### PR TITLE
[codex] fix JS catalog demo regressions

### DIFF
--- a/demo/web/src/index.ts
+++ b/demo/web/src/index.ts
@@ -19,7 +19,7 @@
 import "./highlight";
 import "@moq/watch/element"; // defines <moq-watch>
 import "@moq/watch/ui"; // defines <moq-watch-ui>
-import { Json, Net, Signals } from "@moq/watch";
+import { Hang, Json, Net, Signals } from "@moq/watch";
 import type MoqWatch from "@moq/watch/element";
 import MoqWatchSupport from "@moq/watch/support/element";
 import { bufferBars, formatBitrate, formatFps, graph, renderRows } from "./viz";
@@ -399,7 +399,7 @@ ui.run((effect) => {
 		return;
 	}
 
-	const track = broadcast.track(trackName).subscribe();
+	const track = broadcast.track(trackName).subscribe({ priority: Hang.Catalog.PRIORITY.catalog });
 	effect.cleanup(() => track.close());
 	const consumer = new Json.Consumer<unknown>(track);
 

--- a/demo/web/src/publish.ts
+++ b/demo/web/src/publish.ts
@@ -317,7 +317,9 @@ const setMeta = (value: unknown) => {
 	activeMeta?.update(value);
 };
 
-new Signals.Effect().run((effect) => {
+const meta = new Signals.Effect();
+
+meta.run((effect) => {
 	const net = effect.get(publish.broadcast.net);
 	if (!net) return;
 
@@ -397,6 +399,6 @@ viz.interval(() => {
 // collected unclosed (which the signals library warns about).
 if (import.meta.hot) {
 	import.meta.hot.dispose(() => {
-		for (const effect of [ui, viz]) effect.close();
+		for (const effect of [ui, meta, viz]) effect.close();
 	});
 }

--- a/js/publish/src/catalog.test.ts
+++ b/js/publish/src/catalog.test.ts
@@ -32,6 +32,34 @@ test("catalog producer seeds subscribers and fans out edits", async () => {
 	effect.close();
 });
 
+test("catalog producer publishes every update as a snapshot group", async () => {
+	const catalog = new CatalogProducer();
+	catalog.mutate((c) => {
+		c.video = { renditions: {} };
+	});
+
+	const effect = new Effect();
+	const track = new TrackProducer("catalog.json");
+	catalog.serve(track, effect);
+	const subscriber = track.subscribe();
+
+	const first = await subscriber.nextGroup();
+	expect(first?.sequence).toBe(0);
+	expect(await first?.readJson()).toEqual({ video: { renditions: {} } });
+	expect(first?.done).toBe(true);
+
+	catalog.mutate((c) => {
+		c.scte35 = { splices: [] };
+	});
+
+	const second = await subscriber.nextGroup();
+	expect(second?.sequence).toBe(1);
+	expect(await second?.readJson()).toEqual({ video: { renditions: {} }, scte35: { splices: [] } });
+	expect(second?.done).toBe(true);
+
+	effect.close();
+});
+
 test("a reconnecting subscriber is seeded with the full current catalog", async () => {
 	const catalog = new CatalogProducer();
 	catalog.mutate((c) => {

--- a/js/publish/src/catalog.ts
+++ b/js/publish/src/catalog.ts
@@ -31,7 +31,10 @@ export class CatalogProducer {
 	 * served both plaintext and compressed (e.g. `catalog.json` and `catalog.json.z`).
 	 */
 	serve(track: Moq.TrackProducer, effect: Effect, opts?: { compression?: boolean }): void {
-		const output = new Json.Producer<Catalog.Root>(track, { compression: opts?.compression });
+		const output = new Json.Producer<Catalog.Root>(track, {
+			compression: opts?.compression,
+			deltaRatio: 0,
+		});
 		output.update(this.#value);
 
 		this.#outputs.add(output);


### PR DESCRIPTION
## Summary

- Keep the browser publisher catalog snapshot-only by pinning `deltaRatio: 0` when serving `catalog.json` / `catalog.json.z`.
- Restore high-priority delivery for the demo `meta.json` subscription so metadata does not sit behind media under congestion.
- Close the publish demo's metadata `Effect` during Vite HMR disposal, and add a catalog regression test for snapshot groups.

## Why

`@moq/json` now defaults to merge-patch deltas, but the browser publisher catalog path was previously snapshot-only for consumers that expect each update to be a full catalog group. The demo metadata path also regressed by inheriting the default subscription priority and by creating an untracked module-level `Effect` on hot reload.

## Validation

- `bun test js/publish/src/catalog.test.ts`
- `bun run --filter @moq/publish check`
- `bun run --filter @moq/demo check`
- `bun biome check demo/web/src/index.ts demo/web/src/publish.ts js/publish/src/catalog.ts js/publish/src/catalog.test.ts`

(Written by GPT-5)
