### PR TITLE
fix(hang/consumer, watch/decoder): handle non-sequential groups and AVC description fallback

### DIFF
--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -486,3 +486,28 @@ test("Consumer with CmafFormat delivers correct timestamps", async () => {
 	expect(frames[1].timestamp).toBe(33_333 as Time.Micro); // 3000/90000 * 1_000_000
 	consumer.close();
 });
+
+test("Consumer handles epoch-based group sequences without skipping", async () => {
+	// EML/CMSF uses epoch-based sequences with large gaps (not sequential).
+	// The consumer must advance #active to the next group's actual sequence,
+	// not just increment by 1.
+	const EPOCH_BASE = 85386781784064;
+	const GAP = 48128; // typical EML group gap
+
+	const track = new Track("test");
+	const consumer = new Consumer(track, { format: new LegacyFormat(), latency: 2000 as Time.Milli });
+
+	writeGroupWithLegacyFrames(track, EPOCH_BASE, [0 as Time.Micro, 20_000 as Time.Micro]);
+	writeGroupWithLegacyFrames(track, EPOCH_BASE + GAP, [40_000 as Time.Micro, 60_000 as Time.Micro]);
+	writeGroupWithLegacyFrames(track, EPOCH_BASE + GAP * 2, [80_000 as Time.Micro, 100_000 as Time.Micro]);
+	track.close();
+
+	const frames = await drainFrames(consumer, 500);
+
+	// All 6 frames should be delivered without any being skipped.
+	expect(frames).toHaveLength(6);
+	expect(frames[0].timestamp).toBe(0 as Time.Micro);
+	expect(frames[2].timestamp).toBe(40_000 as Time.Micro);
+	expect(frames[4].timestamp).toBe(80_000 as Time.Micro);
+	consumer.close();
+});

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -112,6 +112,16 @@ export class Consumer {
 
 					this.#updateBuffered();
 
+					// Promote #active eagerly if it drifted below this group
+					// (e.g. +1 fallback with no next group buffered at the time).
+					if (
+						this.#active !== undefined &&
+						this.#groups[0]?.consumer === group.consumer &&
+						group.consumer.sequence > this.#active
+					) {
+						this.#active = group.consumer.sequence;
+					}
+
 					if (group.consumer.sequence === this.#active) {
 						this.#notify?.();
 						this.#notify = undefined;
@@ -129,8 +139,10 @@ export class Consumer {
 			group.done = true;
 
 			if (group.consumer.sequence === this.#active) {
-				// Advance to the next group.
-				this.#active += 1;
+				// Advance to the next group in the buffer, or past this one.
+				const idx = this.#groups.indexOf(group);
+				const next = this.#groups[idx + 1];
+				this.#active = next?.consumer.sequence ?? group.consumer.sequence + 1;
 			}
 
 			// Recompute buffered ranges now that this group is done,
@@ -197,6 +209,16 @@ export class Consumer {
 	// If frame is undefined, the group is done.
 	async next(): Promise<{ frame: Frame | undefined; group: number } | undefined> {
 		for (;;) {
+			// If #active points below all buffered groups (e.g. a +1 guess made when
+			// no next group was buffered), promote it to the first real group.
+			if (
+				this.#active !== undefined &&
+				this.#groups.length > 0 &&
+				this.#groups[0].consumer.sequence > this.#active
+			) {
+				this.#active = this.#groups[0].consumer.sequence;
+			}
+
 			if (
 				this.#groups.length > 0 &&
 				this.#active !== undefined &&
@@ -214,12 +236,13 @@ export class Consumer {
 				// The latter handles the case where #runGroup finished before
 				// #active reached this group (e.g. after a latency skip).
 				if (this.#active > this.#groups[0].consumer.sequence || this.#groups[0].done) {
-					if (this.#groups[0].consumer.sequence === this.#active) {
-						this.#active += 1;
-					}
-
 					const group = this.#groups.shift();
 					if (group) {
+						if (group.consumer.sequence === this.#active) {
+							const next = this.#groups[0];
+							this.#active = next?.consumer.sequence ?? group.consumer.sequence + 1;
+						}
+
 						this.#updateBuffered();
 						return { frame: undefined, group: group.consumer.sequence };
 					}
@@ -250,9 +273,8 @@ export class Consumer {
 	#updateBuffered(): void {
 		const ranges: BufferedRanges = [];
 
-		let prev: Group | undefined;
-
-		for (const group of this.#groups) {
+		for (let i = 0; i < this.#groups.length; i++) {
+			const group = this.#groups[i];
 			const first = group.frames.at(0);
 			if (!first || group.latest === undefined) continue;
 
@@ -260,14 +282,13 @@ export class Consumer {
 			const end = Moq.Time.Milli.fromMicro(group.latest);
 
 			const last = ranges.at(-1);
-			const contiguous = prev?.done && prev.consumer.sequence + 1 === group.consumer.sequence;
+			const prev = this.#groups[i - 1];
+			const contiguous = prev?.done === true && prev.latest !== undefined;
 			if (last && (last.end >= start || contiguous)) {
 				last.end = Moq.Time.Milli.max(last.end, end);
 			} else {
 				ranges.push({ start, end });
 			}
-
-			prev = group;
 		}
 
 		this.#buffered.set(ranges);

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -271,8 +271,14 @@ export class Decoder {
 		const init = Container.Cmaf.decodeInitSegment(initSegment);
 		// Opus in CMAF uses raw packets (not OGG-wrapped), so description must be omitted.
 		// The dOps box from the init segment is not a valid OGG Identification Header.
+		// For other codecs, fall back to the init segment's description (esds, etc.)
+		// when the catalog doesn't provide one (MSF/CMSF path).
 		const description =
-			config.codec === "opus" ? undefined : config.description ? Util.Hex.toBytes(config.description) : undefined;
+			config.codec === "opus"
+				? undefined
+				: config.description
+					? Util.Hex.toBytes(config.description)
+					: init.description;
 
 		const consumer = new Container.Consumer(sub, {
 			format: new Container.Cmaf.Format(init),

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -362,7 +362,9 @@ class DecoderTrack {
 
 		const initSegment = base64ToBytes(this.config.container.init);
 		const init = Container.Cmaf.decodeInitSegment(initSegment);
-		const description = this.config.description ? Util.Hex.toBytes(this.config.description) : undefined;
+		// MSF/CMSF catalogs don't carry a separate description field, the codec
+		// description (avcC, hvcC, etc.) lives inside the init segment's moov box.
+		const description = this.config.description ? Util.Hex.toBytes(this.config.description) : init.description;
 
 		const consumer = new Container.Consumer(sub, {
 			format: new Container.Cmaf.Format(init),


### PR DESCRIPTION
## Problems

### 1. Consumer blocks on non-sequential group sequences

The consumer assumed group sequences increment by 1 (0, 1, 2, ...) but CMSF/EML uses epoch-based sequences with large gaps (e.g. 85386781784064, 85386781832192). After consuming a group, `#active += 1` would set `#active` to a value far below the next group's sequence, causing `next()` to block until `#checkLatency` fired a skip.

Every group transition went through the skip path, causing ~1s audio underflows and choppy playback.

### 2. WebCodecs rejects AVC frames without description

When the MSF/CMSF catalog doesn't carry a separate `description` field, the video and audio decoders passed `undefined` to WebCodecs. For AVC (length-prefixed NALUs), WebCodecs requires the avcC box as the `description` in the `VideoDecoderConfig`. Without it, every keyframe is rejected.

## Fixes

1. **Consumer:** Advance `#active` to the next group's actual sequence in the buffer rather than incrementing by 1. Also fixes the contiguity check in `#updateBuffered`.

2. **Decoder:** Fall back to `init.description` (extracted from the CMAF init segment's moov box) when the catalog doesn't provide a description field.

## Testing

- All 24 consumer tests pass.
- Added new test: "Consumer handles epoch-based group sequences without skipping" which uses sequences with gaps of 48128 (matching real EML/CMSF behavior) and verifies all frames are delivered without skipping.