### PR TITLE
[codex] Fix MSF catalog jitter compatibility

### DIFF
--- a/js/msf/src/catalog.test.ts
+++ b/js/msf/src/catalog.test.ts
@@ -62,7 +62,7 @@ test("decodes a draft-00 catalog whose timeline tracks omit isLive", () => {
 	);
 
 	expect(catalog.tracks).toHaveLength(2);
-	expect(catalog.tracks[0].isLive).toBeUndefined();
+	expect(catalog.tracks[0].isLive).toBe(false);
 	expect(catalog.tracks[0].packaging).toBe("mediatimeline");
 });
 
@@ -135,4 +135,52 @@ test("encode hoists and dedups init data, then round-trips", () => {
 	const parsed = decode(encode(catalog));
 	expect(parsed.tracks[0].initData).toBe("AQID");
 	expect(parsed.tracks[1].initData).toBe("AQID");
+});
+
+test("encode emits isLive when omitted", () => {
+	const wire = decodeJson(
+		encode({
+			tracks: [{ name: "history", packaging: "mediatimeline" }],
+		}),
+	);
+
+	const wireTracks = wire.tracks as { isLive?: boolean }[];
+	expect(wireTracks[0].isLive).toBe(false);
+
+	const parsed = decode(encodeJson(wire));
+	expect(parsed.tracks[0].isLive).toBe(false);
+});
+
+test("preserves SAP fields through decode and encode", () => {
+	const catalog = decode(
+		encodeJson({
+			version: "draft-01",
+			tracks: [
+				{
+					name: "video0",
+					packaging: "cmaf",
+					isLive: true,
+					role: "video",
+					codec: "avc1.640028",
+					maxGrpSapStartingType: 1,
+					maxObjSapStartingType: 2,
+					jitter: 15.0,
+				},
+			],
+		}),
+	);
+
+	expect(catalog.tracks[0].maxGrpSapStartingType).toBe(1);
+	expect(catalog.tracks[0].maxObjSapStartingType).toBe(2);
+	expect(catalog.tracks[0].jitter).toBe(15);
+
+	const wire = decodeJson(encode(catalog));
+	const wireTracks = wire.tracks as {
+		maxGrpSapStartingType?: number;
+		maxObjSapStartingType?: number;
+		jitter?: number;
+	}[];
+	expect(wireTracks[0].maxGrpSapStartingType).toBe(1);
+	expect(wireTracks[0].maxObjSapStartingType).toBe(2);
+	expect(wireTracks[0].jitter).toBe(15);
 });

