### PR TITLE
demo: scope relay bind env vars so the pub client stays a client

### DIFF
--- a/demo/justfile
+++ b/demo/justfile
@@ -21,12 +21,13 @@ default:
     	echo ">>> Port 4443 is busy, using $port instead" >&2
     fi
 
-    export MOQ_SERVER_BIND="[::]:$port"
-    export MOQ_WEB_HTTP_LISTEN="[::]:$port"
     base="http://localhost:$port"
 
+    # Scope the bind env vars to the relay only. The unified `moq` binary also
+    # reads MOQ_SERVER_BIND, so exporting it globally would make the `pub` client
+    # try to start a server (and fail without a TLS cert).
     bun run concurrently --kill-others --names rly,bbb,web --prefix-colors auto \
-    	"just relay" \
+    	"MOQ_SERVER_BIND='[::]:$port' MOQ_WEB_HTTP_LISTEN='[::]:$port' just relay" \
     	"just wait $base/certificate.sha256 && just pub bbb $base" \
     	"just wait $base/certificate.sha256 && just web serve $base"
 


### PR DESCRIPTION
The `default` recipe exported MOQ_SERVER_BIND / MOQ_WEB_HTTP_LISTEN, so every `concurrently` child inherited them. After the moq-cli rename (#1985), the unified `moq` binary's --server-bind reads env = "MOQ_SERVER_BIND", so the `pub` client saw an implicit --server-bind and tried to stand up a server. With no TLS cert or --tls-generate that failed with "must provide at least one cert/key pair or generate entry".

Only moq-relay consumes those vars, so set them inline on the relay child instead of exporting globally. The pub/web children get the port via the $base URL argument and don't need the env.