### PR TITLE
moq-native: resolve client protocol versions once, thread into QUIC backends

### DIFF
--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -105,6 +105,10 @@ impl Default for ClientConfig {
 #[derive(Clone)]
 pub struct Client {
 	moq: moq_net::Client,
+	/// The single resolved set of protocol versions, used to advertise moq ALPNs across
+	/// every transport (passed into the QUIC backends' `connect` and used directly for
+	/// raw TCP/UDS qmux and WebSocket). Resolved once in [`Client::new`] so the ALPN list
+	/// can't diverge between transports.
 	versions: moq_net::Versions,
 	/// The URL from [`ClientConfig::connect`], dialed by [`Client::publish`] / [`Client::consume`].
 	connect: Option<Url>,
@@ -367,7 +371,7 @@ impl Client {
 		if let Some(noq) = self.noq.as_ref() {
 			let tls = self.tls.clone();
 			let quic_url = url.clone();
-			let quic_handle = async { noq.connect(&tls, quic_url).await.map_err(Error::from) };
+			let quic_handle = async { noq.connect(&tls, quic_url, &self.versions).await.map_err(Error::from) };
 
 			#[cfg(feature = "websocket")]
 			{
@@ -385,7 +389,7 @@ impl Client {
 		if let Some(quinn) = self.quinn.as_ref() {
 			let tls = self.tls.clone();
 			let quic_url = url.clone();
-			let quic_handle = async { quinn.connect(&tls, quic_url).await.map_err(Error::from) };
+			let quic_handle = async { quinn.connect(&tls, quic_url, &self.versions).await.map_err(Error::from) };
 
 			#[cfg(feature = "websocket")]
 			{
@@ -402,7 +406,7 @@ impl Client {
 		#[cfg(feature = "quiche")]
 		if let Some(quiche) = self.quiche.as_ref() {
 			let quic_url = url.clone();
-			let quic_handle = async { quiche.connect(quic_url).await.map_err(Error::from) };
+			let quic_handle = async { quiche.connect(quic_url, &self.versions).await.map_err(Error::from) };
 
 			#[cfg(feature = "websocket")]
 			{

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -121,7 +121,6 @@ pub(crate) struct NoqClient {
 	pub transport: Arc<noq::TransportConfig>,
 	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
 	pub http_bootstrap: bool,
-	pub versions: moq_net::Versions,
 }
 
 impl NoqClient {
@@ -152,11 +151,15 @@ impl NoqClient {
 			quic,
 			transport,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
-			versions: config.versions(),
 		})
 	}
 
-	pub async fn connect(&self, tls: &rustls::ClientConfig, url: Url) -> Result<web_transport_noq::Session> {
+	pub async fn connect(
+		&self,
+		tls: &rustls::ClientConfig,
+		url: Url,
+		versions: &moq_net::Versions,
+	) -> Result<web_transport_noq::Session> {
 		let mut url = url;
 		let mut config = tls.clone();
 
@@ -209,12 +212,7 @@ impl NoqClient {
 
 		let alpns: Vec<Vec<u8>> = match url.scheme() {
 			"https" => vec![web_transport_noq::ALPN.as_bytes().to_vec()],
-			"moqt" | "moql" => self
-				.versions
-				.alpns()
-				.iter()
-				.map(|alpn| alpn.as_bytes().to_vec())
-				.collect(),
+			"moqt" | "moql" => versions.alpns().iter().map(|alpn| alpn.as_bytes().to_vec()).collect(),
 			_ => return Err(Error::InvalidScheme),
 		};
 
@@ -231,7 +229,7 @@ impl NoqClient {
 		tracing::Span::current().record("id", connection.stable_id());
 
 		let mut request = web_transport_noq::proto::ConnectRequest::new(url.clone());
-		for alpn in self.versions.alpns() {
+		for alpn in versions.alpns() {
 			request = request.with_protocol(alpn.to_string());
 		}
 

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -109,7 +109,6 @@ pub(crate) struct QuicheClient {
 	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
 	pub http_bootstrap: bool,
 	pub max_streams: u64,
-	pub versions: moq_net::Versions,
 }
 
 impl QuicheClient {
@@ -119,11 +118,10 @@ impl QuicheClient {
 			verification: config.tls.verification()?,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
 			max_streams: config.max_streams.unwrap_or(crate::DEFAULT_MAX_STREAMS),
-			versions: config.versions(),
 		})
 	}
 
-	pub async fn connect(&self, url: Url) -> Result<web_transport_quiche::Connection> {
+	pub async fn connect(&self, url: Url, versions: &moq_net::Versions) -> Result<web_transport_quiche::Connection> {
 		use crate::tls::Verification;
 
 		let host = url.host().ok_or(Error::InvalidDnsName)?.to_string();
@@ -153,12 +151,7 @@ impl QuicheClient {
 
 		let alpns: Vec<Vec<u8>> = match url.scheme() {
 			"https" => vec![web_transport_quiche::ALPN.as_bytes().to_vec()],
-			"moqt" | "moql" => self
-				.versions
-				.alpns()
-				.iter()
-				.map(|alpn| alpn.as_bytes().to_vec())
-				.collect(),
+			"moqt" | "moql" => versions.alpns().iter().map(|alpn| alpn.as_bytes().to_vec()).collect(),
 			_ => return Err(Error::InvalidScheme),
 		};
 
@@ -201,7 +194,7 @@ impl QuicheClient {
 		tracing::debug!(%url, "connecting via quiche");
 
 		let mut request = web_transport_quiche::proto::ConnectRequest::new(url.clone());
-		for alpn in self.versions.alpns() {
+		for alpn in versions.alpns() {
 			request = request.with_protocol(alpn.to_string());
 		}
 

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -119,7 +119,6 @@ pub(crate) struct QuinnClient {
 	pub transport: Arc<quinn::TransportConfig>,
 	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
 	pub http_bootstrap: bool,
-	pub versions: moq_net::Versions,
 }
 
 impl QuinnClient {
@@ -150,11 +149,15 @@ impl QuinnClient {
 			quic,
 			transport,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
-			versions: config.versions(),
 		})
 	}
 
-	pub async fn connect(&self, tls: &rustls::ClientConfig, url: Url) -> Result<web_transport_quinn::Session> {
+	pub async fn connect(
+		&self,
+		tls: &rustls::ClientConfig,
+		url: Url,
+		versions: &moq_net::Versions,
+	) -> Result<web_transport_quinn::Session> {
 		let mut url = url;
 		let mut config = tls.clone();
 
@@ -207,12 +210,7 @@ impl QuinnClient {
 
 		let alpns: Vec<Vec<u8>> = match url.scheme() {
 			"https" => vec![web_transport_quinn::ALPN.as_bytes().to_vec()],
-			"moqt" | "moql" => self
-				.versions
-				.alpns()
-				.iter()
-				.map(|alpn| alpn.as_bytes().to_vec())
-				.collect(),
+			"moqt" | "moql" => versions.alpns().iter().map(|alpn| alpn.as_bytes().to_vec()).collect(),
 			_ => return Err(Error::InvalidScheme),
 		};
 
@@ -229,7 +227,7 @@ impl QuinnClient {
 		tracing::Span::current().record("id", connection.stable_id());
 
 		let mut request = web_transport_quinn::proto::ConnectRequest::new(url.clone());
-		for alpn in self.versions.alpns() {
+		for alpn in versions.alpns() {
 			request = request.with_protocol(alpn.to_string());
 		}
 


### PR DESCRIPTION
## Summary

`moq-native`'s client resolved `ClientConfig::versions()` in **four** separate places: once on `Client` (feeding only the in-band-ALPN transports, i.e. raw TCP/UDS qmux and WebSocket) and again inside each of the quinn/noq/quiche backends, which each stored and used their own `versions` copy.

Because the QUIC backends never read the top-level `Client.versions` field, that field was dead code under any feature combo without `tcp`/`uds`/`websocket` (e.g. `--no-default-features --features quinn,aws-lc-rs`). That trips `-D warnings` (`field \`versions\` is never read`), turning the `cargo clippy --workspace --all-targets --all-features` CI gate red. It went dead when #1974 ("Fold the internal listener into --server-bind") reworked the client.

This consolidates version selection to a single source of truth:

- Resolve the version set **once** in `Client::new` and store it on `Client.versions`.
- Pass it into each backend's `connect(..., versions: &moq_net::Versions)` instead of having them re-derive it from the config and hold their own copy.
- Drop the now-redundant `versions` field from `QuinnClient` / `NoqClient` / `QuicheClient`.

The field is now read on every transport path (QUIC via `connect`, tcp/uds/websocket directly), so no cfg-gate and no dead code, on any feature combination.

## Why not just delete the field

The field is load-bearing for the tcp/uds/websocket paths (their in-band ALPN list), so deleting it breaks those transports; and it was already correctly wired, so there was no version-negotiation bug to "fix up". The real issue was that the *same* value was being resolved in multiple places, leaving the client copy unused whenever no in-band-ALPN transport was compiled in.

## Behavior

Unchanged. All four sites already routed through the same `ClientConfig::versions()` helper (all-if-empty, else the configured subset), so they resolved to identical values; this just removes the duplication. The `broadcast_webtransport_negotiate_*` version-negotiation tests still pass.

## Public API

None. The backend structs (`QuinnClient` etc.) are `pub(crate)` and `Client`'s fields are private, so this is internal-only. Targets `main`.

## Test plan

- [x] `cargo clippy -p moq-native --all-targets --all-features -- -D warnings` (the CI gate) — clean
- [x] `cargo clippy -p moq-native --all-targets -- -D warnings` (default features) — clean
- [x] `cargo clippy -p moq-native --lib --no-default-features --features quinn,aws-lc-rs -- -D warnings` (previously red) — clean
- [x] `cargo clippy -p moq-native --lib --no-default-features --features noq,aws-lc-rs -- -D warnings` — clean
- [x] `cargo test -p moq-native` — 57 passed
- [x] `cargo fmt -p moq-native -- --check` — clean

(Written by Claude Opus 4.8)