### PR TITLE
[codex] fix IETF object property KVP encoding

### DIFF
--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -1,10 +1,11 @@
 import { expect, test } from "bun:test";
 import * as Path from "../path.ts";
 import { Reader, Writer } from "../stream.ts";
+import { Timescale, Timestamp } from "../time.ts";
 import * as Varint from "../varint.ts";
 import * as GoAway from "./goaway.ts";
 import * as Namespace from "./namespace.ts";
-import { Group } from "./object.ts";
+import { Frame, Group, type GroupFlags } from "./object.ts";
 import { SetupOptions } from "./parameters.ts";
 import { Publish, PublishDone } from "./publish.ts";
 import * as Announce from "./publish_namespace.ts";
@@ -59,6 +60,15 @@ async function decodeVersioned<T>(
 ): Promise<T> {
 	const reader = new Reader(undefined, bytes, version);
 	return await decoder(reader, version);
+}
+
+async function encodeFrameVersioned(frame: Frame, flags: GroupFlags, version: IetfVersion): Promise<Uint8Array> {
+	const { stream, written } = createTestWritableStream();
+	const writer = new Writer(stream, version);
+	await frame.encode(writer, flags, version);
+	writer.close();
+	await writer.closed;
+	return concatChunks(written);
 }
 
 // Subscribe tests (v14)
@@ -1114,4 +1124,58 @@ test("Group: draft-18 sets FIRST_OBJECT bit, draft-17 does not", async () => {
 	const v17 = await encodeVersioned(makeGroup(), Version.DRAFT_17);
 	expect(Array.from(v18)).not.toEqual(Array.from(v17));
 	await expect(decodeVersioned(v18, Group.decode, Version.DRAFT_17)).rejects.toThrow(/Unsupported group type/);
+});
+
+test("Frame object time: draft-15 uses absolute property types", async () => {
+	const flags: GroupFlags = {
+		hasExtensions: true,
+		hasSubgroup: false,
+		hasSubgroupObject: false,
+		hasEnd: true,
+		hasPriority: true,
+	};
+	const timestamp = new Timestamp(96_000, Timescale.MILLI);
+	const frame = new Frame({ payload: new Uint8Array([0xaa]), timestamp });
+	const encoded = await encodeFrameVersioned(frame, flags, Version.DRAFT_15);
+
+	const reader = new Reader(undefined, encoded, Version.DRAFT_15);
+	expect(await reader.u53()).toBe(0);
+	const extensions = await reader.read(await reader.u53());
+	const props = new Reader(undefined, extensions, Version.DRAFT_15);
+	expect(await props.u62()).toBe(0x06n);
+	expect(await props.u62()).toBe(96_000n);
+	expect(await props.u62()).toBe(0x08n);
+	expect(await props.u62()).toBe(1_000n);
+	expect(await props.done()).toBe(true);
+
+	const decoded = await Frame.decode(new Reader(undefined, encoded, Version.DRAFT_15), flags, Version.DRAFT_15);
+	expect(decoded.timestamp?.value).toBe(96_000);
+	expect(decoded.timestamp?.scale).toBe(Timescale.MILLI);
+});
+
+test("Frame object time: draft-16 starts delta property types", async () => {
+	const flags: GroupFlags = {
+		hasExtensions: true,
+		hasSubgroup: false,
+		hasSubgroupObject: false,
+		hasEnd: true,
+		hasPriority: true,
+	};
+	const timestamp = new Timestamp(96_000, Timescale.MILLI);
+	const frame = new Frame({ payload: new Uint8Array([0xaa]), timestamp });
+	const encoded = await encodeFrameVersioned(frame, flags, Version.DRAFT_16);
+
+	const reader = new Reader(undefined, encoded, Version.DRAFT_16);
+	expect(await reader.u53()).toBe(0);
+	const extensions = await reader.read(await reader.u53());
+	const props = new Reader(undefined, extensions, Version.DRAFT_16);
+	expect(await props.u62()).toBe(0x06n);
+	expect(await props.u62()).toBe(96_000n);
+	expect(await props.u62()).toBe(0x02n);
+	expect(await props.u62()).toBe(1_000n);
+	expect(await props.done()).toBe(true);
+
+	const decoded = await Frame.decode(new Reader(undefined, encoded, Version.DRAFT_16), flags, Version.DRAFT_16);
+	expect(decoded.timestamp?.value).toBe(96_000);
+	expect(decoded.timestamp?.scale).toBe(Timescale.MILLI);
 });

