### PR TITLE
[codex] fix js public docs and TrackInfo timescale

### DIFF
--- a/js/net/src/lite/track.test.ts
+++ b/js/net/src/lite/track.test.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "bun:test";
+import * as Path from "../path.ts";
+import { Reader, Writer } from "../stream.ts";
+import { Track, TrackInfo } from "./track.ts";
+import { Version } from "./version.ts";
+
+function concat(chunks: Uint8Array[]): Uint8Array {
+	const total = chunks.reduce((sum, c) => sum + c.byteLength, 0);
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const c of chunks) {
+		out.set(c, offset);
+		offset += c.byteLength;
+	}
+	return out;
+}
+
+async function bytes(f: (w: Writer) => Promise<void>): Promise<Uint8Array> {
+	const written: Uint8Array[] = [];
+	const writer = new Writer(
+		new WritableStream<Uint8Array>({ write: (chunk) => void written.push(new Uint8Array(chunk)) }),
+	);
+	await f(writer);
+	writer.close();
+	await writer.closed;
+	return concat(written);
+}
+
+test("TrackInfo round-trips on draft-05", async () => {
+	const info = new TrackInfo({
+		priority: 7,
+		ordered: false,
+		maxLatency: 2000,
+		timescale: 90000,
+	});
+	const reader = new Reader(undefined, await bytes((w) => info.encode(w, Version.DRAFT_05_WIP)));
+	const got = await TrackInfo.decode(reader, Version.DRAFT_05_WIP);
+	expect(got.priority).toBe(7);
+	expect(got.ordered).toBe(false);
+	expect(got.maxLatency).toBe(2000);
+	expect(got.timescale).toBe(90000);
+});
+
+test("Track request round-trips on draft-05", async () => {
+	const msg = new Track({ broadcast: Path.from("room"), track: "video" });
+	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, Version.DRAFT_05_WIP)));
+	const got = await Track.decode(reader, Version.DRAFT_05_WIP);
+	expect(got.broadcast).toBe(Path.from("room"));
+	expect(got.track).toBe("video");
+});
+
+test("TrackInfo rejects zero timescale", () => {
+	expect(() => new TrackInfo({ timescale: 0 })).toThrow(/timescale/);
+});
+
+test("TRACK_INFO is rejected before draft-05", async () => {
+	const info = new TrackInfo({ timescale: 90000 });
+	await expect(bytes((w) => info.encode(w, Version.DRAFT_04))).rejects.toThrow();
+});

