### PR TITLE
refactor(moq-video): run the capture encoder on a dedicated thread

### DIFF
--- a/rs/moq-audio/src/capture.rs
+++ b/rs/moq-audio/src/capture.rs
@@ -64,7 +64,7 @@ impl Microphone {
 	pub async fn open(config: &Config) -> Result<Self, AudioError> {
 		// Fail fast on a denied/restricted mic (macOS TCC) instead of opening a
 		// stream that silently delivers nothing. A no-op on other platforms.
-		permission::ensure_microphone_access()?;
+		permission::ensure_microphone_access().await?;
 
 		let (device, sample_format, stream_config) = resolve(config)?;
 		let sample_rate = stream_config.sample_rate;

--- a/rs/moq-audio/src/capture/permission.rs
+++ b/rs/moq-audio/src/capture/permission.rs
@@ -11,7 +11,7 @@
 use crate::AudioError;
 
 #[cfg(target_os = "macos")]
-pub(super) fn ensure_microphone_access() -> Result<(), AudioError> {
+pub(super) async fn ensure_microphone_access() -> Result<(), AudioError> {
 	use objc2_av_foundation::{AVAuthorizationStatus, AVCaptureDevice, AVMediaTypeAudio};
 
 	let media =
@@ -31,7 +31,7 @@ pub(super) fn ensure_microphone_access() -> Result<(), AudioError> {
 		));
 	}
 	if status == AVAuthorizationStatus::NotDetermined {
-		return request_access(media);
+		return request_access(media).await;
 	}
 
 	// Unknown future status: don't block capture, let the stream open and the
@@ -47,29 +47,34 @@ pub(super) fn ensure_microphone_access() -> Result<(), AudioError> {
 #[cfg(target_os = "macos")]
 const PROMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-/// Trigger the system prompt and block (on this `spawn_blocking` thread) until
-/// the user answers. Unbundled CLIs usually get auto-denied without UI, which we
-/// surface as the same clear error.
+/// Trigger the system prompt and await the user's answer. Unbundled CLIs usually
+/// get auto-denied without UI, which we surface as the same clear error.
 #[cfg(target_os = "macos")]
-fn request_access(media: &objc2_av_foundation::AVMediaType) -> Result<(), AudioError> {
+async fn request_access(media: &objc2_av_foundation::AVMediaType) -> Result<(), AudioError> {
+	use std::sync::Mutex;
+
 	use objc2_av_foundation::AVCaptureDevice;
 
-	let (tx, rx) = std::sync::mpsc::channel::<bool>();
-	// `handler` owns `tx` and stays alive until this function returns, so the
-	// channel never reports `Disconnected`; a never-firing callback surfaces as
-	// `Timeout` instead of hanging.
+	// requestAccess invokes the handler once, asynchronously, on an arbitrary
+	// queue. Bridge it to a oneshot we await, so the prompt doesn't block a
+	// runtime worker and a cancelled capture drops cleanly mid-prompt.
+	let (tx, rx) = tokio::sync::oneshot::channel::<bool>();
+	let tx = Mutex::new(Some(tx));
 	let handler = block2::RcBlock::new(move |granted: objc2::runtime::Bool| {
-		let _ = tx.send(granted.as_bool());
+		if let Some(tx) = tx.lock().unwrap().take() {
+			let _ = tx.send(granted.as_bool());
+		}
 	});
 
 	unsafe { AVCaptureDevice::requestAccessForMediaType_completionHandler(media, &handler) };
 
-	match rx.recv_timeout(PROMPT_TIMEOUT) {
-		Ok(true) => Ok(()),
-		Ok(false) => Err(denied()),
-		// Callback never fired within the window: don't hard-fail, fall through to
-		// the stream open and let the first-buffer timeout catch a real hang.
-		Err(_) => Ok(()),
+	match tokio::time::timeout(PROMPT_TIMEOUT, rx).await {
+		Ok(Ok(true)) => Ok(()),
+		Ok(Ok(false)) => Err(denied()),
+		// Prompt dismissed without a decision, or the callback never fired within
+		// the window: don't hard-fail, fall through to the stream open and let the
+		// first-buffer timeout catch a real hang.
+		Ok(Err(_)) | Err(_) => Ok(()),
 	}
 }
 
@@ -81,6 +86,6 @@ fn denied() -> AudioError {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub(super) fn ensure_microphone_access() -> Result<(), AudioError> {
+pub(super) async fn ensure_microphone_access() -> Result<(), AudioError> {
 	Ok(())
 }

--- a/rs/moq-video/src/capture/mod.rs
+++ b/rs/moq-video/src/capture/mod.rs
@@ -16,6 +16,18 @@ use crate::frame::Frame;
 mod channel;
 use channel::FrameChannel;
 
+/// Type-erased keep-alive for a capture backend, dropped to release the device.
+///
+/// `Send` off macOS (the backend is a pump-thread guard: an `Arc` stop flag plus
+/// a `JoinHandle`), which keeps [`publish_capture`](crate::encode::publish_capture)
+/// `Send` so a server can `tokio::spawn` it. On macOS the backend is the objc
+/// `AVCaptureSession` (plus its delegate), which is `!Send`, so that platform's
+/// capture future is `!Send` too.
+#[cfg(not(target_os = "macos"))]
+type Keepalive = Box<dyn std::any::Any + Send>;
+#[cfg(target_os = "macos")]
+type Keepalive = Box<dyn std::any::Any>;
+
 #[cfg(target_os = "macos")]
 mod avfoundation;
 #[cfg(target_os = "macos")]
@@ -90,7 +102,7 @@ pub(crate) struct FrameStream {
 	pending: Option<Frame>,
 	/// Keeps the backend alive and releases it on drop. Type-erased because it
 	/// differs per platform (objc session + delegate, or pump-thread guard).
-	_backend: Box<dyn std::any::Any>,
+	_backend: Keepalive,
 }
 
 impl FrameStream {
@@ -102,7 +114,7 @@ impl FrameStream {
 		framerate: Option<u32>,
 		device: String,
 		pending: Option<Frame>,
-		backend: Box<dyn std::any::Any>,
+		backend: Keepalive,
 	) -> Self {
 		Self {
 			chan,

--- a/rs/moq-video/src/capture/pump.rs
+++ b/rs/moq-video/src/capture/pump.rs
@@ -94,14 +94,16 @@ where
 		}
 	});
 
+	// Own the thread from here on, so cancelling this `await` (dropping the
+	// `open` future before geometry arrives) still stops and joins it instead of
+	// detaching a thread that holds the device open with the camera LED lit.
+	let guard = PumpGuard {
+		stop,
+		handle: Some(handle),
+	};
+
 	match geo_rx.await {
-		Ok(Ok(geometry)) => Ok((
-			geometry,
-			PumpGuard {
-				stop,
-				handle: Some(handle),
-			},
-		)),
+		Ok(Ok(geometry)) => Ok((geometry, guard)),
 		Ok(Err(err)) => Err(err),
 		Err(_) => Err(Error::Codec(anyhow::anyhow!(
 			"capture thread exited before reporting geometry"

--- a/rs/moq-video/src/encode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/encode/backend/mediafoundation.rs
@@ -9,8 +9,9 @@
 //! The MFT emits an Annex-B byte stream with parameter sets inline ahead of each
 //! IDR/IRAP (SPS/PPS for H.264, VPS/SPS/PPS for H.265), which is exactly what
 //! `moq_mux` avc3 / hev1 mode wants, so unlike VideoToolbox there's no
-//! AVCC/HVCC -> Annex-B rewrite. Used only from the one capture/encode thread, so
-//! the COM handles are wrapped in a thread-confined `Send` type.
+//! AVCC/HVCC -> Annex-B rewrite. The whole encoder lives on the dedicated encode
+//! thread (see `encode::sink`), so its COM apartment stays balanced and its
+//! blocking waits never park a tokio worker.
 
 use std::mem::ManuallyDrop;
 use std::ptr;
@@ -74,8 +75,10 @@ pub(crate) struct MediaFoundation {
 	_com: ComGuard,
 }
 
-// The MFT and its COM handles are only ever touched from the one capture/encode
-// thread (see `publish_capture`'s `spawn_blocking`).
+// The MFT and its COM handles are created, driven, and dropped only on the
+// dedicated encode thread (see `encode::sink`), so the per-thread COM apartment
+// this opens in `ComGuard::new` stays balanced. `Send` lets the boxed trait
+// object satisfy `Backend: Send`.
 unsafe impl Send for MediaFoundation {}
 
 impl MediaFoundation {
@@ -323,7 +326,8 @@ impl MediaFoundation {
 	}
 
 	/// Block on events until the MFT is ready for input, collecting any output
-	/// that arrives meanwhile.
+	/// that arrives meanwhile. Runs on the dedicated encode thread (see
+	/// `encode::sink`), so this blocking wait never parks a tokio worker.
 	fn wait_for_input(&mut self, out: &mut Vec<Bytes>) -> Result<(), Error> {
 		while !self.needs_input {
 			let event = unsafe {

--- a/rs/moq-video/src/encode/backend/vaapi.rs
+++ b/rs/moq-video/src/encode/backend/vaapi.rs
@@ -34,8 +34,9 @@ pub(crate) struct Vaapi {
 	encoder: Encoder,
 }
 
-// The encoder is `!Send` (libva uses `Rc` internally) but is only ever touched
-// from the single capture/encode thread (see `publish_capture`).
+// The encoder is `!Send` (libva uses `Rc` internally) but is created, used, and
+// dropped only on the dedicated encode thread (see `encode::sink`); the `Send`
+// impl just lets the boxed trait object satisfy `Backend: Send`.
 unsafe impl Send for Vaapi {}
 
 impl Vaapi {

--- a/rs/moq-video/src/encode/backend/videotoolbox.rs
+++ b/rs/moq-video/src/encode/backend/videotoolbox.rs
@@ -8,8 +8,10 @@
 //! format description.
 //!
 //! Hand-written on the raw `objc2-video-toolbox` bindings; there's no
-//! higher-level crate we trust. Used only from the single capture/encode thread,
-//! so the `!Send` CoreFoundation handles are wrapped in a thread-confined type.
+//! higher-level crate we trust. The capture loop drives it inline and always
+//! sequentially, so the `!Send` CoreFoundation handles are wrapped in a `Send`
+//! type (safe to move between tokio workers between frames, never used
+//! concurrently).
 
 use std::ffi::{c_int, c_void};
 use std::ptr::{self, NonNull};
@@ -61,8 +63,10 @@ pub(crate) struct VideoToolbox {
 	frame_index: i64,
 }
 
-// The session and its CoreFoundation handles are only ever touched from the one
-// capture/encode thread (see `publish_capture`'s `spawn_blocking`).
+// The capture loop drives this inline (macOS skips the dedicated encode thread),
+// always sequentially. Core Foundation handles are safe to use from a different
+// thread as long as never concurrently, so `Send` (which just lets the encoder
+// move between tokio workers between frames) is sound.
 unsafe impl Send for VideoToolbox {}
 
 impl VideoToolbox {

--- a/rs/moq-video/src/encode/backend/videotoolbox.rs
+++ b/rs/moq-video/src/encode/backend/videotoolbox.rs
@@ -268,10 +268,27 @@ fn annexb_from_sample(sample: &CMSampleBuffer, codec: Codec) -> Result<Option<By
 	if status != 0 {
 		return Err(status);
 	}
-	if data_ptr.is_null() || total == 0 {
+	if total == 0 {
 		return Ok(None);
 	}
-	let avcc = unsafe { slice::from_raw_parts(data_ptr as *const u8, total) };
+
+	// `data_pointer` only guarantees `length_at_offset` contiguous bytes at
+	// `data_ptr`; a non-contiguous block buffer would make a `total`-length slice
+	// read past the mapped region. VideoToolbox output is contiguous in practice,
+	// but copy the whole access unit flat if it ever isn't.
+	let owned;
+	let avcc: &[u8] = if !data_ptr.is_null() && length_at_offset >= total {
+		unsafe { slice::from_raw_parts(data_ptr as *const u8, total) }
+	} else {
+		let mut buf = vec![0u8; total];
+		let dst = NonNull::new(buf.as_mut_ptr().cast::<c_void>()).ok_or(-1)?;
+		let status = unsafe { block.copy_data_bytes(0, total, dst) };
+		if status != 0 {
+			return Err(status);
+		}
+		owned = buf;
+		&owned
+	};
 
 	let slices = split_avcc(avcc, nal_length_size as usize);
 	let is_keyframe = slices.iter().any(|nal| is_keyframe_nal(nal, codec));

--- a/rs/moq-video/src/encode/mod.rs
+++ b/rs/moq-video/src/encode/mod.rs
@@ -17,6 +17,7 @@
 mod backend;
 mod encoder;
 mod producer;
+mod sink;
 
 pub use encoder::{Codec, Config, Encoder, Kind};
 pub use producer::{Options, Producer, publish_capture};

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -11,7 +11,8 @@ use moq_net::Timestamp;
 use crate::Error;
 use crate::capture;
 
-use super::encoder::{self, Codec, Encoder};
+use super::encoder::{self, Codec};
+use super::sink::Sink;
 
 /// Last-resort framerate when neither the caller nor the camera reports one.
 const DEFAULT_FRAMERATE: u32 = 30;
@@ -161,6 +162,24 @@ pub async fn publish_capture(
 	result
 }
 
+/// Off macOS, [`publish_capture`]'s future must stay `Send` so a server can
+/// `tokio::spawn` it: the encoder runs on its own thread and the capture guard
+/// is `Send` there. This is never called; it exists only to fail compilation if
+/// the future ever regains a `!Send` component. macOS is exempt (the objc
+/// capture session is `!Send`).
+#[cfg(not(target_os = "macos"))]
+#[allow(dead_code)]
+fn assert_publish_capture_send(
+	broadcast: moq_net::BroadcastProducer,
+	catalog: moq_mux::catalog::Producer,
+	capture: capture::Config,
+	encode: Options,
+	clock: moq_mux::Clock,
+) {
+	fn is_send<T: Send>(_: &T) {}
+	is_send(&publish_capture(broadcast, catalog, capture, encode, clock));
+}
+
 /// A dropped or closed track is the normal end of a publish; any other cause is
 /// a real abort (e.g. a transport reset) worth surfacing rather than treating as
 /// a clean exit.
@@ -177,9 +196,12 @@ fn log_track_ended(err: moq_net::Error) {
 /// SPS), then releases the camera whenever the last viewer leaves and reopens it
 /// when one returns.
 ///
-/// Cancel safety: every wait here is a real `.await` (a frame read or a demand
-/// transition), so dropping this future (e.g. on Ctrl+C) drops `camera`, which
-/// releases the device and turns the LED off. No blocking thread is left behind.
+/// Cancel safety: every wait here is a real `.await` (a frame read, a demand
+/// transition, or an encode), so dropping this future (e.g. on Ctrl+C) drops
+/// `camera` and `encoder`, which release the device (LED off) and join the
+/// encode thread. Both the capture and encode threads sit idle between frames,
+/// so their joins return promptly unless the underlying device or encoder is
+/// itself wedged.
 async fn capture_loop(
 	producer: &mut Producer,
 	demand: &moq_net::TrackDemand,
@@ -214,7 +236,8 @@ async fn capture_loop(
 		encoder_config.bitrate = encode.bitrate;
 		encoder_config.codec = encode.codec;
 		encoder_config.kind = encode.kind.clone();
-		let mut encoder = Encoder::new(&encoder_config)?;
+		// Off macOS this opens the encoder on a dedicated thread; see `sink`.
+		let mut encoder = Sink::open(&encoder_config).await?;
 		// Force an IDR on the first frame of each (re)open so a viewer subscribing
 		// after an idle gap can start decoding immediately.
 		let mut force_keyframe = true;
@@ -243,7 +266,7 @@ async fn capture_loop(
 			let Some(frame) = frame else { break }; // device stopped producing frames
 
 			let ts = Timestamp::from_micros(clock.micros())?;
-			let packets = encoder.encode(&frame, force_keyframe)?;
+			let packets = encoder.encode(frame, force_keyframe).await?;
 			force_keyframe = false;
 			// Once the encoder emits a frame the importer has parsed the SPS and
 			// the catalog rendition exists, so demand gating can take over.

--- a/rs/moq-video/src/encode/sink.rs
+++ b/rs/moq-video/src/encode/sink.rs
@@ -1,0 +1,159 @@
+//! The encoder as [`publish_capture`](super::publish_capture)'s capture loop
+//! drives it, abstracting over where the encode actually runs.
+//!
+//! Off macOS the encoder runs on a dedicated OS thread (mirroring
+//! [`capture::pump`](crate::capture)): the Windows hardware encoder is a Media
+//! Foundation MFT whose COM handles must be created, driven, and dropped all on
+//! one thread (COM apartments are per-thread), and whose encode call blocks on
+//! MFT events. Driving it inline on a tokio worker would unbalance the
+//! per-thread COM refcount as the future migrates between workers and park a
+//! worker on a stalled MFT. Confining the whole encoder lifetime to one thread
+//! fixes both; frames are `Send` there (Windows D3D11 textures and CPU I420 both
+//! are) and packets come back over a channel.
+//!
+//! macOS keeps encoding inline: VideoToolbox has no COM apartment to balance and
+//! doesn't block on an event loop, so a thread would only add a hop, and its
+//! zero-copy `CVPixelBuffer` surface is `!Send` and couldn't cross to one anyway.
+
+#[cfg(not(target_os = "macos"))]
+pub(super) use threaded::Sink;
+
+#[cfg(target_os = "macos")]
+pub(super) use inline::Sink;
+
+#[cfg(not(target_os = "macos"))]
+mod threaded {
+	use std::thread::JoinHandle;
+
+	use bytes::Bytes;
+	use tokio::sync::{mpsc, oneshot};
+
+	use super::super::encoder::{self, Encoder};
+	use crate::Error;
+	use crate::frame::Frame;
+
+	/// One encode request: a frame and whether to force a keyframe, plus a
+	/// oneshot to return that frame's packets (or an error) in order.
+	struct Request {
+		frame: Frame,
+		keyframe: bool,
+		resp: oneshot::Sender<Result<Vec<Bytes>, Error>>,
+	}
+
+	/// An [`Encoder`] running on its own thread. See the module docs.
+	pub(in crate::encode) struct Sink {
+		/// `Option` so `Drop` can drop the sender (signalling the thread to exit)
+		/// before joining.
+		tx: Option<mpsc::UnboundedSender<Request>>,
+		handle: Option<JoinHandle<()>>,
+		name: String,
+	}
+
+	impl Sink {
+		/// Open an encoder for `config` on a dedicated thread. Returns once the
+		/// encoder is built (or its construction fails), so a bad config or a
+		/// missing backend surfaces here rather than on the first frame.
+		pub(in crate::encode) async fn open(config: &encoder::Config) -> Result<Self, Error> {
+			let (req_tx, mut req_rx) = mpsc::unbounded_channel::<Request>();
+			let (ready_tx, ready_rx) = oneshot::channel::<Result<String, Error>>();
+			let config = config.clone();
+
+			let handle = std::thread::spawn(move || {
+				let mut encoder = match Encoder::new(&config) {
+					Ok(encoder) => encoder,
+					Err(err) => {
+						let _ = ready_tx.send(Err(err));
+						return;
+					}
+				};
+				// If the awaiting `open` was cancelled, give up before encoding.
+				if ready_tx.send(Ok(encoder.name().to_string())).is_err() {
+					return;
+				}
+
+				// Encode each request in arrival order. The encoder and its COM /
+				// MFT handles are created, used, and dropped only on this thread.
+				while let Some(req) = req_rx.blocking_recv() {
+					let result = encoder.encode(&req.frame, req.keyframe);
+					let _ = req.resp.send(result);
+				}
+				// `encoder` drops here, on this thread, balancing the COM apartment.
+			});
+
+			match ready_rx.await {
+				Ok(Ok(name)) => Ok(Self {
+					tx: Some(req_tx),
+					handle: Some(handle),
+					name,
+				}),
+				Ok(Err(err)) => Err(err),
+				Err(_) => {
+					let _ = handle.join();
+					Err(Error::Codec(anyhow::anyhow!("encode thread exited before opening")))
+				}
+			}
+		}
+
+		/// The encoder name in use, e.g. `"mediafoundation"`.
+		pub(in crate::encode) fn name(&self) -> &str {
+			&self.name
+		}
+
+		/// Encode one frame, awaiting its packets. The frame is moved to the
+		/// encode thread; the result returns over a oneshot.
+		pub(in crate::encode) async fn encode(&mut self, frame: Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+			let (resp_tx, resp_rx) = oneshot::channel();
+			let req = Request {
+				frame,
+				keyframe,
+				resp: resp_tx,
+			};
+			self.tx.as_ref().ok_or_else(gone)?.send(req).map_err(|_| gone())?;
+			resp_rx.await.map_err(|_| gone())?
+		}
+	}
+
+	impl Drop for Sink {
+		fn drop(&mut self) {
+			// Drop the sender so the thread's `blocking_recv` returns `None` and it
+			// exits, dropping the encoder on its own thread; then join so teardown
+			// (COM uninit) completes before we return. A wedged encode blocking the
+			// thread would stall this join, the same tradeoff as the capture pump.
+			self.tx.take();
+			if let Some(handle) = self.handle.take() {
+				let _ = handle.join();
+			}
+		}
+	}
+
+	fn gone() -> Error {
+		Error::Codec(anyhow::anyhow!("encode thread stopped unexpectedly"))
+	}
+}
+
+#[cfg(target_os = "macos")]
+mod inline {
+	use bytes::Bytes;
+
+	use super::super::encoder::{self, Encoder};
+	use crate::Error;
+	use crate::frame::Frame;
+
+	/// An [`Encoder`] driven inline on the capture task (see the module docs).
+	pub(in crate::encode) struct Sink(Encoder);
+
+	impl Sink {
+		pub(in crate::encode) async fn open(config: &encoder::Config) -> Result<Self, Error> {
+			Ok(Self(Encoder::new(config)?))
+		}
+
+		/// The encoder name in use, e.g. `"videotoolbox"`.
+		pub(in crate::encode) fn name(&self) -> &str {
+			self.0.name()
+		}
+
+		pub(in crate::encode) async fn encode(&mut self, frame: Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+			self.0.encode(&frame, keyframe)
+		}
+	}
+}

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -489,6 +489,12 @@ pub(crate) mod d3d11 {
 			let (cw, ch) = (w / 2, h / 2);
 			let pitch = mapped.RowPitch as usize;
 			let base = mapped.pData as *const u8;
+			// The UV plane begins after the *texture's* Y plane, which spans the
+			// allocated height, not the display height. A DXVA decode pool allocates
+			// textures at the coded size (e.g. 1088 rows for a 1080p display), so
+			// keying the offset off `self.height` would read chroma from inside the
+			// still-luma padding rows and produce garbage color.
+			let tex_height = desc.Height as usize;
 
 			let mut data = vec![0u8; I420::len(self.width, self.height)];
 			let (luma, chroma) = data.split_at_mut(w * h);
@@ -500,8 +506,8 @@ pub(crate) mod d3d11 {
 					ptr::copy_nonoverlapping(base.add(row * pitch), luma[row * w..].as_mut_ptr(), w);
 				}
 			}
-			// Interleaved UV plane sits right after Y at `pitch * h`, h/2 rows.
-			let uv_base = unsafe { base.add(pitch * h) };
+			// Interleaved UV plane sits right after the full Y plane, h/2 rows.
+			let uv_base = unsafe { base.add(pitch * tex_height) };
 			for row in 0..ch {
 				let src = unsafe { uv_base.add(row * pitch) };
 				for col in 0..cw {


### PR DESCRIPTION
Follow-up to #2034, addressing the remaining three `moq-video` capture/encode threading issues from the #1807 async refactor. **Stacked on #2034** — this PR's diff includes #2034's three commits until that lands; review only the two commits titled `refactor(moq-video): run the capture encoder on a dedicated thread` and `fix(moq-video): join the capture pump thread ...`.

## Problem

`capture_loop` encoded **inline on the tokio task**, so the encoder backend was opened, driven, and dropped across whatever workers polled the future. On Windows that broke the Media Foundation MFT:

- **COM thread mismatch:** COM apartments are per-thread, so the `ComGuard` (`CoInitializeEx`/`CoUninitialize`) refcount unbalanced as the future migrated between workers.
- **Worker blocking:** the MFT's blocking event wait (`wait_for_input` → `GetEvent`) parked a tokio worker on a stalled encoder — the Ctrl+C-hang class #1807 was meant to eliminate.
- **`!Send` futures:** the inline encoder (and the capture handle) made `publish_capture` `!Send`, a capability regression for external `tokio::spawn` callers.

## Change

- **`encode::sink::Sink`** (new): off macOS, the encoder runs on a dedicated OS thread (mirroring `capture::pump`) — opened, driven, and dropped all on one thread, with frames sent in and packets returned over channels. Frames are `Send` on Windows (D3D11 textures) and Linux (CPU I420). This balances the COM apartment and keeps the blocking wait off the tokio workers.
- **macOS keeps encoding inline:** VideoToolbox has no COM apartment and doesn't block on an event loop, and its zero-copy `CVPixelBuffer` surface is `!Send`, so a thread would only add a hop it can't take.
- **`publish_capture` is `Send` again off macOS:** the encoder no longer pins the future, and the non-macOS capture guard is a `Send` pump-thread handle (`FrameStream`'s keep-alive is now `Box<dyn Any + Send>` there). A compile-time assertion (`assert_publish_capture_send`) fails the build if the future ever regains a `!Send` component. macOS stays `!Send` (the objc `AVCaptureSession` is `!Send`).
- **Pump cancel-race fix:** `pump::spawn` only wrapped the capture thread's `JoinHandle` in `PumpGuard` *after* awaiting geometry; cancelling `open` during that await detached the thread with the camera LED lit. The guard is now built before the await.
- Updated the stale backend safety comments that referenced a `spawn_blocking` removed in #1807.

## Not covered

- `publish_microphone` (moq-audio) stays `!Send`: `cpal::Stream` is `!Send` and lives in the future. Same class, different crate; left for a follow-up.
- macOS `publish_capture` stays `!Send` (capture session), as above.

## Test plan

- [x] macOS: `cargo clippy -p moq-video --all-targets -- -D warnings` + `cargo test -p moq-video` (20 tests, incl. VideoToolbox encode) green
- [x] Windows cross-compile (`cargo zigbuild --target x86_64-pc-windows-gnu -p moq-video`): threaded MF path + `Send` assertion compile
- [x] Linux cross-compile (`--target x86_64-unknown-linux-gnu --no-default-features`): threaded openh264 path + `Send` assertion compile
- [ ] Runtime on Windows (MFT encode, COM balance, no worker hang) — compile-checked only, no Windows access here
- [ ] Runtime on macOS camera (inline path unchanged) — TCC blocks capture from the agent process

Branch target: `dev` (moq-video changes; see Branch Targeting).

(Written by Claude Opus 4.8)