### PR TITLE
[codex] fix lite wire edge cases

### DIFF
--- a/js/net/src/lite/announce.test.ts
+++ b/js/net/src/lite/announce.test.ts
@@ -45,3 +45,23 @@ test("AnnounceBroadcast round-trips on draft-05", async () => {
 	expect(gotEnded.active).toBe(false);
 	expect(gotEnded.suffix).toBe(Path.from("room/cam"));
 });
+
+test("AnnounceBroadcast accepts explicit restart status on draft-05", async () => {
+	const wire = await bytes((w) =>
+		new AnnounceBroadcast({ suffix: Path.from("room/cam"), active: true }).encode(w, Version.DRAFT_05_WIP),
+	);
+	wire[1] = 2;
+
+	const got = await AnnounceBroadcast.decode(new Reader(undefined, wire), Version.DRAFT_05_WIP);
+	expect(got.active).toBe(true);
+	expect(got.suffix).toBe(Path.from("room/cam"));
+});
+
+test("AnnounceBroadcast rejects explicit restart status before draft-05", async () => {
+	const wire = await bytes((w) =>
+		new AnnounceBroadcast({ suffix: Path.from("room/cam"), active: true }).encode(w, Version.DRAFT_04),
+	);
+	wire[1] = 2;
+
+	await expect(AnnounceBroadcast.decode(new Reader(undefined, wire), Version.DRAFT_04)).rejects.toThrow();
+});

--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -2,12 +2,16 @@ import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
 import * as Message from "./message.ts";
 import { type Origin, OriginSchema } from "./origin.ts";
-import { Version } from "./version.ts";
+import { hasAnnounceOk, Version } from "./version.ts";
 
 // Must match the MAX_HOPS in Rust's model/origin.rs. Broadcasts with longer
 // hop chains are rejected; this keeps loop-detection bounded and rejects
 // pathological announcements across clusters with unbounded forwarding.
 export const MAX_HOPS = 32;
