### PR TITLE
[codex] fix dev cli doc cleanups

### DIFF
--- a/demo/pub/justfile
+++ b/demo/pub/justfile
@@ -12,13 +12,7 @@ deploy:
     bun install
     bun wrangler deploy
 
-# Upload a single file to R2.
-# NOTE: Videos should be fragmented to minimize latency when streaming.
-# Use ffmpeg to fragment before uploading:
-#	 ffmpeg -i input.mp4 -c copy -f mp4 \
-#		 -movflags cmaf+separate_moof+delay_moov+skip_trailer+frag_every_frame \
-
-# output.mp4
+# Upload a single file to R2. Fragment videos first, e.g. `ffmpeg -i input.mp4 -c copy -f mp4 -movflags cmaf+separate_moof+delay_moov+skip_trailer+frag_every_frame output.mp4`.
 upload file:
     bun install
     bun wrangler r2 object put "video-moq-dev/{{ file }}" --file "media/{{ file }}" --remote
@@ -54,24 +48,18 @@ tos url='http://localhost:4443' *args:
 # Publish a video using ffmpeg (CMAF / fMP4) to a relay server.
 cmaf name url='http://localhost:4443' *args:
     cargo build --bin moq
-    just ffmpeg-cmaf "media/{{ name }}.mp4" |\
-    cargo run --bin moq -- \
-    	{{ args }} --client-connect "{{ url }}" --broadcast "{{ name }}.hang" import fmp4
+    just ffmpeg-cmaf "media/{{ name }}.mp4" | cargo run --bin moq -- {{ args }} --client-connect "{{ url }}" --broadcast "{{ name }}.hang" import fmp4
 
 # Publish a video using ffmpeg (MPEG-TS) to a relay server.
 ts name url='http://localhost:4443' *args:
     cargo build --bin moq
-    just ffmpeg-ts "media/{{ name }}.mp4" |\
-    cargo run --bin moq -- \
-    	{{ args }} --client-connect "{{ url }}" --broadcast "{{ name }}.hang" import ts
+    just ffmpeg-ts "media/{{ name }}.mp4" | cargo run --bin moq -- {{ args }} --client-connect "{{ url }}" --broadcast "{{ name }}.hang" import ts
 
 # Publish a video via iroh.
 iroh name url prefix="":
     just download "{{ name }}"
     cargo build --bin moq
-    just ffmpeg-cmaf "media/{{ name }}.mp4" |\
-    cargo run --bin moq -- \
-    	--iroh-enabled --client-connect "{{ url }}" --broadcast "{{ prefix }}{{ name }}.hang" import fmp4
+    just ffmpeg-cmaf "media/{{ name }}.mp4" | cargo run --bin moq -- --iroh-enabled --client-connect "{{ url }}" --broadcast "{{ prefix }}{{ name }}.hang" import fmp4
 
 # Generate and ingest an HLS stream from a video file.
 hls name relay="http://localhost:4443":
@@ -166,10 +154,7 @@ h264 name url="http://localhost:4443" *args:
 serve name *args:
     just download "{{ name }}"
     cargo build --bin moq
-    just ffmpeg-cmaf "media/{{ name }}.mp4" |\
-    cargo run --bin moq -- \
-    	{{ args }} --server-bind "[::]:4443" --tls-generate "localhost" \
-    	--broadcast "{{ name }}.hang" import fmp4
+    just ffmpeg-cmaf "media/{{ name }}.mp4" | cargo run --bin moq -- {{ args }} --server-bind "[::]:4443" --tls-generate "localhost" --broadcast "{{ name }}.hang" import fmp4
 
 # Generate and serve an HLS stream from a video for testing.
 serve-hls name port="8000":
@@ -254,11 +239,7 @@ ffmpeg-cmaf input output='-' *args:
     	-c copy \
     	-f mp4 -movflags cmaf+separate_moof+delay_moov+skip_trailer+frag_every_frame {{ args }} {{ output }}
 
