### PR TITLE
fix(moq-mux): settle the TS export catalog before freezing PSI

### DIFF
--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -37,7 +37,7 @@ serde = { workspace = true }
 serde_json = "1"
 serde_with = { version = "3", features = ["base64"] }
 thiserror = "2"
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "time"] }
 tracing = "0.1"
 url = "2"
 webm-iterable = "0.6"

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -43,6 +43,12 @@ const PMT_PID: u16 = 0x1000;
 const FIRST_ES_PID: u16 = 0x1001;
 /// Re-emit PAT/PMT at least this often (wall-clock of the media) for tune-in.
 const PSI_INTERVAL: Duration = Duration::from_millis(500);
+/// How long [`next`](Export::next) waits, in real time, for the catalog's track set to
+/// fill in before it freezes the program tables (PSI). The importer publishes renditions
+/// as each codec resolves (H.264 after its first keyframe's SPS, AAC after the first ADTS
+/// header), so a program's tracks appear a beat apart. Building PSI on the first snapshot
+/// would lock a partial layout (e.g. audio only). This settle window lets the rest arrive.
+const DEFAULT_CATALOG_TIMEOUT: Duration = Duration::from_millis(500);
 
 /// Subscribe to a broadcast and produce an MPEG-TS byte stream.
 ///
@@ -78,6 +84,20 @@ pub struct Export<E: CatalogExt = ()> {
 	/// up before it ever configures video. `None` until the tables are built, and for
 	/// programs with no video track (nothing to align to).
 	video_start: Option<Timestamp>,
+
+	/// How long to wait for the catalog's track set to fill in before freezing PSI. See
+	/// [`DEFAULT_CATALOG_TIMEOUT`].
+	catalog_timeout: Duration,
+	/// Real-time deadline for the catalog settle, armed on the first [`next`](Self::next)
+	/// pull. Until it passes, PSI is held even if the tracks seen so far are ready, so a
+	/// late-resolving track (e.g. video's SPS) can still join the program.
+	settle_deadline: Option<tokio::time::Instant>,
+	/// Set once [`catalog_timeout`](Self::catalog_timeout) elapses: PSI is then built from
+	/// whatever resolved, dropping (with a warning) any track whose config never arrived.
+	settle_expired: bool,
+	/// Tracks dropped at settle because their config never resolved. Kept so a later catalog
+	/// snapshot doesn't re-add them (which, after PSI is frozen, is a fatal layout change).
+	excluded: std::collections::HashSet<String>,
 }
 
 struct Track {
@@ -192,12 +212,24 @@ impl<E: CatalogExt> Export<E> {
 			psi: None,
 			last_psi: None,
 			video_start: None,
+			catalog_timeout: DEFAULT_CATALOG_TIMEOUT,
+			settle_deadline: None,
+			settle_expired: false,
+			excluded: std::collections::HashSet::new(),
 		})
 	}
 
 	/// Set the maximum buffering latency for each per-track source.
 	pub fn with_latency(mut self, latency: Duration) -> Self {
 		self.latency = latency;
+		self
+	}
+
+	/// Set how long to wait for the catalog's track set to fill in before freezing the
+	/// program tables (PSI). Defaults to 500ms. A zero timeout builds PSI as soon as the
+	/// first snapshot's tracks are ready (no settle).
+	pub fn with_catalog_timeout(mut self, timeout: Duration) -> Self {
+		self.catalog_timeout = timeout;
 		self
 	}
 
