### PR TITLE
[codex] fix Swift and Kotlin packaging checks

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -8,6 +8,8 @@
 #   release.sh git-tag-exists <repo> <tag>     — check whether a tag exists on a remote repo
 #   release.sh read-version <pyproject.toml>   — read `version = "x.y.z"` from a manifest
 #   release.sh pypi-exists <dist> <version>    — check whether <dist>==<version> is already on PyPI
+#   release.sh maven-exists <group> <artifact> <version>
+#   release.sh maven-version-in-range <group> <artifact> <range>
 #
 # Environment:
 #   GITHUB_REF        — set by GitHub Actions (e.g. refs/tags/moq-relay-v1.2.3)
@@ -156,6 +158,148 @@ pypi_exists() {
     echo "PyPI ${dist}==${version}: exists=${exists}"
 }
 
+maven_path() {
+    local group="$1"
+    local artifact="$2"
+    echo "${group//.//}/${artifact}"
+}
+
+maven_status() {
+    local url="$1"
+    local output="${2:-/dev/null}"
+
+    curl -s -o "$output" -w '%{http_code}' --max-time 10 --retry 3 --retry-connrefused "$url" 2>/dev/null || true
+}
+
+maven_emit_exists() {
+    local exists="$1"
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        echo "exists=${exists}" >>"$GITHUB_OUTPUT"
+    fi
+}
+
+# Check whether a Maven Central artifact version exists. Writes
+# exists=true|false to $GITHUB_OUTPUT. A 404 means unpublished; any other
+# non-200 status is fatal so an outage does not look like a fresh version.
+maven_exists() {
+    local group="$1"
+    local artifact="$2"
+    local version="$3"
+    local path
+    path=$(maven_path "$group" "$artifact")
+    local url="https://repo1.maven.org/maven2/${path}/${version}/${artifact}-${version}.pom"
+
+    local code
+    code=$(maven_status "$url")
+
+    local exists
+    case "$code" in
+        200) exists=true ;;
+        404) exists=false ;;
+        *)
+            echo "Unexpected status $code querying $url" >&2
+            exit 1
+            ;;
+    esac
+
+    maven_emit_exists "$exists"
+    echo "Maven ${group}:${artifact}:${version}: exists=${exists}"
+}
+
+semver_key() {
+    local version="${1%%[-+]*}"
+    local major minor patch
+    IFS=. read -r major minor patch <<<"$version"
+    printf '%06d%06d%06d\n' "${major:-0}" "${minor:-0}" "${patch:-0}"
+}
+
+semver_ge() {
+    [[ "$(semver_key "$1")" > "$(semver_key "$2")" || "$(semver_key "$1")" == "$(semver_key "$2")" ]]
+}
+
+semver_gt() {
+    [[ "$(semver_key "$1")" > "$(semver_key "$2")" ]]
+}
+
+semver_le() {
+    [[ "$(semver_key "$1")" < "$(semver_key "$2")" || "$(semver_key "$1")" == "$(semver_key "$2")" ]]
+}
+
+semver_lt() {
+    [[ "$(semver_key "$1")" < "$(semver_key "$2")" ]]
+}
+
+version_in_range() {
+    local version="$1"
+    local range="$2"
+
+    if [[ ! "$range" =~ ^([\[\(])([^,]+),([^\]\)]+)([\]\)])$ ]]; then
+        echo "Unsupported Maven version range: $range" >&2
+        exit 1
+    fi
+
+    local lower_bound="${BASH_REMATCH[1]}"
+    local lower="${BASH_REMATCH[2]}"
+    local upper="${BASH_REMATCH[3]}"
+    local upper_bound="${BASH_REMATCH[4]}"
+
+    if [[ "$lower_bound" == "[" ]]; then
+        semver_ge "$version" "$lower" || return 1
+    else
+        semver_gt "$version" "$lower" || return 1
+    fi
+
+    if [[ "$upper_bound" == "]" ]]; then
+        semver_le "$version" "$upper" || return 1
+    else
+        semver_lt "$version" "$upper" || return 1
+    fi
+}
+
+# Check whether Maven Central metadata contains any version in a Gradle-style
+# half-open range such as [0.3,0.4). Writes exists=true|false to $GITHUB_OUTPUT.
+maven_version_in_range() {
+    local group="$1"
+    local artifact="$2"
+    local range="$3"
+    local path
+    path=$(maven_path "$group" "$artifact")
+    local url="https://repo1.maven.org/maven2/${path}/maven-metadata.xml"
+
+    local body
+    body=$(mktemp)
+
+    local code
+    code=$(maven_status "$url" "$body")
+
+    case "$code" in
+        200) ;;
+        404)
+            maven_emit_exists false
+            echo "Maven ${group}:${artifact} has version in ${range}: exists=false"
+            rm -f "$body"
+            return
+            ;;
+        *)
+            echo "Unexpected status $code querying $url" >&2
+            exit 1
+            ;;
+    esac
+
+    local exists=false
+    local version
+    while IFS= read -r version; do
+        if version_in_range "$version" "$range"; then
+            exists=true
+            break
+        fi
+    done < <(grep -oE '<version>[^<]+</version>' "$body" | sed 's#</\?version>##g')
+
+    rm -f "$body"
+    maven_emit_exists "$exists"
+    echo "Maven ${group}:${artifact} has version in ${range}: exists=${exists}"
+}
+
 # Dispatch subcommands
 case "${1:-}" in
     parse-version) parse_version "$2" ;;
