### PR TITLE
fix(smoke): _exit the C client so a racing frame callback can't corrupt the stack

### DIFF
--- a/test/smoke/clients/c/subscribe.c
+++ b/test/smoke/clients/c/subscribe.c
@@ -25,9 +25,15 @@ typedef struct {
     int video_started; // guard: start the video track only once
 } ctx_t;
 
-// Callbacks run on libmoq's runtime thread; main waits on the condvar. ctx
-// lives on main's stack and outlives the callbacks (main blocks until got/
-// timeout, then the process exits), so there's no use-after-free.
+// Callbacks run on libmoq's runtime thread while main waits on the condvar.
+// The video track-consume task keeps firing on_frame until it's closed AND has
+// delivered a terminal callback; moq_session_close only signals shutdown, it
+// doesn't synchronously stop that task. So a frame callback can still be in
+// flight when main is ready to leave. We terminate the terminal paths with
+// _exit rather than returning, so main's stack frame (which backs ctx, mu, and
+// cv) is never unwound out from under an in-flight callback. Returning normally
+// let the racing on_frame lock a mutex on a dead stack frame and corrupt it,
+// tripping a glibc tpp.c assertion (abort) on Linux.
 static void on_status(void *ud, int32_t code) {
     (void)ud;
     fprintf(stderr, "session status: %d\n", code);
@@ -139,11 +145,15 @@ int main(int argc, char **argv) {
     int got = c.got;
     pthread_mutex_unlock(&c.mu);
 
+    // The track-consume task is still running on libmoq's runtime thread and may
+    // be mid on_frame, touching mu/cv on this stack frame. _exit ends the process
+    // without unwinding the stack or running teardown, so that memory stays valid
+    // for any in-flight callback (see the note above on_status). We already have
+    // our verdict, so a clean session close isn't worth the teardown race.
     if (got) {
         fprintf(stderr, "received a frame from %s\n", broadcast);
-        moq_session_close((uint32_t)session);
-        return 0;
+        _exit(0);
     }
     fprintf(stderr, "error: timed out waiting for data\n");
-    return 1;
+    _exit(1);
 }


### PR DESCRIPTION
## Summary

Fixes the `rust -> c` smoke-test failure, where the C subscriber received a frame and then crashed at teardown with a glibc pthread assertion:

```
received a frame from smoke-rust-...hang
Fatal glibc error: tpp.c:83 (__pthread_tpp_change_priority): assertion failed
Aborted (core dumped)
```

This is a use-after-scope in the test client, **not** a moq/protocol bug.

## Root cause

In `test/smoke/clients/c/subscribe.c`, `ctx_t c` (holding the `pthread_mutex_t`/`pthread_cond_t`) lives on `main`'s stack.

- After the first non-empty frame, `main` calls `moq_session_close` and returns.
- But `moq_session_close` only signals the **session** task (`rs/libmoq/src/session.rs`). It does **not** stop the **video track-consume** task (`rs/libmoq/src/consume.rs`), and the client never closes that track nor waits for its terminal callback.
- So `on_frame` keeps firing on libmoq's runtime thread and locks `&c->mu` after `main`'s stack frame is gone. Exit teardown reuses that memory; glibc misreads the clobbered mutex as priority-protected and `__pthread_tpp_change_priority` aborts at `tpp.c:83`. Those stack `pthread` primitives are the only objects in the process that glibc's `tpp.c` path touches (Rust std mutexes are raw futexes; jemalloc uses its own locks), which pinpoints the corruption.

**Why only `rust -> c`:** it's a race decided by frame cadence. The rust importer (`moq import avc3`) streams the `-re`-paced 30fps Annex-B stream continuously, so a callback is almost always in flight at teardown and the abort is reliable. The sparser python/js publishers usually miss the window, so `python -> c` and `js -> c` pass. The old comment claiming "no use-after-free" had the lifetime backwards: the callbacks outlive `main`.

## Fix

Terminate the terminal paths with `_exit` instead of returning. `_exit` ends the process with a single syscall (no stack unwind, no destructors), so the memory backing `ctx`/`mu`/`cv` stays valid and unclobbered for any in-flight callback until the kernel reaps the process.

This mirrors the harness's existing stance for the js-native clients (`test/smoke/smoke.sh` swallows an analogous NAPI teardown segfault and judges by a printed marker), where teardown crashes are out of scope and the end-to-end data path is the actual test.

## Test plan

- [ ] Run the smoke matrix on the Linux runner (`just test smoke`, or at least the `rust -> c` cell) and confirm 21/21.

Change is confined to the smoke test's C client; no library or wire code is touched.

(Written by Claude Opus 4.8)