### PR TITLE
[codex] configure moq-cli CORS origins

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -214,6 +214,10 @@ moq --client-connect https://relay.example.com/anon --broadcast my-stream.hang \
     export hls --listen '[::]:8089'
 ```
 
+HLS export does not allow cross-origin browser access unless configured. Pass
+`--cors-origin <origin>` one or more times to allow specific origins, or
+`--cors-origin '*'` to allow any browser origin.
+
 ## Network Gateways (RTMP / SRT / WebRTC)
 
 The `rtmp`, `srt`, and `rtc` endpoints bridge other live protocols. Each takes
@@ -273,6 +277,10 @@ moq --client-connect https://relay.example.com/anon --broadcast my-stream.hang i
 # WHEP playback: serve a broadcast to browsers
 moq --client-connect https://relay.example.com/anon --broadcast my-stream.hang export rtc --listen '[::]:8080'
 ```
+
+The WHIP/WHEP HTTP listener does not allow cross-origin browser access unless
+configured. Pass `--cors-origin <origin>` one or more times to allow specific
+origins, or `--cors-origin '*'` to allow any browser origin.
 
 ## Authentication
 

--- a/rs/moq-cli/src/hls.rs
+++ b/rs/moq-cli/src/hls.rs
@@ -5,9 +5,9 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use anyhow::Context;
+use axum::http::Method;
 use hang::moq_net;
 use hang::moq_net::AsPath;
-use tower_http::cors::{Any, CorsLayer};
 
 use crate::moq::notify_ready;
 
@@ -36,6 +36,10 @@ pub struct ExportArgs {
 	/// Minimum media kept in each rendition's sliding window.
 	#[arg(long, default_value = "16s", value_parser = humantime::parse_duration)]
 	pub window: Duration,
+
+	/// Browser CORS policy for the HLS listener.
+	#[command(flatten)]
+	pub cors: crate::web::Cors,
 }
 
 /// Pull a remote HLS/LL-HLS playlist (URL or file path) into the Origin under `name`.
@@ -69,9 +73,7 @@ pub async fn export(origin: moq_net::OriginConsumer, args: ExportArgs, name: Str
 		..Default::default()
 	};
 	let server = moq_hls::Server::new(scoped, config);
-	let app = server
-		.router()
-		.layer(CorsLayer::new().allow_origin(Any).allow_methods(Any).allow_headers(Any));
+	let app = server.router().layer(args.cors.layer([Method::GET])?);
 
 	let tls = if args.tls.cert.is_empty() && args.tls.generate.is_empty() {
 		None

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -129,9 +129,11 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 						addr,
 						rtc.udp_bind,
 						rtc.public_addr,
+						rtc.cors,
 						name,
 					));
 				} else if let Some(url) = rtc.connect {
+					reject_listener_cors(&rtc.cors, "import rtc")?;
 					tasks.spawn(rtc::connect_import(origin.clone(), url, name));
 				}
 			}
@@ -203,9 +205,11 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 						addr,
 						rtc.udp_bind,
 						rtc.public_addr,
+						rtc.cors,
 						name,
 					));
 				} else if let Some(url) = rtc.connect {
+					reject_listener_cors(&rtc.cors, "export rtc")?;
 					tasks.spawn(rtc::connect_export(origin.consume(), url, name));
 				}
 			}
@@ -265,4 +269,12 @@ fn warn_if_missing_format(name: &str) {
 			"You should append .hang to your broadcast name to make the catalog format explicit."
 		);
 	}
+}
+
+fn reject_listener_cors(cors: &crate::web::Cors, endpoint: &str) -> anyhow::Result<()> {
+	anyhow::ensure!(
+		cors.origin.is_empty(),
+		"`--cors-origin` only applies to `{endpoint} --listen`"
+	);
+	Ok(())
 }

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -76,6 +76,12 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 	let name = moq.broadcast.clone().unwrap_or_default();
 	let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
 
+	if let ImportSource::Rtc(rtc) = &import.source {
+		if rtc.connect.is_some() {
+			reject_listener_cors(&rtc.cors, "import rtc")?;
+		}
+	}
+
 	// MoQ side: publish the Origin outward.
 	if let Some(url) = moq.client_connect.clone() {
 		let client = net.client(moq.client.clone())?;
@@ -133,7 +139,6 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 						name,
 					));
 				} else if let Some(url) = rtc.connect {
-					reject_listener_cors(&rtc.cors, "import rtc")?;
 					tasks.spawn(rtc::connect_import(origin.clone(), url, name));
 				}
 			}
@@ -151,6 +156,12 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 	// path plus any explicit `--broadcast`, so an unset name is the root broadcast.
 	let name = moq.broadcast.clone().unwrap_or_default();
 	let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