-# Convert an h264 input file to MPEG-TS format to stdout.
-#
-# `-pes_payload_size 0` flushes one PES per audio frame instead of batching ~8
-# (the default 2930-byte minimum), so audio interleaves evenly with video rather
-# than arriving in ~185ms bursts. Without it the player must buffer a whole burst.
+# Convert an h264 input file to MPEG-TS format to stdout, with one PES per audio frame.
 [private]
 ffmpeg-ts input output='-' *args:
     ffmpeg -hide_banner -v quiet \

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -134,7 +134,7 @@ default features:
 
 ```bash
 cargo build --release -p moq-cli --no-default-features \
-    --features "iroh quinn websocket capture"
+    --features "iroh noq websocket capture"
 ```
 
 Video capture uses a native per-platform backend (AVFoundation on macOS, V4L2 on
@@ -199,6 +199,8 @@ Export formats:
 - `mkv` - Matroska / WebM
 - `ts` - MPEG-TS
 - `flv` - FLV / RTMP (H.264 video, AAC audio)
+- `h264` - raw H.264 Annex-B
+- `h265` - raw H.265 Annex-B
 
 `export` also takes `--catalog-format` to pick which catalog track to read for track
 discovery. When omitted, it's auto-detected from the broadcast name suffix
@@ -207,6 +209,24 @@ discovery. When omitted, it's auto-detected from the broadcast name suffix
 - `hang` - the `catalog.json` JSON catalog (default)
 - `hangz` - the DEFLATE-compressed `catalog.json.z` catalog (opt-in; shares the `.hang` suffix and is never auto-detected)
 - `msf` - the MSF `catalog` track
+
+Stdout exports can also select one rendition per media role before the sink
+subcommand:
+
+```bash
+moq --client-connect https://relay.example.com/anon --broadcast my-stream.hang \
+    export --video-name 720p --audio-codec opus fmp4 | ffplay -
+```
+
+- `--video-name <name>` picks the video rendition with that exact catalog name.
+- `--video-codec <h264|h265|vp8|vp9|av1>` keeps only matching video renditions.
+- `--audio-name <name>` picks the audio rendition with that exact catalog name.
+- `--audio-codec <aac|opus>` keeps only matching audio renditions.
+
+With no selection flags, every matching rendition is kept. The `h264` and `h265`
+export sinks force the matching video codec, so use `export h264` / `export h265`
+for raw elementary streams instead of combining those sinks with a contradictory
+`--video-codec`.
 
 Every export sink caps how long a stalled group is waited on before the muxer
 skips to a newer one. Each owns the knob so its default fits the transport: the

--- a/doc/lib/rs/env/wasm.md
+++ b/doc/lib/rs/env/wasm.md
@@ -75,7 +75,7 @@ let transport = web_transport::ClientBuilder::new()
 let origin = moq_net::Origin::new().produce();
 let mut consumer = origin.consume();
 let session = moq_net::Client::new()
-    .with_consume(origin)
+    .with_subscriber(origin)
     .connect(transport)
     .await?;
 

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -243,7 +243,7 @@ into the session before connecting:
 // Subscribe: wait for broadcasts to be announced.
 let origin = moq_net::Origin::new().produce();
 let mut consumer = origin.consume();
-let session = client.with_consume(origin).connect(url).await?;
+let session = client.with_subscriber(origin).connect(url).await?;
 
 while let Some((path, broadcast)) = consumer.announced().await {
     // ... subscribe to tracks on each broadcast ...

--- a/justfile
+++ b/justfile
@@ -1,21 +1,17 @@
 #!/usr/bin/env just --justfile
 # Using Just: https://github.com/casey/just?tab=readme-ov-file#installation
-# Per-language modules. Anything that's specific to one language lives in
 
-# its own justfile; the recipes below orchestrate across them.
+# Per-language modules. Language-specific recipes live in their own justfiles.
 mod js
 mod rs
 mod py
 mod kt
 mod swift
 mod go
-
 # OBS Studio plugin (C++). See doc/bin/obs.md.
 mod obs 'cpp/obs'
-
 # Unit tests per language (`just test`).
 mod test
-
 # Demos and infra.
 mod demo
 mod infra
@@ -36,18 +32,12 @@ default:
 dev:
     just demo
 
-# Install repo-wide tooling. Per-language deps install on first invocation
-
-# of `just <lang> check`.
+# Install repo-wide tooling. Per-language deps install on first check.
 install:
     bun install
     cargo install --locked cargo-shear cargo-sort cargo-upgrades cargo-edit cargo-semver-checks release-plz
 
-# Fast inner-loop checks. Runs JS, Rust, and Markdown lints.
-# Shell + workflow + TOML + Nix + justfile lints skip silently if their
-# binaries aren't on $PATH; `nix develop` provides them, and `just ci`
-
-# requires them.
+# Fast inner-loop checks. Optional shell, workflow, TOML, Nix, and justfile lints skip if missing.
 check *args:
     just js check
     just rs check {{ args }}
@@ -58,10 +48,7 @@ check *args:
     @for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); do just --fmt --unstable --check --justfile "$f"; done
     just gh check
 
-# Run every per-language `ci` with the diff vs BASE; each greps for its
-# own scope and skips when nothing relevant changed. Pass BASE="" to
-
-# default to $GITHUB_BASE_REF (CI) or origin/main (local).
+# Run per-language CI against BASE, skipping scopes with no relevant diff.
 ci BASE="":
     #!/usr/bin/env bash
     set -euo pipefail
@@ -116,9 +103,7 @@ ci BASE="":
     for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); do just --fmt --unstable --check --justfile "$f"; done
     just gh ci
 
