### PR TITLE
[codex] Future-proof moq-net metadata structs

### DIFF
--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -72,10 +72,7 @@ async fn run_subscribe(mut consumer: moq_net::OriginConsumer) -> anyhow::Result<
 	);
 
 	// Subscribe to the video track.
-	let track = moq_net::Track {
-		name: name.clone(),
-		priority: 1,
-	};
+	let track = moq_net::Track::new(name.clone()).with_priority(1);
 
 	let track_consumer = broadcast.subscribe_track(&track)?;
 	let mut ordered = moq_mux::container::Consumer::new(track_consumer, moq_mux::catalog::hang::Container::Legacy)

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -41,10 +41,7 @@ async fn run_session(origin: moq_net::OriginConsumer) -> anyhow::Result<()> {
 // The catalog can contain multiple tracks, used by the viewer to choose the best track.
 fn create_track(broadcast: &mut moq_net::BroadcastProducer) -> anyhow::Result<moq_net::TrackProducer> {
 	// Basic information about the video track.
-	let video_track = moq_net::Track {
-		name: "video".to_string(),
-		priority: 1, // Video typically has lower priority than audio
-	};
+	let video_track = moq_net::Track::new("video").with_priority(1);
 
 	// Example video configuration
 	// In a real application, you would get this from the encoder

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -76,18 +76,12 @@ impl Catalog {
 	}
 
 	pub fn default_track() -> moq_net::Track {
-		moq_net::Track {
-			name: Catalog::DEFAULT_NAME.to_string(),
-			priority: 100,
-		}
+		moq_net::Track::new(Catalog::DEFAULT_NAME).with_priority(100)
 	}
 
 	/// The track carrying the DEFLATE-compressed catalog ([`COMPRESSED_NAME`](Self::COMPRESSED_NAME)).
 	pub fn compressed_track() -> moq_net::Track {
-		moq_net::Track {
-			name: Catalog::COMPRESSED_NAME.to_string(),
-			priority: 100,
-		}
+		moq_net::Track::new(Catalog::COMPRESSED_NAME).with_priority(100)
 	}
 }
 

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -260,10 +260,9 @@ impl Consume {
 		// (e.g. ffmpeg moqenc, browser @moq/publish) are misread as raw frames.
 		let container = moq_mux::catalog::hang::Container::try_from(&config.container)?;
 
-		let track = consume.broadcast.subscribe_track(&moq_net::Track {
-			name: rendition.clone(),
-			priority: 1, // TODO: Remove priority
-		})?;
+		let track = consume
+			.broadcast
+			.subscribe_track(&moq_net::Track::new(rendition.clone()).with_priority(1))?;
 		let track = moq_mux::container::Consumer::new(track, container).with_latency(latency);
 
 		let channel = oneshot::channel();
@@ -305,10 +304,9 @@ impl Consume {
 
 		let container = moq_mux::catalog::hang::Container::try_from(&config.container)?;
 
-		let track = consume.broadcast.subscribe_track(&moq_net::Track {
-			name: rendition.clone(),
-			priority: 2, // TODO: Remove priority
-		})?;
+		let track = consume
+			.broadcast
+			.subscribe_track(&moq_net::Track::new(rendition.clone()).with_priority(2))?;
 		let track = moq_mux::container::Consumer::new(track, container).with_latency(latency);
 
 		let channel = oneshot::channel();
@@ -402,10 +400,7 @@ impl Consume {
 	/// in arrival order. Frames must be released with [`Self::raw_frame_close`].
 	pub fn raw_track(&mut self, broadcast: Id, name: &str, on_frame: OnStatus) -> Result<Id, Error> {
 		let broadcast = self.broadcast.get(broadcast).ok_or(Error::BroadcastNotFound)?;
-		let track = broadcast.subscribe_track(&moq_net::Track {
-			name: name.to_string(),
-			priority: 0,
-		})?;
+		let track = broadcast.subscribe_track(&moq_net::Track::new(name))?;
 
 		let channel = oneshot::channel();
 		let entry = TaskEntry {

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -171,10 +171,7 @@ impl Publish {
 	/// if you want to describe the track in the catalog as well.
 	pub fn track(&mut self, broadcast: Id, name: &str) -> Result<Id, Error> {
 		let (broadcast, _) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
-		let track = broadcast.create_track(moq_net::Track {
-			name: name.to_string(),
-			priority: 0,
-		})?;
+		let track = broadcast.create_track(moq_net::Track::new(name))?;
 		self.tracks.insert(track)
 	}
 

--- a/rs/moq-audio/src/consumer.rs
+++ b/rs/moq-audio/src/consumer.rs
@@ -53,7 +53,7 @@ impl AudioConsumer {
 		};
 
 		let name = name.into();
-		let track = broadcast.subscribe_track(&moq_net::Track { name, priority: 0 })?;
+		let track = broadcast.subscribe_track(&moq_net::Track::new(name))?;
 		let mut track = moq_mux::container::Consumer::new(track, moq_mux::container::legacy::Wire);
 		if let Some(latency) = output.latency_max {
 			track = track.with_latency(latency);

--- a/rs/moq-audio/src/producer.rs
+++ b/rs/moq-audio/src/producer.rs
@@ -62,10 +62,7 @@ impl<E: moq_mux::catalog::hang::CatalogExt> AudioProducer<E> {
 		};
 
 		let name = name.into();
-		let track = broadcast.create_track(moq_net::Track {
-			name: name.clone(),
-			priority: 0,
-		})?;
+		let track = broadcast.create_track(moq_net::Track::new(name.clone()))?;
 		let track = moq_mux::container::Producer::new(track, moq_mux::container::legacy::Wire);
 
 		let mut catalog_mut = catalog.clone();
@@ -220,12 +217,7 @@ mod tests {
 		let mut producer =
 			AudioProducer::new(&mut broadcast, catalog, "audio", input, EncoderOutput::default()).unwrap();
 
-		let track = consumer
-			.subscribe_track(&moq_net::Track {
-				name: "audio".into(),
-				priority: 0,
-			})
-			.unwrap();
+		let track = consumer.subscribe_track(&moq_net::Track::new("audio")).unwrap();
 		let mut reader = moq_mux::container::Consumer::new(track, moq_mux::container::legacy::Wire);
 
 		let mut pts = Vec::new();

--- a/rs/moq-boy/src/input.rs
+++ b/rs/moq-boy/src/input.rs
@@ -99,10 +99,7 @@ async fn handle_viewer_commands(
 	broadcast: moq_net::BroadcastConsumer,
 	cmd_tx: &tokio::sync::mpsc::Sender<Command>,
 ) -> anyhow::Result<()> {
-	let command_track = moq_net::Track {
-		name: "command".to_string(),
-		priority: 0,
-	};
+	let command_track = moq_net::Track::new("command");
 
 	let track = broadcast.subscribe_track(&command_track)?;
 	let mut commands = moq_json::Consumer::<RawCommand>::new(track, moq_json::ConsumerConfig::default());

--- a/rs/moq-boy/src/status.rs
+++ b/rs/moq-boy/src/status.rs
@@ -40,10 +40,7 @@ pub struct StatusPublisher {
 
 impl StatusPublisher {
 	pub fn new(broadcast: &mut moq_net::BroadcastProducer) -> anyhow::Result<Self> {
-		let track = moq_net::Track {
-			name: "status".to_string(),
-			priority: 10,
-		};
+		let track = moq_net::Track::new("status").with_priority(10);
 		let producer = broadcast.create_track(track)?;
 
 		Ok(Self {

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -95,7 +95,7 @@ impl MoqBroadcastConsumer {
 	/// Frames are returned as plain byte payloads with no codec or container parsing.
 	pub fn subscribe_track(&self, name: String) -> Result<Arc<MoqTrackConsumer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		let track = self.inner.subscribe_track(&moq_net::Track { name, priority: 0 })?;
+		let track = self.inner.subscribe_track(&moq_net::Track::new(name))?;
 		Ok(Arc::new(MoqTrackConsumer::new(track)))
 	}
 
@@ -116,7 +116,7 @@ impl MoqBroadcastConsumer {
 		let media: moq_mux::catalog::hang::Container = (&container)
 			.try_into()
 			.map_err(|e| MoqError::Codec(format!("invalid container: {e}")))?;
-		let track = self.inner.subscribe_track(&moq_net::Track { name, priority: 0 })?;
+		let track = self.inner.subscribe_track(&moq_net::Track::new(name))?;
 		let latency = std::time::Duration::from_millis(max_latency_ms);
 		let consumer = moq_mux::container::Consumer::new(track, media).with_latency(latency);
 		Ok(Arc::new(MoqMediaConsumer {

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -281,7 +281,7 @@ impl MoqBroadcastProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
-		let track = moq_net::Track { name, priority: 0 };
+		let track = moq_net::Track::new(name);
 		// Clone the broadcast handle (shared Arc internally) to get &mut access.
 		let mut broadcast = state.broadcast.clone();
 		let producer = broadcast.create_track(track)?;

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -63,15 +63,9 @@ impl<E: CatalogExt> Producer<E> {
 		broadcast: &mut moq_net::BroadcastProducer,
 		catalog: Catalog<E>,
 	) -> Result<Self, moq_net::Error> {
-		let hang_track = broadcast.create_track(moq_net::Track {
-			name: hang::Catalog::DEFAULT_NAME.to_string(),
-			priority: 0,
-		})?;
+		let hang_track = broadcast.create_track(moq_net::Track::new(hang::Catalog::DEFAULT_NAME))?;
 		let hangz_track = broadcast.create_track(hang::Catalog::compressed_track())?;
-		let msf_track = broadcast.create_track(moq_net::Track {
-			name: moq_msf::DEFAULT_NAME.to_string(),
-			priority: 0,
-		})?;
+		let msf_track = broadcast.create_track(moq_net::Track::new(moq_msf::DEFAULT_NAME))?;
 
 		// Disable deltas for now to stay byte-compatible with consumers that only read snapshots.
 		let mut json_config = moq_json::ProducerConfig::default();

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -41,10 +41,7 @@ async fn run_broadcast(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 
 	// Create a track that we'll insert into the broadcast.
 	// A track is a series of groups representing a live stream.
-	let mut track = broadcast.create_track(moq_net::Track {
-		name: "chat".to_string(),
-		priority: 0,
-	})?;
+	let mut track = broadcast.create_track(moq_net::Track::new("chat"))?;
 
 	// NOTE: The path is empty because we're using the URL to scope the broadcast.
 	// If you put "alice" here, it would be published as "anon/chat-example/alice".

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -60,10 +60,7 @@ async fn main() -> anyhow::Result<()> {
 
 	tracing::info!(url = ?config.url, "connecting to server");
 
-	let track = Track {
-		name: config.track,
-		priority: 0,
-	};
+	let track = Track::new(config.track);
 
 	let origin = moq_net::Origin::random().produce();
 

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -12,6 +12,7 @@ use super::{OriginList, Track};
 ///
 /// Create via [`Broadcast::produce`] to obtain both [`BroadcastProducer`] and [`BroadcastConsumer`] pair.
 #[derive(Clone, Debug, Default)]
+#[non_exhaustive]
 pub struct Broadcast {
 	/// The chain of origins the broadcast has traversed. Each relay appends its own
 	/// [`crate::Origin`] when forwarding, so the list is used for loop detection and

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -29,6 +29,7 @@ const MAX_GROUP_AGE: Duration = Duration::from_secs(5);
 /// A track is a collection of groups, delivered out-of-order until expired.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub struct Track {
 	/// Identifier within a broadcast. Unique per [`crate::Broadcast`].
 	pub name: String,
@@ -43,6 +44,12 @@ impl Track {
 			name: name.into(),
 			priority: 0,
 		}
+	}
+
+	/// Set the delivery priority, returning `self` for chaining.
+	pub fn with_priority(mut self, priority: u8) -> Self {
+		self.priority = priority;
+		self
 	}
 
 	/// Consume this [`Track`] to create a producer that owns its metadata.

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -563,10 +563,7 @@ async fn serve_fetch(
 
 	tracing::info!(%broadcast, %track, "fetching track");
 
-	let track = moq_net::Track {
-		name: track,
-		priority: 0,
-	};
+	let track = moq_net::Track::new(track);
 
 	let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_secs(30);
 


### PR DESCRIPTION
Summary
- Add #[non_exhaustive] to the current moq-net public metadata structs Broadcast and Track.
- Add Track::with_priority(...) so callers can replace Track struct literals with Track::new(...).with_priority(...).
- Update downstream Rust call sites to construct tracks through Track::new(...).

Public API changes
- Added Track::with_priority(self, priority: u8) -> Self.
- Marked Broadcast and Track as #[non_exhaustive]. Current main has already renamed the older BroadcastInfo and TrackInfo model structs, and no longer has model-level Subscription or Fetch types.

Validation
- cargo check --all-targets
- just fix
- just check

(Written by GPT-5)