### PR TITLE
[codex] implement JS lite FETCH

### DIFF
--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -88,13 +88,20 @@ async function fetchGroup(
 		for (;;) {
 			const group = await subscriber.recvGroup();
 			if (!group) throw new Error(`group not found: ${sequence}`);
-			if (group.sequence === sequence) return group;
+			if (group.sequence === sequence) {
+				// Close the subscription when the returned group finishes, not now: an
+				// in-progress group must keep receiving frames for its lifetime (mirrors
+				// Rust poll_fetch). Also fires if the caller closes the group early.
+				void group.closed.then(() => subscriber.close());
+				return group;
+			}
 
 			group.close();
 			if (group.sequence > sequence) throw new Error(`group not found: ${sequence}`);
 		}
-	} finally {
+	} catch (err) {
 		subscriber.close();
+		throw err;
 	}
 }
 

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -1,4 +1,5 @@
 import { Signal } from "@moq/signals";
+import type { Consumer as GroupConsumer } from "./group.ts";
 import * as track from "./track.ts";
 
 /** Reactive backing state shared by broadcast producers and consumers. */
@@ -6,7 +7,6 @@ class BroadcastState {
 	requested = new Signal<track.Request[]>([]);
 	closed = new Signal<boolean | Error>(false);
 	tracks = new Map<string, track.Producer>();
-	infoResolver?: (name: string) => Promise<track.Info>;
 }
 
 function closedPromise(state: BroadcastState): Promise<Error | undefined> {
@@ -52,10 +52,6 @@ function subscribe(state: BroadcastState, name: string, priority: number): track
 }
 
 async function resolveTrackInfo(state: BroadcastState, name: string): Promise<track.Info> {
-	if (state.infoResolver) {
-		return state.infoResolver(name);
-	}
-
 	const existing = state.tracks.get(name);
 	if (existing && !existing.closedSignal.peek()) {
 		return existing.info();
@@ -78,12 +74,36 @@ async function resolveTrackInfo(state: BroadcastState, name: string): Promise<tr
 	}
 }
 
+// Serve a group from the local retained window by subscribing and scanning to the
+// requested sequence. The default for a produced broadcast; the consuming wire layer
+// overrides it to fetch over the network (or to reject when the transport has no FETCH).
+async function fetchGroup(
+	state: BroadcastState,
+	name: string,
+	sequence: number,
+	options: track.FetchGroupOptions = {},
+): Promise<GroupConsumer> {
+	const subscriber = subscribe(state, name, options.priority ?? 0);
+	try {
+		for (;;) {
+			const group = await subscriber.recvGroup();
+			if (!group) throw new Error(`group not found: ${sequence}`);
+			if (group.sequence === sequence) return group;
+
+			group.close();
+			if (group.sequence > sequence) throw new Error(`group not found: ${sequence}`);
+		}
+	} finally {
+		subscriber.close();
+	}
+}
+
 /**
  * The write side of a broadcast.
  *
  * @public
  */
