### PR TITLE
fix(moq-video): make NVENC encode correct on hardware (forced IDR, in-band param sets, pitched input)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -107,10 +107,12 @@
             # cpal's `alsa-sys` (moq-audio `capture` feature) links libasound on
             # Linux via pkg-config; macOS uses CoreAudio, so no dep there.
             pkgs.alsa-lib
-            # moq-video's VAAPI backend (always-on for Linux): the moq-vaapi crate
-            # (moq-dev/vaapi) vendors the libva headers so bindgen needs no system
-            # libva, but libva is dlopen'd at runtime, so this provides libva.so for
-            # actually running vaapi encode in the devShell. macOS has no VAAPI.
+            # moq-video's VAAPI backend (always-on for Linux): moq-vaapi links
+            # libva via pkg-config at build time and the resulting binary carries
+            # NEEDED libva.so.2 / libva-drm.so.2, so libva must be present both to
+            # build and to run vaapi in the devShell. macOS has no VAAPI. (See
+            # #1837: if moq-vaapi switches to dlopen'ing libva, this stays needed
+            # only to run it, and a libva-less build/host would fall back cleanly.)
             pkgs.libva
           ];
 

--- a/rs/moq-video/CHANGELOG.md
+++ b/rs/moq-video/CHANGELOG.md
@@ -32,8 +32,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unverified on hardware (the test box had no HEVC decoder MFT installed).
 - H.265 encode via the NVENC backend (Linux, `nvenc` feature). The codec is
   selected by `encode::Codec`; the NVENC HEVC path shares the H.264 preset / GOP
-  / rate-control setup and emits Annex-B with inline VPS/SPS/PPS. Not yet
-  validated on hardware.
+  / rate-control setup and emits Annex-B with inline VPS/SPS/PPS.
+- NVENC H.264/H.265 encode verified end-to-end on a Linux + NVIDIA box (RTX 30
+  series), which fixed three correctness bugs the software-only path had hidden:
+  a forced keyframe now emits an IDR (via the `FORCEIDR` picture flag, since
+  picture-type decision makes NVENC ignore `pictureType`); every IDR, not just
+  the first, carries inline SPS/PPS (VPS too for HEVC) so a mid-stream subscriber
+  can join at any keyframe (`repeatSPSPPS` + `idrPeriod`); and the input frame is
+  copied at NVENC's real buffer pitch (e.g. 512 for a 320-wide buffer) instead of
+  a flat copy that sheared the image, which also drops the former width-multiple-
+  of-64 restriction. Requires a matching `nvidia-video-codec-sdk` fork bump
+  (`force_idr` flag + pitched `BufferLock::write_rows`).
 
 ## [0.0.5](https://github.com/moq-dev/moq/compare/moq-video-v0.0.4...moq-video-v0.0.5) - 2026-06-23
 

--- a/rs/moq-video/src/decode/mod.rs
+++ b/rs/moq-video/src/decode/mod.rs
@@ -12,7 +12,10 @@
 
 use bytes::Bytes;
 
-mod backend;
+// Crate-visible so the NVENC encode backend's round-trip test can decode its
+// output with the software decoder (an in-crate, ffmpeg-free encode->decode
+// check that catches input-pitch corruption).
+pub(crate) mod backend;
 mod consumer;
 mod decoder;
 

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -8,23 +8,26 @@
 //! inline avc3 / hev1 mode directly. The codec is chosen by [`Config::codec`];
 //! only the codec GUID differs, the preset / GOP / rate-control setup is shared.
 //!
