### PR TITLE
[codex] fix moq-net timestamp fallback on wasm

### DIFF
--- a/rs/moq-net/src/model/time.rs
+++ b/rs/moq-net/src/model/time.rs
@@ -1,8 +1,4 @@
 use std::num::NonZero;
-use std::sync::LazyLock;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-use rand::RngExt;
 
 use crate::coding::VarInt;
 
@@ -302,15 +298,15 @@ impl Timestamp {
 		}
 	}
 
-	/// Wall-clock now, expressed in the default timescale ([`Timescale::MILLI`]).
+	/// Current time, expressed in the default timescale ([`Timescale::MILLI`]).
 	///
-	/// This is the one-way bridge from wall-clock time to a track timestamp: there is
+	/// This is the one-way bridge from a local clock to a track timestamp: there is
 	/// deliberately no inverse (a [`Timestamp`] is relative and jittered, never a clock).
 	/// Used to stamp frames that arrive without one, e.g. on protocols whose wire can't
-	/// carry a timestamp. Uses [`tokio::time::Instant::now`] so it honors
+	/// carry a timestamp. Uses [`web_async::time::Instant::now`] so it works on wasm and honors
 	/// `tokio::time::pause` in tests.
 	pub fn now() -> Self {
-		tokio::time::Instant::now().into()
+		clock::now()
 	}
 }
 
@@ -409,29 +405,37 @@ impl std::ops::SubAssign for Timestamp {
 	}
 }
 