@@ -210,9 +242,35 @@ impl<E: CatalogExt> Export<E> {
 	/// keyframes and periodically for mid-stream tune-in. Returns `None` when the
 	/// broadcast ends. `duration` is always `None`: the muxer has no use for it.
 	pub async fn next(&mut self) -> anyhow::Result<Option<Frame>> {
-		kio::wait(|waiter| self.poll_next(waiter)).await
+		// Arm the catalog settle window on the first pull. Until it elapses, `poll_next` holds
+		// PSI so a late-resolving track (video's SPS lagging audio) can still join the program.
+		if self.settle_deadline.is_none() {
+			self.settle_deadline = Some(tokio::time::Instant::now() + self.catalog_timeout);
+		}
+
+		loop {
+			// While still settling, race making progress against the deadline. `poll_next`
+			// yields nothing before PSI, so the winner is either end-of-stream/error or the
+			// timer. A zero timeout leaves the deadline already past, so PSI builds at once.
+			if self.psi.is_none() && !self.settle_expired {
+				let deadline = self.settle_deadline.expect("settle deadline armed above");
+				tokio::select! {
+					biased;
+					result = kio::wait(|waiter| self.poll_next(waiter)) => return result,
+					_ = tokio::time::sleep_until(deadline) => {
+						self.settle_expired = true;
+						continue; // re-poll: PSI now freezes from whatever resolved
+					}
+				}
+			}
+
+			return kio::wait(|waiter| self.poll_next(waiter)).await;
+		}
 	}
 
+	/// Poll for the next muxed frame. Prefer [`next`](Self::next), which also drives the
+	/// catalog settle timer; a direct poller holds PSI until [`next`](Self::next) marks the
+	/// settle window elapsed (or must advance it itself).
 	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<anyhow::Result<Option<Frame>>> {
 		// 1. Drain catalog updates, discovering the track layout.
 		while let Some(catalog) = self.catalog.as_mut() {
@@ -277,12 +335,26 @@ impl<E: CatalogExt> Export<E> {
 				}
 				return Poll::Pending;
 			}
+			// Hold PSI until the catalog settle window elapses (see `settle_deadline`) so a
+			// track that resolves a beat later (video's SPS lagging audio) still joins the
+			// program instead of being locked out of a frozen PMT. `next` wakes us at the
+			// deadline; a zero timeout skips the wait.
+			if !self.settle_expired {
+				return Poll::Pending;
+			}
+			// Window elapsed: give up on any track whose codec config never resolved, dropping
+			// it with a warning so it neither blocks the program nor changes the layout later.
+			self.drop_unready_tracks();
+			if self.tracks.is_empty() {
+				if self.catalog.is_none() {
+					return Poll::Ready(Ok(None));
+				}
+				return Poll::Pending;
+			}
 			if !self.header_ready() || !self.video_ready() {
-				// Hold all output (tables and audio alike) until codec configs resolve
-				// and, when the program has a video rendition, its first keyframe is
-				// buffered: the stream must begin on that keyframe so the in-band
-				// parameter sets lead it. An audio-only program has nothing to wait for.
-				// If every track finished without producing a config, it can't be muxed.
+				// Every remaining track has its config; wait only for a video track to buffer
+				// its first keyframe, so the stream begins on it and the in-band parameter sets
+				// lead. An audio-only program has nothing to wait for.
 				if self.catalog.is_none() && self.tracks.values().all(|t| t.finished) {
 					return Poll::Ready(Ok(None));
 				}
@@ -342,6 +414,10 @@ impl<E: CatalogExt> Export<E> {
 				active.insert(name.clone(), ());
 			}
 		}
+
+		// Never resurrect a track dropped at settle: re-adding it after PSI is frozen would be
+		// a fatal layout change, and it already timed out once.
+		active.retain(|name, _| !self.excluded.contains(name));
 
 		// The program tables are written once; reject layout changes afterwards.
 		if self.psi.is_some() {
@@ -477,6 +553,24 @@ impl<E: CatalogExt> Export<E> {
 				dts_reserve,
 			},
 		);
+	}
+
+	/// Drop tracks whose codec config never resolved within the settle window. Their config
+	/// can't be muxed and, once PSI is frozen, can't join the program, so exclude them (with a
+	/// warning) rather than block the whole output on a stuck track. Recorded in `excluded` so
+	/// a later catalog snapshot doesn't re-add them.
+	fn drop_unready_tracks(&mut self) {
+		let unready: Vec<String> = self
+			.tracks
+			.iter()
+			.filter(|(_, track)| !track.source.header_ready())
+			.map(|(name, _)| name.clone())
+			.collect();
+		for name in unready {
+			tracing::warn!(track = %name, "codec config not resolved within the catalog timeout; dropping from the TS program");
+			self.tracks.remove(&name);
+			self.excluded.insert(name);
+		}
 	}
 
 	/// Header is ready when every track's [`ExportSource`] has resolved its

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -85,6 +85,158 @@ fn assert_packet_aligned(ts: &[u8]) {
 	);
 }
 
