### PR TITLE
feat(moq-mux, libmoq): add CMSF muxer, demuxer, and C API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3647,6 +3647,7 @@ dependencies = [
  "reqwest",
  "scuffle-av1",
  "scuffle-h265",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/demo/pub/justfile
+++ b/demo/pub/justfile
@@ -44,6 +44,11 @@ bbb url='http://localhost:4443/anon' *args:
 	just download bbb
 	just cmaf bbb "{{url}}" {{args}}
 
+# Publish Big Buck Bunny via CMSF format.
+bbb-cmsf url='http://localhost:4443/anon' *args:
+	just download bbb
+	just cmsf bbb "{{url}}" {{args}}
+
 # Publish Tears of Steel to a relay server.
 tos url='http://localhost:4443/anon' *args:
 	just download tos
@@ -55,6 +60,13 @@ cmaf name url='http://localhost:4443/anon' *args:
 	just ffmpeg-cmaf "media/{{name}}.mp4" |\
 	cargo run --bin moq-cli -- \
 		{{args}} publish --url "{{url}}" --name "{{name}}" fmp4
+
+# Publish a video using CMSF format to a relay server.
+cmsf name url='http://localhost:4443/anon' *args:
+	cargo build --bin moq-cli
+	just ffmpeg-cmaf "media/{{name}}.mp4" |\
+	cargo run --bin moq-cli -- \
+		{{args}} publish --url "{{url}}" --name "{{name}}" cmsf
 
 # Publish a video via iroh.
 iroh name url prefix="":

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -271,8 +271,14 @@ export class Decoder {
 		const init = Container.Cmaf.decodeInitSegment(initSegment);
 		// Opus in CMAF uses raw packets (not OGG-wrapped), so description must be omitted.
 		// The dOps box from the init segment is not a valid OGG Identification Header.
+		// For other codecs, fall back to the init segment's description (esds, etc.)
+		// when the catalog doesn't provide one (MSF/CMSF path).
 		const description =
-			config.codec === "opus" ? undefined : config.description ? Util.Hex.toBytes(config.description) : undefined;
+			config.codec === "opus"
+				? undefined
+				: config.description
+					? Util.Hex.toBytes(config.description)
+					: init.description;
 
 		const consumer = new Container.Consumer(sub, {
 			format: new Container.Cmaf.Format(init),

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -362,7 +362,9 @@ class DecoderTrack {
 
 		const initSegment = base64ToBytes(this.config.container.init);
 		const init = Container.Cmaf.decodeInitSegment(initSegment);
-		const description = this.config.description ? Util.Hex.toBytes(this.config.description) : undefined;
+		// MSF/CMSF catalogs don't carry a separate description field — the codec
+		// description (avcC, hvcC, etc.) lives inside the init segment's moov box.
+		const description = this.config.description ? Util.Hex.toBytes(this.config.description) : init.description;
 
 		const consumer = new Container.Consumer(sub, {
 			format: new Container.Cmaf.Format(init),

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -359,6 +359,141 @@ pub unsafe extern "C" fn moq_publish_media_frame(
 	})
 }
 
+// --- CMSF Broadcast Producer ---
+
+/// Create a CMSF broadcast producer and announce it to an origin.
+///
+/// - `origin`: origin handle from [moq_origin_create]
+/// - `path` / `path_len`: broadcast path (e.g. "live")
+/// - `publish_hang`: if true, also publish a hang catalog (catalog.json)
+///
+/// Returns a non-zero CMSF handle on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that path is a valid pointer to path_len bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_cmsf_create(origin: u32, path: *const c_char, path_len: usize, publish_hang: bool) -> i32 {
+	ffi::enter(move || {
+		let path = unsafe { ffi::parse_str(path, path_len)? };
+		let origin_id = ffi::parse_id(origin)?;
+		let mut state = State::lock();
+		let (id, consumer) = state.publish.cmsf_create(publish_hang)?;
+		if let Err(err) = state.origin.publish(origin_id, path, consumer) {
+			let _ = state.publish.cmsf_close(id);
+			return Err(err);
+		}
+		Ok(id)
+	})
+}
+
+/// Add a video track to a CMSF broadcast.
+///
+/// Returns a non-zero track handle on success, or a negative code on failure.
+///
+/// # Safety
+/// - All pointer+length pairs must be valid.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_cmsf_add_video(
+	cmsf: u32,
+	codec: *const c_char,
+	codec_len: usize,
+	description: *const u8,
+	description_len: usize,
+	width: u32,
+	height: u32,
+	bitrate: u64,
+	framerate: f64,
+	timescale: u64,
+	init_segment: *const u8,
+	init_segment_len: usize,
+	alt_group: u32,
+) -> i32 {
+	ffi::enter(move || {
+		let codec = unsafe { ffi::parse_str(codec, codec_len)? };
+		let desc = unsafe { ffi::parse_slice(description, description_len)? };
+		let desc = if desc.is_empty() { None } else { Some(desc) };
+		let init = unsafe { ffi::parse_slice(init_segment, init_segment_len)? };
+		let id = ffi::parse_id(cmsf)?;
+		State::lock().publish.cmsf_add_video(
+			id, codec, desc, width, height, bitrate, framerate, timescale, init, alt_group,
+		)
+	})
+}
+
+/// Add an audio track to a CMSF broadcast.
+///
+/// Returns a non-zero track handle on success, or a negative code on failure.
+///
+/// # Safety
+/// - All pointer+length pairs must be valid.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_cmsf_add_audio(
+	cmsf: u32,
+	codec: *const c_char,
+	codec_len: usize,
+	description: *const u8,
+	description_len: usize,
+	sample_rate: u32,
+	channel_count: u32,
+	bitrate: u64,
+	timescale: u64,
+	init_segment: *const u8,
+	init_segment_len: usize,
+	alt_group: u32,
+) -> i32 {
+	ffi::enter(move || {
+		let codec = unsafe { ffi::parse_str(codec, codec_len)? };
+		let desc = unsafe { ffi::parse_slice(description, description_len)? };
+		let desc = if desc.is_empty() { None } else { Some(desc) };
+		let init = unsafe { ffi::parse_slice(init_segment, init_segment_len)? };
+		let id = ffi::parse_id(cmsf)?;
+		State::lock().publish.cmsf_add_audio(
+			id,
+			codec,
+			desc,
+			sample_rate,
+			channel_count,
+			bitrate,
+			timescale,
+			init,
+			alt_group,
+		)
+	})
+}
+
+/// Write a CMAF object (moof+mdat) to a track.
+///
+/// - `cmsf`: CMSF handle from [moq_cmsf_create]
+/// - `track`: track handle from [moq_cmsf_add_video] / [moq_cmsf_add_audio]
+/// - `data` / `data_len`: complete moof+mdat fragment bytes
+/// - `group_id`: explicit group ID (0 = auto-detect from keyframes)
+///
+/// SAP type is auto-detected from the moof sample flags.
+///
+/// Returns zero on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that data is a valid pointer to data_len bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_cmsf_write(cmsf: u32, track: u32, data: *const u8, data_len: usize, group_id: u64) -> i32 {
+	ffi::enter(move || {
+		let id = ffi::parse_id(cmsf)?;
+		let data = unsafe { ffi::parse_slice(data, data_len)? };
+		State::lock().publish.cmsf_write(id, track, data, group_id)
+	})
+}
+
+/// Close a CMSF broadcast producer and finish all tracks.
+///
+/// Returns zero on success, or a negative code on failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_cmsf_close(cmsf: u32) -> i32 {
+	ffi::enter(move || {
+		let id = ffi::parse_id(cmsf)?;
+		State::lock().publish.cmsf_close(id)
+	})
+}
+
 /// Create a catalog consumer for a broadcast.
 ///
 /// The callback is called with a catalog ID when a new catalog is available.

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -1,6 +1,6 @@
 use std::{str::FromStr, sync::Arc};
 
-use bytes::Buf;
+use bytes::{Buf, Bytes};
 use moq_mux::import;
 
 use crate::{Error, Id, NonZeroSlab};
