### PR TITLE
Enable TCP keepalive on the HTTP/WebSocket listener and RTMP client

### DIFF
--- a/rs/moq-native/src/bind.rs
+++ b/rs/moq-native/src/bind.rs
@@ -8,8 +8,19 @@
 //! addresses; the client's address-family matching lives in `util::pick_addr`).
 //! See <https://github.com/moq-dev/moq/issues/1375>.
 
-use socket2::{Domain, Protocol, Socket, Type};
+use socket2::{Domain, Protocol, Socket, TcpKeepalive, Type};
 use std::net::{SocketAddr, TcpListener, UdpSocket};
+use std::time::Duration;
+
+/// TCP keepalive idle period before the kernel starts probing a silent peer, and
+/// the interval between probes. A long-lived connection (a parked WebSocket, an
+/// idle HTTP/2 session) can otherwise sit in a `read` forever, so a peer that
+/// vanished without a FIN/RST (a yanked cable, a crashed NAT) would pin its
+/// socket and any resources behind it. Keepalive lets the kernel surface the dead
+/// peer as a read error and tear the connection down. The values are generous
+/// enough not to disturb a healthy but momentarily quiet connection.
+const KEEPALIVE_IDLE: Duration = Duration::from_secs(30);
+const KEEPALIVE_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Bind a UDP socket, making an IPv6 socket dual-stack so it also serves IPv4.
 pub fn udp(addr: SocketAddr) -> std::io::Result<UdpSocket> {
@@ -32,6 +43,17 @@ pub fn tcp(addr: SocketAddr) -> std::io::Result<TcpListener> {
 	// restarted relay can rebind a port still in TIME_WAIT.
 	#[cfg(not(windows))]
 	socket.set_reuse_address(true)?;
+	// Enable keepalive on the listening socket so every accepted connection
+	// inherits it (accept() carries socket options across on Linux, macOS, and
+	// Windows). axum_server owns the accept loop, so this is the one hook we have
+	// to reach the HTTP/HTTPS/WebSocket connections it serves. Best-effort: a
+	// platform that rejects the option keeps the connection rather than failing.
+	let keepalive = TcpKeepalive::new()
+		.with_time(KEEPALIVE_IDLE)
+		.with_interval(KEEPALIVE_INTERVAL);
+	if let Err(err) = socket.set_tcp_keepalive(&keepalive) {
+		tracing::warn!(%err, "failed to enable TCP keepalive; dead peers may linger");
+	}
 	socket.bind(&addr.into())?;
 	socket.listen(1024)?;
 	let listener: TcpListener = socket.into();

--- a/rs/moq-rtmp/src/dial.rs
+++ b/rs/moq-rtmp/src/dial.rs
@@ -78,7 +78,7 @@ impl Client<TcpStream> {
 	/// [`with_stream`](Self::with_stream) instead.
 	pub async fn connect(addr: SocketAddr, app: &str) -> Result<Self> {
 		let stream = TcpStream::connect(addr).await?;
-		stream.set_nodelay(true).ok();
+		crate::server::configure_socket(&stream, addr);
 		// Advertise a tcUrl derived from the dial target: several ingest servers
 		// (YouTube, Twitch, some nginx-rtmp configs) reject a connect without one.
 		Self::with_stream_config(stream, app, Some(format!("rtmp://{addr}/{app}"))).await

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -276,12 +276,13 @@ impl Server {
 	}
 }
 
-/// Tune a freshly accepted RTMP socket: Nagle off for latency, keepalive on so a
-/// dead peer is reaped rather than pinning a broadcast forever.
+/// Tune an RTMP TCP socket (accepted by the server or dialed by the client):
+/// Nagle off for latency, keepalive on so a dead peer is reaped rather than
+/// pinning a broadcast forever.
 ///
 /// Both are best-effort: a failure to set either is logged and ignored rather
 /// than dropping an otherwise healthy connection.
-fn configure_socket(stream: &TcpStream, peer: SocketAddr) {
+pub(crate) fn configure_socket(stream: &TcpStream, peer: SocketAddr) {
 	// Nagle off: RTMP is latency-sensitive and we write whole packets.
 	if let Err(err) = stream.set_nodelay(true) {
 		tracing::debug!(%peer, %err, "failed to set TCP_NODELAY");


### PR DESCRIPTION
## Summary

MoQ is QUIC-first (quinn keepalive is already on at a 5s interval), but the TCP-based paths were inconsistent about socket keepalive. This closes the gap so **every** TCP connection is reaped when its peer vanishes without a FIN/RST (a yanked cable, a crashed NAT, a dead load balancer).

- **HTTP / HTTPS / WebSocket** (`moq-native::bind::tcp`, used by the relay's web listeners): had **no** keepalive. A parked WebSocket or idle HTTP/2 session sitting in a `read` could be pinned forever by a half-open peer. `axum_server` owns the accept loop, so there's no per-connection hook. The fix sets keepalive on the **listening socket**, which accepted connections inherit across `accept()` on Linux, macOS, and Windows. This is the single point that reaches every connection the web server serves.
- **RTMP client dial** (`moq-rtmp::dial`): previously only set `TCP_NODELAY`. Now routes through the server's `configure_socket` helper (made `pub(crate)`), so a dialed connection gets the same Nagle-off + keepalive treatment as an accepted one.
- **RTMP server**: already set keepalive per accepted connection. Unchanged.

Keepalive values are **30s idle / 10s probe interval** across the board (matching what RTMP already used), so behavior is consistent everywhere.

## Public API

No public API change. `bind::tcp` keeps its signature; the values are internal constants. `configure_socket` is `pub(crate)`, not exported. Not a wire-protocol change, so this targets `main`.

## Test plan

- [x] `cargo check` + `cargo clippy --all-targets` clean on `moq-native` and `moq-rtmp`
- [x] `cargo test -p moq-native -p moq-rtmp` — 188 passed (bind dual-stack tests + RTMP loopback round-trip)
- [ ] Not runtime-tested against a live relay: keepalive-inheritance and dead-peer reaping is inherently a wall-clock/network-partition behavior. Reviewed against the platform inheritance guarantees instead.

Note: clippy was run with the system toolchain rather than the nix dev shell, which currently fails to build for an unrelated reason (a tsduck C++ `-Wms-bitfield-padding` error while building the shell). CI still runs fmt/clippy in nix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)