### PR TITLE
feat(moq-mux): re-stamp PCR as a dense uniform ramp on TS export

### DIFF
--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -75,6 +75,12 @@ pub struct Export<E: CatalogExt = ()> {
 	psi: Option<Psi>,
 	/// Media timestamp of the last PAT/PMT emission.
 	last_psi: Option<Timestamp>,
+	/// Decode timestamp of the previous PCR-track frame, so the PCR re-stamp interpolates
+	/// across each frame's on-wire span between real decode times (see [`Self::write_pes`]).
+	last_pcr_decode: Option<Timestamp>,
+	/// Continuous 90 kHz tick of the next PCR due on the PCR track. Carried across frames so
+	/// the re-stamp keeps a uniform PCR cadence independent of the frame rate.
+	next_pcr: Option<u64>,
 	/// Tune-in point: the first video keyframe's timestamp, captured when the program
 	/// tables are built. Non-video frames before it are dropped so the keyframe leads
 	/// the stream.
@@ -183,6 +189,12 @@ struct PesUnit {
 	/// (unwrapped) 90 kHz ticks (wrapped to the wire field in `write_pes`). `Some` only when
 	/// it differs from the PTS; the PES then carries both PTS and DTS.
 	dts: Option<u64>,
+	/// This frame's decode time (the pace/PCR clock): the authored DTS for reordered video,
+	/// else the PTS. The PCR re-stamp interpolates from `last_decode` up to here.
+	decode: Timestamp,
+	/// The previous PCR-track frame's decode time, or `None` for the first frame (and for
+	/// non-PCR tracks). Anchors the lower end of the PCR interpolation span.
+	last_decode: Option<Timestamp>,
 	/// Explicit PES stream_id (verbatim PES); `None` derives it from `is_video`.
 	stream_id: Option<u8>,
 }
@@ -229,6 +241,8 @@ impl<E: CatalogExt> Export<E> {
 			program_descriptors: Vec::new(),
 			psi: None,
 			last_psi: None,
+			last_pcr_decode: None,
+			next_pcr: None,
 			video_start: None,
 		})
 	}
@@ -799,9 +813,15 @@ impl<E: CatalogExt> Export<E> {
 					keyframe: frame.keyframe,
 					timestamp: frame.timestamp,
 					dts,
+					decode,
+					// Only the PCR track interpolates; other tracks carry no PCR.
+					last_decode: if is_pcr { self.last_pcr_decode } else { None },
 					stream_id,
 				};
 				self.write_pes(&mut out, &unit, &es_payload)?;
