### PR TITLE
feat(moq-mux): windowed TS export with dense uniform PCR (supersedes #1988, #1989)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,6 +3729,7 @@ name = "kio"
 version = "0.4.1"
 dependencies = [
  "smallvec",
+ "tokio",
 ]
 
 [[package]]

--- a/rs/kio/Cargo.toml
+++ b/rs/kio/Cargo.toml
@@ -15,5 +15,14 @@ categories = ["asynchronous", "concurrency"]
 [lib]
 doctest = false
 
+[features]
+# Opt-in `time::Timer`, a poll-driven wall-clock wait backed by `tokio::time`. Off by
+# default so kio stays runtime-free; enable it when driving `poll_*` functions on tokio.
+tokio = ["dep:tokio"]
+
 [dependencies]
 smallvec = "1.15"
+tokio = { workspace = true, features = ["time"], optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "test-util", "time"] }

--- a/rs/kio/src/lib.rs
+++ b/rs/kio/src/lib.rs
@@ -18,6 +18,9 @@ mod future;
 mod producer;
 mod weak;
 
+#[cfg(feature = "tokio")]
+pub mod tokio;
+
 #[cfg(test)]
 mod tests;
 

--- a/rs/kio/src/tokio.rs
+++ b/rs/kio/src/tokio.rs
@@ -1,0 +1,49 @@
+//! kio integration for `tokio`.
+//!
+//! Behind the `tokio` feature. Wraps a [`tokio::time::Sleep`] so a `poll_*` function can
+//! drive it against a [`Waiter`], keeping the rest of kio runtime-free.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::Waiter;
+
+/// A `tokio` sleep driven by kio's poll model.
+///
+/// Construct it once for a deadline (`Sleep::new(tokio::time::sleep_until(deadline))`), then
+/// [`poll`](Self::poll) it against a [`Waiter`] each time your `poll_*` runs. Reading the
+/// clock through `tokio::time` means a `tokio::time::pause()` test advances it in step.
+pub struct Sleep {
+	inner: Pin<Box<::tokio::time::Sleep>>,
+}
+
+impl Sleep {
+	/// Wrap a `tokio` sleep future.
+	pub fn new(sleep: ::tokio::time::Sleep) -> Self {
+		Self { inner: Box::pin(sleep) }
+	}
+
+	/// Poll the sleep, registering `waiter` so the poll re-fires once it elapses.
+	pub fn poll(&mut self, waiter: &Waiter) -> Poll<()> {
+		let mut cx = Context::from_waker(waiter.waker());
+		self.inner.as_mut().poll(&mut cx)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use ::tokio::time::Instant;
+	use std::time::Duration;
+
+	#[::tokio::test(start_paused = true)]
+	async fn sleep_fires_at_its_deadline() {
+		let deadline = Instant::now() + Duration::from_millis(50);
+		let mut sleep = Sleep::new(::tokio::time::sleep_until(deadline));
+		// `crate::wait` drives the poll; under paused time tokio auto-advances to the sleep,
+		// so this resolves at the deadline rather than blocking for real.
+		crate::wait(|waiter| sleep.poll(waiter)).await;
+		assert!(Instant::now() >= deadline, "returned before the deadline");
+	}
+}

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -42,6 +42,14 @@ impl Waiter {
 	pub fn register(&self, list: &mut WaiterList) {
 		list.register(self);
 	}
+
+	/// The underlying task [`Waker`], for driving a foreign future inside a `poll_*`
+	/// function. Build a [`Context`] from it and poll the future (e.g. a timer) so that
+	/// future re-wakes this poll when it's ready, without kio itself taking a runtime
+	/// dependency.
+	pub fn waker(&self) -> &Waker {
+		&self.waker
+	}
 }
 
 /// A list of weak wakers waiting for notification.

--- a/rs/moq-cli/src/subscribe.rs
+++ b/rs/moq-cli/src/subscribe.rs
@@ -168,7 +168,7 @@ impl Subscribe {
 			// and follows the live edge with up to `--max-latency` of buffer, so a retained
 			// broadcast drains in real time while a live source stays near the edge.
 			if pace {
-				tokio::time::sleep_until(frame.pace.into()).await;
+				tokio::time::sleep_until(frame.pace).await;
 			}
 
 			stdout.write_all(&frame.payload).await?;

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -22,7 +22,7 @@ base64 = "0.22"
 bytes = "1"
 h264-parser = { version = "0.4.0" }
 hang = { workspace = true }
-kio = { workspace = true }
+kio = { workspace = true, features = ["tokio"] }
 memchr = "2"
 moq-json = { workspace = true }
 moq-loc = { workspace = true }

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -37,7 +37,7 @@ serde = { workspace = true }
 serde_json = "1"
 serde_with = { version = "3", features = ["base64"] }
 thiserror = "2"
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "time"] }
 tracing = "0.1"
 url = "2"
 webm-iterable = "0.6"

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -28,7 +28,7 @@ pub mod mkv;
 pub mod ts;
 
 pub use consumer::Consumer;
-pub(crate) use pace::{Pacer, Timer};
+pub(crate) use pace::Pacer;
 pub use producer::Producer;
 pub(crate) use source::ExportSource;
 

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -28,7 +28,7 @@ pub mod mkv;
 pub mod ts;
 
 pub use consumer::Consumer;
-pub(crate) use pace::Pacer;
+pub(crate) use pace::{Pacer, Timer};
 pub use producer::Producer;
 pub(crate) use source::ExportSource;
 

--- a/rs/moq-mux/src/container/pace.rs
+++ b/rs/moq-mux/src/container/pace.rs
@@ -16,9 +16,6 @@ use super::Timestamp;
 /// stored tokio sleep against the poll's [`kio::Waiter`], so the poll re-fires when the
 /// deadline passes. moq-mux already depends on tokio, so this keeps the wait local
 /// instead of pushing a runtime dependency into kio.