+
+	if let ExportSink::Rtc(rtc) = &export.sink {
+		if rtc.connect.is_some() {
+			reject_listener_cors(&rtc.cors, "export rtc")?;
+		}
+	}
 
 	// MoQ side: fill the Origin.
 	if let Some(url) = moq.client_connect.clone() {
@@ -209,7 +220,6 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 						name,
 					));
 				} else if let Some(url) = rtc.connect {
-					reject_listener_cors(&rtc.cors, "export rtc")?;
 					tasks.spawn(rtc::connect_export(origin.consume(), url, name));
 				}
 			}

--- a/rs/moq-cli/src/rtc.rs
+++ b/rs/moq-cli/src/rtc.rs
@@ -5,9 +5,9 @@
 use std::net::SocketAddr;
 
 use anyhow::Context;
+use axum::http::Method;
 use hang::moq_net;
 use hang::moq_net::AsPath;
-use tower_http::cors::{Any, CorsLayer};
 use url::Url;
 
 use crate::moq::notify_ready;
@@ -33,6 +33,10 @@ pub struct Args {
 	/// Public UDP address(es) advertised as ICE host candidates (repeatable).
 	#[arg(long, requires = "rtc-listen")]
 	pub public_addr: Vec<SocketAddr>,
+
+	/// Browser CORS policy for the WHIP/WHEP listener.
+	#[command(flatten)]
+	pub cors: crate::web::Cors,
 }
 
 /// WHIP server: accept incoming WebRTC publishes into the Origin as `name` (import).
@@ -41,11 +45,12 @@ pub async fn listen_import(
 	listen: SocketAddr,
 	udp_bind: SocketAddr,
 	public_addr: Vec<SocketAddr>,
+	cors: crate::web::Cors,
 	name: String,
 ) -> anyhow::Result<()> {
 	let publisher = scope_producer(&origin, &name)?;
 	let server = server(publisher, origin.consume(), udp_bind, public_addr);
-	serve(server.publish_router(), listen, "WHIP").await
+	serve(server.publish_router(), listen, "WHIP", cors).await
 }
 
 /// WHEP server: serve WebRTC plays of `name` from the Origin (export).
