### PR TITLE
Default moq-watch visible margin to 20% instead of 0px

### DIFF
--- a/js/watch/README.md
+++ b/js/watch/README.md
@@ -70,7 +70,7 @@ The simplest way to watch a stream:
 | `name`    | string                              | required | Broadcast name/path                      |
 | `paused`  | boolean                             | false    | Pause playback                           |
 | `muted`   | boolean                             | false    | Mute audio                               |
-| `visible` | never, distance, or always          | `0px`    | When to download video (see below)       |
+| `visible` | never, distance, or always          | `20%`    | When to download video (see below)       |
 | `volume`  | number                              | 0.5      | Audio volume (0-1)                       |
 | `reload`  | boolean                             | true     | Wait for (re)announcement before subscribing. Defaults off for `mediaoverquic.com` relays until they support broadcast discovery. |
 
@@ -79,8 +79,8 @@ position relative to the viewport:
 
 - `never`: never download video.
 - a distance (`0px`, `200px`, `100%`, ...): download while the canvas is within that distance
-  of the viewport **and** the tab is visible. `0px` (the default) means strictly on screen; a
-  larger distance pre-warms the video before it scrolls into view.
+  of the viewport **and** the tab is visible. `0px` means strictly on screen; a larger distance
+  (`20%`, the default) pre-warms the video before it scrolls into view.
 - `always`: always download video, regardless of the canvas position or tab visibility.
 
 Only the distance mode suspends video while the tab is hidden; `always` keeps downloading.

--- a/js/watch/src/backend.ts
+++ b/js/watch/src/backend.ts
@@ -144,7 +144,7 @@ export class MultiBackend implements Backend {
 		this.audio = new AudioBackend(this.#audioSource);
 
 		this.paused = Signal.from(props?.paused ?? false);
-		this.visible = Signal.from(props?.visible ?? "0px");
+		this.visible = Signal.from(props?.visible ?? "20%");
 
 		this.signals.run(this.#runElement.bind(this));
 	}

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -23,17 +23,17 @@ const OBSERVED = [
 ] as const;
 type Observed = (typeof OBSERVED)[number];
 
-// Parse the `visible` attribute into a Visible value, falling back to "0px" (on screen only).
+// Parse the `visible` attribute into a Visible value, falling back to "20%".
 function parseVisible(value: string | null): Visible {
 	const trimmed = value?.trim();
-	if (!trimmed) return "0px";
+	if (!trimmed) return "20%";
 	if (trimmed === "never" || trimmed === "always") return trimmed;
 	// A CSS length usable as an IntersectionObserver rootMargin (px or %).
 	if (/^-?\d+(\.\d+)?(px|%)$/.test(trimmed)) return trimmed;
 	// Allow a bare number as a px convenience (e.g. visible="200").
 	if (/^-?\d+(\.\d+)?$/.test(trimmed)) return `${trimmed}px`;
 	console.warn(`moq-watch: invalid visible="${value}", expected "never", "always", or a CSS length like "200px"`);
-	return "0px";
+	return "20%";
 }
 
 function parseBoolean(value: string | null, defaultValue: boolean): boolean {

--- a/js/watch/src/video/renderer.ts
+++ b/js/watch/src/video/renderer.ts
@@ -23,7 +23,7 @@ export type RendererProps = {
 	canvas?: HTMLCanvasElement | Signal<HTMLCanvasElement | undefined>;
 	/** Whether playback is paused; when paused only a single preview frame is fetched. */
 	paused?: boolean | Signal<boolean>;
-	/** When video is downloaded relative to the canvas position. See {@link Visible}. Defaults to `"0px"`. */
+	/** When video is downloaded relative to the canvas position. See {@link Visible}. Defaults to `"20%"`. */
 	visible?: Visible | Signal<Visible>;
 };
 
@@ -55,7 +55,7 @@ export class Renderer {
 		this.decoder = decoder;
 		this.canvas = Signal.from(props?.canvas);
 		this.paused = Signal.from(props?.paused ?? false);
-		this.visible = Signal.from(props?.visible ?? "0px");
+		this.visible = Signal.from(props?.visible ?? "20%");
 
 		this.#signals.run((effect) => {
 			const canvas = effect.get(this.canvas);


### PR DESCRIPTION
## Summary

Changes the default `visible` margin in `@moq/watch` from `"0px"` to `"20%"`.

The previous `"0px"` default only downloaded video while the canvas was strictly on screen, so scrolling a video into view meant the download started from cold. `"20%"` pre-warms the video just before it scrolls in, which feels less aggressive without keeping off-screen video downloading indefinitely.

`"20%"` is a valid `IntersectionObserver` `rootMargin`, so it flows through the existing parsing/observer path unchanged.

## Changes

- `renderer.ts` — underlying `Renderer` default + doc comment
- `backend.ts` — backend default
- `element.ts` — `<moq-watch>` attribute fallback (empty and invalid input both fall back to `"20%"`)
- `README.md` — attribute table + prose

## Test plan

- [ ] Existing behavior unchanged for explicit `visible` values (`never`, `always`, a CSS length)
- [ ] Default pre-warms video ~20% before it scrolls into the viewport

(Written by Claude Opus 4.8)