### PR TITLE
[codex] fix js group cache accounting

### DIFF
--- a/js/net/src/group.test.ts
+++ b/js/net/src/group.test.ts
@@ -35,6 +35,17 @@ test("a group caps its byte size, dropping from the front", () => {
 	expect(frames.length).toBe(MAX_GROUP_CACHE_BYTES / oneMiB);
 });
 
+test("a caught-up reader does not trip the byte cache cap", async () => {
+	const group = new Group(0);
+
+	const oneMiB = 1024 * 1024;
+	const frames = MAX_GROUP_CACHE_BYTES / oneMiB + 8;
+	for (let i = 0; i < frames; i++) {
+		group.writeFrame({ data: new Uint8Array(oneMiB), timestamp: Timestamp.now() });
+		expect((await group.readFrame())?.data.byteLength).toBe(oneMiB);
+	}
+});
+
 test("reading a group whose frames were evicted throws CacheFull", async () => {
 	const group = new Group(0);
 
@@ -77,6 +88,15 @@ test("tryReadFrameSequence reports per-frame sequence numbers", () => {
 	expect(group.tryReadFrameSequence()).toEqual({ sequence: 0, data: new TextEncoder().encode("a") });
 	expect(group.tryReadFrameSequence()).toEqual({ sequence: 1, data: new TextEncoder().encode("b") });
 	expect(group.tryReadFrameSequence()).toBeUndefined();
+});
+
+test("readFrameSequence reports per-frame sequence numbers", async () => {
+	const group = new Group(7);
+	group.writeString("a");
+	group.writeString("b");
+
+	expect(await group.readFrameSequence()).toEqual({ sequence: 0, data: new TextEncoder().encode("a") });
+	expect(await group.readFrameSequence()).toEqual({ sequence: 1, data: new TextEncoder().encode("b") });
 });
 
 test("done distinguishes a finished group from one that is merely empty", () => {

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -109,6 +109,15 @@ export class Group {
 		}
 	}
 
+	#readBufferedFrame(): { sequence: number; frame: Frame } | undefined {
+		const frames = this.state.frames.peek();
+		const frame = frames.shift();
+		if (!frame) return undefined;
+
+		this.#cacheBytes -= frame.data.byteLength;
+		return { sequence: this.state.total.peek() - frames.length - 1, frame };
+	}
+
 	/**
 	 * Create an independent copy that receives every frame written to this group.
 	 *
@@ -175,10 +184,9 @@ export class Group {
 	 * lives only in the blocking {@link readFrame}/{@link readFrameSequence} paths.
 	 */
 	tryReadFrameSequence(): { sequence: number; data: Uint8Array } | undefined {
-		const frames = this.state.frames.peek();
-		const frame = frames.shift();
-		if (frame === undefined) return undefined;
-		return { sequence: this.state.total.peek() - frames.length - 1, data: frame.data };
+		const read = this.#readBufferedFrame();
+		if (!read) return undefined;
+		return { sequence: read.sequence, data: read.frame.data };
 	}
 
 	/**
@@ -205,9 +213,8 @@ export class Group {
 		for (;;) {
 			if (this.state.offset > 0) throw new CacheFull();
 
-			const frames = this.state.frames.peek();
-			const frame = frames.shift();
-			if (frame) return frame;
+			const read = this.#readBufferedFrame();
+			if (read) return read.frame;
 
 			const closed = this.state.closed.peek();
 			if (closed instanceof Error) throw closed;
@@ -222,9 +229,8 @@ export class Group {
 		for (;;) {
 			if (this.state.offset > 0) throw new CacheFull();
 
-			const frames = this.state.frames.peek();
-			const frame = frames.shift();
-			if (frame) return { sequence: this.state.total.peek() - frames.length - 1, data: frame.data };
+			const read = this.#readBufferedFrame();
+			if (read) return { sequence: read.sequence, data: read.frame.data };
 
 			const closed = this.state.closed.peek();
 			if (closed instanceof Error) throw closed;


### PR DESCRIPTION
## Summary

- Decrement the JS group cache byte counter whenever a buffered frame is read.
- Share buffered-frame draining between `tryReadFrame`, `readFrame`, and `readFrameSequence` so all read paths keep byte accounting consistent.
- Add regression coverage for a caught-up reader writing and immediately reading past the 32 MiB group cache cap.

## Root Cause

`Group.writeFrame` incremented `#cacheBytes` for every frame, but reads removed frames from `state.frames` without decrementing the byte counter. After 32 MiB of cumulative writes, the group thought it was permanently over the byte cap and evicted newly written frames even when no frames were buffered.

## Public API Changes

None.

## Validation

- `bun test js/net/src/group.test.ts`
- `bun run --filter='@moq/net' check`
- `bun biome check js/net/src/group.ts js/net/src/group.test.ts`
- `bun test js/net/src`

(Written by GPT-5)
