### PR TITLE
Move the connect URL and connect/serve loops into moq-native

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4015,7 +4015,6 @@ dependencies = [
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
- "url",
 ]
 
 [[package]]
@@ -4036,7 +4035,6 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
- "url",
 ]
 
 [[package]]

--- a/demo/boy/justfile
+++ b/demo/boy/justfile
@@ -51,7 +51,7 @@ gb-run:
 
 # Start a Game Boy emulator publisher.
 start rom url='http://localhost:4443':
-    cargo run --bin moq-boy -- --url "{{ url }}" --rom "{{ rom }}" --location localhost
+    cargo run --bin moq-boy -- --client-connect "{{ url }}" --rom "{{ rom }}" --location localhost
 
 # Host the web server
 web url='http://localhost:4443':

--- a/demo/pub/justfile
+++ b/demo/pub/justfile
@@ -219,7 +219,7 @@ clock action url="http://localhost:4443" *args:
     	exit 1; \
     fi
 
-    cargo run -p moq-native --example clock -- --url "{{ url }}" --broadcast "clock" {{ args }} {{ action }}
+    cargo run -p moq-native --example clock -- --client-connect "{{ url }}" --broadcast "clock" {{ args }} {{ action }}
 
 # --- GStreamer ---
 

--- a/doc/setup/windows.md
+++ b/doc/setup/windows.md
@@ -62,10 +62,10 @@ REM Grab the relay's certificate fingerprint
 for /f %f in ('curl -s http://localhost:4443/certificate.sha256') do set FP=%f
 
 REM Publish
-cargo run -p moq-native --example clock -- --url https://localhost:4443 --broadcast clock --client-tls-fingerprint %FP% publish
+cargo run -p moq-native --example clock -- --client-connect https://localhost:4443 --broadcast clock --client-tls-fingerprint %FP% publish
 
 REM Subscribe (separate terminal)
-cargo run -p moq-native --example clock -- --url https://localhost:4443 --broadcast clock --client-tls-fingerprint %FP% subscribe
+cargo run -p moq-native --example clock -- --client-connect https://localhost:4443 --broadcast clock --client-tls-fingerprint %FP% subscribe
 ```
 
 The subscriber prints the current time once per second, sourced from the

--- a/rs/moq-bench/Cargo.toml
+++ b/rs/moq-bench/Cargo.toml
@@ -40,4 +40,3 @@ serde_json = "1"
 tokio = { workspace = true, features = ["full"] }
 toml = "1.1"
 tracing = "0.1"
-url = { version = "2", features = ["serde"] }

--- a/rs/moq-bench/README.md
+++ b/rs/moq-bench/README.md
@@ -48,11 +48,11 @@ shape, so a subscriber works against peers it didn't publish itself.
 
 ```bash
 # Roll the dice with the built-in defaults (1 connection, 1 broadcast, 30fps).
-moq-bench --url https://relay.example.com
+moq-bench --client-connect https://relay.example.com
 
 # Use a preset, overriding the target and connection count on the CLI.
 moq-bench --file rs/moq-bench/config/hd.toml \
-  --url https://relay.example.com \
+  --client-connect https://relay.example.com \
   --connections 500
 ```
 

--- a/rs/moq-bench/config/hd.toml
+++ b/rs/moq-bench/config/hd.toml
@@ -4,9 +4,10 @@
 # of viewers per connection. Roughly 4-29 Mbps per track depending on the roll.
 #
 # Override the target on the CLI:
-#   moq-bench --file rs/moq-bench/config/hd.toml --url https://relay.example.com
+#   moq-bench --file rs/moq-bench/config/hd.toml --client-connect https://relay.example.com
 
-# url = "https://relay.example.com"
+# [client]
+# connect = "https://relay.example.com"
 
 startup = "30s"
 report = "5s"

--- a/rs/moq-bench/src/config.rs
+++ b/rs/moq-bench/src/config.rs
@@ -16,11 +16,6 @@ use crate::Range;
 #[command(version = env!("VERSION"))]
 #[non_exhaustive]
 pub struct Config {
-	/// The URL of the MoQ server to benchmark (e.g. `https://relay.example.com`).
-	#[arg(long, env = "MOQ_BENCH_URL")]
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub url: Option<url::Url>,
-
 	/// The broadcast namespace prefix. Each broadcast is published under
 	/// `<name>/<run>/<connection>/<index>` and subscribers discover peers under `<name>`.
 	#[arg(long, env = "MOQ_BENCH_NAME")]