-//! NOT YET VALIDATED ON HARDWARE. Two things need checking on a real Linux+GPU
-//! box before this ships in releases:
-//!   1. The safe wrapper's input buffer does a flat `write`, which only matches
-//!      NVENC's chosen pitch when the width is suitably aligned (multiples of 64
-//!      are safe). Non-aligned widths would need pitched writes via the `sys`
-//!      lock API. We warn at open if the width looks risky.
-//!   2. The exact `NV_ENC_CONFIG` field set for rate control / GOP.
-//!   3. H.265: that the HEVC GUID path emits Annex-B with VPS/SPS/PPS inline
-//!      ahead of each IDR (the hev1 importer relies on it, as it does for the
-//!      VideoToolbox H.265 backend).
+//! Three hardware details this backend gets right (all verified on a Linux +
+//! NVIDIA box, see the tests below):
+//!   1. A forced keyframe uses the `FORCEIDR` picture flag, not `pictureType`.
+//!      Picture-type decision stays on (the low-latency presets are tuned for
+//!      it), which makes NVENC ignore `pictureType`; `FORCEIDR` still applies and
+//!      is how [`Nvenc::encode`] turns `keyframe` into an out-of-cadence IDR.
+//!   2. `repeatSPSPPS` is set so every IDR (not just the first) carries in-band
+//!      SPS/PPS (plus VPS for HEVC), which a mid-stream subscriber's avc3 / hev1
+//!      importer needs to start decoding at any keyframe.
+//!   3. The input frame is copied row by row at NVENC's chosen buffer pitch. The
+//!      pitch is aligned (e.g. 512 for a 320-wide buffer) and usually exceeds the
+//!      width, so a flat copy would shear the image; [`Nvenc::encode`] writes
+//!      each plane pitched, which works for any (even) width.
 
 use std::sync::Arc;
 
 use bytes::Bytes;
 use cudarc::driver::CudaContext;
 use nvidia_video_codec_sdk::sys::nvEncodeAPI::{
-	GUID, NV_ENC_BUFFER_FORMAT, NV_ENC_CODEC_H264_GUID, NV_ENC_CODEC_HEVC_GUID, NV_ENC_PARAMS_RC_MODE, NV_ENC_PIC_TYPE,
+	GUID, NV_ENC_BUFFER_FORMAT, NV_ENC_CODEC_H264_GUID, NV_ENC_CODEC_HEVC_GUID, NV_ENC_PARAMS_RC_MODE,
 	NV_ENC_PRESET_P4_GUID, NV_ENC_TUNING_INFO,
 };
 use nvidia_video_codec_sdk::{Encoder, EncoderInitParams, Session};