+/// Regression for moq-dev/moq#1979: the exporter must not freeze its PSI on the first
+/// (partial) catalog snapshot. AAC registers its rendition on the first PES while H.264 waits
+/// for the first keyframe's SPS, so an audio-only catalog can reach the exporter first. The
+/// settle window holds the program tables open until the late video rendition joins.
+#[tokio::test(start_paused = true)]
+async fn export_settles_before_freezing_psi() {
+	let mut broadcast = moq_net::Broadcast::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog =
+		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+
+	// Audio resolves first.
+	let atrack = broadcast
+		.create_track(moq_net::Track::new(broadcast.unique_name(".aac")))
+		.unwrap();
+	{
+		let mut cfg = AudioConfig::new(AAC { profile: 2 }, 48_000, 2);
+		cfg.container = Container::Legacy;
+		catalog.lock().audio.renditions.insert(atrack.name().to_string(), cfg);
+	}
+	let mut audio = Producer::new(atrack, HangContainer::Legacy);
+	audio
+		.write(Frame {
+			timestamp: Timestamp::from_millis(0).unwrap(),
+			duration: None,
+			payload: Bytes::from_static(&[0xAAu8; 16]),
+			keyframe: true,
+		})
+		.unwrap();
+	audio.finish_group().unwrap();
+
+	let mut exporter = Export::with_ts(consumer, crate::catalog::CatalogFormat::Hang).unwrap();
+
+	// Only audio has resolved and the settle window is still open: the exporter must hold PSI
+	// rather than freeze an audio-only program.
+	match tokio::time::timeout(std::time::Duration::from_millis(100), exporter.next()).await {
+		Err(_) => {} // still settling, as expected
+		Ok(other) => panic!("exporter must hold PSI during the settle window, got {other:?}"),
+	}
+
+	// Video resolves before the window closes.
+	let vtrack = broadcast
+		.create_track(moq_net::Track::new(broadcast.unique_name(".avc3")))
+		.unwrap();
+	{
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: 0x1f,
+			inline: true,
+		});
+		cfg.container = Container::Legacy;
+		catalog.lock().video.renditions.insert(vtrack.name().to_string(), cfg);
+	}
+	let mut video = Producer::new(vtrack, HangContainer::Legacy);
+	let mut idr = vec![0x65u8];
+	idr.extend(std::iter::repeat_n(0xAB, 16));
+	video
+		.write(Frame {
+			timestamp: Timestamp::from_millis(0).unwrap(),
+			duration: None,
+			payload: annexb(&[SPS, PPS, &idr]),
+			keyframe: true,
+		})
+		.unwrap();
+	video.finish_group().unwrap();
+	audio.finish().unwrap();
+	video.finish().unwrap();
+
+	let ts = drain_with(exporter).await;
+	assert_packet_aligned(&ts);
+
+	// PSI advertises both streams: the settle window absorbed the late video rendition.
+	let mut reader = TsPacketReader::new(Cursor::new(ts.as_ref()));
+	let mut checked = false;
+	while let Some(packet) = reader.read_ts_packet().unwrap() {
+		if let Some(TsPayload::Pmt(pmt)) = packet.payload {
+			assert_eq!(pmt.es_info.len(), 2, "PMT must advertise both tracks");
+			checked = true;
+			break;
+		}
+	}
+	assert!(checked, "missing PMT");
+}
+
+/// When a declared track's config never resolves within the settle window, the exporter drops
+/// it (with a warning) and freezes PSI on the tracks that did resolve, rather than stalling on
+/// a track that never arrives.
+#[tokio::test(start_paused = true)]
+async fn export_drops_track_that_never_resolves() {
+	let mut broadcast = moq_net::Broadcast::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog =
+		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+
+	// Audio resolves.
+	let atrack = broadcast
+		.create_track(moq_net::Track::new(broadcast.unique_name(".aac")))
+		.unwrap();
+	{
+		let mut cfg = AudioConfig::new(AAC { profile: 2 }, 48_000, 2);
+		cfg.container = Container::Legacy;
+		catalog.lock().audio.renditions.insert(atrack.name().to_string(), cfg);
+	}
+	let mut audio = Producer::new(atrack, HangContainer::Legacy);
+	audio
+		.write(Frame {
+			timestamp: Timestamp::from_millis(0).unwrap(),
+			duration: None,
+			payload: Bytes::from_static(&[0xAAu8; 16]),
+			keyframe: true,
+		})
+		.unwrap();
+	audio.finish_group().unwrap();
+
+	// A video rendition is declared, but its track never delivers a keyframe (no SPS), so its
+	// avc3 config never resolves.
+	let vtrack = broadcast
+		.create_track(moq_net::Track::new(broadcast.unique_name(".avc3")))
+		.unwrap();
+	{
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: 0x1f,
+			inline: true,
+		});
+		cfg.container = Container::Legacy;
+		catalog.lock().video.renditions.insert(vtrack.name().to_string(), cfg);
+	}
+	let mut video = Producer::new(vtrack, HangContainer::Legacy);
+	video.finish().unwrap();
+	audio.finish().unwrap();
+
+	let ts = drain_with(Export::with_ts(consumer, crate::catalog::CatalogFormat::Hang).unwrap()).await;
+	assert_packet_aligned(&ts);
+
+	// PSI advertises only the audio stream: the stuck video track was dropped after the window.
+	let mut reader = TsPacketReader::new(Cursor::new(ts.as_ref()));
+	let mut checked = false;
+	while let Some(packet) = reader.read_ts_packet().unwrap() {
+		if let Some(TsPayload::Pmt(pmt)) = packet.payload {
+			assert_eq!(pmt.es_info.len(), 1, "PMT must advertise only the resolved audio track");
+			checked = true;
+			break;
+		}
+	}
+	assert!(checked, "missing PMT");
+}
+
 #[tokio::test(start_paused = true)]
 async fn export_aac_roundtrip() {
 	let mut broadcast = moq_net::Broadcast::new().produce();


### PR DESCRIPTION
## Summary

Fixes moq-dev/moq#1979: MPEG-TS exporter PSI race. The exporter emits its PAT/PMT **once** and then freezes the track layout, but the importer publishes catalog renditions **incrementally** as each codec resolves its config (H.264 after the first keyframe's SPS, AAC after the first ADTS header). When audio resolved before video, the exporter locked PSI on an audio-only layout, then hard-failed once video's rendition arrived (`TS track layout changed ... added`).

Fixed on the **consumer side**, where the constraint actually lives (the exporter is the only thing that can't tolerate a partial layout). A MoQ broadcast has no "track set complete" signal — completeness is only knowable by waiting — so the exporter waits a short **settle window** before freezing PSI, then commits to whatever resolved.

## Behavior

- The exporter waits `catalog_timeout` (default **500ms**, `Export::with_catalog_timeout(..)`) of real time after it starts pulling before it freezes PSI, absorbing catalog updates in the meantime so a late-resolving track (video's SPS lagging audio) still joins the program.
- When the window elapses, it builds PSI from whatever resolved and **drops, with a warning, any declared track whose config never arrived** — so a stuck track can't stall output or change the layout after the tables are frozen. Dropped tracks are remembered so a later catalog snapshot can't re-add one and trip the post-PSI layout-change guard.
- A zero timeout preserves the old aggressive behavior (freeze on the first ready snapshot).

## Why here, not the importer / a wire field

Earlier iterations put the fix on the producer side — a wire `expected_tracks` count (#1980) or a catalog-publish hold. Both push completeness signaling onto the shared/generic catalog. But a MoQ broadcast deliberately has no total-track signal (the relay is media-agnostic), and the only consumer that needs completeness is the TS muxer — so a bounded wait *there* keeps `Producer`, the wire, and the catalog format all untouched, and works for any source, not just TS→moq→TS. The trade-off is a fixed startup delay bounded by `catalog_timeout` and a timer.

## Implementation note

`kio` has no wall-clock wake, so `next()` races `kio::wait` against a `tokio::time::sleep` deadline (adds the `tokio` `time` feature). The settle timer is driven by `next()`; `poll_next` documents that.

## Testing

- `export_settles_before_freezing_psi`: audio resolves first; exporter holds PSI through the window; video joins; the re-parsed PMT advertises **both** streams.
- `export_drops_track_that_never_resolves`: a declared video track never delivers a keyframe; after the window the exporter drops it (warning) and emits an audio-only program instead of stalling.
- Full `moq-mux` suite green; `fmt` / `clippy --all-targets` / `rustdoc` clean via nix; `moq-cli` compiles. (Pre-existing unrelated rustdoc HTML-tag warnings in `mkv/export.rs` are not touched.)

## Cross-package sync

None: no `moq-net` wire change, no `hang` catalog/container format change. New public surface is one additive builder (`Export::with_catalog_timeout`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)