### PR TITLE
[codex] evict finished HLS broadcasters

### DIFF
--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -53,6 +53,7 @@ impl Default for Config {
 
 /// All renditions of one broadcast, kept in sync with its catalog.
 pub struct Broadcaster {
+	broadcast: moq_net::BroadcastConsumer,
 	renditions: Mutex<BTreeMap<String, Arc<Rendition>>>,
 	/// Current rendition count, bumped on every catalog sync so handlers can wait
 	/// for the catalog to populate before rendering a playlist.
@@ -69,6 +70,7 @@ impl Broadcaster {
 		let (ready, _) = watch::channel(0);
 		let (paused, _) = watch::channel(false);
 		let broadcaster = Arc::new(Self {
+			broadcast: broadcast.clone(),
 			renditions: Mutex::new(BTreeMap::new()),
 			ready,
 			paused,
@@ -94,6 +96,14 @@ impl Broadcaster {
 	/// Whether the export is currently paused.
 	pub fn is_paused(&self) -> bool {
 		*self.paused.borrow()
+	}
+
+	pub(crate) fn is_closed(&self) -> bool {
+		self.broadcast.is_closed()
+	}
+
+	pub(crate) async fn closed(&self) {
+		self.broadcast.closed().await;
 	}
 
 	/// Look up a rendition by name.

--- a/rs/moq-hls/src/server/mod.rs
+++ b/rs/moq-hls/src/server/mod.rs
@@ -56,8 +56,14 @@ impl Server {
 	/// the relay (waiting briefly for its announcement). Returns `None` if the
 	/// broadcast never shows up.
 	pub(crate) async fn broadcaster(&self, name: &str) -> Option<Arc<Broadcaster>> {
-		if let Some(existing) = self.inner.broadcasters.lock().unwrap().get(name).cloned() {
-			return Some(existing);
+		{
+			let mut broadcasters = self.inner.broadcasters.lock().unwrap();
+			if let Some(existing) = broadcasters.get(name) {
+				if !existing.is_closed() {
+					return Some(existing.clone());
+				}
+				broadcasters.remove(name);
+			}
 		}
 
 		let broadcast = tokio::time::timeout(RESOLVE_TIMEOUT, self.inner.origin.announced_broadcast(name))
@@ -66,9 +72,83 @@ impl Server {
 			.flatten()?;
 
 		let mut broadcasters = self.inner.broadcasters.lock().unwrap();
-		let broadcaster = broadcasters
-			.entry(name.to_string())
-			.or_insert_with(|| Broadcaster::new(broadcast, self.inner.config.clone()));
-		Some(broadcaster.clone())
+		if let Some(existing) = broadcasters.get(name) {
+			if !existing.is_closed() {
+				return Some(existing.clone());
+			}
+			broadcasters.remove(name);
+		}
+
+		let name = name.to_string();
+		let broadcaster = Broadcaster::new(broadcast, self.inner.config.clone());
+		broadcasters.insert(name.clone(), broadcaster.clone());
+		tokio::spawn(evict_closed(self.inner.clone(), name, broadcaster.clone()));
+		Some(broadcaster)
+	}
+}
+
+async fn evict_closed(inner: Arc<Inner>, name: String, broadcaster: Arc<Broadcaster>) {
+	broadcaster.closed().await;
+
+	let mut broadcasters = inner.broadcasters.lock().unwrap();
+	if broadcasters
+		.get(&name)
+		.is_some_and(|current| Arc::ptr_eq(current, &broadcaster))
+	{
+		broadcasters.remove(&name);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn closed_broadcaster() -> Arc<Broadcaster> {
+		let producer = moq_net::Broadcast::new().produce();
+		let broadcaster = Broadcaster::new(producer.consume(), Config::default());
+		drop(producer);
+		broadcaster
+	}
+
+	#[tokio::test]
+	async fn broadcaster_replaces_finished_cached_instance() {
+		let origin = moq_net::Origin::random().produce();
+		let server = Server::new(origin.consume(), Config::default());
+		let stale = closed_broadcaster();
+
+		server
+			.inner
+			.broadcasters
+			.lock()
+			.unwrap()
+			.insert("live".to_string(), stale.clone());
+		let _producer = origin.create_broadcast("live").expect("publish allowed");
+
+		let fresh = server.broadcaster("live").await.expect("broadcast announced");
+
+		assert!(!Arc::ptr_eq(&stale, &fresh));
+		assert!(server.inner.broadcasters.lock().unwrap().contains_key("live"));
+	}
+
+	#[tokio::test]
+	async fn eviction_keeps_newer_cached_instance() {
+		let origin = moq_net::Origin::random().produce();
+		let server = Server::new(origin.consume(), Config::default());
+		let old = closed_broadcaster();
+		let new_producer = moq_net::Broadcast::new().produce();
+		let new = Broadcaster::new(new_producer.consume(), Config::default());
+
+		server
+			.inner
+			.broadcasters
+			.lock()
+			.unwrap()
+			.insert("live".to_string(), new.clone());
+
+		evict_closed(server.inner.clone(), "live".to_string(), old).await;
+
+		let cached = server.inner.broadcasters.lock().unwrap().get("live").cloned();
+		assert!(cached.is_some_and(|cached| Arc::ptr_eq(&cached, &new)));
+		drop(new_producer);
 	}
 }


### PR DESCRIPTION
## Summary

- mark moq-hls broadcasters finished when their catalog watcher exits
- evict finished broadcasters from the server cache so a same-name republish gets a fresh instance
- guard cleanup with Arc::ptr_eq so a late cleanup cannot remove a newer broadcaster

Fixes #2010.

## Validation

- cargo test -p moq-hls
- just fix
- just check progressed through JS checks, Rust check, clippy, fmt, docs, shear, and cargo sort, then failed at the repo-wide justfile formatting gate because existing justfiles differ from just --fmt --unstable --check output. I left that unrelated formatter churn out of this PR.

(Written by GPT-5)