### PR TITLE
[codex] fix MSF catalog root semantics

### DIFF
--- a/rs/moq-msf/CHANGELOG.md
+++ b/rs/moq-msf/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Preserve draft-00 `generatedAt` and `isComplete` as version-neutral `Catalog` fields so broadcast termination can be represented.
+- Mark `Catalog` as `#[non_exhaustive]` and add `Catalog::new` for external construction.
+
+### Fixed
+
+- Reject draft-01 tracks whose `initRef` points at a missing or unsupported `initDataList` entry instead of silently exposing `Track::init_data = None`.
+
 ## [0.3.0](https://github.com/moq-dev/moq/compare/moq-msf-v0.2.0...moq-msf-v0.3.0) - 2026-06-30
 
 ### Other
@@ -15,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Track draft-ietf-moq-msf-01, with the wire format hidden behind the API. `Catalog` is now a version-agnostic snapshot (`{ tracks }`); the `version` field and the `Version` enum are gone. Parsing accepts draft-00 (numeric `version`, inline `initData`) and draft-01 (string `version`, root `initDataList` + per-track `initRef`); serializing always emits draft-01. Init data is resolved to inline `Track::init_data` on parse and hoisted into a deduplicated `initDataList` on serialize, so callers never touch the version or the init-data indirection.
+- Track draft-ietf-moq-msf-01, with the wire format hidden behind the API. `Catalog` is now a version-agnostic snapshot (`{ tracks }`) and no longer exposes the wire `version` field. Parsing accepts draft-00 (numeric `version`, inline `initData`) and draft-01 (string `version`, root `initDataList` + per-track `initRef`); serializing always emits draft-01. Init data is resolved to inline `Track::init_data` on parse and hoisted into a deduplicated `initDataList` on serialize, so callers never touch the version or the init-data indirection.
 
 ## [0.2.0](https://github.com/moq-dev/moq/compare/moq-msf-v0.1.3...moq-msf-v0.2.0) - 2026-05-23
 

