### PR TITLE
[codex] fix FLV export DTS timestamps

### DIFF
--- a/rs/moq-mux/src/container/flv/export.rs
+++ b/rs/moq-mux/src/container/flv/export.rs
@@ -56,6 +56,10 @@ impl Flavor {
 			Flavor::Avc | Flavor::Aac | Flavor::Mp3 => None,
 		}
 	}
+
+	fn has_composition_time(self) -> bool {
+		matches!(self, Flavor::Avc | Flavor::Hevc)
+	}
 }
 
 /// Subscribe to a broadcast and produce an FLV byte stream.
@@ -97,6 +101,21 @@ struct FlvTrack {
 	/// tag, used when the catalog (and thus [`ExportSource::description`]) carries
 	/// none. Only AV1 needs this today (its av1C is optional in the catalog).
 	fallback_description: Option<Bytes>,
+	/// How far to run the authored decode clock behind the PTS, in FLV milliseconds.
+	dts_reserve: u32,
+	/// Last authored video DTS, in FLV milliseconds.
+	last_dts: Option<u32>,
+}
+
+impl FlvTrack {
+	fn tag_timestamp(&self, frame: &Frame) -> anyhow::Result<u32> {
+		let pts = frame_timestamp_ms(frame)?;
+		if self.flavor.has_composition_time() {
+			author_dts(pts, self.dts_reserve, self.last_dts)
+		} else {
+			Ok(pts)
+		}
+	}
 }
 
 impl Export {
@@ -190,8 +209,8 @@ impl Export {
 			return Poll::Pending;
 		}
 
-		// 4. Emit the smallest-timestamp pending frame as one tag.
-		if let Some(is_video) = self.pick_next_track() {
+		// 4. Emit the smallest FLV tag timestamp as one tag.
+		if let Some(is_video) = self.pick_next_track()? {
 			let track = if is_video {
 				self.video.as_mut()
 			} else {
@@ -246,6 +265,8 @@ impl Export {
 				finished: false,
 				flavor,
 				fallback_description,
+				dts_reserve: dts_reserve(config),
+				last_dts: None,
 			});
 		}
 		if catalog.video.renditions.len() > 1 {
@@ -265,6 +286,8 @@ impl Export {
 				finished: false,
 				flavor,
 				fallback_description: None,
+				dts_reserve: 0,
+				last_dts: None,
 			});
 		}
 		if catalog.audio.renditions.len() > 1 {
@@ -330,36 +353,36 @@ impl Export {
 		Ok(out.freeze())
 	}
 
-	/// Pick the track with the smallest pending timestamp. Returns whether it's the
-	/// video track, or `None` if no frame is pending.
-	fn pick_next_track(&self) -> Option<bool> {
+	/// Pick the track with the smallest pending FLV tag timestamp. Returns whether
+	/// it's the video track, or `None` if no frame is pending.
+	fn pick_next_track(&self) -> anyhow::Result<Option<bool>> {
 		let video = self
 			.video
 			.as_ref()
-			.and_then(|t| t.pending.as_ref())
-			.map(|f| f.timestamp);
+			.and_then(|track| track.pending.as_ref().map(|frame| track.tag_timestamp(frame)))
+			.transpose()?;
 		let audio = self
 			.audio
 			.as_ref()
 			.and_then(|t| t.pending.as_ref())
-			.map(|f| f.timestamp);
-		match (video, audio) {
+			.map(frame_timestamp_ms)
+			.transpose()?;
+		Ok(match (video, audio) {
 			(Some(v), Some(a)) => Some(v <= a),
 			(Some(_), None) => Some(true),
 			(None, Some(_)) => Some(false),
 			(None, None) => None,
-		}
+		})
 	}
 
 	/// Encode one frame as a single FLV tag.
-	fn encode_frame(&self, is_video: bool, frame: Frame) -> anyhow::Result<Bytes> {
-		let timestamp_ms: u32 = (frame.timestamp.as_millis())
-			.try_into()
-			.context("FLV timestamp exceeds 32 bits")?;
-
+	fn encode_frame(&mut self, is_video: bool, frame: Frame) -> anyhow::Result<Bytes> {
 		let mut out = BytesMut::with_capacity(TAG_HEADER_LEN + frame.payload.len() + 8);
 		if is_video {
-			let flavor = self.video.as_ref().expect("video frame without a video track").flavor;
+			let track = self.video.as_mut().expect("video frame without a video track");
+			let flavor = track.flavor;
+			let pts_ms = frame_timestamp_ms(&frame)?;
+			let timestamp_ms = track.tag_timestamp(&frame)?;
 			let frame_type = if frame.keyframe {
 				FRAME_TYPE_KEY
 			} else {
@@ -367,25 +390,29 @@ impl Export {
 			};
 			let mut body = BytesMut::with_capacity(8 + frame.payload.len());
 			match flavor.fourcc() {
-				// Legacy AVC: CodecID + AVCPacketType + composition time (PTS in the tag).
+				// Legacy AVC: CodecID + AVCPacketType + signed composition time.
 				None => {
 					body.put_u8((frame_type << 4) | VIDEO_CODEC_AVC);
 					body.put_u8(AVC_NALU);
-					body.put_slice(&[0, 0, 0]);
+					write_i24(&mut body, composition_time(pts_ms, timestamp_ms)?)?;
 				}
 				// Enhanced FourCC CodedFrames. hvc1 keeps the 3-byte composition
-				// time (zero, since we carry PTS in the tag); av01/vp09 omit it.
+				// time; av01/vp09 omit it.
 				Some(fourcc) => {
 					body.put_u8(VIDEO_EX_HEADER | (frame_type << 4) | VIDEO_PACKET_CODED_FRAMES);
 					body.put_slice(&fourcc);
 					if flavor == Flavor::Hevc {
-						body.put_slice(&[0, 0, 0]);
+						write_i24(&mut body, composition_time(pts_ms, timestamp_ms)?)?;
 					}
 				}
+			}
+			if flavor.has_composition_time() {
+				track.last_dts = Some(timestamp_ms);
 			}
 			body.put_slice(&frame.payload);
 			write_tag(&mut out, TAG_VIDEO, timestamp_ms, &body)?;
 		} else {
+			let timestamp_ms = frame_timestamp_ms(&frame)?;
 			let flavor = self.audio.as_ref().expect("audio frame without an audio track").flavor;
 			let mut body = BytesMut::with_capacity(5 + frame.payload.len());
 			match flavor {
@@ -457,6 +484,49 @@ fn audio_flavor(config: &hang::catalog::AudioConfig) -> anyhow::Result<Flavor> {
 		AudioCodec::Ec3 => Ok(Flavor::Eac3),
 		other => anyhow::bail!("FLV export does not support audio codec {other:?}"),
 	}
+}
+
+fn frame_timestamp_ms(frame: &Frame) -> anyhow::Result<u32> {
+	frame
+		.timestamp
+		.as_millis()
+		.try_into()
+		.context("FLV timestamp exceeds 32 bits")
+}
+
+fn composition_time(pts: u32, dts: u32) -> anyhow::Result<i32> {
+	let cts = i64::from(pts) - i64::from(dts);
+	i32::try_from(cts)
+		.ok()
+		.filter(|cts| (-0x80_0000..=0x7f_ffff).contains(cts))
+		.context("FLV composition time exceeds signed 24 bits")
+}
+
+fn write_i24(out: &mut BytesMut, value: i32) -> anyhow::Result<()> {
+	anyhow::ensure!(
+		(-0x80_0000..=0x7f_ffff).contains(&value),
+		"FLV composition time exceeds signed 24 bits"
+	);
+	out.put_slice(&(value as u32).to_be_bytes()[1..]);
+	Ok(())
+}
+
+fn author_dts(pts: u32, reserve: u32, last: Option<u32>) -> anyhow::Result<u32> {
+	let mut dts = pts.saturating_sub(reserve);
+	if let Some(prev) = last
+		&& dts <= prev
+	{
+		dts = prev.checked_add(1).context("FLV DTS exceeds 32 bits")?;
+	}
+	Ok(dts)
+}
+
+fn dts_reserve(config: &hang::catalog::VideoConfig) -> u32 {
+	config
+		.jitter
+		.and_then(|t| u32::try_from(t.as_millis()).ok())
+		.filter(|reserve| *reserve > 0)
+		.unwrap_or(1)
 }
 
 /// Build the FLV video sequence-header tag body, or `None` for codecs that carry

--- a/rs/moq-mux/src/container/flv/export_test.rs
+++ b/rs/moq-mux/src/container/flv/export_test.rs
@@ -5,6 +5,7 @@
 
 use std::time::Duration;
 
+use bytes::Bytes;
 use hang::catalog::{AudioCodec, VideoCodec};
 
 use super::{Export, Import};
@@ -356,7 +357,7 @@ fn parse_tags(flv: &[u8]) -> Vec<ParsedTag> {
 	tags
 }
 
-/// A frame's tag timestamp must survive the round trip (PTS in milliseconds).
+/// A frame's presentation timestamp must survive as DTS plus composition time.
 #[tokio::test(start_paused = true)]
 async fn export_preserves_timestamps() {
 	let mut producer = moq_net::Broadcast::new().produce();
@@ -371,10 +372,119 @@ async fn export_preserves_timestamps() {
 	let exported = drain_export(exporter, importer).await;
 
 	let tags = parse_tags(&exported);
-	let video_ts: Vec<u32> = tags
+	let video_pts: Vec<i64> = tags
 		.iter()
 		.filter(|t| t.tag_type == super::TAG_VIDEO && t.body[1] == super::AVC_NALU)
-		.map(|t| t.timestamp)
+		.map(|t| i64::from(t.timestamp) + i64::from(super::read_i24(&t.body[2..5])))
 		.collect();
-	assert_eq!(video_ts, vec![0, 33]);
+	assert_eq!(video_pts, vec![0, 33]);
+}
+
+#[tokio::test(start_paused = true)]
+async fn export_authors_dts_and_composition_time_for_reordered_avc() {
+	use crate::container::Timestamp;
+	use hang::catalog::{AAC, AudioConfig, Container, H264, VideoConfig};
+
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let consumer = producer.consume();
+
+	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let video_track = producer
+		.create_track(moq_net::Track::new(producer.unique_name(".avc1")))
+		.unwrap();
+	let audio_track = producer
+		.create_track(moq_net::Track::new(producer.unique_name(".aac")))
+		.unwrap();
+
+	let mut video_config = VideoConfig::new(H264 {
+		profile: 0x42,
+		constraints: 0xc0,
+		level: 0x1f,
+		inline: false,
+	});
+	video_config.container = Container::Legacy;
+	video_config.description = Some(Bytes::from(avcc()));
+	video_config.jitter = Some(moq_net::Time::try_from(Duration::from_millis(80)).unwrap());
+	catalog
+		.lock()
+		.video
+		.renditions
+		.insert(video_track.name().to_string(), video_config);
+
+	let mut audio_config = AudioConfig::new(AAC { profile: 2 }, 44100, 2);
+	audio_config.container = Container::Legacy;
+	audio_config.description = Some(Bytes::from_static(&ASC));
+	catalog
+		.lock()
+		.audio
+		.renditions
+		.insert(audio_track.name().to_string(), audio_config);
+
+	let mut video = crate::container::Producer::new(video_track, crate::catalog::hang::Container::Legacy);
+	let video_frame = |timestamp_ms: u64, payload: &'static [u8], keyframe| crate::container::Frame {
+		timestamp: Timestamp::from_millis(timestamp_ms).unwrap(),
+		duration: None,
+		payload: Bytes::from_static(payload),
+		keyframe,
+	};
+	video.write(video_frame(0, &[0, 0, 0, 1, 0x65], true)).unwrap();
+	video.write(video_frame(80, &[0, 0, 0, 1, 0x41], false)).unwrap();
+	video.write(video_frame(40, &[0, 0, 0, 1, 0x01], false)).unwrap();
+	video.write(video_frame(120, &[0, 0, 0, 1, 0x41], false)).unwrap();
+	video.finish().unwrap();
+
+	let mut audio = crate::container::Producer::new(audio_track, crate::catalog::hang::Container::Legacy);
+	audio
+		.write(crate::container::Frame {
+			timestamp: Timestamp::from_millis(20).unwrap(),
+			duration: None,
+			payload: Bytes::from_static(&[0xde, 0xad]),
+			keyframe: true,
+		})
+		.unwrap();
+	audio.finish().unwrap();
+	catalog.finish().unwrap();
+
+	let exporter = Export::new(consumer).unwrap();
+	let exported = drain_exporter_chunks(exporter, 6).await;
+	let tags = parse_tags(&exported);
+
+	let tag_timestamps: Vec<u32> = tags.iter().map(|tag| tag.timestamp).collect();
+	assert!(
+		tag_timestamps.windows(2).all(|pair| pair[1] >= pair[0]),
+		"FLV tag timestamps must not go backwards: {tag_timestamps:?}"
+	);
+
+	let video_frames: Vec<(u32, i32)> = tags
+		.iter()
+		.filter(|tag| tag.tag_type == super::TAG_VIDEO && tag.body[1] == super::AVC_NALU)
+		.map(|tag| (tag.timestamp, super::read_i24(&tag.body[2..5])))
+		.collect();
+	assert_eq!(
+		video_frames.iter().map(|(dts, _)| *dts).collect::<Vec<_>>(),
+		vec![0, 1, 2, 40],
+		"video tag timestamps should be authored DTS"
+	);
+	assert_eq!(
+		video_frames
+			.iter()
+			.map(|(dts, cts)| i64::from(*dts) + i64::from(*cts))
+			.collect::<Vec<_>>(),
+		vec![0, 80, 40, 120],
+		"composition time should recover the source PTS"
+	);
+}
+
+async fn drain_exporter_chunks(mut exporter: Export, chunks: usize) -> Vec<u8> {
+	let mut exported = Vec::new();
+	for _ in 0..chunks {
+		match tokio::time::timeout(Duration::from_millis(100), exporter.next()).await {
+			Ok(Ok(Some(chunk))) => exported.extend_from_slice(&chunk),
+			Ok(Ok(None)) => panic!("exporter ended early"),
+			Ok(Err(e)) => panic!("exporter error: {e}"),
+			Err(_) => panic!("exporter timed out"),
+		}
+	}
+	exported
 }


### PR DESCRIPTION
## Summary
- Author FLV video tag timestamps as DTS for AVC/HEVC instead of writing PTS into the tag timestamp.
- Emit signed composition time so DTS + CTS recovers the original PTS.
- Add a reordered AVC regression that verifies monotonic FLV tag timestamps and PTS recovery.

## Root Cause
FLV tag timestamps are decode timestamps, but the exporter wrote presentation timestamps and zero composition offsets. B-frame streams therefore produced non-monotonic DTS on RTMP/FLV playback.

## Validation
- cargo test -p moq-mux container::flv::export_test -- --nocapture
- cargo test -p moq-mux
- just fix
- just check progressed through JS, Rust check, clippy, fmt, docs, shear, and sort, then failed on unrelated repo-wide justfile formatting drift.

Fixes #2000

(Written by GPT-5)