### PR TITLE
[codex] fix timestamp elapsed arithmetic

### DIFF
--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -547,7 +547,7 @@ impl GroupBuffer {
 		});
 
 		self.max_timestamp = Some(match self.max_timestamp {
-			Some(existing) => existing.max(frame.timestamp),
+			Some(existing) => std::cmp::max(existing, frame.timestamp),
 			None => frame.timestamp,
 		});
 

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -699,10 +699,7 @@ impl<E: CatalogExt> Export<E> {
 		let mut out = Vec::with_capacity(TsPacket::SIZE);
 
 		// Refresh PSI at keyframes or after the interval lapses.
-		let psi_due = match self.last_psi {
-			None => true,
-			Some(last) => frame.timestamp >= last && (frame.timestamp - last) >= psi_interval(),
-		};
+		let psi_due = psi_due(frame.timestamp, self.last_psi);
 		if (is_video && frame.keyframe) || psi_due {
 			let psi = self.psi.as_ref().context("PSI not built")?;
 			let pat = TsPayload::Pat(psi.pat.clone());
@@ -915,8 +912,13 @@ const PES_DTS_LEN: usize = 5;
 /// [`author_dts`] and [`Track::dts_reserve`].
 const DEFAULT_DTS_RESERVE: u64 = 16;
 
-fn psi_interval() -> Timestamp {
-	Timestamp::try_from(PSI_INTERVAL).unwrap_or(Timestamp::ZERO)
+fn psi_due(timestamp: Timestamp, last: Option<Timestamp>) -> bool {
+	let Some(last) = last else {
+		return true;
+	};
+	Duration::from(timestamp)
+		.checked_sub(Duration::from(last))
+		.is_some_and(|elapsed| elapsed >= PSI_INTERVAL)
 }
 
 /// External byte size of an adaptation field (manual mirror of the crate's
@@ -1113,7 +1115,12 @@ fn dts_reserve(config: &VideoConfig) -> u64 {
 
 #[cfg(test)]
 mod tests {
-	use super::{DEFAULT_DTS_RESERVE, author_dts, is_complete_section};
+	use super::{DEFAULT_DTS_RESERVE, author_dts, is_complete_section, psi_due};
+	use crate::container::Timestamp;
+
+	fn ms(value: u64) -> Timestamp {
+		Timestamp::from_millis(value).unwrap()
+	}
 
 	/// Push a decode-order PTS stream (90 kHz) through the decode clock with a given reserve and
 	/// return the effective DTS per frame (the authored DTS, or the PTS when none is authored).
@@ -1207,6 +1214,14 @@ mod tests {
 		for (i, (&d, &p)) in dts.iter().zip(pts.iter()).enumerate() {
 			assert_eq!(d, p - DEFAULT_DTS_RESERVE, "DTS should trail PTS by the reserve at {i}");
 		}
+	}
+
+	#[test]
+	fn psi_due_uses_elapsed_duration() {
+		assert!(psi_due(ms(1_000), None));
+		assert!(!psi_due(ms(1_250), Some(ms(1_000))));
+		assert!(psi_due(ms(1_500), Some(ms(1_000))));
+		assert!(!psi_due(ms(750), Some(ms(1_000))));
 	}
 
 	#[test]

--- a/rs/moq-srt/src/server.rs
+++ b/rs/moq-srt/src/server.rs
@@ -385,10 +385,7 @@ fn pace(
 	ts: moq_mux::container::Timestamp,
 	now: Instant,
 ) -> Paced {
-	let send_at = match ts.checked_sub(base) {
-		Ok(offset) => anchor + Duration::from(offset),
-		Err(_) => anchor.checked_sub(Duration::from(base - ts)).unwrap_or(anchor),
-	};
+	let send_at = paced_send_at(anchor, base, ts);
 	if send_at > now {
 		// Media outran wall-clock: re-anchor so this newest frame is the live edge.
 		Paced {
@@ -398,6 +395,15 @@ fn pace(
 		}
 	} else {
 		Paced { send_at, anchor, base }
+	}
+}
+
+fn paced_send_at(anchor: Instant, base: moq_mux::container::Timestamp, ts: moq_mux::container::Timestamp) -> Instant {
+	let base = Duration::from(base);
+	let ts = Duration::from(ts);
+	match ts.checked_sub(base) {
+		Some(offset) => anchor + offset,
+		None => anchor.checked_sub(base - ts).unwrap_or(anchor),
 	}
 }
 
@@ -500,6 +506,20 @@ mod tests {
 			"a reordered frame can pace before the anchor"
 		);
 		assert_eq!(reordered.anchor, edge.anchor, "no re-anchor when media trails the edge");
+	}
+
+	#[test]
+	fn pace_handles_media_before_base() {
+		use moq_mux::container::Timestamp;
+		use std::time::{Duration, Instant};
+		let ms = |m: u64| Timestamp::from_micros(m * 1_000).unwrap();
+
+		let anchor = Instant::now();
+		let paced = pace(anchor, ms(1_000), ms(750), anchor);
+
+		assert_eq!(paced.send_at, anchor - Duration::from_millis(250));
+		assert_eq!(paced.anchor, anchor);
+		assert_eq!(paced.base, ms(1_000));
 	}
 
 	fn sid(s: &str) -> StreamId {


### PR DESCRIPTION
## Summary

- Avoid raw `Timestamp` subtraction in TS PSI interval checks by comparing elapsed `Duration`s.
- Use trait-based max for consumer group timestamp tracking so the scale-safe ordering path is selected.
- Pace SRT payloads with `Duration` offsets instead of subtracting timestamps directly.

Fixes #2001.

## Validation

- `cargo fmt`
- `cargo test -p moq-mux -p moq-srt` (all `moq-mux` tests passed; two `moq-srt` dial tests were blocked by sandbox socket permissions)
- `cargo test -p moq-srt server::tests`
- `git diff --check`

(Written by GPT-5)