### PR TITLE
[codex] remove unstable flag from just fmt

### DIFF
--- a/.github/justfile
+++ b/.github/justfile
@@ -1,5 +1,5 @@
-set fallback := true
-set unstable := true
+set fallback
+set unstable
 
 # Lint GitHub Actions workflows. Silently skipped if actionlint is not installed.
 check:

--- a/.github/justfile
+++ b/.github/justfile
@@ -1,4 +1,5 @@
-set fallback
+set fallback := true
+set unstable := true
 
 # Lint GitHub Actions workflows. Silently skipped if actionlint is not installed.
 check:

--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -1,5 +1,4 @@
 #!/usr/bin/env just --justfile
-
 # OBS Studio plugin for MoQ. See doc/bin/obs.md for the full build guide.
 #
 # Linux:   `nix develop` provides obs-studio/qt6/ffmpeg/cmake, then `just obs build`.
@@ -11,7 +10,8 @@
 # libmoq is built from the in-tree crate (rs/libmoq) via cargo. MOQ_LOCAL points
 # CMake at the repo root by default, so there's no prebuilt release to download.
 
-set quiet
+set unstable := true
+set quiet := true
 
 # List all of the available commands.
 default:
@@ -21,6 +21,7 @@ default:
 # CMakeLists.txt (so libmoq builds from rs/libmoq); pass `path=/some/moq` to
 # override. We deliberately don't compute the path here: `justfile_directory()`
 # resolves to the root justfile when this runs as `just obs setup`, so the
+
 # relative math would point outside the repo.
 setup preset="" path="":
     #!/usr/bin/env bash
@@ -35,6 +36,7 @@ setup preset="" path="":
     fi
 
 # Build via CMake presets. Run `just obs setup` first (it configures + downloads
+
 # deps); not chained here because on macOS setup reconfigures OBS, which is slow.
 build preset="":
     #!/usr/bin/env bash
@@ -43,6 +45,7 @@ build preset="":
     cmake --build --preset "$PRESET"
 
 # Copy the freshly built plugin into the OBS user plugin dir and launch OBS.
+
 # Uses the installed OBS (no local OBS build required). macOS only for now.
 run:
     #!/usr/bin/env bash

--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -10,8 +10,8 @@
 # libmoq is built from the in-tree crate (rs/libmoq) via cargo. MOQ_LOCAL points
 # CMake at the repo root by default, so there's no prebuilt release to download.
 
-set unstable := true
-set quiet := true
+set unstable
+set quiet
 
 # List all of the available commands.
 default:

--- a/demo/boy/justfile
+++ b/demo/boy/justfile
@@ -1,4 +1,5 @@
-set fallback
+set fallback := true
+set unstable := true
 
 # Run the GB demo: relay + emulator publisher + web viewer.
 default:

--- a/demo/boy/justfile
+++ b/demo/boy/justfile
@@ -1,5 +1,5 @@
-set fallback := true
-set unstable := true
+set fallback
+set unstable
 
 # Run the GB demo: relay + emulator publisher + web viewer.
 default:

--- a/demo/justfile
+++ b/demo/justfile
@@ -1,4 +1,5 @@
-set fallback
+set fallback := true
+set unstable := true
 
 mod boy
 mod pub
@@ -10,6 +11,7 @@ mod web
 #
 # Picks the first free port at/after 4443 (both UDP for QUIC and TCP for HTTP)
 # so multiple worktrees can run `just dev` without colliding. The relay reads
+
 # the port from MOQ_SERVER_BIND/MOQ_WEB_HTTP_LISTEN, overriding localhost.toml.
 default:
     #!/usr/bin/env bash
@@ -34,6 +36,7 @@ default:
 # Find the first free port at/after `start` (checked on both TCP and UDP).
 # `lsof` isn't available everywhere (e.g. Git Bash on Windows); without it we
 # can't probe, so fall back to `start` and let the relay surface a bind error if
+
 # it's actually taken.
 [private]
 port start="4443":

--- a/demo/justfile
+++ b/demo/justfile
@@ -1,5 +1,5 @@
-set fallback := true
-set unstable := true
+set fallback
+set unstable
 
 mod boy
 mod pub

--- a/demo/pub/justfile
+++ b/demo/pub/justfile
@@ -1,4 +1,5 @@
-set fallback
+set fallback := true
+set unstable := true
 
 # --- R2 bucket management (vid.moq.dev) ---
 