@@ -57,17 +60,6 @@ unsafe impl Send for Nvenc {}
 
 impl Nvenc {
 	pub(crate) fn open(config: &Config) -> Result<Box<dyn Backend>, Error> {
-		if config.width % 64 != 0 {
-			// Flat writes assume pitch == width; NVENC aligns pitch, so a
-			// non-64-aligned width risks corrupting the encoded chroma. Fail so
-			// `Kind::Auto` falls back to the next backend instead of producing
-			// garbage.
-			return Err(Error::Codec(anyhow::anyhow!(
-				"nvenc requires a width that is a multiple of 64 (got {})",
-				config.width
-			)));
-		}
-
 		// cudarc and the NVENC SDK dlopen their driver libraries lazily and
 		// *panic* (which aborts the process, since release builds set
 		// `panic = "abort"`) when a library is missing, e.g. on a host with no
@@ -102,7 +94,34 @@ impl Nvenc {
 		cfg.rcParams.rateControlMode = NV_ENC_PARAMS_RC_MODE::NV_ENC_PARAMS_RC_CBR;
 		cfg.rcParams.averageBitRate = config.resolved_bitrate().min(u32::MAX as u64) as u32;
 
+		// Two codec-specific knobs the importer relies on, verified on hardware:
+		//   - repeatSPSPPS: emit the parameter sets in-band ahead of *every* IDR,
+		//     not just the first. A moq subscriber can join at any keyframe and the
+		//     avc3 / hev1 importer reads SPS/PPS (plus VPS for HEVC) from each one;
+		//     without this NVENC sends them once and later keyframes are
+		//     undecodable for late joiners.
+		//   - idrPeriod == gopLength: make every periodic I-frame an IDR (a clean
+		//     random-access point), so each GOP boundary is joinable.
+		//
+		// SAFETY: the preset config's codec union was initialized by
+		// `get_preset_config` for `codec_guid`, so we write the matching arm.
+		unsafe {
+			match config.codec {
+				Codec::H264 => {
+					cfg.encodeCodecConfig.h264Config.set_repeatSPSPPS(1);
+					cfg.encodeCodecConfig.h264Config.idrPeriod = config.gop;
+				}
+				Codec::H265 => {
+					cfg.encodeCodecConfig.hevcConfig.set_repeatSPSPPS(1);
+					cfg.encodeCodecConfig.hevcConfig.idrPeriod = config.gop;
+				}
+			}
+		}
+
 		let mut init = EncoderInitParams::new(codec_guid, config.width, config.height);
+		// Picture-type decision on: NVENC owns the P/IDR structure and inserts an
+		// IDR every `gopLength`. The low-latency presets are tuned for this mode;
+		// driving picture types by hand (PTD off) misbehaves on these presets.
 		init.preset_guid(NV_ENC_PRESET_P4_GUID)
 			.tuning_info(NV_ENC_TUNING_INFO::NV_ENC_TUNING_INFO_LOW_LATENCY)
 			.framerate(config.framerate, 1)
@@ -142,22 +161,29 @@ impl Backend for Nvenc {
 		// NVENC takes CPU I420; download a surface if capture handed us one.
 		let i420 = frame.to_i420()?;
 
-		// SAFETY: the lock is held until the guard drops, and we write exactly
-		// one I420 frame's worth of bytes. See the pitch caveat at the top.
+		// Copy the tightly-packed I420 planes into the input buffer honoring
+		// NVENC's chosen row stride: the buffer pitch can exceed the width even
+		// for aligned widths, so a flat write would shear the image. For IYUV the
+		// chroma planes use half the luma pitch.
+		let mut lock = input
+			.lock()
+			.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC lock input: {e}")))?;
+		let pitch = lock.pitch() as usize;
+		let (w, h) = (i420.width as usize, i420.height as usize);
+		let (cw, ch) = (w / 2, h / 2);
+		let cpitch = pitch / 2;
+		// SAFETY: offsets stay within the pitch*height*3/2 IYUV buffer and each
+		// source plane is exactly row_bytes * rows.
 		unsafe {
-			input
-				.lock()
-				.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC lock input: {e}")))?
-				.write(&i420.data);
+			lock.write_rows(0, pitch, i420.y(), w, h);
+			lock.write_rows(pitch * h, cpitch, i420.u(), cw, ch);
+			lock.write_rows(pitch * h + cpitch * ch, cpitch, i420.v(), cw, ch);
 		}
+		drop(lock);
 
 		let params = nvidia_video_codec_sdk::EncodePictureParams {
 			input_timestamp: self.timestamp,
-			picture_type: if keyframe {
-				NV_ENC_PIC_TYPE::NV_ENC_PIC_TYPE_IDR
-			} else {
-				NV_ENC_PIC_TYPE::NV_ENC_PIC_TYPE_UNKNOWN
-			},
+			force_idr: keyframe,
 			..Default::default()
 		};
 		self.timestamp += 1;
@@ -223,8 +249,236 @@ mod tests {
 		if driver_libs_present() {
 			return; // real driver present: open() would legitimately try to run
 		}
-		// width % 64 == 0 so we get past the pitch guard to the driver probe.
 		let config = Config::new(1920, 1080, 30);
 		assert!(Nvenc::open(&config).is_err());
+	}
+
+	/// A mid-gray RGBA frame, encodable without a camera.
+	fn gray_rgba(width: u32, height: u32) -> Vec<u8> {
+		vec![0x80u8; width as usize * height as usize * 4]
+	}
+
+	/// H.264 NAL unit types in an Annex-B buffer, found via 3-byte start codes (a
+	/// 4-byte `00 00 00 01` code contains `00 00 01` too, so this catches both).
+	fn h264_nal_types(annexb: &[u8]) -> Vec<u8> {
+		let mut types = Vec::new();
+		let mut i = 0;
+		while i + 3 < annexb.len() {
+			if annexb[i..i + 3] == [0, 0, 1] {
+				types.push(annexb[i + 3] & 0x1f);
+				i += 3;
+			} else {
+				i += 1;
+			}
+		}
+		types
+	}
+
+	/// HEVC NAL unit types in an Annex-B buffer (type = `(byte >> 1) & 0x3f`).
+	fn hevc_nal_types(annexb: &[u8]) -> Vec<u8> {
+		let mut types = Vec::new();
+		let mut i = 0;
+		while i + 3 < annexb.len() {
+			if annexb[i..i + 3] == [0, 0, 1] {
+				types.push((annexb[i + 3] >> 1) & 0x3f);
+				i += 3;
+			} else {
+				i += 1;
+			}
+		}
+		types
+	}
+
+	/// Real-hardware H.264 encode through NVENC. Skipped (returns) on a box with
+	/// no NVIDIA driver, so it is a no-op on GPU-less CI and validates on a real
+	/// Linux + NVIDIA box. Asserts a self-contained IDR (inline SPS+PPS+slice)
+	/// and, critically, that a mid-stream *forced* keyframe repeats the parameter
+	/// sets: the avc3 importer relies on every IDR carrying its own SPS/PPS, which
+	/// NVENC only does with `repeatSPSPPS` enabled.
+	#[test]
+	fn nvenc_h264_keyframes_carry_param_sets() {
+		if !driver_libs_present() {
+			return;
+		}
+		// 320 % 64 == 0, so the flat-write pitch assumption holds.
+		let config = crate::encode::Config {
+			kind: crate::encode::Kind::Named(NAME.into()),
+			..crate::encode::Config::new(320, 240, 30)
+		};
+		let Ok(mut encoder) = crate::encode::Encoder::new(&config) else {
+			// Driver present but NVENC still unusable (e.g. GPU busy); don't fail.
+			return;
+		};
+		assert_eq!(encoder.name(), NAME);
+
+		let frame = gray_rgba(320, 240);
+		// Force a keyframe on frame 0 and again mid-stream at frame 5.
+		let mut first = Vec::new();
+		let mut forced = Vec::new();
+		for i in 0..10u32 {
+			let keyframe = i == 0 || i == 5;
+			let packets = encoder.encode_rgba(&frame, 320, 240, keyframe).unwrap();
+			let joined: Vec<u8> = packets.iter().flatten().copied().collect();
+			if i == 0 {
+				first = joined;
+			} else if i == 5 {
+				forced = joined;
+			}
+		}
+
+		let types = h264_nal_types(&first);
+		assert!(types.contains(&7), "no SPS in first IDR: {types:?}");
+		assert!(types.contains(&8), "no PPS in first IDR: {types:?}");
+		assert!(types.contains(&5), "first packet is not an IDR: {types:?}");
+
+		let types = h264_nal_types(&forced);
+		assert!(types.contains(&5), "forced keyframe is not an IDR: {types:?}");
+		assert!(types.contains(&7), "forced IDR is missing inline SPS: {types:?}");
+		assert!(types.contains(&8), "forced IDR is missing inline PPS: {types:?}");
+	}
+
+	/// Real-hardware H.265 encode through NVENC. Same skip rule as the H.264 test.
+	/// Asserts the HEVC GUID path emits Annex-B with a self-contained IRAP
+	/// (VPS+SPS+PPS+IDR slice) and repeats them on a mid-stream forced keyframe,
+	/// which the hev1 importer relies on.
+	#[test]
+	fn nvenc_h265_keyframes_carry_param_sets() {
+		if !driver_libs_present() {
+			return;
+		}
+		let config = crate::encode::Config {
+			codec: crate::encode::Codec::H265,
+			kind: crate::encode::Kind::Named(NAME.into()),
+			..crate::encode::Config::new(320, 240, 30)
+		};
+		let Ok(mut encoder) = crate::encode::Encoder::new(&config) else {
+			return;
+		};
+		assert_eq!(encoder.name(), NAME);
+		assert_eq!(encoder.codec(), crate::encode::Codec::H265);
+
+		let frame = gray_rgba(320, 240);
+		let mut first = Vec::new();
+		let mut forced = Vec::new();
+		for i in 0..10u32 {
+			let keyframe = i == 0 || i == 5;
+			let packets = encoder.encode_rgba(&frame, 320, 240, keyframe).unwrap();
+			let joined: Vec<u8> = packets.iter().flatten().copied().collect();
+			if i == 0 {
+				first = joined;
+			} else if i == 5 {
+				forced = joined;
+			}
+		}
+
+		let is_irap = |t: &u8| (16..=23).contains(t);
+		let types = hevc_nal_types(&first);
+		assert!(types.contains(&32), "no VPS in first IRAP: {types:?}");
+		assert!(types.contains(&33), "no SPS in first IRAP: {types:?}");
+		assert!(types.contains(&34), "no PPS in first IRAP: {types:?}");
+		assert!(types.iter().any(is_irap), "first packet is not an IRAP: {types:?}");
+
+		let types = hevc_nal_types(&forced);
+		assert!(types.iter().any(is_irap), "forced keyframe is not an IRAP: {types:?}");
+		assert!(types.contains(&32), "forced IRAP is missing inline VPS: {types:?}");
+		assert!(types.contains(&33), "forced IRAP is missing inline SPS: {types:?}");
+		assert!(types.contains(&34), "forced IRAP is missing inline PPS: {types:?}");
+	}
+
+	/// The capture producer forces a keyframe only on the first frame and relies
+	/// on the backend to insert periodic IDRs at the GOP boundary. Verify those
+	/// happen without a forced keyframe and each carries inline SPS/PPS, so a
+	/// mid-stream subscriber can join at any GOP boundary.
+	#[test]
+	fn nvenc_h264_periodic_idr_at_gop() {
+		if !driver_libs_present() {
+			return;
+		}
+		let mut config = crate::encode::Config::new(320, 240, 30);
+		config.kind = crate::encode::Kind::Named(NAME.into());
+		config.gop = 3;
+		let Ok(mut encoder) = crate::encode::Encoder::new(&config) else {
+			return;
+		};
+
+		let frame = gray_rgba(320, 240);
+		let mut idr_frames = Vec::new();
+		// Never force a keyframe (only frame 0 would be); the backend must insert
+		// IDRs at frames 3 and 6 on its own.
+		for i in 0..7u32 {
+			let packets = encoder.encode_rgba(&frame, 320, 240, false).unwrap();
+			let joined: Vec<u8> = packets.iter().flatten().copied().collect();
+			let types = h264_nal_types(&joined);
+			if types.contains(&5) {
+				assert!(types.contains(&7), "periodic IDR at frame {i} missing SPS: {types:?}");
+				assert!(types.contains(&8), "periodic IDR at frame {i} missing PPS: {types:?}");
+				idr_frames.push(i);
+			}
+		}
+		assert_eq!(idr_frames, vec![0, 3, 6], "IDRs not at the expected GOP boundaries");
+	}
+
+	/// A static RGBA gradient that varies in both axes, so the chroma planes have
+	/// spatial structure and an input-pitch bug shears the decoded image.
+	fn gradient_rgba(width: u32, height: u32) -> Vec<u8> {
+		let (w, h) = (width as usize, height as usize);
+		let mut buf = vec![0u8; w * h * 4];
+		for y in 0..h {
+			for x in 0..w {
+				let i = (y * w + x) * 4;
+				buf[i] = (x * 255 / w) as u8;
+				buf[i + 1] = (y * 255 / h) as u8;
+				buf[i + 2] = ((x + y) * 255 / (w + h)) as u8;
+				buf[i + 3] = 255;
+			}
+		}
+		buf
+	}
+
+	/// End-to-end pitch check with no external decoder: encode a spatial gradient
+	/// through NVENC, decode it with the in-crate openh264 software decoder, and
+	/// assert the result matches the input. NVENC's input buffer pitch exceeds the
+	/// width (e.g. 512 for 320), so a flat copy would shear the image; this guards
+	/// the pitched write in [`Nvenc::encode`]. Uses a width that is not a multiple
+	/// of 64 so pitch != width is actually exercised.
+	#[test]
+	fn nvenc_h264_pitched_write_roundtrips() {
+		if !driver_libs_present() {
+			return;
+		}
+		let (w, h) = (300u32, 240u32);
+		let config = crate::encode::Config {
+			kind: crate::encode::Kind::Named(NAME.into()),
+			..crate::encode::Config::new(w, h, 30)
+		};
+		let Ok(mut encoder) = crate::encode::Encoder::new(&config) else {
+			return;
+		};
+
+		let rgba = gradient_rgba(w, h);
+		let expected = crate::frame::I420::from_rgba(&rgba, w, h).unwrap();
+
+		let mut decoder =
+			crate::decode::backend::open(crate::decode::backend::Codec::H264, &crate::decode::Kind::Software).unwrap();
+
+		// A static image, so every decoded frame equals the input regardless of
+		// decoder latency or frame reordering.
+		let mut decoded = None;
+		for i in 0..10u32 {
+			for packet in encoder.encode_rgba(&rgba, w, h, i == 0).unwrap() {
+				for frame in decoder.decode(packet, i == 0).unwrap() {
+					decoded = Some(frame);
+				}
+			}
+		}
+		let decoded = decoded.expect("decoder produced at least one frame");
+
+		// Mean absolute error per plane. A pitch bug shears the chroma and pushes
+		// this well above 20; compression alone keeps it near zero.
+		let mae =
+			|a: &[u8], b: &[u8]| a.iter().zip(b).map(|(x, y)| x.abs_diff(*y) as u64).sum::<u64>() / a.len() as u64;
+		assert!(mae(decoded.y(), expected.y()) < 8, "Y plane corrupt (pitch?)");
+		assert!(mae(decoded.u(), expected.u()) < 8, "U plane corrupt (pitch?)");
+		assert!(mae(decoded.v(), expected.v()) < 8, "V plane corrupt (pitch?)");
 	}
 }

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -300,7 +300,6 @@ mod tests {
 		if !driver_libs_present() {
 			return;
 		}
-		// 320 % 64 == 0, so the flat-write pitch assumption holds.
 		let config = crate::encode::Config {
 			kind: crate::encode::Kind::Named(NAME.into()),
 			..crate::encode::Config::new(320, 240, 30)


### PR DESCRIPTION
## Summary

Validated `moq-video`'s NVENC backend on a Linux + NVIDIA box (RTX 3070 Ti, driver 595.71.05) for [#1837](https://github.com/moq-dev/moq/issues/1837). NVENC encode was compile-verified only and had never actually run on hardware; doing so surfaced **three correctness bugs**, all fixed here with hardware-gated regression tests.

1. **Forced keyframes were silently ignored.** `enable_picture_type_decision` makes NVENC choose frame types and ignore the per-frame `pictureType`, so `encode(..., keyframe=true)` mid-stream produced a P frame, not an IDR. Now uses the `FORCEIDR` picture flag, which applies with picture-type decision on. (Masked before because the capture producer only forces a keyframe on the first frame, which is an IDR regardless.)
2. **Only the first IDR carried parameter sets.** Periodic/GOP IDRs had no SPS/PPS (nor VPS for HEVC), so a subscriber joining mid-stream couldn't decode at any later keyframe — exactly what avc3/hev1 rely on. Fixed with `repeatSPSPPS` + `idrPeriod = gop`.
3. **Every frame was corrupted.** NVENC's input-buffer pitch exceeds the width (512 for a 320-wide IYUV buffer, 256-aligned), but the write was flat, shearing the image. The old `width % 64 == 0` guard's "aligned is safe" premise was wrong. Fixed with a pitched, plane-by-plane copy at the buffer's real stride. Also removes the width-multiple-of-64 restriction (any even width works now).

Plus a small **flake doc fix**: the `libva` devShell comment claimed moq-vaapi dlopens libva with vendored headers; moq-vaapi 0.0.2 actually links it via pkg-config and the binary carries `NEEDED libva.so.2` / `libva-drm.so.2` (build- and run-time dep). Verified in a fresh `nix develop` that the vaapi feature builds and the vaapi-linked binary loads without any `LD_LIBRARY_PATH` override.

## Dependency

Fixes 1 and 3 need additions to the `nvidia-video-codec-sdk` fork (the safe wrapper exposed neither `FORCEIDR` nor a pitched write — it had a literal `TODO: Write pitched?`): a `force_idr` flag and `BufferLock::write_rows` / `pitch()`. **Already pushed to the `dynamic-loading` branch** (kixelated/nvidia-video-codec-sdk@5434cc8), which this crate's `[patch.crates-io]` tracks. A `cargo update -p nvidia-video-codec-sdk` picks it up.

## Public API

No public API change to `moq-video`. `decode::backend` widened from private to `pub(crate)` (crate-internal only) so the NVENC round-trip test can decode its own output with the software decoder.

## Test plan

- [x] `LD_LIBRARY_PATH=/usr/lib64 cargo test -p moq-video --no-default-features --features nvenc` — all pass on the RTX 3070 Ti (the 4 `nvenc_*` tests are no-ops on a GPU-less host).
- [x] `nvenc_h264/h265_keyframes_carry_param_sets` — forced mid-stream IDR carries SPS/PPS (+VPS).
- [x] `nvenc_h264_periodic_idr_at_gop` — periodic IDRs land at GOP boundaries and carry SPS/PPS.
- [x] `nvenc_h264_pitched_write_roundtrips` — encode→openh264-decode round-trip, MAE ~0.3 vs input (ffmpeg-free); independently confirmed with an ffmpeg decode at 320x240, 300x240, 1280x720.
- [x] clippy clean, all 18 moq-video tests pass.
- [x] VAAPI fallback spot-checked (this box has no VA driver): `Kind::Named("vaapi")` errors cleanly, `Kind::Auto` falls back to openh264.

Environment note (not a code bug): on a Nix dev-shell the runtime driver probe returns "not found" even with the driver present, because the nix loader doesn't search `/usr/lib64` by soname (no `ldconfig` cache); hence `LD_LIBRARY_PATH=/usr/lib64` above. A normal glibc distro resolves it via `ldconfig`.

(Written by Claude Opus 4.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T68neyMTMV7j8qzJohUqfk