### PR TITLE
[codex] fix HLS playlist RFC counters

### DIFF
--- a/rs/moq-hls/src/export/playlist.rs
+++ b/rs/moq-hls/src/export/playlist.rs
@@ -15,30 +15,22 @@ const VERSION: u32 = 9;
 
 /// Render a media playlist for one rendition from a [`Snapshot`].
 pub fn render_media(snapshot: &Snapshot) -> String {
-	// TARGETDURATION must be >= the longest *complete* segment (rounded up), and
-	// at least the part target so a part-only edge still produces a sane value.
-	let max_segment = snapshot
-		.segments
-		.iter()
-		.filter(|s| s.complete)
-		.map(|s| s.duration)
-		.fold(0.0_f64, f64::max)
-		.max(snapshot.part_target);
-	let target_duration = max_segment.ceil().max(1.0) as u64;
-
 	// PART-HOLD-BACK must be at least 3x the part target (HLS spec).
 	let part_hold_back = snapshot.part_target * 3.0;
 
 	let mut out = String::new();
 	let _ = writeln!(out, "#EXTM3U");
 	let _ = writeln!(out, "#EXT-X-VERSION:{VERSION}");
-	let _ = writeln!(out, "#EXT-X-TARGETDURATION:{target_duration}");
+	let _ = writeln!(out, "#EXT-X-TARGETDURATION:{}", snapshot.target_duration);
 	let _ = writeln!(
 		out,
 		"#EXT-X-SERVER-CONTROL:CAN-BLOCK-RELOAD=YES,PART-HOLD-BACK={part_hold_back:.3}"
 	);
 	let _ = writeln!(out, "#EXT-X-PART-INF:PART-TARGET={:.3}", snapshot.part_target);
 	let _ = writeln!(out, "#EXT-X-MEDIA-SEQUENCE:{}", snapshot.media_sequence);
+	if snapshot.discontinuity_sequence > 0 {
+		let _ = writeln!(out, "#EXT-X-DISCONTINUITY-SEQUENCE:{}", snapshot.discontinuity_sequence);
+	}
 	let _ = writeln!(out, "#EXT-X-MAP:URI=\"init.mp4\"");
 
 	for segment in &snapshot.segments {
@@ -87,7 +79,9 @@ mod tests {
 		let snapshot = Snapshot {
 			init_ready: true,
 			part_target: 0.5,
+			target_duration: 1,
 			media_sequence: 10,
+			discontinuity_sequence: 0,
 			next_sequence: 12,
 			segments: vec![
 				SegmentMeta {
@@ -135,7 +129,9 @@ mod tests {
 		let snapshot = Snapshot {
 			init_ready: true,
 			part_target: 1.0,
+			target_duration: 1,
 			media_sequence: 0,
+			discontinuity_sequence: 0,
 			next_sequence: 1,
 			segments: vec![SegmentMeta {
 				sequence: 0,
@@ -157,7 +153,9 @@ mod tests {
 		let snapshot = Snapshot {
 			init_ready: true,
 			part_target: 1.0,
+			target_duration: 1,
 			media_sequence: 0,
+			discontinuity_sequence: 0,
 			next_sequence: 2,
 			segments: vec![
 				SegmentMeta {
@@ -188,5 +186,30 @@ mod tests {
 			seg0 < disc && disc < seg1,
 			"discontinuity must sit between seg 0 and seg 1"
 		);
+	}
+
+	#[test]
+	fn emits_discontinuity_sequence_when_nonzero() {
+		let snapshot = Snapshot {
+			init_ready: true,
+			part_target: 1.0,
+			target_duration: 6,
+			media_sequence: 8,
+			discontinuity_sequence: 2,
+			next_sequence: 9,
+			segments: vec![SegmentMeta {
+				sequence: 8,
+				parts: vec![part(1.0, true)],
+				duration: 1.0,
+				complete: true,
+				discontinuity: false,
+			}],
+			finished: false,
+		};
+
+		let out = render_media(&snapshot);
+
+		assert!(out.contains("#EXT-X-TARGETDURATION:6\n"));
+		assert!(out.contains("#EXT-X-DISCONTINUITY-SEQUENCE:2\n"));
 	}
 }

--- a/rs/moq-hls/src/export/store.rs
+++ b/rs/moq-hls/src/export/store.rs
@@ -67,8 +67,12 @@ pub struct Snapshot {
 	pub init_ready: bool,
 	/// LL-HLS PART-TARGET, in seconds.
 	pub part_target: f64,
+	/// Latched `EXT-X-TARGETDURATION`, in seconds.
+	pub target_duration: u64,
 	/// `EXT-X-MEDIA-SEQUENCE`: sequence of the first segment in the window.
 	pub media_sequence: u64,
+	/// `EXT-X-DISCONTINUITY-SEQUENCE`: discontinuities before the window.
+	pub discontinuity_sequence: u64,
 	/// Sequence the next segment to roll will be assigned.
 	pub next_sequence: u64,
 	/// Segments currently in the sliding window, oldest first.
@@ -95,6 +99,8 @@ struct Inner {
 	init: Option<Bytes>,
 	segments: VecDeque<Segment>,
 	next_sequence: u64,
+	discontinuity_sequence: u64,
+	target_duration: u64,
 	finished: bool,
 	/// Set by [`SegmentStore::mark_discontinuity`] after a resume; the next segment
 	/// to roll is forced open and tagged discontinuous, then this clears.
@@ -121,11 +127,14 @@ impl SegmentStore {
 	/// timing from `config`.
 	pub fn new(kind: Kind, config: &Config) -> Self {
 		let (notify, _) = watch::channel(Version::default());
+		let target_duration = config.part_target.as_secs_f64().ceil().max(1.0) as u64;
 		Self {
 			inner: Mutex::new(Inner {
 				init: None,
 				segments: VecDeque::new(),
 				next_sequence: 0,
+				discontinuity_sequence: 0,
+				target_duration,
 				finished: false,
 				discontinuity_pending: false,
 			}),
@@ -168,8 +177,11 @@ impl SegmentStore {
 				};
 
 			if need_new {
-				if let Some(cur) = inner.segments.back_mut() {
+				if let Some(duration) = inner.segments.back_mut().map(|cur| {
 					cur.complete = true;
+					cur.duration
+				}) {
+					latch_target_duration(duration, &mut inner.target_duration);
 				}
 				let sequence = inner.next_sequence;
 				inner.next_sequence += 1;
@@ -197,7 +209,10 @@ impl SegmentStore {
 				let total: f64 = inner.segments.iter().map(|s| s.duration).sum();
 				let oldest = inner.segments.front().expect("segments non-empty").duration;
 				if total - oldest >= self.window {
-					inner.segments.pop_front();
+					let evicted = inner.segments.pop_front().expect("segments non-empty");
+					if evicted.discontinuity {
+						inner.discontinuity_sequence = inner.discontinuity_sequence.saturating_add(1);
+					}
 				} else {
 					break;
 				}
@@ -219,8 +234,11 @@ impl SegmentStore {
 	pub fn finish(&self) {
 		{
 			let mut inner = self.inner.lock().unwrap();
-			if let Some(cur) = inner.segments.back_mut() {
+			if let Some(duration) = inner.segments.back_mut().map(|cur| {
 				cur.complete = true;
+				cur.duration
+			}) {
+				latch_target_duration(duration, &mut inner.target_duration);
 			}
 			inner.finished = true;
 		}
@@ -332,10 +350,86 @@ impl SegmentStore {
 		Snapshot {
 			init_ready: inner.init.is_some(),
 			part_target: self.part_target,
+			target_duration: inner.target_duration,
 			media_sequence,
+			discontinuity_sequence: inner.discontinuity_sequence,
 			next_sequence: inner.next_sequence,
 			segments,
 			finished: inner.finished,
 		}
+	}
+}
+
+fn latch_target_duration(duration: f64, target_duration: &mut u64) {
+	*target_duration = (*target_duration).max(duration.ceil().max(1.0) as u64);
+}
+
+#[cfg(test)]
+mod tests {
+	use std::time::Duration;
+
+	use bytes::Bytes;
+
+	use super::*;
+
+	fn config(window: Duration) -> Config {
+		Config {
+			part_target: Duration::from_millis(500),
+			window,
+			latency: Duration::from_secs(10),
+			audio_segment_target: Duration::from_secs(2),
+		}
+	}
+
+	fn fragment(duration: f64) -> Fragment {
+		Fragment {
+			data: Bytes::new(),
+			init: false,
+			independent: true,
+			duration,
+		}
+	}
+
+	#[test]
+	fn evicting_discontinuous_segment_advances_sequence() {
+		let cfg = config(Duration::from_secs(2));
+		let store = SegmentStore::new(Kind::Video, &cfg);
+
+		store.push(fragment(1.0));
+		store.mark_discontinuity();
+		store.push(fragment(1.0));
+		store.push(fragment(1.0));
+
+		let snapshot = store.snapshot();
+		assert_eq!(snapshot.media_sequence, 1);
+		assert_eq!(snapshot.discontinuity_sequence, 0);
+		assert!(snapshot.segments[0].discontinuity);
+
+		store.push(fragment(1.0));
+
+		let snapshot = store.snapshot();
+		assert_eq!(snapshot.media_sequence, 2);
+		assert_eq!(snapshot.discontinuity_sequence, 1);
+		assert!(snapshot.segments.iter().all(|s| !s.discontinuity));
+	}
+
+	#[test]
+	fn target_duration_never_decreases_after_eviction() {
+		let cfg = config(Duration::from_secs(2));
+		let store = SegmentStore::new(Kind::Video, &cfg);
+
+		store.push(fragment(6.0));
+		store.push(fragment(1.0));
+
+		let snapshot = store.snapshot();
+		assert_eq!(snapshot.target_duration, 6);
+		assert_eq!(snapshot.media_sequence, 0);
+
+		store.push(fragment(1.0));
+		store.push(fragment(1.0));
+
+		let snapshot = store.snapshot();
+		assert_eq!(snapshot.media_sequence, 2);
+		assert_eq!(snapshot.target_duration, 6);
 	}
 }


### PR DESCRIPTION
## Summary

- Track a monotonic HLS discontinuity sequence in the export segment store and emit `EXT-X-DISCONTINUITY-SEQUENCE` once discontinuities have scrolled out of the live window.
- Latch `EXT-X-TARGETDURATION` to the maximum complete segment duration observed for the rendition instead of recomputing it from the current window.
- Add regressions for discontinuity eviction, target-duration stability, and playlist rendering.

## Root Cause

The playlist renderer derived target duration from only the currently retained segments, so the value could decrease after a long segment was evicted. The store also discarded the `discontinuity` marker when evicting a flagged segment without preserving the count required by RFC 8216 for later playlist reloads.

## Validation

- `cargo test -p moq-hls`
- `just fix`
- `just check` passed JS checks, Rust check, clippy, fmt, docs, dependency checks, and cargo sort, then failed at `bun remark --frail` because existing `justfile`s differ from the current formatter. Those unrelated formatter changes were intentionally left out of this PR.

Fixes #2009

(Written by GPT-5)