--- a/js/net/src/lite/track.ts
+++ b/js/net/src/lite/track.ts
@@ -49,6 +49,9 @@ export class TrackInfo {
 	timescale: number;
 
 	constructor(props: { priority?: number; ordered?: boolean; maxLatency?: number; timescale: number }) {
+		if (!Number.isInteger(props.timescale) || props.timescale <= 0) {
+			throw new Error("TRACK_INFO timescale must be a positive integer");
+		}
 		this.priority = props.priority ?? 0;
 		this.ordered = props.ordered ?? false;
 		this.maxLatency = props.maxLatency ?? 0;
@@ -68,15 +71,12 @@ export class TrackInfo {
 		const maxLatency = await r.u53();
 		const timescale = await r.u53();
 		// A zero timescale is a protocol violation: every track has a media timeline.
-		if (timescale === 0) throw new Error("TRACK_INFO timescale must be non-zero");
+		if (timescale === 0) throw new Error("TRACK_INFO timescale must be a positive integer");
 		return new TrackInfo({ priority, ordered, maxLatency, timescale });
 	}
 
 	async encode(w: Writer, version: Version): Promise<void> {
 		if (!hasTrackStream(version)) throw new Error("TRACK_INFO requires moq-lite-05+");
-		// Reject a zero timescale on encode too (mirrors the Rust side), so an invalid
-		// TrackInfo fails fast on the sender rather than only at the peer's decoder.
-		if (this.timescale === 0) throw new Error("TRACK_INFO timescale must be non-zero");
 		return Message.encode(w, this.#encode.bind(this));
 	}
 

--- a/js/net/src/time.ts
+++ b/js/net/src/time.ts
@@ -1,7 +1,13 @@
 /** A duration in nanoseconds, branded so it can't be mixed with other units. */
 export type Nano = number & { readonly _brand: "nano" };
 
-/** Constructors, conversions, and arithmetic for {@link Nano} values. */
+/**
+ * Constructors, conversions, and arithmetic for {@link Nano} values.
+ *
+ * Calling `Nano(x)` brands a raw number as nanoseconds. The unit is the caller's
+ * assertion: no conversion happens, so reach for `fromMicro`/`fromMilli`/`fromSecond`
+ * when the source has a unit.
+ */
 export const Nano = {
 	zero: 0 as Nano,
 	fromMicro: (us: Micro): Nano => (us * 1_000) as Nano,
@@ -22,7 +28,13 @@ export const Nano = {
 /** A duration in microseconds, branded so it can't be mixed with other units. */
 export type Micro = number & { readonly _brand: "micro" };
 
-/** Constructors, conversions, and arithmetic for {@link Micro} values. */
+/**
+ * Constructors, conversions, and arithmetic for {@link Micro} values.
+ *
+ * Calling `Micro(x)` brands a raw number as microseconds. This asserts the unit
+ * rather than converting, so use `fromNano`/`fromMilli`/`fromSecond` to convert
+ * from another unit.
+ */
 export const Micro = {
 	zero: 0 as Micro,
 	fromNano: (ns: Nano): Micro => (ns / 1_000) as Micro,
@@ -43,7 +55,13 @@ export const Micro = {
 /** A duration in milliseconds, branded so it can't be mixed with other units. */
 export type Milli = number & { readonly _brand: "milli" };
 
-/** Constructors, conversions, and arithmetic for {@link Milli} values. */
+/**
+ * Constructors, conversions, and arithmetic for {@link Milli} values.
+ *
+ * Calling `Milli(x)` brands a raw number as milliseconds. This asserts the unit
+ * rather than converting, so use `fromNano`/`fromMicro`/`fromSecond` to convert
+ * from another unit.
+ */
 export const Milli = {
 	zero: 0 as Milli,
 	fromNano: (ns: Nano): Milli => (ns / 1_000_000) as Milli,
@@ -64,7 +82,13 @@ export const Milli = {
 /** A duration in seconds, branded so it can't be mixed with other units. */
 export type Second = number & { readonly _brand: "second" };
 
-/** Constructors, conversions, and arithmetic for {@link Second} values. */
+/**
+ * Constructors, conversions, and arithmetic for {@link Second} values.
+ *
+ * Calling `Second(x)` brands a raw number as seconds. This asserts the unit
+ * rather than converting, so use `fromNano`/`fromMicro`/`fromMilli` to convert
+ * from another unit.
+ */
 export const Second = {
 	zero: 0 as Second,
 	fromNano: (ns: Nano): Second => (ns / 1_000_000_000) as Second,

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -27,10 +27,14 @@ export class Broadcast {
 	audio: Audio.Encoder;
 	video: Video.Root;
 
-	// The catalog, editable at any time regardless of whether anyone is subscribed. The base
-	// `video`/`audio` sections are kept in sync from the encoders; an application adds its own root
-	// sections (e.g. `scte35`) by mutating it too. Catalog.Producer pins deltas off (one snapshot per
-	// group) to stay byte-compatible with consumers that only read snapshots.
+	/**
+	 * The catalog, editable at any time regardless of whether anyone is subscribed.
+	 *
+	 * The base `video`/`audio` sections are kept in sync from the encoders; an
+	 * application adds its own root sections (e.g. `scte35`) by mutating it too.
+	 * `Catalog.Producer` pins deltas off to stay byte-compatible with consumers
+	 * that only read snapshots.
+	 */
 	readonly catalog: Catalog.Producer = new Catalog.Producer();
 
 	// Handlers for custom tracks registered via `publishTrack`, keyed by track name. Persists across

--- a/js/publish/src/index.ts
+++ b/js/publish/src/index.ts
@@ -1,4 +1,5 @@
 export * as Hang from "@moq/hang";
+export { Producer as CatalogProducer } from "@moq/hang/catalog";
 export * as Json from "@moq/json";
 export * as Net from "@moq/net";
 /** @deprecated Use `Net` instead. */

--- a/js/watch/src/audio/backend.ts
+++ b/js/watch/src/audio/backend.ts
@@ -2,28 +2,31 @@ import type { Getter, Signal } from "@moq/signals";
 import type { BufferedRanges } from "../buffered";
 import type { Source } from "./source";
 
-// Audio specific signals that work regardless of the backend source (mse vs webcodecs).
+/** Audio-specific signals that work regardless of the backend source (MSE vs WebCodecs). */
 export interface Backend {
-	// The source of the audio.
+	/** The source of the audio. */
 	source: Source;
 
-	// The volume of the audio, between 0 and 1.
+	/** The volume of the audio, between 0 and 1. */
 	volume: Signal<number>;
 
-	// Whether the audio is muted.
+	/** Whether the audio is muted. */
 	muted: Signal<boolean>;
 
-	// The stats of the audio.
+	/** The stats of the audio. */
 	stats: Getter<Stats | undefined>;
 
-	// Buffered time ranges (for MSE backend).
+	/** Buffered time ranges for the MSE backend. */
 	buffered: Getter<BufferedRanges>;
 
-	// The AudioContext used for playback (WebCodecs backend only).
+	/** The AudioContext used for WebCodecs playback. */
 	context: Getter<AudioContext | undefined>;
 }
 
+/** Audio playback statistics. */
 export interface Stats {
+	/** Number of samples decoded. */
 	sampleCount: number;
+	/** Number of encoded bytes received. */
 	bytesReceived: number;
 }

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -17,11 +17,15 @@ export type DecoderProps = {
 };
 
 export interface AudioStats {
+	/** Number of encoded bytes received. */
 	bytesReceived: number;
 }
 
-// Downloads audio from a track and emits it to an AudioContext.
-// The user is responsible for hooking up audio to speakers, an analyzer, etc.
+/**
+ * Downloads audio from a track and emits it to an AudioContext.
+ *
+ * The user is responsible for hooking up audio to speakers, an analyzer, etc.
+ */
 export class Decoder {
 	source: Source;
 	enabled: Signal<boolean>;

--- a/js/watch/src/backend.ts
+++ b/js/watch/src/backend.ts
@@ -94,9 +94,11 @@ class AudioBackend implements Audio.Backend {
 	}
 }
 
-/// A generic backend that supports either MSE or WebCodecs based on the provided element.
-///
-/// This is primarily what backs the <moq-watch> web component, but it's useful as a standalone for other use cases.
+/**
+ * A generic backend that supports either MSE or WebCodecs based on the provided element.
+ *
+ * This primarily backs the `<moq-watch>` web component, but is useful standalone.
+ */
 export class MultiBackend implements Backend {
 	element = new Signal<HTMLCanvasElement | HTMLVideoElement | undefined>(undefined);
 	broadcast: Signal<Broadcast | undefined>;

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -9,13 +9,20 @@ import { toHang } from "./msf";
 /** Consumes a custom track once subscribed, scoped to the subscription's lifetime. */
 export type ConsumeTrack = (track: Moq.Track, effect: Effect) => void;
 
-// Watch supports the on-the-wire catalog formats from @moq/hang, plus "hangz" (the
-// DEFLATE-compressed `catalog.json.z` track) and a "manual" mode where the user supplies the
-// catalog directly without fetching. "hangz" is opt-in only: it shares the `.hang` broadcast suffix
-// and is never auto-detected, so set it explicitly via `catalogFormat`.
+/**
+ * Catalog formats accepted by Watch.
+ *
+ * Watch supports the on-the-wire catalog formats from `@moq/hang`, plus
+ * `"hangz"` (the DEFLATE-compressed `catalog.json.z` track) and `"manual"`, where
+ * the user supplies the catalog directly without fetching. `"hangz"` is opt-in
+ * only: it shares the `.hang` broadcast suffix and is never auto-detected, so set
+ * it explicitly via `catalogFormat`.
+ */
 export const CATALOG_FORMATS = [...Catalog.FORMATS, "hangz", "manual"] as const;
+/** A catalog format accepted by Watch. */
 export type CatalogFormat = (typeof CATALOG_FORMATS)[number];
 
+/** Parse a catalog format string, returning `undefined` for unknown values. */
 export function parseCatalogFormat(value: string | null): CatalogFormat | undefined {
 	if (value === null) return undefined;
 	return CATALOG_FORMATS.find((f) => f === value);
@@ -54,7 +61,7 @@ export interface BroadcastProps {
 	catalog?: Catalog.Root | Signal<Catalog.Root | undefined>;
 }
 
-// A catalog source that (optionally) reloads automatically when live/offline.
+/** A catalog source that optionally reloads automatically when live or offline. */
 export class Broadcast {
 	connection: Signal<Moq.Connection.Established | undefined>;
 

--- a/js/watch/src/video/backend.ts
+++ b/js/watch/src/video/backend.ts
@@ -3,25 +3,28 @@ import type { Getter } from "@moq/signals";
 import type { BufferedRanges } from "../buffered";
 import type { Source } from "./source";
 
-// Video specific signals that work regardless of the backend source (mse vs webcodecs).
+/** Video-specific signals that work regardless of the backend source (MSE vs WebCodecs). */
 export interface Backend {
-	// The source of the video.
+	/** The source of the video. */
 	source: Source;
 
-	// The stats of the video.
+	/** The stats of the video. */
 	stats: Getter<Stats | undefined>;
 
-	// Whether the video is currently buffering
+	/** Whether the video is currently buffering. */
 	stalled: Getter<boolean>;
 
-	// Buffered time ranges (for MSE backend).
+	/** Buffered time ranges for the MSE backend. */
 	buffered: Getter<BufferedRanges>;
 
-	// The timestamp of the current frame.
+	/** The timestamp of the current frame. */
 	timestamp: Getter<Moq.Time.Milli | undefined>;
 }
 
+/** Video playback statistics. */
 export interface Stats {
+	/** Number of frames decoded. */
 	frameCount: number;
+	/** Number of encoded bytes received. */
 	bytesReceived: number;
 }


### PR DESCRIPTION
## Summary

- Document public JS exports in net, publish, and watch with JSDoc blocks so generated API docs can render them.
- Require a positive Lite `TrackInfo.timescale` at construction time and add TrackInfo wire-message tests.
- Re-export `CatalogProducer` from `@moq/publish` as an alias for `@moq/hang/catalog` `Producer`.

## Public API changes

- `@moq/publish` now exports `CatalogProducer` from its package root.
- `TrackInfo` construction in `@moq/net` Lite internals requires a positive integer `timescale` and rejects invalid values immediately.

## Validation

- `bun test src/lite/track.test.ts` in `js/net`
- `bun run check` in `js/net`, `js/publish`, and `js/watch`
- `just js check`

(Written by GPT-5)