### PR TITLE
[codex] share RTMP active publish paths

### DIFF
--- a/rs/moq-rtmp/README.md
+++ b/rs/moq-rtmp/README.md
@@ -86,15 +86,18 @@ Two ways to serve `rtmps://`:
   `Server::with_tls`) with a `rustls::ServerConfig`, and the listener speaks
   RTMPS with no other change. Build the config from a `moq_native::tls::Server`
   instance (RTMPS has no ALPN), or supply any `rustls::ServerConfig`. To serve
-  both RTMP and RTMPS, run two listeners (`run` once per config) against a
-  cloned origin.
+  both RTMP and RTMPS, clone one base config so duplicate-publish rejection is
+  shared across both listeners, then call `run` with a cloned origin.
 
   ```rust
   let mut tls = moq_native::tls::Server::default();
   tls.generate = vec!["your-domain.com".to_string()]; // or set tls.cert / tls.key
   let server_config = tls.server_config(vec![])?; // RTMPS has no ALPN
 
-  let mut rtmps = moq_rtmp::Config::default();
+  let mut rtmp = moq_rtmp::Config::default();
+  rtmp.listen = Some("0.0.0.0:1935".parse()?);
+
+  let mut rtmps = rtmp.clone();
   rtmps.listen = Some("0.0.0.0:443".parse()?);
   rtmps.tls = Some(server_config); // Arc<rustls::ServerConfig>
   ```

--- a/rs/moq-rtmp/src/listen.rs
+++ b/rs/moq-rtmp/src/listen.rs
@@ -56,10 +56,12 @@ pub struct Config {
 	/// `moq_native::tls::Server::server_config` (pass an empty ALPN list) or
 	/// any [`rustls::ServerConfig`]. Leave `None` for plaintext.
 	///
-	/// To serve both RTMP and RTMPS, run two listeners: call [`run`] once per
-	/// config (one with `tls`, one without) against a cloned origin.
+	/// To serve both RTMP and RTMPS, clone one base config and call [`run`] for
+	/// each listener against a cloned origin.
 	#[cfg(feature = "tls")]
 	pub tls: Option<std::sync::Arc<rustls::ServerConfig>>,
+
+	active: ActivePaths,
 }
 
 /// Run the RTMP listener until it fails, bridging each connection to `origin`:
@@ -100,8 +102,9 @@ pub async fn run(origin: OriginProducer, config: Config) -> Result<()> {
 
 	// Tracks which broadcast paths are currently being ingested so a second
 	// publisher on the same stream key is rejected (first-publisher-wins) instead
-	// of clobbering the live one.
-	let active = ActivePaths::default();
+	// of clobbering the live one. This lives on Config so cloned RTMP/RTMPS
+	// listeners share the same claim table.
+	let active = config.active.clone();
 	let prefix = Arc::new(config.prefix);
 	let latency = config.latency;
 	// Players are served out of the same origin the publishers write into.
@@ -176,7 +179,7 @@ pub(crate) fn resolve_path(prefix: &str, app: &str, key: &str) -> Option<String>
 
 /// The set of broadcast paths with a live ingest, used to reject duplicate
 /// stream keys. Cheap to clone (shared `Arc`).
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct ActivePaths(Arc<Mutex<HashSet<String>>>);
 
 impl ActivePaths {
@@ -247,5 +250,17 @@ mod tests {
 		assert!(active.claim("live/cam0").is_some());
 
 		drop(other);
+	}
+
+	#[test]
+	fn cloned_configs_share_active_paths() {
+		let config = Config::default();
+		let cloned = config.clone();
+
+		let guard = config.active.claim("live/cam0").expect("first claim succeeds");
+		assert!(cloned.active.claim("live/cam0").is_none());
+
+		drop(guard);
+		assert!(cloned.active.claim("live/cam0").is_some());
 	}
 }


### PR DESCRIPTION
## Summary

- Share moq-rtmp ActivePaths through Config so cloned RTMP and RTMPS listeners reject duplicate publishes across both sockets.
- Update the RTMPS README example to clone a base config for dual-listener setups.

## Root Cause

Issue #2008 found that run() created a fresh ActivePaths set per listener. Embedders serving RTMP and RTMPS by calling run() twice against cloned origin handles shared the same broadcast namespace, but not the duplicate-publish claim table. A second publisher could be accepted on the other listener and sit as an origin backup.

## Public API

No public API changes. The new Config field is private and preserves the existing Default plus field assignment construction style.

## Validation

- cargo fmt --package moq-rtmp
- cargo check -p moq-rtmp --no-default-features
- git diff --check

Attempted cargo test -p moq-rtmp and the targeted cloned_configs_share_active_paths unit test, but both stopped producing progress in the dev-dependency test build/link path after several minutes and were interrupted.

Fixes #2008

(Written by GPT-5)