-export class Producer {
+export class Producer implements track.Broadcast {
 	#state = new BroadcastState();
 
 	/** Resolves with the abort error (or undefined) once closed. */
@@ -154,13 +174,14 @@ export class Producer {
 		return resolveTrackInfo(this.#state, name);
 	}
 
+	/** Fetch a single group from the local retained window. Used by track handles. */
+	fetchGroup(name: string, sequence: number, options?: track.FetchGroupOptions): Promise<GroupConsumer> {
+		return fetchGroup(this.#state, name, sequence, options);
+	}
+
 	/** A lazy read handle for a track on this broadcast. */
 	track(name: string): track.Consumer {
-		return new track.Consumer(
-			name,
-			(priority) => subscribe(this.#state, name, priority),
-			() => resolveTrackInfo(this.#state, name),
-		);
+		return new track.Consumer(name, this);
 	}
 
 	/** Close the broadcast, optionally with an error to abort waiters. */
@@ -174,7 +195,7 @@ export class Producer {
  *
  * @public
  */
-export class Consumer {
+export class Consumer implements track.Broadcast {
 	#state: BroadcastState;
 
 	/** Resolves with the abort error (or undefined) once closed. */
@@ -188,11 +209,7 @@ export class Consumer {
 
 	/** Get a lazy handle for a track on this broadcast. */
 	track(name: string): track.Consumer {
-		return new track.Consumer(
-			name,
-			(priority) => subscribe(this.#state, name, priority),
-			() => resolveTrackInfo(this.#state, name),
-		);
+		return new track.Consumer(name, this);
 	}
 
 	/** Open a live subscription to a track. Used by the subscribing wire layer. */
@@ -214,14 +231,21 @@ export class Consumer {
 		}
 	}
 
-	/** Install the read-side TRACK_INFO resolver. Used by the wire layer. */
-	onTrackInfo(resolver: (name: string) => Promise<track.Info>): void {
-		this.#state.infoResolver = resolver;
-	}
-
-	/** Resolve a track's immutable info. Used by track handles. */
+	/**
+	 * Resolve a track's immutable info. Used by track handles. This base resolves it from
+	 * the local producers; the consuming wire layer overrides it to fetch over the wire.
+	 */
 	resolveTrackInfo(name: string): Promise<track.Info> {
 		return resolveTrackInfo(this.#state, name);
+	}
+
+	/**
+	 * Fetch a single group by sequence. Used by track handles. This base serves from the
+	 * local retained window; the consuming wire layer overrides it to fetch over the wire
+	 * (or to reject when the transport has no FETCH).
+	 */
+	fetchGroup(name: string, sequence: number, options?: track.FetchGroupOptions): Promise<GroupConsumer> {
+		return fetchGroup(this.#state, name, sequence, options);
 	}
 
 	/** Close the broadcast, optionally with an error to abort waiters. */

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -200,7 +200,9 @@ export class Subscriber {
 	 * Consumes a broadcast from the connection.
 	 */
 	consume(path: Path.Valid): broadcast.Consumer {
-		const consumer = new broadcast.Consumer();
+		// moq-transport has no one-shot group fetch; ConsumeBroadcast rejects it. Track info
+		// is resolved by the subscribe path (the inherited resolveTrackInfo).
+		const consumer = new ConsumeBroadcast();
 
 		void (async () => {
 			for (;;) {
@@ -500,5 +502,16 @@ export class Subscriber {
 			producer.close(e);
 			stream.stop(e);
 		}
+	}
+}
+
+/**
+ * A broadcast consumed from a moq-transport session. Track info is resolved by the
+ * subscribe path (the inherited `resolveTrackInfo`), but the protocol has no one-shot
+ * group fetch, so `track.Consumer.fetchGroup()` is rejected.
+ */
+class ConsumeBroadcast extends broadcast.Consumer {
+	override fetchGroup(): Promise<netGroup.Consumer> {
+		return Promise.reject(new Error("fetch group is not supported for moq-transport"));
 	}
 }

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -177,6 +177,59 @@ test("integration: lite draft-05 datagrams not sent on a non-datagram transport"
 	server.close();
 });
 
+test("integration: lite draft-05 fetches a cached group", async () => {
+	const enc = new TextEncoder();
+	const dec = new TextDecoder();
+	const pair = createMockTransportPair(Lite.ALPN_05);
+
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	const broadcast = new BroadcastProducer();
+	const producer = broadcast.createTrack("video");
+	server.publish(Path.from("test"), broadcast);
+
+	const group0 = producer.appendGroup();
+	group0.writeFrame({ data: enc.encode("alpha"), timestamp: Timestamp.fromMillis(10) });
+	group0.writeFrame({ data: enc.encode("beta"), timestamp: Timestamp.fromMillis(15) });
+	group0.close();
+
+	const group1 = producer.appendGroup();
+	group1.writeFrame({ data: enc.encode("newer"), timestamp: Timestamp.fromMillis(20) });
+	group1.close();
+
+	// Fetch group 0 without holding a live subscription; the timestamps round-trip.
+	const remote = client.consume(Path.from("test"));
+	const fetched = await remote.track("video").fetchGroup(0);
+
+	const first = await fetched.readFrame();
+	expect(dec.decode(first?.data)).toBe("alpha");
+	expect(first?.timestamp.asMillis()).toBe(10);
+
+	const second = await fetched.readFrame();
+	expect(dec.decode(second?.data)).toBe("beta");
+	expect(second?.timestamp.asMillis()).toBe(15);
+
+	expect(await fetched.readFrame()).toBeUndefined();
+
+	broadcast.close();
+	remote.close();
+	client.close();
+	server.close();
+});
+
+test("integration: ietf fetch group is unsupported", async () => {
+	const pair = createMockTransportPair(Ietf.ALPN.DRAFT_18);
+
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	const remote = client.consume(Path.from("test"));
+	await expect(remote.track("video").fetchGroup(0)).rejects.toThrow("fetch group is not supported for moq-transport");
+
+	remote.close();
+	client.close();
+	server.close();
+});
+
 test("integration: ietf draft-14", async () => {
 	await runPublishSubscribeFlow("", Ietf.Version.DRAFT_14);
 });

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -217,6 +217,42 @@ test("integration: lite draft-05 fetches a cached group", async () => {
 	server.close();
 });
 
+test("integration: lite draft-05 fetches an in-progress group", async () => {
+	const enc = new TextEncoder();
+	const dec = new TextDecoder();
+	const pair = createMockTransportPair(Lite.ALPN_05);
+
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	const broadcast = new BroadcastProducer();
+	const producer = broadcast.createTrack("video");
+	server.publish(Path.from("test"), broadcast);
+
+	// Open the group and write one frame, but leave it open (in-progress).
+	const group0 = producer.appendGroup();
+	group0.writeFrame({ data: enc.encode("alpha"), timestamp: Timestamp.fromMillis(10) });
+
+	const remote = client.consume(Path.from("test"));
+	const fetched = await remote.track("video").fetchGroup(0);
+
+	const first = await fetched.readFrame();
+	expect(dec.decode(first?.data)).toBe("alpha");
+
+	// Frames appended after the fetch started must still stream through, not be truncated.
+	group0.writeFrame({ data: enc.encode("beta"), timestamp: Timestamp.fromMillis(15) });
+	const second = await fetched.readFrame();
+	expect(dec.decode(second?.data)).toBe("beta");
+	expect(second?.timestamp.asMillis()).toBe(15);
+
+	group0.close();
+	expect(await fetched.readFrame()).toBeUndefined();
+
+	broadcast.close();
+	remote.close();
+	client.close();
+	server.close();
+});
+
 test("integration: ietf fetch group is unsupported", async () => {
 	const pair = createMockTransportPair(Ietf.ALPN.DRAFT_18);
 

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -7,6 +7,7 @@ import * as Path from "../path.ts";
 import { type Reader, Readers, Stream, Writer } from "../stream.ts";
 import type * as Time from "../time.ts";
 import { AnnounceRequest } from "./announce.ts";
+import { Fetch } from "./fetch.ts";
 import { Goaway } from "./goaway.ts";
 import { Group } from "./group.ts";
 import { type Origin, randomOrigin } from "./origin.ts";
@@ -224,6 +225,9 @@ export class Connection implements Established {
 		} else if (typ === StreamId.Subscribe) {
 			const msg = await Subscribe.decode(stream.reader, this.#version);
 			await this.#publisher.runSubscribe(msg, stream);
+		} else if (typ === StreamId.Fetch) {
+			const msg = await Fetch.decode(stream.reader, this.#version);
+			await this.#publisher.runFetch(msg, stream);
 		} else if (typ === StreamId.Track) {
 			const msg = await TrackMessage.decode(stream.reader, this.#version);
 			await this.#publisher.runTrackInfo(msg, stream);

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -8,6 +8,7 @@ import type * as track from "../track.ts";
 import { error } from "../util/error.ts";
 import { AnnounceBroadcast, AnnounceInit, AnnounceOk, type AnnounceRequest } from "./announce.ts";
 import { Datagram as DatagramMessage } from "./datagram.ts";
+import type { Fetch } from "./fetch.ts";
 import { Group as GroupMessage } from "./group.ts";
 import type { Origin } from "./origin.ts";
 import { Probe } from "./probe.ts";
@@ -296,6 +297,43 @@ export class Publisher {
 	}
 
 	/**
+	 * Handles a FETCH stream by serving one group as bare frame records (lite-05+).
+	 *
+	 * @internal
+	 */
+	async runFetch(msg: Fetch, stream: Stream) {
+		if (!supportsTrackStream(this.version)) {
+			stream.writer.reset(new Error("fetch requires moq-lite-05 or newer"));
+			return;
+		}
+
+		const broadcast = this.#broadcasts.peek()?.get(msg.broadcast);
+		if (!broadcast) {
+			console.debug(`fetch unknown: broadcast=${msg.broadcast}`);
+			stream.writer.reset(new Error("not found"));
+			return;
+		}
+
+		let group: group.Consumer | undefined;
+		try {
+			// The timescale is immutable, so serve exactly what TRACK_INFO advertised.
+			const info = await this.#resolveTrackInfo(msg.broadcast, msg.track);
+			group = await broadcast.track(msg.track).fetchGroup(msg.group, { priority: msg.priority });
+			await this.#runFetchGroup(group, stream.writer, Timescale(info.timescale));
+			console.debug(`fetch done: broadcast=${msg.broadcast} track=${msg.track} group=${msg.group}`);
+			stream.close();
+			group.close();
+		} catch (err: unknown) {
+			const e = error(err);
+			console.warn(
+				`fetch error: broadcast=${msg.broadcast} track=${msg.track} group=${msg.group} error=${e.message}`,
+			);
+			group?.close(e);
+			stream.abort(e);
+		}
+	}
+
+	/**
 	 * Runs a track and sends its data to the stream.
 	 * @param sub - The subscription ID
 	 * @param broadcast - The broadcast name
@@ -435,6 +473,23 @@ export class Publisher {
 	 *
 	 * @internal
 	 */
+	// Serialize a fetched group's frames onto the FETCH stream as bare records: each a
+	// zigzag-delta timestamp (at the track's advertised timescale) followed by size + bytes.
+	async #runFetchGroup(group: group.Consumer, stream: Writer, timescale: Timescale) {
+		let prevTs = 0n;
+		for (;;) {
+			const frame = await Promise.race([group.readFrame(), stream.closed]);
+			if (!frame) break;
+
+			const ts = BigInt(Math.round(frame.timestamp.as(timescale)));
+			await stream.u62(zigzag(ts - prevTs));
+			prevTs = ts;
+
+			await stream.u53(frame.data.byteLength);
+			await stream.write(frame.data);
+		}
+	}
+
 	async #runGroup(sub: bigint, group: group.Consumer, timescale: Timescale) {
 		const msg = new GroupMessage(sub, group.sequence);
 		try {

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -11,6 +11,7 @@ import { error } from "../util/error.ts";
 import { withTimeout } from "../util/timeout.ts";
 import { AnnounceBroadcast, AnnounceInit, AnnounceOk, AnnounceRequest } from "./announce.ts";
 import { Datagram as DatagramMessage } from "./datagram.ts";
+import { Fetch as FetchMessage } from "./fetch.ts";
 import type { Group as GroupMessage } from "./group.ts";
 import type { Origin } from "./origin.ts";
 import { Probe } from "./probe.ts";
@@ -218,24 +219,10 @@ export class Subscriber {
 	 * @returns A Broadcast instance
 	 */
 	consume(path: Path.Valid): broadcast.Consumer {
-		const consumer = new broadcast.Consumer();
-
-		// Resolve TrackConsumer.info() via a TRACK stream (lite-05+). On older drafts
-		// there's no TRACK stream, so info() rejects rather than fabricating defaults.
-		consumer.onTrackInfo(async (name) => {
-			if (!supportsTrackStream(this.version)) {
-				throw new Error("track info requires moq-lite-05 or newer");
-			}
-			const info = await this.#trackInfo(path, name);
-			return {
-				timescale: Time.Timescale(info.timescale),
-				// Publisher Max Latency rides on the wire, so the local retention window
-				// matches what the upstream advertises (relays re-serve with the same bound).
-				cache: info.cache,
-				priority: info.priority,
-				ordered: info.ordered,
-			};
-		});
+		// A consumed broadcast resolves info() and fetchGroup() over the wire by reaching
+		// back into this Subscriber (see ConsumeBroadcast below), rather than the wire
+		// installing callbacks on the broadcast.
+		const consumer = new ConsumeBroadcast(this, path);
 
 		void (async () => {
 			for (;;) {
@@ -344,14 +331,7 @@ export class Subscriber {
 		if (supportsTrackStream(this.version)) {
 			// Fetch the immutable properties once via the TRACK stream.
 			const info = await this.#trackInfo(msg.broadcast, msg.track);
-			producer = request.accept({
-				timescale: Time.Timescale(info.timescale),
-				// Publisher Max Latency rides on the wire, so the local retention window
-				// matches what the upstream advertises (relays re-serve with the same bound).
-				cache: info.cache,
-				priority: info.priority,
-				ordered: info.ordered,
-			});
+			producer = request.accept(this.#toModelInfo(info));
 			timescale.set(info.timescale);
 		} else {
 			// Older drafts negotiate nothing per-track: verbatim frames, no timescale.
@@ -391,6 +371,86 @@ export class Subscriber {
 		} catch (err) {
 			stream.abort(error(err));
 			throw err;
+		}
+	}
+
+	// Map the wire TRACK_INFO onto the model track.Info a producer/consumer holds.
+	#toModelInfo(info: TrackInfo): track.Info {
+		return {
+			timescale: Time.Timescale(info.timescale),
+			// Publisher Max Latency rides on the wire, so the local retention window
+			// matches what the upstream advertises (relays re-serve with the same bound).
+			cache: info.cache,
+			priority: info.priority,
+			ordered: info.ordered,
+		};
+	}
+
+	// Resolve a track's immutable model info via a TRACK stream (lite-05+), for the
+	// ConsumeBroadcast backing track.Consumer.info(). On older drafts there's no TRACK
+	// stream, so this rejects rather than fabricating defaults.
+	async resolveTrackInfo(broadcast: Path.Valid, track: string): Promise<track.Info> {
+		if (!supportsTrackStream(this.version)) {
+			throw new Error("track info requires moq-lite-05 or newer");
+		}
+		return this.#toModelInfo(await this.#trackInfo(broadcast, track));
+	}
+
+	// Open a FETCH stream for one group and stream its bare frames into a group, for the
+	// ConsumeBroadcast backing track.Consumer.fetchGroup() (lite-05+).
+	async fetchGroup(
+		broadcast: Path.Valid,
+		track: string,
+		sequence: number,
+		options: track.FetchGroupOptions = {},
+	): Promise<netGroup.Consumer> {
+		if (!supportsTrackStream(this.version)) {
+			throw new Error("fetch group requires moq-lite-05 or newer");
+		}
+
+		const info = await this.#trackInfo(broadcast, track);
+		const priority = options.priority ?? 0;
+		const stream = await Stream.open(this.#quic, undefined, priority);
+		const group = new netGroup.Producer(sequence);
+
+		try {
+			await stream.writer.u53(StreamId.Fetch);
+			await new FetchMessage(broadcast, track, priority, sequence).encode(stream.writer, this.version);
+		} catch (err: unknown) {
+			const e = error(err);
+			group.close(e);
+			stream.abort(e);
+			throw e;
+		}
+
+		void this.#runFetchResponse(stream, group, Time.Timescale(info.timescale));
+		return group.consume();
+	}
+
+	// Read the FETCH response (bare zigzag-delta-timestamped frames) into the group, then
+	// FIN. A stream-level failure aborts the group so its reader observes the gap.
+	async #runFetchResponse(stream: Stream, group: netGroup.Producer, timescale: Time.Timescale): Promise<void> {
+		try {
+			let prevTs = 0n;
+
+			for (;;) {
+				const done = await Promise.race([stream.reader.done(), group.closed]);
+				if (done !== false) break;
+
+				prevTs += unzigzag(await stream.reader.u62());
+				const timestamp = new Time.Timestamp(Number(prevTs), timescale);
+				const size = await stream.reader.u53();
+				const payload = await stream.reader.read(size);
+				if (!payload) break;
+				group.writeFrame({ data: payload, timestamp });
+			}
+
+			group.close();
+			stream.close();
+		} catch (err: unknown) {
+			const e = error(err);
+			group.close(e);
+			stream.abort(e);
 		}
 	}
 
@@ -640,5 +700,30 @@ export class Subscriber {
 		}
 
 		this.#subscribes.clear();
+	}
+}
+
+/**
+ * A broadcast consumed from a lite session. It resolves `track.Consumer.info()` and
+ * `.fetchGroup()` over the wire (lite-05+ TRACK / FETCH streams) by reaching into the
+ * {@link Subscriber} it was opened from, the way the Rust `BroadcastConsumer` holds its
+ * session. Live subscribes still flow through the inherited requested() queue.
+ */
+class ConsumeBroadcast extends broadcast.Consumer {
+	#subscriber: Subscriber;
+	#path: Path.Valid;
+
+	constructor(subscriber: Subscriber, path: Path.Valid) {
+		super();
+		this.#subscriber = subscriber;
+		this.#path = path;
+	}
+
+	override resolveTrackInfo(name: string): Promise<track.Info> {
+		return this.#subscriber.resolveTrackInfo(this.#path, name);
+	}
+
+	override fetchGroup(name: string, sequence: number, options?: track.FetchGroupOptions): Promise<netGroup.Consumer> {
+		return this.#subscriber.fetchGroup(this.#path, name, sequence, options);
 	}
 }

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -83,6 +83,28 @@ export class Request {
 	}
 }
 
+/** Options for {@link Consumer.fetchGroup}. */
+export interface FetchGroupOptions {
+	/** Delivery priority for the fetch stream. Defaults to `0`. */
+	priority?: number;
+}
+
+/**
+ * The per-track operations a lazy {@link Consumer} delegates to the broadcast it came from.
+ *
+ * Implemented by `broadcast.Producer` / `broadcast.Consumer` (and the wire-layer subclasses
+ * that resolve them over the network), so a track handle holds a reference to its broadcast
+ * and calls methods on it rather than capturing a bag of callbacks.
+ */
+export interface Broadcast {
+	/** Open a live subscription to the named track. */
+	subscribe(name: string, priority: number): Subscriber;
+	/** Resolve the named track's immutable info. */
+	resolveTrackInfo(name: string): Promise<Info>;
+	/** Fetch a single group of the named track by sequence. */
+	fetchGroup(name: string, sequence: number, options?: FetchGroupOptions): Promise<GroupConsumer>;
+}
+
 /**
  * A lazy handle to a track on a consumed broadcast.
  *
@@ -92,23 +114,26 @@ export class Consumer {
 	/** The track name. */
 	readonly name: string;
 
-	#subscribe: (priority: number) => Subscriber;
-	#info: () => Promise<Info>;
+	#broadcast: Broadcast;
 
-	constructor(name: string, subscribe: (priority: number) => Subscriber, info: () => Promise<Info>) {
+	constructor(name: string, broadcast: Broadcast) {
 		this.name = name;
-		this.#subscribe = subscribe;
-		this.#info = info;
+		this.#broadcast = broadcast;
 	}
 
 	/** Open a live subscription to the track. */
 	subscribe(options?: { priority?: number }): Subscriber {
-		return this.#subscribe(options?.priority ?? 0);
+		return this.#broadcast.subscribe(this.name, options?.priority ?? 0);
 	}
 
 	/** Fetch the track's immutable publisher properties without subscribing. */
 	info(): Promise<Info> {
-		return this.#info();
+		return this.#broadcast.resolveTrackInfo(this.name);
+	}
+
+	/** Fetch a single group by sequence without holding a live subscription. */
+	fetchGroup(sequence: number, options?: FetchGroupOptions): Promise<GroupConsumer> {
+		return this.#broadcast.fetchGroup(this.name, sequence, options);
 	}
 }
 


### PR DESCRIPTION
## Summary

Rebased onto current `dev` and reimplemented against its refactored `broadcast.Producer` / `broadcast.Consumer` split. Adds one-shot group fetch to `@moq/net` and reworks the consume side to be **callback-free**.

### Fetch
- `track.Consumer.fetchGroup(sequence, options?)` opens a lite-05+ FETCH stream and returns a `group.Consumer` streaming the fetched frames. `FetchGroupOptions` carries an optional `priority`.
- The lite connection dispatches `StreamId.Fetch`; the publisher serves one group as bare zigzag-delta-timestamped frame records (reusing the group frame wire format).
- moq-transport has no one-shot fetch, so it rejects `fetchGroup`.

### Consume side, no callbacks
- `track.Consumer` now holds a `track.Broadcast` reference (`subscribe` / `resolveTrackInfo` / `fetchGroup`) instead of the `subscribe`/`info` **closures** it used to be constructed with.
- `broadcast.Producer` / `broadcast.Consumer` `implement track.Broadcast`. The base methods serve from local producers; the wire layer **subclasses** `broadcast.Consumer` (`ConsumeBroadcast` in lite/ietf) and overrides `resolveTrackInfo` / `fetchGroup` to resolve over the network, replacing the removed `onTrackInfo` resolver.
- This mirrors the Rust `BroadcastConsumer`, which owns its session and calls methods on it rather than having the session install callbacks. Live subscribes still flow through the inherited `requested()` queue.

## Public API changes (`@moq/net`)
- **Added:** `track.Consumer.fetchGroup(sequence, options?)`, `track.FetchGroupOptions`, `track.Broadcast` (the delegation interface implemented by `broadcast.Producer` / `broadcast.Consumer`).
- **Changed:** `track.Consumer` constructor now takes `(name, broadcast: track.Broadcast)` instead of `(name, subscribeFn, infoFn)`. Constructed only by `broadcast.*.track()`, not by consumers.
- **Removed:** `broadcast.Consumer.onTrackInfo(resolver)`.

Targets `dev` (breaking JS API changes belong there).

## Validation
- `bun run --filter='*' check` (all packages type-check + lint clean, incl. hang/watch/publish which consume `track`/`broadcast`).
- `bun test js/net/` (211 pass), including a new lite cached-group fetch test and an ietf unsupported-fetch test.

(Reworked by Claude Opus 4.8; original implementation written by GPT-5)