+
+const ANNOUNCE_ENDED = 0;
+const ANNOUNCE_ACTIVE = 1;
+const ANNOUNCE_RESTART = 2;
 
 /**
  * ANNOUNCE_BROADCAST: sent by the publisher to advertise (or retract) a broadcast.
@@ -29,7 +33,7 @@ export class AnnounceBroadcast {
 	}
 
 	async #encode(w: Writer, version: Version) {
-		await w.bool(this.active);
+		await w.u8(this.active ? ANNOUNCE_ACTIVE : ANNOUNCE_ENDED);
 		await w.string(this.suffix);
 
 		switch (version) {
@@ -50,7 +54,11 @@ export class AnnounceBroadcast {
 	}
 
 	static async #decode(r: Reader, version: Version): Promise<AnnounceBroadcast> {
-		const active = await r.bool();
+		const status = await r.u8();
+		const active = status === ANNOUNCE_ACTIVE || (status === ANNOUNCE_RESTART && hasAnnounceOk(version));
+		if (status !== ANNOUNCE_ENDED && status !== ANNOUNCE_ACTIVE && !active) {
+			throw new Error("invalid announce status");
+		}
 		const suffix = Path.from(await r.string());
 
 		let hops: Origin[] = [];
@@ -211,11 +219,8 @@ export class AnnounceOk {
 	}
 
 	static #guard(version: Version) {
-		switch (version) {
-			case Version.DRAFT_05_WIP:
-				break;
-			default:
-				throw new Error("announce ok not supported for this version");
+		if (!hasAnnounceOk(version)) {
+			throw new Error("announce ok not supported for this version");
 		}
 	}
 

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -183,7 +183,7 @@ export class Connection implements Established {
 	async #sendSetup(): Promise<void> {
 		const writer = await Writer.open(this.#quic);
 		try {
-			await writer.u8(DataType.Setup);
+			await writer.u53(DataType.Setup);
 			await new Setup(ProbeLevel.Report).encode(writer, this.#version);
 			writer.close();
 		} catch (err: unknown) {
@@ -249,7 +249,7 @@ export class Connection implements Established {
 	}
 
 	async #runUni(stream: Reader) {
-		const typ = await stream.u8();
+		const typ = await stream.u53();
 		if (typ === DataType.Group) {
 			const msg = await Group.decode(stream);
 			await this.#subscriber.runGroup(msg, stream);

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -19,7 +19,7 @@ import {
 	SubscribeUpdate,
 } from "./subscribe.ts";
 import { TrackInfo as TrackInfoMessage, type Track as TrackMessage } from "./track.ts";
-import { Version } from "./version.ts";
+import { hasAnnounceOk, Version } from "./version.ts";
 
 const PROBE_INTERVAL = 100; // ms
 const PROBE_MAX_AGE = 10_000; // ms
@@ -133,7 +133,16 @@ export class Publisher {
 				await init.encode(stream.writer, this.version);
 				break;
 			}
-			case Version.DRAFT_05_WIP: {
+			default: {
+				if (!hasAnnounceOk(this.version)) {
+					// Draft03/04: send individual Announce messages, stamping our origin as a hop.
+					for (const suffix of active) {
+						const wire = new AnnounceBroadcast({ suffix, active: true, hops: [this.origin] });
+						await wire.encode(stream.writer, this.version);
+					}
+					break;
+				}
+
 				// Report our origin id once via AnnounceOk and the count of initial announces
 				// that follow; the subscriber stamps our origin onto each hop chain, so we omit it.
 				const ok = new AnnounceOk(this.origin, active.size);
@@ -144,13 +153,6 @@ export class Publisher {
 				}
 				break;
 			}
-			default:
-				// Draft03/04: send individual Announce messages, stamping our origin as a hop.
-				for (const suffix of active) {
-					const wire = new AnnounceBroadcast({ suffix, active: true, hops: [this.origin] });
-					await wire.encode(stream.writer, this.version);
-				}
-				break;
 		}
 
 		// Wait for updates to the broadcasts.
@@ -179,7 +181,7 @@ export class Publisher {
 			// the subscriber stamps it onto each hop chain; older versions stamp it here.
 			for (const added of newActive.difference(active)) {
 				console.debug(`announce: broadcast=${added} active=true`);
-				const hops = this.version === Version.DRAFT_05_WIP ? [] : [this.origin];
+				const hops = hasAnnounceOk(this.version) ? [] : [this.origin];
 				const wire = new AnnounceBroadcast({ suffix: added, active: true, hops });
 				await wire.encode(stream.writer, this.version);
 			}
@@ -376,7 +378,7 @@ export class Publisher {
 		const msg = new GroupMessage(sub, group.sequence);
 		try {
 			const stream = await Writer.open(this.#quic);
-			await stream.u8(0); // stream type
+			await stream.u53(0); // stream type
 			await msg.encode(stream);
 
 			// Lite05+ prefixes every frame with a zigzag-delta timestamp at the track's

--- a/js/net/src/lite/stream.ts
+++ b/js/net/src/lite/stream.ts
@@ -21,7 +21,7 @@ export const StreamId = {
 } as const;
 
 /**
- * The type prefix on a unidirectional data stream, read/written as a single byte.
+ * The varint type prefix on a unidirectional data stream.
  *
  * `Group` is the per-group frame stream. `Setup` (lite-05+) carries the single SETUP
  * message advertising this endpoint's capabilities.

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -17,7 +17,7 @@ import { ProbeLevel, type Setup } from "./setup.ts";
 import { StreamId } from "./stream.ts";
 import { decodeSubscribeResponse, decodeSubscribeResponseMaybe, Subscribe, SubscribeUpdate } from "./subscribe.ts";
 import { TrackInfo, Track as TrackMessage } from "./track.ts";
-import { Version } from "./version.ts";
+import { hasAnnounceOk, Version } from "./version.ts";
 
 // Bound on how long stream-open plus the first response (SUBSCRIBE_OK on older
 // drafts, or TRACK_INFO on lite-05+) may take. Browsers cap concurrent QUIC
@@ -156,7 +156,7 @@ export class Subscriber {
 			// It no longer stamps itself onto each hop chain, so we append it here to
 			// keep the ignoreSelf loop check seeing the full chain.
 			let responderOrigin: Origin | undefined;
-			if (this.version === Version.DRAFT_05_WIP) {
+			if (hasAnnounceOk(this.version)) {
 				const ok = await AnnounceOk.decode(stream.reader, this.version);
 				responderOrigin = ok.origin;
 			}

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -26,6 +26,20 @@ export function hasSetupStream(version: Version): boolean {
 	}
 }
 
+/** Whether announce streams begin with ANNOUNCE_OK and omit the sender's origin from each hop chain. */
+export function hasAnnounceOk(version: Version): boolean {
+	// Explicitly list older versions so future versions keep the lite-05+ announce behavior.
+	switch (version) {
+		case Version.DRAFT_01:
+		case Version.DRAFT_02:
+		case Version.DRAFT_03:
+		case Version.DRAFT_04:
+			return false;
+		default:
+			return true;
+	}
+}
+
 /// The WebTransport subprotocol identifier for moq-lite.
 /// Version negotiation still happens via SETUP when this is used.
 export const ALPN = "moql";

--- a/js/net/src/stream.test.ts
+++ b/js/net/src/stream.test.ts
@@ -275,3 +275,16 @@ test("Reader stream with partial reads", async () => {
 
 	expect(await reader.done()).toBe(true);
 });
+
+test("Reader u53 decodes two-byte stream type prefixes", async () => {
+	const { stream, written } = createTestWritableStream();
+	const writer = new Writer(stream);
+
+	await writer.u53(0x40);
+	writer.close();
+	await writer.closed;
+
+	const reader = new Reader(undefined, concatChunks(written));
+	expect(await reader.u53()).toBe(0x40);
+	expect(await reader.done()).toBe(true);
+});

--- a/js/net/src/time.test.ts
+++ b/js/net/src/time.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test";
+import { Timescale, Timestamp } from "./time.ts";
+
+test("Timestamp rejects negative values", () => {
+	expect(() => new Timestamp(-1, Timescale.MILLI)).toThrow();
+	expect(() => Timestamp.fromMicros(-1)).toThrow();
+});
+
+test("Timestamp rejects non-finite values", () => {
+	expect(() => new Timestamp(Number.NaN, Timescale.MILLI)).toThrow();
+	expect(() => Timestamp.fromMillis(Number.POSITIVE_INFINITY)).toThrow();
+});

