### PR TITLE
Add track name to the consumer skip/reset logs

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,14 +26,13 @@ ignore = [
     # requires Rust 1.92; workspace MSRV is 1.85. Build-time only.
     "RUSTSEC-2024-0436",
 
-    # http-cache (via http-cache-reqwest in moq-relay) still depends on
-    # bincode 1.x. Awaits upstream bump to bincode 2.x.
-    "RUSTSEC-2025-0141",
-
-    # proc-macro-error2 unmaintained. Pulled in transitively as a build-time
-    # proc-macro via local-ip-address -> neli -> getset; no runtime exposure.
-    # Drop the ignore when getset migrates off proc-macro-error2.
-    "RUSTSEC-2026-0173",
+    # quick-xml < 0.41 DoS when parsing untrusted XML (quadratic duplicate
+    # attribute check; unbounded namespace allocation). Reachable only via
+    # plist -> netdev -> netwatch -> iroh, where plist parses local macOS
+    # system network configuration, not attacker-controlled input. Drop both
+    # ignores when plist releases with quick-xml >= 0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]
 
 [licenses]

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -250,7 +250,9 @@ export class Consumer {
 			const first = this.#groups.shift();
 			if (!first) break;
 			this.#active = this.#groups[0]?.consumer.sequence;
-			console.warn(`skipping slow group: ${first.consumer.sequence} -> ${this.#active}`);
+			console.warn(
+				`skipping slow group: track=${this.#track.name} ${first.consumer.sequence} -> ${this.#active}`,
+			);
 
 			first.consumer.close();
 			first.frames.length = 0;

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -132,7 +132,7 @@ export class Consumer {
 			}
 
 			if (drop) {
-				console.warn(`skipping old group: ${consumer.sequence}`);
+				console.warn(`skipping old group: track=${this.#track.name} ${consumer.sequence}`);
 				consumer.close();
 				continue;
 			}
@@ -306,7 +306,9 @@ export class Consumer {
 			return !stale;
 		});
 
-		console.warn(`buffer reset: group timestamps rewound (prevMax ${reset.prevMax}, group ${reset.group})`);
+		console.warn(
+			`buffer reset: track=${this.#track.name} group timestamps rewound (prevMax ${reset.prevMax}, group ${reset.group})`,
+		);
 
 		// Resume from the earliest survivor; if none, from the rewound group. Anchor the live
 		// edge at the rewind point (delivered), not group.latest (buffered ahead of playback).

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -224,7 +224,11 @@ impl<F: Container> Consumer<F> {
 						// evicted alongside it, so jump straight to that group instead of
 						// stepping one-by-one and then blocking on a sequence gap of groups
 						// that will never arrive.
-						tracing::warn!(error = ?e, "current group evicted; skipping to next buffered group");
+						tracing::warn!(
+							track = self.track.name(),
+							error = ?e,
+							"current group evicted; skipping to next buffered group"
+						);
 						self.pending.pop_front();
 						self.current = self.pending.front().map_or(self.current + 1, |g| g.sequence);
 					}
@@ -303,7 +307,12 @@ impl<F: Container> Consumer<F> {
 				self.pending.drain(0..new_idx);
 				let new_current = self.pending.front().map(|g| g.sequence).unwrap();
 
-				tracing::debug!(old = self.current, new = new_current, "skipping slow groups");
+				tracing::debug!(
+					track = self.track.name(),
+					old = self.current,
+					new = new_current,
+					"skipping slow groups"
+				);
 
 				self.current = new_current;
 				continue;
@@ -343,7 +352,7 @@ impl<F: Container> Consumer<F> {
 				None => sequence < self.current,
 			};
 			if drop {
-				tracing::debug!(old = ?sequence, current = ?self.current, "skipping old group");
+				tracing::debug!(track = self.track.name(), old = ?sequence, current = ?self.current, "skipping old group");
 				continue;
 			}
 
@@ -413,6 +422,7 @@ impl<F: Container> Consumer<F> {
 
 		self.rewind.discontinuity += 1;
 		tracing::debug!(
+			track = self.track.name(),
 			prev_max = reset.prev_max,
 			group = reset.group,
 			discontinuity = self.rewind.discontinuity,


### PR DESCRIPTION
## Summary

- The `skipping slow group` console warning in `js/hang`'s container `Consumer` now includes the track name (`track=${this.#track.name}`), so logs from multiple concurrent tracks (e.g. audio and video) can be told apart.
- The sibling diagnostics in the same class (`skipping old group`, `buffer reset`) get the same `track=` context, since they have the same multi-track ambiguity.
- The Rust counterpart in `rs/moq-mux`'s container `Consumer` gets a matching `track = self.track.name()` field on its `skipping slow groups`, `skipping old group`, `buffer reset`, and `group evicted` tracing events.
- CI fix (unrelated to the logging change, but it blocks every PR): `cargo deny` started failing on the new RUSTSEC-2026-0194/0195 advisories against `quick-xml < 0.41`. No compatible update exists yet (`plist 1.9.0` is the latest release and pins `quick-xml 0.39`), and the only dependency path is `plist -> netdev -> netwatch -> iroh`, which parses local macOS system network configuration rather than attacker-controlled XML. Added both IDs to the `deny.toml` ignore list with that rationale, and dropped the RUSTSEC-2025-0141 / RUSTSEC-2026-0173 ignores that cargo deny warns no longer match any crate.

No public API changes; only log messages and the cargo deny config are touched. Not listed in the Cross-Package Sync table (no wire, catalog, or API surface involved), but the JS and Rust consumers are kept in parity anyway.

(Written by Claude)