### PR TITLE
feat(moq-net): usage stats in the model (BroadcastInfo-carried, origin-attributed)

### DIFF
--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -300,7 +300,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		msg: ietf::GroupHeader,
 		priority: u8,
 		mut group: GroupConsumer,
-		track_stats: std::sync::Arc<crate::PublisherTrack>,
+		// Held for the group's lifetime so it counts as one subscription; payload
+		// is metered by the model when the frames are read.
+		_track_stats: std::sync::Arc<crate::PublisherTrack>,
 		version: Version,
 	) -> Result<(), Error> {
 		let mut stream = session.open_uni().await.map_err(Error::from_transport)?;
@@ -309,7 +311,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let mut stream = Writer::new(stream, version);
 
 		stream.encode(&msg).await?;
-		track_stats.group();
 
 		loop {
 			let frame = tokio::select! {
@@ -333,7 +334,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 			// Write the size of the frame.
 			stream.encode(&frame.size).await?;
-			track_stats.frame();
 
 			if frame.size == 0 {
 				// Have to write the object status too.
@@ -349,9 +349,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 					match chunk? {
 						Some(mut chunk) => {
-							let n = chunk.len() as u64;
 							stream.write_all(&mut chunk).await?;
-							track_stats.bytes(n);
 						}
 						None => break,
 					}

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -19,22 +19,16 @@ pub(super) struct Publisher<S: web_transport_trait::Session> {
 	origin: OriginConsumer,
 	control: Control,
 	stats: StatsHandle,
-	/// Per-session egress broadcast-subscription tracker. Each downstream
-	/// subscription holds a guard so `broadcasts - broadcasts_closed` counts
-	/// the distinct sessions (viewers) watching each broadcast.
-	broadcasts: crate::SessionBroadcasts,
 	version: Version,
 }
 
 impl<S: web_transport_trait::Session> Publisher<S> {
 	pub fn new(session: S, origin: OriginConsumer, control: Control, stats: StatsHandle, version: Version) -> Self {
-		let broadcasts = stats.publisher_broadcasts();
 		Self {
 			session,
 			origin,
 			control,
 			stats,
-			broadcasts,
 			version,
 		}
 	}
@@ -125,9 +119,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		// Per-track subscription guard (bumps `subscriptions`). Taken before
 		// validation so a stale/invalid SUBSCRIBE still counts as an attempt,
-		// matching the lite path. The per-(session, broadcast) `broadcasts`
-		// sentinel that counts viewers is taken only once the subscription is
-		// validated and active, below.
+		// matching the lite path. The viewer count (`broadcasts`) is owned by the
+		// model: `broadcast.track()` hands the subscription a live-viewer token.
 		let track_stats = std::sync::Arc::new(self.stats.broadcast(&absolute).publisher_track(&track_name));
 
 		// We just received a subscribe for this exact namespace, so the peer must have already
@@ -155,10 +148,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				return Ok(());
 			}
 		};
-
-		// Subscription is now active: count this session as a viewer of the
-		// broadcast. Dropping this guard (subscription end) releases it.
-		let _broadcast_sub = self.broadcasts.subscribe(&absolute);
 
 		// Send SubscribeOk on the stream
 		stream.writer.encode(&ietf::SubscribeOk::ID).await?;

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -27,6 +27,15 @@ pub fn start<S: web_transport_trait::Session>(
 		// nothing, and an empty subscribe origin issues no SUBSCRIBE_NAMESPACE.
 		let publish = publish.unwrap_or_else(|| OriginProducer::empty(Origin::random()).consume());
 		let subscribe = subscribe.unwrap_or_else(|| OriginProducer::empty(Origin::random()));
+
+		// Attach this session's egress sink provider so the model meters every
+		// broadcast the publisher serves downstream, keyed by absolute path and tier.
+		let publish = {
+			let stats = stats.clone();
+			publish.with_egress(std::sync::Arc::new(move |abs: &str| {
+				stats.broadcast(abs).egress_usage()
+			}))
+		};
 		let res = match version {
 			Version::Draft14 | Version::Draft15 | Version::Draft16 => {
 				let Some(setup) = setup else {

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -60,10 +60,6 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	origin: OriginProducer,
 	control: Control,
 	stats: StatsHandle,
-	/// Per-session ingress broadcast-subscription tracker. Each upstream
-	/// subscription holds a guard so `broadcasts - broadcasts_closed` counts the
-	/// distinct upstream sessions feeding each broadcast.
-	broadcasts: crate::SessionBroadcasts,
 	// A random per-connection origin stamped into the hop chain of every
 	// broadcast. moq-transport never carries hop ids on the wire, so each
 	// upstream session needs a stable, unique identity in the hop list for two
@@ -76,13 +72,11 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 
 impl<S: web_transport_trait::Session> Subscriber<S> {
 	pub fn new(session: S, origin: OriginProducer, control: Control, stats: StatsHandle, version: Version) -> Self {
-		let broadcasts = stats.subscriber_broadcasts();
 		Self {
 			session,
 			origin,
 			control,
 			stats,
-			broadcasts,
 			session_origin: crate::Origin::random(),
 			state: Default::default(),
 			version,
@@ -268,11 +262,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let res = self.write_publish_ok(&mut stream, &msg).await;
 
 		if res.is_ok() {
-			// PUBLISH is the peer feeding us a broadcast, so count this session as
-			// an active upstream feed for the lifetime of the publish. The guard
-			// drops (releasing `broadcasts_closed`) when the stream closes below.
-			let abs = self.origin.absolute(&msg.track_namespace).to_owned();
-			let _broadcast_sub = self.broadcasts.subscribe(&abs);
+			// PUBLISH is the peer feeding us a broadcast; the model counts this
+			// session as a live publisher via the producer tokens on the tracks it
+			// serves into the broadcast.
 
 			// Wait for PublishDone or stream close
 			let _ = stream.reader.closed().await;
@@ -662,10 +654,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 		};
 
-		// Upstream confirmed (SubscribeOk), so this session is now actively feeding
-		// the broadcast: take the `broadcasts` sentinel for the subscription's
-		// lifetime. It drops (releasing `broadcasts_closed`) when this fn returns.
-		let _broadcast_sub = self.broadcasts.subscribe(&abs);
+		// Upstream confirmed (SubscribeOk): the model counts this session as a live
+		// publisher via the producer token on the track it feeds the broadcast.
 
 		tokio::select! {
 			_ = track.unused() => {

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -32,8 +32,9 @@ struct State {
 struct TrackState {
 	producer: TrackProducer,
 	alias: Option<u64>,
-	/// Subscriber-side track stats; counters bump as frames/bytes/groups arrive.
-	/// Dropping on subscription end records `subscriptions_closed`.
+	/// Held for its `Drop`, which records the `subscriptions` lifecycle. Payload is
+	/// metered by the model through the broadcast's ingress sink, so it's never read.
+	#[allow(dead_code)]
 	stats: Arc<SubscriberTrack>,
 }
 
@@ -462,8 +463,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					.expect("an empty hop chain has room for one entry");
 				// moq-transport carries no broadcast epoch on the wire; stamp the current
 				// time so the instance is still ordered against any future re-announce.
+				// Bake the ingress usage sink so the model meters everything written.
 				let broadcast = BroadcastInfo {
 					hops,
+					stats: crate::BroadcastStats {
+						producer: self.stats.broadcast(&abs).ingress_usage(),
+						..Default::default()
+					},
 					..Default::default()
 				}
 				.produce();
@@ -749,7 +755,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			return Err(Error::Unsupported);
 		}
 
-		let (mut producer, track, track_stats) = {
+		let (mut producer, track) = {
 			let mut state = self.state.lock();
 			let request_id = match state.aliases.get(&group.track_alias) {
 				Some(request_id) => *request_id,
@@ -763,17 +769,16 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let group_info = Group {
 				sequence: group.group_id,
 			};
+			// `create_group` bumps the broadcast's ingress usage (groups); frames and
+			// bytes are metered by the model as they're written below.
 			let producer = track.producer.create_group(group_info)?;
-			(producer, track.producer.clone(), track.stats.clone())
+			(producer, track.producer.clone())
 		};
-
-		// Bump groups counter for this incoming group on the subscriber side.
-		track_stats.group();
 
 		let res = tokio::select! {
 			err = track.closed() => Err(err),
 			err = producer.closed() => Err(err),
-			res = self.run_group(group, stream, producer.clone(), track_stats.clone()) => res,
+			res = self.run_group(group, stream, producer.clone()) => res,
 		};
 
 		match res {
@@ -797,7 +802,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		group: ietf::GroupHeader,
 		stream: &mut Reader<S::RecvStream, Version>,
 		mut producer: GroupProducer,
-		track_stats: Arc<SubscriberTrack>,
 	) -> Result<(), Error> {
 		while let Some(id_delta) = stream.decode_maybe::<u64>().await? {
 			if id_delta != 0 {
@@ -818,7 +822,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						size: 0,
 						timestamp: None,
 					})?;
-					track_stats.frame();
 					frame.finish()?;
 				} else if status == 3 && !group.flags.has_end {
 					break;
@@ -829,9 +832,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				// `create_frame` is the allocation chokepoint and rejects an oversized
 				// `size` before allocating, so no pre-check is needed.
 				let mut frame = producer.create_frame(Frame { size, timestamp: None })?;
-				track_stats.frame();
 
-				if let Err(err) = self.run_frame(stream, frame.clone(), &track_stats).await {
+				if let Err(err) = self.run_frame(stream, frame.clone()).await {
 					let _ = frame.abort(err.clone());
 					return Err(err);
 				}
@@ -847,15 +849,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		stream: &mut Reader<S::RecvStream, Version>,
 		mut frame: FrameProducer,
-		track_stats: &SubscriberTrack,
 	) -> Result<(), Error> {
 		// FrameProducer impls BufMut; read_buf writes stream bytes directly into
 		// the per-frame buffer (see lite/subscriber.rs run_frame for rationale).
+		// The model metered this frame's bytes at `create_frame` (ingress).
 		while bytes::BufMut::has_remaining_mut(&frame) {
 			match stream.read_buf(&mut frame).await? {
-				Some(n) if n > 0 => {
-					track_stats.bytes(n as u64);
-				}
+				Some(n) if n > 0 => {}
 				_ => return Err(Error::WrongSize),
 			}
 		}

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -670,7 +670,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		stream: &mut Stream<S, Version>,
 		fetch: &lite::Fetch<'_>,
 		broadcast: kio::Pending<crate::BroadcastRequested>,
-		track_stats: crate::PublisherTrack,
+		// Held for the fetch's lifetime so it counts as one subscription; payload is
+		// metered by the model.
+		_track_stats: crate::PublisherTrack,
 		version: Version,
 	) -> Result<(), Error> {
 		let broadcast = broadcast.await?;
@@ -704,7 +706,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		// Lite05+ FETCH responds with bare FRAME messages; the subscriber already has
 		// the codec/timescale from TRACK_INFO and the group sequence from its request.
-		track_stats.group();
+		// A fetch re-serves an existing group, so the model meters its frames/bytes
+		// (via `get_frame`) but not `groups`.
 
 		// Honor frame_start: skip earlier frames, then stream the rest in order. The
 		// delta-timestamp baseline resets to 0, so the first served frame's delta is
@@ -712,15 +715,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let mut index = fetch.frame_start as usize;
 		let mut prev_ts: u64 = 0;
 		while let Some(mut frame) = group.get_frame(index).await? {
-			write_fetch_frame(
-				&mut stream.writer,
-				&mut frame,
-				compression,
-				timescale,
-				&mut prev_ts,
-				&track_stats,
-			)
-			.await?;
+			write_fetch_frame(&mut stream.writer, &mut frame, compression, timescale, &mut prev_ts).await?;
 			index += 1;
 		}
 
@@ -784,28 +779,21 @@ async fn write_fetch_frame<W: web_transport_trait::SendStream>(
 	compression: Compression,
 	timescale: Option<crate::Timescale>,
 	prev_ts: &mut u64,
-	track_stats: &crate::PublisherTrack,
 ) -> Result<(), Error> {
 	encode_frame_timing(writer, frame, timescale, prev_ts).await?;
 
 	match compression {
 		Compression::None => {
 			writer.encode(&frame.size).await?;
-			track_stats.frame();
 			while let Some(mut chunk) = frame.read_chunk().await? {
-				let n = chunk.len() as u64;
 				writer.write_all(&mut chunk).await?;
-				track_stats.bytes(n);
 			}
 		}
 		compression => {
 			let payload = frame.read_all().await?;
 			let mut chunk = bytes::Bytes::from(compression.compress(&payload));
-			let n = chunk.len() as u64;
-			writer.encode(&n).await?;
-			track_stats.frame();
+			writer.encode(&(chunk.len() as u64)).await?;
 			writer.write_all(&mut chunk).await?;
-			track_stats.bytes(n);
 		}
 	}
 
@@ -821,6 +809,9 @@ struct Subscription<S: web_transport_trait::Session> {
 	session: S,
 	id: u64,
 	track_name: Arc<str>,
+	// Held for its `Drop`, which records the `subscriptions` lifecycle; egress
+	// payload is metered by the model, so the guard is never read.
+	#[allow(dead_code)]
 	track_stats: Arc<crate::PublisherTrack>,
 	priority: PriorityQueue,
 	track_priority: tokio::sync::watch::Receiver<u8>,
@@ -941,7 +932,6 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		stream.set_priority(priority.current());
 		stream.encode(&lite::DataType::Group).await?;
 		stream.encode(&msg).await?;
-		self.track_stats.group();
 
 		// Lite05+ delta-encodes per-frame timestamps within the group. The first
 		// frame's delta is absolute (against an implicit prev value of 0), every
@@ -976,7 +966,6 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		match self.compression {
 			Compression::None => {
 				stream.encode(&frame.size).await?;
-				self.track_stats.frame();
 
 				while let Some(chunk) = self.read_chunk(stream, priority, &mut frame).await? {
 					self.write_chunk(stream, priority, chunk).await?;
@@ -986,7 +975,6 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 				let payload = self.read_all(stream, priority, &mut frame).await?;
 				let chunk = bytes::Bytes::from(compression.compress(&payload));
 				stream.encode(&(chunk.len() as u64)).await?;
-				self.track_stats.frame();
 				self.write_chunk(stream, priority, chunk).await?;
 			}
 		}
@@ -1057,7 +1045,6 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		priority: &mut PriorityHandle,
 		mut chunk: bytes::Bytes,
 	) -> Result<(), Error> {
-		let n = chunk.len() as u64;
 		loop {
 			tokio::select! {
 				biased;
@@ -1069,7 +1056,8 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 				Ok(()) = self.track_priority.changed() => priority.set_track(*self.track_priority.borrow_and_update()),
 			}
 		}
-		self.track_stats.bytes(n);
+		// Egress bytes are metered by the model when the frame is read
+		// (`GroupConsumer::next_frame`), not per wire chunk.
 		Ok(())
 	}
 }

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -31,10 +31,6 @@ pub(super) struct Publisher<S: web_transport_trait::Session> {
 	session: S,
 	origin: OriginConsumer,
 	stats: MoqStats,
-	/// Per-session egress broadcast-subscription tracker. Each downstream
-	/// subscription holds a guard so `broadcasts - broadcasts_closed` counts
-	/// the distinct sessions (viewers) watching each broadcast.
-	broadcasts: crate::SessionBroadcasts,
 	self_origin: Origin,
 	priority: PriorityQueue,
 	version: Version,
@@ -46,12 +42,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// origin we're consuming so it matches the local relay identity
 		// across every session, required for cross-session loop detection.
 		let self_origin = *config.origin;
-		let broadcasts = config.stats.publisher_broadcasts();
 		Self {
 			session: config.session,
 			origin: config.origin,
 			stats: config.stats,
-			broadcasts,
 			self_origin,
 			priority: Default::default(),
 			version: config.version,
@@ -494,10 +488,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// handler (or resolves to an error when there is none).
 		let broadcast = self.origin.request_broadcast(&subscribe.broadcast);
 
-		// Per-track subscription guard (bumps `subscriptions`). The per-(session,
-		// broadcast) `broadcasts` sentinel that counts viewers is taken inside
-		// `run_subscribe`, only once the subscription is validated and active, so
-		// a stale/invalid SUBSCRIBE isn't counted as a viewer.
+		// Per-track subscription guard (bumps `subscriptions`). The viewer count
+		// (`broadcasts`) is owned by the model: `broadcast.track()` hands the
+		// subscription a live-viewer token for its lifetime.
 		let track_stats = self.stats.broadcast(&absolute).publisher_track(&track);
 
 		if let Err(err) = Self::run_subscribe(
@@ -506,7 +499,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			&subscribe,
 			broadcast,
 			self.priority.clone(),
-			(track_stats, self.broadcasts.clone(), absolute.clone()),
+			track_stats,
 			self.version,
 		)
 		.await
@@ -534,13 +527,11 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		subscribe: &lite::Subscribe<'_>,
 		broadcast: kio::Pending<crate::BroadcastRequested>,
 		priority: PriorityQueue,
-		// The track guard (bumps `subscriptions`), the per-session broadcast
-		// tracker, and the broadcast path. The `broadcasts` sentinel is taken
-		// below, after the subscription is validated, and held for its lifetime.
-		stats: (crate::PublisherTrack, crate::SessionBroadcasts, crate::PathOwned),
+		// The track guard, bumping `subscriptions` for its lifetime. The viewer
+		// count is owned by the model (see the caller).
+		track_stats: crate::PublisherTrack,
 		version: Version,
 	) -> Result<(), Error> {
-		let (track_stats, broadcasts, absolute) = stats;
 		let subscription = crate::Subscription {
 			priority: subscribe.priority,
 			ordered: subscribe.ordered,
@@ -574,10 +565,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		} else {
 			None
 		};
-
-		// Subscription is now active: count this session as a viewer of the
-		// broadcast. Dropping this guard (subscription end) releases it.
-		let _broadcast_sub = broadcasts.subscribe(&absolute);
 
 		// Lite05+ accepts implicitly: no SUBSCRIBE_OK, the immutable properties live
 		// in TRACK_INFO, and the resolved range arrives as SUBSCRIBE_START/END emitted

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -676,16 +676,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		// FETCH is gated to lite-05+, which always carries timestamps when the track
 		// advertised a timescale; `None` means an untimed track (frames omit them).
-		let timescale = if version.has_timestamps() {
-			group.timescale()
-		} else {
-			None
-		};
-
-		// Compression is an immutable per-track property (reported in TRACK_INFO), so
-		// fetched frames use the same codec as live ones. The group resolved above, so
-		// the track's info is set and this resolves immediately.
-		let compression = if track.info().await?.compress && version.has_timestamps() {
+		// Codec + timescale are immutable per-track properties (reported in
+		// TRACK_INFO), so fetched frames use the same codec/timing as live ones. The
+		// group resolved above, so the track's info is set and this resolves immediately.
+		let info = track.info().await?;
+		let timescale = if version.has_timestamps() { info.timescale } else { None };
+		let compression = if info.compress && version.has_timestamps() {
 			Compression::Deflate
 		} else {
 			Compression::None

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -62,6 +62,15 @@ pub fn start<S: web_transport_trait::Session>(
 	let publish = publish.unwrap_or_else(|| OriginProducer::empty(Origin::random()).consume());
 	let subscribe = subscribe.unwrap_or_else(|| OriginProducer::empty(Origin::random()));
 
+	// Attach this session's egress sink provider so every broadcast the publisher
+	// serves downstream is metered by the model, keyed by absolute path and tier.
+	let publish = {
+		let stats = stats.clone();
+		publish.with_egress(std::sync::Arc::new(move |abs: &str| {
+			stats.broadcast(abs).egress_usage()
+		}))
+	};
+
 	// Publisher and Subscriber each derive their identity from their own
 	// attached origin (publish.info / subscribe.info). This is what gets
 	// stamped onto outbound hops and checked against incoming hops, so it

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -448,6 +448,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let broadcast = BroadcastInfo {
 			hops,
 			epoch: BroadcastInfo::epoch_from_wire(epoch),
+			..Default::default()
 		}
 		.produce();
 
@@ -506,6 +507,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let broadcast = BroadcastInfo {
 			hops,
 			epoch: BroadcastInfo::epoch_from_wire(epoch),
+			..Default::default()
 		}
 		.produce();
 		let dynamic = broadcast.dynamic();

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -76,6 +76,9 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 #[derive(Clone)]
 struct TrackEntry {
 	producer: TrackProducer,
+	// Held for its `Drop`, which records the `subscriptions` lifecycle; payload is
+	// metered by the model, so the guard is never read.
+	#[allow(dead_code)]
 	stats: Arc<SubscriberTrack>,
 	/// Codec + timestamp scale from this track's TRACK_INFO, known before the
 	/// SUBSCRIBE is even opened, so group streams decode frames without blocking.
@@ -445,10 +448,16 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "announce");
 
+		// Bake the ingress usage sink so the model meters everything this upstream
+		// subscription writes into the broadcast.
+		let ingress = self.stats.broadcast(self.origin.absolute(&path)).ingress_usage();
 		let broadcast = BroadcastInfo {
 			hops,
 			epoch: BroadcastInfo::epoch_from_wire(epoch),
-			..Default::default()
+			stats: crate::BroadcastStats {
+				producer: ingress,
+				..Default::default()
+			},
 		}
 		.produce();
 
@@ -504,10 +513,16 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "restart");
 
+		// Bake the ingress usage sink so the model meters everything this upstream
+		// subscription writes into the broadcast.
+		let ingress = self.stats.broadcast(self.origin.absolute(&path)).ingress_usage();
 		let broadcast = BroadcastInfo {
 			hops,
 			epoch: BroadcastInfo::epoch_from_wire(epoch),
-			..Default::default()
+			stats: crate::BroadcastStats {
+				producer: ingress,
+				..Default::default()
+			},
 		}
 		.produce();
 		let dynamic = broadcast.dynamic();
@@ -567,23 +582,16 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	pub async fn recv_group(&mut self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {
 		let hdr: lite::Group = stream.decode().await?;
 
-		let (mut group, track, track_stats, compression, timescale) = {
+		let (mut group, track, compression, timescale) = {
 			let mut subs = self.subscribes.lock();
 			let entry = subs.get_mut(&hdr.subscribe).ok_or(Error::Cancel)?;
 
 			let group_info = Group { sequence: hdr.sequence };
+			// `create_group` bumps the broadcast's ingress usage (groups); the model
+			// meters frames/bytes as they're written below.
 			let group = entry.producer.create_group(group_info)?;
-			(
-				group,
-				entry.producer.clone(),
-				entry.stats.clone(),
-				entry.compression,
-				entry.timescale,
-			)
+			(group, entry.producer.clone(), entry.compression, entry.timescale)
 		};
-
-		// Bump groups counter for this incoming group on the subscriber side.
-		track_stats.group();
 
 		// The codec/timescale came from TRACK_INFO (read before this subscription was
 		// even registered), so frames decode immediately. No SUBSCRIBE_OK to wait on.
@@ -591,7 +599,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let res = tokio::select! {
 			err = track.closed() => Err(err),
 			err = group.closed() => Err(err),
-			res = self.run_group(stream, group.clone(), track_stats.clone(), compression, timescale) => res,
+			res = self.run_group(stream, group.clone(), compression, timescale) => res,
 		};
 
 		match res {
@@ -614,7 +622,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		stream: &mut Reader<S::RecvStream, Version>,
 		mut group: GroupProducer,
-		track_stats: Arc<SubscriberTrack>,
 		compression: Compression,
 		timescale: Option<Timescale>,
 	) -> Result<(), Error> {
@@ -650,9 +657,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					// `create_frame` is the allocation chokepoint and rejects an
 					// oversized `size` before allocating, so no pre-check is needed.
 					let mut frame = group.create_frame(Frame { size, timestamp })?;
-					track_stats.frame();
 
-					if let Err(err) = self.run_frame(stream, &mut frame, &track_stats).await {
+					if let Err(err) = self.run_frame(stream, &mut frame).await {
 						let _ = frame.abort(err.clone());
 						return Err(err);
 					}
@@ -669,9 +675,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					// Pull the compressed bytes off the wire, then inflate. The frame
 					// the consumer sees carries the original (decompressed) size.
 					let packed = stream.read_exact(size as usize).await?;
-					track_stats.frame();
-					track_stats.bytes(size);
-
 					let payload = compression.decompress(&packed)?;
 					let mut frame = group.create_frame(Frame {
 						size: payload.len() as u64,
@@ -690,17 +693,15 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		stream: &mut Reader<S::RecvStream, Version>,
 		frame: &mut FrameProducer,
-		track_stats: &SubscriberTrack,
 	) -> Result<(), Error> {
 		// FrameProducer impls BufMut over its pre-allocated per-frame buffer, so
 		// read_buf writes QUIC stream bytes directly into the frame — no
 		// intermediate Bytes allocations, and quinn's reassembly arena is freed
-		// as we drain it.
+		// as we drain it. The model already metered this frame's bytes at
+		// `create_frame` (ingress), so no per-chunk counting here.
 		while bytes::BufMut::has_remaining_mut(frame) {
 			match stream.read_buf(frame).await? {
-				Some(n) if n > 0 => {
-					track_stats.bytes(n as u64);
-				}
+				Some(n) if n > 0 => {}
 				_ => return Err(Error::WrongSize),
 			}
 		}
@@ -1208,7 +1209,9 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			mut subscriber,
 			path,
 			broadcast: _,
-			track_stats,
+			// Held for the fetch's lifetime so it counts as one subscription; the
+			// model meters the fetched group's payload.
+			track_stats: _track_stats,
 			name,
 		} = self;
 		let group = request.sequence();
@@ -1257,13 +1260,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		};
 
 		let res = subscriber
-			.run_group(
-				&mut stream.reader,
-				producer.clone(),
-				track_stats,
-				compression,
-				timescale,
-			)
+			.run_group(&mut stream.reader, producer.clone(), compression, timescale)
 			.await;
 		match res {
 			Ok(()) => {

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -50,10 +50,6 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 
 	origin: OriginProducer,
 	stats: StatsHandle,
-	/// Per-session ingress broadcast-subscription tracker. Each upstream
-	/// subscription holds a guard so `broadcasts - broadcasts_closed` counts the
-	/// distinct upstream sessions feeding each broadcast.
-	broadcasts: crate::SessionBroadcasts,
 	recv_bandwidth: Option<BandwidthProducer>,
 	// Session-level origin id shared with the Publisher. Used to filter out
 	// reflected announces: we ask the peer (via AnnounceInterest.exclude_hop)
@@ -93,12 +89,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// every session sharing that origin, required for cross-session
 		// loop detection.
 		let self_origin = *config.origin;
-		let broadcasts = config.stats.subscriber_broadcasts();
 		Self {
 			session: config.session,
 			origin: config.origin,
 			stats: config.stats,
-			broadcasts,
 			recv_bandwidth: config.recv_bandwidth,
 			self_origin,
 			session_origin: crate::Origin::random(),
@@ -769,8 +763,6 @@ struct SubStream<S: web_transport_trait::Session> {
 	max_latency: Duration,
 	start_group: Option<u64>,
 	priority: u8,
-	/// Per-(session, broadcast) viewer sentinel, held for the subscription's life.
-	_broadcast_sub: crate::BroadcastSubscription,
 }
 
 enum Sub<S: web_transport_trait::Session> {
@@ -1158,11 +1150,9 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			producer
 		};
 
-		// This session is now actively feeding the broadcast, so take the per-(session,
-		// broadcast) viewer sentinel for the subscription's life.
-		let abs = self.subscriber.origin.absolute(&self.path).to_owned();
-		let broadcast_sub = self.subscriber.broadcasts.subscribe(&abs);
-
+		// The accepted producer holds a live-publisher token (taken when the
+		// broadcast served this track request), so the model counts this session as
+		// feeding the broadcast for the producer's lifetime.
 		self.subscriber.subscribes.lock().insert(
 			id,
 			TrackEntry {
@@ -1181,7 +1171,6 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			max_latency: subscription.stale,
 			start_group: subscription.group_start,
 			priority: subscription.priority,
-			_broadcast_sub: broadcast_sub,
 		});
 
 		Ok(())
@@ -1286,6 +1275,6 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			}
 			Track::Pending(request) => request.reject(err),
 		}
-		// Dropping `sub` releases the BroadcastSubscription viewer sentinel.
+		// Dropping the producer releases its live-publisher token.
 	}
 }

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -1,13 +1,23 @@
 use std::{
 	collections::{HashMap, VecDeque, hash_map},
-	sync::Arc,
+	sync::{Arc, LazyLock},
 	task::{Poll, ready},
 	time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use crate::{Error, TrackConsumer, TrackProducer, TrackRequest, TrackWeak};
 
-use super::{OriginList, TrackInfo};
+use super::{BroadcastStats, OriginList, TrackInfo};
+
+/// Shared no-op broadcast metadata for tracks created outside a broadcast.
+///
+/// A standalone [`TrackProducer::new`] track has no broadcast to inherit from, so
+/// it points at this default instance; its usage sinks have no reader, so bumping
+/// them is harmless. Shared so a fresh standalone track is a cheap `Arc` clone.
+pub(crate) fn noop_broadcast() -> Arc<BroadcastInfo> {
+	static NOOP: LazyLock<Arc<BroadcastInfo>> = LazyLock::new(|| Arc::new(BroadcastInfo::default()));
+	NOOP.clone()
+}
 
 /// Wall-clock base for the broadcast epoch: 2020-01-01T00:00:00 UTC, expressed as
 /// seconds since the Unix epoch. The wire carries milliseconds since this base
@@ -32,6 +42,13 @@ pub struct BroadcastInfo {
 	/// created). Origin-assigned and forwarded unchanged by relays. On the wire
 	/// (ANNOUNCE_BROADCAST, lite-05+) it is encoded as milliseconds since 2020-01-01 UTC.
 	pub epoch: SystemTime,
+
+	/// Usage sinks for this broadcast, carried immutably to every track, group,
+	/// and frame. The ingress sink is baked in by the publisher at construction;
+	/// the egress sink is stamped per consuming session by the origin. Defaults to
+	/// unreferenced no-op sinks, so a broadcast is unmetered unless a stats layer
+	/// supplies them.
+	pub stats: BroadcastStats,
 }
 
 impl Default for BroadcastInfo {
@@ -40,6 +57,7 @@ impl Default for BroadcastInfo {
 			hops: OriginList::new(),
 			// A fresh broadcast instance is stamped with the current wall clock.
 			epoch: SystemTime::now(),
+			stats: BroadcastStats::default(),
 		}
 	}
 }
@@ -133,7 +151,7 @@ impl BroadcastState {
 /// or handle on-demand requests via [Self::dynamic].
 #[derive(Clone)]
 pub struct BroadcastProducer {
-	info: BroadcastInfo,
+	info: Arc<BroadcastInfo>,
 	state: kio::Producer<BroadcastState>,
 }
 
@@ -141,7 +159,7 @@ impl BroadcastProducer {
 	/// Create a producer for the given broadcast metadata. Prefer [`BroadcastInfo::produce`].
 	pub fn new(info: BroadcastInfo) -> Self {
 		Self {
-			info,
+			info: Arc::new(info),
 			state: Default::default(),
 		}
 	}
@@ -179,7 +197,7 @@ impl BroadcastProducer {
 		info: impl Into<Option<TrackInfo>>,
 	) -> Result<TrackProducer, Error> {
 		let info = info.into().unwrap_or_default();
-		let track = TrackProducer::new(name, info);
+		let track = TrackProducer::for_broadcast(name, info, self.info.clone());
 		let mut state = BroadcastState::modify(&self.state)?;
 		state.insert_track(track.weak())?;
 		drop(state);
@@ -194,7 +212,7 @@ impl BroadcastProducer {
 	/// inspected the media, the same shape as a consumer-driven
 	/// [`BroadcastDynamic::requested_track`].
 	pub fn reserve_track(&mut self, name: impl Into<Arc<str>>) -> Result<TrackRequest, Error> {
-		let request = TrackRequest::new(name);
+		let request = TrackRequest::for_broadcast(name, self.info.clone());
 		let mut state = BroadcastState::modify(&self.state)?;
 		state.insert_track(request.weak())?;
 		drop(state);
@@ -265,7 +283,7 @@ impl BroadcastProducer {
 /// [`TrackRequest::reject`]s it. Dropped when no longer needed; pending requests
 /// are automatically aborted.
 pub struct BroadcastDynamic {
-	info: BroadcastInfo,
+	info: Arc<BroadcastInfo>,
 	state: kio::Producer<BroadcastState>,
 }
 
@@ -287,7 +305,7 @@ impl Clone for BroadcastDynamic {
 }
 
 impl BroadcastDynamic {
-	fn new(info: BroadcastInfo, state: kio::Producer<BroadcastState>) -> Self {
+	fn new(info: Arc<BroadcastInfo>, state: kio::Producer<BroadcastState>) -> Self {
 		if let Ok(mut state) = state.write() {
 			// If the broadcast is already closed, we can't handle any new requests.
 			state.dynamic += 1;
@@ -388,7 +406,7 @@ impl BroadcastDynamic {
 /// Subscribe to arbitrary broadcast/tracks.
 #[derive(Clone)]
 pub struct BroadcastConsumer {
-	info: BroadcastInfo,
+	info: Arc<BroadcastInfo>,
 	state: kio::Consumer<BroadcastState>,
 }
 
@@ -408,7 +426,11 @@ impl BroadcastConsumer {
 		// Reuse a live producer if one is already publishing the track.
 		if let Some(weak) = state.tracks.get(name) {
 			if !weak.is_closed() {
-				return Ok(weak.consume());
+				let mut consumer = weak.consume();
+				// Attribute egress to this consuming session, not whoever produced
+				// or first requested the track.
+				consumer.set_broadcast(self.info.clone());
+				return Ok(consumer);
 			}
 			// Drop the stale entry and fall through to a fresh request.
 			state.tracks.remove(name);
@@ -416,7 +438,9 @@ impl BroadcastConsumer {
 
 		if let Some(pending) = state.requests.get_mut(name) {
 			// Coalesce onto an in-flight request for the same name.
-			return Ok(pending.consume());
+			let mut consumer = pending.consume();
+			consumer.set_broadcast(self.info.clone());
+			return Ok(consumer);
 		}
 
 		if state.dynamic == 0 {
@@ -424,9 +448,10 @@ impl BroadcastConsumer {
 		}
 
 		// Allocate the name once and share the same Arc across the request, the
-		// requests map, and the FIFO order.
+		// requests map, and the FIFO order. The request carries this broadcast's
+		// info so the accepted producer meters ingress and this consumer meters egress.
 		let name: Arc<str> = name.into();
-		let request = TrackRequest::new(name.clone());
+		let request = TrackRequest::for_broadcast(name.clone(), self.info.clone());
 		let consumer = request.consume();
 
 		state.requests.insert(name.clone(), request);

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -166,11 +166,11 @@ impl BroadcastProducer {
 	/// Create a producer for the given broadcast metadata. Prefer [`BroadcastInfo::produce`].
 	pub fn new(info: BroadcastInfo) -> Self {
 		let info = Arc::new(info);
-		let state = kio::Producer::<BroadcastState>::default();
-		if let Ok(mut s) = state.write() {
-			// Key the live-publisher count to this broadcast's ingress sink.
-			s.publishers = Live::new(info.stats.producer.clone());
-		}
+		// Key the live-publisher count to this broadcast's ingress sink.
+		let state = kio::Producer::new(BroadcastState {
+			publishers: Live::new(info.stats.producer.clone()),
+			..Default::default()
+		});
 		Self { info, state }
 	}
 

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{Error, TrackConsumer, TrackProducer, TrackRequest, TrackWeak};
 
-use super::{BroadcastStats, OriginList, TrackInfo};
+use super::{BroadcastStats, OriginList, TrackInfo, Usage};
 
 /// Shared no-op broadcast metadata for tracks created outside a broadcast.
 ///
@@ -415,6 +415,19 @@ impl BroadcastConsumer {
 		&self.info
 	}
 
+	/// Replace this consumer's egress usage sink, attributing everything it
+	/// delivers to a particular session/tier.
+	///
+	/// The shared channel is untouched (so [`Self::is_clone`] and origin routing
+	/// are unaffected); only this handle's `Arc<BroadcastInfo>` is swapped for one
+	/// with a different `stats.consumer`. The origin calls this once per session
+	/// when it hands the consumer out.
+	pub(crate) fn set_consumer_sink(&mut self, usage: Arc<Usage>) {
+		let mut info = (*self.info).clone();
+		info.stats.consumer = usage;
+		self.info = Arc::new(info);
+	}
+
 	/// Get a handle to a track on this broadcast.
 	pub fn track(&self, name: &str) -> Result<TrackConsumer, Error> {
 		// Upgrade to a temporary producer so we can modify the state.
@@ -711,5 +724,62 @@ mod test {
 		// Original handle is still live, so the request registers (stays pending)
 		// instead of failing with NotFound.
 		let _fut = subscribe_pending!(consumer, "track1");
+	}
+
+	/// Ingress is metered once (single writer) and egress per consumer: two viewers
+	/// of the same track count the payload twice on the egress sink while the
+	/// ingress sink counts it once.
+	#[tokio::test]
+	async fn usage_ingress_once_egress_per_viewer() {
+		use std::sync::Arc;
+
+		use crate::{BroadcastStats, Usage};
+
+		let ingress = Arc::new(Usage::default());
+		let egress = Arc::new(Usage::default());
+		let info = BroadcastInfo {
+			stats: BroadcastStats {
+				producer: ingress.clone(),
+				consumer: egress.clone(),
+			},
+			..Default::default()
+		};
+
+		let mut broadcast = info.produce();
+		let mut track = broadcast.assert_create_track("video", None);
+		let consumer = broadcast.consume();
+
+		// Ingress: one group of two frames (5 + 6 bytes).
+		let mut group = track.append_group().unwrap();
+		group.write_frame(bytes::Bytes::from_static(b"hello")).unwrap();
+		group.write_frame(bytes::Bytes::from_static(b"world!")).unwrap();
+		group.finish().unwrap();
+
+		assert_eq!(ingress.groups(), 1);
+		assert_eq!(ingress.frames(), 2);
+		assert_eq!(ingress.bytes(), 11);
+		// Nothing delivered yet.
+		assert_eq!(egress.groups(), 0);
+		assert_eq!(egress.bytes(), 0);
+
+		// Two viewers each read the group and its frames.
+		for _ in 0..2 {
+			let mut sub = consumer.track("video").unwrap().subscribe(None).await.unwrap();
+			let mut g = sub.next_group().await.unwrap().expect("group");
+			assert_eq!(
+				g.read_frame().await.unwrap().unwrap(),
+				bytes::Bytes::from_static(b"hello")
+			);
+			assert_eq!(
+				g.read_frame().await.unwrap().unwrap(),
+				bytes::Bytes::from_static(b"world!")
+			);
+		}
+
+		// Ingress unchanged; egress counted once per viewer.
+		assert_eq!(ingress.groups(), 1);
+		assert_eq!(egress.groups(), 2);
+		assert_eq!(egress.frames(), 4);
+		assert_eq!(egress.bytes(), 22);
 	}
 }

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{Error, TrackConsumer, TrackProducer, TrackRequest, TrackWeak};
 
-use super::{BroadcastStats, OriginList, TrackInfo, Usage};
+use super::{BroadcastStats, OriginList, TrackInfo, Usage, usage::Live};
 
 /// Shared no-op broadcast metadata for tracks created outside a broadcast.
 ///
@@ -119,6 +119,13 @@ struct BroadcastState {
 	// The current number of dynamic producers.
 	// If this is 0, requests must be empty.
 	dynamic: usize,
+
+	// Live-publisher refcount over the ingress sink: the broadcast counts as one
+	// live publisher while >= 1 `TrackProducer` (created here or via the dynamic
+	// handler) is alive. Shared by every producer/dynamic handle through the kio
+	// channel. Set by `BroadcastProducer::new`; a default-constructed state has a
+	// no-op sink.
+	publishers: Arc<Live>,
 }
 
 impl BroadcastState {
@@ -158,10 +165,13 @@ pub struct BroadcastProducer {
 impl BroadcastProducer {
 	/// Create a producer for the given broadcast metadata. Prefer [`BroadcastInfo::produce`].
 	pub fn new(info: BroadcastInfo) -> Self {
-		Self {
-			info: Arc::new(info),
-			state: Default::default(),
+		let info = Arc::new(info);
+		let state = kio::Producer::<BroadcastState>::default();
+		if let Ok(mut s) = state.write() {
+			// Key the live-publisher count to this broadcast's ingress sink.
+			s.publishers = Live::new(info.stats.producer.clone());
 		}
+		Self { info, state }
 	}
 
 	pub fn info(&self) -> &BroadcastInfo {
@@ -197,8 +207,9 @@ impl BroadcastProducer {
 		info: impl Into<Option<TrackInfo>>,
 	) -> Result<TrackProducer, Error> {
 		let info = info.into().unwrap_or_default();
-		let track = TrackProducer::for_broadcast(name, info, self.info.clone());
 		let mut state = BroadcastState::modify(&self.state)?;
+		let publisher = state.publishers.enter();
+		let track = TrackProducer::for_broadcast(name, info, self.info.clone(), Some(publisher));
 		state.insert_track(track.weak())?;
 		drop(state);
 		Ok(track)
@@ -212,8 +223,10 @@ impl BroadcastProducer {
 	/// inspected the media, the same shape as a consumer-driven
 	/// [`BroadcastDynamic::requested_track`].
 	pub fn reserve_track(&mut self, name: impl Into<Arc<str>>) -> Result<TrackRequest, Error> {
-		let request = TrackRequest::for_broadcast(name, self.info.clone());
 		let mut state = BroadcastState::modify(&self.state)?;
+		let mut request = TrackRequest::for_broadcast(name, self.info.clone());
+		// The reserved track is published into by this producer, so count it.
+		request.set_publisher(state.publishers.enter());
 		state.insert_track(request.weak())?;
 		drop(state);
 		Ok(request)
@@ -251,6 +264,7 @@ impl BroadcastProducer {
 		BroadcastConsumer {
 			info: self.info.clone(),
 			state: self.state.consume(),
+			viewers: Live::new(self.info.stats.consumer.clone()),
 		}
 	}
 
@@ -341,7 +355,10 @@ impl BroadcastDynamic {
 		}))?;
 
 		let name = state.request_order.pop_front().expect("predicate guaranteed a request");
-		let pending = state.requests.remove(&name).expect("request_order out of sync");
+		let mut pending = state.requests.remove(&name).expect("request_order out of sync");
+		// Serving this request makes the broadcast a live publisher (the relay's
+		// ingress tracks are created on this path).
+		pending.set_publisher(state.publishers.enter());
 		state.tracks.insert(name, pending.weak());
 		Poll::Ready(Ok(pending))
 	}
@@ -356,6 +373,7 @@ impl BroadcastDynamic {
 		BroadcastConsumer {
 			info: self.info.clone(),
 			state: self.state.consume(),
+			viewers: Live::new(self.info.stats.consumer.clone()),
 		}
 	}
 
@@ -408,6 +426,10 @@ impl BroadcastDynamic {
 pub struct BroadcastConsumer {
 	info: Arc<BroadcastInfo>,
 	state: kio::Consumer<BroadcastState>,
+
+	// Live-viewer refcount over the egress sink: this consumer (and its clones)
+	// counts as one viewer while it has >= 1 outstanding `TrackConsumer`.
+	viewers: Arc<Live>,
 }
 
 impl BroadcastConsumer {
@@ -424,8 +446,11 @@ impl BroadcastConsumer {
 	/// when it hands the consumer out.
 	pub(crate) fn set_consumer_sink(&mut self, usage: Arc<Usage>) {
 		let mut info = (*self.info).clone();
-		info.stats.consumer = usage;
+		info.stats.consumer = usage.clone();
 		self.info = Arc::new(info);
+		// Re-key the viewer count to the session's sink. The origin stamps before
+		// the consumer is cloned or used, so the count is still zero here.
+		self.viewers = Live::new(usage);
 	}
 
 	/// Get a handle to a track on this broadcast.
@@ -441,8 +466,9 @@ impl BroadcastConsumer {
 			if !weak.is_closed() {
 				let mut consumer = weak.consume();
 				// Attribute egress to this consuming session, not whoever produced
-				// or first requested the track.
+				// or first requested the track, and count it toward this viewer.
 				consumer.set_broadcast(self.info.clone());
+				consumer.set_viewer(self.viewers.enter());
 				return Ok(consumer);
 			}
 			// Drop the stale entry and fall through to a fresh request.
@@ -453,6 +479,7 @@ impl BroadcastConsumer {
 			// Coalesce onto an in-flight request for the same name.
 			let mut consumer = pending.consume();
 			consumer.set_broadcast(self.info.clone());
+			consumer.set_viewer(self.viewers.enter());
 			return Ok(consumer);
 		}
 
@@ -465,7 +492,8 @@ impl BroadcastConsumer {
 		// info so the accepted producer meters ingress and this consumer meters egress.
 		let name: Arc<str> = name.into();
 		let request = TrackRequest::for_broadcast(name.clone(), self.info.clone());
-		let consumer = request.consume();
+		let mut consumer = request.consume();
+		consumer.set_viewer(self.viewers.enter());
 
 		state.requests.insert(name.clone(), request);
 		state.request_order.push_back(name);
@@ -781,5 +809,47 @@ mod test {
 		assert_eq!(egress.groups(), 2);
 		assert_eq!(egress.frames(), 4);
 		assert_eq!(egress.bytes(), 22);
+	}
+
+	/// Live counts: a producer with >= 1 track is one publisher; a consumer with
+	/// >= 1 outstanding `TrackConsumer` is one viewer regardless of track count.
+	#[tokio::test]
+	async fn live_viewer_and_publisher_counts() {
+		use std::sync::Arc;
+
+		use crate::{BroadcastStats, Usage};
+
+		let ingress = Arc::new(Usage::default());
+		let egress = Arc::new(Usage::default());
+		let info = BroadcastInfo {
+			stats: BroadcastStats {
+				producer: ingress.clone(),
+				consumer: egress.clone(),
+			},
+			..Default::default()
+		};
+
+		let mut producer = info.produce();
+
+		// Publisher: creating a track opens one publisher.
+		assert_eq!(ingress.opened(), 0);
+		let track = producer.assert_create_track("video", None);
+		assert_eq!((ingress.opened(), ingress.closed()), (1, 0));
+
+		// Viewer: one consumer counts once regardless of how many tracks it holds.
+		let consumer = producer.consume();
+		let t1 = consumer.track("video").unwrap();
+		assert_eq!((egress.opened(), egress.closed()), (1, 0));
+		let t2 = consumer.track("video").unwrap();
+		assert_eq!(egress.opened(), 1, "same consumer, still one viewer");
+
+		drop(t1);
+		assert_eq!(egress.closed(), 0, "a track is still outstanding");
+		drop(t2);
+		assert_eq!(egress.closed(), 1, "last track dropped closes the viewer");
+
+		// Publisher closes when its last track drops.
+		drop(track);
+		assert_eq!(ingress.closed(), 1);
 	}
 }

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -13,7 +13,7 @@ use std::task::{Poll, ready};
 
 use bytes::Bytes;
 
-use crate::{Error, Result};
+use crate::{Error, Result, Timescale};
 
 #[cfg(test)]
 use super::broadcast::noop_broadcast;
@@ -183,6 +183,14 @@ impl GroupProducer {
 			track,
 			broadcast,
 		}
+	}
+
+	/// The parent track's negotiated timescale, or `None` for untimed tracks.
+	///
+	/// A frame writer (e.g. `hang`) queries this to decide whether to attach a
+	/// per-frame timestamp, which is only meaningful on a timed track.
+	pub fn timescale(&self) -> Option<Timescale> {
+		self.track.timescale
 	}
 
 	/// A helper method to write a frame from a single byte buffer.

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -389,7 +389,13 @@ impl GroupConsumer {
 	///
 	/// Returns None if the group is finished and the index is out of range.
 	pub async fn get_frame(&self, index: usize) -> Result<Option<FrameConsumer>> {
-		kio::wait(|waiter| self.poll_get_frame(waiter, index)).await
+		let frame = kio::wait(|waiter| self.poll_get_frame(waiter, index)).await?;
+		// Egress dual for random-access reads (the fetch serve path). The live
+		// path goes through `poll_next_frame`/`poll_read_frame` instead.
+		if let Some(frame) = &frame {
+			self.broadcast.stats.consumer.add_frame(frame.size);
+		}
+		Ok(frame)
 	}
 
 	/// Poll for the frame at the given index, without blocking.

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -15,9 +15,9 @@ use bytes::Bytes;
 
 use crate::{Error, Result, Timescale};
 
-use super::{BroadcastInfo, Frame, FrameConsumer, FrameProducer, TrackInfo};
 #[cfg(test)]
 use super::broadcast::noop_broadcast;
+use super::{BroadcastInfo, Frame, FrameConsumer, FrameProducer, TrackInfo};
 
 /// Maximum total size of frames cached in a group before old frames are evicted.
 ///

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -8,13 +8,16 @@
 //!
 //! The stream is closed with [Error] when all writers or readers are dropped.
 use std::collections::VecDeque;
+use std::sync::Arc;
 use std::task::{Poll, ready};
 
 use bytes::Bytes;
 
 use crate::{Error, Result, Timescale};
 
-use super::{Frame, FrameConsumer, FrameProducer};
+use super::{BroadcastInfo, Frame, FrameConsumer, FrameProducer, TrackInfo};
+#[cfg(test)]
+use super::broadcast::noop_broadcast;
 
 /// Maximum total size of frames cached in a group before old frames are evicted.
 ///
@@ -43,7 +46,7 @@ impl Group {
 	/// tests that don't exercise timestamps.
 	#[cfg(test)]
 	pub(crate) fn produce(self) -> GroupProducer {
-		GroupProducer::new(self, None)
+		GroupProducer::new(self, Arc::new(TrackInfo::default()), noop_broadcast())
 	}
 }
 
@@ -149,12 +152,12 @@ pub struct GroupProducer {
 	// The group header containing the sequence number.
 	info: Group,
 
-	// Parent track's negotiated timescale, used by [`Self::create_frame`] to
-	// validate per-frame timestamps before they enter the stream. `None` means
-	// frames on this group must have `Frame::timestamp = None`; `Some(scale)`
-	// requires `Frame::timestamp = Some(ts)` with `ts.scale() == scale`.
-	// Populated by [`crate::TrackProducer::create_group`] / `append_group`.
-	timescale: Option<Timescale>,
+	// Parent track's info, used by [`Self::create_frame`] to validate per-frame
+	// timestamps against the negotiated timescale before they enter the stream.
+	track: Arc<TrackInfo>,
+
+	// The broadcast this group belongs to. Each frame bumps its ingress usage sink.
+	broadcast: Arc<BroadcastInfo>,
 }
 
 impl std::ops::Deref for GroupProducer {
@@ -169,20 +172,22 @@ impl GroupProducer {
 	/// Create a group producer bound to its parent track's timescale.
 	///
 	/// Crate-private: groups are only constructed via [`crate::TrackProducer`],
-	/// which supplies the negotiated timescale. `None` means the parent track is
-	/// untimed and added frames must have `timestamp = None`; `Some(scale)`
-	/// requires every frame's `timestamp` to be `Some(ts)` with `ts.scale() == scale`.
-	pub(crate) fn new(info: Group, timescale: Option<Timescale>) -> Self {
+	/// which supplies the parent track info (for the negotiated timescale) and the
+	/// owning broadcast (for the usage sink). An untimed track requires every
+	/// frame's `timestamp` to be `None`; a timed one requires `Some(ts)` with
+	/// `ts.scale()` equal to the track's timescale.
+	pub(crate) fn new(info: Group, track: Arc<TrackInfo>, broadcast: Arc<BroadcastInfo>) -> Self {
 		Self {
 			info,
 			state: kio::Producer::default(),
-			timescale,
+			track,
+			broadcast,
 		}
 	}
 
 	/// The parent track's negotiated timescale, or `None` for untimed tracks.
 	pub fn timescale(&self) -> Option<Timescale> {
-		self.timescale
+		self.track.timescale
 	}
 
 	/// A helper method to write a frame from a single byte buffer.
@@ -216,19 +221,24 @@ impl GroupProducer {
 		// Catch the contract violation here, at the model layer, so peers that
 		// downstream-encode (e.g. the lite publisher's `serve_frame`) can rely
 		// on the invariant instead of re-validating per byte.
-		match (self.timescale, frame.timestamp) {
+		match (self.track.timescale, frame.timestamp) {
 			(Some(track_scale), Some(ts)) if ts.scale() == track_scale => {}
 			(None, None) => {}
 			_ => return Err(Error::TimestampMismatch),
 		}
 
+		let size = frame.size;
 		let mut state = modify(&self.state)?;
 		if state.fin {
 			return Err(Error::Closed);
 		}
-		state.cache += frame.size;
+		state.cache += size;
 		state.frames.push_back(frame);
 		state.evict();
+		drop(state);
+
+		// Ingress: every frame written to the group bumps the producer sink.
+		self.broadcast.stats.producer.add_frame(size);
 		Ok(())
 	}
 
@@ -266,7 +276,8 @@ impl GroupProducer {
 		GroupConsumer {
 			info: self.info.clone(),
 			state: self.state.consume(),
-			timescale: self.timescale,
+			track: self.track.clone(),
+			broadcast: self.broadcast.clone(),
 			index: 0,
 		}
 	}
@@ -291,7 +302,8 @@ impl Clone for GroupProducer {
 		Self {
 			info: self.info.clone(),
 			state: self.state.clone(),
-			timescale: self.timescale,
+			track: self.track.clone(),
+			broadcast: self.broadcast.clone(),
 		}
 	}
 }
@@ -322,9 +334,14 @@ pub struct GroupConsumer {
 	// Immutable stream state.
 	info: Group,
 
-	// Parent track's negotiated timescale, copied from the producer. Lets the
-	// wire publisher decide whether to emit per-frame timestamps for a fetched group.
-	timescale: Option<Timescale>,
+	// Parent track's info, copied from the producer. Lets the wire publisher
+	// decide whether to emit per-frame timestamps for a fetched group.
+	track: Arc<TrackInfo>,
+
+	// The broadcast this group is delivered through. Each frame read bumps its
+	// egress usage sink. The owning `TrackSubscriber` stamps the consuming
+	// session's sink here before delivery.
+	broadcast: Arc<BroadcastInfo>,
 
 	// The number of frames we've read.
 	// NOTE: Cloned readers inherit this offset, but then run in parallel.
@@ -342,7 +359,18 @@ impl std::ops::Deref for GroupConsumer {
 impl GroupConsumer {
 	/// The parent track's negotiated timescale, or `None` for untimed tracks.
 	pub fn timescale(&self) -> Option<Timescale> {
-		self.timescale
+		self.track.timescale
+	}
+
+	/// Stamp the egress usage sink (and shared track info) onto this consumer, so
+	/// frames read from it are metered against the consuming session. Used by
+	/// [`crate::TrackSubscriber`] when delivering a group.
+	pub(crate) fn set_broadcast(&mut self, broadcast: Arc<BroadcastInfo>) {
+		self.broadcast = broadcast;
+	}
+
+	pub(crate) fn set_track(&mut self, track: Arc<TrackInfo>) {
+		self.track = track;
 	}
 
 	// A helper to automatically apply Dropped if the state is closed without an error.
@@ -385,6 +413,7 @@ impl GroupConsumer {
 		};
 
 		self.index += 1;
+		self.broadcast.stats.consumer.add_frame(frame.size);
 		Poll::Ready(Ok(Some(frame)))
 	}
 
@@ -394,9 +423,11 @@ impl GroupConsumer {
 			return Poll::Ready(Ok(None));
 		};
 
+		let size = frame.size;
 		let data = ready!(frame.poll_read_all(waiter))?;
 		self.index += 1;
 
+		self.broadcast.stats.consumer.add_frame(size);
 		Poll::Ready(Ok(Some(data)))
 	}
 
@@ -411,9 +442,11 @@ impl GroupConsumer {
 			return Poll::Ready(Ok(None));
 		};
 
+		let size = frame.size;
 		let data = ready!(frame.poll_read_all_chunks(waiter))?;
 		self.index += 1;
 
+		self.broadcast.stats.consumer.add_frame(size);
 		Poll::Ready(Ok(Some(data)))
 	}
 
@@ -697,7 +730,7 @@ mod test {
 	fn append_frame_rejects_timestamp_on_untimed_group() {
 		use crate::Timestamp;
 
-		let mut producer = GroupProducer::new(Group { sequence: 0 }, None);
+		let mut producer = GroupProducer::new(Group { sequence: 0 }, Arc::new(TrackInfo::default()), noop_broadcast());
 		let frame = Frame {
 			size: 3,
 			timestamp: Some(Timestamp::from_micros(42).unwrap()),
@@ -710,7 +743,11 @@ mod test {
 	fn append_frame_rejects_missing_timestamp_on_timed_group() {
 		use crate::Timescale;
 
-		let mut producer = GroupProducer::new(Group { sequence: 0 }, Some(Timescale::MICRO));
+		let mut producer = GroupProducer::new(
+			Group { sequence: 0 },
+			Arc::new(TrackInfo::default().with_timescale(Timescale::MICRO)),
+			noop_broadcast(),
+		);
 		let frame = Frame {
 			size: 3,
 			timestamp: None,
@@ -723,7 +760,11 @@ mod test {
 	fn append_frame_rejects_scale_mismatch() {
 		use crate::{Timescale, Timestamp};
 
-		let mut producer = GroupProducer::new(Group { sequence: 0 }, Some(Timescale::MICRO));
+		let mut producer = GroupProducer::new(
+			Group { sequence: 0 },
+			Arc::new(TrackInfo::default().with_timescale(Timescale::MICRO)),
+			noop_broadcast(),
+		);
 		let frame = Frame {
 			size: 3,
 			timestamp: Some(Timestamp::from_millis(1).unwrap()), // millis, not micros
@@ -736,7 +777,11 @@ mod test {
 	fn append_frame_accepts_matching_scale() {
 		use crate::{Timescale, Timestamp};
 
-		let mut producer = GroupProducer::new(Group { sequence: 0 }, Some(Timescale::MICRO));
+		let mut producer = GroupProducer::new(
+			Group { sequence: 0 },
+			Arc::new(TrackInfo::default().with_timescale(Timescale::MICRO)),
+			noop_broadcast(),
+		);
 		let frame = Frame {
 			size: 1,
 			timestamp: Some(Timestamp::from_micros(7).unwrap()),

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -13,7 +13,7 @@ use std::task::{Poll, ready};
 
 use bytes::Bytes;
 
-use crate::{Error, Result, Timescale};
+use crate::{Error, Result};
 
 #[cfg(test)]
 use super::broadcast::noop_broadcast;
@@ -185,11 +185,6 @@ impl GroupProducer {
 		}
 	}
 
-	/// The parent track's negotiated timescale, or `None` for untimed tracks.
-	pub fn timescale(&self) -> Option<Timescale> {
-		self.track.timescale
-	}
-
 	/// A helper method to write a frame from a single byte buffer.
 	///
 	/// If you want to write multiple chunks, use [Self::create_frame] to get a frame producer.
@@ -357,11 +352,6 @@ impl std::ops::Deref for GroupConsumer {
 }
 
 impl GroupConsumer {
-	/// The parent track's negotiated timescale, or `None` for untimed tracks.
-	pub fn timescale(&self) -> Option<Timescale> {
-		self.track.timescale
-	}
-
 	/// Stamp the egress usage sink (and shared track info) onto this consumer, so
 	/// frames read from it are metered against the consuming session. Used by
 	/// [`crate::TrackSubscriber`] when delivering a group.

--- a/rs/moq-net/src/model/mod.rs
+++ b/rs/moq-net/src/model/mod.rs
@@ -7,6 +7,7 @@ mod origin;
 mod subscription;
 mod time;
 mod track;
+mod usage;
 
 pub use bandwidth::*;
 pub use broadcast::*;
@@ -17,3 +18,4 @@ pub use origin::*;
 pub use subscription::*;
 pub use time::*;
 pub use track::*;
+pub use usage::*;

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1179,6 +1179,10 @@ impl BroadcastRequest {
 /// handler drops before serving it.
 pub struct BroadcastRequested {
 	inner: Requested,
+	// When set, stamp the resolved (dynamically served) consumer with this
+	// session's egress sink for the absolute path. The already-announced path
+	// (`Ready`) is stamped by `get_broadcast` instead.
+	stamp: Option<(EgressSink, PathOwned)>,
 }
 
 enum Requested {
@@ -1195,18 +1199,21 @@ impl BroadcastRequested {
 	fn ready(broadcast: BroadcastConsumer) -> Self {
 		Self {
 			inner: Requested::Ready(broadcast),
+			stamp: None,
 		}
 	}
 
 	fn failed(error: Error) -> Self {
 		Self {
 			inner: Requested::Failed(error),
+			stamp: None,
 		}
 	}
 
-	fn pending(consumer: kio::Consumer<PendingBroadcast>) -> Self {
+	fn pending(consumer: kio::Consumer<PendingBroadcast>, stamp: Option<(EgressSink, PathOwned)>) -> Self {
 		Self {
 			inner: Requested::Pending(consumer),
+			stamp,
 		}
 	}
 
@@ -1220,7 +1227,13 @@ impl BroadcastRequested {
 					Some(result) => Poll::Ready(result.clone()),
 					None => Poll::Pending,
 				})) {
-					Ok(result) => result,
+					Ok(Ok(mut broadcast)) => {
+						if let Some((egress, path)) = &self.stamp {
+							broadcast.set_consumer_sink(egress(path.as_str()));
+						}
+						Ok(broadcast)
+					}
+					Ok(Err(err)) => Err(err),
 					// Every handler dropped without resolving: nobody could route it.
 					Err(_closed) => Err(Error::Unroutable),
 				},
@@ -1298,6 +1311,15 @@ impl Consume<crate::TrackConsumer> for crate::TrackConsumer {
 /// Clones share the underlying tree state without allocating any per-cursor
 /// resources. To actually receive announce / unannounce events, call
 /// [`Self::announced`] to obtain an [`AnnounceConsumer`].
+/// Per-session egress sink provider.
+///
+/// Given a broadcast's absolute path, returns the [`crate::Usage`] sink that this
+/// session's downstream delivery should be metered against. Supplied by the relay
+/// when it scopes an origin per session; `None` means no metering (the consumer
+/// keeps its default no-op egress sink). Keeps the model independent of the stats
+/// layer, which is the only thing that knows about tiers.
+pub(crate) type EgressSink = std::sync::Arc<dyn Fn(&str) -> std::sync::Arc<crate::Usage> + Send + Sync>;
+
 #[derive(Clone)]
 pub struct OriginConsumer {
 	// Identity of the origin this consumer was derived from.
@@ -1310,6 +1332,10 @@ pub struct OriginConsumer {
 	// Shared fallback request queue, fed to any `OriginDynamic` handler on the
 	// producer side. Used only by `request_broadcast`; announced lookups ignore it.
 	dynamic: kio::Consumer<OriginDynamicState>,
+
+	// Per-session egress sink provider. When set, every `BroadcastConsumer` this
+	// handle yields is stamped with the session's egress sink for its path.
+	egress: Option<EgressSink>,
 }
 
 impl std::ops::Deref for OriginConsumer {
@@ -1327,7 +1353,25 @@ impl OriginConsumer {
 			nodes,
 			root,
 			dynamic,
+			egress: None,
 		}
+	}
+
+	/// Attach a per-session egress sink provider (see [`EgressSink`]).
+	///
+	/// Every `BroadcastConsumer` this handle (and the [`AnnounceConsumer`]s it
+	/// spawns) yields is stamped with the session's egress sink for its path, so
+	/// downstream delivery is metered without any per-handler setter.
+	pub(crate) fn with_egress(mut self, egress: EgressSink) -> Self {
+		self.egress = Some(egress);
+		self
+	}
+
+	/// The absolute egress sink for `path` (relative to this consumer's root), or
+	/// `None` when no provider is attached.
+	fn egress_sink(&self, path: &Path) -> Option<std::sync::Arc<crate::Usage>> {
+		let egress = self.egress.as_ref()?;
+		Some(egress(self.root.join(path).as_str()))
 	}
 
 	/// A view with this consumer's identity and root but no broadcasts:
@@ -1340,6 +1384,7 @@ impl OriginConsumer {
 			nodes: OriginNodes { nodes: Vec::new() },
 			root: self.root.clone(),
 			dynamic: self.dynamic.clone(),
+			egress: self.egress.clone(),
 		}
 	}
 
@@ -1350,7 +1395,7 @@ impl OriginConsumer {
 	/// set as initial announcements. Drop the returned [`AnnounceConsumer`]
 	/// to unregister.
 	pub fn announced(&self) -> AnnounceConsumer {
-		AnnounceConsumer::new(self.root.clone(), self.nodes.clone())
+		AnnounceConsumer::new(self.root.clone(), self.nodes.clone(), self.egress.clone())
 	}
 
 	/// Returns a cheap duplicate of this read handle.
@@ -1367,8 +1412,15 @@ impl OriginConsumer {
 	fn get_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
 		let path = path.as_path();
 		let (root, rest) = self.nodes.get(&path)?;
-		let state = root.lock();
-		state.consume_broadcast(&rest)
+		let mut broadcast = {
+			let state = root.lock();
+			state.consume_broadcast(&rest)?
+		};
+		// Stamp this session's egress sink so downstream delivery is metered.
+		if let Some(usage) = self.egress_sink(&path) {
+			broadcast.set_consumer_sink(usage);
+		}
+		Some(broadcast)
 	}
 
 	/// Block until a broadcast with the given path is announced and return it.
@@ -1414,12 +1466,14 @@ impl OriginConsumer {
 	// TODO accept PathPrefixes instead of &[Path]
 	pub fn scope(&self, prefixes: &[Path]) -> Option<OriginConsumer> {
 		let prefixes = PathPrefixes::new(prefixes);
-		Some(OriginConsumer::new(
+		let mut scoped = OriginConsumer::new(
 			self.info,
 			self.root.clone(),
 			self.nodes.select(&prefixes)?,
 			self.dynamic.clone(),
-		))
+		);
+		scoped.egress = self.egress.clone();
+		Some(scoped)
 	}
 
 	/// Get a broadcast by path, falling back to a dynamic request when it is not announced.
@@ -1465,11 +1519,13 @@ impl OriginConsumer {
 			let producer = kio::Producer::<PendingBroadcast>::default();
 			let consumer = producer.consume();
 			state.requests.insert(absolute.clone(), producer);
-			state.request_order.push_back(absolute);
+			state.request_order.push_back(absolute.clone());
 			consumer
 		};
 
-		kio::Pending::new(BroadcastRequested::pending(consumer))
+		// Stamp the served consumer with this session's egress sink when it resolves.
+		let stamp = self.egress.clone().map(|e| (e, absolute));
+		kio::Pending::new(BroadcastRequested::pending(consumer, stamp))
 	}
 
 	/// Returns a new OriginConsumer that automatically strips out the provided prefix.
@@ -1479,12 +1535,14 @@ impl OriginConsumer {
 	pub fn with_root(&self, prefix: impl AsPath) -> Option<Self> {
 		let prefix = prefix.as_path();
 
-		Some(Self::new(
+		let mut rooted = Self::new(
 			self.info,
 			self.root.join(&prefix).to_owned(),
 			self.nodes.root(&prefix)?,
 			self.dynamic.clone(),
-		))
+		);
+		rooted.egress = self.egress.clone();
+		Some(rooted)
 	}
 
 	/// Returns the prefix that is automatically stripped from all paths.
@@ -1525,7 +1583,7 @@ impl AnnounceProducer {
 	/// as initial announcements. Drop the returned [`AnnounceConsumer`] to
 	/// unregister.
 	pub fn consume(&self) -> AnnounceConsumer {
-		AnnounceConsumer::new(self.root.clone(), self.nodes.clone())
+		AnnounceConsumer::new(self.root.clone(), self.nodes.clone(), None)
 	}
 
 	/// Returns the prefix that is automatically stripped from announced paths.
@@ -1546,10 +1604,14 @@ pub struct AnnounceConsumer {
 	// Pending updates queued for this cursor. Coalesced so a slow consumer
 	// can't accumulate redundant announce/unannounce pairs.
 	state: kio::Producer<OriginConsumerState>,
+
+	// Per-session egress sink provider, inherited from the originating
+	// `OriginConsumer`. Stamps each delivered broadcast with this session's sink.
+	egress: Option<EgressSink>,
 }
 
 impl AnnounceConsumer {
-	fn new(root: PathOwned, nodes: OriginNodes) -> Self {
+	fn new(root: PathOwned, nodes: OriginNodes, egress: Option<EgressSink>) -> Self {
 		let state = kio::Producer::<OriginConsumerState>::default();
 		let id = ConsumerId::new();
 
@@ -1561,7 +1623,33 @@ impl AnnounceConsumer {
 			node.lock().consume(id, notify);
 		}
 
-		Self { id, nodes, root, state }
+		Self {
+			id,
+			nodes,
+			root,
+			state,
+			egress,
+		}
+	}
+
+	/// Stamp this session's egress sink onto a delivered broadcast. `path` is
+	/// relative to this cursor's root, so the absolute path is `root.join(path)`.
+	fn stamp(&self, path: &Path, announced: Announced) -> Announced {
+		let Some(egress) = &self.egress else {
+			return announced;
+		};
+		let usage = egress(self.root.join(path).as_str());
+		match announced {
+			Announced::Active(mut b) => {
+				b.set_consumer_sink(usage);
+				Announced::Active(b)
+			}
+			Announced::Restart(mut b) => {
+				b.set_consumer_sink(usage);
+				Announced::Restart(b)
+			}
+			Announced::Ended => Announced::Ended,
+		}
 	}
 
 	/// Returns the next (un)announced broadcast and its path relative to this
@@ -1591,7 +1679,10 @@ impl AnnounceConsumer {
 			// Closed: discard the Ref so its MutexGuard doesn't escape this call.
 			Err(_) => return Poll::Ready(None),
 		};
-		Poll::Ready(Some(state.take().expect("predicate guaranteed an update")))
+		let (path, announced) = state.take().expect("predicate guaranteed an update");
+		drop(state);
+		let announced = self.stamp(&path, announced);
+		Poll::Ready(Some((path, announced)))
 	}
 
 	/// Returns the next (un)announced broadcast without blocking.
@@ -1599,7 +1690,9 @@ impl AnnounceConsumer {
 	/// Returns None if there is no update available; NOT because the cursor is closed.
 	/// Use [`Self::is_closed`] to check if the cursor is closed.
 	pub fn try_next(&mut self) -> Option<OriginAnnounce> {
-		self.state.write().ok()?.take()
+		let (path, announced) = self.state.write().ok()?.take()?;
+		let announced = self.stamp(&path, announced);
+		Some((path, announced))
 	}
 
 	/// Returns true if the cursor is closed (no more updates will arrive).
@@ -1711,6 +1804,40 @@ mod tests {
 	use crate::BroadcastInfo;
 
 	use super::*;
+
+	/// A consumer scoped with `with_egress` stamps every broadcast it yields, so
+	/// downstream reads are metered against this session's egress sink even though
+	/// the producer baked only an ingress sink.
+	#[tokio::test]
+	async fn egress_sink_stamped_by_origin() {
+		use std::sync::Arc;
+
+		use crate::Usage;
+
+		let origin = Origin::random().produce();
+		let mut producer = BroadcastInfo::new().produce();
+		let mut track = producer.create_track("video", None).unwrap();
+		let _publish = origin.publish_broadcast("demo", &producer).unwrap();
+
+		let egress = Arc::new(Usage::default());
+		let sink = egress.clone();
+		let consumer = origin.consume().with_egress(Arc::new(move |_abs: &str| sink.clone()));
+
+		// Resolve the announced broadcast (stamped with this session's egress sink).
+		let bc = consumer.request_broadcast("demo").await.unwrap();
+
+		let mut group = track.append_group().unwrap();
+		group.write_frame(bytes::Bytes::from_static(b"hi")).unwrap();
+		group.finish().unwrap();
+
+		let mut sub = bc.track("video").unwrap().subscribe(None).await.unwrap();
+		let mut g = sub.next_group().await.unwrap().expect("group");
+		assert_eq!(g.read_frame().await.unwrap().unwrap(), bytes::Bytes::from_static(b"hi"));
+
+		assert_eq!(egress.groups(), 1);
+		assert_eq!(egress.frames(), 1);
+		assert_eq!(egress.bytes(), 2);
+	}
 
 	#[test]
 	fn origin_list_push_fails_at_limit() {

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1950,6 +1950,7 @@ mod tests {
 			BroadcastInfo {
 				hops,
 				epoch: BroadcastInfo::epoch_from_wire(0),
+				..Default::default()
 			}
 			.produce()
 		}

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1065,7 +1065,10 @@ impl TrackConsumer {
 	/// the cache. Use [`Self::fetch_group`] to wait for a group that a [`TrackDynamic`]
 	/// will serve on demand.
 	pub fn get_group(&self, sequence: u64) -> Option<GroupConsumer> {
-		self.state.read().cached_group(sequence)
+		let mut group = self.state.read().cached_group(sequence)?;
+		// Meter reads against this consumer's egress sink, not the producer's.
+		group.set_broadcast(self.broadcast.clone());
+		Some(group)
 	}
 
 	/// Fetch a single past group, without holding a live subscription.
@@ -1096,6 +1099,7 @@ impl TrackConsumer {
 		kio::Pending::new(TrackFetch {
 			state: self.state.clone(),
 			sequence,
+			broadcast: self.broadcast.clone(),
 		})
 	}
 
@@ -1230,6 +1234,9 @@ impl GroupRequest {
 pub struct TrackFetch {
 	state: kio::Consumer<TrackState>,
 	sequence: u64,
+	// Egress sink stamped onto the fetched group so its frames meter against the
+	// consuming session.
+	broadcast: Arc<BroadcastInfo>,
 }
 
 impl kio::Future for TrackFetch {
@@ -1240,7 +1247,11 @@ impl kio::Future for TrackFetch {
 		// abort); the outer error is the channel closing without one.
 		Poll::Ready(
 			match ready!(self.state.poll(waiter, |state| state.poll_fetch(self.sequence))) {
-				Ok(res) => res,
+				Ok(Ok(mut group)) => {
+					group.set_broadcast(self.broadcast.clone());
+					Ok(group)
+				}
+				Ok(Err(e)) => Err(e),
 				Err(closed) => Err(closed.abort.clone().unwrap_or(Error::Dropped)),
 			},
 		)

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -15,7 +15,7 @@
 
 use crate::{Error, Result, Subscription, Timescale, coding};
 
-use super::{Fetch, Group, GroupConsumer, GroupProducer};
+use super::{BroadcastInfo, Fetch, Group, GroupConsumer, GroupProducer, broadcast::noop_broadcast};
 
 use std::{
 	collections::{HashSet, VecDeque},
@@ -156,7 +156,13 @@ impl TrackInfo {
 #[derive(Default)]
 struct TrackState {
 	// The info for the track; always Some for TrackSubscriber/TrackProducer.
-	info: Option<TrackInfo>,
+	// Held as an `Arc` so each group can cheaply share it (for timescale etc.).
+	info: Option<Arc<TrackInfo>>,
+
+	// The broadcast this track belongs to, carrying the ingress usage sink that
+	// groups created here bump. Defaults to a shared no-op broadcast for a
+	// standalone track. The egress sink is supplied per-subscriber instead.
+	broadcast: Arc<BroadcastInfo>,
 
 	// Groups in arrival order. `None` entries are tombstones for evicted groups.
 	groups: VecDeque<Option<(GroupProducer, web_async::time::Instant)>>,
@@ -191,6 +197,16 @@ struct TrackState {
 
 impl TrackState {
 	fn poll_info(&self) -> Poll<Result<TrackInfo>> {
+		if let Some(info) = &self.info {
+			Poll::Ready(Ok((**info).clone()))
+		} else {
+			Poll::Pending
+		}
+	}
+
+	/// Like [`Self::poll_info`] but yields the shared `Arc<TrackInfo>` so a
+	/// subscriber can hand the same info to every group it delivers.
+	fn poll_info_arc(&self) -> Poll<Result<Arc<TrackInfo>>> {
 		if let Some(info) = &self.info {
 			Poll::Ready(Ok(info.clone()))
 		} else {
@@ -452,10 +468,12 @@ impl TrackState {
 		}
 
 		// Adopt the supplied info only if the track hasn't been accepted yet.
-		let info = self.info.get_or_insert_with(|| info.unwrap_or_default());
+		let info = self.info.get_or_insert_with(|| Arc::new(info.unwrap_or_default()));
 
-		let group = GroupProducer::new(Group { sequence }, info.timescale);
 		let cache = info.cache;
+		// A fetch re-serves an existing group, so it bumps frames/bytes (via the
+		// returned producer) but not `groups`.
+		let group = GroupProducer::new(Group { sequence }, info.clone(), self.broadcast.clone());
 		let now = web_async::time::Instant::now();
 		self.max_sequence = Some(self.max_sequence.unwrap_or(0).max(sequence));
 		self.groups.push_back(Some((group.clone(), now)));
@@ -470,19 +488,39 @@ pub struct TrackProducer {
 	name: Arc<str>,
 	state: kio::Producer<TrackState>,
 	prev_subscription: Option<Subscription>,
+
+	// The broadcast this track belongs to. Groups created here bump its ingress
+	// usage sink. A standalone track gets a shared no-op broadcast.
+	broadcast: Arc<BroadcastInfo>,
 }
 
 impl TrackProducer {
 	/// Build a producer for the given track metadata.
+	///
+	/// Standalone: the track belongs to no broadcast, so its usage goes to a
+	/// shared no-op sink. Use [`crate::BroadcastProducer::create_track`] to make a
+	/// track whose usage is metered against its broadcast.
 	pub fn new(name: impl Into<Arc<str>>, info: impl Into<Option<TrackInfo>>) -> Self {
+		Self::for_broadcast(name, info, noop_broadcast())
+	}
+
+	/// Build a producer for a track that belongs to `broadcast`, inheriting its
+	/// ingress usage sink.
+	pub(crate) fn for_broadcast(
+		name: impl Into<Arc<str>>,
+		info: impl Into<Option<TrackInfo>>,
+		broadcast: Arc<BroadcastInfo>,
+	) -> Self {
 		let info = info.into().unwrap_or_default();
 		Self {
 			name: name.into(),
 			state: kio::Producer::new(TrackState {
-				info: Some(info),
+				info: Some(Arc::new(info)),
+				broadcast: broadcast.clone(),
 				..Default::default()
 			}),
 			prev_subscription: None,
+			broadcast,
 		}
 	}
 
@@ -498,11 +536,10 @@ impl TrackProducer {
 		{
 			return Err(Error::Closed);
 		}
-		let info = state.info.as_ref().unwrap();
-		let timescale = info.timescale;
+		let info = state.info.clone().unwrap();
 		let cache = info.cache;
 
-		let group = GroupProducer::new(group, timescale);
+		let group = GroupProducer::new(group, info, self.broadcast.clone());
 		if !state.duplicates.insert(group.sequence) {
 			return Err(Error::Duplicate);
 		}
@@ -512,6 +549,7 @@ impl TrackProducer {
 		state.groups.push_back(Some((group.clone(), now)));
 		state.evict_expired(now, cache);
 
+		self.broadcast.stats.producer.add_group();
 		Ok(group)
 	}
 
@@ -528,11 +566,10 @@ impl TrackProducer {
 			return Err(Error::Closed);
 		}
 
-		let info = state.info.as_ref().unwrap();
-		let timescale = info.timescale;
+		let info = state.info.clone().unwrap();
 		let cache = info.cache;
 
-		let group = GroupProducer::new(Group { sequence }, timescale);
+		let group = GroupProducer::new(Group { sequence }, info, self.broadcast.clone());
 
 		let now = web_async::time::Instant::now();
 		state.duplicates.insert(sequence);
@@ -540,6 +577,7 @@ impl TrackProducer {
 		state.groups.push_back(Some((group.clone(), now)));
 		state.evict_expired(now, cache);
 
+		self.broadcast.stats.producer.add_group();
 		Ok(group)
 	}
 
@@ -667,6 +705,7 @@ impl TrackProducer {
 		TrackConsumer {
 			name: self.name.clone(),
 			state: self.state.consume(),
+			broadcast: self.broadcast.clone(),
 		}
 	}
 
@@ -694,6 +733,7 @@ impl TrackProducer {
 			min_sequence: 0,
 			next_sequence: 0,
 			end_sequence: None,
+			broadcast: self.broadcast.clone(),
 		}
 	}
 
@@ -904,9 +944,12 @@ impl TrackWeak {
 	}
 
 	pub fn consume(&self) -> TrackConsumer {
+		// The egress sink is supplied by the consuming `BroadcastConsumer`, which
+		// overrides this no-op default via `set_broadcast`.
 		TrackConsumer {
 			name: self.name.clone(),
 			state: self.state.consume(),
+			broadcast: noop_broadcast(),
 		}
 	}
 
@@ -970,6 +1013,10 @@ impl TrackDemand {
 pub struct TrackConsumer {
 	name: Arc<str>,
 	state: kio::Consumer<TrackState>,
+
+	// The broadcast this consumer reads through, carrying the egress usage sink
+	// that delivered groups/frames bump. Stamped by the owning `BroadcastConsumer`.
+	broadcast: Arc<BroadcastInfo>,
 }
 
 impl TrackConsumer {
@@ -983,6 +1030,13 @@ impl TrackConsumer {
 			name: self.name.clone(),
 			state: self.state.weak(),
 		}
+	}
+
+	/// Stamp the egress usage sink onto this consumer, used by
+	/// [`crate::BroadcastConsumer::track`] so a delivered group/frame is metered
+	/// against the consuming session rather than the publisher.
+	pub(crate) fn set_broadcast(&mut self, broadcast: Arc<BroadcastInfo>) {
+		self.broadcast = broadcast;
 	}
 
 	/// Open a live subscription.
@@ -1003,6 +1057,7 @@ impl TrackConsumer {
 			name: self.name.clone(),
 			state: self.state.clone(),
 			subscription,
+			broadcast: self.broadcast.clone(),
 		})
 	}
 
@@ -1057,12 +1112,13 @@ pub struct TrackSubscribe {
 	name: Arc<str>,
 	state: kio::Consumer<TrackState>,
 	subscription: kio::Producer<Subscription>,
+	broadcast: Arc<BroadcastInfo>,
 }
 
 impl TrackSubscribe {
 	pub fn poll_ok(&self, waiter: &kio::Waiter) -> Poll<Result<TrackSubscriber>> {
 		// Wait until the track info is available
-		let info = ready!(self.state.poll(waiter, |state| state.poll_info()))
+		let info = ready!(self.state.poll(waiter, |state| state.poll_info_arc()))
 			.map_err(|e| e.abort.clone().unwrap_or(Error::Dropped))??;
 
 		Poll::Ready(Ok(TrackSubscriber {
@@ -1074,6 +1130,7 @@ impl TrackSubscribe {
 			min_sequence: 0,
 			next_sequence: 0,
 			end_sequence: None,
+			broadcast: self.broadcast.clone(),
 		}))
 	}
 
@@ -1197,8 +1254,12 @@ impl kio::Future for TrackFetch {
 /// subscriber's [`Subscription`] preferences, which feed the producer's aggregate.
 pub struct TrackSubscriber {
 	name: Arc<str>,
-	info: TrackInfo,
+	info: Arc<TrackInfo>,
 	state: kio::Consumer<TrackState>,
+
+	// The broadcast this subscriber reads through, carrying the egress usage
+	// sink. Stamped onto each delivered group so its frames bump the same sink.
+	broadcast: Arc<BroadcastInfo>,
 
 	subscription: kio::Producer<Subscription>,
 	/// Arrival-order cursor used by [`Self::recv_group`].
@@ -1254,7 +1315,17 @@ impl TrackSubscriber {
 		};
 
 		self.index = found_index + 1;
-		Poll::Ready(Ok(Some(consumer)))
+		Poll::Ready(Ok(Some(self.deliver(consumer))))
+	}
+
+	/// Stamp the egress usage sink and shared track info onto a delivered group,
+	/// and record the group against egress. Each group a subscriber receives
+	/// counts once; its frames are counted as the consumer reads them.
+	fn deliver(&self, mut group: GroupConsumer) -> GroupConsumer {
+		group.set_broadcast(self.broadcast.clone());
+		group.set_track(self.info.clone());
+		self.broadcast.stats.consumer.add_group();
+		group
 	}
 
 	/// Receive the next group in arrival order.
@@ -1280,7 +1351,7 @@ impl TrackSubscriber {
 			return Poll::Ready(Ok(None));
 		};
 		self.next_sequence = group.sequence.saturating_add(1);
-		Poll::Ready(Ok(Some(group)))
+		Poll::Ready(Ok(Some(self.deliver(group))))
 	}
 
 	/// Return the next group with a higher sequence number than any previously returned.
@@ -1305,6 +1376,9 @@ impl TrackSubscriber {
 
 		self.index = found_index + 1;
 		self.next_sequence = sequence.saturating_add(1);
+		// Egress dual of the producer's per-frame bump; the group path counts the
+		// group, this helper counts the single frame it reads.
+		self.broadcast.stats.consumer.add_frame(frame.len() as u64);
 		Poll::Ready(Ok(Some(frame)))
 	}
 
@@ -1407,18 +1481,32 @@ pub struct TrackRequest {
 	// racing the producer (e.g. a relay) into creating its own handler. Released
 	// when the request is accepted or dropped; by then the relay holds its own.
 	_dynamic: TrackDynamic,
+
+	// The broadcast this request belongs to. Threaded to the accepted
+	// `TrackProducer` (ingress sink) and to consumers it hands out.
+	broadcast: Arc<BroadcastInfo>,
 }
 
 impl TrackRequest {
 	pub fn new(name: impl Into<Arc<str>>) -> Self {
+		Self::for_broadcast(name, noop_broadcast())
+	}
+
+	/// Build a request for a track that belongs to `broadcast`, inheriting its
+	/// usage sinks.
+	pub(crate) fn for_broadcast(name: impl Into<Arc<str>>, broadcast: Arc<BroadcastInfo>) -> Self {
 		let name = name.into();
-		let state = kio::Producer::<TrackState>::default();
+		let state = kio::Producer::new(TrackState {
+			broadcast: broadcast.clone(),
+			..Default::default()
+		});
 		let dynamic = TrackDynamic::new(name.clone(), state.clone());
 		Self {
 			name,
 			state,
 			prev_subscription: None,
 			_dynamic: dynamic,
+			broadcast,
 		}
 	}
 
@@ -1431,6 +1519,7 @@ impl TrackRequest {
 		TrackConsumer {
 			name: self.name.clone(),
 			state: self.state.consume(),
+			broadcast: self.broadcast.clone(),
 		}
 	}
 
@@ -1452,11 +1541,12 @@ impl TrackRequest {
 	/// The track's name must match [`Self::name`]. Returns [`Error::NotFound`] on
 	/// mismatch, or the broadcast's abort error if it closed while pending.
 	pub fn accept(self, info: impl Into<Option<TrackInfo>>) -> TrackProducer {
-		self.state.write().ok().unwrap().info = Some(info.into().unwrap_or_default());
+		self.state.write().ok().unwrap().info = Some(Arc::new(info.into().unwrap_or_default()));
 		TrackProducer {
 			name: self.name,
 			state: self.state,
 			prev_subscription: None,
+			broadcast: self.broadcast,
 		}
 	}
 

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -15,7 +15,7 @@
 
 use crate::{Error, Result, Subscription, Timescale, coding};
 
-use super::{BroadcastInfo, Fetch, Group, GroupConsumer, GroupProducer, broadcast::noop_broadcast};
+use super::{BroadcastInfo, Fetch, Group, GroupConsumer, GroupProducer, broadcast::noop_broadcast, usage::LiveToken};
 
 use std::{
 	collections::{HashSet, VecDeque},
@@ -492,6 +492,10 @@ pub struct TrackProducer {
 	// The broadcast this track belongs to. Groups created here bump its ingress
 	// usage sink. A standalone track gets a shared no-op broadcast.
 	broadcast: Arc<BroadcastInfo>,
+
+	// Live-publisher token: holding it (or any clone) keeps the broadcast's
+	// publisher count at >= 1. `None` for a standalone track.
+	_publisher: Option<LiveToken>,
 }
 
 impl TrackProducer {
@@ -501,15 +505,17 @@ impl TrackProducer {
 	/// shared no-op sink. Use [`crate::BroadcastProducer::create_track`] to make a
 	/// track whose usage is metered against its broadcast.
 	pub fn new(name: impl Into<Arc<str>>, info: impl Into<Option<TrackInfo>>) -> Self {
-		Self::for_broadcast(name, info, noop_broadcast())
+		Self::for_broadcast(name, info, noop_broadcast(), None)
 	}
 
 	/// Build a producer for a track that belongs to `broadcast`, inheriting its
-	/// ingress usage sink.
+	/// ingress usage sink. `publisher` counts the track toward the broadcast's
+	/// live-publisher count.
 	pub(crate) fn for_broadcast(
 		name: impl Into<Arc<str>>,
 		info: impl Into<Option<TrackInfo>>,
 		broadcast: Arc<BroadcastInfo>,
+		publisher: Option<LiveToken>,
 	) -> Self {
 		let info = info.into().unwrap_or_default();
 		Self {
@@ -521,6 +527,7 @@ impl TrackProducer {
 			}),
 			prev_subscription: None,
 			broadcast,
+			_publisher: publisher,
 		}
 	}
 
@@ -706,6 +713,7 @@ impl TrackProducer {
 			name: self.name.clone(),
 			state: self.state.consume(),
 			broadcast: self.broadcast.clone(),
+			_viewer: None,
 		}
 	}
 
@@ -734,6 +742,8 @@ impl TrackProducer {
 			next_sequence: 0,
 			end_sequence: None,
 			broadcast: self.broadcast.clone(),
+			// In-process producer subscription: not an external viewer.
+			_viewer: None,
 		}
 	}
 
@@ -944,12 +954,13 @@ impl TrackWeak {
 	}
 
 	pub fn consume(&self) -> TrackConsumer {
-		// The egress sink is supplied by the consuming `BroadcastConsumer`, which
-		// overrides this no-op default via `set_broadcast`.
+		// The egress sink and viewer token are supplied by the consuming
+		// `BroadcastConsumer` via `set_broadcast` / `set_viewer`.
 		TrackConsumer {
 			name: self.name.clone(),
 			state: self.state.consume(),
 			broadcast: noop_broadcast(),
+			_viewer: None,
 		}
 	}
 
@@ -1017,6 +1028,11 @@ pub struct TrackConsumer {
 	// The broadcast this consumer reads through, carrying the egress usage sink
 	// that delivered groups/frames bump. Stamped by the owning `BroadcastConsumer`.
 	broadcast: Arc<BroadcastInfo>,
+
+	// Live-viewer token, set by `BroadcastConsumer::track`. Holding it (or any
+	// clone) keeps the broadcast's viewer count at >= 1; dropping the last one
+	// records the viewer as gone. `None` for standalone/internal track handles.
+	_viewer: Option<LiveToken>,
 }
 
 impl TrackConsumer {
@@ -1039,6 +1055,11 @@ impl TrackConsumer {
 		self.broadcast = broadcast;
 	}
 
+	/// Attach the live-viewer token (see [`crate::BroadcastConsumer::track`]).
+	pub(crate) fn set_viewer(&mut self, token: LiveToken) {
+		self._viewer = Some(token);
+	}
+
 	/// Open a live subscription.
 	///
 	/// Registers the subscription on the track and returns a [`kio::Pending`] that resolves to the
@@ -1058,6 +1079,9 @@ impl TrackConsumer {
 			state: self.state.clone(),
 			subscription,
 			broadcast: self.broadcast.clone(),
+			// Keep this consumer counted as a viewer for the subscription's
+			// lifetime, even after the `TrackConsumer` handle is dropped.
+			viewer: self._viewer.clone(),
 		})
 	}
 
@@ -1117,6 +1141,7 @@ pub struct TrackSubscribe {
 	state: kio::Consumer<TrackState>,
 	subscription: kio::Producer<Subscription>,
 	broadcast: Arc<BroadcastInfo>,
+	viewer: Option<LiveToken>,
 }
 
 impl TrackSubscribe {
@@ -1135,6 +1160,7 @@ impl TrackSubscribe {
 			next_sequence: 0,
 			end_sequence: None,
 			broadcast: self.broadcast.clone(),
+			_viewer: self.viewer.clone(),
 		}))
 	}
 
@@ -1271,6 +1297,10 @@ pub struct TrackSubscriber {
 	// The broadcast this subscriber reads through, carrying the egress usage
 	// sink. Stamped onto each delivered group so its frames bump the same sink.
 	broadcast: Arc<BroadcastInfo>,
+
+	// Live-viewer token held for the subscription's lifetime (see
+	// `BroadcastConsumer::track`). `None` for an in-process `TrackProducer::subscribe`.
+	_viewer: Option<LiveToken>,
 
 	subscription: kio::Producer<Subscription>,
 	/// Arrival-order cursor used by [`Self::recv_group`].
@@ -1496,6 +1526,10 @@ pub struct TrackRequest {
 	// The broadcast this request belongs to. Threaded to the accepted
 	// `TrackProducer` (ingress sink) and to consumers it hands out.
 	broadcast: Arc<BroadcastInfo>,
+
+	// Live-publisher token, set when the request is reserved or served. Moved to
+	// the `TrackProducer` on accept so the broadcast counts as a live publisher.
+	publisher: Option<LiveToken>,
 }
 
 impl TrackRequest {
@@ -1518,7 +1552,13 @@ impl TrackRequest {
 			prev_subscription: None,
 			_dynamic: dynamic,
 			broadcast,
+			publisher: None,
 		}
+	}
+
+	/// Count the served track toward the broadcast's live-publisher count.
+	pub(crate) fn set_publisher(&mut self, token: LiveToken) {
+		self.publisher = Some(token);
 	}
 
 	/// The requested track name.
@@ -1531,6 +1571,7 @@ impl TrackRequest {
 			name: self.name.clone(),
 			state: self.state.consume(),
 			broadcast: self.broadcast.clone(),
+			_viewer: None,
 		}
 	}
 
@@ -1558,6 +1599,7 @@ impl TrackRequest {
 			state: self.state,
 			prev_subscription: None,
 			broadcast: self.broadcast,
+			_publisher: self.publisher,
 		}
 	}
 

--- a/rs/moq-net/src/model/usage.rs
+++ b/rs/moq-net/src/model/usage.rs
@@ -1,0 +1,100 @@
+//! Per-broadcast usage counters carried by [`crate::BroadcastInfo`].
+//!
+//! [`Usage`] is a set of atomics, so the model bumps it through a shared
+//! `&Arc<Usage>` with no mutation: there is no setter and no `Arc::make_mut`.
+//! Each broadcast carries a [`BroadcastStats`] pair (one [`Usage`] per
+//! direction) in its immutable [`crate::BroadcastInfo`], which flows down to
+//! every track, group, and frame. A producer-side handle bumps the ingress
+//! ([`BroadcastStats::producer`]) counter; a consumer-side handle bumps the
+//! egress ([`BroadcastStats::consumer`]) one.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Cumulative usage counters for one direction of a broadcast.
+///
+/// `groups` / `frames` / `bytes` are payload counters bumped as media flows;
+/// `opened` / `closed` are lifecycle counters bumped as handles open and close,
+/// so `opened - closed` is the number of live handles. Every counter is strictly
+/// monotonic (only `fetch_add`). A reader pairs an `Acquire` load of `closed`
+/// with the matching `Release` bump so a snapshot never observes `closed > opened`.
+#[derive(Debug, Default)]
+pub struct Usage {
+	groups: AtomicU64,
+	frames: AtomicU64,
+	bytes: AtomicU64,
+	opened: AtomicU64,
+	closed: AtomicU64,
+}
+
+impl Usage {
+	/// Record one group.
+	pub(crate) fn add_group(&self) {
+		self.groups.fetch_add(1, Ordering::Relaxed);
+	}
+
+	/// Record one frame of `bytes` bytes.
+	pub(crate) fn add_frame(&self, bytes: u64) {
+		self.frames.fetch_add(1, Ordering::Relaxed);
+		self.bytes.fetch_add(bytes, Ordering::Relaxed);
+	}
+
+	/// Record a handle opening (the live count goes up by one).
+	// Wired by the model's live viewer/publisher counting (a later phase).
+	#[allow(dead_code)]
+	pub(crate) fn open(&self) {
+		self.opened.fetch_add(1, Ordering::Relaxed);
+	}
+
+	/// Record a handle closing (the live count goes down by one).
+	///
+	/// `Release` so the matching `Acquire` load of `closed` in [`Self::closed`]
+	/// transitively publishes the earlier `open` bump to the reader.
+	#[allow(dead_code)]
+	pub(crate) fn close(&self) {
+		self.closed.fetch_add(1, Ordering::Release);
+	}
+
+	/// Cumulative number of groups recorded.
+	pub fn groups(&self) -> u64 {
+		self.groups.load(Ordering::Relaxed)
+	}
+
+	/// Cumulative number of frames recorded.
+	pub fn frames(&self) -> u64 {
+		self.frames.load(Ordering::Relaxed)
+	}
+
+	/// Cumulative number of payload bytes recorded.
+	pub fn bytes(&self) -> u64 {
+		self.bytes.load(Ordering::Relaxed)
+	}
+
+	/// Cumulative number of handles opened.
+	///
+	/// Load `closed` (with [`Self::closed`]) before `opened` so the readout
+	/// always satisfies `opened >= closed`.
+	pub fn opened(&self) -> u64 {
+		self.opened.load(Ordering::Relaxed)
+	}
+
+	/// Cumulative number of handles closed. Loaded with `Acquire`; see [`Self::close`].
+	pub fn closed(&self) -> u64 {
+		self.closed.load(Ordering::Acquire)
+	}
+}
+
+/// Usage sinks for a broadcast, one [`Usage`] per direction.
+///
+/// Lives in [`crate::BroadcastInfo`] so the immutable broadcast handle carries
+/// the counters down to every track, group, and frame. Cloning shares the same
+/// atomics (it is an `Arc` pair), so the model can bump through any clone. The
+/// default is a pair of fresh, unreferenced sinks: bumps are recorded but
+/// nothing reads them, so a standalone broadcast is effectively unmetered.
+#[derive(Clone, Debug, Default)]
+pub struct BroadcastStats {
+	/// Ingress sink, bumped by producer-side handles as media is published.
+	pub producer: Arc<Usage>,
+	/// Egress sink, bumped by consumer-side handles as media is delivered.
+	pub consumer: Arc<Usage>,
+}

--- a/rs/moq-net/src/model/usage.rs
+++ b/rs/moq-net/src/model/usage.rs
@@ -78,7 +78,8 @@ impl Usage {
 		self.opened.load(Ordering::Relaxed)
 	}
 
-	/// Cumulative number of handles closed. Loaded with `Acquire`; see [`Self::close`].
+	/// Cumulative number of handles closed. Loaded with `Acquire` so it pairs
+	/// with the `Release` store on close.
 	pub fn closed(&self) -> u64 {
 		self.closed.load(Ordering::Acquire)
 	}

--- a/rs/moq-net/src/model/usage.rs
+++ b/rs/moq-net/src/model/usage.rs
@@ -9,7 +9,7 @@
 //! egress ([`BroadcastStats::consumer`]) one.
 
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 /// Cumulative usage counters for one direction of a broadcast.
 ///
@@ -40,8 +40,6 @@ impl Usage {
 	}
 
 	/// Record a handle opening (the live count goes up by one).
-	// Wired by the model's live viewer/publisher counting (a later phase).
-	#[allow(dead_code)]
 	pub(crate) fn open(&self) {
 		self.opened.fetch_add(1, Ordering::Relaxed);
 	}
@@ -50,7 +48,6 @@ impl Usage {
 	///
 	/// `Release` so the matching `Acquire` load of `closed` in [`Self::closed`]
 	/// transitively publishes the earlier `open` bump to the reader.
-	#[allow(dead_code)]
 	pub(crate) fn close(&self) {
 		self.closed.fetch_add(1, Ordering::Release);
 	}
@@ -82,6 +79,67 @@ impl Usage {
 	/// with the `Release` store on close.
 	pub fn closed(&self) -> u64 {
 		self.closed.load(Ordering::Acquire)
+	}
+}
+
+/// Liveness refcount for a broadcast handle (viewers on the consumer side,
+/// publishers on the producer side).
+///
+/// While at least one [`LiveToken`] is outstanding the handle counts as one live
+/// viewer/publisher: the `0 -> 1` transition bumps [`Usage::open`] and the last
+/// `1 -> 0` drop bumps [`Usage::close`], so `opened - closed` is the live count.
+/// Clones of a handle share one `Live`, so they are a single logical
+/// viewer/publisher.
+#[derive(Debug)]
+pub(crate) struct Live {
+	usage: Arc<Usage>,
+	count: AtomicUsize,
+}
+
+impl Default for Live {
+	/// A no-op refcount over an unreferenced sink, for default-constructed state
+	/// that is overwritten with a real sink before use.
+	fn default() -> Self {
+		Self {
+			usage: Arc::default(),
+			count: AtomicUsize::new(0),
+		}
+	}
+}
+
+impl Live {
+	/// Create a refcount that bumps `usage`'s lifecycle counters.
+	pub(crate) fn new(usage: Arc<Usage>) -> Arc<Self> {
+		Arc::new(Self {
+			usage,
+			count: AtomicUsize::new(0),
+		})
+	}
+
+	/// Take a token, bumping `opened` on the `0 -> 1` transition.
+	pub(crate) fn enter(self: &Arc<Self>) -> LiveToken {
+		if self.count.fetch_add(1, Ordering::AcqRel) == 0 {
+			self.usage.open();
+		}
+		LiveToken(self.clone())
+	}
+}
+
+/// RAII guard from [`Live::enter`]. The last token to drop bumps `close`.
+#[derive(Debug)]
+pub(crate) struct LiveToken(Arc<Live>);
+
+impl Clone for LiveToken {
+	fn clone(&self) -> Self {
+		self.0.enter()
+	}
+}
+
+impl Drop for LiveToken {
+	fn drop(&mut self) {
+		if self.0.count.fetch_sub(1, Ordering::AcqRel) == 1 {
+			self.0.usage.close();
+		}
 	}
 }
 

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -129,17 +129,17 @@ use std::{
 use serde::Serialize;
 use web_async::{Lock, spawn};
 
-use crate::{AsPath, BroadcastInfo, OriginProducer, Path, PathOwned, TrackProducer};
+use crate::{AsPath, BroadcastInfo, OriginProducer, Path, PathOwned, TrackProducer, Usage};
 
 /// Cumulative atomic counters for a single `(tier, role)` on a broadcast.
 ///
-/// Every field is bumped from a RAII guard: the open counters on construction
-/// and their `_closed` counterparts on drop. `broadcasts` / `broadcasts_closed`
-/// are the per-(broadcast, session) subscription sentinel driven by
-/// [`SessionBroadcasts`] (the first active subscription a session opens for the
-/// broadcast bumps `broadcasts`, the last to close bumps `broadcasts_closed`),
-/// so summed across sessions `broadcasts - broadcasts_closed` is the count of
-/// distinct sessions currently subscribed.
+/// `announced` / `subscriptions` / `broadcasts` (and their `_closed`
+/// counterparts) are bumped from RAII guards: the open counters on construction
+/// and their `_closed` counterparts on drop. The payload counters
+/// (groups/frames/bytes) live in [`Usage`], bumped by the model through the sink
+/// baked into the broadcast (ingress) or stamped onto the consumer (egress); the
+/// snapshot reads them back. `broadcasts` / `broadcasts_closed` are the
+/// per-(broadcast, session) subscription sentinel driven by [`SessionBroadcasts`].
 #[derive(Default, Debug)]
 #[non_exhaustive]
 pub struct Counters {
@@ -149,9 +149,10 @@ pub struct Counters {
 	pub subscriptions_closed: AtomicU64,
 	pub broadcasts: AtomicU64,
 	pub broadcasts_closed: AtomicU64,
-	pub bytes: AtomicU64,
-	pub frames: AtomicU64,
-	pub groups: AtomicU64,
+	/// Payload usage (groups/frames/bytes) for this `(tier, role)`, shared with
+	/// the model: the same `Arc` is baked into the broadcast so the model's bumps
+	/// land here. The snapshot reads it back.
+	pub usage: Arc<Usage>,
 }
 
 impl Counters {
@@ -169,9 +170,9 @@ impl Counters {
 		let announced = self.announced.load(Ordering::Relaxed);
 		let subscriptions = self.subscriptions.load(Ordering::Relaxed);
 		let broadcasts = self.broadcasts.load(Ordering::Relaxed);
-		let bytes = self.bytes.load(Ordering::Relaxed);
-		let frames = self.frames.load(Ordering::Relaxed);
-		let groups = self.groups.load(Ordering::Relaxed);
+		let bytes = self.usage.bytes();
+		let frames = self.usage.frames();
+		let groups = self.usage.groups();
 		RawCounts {
 			announced,
 			announced_closed,
@@ -657,6 +658,30 @@ impl BroadcastHandle {
 			tier: self.tier,
 		}
 	}
+
+	/// The ingress (subscriber-role) payload sink for this tier.
+	///
+	/// Bake it into a [`BroadcastInfo::stats`]`.producer` at construction so the
+	/// model meters everything the publisher writes. An empty handle yields a fresh
+	/// unreferenced sink, so the bumps are dropped.
+	pub fn ingress_usage(&self) -> Arc<Usage> {
+		self.entry
+			.as_ref()
+			.map(|e| e.subscriber[self.tier.idx()].usage.clone())
+			.unwrap_or_default()
+	}
+
+	/// The egress (publisher-role) payload sink for this tier.
+	///
+	/// Stamp it onto a [`crate::BroadcastConsumer`]'s `stats.consumer` (the origin
+	/// does this per session) so the model meters everything delivered downstream.
+	/// An empty handle yields a fresh unreferenced sink.
+	pub fn egress_usage(&self) -> Arc<Usage> {
+		self.entry
+			.as_ref()
+			.map(|e| e.publisher[self.tier.idx()].usage.clone())
+			.unwrap_or_default()
+	}
 }
 
 /// Which side of a [`BroadcastEntry`] a [`SessionBroadcasts`] bumps.
@@ -870,33 +895,13 @@ impl Drop for SubscriberStats {
 }
 
 /// RAII subscription guard for the publisher role.
+///
+/// Tracks only the `subscriptions` lifecycle; payload is metered by the model
+/// through the broadcast's egress sink, not this guard.
 #[must_use = "drop the guard to record the subscription as closed"]
 pub struct PublisherTrack {
 	entry: Option<Arc<BroadcastEntry>>,
 	tier: Tier,
-}
-
-impl PublisherTrack {
-	/// Bumps `frames` once.
-	pub fn frame(&self) {
-		if let Some(entry) = &self.entry {
-			entry.publisher[self.tier.idx()].frames.fetch_add(1, Ordering::Relaxed);
-		}
-	}
-
-	/// Bumps `bytes` by `n`.
-	pub fn bytes(&self, n: u64) {
-		if let Some(entry) = &self.entry {
-			entry.publisher[self.tier.idx()].bytes.fetch_add(n, Ordering::Relaxed);
-		}
-	}
-
-	/// Bumps `groups` once.
-	pub fn group(&self) {
-		if let Some(entry) = &self.entry {
-			entry.publisher[self.tier.idx()].groups.fetch_add(1, Ordering::Relaxed);
-		}
-	}
 }
 
 impl Drop for PublisherTrack {
@@ -911,33 +916,13 @@ impl Drop for PublisherTrack {
 }
 
 /// RAII subscription guard for the subscriber role.
+///
+/// Tracks only the `subscriptions` lifecycle; payload is metered by the model
+/// through the broadcast's ingress sink, not this guard.
 #[must_use = "drop the guard to record the subscription as closed"]
 pub struct SubscriberTrack {
 	entry: Option<Arc<BroadcastEntry>>,
 	tier: Tier,
-}
-
-impl SubscriberTrack {
-	/// Bumps `frames` once.
-	pub fn frame(&self) {
-		if let Some(entry) = &self.entry {
-			entry.subscriber[self.tier.idx()].frames.fetch_add(1, Ordering::Relaxed);
-		}
-	}
-
-	/// Bumps `bytes` by `n`.
-	pub fn bytes(&self, n: u64) {
-		if let Some(entry) = &self.entry {
-			entry.subscriber[self.tier.idx()].bytes.fetch_add(n, Ordering::Relaxed);
-		}
-	}
-
-	/// Bumps `groups` once.
-	pub fn group(&self) {
-		if let Some(entry) = &self.entry {
-			entry.subscriber[self.tier.idx()].groups.fetch_add(1, Ordering::Relaxed);
-		}
-	}
 }
 
 impl Drop for SubscriberTrack {
@@ -1221,7 +1206,7 @@ fn advertised_path(prefix: &Path, node: Option<&str>) -> PathOwned {
 
 #[cfg(test)]
 mod tests {
-	use std::{collections::BTreeMap, sync::atomic::Ordering::Relaxed};
+	use std::collections::BTreeMap;
 
 	use crate::{Origin, Path};
 
@@ -1276,16 +1261,15 @@ mod tests {
 		let (stats, _origin) = test_stats(Some("sjc"));
 		let bs1 = stats.tier(Tier::External).broadcast("demo/bbb");
 		let bs2 = stats.tier(Tier::External).broadcast("demo/ccc");
-		let g1 = bs1.publisher().track("video");
-		g1.bytes(100);
-		let g2 = bs2.publisher().track("video");
-		g2.bytes(7);
+		// Bump the egress payload sink the way the model would.
+		bs1.egress_usage().add_frame(100);
+		bs2.egress_usage().add_frame(7);
 
 		let entries = stats.shared().entries.lock();
 		let e1 = entries.get(&PathOwned::from("demo/bbb")).expect("entry");
 		let e2 = entries.get(&PathOwned::from("demo/ccc")).expect("entry");
-		assert_eq!(e1.publisher[Tier::External.idx()].bytes.load(Relaxed), 100);
-		assert_eq!(e2.publisher[Tier::External.idx()].bytes.load(Relaxed), 7);
+		assert_eq!(e1.publisher[Tier::External.idx()].usage.bytes(), 100);
+		assert_eq!(e2.publisher[Tier::External.idx()].usage.bytes(), 7);
 	}
 
 	#[tokio::test(start_paused = true)]
@@ -1294,17 +1278,16 @@ mod tests {
 		let ext = stats.tier(Tier::External);
 		let int = stats.tier(Tier::Internal);
 
-		let ext_track = ext.broadcast("demo/bbb").publisher().track("video");
-		ext_track.bytes(100);
-		let int_track = int.broadcast("demo/bbb").subscriber().track("audio");
-		int_track.bytes(7);
+		// External egress and internal ingress: distinct (tier, role) sinks.
+		ext.broadcast("demo/bbb").egress_usage().add_frame(100);
+		int.broadcast("demo/bbb").ingress_usage().add_frame(7);
 
 		let entries = stats.shared().entries.lock();
 		let entry = entries.get(&PathOwned::from("demo/bbb")).expect("entry");
-		assert_eq!(entry.publisher[Tier::External.idx()].bytes.load(Relaxed), 100);
-		assert_eq!(entry.subscriber[Tier::External.idx()].bytes.load(Relaxed), 0);
-		assert_eq!(entry.publisher[Tier::Internal.idx()].bytes.load(Relaxed), 0);
-		assert_eq!(entry.subscriber[Tier::Internal.idx()].bytes.load(Relaxed), 7);
+		assert_eq!(entry.publisher[Tier::External.idx()].usage.bytes(), 100);
+		assert_eq!(entry.subscriber[Tier::External.idx()].usage.bytes(), 0);
+		assert_eq!(entry.publisher[Tier::Internal.idx()].usage.bytes(), 0);
+		assert_eq!(entry.subscriber[Tier::Internal.idx()].usage.bytes(), 7);
 	}
 
 	#[tokio::test(start_paused = true)]
@@ -1315,9 +1298,7 @@ mod tests {
 		let bs = stats.tier(Tier::External).broadcast(".stats/node/sjc");
 		assert!(bs.is_empty());
 		let p = bs.publisher();
-		let track = p.track("video");
-		track.bytes(100);
-		drop(track);
+		bs.egress_usage().add_frame(100);
 		drop(p);
 		assert!(stats.shared().entries.lock().is_empty());
 	}
@@ -1331,9 +1312,7 @@ mod tests {
 		let bs = stats.tier(Tier::External).broadcast("demo/bbb");
 		assert!(bs.is_empty());
 		let p = bs.publisher();
-		let track = p.track("video");
-		track.bytes(100);
-		drop(track);
+		bs.egress_usage().add_frame(100);
 		drop(p);
 	}
 
@@ -1442,9 +1421,8 @@ mod tests {
 		let (stats, origin) = test_stats(Some("sjc"));
 		let mut consumer = origin.consume().announced();
 		let bs = stats.tier(Tier::External).broadcast("foo/bar");
-		let track = bs.publisher().track("video");
-		track.bytes(42);
-		track.frame();
+		let _track = bs.publisher().track("video");
+		bs.egress_usage().add_frame(42);
 		let sessions = stats.tier(Tier::External).publisher_broadcasts();
 		let _sub = sessions.subscribe("foo/bar");
 
@@ -1505,9 +1483,8 @@ mod tests {
 		let bs = stats.tier(Tier::External).broadcast("foo/bar");
 		let sessions = stats.tier(Tier::External).publisher_broadcasts();
 		{
-			let track = bs.publisher().track("video");
-			track.bytes(123);
-			track.frame();
+			let _track = bs.publisher().track("video");
+			bs.egress_usage().add_frame(123);
 			let _sub = sessions.subscribe("foo/bar");
 			// track + sub dropped here, all within tick 1
 		}
@@ -1701,8 +1678,8 @@ mod tests {
 		let (stats, origin) = test_stats(Some("sjc"));
 		let mut consumer = origin.consume().announced();
 		let bs = stats.tier(Tier::External).broadcast("foo/bar");
-		let track = bs.publisher().track("video");
-		track.frame();
+		let _track = bs.publisher().track("video");
+		bs.egress_usage().add_frame(1);
 
 		drive_ticks(2).await;
 

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -538,8 +538,8 @@ impl StatsHandle {
 	/// Paths under the aggregator's configured `prefix` return an empty handle
 	/// whose bumps are no-ops. This keeps stats traffic from feeding back into
 	/// the aggregator.
-	pub fn broadcast(&self, path: impl AsPath) -> BroadcastStats {
-		BroadcastStats {
+	pub fn broadcast(&self, path: impl AsPath) -> BroadcastHandle {
+		BroadcastHandle {
 			entry: self.stats.entry(path),
 			tier: self.tier,
 		}
@@ -583,12 +583,12 @@ impl Default for StatsHandle {
 /// [`Self::subscriber_track`] when the broadcast's lifetime is tracked
 /// elsewhere.
 #[derive(Clone)]
-pub struct BroadcastStats {
+pub struct BroadcastHandle {
 	entry: Option<Arc<BroadcastEntry>>,
 	tier: Tier,
 }
 
-impl BroadcastStats {
+impl BroadcastHandle {
 	/// True if this handle has no underlying entry (path was under the
 	/// aggregator's own prefix, or stats are disabled). All bumps through an
 	/// empty handle are no-ops.
@@ -808,7 +808,7 @@ impl Drop for SessionStats {
 	}
 }
 
-/// RAII broadcast guard for the publisher role. See [`BroadcastStats::publisher`].
+/// RAII broadcast guard for the publisher role. See [`BroadcastHandle::publisher`].
 #[must_use = "drop the guard to record the broadcast as closed"]
 pub struct PublisherStats {
 	entry: Option<Arc<BroadcastEntry>>,
@@ -819,7 +819,7 @@ impl PublisherStats {
 	/// Open a track-subscription guard. Bumps `subscriptions` on construction
 	/// and `subscriptions_closed` on drop.
 	pub fn track(&self, name: &str) -> PublisherTrack {
-		BroadcastStats {
+		BroadcastHandle {
 			entry: self.entry.clone(),
 			tier: self.tier,
 		}
@@ -840,7 +840,7 @@ impl Drop for PublisherStats {
 	}
 }
 
-/// RAII broadcast guard for the subscriber role. See [`BroadcastStats::subscriber`].
+/// RAII broadcast guard for the subscriber role. See [`BroadcastHandle::subscriber`].
 #[must_use = "drop the guard to record the broadcast as closed"]
 pub struct SubscriberStats {
 	entry: Option<Arc<BroadcastEntry>>,
@@ -850,7 +850,7 @@ pub struct SubscriberStats {
 impl SubscriberStats {
 	/// Open a track-subscription guard. Mirrors [`PublisherStats::track`].
 	pub fn track(&self, name: &str) -> SubscriberTrack {
-		BroadcastStats {
+		BroadcastHandle {
 			entry: self.entry.clone(),
 			tier: self.tier,
 		}
@@ -1136,7 +1136,7 @@ async fn run_publisher(weak: Weak<StatsShared>, advertised: PathOwned, interval:
 		// publisher/subscriber/track guard remains, so every open counter
 		// has caught up to its `*_closed` counterpart and no traffic can
 		// flow. We can't key this on the counters directly: a held but idle
-		// `BroadcastStats` (all counters equal) must stay so a later bump
+		// `BroadcastHandle` (all counters equal) must stay so a later bump
 		// isn't lost on an orphaned `Arc`. Then drop local state for any
 		// path that left the map. We already emitted each removed entry's
 		// final snapshot above, so nothing is lost.

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -40,18 +40,16 @@
 //! * `announced` / `announced_closed`: cumulative count of broadcast
 //!   announce/unannounce events on this `(tier, role)`. Bumped on every
 //!   `publisher()` / `subscriber()` guard creation and drop.
-//! * `broadcasts` / `broadcasts_closed`: per-(broadcast, session)
-//!   subscription sentinel. The first active subscription a peer session
-//!   opens for a broadcast bumps `broadcasts`; the last one it closes bumps
-//!   `broadcasts_closed`. Summed across sessions, `broadcasts -
-//!   broadcasts_closed` is the number of distinct sessions currently
-//!   subscribed to the broadcast (i.e. viewers on the egress side). Driven
-//!   by [`SessionBroadcasts`]; use `announced` if you want all broadcasts
-//!   ever seen.
+//! * `broadcasts` / `broadcasts_closed`: live viewer/publisher count, owned by
+//!   the model. A consuming session counts as one viewer while it holds >= 1
+//!   `TrackConsumer` for the broadcast (egress side); a producer counts as one
+//!   publisher while it has >= 1 live track (ingress side). `broadcasts -
+//!   broadcasts_closed` is the current count; use `announced` if you want all
+//!   broadcasts ever seen.
 //! * `subscriptions` / `subscriptions_closed`: cumulative count of
 //!   track-level subscription guards opened/dropped.
-//! * `bytes` / `frames` / `groups`: cumulative payload counters bumped from
-//!   the session loops (both lite and IETF).
+//! * `bytes` / `frames` / `groups`: cumulative payload counters, owned by the
+//!   model and bumped as media flows through the broadcast.
 //! * `sessions` / `sessions_closed` (session tracks only): cumulative count
 //!   of sessions connected/disconnected under an auth root on this tier.
 //!   Driven by [`StatsHandle::session`].
@@ -139,7 +137,8 @@ use crate::{AsPath, BroadcastInfo, OriginProducer, Path, PathOwned, TrackProduce
 /// (groups/frames/bytes) live in [`Usage`], bumped by the model through the sink
 /// baked into the broadcast (ingress) or stamped onto the consumer (egress); the
 /// snapshot reads them back. `broadcasts` / `broadcasts_closed` are the
-/// per-(broadcast, session) subscription sentinel driven by [`SessionBroadcasts`].
+/// live viewer/publisher count, owned by the model (the egress/ingress
+/// `opened`/`closed` in [`Usage`]).
 #[derive(Default, Debug)]
 #[non_exhaustive]
 pub struct Counters {
@@ -147,11 +146,10 @@ pub struct Counters {
 	pub announced_closed: AtomicU64,
 	pub subscriptions: AtomicU64,
 	pub subscriptions_closed: AtomicU64,
-	pub broadcasts: AtomicU64,
-	pub broadcasts_closed: AtomicU64,
-	/// Payload usage (groups/frames/bytes) for this `(tier, role)`, shared with
-	/// the model: the same `Arc` is baked into the broadcast so the model's bumps
-	/// land here. The snapshot reads it back.
+	/// Payload usage (groups/frames/bytes) plus the live viewer/publisher counts
+	/// (`broadcasts` = `opened`, `broadcasts_closed` = `closed`) for this
+	/// `(tier, role)`, shared with the model: the same `Arc` is baked into the
+	/// broadcast so the model's bumps land here. The snapshot reads it back.
 	pub usage: Arc<Usage>,
 }
 
@@ -166,10 +164,12 @@ impl Counters {
 	fn snapshot(&self) -> RawCounts {
 		let announced_closed = self.announced_closed.load(Ordering::Acquire);
 		let subscriptions_closed = self.subscriptions_closed.load(Ordering::Acquire);
-		let broadcasts_closed = self.broadcasts_closed.load(Ordering::Acquire);
+		// Live viewer/publisher count, owned by the model: `closed` (Acquire) read
+		// before `opened` so the snapshot never shows `closed > opened`.
+		let broadcasts_closed = self.usage.closed();
+		let broadcasts = self.usage.opened();
 		let announced = self.announced.load(Ordering::Relaxed);
 		let subscriptions = self.subscriptions.load(Ordering::Relaxed);
-		let broadcasts = self.broadcasts.load(Ordering::Relaxed);
 		let bytes = self.usage.bytes();
 		let frames = self.usage.frames();
 		let groups = self.usage.groups();
@@ -546,20 +546,6 @@ impl StatsHandle {
 		}
 	}
 
-	/// Per-session egress (publisher) broadcast-subscription tracker. Construct
-	/// one per session and call [`SessionBroadcasts::subscribe`] for each
-	/// downstream subscription so `broadcasts - broadcasts_closed` counts the
-	/// distinct sessions watching each broadcast.
-	pub fn publisher_broadcasts(&self) -> SessionBroadcasts {
-		SessionBroadcasts::new(self.stats.clone(), self.tier, Side::Publisher)
-	}
-
-	/// Per-session ingress (subscriber) counterpart to
-	/// [`Self::publisher_broadcasts`].
-	pub fn subscriber_broadcasts(&self) -> SessionBroadcasts {
-		SessionBroadcasts::new(self.stats.clone(), self.tier, Side::Subscriber)
-	}
-
 	/// Record a connected session authenticated under `root` on this tier. Hold
 	/// the returned guard for the session's lifetime; dropping it bumps
 	/// `sessions_closed`. Counts presence regardless of any data flow, so a
@@ -599,8 +585,6 @@ impl BroadcastHandle {
 
 	/// Open a broadcast-lifetime guard for the publisher (egress) role.
 	/// Bumps `announced` on construction and `announced_closed` on drop.
-	/// (The `broadcasts` sentinel is driven separately by
-	/// [`SessionBroadcasts`]; see the module docs.)
 	pub fn publisher(&self) -> PublisherStats {
 		if let Some(entry) = &self.entry {
 			entry.publisher[self.tier.idx()]
@@ -615,8 +599,6 @@ impl BroadcastHandle {
 
 	/// Open a broadcast-lifetime guard for the subscriber (ingress) role.
 	/// Bumps `announced` on construction and `announced_closed` on drop.
-	/// (The `broadcasts` sentinel is driven separately by
-	/// [`SessionBroadcasts`]; see the module docs.)
 	pub fn subscriber(&self) -> SubscriberStats {
 		if let Some(entry) = &self.entry {
 			entry.subscriber[self.tier.idx()]
@@ -681,127 +663,6 @@ impl BroadcastHandle {
 			.as_ref()
 			.map(|e| e.publisher[self.tier.idx()].usage.clone())
 			.unwrap_or_default()
-	}
-}
-
-/// Which side of a [`BroadcastEntry`] a [`SessionBroadcasts`] bumps.
-#[derive(Copy, Clone)]
-enum Side {
-	Publisher,
-	Subscriber,
-}
-
-impl Side {
-	fn counters(self, entry: &BroadcastEntry, tier: Tier) -> &Counters {
-		match self {
-			Side::Publisher => &entry.publisher[tier.idx()],
-			Side::Subscriber => &entry.subscriber[tier.idx()],
-		}
-	}
-}
-
-/// Per-session tracker that turns a peer session's per-broadcast subscription
-/// lifecycle into `broadcasts` / `broadcasts_closed` bumps.
-///
-/// Hold one per session (and side). Call [`Self::subscribe`] for every
-/// subscription the session opens and keep the returned [`BroadcastSubscription`]
-/// alive for that subscription's lifetime. The guard refcounts subscriptions per
-/// broadcast for this session, so the session's *first* subscription to a
-/// broadcast bumps `broadcasts` and its *last* to drop bumps `broadcasts_closed`.
-/// Summed across sessions, `broadcasts - broadcasts_closed` is the number of
-/// distinct sessions currently subscribed to the broadcast (viewers on the
-/// egress side).
-///
-/// Cheap to clone; clones share the same per-broadcast refcounts (so a single
-/// logical session that clones its handle still counts as one).
-#[derive(Clone)]
-pub struct SessionBroadcasts {
-	stats: Stats,
-	tier: Tier,
-	side: Side,
-	counts: Arc<std::sync::Mutex<HashMap<PathOwned, u32>>>,
-}
-
-impl SessionBroadcasts {
-	fn new(stats: Stats, tier: Tier, side: Side) -> Self {
-		Self {
-			stats,
-			tier,
-			side,
-			counts: Arc::new(std::sync::Mutex::new(HashMap::new())),
-		}
-	}
-
-	/// Register one active subscription to `path` for this session. Hold the
-	/// returned guard for the subscription's lifetime; dropping it releases the
-	/// subscription (bumping `broadcasts_closed` when it was the session's last
-	/// for that broadcast).
-	pub fn subscribe(&self, path: impl AsPath) -> BroadcastSubscription {
-		let path = path.as_path().to_owned();
-		let entry = self.stats.entry(&path);
-		let first = {
-			let mut counts = self.counts.lock().expect("stats refcount poisoned");
-			let n = counts.entry(path.clone()).or_insert(0);
-			let first = *n == 0;
-			*n += 1;
-			first
-		};
-		if first {
-			if let Some(entry) = &entry {
-				self.side
-					.counters(entry, self.tier)
-					.broadcasts
-					.fetch_add(1, Ordering::Relaxed);
-			}
-		}
-		BroadcastSubscription {
-			entry,
-			tier: self.tier,
-			side: self.side,
-			counts: self.counts.clone(),
-			path,
-		}
-	}
-}
-
-/// RAII guard for one of a session's per-broadcast subscriptions.
-/// See [`SessionBroadcasts::subscribe`].
-#[must_use = "drop the guard to release the subscription"]
-pub struct BroadcastSubscription {
-	entry: Option<Arc<BroadcastEntry>>,
-	tier: Tier,
-	side: Side,
-	counts: Arc<std::sync::Mutex<HashMap<PathOwned, u32>>>,
-	path: PathOwned,
-}
-
-impl Drop for BroadcastSubscription {
-	fn drop(&mut self) {
-		let last = {
-			let mut counts = self.counts.lock().expect("stats refcount poisoned");
-			match counts.get_mut(&self.path) {
-				Some(n) => {
-					*n -= 1;
-					if *n == 0 {
-						counts.remove(&self.path);
-						true
-					} else {
-						false
-					}
-				}
-				None => false,
-			}
-		};
-		if last {
-			if let Some(entry) = &self.entry {
-				// Release pairs with the snapshot reader's Acquire load of
-				// `broadcasts_closed`; see `PublisherStats::drop`.
-				self.side
-					.counters(entry, self.tier)
-					.broadcasts_closed
-					.fetch_add(1, Ordering::Release);
-			}
-		}
 	}
 }
 
@@ -1167,9 +1028,8 @@ async fn run_publisher(weak: Weak<StatsShared>, advertised: PathOwned, interval:
 }
 
 /// What we emit for one entry on one tier-role track. Every field comes
-/// straight from [`RawCounts`]; `broadcasts` / `broadcasts_closed` are the
-/// per-(broadcast, session) subscription sentinel maintained by
-/// [`SessionBroadcasts`].
+/// straight from [`RawCounts`]; `broadcasts` / `broadcasts_closed` are the live
+/// viewer/publisher count owned by the model.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize)]
 #[cfg_attr(test, derive(serde::Deserialize))]
 struct Snapshot {
@@ -1423,8 +1283,8 @@ mod tests {
 		let bs = stats.tier(Tier::External).broadcast("foo/bar");
 		let _track = bs.publisher().track("video");
 		bs.egress_usage().add_frame(42);
-		let sessions = stats.tier(Tier::External).publisher_broadcasts();
-		let _sub = sessions.subscribe("foo/bar");
+		// One live viewer, the way the model's `Live` refcount would record it.
+		bs.egress_usage().open();
 
 		tokio::time::advance(Duration::from_millis(1100)).await;
 
@@ -1481,12 +1341,14 @@ mod tests {
 		let (stats, origin) = test_stats(Some("sjc"));
 		let mut consumer = origin.consume().announced();
 		let bs = stats.tier(Tier::External).broadcast("foo/bar");
-		let sessions = stats.tier(Tier::External).publisher_broadcasts();
 		{
 			let _track = bs.publisher().track("video");
 			bs.egress_usage().add_frame(123);
-			let _sub = sessions.subscribe("foo/bar");
-			// track + sub dropped here, all within tick 1
+			// One viewer opens and closes within the tick.
+			let usage = bs.egress_usage();
+			usage.open();
+			usage.close();
+			// track dropped here, all within tick 1
 		}
 
 		tokio::time::advance(Duration::from_millis(1100)).await;
@@ -1511,19 +1373,14 @@ mod tests {
 	}
 
 	#[tokio::test(start_paused = true)]
-	async fn multiple_subs_count_as_one_broadcast() {
-		// Two concurrent subs from the SAME session count as one broadcast, not
-		// two: broadcasts is "distinct sessions with >=1 active sub", not
-		// "subscription count". broadcasts_closed only bumps once the session's
-		// last sub for the broadcast closes.
+	async fn broadcasts_reflect_usage_lifecycle() {
+		// The snapshot maps the model's egress `opened`/`closed` (the live-viewer
+		// count, owned by the model's `Live` refcount) onto broadcasts /
+		// broadcasts_closed. The dedup ("N tracks = one viewer") and per-session
+		// distinctness live in the model; here we just check the mapping.
 		let (stats, _origin) = test_stats(Some("sjc"));
 		let bs = stats.tier(Tier::External).broadcast("foo/bar");
-		let sessions = stats.tier(Tier::External).publisher_broadcasts();
-		let pub_guard = bs.publisher();
-		let t1 = pub_guard.track("video");
-		let t2 = pub_guard.track("audio");
-		let s1 = sessions.subscribe("foo/bar");
-		let s2 = sessions.subscribe("foo/bar");
+		let usage = bs.egress_usage();
 
 		let raw = || {
 			let entries = stats.shared().entries.lock();
@@ -1531,54 +1388,18 @@ mod tests {
 			entry.publisher[Tier::External.idx()].snapshot()
 		};
 
+		usage.open();
+		usage.open();
 		let r = raw();
-		assert_eq!(r.subscriptions, 2, "two track subs");
-		assert_eq!(r.subscriptions_closed, 0, "neither dropped yet");
-		assert_eq!(r.broadcasts, 1, "one session => one broadcast");
+		assert_eq!(r.broadcasts, 2, "two live viewers");
 		assert_eq!(r.broadcasts_closed, 0);
 
-		drop(s1);
-		assert_eq!(raw().broadcasts_closed, 0, "session still has a sub open");
-
-		drop(s2);
-		drop(t1);
-		drop(t2);
-		let r = raw();
-		assert_eq!(r.subscriptions_closed, 2, "both track subs dropped");
-		assert_eq!(r.broadcasts, 1);
-		assert_eq!(r.broadcasts_closed, 1, "last sub closed => one broadcasts_closed");
-
-		drop(pub_guard);
-		drop(bs);
-	}
-
-	#[tokio::test(start_paused = true)]
-	async fn distinct_sessions_count_as_separate_broadcasts() {
-		// The viewer-count invariant: two different sessions subscribing to the
-		// same broadcast bump broadcasts to 2 (each is a distinct viewer).
-		let (stats, _origin) = test_stats(Some("sjc"));
-		let viewer1 = stats.tier(Tier::External).publisher_broadcasts();
-		let viewer2 = stats.tier(Tier::External).publisher_broadcasts();
-
-		let raw = || {
-			let entries = stats.shared().entries.lock();
-			let entry = entries.get(&PathOwned::from("foo/bar")).expect("entry");
-			entry.publisher[Tier::External.idx()].snapshot()
-		};
-
-		let s1 = viewer1.subscribe("foo/bar");
-		assert_eq!(raw().broadcasts, 1, "one viewer");
-		let s2 = viewer2.subscribe("foo/bar");
-		assert_eq!(raw().broadcasts, 2, "two distinct viewers");
-		assert_eq!(raw().broadcasts_closed, 0);
-
-		drop(s1);
+		usage.close();
 		let r = raw();
 		assert_eq!(r.broadcasts, 2, "broadcasts is cumulative");
 		assert_eq!(r.broadcasts_closed, 1, "one viewer left");
-		// broadcasts - broadcasts_closed = 1 remaining viewer.
 
-		drop(s2);
+		usage.close();
 		assert_eq!(raw().broadcasts_closed, 2, "both viewers gone");
 	}
 


### PR DESCRIPTION
Implements the design in [`rs/moq-net/DESIGN-stats.md`](https://github.com/moq-dev/moq/pull/1894/files) (PR #1894), which supersedes the `with_meter` / `set_meter` approach on #1873. Per-broadcast usage sinks live in `BroadcastInfo`, are set at construction, and ride the immutable `Arc<BroadcastInfo>` down to every track, group, and frame. `Usage` is atomics, so the model bumps through a shared `&Arc<Usage>` with no mutation, no setter, and no `Arc::make_mut`.

This takes over #1873 (which should be closed in favor of this).

## What changed

The design's three phases, each landed as its own commit:

1. **The model carries usage stats.** New `model/usage.rs`: `Usage` (groups/frames/bytes payload + opened/closed lifecycle atomics) and `BroadcastStats` (one `Usage` per direction). `BroadcastInfo` gains a `stats` field; `Arc<BroadcastInfo>` + `Arc<TrackInfo>` are threaded through Broadcast/Track/Group; payload bumps move into the model (ingress at create_group/append_frame, egress as the consumer reads). The stats-layer `BroadcastStats` is renamed `BroadcastHandle`.

2. **Origin attributes egress, ingress baked at construction.** The lite/IETF subscriber loops build the broadcast with `stats.producer` already set. The per-session `OriginConsumer::with_egress` provider stamps each `BroadcastConsumer` it yields (announce stream, `request_broadcast`, dynamic accept) with that session's egress sink, so per-tier egress survives with zero mutation. The handler/gateway per-frame/byte/group bumps are deleted; the stats layer reads the shared `Arc<Usage>` instead of vending payload guards.

3. **Model-tracked live viewer/publisher counts.** A `Live` refcount over each sink: a `BroadcastConsumer` is one live viewer while it has ≥1 outstanding `TrackConsumer` (the token rides into the `TrackSubscriber`, so a subscription counts for its whole life); a broadcast with ≥1 live `TrackProducer` is one publisher (the publisher token rides the shared broadcast state, so the relay's dynamic-accept ingress path is covered). `SessionBroadcasts` is gone; the publish loop maps `opened - closed` onto the existing `broadcasts` / `broadcasts_closed` fields, so the **published schema is unchanged**.

## Semantics

- **Egress is per-consumer** (N viewers count N times); **ingress is single-writer** (counts once). A relay counts both directions without double-counting either.
- The lite **fetch** path is metered through the model: a fetch re-serves an existing group, so it bumps frames/bytes but not `groups`.
- The model counts **raw (decompressed)** bytes vs. the old post-compression wire bytes. Only the hang catalog track sets `compress`, so the difference is noise; a follow-up will cache compressed bytes so the count is the wire size again. (Confirmed acceptable.)

## Testing

`cargo test -p moq-net` passes (400 lib + 4 integration), including new model tests for ingress-once/egress-per-viewer, origin egress-stamping, and live viewer/publisher counts. `clippy`/`doc`/`fmt` clean; dependent crates (`moq-mux`, `hang`, `moq-relay`, `moq-native`, `moq-srt`, `moq-json`, `moq-ffi`) compile.

> Note: this environment's egress policy blocks the `kixelated/nvidia-video-codec-sdk` git fork and the sandbox has no IPv6, so the full workspace `just check` and the `moq-native` end-to-end relay suite can't run here. CI's nix run is the source of truth for those.

## Cross-package sync

- `js/net`: not mirrored. The stats aggregator / usage sinks are relay-side Rust only; the browser client has no equivalent. No `doc/concept` wire change (this is API, not wire).

## Breaking changes (target `dev`)

Public API in `rs/moq-net`: `BroadcastInfo` gains `stats`; `Broadcast{Producer,Consumer,Dynamic}` carry `Arc<BroadcastInfo>`; `GroupProducer::new` takes `Arc<TrackInfo>` + `Arc<BroadcastInfo>` (was `Option<Timescale>`); the stats-layer `BroadcastStats` is renamed `BroadcastHandle`; `SessionBroadcasts` / `BroadcastSubscription` and the `publisher_broadcasts` / `subscriber_broadcasts` / per-track `frame`/`bytes`/`group` methods are removed; `Counters` swaps its payload + broadcasts atoms for a shared `Arc<Usage>`. `TrackProducer::new(name, info)` keeps its signature (standalone tracks get a shared no-op broadcast).

## Follow-ups

- Wire moq-rtc (WHIP/WHEP) and moq-rtmp through the same origin egress / ingress-at-construction seam (the mechanism exists; their origins just need `with_egress` and an ingress-baked broadcast).
- Cache compressed bytes in the model so the byte count is the wire size for compressed tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude)