### PR TITLE
refactor(kio): add a poll-driven tokio::Sleep wrapper behind a `tokio` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,6 +3729,7 @@ name = "kio"
 version = "0.4.1"
 dependencies = [
  "smallvec",
+ "tokio",
 ]
 
 [[package]]

--- a/rs/kio/Cargo.toml
+++ b/rs/kio/Cargo.toml
@@ -15,5 +15,14 @@ categories = ["asynchronous", "concurrency"]
 [lib]
 doctest = false
 
+[features]
+# Opt-in `time::Timer`, a poll-driven wall-clock wait backed by `tokio::time`. Off by
+# default so kio stays runtime-free; enable it when driving `poll_*` functions on tokio.
+tokio = ["dep:tokio"]
+
 [dependencies]
 smallvec = "1.15"
+tokio = { workspace = true, features = ["time"], optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "test-util", "time"] }

--- a/rs/kio/src/lib.rs
+++ b/rs/kio/src/lib.rs
@@ -18,6 +18,9 @@ mod future;
 mod producer;
 mod weak;
 
+#[cfg(feature = "tokio")]
+pub mod tokio;
+
 #[cfg(test)]
 mod tests;
 

--- a/rs/kio/src/tokio.rs
+++ b/rs/kio/src/tokio.rs
@@ -1,0 +1,49 @@
+//! kio integration for `tokio`.
+//!
+//! Behind the `tokio` feature. Wraps a [`tokio::time::Sleep`] so a `poll_*` function can
+//! drive it against a [`Waiter`], keeping the rest of kio runtime-free.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::Waiter;
+
+/// A `tokio` sleep driven by kio's poll model.
+///
+/// Construct it once for a deadline (`Sleep::new(tokio::time::sleep_until(deadline))`), then
+/// [`poll`](Self::poll) it against a [`Waiter`] each time your `poll_*` runs. Reading the
+/// clock through `tokio::time` means a `tokio::time::pause()` test advances it in step.
+pub struct Sleep {
+	inner: Pin<Box<::tokio::time::Sleep>>,
+}
+
+impl Sleep {
+	/// Wrap a `tokio` sleep future.
+	pub fn new(sleep: ::tokio::time::Sleep) -> Self {
+		Self { inner: Box::pin(sleep) }
+	}
+
+	/// Poll the sleep, registering `waiter` so the poll re-fires once it elapses.
+	pub fn poll(&mut self, waiter: &Waiter) -> Poll<()> {
+		let mut cx = Context::from_waker(waiter.waker());
+		self.inner.as_mut().poll(&mut cx)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use ::tokio::time::Instant;
+	use std::time::Duration;
+
+	#[::tokio::test(start_paused = true)]
+	async fn sleep_fires_at_its_deadline() {
+		let deadline = Instant::now() + Duration::from_millis(50);
+		let mut sleep = Sleep::new(::tokio::time::sleep_until(deadline));
+		// `crate::wait` drives the poll; under paused time tokio auto-advances to the sleep,
+		// so this resolves at the deadline rather than blocking for real.
+		crate::wait(|waiter| sleep.poll(waiter)).await;
+		assert!(Instant::now() >= deadline, "returned before the deadline");
+	}
+}

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -22,7 +22,7 @@ base64 = "0.22"
 bytes = "1"
 h264-parser = { version = "0.4.0" }
 hang = { workspace = true }
-kio = { workspace = true }
+kio = { workspace = true, features = ["tokio"] }
 memchr = "2"
 moq-json = { workspace = true }
 moq-loc = { workspace = true }

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -28,7 +28,7 @@ pub mod mkv;
 pub mod ts;
 
 pub use consumer::Consumer;
-pub(crate) use pace::{Pacer, Timer};
+pub(crate) use pace::Pacer;
 pub use producer::Producer;
 pub(crate) use source::ExportSource;
 

--- a/rs/moq-mux/src/container/pace.rs
+++ b/rs/moq-mux/src/container/pace.rs
@@ -1,63 +1,10 @@
 //! Pace media output on a media clock, following the live edge.
 
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
 use std::time::Duration;
 
 use tokio::time::Instant;
 
 use super::Timestamp;
-
-/// A one-shot wall-clock timer wired into kio's poll model.
-///
-/// [`Pacer`] answers "at what wall-clock instant is this media due"; `Timer` is the
-/// other half, letting a `poll_*` function actually wait for that instant. It drives a
-/// stored tokio sleep against the poll's [`kio::Waiter`], so the poll re-fires when the
-/// deadline passes. moq-mux already depends on tokio, so this keeps the wait local
-/// instead of pushing a runtime dependency into kio.
-#[derive(Default)]
-pub(crate) struct Timer {
-	/// The armed sleep, kept alive across polls so its timer registration persists.
-	sleep: Option<Pin<Box<tokio::time::Sleep>>>,
-	/// The instant `sleep` targets, so we only re-arm when it moves.
-	until: Option<Instant>,
-}
-
-impl Timer {
-	/// Poll until `after`. Returns `Ready(now)` once the clock reaches `after`; otherwise
-	/// arms (or re-arms) against `waiter` and returns `Pending`. Re-arms only when `after`
-	/// changes, so repeated polls for one deadline reuse a single timer registration.
-	///
-	/// Reads the clock through `tokio::time`, so a `tokio::time::pause()` test advances the
-	/// deadline check and the sleep together.
-	pub(crate) fn poll(&mut self, after: Instant, waiter: &kio::Waiter) -> Poll<Instant> {
-		let now = Instant::now();
-		if now >= after {
-			self.disarm();
-			return Poll::Ready(now);
-		}
-		if self.until != Some(after) {
-			self.until = Some(after);
-			self.sleep = Some(Box::pin(tokio::time::sleep_until(after)));
-		}
-		let mut cx = Context::from_waker(waiter.waker());
-		match self.sleep.as_mut().unwrap().as_mut().poll(&mut cx) {
-			Poll::Ready(()) => {
-				self.disarm();
-				Poll::Ready(Instant::now())
-			}
-			Poll::Pending => Poll::Pending,
-		}
-	}
-
-	/// Drop the armed sleep. Called once the deadline fires so a later poll for a new
-	/// deadline starts clean.
-	fn disarm(&mut self) {
-		self.sleep = None;
-		self.until = None;
-	}
-}
 
 /// Maps media (decode) timestamps onto the wall clock so a caller can emit frames at
 /// the source's real-time rate while bounding how far behind the live edge it falls.
@@ -136,17 +83,6 @@ mod tests {
 
 	fn ms(m: u64) -> Timestamp {
 		Timestamp::from_micros(m * 1_000).unwrap()
-	}
-
-	#[tokio::test(start_paused = true)]
-	async fn timer_fires_at_its_deadline() {
-		let start = Instant::now();
-		let deadline = start + Duration::from_millis(50);
-		let mut timer = Timer::default();
-		// `kio::wait` drives the poll; under paused time tokio auto-advances to the armed
-		// sleep, so this resolves at the deadline rather than blocking for real.
-		let fired = kio::wait(|waiter| timer.poll(deadline, waiter)).await;
-		assert!(fired >= deadline, "fired {fired:?} before deadline {deadline:?}");
 	}
 
 	#[test]

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -36,7 +36,7 @@ use mpeg2ts::ts::{
 use crate::catalog::hang::{Catalog, CatalogExt};
 use crate::catalog::{CatalogFormat, Stream};
 use crate::codec::annexb;
-use crate::container::{ExportSource, Frame, Pacer, Timer, Timestamp};
+use crate::container::{ExportSource, Frame, Pacer, Timestamp};
 
 use super::adts;
 use super::catalog;
@@ -96,9 +96,9 @@ pub struct Export<E: CatalogExt = ()> {
 
 	/// The in-progress output window, or `None` before the first frame is placed.
 	window: Option<Window>,
-	/// Wall-clock timer for the live-edge case: when a track blocks mid-window, wait for
-	/// its media or for the window's deadline (then flush a filler), rather than stalling.
-	timer: Timer,
+	/// The live-edge wait: a sleep to the current window's deadline, constructed once when a
+	/// track blocks mid-window and dropped when the window flushes. `None` when not waiting.
+	sleep: Option<kio::tokio::Sleep>,
 }
 
 struct Track {
@@ -266,7 +266,7 @@ impl<E: CatalogExt> Export<E> {
 			last_psi: None,
 			video_start: None,
 			window: None,
-			timer: Timer::default(),
+			sleep: None,
 		})
 	}
 
@@ -396,12 +396,18 @@ impl<E: CatalogExt> Export<E> {
 		}
 
 		// A track is blocking at the live edge. Wait for its media or, once the window's
-		// wall-clock deadline passes, flush what we have (a filler PCR if it's empty).
+		// wall-clock deadline passes, flush what we have (a filler PCR if it's empty). The
+		// sleep is built once for this window's deadline and reused until the window flushes.
 		if let Some(deadline) = self.window_deadline() {
-			match self.timer.poll(deadline, waiter) {
-				Poll::Ready(_) => return Poll::Ready(Ok(Some(self.flush_window()?))),
-				Poll::Pending => return Poll::Pending,
+			let ready = self
+				.sleep
+				.get_or_insert_with(|| kio::tokio::Sleep::new(tokio::time::sleep_until(deadline)))
+				.poll(waiter)
+				.is_ready();
+			if ready {
+				return Poll::Ready(Ok(Some(self.flush_window()?)));
 			}
+			return Poll::Pending;
 		}
 
 		Poll::Pending
@@ -476,9 +482,11 @@ impl<E: CatalogExt> Export<E> {
 		Ok(())
 	}
 
-	/// Emit the current window and open the next one on the continuous grid.
+	/// Emit the current window and open the next one on the continuous grid. Drops any
+	/// live-edge sleep, whose deadline belonged to the window just flushed.
 	fn flush_window(&mut self) -> anyhow::Result<Output> {
 		let window = self.window.take().context("no window to flush")?;
+		self.sleep = None;
 		let output = Output {
 			payload: Bytes::from(window.buf),
 			pace: window.pace,
@@ -490,6 +498,7 @@ impl<E: CatalogExt> Export<E> {
 	/// Emit the trailing window at end of stream, or `None` when it holds only its PCR: with
 	/// nothing left to bridge to, an empty window is not worth a filler.
 	fn flush_final(&mut self) -> Option<Output> {
+		self.sleep = None;
 		let window = self.window.take()?;
 		window.has_media.then(|| Output {
 			payload: Bytes::from(window.buf),


### PR DESCRIPTION
## Summary

Stacked on #1992. Moves the windowed exporter's live-edge wait out of moq-mux and into kio as **`kio::tokio::Sleep`**, behind an off-by-default `tokio` feature.

Rather than a re-arming `Timer`, `kio::tokio::Sleep` is a thin wrapper over `tokio::time::Sleep`: construct it once for a deadline, then poll it against a `kio::Waiter` (the wrapper builds a `Context` from the waiter's waker). It's a general `poll_*` primitive, so it belongs next to the `Waiter` machinery it hooks into, not inlined in the TS muxer.

## What changes

- **kio**: new `tokio` module (public, gated behind the `tokio` feature) with `Sleep`. The feature pulls in `tokio` (only `time`) as an optional dependency, so **kio stays runtime-free by default** — the pure `smallvec`-only build is unchanged, and a caller opts into the wrapper explicitly. `Waiter::waker()` (added in #1992) is now used in-crate as intended.
- **moq-mux**: drops the inlined `pace::Timer`, enables `kio`'s `tokio` feature, and uses `kio::tokio::Sleep`. It builds one sleep per live-edge episode (when a track blocks mid-window) and drops it when the window flushes, so a changed deadline gets a fresh sleep. The unit test moves to kio.

## API surface

- kio: new `kio::tokio` module + `kio::tokio::Sleep` (public, only under `feature = "tokio"`); new `tokio` feature. Additive.
- moq-mux: internal only (`pace::Timer` was `pub(crate)`).

## Test plan

- [x] `cargo build -p kio` (default, pure) and `-p kio --features tokio` both clean.
- [x] `cargo test -p kio --features tokio` — `sleep_fires_at_its_deadline` passes under paused time.
- [x] `cargo test -p moq-mux --lib container::ts` (66) green using `kio::tokio::Sleep`.
- [x] `cargo clippy -p kio --features tokio -p moq-mux --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)