--- a/js/msf/src/catalog.ts
+++ b/js/msf/src/catalog.ts
@@ -39,6 +39,8 @@ const trackShape = {
 	initData: z.optional(z.string()),
 	renderGroup: z.optional(z.number()),
 	altGroup: z.optional(z.number()),
+	maxGrpSapStartingType: z.optional(z.number()),
+	maxObjSapStartingType: z.optional(z.number()),
 
 	// Non-standard: maximum delay (ms) between consecutive frames on this track.
 	// The player's buffer must be at least this large to avoid underruns.
@@ -96,7 +98,8 @@ export function encode(catalog: Catalog): Uint8Array {
 
 	const tracks = catalog.tracks.map((track) => {
 		const { initData, ...rest } = track;
-		if (initData === undefined) return rest;
+		const wireTrack = { ...rest, isLive: rest.isLive ?? false };
+		if (initData === undefined) return wireTrack;
 
 		let id = ids.get(initData);
 		if (id === undefined) {
@@ -104,7 +107,7 @@ export function encode(catalog: Catalog): Uint8Array {
 			initDataList.push({ id, type: "inline", data: initData });
 			ids.set(initData, id);
 		}
-		return { ...rest, initRef: id };
+		return { ...wireTrack, initRef: id };
 	});
 
 	const wire: Record<string, unknown> = { version: VERSION, tracks };
@@ -124,6 +127,8 @@ export function decode(raw: Uint8Array): Catalog {
 		const inline = new Map((wire.initDataList ?? []).filter((e) => e.type === "inline").map((e) => [e.id, e.data]));
 
 		const tracks = (wire.tracks ?? []).map(({ initRef, ...track }) => {
+			track.isLive ??= false;
+
 			// Resolve draft-01 initRef into inline initData so callers never see
 			// the indirection. Inline initData (draft-00) is left untouched.
 			if (track.initData === undefined && initRef !== undefined) {

--- a/rs/moq-msf/src/lib.rs
+++ b/rs/moq-msf/src/lib.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
-use serde_with::DurationMilliSeconds;
+use serde_with::DurationMilliSecondsWithFrac;
 
 /// The default track name for the MSF catalog.
 pub const DEFAULT_NAME: &str = "catalog";
@@ -122,9 +122,8 @@ pub struct Track {
 
 	/// Jitter (non-standard extension; not in the MSF/CMSF drafts).
 	///
-	/// Serialized as a JSON integer number of milliseconds, matching the hang
-	/// catalog. Sub-ms precision isn't meaningful for jitter.
-	#[serde_as(as = "Option<DurationMilliSeconds<u64>>")]
+	/// Serialized as a JSON number of milliseconds, matching the hang catalog.
+	#[serde_as(as = "Option<DurationMilliSecondsWithFrac>")]
 	pub jitter: Option<Duration>,
 }
 
@@ -641,7 +640,7 @@ mod test {
 		let track = &value["tracks"][0];
 		assert_eq!(track.get("maxGrpSapStartingType"), Some(&serde_json::json!(1)));
 		assert_eq!(track.get("maxObjSapStartingType"), Some(&serde_json::json!(2)));
-		assert_eq!(track.get("jitter"), Some(&serde_json::json!(15)));
+		assert_eq!(track.get("jitter").and_then(serde_json::Value::as_f64), Some(15.0));
 
 		// Snake-case names must NOT appear on the wire.
 		assert!(track.get("max_grp_sap_starting_type").is_none());
@@ -687,6 +686,27 @@ mod test {
 		assert_eq!(parsed.tracks[0].max_grp_sap_starting_type, Some(1));
 		assert_eq!(parsed.tracks[0].max_obj_sap_starting_type, Some(2));
 		assert_eq!(parsed.tracks[0].jitter, Some(Duration::from_millis(15)));
+	}
+
+	#[test]
+	fn fractional_jitter_roundtrips() {
+		let json = r#"{
+			"version": "draft-01",
+			"tracks": [{
+				"name": "video0",
+				"packaging": "cmaf",
+				"isLive": true,
+				"role": "video",
+				"codec": "avc1.640028",
+				"jitter": 15.0
+			}]
+		}"#;
+
+		let catalog = Catalog::from_str(json).expect("fractional jitter must decode");
+		assert_eq!(catalog.tracks[0].jitter, Some(Duration::from_millis(15)));
+
+		let value: serde_json::Value = serde_json::from_str(&catalog.to_string().unwrap()).unwrap();
+		assert_eq!(value["tracks"][0]["jitter"].as_f64(), Some(15.0));
 	}
 
 	#[test]


### PR DESCRIPTION
Fixes #2002.

## Summary
- Accept fractional millisecond `jitter` values in Rust MSF catalogs with `DurationMilliSecondsWithFrac`.
- Keep `js/msf` aligned by preserving CMSF SAP fields and normalizing/emitting `isLive: false` when omitted.
- Add Rust and JS regressions for fractional jitter and JS catalog round trips.

## Root Cause
`moq-msf` 0.3.0 changed `jitter` from a float to an integer millisecond `Duration` encoding, so catalogs emitted by 0.2.0 with values like `15.0` failed strict Rust deserialization. The JS schema also omitted fields that Rust already modeled, causing decode/encode drift.

## Validation
- `cargo test -p moq-msf`
- `cargo clippy -p moq-msf --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p moq-msf --no-deps`
- `bun test js/msf/src/catalog.test.ts`
- `bun run --filter @moq/msf check`
- `bun biome check js/msf/src/catalog.ts js/msf/src/catalog.test.ts`

(Written by GPT-5)