### PR TITLE
[codex] remove just unstable opt-ins

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,14 @@
+{
+	"hooks": {
+		"SessionStart": [
+			{
+				"hooks": [
+					{
+						"type": "command",
+						"command": "bash -lc 'project_dir=\"${CODEX_PROJECT_DIR:-${CLAUDE_PROJECT_DIR:-$PWD}}\"; exec bash \"$project_dir/.codex/hooks/direnv.sh\"'"
+					}
+				]
+			}
+		]
+	}
+}

--- a/.codex/hooks/direnv.sh
+++ b/.codex/hooks/direnv.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Load the project's direnv/Nix dev shell into the agent session so shell tool
+# commands resolve flake-pinned tools (just, bun, nixfmt, ...) instead of system
+# ones. No-op for anyone without direnv or an .envrc, so non-Nix setups are
+# unaffected.
+#
+# direnv only approves the .envrc; the actual env is exported into the session
+# env file, which the agent sources for later shell commands.
+
+set -u
+
+env_file="${CODEX_ENV_FILE:-${CLAUDE_ENV_FILE:-}}"
+
+# Nothing to export into without this; older agent versions won't set it.
+[ -n "$env_file" ] || exit 0
+
+command -v direnv >/dev/null 2>&1 || exit 0
+
+# Require an explicit project dir so we never approve/export a stray .envrc from
+# some unrelated working directory.
+project_dir="${CODEX_PROJECT_DIR:-${CLAUDE_PROJECT_DIR:-${PWD:-}}}"
+[ -n "$project_dir" ] || exit 0
+cd "$project_dir" || exit 0
+[ -f .envrc ] || exit 0
+
+# Clear any inherited direnv state so `export` recomputes the full diff. Without
+# this, a stale DIRENV_DIFF from the parent process makes direnv assume the env
+# is already loaded and emit nothing.
+unset DIRENV_DIR DIRENV_DIFF DIRENV_WATCHES DIRENV_FILE DIRENV_LAYOUT
+
+direnv allow . 2>/dev/null
+direnv export bash >>"$env_file" 2>/dev/null
+
+exit 0

--- a/.github/justfile
+++ b/.github/justfile
@@ -1,5 +1,4 @@
 set fallback
-set unstable
 
 # Lint GitHub Actions workflows. Silently skipped if actionlint is not installed.
 check:

--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -10,7 +10,6 @@
 # libmoq is built from the in-tree crate (rs/libmoq) via cargo. MOQ_LOCAL points
 # CMake at the repo root by default, so there's no prebuilt release to download.
 
-set unstable
 set quiet
 
 # List all of the available commands.

--- a/demo/boy/justfile
+++ b/demo/boy/justfile
@@ -1,5 +1,4 @@
 set fallback
-set unstable
 
 # Run the GB demo: relay + emulator publisher + web viewer.
 default:

--- a/demo/justfile
+++ b/demo/justfile
@@ -1,5 +1,4 @@
 set fallback
-set unstable
 
 mod boy
 mod pub

--- a/demo/pub/justfile
+++ b/demo/pub/justfile
@@ -1,5 +1,4 @@
 set fallback
-set unstable
 
 # --- R2 bucket management (vid.moq.dev) ---
 

--- a/demo/relay/justfile
+++ b/demo/relay/justfile
@@ -1,5 +1,4 @@
 set fallback
-set unstable
 
 # Run a localhost relay server without authentication.
 default:

--- a/demo/sub/justfile
+++ b/demo/sub/justfile
@@ -1,5 +1,4 @@
 set fallback
-set unstable
 
 # Subscribe to a broadcast using GStreamer and render to the screen.
 gst name url='http://localhost:4443' *args:

--- a/demo/web/justfile
+++ b/demo/web/justfile
@@ -1,5 +1,4 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
-set unstable
 
 # Run the web server targeting the default relay.
 default:

--- a/go/justfile
+++ b/go/justfile
@@ -3,7 +3,6 @@
 # Language-specific recipes for the Go bindings under go/. Invoked from
 # the repo root as `just go <recipe>` via the `mod go` import.
 
-set unstable
 set working-directory := '.'
 
 default:

--- a/infra/apt/justfile
+++ b/infra/apt/justfile
@@ -1,5 +1,4 @@
 set fallback
-set unstable
 
 # Deploy the apt.moq.dev worker.
 deploy:

--- a/infra/justfile
+++ b/infra/justfile
@@ -1,5 +1,4 @@
 set fallback
-set unstable
 
 mod apt
 mod rpm

--- a/infra/rpm/justfile
+++ b/infra/rpm/justfile
@@ -1,5 +1,4 @@
 set fallback
-set unstable
 
 # Deploy the rpm.moq.dev worker.
 deploy:

--- a/js/justfile
+++ b/js/justfile
@@ -4,7 +4,6 @@
 # js/. Invoked from the repo root as `just js <recipe>` via the `mod js`
 # import in the root justfile.
 
-set unstable
 set working-directory := '.'
 
 # Run all checks by default.

--- a/justfile
+++ b/justfile
@@ -1,8 +1,5 @@
 #!/usr/bin/env just --justfile
 # Using Just: https://github.com/casey/just?tab=readme-ov-file#installation
-
-set unstable
-
 # Per-language modules. Anything that's specific to one language lives in
 
 # its own justfile; the recipes below orchestrate across them.

--- a/kt/justfile
+++ b/kt/justfile
@@ -4,7 +4,6 @@
 # kt/. Invoked from the repo root as `just kt <recipe>` via the `mod kt`
 # import.
 
-set unstable
 set working-directory := '.'
 
 default:

--- a/py/justfile
+++ b/py/justfile
@@ -8,7 +8,6 @@
 #   moq-rs/   pure-python ergonomic wrapper depending on moq-ffi (dist `moq-rs`,
 #             import `moq`)
 
-set unstable
 set working-directory := '.'
 
 default:

--- a/rs/justfile
+++ b/rs/justfile
@@ -7,7 +7,6 @@
 # the repository root, so these recipes run from the repo root rather than
 # from rs/ (cargo resolves paths relative to the workspace root either way).
 
-set unstable
 set working-directory := '..'
 
 default:

--- a/swift/justfile
+++ b/swift/justfile
@@ -3,7 +3,6 @@
 # Language-specific recipes for the Swift package under swift/. Invoked
 # from the repo root as `just swift <recipe>` via the `mod swift` import.
 
-set unstable
 set working-directory := '.'
 
 default:

--- a/test/justfile
+++ b/test/justfile
@@ -11,7 +11,6 @@
 # Fall back to the root justfile so `just js test` (etc.) resolve from here.
 
 set fallback
-set unstable
 set working-directory := '.'
 
 # Run unit tests for every language (default).


### PR DESCRIPTION
## Summary

- Remove `set unstable` from every justfile now that `just --fmt` no longer needs the unstable opt-in in the repo toolchain.
- Add a Codex `SessionStart` hook that loads the existing `.envrc` through direnv, mirroring the Claude hook so future Codex shell commands resolve flake-pinned tools like `just` automatically.

## Public API Changes

None. This only changes repository tooling and Codex session setup.

## Validation

- `python3 -m json.tool .codex/hooks.json`
- `bash -n .codex/hooks/direnv.sh`
- `rg --hidden -n "set unstable|JUST_UNSTABLE|--unstable" -g justfile`
- `git diff --check`

I could not run `just --fmt` locally after Homebrew `just` was removed because this already-running Codex session has not loaded the Nix shell yet. The new Codex hook should fix that for future sessions; CI will validate the flake-provided formatter.

(Written by GPT-5)