+				if is_pcr {
+					self.last_pcr_decode = Some(decode);
+				}
 			}
 		}
 		Ok(Output {
@@ -849,18 +869,42 @@ impl<E: CatalogExt> Export<E> {
 			u16::try_from(optional_len + payload.len()).unwrap_or(0)
 		};
 
-		// PCR follows the decode clock, so a B-frame stream advertises DTS (not PTS) here.
-		let pcr = dts.unwrap_or(pts);
+		// PCR re-stamp. On the PCR track, interpolate the reference clock across this frame's
+		// on-wire span, from the previous frame's decode time up to this one, and drop a PCR
+		// whenever `PCR_INTERVAL_TICKS` of media time has elapsed. Anchoring on real decode
+		// times keeps the ramp monotonic, gap-free, and <= the frame's DTS; the fixed cadence
+		// keeps repetition under the 40 ms TR 101 290 limit whatever the frame rate. A bare
+		// per-frame DTS PCR is too sparse and uneven for a hardware IRD's clock-recovery PLL.
+		let end = to_ticks(unit.decode);
+		let start = unit.last_decode.map(to_ticks);
+		let total = payload.len();
 
 		let mut offset = 0;
 		let mut first = true;
 		loop {
-			let adaptation = if first && (unit.is_pcr || unit.keyframe) {
+			// Continuous 90 kHz clock at this packet's byte position, interpolated across the
+			// frame. Pins to the decode time for the first frame (no `start`) or an empty payload.
+			let clock = match start {
+				Some(start) if total > 0 => start + (end - start) * offset as u64 / total as u64,
+				_ => end,
+			};
+			let pcr = if unit.is_pcr && self.next_pcr.is_none_or(|next| clock >= next) {
+				self.next_pcr = Some(clock + PCR_INTERVAL_TICKS);
+				Some(
+					TsTimestamp::new(clock & TS_TIMESTAMP_MASK)
+						.map_err(anyhow::Error::msg)?
+						.into(),
+				)
+			} else {
+				None
+			};
+
+			let adaptation = if pcr.is_some() || (first && unit.keyframe) {
 				Some(AdaptationField {
 					discontinuity_indicator: false,
-					random_access_indicator: unit.keyframe,
+					random_access_indicator: first && unit.keyframe,
 					es_priority_indicator: false,
-					pcr: if unit.is_pcr { Some(pcr.into()) } else { None },
+					pcr,
 					opcr: None,
 					splice_countdown: None,
 					transport_private_data: Vec::new(),
@@ -980,6 +1024,11 @@ const PES_DTS_LEN: usize = 5;
 /// import), the track uses that instead, which is large enough to keep `DTS <= PTS`. See
 /// [`author_dts`] and [`Track::dts_reserve`].
 const DEFAULT_DTS_RESERVE: u64 = 16;
+
+/// Insert a PCR at least this often on the PCR track: 20 ms (90 kHz * 20) matches ffmpeg's
+/// default `pcr_period` and stays under the 40 ms DVB TR 101 290 repetition limit, so a
+/// hardware decoder's clock-recovery PLL sees a dense, uniform clock.
+const PCR_INTERVAL_TICKS: u64 = 20 * 90;
 
 fn psi_interval() -> Timestamp {
 	Timestamp::try_from(PSI_INTERVAL).unwrap_or(Timestamp::ZERO)

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1408,3 +1408,75 @@ async fn opus_export_import_roundtrip() {
 		assert_eq!(got.as_slice(), orig.as_ref(), "Opus packet survived the round-trip");
 	}
 }
+
+/// The exporter re-stamps PCR as a dense, uniform ramp rather than one sparse sample per
+/// frame: a hardware IRD rebuilds its clock from PCR with a PLL, which needs frequent
+/// (<= 40 ms) monotonic, evenly-spaced values. Frames are 40 ms apart with a payload big
+/// enough to span many TS packets, so the 20 ms cadence must emit multiple PCRs per frame.
+#[tokio::test(start_paused = true)]
+async fn pcr_restamped_at_uniform_cadence() {
+	let mut broadcast = moq_net::Broadcast::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+
+	let vtrack = broadcast
+		.create_track(moq_net::Track::new(broadcast.unique_name(".avc3")))
+		.unwrap();
+	{
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: 0x1f,
+			inline: true,
+		});
+		cfg.container = Container::Legacy;
+		catalog.lock().video.renditions.insert(vtrack.name().to_string(), cfg);
+	}
+	let mut video = Producer::new(vtrack, HangContainer::Legacy);
+
+	// A keyframe every 40 ms, each ~4 KB so it spans ~20 TS packets. With a 20 ms PCR
+	// cadence the exporter must interpolate two PCRs across each frame.
+	let mut idr = vec![0x65u8];
+	idr.extend(std::iter::repeat_n(0xABu8, 4000));
+	let payload = annexb(&[SPS, PPS, &idr]);
+	for i in 0..6u64 {
+		video
+			.write(Frame {
+				timestamp: Timestamp::from_micros(i * 40_000).unwrap(),
+				duration: None,
+				payload: payload.clone(),
+				keyframe: true,
+			})
+			.unwrap();
+		video.finish_group().unwrap();
+	}
+	video.finish().unwrap();
+
+	let ts = drain(consumer).await;
+
+	// PCR values (27 MHz) in transport order.
+	let mut pcrs = Vec::new();
+	let mut reader = TsPacketReader::new(Cursor::new(ts.as_ref()));
+	while let Some(packet) = reader.read_ts_packet().unwrap() {
+		if let Some(pcr) = packet.adaptation_field.and_then(|af| af.pcr) {
+			pcrs.push(pcr.as_u64());
+		}
+	}
+
+	// Dense: roughly one PCR per 20 ms across ~200 ms, so well more than the 6 frames.
+	assert!(pcrs.len() >= 8, "PCR is too sparse: {} samples", pcrs.len());
+	assert!(
+		pcrs.windows(2).all(|w| w[1] > w[0]),
+		"PCR must increase monotonically: {pcrs:?}"
+	);
+	// Evenly spaced at ~20 ms (540000 in 27 MHz units), within a generous tolerance for
+	// byte-position quantization (a PCR lands on the first packet past each due tick).
+	let interval = 20_000 * 27;
+	for w in pcrs.windows(2) {
+		let delta = w[1] - w[0];
+		assert!(
+			delta.abs_diff(interval) <= interval / 3,
+			"PCR spacing {delta} is not ~{interval} (±33%)"
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #1973 (independent of the #1988 delivery-spreading PR). This is the **operative fix** for @ArielM's Sencore IRD corruption: the elementary stream was perfect, but the PCR clock was not.

The exporter wrote a single PCR per video frame, valued at the frame's authored DTS. That is too sparse (over 40 ms apart at low frame rates or under B-frame reorder) and too uneven for a hardware IRD, which has no clock of its own and rebuilds the 27 MHz system clock from the PCR values with a PLL. A jittery, gappy PCR makes the PLL hunt, so the decoder throws a cascade of TR 101 290 clock errors even though the bitstream is fine. That is what ffmpeg's `-muxrate 11M -pcr_period 20` was papering over (CBR padding makes PCR-by-byte-position a clean ramp).

## What it does

Re-stamp PCR on the PCR track: interpolate the reference clock across each frame's on-wire span, anchored on the **real decode times** of the previous and current frame, and drop a PCR whenever 20 ms of media time has elapsed.

- **Monotonic, gap-free, `<=` DTS**: the anchors are true decode times, so the ramp never jumps and never leads the frame's own DTS.
- **Uniform, `<= 40 ms`**: the fixed 20 ms cadence (matching ffmpeg's default `pcr_period`) holds repetition under the TR 101 290 limit whatever the frame rate.
- **No padding waste**: moq defines the clock in the *time* domain (it already paces delivery there), not the *byte* domain, so there is no CBR null-packet padding. This is the "moq can do better via internals" Ariel asked for.

## The interval question

Ariel raised where to source the frame interval (catalog frame rate, which WebCodecs marks optional and is often unpopulated, vs estimating from PTS deltas with buffering). This sidesteps it: the interpolation interval is just the **actual decode-time gap** between consecutive frames, which the exporter already has. No catalog frame rate, no lookahead buffering.

## Relationship to #1988

Complementary. #1988 makes *delivery* smooth (per-packet trickle); this makes the *PCR values* a clean clock. Both compose for the full IRD fix. This PR alone already improves clock density/uniformity; combined with #1988 the PCR-bearing packets also arrive evenly.

## API surface

None. No new public API; internal PCR-writing behavior only. `ts::Output` is unchanged.

## Test plan

- [x] `cargo test -p moq-mux` (new `pcr_restamped_at_uniform_cadence`: dense, monotonic, ~20 ms-spaced PCRs across multi-packet frames; all existing TS import/export roundtrips still pass byte-exact)
- [x] `cargo clippy -p moq-mux --all-targets` clean
- [ ] Not yet verified against a real IRD (Ariel to test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sv3GrsvEy1wyd2SYbApDzh)_