@@ -17,6 +18,7 @@ deploy:
 # Use ffmpeg to fragment before uploading:
 #	 ffmpeg -i input.mp4 -c copy -f mp4 \
 #		 -movflags cmaf+separate_moof+delay_moov+skip_trailer+frag_every_frame \
+
 # output.mp4
 upload file:
     bun install
@@ -257,6 +259,7 @@ ffmpeg-cmaf input output='-' *args:
 #
 # `-pes_payload_size 0` flushes one PES per audio frame instead of batching ~8
 # (the default 2930-byte minimum), so audio interleaves evenly with video rather
+
 # than arriving in ~185ms bursts. Without it the player must buffer a whole burst.
 [private]
 ffmpeg-ts input output='-' *args:

--- a/demo/pub/justfile
+++ b/demo/pub/justfile
@@ -1,5 +1,5 @@
-set fallback := true
-set unstable := true
+set fallback
+set unstable
 
 # --- R2 bucket management (vid.moq.dev) ---
 

--- a/demo/relay/justfile
+++ b/demo/relay/justfile
@@ -1,5 +1,5 @@
-set fallback := true
-set unstable := true
+set fallback
+set unstable
 
 # Run a localhost relay server without authentication.
 default:

--- a/demo/relay/justfile
+++ b/demo/relay/justfile
@@ -1,4 +1,5 @@
-set fallback
+set fallback := true
+set unstable := true
 
 # Run a localhost relay server without authentication.
 default:
@@ -7,6 +8,7 @@ default:
 # Run a cluster of relay servers.
 #
 # The relays grant anonymous access (see *.toml), so no JWT is needed locally.
+
 # Cluster peers still authenticate to each other via mTLS (the cert/ca recipes).
 cluster:
     bun install

--- a/demo/sub/justfile
+++ b/demo/sub/justfile
@@ -1,5 +1,5 @@
-set fallback := true
-set unstable := true
+set fallback
+set unstable
 
 # Subscribe to a broadcast using GStreamer and render to the screen.
 gst name url='http://localhost:4443' *args:

--- a/demo/sub/justfile
+++ b/demo/sub/justfile
@@ -1,4 +1,5 @@
-set fallback
+set fallback := true
+set unstable := true
 
 # Subscribe to a broadcast using GStreamer and render to the screen.
 gst name url='http://localhost:4443' *args:

--- a/demo/web/justfile
+++ b/demo/web/justfile
@@ -1,5 +1,5 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
-set unstable := true
+set unstable
 
 # Run the web server targeting the default relay.
 default:

--- a/demo/web/justfile
+++ b/demo/web/justfile
@@ -1,4 +1,5 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
+set unstable := true
 
 # Run the web server targeting the default relay.
 default:
@@ -6,6 +7,7 @@ default:
 
 # Run the web server targeting the specified relay.
 # The vite config opens the watch, publish, and stats demos in separate tabs;
+
 # set MOQ_NO_OPEN=1 to skip opening a browser.
 serve url='http://localhost:4443':
     VITE_RELAY_URL="{{ url }}" bun --bun vite

--- a/go/justfile
+++ b/go/justfile
@@ -3,7 +3,7 @@
 # Language-specific recipes for the Go bindings under go/. Invoked from
 # the repo root as `just go <recipe>` via the `mod go` import.
 
-set unstable := true
+set unstable
 set working-directory := '.'
 
 default:

--- a/go/justfile
+++ b/go/justfile
@@ -3,6 +3,7 @@
 # Language-specific recipes for the Go bindings under go/. Invoked from
 # the repo root as `just go <recipe>` via the `mod go` import.
 
+set unstable := true
 set working-directory := '.'
 
 default:
@@ -10,17 +11,20 @@ default:
 
 # Build moq-ffi for the host, run uniffi-bindgen-go, stage everything
 # into a tmp dir, and run `go build`/`go vet`/`go test` from there.
+
 # Skips cleanly if cargo, go, or uniffi-bindgen-go is missing.
 check:
     bash scripts/check.sh
 
 # Stage the in-tree go/ source + per-target moq-ffi libs + generated
+
 # bindings into a single Go module ready for publish.
 package *args:
     bash scripts/package.sh {{ args }}
 
 # Remove the generated bindings, native libs, and vendoring that
 # scripts/check.sh produces in go/ (see go/.gitignore). The tmp staging