@@ -164,11 +159,11 @@ mod tests {
 	#[test]
 	fn cli_overrides_toml() {
 		let toml = r#"
-url = "https://example.com"
 connections = 100
 fps = "24:60"
 
 [client]
+connect = "https://example.com"
 tls.disable_verify = true
 "#;
 		let dir = std::env::temp_dir().join("moq-bench-config-test");
@@ -185,6 +180,7 @@ tls.disable_verify = true
 		let config = Config::parse_and_merge(args).unwrap();
 		assert_eq!(config.connections(), Range::new(100, 100));
 		assert_eq!(config.fps(), Range::new(24, 60));
+		assert_eq!(config.client.connect.as_ref().unwrap().as_str(), "https://example.com/");
 		assert_eq!(config.client.tls.disable_verify, Some(true));
 
 		// CLI flag wins over the TOML value.

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -75,7 +75,7 @@ pub async fn run(ctx: Connection) {
 		stats,
 	} = ctx;
 
-	let url = config.url.clone().expect("url required");
+	let url = config.client.connect.clone().expect("url required");
 
 	// Publish side: an origin we fill with our broadcasts and hand to the session.
 	let publish = Origin::random().produce();

--- a/rs/moq-bench/src/main.rs
+++ b/rs/moq-bench/src/main.rs
@@ -22,7 +22,10 @@ async fn main() -> anyhow::Result<()> {
 		.expect("failed to install default crypto provider");
 
 	let config = Config::load()?;
-	anyhow::ensure!(config.url.is_some(), "--url is required (or set it in the TOML file)");
+	anyhow::ensure!(
+		config.client.connect.is_some(),
+		"--client-connect is required (or set it in the TOML file)"
+	);
 
 	let config = Arc::new(config);
 	let client = config.client.clone().init()?;
@@ -42,7 +45,7 @@ async fn main() -> anyhow::Result<()> {
 	let run_id = rng.random_range(0..=u64::MAX);
 	let startup = config.startup();
 
-	tracing::info!(connections = count, url = %config.url.as_ref().unwrap(), "starting benchmark");
+	tracing::info!(connections = count, url = %config.client.connect.as_ref().unwrap(), "starting benchmark");
 
 	let mut tasks = tokio::task::JoinSet::new();
 	for i in 0..count {

--- a/rs/moq-boy/Cargo.toml
+++ b/rs/moq-boy/Cargo.toml
@@ -32,4 +32,3 @@ moq-video = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = "0.1"
-url = "2"

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -31,7 +31,6 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
-use url::Url;
 
 #[cfg(feature = "jemalloc")]
 #[global_allocator]
@@ -46,10 +45,6 @@ mod video;
 
 #[derive(Parser, Clone)]
 pub struct Config {
-	/// Connect to the given relay URL.
-	#[arg(long)]
-	pub url: Url,
-
 	/// Path to the Game Boy ROM file.
 	#[arg(long)]
 	pub rom: PathBuf,
@@ -207,6 +202,7 @@ async fn run(config: &Config) -> Result<()> {
 
 	let (cmd_tx, cmd_rx) = tokio::sync::mpsc::channel::<input::Command>(64);
 	let client = config.client.clone().init()?;
+	let url = config.client.connect.clone().context("--client-connect is required")?;
 
 	// Create the broadcast producer.
 	let mut broadcast = moq_net::Broadcast::new().produce();
@@ -230,12 +226,12 @@ async fn run(config: &Config) -> Result<()> {
 		.expect("viewer prefix should be valid")
 		.consume();
 
-	tracing::info!(url = %config.url, %name, broadcast = %broadcast_path, "connecting to relay");
+	tracing::info!(%url, %name, broadcast = %broadcast_path, "connecting to relay");
 
 	let reconnect = client
 		.with_publish(publish_origin.consume())
 		.with_consume(consume_origin)
-		.reconnect(config.url.clone());
+		.reconnect(url);
 
 	// Set up catalog and encoders.
 	let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -16,7 +16,6 @@
 use std::time::Duration;
 
 use clap::{ArgGroup, Args, Parser, Subcommand};
-use url::Url;
 
 use crate::publish::PublishFormat;
 use crate::subscribe::{CatalogFormatArg, SubscribeFormat};
@@ -43,20 +42,6 @@ pub struct Cli {
 #[derive(Args, Clone)]
 #[command(group = ArgGroup::new("moq").required(true).multiple(true).args(["client-connect", "server-bind"]))]
 pub struct MoqSide {
-	/// Dial a MoQ relay/server over WebTransport.
-	///
-	/// The URL path is the relay auth path (e.g. `/anon` for a public relay); the
-	/// broadcast rides on top of it (via `--broadcast` or the endpoint). `?jwt=`
-	/// supplies a token. `http://` first fetches `/certificate.sha256` for the
-	/// (insecure) self-signed fingerprint; `https://` connects directly.
-	#[arg(
-		id = "client-connect",
-		long = "client-connect",
-		env = "MOQ_CLIENT_CONNECT",
-		help_heading = "MoQ"
-	)]
-	pub client_connect: Option<Url>,
-
 	/// The broadcast name. Optional for the point endpoints (stdin/stdout, HLS
 	/// import, and the `--connect` dials), which default to the root broadcast at
 	/// the connection path; required by the `--listen` endpoints and `hls export`,
@@ -64,7 +49,7 @@ pub struct MoqSide {
 	#[arg(long, alias = "name", help_heading = "MoQ")]
 	pub broadcast: Option<String>,
 
-	/// MoQ client transport config (`--client-bind`, `--client-tls-*`, ...).
+	/// MoQ client config (`--client-connect`, `--client-bind`, `--client-tls-*`, ...).
 	#[command(flatten)]
 	pub client: moq_native::ClientConfig,
 

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -83,7 +83,7 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 	}
 
 	// MoQ side: publish the Origin outward.
-	if let Some(url) = moq.client_connect.clone() {
+	if let Some(url) = moq.client.connect.clone() {
 		let client = net.client(moq.client.clone())?;
 		let origin = origin.clone();
 		tasks.spawn(async move { moq::client_import(client, url, &origin).await });
@@ -164,7 +164,7 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 	}
 
 	// MoQ side: fill the Origin.
-	if let Some(url) = moq.client_connect.clone() {
+	if let Some(url) = moq.client.connect.clone() {
 		let client = net.client(moq.client.clone())?;
 		let origin = origin.clone();
 		tasks.spawn(async move { moq::client_export(client, url, origin).await });

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -83,15 +83,18 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 	}
 
 	// MoQ side: publish the Origin outward.
-	if let Some(url) = moq.client.connect.clone() {
-		let client = net.client(moq.client.clone())?;
-		let origin = origin.clone();
-		tasks.spawn(async move { moq::client_import(client, url, &origin).await });
+	if moq.client.connect.is_some() {
+		if let Some(reconnect) = net.client(moq.client.clone())?.publish(origin.consume()) {
+			moq::notify_ready();
+			tasks.spawn(async move { Ok(reconnect.closed().await?) });
+		}
 	}
 	if let Some(web_bind) = moq.server.bind.clone() {
 		let server = net.server(moq.server.clone())?;
 		let tls_info = server.tls_info();
-		tasks.spawn(moq::server_import(server, origin.clone()));
+		moq::notify_ready();
+		let origin = origin.consume();
+		tasks.spawn(async move { Ok(server.serve_publish(origin).await?) });
 		tasks.spawn(async move { web::run_web(&web_bind, tls_info).await });
 	}
 
@@ -164,15 +167,18 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 	}
 
 	// MoQ side: fill the Origin.
-	if let Some(url) = moq.client.connect.clone() {
-		let client = net.client(moq.client.clone())?;
-		let origin = origin.clone();
-		tasks.spawn(async move { moq::client_export(client, url, origin).await });
+	if moq.client.connect.is_some() {
+		if let Some(reconnect) = net.client(moq.client.clone())?.consume(origin.clone()) {
+			moq::notify_ready();
+			tasks.spawn(async move { Ok(reconnect.closed().await?) });
+		}
 	}
 	if let Some(web_bind) = moq.server.bind.clone() {
 		let server = net.server(moq.server.clone())?;
 		let tls_info = server.tls_info();
-		tasks.spawn(moq::server_export(server, origin.clone()));
+		moq::notify_ready();
+		let origin = origin.clone();
+		tasks.spawn(async move { Ok(server.serve_consume(origin).await?) });
 		tasks.spawn(async move { web::run_web(&web_bind, tls_info).await });
 	}
 

--- a/rs/moq-cli/src/moq.rs
+++ b/rs/moq-cli/src/moq.rs
@@ -1,80 +1,8 @@
-//! The MoQ side of the router: attaching the shared Origin to the network via a
-//! dialed client (`--client-connect`) and/or a hosted server (`--server-bind`).
+//! Small MoQ-side helpers shared across endpoints.
 //!
-//! Direction determines data flow off the one shared Origin:
-//! - import: MoQ publishes the Origin outward (client publishes to the relay;
-//!   each accepted server session serves subscribers).
-//! - export: MoQ fills the Origin (client subscribes from the relay; each
-//!   accepted server session ingests a remote publish).
-
-use hang::moq_net;
-use url::Url;
-
-/// Dial a relay and publish the Origin's broadcasts to it (import).
-pub async fn client_import(
-	client: moq_native::Client,
-	url: Url,
-	origin: &moq_net::OriginProducer,
-) -> anyhow::Result<()> {
-	let reconnect = client.with_publish(origin.consume()).reconnect(url);
-	notify_ready();
-	Ok(reconnect.closed().await?)
-}
-
-/// Dial a relay and subscribe its broadcasts into the Origin (export).
-pub async fn client_export(
-	client: moq_native::Client,
-	url: Url,
-	origin: moq_net::OriginProducer,
-) -> anyhow::Result<()> {
-	let reconnect = client.with_consume(origin).reconnect(url);
-	notify_ready();
-	Ok(reconnect.closed().await?)
-}
-
-/// Host a MoQ server; each accepted session serves the Origin to subscribers (import).
-pub async fn server_import(mut server: moq_native::Server, origin: moq_net::OriginProducer) -> anyhow::Result<()> {
-	notify_ready();
-	tracing::info!(addr = ?server.local_addr(), "listening");
-
-	while let Some(session) = server.accept().await {
-		let origin = origin.clone();
-		tokio::spawn(async move {
-			if let Err(err) = serve_session(session, origin).await {
-				tracing::warn!(%err, "session ended with error");
-			}
-		});
-	}
-
-	Ok(())
-}
-
-async fn serve_session(session: moq_native::Request, origin: moq_net::OriginProducer) -> anyhow::Result<()> {
-	let session = session.with_publish(origin.consume()).ok().await?;
-	Ok(session.closed().await?)
-}
-
-/// Host a MoQ server; each accepted session ingests a remote publish into the Origin (export).
-pub async fn server_export(mut server: moq_native::Server, origin: moq_net::OriginProducer) -> anyhow::Result<()> {
-	notify_ready();
-	tracing::info!(addr = ?server.local_addr(), "listening");
-
-	while let Some(session) = server.accept().await {
-		let origin = origin.clone();
-		tokio::spawn(async move {
-			if let Err(err) = accept_session(session, origin).await {
-				tracing::warn!(%err, "session ended with error");
-			}
-		});
-	}
-
-	Ok(())
-}
-
-async fn accept_session(session: moq_native::Request, origin: moq_net::OriginProducer) -> anyhow::Result<()> {
-	let session = session.with_consume(origin).ok().await?;
-	Ok(session.closed().await?)
-}
+//! The dial and accept loops live in `moq-native` (`Client::publish`/`consume`
+//! and `Server::serve_publish`/`serve_consume`); this module just carries the
+//! systemd readiness notification used by every endpoint.
 
 /// Notify systemd (if any) that the endpoint is up.
 pub fn notify_ready() {

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -65,7 +65,7 @@ time = "0.3"
 tokio = { workspace = true, features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-url = "2"
+url = { version = "2", features = ["serde"] }
 web-transport-iroh = { workspace = true, optional = true }
 web-transport-noq = { workspace = true, optional = true }
 web-transport-proto = { workspace = true, optional = true }

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -8,22 +8,17 @@
 //! Run with:
 //!
 //! ```text
-//! cargo run -p moq-native --example clock -- --url https://relay.example.com/anon --broadcast clock publish
-//! cargo run -p moq-native --example clock -- --url https://relay.example.com/anon --broadcast clock subscribe
+//! cargo run -p moq-native --example clock -- --client-connect https://relay.example.com/anon --broadcast clock publish
+//! cargo run -p moq-native --example clock -- --client-connect https://relay.example.com/anon --broadcast clock subscribe
 //! ```
 
 use anyhow::Context;
 use chrono::prelude::*;
 use clap::Parser;
 use moq_net::*;
-use url::Url;
 
 #[derive(Parser, Clone)]
 struct Config {
-	/// Connect to the given URL starting with https://
-	#[arg(long)]
-	url: Url,
-
 	/// The name of the broadcast to publish or subscribe to.
 	#[arg(long)]
 	broadcast: String,
@@ -56,9 +51,8 @@ async fn main() -> anyhow::Result<()> {
 	let config = Config::parse();
 	config.log.init()?;
 
+	tracing::info!(url = ?config.client.connect, "connecting to server");
 	let client = config.client.init()?;
-
-	tracing::info!(url = ?config.url, "connecting to server");
 
 	let track = Track {
 		name: config.track,
@@ -75,7 +69,9 @@ async fn main() -> anyhow::Result<()> {
 
 			origin.publish_broadcast(&config.broadcast, broadcast.consume());
 
-			let reconnect = client.with_publish(origin.consume()).reconnect(config.url);
+			let reconnect = client
+				.publish(origin.consume())
+				.context("--client-connect is required")?;
 
 			tokio::select! {
 				res = reconnect.closed() => Ok(res?),
@@ -83,7 +79,7 @@ async fn main() -> anyhow::Result<()> {
 			}
 		}
 		Command::Subscribe => {
-			let reconnect = client.with_consume(origin.clone()).reconnect(config.url);
+			let reconnect = client.consume(origin.clone()).context("--client-connect is required")?;
 
 			// IETF MoQ + the current OriginConsumer API don't let us call
 			// `session.consume_broadcast(&path)` directly, so loop on announces

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -755,17 +755,26 @@ mod tests {
 		"#;
 
 		let mut config: ClientConfig = toml::from_str(toml).unwrap();
-		assert_eq!(config.connect.as_ref().unwrap().as_str(), "https://relay.example.com/anon");
+		assert_eq!(
+			config.connect.as_ref().unwrap().as_str(),
+			"https://relay.example.com/anon"
+		);
 
 		// Simulate: TOML loaded, then CLI args re-applied (no --client-connect flag).
 		config.update_from(["test"]);
-		assert_eq!(config.connect.as_ref().unwrap().as_str(), "https://relay.example.com/anon");
+		assert_eq!(
+			config.connect.as_ref().unwrap().as_str(),
+			"https://relay.example.com/anon"
+		);
 	}
 
 	#[test]
 	fn test_cli_connect() {
 		let config = ClientConfig::parse_from(["test", "--client-connect", "https://relay.example.com/anon"]);
-		assert_eq!(config.connect.as_ref().unwrap().as_str(), "https://relay.example.com/anon");
+		assert_eq!(
+			config.connect.as_ref().unwrap().as_str(),
+			"https://relay.example.com/anon"
+		);
 	}
 
 	#[test]

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -106,6 +106,8 @@ impl Default for ClientConfig {
 pub struct Client {
 	moq: moq_net::Client,
 	versions: moq_net::Versions,
+	/// The URL from [`ClientConfig::connect`], dialed by [`Client::publish`] / [`Client::consume`].
+	connect: Option<Url>,
 	backoff: Backoff,
 	#[cfg(feature = "websocket")]
 	websocket: crate::websocket::Client,
@@ -191,6 +193,7 @@ impl Client {
 		Ok(Self {
 			moq: moq_net::Client::new().with_versions(versions.clone()),
 			versions,
+			connect: config.connect,
 			backoff: config.backoff,
 			#[cfg(feature = "websocket")]
 			websocket: config.websocket,
@@ -246,6 +249,26 @@ impl Client {
 	/// Returns a [`Reconnect`] handle; drop the last handle to stop the loop.
 	pub fn reconnect(&self, url: Url) -> Reconnect {
 		Reconnect::new(self.clone(), url, self.backoff.clone())
+	}
+
+	/// Dial the configured [`ClientConfig::connect`] URL, publishing `origin` to it
+	/// and reconnecting with backoff until the returned handle is dropped.
+	///
+	/// Returns `None` when no `--client-connect` URL was configured, so a caller
+	/// that may run server-only doesn't have to branch on the URL itself.
+	pub fn publish(self, origin: moq_net::OriginConsumer) -> Option<Reconnect> {
+		let url = self.connect.clone()?;
+		Some(self.with_publish(origin).reconnect(url))
+	}
+
+	/// Dial the configured [`ClientConfig::connect`] URL, consuming its broadcasts
+	/// into `origin` and reconnecting with backoff until the returned handle is
+	/// dropped.
+	///
+	/// Returns `None` when no `--client-connect` URL was configured.
+	pub fn consume(self, origin: moq_net::OriginProducer) -> Option<Reconnect> {
+		let url = self.connect.clone()?;
+		Some(self.with_consume(origin).reconnect(url))
 	}
 
 	#[cfg(not(any(

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -9,6 +9,17 @@ use url::Url;
 #[serde(deny_unknown_fields, default)]
 #[non_exhaustive]
 pub struct ClientConfig {
+	/// The URL to dial.
+	///
+	/// Supports WebTransport (`https`/`http`), WebSocket (`ws`/`wss`), raw QUIC
+	/// (`moqt`/`moql`), qmux over `tcp`/`unix`, and `iroh`. The URL path is the
+	/// request/auth path (e.g. `/anon` for a public relay) and `?jwt=` supplies a
+	/// token. `http://` first fetches `/certificate.sha256` for the (insecure)
+	/// self-signed fingerprint; `https://` connects directly.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[arg(id = "client-connect", long = "client-connect", env = "MOQ_CLIENT_CONNECT")]
+	pub connect: Option<Url>,
+
 	/// Listen for UDP packets on the given address.
 	#[arg(
 		id = "client-bind",
@@ -75,6 +86,7 @@ impl ClientConfig {
 impl Default for ClientConfig {
 	fn default() -> Self {
 		Self {
+			connect: None,
 			bind: "[::]:0".parse().unwrap(),
 			backend: None,
 			max_streams: None,

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -749,6 +749,26 @@ mod tests {
 	}
 
 	#[test]
+	fn test_toml_connect_survives_update_from() {
+		let toml = r#"
+			connect = "https://relay.example.com/anon"
+		"#;
+
+		let mut config: ClientConfig = toml::from_str(toml).unwrap();
+		assert_eq!(config.connect.as_ref().unwrap().as_str(), "https://relay.example.com/anon");
+
+		// Simulate: TOML loaded, then CLI args re-applied (no --client-connect flag).
+		config.update_from(["test"]);
+		assert_eq!(config.connect.as_ref().unwrap().as_str(), "https://relay.example.com/anon");
+	}
+
+	#[test]
+	fn test_cli_connect() {
+		let config = ClientConfig::parse_from(["test", "--client-connect", "https://relay.example.com/anon"]);
+		assert_eq!(config.connect.as_ref().unwrap().as_str(), "https://relay.example.com/anon");
+	}
+
+	#[test]
 	fn test_cli_no_version_defaults_to_all() {
 		let config = ClientConfig::parse_from(["test"]);
 		assert!(config.version.is_empty());

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -402,6 +402,39 @@ impl Server {
 		self
 	}
 
+	/// Accept sessions until the listener stops, serving `origin` to each subscriber.
+	///
+	/// Spawns a task per session and logs (rather than propagates) per-session
+	/// errors, so one bad peer never tears down the listener. Returns when
+	/// interrupted (Ctrl-C) or on a fatal bind failure. For per-session auth or
+	/// routing, drive [`accept`](Self::accept) yourself instead.
+	pub async fn serve_publish(self, origin: moq_net::OriginConsumer) -> crate::Result<()> {
+		self.with_publish(origin).serve().await
+	}
+
+	/// Accept sessions until the listener stops, ingesting each publisher into `origin`.
+	///
+	/// The mirror of [`serve_publish`](Self::serve_publish) for the consume direction.
+	pub async fn serve_consume(self, origin: moq_net::OriginProducer) -> crate::Result<()> {
+		self.with_consume(origin).serve().await
+	}
+
+	/// Shared accept loop for [`serve_publish`](Self::serve_publish) /
+	/// [`serve_consume`](Self::serve_consume); the origin is already attached.
+	async fn serve(mut self) -> crate::Result<()> {
+		if let Ok(addr) = self.local_addr() {
+			tracing::info!(%addr, "listening");
+		}
+		while let Some(request) = self.accept().await {
+			tokio::spawn(async move {
+				if let Err(err) = serve_session(request).await {
+					tracing::warn!(%err, "session ended with error");
+				}
+			});
+		}
+		Ok(())
+	}
+
 	// Return the SHA256 fingerprints of all our certificates.
 	pub fn tls_info(&self) -> Arc<RwLock<crate::tls::Info>> {
 		#[cfg(feature = "noq")]
@@ -657,6 +690,13 @@ impl Server {
 		#[cfg(not(any(feature = "noq", feature = "quinn", feature = "quiche", feature = "iroh")))]
 		unreachable!("no QUIC backend compiled");
 	}
+}
+
+/// Complete one accepted [`Request`] and wait for the session to close.
+async fn serve_session(request: Request) -> crate::Result<()> {
+	let session = request.ok().await?;
+	session.closed().await?;
+	Ok(())
 }
 
 /// The version set offered on stream (`tcp://`/`unix://`) listeners.


### PR DESCRIPTION
Closes #1990.

## What

Each binary used to declare its own `--client-connect` flag, pull the URL out of config, and re-implement the dial/reconnect and server accept loops. This moves the flag **and** the loops into `moq-native` so callers just hand it an `Origin`, then converges the other consumers onto the shared flag.

### `ClientConfig` owns the dial URL
- New `ClientConfig::connect: Option<Url>` (flag `--client-connect`, env `MOQ_CLIENT_CONNECT`), additive on the `#[non_exhaustive]` struct.
- Enables the `url` crate's `serde` feature in moq-native (the struct is `Serialize`/`Deserialize` and now holds a `Url`; it previously had none, so a full-workspace build masked the gap via feature unification — `cargo test -p moq-native` alone caught it).

### High-level connect/serve entry points
- `Client::publish(origin) -> Option<Reconnect>` / `Client::consume(origin) -> Option<Reconnect>`: dial the configured URL, attach the `Origin`, drive the reconnect loop. `None` when no `--client-connect` is set.
- `Server::serve_publish(origin)` / `Server::serve_consume(origin)`: run the accept loop, attaching the `Origin` to each session and logging (not propagating) per-session errors. For per-session auth/routing, callers still drive `accept()` themselves (e.g. moq-relay).

### Callers converge on the shared flag
- **moq-cli**: `moq.rs` shrinks from four dial/accept functions to just the systemd `notify_ready` helper; `main.rs` calls the new methods.
- **moq-bench / moq-boy / clock example**: all three flatten `ClientConfig`, so they used to carry their own `--url` *plus* an inert inherited `--client-connect`. They now dial `client.connect` and drop the duplicate `--url`. The clock example doubles as the showcase for `Client::publish`/`consume`.
- Docs/justfiles updated to match (moq-bench README + `hd.toml`, `doc/setup/windows.md`, the boy/pub demo justfiles). The Python and JS clock examples are separate programs and keep their own `--url`.

## Why

moq-native already performed the networking; callers were left doing plumbing (pull URL, attach origin, spawn, await `closed()`) and re-writing the accept loop. These entry points close that gap: plain config + an `Origin` in, a running handle out. Putting the URL in `ClientConfig` means every flattening binary shares one dial flag instead of inventing its own.

## Notes / API scrutiny
- All library additions are new methods/fields on existing types → **not breaking**, targets `main`.
- Terminal ops consume `self` (`publish`/`consume`/`serve_*`), so use-after-connect can't be expressed. `Client::publish` (terminal) vs `with_publish` (builder) follow the existing `with_`/bare-verb split.
- Behavioral change for the migrated binaries: `--url`/`MOQ_BENCH_URL` are gone; use `--client-connect`/`MOQ_CLIENT_CONNECT`. These are internal dev tools with no external consumers.

## Test plan
- [x] `cargo test -p moq-native -p moq-bench -p moq-boy` (all pass), incl. new `connect` config-merge regression tests
- [x] `cargo clippy ... --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p moq-native` **in isolation** (guards against the feature-unification trap)
- [x] Runtime: `moq import fmp4` with no MoQ side still errors requiring `--client-connect`/`--server-bind`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)