### PR TITLE
docs: reconcile nav with filesystem and tidy sidebar

### DIFF
--- a/doc/.vitepress/config.ts
+++ b/doc/.vitepress/config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
 		nav: [
 			{ text: "Setup", link: "/setup/" },
 			{ text: "Concepts", link: "/concept/" },
-			{ text: "Apps", link: "/bin/" },
+			{ text: "Applications", link: "/bin/" },
 			{
 				text: "Libraries",
 				link: "/lib/",
@@ -56,6 +56,7 @@ export default defineConfig({
 					{ text: "Go", link: "/lib/go/" },
 				],
 			},
+			{ text: "Demos", link: "/demo/" },
 		],
 
 		sidebar: {
@@ -71,7 +72,7 @@ export default defineConfig({
 					],
 				},
 				{
-					text: "Demos",
+					text: "Demo Setup",
 					items: [
 						{ text: "Web", link: "/setup/demo/web" },
 						{ text: "MoQ Boy", link: "/setup/demo/boy" },
@@ -88,9 +89,9 @@ export default defineConfig({
 							text: "Layers",
 							link: "/concept/layer/",
 							items: [
-								{ text: "quic", link: "/concept/layer/quic" },
-								{ text: "web-transport", link: "/concept/layer/web-transport" },
-								{ text: "web-socket", link: "/concept/layer/web-socket" },
+								{ text: "QUIC", link: "/concept/layer/quic" },
+								{ text: "WebTransport", link: "/concept/layer/web-transport" },
+								{ text: "WebSocket", link: "/concept/layer/web-socket" },
 								{ text: "moq-lite", link: "/concept/layer/moq-lite" },
 								{ text: "hang", link: "/concept/layer/hang" },
 							],
@@ -102,6 +103,7 @@ export default defineConfig({
 								{ text: "MoqTransport", link: "/concept/standard/moq-transport" },
 								{ text: "MSF", link: "/concept/standard/msf" },
 								{ text: "LOC", link: "/concept/standard/loc" },
+								{ text: "CMAF", link: "/concept/standard/cmaf" },
 								{ text: "Interop", link: "/concept/standard/interop" },
 							],
 						},
@@ -171,7 +173,9 @@ export default defineConfig({
 										{ text: "moq-native", link: "/lib/rs/crate/moq-native" },
 										{ text: "moq-token", link: "/lib/rs/crate/moq-token" },
 										{ text: "hang", link: "/lib/rs/crate/hang" },
+										{ text: "moq-mux", link: "/lib/rs/crate/moq-mux" },
 										{ text: "web-transport", link: "/lib/rs/crate/web-transport" },
+										{ text: "moq-boy", link: "/lib/rs/crate/moq-boy" },
 										{ text: "libmoq", link: "/lib/rs/crate/libmoq" },
 									],
 								},
@@ -199,6 +203,8 @@ export default defineConfig({
 										{ text: "@moq/publish", link: "/lib/js/@moq/publish" },
 										{ text: "@moq/token", link: "/lib/js/@moq/token" },
 										{ text: "@moq/signals", link: "/lib/js/@moq/signals" },
+										{ text: "@moq/demo", link: "/lib/js/@moq/demo" },
+										{ text: "@moq/boy", link: "/lib/js/@moq/boy" },
 									],
 								},
 							],
@@ -206,7 +212,7 @@ export default defineConfig({
 						{
 							text: "C",
 							link: "/lib/c/",
-							items: [{ text: "libmoq", link: "/lib/rs/crate/libmoq" }],
+							items: [{ text: "libmoq", link: "/lib/c/#libmoq" }],
 						},
 						{
 							text: "Python",
@@ -229,6 +235,14 @@ export default defineConfig({
 							items: [{ text: "moq", link: "/lib/go/moq" }],
 						},
 					],
+				},
+			],
+
+			"/demo/": [
+				{
+					text: "Demos",
+					link: "/demo/",
+					items: [{ text: "MoQ Boy", link: "/demo/moq-boy" }],
 				},
 			],
 		},

--- a/doc/index.md
+++ b/doc/index.md
@@ -10,14 +10,14 @@ hero:
       text: Concepts
       link: /concept/
     - theme: alt
-      text: Apps
+      text: Applications
       link: /bin/
     - theme: alt
       text: Libraries
       link: /lib/
     - theme: alt
-      text: Demo
-      link: https://moq.dev/
+      text: Demos
+      link: /demo/
 
 features:
   - icon:


### PR DESCRIPTION
## Summary

The docs are asking "is there a better way to organize this so it's less hodge-podge and more professional?" The top-level structure (Setup / Concepts / Applications / Libraries) is actually solid. What made it *feel* unpolished was a layer of drift and inconsistency underneath it. This PR fixes the clearly-correct issues; voice/prose tone is intentionally left untouched pending a separate call.

### Sidebar had drifted out of sync with the pages on disk
Several pages existed but were unreachable from the nav (nothing signals "unmaintained" faster):
- Added `moq-mux` and `moq-boy` (Rust crates) — `moq-mux` was even *featured on the homepage* yet missing from the sidebar.
- Added `@moq/demo` and `@moq/boy` (JS packages).
- Added the `CMAF` standard under Concepts → Standards.

### Fixed a broken sidebar link
The C library's `libmoq` entry linked to `/lib/rs/crate/libmoq`, which yanked the reader out of the C section and into Rust (switching the whole sidebar). It now stays in `/lib/c/`.

### De-orphaned the `/demo/` section
`/demo/` had a real overview + a substantive MoQ Boy architecture page, but nothing in the nav pointed to it, and the homepage "Demo" button left the docs site entirely for `moq.dev`.
- Promoted `/demo/` to a first-class nav + sidebar section.
- Renamed Setup's overlapping "Demos" subsection to "Demo Setup" so the two "Demos" stop colliding (Setup = how to run locally; top-level Demos = what it showcases).
- Repointed the homepage "Demo" hero button back into the docs.

### Unified labels
- Capitalized well-known tech in the Layers list (`quic` → `QUIC`, `web-transport` → `WebTransport`, `web-socket` → `WebSocket`) while keeping project literals (`moq-lite`, `hang`).
- Renamed the navbar "Apps" to "Applications" to match the page title and sidebar it links to.

### Deliberately not in this PR
Homepage prose/voice cleanup (e.g. the lone 🦀 on "Rust Crates", casual asides) is a taste call and left for a follow-up.

## Test plan
- [x] `vitepress build` completes with no dead-link errors.
- [x] Every new sidebar link resolves to an existing `.md` file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBqk5qwpJmbcWQdDnxNZ4w)_