### PR TITLE
[codex] Fix moq-rtc loopback ICE fallback

### DIFF
--- a/rs/moq-rtc/src/client/mod.rs
+++ b/rs/moq-rtc/src/client/mod.rs
@@ -18,7 +18,7 @@ use url::Url;
 #[non_exhaustive]
 pub struct Config {
 	/// Public UDP socket addresses to advertise as ICE host candidates in
-	/// our outbound offer. Same semantics as [`crate::server::Config`].
+	/// our outbound offer. Same semantics as [`crate::server::Config::ice_candidates`].
 	pub ice_candidates: Vec<SocketAddr>,
 }
 

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -140,8 +140,9 @@ pub struct Config {
 	/// candidates. Each is sent as a separate `candidate` line in the SDP
 	/// answer so a remote peer can reach us.
 	///
-	/// If empty, the mux advertises whatever address the OS picked for the
-	/// shared socket. That works for loopback testing but not behind NAT.
+	/// If empty, the mux advertises the bound address, substituting loopback
+	/// when the socket is bound to an unspecified address. That works for
+	/// loopback testing but not behind NAT.
 	pub ice_candidates: Vec<SocketAddr>,
 
 	/// Address the shared WebRTC media socket binds to. Every WHIP/WHEP session

--- a/rs/moq-rtc/src/server/mux.rs
+++ b/rs/moq-rtc/src/server/mux.rs
@@ -28,7 +28,7 @@ use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
 
 use crate::Result;
-use crate::session::{Packet, SESSION_INBOX};
+use crate::session::{Packet, SESSION_INBOX, advertised_candidates};
 
 /// Per-session routing table, shared between the demux task and the accept path.
 #[derive(Default)]
@@ -75,20 +75,11 @@ impl Drop for Registration {
 impl Mux {
 	/// Bind the shared socket to `udp_bind` and spawn the demux task. The
 	/// advertised candidates are `ice_candidates` (each reusing the socket's
-	/// real port), or the bound address itself when none are configured.
+	/// real port), or the bound address when none are configured. An unspecified
+	/// bind falls back to loopback for local testing.
 	pub(crate) async fn bind(udp_bind: SocketAddr, ice_candidates: &[SocketAddr]) -> Result<Self> {
 		let socket = Arc::new(UdpSocket::bind(udp_bind).await?);
-		let port = socket.local_addr()?.port();
-		let candidates = if ice_candidates.is_empty() {
-			vec![socket.local_addr()?]
-		} else {
-			// str0m's ICE agent sends to the candidate's port, so reuse the one
-			// real bound port across each advertised IP.
-			ice_candidates
-				.iter()
-				.map(|addr| SocketAddr::new(addr.ip(), port))
-				.collect()
-		};
+		let candidates = advertised_candidates(ice_candidates, socket.local_addr()?)?;
 
 		let registry = Arc::new(Mutex::new(Registry::default()));
 		tokio::spawn(demux(socket.clone(), registry.clone()));
@@ -123,7 +114,7 @@ impl Mux {
 
 	/// ICE host candidates to advertise in the SDP answer. The session tags each
 	/// inbound datagram with the family-matching candidate; never empty (falls
-	/// back to the bound address).
+	/// back to the bound address or loopback).
 	pub(crate) fn candidates(&self) -> &[SocketAddr] {
 		&self.candidates
 	}

--- a/rs/moq-rtc/src/session.rs
+++ b/rs/moq-rtc/src/session.rs
@@ -11,7 +11,7 @@
 //! ([`MediaSink`]) or RTP-out ([`crate::egress::EgressSource`]).
 
 use std::collections::HashMap;
-use std::net::SocketAddr;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -466,23 +466,40 @@ pub fn rtc_with_codecs(codecs: &[str0m::format::Codec]) -> Rtc {
 ///
 /// The client paths are 1:1 (one socket per dialed session, no demux); the
 /// server paths share one socket via `crate::server::mux` instead. `advertise`
-/// IPs are used verbatim (reusing the bound port); empty falls back to whatever
-/// address the OS picked (loopback only).
+/// IPs are used verbatim (reusing the bound port); empty falls back to the
+/// bound address, substituting loopback when that address is unspecified.
 pub async fn bind_udp(advertise: &[SocketAddr]) -> Result<(Arc<UdpSocket>, Vec<SocketAddr>)> {
 	let socket = UdpSocket::bind(("0.0.0.0", 0)).await?;
 	let local = socket.local_addr()?;
-	let candidates = if advertise.is_empty() {
-		vec![local]
-	} else {
-		// Reuse the bound port across each advertised IP, since str0m's ICE
-		// agent picks the destination port from the candidate it's pairing
-		// against.
-		advertise
-			.iter()
-			.map(|addr| SocketAddr::new(addr.ip(), local.port()))
-			.collect()
-	};
+	let candidates = advertised_candidates(advertise, local)?;
 	Ok((Arc::new(socket), candidates))
+}
+
+/// Pair configured ICE candidates with the bound UDP port and validate them.
+pub(crate) fn advertised_candidates(advertise: &[SocketAddr], local: SocketAddr) -> Result<Vec<SocketAddr>> {
+	let port = local.port();
+	let candidates = if advertise.is_empty() {
+		let ip = match local.ip() {
+			IpAddr::V4(ip) if ip.is_unspecified() => IpAddr::V4(Ipv4Addr::LOCALHOST),
+			IpAddr::V6(ip) if ip.is_unspecified() => IpAddr::V6(Ipv6Addr::LOCALHOST),
+			ip => ip,
+		};
+
+		let candidate = SocketAddr::new(ip, port);
+		if candidate != local {
+			tracing::info!(bound = %local, advertised = %candidate, "webrtc udp bind is unspecified, advertising loopback ICE candidate");
+		}
+		vec![candidate]
+	} else {
+		// Reuse the bound port across each advertised IP, since str0m's ICE agent
+		// picks the destination port from the candidate it's pairing against.
+		advertise.iter().map(|addr| SocketAddr::new(addr.ip(), port)).collect()
+	};
+
+	for addr in &candidates {
+		str0m::ice::Candidate::host(*addr, "udp").map_err(str0m::RtcError::from)?;
+	}
+	Ok(candidates)
 }
 
 /// Spawn a 1:1 reader pumping every datagram from `socket` into a channel, for
@@ -518,6 +535,44 @@ mod tests {
 	use str0m::media::Mid;
 
 	use super::*;
+
+	#[test]
+	fn advertised_candidates_use_loopback_for_unspecified_ipv4() {
+		let local: SocketAddr = "0.0.0.0:4444".parse().unwrap();
+		let candidates = advertised_candidates(&[], local).unwrap();
+		assert_eq!(candidates, vec!["127.0.0.1:4444".parse().unwrap()]);
+	}
+
+	#[test]
+	fn advertised_candidates_use_loopback_for_unspecified_ipv6() {
+		let local: SocketAddr = "[::]:4444".parse().unwrap();
+		let candidates = advertised_candidates(&[], local).unwrap();
+		assert_eq!(candidates, vec!["[::1]:4444".parse().unwrap()]);
+	}
+
+	#[test]
+	fn advertised_candidates_keep_bound_address_when_specific() {
+		let local: SocketAddr = "127.0.0.1:4444".parse().unwrap();
+		assert_eq!(advertised_candidates(&[], local).unwrap(), vec![local]);
+	}
+
+	#[test]
+	fn advertised_candidates_reuse_bound_port_for_configured_addresses() {
+		let local: SocketAddr = "0.0.0.0:4444".parse().unwrap();
+		let advertised = vec!["127.0.0.1:1000".parse().unwrap(), "[::1]:2000".parse().unwrap()];
+
+		assert_eq!(
+			advertised_candidates(&advertised, local).unwrap(),
+			vec!["127.0.0.1:4444".parse().unwrap(), "[::1]:4444".parse().unwrap()]
+		);
+	}
+
+	#[test]
+	fn advertised_candidates_reject_configured_unspecified_addresses() {
+		let local: SocketAddr = "127.0.0.1:4444".parse().unwrap();
+		let advertised = vec!["0.0.0.0:1000".parse().unwrap()];
+		assert!(advertised_candidates(&advertised, local).is_err());
+	}
 
 	#[test]
 	fn pick_local_matches_address_family() {

--- a/rs/moq-rtc/src/session.rs
+++ b/rs/moq-rtc/src/session.rs
@@ -15,7 +15,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use str0m::{Event, IceConnectionState, Input, Output, Rtc, net::Receive};
+use str0m::{Candidate, Event, IceConnectionState, Input, Output, Rtc, net::Receive};
 use tokio::net::UdpSocket;
 use tokio::sync::mpsc;
 
@@ -497,7 +497,7 @@ pub(crate) fn advertised_candidates(advertise: &[SocketAddr], local: SocketAddr)
 	};
 
 	for addr in &candidates {
-		str0m::ice::Candidate::host(*addr, "udp").map_err(str0m::RtcError::from)?;
+		Candidate::host(*addr, "udp").map_err(str0m::RtcError::from)?;
 	}
 	Ok(candidates)
 }


### PR DESCRIPTION
## Summary

- Substitute loopback ICE candidates when moq-rtc binds UDP to an unspecified address and no explicit ICE candidates are configured.
- Share the candidate construction between the server mux and client UDP bind path, including upfront validation with str0m.
- Update config docs and add unit coverage for loopback fallback, configured port reuse, and invalid unspecified candidates.

Fixes #2004.

## Test plan

- [x] cargo fmt --package moq-rtc --check
- [x] cargo check -p moq-rtc
- [x] cargo test -p moq-rtc advertised_candidates --lib
- [x] git diff --check

(Written by GPT-5)