### PR TITLE
[codex] fix cargo deny config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4518,6 +4518,7 @@ dependencies = [
  "moq-mux",
  "moq-net",
  "moq-vaapi",
+ "nvidia-video-codec-sdk",
  "objc2",
  "objc2-av-foundation",
  "objc2-core-foundation",
@@ -5121,6 +5122,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1e13adea6de269faa0724df58f43f6fe2a81af7094f1dcb8b5b968eb2103cb3"
 dependencies = [
  "scuffle-workspace-hack",
+]
+
+[[package]]
+name = "nvidia-video-codec-sdk"
+version = "0.4.0"
+source = "git+https://github.com/kixelated/nvidia-video-codec-sdk.git?branch=dynamic-loading#5434cc808bd590705217d6e9e00c6dc041f8c0f5"
+dependencies = [
+ "cudarc",
+ "lazy_static",
+ "libloading 0.8.9",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -51,13 +51,11 @@ allow = [
     "BSD-3-Clause",
     "CC0-1.0",
     "CDLA-Permissive-2.0", # webpki-roots cert bundle
-    "IJG", # mozjpeg-sys (MJPEG decode via nokhwa in moq-video)
     "ISC",
     "MIT",
     "MPL-2.0",
     "Unicode-3.0",
     "Unlicense",
-    "WTFPL", # ffmpeg-next, ffmpeg-sys-next
     "Zlib",
 ]
 


### PR DESCRIPTION
## Summary

- remove stale `IJG` and `WTFPL` license allowances that cargo-deny no longer encounters
- refresh `Cargo.lock` with the resolved `nvidia-video-codec-sdk` git patch entry already referenced by `moq-video`

## Why

`cargo deny check licenses` warned about unused license allowances, and the lockfile was missing the git package entry needed to make the all-features deny graph reproducible from checked-in files.

## Validation

- `cargo deny check licenses`
- `cargo deny check`
- `git diff --check`

Targeting `dev` because this worktree is based on `dev`; targeting `main` would include the broader dev staging diff.

(Written by GPT-5)