### PR TITLE
feat(moq-cli): per-sink frame-drop latency for the export gateways

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -64,6 +64,7 @@ moq <MoQ side>  <import|export>  <endpoint> [endpoint options]
 
 - **MoQ side** attaches the Origin to the network, and comes before the verb. At
   least one of:
+
   - `--client-connect <url>` dials a relay. The URL path is the relay auth path
     (e.g. `/anon`), `?jwt=<token>` supplies a token, and `--broadcast` names the
     broadcast.
@@ -156,6 +157,14 @@ discovery. When omitted, it's auto-detected from the broadcast name suffix
 - `hang` - the `catalog.json` JSON catalog (default)
 - `hangz` - the DEFLATE-compressed `catalog.json.z` catalog (opt-in; shares the `.hang` suffix and is never auto-detected)
 - `msf` - the MSF `catalog` track
+
+Every export sink caps how long a stalled group is waited on before the muxer
+skips to a newer one. Each owns the knob so its default fits the transport: the
+stdout containers and `rtmp` take `--latency-max` (default `500ms`), `hls` takes
+`--latency-max` (default `10s`, generous so live GOPs aren't skipped while
+segments build), and `srt` reuses its `--latency` (the receive buffer doubles as
+the skip threshold). WebRTC (`rtc`) is real-time and doesn't buffer, so it has no
+such knob.
 
 ### MPEG-TS
 

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -137,12 +137,6 @@ impl ImportSource {
 /// export = MoQ -> one sink.
 #[derive(Args, Clone)]
 pub struct Export {
-	/// Maximum latency before skipping groups (e.g. `500ms`, `1s`), for the stdout
-	/// container formats. The gateways (`hls`, `srt`, ...) have their own latency
-	/// controls.
-	#[arg(long = "latency-max", default_value = "500ms", value_parser = humantime::parse_duration)]
-	pub latency_max: Duration,
-
 	/// Catalog format to read for track discovery (default: detect from the broadcast suffix).
 	#[arg(long = "catalog-format")]
 	pub catalog_format: Option<CatalogFormatArg>,
@@ -161,13 +155,13 @@ pub enum ExportSink {
 	/// Matroska / WebM to stdout.
 	Mkv(Fragmented),
 	/// MPEG-TS to stdout.
-	Ts,
+	Ts(Container),
 	/// FLV / RTMP container to stdout.
-	Flv,
+	Flv(Container),
 	/// Serve HLS / LL-HLS over HTTP.
 	Hls(crate::hls::ExportArgs),
 	/// RTMP: push to a remote (`--connect`) or serve plays (`--listen`).
-	Rtmp(crate::rtmp::Args),
+	Rtmp(crate::rtmp::ExportArgs),
 	/// SRT: push to a remote (`--connect`) or serve requests (`--listen`).
 	Srt(crate::srt::Args),
 	/// WebRTC: WHIP client pushing to a remote (`--connect`) or WHEP server serving plays (`--listen`).
@@ -175,22 +169,38 @@ pub enum ExportSink {
 }
 
 impl ExportSink {
-	/// The stdout container format and its fragment cap, when this sink writes to
-	/// stdout (the container formats). The fragment cap is fmp4/mkv-only.
-	pub fn stdout(&self) -> Option<(SubscribeFormat, Option<Duration>)> {
+	/// The stdout container format plus its latency and fragment cap, when this
+	/// sink writes to stdout (the container formats). The fragment cap is
+	/// fmp4/mkv-only.
+	pub fn stdout(&self) -> Option<(SubscribeFormat, Duration, Option<Duration>)> {
 		Some(match self {
-			Self::Fmp4(args) => (SubscribeFormat::Fmp4, args.fragment_duration),
-			Self::Mkv(args) => (SubscribeFormat::Mkv, args.fragment_duration),
-			Self::Ts => (SubscribeFormat::Ts, None),
-			Self::Flv => (SubscribeFormat::Flv, None),
+			Self::Fmp4(args) => (
+				SubscribeFormat::Fmp4,
+				args.container.latency_max,
+				args.fragment_duration,
+			),
+			Self::Mkv(args) => (SubscribeFormat::Mkv, args.container.latency_max, args.fragment_duration),
+			Self::Ts(args) => (SubscribeFormat::Ts, args.latency_max, None),
+			Self::Flv(args) => (SubscribeFormat::Flv, args.latency_max, None),
 			_ => return None,
 		})
 	}
 }
 
-/// Fragmenting option shared by the fmp4 / mkv stdout containers.
+/// Options shared by every stdout container sink.
+#[derive(Args, Clone)]
+pub struct Container {
+	/// Maximum latency before skipping a stalled group (e.g. `500ms`, `1s`).
+	#[arg(long = "latency-max", default_value = "500ms", value_parser = humantime::parse_duration)]
+	pub latency_max: Duration,
+}
+
+/// The fmp4 / mkv stdout containers: [`Container`] plus a fragment cap.
 #[derive(Args, Clone)]
 pub struct Fragmented {
+	#[command(flatten)]
+	pub container: Container,
+
 	/// Cap the output fragment/cluster duration (e.g. `2s`). Default: one GOP.
 	#[arg(long, value_parser = humantime::parse_duration)]
 	pub fragment_duration: Option<Duration>,

--- a/rs/moq-cli/src/hls.rs
+++ b/rs/moq-cli/src/hls.rs
@@ -36,6 +36,11 @@ pub struct ExportArgs {
 	/// Minimum media kept in each rendition's sliding window.
 	#[arg(long, default_value = "16s", value_parser = humantime::parse_duration)]
 	pub window: Duration,
+
+	/// Maximum latency before skipping a stalled group. Generous by default so
+	/// live GOPs aren't skipped while segments build.
+	#[arg(long = "latency-max", default_value = "10s", value_parser = humantime::parse_duration)]
+	pub latency_max: Duration,
 }
 
 /// Pull a remote HLS/LL-HLS playlist (URL or file path) into the Origin under `name`.
@@ -66,6 +71,7 @@ pub async fn export(origin: moq_net::OriginConsumer, args: ExportArgs, name: Str
 	let config = moq_hls::export::Config {
 		part_target: args.part_target,
 		window: args.window,
+		latency: args.latency_max,
 		..Default::default()
 	};
 	let server = moq_hls::Server::new(scoped, config);

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -164,10 +164,10 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 	}
 
 	// Foreign side: the single sink.
-	if let Some((format, fragment_duration)) = export.sink.stdout() {
+	if let Some((format, max_latency, fragment_duration)) = export.sink.stdout() {
 		let args = SubscribeArgs {
 			format,
-			max_latency: export.latency_max,
+			max_latency,
 			fragment_duration,
 			catalog: export.catalog_format,
 		};
@@ -180,11 +180,11 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 				tasks.spawn(hls::export(origin.consume(), args, name));
 			}
 			ExportSink::Rtmp(rtmp) => {
-				if let Some(addr) = rtmp.listen {
+				if let Some(addr) = rtmp.endpoint.listen {
 					let name = require_broadcast(name, "export rtmp --listen")?;
-					tasks.spawn(rtmp::listen_export(origin.consume(), addr, name));
-				} else if let Some(url) = rtmp.connect {
-					tasks.spawn(rtmp::connect_export(origin.consume(), url, name));
+					tasks.spawn(rtmp::listen_export(origin.consume(), addr, name, rtmp.latency_max));
+				} else if let Some(url) = rtmp.endpoint.connect {
+					tasks.spawn(rtmp::connect_export(origin.consume(), url, name, rtmp.latency_max));
 				}
 			}
 			ExportSink::Srt(srt) => {

--- a/rs/moq-cli/src/rtmp.rs
+++ b/rs/moq-cli/src/rtmp.rs
@@ -3,6 +3,7 @@
 //! (rejecting publishes). The operator declares direction; the peer can't choose.
 
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use anyhow::Context;
 use hang::moq_net;
@@ -12,7 +13,8 @@ use url::Url;
 use crate::moq::notify_ready;
 
 /// RTMP endpoint args: exactly one of `--connect` (dial) / `--listen` (bind).
-/// The parent direction fixes whether that dial/bind pushes or pulls.
+/// The parent direction fixes whether that dial/bind pushes or pulls. Import uses
+/// this directly; export wraps it in [`ExportArgs`] for the egress-only knobs.
 #[derive(clap::Args, Clone)]
 #[command(group = clap::ArgGroup::new("rtmp-mode").required(true).multiple(false).args(["rtmp-connect", "rtmp-listen"]))]
 pub struct Args {
@@ -24,6 +26,19 @@ pub struct Args {
 	/// is accepted but not used for routing).
 	#[arg(id = "rtmp-listen", long = "listen", value_name = "ADDR")]
 	pub listen: Option<SocketAddr>,
+}
+
+/// RTMP export args: the endpoint plus egress-only tuning. Split from the import
+/// side so the frame-drop knob only shows where it applies.
+#[derive(clap::Args, Clone)]
+pub struct ExportArgs {
+	#[command(flatten)]
+	pub endpoint: Args,
+
+	/// Maximum latency before skipping a stalled group. RTMP is unpaced, so this
+	/// bounds buffering, not the wire rate.
+	#[arg(long = "latency-max", default_value = "500ms", value_parser = humantime::parse_duration)]
+	pub latency_max: Duration,
 }
 
 /// Accept incoming RTMP publishes into the Origin as `name`; reject plays (import).
@@ -56,7 +71,12 @@ pub async fn listen_import(origin: moq_net::OriginProducer, addr: SocketAddr, na
 }
 
 /// Serve RTMP plays of `name` from the Origin; reject publishes (export).
-pub async fn listen_export(origin: moq_net::OriginConsumer, addr: SocketAddr, name: String) -> anyhow::Result<()> {
+pub async fn listen_export(
+	origin: moq_net::OriginConsumer,
+	addr: SocketAddr,
+	name: String,
+	latency: Duration,
+) -> anyhow::Result<()> {
 	let mut server = Server::bind(addr).await?;
 	tracing::info!(%addr, %name, "RTMP listening (export)");
 	notify_ready();
@@ -67,7 +87,7 @@ pub async fn listen_export(origin: moq_net::OriginConsumer, addr: SocketAddr, na
 				let origin = origin.clone();
 				let name = name.clone();
 				tokio::spawn(async move {
-					if let Err(err) = play.accept(&origin, &name).await {
+					if let Err(err) = play.with_latency(latency).accept(&origin, &name).await {
 						tracing::warn!(%name, %err, "RTMP play ended with error");
 					}
 				});
@@ -97,7 +117,12 @@ pub async fn connect_import(origin: moq_net::OriginProducer, url: Url, name: Str
 }
 
 /// Push a broadcast from the Origin to a remote RTMP server (export).
-pub async fn connect_export(origin: moq_net::OriginConsumer, url: Url, name: String) -> anyhow::Result<()> {
+pub async fn connect_export(
+	origin: moq_net::OriginConsumer,
+	url: Url,
+	name: String,
+	latency: Duration,
+) -> anyhow::Result<()> {
 	let (addr, app, key) = parse_url(&url).await?;
 	let broadcast = origin
 		.announced_broadcast(&name)
@@ -107,7 +132,7 @@ pub async fn connect_export(origin: moq_net::OriginConsumer, url: Url, name: Str
 	tracing::info!(%url, %name, "RTMP client pushing");
 	notify_ready();
 
-	let client = Client::connect(addr, &app).await?;
+	let client = Client::connect(addr, &app).await?.with_latency(latency);
 	Ok(client.publish(&key, broadcast).await?)
 }
 

--- a/rs/moq-rtmp/src/dial.rs
+++ b/rs/moq-rtmp/src/dial.rs
@@ -26,6 +26,7 @@
 
 use std::collections::VecDeque;
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use bytes::Bytes;
 use moq_mux::container::flv::{Export as FlvExport, Import as FlvImport};
@@ -64,6 +65,9 @@ pub struct Client<S = TcpStream> {
 	session: ClientSession,
 	/// Session results queued during connect, drained by the first publish/pull.
 	work: VecDeque<ClientSessionResult>,
+	/// How long [`publish`](Self::publish)'s FLV muxer waits for a stalled group
+	/// before skipping. Zero (the default) drops stale groups aggressively.
+	latency: Duration,
 }
 
 impl Client<TcpStream> {
@@ -137,7 +141,20 @@ impl<S: Stream> Client<S> {
 			work.extend(results);
 		}
 
-		Ok(Self { stream, session, work })
+		Ok(Self {
+			stream,
+			session,
+			work,
+			latency: Duration::ZERO,
+		})
+	}
+
+	/// Set how long [`publish`](Self::publish)'s FLV muxer waits for a stalled group
+	/// before skipping to a newer one (the moq-level frame-drop latency). Defaults
+	/// to zero, which drops stale groups aggressively.
+	pub fn with_latency(mut self, latency: Duration) -> Self {
+		self.latency = latency;
+		self
 	}
 
 	/// Push a MoQ broadcast out to the remote: request `publish` on `stream_key`,
@@ -161,7 +178,9 @@ impl<S: Stream> Client<S> {
 		let queued = std::mem::take(&mut self.work);
 		self.drain(queued).await?;
 
-		let mut export = FlvExport::new(broadcast).map_err(|e| anyhow::anyhow!("init FLV export: {e}"))?;
+		let mut export = FlvExport::new(broadcast)
+			.map_err(|e| anyhow::anyhow!("init FLV export: {e}"))?
+			.with_latency(self.latency);
 		let mut tags = flv::TagReader::new();
 		let mut buffer = [0u8; READ_BUFFER];
 

--- a/rs/moq-rtmp/src/listen.rs
+++ b/rs/moq-rtmp/src/listen.rs
@@ -21,6 +21,7 @@
 use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use moq_net::OriginProducer;
 
@@ -43,6 +44,11 @@ pub struct Config {
 	/// Prefix prepended to every ingested broadcast path. Lets one listener
 	/// namespace all of its streams (e.g. `live/`).
 	pub prefix: String,
+
+	/// How long a play's FLV muxer waits for a stalled group before skipping to a
+	/// newer one (the moq-level frame-drop latency). Zero (the default) drops
+	/// stale groups aggressively. Only affects egress (plays); ingest ignores it.
+	pub latency: Duration,
 
 	/// TLS configuration for RTMPS (RTMP over TLS). When set, the
 	/// [`listen`](Self::listen) address speaks RTMPS instead of plaintext RTMP,
@@ -97,6 +103,7 @@ pub async fn run(origin: OriginProducer, config: Config) -> Result<()> {
 	// of clobbering the live one.
 	let active = ActivePaths::default();
 	let prefix = Arc::new(config.prefix);
+	let latency = config.latency;
 	// Players are served out of the same origin the publishers write into.
 	let consumer = origin.consume();
 
@@ -139,7 +146,7 @@ pub async fn run(origin: OriginProducer, config: Config) -> Result<()> {
 						let _ = play.reject("missing broadcast path (RTMP app/key)").await;
 						return;
 					};
-					if let Err(err) = play.accept(&consumer, &path).await {
+					if let Err(err) = play.with_latency(latency).accept(&consumer, &path).await {
 						tracing::warn!(%peer, %path, %err, "RTMP play ended with error");
 					}
 				});

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -451,6 +451,10 @@ pub struct Play<S = Conn> {
 	app: String,
 	stream_key: String,
 	peer: SocketAddr,
+	/// How long the FLV muxer waits for a stalled group before skipping to a newer
+	/// one. Zero (the default) drops stale groups aggressively; raise it with
+	/// [`with_latency`](Self::with_latency).
+	latency: Duration,
 }
 
 impl<S: Stream> Play<S> {
@@ -470,6 +474,15 @@ impl<S: Stream> Play<S> {
 	/// The remote peer address.
 	pub fn peer(&self) -> SocketAddr {
 		self.peer
+	}
+
+	/// Set how long the FLV muxer waits for a stalled group before skipping to a
+	/// newer one (the moq-level frame-drop latency). Defaults to zero, which drops
+	/// stale groups aggressively. RTMP is unpaced (tags go out as fast as the
+	/// socket accepts them), so this bounds buffering, not the wire rate.
+	pub fn with_latency(mut self, latency: Duration) -> Self {
+		self.latency = latency;
+		self
 	}
 
 	/// Accept the play: subscribe to the broadcast at `path` in `origin`, mux it
@@ -507,7 +520,9 @@ impl<S: Stream> Play<S> {
 			return Ok(());
 		};
 
-		let mut export = FlvExport::new(broadcast).map_err(|e| anyhow::anyhow!("init FLV export: {e}"))?;
+		let mut export = FlvExport::new(broadcast)
+			.map_err(|e| anyhow::anyhow!("init FLV export: {e}"))?
+			.with_latency(self.latency);
 		let result = play_pump(
 			&mut self.stream,
 			&mut self.session,
@@ -607,6 +622,7 @@ async fn accept_until_request<S: Stream>(mut stream: S, peer: SocketAddr) -> any
 							app: app_name,
 							stream_key,
 							peer,
+							latency: Duration::ZERO,
 						})));
 					}
 					other => tracing::trace!(%peer, ?other, "ignoring RTMP event before publish/play"),

--- a/rs/moq-srt/src/dial.rs
+++ b/rs/moq-srt/src/dial.rs
@@ -40,8 +40,9 @@ pub async fn publish(
 	origin: &OriginConsumer,
 	path: &str,
 ) -> Result<()> {
+	let latency = latency.into().unwrap_or(DEFAULT_LATENCY);
 	let socket = call(addr, resource, Mode::Publish, latency).await?;
-	serve_subscribe(origin, path, socket).await
+	serve_subscribe(origin, path, socket, latency).await
 }
 
 /// Dial `addr` and pull a remote stream into `origin`: connect as an SRT caller

--- a/rs/moq-srt/src/server.rs
+++ b/rs/moq-srt/src/server.rs
@@ -50,19 +50,24 @@ pub struct Server {
 	/// Held to keep the listener (and its UDP socket) alive for the server's lifetime.
 	_listener: SrtListener,
 	incoming: SrtIncoming,
+	/// The negotiated SRT receive latency, reused as the egress skip threshold on
+	/// each [`Subscribe`] (see [`crate::ts::Subscriber::new`]).
+	latency: Duration,
 }
 
 impl Server {
 	/// Bind an SRT listener on `addr` (SRT has no well-known port; 9000 is common).
 	///
 	/// `latency` is the SRT receive latency, negotiated at handshake time; pass
-	/// `None` for a sensible default (200ms).
+	/// `None` for a sensible default (200ms). It doubles as the egress skip
+	/// threshold for [`Subscribe`] requests.
 	pub async fn bind(addr: SocketAddr, latency: impl Into<Option<Duration>>) -> Result<Self> {
 		let latency = latency.into().unwrap_or(DEFAULT_LATENCY);
 		let (listener, incoming) = SrtListener::builder().latency(latency).bind(addr).await?;
 		Ok(Self {
 			_listener: listener,
 			incoming,
+			latency,
 		})
 	}
 
@@ -87,6 +92,7 @@ impl Server {
 				resource,
 				stream_id,
 				peer,
+				latency: self.latency,
 			};
 
 			// `m=request` reads a broadcast out; everything else publishes one in.
@@ -111,6 +117,8 @@ struct Pending {
 	/// fields out of it (e.g. a token in `u=` or a custom key).
 	stream_id: Option<String>,
 	peer: SocketAddr,
+	/// The SRT receive latency, reused as the egress skip threshold on a subscribe.
+	latency: Duration,
 }
 
 /// What an accepted SRT connection wants: to contribute media ([`Publish`]) or to
@@ -243,7 +251,7 @@ impl Subscribe {
 	pub async fn accept(self, origin: &OriginConsumer, path: &str) -> Result<()> {
 		let socket = self.0.request.accept(None).await?;
 		tracing::info!(peer = %self.0.peer, %path, "SRT subscribe accepted");
-		serve_subscribe(origin, path, socket).await
+		serve_subscribe(origin, path, socket, self.0.latency).await
 	}
 
 	/// Reject the subscribe, sending the client a `Forbidden` rejection.
@@ -282,7 +290,12 @@ pub(crate) async fn serve_publish(origin: &OriginProducer, path: &str, mut socke
 /// Waits for the broadcast to be announced (so a caller may connect before the
 /// publisher), then packs the muxer's output into [`SRT_PAYLOAD`]-sized SRT
 /// messages. Returns once the broadcast ends or the caller disconnects.
-pub(crate) async fn serve_subscribe(origin: &OriginConsumer, path: &str, mut socket: SrtSocket) -> Result<()> {
+pub(crate) async fn serve_subscribe(
+	origin: &OriginConsumer,
+	path: &str,
+	mut socket: SrtSocket,
+	latency: Duration,
+) -> Result<()> {
 	// Resolve the broadcast, but watch the socket while we wait: `announced_broadcast`
 	// parks forever for a stream that is never published, and nothing else polls the
 	// socket during that wait, so without this a caller who requests a non-existent
@@ -293,7 +306,7 @@ pub(crate) async fn serve_subscribe(origin: &OriginConsumer, path: &str, mut soc
 			tracing::debug!(%path, "SRT subscribe closed before its broadcast was available");
 			return Ok(());
 		}
-		subscriber = crate::ts::Subscriber::new(origin, path) => subscriber?,
+		subscriber = crate::ts::Subscriber::new(origin, path, latency) => subscriber?,
 	};
 
 	let Some(mut subscriber) = subscriber else {

--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -76,9 +76,12 @@ impl Subscriber {
 	/// Resolve the broadcast at `path` in the origin and prepare to mux it to TS.
 	///
 	/// `latency` bounds how long the muxer waits for a stalled group before it
-	/// skips ahead to a newer one. We reuse the SRT receive latency for it: SRT
-	/// paces egress on the media clock, so the skip threshold and the negotiated
-	/// receive buffer are the same end-to-end budget.
+	/// skips ahead to a newer one. We reuse the locally configured SRT receive
+	/// latency for it: SRT paces egress on the media clock, so the skip threshold
+	/// shares the same latency budget. It's the configured value, not the
+	/// handshake result (srt-tokio doesn't expose the negotiated latency), so a
+	/// peer that requests a higher receive latency gets a larger actual buffer
+	/// than this skip threshold.
 	///
 	/// Returns `Ok(None)` if the broadcast can never be served (path outside the
 	/// consumer's scope, or the origin closed). Otherwise waits for the broadcast

--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -7,6 +7,8 @@
 //! mirror image for egress: it consumes a broadcast from the origin and re-muxes
 //! it back to MPEG-TS for an SRT caller (VLC, ffmpeg) to play.
 
+use std::time::Duration;
+
 use bytes::Bytes;
 use moq_mux::container::{Frame, ts};
 use moq_net::{Broadcast, OriginConsumer, OriginProducer};
@@ -73,15 +75,20 @@ pub struct Subscriber {
 impl Subscriber {
 	/// Resolve the broadcast at `path` in the origin and prepare to mux it to TS.
 	///
+	/// `latency` bounds how long the muxer waits for a stalled group before it
+	/// skips ahead to a newer one. We reuse the SRT receive latency for it: SRT
+	/// paces egress on the media clock, so the skip threshold and the negotiated
+	/// receive buffer are the same end-to-end budget.
+	///
 	/// Returns `Ok(None)` if the broadcast can never be served (path outside the
 	/// consumer's scope, or the origin closed). Otherwise waits for the broadcast
 	/// to be announced, so a caller may connect before the publisher does.
-	pub async fn new(origin: &OriginConsumer, path: &str) -> Result<Option<Self>> {
+	pub async fn new(origin: &OriginConsumer, path: &str, latency: Duration) -> Result<Option<Self>> {
 		let Some(broadcast) = origin.announced_broadcast(path).await else {
 			return Ok(None);
 		};
 
-		let export = ts::Export::new(broadcast)?;
+		let export = ts::Export::new(broadcast)?.with_latency(latency);
 		Ok(Some(Self { export }))
 	}
 


### PR DESCRIPTION
## Summary

`export --latency-max` previously only reached the stdout container path (added in #1985). The gateway egress sinks (`rtmp`, `srt`, `hls`) build their own moq-mux exports internally and never set a latency, so they fell back to the default (`0` = drop stale groups aggressively) with **no way to configure the frame-drop budget**. Closes #1987.

The frame-drop latency is the moq-level "how long to wait for a stalled group before skipping to a newer one" — the `moq_mux::container::Consumer::with_latency` knob (the ordered/skip consumer). It's media-agnostic, and every egress pulls frames through it, so all of them can carry it.

Rather than a global `export` flag that silently applies to only some sinks, **each sink owns its own `--latency-max`** so the default fits the transport:

| sink | flag | default | notes |
|---|---|---|---|
| `fmp4` / `mkv` / `ts` / `flv` (stdout) | `--latency-max` | `500ms` | shared `Container` args |
| `rtmp` | `--latency-max` | `500ms` | export-only (`ExportArgs`) |
| `hls` | `--latency-max` | `10s` | exposes the lib's existing `Config.latency`; generous so live GOPs aren't skipped while segments build |
| `srt` | `--latency` | `200ms` | reuses the SRT receive buffer as the skip threshold |
| `rtc` | — | — | WebRTC is real-time, doesn't buffer |

## Changes

**moq-rtmp** (additive public API):
- `Play::with_latency()` and `Client::with_latency()` builders + `listen::Config.latency` (defaults to `0` = today's behavior, `#[non_exhaustive]` Config so `run()` stays compatible). Wired into `FlvExport::with_latency` on both the serve and dial egress paths.

**moq-srt** (internal only, no public API change):
- The SRT receive latency (`Server::bind` / `dial::publish` / `Config.latency`) now also drives the egress `ts::Export` skip threshold. SRT paces egress on the media clock, so the receive buffer and the skip threshold are the same end-to-end budget.

**moq-cli**:
- Removed the global `Export`-level latency flag; pushed `--latency-max` down onto each stdout container (new shared `Container` args struct; `Fragmented` flattens it) and onto `hls`.
- Split `rtmp::Args` into the shared endpoint (`Args`, used by import) and `rtmp::ExportArgs` (flattens `Args` + `--latency-max`) so the frame-drop knob only appears on `export rtmp`, not `import rtmp`.
- `srt` needed no CLI change — the library now consumes the `--latency` it was already passing.

**doc/bin/cli.md**: documents the per-sink latency knobs.

## Notes for reviewers

- **Public API** (per branch-targeting rules): moq-rtmp gains `Play::with_latency`, `Client::with_latency`, and `Config.latency` — all additive, non-breaking. moq-srt has no public API change. moq-cli renames/reshapes CLI flags (`--latency-max` is now per-sink; the flag added in #1985 was not yet released). Nothing wire-level. Targeting **main**.
- The relay does **not** embed `moq_rtmp::run` / `moq_srt::run` in this repo, so no relay blast radius; the additive `Config.latency` keeps `run()` compatible for any out-of-tree embedder.
- Behavior change: SRT egress previously dropped stale groups at `0` latency; it now uses the SRT receive latency (default 200ms). Arguably a fix for a paced egress.

## Test plan

- [x] `cargo clippy` + `cargo test` on moq-cli / moq-rtmp / moq-srt (green)
- [x] rustdoc `-D warnings` (no broken intra-doc links)
- [x] `cargo fmt --check`, `taplo format --check`
- [x] `moq export <sink> --help` shows each sink's own latency flag; `export rtmp` has `--latency-max`, `import rtmp` does not; the `--connect|--listen` group is still enforced through the flatten
- [ ] Not e2e-tested against a live RTMP/SRT/HLS player

_(Written by Claude Opus 4.8)_