@@ -12,6 +12,9 @@ pub struct Publish {
 
 	/// Active media encoders/decoders for publishing.
 	media: NonZeroSlab<import::Framed>,
+
+	/// Active CMSF broadcast producers.
+	cmsf: NonZeroSlab<import::CmsfBroadcastProducer>,
 }
 
 impl Publish {
@@ -70,6 +73,101 @@ impl Publish {
 	pub fn media_close(&mut self, media: Id) -> Result<(), Error> {
 		let mut decoder = self.media.remove(media).ok_or(Error::MediaNotFound)?;
 		decoder.finish().map_err(|err| Error::DecodeFailed(Arc::new(err)))?;
+		Ok(())
+	}
+
+	// --- CMSF broadcast producer ---
+
+	pub fn cmsf_create(&mut self, publish_hang: bool) -> Result<(Id, moq_lite::BroadcastConsumer), Error> {
+		let broadcast = moq_lite::Broadcast::new().produce();
+		let consumer = broadcast.consume();
+		let config = import::CmsfConfig { publish_hang };
+		let p =
+			import::CmsfBroadcastProducer::new(broadcast, config).map_err(|err| Error::InitFailed(Arc::new(err)))?;
+		let id = self.cmsf.insert(p)?;
+		Ok((id, consumer))
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	pub fn cmsf_add_video(
+		&mut self,
+		id: Id,
+		codec: &str,
+		description: Option<&[u8]>,
+		width: u32,
+		height: u32,
+		bitrate: u64,
+		framerate: f64,
+		timescale: u64,
+		init_segment: &[u8],
+		alt_group: u32,
+	) -> Result<Id, Error> {
+		let p = self.cmsf.get_mut(id).ok_or(Error::BroadcastNotFound)?;
+		let codec = hang::catalog::VideoCodec::from_str(codec).map_err(|_| Error::UnknownFormat(codec.to_string()))?;
+		let track = import::CmsfVideoTrack {
+			codec,
+			description: description.map(Bytes::copy_from_slice),
+			width: if width == 0 { None } else { Some(width) },
+			height: if height == 0 { None } else { Some(height) },
+			bitrate: if bitrate == 0 { None } else { Some(bitrate) },
+			framerate: if framerate == 0.0 { None } else { Some(framerate) },
+			timescale,
+			init_segment: Bytes::copy_from_slice(init_segment),
+			alt_group: if alt_group == 0 { None } else { Some(alt_group) },
+		};
+		let tid = p
+			.add_video_track(track)
+			.map_err(|err| Error::InitFailed(Arc::new(err)))?;
+		Id::try_from(tid.0 as u32 + 1)
+	}
+
+	#[allow(clippy::too_many_arguments)]
+	pub fn cmsf_add_audio(
+		&mut self,
+		id: Id,
+		codec: &str,
+		description: Option<&[u8]>,
+		sample_rate: u32,
+		channel_count: u32,
+		bitrate: u64,
+		timescale: u64,
+		init_segment: &[u8],
+		alt_group: u32,
+	) -> Result<Id, Error> {
+		let p = self.cmsf.get_mut(id).ok_or(Error::BroadcastNotFound)?;
+		let codec = hang::catalog::AudioCodec::from_str(codec).map_err(|_| Error::UnknownFormat(codec.to_string()))?;
+		let track = import::CmsfAudioTrack {
+			codec,
+			description: description.map(Bytes::copy_from_slice),
+			sample_rate,
+			channel_count,
+			bitrate: if bitrate == 0 { None } else { Some(bitrate) },
+			timescale,
+			init_segment: Bytes::copy_from_slice(init_segment),
+			alt_group: if alt_group == 0 { None } else { Some(alt_group) },
+		};
+		let tid = p
+			.add_audio_track(track)
+			.map_err(|err| Error::InitFailed(Arc::new(err)))?;
+		Id::try_from(tid.0 as u32 + 1)
+	}
+
+	pub fn cmsf_write(&mut self, id: Id, track_handle: u32, data: &[u8], group_id: u64) -> Result<(), Error> {
+		let p = self.cmsf.get_mut(id).ok_or(Error::BroadcastNotFound)?;
+		if track_handle == 0 {
+			return Err(Error::InvalidId);
+		}
+		let track_id = import::TrackId((track_handle - 1) as usize);
+		let obj = import::CmsfObject {
+			data: Bytes::copy_from_slice(data),
+			group_id: if group_id == 0 { None } else { Some(group_id) },
+		};
+		p.write(track_id, obj).map_err(|err| Error::DecodeFailed(Arc::new(err)))
+	}
+
+	pub fn cmsf_close(&mut self, id: Id) -> Result<(), Error> {
+		let mut p = self.cmsf.remove(id).ok_or(Error::BroadcastNotFound)?;
+		p.finish().map_err(|err| Error::DecodeFailed(Arc::new(err)))?;
 		Ok(())
 	}
 }

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -6,6 +6,7 @@ use moq_mux::import;
 pub enum PublishFormat {
 	Avc3,
 	Fmp4,
+	Cmsf,
 	// NOTE: No aac support because it needs framing.
 	Hls {
 		/// URL or file path of an HLS playlist to ingest.
@@ -17,16 +18,26 @@ pub enum PublishFormat {
 enum PublishDecoder {
 	Avc3(Box<import::Avc3>),
 	Fmp4(Box<import::Fmp4>),
+	Cmsf(Box<import::CmsfFmp4Importer>),
 	Hls(Box<import::Hls>),
 }
 
 impl PublishDecoder {
-	/// Decode a chunk of bytes from stdin (Avc3 or Fmp4 only).
+	/// Decode a chunk of bytes from stdin (Avc3, Fmp4, or Cmsf only).
 	fn decode_buf(&mut self, buffer: &mut bytes::BytesMut) -> anyhow::Result<()> {
 		match self {
 			Self::Avc3(d) => d.decode_stream(buffer, None),
 			Self::Fmp4(d) => d.decode(buffer),
+			Self::Cmsf(d) => d.decode(buffer),
 			Self::Hls(_) => unreachable!(),
+		}
+	}
+
+	/// Signal end-of-input so tracks and catalogs are closed cleanly.
+	fn finish(&mut self) -> anyhow::Result<()> {
+		match self {
+			Self::Cmsf(d) => d.finish(),
+			_ => Ok(()),
 		}
 	}
 }
@@ -39,24 +50,34 @@ pub struct Publish {
 impl Publish {
 	pub fn new(format: &PublishFormat) -> anyhow::Result<Self> {
 		let mut broadcast = moq_lite::Broadcast::new().produce();
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 
 		let decoder = match format {
-			PublishFormat::Avc3 => {
-				let avc3 = import::Avc3::new(broadcast.clone(), catalog.clone());
-				PublishDecoder::Avc3(Box::new(avc3))
+			// CMSF manages its own catalog tracks — skip catalog::Producer.
+			PublishFormat::Cmsf => {
+				let cmsf = import::CmsfFmp4Importer::new(broadcast.clone(), import::CmsfConfig::default())?;
+				PublishDecoder::Cmsf(Box::new(cmsf))
 			}
-			PublishFormat::Fmp4 => {
-				let fmp4 = import::Fmp4::new(broadcast.clone(), catalog.clone());
-				PublishDecoder::Fmp4(Box::new(fmp4))
-			}
-			PublishFormat::Hls { playlist } => {
-				let hls = import::Hls::new(
-					broadcast.clone(),
-					catalog.clone(),
-					import::HlsConfig::new(playlist.clone()),
-				)?;
-				PublishDecoder::Hls(Box::new(hls))
+			_ => {
+				let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
+				match format {
+					PublishFormat::Avc3 => {
+						let avc3 = import::Avc3::new(broadcast.clone(), catalog.clone());
+						PublishDecoder::Avc3(Box::new(avc3))
+					}
+					PublishFormat::Fmp4 => {
+						let fmp4 = import::Fmp4::new(broadcast.clone(), catalog.clone());
+						PublishDecoder::Fmp4(Box::new(fmp4))
+					}
+					PublishFormat::Hls { playlist } => {
+						let hls = import::Hls::new(
+							broadcast.clone(),
+							catalog.clone(),
+							import::HlsConfig::new(playlist.clone()),
+						)?;
+						PublishDecoder::Hls(Box::new(hls))
+					}
+					PublishFormat::Cmsf => unreachable!(),
+				}
 			}
 		};
 
@@ -78,6 +99,7 @@ impl Publish {
 			loop {
 				let n = tokio::io::AsyncReadExt::read_buf(&mut stdin, &mut buffer).await?;
 				if n == 0 {
+					self.decoder.finish()?;
 					return Ok(());
 				}
 				self.decoder.decode_buf(&mut buffer)?;

--- a/rs/moq-cli/src/subscribe.rs
+++ b/rs/moq-cli/src/subscribe.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use anyhow::Context;
 use clap::ValueEnum;
 use hang::moq_lite;
 use tokio::io::AsyncWriteExt;
@@ -7,6 +8,8 @@ use tokio::io::AsyncWriteExt;
 #[derive(ValueEnum, Clone, Copy)]
 pub enum SubscribeFormat {
 	Fmp4,
+	/// CMSF-aware fMP4 output (reads MSF catalog instead of hang catalog).
+	CmsfFmp4,
 }
 
 #[derive(clap::Args, Clone)]
@@ -33,6 +36,7 @@ impl Subscribe {
 	pub async fn run(self) -> anyhow::Result<()> {
 		match self.args.format {
 			SubscribeFormat::Fmp4 => self.run_fmp4().await,
+			SubscribeFormat::CmsfFmp4 => self.run_cmsf_fmp4().await,
 		}
 	}
 
@@ -46,6 +50,40 @@ impl Subscribe {
 
 		while let Some(chunk) = fmp4.next().await? {
 			stdout.write_all(&chunk).await?;
+			stdout.flush().await?;
+		}
+
+		Ok(())
+	}
+
+	async fn run_cmsf_fmp4(self) -> anyhow::Result<()> {
+		let mut stdout = tokio::io::stdout();
+
+		if self.args.max_latency != Duration::from_millis(500) {
+			anyhow::bail!(
+				"--max-latency is not supported for cmsf-fmp4 output (CmsfBroadcastDemuxer \
+				 does not yet implement group skipping). Omit --max-latency or use --format fmp4."
+			);
+		}
+
+		let mut demuxer = moq_mux::export::cmsf::CmsfBroadcastDemuxer::new(self.broadcast)?;
+
+		// Wait for the first catalog and track subscriptions.
+		demuxer
+			.ready()
+			.await
+			.context("CMSF demuxer failed waiting for catalog")?;
+
+		// Build merged init segment from per-track init data.
+		let inits = demuxer.init_segments();
+		let init =
+			moq_mux::export::cmsf::build_merged_init(&inits).context("failed to build merged CMSF init segment")?;
+		stdout.write_all(&init).await?;
+		stdout.flush().await?;
+
+		// Each segment's media_data is already a valid moof+mdat fragment.
+		while let Some(seg) = demuxer.next().await.context("failed reading next CMSF segment")? {
+			stdout.write_all(&seg.media_data).await?;
 			stdout.flush().await?;
 		}
 

--- a/rs/moq-msf/src/lib.rs
+++ b/rs/moq-msf/src/lib.rs
@@ -24,6 +24,9 @@ pub struct Catalog {
 	/// MSF version — always 1 for this draft.
 	pub version: u32,
 
+	/// Milliseconds since Unix epoch when this catalog was generated.
+	pub generated_at: Option<u64>,
+
 	/// Array of track descriptions.
 	pub tracks: Vec<Track>,
 }
@@ -74,6 +77,12 @@ pub struct Track {
 
 	/// Alternate group for quality switching.
 	pub alt_group: Option<u32>,
+
+	/// Maximum SAP type at the start of any group (CMSF §3.4).
+	pub max_grp_sap_starting_type: Option<u32>,
+
+	/// Maximum SAP type at the start of any object (CMSF §3.4).
+	pub max_obj_sap_starting_type: Option<u32>,
 }
 
 impl Catalog {
@@ -219,6 +228,7 @@ mod test {
 	fn serialize_video_track() {
 		let catalog = Catalog {
 			version: 1,
+			generated_at: None,
 			tracks: vec![Track {
 				name: "video0".to_string(),
 				packaging: Packaging::Legacy,
@@ -234,6 +244,8 @@ mod test {
 				init_data: None,
 				render_group: Some(1),
 				alt_group: None,
+				max_grp_sap_starting_type: None,
+				max_obj_sap_starting_type: None,
 			}],
 		};
 
@@ -252,6 +264,7 @@ mod test {
 	fn serialize_audio_track() {
 		let catalog = Catalog {
 			version: 1,
+			generated_at: None,
 			tracks: vec![Track {
 				name: "audio0".to_string(),
 				packaging: Packaging::Legacy,
@@ -267,6 +280,8 @@ mod test {
 				init_data: None,
 				render_group: Some(1),
 				alt_group: None,
+				max_grp_sap_starting_type: None,
+				max_obj_sap_starting_type: None,
 			}],
 		};
 
@@ -319,6 +334,7 @@ mod test {
 	fn roundtrip_empty() {
 		let catalog = Catalog {
 			version: 1,
+			generated_at: None,
 			tracks: vec![],
 		};
 		let json = catalog.to_string().unwrap();
@@ -330,6 +346,7 @@ mod test {
 	fn cmaf_packaging() {
 		let catalog = Catalog {
 			version: 1,
+			generated_at: None,
 			tracks: vec![Track {
 				name: "hd".to_string(),
 				packaging: Packaging::Cmaf,
@@ -345,6 +362,8 @@ mod test {
 				init_data: Some("AQID".to_string()),
 				render_group: Some(1),
 				alt_group: Some(1),
+				max_grp_sap_starting_type: None,
+				max_obj_sap_starting_type: None,
 			}],
 		};
 
@@ -352,5 +371,104 @@ mod test {
 		assert!(json.contains("\"packaging\":\"cmaf\""));
 		let parsed = Catalog::from_str(&json).unwrap();
 		assert_eq!(catalog, parsed);
+	}
+
+	#[test]
+	fn cmsf_generated_at() {
+		let catalog = Catalog {
+			version: 1,
+			generated_at: Some(1714500000000),
+			tracks: vec![],
+		};
+
+		let json = catalog.to_string().unwrap();
+		assert!(json.contains("\"generatedAt\":1714500000000"));
+		let parsed = Catalog::from_str(&json).unwrap();
+		assert_eq!(parsed.generated_at, Some(1714500000000));
+	}
+
+	#[test]
+	fn cmsf_generated_at_omitted_when_none() {
+		let catalog = Catalog {
+			version: 1,
+			generated_at: None,
+			tracks: vec![],
+		};
+
+		let json = catalog.to_string().unwrap();
+		assert!(!json.contains("generatedAt"));
+	}
+
+	#[test]
+	fn cmsf_sap_fields() {
+		let catalog = Catalog {
+			version: 1,
+			generated_at: None,
+			tracks: vec![Track {
+				name: "video0.m4s".to_string(),
+				packaging: Packaging::Cmaf,
+				is_live: true,
+				role: Some(Role::Video),
+				codec: Some("avc1.640028".to_string()),
+				width: Some(1920),
+				height: Some(1080),
+				framerate: Some(30.0),
+				samplerate: None,
+				channel_config: None,
+				bitrate: Some(5_000_000),
+				init_data: Some("AQID".to_string()),
+				render_group: Some(1),
+				alt_group: Some(1),
+				max_grp_sap_starting_type: Some(1),
+				max_obj_sap_starting_type: Some(2),
+			}],
+		};
+
+		let json = catalog.to_string().unwrap();
+		assert!(json.contains("\"maxGrpSapStartingType\":1"));
+		assert!(json.contains("\"maxObjSapStartingType\":2"));
+		let parsed = Catalog::from_str(&json).unwrap();
+		assert_eq!(parsed.tracks[0].max_grp_sap_starting_type, Some(1));
+		assert_eq!(parsed.tracks[0].max_obj_sap_starting_type, Some(2));
+	}
+
+	#[test]
+	fn cmsf_sap_fields_omitted_when_none() {
+		let catalog = Catalog {
+			version: 1,
+			generated_at: None,
+			tracks: vec![Track {
+				name: "video0.m4s".to_string(),
+				packaging: Packaging::Cmaf,
+				is_live: true,
+				role: None,
+				codec: None,
+				width: None,
+				height: None,
+				framerate: None,
+				samplerate: None,
+				channel_config: None,
+				bitrate: None,
+				init_data: None,
+				render_group: None,
+				alt_group: None,
+				max_grp_sap_starting_type: None,
+				max_obj_sap_starting_type: None,
+			}],
+		};
+
+		let json = catalog.to_string().unwrap();
+		assert!(!json.contains("maxGrpSapStartingType"));
+		assert!(!json.contains("maxObjSapStartingType"));
+	}
+
+	#[test]
+	fn cmsf_backward_compat_missing_fields() {
+		// JSON without the new CMSF fields should still deserialize.
+		let json = r#"{"version":1,"tracks":[{"name":"v","packaging":"cmaf","isLive":true}]}"#;
+		let catalog = Catalog::from_str(json).unwrap();
+		assert_eq!(catalog.generated_at, None);
+		assert_eq!(catalog.tracks[0].max_grp_sap_starting_type, None);
+		assert_eq!(catalog.tracks[0].max_obj_sap_starting_type, None);
 	}
 }

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -31,6 +31,7 @@ num_enum = "0.7"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "gzip"] }
 scuffle-av1 = { version = "0.1.4" }
 scuffle-h265 = { version = "0.2.2" }
+serde_json = "1"
 thiserror = "2"
 tokio = { workspace = true, features = ["macros", "fs"] }
 tracing = "0.1"

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -153,6 +153,8 @@ fn to_msf(catalog: &hang::Catalog) -> moq_msf::Catalog {
 			init_data,
 			render_group: Some(1),
 			alt_group: if has_multiple_video { Some(1) } else { None },
+			max_grp_sap_starting_type: None,
+			max_obj_sap_starting_type: None,
 		});
 	}
 
@@ -186,10 +188,16 @@ fn to_msf(catalog: &hang::Catalog) -> moq_msf::Catalog {
 			init_data,
 			render_group: Some(1),
 			alt_group: if has_multiple_audio { Some(1) } else { None },
+			max_grp_sap_starting_type: None,
+			max_obj_sap_starting_type: None,
 		});
 	}
 
-	moq_msf::Catalog { version: 1, tracks }
+	moq_msf::Catalog {
+		version: 1,
+		generated_at: None,
+		tracks,
+	}
 }
 
 #[cfg(test)]

--- a/rs/moq-mux/src/cmsf.rs
+++ b/rs/moq-mux/src/cmsf.rs
@@ -1,0 +1,204 @@
+//! Shared CMSF types and parsing utilities.
+//!
+//! Used by both the producer (import) and consumer (export) sides of the CMSF pipeline.
+
+use mp4_atom::DecodeMaybe;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/// Metadata extracted from a CMSF Object (moof+mdat).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CmsfMetadata {
+	/// Presentation timestamp derived from `base_media_decode_time` + first sample's
+	/// composition time offset. For single-sample fragments (the CMSF norm), this is
+	/// the exact PTS. For multi-sample fragments with B-frames, this is the PTS of
+	/// the first sample only.
+	pub pts: u64,
+	pub duration: u64,
+	pub is_keyframe: bool,
+}
+
+/// Errors from CMSF parsing operations.
+#[derive(Debug, thiserror::Error)]
+pub enum CmsfError {
+	#[error("no moof box found")]
+	NoMoof,
+	#[error("no traf in moof")]
+	NoTraf,
+	#[error("no tfdt in traf")]
+	NoTfdt,
+	#[error("no trun in traf")]
+	NoTrun,
+	#[error("mp4 parse error: {0}")]
+	Mp4(#[from] mp4_atom::Error),
+	#[error("moq error: {0}")]
+	Moq(#[from] moq_lite::Error),
+	#[error("invalid base64: {0}")]
+	Base64(#[from] base64::DecodeError),
+	#[error("missing init_data in catalog track")]
+	MissingInitData,
+	#[error("no moov in init segment")]
+	NoMoov,
+	#[error("no tracks in moov")]
+	NoTracks,
+	#[error("catalog parse error: {0}")]
+	CatalogParse(#[from] serde_json::Error),
+	#[error("mp4 encode error")]
+	EncodeFailed,
+}
+
+// ---------------------------------------------------------------------------
+// Parsing Functions
+// ---------------------------------------------------------------------------
+
+/// Parse metadata from a CMSF Object (moof+mdat bytes) without modifying them.
+pub fn parse_cmsf_metadata(data: &[u8]) -> Result<CmsfMetadata, CmsfError> {
+	let mut cursor = std::io::Cursor::new(data);
+
+	while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor)? {
+		if let mp4_atom::Any::Moof(moof) = atom {
+			let traf = moof.traf.first().ok_or(CmsfError::NoTraf)?;
+			let tfdt = traf.tfdt.as_ref().ok_or(CmsfError::NoTfdt)?;
+
+			if traf.trun.is_empty() {
+				return Err(CmsfError::NoTrun);
+			}
+
+			let default_duration = traf.tfhd.default_sample_duration.unwrap_or(0);
+			let default_flags = traf.tfhd.default_sample_flags.unwrap_or(0);
+
+			let mut duration = 0u64;
+			let mut first_flags = None;
+			let mut first_cts: Option<i32> = None;
+
+			for trun in &traf.trun {
+				for entry in &trun.entries {
+					duration += entry.duration.unwrap_or(default_duration) as u64;
+					if first_flags.is_none() {
+						first_flags = Some(entry.flags.unwrap_or(default_flags));
+					}
+					if first_cts.is_none() {
+						first_cts = Some(entry.cts.unwrap_or(0));
+					}
+				}
+			}
+
+			let flags = first_flags.unwrap_or(default_flags);
+			let is_keyframe = (flags >> 24) & 0x3 == 0x2 && (flags >> 16) & 0x1 == 0;
+			let dts = tfdt.base_media_decode_time;
+			let pts = (dts as i64 + first_cts.unwrap_or(0) as i64).max(0) as u64;
+
+			return Ok(CmsfMetadata {
+				pts,
+				duration,
+				is_keyframe,
+			});
+		}
+	}
+
+	Err(CmsfError::NoMoof)
+}
+
+/// Parse timescale from a decoded init segment (ftyp+moov bytes).
+pub fn parse_timescale(init_data: &[u8]) -> Result<u64, CmsfError> {
+	let mut cursor = std::io::Cursor::new(init_data);
+
+	while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor)? {
+		if let mp4_atom::Any::Moov(moov) = atom {
+			let trak = moov.trak.first().ok_or(CmsfError::NoTracks)?;
+			return Ok(trak.mdia.mdhd.timescale as u64);
+		}
+	}
+
+	Err(CmsfError::NoMoov)
+}
+
+// ---------------------------------------------------------------------------
+// Test Helpers
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+pub(crate) mod test_helpers {
+	use mp4_atom::Encode;
+
+	/// Build a minimal valid moof+mdat with the given DTS, sample duration, and flags.
+	pub fn build_moof_mdat(dts: u64, duration: u32, flags: u32) -> Vec<u8> {
+		let moof = mp4_atom::Moof {
+			mfhd: mp4_atom::Mfhd { sequence_number: 1 },
+			traf: vec![mp4_atom::Traf {
+				tfhd: mp4_atom::Tfhd {
+					track_id: 1,
+					..Default::default()
+				},
+				tfdt: Some(mp4_atom::Tfdt {
+					base_media_decode_time: dts,
+				}),
+				trun: vec![mp4_atom::Trun {
+					data_offset: Some(0),
+					entries: vec![mp4_atom::TrunEntry {
+						size: Some(4),
+						duration: Some(duration),
+						flags: Some(flags),
+						..Default::default()
+					}],
+				}],
+				..Default::default()
+			}],
+		};
+		let mdat = mp4_atom::Mdat { data: vec![0; 4] };
+		let mut buf = Vec::new();
+		moof.encode(&mut buf).unwrap();
+		mdat.encode(&mut buf).unwrap();
+		buf
+	}
+
+	/// Build a minimal valid init segment (ftyp+moov) with the given timescale.
+	pub fn build_init_segment(timescale: u32) -> Vec<u8> {
+		let ftyp = mp4_atom::Ftyp {
+			major_brand: b"isom".into(),
+			minor_version: 0x200,
+			compatible_brands: vec![b"isom".into()],
+		};
+		let moov = mp4_atom::Moov {
+			mvhd: mp4_atom::Mvhd {
+				timescale,
+				..Default::default()
+			},
+			trak: vec![mp4_atom::Trak {
+				tkhd: mp4_atom::Tkhd {
+					track_id: 1,
+					..Default::default()
+				},
+				mdia: mp4_atom::Mdia {
+					mdhd: mp4_atom::Mdhd {
+						timescale,
+						..Default::default()
+					},
+					hdlr: mp4_atom::Hdlr {
+						handler: b"vide".into(),
+						name: "V".into(),
+					},
+					minf: mp4_atom::Minf {
+						vmhd: Some(mp4_atom::Vmhd::default()),
+						dinf: mp4_atom::Dinf {
+							dref: mp4_atom::Dref { urls: vec![] },
+						},
+						stbl: mp4_atom::Stbl {
+							stsd: mp4_atom::Stsd { codecs: vec![] },
+							..Default::default()
+						},
+						..Default::default()
+					},
+				},
+				..Default::default()
+			}],
+			..Default::default()
+		};
+		let mut buf = Vec::new();
+		ftyp.encode(&mut buf).unwrap();
+		moov.encode(&mut buf).unwrap();
+		buf
+	}
+}

--- a/rs/moq-mux/src/export/cmsf.rs
+++ b/rs/moq-mux/src/export/cmsf.rs
@@ -1,0 +1,606 @@
+//! CMSF demuxer — three layers for consuming CMSF-encoded MoQ broadcasts.
+//!
+//! - [`parse_cmsf_metadata`]: Pure function extracting timing/keyframe info from moof+mdat.
+//! - [`CmsfTrackDemuxer`]: Per-track async wrapper yielding [`CmsfSegment`].
+//! - [`CmsfBroadcastDemuxer`]: Broadcast-level coordinator managing catalog + subscriptions.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use bytes::Bytes;
+
+// Re-export shared CMSF types and functions for backward compatibility.
+pub use crate::cmsf::{CmsfError, CmsfMetadata, parse_cmsf_metadata, parse_timescale};
+
+/// A demuxed CMSF segment.
+#[derive(Clone, Debug)]
+pub struct CmsfSegment {
+	pub track_name: Arc<str>,
+	pub group_id: u64,
+	pub media_data: Bytes,
+	pub pts: u64,
+	pub duration: u64,
+	pub timescale: u64,
+	pub is_keyframe: bool,
+}
+
+/// Why a track ended.
+#[derive(Clone, Debug)]
+pub enum EndReason {
+	CatalogRemoved,
+	TrackFinished,
+	TrackError(moq_lite::Error),
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2: Per-Track Demuxer
+// ---------------------------------------------------------------------------
+
+/// Per-track CMSF demuxer yielding [`CmsfSegment`] per MoQ Object.
+pub struct CmsfTrackDemuxer {
+	track: moq_lite::TrackConsumer,
+	pub(crate) init_data: Bytes,
+	timescale: u64,
+	name: Arc<str>,
+	current_group: Option<moq_lite::GroupConsumer>,
+	end_reason: Option<EndReason>,
+	malformed_count: u32,
+}
+
+impl CmsfTrackDemuxer {
+	pub fn new(track: moq_lite::TrackConsumer, init_data: Bytes, timescale: u64) -> Self {
+		let name: Arc<str> = track.name.as_str().into();
+		Self {
+			track,
+			init_data,
+			timescale,
+			name,
+			current_group: None,
+			end_reason: None,
+			malformed_count: 0,
+		}
+	}
+
+	/// Create from an MSF catalog track entry.
+	pub fn from_msf_track(track: moq_lite::TrackConsumer, msf_track: &moq_msf::Track) -> Result<Self, CmsfError> {
+		use base64::Engine;
+		let init_b64 = msf_track.init_data.as_deref().ok_or(CmsfError::MissingInitData)?;
+		let init_data = base64::engine::general_purpose::STANDARD.decode(init_b64)?;
+		let timescale = parse_timescale(&init_data)?;
+		Ok(Self::new(track, Bytes::from(init_data), timescale))
+	}
+
+	/// Read the next segment. Returns `None` when the track ends.
+	pub async fn next(&mut self) -> Result<Option<CmsfSegment>, CmsfError> {
+		conducer::wait(|waiter| self.poll_next(waiter)).await
+	}
+
+	pub fn poll_next(&mut self, waiter: &conducer::Waiter) -> std::task::Poll<Result<Option<CmsfSegment>, CmsfError>> {
+		use std::task::{Poll, ready};
+
+		loop {
+			if let Some(group) = &mut self.current_group {
+				match group.poll_read_frame(waiter) {
+					Poll::Ready(Ok(Some(data))) => {
+						let group_id = group.sequence;
+						match parse_cmsf_metadata(&data) {
+							Ok(meta) => {
+								self.malformed_count = 0;
+								return Poll::Ready(Ok(Some(CmsfSegment {
+									track_name: self.name.clone(),
+									group_id,
+									media_data: data,
+									pts: meta.pts,
+									duration: meta.duration,
+									timescale: self.timescale,
+									is_keyframe: meta.is_keyframe,
+								})));
+							}
+							Err(_) => {
+								self.malformed_count += 1;
+								if self.malformed_count == 1 {
+									tracing::warn!(track = %self.name, "skipping malformed segment");
+								}
+								if self.malformed_count >= 100 {
+									tracing::error!(track = %self.name, "100 consecutive malformed segments, closing track");
+									self.end_reason = Some(EndReason::TrackFinished);
+									return Poll::Ready(Ok(None));
+								}
+								continue;
+							}
+						}
+					}
+					Poll::Ready(Ok(None)) => {
+						self.current_group = None;
+						continue;
+					}
+					Poll::Ready(Err(err)) => {
+						tracing::debug!(track = %self.name, %err, "group read error, skipping");
+						self.current_group = None;
+						continue;
+					}
+					Poll::Pending => return Poll::Pending,
+				}
+			}
+
+			match ready!(self.track.poll_recv_group(waiter)) {
+				Ok(Some(group)) => {
+					self.current_group = Some(group);
+				}
+				Ok(None) => {
+					self.end_reason = Some(EndReason::TrackFinished);
+					return Poll::Ready(Ok(None));
+				}
+				Err(e) => {
+					self.end_reason = Some(EndReason::TrackError(e));
+					return Poll::Ready(Ok(None));
+				}
+			}
+		}
+	}
+
+	pub fn init_data(&self) -> &Bytes {
+		&self.init_data
+	}
+
+	pub fn end_reason(&self) -> Option<&EndReason> {
+		self.end_reason.as_ref()
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Layer 3: Broadcast Demuxer
+// ---------------------------------------------------------------------------
+
+struct BroadcastTrackState {
+	demuxer: CmsfTrackDemuxer,
+	active: bool,
+}
+
+/// Broadcast-level CMSF demuxer. Subscribes to MSF catalog, manages track demuxers.
+pub struct CmsfBroadcastDemuxer {
+	broadcast: moq_lite::BroadcastConsumer,
+	catalog_track: moq_lite::TrackConsumer,
+	catalog_group: Option<moq_lite::GroupConsumer>,
+	tracks: HashMap<Arc<str>, BroadcastTrackState>,
+	catalog_closed: bool,
+}
+
+impl CmsfBroadcastDemuxer {
+	pub fn new(broadcast: moq_lite::BroadcastConsumer) -> Result<Self, CmsfError> {
+		let catalog_track = broadcast.subscribe_track(&moq_lite::Track::new("catalog"))?;
+		Ok(Self {
+			broadcast,
+			catalog_track,
+			catalog_group: None,
+			tracks: HashMap::new(),
+			catalog_closed: false,
+		})
+	}
+
+	/// Wait until the first catalog is received and tracks are subscribed.
+	pub async fn ready(&mut self) -> Result<(), CmsfError> {
+		conducer::wait(|waiter| self.poll_ready(waiter)).await
+	}
+
+	fn poll_ready(&mut self, waiter: &conducer::Waiter) -> std::task::Poll<Result<(), CmsfError>> {
+		use std::task::Poll;
+
+		if !self.tracks.is_empty() {
+			return Poll::Ready(Ok(()));
+		}
+
+		match self.poll_catalog(waiter) {
+			Poll::Ready(Ok(Some(catalog))) => {
+				self.apply_catalog(&catalog);
+				if self.tracks.is_empty() {
+					Poll::Ready(Err(CmsfError::NoTracks))
+				} else {
+					Poll::Ready(Ok(()))
+				}
+			}
+			Poll::Ready(Ok(None)) => {
+				self.catalog_closed = true;
+				Poll::Ready(Err(CmsfError::NoTracks))
+			}
+			Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+			Poll::Pending => Poll::Pending,
+		}
+	}
+
+	/// Read the next segment from any track.
+	pub async fn next(&mut self) -> Result<Option<CmsfSegment>, CmsfError> {
+		conducer::wait(|waiter| self.poll_next(waiter)).await
+	}
+
+	pub fn poll_next(&mut self, waiter: &conducer::Waiter) -> std::task::Poll<Result<Option<CmsfSegment>, CmsfError>> {
+		use std::task::Poll;
+
+		// Poll catalog for updates.
+		if !self.catalog_closed {
+			match self.poll_catalog(waiter) {
+				Poll::Ready(Ok(Some(catalog))) => {
+					self.apply_catalog(&catalog);
+				}
+				Poll::Ready(Ok(None)) => {
+					self.catalog_closed = true;
+				}
+				Poll::Ready(Err(_)) => {
+					self.catalog_closed = true;
+				}
+				Poll::Pending => {}
+			}
+		}
+
+		// Poll all active track demuxers.
+		for state in self.tracks.values_mut() {
+			if !state.active {
+				continue;
+			}
+			match state.demuxer.poll_next(waiter) {
+				Poll::Ready(Ok(Some(seg))) => {
+					return Poll::Ready(Ok(Some(seg)));
+				}
+				Poll::Ready(Ok(None)) => {
+					state.active = false;
+				}
+				Poll::Ready(Err(_)) => {
+					state.active = false;
+				}
+				Poll::Pending => {}
+			}
+		}
+
+		let all_ended = self.tracks.is_empty() || self.tracks.values().all(|s| !s.active);
+		if all_ended && self.catalog_closed {
+			return Poll::Ready(Ok(None));
+		}
+
+		Poll::Pending
+	}
+
+	/// Names of currently active tracks.
+	pub fn active_tracks(&self) -> Vec<&str> {
+		self.tracks
+			.iter()
+			.filter(|(_, s)| s.active)
+			.map(|(name, _)| name.as_ref())
+			.collect()
+	}
+
+	/// Init segments for all active tracks, suitable for building a merged fMP4 init.
+	pub fn init_segments(&self) -> Vec<&Bytes> {
+		self.tracks
+			.values()
+			.filter(|s| s.active)
+			.map(|s| &s.demuxer.init_data)
+			.collect()
+	}
+
+	/// Poll for a new catalog. Assumes each catalog group contains exactly one frame.
+	///
+	/// If multiple catalog groups arrive between polls, only the latest is read
+	/// (intermediate versions are skipped). This is intentional: the latest catalog
+	/// is always authoritative and supersedes prior versions.
+	fn poll_catalog(
+		&mut self,
+		waiter: &conducer::Waiter,
+	) -> std::task::Poll<Result<Option<moq_msf::Catalog>, CmsfError>> {
+		use std::task::Poll;
+
+		// Get newest group.
+		while let Poll::Ready(result) = self.catalog_track.poll_recv_group(waiter) {
+			match result {
+				Ok(Some(group)) => self.catalog_group = Some(group),
+				Ok(None) => {
+					if self.catalog_group.is_none() {
+						return Poll::Ready(Ok(None));
+					}
+					break;
+				}
+				Err(e) => return Poll::Ready(Err(CmsfError::Moq(e))),
+			}
+		}
+
+		let Some(group) = &mut self.catalog_group else {
+			return Poll::Pending;
+		};
+
+		if let Poll::Ready(result) = group.poll_read_frame(waiter) {
+			self.catalog_group.take();
+			match result {
+				Ok(Some(data)) => {
+					let catalog = serde_json::from_slice::<moq_msf::Catalog>(&data)?;
+					return Poll::Ready(Ok(Some(catalog)));
+				}
+				Ok(None) => {}
+				Err(e) => return Poll::Ready(Err(CmsfError::Moq(e))),
+			}
+		}
+
+		Poll::Pending
+	}
+
+	fn apply_catalog(&mut self, catalog: &moq_msf::Catalog) {
+		use base64::Engine;
+
+		// Mark tracks not present in the new catalog as inactive.
+		for (name, state) in &mut self.tracks {
+			if state.active && !catalog.tracks.iter().any(|t| t.name.as_str() == name.as_ref()) {
+				state.active = false;
+				state.demuxer.end_reason = Some(EndReason::CatalogRemoved);
+			}
+		}
+
+		// Remove inactive tracks so re-added tracks get a fresh subscription.
+		self.tracks.retain(|_, s| s.active);
+
+		for msf_track in &catalog.tracks {
+			if msf_track.packaging != moq_msf::Packaging::Cmaf {
+				continue;
+			}
+			if self.tracks.get(msf_track.name.as_str()).is_some_and(|s| s.active) {
+				continue;
+			}
+			let Some(init_b64) = &msf_track.init_data else { continue };
+			let Ok(init_data) = base64::engine::general_purpose::STANDARD.decode(init_b64) else {
+				continue;
+			};
+			let Ok(timescale) = parse_timescale(&init_data) else {
+				continue;
+			};
+
+			let track = moq_lite::Track::new(msf_track.name.as_str());
+			let Ok(consumer) = self.broadcast.subscribe_track(&track) else {
+				continue;
+			};
+
+			let demuxer = CmsfTrackDemuxer::new(consumer, Bytes::from(init_data), timescale);
+			let name: Arc<str> = msf_track.name.as_str().into();
+			self.tracks.insert(name, BroadcastTrackState { demuxer, active: true });
+		}
+	}
+}
+
+/// Build a merged ftyp + multi-track moov init segment from per-track init segments.
+///
+/// Each input should be a complete single-track init segment (ftyp + moov) as stored
+/// in the MSF catalog's `init_data` field. The output is a single multi-track init
+/// segment suitable for fMP4 playback.
+pub fn build_merged_init(inits: &[&Bytes]) -> Result<Bytes, CmsfError> {
+	use mp4_atom::{DecodeMaybe, Encode};
+
+	let mut traks = Vec::new();
+	let mut trexs = Vec::new();
+	let mut ftyp_data = None;
+
+	for init in inits {
+		let mut cursor = std::io::Cursor::new(init.as_ref());
+		while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).map_err(|_| CmsfError::NoMoov)? {
+			match atom {
+				mp4_atom::Any::Ftyp(f) if ftyp_data.is_none() => ftyp_data = Some(f),
+				mp4_atom::Any::Moov(moov) => {
+					for trak in moov.trak {
+						traks.push(trak);
+					}
+					if let Some(mvex) = moov.mvex {
+						for trex in mvex.trex {
+							trexs.push(trex);
+						}
+					}
+				}
+				_ => {}
+			}
+		}
+	}
+
+	let ftyp = ftyp_data.ok_or(CmsfError::NoMoov)?;
+
+	// Renumber track IDs sequentially to avoid collisions when merging
+	// independently-produced init segments (each may start at track_id=1).
+	// Map old→new so trex entries stay paired with their trak.
+	let mut id_map = HashMap::new();
+	for (i, trak) in traks.iter_mut().enumerate() {
+		let new_id = (i + 1) as u32;
+		id_map.insert(trak.tkhd.track_id, new_id);
+		trak.tkhd.track_id = new_id;
+	}
+	for trex in &mut trexs {
+		if let Some(&new_id) = id_map.get(&trex.track_id) {
+			trex.track_id = new_id;
+		}
+	}
+
+	// mvhd.timescale is the movie-level timescale (not per-track). Use 1000 (ms)
+	// which is the conventional value for fragmented MP4 with no movie-level duration.
+	let timescale = 1000;
+
+	let moov = mp4_atom::Moov {
+		mvhd: mp4_atom::Mvhd {
+			timescale,
+			..Default::default()
+		},
+		trak: traks,
+		mvex: if trexs.is_empty() {
+			None
+		} else {
+			Some(mp4_atom::Mvex {
+				trex: trexs,
+				..Default::default()
+			})
+		},
+		..Default::default()
+	};
+
+	let mut buf = Vec::new();
+	ftyp.encode(&mut buf).map_err(|_| CmsfError::EncodeFailed)?;
+	moov.encode(&mut buf).map_err(|_| CmsfError::EncodeFailed)?;
+	Ok(Bytes::from(buf))
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use crate::cmsf::test_helpers::{build_init_segment, build_moof_mdat};
+	use mp4_atom::Encode;
+
+	#[test]
+	fn parse_keyframe() {
+		let data = build_moof_mdat(90000, 3000, 0x0200_0000);
+		let meta = parse_cmsf_metadata(&data).unwrap();
+		assert_eq!(meta.pts, 90000);
+		assert_eq!(meta.duration, 3000);
+		assert!(meta.is_keyframe);
+	}
+
+	#[test]
+	fn parse_non_keyframe() {
+		let data = build_moof_mdat(93000, 3000, 0x0001_0000);
+		let meta = parse_cmsf_metadata(&data).unwrap();
+		assert_eq!(meta.pts, 93000);
+		assert!(!meta.is_keyframe);
+	}
+
+	#[test]
+	fn parse_empty_input() {
+		assert!(matches!(parse_cmsf_metadata(&[]), Err(CmsfError::NoMoof)));
+	}
+
+	#[test]
+	fn parse_no_tfdt() {
+		let moof = mp4_atom::Moof {
+			mfhd: mp4_atom::Mfhd { sequence_number: 1 },
+			traf: vec![mp4_atom::Traf {
+				tfhd: mp4_atom::Tfhd {
+					track_id: 1,
+					..Default::default()
+				},
+				tfdt: None,
+				trun: vec![mp4_atom::Trun {
+					data_offset: Some(0),
+					entries: vec![mp4_atom::TrunEntry {
+						size: Some(4),
+						duration: Some(1000),
+						flags: Some(0x0200_0000),
+						..Default::default()
+					}],
+				}],
+				..Default::default()
+			}],
+		};
+		let mut buf = Vec::new();
+		moof.encode(&mut buf).unwrap();
+		assert!(matches!(parse_cmsf_metadata(&buf), Err(CmsfError::NoTfdt)));
+	}
+
+	#[test]
+	fn parse_no_trun() {
+		let moof = mp4_atom::Moof {
+			mfhd: mp4_atom::Mfhd { sequence_number: 1 },
+			traf: vec![mp4_atom::Traf {
+				tfhd: mp4_atom::Tfhd {
+					track_id: 1,
+					..Default::default()
+				},
+				tfdt: Some(mp4_atom::Tfdt {
+					base_media_decode_time: 0,
+				}),
+				trun: vec![],
+				..Default::default()
+			}],
+		};
+		let mut buf = Vec::new();
+		moof.encode(&mut buf).unwrap();
+		assert!(matches!(parse_cmsf_metadata(&buf), Err(CmsfError::NoTrun)));
+	}
+
+	#[test]
+	fn parse_timescale_valid() {
+		let init = build_init_segment(48000);
+		assert_eq!(parse_timescale(&init).unwrap(), 48000);
+	}
+
+	#[test]
+	fn parse_timescale_no_moov() {
+		assert!(matches!(parse_timescale(&[]), Err(CmsfError::NoMoov)));
+	}
+
+	#[test]
+	fn parse_multi_sample_duration() {
+		let entries: Vec<mp4_atom::TrunEntry> = (0..4)
+			.map(|i| mp4_atom::TrunEntry {
+				size: Some(4),
+				duration: Some(1000),
+				flags: Some(if i == 0 { 0x0200_0000 } else { 0x0001_0000 }),
+				..Default::default()
+			})
+			.collect();
+		let moof = mp4_atom::Moof {
+			mfhd: mp4_atom::Mfhd { sequence_number: 1 },
+			traf: vec![mp4_atom::Traf {
+				tfhd: mp4_atom::Tfhd {
+					track_id: 1,
+					..Default::default()
+				},
+				tfdt: Some(mp4_atom::Tfdt {
+					base_media_decode_time: 0,
+				}),
+				trun: vec![mp4_atom::Trun {
+					data_offset: Some(0),
+					entries,
+				}],
+				..Default::default()
+			}],
+		};
+		let mdat = mp4_atom::Mdat { data: vec![0; 16] };
+		let mut buf = Vec::new();
+		moof.encode(&mut buf).unwrap();
+		mdat.encode(&mut buf).unwrap();
+		let meta = parse_cmsf_metadata(&buf).unwrap();
+		assert_eq!(meta.duration, 4000);
+		assert!(meta.is_keyframe);
+	}
+
+	#[test]
+	fn parse_default_duration_fallback() {
+		let moof = mp4_atom::Moof {
+			mfhd: mp4_atom::Mfhd { sequence_number: 1 },
+			traf: vec![mp4_atom::Traf {
+				tfhd: mp4_atom::Tfhd {
+					track_id: 1,
+					default_sample_duration: Some(512),
+					default_sample_flags: Some(0x0200_0000),
+					..Default::default()
+				},
+				tfdt: Some(mp4_atom::Tfdt {
+					base_media_decode_time: 0,
+				}),
+				trun: vec![mp4_atom::Trun {
+					data_offset: Some(0),
+					entries: vec![
+						mp4_atom::TrunEntry {
+							size: Some(4),
+							..Default::default()
+						},
+						mp4_atom::TrunEntry {
+							size: Some(4),
+							..Default::default()
+						},
+						mp4_atom::TrunEntry {
+							size: Some(4),
+							..Default::default()
+						},
+					],
+				}],
+				..Default::default()
+			}],
+		};
+		let mdat = mp4_atom::Mdat { data: vec![0; 12] };
+		let mut buf = Vec::new();
+		moof.encode(&mut buf).unwrap();
+		mdat.encode(&mut buf).unwrap();
+		let meta = parse_cmsf_metadata(&buf).unwrap();
+		assert_eq!(meta.duration, 512 * 3);
+		assert!(meta.is_keyframe);
+	}
+}

--- a/rs/moq-mux/src/export/mod.rs
+++ b/rs/moq-mux/src/export/mod.rs
@@ -2,9 +2,12 @@
 //!
 //! [`Fmp4`] subscribes to a broadcast, decodes every track via
 //! [`Consumer<Hang>`](crate::container::Consumer), and yields a single fMP4 / CMAF byte
-//! stream — the merged init segment followed by moof+mdat fragments in
+//! stream. The merged init segment is followed by moof+mdat fragments in
 //! timestamp order across tracks.
+//!
+//! The [`cmsf`] module provides CMSF-native demuxing without the hang container layer.
 
+pub mod cmsf;
 mod fmp4;
 
 pub use fmp4::*;

--- a/rs/moq-mux/src/import/cmsf_broadcast.rs
+++ b/rs/moq-mux/src/import/cmsf_broadcast.rs
@@ -1,0 +1,838 @@
+use anyhow::Context;
+use base64::Engine;
+use bytes::Bytes;
+use hang::catalog::{Audio, AudioConfig, Container, Video, VideoConfig};
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::cmsf_types::{
+	CmsfAudioTrack, CmsfConfig, CmsfObject, CmsfTrackConfig, CmsfTrackProducer, CmsfVideoTrack, SapType, TrackId,
+};
+use super::fmp4_parser::TrackKind;
+
+/// Coordinates multi-rendition CMSF-compliant broadcast publishing.
+///
+/// ## Group Lifecycle
+///
+/// Video keyframes drive group boundaries. Each video keyframe starts a new moq-lite
+/// group. Non-switching audio (no `alt_group`) is aligned to video: a new audio group
+/// starts on each video keyframe. Switching audio (with `alt_group`) manages its own
+/// groups independently.
+///
+/// ## Audio Pre-Roll Buffering
+///
+/// Audio arriving before the first video keyframe is buffered and flushed once the
+/// first video keyframe arrives. This ensures subscribers joining at a group boundary
+/// get both the video keyframe and corresponding audio.
+///
+/// ## Explicit Group Mode
+///
+/// When `CmsfObject::group_id` is `Some(id)`, the track enters "explicit mode" —
+/// the caller controls group boundaries (e.g. for dual-pipeline redundancy).
+/// Explicit-mode audio bypasses the pre-roll buffer and is not auto-rotated on
+/// video keyframes.
+///
+/// ## SAP Type Derivation
+///
+/// SAP type is derived from the track's codec configuration rather than stream
+/// analysis. H264/VP8 keyframes → Type 1 (IDR), H265/AV1/VP9 → Type 2 (conservative,
+/// may be CRA). This is a known deviation from strict spec compliance — an H265
+/// stream with only IDR frames will be reported as Type 2.
+///
+/// Owns its catalog tracks independently of `catalog::Producer`. Publishes an MSF
+/// catalog with CMSF-specific metadata and optionally a hang catalog for backward
+/// compatibility.
+pub struct CmsfBroadcastProducer {
+	broadcast: moq_lite::BroadcastProducer,
+	pub(crate) msf_track: moq_lite::TrackProducer,
+	pub(crate) hang_track: Option<moq_lite::TrackProducer>,
+	pub(crate) tracks: Vec<CmsfTrackProducer>,
+	video_count: usize,
+	audio_count: usize,
+	audio_buffer: Vec<(TrackId, CmsfObject)>,
+	first_video_group: bool,
+	has_video_track: bool,
+	catalog_failed: bool,
+}
+
+impl CmsfBroadcastProducer {
+	/// Create a new CMSF broadcast producer that owns its catalog tracks.
+	pub fn new(mut broadcast: moq_lite::BroadcastProducer, config: CmsfConfig) -> anyhow::Result<Self> {
+		let msf_track = broadcast.create_track(moq_lite::Track::new("catalog"))?;
+		let hang_track = if config.publish_hang {
+			Some(broadcast.create_track(moq_lite::Track::new("catalog.json"))?)
+		} else {
+			None
+		};
+
+		Ok(Self {
+			broadcast,
+			msf_track,
+			hang_track,
+			tracks: Vec::new(),
+			video_count: 0,
+			audio_count: 0,
+			audio_buffer: Vec::new(),
+			first_video_group: false,
+			has_video_track: false,
+			catalog_failed: false,
+		})
+	}
+
+	/// Add a video track. Returns a handle for writing chunks.
+	pub fn add_video_track(&mut self, track: CmsfVideoTrack) -> anyhow::Result<TrackId> {
+		let init_data = base64::engine::general_purpose::STANDARD.encode(&track.init_segment);
+		let name = format!("video{}.m4s", self.video_count);
+		self.video_count += 1;
+
+		let moq_track = self.broadcast.create_track(moq_lite::Track::new(&name))?;
+		let id = TrackId(self.tracks.len());
+		let config = CmsfTrackConfig::Video {
+			codec: track.codec,
+			description: track.description,
+			width: track.width,
+			height: track.height,
+			bitrate: track.bitrate,
+			framerate: track.framerate,
+			init_data,
+		};
+		self.tracks.push(CmsfTrackProducer::new(
+			TrackKind::Video,
+			moq_track,
+			track.alt_group,
+			config,
+			track.timescale,
+		));
+		self.has_video_track = true;
+		self.publish_catalogs();
+		Ok(id)
+	}
+
+	/// Add an audio track. Returns a handle for writing chunks.
+	pub fn add_audio_track(&mut self, track: CmsfAudioTrack) -> anyhow::Result<TrackId> {
+		let init_data = base64::engine::general_purpose::STANDARD.encode(&track.init_segment);
+		let name = format!("audio{}.m4s", self.audio_count);
+		self.audio_count += 1;
+
+		let moq_track = self.broadcast.create_track(moq_lite::Track::new(&name))?;
+		let id = TrackId(self.tracks.len());
+		let config = CmsfTrackConfig::Audio {
+			codec: track.codec,
+			description: track.description,
+			sample_rate: track.sample_rate,
+			channel_count: track.channel_count,
+			bitrate: track.bitrate,
+			init_data,
+		};
+		self.tracks.push(CmsfTrackProducer::new(
+			TrackKind::Audio,
+			moq_track,
+			track.alt_group,
+			config,
+			track.timescale,
+		));
+		self.publish_catalogs();
+		Ok(id)
+	}
+
+	/// Write a CMSF Object to the specified track.
+	///
+	/// Internally parses moof+mdat metadata (PTS, duration, keyframe) and derives
+	/// SAP type from the track's codec configuration.
+	pub fn write(&mut self, track_id: TrackId, obj: CmsfObject) -> anyhow::Result<()> {
+		let meta = crate::cmsf::parse_cmsf_metadata(&obj.data)?;
+		let track = self.tracks.get(track_id.0).context("invalid track ID")?;
+		let sap_type = if meta.is_keyframe {
+			track.sap_type_for_keyframe()
+		} else {
+			SapType::None
+		};
+		let kind = track.kind;
+		let alt_group = track.alt_group;
+		let is_non_switching_audio = kind == TrackKind::Audio && alt_group.is_none();
+		let is_explicit = obj.group_id.is_some();
+
+		// Explicit-mode audio bypasses the pre-roll buffer.
+		if is_non_switching_audio && is_explicit {
+			let track = self.tracks.get_mut(track_id.0).unwrap();
+			track.explicit_groups = true;
+			if let Some(id) = obj.group_id {
+				if let Some(last) = track.last_explicit_group_id {
+					anyhow::ensure!(id >= last, "non-monotonic group_id: {id} < {last}");
+				}
+				if track.group.is_none() || track.last_explicit_group_id != Some(id) {
+					track.validate_group_sap(sap_type)?;
+					track.start_group(Some(id))?;
+				}
+				track.last_explicit_group_id = Some(id);
+			}
+			track.track_object_sap(sap_type);
+			track.write_fragment(obj.data)?;
+			let _ = track.update_jitter(meta.pts, Some(meta.duration));
+			return Ok(());
+		}
+
+		// Auto-mode non-switching audio: buffer before first video keyframe.
+		if is_non_switching_audio && self.has_video_track && !self.first_video_group {
+			self.audio_buffer.push((track_id, obj));
+			return Ok(());
+		}
+
+		// Auto-mode non-switching audio after first video group.
+		if is_non_switching_audio && self.has_video_track {
+			let track = self.tracks.get_mut(track_id.0).unwrap();
+			if track.group.is_none() {
+				track.validate_group_sap(sap_type)?;
+				track.start_group(None)?;
+			}
+			track.track_object_sap(sap_type);
+			track.write_fragment(obj.data)?;
+			let _ = track.update_jitter(meta.pts, Some(meta.duration));
+			return Ok(());
+		}
+
+		// Video or switching audio track.
+		let is_keyframe = sap_type.is_keyframe();
+		let is_video_keyframe = kind == TrackKind::Video && is_keyframe;
+		let track = self.tracks.get_mut(track_id.0).unwrap();
+
+		if track.group.is_none() && !is_keyframe {
+			anyhow::bail!("first chunk for track must be a keyframe");
+		}
+
+		if is_keyframe {
+			track.validate_group_sap(sap_type)?;
+			if is_explicit {
+				track.explicit_groups = true;
+				let id = obj.group_id.unwrap();
+				if let Some(last) = track.last_explicit_group_id {
+					anyhow::ensure!(id >= last, "non-monotonic group_id: {id} < {last}");
+				}
+				if track.last_explicit_group_id != Some(id) {
+					track.start_group(Some(id))?;
+				}
+				track.last_explicit_group_id = Some(id);
+			} else {
+				track.start_group(None)?;
+			}
+		}
+
+		track.track_object_sap(sap_type);
+		track.write_fragment(obj.data)?;
+		let jitter_changed = track.update_jitter(meta.pts, Some(meta.duration));
+
+		let republish = track.sap_changed() || (jitter_changed && track.jitter.is_some());
+
+		if republish {
+			self.publish_catalogs();
+		}
+
+		if is_video_keyframe {
+			if !self.first_video_group {
+				self.first_video_group = true;
+				self.flush_audio_buffer()?;
+			} else {
+				self.start_non_switching_audio_groups()?;
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Build the MSF catalog from current track state.
+	pub fn msf_catalog(&self) -> moq_msf::Catalog {
+		let tracks = self
+			.tracks
+			.iter()
+			.map(|tp| match &tp.config {
+				CmsfTrackConfig::Video {
+					codec,
+					width,
+					height,
+					framerate,
+					bitrate,
+					init_data,
+					..
+				} => moq_msf::Track {
+					name: tp.track.name.clone(),
+					packaging: moq_msf::Packaging::Cmaf,
+					is_live: true,
+					role: Some(moq_msf::Role::Video),
+					codec: Some(codec.to_string()),
+					width: *width,
+					height: *height,
+					framerate: *framerate,
+					samplerate: None,
+					channel_config: None,
+					bitrate: *bitrate,
+					init_data: Some(init_data.clone()),
+					render_group: Some(1),
+					alt_group: tp.alt_group,
+					max_grp_sap_starting_type: tp.max_grp_sap.to_msf_value(),
+					max_obj_sap_starting_type: tp.max_obj_sap.to_msf_value(),
+				},
+				CmsfTrackConfig::Audio {
+					codec,
+					sample_rate,
+					channel_count,
+					bitrate,
+					init_data,
+					..
+				} => moq_msf::Track {
+					name: tp.track.name.clone(),
+					packaging: moq_msf::Packaging::Cmaf,
+					is_live: true,
+					role: Some(moq_msf::Role::Audio),
+					codec: Some(codec.to_string()),
+					width: None,
+					height: None,
+					framerate: None,
+					samplerate: Some(*sample_rate),
+					channel_config: Some(channel_count.to_string()),
+					bitrate: *bitrate,
+					init_data: Some(init_data.clone()),
+					render_group: Some(1),
+					alt_group: tp.alt_group,
+					max_grp_sap_starting_type: tp.max_grp_sap.to_msf_value(),
+					max_obj_sap_starting_type: tp.max_obj_sap.to_msf_value(),
+				},
+			})
+			.collect();
+
+		moq_msf::Catalog {
+			version: 1,
+			generated_at: SystemTime::now()
+				.duration_since(UNIX_EPOCH)
+				.ok()
+				// u128 → u64 truncation is safe until year ~584 million.
+				.map(|d| d.as_millis() as u64),
+			tracks,
+		}
+	}
+
+	/// Finish all tracks and catalog tracks.
+	pub fn finish(&mut self) -> anyhow::Result<()> {
+		for track in &mut self.tracks {
+			track.finish()?;
+		}
+		self.msf_track.finish()?;
+		if let Some(hang) = &mut self.hang_track {
+			hang.finish()?;
+		}
+		Ok(())
+	}
+
+	fn flush_audio_buffer(&mut self) -> anyhow::Result<()> {
+		let buffer = std::mem::take(&mut self.audio_buffer);
+		for (tid, obj) in buffer {
+			let meta = crate::cmsf::parse_cmsf_metadata(&obj.data)?;
+			let track = self.tracks.get_mut(tid.0).context("invalid track ID")?;
+			let sap_type = if meta.is_keyframe {
+				track.sap_type_for_keyframe()
+			} else {
+				SapType::None
+			};
+			if track.group.is_none() {
+				track.validate_group_sap(sap_type)?;
+				track.start_group(None)?;
+			}
+			track.track_object_sap(sap_type);
+			track.write_fragment(obj.data)?;
+			let _ = track.update_jitter(meta.pts, Some(meta.duration));
+		}
+		Ok(())
+	}
+
+	fn start_non_switching_audio_groups(&mut self) -> anyhow::Result<()> {
+		for track in &mut self.tracks {
+			if track.kind == TrackKind::Audio
+				&& track.alt_group.is_none()
+				&& track.group.is_some()
+				&& !track.explicit_groups
+			{
+				track.start_group(None)?;
+			}
+		}
+		Ok(())
+	}
+
+	fn build_hang_catalog(&self) -> hang::Catalog {
+		let mut video_renditions = BTreeMap::new();
+		let mut audio_renditions = BTreeMap::new();
+
+		for tp in &self.tracks {
+			match &tp.config {
+				CmsfTrackConfig::Video {
+					codec,
+					description,
+					width,
+					height,
+					bitrate,
+					framerate,
+					init_data,
+				} => {
+					let init_bytes = base64::engine::general_purpose::STANDARD
+						.decode(init_data)
+						.unwrap_or_default();
+					video_renditions.insert(
+						tp.track.name.clone(),
+						VideoConfig {
+							codec: codec.clone(),
+							description: description.clone(),
+							coded_width: *width,
+							coded_height: *height,
+							bitrate: *bitrate,
+							framerate: *framerate,
+							container: Container::Cmaf {
+								init: Bytes::from(init_bytes),
+							},
+							jitter: tp.jitter_as_time(),
+							display_ratio_width: None,
+							display_ratio_height: None,
+							optimize_for_latency: None,
+						},
+					);
+				}
+				CmsfTrackConfig::Audio {
+					codec,
+					description,
+					sample_rate,
+					channel_count,
+					bitrate,
+					init_data,
+				} => {
+					let init_bytes = base64::engine::general_purpose::STANDARD
+						.decode(init_data)
+						.unwrap_or_default();
+					audio_renditions.insert(
+						tp.track.name.clone(),
+						AudioConfig {
+							codec: codec.clone(),
+							description: description.clone(),
+							sample_rate: *sample_rate,
+							channel_count: *channel_count,
+							bitrate: *bitrate,
+							container: Container::Cmaf {
+								init: Bytes::from(init_bytes),
+							},
+							jitter: tp.jitter_as_time(),
+						},
+					);
+				}
+			}
+		}
+
+		hang::Catalog {
+			video: Video {
+				renditions: video_renditions,
+				..Default::default()
+			},
+			audio: Audio {
+				renditions: audio_renditions,
+			},
+			..Default::default()
+		}
+	}
+
+	fn publish_catalogs(&mut self) {
+		if self.catalog_failed {
+			return;
+		}
+
+		let msf = self.msf_catalog();
+		let Ok(msf_json) = msf.to_string() else {
+			tracing::warn!("failed to serialize MSF catalog");
+			return;
+		};
+		let Ok(mut group) = self.msf_track.append_group() else {
+			tracing::warn!("catalog track closed, stopping catalog updates");
+			self.catalog_failed = true;
+			return;
+		};
+		if group.write_frame(msf_json).is_err() {
+			tracing::warn!("failed to write MSF catalog frame");
+		}
+		let _ = group.finish();
+
+		// NB: can't use `if let Some(t) = &mut self.hang_track` because
+		// build_hang_catalog() borrows self.tracks immutably.
+		#[allow(clippy::unnecessary_unwrap)]
+		if self.hang_track.is_some() {
+			let hang = self.build_hang_catalog();
+			let Ok(hang_json) = hang.to_string() else {
+				tracing::warn!("failed to serialize hang catalog");
+				return;
+			};
+			let hang_track = self.hang_track.as_mut().unwrap();
+			let Ok(mut group) = hang_track.append_group() else {
+				tracing::warn!("failed to create hang catalog group");
+				return;
+			};
+			if group.write_frame(hang_json).is_err() {
+				tracing::warn!("failed to write hang catalog frame");
+			}
+			let _ = group.finish();
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use hang::catalog::{AudioCodec, H264};
+
+	fn make_producer(config: CmsfConfig) -> CmsfBroadcastProducer {
+		let broadcast = moq_lite::Broadcast::new().produce();
+		CmsfBroadcastProducer::new(broadcast, config).unwrap()
+	}
+
+	fn video_track() -> CmsfVideoTrack {
+		CmsfVideoTrack {
+			codec: H264 {
+				profile: 100,
+				constraints: 0,
+				level: 31,
+				inline: false,
+			}
+			.into(),
+			description: None,
+			width: Some(1280),
+			height: Some(720),
+			bitrate: Some(6_000_000),
+			framerate: Some(30.0),
+			init_segment: Bytes::from_static(b"video-init"),
+			alt_group: Some(1),
+			timescale: 90000,
+		}
+	}
+
+	fn audio_track() -> CmsfAudioTrack {
+		CmsfAudioTrack {
+			codec: AudioCodec::Opus,
+			description: None,
+			sample_rate: 48000,
+			channel_count: 2,
+			bitrate: Some(128_000),
+			init_segment: Bytes::from_static(b"audio-init"),
+			alt_group: Some(2),
+			timescale: 48000,
+		}
+	}
+
+	// --- Constructor tests ---
+
+	#[test]
+	fn test_constructor_creates_msf_track() {
+		let p = make_producer(CmsfConfig::default());
+		assert_eq!(p.msf_track.name, "catalog");
+	}
+
+	#[test]
+	fn test_constructor_hang_creates_both() {
+		let config = CmsfConfig { publish_hang: true };
+		let p = make_producer(config);
+		assert!(p.hang_track.is_some());
+		assert_eq!(p.hang_track.as_ref().unwrap().name, "catalog.json");
+	}
+
+	#[test]
+	fn test_constructor_no_hang_by_default() {
+		let p = make_producer(CmsfConfig::default());
+		assert!(p.hang_track.is_none());
+	}
+
+	// --- Track addition tests ---
+
+	#[test]
+	fn test_add_video_track_sequential_ids() {
+		let mut p = make_producer(CmsfConfig::default());
+		let id0 = p.add_video_track(video_track()).unwrap();
+		let id1 = p.add_video_track(video_track()).unwrap();
+		assert_eq!(id0, TrackId(0));
+		assert_eq!(id1, TrackId(1));
+	}
+
+	#[test]
+	fn test_add_audio_track() {
+		let mut p = make_producer(CmsfConfig::default());
+		let id = p.add_audio_track(audio_track()).unwrap();
+		assert_eq!(id, TrackId(0));
+		assert_eq!(p.tracks[0].kind, TrackKind::Audio);
+	}
+
+	#[test]
+	fn test_track_naming() {
+		let mut p = make_producer(CmsfConfig::default());
+		p.add_video_track(video_track()).unwrap();
+		p.add_video_track(video_track()).unwrap();
+		p.add_audio_track(audio_track()).unwrap();
+		assert_eq!(p.tracks[0].track.name, "video0.m4s");
+		assert_eq!(p.tracks[1].track.name, "video1.m4s");
+		assert_eq!(p.tracks[2].track.name, "audio0.m4s");
+	}
+
+	#[test]
+	fn test_add_video_base64_init_data() {
+		let mut p = make_producer(CmsfConfig::default());
+		p.add_video_track(video_track()).unwrap();
+		match &p.tracks[0].config {
+			CmsfTrackConfig::Video { init_data, .. } => {
+				let decoded = base64::engine::general_purpose::STANDARD.decode(init_data).unwrap();
+				assert_eq!(decoded, b"video-init");
+			}
+			_ => panic!("expected Video config"),
+		}
+	}
+
+	// --- MSF catalog tests ---
+
+	#[test]
+	fn test_msf_catalog_empty() {
+		let p = make_producer(CmsfConfig::default());
+		let msf = p.msf_catalog();
+		assert_eq!(msf.version, 1);
+		assert!(msf.generated_at.is_some());
+		assert!(msf.tracks.is_empty());
+	}
+
+	#[test]
+	fn test_msf_catalog_video_track() {
+		let mut p = make_producer(CmsfConfig::default());
+		p.add_video_track(video_track()).unwrap();
+		let msf = p.msf_catalog();
+
+		assert_eq!(msf.tracks.len(), 1);
+		let t = &msf.tracks[0];
+		assert_eq!(t.name, "video0.m4s");
+		assert_eq!(t.packaging, moq_msf::Packaging::Cmaf);
+		assert!(t.is_live);
+		assert_eq!(t.role, Some(moq_msf::Role::Video));
+		assert_eq!(t.width, Some(1280));
+		assert_eq!(t.height, Some(720));
+		assert_eq!(t.framerate, Some(30.0));
+		assert_eq!(t.bitrate, Some(6_000_000));
+		assert_eq!(t.render_group, Some(1));
+		assert_eq!(t.alt_group, Some(1));
+		let decoded = base64::engine::general_purpose::STANDARD
+			.decode(t.init_data.as_ref().unwrap())
+			.unwrap();
+		assert_eq!(decoded, b"video-init");
+	}
+
+	#[test]
+	fn test_msf_catalog_audio_track() {
+		let mut p = make_producer(CmsfConfig::default());
+		p.add_audio_track(audio_track()).unwrap();
+		let msf = p.msf_catalog();
+
+		let t = &msf.tracks[0];
+		assert_eq!(t.name, "audio0.m4s");
+		assert_eq!(t.role, Some(moq_msf::Role::Audio));
+		assert_eq!(t.samplerate, Some(48000));
+		assert_eq!(t.channel_config, Some("2".into()));
+		assert_eq!(t.bitrate, Some(128_000));
+		assert_eq!(t.alt_group, Some(2));
+	}
+
+	#[test]
+	fn test_msf_catalog_sap_before_chunks() {
+		let mut p = make_producer(CmsfConfig::default());
+		p.add_video_track(video_track()).unwrap();
+		let msf = p.msf_catalog();
+		let t = &msf.tracks[0];
+		assert_eq!(t.max_grp_sap_starting_type, None);
+		assert_eq!(t.max_obj_sap_starting_type, None);
+	}
+
+	#[test]
+	fn test_msf_catalog_sap_after_chunks() {
+		let mut p = make_producer(CmsfConfig::default());
+		let id = p.add_video_track(video_track()).unwrap();
+		p.write(id, cmsf_obj(0, 3003, KF_FLAGS, None)).unwrap();
+		let msf = p.msf_catalog();
+		let t = &msf.tracks[0];
+		assert_eq!(t.max_grp_sap_starting_type, Some(1));
+		assert_eq!(t.max_obj_sap_starting_type, Some(1));
+	}
+
+	// --- Finish test ---
+
+	#[test]
+	fn test_finish() {
+		let mut p = make_producer(CmsfConfig::default());
+		p.add_video_track(video_track()).unwrap();
+		p.finish().unwrap();
+	}
+
+	// --- write() method tests ---
+
+	use crate::cmsf::test_helpers::build_moof_mdat;
+
+	const KF_FLAGS: u32 = 0x0200_0000;
+	const NON_KF_FLAGS: u32 = 0x0001_0000;
+
+	fn cmsf_obj(dts: u64, duration: u32, flags: u32, group_id: Option<u64>) -> CmsfObject {
+		CmsfObject {
+			data: Bytes::from(build_moof_mdat(dts, duration, flags)),
+			group_id,
+		}
+	}
+
+	#[test]
+	fn test_write_keyframe_starts_group() {
+		let mut p = make_producer(CmsfConfig::default());
+		let id = p.add_video_track(video_track()).unwrap();
+		p.write(id, cmsf_obj(0, 3003, KF_FLAGS, None)).unwrap();
+		assert!(p.tracks[0].group.is_some());
+	}
+
+	#[test]
+	fn test_write_non_keyframe_continues() {
+		let mut p = make_producer(CmsfConfig::default());
+		let id = p.add_video_track(video_track()).unwrap();
+		p.write(id, cmsf_obj(0, 3003, KF_FLAGS, None)).unwrap();
+		p.write(id, cmsf_obj(3003, 3003, NON_KF_FLAGS, None)).unwrap();
+	}
+
+	#[test]
+	fn test_write_non_keyframe_first_fails() {
+		let mut p = make_producer(CmsfConfig::default());
+		let id = p.add_video_track(video_track()).unwrap();
+		let err = p.write(id, cmsf_obj(0, 3003, NON_KF_FLAGS, None)).unwrap_err();
+		assert!(err.to_string().contains("keyframe"));
+	}
+
+	#[test]
+	fn test_write_audio_buffered_before_video_keyframe() {
+		let mut p = make_producer(CmsfConfig::default());
+		p.add_video_track(video_track()).unwrap();
+		let aid = p
+			.add_audio_track(CmsfAudioTrack {
+				alt_group: None,
+				..audio_track()
+			})
+			.unwrap();
+		p.write(aid, cmsf_obj(0, 1024, KF_FLAGS, None)).unwrap();
+		assert!(p.tracks[aid.0].group.is_none());
+		assert_eq!(p.audio_buffer.len(), 1);
+	}
+
+	#[test]
+	fn test_write_audio_flushed_on_video_keyframe() {
+		let mut p = make_producer(CmsfConfig::default());
+		let vid = p.add_video_track(video_track()).unwrap();
+		let aid = p
+			.add_audio_track(CmsfAudioTrack {
+				alt_group: None,
+				..audio_track()
+			})
+			.unwrap();
+		p.write(aid, cmsf_obj(0, 1024, KF_FLAGS, None)).unwrap();
+		p.write(vid, cmsf_obj(0, 3003, KF_FLAGS, None)).unwrap();
+		assert!(p.audio_buffer.is_empty());
+		assert!(p.tracks[aid.0].group.is_some());
+	}
+
+	#[test]
+	fn test_write_explicit_audio_bypasses_buffer() {
+		let mut p = make_producer(CmsfConfig::default());
+		p.add_video_track(video_track()).unwrap();
+		let aid = p
+			.add_audio_track(CmsfAudioTrack {
+				alt_group: None,
+				..audio_track()
+			})
+			.unwrap();
+		p.write(aid, cmsf_obj(0, 1024, KF_FLAGS, Some(1))).unwrap();
+		assert!(p.audio_buffer.is_empty());
+		assert!(p.tracks[aid.0].group.is_some());
+		assert!(p.tracks[aid.0].explicit_groups);
+	}
+
+	#[test]
+	fn test_write_explicit_audio_not_rotated_on_video_keyframe() {
+		let mut p = make_producer(CmsfConfig::default());
+		let vid = p.add_video_track(video_track()).unwrap();
+		let aid = p
+			.add_audio_track(CmsfAudioTrack {
+				alt_group: None,
+				..audio_track()
+			})
+			.unwrap();
+		// Explicit audio write
+		p.write(aid, cmsf_obj(0, 1024, KF_FLAGS, Some(1))).unwrap();
+		// First video keyframe
+		p.write(vid, cmsf_obj(0, 3003, KF_FLAGS, None)).unwrap();
+		// Second video keyframe — should NOT rotate explicit audio
+		p.write(vid, cmsf_obj(90000, 3003, KF_FLAGS, None)).unwrap();
+		// Audio group_id should still be 1 (not auto-rotated)
+		assert_eq!(p.tracks[aid.0].last_explicit_group_id, Some(1));
+	}
+
+	#[test]
+	fn test_write_malformed_data_returns_error() {
+		let mut p = make_producer(CmsfConfig::default());
+		let id = p.add_video_track(video_track()).unwrap();
+		let result = p.write(
+			id,
+			CmsfObject {
+				data: Bytes::from_static(b"garbage"),
+				group_id: None,
+			},
+		);
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_write_jitter_from_parsed_pts() {
+		let mut p = make_producer(CmsfConfig::default());
+		let id = p.add_video_track(video_track()).unwrap();
+		p.write(id, cmsf_obj(0, 3003, KF_FLAGS, None)).unwrap();
+		p.write(id, cmsf_obj(3003, 3003, NON_KF_FLAGS, None)).unwrap();
+		p.write(id, cmsf_obj(6006, 3003, NON_KF_FLAGS, None)).unwrap();
+		assert_eq!(p.tracks[0].jitter, Some(3003));
+	}
+
+	// --- Explicit group_id edge case tests ---
+
+	#[test]
+	fn test_write_sequential_explicit_groups() {
+		let mut p = make_producer(CmsfConfig::default());
+		let id = p.add_video_track(video_track()).unwrap();
+		p.write(id, cmsf_obj(0, 3003, KF_FLAGS, Some(1))).unwrap();
+		p.write(id, cmsf_obj(90000, 3003, KF_FLAGS, Some(2))).unwrap();
+		assert_eq!(p.tracks[0].last_explicit_group_id, Some(2));
+		assert!(p.tracks[0].explicit_groups);
+	}
+
+	#[test]
+	fn test_write_same_group_id_no_new_group() {
+		let mut p = make_producer(CmsfConfig::default());
+		let id = p.add_video_track(video_track()).unwrap();
+		p.write(id, cmsf_obj(0, 3003, KF_FLAGS, Some(1))).unwrap();
+		// Same group_id, non-keyframe — continues current group
+		p.write(id, cmsf_obj(3003, 3003, NON_KF_FLAGS, Some(1))).unwrap();
+		assert_eq!(p.tracks[0].last_explicit_group_id, Some(1));
+	}
+
+	#[test]
+	fn test_write_none_after_latch_continues_group() {
+		let mut p = make_producer(CmsfConfig::default());
+		let id = p.add_video_track(video_track()).unwrap();
+		p.write(id, cmsf_obj(0, 3003, KF_FLAGS, Some(5))).unwrap();
+		// None in explicit mode = continue current group
+		p.write(id, cmsf_obj(3003, 3003, NON_KF_FLAGS, None)).unwrap();
+		// Then a new explicit group
+		p.write(id, cmsf_obj(90000, 3003, KF_FLAGS, Some(7))).unwrap();
+		assert_eq!(p.tracks[0].last_explicit_group_id, Some(7));
+	}
+
+	#[test]
+	fn test_write_non_monotonic_group_id_errors() {
+		let mut p = make_producer(CmsfConfig::default());
+		let id = p.add_video_track(video_track()).unwrap();
+		p.write(id, cmsf_obj(0, 3003, KF_FLAGS, Some(5))).unwrap();
+		let err = p.write(id, cmsf_obj(90000, 3003, KF_FLAGS, Some(3))).unwrap_err();
+		assert!(err.to_string().contains("non-monotonic"));
+	}
+}

--- a/rs/moq-mux/src/import/cmsf_fmp4.rs
+++ b/rs/moq-mux/src/import/cmsf_fmp4.rs
@@ -1,0 +1,402 @@
+use anyhow::Context;
+use bytes::{Buf, Bytes, BytesMut};
+use hang::catalog::{AAC, AV1, AudioCodec, H264, H265, VP9, VideoCodec};
+use mp4_atom::{Atom, Moov, Trak};
+use std::collections::HashMap;
+use tokio::io::AsyncRead;
+
+use super::cmsf_broadcast::CmsfBroadcastProducer;
+use super::cmsf_types::{CmsfAudioTrack, CmsfConfig, CmsfObject, CmsfVideoTrack, TrackId};
+use super::fmp4::build_aac_audio_specific_config;
+use super::fmp4_parser::{Fmp4Parser, Fmp4Sink, SampleInfo, TrackKind, build_init_segment};
+
+/// Bridges fMP4 input to CMSF broadcast output.
+///
+/// Parses fragmented MP4 via `Fmp4Parser`, auto-detects codecs, and feeds
+/// `CmsfObject`s to a `CmsfBroadcastProducer`.
+pub struct CmsfFmp4Importer {
+	parser: Fmp4Parser<CmsfFmp4Consumer>,
+}
+
+struct CmsfFmp4Consumer {
+	producer: CmsfBroadcastProducer,
+	track_map: HashMap<u32, TrackId>,
+}
+
+impl Fmp4Sink for CmsfFmp4Consumer {
+	fn on_init(&mut self, track_id: u32, kind: TrackKind, trak: &Trak, moov: &Moov) -> anyhow::Result<()> {
+		let init_segment = build_init_segment(trak, moov)?;
+		let timescale = trak.mdia.mdhd.timescale as u64;
+
+		let id = match kind {
+			TrackKind::Video => {
+				let (mut track, _is_h264) = build_video_config(trak)?;
+				track.init_segment = init_segment;
+				track.timescale = timescale;
+				self.producer.add_video_track(track)?
+			}
+			TrackKind::Audio => {
+				let mut track = build_audio_config(trak)?;
+				track.init_segment = init_segment;
+				track.timescale = timescale;
+				self.producer.add_audio_track(track)?
+			}
+		};
+
+		self.track_map.insert(track_id, id);
+		Ok(())
+	}
+
+	fn on_fragment(
+		&mut self,
+		track_id: u32,
+		fragment: Bytes,
+		_keyframe: bool,
+		_samples: Vec<SampleInfo>,
+	) -> anyhow::Result<()> {
+		let &moq_track_id = self.track_map.get(&track_id).context("unknown track")?;
+		self.producer.write(
+			moq_track_id,
+			CmsfObject {
+				data: fragment,
+				group_id: None,
+			},
+		)
+	}
+}
+
+impl CmsfFmp4Importer {
+	/// Create a new CMSF fMP4 importer.
+	pub fn new(broadcast: moq_lite::BroadcastProducer, config: CmsfConfig) -> anyhow::Result<Self> {
+		let producer = CmsfBroadcastProducer::new(broadcast, config)?;
+		Ok(Self {
+			parser: Fmp4Parser::new(CmsfFmp4Consumer {
+				producer,
+				track_map: HashMap::new(),
+			}),
+		})
+	}
+
+	pub async fn decode_from<T: AsyncRead + Unpin>(&mut self, reader: &mut T) -> anyhow::Result<()> {
+		self.parser.decode_from(reader).await
+	}
+
+	pub fn decode<T: Buf + AsRef<[u8]>>(&mut self, buf: &mut T) -> anyhow::Result<()> {
+		self.parser.decode(buf)
+	}
+
+	pub fn is_initialized(&self) -> bool {
+		self.parser.is_initialized()
+	}
+
+	pub fn finish(&mut self) -> anyhow::Result<()> {
+		self.parser.sink.producer.finish()
+	}
+
+	/// Get the current MSF catalog.
+	pub fn msf_catalog(&self) -> moq_msf::Catalog {
+		self.parser.sink.producer.msf_catalog()
+	}
+}
+
+/// Build video config from an fMP4 track.
+///
+/// NOTE: All video tracks are assigned `alt_group: Some(1)` — this assumes a single
+/// ABR ladder where all video renditions are switchable. Multi-angle or independent
+/// video tracks are not supported via the fMP4 import path.
+fn build_video_config(trak: &Trak) -> anyhow::Result<(CmsfVideoTrack, bool)> {
+	let stsd = &trak.mdia.minf.stbl.stsd;
+	let codec = match stsd.codecs.len() {
+		0 => anyhow::bail!("missing codec"),
+		1 => &stsd.codecs[0],
+		_ => anyhow::bail!("multiple codecs"),
+	};
+
+	let (video_codec, description, width, height, is_h264) = match codec {
+		mp4_atom::Codec::Avc1(avc1) => {
+			let mut desc = BytesMut::new();
+			avc1.avcc.encode_body(&mut desc)?;
+			(
+				H264 {
+					profile: avc1.avcc.avc_profile_indication,
+					constraints: avc1.avcc.profile_compatibility,
+					level: avc1.avcc.avc_level_indication,
+					inline: false,
+				}
+				.into(),
+				Some(desc.freeze()),
+				avc1.visual.width as u32,
+				avc1.visual.height as u32,
+				true,
+			)
+		}
+		mp4_atom::Codec::Hev1(hev1) => {
+			let (c, d, w, h) = build_h265(true, &hev1.hvcc, &hev1.visual)?;
+			(c, Some(d), w, h, false)
+		}
+		mp4_atom::Codec::Hvc1(hvc1) => {
+			let (c, d, w, h) = build_h265(false, &hvc1.hvcc, &hvc1.visual)?;
+			(c, Some(d), w, h, false)
+		}
+		mp4_atom::Codec::Vp08(vp08) => (
+			VideoCodec::VP8,
+			None,
+			vp08.visual.width as u32,
+			vp08.visual.height as u32,
+			false,
+		),
+		mp4_atom::Codec::Vp09(vp09) => {
+			let vpcc = &vp09.vpcc;
+			(
+				VP9 {
+					profile: vpcc.profile,
+					level: vpcc.level,
+					bit_depth: vpcc.bit_depth,
+					color_primaries: vpcc.color_primaries,
+					chroma_subsampling: vpcc.chroma_subsampling,
+					transfer_characteristics: vpcc.transfer_characteristics,
+					matrix_coefficients: vpcc.matrix_coefficients,
+					full_range: vpcc.video_full_range_flag,
+				}
+				.into(),
+				None,
+				vp09.visual.width as u32,
+				vp09.visual.height as u32,
+				false,
+			)
+		}
+		mp4_atom::Codec::Av01(av01) => {
+			let av1c = &av01.av1c;
+			(
+				AV1 {
+					profile: av1c.seq_profile,
+					level: av1c.seq_level_idx_0,
+					bitdepth: match (av1c.seq_tier_0, av1c.high_bitdepth) {
+						(true, true) => 12,
+						(true, false) | (false, true) => 10,
+						(false, false) => 8,
+					},
+					mono_chrome: av1c.monochrome,
+					chroma_subsampling_x: av1c.chroma_subsampling_x,
+					chroma_subsampling_y: av1c.chroma_subsampling_y,
+					chroma_sample_position: av1c.chroma_sample_position,
+					..Default::default()
+				}
+				.into(),
+				None,
+				av01.visual.width as u32,
+				av01.visual.height as u32,
+				false,
+			)
+		}
+		mp4_atom::Codec::Unknown(unknown) => anyhow::bail!("unknown codec: {:?}", unknown),
+		unsupported => anyhow::bail!("unsupported codec: {:?}", unsupported),
+	};
+
+	Ok((
+		CmsfVideoTrack {
+			codec: video_codec,
+			description,
+			width: Some(width),
+			height: Some(height),
+			bitrate: None,
+			framerate: None,
+			init_segment: Bytes::new(),
+			alt_group: Some(1),
+			timescale: 0,
+		},
+		is_h264,
+	))
+}
+
+fn build_h265(
+	in_band: bool,
+	hvcc: &mp4_atom::Hvcc,
+	visual: &mp4_atom::Visual,
+) -> anyhow::Result<(VideoCodec, Bytes, u32, u32)> {
+	let mut desc = BytesMut::new();
+	hvcc.encode_body(&mut desc)?;
+	Ok((
+		H265 {
+			in_band,
+			profile_space: hvcc.general_profile_space,
+			profile_idc: hvcc.general_profile_idc,
+			profile_compatibility_flags: hvcc.general_profile_compatibility_flags,
+			tier_flag: hvcc.general_tier_flag,
+			level_idc: hvcc.general_level_idc,
+			constraint_flags: hvcc.general_constraint_indicator_flags,
+		}
+		.into(),
+		desc.freeze(),
+		visual.width as u32,
+		visual.height as u32,
+	))
+}
+
+/// Build audio config from an fMP4 track.
+///
+/// NOTE: All audio tracks are assigned `alt_group: Some(2)` — this makes them
+/// "switching audio" in CMSF terms. Non-switching audio (aligned to video groups)
+/// is not triggered via the fMP4 import path.
+fn build_audio_config(trak: &Trak) -> anyhow::Result<CmsfAudioTrack> {
+	let stsd = &trak.mdia.minf.stbl.stsd;
+	let codec = match stsd.codecs.len() {
+		0 => anyhow::bail!("missing codec"),
+		1 => &stsd.codecs[0],
+		_ => anyhow::bail!("multiple codecs"),
+	};
+
+	let track = match codec {
+		mp4_atom::Codec::Mp4a(mp4a) => {
+			let desc = &mp4a.esds.es_desc.dec_config;
+			if desc.object_type_indication != 0x40 {
+				anyhow::bail!("unsupported codec: MPEG2");
+			}
+			let bitrate = desc.avg_bitrate.max(desc.max_bitrate);
+			let profile = desc.dec_specific.profile;
+			let sample_rate = mp4a.audio.sample_rate.integer() as u32;
+			let channel_count = mp4a.audio.channel_count as u32;
+			let description = build_aac_audio_specific_config(profile, sample_rate, channel_count);
+			CmsfAudioTrack {
+				codec: AAC { profile }.into(),
+				description: Some(description),
+				sample_rate,
+				channel_count,
+				bitrate: Some(bitrate.into()),
+				init_segment: Bytes::new(),
+				alt_group: Some(2),
+				timescale: 0,
+			}
+		}
+		mp4_atom::Codec::Opus(opus) => CmsfAudioTrack {
+			codec: AudioCodec::Opus,
+			description: None,
+			sample_rate: opus.audio.sample_rate.integer() as _,
+			channel_count: opus.audio.channel_count as _,
+			bitrate: None,
+			init_segment: Bytes::new(),
+			alt_group: Some(2),
+			timescale: 0,
+		},
+		mp4_atom::Codec::Unknown(unknown) => anyhow::bail!("unknown codec: {:?}", unknown),
+		unsupported => anyhow::bail!("unsupported codec: {:?}", unsupported),
+	};
+
+	Ok(track)
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use base64::Engine;
+
+	fn run_cmsf_fmp4(data: &[u8]) -> CmsfFmp4Importer {
+		let broadcast = moq_lite::Broadcast::new().produce();
+		let mut importer = CmsfFmp4Importer::new(broadcast, CmsfConfig::default()).unwrap();
+		let mut buf = bytes::BytesMut::from(data);
+		let _ = importer.decode(&mut buf);
+		importer
+	}
+
+	#[test]
+	fn test_bbb_creates_tracks() {
+		let data = include_bytes!("test/bbb.mp4");
+		let importer = run_cmsf_fmp4(data);
+		assert!(importer.is_initialized());
+		assert_eq!(importer.parser.sink.track_map.len(), 2);
+	}
+
+	#[test]
+	fn test_bbb_codec_detection() {
+		let data = include_bytes!("test/bbb.mp4");
+		let importer = run_cmsf_fmp4(data);
+		let msf = importer.msf_catalog();
+
+		let video = msf
+			.tracks
+			.iter()
+			.find(|t| t.role == Some(moq_msf::Role::Video))
+			.unwrap();
+		assert!(
+			video.codec.as_ref().unwrap().starts_with("avc1."),
+			"got: {:?}",
+			video.codec
+		);
+
+		let audio = msf
+			.tracks
+			.iter()
+			.find(|t| t.role == Some(moq_msf::Role::Audio))
+			.unwrap();
+		assert!(
+			audio.codec.as_ref().unwrap().starts_with("mp4a."),
+			"got: {:?}",
+			audio.codec
+		);
+	}
+
+	#[test]
+	fn test_bbb_alt_group_assignment() {
+		let data = include_bytes!("test/bbb.mp4");
+		let importer = run_cmsf_fmp4(data);
+		let msf = importer.msf_catalog();
+
+		let video = msf
+			.tracks
+			.iter()
+			.find(|t| t.role == Some(moq_msf::Role::Video))
+			.unwrap();
+		assert_eq!(video.alt_group, Some(1));
+
+		let audio = msf
+			.tracks
+			.iter()
+			.find(|t| t.role == Some(moq_msf::Role::Audio))
+			.unwrap();
+		assert_eq!(audio.alt_group, Some(2));
+	}
+
+	#[test]
+	fn test_bbb_init_segments_base64() {
+		let data = include_bytes!("test/bbb.mp4");
+		let importer = run_cmsf_fmp4(data);
+		let msf = importer.msf_catalog();
+
+		for track in &msf.tracks {
+			let init_data = track.init_data.as_ref().expect("should have init_data");
+			let decoded = base64::engine::general_purpose::STANDARD.decode(init_data).unwrap();
+			assert!(!decoded.is_empty());
+		}
+	}
+
+	#[test]
+	fn test_bbb_sap_type1_for_h264() {
+		let data = include_bytes!("test/bbb.mp4");
+		let importer = run_cmsf_fmp4(data);
+		let msf = importer.msf_catalog();
+
+		let video = msf
+			.tracks
+			.iter()
+			.find(|t| t.role == Some(moq_msf::Role::Video))
+			.unwrap();
+		assert_eq!(video.max_grp_sap_starting_type, Some(1));
+		assert_eq!(video.max_obj_sap_starting_type, Some(1));
+	}
+
+	#[test]
+	fn test_bbb_groups_created() {
+		let data = include_bytes!("test/bbb.mp4");
+		let importer = run_cmsf_fmp4(data);
+		for tp in &importer.parser.sink.producer.tracks {
+			assert!(tp.group.is_some(), "track should have an open group");
+		}
+	}
+
+	#[test]
+	fn test_finish() {
+		let data = include_bytes!("test/bbb.mp4");
+		let mut importer = run_cmsf_fmp4(data);
+		importer.finish().unwrap();
+	}
+}

--- a/rs/moq-mux/src/import/cmsf_types.rs
+++ b/rs/moq-mux/src/import/cmsf_types.rs
@@ -1,0 +1,646 @@
+use anyhow::Context;
+use bytes::Bytes;
+
+use super::fmp4_parser::TrackKind;
+
+/// Stream Access Point type per ISO 14496-12.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum SapType {
+	/// Not a random access point.
+	None,
+	/// Type 1: IDR / clean random access.
+	Type1,
+	/// Type 2: CRA / open-GOP.
+	Type2,
+	/// Type 3: Gradual decoding refresh.
+	#[allow(dead_code)]
+	Type3,
+}
+
+impl SapType {
+	pub fn is_keyframe(&self) -> bool {
+		matches!(self, SapType::Type1 | SapType::Type2)
+	}
+
+	pub fn is_valid_group_start(&self) -> bool {
+		matches!(self, SapType::Type1 | SapType::Type2)
+	}
+
+	/// Convert to the MSF catalog integer representation.
+	pub fn to_msf_value(self) -> Option<u32> {
+		match self {
+			SapType::None => Option::None,
+			SapType::Type1 => Some(1),
+			SapType::Type2 => Some(2),
+			SapType::Type3 => Some(3),
+		}
+	}
+}
+
+/// A CMSF Object — the moof+mdat payload written to a moq-lite group.
+///
+/// Corresponds to "Object" in CMSF spec §3.3. This is the simplified input
+/// to [`CmsfBroadcastProducer::write()`](super::CmsfBroadcastProducer::write). The producer internally parses
+/// metadata (PTS, duration, keyframe) from the moof box.
+pub struct CmsfObject {
+	/// Raw moof+mdat bytes, passed through unchanged to the moq-lite group.
+	pub data: Bytes,
+
+	/// Optional group assignment. Monotonically increasing when present.
+	///
+	/// - `Some(id)`: Producer starts a new moq-lite group when this value changes.
+	///   The caller is asserting canonical group boundaries (e.g. from EML).
+	///   Applies to ALL track types including audio — the caller is responsible
+	///   for coordinating audio/video group boundaries.
+	///   Once a track receives `Some(_)`, it enters "explicit mode" for the session.
+	///   Sending a value less than the previous `Some` is an error (non-monotonic).
+	///
+	/// - `None`: Behavior depends on track mode:
+	///   - If the track has never received `Some(_)`: Producer auto-assigns groups
+	///     based on parsed keyframes. Video: new group on each keyframe.
+	///     Non-switching audio: new group aligned to video keyframes.
+	///   - If the track is in explicit mode (previously received `Some(_)`):
+	///     Continues writing to the current group without starting a new one.
+	pub group_id: Option<u64>,
+}
+
+/// Lightweight handle returned by `add_video_track`/`add_audio_track`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct TrackId(pub usize);
+
+/// Internal per-track producer managing group lifecycle, SAP tracking, and jitter.
+pub(crate) struct CmsfTrackProducer {
+	pub kind: TrackKind,
+	pub track: moq_lite::TrackProducer,
+	pub group: Option<moq_lite::GroupProducer>,
+	pub alt_group: Option<u32>,
+	pub media_group_id: Option<u64>,
+	pub max_grp_sap: SapType,
+	pub max_obj_sap: SapType,
+	pub jitter: Option<u64>,
+	pub config: CmsfTrackConfig,
+	/// Whether this track uses explicit group IDs from the caller.
+	/// Set to true on first `write()` with `group_id: Some(_)`.
+	pub explicit_groups: bool,
+	/// Last explicit group_id received, for monotonicity checking.
+	pub last_explicit_group_id: Option<u64>,
+	timescale: u64,
+	last_timestamp: Option<u64>,
+	sap_dirty: bool,
+}
+
+impl CmsfTrackProducer {
+	pub fn new(
+		kind: TrackKind,
+		track: moq_lite::TrackProducer,
+		alt_group: Option<u32>,
+		config: CmsfTrackConfig,
+		timescale: u64,
+	) -> Self {
+		Self {
+			kind,
+			track,
+			group: None,
+			alt_group,
+			media_group_id: None,
+			max_grp_sap: SapType::None,
+			max_obj_sap: SapType::None,
+			jitter: None,
+			config,
+			explicit_groups: false,
+			last_explicit_group_id: None,
+			timescale,
+			last_timestamp: None,
+			sap_dirty: false,
+		}
+	}
+
+	pub fn start_group(&mut self, media_group_id: Option<u64>) -> anyhow::Result<()> {
+		if let Some(mut prev) = self.group.take() {
+			prev.finish()?;
+		}
+		self.group = Some(match media_group_id {
+			Some(seq) => self.track.create_group(moq_lite::Group { sequence: seq })?,
+			None => self.track.append_group()?,
+		});
+		self.media_group_id = media_group_id;
+		Ok(())
+	}
+
+	pub fn write_fragment(&mut self, data: Bytes) -> anyhow::Result<()> {
+		let group = self.group.as_mut().context("no open group")?;
+		group.write_frame(data)?;
+		Ok(())
+	}
+
+	pub fn validate_group_sap(&mut self, sap_type: SapType) -> anyhow::Result<()> {
+		anyhow::ensure!(
+			sap_type.is_valid_group_start(),
+			"group starts with {:?}, §3.4 requires type 1 or 2",
+			sap_type
+		);
+		let prev = self.max_grp_sap;
+		self.max_grp_sap = self.max_grp_sap.max(sap_type);
+		if self.max_grp_sap != prev {
+			self.sap_dirty = true;
+		}
+		Ok(())
+	}
+
+	pub fn track_object_sap(&mut self, sap_type: SapType) {
+		let prev = self.max_obj_sap;
+		self.max_obj_sap = self.max_obj_sap.max(sap_type);
+		if self.max_obj_sap != prev {
+			self.sap_dirty = true;
+		}
+	}
+
+	/// Update jitter tracking from a new PTS value.
+	///
+	/// Jitter is the minimum inter-sample PTS delta observed. This represents the
+	/// smallest GOP/frame duration, which is what subscribers need to size their
+	/// decode buffers. Published in the catalog as milliseconds.
+	pub fn update_jitter(&mut self, pts: u64, _duration: Option<u64>) -> bool {
+		if let Some(last) = self.last_timestamp
+			&& let Some(d) = pts.checked_sub(last)
+			&& d > 0 && d < self.jitter.unwrap_or(u64::MAX)
+		{
+			self.jitter = Some(d);
+			self.last_timestamp = Some(pts);
+			return true;
+		}
+		// Only advance last_timestamp for monotonically increasing PTS
+		// to avoid corrupting jitter with B-frame reordering.
+		if self.last_timestamp.is_none() || pts > self.last_timestamp.unwrap() {
+			self.last_timestamp = Some(pts);
+		}
+		false
+	}
+
+	/// Convert jitter from native ticks to milliseconds for catalog publishing.
+	pub fn jitter_as_time(&self) -> Option<moq_lite::Time> {
+		let j = self.jitter?;
+		if self.timescale == 0 {
+			return None;
+		}
+		let ms = (j as u128 * 1000 / self.timescale as u128) as u64;
+		moq_lite::Time::new_u64(ms).ok()
+	}
+
+	/// Derive the SAP type for a keyframe based on the track's codec.
+	///
+	/// - Audio → Type1 (always independently decodable)
+	/// - Video H264/VP8 → Type1 (IDR only, no open-GOP)
+	/// - Video H265/AV1/VP9/Unknown → Type2 (may be CRA/open-GOP, conservative)
+	pub fn sap_type_for_keyframe(&self) -> SapType {
+		match self.kind {
+			TrackKind::Audio => SapType::Type1,
+			TrackKind::Video => match &self.config {
+				CmsfTrackConfig::Video {
+					codec: hang::catalog::VideoCodec::H264(_) | hang::catalog::VideoCodec::VP8,
+					..
+				} => SapType::Type1,
+				_ => SapType::Type2,
+			},
+		}
+	}
+
+	pub fn finish(&mut self) -> anyhow::Result<()> {
+		if let Some(mut g) = self.group.take() {
+			g.finish()?;
+		}
+		self.track.finish()?;
+		Ok(())
+	}
+
+	pub fn sap_changed(&mut self) -> bool {
+		let changed = self.sap_dirty;
+		self.sap_dirty = false;
+		changed
+	}
+}
+
+/// Configuration for the CMSF broadcast producer.
+#[derive(Default)]
+pub struct CmsfConfig {
+	pub publish_hang: bool,
+}
+
+/// Video track input for `CmsfBroadcastProducer::add_video_track`.
+pub struct CmsfVideoTrack {
+	pub codec: hang::catalog::VideoCodec,
+	pub description: Option<Bytes>,
+	pub width: Option<u32>,
+	pub height: Option<u32>,
+	pub bitrate: Option<u64>,
+	pub framerate: Option<f64>,
+	pub init_segment: Bytes,
+	pub alt_group: Option<u32>,
+	pub timescale: u64,
+}
+
+/// Audio track input for `CmsfBroadcastProducer::add_audio_track`.
+pub struct CmsfAudioTrack {
+	pub codec: hang::catalog::AudioCodec,
+	pub description: Option<Bytes>,
+	pub sample_rate: u32,
+	pub channel_count: u32,
+	pub bitrate: Option<u64>,
+	pub init_segment: Bytes,
+	pub alt_group: Option<u32>,
+	pub timescale: u64,
+}
+
+/// Stored track config for building catalogs.
+pub(crate) enum CmsfTrackConfig {
+	Video {
+		codec: hang::catalog::VideoCodec,
+		description: Option<Bytes>,
+		width: Option<u32>,
+		height: Option<u32>,
+		bitrate: Option<u64>,
+		framerate: Option<f64>,
+		init_data: String,
+	},
+	Audio {
+		codec: hang::catalog::AudioCodec,
+		description: Option<Bytes>,
+		sample_rate: u32,
+		channel_count: u32,
+		bitrate: Option<u64>,
+		init_data: String,
+	},
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use std::collections::HashMap;
+
+	#[test]
+	fn test_sap_type_ordering() {
+		assert!(SapType::None < SapType::Type1);
+		assert!(SapType::Type1 < SapType::Type2);
+		assert!(SapType::Type2 < SapType::Type3);
+	}
+
+	#[test]
+	fn test_sap_type_is_keyframe() {
+		assert!(!SapType::None.is_keyframe());
+		assert!(SapType::Type1.is_keyframe());
+		assert!(SapType::Type2.is_keyframe());
+		assert!(!SapType::Type3.is_keyframe());
+	}
+
+	#[test]
+	fn test_sap_type_is_valid_group_start() {
+		assert!(!SapType::None.is_valid_group_start());
+		assert!(SapType::Type1.is_valid_group_start());
+		assert!(SapType::Type2.is_valid_group_start());
+		assert!(!SapType::Type3.is_valid_group_start());
+	}
+
+	#[test]
+	fn test_sap_type_monotonic_max() {
+		let mut max = SapType::None;
+		max = max.max(SapType::Type1);
+		assert_eq!(max, SapType::Type1);
+		max = max.max(SapType::Type1);
+		assert_eq!(max, SapType::Type1);
+		max = max.max(SapType::Type2);
+		assert_eq!(max, SapType::Type2);
+		max = max.max(SapType::None);
+		assert_eq!(max, SapType::Type2);
+	}
+
+	#[test]
+	fn test_sap_type_to_msf_value() {
+		assert_eq!(SapType::None.to_msf_value(), Option::None);
+		assert_eq!(SapType::Type1.to_msf_value(), Some(1));
+		assert_eq!(SapType::Type2.to_msf_value(), Some(2));
+		assert_eq!(SapType::Type3.to_msf_value(), Some(3));
+	}
+
+	#[test]
+	fn test_cmsf_object_construction() {
+		let obj = CmsfObject {
+			data: Bytes::from_static(b"test"),
+			group_id: Some(42),
+		};
+		assert_eq!(obj.data, Bytes::from_static(b"test"));
+		assert_eq!(obj.group_id, Some(42));
+	}
+
+	#[test]
+	fn test_track_id_equality_and_hashing() {
+		let a = TrackId(0);
+		let b = TrackId(0);
+		let c = TrackId(1);
+		assert_eq!(a, b);
+		assert_ne!(a, c);
+
+		let mut map = HashMap::new();
+		map.insert(a, "first");
+		assert_eq!(map.get(&b), Some(&"first"));
+		assert_eq!(map.get(&c), None);
+	}
+
+	fn make_track_producer(kind: TrackKind) -> CmsfTrackProducer {
+		make_track_producer_with_timescale(kind, 90000)
+	}
+
+	fn make_track_producer_with_timescale(kind: TrackKind, timescale: u64) -> CmsfTrackProducer {
+		let mut broadcast = moq_lite::Broadcast::new().produce();
+		let track = broadcast.create_track(moq_lite::Track::new("test")).unwrap();
+		let config = CmsfTrackConfig::Video {
+			codec: hang::catalog::H264 {
+				profile: 100,
+				constraints: 0,
+				level: 31,
+				inline: false,
+			}
+			.into(),
+			description: None,
+			width: None,
+			height: None,
+			bitrate: None,
+			framerate: None,
+			init_data: String::new(),
+		};
+		CmsfTrackProducer::new(kind, track, None, config, timescale)
+	}
+
+	#[test]
+	fn test_track_producer_start_group() {
+		let mut tp = make_track_producer(TrackKind::Video);
+		assert!(tp.group.is_none());
+		tp.start_group(Some(0)).unwrap();
+		assert!(tp.group.is_some());
+		assert_eq!(tp.media_group_id, Some(0));
+	}
+
+	#[test]
+	fn test_track_producer_start_group_finishes_previous() {
+		let mut tp = make_track_producer(TrackKind::Video);
+		tp.start_group(Some(0)).unwrap();
+		tp.write_fragment(Bytes::from_static(b"frame1")).unwrap();
+		tp.start_group(Some(1)).unwrap();
+		assert_eq!(tp.media_group_id, Some(1));
+	}
+
+	#[test]
+	fn test_track_producer_write_fragment() {
+		let mut tp = make_track_producer(TrackKind::Video);
+		tp.start_group(None).unwrap();
+		tp.write_fragment(Bytes::from_static(b"data")).unwrap();
+	}
+
+	#[test]
+	fn test_track_producer_write_fragment_no_group() {
+		let mut tp = make_track_producer(TrackKind::Video);
+		let err = tp.write_fragment(Bytes::from_static(b"data")).unwrap_err();
+		assert!(err.to_string().contains("no open group"));
+	}
+
+	#[test]
+	fn test_track_producer_validate_group_sap_accepts() {
+		let mut tp = make_track_producer(TrackKind::Video);
+		tp.validate_group_sap(SapType::Type1).unwrap();
+		assert_eq!(tp.max_grp_sap, SapType::Type1);
+		tp.validate_group_sap(SapType::Type2).unwrap();
+		assert_eq!(tp.max_grp_sap, SapType::Type2);
+	}
+
+	#[test]
+	fn test_track_producer_validate_group_sap_rejects() {
+		let mut tp = make_track_producer(TrackKind::Video);
+		let err = tp.validate_group_sap(SapType::None).unwrap_err();
+		assert!(err.to_string().contains("§3.4"));
+		let err = tp.validate_group_sap(SapType::Type3).unwrap_err();
+		assert!(err.to_string().contains("§3.4"));
+	}
+
+	#[test]
+	fn test_track_producer_sap_monotonic() {
+		let mut tp = make_track_producer(TrackKind::Video);
+		tp.validate_group_sap(SapType::Type1).unwrap();
+		tp.validate_group_sap(SapType::Type2).unwrap();
+		tp.validate_group_sap(SapType::Type1).unwrap();
+		assert_eq!(tp.max_grp_sap, SapType::Type2);
+	}
+
+	#[test]
+	fn test_track_producer_object_sap() {
+		let mut tp = make_track_producer(TrackKind::Video);
+		tp.track_object_sap(SapType::Type1);
+		assert_eq!(tp.max_obj_sap, SapType::Type1);
+		tp.track_object_sap(SapType::Type2);
+		assert_eq!(tp.max_obj_sap, SapType::Type2);
+		tp.track_object_sap(SapType::None);
+		assert_eq!(tp.max_obj_sap, SapType::Type2);
+	}
+
+	#[test]
+	fn test_track_producer_sap_changed() {
+		let mut tp = make_track_producer(TrackKind::Video);
+		assert!(!tp.sap_changed());
+		tp.validate_group_sap(SapType::Type1).unwrap();
+		assert!(tp.sap_changed());
+		assert!(!tp.sap_changed());
+		tp.track_object_sap(SapType::Type2);
+		assert!(tp.sap_changed());
+		assert!(!tp.sap_changed());
+	}
+
+	#[test]
+	fn test_track_producer_update_jitter() {
+		// 90kHz timescale, 29.97fps → 3003 ticks per frame
+		let mut tp = make_track_producer(TrackKind::Video);
+		assert!(!tp.update_jitter(0, None)); // first PTS, no previous
+		assert!(tp.update_jitter(3003, None)); // first jitter computed
+		assert_eq!(tp.jitter, Some(3003));
+		assert!(!tp.update_jitter(6006, None)); // same interval, no change
+		assert_eq!(tp.jitter, Some(3003));
+	}
+
+	#[test]
+	fn test_jitter_as_time_90khz() {
+		let mut tp = make_track_producer_with_timescale(TrackKind::Video, 90000);
+		tp.update_jitter(0, None);
+		tp.update_jitter(3003, None);
+		// 3003 * 1000 / 90000 = 33ms
+		let time = tp.jitter_as_time().unwrap();
+		assert_eq!(time, moq_lite::Time::new(33));
+	}
+
+	#[test]
+	fn test_jitter_as_time_48khz() {
+		let mut tp = make_track_producer_with_timescale(TrackKind::Audio, 48000);
+		tp.update_jitter(0, None);
+		tp.update_jitter(1024, None);
+		// 1024 * 1000 / 48000 = 21ms
+		let time = tp.jitter_as_time().unwrap();
+		assert_eq!(time, moq_lite::Time::new(21));
+	}
+
+	#[test]
+	fn test_jitter_as_time_none_when_no_jitter() {
+		let tp = make_track_producer(TrackKind::Video);
+		assert_eq!(tp.jitter_as_time(), None);
+	}
+
+	#[test]
+	fn test_track_producer_finish() {
+		let mut tp = make_track_producer(TrackKind::Video);
+		tp.start_group(None).unwrap();
+		tp.write_fragment(Bytes::from_static(b"data")).unwrap();
+		tp.finish().unwrap();
+		assert!(tp.group.is_none());
+	}
+
+	#[test]
+	fn test_cmsf_config_default() {
+		let config = CmsfConfig::default();
+		assert!(!config.publish_hang);
+	}
+
+	#[test]
+	fn test_precision_1000_frames_29_97fps() {
+		// 29.97fps at 90kHz: frame duration = 3003 ticks (exact integer)
+		let mut tp = make_track_producer_with_timescale(TrackKind::Video, 90000);
+		for i in 0..1000u64 {
+			tp.update_jitter(i * 3003, None);
+		}
+		// Jitter should be exactly 3003 — no accumulated rounding error
+		assert_eq!(tp.jitter, Some(3003));
+		assert_eq!(tp.jitter_as_time(), Some(moq_lite::Time::new(33)));
+	}
+
+	#[test]
+	fn test_precision_48khz_audio() {
+		// 48kHz audio with 1024-sample frames
+		let mut tp = make_track_producer_with_timescale(TrackKind::Audio, 48000);
+		for i in 0..500u64 {
+			tp.update_jitter(i * 1024, None);
+		}
+		assert_eq!(tp.jitter, Some(1024));
+		assert_eq!(tp.jitter_as_time(), Some(moq_lite::Time::new(21)));
+	}
+
+	#[test]
+	fn test_multi_sample_duration() {
+		// 4 samples at 3003-tick intervals: PTS 0, 3003, 6006, 9009
+		// Duration = last.pts - first.pts = 9009 - 0 = 9009
+		let first_pts: u64 = 0;
+		let last_pts: u64 = 9009;
+		let duration = last_pts.checked_sub(first_pts);
+		assert_eq!(duration, Some(9009));
+	}
+
+	#[test]
+	fn test_jitter_catalog_output() {
+		// Verify the full path: native ticks → jitter_as_time() → moq_lite::Time
+		let mut tp = make_track_producer_with_timescale(TrackKind::Video, 90000);
+		tp.update_jitter(0, None);
+		tp.update_jitter(3003, None);
+		tp.update_jitter(6006, None);
+
+		let time = tp.jitter_as_time().unwrap();
+		// 3003 * 1000 / 90000 = 33
+		assert_eq!(time, moq_lite::Time::new(33));
+
+		// Verify this is the exact value that would be written to the hang catalog
+		let expected_catalog_jitter: Option<moq_lite::Time> = Some(moq_lite::Time::new(33));
+		assert_eq!(tp.jitter_as_time(), expected_catalog_jitter);
+	}
+
+	// --- sap_type_for_keyframe tests ---
+
+	fn make_video_producer_with_codec(codec: hang::catalog::VideoCodec) -> CmsfTrackProducer {
+		let mut broadcast = moq_lite::Broadcast::new().produce();
+		let track = broadcast.create_track(moq_lite::Track::new("test")).unwrap();
+		let config = CmsfTrackConfig::Video {
+			codec,
+			description: None,
+			width: None,
+			height: None,
+			bitrate: None,
+			framerate: None,
+			init_data: String::new(),
+		};
+		CmsfTrackProducer::new(TrackKind::Video, track, None, config, 90000)
+	}
+
+	#[test]
+	fn test_sap_type_audio_always_type1() {
+		let tp = make_track_producer(TrackKind::Audio);
+		assert_eq!(tp.sap_type_for_keyframe(), SapType::Type1);
+	}
+
+	#[test]
+	fn test_sap_type_h264_type1() {
+		let codec = hang::catalog::H264 {
+			profile: 100,
+			constraints: 0,
+			level: 31,
+			inline: false,
+		};
+		let tp = make_video_producer_with_codec(codec.into());
+		assert_eq!(tp.sap_type_for_keyframe(), SapType::Type1);
+	}
+
+	#[test]
+	fn test_sap_type_vp8_type1() {
+		let tp = make_video_producer_with_codec(hang::catalog::VideoCodec::VP8);
+		assert_eq!(tp.sap_type_for_keyframe(), SapType::Type1);
+	}
+
+	#[test]
+	fn test_sap_type_h265_type2() {
+		let codec = hang::catalog::H265 {
+			in_band: false,
+			profile_space: 0,
+			profile_idc: 1,
+			profile_compatibility_flags: [0x60, 0, 0, 0],
+			tier_flag: false,
+			level_idc: 120,
+			constraint_flags: [0xB0, 0, 0, 0, 0, 0],
+		};
+		let tp = make_video_producer_with_codec(codec.into());
+		assert_eq!(tp.sap_type_for_keyframe(), SapType::Type2);
+	}
+
+	#[test]
+	fn test_sap_type_av1_type2() {
+		let codec = hang::catalog::AV1 {
+			profile: 0,
+			level: 8,
+			bitdepth: 8,
+			..Default::default()
+		};
+		let tp = make_video_producer_with_codec(codec.into());
+		assert_eq!(tp.sap_type_for_keyframe(), SapType::Type2);
+	}
+
+	#[test]
+	fn test_sap_type_vp9_type2() {
+		let codec = hang::catalog::VP9 {
+			profile: 0,
+			level: 31,
+			bit_depth: 8,
+			chroma_subsampling: 1,
+			color_primaries: 1,
+			transfer_characteristics: 1,
+			matrix_coefficients: 1,
+			full_range: false,
+		};
+		let tp = make_video_producer_with_codec(codec.into());
+		assert_eq!(tp.sap_type_for_keyframe(), SapType::Type2);
+	}
+
+	#[test]
+	fn test_sap_type_unknown_type2() {
+		let tp = make_video_producer_with_codec(hang::catalog::VideoCodec::Unknown("custom.codec".into()));
+		assert_eq!(tp.sap_type_for_keyframe(), SapType::Type2);
+	}
+}

--- a/rs/moq-mux/src/import/fmp4.rs
+++ b/rs/moq-mux/src/import/fmp4.rs
@@ -2,50 +2,11 @@ use anyhow::Context;
 use bytes::{Buf, Bytes, BytesMut};
 use hang::catalog::{AAC, AV1, AudioCodec, AudioConfig, Container, H264, H265, VP9, VideoCodec, VideoConfig};
 use hang::container::Timestamp;
-use mp4_atom::{Any, Atom, DecodeMaybe, Encode, Mdat, Moof, Moov, Trak};
+use mp4_atom::{Atom, Moov, Trak};
 use std::collections::HashMap;
-use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio::io::AsyncRead;
 
-/// Converts fMP4/CMAF files into MoQ broadcast streams using CMAF passthrough.
-///
-/// This struct processes fragmented MP4 (fMP4) files and transports complete
-/// moof+mdat fragments directly as MoQ frames, preserving the CMAF container format.
-///
-/// ## Supported Codecs
-///
-/// **Video:**
-/// - H.264 (AVC1)
-/// - H.265 (HEVC/HEV1/HVC1)
-/// - VP8
-/// - VP9
-/// - AV1
-///
-/// **Audio:**
-/// - AAC (MP4A)
-/// - Opus
-pub struct Fmp4 {
-	/// The broadcast being produced
-	broadcast: moq_lite::BroadcastProducer,
-
-	/// The catalog being produced
-	catalog: crate::catalog::Producer,
-
-	// A lookup to tracks in the broadcast
-	tracks: HashMap<u32, Fmp4Track>,
-
-	// The moov atom at the start of the file.
-	moov: Option<Moov>,
-
-	// The latest moof header
-	moof: Option<Moof>,
-	moof_size: usize,
-}
-
-#[derive(PartialEq, Debug)]
-enum TrackKind {
-	Video,
-	Audio,
-}
+use super::fmp4_parser::{Fmp4Parser, Fmp4Sink, SampleInfo, TrackKind};
 
 struct Fmp4Track {
 	kind: TrackKind,
@@ -63,164 +24,140 @@ struct Fmp4Track {
 	min_duration: Option<Timestamp>,
 }
 
-impl Fmp4 {
-	/// Create a new CMAF importer that will write to the given broadcast.
-	///
-	/// The broadcast will be populated with tracks as they're discovered in the fMP4 file.
-	pub fn new(broadcast: moq_lite::BroadcastProducer, catalog: crate::catalog::Producer) -> Self {
-		Self {
-			catalog,
-			tracks: HashMap::default(),
-			moov: None,
-			moof: None,
-			moof_size: 0,
-			broadcast,
-		}
-	}
+/// Internal sink state that handles track creation, group writing, and catalog management.
+struct Fmp4Inner {
+	broadcast: moq_lite::BroadcastProducer,
+	catalog: crate::catalog::Producer,
+	tracks: HashMap<u32, Fmp4Track>,
+	moov: Option<Moov>,
+}
 
-	/// Decode from an asynchronous reader.
-	pub async fn decode_from<T: AsyncRead + Unpin>(&mut self, reader: &mut T) -> anyhow::Result<()> {
-		let mut buffer = BytesMut::new();
-		while reader.read_buf(&mut buffer).await? > 0 {
-			self.decode(&mut buffer)?;
+impl Fmp4Sink for Fmp4Inner {
+	fn on_init(&mut self, track_id: u32, kind: TrackKind, trak: &Trak, moov: &Moov) -> anyhow::Result<()> {
+		// Store moov on first init call for container() building.
+		if self.moov.is_none() {
+			self.moov = Some(moov.clone());
 		}
 
-		Ok(())
-	}
-
-	/// Decode a buffer of bytes.
-	pub fn decode<T: Buf + AsRef<[u8]>>(&mut self, buf: &mut T) -> anyhow::Result<()> {
-		let mut cursor = std::io::Cursor::new(buf);
-		let mut position = 0;
-
-		while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor)? {
-			// Process the parsed atom.
-			let size = cursor.position() as usize - position;
-
-			// The raw bytes of the atom we just parsed (not copied).
-			let raw = &cursor.get_ref().as_ref()[position..position + size];
-
-			match atom {
-				Any::Ftyp(_) | Any::Styp(_) => {}
-				Any::Moov(moov) => {
-					self.init(moov)?;
-				}
-				Any::Moof(moof) => {
-					anyhow::ensure!(self.moof.is_none(), "duplicate moof box");
-					self.moof.replace(moof);
-					self.moof_size = size;
-				}
-				Any::Mdat(mdat) => {
-					self.extract(mdat, raw)?;
-				}
-				_ => {
-					// Skip unknown atoms (e.g., sidx, which is optional and used for segment indexing)
-					// These are safe to ignore and don't affect playback
-				}
-			}
-
-			position = cursor.position() as usize;
-		}
-
-		// Advance the buffer by the amount of data that was processed.
-		cursor.into_inner().advance(position);
-
-		Ok(())
-	}
-
-	pub fn is_initialized(&self) -> bool {
-		self.moov.is_some()
-	}
-
-	fn init(&mut self, moov: Moov) -> anyhow::Result<()> {
-		// Clone the catalog to avoid the borrow checker.
 		let mut catalog = self.catalog.clone();
 		let mut catalog = catalog.lock();
 
-		for trak in &moov.trak {
-			let track_id = trak.tkhd.track_id;
-			let handler = &trak.mdia.hdlr.handler;
-			let suffix = ".m4s";
+		let suffix = ".m4s";
+		let track = self.broadcast.unique_track(suffix)?;
 
-			let track = self.broadcast.unique_track(suffix)?;
-
-			let kind = match handler.as_ref() {
-				b"vide" => {
-					let config = self.init_video(trak, &moov)?;
-					catalog.video.renditions.insert(track.name.clone(), config);
-					TrackKind::Video
-				}
-				b"soun" => {
-					let config = self.init_audio(trak, &moov)?;
-					catalog.audio.renditions.insert(track.name.clone(), config);
-					TrackKind::Audio
-				}
-				b"sbtl" => anyhow::bail!("subtitle tracks are not supported"),
-				handler => anyhow::bail!("unknown track type: {:?}", handler),
-			};
-
-			self.tracks.insert(
-				track_id,
-				Fmp4Track {
-					kind,
-					track,
-					group: None,
-					jitter: None,
-					last_timestamp: None,
-					min_duration: None,
-				},
-			);
+		match kind {
+			TrackKind::Video => {
+				let config = self.init_video(trak, moov)?;
+				catalog.video.renditions.insert(track.name.clone(), config);
+			}
+			TrackKind::Audio => {
+				let config = self.init_audio(trak, moov)?;
+				catalog.audio.renditions.insert(track.name.clone(), config);
+			}
 		}
 
-		drop(catalog);
-
-		self.moov = Some(moov);
+		self.tracks.insert(
+			track_id,
+			Fmp4Track {
+				kind,
+				track,
+				group: None,
+				jitter: None,
+				last_timestamp: None,
+				min_duration: None,
+			},
+		);
 
 		Ok(())
 	}
 
-	fn container(&self, trak: &Trak, moov: &Moov) -> anyhow::Result<Container> {
-		// Build a single-track init segment (ftyp+moov) for this track.
-		{
-			let ftyp = mp4_atom::Ftyp {
-				major_brand: b"isom".into(),
-				minor_version: 0x200,
-				compatible_brands: vec![b"isom".into(), b"iso6".into(), b"mp41".into()],
-			};
+	fn on_fragment(
+		&mut self,
+		track_id: u32,
+		fragment: Bytes,
+		keyframe: bool,
+		samples: Vec<SampleInfo>,
+	) -> anyhow::Result<()> {
+		let track = self.tracks.get_mut(&track_id).context("unknown track")?;
 
-			// Build a moov with just this single track and matching mvex/trex.
-			let track_id = trak.tkhd.track_id;
-			let trex = moov
-				.mvex
-				.as_ref()
-				.and_then(|mvex| mvex.trex.iter().find(|trex| trex.track_id == track_id))
-				.cloned()
-				.unwrap_or(mp4_atom::Trex {
-					track_id,
-					default_sample_description_index: 1,
-					..Default::default()
-				});
+		// Compute jitter from sample timestamps.
+		let mut min_timestamp = None;
+		let mut max_timestamp = None;
 
-			let single_moov = Moov {
-				mvhd: moov.mvhd.clone(),
-				trak: vec![trak.clone()],
-				mvex: Some(mp4_atom::Mvex {
-					mehd: None,
-					trex: vec![trex],
-				}),
-				meta: None,
-				udta: None,
-			};
+		for sample in &samples {
+			let timestamp = Timestamp::from_scale(sample.pts, sample.timescale)?;
 
-			let mut buf = Vec::new();
-			ftyp.encode(&mut buf)?;
-			single_moov.encode(&mut buf)?;
+			if timestamp >= max_timestamp.unwrap_or(Timestamp::ZERO) {
+				max_timestamp = Some(timestamp);
+			}
+			if timestamp <= min_timestamp.unwrap_or(Timestamp::MAX) {
+				min_timestamp = Some(timestamp);
+			}
 
-			Ok(Container::Cmaf { init: buf.into() })
+			if let Some(last_timestamp) = track.last_timestamp
+				&& let Ok(duration) = timestamp.checked_sub(last_timestamp)
+				&& duration < track.min_duration.unwrap_or(Timestamp::MAX)
+			{
+				track.min_duration = Some(duration);
+			}
+
+			track.last_timestamp = Some(timestamp);
 		}
+
+		// Write the fragment as a single MoQ frame.
+		let mut g = if keyframe {
+			if let Some(mut prev) = track.group.take() {
+				prev.finish()?;
+			}
+			track.track.append_group()?
+		} else {
+			track.group.take().context("no keyframe at start")?
+		};
+
+		g.write_frame(fragment)?;
+		track.group = Some(g);
+
+		// Update jitter in catalog if improved.
+		if let (Some(min), Some(max), Some(min_duration)) = (min_timestamp, max_timestamp, track.min_duration) {
+			let jitter = max - min + min_duration;
+
+			if jitter < track.jitter.unwrap_or(Timestamp::MAX) {
+				track.jitter = Some(jitter);
+
+				let mut catalog = self.catalog.lock();
+
+				match track.kind {
+					TrackKind::Video => {
+						let config = catalog
+							.video
+							.renditions
+							.get_mut(&track.track.name)
+							.context("missing video config")?;
+						config.jitter = Some(jitter.convert()?);
+					}
+					TrackKind::Audio => {
+						let config = catalog
+							.audio
+							.renditions
+							.get_mut(&track.track.name)
+							.context("missing audio config")?;
+						config.jitter = Some(jitter.convert()?);
+					}
+				}
+			}
+		}
+
+		Ok(())
+	}
+}
+
+impl Fmp4Inner {
+	fn container(&self, trak: &Trak, moov: &Moov) -> anyhow::Result<Container> {
+		let init = super::fmp4_parser::build_init_segment(trak, moov)?;
+		Ok(Container::Cmaf { init })
 	}
 
-	fn init_video(&mut self, trak: &Trak, moov: &Moov) -> anyhow::Result<VideoConfig> {
+	fn init_video(&self, trak: &Trak, moov: &Moov) -> anyhow::Result<VideoConfig> {
 		let container = self.container(trak, moov)?;
 		let stsd = &trak.mdia.minf.stbl.stsd;
 
@@ -248,7 +185,6 @@ impl Fmp4 {
 					}
 					.into(),
 					description: Some(description.freeze()),
-					// TODO: populate these fields
 					framerate: None,
 					bitrate: None,
 					display_ratio_width: None,
@@ -265,7 +201,6 @@ impl Fmp4 {
 				description: Default::default(),
 				coded_width: Some(vp08.visual.width as _),
 				coded_height: Some(vp08.visual.height as _),
-				// TODO: populate these fields
 				framerate: None,
 				bitrate: None,
 				display_ratio_width: None,
@@ -275,7 +210,6 @@ impl Fmp4 {
 				jitter: None,
 			},
 			mp4_atom::Codec::Vp09(vp09) => {
-				// https://github.com/gpac/mp4box.js/blob/325741b592d910297bf609bc7c400fc76101077b/src/box-codecs.js#L238
 				let vpcc = &vp09.vpcc;
 
 				VideoConfig {
@@ -293,7 +227,6 @@ impl Fmp4 {
 					description: Default::default(),
 					coded_width: Some(vp09.visual.width as _),
 					coded_height: Some(vp09.visual.height as _),
-					// TODO: populate these fields
 					display_ratio_width: None,
 					display_ratio_height: None,
 					optimize_for_latency: None,
@@ -320,14 +253,12 @@ impl Fmp4 {
 						chroma_subsampling_x: av1c.chroma_subsampling_x,
 						chroma_subsampling_y: av1c.chroma_subsampling_y,
 						chroma_sample_position: av1c.chroma_sample_position,
-						// TODO HDR stuff?
 						..Default::default()
 					}
 					.into(),
 					description: Default::default(),
 					coded_width: Some(av01.visual.width as _),
 					coded_height: Some(av01.visual.height as _),
-					// TODO: populate these fields
 					display_ratio_width: None,
 					display_ratio_height: None,
 					optimize_for_latency: None,
@@ -345,7 +276,7 @@ impl Fmp4 {
 	}
 
 	fn init_h265(
-		&mut self,
+		&self,
 		in_band: bool,
 		hvcc: &mp4_atom::Hvcc,
 		visual: &mp4_atom::Visual,
@@ -368,7 +299,6 @@ impl Fmp4 {
 			description: Some(description.freeze()),
 			coded_width: Some(visual.width as _),
 			coded_height: Some(visual.height as _),
-			// TODO: populate these fields
 			bitrate: None,
 			framerate: None,
 			display_ratio_width: None,
@@ -379,7 +309,7 @@ impl Fmp4 {
 		})
 	}
 
-	fn init_audio(&mut self, trak: &Trak, moov: &Moov) -> anyhow::Result<AudioConfig> {
+	fn init_audio(&self, trak: &Trak, moov: &Moov) -> anyhow::Result<AudioConfig> {
 		let container = self.container(trak, moov)?;
 		let stsd = &trak.mdia.minf.stbl.stsd;
 
@@ -393,7 +323,6 @@ impl Fmp4 {
 			mp4_atom::Codec::Mp4a(mp4a) => {
 				let desc = &mp4a.esds.es_desc.dec_config;
 
-				// TODO Also support mp4a.67
 				if desc.object_type_indication != 0x40 {
 					anyhow::bail!("unsupported codec: MPEG2");
 				}
@@ -403,8 +332,6 @@ impl Fmp4 {
 				let sample_rate = mp4a.audio.sample_rate.integer() as u32;
 				let channel_count = mp4a.audio.channel_count as u32;
 
-				// Build the AudioSpecificConfig (ISO 14496-3 §1.6.2.1)
-				// This is what GStreamer/WebCodecs need as codec_data.
 				let description = build_aac_audio_specific_config(profile, sample_rate, channel_count);
 
 				AudioConfig {
@@ -417,266 +344,77 @@ impl Fmp4 {
 					jitter: None,
 				}
 			}
-			mp4_atom::Codec::Opus(opus) => {
-				AudioConfig {
-					codec: AudioCodec::Opus,
-					sample_rate: opus.audio.sample_rate.integer() as _,
-					channel_count: opus.audio.channel_count as _,
-					bitrate: None,
-					description: None, // TODO?
-					container,
-					jitter: None,
-				}
-			}
+			mp4_atom::Codec::Opus(opus) => AudioConfig {
+				codec: AudioCodec::Opus,
+				sample_rate: opus.audio.sample_rate.integer() as _,
+				channel_count: opus.audio.channel_count as _,
+				bitrate: None,
+				description: None,
+				container,
+				jitter: None,
+			},
 			mp4_atom::Codec::Unknown(unknown) => anyhow::bail!("unknown codec: {:?}", unknown),
 			unsupported => anyhow::bail!("unsupported codec: {:?}", unsupported),
 		};
 
 		Ok(config)
 	}
+}
 
-	// Extract all frames out of an mdat atom using CMAF passthrough.
-	fn extract(&mut self, mdat: Mdat, mdat_raw: &[u8]) -> anyhow::Result<()> {
-		let moov = self.moov.as_ref().context("missing moov box")?;
-		let moof = self.moof.take().context("missing moof box")?;
-		let moof_size = self.moof_size;
-		let header_size = mdat_raw.len() - mdat.data.len();
-
-		// Loop over all of the traf boxes in the moof.
-		for traf in &moof.traf {
-			let track_id = traf.tfhd.track_id;
-			let track = self.tracks.get_mut(&track_id).context("unknown track")?;
-
-			// Find the track information in the moov
-			let trak = moov
-				.trak
-				.iter()
-				.find(|trak| trak.tkhd.track_id == track_id)
-				.context("unknown track")?;
-			let trex = moov
-				.mvex
-				.as_ref()
-				.and_then(|mvex| mvex.trex.iter().find(|trex| trex.track_id == track_id));
-
-			// The moov contains some defaults
-			let default_sample_duration = trex.map(|trex| trex.default_sample_duration).unwrap_or_default();
-			let default_sample_size = trex.map(|trex| trex.default_sample_size).unwrap_or_default();
-			let default_sample_flags = trex.map(|trex| trex.default_sample_flags).unwrap_or_default();
-
-			let tfdt = traf.tfdt.as_ref().context("missing tfdt box")?;
-			let mut dts = tfdt.base_media_decode_time;
-			let timescale = trak.mdia.mdhd.timescale as u64;
-
-			let mut offset = traf.tfhd.base_data_offset.unwrap_or_default() as usize;
-			let mut track_data_start: Option<usize> = None;
-
-			if traf.trun.is_empty() {
-				anyhow::bail!("missing trun box");
-			}
-
-			// Keep track of the minimum and maximum timestamp for this track to compute the jitter.
-			let mut min_timestamp = None;
-			let mut max_timestamp = None;
-			let mut contains_keyframe = false;
-
-			for trun in &traf.trun {
-				let tfhd = &traf.tfhd;
-
-				if let Some(data_offset) = trun.data_offset {
-					let base_offset = tfhd.base_data_offset.unwrap_or_default() as usize;
-					let data_offset: usize = data_offset.try_into().context("invalid data offset")?;
-
-					let relative_offset = data_offset
-						.checked_sub(moof_size)
-						.and_then(|v| v.checked_sub(header_size))
-						.context("invalid data offset: underflow")?;
-
-					offset = base_offset
-						.checked_add(relative_offset)
-						.context("invalid data offset: overflow")?;
-				}
-
-				// Capture the actual start offset for this traf before consuming samples
-				if track_data_start.is_none() {
-					track_data_start = Some(offset);
-				}
-
-				for entry in &trun.entries {
-					let flags = entry
-						.flags
-						.unwrap_or(tfhd.default_sample_flags.unwrap_or(default_sample_flags));
-					let duration = entry
-						.duration
-						.unwrap_or(tfhd.default_sample_duration.unwrap_or(default_sample_duration));
-					let size = entry
-						.size
-						.unwrap_or(tfhd.default_sample_size.unwrap_or(default_sample_size)) as usize;
-
-					let pts = (dts as i64 + entry.cts.unwrap_or_default() as i64) as u64;
-					let timestamp = hang::container::Timestamp::from_scale(pts, timescale)?;
-
-					if offset + size > mdat.data.len() {
-						anyhow::bail!("invalid data offset");
-					}
-
-					let keyframe = match track.kind {
-						TrackKind::Video => {
-							let keyframe = (flags >> 24) & 0x3 == 0x2;
-							let non_sync = (flags >> 16) & 0x1 == 0x1;
-							keyframe && !non_sync
-						}
-						TrackKind::Audio => true,
-					};
-
-					contains_keyframe |= keyframe;
-
-					if timestamp >= max_timestamp.unwrap_or(Timestamp::ZERO) {
-						max_timestamp = Some(timestamp);
-					}
-					if timestamp <= min_timestamp.unwrap_or(Timestamp::MAX) {
-						min_timestamp = Some(timestamp);
-					}
-
-					if let Some(last_timestamp) = track.last_timestamp
-						&& let Ok(duration) = timestamp.checked_sub(last_timestamp)
-						&& duration < track.min_duration.unwrap_or(Timestamp::MAX)
-					{
-						track.min_duration = Some(duration);
-					}
-
-					track.last_timestamp = Some(timestamp);
-
-					dts += duration as u64;
-					offset += size;
-				}
-			}
-
-			// Build a per-track moof containing only this traf, and a per-track mdat
-			// with only the samples belonging to this track.
-			let single_traf_moof = Moof {
-				mfhd: moof.mfhd.clone(),
-				traf: vec![traf.clone()],
-			};
-
-			// Compute the data range within the original mdat for this traf's samples.
-			let track_data_start = track_data_start.unwrap_or(0);
-			let track_data_end = offset; // offset was advanced past all samples above
-
-			// The per-track sample range must be in bounds of the original mdat.
-			// If not, the parsed sample sizes/offsets disagree with the actual data
-			// and we cannot safely emit a passthrough fragment with rewritten offsets.
-			anyhow::ensure!(
-				track_data_start <= track_data_end && track_data_end <= mdat.data.len(),
-				"track sample range {}..{} is out of bounds of mdat (len {})",
-				track_data_start,
-				track_data_end,
-				mdat.data.len()
-			);
-			let track_mdat_data = &mdat.data[track_data_start..track_data_end];
-
-			let mut adjusted_moof = single_traf_moof;
-
-			// Apply structural (flag-presence) changes BEFORE measuring the encoded
-			// size, otherwise the rewritten data_offset values are computed from a
-			// stale size and the resulting fragment misaddresses sample data.
-			// In particular: clearing tfhd.base_data_offset removes 8 bytes per traf,
-			// and ensuring trun.data_offset is Some(...) reserves 4 bytes per trun.
-			for traf_mut in &mut adjusted_moof.traf {
-				traf_mut.tfhd.base_data_offset = None;
-				for trun_mut in &mut traf_mut.trun {
-					// Reserve the data_offset field; the real value is filled in below.
-					trun_mut.data_offset = Some(0);
-				}
-			}
-
-			let mut moof_buf = Vec::new();
-			adjusted_moof.encode(&mut moof_buf)?;
-			let new_moof_size = moof_buf.len();
-
-			// Re-encode moof with corrected per-trun data_offset for the per-track fragment.
-			// Each trun's data_offset points to the start of that run's data within the new mdat.
-			let mdat_header_size_new = 8u64; // 4 bytes size + 4 bytes 'mdat'
-			let mut cumulative_offset = 0u64;
-			for traf_mut in &mut adjusted_moof.traf {
-				for trun_mut in &mut traf_mut.trun {
-					trun_mut.data_offset =
-						Some((new_moof_size as u64 + mdat_header_size_new + cumulative_offset) as i32);
-
-					// Advance past this trun's sample data
-					let trun_data_size: u64 = trun_mut
-						.entries
-						.iter()
-						.map(|e| {
-							e.size
-								.unwrap_or(traf_mut.tfhd.default_sample_size.unwrap_or(default_sample_size)) as u64
-						})
-						.sum();
-					cumulative_offset += trun_data_size;
-				}
-			}
-
-			moof_buf.clear();
-			adjusted_moof.encode(&mut moof_buf)?;
-
-			let per_track_mdat = Mdat {
-				data: track_mdat_data.to_vec(),
-			};
-			per_track_mdat.encode(&mut moof_buf)?;
-
-			let fragment_bytes = Bytes::from(moof_buf);
-
-			// Write the per-track fragment as a single MoQ frame (passthrough).
-			let mut g = if contains_keyframe {
-				if let Some(mut prev) = track.group.take() {
-					prev.finish()?;
-				}
-				track.track.append_group()?
-			} else {
-				track.group.take().context("no keyframe at start")?
-			};
-
-			g.write_frame(fragment_bytes)?;
-
-			track.group = Some(g);
-
-			if let (Some(min), Some(max), Some(min_duration)) = (min_timestamp, max_timestamp, track.min_duration) {
-				let jitter = max - min + min_duration;
-
-				if jitter < track.jitter.unwrap_or(Timestamp::MAX) {
-					track.jitter = Some(jitter);
-
-					let mut catalog = self.catalog.lock();
-
-					match track.kind {
-						TrackKind::Video => {
-							let config = catalog
-								.video
-								.renditions
-								.get_mut(&track.track.name)
-								.context("missing video config")?;
-							config.jitter = Some(jitter.convert()?);
-						}
-						TrackKind::Audio => {
-							let config = catalog
-								.audio
-								.renditions
-								.get_mut(&track.track.name)
-								.context("missing audio config")?;
-							config.jitter = Some(jitter.convert()?);
-						}
-					}
-				}
-			}
-		}
-
-		Ok(())
-	}
+/// Converts fMP4/CMAF files into MoQ broadcast streams using CMAF passthrough.
+///
+/// This struct processes fragmented MP4 (fMP4) files and transports complete
+/// moof+mdat fragments directly as MoQ frames, preserving the CMAF container format.
+///
+/// ## Supported Codecs
+///
+/// **Video:**
+/// - H.264 (AVC1)
+/// - H.265 (HEVC/HEV1/HVC1)
+/// - VP8
+/// - VP9
+/// - AV1
+///
+/// **Audio:**
+/// - AAC (MP4A)
+/// - Opus
+pub struct Fmp4 {
+	parser: Fmp4Parser<Fmp4Inner>,
 }
 
 impl Fmp4 {
+	/// Create a new CMAF importer that will write to the given broadcast.
+	///
+	/// The broadcast will be populated with tracks as they're discovered in the fMP4 file.
+	pub fn new(broadcast: moq_lite::BroadcastProducer, catalog: crate::catalog::Producer) -> Self {
+		let inner = Fmp4Inner {
+			broadcast,
+			catalog,
+			tracks: HashMap::default(),
+			moov: None,
+		};
+		Self {
+			parser: Fmp4Parser::new(inner),
+		}
+	}
+
+	/// Decode from an asynchronous reader.
+	pub async fn decode_from<T: AsyncRead + Unpin>(&mut self, reader: &mut T) -> anyhow::Result<()> {
+		self.parser.decode_from(reader).await
+	}
+
+	/// Decode a buffer of bytes.
+	pub fn decode<T: Buf + AsRef<[u8]>>(&mut self, buf: &mut T) -> anyhow::Result<()> {
+		self.parser.decode(buf)
+	}
+
+	pub fn is_initialized(&self) -> bool {
+		self.parser.is_initialized()
+	}
+
 	/// Finish all tracks, flushing current groups.
 	pub fn finish(&mut self) -> anyhow::Result<()> {
-		for track in self.tracks.values_mut() {
+		for track in self.parser.sink.tracks.values_mut() {
 			if let Some(mut g) = track.group.take() {
 				g.finish()?;
 			}
@@ -688,9 +426,9 @@ impl Fmp4 {
 
 impl Drop for Fmp4 {
 	fn drop(&mut self) {
-		let mut catalog = self.catalog.lock();
+		let mut catalog = self.parser.sink.catalog.lock();
 
-		for track in self.tracks.values() {
+		for track in self.parser.sink.tracks.values() {
 			match track.kind {
 				TrackKind::Video => {
 					catalog.video.renditions.remove(&track.track.name);
@@ -713,7 +451,7 @@ impl Drop for Fmp4 {
 ///
 /// For standard sample rates this produces exactly 2 bytes (e.g. 0x12 0x10
 /// for AAC-LC / 44100 Hz / stereo).
-fn build_aac_audio_specific_config(profile: u8, sample_rate: u32, channels: u32) -> Bytes {
+pub(crate) fn build_aac_audio_specific_config(profile: u8, sample_rate: u32, channels: u32) -> Bytes {
 	// audioObjectType is a 5-bit field; mask to prevent shift overflow.
 	let profile = profile & 0x1F;
 
@@ -731,16 +469,14 @@ fn build_aac_audio_specific_config(profile: u8, sample_rate: u32, channels: u32)
 		11025 => 10,
 		8000 => 11,
 		7350 => 12,
-		_ => 0xF, // explicit 24-bit frequency follows
+		_ => 0xF,
 	};
 
 	if freq_index != 0xF {
-		// 5 + 4 + 4 = 13 bits → 2 bytes (3 bits padding)
 		let b0 = (profile << 3) | (freq_index >> 1);
 		let b1 = ((freq_index & 1) << 7) | ((channels as u8 & 0x0F) << 3);
 		Bytes::from(vec![b0, b1])
 	} else {
-		// 5 + 4 + 24 + 4 = 37 bits → 5 bytes (3 bits padding)
 		let mut bits: u64 = 0;
 		bits |= (profile as u64) << 35;
 		bits |= 0xF_u64 << 31;

--- a/rs/moq-mux/src/import/fmp4_parser.rs
+++ b/rs/moq-mux/src/import/fmp4_parser.rs
@@ -1,0 +1,420 @@
+use anyhow::Context;
+use bytes::{Buf, Bytes, BytesMut};
+use mp4_atom::{Any, DecodeMaybe, Encode, Mdat, Moof, Moov, Trak};
+use tokio::io::{AsyncRead, AsyncReadExt};
+
+/// Build a single-track init segment (ftyp+moov) for the given track.
+pub(crate) fn build_init_segment(trak: &Trak, moov: &Moov) -> anyhow::Result<Bytes> {
+	let ftyp = mp4_atom::Ftyp {
+		major_brand: b"isom".into(),
+		minor_version: 0x200,
+		compatible_brands: vec![b"isom".into(), b"iso6".into(), b"mp41".into()],
+	};
+
+	let track_id = trak.tkhd.track_id;
+	let trex = moov
+		.mvex
+		.as_ref()
+		.and_then(|mvex| mvex.trex.iter().find(|trex| trex.track_id == track_id))
+		.cloned()
+		.unwrap_or(mp4_atom::Trex {
+			track_id,
+			default_sample_description_index: 1,
+			..Default::default()
+		});
+
+	let single_moov = Moov {
+		mvhd: moov.mvhd.clone(),
+		trak: vec![trak.clone()],
+		mvex: Some(mp4_atom::Mvex {
+			mehd: None,
+			trex: vec![trex],
+		}),
+		meta: None,
+		udta: None,
+	};
+
+	let mut buf = Vec::new();
+	ftyp.encode(&mut buf)?;
+	single_moov.encode(&mut buf)?;
+	Ok(Bytes::from(buf))
+}
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum TrackKind {
+	Video,
+	Audio,
+}
+
+/// Per-sample metadata extracted from trun entries.
+#[allow(dead_code)]
+pub(crate) struct SampleInfo {
+	pub flags: u32,
+	pub pts: u64,
+	pub duration: u32,
+	pub timescale: u64,
+	pub keyframe: bool,
+}
+
+/// Callback trait for consuming parsed fMP4 events.
+///
+/// Implement this to receive track initialization and fragment data from the parser.
+/// The parser handles the moov/moof/mdat state machine; the sink handles what to do
+/// with the parsed results (e.g., create MoQ tracks, write CMSF segments).
+pub(crate) trait Fmp4Sink {
+	/// Called once per track when the moov box is parsed.
+	fn on_init(&mut self, track_id: u32, kind: TrackKind, trak: &Trak, moov: &Moov) -> anyhow::Result<()>;
+
+	/// Called once per track per moof+mdat pair with the per-track fragment bytes.
+	fn on_fragment(
+		&mut self,
+		track_id: u32,
+		fragment: Bytes,
+		keyframe: bool,
+		samples: Vec<SampleInfo>,
+	) -> anyhow::Result<()>;
+}
+
+/// Reusable fMP4 parser that dispatches events to an [`Fmp4Sink`].
+///
+/// Handles the moov/moof/mdat state machine and per-track fragment splitting.
+/// Consumer-specific logic (track creation, group management, codec detection)
+/// is delegated to the sink.
+pub(crate) struct Fmp4Parser<S> {
+	pub sink: S,
+	moov: Option<Moov>,
+	moof: Option<Moof>,
+	moof_size: usize,
+}
+
+impl<S: Fmp4Sink> Fmp4Parser<S> {
+	pub fn new(sink: S) -> Self {
+		Self {
+			sink,
+			moov: None,
+			moof: None,
+			moof_size: 0,
+		}
+	}
+
+	pub fn is_initialized(&self) -> bool {
+		self.moov.is_some()
+	}
+
+	/// Decode from an asynchronous reader.
+	pub async fn decode_from<T: AsyncRead + Unpin>(&mut self, reader: &mut T) -> anyhow::Result<()> {
+		let mut buffer = BytesMut::new();
+		while reader.read_buf(&mut buffer).await? > 0 {
+			self.decode(&mut buffer)?;
+		}
+		Ok(())
+	}
+
+	/// Decode a buffer of bytes.
+	pub fn decode<T: Buf + AsRef<[u8]>>(&mut self, buf: &mut T) -> anyhow::Result<()> {
+		let mut cursor = std::io::Cursor::new(buf);
+		let mut position = 0;
+
+		while let Some(atom) = Any::decode_maybe(&mut cursor)? {
+			let size = cursor.position() as usize - position;
+			let raw = &cursor.get_ref().as_ref()[position..position + size];
+
+			match atom {
+				Any::Ftyp(_) | Any::Styp(_) => {}
+				Any::Moov(moov) => {
+					self.init(moov)?;
+				}
+				Any::Moof(moof) => {
+					anyhow::ensure!(self.moof.is_none(), "duplicate moof box");
+					self.moof.replace(moof);
+					self.moof_size = size;
+				}
+				Any::Mdat(mdat) => {
+					self.extract(mdat, raw)?;
+				}
+				_ => {}
+			}
+
+			position = cursor.position() as usize;
+		}
+
+		cursor.into_inner().advance(position);
+		Ok(())
+	}
+
+	fn init(&mut self, moov: Moov) -> anyhow::Result<()> {
+		for trak in &moov.trak {
+			let track_id = trak.tkhd.track_id;
+			let handler = &trak.mdia.hdlr.handler;
+
+			let kind = match handler.as_ref() {
+				b"vide" => TrackKind::Video,
+				b"soun" => TrackKind::Audio,
+				b"sbtl" => anyhow::bail!("subtitle tracks are not supported"),
+				handler => anyhow::bail!("unknown track type: {:?}", handler),
+			};
+
+			self.sink.on_init(track_id, kind, trak, &moov)?;
+		}
+
+		self.moov = Some(moov);
+		Ok(())
+	}
+
+	fn extract(&mut self, mdat: Mdat, mdat_raw: &[u8]) -> anyhow::Result<()> {
+		let moov = self.moov.as_ref().context("missing moov box")?;
+		let moof = self.moof.take().context("missing moof box")?;
+		let moof_size = self.moof_size;
+		let header_size = mdat_raw.len() - mdat.data.len();
+
+		for traf in &moof.traf {
+			let track_id = traf.tfhd.track_id;
+
+			let trak = moov
+				.trak
+				.iter()
+				.find(|trak| trak.tkhd.track_id == track_id)
+				.context("unknown track")?;
+			let trex = moov
+				.mvex
+				.as_ref()
+				.and_then(|mvex| mvex.trex.iter().find(|trex| trex.track_id == track_id));
+
+			let default_sample_duration = trex.map(|trex| trex.default_sample_duration).unwrap_or_default();
+			let default_sample_size = trex.map(|trex| trex.default_sample_size).unwrap_or_default();
+			let default_sample_flags = trex.map(|trex| trex.default_sample_flags).unwrap_or_default();
+
+			let handler = &trak.mdia.hdlr.handler;
+			let kind = match handler.as_ref() {
+				b"vide" => TrackKind::Video,
+				b"soun" => TrackKind::Audio,
+				handler => anyhow::bail!("unexpected track handler in traf: {:?}", handler),
+			};
+
+			let tfdt = traf.tfdt.as_ref().context("missing tfdt box")?;
+			let mut dts = tfdt.base_media_decode_time;
+			let timescale = trak.mdia.mdhd.timescale as u64;
+
+			let mut offset = traf.tfhd.base_data_offset.unwrap_or_default() as usize;
+			let mut track_data_start: Option<usize> = None;
+
+			if traf.trun.is_empty() {
+				anyhow::bail!("missing trun box");
+			}
+
+			let mut contains_keyframe = false;
+			let mut samples = Vec::new();
+
+			for trun in &traf.trun {
+				let tfhd = &traf.tfhd;
+
+				if let Some(data_offset) = trun.data_offset {
+					let base_offset = tfhd.base_data_offset.unwrap_or_default() as usize;
+					let data_offset: usize = data_offset.try_into().context("invalid data offset")?;
+
+					let relative_offset = data_offset
+						.checked_sub(moof_size)
+						.and_then(|v| v.checked_sub(header_size))
+						.context("invalid data offset: underflow")?;
+
+					offset = base_offset
+						.checked_add(relative_offset)
+						.context("invalid data offset: overflow")?;
+				}
+
+				if track_data_start.is_none() {
+					track_data_start = Some(offset);
+				}
+
+				for entry in &trun.entries {
+					let flags = entry
+						.flags
+						.unwrap_or(tfhd.default_sample_flags.unwrap_or(default_sample_flags));
+					let duration = entry
+						.duration
+						.unwrap_or(tfhd.default_sample_duration.unwrap_or(default_sample_duration));
+					let size = entry
+						.size
+						.unwrap_or(tfhd.default_sample_size.unwrap_or(default_sample_size)) as usize;
+
+					let pts = (dts as i64 + entry.cts.unwrap_or_default() as i64) as u64;
+
+					if offset + size > mdat.data.len() {
+						anyhow::bail!("invalid data offset");
+					}
+
+					let keyframe = match kind {
+						TrackKind::Video => {
+							let kf = (flags >> 24) & 0x3 == 0x2;
+							let non_sync = (flags >> 16) & 0x1 == 0x1;
+							kf && !non_sync
+						}
+						TrackKind::Audio => true,
+					};
+
+					contains_keyframe |= keyframe;
+
+					samples.push(SampleInfo {
+						flags,
+						pts,
+						duration,
+						timescale,
+						keyframe,
+					});
+
+					dts += duration as u64;
+					offset += size;
+				}
+			}
+
+			// Build per-track moof+mdat fragment.
+			let single_traf_moof = Moof {
+				mfhd: moof.mfhd.clone(),
+				traf: vec![traf.clone()],
+			};
+
+			let track_data_start = track_data_start.unwrap_or(0);
+			let track_data_end = offset;
+
+			anyhow::ensure!(
+				track_data_start <= track_data_end && track_data_end <= mdat.data.len(),
+				"track sample range {}..{} is out of bounds of mdat (len {})",
+				track_data_start,
+				track_data_end,
+				mdat.data.len()
+			);
+			let track_mdat_data = &mdat.data[track_data_start..track_data_end];
+
+			let mut adjusted_moof = single_traf_moof;
+
+			// Workaround: mp4_atom's trun encoder drops first_sample_flags when entries
+			// lack explicit per-sample flags. Fill in the default so keyframe indication
+			// is preserved on re-encode. See: https://github.com/kixelated/mp4-atom/pull/160
+			for traf_mut in &mut adjusted_moof.traf {
+				let default_flags = traf_mut.tfhd.default_sample_flags.unwrap_or(default_sample_flags);
+
+				traf_mut.tfhd.base_data_offset = None;
+
+				for trun_mut in &mut traf_mut.trun {
+					for entry in &mut trun_mut.entries {
+						if entry.flags.is_none() {
+							entry.flags = Some(default_flags);
+						}
+					}
+					// Reserve the data_offset field; the real value is filled in below.
+					trun_mut.data_offset = Some(0);
+				}
+			}
+
+			// Measure encoded moof size after structural changes.
+			let mut moof_buf = Vec::new();
+			adjusted_moof.encode(&mut moof_buf)?;
+			let new_moof_size = moof_buf.len();
+
+			// Re-encode moof with corrected per-trun data_offset for the per-track fragment.
+			let mdat_header_size_new = 8u64;
+			let mut cumulative_offset = 0u64;
+			for traf_mut in &mut adjusted_moof.traf {
+				for trun_mut in &mut traf_mut.trun {
+					trun_mut.data_offset =
+						Some((new_moof_size as u64 + mdat_header_size_new + cumulative_offset) as i32);
+
+					let trun_data_size: u64 = trun_mut
+						.entries
+						.iter()
+						.map(|e| {
+							e.size
+								.unwrap_or(traf_mut.tfhd.default_sample_size.unwrap_or(default_sample_size)) as u64
+						})
+						.sum();
+					cumulative_offset += trun_data_size;
+				}
+			}
+
+			moof_buf.clear();
+			adjusted_moof.encode(&mut moof_buf)?;
+
+			let per_track_mdat = Mdat {
+				data: track_mdat_data.to_vec(),
+			};
+			per_track_mdat.encode(&mut moof_buf)?;
+
+			let fragment_bytes = Bytes::from(moof_buf);
+
+			self.sink
+				.on_fragment(track_id, fragment_bytes, contains_keyframe, samples)?;
+		}
+
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	struct MockSink {
+		inits: Vec<(u32, TrackKind)>,
+		fragments: Vec<(u32, Bytes, bool, usize)>,
+	}
+
+	impl MockSink {
+		fn new() -> Self {
+			Self {
+				inits: Vec::new(),
+				fragments: Vec::new(),
+			}
+		}
+	}
+
+	impl Fmp4Sink for MockSink {
+		fn on_init(&mut self, track_id: u32, kind: TrackKind, _trak: &Trak, _moov: &Moov) -> anyhow::Result<()> {
+			self.inits.push((track_id, kind));
+			Ok(())
+		}
+
+		fn on_fragment(
+			&mut self,
+			track_id: u32,
+			fragment: Bytes,
+			keyframe: bool,
+			samples: Vec<SampleInfo>,
+		) -> anyhow::Result<()> {
+			self.fragments.push((track_id, fragment, keyframe, samples.len()));
+			Ok(())
+		}
+	}
+
+	#[test]
+	fn test_parser_bbb_init() {
+		let data = include_bytes!("test/bbb.mp4");
+		let mut parser = Fmp4Parser::new(MockSink::new());
+		let mut buf = BytesMut::from(&data[..]);
+		let _ = parser.decode(&mut buf);
+
+		assert!(parser.is_initialized());
+
+		// bbb.mp4 has track_id=1 (video) and track_id=2 (audio)
+		assert_eq!(parser.sink.inits.len(), 2);
+		assert_eq!(parser.sink.inits[0], (1, TrackKind::Video));
+		assert_eq!(parser.sink.inits[1], (2, TrackKind::Audio));
+	}
+
+	#[test]
+	fn test_parser_bbb_fragments() {
+		let data = include_bytes!("test/bbb.mp4");
+		let mut parser = Fmp4Parser::new(MockSink::new());
+		let mut buf = BytesMut::from(&data[..]);
+		let _ = parser.decode(&mut buf);
+
+		assert!(!parser.sink.fragments.is_empty());
+
+		for (_, fragment, _, sample_count) in &parser.sink.fragments {
+			assert!(!fragment.is_empty());
+			assert!(*sample_count > 0);
+		}
+
+		// First video fragment should be a keyframe
+		let first_video = parser.sink.fragments.iter().find(|(id, _, _, _)| *id == 1).unwrap();
+		assert!(first_video.2, "first video fragment should be a keyframe");
+	}
+}

--- a/rs/moq-mux/src/import/mod.rs
+++ b/rs/moq-mux/src/import/mod.rs
@@ -20,7 +20,11 @@ mod annexb;
 mod av01;
 mod avc1;
 mod avc3;
+pub(crate) mod cmsf_broadcast;
+pub(crate) mod cmsf_fmp4;
+pub(crate) mod cmsf_types;
 mod fmp4;
+pub(crate) mod fmp4_parser;
 mod framed;
 mod hev1;
 mod hls;
@@ -38,6 +42,10 @@ pub use hev1::*;
 pub use hls::*;
 pub use opus::*;
 pub use stream::*;
+
+pub use cmsf_broadcast::CmsfBroadcastProducer;
+pub use cmsf_fmp4::CmsfFmp4Importer;
+pub use cmsf_types::{CmsfAudioTrack, CmsfConfig, CmsfObject, CmsfVideoTrack, TrackId};
 
 #[cfg(test)]
 mod test;

--- a/rs/moq-mux/src/import/test/mod.rs
+++ b/rs/moq-mux/src/import/test/mod.rs
@@ -127,3 +127,146 @@ fn test_vp9_catalog() {
 	assert_eq!(mvex.trex.len(), 1);
 	assert_eq!(mvex.trex[0].track_id, moov.trak[0].tkhd.track_id);
 }
+
+// --- Adaptation tests (Step 7) ---
+
+#[test]
+fn test_container_cmaf_serde_roundtrip() {
+	let original = Container::Cmaf {
+		init: bytes::Bytes::from_static(b"hello world init segment"),
+	};
+
+	let json = serde_json::to_string(&original).unwrap();
+	assert!(json.contains("\"kind\":\"cmaf\""));
+	assert!(json.contains("\"init\""));
+
+	let deserialized: Container = serde_json::from_str(&json).unwrap();
+	assert_eq!(deserialized, original);
+}
+
+#[tokio::test]
+async fn test_cmsf_producer_consumer_roundtrip() {
+	use crate::export::cmsf::CmsfBroadcastDemuxer;
+	use crate::import::cmsf_fmp4::CmsfFmp4Importer;
+	use crate::import::cmsf_types::CmsfConfig;
+
+	let data = include_bytes!("bbb.mp4");
+
+	// Producer side: feed bbb.mp4 through CMSF importer.
+	let broadcast = moq_lite::Broadcast::new().produce();
+	let consumer = broadcast.consume();
+
+	let mut importer = CmsfFmp4Importer::new(broadcast, CmsfConfig::default()).unwrap();
+	let mut buf = bytes::BytesMut::from(&data[..]);
+	let _ = importer.decode(&mut buf);
+	importer.finish().unwrap();
+
+	// Consumer side: create demuxer from the broadcast consumer.
+	let mut demuxer = CmsfBroadcastDemuxer::new(consumer).unwrap();
+
+	// Wait for catalog to be received and tracks subscribed.
+	demuxer.ready().await.unwrap();
+
+	let tracks = demuxer.active_tracks();
+	assert!(tracks.len() >= 2, "expected at least video + audio, got {:?}", tracks);
+
+	// Read segments and verify metadata fidelity.
+	let seg = demuxer.next().await.unwrap().expect("should get a segment");
+	assert!(!seg.media_data.is_empty());
+	assert!(seg.track_name.ends_with(".m4s"));
+	assert!(seg.timescale > 0, "timescale should be non-zero");
+	assert!(seg.duration > 0, "duration should be non-zero");
+
+	// Verify the first segment of a group is a keyframe.
+	if seg.group_id == 0 {
+		assert!(seg.is_keyframe, "first segment in first group should be a keyframe");
+	}
+
+	// Verify PTS is parseable and consistent with parse_cmsf_metadata.
+	let reparsed = crate::cmsf::parse_cmsf_metadata(&seg.media_data).unwrap();
+	assert_eq!(seg.pts, reparsed.pts, "PTS should match re-parse");
+	assert_eq!(seg.duration, reparsed.duration, "duration should match re-parse");
+	assert_eq!(
+		seg.is_keyframe, reparsed.is_keyframe,
+		"keyframe flag should match re-parse"
+	);
+
+	// Read more segments to verify continuity.
+	let mut count = 1;
+	while let Some(seg) = demuxer.next().await.unwrap() {
+		assert!(seg.timescale > 0);
+		assert!(!seg.media_data.is_empty());
+		count += 1;
+		if count >= 10 {
+			break;
+		}
+	}
+	assert!(count >= 3, "expected at least 3 segments from bbb.mp4, got {count}");
+}
+
+#[tokio::test]
+async fn test_cmsf_demuxer_skips_malformed_frames() {
+	use crate::export::cmsf::CmsfTrackDemuxer;
+
+	// Create a track with valid init data but feed it a malformed frame.
+	let mut broadcast = moq_lite::Broadcast::new().produce();
+	let mut track_producer = broadcast.create_track(moq_lite::Track::new("video0.m4s")).unwrap();
+	let track_consumer = broadcast
+		.consume()
+		.subscribe_track(&moq_lite::Track::new("video0.m4s"))
+		.unwrap();
+
+	// Build a valid init segment for timescale.
+	let init_data = crate::cmsf::test_helpers::build_init_segment(90000);
+
+	let mut demuxer = CmsfTrackDemuxer::new(track_consumer, bytes::Bytes::from(init_data), 90000);
+
+	// Write a valid keyframe followed by garbage.
+	let valid = crate::cmsf::test_helpers::build_moof_mdat(0, 3003, 0x0200_0000);
+	let mut group = track_producer.append_group().unwrap();
+	group.write_frame(bytes::Bytes::from(valid)).unwrap();
+	group.write_frame(bytes::Bytes::from_static(b"garbage")).unwrap();
+	group.finish().unwrap();
+	track_producer.finish().unwrap();
+
+	// Should get the valid frame.
+	let seg = demuxer.next().await.unwrap().expect("should get valid segment");
+	assert_eq!(seg.pts, 0);
+	assert!(seg.is_keyframe);
+
+	// Malformed frame should be skipped, track ends.
+	let end = demuxer.next().await.unwrap();
+	assert!(end.is_none(), "should end after skipping malformed frame");
+}
+
+#[tokio::test]
+async fn test_cmsf_demuxer_end_reason_track_finished() {
+	use crate::export::cmsf::{CmsfTrackDemuxer, EndReason};
+
+	let mut broadcast = moq_lite::Broadcast::new().produce();
+	let mut track_producer = broadcast.create_track(moq_lite::Track::new("audio0.m4s")).unwrap();
+	let track_consumer = broadcast
+		.consume()
+		.subscribe_track(&moq_lite::Track::new("audio0.m4s"))
+		.unwrap();
+
+	let init_data = crate::cmsf::test_helpers::build_init_segment(48000);
+	let mut demuxer = CmsfTrackDemuxer::new(track_consumer, bytes::Bytes::from(init_data), 48000);
+
+	// Write one frame then finish the track.
+	let frame = crate::cmsf::test_helpers::build_moof_mdat(0, 1024, 0x0200_0000);
+	let mut group = track_producer.append_group().unwrap();
+	group.write_frame(bytes::Bytes::from(frame)).unwrap();
+	group.finish().unwrap();
+	track_producer.finish().unwrap();
+
+	// Read the frame.
+	let seg = demuxer.next().await.unwrap().expect("should get segment");
+	assert_eq!(seg.pts, 0);
+	assert_eq!(seg.timescale, 48000);
+
+	// Track should end.
+	let end = demuxer.next().await.unwrap();
+	assert!(end.is_none());
+	assert!(matches!(demuxer.end_reason(), Some(EndReason::TrackFinished)));
+}

--- a/rs/moq-mux/src/lib.rs
+++ b/rs/moq-mux/src/lib.rs
@@ -19,6 +19,7 @@
 //!   moof+mdat fragments) in timestamp order across tracks.
 
 pub mod catalog;
+pub mod cmsf;
 pub mod container;
 mod error;
 pub mod export;


### PR DESCRIPTION
## Summary

Adds full CMSF (CMAF Streaming Format) support to the MoQ stack — a muxer (broadcast producer), demuxer (broadcast consumer), fMP4-to-CMSF bridge, and C FFI bindings.

## What is CMSF?

CMSF is a profile of CMAF for live streaming over MoQ. It defines how moof+mdat fragments map to moq-lite groups/objects, how catalogs describe tracks with SAP types and init segments, and how group boundaries align with video keyframes.

## Changes

### New: CMSF Broadcast Producer (`import/cmsf_broadcast.rs`)
* Multi-rendition publishing with automatic group lifecycle management
* Video keyframes drive group boundaries; non-switching audio aligns to video
* Audio pre-roll buffering (audio before first video keyframe is buffered and flushed)
* Explicit group mode for caller-controlled boundaries (e.g. dual-pipeline redundancy)
* SAP type derivation from codec config (H264/VP8 → Type 1, H265/AV1/VP9 → Type 2)
* Jitter tracking from inter-sample PTS deltas, published in catalog
* Publishes both MSF catalog (`catalog`) and optionally a hang catalog (`catalog.json`)

### New: CMSF Demuxer (`export/cmsf.rs`)
* `CmsfTrackDemuxer`: per-track async consumer yielding `CmsfSegment`
* `CmsfBroadcastDemuxer`: broadcast-level coordinator managing catalog subscriptions
* Handles catalog updates (track addition/removal), malformed frame protection
* `build_merged_init()`: merges per-track init segments into a multi-track fMP4 init with track ID renumbering

### New: `moq-cli subscribe --output cmsf-fmp4`
* CMSF-aware fMP4 output that reads the MSF catalog directly (no hang catalog required)
* Builds merged init segment from per-track init data, then passes through raw moof+mdat segments

### New: fMP4 → CMSF Bridge (`import/cmsf_fmp4.rs`)
* `CmsfFmp4Importer`: parses fragmented MP4 stdin, auto-detects codecs, feeds CMSF producer
* Supports H.264, H.265, VP8, VP9, AV1 video and AAC, Opus audio
* `PublishDecoder::finish()`: explicit cleanup on stdin EOF to close tracks/catalogs cleanly

### New: Shared CMSF Parser (`cmsf.rs`)
* `parse_cmsf_metadata()`: extracts PTS (with CTS offset), duration, keyframe from moof+mdat
* `parse_timescale()`: extracts timescale from init segment

### New: C FFI (`libmoq/src/api.rs`, `libmoq/src/publish.rs`)
* `moq_cmsf_create`, `moq_cmsf_add_video`, `moq_cmsf_add_audio`, `moq_cmsf_write`, `moq_cmsf_close`

### Refactored: fMP4 Parser (`import/fmp4_parser.rs`)
* Extracted the moov/moof/mdat state machine into a reusable `Fmp4Parser<S: Fmp4Sink>` trait
* Both the existing `Fmp4` importer and new `CmsfFmp4Importer` share this parser
* No behavioral changes to existing fMP4 import path

### MSF Catalog Extensions (`moq-msf`)
* Added `generated_at`, `max_grp_sap_starting_type`, `max_obj_sap_starting_type` fields
* Backward compatible (all new fields are optional, old catalogs parse fine)

### TypeScript (`js/watch`)
* Video/audio decoders now fall back to init segment description when catalog lacks one (MSF/CMSF path)

### Demo
* Added `just bbb-cmsf` and `just cmsf` commands for publishing via CMSF format

## Testing
* 159 tests across moq-mux, libmoq, moq-msf, moq-cli — all passing
* Unit tests cover: SAP type derivation, jitter calculation, group lifecycle, explicit/auto mode, catalog serialization, fMP4 parser, codec detection, malformed frame handling
* Integration test with real media (`bbb.mp4`) verifying end-to-end codec detection, init segment generation, and fragment splitting