--- a/js/net/src/ietf/object.ts
+++ b/js/net/src/ietf/object.ts
@@ -1,7 +1,10 @@
-import type { Reader, Writer } from "../stream.ts";
+import { Reader, Writer } from "../stream.ts";
+import { Timescale, Timestamp } from "../time.ts";
 import { type IetfVersion, Version } from "./version.ts";
 
 const GROUP_END = 0x03;
+const PROP_TIMESTAMP = 0x06n;
+const PROP_TIMESCALE = 0x08n;
 
 // draft-18 adds bit 0x40 (FIRST_OBJECT) to the subgroup header type per spec
 // 11.4.2. moq-lite always starts subgroups at object 0, so the bit carries no
@@ -18,6 +21,96 @@ function hasFirstObjectBit(version: IetfVersion): boolean {
 		default:
 			return true;
 	}
+}
+
+function hasDeltaObjectPropertyTypes(version: IetfVersion | undefined): boolean {
+	switch (version) {
+		case Version.DRAFT_14:
+		case Version.DRAFT_15:
+			return false;
+		default:
+			return true;
+	}
+}
+
+async function encodeObjectPropertyType(
+	w: Writer,
+	id: bigint,
+	prev: bigint,
+	version: IetfVersion | undefined,
+): Promise<void> {
+	const encoded = hasDeltaObjectPropertyTypes(version) ? id - prev : id;
+	await w.u62(encoded);
+}
+
+async function encodeObjectTime(w: Writer, timestamp: Timestamp, version: IetfVersion | undefined): Promise<void> {
+	await encodeObjectPropertyType(w, PROP_TIMESTAMP, 0n, version);
+	await w.u62(BigInt(Math.round(timestamp.value)));
+	await encodeObjectPropertyType(w, PROP_TIMESCALE, PROP_TIMESTAMP, version);
+	await w.u62(BigInt(timestamp.scale));
+}
+
+async function encodeObjectExtensions(
+	timestamp: Timestamp | undefined,
+	version: IetfVersion | undefined,
+): Promise<Uint8Array> {
+	if (timestamp === undefined) {
+		return new Uint8Array();
+	}
+
+	const chunks: Uint8Array[] = [];
+	const writer = new Writer(
+		new WritableStream<Uint8Array>({
+			write(chunk) {
+				chunks.push(new Uint8Array(chunk));
+			},
+		}),
+		version,
+	);
+	await encodeObjectTime(writer, timestamp, version);
+	writer.close();
+	await writer.closed;
+
+	const size = chunks.reduce((total, chunk) => total + chunk.byteLength, 0);
+	const result = new Uint8Array(size);
+	let offset = 0;
+	for (const chunk of chunks) {
+		result.set(chunk, offset);
+		offset += chunk.byteLength;
+	}
+	return result;
+}
+
+async function decodeObjectTime(r: Reader, version: IetfVersion | undefined): Promise<Timestamp | undefined> {
+	let timestamp: bigint | undefined;
+	let timescale: bigint | undefined;
+	let prevType = 0n;
+	let first = true;
+
+	while (!(await r.done())) {
+		const step = await r.u62();
+		const id = !hasDeltaObjectPropertyTypes(version) || first ? step : prevType + step;
+		first = false;
+		prevType = id;
+
+		if (id % 2n === 0n) {
+			const value = await r.u62();
+			if (id === PROP_TIMESTAMP) {
+				timestamp = value;
+			} else if (id === PROP_TIMESCALE) {
+				timescale = value;
+			}
+		} else {
+			const size = await r.u53();
+			await r.read(size);
+		}
+	}
+
+	if (timestamp === undefined) {
+		return undefined;
+	}
+
+	return new Timestamp(Number(timestamp), Timescale(Number(timescale ?? BigInt(Timescale.MICRO))));
 }
 
 export interface GroupFlags {
@@ -128,19 +221,26 @@ export class Group {
 	}
 }
 
