### PR TITLE
chore(release): bump moq-rtmp/srt/rtc/hls to 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "moq-hls"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "moq-rtc"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4319,7 +4319,7 @@ dependencies = [
 
 [[package]]
 name = "moq-rtmp"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4338,7 +4338,7 @@ dependencies = [
 
 [[package]]
 name = "moq-srt"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,16 +62,16 @@ hang = { version = "0.19", path = "rs/hang" }
 kio = { version = "0.4", path = "rs/kio" }
 moq-audio = { version = "0.0.6", path = "rs/moq-audio" }
 moq-flate = { version = "0.1.0", path = "rs/moq-flate" }
-moq-hls = { version = "0.0.1", path = "rs/moq-hls", default-features = false }
+moq-hls = { version = "0.1.0", path = "rs/moq-hls", default-features = false }
 moq-json = { version = "0.1.1", path = "rs/moq-json" }
 moq-loc = { version = "0.1", path = "rs/moq-loc" }
 moq-msf = { version = "0.3", path = "rs/moq-msf" }
 moq-mux = { version = "0.7", path = "rs/moq-mux" }
 moq-native = { version = "0.17", path = "rs/moq-native", default-features = false }
 moq-net = { version = "0.1", path = "rs/moq-net" }
-moq-rtc = { version = "0.0.1", path = "rs/moq-rtc" }
-moq-rtmp = { version = "0.0.1", path = "rs/moq-rtmp" }
-moq-srt = { version = "0.0.1", path = "rs/moq-srt" }
+moq-rtc = { version = "0.1.0", path = "rs/moq-rtc" }
+moq-rtmp = { version = "0.1.0", path = "rs/moq-rtmp" }
+moq-srt = { version = "0.1.0", path = "rs/moq-srt" }
 moq-token = { version = "0.6", path = "rs/moq-token" }
 moq-video = { version = "0.0.6", path = "rs/moq-video" }
 qmux = { version = "0.2", default-features = false }

--- a/rs/moq-hls/Cargo.toml
+++ b/rs/moq-hls/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley <kixelated@gmail.com>"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.0.1"
+version = "0.1.0"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-rtc/Cargo.toml
+++ b/rs/moq-rtc/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley <kixelated@gmail.com>"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.0.1"
+version = "0.1.0"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-rtmp/Cargo.toml
+++ b/rs/moq-rtmp/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley <kixelated@gmail.com>"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.0.1"
+version = "0.1.0"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-srt/Cargo.toml
+++ b/rs/moq-srt/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley <kixelated@gmail.com>"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.0.1"
+version = "0.1.0"
 edition = "2024"
 rust-version.workspace = true
 


### PR DESCRIPTION
## Why

The `Plz / Release` job on `main` is failing to publish `moq-cli 0.8.0` ([run](https://github.com/moq-dev/moq/actions/runs/28619244377/job/84870575494)):

```
error[E0432]: unresolved import `moq_rtmp::Client`
error[E0433]: cannot find `dial` in `moq_srt`
error[E0599]: no method `with_latency` on `moq_rtmp::Play`
```

The gateway crates were still at `0.0.1`. Their published crates.io tarballs predate the APIs `moq-cli 0.8.0` now calls, and release-plz skips republishing them because the `moq-*-v0.0.1` tags already exist. So `cargo publish` verifies the `moq-cli` tarball against the stale `0.0.1` deps and fails to compile. (For `0.0.x`, caret requirements only match the exact patch, so a `0.0.2` wouldn't have satisfied `moq-cli` either.)

## What

Bump all four gateway crates to `0.1.0` — both the package version and the `[workspace.dependencies]` requirement:

- `moq-rtmp` `0.0.1` → `0.1.0`
- `moq-srt` `0.0.1` → `0.1.0`
- `moq-rtc` `0.0.1` → `0.1.0`
- `moq-hls` `0.0.1` → `0.1.0`

`moq-cli` stays at `0.8.0`; it depends on all four via `workspace = true`, so its `^0.1.0` requirement now points at the version that actually contains the APIs. On the next `main` release, release-plz publishes the four fresh (their `v0.1.0` tags don't exist yet), in dependency order, ahead of `moq-cli`.

## Test plan

- [x] `cargo metadata --no-deps` resolves
- [ ] `just check`
- [ ] `Plz / Release` on `main` publishes the four crates then `moq-cli 0.8.0`

(Written by Claude Opus 4.8)