### PR TITLE
[codex] Backport kio tokio sleep wrapper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3723,6 +3723,7 @@ name = "kio"
 version = "0.4.1"
 dependencies = [
  "smallvec",
+ "tokio",
 ]
 
 [[package]]

--- a/rs/kio/Cargo.toml
+++ b/rs/kio/Cargo.toml
@@ -15,5 +15,14 @@ categories = ["asynchronous", "concurrency"]
 [lib]
 doctest = false
 
+[features]
+# Opt-in `tokio::time::Sleep`, a poll-driven wall-clock wait backed by tokio. Off by
+# default so kio stays runtime-free. Enable it when driving `poll_*` functions on tokio.
+tokio = ["dep:tokio"]
+
 [dependencies]
 smallvec = "1.15"
+tokio = { workspace = true, features = ["time"], optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt", "test-util", "time"] }

--- a/rs/kio/src/lib.rs
+++ b/rs/kio/src/lib.rs
@@ -18,6 +18,9 @@ mod future;
 mod producer;
 mod weak;
 
+#[cfg(feature = "tokio")]
+pub mod tokio;
+
 #[cfg(test)]
 mod tests;
 

--- a/rs/kio/src/tokio.rs
+++ b/rs/kio/src/tokio.rs
@@ -1,0 +1,52 @@
+//! kio integration for tokio.
+//!
+//! Behind the `tokio` feature. Wraps a [`tokio::time::Sleep`] so a `poll_*` function can
+//! drive it against a [`Waiter`], keeping the rest of kio runtime-free.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use crate::Waiter;
+
+/// A tokio sleep driven by kio's poll model.
+///
+/// Construct it once for a deadline (`Sleep::new(tokio::time::sleep_until(deadline))`), then
+/// [`poll`](Self::poll) it against a [`Waiter`] each time your `poll_*` runs. Reading the
+/// clock through `tokio::time` means a `tokio::time::pause()` test advances it in step.
+pub struct Sleep {
+	inner: Pin<Box<::tokio::time::Sleep>>,
+}
+
+impl Sleep {
+	/// Wrap a tokio sleep future.
+	pub fn new(sleep: ::tokio::time::Sleep) -> Self {
+		Self { inner: Box::pin(sleep) }
+	}
+
+	/// Poll the sleep, registering `waiter` so the poll re-fires once it elapses.
+	pub fn poll(&mut self, waiter: &Waiter) -> Poll<()> {
+		let mut cx = Context::from_waker(waiter.waker());
+		self.inner.as_mut().poll(&mut cx)
+	}
+
+	/// Wait until the sleep elapses.
+	pub async fn wait(&mut self) {
+		crate::wait(|waiter| self.poll(waiter)).await
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use ::tokio::time::Instant;
+	use std::time::Duration;
+
+	#[::tokio::test(start_paused = true)]
+	async fn sleep_fires_at_its_deadline() {
+		let deadline = Instant::now() + Duration::from_millis(50);
+		let mut sleep = Sleep::new(::tokio::time::sleep_until(deadline));
+		sleep.wait().await;
+		assert!(Instant::now() >= deadline, "returned before the deadline");
+	}
+}

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -42,6 +42,14 @@ impl Waiter {
 	pub fn register(&self, list: &mut WaiterList) {
 		list.register(self);
 	}
+
+	/// The underlying task [`Waker`], for driving a foreign future inside a `poll_*`
+	/// function. Build a [`Context`] from it and poll the future so that future
+	/// re-wakes this poll when it's ready, without kio itself taking a runtime
+	/// dependency.
+	pub fn waker(&self) -> &Waker {
+		&self.waker
+	}
 }
 
 /// A list of weak wakers waiting for notification.


### PR DESCRIPTION
Summary
- Backport the kio portion of #1994 onto main.
- Add an optional kio tokio feature with a poll-driven Sleep wrapper.
- Add Waiter::waker() so poll functions can drive foreign futures without making kio runtime-dependent.

Validation
- cargo test -p kio
- cargo test -p kio --features tokio
- just check reached the repo-level justfile format gate after JS, Rust check, clippy, fmt, docs, shear, and cargo-sort passed. The remaining failure is unrelated generated justfile formatting churn, left out to keep this backport scoped.

(Written by GPT-5)