### PR TITLE
[codex] Fix RTMP play resolve timeout

### DIFF
--- a/rs/moq-rtmp/Cargo.toml
+++ b/rs/moq-rtmp/Cargo.toml
@@ -51,3 +51,4 @@ tracing = "0.1"
 # The RTMPS test borrows moq-native's self-signed cert generation to build a
 # `rustls::ServerConfig`; `quinn` pulls in a backend so `tls::Server` is built.
 moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs", "quinn"] }
+tokio = { workspace = true, features = ["test-util"] }

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -56,6 +56,10 @@ const READ_BUFFER: usize = 16 * 1024;
 /// handshake.
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
+/// How long a play request may wait for its broadcast and initial FLV header
+/// before the server rejects it.
+const PLAY_RESOLVE_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// TCP keepalive idle period before the kernel starts probing a silent peer, and
 /// the interval between probes. Once a connection is publishing or playing it can
 /// block in a `read` indefinitely, so without keepalive a half-open connection (a
@@ -493,6 +497,61 @@ impl<S: Stream> Play<S> {
 	/// This future resolves when playback ends, so callers usually run it on its
 	/// own task.
 	pub async fn accept(mut self, origin: &OriginConsumer, path: &str) -> Result<()> {
+		// Wait for the broadcast before telling the client playback started. Feed the
+		// client's bytes through the session (not discard them) so its deserializer
+		// stays in sync for everything `play_pump` parses next.
+		let broadcast = tokio::select! {
+			biased;
+			res = feed_input(&mut self.stream, &mut self.session, &mut self.work) => {
+				res?;
+				tracing::debug!(peer = %self.peer, %path, "viewer disconnected before play started");
+				return Ok(());
+			}
+			broadcast = tokio::time::timeout(PLAY_RESOLVE_TIMEOUT, origin.announced_broadcast(path)) => {
+				match broadcast {
+					Ok(broadcast) => broadcast,
+					Err(_) => {
+						tracing::debug!(peer = %self.peer, %path, "play broadcast resolve timed out");
+						return self.reject("stream not found").await;
+					}
+				}
+			}
+		};
+		let Some(broadcast) = broadcast else {
+			tracing::debug!(peer = %self.peer, %path, "play broadcast unavailable");
+			return self.reject("stream not found").await;
+		};
+
+		let mut export = FlvExport::new(broadcast)
+			.map_err(|e| anyhow::anyhow!("init FLV export: {e}"))?
+			.with_latency(self.latency);
+
+		// Resolve the catalog and codec headers before Play.Start, too. Otherwise a
+		// broadcast that never produces a playable FLV header looks successful to the
+		// viewer but never emits media.
+		let first_chunk = tokio::select! {
+			biased;
+			res = feed_input(&mut self.stream, &mut self.session, &mut self.work) => {
+				res?;
+				tracing::debug!(peer = %self.peer, %path, "viewer disconnected before play started");
+				return Ok(());
+			}
+			chunk = tokio::time::timeout(PLAY_RESOLVE_TIMEOUT, export.next()) => {
+				match chunk {
+					Ok(Ok(Some(chunk))) => chunk,
+					Ok(Ok(None)) => {
+						tracing::debug!(peer = %self.peer, %path, "play broadcast ended before FLV header");
+						return self.reject("stream not available").await;
+					}
+					Ok(Err(e)) => return Err(e.into()),
+					Err(_) => {
+						tracing::debug!(peer = %self.peer, %path, "play FLV header resolve timed out");
+						return self.reject("stream not available").await;
+					}
+				}
+			}
+		};
+
 		// Tell the client playback is starting (Play.Reset / Play.Start + StreamBegin).
 		let results = self
 			.session
@@ -503,31 +562,22 @@ impl<S: Stream> Play<S> {
 
 		tracing::info!(peer = %self.peer, %path, "rtmp play accepted");
 
-		// Wait for the broadcast, but abandon the wait if the viewer hangs up. Feed
-		// the client's bytes through the session (not discard them) so its
-		// deserializer stays in sync for everything `play_pump` parses next.
-		let broadcast = tokio::select! {
-			biased;
-			res = feed_input(&mut self.stream, &mut self.session, &mut self.work) => {
-				res?;
-				tracing::debug!(peer = %self.peer, %path, "viewer disconnected before play started");
-				return Ok(());
-			}
-			broadcast = origin.announced_broadcast(path) => broadcast,
-		};
-		let Some(broadcast) = broadcast else {
-			tracing::debug!(peer = %self.peer, %path, "play broadcast unavailable");
-			return Ok(());
-		};
+		let mut tags = flv::TagReader::new();
+		send_flv_chunk(
+			&mut self.stream,
+			&mut self.session,
+			&mut tags,
+			self.stream_id,
+			first_chunk,
+		)
+		.await?;
 
-		let mut export = FlvExport::new(broadcast)
-			.map_err(|e| anyhow::anyhow!("init FLV export: {e}"))?
-			.with_latency(self.latency);
 		let result = play_pump(
 			&mut self.stream,
 			&mut self.session,
 			&mut self.work,
 			&mut export,
+			tags,
 			self.stream_id,
 			self.peer,
 		)
@@ -716,45 +766,25 @@ async fn play_pump<S: Stream>(
 	session: &mut ServerSession,
 	work: &mut VecDeque<ServerSessionResult>,
 	export: &mut FlvExport,
+	mut tags: flv::TagReader,
 	stream_id: u32,
 	peer: SocketAddr,
 ) -> Result<()> {
 	let (mut reader, mut writer) = tokio::io::split(stream);
-	let mut tags = flv::TagReader::new();
 	let mut buffer = [0u8; READ_BUFFER];
 
-	loop {
-		// Flush responses queued by the last batch of client input.
-		while let Some(result) = work.pop_front() {
-			match result {
-				ServerSessionResult::OutboundResponse(packet) => writer.write_all(&packet.bytes).await?,
-				ServerSessionResult::RaisedEvent(ServerSessionEvent::PlayStreamFinished { .. }) => {
-					tracing::debug!(%peer, "viewer stopped playback");
-					return Ok(());
-				}
-				ServerSessionResult::RaisedEvent(other) => {
-					tracing::trace!(%peer, ?other, "ignoring RTMP event during play")
-				}
-				ServerSessionResult::UnhandleableMessageReceived(_) => {}
-			}
-		}
+	if flush_play_work(work, &mut writer, peer).await? {
+		return Ok(());
+	}
 
+	loop {
+		if flush_play_work(work, &mut writer, peer).await? {
+			return Ok(());
+		}
 		tokio::select! {
 			// Media from the broadcast: split into tags and send each one down.
 			chunk = export.next() => match chunk? {
-				Some(bytes) => {
-					tags.push(&bytes);
-					while let Some(tag) = tags.next()? {
-						let ts = RtmpTimestamp::new(tag.timestamp);
-						let packet = match tag.tag_type {
-							flv::TAG_VIDEO => session.send_video_data(stream_id, tag.body, ts, false),
-							flv::TAG_AUDIO => session.send_audio_data(stream_id, tag.body, ts, false),
-							_ => continue,
-						}
-						.map_err(|e| anyhow::anyhow!("rtmp send media: {e:?}"))?;
-						writer.write_all(&packet.bytes).await?;
-					}
-				}
+				Some(bytes) => send_flv_chunk(&mut writer, session, &mut tags, stream_id, bytes).await?,
 				// Broadcast ended: tell the player and finish.
 				None => {
 					let packet = session
@@ -777,6 +807,50 @@ async fn play_pump<S: Stream>(
 			}
 		}
 	}
+}
+
+/// Flush responses queued by RTMP client input during playback.
+async fn flush_play_work<W: AsyncWrite + Unpin>(
+	work: &mut VecDeque<ServerSessionResult>,
+	writer: &mut W,
+	peer: SocketAddr,
+) -> Result<bool> {
+	while let Some(result) = work.pop_front() {
+		match result {
+			ServerSessionResult::OutboundResponse(packet) => writer.write_all(&packet.bytes).await?,
+			ServerSessionResult::RaisedEvent(ServerSessionEvent::PlayStreamFinished { .. }) => {
+				tracing::debug!(%peer, "viewer stopped playback");
+				return Ok(true);
+			}
+			ServerSessionResult::RaisedEvent(other) => {
+				tracing::trace!(%peer, ?other, "ignoring RTMP event during play")
+			}
+			ServerSessionResult::UnhandleableMessageReceived(_) => {}
+		}
+	}
+	Ok(false)
+}
+
+/// Convert one FLV chunk into RTMP media messages.
+async fn send_flv_chunk<W: AsyncWrite + Unpin>(
+	writer: &mut W,
+	session: &mut ServerSession,
+	tags: &mut flv::TagReader,
+	stream_id: u32,
+	bytes: bytes::Bytes,
+) -> Result<()> {
+	tags.push(&bytes);
+	while let Some(tag) = tags.next()? {
+		let ts = RtmpTimestamp::new(tag.timestamp);
+		let packet = match tag.tag_type {
+			flv::TAG_VIDEO => session.send_video_data(stream_id, tag.body, ts, false),
+			flv::TAG_AUDIO => session.send_audio_data(stream_id, tag.body, ts, false),
+			_ => continue,
+		}
+		.map_err(|e| anyhow::anyhow!("rtmp send media: {e:?}"))?;
+		writer.write_all(&packet.bytes).await?;
+	}
+	Ok(())
 }
 
 /// Write every queued [`OutboundResponse`](ServerSessionResult::OutboundResponse)
@@ -1135,6 +1209,46 @@ mod tests {
 		assert_eq!(media[1].1[1], 0x01);
 
 		server_task.abort();
+	}
+
+	#[tokio::test]
+	async fn play_missing_broadcast_rejects_without_start() {
+		let mut server = Server::bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+		let addr = server.local_addr().unwrap();
+
+		let origin = moq_net::Origin::random().produce();
+		let consumer = origin.consume();
+
+		let stream = TcpStream::connect(addr).await.unwrap();
+		let client = tokio::spawn(async move {
+			run_client(stream, ClientMode::Play).await;
+		});
+		let request = server.accept().await.expect("a request");
+		let Request::Play(play) = request else {
+			panic!("expected a play request");
+		};
+
+		tokio::time::pause();
+		let server_task = tokio::spawn(async move {
+			play.accept(&consumer, "live/missing").await.unwrap();
+		});
+
+		tokio::task::yield_now().await;
+		tokio::time::advance(PLAY_RESOLVE_TIMEOUT + Duration::from_millis(1)).await;
+		for _ in 0..10 {
+			if server_task.is_finished() {
+				break;
+			}
+			tokio::task::yield_now().await;
+		}
+
+		if !server_task.is_finished() {
+			client.abort();
+			server_task.abort();
+			panic!("play accept did not finish after resolve timeout");
+		}
+		server_task.await.unwrap();
+		client.abort();
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
## Summary

- Delay RTMP `Play.Start` until the requested broadcast and initial FLV header are available.
- Add a bounded resolve timeout and keep racing the wait against client disconnects.
- Add a regression test for playing a nonexistent broadcast without reporting playback accepted.

## Root Cause

`Play::accept` accepted the RTMP play request before resolving the MoQ broadcast. A typo or random path could therefore receive `Play.Start` and then park indefinitely while waiting on `announced_broadcast`.

## Validation

- `cargo fmt -p moq-rtmp --check`
- `cargo test -p moq-rtmp play_missing_broadcast_rejects_without_start`
- `cargo test -p moq-rtmp`
- `git diff --check`

(Written by GPT-5)