### PR TITLE
[codex] fix lite05 moq-net edge cases

### DIFF
--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -33,7 +33,7 @@ impl Announced {
 					let Some(broadcast) = event.broadcast() else {
 						continue;
 					};
-					let hops = broadcast.info().hops.iter().map(|origin| origin.id).collect();
+					let hops = broadcast.info().hops.iter().map(|origin| origin.id()).collect();
 					return Ok(Some(Arc::new(MoqAnnouncement {
 						path: path.to_string(),
 						hops,

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -162,9 +162,14 @@ pub async fn accept_setup<S: web_transport_trait::Session>(
 
 		let setup: setup::Setup = reader.decode().await?;
 		let mut bytes = setup.parameters;
-		let path = ietf::Parameters::decode(&mut bytes, version)?
-			.get_bytes(ietf::ParameterBytes::Path)
-			.map(|b| String::from_utf8_lossy(b).into_owned());
+		let path = match ietf::Parameters::decode(&mut bytes, version)?.get_bytes(ietf::ParameterBytes::Path) {
+			Some(bytes) => Some(
+				std::str::from_utf8(bytes)
+					.map_err(|_| Error::Decode(crate::DecodeError::InvalidValue))?
+					.to_owned(),
+			),
+			None => None,
+		};
 
 		return Ok((reader, path));
 	}

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -220,10 +220,6 @@ impl Message for AnnounceOk {
 		}
 
 		let origin = Origin::decode(r, version)?;
-		if origin.id == 0 {
-			// A zero responder id is never legitimate; it would stamp UNKNOWN onto chains.
-			return Err(DecodeError::InvalidValue);
-		}
 		let active = u64::decode(r, version)?;
 		Ok(Self { origin, active })
 	}
@@ -305,7 +301,7 @@ mod tests {
 	#[test]
 	fn announce_ok_round_trip() {
 		let msg = AnnounceOk {
-			origin: Origin { id: 42 },
+			origin: Origin::new(42).unwrap(),
 			active: 3,
 		};
 		assert_eq!(round_trip(&msg), msg);
@@ -314,7 +310,7 @@ mod tests {
 	#[test]
 	fn announce_ok_zero_active() {
 		let msg = AnnounceOk {
-			origin: Origin { id: 7 },
+			origin: Origin::new(7).unwrap(),
 			active: 0,
 		};
 		assert_eq!(round_trip(&msg), msg);
@@ -342,7 +338,7 @@ mod tests {
 	#[test]
 	fn announce_broadcast_round_trip_on_lite05() {
 		let mut hops = OriginList::new();
-		hops.push(Origin { id: 7 }).unwrap();
+		hops.push(Origin::new(7).unwrap()).unwrap();
 		let msg = AnnounceBroadcast::Active {
 			suffix: Path::new("room/cam"),
 			hops: hops.clone(),
@@ -359,7 +355,7 @@ mod tests {
 	#[test]
 	fn announce_ok_rejects_old_versions() {
 		let msg = AnnounceOk {
-			origin: Origin { id: 1 },
+			origin: Origin::new(1).unwrap(),
 			active: 0,
 		};
 		let mut buf = bytes::BytesMut::new();
@@ -370,11 +366,11 @@ mod tests {
 	}
 
 	#[test]
-	fn announce_ok_rejects_zero_origin() {
+	fn announce_ok_accepts_zero_origin() {
 		// Encode a well-formed message then patch the origin to 0 on the wire.
 		let mut buf = bytes::BytesMut::new();
 		AnnounceOk {
-			origin: Origin { id: 1 },
+			origin: Origin::new(1).unwrap(),
 			active: 0,
 		}
 		.encode(&mut buf, Version::Lite05Wip)
@@ -385,9 +381,8 @@ mod tests {
 		// size(1 byte) | origin varint(1 byte = 0x01) | active varint(1 byte)
 		patched[1] = 0x00;
 		let mut slice = &patched[..];
-		assert!(matches!(
-			AnnounceOk::decode(&mut slice, Version::Lite05Wip),
-			Err(DecodeError::InvalidValue)
-		));
+		let got = AnnounceOk::decode(&mut slice, Version::Lite05Wip).unwrap();
+		assert_eq!(got.origin.id(), 0);
+		assert_eq!(got.active, 0);
 	}
 }

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -5,7 +5,7 @@ use web_transport_trait::Stats;
 
 use crate::{
 	AnnounceConsumer, AsPath, Error, Origin, OriginConsumer, OriginList, StatsHandle as MoqStats, TrackSubscriber,
-	coding::{Stream, Writer},
+	coding::{Encode, Stream, Writer},
 	lite::{
 		self,
 		priority::{Priority, PriorityHandle, PriorityQueue},
@@ -270,7 +270,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 							let hops = &info.hops;
 							// Apply the same exclude_hop and reflected-announce skips as the live
 							// loop so the count matches exactly what we send (minus the self push).
-							if exclude_hop != 0 && hops.iter().any(|h| h.id == exclude_hop) {
+							if exclude_hop != 0 && hops.iter().any(|h| h.id() == exclude_hop) {
 								continue;
 							}
 							if hops.contains(&self_origin) {
@@ -297,14 +297,17 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					origin: self_origin,
 					active: initial.len() as u64,
 				};
-				stream.writer.encode(&ok).await?;
-
-				for (suffix, hops) in initial {
-					stream
-						.writer
-						.encode(&lite::AnnounceBroadcast::Active { suffix, hops })
-						.await?;
+				let mut buf = bytes::BytesMut::new();
+				ok.encode(&mut buf, version)?;
+				for (suffix, hops) in &initial {
+					lite::AnnounceBroadcast::Active {
+						suffix: suffix.as_path(),
+						hops: hops.clone(),
+					}
+					.encode(&mut buf, version)?;
 				}
+				let mut buf = buf.freeze();
+				stream.writer.write_all(&mut buf).await?;
 
 				// Count each initial announce by broadcast name length, mirroring the
 				// live loop below (the name, not the encoded message size).
@@ -412,7 +415,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		version: Version,
 		absolute: &crate::Path,
 	) -> Option<OriginList> {
-		if exclude_hop != 0 && hops.iter().any(|h| h.id == exclude_hop) {
+		if exclude_hop != 0 && hops.iter().any(|h| h.id() == exclude_hop) {
 			tracing::debug!(broadcast = %absolute, %exclude_hop, "skipping announce per peer's exclude_hop");
 			return None;
 		}
@@ -433,7 +436,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 	pub async fn recv_track(&self, mut stream: Stream<S, Version>) -> Result<(), Error> {
 		// The Track Stream is lite-05+ only.
-		if !self.version.has_timestamps() {
+		if !self.version.has_track_stream() {
 			return Err(Error::UnexpectedStream);
 		}
 
@@ -559,7 +562,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// every frame with a zigzag-delta timestamp at the track's timescale; older
 		// drafts have no wire field, so `None` here means "don't emit the prefix" (the
 		// frames still carry timestamps in the model, just not on this wire).
-		let timescale = if version.has_timestamps() {
+		let timescale = if version.has_track_stream() {
 			Some(track.info().timescale)
 		} else {
 			None
@@ -572,7 +575,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// Lite05+ accepts implicitly: no SUBSCRIBE_OK, the immutable properties live
 		// in TRACK_INFO, and the resolved range arrives as SUBSCRIBE_START/END emitted
 		// from run_track. Older drafts still acknowledge with SUBSCRIBE_OK here.
-		if !version.has_timestamps() {
+		if !version.has_track_stream() {
 			let info = lite::SubscribeOk {
 				priority: subscribe.priority,
 				ordered: false,
@@ -621,8 +624,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	pub async fn recv_fetch(&self, mut stream: Stream<S, Version>) -> Result<(), Error> {
-		// FETCH is lite-05+ only; older drafts have no per-frame timestamp format.
-		if !self.version.has_timestamps() {
+		// FETCH is lite-05+ only; older drafts have no dedicated FETCH stream.
+		if !self.version.has_track_stream() {
 			return Err(Error::UnexpectedStream);
 		}
 
@@ -674,9 +677,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			)
 			.await?;
 
-		// FETCH is gated to lite-05+, which always prefixes frames with a timestamp at
-		// the track's timescale.
-		let timescale = if version.has_timestamps() {
+		// FETCH is gated to lite-05+, which learned the track timescale via TRACK_INFO.
+		let timescale = if version.has_track_stream() {
 			Some(group.timescale())
 		} else {
 			None
@@ -780,9 +782,8 @@ struct Subscription<S: web_transport_trait::Session> {
 	priority: PriorityQueue,
 	track_priority: tokio::sync::watch::Receiver<u8>,
 	version: Version,
-	/// Negotiated timestamp scale for this track. `Some(_)` iff
-	/// [`Version::has_timestamps`] is true for `version` (gated in
-	/// `run_subscribe`); used to validate per-frame timestamps before encoding.
+	/// Negotiated timestamp scale for this track. `Some(_)` on lite-05+ after
+	/// TRACK_INFO; used to validate per-frame timestamps before encoding.
 	timescale: Option<crate::Timescale>,
 }
 
@@ -809,7 +810,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 
 		// Lite05+ resolves the range on the Subscribe Stream itself: SUBSCRIBE_START
 		// once the first group is known, SUBSCRIBE_END when the track finishes.
-		let emit_range = self.version.has_timestamps();
+		let emit_range = self.version.has_track_stream();
 		let mut start_sent = false;
 
 		loop {
@@ -838,7 +839,11 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 							// Track finished cleanly. Tell the subscriber no group will
 							// follow, then drain in-flight tasks and exit.
 							if emit_range {
-								let group = track.latest().unwrap_or(0);
+								let group = track
+									.latest()
+									.map(|group| group.checked_add(1).ok_or(crate::coding::BoundsExceeded))
+									.transpose()?
+									.unwrap_or(0);
 								writer
 									.encode(&lite::SubscribeResponse::End(lite::SubscribeEnd { group }))
 									.await?;

--- a/rs/moq-net/src/lite/subscribe.rs
+++ b/rs/moq-net/src/lite/subscribe.rs
@@ -152,7 +152,7 @@ pub struct SubscribeStart {
 
 impl Message for SubscribeStart {
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		if !version.has_timestamps() {
+		if !version.has_track_stream() {
 			return Err(DecodeError::Version);
 		}
 		Ok(Self {
@@ -161,16 +161,17 @@ impl Message for SubscribeStart {
 	}
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		if !version.has_timestamps() {
+		if !version.has_track_stream() {
 			return Err(EncodeError::Version);
 		}
 		self.group.encode(w, version)
 	}
 }
 
-/// Signals that no group after `group` (inclusive upper bound) will be produced on
-/// a Lite05+ subscription. Bounds the range but doesn't end the stream: stragglers
-/// at or below it may still be dropped before FIN.
+/// Signals the exclusive end of a Lite05+ subscription.
+///
+/// No group at or after `group` will be produced. `0` means the track ended
+/// before producing any groups.
 #[derive(Clone, Debug)]
 pub struct SubscribeEnd {
 	pub group: u64,
@@ -178,7 +179,7 @@ pub struct SubscribeEnd {
 
 impl Message for SubscribeEnd {
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		if !version.has_timestamps() {
+		if !version.has_track_stream() {
 			return Err(DecodeError::Version);
 		}
 		Ok(Self {
@@ -187,7 +188,7 @@ impl Message for SubscribeEnd {
 	}
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		if !version.has_timestamps() {
+		if !version.has_track_stream() {
 			return Err(EncodeError::Version);
 		}
 		self.group.encode(w, version)

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -194,7 +194,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// peers ignore this field, in which case start_announce below still drops.
 		let msg = lite::AnnounceRequest {
 			prefix: prefix.as_path(),
-			exclude_hop: self.self_origin.id,
+			exclude_hop: self.self_origin.id(),
 		};
 		stream.writer.encode(&msg).await?;
 
@@ -429,13 +429,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			hops.replace_first(crate::Origin::UNKNOWN, self.session_origin);
 		}
 
-		// Guarantee at least one hop we control. A peer is meant to stamp its
-		// own origin (Lite04), be reconstructed from the responder above (Lite05+),
-		// or filled in above (Lite03), but we don't trust an empty chain: a peer
-		// that sends zero hops would otherwise be indistinguishable from any other,
-		// so two empty-chain routes to the same path would collide. Insert our
-		// session origin so every broadcast stays attributable. The list is empty
-		// here, so this can't overflow.
+		// Guarantee at least one attributable hop for versions that did not provide
+		// one. Lite05 peers may legally advertise responder id 0; preserve it above
+		// rather than replacing it, even though that route stays loop-blind.
 		if hops.is_empty() {
 			hops.push(self.session_origin)
 				.expect("an empty hop chain always has room for one entry");
@@ -783,7 +779,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		// SUBSCRIBE_UPDATE (and thus pause/resume linger) only exists on Lite03+.
 		// Older versions tear the upstream down as soon as the track goes idle.
 		let supports_linger = !matches!(self.subscriber.version, Version::Lite01 | Version::Lite02);
-		let supports_fetch = self.subscriber.version.has_timestamps();
+		let supports_fetch = self.subscriber.version.has_track_stream();
 
 		// Mark the track as fetch-capable up front (before accept), so a consumer's
 		// cache-miss fetch waits to be served rather than failing fast. Held for the
@@ -795,7 +791,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		// The timescale then flows into every SUBSCRIBE and FETCH without a per-response
 		// header. Older drafts have no TRACK stream: the request stays pending until the
 		// first SUBSCRIBE_OK supplies the properties (see `establish`).
-		let (mut track, timescale) = if self.subscriber.version.has_timestamps() {
+		let (mut track, timescale) = if self.subscriber.version.has_track_stream() {
 			match self.track_info().await {
 				Ok(info) => {
 					// Lite05 carries per-frame timestamps on the wire at this scale; `Some`
@@ -996,7 +992,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 					// track means it was never subscribed.
 					let establish = match track.as_ref() {
 						Some(Track::Pending(_)) => true,
-						Some(Track::Active(_)) => self.subscriber.version.has_timestamps() && !completed,
+						Some(Track::Active(_)) => self.subscriber.version.has_track_stream() && !completed,
 						None => false,
 					};
 					if establish {
@@ -1083,7 +1079,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		stream.writer.encode(&lite::ControlType::Subscribe).await?;
 		stream.writer.encode(&msg).await?;
 
-		let producer = if self.subscriber.version.has_timestamps() {
+		let producer = if self.subscriber.version.has_track_stream() {
 			// Lite05+: implicit acceptance, no SUBSCRIBE_OK. The producer already exists.
 			let Some(Track::Active(producer)) = track.as_ref() else {
 				unreachable!("lite05 track is active before establish");

--- a/rs/moq-net/src/lite/track.rs
+++ b/rs/moq-net/src/lite/track.rs
@@ -19,7 +19,7 @@ pub struct Track<'a> {
 
 impl Message for Track<'_> {
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		if !version.has_timestamps() {
+		if !version.has_track_stream() {
 			return Err(DecodeError::Version);
 		}
 
@@ -30,7 +30,7 @@ impl Message for Track<'_> {
 	}
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		if !version.has_timestamps() {
+		if !version.has_track_stream() {
 			return Err(EncodeError::Version);
 		}
 
@@ -61,7 +61,7 @@ pub struct TrackInfo {
 
 impl Message for TrackInfo {
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		if !version.has_timestamps() {
+		if !version.has_track_stream() {
 			return Err(DecodeError::Version);
 		}
 
@@ -79,7 +79,7 @@ impl Message for TrackInfo {
 	}
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		if !version.has_timestamps() {
+		if !version.has_track_stream() {
 			return Err(EncodeError::Version);
 		}
 

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -16,13 +16,13 @@ pub enum Version {
 }
 
 impl Version {
-	/// Whether the track can carry a per-track timescale (reported in TRACK_INFO on
-	/// lite-05+). When the publisher advertises one, the publisher and subscriber
-	/// agree to prefix every frame with a zigzag-delta timestamp varint; with `None`
-	/// the wire skips the byte entirely, so this method only governs whether the
-	/// negotiation field exists, not whether timestamps are always present.
+	/// Whether the version has lite-05's dedicated TRACK stream and related stream
+	/// layout changes.
+	///
+	/// This is the common feature boundary for TRACK_INFO, FETCH streams,
+	/// SUBSCRIBE_START/END, and per-frame timestamp prefixes.
 	#[allow(clippy::match_like_matches_macro)]
-	pub fn has_timestamps(self) -> bool {
+	pub fn has_track_stream(self) -> bool {
 		// Match form so future versions default forward (CLAUDE.md convention).
 		match self {
 			Self::Lite01 | Self::Lite02 | Self::Lite03 | Self::Lite04 => false,

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -16,22 +16,71 @@ use crate::{
 
 /// A relay origin, identified by a 62-bit varint on the wire.
 ///
-/// `id` must be non-zero for a real origin; `id == 0` is reserved as a
-/// placeholder for Lite03-style hops where the actual value isn't carried.
-/// Encoding a value outside the 62-bit range (>= 2^62) will fail at the
-/// varint layer; [`Origin::random`] picks a valid random nonzero id.
+/// Local origins are built with [`Origin::new`] or [`Origin::random`], both of
+/// which guarantee a non-zero id so loop detection can work. Remote peers may
+/// still send `0`; it is legal on the wire but cannot be used for loop detection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Origin {
-	/// Non-zero 62-bit identifier. Encoded as a QUIC varint on the wire.
-	pub id: u64,
+	/// 62-bit identifier. Encoded as a QUIC varint on the wire.
+	id: u64,
+}
+
+/// Returned when a local origin id is zero or outside the 62-bit wire range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct InvalidOrigin;
+
+impl fmt::Display for InvalidOrigin {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		write!(f, "local origin id must be non-zero and below 2^62")
+	}
+}
+
+impl std::error::Error for InvalidOrigin {}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Origin {
+	fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+		use serde::ser::SerializeStruct;
+
+		let mut state = serializer.serialize_struct("Origin", 1)?;
+		state.serialize_field("id", &self.id)?;
+		state.end()
+	}
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Origin {
+	fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+		#[derive(serde::Deserialize)]
+		struct OriginSerde {
+			id: u64,
+		}
+
+		let origin = <OriginSerde as serde::Deserialize>::deserialize(deserializer)?;
+		if origin.id >= 1u64 << 62 {
+			return Err(serde::de::Error::custom("origin id must be below 2^62"));
+		}
+		Ok(Self { id: origin.id })
+	}
 }
 
 impl Origin {
 	/// Placeholder for hop entries whose actual id is not on the wire (Lite03).
-	/// `0` is a legal wire value and round-trips through the codec; we reserve it
-	/// as the "unknown" marker rather than hand it to a real origin.
+	/// Also used for remote peers that choose the legal but loop-blind id 0.
 	pub(crate) const UNKNOWN: Self = Self { id: 0 };
+
+	/// Build an origin from a stable id.
+	///
+	/// The id must be non-zero and fit in the 62-bit QUIC varint range. Wire
+	/// decode accepts remote id 0, but local origins should not use it because
+	/// downstream peers cannot exclude it for loop detection.
+	pub fn new(id: u64) -> Result<Self, InvalidOrigin> {
+		if id == 0 || id >= 1u64 << 62 {
+			return Err(InvalidOrigin);
+		}
+		Ok(Self { id })
+	}
 
 	/// Generate a fresh origin with a random non-zero id. Use this for any
 	/// origin that does not need a stable identity across restarts.
@@ -47,15 +96,22 @@ impl Origin {
 		Self { id }
 	}
 
+	/// Return the origin's wire id.
+	pub fn id(self) -> u64 {
+		self.id
+	}
+
 	/// Consume this [Origin] to create a producer that carries its id.
 	pub fn produce(self) -> OriginProducer {
 		OriginProducer::new(self)
 	}
 }
 
-impl From<u64> for Origin {
-	fn from(id: u64) -> Self {
-		Self { id }
+impl TryFrom<u64> for Origin {
+	type Error = InvalidOrigin;
+
+	fn try_from(id: u64) -> Result<Self, Self::Error> {
+		Self::new(id)
 	}
 }
 
@@ -266,7 +322,7 @@ fn route_key(name: &Path, info: &BroadcastInfo) -> (usize, u64) {
 		hash = (hash ^ u64::from(byte)).wrapping_mul(FNV_PRIME);
 	}
 	for hop in &info.hops {
-		for &byte in &hop.id.to_le_bytes() {
+		for &byte in &hop.id().to_le_bytes() {
 			hash = (hash ^ u64::from(byte)).wrapping_mul(FNV_PRIME);
 		}
 	}
@@ -1695,9 +1751,22 @@ impl OriginProducer {
 
 #[cfg(test)]
 mod tests {
-	use crate::BroadcastInfo;
+	use crate::{BroadcastInfo, coding::Decode};
 
 	use super::*;
+
+	#[test]
+	fn origin_rejects_reserved_ids() {
+		assert!(Origin::new(0).is_err());
+		assert!(Origin::new(1u64 << 62).is_err());
+		assert_eq!(Origin::new(1).unwrap().id(), 1);
+
+		let mut zero = [0u8].as_slice();
+		assert_eq!(
+			Origin::decode(&mut zero, crate::lite::Version::Lite05Wip).unwrap(),
+			Origin::UNKNOWN
+		);
+	}
 
 	#[test]
 	fn origin_list_push_fails_at_limit() {
@@ -1710,19 +1779,6 @@ mod tests {
 	}
 
 	#[test]
-	fn origin_zero_round_trips() {
-		// `0` is the reserved UNKNOWN placeholder; it must stay a legal wire value.
-		let mut buf = bytes::BytesMut::new();
-		Origin::UNKNOWN
-			.encode(&mut buf, crate::lite::Version::Lite05Wip)
-			.unwrap();
-		let mut slice = &buf[..];
-		let got = Origin::decode(&mut slice, crate::lite::Version::Lite05Wip).unwrap();
-		assert!(slice.is_empty());
-		assert_eq!(got, Origin::UNKNOWN);
-	}
-
-	#[test]
 	fn origin_list_replace_first() {
 		let mut list = OriginList::new();
 		for _ in 0..3 {
@@ -1730,11 +1786,14 @@ mod tests {
 		}
 
 		// Rewrites only the first placeholder, keeping the length the same.
-		assert!(list.replace_first(Origin::UNKNOWN, Origin::from(7)));
-		assert_eq!(list.as_slice(), &[Origin::from(7), Origin::UNKNOWN, Origin::UNKNOWN]);
+		assert!(list.replace_first(Origin::UNKNOWN, Origin::new(7).unwrap()));
+		assert_eq!(
+			list.as_slice(),
+			&[Origin::new(7).unwrap(), Origin::UNKNOWN, Origin::UNKNOWN]
+		);
 
 		// No match leaves the list untouched.
-		assert!(!list.replace_first(Origin::from(99), Origin::from(8)));
+		assert!(!list.replace_first(Origin::new(99).unwrap(), Origin::new(8).unwrap()));
 		assert_eq!(list.len(), 3);
 	}
 
@@ -1877,7 +1936,7 @@ mod tests {
 		let origin = Origin::random().produce();
 		// `a` carries one hop; `b` has none, so `b` wins the route and replaces it.
 		let a = BroadcastInfo {
-			hops: OriginList::try_from(vec![Origin::from(1u64)]).unwrap(),
+			hops: OriginList::try_from(vec![Origin::new(1u64).unwrap()]).unwrap(),
 		}
 		.produce();
 		let b = BroadcastInfo::new().produce();
@@ -1898,7 +1957,7 @@ mod tests {
 		let origin = Origin::random().produce();
 		// `a` carries one hop; `b` has none, so `b` wins the route and replaces it.
 		let a = BroadcastInfo {
-			hops: OriginList::try_from(vec![Origin::from(1u64)]).unwrap(),
+			hops: OriginList::try_from(vec![Origin::new(1u64).unwrap()]).unwrap(),
 		}
 		.produce();
 		let b = BroadcastInfo::new().produce();
@@ -1942,7 +2001,13 @@ mod tests {
 		tokio::time::pause();
 
 		fn route(ids: &[u64]) -> BroadcastProducer {
-			let hops = OriginList::try_from(ids.iter().copied().map(Origin::from).collect::<Vec<_>>()).unwrap();
+			let hops = OriginList::try_from(
+				ids.iter()
+					.copied()
+					.map(|id| Origin::new(id).unwrap())
+					.collect::<Vec<_>>(),
+			)
+			.unwrap();
 			BroadcastInfo { hops }.produce()
 		}
 

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1390,7 +1390,12 @@ impl TrackSubscriber {
 		kio::wait(|waiter| self.poll_read_frame(waiter)).await
 	}
 
-	/// Poll for the group with the given sequence, without blocking.
+	/// Poll for the group with the given sequence.
+	///
+	/// This waits for live arrival, not on-demand retrieval. If the sequence is
+	/// below the final sequence but was already evicted from the cache, this parks
+	/// until the track closes. Use [`TrackConsumer::fetch_group`] for a past group that a
+	/// [`TrackDynamic`] can serve on demand.
 	pub fn poll_get_group(&self, waiter: &kio::Waiter, sequence: u64) -> Poll<Result<Option<GroupConsumer>>> {
 		self.poll(waiter, |state| state.poll_get_group(sequence))
 	}
@@ -1401,7 +1406,9 @@ impl TrackSubscriber {
 	/// Resolves to `None` only when `sequence` is at or past the track's
 	/// `final_sequence` (set by `finish()` / `finish_at()`), since such a
 	/// group can never be produced. Sequences below `final_sequence` still
-	/// wait, since older groups may still arrive out of order.
+	/// wait, since older groups may still arrive out of order. If the sequence
+	/// was already evicted, this waits until the track closes; use
+	/// [`TrackConsumer::fetch_group`] for on-demand retrieval of past groups.
 	pub async fn get_group(&self, sequence: u64) -> Result<Option<GroupConsumer>> {
 		kio::wait(|waiter| self.poll_get_group(waiter, sequence)).await
 	}

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -184,9 +184,14 @@ impl Server {
 		let (path, request_id_max) = match version {
 			Version::Ietf(v) => {
 				let params = ietf::Parameters::decode(&mut client.parameters, v)?;
-				let path = params
-					.get_bytes(ietf::ParameterBytes::Path)
-					.map(|b| String::from_utf8_lossy(b).into_owned());
+				let path = match params.get_bytes(ietf::ParameterBytes::Path) {
+					Some(bytes) => Some(
+						std::str::from_utf8(bytes)
+							.map_err(|_| Error::Decode(crate::DecodeError::InvalidValue))?
+							.to_owned(),
+					),
+					None => None,
+				};
 				let request_id_max = params
 					.get_varint(ietf::ParameterVarInt::MaxRequestId)
 					.map(ietf::RequestId);

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -367,11 +367,11 @@ impl Cluster {
 			Some(id) if id >= 1 << 62 => {
 				anyhow::bail!("--cluster-id must be below 2^62 (wire varint limit), got {id}")
 			}
-			Some(id) => Origin::from(id),
+			Some(id) => Origin::new(id).expect("cluster id already validated"),
 			None => Origin::random(),
 		}
 		.produce();
-		tracing::info!(origin_id = %origin.id, configured = config.id.is_some(), "cluster initialized");
+		tracing::info!(origin_id = %origin.id(), configured = config.id.is_some(), "cluster initialized");
 		Ok(Cluster {
 			config,
 			client: None,
@@ -1145,7 +1145,7 @@ mod tests {
 			..Default::default()
 		})
 		.expect("valid id");
-		assert_eq!(cluster.origin.id, 42);
+		assert_eq!(cluster.origin.id(), 42);
 	}
 
 	/// A reserved (0) or out-of-range (>= 2^62) `cluster.id` is rejected rather


### PR DESCRIPTION
## Summary

- Rename the lite-05 feature predicate from `has_timestamps` to `has_track_stream` and update the call sites that gate TRACK, FETCH, and subscribe range messages.
- Validate local `Origin` ids at construction while continuing to accept remote id `0` on the wire.
- Batch the lite-05 initial announce response, make `SubscribeEnd` use an exclusive end bound, and align IETF setup path UTF-8 validation with lite.
- Document `get_group` eviction behavior and steer past-group callers to `fetch_group`.

## Public API changes

- `moq_net::Origin::id` is now private.
- Added `moq_net::Origin::new(u64) -> Result<Origin, InvalidOrigin>`.
- Added `moq_net::Origin::id() -> u64`.
- Added `moq_net::InvalidOrigin`.
- Replaced `impl From<u64> for Origin` with `impl TryFrom<u64> for Origin`.

## Breaking change

This is breaking for external callers that used `Origin { id }`, `origin.id`, or `Origin::from(id)`. Remote peers may still send origin id `0`; only local construction rejects it because loop detection cannot use it. The PR targets `dev` because this touches `rs/moq-net` public API shape.

## Validation

- `cargo test -p moq-net --all-features`
- `cargo check -p moq-relay`

(Written by GPT-5)
