### PR TITLE
fix(moq-video, moq-audio): non-contiguous VT output, blocking mic prompt, DXVA NV12 offset

### DIFF
--- a/rs/moq-audio/src/capture.rs
+++ b/rs/moq-audio/src/capture.rs
@@ -64,7 +64,7 @@ impl Microphone {
 	pub async fn open(config: &Config) -> Result<Self, AudioError> {
 		// Fail fast on a denied/restricted mic (macOS TCC) instead of opening a
 		// stream that silently delivers nothing. A no-op on other platforms.
-		permission::ensure_microphone_access()?;
+		permission::ensure_microphone_access().await?;
 
 		let (device, sample_format, stream_config) = resolve(config)?;
 		let sample_rate = stream_config.sample_rate;

--- a/rs/moq-audio/src/capture/permission.rs
+++ b/rs/moq-audio/src/capture/permission.rs
@@ -11,7 +11,7 @@
 use crate::AudioError;
 
 #[cfg(target_os = "macos")]
-pub(super) fn ensure_microphone_access() -> Result<(), AudioError> {
+pub(super) async fn ensure_microphone_access() -> Result<(), AudioError> {
 	use objc2_av_foundation::{AVAuthorizationStatus, AVCaptureDevice, AVMediaTypeAudio};
 
 	let media =
@@ -31,7 +31,7 @@ pub(super) fn ensure_microphone_access() -> Result<(), AudioError> {
 		));
 	}
 	if status == AVAuthorizationStatus::NotDetermined {
-		return request_access(media);
+		return request_access(media).await;
 	}
 
 	// Unknown future status: don't block capture, let the stream open and the
@@ -47,29 +47,34 @@ pub(super) fn ensure_microphone_access() -> Result<(), AudioError> {
 #[cfg(target_os = "macos")]
 const PROMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-/// Trigger the system prompt and block (on this `spawn_blocking` thread) until
-/// the user answers. Unbundled CLIs usually get auto-denied without UI, which we
-/// surface as the same clear error.
+/// Trigger the system prompt and await the user's answer. Unbundled CLIs usually
+/// get auto-denied without UI, which we surface as the same clear error.
 #[cfg(target_os = "macos")]
-fn request_access(media: &objc2_av_foundation::AVMediaType) -> Result<(), AudioError> {
+async fn request_access(media: &objc2_av_foundation::AVMediaType) -> Result<(), AudioError> {
+	use std::sync::Mutex;
+
 	use objc2_av_foundation::AVCaptureDevice;
 
-	let (tx, rx) = std::sync::mpsc::channel::<bool>();
-	// `handler` owns `tx` and stays alive until this function returns, so the
-	// channel never reports `Disconnected`; a never-firing callback surfaces as
-	// `Timeout` instead of hanging.
+	// requestAccess invokes the handler once, asynchronously, on an arbitrary
+	// queue. Bridge it to a oneshot we await, so the prompt doesn't block a
+	// runtime worker and a cancelled capture drops cleanly mid-prompt.
+	let (tx, rx) = tokio::sync::oneshot::channel::<bool>();
+	let tx = Mutex::new(Some(tx));
 	let handler = block2::RcBlock::new(move |granted: objc2::runtime::Bool| {
-		let _ = tx.send(granted.as_bool());
+		if let Some(tx) = tx.lock().unwrap().take() {
+			let _ = tx.send(granted.as_bool());
+		}
 	});
 
 	unsafe { AVCaptureDevice::requestAccessForMediaType_completionHandler(media, &handler) };
 
-	match rx.recv_timeout(PROMPT_TIMEOUT) {
-		Ok(true) => Ok(()),
-		Ok(false) => Err(denied()),
-		// Callback never fired within the window: don't hard-fail, fall through to
-		// the stream open and let the first-buffer timeout catch a real hang.
-		Err(_) => Ok(()),
+	match tokio::time::timeout(PROMPT_TIMEOUT, rx).await {
+		Ok(Ok(true)) => Ok(()),
+		Ok(Ok(false)) => Err(denied()),
+		// Prompt dismissed without a decision, or the callback never fired within
+		// the window: don't hard-fail, fall through to the stream open and let the
+		// first-buffer timeout catch a real hang.
+		Ok(Err(_)) | Err(_) => Ok(()),
 	}
 }
 
@@ -81,6 +86,6 @@ fn denied() -> AudioError {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub(super) fn ensure_microphone_access() -> Result<(), AudioError> {
+pub(super) async fn ensure_microphone_access() -> Result<(), AudioError> {
 	Ok(())
 }

--- a/rs/moq-video/src/encode/backend/videotoolbox.rs
+++ b/rs/moq-video/src/encode/backend/videotoolbox.rs
@@ -268,10 +268,27 @@ fn annexb_from_sample(sample: &CMSampleBuffer, codec: Codec) -> Result<Option<By
 	if status != 0 {
 		return Err(status);
 	}
-	if data_ptr.is_null() || total == 0 {
+	if total == 0 {
 		return Ok(None);
 	}
-	let avcc = unsafe { slice::from_raw_parts(data_ptr as *const u8, total) };
+
+	// `data_pointer` only guarantees `length_at_offset` contiguous bytes at
+	// `data_ptr`; a non-contiguous block buffer would make a `total`-length slice
+	// read past the mapped region. VideoToolbox output is contiguous in practice,
+	// but copy the whole access unit flat if it ever isn't.
+	let owned;
+	let avcc: &[u8] = if !data_ptr.is_null() && length_at_offset >= total {
+		unsafe { slice::from_raw_parts(data_ptr as *const u8, total) }
+	} else {
+		let mut buf = vec![0u8; total];
+		let dst = NonNull::new(buf.as_mut_ptr().cast::<c_void>()).ok_or(-1)?;
+		let status = unsafe { block.copy_data_bytes(0, total, dst) };
+		if status != 0 {
+			return Err(status);
+		}
+		owned = buf;
+		&owned
+	};
 
 	let slices = split_avcc(avcc, nal_length_size as usize);
 	let is_keyframe = slices.iter().any(|nal| is_keyframe_nal(nal, codec));

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -489,6 +489,12 @@ pub(crate) mod d3d11 {
 			let (cw, ch) = (w / 2, h / 2);
 			let pitch = mapped.RowPitch as usize;
 			let base = mapped.pData as *const u8;
+			// The UV plane begins after the *texture's* Y plane, which spans the
+			// allocated height, not the display height. A DXVA decode pool allocates
+			// textures at the coded size (e.g. 1088 rows for a 1080p display), so
+			// keying the offset off `self.height` would read chroma from inside the
+			// still-luma padding rows and produce garbage color.
+			let tex_height = desc.Height as usize;
 
 			let mut data = vec![0u8; I420::len(self.width, self.height)];
 			let (luma, chroma) = data.split_at_mut(w * h);
@@ -500,8 +506,8 @@ pub(crate) mod d3d11 {
 					ptr::copy_nonoverlapping(base.add(row * pitch), luma[row * w..].as_mut_ptr(), w);
 				}
 			}
-			// Interleaved UV plane sits right after Y at `pitch * h`, h/2 rows.
-			let uv_base = unsafe { base.add(pitch * h) };
+			// Interleaved UV plane sits right after the full Y plane, h/2 rows.
+			let uv_base = unsafe { base.add(pitch * tex_height) };
 			for row in 0..ch {
 				let src = unsafe { uv_base.add(row * pitch) };
 				for col in 0..cw {


### PR DESCRIPTION
Fixes three of the reported `moq-video` / `moq-audio` issues on `dev`. Each is self-contained; a follow-up will handle the remaining encode/capture-threading items (COM thread mismatch, `wait_for_input` blocking a worker, `!Send` publish futures) via a dedicated encode thread, which needs runtime testing on Windows/macOS.

## Summary

- **moq-video (macOS): guard VideoToolbox output against non-contiguous block buffers.** `annexb_from_sample` sliced `total` bytes off the pointer from `CMBlockBufferGetDataPointer`, which only guarantees `length_at_offset` contiguous bytes. A non-contiguous sample buffer would read out of bounds. Falls back to `CMBlockBufferCopyDataBytes` into a flat buffer when the fast path isn't contiguous (the common case still takes the zero-copy slice).
- **moq-audio (macOS): await the mic-permission prompt instead of blocking a worker.** `ensure_microphone_access` ran `recv_timeout` (up to 30s) synchronously on the async `Microphone::open` path, parking a tokio worker. Now mirrors the camera path: the completion handler bridges to a `tokio::sync::oneshot` awaited under `tokio::time::timeout`, so it no longer blocks a worker and a cancelled capture drops cleanly mid-prompt.
- **moq-video (Windows): use the texture height for the NV12 UV-plane offset on DXVA decode.** The decode pool allocates textures at the coded size (e.g. 1088 rows for a 1080p display); `download_i420` keyed the UV offset off the display height (`pitch * display_height`), reading chroma from luma padding and producing garbage color at 1080p. The UV plane of a D3D11 NV12 texture always starts at `pitch * texture_height`, so it now uses the staging texture's allocated `desc.Height`.

## Unrelated CI unblock

- **`deny.toml`: ignore `RUSTSEC-2026-0194` / `RUSTSEC-2026-0195` (quick-xml).** Two DoS advisories published 2026-07-02 that fail `cargo deny advisories` on every PR against `dev`. quick-xml 0.39 is reachable only via `iroh -> netdev -> netwatch -> plist` (network-interface discovery in moq-native's iroh QUIC backend); plist 1.9 pins 0.39 so the patched 0.41 can't be selected, and our media/protocol paths never feed it untrusted XML. Follows the existing `deny.toml` ignore pattern. Easy to cherry-pick out if you'd rather land it separately. Drop the ignore when the iroh/plist chain moves to quick-xml >=0.41.

## Test plan

- [x] `cargo clippy -p moq-audio --features capture -p moq-video --all-targets -- -D warnings` (nix) clean
- [x] `cargo test -p moq-audio --features capture -p moq-video` (nix) green (20 moq-video tests incl. VideoToolbox encode paths, plus moq-audio)
- [x] `cargo check -p moq-audio` (default, no `capture`) green
- [x] Windows cross-compile: `cargo zigbuild --target x86_64-pc-windows-gnu -p moq-video` green (covers the DXVA `frame.rs` change)
- [x] `cargo deny check advisories` (nix) green
- [ ] Runtime: DXVA 1080p decode color-correct on Windows (compile-checked only)
- [ ] Runtime: mic-permission prompt on macOS (TCC blocks capture from the agent process)

Branch target: `dev` (per Branch Targeting; these are `moq-video`/`moq-audio` changes).

(Written by Claude Opus 4.8)