### PR TITLE
Harden the ts compliance harness from review

### DIFF
--- a/test/ts/compliance.py
+++ b/test/ts/compliance.py
@@ -6,12 +6,12 @@ checks an Integrated Receiver/Decoder cares about and prints a PASS/WARN/FAIL
 summary, exiting non-zero on failure.
 
 Division of labour: TSDuck does the transport-stream parsing (we shell out to
-`tsanalyze --json` for PSI/service/structure and to `tsp -P pcrextract` for the
-PCR/PTS/DTS timeline), and this script does the model math TSDuck does not cover
-directly (PCR jitter/repetition, packet inter-arrival, burstiness, instantaneous
-bitrate, and a transport-buffer model). The only raw-byte work done here is a
-188/204-byte packet-header scan for per-packet PID + PCR, which the timing model
-needs and which pcrextract does not expose per packet.
+`tsanalyze --json` for PSI/service/structure), and this script does the model
+math TSDuck does not cover directly (PCR jitter/repetition, packet
+inter-arrival, burstiness, instantaneous bitrate, and a transport-buffer model).
+The PCR/PTS/DTS timeline the timing model needs comes from a 188/204-byte
+packet-header scan done here, which also gives the per-packet PID that
+`tsp -P pcrextract` does not expose.
 
 Checks split into two severities:
   - HARD (structural): fail the run by default. PAT/PMT, packet size, sync,
@@ -28,7 +28,6 @@ from __future__ import annotations
 
 import argparse
 import bisect
-import csv
 import json
 import subprocess
 import sys
@@ -101,31 +100,6 @@ def run_tsanalyze(ts_path: str) -> dict:
     data = json.loads(proc.stdout)
     data["_stderr"] = proc.stderr
     return data
-
-
-def run_pcrextract(ts_path: str) -> list[dict]:
-    """Return pcrextract rows: {pid, ts_index, type, value} for PCR/PTS/DTS events."""
-    proc = subprocess.run(
-        ["tsp", "-I", "file", ts_path, "-P", "pcrextract", "--pcr", "--pts", "--dts", "-O", "drop"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    rows: list[dict] = []
-    reader = csv.DictReader(proc.stdout.splitlines())
-    for row in reader:
-        try:
-            rows.append(
-                {
-                    "pid": int(row["PID"]),
-                    "ts_index": int(row["Packet index in TS"]),
-                    "type": row["Type"],
-                    "value": int(row["Value"]),
-                }
-            )
-        except (KeyError, ValueError):
-            continue
-    return rows
 
 
 @dataclass

--- a/test/ts/run.sh
+++ b/test/ts/run.sh
@@ -71,8 +71,9 @@ require_tools() {
         have "$t" || missing+=("$t")
     done
     # ffmpeg + cargo are only needed for the round-trip, not for --analyze-only.
+    # pgrep backs kill_tree; without it grandchild tsp/moq processes would leak.
     if [[ -z "$ANALYZE_ONLY" ]]; then
-        for t in cargo ffmpeg curl timeout; do have "$t" || missing+=("$t"); done
+        for t in cargo ffmpeg curl timeout pgrep; do have "$t" || missing+=("$t"); done
     fi
     if [[ ${#missing[@]} -gt 0 ]]; then
         echo "error: missing required tools: ${missing[*]}" >&2
@@ -149,7 +150,10 @@ if [[ -n "$SOURCE" ]]; then
     }
     echo "### cutting ~${DURATION}s from $SOURCE with TSDuck (all PIDs preserved)"
     PKTS=$((DURATION * BITRATE / 8 / 188))
-    tsp -I file "$SOURCE" -P until --packets "$PKTS" -O file "$SRC_TS" 2>/dev/null
+    tsp -I file "$SOURCE" -P until --packets "$PKTS" -O file "$SRC_TS" 2>"$TMP/tsp-cut.log" || {
+        sed 's/^/  tsp: /' "$TMP/tsp-cut.log" >&2 || true
+        exit 1
+    }
 else
     echo "### generating ~${DURATION}s broadcast-like clip with ffmpeg"
     ffmpeg -y -hide_banner -loglevel error \
@@ -187,9 +191,15 @@ sleep 1
 
 # Pace on the source PCR (real media time), not a fixed bitrate: a synthetic clip
 # compresses tiny, so bitrate pacing would rush the whole stream out in a blink.
+# Bounded like the subscriber: if the relay stalls after readiness, `moq import
+# ts` could otherwise block `wait "$PUB_PID"` forever. tsp/moq stderr lands in
+# pub.log, which the empty-capture handler below dumps on failure.
 echo "### publishing PCR-paced TS -> $BROADCAST"
-(tsp -I file "$SRC_TS" -P regulate --pcr-synchronous 2>/dev/null |
-    "$MOQ" --client-connect "$URL" --broadcast "$BROADCAST" import ts) >"$TMP/pub.log" 2>&1 &
+# shellcheck disable=SC2016  # $1..$4 are the child bash -c positionals, not ours.
+timeout -k 3 $((DURATION + 20)) bash -c '
+    tsp -I file "$1" -P regulate --pcr-synchronous |
+        "$2" --client-connect "$3" --broadcast "$4" import ts
+' _ "$SRC_TS" "$MOQ" "$URL" "$BROADCAST" >"$TMP/pub.log" 2>&1 &
 PUB_PID=$!
 
 wait "$PUB_PID" 2>/dev/null || true


### PR DESCRIPTION
Follow-up to #2011, which landed the TS/IRD compliance harness (originally @t0ms's #2024). CodeRabbit's review of #2011 raised several findings against the harness; this addresses the ones worth acting on.

## Changes

- **Remove dead code + fix the docstring** (`compliance.py`). `run_pcrextract` was defined but never called, and `csv` was imported only to serve it. The module docstring also claimed the PCR/PTS/DTS timeline comes from `tsp -P pcrextract`, when it actually comes from the raw 188/204-byte header scan. Dropped the function and the import, and corrected the docstring. No behavior change.
- **Bound the publisher pipeline** (`run.sh`). The subscriber capture was already wrapped in `timeout`, but the `tsp | moq import ts` publisher was not, so a relay that stalled after readiness could block `wait "$PUB_PID"` indefinitely (only the outer CI job timeout would eventually catch it). It's now wrapped in the same `timeout -k 3 $((DURATION + 20))` bound, and `tsp`/`moq` stderr flows into `pub.log` (previously `tsp` stderr went to `/dev/null`), which the empty-capture handler already dumps on failure.
- **Require `pgrep` in round-trip mode** (`run.sh`). `kill_tree` relies on `pgrep` to reap grandchild `tsp`/`moq` processes; it's now in the round-trip tool check so a missing `pgrep` fails loudly instead of silently leaking orphans.

Skipped, with reasons, from the same review: the fixed `sleep 1` before the publisher (the subscriber-first ordering is deliberate and the duration-fidelity band tolerates a little lead loss), and the note about the smoke job's total runtime (operational, no change needed yet).

## Test plan

- [x] `compliance.py` `py_compile` clean; regression-checked that `run_pcrextract`/`csv` are gone and the packet scan + `duration-fidelity` checks still behave.
- [x] `run.sh` `shfmt`/`shellcheck`/`bash -n` clean; verified the `bash -c '... "$1" ...' _ "$SRC_TS" ...` form passes its positionals correctly.
- [ ] Full `just test ts` under real TSDuck runs in the smoke job (no TSDuck in the dev sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEdezKF9idvnjCPfMLsob5)_