### PR TITLE
feat(ts): spread paced TS output across each frame's duration

### DIFF
--- a/rs/moq-cli/src/subscribe.rs
+++ b/rs/moq-cli/src/subscribe.rs
@@ -5,6 +5,10 @@ use hang::moq_net;
 use moq_mux::catalog::CatalogFormat;
 use tokio::io::AsyncWriteExt;
 
+/// Chunk size for `--pace`: 7 TS packets (7 x 188), one MTU-sized write, so a frame
+/// trickles out at roughly millisecond granularity instead of one burst.
+const PACE_CHUNK: usize = 7 * 188;
+
 #[derive(ValueEnum, Clone, Copy)]
 pub enum SubscribeFormat {
 	Fmp4,
@@ -163,16 +167,28 @@ impl Subscribe {
 		let mut ts =
 			moq_mux::container::ts::Export::with_ts(self.broadcast, self.catalog)?.with_latency(self.args.max_latency);
 
+		// `--pace` spreads each frame's TS packets across its on-wire duration instead of
+		// writing the whole frame at its due instant. A per-frame burst overruns a
+		// downstream TS decoder's constant-rate buffer model (glitches and PCR errors
+		// unless the caller pads the mux to CBR); trickling the bytes keeps arrival near
+		// the media rate. We estimate the duration from the previous frame's pace gap,
+		// which tracks a steady frame rate and collapses to an immediate burst on a
+		// tune-in re-anchor.
+		let mut prev = None;
 		while let Some(frame) = ts.next().await? {
-			// `--pace`: hold each frame until it's due. The muxer paces on its decode clock
-			// and follows the live edge with up to `--max-latency` of buffer, so a retained
-			// broadcast drains in real time while a live source stays near the edge.
-			if pace {
-				tokio::time::sleep_until(frame.pace.into()).await;
+			if !pace {
+				stdout.write_all(&frame.payload).await?;
+				stdout.flush().await?;
+				continue;
 			}
 
-			stdout.write_all(&frame.payload).await?;
-			stdout.flush().await?;
+			let span = prev.map_or(Duration::ZERO, |p| frame.pace.saturating_duration_since(p));
+			prev = Some(frame.pace);
+			for (at, chunk) in frame.spread(span, PACE_CHUNK) {
+				tokio::time::sleep_until(at.into()).await;
+				stdout.write_all(&chunk).await?;
+				stdout.flush().await?;
+			}
 		}
 
 		Ok(())

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -165,6 +165,32 @@ pub struct Output {
 	pub pace: Instant,
 }
 
+impl Output {
+	/// Split this frame into `chunk`-byte pieces, each paired with the wall-clock
+	/// instant it's due, spread evenly across `span` starting at [`pace`](Self::pace).
+	///
+	/// Emitting each piece at its instant (sleeping, or stamping a transport send time)
+	/// trickles the frame onto the wire at the source's real-time rate instead of
+	/// firing a whole frame at its [`pace`](Self::pace) boundary. A per-frame burst
+	/// overruns a TS decoder's constant-rate buffer model unless the mux is padded to
+	/// CBR; spreading keeps PCR-to-arrival roughly linear without that padding. `span`
+	/// is the frame's on-wire duration, typically the gap to the next frame's `pace`; a
+	/// zero span (the first frame, or a tune-in burst re-anchored to the live edge)
+	/// yields every piece at `pace`. `chunk` is clamped to at least one byte; keep it a
+	/// multiple of 188 to preserve TS-packet alignment.
+	pub fn spread(&self, span: Duration, chunk: usize) -> impl Iterator<Item = (Instant, Bytes)> {
+		let payload = self.payload.clone();
+		let pace = self.pace;
+		let chunk = chunk.max(1);
+		let count = payload.len().div_ceil(chunk);
+		(0..count).map(move |i| {
+			let at = pace + span.mul_f64(i as f64 / count as f64);
+			let end = ((i + 1) * chunk).min(payload.len());
+			(at, payload.slice(i * chunk..end))
+		})
+	}
+}
+
 /// The program tables plus the resolved PID layout.
 struct Psi {
 	pat: Pat,
@@ -1187,7 +1213,58 @@ fn dts_reserve(config: &VideoConfig) -> u64 {
 
 #[cfg(test)]
 mod tests {
-	use super::{DEFAULT_DTS_RESERVE, author_dts, is_complete_section};
+	use super::{DEFAULT_DTS_RESERVE, Output, author_dts, is_complete_section};
+	use bytes::Bytes;
+	use std::time::{Duration, Instant};
+
+	use crate::container::Timestamp;
+
+	fn output(len: usize, pace: Instant) -> Output {
+		Output {
+			payload: Bytes::from(vec![0u8; len]),
+			timestamp: Timestamp::from_micros(0).unwrap(),
+			keyframe: true,
+			pace,
+		}
+	}
+
+	#[test]
+	fn spread_trickles_chunks_across_the_span() {
+		// 1000 bytes in 250-byte chunks -> 4 pieces, due at even quarters of the 40ms
+		// window (0, 10, 20, 30 ms) so the last piece leaves before the next frame's pace.
+		let start = Instant::now();
+		let pieces: Vec<_> = output(1000, start).spread(Duration::from_millis(40), 250).collect();
+		assert_eq!(pieces.len(), 4);
+		for (i, expected) in [0, 10, 20, 30].into_iter().enumerate() {
+			assert_eq!(pieces[i].0, start + Duration::from_millis(expected));
+			assert_eq!(pieces[i].1.len(), 250);
+		}
+		// The pieces reassemble to the whole frame with nothing dropped or duplicated.
+		let total: usize = pieces.iter().map(|(_, b)| b.len()).sum();
+		assert_eq!(total, 1000);
+	}
+
+	#[test]
+	fn spread_keeps_a_short_final_chunk() {
+		let start = Instant::now();
+		let pieces: Vec<_> = output(900, start).spread(Duration::from_millis(30), 400).collect();
+		assert_eq!(pieces.len(), 3);
+		assert_eq!(
+			pieces[2].1.len(),
+			100,
+			"the trailing partial chunk keeps its real length"
+		);
+	}
+
+	#[test]
+	fn spread_zero_span_bursts_at_pace() {
+		// A collapsed window (first frame, or a re-anchored tune-in burst) sends everything
+		// at once rather than dividing by zero.
+		let start = Instant::now();
+		let pieces: Vec<_> = output(500, start).spread(Duration::ZERO, 100).collect();
+		assert_eq!(pieces.len(), 5);
+		assert!(pieces.iter().all(|(at, _)| *at == start));
+	}
 
 	/// Push a decode-order PTS stream (90 kHz) through the decode clock with a given reserve and
 	/// return the effective DTS per frame (the authored DTS, or the PTS when none is authored).

--- a/rs/moq-srt/src/server.rs
+++ b/rs/moq-srt/src/server.rs
@@ -20,7 +20,7 @@
 //! everything and routes by prefix, use [`crate::run`].
 
 use std::net::SocketAddr;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use futures::{SinkExt, StreamExt};
 use moq_net::{OriginConsumer, OriginProducer};
@@ -288,8 +288,9 @@ async fn serve_publish(origin: &OriginProducer, path: &str, mut socket: SrtSocke
 /// (`m=request`).
 ///
 /// Waits for the broadcast to be announced (so a caller may connect before the
-/// publisher), then packs the muxer's output into [`SRT_PAYLOAD`]-sized SRT
-/// messages. Returns once the broadcast ends or the caller disconnects.
+/// publisher), then slices the muxer's output into [`SRT_PAYLOAD`]-sized messages,
+/// stamped with pacing instants spread across each frame's duration. Returns once
+/// the broadcast ends or the caller disconnects.
 async fn serve_subscribe(origin: &OriginConsumer, path: &str, mut socket: SrtSocket, latency: Duration) -> Result<()> {
 	// Resolve the broadcast, but watch the socket while we wait: `announced_broadcast`
 	// parks forever for a stream that is never published, and nothing else polls the
@@ -312,28 +313,23 @@ async fn serve_subscribe(origin: &OriginConsumer, path: &str, mut socket: SrtSoc
 		return Ok(());
 	};
 
-	// MPEG-TS is a continuous byte stream, so we coalesce the muxer's per-frame
-	// output and slice it on a fixed boundary rather than preserving frames.
+	// The Instant handed to `send` is each payload's TSBPD origin time, which the
+	// receiver clocks delivery off. The muxer paces each frame on its decode clock; with
+	// the pace lead at zero (the SRT receiver owns the jitter buffer) it re-anchors any
+	// tune-in burst to the live edge, so nothing is stamped seconds into the future where
+	// SRT would hold it past the TSBPD window and stall after ~one packet.
 	//
-	// The Instant handed to `send` is the payload's TSBPD origin time, from which the
-	// receiver reconstructs inter-frame spacing. The muxer paces each frame on its
-	// decode clock; with the pace lead at zero (the SRT receiver owns the jitter buffer)
-	// it re-anchors any tune-in burst to the live edge, so nothing is stamped seconds
-	// into the future where SRT would hold it past the TSBPD window and stall after
-	// ~one packet.
-	let mut send_at = Instant::now();
-	let mut buffer = bytes::BytesMut::new();
+	// Spread each frame's TS packets across its on-wire duration rather than stamping the
+	// whole frame at one instant: a per-frame burst overruns the receiver's constant-rate
+	// TS buffer model. We estimate the duration from the previous frame's pace gap (a
+	// steady frame rate holds it; a re-anchored burst collapses it to an immediate send).
+	let mut prev = None;
 	while let Some(frame) = subscriber.next().await? {
-		send_at = frame.pace;
-
-		buffer.extend_from_slice(&frame.payload);
-		while buffer.len() >= SRT_PAYLOAD {
-			socket.send((send_at, buffer.split_to(SRT_PAYLOAD).freeze())).await?;
+		let span = prev.map_or(Duration::ZERO, |p| frame.pace.saturating_duration_since(p));
+		prev = Some(frame.pace);
+		for (send_at, chunk) in frame.spread(span, SRT_PAYLOAD) {
+			socket.send((send_at, chunk)).await?;
 		}
-	}
-
-	if !buffer.is_empty() {
-		socket.send((send_at, buffer.freeze())).await?;
 	}
 	socket.close().await?;
 


### PR DESCRIPTION
## Summary

Stacked on #1973. The paced TS egress there stamps a whole frame at one `pace` instant, so every packet in the frame leaves in a single burst at the frame boundary. A downstream TS decoder assumes a near-constant arrival rate, so a per-frame burst overruns its buffer model (glitches and PCR errors) unless the mux is padded to CBR (ffmpeg's `-muxrate`). This trickles each frame out instead.

- **moq-mux**: new `Output::spread(span, chunk)` slices a frame into `chunk`-sized pieces, each due at an instant interpolated across the frame's on-wire duration.
- **moq-cli `--pace`**: sleeps per chunk instead of per frame.
- **moq-srt egress**: stamps each SRT payload's TSBPD instant from the spread.

Both consumers estimate the frame's on-wire duration from the previous frame's `pace` gap (tracks a steady frame rate; collapses to an immediate burst on a tune-in re-anchor), so no lookahead buffering and no added latency.

## Scope / what this does NOT do

This is the **delivery half** only. Per @ArielM's IRD findings, it does **not** re-stamp PCR: the PCR values still come from `author_dts` per video frame, so a hardware IRD's PLL (which rebuilds its 27 MHz clock from PCR and needs uniform, ≤40 ms-spaced samples per TR 101 290) will still see a sparse, non-uniform clock. The operative IRD fix is a separate PCR re-stamp (uniform cadence, value from the pace/media clock, no null padding) layered on top of this. Happy to fold that in here or land it as a follow-up.

## Public API (moq-mux, additive)

- new `pub fn ts::Output::spread(&self, span: Duration, chunk: usize) -> impl Iterator<Item = (Instant, Bytes)>`.

## Test plan

- [x] `cargo test -p moq-mux -p moq-cli -p moq-srt` (spread covers even split, short final chunk, zero-span burst)
- [x] `cargo clippy -p moq-mux -p moq-cli -p moq-srt --all-targets` clean
- [ ] Not exercised end-to-end against a real IRD (needs the PCR re-stamp for that)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sv3GrsvEy1wyd2SYbApDzh)_