--- a/rs/moq-msf/README.md
+++ b/rs/moq-msf/README.md
@@ -13,7 +13,7 @@ Catalog types for the MOQT Streaming Format (MSF).
 This crate implements the catalog format defined in [draft-ietf-moq-msf-01](https://www.ietf.org/archive/id/draft-ietf-moq-msf-01.txt),
 with additional support for CMAF packaging from [draft-ietf-moq-cmsf-00](https://www.ietf.org/archive/id/draft-ietf-moq-cmsf-00.txt).
 
-`Catalog` is a version-agnostic snapshot of tracks: the wire details (the catalog `version` and draft-01's `initDataList`/`initRef` indirection for init data) are handled during (de)serialization. Parsing accepts both draft-00 and draft-01 catalogs and serializing always emits the newest draft, so older publishers remain compatible and callers never touch the version on the wire.
+`Catalog` is a version-agnostic snapshot of tracks: the wire details (the catalog `version` and draft-01's `initDataList`/`initRef` indirection for init data) are handled during (de)serialization. Parsing accepts both draft-00 and draft-01 catalogs and serializing always emits the newest draft, so older publishers remain compatible and callers never touch the version on the wire. draft-00's `generatedAt` and `isComplete` remain available as root catalog fields.
 
 Used by [moq-mux](https://github.com/moq-dev/moq/tree/main/rs/moq-mux) for muxing/demuxing media. For the higher-level [hang](https://github.com/moq-dev/moq/tree/main/rs/hang) catalog format used elsewhere in this repo, see that crate.
 

--- a/rs/moq-msf/src/lib.rs
+++ b/rs/moq-msf/src/lib.rs
@@ -10,7 +10,8 @@
 //! held in a root `initDataList` and referenced per-track by `initRef`).
 //! Serializing always emits the newest draft, and init data is resolved to
 //! inline [`Track::init_data`] either way, so callers never touch the version
-//! or the init-data indirection.
+//! or the init-data indirection. draft-00's `generatedAt` and `isComplete`
+//! fields stay available as version-neutral catalog fields.
 //!
 //! References:
 //! - <https://www.ietf.org/archive/id/draft-ietf-moq-msf-01.txt>
@@ -33,8 +34,19 @@ pub const DEFAULT_NAME: &str = "catalog";
 /// data) are handled during (de)serialization, so callers only ever see
 /// resolved tracks with inline [`Track::init_data`]. Parsing accepts both
 /// draft-00 and draft-01 catalogs; serializing always emits the newest draft.
+///
+/// Marked `#[non_exhaustive]` because the MSF drafts continue to grow optional
+/// root fields. External callers build a catalog with [`Catalog::new`] or
+/// [`Catalog::default`] and then assign whichever optional fields they need.
 #[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
 pub struct Catalog {
+	/// Catalog generation time as Unix epoch milliseconds.
+	pub generated_at: Option<u64>,
+
+	/// Whether the broadcast has finished and no more tracks will appear.
+	pub is_complete: bool,
+
 	/// The tracks in this catalog snapshot.
 	pub tracks: Vec<Track>,
 }
@@ -129,6 +141,15 @@ pub struct Track {
 }
 
 impl Catalog {
+	/// Construct a catalog with tracks and no root-level optional fields.
+	pub fn new(tracks: Vec<Track>) -> Self {
+		Self {
+			generated_at: None,
+			is_complete: false,
+			tracks,
+		}
+	}
+
 	/// Serialize the MSF catalog to a JSON string.
 	pub fn to_string(&self) -> Result<String, serde_json::Error> {
 		serde_json::to_string(self)
@@ -177,6 +198,8 @@ impl Serialize for Catalog {
 
 		Wire {
 			version: WireVersion,
+			generated_at: self.generated_at,
+			is_complete: self.is_complete,
 			tracks,
 			init_data_list: (!init_data_list.is_empty()).then_some(init_data_list),
 		}
@@ -191,32 +214,58 @@ impl<'de> Deserialize<'de> for Catalog {
 		let wire = Wire::deserialize(deserializer)?;
 		let init_data_list = wire.init_data_list.unwrap_or_default();
 
-		// id -> inline payload, built once so resolution is linear in the number
+		// id -> init data entry, built once so resolution is linear in the number
 		// of tracks rather than tracks x entries.
-		let inline: HashMap<&str, &str> = init_data_list
-			.iter()
-			.filter(|e| e.kind == "inline")
-			.map(|e| (e.id.as_str(), e.data.as_str()))
-			.collect();
+		let by_id: HashMap<&str, &InitData> = init_data_list.iter().map(|e| (e.id.as_str(), e)).collect();
 
 		let tracks = wire
 			.tracks
 			.into_iter()
-			.map(|mut track| {
+			.map(|mut track| -> Result<Track, D::Error> {
 				// Resolve draft-01 initRef into inline init_data so callers never
-				// see the indirection. Inline init_data (draft-00) is kept as-is.
-				if track.init_data.is_none() {
-					if let Some(id) = track.init_ref.take() {
-						track.init_data = inline.get(id.as_str()).map(|data| data.to_string());
+				// see the indirection. Inline init_data (draft-00) is kept as-is,
+				// but a catalog that carries both forms must not disagree.
+				if let Some(id) = track.init_ref.take() {
+					let entry = by_id.get(id.as_str()).ok_or_else(|| {
+						serde::de::Error::custom(format!(
+							"MSF track {:?} references missing initData {:?}",
+							track.name, id
+						))
+					})?;
+
+					if entry.kind != "inline" {
+						return Err(serde::de::Error::custom(format!(
+							"MSF track {:?} references initData {:?} with unsupported type {:?}",
+							track.name, id, entry.kind
+						)));
+					}
+
+					match &track.init_data {
+						Some(inline) if inline != &entry.data => {
+							return Err(serde::de::Error::custom(format!(
+								"MSF track {:?} carries conflicting initData and initRef {:?}",
+								track.name, id
+							)));
+						}
+						Some(_) => {}
+						None => track.init_data = Some(entry.data.clone()),
 					}
 				}
 				track.init_ref = None;
-				track
+				Ok(track)
 			})
-			.collect();
+			.collect::<Result<Vec<_>, _>>()?;
 
-		Ok(Catalog { tracks })
+		Ok(Catalog {
+			generated_at: wire.generated_at,
+			is_complete: wire.is_complete,
+			tracks,
+		})
 	}
+}
+
+fn is_false(value: &bool) -> bool {
+	!*value
 }
 
 /// The on-wire catalog shape, carrying the bits [`Catalog`] hides from callers.
@@ -225,6 +274,9 @@ impl<'de> Deserialize<'de> for Catalog {
 #[serde(rename_all = "camelCase")]
 struct Wire {
 	version: WireVersion,
+	generated_at: Option<u64>,
+	#[serde(default, skip_serializing_if = "is_false")]
+	is_complete: bool,
 	#[serde(default)]
 	tracks: Vec<Track>,
 	init_data_list: Option<Vec<InitData>>,
@@ -529,9 +581,7 @@ mod test {
 
 	#[test]
 	fn serialize_video_track() {
-		let catalog = Catalog {
-			tracks: vec![video_track()],
-		};
+		let catalog = Catalog::new(vec![video_track()]);
 
 		let json = catalog.to_string().unwrap();
 		let parsed = Catalog::from_str(&json).unwrap();
@@ -551,9 +601,7 @@ mod test {
 
 	#[test]
 	fn serialize_audio_track() {
-		let catalog = Catalog {
-			tracks: vec![audio_track()],
-		};
+		let catalog = Catalog::new(vec![audio_track()]);
 
 		let json = catalog.to_string().unwrap();
 		let parsed = Catalog::from_str(&json).unwrap();
@@ -602,7 +650,7 @@ mod test {
 
 	#[test]
 	fn roundtrip_empty() {
-		let catalog = Catalog { tracks: vec![] };
+		let catalog = Catalog::new(vec![]);
 		let json = catalog.to_string().unwrap();
 		let parsed = Catalog::from_str(&json).unwrap();
 		assert_eq!(catalog, parsed);
@@ -618,7 +666,7 @@ mod test {
 		track.jitter = None;
 		track.init_data = Some("AQID".to_string());
 
-		let catalog = Catalog { tracks: vec![track] };
+		let catalog = Catalog::new(vec![track]);
 
 		let json = catalog.to_string().unwrap();
 		assert!(json.contains("\"packaging\":\"cmaf\""));
@@ -629,9 +677,7 @@ mod test {
 
 	#[test]
 	fn serialize_sap_fields() {
-		let catalog = Catalog {
-			tracks: vec![track_with_sap_and_jitter()],
-		};
+		let catalog = Catalog::new(vec![track_with_sap_and_jitter()]);
 
 		let json = catalog.to_string().unwrap();
 
@@ -677,9 +723,7 @@ mod test {
 
 	#[test]
 	fn sap_and_jitter_roundtrip() {
-		let original = Catalog {
-			tracks: vec![track_with_sap_and_jitter()],
-		};
+		let original = Catalog::new(vec![track_with_sap_and_jitter()]);
 
 		let json = original.to_string().unwrap();
 		let parsed = Catalog::from_str(&json).unwrap();
@@ -736,26 +780,75 @@ mod test {
 	}
 
 	#[test]
-	fn unresolved_init_ref_leaves_init_data_none() {
-		// A dangling initRef (no matching entry, or a non-inline type) resolves to
-		// no init data rather than failing the whole catalog. Downstream decides
-		// whether a track without init data is usable.
+	fn dangling_init_ref_errors() {
+		// A dangling initRef would otherwise look like a track with no init_data.
+		// Reject it so publishers do not silently lose decoder setup bytes.
+		let json = r#"{
+			"version": "draft-01",
+			"initDataList": [
+				{ "id": "v0", "type": "inline", "data": "AQID" }
+			],
+			"tracks": [
+				{ "name": "a", "packaging": "cmaf", "isLive": true, "role": "video",
+				  "codec": "avc1.640028", "initRef": "missing" }
+			]
+		}"#;
+
+		let err = Catalog::from_str(json).expect_err("dangling initRef must fail");
+		assert!(err.to_string().contains("missing initData"), "unexpected error: {err}");
+	}
+
+	#[test]
+	fn unsupported_init_ref_type_errors() {
+		// Only inline init data can be resolved into Track::init_data. Other
+		// reference types must not become indistinguishable from absent init data.
 		let json = r#"{
 			"version": "draft-01",
 			"initDataList": [
 				{ "id": "v0", "type": "url", "data": "https://example.com/init" }
 			],
 			"tracks": [
-				{ "name": "a", "packaging": "cmaf", "isLive": true, "role": "video",
-				  "codec": "avc1.640028", "initRef": "missing" },
-				{ "name": "b", "packaging": "cmaf", "isLive": true, "role": "video",
+				{ "name": "video0", "packaging": "cmaf", "isLive": true, "role": "video",
 				  "codec": "avc1.640028", "initRef": "v0" }
 			]
 		}"#;
 
+		let err = Catalog::from_str(json).expect_err("unsupported initRef type must fail");
+		assert!(err.to_string().contains("unsupported type"), "unexpected error: {err}");
+	}
+
+	#[test]
+	fn inline_init_data_and_init_ref_must_agree() {
+		let json = r#"{
+			"version": "draft-01",
+			"initDataList": [
+				{ "id": "v0", "type": "inline", "data": "AQID" }
+			],
+			"tracks": [
+				{ "name": "video0", "packaging": "cmaf", "isLive": true, "role": "video",
+				  "codec": "avc1.640028", "initData": "BAUG", "initRef": "v0" }
+			]
+		}"#;
+
+		let err = Catalog::from_str(json).expect_err("conflicting initData/initRef must fail");
+		assert!(err.to_string().contains("conflicting"), "unexpected error: {err}");
+	}
+
+	#[test]
+	fn matching_inline_init_data_and_init_ref_decodes() {
+		let json = r#"{
+			"version": "draft-01",
+			"initDataList": [
+				{ "id": "v0", "type": "inline", "data": "AQID" }
+			],
+			"tracks": [
+				{ "name": "video0", "packaging": "cmaf", "isLive": true, "role": "video",
+				  "codec": "avc1.640028", "initData": "AQID", "initRef": "v0" }
+			]
+		}"#;
+
 		let catalog = Catalog::from_str(json).unwrap();
-		assert_eq!(catalog.tracks[0].init_data, None);
-		assert_eq!(catalog.tracks[1].init_data, None);
+		assert_eq!(catalog.tracks[0].init_data.as_deref(), Some("AQID"));
 	}
 
 	#[test]
@@ -789,7 +882,7 @@ mod test {
 		b.name = "b".to_string();
 		b.init_data = Some("AQID".to_string());
 
-		let catalog = Catalog { tracks: vec![a, b] };
+		let catalog = Catalog::new(vec![a, b]);
 		let value: serde_json::Value = serde_json::from_str(&catalog.to_string().unwrap()).unwrap();
 
 		let list = value["initDataList"].as_array().expect("initDataList present");
@@ -812,8 +905,8 @@ mod test {
 	#[test]
 	fn draft00_example_av_decodes() {
 		// Example 1 from draft-ietf-moq-msf-00: time-aligned audio/video. Exercises the
-		// numeric version, integer framerate into an f64 field, and unmodeled fields
-		// (namespace, targetLatency, generatedAt) which must be ignored, not rejected.
+		// numeric version, integer framerate into an f64 field, preserved generatedAt,
+		// and unmodeled fields (namespace, targetLatency) which must be ignored.
 		let json = r#"{
 			"version": 1,
 			"generatedAt": 1746104606044,
@@ -848,6 +941,7 @@ mod test {
 		}"#;
 
 		let catalog = Catalog::from_str(json).expect("draft-00 AV catalog must decode");
+		assert_eq!(catalog.generated_at, Some(1746104606044));
 		assert_eq!(catalog.tracks.len(), 2);
 		assert_eq!(catalog.tracks[0].framerate, Some(30.0));
 		assert_eq!(catalog.tracks[1].channel_config.as_deref(), Some("2"));
@@ -900,6 +994,19 @@ mod test {
 			"tracks": []
 		}"#;
 		let catalog = Catalog::from_str(json).expect("draft-00 completion catalog must decode");
+		assert_eq!(catalog.generated_at, Some(1746104606044));
+		assert!(catalog.is_complete);
 		assert!(catalog.tracks.is_empty());
+
+		let value: serde_json::Value = serde_json::from_str(&catalog.to_string().unwrap()).unwrap();
+		assert_eq!(value["generatedAt"], serde_json::json!(1746104606044u64));
+		assert_eq!(value["isComplete"], serde_json::json!(true));
+	}
+
+	#[test]
+	fn default_catalog_omits_completion_fields() {
+		let value: serde_json::Value = serde_json::from_str(&Catalog::default().to_string().unwrap()).unwrap();
+		assert!(value.get("generatedAt").is_none());
+		assert!(value.get("isComplete").is_none());
 	}
 }

--- a/rs/moq-mux/src/catalog/msf/consumer.rs
+++ b/rs/moq-mux/src/catalog/msf/consumer.rs
@@ -43,7 +43,13 @@ impl Consumer {
 				Poll::Ready(Some(frame)) => {
 					self.group = None;
 					let json = std::str::from_utf8(&frame).map_err(|_| Error::InvalidUtf8)?;
-					let msf = moq_msf::Catalog::from_str(json).map_err(|_| Error::ParseFrame)?;
+					let msf = match moq_msf::Catalog::from_str(json) {
+						Ok(msf) => msf,
+						Err(err) => {
+							tracing::warn!(error = %err, "failed to parse MSF catalog frame");
+							return Poll::Ready(Err(Error::ParseFrame.into()));
+						}
+					};
 					let catalog = from_msf(&msf)?;
 					return Poll::Ready(Ok(Some(catalog)));
 				}
@@ -86,8 +92,9 @@ impl From<moq_net::TrackSubscriber> for Consumer {
 /// [`Container::Legacy`]. [`moq_msf::Packaging::Cmaf`] requires `init_data` to be present
 /// (base64-encoded ftyp+moov); a missing or malformed init segment is an error.
 ///
-/// Fields with no representation in `hang::Catalog` (`is_live`, `render_group`, `alt_group`,
-/// `max_grp_sap_starting_type`, `max_obj_sap_starting_type`) are dropped.
+/// Fields with no representation in `hang::Catalog` (`generated_at`, `is_complete`, `is_live`,
+/// `render_group`, `alt_group`, `max_grp_sap_starting_type`, `max_obj_sap_starting_type`) are
+/// dropped.
 pub(crate) fn from_msf(msf: &moq_msf::Catalog) -> Result<hang::Catalog> {
 	let mut catalog = hang::Catalog::default();
 
@@ -403,9 +410,7 @@ mod test {
 		let init_b64 = "AAAYZ2Z0eXA=";
 		let expected_init = base64::engine::general_purpose::STANDARD.decode(init_b64).unwrap();
 
-		let msf = moq_msf::Catalog {
-			tracks: vec![video_track("video0", moq_msf::Packaging::Cmaf, Some(init_b64))],
-		};
+		let msf = moq_msf::Catalog::new(vec![video_track("video0", moq_msf::Packaging::Cmaf, Some(init_b64))]);
 
 		let catalog = from_msf(&msf).expect("CMAF video should convert");
 		let video = catalog.video.renditions.get("video0").expect("video0 rendition");
@@ -422,9 +427,7 @@ mod test {
 
 	#[test]
 	fn loc_audio_yields_legacy_container() {
-		let msf = moq_msf::Catalog {
-			tracks: vec![audio_track("audio0", moq_msf::Packaging::Loc)],
-		};
+		let msf = moq_msf::Catalog::new(vec![audio_track("audio0", moq_msf::Packaging::Loc)]);
 
 		let catalog = from_msf(&msf).expect("LOC audio should convert");
 		let audio = catalog.audio.renditions.get("audio0").expect("audio0 rendition");
@@ -450,9 +453,7 @@ mod test {
 		let mut audio = audio_track("audio0", moq_msf::Packaging::Loc);
 		audio.init_data = Some(init_b64);
 
-		let msf = moq_msf::Catalog {
-			tracks: vec![video, audio],
-		};
+		let msf = moq_msf::Catalog::new(vec![video, audio]);
 
 		let catalog = from_msf(&msf).expect("legacy tracks should convert");
 		let v = catalog.video.renditions.get("video0").expect("video0 rendition");
@@ -467,9 +468,7 @@ mod test {
 		// CMAF tracks carry their bytes inside Container::Cmaf::init; description
 		// must stay None so downstream code reads the bytes from one place only.
 		let init_b64 = "AAAYZ2Z0eXA=";
-		let msf = moq_msf::Catalog {
-			tracks: vec![video_track("video0", moq_msf::Packaging::Cmaf, Some(init_b64))],
-		};
+		let msf = moq_msf::Catalog::new(vec![video_track("video0", moq_msf::Packaging::Cmaf, Some(init_b64))]);
 		let catalog = from_msf(&msf).unwrap();
 		assert!(catalog.video.renditions["video0"].description.is_none());
 	}
@@ -498,7 +497,7 @@ mod test {
 		audio.channel_config = None;
 		audio.init_data = Some(init_b64);
 
-		let msf = moq_msf::Catalog { tracks: vec![audio] };
+		let msf = moq_msf::Catalog::new(vec![audio]);
 
 		let catalog = from_msf(&msf).expect("flac track should convert");
 		let a = catalog.audio.renditions.get("audio0").expect("audio0 rendition");
@@ -511,7 +510,7 @@ mod test {
 	fn legacy_malformed_init_data_is_error() {
 		let mut track = video_track("video0", moq_msf::Packaging::Legacy, Some("!!!not-base64!!!"));
 		track.codec = Some("avc1.42c01e".to_string());
-		let msf = moq_msf::Catalog { tracks: vec![track] };
+		let msf = moq_msf::Catalog::new(vec![track]);
 		let err = from_msf(&msf).expect_err("malformed base64 should error");
 		assert!(
 			err.to_string().contains("malformed init_data"),
@@ -524,7 +523,7 @@ mod test {
 	fn unknown_codec_yields_unknown_variant() {
 		let mut track = video_track("video0", moq_msf::Packaging::Legacy, None);
 		track.codec = Some("weirdcodec".to_string());
-		let msf = moq_msf::Catalog { tracks: vec![track] };
+		let msf = moq_msf::Catalog::new(vec![track]);
 
 		let catalog = from_msf(&msf).expect("unknown codec is not an error");
 		let video = catalog.video.renditions.get("video0").expect("video0 rendition");
@@ -533,9 +532,7 @@ mod test {
 
 	#[test]
 	fn cmaf_without_init_data_is_error() {
-		let msf = moq_msf::Catalog {
-			tracks: vec![video_track("video0", moq_msf::Packaging::Cmaf, None)],
-		};
+		let msf = moq_msf::Catalog::new(vec![video_track("video0", moq_msf::Packaging::Cmaf, None)]);
 
 		let err = from_msf(&msf).expect_err("CMAF without init_data must error");
 		let msg = format!("{err:#}");
@@ -544,7 +541,7 @@ mod test {
 
 	#[test]
 	fn empty_catalog_is_empty_hang_catalog() {
-		let msf = moq_msf::Catalog { tracks: vec![] };
+		let msf = moq_msf::Catalog::new(vec![]);
 
 		let catalog = from_msf(&msf).expect("empty catalog should convert");
 		assert!(catalog.video.renditions.is_empty());
@@ -555,7 +552,7 @@ mod test {
 	fn track_without_role_is_skipped() {
 		let mut track = video_track("video0", moq_msf::Packaging::Legacy, None);
 		track.role = None;
-		let msf = moq_msf::Catalog { tracks: vec![track] };
+		let msf = moq_msf::Catalog::new(vec![track]);
 
 		let catalog = from_msf(&msf).expect("no-role track should be skipped, not error");
 		assert!(catalog.video.renditions.is_empty());
@@ -566,7 +563,7 @@ mod test {
 	fn unsupported_role_is_skipped() {
 		let mut track = audio_track("caption0", moq_msf::Packaging::Legacy);
 		track.role = Some(moq_msf::Role::Caption);
-		let msf = moq_msf::Catalog { tracks: vec![track] };
+		let msf = moq_msf::Catalog::new(vec![track]);
 
 		let catalog = from_msf(&msf).expect("unsupported role should be skipped, not error");
 		assert!(catalog.audio.renditions.is_empty());
@@ -581,7 +578,7 @@ mod test {
 		track.samplerate = None;
 		track.channel_config = None;
 		track.init_data = None;
-		let msf = moq_msf::Catalog { tracks: vec![track] };
+		let msf = moq_msf::Catalog::new(vec![track]);
 
 		let err = from_msf(&msf).expect_err("missing fields with no init_data should error");
 		assert!(err.to_string().contains("no init_data"), "unexpected error: {}", err);
@@ -605,7 +602,7 @@ mod test {
 		track.samplerate = None;
 		track.channel_config = None;
 		track.init_data = Some(init_b64);
-		let msf = moq_msf::Catalog { tracks: vec![track] };
+		let msf = moq_msf::Catalog::new(vec![track]);
 
 		let catalog = from_msf(&msf).expect("Opus OpusHead should parse");
 		let audio = catalog.audio.renditions.get("audio0").expect("audio0 rendition");
@@ -629,7 +626,7 @@ mod test {
 		track.samplerate = None;
 		track.channel_config = None;
 		track.init_data = Some(init_b64);
-		let msf = moq_msf::Catalog { tracks: vec![track] };
+		let msf = moq_msf::Catalog::new(vec![track]);
 
 		let catalog = from_msf(&msf).expect("AAC AudioSpecificConfig should parse");
 		let audio = catalog.audio.renditions.get("audio0").expect("audio0 rendition");
@@ -654,7 +651,7 @@ mod test {
 		track.samplerate = Some(24_000); // explicit, must be preserved
 		track.channel_config = None; // missing, derive from init_data
 		track.init_data = Some(init_b64);
-		let msf = moq_msf::Catalog { tracks: vec![track] };
+		let msf = moq_msf::Catalog::new(vec![track]);
 
 		let catalog = from_msf(&msf).expect("partial derivation should succeed");
 		let audio = catalog.audio.renditions.get("audio0").expect("audio0 rendition");
@@ -667,9 +664,7 @@ mod test {
 		// MediaTimeline isn't a media payload, so the track must be skipped (not error).
 		let bad = video_track("timeline0", moq_msf::Packaging::MediaTimeline, None);
 		let good = video_track("video0", moq_msf::Packaging::Legacy, None);
-		let msf = moq_msf::Catalog {
-			tracks: vec![bad, good],
-		};
+		let msf = moq_msf::Catalog::new(vec![bad, good]);
 
 		let catalog = from_msf(&msf).expect("unsupported packaging should be skipped, not error");
 		assert!(
@@ -688,9 +683,7 @@ mod test {
 		// Drop the codec so we'd see a hard error if the skip path didn't short-circuit.
 		bad.codec = None;
 		let good = audio_track("audio0", moq_msf::Packaging::Loc);
-		let msf = moq_msf::Catalog {
-			tracks: vec![bad, good],
-		};
+		let msf = moq_msf::Catalog::new(vec![bad, good]);
 
 		let catalog = from_msf(&msf).expect("unsupported packaging should be skipped, not error");
 		assert!(!catalog.audio.renditions.contains_key("event0"));
@@ -700,7 +693,7 @@ mod test {
 	#[test]
 	fn unknown_packaging_variant_is_skipped() {
 		let track = video_track("video0", moq_msf::Packaging::Unknown("custom".to_string()), None);
-		let msf = moq_msf::Catalog { tracks: vec![track] };
+		let msf = moq_msf::Catalog::new(vec![track]);
 
 		let catalog = from_msf(&msf).expect("unknown packaging should be skipped, not error");
 		assert!(catalog.video.renditions.is_empty());
@@ -710,7 +703,7 @@ mod test {
 	fn missing_video_codec_is_error() {
 		let mut track = video_track("video0", moq_msf::Packaging::Legacy, None);
 		track.codec = None;
-		let msf = moq_msf::Catalog { tracks: vec![track] };
+		let msf = moq_msf::Catalog::new(vec![track]);
 
 		let err = from_msf(&msf).expect_err("missing video codec must error");
 		let msg = format!("{err:#}");
@@ -724,7 +717,7 @@ mod test {
 	fn missing_audio_codec_is_error() {
 		let mut track = audio_track("audio0", moq_msf::Packaging::Legacy);
 		track.codec = None;
-		let msf = moq_msf::Catalog { tracks: vec![track] };
+		let msf = moq_msf::Catalog::new(vec![track]);
 
 		let err = from_msf(&msf).expect_err("missing audio codec must error");
 		let msg = format!("{err:#}");
@@ -739,7 +732,7 @@ mod test {
 		// avc1 with a too-short profile string is a malformed structured codec.
 		let mut track = video_track("video0", moq_msf::Packaging::Legacy, None);
 		track.codec = Some("avc1.0".to_string());
-		let msf = moq_msf::Catalog { tracks: vec![track] };
+		let msf = moq_msf::Catalog::new(vec![track]);
 
 		let err = from_msf(&msf).expect_err("malformed avc1 codec must error");
 		let msg = format!("{err:#}");

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -303,7 +303,7 @@ fn to_msf(catalog: &hang::Catalog) -> moq_msf::Catalog {
 		tracks.push(track);
 	}
 
-	moq_msf::Catalog { tracks }
+	moq_msf::Catalog::new(tracks)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Preserve draft-00 `generatedAt` and `isComplete` as version-neutral `moq_msf::Catalog` fields.
- Mark `Catalog` as `#[non_exhaustive]` and add `Catalog::new` for external construction.
- Reject missing or unsupported draft-01 `initRef` targets instead of silently exposing `Track::init_data = None`.
- Log the concrete MSF parse error in `moq-mux` before returning the existing `ParseFrame` error.
- Fix the `moq-msf` changelog entry that mentioned a `Version` enum that never existed.

## Public API Changes

- Added `moq_msf::Catalog::generated_at: Option<u64>`.
- Added `moq_msf::Catalog::is_complete: bool`.
- Added `moq_msf::Catalog::new(Vec<Track>)`.
- Marked `moq_msf::Catalog` as `#[non_exhaustive]`.

## Validation

- `cargo test -p moq-msf -p moq-mux`
- `cargo clippy -p moq-msf -p moq-mux --all-targets -- -D warnings`
- `cargo fmt --all --check`

(Written by GPT-5)