-/// Epoch the wall-clock timestamps are measured from: 2020-01-01T00:00:00Z.
-///
-/// A [`Timestamp`] isn't a real clock, it just needs to be non-negative and roughly
-/// monotonic with wall time. Anchoring 50 years after the Unix epoch keeps the value
-/// ~1.5e12 ms smaller, trimming a byte or two off the first frame's varint.
-const ANCHOR_EPOCH_SECS: u64 = 1_577_836_800;
+#[cfg(any(not(target_arch = "wasm32"), target_os = "wasi"))]
+mod clock {
+	use std::sync::LazyLock;
+	use std::time::{SystemTime, UNIX_EPOCH};
 
-// There's no zero Instant, so we need to use a reference point.
-static TIME_ANCHOR: LazyLock<(std::time::Instant, SystemTime)> = LazyLock::new(|| {
-	// To deter nerds trying to use timestamp as wall clock time, we subtract a random amount of time from the anchor.
-	// This will make our timestamps appear to be late; just enough to be annoying and obscure our clock drift.
-	// This will also catch bad implementations that assume unrelated broadcasts are synchronized.
-	let jitter = std::time::Duration::from_millis(rand::rng().random_range(0..69_420));
-	(std::time::Instant::now(), SystemTime::now() - jitter)
-});
+	use rand::RngExt;
 
-impl From<std::time::Instant> for Timestamp {
-	/// Convert an [`std::time::Instant`] into a millisecond-scale timestamp (the default
-	/// timescale), anchored at 2020-01-01 plus a per-process jitter (see `TIME_ANCHOR`).
+	use super::Timestamp;
+
+	/// Epoch the wall-clock timestamps are measured from: 2020-01-01T00:00:00Z.
 	///
-	/// One-way only: there is no inverse, since the anchor is jittered to keep a
-	/// [`Timestamp`] from being read back as a clock.
-	fn from(instant: std::time::Instant) -> Self {
+	/// A [`Timestamp`] isn't a real clock, it just needs to be non-negative and roughly
+	/// monotonic with wall time. Anchoring 50 years after the Unix epoch keeps the value
+	/// ~1.5e12 ms smaller, trimming a byte or two off the first frame's varint.
+	const ANCHOR_EPOCH_SECS: u64 = 1_577_836_800;
+
+	// There's no zero Instant, so we need to use a reference point.
+	static TIME_ANCHOR: LazyLock<(std::time::Instant, SystemTime)> = LazyLock::new(|| {
+		// To deter nerds trying to use timestamp as wall clock time, we subtract a random amount of time from the anchor.
+		// This will make our timestamps appear to be late; just enough to be annoying and obscure our clock drift.
+		// This will also catch bad implementations that assume unrelated broadcasts are synchronized.
+		let jitter = std::time::Duration::from_millis(rand::rng().random_range(0..69_420));
+		(std::time::Instant::now(), SystemTime::now() - jitter)
+	});
+
+	pub(super) fn now() -> Timestamp {
+		let instant: std::time::Instant = web_async::time::Instant::now().into();
+		from_std_instant(instant)
+	}
+
+	fn from_std_instant(instant: std::time::Instant) -> Timestamp {
 		let (anchor_instant, anchor_system) = *TIME_ANCHOR;
 
 		let system = match instant.checked_duration_since(anchor_instant) {
@@ -444,13 +448,51 @@ impl From<std::time::Instant> for Timestamp {
 		// clock on a peer-driven path), since the only requirement is a non-negative start.
 		let duration = system.duration_since(epoch).unwrap_or(std::time::Duration::ZERO);
 
-		Self::from_millis(duration.as_millis() as u64).expect("clock is somehow past the year 2300")
+		Timestamp::from_millis(duration.as_millis() as u64).expect("clock is somehow past the year 2300")
+	}
+
+	impl From<std::time::Instant> for Timestamp {
+		/// Convert an [`std::time::Instant`] into a millisecond-scale timestamp (the default
+		/// timescale), anchored at 2020-01-01 plus a per-process jitter (see `TIME_ANCHOR`).
+		///
+		/// One-way only: there is no inverse, since the anchor is jittered to keep a
+		/// [`Timestamp`] from being read back as a clock.
+		fn from(instant: std::time::Instant) -> Self {
+			from_std_instant(instant)
+		}
+	}
+
+	impl From<tokio::time::Instant> for Timestamp {
+		fn from(instant: tokio::time::Instant) -> Self {
+			from_std_instant(instant.into_std())
+		}
 	}
 }
 
-impl From<tokio::time::Instant> for Timestamp {
-	fn from(instant: tokio::time::Instant) -> Self {
-		instant.into_std().into()
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+mod clock {
+	use std::sync::LazyLock;
+
+	use rand::RngExt;
+
+	use super::Timestamp;
+
+	static TIME_ANCHOR: LazyLock<(web_async::time::Instant, std::time::Duration)> = LazyLock::new(|| {
+		let jitter = std::time::Duration::from_millis(rand::rng().random_range(1..69_420));
+		(web_async::time::Instant::now(), jitter)
+	});
+
+	pub(super) fn now() -> Timestamp {
+		let (anchor_instant, anchor_duration) = *TIME_ANCHOR;
+		let instant = web_async::time::Instant::now();
+		let duration = match instant.checked_duration_since(anchor_instant) {
+			Some(forward) => anchor_duration + forward,
+			None => anchor_duration
+				.checked_sub(anchor_instant.duration_since(instant))
+				.unwrap_or(std::time::Duration::ZERO),
+		};
+
+		Timestamp::from_millis(duration.as_millis() as u64).expect("clock is somehow past the year 2300")
 	}
 }
 

--- a/rs/moq-wasm/README.md
+++ b/rs/moq-wasm/README.md
@@ -13,7 +13,7 @@ Go). Browsers need `wasm-bindgen`, so this is a separate sibling crate. (For
 *React Native* JS, `uniffi-bindgen-react-native` can reuse `moq-ffi` directly;
 that path is unrelated to this crate.)
 
-## Status: compiles and ships a typed JS package; one runtime blocker left
+## Status: compiles and ships a typed JS package
 
 What works today:
 
@@ -54,19 +54,12 @@ What works today:
 
 These touch the wire layer, so the PR should target `dev`.
 
-### Not ported: the wall-clock anchor (and it doesn't need to be)
+### Timestamp fallback
 
-`model/time.rs`'s `TIME_ANCHOR` uses `std::time::Instant::now()` +
-`SystemTime::now()` (both panic on wasm) to map a monotonic instant to a
-jittered wall-clock `Timestamp`. It looks like a wasm hazard, but it's a
-`LazyLock` reached only through `Timestamp::now()` / `From<Instant>`, and
-**nothing in the repo calls those** (frames carry wire timestamps; cache
-eviction uses monotonic `Instant`). So the anchor never initializes and never
-panics on wasm. It's left as an unused public helper.
-
-If a caller ever materializes (e.g. a publish helper that stamps capture time
-locally), porting it would mean a portable `SystemTime` (wasmtimer already has
-`wasmtimer::std::SystemTime`), but that's not needed today.
+`model/time.rs`'s `Timestamp::now()` routes through `web_async::time::Instant`,
+so the receive fallback for protocols that do not carry frame timestamps works
+on wasm too. Native keeps the jittered wall-clock anchor; browser builds use
+`performance.now()` plus a per-process jitter.
 
 ### Out of scope here: moq-mux
 


### PR DESCRIPTION
## Summary

- Route `Timestamp::now()` through `web_async::time::Instant` so browser builds avoid `std::time::Instant::now()` and `SystemTime::now()` on the receive timestamp fallback path.
- Hide the native/browser clock split behind private `clock` modules, keeping `Timestamp::now()` cfg-free.
- Keep the native jittered wall-clock anchor, while using `performance.now()` plus a per-process jitter for wasm.
- Update the `moq-wasm` README now that the timestamp fallback is ported.

## Root Cause

Mandatory receive timestamps made `create_frame_now` run for frames received from pre-lite-05 sessions. That path initialized `TIME_ANCHOR`, which called standard library clocks that panic on `wasm32-unknown-unknown`.

## Validation

- `cargo fmt --check`
- `cargo check -p moq-net`
- `cargo check -p moq-wasm --target wasm32-unknown-unknown`
- `git diff --check`

Note: `--locked` checks currently fail on `dev` before compiling because Cargo wants to refresh unrelated `Cargo.lock` entries. I left the lockfile out of this PR.

(Written by GPT-5)