+
 # under the workspace dist/ is swept by `just js clean`.
 clean:
     rm -rf moq/moq.go moq/lib go.sum vendor
@@ -28,6 +32,7 @@ clean:
 # Full Go CI: `check` builds moq-ffi, regenerates bindings, runs go
 # vet/build/test. Takes a newline-separated list of changed files;
 # skips if FILES is non-empty and none match the Go scope. Run
+
 # `just go ci` (no FILES) to force-run.
 ci FILES="":
     #!/usr/bin/env bash

--- a/infra/apt/justfile
+++ b/infra/apt/justfile
@@ -1,4 +1,5 @@
-set fallback
+set fallback := true
+set unstable := true
 
 # Deploy the apt.moq.dev worker.
 deploy:
@@ -6,6 +7,7 @@ deploy:
     bun wrangler deploy
 
 # Regenerate apt repo metadata and upload to the apt-moq-dev R2 bucket.
+
 # Reads .deb files from $ARTIFACTS_DIR (defaults to ./artifacts).
 publish artifacts="artifacts":
     ARTIFACTS_DIR="{{ artifacts }}" ./publish.sh

--- a/infra/apt/justfile
+++ b/infra/apt/justfile
@@ -1,5 +1,5 @@
-set fallback := true
-set unstable := true
+set fallback
+set unstable
 
 # Deploy the apt.moq.dev worker.
 deploy:

--- a/infra/justfile
+++ b/infra/justfile
@@ -1,5 +1,5 @@
-set fallback := true
-set unstable := true
+set fallback
+set unstable
 
 mod apt
 mod rpm

--- a/infra/justfile
+++ b/infra/justfile
@@ -1,4 +1,5 @@
-set fallback
+set fallback := true
+set unstable := true
 
 mod apt
 mod rpm

--- a/infra/rpm/justfile
+++ b/infra/rpm/justfile
@@ -1,5 +1,5 @@
-set fallback := true
-set unstable := true
+set fallback
+set unstable
 
 # Deploy the rpm.moq.dev worker.
 deploy:

--- a/infra/rpm/justfile
+++ b/infra/rpm/justfile
@@ -1,4 +1,5 @@
-set fallback
+set fallback := true
+set unstable := true
 
 # Deploy the rpm.moq.dev worker.
 deploy:
@@ -6,6 +7,7 @@ deploy:
     bun wrangler deploy
 
 # Regenerate rpm repo metadata and upload to the rpm-moq-dev R2 bucket.
+
 # Reads .rpm files from $ARTIFACTS_DIR (defaults to ./artifacts).
 publish artifacts="artifacts":
     ARTIFACTS_DIR="{{ artifacts }}" ./publish.sh

--- a/js/justfile
+++ b/js/justfile
@@ -4,6 +4,7 @@
 # js/. Invoked from the repo root as `just js <recipe>` via the `mod js`
 # import in the root justfile.
 
+set unstable := true
 set working-directory := '.'
 
 # Run all checks by default.
@@ -42,6 +43,7 @@ build:
     bun run --filter='*' build
 
 # Remove node_modules and build output. The bun workspace spans the repo
+
 # (deps hoist to the root, not into js/), so sweep from the workspace root.
 clean:
     #!/usr/bin/env bash
@@ -54,6 +56,7 @@ clean:
 
 # Full JS CI: lint + tests + build. Takes a newline-separated list of
 # changed files; skips if FILES is non-empty and none match the JS
+
 # scope. Run `just js ci` (no FILES) to force-run everything.
 ci FILES="":
     #!/usr/bin/env bash

--- a/js/justfile
+++ b/js/justfile
@@ -4,7 +4,7 @@
 # js/. Invoked from the repo root as `just js <recipe>` via the `mod js`
 # import in the root justfile.
 
-set unstable := true
+set unstable
 set working-directory := '.'
 
 # Run all checks by default.

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env just --justfile
 # Using Just: https://github.com/casey/just?tab=readme-ov-file#installation
 
-set unstable := true
+set unstable
 
 # Per-language modules. Anything that's specific to one language lives in
 

--- a/justfile
+++ b/justfile
@@ -1,8 +1,10 @@
 #!/usr/bin/env just --justfile
-
 # Using Just: https://github.com/casey/just?tab=readme-ov-file#installation
 
+set unstable := true
+
 # Per-language modules. Anything that's specific to one language lives in
+
 # its own justfile; the recipes below orchestrate across them.
 mod js
 mod rs
