### PR TITLE
[codex] fix python connect TLS pinning

### DIFF
--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -101,7 +101,7 @@ client = moq.Client(
 
 ### Connection
 
-- **`connect(url, *, tls_verify=True, bind=None, publish=None, subscribe=None)`**. Shorthand for `Client(...)`; use as `async with moq.connect(url) as client:`.
+- **`connect(url, *, tls_verify=True, tls_roots=None, tls_fingerprints=None, bind=None, publish=None, subscribe=None)`**. Shorthand for `Client(...)`; use as `async with moq.connect(url) as client:`.
 - **`Client(url, *, tls_verify=True, tls_roots=None, tls_fingerprints=None, bind=None, publish=None, subscribe=None)`**. Async context manager for connecting to a relay.
   - `tls_roots`. PEM root certificate file path(s) to trust instead of the system roots.
   - `tls_fingerprints`. Hex SHA-256 fingerprint(s) to pin the peer's certificate to, the native equivalent of `serverCertificateHashes`. Accepts the values a server reports via `cert_fingerprints()`, so you can trust a self-signed certificate without `tls_verify=False`.

--- a/py/moq-rs/moq/client.py
+++ b/py/moq-rs/moq/client.py
@@ -1,4 +1,4 @@
-"""Client wrapper — simplified connection with automatic origin wiring."""
+"""Client wrapper for simplified connection with automatic origin wiring."""
 
 from __future__ import annotations
 
@@ -111,6 +111,7 @@ class Client:
         return self._consumer.announced_broadcast(path)
 
     async def request_broadcast(self, path: str) -> BroadcastConsumer:
+        """Request a broadcast by path, resolving as soon as it can be served."""
         if self._consumer is None:
             raise RuntimeError("no consume origin configured")
         return await self._consumer.request_broadcast(path)
@@ -125,6 +126,8 @@ def connect(
     url: str,
     *,
     tls_verify: bool = True,
+    tls_roots: list[str] | None = None,
+    tls_fingerprints: list[str] | None = None,
     bind: str | None = None,
     publish: OriginProducer | None = None,
     subscribe: OriginProducer | None = None,
@@ -136,4 +139,12 @@ def connect(
         async with moq.connect("https://relay.example.com") as client:
             ...
     """
-    return Client(url, tls_verify=tls_verify, bind=bind, publish=publish, subscribe=subscribe)
+    return Client(
+        url,
+        tls_verify=tls_verify,
+        tls_roots=tls_roots,
+        tls_fingerprints=tls_fingerprints,
+        bind=bind,
+        publish=publish,
+        subscribe=subscribe,
+    )

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -1,4 +1,4 @@
-"""Origin wrappers — manage announcements and broadcast discovery."""
+"""Origin wrappers for announcements and broadcast discovery."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from .subscribe import BroadcastConsumer
 
 
 class Announcement:
-    """Wraps MoqAnnouncement — a discovered broadcast."""
+    """Wraps MoqAnnouncement, a discovered broadcast."""
 
     def __init__(self, inner: MoqAnnouncement) -> None:
         self._inner = inner
@@ -54,7 +54,7 @@ class Announced:
 
 
 class AnnouncedBroadcast:
-    """Wraps MoqAnnouncedBroadcast — awaitable for a specific broadcast."""
+    """Wraps MoqAnnouncedBroadcast, awaitable for a specific broadcast."""
 
     def __init__(self, inner: MoqAnnouncedBroadcast) -> None:
         self._inner = inner

--- a/py/moq-rs/moq/server.py
+++ b/py/moq-rs/moq/server.py
@@ -1,4 +1,4 @@
-"""Server wrapper — accept incoming sessions with automatic origin wiring."""
+"""Server wrapper for accepting incoming sessions with automatic origin wiring."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ Transport = Literal["quic", "iroh", "websocket"]
 
 
 class Request:
-    """Wraps MoqRequest — an incoming session that can be accepted or rejected.
+    """Wraps MoqRequest, an incoming session that can be accepted or rejected.
 
     Use `await request.ok()` to complete the handshake, or
     `await request.close(code)` to reject with an HTTP status code.

--- a/py/moq-rs/moq/session.py
+++ b/py/moq-rs/moq/session.py
@@ -1,4 +1,4 @@
-"""Session wrapper — an established MoQ connection."""
+"""Session wrapper for an established MoQ connection."""
 
 from __future__ import annotations
 

--- a/py/moq-rs/moq/subscribe.py
+++ b/py/moq-rs/moq/subscribe.py
@@ -1,4 +1,4 @@
-"""Consumer wrappers — subscribe to broadcasts, catalogs, and media tracks."""
+"""Consumer wrappers for broadcasts, catalogs, and media tracks."""
 
 from __future__ import annotations
 
@@ -194,7 +194,7 @@ class BroadcastConsumer:
         return CatalogConsumer(await self._inner.subscribe_catalog())
 
     async def subscribe_track(self, name: str, subscription: Subscription | None = None) -> TrackConsumer:
-        """Subscribe to a track — receive arbitrary byte payloads.
+        """Subscribe to a track and receive arbitrary byte payloads.
 
         ``subscription`` tunes delivery (priority, ordering, group range); omit for defaults.
         """
@@ -231,7 +231,7 @@ class BroadcastConsumer:
         ``catalog_audio`` comes from the catalog (e.g.
         ``await broadcast.catalog()`` followed by
         ``catalog.audio[name]``). Use ``output.latency_max_ms`` to
-        control how aggressively stalled groups get skipped — that's
+        control how aggressively stalled groups get skipped. That's
         the congestion-control knob. (Named ``_max`` to leave room for
         a future ``latency_min_ms`` jitter-buffer floor.)
         """

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -410,6 +410,13 @@ def test_public_api_exports():
     assert hasattr(moq.Error, "Cancelled")
     assert callable(moq.log_level)
     assert isinstance(moq.connect("https://example.com"), moq.Client)
+    client = moq.connect(
+        "https://example.com",
+        tls_roots=["root.pem"],
+        tls_fingerprints=["abc123"],
+    )
+    assert client._tls_roots == ["root.pem"]
+    assert client._tls_fingerprints == ["abc123"]
 
 
 async def test_subscribe_media_default_latency_and_context_manager():

--- a/py/moq-rs/tests/test_server.py
+++ b/py/moq-rs/tests/test_server.py
@@ -1,4 +1,4 @@
-"""Server tests — end-to-end Server + Client over loopback with TLS."""
+"""Server tests for end-to-end Server + Client over loopback with TLS."""
 
 import asyncio
 import struct


### PR DESCRIPTION
## Summary

- Pass `tls_roots` and `tls_fingerprints` through the Python `moq.connect()` shorthand so it matches `Client`.
- Add the missing `Client.request_broadcast()` docstring.
- Clean em dashes out of the touched Python wrapper docstrings and tests, and update the `moq-rs` README signature.

## Public API Changes

- Python `moq.connect()` now accepts `tls_roots` and `tls_fingerprints` keyword arguments. This is additive and matches the existing `Client(...)` constructor.

## Validation

- `just py fix`
- `just py test` (41 passed)
- `just py check`

(Written by GPT-5)
