### PR TITLE
feat(moq-rtmp,moq-mux): enhanced-RTMP capsEx negotiation + multitrack

### DIFF
--- a/doc/lib/rs/crate/moq-mux.md
+++ b/doc/lib/rs/crate/moq-mux.md
@@ -18,7 +18,7 @@ Media muxers and demuxers for converting existing media formats into MoQ broadca
 - **fMP4/CMAF** - Fragmented MP4 and Common Media Application Format
 - **MPEG-TS** - Transport stream (import and export)
 - **Matroska / WebM** - EBML container (import and export)
-- **FLV** - Flash Video / RTMP container (H.264 + AAC; import and export)
+- **FLV** - Flash Video / RTMP container (import and export). Legacy H.264 + AAC + MP3 plus the enhanced-RTMP FourCC codecs (HEVC, AV1, VP9, Opus, AC-3, E-AC-3), including enhanced-RTMP multitrack (several video/audio renditions in one stream)
 - **Annex B** - H.264/H.265 raw NAL unit streams
 
 This crate is designed for ingesting existing content into the MoQ ecosystem, converting from traditional formats into [hang](/lib/rs/crate/hang) broadcasts.

--- a/rs/moq-mux/src/container/flv/export.rs
+++ b/rs/moq-mux/src/container/flv/export.rs
@@ -304,8 +304,19 @@ impl Export {
 		// A single-track FLV stream binds only the first rendition of each kind;
 		// multitrack binds them all. Bind newly-seen renditions in name order (the
 		// catalog is a BTreeMap) so each keeps a stable track id.
-		self.bind_video(&catalog)?;
-		self.bind_audio(&catalog)?;
+		//
+		// Only bind before the header is emitted: the sequence-header (config) tags
+		// go out with the header, and there's no in-band way to introduce a new
+		// track's config mid-stream, so a rendition first seen afterward is left
+		// unmuxed rather than emitted as undecodable config-less frames. (This
+		// mirrors the single-track path ignoring extra renditions.)
+		if !self.header_emitted {
+			self.bind_video(&catalog)?;
+			self.bind_audio(&catalog)?;
+		} else if catalog.video.renditions.len() > self.video.len() || catalog.audio.renditions.len() > self.audio.len()
+		{
+			tracing::warn!("ignoring FLV rendition that appeared after the stream header");
+		}
 
 		// A bound track vanishing from the catalog is a layout change FLV can't express.
 		for track in self.tracks() {

--- a/rs/moq-mux/src/container/flv/export.rs
+++ b/rs/moq-mux/src/container/flv/export.rs
@@ -7,9 +7,13 @@
 //! the enhanced-RTMP (E-RTMP) FourCC payloads. Frames flow through [`ExportSource`],
 //! which normalizes H.264/H.265 to length-prefixed NALU plus a resolved
 //! avcC/hvcC (parsing inline avc3/hev1 parameter sets when needed) and hands the
-//! other codecs through unchanged. FLV carries a single video and a single audio
-//! stream, so only the first rendition of each kind is muxed; extra renditions
-//! and any unsupported codec are rejected.
+//! other codecs through unchanged.
+//!
+//! By default FLV carries a single video and a single audio stream, so only the
+//! first rendition of each kind is muxed and the rest are ignored. With
+//! [`with_multitrack`](Export::with_multitrack) every rendition is muxed instead,
+//! each as an enhanced-RTMP multitrack track addressed by its own track id (use
+//! this only for a player that advertised the `Multitrack` capability).
 
 use std::task::Poll;
 use std::time::Duration;
@@ -20,9 +24,9 @@ use hang::catalog::{AV1, AudioCodec, Catalog, Container, VideoCodec};
 
 use super::{
 	AAC_AUDIO_TAG_HEADER, AAC_RAW, AAC_SEQUENCE_HEADER, AUDIO_FORMAT_EX, AUDIO_PACKET_CODED_FRAMES,
-	AUDIO_PACKET_SEQUENCE_START, AVC_NALU, AVC_SEQUENCE_HEADER, FRAME_TYPE_INTER, FRAME_TYPE_KEY, MP3_AUDIO_TAG_HEADER,
-	TAG_AUDIO, TAG_HEADER_LEN, TAG_VIDEO, VIDEO_CODEC_AVC, VIDEO_EX_HEADER, VIDEO_PACKET_CODED_FRAMES,
-	VIDEO_PACKET_SEQUENCE_START,
+	AUDIO_PACKET_MULTITRACK, AUDIO_PACKET_SEQUENCE_START, AVC_NALU, AVC_SEQUENCE_HEADER, FRAME_TYPE_INTER,
+	FRAME_TYPE_KEY, MP3_AUDIO_TAG_HEADER, MULTITRACK_ONE_TRACK, TAG_AUDIO, TAG_HEADER_LEN, TAG_VIDEO, VIDEO_CODEC_AVC,
+	VIDEO_EX_HEADER, VIDEO_PACKET_CODED_FRAMES, VIDEO_PACKET_MULTITRACK, VIDEO_PACKET_SEQUENCE_START,
 };
 use crate::catalog::{CatalogFormat, Stream};
 use crate::container::{ExportSource, Frame};
@@ -57,8 +61,29 @@ impl Flavor {
 		}
 	}
 
+	/// The enhanced-RTMP FourCC to use in multitrack framing, where every codec
+	/// (including the ones with a legacy CodecID) is identified by FourCC.
+	fn multitrack_fourcc(self) -> [u8; 4] {
+		match self {
+			Flavor::Avc => *b"avc1",
+			Flavor::Aac => *b"mp4a",
+			Flavor::Mp3 => *b".mp3",
+			// The rest share their single-track FourCC.
+			_ => self.fourcc().expect("enhanced flavor has a FourCC"),
+		}
+	}
+
 	fn has_composition_time(self) -> bool {
 		matches!(self, Flavor::Avc | Flavor::Hevc)
+	}
+
+	/// True if the codec carries an out-of-band config record (emitted as a
+	/// sequence-header tag). VP9 / MP3 / AC-3 / E-AC-3 carry their config in band.
+	fn has_sequence_header(self) -> bool {
+		matches!(
+			self,
+			Flavor::Avc | Flavor::Hevc | Flavor::Av1 | Flavor::Aac | Flavor::Opus
+		)
 	}
 }
 
@@ -80,9 +105,12 @@ pub struct Export {
 	broadcast: moq_net::BroadcastConsumer,
 	catalog: Option<crate::catalog::Consumer>,
 	latency: Duration,
+	/// Emit every rendition as an enhanced-RTMP multitrack track, rather than only
+	/// the first video + first audio rendition.
+	multitrack: bool,
 
-	video: Option<FlvTrack>,
-	audio: Option<FlvTrack>,
+	video: Vec<FlvTrack>,
+	audio: Vec<FlvTrack>,
 
 	/// True once the file header and sequence headers have been emitted.
 	header_emitted: bool,
@@ -91,6 +119,9 @@ pub struct Export {
 /// A subscribed rendition feeding the muxer.
 struct FlvTrack {
 	name: String,
+	/// The enhanced-RTMP track id, assigned by bind order within its kind. Only
+	/// used when muxing multitrack; a single-track FLV stream carries no id.
+	track_id: u8,
 	source: ExportSource,
 	pending: Option<Frame>,
 	finished: bool,
@@ -116,6 +147,20 @@ impl FlvTrack {
 			Ok(pts)
 		}
 	}
+
+	/// The out-of-band config record for this track's sequence-header tag, or
+	/// `None` for codecs that carry their config in band.
+	fn config_record(&self) -> anyhow::Result<Option<&[u8]>> {
+		if !self.flavor.has_sequence_header() {
+			return Ok(None);
+		}
+		let record = self
+			.source
+			.description()
+			.or(self.fallback_description.as_ref())
+			.with_context(|| format!("FLV track '{}' missing its codec config record", self.name))?;
+		Ok(Some(record.as_ref()))
+	}
 }
 
 impl Export {
@@ -136,8 +181,9 @@ impl Export {
 			broadcast,
 			catalog: Some(catalog),
 			latency: Duration::ZERO,
-			video: None,
-			audio: None,
+			multitrack: false,
+			video: Vec::new(),
+			audio: Vec::new(),
 			header_emitted: false,
 		})
 	}