@@ -10,20 +12,15 @@ mod py
 mod kt
 mod swift
 mod go
-
 # OBS Studio plugin (C++). See doc/bin/obs.md.
 mod obs 'cpp/obs'
-
 # Unit tests per language (`just test`).
 mod test
-
 # Demos and infra.
 mod demo
 mod infra
-
 # GitHub Actions workflow linting.
 mod gh '.github'
-
 # Shortcuts to avoid `demo::` prefix.
 mod boy 'demo/boy'
 mod pub 'demo/pub'
@@ -40,6 +37,7 @@ dev:
     just demo
 
 # Install repo-wide tooling. Per-language deps install on first invocation
+
 # of `just <lang> check`.
 install:
     bun install
@@ -48,6 +46,7 @@ install:
 # Fast inner-loop checks. Runs JS, Rust, and Markdown lints.
 # Shell + workflow + TOML + Nix + justfile lints skip silently if their
 # binaries aren't on $PATH; `nix develop` provides them, and `just ci`
+
 # requires them.
 check *args:
     just js check
@@ -56,11 +55,12 @@ check *args:
     @if command -v shellcheck >/dev/null 2>&1 && command -v shfmt >/dev/null 2>&1; then shfmt --diff $(shfmt -f .) && shellcheck $(shfmt -f .); fi
     @if command -v taplo >/dev/null 2>&1; then RUST_LOG=error taplo format --check; fi
     @if command -v nixfmt >/dev/null 2>&1; then nixfmt --check $(find . -name '*.nix' -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*'); fi
-    @for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*'); do just --fmt --unstable --check --justfile "$f"; done
+    @for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*'); do just --fmt --check --justfile "$f"; done
     just gh check
 
 # Run every per-language `ci` with the diff vs BASE; each greps for its
 # own scope and skips when nothing relevant changed. Pass BASE="" to
+
 # default to $GITHUB_BASE_REF (CI) or origin/main (local).
 ci BASE="":
     #!/usr/bin/env bash
@@ -113,10 +113,11 @@ ci BASE="":
     shellcheck $(shfmt -f .)
     RUST_LOG=error taplo format --check
     nixfmt --check $(find . -name '*.nix' -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*')
-    for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*'); do just --fmt --unstable --check --justfile "$f"; done
+    for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*'); do just --fmt --check --justfile "$f"; done
     just gh ci
 
 # Auto-fix linting/formatting issues across all languages.
+
 # shfmt / taplo / nixfmt / just --fmt skipped silently if missing locally.
 fix:
     just js fix
@@ -126,7 +127,7 @@ fix:
     @if command -v shfmt >/dev/null 2>&1; then shfmt --write $(shfmt -f .); fi
     @if command -v taplo >/dev/null 2>&1; then RUST_LOG=error taplo format; fi
     @if command -v nixfmt >/dev/null 2>&1; then nixfmt $(find . -name '*.nix' -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*'); fi
-    @for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*'); do just --fmt --unstable --justfile "$f"; done
+    @for f in $(find . -name justfile -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*'); do just --fmt --justfile "$f"; done
 
 # Build the packages.
 build:
@@ -137,6 +138,7 @@ build:
 # Delete build artifacts and caches to reclaim disk space. Each language
 # owns its own `clean` (see js/rs/py/kt/swift/go justfiles); this
 # orchestrates them, sweeps the caches no language owns, then recurses into
+
 # any agent worktrees under .claude/worktrees/.
 clean:
     #!/usr/bin/env bash

--- a/kt/justfile
+++ b/kt/justfile
@@ -4,7 +4,7 @@
 # kt/. Invoked from the repo root as `just kt <recipe>` via the `mod kt`
 # import.
 
-set unstable := true
+set unstable
 set working-directory := '.'
 
 default:

--- a/kt/justfile
+++ b/kt/justfile
@@ -4,23 +4,27 @@
 # kt/. Invoked from the repo root as `just kt <recipe>` via the `mod kt`
 # import.
 
+set unstable := true
 set working-directory := '.'
 
 default:
     just check
 
 # Build moq-ffi for the host, regenerate uniffi bindings, run :moq:jvmTest.
+
 # Skips cleanly if cargo, java, or gradle is missing.
 check:
     bash scripts/check.sh
 
 # Assemble the KMP module from per-target moq-ffi binaries + bindings.
 # Used by .github/workflows/release-kt.yml; see kt/README.md for the
+
 # expected --lib-dir layout.
 package *args:
     bash scripts/package.sh {{ args }}
 
 # Remove gradle output plus the moq-ffi bindings and native libs that
+
 # scripts/check.sh generates into the source tree (see kt/.gitignore).
 clean:
     #!/usr/bin/env bash
@@ -34,6 +38,7 @@ clean:
 # Full Kotlin CI: `check` already builds moq-ffi and runs gradle tests.
 # Takes a newline-separated list of changed files; skips if FILES is
 # non-empty and none match the Kotlin scope. Run `just kt ci` (no
+
 # FILES) to force-run.
 ci FILES="":
     #!/usr/bin/env bash

--- a/py/justfile
+++ b/py/justfile
@@ -8,7 +8,7 @@
 #   moq-rs/   pure-python ergonomic wrapper depending on moq-ffi (dist `moq-rs`,
 #             import `moq`)
 
-set unstable := true
+set unstable
 set working-directory := '.'
 
 default:

--- a/py/justfile
+++ b/py/justfile
@@ -8,6 +8,7 @@
 #   moq-rs/   pure-python ergonomic wrapper depending on moq-ffi (dist `moq-rs`,
 #             import `moq`)
 
+set unstable := true
 set working-directory := '.'
 
 default:
@@ -15,6 +16,7 @@ default:
 
 # Build moq-ffi (maturin cdylib + bindings) and install the pure-python moq-rs
 # wrapper, both editable into the workspace venv. `--no-deps` on the wrapper
+
 # keeps uv from fetching moq-ffi off PyPI; maturin just installed it locally.
 _develop:
     cd moq-ffi && uv run --no-sync maturin develop --uv
@@ -22,6 +24,7 @@ _develop:
 
 # Lint + format + editable build + pyright. `--no-install-workspace` installs
 # the root dev group (ruff, maturin, pyright, pytest) without trying to
+
 # pip-build the workspace members; `_develop` then installs them editable.
 check:
     uv sync --no-install-workspace
@@ -41,6 +44,7 @@ test:
     uv run --no-sync pytest moq-rs/tests/ moq-ffi/tests/
 
 # Local dev build: editable install of moq-ffi (with the cdylib + uniffi
+
 # bindings) and the moq-rs wrapper into the workspace venv.
 build:
     uv sync --no-install-workspace
@@ -48,6 +52,7 @@ build:
 
 # Remove the virtualenv, release dist, bytecode caches, and the uniffi
 # bindings maturin drops in during editable installs. The uv workspace venv
+
 # lives at the repo root, so reach up for it.
 clean:
     #!/usr/bin/env bash
@@ -59,6 +64,7 @@ clean:
 
 # Build the pure-python moq-rs wrapper sdist + wheel into py/dist (for release).
 # moq-ffi is built separately by maturin (see release-py.yml); the wrapper is
+
 # pure python so it needs no compilation, just a metadata-correct wheel.
 package:
     rm -rf dist
@@ -67,6 +73,7 @@ package:
 # Full Python CI: lint + tests + build. Takes a newline-separated list
 # of changed files; skips if FILES is non-empty and none match the
 # Python scope (which includes rs/moq-ffi because moq-ffi bundles it via
+
 # maturin). Run `just py ci` (no FILES) to force-run everything.
 ci FILES="":
     #!/usr/bin/env bash

--- a/rs/justfile
+++ b/rs/justfile
@@ -7,7 +7,7 @@
 # the repository root, so these recipes run from the repo root rather than
 # from rs/ (cargo resolves paths relative to the workspace root either way).
 
-set unstable := true
+set unstable
 set working-directory := '..'
 
 default:

--- a/rs/justfile
+++ b/rs/justfile
@@ -7,6 +7,7 @@
 # the repository root, so these recipes run from the repo root rather than
 # from rs/ (cargo resolves paths relative to the workspace root either way).
 
+set unstable := true
 set working-directory := '..'
 
 default:
@@ -27,6 +28,7 @@ check *args:
 # force-run everything. `cargo publish --dry-run` lives in release-rs.yml.
 #
 # `cargo deny` runs here (not in `check`) so the inner-loop stays fast
+
 # and devs aren't blocked by a fresh upstream advisory mid-edit.
 ci FILES="":
     #!/usr/bin/env bash
@@ -101,6 +103,7 @@ update:
 #
 # Examples:
 #   just rs package moq-relay deb
+
 # just rs package moq-cli rpm
 package crate packager:
     #!/usr/bin/env bash

--- a/swift/justfile
+++ b/swift/justfile
@@ -3,7 +3,7 @@
 # Language-specific recipes for the Swift package under swift/. Invoked
 # from the repo root as `just swift <recipe>` via the `mod swift` import.
 
-set unstable := true
+set unstable
 set working-directory := '.'
 
 default:

--- a/swift/justfile
+++ b/swift/justfile
@@ -3,23 +3,27 @@
 # Language-specific recipes for the Swift package under swift/. Invoked
 # from the repo root as `just swift <recipe>` via the `mod swift` import.
 
+set unstable := true
 set working-directory := '.'
 
 default:
     just check
 
 # Build moq-ffi for the host, regenerate uniffi bindings, run swift test.
+
 # Skips cleanly on non-macOS hosts.
 check:
     bash scripts/check.sh
 
 # Assemble the XCFramework + Package.swift from per-target moq-ffi
 # binaries + bindings. Used by .github/workflows/release-swift.yml; see
+
 # swift/README.md for the expected --lib-dir layout.
 package *args:
     bash scripts/package.sh {{ args }}
 
 # Remove SwiftPM build output plus the XCFramework and generated bindings
+
 # that scripts/check.sh lays down (see swift/.gitignore).
 clean:
     rm -rf .build .swiftpm Package.resolved Sources/MoqFFI/Generated.swift MoqFFI.xcframework
@@ -27,6 +31,7 @@ clean:
 # Full Swift CI: `check` already builds moq-ffi and runs swift test.
 # Takes a newline-separated list of changed files; skips if FILES is
 # non-empty and none match the Swift scope. Run `just swift ci` (no
+
 # FILES) to force-run.
 ci FILES="":
     #!/usr/bin/env bash

--- a/test/justfile
+++ b/test/justfile
@@ -10,8 +10,8 @@
 #     to catch interop regressions before anything is published.
 # Fall back to the root justfile so `just js test` (etc.) resolve from here.
 
-set fallback := true
-set unstable := true
+set fallback
+set unstable
 set working-directory := '.'
 
 # Run unit tests for every language (default).

--- a/test/justfile
+++ b/test/justfile
@@ -8,9 +8,10 @@
 #     package registry to catch packaging breakage in a release.
 #   - `just test smoke` (smoke/, below) builds every client from THIS checkout
 #     to catch interop regressions before anything is published.
-
 # Fall back to the root justfile so `just js test` (etc.) resolve from here.
-set fallback
+
+set fallback := true
+set unstable := true
 set working-directory := '.'
 
 # Run unit tests for every language (default).
@@ -22,17 +23,20 @@ default *args:
 # Cross-language media interop smoke test, built from this checkout. Stands up a
 # relay and runs the publisher x subscriber matrix. Default: rust only. Pass
 # flags through, e.g.
+
 # just test smoke --publishers rust,python,js --subscribers rust,c
 smoke *args:
     ./smoke/smoke.sh {{ args }}
 
 # Full interop matrix: rust + python + browser publish; everyone subscribes
 # (incl. native node/bun JS, the C libmoq client, and the GStreamer moqsrc
+
 # plugin). --timeout 30 gives headless Chromium cold-start headroom.
 smoke-full:
     ./smoke/smoke.sh --publishers rust,python,js --subscribers rust,python,js,js-native-node,js-native-bun,c,gst --timeout 30
 
 # Negative control: no publisher, every subscriber must time out (proves the
+
 # harness can actually report failure).
 smoke-negative *args:
     ./smoke/smoke.sh --negative {{ args }}


### PR DESCRIPTION
## Summary

- Remove `--unstable` from the root `just --fmt` invocations used by `check`, `ci`, and `fix`.
- Add `set unstable` to each justfile so bare `just --fmt` works with the Nix/CI Just formatter.
- Let `just --fmt` normalize the touched justfiles.

## Public API Changes

None. This only changes repository tooling recipes.

## Validation

- `just fix`
- `rg -n -e "--unstable" --glob justfile`
- formatter loop with `just --fmt --check --justfile` over every justfile
- `git diff --check`
- PR Check initially found local Just 1.46 had normalized boolean settings differently than the Nix/CI formatter; the follow-up commit switches to the CI-canonical `set unstable` form.

(Written by GPT-5)