### PR TITLE
feat(net): pluggable GroupSource for deep out-of-RAM replay window

### DIFF
--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -12,7 +12,7 @@ use crate::{
 		self,
 		priority::{Priority, PriorityHandle, PriorityQueue},
 	},
-	model::GroupConsumer,
+	model::{Group, GroupConsumer},
 };
 
 use super::Version;
@@ -552,6 +552,55 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// Highest group sequence handed to a Group stream, reported in SUBSCRIBE_END (moq-lite-05+).
 		// The consumer was already positioned by `run_subscribe` from the resolved start group.
 		let mut last_sequence: Option<u64> = None;
+
+		// Deep replay: if the subscriber asked to resume from a group older than
+		// anything still in the in-RAM cache, serve the missing range from the
+		// publisher's group source (e.g. disk) before joining the live stream.
+		// The live `start_at` above already filters the cache to `start_group`,
+		// so the cache serves `[cache_floor..]` and this serves `[start..cache_floor)`.
+		if let Some(requested) = subscribe.start_group {
+			if let Some(source) = track.group_source() {
+				let mut next = match source.oldest() {
+					Some(oldest) => requested.max(oldest),
+					None => requested,
+				};
+				// Serve sequentially (one open uni-stream at a time, so the
+				// subscriber's flow control paces us). Re-read the cache floor
+				// each iteration: disk replay outruns the live rate, so `next`
+				// converges on the slowly-advancing eviction boundary, at which
+				// point the live loop below takes over without a gap.
+				while let Some(cache_floor) = track.oldest() {
+					if next >= cache_floor {
+						break;
+					}
+					if let Some(frames) = source.group(next) {
+						let mut producer = Group { sequence: next }.produce();
+						for frame in frames {
+							producer.write_frame(frame)?;
+						}
+						producer.finish()?;
+
+						let msg = lite::Group {
+							subscribe: subscribe.id,
+							sequence: next,
+						};
+						let current_priority = *track_priority.borrow_and_update();
+						let handle = priority.insert(Priority::new(current_priority, next));
+						Self::serve_group(
+							session.clone(),
+							msg,
+							handle,
+							producer.consume(),
+							track_stats.clone(),
+							track_priority.clone(),
+							version,
+						)
+						.await?;
+					}
+					next += 1;
+				}
+			}
+		}
 
 		loop {
 			let group = tokio::select! {

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -60,6 +60,10 @@ struct State {
 	max_sequence: Option<u64>,
 	final_sequence: Option<u64>,
 	abort: Option<Error>,
+	/// Per-track override for how long evicted-eligible groups are retained.
+	/// `None` falls back to [`MAX_GROUP_AGE`]. Lets a publisher trade memory for
+	/// a deeper late-join / replay window.
+	max_group_age: Option<std::time::Duration>,
 }
 
 impl State {
@@ -169,6 +173,7 @@ impl State {
 	/// When max_sequence is at the front, we skip past it and tombstone expired groups
 	/// behind it.
 	fn evict_expired(&mut self, now: tokio::time::Instant) {
+		let max_group_age = self.max_group_age.unwrap_or(MAX_GROUP_AGE);
 		for slot in self.groups.iter_mut() {
 			let Some((group, created_at)) = slot else { continue };
 
@@ -176,7 +181,7 @@ impl State {
 				continue;
 			}
 
-			if now.duration_since(*created_at) <= MAX_GROUP_AGE {
+			if now.duration_since(*created_at) <= max_group_age {
 				break;
 			}
 
@@ -223,6 +228,15 @@ impl TrackProducer {
 			info,
 			state: kio::Producer::default(),
 		}
+	}
+
+	/// Override how long groups are retained in the cache before eviction
+	/// (default [`MAX_GROUP_AGE`]). A larger value gives late-joining
+	/// subscribers a deeper replay window at the cost of memory. The
+	/// max-sequence (latest) group is always retained regardless.
+	pub fn set_max_group_age(&mut self, age: std::time::Duration) -> Result<()> {
+		self.modify()?.max_group_age = Some(age);
+		Ok(())
 	}
 
 	/// Create a new group with the given sequence number.
@@ -782,6 +796,37 @@ mod test {
 			assert!(!state.duplicates.contains(&1));
 			assert!(!state.duplicates.contains(&2));
 			assert!(state.duplicates.contains(&3));
+		}
+	}
+
+	#[tokio::test]
+	async fn set_max_group_age_extends_retention() {
+		tokio::time::pause();
+
+		let mut producer = Track::new("test").produce();
+		// Retain groups far longer than the default.
+		let window = MAX_GROUP_AGE + Duration::from_secs(30);
+		producer.set_max_group_age(window).unwrap();
+
+		producer.append_group().unwrap(); // seq 0
+		producer.append_group().unwrap(); // seq 1
+
+		// Past the *default* threshold but within the override: nothing evicted.
+		tokio::time::advance(MAX_GROUP_AGE + Duration::from_secs(1)).await;
+		producer.append_group().unwrap(); // seq 2 (triggers an eviction pass)
+		{
+			let state = producer.state.read();
+			assert_eq!(live_groups(&state), 3, "override should keep groups past 5s");
+			assert_eq!(first_live_sequence(&state), 0);
+		}
+
+		// Past the override window: the old groups now evict (seq 2 is kept as max).
+		tokio::time::advance(window + Duration::from_secs(1)).await;
+		producer.append_group().unwrap(); // seq 3
+		{
+			let state = producer.state.read();
+			assert_eq!(live_groups(&state), 1);
+			assert_eq!(first_live_sequence(&state), 3);
 		}
 	}
 

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -26,6 +26,26 @@ use std::{
 // TODO: Replace with a configurable cache size.
 const MAX_GROUP_AGE: Duration = Duration::from_secs(5);
 
+/// A fallback source of historical groups, consulted by the publisher when a
+/// subscriber requests a `start_group` older than anything still in the in-RAM
+/// track cache (see the lite publisher's `run_track`). This lets a publisher
+/// serve a replay window far deeper than memory allows — e.g. disk-backed —
+/// without holding every group in the cache.
+///
+/// Wrapped in an `Arc` and shared with the publisher's async task, so
+/// implementations must be `Send + Sync`. [`Self::group`] may block briefly on
+/// I/O; the publisher only calls it on the backfill path, never in the hot live
+/// loop.
+pub trait GroupSource: Send + Sync {
+	/// Return the frames of the group with this sequence in order, or `None` if
+	/// it is not stored (never produced, or already evicted from the deep store).
+	fn group(&self, sequence: u64) -> Option<Vec<bytes::Bytes>>;
+
+	/// The oldest sequence the source can still serve, or `None` if it is empty.
+	/// Used to clamp a subscriber's requested `start_group` to what's available.
+	fn oldest(&self) -> Option<u64>;
+}
+
 /// A track is a collection of groups, delivered out-of-order until expired.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -64,6 +84,10 @@ struct State {
 	/// `None` falls back to [`MAX_GROUP_AGE`]. Lets a publisher trade memory for
 	/// a deeper late-join / replay window.
 	max_group_age: Option<std::time::Duration>,
+	/// Optional fallback for groups older than the in-RAM cache. Lets the
+	/// publisher serve a deep (e.g. disk-backed) replay window without holding
+	/// it all in memory. `None` = serve only what's cached.
+	group_source: Option<std::sync::Arc<dyn GroupSource>>,
 }
 
 impl State {
@@ -236,6 +260,15 @@ impl TrackProducer {
 	/// max-sequence (latest) group is always retained regardless.
 	pub fn set_max_group_age(&mut self, age: std::time::Duration) -> Result<()> {
 		self.modify()?.max_group_age = Some(age);
+		Ok(())
+	}
+
+	/// Set a fallback [`GroupSource`] for groups older than the in-RAM cache.
+	/// The publisher consults it when a subscriber resumes from a `start_group`
+	/// that has already been evicted, serving the missing range before the live
+	/// stream — a replay window deeper than memory allows.
+	pub fn set_group_source(&mut self, source: std::sync::Arc<dyn GroupSource>) -> Result<()> {
+		self.modify()?.group_source = Some(source);
 		Ok(())
 	}
 
@@ -692,6 +725,24 @@ impl TrackConsumer {
 	/// Return the latest sequence number in the track.
 	pub fn latest(&self) -> Option<u64> {
 		self.state.read().max_sequence
+	}
+
+	/// Return the oldest sequence still live in the in-RAM cache, or `None` if
+	/// the cache is empty. This is the floor below which a resuming subscriber
+	/// must be served from the [`GroupSource`] instead of the cache.
+	pub fn oldest(&self) -> Option<u64> {
+		self.state
+			.read()
+			.groups
+			.iter()
+			.flatten()
+			.map(|(group, _)| group.sequence)
+			.min()
+	}
+
+	/// The fallback source of historical groups, if the producer set one.
+	pub fn group_source(&self) -> Option<std::sync::Arc<dyn GroupSource>> {
+		self.state.read().group_source.clone()
 	}
 
 	/// Create a weak reference that doesn't prevent auto-close.
@@ -1342,6 +1393,54 @@ mod test {
 				.is_none(),
 			"sequence at-or-after fin should not exist"
 		);
+	}
+
+	#[tokio::test]
+	async fn group_source_plumbing() {
+		// A trivial in-memory source for the plumbing test.
+		struct VecSource {
+			oldest: u64,
+			groups: std::collections::HashMap<u64, Vec<bytes::Bytes>>,
+		}
+		impl GroupSource for VecSource {
+			fn group(&self, sequence: u64) -> Option<Vec<bytes::Bytes>> {
+				self.groups.get(&sequence).cloned()
+			}
+			fn oldest(&self) -> Option<u64> {
+				Some(self.oldest)
+			}
+		}
+
+		let mut producer = Track::new("test").produce();
+		let consumer = producer.consume();
+
+		// No source by default.
+		assert!(consumer.group_source().is_none());
+
+		let mut groups = std::collections::HashMap::new();
+		groups.insert(7u64, vec![bytes::Bytes::from_static(b"seven")]);
+		let source = std::sync::Arc::new(VecSource { oldest: 7, groups });
+		producer.set_group_source(source).unwrap();
+
+		let src = consumer.group_source().expect("source should be set");
+		assert_eq!(src.oldest(), Some(7));
+		assert_eq!(src.group(7).unwrap()[0], bytes::Bytes::from_static(b"seven"));
+		assert!(src.group(8).is_none());
+	}
+
+	#[tokio::test]
+	async fn oldest_returns_min_live_sequence() {
+		tokio::time::pause();
+
+		let mut producer = Track::new("test").produce();
+		let consumer = producer.consume();
+		assert_eq!(consumer.oldest(), None, "empty cache has no floor");
+
+		// Out-of-order arrivals: oldest tracks the minimum live sequence.
+		producer.create_group(Group { sequence: 5 }).unwrap();
+		producer.create_group(Group { sequence: 3 }).unwrap();
+		producer.create_group(Group { sequence: 4 }).unwrap();
+		assert_eq!(consumer.oldest(), Some(3));
 	}
 
 	#[test]


### PR DESCRIPTION
@kixelated So this is what Claude came up with for implementing atmoq's 72-hour replay window. Works, but let me know if this is completely wrongheaded and I'm happy to scrap it and do a FETCH-based backfill implementation instead. That said, this behavior is kinda neat, allows library consumers to bring their own backing store for use cases where you want to backfill older content right up to live.