-# Auto-fix linting/formatting issues across all languages.
-
-# shfmt / taplo / nixfmt / just --fmt skipped silently if missing locally.
+# Auto-fix linting/formatting issues; optional tools skip if missing locally.
 fix:
     just js fix
     just rs fix
@@ -136,23 +121,13 @@ build:
     if command -v uv &> /dev/null; then just py build; fi
     if command -v wasm-bindgen &> /dev/null; then just wasm; fi
 
-# Build the browser/WASM bindings (rs/moq-wasm) into the @moq/wasm package.
-# wasm-bindgen comes from the Nix dev shell (its version must match the pinned
-# wasm-bindgen crate); the wasm32 target, the size-optimized `wasm-release`
-# profile, and cfg flags (getrandom, web-sys unstable) live in Cargo.toml and
-# .cargo/config.toml. The profile already optimizes for size; wasm-opt is
-# skipped since it didn't improve the gzipped (over-the-wire) size here.
-# Resolve the artifact via CARGO_TARGET_DIR so it also works on runners that
-# redirect the target directory (it defaults to `target`).
+# Build browser/WASM bindings into @moq/wasm using the pinned wasm-bindgen toolchain.
 wasm:
     cargo build -p moq-wasm --target wasm32-unknown-unknown --profile wasm-release
     wasm-bindgen --target web --out-name moq \
     	--out-dir js/wasm/dist "${CARGO_TARGET_DIR:-target}/wasm32-unknown-unknown/wasm-release/moq_wasm.wasm"
 
-# Delete build artifacts and caches to reclaim disk space. Each language
-# owns its own `clean` (see js/rs/py/kt/swift/go justfiles); this
-# orchestrates them, sweeps the caches no language owns, then recurses into
-# any agent worktrees under .claude/worktrees/.
+# Delete build artifacts and caches, including per-language outputs and agent worktrees.
 clean:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -34,7 +34,7 @@ capture = ["dep:moq-video", "dep:moq-audio", "moq-audio/capture"]
 # NVENC / VAAPI hardware encoders for `capture` (Linux), on by default. Each just
 # turns on the matching moq-video feature, and only bites when `capture` pulls in
 # moq-video. For a `capture` build with no CUDA / libva system deps, drop them, e.g.