-// Wired into the windowed TS exporter's `poll_next`; until that lands only the unit test
-// constructs it, so allow the transitional dead code.
-#[allow(dead_code)]
 #[derive(Default)]
 pub(crate) struct Timer {
 	/// The armed sleep, kept alive across polls so its timer registration persists.
@@ -27,7 +24,6 @@ pub(crate) struct Timer {
 	until: Option<Instant>,
 }
 
-#[allow(dead_code)]
 impl Timer {
 	/// Poll until `after`. Returns `Ready(now)` once the clock reaches `after`; otherwise
 	/// arms (or re-arms) against `waiter` and returns `Pending`. Re-arms only when `after`

--- a/rs/moq-mux/src/container/pace.rs
+++ b/rs/moq-mux/src/container/pace.rs
@@ -3,7 +3,9 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+use tokio::time::Instant;
 
 use super::Timestamp;
 
@@ -31,24 +33,23 @@ impl Timer {
 	/// arms (or re-arms) against `waiter` and returns `Pending`. Re-arms only when `after`
 	/// changes, so repeated polls for one deadline reuse a single timer registration.
 	///
-	/// Reads the clock through `tokio::time` (not `std`), so a `tokio::time::pause()` test
-	/// advances the deadline check and the sleep together.
+	/// Reads the clock through `tokio::time`, so a `tokio::time::pause()` test advances the
+	/// deadline check and the sleep together.
 	pub(crate) fn poll(&mut self, after: Instant, waiter: &kio::Waiter) -> Poll<Instant> {
-		let deadline = tokio::time::Instant::from_std(after);
-		let now = tokio::time::Instant::now();
-		if now >= deadline {
+		let now = Instant::now();
+		if now >= after {
 			self.disarm();
-			return Poll::Ready(now.into_std());
+			return Poll::Ready(now);
 		}
 		if self.until != Some(after) {
 			self.until = Some(after);
-			self.sleep = Some(Box::pin(tokio::time::sleep_until(deadline)));
+			self.sleep = Some(Box::pin(tokio::time::sleep_until(after)));
 		}
 		let mut cx = Context::from_waker(waiter.waker());
 		match self.sleep.as_mut().unwrap().as_mut().poll(&mut cx) {
 			Poll::Ready(()) => {
 				self.disarm();
-				Poll::Ready(tokio::time::Instant::now().into_std())
+				Poll::Ready(Instant::now())
 			}
 			Poll::Pending => Poll::Pending,
 		}
@@ -143,9 +144,7 @@ mod tests {
 
 	#[tokio::test(start_paused = true)]
 	async fn timer_fires_at_its_deadline() {
-		// Snapshot the (paused) tokio clock as a std instant; the Timer reads tokio time,
-		// so `start` and the deadline live on the same clock the test advances.
-		let start = tokio::time::Instant::now().into_std();
+		let start = Instant::now();
 		let deadline = start + Duration::from_millis(50);
 		let mut timer = Timer::default();
 		// `kio::wait` drives the poll; under paused time tokio auto-advances to the armed

--- a/rs/moq-mux/src/container/pace.rs
+++ b/rs/moq-mux/src/container/pace.rs
@@ -1,63 +1,10 @@
 //! Pace media output on a media clock, following the live edge.
 
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 use std::time::Duration;
 
 use tokio::time::Instant;
 
 use super::Timestamp;
-
-/// A one-shot wall-clock timer wired into kio's poll model.
-///
-/// [`Pacer`] answers "at what wall-clock instant is this media due"; `Timer` is the
-/// other half, letting a `poll_*` function actually wait for that instant. It drives a
-/// stored tokio sleep against the poll's [`kio::Waiter`], so the poll re-fires when the
-/// deadline passes. moq-mux already depends on tokio, so this keeps the wait local
-/// instead of pushing a runtime dependency into kio.
-#[derive(Default)]
-pub(crate) struct Timer {
-	/// The armed sleep, kept alive across polls so its timer registration persists.
-	sleep: Option<Pin<Box<tokio::time::Sleep>>>,
-	/// The instant `sleep` targets, so we only re-arm when it moves.
-	until: Option<Instant>,
-}
-
-impl Timer {
-	/// Poll until `after`. Returns `Ready(now)` once the clock reaches `after`; otherwise
-	/// arms (or re-arms) against `waiter` and returns `Pending`. Re-arms only when `after`
-	/// changes, so repeated polls for one deadline reuse a single timer registration.
-	///
-	/// Reads the clock through `tokio::time`, so a `tokio::time::pause()` test advances the
-	/// deadline check and the sleep together.
-	pub(crate) fn poll(&mut self, after: Instant, waiter: &kio::Waiter) -> Poll<Instant> {
-		let now = Instant::now();
-		if now >= after {
-			self.disarm();
-			return Poll::Ready(now);
-		}
-		if self.until != Some(after) {
-			self.until = Some(after);
-			self.sleep = Some(Box::pin(tokio::time::sleep_until(after)));
-		}
-		let mut cx = Context::from_waker(waiter.waker());
-		match self.sleep.as_mut().unwrap().as_mut().poll(&mut cx) {
-			Poll::Ready(()) => {
-				self.disarm();
-				Poll::Ready(Instant::now())
-			}
-			Poll::Pending => Poll::Pending,
-		}
-	}
-
-	/// Drop the armed sleep. Called once the deadline fires so a later poll for a new
-	/// deadline starts clean.
-	fn disarm(&mut self) {
-		self.sleep = None;
-		self.until = None;
-	}
-}
 
 /// Maps media (decode) timestamps onto the wall clock so a caller can emit frames at
 /// the source's real-time rate while bounding how far behind the live edge it falls.
@@ -136,17 +83,6 @@ mod tests {
 
 	fn ms(m: u64) -> Timestamp {
 		Timestamp::from_micros(m * 1_000).unwrap()
-	}
-
-	#[tokio::test(start_paused = true)]
-	async fn timer_fires_at_its_deadline() {
-		let start = Instant::now();
-		let deadline = start + Duration::from_millis(50);
-		let mut timer = Timer::default();
-		// `kio::wait` drives the poll; under paused time tokio auto-advances to the armed
-		// sleep, so this resolves at the deadline rather than blocking for real.
-		let fired = kio::wait(|waiter| timer.poll(deadline, waiter)).await;
-		assert!(fired >= deadline, "fired {fired:?} before deadline {deadline:?}");
 	}
 
 	#[test]

--- a/rs/moq-mux/src/container/pace.rs
+++ b/rs/moq-mux/src/container/pace.rs
@@ -1,8 +1,66 @@
 //! Pace media output on a media clock, following the live edge.
 
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
 use super::Timestamp;
+
+/// A one-shot wall-clock timer wired into kio's poll model.
+///
+/// [`Pacer`] answers "at what wall-clock instant is this media due"; `Timer` is the
+/// other half, letting a `poll_*` function actually wait for that instant. It drives a
+/// stored tokio sleep against the poll's [`kio::Waiter`], so the poll re-fires when the
+/// deadline passes. moq-mux already depends on tokio, so this keeps the wait local
+/// instead of pushing a runtime dependency into kio.
+// Wired into the windowed TS exporter's `poll_next`; until that lands only the unit test
+// constructs it, so allow the transitional dead code.
+#[allow(dead_code)]
+#[derive(Default)]
+pub(crate) struct Timer {
+	/// The armed sleep, kept alive across polls so its timer registration persists.
+	sleep: Option<Pin<Box<tokio::time::Sleep>>>,
+	/// The instant `sleep` targets, so we only re-arm when it moves.
+	until: Option<Instant>,
+}
+
+#[allow(dead_code)]
+impl Timer {
+	/// Poll until `after`. Returns `Ready(now)` once the clock reaches `after`; otherwise
+	/// arms (or re-arms) against `waiter` and returns `Pending`. Re-arms only when `after`
+	/// changes, so repeated polls for one deadline reuse a single timer registration.
+	///
+	/// Reads the clock through `tokio::time` (not `std`), so a `tokio::time::pause()` test
+	/// advances the deadline check and the sleep together.
+	pub(crate) fn poll(&mut self, after: Instant, waiter: &kio::Waiter) -> Poll<Instant> {
+		let deadline = tokio::time::Instant::from_std(after);
+		let now = tokio::time::Instant::now();
+		if now >= deadline {
+			self.disarm();
+			return Poll::Ready(now.into_std());
+		}
+		if self.until != Some(after) {
+			self.until = Some(after);
+			self.sleep = Some(Box::pin(tokio::time::sleep_until(deadline)));
+		}
+		let mut cx = Context::from_waker(waiter.waker());
+		match self.sleep.as_mut().unwrap().as_mut().poll(&mut cx) {
+			Poll::Ready(()) => {
+				self.disarm();
+				Poll::Ready(tokio::time::Instant::now().into_std())
+			}
+			Poll::Pending => Poll::Pending,
+		}
+	}
+
+	/// Drop the armed sleep. Called once the deadline fires so a later poll for a new
+	/// deadline starts clean.
+	fn disarm(&mut self) {
+		self.sleep = None;
+		self.until = None;
+	}
+}
 
 /// Maps media (decode) timestamps onto the wall clock so a caller can emit frames at
 /// the source's real-time rate while bounding how far behind the live edge it falls.
@@ -81,6 +139,19 @@ mod tests {
 
 	fn ms(m: u64) -> Timestamp {
 		Timestamp::from_micros(m * 1_000).unwrap()
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn timer_fires_at_its_deadline() {
+		// Snapshot the (paused) tokio clock as a std instant; the Timer reads tokio time,
+		// so `start` and the deadline live on the same clock the test advances.
+		let start = tokio::time::Instant::now().into_std();
+		let deadline = start + Duration::from_millis(50);
+		let mut timer = Timer::default();
+		// `kio::wait` drives the poll; under paused time tokio auto-advances to the armed
+		// sleep, so this resolves at the deadline rather than blocking for real.
+		let fired = kio::wait(|waiter| timer.poll(deadline, waiter)).await;
+		assert!(fired >= deadline, "fired {fired:?} before deadline {deadline:?}");
 	}
 
 	#[test]

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -15,7 +15,9 @@
 
 use std::collections::HashMap;
 use std::task::Poll;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+
+use tokio::time::Instant;
 
 use anyhow::Context;
 use bytes::Bytes;

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -36,7 +36,7 @@ use mpeg2ts::ts::{
 use crate::catalog::hang::{Catalog, CatalogExt};
 use crate::catalog::{CatalogFormat, Stream};
 use crate::codec::annexb;
-use crate::container::{ExportSource, Frame, Pacer, Timer, Timestamp};
+use crate::container::{ExportSource, Frame, Pacer, Timestamp};
 
 use super::adts;
 use super::catalog;
@@ -96,9 +96,9 @@ pub struct Export<E: CatalogExt = ()> {
 
 	/// The in-progress output window, or `None` before the first frame is placed.
 	window: Option<Window>,
-	/// Wall-clock timer for the live-edge case: when a track blocks mid-window, wait for
-	/// its media or for the window's deadline (then flush a filler), rather than stalling.
-	timer: Timer,
+	/// The live-edge wait: a sleep to the current window's deadline, constructed once when a
+	/// track blocks mid-window and dropped when the window flushes. `None` when not waiting.
+	sleep: Option<kio::tokio::Sleep>,
 }
 
 struct Track {
@@ -266,7 +266,7 @@ impl<E: CatalogExt> Export<E> {
 			last_psi: None,
 			video_start: None,
 			window: None,
-			timer: Timer::default(),
+			sleep: None,
 		})
 	}
 
@@ -396,12 +396,18 @@ impl<E: CatalogExt> Export<E> {
 		}
 
 		// A track is blocking at the live edge. Wait for its media or, once the window's
-		// wall-clock deadline passes, flush what we have (a filler PCR if it's empty).
+		// wall-clock deadline passes, flush what we have (a filler PCR if it's empty). The
+		// sleep is built once for this window's deadline and reused until the window flushes.
 		if let Some(deadline) = self.window_deadline() {
-			match self.timer.poll(deadline, waiter) {
-				Poll::Ready(_) => return Poll::Ready(Ok(Some(self.flush_window()?))),
-				Poll::Pending => return Poll::Pending,
+			let ready = self
+				.sleep
+				.get_or_insert_with(|| kio::tokio::Sleep::new(tokio::time::sleep_until(deadline)))
+				.poll(waiter)
+				.is_ready();
+			if ready {
+				return Poll::Ready(Ok(Some(self.flush_window()?)));
 			}
+			return Poll::Pending;
 		}
 
 		Poll::Pending
@@ -476,9 +482,11 @@ impl<E: CatalogExt> Export<E> {
 		Ok(())
 	}
 
-	/// Emit the current window and open the next one on the continuous grid.
+	/// Emit the current window and open the next one on the continuous grid. Drops any
+	/// live-edge sleep, whose deadline belonged to the window just flushed.
 	fn flush_window(&mut self) -> anyhow::Result<Output> {
 		let window = self.window.take().context("no window to flush")?;
+		self.sleep = None;
 		let output = Output {
 			payload: Bytes::from(window.buf),
 			pace: window.pace,
@@ -490,6 +498,7 @@ impl<E: CatalogExt> Export<E> {
 	/// Emit the trailing window at end of stream, or `None` when it holds only its PCR: with
 	/// nothing left to bridge to, an empty window is not worth a filler.
 	fn flush_final(&mut self) -> Option<Output> {
+		self.sleep = None;
 		let window = self.window.take()?;
 		window.has_media.then(|| Output {
 			payload: Bytes::from(window.buf),

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -1,10 +1,12 @@
 //! MPEG-TS muxer.
 //!
-//! [`Export`] subscribes to a MoQ broadcast and produces MPEG-TS, yielding one
-//! [`Frame`] per media frame: PAT/PMT program tables followed by one PES packet,
-//! packetized into 188-byte TS packets. Each frame keeps its media timestamp so
-//! the caller can pace delivery on the media clock. Video is carried as Annex-B,
-//! audio as ADTS AAC.
+//! [`Export`] subscribes to a MoQ broadcast and produces MPEG-TS in fixed ~20 ms
+//! [`Output`] windows on the media clock, each led by a PCR so the reference clock
+//! stays dense and uniform for a hardware decoder's PLL, regardless of frame rate.
+//! PAT/PMT ride the windows at keyframes and periodically; a window with no media is
+//! just its PCR, bridging a low-frame-rate gap without CBR padding. Each window carries
+//! the wall-clock instant it's due so the caller can pace delivery. Video is carried as
+//! Annex-B, audio as ADTS AAC.
 //!
 //! Video flows through [`ExportSource`], which normalizes every H.264/H.265
 //! source to length-prefixed NALU plus a resolved avcC/hvcC (parsing in-band
@@ -34,7 +36,7 @@ use mpeg2ts::ts::{
 use crate::catalog::hang::{Catalog, CatalogExt};
 use crate::catalog::{CatalogFormat, Stream};
 use crate::codec::annexb;
-use crate::container::{ExportSource, Frame, Pacer, Timestamp};
+use crate::container::{ExportSource, Frame, Pacer, Timer, Timestamp};
 
 use super::adts;
 use super::catalog;
@@ -45,15 +47,17 @@ const PMT_PID: u16 = 0x1000;
 const FIRST_ES_PID: u16 = 0x1001;
 /// Re-emit PAT/PMT at least this often (wall-clock of the media) for tune-in.
 const PSI_INTERVAL: Duration = Duration::from_millis(500);
+/// Output-window cadence: emit a window (carrying at least a PCR) this often on the media
+/// clock. 20 ms matches ffmpeg's default `pcr_period` and stays under the 40 ms DVB
+/// TR 101 290 repetition limit, so a hardware decoder's clock-recovery PLL stays locked.
+const WINDOW: Duration = Duration::from_millis(20);
 
 /// Subscribe to a broadcast and produce an MPEG-TS byte stream.
 ///
-/// Use [`next`](Self::next) to pull one [`Output`] per media frame: its `payload`
-/// is the TS packets, stamped with the source `timestamp` and `keyframe` flag,
-/// plus a [`pace`](Output::pace) instant on the decode clock for real-time output.
-/// The leading PAT/PMT rides on the first frame (so it inherits a real
-/// timestamp), and is re-emitted at video keyframes and periodically for
-/// mid-stream tune-in. Returns `None` when the broadcast ends.
+/// Use [`next`](Self::next) to pull one [`Output`] per ~20 ms window: its `payload` is the
+/// window's TS packets (a leading PCR, then any media), plus a [`pace`](Output::pace)
+/// instant on the decode clock for real-time output. PAT/PMT ride the windows at video
+/// keyframes and periodically for mid-stream tune-in. Returns `None` when the broadcast ends.
 pub struct Export<E: CatalogExt = ()> {
 	broadcast: moq_net::BroadcastConsumer,
 	catalog: Option<crate::catalog::Consumer<E>>,
@@ -89,11 +93,17 @@ pub struct Export<E: CatalogExt = ()> {
 	/// up before it ever configures video. `None` until the tables are built, and for
 	/// programs with no video track (nothing to align to).
 	video_start: Option<Timestamp>,
+
+	/// The in-progress output window, or `None` before the first frame is placed.
+	window: Option<Window>,
+	/// Wall-clock timer for the live-edge case: when a track blocks mid-window, wait for
+	/// its media or for the window's deadline (then flush a filler), rather than stalling.
+	timer: Timer,
 }
 
 struct Track {
 	source: ExportSource,
-	pending: Option<Frame>,
+	pending: Option<PendingFrame>,
 	finished: bool,
 	pid: u16,
 	kind: Kind,
@@ -107,6 +117,18 @@ struct Track {
 	/// from the catalog `jitter` (the reorder depth) so it is large enough for `DTS <= PTS`,
 	/// or [`DEFAULT_DTS_RESERVE`] when the catalog declares none. Only video uses it.
 	dts_reserve: u64,
+}
+
+/// A pulled frame with its decode clock resolved, so windowing keys on the monotonic
+/// decode time while the PES still carries the original PTS.
+struct PendingFrame {
+	frame: Frame,
+	/// Decode-clock time: the authored DTS for reordered video, else the PTS. Its window
+	/// (`[start, end)`) and the ordering across tracks key on this, not the PTS.
+	decode: Timestamp,
+	/// Authored DTS in continuous 90 kHz ticks when it differs from the PTS (B-frame video),
+	/// so the PES carries both. `None` when DTS == PTS.
+	dts: Option<u64>,
 }
 
 #[derive(Clone)]
@@ -140,31 +162,43 @@ enum Kind {
 	},
 }
 
-/// One muxed MPEG-TS frame produced by [`Export::next`].
+/// One ~20 ms window of MPEG-TS produced by [`Export::next`].
 ///
-/// `payload` is the TS packets (188-byte aligned) for a single media frame.
+/// The exporter emits fixed windows on the media clock rather than one output per
+/// media frame. Each window carries the TS packets (188-byte aligned) for whatever
+/// media falls in it, led by a PCR so the reference clock stays dense and uniform
+/// (under the 40 ms TR 101 290 limit) regardless of frame rate. A window with no
+/// media is just that PCR packet, bridging a low-frame-rate gap without CBR padding.
 #[non_exhaustive]
 pub struct Output {
-	/// The TS packets for one media frame.
+	/// The TS packets for this window: a leading PCR packet, then any media.
 	pub payload: Bytes,
 
-	/// Source presentation timestamp.
-	pub timestamp: Timestamp,
-
-	/// Whether this frame is a keyframe.
-	pub keyframe: bool,
-
-	/// Wall-clock instant this frame is due, paced on the decode clock (DTS) so a
-	/// reordered (B-frame) stream paces evenly rather than on its non-monotonic
-	/// presentation timestamps.
+	/// Wall-clock instant this window is due, paced on the decode clock so a reordered
+	/// (B-frame) stream paces evenly rather than on its non-monotonic presentation
+	/// timestamps.
 	///
 	/// The muxer follows the live edge: it holds at most the configured latency
 	/// ([`with_latency`](Export::with_latency)) of buffer ahead of now, re-anchoring
 	/// past that so a tune-in burst or a faster-than-real source never accrues more
-	/// latency than the budget. Sleep until it (or stamp a transport send time with
-	/// it) to emit at the source's real-time rate, like ffmpeg's `-re`; ignore it to
-	/// emit as fast as the broadcast can be read.
+	/// latency than the budget. Sleep until it (or stamp a transport send time with it)
+	/// to emit at the source's real-time rate, like ffmpeg's `-re`; ignore it to emit as
+	/// fast as the broadcast can be read.
 	pub pace: Instant,
+}
+
+/// The in-progress output window: its media-clock span, accumulated bytes, and the
+/// wall-clock instant it's due. Bundled so the window state advances as a unit.
+struct Window {
+	/// Window end on the media (decode) clock: media with a decode time below this belongs
+	/// here. The start (its PCR value and pace anchor) is consumed when the window opens.
+	end: Timestamp,
+	/// TS bytes so far: a leading PCR packet, then any media frames.
+	buf: Vec<u8>,
+	/// Whether a media frame has landed in this window (an empty window is a filler).
+	has_media: bool,
+	/// The instant this window is due, `due(start)`, stamped onto the [`Output`].
+	pace: Instant,
 }
 
 /// The program tables plus the resolved PID layout.
@@ -177,7 +211,6 @@ struct Psi {
 /// Per-frame PES descriptor (everything but the payload bytes).
 struct PesUnit {
 	pid: u16,
-	is_pcr: bool,
 	is_video: bool,
 	keyframe: bool,
 	timestamp: Timestamp,
@@ -232,6 +265,8 @@ impl<E: CatalogExt> Export<E> {
 			psi: None,
 			last_psi: None,
 			video_start: None,
+			window: None,
+			timer: Timer::default(),
 		})
 	}
 
@@ -257,14 +292,12 @@ impl<E: CatalogExt> Export<E> {
 		self
 	}
 
-	/// Get the next muxed frame.
+	/// Get the next output window.
 	///
-	/// Each [`Output`] carries the TS packets for one media frame in `payload`,
-	/// stamped with that frame's media `timestamp` and `keyframe` flag, plus a
-	/// [`pace`](Output::pace) instant so a transport can emit on the media clock.
-	/// The leading PAT/PMT rides on the first frame (inheriting its timestamp), and
-	/// is re-emitted at video keyframes and periodically for mid-stream tune-in.
-	/// Returns `None` when the broadcast ends.
+	/// Each [`Output`] carries one ~20 ms window's TS packets in `payload` (a leading PCR,
+	/// then any media), plus a [`pace`](Output::pace) instant so a transport can emit on the
+	/// media clock. PAT/PMT ride the windows at video keyframes and periodically for
+	/// mid-stream tune-in. Returns `None` when the broadcast ends.
 	pub async fn next(&mut self) -> anyhow::Result<Option<Output>> {
 		kio::wait(|waiter| self.poll_next(waiter)).await
 	}
@@ -283,49 +316,15 @@ impl<E: CatalogExt> Export<E> {
 			}
 		}
 
-		// 2. Pull a frame into every idle track. ExportSource has already
-		// transformed Annex-B avc3/hev1 into length-prefixed form and resolved
-		// the avcC/hvcC. Before the program tables are written, drop slices that
-		// arrive before their codec config resolves: a receiver joining mid-GOP
-		// can't use them, and parking them would stop us polling for the keyframe
-		// that carries the parameter sets.
-		let waiting_for_header = self.psi.is_none();
-		let video_start = self.video_start;
-		for track in self.tracks.values_mut() {
-			if track.pending.is_some() || track.finished {
-				continue;
-			}
-			let is_video = matches!(track.kind, Kind::Video(_));
-			loop {
-				match track.source.poll_read(waiter) {
-					Poll::Ready(Ok(Some(frame))) => {
-						if waiting_for_header && !track.source.header_ready() {
-							continue;
-						}
-						// Tune-in alignment: drop non-video frames before the first video
-						// keyframe (see `video_start`) so the in-band SPS/PPS leads the stream.
-						if let Some(start) = video_start
-							&& !is_video && frame.timestamp < start
-						{
-							continue;
-						}
-						track.pending = Some(frame);
-						break;
-					}
-					Poll::Ready(Ok(None)) => {
-						track.finished = true;
-						break;
-					}
-					Poll::Ready(Err(e)) => return Poll::Ready(Err(e.into())),
-					Poll::Pending => break,
-				}
-			}
+		// 2. Pull a frame into every idle track (resolving its decode clock).
+		if let Err(e) = self.pull_idle(waiter) {
+			return Poll::Ready(Err(e));
 		}
 
 		// 3. Build the program tables once the layout is resolved and every
 		// track's codec config is ready. The tables aren't emitted here: PSI has
-		// no media time of its own, so `write_frame` prepends them to the first
-		// frame instead, letting the leading PAT/PMT inherit a real timestamp.
+		// no media time of its own, so `mux_into_window` writes them alongside the
+		// first frame, letting the leading PAT/PMT inherit a real timestamp.
 		if self.psi.is_none() {
 			if self.tracks.is_empty() {
 				// No tracks yet. If the catalog is also done, the broadcast is empty.
@@ -352,7 +351,7 @@ impl<E: CatalogExt> Export<E> {
 			if let Some(start) = self.video_start {
 				for track in self.tracks.values_mut() {
 					if !matches!(track.kind, Kind::Video(_))
-						&& track.pending.as_ref().is_some_and(|f| f.timestamp < start)
+						&& track.pending.as_ref().is_some_and(|p| p.frame.timestamp < start)
 					{
 						track.pending = None;
 					}
@@ -360,23 +359,186 @@ impl<E: CatalogExt> Export<E> {
 			}
 		}
 
-		// 4. Emit the smallest-timestamp pending frame as a PES packet (the first
-		// one carries the buffered PAT/PMT).
-		if let Some(name) = self.pick_next_track() {
-			let frame = self.tracks.get_mut(&name).unwrap().pending.take().unwrap();
-			let out = self.write_frame(&name, frame)?;
-			return Poll::Ready(Ok(Some(out)));
+		// 4. Fill the current window: mux every pending frame whose decode time falls before
+		// the window end, refilling tracks as they drain. A frame that lands in a later
+		// window ends the current one (once nothing is still blocking).
+		loop {
+			if let Err(e) = self.pull_idle(waiter) {
+				return Poll::Ready(Err(e));
+			}
+			let Some(name) = self.pick_next_track() else {
+				break; // no pending frame: every track is finished or blocking
+			};
+			let decode = self.tracks[&name].pending.as_ref().unwrap().decode;
+			if self.window.is_none() {
+				self.open_window(decode)?;
+			}
+			if decode < self.window.as_ref().unwrap().end {
+				let pending = self.tracks.get_mut(&name).unwrap().pending.take().unwrap();
+				self.mux_into_window(&name, pending)?;
+				continue;
+			}
+			// The next frame belongs to a later window, so this one has all its media, unless
+			// another track is still blocking (it may yet produce a frame for this window).
+			if self.any_blocking() {
+				break;
+			}
+			return Poll::Ready(Ok(Some(self.flush_window()?)));
 		}
 
-		// 5. End of stream once every track has drained and the catalog is closed.
-		if self.catalog.is_none() && !self.tracks.is_empty() && self.tracks.values().all(|t| t.finished) {
-			return Poll::Ready(Ok(None));
+		// 5. No frame is immediately available.
+		if self.psi.is_some() && self.tracks.values().all(|t| t.finished) {
+			// End of stream: flush the trailing window (if it holds media), then finish.
+			return Poll::Ready(Ok(self.flush_final()));
 		}
 		if self.catalog.is_none() && self.tracks.is_empty() {
 			return Poll::Ready(Ok(None));
 		}
 
+		// A track is blocking at the live edge. Wait for its media or, once the window's
+		// wall-clock deadline passes, flush what we have (a filler PCR if it's empty).
+		if let Some(deadline) = self.window_deadline() {
+			match self.timer.poll(deadline, waiter) {
+				Poll::Ready(_) => return Poll::Ready(Ok(Some(self.flush_window()?))),
+				Poll::Pending => return Poll::Pending,
+			}
+		}
+
 		Poll::Pending
+	}
+
+	/// Pull one frame into every idle, unfinished track, resolving each kept frame's decode
+	/// clock. Frames that arrive before the codec config resolves, or before the tune-in
+	/// keyframe, are dropped here so `author_dts` only advances for frames that get muxed.
+	fn pull_idle(&mut self, waiter: &kio::Waiter) -> anyhow::Result<()> {
+		let waiting_for_header = self.psi.is_none();
+		let video_start = self.video_start;
+		for track in self.tracks.values_mut() {
+			if track.pending.is_some() || track.finished {
+				continue;
+			}
+			let is_video = matches!(track.kind, Kind::Video(_));
+			loop {
+				match track.source.poll_read(waiter) {
+					Poll::Ready(Ok(Some(frame))) => {
+						if waiting_for_header && !track.source.header_ready() {
+							continue;
+						}
+						// Tune-in alignment: drop non-video frames before the first video
+						// keyframe (see `video_start`) so the in-band SPS/PPS leads the stream.
+						if let Some(start) = video_start
+							&& !is_video && frame.timestamp < start
+						{
+							continue;
+						}
+						// Resolve the decode clock now, in per-track decode order: reordered
+						// video authors a monotonic DTS, everything else decodes at its PTS.
+						let (decode, dts) = if is_video {
+							let pts = to_ticks(frame.timestamp);
+							let dts = author_dts(pts, track.dts_reserve, &mut track.last_dts);
+							let decode = match dts {
+								Some(ticks) => from_ticks(ticks).unwrap_or(frame.timestamp),
+								None => frame.timestamp,
+							};
+							(decode, dts)
+						} else {
+							(frame.timestamp, None)
+						};
+						track.pending = Some(PendingFrame { frame, decode, dts });
+						break;
+					}
+					Poll::Ready(Ok(None)) => {
+						track.finished = true;
+						break;
+					}
+					Poll::Ready(Err(e)) => return Err(e.into()),
+					Poll::Pending => break,
+				}
+			}
+		}
+		Ok(())
+	}
+
+	/// Open a window at media time `start`: stamp its pace instant and write the leading PCR
+	/// packet, so every window carries a dense, uniform reference clock.
+	fn open_window(&mut self, start: Timestamp) -> anyhow::Result<()> {
+		let end = start + window_len();
+		let lead = self.pace_lead.unwrap_or(self.latency);
+		let pace = self.pacer.due(start, lead);
+		let mut buf = Vec::new();
+		self.write_pcr_packet(&mut buf, start)?;
+		self.window = Some(Window {
+			end,
+			buf,
+			has_media: false,
+			pace,
+		});
+		Ok(())
+	}
+
+	/// Emit the current window and open the next one on the continuous grid.
+	fn flush_window(&mut self) -> anyhow::Result<Output> {
+		let window = self.window.take().context("no window to flush")?;
+		let output = Output {
+			payload: Bytes::from(window.buf),
+			pace: window.pace,
+		};
+		self.open_window(window.end)?;
+		Ok(output)
+	}
+
+	/// Emit the trailing window at end of stream, or `None` when it holds only its PCR: with
+	/// nothing left to bridge to, an empty window is not worth a filler.
+	fn flush_final(&mut self) -> Option<Output> {
+		let window = self.window.take()?;
+		window.has_media.then(|| Output {
+			payload: Bytes::from(window.buf),
+			pace: window.pace,
+		})
+	}
+
+	/// Write a PCR-only TS packet (adaptation field only, stuffed to 188 bytes) on the PCR
+	/// PID. It carries no payload, so it must not advance the continuity counter.
+	fn write_pcr_packet(&mut self, out: &mut Vec<u8>, pcr: Timestamp) -> anyhow::Result<()> {
+		let pcr_pid = self.psi.as_ref().context("PSI not built")?.pcr_pid;
+		let clock = TsTimestamp::new(to_ticks(pcr) & TS_TIMESTAMP_MASK).map_err(anyhow::Error::msg)?;
+		let counter = *self.counters.entry(pcr_pid).or_default();
+		let packet = TsPacket {
+			header: TsHeader {
+				transport_error_indicator: false,
+				transport_priority: false,
+				pid: Pid::new(pcr_pid)?,
+				transport_scrambling_control: TransportScramblingControl::NotScrambled,
+				continuity_counter: counter,
+			},
+			adaptation_field: Some(AdaptationField {
+				discontinuity_indicator: false,
+				random_access_indicator: false,
+				es_priority_indicator: false,
+				pcr: Some(clock.into()),
+				opcr: None,
+				splice_countdown: None,
+				transport_private_data: Vec::new(),
+				extension: None,
+			}),
+			payload: None,
+		};
+		TsPacketWriter::new(out)
+			.write_ts_packet(&packet)
+			.map_err(anyhow::Error::msg)?;
+		Ok(())
+	}
+
+	/// The wall-clock deadline for the current window's live-edge wait: one window past its
+	/// pace instant, the point by which its media should have arrived in real time.
+	fn window_deadline(&self) -> Option<Instant> {
+		self.window.as_ref().map(|w| w.pace + WINDOW)
+	}
+
+	/// Whether any unfinished track has no pending frame (it blocked at the live edge), so the
+	/// current window can't yet be declared complete.
+	fn any_blocking(&self) -> bool {
+		self.tracks.values().any(|t| !t.finished && t.pending.is_none())
 	}
 
 	fn update_catalog(&mut self, mut catalog: Catalog<E>) -> anyhow::Result<()> {
@@ -560,7 +722,7 @@ impl<E: CatalogExt> Export<E> {
 		self.tracks
 			.values()
 			.filter(|t| matches!(t.kind, Kind::Video(_)))
-			.filter_map(|t| t.pending.as_ref().map(|f| f.timestamp))
+			.filter_map(|t| t.pending.as_ref().map(|p| p.frame.timestamp))
 			.min()
 	}
 
@@ -690,27 +852,25 @@ impl<E: CatalogExt> Export<E> {
 		Ok(())
 	}
 
-	/// Name of the track whose pending frame has the smallest timestamp.
+	/// Name of the track whose pending frame has the smallest decode time. Interleaving on
+	/// the decode clock keeps the mux (and its windows) monotonic across reordered video.
 	fn pick_next_track(&self) -> Option<String> {
 		self.tracks
 			.iter()
-			.filter_map(|(n, t)| t.pending.as_ref().map(|f| (n.clone(), f.timestamp)))
-			.min_by_key(|(_, ts)| *ts)
+			.filter_map(|(n, t)| t.pending.as_ref().map(|p| (n.clone(), p.decode)))
+			.min_by_key(|(_, decode)| *decode)
 			.map(|(n, _)| n)
 	}
 
-	/// Packetize one media frame into an [`Output`], re-emitting PAT/PMT before video
-	/// keyframes (and periodically) so receivers can tune in mid-stream. The output
-	/// keeps the source `timestamp` and `keyframe` flag, plus a decode-clock `pace`
-	/// instant for real-time delivery.
-	fn write_frame(&mut self, name: &str, frame: Frame) -> anyhow::Result<Output> {
+	/// Mux one pending frame into the current window's buffer, re-emitting PAT/PMT before
+	/// video keyframes (and periodically) so receivers can tune in mid-stream. The window
+	/// already carries its leading PCR, so no PCR is written here.
+	fn mux_into_window(&mut self, name: &str, pending: PendingFrame) -> anyhow::Result<()> {
+		let PendingFrame { frame, dts, .. } = pending;
 		let track = self.tracks.get(name).context("missing track")?;
 		let pid = track.pid;
 		let kind = track.kind.clone();
-		let is_pcr = self.psi.as_ref().is_some_and(|p| p.pcr_pid == pid);
 		let is_video = matches!(kind, Kind::Video(_));
-		let timestamp = frame.timestamp;
-		let keyframe = frame.keyframe;
 
 		// Build the elementary-stream payload for this frame. Video needs the
 		// resolved avcC/hvcC to rewrite length-prefixed NALs as Annex-B. Section-framed
@@ -743,28 +903,7 @@ impl<E: CatalogExt> Export<E> {
 			} => None,
 		};
 
-		// Author a monotonic decode timeline for reordered video (B-frames). Other kinds
-		// never reorder, so DTS == PTS and the PES stays PTS-only.
-		let dts = if is_video {
-			let pts = to_ticks(frame.timestamp);
-			let track = self.tracks.get_mut(name).context("missing track")?;
-			author_dts(pts, track.dts_reserve, &mut track.last_dts)
-		} else {
-			None
-		};
-
-		// Pace on the decode clock: reordered video uses the authored DTS (monotonic), so
-		// a caller honoring `pace` emits B-frames evenly instead of bursting on their
-		// non-monotonic PTS. Audio and non-reordered video have DTS == PTS. The pace buffer
-		// follows the read latency unless overridden (an SRT egress pins it to zero).
-		let decode = match dts {
-			Some(ticks) => from_ticks(ticks).unwrap_or(timestamp),
-			None => timestamp,
-		};
-		let lead = self.pace_lead.unwrap_or(self.latency);
-		let pace = self.pacer.due(decode, lead);
-
-		let mut out = Vec::with_capacity(TsPacket::SIZE);
+		let mut out = std::mem::take(&mut self.window.as_mut().context("no open window")?.buf);
 
 		// Refresh PSI at keyframes or after the interval lapses.
 		let psi_due = match self.last_psi {
@@ -796,7 +935,6 @@ impl<E: CatalogExt> Export<E> {
 				};
 				let unit = PesUnit {
 					pid,
-					is_pcr,
 					is_video,
 					keyframe: frame.keyframe,
 					timestamp: frame.timestamp,
@@ -806,12 +944,11 @@ impl<E: CatalogExt> Export<E> {
 				self.write_pes(&mut out, &unit, &es_payload)?;
 			}
 		}
-		Ok(Output {
-			payload: Bytes::from(out),
-			timestamp,
-			keyframe,
-			pace,
-		})
+
+		let window = self.window.as_mut().context("no open window")?;
+		window.buf = out;
+		window.has_media = true;
+		Ok(())
 	}
 
 	/// Packetize a PES payload into 188-byte TS packets.
@@ -851,18 +988,17 @@ impl<E: CatalogExt> Export<E> {
 			u16::try_from(optional_len + payload.len()).unwrap_or(0)
 		};
 
-		// PCR follows the decode clock, so a B-frame stream advertises DTS (not PTS) here.
-		let pcr = dts.unwrap_or(pts);
-
 		let mut offset = 0;
 		let mut first = true;
 		loop {
-			let adaptation = if first && (unit.is_pcr || unit.keyframe) {
+			// The window's leading PCR packet carries the clock; a keyframe's first packet
+			// only flags random access here.
+			let adaptation = if first && unit.keyframe {
 				Some(AdaptationField {
 					discontinuity_indicator: false,
-					random_access_indicator: unit.keyframe,
+					random_access_indicator: true,
 					es_priority_indicator: false,
-					pcr: if unit.is_pcr { Some(pcr.into()) } else { None },
+					pcr: None,
 					opcr: None,
 					splice_countdown: None,
 					transport_private_data: Vec::new(),
@@ -985,6 +1121,11 @@ const DEFAULT_DTS_RESERVE: u64 = 16;
 
 fn psi_interval() -> Timestamp {
 	Timestamp::try_from(PSI_INTERVAL).unwrap_or(Timestamp::ZERO)
+}
+
+/// [`WINDOW`] as a media [`Timestamp`], the span each output window covers.
+fn window_len() -> Timestamp {
+	Timestamp::try_from(WINDOW).unwrap_or(Timestamp::ZERO)
 }
 
 /// External byte size of an adaptation field (manual mirror of the crate's

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -302,6 +302,11 @@ fn reassemble_video(ts: &[u8], expected_stream_type: StreamType) -> Vec<u8> {
 	let mut unbounded = false;
 
 	while let Some(packet) = reader.read_ts_packet().unwrap() {
+		// PCR rides its own leading packet per window; random access flags the keyframe PES.
+		if let Some(af) = &packet.adaptation_field {
+			saw_random_access |= af.random_access_indicator;
+			saw_pcr |= af.pcr.is_some();
+		}
 		match packet.payload {
 			Some(TsPayload::Pmt(pmt)) => {
 				assert_eq!(pmt.es_info.len(), 1);
@@ -309,11 +314,6 @@ fn reassemble_video(ts: &[u8], expected_stream_type: StreamType) -> Vec<u8> {
 				video_pid = Some(pmt.es_info[0].elementary_pid);
 			}
 			Some(TsPayload::PesStart(pes)) => {
-				// The first packet of a keyframe must signal random access and carry a PCR.
-				if let Some(af) = &packet.adaptation_field {
-					saw_random_access |= af.random_access_indicator;
-					saw_pcr |= af.pcr.is_some();
-				}
 				unbounded = pes.pes_packet_len == 0;
 				reassembled.extend_from_slice(&pes.data);
 			}
@@ -324,7 +324,7 @@ fn reassemble_video(ts: &[u8], expected_stream_type: StreamType) -> Vec<u8> {
 
 	assert!(video_pid.is_some(), "missing video PMT entry");
 	assert!(saw_random_access, "keyframe should set random_access_indicator");
-	assert!(saw_pcr, "PCR pid should carry a PCR on the keyframe");
+	assert!(saw_pcr, "the PCR pid should carry a PCR");
 	assert!(unbounded, "video PES should be unbounded");
 	reassembled
 }
@@ -1406,5 +1406,70 @@ async fn opus_export_import_roundtrip() {
 	assert_eq!(recovered.len(), packets.len(), "frame count");
 	for (orig, got) in packets.iter().zip(&recovered) {
 		assert_eq!(got.as_slice(), orig.as_ref(), "Opus packet survived the round-trip");
+	}
+}
+
+/// The exporter emits fixed 20 ms windows, each led by a PCR, inserting bare-PCR filler
+/// windows to bridge a low-frame-rate gap. So even at 10 fps the reference clock stays dense
+/// and uniform (well under the 40 ms TR 101 290 limit) instead of one sparse sample per frame.
+#[tokio::test(start_paused = true)]
+async fn windows_emit_uniform_pcr_with_fillers() {
+	let mut broadcast = moq_net::Broadcast::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+
+	let vtrack = broadcast
+		.create_track(moq_net::Track::new(broadcast.unique_name(".avc3")))
+		.unwrap();
+	{
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: 0x1f,
+			inline: true,
+		});
+		cfg.container = Container::Legacy;
+		catalog.lock().video.renditions.insert(vtrack.name().to_string(), cfg);
+	}
+	let mut video = Producer::new(vtrack, HangContainer::Legacy);
+
+	// Keyframes every 100 ms (10 fps): each pair is five 20 ms windows apart, so most windows
+	// carry no media and must be filled with a bare PCR.
+	let mut idr = vec![0x65u8];
+	idr.extend(std::iter::repeat_n(0xABu8, 200));
+	let payload = annexb(&[SPS, PPS, &idr]);
+	for i in 0..5u64 {
+		video
+			.write(Frame {
+				timestamp: Timestamp::from_micros(i * 100_000).unwrap(),
+				duration: None,
+				payload: payload.clone(),
+				keyframe: true,
+			})
+			.unwrap();
+		video.finish_group().unwrap();
+	}
+	video.finish().unwrap();
+
+	let ts = drain(consumer).await;
+
+	// PCR values (27 MHz) in transport order.
+	let mut pcrs = Vec::new();
+	let mut reader = TsPacketReader::new(Cursor::new(ts.as_ref()));
+	while let Some(packet) = reader.read_ts_packet().unwrap() {
+		if let Some(pcr) = packet.adaptation_field.and_then(|af| af.pcr) {
+			pcrs.push(pcr.as_u64());
+		}
+	}
+
+	// ~400 ms of media at 20 ms windows is ~20 PCRs, far more than the 5 frames: fillers bridge.
+	assert!(pcrs.len() >= 15, "expected filler-dense PCR, got {}", pcrs.len());
+	assert!(
+		pcrs.windows(2).all(|w| w[1] > w[0]),
+		"PCR must increase monotonically: {pcrs:?}"
+	);
+	// Every step is a uniform 20 ms (20 ms at 27 MHz = 540000), never past the 40 ms limit.
+	for w in pcrs.windows(2) {
+		assert_eq!(w[1] - w[0], 540_000, "PCR spacing must be a uniform 20 ms");
 	}
 }

--- a/rs/moq-srt/src/server.rs
+++ b/rs/moq-srt/src/server.rs
@@ -324,7 +324,8 @@ async fn serve_subscribe(origin: &OriginConsumer, path: &str, mut socket: SrtSoc
 	let mut send_at = Instant::now();
 	let mut buffer = bytes::BytesMut::new();
 	while let Some(frame) = subscriber.next().await? {
-		send_at = frame.pace;
+		// The muxer paces on the tokio clock; SRT's TSBPD send time is a std instant.
+		send_at = frame.pace.into_std();
 
 		buffer.extend_from_slice(&frame.payload);
 		while buffer.len() >= SRT_PAYLOAD {


### PR DESCRIPTION
## Summary

Reworks the MPEG-TS exporter from **one output per media frame** into fixed **~20 ms windows** on the media clock, each led by a PCR. This is the design @ArielM and @kixelated converged on in discussion, and it folds the two prior fixes into one clean model.

The problem (Ariel's Sencore IRD): the elementary stream is perfect, but the exporter wrote a single PCR per frame valued at the authored DTS — too sparse at low frame rates, too uneven under B-frame reorder. A hardware IRD has no clock of its own; it rebuilds the 27 MHz clock from the PCR values with a PLL that needs a **dense (≤40 ms TR 101 290), monotonic, uniform** reference. The sparse/jittery PCR makes the PLL hunt → the cascade of clock errors. `-muxrate 11M` papered over it by padding to CBR so PCR-by-byte-position is a clean ramp.

## The model

Each `Output` is one ~20 ms window:
- **Opens on the decode grid** (PCR value = window start), so the PCR ramp is *exactly* uniform regardless of frame rate — no interpolation.
- Carries a **leading PCR-only packet** (adaptation-only, auto-stuffed to 188 bytes, no continuity-counter bump), then any media whose decode time falls in the window.
- Stamped with its `pace` instant, so a caller paces delivery per window.

A window with **no media is just that PCR packet** — bridging a low-frame-rate gap with a few bytes instead of padding the mux to CBR (no wasted null-packet bitrate, the "moq can do better internally" point). Gaps the exporter can see (buffered/VOD) fill deterministically; at the live edge a `Timer` flushes a filler once the window's wall-clock deadline passes. **The exporter owns the clock end to end** — it decides every PCR's value *and* its due instant; the consumer just executes.

This resolves Ariel's open "where do I get the frame interval" question: the window grid is fixed on the decode clock, so nothing depends on catalog frame rate or lookahead buffering.

## Commits

1. **kio `Waiter::waker()` + `Timer`** — a poll-driven wall-clock wait so a runtime-free `poll_*` can drive a `tokio` sleep against its own waker (kio gains no dependency; the sleep lives in moq-mux, which already depends on tokio).
2. **Pace on `tokio::time::Instant`** — drops the std↔tokio conversion and lets `tokio::time::pause()` advance the whole pace pipeline, so windowed emission tests deterministically.
3. **Windowed exporter** — the rework above. Frames resolve their decode clock when pulled (`PendingFrame`) and window/interleave on decode time, keeping the mux monotonic across reorder. `Output` collapses to `{ payload, pace }`.

## `--pace` behavior

Unchanged in spirit: PCR/filler correctness is independent of `--pace`. The flag only decides whether the consumer *sleeps* on each window's `pace` (real-time playout of a retained broadcast) or dumps as fast as readable. moq-srt always stamps `pace` (TSBPD); moq-cli gates the sleep.

## API surface (moq-mux, breaking)

- `ts::Output` is now `{ payload, pace }` (dropped per-frame `timestamp`/`keyframe`; no consumer read them). Payload is a window, not a frame.
- `Output::pace` is `tokio::time::Instant` (was `std`).
- `kio::Waiter::waker()` added (additive).

## Test plan

- [x] `cargo test -p moq-mux -p moq-srt -p moq-cli -p kio` (342 / 6 / 1 / 7). New `windows_emit_uniform_pcr_with_fillers` asserts an exactly-uniform 20 ms PCR ramp with fillers bridging a 10 fps gap; `Timer` has its own paused-time test. All existing TS import→export→import roundtrips still pass byte-exact, validating the windowed wire output.
- [x] `cargo clippy ... --all-targets` clean.
- [ ] Not yet verified end-to-end against a real IRD (Ariel to test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sv3GrsvEy1wyd2SYbApDzh)_