--- a/js/net/src/time.ts
+++ b/js/net/src/time.ts
@@ -104,6 +104,9 @@ export class Timestamp {
 
 	/** Build a timestamp of `value` units at `scale`. */
 	constructor(value: number, scale: Timescale) {
+		if (!Number.isFinite(value) || value < 0) {
+			throw new Error(`invalid timestamp: ${value}`);
+		}
 		this.value = value;
 		this.scale = scale;
 	}

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -215,9 +215,8 @@ pub struct AnnounceOk {
 
 impl Message for AnnounceOk {
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		match version {
-			Version::Lite05Wip => {}
-			_ => return Err(DecodeError::Version),
+		if !version.has_announce_ok() {
+			return Err(DecodeError::Version);
 		}
 
 		let origin = Origin::decode(r, version)?;
@@ -230,9 +229,8 @@ impl Message for AnnounceOk {
 	}
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		match version {
-			Version::Lite05Wip => {}
-			_ => return Err(EncodeError::Version),
+		if !version.has_announce_ok() {
+			return Err(EncodeError::Version);
 		}
 
 		self.origin.encode(w, version)?;

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -251,7 +251,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						.publisher_announced_bytes(absolute.as_str().len() as u64);
 				}
 			}
-			Version::Lite05Wip => {
+			_ if version.has_announce_ok() => {
 				// Drain the current active set synchronously (like the Lite01/02 path),
 				// stashing suffix+hops so we can both COUNT them for AnnounceOk and re-send
 				// them afterward. The receiver stamps our origin onto each hop chain, so we
@@ -424,7 +424,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// Lite05+ moves the self-stamp to the receiver, which appends our id (reported
 		// once via AnnounceOk) on receipt. Older versions stamp it here, dropping if the
 		// chain is full.
-		if !matches!(version, Version::Lite05Wip) && hops.push(self_origin).is_err() {
+		if !version.has_announce_ok() && hops.push(self_origin).is_err() {
 			tracing::warn!(broadcast = %absolute, "dropping announce; hop chain at MAX_HOPS (possible loop)");
 			return None;
 		}

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -201,12 +201,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// Lite05+: the publisher reports its own origin id (which we stamp onto every
 		// received Announce's hop chain, since it no longer does so itself) plus the
 		// count of initial active announces that follow immediately.
-		let (responder_origin, initial_count) = match self.version {
-			Version::Lite05Wip => {
-				let ok: lite::AnnounceOk = stream.reader.decode().await?;
-				(Some(ok.origin), ok.active)
-			}
-			_ => (None, 0),
+		let (responder_origin, initial_count) = if self.version.has_announce_ok() {
+			let ok: lite::AnnounceOk = stream.reader.decode().await?;
+			(Some(ok.origin), ok.active)
+		} else {
+			(None, 0)
 		};
 
 		let mut producers = HashMap::new();
@@ -256,7 +255,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				connecting.take();
 				0
 			}
-			Version::Lite05Wip => {
+			_ if self.version.has_announce_ok() => {
 				if initial_count == 0 {
 					connecting.take();
 				}

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -41,6 +41,17 @@ impl Version {
 			_ => true,
 		}
 	}
+
+	/// Whether announce streams begin with ANNOUNCE_OK and omit the sender's origin
+	/// from each announcement's hop chain. Added in lite-05.
+	#[allow(clippy::match_like_matches_macro)]
+	pub fn has_announce_ok(self) -> bool {
+		// Match form so future versions default forward (CLAUDE.md convention).
+		match self {
+			Self::Lite01 | Self::Lite02 | Self::Lite03 | Self::Lite04 => false,
+			_ => true,
+		}
+	}
 }
 
 impl fmt::Display for Version {


### PR DESCRIPTION
## Summary

- Accept the explicit Lite05 ANNOUNCE restart status byte in JS while preserving pre-Lite05 rejection.
- Read and write JS Lite unidirectional stream type prefixes as varints.
- Reject negative/non-finite JS timestamps and make Lite05+ announce behavior default forward in JS and Rust.

## Validation

- `bun test js/net/src/lite/announce.test.ts js/net/src/stream.test.ts js/net/src/time.test.ts`
- `bun biome check js/net/src/lite/version.ts js/net/src/lite/announce.ts js/net/src/lite/publisher.ts js/net/src/lite/subscriber.ts js/net/src/lite/connection.ts js/net/src/lite/stream.ts js/net/src/time.ts js/net/src/lite/announce.test.ts js/net/src/stream.test.ts js/net/src/time.test.ts`
- `cargo test -p moq-net lite::announce`
- `cargo deny check advisories`
- `just fix`
- `just check` progressed through JS checks, Rust check, clippy, fmt, docs, shear, and sort locally, then failed on unrelated justfile formatting drift.

(Written by GPT-5)