-#   cargo build -p moq-cli --no-default-features --features "iroh quinn websocket capture"
+#   cargo build -p moq-cli --no-default-features --features "iroh noq websocket capture"
 nvenc = ["moq-video?/nvenc"]
 vaapi = ["moq-video?/vaapi"]
 

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -82,8 +82,10 @@ pub struct MoqSide {
 #[derive(Subcommand, Clone)]
 pub enum Direction {
 	/// Route media INTO MoQ from one source.
+	#[command(alias = "publish")]
 	Import(Import),
 	/// Route media OUT OF MoQ to one sink.
+	#[command(alias = "subscribe")]
 	Export(Export),
 }
 

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -222,13 +222,13 @@ impl Client {
 		self
 	}
 
-	/// Deprecated alias for [`with_publisher`](Self::with_publisher).
+	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_publisher`")]
 	pub fn with_publish(self, publish: moq_net::OriginConsumer) -> Self {
 		self.with_publisher(publish)
 	}
 
-	/// Deprecated alias for [`with_subscriber`](Self::with_subscriber).
+	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_subscriber`")]
 	pub fn with_consume(self, subscribe: moq_net::OriginProducer) -> Self {
 		self.with_subscriber(subscribe)

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -396,13 +396,13 @@ impl Server {
 		self
 	}
 
-	/// Deprecated alias for [`with_publisher`](Self::with_publisher).
+	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_publisher`")]
 	pub fn with_publish(self, publish: moq_net::OriginConsumer) -> Self {
 		self.with_publisher(publish)
 	}
 
-	/// Deprecated alias for [`with_subscriber`](Self::with_subscriber).
+	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_subscriber`")]
 	pub fn with_consume(self, subscribe: moq_net::OriginProducer) -> Self {
 		self.with_subscriber(subscribe)
@@ -982,13 +982,13 @@ impl Request {
 		}
 	}
 
-	/// Deprecated alias for [`with_publisher`](Self::with_publisher).
+	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_publisher`")]
 	pub fn with_publish(self, publish: moq_net::OriginConsumer) -> Self {
 		self.with_publisher(publish)
 	}
 
-	/// Deprecated alias for [`with_subscriber`](Self::with_subscriber).
+	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_subscriber`")]
 	pub fn with_consume(self, subscribe: moq_net::OriginProducer) -> Self {
 		self.with_subscriber(subscribe)

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -35,13 +35,13 @@ impl Client {
 		self
 	}
 
-	/// Deprecated alias for [`with_publisher`](Self::with_publisher).
+	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_publisher`")]
 	pub fn with_publish(self, publish: OriginConsumer) -> Self {
 		self.with_publisher(publish)
 	}
 
-	/// Deprecated alias for [`with_subscriber`](Self::with_subscriber).
+	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_subscriber`")]
 	pub fn with_consume(self, subscribe: OriginProducer) -> Self {
 		self.with_subscriber(subscribe)

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -492,7 +492,7 @@ impl OriginNode {
 			//
 			// Drop duplicates (same underlying broadcast delivered via multiple links) so the
 			// backup queue can't accumulate clones of the active entry and trigger redundant
-			// restartments when a peer churns.
+			// re-announces when a peer churns.
 			if existing.active.is_clone(broadcast) || existing.backup.iter().any(|b| b.is_clone(broadcast)) {
 				return;
 			}

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -35,13 +35,13 @@ impl Server {
 		self
 	}
 
-	/// Deprecated alias for [`with_publisher`](Self::with_publisher).
+	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_publisher`")]
 	pub fn with_publish(self, publish: OriginConsumer) -> Self {
 		self.with_publisher(publish)
 	}
 
-	/// Deprecated alias for [`with_subscriber`](Self::with_subscriber).
+	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_subscriber`")]
 	pub fn with_consume(self, subscribe: OriginProducer) -> Self {
 		self.with_subscriber(subscribe)

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -21,8 +21,9 @@ const MESH_PREFIX: &str = ".internal/origins";
 const SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 
 /// How long a peer must stay unannounced before we abort the dial. Must clear the
-/// "prefer shorter hop" restart flap (which arrives as unannounce-then-announce
-/// within sub-milliseconds) plus reasonable churn from a peer restart.
+/// "prefer shorter hop" re-announce flap (which arrives as
+/// unannounce-then-announce within sub-milliseconds) plus reasonable churn from
+/// a peer restart.
 const STALE_AFTER: Duration = Duration::from_secs(60);
 
 /// How often the relay re-checks an http(s) `--cluster-connect-api` endpoint. The
@@ -594,7 +595,7 @@ impl Cluster {
 	/// instead of two. Unannounces don't abort immediately. They just mark the
 	/// entry as "pending cleanup" with a timestamp. A periodic sweep evicts
 	/// entries whose unannounce has stuck for [`STALE_AFTER`]. The "prefer
-	/// shorter hop" path in OriginProducer delivers restartments as
+	/// shorter hop" path in OriginProducer delivers re-announces as
 	/// unannounce-then-announce within sub-milliseconds, which clears the
 	/// pending-cleanup timestamp long before the sweep fires.
 	async fn run_discovery(self, self_url: String, token: String, dialed: DialMap) {
@@ -1002,7 +1003,7 @@ mod tests {
 		assert!(dialed.contains("healthy:4443"));
 	}
 
-	/// A restart after an unannounce clears the pending-sweep timestamp, so
+	/// A re-announce after an unannounce clears the pending-sweep timestamp, so
 	/// the entry survives even if the original unannounce was old enough to
 	/// otherwise trigger eviction.
 	#[tokio::test]


### PR DESCRIPTION
## Summary
- document the current moq-cli export surface, including raw H.264/H.265 sinks and rendition selection flags
- keep deprecated publish/subscribe and with_publish/with_consume paths working but hidden from generated docs/help
- clean up stale transport examples, re-announce wording, and justfile comments that were mangled by just formatting

## Test Plan
- cargo check -p moq-cli -p moq-native -p moq-net -p moq-relay
- cargo fmt --check
- just --fmt --unstable --check --justfile justfile
- just --fmt --unstable --check --justfile demo/pub/justfile
- git diff --check
- just --list --justfile justfile
- just --list --justfile demo/pub/justfile

(Written by GPT-5)