### PR TITLE
[codex] fix moq-boy playback support probes

### DIFF
--- a/js/moq-boy/src/game.ts
+++ b/js/moq-boy/src/game.ts
@@ -122,10 +122,17 @@ export class Game {
 
 		// Sources produce the per-rendition jitter that Sync reads, so they're created
 		// before Sync to avoid a construction cycle.
-		this.videoSource = new Watch.Video.Source({ broadcast: this.broadcast, target: this.#target });
+		this.videoSource = new Watch.Video.Source({
+			broadcast: this.broadcast,
+			target: this.#target,
+			supported: Watch.Video.Decoder.supported,
+		});
 		this.#signals.cleanup(() => this.videoSource.close());
 
-		this.audioSource = new Watch.Audio.Source({ broadcast: this.broadcast });
+		this.audioSource = new Watch.Audio.Source({
+			broadcast: this.broadcast,
+			supported: Watch.Audio.Decoder.supported,
+		});
 		this.#signals.cleanup(() => this.audioSource.close());
 
 		this.sync = new Watch.Sync({


### PR DESCRIPTION
## Summary

- Wire WebCodecs video and audio support probes into MoQ Boy's direct `Watch.*.Source` construction.
- Restore rendition availability so the grid can select tracks and play video/audio.

## Root Cause

`Watch.Video.Source` and `Watch.Audio.Source` now depend on an explicit `supported` probe to populate `available` renditions. MoQ Boy builds sources manually and was not passing the decoder probes, so no track was ever selected.

## Validation

- `bun run --filter='@moq/boy' check`
- `bun biome check js/moq-boy/src/game.ts`

(Written by GPT-5)
