### PR TITLE
[codex] harden moq mux edge cases

### DIFF
--- a/rs/moq-mux/src/codec/h265/export.rs
+++ b/rs/moq-mux/src/codec/h265/export.rs
@@ -243,11 +243,12 @@ mod tests {
 			payload.extend_from_slice(&(nal.len() as u32).to_be_bytes());
 			payload.extend_from_slice(nal);
 		}
-		let frame = crate::container::Frame::new(
-			moq_net::Timestamp::from_micros(timestamp_us).unwrap(),
-			payload.freeze(),
-			false,
-		);
+		let frame = crate::container::Frame {
+			timestamp: moq_net::Timestamp::from_micros(timestamp_us).unwrap(),
+			duration: None,
+			payload: payload.freeze(),
+			keyframe: false,
+		};
 		<crate::catalog::hang::Container as crate::container::Container>::write(
 			&crate::catalog::hang::Container::Legacy,
 			group,

--- a/rs/moq-mux/src/codec/h265/export.rs
+++ b/rs/moq-mux/src/codec/h265/export.rs
@@ -173,3 +173,137 @@ impl<S: Stream> Export<S> {
 		Ok(())
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use std::collections::BTreeMap;
+	use std::task::Poll;
+
+	use bytes::{Bytes, BytesMut};
+	use hang::catalog::{H265, Video, VideoConfig};
+
+	use super::*;
+	use crate::catalog::Stream;
+	use crate::catalog::hang::Catalog;
+
+	struct Once(Option<Catalog>);
+
+	impl Stream for Once {
+		type Ext = ();
+
+		fn poll_next(&mut self, _: &kio::Waiter) -> Poll<crate::Result<Option<Catalog>>> {
+			Poll::Ready(Ok(self.0.take()))
+		}
+	}
+
+	fn hvc1_catalog(name: &str, hvcc: Bytes) -> Catalog {
+		let mut config = VideoConfig::new(H265 {
+			in_band: false,
+			profile_space: 0,
+			profile_idc: 1,
+			profile_compatibility_flags: [0, 0, 0, 0],
+			tier_flag: false,
+			level_idc: 93,
+			constraint_flags: [0, 0, 0, 0, 0, 0],
+		});
+		config.coded_width = Some(320);
+		config.coded_height = Some(240);
+		config.description = Some(hvcc);
+		config.container = hang::catalog::Container::Legacy;
+
+		let mut renditions = BTreeMap::new();
+		renditions.insert(name.to_string(), config);
+
+		Catalog {
+			video: Video {
+				renditions,
+				display: None,
+				rotation: None,
+				flip: None,
+			},
+			..Default::default()
+		}
+	}
+
+	fn hvcc(vps: &[u8], sps: &[u8], pps: &[u8]) -> Bytes {
+		let mut out = BytesMut::new();
+		out.extend_from_slice(&[0u8; 21]);
+		out.extend_from_slice(&[0xff, 3]);
+		for (nal_type, nal) in [(32u8, vps), (33, sps), (34, pps)] {
+			out.extend_from_slice(&[0x80 | nal_type, 0, 1]);
+			out.extend_from_slice(&(nal.len() as u16).to_be_bytes());
+			out.extend_from_slice(nal);
+		}
+		out.freeze()
+	}
+
+	fn write_length_prefixed(group: &mut moq_net::GroupProducer, timestamp_us: u64, nals: &[&[u8]]) {
+		let mut payload = BytesMut::new();
+		for nal in nals {
+			payload.extend_from_slice(&(nal.len() as u32).to_be_bytes());
+			payload.extend_from_slice(nal);
+		}
+		let frame = crate::container::Frame::new(
+			moq_net::Timestamp::from_micros(timestamp_us).unwrap(),
+			payload.freeze(),
+			false,
+		);
+		<crate::catalog::hang::Container as crate::container::Container>::write(
+			&crate::catalog::hang::Container::Legacy,
+			group,
+			&[frame],
+		)
+		.unwrap();
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn hvc1_export_injects_vps_sps_pps_on_keyframes() {
+		let vps = &[0x40, 0x01, 0x0c][..];
+		let sps = &[0x42, 0x01, 0x01, 0x60][..];
+		let pps = &[0x44, 0x01, 0xc0][..];
+		let idr = &[0x26, 0x01, 0x88, 0x84][..];
+		let trail = &[0x02, 0x01, 0xe0, 0x12][..];
+
+		let catalog = hvc1_catalog("video.hvc1", hvcc(vps, sps, pps));
+		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut track = broadcast
+			.create_track(
+				"video.hvc1",
+				moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			)
+			.unwrap();
+
+		let mut g0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		write_length_prefixed(&mut g0, 0, &[idr]);
+		g0.finish().unwrap();
+
+		let mut g1 = track.create_group(moq_net::GroupInfo { sequence: 1 }).unwrap();
+		write_length_prefixed(&mut g1, 33_000, &[trail]);
+		g1.finish().unwrap();
+		track.finish().unwrap();
+
+		let consumer = broadcast.consume();
+		let mut export = Export::new(consumer, Once(Some(catalog)));
+
+		let frame0 = export.next().await.unwrap().expect("first frame");
+		let frame1 = export.next().await.unwrap().expect("second frame");
+		assert!(export.next().await.unwrap().is_none(), "track ended");
+
+		let prefix = crate::codec::annexb::build_prefix(
+			[
+				Bytes::copy_from_slice(vps),
+				Bytes::copy_from_slice(sps),
+				Bytes::copy_from_slice(pps),
+			]
+			.iter(),
+		);
+
+		assert!(frame0.starts_with(&prefix), "frame 0 must begin with VPS/SPS/PPS");
+		assert_eq!(&frame0[prefix.len()..], &[0, 0, 0, 1, 0x26, 0x01, 0x88, 0x84]);
+		assert!(
+			frame1.starts_with(&prefix),
+			"group-start frame must begin with VPS/SPS/PPS"
+		);
+		assert_eq!(&frame1[prefix.len()..], &[0, 0, 0, 1, 0x02, 0x01, 0xe0, 0x12]);
+	}
+}

--- a/rs/moq-mux/src/container/flv/export_test.rs
+++ b/rs/moq-mux/src/container/flv/export_test.rs
@@ -20,6 +20,19 @@ fn avcc() -> Vec<u8> {
 
 /// AudioSpecificConfig for AAC-LC, 44100 Hz, stereo.
 const ASC: [u8; 2] = [0x12, 0x10];
+const AV1C: [u8; 4] = [0x81, 0x08, 0x0c, 0x00];
+const AC3_FRAME: [u8; 7] = [0x0B, 0x77, 0x00, 0x00, 0x1C, 0x40, 0xE1];
+const EAC3_FRAME: [u8; 6] = [0x0B, 0x77, 0x00, 0xFF, 0x3F, 0x80];
+
+fn flv_header(flags: u8) -> Vec<u8> {
+	let mut out = Vec::new();
+	out.extend_from_slice(b"FLV");
+	out.push(1);
+	out.push(flags);
+	out.extend_from_slice(&9u32.to_be_bytes());
+	out.extend_from_slice(&0u32.to_be_bytes());
+	out
+}
 
 fn write_tag(out: &mut Vec<u8>, tag_type: u8, timestamp: u32, body: &[u8]) {
 	out.push(tag_type);
@@ -325,6 +338,143 @@ async fn export_roundtrips_mp3() {
 	assert!(matches!(a.codec, AudioCodec::Mp3));
 	assert_eq!(a.sample_rate, 44100);
 	assert_eq!(a.channel_count, 2);
+}
+
+fn synth_av1_flv() -> Vec<u8> {
+	let mut out = flv_header(0x01);
+
+	let mut seq = vec![super::VIDEO_EX_HEADER | (super::FRAME_TYPE_KEY << 4) | super::VIDEO_PACKET_SEQUENCE_START];
+	seq.extend_from_slice(b"av01");
+	seq.extend_from_slice(&AV1C);
+	write_tag(&mut out, super::TAG_VIDEO, 0, &seq);
+
+	let mut frame = vec![super::VIDEO_EX_HEADER | (super::FRAME_TYPE_KEY << 4) | super::VIDEO_PACKET_CODED_FRAMES_X];
+	frame.extend_from_slice(b"av01");
+	frame.extend_from_slice(&[0x12, 0x00, 0x34, 0x56]);
+	write_tag(&mut out, super::TAG_VIDEO, 0, &frame);
+
+	out
+}
+
+#[tokio::test(start_paused = true)]
+async fn export_roundtrips_av1() {
+	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let consumer = producer.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+
+	let mut importer = Import::new(producer, catalog.clone());
+	importer
+		.decode(&bytes::BytesMut::from(synth_av1_flv().as_slice()))
+		.unwrap();
+	catalog.finish().unwrap();
+
+	let exporter = Export::new(consumer).await.unwrap();
+	let exported = drain_export(exporter, importer).await;
+	let tags = parse_tags(&exported);
+
+	assert!(
+		tags.iter().any(|t| t.tag_type == super::TAG_VIDEO
+			&& t.body[0] & super::VIDEO_EX_HEADER != 0
+			&& (t.body[0] & 0x0f) == super::VIDEO_PACKET_SEQUENCE_START
+			&& &t.body[1..5] == b"av01"),
+		"expected an AV1 enhanced sequence header"
+	);
+	assert!(
+		tags.iter().any(|t| t.tag_type == super::TAG_VIDEO
+			&& t.body[0] & super::VIDEO_EX_HEADER != 0
+			&& (t.body[0] & 0x0f) == super::VIDEO_PACKET_CODED_FRAMES
+			&& &t.body[1..5] == b"av01"),
+		"expected an AV1 enhanced frame"
+	);
+
+	let mut bcast2 = moq_net::BroadcastInfo::new().produce();
+	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
+	let mut imp2 = Import::new(bcast2, cat2.clone());
+	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
+	imp2.finish().unwrap();
+
+	let snap = cat2.snapshot();
+	assert!(matches!(
+		snap.video.renditions.values().next().unwrap().codec,
+		VideoCodec::AV1(_)
+	));
+}
+
+fn synth_enhanced_audio_flv(fourcc: &[u8; 4], frame: &[u8]) -> Vec<u8> {
+	let mut out = flv_header(0x04);
+	let mut tag = vec![(super::AUDIO_FORMAT_EX << 4) | super::AUDIO_PACKET_CODED_FRAMES];
+	tag.extend_from_slice(fourcc);
+	tag.extend_from_slice(frame);
+	write_tag(&mut out, super::TAG_AUDIO, 0, &tag);
+	out
+}
+
+#[tokio::test(start_paused = true)]
+async fn export_roundtrips_ac3() {
+	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let consumer = producer.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+
+	let mut importer = Import::new(producer, catalog.clone());
+	importer
+		.decode(&bytes::BytesMut::from(
+			synth_enhanced_audio_flv(b"ac-3", &AC3_FRAME).as_slice(),
+		))
+		.unwrap();
+	catalog.finish().unwrap();
+
+	let exporter = Export::new(consumer).await.unwrap();
+	let exported = drain_export(exporter, importer).await;
+	let tags = parse_tags(&exported);
+	assert!(
+		tags.iter()
+			.any(|t| t.tag_type == super::TAG_AUDIO && &t.body[1..5] == b"ac-3"),
+		"expected an enhanced AC-3 audio tag"
+	);
+
+	let mut bcast2 = moq_net::BroadcastInfo::new().produce();
+	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
+	let mut imp2 = Import::new(bcast2, cat2.clone());
+	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
+	imp2.finish().unwrap();
+	assert!(matches!(
+		cat2.snapshot().audio.renditions.values().next().unwrap().codec,
+		AudioCodec::Ac3
+	));
+}
+
+#[tokio::test(start_paused = true)]
+async fn export_roundtrips_eac3() {
+	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let consumer = producer.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+
+	let mut importer = Import::new(producer, catalog.clone());
+	importer
+		.decode(&bytes::BytesMut::from(
+			synth_enhanced_audio_flv(b"ec-3", &EAC3_FRAME).as_slice(),
+		))
+		.unwrap();
+	catalog.finish().unwrap();
+
+	let exporter = Export::new(consumer).await.unwrap();
+	let exported = drain_export(exporter, importer).await;
+	let tags = parse_tags(&exported);
+	assert!(
+		tags.iter()
+			.any(|t| t.tag_type == super::TAG_AUDIO && &t.body[1..5] == b"ec-3"),
+		"expected an enhanced E-AC-3 audio tag"
+	);
+
+	let mut bcast2 = moq_net::BroadcastInfo::new().produce();
+	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
+	let mut imp2 = Import::new(bcast2, cat2.clone());
+	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
+	imp2.finish().unwrap();
+	assert!(matches!(
+		cat2.snapshot().audio.renditions.values().next().unwrap().codec,
+		AudioCodec::Ec3
+	));
 }
 
 struct ParsedTag {

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -91,7 +91,13 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	pub fn decode(&mut self, data: &[u8]) -> crate::Result<()> {
 		self.buffer.extend_from_slice(data);
 
-		Ok(self.drain()?)
+		match self.drain() {
+			Ok(()) => Ok(()),
+			Err(err) => match err.downcast::<crate::Error>() {
+				Ok(err) => Err(err),
+				Err(err) => Err(err.into()),
+			},
+		}
 	}
 
 	fn drain(&mut self) -> anyhow::Result<()> {
@@ -317,12 +323,11 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		// FLV stores DTS in the tag; PTS is DTS plus the composition offset.
 		let pts_ms = (dts as i64) + (composition_time as i64);
 		if pts_ms < 0 {
-			tracing::warn!(
-				dts_ms = dts,
-				composition_time,
-				"dropping FLV video frame with negative PTS"
-			);
-			return Ok(());
+			return Err(crate::Error::NegativeFlvPts {
+				dts_ms: dts,
+				composition_time_ms: composition_time,
+			}
+			.into());
 		}
 		match stream.track.write(Frame {
 			timestamp: Timestamp::from_millis(pts_ms as u64)?,

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -88,10 +88,10 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	/// Append `buf` to the internal scratch and demux every whole tag it now
 	/// completes. The buffer is fully consumed; a trailing partial tag is retained
 	/// for the next call.
-	pub fn decode(&mut self, data: &[u8]) -> anyhow::Result<()> {
+	pub fn decode(&mut self, data: &[u8]) -> crate::Result<()> {
 		self.buffer.extend_from_slice(data);
 
-		self.drain()
+		Ok(self.drain()?)
 	}
 
 	fn drain(&mut self) -> anyhow::Result<()> {
@@ -316,7 +316,14 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		};
 		// FLV stores DTS in the tag; PTS is DTS plus the composition offset.
 		let pts_ms = (dts as i64) + (composition_time as i64);
-		anyhow::ensure!(pts_ms >= 0, "negative video presentation timestamp");
+		if pts_ms < 0 {
+			tracing::warn!(
+				dts_ms = dts,
+				composition_time,
+				"dropping FLV video frame with negative PTS"
+			);
+			return Ok(());
+		}
 		match stream.track.write(Frame {
 			timestamp: Timestamp::from_millis(pts_ms as u64)?,
 			duration: None,
@@ -411,7 +418,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	}
 
 	/// Close the current group on every track and reopen at `sequence`.
-	pub fn seek(&mut self, sequence: u64) -> anyhow::Result<()> {
+	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		if let Some(stream) = self.video.as_mut() {
 			stream.track.seek(sequence)?;
 		}
@@ -422,7 +429,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	}
 
 	/// Finish every track, flushing the current group.
-	pub fn finish(&mut self) -> anyhow::Result<()> {
+	pub fn finish(&mut self) -> crate::Result<()> {
 		if let Some(stream) = self.video.as_mut() {
 			stream.track.finish()?;
 		}

--- a/rs/moq-mux/src/container/flv/import_test.rs
+++ b/rs/moq-mux/src/container/flv/import_test.rs
@@ -16,6 +16,19 @@ fn avcc() -> Vec<u8> {
 
 /// AudioSpecificConfig for AAC-LC, 44100 Hz, stereo.
 const ASC: [u8; 2] = [0x12, 0x10];
+const AV1C: [u8; 4] = [0x81, 0x08, 0x0c, 0x00];
+const AC3_FRAME: [u8; 7] = [0x0B, 0x77, 0x00, 0x00, 0x1C, 0x40, 0xE1];
+const EAC3_FRAME: [u8; 6] = [0x0B, 0x77, 0x00, 0xFF, 0x3F, 0x80];
+
+fn flv_header(flags: u8) -> Vec<u8> {
+	let mut out = Vec::new();
+	out.extend_from_slice(b"FLV");
+	out.push(1);
+	out.push(flags);
+	out.extend_from_slice(&9u32.to_be_bytes());
+	out.extend_from_slice(&0u32.to_be_bytes());
+	out
+}
 
 /// Append an FLV tag (header + body + trailing PreviousTagSize) to `out`.
 fn write_tag(out: &mut Vec<u8>, tag_type: u8, timestamp: u32, body: &[u8]) {
@@ -256,6 +269,168 @@ async fn import_legacy_mp3() {
 	assert_eq!(a.sample_rate, 44100);
 	assert_eq!(a.channel_count, 2);
 	assert!(a.description.is_none(), "MP3 config is in band");
+}
+
+#[tokio::test(start_paused = true)]
+async fn import_enhanced_av1() {
+	let mut out = flv_header(0x01);
+
+	let mut seq = vec![super::VIDEO_EX_HEADER | (super::FRAME_TYPE_KEY << 4) | super::VIDEO_PACKET_SEQUENCE_START];
+	seq.extend_from_slice(b"av01");
+	seq.extend_from_slice(&AV1C);
+	write_tag(&mut out, super::TAG_VIDEO, 0, &seq);
+
+	let payload = [0x12, 0x00, 0x34, 0x56];
+	let mut frame = vec![super::VIDEO_EX_HEADER | (super::FRAME_TYPE_KEY << 4) | super::VIDEO_PACKET_CODED_FRAMES_X];
+	frame.extend_from_slice(b"av01");
+	frame.extend_from_slice(&payload);
+	write_tag(&mut out, super::TAG_VIDEO, 33, &frame);
+
+	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let consumer = producer.consume();
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let mut importer = Import::new(producer, catalog.clone());
+	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
+	importer.finish().unwrap();
+
+	let snap = catalog.snapshot();
+	let (name, v) = snap.video.renditions.iter().next().unwrap();
+	assert!(matches!(v.codec, VideoCodec::AV1(_)));
+	assert_eq!(v.description.as_ref().map(|b| b.as_ref()), Some(&AV1C[..]));
+
+	let track = consumer.track(name).unwrap().subscribe(None).await.unwrap();
+	let mut decoder = crate::container::Consumer::new(track, crate::catalog::hang::Container::Legacy)
+		.with_latency(std::time::Duration::from_secs(1));
+	let frame = decoder.read().await.unwrap().expect("an AV1 frame");
+	assert!(frame.keyframe);
+	assert_eq!(frame.payload.as_ref(), payload);
+}
+
+#[tokio::test(start_paused = true)]
+async fn import_enhanced_ac3() {
+	let mut out = flv_header(0x04);
+	let mut frame = vec![(super::AUDIO_FORMAT_EX << 4) | super::AUDIO_PACKET_CODED_FRAMES];
+	frame.extend_from_slice(b"ac-3");
+	frame.extend_from_slice(&AC3_FRAME);
+	write_tag(&mut out, super::TAG_AUDIO, 0, &frame);
+
+	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let mut importer = Import::new(producer, catalog.clone());
+	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
+	importer.finish().unwrap();
+
+	let snap = catalog.snapshot();
+	let a = snap.audio.renditions.values().next().unwrap();
+	assert!(matches!(a.codec, AudioCodec::Ac3));
+	assert_eq!(a.sample_rate, 48_000);
+	assert_eq!(a.channel_count, 6);
+	assert!(a.description.is_none());
+}
+
+#[tokio::test(start_paused = true)]
+async fn import_enhanced_eac3() {
+	let mut out = flv_header(0x04);
+	let mut frame = vec![(super::AUDIO_FORMAT_EX << 4) | super::AUDIO_PACKET_CODED_FRAMES];
+	frame.extend_from_slice(b"ec-3");
+	frame.extend_from_slice(&EAC3_FRAME);
+	write_tag(&mut out, super::TAG_AUDIO, 0, &frame);
+
+	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let mut importer = Import::new(producer, catalog.clone());
+	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
+	importer.finish().unwrap();
+
+	let snap = catalog.snapshot();
+	let a = snap.audio.renditions.values().next().unwrap();
+	assert!(matches!(a.codec, AudioCodec::Ec3));
+	assert_eq!(a.sample_rate, 48_000);
+	assert_eq!(a.channel_count, 6);
+	assert!(a.description.is_none());
+}
+
+#[tokio::test(start_paused = true)]
+async fn import_drops_negative_pts_and_keeps_decoding() {
+	let mut out = flv_header(0x01);
+
+	let mut seq = vec![
+		(super::FRAME_TYPE_KEY << 4) | super::VIDEO_CODEC_AVC,
+		super::AVC_SEQUENCE_HEADER,
+		0,
+		0,
+		0,
+	];
+	seq.extend_from_slice(&avcc());
+	write_tag(&mut out, super::TAG_VIDEO, 0, &seq);
+
+	let mut negative = vec![
+		(super::FRAME_TYPE_KEY << 4) | super::VIDEO_CODEC_AVC,
+		super::AVC_NALU,
+		0xff,
+		0xff,
+		0xff,
+	];
+	negative.extend_from_slice(&[0, 0, 0, 1, 0x65]);
+	write_tag(&mut out, super::TAG_VIDEO, 0, &negative);
+
+	let mut good = vec![
+		(super::FRAME_TYPE_KEY << 4) | super::VIDEO_CODEC_AVC,
+		super::AVC_NALU,
+		0,
+		0,
+		0,
+	];
+	good.extend_from_slice(&[0, 0, 0, 1, 0x65]);
+	write_tag(&mut out, super::TAG_VIDEO, 10, &good);
+
+	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let consumer = producer.consume();
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let mut importer = Import::new(producer, catalog.clone());
+	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
+	importer.finish().unwrap();
+
+	let snap = catalog.snapshot();
+	let name = snap.video.renditions.keys().next().unwrap();
+	let track = consumer.track(name).unwrap().subscribe(None).await.unwrap();
+	let mut decoder = crate::container::Consumer::new(track, crate::catalog::hang::Container::Legacy)
+		.with_latency(std::time::Duration::from_secs(1));
+	let frame = decoder.read().await.unwrap().expect("the good frame");
+	assert_eq!(frame.timestamp.as_millis(), 10);
+}
+
+#[tokio::test(start_paused = true)]
+async fn import_enhanced_hvc1_applies_composition_time() {
+	let mut out = flv_header(0x01);
+
+	// Use avc1 to bootstrap a video track with a tiny config record; the coded
+	// frame below uses hvc1, which is the branch this regression covers.
+	let mut seq = vec![super::VIDEO_EX_HEADER | (super::FRAME_TYPE_KEY << 4) | super::VIDEO_PACKET_SEQUENCE_START];
+	seq.extend_from_slice(b"avc1");
+	seq.extend_from_slice(&avcc());
+	write_tag(&mut out, super::TAG_VIDEO, 0, &seq);
+
+	let mut coded = vec![super::VIDEO_EX_HEADER | (super::FRAME_TYPE_KEY << 4) | super::VIDEO_PACKET_CODED_FRAMES];
+	coded.extend_from_slice(b"hvc1");
+	coded.extend_from_slice(&[0, 0, 7]);
+	coded.extend_from_slice(&[0, 0, 0, 1, 0x65]);
+	write_tag(&mut out, super::TAG_VIDEO, 10, &coded);
+
+	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let consumer = producer.consume();
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let mut importer = Import::new(producer, catalog.clone());
+	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
+	importer.finish().unwrap();
+
+	let snap = catalog.snapshot();
+	let name = snap.video.renditions.keys().next().unwrap();
+	let track = consumer.track(name).unwrap().subscribe(None).await.unwrap();
+	let mut decoder = crate::container::Consumer::new(track, crate::catalog::hang::Container::Legacy)
+		.with_latency(std::time::Duration::from_secs(1));
+	let frame = decoder.read().await.unwrap().expect("a video frame");
+	assert_eq!(frame.timestamp.as_millis(), 17);
 }
 
 #[tokio::test(start_paused = true)]

--- a/rs/moq-mux/src/container/flv/import_test.rs
+++ b/rs/moq-mux/src/container/flv/import_test.rs
@@ -351,7 +351,7 @@ async fn import_enhanced_eac3() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn import_drops_negative_pts_and_keeps_decoding() {
+async fn import_reports_negative_pts_and_can_resume() {
 	let mut out = flv_header(0x01);
 
 	let mut seq = vec![
@@ -388,7 +388,15 @@ async fn import_drops_negative_pts_and_keeps_decoding() {
 	let consumer = producer.consume();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let mut importer = Import::new(producer, catalog.clone());
-	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
+	let err = importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap_err();
+	assert!(matches!(
+		err,
+		crate::Error::NegativeFlvPts {
+			dts_ms: 0,
+			composition_time_ms: -1
+		}
+	));
+	importer.decode(&[]).unwrap();
 	importer.finish().unwrap();
 
 	let snap = catalog.snapshot();

--- a/rs/moq-mux/src/container/jitter.rs
+++ b/rs/moq-mux/src/container/jitter.rs
@@ -78,3 +78,43 @@ impl Jitter {
 		Some(jitter)
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn micros(value: u64) -> Timestamp {
+		Timestamp::from_micros(value).unwrap()
+	}
+
+	#[test]
+	fn reports_min_frame_spacing_once_it_changes() {
+		let mut jitter = Jitter::new();
+
+		assert_eq!(jitter.observe(micros(1_000)), None);
+		assert_eq!(jitter.observe(micros(41_000)), Some(Duration::from_millis(40)));
+		assert_eq!(jitter.observe(micros(81_000)), None);
+		assert_eq!(jitter.observe(micros(101_000)), Some(Duration::from_millis(20)));
+		assert_eq!(jitter.current(), Some(Duration::from_millis(20)));
+	}
+
+	#[test]
+	fn reorder_delay_wins_over_frame_spacing() {
+		let mut jitter = Jitter::new();
+
+		assert_eq!(jitter.observe(micros(0)), None);
+		assert_eq!(jitter.observe(micros(16_000)), Some(Duration::from_millis(16)));
+		assert_eq!(jitter.observe_reorder(micros(48_000)), Some(Duration::from_millis(48)));
+		assert_eq!(jitter.observe(micros(32_000)), None);
+		assert_eq!(jitter.current(), Some(Duration::from_millis(48)));
+	}
+
+	#[test]
+	fn ignores_non_monotonic_presentation_spacing() {
+		let mut jitter = Jitter::new();
+
+		assert_eq!(jitter.observe(micros(100_000)), None);
+		assert_eq!(jitter.observe(micros(80_000)), None);
+		assert_eq!(jitter.observe(micros(120_000)), Some(Duration::from_millis(40)));
+	}
+}

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -71,18 +71,6 @@ pub struct Frame {
 	pub keyframe: bool,
 }
 
-impl Frame {
-	/// Build a frame with no explicit duration.
-	pub fn new(timestamp: moq_net::Timestamp, payload: Bytes, keyframe: bool) -> Self {
-		Self {
-			timestamp,
-			duration: None,
-			payload,
-			keyframe,
-		}
-	}
-}
-
 /// A non-keyframe frame arrived with no open group.
 ///
 /// A track must open with a keyframe (and so must the frame after

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -36,7 +36,6 @@ pub(crate) use source::ExportSource;
 /// The exact shape depends on the codec (Annex B for H.264/H.265, OBU for
 /// AV1, and so on).
 #[derive(Clone, Debug)]
-#[non_exhaustive]
 pub struct Frame {
 	/// Presentation timestamp.
 	///
@@ -48,8 +47,7 @@ pub struct Frame {
 	/// order. B-frames may have non-monotonic presentation timestamps.
 	pub timestamp: moq_net::Timestamp,
 
-	/// How long this frame occupies the presentation timeline, in the frame's
-	/// own scale, when the container reports it.
+	/// Sample duration in the frame's own scale, when the container reports it.
 	///
 	/// CMAF carries a per-sample duration (trun sample-duration); containers
 	/// that don't (Legacy, LOC) leave this `None`. The [`Consumer`] adds it to

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -36,6 +36,7 @@ pub(crate) use source::ExportSource;
 /// The exact shape depends on the codec (Annex B for H.264/H.265, OBU for
 /// AV1, and so on).
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct Frame {
 	/// Presentation timestamp.
 	///
@@ -68,6 +69,18 @@ pub struct Frame {
 	/// "first frame in a group is a keyframe" as a fallback, so the
 	/// Legacy/LOC case lands correctly without anyone having to know.
 	pub keyframe: bool,
+}
+
+impl Frame {
+	/// Build a frame with no explicit duration.
+	pub fn new(timestamp: moq_net::Timestamp, payload: Bytes, keyframe: bool) -> Self {
+		Self {
+			timestamp,
+			duration: None,
+			payload,
+			keyframe,
+		}
+	}
 }
 
 /// A non-keyframe frame arrived with no open group.

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -264,7 +264,7 @@ impl<E: catalog::Catalog> Export<E> {
 						track.finished = true;
 						break;
 					}
-					Poll::Ready(Err(e)) => return Poll::Ready(Err(e.into())),
+					Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
 					Poll::Pending => break,
 				}
 			}

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -13,7 +13,7 @@
 //! length-prefixed -> Annex-B conversion, re-injecting the parameter sets as
 //! inline NALs on every keyframe. CMAF tracks are rejected with a clear error.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::task::Poll;
 use std::time::Duration;
 
@@ -214,11 +214,11 @@ impl<E: catalog::Catalog> Export<E> {
 	/// on the first frame (inheriting its timestamp), and is re-emitted at video
 	/// keyframes and periodically for mid-stream tune-in. Returns `None` when the
 	/// broadcast ends. `duration` is always `None`: the muxer has no use for it.
-	pub async fn next(&mut self) -> anyhow::Result<Option<Frame>> {
+	pub async fn next(&mut self) -> crate::Result<Option<Frame>> {
 		kio::wait(|waiter| self.poll_next(waiter)).await
 	}
 
-	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<anyhow::Result<Option<Frame>>> {
+	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<crate::Result<Option<Frame>>> {
 		// 1. Drain catalog updates, discovering the track layout.
 		while let Some(catalog) = self.catalog.as_mut() {
 			match catalog.poll_next(waiter)? {
@@ -335,7 +335,7 @@ impl<E: catalog::Catalog> Export<E> {
 		self.program_descriptors = mpegts.program_descriptors.clone();
 
 		// The desired track set: media renditions plus the verbatim streams.
-		let mut active: HashMap<String, ()> = HashMap::new();
+		let mut active: BTreeMap<String, ()> = BTreeMap::new();
 		for name in catalog.video.renditions.keys() {
 			active.insert(name.clone(), ());
 		}
@@ -371,7 +371,7 @@ impl<E: catalog::Catalog> Export<E> {
 		// runs every snapshot until the PMT is built and the tracks below are
 		// *refreshed*, not latched from the first (partial) snapshot.
 		let mut used: Vec<u16> = vec![0x0000, PMT_PID, 0x1FFF];
-		let mut pids: HashMap<String, u16> = HashMap::new();
+		let mut pids: BTreeMap<String, u16> = BTreeMap::new();
 		for name in active.keys() {
 			if let Some(pid) = mpegts.tracks.get(name).map(|t| t.pid)
 				&& !used.contains(&pid)
@@ -642,9 +642,9 @@ impl<E: catalog::Catalog> Export<E> {
 	fn pick_next_track(&self) -> Option<String> {
 		self.tracks
 			.iter()
-			.filter_map(|(n, t)| t.pending.as_ref().map(|f| (n.clone(), f.timestamp)))
-			.min_by_key(|(_, ts)| *ts)
-			.map(|(n, _)| n)
+			.filter_map(|(n, t)| t.pending.as_ref().map(|f| (f.timestamp, t.pid, n)))
+			.min_by_key(|(timestamp, pid, name)| (*timestamp, *pid, *name))
+			.map(|(_, _, name)| name.clone())
 	}
 
 	/// Packetize one media frame into an output [`Frame`], re-emitting PAT/PMT

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -1447,9 +1447,6 @@ fn pes_data_len(header: &PesHeader, pes_packet_len: u16) -> Option<usize> {
 	pes_packet_len.checked_sub(optional).map(|n| n as usize)
 }
 
-/// Convert a raw 90 kHz PTS to a microsecond [`Timestamp`], unwrapping the
-/// 33-bit field. Returns `None` when the PES carried no PTS (the codec layer
-/// then falls back to a wall-clock timestamp).
 /// Swallow a [`MissingKeyframe`](crate::container::MissingKeyframe) from a video
 /// decode: a TS capture can join mid-GOP, so the deltas before the first keyframe
 /// have no group to anchor and are simply dropped rather than aborting the demux.
@@ -1460,6 +1457,8 @@ fn skip_missing_keyframe(result: crate::Result<()>) -> anyhow::Result<()> {
 	}
 }
 
+/// Convert a raw 90 kHz PTS to a microsecond [`Timestamp`], unwrapping the
+/// 33-bit field. Returns `None` when the PES carried no PTS.
 fn unwrap_pts(unwrap: &mut PtsUnwrap, pts: Option<u64>) -> anyhow::Result<Option<Timestamp>> {
 	let Some(raw) = pts else {
 		return Ok(None);

--- a/rs/moq-mux/src/error.rs
+++ b/rs/moq-mux/src/error.rs
@@ -104,6 +104,15 @@ pub enum Error {
 	#[error("{0}")]
 	MissingKeyframe(#[from] crate::container::MissingKeyframe),
 
+	/// A FLV video frame resolved to a negative presentation timestamp.
+	#[error("negative FLV video presentation timestamp: dts={dts_ms}ms composition_time={composition_time_ms}ms")]
+	NegativeFlvPts {
+		/// The FLV tag decode timestamp in milliseconds.
+		dts_ms: u64,
+		/// The signed FLV composition-time offset in milliseconds.
+		composition_time_ms: i32,
+	},
+
 	/// Error from a muxer/demuxer that reports via `anyhow` (currently MPEG-TS).
 	/// Boxed in an `Arc` so the enum stays `Clone` (`anyhow::Error` is not).
 	#[error("{0}")]

--- a/rs/moq-mux/src/import/container.rs
+++ b/rs/moq-mux/src/import/container.rs
@@ -40,7 +40,7 @@ impl<E: crate::container::ts::catalog::Catalog> ContainerImpl<E> {
 			ContainerImpl::Fmp4(decoder) => decoder.decode(data),
 			ContainerImpl::Mkv(decoder) => decoder.decode(data),
 			ContainerImpl::Ts(decoder) => decoder.decode(data).map_err(Into::into),
-			ContainerImpl::Flv(decoder) => decoder.decode(data).map_err(Into::into),
+			ContainerImpl::Flv(decoder) => decoder.decode(data),
 		}
 	}
 
@@ -49,7 +49,7 @@ impl<E: crate::container::ts::catalog::Catalog> ContainerImpl<E> {
 			ContainerImpl::Fmp4(decoder) => decoder.finish(),
 			ContainerImpl::Mkv(decoder) => decoder.finish(),
 			ContainerImpl::Ts(decoder) => decoder.finish().map_err(Into::into),
-			ContainerImpl::Flv(decoder) => decoder.finish().map_err(Into::into),
+			ContainerImpl::Flv(decoder) => decoder.finish(),
 		}
 	}
 
@@ -58,7 +58,7 @@ impl<E: crate::container::ts::catalog::Catalog> ContainerImpl<E> {
 			ContainerImpl::Fmp4(decoder) => decoder.seek(sequence),
 			ContainerImpl::Mkv(decoder) => decoder.seek(sequence),
 			ContainerImpl::Ts(decoder) => decoder.seek(sequence).map_err(Into::into),
-			ContainerImpl::Flv(decoder) => decoder.seek(sequence).map_err(Into::into),
+			ContainerImpl::Flv(decoder) => decoder.seek(sequence),
 		}
 	}
 }

--- a/rs/moq-rtmp/src/dial.rs
+++ b/rs/moq-rtmp/src/dial.rs
@@ -444,11 +444,11 @@ impl Publisher {
 			"RTMP message body {} exceeds FLV's 24-bit tag size limit",
 			body.len()
 		);
-		self.importer.decode(&flv::tag(tag_type, timestamp, body))
+		Ok(self.importer.decode(&flv::tag(tag_type, timestamp, body))?)
 	}
 
 	fn finish(&mut self) -> anyhow::Result<()> {
-		self.importer.finish()
+		Ok(self.importer.finish()?)
 	}
 }
 

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -906,12 +906,12 @@ impl Publisher {
 			"RTMP message body {} exceeds FLV's 24-bit tag size limit",
 			body.len()
 		);
-		self.importer.decode(&flv::tag(tag_type, timestamp, body))
+		Ok(self.importer.decode(&flv::tag(tag_type, timestamp, body))?)
 	}
 
 	/// Flush any buffered media and close out the broadcast's open groups.
 	fn finish(&mut self) -> anyhow::Result<()> {
-		self.importer.finish()
+		Ok(self.importer.finish()?)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Return `Error::NegativeFlvPts` from FLV ingest when a composition-time offset would make PTS negative, while keeping the importer usable after the error.
- Move public FLV import and TS export paths from `anyhow::Result` to the crate typed error, and keep TS track tie-breaking deterministic.
- Convert downstream RTMP FLV importer boundaries back into their existing `anyhow::Result` type.
- Clarify `Frame::duration` docs as a per-sample duration hint rather than reshaping the `Frame` API in this PR.
- Add coverage for FLV AV1, AC-3, E-AC-3, H.265 composition-time offsets, H.265 export parameter injection, and jitter behavior.

## Public API Changes
- Added `Error::NegativeFlvPts { dts_ms, composition_time_ms }`.
- Changed `flv::Import::{decode, seek, finish}` to return `crate::Result`.
- Changed `ts::Export::{next, poll_next}` to return `crate::Result`.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p moq-audio`
- `cargo check -p moq-rtmp`
- `cargo clippy -p moq-mux --all-targets -- -D warnings`
- `cargo test -p moq-mux`

(Written by GPT-5)