@@ -145,6 +191,18 @@ impl Export {
 	/// Set the maximum buffering latency for each per-track source.
 	pub fn with_latency(mut self, latency: Duration) -> Self {
 		self.latency = latency;
+		self
+	}
+
+	/// Mux every rendition as an enhanced-RTMP multitrack track (one FLV stream
+	/// carrying several video and/or audio tracks), rather than only the first
+	/// video + first audio rendition.
+	///
+	/// Only enable this for a player that advertised the enhanced-RTMP
+	/// `Multitrack` capability in its `connect` `capsEx`; a legacy player can't
+	/// parse the multitrack framing. Defaults to off.
+	pub fn with_multitrack(mut self, multitrack: bool) -> Self {
+		self.multitrack = multitrack;
 		self
 	}
 
@@ -171,7 +229,7 @@ impl Export {
 		// that arrived before the track's codec config is ready: a mid-GOP joiner
 		// can't render them, and parking would block polling for the next SPS/PPS.
 		let waiting_for_header = !self.header_emitted;
-		for track in [self.video.as_mut(), self.audio.as_mut()].into_iter().flatten() {
+		for track in self.video.iter_mut().chain(self.audio.iter_mut()) {
 			if track.pending.is_some() || track.finished {
 				continue;
 			}
@@ -210,15 +268,14 @@ impl Export {
 		}
 
 		// 4. Emit the smallest FLV tag timestamp as one tag.
-		if let Some(is_video) = self.pick_next_track()? {
+		if let Some((is_video, index)) = self.pick_next_track()? {
 			let track = if is_video {
-				self.video.as_mut()
+				&mut self.video[index]
 			} else {
-				self.audio.as_mut()
+				&mut self.audio[index]
 			};
-			let track = track.unwrap();
 			let frame = track.pending.take().unwrap();
-			let chunk = self.encode_frame(is_video, frame)?;
+			let chunk = self.encode_frame(is_video, index, frame)?;
 			return Poll::Ready(Ok(Some(chunk)));
 		}
 
@@ -236,19 +293,42 @@ impl Export {
 
 	/// Iterate the subscribed tracks (video first, then audio).
 	fn tracks(&self) -> impl Iterator<Item = &FlvTrack> {
-		[self.video.as_ref(), self.audio.as_ref()].into_iter().flatten()
+		self.video.iter().chain(self.audio.iter())
 	}
 
 	fn has_tracks(&self) -> bool {
-		self.video.is_some() || self.audio.is_some()
+		!self.video.is_empty() || !self.audio.is_empty()
 	}
 
 	fn update_catalog(&mut self, catalog: Catalog) -> anyhow::Result<()> {
-		// FLV carries one video and one audio stream. Bind to the first rendition of
-		// each kind and ignore the rest; a layout change once bound is rejected.
-		if self.video.is_none()
-			&& let Some((name, config)) = catalog.video.renditions.iter().next()
-		{
+		// A single-track FLV stream binds only the first rendition of each kind;
+		// multitrack binds them all. Bind newly-seen renditions in name order (the
+		// catalog is a BTreeMap) so each keeps a stable track id.
+		self.bind_video(&catalog)?;
+		self.bind_audio(&catalog)?;
+
+		// A bound track vanishing from the catalog is a layout change FLV can't express.
+		for track in self.tracks() {
+			let present = if is_video_flavor(track.flavor) {
+				catalog.video.renditions.contains_key(&track.name)
+			} else {
+				catalog.audio.renditions.contains_key(&track.name)
+			};
+			anyhow::ensure!(present, "FLV track '{}' removed mid-stream", track.name);
+		}
+
+		Ok(())
+	}
+
+	fn bind_video(&mut self, catalog: &Catalog) -> anyhow::Result<()> {
+		for (name, config) in &catalog.video.renditions {
+			if !self.multitrack && !self.video.is_empty() {
+				tracing::warn!("FLV export only supports one video track; ignoring the rest (enable multitrack)");
+				break;
+			}
+			if self.video.iter().any(|t| &t.name == name) {
+				continue;
+			}
 			let flavor = video_flavor(config)?;
 			ensure_legacy(&config.container, "video", name)?;
 			// AV1's av1C is optional in the catalog; synthesize one from the codec
@@ -258,8 +338,10 @@ impl Export {
 				_ => None,
 			};
 			let source = ExportSource::for_video(&self.broadcast, name, config, self.latency)?;
-			self.video = Some(FlvTrack {
+			let track_id = u8::try_from(self.video.len()).context("too many FLV video tracks")?;
+			self.video.push(FlvTrack {
 				name: name.clone(),
+				track_id,
 				source,
 				pending: None,
 				finished: false,
@@ -269,18 +351,25 @@ impl Export {
 				last_dts: None,
 			});
 		}
-		if catalog.video.renditions.len() > 1 {
-			tracing::warn!("FLV export only supports one video track; ignoring the rest");
-		}
+		Ok(())
+	}
 
-		if self.audio.is_none()
-			&& let Some((name, config)) = catalog.audio.renditions.iter().next()
-		{
+	fn bind_audio(&mut self, catalog: &Catalog) -> anyhow::Result<()> {
+		for (name, config) in &catalog.audio.renditions {
+			if !self.multitrack && !self.audio.is_empty() {
+				tracing::warn!("FLV export only supports one audio track; ignoring the rest (enable multitrack)");
+				break;
+			}
+			if self.audio.iter().any(|t| &t.name == name) {
+				continue;
+			}
 			let flavor = audio_flavor(config)?;
 			ensure_legacy(&config.container, "audio", name)?;
 			let source = ExportSource::for_audio(&self.broadcast, name, config, self.latency)?;
-			self.audio = Some(FlvTrack {
+			let track_id = u8::try_from(self.audio.len()).context("too many FLV audio tracks")?;
+			self.audio.push(FlvTrack {
 				name: name.clone(),
+				track_id,
 				source,
 				pending: None,
 				finished: false,
@@ -290,26 +379,6 @@ impl Export {
 				last_dts: None,
 			});
 		}
-		if catalog.audio.renditions.len() > 1 {
-			tracing::warn!("FLV export only supports one audio track; ignoring the rest");
-		}
-
-		// A bound track vanishing from the catalog is a layout change FLV can't express.
-		if let Some(track) = &self.video {
-			anyhow::ensure!(
-				catalog.video.renditions.contains_key(&track.name),
-				"FLV video track '{}' removed mid-stream",
-				track.name
-			);
-		}
-		if let Some(track) = &self.audio {
-			anyhow::ensure!(
-				catalog.audio.renditions.contains_key(&track.name),
-				"FLV audio track '{}' removed mid-stream",
-				track.name
-			);
-		}
-
 		Ok(())
 	}
 
@@ -320,7 +389,7 @@ impl Export {
 		self.has_tracks() && self.tracks().all(|t| t.source.header_ready())
 	}
 
-	/// Build the FLV file header plus the AVC/AAC sequence-header tags.
+	/// Build the FLV file header plus every bound track's sequence-header tag.
 	fn build_header(&self) -> anyhow::Result<Bytes> {
 		let mut out = BytesMut::new();
 
@@ -328,10 +397,10 @@ impl Export {
 		out.put_slice(b"FLV");
 		out.put_u8(1);
 		let mut flags = 0u8;
-		if self.video.is_some() {
+		if !self.video.is_empty() {
 			flags |= 0x01;
 		}
-		if self.audio.is_some() {
+		if !self.audio.is_empty() {
 			flags |= 0x04;
 		}
 		out.put_u8(flags);
@@ -339,48 +408,52 @@ impl Export {
 		// PreviousTagSize0 is always zero.
 		out.put_u32(0);
 
-		if let Some(track) = &self.video
-			&& let Some(body) = video_sequence_header(track)?
-		{
-			write_tag(&mut out, TAG_VIDEO, 0, &body)?;
+		for track in &self.video {
+			if let Some(body) = self.video_sequence_header(track)? {
+				write_tag(&mut out, TAG_VIDEO, 0, &body)?;
+			}
 		}
-		if let Some(track) = &self.audio
-			&& let Some(body) = audio_sequence_header(track)?
-		{
-			write_tag(&mut out, TAG_AUDIO, 0, &body)?;
+		for track in &self.audio {
+			if let Some(body) = self.audio_sequence_header(track)? {
+				write_tag(&mut out, TAG_AUDIO, 0, &body)?;
+			}
 		}
 
 		Ok(out.freeze())
 	}
 
 	/// Pick the track with the smallest pending FLV tag timestamp. Returns whether
-	/// it's the video track, or `None` if no frame is pending.
-	fn pick_next_track(&self) -> anyhow::Result<Option<bool>> {
-		let video = self
-			.video
-			.as_ref()
-			.and_then(|track| track.pending.as_ref().map(|frame| track.tag_timestamp(frame)))
-			.transpose()?;
-		let audio = self
-			.audio
-			.as_ref()
-			.and_then(|t| t.pending.as_ref())
-			.map(frame_timestamp_ms)
-			.transpose()?;
-		Ok(match (video, audio) {
-			(Some(v), Some(a)) => Some(v <= a),
-			(Some(_), None) => Some(true),
-			(None, Some(_)) => Some(false),
-			(None, None) => None,
-		})
+	/// it's a video track and its index within that kind, or `None` if no frame is
+	/// pending. Video wins ties, matching the single-track interleave.
+	fn pick_next_track(&self) -> anyhow::Result<Option<(bool, usize)>> {
+		let mut best: Option<(u32, bool, usize)> = None;
+		for (index, track) in self.video.iter().enumerate() {
+			if let Some(frame) = &track.pending {
+				let ts = track.tag_timestamp(frame)?;
+				if best.is_none_or(|(b, _, _)| ts < b) {
+					best = Some((ts, true, index));
+				}
+			}
+		}
+		for (index, track) in self.audio.iter().enumerate() {
+			if let Some(frame) = &track.pending {
+				let ts = frame_timestamp_ms(frame)?;
+				if best.is_none_or(|(b, _, _)| ts < b) {
+					best = Some((ts, false, index));
+				}
+			}
+		}
+		Ok(best.map(|(_, is_video, index)| (is_video, index)))
 	}
 
 	/// Encode one frame as a single FLV tag.
-	fn encode_frame(&mut self, is_video: bool, frame: Frame) -> anyhow::Result<Bytes> {
+	fn encode_frame(&mut self, is_video: bool, index: usize, frame: Frame) -> anyhow::Result<Bytes> {
 		let mut out = BytesMut::with_capacity(TAG_HEADER_LEN + frame.payload.len() + 8);
+		let multitrack = self.multitrack;
 		if is_video {
-			let track = self.video.as_mut().expect("video frame without a video track");
+			let track = &mut self.video[index];
 			let flavor = track.flavor;
+			let track_id = track.track_id;
 			let pts_ms = frame_timestamp_ms(&frame)?;
 			let timestamp_ms = track.tag_timestamp(&frame)?;
 			let frame_type = if frame.keyframe {
@@ -388,21 +461,38 @@ impl Export {
 			} else {
 				FRAME_TYPE_INTER
 			};
-			let mut body = BytesMut::with_capacity(8 + frame.payload.len());
-			match flavor.fourcc() {
-				// Legacy AVC: CodecID + AVCPacketType + signed composition time.
-				None => {
-					body.put_u8((frame_type << 4) | VIDEO_CODEC_AVC);
-					body.put_u8(AVC_NALU);
-					write_i24(&mut body, composition_time(pts_ms, timestamp_ms)?)?;
+			let cts = if flavor.has_composition_time() {
+				composition_time(pts_ms, timestamp_ms)?
+			} else {
+				0
+			};
+			let mut body = BytesMut::with_capacity(12 + frame.payload.len());
+			if multitrack {
+				// Enhanced multitrack CodedFrames: ex-header + framing byte + FourCC +
+				// track id, then the per-codec composition time (avc1/hvc1) and payload.
+				body.put_u8(VIDEO_EX_HEADER | (frame_type << 4) | VIDEO_PACKET_MULTITRACK);
+				body.put_u8((MULTITRACK_ONE_TRACK << 4) | VIDEO_PACKET_CODED_FRAMES);
+				body.put_slice(&flavor.multitrack_fourcc());
+				body.put_u8(track_id);
+				if flavor.has_composition_time() {
+					write_i24(&mut body, cts)?;
 				}
-				// Enhanced FourCC CodedFrames. hvc1 keeps the 3-byte composition
-				// time; av01/vp09 omit it.
-				Some(fourcc) => {
-					body.put_u8(VIDEO_EX_HEADER | (frame_type << 4) | VIDEO_PACKET_CODED_FRAMES);
-					body.put_slice(&fourcc);
-					if flavor == Flavor::Hevc {
-						write_i24(&mut body, composition_time(pts_ms, timestamp_ms)?)?;
+			} else {
+				match flavor.fourcc() {
+					// Legacy AVC: CodecID + AVCPacketType + signed composition time.
+					None => {
+						body.put_u8((frame_type << 4) | VIDEO_CODEC_AVC);
+						body.put_u8(AVC_NALU);
+						write_i24(&mut body, cts)?;
+					}
+					// Enhanced FourCC CodedFrames. hvc1 keeps the 3-byte composition
+					// time; av01/vp09 omit it.
+					Some(fourcc) => {
+						body.put_u8(VIDEO_EX_HEADER | (frame_type << 4) | VIDEO_PACKET_CODED_FRAMES);
+						body.put_slice(&fourcc);
+						if flavor == Flavor::Hevc {
+							write_i24(&mut body, cts)?;
+						}
 					}
 				}
 			}
@@ -412,28 +502,107 @@ impl Export {
 			body.put_slice(&frame.payload);
 			write_tag(&mut out, TAG_VIDEO, timestamp_ms, &body)?;
 		} else {
+			let track = &self.audio[index];
+			let flavor = track.flavor;
+			let track_id = track.track_id;
 			let timestamp_ms = frame_timestamp_ms(&frame)?;
-			let flavor = self.audio.as_ref().expect("audio frame without an audio track").flavor;
-			let mut body = BytesMut::with_capacity(5 + frame.payload.len());
-			match flavor {
-				// Legacy AAC: tag header + AACPacketType (raw frame follows).
-				Flavor::Aac => {
-					body.put_u8(AAC_AUDIO_TAG_HEADER);
-					body.put_u8(AAC_RAW);
-				}
-				// Legacy MP3: tag header only; the raw frame carries its own config.
-				Flavor::Mp3 => body.put_u8(MP3_AUDIO_TAG_HEADER),
-				// Enhanced FourCC CodedFrames.
-				_ => {
-					let fourcc = flavor.fourcc().expect("enhanced audio flavor missing FourCC");
-					body.put_u8((AUDIO_FORMAT_EX << 4) | AUDIO_PACKET_CODED_FRAMES);
-					body.put_slice(&fourcc);
+			let mut body = BytesMut::with_capacity(7 + frame.payload.len());
+			if multitrack {
+				body.put_u8((AUDIO_FORMAT_EX << 4) | AUDIO_PACKET_MULTITRACK);
+				body.put_u8((MULTITRACK_ONE_TRACK << 4) | AUDIO_PACKET_CODED_FRAMES);
+				body.put_slice(&flavor.multitrack_fourcc());
+				body.put_u8(track_id);
+			} else {
+				match flavor {
+					// Legacy AAC: tag header + AACPacketType (raw frame follows).
+					Flavor::Aac => {
+						body.put_u8(AAC_AUDIO_TAG_HEADER);
+						body.put_u8(AAC_RAW);
+					}
+					// Legacy MP3: tag header only; the raw frame carries its own config.
+					Flavor::Mp3 => body.put_u8(MP3_AUDIO_TAG_HEADER),
+					// Enhanced FourCC CodedFrames.
+					_ => {
+						let fourcc = flavor.fourcc().expect("enhanced audio flavor missing FourCC");
+						body.put_u8((AUDIO_FORMAT_EX << 4) | AUDIO_PACKET_CODED_FRAMES);
+						body.put_slice(&fourcc);
+					}
 				}
 			}
 			body.put_slice(&frame.payload);
 			write_tag(&mut out, TAG_AUDIO, timestamp_ms, &body)?;
 		}
 		Ok(out.freeze())
+	}
+
+	/// Build the FLV video sequence-header tag body for `track`, or `None` for
+	/// codecs that carry their config in band (VP9).
+	fn video_sequence_header(&self, track: &FlvTrack) -> anyhow::Result<Option<BytesMut>> {
+		let Some(config) = track.config_record()? else {
+			return Ok(None);
+		};
+		let mut body = BytesMut::new();
+		if self.multitrack {
+			ex_multitrack_sequence_start(
+				&mut body,
+				TAG_VIDEO,
+				&track.flavor.multitrack_fourcc(),
+				track.track_id,
+				config,
+			);
+			return Ok(Some(body));
+		}
+		match track.flavor {
+			Flavor::Avc => {
+				body.put_u8((FRAME_TYPE_KEY << 4) | VIDEO_CODEC_AVC);
+				body.put_u8(AVC_SEQUENCE_HEADER);
+				body.put_slice(&[0, 0, 0]); // composition time
+				body.put_slice(config);
+			}
+			Flavor::Hevc => ex_video_sequence_start(&mut body, b"hvc1", config),
+			Flavor::Av1 => ex_video_sequence_start(&mut body, b"av01", config),
+			// Codecs with no out-of-band record are filtered out by `config_record`.
+			Flavor::Vp9 | Flavor::Aac | Flavor::Mp3 | Flavor::Opus | Flavor::Ac3 | Flavor::Eac3 => {
+				unreachable!("no video sequence header for {:?}", track.name)
+			}
+		}
+		Ok(Some(body))
+	}
+
+	/// Build the FLV audio sequence-header tag body for `track`, or `None` for
+	/// codecs that carry their config in band (MP3 / AC-3 / E-AC-3).
+	fn audio_sequence_header(&self, track: &FlvTrack) -> anyhow::Result<Option<BytesMut>> {
+		let Some(config) = track.config_record()? else {
+			return Ok(None);
+		};
+		let mut body = BytesMut::new();
+		if self.multitrack {
+			ex_multitrack_sequence_start(
+				&mut body,
+				TAG_AUDIO,
+				&track.flavor.multitrack_fourcc(),
+				track.track_id,
+				config,
+			);
+			return Ok(Some(body));
+		}
+		match track.flavor {
+			Flavor::Aac => {
+				body.put_u8(AAC_AUDIO_TAG_HEADER);
+				body.put_u8(AAC_SEQUENCE_HEADER);
+				body.put_slice(config);
+			}
+			Flavor::Opus => {
+				body.put_u8((AUDIO_FORMAT_EX << 4) | AUDIO_PACKET_SEQUENCE_START);
+				body.put_slice(b"Opus");
+				body.put_slice(config);
+			}
+			// Codecs with no out-of-band record are filtered out by `config_record`.
+			Flavor::Mp3 | Flavor::Ac3 | Flavor::Eac3 | Flavor::Avc | Flavor::Hevc | Flavor::Av1 | Flavor::Vp9 => {
+				unreachable!("no audio sequence header for {:?}", track.name)
+			}
+		}
+		Ok(Some(body))
 	}
 }
 
@@ -463,6 +632,10 @@ fn ensure_legacy(container: &Container, kind: &str, name: &str) -> anyhow::Resul
 		Container::Legacy | Container::Loc => Ok(()),
 		Container::Cmaf { .. } => anyhow::bail!("FLV export does not support CMAF {kind} track '{name}'"),
 	}
+}
+
+fn is_video_flavor(flavor: Flavor) -> bool {
+	matches!(flavor, Flavor::Avc | Flavor::Hevc | Flavor::Av1 | Flavor::Vp9)
 }
 
 fn video_flavor(config: &hang::catalog::VideoConfig) -> anyhow::Result<Flavor> {
@@ -529,74 +702,27 @@ fn dts_reserve(config: &hang::catalog::VideoConfig) -> u32 {
 		.unwrap_or(1)
 }
 
-/// Build the FLV video sequence-header tag body, or `None` for codecs that carry
-/// their config in band (VP9), so no out-of-band record is emitted.
-fn video_sequence_header(track: &FlvTrack) -> anyhow::Result<Option<BytesMut>> {
-	let mut body = BytesMut::new();
-	match track.flavor {
-		Flavor::Avc => {
-			let avcc = track.source.description().context("H.264 track missing avcC")?;
-			body.put_u8((FRAME_TYPE_KEY << 4) | VIDEO_CODEC_AVC);
-			body.put_u8(AVC_SEQUENCE_HEADER);
-			body.put_slice(&[0, 0, 0]); // composition time
-			body.put_slice(avcc);
-		}
-		Flavor::Hevc => {
-			let hvcc = track.source.description().context("H.265 track missing hvcC")?;
-			ex_video_sequence_start(&mut body, b"hvc1", hvcc);
-		}
-		Flavor::Av1 => {
-			// av1C from the catalog `description`, or the record synthesized at bind
-			// time (the sequence header is carried in band, so an empty configOBUs
-			// record is enough for the decoder).
-			let av1c = track
-				.source
-				.description()
-				.or(track.fallback_description.as_ref())
-				.context("AV1 track missing av1C")?;
-			ex_video_sequence_start(&mut body, b"av01", av1c);
-		}
-		// VP9 configures the decoder from the key frame; no sequence header tag.
-		Flavor::Vp9 => return Ok(None),
-		Flavor::Aac | Flavor::Mp3 | Flavor::Opus | Flavor::Ac3 | Flavor::Eac3 => {
-			unreachable!("audio flavor on a video track")
-		}
-	}
-	Ok(Some(body))
-}
-
-/// Build the FLV audio sequence-header tag body, or `None` for codecs that carry
-/// their config in band (MP3 / AC-3 / E-AC-3).
-fn audio_sequence_header(track: &FlvTrack) -> anyhow::Result<Option<BytesMut>> {
-	let mut body = BytesMut::new();
-	match track.flavor {
-		Flavor::Aac => {
-			let asc = track
-				.source
-				.description()
-				.context("AAC track missing AudioSpecificConfig")?;
-			body.put_u8(AAC_AUDIO_TAG_HEADER);
-			body.put_u8(AAC_SEQUENCE_HEADER);
-			body.put_slice(asc);
-		}
-		Flavor::Opus => {
-			let head = track.source.description().context("Opus track missing OpusHead")?;
-			body.put_u8((AUDIO_FORMAT_EX << 4) | AUDIO_PACKET_SEQUENCE_START);
-			body.put_slice(b"Opus");
-			body.put_slice(head);
-		}
-		// MP3 / AC-3 / E-AC-3 carry their config in each frame; no sequence header tag.
-		Flavor::Mp3 | Flavor::Ac3 | Flavor::Eac3 => return Ok(None),
-		Flavor::Avc | Flavor::Hevc | Flavor::Av1 | Flavor::Vp9 => unreachable!("video flavor on an audio track"),
-	}
-	Ok(Some(body))
-}
-
 /// Append an enhanced-RTMP video `SequenceStart` tag body: ex-header + FourCC +
 /// the codec config record.
 fn ex_video_sequence_start(body: &mut BytesMut, fourcc: &[u8; 4], config: &[u8]) {
 	body.put_u8(VIDEO_EX_HEADER | (FRAME_TYPE_KEY << 4) | VIDEO_PACKET_SEQUENCE_START);
 	body.put_slice(fourcc);
+	body.put_slice(config);
+}
+
+/// Append an enhanced-RTMP multitrack `SequenceStart` tag body (a single
+/// `OneTrack` record): ex-header + multitrack framing + FourCC + track id + the
+/// codec config record. `tag_type` selects the video vs audio ex-header byte.
+fn ex_multitrack_sequence_start(body: &mut BytesMut, tag_type: u8, fourcc: &[u8; 4], track_id: u8, config: &[u8]) {
+	if tag_type == TAG_VIDEO {
+		body.put_u8(VIDEO_EX_HEADER | (FRAME_TYPE_KEY << 4) | VIDEO_PACKET_MULTITRACK);
+		body.put_u8((MULTITRACK_ONE_TRACK << 4) | VIDEO_PACKET_SEQUENCE_START);
+	} else {
+		body.put_u8((AUDIO_FORMAT_EX << 4) | AUDIO_PACKET_MULTITRACK);
+		body.put_u8((MULTITRACK_ONE_TRACK << 4) | AUDIO_PACKET_SEQUENCE_START);
+	}
+	body.put_slice(fourcc);
+	body.put_u8(track_id);
 	body.put_slice(config);
 }
 

--- a/rs/moq-mux/src/container/flv/export_test.rs
+++ b/rs/moq-mux/src/container/flv/export_test.rs
@@ -328,6 +328,200 @@ async fn export_roundtrips_mp3() {
 	assert_eq!(a.channel_count, 2);
 }
 
+/// A minimal avcC like [`avcc`], but with a caller-chosen level byte so two video
+/// renditions carry distinct codec configs.
+fn avcc_level(level: u8) -> Vec<u8> {
+	let sps = [0x67u8, 0x42, 0xc0, level];
+	let mut out = vec![0x01, 0x42, 0xc0, level, 0xff, 0xe1, 0x00, sps.len() as u8];
+	out.extend_from_slice(&sps);
+	out.extend_from_slice(&[0x01, 0x00, 0x04, 0x68, 0xce, 0x3c, 0x80]);
+	out
+}
+
+/// Producer handles that keep a built broadcast open (and its finished tracks
+/// subscribable) until dropped, which then lets the exporter reach end-of-stream.
+type Keepalive = (
+	moq_net::BroadcastProducer,
+	crate::catalog::Producer,
+	Vec<crate::container::Producer<crate::catalog::hang::Container>>,
+);
+
+/// Build a broadcast with two H.264 video renditions plus one AAC audio rendition,
+/// each with a single keyframe, so multitrack export has several tracks to mux.
+fn build_multitrack_broadcast() -> (moq_net::BroadcastConsumer, Vec<Vec<u8>>, Keepalive) {
+	use hang::catalog::{AAC, AudioConfig, Container, H264, VideoConfig};
+
+	use crate::container::{Producer, Timestamp};
+
+	let mut producer = moq_net::Broadcast::new().produce();
+	let consumer = producer.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	// A finished track stays subscribable only while its producer is alive, so keep
+	// each one until the exporter has drained.
+	let mut tracks = Vec::new();
+
+	let descriptions: Vec<Vec<u8>> = vec![avcc_level(0x1f), avcc_level(0x1e)];
+	for description in &descriptions {
+		let track = producer
+			.create_track(moq_net::Track::new(producer.unique_name(".avc1")))
+			.unwrap();
+		let mut config = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: description[3],
+			inline: false,
+		});
+		config.container = Container::Legacy;
+		config.description = Some(Bytes::from(description.clone()));
+		catalog.lock().video.renditions.insert(track.name().to_string(), config);
+
+		let mut video = Producer::new(track, crate::catalog::hang::Container::Legacy);
+		video
+			.write(crate::container::Frame {
+				timestamp: Timestamp::from_millis(0).unwrap(),
+				duration: None,
+				payload: Bytes::from_static(&[0, 0, 0, 1, 0x65]),
+				keyframe: true,
+			})
+			.unwrap();
+		video.finish().unwrap();
+		tracks.push(video);
+	}
+
+	let audio_track = producer
+		.create_track(moq_net::Track::new(producer.unique_name(".aac")))
+		.unwrap();
+	let mut audio_config = AudioConfig::new(AAC { profile: 2 }, 44100, 2);
+	audio_config.container = Container::Legacy;
+	audio_config.description = Some(Bytes::from_static(&ASC));
+	catalog
+		.lock()
+		.audio
+		.renditions
+		.insert(audio_track.name().to_string(), audio_config);
+	let mut audio = crate::container::Producer::new(audio_track, crate::catalog::hang::Container::Legacy);
+	audio
+		.write(crate::container::Frame {
+			timestamp: Timestamp::from_millis(0).unwrap(),
+			duration: None,
+			payload: Bytes::from_static(&[0xde, 0xad]),
+			keyframe: true,
+		})
+		.unwrap();
+	audio.finish().unwrap();
+	tracks.push(audio);
+	catalog.finish().unwrap();
+
+	// Keep the broadcast, catalog, and track producers alive so the exporter can
+	// subscribe; the caller drops them mid-drain to signal end-of-stream.
+	(consumer, descriptions, (producer, catalog, tracks))
+}
+
+/// Drive the exporter to completion, dropping the producer handles on the first
+/// stall so it can reach end-of-stream (the already-published groups stay readable).
+async fn drain_to_end(mut exporter: Export, keepalive: Keepalive) -> Vec<u8> {
+	let mut exported = Vec::new();
+	let mut keepalive = Some(keepalive);
+	for _ in 0..64 {
+		match tokio::time::timeout(Duration::from_millis(100), exporter.next()).await {
+			Ok(Ok(Some(chunk))) => exported.extend_from_slice(&chunk),
+			Ok(Ok(None)) => break,
+			Ok(Err(e)) => panic!("exporter error: {e}"),
+			Err(_) => keepalive = None, // close the broadcast so the exporter can EOS
+		}
+	}
+	drop(keepalive);
+	exported
+}
+
+/// With multitrack enabled, every rendition is muxed as an enhanced-RTMP
+/// multitrack track and survives an export -> import round trip. Without it, only
+/// the first video rendition is muxed.
+#[tokio::test(start_paused = true)]
+async fn export_multitrack_roundtrips_all_renditions() {
+	let (consumer, descriptions, keepalive) = build_multitrack_broadcast();
+
+	let exporter = Export::new(consumer).unwrap().with_multitrack(true);
+	let exported = drain_to_end(exporter, keepalive).await;
+
+	assert_eq!(&exported[0..3], b"FLV");
+
+	// Every video media tag uses the multitrack framing (packet type 5, OneTrack),
+	// and both track ids show up.
+	let tags = parse_tags(&exported);
+	let mut video_track_ids: Vec<u8> = tags
+		.iter()
+		.filter(|t| {
+			t.tag_type == super::TAG_VIDEO
+				&& t.body[0] & super::VIDEO_EX_HEADER != 0
+				&& t.body[0] & 0x0f == super::VIDEO_PACKET_MULTITRACK
+				&& t.body[1] & 0x0f == super::VIDEO_PACKET_CODED_FRAMES
+				&& &t.body[2..6] == b"avc1"
+		})
+		.map(|t| t.body[6])
+		.collect();
+	video_track_ids.sort_unstable();
+	video_track_ids.dedup();
+	assert_eq!(video_track_ids, vec![0, 1], "expected two multitrack video track ids");
+
+	// Re-import and confirm both video renditions plus the audio rebuild.
+	let mut bcast2 = moq_net::Broadcast::new().produce();
+	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
+	let mut imp2 = Import::new(bcast2, cat2.clone());
+	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
+	imp2.finish().unwrap();
+
+	let snap = cat2.snapshot();
+	assert_eq!(
+		snap.video.renditions.len(),
+		2,
+		"both video renditions should round-trip"
+	);
+	assert_eq!(snap.audio.renditions.len(), 1);
+
+	// Both distinct avcC descriptions survive.
+	let mut got: Vec<Vec<u8>> = snap
+		.video
+		.renditions
+		.values()
+		.filter_map(|c| c.description.as_ref().map(|b| b.to_vec()))
+		.collect();
+	got.sort();
+	let mut want = descriptions.clone();
+	want.sort();
+	assert_eq!(got, want, "each rendition should keep its own avcC");
+}
+
+/// Without multitrack, a multi-rendition broadcast exports only the first video
+/// rendition (the single-track fallback for a legacy player).
+#[tokio::test(start_paused = true)]
+async fn export_without_multitrack_keeps_first_rendition() {
+	let (consumer, _, keepalive) = build_multitrack_broadcast();
+
+	let exporter = Export::new(consumer).unwrap();
+	let exported = drain_to_end(exporter, keepalive).await;
+
+	// No multitrack framing: the single video track is a legacy AVC tag.
+	let tags = parse_tags(&exported);
+	assert!(
+		tags.iter()
+			.all(|t| !(t.tag_type == super::TAG_VIDEO && t.body[0] & 0x0f == super::VIDEO_PACKET_MULTITRACK)),
+		"single-track export must not use multitrack framing"
+	);
+
+	let mut bcast2 = moq_net::Broadcast::new().produce();
+	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
+	let mut imp2 = Import::new(bcast2, cat2.clone());
+	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
+	imp2.finish().unwrap();
+
+	assert_eq!(
+		cat2.snapshot().video.renditions.len(),
+		1,
+		"only one rendition without multitrack"
+	);
+}
+
 struct ParsedTag {
 	tag_type: u8,
 	timestamp: u32,

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -20,17 +20,26 @@
 //! container, so no codec transform is needed. FLAC (`fLaC`) enhanced audio, and
 //! any other codec, are logged and dropped.
 
+use std::collections::BTreeMap;
+
+use anyhow::Context;
 use bytes::{Buf, Bytes, BytesMut};
 use hang::catalog::{AAC, AudioCodec, AudioConfig, Container, H264, VideoConfig};
 
 use super::{
 	AAC_RAW, AAC_SEQUENCE_HEADER, AUDIO_FORMAT_AAC, AUDIO_FORMAT_EX, AUDIO_FORMAT_MP3, AUDIO_PACKET_CODED_FRAMES,
-	AUDIO_PACKET_MULTICHANNEL_CONFIG, AUDIO_PACKET_SEQUENCE_END, AUDIO_PACKET_SEQUENCE_START, AVC_NALU,
-	AVC_SEQUENCE_HEADER, FILE_HEADER_LEN, FRAME_TYPE_KEY, PREV_TAG_SIZE_LEN, TAG_AUDIO, TAG_HEADER_LEN, TAG_SCRIPT,
+	AUDIO_PACKET_MULTICHANNEL_CONFIG, AUDIO_PACKET_MULTITRACK, AUDIO_PACKET_SEQUENCE_END, AUDIO_PACKET_SEQUENCE_START,
+	AVC_NALU, AVC_SEQUENCE_HEADER, FILE_HEADER_LEN, FRAME_TYPE_KEY, MULTITRACK_MANY_TRACKS,
+	MULTITRACK_MANY_TRACKS_MANY_CODECS, MULTITRACK_ONE_TRACK, PREV_TAG_SIZE_LEN, TAG_AUDIO, TAG_HEADER_LEN, TAG_SCRIPT,
 	TAG_VIDEO, VIDEO_CODEC_AVC, VIDEO_EX_HEADER, VIDEO_PACKET_CODED_FRAMES, VIDEO_PACKET_CODED_FRAMES_X,
-	VIDEO_PACKET_METADATA, VIDEO_PACKET_SEQUENCE_END, VIDEO_PACKET_SEQUENCE_START, read_i24, read_u24,
+	VIDEO_PACKET_METADATA, VIDEO_PACKET_MULTITRACK, VIDEO_PACKET_SEQUENCE_END, VIDEO_PACKET_SEQUENCE_START, read_i24,
+	read_u24,
 };
 use crate::container::{Frame, Timestamp};
+
+/// Implicit RTMP track id for a legacy or single-track enhanced tag (which carry
+/// no explicit id). Multitrack tags address tracks by an explicit id instead.
+const DEFAULT_TRACK_ID: u8 = 0;
 
 /// Upper bound on the FLV header's `data_offset`. The header is 9 bytes in
 /// practice; this cap stops a crafted offset from forcing unbounded buffering.
@@ -41,8 +50,12 @@ const MAX_DATA_OFFSET: usize = 64 * 1024;
 /// Supports legacy H.264 + AAC and the enhanced-RTMP FourCC codecs (HEVC, AV1,
 /// VP9, Opus, AC-3, E-AC-3), the payloads produced by RTMP encoders and
 /// `ffmpeg -f flv`. Unsupported codecs, plus `onMetaData` script tags, are logged
-/// and dropped. A single FLV stream carries at most one video and one audio
-/// track; a new sequence header replaces the previous configuration.
+/// and dropped.
+///
+/// Legacy and single-track enhanced tags carry one video and one audio track;
+/// enhanced-RTMP multitrack tags carry several of each, addressed by track id,
+/// and each id becomes its own catalog rendition. A new sequence header for a
+/// track replaces that track's previous configuration.
 pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
 	broadcast: moq_net::BroadcastProducer,
 	catalog: crate::catalog::Producer<E>,
@@ -53,8 +66,11 @@ pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
 	/// True once the 9-byte FLV file header and its `PreviousTagSize0` have been consumed.
 	header_seen: bool,
 
-	video: Option<VideoStream>,
-	audio: Option<AudioStream>,
+	/// Demuxed video tracks keyed by RTMP track id (legacy / single-track tags use
+	/// [`DEFAULT_TRACK_ID`]).
+	video: BTreeMap<u8, VideoStream>,
+	/// Demuxed audio tracks keyed by RTMP track id.
+	audio: BTreeMap<u8, AudioStream>,
 }
 
 /// The demuxed video track plus its current catalog config, so a repeated
@@ -78,8 +94,8 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			catalog,
 			buffer: BytesMut::new(),
 			header_seen: false,
-			video: None,
-			audio: None,
+			video: BTreeMap::new(),
+			audio: BTreeMap::new(),
 		}
 	}
 
@@ -162,25 +178,76 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		let data = &body[5..];
 
 		match avc_packet_type {
-			AVC_SEQUENCE_HEADER => self.init_video(config_from_avcc(data)?),
-			AVC_NALU => self.write_video(data, timestamp, composition_time, frame_type == FRAME_TYPE_KEY),
+			AVC_SEQUENCE_HEADER => self.init_video(DEFAULT_TRACK_ID, config_from_avcc(data)?),
+			AVC_NALU => self.write_video(
+				DEFAULT_TRACK_ID,
+				data,
+				timestamp,
+				composition_time,
+				frame_type == FRAME_TYPE_KEY,
+			),
 			// AVCPacketType 2 is "end of sequence"; nothing to emit.
 			_ => Ok(()),
 		}
 	}
 
-	/// Handle an enhanced-RTMP (FourCC) video tag.
+	/// Handle an enhanced-RTMP (FourCC) video tag, single-track or multitrack.
 	fn handle_video_enhanced(&mut self, first: u8, body: &[u8], timestamp: u64) -> anyhow::Result<()> {
-		let frame_type = (first >> 4) & 0x07;
+		let keyframe = (first >> 4) & 0x07 == FRAME_TYPE_KEY;
 		let packet_type = first & 0x0f;
+
+		if packet_type == VIDEO_PACKET_MULTITRACK {
+			return self.handle_video_multitrack(&body[1..], keyframe, timestamp);
+		}
+
 		anyhow::ensure!(body.len() >= 5, "enhanced video tag too short for FourCC");
 		let fourcc: [u8; 4] = body[1..5].try_into().expect("slice is 4 bytes");
-		let payload = &body[5..];
-		let keyframe = frame_type == FRAME_TYPE_KEY;
+		self.handle_video_track(DEFAULT_TRACK_ID, &fourcc, packet_type, keyframe, &body[5..], timestamp)
+	}
 
+	/// Split a multitrack video tag into its per-track payloads and route each to
+	/// [`handle_video_track`](Self::handle_video_track).
+	///
+	/// `data` starts at the multitrack framing byte (after the ex-header byte).
+	fn handle_video_multitrack(&mut self, data: &[u8], keyframe: bool, timestamp: u64) -> anyhow::Result<()> {
+		let mut cursor = data;
+		let header = split_multitrack_header(&mut cursor, "video")?;
+		anyhow::ensure!(
+			header.packet_type != VIDEO_PACKET_MULTITRACK,
+			"nested multitrack video tag"
+		);
+
+		loop {
+			let track = split_multitrack_track(&mut cursor, &header, "video")?;
+			self.handle_video_track(
+				track.track_id,
+				&track.fourcc,
+				header.packet_type,
+				keyframe,
+				track.payload,
+				timestamp,
+			)?;
+			if header.multitrack_type == MULTITRACK_ONE_TRACK || cursor.is_empty() {
+				break;
+			}
+		}
+		Ok(())
+	}
+
+	/// Route one track's video payload (a FourCC codec + `VideoPacketType`) onto
+	/// the track's MoQ rendition, keyed by `track_id`.
+	fn handle_video_track(
+		&mut self,
+		track_id: u8,
+		fourcc: &[u8; 4],
+		packet_type: u8,
+		keyframe: bool,
+		payload: &[u8],
+		timestamp: u64,
+	) -> anyhow::Result<()> {
 		match packet_type {
 			VIDEO_PACKET_SEQUENCE_START => {
-				let config = match &fourcc {
+				let config = match fourcc {
 					b"avc1" => config_from_avcc(payload)?,
 					b"hvc1" => crate::codec::h265::config_from_hvcc(payload)?,
 					b"av01" => crate::codec::av1::config_from_av1c(payload)?,
@@ -192,12 +259,12 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 						return Ok(());
 					}
 				};
-				self.init_video(config)
+				self.init_video(track_id, config)
 			}
 			VIDEO_PACKET_CODED_FRAMES | VIDEO_PACKET_CODED_FRAMES_X => {
 				// hvc1/avc1 CodedFrames prefix a 3-byte composition time; CodedFramesX
 				// and the always-zero-offset av01/vp09 do not.
-				let has_cts = packet_type == VIDEO_PACKET_CODED_FRAMES && matches!(&fourcc, b"hvc1" | b"avc1");
+				let has_cts = packet_type == VIDEO_PACKET_CODED_FRAMES && matches!(fourcc, b"hvc1" | b"avc1");
 				let (data, cts) = if has_cts {
 					anyhow::ensure!(payload.len() >= 3, "enhanced CodedFrames missing composition time");
 					(&payload[3..], read_i24(&payload[0..3]))
@@ -209,15 +276,15 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 				// frame's uncompressed header. `init_video` dedups when unchanged, so
 				// this is a no-op except on the first key frame or a resolution change.
 				// A malformed header drops just this frame rather than aborting the stream.
-				if &fourcc == b"vp09" && keyframe {
+				if fourcc == b"vp09" && keyframe {
 					match crate::codec::vp9::config_from_keyframe(data) {
-						Ok(Some(config)) => self.init_video(config)?,
+						Ok(Some(config)) => self.init_video(track_id, config)?,
 						Ok(None) => {}
 						Err(err) => tracing::warn!(%err, "dropping malformed VP9 key frame"),
 					}
 				}
 
-				self.write_video(data, timestamp, cts, keyframe)
+				self.write_video(track_id, data, timestamp, cts, keyframe)
 			}
 			VIDEO_PACKET_SEQUENCE_END | VIDEO_PACKET_METADATA => Ok(()),
 			other => {
@@ -239,10 +306,10 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			// Legacy MP3: the raw frame follows the one-byte tag header, with the
 			// config in band. Configure from the first frame, then write it.
 			let frame = &body[1..];
-			if self.audio.is_none() {
-				self.init_audio(config_from_mp3(frame)?)?;
+			if !self.audio.contains_key(&DEFAULT_TRACK_ID) {
+				self.init_audio(DEFAULT_TRACK_ID, config_from_mp3(frame)?)?;
 			}
-			return self.write_audio(frame, timestamp);
+			return self.write_audio(DEFAULT_TRACK_ID, frame, timestamp);
 		}
 		if sound_format != AUDIO_FORMAT_AAC {
 			tracing::warn!(sound_format, "unsupported FLV audio format, dropping");
@@ -254,22 +321,64 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		let data = &body[2..];
 
 		match aac_packet_type {
-			AAC_SEQUENCE_HEADER => self.init_audio(config_from_asc(data)?),
-			AAC_RAW => self.write_audio(data, timestamp),
+			AAC_SEQUENCE_HEADER => self.init_audio(DEFAULT_TRACK_ID, config_from_asc(data)?),
+			AAC_RAW => self.write_audio(DEFAULT_TRACK_ID, data, timestamp),
 			_ => Ok(()),
 		}
 	}
 
-	/// Handle an enhanced-RTMP (FourCC) audio tag.
+	/// Handle an enhanced-RTMP (FourCC) audio tag, single-track or multitrack.
 	fn handle_audio_enhanced(&mut self, first: u8, body: &[u8], timestamp: u64) -> anyhow::Result<()> {
 		let packet_type = first & 0x0f;
+
+		if packet_type == AUDIO_PACKET_MULTITRACK {
+			return self.handle_audio_multitrack(&body[1..], timestamp);
+		}
+
 		anyhow::ensure!(body.len() >= 5, "enhanced audio tag too short for FourCC");
 		let fourcc: [u8; 4] = body[1..5].try_into().expect("slice is 4 bytes");
-		let payload = &body[5..];
+		self.handle_audio_track(DEFAULT_TRACK_ID, &fourcc, packet_type, &body[5..], timestamp)
+	}
 
+	/// Split a multitrack audio tag into its per-track payloads and route each to
+	/// [`handle_audio_track`](Self::handle_audio_track).
+	fn handle_audio_multitrack(&mut self, data: &[u8], timestamp: u64) -> anyhow::Result<()> {
+		let mut cursor = data;
+		let header = split_multitrack_header(&mut cursor, "audio")?;
+		anyhow::ensure!(
+			header.packet_type != AUDIO_PACKET_MULTITRACK,
+			"nested multitrack audio tag"
+		);
+
+		loop {
+			let track = split_multitrack_track(&mut cursor, &header, "audio")?;
+			self.handle_audio_track(
+				track.track_id,
+				&track.fourcc,
+				header.packet_type,
+				track.payload,
+				timestamp,
+			)?;
+			if header.multitrack_type == MULTITRACK_ONE_TRACK || cursor.is_empty() {
+				break;
+			}
+		}
+		Ok(())
+	}
+
+	/// Route one track's audio payload (a FourCC codec + `AudioPacketType`) onto
+	/// the track's MoQ rendition, keyed by `track_id`.
+	fn handle_audio_track(
+		&mut self,
+		track_id: u8,
+		fourcc: &[u8; 4],
+		packet_type: u8,
+		payload: &[u8],
+		timestamp: u64,
+	) -> anyhow::Result<()> {
 		match packet_type {
 			AUDIO_PACKET_SEQUENCE_START => {
-				let config = match &fourcc {
+				let config = match fourcc {
 					b"Opus" => config_from_opus_head(payload)?,
 					b"mp4a" => config_from_asc(payload)?,
 					// MP3 / AC-3 / E-AC-3 are verbatim with no sequence header; they
@@ -279,23 +388,23 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 						return Ok(());
 					}
 				};
-				self.init_audio(config)
+				self.init_audio(track_id, config)
 			}
 			AUDIO_PACKET_CODED_FRAMES => {
 				// MP3 / AC-3 / E-AC-3 carry their config in the frame header, so
 				// configure from the first frame when no sequence header preceded it.
-				if self.audio.is_none() {
-					let config = match &fourcc {
+				if !self.audio.contains_key(&track_id) {
+					let config = match fourcc {
 						b".mp3" => Some(config_from_mp3(payload)?),
 						b"ac-3" => Some(config_from_ac3(payload)?),
 						b"ec-3" => Some(config_from_eac3(payload)?),
 						_ => None,
 					};
 					if let Some(config) = config {
-						self.init_audio(config)?;
+						self.init_audio(track_id, config)?;
 					}
 				}
-				self.write_audio(payload, timestamp)
+				self.write_audio(track_id, payload, timestamp)
 			}
 			AUDIO_PACKET_SEQUENCE_END | AUDIO_PACKET_MULTICHANNEL_CONFIG => Ok(()),
 			other => {
@@ -307,8 +416,15 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 	/// Write one decoded video sample, dropping a leading delta before the first
 	/// keyframe (a mid-GOP join) rather than aborting.
-	fn write_video(&mut self, data: &[u8], dts: u64, composition_time: i32, keyframe: bool) -> anyhow::Result<()> {
-		let Some(stream) = self.video.as_mut() else {
+	fn write_video(
+		&mut self,
+		track_id: u8,
+		data: &[u8],
+		dts: u64,
+		composition_time: i32,
+		keyframe: bool,
+	) -> anyhow::Result<()> {
+		let Some(stream) = self.video.get_mut(&track_id) else {
 			tracing::debug!("video frame before sequence header, dropping");
 			return Ok(());
 		};
@@ -327,8 +443,8 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	}
 
 	/// Write one audio frame as its own group, so the relay can forward it immediately.
-	fn write_audio(&mut self, data: &[u8], timestamp: u64) -> anyhow::Result<()> {
-		let Some(stream) = self.audio.as_mut() else {
+	fn write_audio(&mut self, track_id: u8, data: &[u8], timestamp: u64) -> anyhow::Result<()> {
+		let Some(stream) = self.audio.get_mut(&track_id) else {
 			tracing::debug!("audio frame before config, dropping");
 			return Ok(());
 		};
@@ -342,60 +458,66 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		Ok(())
 	}
 
-	/// (Re)build the video track for `config`, unless it matches the current one.
-	fn init_video(&mut self, config: VideoConfig) -> anyhow::Result<()> {
-		if self.video.as_ref().is_some_and(|s| s.config == config) {
+	/// (Re)build the video track `track_id` for `config`, unless it matches the current one.
+	fn init_video(&mut self, track_id: u8, config: VideoConfig) -> anyhow::Result<()> {
+		if self.video.get(&track_id).is_some_and(|s| s.config == config) {
 			return Ok(());
 		}
 
-		let net_track = self.replace_video()?;
+		let net_track = self.replace_video(track_id)?;
 		self.catalog
 			.lock()
 			.video
 			.renditions
 			.insert(net_track.name().to_string(), config.clone());
-		self.video = Some(VideoStream {
-			// Leading deltas before the first keyframe are skipped at the write
-			// site (the producer reports MissingKeyframe), so a mid-GOP join works.
-			track: crate::container::Producer::new(net_track, crate::catalog::hang::Container::Legacy),
-			config,
-		});
+		self.video.insert(
+			track_id,
+			VideoStream {
+				// Leading deltas before the first keyframe are skipped at the write
+				// site (the producer reports MissingKeyframe), so a mid-GOP join works.
+				track: crate::container::Producer::new(net_track, crate::catalog::hang::Container::Legacy),
+				config,
+			},
+		);
 		Ok(())
 	}
 
-	/// (Re)build the audio track for `config`, unless it matches the current one.
-	fn init_audio(&mut self, config: AudioConfig) -> anyhow::Result<()> {
-		if self.audio.as_ref().is_some_and(|s| s.config == config) {
+	/// (Re)build the audio track `track_id` for `config`, unless it matches the current one.
+	fn init_audio(&mut self, track_id: u8, config: AudioConfig) -> anyhow::Result<()> {
+		if self.audio.get(&track_id).is_some_and(|s| s.config == config) {
 			return Ok(());
 		}
 
-		let net_track = self.replace_audio()?;
+		let net_track = self.replace_audio(track_id)?;
 		self.catalog
 			.lock()
 			.audio
 			.renditions
 			.insert(net_track.name().to_string(), config.clone());
-		self.audio = Some(AudioStream {
-			track: crate::container::Producer::new(net_track, crate::catalog::hang::Container::Legacy),
-			config,
-		});
+		self.audio.insert(
+			track_id,
+			AudioStream {
+				track: crate::container::Producer::new(net_track, crate::catalog::hang::Container::Legacy),
+				config,
+			},
+		);
 		Ok(())
 	}
 
-	/// Drop any existing video track (finishing it and clearing its catalog
-	/// rendition) and allocate a fresh one.
-	fn replace_video(&mut self) -> anyhow::Result<moq_net::TrackProducer> {
-		if let Some(mut old) = self.video.take() {
+	/// Drop any existing video track `track_id` (finishing it and clearing its
+	/// catalog rendition) and allocate a fresh one.
+	fn replace_video(&mut self, track_id: u8) -> anyhow::Result<moq_net::TrackProducer> {
+		if let Some(mut old) = self.video.remove(&track_id) {
 			old.track.finish()?;
 			self.catalog.lock().video.renditions.remove(old.track.name());
 		}
 		Ok(self.broadcast.unique_track(".flv-v")?)
 	}
 
-	/// Drop any existing audio track (finishing it and clearing its catalog
-	/// rendition) and allocate a fresh one.
-	fn replace_audio(&mut self) -> anyhow::Result<moq_net::TrackProducer> {
-		if let Some(mut old) = self.audio.take() {
+	/// Drop any existing audio track `track_id` (finishing it and clearing its
+	/// catalog rendition) and allocate a fresh one.
+	fn replace_audio(&mut self, track_id: u8) -> anyhow::Result<moq_net::TrackProducer> {
+		if let Some(mut old) = self.audio.remove(&track_id) {
 			old.track.finish()?;
 			self.catalog.lock().audio.renditions.remove(old.track.name());
 		}
@@ -404,10 +526,10 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 	/// Close the current group on every track and reopen at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> anyhow::Result<()> {
-		if let Some(stream) = self.video.as_mut() {
+		for stream in self.video.values_mut() {
 			stream.track.seek(sequence)?;
 		}
-		if let Some(stream) = self.audio.as_mut() {
+		for stream in self.audio.values_mut() {
 			stream.track.seek(sequence)?;
 		}
 		Ok(())
@@ -415,10 +537,10 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 	/// Finish every track, flushing the current group.
 	pub fn finish(&mut self) -> anyhow::Result<()> {
-		if let Some(stream) = self.video.as_mut() {
+		for stream in self.video.values_mut() {
 			stream.track.finish()?;
 		}
-		if let Some(stream) = self.audio.as_mut() {
+		for stream in self.audio.values_mut() {
 			stream.track.finish()?;
 		}
 		Ok(())
@@ -428,13 +550,109 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 impl<E: crate::catalog::hang::CatalogExt> Drop for Import<E> {
 	fn drop(&mut self) {
 		let mut catalog = self.catalog.lock();
-		if let Some(stream) = &self.video {
+		for stream in self.video.values() {
 			catalog.video.renditions.remove(stream.track.name());
 		}
-		if let Some(stream) = &self.audio {
+		for stream in self.audio.values() {
 			catalog.audio.renditions.remove(stream.track.name());
 		}
 	}
+}
+
+/// The multitrack framing common to every track in one tag: the layout and the
+/// real `VideoPacketType`/`AudioPacketType`, plus the shared FourCC (present for
+/// every layout except `ManyTracksManyCodecs`, where each track carries its own).
+struct MultitrackHeader {
+	multitrack_type: u8,
+	packet_type: u8,
+	shared_fourcc: Option<[u8; 4]>,
+}
+
+/// One track record inside a multitrack tag.
+struct MultitrackTrack<'a> {
+	fourcc: [u8; 4],
+	track_id: u8,
+	payload: &'a [u8],
+}
+
+/// Parse the multitrack framing byte and shared FourCC, advancing `cursor` past
+/// them. `cursor` starts at the framing byte (after the ex-header byte).
+fn split_multitrack_header(cursor: &mut &[u8], kind: &str) -> anyhow::Result<MultitrackHeader> {
+	let (&framing, rest) = cursor
+		.split_first()
+		.with_context(|| format!("multitrack {kind} tag missing framing byte"))?;
+	*cursor = rest;
+	let multitrack_type = framing >> 4;
+	let packet_type = framing & 0x0f;
+	anyhow::ensure!(
+		matches!(
+			multitrack_type,
+			MULTITRACK_ONE_TRACK | MULTITRACK_MANY_TRACKS | MULTITRACK_MANY_TRACKS_MANY_CODECS
+		),
+		"unsupported multitrack {kind} type {multitrack_type}"
+	);
+
+	let shared_fourcc = if multitrack_type == MULTITRACK_MANY_TRACKS_MANY_CODECS {
+		None
+	} else {
+		Some(take_fourcc(cursor).with_context(|| format!("multitrack {kind} missing shared FourCC"))?)
+	};
+
+	Ok(MultitrackHeader {
+		multitrack_type,
+		packet_type,
+		shared_fourcc,
+	})
+}
+
+/// Parse one track record from a multitrack tag body, advancing `cursor` past it.
+///
+/// Reads the per-track FourCC (only for `ManyTracksManyCodecs`), the one-byte
+/// track id, and the payload: length-prefixed for `ManyTracks*`, or the rest of
+/// the tag for `OneTrack`.
+fn split_multitrack_track<'a>(
+	cursor: &mut &'a [u8],
+	header: &MultitrackHeader,
+	kind: &str,
+) -> anyhow::Result<MultitrackTrack<'a>> {
+	let fourcc = match header.shared_fourcc {
+		Some(fourcc) => fourcc,
+		None => take_fourcc(cursor).with_context(|| format!("multitrack {kind} missing per-track FourCC"))?,
+	};
+
+	let (&track_id, rest) = cursor
+		.split_first()
+		.with_context(|| format!("multitrack {kind} missing track id"))?;
+	*cursor = rest;
+
+	let payload = if header.multitrack_type == MULTITRACK_ONE_TRACK {
+		std::mem::take(cursor)
+	} else {
+		anyhow::ensure!(cursor.len() >= 3, "multitrack {kind} missing track size");
+		let size = read_u24(&cursor[0..3]) as usize;
+		*cursor = &cursor[3..];
+		anyhow::ensure!(
+			cursor.len() >= size,
+			"multitrack {kind} track size {size} exceeds remaining {}",
+			cursor.len()
+		);
+		let (payload, rest) = cursor.split_at(size);
+		*cursor = rest;
+		payload
+	};
+
+	Ok(MultitrackTrack {
+		fourcc,
+		track_id,
+		payload,
+	})
+}
+
+/// Read a 4-byte FourCC from the front of `cursor`, advancing past it.
+fn take_fourcc(cursor: &mut &[u8]) -> Option<[u8; 4]> {
+	let fourcc = cursor.get(0..4)?.try_into().expect("slice is 4 bytes");
+	*cursor = &cursor[4..];
+	Some(fourcc)
 }
 
 /// Build a video config for the `avc1` shape from an `AVCDecoderConfigurationRecord`.

--- a/rs/moq-mux/src/container/flv/import_test.rs
+++ b/rs/moq-mux/src/container/flv/import_test.rs
@@ -260,6 +260,128 @@ async fn import_legacy_mp3() {
 	assert!(a.description.is_none(), "MP3 config is in band");
 }
 
+/// A minimal avcC like [`avcc`], but with a caller-chosen level byte so two video
+/// renditions carry distinct codec configs.
+fn avcc_level(level: u8) -> Vec<u8> {
+	let sps = [0x67u8, 0x42, 0xc0, level];
+	let mut out = vec![0x01, 0x42, 0xc0, level, 0xff, 0xe1, 0x00, sps.len() as u8];
+	out.extend_from_slice(&sps);
+	out.extend_from_slice(&[0x01, 0x00, 0x04, 0x68, 0xce, 0x3c, 0x80]);
+	out
+}
+
+/// Build one enhanced-RTMP multitrack video tag body: the ex-header + framing
+/// byte, the shared FourCC (unless per-track), then each track's optional FourCC,
+/// one-byte id, UI24 size (omitted for `OneTrack`), and payload.
+fn multitrack_video_body(
+	frame_type: u8,
+	multitrack_type: u8,
+	packet_type: u8,
+	shared_fourcc: Option<&[u8; 4]>,
+	tracks: &[(u8, [u8; 4], Vec<u8>)],
+) -> Vec<u8> {
+	let mut body = vec![super::VIDEO_EX_HEADER | (frame_type << 4) | super::VIDEO_PACKET_MULTITRACK];
+	body.push((multitrack_type << 4) | packet_type);
+	if let Some(fourcc) = shared_fourcc {
+		body.extend_from_slice(fourcc);
+	}
+	for (track_id, fourcc, payload) in tracks {
+		if shared_fourcc.is_none() {
+			body.extend_from_slice(fourcc);
+		}
+		body.push(*track_id);
+		if multitrack_type != super::MULTITRACK_ONE_TRACK {
+			body.extend_from_slice(&(payload.len() as u32).to_be_bytes()[1..]); // UI24 size
+		}
+		body.extend_from_slice(payload);
+	}
+	body
+}
+
+/// A `ManyTracks` multitrack tag (several length-prefixed tracks sharing one
+/// codec in a single tag) demuxes into one rendition per track id.
+#[tokio::test(start_paused = true)]
+async fn import_multitrack_video_many_tracks() {
+	let (avcc0, avcc1) = (avcc_level(0x1f), avcc_level(0x1e));
+
+	let mut out = Vec::new();
+	out.extend_from_slice(b"FLV");
+	out.push(1);
+	out.push(0x01); // video only
+	out.extend_from_slice(&9u32.to_be_bytes());
+	out.extend_from_slice(&0u32.to_be_bytes());
+
+	// Two-track SequenceStart sharing the avc1 codec.
+	let seq = multitrack_video_body(
+		super::FRAME_TYPE_KEY,
+		super::MULTITRACK_MANY_TRACKS,
+		super::VIDEO_PACKET_SEQUENCE_START,
+		Some(b"avc1"),
+		&[(0, *b"avc1", avcc0.clone()), (1, *b"avc1", avcc1.clone())],
+	);
+	write_tag(&mut out, super::TAG_VIDEO, 0, &seq);
+
+	// Two-track CodedFrames: avc1 prefixes a 3-byte composition time (zero here).
+	let nalu0 = vec![0, 0, 0, 0, 0, 5, 0x65, 0x88, 0x84, 0x21, 0x00];
+	let nalu1 = vec![0, 0, 0, 0, 0, 5, 0x65, 0x11, 0x22, 0x33, 0x44];
+	let frames = multitrack_video_body(
+		super::FRAME_TYPE_KEY,
+		super::MULTITRACK_MANY_TRACKS,
+		super::VIDEO_PACKET_CODED_FRAMES,
+		Some(b"avc1"),
+		&[(0, *b"avc1", nalu0), (1, *b"avc1", nalu1)],
+	);
+	write_tag(&mut out, super::TAG_VIDEO, 0, &frames);
+
+	let mut producer = moq_net::Broadcast::new().produce();
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let mut importer = Import::new(producer, catalog.clone());
+	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
+	importer.finish().unwrap();
+
+	let snap = catalog.snapshot();
+	assert_eq!(snap.video.renditions.len(), 2, "one rendition per multitrack track id");
+	let mut descriptions: Vec<Vec<u8>> = snap
+		.video
+		.renditions
+		.values()
+		.filter_map(|c| c.description.as_ref().map(|b| b.to_vec()))
+		.collect();
+	descriptions.sort();
+	let mut want = vec![avcc0, avcc1];
+	want.sort();
+	assert_eq!(descriptions, want, "each track keeps its own avcC");
+}
+
+/// A `ManyTracksManyCodecs` tag carries a FourCC per track; both are demuxed.
+#[tokio::test(start_paused = true)]
+async fn import_multitrack_video_many_codecs() {
+	let mut out = Vec::new();
+	out.extend_from_slice(b"FLV");
+	out.push(1);
+	out.push(0x01);
+	out.extend_from_slice(&9u32.to_be_bytes());
+	out.extend_from_slice(&0u32.to_be_bytes());
+
+	// Two tracks, each carrying its own FourCC (both avc1 here for a simple config).
+	let seq = multitrack_video_body(
+		super::FRAME_TYPE_KEY,
+		super::MULTITRACK_MANY_TRACKS_MANY_CODECS,
+		super::VIDEO_PACKET_SEQUENCE_START,
+		None,
+		&[(0, *b"avc1", avcc_level(0x1f)), (1, *b"avc1", avcc_level(0x1e))],
+	);
+	write_tag(&mut out, super::TAG_VIDEO, 0, &seq);
+
+	let mut producer = moq_net::Broadcast::new().produce();
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let mut importer = Import::new(producer, catalog.clone());
+	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
+	importer.finish().unwrap();
+
+	assert_eq!(catalog.snapshot().video.renditions.len(), 2);
+}
+
 #[tokio::test(start_paused = true)]
 async fn import_rejects_non_flv() {
 	let mut producer = moq_net::Broadcast::new().produce();

--- a/rs/moq-mux/src/container/flv/mod.rs
+++ b/rs/moq-mux/src/container/flv/mod.rs
@@ -88,6 +88,9 @@ const VIDEO_PACKET_SEQUENCE_END: u8 = 2;
 /// Coded frames with the composition-time offset omitted (always zero).
 const VIDEO_PACKET_CODED_FRAMES_X: u8 = 3;
 const VIDEO_PACKET_METADATA: u8 = 4;
+/// Multitrack framing: the next byte carries the `AvMultitrackType` plus the real
+/// `VideoPacketType`, and each track payload is tagged with its own track id.
+const VIDEO_PACKET_MULTITRACK: u8 = 5;
 
 /// Enhanced-RTMP audio signaling: SoundFormat 9 in the high nibble of an audio
 /// tag's first byte switches to a FourCC codec + packet type.
@@ -98,6 +101,20 @@ const AUDIO_PACKET_SEQUENCE_START: u8 = 0;
 const AUDIO_PACKET_CODED_FRAMES: u8 = 1;
 const AUDIO_PACKET_SEQUENCE_END: u8 = 2;
 const AUDIO_PACKET_MULTICHANNEL_CONFIG: u8 = 4;
+/// Multitrack framing, mirroring [`VIDEO_PACKET_MULTITRACK`] for audio.
+const AUDIO_PACKET_MULTITRACK: u8 = 5;
+
+/// `AvMultitrackType` (high nibble of the multitrack framing byte): how the
+/// per-track payloads that follow are laid out.
+///
+/// - `OneTrack`: a single track, tagged with its id; the payload runs to the end
+///   of the tag (no per-track size).
+/// - `ManyTracks`: several tracks sharing one codec, each length-prefixed.
+/// - `ManyTracksManyCodecs`: several tracks, each carrying its own FourCC and
+///   length prefix.
+const MULTITRACK_ONE_TRACK: u8 = 0;
+const MULTITRACK_MANY_TRACKS: u8 = 1;
+const MULTITRACK_MANY_TRACKS_MANY_CODECS: u8 = 2;
 
 /// Read a 24-bit big-endian unsigned integer.
 fn read_u24(b: &[u8]) -> u32 {

--- a/rs/moq-rtmp/src/rml/sessions/client/mod.rs
+++ b/rs/moq-rtmp/src/rml/sessions/client/mod.rs
@@ -62,6 +62,7 @@ pub struct ClientSession {
 	peer_window_ack_size: Option<u32>,
 	bytes_received: u64,
 	bytes_received_since_last_ack: u32,
+	connect_request_properties: HashMap<String, Amf0Value>,
 }
 
 impl ClientSession {
@@ -82,6 +83,7 @@ impl ClientSession {
 			peer_window_ack_size: None,
 			bytes_received: 0,
 			bytes_received_since_last_ack: 0,
+			connect_request_properties: HashMap::new(),
 			config,
 		};
 
@@ -166,6 +168,16 @@ impl ClientSession {
 		Ok(results)
 	}
 
+	/// Sets extra name-value pairs to include in the `connect` command object,
+	/// alongside `app` / `flashVer` / `objectEncoding`. This lets a client
+	/// advertise enhanced-RTMP capabilities (e.g. `capsEx`) to the server.
+	///
+	/// Must be called before `request_connection`. Keys here override the built-in
+	/// properties if they collide.
+	pub fn set_connect_request_properties(&mut self, properties: HashMap<String, Amf0Value>) {
+		self.connect_request_properties = properties;
+	}
+
 	/// Forms an RTMP message requesting a connection to the specified application on the server.
 	/// An event will be raised when the request is accepted or rejected.
 	pub fn request_connection(&mut self, app_name: String) -> Result<ClientSessionResult, ClientSessionError> {
@@ -197,6 +209,11 @@ impl ClientSession {
 			}
 			None => (),
 		};
+
+		// Caller-supplied properties (e.g. capsEx) override the built-ins on collision.
+		for (key, value) in self.connect_request_properties.drain() {
+			properties.insert(key, value);
+		}
 
 		let message = RtmpMessage::Amf0Command {
 			command_name: "connect".to_string(),

--- a/rs/moq-rtmp/src/rml/sessions/client/mod.rs
+++ b/rs/moq-rtmp/src/rml/sessions/client/mod.rs
@@ -211,8 +211,8 @@ impl ClientSession {
 		};
 
 		// Caller-supplied properties (e.g. capsEx) override the built-ins on collision.
-		for (key, value) in self.connect_request_properties.drain() {
-			properties.insert(key, value);
+		for (key, value) in &self.connect_request_properties {
+			properties.insert(key.clone(), value.clone());
 		}
 
 		let message = RtmpMessage::Amf0Command {

--- a/rs/moq-rtmp/src/rml/sessions/server/events.rs
+++ b/rs/moq-rtmp/src/rml/sessions/server/events.rs
@@ -24,8 +24,14 @@ pub enum ServerSessionEvent {
 	/// The client is changing the maximum size of the RTMP chunks they will be sending
 	ClientChunkSizeChanged { new_chunk_size: u32 },
 
-	/// The client is requesting a connection on the specified RTMP application name
-	ConnectionRequested { request_id: u32, app_name: String },
+	/// The client is requesting a connection on the specified RTMP application name.
+	/// `caps_ex` is the enhanced-RTMP `capsEx` capability bitmask the client
+	/// advertised in its `connect` command object (0 if absent).
+	ConnectionRequested {
+		request_id: u32,
+		app_name: String,
+		caps_ex: u32,
+	},
 
 	/// The client is requesting a stream key be released for use.
 	ReleaseStreamRequested {

--- a/rs/moq-rtmp/src/rml/sessions/server/mod.rs
+++ b/rs/moq-rtmp/src/rml/sessions/server/mod.rs
@@ -503,6 +503,13 @@ impl ServerSession {
 			None => 0.0,
 		};
 
+		// Enhanced-RTMP capsEx: a numeric capability bitmask. Absent (or a
+		// non-number) means a legacy client with no advertised capabilities.
+		let caps_ex = match properties.remove("capsEx") {
+			Some(Amf0Value::Number(number)) if number >= 0.0 => number as u32,
+			_ => 0,
+		};
+
 		let request = OutstandingRequest::ConnectionRequest {
 			app_name: app_name.clone(),
 			transaction_id,
@@ -515,6 +522,7 @@ impl ServerSession {
 		let event = ServerSessionEvent::ConnectionRequested {
 			app_name: app_name,
 			request_id: request_number,
+			caps_ex,
 		};
 
 		Ok(vec![ServerSessionResult::RaisedEvent(event)])

--- a/rs/moq-rtmp/src/rml/sessions/server/tests.rs
+++ b/rs/moq-rtmp/src/rml/sessions/server/tests.rs
@@ -106,6 +106,7 @@ fn can_accept_connection_request() {
 		ServerSessionEvent::ConnectionRequested {
 			ref app_name,
 			request_id,
+			..
 		} if app_name == "some_app" => request_id,
 		_ => panic!("First event was not as expected: {:?}", events[0]),
 	};
@@ -189,6 +190,7 @@ fn connect_request_strips_trailing_slash() {
 		ServerSessionEvent::ConnectionRequested {
 			ref app_name,
 			request_id: _,
+			..
 		} => assert_eq!(app_name, "some_app", "Unexpected app name"),
 		_ => panic!("First event was not as expected: {:?}", events[0]),
 	};
@@ -214,6 +216,7 @@ fn accepted_connection_responds_with_same_object_encoding_value_as_connection_re
 		ServerSessionEvent::ConnectionRequested {
 			ref app_name,
 			request_id,
+			..
 		} if app_name == "some_app" => request_id,
 		_ => panic!("First event was not as expected: {:?}", events[0]),
 	};
@@ -1368,6 +1371,7 @@ fn perform_connection(
 		ServerSessionEvent::ConnectionRequested {
 			ref app_name,
 			request_id,
+			..
 		} if app_name == "some_app" => request_id,
 		_ => panic!("First event was not as expected: {:?}", events[0]),
 	};

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -82,8 +82,18 @@ const FOURCC_CAN_FORWARD: f64 = 0x04 as f64;
 const INGEST_VIDEO_FOURCCS: [&[u8; 4]; 4] = [b"avc1", b"hvc1", b"av01", b"vp09"];
 const INGEST_AUDIO_FOURCCS: [&[u8; 4]; 5] = [b"Opus", b"mp4a", b".mp3", b"ac-3", b"ec-3"];
 
+// Enhanced-RTMP `capsEx` (CapsExMask) bit for multitrack audio/video: several
+// tracks in one RTMP stream. We ingest and egress multitrack, so we advertise it.
+const CAPS_EX_MULTITRACK: u32 = 0x02;
+
+/// The enhanced-RTMP `capsEx` capabilities this gateway supports. We handle
+/// multitrack on both ingest (demux several tracks) and egress (mux several
+/// renditions); reconnect and the ModEx timestamp extensions are not supported.
+const SUPPORTED_CAPS_EX: u32 = CAPS_EX_MULTITRACK;
+
 /// Enhanced-RTMP capabilities to echo in the connect `_result` command object, so
-/// an enhanced encoder knows it may send these FourCC codecs on ingest.
+/// an enhanced encoder knows it may send these FourCC codecs on ingest and that
+/// multitrack is negotiated.
 fn advertised_connect_properties() -> HashMap<String, Amf0Value> {
 	fn info_map(fourccs: &[&[u8; 4]]) -> Amf0Value {
 		Amf0Value::Object(
@@ -102,6 +112,7 @@ fn advertised_connect_properties() -> HashMap<String, Amf0Value> {
 	HashMap::from([
 		("videoFourCcInfoMap".to_string(), info_map(&INGEST_VIDEO_FOURCCS)),
 		("audioFourCcInfoMap".to_string(), info_map(&INGEST_AUDIO_FOURCCS)),
+		("capsEx".to_string(), Amf0Value::Number(SUPPORTED_CAPS_EX as f64)),
 	])
 }
 
@@ -493,6 +504,10 @@ pub struct Play<S = Conn> {
 	/// one. Zero (the default) drops stale groups aggressively; raise it with
 	/// [`with_latency`](Self::with_latency).
 	latency: Duration,
+	/// Whether the player advertised enhanced-RTMP multitrack support (connect
+	/// `capsEx`). When set, every rendition is muxed as a multitrack track;
+	/// otherwise only the first video + first audio rendition is sent.
+	multitrack: bool,
 }
 
 impl<S: Stream> Play<S> {
@@ -558,7 +573,8 @@ impl<S: Stream> Play<S> {
 
 		let mut export = FlvExport::new(broadcast)
 			.map_err(|e| anyhow::anyhow!("init FLV export: {e}"))?
-			.with_latency(self.latency);
+			.with_latency(self.latency)
+			.with_multitrack(self.multitrack);
 
 		// Resolve the catalog and codec headers before Play.Start, too. Otherwise a
 		// broadcast that never produces a playable FLV header looks successful to the
@@ -656,6 +672,11 @@ async fn accept_until_request<S: Stream>(mut stream: S, peer: SocketAddr) -> any
 		work.extend(results);
 	}
 
+	// Whether the client advertised enhanced-RTMP multitrack support in its
+	// connect `capsEx`. Set at connect time and carried into a later play so the
+	// FLV muxer only emits multitrack tags to a player that can parse them.
+	let mut client_multitrack = false;
+
 	let mut buffer = [0u8; READ_BUFFER];
 	loop {
 		while let Some(result) = work.pop_front() {
@@ -665,9 +686,15 @@ async fn accept_until_request<S: Stream>(mut stream: S, peer: SocketAddr) -> any
 				}
 				ServerSessionResult::RaisedEvent(event) => match event {
 					// Accept every connect; authorization happens at publish/play time.
-					ServerSessionEvent::ConnectionRequested { request_id, app_name } => {
-						tracing::debug!(%peer, %app_name, "rtmp connect");
-						// Advertise the enhanced-RTMP codecs we ingest in the connect _result.
+					ServerSessionEvent::ConnectionRequested {
+						request_id,
+						app_name,
+						caps_ex,
+					} => {
+						client_multitrack = caps_ex & CAPS_EX_MULTITRACK != 0;
+						tracing::debug!(%peer, %app_name, caps_ex, client_multitrack, "rtmp connect");
+						// Advertise the enhanced-RTMP codecs we ingest, and our capsEx, in
+						// the connect _result.
 						session.set_connect_response_properties(advertised_connect_properties());
 						let results = session
 							.accept_request(request_id)
@@ -709,6 +736,7 @@ async fn accept_until_request<S: Stream>(mut stream: S, peer: SocketAddr) -> any
 							stream_key,
 							peer,
 							latency: Duration::ZERO,
+							multitrack: client_multitrack,
 						})));
 					}
 					other => tracing::trace!(%peer, ?other, "ignoring RTMP event before publish/play"),
@@ -1117,7 +1145,8 @@ mod tests {
 
 	/// Drive an RTMP play client over `stream` through handshake -> connect(`live`)
 	/// -> play(`cam0`), collecting media messages until `want` have arrived.
-	async fn play_client_collect<S: Stream>(mut stream: S, want: usize) -> Vec<Media> {
+	/// `caps_ex` is advertised in the connect `capsEx` (0 for a legacy player).
+	async fn play_client_collect<S: Stream>(mut stream: S, want: usize, caps_ex: u32) -> Vec<Media> {
 		// Handshake.
 		let mut handshake = Handshake::new(PeerType::Client);
 		stream
@@ -1149,6 +1178,12 @@ mod tests {
 		let mut work: VecDeque<ClientSessionResult> = VecDeque::from(initial);
 		if !remaining.is_empty() {
 			work.extend(session.handle_input(&remaining).unwrap());
+		}
+		if caps_ex != 0 {
+			session.set_connect_request_properties(HashMap::from([(
+				"capsEx".to_string(),
+				Amf0Value::Number(caps_ex as f64),
+			)]));
 		}
 		work.push_back(session.request_connection("live".to_string()).unwrap());
 
@@ -1227,7 +1262,7 @@ mod tests {
 		});
 
 		let stream = TcpStream::connect(addr).await.unwrap();
-		let media = tokio::time::timeout(Duration::from_secs(5), play_client_collect(stream, 2))
+		let media = tokio::time::timeout(Duration::from_secs(5), play_client_collect(stream, 2, 0))
 			.await
 			.expect("play client timed out");
 
@@ -1243,6 +1278,100 @@ mod tests {
 		// Second is the keyframe NALU (AVCPacketType 1).
 		assert!(media[1].0, "second message should be video");
 		assert_eq!(media[1].1[1], 0x01);
+
+		server_task.abort();
+	}
+
+	/// End-to-end multitrack egress: publish a broadcast carrying two H.264
+	/// renditions, then a play client that advertised the multitrack `capsEx`
+	/// receives enhanced-RTMP multitrack video tags for both track ids. Proves the
+	/// negotiation reaches the FLV muxer.
+	#[tokio::test]
+	async fn play_multitrack_to_capable_client() {
+		// Enhanced-RTMP multitrack framing constants, matching moq-mux's FLV muxer.
+		const EX: u8 = 0x80;
+		const MULTITRACK: u8 = 5;
+		const SEQUENCE_START: u8 = 0;
+		const CODED_FRAMES: u8 = 1;
+		const MANY_TRACKS: u8 = 1;
+
+		let avcc = |level: u8| {
+			let sps = [0x67u8, 0x42, 0xc0, level];
+			let mut out = vec![0x01, 0x42, 0xc0, level, 0xff, 0xe1, 0x00, sps.len() as u8];
+			out.extend_from_slice(&sps);
+			out.extend_from_slice(&[0x01, 0x00, 0x04, 0x68, 0xce, 0x3c, 0x80]);
+			out
+		};
+
+		// Build one ManyTracks multitrack video tag body over two avc1 tracks.
+		let multitrack_body = |packet_type: u8, tracks: &[(u8, Vec<u8>)]| {
+			let mut body = vec![EX | (1 << 4) | MULTITRACK, (MANY_TRACKS << 4) | packet_type];
+			body.extend_from_slice(b"avc1"); // shared codec
+			for (track_id, payload) in tracks {
+				body.push(*track_id);
+				body.extend_from_slice(&(payload.len() as u32).to_be_bytes()[1..]); // UI24 size
+				body.extend_from_slice(payload);
+			}
+			body
+		};
+
+		let seq = multitrack_body(SEQUENCE_START, &[(0, avcc(0x1f)), (1, avcc(0x1e))]);
+		// CodedFrames: avc1 prefixes a 3-byte composition time (zero) before the NALU.
+		let nalu = |b: u8| vec![0, 0, 0, 0, 0, 5, 0x65, b, 0x84, 0x21, 0x00];
+		let frames = multitrack_body(CODED_FRAMES, &[(0, nalu(0x88)), (1, nalu(0x99))]);
+
+		let origin = moq_net::Origin::random().produce();
+		let mut broadcast = Broadcast::new().produce();
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let mut importer = FlvImport::new(broadcast.clone(), catalog);
+		assert!(origin.publish_broadcast("live/cam0", broadcast.consume()));
+		importer.decode(&flv::file_header()).unwrap();
+		importer.decode(&flv::tag(flv::TAG_VIDEO, 0, &seq)).unwrap();
+		importer.decode(&flv::tag(flv::TAG_VIDEO, 0, &frames)).unwrap();
+		importer.finish().unwrap();
+
+		let mut server = Server::bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+		let addr = server.local_addr().unwrap();
+		let consumer = origin.consume();
+
+		let server_task = tokio::spawn(async move {
+			let request = server.accept().await.expect("a request");
+			let Request::Play(play) = request else {
+				panic!("expected a play request");
+			};
+			play.accept(&consumer, "live/cam0").await.unwrap();
+		});
+
+		// The player advertises multitrack; collect the four video messages (two
+		// sequence headers + two keyframes across the two tracks).
+		let stream = TcpStream::connect(addr).await.unwrap();
+		let media = tokio::time::timeout(
+			Duration::from_secs(5),
+			play_client_collect(stream, 4, CAPS_EX_MULTITRACK),
+		)
+		.await
+		.expect("play client timed out");
+
+		let video: Vec<&bytes::Bytes> = media.iter().filter(|(is_video, _)| *is_video).map(|(_, d)| d).collect();
+		assert!(
+			video.len() >= 2,
+			"expected multitrack video messages, got {}",
+			video.len()
+		);
+		// Every video message uses the multitrack framing (packet type 5) over avc1.
+		for data in &video {
+			assert_eq!(data[0] & 0x0f, MULTITRACK, "video message should be multitrack-framed");
+			assert_eq!(&data[2..6], b"avc1");
+		}
+		// Both track ids show up (the byte after the FourCC in each OneTrack tag).
+		let mut track_ids: Vec<u8> = video.iter().map(|data| data[6]).collect();
+		track_ids.sort_unstable();
+		track_ids.dedup();
+		assert_eq!(
+			track_ids,
+			vec![0, 1],
+			"both renditions should egress as multitrack tracks"
+		);
 
 		server_task.abort();
 	}
@@ -1312,12 +1441,13 @@ mod tests {
 		client.abort();
 	}
 
-	/// The connect `_result` should advertise the enhanced-RTMP codecs we ingest,
-	/// so an enhanced encoder knows it may send them. Drives a raw client through
-	/// the handshake, sends `connect`, and deserializes the server's `_result` to
-	/// read the command object (rml's ClientSession discards those properties).
+	/// The connect `_result` should advertise the enhanced-RTMP codecs we ingest
+	/// plus our `capsEx` (multitrack), so an enhanced encoder knows what it may
+	/// send. Drives a raw client through the handshake, sends `connect` (itself
+	/// advertising `capsEx`), and deserializes the server's `_result` to read the
+	/// command object (rml's ClientSession discards those properties).
 	#[tokio::test]
-	async fn connect_result_advertises_ingest_codecs() {
+	async fn connect_result_advertises_capabilities() {
 		use crate::rml::chunk_io::{ChunkDeserializer, ChunkSerializer};
 		use crate::rml::messages::RtmpMessage;
 
@@ -1359,14 +1489,14 @@ mod tests {
 			}
 		};
 
-		// Send a minimal `connect`.
+		// Send a `connect` advertising our own capsEx (multitrack).
 		let connect = RtmpMessage::Amf0Command {
 			command_name: "connect".to_string(),
 			transaction_id: 1.0,
-			command_object: Amf0Value::Object(HashMap::from([(
-				"app".to_string(),
-				Amf0Value::Utf8String("live".to_string()),
-			)])),
+			command_object: Amf0Value::Object(HashMap::from([
+				("app".to_string(), Amf0Value::Utf8String("live".to_string())),
+				("capsEx".to_string(), Amf0Value::Number(CAPS_EX_MULTITRACK as f64)),
+			])),
 			additional_arguments: Vec::new(),
 		};
 		let payload = connect.into_message_payload(RtmpTimestamp::new(0), 0).unwrap();
@@ -1413,6 +1543,16 @@ mod tests {
 			panic!("connect _result did not advertise audioFourCcInfoMap");
 		};
 		assert!(audio.contains_key("Opus"), "expected Opus in audioFourCcInfoMap");
+
+		// The server echoes its supported capsEx, including the multitrack bit.
+		let Some(Amf0Value::Number(caps_ex)) = properties.get("capsEx") else {
+			panic!("connect _result did not advertise capsEx");
+		};
+		assert_eq!(
+			*caps_ex as u32 & CAPS_EX_MULTITRACK,
+			CAPS_EX_MULTITRACK,
+			"connect _result should advertise the multitrack capsEx bit"
+		);
 
 		server_task.abort();
 	}


### PR DESCRIPTION
Closes #2049.

Adds enhanced-RTMP v2 `capsEx` capability negotiation to the RTMP gateway, and full **Multitrack** support (several audio/video renditions carried in one RTMP stream) end to end.

## capsEx negotiation (`moq-rtmp`)

- **Parse** the client's `capsEx` bitmask from the `connect` command object (in the vendored `rml` server) and surface it on the `ConnectionRequested` event.
- **Advertise** our supported `capsEx` (the `Multitrack` bit, `0x02`) in the connect `_result`, alongside the existing `videoFourCcInfoMap` / `audioFourCcInfoMap`.
- **Gate egress**: the negotiated multitrack support is carried into a play request, so the FLV muxer only emits multitrack tags to a player that advertised it and falls back to a single track otherwise.
- Added a symmetric `set_connect_request_properties` to the vendored `rml` client (mirrors the server's `set_connect_response_properties`) so a client can advertise its own `capsEx`.

`CapsExMask` values handled: `Multitrack` (`0x02`). `Reconnect` / `ModEx` / `TimestampNanoOffset` are parsed but not advertised (not supported), per the issue's priority.

## Multitrack FLV (`moq-mux`)

- **Import (demux)**: handles the enhanced-RTMP multitrack video/audio packet types (`OneTrack`, `ManyTracks`, `ManyTracksManyCodecs`), keying tracks by RTMP track id so each id becomes its own catalog rendition. Legacy and single-track enhanced tags map to track id 0, behavior unchanged.
- **Export (mux)**: new `Export::with_multitrack(bool)` builder. When enabled, every rendition is muxed as a `OneTrack` multitrack track addressed by its own id (one frame per tag, so no cross-rendition frame alignment is needed). Default off preserves the existing single-track, first-rendition-only behavior for legacy players.

## Public API

- `moq-mux`: `Export::with_multitrack(self, bool) -> Self` (additive, non-breaking). `Import` is unchanged (it just accepts more input shapes).
- `moq-rtmp`: no public surface change; capsEx/multitrack are negotiated automatically.

Targets `main`: additive, no wire-protocol or breaking API changes.

## Test plan / smoke test

- [x] `moq-mux`: export → import round trips with multitrack enabled (two H.264 renditions + one AAC), asserting both renditions and their distinct codec configs survive; and that without multitrack a multi-rendition broadcast exports only the first rendition.
- [x] `moq-mux`: direct import tests for the `ManyTracks` (size-prefixed) and `ManyTracksManyCodecs` (per-track FourCC) layouts, which export's `OneTrack` framing doesn't exercise.
- [x] `moq-rtmp`: connect `_result` advertises `capsEx` (and echoes it when the client advertises its own).
- [x] `moq-rtmp` **end-to-end smoke test** (`play_multitrack_to_capable_client`): full RTMP handshake → `connect` advertising `capsEx` Multitrack → publish a broadcast with two H.264 renditions → play → assert the client receives enhanced-RTMP multitrack video tags for **both** track ids. This exercises the whole negotiation → muxer path.

The cross-language `test/smoke/` harness wasn't extended: it drives moq-native clients through a relay and has no RTMP gateway or E-RTMP-multitrack-capable client (ffmpeg can't emit E-RTMP multitrack), so the in-crate end-to-end test above is the honest smoke test for this feature.

## Cross-package sync

- Updated `doc/lib/rs/crate/moq-mux.md` FLV bullet (was stale at "H.264 + AAC"; now lists the enhanced-RTMP codecs and multitrack).
- No JS mirror: FLV/RTMP is Rust-only (`moq-mux` has no `js/` counterpart). No `moq-ffi`/wrapper surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)