@@ -54,6 +59,7 @@ pub async fn listen_export(
 	listen: SocketAddr,
 	udp_bind: SocketAddr,
 	public_addr: Vec<SocketAddr>,
+	cors: crate::web::Cors,
 	name: String,
 ) -> anyhow::Result<()> {
 	let subscriber = origin
@@ -63,7 +69,7 @@ pub async fn listen_export(
 	// glue, so hand it an unused, empty Origin producer.
 	let publisher = moq_net::Origin::random().produce();
 	let server = server(publisher, subscriber, udp_bind, public_addr);
-	serve(server.subscribe_router(), listen, "WHEP").await
+	serve(server.subscribe_router(), listen, "WHEP", cors).await
 }
 
 /// Restrict a producer to the single broadcast `name` so a WHIP peer can only publish it.
@@ -114,8 +120,9 @@ fn server(
 	moq_rtc::Server::new(config, publisher, subscriber)
 }
 
-async fn serve(router: axum::Router, listen: SocketAddr, role: &str) -> anyhow::Result<()> {
-	let app = router.layer(CorsLayer::new().allow_origin(Any).allow_methods(Any).allow_headers(Any));
+async fn serve(router: axum::Router, listen: SocketAddr, role: &str, cors: crate::web::Cors) -> anyhow::Result<()> {
+	let cors = cors.layer([Method::POST, Method::PATCH, Method::DELETE, Method::OPTIONS])?;
+	let app = router.layer(cors);
 	let listener = moq_native::bind::tcp(listen)?;
 
 	tracing::info!(%listen, role, "serving WebRTC");

--- a/rs/moq-cli/src/web.rs
+++ b/rs/moq-cli/src/web.rs
@@ -38,39 +38,6 @@ fn parse_origin(origin: &str) -> Result<HeaderValue, axum::http::header::Invalid
 	origin.parse()
 }
 
-#[cfg(test)]
-mod tests {
-	use super::*;
-
-	#[test]
-	fn cors_origin_defaults_to_no_browser_origin() {
-		let cors = Cors::default();
-
-		assert!(cors.layer([Method::GET]).is_ok());
-	}
-
-	#[test]
-	fn cors_origin_allows_specific_allowlist() {
-		let cors = Cors {
-			origin: vec![HeaderValue::from_static("https://example.com")],
-		};
-
-		assert!(cors.layer([Method::GET]).is_ok());
-	}
-
-	#[test]
-	fn cors_origin_rejects_wildcard_with_allowlist() {
-		let cors = Cors {
-			origin: vec![
-				HeaderValue::from_static("*"),
-				HeaderValue::from_static("https://example.com"),
-			],
-		};
-
-		assert!(cors.layer([Method::GET]).is_err());
-	}
-}
-
 /// Serve an axum router over TCP, optionally terminating TLS. Used by the HLS
 /// and WebRTC (WHIP/WHEP) HTTP endpoints.
 pub async fn serve(
@@ -128,4 +95,37 @@ pub async fn run_web(bind: &str, tls_info: Arc<RwLock<moq_native::tls::Info>>) -
 	server.serve(app.into_make_service()).await?;
 
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn cors_origin_defaults_to_no_browser_origin() {
+		let cors = Cors::default();
+
+		assert!(cors.layer([Method::GET]).is_ok());
+	}
+
+	#[test]
+	fn cors_origin_allows_specific_allowlist() {
+		let cors = Cors {
+			origin: vec![HeaderValue::from_static("https://example.com")],
+		};
+
+		assert!(cors.layer([Method::GET]).is_ok());
+	}
+
+	#[test]
+	fn cors_origin_rejects_wildcard_with_allowlist() {
+		let cors = Cors {
+			origin: vec![
+				HeaderValue::from_static("*"),
+				HeaderValue::from_static("https://example.com"),
+			],
+		};
+
+		assert!(cors.layer([Method::GET]).is_err());
+	}
 }

--- a/rs/moq-cli/src/web.rs
+++ b/rs/moq-cli/src/web.rs
@@ -1,10 +1,75 @@
 use anyhow::Context;
 use axum::handler::HandlerWithoutStateExt;
-use axum::http::StatusCode;
+use axum::http::{HeaderValue, Method, StatusCode};
 use axum::response::IntoResponse;
-use axum::{Router, http::Method, routing::get};
+use axum::{Router, routing::get};
 use std::sync::{Arc, RwLock};
 use tower_http::cors::{Any, CorsLayer};
+
+/// Browser CORS policy for HTTP gateway listeners.
+#[derive(clap::Args, Clone, Default)]
+pub struct Cors {
+	/// Browser origin allowed to call this listener. Repeat to allow multiple.
+	#[arg(long = "cors-origin", value_name = "ORIGIN", value_parser = parse_origin)]
+	pub origin: Vec<HeaderValue>,
+}
+
+impl Cors {
+	/// Build a CORS layer for the given listener methods.
+	pub fn layer<const N: usize>(&self, methods: [Method; N]) -> anyhow::Result<CorsLayer> {
+		let layer = CorsLayer::new().allow_methods(methods).allow_headers(Any);
+		let wildcard = HeaderValue::from_static("*");
+
+		Ok(match self.origin.as_slice() {
+			[] => layer,
+			[origin] if origin == wildcard => layer.allow_origin(Any),
+			origins => {
+				anyhow::ensure!(
+					!origins.contains(&wildcard),
+					"`--cors-origin *` cannot be combined with specific origins"
+				);
+				layer.allow_origin(origins.to_vec())
+			}
+		})
+	}
+}
+
+fn parse_origin(origin: &str) -> Result<HeaderValue, axum::http::header::InvalidHeaderValue> {
+	origin.parse()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn cors_origin_defaults_to_no_browser_origin() {
+		let cors = Cors::default();
+
+		assert!(cors.layer([Method::GET]).is_ok());
+	}
+
+	#[test]
+	fn cors_origin_allows_specific_allowlist() {
+		let cors = Cors {
+			origin: vec![HeaderValue::from_static("https://example.com")],
+		};
+
+		assert!(cors.layer([Method::GET]).is_ok());
+	}
+
+	#[test]
+	fn cors_origin_rejects_wildcard_with_allowlist() {
+		let cors = Cors {
+			origin: vec![
+				HeaderValue::from_static("*"),
+				HeaderValue::from_static("https://example.com"),
+			],
+		};
+
+		assert!(cors.layer([Method::GET]).is_err());
+	}
+}
 
 /// Serve an axum router over TCP, optionally terminating TLS. Used by the HLS
 /// and WebRTC (WHIP/WHEP) HTTP endpoints.


### PR DESCRIPTION
## Summary

- Add `--cors-origin <ORIGIN>` to the `moq-cli` HLS export and WHIP/WHEP listener paths.
- Leave CORS disabled by default when no origins are provided, while supporting explicit origin allowlists and `--cors-origin '*'` for wildcard access.
- Narrow CORS methods for HLS and WHIP/WHEP and document the new listener behavior.

Fixes #1986.

## Validation

- `just fix`
- `cargo fmt --all`
- `cargo test -p moq-cli web::tests`
- `cargo check -p moq-cli`
- `git diff --check`

(Written by GPT-5)