@@ -164,8 +308,10 @@ case "${1:-}" in
     git-tag-exists) git_tag_exists "$2" "$3" ;;
     read-version) read_version "$2" ;;
     pypi-exists) pypi_exists "$2" "$3" ;;
+    maven-exists) maven_exists "$2" "$3" "$4" ;;
+    maven-version-in-range) maven_version_in_range "$2" "$3" "$4" ;;
     *)
-        echo "Usage: $0 {parse-version|prev-tag|create|git-tag-exists|read-version|pypi-exists} <args>" >&2
+        echo "Usage: $0 {parse-version|prev-tag|create|git-tag-exists|read-version|pypi-exists|maven-exists|maven-version-in-range} <args>" >&2
         exit 1
         ;;
 esac

--- a/.github/workflows/release-kt-ffi.yml
+++ b/.github/workflows/release-kt-ffi.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-kt
+  group: release-kt-ffi
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release-kt-lib.yml
+++ b/.github/workflows/release-kt-lib.yml
@@ -25,6 +25,7 @@ on:
       - "kt/build.gradle.kts"
       - "kt/settings.gradle.kts"
       - ".github/workflows/release-kt-lib.yml"
+      - ".github/scripts/release.sh"
   pull_request:
     paths:
       - "kt/moq/**"
@@ -32,6 +33,7 @@ on:
       - "kt/build.gradle.kts"
       - "kt/settings.gradle.kts"
       - ".github/workflows/release-kt-lib.yml"
+      - ".github/scripts/release.sh"
       - "rs/moq-ffi/build.sh"
   # Manual trigger so a wrapper bump can be published once the bindings it
   # depends on land on Maven Central (the guard below skips otherwise).