+/** A moq-transport object inside a group stream. */
 export class Frame {
-	// undefined means end of group
+	/** The object payload, or `undefined` for the end of group marker. */
 	payload?: Uint8Array;
+	/** The presentation timestamp carried in object properties, when present. */
+	timestamp?: Timestamp;
 
-	constructor({ payload }: { payload?: Uint8Array } = {}) {
+	constructor({ payload, timestamp }: { payload?: Uint8Array; timestamp?: Timestamp } = {}) {
 		this.payload = payload;
+		this.timestamp = timestamp;
 	}
 
-	async encode(w: Writer, flags: GroupFlags): Promise<void> {
+	/** Encode this frame using the group flags and negotiated IETF version. */
+	async encode(w: Writer, flags: GroupFlags, version = w.version): Promise<void> {
 		await w.u53(0); // id_delta = 0
 
 		if (flags.hasExtensions) {
-			await w.u53(0); // extensions length = 0
+			const extensions = await encodeObjectExtensions(this.timestamp, version);
+			await w.u53(extensions.byteLength);
+			await w.write(extensions);
 		}
 
 		if (this.payload !== undefined) {
@@ -157,30 +257,32 @@ export class Frame {
 		}
 	}
 
-	static async decode(r: Reader, flags: GroupFlags): Promise<Frame> {
+	/** Decode a frame using the group flags and negotiated IETF version. */
+	static async decode(r: Reader, flags: GroupFlags, version = r.version): Promise<Frame> {
 		const delta = await r.u53();
 		if (delta !== 0) {
 			throw new Error(`object ID delta is not supported: ${delta}`);
 		}
 
+		let timestamp: Timestamp | undefined;
 		if (flags.hasExtensions) {
 			const extensionsLength = await r.u53();
-			// We don't care about extensions
-			await r.read(extensionsLength);
+			const extensions = await r.read(extensionsLength);
+			timestamp = await decodeObjectTime(new Reader(undefined, extensions, version), version);
 		}
 
 		const payloadLength = await r.u53();
 
 		if (payloadLength > 0) {
 			const payload = await r.read(payloadLength);
-			return new Frame({ payload });
+			return new Frame({ payload, timestamp });
 		}
 
 		const status = await r.u53();
 
 		if (flags.hasEnd) {
 			// Empty frame
-			if (status === 0) return new Frame({ payload: new Uint8Array(0) });
+			if (status === 0) return new Frame({ payload: new Uint8Array(0), timestamp });
 		} else if (status === 0 || status === GROUP_END) {
 			// TODO status === 0 should be an empty frame, but moq-rs seems to be sending it incorrectly on group end.
 			return new Frame();

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -216,7 +216,7 @@ export class Publisher {
 				subGroupId: 0,
 				publisherPriority: 0,
 				flags: {
-					hasExtensions: false,
+					hasExtensions: true,
 					hasSubgroup: false,
 					hasSubgroupObject: false,
 					hasEnd: true,
@@ -231,8 +231,8 @@ export class Publisher {
 					const frame = await Promise.race([group.readFrame(), stream.closed]);
 					if (!frame) break;
 
-					const obj = new Frame({ payload: frame.data });
-					await obj.encode(stream, header.flags);
+					const obj = new Frame({ payload: frame.data, timestamp: frame.timestamp });
+					await obj.encode(stream, header.flags, this.#session.version);
 				}
 
 				stream.close();

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -485,10 +485,10 @@ export class Subscriber {
 				const done = await Promise.race([stream.done(), producer.closed, track.closed]);
 				if (done !== false) break;
 
-				const frame = await Frame.decode(stream, group.flags);
+				const frame = await Frame.decode(stream, group.flags, this.#session.version);
 				if (frame.payload === undefined) break;
 
-				producer.writeFrame({ data: frame.payload, timestamp: Timestamp.now() });
+				producer.writeFrame({ data: frame.payload, timestamp: frame.timestamp ?? Timestamp.now() });
 			}
 
 			producer.close();

--- a/rs/moq-net/src/ietf/group.rs
+++ b/rs/moq-net/src/ietf/group.rs
@@ -11,24 +11,35 @@ use crate::ietf::Param;
 const PROP_TIMESTAMP: u64 = 0x06;
 const PROP_TIMESCALE: u64 = 0x08;
 
-/// Encode a frame's presentation timestamp as moq-transport Object Properties:
-/// Timestamp (0x06) in Timescale (0x08) units, both absolute varints.
+/// Encode a frame's presentation timestamp as moq-transport Object Properties.
 ///
 /// Matches the LOC encoding of the same registry ids so a relay or LOC-aware peer
-/// reads the same bytes. (moq-lite delta-compresses its per-frame timestamps; the
-/// moq-transport object property is the absolute value.) Writes the raw KVP bytes
+/// reads the same bytes on drafts that delta-encode KVP type ids. The Timestamp
+/// value is always absolute. Writes the raw KVP bytes
 /// (no outer length prefix); the caller frames the block with its byte length.
 pub fn encode_object_time<W: bytes::BufMut>(
 	w: &mut W,
 	timestamp: Timestamp,
 	version: Version,
 ) -> Result<(), EncodeError> {
-	// KVP type ids are delta-encoded ascending: 0x06 then 0x08 (delta 0x02).
-	PROP_TIMESTAMP.encode(w, version)?;
+	encode_object_property_type(w, PROP_TIMESTAMP, 0, version)?;
 	timestamp.value().encode(w, version)?;
-	(PROP_TIMESCALE - PROP_TIMESTAMP).encode(w, version)?;
+	encode_object_property_type(w, PROP_TIMESCALE, PROP_TIMESTAMP, version)?;
 	u64::from(timestamp.scale()).encode(w, version)?;
 	Ok(())
+}
+
+fn encode_object_property_type<W: bytes::BufMut>(
+	w: &mut W,
+	kind: u64,
+	prev: u64,
+	version: Version,
+) -> Result<(), EncodeError> {
+	let encoded = match version {
+		Version::Draft14 | Version::Draft15 => kind,
+		_ => kind.checked_sub(prev).ok_or(EncodeError::BoundsExceeded)?,
+	};
+	encoded.encode(w, version)
 }
 
 /// Decode the Timestamp (0x06) + Timescale (0x08) Object Properties from an object's
@@ -42,10 +53,10 @@ pub fn decode_object_time<R: bytes::Buf>(r: &mut R, version: Version) -> Result<
 
 	while r.has_remaining() {
 		let step = u64::decode(r, version)?;
-		let abs = if first {
-			step
-		} else {
-			prev_type.checked_add(step).ok_or(DecodeError::BoundsExceeded)?
+		let abs = match version {
+			Version::Draft14 | Version::Draft15 => step,
+			_ if first => step,
+			_ => prev_type.checked_add(step).ok_or(DecodeError::BoundsExceeded)?,
 		};
 		first = false;
 		prev_type = abs;
@@ -324,6 +335,62 @@ mod tests {
 		assert_eq!(decoded.value(), 96_000);
 		assert_eq!(decoded.scale(), Timescale::MICRO);
 		assert!(!bytes.has_remaining());
+	}
+
+	#[test]
+	fn test_object_time_legacy_uses_absolute_types() {
+		let ts = Timestamp::new(96_000, Timescale::MILLI).unwrap();
+		let mut buf = bytes::BytesMut::new();
+		encode_object_time(&mut buf, ts, Version::Draft15).unwrap();
+
+		let mut bytes = buf.clone().freeze();
+		assert_eq!(u64::decode(&mut bytes, Version::Draft15).unwrap(), PROP_TIMESTAMP);
+		assert_eq!(u64::decode(&mut bytes, Version::Draft15).unwrap(), ts.value());
+		assert_eq!(u64::decode(&mut bytes, Version::Draft15).unwrap(), PROP_TIMESCALE);
+		assert_eq!(
+			u64::decode(&mut bytes, Version::Draft15).unwrap(),
+			u64::from(ts.scale())
+		);
+		assert!(!bytes.has_remaining());
+
+		let mut bytes = buf.freeze();
+		let decoded = decode_object_time(&mut bytes, Version::Draft15).unwrap().unwrap();
+		assert_eq!(decoded.value(), ts.value());
+		assert_eq!(decoded.scale(), Timescale::MILLI);
+	}
+
+	#[test]
+	fn test_object_time_delta_types_start_at_draft16() {
+		let ts = Timestamp::new(96_000, Timescale::MILLI).unwrap();
+		let mut buf = bytes::BytesMut::new();
+		encode_object_time(&mut buf, ts, Version::Draft16).unwrap();
+
+		let mut bytes = buf.freeze();
+		assert_eq!(u64::decode(&mut bytes, Version::Draft16).unwrap(), PROP_TIMESTAMP);
+		assert_eq!(u64::decode(&mut bytes, Version::Draft16).unwrap(), ts.value());
+		assert_eq!(
+			u64::decode(&mut bytes, Version::Draft16).unwrap(),
+			PROP_TIMESCALE - PROP_TIMESTAMP
+		);
+		assert_eq!(
+			u64::decode(&mut bytes, Version::Draft16).unwrap(),
+			u64::from(ts.scale())
+		);
+		assert!(!bytes.has_remaining());
+	}
+
+	#[test]
+	fn test_object_time_decodes_draft14_absolute_timescale() {
+		let mut buf = bytes::BytesMut::new();
+		PROP_TIMESTAMP.encode(&mut buf, Version::Draft14).unwrap();
+		42u64.encode(&mut buf, Version::Draft14).unwrap();
+		PROP_TIMESCALE.encode(&mut buf, Version::Draft14).unwrap();
+		u64::from(Timescale::MILLI).encode(&mut buf, Version::Draft14).unwrap();
+
+		let mut bytes = buf.freeze();
+		let decoded = decode_object_time(&mut bytes, Version::Draft14).unwrap().unwrap();
+		assert_eq!(decoded.value(), 42);
+		assert_eq!(decoded.scale(), Timescale::MILLI);
 	}
 
 	/// A timescale-less extension block falls back to microseconds (registry default).


### PR DESCRIPTION
## Summary
- Fix Rust IETF object-property KVP type encoding so draft-14/15 use absolute property IDs and draft-16+ keeps delta IDs.
- Mirror Timestamp/Timescale object-property behavior in JS IETF publish and subscribe paths.
- Add Rust and JS regression coverage for the draft-14/15 versus draft-16 cutoff.

## Root Cause
The group object-property helpers encoded draft-14/15 property type IDs as deltas, while those drafts define absolute type IDs. Self-interop hid the issue, but compliant peers skipped Timescale and interpreted timestamps at the wrong scale. The JS path also failed to preserve object timestamps through IETF publish/subscribe.

## CI
- Rebased onto current dev, which already includes the cargo-deny ignores for quick-xml RUSTSEC-2026-0194/0195.
- cargo-deny now passes locally.

## Public API Changes
None. Internal wire encoding/decoding behavior only.

## Cross-Package Sync
Updated both rs/moq-net and js/net. No docs changes because this fixes protocol interop without changing public APIs or documented examples.

## Tests
- cargo test -p moq-net ietf::group::tests::test_object_time
- bun test js/net/src/ietf/ietf.test.ts
- just js check
- cargo deny check --show-stats

(Written by GPT-5)