@@ -49,16 +51,16 @@ jobs:
     name: Check version
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.probe.outputs.version }}
-      should_publish: ${{ steps.probe.outputs.should_publish }}
+      version: ${{ steps.version.outputs.version }}
+      should_publish: ${{ steps.decide.outputs.should_publish }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
-      - name: Read moq.version and probe Maven Central
-        id: probe
+      - name: Read moq.version
+        id: version
         run: |
           VERSION=$(sed -n 's/^moq\.version=//p' kt/gradle.properties | head -1)
           if [[ -z "$VERSION" ]]; then
@@ -67,25 +69,36 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-          # Already published? HEAD the POM; 200 means this version exists.
-          POM_URL="https://repo1.maven.org/maven2/dev/moq/moq/${VERSION}/moq-${VERSION}.pom"
-          if curl -sfI "$POM_URL" >/dev/null 2>&1; then
+      - name: Check wrapper publication
+        id: wrapper
+        run: .github/scripts/release.sh maven-exists dev.moq moq "${{ steps.version.outputs.version }}"
+
+      - name: Check bindings publication
+        id: bindings
+        if: steps.wrapper.outputs.exists != 'true'
+        run: .github/scripts/release.sh maven-version-in-range dev.moq moq-ffi "[0.3,0.4)"
+
+      - name: Decide publish
+        id: decide
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          if [[ "${{ steps.wrapper.outputs.exists }}" == "true" ]]; then
             echo "dev.moq:moq:${VERSION} already on Maven Central; nothing to publish."
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # Bindings guard: the wrapper POM declares dev.moq:moq-ffi:[0.2,0.3),
+          # Bindings guard: the wrapper POM declares dev.moq:moq-ffi:[0.3,0.4),
           # so don't publish a wrapper that consumers can't resolve. Require a
-          # 0.2.x bindings release to exist first (it's published separately by
-          # release-kt-ffi.yml on a moq-ffi-v* tag). Re-run via workflow_dispatch
-          # once it lands.
-          FFI_META="https://repo1.maven.org/maven2/dev/moq/moq-ffi/maven-metadata.xml"
-          if curl -sf "$FFI_META" 2>/dev/null | grep -q "<version>0\.2\."; then
+          # compatible bindings release to exist first (it's published separately
+          # by release-kt-ffi.yml on a moq-ffi-v* tag). Re-run via
+          # workflow_dispatch once it lands.
+          if [[ "${{ steps.bindings.outputs.exists }}" == "true" ]]; then
             echo "dev.moq:moq:${VERSION} not published yet; bindings available; will publish."
             echo "should_publish=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::dev.moq:moq-ffi has no 0.2.x release on Maven Central yet; skipping wrapper publish until the bindings land (then re-run this workflow)."
+            echo "::warning::dev.moq:moq-ffi has no [0.3,0.4) release on Maven Central yet; skipping wrapper publish until the bindings land (then re-run this workflow)."
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,0 +1,42 @@
+name: Swift
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    # `closed` is here only so merging/closing a PR cancels its in-flight run
+    # via the concurrency group below; the job itself is skipped on close.
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - "swift/**"
+      - "rs/moq-ffi/**"
+      - ".github/workflows/swift.yml"
+
+concurrency:
+  group: swift-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Swift
+    if: github.event.action != 'closed'
+    runs-on: macos-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
+
+      - name: Swift check
+        run: ./swift/scripts/check.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Top-level layout only. Per-crate and per-package detail lives in the nested guid
 
 ## Language Bindings
 
-`rs/moq-ffi` is the single UniFFI core that every non-Rust binding is generated from. The wrappers under `/py`, `/swift`, `/kt`, and `/go` are thin layers over it, and `rs/libmoq` exposes the same core as a C staticlib. So one `moq-ffi` change ripples out to all of them (and their docs) per the [Cross-Package Sync](#cross-package-sync) table. CI mirrors the `swift`/`kt`/`go` source skeletons to `moq-dev/moq-{swift,kotlin,go}` on each `moq-ffi-v*` tag. For Python, most callers want the ergonomic `moq-rs` wrapper rather than the generated `moq-ffi` bindings directly.
+`rs/moq-ffi` is the single UniFFI core that every non-Rust binding is generated from. The wrappers under `/py`, `/swift`, `/kt`, and `/go` are thin layers over it, and `rs/libmoq` exposes the same core as a C staticlib. So one `moq-ffi` change ripples out to all of them (and their docs) per the [Cross-Package Sync](#cross-package-sync) table. CI mirrors the Swift and Go source packages to their external repos; Kotlin publishes `dev.moq:*` artifacts to Maven Central. For Python, most callers want the ergonomic `moq-rs` wrapper rather than the generated `moq-ffi` bindings directly.
 
 ## Per-Directory Guides
 
@@ -60,7 +60,7 @@ Language-specific conventions, crate/package maps, and patterns live in nested `
 - **`js/CLAUDE.md`** - TypeScript/JS workspace: package map, the signals + Effect reactivity model and its lifecycle rules, Web Components UI, `bun`/Biome tooling.
 - **`py/CLAUDE.md`** - Python wrappers: the `moq-ffi` (generated bindings) vs `moq-rs` (ergonomic) split and the `moq` public surface.
 
-The `swift/`, `kt/`, and `go/` directories are thin wrappers over `rs/moq-ffi` (mirrored to external repos); see each directory's `README.md` rather than a dedicated guide.
+The `swift/`, `kt/`, and `go/` directories are thin wrappers over `rs/moq-ffi`; see each directory's `README.md` rather than a dedicated guide.
 
 This root file holds only cross-cutting rules that apply everywhere (writing style, branch targeting, cross-package sync, public-API scrutiny, comment/doc conventions).
 

--- a/kt/README.md
+++ b/kt/README.md
@@ -19,7 +19,7 @@ dependencies {
 }
 ```
 
-The wrapper's POM declares `dev.moq:moq-ffi:[0.2,0.3)`, so Gradle resolves the latest `0.2.x` bindings automatically. Pin `dev.moq:moq-ffi` yourself if you need a reproducible bindings version.
+The wrapper's POM declares `dev.moq:moq-ffi:[0.3,0.4)`, so Gradle resolves the latest `0.3.x` bindings automatically. Pin `dev.moq:moq-ffi` yourself if you need a reproducible bindings version.
 
 ## Quick start
 

--- a/kt/gradle.properties
+++ b/kt/gradle.properties
@@ -13,7 +13,7 @@ moqffi.version=0.0.0-dev
 
 # Wrapper (`dev.moq:moq`) version. Source of truth, bumped by hand. Independent
 # of the crate: release-kt-lib.yml publishes a new version only when this
-# changes. Must stay >= the last published wrapper version (0.2.17 era).
+# changes. Must stay >= the last published wrapper version.
 moq.version=0.3.0
 
 # Publishing is disabled by default. CI flips this when MAVEN_CENTRAL_USERNAME

--- a/kt/scripts/check.sh
+++ b/kt/scripts/check.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 # layout of the :moq-ffi KMP module, regenerates the bindings, and runs
 # `:moq-ffi:jvmTest` (raw bindings) + `:moq:jvmTest` (the wrapper, which
 # resolves :moq-ffi via the sibling-project substitution). Intended for
-# `just check-ffi`.
+# `just kt check`.
 #
 # Skipped cleanly on hosts without `java` or `cargo`.
 

--- a/swift/README.md
+++ b/swift/README.md
@@ -66,7 +66,7 @@ Every consumer conforms to `AsyncSequence`, so `for try await x in consumer` wor
 
 ## Local development
 
-`swift/scripts/check.sh` builds `moq-ffi` for the host, regenerates the UniFFI Swift bindings, builds a single-slice `MoqFFI.xcframework`, and runs `swift test`. Requires macOS with `xcodebuild` and `swift` on `$PATH`. Invoked by `just check-ffi`; skips cleanly on non-macOS hosts.
+`swift/scripts/check.sh` builds `moq-ffi` for the host, regenerates the UniFFI Swift bindings, builds a single-slice `MoqFFI.xcframework`, and runs `swift test`. Requires macOS with `xcodebuild` and `swift` on `$PATH`. Run via `just swift check`; skips cleanly on non-macOS hosts.
 
 Local development uses one **monolithic** `Package.swift` containing both the `Moq` and `MoqFFI` targets plus the path-based XCFramework, so `swift test` and Xcode work against a single package. The split into two packages exists only in the released artifacts, assembled from the two templates below at release time. Because the FFI module is named `MoqFFI` in both layouts, the wrapper sources (`import MoqFFI`) compile identically either way.
 

--- a/swift/justfile
+++ b/swift/justfile
@@ -14,14 +14,14 @@ default:
 check:
     bash scripts/check.sh
 
-# Assemble the XCFramework + Package.swift from per-target moq-ffi
-# binaries + bindings. Used by .github/workflows/release-swift.yml; see
+# Assemble the released wrapper package from Package.swift.template.
 
-# swift/README.md for the expected --lib-dir layout.
+# Used by .github/workflows/release-swift-lib.yml.
 package *args:
     bash scripts/package.sh {{ args }}
 
 # Remove SwiftPM build output plus the XCFramework and generated bindings
+
 # that scripts/check.sh lays down (see swift/.gitignore).
 clean:
     rm -rf .build .swiftpm Package.resolved Sources/MoqFFI/Generated.swift MoqFFI.xcframework

--- a/swift/scripts/check.sh
+++ b/swift/scripts/check.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # macOS target, lays out a local XCFramework, and runs `swift test`.
 #
 # Skipped on hosts without `swift` (Linux dev environments) or without
-# `cargo`. Intended for `just check-ffi`.
+# `cargo`. Intended for `just swift check`.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SWIFT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"


### PR DESCRIPTION
## Summary

- Move Kotlin Maven Central publication probes into the shared release helper, including fatal handling for unexpected Maven status codes.
- Update the Kotlin wrapper release guard to the current `[0.3,0.4)` bindings range and rename the stale Kotlin FFI concurrency group.
- Add Swift PR compile coverage on macOS when Swift or `rs/moq-ffi` changes, and clean up stale Swift/Kotlin packaging docs and comments.

## Validation

- `bash -n .github/scripts/release.sh swift/scripts/check.sh kt/scripts/check.sh`
- `just --fmt --unstable --check --justfile swift/justfile`
- `git diff --check`

`shfmt`, `shellcheck`, and `actionlint` were not installed locally, so those checks were not run here.

(Written by GPT-5)