### PR TITLE
refactor(moq-net): split flat type names into role modules

### DIFF
--- a/doc/demo/moq-boy.md
+++ b/doc/demo/moq-boy.md
@@ -62,7 +62,7 @@ The `status` and `command` tracks bypass the container format — they're raw UT
 | `status` | Server → viewers | `{"buttons": ["up", "a"], "latency": {"abc123": 42}}` |
 | `command` | Viewer → server | `{"type": "buttons", "buttons": ["left"]}` or `{"type": "reset"}` |
 
-Every viewer subscribes to the server's `status` track so they see shared input. The server subscribes to the viewer prefix via `OriginProducer::with_root()` and fans in all `command` tracks, so adding a new viewer is just a new announcement.
+Every viewer subscribes to the server's `status` track so they see shared input. The server subscribes to the viewer prefix via `origin::Producer::with_root()` and fans in all `command` tracks, so adding a new viewer is just a new announcement.
 
 ## Auto-pause
 

--- a/doc/lib/rs/crate/moq-net.md
+++ b/doc/lib/rs/crate/moq-net.md
@@ -35,7 +35,7 @@ moq-net = "0.1"
 
 ## API Reference
 
-The Rust API uses a builder pattern with `Session`, `OriginProducer`/`OriginConsumer`, and related types. See the full API documentation for details:
+The Rust API uses a builder pattern with `Session`, `origin::Producer`/`origin::Consumer`, and related types. See the full API documentation for details:
 
 **[docs.rs/moq-net](https://docs.rs/moq-net)**
 

--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -61,7 +61,7 @@ See the [Authentication guide](/bin/relay/auth) for how to generate tokens.
 
 The [video example](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/video.rs) demonstrates publishing end-to-end.
 
-The connected [`Session`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html) exposes a [`publisher()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.publisher) [`OriginProducer`](https://docs.rs/moq-net/latest/moq_net/struct.OriginProducer.html) you publish broadcasts into:
+The connected [`Session`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html) exposes a [`publisher()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.publisher) [`origin::Producer`](https://docs.rs/moq-net/latest/moq_net/origin/struct.Producer.html) you publish broadcasts into:
 
 ```rust
 let session = client.connect(url).await?;
@@ -77,7 +77,7 @@ See the full [video.rs](https://github.com/moq-dev/moq/blob/main/rs/hang/example
 
 The [subscribe example](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/subscribe.rs) demonstrates subscribing end-to-end.
 
-The session also exposes a [`consumer()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.consumer) [`OriginConsumer`](https://docs.rs/moq-net/latest/moq_net/struct.OriginConsumer.html) for receiving announcements:
+The session also exposes a [`consumer()`](https://docs.rs/moq-net/latest/moq_net/struct.Session.html#method.consumer) [`origin::Consumer`](https://docs.rs/moq-net/latest/moq_net/origin/struct.Consumer.html) for receiving announcements:
 
 ```rust
 let session = client.connect(url).await?;

--- a/doc/setup/demo/boy.md
+++ b/doc/setup/demo/boy.md
@@ -92,7 +92,7 @@ The emulator and viewer use configurable path prefixes to separate authenticated
 ### Discovery
 
 - **Viewers discover sessions** — subscribe to announcements with the game prefix, filter to single-component suffixes
-- **Emulator discovers viewers** — subscribes to the viewer prefix using `OriginProducer::with_root()`
+- **Emulator discovers viewers** — subscribes to the viewer prefix using `origin::Producer::with_root()`
 
 ### Auto-Pause
 

--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -10,7 +10,7 @@ Layered roughly transport -> container/format -> media -> apps/bindings.
 
 **Transport / protocol**
 
-- `moq-net` (lib): the core wire layer. Negotiates `moq-lite` or IETF `moq-transport`. Owns the Broadcast/Track/Group/Frame model and the Producer/Consumer split (see below). Generic over `web_transport_trait::Session` (no concrete QUIC dep). Submodules are private; the public surface is re-exported flat from the crate root.
+- `moq-net` (lib): the core wire layer. Negotiates `moq-lite` or IETF `moq-transport`. Owns the Broadcast/Track/Group/Frame model and the Producer/Consumer split (see below). Generic over `web_transport_trait::Session` (no concrete QUIC dep). Each level of the hierarchy is a public role module that owns short names (`broadcast::Consumer`, `track::Producer`, `group::Info`, `frame::Producer`, `origin::Consumer`, `announce::Consumer`); origin + announce share one private implementation surfaced as two curated modules.
 - `moq-native` (lib): native connection helpers. `ClientConfig`/`ServerConfig` wrap QUIC backends (Quinn/Quiche/Noq/Iroh), WebTransport, WebSocket, TCP (qmux), Unix sockets, TLS, cert hot-reload, logging, jemalloc. Re-exports `moq_net`. Example: `examples/clock.rs`.
 - `kio` (lib): "easy async". `Producer<T>`/`Consumer<T>` shared-state channels with `Waiter`-based notification, built on `std::task::Waker`, no runtime dependency. Underpins all the `poll_*` plumbing in moq-net and moq-mux. `src/producer.rs`, `src/consumer.rs`, `src/waiter.rs`.
 
@@ -51,18 +51,20 @@ When you change `moq-ffi`'s surface, mirror it in `libmoq` and the language wrap
 
 The whole stack is built on a split-handle pattern: a `Producer` writes, one or more `Consumer`s read, state is shared via `kio`. This recurs in moq-net, moq-mux, moq-json.
 
-- Broadcast: `BroadcastProducer` / `BroadcastConsumer` / `BroadcastDynamic` (`model/broadcast.rs:74,370,216`).
-- Track: `TrackProducer` / `TrackConsumer` / `TrackWeak` (`model/track.rs:206,459,425`).
-- Group: `GroupProducer` / `GroupConsumer` (`model/group.rs:140,286`). Consumers `clone()` for fanout.
-- Frame: `FrameProducer` (impls `BufMut`) / `FrameConsumer` (`model/frame.rs:162,317`).
-- Origin: `OriginProducer` / `OriginConsumer` (`model/origin.rs`).
+Each level is a role module (`broadcast`, `track`, `group`, `frame`, `origin`, `announce`) owning short `Producer`/`Consumer` names:
+
+- Broadcast: `broadcast::{Producer, Consumer, Dynamic}` (`model/broadcast.rs`).
+- Track: `track::{Producer, Consumer, Subscriber, ...}` plus the `pub(crate)` `track::TrackWeak` (`model/track.rs`).
+- Group: `group::{Producer, Consumer, Info}` (`model/group.rs`). Consumers `clone()` for fanout.
+- Frame: `frame::Producer` (impls `BufMut`) / `frame::Consumer` (`model/frame.rs`).
+- Origin: `origin::{Producer, Consumer}` for the broadcast set; `announce::{Producer, Consumer}` for (un)announce events. Both share the private `origin.rs` implementation (`mod origin_impl`), surfaced via `model/mod.rs`.
 
 ## Async / poll plumbing
 
 Two ways to drive things, both backed by `kio`:
 
 - `async fn` (requires an active tokio runtime; awaiting outside one may panic, see `moq-net/src/lib.rs:42`).
-- `poll_*` counterparts that take a `&kio::Waiter` and return `Poll<...>`, drivable from any executor or synchronously (`kio` is built on `std::task::Waker`). The `async` method usually just wraps the `poll_*` one via `kio::wait`. Example pair: `TrackConsumer::poll_recv_group` / `recv_group` (`moq-net/src/model/track.rs:502,518`).
+- `poll_*` counterparts that take a `&kio::Waiter` and return `Poll<...>`, drivable from any executor or synchronously (`kio` is built on `std::task::Waker`). The `async` method usually just wraps the `poll_*` one via `kio::wait`. Example pair: `track::Consumer::poll_recv_group` / `recv_group` (`moq-net/src/model/track.rs`).
 
 Follow the root `poll_*` conventions: collapse `Poll::Pending => Poll::Pending` with `ready!(...)`, and prefer `Ok(x?)` over `.map_err(Into::into)` so a fallible poll reads `let v = ready!(inner.poll_next(cx))?;`. Representative `ready!` sites: `moq-mux/src/container/consumer.rs:201`, `moq-net/src/model/group.rs`.
 

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
 
 // Connect to the server and subscribe to broadcasts.
 // Automatically reconnects if the connection drops.
-async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
+async fn run_session(origin: moq_net::origin::Producer) -> anyhow::Result<()> {
 	// Optional: Use moq_native to make a QUIC client.
 	let client = moq_native::ClientConfig::default().init()?;
 
@@ -40,7 +40,7 @@ async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 }
 
 // Subscribe to a broadcast and read media frames.
-async fn run_subscribe(consumer: moq_net::OriginConsumer) -> anyhow::Result<()> {
+async fn run_subscribe(consumer: moq_net::origin::Consumer) -> anyhow::Result<()> {
 	// Wait for a broadcast to be announced.
 	let (path, broadcast) = consumer.announced().next().await.context("origin closed")?;
 

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -21,7 +21,7 @@ async fn main() -> anyhow::Result<()> {
 
 // Connect to the server and publish our origin of broadcasts.
 // Automatically reconnects if the connection drops.
-async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
+async fn run_session(origin: moq_net::origin::Producer) -> anyhow::Result<()> {
 	// Optional: Use moq_native to make a QUIC client.
 	let client = moq_native::ClientConfig::default().init()?;
 
@@ -41,7 +41,7 @@ async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 
 // Create a video track with a catalog that describes it.
 // The catalog can contain multiple tracks, used by the viewer to choose the best track.
-fn create_track(broadcast: &mut moq_net::BroadcastProducer) -> anyhow::Result<moq_net::TrackProducer> {
+fn create_track(broadcast: &mut moq_net::broadcast::Producer) -> anyhow::Result<moq_net::track::Producer> {
 	// Basic information about the video track.
 	let video_track = "video";
 
@@ -88,9 +88,9 @@ fn create_track(broadcast: &mut moq_net::BroadcastProducer) -> anyhow::Result<mo
 }
 
 // Produce a broadcast and publish it to the origin.
-async fn run_broadcast(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
+async fn run_broadcast(origin: moq_net::origin::Producer) -> anyhow::Result<()> {
 	// Create and publish a broadcast to the origin.
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let track = create_track(&mut broadcast)?;
 
 	// NOTE: The path is empty because we're using the URL to scope the broadcast.

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -76,10 +76,10 @@ impl Catalog {
 	}
 
 	/// Track properties for creating the catalog track via
-	/// [`create_track`](moq_net::BroadcastProducer::create_track) at
+	/// [`create_track`](moq_net::broadcast::Producer::create_track) at
 	/// [`DEFAULT_NAME`](Self::DEFAULT_NAME).
-	pub fn default_track_info() -> moq_net::TrackInfo {
-		moq_net::TrackInfo::default()
+	pub fn default_track_info() -> moq_net::track::Info {
+		moq_net::track::Info::default()
 	}
 
 	/// The subscription preferences used for the catalog track (high priority so

--- a/rs/hang/src/container/frame.rs
+++ b/rs/hang/src/container/frame.rs
@@ -41,7 +41,7 @@ impl Frame {
 	/// The timestamp is normalized to [`TIMESCALE`] (microseconds) on the wire so
 	/// peers using a different source scale (e.g. nanoseconds from MKV) can decode
 	/// without knowing the producer's internal scale.
-	pub fn encode(&self, group: &mut moq_net::GroupProducer) -> Result<(), Error> {
+	pub fn encode(&self, group: &mut moq_net::group::Producer) -> Result<(), Error> {
 		let timestamp = self.timestamp.convert(TIMESCALE)?;
 		let value = VarInt::try_from(timestamp.value()).map_err(moq_net::Error::from)?;
 
@@ -53,7 +53,7 @@ impl Frame {
 		// Stamp the moq-net frame timestamp too so Lite05+ can delta-encode it on the
 		// wire independently of the container-level prefix. `create_frame` converts it
 		// into the track's timescale; older drafts simply don't put it on the wire.
-		let net_frame = moq_net::FrameInfo {
+		let net_frame = moq_net::frame::Info {
 			size,
 			timestamp: self.timestamp,
 		};

--- a/rs/libmoq/src/audio.rs
+++ b/rs/libmoq/src/audio.rs
@@ -144,7 +144,7 @@ struct AudioTaskEntry {
 impl Audio {
 	pub fn publish(
 		&mut self,
-		broadcast: &mut moq_net::BroadcastProducer,
+		broadcast: &mut moq_net::broadcast::Producer,
 		catalog: moq_mux::catalog::Producer<moq_mux::catalog::hang::Extra>,
 		name: &str,
 		input: moq_audio::EncoderInput,
@@ -168,7 +168,7 @@ impl Audio {
 
 	pub fn consume(
 		&mut self,
-		broadcast: &moq_net::BroadcastConsumer,
+		broadcast: &moq_net::broadcast::Consumer,
 		catalog: &hang::catalog::AudioConfig,
 		name: &str,
 		output: moq_audio::DecoderOutput,

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -5,7 +5,7 @@ use crate::ffi::OnStatus;
 use crate::{Error, Id, NonZeroSlab, State, moq_audio_config, moq_frame, moq_section, moq_string, moq_video_config};
 
 struct ConsumeCatalog {
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 
 	// Carries the untyped `Extra` extension so application catalog sections survive
 	// into `moq_catalog_section_*` instead of being dropped on parse.
@@ -34,7 +34,7 @@ struct TaskEntry {
 #[derive(Default)]
 pub struct Consume {
 	/// Active broadcast consumers.
-	broadcast: NonZeroSlab<moq_net::BroadcastConsumer>,
+	broadcast: NonZeroSlab<moq_net::broadcast::Consumer>,
 
 	/// Active catalog consumers and their broadcast references.
 	catalog: NonZeroSlab<ConsumeCatalog>,
@@ -56,7 +56,7 @@ pub struct Consume {
 }
 
 impl Consume {
-	pub fn start(&mut self, broadcast: moq_net::BroadcastConsumer) -> Result<Id, Error> {
+	pub fn start(&mut self, broadcast: moq_net::broadcast::Consumer) -> Result<Id, Error> {
 		self.broadcast.insert(broadcast)
 	}
 
@@ -95,7 +95,7 @@ impl Consume {
 
 	async fn run_catalog(
 		callback: OnStatus,
-		broadcast: moq_net::BroadcastConsumer,
+		broadcast: moq_net::broadcast::Consumer,
 		mut catalog: moq_mux::catalog::hang::Consumer<moq_mux::catalog::hang::Extra>,
 		mut close: oneshot::Receiver<()>,
 	) -> Result<(), Error> {
@@ -483,7 +483,7 @@ impl Consume {
 
 	async fn run_raw(
 		callback: OnStatus,
-		mut track: moq_net::TrackSubscriber,
+		mut track: moq_net::track::Subscriber,
 		mut close: oneshot::Receiver<()>,
 	) -> Result<(), Error> {
 		// Deliver every frame in sequence order, reading all frames within each
@@ -557,7 +557,7 @@ impl Consume {
 		&self,
 		catalog: Id,
 		index: usize,
-	) -> Result<(moq_net::BroadcastConsumer, hang::catalog::VideoConfig, String), Error> {
+	) -> Result<(moq_net::broadcast::Consumer, hang::catalog::VideoConfig, String), Error> {
 		let consume = self.catalog.get(catalog).ok_or(Error::CatalogNotFound)?;
 		let (name, config) = consume
 			.catalog
@@ -576,7 +576,7 @@ impl Consume {
 		&self,
 		catalog: Id,
 		index: usize,
-	) -> Result<(moq_net::BroadcastConsumer, hang::catalog::AudioConfig, String), Error> {
+	) -> Result<(moq_net::broadcast::Consumer, hang::catalog::AudioConfig, String), Error> {
 		let consume = self.catalog.get(catalog).ok_or(Error::CatalogNotFound)?;
 		let (name, config) = consume
 			.catalog

--- a/rs/libmoq/src/origin.rs
+++ b/rs/libmoq/src/origin.rs
@@ -23,11 +23,11 @@ struct TaskEntry {
 #[derive(Default)]
 pub struct Origin {
 	/// Active origin producers for publishing and consuming broadcasts.
-	active: NonZeroSlab<moq_net::OriginProducer>,
+	active: NonZeroSlab<moq_net::origin::Producer>,
 
 	/// Announcement guards from `publish`. Removing an entry (via `unpublish`) drops the
 	/// guard, which unannounces the broadcast.
-	published: NonZeroSlab<moq_net::OriginPublish>,
+	published: NonZeroSlab<moq_net::origin::Publish>,
 
 	/// Broadcast announcement information (path, active status).
 	announced: NonZeroSlab<(String, bool)>,
@@ -44,7 +44,7 @@ impl Origin {
 		self.active.insert(moq_net::Origin::random().produce())
 	}
 
-	pub fn get(&self, id: Id) -> Result<&moq_net::OriginProducer, Error> {
+	pub fn get(&self, id: Id) -> Result<&moq_net::origin::Producer, Error> {
 		self.active.get(id).ok_or(Error::OriginNotFound)
 	}
 
@@ -75,7 +75,7 @@ impl Origin {
 
 	async fn run_announced(
 		callback: OnStatus,
-		mut consumer: moq_net::AnnounceConsumer,
+		mut consumer: moq_net::announce::Consumer,
 		mut close: oneshot::Receiver<()>,
 	) -> Result<(), Error> {
 		loop {
@@ -165,7 +165,7 @@ impl Origin {
 
 	async fn run_consume_announced(
 		callback: OnStatus,
-		consumer: moq_net::OriginConsumer,
+		consumer: moq_net::origin::Consumer,
 		path: String,
 		mut close: oneshot::Receiver<()>,
 	) -> Result<(), Error> {
@@ -216,7 +216,7 @@ impl Origin {
 
 	async fn run_request(
 		callback: OnStatus,
-		consumer: moq_net::OriginConsumer,
+		consumer: moq_net::origin::Consumer,
 		path: String,
 		mut close: oneshot::Receiver<()>,
 	) -> Result<(), Error> {
@@ -256,7 +256,7 @@ impl Origin {
 		&mut self,
 		origin: Id,
 		path: P,
-		broadcast: moq_net::BroadcastConsumer,
+		broadcast: moq_net::broadcast::Consumer,
 	) -> Result<Id, Error> {
 		let origin = self.active.get(origin).ok_or(Error::OriginNotFound)?;
 		let publish = origin.publish_broadcast(path, &broadcast)?;

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -15,21 +15,21 @@ enum Media {
 #[derive(Default)]
 pub struct Publish {
 	/// Active broadcast producers for publishing.
-	broadcasts: NonZeroSlab<(moq_net::BroadcastProducer, moq_mux::catalog::Producer<Extra>)>,
+	broadcasts: NonZeroSlab<(moq_net::broadcast::Producer, moq_mux::catalog::Producer<Extra>)>,
 
 	/// Active media encoders/decoders for publishing.
 	media: NonZeroSlab<Media>,
 
 	/// Raw track producers (no media/container/catalog framing).
-	tracks: NonZeroSlab<moq_net::TrackProducer>,
+	tracks: NonZeroSlab<moq_net::track::Producer>,
 
 	/// Raw group producers, created from a raw track producer.
-	groups: NonZeroSlab<moq_net::GroupProducer>,
+	groups: NonZeroSlab<moq_net::group::Producer>,
 }
 
 impl Publish {
 	pub fn create(&mut self) -> Result<Id, Error> {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog =
 			moq_mux::catalog::Producer::with_catalog(&mut broadcast, moq_mux::catalog::hang::Catalog::default())?;
 
@@ -37,7 +37,7 @@ impl Publish {
 		Ok(id)
 	}
 
-	pub fn get(&self, id: Id) -> Result<&moq_net::BroadcastProducer, Error> {
+	pub fn get(&self, id: Id) -> Result<&moq_net::broadcast::Producer, Error> {
 		self.broadcasts
 			.get(id)
 			.ok_or(Error::BroadcastNotFound)
@@ -50,7 +50,13 @@ impl Publish {
 	pub fn pair_mut(
 		&mut self,
 		id: Id,
-	) -> Result<(&mut moq_net::BroadcastProducer, &mut moq_mux::catalog::Producer<Extra>), Error> {
+	) -> Result<
+		(
+			&mut moq_net::broadcast::Producer,
+			&mut moq_mux::catalog::Producer<Extra>,
+		),
+		Error,
+	> {
 		let (broadcast, catalog) = self.broadcasts.get_mut(id).ok_or(Error::BroadcastNotFound)?;
 		Ok((broadcast, catalog))
 	}

--- a/rs/libmoq/src/session.rs
+++ b/rs/libmoq/src/session.rs
@@ -28,8 +28,8 @@ impl Session {
 	pub fn connect(
 		&mut self,
 		url: Url,
-		publish: Option<moq_net::OriginProducer>,
-		consume: Option<moq_net::OriginProducer>,
+		publish: Option<moq_net::origin::Producer>,
+		consume: Option<moq_net::origin::Producer>,
 		callback: ffi::OnStatus,
 	) -> Result<Id, Error> {
 		let mut client = moq_native::ClientConfig::default().init()?;

--- a/rs/libmoq/src/video.rs
+++ b/rs/libmoq/src/video.rs
@@ -74,7 +74,7 @@ struct VideoTaskEntry {
 impl Video {
 	pub fn consume(
 		&mut self,
-		broadcast: &moq_net::BroadcastConsumer,
+		broadcast: &moq_net::broadcast::Consumer,
 		catalog: &hang::catalog::VideoConfig,
 		name: &str,
 		config: moq_video::decode::Config,

--- a/rs/moq-audio/src/capture.rs
+++ b/rs/moq-audio/src/capture.rs
@@ -181,7 +181,7 @@ impl Microphone {
 /// (codec, bitrate, frame duration) from [`EncoderOutput`]. Returns when the
 /// broadcast is dropped or the capture loop fails.
 pub async fn publish_microphone(
-	mut broadcast: moq_net::BroadcastProducer,
+	mut broadcast: moq_net::broadcast::Producer,
 	catalog: moq_mux::catalog::Producer,
 	config: Config,
 	track_name: impl Into<String>,
@@ -218,7 +218,7 @@ pub async fn publish_microphone(
 /// and stops the cpal stream. No blocking thread is left behind.
 async fn capture_loop(
 	producer: &mut AudioProducer,
-	track: &moq_net::TrackProducer,
+	track: &moq_net::track::Producer,
 	config: &Config,
 	clock: &moq_mux::Clock,
 ) -> Result<(), AudioError> {

--- a/rs/moq-audio/src/consumer.rs
+++ b/rs/moq-audio/src/consumer.rs
@@ -24,7 +24,7 @@ impl AudioConsumer {
 	/// Subscribe to `name` in `broadcast` using the catalog entry to
 	/// pick the codec.
 	pub async fn new(
-		broadcast: &moq_net::BroadcastConsumer,
+		broadcast: &moq_net::broadcast::Consumer,
 		catalog: &hang::catalog::AudioConfig,
 		name: impl Into<String>,
 		output: DecoderOutput,

--- a/rs/moq-audio/src/producer.rs
+++ b/rs/moq-audio/src/producer.rs
@@ -40,7 +40,7 @@ impl<E: CatalogExt> AudioProducer<E> {
 	/// Build a producer for `name` on `broadcast`, registering the
 	/// rendition in `catalog` immediately.
 	pub fn new(
-		broadcast: &mut moq_net::BroadcastProducer,
+		broadcast: &mut moq_net::broadcast::Producer,
 		catalog: moq_mux::catalog::Producer<E>,
 		name: impl Into<String>,
 		input: EncoderInput,
@@ -69,7 +69,7 @@ impl<E: CatalogExt> AudioProducer<E> {
 		// layer accepts Frame::timestamp on append.
 		let track = broadcast.create_track(
 			name.clone(),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)?;
 		let track = moq_mux::container::Producer::new(track, moq_mux::container::legacy::Wire);
 
@@ -93,8 +93,8 @@ impl<E: CatalogExt> AudioProducer<E> {
 	}
 
 	/// The underlying track producer, e.g. to watch subscriber state via
-	/// [`used`](moq_net::TrackProducer::used) / [`unused`](moq_net::TrackProducer::unused).
-	pub fn track(&self) -> &moq_net::TrackProducer {
+	/// [`used`](moq_net::track::Producer::used) / [`unused`](moq_net::track::Producer::unused).
+	pub fn track(&self) -> &moq_net::track::Producer {
 		self.track.track()
 	}
 
@@ -211,7 +211,7 @@ mod tests {
 	/// If `reset_before` contains an index, `reset_epoch()` is called before that
 	/// frame's `write`.
 	async fn published_pts(frames: &[Frame], reset_before: Option<usize>) -> Vec<u128> {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 		let consumer = broadcast.consume();
 

--- a/rs/moq-audio/tests/roundtrip.rs
+++ b/rs/moq-audio/tests/roundtrip.rs
@@ -30,7 +30,7 @@ fn f32_bytes(samples: &[f32]) -> Bytes {
 
 #[tokio::test]
 async fn opus_round_trip_48k_stereo() {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut catalog_consumer = catalog.consume().unwrap();
 	let broadcast_consumer = broadcast.consume();
@@ -110,7 +110,7 @@ async fn opus_round_trip_48k_stereo() {
 
 #[tokio::test]
 async fn opus_round_trip_44100_s16_resampled() {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut catalog_consumer = catalog.consume().unwrap();
 	let broadcast_consumer = broadcast.consume();

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -4,7 +4,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use moq_native::Status;
-use moq_native::moq_net::{self, BroadcastConsumer, BroadcastInfo, Origin, TrackProducer, bytes::Bytes};
+use moq_native::moq_net::{self, Origin, bytes::Bytes};
+use moq_native::moq_net::{broadcast, track};
 use rand::RngExt;
 use serde::{Deserialize, Serialize};
 use tokio::task::JoinSet;
@@ -91,7 +92,7 @@ pub async fn run(ctx: Connection) {
 	for index in 0..rolled.broadcasts {
 		let path = format!("{name}/{run_id:08x}/{connection}/{index}");
 
-		let mut broadcast = BroadcastInfo::new().produce();
+		let mut broadcast = broadcast::Info::new().produce();
 		let track = match broadcast.create_track(TRACK, None) {
 			Ok(track) => track,
 			Err(err) => {
@@ -173,7 +174,7 @@ async fn produce(
 	connection: u64,
 	path: String,
 	rolled: Rolled,
-	mut track: TrackProducer,
+	mut track: track::Producer,
 	stats: Arc<Stats>,
 ) -> anyhow::Result<()> {
 	let _gauge = Gauge::inc(&stats.broadcasts);
@@ -228,7 +229,7 @@ async fn produce(
 /// Watch announcements and drain up to `want` peer broadcasts (excluding our own),
 /// spreading each subscription's start over `startup` to avoid a thundering herd.
 async fn subscribe(
-	mut announced: moq_net::AnnounceConsumer,
+	mut announced: moq_net::announce::Consumer,
 	own: HashSet<String>,
 	want: u64,
 	startup: Duration,
@@ -272,7 +273,7 @@ async fn subscribe(
 
 /// Subscribe to the broadcast's track, counting every frame received and tracking
 /// group-sequence gaps to report skipped groups.
-async fn drain(broadcast: BroadcastConsumer, stats: &Stats) -> anyhow::Result<()> {
+async fn drain(broadcast: broadcast::Consumer, stats: &Stats) -> anyhow::Result<()> {
 	let _gauge = Gauge::inc(&stats.subscriptions);
 
 	let mut track = broadcast.track(TRACK)?.subscribe(None).await?;
@@ -418,7 +419,7 @@ mod tests {
 		tokio::time::pause();
 
 		let stats = Arc::new(Stats::default());
-		let mut broadcast = BroadcastInfo::new().produce();
+		let mut broadcast = broadcast::Info::new().produce();
 		let track = broadcast.create_track(TRACK, None).unwrap();
 		let consumer = broadcast.consume();
 
@@ -456,7 +457,7 @@ mod tests {
 		tokio::time::pause();
 
 		let stats = Arc::new(Stats::default());
-		let mut broadcast = BroadcastInfo::new().produce();
+		let mut broadcast = broadcast::Info::new().produce();
 		let track = broadcast.create_track(TRACK, None).unwrap();
 		let consumer = broadcast.consume();
 

--- a/rs/moq-boy/src/audio.rs
+++ b/rs/moq-boy/src/audio.rs
@@ -21,7 +21,7 @@ pub struct AudioEncoder {
 
 impl AudioEncoder {
 	pub fn new(
-		mut broadcast: moq_net::BroadcastProducer,
+		mut broadcast: moq_net::broadcast::Producer,
 		catalog: moq_mux::catalog::Producer,
 		input_sample_rate: u32,
 	) -> Result<Self> {
@@ -39,7 +39,7 @@ impl AudioEncoder {
 		Ok(Self { producer })
 	}
 
-	pub fn track(&self) -> &moq_net::TrackProducer {
+	pub fn track(&self) -> &moq_net::track::Producer {
 		self.producer.track()
 	}
 

--- a/rs/moq-boy/src/input.rs
+++ b/rs/moq-boy/src/input.rs
@@ -61,7 +61,7 @@ pub enum Command {
 
 /// Handles discovered viewers: subscribes to their command tracks.
 pub async fn handle_viewers(
-	viewer_origin: &mut moq_net::AnnounceConsumer,
+	viewer_origin: &mut moq_net::announce::Consumer,
 	cmd_tx: &tokio::sync::mpsc::Sender<Command>,
 ) -> anyhow::Result<()> {
 	loop {
@@ -96,7 +96,7 @@ pub async fn handle_viewers(
 
 async fn handle_viewer_commands(
 	viewer_id: &str,
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 	cmd_tx: &tokio::sync::mpsc::Sender<Command>,
 ) -> anyhow::Result<()> {
 	let track = broadcast.track("command")?.subscribe(None).await?;

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -90,8 +90,8 @@ pub struct Config {
 /// track monitors, and async tasks.
 struct Session {
 	video_encoder: video::VideoEncoder,
-	video_track: moq_net::TrackDemand,
-	audio_track: moq_net::TrackDemand,
+	video_track: moq_net::track::Demand,
+	audio_track: moq_net::track::Demand,
 
 	/// Whether anyone is subscribed to the video/audio tracks.
 	video_active: AtomicBool,
@@ -109,7 +109,7 @@ struct Session {
 impl Session {
 	/// Monitor a single track's subscription state.
 	/// Sets the flag when a viewer subscribes, clears it when all unsubscribe.
-	async fn run_track_monitor(&self, name: &str, track: &moq_net::TrackDemand, flag: &AtomicBool) {
+	async fn run_track_monitor(&self, name: &str, track: &moq_net::track::Demand, flag: &AtomicBool) {
 		loop {
 			if track.used().await.is_err() {
 				break;
@@ -209,7 +209,7 @@ async fn run(config: &Config) -> Result<()> {
 	let client = config.client.clone().init()?;
 
 	// Create the broadcast producer.
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 
 	// Publish origin: the game session broadcast.
 	let publish_origin = moq_net::Origin::random().produce();

--- a/rs/moq-boy/src/status.rs
+++ b/rs/moq-boy/src/status.rs
@@ -39,7 +39,7 @@ pub struct StatusPublisher {
 }
 
 impl StatusPublisher {
-	pub fn new(broadcast: &mut moq_net::BroadcastProducer) -> anyhow::Result<Self> {
+	pub fn new(broadcast: &mut moq_net::broadcast::Producer) -> anyhow::Result<Self> {
 		let producer = broadcast.create_track("status", None)?;
 
 		Ok(Self {

--- a/rs/moq-boy/src/video.rs
+++ b/rs/moq-boy/src/video.rs
@@ -20,7 +20,7 @@ use crate::emulator::{HEIGHT, WIDTH};
 pub struct VideoEncoder {
 	tx: tokio::sync::mpsc::Sender<EncoderMsg>,
 	/// Watch-only handle to the video track, for monitoring used/unused.
-	pub demand: moq_net::TrackDemand,
+	pub demand: moq_net::track::Demand,
 	force_keyframe: Arc<AtomicBool>,
 	/// Latest encode duration in microseconds.
 	encode_duration: Arc<AtomicU64>,
@@ -33,7 +33,7 @@ struct EncoderMsg {
 }
 
 impl VideoEncoder {
-	pub fn spawn(broadcast: moq_net::BroadcastProducer, catalog: moq_mux::catalog::Producer) -> Self {
+	pub fn spawn(broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Self {
 		let (tx, rx) = tokio::sync::mpsc::channel(4);
 		let producer = moq_video::encode::Producer::new(broadcast, catalog, moq_video::encode::Codec::H264)
 			.expect("failed to create avc3 producer");

--- a/rs/moq-cli/src/hls.rs
+++ b/rs/moq-cli/src/hls.rs
@@ -48,8 +48,8 @@ pub struct ExportArgs {
 }
 
 /// Pull a remote HLS/LL-HLS playlist (URL or file path) into the Origin under `name`.
-pub async fn import(origin: &moq_net::OriginProducer, name: String, playlist: String) -> anyhow::Result<()> {
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+pub async fn import(origin: &moq_net::origin::Producer, name: String, playlist: String) -> anyhow::Result<()> {
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	// Hold the RAII announcement for the lifetime of the import.
 	let _announce = origin
 		.publish_broadcast(&name, producer.consume())
@@ -67,7 +67,7 @@ pub async fn import(origin: &moq_net::OriginProducer, name: String, playlist: St
 
 /// Serve HLS/LL-HLS over HTTP for the single broadcast `name` (reached at
 /// `/<name>/master.m3u8`); other broadcasts in the Origin are not served.
-pub async fn export(origin: moq_net::OriginConsumer, args: ExportArgs, name: String) -> anyhow::Result<()> {
+pub async fn export(origin: moq_net::origin::Consumer, args: ExportArgs, name: String) -> anyhow::Result<()> {
 	let scoped = origin
 		.scope(&[name.as_path()])
 		.with_context(|| format!("failed to scope origin to broadcast `{name}`"))?;

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -262,7 +262,7 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 }
 
 /// Subscribe to `name` from the Origin and write it to stdout.
-async fn run_stdout(consumer: moq_net::OriginConsumer, name: String, args: SubscribeArgs) -> anyhow::Result<()> {
+async fn run_stdout(consumer: moq_net::origin::Consumer, name: String, args: SubscribeArgs) -> anyhow::Result<()> {
 	let catalog = args.catalog_format(&name);
 	let broadcast = consumer
 		.announced_broadcast(&name)

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -165,13 +165,13 @@ enum Source {
 /// a broadcast that the MoQ side announces.
 pub struct Publish {
 	source: Source,
-	broadcast: moq_net::BroadcastProducer,
+	broadcast: moq_net::broadcast::Producer,
 }
 
 impl Publish {
 	/// Build a publisher decoding the given container format from stdin.
 	pub fn new(format: &PublishFormat) -> anyhow::Result<Self> {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 
 		// TS carries undecoded elementary streams (SCTE-35, teletext, DVB AC-3, ...)
 		// verbatim, so it uses the `mpegts` catalog extension rather than the media-only
@@ -217,7 +217,7 @@ impl Publish {
 	/// Build a publisher capturing local devices (camera/screen and microphone).
 	#[cfg(feature = "capture")]
 	pub fn capture(args: &CaptureArgs) -> anyhow::Result<Self> {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 
 		let video = (!args.no_video).then(|| (args.video_config(), args.video_encode()));
@@ -231,7 +231,7 @@ impl Publish {
 	}
 
 	/// A consumer of the broadcast being published, for announcing it on an Origin.
-	pub fn consume(&self) -> moq_net::BroadcastConsumer {
+	pub fn consume(&self) -> moq_net::broadcast::Consumer {
 		self.broadcast.consume()
 	}
 
@@ -391,7 +391,7 @@ mod tests {
 	/// `bbb.ts` into a broadcast that also holds the two ancillary tracks and
 	/// re-exporting with the `mpegts` catalog extension.
 	async fn manufacture_input() -> Vec<u8> {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let consumer = broadcast.consume();
 		let mut catalog =
 			moq_mux::catalog::Producer::with_catalog(&mut broadcast, Catalog::<tscat::Ext>::default()).unwrap();
@@ -400,7 +400,7 @@ mod tests {
 		let section = broadcast
 			.unique_track(
 				".scte35",
-				moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 			)
 			.unwrap();
 		let mut section_track = tscat::Track::new(SECTION_PID);
@@ -430,7 +430,7 @@ mod tests {
 		let pes = broadcast
 			.unique_track(
 				".data",
-				moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 			)
 			.unwrap();
 		let mut verbatim = tscat::Verbatim::new(0x06, tscat::Framing::Pes);
@@ -498,7 +498,7 @@ mod tests {
 		.await;
 
 		// Re-import the round-tripped TS and inspect the recovered `mpegts` section.
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let consumer = broadcast.consume();
 		let catalog =
 			moq_mux::catalog::Producer::with_catalog(&mut broadcast, Catalog::<tscat::Ext>::default()).unwrap();
@@ -550,7 +550,7 @@ mod tests {
 	}
 
 	/// Read the first frame of a verbatim track back as raw bytes.
-	async fn read_frame(consumer: &moq_net::BroadcastConsumer, name: &str) -> Vec<u8> {
+	async fn read_frame(consumer: &moq_net::broadcast::Consumer, name: &str) -> Vec<u8> {
 		let track = consumer.track(name).unwrap().subscribe(None).await.unwrap();
 		let mut reader = Consumer::new(track, Container::Legacy).with_latency(Duration::ZERO);
 		let frame = tokio::time::timeout(Duration::from_secs(1), reader.read())

--- a/rs/moq-cli/src/rtc.rs
+++ b/rs/moq-cli/src/rtc.rs
@@ -41,7 +41,7 @@ pub struct Args {
 
 /// WHIP server: accept incoming WebRTC publishes into the Origin as `name` (import).
 pub async fn listen_import(
-	origin: moq_net::OriginProducer,
+	origin: moq_net::origin::Producer,
 	listen: SocketAddr,
 	udp_bind: SocketAddr,
 	public_addr: Vec<SocketAddr>,
@@ -55,7 +55,7 @@ pub async fn listen_import(
 
 /// WHEP server: serve WebRTC plays of `name` from the Origin (export).
 pub async fn listen_export(
-	origin: moq_net::OriginConsumer,
+	origin: moq_net::origin::Consumer,
 	listen: SocketAddr,
 	udp_bind: SocketAddr,
 	public_addr: Vec<SocketAddr>,
@@ -73,15 +73,15 @@ pub async fn listen_export(
 }
 
 /// Restrict a producer to the single broadcast `name` so a WHIP peer can only publish it.
-fn scope_producer(origin: &moq_net::OriginProducer, name: &str) -> anyhow::Result<moq_net::OriginProducer> {
+fn scope_producer(origin: &moq_net::origin::Producer, name: &str) -> anyhow::Result<moq_net::origin::Producer> {
 	origin
 		.scope(&[name.as_path()])
 		.with_context(|| format!("failed to scope origin to broadcast `{name}`"))
 }
 
 /// WHEP client: pull a remote broadcast into the Origin under `name` (import).
-pub async fn connect_import(origin: moq_net::OriginProducer, url: Url, name: String) -> anyhow::Result<()> {
-	let producer = moq_net::BroadcastInfo::new().produce();
+pub async fn connect_import(origin: moq_net::origin::Producer, url: Url, name: String) -> anyhow::Result<()> {
+	let producer = moq_net::broadcast::Info::new().produce();
 	// Hold the RAII announcement for the lifetime of the pull.
 	let _announce = origin
 		.publish_broadcast(&name, producer.consume())
@@ -95,7 +95,7 @@ pub async fn connect_import(origin: moq_net::OriginProducer, url: Url, name: Str
 }
 
 /// WHIP client: push a broadcast from the Origin to a remote (export).
-pub async fn connect_export(origin: moq_net::OriginConsumer, url: Url, name: String) -> anyhow::Result<()> {
+pub async fn connect_export(origin: moq_net::origin::Consumer, url: Url, name: String) -> anyhow::Result<()> {
 	let broadcast = origin
 		.announced_broadcast(&name)
 		.await
@@ -109,8 +109,8 @@ pub async fn connect_export(origin: moq_net::OriginConsumer, url: Url, name: Str
 }
 
 fn server(
-	publisher: moq_net::OriginProducer,
-	subscriber: moq_net::OriginConsumer,
+	publisher: moq_net::origin::Producer,
+	subscriber: moq_net::origin::Consumer,
 	udp_bind: SocketAddr,
 	public_addr: Vec<SocketAddr>,
 ) -> moq_rtc::Server {

--- a/rs/moq-cli/src/rtmp.rs
+++ b/rs/moq-cli/src/rtmp.rs
@@ -42,7 +42,7 @@ pub struct ExportArgs {
 }
 
 /// Accept incoming RTMP publishes into the Origin as `name`; reject plays (import).
-pub async fn listen_import(origin: moq_net::OriginProducer, addr: SocketAddr, name: String) -> anyhow::Result<()> {
+pub async fn listen_import(origin: moq_net::origin::Producer, addr: SocketAddr, name: String) -> anyhow::Result<()> {
 	let mut server = Server::bind(addr).await?;
 	tracing::info!(%addr, %name, "RTMP listening (import)");
 	notify_ready();
@@ -72,7 +72,7 @@ pub async fn listen_import(origin: moq_net::OriginProducer, addr: SocketAddr, na
 
 /// Serve RTMP plays of `name` from the Origin; reject publishes (export).
 pub async fn listen_export(
-	origin: moq_net::OriginConsumer,
+	origin: moq_net::origin::Consumer,
 	addr: SocketAddr,
 	name: String,
 	latency: Duration,
@@ -107,7 +107,7 @@ pub async fn listen_export(
 }
 
 /// Dial a remote RTMP server and pull its play into the Origin under `name` (import).
-pub async fn connect_import(origin: moq_net::OriginProducer, url: Url, name: String) -> anyhow::Result<()> {
+pub async fn connect_import(origin: moq_net::origin::Producer, url: Url, name: String) -> anyhow::Result<()> {
 	let (addr, app, key) = parse_url(&url).await?;
 	tracing::info!(%url, %name, "RTMP client pulling");
 	notify_ready();
@@ -118,7 +118,7 @@ pub async fn connect_import(origin: moq_net::OriginProducer, url: Url, name: Str
 
 /// Push a broadcast from the Origin to a remote RTMP server (export).
 pub async fn connect_export(
-	origin: moq_net::OriginConsumer,
+	origin: moq_net::origin::Consumer,
 	url: Url,
 	name: String,
 	latency: Duration,

--- a/rs/moq-cli/src/srt.rs
+++ b/rs/moq-cli/src/srt.rs
@@ -31,7 +31,7 @@ pub struct Args {
 
 /// Accept incoming SRT publishes into the Origin as `name`; reject requests (import).
 pub async fn listen_import(
-	origin: moq_net::OriginProducer,
+	origin: moq_net::origin::Producer,
 	addr: SocketAddr,
 	name: String,
 	latency: Duration,
@@ -65,7 +65,7 @@ pub async fn listen_import(
 
 /// Serve SRT requests for `name` from the Origin; reject publishes (export).
 pub async fn listen_export(
-	origin: moq_net::OriginConsumer,
+	origin: moq_net::origin::Consumer,
 	addr: SocketAddr,
 	name: String,
 	latency: Duration,
@@ -99,7 +99,7 @@ pub async fn listen_export(
 
 /// Dial a remote SRT server and pull its stream into the Origin under `name` (import).
 pub async fn connect_import(
-	origin: moq_net::OriginProducer,
+	origin: moq_net::origin::Producer,
 	url: Url,
 	name: String,
 	latency: Duration,
@@ -113,7 +113,7 @@ pub async fn connect_import(
 
 /// Push a broadcast from the Origin to a remote SRT server (export).
 pub async fn connect_export(
-	origin: moq_net::OriginConsumer,
+	origin: moq_net::origin::Consumer,
 	url: Url,
 	name: String,
 	latency: Duration,

--- a/rs/moq-cli/src/subscribe.rs
+++ b/rs/moq-cli/src/subscribe.rs
@@ -183,14 +183,14 @@ impl SubscribeArgs {
 
 /// Exports one broadcast from the Origin to stdout in the requested format.
 pub struct Subscribe {
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 	catalog: CatalogFormat,
 	args: SubscribeArgs,
 }
 
 impl Subscribe {
 	/// Wrap the broadcast + resolved settings; [`run`](Self::run) drives it.
-	pub fn new(broadcast: moq_net::BroadcastConsumer, catalog: CatalogFormat, args: SubscribeArgs) -> Self {
+	pub fn new(broadcast: moq_net::broadcast::Consumer, catalog: CatalogFormat, args: SubscribeArgs) -> Self {
 		Self {
 			broadcast,
 			catalog,

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -43,17 +43,17 @@ impl From<MoqSubscription> for moq_net::Subscription {
 
 #[derive(Clone, uniffi::Object)]
 pub struct MoqBroadcastConsumer {
-	inner: moq_net::BroadcastConsumer,
+	inner: moq_net::broadcast::Consumer,
 }
 
 impl MoqBroadcastConsumer {
-	pub(crate) fn new(inner: moq_net::BroadcastConsumer) -> Self {
+	pub(crate) fn new(inner: moq_net::broadcast::Consumer) -> Self {
 		Self { inner }
 	}
 
-	/// Access the underlying `moq_net::BroadcastConsumer` for sibling
+	/// Access the underlying `moq_net::broadcast::Consumer` for sibling
 	/// modules (e.g. `audio`) that need to subscribe a typed track.
-	pub(crate) fn inner(&self) -> &moq_net::BroadcastConsumer {
+	pub(crate) fn inner(&self) -> &moq_net::broadcast::Consumer {
 		&self.inner
 	}
 }
@@ -175,15 +175,15 @@ impl MoqBroadcastConsumer {
 // ---- Track Consumer ----
 
 struct TrackInner {
-	track: moq_net::TrackSubscriber,
+	track: moq_net::track::Subscriber,
 }
 
 impl TrackInner {
-	async fn recv_group(&mut self) -> Result<Option<moq_net::GroupConsumer>, MoqError> {
+	async fn recv_group(&mut self) -> Result<Option<moq_net::group::Consumer>, MoqError> {
 		Ok(self.track.recv_group().await?)
 	}
 
-	async fn next_group(&mut self) -> Result<Option<moq_net::GroupConsumer>, MoqError> {
+	async fn next_group(&mut self) -> Result<Option<moq_net::group::Consumer>, MoqError> {
 		Ok(self.track.next_group().await?)
 	}
 
@@ -198,7 +198,7 @@ pub struct MoqTrackConsumer {
 }
 
 impl MoqTrackConsumer {
-	pub(crate) fn new(track: moq_net::TrackSubscriber) -> Self {
+	pub(crate) fn new(track: moq_net::track::Subscriber) -> Self {
 		Self {
 			task: Task::new(TrackInner { track }),
 		}
@@ -253,7 +253,7 @@ impl MoqTrackConsumer {
 }
 
 struct GroupInner {
-	group: moq_net::GroupConsumer,
+	group: moq_net::group::Consumer,
 }
 
 impl GroupInner {
@@ -269,7 +269,7 @@ pub struct MoqGroupConsumer {
 }
 
 impl MoqGroupConsumer {
-	pub(crate) fn new(group: moq_net::GroupConsumer) -> Self {
+	pub(crate) fn new(group: moq_net::group::Consumer) -> Self {
 		Self {
 			sequence: group.sequence,
 			task: Task::new(GroupInner { group }),

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -7,12 +7,12 @@ use crate::producer::MoqBroadcastProducer;
 
 #[derive(uniffi::Object)]
 pub struct MoqOriginProducer {
-	inner: moq_net::OriginProducer,
+	inner: moq_net::origin::Producer,
 }
 
 #[derive(uniffi::Object)]
 pub struct MoqOriginConsumer {
-	inner: moq_net::OriginConsumer,
+	inner: moq_net::origin::Consumer,
 }
 
 #[derive(uniffi::Object)]
@@ -21,7 +21,7 @@ pub struct MoqAnnounced {
 }
 
 struct Announced {
-	inner: moq_net::AnnounceConsumer,
+	inner: moq_net::announce::Consumer,
 }
 
 impl Announced {
@@ -74,19 +74,19 @@ pub struct MoqAnnouncedBroadcast {
 }
 
 impl MoqOriginProducer {
-	pub(crate) fn inner(&self) -> &moq_net::OriginProducer {
+	pub(crate) fn inner(&self) -> &moq_net::origin::Producer {
 		&self.inner
 	}
 
-	/// Wrap an existing `moq_net::OriginProducer` (e.g. one auto-created
+	/// Wrap an existing `moq_net::origin::Producer` (e.g. one auto-created
 	/// during `MoqClient::connect`) so it can cross the FFI boundary.
-	pub(crate) fn from_inner(inner: moq_net::OriginProducer) -> Self {
+	pub(crate) fn from_inner(inner: moq_net::origin::Producer) -> Self {
 		Self { inner }
 	}
 }
 
 impl MoqOriginConsumer {
-	pub(crate) fn from_inner(inner: moq_net::OriginConsumer) -> Self {
+	pub(crate) fn from_inner(inner: moq_net::origin::Consumer) -> Self {
 		Self { inner }
 	}
 }

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -6,7 +6,7 @@ use crate::consumer::{MoqBroadcastConsumer, MoqGroupConsumer, MoqSubscription, M
 use crate::error::MoqError;
 use crate::ffi::Task;
 
-/// Publisher-side track properties, mirroring [`moq_net::TrackInfo`].
+/// Publisher-side track properties, mirroring [`moq_net::track::Info`].
 ///
 /// Construct with the fields you care about; the rest default to moq-net's defaults
 /// (priority 0, ordered, default cache, millisecond timescale).
@@ -28,11 +28,11 @@ pub struct MoqTrackInfo {
 	pub timescale: Option<u64>,
 }
 
-impl TryFrom<MoqTrackInfo> for moq_net::TrackInfo {
+impl TryFrom<MoqTrackInfo> for moq_net::track::Info {
 	type Error = MoqError;
 
 	fn try_from(info: MoqTrackInfo) -> Result<Self, MoqError> {
-		let mut out = moq_net::TrackInfo::default()
+		let mut out = moq_net::track::Info::default()
 			.with_priority(info.priority)
 			.with_ordered(info.ordered);
 		if let Some(ms) = info.cache_ms {
@@ -50,7 +50,7 @@ impl TryFrom<MoqTrackInfo> for moq_net::TrackInfo {
 // ---- UniFFI Objects ----
 
 pub(crate) struct BroadcastProducer {
-	pub(crate) broadcast: moq_net::BroadcastProducer,
+	pub(crate) broadcast: moq_net::broadcast::Producer,
 	// Carries the untyped `Extra` extension so callers can attach application catalog
 	// sections by name (the only extension shape that crosses the FFI boundary).
 	pub(crate) catalog: moq_mux::catalog::Producer<Extra>,
@@ -85,7 +85,7 @@ struct MediaProducer {
 	decoder: MediaDecoder,
 	/// `Some` for a single codec track, whose subscriber demand (name/used/unused)
 	/// is observable; `None` for a container that may publish several tracks.
-	demand: Option<moq_net::TrackDemand>,
+	demand: Option<moq_net::track::Demand>,
 }
 
 /// A byte-stream importer: a single codec track or a container that may publish
@@ -130,12 +130,12 @@ pub struct MoqBroadcastDynamic {
 }
 
 struct DynamicProducer {
-	inner: moq_net::BroadcastDynamic,
+	inner: moq_net::broadcast::Dynamic,
 }
 
 impl DynamicProducer {
 	async fn requested_track(&mut self) -> Result<Arc<MoqTrackRequest>, MoqError> {
-		// Hand back the un-accepted request, mirroring `moq_net::BroadcastDynamic`: the caller
+		// Hand back the un-accepted request, mirroring `moq_net::broadcast::Dynamic`: the caller
 		// accepts it (raw, at a chosen timescale) or publishes media onto it (importer accepts).
 		// The subscriber's subscribe stays pending until then.
 		let request = self.inner.requested_track().await?;
@@ -144,7 +144,7 @@ impl DynamicProducer {
 }
 
 impl MoqBroadcastProducer {
-	pub(crate) fn consume_inner(&self) -> Result<moq_net::BroadcastConsumer, MoqError> {
+	pub(crate) fn consume_inner(&self) -> Result<moq_net::broadcast::Consumer, MoqError> {
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
 		Ok(state.broadcast.consume())
@@ -202,7 +202,7 @@ impl MoqBroadcastProducer {
 	#[uniffi::constructor]
 	pub fn new() -> Result<Arc<Self>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog =
 			moq_mux::catalog::Producer::with_catalog(&mut broadcast, moq_mux::catalog::hang::Catalog::default())?;
 		Ok(Arc::new(Self {
@@ -352,7 +352,7 @@ impl MoqBroadcastProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
-		let info = info.map(moq_net::TrackInfo::try_from).transpose()?;
+		let info = info.map(moq_net::track::Info::try_from).transpose()?;
 		// Clone the broadcast handle (shared Arc internally) to get &mut access.
 		let mut broadcast = state.broadcast.clone();
 		let producer = broadcast.create_track(name, info)?;
@@ -399,16 +399,16 @@ impl MoqBroadcastDynamic {
 
 /// A track requested by a subscriber that hasn't been accepted yet.
 ///
-/// Mirrors [`moq_net::TrackRequest`]: [`accept`](Self::accept) it to start producing raw
+/// Mirrors [`moq_net::track::Request`]: [`accept`](Self::accept) it to start producing raw
 /// frames, hand it to [`MoqBroadcastProducer::publish_media_on_track`] to publish media,
 /// or [`abort`](Self::abort) it to reject the waiting subscriber.
 #[derive(uniffi::Object)]
 pub struct MoqTrackRequest {
-	inner: std::sync::Mutex<Option<moq_net::TrackRequest>>,
+	inner: std::sync::Mutex<Option<moq_net::track::Request>>,
 }
 
 impl MoqTrackRequest {
-	pub(crate) fn new(request: moq_net::TrackRequest) -> Self {
+	pub(crate) fn new(request: moq_net::track::Request) -> Self {
 		Self {
 			inner: std::sync::Mutex::new(Some(request)),
 		}
@@ -416,7 +416,7 @@ impl MoqTrackRequest {
 
 	/// Take the inner request so an importer can accept it (setting the timescale). Used by
 	/// [`MoqBroadcastProducer::publish_media_on_track`].
-	pub(crate) fn take(&self) -> Result<moq_net::TrackRequest, MoqError> {
+	pub(crate) fn take(&self) -> Result<moq_net::track::Request, MoqError> {
 		self.inner.lock().unwrap().take().ok_or(MoqError::Closed)
 	}
 }
@@ -436,7 +436,7 @@ impl MoqTrackRequest {
 	/// the importer pick the timescale.
 	pub fn accept(&self, info: Option<MoqTrackInfo>) -> Result<Arc<MoqTrackProducer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		let info = info.map(moq_net::TrackInfo::try_from).transpose()?;
+		let info = info.map(moq_net::track::Info::try_from).transpose()?;
 		let request = self.take()?;
 		Ok(Arc::new(MoqTrackProducer {
 			inner: std::sync::Mutex::new(Some(request.accept(info))),
@@ -457,7 +457,7 @@ impl MoqTrackRequest {
 
 #[derive(uniffi::Object)]
 pub struct MoqTrackProducer {
-	inner: std::sync::Mutex<Option<moq_net::TrackProducer>>,
+	inner: std::sync::Mutex<Option<moq_net::track::Producer>>,
 }
 
 #[uniffi::export]
@@ -546,7 +546,7 @@ impl MoqTrackProducer {
 #[derive(uniffi::Object)]
 pub struct MoqGroupProducer {
 	sequence: u64,
-	inner: std::sync::Mutex<Option<moq_net::GroupProducer>>,
+	inner: std::sync::Mutex<Option<moq_net::group::Producer>>,
 }
 
 #[uniffi::export]

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -245,8 +245,8 @@ pub struct MoqSession {
 impl MoqSession {
 	pub(crate) fn new(
 		session: moq_net::Session,
-		publish: moq_net::OriginProducer,
-		subscribe: moq_net::OriginProducer,
+		publish: moq_net::origin::Producer,
+		subscribe: moq_net::origin::Producer,
 	) -> Self {
 		// Eagerly wrap the wired origin sides so each publisher()/consumer()
 		// call hands back the same Arc. `publish` is published into; `subscribe`

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -47,7 +47,7 @@ impl TryFrom<Settings> for ResolvedSettings {
 /// finalize. Per-pad media lives in `pads`; `ended` tracks EOS for element-level EOS aggregation.
 struct State {
 	session: Session,
-	broadcast: moq_net::BroadcastProducer,
+	broadcast: moq_net::broadcast::Producer,
 	catalog: Option<moq_mux::catalog::Producer>,
 	pads: HashMap<String, Pad>,
 	ended: HashSet<String>,

--- a/rs/moq-gst/src/sink/pad.rs
+++ b/rs/moq-gst/src/sink/pad.rs
@@ -65,7 +65,7 @@ impl Pad {
 	/// sticky event keep the live producer.
 	pub fn observe_caps(
 		&mut self,
-		broadcast: &moq_net::BroadcastProducer,
+		broadcast: &moq_net::broadcast::Producer,
 		catalog: &moq_mux::catalog::Producer,
 		caps: &gst::Caps,
 	) {
@@ -80,7 +80,7 @@ impl Pad {
 
 	fn build(
 		&mut self,
-		broadcast: &moq_net::BroadcastProducer,
+		broadcast: &moq_net::broadcast::Producer,
 		catalog: &moq_mux::catalog::Producer,
 		caps: &gst::Caps,
 	) -> Result<()> {
@@ -117,7 +117,8 @@ impl Pad {
 				// directly and lifts it into a `Track` via `.into()`.
 				let name = broadcast.unique_name(".mp3");
 				let request = broadcast.reserve_track(name)?;
-				let producer = request.accept(moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE));
+				let producer =
+					request.accept(moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE));
 				moq_mux::codec::mp3::Import::new(producer, catalog, config)?.into()
 			}
 			"audio/mpeg" => {
@@ -148,7 +149,8 @@ impl Pad {
 				// importer directly and lifts it into a `Track` via `.into()`.
 				let name = broadcast.unique_name(".opus");
 				let request = broadcast.reserve_track(name)?;
-				let producer = request.accept(moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE));
+				let producer =
+					request.accept(moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE));
 				moq_mux::codec::opus::Import::new(producer, catalog, config)?.into()
 			}
 			other => anyhow::bail!("unsupported caps: {other}"),
@@ -161,7 +163,7 @@ impl Pad {
 	/// Reserve a uniquely named track and hand it to the single-codec importer, which accepts the request
 	/// (setting the microsecond timescale) and registers the catalog rendition once the config resolves.
 	fn reserve(
-		broadcast: &mut moq_net::BroadcastProducer,
+		broadcast: &mut moq_net::broadcast::Producer,
 		catalog: moq_mux::catalog::Producer,
 		suffix: &str,
 		format: &str,
@@ -330,8 +332,8 @@ mod tests {
 	use super::*;
 
 	/// Local producers, no network: a broadcast plus its catalog, exactly what the element holds.
-	fn producers() -> (moq_net::BroadcastProducer, moq_mux::catalog::Producer) {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	fn producers() -> (moq_net::broadcast::Producer, moq_mux::catalog::Producer) {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 		(broadcast, catalog)
 	}

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -101,12 +101,12 @@ impl Session {
 	pub fn start(
 		settings: ResolvedSettings,
 		element: glib::WeakRef<Element>,
-	) -> Result<(Self, moq_net::BroadcastProducer, moq_mux::catalog::Producer)> {
+	) -> Result<(Self, moq_net::broadcast::Producer, moq_mux::catalog::Producer)> {
 		// Producer setup may touch tokio time (group eviction), so run it inside the runtime context.
 		let _rt = RUNTIME.enter();
 
 		let origin = moq_net::Origin::random().produce();
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let broadcast_consumer = broadcast.consume();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 		// The returned guard unannounces the broadcast when dropped, so it is held by the session task for
@@ -142,8 +142,8 @@ impl Session {
 /// element error on the bus; [`Session::stop`] aborts this task instead, which is quiet.
 async fn run(
 	settings: ResolvedSettings,
-	origin: moq_net::OriginProducer,
-	publish: moq_net::OriginPublish,
+	origin: moq_net::origin::Producer,
+	publish: moq_net::origin::Publish,
 	status: Arc<Status>,
 	errored: Arc<AtomicBool>,
 	element: glib::WeakRef<Element>,
@@ -168,7 +168,7 @@ async fn run(
 
 async fn connect_and_run(
 	settings: &ResolvedSettings,
-	origin: &moq_net::OriginProducer,
+	origin: &moq_net::origin::Producer,
 	status: &Status,
 	element: &glib::WeakRef<Element>,
 ) -> Result<()> {

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -359,7 +359,7 @@ async fn reconcile(
 	catalog: &moq_mux::catalog::hang::Catalog,
 	active: &mut HashMap<String, ActiveTrack>,
 	pumps: &mut tokio::task::JoinSet<()>,
-	broadcast: &moq_net::BroadcastConsumer,
+	broadcast: &moq_net::broadcast::Consumer,
 	element: &glib::WeakRef<super::MoqSrc>,
 ) -> Result<()> {
 	struct Desired {

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -58,7 +58,7 @@ impl Default for Config {
 
 /// All renditions of one broadcast, kept in sync with its catalog.
 pub struct Broadcaster {
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 	/// Keyed by `(kind, name)` so a video and an audio rendition can share a name
 	/// without one silently evicting the other.
 	renditions: Mutex<BTreeMap<(Kind, String), Arc<Rendition>>>,
@@ -77,7 +77,7 @@ pub struct Broadcaster {
 
 impl Broadcaster {
 	/// Subscribe to `broadcast` and start tracking its renditions.
-	pub fn new(broadcast: moq_net::BroadcastConsumer, config: Config) -> Arc<Self> {
+	pub fn new(broadcast: moq_net::broadcast::Consumer, config: Config) -> Arc<Self> {
 		let (ready, _) = watch::channel(0);
 		let (paused, _) = watch::channel(false);
 		let broadcaster = Arc::new(Self {
@@ -169,7 +169,7 @@ impl Broadcaster {
 
 	/// Add renditions newly present in `catalog`. Renditions are not removed when
 	/// they disappear; their stores simply go stale (rare for a live broadcast).
-	fn sync(&self, broadcast: &moq_net::BroadcastConsumer, config: &Config, catalog: &Catalog) {
+	fn sync(&self, broadcast: &moq_net::broadcast::Consumer, config: &Config, catalog: &Catalog) {
 		let mut renditions = self.renditions.lock().unwrap();
 		for (name, video) in &catalog.video.renditions {
 			renditions.entry((Kind::Video, name.clone())).or_insert_with(|| {
@@ -203,7 +203,7 @@ impl Drop for Broadcaster {
 	}
 }
 
-async fn watch_catalog(broadcast: moq_net::BroadcastConsumer, config: Config, broadcaster: Weak<Broadcaster>) {
+async fn watch_catalog(broadcast: moq_net::broadcast::Consumer, config: Config, broadcaster: Weak<Broadcaster>) {
 	let mut consumer = loop {
 		match catalog::Consumer::<()>::new(&broadcast, CatalogFormat::Hang).await {
 			Ok(consumer) => break consumer,

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -53,7 +53,7 @@ impl Default for Config {
 
 /// All renditions of one broadcast, kept in sync with its catalog.
 pub struct Broadcaster {
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 	renditions: Mutex<BTreeMap<String, Arc<Rendition>>>,
 	/// Current rendition count, bumped on every catalog sync so handlers can wait
 	/// for the catalog to populate before rendering a playlist.
@@ -66,7 +66,7 @@ pub struct Broadcaster {
 
 impl Broadcaster {
 	/// Subscribe to `broadcast` and start tracking its renditions.
-	pub fn new(broadcast: moq_net::BroadcastConsumer, config: Config) -> Arc<Self> {
+	pub fn new(broadcast: moq_net::broadcast::Consumer, config: Config) -> Arc<Self> {
 		let (ready, _) = watch::channel(0);
 		let (paused, _) = watch::channel(false);
 		let broadcaster = Arc::new(Self {
@@ -153,7 +153,7 @@ impl Broadcaster {
 
 	/// Add renditions newly present in `catalog`. Renditions are not removed when
 	/// they disappear; their stores simply go stale (rare for a live broadcast).
-	fn sync(&self, broadcast: &moq_net::BroadcastConsumer, config: &Config, catalog: &Catalog) {
+	fn sync(&self, broadcast: &moq_net::broadcast::Consumer, config: &Config, catalog: &Catalog) {
 		let mut renditions = self.renditions.lock().unwrap();
 		for (name, video) in &catalog.video.renditions {
 			renditions.entry(name.clone()).or_insert_with(|| {
@@ -181,7 +181,7 @@ impl Broadcaster {
 	}
 }
 
-async fn watch_catalog(broadcast: moq_net::BroadcastConsumer, config: Config, broadcaster: Arc<Broadcaster>) {
+async fn watch_catalog(broadcast: moq_net::broadcast::Consumer, config: Config, broadcaster: Arc<Broadcaster>) {
 	let mut consumer = loop {
 		match catalog::Consumer::<()>::new(&broadcast, CatalogFormat::Hang).await {
 			Ok(consumer) => break consumer,

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -49,7 +49,7 @@ impl Rendition {
 	pub fn video(
 		name: String,
 		config: &VideoConfig,
-		broadcast: moq_net::BroadcastConsumer,
+		broadcast: moq_net::broadcast::Consumer,
 		cfg: &Config,
 		paused: watch::Receiver<bool>,
 	) -> Self {
@@ -70,7 +70,7 @@ impl Rendition {
 	pub fn audio(
 		name: String,
 		config: &AudioConfig,
-		broadcast: moq_net::BroadcastConsumer,
+		broadcast: moq_net::broadcast::Consumer,
 		cfg: &Config,
 		paused: watch::Receiver<bool>,
 	) -> Self {
@@ -89,7 +89,7 @@ impl Rendition {
 }
 
 fn spawn_pump(
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 	name: String,
 	kind: Kind,
 	store: Arc<SegmentStore>,
@@ -106,7 +106,7 @@ fn spawn_pump(
 }
 
 async fn run_pump(
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 	name: &str,
 	kind: Kind,
 	store: &SegmentStore,

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -55,7 +55,7 @@ impl std::str::FromStr for Kind {
 /// don't take a long list of easily-transposed positional arguments.
 pub(crate) struct Context<'a> {
 	/// The broadcast whose track this rendition exports.
-	pub broadcast: moq_net::BroadcastConsumer,
+	pub broadcast: moq_net::broadcast::Consumer,
 	/// Export tuning shared across renditions.
 	pub cfg: &'a Config,
 	/// Pause signal shared with every rendition pump.
@@ -139,7 +139,7 @@ fn spawn_pump(name: String, kind: Kind, store: Arc<SegmentStore>, ctx: &Context<
 }
 
 async fn run_pump(
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 	name: &str,
 	kind: Kind,
 	store: &SegmentStore,

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -79,7 +79,7 @@ struct StepOutcome {
 /// to run the continuous import loop.
 pub struct Import {
 	/// Broadcast that all CMAF importers write into.
-	broadcast: moq_net::BroadcastProducer,
+	broadcast: moq_net::broadcast::Producer,
 
 	/// The catalog being produced.
 	catalog: CatalogProducer,
@@ -147,7 +147,7 @@ fn select_audio_only() -> select::Broadcast {
 
 impl Import {
 	/// Create a new HLS import that will write into the given broadcast.
-	pub fn new(broadcast: moq_net::BroadcastProducer, catalog: CatalogProducer, cfg: Config) -> Result<Self> {
+	pub fn new(broadcast: moq_net::broadcast::Producer, catalog: CatalogProducer, cfg: Config) -> Result<Self> {
 		let base_url = cfg.parse_playlist()?;
 		let client = match cfg.client {
 			Some(client) => client,
@@ -747,7 +747,7 @@ mod tests {
 
 	#[test]
 	fn hls_import_starts_without_importers() {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = CatalogProducer::new(&mut broadcast).unwrap();
 		let url = "https://example.com/master.m3u8".to_string();
 		let cfg = Config::new(url);
@@ -768,7 +768,7 @@ mod tests {
 		let path = dir.join("master.m3u8");
 		std::fs::write(&path, master_body).unwrap();
 
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = CatalogProducer::new(&mut broadcast).unwrap();
 		// `Config` takes a filesystem path for non-http inputs.
 		let cfg = Config::new(path.to_str().unwrap().to_string());

--- a/rs/moq-hls/src/server/mod.rs
+++ b/rs/moq-hls/src/server/mod.rs
@@ -30,14 +30,14 @@ pub struct Server {
 }
 
 struct Inner {
-	origin: moq_net::OriginConsumer,
+	origin: moq_net::origin::Consumer,
 	config: Config,
 	broadcasters: Mutex<HashMap<String, Arc<Broadcaster>>>,
 }
 
 impl Server {
 	/// Build a server reading broadcasts from `origin`.
-	pub fn new(origin: moq_net::OriginConsumer, config: Config) -> Self {
+	pub fn new(origin: moq_net::origin::Consumer, config: Config) -> Self {
 		Self {
 			inner: Arc::new(Inner {
 				origin,
@@ -104,7 +104,7 @@ mod tests {
 	use super::*;
 
 	fn closed_broadcaster() -> Arc<Broadcaster> {
-		let producer = moq_net::BroadcastInfo::new().produce();
+		let producer = moq_net::broadcast::Info::new().produce();
 		let broadcaster = Broadcaster::new(producer.consume(), Config::default());
 		drop(producer);
 		broadcaster
@@ -135,7 +135,7 @@ mod tests {
 		let origin = moq_net::Origin::random().produce();
 		let server = Server::new(origin.consume(), Config::default());
 		let old = closed_broadcaster();
-		let new_producer = moq_net::BroadcastInfo::new().produce();
+		let new_producer = moq_net::broadcast::Info::new().produce();
 		let new = Broadcaster::new(new_producer.consume(), Config::default());
 
 		server

--- a/rs/moq-hls/src/server/mod.rs
+++ b/rs/moq-hls/src/server/mod.rs
@@ -56,7 +56,7 @@ pub struct Server {
 }
 
 struct Inner {
-	origin: moq_net::OriginConsumer,
+	origin: moq_net::origin::Consumer,
 	config: Config,
 	broadcasters: Mutex<HashMap<String, Arc<Broadcaster>>>,
 	/// Optional per-request authorizer, set at most once via [`Server::with_authorizer`];
@@ -68,7 +68,7 @@ struct Inner {
 impl Server {
 	/// Build a server reading broadcasts from `origin`. Every request is allowed;
 	/// call [`with_authorizer`](Self::with_authorizer) to gate access.
-	pub fn new(origin: moq_net::OriginConsumer, config: Config) -> Self {
+	pub fn new(origin: moq_net::origin::Consumer, config: Config) -> Self {
 		Self {
 			inner: Arc::new(Inner {
 				origin,
@@ -158,7 +158,7 @@ mod tests {
 	use super::*;
 
 	fn closed_broadcaster() -> Arc<Broadcaster> {
-		let producer = moq_net::BroadcastInfo::new().produce();
+		let producer = moq_net::broadcast::Info::new().produce();
 		let broadcaster = Broadcaster::new(producer.consume(), Config::default());
 		drop(producer);
 		broadcaster
@@ -189,7 +189,7 @@ mod tests {
 		let origin = moq_net::Origin::random().produce();
 		let server = Server::new(origin.consume(), Config::default());
 		let old = closed_broadcaster();
-		let new_producer = moq_net::BroadcastInfo::new().produce();
+		let new_producer = moq_net::broadcast::Info::new().produce();
 		let new = Broadcaster::new(new_producer.consume(), Config::default());
 
 		server

--- a/rs/moq-json/examples/telemetry.rs
+++ b/rs/moq-json/examples/telemetry.rs
@@ -76,7 +76,7 @@ fn telemetry(tick: u64) -> Value {
 
 /// Total wire bytes of every frame across every group for a full run under `config`.
 fn wire_bytes(config: ProducerConfig, ticks: u64) -> usize {
-	let track = moq_net::BroadcastInfo::new()
+	let track = moq_net::broadcast::Info::new()
 		.produce()
 		.create_track("telemetry", None)
 		.unwrap();
@@ -103,7 +103,7 @@ fn wire_bytes(config: ProducerConfig, ticks: u64) -> usize {
 /// Drive a producer and a live consumer in lockstep, asserting that EVERY tick reconstructs to the
 /// exact input value after decompression and delta application (not just the final one).
 fn verify(producer_config: ProducerConfig, ticks: u64) {
-	let track = moq_net::BroadcastInfo::new()
+	let track = moq_net::broadcast::Info::new()
 		.produce()
 		.create_track("telemetry", None)
 		.unwrap();
@@ -141,7 +141,7 @@ fn verify(producer_config: ProducerConfig, ticks: u64) {
 /// Returns how many values the late joiner surfaced to the application: with backlog collapsing this
 /// is far below `ticks`, since stale intermediate reconstructions are applied internally but skipped.
 fn verify_late_joiner(producer_config: ProducerConfig, ticks: u64) -> usize {
-	let track = moq_net::BroadcastInfo::new()
+	let track = moq_net::broadcast::Info::new()
 		.produce()
 		.create_track("telemetry", None)
 		.unwrap();

--- a/rs/moq-json/src/lib.rs
+++ b/rs/moq-json/src/lib.rs
@@ -130,14 +130,14 @@ impl<T> Clone for Producer<T> {
 
 impl<T> Producer<T> {
 	/// Create a subscriber for the underlying track.
-	pub fn consume(&self) -> moq_net::TrackSubscriber {
+	pub fn consume(&self) -> moq_net::track::Subscriber {
 		self.inner.lock().unwrap().track.subscribe(None)
 	}
 }
 
 impl<T: Serialize> Producer<T> {
 	/// Create a producer that publishes to the given track.
-	pub fn new(track: moq_net::TrackProducer, config: ProducerConfig) -> Self {
+	pub fn new(track: moq_net::track::Producer, config: ProducerConfig) -> Self {
 		Self {
 			inner: Arc::new(Mutex::new(Inner {
 				track,
@@ -232,8 +232,8 @@ impl<T: Serialize> Drop for Guard<'_, T> {
 
 /// Shared publishing state behind [`Producer`]'s `Arc<Mutex>`.
 struct Inner {
-	track: moq_net::TrackProducer,
-	group: Option<moq_net::GroupProducer>,
+	track: moq_net::track::Producer,
+	group: Option<moq_net::group::Producer>,
 	// Per-group DEFLATE encoder, `Some` while a compressed group is open (recreated per group).
 	encoder: Option<Encoder>,
 	last: Option<Value>,
@@ -356,8 +356,8 @@ impl Inner {
 
 /// Consumes a JSON value from a track, reconstructing it from snapshots and deltas.
 pub struct Consumer<T> {
-	track: moq_net::TrackSubscriber,
-	group: Option<moq_net::GroupConsumer>,
+	track: moq_net::track::Subscriber,
+	group: Option<moq_net::group::Consumer>,
 	// Whether frames are DEFLATE-compressed, matching the producer's [`ProducerConfig::compression`].
 	compressed: bool,
 	// Per-group DEFLATE decoder, built lazily on the first compressed frame of a group.
@@ -372,7 +372,7 @@ impl<T: DeserializeOwned> Consumer<T> {
 	///
 	/// Set [`ConsumerConfig::compression`] to read a track written by a producer with
 	/// [`ProducerConfig::compression`] on.
-	pub fn new(track: moq_net::TrackSubscriber, config: ConsumerConfig) -> Self {
+	pub fn new(track: moq_net::track::Subscriber, config: ConsumerConfig) -> Self {
 		Self {
 			track,
 			group: None,
@@ -521,12 +521,12 @@ mod test {
 	}
 
 	/// A consumer reading compressed frames.
-	fn deflate_consumer(track: moq_net::TrackSubscriber) -> Consumer<Value> {
+	fn deflate_consumer(track: moq_net::track::Subscriber) -> Consumer<Value> {
 		Consumer::new(track, ConsumerConfig { compression: true })
 	}
 
-	fn producer(config: ProducerConfig) -> (Producer<Value>, moq_net::TrackSubscriber) {
-		let track = moq_net::BroadcastInfo::new()
+	fn producer(config: ProducerConfig) -> (Producer<Value>, moq_net::track::Subscriber) {
+		let track = moq_net::broadcast::Info::new()
 			.produce()
 			.create_track("test", None)
 			.unwrap();
@@ -535,7 +535,7 @@ mod test {
 	}
 
 	/// Drain every value currently available from a plaintext consumer without blocking.
-	fn drain(track: moq_net::TrackSubscriber) -> Vec<Value> {
+	fn drain(track: moq_net::track::Subscriber) -> Vec<Value> {
 		drain_with(Consumer::<Value>::new(track, ConsumerConfig::default()))
 	}
 
@@ -691,7 +691,7 @@ mod test {
 			scte35: Option<u32>,
 		}
 
-		let track = moq_net::BroadcastInfo::new()
+		let track = moq_net::broadcast::Info::new()
 			.produce()
 			.create_track("test", None)
 			.unwrap();
@@ -758,7 +758,7 @@ mod test {
 	fn open_group_pends_after_track_finish() {
 		// A group appended before the track finishes may still deliver frames, so the consumer must
 		// keep waiting on it rather than ending the stream. Regression for the backlog-collapse poll.
-		let mut track = moq_net::BroadcastInfo::new()
+		let mut track = moq_net::broadcast::Info::new()
 			.produce()
 			.create_track("test", None)
 			.unwrap();

--- a/rs/moq-mux/src/catalog/consumer.rs
+++ b/rs/moq-mux/src/catalog/consumer.rs
@@ -9,7 +9,7 @@ use std::task::{Poll, ready};
 use super::hang::{Catalog, CatalogExt};
 use super::{CatalogFormat, Stream};
 
-/// A catalog stream sourced from a [`moq_net::BroadcastConsumer`].
+/// A catalog stream sourced from a [`moq_net::broadcast::Consumer`].
 ///
 /// Both variants emit [`Catalog<E>`](super::hang::Catalog); the MSF variant is
 /// media-only, so its extension is always the default. Wrap with
@@ -28,7 +28,7 @@ pub enum Consumer<E: CatalogExt = ()> {
 
 impl<E: CatalogExt> Consumer<E> {
 	/// Subscribe to the catalog track advertised by `format`.
-	pub async fn new(broadcast: &moq_net::BroadcastConsumer, format: CatalogFormat) -> Result<Self, crate::Error> {
+	pub async fn new(broadcast: &moq_net::broadcast::Consumer, format: CatalogFormat) -> Result<Self, crate::Error> {
 		Ok(match format {
 			CatalogFormat::Hang => {
 				let track = broadcast

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -16,7 +16,7 @@ pub struct Consumer<E: CatalogExt = ()> {
 
 impl<E: CatalogExt> Consumer<E> {
 	/// Create a new catalog consumer from a MoQ track subscriber (uncompressed `catalog.json`).
-	pub fn new(track: moq_net::TrackSubscriber) -> Self {
+	pub fn new(track: moq_net::track::Subscriber) -> Self {
 		Self {
 			inner: moq_json::Consumer::new(track, moq_json::ConsumerConfig::default()),
 		}
@@ -25,7 +25,7 @@ impl<E: CatalogExt> Consumer<E> {
 	/// Create a consumer for the DEFLATE-compressed catalog track (`catalog.json.z`).
 	///
 	/// The track must be the compressed one (see [`hang::Catalog::COMPRESSED_NAME`]).
-	pub fn compressed(track: moq_net::TrackSubscriber) -> Self {
+	pub fn compressed(track: moq_net::track::Subscriber) -> Self {
 		let mut config = moq_json::ConsumerConfig::default();
 		config.compression = true;
 		Self {
@@ -51,8 +51,8 @@ impl<E: CatalogExt> Consumer<E> {
 	}
 }
 
-impl<E: CatalogExt> From<moq_net::TrackSubscriber> for Consumer<E> {
-	fn from(inner: moq_net::TrackSubscriber) -> Self {
+impl<E: CatalogExt> From<moq_net::track::Subscriber> for Consumer<E> {
+	fn from(inner: moq_net::track::Subscriber) -> Self {
 		Self::new(inner)
 	}
 }
@@ -67,9 +67,9 @@ mod test {
 	/// born from their broadcast (no public `TrackProducer::new`).
 	fn track_producer(
 		name: impl Into<std::sync::Arc<str>>,
-		info: impl Into<Option<moq_net::TrackInfo>>,
-	) -> moq_net::TrackProducer {
-		moq_net::BroadcastInfo::new()
+		info: impl Into<Option<moq_net::track::Info>>,
+	) -> moq_net::track::Producer {
+		moq_net::broadcast::Info::new()
 			.produce()
 			.create_track(name, info)
 			.unwrap()

--- a/rs/moq-mux/src/catalog/hang/container.rs
+++ b/rs/moq-mux/src/catalog/hang/container.rs
@@ -34,7 +34,7 @@ impl TryFrom<&hang::catalog::Container> for Container {
 impl ContainerTrait for Container {
 	type Error = crate::Error;
 
-	fn write(&self, group: &mut moq_net::GroupProducer, frames: &[Frame]) -> Result<(), Self::Error> {
+	fn write(&self, group: &mut moq_net::group::Producer, frames: &[Frame]) -> Result<(), Self::Error> {
 		match self {
 			Self::Legacy => legacy::Wire.write(group, frames),
 			Self::Cmaf(cmaf) => cmaf.write(group, frames).map_err(Into::into),
@@ -44,7 +44,7 @@ impl ContainerTrait for Container {
 
 	fn poll_read(
 		&self,
-		group: &mut moq_net::GroupConsumer,
+		group: &mut moq_net::group::Consumer,
 		waiter: &kio::Waiter,
 	) -> Poll<Result<Option<Vec<Frame>>, Self::Error>> {
 		match self {

--- a/rs/moq-mux/src/catalog/hang/ext.rs
+++ b/rs/moq-mux/src/catalog/hang/ext.rs
@@ -166,7 +166,7 @@ mod test {
 
 	#[test]
 	fn extension_roundtrip() {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut producer =
 			crate::catalog::Producer::with_catalog(&mut broadcast, Catalog::<Scte35Ext>::default()).unwrap();
 		let mut consumer = producer.consume().unwrap();
@@ -192,7 +192,7 @@ mod test {
 
 	#[test]
 	fn untyped_extra_roundtrip() {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut producer = crate::catalog::Producer::<Extra>::with_catalog(&mut broadcast, Catalog::default()).unwrap();
 		let mut consumer = producer.consume().unwrap();
 

--- a/rs/moq-mux/src/catalog/msf/consumer.rs
+++ b/rs/moq-mux/src/catalog/msf/consumer.rs
@@ -14,15 +14,15 @@ use crate::catalog::msf::Error;
 /// so the rest of the pipeline only deals with hang types.
 pub struct Consumer {
 	/// Access to the underlying track consumer.
-	pub track: moq_net::TrackSubscriber,
-	group: Option<moq_net::GroupConsumer>,
+	pub track: moq_net::track::Subscriber,
+	group: Option<moq_net::group::Consumer>,
 }
 
 impl Consumer {
 	/// Create a new MSF catalog consumer from a MoQ track consumer.
 	///
 	/// The track is expected to carry MSF catalog payloads (track name [`moq_msf::DEFAULT_NAME`]).
-	pub fn new(track: moq_net::TrackSubscriber) -> Self {
+	pub fn new(track: moq_net::track::Subscriber) -> Self {
 		Self { track, group: None }
 	}
 
@@ -74,8 +74,8 @@ impl Consumer {
 	}
 }
 
-impl From<moq_net::TrackSubscriber> for Consumer {
-	fn from(inner: moq_net::TrackSubscriber) -> Self {
+impl From<moq_net::track::Subscriber> for Consumer {
+	fn from(inner: moq_net::track::Subscriber) -> Self {
 		Self::new(inner)
 	}
 }

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -23,7 +23,7 @@ use super::hang::{Catalog, CatalogExt, Consumer, Extra};
 pub struct Producer<E: CatalogExt = ()> {
 	hang: moq_json::Producer<Catalog<E>>,
 	hangz: moq_json::Producer<Catalog<E>>,
-	msf_track: moq_net::TrackProducer,
+	msf_track: moq_net::track::Producer,
 
 	current: Arc<Mutex<Catalog<E>>>,
 
@@ -52,7 +52,7 @@ impl Producer<()> {
 	/// For an extended catalog, use [`with_catalog`](Self::with_catalog) with a
 	/// `Catalog<E>` (e.g. the untyped [`Extra`] for the by-name / FFI path). Set
 	/// application sections through [`lock`](Self::lock).
-	pub fn new(broadcast: &mut moq_net::BroadcastProducer) -> Result<Self, moq_net::Error> {
+	pub fn new(broadcast: &mut moq_net::broadcast::Producer) -> Result<Self, moq_net::Error> {
 		Self::with_catalog(broadcast, Catalog::default())
 	}
 }
@@ -60,7 +60,7 @@ impl Producer<()> {
 impl<E: CatalogExt> Producer<E> {
 	/// Create a new catalog producer with the given initial catalog.
 	pub fn with_catalog(
-		broadcast: &mut moq_net::BroadcastProducer,
+		broadcast: &mut moq_net::broadcast::Producer,
 		catalog: Catalog<E>,
 	) -> Result<Self, moq_net::Error> {
 		let hang_track = broadcast.create_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info())?;
@@ -153,7 +153,7 @@ pub struct Guard<'a, E: CatalogExt = ()> {
 	catalog: MutexGuard<'a, Catalog<E>>,
 	hang: &'a mut moq_json::Producer<Catalog<E>>,
 	hangz: &'a mut moq_json::Producer<Catalog<E>>,
-	msf_track: &'a mut moq_net::TrackProducer,
+	msf_track: &'a mut moq_net::track::Producer,
 	updated: bool,
 }
 
@@ -319,7 +319,7 @@ mod test {
 
 	#[test]
 	fn publishes_plain_and_compressed_tracks() {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut catalog = Producer::new(&mut broadcast).unwrap();
 
 		let mut plain = Consumer::new(catalog.hang.consume());

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -18,7 +18,7 @@ pub struct Import<E: CatalogExt = ()> {
 impl<E: CatalogExt> Import<E> {
 	/// Publish on an existing track producer, registering the rendition in `catalog`.
 	pub fn new(
-		track: moq_net::TrackProducer,
+		track: moq_net::track::Producer,
 		catalog: crate::catalog::Producer<E>,
 		config: Config,
 	) -> crate::Result<Self> {
@@ -48,7 +48,7 @@ impl<E: CatalogExt> Import<E> {
 	}
 
 	/// A watch-only handle to this track's subscriber demand.
-	pub fn demand(&self) -> moq_net::TrackDemand {
+	pub fn demand(&self) -> moq_net::track::Demand {
 		self.track.track().demand()
 	}
 

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -37,7 +37,7 @@ pub struct Import<E: CatalogExt = ()> {
 
 impl<E: CatalogExt> Import<E> {
 	/// Publish on an existing track producer, registering the rendition in `catalog`.
-	pub fn new(track: moq_net::TrackProducer, catalog: crate::catalog::Producer<E>) -> Self {
+	pub fn new(track: moq_net::track::Producer, catalog: crate::catalog::Producer<E>) -> Self {
 		let rendition = catalog.video_track(track.name());
 		Self {
 			track: crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy),
@@ -195,7 +195,7 @@ impl<E: CatalogExt> Import<E> {
 	}
 
 	/// A watch-only handle to this track's subscriber demand.
-	pub fn demand(&self) -> moq_net::TrackDemand {
+	pub fn demand(&self) -> moq_net::track::Demand {
 		self.track.track().demand()
 	}
 

--- a/rs/moq-mux/src/codec/flac/import.rs
+++ b/rs/moq-mux/src/codec/flac/import.rs
@@ -21,7 +21,7 @@ pub struct Import<E: CatalogExt = ()> {
 impl<E: CatalogExt> Import<E> {
 	/// Publish on an existing track producer, registering the rendition in `catalog`.
 	pub fn new(
-		track: moq_net::TrackProducer,
+		track: moq_net::track::Producer,
 		catalog: crate::catalog::Producer<E>,
 		config: Config,
 	) -> crate::Result<Self> {
@@ -45,7 +45,7 @@ impl<E: CatalogExt> Import<E> {
 	}
 
 	/// A watch-only handle to this track's subscriber demand.
-	pub fn demand(&self) -> moq_net::TrackDemand {
+	pub fn demand(&self) -> moq_net::track::Demand {
 		self.track.track().demand()
 	}
 

--- a/rs/moq-mux/src/codec/h264/export.rs
+++ b/rs/moq-mux/src/codec/h264/export.rs
@@ -25,7 +25,7 @@ use crate::container::ExportSource;
 
 /// Single-rendition H.264 Annex-B exporter.
 pub struct Export<S: Stream> {
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 	catalog: Option<S>,
 	latency: Duration,
 	track: Option<H264Track>,
@@ -57,7 +57,7 @@ impl<S: Stream> Export<S> {
 	/// `consumer.select(select::Broadcast::default().video(select::Video::default().name("hd")))`).
 	/// Renditions of other codecs are ignored; if multiple H.264 renditions appear
 	/// in a snapshot, the first by BTreeMap order wins and a warning is logged.
-	pub fn new(broadcast: moq_net::BroadcastConsumer, catalog: S) -> Self {
+	pub fn new(broadcast: moq_net::broadcast::Consumer, catalog: S) -> Self {
 		Self {
 			broadcast,
 			catalog: Some(catalog),
@@ -238,7 +238,7 @@ mod tests {
 
 	/// Write a length-prefixed (4-byte) NAL frame onto a moq-net group via
 	/// the Legacy wire codec.
-	fn write_length_prefixed(group: &mut moq_net::GroupProducer, timestamp_us: u64, nals: &[&[u8]]) {
+	fn write_length_prefixed(group: &mut moq_net::group::Producer, timestamp_us: u64, nals: &[&[u8]]) {
 		let mut payload = bytes::BytesMut::new();
 		for nal in nals {
 			payload.extend_from_slice(&(nal.len() as u32).to_be_bytes());
@@ -275,23 +275,23 @@ mod tests {
 		let catalog = avc1_catalog("video.m4s", avcc);
 
 		// Producer side: publish the broadcast with one length-prefixed video track.
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut track = broadcast
 			.create_track(
 				"video.m4s",
-				moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 			)
 			.unwrap();
 
 		// Group 0 (keyframe-starting group): one IDR frame.
-		let mut g0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut g0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		write_length_prefixed(&mut g0, 0, &[idr]);
 		g0.finish().unwrap();
 
 		// Group 1 (next group): one P-slice. Consumer marks the first frame
 		// of every group as keyframe by protocol invariant, so the exporter
 		// MUST treat both group-starts as keyframes and inject SPS+PPS twice.
-		let mut g1 = track.create_group(moq_net::GroupInfo { sequence: 1 }).unwrap();
+		let mut g1 = track.create_group(moq_net::group::Info { sequence: 1 }).unwrap();
 		write_length_prefixed(&mut g1, 33_000, &[p_slice]);
 		g1.finish().unwrap();
 		track.finish().unwrap();

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -40,7 +40,7 @@ pub struct Import<E: CatalogExt = ()> {
 
 impl<E: CatalogExt> Import<E> {
 	/// Publish on an existing track producer, registering the rendition in `catalog`.
-	pub fn new(track: moq_net::TrackProducer, catalog: crate::catalog::Producer<E>) -> Self {
+	pub fn new(track: moq_net::track::Producer, catalog: crate::catalog::Producer<E>) -> Self {
 		let rendition = catalog.video_track(track.name());
 		Self {
 			avc1: false,
@@ -116,7 +116,7 @@ impl<E: CatalogExt> Import<E> {
 	}
 
 	/// A watch-only handle to this track's subscriber demand.
-	pub fn demand(&self) -> moq_net::TrackDemand {
+	pub fn demand(&self) -> moq_net::track::Demand {
 		self.track.track().demand()
 	}
 
@@ -255,13 +255,13 @@ mod tests {
 	use super::*;
 	use crate::codec::h264::Split;
 
-	fn setup(name: &str) -> (moq_net::TrackProducer, crate::catalog::Producer) {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	fn setup(name: &str) -> (moq_net::track::Producer, crate::catalog::Producer) {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 		let track = broadcast
 			.create_track(
 				name,
-				moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 			)
 			.unwrap();
 		(track, catalog)

--- a/rs/moq-mux/src/codec/h265/export.rs
+++ b/rs/moq-mux/src/codec/h265/export.rs
@@ -18,7 +18,7 @@ use crate::container::ExportSource;
 
 /// Single-rendition H.265 Annex-B exporter.
 pub struct Export<S: Stream> {
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 	catalog: Option<S>,
 	latency: Duration,
 	track: Option<H265Track>,
@@ -49,7 +49,7 @@ impl<S: Stream> Export<S> {
 	/// `catalog` is expected to be narrowed to a single H.265 rendition. If
 	/// multiple H.265 renditions appear in a snapshot, the first by BTreeMap
 	/// order wins and a warning is logged.
-	pub fn new(broadcast: moq_net::BroadcastConsumer, catalog: S) -> Self {
+	pub fn new(broadcast: moq_net::broadcast::Consumer, catalog: S) -> Self {
 		Self {
 			broadcast,
 			catalog: Some(catalog),
@@ -237,7 +237,7 @@ mod tests {
 		out.freeze()
 	}
 
-	fn write_length_prefixed(group: &mut moq_net::GroupProducer, timestamp_us: u64, nals: &[&[u8]]) {
+	fn write_length_prefixed(group: &mut moq_net::group::Producer, timestamp_us: u64, nals: &[&[u8]]) {
 		let mut payload = BytesMut::new();
 		for nal in nals {
 			payload.extend_from_slice(&(nal.len() as u32).to_be_bytes());
@@ -266,19 +266,19 @@ mod tests {
 		let trail = &[0x02, 0x01, 0xe0, 0x12][..];
 
 		let catalog = hvc1_catalog("video.hvc1", hvcc(vps, sps, pps));
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut track = broadcast
 			.create_track(
 				"video.hvc1",
-				moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 			)
 			.unwrap();
 
-		let mut g0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut g0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		write_length_prefixed(&mut g0, 0, &[idr]);
 		g0.finish().unwrap();
 
-		let mut g1 = track.create_group(moq_net::GroupInfo { sequence: 1 }).unwrap();
+		let mut g1 = track.create_group(moq_net::group::Info { sequence: 1 }).unwrap();
 		write_length_prefixed(&mut g1, 33_000, &[trail]);
 		g1.finish().unwrap();
 		track.finish().unwrap();

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -39,7 +39,7 @@ pub struct Import<E: CatalogExt = ()> {
 
 impl<E: CatalogExt> Import<E> {
 	/// Publish on an existing track producer, registering the rendition in `catalog`.
-	pub fn new(track: moq_net::TrackProducer, catalog: crate::catalog::Producer<E>) -> Self {
+	pub fn new(track: moq_net::track::Producer, catalog: crate::catalog::Producer<E>) -> Self {
 		let rendition = catalog.video_track(track.name());
 		Self {
 			track: crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy),
@@ -78,7 +78,7 @@ impl<E: CatalogExt> Import<E> {
 	}
 
 	/// A watch-only handle to this track's subscriber demand.
-	pub fn demand(&self) -> moq_net::TrackDemand {
+	pub fn demand(&self) -> moq_net::track::Demand {
 		self.track.track().demand()
 	}
 

--- a/rs/moq-mux/src/codec/legacy.rs
+++ b/rs/moq-mux/src/codec/legacy.rs
@@ -124,7 +124,7 @@ impl<E: CatalogExt> Import<E> {
 	/// [`hang::container::TIMESCALE`] (e.g. via [`crate::import::unique_track`]).
 	pub fn new(
 		descriptor: &'static Descriptor,
-		track: moq_net::TrackProducer,
+		track: moq_net::track::Producer,
 		catalog: crate::catalog::Producer<E>,
 		config: Config,
 	) -> Self {

--- a/rs/moq-mux/src/codec/mp3.rs
+++ b/rs/moq-mux/src/codec/mp3.rs
@@ -108,7 +108,7 @@ pub struct Import<E: CatalogExt = ()> {
 impl<E: CatalogExt> Import<E> {
 	/// Publish on an existing track producer, registering the rendition in `catalog`.
 	pub fn new(
-		track: moq_net::TrackProducer,
+		track: moq_net::track::Producer,
 		catalog: crate::catalog::Producer<E>,
 		config: Config,
 	) -> crate::Result<Self> {
@@ -128,7 +128,7 @@ impl<E: CatalogExt> Import<E> {
 	}
 
 	/// A watch-only handle to this track's subscriber demand.
-	pub fn demand(&self) -> moq_net::TrackDemand {
+	pub fn demand(&self) -> moq_net::track::Demand {
 		self.track.track().demand()
 	}
 

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -19,7 +19,7 @@ pub struct Import<E: CatalogExt = ()> {
 impl<E: CatalogExt> Import<E> {
 	/// Publish on an existing track producer, registering the rendition in `catalog`.
 	pub fn new(
-		track: moq_net::TrackProducer,
+		track: moq_net::track::Producer,
 		catalog: crate::catalog::Producer<E>,
 		config: Config,
 	) -> crate::Result<Self> {
@@ -47,7 +47,7 @@ impl<E: CatalogExt> Import<E> {
 	}
 
 	/// A watch-only handle to this track's subscriber demand.
-	pub fn demand(&self) -> moq_net::TrackDemand {
+	pub fn demand(&self) -> moq_net::track::Demand {
 		self.track.track().demand()
 	}
 

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -29,7 +29,7 @@ pub struct Import<E: CatalogExt = ()> {
 
 impl<E: CatalogExt> Import<E> {
 	/// Publish on an existing track producer, registering the rendition in `catalog`.
-	pub fn new(track: moq_net::TrackProducer, catalog: crate::catalog::Producer<E>) -> Self {
+	pub fn new(track: moq_net::track::Producer, catalog: crate::catalog::Producer<E>) -> Self {
 		let rendition = catalog.video_track(track.name());
 		Self {
 			track: crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy),
@@ -97,7 +97,7 @@ impl<E: CatalogExt> Import<E> {
 	}
 
 	/// A watch-only handle to this track's subscriber demand.
-	pub fn demand(&self) -> moq_net::TrackDemand {
+	pub fn demand(&self) -> moq_net::track::Demand {
 		self.track.track().demand()
 	}
 
@@ -120,13 +120,13 @@ mod tests {
 
 	use moq_net::Timestamp;
 
-	fn setup() -> (moq_net::TrackProducer, crate::catalog::Producer) {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	fn setup() -> (moq_net::track::Producer, crate::catalog::Producer) {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 		let track = broadcast
 			.create_track(
 				"0.vp8",
-				moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 			)
 			.unwrap();
 		(track, catalog)

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -29,7 +29,7 @@ pub struct Import<E: CatalogExt = ()> {
 
 impl<E: CatalogExt> Import<E> {
 	/// Publish on an existing track producer, registering the rendition in `catalog`.
-	pub fn new(track: moq_net::TrackProducer, catalog: crate::catalog::Producer<E>) -> Self {
+	pub fn new(track: moq_net::track::Producer, catalog: crate::catalog::Producer<E>) -> Self {
 		let rendition = catalog.video_track(track.name());
 		Self {
 			track: crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy),
@@ -97,7 +97,7 @@ impl<E: CatalogExt> Import<E> {
 	}
 
 	/// A watch-only handle to this track's subscriber demand.
-	pub fn demand(&self) -> moq_net::TrackDemand {
+	pub fn demand(&self) -> moq_net::track::Demand {
 		self.track.track().demand()
 	}
 
@@ -123,13 +123,13 @@ mod tests {
 	// profile 0, 8-bit, CS_BT_601, studio range, 4:2:0, 320x240.
 	const KEYFRAME: &[u8] = &[0x82, 0x49, 0x83, 0x42, 0x20, 0x13, 0xf0, 0x0e, 0xf0, 0x00];
 
-	fn setup() -> (moq_net::TrackProducer, crate::catalog::Producer) {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	fn setup() -> (moq_net::track::Producer, crate::catalog::Producer) {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 		let track = broadcast
 			.create_track(
 				"0.vp9",
-				moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 			)
 			.unwrap();
 		(track, catalog)

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -8,7 +8,7 @@ use super::{Container, Frame};
 /// Decode a moq-lite track into a stream of media [`Frame`]s in latency-bounded
 /// presentation order.
 ///
-/// `Consumer` wraps a [`moq_net::TrackSubscriber`] and a [`Container`]
+/// `Consumer` wraps a [`moq_net::track::Subscriber`] and a [`Container`]
 /// format implementation, typically
 /// [`catalog::hang::Container`](crate::catalog::hang::Container). Yields
 /// decoded frames via [`read`](Self::read).
@@ -40,7 +40,7 @@ use super::{Container, Frame};
 /// [`discontinuity`](Self::discontinuity) so downstream consumers can flush their own
 /// buffers. This is always on.
 pub struct Consumer<F: Container> {
-	track: moq_net::TrackSubscriber,
+	track: moq_net::track::Subscriber,
 
 	format: F,
 
@@ -127,7 +127,7 @@ impl Reset {
 
 impl<F: Container> Consumer<F> {
 	/// Create a new Consumer wrapping the given moq-lite consumer.
-	pub fn new(track: moq_net::TrackSubscriber, format: F) -> Self {
+	pub fn new(track: moq_net::track::Subscriber, format: F) -> Self {
 		Self {
 			track,
 			format,
@@ -489,7 +489,7 @@ impl<F: Container> Consumer<F> {
 /// Handles two-phase frame reading (get FrameConsumer, then read all data),
 /// timestamp parsing, and min/max timestamp tracking for latency decisions.
 struct GroupBuffer {
-	group: moq_net::GroupConsumer,
+	group: moq_net::group::Consumer,
 
 	// The current frame index within the group.
 	index: usize,
@@ -510,7 +510,7 @@ struct GroupBuffer {
 }
 
 impl GroupBuffer {
-	fn new(group: moq_net::GroupConsumer) -> Self {
+	fn new(group: moq_net::group::Consumer) -> Self {
 		Self {
 			group,
 			index: 0,
@@ -639,7 +639,7 @@ impl GroupBuffer {
 }
 
 impl std::ops::Deref for GroupBuffer {
-	type Target = moq_net::GroupConsumer;
+	type Target = moq_net::group::Consumer;
 
 	fn deref(&self) -> &Self::Target {
 		&self.group
@@ -659,9 +659,9 @@ mod tests {
 	/// born from their broadcast (no public `TrackProducer::new`).
 	fn track_producer(
 		name: impl Into<std::sync::Arc<str>>,
-		info: impl Into<Option<moq_net::TrackInfo>>,
-	) -> moq_net::TrackProducer {
-		moq_net::BroadcastInfo::new()
+		info: impl Into<Option<moq_net::track::Info>>,
+	) -> moq_net::track::Producer {
+		moq_net::broadcast::Info::new()
 			.produce()
 			.create_track(name, info)
 			.unwrap()
@@ -688,7 +688,7 @@ mod tests {
 	impl ContainerTrait for DurationWire {
 		type Error = crate::Error;
 
-		fn write(&self, group: &mut moq_net::GroupProducer, frames: &[Frame]) -> Result<(), Self::Error> {
+		fn write(&self, group: &mut moq_net::group::Producer, frames: &[Frame]) -> Result<(), Self::Error> {
 			// The duration tests write frames directly via `write_duration_frame`;
 			// this path just preserves the timestamp with an unknown duration.
 			for frame in frames {
@@ -699,7 +699,7 @@ mod tests {
 
 		fn poll_read(
 			&self,
-			group: &mut moq_net::GroupConsumer,
+			group: &mut moq_net::group::Consumer,
 			waiter: &kio::Waiter,
 		) -> Poll<Result<Option<Vec<Frame>>, Self::Error>> {
 			use bytes::Buf;
@@ -722,15 +722,15 @@ mod tests {
 	}
 
 	/// Write one DurationWire frame (timestamp and duration in µs) into a group.
-	fn write_duration_frame(group: &mut moq_net::GroupProducer, timestamp: Timestamp, duration: Timestamp) {
+	fn write_duration_frame(group: &mut moq_net::group::Producer, timestamp: Timestamp, duration: Timestamp) {
 		group
 			.write_frame(timestamp, encode_duration_frame(timestamp, duration))
 			.unwrap();
 	}
 
 	/// Write a finished group with explicit sequence and timestamps (Container::Legacy format).
-	fn write_group(track: &mut moq_net::TrackProducer, sequence: u64, timestamps: &[Timestamp]) {
-		let mut group = track.create_group(moq_net::GroupInfo { sequence }).unwrap();
+	fn write_group(track: &mut moq_net::track::Producer, sequence: u64, timestamps: &[Timestamp]) {
+		let mut group = track.create_group(moq_net::group::Info { sequence }).unwrap();
 		for &timestamp in timestamps {
 			let frame = Frame {
 				timestamp,
@@ -766,7 +766,7 @@ mod tests {
 	async fn read_single_group() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
@@ -787,7 +787,7 @@ mod tests {
 	async fn read_multiple_frames_single_group() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
@@ -808,7 +808,7 @@ mod tests {
 	async fn read_multiple_groups_within_latency() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
@@ -830,13 +830,13 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: 5 frames, NOT finished (blocks consumer)
-		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		for f in 0..5u64 {
 			Container::Legacy
 				.write(
@@ -875,14 +875,14 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::ZERO);
 
 		// Group 0 at ts 0 keeps timestamps monotonic with sequence (groups 1-9 follow at
 		// g*50 ms), so the test exercises latency skipping and not rewind detection.
-		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -917,12 +917,12 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
-		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -989,7 +989,7 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
@@ -1031,7 +1031,7 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
@@ -1069,7 +1069,7 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		// Large latency so the slow-group skip never fires; isolate the rewind path.
@@ -1098,7 +1098,7 @@ mod tests {
 	async fn backwards_timestamp_always_resets() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
@@ -1122,12 +1122,12 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
-		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -1161,7 +1161,7 @@ mod tests {
 	async fn adjacent_group_flushed_immediately() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
@@ -1182,7 +1182,7 @@ mod tests {
 	async fn bframes_within_group() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
@@ -1204,7 +1204,7 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
@@ -1225,7 +1225,7 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
@@ -1250,7 +1250,7 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
@@ -1276,7 +1276,7 @@ mod tests {
 	async fn gap_in_group_sequence_recovery() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
@@ -1297,7 +1297,7 @@ mod tests {
 	async fn gap_at_start_of_sequence() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(80));
@@ -1323,13 +1323,13 @@ mod tests {
 	async fn evicted_group_with_gap_skips_to_live() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: a frame the consumer reads, positioning it there.
-		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -1369,7 +1369,7 @@ mod tests {
 	async fn missing_sequence_skips_on_live_track() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
@@ -1402,7 +1402,7 @@ mod tests {
 	impl ContainerTrait for FailingDecode {
 		type Error = crate::Error;
 
-		fn write(&self, group: &mut moq_net::GroupProducer, frames: &[Frame]) -> Result<(), Self::Error> {
+		fn write(&self, group: &mut moq_net::group::Producer, frames: &[Frame]) -> Result<(), Self::Error> {
 			for frame in frames {
 				group.write_frame_now(frame.payload.clone())?;
 			}
@@ -1411,7 +1411,7 @@ mod tests {
 
 		fn poll_read(
 			&self,
-			group: &mut moq_net::GroupConsumer,
+			group: &mut moq_net::group::Consumer,
 			waiter: &kio::Waiter,
 		) -> Poll<Result<Option<Vec<Frame>>, Self::Error>> {
 			use bytes::Buf;
@@ -1442,7 +1442,7 @@ mod tests {
 		let mut consumer = Consumer::new(consumer_track, FailingDecode);
 
 		// A decodable frame first (so startup selects the group), then a malformed one.
-		let mut group = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		group.write_frame_now(Bytes::from(0u64.to_le_bytes().to_vec())).unwrap();
 		group.write_frame_now(Bytes::from_static(b"FAIL")).unwrap();
 		group.finish().unwrap();
@@ -1467,7 +1467,7 @@ mod tests {
 	async fn frame_timestamp_and_index_decoding() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
@@ -1490,13 +1490,13 @@ mod tests {
 	async fn frame_payload_preserved() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		let payload_bytes = vec![0x01, 0x02, 0x03, 0x04, 0x05];
-		let mut group = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group,
@@ -1531,12 +1531,12 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
 
-		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -1580,7 +1580,7 @@ mod tests {
 	async fn large_timestamps() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(3700));
@@ -1599,7 +1599,7 @@ mod tests {
 	async fn set_latency_changes_behavior() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
@@ -1620,14 +1620,14 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		// latency must exceed (group1_max - group0_min) = 100ms - 0ms = 100ms
 		// to avoid the latency skip and test B-frame timestamp tracking.
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(110));
 
-		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		for &timestamp in &[ts(0), ts(66_000), ts(33_000)] {
 			Container::Legacy
 				.write(
@@ -1675,7 +1675,7 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
@@ -1683,7 +1683,7 @@ mod tests {
 		write_group(&mut track, 3, &[ts(0)]);
 		write_group(&mut track, 5, &[ts(150_000)]);
 
-		let mut group7 = track.create_group(moq_net::GroupInfo { sequence: 7 }).unwrap();
+		let mut group7 = track.create_group(moq_net::group::Info { sequence: 7 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group7,
@@ -1731,12 +1731,12 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
-		let _group5 = track.create_group(moq_net::GroupInfo { sequence: 5 }).unwrap();
+		let _group5 = track.create_group(moq_net::group::Info { sequence: 5 }).unwrap();
 		write_group(&mut track, 7, &[ts(210_000)]);
 		track.finish().unwrap();
 
@@ -1757,7 +1757,7 @@ mod tests {
 	async fn startup_single_group_mid_stream() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
@@ -1774,12 +1774,12 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(50));
 
-		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -1813,12 +1813,12 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
-		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -1854,13 +1854,13 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0: stalled at ts=0, NOT finished
-		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		Container::Legacy
 			.write(
 				&mut group0,
@@ -1895,7 +1895,7 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
@@ -1914,12 +1914,12 @@ mod tests {
 	async fn group_error_skips_to_next() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
-		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		group0.abort(moq_net::Error::Cancel).unwrap();
 
 		write_group(&mut track, 1, &[ts(30_000)]);
@@ -1934,7 +1934,7 @@ mod tests {
 		tokio::time::pause();
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
@@ -1966,12 +1966,12 @@ mod tests {
 	async fn empty_group_advances() {
 		let mut track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
-		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		group0.finish().unwrap();
 
 		write_group(&mut track, 1, &[ts(30_000)]);
@@ -1989,13 +1989,13 @@ mod tests {
 
 		let mut track = track_producer(
 			"video",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
 		// Write frames using Container::Legacy encoding
-		let mut group = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		for i in 0..3u64 {
 			let frame = Frame {
 				timestamp: ts(i * 33_333),
@@ -2038,11 +2038,11 @@ mod tests {
 		let mut consumer = Consumer::new(consumer_track, DurationWire).with_latency(Duration::from_secs(10));
 
 		// Group 0: one frame at ts=0 lasting 33ms, never finished.
-		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		write_duration_frame(&mut group0, ts(0), ts(33_000));
 
 		// Group 1: finished, starts exactly where group 0's frame ends.
-		let mut group1 = track.create_group(moq_net::GroupInfo { sequence: 1 }).unwrap();
+		let mut group1 = track.create_group(moq_net::group::Info { sequence: 1 }).unwrap();
 		write_duration_frame(&mut group1, ts(33_000), ts(33_000));
 		group1.finish().unwrap();
 
@@ -2078,11 +2078,11 @@ mod tests {
 		let mut consumer = Consumer::new(consumer_track, DurationWire).with_latency(Duration::from_secs(10));
 
 		// Group 0: frame at ts=0 lasting only 10ms, far short of group 1 at 33ms.
-		let mut group0 = track.create_group(moq_net::GroupInfo { sequence: 0 }).unwrap();
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		write_duration_frame(&mut group0, ts(0), ts(10_000));
 
 		// Group 1: finished at 33ms.
-		let mut group1 = track.create_group(moq_net::GroupInfo { sequence: 1 }).unwrap();
+		let mut group1 = track.create_group(moq_net::group::Info { sequence: 1 }).unwrap();
 		write_duration_frame(&mut group1, ts(33_000), ts(33_000));
 		group1.finish().unwrap();
 		track.finish().unwrap();

--- a/rs/moq-mux/src/container/flv/export.rs
+++ b/rs/moq-mux/src/container/flv/export.rs
@@ -77,7 +77,7 @@ impl Flavor {
 /// keyframe). Only Legacy and LOC container tracks (raw codec payloads) are
 /// supported; CMAF tracks are rejected.
 pub struct Export {
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 	catalog: Option<crate::catalog::Consumer>,
 	latency: Duration,
 
@@ -121,14 +121,14 @@ impl FlvTrack {
 impl Export {
 	/// Subscribe to `broadcast` and produce FLV byte chunks, using the default
 	/// catalog format ([`CatalogFormat::Hang`]).
-	pub async fn new(broadcast: moq_net::BroadcastConsumer) -> Result<Self, crate::Error> {
+	pub async fn new(broadcast: moq_net::broadcast::Consumer) -> Result<Self, crate::Error> {
 		Self::with_catalog_format(broadcast, CatalogFormat::default()).await
 	}
 
 	/// Subscribe to `broadcast` and produce FLV byte chunks, selecting an explicit
 	/// `catalog_format` for track discovery.
 	pub async fn with_catalog_format(
-		broadcast: moq_net::BroadcastConsumer,
+		broadcast: moq_net::broadcast::Consumer,
 		catalog_format: CatalogFormat,
 	) -> Result<Self, crate::Error> {
 		let catalog = crate::catalog::Consumer::new(&broadcast, catalog_format).await?;

--- a/rs/moq-mux/src/container/flv/export_test.rs
+++ b/rs/moq-mux/src/container/flv/export_test.rs
@@ -124,7 +124,7 @@ async fn drain_export(mut exporter: Export, mut importer: Import) -> Vec<u8> {
 
 #[tokio::test(start_paused = true)]
 async fn export_roundtrips_through_import() {
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
@@ -139,7 +139,7 @@ async fn export_roundtrips_through_import() {
 	assert_eq!(&exported[0..3], b"FLV");
 
 	// Re-import the exported bytes and confirm the catalog rebuilds identically.
-	let mut bcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
 	let mut imp2 = Import::new(bcast2, cat2.clone());
 	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
@@ -161,7 +161,7 @@ async fn export_roundtrips_through_import() {
 
 #[tokio::test(start_paused = true)]
 async fn export_emits_sequence_headers_and_frames() {
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
@@ -243,7 +243,7 @@ fn synth_enhanced_flv() -> Vec<u8> {
 /// round trip as enhanced-RTMP FourCC payloads.
 #[tokio::test(start_paused = true)]
 async fn export_roundtrips_enhanced() {
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
@@ -273,7 +273,7 @@ async fn export_roundtrips_enhanced() {
 	);
 
 	// Re-import the exported bytes and confirm the codecs rebuild.
-	let mut bcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
 	let mut imp2 = Import::new(bcast2, cat2.clone());
 	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
@@ -308,7 +308,7 @@ async fn export_roundtrips_mp3() {
 	tag.extend_from_slice(&mp3);
 	write_tag(&mut flv, super::TAG_AUDIO, 0, &tag);
 
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
@@ -328,7 +328,7 @@ async fn export_roundtrips_mp3() {
 	);
 
 	// Re-import and confirm the codec rebuilds.
-	let mut bcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
 	let mut imp2 = Import::new(bcast2, cat2.clone());
 	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
@@ -359,7 +359,7 @@ fn synth_av1_flv() -> Vec<u8> {
 
 #[tokio::test(start_paused = true)]
 async fn export_roundtrips_av1() {
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
@@ -388,7 +388,7 @@ async fn export_roundtrips_av1() {
 		"expected an AV1 enhanced frame"
 	);
 
-	let mut bcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
 	let mut imp2 = Import::new(bcast2, cat2.clone());
 	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
@@ -412,7 +412,7 @@ fn synth_enhanced_audio_flv(fourcc: &[u8; 4], frame: &[u8]) -> Vec<u8> {
 
 #[tokio::test(start_paused = true)]
 async fn export_roundtrips_ac3() {
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
@@ -433,7 +433,7 @@ async fn export_roundtrips_ac3() {
 		"expected an enhanced AC-3 audio tag"
 	);
 
-	let mut bcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
 	let mut imp2 = Import::new(bcast2, cat2.clone());
 	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
@@ -446,7 +446,7 @@ async fn export_roundtrips_ac3() {
 
 #[tokio::test(start_paused = true)]
 async fn export_roundtrips_eac3() {
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
@@ -467,7 +467,7 @@ async fn export_roundtrips_eac3() {
 		"expected an enhanced E-AC-3 audio tag"
 	);
 
-	let mut bcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
 	let mut imp2 = Import::new(bcast2, cat2.clone());
 	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
@@ -510,7 +510,7 @@ fn parse_tags(flv: &[u8]) -> Vec<ParsedTag> {
 /// A frame's presentation timestamp must survive as DTS plus composition time.
 #[tokio::test(start_paused = true)]
 async fn export_preserves_timestamps() {
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
@@ -535,7 +535,7 @@ async fn export_authors_dts_and_composition_time_for_reordered_avc() {
 	use hang::catalog::{AAC, AudioConfig, Container, H264, VideoConfig};
 	use moq_net::Timestamp;
 
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -46,7 +46,7 @@ const MAX_DATA_OFFSET: usize = 64 * 1024;
 /// and dropped. A single FLV stream carries at most one video and one audio
 /// track; a new sequence header replaces the previous configuration.
 pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
-	broadcast: moq_net::BroadcastProducer,
+	broadcast: moq_net::broadcast::Producer,
 	catalog: crate::catalog::Producer<E>,
 
 	/// Accumulated unparsed input. Whole tags are drained out; a trailing partial
@@ -74,7 +74,7 @@ struct AudioStream {
 
 impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	/// Create a demuxer publishing into `broadcast` with renditions announced on `catalog`.
-	pub fn new(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer<E>) -> Self {
+	pub fn new(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
 		Self {
 			broadcast,
 			catalog,
@@ -398,27 +398,27 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 	/// Drop any existing video track (finishing it and clearing its catalog
 	/// rendition) and allocate a fresh one.
-	fn replace_video(&mut self) -> anyhow::Result<moq_net::TrackProducer> {
+	fn replace_video(&mut self) -> anyhow::Result<moq_net::track::Producer> {
 		if let Some(mut old) = self.video.take() {
 			old.track.finish()?;
 			self.catalog.lock().video.renditions.remove(old.track.name());
 		}
 		Ok(self.broadcast.unique_track(
 			".flv-v",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)?)
 	}
 
 	/// Drop any existing audio track (finishing it and clearing its catalog
 	/// rendition) and allocate a fresh one.
-	fn replace_audio(&mut self) -> anyhow::Result<moq_net::TrackProducer> {
+	fn replace_audio(&mut self) -> anyhow::Result<moq_net::track::Producer> {
 		if let Some(mut old) = self.audio.take() {
 			old.track.finish()?;
 			self.catalog.lock().audio.renditions.remove(old.track.name());
 		}
 		Ok(self.broadcast.unique_track(
 			".flv-a",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)?)
 	}
 

--- a/rs/moq-mux/src/container/flv/import_test.rs
+++ b/rs/moq-mux/src/container/flv/import_test.rs
@@ -88,7 +88,7 @@ fn synth_flv() -> Vec<u8> {
 
 #[tokio::test(start_paused = true)]
 async fn import_populates_catalog() {
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
 	let mut importer = Import::new(producer, catalog.clone());
@@ -113,7 +113,7 @@ async fn import_populates_catalog() {
 
 #[tokio::test(start_paused = true)]
 async fn import_emits_frames() {
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
@@ -143,7 +143,7 @@ async fn import_handles_split_input() {
 	let flv = synth_flv();
 	let (head, tail) = flv.split_at(flv.len() / 2);
 
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
 	let mut importer = Import::new(producer, catalog.clone());
@@ -177,7 +177,7 @@ async fn import_enhanced_vp9() {
 	body.extend_from_slice(VP9_KEYFRAME_320X240);
 	write_tag(&mut out, super::TAG_VIDEO, 0, &body);
 
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let mut importer = Import::new(producer, catalog.clone());
 	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
@@ -221,7 +221,7 @@ async fn import_enhanced_opus() {
 	frame.extend_from_slice(&[0xfc, 0xff, 0xfe]);
 	write_tag(&mut out, super::TAG_AUDIO, 20, &frame);
 
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let mut importer = Import::new(producer, catalog.clone());
 	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
@@ -256,7 +256,7 @@ async fn import_legacy_mp3() {
 	tag.extend_from_slice(&mp3);
 	write_tag(&mut out, super::TAG_AUDIO, 0, &tag);
 
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let mut importer = Import::new(producer, catalog.clone());
 	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
@@ -286,7 +286,7 @@ async fn import_enhanced_av1() {
 	frame.extend_from_slice(&payload);
 	write_tag(&mut out, super::TAG_VIDEO, 33, &frame);
 
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let mut importer = Import::new(producer, catalog.clone());
@@ -314,7 +314,7 @@ async fn import_enhanced_ac3() {
 	frame.extend_from_slice(&AC3_FRAME);
 	write_tag(&mut out, super::TAG_AUDIO, 0, &frame);
 
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let mut importer = Import::new(producer, catalog.clone());
 	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
@@ -336,7 +336,7 @@ async fn import_enhanced_eac3() {
 	frame.extend_from_slice(&EAC3_FRAME);
 	write_tag(&mut out, super::TAG_AUDIO, 0, &frame);
 
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let mut importer = Import::new(producer, catalog.clone());
 	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
@@ -384,7 +384,7 @@ async fn import_reports_negative_pts_and_can_resume() {
 	good.extend_from_slice(&[0, 0, 0, 1, 0x65]);
 	write_tag(&mut out, super::TAG_VIDEO, 10, &good);
 
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let mut importer = Import::new(producer, catalog.clone());
@@ -425,7 +425,7 @@ async fn import_enhanced_hvc1_applies_composition_time() {
 	coded.extend_from_slice(&[0, 0, 0, 1, 0x65]);
 	write_tag(&mut out, super::TAG_VIDEO, 10, &coded);
 
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let mut importer = Import::new(producer, catalog.clone());
@@ -443,7 +443,7 @@ async fn import_enhanced_hvc1_applies_composition_time() {
 
 #[tokio::test(start_paused = true)]
 async fn import_rejects_non_flv() {
-	let mut producer = moq_net::BroadcastInfo::new().produce();
+	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
 	let mut importer = Import::new(producer, catalog);

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -15,7 +15,7 @@ use moq_net::Timestamp;
 
 /// Subscribe to a moq broadcast and produce a single fMP4 / CMAF byte stream.
 ///
-/// Built from a [`moq_net::BroadcastConsumer`], `Export` subscribes to the hang catalog,
+/// Built from a [`moq_net::broadcast::Consumer`], `Export` subscribes to the hang catalog,
 /// (un)subscribes per-rendition tracks as the catalog changes, decodes both Legacy and
 /// CMAF tracks via a per-track source, and re-encodes everything as a merged init
 /// segment + moof+mdat fragments in presentation-timestamp order across tracks. This
@@ -35,7 +35,7 @@ use moq_net::Timestamp;
 /// onto segments and parts; narrow the catalog to a single rendition with
 /// [`Stream::select`](crate::catalog::Stream::select) so the fragments belong to one track.
 pub struct Export<S: Stream> {
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 	catalog: Option<S>,
 	latency: Duration,
 	fragment_duration: Option<Duration>,
@@ -106,7 +106,7 @@ impl<S: Stream> Export<S> {
 	/// `catalog` is any [`Stream`] of catalog snapshots, typically a
 	/// [`catalog::Consumer`](crate::catalog::Consumer) directly, or narrowed to
 	/// one rendition set via [`Stream::select`](crate::catalog::Stream::select).
-	pub fn new(broadcast: moq_net::BroadcastConsumer, catalog: S) -> Self {
+	pub fn new(broadcast: moq_net::broadcast::Consumer, catalog: S) -> Self {
 		Self {
 			broadcast,
 			catalog: Some(catalog),

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -19,7 +19,7 @@ async fn avc3_source_to_cmaf_export_roundtrip() {
 	use hang::catalog::{Container, H264, VideoConfig};
 	use moq_net::Timestamp;
 
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let consumer = producer.consume();
 
@@ -27,7 +27,7 @@ async fn avc3_source_to_cmaf_export_roundtrip() {
 	let track = producer
 		.create_track(
 			producer.unique_name(".avc3"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let mut config = VideoConfig::new(H264 {
@@ -123,7 +123,7 @@ async fn legacy_aac_source_to_cmaf_export_synthesizes_esds() {
 	use hang::catalog::{AAC, AudioConfig, Container};
 	use moq_net::Timestamp;
 
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let consumer = producer.consume();
 
@@ -131,7 +131,7 @@ async fn legacy_aac_source_to_cmaf_export_synthesizes_esds() {
 	let track = producer
 		.create_track(
 			producer.unique_name(".aac"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 
@@ -218,7 +218,7 @@ async fn vp8_source_to_cmaf_export_synthesizes_vp08() {
 	use hang::catalog::{Container, VideoCodec, VideoConfig};
 	use moq_net::Timestamp;
 
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let consumer = producer.consume();
 
@@ -226,7 +226,7 @@ async fn vp8_source_to_cmaf_export_synthesizes_vp08() {
 	let track = producer
 		.create_track(
 			producer.unique_name(".vp8"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let mut config = VideoConfig::new(VideoCodec::VP8);
@@ -296,7 +296,7 @@ async fn vp9_source_to_cmaf_export_synthesizes_vp09() {
 	use hang::catalog::{Container, VP9, VideoConfig};
 	use moq_net::Timestamp;
 
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let consumer = producer.consume();
 
@@ -304,7 +304,7 @@ async fn vp9_source_to_cmaf_export_synthesizes_vp09() {
 	let track = producer
 		.create_track(
 			producer.unique_name(".vp9"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let mut config = VideoConfig::new(VP9 {
@@ -386,7 +386,7 @@ async fn av1_source_to_cmaf_export_synthesizes_av01() {
 	use hang::catalog::{AV1, Container, VideoConfig};
 	use moq_net::Timestamp;
 
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let consumer = producer.consume();
 
@@ -394,7 +394,7 @@ async fn av1_source_to_cmaf_export_synthesizes_av01() {
 	let track = producer
 		.create_track(
 			producer.unique_name(".av01"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let mut config = VideoConfig::new(AV1 {
@@ -486,7 +486,7 @@ async fn av1_source_to_cmaf_export_synthesizes_av01() {
 async fn cmaf_source_to_cmaf_export_passthrough() {
 	let data = include_bytes!("test_data/bbb.mp4");
 
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let consumer = producer.consume();
 
@@ -542,7 +542,7 @@ async fn next_fragment_reports_segment_metadata() {
 	use hang::catalog::{Container, H264, VideoConfig};
 	use moq_net::Timestamp;
 
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let consumer = producer.consume();
 
@@ -550,7 +550,7 @@ async fn next_fragment_reports_segment_metadata() {
 	let track = producer
 		.create_track(
 			producer.unique_name(".avc3"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let mut config = VideoConfig::new(H264 {

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -27,7 +27,7 @@ use crate::Result;
 /// - FLAC
 pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
 	/// The broadcast being produced
-	broadcast: moq_net::BroadcastProducer,
+	broadcast: moq_net::broadcast::Producer,
 
 	/// The catalog being produced
 	catalog: crate::catalog::Producer<E>,
@@ -63,8 +63,8 @@ enum TrackKind {
 struct Fmp4Track {
 	kind: TrackKind,
 
-	track: moq_net::TrackProducer,
-	group: Option<moq_net::GroupProducer>,
+	track: moq_net::track::Producer,
+	group: Option<moq_net::group::Producer>,
 
 	// The minimum buffer required for the track.
 	jitter: Option<Timestamp>,
@@ -83,7 +83,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	/// Create a new CMAF importer that will write to the given broadcast.
 	///
 	/// The broadcast will be populated with tracks as they're discovered in the fMP4 file.
-	pub fn new(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer<E>) -> Self {
+	pub fn new(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
 		Self {
 			catalog,
 			select: None,
@@ -212,7 +212,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			let timescale = moq_net::Timescale::new(trak.mdia.mdhd.timescale as u64)?;
 			let track = self.broadcast.create_track(
 				self.broadcast.unique_name(suffix),
-				moq_net::TrackInfo::default().with_timescale(timescale),
+				moq_net::track::Info::default().with_timescale(timescale),
 			)?;
 
 			match kind {
@@ -712,7 +712,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 					prev.finish()?;
 				}
 				match track.pending_sequence.take() {
-					Some(sequence) => track.track.create_group(moq_net::GroupInfo { sequence })?,
+					Some(sequence) => track.track.create_group(moq_net::group::Info { sequence })?,
 					None => track.track.append_group()?,
 				}
 			} else {
@@ -723,7 +723,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			// in the track's native timescale. The relay reads it off the wire; the
 			// consumer still drives playback from the fragment's internal timing.
 			let timestamp = min_timestamp.ok_or(Error::MissingTrun)?;
-			let mut frame = g.create_frame(moq_net::FrameInfo {
+			let mut frame = g.create_frame(moq_net::frame::Info {
 				size: fragment_bytes.len() as u64,
 				timestamp,
 			})?;

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -5,7 +5,7 @@ use mp4_atom::{Decode, Encode};
 /// Drain every group currently buffered on the consumer without waiting for new ones.
 /// Used in tests where the producer is still alive after writing.
 #[cfg(test)]
-fn drain_group_sequences(consumer: &mut moq_net::TrackSubscriber) -> Vec<u64> {
+fn drain_group_sequences(consumer: &mut moq_net::track::Subscriber) -> Vec<u64> {
 	let mut sequences = Vec::new();
 	while let Some(group) = consumer.recv_group().now_or_never().and_then(|r| r.ok().flatten()) {
 		sequences.push(group.sequence);
@@ -14,7 +14,7 @@ fn drain_group_sequences(consumer: &mut moq_net::TrackSubscriber) -> Vec<u64> {
 }
 
 fn run_fmp4(data: &[u8]) -> crate::catalog::hang::Catalog {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.clone());
@@ -27,7 +27,7 @@ fn run_fmp4(data: &[u8]) -> crate::catalog::hang::Catalog {
 }
 
 fn run_fmp4_select(data: &[u8], select: crate::select::Broadcast) -> crate::catalog::hang::Catalog {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.clone()).with_select(select);
@@ -198,7 +198,7 @@ fn test_vp9_catalog() {
 async fn test_seek_sets_initial_sequence() {
 	use mp4_atom::{Any, DecodeMaybe};
 
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let broadcast_consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.clone());
@@ -262,7 +262,7 @@ async fn test_seek_sets_initial_sequence() {
 /// exercises the full unified pipeline (hang -> MSF JSON on the wire -> hang).
 #[tokio::test]
 async fn test_msf_catalog_roundtrip() {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	// Take the consumer before adding tracks; track() is called after the
 	// MSF catalog track has been created by `catalog::Producer::new`.
 	let consumer = broadcast.consume();

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -187,7 +187,7 @@ impl Wire {
 impl Container for Wire {
 	type Error = Error;
 
-	fn write(&self, group: &mut moq_net::GroupProducer, frames: &[Frame]) -> std::result::Result<(), Self::Error> {
+	fn write(&self, group: &mut moq_net::group::Producer, frames: &[Frame]) -> std::result::Result<(), Self::Error> {
 		let timescale = moq_net::Timescale::new(self.trak.mdia.mdhd.timescale as u64)?;
 		let track_id = self.trak.tkhd.track_id;
 		encode(group, frames, timescale, track_id)
@@ -195,7 +195,7 @@ impl Container for Wire {
 
 	fn poll_read(
 		&self,
-		group: &mut moq_net::GroupConsumer,
+		group: &mut moq_net::group::Consumer,
 		waiter: &kio::Waiter,
 	) -> Poll<std::result::Result<Option<Vec<Frame>>, Self::Error>> {
 		use std::task::ready;
@@ -297,7 +297,7 @@ pub(crate) fn decode(data: Bytes, timescale: moq_net::Timescale) -> Result<Vec<F
 }
 
 pub(crate) fn encode(
-	group: &mut moq_net::GroupProducer,
+	group: &mut moq_net::group::Producer,
 	frames: &[Frame],
 	timescale: moq_net::Timescale,
 	track_id: u32,
@@ -310,7 +310,7 @@ pub(crate) fn encode(
 	let bytes = encode_fragment(track_id, timescale, sequence_number, frames)?;
 	// The fragment may carry several samples; the net frame's timestamp is the
 	// fragment's earliest presentation time so a relay can order it.
-	let mut writer = group.create_frame(moq_net::FrameInfo {
+	let mut writer = group.create_frame(moq_net::frame::Info {
 		size: bytes.len() as u64,
 		timestamp: frames[0].timestamp,
 	})?;

--- a/rs/moq-mux/src/container/legacy/mod.rs
+++ b/rs/moq-mux/src/container/legacy/mod.rs
@@ -17,7 +17,7 @@ pub struct Wire;
 impl Container for Wire {
 	type Error = crate::Error;
 
-	fn write(&self, group: &mut moq_net::GroupProducer, frames: &[Frame]) -> Result<(), Self::Error> {
+	fn write(&self, group: &mut moq_net::group::Producer, frames: &[Frame]) -> Result<(), Self::Error> {
 		for frame in frames {
 			let hang_frame = hang::container::Frame {
 				timestamp: frame.timestamp,
@@ -30,7 +30,7 @@ impl Container for Wire {
 
 	fn poll_read(
 		&self,
-		group: &mut moq_net::GroupConsumer,
+		group: &mut moq_net::group::Consumer,
 		waiter: &kio::Waiter,
 	) -> Poll<Result<Option<Vec<Frame>>, Self::Error>> {
 		use std::task::ready;

--- a/rs/moq-mux/src/container/loc/mod.rs
+++ b/rs/moq-mux/src/container/loc/mod.rs
@@ -22,7 +22,7 @@ pub struct Wire;
 impl Container for Wire {
 	type Error = crate::Error;
 
-	fn write(&self, group: &mut moq_net::GroupProducer, frames: &[Frame]) -> Result<(), Self::Error> {
+	fn write(&self, group: &mut moq_net::group::Producer, frames: &[Frame]) -> Result<(), Self::Error> {
 		for frame in frames {
 			// LOC's wire format omits per-frame timescale by convention; the catalog
 			// default is microseconds, so convert at the boundary.
@@ -31,7 +31,7 @@ impl Container for Wire {
 
 			// Carry the timestamp on the net frame too (converted to the track's
 			// timescale), so a relay sees it without parsing the LOC payload.
-			let mut chunked = group.create_frame(moq_net::FrameInfo {
+			let mut chunked = group.create_frame(moq_net::frame::Info {
 				size: data.len() as u64,
 				timestamp: frame.timestamp,
 			})?;
@@ -43,7 +43,7 @@ impl Container for Wire {
 
 	fn poll_read(
 		&self,
-		group: &mut moq_net::GroupConsumer,
+		group: &mut moq_net::group::Consumer,
 		waiter: &kio::Waiter,
 	) -> Poll<Result<Option<Vec<Frame>>, Self::Error>> {
 		use std::task::ready;

--- a/rs/moq-mux/src/container/mkv/export.rs
+++ b/rs/moq-mux/src/container/mkv/export.rs
@@ -19,7 +19,7 @@ const TIMESTAMP_SCALE_NS: u64 = 1_000_000;
 
 /// Subscribe to a moq broadcast and produce a single Matroska / WebM byte stream.
 ///
-/// Built from a [`moq_net::BroadcastConsumer`], `Export` subscribes to the hang catalog,
+/// Built from a [`moq_net::broadcast::Consumer`], `Export` subscribes to the hang catalog,
 /// (un)subscribes per-rendition tracks, decodes them via a per-track source, and
 /// re-encodes everything as EBML + Segment + Tracks + Cluster/SimpleBlock tags ready
 /// for any Matroska-aware consumer (ffplay, libwebm, browser MSE for WebM).
@@ -45,7 +45,7 @@ const TIMESTAMP_SCALE_NS: u64 = 1_000_000;
 /// Only Legacy-container tracks (raw codec payloads) are supported. CMAF tracks
 /// (moof+mdat passthrough) are rejected with a clear error.
 pub struct Export<S: Stream> {
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 	catalog: Option<S>,
 	latency: Duration,
 	fragment_duration: Option<Duration>,
@@ -158,7 +158,7 @@ impl<S: Stream> Export<S> {
 	/// `catalog` is any [`Stream`] of catalog snapshots, typically a
 	/// [`catalog::Consumer`](crate::catalog::Consumer) directly, or narrowed to
 	/// one rendition set via [`Stream::select`](crate::catalog::Stream::select).
-	pub fn new(broadcast: moq_net::BroadcastConsumer, catalog: S) -> Self {
+	pub fn new(broadcast: moq_net::broadcast::Consumer, catalog: S) -> Self {
 		Self {
 			broadcast,
 			catalog: Some(catalog),

--- a/rs/moq-mux/src/container/mkv/export_test.rs
+++ b/rs/moq-mux/src/container/mkv/export_test.rs
@@ -17,7 +17,7 @@ async fn export_header_roundtrip_vp9_opus() {
 	let import_bytes = synth_webm();
 
 	// Ingest into a broadcast.
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let consumer = producer.consume();
 
@@ -123,7 +123,7 @@ async fn export_header_roundtrip_vp9_opus() {
 
 	// Verify the round-trip by re-importing the header (a header alone is enough
 	// to populate the catalog).
-	let mut broadcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 	let catalog2 = crate::catalog::Producer::new(&mut broadcast2).unwrap();
 	let mut importer2 = crate::container::mkv::Import::new(broadcast2, catalog2.clone());
 	let hbuf = bytes::BytesMut::from(header.as_ref());
@@ -197,7 +197,7 @@ fn build_flac_audio_track_entry() {
 async fn export_header_roundtrip_mp3() {
 	let import_bytes = synth_matroska_mp3();
 
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let consumer = producer.consume();
 
@@ -220,7 +220,7 @@ async fn export_header_roundtrip_mp3() {
 		.expect("expected header bytes");
 
 	// Re-import the exported header and confirm the codec rebuilds.
-	let mut broadcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 	let catalog2 = crate::catalog::Producer::new(&mut broadcast2).unwrap();
 	let mut importer2 = crate::container::mkv::Import::new(broadcast2, catalog2.clone());
 	importer2.decode(&bytes::BytesMut::from(header.as_ref())).unwrap();
@@ -279,7 +279,7 @@ fn synth_matroska_mp3() -> Vec<u8> {
 /// pending until the catalog lands.
 #[tokio::test(start_paused = true)]
 async fn export_waits_for_catalog_before_header() {
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let consumer = producer.consume();
 
@@ -310,7 +310,7 @@ async fn export_emits_blocks_for_each_frame() {
 	// of SimpleBlock elements with the right track assignments.
 	let import_bytes = synth_webm_with_frames();
 
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let consumer = producer.consume();
 
@@ -362,7 +362,7 @@ async fn export_emits_blocks_for_each_frame() {
 
 	// Round-trip verification: feed the exported bytes back through the importer
 	// and check the catalog repopulates with the same codecs.
-	let mut bcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
 	let mut imp2 = crate::container::mkv::Import::new(bcast2, cat2.clone());
 	let rt = bytes::BytesMut::from(exported.as_slice());
@@ -387,7 +387,7 @@ async fn export_rejects_cmaf_track() {
 	// video track. The exporter should bail.
 	use hang::catalog::{Container, H264, VideoConfig};
 
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let consumer = producer.consume();
 
@@ -395,7 +395,7 @@ async fn export_rejects_cmaf_track() {
 	let track = producer
 		.create_track(
 			producer.unique_name(".avc1"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let mut config = VideoConfig::new(H264 {
@@ -433,7 +433,7 @@ async fn export_avc3_source_synthesizes_avcc_and_length_prefixes() {
 	use hang::catalog::{Container, H264, VideoConfig};
 	use moq_net::Timestamp;
 
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let consumer = producer.consume();
 
@@ -441,7 +441,7 @@ async fn export_avc3_source_synthesizes_avcc_and_length_prefixes() {
 	let track = producer
 		.create_track(
 			producer.unique_name(".avc3"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let mut config = VideoConfig::new(H264 {
@@ -599,7 +599,7 @@ async fn export_avc3_source_synthesizes_avcc_and_length_prefixes() {
 	// avcC carried through as `description`. This catches subtle structural
 	// mistakes in the avcC layout that the slot-by-slot check above might
 	// pass even when the record as a whole is malformed.
-	let mut bcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
 	let mut imp2 = crate::container::mkv::Import::new(bcast2, cat2.clone());
 	let rt = bytes::BytesMut::from(exported.as_slice());
@@ -622,7 +622,7 @@ async fn export_fragment_duration_batches_blocks() {
 	// should land in ONE Cluster (vs 5 separate Clusters in per-frame mode).
 	let import_bytes = synth_webm_with_frames();
 
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let consumer = producer.consume();
 

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -39,7 +39,7 @@ const DEFAULT_TIMESTAMP_SCALE_NS: u64 = 1_000_000;
 ///
 /// Unsupported codecs (e.g. Vorbis, AC3, subtitles) are logged and dropped.
 pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
-	broadcast: moq_net::BroadcastProducer,
+	broadcast: moq_net::broadcast::Producer,
 	catalog: crate::catalog::Producer<E>,
 
 	/// Accumulated unparsed input.
@@ -65,14 +65,14 @@ enum TrackKind {
 struct MkvTrack {
 	kind: TrackKind,
 	track: crate::container::Producer<crate::catalog::hang::Container>,
-	group: Option<moq_net::GroupProducer>,
+	group: Option<moq_net::group::Producer>,
 	/// Highest block timestamp (Matroska ticks: cluster_ts + block_relative) already emitted.
 	/// Used to dedup re-parsed blocks across decode() calls.
 	last_emitted_ticks: Option<i64>,
 }
 
 impl<E: crate::catalog::hang::CatalogExt> Import<E> {
-	pub fn new(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer<E>) -> Self {
+	pub fn new(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
 		Self {
 			broadcast,
 			catalog,
@@ -265,7 +265,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 		let track = self.broadcast.create_track(
 			self.broadcast.unique_name(suffix),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)?;
 		let mut catalog = self.catalog.clone();
 		let mut catalog = catalog.lock();

--- a/rs/moq-mux/src/container/mkv/import_test.rs
+++ b/rs/moq-mux/src/container/mkv/import_test.rs
@@ -179,7 +179,7 @@ fn track_entry_video_vp9(number: u64, width: u64, height: u64) -> MatroskaSpec {
 }
 
 fn run(data: &[u8]) -> crate::catalog::hang::Catalog {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut mkv = crate::container::mkv::Import::new(broadcast, catalog.clone());
 	let buf = bytes::BytesMut::from(data);
@@ -310,7 +310,7 @@ fn test_chunked_decode_dedup() {
 		.segment_end()
 		.build();
 
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut mkv = crate::container::mkv::Import::new(broadcast, catalog.clone());
 

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -91,7 +91,7 @@ pub trait Container {
 	type Error: std::error::Error + Send + Sync + Unpin + From<moq_net::Error> + From<MissingKeyframe>;
 
 	/// Encode one or more frames into a single moq-lite frame appended to `group`.
-	fn write(&self, group: &mut moq_net::GroupProducer, frames: &[Frame]) -> Result<(), Self::Error>;
+	fn write(&self, group: &mut moq_net::group::Producer, frames: &[Frame]) -> Result<(), Self::Error>;
 
 	/// Poll the next moq-lite frame from `group` and decode it into media
 	/// frames. Returns `Ok(None)` when the group has ended. A single call
@@ -99,14 +99,14 @@ pub trait Container {
 	/// fragment).
 	fn poll_read(
 		&self,
-		group: &mut moq_net::GroupConsumer,
+		group: &mut moq_net::group::Consumer,
 		waiter: &kio::Waiter,
 	) -> Poll<Result<Option<Vec<Frame>>, Self::Error>>;
 
 	/// Async wrapper around [`Self::poll_read`].
 	fn read(
 		&self,
-		group: &mut moq_net::GroupConsumer,
+		group: &mut moq_net::group::Consumer,
 	) -> impl std::future::Future<Output = Result<Option<Vec<Frame>>, Self::Error>>
 	where
 		Self: Sync,

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -27,9 +27,9 @@ use super::{Container, Frame};
 ///
 /// This is useful for CMAF where multiple samples should be packed into one moof+mdat.
 pub struct Producer<C: Container> {
-	inner: moq_net::TrackProducer,
+	inner: moq_net::track::Producer,
 	container: C,
-	group: Option<moq_net::GroupProducer>,
+	group: Option<moq_net::group::Producer>,
 	buffer: Vec<Frame>,
 
 	latency: std::time::Duration,
@@ -41,7 +41,7 @@ pub struct Producer<C: Container> {
 
 impl<C: Container> Producer<C> {
 	/// Create a new Producer wrapping the given moq-lite producer.
-	pub fn new(track: moq_net::TrackProducer, container: C) -> Self {
+	pub fn new(track: moq_net::track::Producer, container: C) -> Self {
 		Self {
 			inner: track,
 			container,
@@ -54,7 +54,7 @@ impl<C: Container> Producer<C> {
 
 	/// The underlying moq-lite track producer. Read-only; mutating it directly
 	/// would sidestep group/keyframe invariants.
-	pub fn track(&self) -> &moq_net::TrackProducer {
+	pub fn track(&self) -> &moq_net::track::Producer {
 		&self.inner
 	}
 
@@ -90,7 +90,7 @@ impl<C: Container> Producer<C> {
 				return Err(super::MissingKeyframe.into());
 			}
 			self.group = Some(match self.pending_sequence.take() {
-				Some(sequence) => self.inner.create_group(moq_net::GroupInfo { sequence })?,
+				Some(sequence) => self.inner.create_group(moq_net::group::Info { sequence })?,
 				None => self.inner.append_group()?,
 			});
 		}
@@ -195,13 +195,13 @@ impl<C: Container> Producer<C> {
 	}
 
 	/// Create a consumer for this track.
-	pub fn consume(&self) -> moq_net::TrackSubscriber {
+	pub fn consume(&self) -> moq_net::track::Subscriber {
 		self.inner.subscribe(None)
 	}
 }
 
 impl<C: Container> std::ops::Deref for Producer<C> {
-	type Target = moq_net::TrackProducer;
+	type Target = moq_net::track::Producer;
 
 	fn deref(&self) -> &Self::Target {
 		&self.inner
@@ -220,9 +220,9 @@ mod tests {
 	/// born from their broadcast (no public `TrackProducer::new`).
 	fn track_producer(
 		name: impl Into<std::sync::Arc<str>>,
-		info: impl Into<Option<moq_net::TrackInfo>>,
-	) -> moq_net::TrackProducer {
-		moq_net::BroadcastInfo::new()
+		info: impl Into<Option<moq_net::track::Info>>,
+	) -> moq_net::track::Producer {
+		moq_net::broadcast::Info::new()
 			.produce()
 			.create_track(name, info)
 			.unwrap()
@@ -238,7 +238,7 @@ mod tests {
 	}
 
 	/// Drain all groups from a finished track, returning their frame counts.
-	async fn collect_groups(mut consumer: moq_net::TrackSubscriber) -> Vec<usize> {
+	async fn collect_groups(mut consumer: moq_net::track::Subscriber) -> Vec<usize> {
 		let mut groups = Vec::new();
 		while let Some(mut group) = consumer.recv_group().await.unwrap() {
 			let mut count = 0;
@@ -255,7 +255,7 @@ mod tests {
 	async fn keyframe_closes_group_immediately() {
 		let track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer = track.subscribe(None);
 		let mut producer = Producer::new(track, Container::Legacy);
@@ -274,7 +274,7 @@ mod tests {
 	async fn finish_group_closes_immediately() {
 		let track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer = track.subscribe(None);
 		let mut producer = Producer::new(track, Container::Legacy);
@@ -293,7 +293,7 @@ mod tests {
 	fn first_frame_must_be_keyframe() {
 		let track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let mut producer = Producer::new(track, Container::Legacy);
 
@@ -302,7 +302,7 @@ mod tests {
 	}
 
 	/// Drain all groups from a finished track, returning their sequence numbers.
-	async fn collect_sequences(mut consumer: moq_net::TrackSubscriber) -> Vec<u64> {
+	async fn collect_sequences(mut consumer: moq_net::track::Subscriber) -> Vec<u64> {
 		let mut sequences = Vec::new();
 		while let Some(group) = consumer.recv_group().await.unwrap() {
 			sequences.push(group.sequence);
@@ -315,7 +315,7 @@ mod tests {
 	async fn seek_uses_explicit_sequence() {
 		let track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer = track.subscribe(None);
 		let mut producer = Producer::new(track, Container::Legacy);
@@ -333,7 +333,7 @@ mod tests {
 	async fn seek_clears_pending_after_use() {
 		let track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let consumer = track.subscribe(None);
 		let mut producer = Producer::new(track, Container::Legacy);
@@ -354,14 +354,14 @@ mod tests {
 	impl super::Container for Recording {
 		type Error = crate::Error;
 
-		fn write(&self, _group: &mut moq_net::GroupProducer, frames: &[Frame]) -> Result<(), Self::Error> {
+		fn write(&self, _group: &mut moq_net::group::Producer, frames: &[Frame]) -> Result<(), Self::Error> {
 			self.0.borrow_mut().push(frames.to_vec());
 			Ok(())
 		}
 
 		fn poll_read(
 			&self,
-			_group: &mut moq_net::GroupConsumer,
+			_group: &mut moq_net::group::Consumer,
 			_waiter: &kio::Waiter,
 		) -> std::task::Poll<Result<Option<Vec<Frame>>, Self::Error>> {
 			unreachable!("Recording is write-only")
@@ -374,7 +374,7 @@ mod tests {
 	async fn keyframe_backfills_batched_durations() {
 		let track = track_producer(
 			"test",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		);
 		let recording = Recording::default();
 		let mut producer = Producer::new(track, recording.clone()).with_latency(std::time::Duration::from_secs(10));

--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -49,7 +49,7 @@ impl VideoTransform {
 /// A subscription that resolves on first poll, then the live consumer.
 enum SourceState {
 	/// Waiting for the subscription to resolve (blocks on the publisher's SUBSCRIBE_OK).
-	Subscribing(kio::Pending<moq_net::TrackSubscribe>),
+	Subscribing(kio::Pending<moq_net::track::Subscribe>),
 	/// The resolved consumer, reading frames. Boxed because it's much larger than
 	/// the `Subscribing` variant (clippy `large_enum_variant`).
 	Active(Box<Consumer<HangContainer>>),
@@ -73,7 +73,7 @@ pub(crate) struct ExportSource {
 impl ExportSource {
 	/// Subscribe to a video rendition and build an `ExportSource`.
 	pub fn for_video(
-		broadcast: &moq_net::BroadcastConsumer,
+		broadcast: &moq_net::broadcast::Consumer,
 		name: &str,
 		config: &VideoConfig,
 		latency: Duration,
@@ -96,7 +96,7 @@ impl ExportSource {
 	/// avc1 length-prefixed stays length-prefixed). The Annex-B exporter
 	/// uses this to keep parameter sets in-band.
 	pub fn for_video_raw(
-		broadcast: &moq_net::BroadcastConsumer,
+		broadcast: &moq_net::broadcast::Consumer,
 		name: &str,
 		config: &VideoConfig,
 		latency: Duration,
@@ -116,7 +116,7 @@ impl ExportSource {
 	/// Subscribe to an audio rendition. Audio has no codec-shape transform;
 	/// `description` is taken straight from the catalog.
 	pub fn for_audio(
-		broadcast: &moq_net::BroadcastConsumer,
+		broadcast: &moq_net::broadcast::Consumer,
 		name: &str,
 		config: &AudioConfig,
 		latency: Duration,
@@ -137,7 +137,7 @@ impl ExportSource {
 	/// No codec-shape transform and no description: the frames are Legacy-framed
 	/// verbatim bytes the muxer writes back out as PES or private sections.
 	pub fn for_stream(
-		broadcast: &moq_net::BroadcastConsumer,
+		broadcast: &moq_net::broadcast::Consumer,
 		name: &str,
 		latency: Duration,
 	) -> Result<Self, crate::Error> {

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -54,7 +54,7 @@ const PSI_INTERVAL: Duration = Duration::from_millis(500);
 /// timestamp), and is re-emitted at video keyframes and periodically for
 /// mid-stream tune-in. Returns `None` when the broadcast ends.
 pub struct Export<E: catalog::Catalog = ()> {
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 	catalog: Option<crate::catalog::Consumer<E>>,
 	latency: Duration,
 
@@ -155,14 +155,14 @@ struct PesUnit {
 
 impl Export {
 	/// Subscribe to `broadcast`, using the default catalog format.
-	pub async fn new(broadcast: moq_net::BroadcastConsumer) -> Result<Self, crate::Error> {
+	pub async fn new(broadcast: moq_net::broadcast::Consumer) -> Result<Self, crate::Error> {
 		Self::with_catalog_format(broadcast, CatalogFormat::default()).await
 	}
 
 	/// Subscribe to `broadcast`, selecting an explicit catalog format. Media only;
 	/// any catalog extension (e.g. the `mpegts` verbatim streams) is ignored.
 	pub async fn with_catalog_format(
-		broadcast: moq_net::BroadcastConsumer,
+		broadcast: moq_net::broadcast::Consumer,
 		catalog_format: CatalogFormat,
 	) -> Result<Self, crate::Error> {
 		Self::build(broadcast, catalog_format).await
@@ -175,7 +175,7 @@ impl Export<catalog::Ext> {
 	/// the extension, so callers write `Export::with_ts(..)` with no turbofish (the
 	/// plain constructors are media-only).
 	pub async fn with_ts(
-		broadcast: moq_net::BroadcastConsumer,
+		broadcast: moq_net::broadcast::Consumer,
 		catalog_format: CatalogFormat,
 	) -> Result<Self, crate::Error> {
 		Self::build(broadcast, catalog_format).await
@@ -185,7 +185,10 @@ impl Export<catalog::Ext> {
 impl<E: catalog::Catalog> Export<E> {
 	/// Shared constructor. The public entry points each live on a concrete
 	/// `Export<E>` impl that pins `E`, so the extension is chosen by which one you call.
-	async fn build(broadcast: moq_net::BroadcastConsumer, catalog_format: CatalogFormat) -> Result<Self, crate::Error> {
+	async fn build(
+		broadcast: moq_net::broadcast::Consumer,
+		catalog_format: CatalogFormat,
+	) -> Result<Self, crate::Error> {
 		let catalog = crate::catalog::Consumer::<E>::new(&broadcast, catalog_format).await?;
 		Ok(Self {
 			broadcast,

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -59,7 +59,7 @@ fn length_prefixed(nals: &[&[u8]]) -> Bytes {
 /// finished, retained tracks; that means it never reaches a hard end-of-stream,
 /// so we pull until a `next()` blocks (`Pending`, surfaced as a timeout under
 /// paused time) or the stream ends.
-async fn drain(consumer: moq_net::BroadcastConsumer) -> BytesMut {
+async fn drain(consumer: moq_net::broadcast::Consumer) -> BytesMut {
 	drain_with(Export::new(consumer).await.unwrap()).await
 }
 
@@ -87,14 +87,14 @@ fn assert_packet_aligned(ts: &[u8]) {
 
 #[tokio::test(start_paused = true)]
 async fn export_aac_roundtrip() {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
 		.create_track(
 			broadcast.unique_name(".aac"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let name = track.name().to_string();
@@ -202,7 +202,7 @@ fn collect_pes_pts(ts: &[u8]) -> (Vec<u64>, Vec<u64>) {
 /// mid-stream tune-in produces: the audio source is cached further back than the oldest
 /// retained video keyframe), then export it to TS.
 async fn export_lead_audio() -> BytesMut {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
@@ -210,7 +210,7 @@ async fn export_lead_audio() -> BytesMut {
 	let vtrack = broadcast
 		.create_track(
 			broadcast.unique_name(".avc3"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	{
@@ -228,7 +228,7 @@ async fn export_lead_audio() -> BytesMut {
 	let atrack = broadcast
 		.create_track(
 			broadcast.unique_name(".aac"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	{
@@ -342,14 +342,14 @@ fn reassemble_video(ts: &[u8], expected_stream_type: StreamType) -> Vec<u8> {
 /// into a synthesized avcC, and the muxer re-injects them on the keyframe.
 #[tokio::test(start_paused = true)]
 async fn export_avc3_in_band_reassembles() {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
 		.create_track(
 			broadcast.unique_name(".avc3"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let name = track.name().to_string();
@@ -393,14 +393,14 @@ async fn export_avc3_in_band_reassembles() {
 /// (regression for non-existing PPS 0 referenced).
 #[tokio::test(start_paused = true)]
 async fn export_avc3_preserves_multiple_pps() {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
 		.create_track(
 			broadcast.unique_name(".avc3"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let name = track.name().to_string();
@@ -444,7 +444,7 @@ async fn export_avc3_preserves_multiple_pps() {
 /// length prefixes to start codes.
 #[tokio::test(start_paused = true)]
 async fn export_avc1_out_of_band_reassembles() {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
@@ -453,7 +453,7 @@ async fn export_avc1_out_of_band_reassembles() {
 	let track = broadcast
 		.create_track(
 			broadcast.unique_name(".avc1"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let name = track.name().to_string();
@@ -502,7 +502,7 @@ async fn export_avc1_out_of_band_reassembles() {
 async fn export_bframe_video_authors_dts() {
 	let data = include_bytes!("test_data/scte35/kyrion_dirtystart.ts");
 
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
@@ -570,7 +570,7 @@ async fn export_bframe_video_authors_dts() {
 async fn export_scte35_roundtrip() {
 	let data = include_bytes!("test_data/bbb.ts");
 
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let mut catalog =
 		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
@@ -582,7 +582,7 @@ async fn export_scte35_roundtrip() {
 	let scte = broadcast
 		.unique_track(
 			".scte35",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let scte_name = scte.name().to_string();
@@ -646,7 +646,7 @@ async fn export_scte35_roundtrip() {
 	assert!(saw_cuei, "PMT missing the program-level CUEI registration descriptor");
 
 	// Re-import the exported TS and read the .scte35 frame back.
-	let mut broadcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 	let consumer2 = broadcast2.consume();
 	let catalog2 =
 		crate::catalog::Producer::with_catalog(&mut broadcast2, crate::catalog::hang::Catalog::<tscat::Ext>::default())
@@ -687,7 +687,7 @@ async fn export_pes_verbatim_roundtrip() {
 
 	let data = include_bytes!("test_data/bbb.ts");
 
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let mut catalog =
 		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
@@ -698,7 +698,7 @@ async fn export_pes_verbatim_roundtrip() {
 	let data_track = broadcast
 		.unique_track(
 			".data",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let data_name = data_track.name().to_string();
@@ -738,7 +738,7 @@ async fn export_pes_verbatim_roundtrip() {
 	assert_packet_aligned(&ts);
 
 	// Re-import the exported TS and recover the verbatim PES stream.
-	let mut broadcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 	let consumer2 = broadcast2.consume();
 	let catalog2 =
 		crate::catalog::Producer::with_catalog(&mut broadcast2, crate::catalog::hang::Catalog::<tscat::Ext>::default())
@@ -778,7 +778,7 @@ async fn export_pes_verbatim_roundtrip() {
 // track rather than emitting cues pinned to zero.
 #[tokio::test(start_paused = true)]
 async fn scte35_without_video_export_is_rejected() {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let mut catalog =
 		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
@@ -788,7 +788,7 @@ async fn scte35_without_video_export_is_rejected() {
 	let scte = broadcast
 		.unique_track(
 			".scte35",
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let scte_name = scte.name().to_string();
@@ -830,7 +830,7 @@ async fn scte35_without_video_export_is_rejected() {
 }
 
 /// Subscribe to a track and read every retained frame payload it holds.
-async fn read_frames(consumer: &moq_net::BroadcastConsumer, name: &str) -> Vec<Vec<u8>> {
+async fn read_frames(consumer: &moq_net::broadcast::Consumer, name: &str) -> Vec<Vec<u8>> {
 	let track = consumer.track(name).unwrap().subscribe(None).await.unwrap();
 	let mut reader = crate::container::Consumer::new(track, HangContainer::Legacy);
 	let mut frames = Vec::new();
@@ -850,7 +850,7 @@ async fn read_frames(consumer: &moq_net::BroadcastConsumer, name: &str) -> Vec<V
 async fn mp2_kyrion_roundtrip_byte_exact() {
 	let data = include_bytes!("test_data/scte35/kyrion_dirtystart.ts");
 
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
@@ -886,7 +886,7 @@ async fn mp2_kyrion_roundtrip_byte_exact() {
 		}
 	}
 
-	let mut broadcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 	let consumer2 = broadcast2.consume();
 	let catalog2 = crate::catalog::Producer::new(&mut broadcast2).unwrap();
 	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.clone());
@@ -919,7 +919,7 @@ async fn mp2_kyrion_roundtrip_byte_exact() {
 async fn ac3_roundtrip_byte_exact() {
 	let data = include_bytes!("test_data/ac3.ts");
 
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
@@ -963,7 +963,7 @@ async fn ac3_roundtrip_byte_exact() {
 	}
 	assert!(checked_pmt, "missing PMT");
 
-	let mut broadcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 	let consumer2 = broadcast2.consume();
 	let catalog2 = crate::catalog::Producer::new(&mut broadcast2).unwrap();
 	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.clone());
@@ -989,7 +989,7 @@ async fn ac3_roundtrip_byte_exact() {
 async fn eac3_roundtrip_byte_exact() {
 	let data = include_bytes!("test_data/eac3.ts");
 
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
@@ -1036,7 +1036,7 @@ async fn eac3_roundtrip_byte_exact() {
 	}
 	assert!(checked_pmt, "missing PMT");
 
-	let mut broadcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 	let consumer2 = broadcast2.consume();
 	let catalog2 = crate::catalog::Producer::new(&mut broadcast2).unwrap();
 	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.clone());
@@ -1057,7 +1057,7 @@ async fn eac3_roundtrip_byte_exact() {
 
 /// Read every audio rendition's retained frames, keyed by codec string.
 async fn read_audio_by_codec(
-	consumer: &moq_net::BroadcastConsumer,
+	consumer: &moq_net::broadcast::Consumer,
 	catalog: &crate::catalog::Producer,
 ) -> std::collections::BTreeMap<String, Vec<Vec<u8>>> {
 	let mut out = std::collections::BTreeMap::new();
@@ -1076,7 +1076,7 @@ async fn read_audio_by_codec(
 async fn kyrion_ac3_mp2_roundtrip_byte_exact() {
 	let data = include_bytes!("test_data/kyrion_mpeg2av_ac3.ts");
 
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
@@ -1124,7 +1124,7 @@ async fn kyrion_ac3_mp2_roundtrip_byte_exact() {
 		}
 	}
 
-	let mut broadcast2 = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 	let consumer2 = broadcast2.consume();
 	let catalog2 = crate::catalog::Producer::new(&mut broadcast2).unwrap();
 	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.clone());
@@ -1146,7 +1146,7 @@ fn scte_track(snap: &crate::catalog::hang::Catalog<tscat::Ext>) -> Option<String
 }
 
 /// Subscribe to a cue track and read every retained `splice_info_section` it holds.
-async fn read_cues(consumer: &moq_net::BroadcastConsumer, name: &str) -> Vec<(Vec<u8>, Timestamp)> {
+async fn read_cues(consumer: &moq_net::broadcast::Consumer, name: &str) -> Vec<(Vec<u8>, Timestamp)> {
 	let track = consumer.track(name).unwrap().subscribe(None).await.unwrap();
 	let mut reader = crate::container::Consumer::new(track, HangContainer::Legacy);
 	let mut cues = Vec::new();
@@ -1213,7 +1213,7 @@ async fn scte35_fixtures_survive_roundtrip() {
 
 	for (source, total, distinct, command_types, data) in fixtures {
 		// Ingest the fixture.
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let consumer = broadcast.consume();
 		let catalog = crate::catalog::Producer::with_catalog(
 			&mut broadcast,
@@ -1269,7 +1269,7 @@ async fn scte35_fixtures_survive_roundtrip() {
 		.await;
 		assert_packet_aligned(&ts);
 
-		let mut broadcast2 = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 		let consumer2 = broadcast2.consume();
 		let catalog2 = crate::catalog::Producer::with_catalog(
 			&mut broadcast2,
@@ -1328,14 +1328,14 @@ fn strip_opus_control(mut data: &[u8]) -> Vec<Vec<u8>> {
 /// the control-header-wrapped PES recovers the raw Opus packets with the right PTS.
 #[tokio::test(start_paused = true)]
 async fn export_opus_roundtrip() {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
 		.create_track(
 			broadcast.unique_name(".opus"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let name = track.name().to_string();
@@ -1408,14 +1408,14 @@ async fn export_opus_roundtrip() {
 /// catalog surfaces one 48 kHz Opus track whose frames recover the original packets.
 #[tokio::test(start_paused = true)]
 async fn opus_export_import_roundtrip() {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
 		.create_track(
 			broadcast.unique_name(".opus"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)
 		.unwrap();
 	let name = track.name().to_string();
@@ -1443,7 +1443,7 @@ async fn opus_export_import_roundtrip() {
 	let ts = drain(consumer).await;
 
 	// Re-import the TS we just produced.
-	let mut imported = moq_net::BroadcastInfo::new().produce();
+	let mut imported = moq_net::broadcast::Info::new().produce();
 	let imported_consumer = imported.consume();
 	let import_catalog = crate::catalog::Producer::new(&mut imported).unwrap();
 	let mut import = crate::container::ts::Import::new(imported, import_catalog.clone());

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -41,7 +41,7 @@ use moq_net::Timestamp;
 /// are intercepted before the reader and reassembled. With a base `Catalog<()>`
 /// they're logged and dropped instead.
 pub struct Import<E: catalog::Catalog = ()> {
-	broadcast: moq_net::BroadcastProducer,
+	broadcast: moq_net::broadcast::Producer,
 	catalog: crate::catalog::Producer<E>,
 
 	/// Shared, refillable byte source the persistent reader pulls whole packets
@@ -100,7 +100,7 @@ pub struct Import<E: catalog::Catalog = ()> {
 }
 
 impl<E: catalog::Catalog> Import<E> {
-	pub fn new(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer<E>) -> Self {
+	pub fn new(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
 		let feed = Feed::default();
 		// Sample the real catalog once at construction, not E::default(): an extension
 		// may carry the section by value, and a snapshot clones under the mutex (no publish).
@@ -607,7 +607,7 @@ fn to_descriptors(descriptors: &[mpeg2ts::ts::Descriptor]) -> Vec<catalog::Descr
 /// [`Track`](catalog::Track) with a `verbatim` carriage record. Shared by the
 /// section- and PES-framed paths.
 fn register_verbatim<E: catalog::Catalog>(
-	broadcast: &mut moq_net::BroadcastProducer,
+	broadcast: &mut moq_net::broadcast::Producer,
 	catalog: &mut crate::catalog::Producer<E>,
 	pid: u16,
 	stream_type: u8,
@@ -619,7 +619,7 @@ fn register_verbatim<E: catalog::Catalog>(
 	// so the track declares that timescale to match.
 	let track = broadcast.unique_track(
 		".ts",
-		moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+		moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 	)?;
 
 	let mut guard = catalog.lock();
@@ -666,7 +666,7 @@ struct SectionStream<E: catalog::Catalog> {
 
 impl<E: catalog::Catalog> SectionStream<E> {
 	fn new(
-		mut broadcast: moq_net::BroadcastProducer,
+		mut broadcast: moq_net::broadcast::Producer,
 		mut catalog: crate::catalog::Producer<E>,
 		pid: u16,
 		stream_type: u8,
@@ -746,7 +746,7 @@ struct VerbatimStream<E: catalog::Catalog> {
 
 impl<E: catalog::Catalog> VerbatimStream<E> {
 	fn new(
-		mut broadcast: moq_net::BroadcastProducer,
+		mut broadcast: moq_net::broadcast::Producer,
 		mut catalog: crate::catalog::Producer<E>,
 		pid: u16,
 		stream_type: u8,
@@ -1076,7 +1076,7 @@ impl<E: catalog::Catalog> Stream<E> {
 /// deferred until the first frame arrives.
 struct AacStream<E: CatalogExt = ()> {
 	import: Option<aac::Import<E>>,
-	broadcast: moq_net::BroadcastProducer,
+	broadcast: moq_net::broadcast::Producer,
 	catalog: crate::catalog::Producer<E>,
 	unwrap: PtsUnwrap,
 	/// Largest audio burst span seen, published as the catalog jitter.
@@ -1318,7 +1318,7 @@ fn parse_opus_control_header(data: &[u8]) -> anyhow::Result<(usize, usize)> {
 struct LegacyStream<E: CatalogExt = ()> {
 	descriptor: &'static legacy::Descriptor,
 	import: Option<legacy::Import<E>>,
-	broadcast: moq_net::BroadcastProducer,
+	broadcast: moq_net::broadcast::Producer,
 	catalog: crate::catalog::Producer<E>,
 	unwrap: PtsUnwrap,
 	/// Partial frame left at the end of the previous PES. ISO 13818-1 doesn't
@@ -1771,7 +1771,7 @@ mod test {
 		use crate::catalog::hang::Catalog;
 		use crate::container::ts::catalog::Ext;
 
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::with_catalog(&mut broadcast, Catalog::<Ext>::default()).unwrap();
 		let mut import = super::Import::new(broadcast, catalog.clone());
 
@@ -1793,7 +1793,7 @@ mod test {
 	// the publishing lock is never taken and the catalog is never republished empty.
 	#[tokio::test(start_paused = true)]
 	async fn base_catalog_routes_cue_pid_to_ignored() {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 		let mut updates = catalog.consume().unwrap();
 		let mut import = super::Import::new(broadcast, catalog.clone());
@@ -1837,7 +1837,7 @@ mod test {
 		const SECTION_PID: u16 = 0x0021;
 		let pid = mpeg2ts::ts::Pid::new(SECTION_PID).unwrap();
 
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let consumer = broadcast.consume();
 		let catalog = crate::catalog::Producer::with_catalog(&mut broadcast, Catalog::<Ext>::default()).unwrap();
 		let mut import = super::Import::new(broadcast, catalog.clone());
@@ -1920,7 +1920,7 @@ mod test {
 		const VIDEO_PID: u16 = 0x0050;
 		const PRIVATE_PID: u16 = 0x0051;
 
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 		let mut import = super::Import::new(broadcast, catalog);
 
@@ -1995,7 +1995,7 @@ mod test {
 		const AAC_PID: u16 = 0x0060;
 		const MP2_PID: u16 = 0x0061;
 
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 		let mut import = super::Import::new(broadcast, catalog.clone());
 
@@ -2036,7 +2036,7 @@ mod test {
 
 	/// Read every retained frame of the single audio rendition in `catalog`.
 	async fn read_audio_frames(
-		consumer: &moq_net::BroadcastConsumer,
+		consumer: &moq_net::broadcast::Consumer,
 		catalog: &crate::catalog::Producer,
 	) -> Vec<crate::container::Frame> {
 		let name = catalog
@@ -2064,7 +2064,7 @@ mod test {
 	async fn legacy_frame_split_across_pes_reassembles() {
 		const MP2_PID: u16 = 0x0061;
 
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let consumer = broadcast.consume();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 		let mut import = super::Import::new(broadcast, catalog.clone());
@@ -2110,7 +2110,7 @@ mod test {
 	async fn legacy_header_split_keeps_origin_pts() {
 		const MP2_PID: u16 = 0x0061;
 
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let consumer = broadcast.consume();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 		let mut import = super::Import::new(broadcast, catalog.clone());
@@ -2158,7 +2158,7 @@ mod test {
 
 		const VIDEO_PID: u16 = 0x0050;
 
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let consumer = broadcast.consume();
 		let catalog = crate::catalog::Producer::with_catalog(&mut broadcast, Catalog::<Ext>::default()).unwrap();
 		let mut import = super::Import::new(broadcast, catalog.clone());
@@ -2208,7 +2208,7 @@ mod test {
 		const VIDEO_PID: u16 = 0x0050;
 		const SECTION_PID: u16 = 0x0021;
 
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		// catalog::Ext (not the base catalog) makes a wrong ensure_scte() observable: it
 		// would create a rendition, which the base catalog silently drops.
 		let catalog = crate::catalog::Producer::with_catalog(&mut broadcast, Catalog::<Ext>::default()).unwrap();
@@ -2280,7 +2280,7 @@ mod test {
 		const VIDEO_PID: u16 = 0x0050;
 		const DATA_PID: u16 = 0x0052;
 
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let consumer = broadcast.consume();
 		let catalog = crate::catalog::Producer::with_catalog(&mut broadcast, Catalog::<Ext>::default()).unwrap();
 		let mut import = super::Import::new(broadcast, catalog.clone());

--- a/rs/moq-mux/src/container/ts/import_test.rs
+++ b/rs/moq-mux/src/container/ts/import_test.rs
@@ -7,7 +7,7 @@ use bytes::BytesMut;
 
 /// Decode a whole TS buffer into a fresh broadcast and return the catalog.
 fn import_ts(data: &[u8]) -> crate::catalog::hang::Catalog {
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
@@ -126,7 +126,7 @@ fn import_opus_catalog() {
 async fn import_opus_frames() {
 	let data = include_bytes!("test_data/opus.ts");
 
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
@@ -246,7 +246,7 @@ fn resyncs_across_chunk_boundaries() {
 	let mut misaligned = vec![0x00, 0x11, 0x22];
 	misaligned.extend_from_slice(data);
 
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
 	for chunk in misaligned.chunks(100) {
@@ -272,7 +272,7 @@ async fn import_export_import_roundtrip() {
 	let data = include_bytes!("test_data/bbb.ts");
 
 	// Import the fixture into a broadcast.
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
@@ -319,7 +319,7 @@ async fn survives_midstream_join() {
 	buf.extend_from_slice(pkt(8)); // IDR AU: flushes the delta, then anchors the first group
 	buf.extend_from_slice(pkt(9));
 
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
@@ -354,7 +354,7 @@ async fn survives_midstream_join() {
 #[tokio::test(start_paused = true)]
 async fn kyrion_dirtystart_extracts_real_cues() {
 	let data = include_bytes!("test_data/scte35/kyrion_dirtystart.ts");
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::with_catalog(
 		&mut broadcast,
@@ -407,7 +407,7 @@ fn import_handles_unaligned_chunks() {
 	// exercising the partial-packet retention across calls.
 	let data = include_bytes!("test_data/bbb.ts");
 
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
 

--- a/rs/moq-mux/src/import/container.rs
+++ b/rs/moq-mux/src/import/container.rs
@@ -19,19 +19,19 @@ enum ContainerImpl<E: crate::container::ts::catalog::Catalog = ()> {
 }
 
 impl<E: crate::container::ts::catalog::Catalog> ContainerImpl<E> {
-	fn fmp4(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer<E>) -> Self {
+	fn fmp4(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
 		ContainerImpl::Fmp4(Box::new(crate::container::fmp4::Import::new(broadcast, catalog)))
 	}
 
-	fn mkv(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer<E>) -> Self {
+	fn mkv(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
 		ContainerImpl::Mkv(Box::new(crate::container::mkv::Import::new(broadcast, catalog)))
 	}
 
-	fn ts(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer<E>) -> Self {
+	fn ts(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
 		ContainerImpl::Ts(Box::new(crate::container::ts::Import::new(broadcast, catalog)))
 	}
 
-	fn flv(broadcast: moq_net::BroadcastProducer, catalog: crate::catalog::Producer<E>) -> Self {
+	fn flv(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
 		ContainerImpl::Flv(Box::new(crate::container::flv::Import::new(broadcast, catalog)))
 	}
 
@@ -74,7 +74,7 @@ pub struct Container<E: crate::container::ts::catalog::Catalog = ()> {
 impl<E: crate::container::ts::catalog::Catalog> Container<E> {
 	/// Create a new container importer, decoding the initial chunk.
 	pub fn new(
-		broadcast: moq_net::BroadcastProducer,
+		broadcast: moq_net::broadcast::Producer,
 		catalog: crate::catalog::Producer<E>,
 		format: &str,
 		init: &[u8],
@@ -117,7 +117,7 @@ pub struct ContainerStream<E: crate::container::ts::catalog::Catalog = ()> {
 impl<E: crate::container::ts::catalog::Catalog> ContainerStream<E> {
 	/// Create a new container stream importer.
 	pub fn new(
-		broadcast: moq_net::BroadcastProducer,
+		broadcast: moq_net::broadcast::Producer,
 		catalog: crate::catalog::Producer<E>,
 		format: &str,
 	) -> Result<Self> {

--- a/rs/moq-mux/src/import/mod.rs
+++ b/rs/moq-mux/src/import/mod.rs
@@ -29,7 +29,10 @@ pub use track::*;
 /// [`hang::container::TIMESCALE`] that the legacy importers stamp their frames
 /// with, so the relay gets timing without parsing the payload. Hand the result to
 /// the importer's `new`.
-pub fn unique_track(broadcast: &mut moq_net::BroadcastProducer, suffix: &str) -> crate::Result<moq_net::TrackProducer> {
-	let info = moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE);
+pub fn unique_track(
+	broadcast: &mut moq_net::broadcast::Producer,
+	suffix: &str,
+) -> crate::Result<moq_net::track::Producer> {
+	let info = moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE);
 	Ok(broadcast.unique_track(suffix, info)?)
 }

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -14,7 +14,7 @@ use crate::catalog::hang::CatalogExt;
 /// leading bytes of the stream (caching any inline SPS/PPS). Any frames in the
 /// init buffer are published.
 fn build_h264_avc3<E: CatalogExt>(
-	track: moq_net::TrackProducer,
+	track: moq_net::track::Producer,
 	catalog: crate::catalog::Producer<E>,
 	init: &[u8],
 ) -> Result<(crate::codec::h264::Split, crate::codec::h264::Import<E>)> {
@@ -30,7 +30,7 @@ fn build_h264_avc3<E: CatalogExt>(
 /// the avcC. avc1 has no splitter: each access unit is wrapped directly via
 /// [`crate::codec::h264::avc1_frame`].
 fn build_h264_avc1<E: CatalogExt>(
-	track: moq_net::TrackProducer,
+	track: moq_net::track::Producer,
 	catalog: crate::catalog::Producer<E>,
 	init: &[u8],
 ) -> Result<(usize, crate::codec::h264::Import<E>)> {
@@ -42,7 +42,7 @@ fn build_h264_avc1<E: CatalogExt>(
 
 /// Build an H.265 split + import pair, resolving the config from `init`.
 fn build_h265<E: CatalogExt>(
-	track: moq_net::TrackProducer,
+	track: moq_net::track::Producer,
 	catalog: crate::catalog::Producer<E>,
 	init: &[u8],
 ) -> Result<(crate::codec::h265::Split, crate::codec::h265::Import<E>)> {
@@ -56,7 +56,7 @@ fn build_h265<E: CatalogExt>(
 
 /// Build an AV1 split + import pair, resolving the config from `init`.
 fn build_av1<E: CatalogExt>(
-	track: moq_net::TrackProducer,
+	track: moq_net::track::Producer,
 	catalog: crate::catalog::Producer<E>,
 	init: &[u8],
 ) -> Result<(crate::codec::av1::Split, crate::codec::av1::Import<E>)> {
@@ -118,11 +118,11 @@ impl<E: CatalogExt> Track<E> {
 	/// Create an importer that publishes a single codec onto a reserved track.
 	///
 	/// The caller reserves the track (by name) with
-	/// [`BroadcastProducer::reserve_track`](moq_net::BroadcastProducer::reserve_track);
+	/// [`BroadcastProducer::reserve_track`](moq_net::broadcast::Producer::reserve_track);
 	/// the importer accepts it here, which is where the track's timescale is set.
 	/// The catalog rendition is registered once the codec config is resolved.
 	pub fn new(
-		request: moq_net::TrackRequest,
+		request: moq_net::track::Request,
 		catalog: crate::catalog::Producer<E>,
 		format: &str,
 		init: &[u8],
@@ -130,7 +130,7 @@ impl<E: CatalogExt> Track<E> {
 		// Accept at the legacy microsecond timescale, matching the frame timestamps
 		// the container stamps. A codec-specific timescale (e.g. the opus sample
 		// rate) would be chosen here instead.
-		let track = request.accept(moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE));
+		let track = request.accept(moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE));
 		let kind = match format {
 			"avc1" | "avcc" => {
 				let (length_size, import) = build_h264_avc1(track, catalog, init)?;
@@ -282,7 +282,7 @@ impl<E: CatalogExt> Track<E> {
 	}
 
 	/// A watch-only handle to the track's subscriber demand.
-	pub fn demand(&self) -> moq_net::TrackDemand {
+	pub fn demand(&self) -> moq_net::track::Demand {
 		match self.kind {
 			TrackKind::Avc3 { ref import, .. } => import.demand(),
 			TrackKind::Avc1 { ref import, .. } => import.demand(),
@@ -362,11 +362,11 @@ impl<E: CatalogExt> TrackStream<E> {
 	/// Create an importer that publishes a single codec onto a reserved track.
 	///
 	/// The caller reserves the track with
-	/// [`BroadcastProducer::reserve_track`](moq_net::BroadcastProducer::reserve_track);
+	/// [`BroadcastProducer::reserve_track`](moq_net::broadcast::Producer::reserve_track);
 	/// the importer accepts it here at the legacy microsecond timescale (where a
 	/// codec-specific timescale would be chosen).
-	pub fn new(request: moq_net::TrackRequest, catalog: crate::catalog::Producer<E>, format: &str) -> Result<Self> {
-		let track = request.accept(moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE));
+	pub fn new(request: moq_net::track::Request, catalog: crate::catalog::Producer<E>, format: &str) -> Result<Self> {
+		let track = request.accept(moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE));
 		// Only the self-delimiting codecs can be recovered from a raw byte stream.
 		let kind = match format {
 			"avc3" | "h264" => TrackStreamKind::Avc3 {
@@ -512,7 +512,7 @@ impl<E: CatalogExt> TrackStream<E> {
 	}
 
 	/// A watch-only handle to the track's subscriber demand.
-	pub fn demand(&self) -> moq_net::TrackDemand {
+	pub fn demand(&self) -> moq_net::track::Demand {
 		match self.kind {
 			TrackStreamKind::Avc3 { ref import, .. } => import.demand(),
 			TrackStreamKind::Hev1 { ref import, .. } => import.demand(),
@@ -557,8 +557,8 @@ mod tests {
 		init
 	}
 
-	fn new_broadcast() -> (moq_net::BroadcastProducer, crate::catalog::Producer) {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	fn new_broadcast() -> (moq_net::broadcast::Producer, crate::catalog::Producer) {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 		(broadcast, catalog)
 	}
@@ -610,7 +610,7 @@ mod tests {
 		let track = broadcast
 			.create_track(
 				"audio",
-				moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 			)
 			.unwrap();
 		let subscriber = track.subscribe(None);

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -20,7 +20,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 // Connect to the server and publish our origin of broadcasts.
-async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
+async fn run_session(origin: moq_net::origin::Producer) -> anyhow::Result<()> {
 	// Optional: Use moq_native to make a QUIC client.
 	let client = moq_native::ClientConfig::default().init()?;
 
@@ -36,10 +36,10 @@ async fn run_session(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
 }
 
 // Produce a broadcast and publish it to the origin.
-async fn run_broadcast(origin: moq_net::OriginProducer) -> anyhow::Result<()> {
+async fn run_broadcast(origin: moq_net::origin::Producer) -> anyhow::Result<()> {
 	// Create and publish a broadcast to the origin..
 	// A broadcast is a collection of tracks, but in this example we'll only create one.
-	let mut broadcast = moq_net::BroadcastInfo::new().produce();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
 
 	// Create a track that we'll insert into the broadcast.
 	// A track is a series of groups representing a live stream.

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -66,7 +66,7 @@ async fn main() -> anyhow::Result<()> {
 
 	match config.role {
 		Command::Publish => {
-			let mut broadcast = moq_net::BroadcastInfo::new().produce();
+			let mut broadcast = moq_net::broadcast::Info::new().produce();
 			let track = broadcast.create_track(track, None)?;
 			let clock = Publisher::new(track);
 
@@ -84,7 +84,7 @@ async fn main() -> anyhow::Result<()> {
 		Command::Subscribe => {
 			let reconnect = client.with_subscriber(origin.clone()).reconnect(config.url);
 
-			// IETF MoQ + the current OriginConsumer API don't let us call
+			// IETF MoQ + the current origin::Consumer API don't let us call
 			// `session.consume_broadcast(&path)` directly, so loop on announces
 			// instead. This also makes the subscriber reconnect-aware.
 			tracing::info!(broadcast = %config.broadcast, "waiting for broadcast to be online");
@@ -121,11 +121,11 @@ async fn main() -> anyhow::Result<()> {
 }
 
 struct Publisher {
-	track: TrackProducer,
+	track: track::Producer,
 }
 
 impl Publisher {
-	fn new(track: TrackProducer) -> Self {
+	fn new(track: track::Producer) -> Self {
 		Self { track }
 	}
 
@@ -157,7 +157,7 @@ impl Publisher {
 		}
 	}
 
-	async fn send_segment(mut segment: GroupProducer, mut now: DateTime<Utc>) -> anyhow::Result<()> {
+	async fn send_segment(mut segment: group::Producer, mut now: DateTime<Utc>) -> anyhow::Result<()> {
 		// Everything but the second.
 		let base = now.format("%Y-%m-%d %H:%M:").to_string();
 
@@ -189,11 +189,11 @@ impl Publisher {
 }
 
 struct Subscriber {
-	track: TrackSubscriber,
+	track: track::Subscriber,
 }
 
 impl Subscriber {
-	fn new(track: TrackSubscriber) -> Self {
+	fn new(track: track::Subscriber) -> Self {
 		Self { track }
 	}
 

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -227,25 +227,25 @@ impl Client {
 		self
 	}
 
-	pub fn with_publisher(mut self, publish: impl moq_net::Consume<moq_net::OriginConsumer>) -> Self {
+	pub fn with_publisher(mut self, publish: impl moq_net::Consume<moq_net::origin::Consumer>) -> Self {
 		self.moq = self.moq.with_publisher(publish);
 		self
 	}
 
-	pub fn with_subscriber(mut self, subscribe: moq_net::OriginProducer) -> Self {
+	pub fn with_subscriber(mut self, subscribe: moq_net::origin::Producer) -> Self {
 		self.moq = self.moq.with_subscriber(subscribe);
 		self
 	}
 
 	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_publisher`")]
-	pub fn with_publish(self, publish: moq_net::OriginConsumer) -> Self {
+	pub fn with_publish(self, publish: moq_net::origin::Consumer) -> Self {
 		self.with_publisher(publish)
 	}
 
 	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_subscriber`")]
-	pub fn with_consume(self, subscribe: moq_net::OriginProducer) -> Self {
+	pub fn with_consume(self, subscribe: moq_net::origin::Producer) -> Self {
 		self.with_subscriber(subscribe)
 	}
 
@@ -268,7 +268,7 @@ impl Client {
 	///
 	/// Returns `None` when no `--client-connect` URL was configured, so a caller
 	/// that may run server-only doesn't have to branch on the URL itself.
-	pub fn publish(self, origin: moq_net::OriginConsumer) -> Option<Reconnect> {
+	pub fn publish(self, origin: moq_net::origin::Consumer) -> Option<Reconnect> {
 		let url = self.connect.clone()?;
 		Some(self.with_publisher(origin).reconnect(url))
 	}
@@ -278,7 +278,7 @@ impl Client {
 	/// dropped.
 	///
 	/// Returns `None` when no `--client-connect` URL was configured.
-	pub fn consume(self, origin: moq_net::OriginProducer) -> Option<Reconnect> {
+	pub fn consume(self, origin: moq_net::origin::Producer) -> Option<Reconnect> {
 		let url = self.connect.clone()?;
 		Some(self.with_subscriber(origin).reconnect(url))
 	}

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -386,25 +386,25 @@ impl Server {
 		self
 	}
 
-	pub fn with_publisher(mut self, publish: impl moq_net::Consume<moq_net::OriginConsumer>) -> Self {
+	pub fn with_publisher(mut self, publish: impl moq_net::Consume<moq_net::origin::Consumer>) -> Self {
 		self.moq = self.moq.with_publisher(publish);
 		self
 	}
 
-	pub fn with_subscriber(mut self, subscribe: moq_net::OriginProducer) -> Self {
+	pub fn with_subscriber(mut self, subscribe: moq_net::origin::Producer) -> Self {
 		self.moq = self.moq.with_subscriber(subscribe);
 		self
 	}
 
 	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_publisher`")]
-	pub fn with_publish(self, publish: moq_net::OriginConsumer) -> Self {
+	pub fn with_publish(self, publish: moq_net::origin::Consumer) -> Self {
 		self.with_publisher(publish)
 	}
 
 	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_subscriber`")]
-	pub fn with_consume(self, subscribe: moq_net::OriginProducer) -> Self {
+	pub fn with_consume(self, subscribe: moq_net::origin::Producer) -> Self {
 		self.with_subscriber(subscribe)
 	}
 
@@ -420,14 +420,14 @@ impl Server {
 	/// errors, so one bad peer never tears down the listener. Returns when
 	/// interrupted (Ctrl-C) or on a fatal bind failure. For per-session auth or
 	/// routing, drive [`accept`](Self::accept) yourself instead.
-	pub async fn serve_publish(self, origin: moq_net::OriginConsumer) -> crate::Result<()> {
+	pub async fn serve_publish(self, origin: moq_net::origin::Consumer) -> crate::Result<()> {
 		self.with_publisher(origin).serve().await
 	}
 
 	/// Accept sessions until the listener stops, ingesting each publisher into `origin`.
 	///
 	/// The mirror of [`serve_publish`](Self::serve_publish) for the consume direction.
-	pub async fn serve_consume(self, origin: moq_net::OriginProducer) -> crate::Result<()> {
+	pub async fn serve_consume(self, origin: moq_net::origin::Producer) -> crate::Result<()> {
 		self.with_subscriber(origin).serve().await
 	}
 
@@ -979,7 +979,7 @@ impl Request {
 	}
 
 	/// Publish the given origin to the session.
-	pub fn with_publisher(self, publish: impl moq_net::Consume<moq_net::OriginConsumer>) -> Self {
+	pub fn with_publisher(self, publish: impl moq_net::Consume<moq_net::origin::Consumer>) -> Self {
 		let Request { server, kind } = self;
 		match kind {
 			#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
@@ -1001,7 +1001,7 @@ impl Request {
 	}
 
 	/// Subscribe to the given origin from the session.
-	pub fn with_subscriber(self, subscribe: moq_net::OriginProducer) -> Self {
+	pub fn with_subscriber(self, subscribe: moq_net::origin::Producer) -> Self {
 		let Request { server, kind } = self;
 		match kind {
 			#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
@@ -1024,13 +1024,13 @@ impl Request {
 
 	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_publisher`")]
-	pub fn with_publish(self, publish: moq_net::OriginConsumer) -> Self {
+	pub fn with_publish(self, publish: moq_net::origin::Consumer) -> Self {
 		self.with_publisher(publish)
 	}
 
 	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_subscriber`")]
-	pub fn with_consume(self, subscribe: moq_net::OriginProducer) -> Self {
+	pub fn with_consume(self, subscribe: moq_net::origin::Producer) -> Self {
 		self.with_subscriber(subscribe)
 	}
 

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -126,7 +126,10 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 
 	// Track with an explicit microsecond timescale (the default is milliseconds).
 	let mut track = broadcast
-		.create_track("video", moq_net::TrackInfo::default().with_timescale(Timescale::MICRO))
+		.create_track(
+			"video",
+			moq_net::track::Info::default().with_timescale(Timescale::MICRO),
+		)
 		.expect("failed to create track");
 
 	// Three frames where the middle PTS goes backwards (B-frame decode order) so the
@@ -135,7 +138,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 	let mut group = track.append_group().expect("failed to append group");
 	for &us in &frames {
 		let payload = format!("frame@{us}").into_bytes();
-		let frame = moq_native::moq_net::FrameInfo {
+		let frame = moq_native::moq_net::frame::Info {
 			size: payload.len() as u64,
 			timestamp: Timestamp::new(us, Timescale::MICRO).unwrap(),
 		};
@@ -237,7 +240,10 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
 	let mut track = broadcast
-		.create_track("video", moq_net::TrackInfo::default().with_timescale(Timescale::MICRO))
+		.create_track(
+			"video",
+			moq_net::track::Info::default().with_timescale(Timescale::MICRO),
+		)
 		.expect("failed to create track");
 
 	// A group with a few timestamped frames (middle PTS goes backwards, so the fetch
@@ -246,7 +252,7 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 	let mut group = track.append_group().expect("failed to append group"); // seq 0
 	for &us in &frames {
 		let payload = format!("frame@{us}").into_bytes();
-		let frame = moq_native::moq_net::FrameInfo {
+		let frame = moq_native::moq_net::frame::Info {
 			size: payload.len() as u64,
 			timestamp: Timestamp::new(us, Timescale::MICRO).unwrap(),
 		};
@@ -349,8 +355,8 @@ async fn broadcast_moq_lite_05_fetch_webtransport() {
 async fn lite05_fetch_during_subscribe(scheme: &str) {
 	use moq_native::moq_net::{Timescale, Timestamp};
 
-	fn timestamped_frame(us: u64, payload: &str) -> moq_net::FrameInfo {
-		moq_net::FrameInfo {
+	fn timestamped_frame(us: u64, payload: &str) -> moq_net::frame::Info {
+		moq_net::frame::Info {
 			size: payload.len() as u64,
 			timestamp: Timestamp::new(us, Timescale::MICRO).unwrap(),
 		}
@@ -359,7 +365,10 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
 	let mut track = broadcast
-		.create_track("video", moq_net::TrackInfo::default().with_timescale(Timescale::MICRO))
+		.create_track(
+			"video",
+			moq_net::track::Info::default().with_timescale(Timescale::MICRO),
+		)
 		.expect("failed to create track");
 
 	// Group 0 is the "past" group only reachable via FETCH; group 1 is the latest,

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -1,6 +1,7 @@
+use crate::origin;
 use crate::{
 	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Consume,
-	Error, NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
+	Error, NEGOTIATED, Session, StatsHandle, Version, Versions,
 	coding::{self, Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -8,8 +9,8 @@ use crate::{
 /// A MoQ client session builder.
 #[derive(Default, Clone)]
 pub struct Client {
-	publish: Option<OriginConsumer>,
-	subscribe: Option<OriginProducer>,
+	publish: Option<origin::Consumer>,
+	subscribe: Option<origin::Producer>,
 	stats: StatsHandle,
 	versions: Versions,
 	setup_path: Option<String>,
@@ -21,29 +22,29 @@ impl Client {
 	}
 
 	/// Publish local broadcasts to the remote: the session reads from the given
-	/// origin (pass an [`OriginProducer`] or [`OriginConsumer`] by reference) and
+	/// origin (pass an [`origin::Producer`] or [`origin::Consumer`] by reference) and
 	/// forwards its announcements. Omit to publish nothing.
-	pub fn with_publisher(mut self, publish: impl Consume<OriginConsumer>) -> Self {
+	pub fn with_publisher(mut self, publish: impl Consume<origin::Consumer>) -> Self {
 		self.publish = Some(publish.consume());
 		self
 	}
 
 	/// Subscribe to remote broadcasts: the session writes the broadcasts the
-	/// remote announces into this [`OriginProducer`]. Omit to subscribe to nothing.
-	pub fn with_subscriber(mut self, subscribe: OriginProducer) -> Self {
+	/// remote announces into this [`origin::Producer`]. Omit to subscribe to nothing.
+	pub fn with_subscriber(mut self, subscribe: origin::Producer) -> Self {
 		self.subscribe = Some(subscribe);
 		self
 	}
 
 	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_publisher`")]
-	pub fn with_publish(self, publish: OriginConsumer) -> Self {
+	pub fn with_publish(self, publish: origin::Consumer) -> Self {
 		self.with_publisher(publish)
 	}
 
 	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_subscriber`")]
-	pub fn with_consume(self, subscribe: OriginProducer) -> Self {
+	pub fn with_consume(self, subscribe: origin::Producer) -> Self {
 		self.with_subscriber(subscribe)
 	}
 
@@ -55,11 +56,11 @@ impl Client {
 		self
 	}
 
-	/// Set both publish and subscribe from one shared [`OriginProducer`].
+	/// Set both publish and subscribe from one shared [`origin::Producer`].
 	///
 	/// Equivalent to [`with_publisher`](Self::with_publisher) and
 	/// [`with_subscriber`](Self::with_subscriber) with the same origin.
-	pub fn with_origin(self, origin: OriginProducer) -> Self {
+	pub fn with_origin(self, origin: origin::Producer) -> Self {
 		self.with_publisher(&origin).with_subscriber(origin)
 	}
 

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -1,3 +1,4 @@
+use crate::{announce, group, origin, track};
 use std::collections::HashMap;
 
 use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
@@ -5,10 +6,9 @@ use web_async::FuturesExt;
 use web_transport_trait::SendStream;
 
 use crate::{
-	AsPath, Error, OriginConsumer, StatsHandle, Subscription, TrackSubscriber,
+	AsPath, Error, StatsHandle, Subscription,
 	coding::{Stream, Writer},
 	ietf::{self, Control, FetchHeader, FetchType, FilterType, GroupOrder, Location, RequestId},
-	model::GroupConsumer,
 };
 
 use super::{Message, Version};
@@ -16,7 +16,7 @@ use super::{Message, Version};
 #[derive(Clone)]
 pub(super) struct Publisher<S: web_transport_trait::Session> {
 	session: S,
-	origin: OriginConsumer,
+	origin: origin::Consumer,
 	control: Control,
 	stats: StatsHandle,
 	/// Per-session egress broadcast-subscription tracker. Each downstream
@@ -27,7 +27,7 @@ pub(super) struct Publisher<S: web_transport_trait::Session> {
 }
 
 impl<S: web_transport_trait::Session> Publisher<S> {
-	pub fn new(session: S, origin: OriginConsumer, control: Control, stats: StatsHandle, version: Version) -> Self {
+	pub fn new(session: S, origin: origin::Consumer, control: Control, stats: StatsHandle, version: Version) -> Self {
 		let broadcasts = stats.publisher_broadcasts();
 		Self {
 			session,
@@ -132,7 +132,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		// We just received a subscribe for this exact namespace, so the peer must have already
 		// seen the announcement. `request_broadcast` resolves it immediately, or falls back to
-		// an `OriginDynamic` handler if one is registered.
+		// an `origin::Dynamic` handler if one is registered.
 		let broadcast = match self.origin.request_broadcast(&msg.track_namespace).await {
 			Ok(broadcast) => broadcast,
 			Err(_) => {
@@ -252,7 +252,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	/// Serve a track using FuturesUnordered for unlimited concurrent groups.
 	async fn run_track(
 		&self,
-		mut track: TrackSubscriber,
+		mut track: track::Subscriber,
 		request_id: RequestId,
 		track_stats: std::sync::Arc<crate::PublisherTrack>,
 	) -> Result<(), Error> {
@@ -304,7 +304,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		session: S,
 		msg: ietf::GroupHeader,
 		priority: u8,
-		mut group: GroupConsumer,
+		mut group: group::Consumer,
 		track_stats: std::sync::Arc<crate::PublisherTrack>,
 		version: Version,
 	) -> Result<(), Error> {
@@ -522,15 +522,15 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			let suffix = path.to_owned();
 
 			match event {
-				crate::Announced::Active(_) => {
+				announce::Event::Active(_) => {
 					self.announce_namespace(suffix, &mut namespace_streams).await?;
 				}
-				crate::Announced::Restart(_) => {
+				announce::Event::Restart(_) => {
 					// moq-transport has no RESTART; fall back to done + re-announce.
 					self.unannounce_namespace(&suffix, &mut namespace_streams).await;
 					self.announce_namespace(suffix, &mut namespace_streams).await?;
 				}
-				crate::Announced::Ended => {
+				announce::Event::Ended => {
 					self.unannounce_namespace(&suffix, &mut namespace_streams).await;
 				}
 			}
@@ -720,12 +720,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						let absolute = origin.absolute(&path).to_owned();
 
 						match event {
-							crate::Announced::Active(_) => {
+							announce::Event::Active(_) => {
 								tracing::debug!(broadcast = %absolute, "namespace");
 								stream.writer.encode(&ietf::Namespace::ID).await?;
 								stream.writer.encode(&ietf::Namespace { suffix }).await?;
 							}
-							crate::Announced::Restart(_) => {
+							announce::Event::Restart(_) => {
 								// moq-transport has no RESTART; fall back to namespace_done + namespace.
 								tracing::debug!(broadcast = %absolute, "namespace_done");
 								stream.writer.encode(&ietf::NamespaceDone::ID).await?;
@@ -734,7 +734,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 								stream.writer.encode(&ietf::Namespace::ID).await?;
 								stream.writer.encode(&ietf::Namespace { suffix }).await?;
 							}
-							crate::Announced::Ended => {
+							announce::Event::Ended => {
 								tracing::debug!(broadcast = %absolute, "namespace_done");
 								stream.writer.encode(&ietf::NamespaceDone::ID).await?;
 								stream.writer.encode(&ietf::NamespaceDone { suffix }).await?;

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -1,5 +1,6 @@
+use crate::origin;
 use crate::{
-	Error, Origin, OriginConsumer, OriginProducer, StatsHandle,
+	Error, Origin, StatsHandle,
 	coding::{Decode, Encode, Reader, Stream, Writer},
 	ietf::{self, FetchHeader, RequestId},
 	setup,
@@ -15,8 +16,8 @@ pub fn start<S: web_transport_trait::Session>(
 	setup: Option<Stream<S, Version>>,
 	request_id_max: Option<RequestId>,
 	client: bool,
-	publish: Option<OriginConsumer>,
-	subscribe: Option<OriginProducer>,
+	publish: Option<origin::Consumer>,
+	subscribe: Option<origin::Producer>,
 	// Tier-scoped stats handle. Pass [`StatsHandle::default`] to opt out.
 	stats: StatsHandle,
 	version: Version,
@@ -32,8 +33,8 @@ pub fn start<S: web_transport_trait::Session>(
 		// moq-transport threads concrete origins through the publisher/subscriber.
 		// An unset half gets an empty origin: an empty publish origin announces
 		// nothing, and an empty subscribe origin issues no SUBSCRIBE_NAMESPACE.
-		let publish = publish.unwrap_or_else(|| OriginProducer::empty(Origin::random()).consume());
-		let subscribe = subscribe.unwrap_or_else(|| OriginProducer::empty(Origin::random()));
+		let publish = publish.unwrap_or_else(|| origin::Producer::empty(Origin::random()).consume());
+		let subscribe = subscribe.unwrap_or_else(|| origin::Producer::empty(Origin::random()));
 		let res = match version {
 			Version::Draft14 | Version::Draft15 | Version::Draft16 => {
 				let Some(setup) = setup else {

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1,13 +1,12 @@
+use crate::{broadcast, frame, group, origin, track};
 use std::collections::{HashMap, hash_map::Entry};
 
 use std::sync::Arc;
 
 use crate::{
-	BroadcastDynamic, BroadcastInfo, Error, FrameInfo, FrameProducer, GroupInfo, GroupProducer, OriginProducer,
-	OriginPublish, Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, TrackProducer, TrackRequest,
+	Error, Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack,
 	coding::{Reader, Stream},
 	ietf::{self, Control, FilterType, GroupOrder, RequestId},
-	model::BroadcastProducer,
 };
 
 use super::{Message, Version};
@@ -30,7 +29,7 @@ struct State {
 }
 
 struct TrackState {
-	producer: TrackProducer,
+	producer: track::Producer,
 	alias: Option<u64>,
 	/// Subscriber-side track stats; counters bump as frames/bytes/groups arrive.
 	/// Dropping on subscription end records `subscriptions_closed`.
@@ -38,7 +37,7 @@ struct TrackState {
 }
 
 struct BroadcastState {
-	producer: BroadcastProducer,
+	producer: broadcast::Producer,
 
 	// active number of PUBLISH or PUBLISH_NAMESPACE messages.
 	count: usize,
@@ -46,7 +45,7 @@ struct BroadcastState {
 	/// Announcement guard into our origin. Dropped when the entry is removed,
 	/// which unannounces the broadcast.
 	#[allow(dead_code)]
-	publish: OriginPublish,
+	publish: origin::Publish,
 
 	/// Subscriber-side announce guard (bumps `announced` / `announced_closed`),
 	/// held for as long as the broadcast is announced into our origin.
@@ -56,7 +55,7 @@ struct BroadcastState {
 #[derive(Clone)]
 pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	session: S,
-	origin: OriginProducer,
+	origin: origin::Producer,
 	control: Control,
 	stats: StatsHandle,
 	/// Per-session ingress broadcast-subscription tracker. Each upstream
@@ -74,7 +73,7 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 }
 
 impl<S: web_transport_trait::Session> Subscriber<S> {
-	pub fn new(session: S, origin: OriginProducer, control: Control, stats: StatsHandle, version: Version) -> Self {
+	pub fn new(session: S, origin: origin::Producer, control: Control, stats: StatsHandle, version: Version) -> Self {
 		let broadcasts = stats.subscriber_broadcasts();
 		Self {
 			session,
@@ -447,7 +446,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	fn start_announce(&mut self, path: PathOwned) -> Result<BroadcastProducer, Error> {
+	fn start_announce(&mut self, path: PathOwned) -> Result<broadcast::Producer, Error> {
 		let abs = self.origin.absolute(&path).to_owned();
 		// Count the broadcast name length per announce (not the encoded message
 		// size, so framing overhead isn't charged), keyed by path so it's
@@ -469,7 +468,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				let mut hops = crate::OriginList::new();
 				hops.push(self.session_origin)
 					.expect("an empty hop chain has room for one entry");
-				let broadcast = BroadcastInfo { hops }.produce();
+				let broadcast = broadcast::Info { hops }.produce();
 
 				// Create the dynamic handler BEFORE publishing so consumers see
 				// dynamic >= 1 the moment they receive the announce. Otherwise a
@@ -538,7 +537,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let namespace = msg.track_namespace.to_owned();
 
 		// Announce the broadcast first so the track is born from it (inheriting the
-		// broadcast's Arc<BroadcastInfo>). Undo the announce on any error path below.
+		// broadcast's Arc<broadcast::Info>). Undo the announce on any error path below.
 		let mut broadcast = self.start_announce(namespace.clone())?;
 		let track = match broadcast.create_track(msg.track_name.to_string(), None) {
 			Ok(track) => track,
@@ -584,7 +583,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	async fn run_broadcast(&self, path: Path<'_>, mut broadcast: BroadcastDynamic) -> Result<(), Error> {
+	async fn run_broadcast(&self, path: Path<'_>, mut broadcast: broadcast::Dynamic) -> Result<(), Error> {
 		loop {
 			let request = tokio::select! {
 				request = broadcast.requested_track() => match request {
@@ -609,7 +608,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	async fn run_subscribe(&mut self, broadcast_path: Path<'_>, broadcast: BroadcastDynamic, request: TrackRequest) {
+	async fn run_subscribe(
+		&mut self,
+		broadcast_path: Path<'_>,
+		broadcast: broadcast::Dynamic,
+		request: track::Request,
+	) {
 		// Accept right away: IETF group data can arrive before SubscribeOk, so we
 		// need the producer in place to route it. This also unblocks the
 		// downstream subscriber's `consume_track`.
@@ -617,7 +621,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// Set the track timescale to microseconds: IETF object timestamps default to
 		// microseconds, and `create_frame` normalizes each frame into the track scale.
 		// Accepting at milliseconds (the default) would truncate microsecond precision.
-		let info = crate::TrackInfo::default().with_timescale(crate::Timescale::MICRO);
+		let info = track::Info::default().with_timescale(crate::Timescale::MICRO);
 		let mut track = request.accept(info);
 
 		let request_id = match self.control.next_request_id().await {
@@ -730,7 +734,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		stream: &mut Stream<S, Version>,
 		request_id: RequestId,
 		broadcast: &Path<'_>,
-		track: &TrackProducer,
+		track: &track::Producer,
 	) -> Result<(), Error> {
 		stream.writer.encode(&ietf::Subscribe::ID).await?;
 		stream
@@ -792,7 +796,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			};
 			let track = state.subscribes.get_mut(&request_id).ok_or(Error::NotFound)?;
 
-			let group_info = GroupInfo {
+			let group_info = group::Info {
 				sequence: group.group_id,
 			};
 			let producer = track.producer.create_group(group_info)?;
@@ -828,7 +832,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		group: ietf::GroupHeader,
 		stream: &mut Reader<S::RecvStream, Version>,
-		mut producer: GroupProducer,
+		mut producer: group::Producer,
 		track_stats: Arc<SubscriberTrack>,
 	) -> Result<(), Error> {
 		while let Some(id_delta) = stream.decode_maybe::<u64>().await? {
@@ -852,7 +856,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				let status: u64 = stream.decode().await?;
 				if status == 0 {
 					let mut frame = match timestamp {
-						Some(ts) => producer.create_frame(FrameInfo { size: 0, timestamp: ts })?,
+						Some(ts) => producer.create_frame(frame::Info { size: 0, timestamp: ts })?,
 						None => producer.create_frame_now(0)?,
 					};
 					track_stats.frame();
@@ -866,7 +870,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				// `create_frame*` is the allocation chokepoint and rejects an oversized
 				// `size` before allocating, so no pre-check is needed.
 				let mut frame = match timestamp {
-					Some(ts) => producer.create_frame(FrameInfo { size, timestamp: ts })?,
+					Some(ts) => producer.create_frame(frame::Info { size, timestamp: ts })?,
 					None => producer.create_frame_now(size)?,
 				};
 				track_stats.frame();
@@ -886,10 +890,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	async fn run_frame(
 		&mut self,
 		stream: &mut Reader<S::RecvStream, Version>,
-		mut frame: FrameProducer,
+		mut frame: frame::Producer,
 		track_stats: &SubscriberTrack,
 	) -> Result<(), Error> {
-		// FrameProducer impls BufMut; read_buf writes stream bytes directly into
+		// frame::Producer impls BufMut; read_buf writes stream bytes directly into
 		// the per-frame buffer (see lite/subscriber.rs run_frame for rationale).
 		while bytes::BufMut::has_remaining_mut(&frame) {
 			match stream.read_buf(&mut frame).await? {

--- a/rs/moq-net/src/lib.rs
+++ b/rs/moq-net/src/lib.rs
@@ -7,11 +7,14 @@
 //!
 //! ## API
 //! The API is built around Producer/Consumer pairs, with the hierarchy:
-//! - [Origin]: A collection of [BroadcastConsumer]s, produced by one or more [Session]s.
-//! - [BroadcastConsumer]: A collection of [TrackConsumer]s, produced by a single publisher.
-//! - [TrackConsumer]: A collection of [GroupInfo]s, delivered out-of-order until expired.
-//! - [GroupInfo]: A collection of [FrameInfo]s, delivered in order until cancelled.
-//! - [FrameInfo]: Chunks of data with an upfront size.
+//! - [origin::Consumer]: A collection of [broadcast::Consumer]s, produced by one or more [Session]s.
+//! - [broadcast::Consumer]: A collection of [track::Consumer]s, produced by a single publisher.
+//! - [track::Consumer]: A collection of [group::Info]s, delivered out-of-order until expired.
+//! - [group::Info]: A collection of [frame::Info]s, delivered in order until cancelled.
+//! - [frame::Info]: Chunks of data with an upfront size.
+//!
+//! Each level lives in its own module (`broadcast`, `track`, `group`, `frame`, `origin`,
+//! `announce`) that owns the short `Producer` / `Consumer` / `Info` names.
 //!
 //! ## Compatibility
 //! The API exposes the intersection of features supported by both protocols, intentionally

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1,16 +1,16 @@
+use crate::{announce, frame, group, origin, track};
 use std::{sync::Arc, time::Duration};
 
 use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
 use web_transport_trait::Stats;
 
 use crate::{
-	AnnounceConsumer, AsPath, Error, Origin, OriginConsumer, OriginList, StatsHandle as MoqStats, TrackSubscriber,
+	AsPath, Error, Origin, OriginList, StatsHandle as MoqStats,
 	coding::{Encode, Stream, Writer},
 	lite::{
 		self,
 		priority::{Priority, PriorityHandle, PriorityQueue},
 	},
-	model::{FrameConsumer, GroupConsumer},
 	util::{MaybeBoxedExt, MaybeSendBox},
 };
 
@@ -19,7 +19,7 @@ use super::Version;
 pub(super) struct PublisherConfig<S: web_transport_trait::Session> {
 	pub session: S,
 	/// The origin we read local broadcasts from.
-	pub origin: OriginConsumer,
+	pub origin: origin::Consumer,
 	/// Stats aggregator for this session's egress. Use [`MoqStats::default`]
 	/// to opt out.
 	pub stats: MoqStats,
@@ -28,7 +28,7 @@ pub(super) struct PublisherConfig<S: web_transport_trait::Session> {
 
 pub(super) struct Publisher<S: web_transport_trait::Session> {
 	session: S,
-	origin: OriginConsumer,
+	origin: origin::Consumer,
 	stats: MoqStats,
 	/// Per-session egress broadcast-subscription tracker. Each downstream
 	/// subscription holds a guard so `broadcasts - broadcasts_closed` counts
@@ -58,7 +58,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	pub async fn run(self) -> Result<(), Error> {
-		// `OriginConsumer` and friends are cheap to clone (shared handles), so each control
+		// `origin::Consumer` and friends are cheap to clone (shared handles), so each control
 		// stream gets its own task and they all make progress independently.
 		let this = Arc::new(self);
 
@@ -190,8 +190,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	#[allow(clippy::too_many_arguments)]
 	async fn run_announce(
 		stream: &mut Stream<S, Version>,
-		origin: &OriginConsumer,
-		announced: &mut AnnounceConsumer,
+		origin: &origin::Consumer,
+		announced: &mut announce::Consumer,
 		prefix: impl AsPath,
 		self_origin: Origin,
 		// Peer's session-level origin id, sent in AnnounceInterest. We skip
@@ -337,7 +337,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						let absolute = origin.absolute(&path).to_owned();
 
 						match event {
-							crate::Announced::Active(active) => {
+							announce::Event::Active(active) => {
 								let info = active.info();
 								let Some(hops) = Self::prepare_active_hops(&info.hops, self_origin, exclude_hop, version, &absolute) else {
 									continue;
@@ -351,7 +351,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 								debug_assert!(prev.is_none(), "origin announced a path that was already active");
 								stream.writer.encode(&lite::AnnounceBroadcast::Active { suffix, hops }).await?;
 							}
-							crate::Announced::Restart(active) => {
+							announce::Event::Restart(active) => {
 								// On lite-05+ a restart travels as a duplicate ANNOUNCE (a second
 								// `Active` for an already-announced path). Older versions never defined
 								// that, so split it into an unannounce followed by a fresh announce.
@@ -388,7 +388,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 									}
 								}
 							}
-							crate::Announced::Ended => {
+							announce::Event::Ended => {
 								tracing::debug!(broadcast = %absolute, "unannounce");
 								// Count the name length whether or not a guard is held: the Ended
 								// message is sent even for announces we filtered out above.
@@ -461,7 +461,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 	async fn run_track_info(&self, stream: &mut Stream<S, Version>, request: &lite::Track<'_>) -> Result<(), Error> {
 		// The peer requested this exact path, so it has already seen an announcement for it.
-		// `request_broadcast` resolves it immediately, or falls back to an `OriginDynamic`
+		// `request_broadcast` resolves it immediately, or falls back to an `origin::Dynamic`
 		// handler (as in recv_subscribe).
 		let broadcast = self.origin.request_broadcast(&request.broadcast).await?;
 		let info = broadcast.track(&request.track)?.info().await?;
@@ -494,7 +494,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		// We just received a subscribe for this exact path, so by definition the peer has
 		// already seen an announcement for it. `request_broadcast` resolves an announced
-		// broadcast immediately; if it isn't announced it falls back to an `OriginDynamic`
+		// broadcast immediately; if it isn't announced it falls back to an `origin::Dynamic`
 		// handler (or resolves to an error when there is none).
 		let broadcast = self.origin.request_broadcast(&subscribe.broadcast);
 
@@ -536,7 +536,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		session: S,
 		stream: &mut Stream<S, Version>,
 		subscribe: &lite::Subscribe<'_>,
-		broadcast: kio::Pending<crate::BroadcastRequested>,
+		broadcast: kio::Pending<origin::Requested>,
 		priority: PriorityQueue,
 		// The track guard (bumps `subscriptions`), the per-session broadcast
 		// tracker, and the broadcast path. The `broadcasts` sentinel is taken
@@ -638,7 +638,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		tracing::info!(broadcast = %absolute, %track, %group, "fetch started");
 
 		// The peer fetched this exact path, so it has already seen an announcement for it.
-		// `request_broadcast` resolves it immediately, or falls back to an `OriginDynamic`
+		// `request_broadcast` resolves it immediately, or falls back to an `origin::Dynamic`
 		// handler (as in recv_subscribe).
 		let broadcast = self.origin.request_broadcast(&fetch.broadcast);
 		let track_stats = self.stats.broadcast(&absolute).publisher_track(&track);
@@ -661,7 +661,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	async fn run_fetch(
 		stream: &mut Stream<S, Version>,
 		fetch: &lite::Fetch<'_>,
-		broadcast: kio::Pending<crate::BroadcastRequested>,
+		broadcast: kio::Pending<origin::Requested>,
 		track_stats: crate::PublisherTrack,
 		version: Version,
 	) -> Result<(), Error> {
@@ -671,7 +671,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let group = track
 			.fetch_group(
 				fetch.group,
-				crate::Fetch {
+				group::Fetch {
 					priority: fetch.priority,
 				},
 			)
@@ -709,12 +709,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 /// (catalogs, control channels, IETF transport).
 ///
 /// `prev_ts` carries the running baseline, so the first frame deltas against 0. The
-/// model layer (`GroupProducer::create_frame`) already converted the timestamp
+/// model layer (`group::Producer::create_frame`) already converted the timestamp
 /// into the track timescale, so its raw value goes straight onto the wire. Mirrors
 /// the decode in the subscriber's `run_group`.
 async fn encode_frame_timing<W: web_transport_trait::SendStream>(
 	writer: &mut Writer<W, Version>,
-	frame: &FrameConsumer,
+	frame: &frame::Consumer,
 	timescale: Option<crate::Timescale>,
 	prev_ts: &mut u64,
 ) -> Result<(), Error> {
@@ -751,7 +751,7 @@ async fn encode_zigzag_delta<W: web_transport_trait::SendStream>(
 /// stream up front.
 async fn write_fetch_frame<W: web_transport_trait::SendStream>(
 	writer: &mut Writer<W, Version>,
-	frame: &mut FrameConsumer,
+	frame: &mut frame::Consumer,
 	timescale: Option<crate::Timescale>,
 	prev_ts: &mut u64,
 	track_stats: &crate::PublisherTrack,
@@ -790,7 +790,7 @@ struct Subscription<S: web_transport_trait::Session> {
 impl<S: web_transport_trait::Session> Subscription<S> {
 	async fn run_track(
 		mut self,
-		mut track: TrackSubscriber,
+		mut track: track::Subscriber,
 		start_group: Option<u64>,
 		initial_end_group: Option<u64>,
 		reader: &mut crate::coding::Reader<S::RecvStream, Version>,
@@ -871,7 +871,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		}
 	}
 
-	fn spawn_serve(&mut self, group: GroupConsumer, tasks: &mut FuturesUnordered<MaybeSendBox<'static, ()>>) {
+	fn spawn_serve(&mut self, group: group::Consumer, tasks: &mut FuturesUnordered<MaybeSendBox<'static, ()>>) {
 		let sequence = group.sequence;
 		tracing::debug!(subscribe = self.id, track = %self.track_name, sequence, "serving group");
 
@@ -886,7 +886,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		mut self,
 		sequence: u64,
 		mut priority: PriorityHandle,
-		mut group: GroupConsumer,
+		mut group: group::Consumer,
 	) -> Result<(), Error> {
 		let msg = lite::Group {
 			subscribe: self.id,
@@ -923,7 +923,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		&mut self,
 		stream: &mut Writer<S::SendStream, Version>,
 		priority: &mut PriorityHandle,
-		mut frame: FrameConsumer,
+		mut frame: frame::Consumer,
 		prev_ts: &mut u64,
 	) -> Result<(), Error> {
 		encode_frame_timing(stream, &frame, self.timescale, prev_ts).await?;
@@ -944,8 +944,8 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		&mut self,
 		stream: &mut Writer<S::SendStream, Version>,
 		priority: &mut PriorityHandle,
-		group: &mut GroupConsumer,
-	) -> Result<Option<FrameConsumer>, Error> {
+		group: &mut group::Consumer,
+	) -> Result<Option<frame::Consumer>, Error> {
 		loop {
 			tokio::select! {
 				biased;
@@ -962,7 +962,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		&mut self,
 		stream: &mut Writer<S::SendStream, Version>,
 		priority: &mut PriorityHandle,
-		frame: &mut FrameConsumer,
+		frame: &mut frame::Consumer,
 	) -> Result<Option<bytes::Bytes>, Error> {
 		loop {
 			tokio::select! {

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -1,5 +1,6 @@
+use crate::origin;
 use crate::{
-	BandwidthConsumer, BandwidthProducer, Error, Origin, OriginConsumer, OriginProducer, StatsHandle,
+	BandwidthConsumer, BandwidthProducer, Error, Origin, StatsHandle,
 	coding::{Reader, Stream, Writer},
 	lite::SessionInfo,
 };
@@ -49,9 +50,9 @@ pub fn start<S: web_transport_trait::Session>(
 	// NOTE: No longer used in draft-03.
 	setup_stream: Option<Stream<S, Version>>,
 	// We will publish any local broadcasts from this origin, when set.
-	publish: Option<OriginConsumer>,
+	publish: Option<origin::Consumer>,
 	// We will consume any remote broadcasts, inserting them into this origin, when set.
-	subscribe: Option<OriginProducer>,
+	subscribe: Option<origin::Producer>,
 	// Tier-scoped stats handle. Pass [`StatsHandle::default`] to opt out.
 	stats: StatsHandle,
 	// The version of the protocol to use.
@@ -94,8 +95,8 @@ pub fn start<S: web_transport_trait::Session>(
 	// (and answers the peer's announce-interest with an empty set), and an empty
 	// subscribe origin issues no ANNOUNCE_PLEASE (zero prefixes, so `run_announce`
 	// drops `connecting` at once and `connect()` still unblocks).
-	let publish = publish.unwrap_or_else(|| OriginProducer::empty(Origin::random()).consume());
-	let subscribe = subscribe.unwrap_or_else(|| OriginProducer::empty(Origin::random()));
+	let publish = publish.unwrap_or_else(|| origin::Producer::empty(Origin::random()).consume());
+	let subscribe = subscribe.unwrap_or_else(|| origin::Producer::empty(Origin::random()));
 
 	// Publisher and Subscriber each derive their identity from their own
 	// attached origin (publish.info / subscribe.info). This is what gets

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1,3 +1,4 @@
+use crate::{broadcast, frame, group, origin, track};
 use std::{
 	collections::HashMap,
 	pin::Pin,
@@ -11,9 +12,8 @@ use futures::{StreamExt, stream::FuturesUnordered};
 use crate::util::{MaybeBoxedExt, MaybeSendBox};
 
 use crate::{
-	AsPath, BandwidthProducer, BroadcastDynamic, BroadcastInfo, Error, FrameInfo, FrameProducer, GroupInfo,
-	GroupProducer, GroupRequest, OriginProducer, OriginPublish, Path, PathOwned, StatsHandle, SubscriberStats,
-	SubscriberTrack, Subscription, Timescale, Timestamp, TrackInfo, TrackProducer, TrackRequest,
+	AsPath, BandwidthProducer, Error, Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, Subscription,
+	Timescale, Timestamp,
 	coding::{Reader, Stream},
 	lite,
 };
@@ -24,14 +24,14 @@ use web_async::Lock;
 
 /// Keep an upstream subscription alive briefly after the track goes idle (no
 /// subscriber, no fetch, no consumers), so a returning consumer reuses the same
-/// TrackProducer instead of forcing a fresh fetch (and the publisher re-serving
+/// track::Producer instead of forcing a fresh fetch (and the publisher re-serving
 /// the latest cached group).
 const LINGER_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 	pub session: S,
 	/// The origin into which remote broadcasts are inserted.
-	pub origin: OriginProducer,
+	pub origin: origin::Producer,
 	/// Receiver-side bandwidth producer for PROBE feedback. None disables the
 	/// feature (used by versions that don't carry probe streams).
 	pub recv_bandwidth: Option<BandwidthProducer>,
@@ -48,7 +48,7 @@ pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	session: S,
 
-	origin: OriginProducer,
+	origin: origin::Producer,
 	stats: StatsHandle,
 	/// Per-session ingress broadcast-subscription tracker. Each upstream
 	/// subscription holds a guard so `broadcasts - broadcasts_closed` counts the
@@ -75,7 +75,7 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 
 #[derive(Clone)]
 struct TrackEntry {
-	producer: TrackProducer,
+	producer: track::Producer,
 	stats: Arc<SubscriberTrack>,
 	/// Timestamp scale from this track's TRACK_INFO, known before the SUBSCRIBE is
 	/// even opened, so group streams decode frames without blocking.
@@ -313,7 +313,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					// The matching Active may have been silently dropped by
 					// start_announce as a reflected loop, in which case
 					// `producers` has no entry; that's expected, not an error.
-					// Dropping the entry drops its OriginPublish guard, which unannounces.
+					// Dropping the entry drops its origin::Publish guard, which unannounces.
 					if producers.remove(&path).is_some() {
 						stats_guards.remove(&abs);
 					}
@@ -397,7 +397,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// the full `[src...sender]` chain Lite04 stored. None for older versions,
 		// where the sender already appended itself.
 		responder_origin: Option<crate::Origin>,
-		producers: &mut HashMap<PathOwned, OriginPublish>,
+		producers: &mut HashMap<PathOwned, origin::Publish>,
 	) -> Result<bool, Error> {
 		if let Some(responder) = responder_origin {
 			// If the chain is already full, drop the announce. This is the same decision
@@ -444,7 +444,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "announce");
 
-		let broadcast = BroadcastInfo { hops }.produce();
+		let broadcast = broadcast::Info { hops }.produce();
 
 		// Create the dynamic handler BEFORE publishing, so that consumers
 		// see dynamic >= 1 immediately when they receive the announcement.
@@ -480,7 +480,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// rebuild the full chain since the sender no longer stamps itself. None for older
 		// versions. See `start_announce`.
 		responder_origin: Option<crate::Origin>,
-		producers: &mut HashMap<PathOwned, OriginPublish>,
+		producers: &mut HashMap<PathOwned, origin::Publish>,
 	) -> Result<bool, Error> {
 		// Reflected loop (or a full chain): the replacement can't be used here. Retire the broadcast.
 		let reflected = match responder_origin {
@@ -496,7 +496,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "restart");
 
-		let broadcast = BroadcastInfo { hops }.produce();
+		let broadcast = broadcast::Info { hops }.produce();
 		let dynamic = broadcast.dynamic();
 
 		// Publish the replacement first so the origin restarts atomically; the old broadcast is
@@ -516,7 +516,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(true)
 	}
 
-	async fn run_broadcast(self, path: PathOwned, mut broadcast: BroadcastDynamic) {
+	async fn run_broadcast(self, path: PathOwned, mut broadcast: broadcast::Dynamic) {
 		// Serve track requests until every consumer of the broadcast is gone.
 		loop {
 			let request = tokio::select! {
@@ -558,7 +558,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let mut subs = self.subscribes.lock();
 			let entry = subs.get_mut(&hdr.subscribe).ok_or(Error::Cancel)?;
 
-			let group_info = GroupInfo { sequence: hdr.sequence };
+			let group_info = group::Info { sequence: hdr.sequence };
 			let group = entry.producer.create_group(group_info)?;
 			(group, entry.producer.clone(), entry.stats.clone(), entry.timescale)
 		};
@@ -594,7 +594,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	async fn run_group(
 		&mut self,
 		stream: &mut Reader<S::RecvStream, Version>,
-		mut group: GroupProducer,
+		mut group: group::Producer,
 		track_stats: Arc<SubscriberTrack>,
 		timescale: Option<Timescale>,
 	) -> Result<(), Error> {
@@ -629,7 +629,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			// `size` before allocating, so no pre-check is needed. No wire timestamp
 			// (pre-lite-05) means wall-clock at receive.
 			let mut frame = match timestamp {
-				Some(ts) => group.create_frame(FrameInfo { size, timestamp: ts })?,
+				Some(ts) => group.create_frame(frame::Info { size, timestamp: ts })?,
 				None => group.create_frame_now(size)?,
 			};
 			track_stats.frame();
@@ -648,10 +648,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	async fn run_frame(
 		&mut self,
 		stream: &mut Reader<S::RecvStream, Version>,
-		frame: &mut FrameProducer,
+		frame: &mut frame::Producer,
 		track_stats: &SubscriberTrack,
 	) -> Result<(), Error> {
-		// FrameProducer impls BufMut over its pre-allocated per-frame buffer, so
+		// frame::Producer impls BufMut over its pre-allocated per-frame buffer, so
 		// read_buf writes QUIC stream bytes directly into the frame. No
 		// intermediate Bytes allocations, and quinn's reassembly arena is freed
 		// as we drain it.
@@ -681,10 +681,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 /// TRACK stream resolves the properties up front); on older drafts it stays
 /// `Pending` until the first SUBSCRIBE_OK promotes it. Both observe subscription
 /// demand, so [`TrackServe`] drives them uniformly. Fetches are served separately
-/// via the [`TrackDynamic`] handle.
+/// via the [`track::Dynamic`] handle.
 enum Track {
-	Pending(TrackRequest),
-	Active(TrackProducer),
+	Pending(track::Request),
+	Active(track::Producer),
 }
 
 impl Track {
@@ -746,7 +746,7 @@ impl<S: web_transport_trait::Session> Sub<S> {
 /// upstream stream, the broadcast, and the linger timer.
 enum Event {
 	/// A consumer fetched a past group.
-	Fetch(GroupRequest),
+	Fetch(track::GroupRequest),
 	/// The downstream aggregate subscription changed (`None` once the last subscriber leaves).
 	Subscription(Option<Subscription>),
 	/// Nothing left to serve (no subscription, no fetch, no consumers): start the linger countdown.
@@ -769,13 +769,13 @@ enum Event {
 struct TrackServe<S: web_transport_trait::Session> {
 	subscriber: Subscriber<S>,
 	path: PathOwned,
-	broadcast: BroadcastDynamic,
+	broadcast: broadcast::Dynamic,
 	track_stats: Arc<SubscriberTrack>,
 	name: String,
 }
 
 impl<S: web_transport_trait::Session> TrackServe<S> {
-	async fn run(self, request: TrackRequest) {
+	async fn run(self, request: track::Request) {
 		// SUBSCRIBE_UPDATE (and thus pause/resume linger) only exists on Lite03+.
 		// Older versions tear the upstream down as soon as the track goes idle.
 		let supports_linger = !matches!(self.subscriber.version, Version::Lite01 | Version::Lite02);
@@ -941,8 +941,8 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 	}
 
 	/// Open a TRACK stream, read the single TRACK_INFO, and map it to the model's
-	/// [`crate::TrackInfo`]. Lite05+ only. Bails if the broadcast dies meanwhile.
-	async fn track_info(&self) -> Result<crate::TrackInfo, Error> {
+	/// [`track::Info`]. Lite05+ only. Bails if the broadcast dies meanwhile.
+	async fn track_info(&self) -> Result<track::Info, Error> {
 		let mut stream = Stream::open(&self.subscriber.session, self.subscriber.version).await?;
 		stream.writer.encode(&lite::ControlType::Track).await?;
 		stream
@@ -962,7 +962,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 
 		// Publisher Max Latency rides on the wire, so the local retention window
 		// matches what the upstream advertises (relays re-serve with the same bound).
-		let model = crate::TrackInfo {
+		let model = track::Info {
 			timescale: info.timescale,
 			cache: info.cache,
 			priority: info.priority,
@@ -1101,7 +1101,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			let Some(Track::Pending(request)) = track.take() else {
 				unreachable!("establish called without a pending track");
 			};
-			let mut producer = request.accept(crate::TrackInfo::default());
+			let mut producer = request.accept(track::Info::default());
 			// The accepted producer starts with a fresh subscription cursor, so its first
 			// poll would re-report the subscription we just sent as a "change". Prime it
 			// now (the params are already on the wire) so only genuine later changes fire.
@@ -1155,7 +1155,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 	/// from this track's TRACK_INFO (already known), and the group sequence is
 	/// implicit from the request. Runs to completion as an independent future in the
 	/// serve loop's `FuturesUnordered`.
-	async fn serve_fetch(self, request: GroupRequest, timescale: Option<Timescale>) {
+	async fn serve_fetch(self, request: track::GroupRequest, timescale: Option<Timescale>) {
 		let TrackServe {
 			mut subscriber,
 			path,
@@ -1194,9 +1194,9 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		}
 
 		// Make the group available (resolving the downstream fetch) and fill it. The
-		// TrackInfo only takes effect if the track isn't accepted yet (a fetch with no
+		// track::Info only takes effect if the track isn't accepted yet (a fetch with no
 		// live subscription); otherwise the group inherits the accepted timescale.
-		let group_info = TrackInfo {
+		let group_info = track::Info {
 			// Relay-served FETCH is lite-05+, so `timescale` is `Some`; fall back to the
 			// default scale defensively rather than panicking.
 			timescale: timescale.unwrap_or_default(),

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -1,26 +1,27 @@
+use crate::track;
 use std::{
 	collections::{HashMap, VecDeque, hash_map},
 	sync::Arc,
 	task::{Poll, ready},
 };
 
-use crate::{Error, TrackConsumer, TrackProducer, TrackRequest, TrackWeak};
+use crate::Error;
 
-use super::{OriginList, TrackInfo};
+use super::OriginList;
 
 /// A collection of media tracks that can be published and subscribed to.
 ///
-/// Create via [`BroadcastInfo::produce`] to obtain both [`BroadcastProducer`] and [`BroadcastConsumer`] pair.
+/// Create via [`Info::produce`] to obtain both [`Producer`] and [`Consumer`] pair.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
-pub struct BroadcastInfo {
+pub struct Info {
 	/// The chain of origins the broadcast has traversed. Each relay appends its own
 	/// [`crate::Origin`] when forwarding, so the list is used for loop detection and
 	/// shortest-path preference.
 	pub hops: OriginList,
 }
 
-impl Default for BroadcastInfo {
+impl Default for Info {
 	fn default() -> Self {
 		Self {
 			hops: OriginList::new(),
@@ -28,16 +29,16 @@ impl Default for BroadcastInfo {
 	}
 }
 
-impl BroadcastInfo {
+impl Info {
 	/// Create a new broadcast with an empty hop chain.
 	pub fn new() -> Self {
 		Self::default()
 	}
 
-	/// Consume this [BroadcastInfo] to create a producer that carries its metadata
+	/// Consume this [Info] to create a producer that carries its metadata
 	/// (including the hop chain).
-	pub fn produce(self) -> BroadcastProducer {
-		BroadcastProducer::new(self)
+	pub fn produce(self) -> Producer {
+		Producer::new(self)
 	}
 }
 
@@ -45,14 +46,14 @@ impl BroadcastInfo {
 struct BroadcastState {
 	// Weak references for deduplication. Doesn't prevent track auto-close.
 	// Keyed by the track's shared `Arc<str>` name (the same Arc the handle holds).
-	tracks: HashMap<Arc<str>, TrackWeak>,
+	tracks: HashMap<Arc<str>, track::TrackWeak>,
 
 	// Pending requests keyed by track name, waiting for the dynamic handler to
 	// accept or deny them.
-	requests: HashMap<Arc<str>, TrackRequest>,
+	requests: HashMap<Arc<str>, track::Request>,
 
 	// Requested names in FIFO order for the dynamic handler to drain. A name
-	// stays in `requests` (but not here) once handed out as a `TrackRequest`.
+	// stays in `requests` (but not here) once handed out as a `track::Request`.
 	request_order: VecDeque<Arc<str>>,
 
 	// The current number of dynamic producers.
@@ -66,7 +67,7 @@ impl BroadcastState {
 	}
 
 	/// Insert a track weak handle into the lookup, returning an error on duplicate.
-	fn insert_track(&mut self, weak: TrackWeak) -> Result<(), Error> {
+	fn insert_track(&mut self, weak: track::TrackWeak) -> Result<(), Error> {
 		let hash_map::Entry::Vacant(entry) = self.tracks.entry(weak.name().clone()) else {
 			return Err(Error::Duplicate);
 		};
@@ -90,23 +91,23 @@ impl BroadcastState {
 /// later with [Self::reserve_track], or handle on-demand consumer requests via
 /// [Self::dynamic].
 #[derive(Clone)]
-pub struct BroadcastProducer {
+pub struct Producer {
 	// Held behind an Arc so each track born from this broadcast can inherit a shared
 	// handle (threaded down by [`Self::create_track`] / [`Self::reserve_track`]).
-	info: Arc<BroadcastInfo>,
+	info: Arc<Info>,
 	state: kio::Producer<BroadcastState>,
 }
 
-impl BroadcastProducer {
-	/// Create a producer for the given broadcast metadata. Prefer [`BroadcastInfo::produce`].
-	pub fn new(info: BroadcastInfo) -> Self {
+impl Producer {
+	/// Create a producer for the given broadcast metadata. Prefer [`Info::produce`].
+	pub fn new(info: Info) -> Self {
 		Self {
 			info: Arc::new(info),
 			state: Default::default(),
 		}
 	}
 
-	pub fn info(&self) -> &BroadcastInfo {
+	pub fn info(&self) -> &Info {
 		&self.info
 	}
 
@@ -119,30 +120,30 @@ impl BroadcastProducer {
 
 	/// Produce a new track and insert it into the broadcast.
 	///
-	/// Pass a name and an optional [`TrackInfo`], so a bare name works:
+	/// Pass a name and an optional [`track::Info`], so a bare name works:
 	/// `create_track("video", None)`.
 	pub fn create_track(
 		&mut self,
 		name: impl Into<Arc<str>>,
-		info: impl Into<Option<TrackInfo>>,
-	) -> Result<TrackProducer, Error> {
+		info: impl Into<Option<track::Info>>,
+	) -> Result<track::Producer, Error> {
 		let info = info.into().unwrap_or_default();
-		let track = TrackProducer::new(self.info.clone(), name, info);
+		let track = track::Producer::new(self.info.clone(), name, info);
 		let mut state = BroadcastState::modify(&self.state)?;
 		state.insert_track(track.weak())?;
 		drop(state);
 		Ok(track)
 	}
 
-	/// Reserve a track by name without finalizing its [`TrackInfo`].
+	/// Reserve a track by name without finalizing its [`track::Info`].
 	///
-	/// Returns a [`TrackRequest`] already discoverable by consumers; call
-	/// [`TrackRequest::accept`] to set its info and start producing. Use this when
+	/// Returns a [`track::Request`] already discoverable by consumers; call
+	/// [`track::Request::accept`] to set its info and start producing. Use this when
 	/// the producer can't pick the track's properties (e.g. timescale) until it has
 	/// inspected the media, the same shape as a consumer-driven
-	/// [`BroadcastDynamic::requested_track`].
-	pub fn reserve_track(&mut self, name: impl Into<Arc<str>>) -> Result<TrackRequest, Error> {
-		let request = TrackRequest::new(self.info.clone(), name);
+	/// [`Dynamic::requested_track`].
+	pub fn reserve_track(&mut self, name: impl Into<Arc<str>>) -> Result<track::Request, Error> {
+		let request = track::Request::new(self.info.clone(), name);
 		let mut state = BroadcastState::modify(&self.state)?;
 		state.insert_track(request.weak())?;
 		drop(state);
@@ -153,7 +154,11 @@ impl BroadcastProducer {
 	///
 	/// Generates names like `0{suffix}`, `1{suffix}`, etc. and picks the first
 	/// one not already used in this broadcast.
-	pub fn unique_track(&mut self, suffix: &str, info: impl Into<Option<TrackInfo>>) -> Result<TrackProducer, Error> {
+	pub fn unique_track(
+		&mut self,
+		suffix: &str,
+		info: impl Into<Option<track::Info>>,
+	) -> Result<track::Producer, Error> {
 		let name = self.unique_name(suffix);
 		self.create_track(name, info)
 	}
@@ -172,13 +177,13 @@ impl BroadcastProducer {
 	}
 
 	/// Create a dynamic producer that handles on-demand track requests from consumers.
-	pub fn dynamic(&self) -> BroadcastDynamic {
-		BroadcastDynamic::new(self.info.clone(), self.state.clone())
+	pub fn dynamic(&self) -> Dynamic {
+		Dynamic::new(self.info.clone(), self.state.clone())
 	}
 
 	/// Create a consumer that can subscribe to tracks in this broadcast.
-	pub fn consume(&self) -> BroadcastConsumer {
-		BroadcastConsumer {
+	pub fn consume(&self) -> Consumer {
+		Consumer {
 			info: self.info.clone(),
 			state: self.state.consume(),
 		}
@@ -191,12 +196,12 @@ impl BroadcastProducer {
 }
 
 #[cfg(test)]
-impl BroadcastProducer {
+impl Producer {
 	pub fn assert_create_track(
 		&mut self,
 		name: impl Into<Arc<str>>,
-		info: impl Into<Option<TrackInfo>>,
-	) -> TrackProducer {
+		info: impl Into<Option<track::Info>>,
+	) -> track::Producer {
 		self.create_track(name, info).expect("should not have errored")
 	}
 }
@@ -205,15 +210,15 @@ impl BroadcastProducer {
 ///
 /// When a consumer requests a track that doesn't exist, the dynamic producer
 /// picks up the request via [`Self::requested_track`] and either
-/// [`TrackRequest::accept`]s it with a concrete [`TrackInfo`] or
-/// [`TrackRequest::reject`]s it. Dropped when no longer needed; pending requests
+/// [`track::Request::accept`]s it with a concrete [`track::Info`] or
+/// [`track::Request::reject`]s it. Dropped when no longer needed; pending requests
 /// are automatically aborted.
-pub struct BroadcastDynamic {
-	info: Arc<BroadcastInfo>,
+pub struct Dynamic {
+	info: Arc<Info>,
 	state: kio::Producer<BroadcastState>,
 }
 
-impl Clone for BroadcastDynamic {
+impl Clone for Dynamic {
 	fn clone(&self) -> Self {
 		// Mirror `new`: bump `state.dynamic` so each live handle is counted.
 		// Without this, deriving Clone would let `Drop` decrement past `new`'s
@@ -230,8 +235,8 @@ impl Clone for BroadcastDynamic {
 	}
 }
 
-impl BroadcastDynamic {
-	fn new(info: Arc<BroadcastInfo>, state: kio::Producer<BroadcastState>) -> Self {
+impl Dynamic {
+	fn new(info: Arc<Info>, state: kio::Producer<BroadcastState>) -> Self {
 		if let Ok(mut state) = state.write() {
 			// If the broadcast is already closed, we can't handle any new requests.
 			state.dynamic += 1;
@@ -240,7 +245,7 @@ impl BroadcastDynamic {
 		Self { info, state }
 	}
 
-	pub fn info(&self) -> &BroadcastInfo {
+	pub fn info(&self) -> &Info {
 		&self.info
 	}
 
@@ -257,7 +262,7 @@ impl BroadcastDynamic {
 	}
 
 	/// Poll for the next consumer-requested track, without blocking.
-	pub fn poll_requested_track(&mut self, waiter: &kio::Waiter) -> Poll<Result<TrackRequest, Error>> {
+	pub fn poll_requested_track(&mut self, waiter: &kio::Waiter) -> Poll<Result<track::Request, Error>> {
 		let mut state = ready!(self.poll(waiter, |state| {
 			if state.request_order.is_empty() {
 				Poll::Pending
@@ -272,14 +277,14 @@ impl BroadcastDynamic {
 		Poll::Ready(Ok(pending))
 	}
 
-	/// Block until a consumer requests a track, returning a [`TrackRequest`] to serve.
-	pub async fn requested_track(&mut self) -> Result<TrackRequest, Error> {
+	/// Block until a consumer requests a track, returning a [`track::Request`] to serve.
+	pub async fn requested_track(&mut self) -> Result<track::Request, Error> {
 		kio::wait(|waiter| self.poll_requested_track(waiter)).await
 	}
 
 	/// Create a consumer that can subscribe to tracks in this broadcast.
-	pub fn consume(&self) -> BroadcastConsumer {
-		BroadcastConsumer {
+	pub fn consume(&self) -> Consumer {
+		Consumer {
 			info: self.info.clone(),
 			state: self.state.consume(),
 		}
@@ -297,7 +302,7 @@ impl BroadcastDynamic {
 	}
 }
 
-impl Drop for BroadcastDynamic {
+impl Drop for Dynamic {
 	fn drop(&mut self) {
 		if let Ok(mut state) = self.state.write() {
 			// We do a saturating sub so Producer::dynamic() can avoid returning an error.
@@ -316,8 +321,8 @@ impl Drop for BroadcastDynamic {
 use futures::FutureExt;
 
 #[cfg(test)]
-impl BroadcastDynamic {
-	pub fn assert_request(&mut self) -> TrackRequest {
+impl Dynamic {
+	pub fn assert_request(&mut self) -> track::Request {
 		self.requested_track()
 			.now_or_never()
 			.expect("should not have blocked")
@@ -331,18 +336,18 @@ impl BroadcastDynamic {
 
 /// Subscribe to arbitrary broadcast/tracks.
 #[derive(Clone)]
-pub struct BroadcastConsumer {
-	info: Arc<BroadcastInfo>,
+pub struct Consumer {
+	info: Arc<Info>,
 	state: kio::Consumer<BroadcastState>,
 }
 
-impl BroadcastConsumer {
-	pub fn info(&self) -> &BroadcastInfo {
+impl Consumer {
+	pub fn info(&self) -> &Info {
 		&self.info
 	}
 
 	/// Get a handle to a track on this broadcast.
-	pub fn track(&self, name: &str) -> Result<TrackConsumer, Error> {
+	pub fn track(&self, name: &str) -> Result<track::Consumer, Error> {
 		// Upgrade to a temporary producer so we can modify the state.
 		let mut state = match self.state.write() {
 			Ok(state) => state,
@@ -370,7 +375,7 @@ impl BroadcastConsumer {
 		// Allocate the name once and share the same Arc across the request, the
 		// requests map, and the FIFO order.
 		let name: Arc<str> = name.into();
-		let request = TrackRequest::new(self.info.clone(), name.clone());
+		let request = track::Request::new(self.info.clone(), name.clone());
 		let consumer = request.consume();
 
 		state.requests.insert(name.clone(), request);
@@ -388,7 +393,7 @@ impl BroadcastConsumer {
 		Error::Dropped
 	}
 
-	/// Returns true if every [`BroadcastProducer`] has been dropped.
+	/// Returns true if every [`Producer`] has been dropped.
 	pub fn is_closed(&self) -> bool {
 		self.state.read().is_closed()
 	}
@@ -409,7 +414,7 @@ impl BroadcastConsumer {
 }
 
 #[cfg(test)]
-impl BroadcastConsumer {
+impl Consumer {
 	pub fn assert_not_closed(&self) {
 		assert!(self.closed().now_or_never().is_none(), "should not be closed");
 	}
@@ -438,7 +443,7 @@ mod test {
 
 	#[tokio::test]
 	async fn insert() {
-		let mut producer = BroadcastInfo::new().produce();
+		let mut producer = Info::new().produce();
 
 		// Create the track before any consumer exists.
 		let mut track1 = producer.assert_create_track("track1", None);
@@ -463,7 +468,7 @@ mod test {
 
 	#[tokio::test]
 	async fn closed() {
-		let mut producer = BroadcastInfo::new().produce();
+		let mut producer = Info::new().produce();
 		let dynamic = producer.dynamic();
 
 		let consumer = producer.consume();
@@ -490,7 +495,7 @@ mod test {
 
 	#[tokio::test]
 	async fn requests() {
-		let mut producer = BroadcastInfo::new().produce().dynamic();
+		let mut producer = Info::new().produce().dynamic();
 
 		let consumer = producer.consume();
 		let consumer2 = consumer.clone();
@@ -530,7 +535,7 @@ mod test {
 
 	#[tokio::test]
 	async fn stale_producer() {
-		let mut broadcast = BroadcastInfo::new().produce().dynamic();
+		let mut broadcast = Info::new().produce().dynamic();
 		let consumer = broadcast.consume();
 
 		// Subscribe to a track and serve it.
@@ -560,7 +565,7 @@ mod test {
 
 	#[tokio::test(start_paused = true)]
 	async fn requested_unused() {
-		let mut broadcast = BroadcastInfo::new().produce().dynamic();
+		let mut broadcast = Info::new().produce().dynamic();
 		let bc = broadcast.consume();
 
 		// Subscribe to a track that doesn't exist yet, then serve it.
@@ -612,14 +617,14 @@ mod test {
 		);
 	}
 
-	// Cloning a `BroadcastDynamic` and dropping the clone must not flip
+	// Cloning a `Dynamic` and dropping the clone must not flip
 	// `state.dynamic` to zero. The relay's lite subscriber clones the
 	// dynamic per spawned subscribe; if Clone skipped the increment, the
 	// first finished subscribe would tear down the broadcast and any
 	// follow-up `track` would return `NotFound`.
 	#[tokio::test]
 	async fn dynamic_clone_keeps_alive() {
-		let broadcast = BroadcastInfo::new().produce().dynamic();
+		let broadcast = Info::new().produce().dynamic();
 		let consumer = broadcast.consume();
 
 		let clone = broadcast.clone();

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -1,3 +1,4 @@
+use crate::group;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::task::{Poll, ready};
@@ -5,15 +6,15 @@ use std::task::{Poll, ready};
 use bytes::buf::UninitSlice;
 use bytes::{BufMut, Bytes};
 
-use crate::{Error, GroupInfo, Result, Timestamp};
+use crate::{Error, Result, Timestamp};
 
 /// Maximum payload size accepted for a single frame.
 ///
 /// The receive path preallocates a buffer from the declared frame size, so an
 /// untrusted peer could otherwise request a multi-gigabyte allocation with a
-/// single varint. [`FrameProducer::new`] enforces this for every frame: it's the
-/// sole allocation chokepoint (reached via [`FrameInfo::produce`] and
-/// [`crate::GroupProducer::create_frame`]) and rejects an oversized declared size
+/// single varint. [`Producer::new`] enforces this for every frame: it's the
+/// sole allocation chokepoint (reached via [`Info::produce`] and
+/// [`group::Producer::create_frame`]) and rejects an oversized declared size
 /// with [`Error::FrameTooLarge`] before allocating.
 ///
 /// Matches the per-group cache cap (`MAX_GROUP_CACHE`), so a single frame may fill
@@ -24,37 +25,37 @@ pub(crate) const MAX_FRAME_SIZE: u64 = 32 * 1024 * 1024;
 /// A chunk of data with an upfront size and a presentation timestamp.
 ///
 /// Note that this is just the header.
-/// You use [FrameProducer] and [FrameConsumer] to deal with the frame payload, potentially chunked.
+/// You use [Producer] and [Consumer] to deal with the frame payload, potentially chunked.
 #[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct FrameInfo {
+pub struct Info {
 	/// Total payload size in bytes. Declared up front so consumers can preallocate.
 	pub size: u64,
 	/// Presentation timestamp.
 	///
-	/// [`crate::GroupProducer::create_frame`] converts it into the parent track's
+	/// [`group::Producer::create_frame`] converts it into the parent track's
 	/// timescale, so the scale you build it with doesn't have to match the track.
-	/// Use [`crate::GroupProducer::create_frame_now`] /
-	/// [`crate::GroupProducer::write_frame_now`] to stamp wall-clock time instead of
+	/// Use [`group::Producer::create_frame_now`] /
+	/// [`group::Producer::write_frame_now`] to stamp wall-clock time instead of
 	/// supplying one explicitly.
 	pub timestamp: Timestamp,
 }
 
-impl FrameInfo {
+impl Info {
 	/// Create an unparented producer for the frame.
 	///
 	/// Test-only: real frames are constructed via
-	/// [`crate::GroupProducer::create_frame`], which threads the parent
-	/// [`GroupInfo`] down and validates the timestamp against the track's
+	/// [`group::Producer::create_frame`], which threads the parent
+	/// [`group::Info`] down and validates the timestamp against the track's
 	/// timescale. This helper defaults the parent group for in-crate tests. Returns
-	/// [`Error::FrameTooLarge`] if [`FrameInfo::size`] exceeds [`MAX_FRAME_SIZE`].
+	/// [`Error::FrameTooLarge`] if [`Info::size`] exceeds [`MAX_FRAME_SIZE`].
 	#[cfg(test)]
-	pub(crate) fn produce(self) -> Result<FrameProducer> {
-		FrameProducer::new(self, GroupInfo { sequence: 0 })
+	pub(crate) fn produce(self) -> Result<Producer> {
+		Producer::new(self, group::Info { sequence: 0 })
 	}
 }
 
-/// Single-allocation buffer shared between a [FrameProducer] and many [FrameConsumer]s.
+/// Single-allocation buffer shared between a [Producer] and many [Consumer]s.
 ///
 /// Internally an [Arc] over a thin pointer + length owning a heap allocation. The
 /// data pointer is stable for the life of any clone, so [Bytes] views taken via
@@ -110,7 +111,7 @@ impl FrameBuf {
 		self.0.written.load(ord)
 	}
 
-	/// Safety: caller must be the sole producer (FrameProducer-as-BufMut invariant).
+	/// Safety: caller must be the sole producer (Producer-as-BufMut invariant).
 	unsafe fn data_ptr(&self) -> *mut u8 {
 		self.0.data
 	}
@@ -144,36 +145,36 @@ struct FrameState {
 
 /// Writes a frame's payload in one or more chunks.
 ///
-/// The total bytes written must exactly match [FrameInfo::size].
+/// The total bytes written must exactly match [Info::size].
 /// Call [Self::finish] after writing all bytes to verify correctness.
 ///
 /// Implements [BufMut] so the receive path can write directly into the
 /// pre-allocated buffer (e.g. via `tokio::io::AsyncReadExt::read_buf`).
-pub struct FrameProducer {
-	info: FrameInfo,
-	// The parent group's info, inherited from [`crate::GroupProducer::create_frame`]
+pub struct Producer {
+	info: Info,
+	// The parent group's info, inherited from [`group::Producer::create_frame`]
 	// so the ownership chain reaches the leaf. A small `Copy` value; carried for
 	// identity/debugging (the timestamp-vs-timescale check lives on the group).
-	group: GroupInfo,
+	group: group::Info,
 	state: kio::Producer<FrameState>,
 	buf: FrameBuf,
 }
 
-impl std::ops::Deref for FrameProducer {
-	type Target = FrameInfo;
+impl std::ops::Deref for Producer {
+	type Target = Info;
 
 	fn deref(&self) -> &Self::Target {
 		&self.info
 	}
 }
 
-impl FrameProducer {
+impl Producer {
 	/// Create a new frame producer for the given frame header.
 	///
 	/// The single allocation chokepoint: rejects a frame whose declared
-	/// [`FrameInfo::size`] exceeds [`MAX_FRAME_SIZE`] with [`Error::FrameTooLarge`]
+	/// [`Info::size`] exceeds [`MAX_FRAME_SIZE`] with [`Error::FrameTooLarge`]
 	/// before allocating the (untrusted) buffer.
-	pub(crate) fn new(info: FrameInfo, group: GroupInfo) -> Result<Self> {
+	pub(crate) fn new(info: Info, group: group::Info) -> Result<Self> {
 		if info.size > MAX_FRAME_SIZE {
 			return Err(Error::FrameTooLarge);
 		}
@@ -187,7 +188,7 @@ impl FrameProducer {
 	}
 
 	/// The parent group this frame belongs to.
-	pub fn group(&self) -> &GroupInfo {
+	pub fn group(&self) -> &group::Info {
 		&self.group
 	}
 
@@ -207,7 +208,7 @@ impl FrameProducer {
 
 	/// Verify that all bytes have been written.
 	///
-	/// Returns [Error::WrongSize] if the bytes written don't match [FrameInfo::size].
+	/// Returns [Error::WrongSize] if the bytes written don't match [Info::size].
 	pub fn finish(&mut self) -> Result<()> {
 		let written = self.buf.written(Ordering::Acquire);
 		if written != self.buf.capacity() {
@@ -228,8 +229,8 @@ impl FrameProducer {
 	}
 
 	/// Create a new consumer for the frame.
-	pub fn consume(&self) -> FrameConsumer {
-		FrameConsumer {
+	pub fn consume(&self) -> Consumer {
+		Consumer {
 			info: self.info,
 			state: self.state.consume(),
 			buf: self.buf.clone(),
@@ -262,11 +263,11 @@ impl FrameProducer {
 
 // Safety: `chunk_mut` returns a slice into the producer-private region of the
 // buffer (`[written..capacity]`). Sole-writer invariant: even though
-// `FrameProducer` is `Clone`, the API exposes BufMut only via `&mut self`,
+// `Producer` is `Clone`, the API exposes BufMut only via `&mut self`,
 // and existing callers never share a single producer between concurrent writers
 // (group.rs clones a handle for `abort` / `consume` only). The defensive
 // `assert!` in `advance_mut` panics loudly if that invariant is ever violated.
-unsafe impl BufMut for FrameProducer {
+unsafe impl BufMut for Producer {
 	fn remaining_mut(&self) -> usize {
 		self.buf.capacity() - self.buf.written(Ordering::Acquire)
 	}
@@ -303,7 +304,7 @@ unsafe impl BufMut for FrameProducer {
 	}
 }
 
-impl Clone for FrameProducer {
+impl Clone for Producer {
 	fn clone(&self) -> Self {
 		Self {
 			info: self.info,
@@ -316,8 +317,8 @@ impl Clone for FrameProducer {
 
 /// Used to consume a frame's worth of data, streaming as bytes arrive.
 #[derive(Clone)]
-pub struct FrameConsumer {
-	info: FrameInfo,
+pub struct Consumer {
+	info: Info,
 	state: kio::Consumer<FrameState>,
 	buf: FrameBuf,
 	// Byte offset into the buffer; cloned consumers inherit this offset and
@@ -325,15 +326,15 @@ pub struct FrameConsumer {
 	read_idx: usize,
 }
 
-impl std::ops::Deref for FrameConsumer {
-	type Target = FrameInfo;
+impl std::ops::Deref for Consumer {
+	type Target = Info;
 
 	fn deref(&self) -> &Self::Target {
 		&self.info
 	}
 }
 
-impl FrameConsumer {
+impl Consumer {
 	// A helper to automatically apply Dropped if the state is closed without an error.
 	fn poll<F, R>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<R>>
 	where
@@ -454,7 +455,7 @@ mod test {
 
 	#[test]
 	fn single_chunk_roundtrip() {
-		let mut producer = FrameInfo {
+		let mut producer = Info {
 			size: 5,
 			timestamp: Timestamp::ZERO,
 		}
@@ -470,7 +471,7 @@ mod test {
 
 	#[test]
 	fn multi_chunk_read_all() {
-		let mut producer = FrameInfo {
+		let mut producer = Info {
 			size: 10,
 			timestamp: Timestamp::ZERO,
 		}
@@ -487,7 +488,7 @@ mod test {
 
 	#[test]
 	fn read_chunk_sequential() {
-		let mut producer = FrameInfo {
+		let mut producer = Info {
 			size: 10,
 			timestamp: Timestamp::ZERO,
 		}
@@ -511,7 +512,7 @@ mod test {
 
 	#[test]
 	fn read_all_chunks() {
-		let mut producer = FrameInfo {
+		let mut producer = Info {
 			size: 10,
 			timestamp: Timestamp::ZERO,
 		}
@@ -529,7 +530,7 @@ mod test {
 
 	#[test]
 	fn finish_checks_remaining() {
-		let mut producer = FrameInfo {
+		let mut producer = Info {
 			size: 5,
 			timestamp: Timestamp::ZERO,
 		}
@@ -542,7 +543,7 @@ mod test {
 
 	#[test]
 	fn write_too_many_bytes() {
-		let mut producer = FrameInfo {
+		let mut producer = Info {
 			size: 3,
 			timestamp: Timestamp::ZERO,
 		}
@@ -556,7 +557,7 @@ mod test {
 	fn rejects_oversized_frame() {
 		// The allocation chokepoint refuses an oversized declared size before any
 		// buffer is allocated, so a single varint can't request a huge allocation.
-		let result = FrameInfo {
+		let result = Info {
 			size: MAX_FRAME_SIZE + 1,
 			timestamp: Timestamp::ZERO,
 		}
@@ -566,7 +567,7 @@ mod test {
 
 	#[test]
 	fn abort_propagates() {
-		let mut producer = FrameInfo {
+		let mut producer = Info {
 			size: 5,
 			timestamp: Timestamp::ZERO,
 		}
@@ -581,7 +582,7 @@ mod test {
 
 	#[test]
 	fn empty_frame() {
-		let mut producer = FrameInfo {
+		let mut producer = Info {
 			size: 0,
 			timestamp: Timestamp::ZERO,
 		}
@@ -596,7 +597,7 @@ mod test {
 
 	#[tokio::test]
 	async fn pending_then_ready() {
-		let mut producer = FrameInfo {
+		let mut producer = Info {
 			size: 5,
 			timestamp: Timestamp::ZERO,
 		}
@@ -617,7 +618,7 @@ mod test {
 	#[test]
 	fn buf_mut_roundtrip() {
 		// Exercise the BufMut path that the receive loop uses via `read_buf`.
-		let mut producer = FrameInfo {
+		let mut producer = Info {
 			size: 12,
 			timestamp: Timestamp::ZERO,
 		}
@@ -638,7 +639,7 @@ mod test {
 	#[test]
 	#[should_panic(expected = "advance_mut past frame.size")]
 	fn buf_mut_advance_past_capacity_panics() {
-		let mut producer = FrameInfo {
+		let mut producer = Info {
 			size: 4,
 			timestamp: Timestamp::ZERO,
 		}
@@ -650,7 +651,7 @@ mod test {
 
 	#[test]
 	fn read_chunk_streams_partial_writes() {
-		let mut producer = FrameInfo {
+		let mut producer = Info {
 			size: 6,
 			timestamp: Timestamp::ZERO,
 		}
@@ -675,7 +676,7 @@ mod test {
 
 	#[test]
 	fn cloned_consumer_independent_cursor() {
-		let mut producer = FrameInfo {
+		let mut producer = Info {
 			size: 10,
 			timestamp: Timestamp::ZERO,
 		}

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -1,20 +1,19 @@
-//! A group is a stream of frames, split into a [GroupProducer] and [GroupConsumer] handle.
+//! A group is a stream of frames, split into a [Producer] and [Consumer] handle.
 //!
-//! A [GroupProducer] writes an ordered stream of frames.
+//! A [Producer] writes an ordered stream of frames.
 //! Frames can be written all at once, or in chunks.
 //!
-//! A [GroupConsumer] reads an ordered stream of frames.
+//! A [Consumer] reads an ordered stream of frames.
 //! The reader can be cloned, in which case each reader receives a copy of each frame. (fanout)
 //!
 //! The stream is closed with [Error] when all writers or readers are dropped.
+use crate::{frame, track};
 use std::collections::VecDeque;
 use std::task::{Poll, ready};
 
 use bytes::Bytes;
 
-use crate::{Error, Result, Timescale, Timestamp, TrackInfo};
-
-use super::{FrameConsumer, FrameInfo, FrameProducer};
+use crate::{Error, Result, Timescale, Timestamp};
 
 /// Maximum total size of frames cached in a group before old frames are evicted.
 ///
@@ -26,28 +25,28 @@ const MAX_GROUP_FRAMES: usize = 1024;
 
 /// A group contains a sequence number because they can arrive out of order.
 ///
-/// You can use [crate::TrackProducer::append_group] if you just want to +1 the sequence number.
+/// You can use [track::Producer::append_group] if you just want to +1 the sequence number.
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct GroupInfo {
+pub struct Info {
 	/// Per-track sequence number used to detect ordering and gaps. Higher numbers
 	/// supersede lower ones; consumers may skip late arrivals.
 	pub sequence: u64,
 }
 
-impl GroupInfo {
+impl Info {
 	/// Create an untimed producer for this group.
 	///
-	/// Test-only: real groups are created via [`crate::TrackProducer`], which
-	/// supplies the parent track's [`TrackInfo`]. This helper exists for in-crate
+	/// Test-only: real groups are created via [`track::Producer`], which
+	/// supplies the parent track's [`track::Info`]. This helper exists for in-crate
 	/// tests that don't exercise timestamps.
 	#[cfg(test)]
-	pub(crate) fn produce(self) -> GroupProducer {
-		GroupProducer::new(self, TrackInfo::default())
+	pub(crate) fn produce(self) -> Producer {
+		Producer::new(self, track::Info::default())
 	}
 }
 
-impl From<usize> for GroupInfo {
+impl From<usize> for Info {
 	fn from(sequence: usize) -> Self {
 		Self {
 			sequence: sequence as u64,
@@ -55,13 +54,13 @@ impl From<usize> for GroupInfo {
 	}
 }
 
-impl From<u64> for GroupInfo {
+impl From<u64> for Info {
 	fn from(sequence: u64) -> Self {
 		Self { sequence }
 	}
 }
 
-impl From<u32> for GroupInfo {
+impl From<u32> for Info {
 	fn from(sequence: u32) -> Self {
 		Self {
 			sequence: sequence as u64,
@@ -69,7 +68,7 @@ impl From<u32> for GroupInfo {
 	}
 }
 
-impl From<u16> for GroupInfo {
+impl From<u16> for Info {
 	fn from(sequence: u16) -> Self {
 		Self {
 			sequence: sequence as u64,
@@ -81,7 +80,7 @@ impl From<u16> for GroupInfo {
 struct GroupState {
 	// The frames currently cached in the group.
 	// Evicted frames are popped from the front; `offset` tracks how many.
-	frames: VecDeque<FrameProducer>,
+	frames: VecDeque<frame::Producer>,
 
 	// The number of frames evicted from the front of the group.
 	offset: usize,
@@ -97,7 +96,7 @@ struct GroupState {
 }
 
 impl GroupState {
-	fn poll_get_frame(&self, index: usize) -> Poll<Result<Option<FrameConsumer>>> {
+	fn poll_get_frame(&self, index: usize) -> Poll<Result<Option<frame::Consumer>>> {
 		if index < self.offset {
 			Poll::Ready(Err(Error::CacheFull))
 		} else if let Some(frame) = self.frames.get(index - self.offset) {
@@ -142,38 +141,38 @@ fn modify(state: &kio::Producer<GroupState>) -> Result<kio::Mut<'_, GroupState>>
 /// Each group is delivered independently over a QUIC stream.
 /// Use [Self::write_frame] for simple single-buffer frames,
 /// or [Self::create_frame] for multi-chunk streaming writes.
-pub struct GroupProducer {
+pub struct Producer {
 	// Mutable stream state.
 	state: kio::Producer<GroupState>,
 
 	// The group header containing the sequence number. A small `Copy` value,
 	// inherited by each frame (see [`Self::create_frame`]).
-	info: GroupInfo,
+	info: Info,
 
 	// The parent track's info, inherited rather than passed piecemeal. Its
 	// `timescale` is used by [`Self::create_frame`] to normalize every frame's
 	// timestamp into the track scale before it enters the stream, and enforced in
 	// [`Self::append_frame`]. Threaded down by value from
-	// [`crate::TrackProducer::create_group`] / `append_group`.
-	track: TrackInfo,
+	// [`track::Producer::create_group`] / `append_group`.
+	track: track::Info,
 }
 
-impl std::ops::Deref for GroupProducer {
-	type Target = GroupInfo;
+impl std::ops::Deref for Producer {
+	type Target = Info;
 
 	fn deref(&self) -> &Self::Target {
 		&self.info
 	}
 }
 
-impl GroupProducer {
-	/// Create a group producer bound to its parent track's [`TrackInfo`].
+impl Producer {
+	/// Create a group producer bound to its parent track's [`track::Info`].
 	///
-	/// Crate-private: groups are only constructed via [`crate::TrackProducer`],
-	/// which threads its [`TrackInfo`] down so properties like the timescale are
+	/// Crate-private: groups are only constructed via [`track::Producer`],
+	/// which threads its [`track::Info`] down so properties like the timescale are
 	/// inherited rather than passed in. Every frame added to this group is
 	/// normalized to the track's timescale by [`Self::create_frame`].
-	pub(crate) fn new(info: GroupInfo, track: TrackInfo) -> Self {
+	pub(crate) fn new(info: Info, track: track::Info) -> Self {
 		Self {
 			info,
 			state: kio::Producer::default(),
@@ -195,7 +194,7 @@ impl GroupProducer {
 	/// [Self::write_frame_now] to stamp wall-clock time instead of supplying one.
 	pub fn write_frame<B: Into<Bytes>>(&mut self, timestamp: Timestamp, data: B) -> Result<()> {
 		let data = data.into();
-		let mut frame = self.create_frame(FrameInfo {
+		let mut frame = self.create_frame(frame::Info {
 			size: data.len() as u64,
 			timestamp,
 		})?;
@@ -218,22 +217,22 @@ impl GroupProducer {
 	/// if the declared size exceeds the per-frame limit (refused before the buffer is
 	/// allocated) or [`Error::TimestampMismatch`] if the timestamp can't be converted
 	/// (overflow).
-	pub fn create_frame(&mut self, frame: FrameInfo) -> Result<FrameProducer> {
+	pub fn create_frame(&mut self, frame: frame::Info) -> Result<frame::Producer> {
 		let mut frame = frame;
 		frame.timestamp = frame
 			.timestamp
 			.convert(self.track.timescale)
 			.map_err(|_| Error::TimestampMismatch)?;
 
-		let frame = FrameProducer::new(frame, self.info)?;
+		let frame = frame::Producer::new(frame, self.info)?;
 		self.append_frame(frame.clone())?;
 		Ok(frame)
 	}
 
 	/// Like [Self::create_frame] but stamps the frame with wall-clock now
 	/// ([`Timestamp::now`]).
-	pub fn create_frame_now(&mut self, size: u64) -> Result<FrameProducer> {
-		self.create_frame(FrameInfo {
+	pub fn create_frame_now(&mut self, size: u64) -> Result<frame::Producer> {
+		self.create_frame(frame::Info {
 			size,
 			timestamp: Timestamp::now(),
 		})
@@ -244,7 +243,7 @@ impl GroupProducer {
 	/// Lower-level than [`Self::create_frame`]: the frame's `timestamp` must already be
 	/// at the parent track's timescale (use [`Self::create_frame`] to convert).
 	/// Returns [`Error::TimestampMismatch`] otherwise.
-	pub fn append_frame(&mut self, frame: FrameProducer) -> Result<()> {
+	pub fn append_frame(&mut self, frame: frame::Producer) -> Result<()> {
 		// Catch the contract violation here, at the model layer, so peers that
 		// downstream-encode (e.g. the lite publisher's `serve_frame`) can rely
 		// on the invariant instead of re-validating per byte.
@@ -278,10 +277,10 @@ impl GroupProducer {
 	/// Abort the group with the given error.
 	///
 	/// No updates can be made after this point. Drops the cached frames so a stale
-	/// [`GroupConsumer`] can't pin their buffers in memory forever; consumers that
+	/// [`Consumer`] can't pin their buffers in memory forever; consumers that
 	/// haven't drained yet surface the abort error instead of the leftover cache.
 	/// Child frames are independent: a consumer that already pulled a
-	/// [`FrameConsumer`] keeps its own handle and can finish reading it.
+	/// [`frame::Consumer`] keeps its own handle and can finish reading it.
 	pub fn abort(&mut self, err: Error) -> Result<()> {
 		let mut guard = modify(&self.state)?;
 		guard.abort = Some(err);
@@ -292,8 +291,8 @@ impl GroupProducer {
 	}
 
 	/// Create a new consumer for the group.
-	pub fn consume(&self) -> GroupConsumer {
-		GroupConsumer {
+	pub fn consume(&self) -> Consumer {
+		Consumer {
 			info: self.info,
 			state: self.state.consume(),
 			track: self.track,
@@ -316,7 +315,7 @@ impl GroupProducer {
 	}
 }
 
-impl Clone for GroupProducer {
+impl Clone for Producer {
 	fn clone(&self) -> Self {
 		Self {
 			info: self.info,
@@ -326,9 +325,9 @@ impl Clone for GroupProducer {
 	}
 }
 
-impl Drop for GroupProducer {
+impl Drop for Producer {
 	fn drop(&mut self) {
-		// See TrackProducer::drop: the last producer dropping without a clean
+		// See track::Producer::drop: the last producer dropping without a clean
 		// finish releases the cached frames so a stale consumer can't pin their
 		// buffers forever. A finished group keeps its cache so consumers can drain.
 		if !self.state.is_last() {
@@ -345,31 +344,31 @@ impl Drop for GroupProducer {
 
 /// Consume a group, frame-by-frame.
 #[derive(Clone)]
-pub struct GroupConsumer {
+pub struct Consumer {
 	// Shared state with the producer.
 	state: kio::Consumer<GroupState>,
 
 	// Immutable stream state.
-	info: GroupInfo,
+	info: Info,
 
 	// The parent track's info, inherited from the producer. Its `timescale` lets the
 	// wire publisher emit per-frame timestamps at the right scale for a fetched group.
-	track: TrackInfo,
+	track: track::Info,
 
 	// The number of frames we've read.
 	// NOTE: Cloned readers inherit this offset, but then run in parallel.
 	index: usize,
 }
 
-impl std::ops::Deref for GroupConsumer {
-	type Target = GroupInfo;
+impl std::ops::Deref for Consumer {
+	type Target = Info;
 
 	fn deref(&self) -> &Self::Target {
 		&self.info
 	}
 }
 
-impl GroupConsumer {
+impl Consumer {
 	/// The parent track's timescale.
 	pub fn timescale(&self) -> Timescale {
 		self.track.timescale
@@ -390,26 +389,26 @@ impl GroupConsumer {
 	/// Block until the frame at the given index is available.
 	///
 	/// Returns None if the group is finished and the index is out of range.
-	pub async fn get_frame(&self, index: usize) -> Result<Option<FrameConsumer>> {
+	pub async fn get_frame(&self, index: usize) -> Result<Option<frame::Consumer>> {
 		kio::wait(|waiter| self.poll_get_frame(waiter, index)).await
 	}
 
 	/// Poll for the frame at the given index, without blocking.
 	///
 	/// Returns None if the group is finished and the index is out of range.
-	pub fn poll_get_frame(&self, waiter: &kio::Waiter, index: usize) -> Poll<Result<Option<FrameConsumer>>> {
+	pub fn poll_get_frame(&self, waiter: &kio::Waiter, index: usize) -> Poll<Result<Option<frame::Consumer>>> {
 		self.poll(waiter, |state| state.poll_get_frame(index))
 	}
 
 	/// Return a consumer for the next frame for chunked reading.
-	pub async fn next_frame(&mut self) -> Result<Option<FrameConsumer>> {
+	pub async fn next_frame(&mut self) -> Result<Option<frame::Consumer>> {
 		kio::wait(|waiter| self.poll_next_frame(waiter)).await
 	}
 
 	/// Poll for the next frame, without blocking.
 	///
 	/// Returns None if the group is finished and the index is out of range.
-	pub fn poll_next_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<FrameConsumer>>> {
+	pub fn poll_next_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<frame::Consumer>>> {
 		let Some(frame) = ready!(self.poll(waiter, |state| state.poll_get_frame(self.index))?) else {
 			return Poll::Ready(Ok(None));
 		};
@@ -463,7 +462,7 @@ impl GroupConsumer {
 	}
 }
 
-/// Options for a one-shot [`crate::TrackConsumer::fetch_group`] of a past group.
+/// Options for a one-shot [`track::Consumer::fetch_group`] of a past group.
 #[derive(Clone, Debug, Default)]
 pub struct Fetch {
 	/// Delivery priority for the fetched group's stream. Defaults to 0.
@@ -485,7 +484,7 @@ mod test {
 
 	#[test]
 	fn basic_frame_reading() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
+		let mut producer = Info { sequence: 0 }.produce();
 		producer.write_frame_now(Bytes::from_static(b"frame0")).unwrap();
 		producer.write_frame_now(Bytes::from_static(b"frame1")).unwrap();
 		producer.finish().unwrap();
@@ -501,7 +500,7 @@ mod test {
 
 	#[test]
 	fn read_frame_all_at_once() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
+		let mut producer = Info { sequence: 0 }.produce();
 		producer.write_frame_now(Bytes::from_static(b"hello")).unwrap();
 		producer.finish().unwrap();
 
@@ -512,7 +511,7 @@ mod test {
 
 	#[test]
 	fn read_frame_chunks() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
+		let mut producer = Info { sequence: 0 }.produce();
 		let mut frame = producer.create_frame_now(10).unwrap();
 		frame.write(Bytes::from_static(b"hello")).unwrap();
 		frame.write(Bytes::from_static(b"world")).unwrap();
@@ -529,7 +528,7 @@ mod test {
 
 	#[test]
 	fn get_frame_by_index() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
+		let mut producer = Info { sequence: 0 }.produce();
 		producer.write_frame_now(Bytes::from_static(b"a")).unwrap();
 		producer.write_frame_now(Bytes::from_static(b"bb")).unwrap();
 		producer.finish().unwrap();
@@ -545,7 +544,7 @@ mod test {
 
 	#[test]
 	fn group_finish_returns_none() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
+		let mut producer = Info { sequence: 0 }.produce();
 		producer.finish().unwrap();
 
 		let mut consumer = producer.consume();
@@ -555,7 +554,7 @@ mod test {
 
 	#[test]
 	fn abort_propagates() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
+		let mut producer = Info { sequence: 0 }.produce();
 		let mut consumer = producer.consume();
 		producer.abort(crate::Error::Cancel).unwrap();
 
@@ -565,7 +564,7 @@ mod test {
 
 	#[test]
 	fn abort_clears_cached_frames() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
+		let mut producer = Info { sequence: 0 }.produce();
 		producer.write_frame_now(Bytes::from_static(b"data")).unwrap();
 
 		// A stale consumer that never reads must not pin the cached frames.
@@ -581,7 +580,7 @@ mod test {
 
 	#[test]
 	fn drop_unfinished_clears_cached_frames() {
-		let producer = GroupInfo { sequence: 0 }.produce();
+		let producer = Info { sequence: 0 }.produce();
 		let mut writer = producer.clone();
 		writer.write_frame_now(Bytes::from_static(b"data")).unwrap();
 
@@ -599,7 +598,7 @@ mod test {
 
 	#[test]
 	fn drop_finished_keeps_cached_frames() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
+		let mut producer = Info { sequence: 0 }.produce();
 		producer.write_frame_now(Bytes::from_static(b"data")).unwrap();
 		producer.finish().unwrap();
 
@@ -613,7 +612,7 @@ mod test {
 
 	#[tokio::test]
 	async fn pending_then_ready() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
+		let mut producer = Info { sequence: 0 }.produce();
 		let mut consumer = producer.consume();
 
 		// Consumer blocks because no frames yet.
@@ -628,7 +627,7 @@ mod test {
 
 	#[test]
 	fn eviction_drops_old_frames() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
+		let mut producer = Info { sequence: 0 }.produce();
 
 		// Write frames that total more than MAX_GROUP_CACHE.
 		let big = Bytes::from(vec![0u8; MAX_GROUP_CACHE as usize]);
@@ -647,7 +646,7 @@ mod test {
 
 	#[test]
 	fn no_eviction_under_limit() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
+		let mut producer = Info { sequence: 0 }.produce();
 		producer.write_frame_now(Bytes::from_static(b"small")).unwrap();
 		producer.write_frame_now(Bytes::from_static(b"frames")).unwrap();
 		producer.finish().unwrap();
@@ -661,7 +660,7 @@ mod test {
 
 	#[test]
 	fn eviction_by_frame_count() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
+		let mut producer = Info { sequence: 0 }.produce();
 
 		// Write more than MAX_GROUP_FRAMES frames.
 		for _ in 0..=MAX_GROUP_FRAMES {
@@ -685,7 +684,7 @@ mod test {
 
 	#[test]
 	fn next_frame_returns_cache_full_on_tombstone() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
+		let mut producer = Info { sequence: 0 }.produce();
 
 		let big = Bytes::from(vec![0u8; MAX_GROUP_CACHE as usize]);
 		producer.write_frame_now(big.clone()).unwrap();
@@ -699,7 +698,7 @@ mod test {
 
 	#[test]
 	fn clone_consumer_independent() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
+		let mut producer = Info { sequence: 0 }.produce();
 		producer.write_frame_now(Bytes::from_static(b"a")).unwrap();
 
 		let mut c1 = producer.consume();
@@ -726,11 +725,11 @@ mod test {
 	fn create_frame_converts_mismatched_scale() {
 		use crate::{Timescale, Timestamp};
 
-		let mut producer = GroupProducer::new(
-			GroupInfo { sequence: 0 },
-			TrackInfo::default().with_timescale(Timescale::MICRO),
+		let mut producer = Producer::new(
+			Info { sequence: 0 },
+			track::Info::default().with_timescale(Timescale::MICRO),
 		);
-		let frame = FrameInfo {
+		let frame = frame::Info {
 			size: 3,
 			timestamp: Timestamp::from_millis(1).unwrap(), // 1ms -> 1000µs
 		};
@@ -744,9 +743,9 @@ mod test {
 	async fn create_frame_now_stamps_wall_clock() {
 		use crate::Timescale;
 
-		let mut producer = GroupProducer::new(
-			GroupInfo { sequence: 0 },
-			TrackInfo::default().with_timescale(Timescale::MICRO),
+		let mut producer = Producer::new(
+			Info { sequence: 0 },
+			track::Info::default().with_timescale(Timescale::MICRO),
 		);
 		let writer = producer.create_frame_now(3).unwrap();
 		assert_eq!(writer.timestamp.scale(), Timescale::MICRO);
@@ -758,11 +757,11 @@ mod test {
 	fn create_frame_accepts_matching_scale() {
 		use crate::{Timescale, Timestamp};
 
-		let mut producer = GroupProducer::new(
-			GroupInfo { sequence: 0 },
-			TrackInfo::default().with_timescale(Timescale::MICRO),
+		let mut producer = Producer::new(
+			Info { sequence: 0 },
+			track::Info::default().with_timescale(Timescale::MICRO),
 		);
-		let frame = FrameInfo {
+		let frame = frame::Info {
 			size: 1,
 			timestamp: Timestamp::from_micros(7).unwrap(),
 		};
@@ -778,11 +777,11 @@ mod test {
 	fn append_frame_rejects_mismatched_scale() {
 		use crate::{Timescale, Timestamp};
 
-		let mut producer = GroupProducer::new(
-			GroupInfo { sequence: 0 },
-			TrackInfo::default().with_timescale(Timescale::MICRO),
+		let mut producer = Producer::new(
+			Info { sequence: 0 },
+			track::Info::default().with_timescale(Timescale::MICRO),
 		);
-		let frame = FrameInfo {
+		let frame = frame::Info {
 			size: 1,
 			timestamp: Timestamp::from_millis(1).unwrap(), // millis, not micros
 		}
@@ -795,8 +794,8 @@ mod test {
 	/// it as FrameTooLarge before allocating the buffer.
 	#[test]
 	fn create_frame_rejects_oversized() {
-		let mut producer = GroupInfo { sequence: 0 }.produce();
-		let result = producer.create_frame_now(crate::MAX_FRAME_SIZE + 1);
+		let mut producer = Info { sequence: 0 }.produce();
+		let result = producer.create_frame_now(frame::MAX_FRAME_SIZE + 1);
 		assert!(matches!(result, Err(Error::FrameTooLarge)));
 	}
 }

--- a/rs/moq-net/src/model/mod.rs
+++ b/rs/moq-net/src/model/mod.rs
@@ -1,17 +1,34 @@
+pub mod broadcast;
+pub mod frame;
+pub mod group;
+pub mod track;
+
+// The origin + announce subsystem shares one implementation (a broadcast tree).
+// It stays in a single private module and is surfaced as two curated public
+// modules so neither leaks the other's plumbing.
+#[path = "origin.rs"]
+mod origin_impl;
+
 mod bandwidth;
-mod broadcast;
-mod frame;
-mod group;
-mod origin;
 mod subscription;
 mod time;
-mod track;
 
 pub use bandwidth::*;
-pub use broadcast::*;
-pub use frame::*;
-pub use group::*;
-pub use origin::*;
 pub use subscription::*;
 pub use time::*;
-pub use track::*;
+
+/// Publishing and consuming the set of broadcasts announced at an origin.
+pub mod origin {
+	pub use super::origin_impl::{Broadcast, Consumer, Dynamic, Producer, Publish, Request, Requested};
+}
+
+/// Subscribing to broadcast (un)announcements from an origin.
+pub mod announce {
+	pub use super::origin_impl::{
+		AnnounceConsumer as Consumer, AnnounceProducer as Producer, Announced as Event, OriginAnnounce as Update,
+	};
+}
+
+// Origin identity and the `Consume` conversion trait aren't part of a role
+// module; keep them flat at the crate root.
+pub use origin_impl::{Consume, InvalidOrigin, Origin, OriginList, TooManyOrigins};

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1,3 +1,4 @@
+use crate::{broadcast, track};
 use std::{
 	collections::{BTreeMap, HashMap, VecDeque},
 	fmt,
@@ -8,9 +9,8 @@ use std::{
 use rand::RngExt;
 use web_async::Lock;
 
-use super::BroadcastConsumer;
 use crate::{
-	AsPath, BroadcastInfo, BroadcastProducer, Error, Path, PathOwned, PathPrefixes,
+	AsPath, Error, Path, PathOwned, PathPrefixes,
 	coding::{Decode, DecodeError, Encode, EncodeError},
 };
 
@@ -102,8 +102,8 @@ impl Origin {
 	}
 
 	/// Consume this [Origin] to create a producer that carries its id.
-	pub fn produce(self) -> OriginProducer {
-		OriginProducer::new(self)
+	pub fn produce(self) -> Producer {
+		Producer::new(self)
 	}
 }
 
@@ -296,8 +296,8 @@ impl ConsumerId {
 // If there are multiple broadcasts with the same path, we keep the oldest active and queue the others.
 struct OriginBroadcast {
 	path: PathOwned,
-	active: BroadcastConsumer,
-	backup: VecDeque<BroadcastConsumer>,
+	active: broadcast::Consumer,
+	backup: VecDeque<broadcast::Consumer>,
 }
 
 /// Ordering key used to pick the active route among broadcasts at the same path.
@@ -308,7 +308,7 @@ struct OriginBroadcast {
 /// on the same winner: the hops are forwarded unchanged, and the hash is
 /// build-stable. Mixing the name in spreads equal routes across different
 /// upstreams rather than funneling onto one.
-fn route_key(name: &Path, info: &BroadcastInfo) -> (usize, u64) {
+fn route_key(name: &Path, info: &broadcast::Info) -> (usize, u64) {
 	// FNV-1a, not the std hasher: its output is fixed across Rust versions and
 	// builds, which matters when nodes run mismatched binaries during a rolling
 	// deploy and still need to agree on the same route. SEED is a custom basis
@@ -341,10 +341,10 @@ fn route_key(name: &Path, info: &BroadcastInfo) -> (usize, u64) {
 /// at the path never became unavailable, so it collapses to a single
 /// [`Announced::Restart`] delivery.
 enum PendingUpdate {
-	Announce(BroadcastConsumer),
+	Announce(broadcast::Consumer),
 	Unannounce,
-	UnannounceAnnounce(BroadcastConsumer),
-	Restart(BroadcastConsumer),
+	UnannounceAnnounce(broadcast::Consumer),
+	Restart(broadcast::Consumer),
 }
 
 /// Pending updates keyed by path. `BTreeMap` keeps memory strictly bounded by
@@ -357,7 +357,7 @@ struct OriginConsumerState {
 }
 
 impl OriginConsumerState {
-	fn apply_announce(&mut self, path: PathOwned, broadcast: BroadcastConsumer) {
+	fn apply_announce(&mut self, path: PathOwned, broadcast: broadcast::Consumer) {
 		let new = match self.pending.remove(&path) {
 			// First announce, or a stale announce being replaced.
 			None | Some(PendingUpdate::Announce(_)) => PendingUpdate::Announce(broadcast),
@@ -371,7 +371,7 @@ impl OriginConsumerState {
 		self.pending.insert(path, new);
 	}
 
-	fn apply_restart(&mut self, path: PathOwned, broadcast: BroadcastConsumer) {
+	fn apply_restart(&mut self, path: PathOwned, broadcast: broadcast::Consumer) {
 		let new = match self.pending.remove(&path) {
 			// Consumer has already drained the prior active; replace it atomically.
 			None => PendingUpdate::Restart(broadcast),
@@ -424,7 +424,7 @@ struct AnnounceConsumerNotify {
 }
 
 impl AnnounceConsumerNotify {
-	fn announce(&self, path: impl AsPath, broadcast: BroadcastConsumer) {
+	fn announce(&self, path: impl AsPath, broadcast: broadcast::Consumer) {
 		let path = path.as_path().strip_prefix(&self.root).unwrap().to_owned();
 		self.state
 			.write()
@@ -433,7 +433,7 @@ impl AnnounceConsumerNotify {
 			.apply_announce(path, broadcast);
 	}
 
-	fn restart(&self, path: impl AsPath, broadcast: BroadcastConsumer) {
+	fn restart(&self, path: impl AsPath, broadcast: broadcast::Consumer) {
 		let path = path.as_path().strip_prefix(&self.root).unwrap().to_owned();
 		self.state
 			.write()
@@ -464,7 +464,7 @@ impl NotifyNode {
 		}
 	}
 
-	fn announce(&mut self, path: impl AsPath, broadcast: &BroadcastConsumer) {
+	fn announce(&mut self, path: impl AsPath, broadcast: &broadcast::Consumer) {
 		for consumer in self.consumers.values() {
 			consumer.announce(path.as_path(), broadcast.clone());
 		}
@@ -474,7 +474,7 @@ impl NotifyNode {
 		}
 	}
 
-	fn restart(&mut self, path: impl AsPath, broadcast: &BroadcastConsumer) {
+	fn restart(&mut self, path: impl AsPath, broadcast: &broadcast::Consumer) {
 		for consumer in self.consumers.values() {
 			consumer.restart(path.as_path(), broadcast.clone());
 		}
@@ -533,7 +533,7 @@ impl OriginNode {
 		}
 	}
 
-	fn publish(&mut self, full: impl AsPath, broadcast: &BroadcastConsumer, relative: impl AsPath) {
+	fn publish(&mut self, full: impl AsPath, broadcast: &broadcast::Consumer, relative: impl AsPath) {
 		let full = full.as_path();
 		let rest = relative.as_path();
 
@@ -591,7 +591,7 @@ impl OriginNode {
 		}
 	}
 
-	fn consume_broadcast(&self, rest: impl AsPath) -> Option<BroadcastConsumer> {
+	fn consume_broadcast(&self, rest: impl AsPath) -> Option<broadcast::Consumer> {
 		let rest = rest.as_path();
 
 		if let Some((dir, rest)) = rest.next_part() {
@@ -611,7 +611,7 @@ impl OriginNode {
 	}
 
 	// Returns true if the broadcast should be unannounced.
-	fn remove(&mut self, full: impl AsPath, broadcast: BroadcastConsumer, relative: impl AsPath) {
+	fn remove(&mut self, full: impl AsPath, broadcast: broadcast::Consumer, relative: impl AsPath) {
 		let full = full.as_path();
 		let relative = relative.as_path();
 
@@ -756,14 +756,14 @@ pub type OriginAnnounce = (PathOwned, Announced);
 #[derive(Clone)]
 pub enum Announced {
 	/// A broadcast became available.
-	Active(BroadcastConsumer),
+	Active(broadcast::Consumer),
 	/// The broadcast was replaced without an interruption in availability (e.g. a
 	/// relay failover or a shorter hop path arriving).
 	///
 	/// Carries the replacement broadcast. On the wire this is a duplicate ANNOUNCE
 	/// (an active announcement for a path that is already announced, with no
 	/// intervening unannounce); there is no distinct status byte.
-	Restart(BroadcastConsumer),
+	Restart(broadcast::Consumer),
 	/// The broadcast is no longer available.
 	Ended,
 }
@@ -773,9 +773,9 @@ impl Announced {
 	///
 	/// Both [`Active`](Self::Active) and [`Restart`](Self::Restart) carry a
 	/// broadcast; [`Ended`](Self::Ended) does not. This is the legacy
-	/// `Option<BroadcastConsumer>` view for callers that don't distinguish a fresh
+	/// `Option<broadcast::Consumer>` view for callers that don't distinguish a fresh
 	/// announce from a restart.
-	pub fn broadcast(self) -> Option<BroadcastConsumer> {
+	pub fn broadcast(self) -> Option<broadcast::Consumer> {
 		match self {
 			Self::Active(broadcast) | Self::Restart(broadcast) => Some(broadcast),
 			Self::Ended => None,
@@ -785,7 +785,7 @@ impl Announced {
 
 /// Announces broadcasts to consumers over the network.
 #[derive(Clone)]
-pub struct OriginProducer {
+pub struct Producer {
 	// Identity for this origin. Appended to broadcast hops when
 	// re-announcing so downstream relays can detect loops and prefer the
 	// shortest path.
@@ -804,7 +804,7 @@ pub struct OriginProducer {
 	dynamic: kio::Producer<OriginDynamicState>,
 }
 
-impl std::ops::Deref for OriginProducer {
+impl std::ops::Deref for Producer {
 	type Target = Origin;
 
 	fn deref(&self) -> &Self::Target {
@@ -812,7 +812,7 @@ impl std::ops::Deref for OriginProducer {
 	}
 }
 
-impl OriginProducer {
+impl Producer {
 	/// Build a producer for the given origin id with no scoped prefix and no
 	/// pre-existing broadcasts. Prefer [`Origin::produce`].
 	pub fn new(info: Origin) -> Self {
@@ -840,21 +840,21 @@ impl OriginProducer {
 	/// Create and publish a new broadcast.
 	///
 	/// This is a helper method when you only want to publish a broadcast to a single origin.
-	/// The returned [`BroadcastPublish`] derefs to a [`BroadcastProducer`]; dropping it
+	/// The returned [`Broadcast`] derefs to a [`broadcast::Producer`]; dropping it
 	/// unannounces the broadcast. See [`publish_broadcast`](Self::publish_broadcast) for the
 	/// error cases.
-	pub fn create_broadcast(&self, path: impl AsPath) -> Result<BroadcastPublish, Error> {
-		let producer = BroadcastInfo::new().produce();
+	pub fn create_broadcast(&self, path: impl AsPath) -> Result<Broadcast, Error> {
+		let producer = broadcast::Info::new().produce();
 		let publish = self.publish_broadcast(path, &producer)?;
-		Ok(BroadcastPublish { producer, publish })
+		Ok(Broadcast { producer, publish })
 	}
 
 	/// Publish a broadcast, announcing it to all consumers.
 	///
-	/// Returns an [`OriginPublish`] guard that keeps the broadcast announced. Drop it (or call
-	/// [`OriginPublish::unannounce`]) to remove the broadcast. The announcement is independent
+	/// Returns an [`Publish`] guard that keeps the broadcast announced. Drop it (or call
+	/// [`Publish::unannounce`]) to remove the broadcast. The announcement is independent
 	/// of the broadcast's own lifetime, so dropping the guard unannounces even while the
-	/// [`BroadcastProducer`] keeps serving tracks.
+	/// [`broadcast::Producer`] keeps serving tracks.
 	///
 	/// Fails with [`Error::Unauthorized`] if `path` is outside the prefixes this producer may
 	/// publish under (after [`scope`](Self::scope) / [`with_root`](Self::with_root)). A full-scope
@@ -872,8 +872,8 @@ impl OriginProducer {
 	pub fn publish_broadcast(
 		&self,
 		path: impl AsPath,
-		broadcast: impl Consume<BroadcastConsumer>,
-	) -> Result<OriginPublish, Error> {
+		broadcast: impl Consume<broadcast::Consumer>,
+	) -> Result<Publish, Error> {
 		let broadcast = broadcast.consume();
 		let path = path.as_path();
 
@@ -889,7 +889,7 @@ impl OriginProducer {
 
 		node.lock().publish(&full, &broadcast, &rest);
 
-		Ok(OriginPublish {
+		Ok(Publish {
 			node,
 			full,
 			rest,
@@ -897,14 +897,14 @@ impl OriginProducer {
 		})
 	}
 
-	/// Returns a new OriginProducer restricted to publishing under one of `prefixes`.
+	/// Returns a new Producer restricted to publishing under one of `prefixes`.
 	///
 	/// Returns None if there are no legal prefixes (the requested prefixes are
 	/// disjoint from this producer's current scope).
 	// TODO accept PathPrefixes instead of &[Path]
-	pub fn scope(&self, prefixes: &[Path]) -> Option<OriginProducer> {
+	pub fn scope(&self, prefixes: &[Path]) -> Option<Producer> {
 		let prefixes = PathPrefixes::new(prefixes);
-		Some(OriginProducer {
+		Some(Producer {
 			info: self.info,
 			nodes: self.nodes.select(&prefixes)?,
 			root: self.root.clone(),
@@ -912,24 +912,24 @@ impl OriginProducer {
 		})
 	}
 
-	/// Create a dynamic handler that picks up [`OriginConsumer::request_broadcast`]
+	/// Create a dynamic handler that picks up [`Consumer::request_broadcast`]
 	/// calls for paths that are not announced.
 	///
-	/// This is the origin-level analogue of [`BroadcastProducer::dynamic`]: it serves
+	/// This is the origin-level analogue of [`broadcast::Producer::dynamic`]: it serves
 	/// broadcasts on demand rather than tracks. Crucially the served broadcasts are
-	/// *not* announced, so [`OriginConsumer::announced`] never sees them; they exist
+	/// *not* announced, so [`Consumer::announced`] never sees them; they exist
 	/// only as a fallback for a consumer that asks for an exact path with no live
 	/// announcement. Drop the handler (and every clone) to reject pending requests.
-	pub fn dynamic(&self) -> OriginDynamic {
-		OriginDynamic::new(self.info, self.root.clone(), self.dynamic.clone())
+	pub fn dynamic(&self) -> Dynamic {
+		Dynamic::new(self.info, self.root.clone(), self.dynamic.clone())
 	}
 
 	/// Cheap read handle over this origin's broadcast tree.
 	///
-	/// Use [`OriginConsumer::announced`] to register interest and start receiving
+	/// Use [`Consumer::announced`] to register interest and start receiving
 	/// announcement events; the consumer itself does not allocate any channels.
-	pub fn consume(&self) -> OriginConsumer {
-		OriginConsumer::new(self.info, self.root.clone(), self.nodes.clone(), self.dynamic.consume())
+	pub fn consume(&self) -> Consumer {
+		Consumer::new(self.info, self.root.clone(), self.nodes.clone(), self.dynamic.consume())
 	}
 
 	/// Handle to the announcement stream for this producer's subtree.
@@ -941,7 +941,7 @@ impl OriginProducer {
 		AnnounceProducer::new(self.root.clone(), self.nodes.clone())
 	}
 
-	/// Returns a new OriginProducer that automatically strips out the provided prefix.
+	/// Returns a new Producer that automatically strips out the provided prefix.
 	///
 	/// Returns None if the provided root is not authorized; when [`Self::scope`]
 	/// was already used without a wildcard.
@@ -975,26 +975,26 @@ impl OriginProducer {
 
 /// Keeps a broadcast announced in the origin tree.
 ///
-/// Returned by [`OriginProducer::publish_broadcast`]. While held, the broadcast stays
+/// Returned by [`Producer::publish_broadcast`]. While held, the broadcast stays
 /// announced to all consumers. Dropping it (or calling [`Self::unannounce`]) removes the
 /// broadcast from the tree: the origin promotes the best remaining backup route (emitting a
 /// restart) or, if none remain, unannounces the path. The guard is independent of the
 /// broadcast's own lifetime, so it can outlive or be dropped before the broadcast itself.
 #[must_use = "the broadcast is unannounced as soon as this guard is dropped"]
-pub struct OriginPublish {
+pub struct Publish {
 	node: Lock<OriginNode>,
 	full: PathOwned,
 	rest: PathOwned,
 	// `Option` so `Drop` can take ownership to hand the consumer to `remove`.
-	broadcast: Option<BroadcastConsumer>,
+	broadcast: Option<broadcast::Consumer>,
 }
 
-impl OriginPublish {
+impl Publish {
 	/// Unannounce the broadcast. Equivalent to dropping the guard, but spells out the intent.
 	pub fn unannounce(self) {}
 }
 
-impl Drop for OriginPublish {
+impl Drop for Publish {
 	fn drop(&mut self) {
 		if let Some(broadcast) = self.broadcast.take() {
 			self.node.lock().remove(&self.full, broadcast, &self.rest);
@@ -1002,33 +1002,33 @@ impl Drop for OriginPublish {
 	}
 }
 
-/// A [`BroadcastProducer`] paired with its [`OriginPublish`] announcement guard.
+/// A [`broadcast::Producer`] paired with its [`Publish`] announcement guard.
 ///
-/// Returned by [`OriginProducer::create_broadcast`]. Derefs to the underlying
-/// [`BroadcastProducer`] so you can add tracks directly; dropping it unannounces the broadcast.
-pub struct BroadcastPublish {
-	producer: BroadcastProducer,
+/// Returned by [`Producer::create_broadcast`]. Derefs to the underlying
+/// [`broadcast::Producer`] so you can add tracks directly; dropping it unannounces the broadcast.
+pub struct Broadcast {
+	producer: broadcast::Producer,
 	// Held only for its Drop, which unannounces the broadcast.
 	#[allow(dead_code)]
-	publish: OriginPublish,
+	publish: Publish,
 }
 
-impl BroadcastPublish {
+impl Broadcast {
 	/// Stop announcing the broadcast but keep producing into it, returning the bare producer.
-	pub fn unannounce(self) -> BroadcastProducer {
+	pub fn unannounce(self) -> broadcast::Producer {
 		self.producer
 	}
 }
 
-impl std::ops::Deref for BroadcastPublish {
-	type Target = BroadcastProducer;
+impl std::ops::Deref for Broadcast {
+	type Target = broadcast::Producer;
 
 	fn deref(&self) -> &Self::Target {
 		&self.producer
 	}
 }
 
-impl std::ops::DerefMut for BroadcastPublish {
+impl std::ops::DerefMut for Broadcast {
 	fn deref_mut(&mut self) -> &mut Self::Target {
 		&mut self.producer
 	}
@@ -1044,13 +1044,13 @@ struct OriginDynamicState {
 	// Result channels for queued requests, keyed by absolute path. Concurrent
 	// `request_broadcast` calls for the same path coalesce onto the same channel while
 	// it is queued. The producer is moved out (and the entry removed) when the handler
-	// picks the request up via [`OriginDynamic::requested_broadcast`].
+	// picks the request up via [`Dynamic::requested_broadcast`].
 	requests: HashMap<PathOwned, kio::Producer<PendingBroadcast>>,
 
 	// Requested paths in FIFO order for the handler to drain.
 	request_order: VecDeque<PathOwned>,
 
-	// The number of live `OriginDynamic` handlers. While zero, `request_broadcast`
+	// The number of live `Dynamic` handlers. While zero, `request_broadcast`
 	// fails fast with `Unroutable` rather than queueing a request nobody will serve.
 	dynamic: usize,
 }
@@ -1066,32 +1066,32 @@ impl OriginDynamicState {
 
 /// One-shot result of a dynamic broadcast request.
 ///
-/// Stays `None` until a handler [`accept`](BroadcastRequest::accept)s (yielding the served
-/// broadcast) or [`reject`](BroadcastRequest::reject)s (yielding an error). The producer is
+/// Stays `None` until a handler [`accept`](Request::accept)s (yielding the served
+/// broadcast) or [`reject`](Request::reject)s (yielding an error). The producer is
 /// dropped right after writing, closing the channel; kio checks the value before the closed
 /// flag, so an awaiting requester still observes the final result.
 #[derive(Default)]
 struct PendingBroadcast {
-	resolved: Option<Result<BroadcastConsumer, Error>>,
+	resolved: Option<Result<broadcast::Consumer, Error>>,
 }
 
-/// Picks up [`OriginConsumer::request_broadcast`] calls for paths that are not announced.
+/// Picks up [`Consumer::request_broadcast`] calls for paths that are not announced.
 ///
-/// The origin-level analogue of [`crate::BroadcastDynamic`]: where that serves tracks on
+/// The origin-level analogue of [`broadcast::Dynamic`]: where that serves tracks on
 /// demand within a broadcast, this serves whole broadcasts on demand within an origin. A
 /// relay uses it as a fallback router, fetching a broadcast from upstream only when a
 /// downstream consumer asks for an exact path that nobody announced.
 ///
 /// Served broadcasts are deliberately *not* announced, so they never appear in
-/// [`OriginConsumer::announced`]. Drop this handle (and every clone) to reject the
+/// [`Consumer::announced`]. Drop this handle (and every clone) to reject the
 /// requests still waiting to be served.
-pub struct OriginDynamic {
+pub struct Dynamic {
 	info: Origin,
 	root: PathOwned,
 	state: kio::Producer<OriginDynamicState>,
 }
 
-impl Clone for OriginDynamic {
+impl Clone for Dynamic {
 	fn clone(&self) -> Self {
 		// Mirror `new`: bump `dynamic` so each live handle is counted. Without this,
 		// dropping a clone would decrement past `new`'s increment and prematurely flip
@@ -1108,7 +1108,7 @@ impl Clone for OriginDynamic {
 	}
 }
 
-impl OriginDynamic {
+impl Dynamic {
 	fn new(info: Origin, root: PathOwned, state: kio::Producer<OriginDynamicState>) -> Self {
 		if let Ok(mut state) = state.write() {
 			state.dynamic += 1;
@@ -1134,7 +1134,7 @@ impl OriginDynamic {
 	}
 
 	/// Poll for the next requested broadcast, without blocking.
-	pub fn poll_requested_broadcast(&mut self, waiter: &kio::Waiter) -> Poll<Result<BroadcastRequest, Error>> {
+	pub fn poll_requested_broadcast(&mut self, waiter: &kio::Waiter) -> Poll<Result<Request, Error>> {
 		let mut state = ready!(self.poll(waiter, |state| {
 			if state.request_order.is_empty() {
 				Poll::Pending
@@ -1145,12 +1145,12 @@ impl OriginDynamic {
 
 		let path = state.request_order.pop_front().expect("predicate guaranteed a request");
 		let producer = state.requests.remove(&path).expect("request_order out of sync");
-		Poll::Ready(Ok(BroadcastRequest { path, producer }))
+		Poll::Ready(Ok(Request { path, producer }))
 	}
 
 	/// Block until a consumer requests an unannounced broadcast, returning a
-	/// [`BroadcastRequest`] to serve.
-	pub async fn requested_broadcast(&mut self) -> Result<BroadcastRequest, Error> {
+	/// [`Request`] to serve.
+	pub async fn requested_broadcast(&mut self) -> Result<Request, Error> {
 		kio::wait(|waiter| self.poll_requested_broadcast(waiter)).await
 	}
 
@@ -1160,10 +1160,10 @@ impl OriginDynamic {
 	}
 }
 
-impl Drop for OriginDynamic {
+impl Drop for Dynamic {
 	fn drop(&mut self) {
 		if let Ok(mut state) = self.state.write() {
-			// Saturating sub so `OriginProducer::dynamic` can stay infallible.
+			// Saturating sub so `Producer::dynamic` can stay infallible.
 			state.dynamic = state.dynamic.saturating_sub(1);
 			if state.dynamic == 0 {
 				// No handlers left to fulfill queued requests; close them.
@@ -1175,11 +1175,11 @@ impl Drop for OriginDynamic {
 
 /// A pending request for a broadcast that was not announced.
 ///
-/// Yielded by [`OriginDynamic::requested_broadcast`]. The requester is awaiting inside
-/// [`OriginConsumer::request_broadcast`]; [`accept`](Self::accept) resolves it with a live
+/// Yielded by [`Dynamic::requested_broadcast`]. The requester is awaiting inside
+/// [`Consumer::request_broadcast`]; [`accept`](Self::accept) resolves it with a live
 /// broadcast (which the handler keeps producing into) and [`reject`](Self::reject) resolves
 /// it with an error. Dropping the request without either rejects it.
-pub struct BroadcastRequest {
+pub struct Request {
 	// Absolute path that was requested.
 	path: PathOwned,
 
@@ -1188,7 +1188,7 @@ pub struct BroadcastRequest {
 	producer: kio::Producer<PendingBroadcast>,
 }
 
-impl BroadcastRequest {
+impl Request {
 	/// The absolute path that was requested.
 	pub fn path(&self) -> &Path<'_> {
 		&self.path
@@ -1199,7 +1199,7 @@ impl BroadcastRequest {
 	/// The caller keeps producing into `broadcast` (e.g. a relay proxying tracks from
 	/// upstream); the requesters receive a consumer for it. The broadcast is *not*
 	/// announced.
-	pub fn accept(self, broadcast: impl Consume<BroadcastConsumer>) {
+	pub fn accept(self, broadcast: impl Consume<broadcast::Consumer>) {
 		if let Ok(mut state) = self.producer.write() {
 			state.resolved = Some(Ok(broadcast.consume()));
 		}
@@ -1214,19 +1214,19 @@ impl BroadcastRequest {
 	}
 }
 
-/// The pollable result of [`OriginConsumer::request_broadcast`].
+/// The pollable result of [`Consumer::request_broadcast`].
 ///
-/// Awaited via the [`kio::Pending`] wrapper; resolves to the [`BroadcastConsumer`]
-/// immediately when the broadcast was already announced, or once an [`OriginDynamic`]
+/// Awaited via the [`kio::Pending`] wrapper; resolves to the [`broadcast::Consumer`]
+/// immediately when the broadcast was already announced, or once an [`Dynamic`]
 /// handler serves the request. Resolves to an error if the request is rejected or every
 /// handler drops before serving it.
-pub struct BroadcastRequested {
-	inner: Requested,
+pub struct Requested {
+	inner: RequestState,
 }
 
-enum Requested {
+enum RequestState {
 	// Already announced: resolves immediately with a clone of this broadcast.
-	Ready(BroadcastConsumer),
+	Ready(broadcast::Consumer),
 	// Unroutable at request time, or the origin was already dropped: resolves immediately
 	// with this error. Baked in so `request_broadcast` itself stays infallible.
 	Failed(Error),
@@ -1234,31 +1234,31 @@ enum Requested {
 	Pending(kio::Consumer<PendingBroadcast>),
 }
 
-impl BroadcastRequested {
-	fn ready(broadcast: BroadcastConsumer) -> Self {
+impl Requested {
+	fn ready(broadcast: broadcast::Consumer) -> Self {
 		Self {
-			inner: Requested::Ready(broadcast),
+			inner: RequestState::Ready(broadcast),
 		}
 	}
 
 	fn failed(error: Error) -> Self {
 		Self {
-			inner: Requested::Failed(error),
+			inner: RequestState::Failed(error),
 		}
 	}
 
 	fn pending(consumer: kio::Consumer<PendingBroadcast>) -> Self {
 		Self {
-			inner: Requested::Pending(consumer),
+			inner: RequestState::Pending(consumer),
 		}
 	}
 
 	/// Poll for the requested broadcast without blocking.
-	pub fn poll_ok(&self, waiter: &kio::Waiter) -> Poll<Result<BroadcastConsumer, Error>> {
+	pub fn poll_ok(&self, waiter: &kio::Waiter) -> Poll<Result<broadcast::Consumer, Error>> {
 		match &self.inner {
-			Requested::Ready(broadcast) => Poll::Ready(Ok(broadcast.clone())),
-			Requested::Failed(error) => Poll::Ready(Err(error.clone())),
-			Requested::Pending(consumer) => Poll::Ready(
+			RequestState::Ready(broadcast) => Poll::Ready(Ok(broadcast.clone())),
+			RequestState::Failed(error) => Poll::Ready(Err(error.clone())),
+			RequestState::Pending(consumer) => Poll::Ready(
 				match ready!(consumer.poll(waiter, |state| match &state.resolved {
 					Some(result) => Poll::Ready(result.clone()),
 					None => Poll::Pending,
@@ -1272,8 +1272,8 @@ impl BroadcastRequested {
 	}
 }
 
-impl kio::Future for BroadcastRequested {
-	type Output = Result<BroadcastConsumer, Error>;
+impl kio::Future for Requested {
+	type Output = Result<broadcast::Consumer, Error>;
 
 	fn poll(&self, waiter: &kio::Waiter) -> Poll<Self::Output> {
 		self.poll_ok(waiter)
@@ -1286,7 +1286,7 @@ impl kio::Future for BroadcastRequested {
 ///
 /// Lets APIs accept either a producer or a consumer (e.g.
 /// [`Client::with_publisher`](crate::Client::with_publisher),
-/// [`OriginProducer::publish_broadcast`]). The blanket `&T` impl means you can
+/// [`Producer::publish_broadcast`]). The blanket `&T` impl means you can
 /// pass by value (`foo(x)`) to hand off ownership, or by reference (`foo(&x)`)
 /// to keep it, without spelling out `.consume()`.
 pub trait Consume<T> {
@@ -1299,41 +1299,41 @@ impl<T, U: Consume<T>> Consume<T> for &U {
 	}
 }
 
-impl Consume<OriginConsumer> for OriginProducer {
-	fn consume(&self) -> OriginConsumer {
-		// Mirrors the inherent `OriginProducer::consume`; inlined to avoid the
+impl Consume<Consumer> for Producer {
+	fn consume(&self) -> Consumer {
+		// Mirrors the inherent `Producer::consume`; inlined to avoid the
 		// inherent-vs-trait `consume` ambiguity.
-		OriginConsumer::new(self.info, self.root.clone(), self.nodes.clone(), self.dynamic.consume())
+		Consumer::new(self.info, self.root.clone(), self.nodes.clone(), self.dynamic.consume())
 	}
 }
 
-impl Consume<OriginConsumer> for OriginConsumer {
-	fn consume(&self) -> OriginConsumer {
+impl Consume<Consumer> for Consumer {
+	fn consume(&self) -> Consumer {
 		self.clone()
 	}
 }
 
-impl Consume<crate::BroadcastConsumer> for crate::BroadcastProducer {
-	fn consume(&self) -> crate::BroadcastConsumer {
+impl Consume<broadcast::Consumer> for broadcast::Producer {
+	fn consume(&self) -> broadcast::Consumer {
 		// The inherent `consume` shadows this trait method, so this delegates.
 		self.consume()
 	}
 }
 
-impl Consume<crate::BroadcastConsumer> for crate::BroadcastConsumer {
-	fn consume(&self) -> crate::BroadcastConsumer {
+impl Consume<broadcast::Consumer> for broadcast::Consumer {
+	fn consume(&self) -> broadcast::Consumer {
 		self.clone()
 	}
 }
 
-impl Consume<crate::TrackConsumer> for crate::TrackProducer {
-	fn consume(&self) -> crate::TrackConsumer {
+impl Consume<track::Consumer> for track::Producer {
+	fn consume(&self) -> track::Consumer {
 		self.consume()
 	}
 }
 
-impl Consume<crate::TrackConsumer> for crate::TrackConsumer {
-	fn consume(&self) -> crate::TrackConsumer {
+impl Consume<track::Consumer> for track::Consumer {
+	fn consume(&self) -> track::Consumer {
 		self.clone()
 	}
 }
@@ -1342,7 +1342,7 @@ impl Consume<crate::TrackConsumer> for crate::TrackConsumer {
 /// resources. To actually receive announce / unannounce events, call
 /// [`Self::announced`] to obtain an [`AnnounceConsumer`].
 #[derive(Clone)]
-pub struct OriginConsumer {
+pub struct Consumer {
 	// Identity of the origin this consumer was derived from.
 	info: Origin,
 	nodes: OriginNodes,
@@ -1350,12 +1350,12 @@ pub struct OriginConsumer {
 	// A prefix that is automatically stripped from all paths.
 	root: PathOwned,
 
-	// Shared fallback request queue, fed to any `OriginDynamic` handler on the
+	// Shared fallback request queue, fed to any `Dynamic` handler on the
 	// producer side. Used only by `request_broadcast`; announced lookups ignore it.
 	dynamic: kio::Consumer<OriginDynamicState>,
 }
 
-impl std::ops::Deref for OriginConsumer {
+impl std::ops::Deref for Consumer {
 	type Target = Origin;
 
 	fn deref(&self) -> &Self::Target {
@@ -1363,7 +1363,7 @@ impl std::ops::Deref for OriginConsumer {
 	}
 }
 
-impl OriginConsumer {
+impl Consumer {
 	fn new(info: Origin, root: PathOwned, nodes: OriginNodes, dynamic: kio::Consumer<OriginDynamicState>) -> Self {
 		Self {
 			info,
@@ -1407,7 +1407,7 @@ impl OriginConsumer {
 	/// broadcast is about to arrive), so it is not public. [`Self::request_broadcast`] is the
 	/// public lookup: it builds on this for the announced case, then falls back to a dynamic
 	/// handler. [`Self::announced_broadcast`] waits for a future announcement.
-	fn get_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
+	fn get_broadcast(&self, path: impl AsPath) -> Option<broadcast::Consumer> {
 		let path = path.as_path();
 		let (root, rest) = self.nodes.get(&path)?;
 		let state = root.lock();
@@ -1418,14 +1418,14 @@ impl OriginConsumer {
 	///
 	/// Returns `None` if the path is outside this consumer's allowed prefixes or if the consumer
 	/// is closed before the broadcast is announced. The returned broadcast may itself be closed
-	/// later. Subscribers should watch [`BroadcastConsumer::closed`] to react to that.
+	/// later. Subscribers should watch [`broadcast::Consumer::closed`] to react to that.
 	///
 	/// Prefer this over [`Self::request_broadcast`] when you know the exact path you want but
 	/// cannot guarantee the announcement has already been received. With moq-lite-05 (and
 	/// the older Lite01/02) `connect()` already blocks until the initial announce set lands,
 	/// so [`Self::request_broadcast`] is race-free for broadcasts that were live at connect time;
 	/// this method is still needed to wait for a broadcast that comes online *after* connect.
-	pub async fn announced_broadcast(&self, path: impl AsPath) -> Option<BroadcastConsumer> {
+	pub async fn announced_broadcast(&self, path: impl AsPath) -> Option<broadcast::Consumer> {
 		let path = path.as_path();
 
 		// Scope a fresh consumer down to this path so we only wake up for relevant announcements.
@@ -1450,14 +1450,14 @@ impl OriginConsumer {
 		}
 	}
 
-	/// Returns a new OriginConsumer restricted to broadcasts under one of `prefixes`.
+	/// Returns a new Consumer restricted to broadcasts under one of `prefixes`.
 	///
 	/// Returns None if there are no legal prefixes (the requested prefixes are
 	/// disjoint from this consumer's current scope, so it would always return None).
 	// TODO accept PathPrefixes instead of &[Path]
-	pub fn scope(&self, prefixes: &[Path]) -> Option<OriginConsumer> {
+	pub fn scope(&self, prefixes: &[Path]) -> Option<Consumer> {
 		let prefixes = PathPrefixes::new(prefixes);
-		Some(OriginConsumer::new(
+		Some(Consumer::new(
 			self.info,
 			self.root.clone(),
 			self.nodes.select(&prefixes)?,
@@ -1468,12 +1468,12 @@ impl OriginConsumer {
 	/// Get a broadcast by path, falling back to a dynamic request when it is not announced.
 	///
 	/// Returns a [`kio::Pending`] future (resolved synchronously for an announced broadcast,
-	/// otherwise once a handler serves it), mirroring [`TrackConsumer::fetch_group`](crate::TrackConsumer::fetch_group).
+	/// otherwise once a handler serves it), mirroring [`track::Consumer::fetch_group`](track::Consumer::fetch_group).
 	/// The lookup order is: an already-announced broadcast resolves
-	/// immediately; otherwise, if an [`OriginDynamic`] handler is live (see
-	/// [`OriginProducer::dynamic`]), a fallback request is registered and the future resolves
-	/// when the handler [`accept`](BroadcastRequest::accept)s it (or errors if it
-	/// [`reject`](BroadcastRequest::reject)s or every handler drops). Concurrent requests for
+	/// immediately; otherwise, if an [`Dynamic`] handler is live (see
+	/// [`Producer::dynamic`]), a fallback request is registered and the future resolves
+	/// when the handler [`accept`](Request::accept)s it (or errors if it
+	/// [`reject`](Request::reject)s or every handler drops). Concurrent requests for
 	/// the same unannounced path coalesce onto one handler request.
 	///
 	/// The returned future resolves to [`Error::Unroutable`] when the path is not announced and no
@@ -1481,12 +1481,12 @@ impl OriginConsumer {
 	/// registered while a handler is live but then loses every handler before being served also
 	/// resolves to [`Error::Unroutable`]. Unlike an announced broadcast, a dynamically served one
 	/// is never visible to [`Self::announced`].
-	pub fn request_broadcast(&self, path: impl AsPath) -> kio::Pending<BroadcastRequested> {
+	pub fn request_broadcast(&self, path: impl AsPath) -> kio::Pending<Requested> {
 		let path = path.as_path();
 
 		// Prefer a live announcement when one is present; the dynamic queue is only a fallback.
 		if let Some(broadcast) = self.get_broadcast(&path) {
-			return kio::Pending::new(BroadcastRequested::ready(broadcast));
+			return kio::Pending::new(Requested::ready(broadcast));
 		}
 
 		// Key requests by absolute path so a scoped/rooted consumer and the handler
@@ -1494,7 +1494,7 @@ impl OriginConsumer {
 		let absolute = self.root.join(&path).to_owned();
 
 		let Ok(mut state) = self.dynamic.write() else {
-			return kio::Pending::new(BroadcastRequested::failed(Error::Dropped));
+			return kio::Pending::new(Requested::failed(Error::Dropped));
 		};
 
 		// Coalesce onto a queued request for the same path; otherwise register a new one.
@@ -1502,7 +1502,7 @@ impl OriginConsumer {
 			producer.consume()
 		} else {
 			if state.dynamic == 0 {
-				return kio::Pending::new(BroadcastRequested::failed(Error::Unroutable));
+				return kio::Pending::new(Requested::failed(Error::Unroutable));
 			}
 
 			let producer = kio::Producer::<PendingBroadcast>::default();
@@ -1512,10 +1512,10 @@ impl OriginConsumer {
 			consumer
 		};
 
-		kio::Pending::new(BroadcastRequested::pending(consumer))
+		kio::Pending::new(Requested::pending(consumer))
 	}
 
-	/// Returns a new OriginConsumer that automatically strips out the provided prefix.
+	/// Returns a new Consumer that automatically strips out the provided prefix.
 	///
 	/// Returns None if the provided root is not authorized; when [`Self::scope`] was
 	/// already used without a wildcard.
@@ -1579,7 +1579,7 @@ impl AnnounceProducer {
 
 /// Receives announce / unannounce events for a subtree.
 ///
-/// Created by [`OriginConsumer::announced`] or [`AnnounceProducer::consume`].
+/// Created by [`Consumer::announced`] or [`AnnounceProducer::consume`].
 /// Drop to unregister.
 pub struct AnnounceConsumer {
 	id: ConsumerId,
@@ -1674,7 +1674,7 @@ use futures::FutureExt;
 
 #[cfg(test)]
 impl AnnounceConsumer {
-	pub fn assert_next(&mut self, expected: impl AsPath, broadcast: &BroadcastConsumer) {
+	pub fn assert_next(&mut self, expected: impl AsPath, broadcast: &broadcast::Consumer) {
 		let expected = expected.as_path();
 		let (path, event) = self.next().now_or_never().expect("next blocked").expect("no next");
 		assert!(matches!(event, Announced::Active(_)), "should be an active announce");
@@ -1685,7 +1685,7 @@ impl AnnounceConsumer {
 		);
 	}
 
-	pub fn assert_next_restart(&mut self, expected: impl AsPath, broadcast: &BroadcastConsumer) {
+	pub fn assert_next_restart(&mut self, expected: impl AsPath, broadcast: &broadcast::Consumer) {
 		let expected = expected.as_path();
 		let (path, event) = self.next().now_or_never().expect("next blocked").expect("no next");
 		assert!(matches!(event, Announced::Restart(_)), "should be a restart");
@@ -1696,7 +1696,7 @@ impl AnnounceConsumer {
 		);
 	}
 
-	pub fn assert_try_next(&mut self, expected: impl AsPath, broadcast: &BroadcastConsumer) {
+	pub fn assert_try_next(&mut self, expected: impl AsPath, broadcast: &broadcast::Consumer) {
 		let expected = expected.as_path();
 		let (path, event) = self.try_next().expect("no next");
 		assert_eq!(path, expected, "wrong path");
@@ -1730,12 +1730,12 @@ impl AnnounceConsumer {
 }
 
 #[cfg(test)]
-impl OriginProducer {
+impl Producer {
 	/// Test helper that reproduces the legacy fire-and-forget contract: publish, then
 	/// auto-unannounce when the broadcast closes (every producer dropped) via a spawned
-	/// watcher that drops the [`OriginPublish`] guard. Returns whether the publish was
-	/// accepted. Exercises [`OriginPublish`]'s `Drop` on the close path.
-	fn publish_broadcast_spawn(&self, path: impl AsPath, broadcast: BroadcastConsumer) -> bool {
+	/// watcher that drops the [`Publish`] guard. Returns whether the publish was
+	/// accepted. Exercises [`Publish`]'s `Drop` on the close path.
+	fn publish_broadcast_spawn(&self, path: impl AsPath, broadcast: broadcast::Consumer) -> bool {
 		match self.publish_broadcast(path, &broadcast) {
 			Ok(publish) => {
 				web_async::spawn(async move {
@@ -1751,7 +1751,7 @@ impl OriginProducer {
 
 #[cfg(test)]
 mod tests {
-	use crate::{BroadcastInfo, coding::Decode};
+	use crate::coding::Decode;
 
 	use super::*;
 
@@ -1811,8 +1811,8 @@ mod tests {
 		tokio::time::pause();
 
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
 
 		let mut consumer1 = origin.consume().announced();
 		// Make a new consumer that should get it.
@@ -1878,9 +1878,9 @@ mod tests {
 
 		let origin = Origin::random().produce();
 
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
-		let broadcast3 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
+		let broadcast3 = broadcast::Info::new().produce();
 
 		let consumer1 = broadcast1.consume();
 		let consumer2 = broadcast2.consume();
@@ -1935,11 +1935,11 @@ mod tests {
 		// single atomic restart.
 		let origin = Origin::random().produce();
 		// `a` carries one hop; `b` has none, so `b` wins the route and replaces it.
-		let a = BroadcastInfo {
+		let a = broadcast::Info {
 			hops: OriginList::try_from(vec![Origin::new(1u64).unwrap()]).unwrap(),
 		}
 		.produce();
-		let b = BroadcastInfo::new().produce();
+		let b = broadcast::Info::new().produce();
 
 		let mut announced = origin.consume().announced();
 		origin.publish_broadcast_spawn("test", a.consume());
@@ -1956,11 +1956,11 @@ mod tests {
 		// just swaps in the newer broadcast and is still delivered as a fresh Active.
 		let origin = Origin::random().produce();
 		// `a` carries one hop; `b` has none, so `b` wins the route and replaces it.
-		let a = BroadcastInfo {
+		let a = broadcast::Info {
 			hops: OriginList::try_from(vec![Origin::new(1u64).unwrap()]).unwrap(),
 		}
 		.produce();
-		let b = BroadcastInfo::new().produce();
+		let b = broadcast::Info::new().produce();
 
 		let mut announced = origin.consume().announced();
 		origin.publish_broadcast_spawn("test", a.consume());
@@ -1975,8 +1975,8 @@ mod tests {
 		tokio::time::pause();
 
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
 
 		origin.publish_broadcast_spawn("test", broadcast1.consume());
 		origin.publish_broadcast_spawn("test", broadcast2.consume());
@@ -2000,7 +2000,7 @@ mod tests {
 	async fn test_deterministic_tiebreak() {
 		tokio::time::pause();
 
-		fn route(ids: &[u64]) -> BroadcastProducer {
+		fn route(ids: &[u64]) -> broadcast::Producer {
 			let hops = OriginList::try_from(
 				ids.iter()
 					.copied()
@@ -2008,7 +2008,7 @@ mod tests {
 					.collect::<Vec<_>>(),
 			)
 			.unwrap();
-			BroadcastInfo { hops }.produce()
+			broadcast::Info { hops }.produce()
 		}
 
 		// Resolve the active route for "test" after publishing both routes in the given order.
@@ -2040,7 +2040,7 @@ mod tests {
 		tokio::time::pause();
 
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		// Ensure it doesn't crash.
 		origin.publish_broadcast_spawn("test", broadcast.consume());
@@ -2061,7 +2061,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_many_announces() {
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		let mut consumer = origin.consume().announced();
 		for i in 0..256 {
@@ -2077,7 +2077,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_many_announces_try() {
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		let mut consumer = origin.consume().announced();
 		for i in 0..256 {
@@ -2092,7 +2092,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_with_root_basic() {
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		// Create a producer with root "/foo"
 		let foo_producer = origin.with_root("foo").expect("should create root");
@@ -2113,7 +2113,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_with_root_nested() {
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		// Create nested roots
 		let foo_producer = origin.with_root("foo").expect("should create foo root");
@@ -2135,7 +2135,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_publish_scope_allows() {
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		// Create a producer that can only publish to "allowed" paths
 		let limited_producer = origin
@@ -2164,9 +2164,9 @@ mod tests {
 	#[tokio::test]
 	async fn test_consume_scope_filters() {
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
-		let broadcast3 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
+		let broadcast3 = broadcast::Info::new().produce();
 
 		let mut consumer = origin.consume().announced();
 
@@ -2196,9 +2196,9 @@ mod tests {
 	#[tokio::test]
 	async fn test_consume_scope_multiple_prefixes() {
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
-		let broadcast3 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
+		let broadcast3 = broadcast::Info::new().produce();
 
 		origin.publish_broadcast_spawn("foo/test", broadcast1.consume());
 		origin.publish_broadcast_spawn("bar/test", broadcast2.consume());
@@ -2220,7 +2220,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_with_root_and_publish_scope() {
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		// User connects to /foo root
 		let foo_producer = origin.with_root("foo").expect("should create foo root");
@@ -2253,9 +2253,9 @@ mod tests {
 	#[tokio::test]
 	async fn test_with_root_and_consume_scope() {
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
-		let broadcast3 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
+		let broadcast3 = broadcast::Info::new().produce();
 
 		// Publish broadcasts
 		origin.publish_broadcast_spawn("foo/bar/test", broadcast1.consume());
@@ -2300,7 +2300,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_wildcard_permission() {
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		// Producer with root access (empty string means wildcard)
 		let root_producer = origin.clone();
@@ -2317,8 +2317,8 @@ mod tests {
 	#[tokio::test]
 	async fn test_consume_broadcast_with_permissions() {
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
 
 		origin.publish_broadcast_spawn("allowed/test", broadcast1.consume());
 		origin.publish_broadcast_spawn("notallowed/test", broadcast2.consume());
@@ -2346,7 +2346,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_nested_paths_with_permissions() {
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		// Create producer limited to "a/b/c"
 		let limited_producer = origin.scope(&["a/b/c".into()]).expect("should create limited producer");
@@ -2365,9 +2365,9 @@ mod tests {
 	#[tokio::test]
 	async fn test_multiple_consumers_with_different_permissions() {
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
-		let broadcast3 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
+		let broadcast3 = broadcast::Info::new().produce();
 
 		// Publish to different paths
 		origin.publish_broadcast_spawn("foo/test", broadcast1.consume());
@@ -2408,8 +2408,8 @@ mod tests {
 	#[tokio::test]
 	async fn test_select_with_empty_prefix() {
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
 
 		// User with root "demo" allowed to subscribe to "worm-node" and "foobar"
 		let demo_producer = origin.with_root("demo").expect("should create demo root");
@@ -2441,9 +2441,9 @@ mod tests {
 	#[tokio::test]
 	async fn test_select_narrowing_scope() {
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
-		let broadcast3 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
+		let broadcast3 = broadcast::Info::new().produce();
 
 		// User with root "demo" allowed to subscribe to "worm-node" and "foobar"
 		let demo_producer = origin.with_root("demo").expect("should create demo root");
@@ -2482,9 +2482,9 @@ mod tests {
 	#[tokio::test]
 	async fn test_select_multiple_roots_with_empty_prefix() {
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
-		let broadcast3 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
+		let broadcast3 = broadcast::Info::new().produce();
 
 		// Producer with multiple allowed roots
 		let limited_producer = origin
@@ -2513,7 +2513,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_publish_scope_with_empty_prefix() {
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		// Producer with specific allowed paths
 		let limited_producer = origin
@@ -2535,9 +2535,9 @@ mod tests {
 	#[tokio::test]
 	async fn test_select_narrowing_to_deeper_path() {
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
-		let broadcast3 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
+		let broadcast3 = broadcast::Info::new().produce();
 
 		// Producer with broad permission
 		let limited_producer = origin.scope(&["org".into()]).expect("should create limited producer");
@@ -2638,8 +2638,8 @@ mod tests {
 	#[tokio::test]
 	async fn test_select_maintains_access_with_wider_prefix() {
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
 
 		// Setup: user with root "demo" allowed to subscribe to specific paths
 		let demo_producer = origin.with_root("demo").expect("should create demo root");
@@ -2681,7 +2681,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_duplicate_prefixes_deduped() {
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		// scope with duplicate prefixes should work (deduped internally)
 		let producer = origin
@@ -2698,7 +2698,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_overlapping_prefixes_deduped() {
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		// "demo" and "demo/foo". "demo/foo" is redundant, only "demo" should remain
 		let producer = origin
@@ -2716,7 +2716,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_overlapping_prefixes_no_duplicate_announcements() {
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		// Both "demo" and "demo/foo" are requested. Should only have one node
 		let producer = origin
@@ -2746,7 +2746,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_announced_broadcast_already_announced() {
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		origin.publish_broadcast_spawn("test", broadcast.consume());
 
@@ -2760,7 +2760,7 @@ mod tests {
 		tokio::time::pause();
 
 		let origin = Origin::random().produce();
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 
 		let consumer = origin.consume();
 
@@ -2784,8 +2784,8 @@ mod tests {
 		tokio::time::pause();
 
 		let origin = Origin::random().produce();
-		let other = BroadcastInfo::new().produce();
-		let target = BroadcastInfo::new().produce();
+		let other = broadcast::Info::new().produce();
+		let target = broadcast::Info::new().produce();
 
 		let consumer = origin.consume();
 
@@ -2811,8 +2811,8 @@ mod tests {
 		tokio::time::pause();
 
 		let origin = Origin::random().produce();
-		let nested = BroadcastInfo::new().produce();
-		let exact = BroadcastInfo::new().produce();
+		let nested = broadcast::Info::new().produce();
+		let exact = broadcast::Info::new().produce();
 
 		let consumer = origin.consume();
 
@@ -2874,7 +2874,7 @@ mod tests {
 		let origin = Origin::random().produce();
 		let mut announced = origin.consume().announced();
 
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 		origin.publish_broadcast_spawn("test", broadcast.consume());
 		drop(broadcast);
 
@@ -2892,8 +2892,8 @@ mod tests {
 		let origin = Origin::random().produce();
 		let mut announced = origin.consume().announced();
 
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
 
 		origin.publish_broadcast_spawn("test", broadcast1.consume());
 		drop(broadcast1);
@@ -2911,7 +2911,7 @@ mod tests {
 		tokio::time::pause();
 
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
 		origin.publish_broadcast_spawn("test", broadcast1.consume());
 
 		let mut announced = origin.consume().announced();
@@ -2921,7 +2921,7 @@ mod tests {
 		drop(broadcast1);
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
 
-		let broadcast2 = BroadcastInfo::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
 		origin.publish_broadcast_spawn("test", broadcast2.consume());
 
 		// The cursor must see the unannounce before the new announce.
@@ -2937,7 +2937,7 @@ mod tests {
 		tokio::time::pause();
 
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
 		origin.publish_broadcast_spawn("test", broadcast1.consume());
 
 		let mut announced = origin.consume().announced();
@@ -2946,7 +2946,7 @@ mod tests {
 		drop(broadcast1);
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
 
-		let broadcast2 = BroadcastInfo::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
 		origin.publish_broadcast_spawn("test", broadcast2.consume());
 		drop(broadcast2);
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
@@ -2967,7 +2967,7 @@ mod tests {
 		let mut announced = origin.consume().announced();
 
 		for _ in 0..1000 {
-			let broadcast = BroadcastInfo::new().produce();
+			let broadcast = broadcast::Info::new().produce();
 			origin.publish_broadcast_spawn("test", broadcast.consume());
 			drop(broadcast);
 		}
@@ -2988,14 +2988,14 @@ mod tests {
 		);
 	}
 
-	// OriginConsumer should be cheap to clone: cloning must NOT drain any
+	// Consumer should be cheap to clone: cloning must NOT drain any
 	// other cursor's announce channel. A freshly-built AnnounceConsumer
 	// still receives the active backlog.
 	#[tokio::test]
 	async fn test_consumer_clone_is_side_effect_free() {
 		let origin = Origin::random().produce();
-		let broadcast1 = BroadcastInfo::new().produce();
-		let broadcast2 = BroadcastInfo::new().produce();
+		let broadcast1 = broadcast::Info::new().produce();
+		let broadcast2 = broadcast::Info::new().produce();
 
 		origin.publish_broadcast_spawn("test1", broadcast1.consume());
 		origin.publish_broadcast_spawn("test2", broadcast2.consume());
@@ -3003,7 +3003,7 @@ mod tests {
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
-		// Cloning the OriginConsumer many times and looking up broadcasts
+		// Cloning the Consumer many times and looking up broadcasts
 		// must not consume any events from the existing cursor.
 		for _ in 0..16 {
 			let cloned = consumer.clone();
@@ -3032,7 +3032,7 @@ mod tests {
 		assert_eq!(paths, ["test1", "test2"]);
 	}
 
-	// With no OriginDynamic handler, an unannounced path resolves to Unroutable.
+	// With no Dynamic handler, an unannounced path resolves to Unroutable.
 	#[tokio::test]
 	async fn dynamic_request_unroutable_without_handler() {
 		let origin = Origin::random().produce();
@@ -3060,7 +3060,7 @@ mod tests {
 		let request_fut = consumer.request_broadcast("fallback");
 
 		// The handler serves it with a live broadcast it keeps producing into.
-		let served = BroadcastInfo::new().produce();
+		let served = broadcast::Info::new().produce();
 		let mut served_dynamic = served.dynamic();
 
 		let request = dynamic.requested_broadcast().await.unwrap();
@@ -3101,7 +3101,7 @@ mod tests {
 		);
 
 		// Accepting resolves both awaiting requesters with the same broadcast.
-		let served = BroadcastInfo::new().produce();
+		let served = broadcast::Info::new().produce();
 		request.accept(&served);
 		assert!(f1.await.unwrap().is_clone(&served.consume()));
 		assert!(f2.await.unwrap().is_clone(&served.consume()));
@@ -3157,7 +3157,7 @@ mod tests {
 		drop(dynamic);
 
 		// Accept still resolves the awaiting requester with the served broadcast.
-		let served = BroadcastInfo::new().produce();
+		let served = broadcast::Info::new().produce();
 		request.accept(&served);
 		assert!(request_fut.await.unwrap().is_clone(&served.consume()));
 	}
@@ -3169,7 +3169,7 @@ mod tests {
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
-		let broadcast = BroadcastInfo::new().produce();
+		let broadcast = broadcast::Info::new().produce();
 		let _publish = origin.publish_broadcast("live", &broadcast).unwrap();
 
 		let got = consumer.request_broadcast("live").await.unwrap();

--- a/rs/moq-net/src/model/subscription.rs
+++ b/rs/moq-net/src/model/subscription.rs
@@ -3,9 +3,9 @@ use std::{task::Poll, time::Duration};
 /// Subscriber-side preferences for receiving a track.
 ///
 /// Each subscriber holds its own [`Subscription`]; the publisher observes an
-/// aggregate across all live subscribers via [`crate::TrackProducer::subscription`].
+/// aggregate across all live subscribers via [`crate::track::Producer::subscription`].
 /// A subscriber can change its preferences after the fact with
-/// [`crate::TrackSubscriber::update`].
+/// [`crate::track::Subscriber::update`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Subscription {
 	/// Delivery priority. Higher values preempt lower ones when bandwidth is constrained.

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1,21 +1,20 @@
-//! A track is a collection of semi-reliable and semi-ordered streams, split into a [TrackProducer] and [TrackSubscriber] handle.
+//! A track is a collection of semi-reliable and semi-ordered streams, split into a [Producer] and [Subscriber] handle.
 //!
-//! A [TrackProducer] creates streams with a sequence number and priority.
+//! A [Producer] creates streams with a sequence number and priority.
 //! The sequence number is used to determine the order of streams, while the priority is used to determine which stream to transmit first.
 //! This may seem counter-intuitive, but is designed for live streaming where the newest streams may be higher priority.
-//! A cloned [TrackProducer] can be used to create streams in parallel, but will error if a duplicate sequence number is used.
+//! A cloned [Producer] can be used to create streams in parallel, but will error if a duplicate sequence number is used.
 //!
-//! A [TrackSubscriber] may not receive all streams in order or at all.
+//! A [Subscriber] may not receive all streams in order or at all.
 //! These streams are meant to be transmitted over congested networks and the key to MoQ Transport is to not block on them.
 //! Streams will be cached for a potentially limited duration added to the unreliable nature.
-//! A [TrackConsumer] is a cheap, cloneable handle; subscribing it multiple times fans the same
-//! cached streams out to each independent [TrackSubscriber].
+//! A [Consumer] is a cheap, cloneable handle; subscribing it multiple times fans the same
+//! cached streams out to each independent [Subscriber].
 //!
 //! The track is closed with [Error] when all writers or readers are dropped.
 
-use crate::{BroadcastInfo, Error, Result, Subscription, Timescale, Timestamp, coding};
-
-use super::{Fetch, GroupConsumer, GroupInfo, GroupProducer};
+use crate::{Error, Result, Subscription, Timescale, Timestamp, coding};
+use crate::{broadcast, group};
 
 use std::{
 	collections::{HashMap, HashSet, VecDeque},
@@ -24,19 +23,19 @@ use std::{
 	time::Duration,
 };
 
-/// Default [`TrackInfo::cache`] age when the publisher doesn't set one.
+/// Default [`Info::cache`] age when the publisher doesn't set one.
 pub const DEFAULT_CACHE: Duration = Duration::from_secs(5);
 
 /// Publisher-side properties of a track.
 ///
 /// These are fixed by the publisher when the track is created and don't change
 /// while the track is alive. A subscriber learns them via
-/// [`crate::BroadcastConsumer::track`](crate::BroadcastConsumer::track),
-/// which returns the publisher's [`TrackInfo`] once the subscription is accepted.
+/// [`broadcast::Consumer::track`](broadcast::Consumer::track),
+/// which returns the publisher's [`Info`] once the subscription is accepted.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
-pub struct TrackInfo {
+pub struct Info {
 	/// Units per second for per-frame timestamps on this track.
 	///
 	/// Every track is timed; this defaults to [`Timescale::MILLI`]. On Lite05+ it is
@@ -80,7 +79,7 @@ fn is_default_cache(cache: &Duration) -> bool {
 	*cache == DEFAULT_CACHE
 }
 
-/// Serialize [`TrackInfo::cache`] as a bare integer of milliseconds, matching the
+/// Serialize [`Info::cache`] as a bare integer of milliseconds, matching the
 /// catalog's other durations (and the wire), rather than serde's `{secs, nanos}`.
 #[cfg(feature = "serde")]
 mod cache_millis {
@@ -95,7 +94,7 @@ mod cache_millis {
 		Ok(Duration::from_millis(ms))
 	}
 }
-impl Default for TrackInfo {
+impl Default for Info {
 	fn default() -> Self {
 		Self {
 			timescale: Timescale::default(),
@@ -106,7 +105,7 @@ impl Default for TrackInfo {
 	}
 }
 
-impl TrackInfo {
+impl Info {
 	/// Set the per-frame timestamp scale, returning `self` for chaining.
 	///
 	/// Defaults to [`Timescale::MILLI`]. On Lite05+ this scale is reported in TRACK_INFO
@@ -144,12 +143,12 @@ impl TrackInfo {
 
 #[derive(Default)]
 struct TrackState {
-	// The info for the track; always Some for TrackSubscriber/TrackProducer.
+	// The info for the track; always Some for Subscriber/Producer.
 	// A small `Copy` value, inherited by each group it creates.
-	info: Option<TrackInfo>,
+	info: Option<Info>,
 
 	// Groups in arrival order. `None` entries are tombstones for evicted groups.
-	groups: VecDeque<Option<(GroupProducer, web_async::time::Instant)>>,
+	groups: VecDeque<Option<(group::Producer, web_async::time::Instant)>>,
 
 	// TODO Do we need this?
 	duplicates: HashSet<u64>,
@@ -170,7 +169,7 @@ struct TrackState {
 	subscriptions: Vec<kio::Consumer<Subscription>>,
 
 	// Specific groups requested via `fetch` that aren't cached yet, FIFO for a
-	// `TrackDynamic` to serve (see `TrackDynamic::requested_group`).
+	// `Dynamic` to serve (see `Dynamic::requested_group`).
 	fetches: VecDeque<GroupRequested>,
 
 	// Monotonic IDs for fetches that reached a dynamic handler.
@@ -180,14 +179,14 @@ struct TrackState {
 	// transient attempt doesn't poison future retries for the same sequence.
 	fetch_rejections: HashMap<u64, Error>,
 
-	// Number of live `TrackDynamic` handles. While zero, the track serves no
+	// Number of live `Dynamic` handles. While zero, the track serves no
 	// uncached groups, so a cache-miss `fetch` on an accepted track fails fast
 	// instead of blocking forever (mirrors `BroadcastState::dynamic`).
 	dynamic: usize,
 }
 
 impl TrackState {
-	fn poll_info(&self) -> Poll<Result<TrackInfo>> {
+	fn poll_info(&self) -> Poll<Result<Info>> {
 		if let Some(info) = &self.info {
 			Poll::Ready(Ok(*info))
 		} else {
@@ -198,7 +197,7 @@ impl TrackState {
 	/// Find the next non-tombstoned group at or after `index` in arrival order.
 	///
 	/// Returns the group and its absolute index so the consumer can advance past it.
-	fn poll_recv_group(&self, index: usize, min_sequence: u64) -> Poll<Result<Option<(GroupConsumer, usize)>>> {
+	fn poll_recv_group(&self, index: usize, min_sequence: u64) -> Poll<Result<Option<(group::Consumer, usize)>>> {
 		let start = index.saturating_sub(self.offset);
 		for (i, slot) in self.groups.iter().enumerate().skip(start) {
 			if let Some((group, _)) = slot
@@ -264,14 +263,18 @@ impl TrackState {
 
 	/// Find the smallest-sequence cached group satisfying
 	/// `next_sequence <= seq <= end_sequence (if set)`. Used by
-	/// [`TrackSubscriber::next_group`] so the range can be widened (or unset)
+	/// [`Subscriber::next_group`] so the range can be widened (or unset)
 	/// after the fact and previously-skipped cached groups become available
 	/// without scanning past them in arrival order.
 	///
 	/// Returns `Poll::Pending` when no in-range group is currently cached but
 	/// future groups could still arrive in range; returns `Ok(None)` only when
 	/// the track is finalized and no further in-range group is possible.
-	fn poll_next_in_range(&self, next_sequence: u64, end_sequence: Option<u64>) -> Poll<Result<Option<GroupConsumer>>> {
+	fn poll_next_in_range(
+		&self,
+		next_sequence: u64,
+		end_sequence: Option<u64>,
+	) -> Poll<Result<Option<group::Consumer>>> {
 		// If the end cap is already below where we'd resume, no group can
 		// ever satisfy this call until the cap rises. Pending (not None) so
 		// the consumer is parked rather than told the stream is over.
@@ -284,7 +287,7 @@ impl TrackState {
 			return Poll::Pending;
 		}
 
-		let mut best: Option<&GroupProducer> = None;
+		let mut best: Option<&group::Producer> = None;
 		for (group, _) in self.groups.iter().flatten() {
 			if group.sequence < next_sequence {
 				continue;
@@ -318,7 +321,7 @@ impl TrackState {
 	}
 
 	/// Find a cached group by sequence, skipping tombstones. Synchronous, never blocks.
-	fn cached_group(&self, sequence: u64) -> Option<GroupConsumer> {
+	fn cached_group(&self, sequence: u64) -> Option<group::Consumer> {
 		self.groups
 			.iter()
 			.flatten()
@@ -326,7 +329,7 @@ impl TrackState {
 			.map(|(group, _)| group.consume())
 	}
 
-	fn poll_get_group(&self, sequence: u64) -> Poll<Result<Option<GroupConsumer>>> {
+	fn poll_get_group(&self, sequence: u64) -> Poll<Result<Option<group::Consumer>>> {
 		if let Some(group) = self.cached_group(sequence) {
 			return Poll::Ready(Ok(Some(group)));
 		}
@@ -350,10 +353,10 @@ impl TrackState {
 	/// missing group is a failure ([`Error::NotFound`]), not an end-of-stream.
 	///
 	/// A miss is unservable when the group is past the final sequence, or when no
-	/// [`TrackDynamic`] exists to fetch old content (`dynamic == 0`). On-demand tracks
-	/// (from a [`TrackRequest`]) are dynamic from creation, so a relay's fetch waits to
+	/// [`Dynamic`] exists to fetch old content (`dynamic == 0`). On-demand tracks
+	/// (from a [`Request`]) are dynamic from creation, so a relay's fetch waits to
 	/// be served rather than racing the handler into existence.
-	fn poll_fetch(&self, sequence: u64, request_id: Option<u64>) -> Poll<Result<GroupConsumer>> {
+	fn poll_fetch(&self, sequence: u64, request_id: Option<u64>) -> Poll<Result<group::Consumer>> {
 		if let Some(group) = self.cached_group(sequence) {
 			return Poll::Ready(Ok(group));
 		}
@@ -436,12 +439,12 @@ impl TrackState {
 		producer.write().map_err(|r| r.abort.clone().unwrap_or(Error::Dropped))
 	}
 
-	/// Insert a group fetched for a [`GroupRequest`], setting the track's [`TrackInfo`]
+	/// Insert a group fetched for a [`GroupRequest`], setting the track's [`Info`]
 	/// if it isn't accepted yet. The group's timescale comes from that info, so a
 	/// fetch can serve an as-yet-unaccepted track (e.g. a relay with no live
 	/// subscription). The group lands in the cache so a waiting
-	/// [`TrackFetch`] resolves via [`Self::poll_fetch`].
-	fn insert_group_request(&mut self, sequence: u64, info: Option<TrackInfo>) -> Result<GroupProducer> {
+	/// [`Fetch`] resolves via [`Self::poll_fetch`].
+	fn insert_group_request(&mut self, sequence: u64, info: Option<Info>) -> Result<group::Producer> {
 		if let Some(err) = &self.abort {
 			return Err(err.clone());
 		}
@@ -457,7 +460,7 @@ impl TrackState {
 		// Adopt the supplied info only if the track hasn't been accepted yet.
 		let info = *self.info.get_or_insert_with(|| info.unwrap_or_default());
 
-		let group = GroupProducer::new(GroupInfo { sequence }, info);
+		let group = group::Producer::new(group::Info { sequence }, info);
 		let cache = info.cache;
 		let now = web_async::time::Instant::now();
 		self.max_sequence = Some(self.max_sequence.unwrap_or(0).max(sequence));
@@ -477,26 +480,26 @@ impl TrackState {
 
 /// A producer for a track, used to create new groups.
 #[derive(Clone)]
-pub struct TrackProducer {
+pub struct Producer {
 	name: Arc<str>,
-	// The parent broadcast's info, inherited from [`crate::BroadcastProducer::create_track`].
+	// The parent broadcast's info, inherited from [`broadcast::Producer::create_track`].
 	// Top link of the ownership chain; carried for identity and future inheritance.
-	broadcast: Arc<BroadcastInfo>,
+	broadcast: Arc<broadcast::Info>,
 	state: kio::Producer<TrackState>,
 	prev_subscription: Option<Subscription>,
 }
 
-impl TrackProducer {
+impl Producer {
 	/// Build a producer for the given track metadata.
 	///
 	/// Crate-private: tracks are born from their broadcast via
-	/// [`crate::BroadcastProducer::create_track`] (or served on demand through a
-	/// [`TrackRequest`]), which threads the broadcast's `Arc<BroadcastInfo>` down so
+	/// [`broadcast::Producer::create_track`] (or served on demand through a
+	/// [`Request`]), which threads the broadcast's `Arc<broadcast::Info>` down so
 	/// the broadcast owns the namespace and there's a single way to mint a track.
 	pub(crate) fn new(
-		broadcast: Arc<BroadcastInfo>,
+		broadcast: Arc<broadcast::Info>,
 		name: impl Into<Arc<str>>,
-		info: impl Into<Option<TrackInfo>>,
+		info: impl Into<Option<Info>>,
 	) -> Self {
 		let info = info.into().unwrap_or_default();
 		Self {
@@ -515,12 +518,12 @@ impl TrackProducer {
 	}
 
 	/// The parent broadcast this track belongs to.
-	pub fn broadcast(&self) -> &BroadcastInfo {
+	pub fn broadcast(&self) -> &broadcast::Info {
 		&self.broadcast
 	}
 
 	/// Create a new group with the given sequence number.
-	pub fn create_group(&mut self, group: GroupInfo) -> Result<GroupProducer> {
+	pub fn create_group(&mut self, group: group::Info) -> Result<group::Producer> {
 		let mut state = self.modify()?;
 		if let Some(fin) = state.final_sequence
 			&& group.sequence >= fin
@@ -531,7 +534,7 @@ impl TrackProducer {
 		let track = *info;
 		let cache = info.cache;
 
-		let group = GroupProducer::new(group, track);
+		let group = group::Producer::new(group, track);
 		if !state.duplicates.insert(group.sequence) {
 			return Err(Error::Duplicate);
 		}
@@ -545,7 +548,7 @@ impl TrackProducer {
 	}
 
 	/// Create a new group with the next sequence number.
-	pub fn append_group(&mut self) -> Result<GroupProducer> {
+	pub fn append_group(&mut self) -> Result<group::Producer> {
 		let mut state = self.modify()?;
 		let sequence = match state.max_sequence {
 			Some(s) => s.checked_add(1).ok_or(coding::BoundsExceeded)?,
@@ -561,7 +564,7 @@ impl TrackProducer {
 		let track = *info;
 		let cache = info.cache;
 
-		let group = GroupProducer::new(GroupInfo { sequence }, track);
+		let group = group::Producer::new(group::Info { sequence }, track);
 
 		let now = web_async::time::Instant::now();
 		state.duplicates.insert(sequence);
@@ -627,10 +630,10 @@ impl TrackProducer {
 
 	/// Abort the track with the given error.
 	///
-	/// Drops the cached groups so a stale [`TrackConsumer`] can't pin them (and
+	/// Drops the cached groups so a stale [`Consumer`] can't pin them (and
 	/// their frame buffers) in memory forever. Consumers that haven't drained yet
 	/// surface the abort error instead of the leftover cache. Child groups are
-	/// independent: a consumer that already pulled a [`GroupConsumer`] keeps its
+	/// independent: a consumer that already pulled a [`group::Consumer`] keeps its
 	/// own handle and can finish reading it.
 	pub fn abort(&mut self, err: Error) -> Result<()> {
 		let mut guard = self.modify()?;
@@ -686,15 +689,15 @@ impl TrackProducer {
 		}
 	}
 
-	/// Create a [`TrackDemand`]: a cloneable, watch-only handle to this track's
+	/// Create a [`Demand`]: a cloneable, watch-only handle to this track's
 	/// subscriber demand.
 	///
 	/// Lets a publisher gate work (e.g. on-demand capture) on whether anyone is
 	/// subscribed, without the ability to publish frames or close the track. The
 	/// handle is weak, so holding one neither keeps the track alive nor pins its
 	/// cached groups.
-	pub fn demand(&self) -> TrackDemand {
-		TrackDemand {
+	pub fn demand(&self) -> Demand {
+		Demand {
 			name: self.name.clone(),
 			state: self.state.weak(),
 		}
@@ -704,8 +707,8 @@ impl TrackProducer {
 	///
 	/// Unlike a wire subscription, the info is already known, so a subscription
 	/// opened from this handle resolves immediately.
-	pub fn consume(&self) -> TrackConsumer {
-		TrackConsumer {
+	pub fn consume(&self) -> Consumer {
+		Consumer {
 			name: self.name.clone(),
 			state: self.state.consume(),
 		}
@@ -716,7 +719,7 @@ impl TrackProducer {
 	/// The info is fixed at creation, so there's nothing to wait for (no
 	/// SUBSCRIBE_OK round trip). The subscriber's stale window is clamped to the
 	/// track's cache. Pass `None` for [`Subscription::default`].
-	pub fn subscribe(&self, subscription: impl Into<Option<Subscription>>) -> TrackSubscriber {
+	pub fn subscribe(&self, subscription: impl Into<Option<Subscription>>) -> Subscriber {
 		let mut preferences = subscription.into().unwrap_or_default();
 
 		let mut state = self.modify().expect("track producer state is never closed");
@@ -726,7 +729,7 @@ impl TrackProducer {
 		state.subscriptions.push(subscription.consume());
 		drop(state);
 
-		TrackSubscriber {
+		Subscriber {
 			name: self.name.clone(),
 			info,
 			state: self.state.consume(),
@@ -789,11 +792,11 @@ impl TrackProducer {
 		self.state.poll_unused(waiter).map(|_| ())
 	}
 
-	/// Create a [`TrackDynamic`] handle that serves on-demand fetches of uncached
+	/// Create a [`Dynamic`] handle that serves on-demand fetches of uncached
 	/// (old) groups. Most producers never need this; a relay creates one to fetch
 	/// past groups from upstream.
-	pub fn dynamic(&self) -> TrackDynamic {
-		TrackDynamic::new(self.name.clone(), self.state.clone())
+	pub fn dynamic(&self) -> Dynamic {
+		Dynamic::new(self.name.clone(), self.state.clone())
 	}
 
 	fn modify(&self) -> Result<kio::Mut<'_, TrackState>> {
@@ -803,7 +806,7 @@ impl TrackProducer {
 
 /// Pop the next queued group fetch off the shared state and wrap it in a
 /// [`GroupRequest`] bound to a fresh producer handle. Shared by every
-/// [`TrackDynamic`] handle on the track.
+/// [`Dynamic`] handle on the track.
 fn poll_requested_group(state: &kio::Producer<TrackState>, waiter: &kio::Waiter) -> Poll<Result<GroupRequest>> {
 	// Read-only predicate: ready once there's a request to pop, or the track aborted.
 	let mut guard = ready!(state.poll(waiter, |state| {
@@ -831,20 +834,20 @@ fn poll_requested_group(state: &kio::Producer<TrackState>, waiter: &kio::Waiter)
 }
 
 /// Serves on-demand fetches of uncached (old) groups for a track, the group-level
-/// analogue of [`crate::BroadcastDynamic`].
+/// analogue of [`broadcast::Dynamic`].
 ///
 /// Most tracks never serve old content, so this capability lives on a dedicated
-/// handle rather than [`TrackProducer`]: a relay creates one (via
-/// [`TrackProducer::dynamic`] or [`TrackRequest::dynamic`]) to pull past groups
+/// handle rather than [`Producer`]: a relay creates one (via
+/// [`Producer::dynamic`] or [`Request::dynamic`]) to pull past groups
 /// from upstream. While at least one is alive the track will block a cache-miss
-/// [`TrackConsumer::fetch_group`] waiting to be served; with none, an accepted track's
+/// [`Consumer::fetch_group`] waiting to be served; with none, an accepted track's
 /// miss fails fast with [`Error::NotFound`].
-pub struct TrackDynamic {
+pub struct Dynamic {
 	name: Arc<str>,
 	state: kio::Producer<TrackState>,
 }
 
-impl TrackDynamic {
+impl Dynamic {
 	fn new(name: Arc<str>, state: kio::Producer<TrackState>) -> Self {
 		if let Ok(mut state) = state.write() {
 			state.dynamic += 1;
@@ -875,9 +878,9 @@ impl TrackDynamic {
 	}
 }
 
-impl Clone for TrackDynamic {
+impl Clone for Dynamic {
 	fn clone(&self) -> Self {
-		// Bump `dynamic` so each live handle is counted (mirrors `BroadcastDynamic`).
+		// Bump `dynamic` so each live handle is counted (mirrors `broadcast::Dynamic`).
 		if let Ok(mut state) = self.state.write() {
 			state.dynamic += 1;
 		}
@@ -888,10 +891,10 @@ impl Clone for TrackDynamic {
 	}
 }
 
-impl Drop for TrackDynamic {
+impl Drop for Dynamic {
 	fn drop(&mut self) {
-		// Unlike `BroadcastDynamic`, dropping the last handle doesn't abort the track:
-		// a live `TrackProducer` may still be serving the subscription. It just stops
+		// Unlike `broadcast::Dynamic`, dropping the last handle doesn't abort the track:
+		// a live `Producer` may still be serving the subscription. It just stops
 		// fetch serving, after which an accepted track's cache miss fails fast.
 		if let Ok(mut state) = self.state.write() {
 			state.dynamic = state.dynamic.saturating_sub(1);
@@ -899,7 +902,7 @@ impl Drop for TrackDynamic {
 	}
 }
 
-impl Drop for TrackProducer {
+impl Drop for Producer {
 	fn drop(&mut self) {
 		// The last producer going away without finishing is an abrupt teardown:
 		// release the cached groups so a stale consumer can't pin them (and their
@@ -921,8 +924,8 @@ impl Drop for TrackProducer {
 ///
 /// Read-only: iterates `subscriptions` immutably and registers `waiter` on each, so it
 /// never flags the [`TrackState`] as modified. Marking it modified would drain and wake
-/// unrelated waiters on the channel (e.g. a [`TrackSubscribe`] parked on track info),
-/// which races with [`TrackRequest::accept`] and can drop that wakeup. Callers decide
+/// unrelated waiters on the channel (e.g. a [`Subscribe`] parked on track info),
+/// which races with [`Request::accept`] and can drop that wakeup. Callers decide
 /// readiness from the returned value, then prune closed subscribers through the `Mut`.
 fn combined_subscription(state: &TrackState, waiter: &kio::Waiter) -> Option<Subscription> {
 	let mut combined = None;
@@ -946,8 +949,8 @@ impl TrackWeak {
 		self.state.is_closed()
 	}
 
-	pub fn consume(&self) -> TrackConsumer {
-		TrackConsumer {
+	pub fn consume(&self) -> Consumer {
+		Consumer {
 			name: self.name.clone(),
 			state: self.state.consume(),
 		}
@@ -962,19 +965,19 @@ impl TrackWeak {
 
 /// A cloneable, watch-only handle to a track's subscriber demand.
 ///
-/// Obtained from [`TrackProducer::demand`]. A publisher uses it to react to
+/// Obtained from [`Producer::demand`]. A publisher uses it to react to
 /// whether anyone is subscribed (on-demand capture / encoding) without being able
 /// to publish frames or close the track. It's a weak handle, so it neither keeps
-/// the track alive nor pins its cached groups; once the owning [`TrackProducer`]
+/// the track alive nor pins its cached groups; once the owning [`Producer`]
 /// goes away, [`used`](Self::used) / [`unused`](Self::unused) report the track's
 /// closure.
 #[derive(Clone)]
-pub struct TrackDemand {
+pub struct Demand {
 	name: Arc<str>,
 	state: kio::Weak<TrackState>,
 }
 
-impl TrackDemand {
+impl Demand {
 	/// The track name this handle is bound to.
 	pub fn name(&self) -> &str {
 		&self.name
@@ -1005,17 +1008,17 @@ impl TrackDemand {
 
 /// A handle to a single track within a broadcast.
 ///
-/// Obtained from [`crate::BroadcastConsumer::track`]. Holding it sends nothing
+/// Obtained from [`broadcast::Consumer::track`]. Holding it sends nothing
 /// to the publisher; it just names a track you can [`subscribe`](Self::subscribe)
 /// to (a live, ongoing stream of groups) later. The same handle can be subscribed
 /// to multiple times, and clones are cheap.
 #[derive(Clone)]
-pub struct TrackConsumer {
+pub struct Consumer {
 	name: Arc<str>,
 	state: kio::Consumer<TrackState>,
 }
 
-impl TrackConsumer {
+impl Consumer {
 	/// The track name this handle is bound to.
 	pub fn name(&self) -> &str {
 		&self.name
@@ -1024,18 +1027,18 @@ impl TrackConsumer {
 	/// Open a live subscription.
 	///
 	/// Registers the subscription on the track and returns a [`kio::Pending`] that resolves to the
-	/// [`TrackSubscriber`] once the track info is available, or the track's abort error (or
+	/// [`Subscriber`] once the track info is available, or the track's abort error (or
 	/// [`Error::Dropped`]) if it is already closed.
-	pub fn subscribe(&self, subscription: impl Into<Option<Subscription>>) -> kio::Pending<TrackSubscribe> {
+	pub fn subscribe(&self, subscription: impl Into<Option<Subscription>>) -> kio::Pending<Subscribe> {
 		let subscription = kio::Producer::new(subscription.into().unwrap_or_default());
 
 		// Register the subscription if the track is live. If it is already closed, the returned
-		// future resolves to the abort error via `TrackSubscribe::poll_ok`.
+		// future resolves to the abort error via `Subscribe::poll_ok`.
 		if let Ok(mut state) = self.state.write() {
 			state.subscriptions.push(subscription.consume());
 		}
 
-		kio::Pending::new(TrackSubscribe {
+		kio::Pending::new(Subscribe {
 			name: self.name.clone(),
 			state: self.state.clone(),
 			subscription,
@@ -1043,29 +1046,29 @@ impl TrackConsumer {
 	}
 
 	/// Return a cached group by sequence without blocking, or `None` if it isn't in
-	/// the cache. Use [`Self::fetch_group`] to wait for a group that a [`TrackDynamic`]
+	/// the cache. Use [`Self::fetch_group`] to wait for a group that a [`Dynamic`]
 	/// will serve on demand.
-	pub fn get_group(&self, sequence: u64) -> Option<GroupConsumer> {
+	pub fn get_group(&self, sequence: u64) -> Option<group::Consumer> {
 		self.state.read().cached_group(sequence)
 	}
 
 	/// Fetch a single past group, without holding a live subscription.
 	///
-	/// Returns a [`kio::Pending`] that resolves to the [`GroupConsumer`]:
-	/// immediately if the group is cached, otherwise once a [`TrackDynamic`] serves
-	/// the request (a wire FETCH for a relay). `options` accepts `None`, a [`Fetch`],
-	/// or `Fetch::default()`.
+	/// Returns a [`kio::Pending`] that resolves to the [`group::Consumer`]:
+	/// immediately if the group is cached, otherwise once a [`Dynamic`] serves
+	/// the request (a wire FETCH for a relay). `options` accepts `None`, a [`group::Fetch`],
+	/// or `group::Fetch::default()`.
 	///
 	/// The returned future resolves to [`Error::NotFound`] when the group can never be served
-	/// (past the final sequence, or no [`TrackDynamic`] on the track), or the track's abort error
+	/// (past the final sequence, or no [`Dynamic`] on the track), or the track's abort error
 	/// if it's already closed.
-	pub fn fetch_group(&self, sequence: u64, options: impl Into<Option<Fetch>>) -> kio::Pending<TrackFetch> {
+	pub fn fetch_group(&self, sequence: u64, options: impl Into<Option<group::Fetch>>) -> kio::Pending<Fetch> {
 		let options = options.into().unwrap_or_default();
 		let mut request_id = None;
 
 		// Queue a request only when a handler can serve it but the group isn't cached yet. A cached
 		// group, an unservable sequence (NotFound), or a closed track all resolve through
-		// `TrackFetch::poll` without a queue entry.
+		// `Fetch::poll` without a queue entry.
 		if let Ok(mut state) = self.state.write() {
 			if state.poll_fetch(sequence, None).is_pending() {
 				let id = state.next_fetch;
@@ -1079,35 +1082,35 @@ impl TrackConsumer {
 			}
 		}
 
-		kio::Pending::new(TrackFetch {
+		kio::Pending::new(Fetch {
 			state: self.state.clone(),
 			sequence,
 			request_id,
 		})
 	}
 
-	pub fn info(&self) -> kio::Pending<TrackInfoQuery> {
-		kio::Pending::new(TrackInfoQuery {
+	pub fn info(&self) -> kio::Pending<InfoQuery> {
+		kio::Pending::new(InfoQuery {
 			state: self.state.clone(),
 		})
 	}
 }
 
-/// The pollable state of a [`TrackConsumer::subscribe`]; awaited via the
+/// The pollable state of a [`Consumer::subscribe`]; awaited via the
 /// [`kio::Pending`] wrapper, whose `DerefMut` exposes [`Self::update`].
-pub struct TrackSubscribe {
+pub struct Subscribe {
 	name: Arc<str>,
 	state: kio::Consumer<TrackState>,
 	subscription: kio::Producer<Subscription>,
 }
 
-impl TrackSubscribe {
-	pub fn poll_ok(&self, waiter: &kio::Waiter) -> Poll<Result<TrackSubscriber>> {
+impl Subscribe {
+	pub fn poll_ok(&self, waiter: &kio::Waiter) -> Poll<Result<Subscriber>> {
 		// Wait until the track info is available
 		let info = ready!(self.state.poll(waiter, |state| state.poll_info()))
 			.map_err(|e| e.abort.clone().unwrap_or(Error::Dropped))??;
 
-		Poll::Ready(Ok(TrackSubscriber {
+		Poll::Ready(Ok(Subscriber {
 			name: self.name.clone(),
 			info,
 			state: self.state.clone(),
@@ -1129,22 +1132,22 @@ impl TrackSubscribe {
 	}
 }
 
-impl kio::Future for TrackSubscribe {
-	type Output = Result<TrackSubscriber>;
+impl kio::Future for Subscribe {
+	type Output = Result<Subscriber>;
 
 	fn poll(&self, waiter: &kio::Waiter) -> Poll<Self::Output> {
 		self.poll_ok(waiter)
 	}
 }
 
-/// The pollable state of a [`TrackConsumer::info`]; awaited via the
+/// The pollable state of a [`Consumer::info`]; awaited via the
 /// [`kio::Pending`] wrapper.
-pub struct TrackInfoQuery {
+pub struct InfoQuery {
 	state: kio::Consumer<TrackState>,
 }
 
-impl TrackInfoQuery {
-	pub fn poll_ok(&self, waiter: &kio::Waiter) -> Poll<Result<TrackInfo>> {
+impl InfoQuery {
+	pub fn poll_ok(&self, waiter: &kio::Waiter) -> Poll<Result<Info>> {
 		// Wait until the track info is available
 		let info = ready!(self.state.poll(waiter, |state| state.poll_info()))
 			.map_err(|e| e.abort.clone().unwrap_or(Error::Dropped))??;
@@ -1152,19 +1155,19 @@ impl TrackInfoQuery {
 	}
 }
 
-impl kio::Future for TrackInfoQuery {
-	type Output = Result<TrackInfo>;
+impl kio::Future for InfoQuery {
+	type Output = Result<Info>;
 
 	fn poll(&self, waiter: &kio::Waiter) -> Poll<Self::Output> {
 		self.poll_ok(waiter)
 	}
 }
 
-/// A specific group requested via [`TrackConsumer::fetch_group`], queued on the
-/// track for a [`TrackDynamic`] to serve.
+/// A specific group requested via [`Consumer::fetch_group`], queued on the
+/// track for a [`Dynamic`] to serve.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct GroupRequested {
-	/// The request ID matching the waiting [`TrackFetch`].
+	/// The request ID matching the waiting [`Fetch`].
 	id: u64,
 	/// The group sequence the consumer wants.
 	sequence: u64,
@@ -1173,11 +1176,11 @@ struct GroupRequested {
 }
 
 /// A consumer's request for a single past group, handed to a handler via
-/// [`TrackDynamic::requested_group`].
+/// [`Dynamic::requested_group`].
 ///
 /// The handler fulfills it by calling [`Self::accept`], which inserts the group
-/// into the track cache (resolving the matching [`TrackConsumer::fetch_group`]) and
-/// returns a [`GroupProducer`] to fill. A relay typically opens a wire FETCH, reads
+/// into the track cache (resolving the matching [`Consumer::fetch_group`]) and
+/// returns a [`group::Producer`] to fill. A relay typically opens a wire FETCH, reads
 /// FETCH_OK, then accepts. The request carries its own producer handle, so it works
 /// the same whether or not the track has been accepted yet.
 pub struct GroupRequest {
@@ -1200,18 +1203,18 @@ impl GroupRequest {
 	}
 
 	/// Insert the fetched group into the track cache, resolving the waiting
-	/// [`TrackConsumer::fetch_group`], and return a [`GroupProducer`] to fill.
+	/// [`Consumer::fetch_group`], and return a [`group::Producer`] to fill.
 	///
-	/// The group's timescale comes from the track's [`TrackInfo`]. `info` sets that
+	/// The group's timescale comes from the track's [`Info`]. `info` sets that
 	/// info if the track hasn't been accepted yet (a fetch with no live subscription),
 	/// and is ignored once accepted. Returns [`Error::Duplicate`] if the group is
 	/// already present, or the track's abort error if it closed while pending.
-	pub fn accept(mut self, info: impl Into<Option<TrackInfo>>) -> Result<GroupProducer> {
+	pub fn accept(mut self, info: impl Into<Option<Info>>) -> Result<group::Producer> {
 		self.done = true;
 		TrackState::modify(&self.state)?.insert_group_request(self.sequence, info.into())
 	}
 
-	/// Reject the fetch, resolving the waiting [`TrackConsumer::fetch_group`] with `err`.
+	/// Reject the fetch, resolving the waiting [`Consumer::fetch_group`] with `err`.
 	pub fn reject(mut self, err: Error) {
 		self.done = true;
 		if let Ok(mut state) = self.state.write() {
@@ -1231,22 +1234,22 @@ impl Drop for GroupRequest {
 	}
 }
 
-/// The pollable state of a [`TrackConsumer::fetch_group`].
+/// The pollable state of a [`Consumer::fetch_group`].
 ///
 /// Awaited via the [`kio::Pending`] wrapper; resolves to the
-/// [`GroupConsumer`] once the group lands in the track's cache (already present,
+/// [`group::Consumer`] once the group lands in the track's cache (already present,
 /// or produced after a wire FETCH), or [`Error::NotFound`] if it can never exist.
-pub struct TrackFetch {
+pub struct Fetch {
 	state: kio::Consumer<TrackState>,
 	sequence: u64,
 	request_id: Option<u64>,
 }
 
-impl kio::Future for TrackFetch {
-	type Output = Result<GroupConsumer>;
+impl kio::Future for Fetch {
+	type Output = Result<group::Consumer>;
 
 	fn poll(&self, waiter: &kio::Waiter) -> Poll<Self::Output> {
-		// `poll_fetch` already yields a `Result<GroupConsumer>` (group, or NotFound /
+		// `poll_fetch` already yields a `Result<group::Consumer>` (group, or NotFound /
 		// abort); the outer error is the channel closing without one.
 		let res = match ready!(
 			self.state
@@ -1268,12 +1271,12 @@ impl kio::Future for TrackFetch {
 
 /// A live subscription to a track, used to read its groups.
 ///
-/// Created via [`TrackConsumer::subscribe`](crate::TrackConsumer::subscribe), or
-/// directly from a [`TrackProducer`] for an in-process track. Carries this
+/// Created via [`Consumer::subscribe`](Consumer::subscribe), or
+/// directly from a [`Producer`] for an in-process track. Carries this
 /// subscriber's [`Subscription`] preferences, which feed the producer's aggregate.
-pub struct TrackSubscriber {
+pub struct Subscriber {
 	name: Arc<str>,
-	info: TrackInfo,
+	info: Info,
 	state: kio::Consumer<TrackState>,
 
 	subscription: kio::Producer<Subscription>,
@@ -1291,8 +1294,8 @@ pub struct TrackSubscriber {
 	end_sequence: Option<u64>,
 }
 
-impl TrackSubscriber {
-	pub fn info(&self) -> &TrackInfo {
+impl Subscriber {
+	pub fn info(&self) -> &Info {
 		&self.info
 	}
 
@@ -1322,7 +1325,7 @@ impl TrackSubscriber {
 	/// `Poll::Ready(Ok(None))` when the track is finished,
 	/// `Poll::Ready(Err(e))` when the track has been aborted, or
 	/// `Poll::Pending` when no group is available yet.
-	pub fn poll_recv_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
+	pub fn poll_recv_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
 		let Some((consumer, found_index)) =
 			ready!(self.poll(waiter, |state| state.poll_recv_group(self.index, self.min_sequence))?)
 		else {
@@ -1338,7 +1341,7 @@ impl TrackSubscriber {
 	/// Every group is returned exactly once, in the order it landed on the wire — which may
 	/// be out of sequence due to network reordering or loss. Use [`Self::next_group`] if you
 	/// only want groups whose sequence number is higher than any previously returned.
-	pub async fn recv_group(&mut self) -> Result<Option<GroupConsumer>> {
+	pub async fn recv_group(&mut self) -> Result<Option<group::Consumer>> {
 		kio::wait(|waiter| self.poll_recv_group(waiter)).await
 	}
 
@@ -1350,7 +1353,7 @@ impl TrackSubscriber {
 	///
 	/// Honors the cap set by [`Self::end_at`]: groups with sequence past the cap are left
 	/// in the producer's cache and become eligible again if the cap is raised or removed.
-	pub fn poll_next_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<GroupConsumer>>> {
+	pub fn poll_next_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
 		let floor = self.next_sequence.max(self.min_sequence);
 		let Some(group) = ready!(self.poll(waiter, |state| state.poll_next_in_range(floor, self.end_sequence))?) else {
 			return Poll::Ready(Ok(None));
@@ -1364,13 +1367,13 @@ impl TrackSubscriber {
 	/// Late arrivals (sequence at or below the last returned) are silently skipped, so this
 	/// produces a monotonically increasing sequence at the cost of dropping out-of-order
 	/// groups. Use [`Self::recv_group`] to see every group in arrival order instead.
-	pub async fn next_group(&mut self) -> Result<Option<GroupConsumer>> {
+	pub async fn next_group(&mut self) -> Result<Option<group::Consumer>> {
 		kio::wait(|waiter| self.poll_next_group(waiter)).await
 	}
 
 	/// A helper that calls [`Self::poll_next_group`] and returns its first frame,
 	/// skipping the rest of the group. Intended for single-frame groups (see
-	/// [`TrackProducer::write_frame`]).
+	/// [`Producer::write_frame`]).
 	pub fn poll_read_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<bytes::Bytes>>> {
 		let lower = self.min_sequence.max(self.next_sequence);
 		let Some((frame, found_index, sequence)) =
@@ -1395,22 +1398,22 @@ impl TrackSubscriber {
 	///
 	/// This waits for live arrival, not on-demand retrieval. If the sequence is
 	/// below the final sequence but was already evicted from the cache, this parks
-	/// until the track closes. Use [`TrackConsumer::fetch_group`] for a past group that a
-	/// [`TrackDynamic`] can serve on demand.
-	pub fn poll_get_group(&self, waiter: &kio::Waiter, sequence: u64) -> Poll<Result<Option<GroupConsumer>>> {
+	/// until the track closes. Use [`Consumer::fetch_group`] for a past group that a
+	/// [`Dynamic`] can serve on demand.
+	pub fn poll_get_group(&self, waiter: &kio::Waiter, sequence: u64) -> Poll<Result<Option<group::Consumer>>> {
 		self.poll(waiter, |state| state.poll_get_group(sequence))
 	}
 
 	/// Wait until the group with the given sequence becomes available.
 	///
-	/// Resolves to `Some(GroupConsumer)` once the group is in the cache.
+	/// Resolves to `Some(group::Consumer)` once the group is in the cache.
 	/// Resolves to `None` only when `sequence` is at or past the track's
 	/// `final_sequence` (set by `finish()` / `finish_at()`), since such a
 	/// group can never be produced. Sequences below `final_sequence` still
 	/// wait, since older groups may still arrive out of order. If the sequence
 	/// was already evicted, this waits until the track closes; use
-	/// [`TrackConsumer::fetch_group`] for on-demand retrieval of past groups.
-	pub async fn get_group(&self, sequence: u64) -> Result<Option<GroupConsumer>> {
+	/// [`Consumer::fetch_group`] for on-demand retrieval of past groups.
+	pub async fn get_group(&self, sequence: u64) -> Result<Option<group::Consumer>> {
 		kio::wait(|waiter| self.poll_get_group(waiter, sequence)).await
 	}
 
@@ -1478,10 +1481,10 @@ impl TrackSubscriber {
 	}
 }
 
-pub struct TrackRequest {
+pub struct Request {
 	name: Arc<str>,
-	// The parent broadcast's info, threaded into the [`TrackProducer`] on accept.
-	broadcast: Arc<BroadcastInfo>,
+	// The parent broadcast's info, threaded into the [`Producer`] on accept.
+	broadcast: Arc<broadcast::Info>,
 	state: kio::Producer<TrackState>,
 
 	// The previous subscription that was combined, used to detect changes.
@@ -1491,14 +1494,14 @@ pub struct TrackRequest {
 	// birth: a consumer's cache-miss `fetch_group` waits to be served instead of
 	// racing the producer (e.g. a relay) into creating its own handler. Released
 	// when the request is accepted or dropped; by then the relay holds its own.
-	_dynamic: TrackDynamic,
+	_dynamic: Dynamic,
 }
 
-impl TrackRequest {
-	pub(crate) fn new(broadcast: Arc<BroadcastInfo>, name: impl Into<Arc<str>>) -> Self {
+impl Request {
+	pub(crate) fn new(broadcast: Arc<broadcast::Info>, name: impl Into<Arc<str>>) -> Self {
 		let name = name.into();
 		let state = kio::Producer::<TrackState>::default();
-		let dynamic = TrackDynamic::new(name.clone(), state.clone());
+		let dynamic = Dynamic::new(name.clone(), state.clone());
 		Self {
 			name,
 			broadcast,
@@ -1513,18 +1516,18 @@ impl TrackRequest {
 		&self.name
 	}
 
-	pub fn consume(&self) -> TrackConsumer {
-		TrackConsumer {
+	pub fn consume(&self) -> Consumer {
+		Consumer {
 			name: self.name.clone(),
 			state: self.state.consume(),
 		}
 	}
 
-	/// Create a [`TrackDynamic`] handle that serves on-demand fetches of uncached
+	/// Create a [`Dynamic`] handle that serves on-demand fetches of uncached
 	/// groups, before [`Self::accept`] is even called. A relay creates one to fetch
 	/// past groups from upstream while (or instead of) serving a live subscription.
-	pub fn dynamic(&self) -> TrackDynamic {
-		TrackDynamic::new(self.name.clone(), self.state.clone())
+	pub fn dynamic(&self) -> Dynamic {
+		Dynamic::new(self.name.clone(), self.state.clone())
 	}
 
 	/// Poll for the request becoming unused (every consumer dropped), so a relay can
@@ -1537,9 +1540,9 @@ impl TrackRequest {
 	///
 	/// The track's name must match [`Self::name`]. Returns [`Error::NotFound`] on
 	/// mismatch, or the broadcast's abort error if it closed while pending.
-	pub fn accept(self, info: impl Into<Option<TrackInfo>>) -> TrackProducer {
+	pub fn accept(self, info: impl Into<Option<Info>>) -> Producer {
 		self.state.write().ok().unwrap().info = Some(info.into().unwrap_or_default());
-		TrackProducer {
+		Producer {
 			name: self.name,
 			broadcast: self.broadcast,
 			state: self.state,
@@ -1583,7 +1586,7 @@ impl TrackRequest {
 			}
 		})) {
 			Ok(state) => state,
-			Err(_) => unreachable!("a TrackRequest holds the only producer"),
+			Err(_) => unreachable!("a Request holds the only producer"),
 		};
 		// The aggregate changed: prune any closed subscribers now that we hold the lock.
 		state.subscriptions.retain(|sub| !sub.is_closed());
@@ -1604,8 +1607,8 @@ impl TrackRequest {
 use futures::FutureExt;
 
 #[cfg(test)]
-impl TrackSubscriber {
-	pub fn assert_group(&mut self) -> GroupConsumer {
+impl Subscriber {
+	pub fn assert_group(&mut self) -> group::Consumer {
 		self.recv_group()
 			.now_or_never()
 			.expect("group would have blocked")
@@ -1650,9 +1653,9 @@ mod test {
 	use super::*;
 
 	/// Mint a track for tests with a default parent broadcast, since tracks are
-	/// normally born from a [`crate::BroadcastProducer`].
-	fn track_producer(name: impl Into<Arc<str>>, info: impl Into<Option<TrackInfo>>) -> TrackProducer {
-		TrackProducer::new(Arc::new(BroadcastInfo::default()), name, info)
+	/// normally born from a [`broadcast::Producer`].
+	fn track_producer(name: impl Into<Arc<str>>, info: impl Into<Option<Info>>) -> Producer {
+		Producer::new(Arc::new(broadcast::Info::default()), name, info)
 	}
 
 	/// Helper: count non-tombstoned groups in state.
@@ -1761,7 +1764,7 @@ mod test {
 		tokio::time::pause();
 
 		// A shorter cache evicts sooner than the default.
-		let mut producer = track_producer("test", TrackInfo::default().with_cache(Duration::from_secs(1)));
+		let mut producer = track_producer("test", Info::default().with_cache(Duration::from_secs(1)));
 		producer.append_group().unwrap(); // seq 0
 
 		// Past the custom cache but well within DEFAULT_CACHE.
@@ -1776,7 +1779,7 @@ mod test {
 
 	#[test]
 	fn stale_clamped_to_cache() {
-		let producer = track_producer("test", TrackInfo::default().with_cache(Duration::from_secs(2)));
+		let producer = track_producer("test", Info::default().with_cache(Duration::from_secs(2)));
 
 		// A stale window beyond the cache is capped to the cache; a group can't be
 		// waited for longer than the publisher keeps it.
@@ -1798,9 +1801,9 @@ mod test {
 		let mut producer = track_producer("test", None);
 
 		// Arrive out of order: seq 5 first, then 3, then 4.
-		producer.create_group(GroupInfo { sequence: 5 }).unwrap();
-		producer.create_group(GroupInfo { sequence: 3 }).unwrap();
-		producer.create_group(GroupInfo { sequence: 4 }).unwrap();
+		producer.create_group(group::Info { sequence: 5 }).unwrap();
+		producer.create_group(group::Info { sequence: 3 }).unwrap();
+		producer.create_group(group::Info { sequence: 4 }).unwrap();
 
 		// max_sequence = 5, which is at the front of the VecDeque.
 		{
@@ -1834,12 +1837,12 @@ mod test {
 		let mut producer = track_producer("test", None);
 
 		// Arrive: seq 5, then seq 3.
-		producer.create_group(GroupInfo { sequence: 5 }).unwrap();
+		producer.create_group(group::Info { sequence: 5 }).unwrap();
 
 		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
 
 		// Seq 3 arrives late; max_sequence is still 5 (at front).
-		producer.create_group(GroupInfo { sequence: 3 }).unwrap();
+		producer.create_group(group::Info { sequence: 3 }).unwrap();
 
 		// Seq 5 is max_sequence (protected). Seq 3 is not expired (just created).
 		// Nothing should be evicted.
@@ -1853,7 +1856,7 @@ mod test {
 		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
 
 		// Seq 2 arrives late, triggering eviction.
-		producer.create_group(GroupInfo { sequence: 2 }).unwrap();
+		producer.create_group(group::Info { sequence: 2 }).unwrap();
 
 		// Seq 5 is still max_sequence (protected, at front, blocks trim).
 		// Seq 3 is expired → tombstoned.
@@ -1954,7 +1957,7 @@ mod test {
 	#[test]
 	fn insert_finish_validates_sequence_and_freezes_to_max() {
 		let mut producer = track_producer("test", None);
-		producer.create_group(GroupInfo { sequence: 5 }).unwrap();
+		producer.create_group(group::Info { sequence: 5 }).unwrap();
 
 		assert!(producer.finish_at(4).is_err());
 		assert!(producer.finish_at(10).is_err());
@@ -1966,14 +1969,14 @@ mod test {
 		}
 
 		assert!(producer.finish_at(5).is_err());
-		assert!(producer.create_group(GroupInfo { sequence: 4 }).is_ok());
-		assert!(producer.create_group(GroupInfo { sequence: 5 }).is_err());
+		assert!(producer.create_group(group::Info { sequence: 4 }).is_ok());
+		assert!(producer.create_group(group::Info { sequence: 5 }).is_err());
 	}
 
 	#[tokio::test]
 	async fn recv_group_finishes_without_waiting_for_gaps() {
 		let mut producer = track_producer("test", None);
-		producer.create_group(GroupInfo { sequence: 1 }).unwrap();
+		producer.create_group(group::Info { sequence: 1 }).unwrap();
 		producer.finish_at(1).unwrap();
 
 		let mut consumer = producer.subscribe(None);
@@ -1993,7 +1996,7 @@ mod test {
 		let mut consumer = producer.subscribe(None);
 
 		// Seq 5 arrives first.
-		producer.create_group(GroupInfo { sequence: 5 }).unwrap();
+		producer.create_group(group::Info { sequence: 5 }).unwrap();
 		let group = consumer
 			.next_group()
 			.now_or_never()
@@ -2003,11 +2006,11 @@ mod test {
 		assert_eq!(group.sequence, 5);
 
 		// Seq 3 arrives late — skipped because 3 <= 5.
-		producer.create_group(GroupInfo { sequence: 3 }).unwrap();
+		producer.create_group(group::Info { sequence: 3 }).unwrap();
 		// Seq 4 arrives late — also skipped.
-		producer.create_group(GroupInfo { sequence: 4 }).unwrap();
+		producer.create_group(group::Info { sequence: 4 }).unwrap();
 		// Seq 7 arrives — returned.
-		producer.create_group(GroupInfo { sequence: 7 }).unwrap();
+		producer.create_group(group::Info { sequence: 7 }).unwrap();
 
 		let group = consumer
 			.next_group()
@@ -2030,8 +2033,8 @@ mod test {
 		let mut consumer = producer.subscribe(None);
 
 		// Seq 3 arrives first, then seq 5 — both should be returned in arrival order.
-		producer.create_group(GroupInfo { sequence: 3 }).unwrap();
-		producer.create_group(GroupInfo { sequence: 5 }).unwrap();
+		producer.create_group(group::Info { sequence: 3 }).unwrap();
+		producer.create_group(group::Info { sequence: 5 }).unwrap();
 
 		let group = consumer
 			.next_group()
@@ -2056,8 +2059,8 @@ mod test {
 		let mut consumer = producer.subscribe(None);
 
 		// Out-of-order arrivals: seq 5 first, then seq 3.
-		producer.create_group(GroupInfo { sequence: 5 }).unwrap();
-		producer.create_group(GroupInfo { sequence: 3 }).unwrap();
+		producer.create_group(group::Info { sequence: 5 }).unwrap();
+		producer.create_group(group::Info { sequence: 3 }).unwrap();
 
 		// next_group is sequence-ordered: it returns the smallest sequence first,
 		// regardless of arrival order.
@@ -2080,7 +2083,7 @@ mod test {
 		let mut consumer = producer.subscribe(None);
 
 		for s in 0..6 {
-			producer.create_group(GroupInfo { sequence: s }).unwrap();
+			producer.create_group(group::Info { sequence: s }).unwrap();
 		}
 
 		consumer.end_at(2);
@@ -2112,7 +2115,7 @@ mod test {
 		let mut consumer = producer.subscribe(None);
 
 		for s in 0..6 {
-			producer.create_group(GroupInfo { sequence: s }).unwrap();
+			producer.create_group(group::Info { sequence: s }).unwrap();
 		}
 
 		consumer.end_at(1);
@@ -2157,7 +2160,7 @@ mod test {
 		let mut consumer = producer.subscribe(None);
 
 		for s in 0..3 {
-			producer.create_group(GroupInfo { sequence: s }).unwrap();
+			producer.create_group(group::Info { sequence: s }).unwrap();
 		}
 
 		// Drain everything with no cap.
@@ -2176,8 +2179,8 @@ mod test {
 
 		// Lower the cap below the cursor. New groups beyond the cap are blocked.
 		consumer.end_at(1);
-		producer.create_group(GroupInfo { sequence: 3 }).unwrap();
-		producer.create_group(GroupInfo { sequence: 4 }).unwrap();
+		producer.create_group(group::Info { sequence: 3 }).unwrap();
+		producer.create_group(group::Info { sequence: 4 }).unwrap();
 		assert!(
 			consumer.next_group().now_or_never().is_none(),
 			"cap is below cursor; nothing returnable until cap rises"
@@ -2203,12 +2206,12 @@ mod test {
 		consumer.end_at(5);
 
 		// Out-of-order arrivals all within the cap.
-		producer.create_group(GroupInfo { sequence: 2 }).unwrap();
-		producer.create_group(GroupInfo { sequence: 5 }).unwrap();
-		producer.create_group(GroupInfo { sequence: 3 }).unwrap();
+		producer.create_group(group::Info { sequence: 2 }).unwrap();
+		producer.create_group(group::Info { sequence: 5 }).unwrap();
+		producer.create_group(group::Info { sequence: 3 }).unwrap();
 		// One beyond the cap; should be held even though it arrived in the middle.
-		producer.create_group(GroupInfo { sequence: 8 }).unwrap();
-		producer.create_group(GroupInfo { sequence: 4 }).unwrap();
+		producer.create_group(group::Info { sequence: 8 }).unwrap();
+		producer.create_group(group::Info { sequence: 4 }).unwrap();
 
 		// next_group walks in sequence order through everything <= cap.
 		assert_eq!(
@@ -2269,9 +2272,9 @@ mod test {
 		let mut consumer = producer.subscribe(None);
 
 		// Seq 3: group open, no frame yet (stalled).
-		let _stalled = producer.create_group(GroupInfo { sequence: 3 }).unwrap();
+		let _stalled = producer.create_group(group::Info { sequence: 3 }).unwrap();
 		// Seq 5: fully-written group with a frame.
-		let mut g5 = producer.create_group(GroupInfo { sequence: 5 }).unwrap();
+		let mut g5 = producer.create_group(group::Info { sequence: 5 }).unwrap();
 		g5.write_frame_now(bytes::Bytes::from_static(b"later")).unwrap();
 		g5.finish().unwrap();
 
@@ -2291,7 +2294,7 @@ mod test {
 		let mut consumer = producer.subscribe(None);
 
 		// Group 0 has two frames; only the first is returned.
-		let mut g0 = producer.create_group(GroupInfo { sequence: 0 }).unwrap();
+		let mut g0 = producer.create_group(group::Info { sequence: 0 }).unwrap();
 		g0.write_frame_now(bytes::Bytes::from_static(b"one")).unwrap();
 		g0.write_frame_now(bytes::Bytes::from_static(b"two")).unwrap();
 		g0.finish().unwrap();
@@ -2324,7 +2327,7 @@ mod test {
 		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
-		let mut g0 = producer.create_group(GroupInfo { sequence: 0 }).unwrap();
+		let mut g0 = producer.create_group(group::Info { sequence: 0 }).unwrap();
 		producer.finish().unwrap();
 
 		// Track is finished but group 0 has no frame yet — must block, not return None.
@@ -2353,11 +2356,11 @@ mod test {
 		consumer.start_at(5);
 
 		// Seq 3 has a frame but is below min_sequence — must be skipped.
-		let mut g3 = producer.create_group(GroupInfo { sequence: 3 }).unwrap();
+		let mut g3 = producer.create_group(group::Info { sequence: 3 }).unwrap();
 		g3.write_frame_now(bytes::Bytes::from_static(b"skip-me")).unwrap();
 		g3.finish().unwrap();
 
-		let mut g5 = producer.create_group(GroupInfo { sequence: 5 }).unwrap();
+		let mut g5 = producer.create_group(group::Info { sequence: 5 }).unwrap();
 		g5.write_frame_now(bytes::Bytes::from_static(b"keep")).unwrap();
 		g5.finish().unwrap();
 
@@ -2397,7 +2400,7 @@ mod test {
 	#[tokio::test]
 	async fn get_group_finishes_without_waiting_for_gaps() {
 		let mut producer = track_producer("test", None);
-		producer.create_group(GroupInfo { sequence: 1 }).unwrap();
+		producer.create_group(group::Info { sequence: 1 }).unwrap();
 		producer.finish_at(1).unwrap();
 
 		let consumer = producer.subscribe(None);
@@ -2458,9 +2461,9 @@ mod test {
 
 		// A cache miss isn't in `get_group`, but a dynamic handler exists, so
 		// `fetch_group` stays pending and queues a request. `*pending` derefs the
-		// wrapper to the inner `TrackFetch` (a `kio::Future`).
+		// wrapper to the inner `Fetch` (a `kio::Future`).
 		assert!(consumer.get_group(5).is_none());
-		let pending = consumer.fetch_group(5, Fetch::default().with_priority(7));
+		let pending = consumer.fetch_group(5, group::Fetch::default().with_priority(7));
 		assert!(kio::Future::poll(&*pending, &kio::Waiter::noop()).is_pending());
 
 		let req = dynamic
@@ -2547,7 +2550,7 @@ mod test {
 
 	#[tokio::test]
 	async fn fetch_miss_no_dynamic_not_found() {
-		// A track with no `TrackDynamic` can't serve old content, so a cache miss
+		// A track with no `Dynamic` can't serve old content, so a cache miss
 		// resolves to NotFound instead of blocking forever.
 		let mut producer = track_producer("test", None);
 		producer.append_group().unwrap(); // seq 0, but we miss on seq 5

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1,6 +1,7 @@
+use crate::origin;
 use crate::{
 	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Consume,
-	Error, NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
+	Error, NEGOTIATED, Session, StatsHandle, Version, Versions,
 	coding::{Decode, Encode, Reader, Stream},
 	ietf, lite, setup,
 };
@@ -8,8 +9,8 @@ use crate::{
 /// A MoQ server session builder.
 #[derive(Default, Clone)]
 pub struct Server {
-	publish: Option<OriginConsumer>,
-	subscribe: Option<OriginProducer>,
+	publish: Option<origin::Consumer>,
+	subscribe: Option<origin::Producer>,
 	stats: StatsHandle,
 	versions: Versions,
 }
@@ -20,30 +21,30 @@ impl Server {
 	}
 
 	/// Publish to the connected client: the session reads from the given origin
-	/// (pass an [`OriginProducer`] or [`OriginConsumer`] by reference) and forwards
+	/// (pass an [`origin::Producer`] or [`origin::Consumer`] by reference) and forwards
 	/// its announcements. Omit to publish nothing. Pre-scoped via
-	/// [`OriginProducer::scope`] for token-gated relays.
-	pub fn with_publisher(mut self, publish: impl Consume<OriginConsumer>) -> Self {
+	/// [`origin::Producer::scope`] for token-gated relays.
+	pub fn with_publisher(mut self, publish: impl Consume<origin::Consumer>) -> Self {
 		self.publish = Some(publish.consume());
 		self
 	}
 
 	/// Subscribe to the connected client: the session writes the broadcasts the
-	/// client announces into this [`OriginProducer`]. Omit to subscribe to nothing.
-	pub fn with_subscriber(mut self, subscribe: OriginProducer) -> Self {
+	/// client announces into this [`origin::Producer`]. Omit to subscribe to nothing.
+	pub fn with_subscriber(mut self, subscribe: origin::Producer) -> Self {
 		self.subscribe = Some(subscribe);
 		self
 	}
 
 	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_publisher`")]
-	pub fn with_publish(self, publish: OriginConsumer) -> Self {
+	pub fn with_publish(self, publish: origin::Consumer) -> Self {
 		self.with_publisher(publish)
 	}
 
 	#[doc(hidden)]
 	#[deprecated(note = "renamed to `with_subscriber`")]
-	pub fn with_consume(self, subscribe: OriginProducer) -> Self {
+	pub fn with_consume(self, subscribe: origin::Producer) -> Self {
 		self.with_subscriber(subscribe)
 	}
 
@@ -55,8 +56,8 @@ impl Server {
 		self
 	}
 
-	/// Set both publish and subscribe from one shared [`OriginProducer`].
-	pub fn with_origin(self, origin: OriginProducer) -> Self {
+	/// Set both publish and subscribe from one shared [`origin::Producer`].
+	pub fn with_origin(self, origin: origin::Producer) -> Self {
 		self.with_publisher(&origin).with_subscriber(origin)
 	}
 
@@ -283,13 +284,13 @@ impl<S: web_transport_trait::Session> Request<S> {
 
 	/// Publish to the connected client. Overrides any value from the [`Server`]
 	/// builder; typically set after inspecting [`path`](Self::path).
-	pub fn with_publisher(mut self, publish: impl Consume<OriginConsumer>) -> Self {
+	pub fn with_publisher(mut self, publish: impl Consume<origin::Consumer>) -> Self {
 		self.server.publish = Some(publish.consume());
 		self
 	}
 
 	/// Subscribe to the connected client. Overrides any value from the [`Server`] builder.
-	pub fn with_subscriber(mut self, subscribe: OriginProducer) -> Self {
+	pub fn with_subscriber(mut self, subscribe: origin::Producer) -> Self {
 		self.server.subscribe = Some(subscribe);
 		self
 	}

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -131,6 +131,7 @@
 //! the feedback loop where serving a `<top-prefix>/...` broadcast would
 //! itself generate more stats traffic.
 
+use crate::{broadcast, origin, track};
 use std::{
 	collections::{BTreeMap, HashMap},
 	fmt,
@@ -144,7 +145,7 @@ use std::{
 use serde::Serialize;
 use web_async::{Lock, spawn};
 
-use crate::{AsPath, BroadcastInfo, BroadcastProducer, OriginProducer, Path, PathOwned, TrackProducer};
+use crate::{AsPath, Path, PathOwned};
 
 /// Cumulative atomic counters for a single `(tier, role)` on a broadcast.
 ///
@@ -313,7 +314,7 @@ impl fmt::Display for Tier {
 pub struct StatsConfig {
 	/// Origin that receives the stats broadcast's `publish_broadcast` calls.
 	/// When `None`, [`Stats::new`] spawns no task and publishes nothing.
-	pub origin: Option<OriginProducer>,
+	pub origin: Option<origin::Producer>,
 	/// Top-level path stats are published under (default `.stats`). The full
 	/// advertised path is `<prefix>/node/<node>` (or `<prefix>/node` when
 	/// `node` is unset).
@@ -343,7 +344,7 @@ impl StatsConfig {
 
 	/// Set the origin to publish the stats broadcast on. Without this the
 	/// aggregator is a no-op.
-	pub fn with_origin(mut self, origin: impl Into<Option<OriginProducer>>) -> Self {
+	pub fn with_origin(mut self, origin: impl Into<Option<origin::Producer>>) -> Self {
 		self.origin = origin.into();
 		self
 	}
@@ -387,7 +388,7 @@ pub struct Stats {
 /// Runtime state shared by every clone of a [`Stats`] and held by the
 /// snapshot task through a `Weak`. Only allocated when an origin is set.
 struct StatsShared {
-	origin: OriginProducer,
+	origin: origin::Producer,
 	entries: Lock<HashMap<PathOwned, Arc<BroadcastEntry>>>,
 	/// Connected-session gauges keyed by `(tier, auth root)`. Independent of any
 	/// broadcast; surfaced on the per-tier session tracks. A tier's inner map is
@@ -1064,7 +1065,7 @@ fn process_session_slot(
 /// Serialize `frame` and write it to `track` unless it's byte-identical to
 /// `last` (idle-frame skipping). On success `last` is updated; on a serialize
 /// or write error it's left untouched so the next tick retries.
-fn flush_track<T: Serialize>(track: &mut TrackProducer, frame: &T, last: &mut Vec<u8>, name: &str) {
+fn flush_track<T: Serialize>(track: &mut track::Producer, frame: &T, last: &mut Vec<u8>, name: &str) {
 	let json = match serde_json::to_vec(frame) {
 		Ok(b) => b,
 		Err(err) => {
@@ -1096,8 +1097,8 @@ type TierSessions = (Tier, Vec<(PathOwned, Arc<SessionCounters>)>);
 /// frame for late subscribers. New tier tracks appear lazily the first tick
 /// traffic routes to their label.
 fn flush_dynamic<T: Serialize>(
-	broadcast: &mut BroadcastProducer,
-	tracks: &mut HashMap<String, TrackProducer>,
+	broadcast: &mut broadcast::Producer,
+	tracks: &mut HashMap<String, track::Producer>,
 	last: &mut HashMap<String, Vec<u8>>,
 	frames: &HashMap<String, BTreeMap<String, T>>,
 ) {
@@ -1128,13 +1129,13 @@ async fn run_publisher(weak: Weak<StatsShared>, advertised: PathOwned, interval:
 		return;
 	};
 
-	let mut broadcast = BroadcastInfo::new().produce();
+	let mut broadcast = broadcast::Info::new().produce();
 
 	// Pre-create the default tier's tracks so they always exist and emit `{}`
 	// while idle. Named-tier tracks are created lazily (see `flush_dynamic`) the
 	// first tick traffic routes to that label.
-	let mut broadcast_tracks: HashMap<String, TrackProducer> = HashMap::new();
-	let mut session_tracks: HashMap<String, TrackProducer> = HashMap::new();
+	let mut broadcast_tracks: HashMap<String, track::Producer> = HashMap::new();
+	let mut session_tracks: HashMap<String, track::Producer> = HashMap::new();
 	for name in [PUBLISHER_TRACK, SUBSCRIBER_TRACK] {
 		match broadcast.create_track(name, None) {
 			Ok(track) => {
@@ -1384,7 +1385,7 @@ mod tests {
 			.is_some_and(|roots| roots.contains_key(&PathOwned::from(root.to_string())))
 	}
 
-	fn test_stats(node: Option<&str>) -> (Stats, OriginProducer) {
+	fn test_stats(node: Option<&str>) -> (Stats, origin::Producer) {
 		let origin = Origin::random().produce();
 		let stats = Stats::new(
 			StatsConfig::new()
@@ -1991,12 +1992,12 @@ mod tests {
 		assert!(closed_pos < open_pos, "sessions_closed must be loaded before sessions",);
 	}
 
-	async fn read_frame(mut track: crate::TrackSubscriber) -> BTreeMap<String, Snapshot> {
+	async fn read_frame(mut track: track::Subscriber) -> BTreeMap<String, Snapshot> {
 		let bytes = track.read_frame().await.expect("ok").expect("frame");
 		serde_json::from_slice(&bytes).expect("json parse")
 	}
 
-	async fn read_session_frame(mut track: crate::TrackSubscriber) -> BTreeMap<String, SessionSnapshot> {
+	async fn read_session_frame(mut track: track::Subscriber) -> BTreeMap<String, SessionSnapshot> {
 		let bytes = track.read_frame().await.expect("ok").expect("frame");
 		serde_json::from_slice(&bytes).expect("json parse")
 	}

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -6,7 +6,8 @@ use std::{
 };
 
 use anyhow::Context;
-use moq_net::{BroadcastPublish, Origin, OriginProducer, Path, Stats, Tier};
+use moq_net::origin;
+use moq_net::{Origin, Path, Stats, Tier};
 use reqwest_middleware::ClientWithMiddleware;
 use tokio::task::AbortHandle;
 use url::Url;
@@ -322,11 +323,11 @@ pub struct ClusterConfig {
 	pub tier: Option<String>,
 }
 
-/// A relay cluster built around a single [`OriginProducer`].
+/// A relay cluster built around a single [`origin::Producer`].
 ///
 /// Local sessions and remote cluster connections all publish into the same
 /// origin. Loop prevention and shortest-path preference come from the
-/// hop list carried on each broadcast (see [`moq_net::BroadcastInfo::hops`]).
+/// hop list carried on each broadcast (see [`moq_net::broadcast::Info::hops`]).
 ///
 /// Construct with [`Cluster::new`], then attach a QUIC client and (optionally)
 /// a [`Stats`] aggregator with the `with_*` builder methods. A cluster without
@@ -343,7 +344,7 @@ pub struct Cluster {
 
 	/// All broadcasts, local and remote. Downstream sessions read from here
 	/// (filtered by their auth token) and remote dials both read and write here.
-	pub origin: OriginProducer,
+	pub origin: origin::Producer,
 
 	/// Stats aggregator. One instance per relay; sessions pick a billing tier via
 	/// [`Stats::tier`] at acceptance time (default tier for JWT/public, `internal`
@@ -416,16 +417,16 @@ impl Cluster {
 		crate::trusted_tier(self.config.tier.clone())
 	}
 
-	/// Returns an [`OriginProducer`] scoped to this session's subscribe permissions.
+	/// Returns an [`origin::Producer`] scoped to this session's subscribe permissions.
 	///
 	/// Passed by reference to [`moq_net::Server::with_publisher`] (or the
 	/// equivalent per-request setter), which derives the read handle.
-	pub fn subscriber(&self, token: &AuthToken) -> Option<OriginProducer> {
+	pub fn subscriber(&self, token: &AuthToken) -> Option<origin::Producer> {
 		self.origin.with_root(&token.root)?.scope(&token.subscribe)
 	}
 
-	/// Returns an [`OriginProducer`] scoped to this session's publish permissions.
-	pub fn publisher(&self, token: &AuthToken) -> Option<OriginProducer> {
+	/// Returns an [`origin::Producer`] scoped to this session's publish permissions.
+	pub fn publisher(&self, token: &AuthToken) -> Option<origin::Producer> {
 		self.origin.with_root(&token.root)?.scope(&token.publish)
 	}
 
@@ -554,7 +555,7 @@ impl Cluster {
 		// Held in scope so the registration stays announced until `run` exits.
 		// Discovery is paired with it: a gossip-only relay (passive rendezvous) has
 		// nothing to discover, so we only run it when we also have an outbound peer.
-		let _self_registration: Option<BroadcastPublish> = if gossip {
+		let _self_registration: Option<origin::Broadcast> = if gossip {
 			// Checked above: gossip requires `node`.
 			let node = node.as_deref().expect("gossip requires --cluster-node");
 			let path = Path::new(MESH_PREFIX).join(node);
@@ -595,7 +596,7 @@ impl Cluster {
 	/// instead of two. Unannounces don't abort immediately. They just mark the
 	/// entry as "pending cleanup" with a timestamp. A periodic sweep evicts
 	/// entries whose unannounce has stuck for [`STALE_AFTER`]. The "prefer
-	/// shorter hop" path in OriginProducer delivers re-announces as
+	/// shorter hop" path in origin::Producer delivers re-announces as
 	/// unannounce-then-announce within sub-milliseconds, which clears the
 	/// pending-cleanup timestamp long before the sweep fires.
 	async fn run_discovery(self, self_url: String, token: String, dialed: DialMap) {

--- a/rs/moq-relay/src/stats.rs
+++ b/rs/moq-relay/src/stats.rs
@@ -6,7 +6,8 @@
 use std::time::Duration;
 
 use clap::Args;
-use moq_net::{OriginProducer, PathOwned, Stats};
+use moq_net::origin;
+use moq_net::{PathOwned, Stats};
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the relay's stats publishing.
@@ -70,7 +71,7 @@ impl StatsConfig {
 	///
 	/// Returns a no-op aggregator ([`Stats::default`]) when [`Self::enabled`]
 	/// is false, so the relay can attach the result unconditionally.
-	pub fn build(&self, origin: OriginProducer) -> Stats {
+	pub fn build(&self, origin: origin::Producer) -> Stats {
 		if !self.enabled.unwrap_or(false) {
 			return Stats::default();
 		}

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -627,8 +627,8 @@ async fn serve_fetch(
 }
 
 struct ServeGroup {
-	group: Option<moq_net::GroupConsumer>,
-	frame: Option<moq_net::FrameConsumer>,
+	group: Option<moq_net::group::Consumer>,
+	frame: Option<moq_net::frame::Consumer>,
 	deadline: tokio::time::Instant,
 }
 

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -14,7 +14,8 @@ use axum::{
 	http::StatusCode,
 	response::Response,
 };
-use moq_net::{OriginProducer, StatsHandle};
+use moq_net::StatsHandle;
+use moq_net::origin;
 
 use crate::{AuthParams, web::AuthQuery, web::MtlsPeer, web::WebState, web::landing_response};
 
@@ -83,8 +84,8 @@ async fn handle_socket<T>(
 	_id: u64,
 	socket: T,
 	alpn: Option<String>,
-	publish: Option<OriginProducer>,
-	subscribe: Option<OriginProducer>,
+	publish: Option<origin::Producer>,
+	subscribe: Option<origin::Producer>,
 	stats: StatsHandle,
 ) -> anyhow::Result<()>
 where

--- a/rs/moq-rtc/src/client/mod.rs
+++ b/rs/moq-rtc/src/client/mod.rs
@@ -51,13 +51,13 @@ impl Client {
 	/// `client subscribe`: pull a remote WHEP feed and publish it as
 	/// `broadcast` on the local origin. Returns once the session is
 	/// running in the background.
-	pub async fn subscribe(&self, url: Url, broadcast: moq_net::BroadcastProducer) -> crate::Result<()> {
+	pub async fn subscribe(&self, url: Url, broadcast: moq_net::broadcast::Producer) -> crate::Result<()> {
 		whep::dial(self, url, broadcast).await
 	}
 
 	/// `client publish`: pull a local broadcast and push it to a remote
 	/// WHIP endpoint. Gated on the per-codec re-packetizer.
-	pub async fn publish(&self, url: Url, broadcast: moq_net::BroadcastConsumer) -> crate::Result<()> {
+	pub async fn publish(&self, url: Url, broadcast: moq_net::broadcast::Consumer) -> crate::Result<()> {
 		whip::dial(self, url, broadcast).await
 	}
 }

--- a/rs/moq-rtc/src/client/whep.rs
+++ b/rs/moq-rtc/src/client/whep.rs
@@ -18,7 +18,7 @@ use url::Url;
 
 use crate::{Error, Result, client::Client, ingest::IngestSink, session};
 
-pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::BroadcastProducer) -> Result<()> {
+pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::broadcast::Producer) -> Result<()> {
 	let sink = Box::new(IngestSink::new(broadcast)?);
 
 	let (socket, candidates) = session::bind_udp(&client.config().ice_candidates).await?;

--- a/rs/moq-rtc/src/client/whip.rs
+++ b/rs/moq-rtc/src/client/whip.rs
@@ -16,7 +16,7 @@ use url::Url;
 
 use crate::{Error, Result, client::Client, egress::EgressSource, session};
 
-pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::BroadcastConsumer) -> Result<()> {
+pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::broadcast::Consumer) -> Result<()> {
 	let source = EgressSource::new(broadcast).await?;
 	let codecs = source.catalog_codecs();
 	if codecs.is_empty() {

--- a/rs/moq-rtc/src/codec/h264.rs
+++ b/rs/moq-rtc/src/codec/h264.rs
@@ -13,7 +13,7 @@ pub struct Bridge {
 }
 
 impl Bridge {
-	pub fn new(mut broadcast: moq_net::BroadcastProducer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
+	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
 		let track = moq_mux::import::unique_track(&mut broadcast, ".avc3")?;
 		let import = moq_mux::codec::h264::Import::new(track, catalog);
 		let split = moq_mux::codec::h264::Split::new();

--- a/rs/moq-rtc/src/codec/mod.rs
+++ b/rs/moq-rtc/src/codec/mod.rs
@@ -80,7 +80,7 @@ enum TrackConvert {
 
 impl Track {
 	/// Audio track for an Opus rendition.
-	pub async fn opus(broadcast: &moq_net::BroadcastConsumer, name: &str) -> Result<Self> {
+	pub async fn opus(broadcast: &moq_net::broadcast::Consumer, name: &str) -> Result<Self> {
 		let container = moq_mux::catalog::hang::Container::Legacy;
 		// `None` subscription => start at the latest (in-progress) group. Groups
 		// begin at a keyframe, so a late joiner gets a decodable start immediately
@@ -97,7 +97,7 @@ impl Track {
 	/// Video track. Codec inferred from `config.codec`; for H.264 / H.265 the
 	/// bitstream shape (inline vs out-of-band parameter sets) is inferred from
 	/// `config.description` (avc1/hvc1 vs avc3/hev1).
-	pub async fn video(broadcast: &moq_net::BroadcastConsumer, name: &str, config: &VideoConfig) -> Result<Self> {
+	pub async fn video(broadcast: &moq_net::broadcast::Consumer, name: &str, config: &VideoConfig) -> Result<Self> {
 		let container: moq_mux::catalog::hang::Container = (&config.container).try_into()?;
 		// `None` subscription => start at the latest (in-progress) group, which
 		// begins at a keyframe, so a late-joining peer gets a decodable start.

--- a/rs/moq-rtc/src/codec/opus.rs
+++ b/rs/moq-rtc/src/codec/opus.rs
@@ -11,7 +11,7 @@ pub struct Bridge {
 
 impl Bridge {
 	pub fn new(
-		mut broadcast: moq_net::BroadcastProducer,
+		mut broadcast: moq_net::broadcast::Producer,
 		catalog: moq_mux::catalog::Producer,
 		sample_rate: u32,
 		channel_count: u32,

--- a/rs/moq-rtc/src/codec/vp8.rs
+++ b/rs/moq-rtc/src/codec/vp8.rs
@@ -15,10 +15,10 @@ pub struct Bridge {
 
 impl Bridge {
 	/// Publish a `.vp8` track on `broadcast`; the catalog rendition is added on the first frame.
-	pub fn new(mut broadcast: moq_net::BroadcastProducer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
+	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
 		let track = broadcast.create_track(
 			broadcast.unique_name(".vp8"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)?;
 		let producer = moq_mux::container::Producer::new(track, moq_mux::catalog::hang::Container::Legacy);
 		Ok(Self {

--- a/rs/moq-rtc/src/codec/vp9.rs
+++ b/rs/moq-rtc/src/codec/vp9.rs
@@ -14,10 +14,10 @@ pub struct Bridge {
 
 impl Bridge {
 	/// Publish a `.vp9` track on `broadcast`; the catalog rendition is added on the first frame.
-	pub fn new(mut broadcast: moq_net::BroadcastProducer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
+	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
 		let track = broadcast.create_track(
 			broadcast.unique_name(".vp9"),
-			moq_net::TrackInfo::default().with_timescale(hang::container::TIMESCALE),
+			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)?;
 		let producer = moq_mux::container::Producer::new(track, moq_mux::catalog::hang::Container::Legacy);
 		Ok(Self {

--- a/rs/moq-rtc/src/egress.rs
+++ b/rs/moq-rtc/src/egress.rs
@@ -1,7 +1,7 @@
 //! Per-broadcast egress source for the RTP-out paths.
 //!
 //! Counterpart to [`crate::ingest::IngestSink`]. Holds a
-//! [`moq_net::BroadcastConsumer`] and a cached catalog snapshot; on each
+//! [`moq_net::broadcast::Consumer`] and a cached catalog snapshot; on each
 //! `MediaAdded` event the session loop calls [`EgressSource::on_track`]
 //! which picks a matching rendition, subscribes to it, and spawns a pump
 //! task that feeds RTP-ready frames back to the session loop via an mpsc
@@ -35,7 +35,7 @@ pub struct WriteRequest {
 
 /// Holds the broadcast + catalog and spawns per-rendition pump tasks.
 pub struct EgressSource {
-	broadcast: moq_net::BroadcastConsumer,
+	broadcast: moq_net::broadcast::Consumer,
 	/// Snapshot of the catalog at session start. Sufficient for v1: SDP
 	/// negotiation happens once and the codec list is fixed for the
 	/// lifetime of the session.
@@ -50,7 +50,7 @@ impl EgressSource {
 	/// The session loop drives the pumps via the returned channel; the
 	/// caller hands `EgressSource` to [`Session::egress`](crate::session::Session::egress)
 	/// which takes the receiver via [`Self::take_writes`].
-	pub async fn new(broadcast: moq_net::BroadcastConsumer) -> Result<Self> {
+	pub async fn new(broadcast: moq_net::broadcast::Consumer) -> Result<Self> {
 		let catalog_track = broadcast
 			.track(hang::Catalog::DEFAULT_NAME)?
 			.subscribe(hang::Catalog::default_subscription())
@@ -141,7 +141,7 @@ impl EgressSource {
 /// Find the first catalog rendition for the given codec and build a
 /// [`codec::Track`] subscribed to it. Returns `None` if no rendition matches.
 async fn pick_track(
-	broadcast: &moq_net::BroadcastConsumer,
+	broadcast: &moq_net::broadcast::Consumer,
 	catalog: &Catalog,
 	codec: Codec,
 ) -> Result<Option<codec::Track>> {

--- a/rs/moq-rtc/src/ingest.rs
+++ b/rs/moq-rtc/src/ingest.rs
@@ -2,20 +2,20 @@
 //! RTP-in flow (`server publish` / WHIP server, `client subscribe` / WHEP
 //! client).
 //!
-//! Holds the [`moq_net::BroadcastProducer`] and per-track codec bridges.
+//! Holds the [`moq_net::broadcast::Producer`] and per-track codec bridges.
 //! On `MediaAdded`, it inspects the negotiated codec and instantiates the
 //! matching bridge; on each `MediaData`, it forwards into the bridge.
 
 use crate::{Error, Result, codec, session};
 
 pub struct IngestSink {
-	broadcast: moq_net::BroadcastProducer,
+	broadcast: moq_net::broadcast::Producer,
 	catalog: moq_mux::catalog::Producer,
 	bridges: session::Bridges,
 }
 
 impl IngestSink {
-	pub fn new(mut broadcast: moq_net::BroadcastProducer) -> Result<Self> {
+	pub fn new(mut broadcast: moq_net::broadcast::Producer) -> Result<Self> {
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 		Ok(Self {
 			broadcast,

--- a/rs/moq-rtc/src/lib.rs
+++ b/rs/moq-rtc/src/lib.rs
@@ -17,8 +17,8 @@
 //! ## Embedding
 //!
 //! Build a [`Server`] over your own
-//! [`OriginProducer`](moq_net::OriginProducer) /
-//! [`OriginConsumer`](moq_net::OriginConsumer) and merge
+//! [`OriginProducer`](moq_net::origin::Producer) /
+//! [`OriginConsumer`](moq_net::origin::Consumer) and merge
 //! [`Server::publish_router`] / [`Server::subscribe_router`] into your own axum
 //! app, or dial out with [`Client`]. A command-line interface is provided by the
 //! `moq-cli` binary, on top of this library.

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -1,7 +1,7 @@
 //! HTTP-server side: accept WHIP/WHEP offers from remote clients.
 //!
-//! Mounts axum routers that publish into [`moq_net::OriginProducer`] (WHIP
-//! / `server publish`) and pull from [`moq_net::OriginConsumer`] (WHEP /
+//! Mounts axum routers that publish into [`moq_net::origin::Producer`] (WHIP
+//! / `server publish`) and pull from [`moq_net::origin::Consumer`] (WHEP /
 //! `server subscribe`). The HTTP listener itself is the caller's
 //! responsibility; the `moq-cli` `rtc` subcommand mounts these under an
 //! HTTP server.
@@ -61,7 +61,7 @@ struct AcceptedSession {
 	session: Option<crate::session::Session>,
 	/// Announcement guard for the ingest (WHIP) path; unannounces on drop.
 	/// `None` for egress (WHEP) sessions.
-	publish: Option<moq_net::OriginPublish>,
+	publish: Option<moq_net::origin::Publish>,
 	registration: Option<mux::Registration>,
 	cancel: Option<oneshot::Receiver<()>>,
 	role: &'static str,
@@ -165,9 +165,9 @@ pub struct Server {
 
 struct Inner {
 	config: Config,
-	publisher: moq_net::OriginProducer,
+	publisher: moq_net::origin::Producer,
 	/// Source for `server subscribe` (WHEP) egress.
-	subscriber: moq_net::OriginConsumer,
+	subscriber: moq_net::origin::Consumer,
 	/// The shared media socket + demux, bound lazily on the first accept so
 	/// `Server::new` can stay synchronous (and an idle server binds no port).
 	mux: OnceCell<Mux>,
@@ -180,7 +180,7 @@ struct Inner {
 impl Server {
 	/// Build a server. `publisher` receives WHIP broadcasts; `subscriber`
 	/// is the source for WHEP egress.
-	pub fn new(config: Config, publisher: moq_net::OriginProducer, subscriber: moq_net::OriginConsumer) -> Self {
+	pub fn new(config: Config, publisher: moq_net::origin::Producer, subscriber: moq_net::origin::Consumer) -> Self {
 		Self {
 			inner: Arc::new(Inner {
 				config,
@@ -222,11 +222,11 @@ impl Server {
 		whep::router(self.clone())
 	}
 
-	pub(crate) fn publisher(&self) -> &moq_net::OriginProducer {
+	pub(crate) fn publisher(&self) -> &moq_net::origin::Producer {
 		&self.inner.publisher
 	}
 
-	pub(crate) fn subscriber(&self) -> &moq_net::OriginConsumer {
+	pub(crate) fn subscriber(&self) -> &moq_net::origin::Consumer {
 		&self.inner.subscriber
 	}
 

--- a/rs/moq-rtc/src/server/whep.rs
+++ b/rs/moq-rtc/src/server/whep.rs
@@ -88,7 +88,7 @@ async fn accept_offer(server: &Server, path: &str, headers: &HeaderMap, body: By
 /// `subscriber`'s scope) as [`Error::Other`].
 pub async fn accept(
 	server: &Server,
-	subscriber: &moq_net::OriginConsumer,
+	subscriber: &moq_net::origin::Consumer,
 	broadcast: impl moq_net::AsPath,
 	offer: &str,
 ) -> Result<Response> {

--- a/rs/moq-rtc/src/server/whip.rs
+++ b/rs/moq-rtc/src/server/whip.rs
@@ -89,7 +89,7 @@ async fn accept_offer(server: &Server, path: &str, headers: &HeaderMap, body: By
 /// outside `publisher`'s scope.
 pub async fn accept(
 	server: &Server,
-	publisher: &moq_net::OriginProducer,
+	publisher: &moq_net::origin::Producer,
 	broadcast: impl moq_net::AsPath,
 	offer: &str,
 ) -> Result<Response> {
@@ -98,7 +98,7 @@ pub async fn accept(
 	// Register the broadcast on the publish origin before negotiating, so a
 	// fast subscriber doesn't see a 404 in the gap between the SDP answer
 	// and the first RTP packet.
-	let producer = moq_net::BroadcastInfo::new().produce();
+	let producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let publish = publisher
 		.publish_broadcast(broadcast, &consumer)

--- a/rs/moq-rtc/tests/bitstream.rs
+++ b/rs/moq-rtc/tests/bitstream.rs
@@ -32,7 +32,7 @@ async fn h264_annexb_frame_publishes_catalog_entry() {
 
 	let frame = annexb(&[sps, pps, idr]);
 
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let catalog = moq_mux::catalog::Producer::new(&mut producer).expect("catalog");
 
@@ -62,7 +62,7 @@ async fn h264_annexb_frame_publishes_catalog_entry() {
 
 #[tokio::test(start_paused = true)]
 async fn opus_frame_publishes_catalog_entry() {
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let catalog = moq_mux::catalog::Producer::new(&mut producer).expect("catalog");
 
@@ -85,7 +85,7 @@ async fn opus_frame_publishes_catalog_entry() {
 
 #[tokio::test(start_paused = true)]
 async fn vp9_keyframe_flag_from_uncompressed_header() {
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let catalog = moq_mux::catalog::Producer::new(&mut producer).expect("catalog");
 
@@ -136,7 +136,7 @@ async fn vp9_keyframe_flag_from_uncompressed_header() {
 #[tokio::test(start_paused = true)]
 async fn egress_opus_passthrough() {
 	// Build an opus broadcast via the ingest bridge.
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let catalog = moq_mux::catalog::Producer::new(&mut producer).expect("catalog");
 	let mut bridge = moq_rtc::codec::opus::Bridge::new(producer.clone(), catalog.clone(), 48_000, 2).expect("bridge");
@@ -172,7 +172,7 @@ async fn egress_h264_avc3_passthrough() {
 	let pps: &[u8] = &[0x68, 0xce, 0x3c, 0x80];
 	let idr: &[u8] = &[0x65, 0x88, 0x84, 0x21];
 
-	let broadcast = moq_net::BroadcastInfo::new();
+	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let catalog = moq_mux::catalog::Producer::new(&mut producer).expect("catalog");
 

--- a/rs/moq-rtmp/src/dial.rs
+++ b/rs/moq-rtmp/src/dial.rs
@@ -30,7 +30,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use moq_mux::container::flv::{Export as FlvExport, Import as FlvImport};
-use moq_net::{BroadcastConsumer, BroadcastInfo, OriginProducer, OriginPublish};
+use moq_net::{broadcast, origin};
 use rml_rtmp::handshake::{Handshake, HandshakeProcessResult, PeerType};
 use rml_rtmp::sessions::{
 	ClientSession, ClientSessionConfig, ClientSessionEvent, ClientSessionResult, PublishRequestType,
@@ -164,7 +164,7 @@ impl<S: Stream> Client<S> {
 	/// `broadcast` is the read side of whatever you want restreamed (e.g. from
 	/// `origin.consume().announced_broadcast(path)`). This future resolves when the
 	/// broadcast ends, so callers usually run it on its own task.
-	pub async fn publish(mut self, stream_key: &str, broadcast: BroadcastConsumer) -> Result<()> {
+	pub async fn publish(mut self, stream_key: &str, broadcast: broadcast::Consumer) -> Result<()> {
 		let request = self
 			.session
 			.request_publishing(stream_key.to_string(), PublishRequestType::Live)
@@ -232,7 +232,7 @@ impl<S: Stream> Client<S> {
 	///
 	/// This future resolves when the remote stream ends, so callers usually run it
 	/// on its own task.
-	pub async fn pull(mut self, stream_key: &str, origin: &OriginProducer, path: &str) -> Result<()> {
+	pub async fn pull(mut self, stream_key: &str, origin: &origin::Producer, path: &str) -> Result<()> {
 		let request = self
 			.session
 			.request_playback(stream_key.to_string())
@@ -415,13 +415,13 @@ async fn client_handshake<S: Stream>(stream: &mut S) -> anyhow::Result<Vec<u8>> 
 /// server's publisher; dropping it unannounces the broadcast.
 struct Publisher {
 	/// Held to keep the broadcast announced for the publisher's lifetime.
-	_publish: OriginPublish,
+	_publish: origin::Publish,
 	importer: FlvImport,
 }
 
 impl Publisher {
-	fn new(origin: &OriginProducer, path: &str) -> anyhow::Result<Self> {
-		let mut broadcast = BroadcastInfo::new().produce();
+	fn new(origin: &origin::Producer, path: &str) -> anyhow::Result<Self> {
+		let mut broadcast = broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 		let mut importer = FlvImport::new(broadcast.clone(), catalog);
 
@@ -479,7 +479,7 @@ mod tests {
 		vframe.extend_from_slice(&[0, 0, 0, 5, 0x65, 0x88, 0x84, 0x21, 0x00]);
 
 		let server_origin = moq_net::Origin::random().produce();
-		let mut broadcast = BroadcastInfo::new().produce();
+		let mut broadcast = broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 		let mut importer = FlvImport::new(broadcast.clone(), catalog);
 		let _publish = server_origin

--- a/rs/moq-rtmp/src/lib.rs
+++ b/rs/moq-rtmp/src/lib.rs
@@ -6,12 +6,12 @@
 //!
 //! - **Publish (ingest)**: a client (OBS, ffmpeg) pushes a stream in; we re-wrap
 //!   its audio/video messages as FLV tags, demux them with [`moq_mux`], and
-//!   publish the result into a [`moq_net::OriginProducer`] as ordinary MoQ
+//!   publish the result into a [`moq_net::origin::Producer`] as ordinary MoQ
 //!   broadcasts. This is the contribution-ingest analogue of `moq-srt`,
 //!   `moq-cli import ... hls`, and `moq-rtc`'s WHIP.
 //! - **Play (egress)**: a client (VLC, ffplay, mpv) pulls
 //!   `rtmp://host/<app>/<key>`; we subscribe to that broadcast from a
-//!   [`moq_net::OriginConsumer`], mux it back to FLV with [`moq_mux`], and stream
+//!   [`moq_net::origin::Consumer`], mux it back to FLV with [`moq_mux`], and stream
 //!   the tags down as RTMP. The counterpart to `moq-cli export ... hls`.
 //!
 //! Both legacy RTMP (H.264 + AAC, plus MP3) and enhanced RTMP (E-RTMP: the HEVC,

--- a/rs/moq-rtmp/src/listen.rs
+++ b/rs/moq-rtmp/src/listen.rs
@@ -23,7 +23,7 @@ use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use moq_net::OriginProducer;
+use moq_net::origin;
 
 use crate::Result;
 use crate::server::{Request, Server};
@@ -78,7 +78,7 @@ pub struct Config {
 /// Stays pending forever (rather than resolving) when RTMP is disabled, so it
 /// composes cleanly inside a `tokio::select!` alongside a relay's other
 /// long-running tasks.
-pub async fn run(origin: OriginProducer, config: Config) -> Result<()> {
+pub async fn run(origin: origin::Producer, config: Config) -> Result<()> {
 	let Some(listen) = config.listen else {
 		tracing::info!("RTMP ingest disabled (no listen address)");
 		std::future::pending::<()>().await;

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -35,7 +35,7 @@ use futures::StreamExt;
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
 use moq_mux::container::flv::{Export as FlvExport, Import as FlvImport};
-use moq_net::{BroadcastInfo, OriginConsumer, OriginProducer, OriginPublish};
+use moq_net::{broadcast, origin};
 use rml_rtmp::handshake::{Handshake, HandshakeProcessResult, PeerType};
 use rml_rtmp::sessions::{ServerSession, ServerSessionConfig, ServerSessionEvent, ServerSessionResult};
 use rml_rtmp::time::RtmpTimestamp;
@@ -379,7 +379,7 @@ impl<S: Stream> Publish<S> {
 	/// relay's shared origin, optionally re-rooted/scoped per the authenticated
 	/// token). This future resolves when the connection ends, so callers usually
 	/// run it on its own task.
-	pub async fn accept(mut self, origin: &OriginProducer, path: &str) -> Result<()> {
+	pub async fn accept(mut self, origin: &origin::Producer, path: &str) -> Result<()> {
 		// Reserve the broadcast path before telling the client the publish succeeded:
 		// if the origin refuses `path`, reject cleanly instead of accepting and then
 		// dropping the connection a moment later.
@@ -506,7 +506,7 @@ impl<S: Stream> Play<S> {
 	/// before the publisher), cancelling cleanly if the viewer disconnects first.
 	/// This future resolves when playback ends, so callers usually run it on its
 	/// own task.
-	pub async fn accept(mut self, origin: &OriginConsumer, path: &str) -> Result<()> {
+	pub async fn accept(mut self, origin: &origin::Consumer, path: &str) -> Result<()> {
 		// Wait for the broadcast before telling the client playback started. Feed the
 		// client's bytes through the session (not discard them) so its deserializer
 		// stays in sync for everything `play_pump` parses next.
@@ -958,19 +958,19 @@ async fn run_handshake<S: Stream>(stream: &mut S, peer: SocketAddr) -> anyhow::R
 }
 
 /// An active publish: the moq-mux FLV importer (which owns the
-/// [`BroadcastProducer`](moq_net::BroadcastProducer) it publishes into) plus the
+/// [`BroadcastProducer`](moq_net::broadcast::Producer) it publishes into) plus the
 /// origin announcement. Dropping it closes and unannounces the broadcast.
 struct Publisher {
 	/// Held to keep the broadcast announced for the publisher's lifetime.
-	_publish: OriginPublish,
+	_publish: origin::Publish,
 	importer: FlvImport,
 }
 
 impl Publisher {
 	/// Open a broadcast at `path` and prime the importer with the FLV file
 	/// header, so subsequent tags decode against an initialized demuxer.
-	fn new(origin: &OriginProducer, path: &str) -> anyhow::Result<Self> {
-		let mut broadcast = BroadcastInfo::new().produce();
+	fn new(origin: &origin::Producer, path: &str) -> anyhow::Result<Self> {
+		let mut broadcast = broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 		let mut importer = FlvImport::new(broadcast.clone(), catalog);
 
@@ -1182,7 +1182,7 @@ mod tests {
 
 		// Publish the broadcast at `live/cam0` by feeding synthetic FLV to the importer.
 		let origin = moq_net::Origin::random().produce();
-		let mut broadcast = BroadcastInfo::new().produce();
+		let mut broadcast = broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 		let mut importer = FlvImport::new(broadcast.clone(), catalog);
 		let _publish = origin.publish_broadcast("live/cam0", broadcast.consume()).unwrap();

--- a/rs/moq-srt/src/dial.rs
+++ b/rs/moq-srt/src/dial.rs
@@ -20,7 +20,7 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use moq_net::{OriginConsumer, OriginProducer};
+use moq_net::origin;
 use srt_tokio::SrtSocket;
 
 use crate::Result;
@@ -37,7 +37,7 @@ pub async fn publish(
 	addr: SocketAddr,
 	resource: &str,
 	latency: impl Into<Option<Duration>>,
-	origin: &OriginConsumer,
+	origin: &origin::Consumer,
 	path: &str,
 ) -> Result<()> {
 	let latency = latency.into().unwrap_or(DEFAULT_LATENCY);
@@ -56,7 +56,7 @@ pub async fn pull(
 	addr: SocketAddr,
 	resource: &str,
 	latency: impl Into<Option<Duration>>,
-	origin: &OriginProducer,
+	origin: &origin::Producer,
 	path: &str,
 ) -> Result<()> {
 	let socket = call(addr, resource, Mode::Request, latency).await?;

--- a/rs/moq-srt/src/lib.rs
+++ b/rs/moq-srt/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Runs an [SRT](https://www.haivision.com/products/srt-secure-reliable-transport/)
 //! listener and routes each connection by its stream-id `m=` mode against a
-//! [`moq_net::OriginProducer`]:
+//! [`moq_net::origin::Producer`]:
 //!
 //! - `m=publish` (the default): demux the MPEG-TS the connection carries with
 //!   [`moq_mux`] and publish it into the origin as an ordinary broadcast. The

--- a/rs/moq-srt/src/listen.rs
+++ b/rs/moq-srt/src/listen.rs
@@ -29,7 +29,7 @@ use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use moq_net::OriginProducer;
+use moq_net::origin;
 
 use crate::Result;
 use crate::server::{Request, Server};
@@ -79,7 +79,7 @@ impl Default for Config {
 /// Stays pending forever (rather than resolving) when SRT is disabled, so it
 /// composes cleanly inside a `tokio::select!` alongside a relay's other
 /// long-running tasks.
-pub async fn run(origin: OriginProducer, config: Config) -> Result<()> {
+pub async fn run(origin: origin::Producer, config: Config) -> Result<()> {
 	let Some(listen) = config.listen else {
 		tracing::info!("SRT gateway disabled (no listen address)");
 		std::future::pending::<()>().await;

--- a/rs/moq-srt/src/server.rs
+++ b/rs/moq-srt/src/server.rs
@@ -23,7 +23,7 @@ use std::net::SocketAddr;
 use std::time::{Duration, Instant};
 
 use futures::{SinkExt, StreamExt};
-use moq_net::{OriginConsumer, OriginProducer};
+use moq_net::origin;
 use srt_tokio::access::{
 	AccessControlList, ConnectionMode, RejectReason, ServerRejectReason, StandardAccessControlEntry,
 };
@@ -198,7 +198,7 @@ impl Publish {
 	/// relay's shared origin, optionally scoped per the authenticated token). This
 	/// future resolves when the connection ends, so callers usually run it on its
 	/// own task.
-	pub async fn accept(self, origin: &OriginProducer, path: &str) -> Result<()> {
+	pub async fn accept(self, origin: &origin::Producer, path: &str) -> Result<()> {
 		let socket = self.0.request.accept(None).await?;
 		tracing::info!(peer = %self.0.peer, %path, "SRT publish accepted");
 		serve_publish(origin, path, socket).await
@@ -248,7 +248,7 @@ impl Subscribe {
 	/// Waits for the broadcast to be announced (so a caller may connect before the
 	/// publisher), cancelling cleanly if the caller disconnects first. This future
 	/// resolves when playback ends, so callers usually run it on its own task.
-	pub async fn accept(self, origin: &OriginConsumer, path: &str) -> Result<()> {
+	pub async fn accept(self, origin: &origin::Consumer, path: &str) -> Result<()> {
 		let socket = self.0.request.accept(None).await?;
 		tracing::info!(peer = %self.0.peer, %path, "SRT subscribe accepted");
 		serve_subscribe(origin, path, socket, self.0.latency).await
@@ -273,7 +273,7 @@ async fn reject_log(request: ConnectionRequest, reason: ServerRejectReason, peer
 }
 
 /// Pump one accepted SRT socket's MPEG-TS payload into the origin (`m=publish`).
-pub(crate) async fn serve_publish(origin: &OriginProducer, path: &str, mut socket: SrtSocket) -> Result<()> {
+pub(crate) async fn serve_publish(origin: &origin::Producer, path: &str, mut socket: SrtSocket) -> Result<()> {
 	use futures::TryStreamExt;
 
 	let mut publisher = crate::ts::Publisher::new(origin, path)?;
@@ -291,7 +291,7 @@ pub(crate) async fn serve_publish(origin: &OriginProducer, path: &str, mut socke
 /// publisher), then packs the muxer's output into [`SRT_PAYLOAD`]-sized SRT
 /// messages. Returns once the broadcast ends or the caller disconnects.
 pub(crate) async fn serve_subscribe(
-	origin: &OriginConsumer,
+	origin: &origin::Consumer,
 	path: &str,
 	mut socket: SrtSocket,
 	latency: Duration,

--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use moq_mux::container::{Frame, ts};
-use moq_net::{BroadcastInfo, OriginConsumer, OriginProducer, OriginPublish};
+use moq_net::{broadcast, origin};
 
 use crate::Result;
 
@@ -20,20 +20,20 @@ use crate::Result;
 /// Each chunk is handed straight to the TS importer, which consumes whole
 /// transport packets and retains any partial trailing packet internally for the
 /// next call (the same pattern `moq-cli import ... stdin ts` uses against stdin).
-/// Dropping the publisher ends the broadcast: the held [`OriginPublish`] guard
+/// Dropping the publisher ends the broadcast: the held [`origin::Publish`] guard
 /// unannounces it from the origin.
 pub struct Publisher {
 	/// Held to keep the broadcast announced for the publisher's lifetime; the
 	/// importer owns its own clone of the broadcast for writing frames.
-	_publish: OriginPublish,
+	_publish: origin::Publish,
 	importer: ts::Import,
 }
 
 impl Publisher {
 	/// Create the broadcast, wire up the TS importer + catalog, and announce it
 	/// into `origin` at `path`.
-	pub fn new(origin: &OriginProducer, path: &str) -> Result<Self> {
-		let mut broadcast = BroadcastInfo::new().produce();
+	pub fn new(origin: &origin::Producer, path: &str) -> Result<Self> {
+		let mut broadcast = broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 		let importer = ts::Import::new(broadcast.clone(), catalog);
 
@@ -84,7 +84,7 @@ impl Subscriber {
 	/// Returns `Ok(None)` if the broadcast can never be served (path outside the
 	/// consumer's scope, or the origin closed). Otherwise waits for the broadcast
 	/// to be announced, so a caller may connect before the publisher does.
-	pub async fn new(origin: &OriginConsumer, path: &str, latency: Duration) -> Result<Option<Self>> {
+	pub async fn new(origin: &origin::Consumer, path: &str, latency: Duration) -> Result<Option<Self>> {
 		let Some(broadcast) = origin.announced_broadcast(path).await else {
 			return Ok(None);
 		};

--- a/rs/moq-video/src/decode/consumer.rs
+++ b/rs/moq-video/src/decode/consumer.rs
@@ -26,7 +26,7 @@ impl Consumer {
 	/// Subscribe to `name` in `broadcast`, decoding it per the catalog entry.
 	/// Errors if the rendition isn't H.264 or H.265.
 	pub async fn new(
-		broadcast: &moq_net::BroadcastConsumer,
+		broadcast: &moq_net::broadcast::Consumer,
 		catalog: &VideoConfig,
 		name: impl Into<String>,
 		config: Config,

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -46,7 +46,7 @@ impl Producer {
 	/// in `catalog`. The packets fed to [`publish`](Self::publish) must be in
 	/// that codec's framing (the matching [`Encoder`](super::Encoder) emits it).
 	pub fn new(
-		mut broadcast: moq_net::BroadcastProducer,
+		mut broadcast: moq_net::broadcast::Producer,
 		catalog: moq_mux::catalog::Producer,
 		codec: Codec,
 	) -> Result<Self, Error> {
@@ -71,8 +71,8 @@ impl Producer {
 
 	/// A watch-only handle to the track's subscriber demand, created eagerly so
 	/// subscription state is observable before any frames arrive. Watch it via
-	/// [`used`](moq_net::TrackDemand::used) / [`unused`](moq_net::TrackDemand::unused).
-	pub fn demand(&self) -> moq_net::TrackDemand {
+	/// [`used`](moq_net::track::Demand::used) / [`unused`](moq_net::track::Demand::unused).
+	pub fn demand(&self) -> moq_net::track::Demand {
 		match &self.codecs {
 			Codecs::H264 { import, .. } => import.demand(),
 			Codecs::H265 { import, .. } => import.demand(),
@@ -136,7 +136,7 @@ pub struct Options {
 /// same [`Clock`](moq_mux::Clock) to a concurrent audio publish keeps the two
 /// tracks aligned.
 pub async fn publish_capture(
-	broadcast: moq_net::BroadcastProducer,
+	broadcast: moq_net::broadcast::Producer,
 	catalog: moq_mux::catalog::Producer,
 	capture: capture::Config,
 	encode: Options,
@@ -170,7 +170,7 @@ pub async fn publish_capture(
 #[cfg(not(target_os = "macos"))]
 #[allow(dead_code)]
 fn assert_publish_capture_send(
-	broadcast: moq_net::BroadcastProducer,
+	broadcast: moq_net::broadcast::Producer,
 	catalog: moq_mux::catalog::Producer,
 	capture: capture::Config,
 	encode: Options,
@@ -204,7 +204,7 @@ fn log_track_ended(err: moq_net::Error) {
 /// itself wedged.
 async fn capture_loop(
 	producer: &mut Producer,
-	demand: &moq_net::TrackDemand,
+	demand: &moq_net::track::Demand,
 	capture: &capture::Config,
 	encode: &Options,
 	clock: &moq_mux::Clock,
@@ -297,7 +297,7 @@ mod tests {
 	/// `Auto`, which on Linux CI would try the NVENC backend and panic in cudarc
 	/// on a GPU-less runner.
 	async fn roundtrip_rendition(codec: Codec, kind: encoder::Kind) -> String {
-		let mut broadcast = moq_net::BroadcastInfo::new().produce();
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 		let mut producer = Producer::new(broadcast, catalog.clone(), codec).unwrap();
 

--- a/rs/moq-wasm/src/lib.rs
+++ b/rs/moq-wasm/src/lib.rs
@@ -44,7 +44,7 @@ pub fn setup() {
 pub struct Session {
 	inner: moq_net::Session,
 	// The origin remote broadcasts are announced into; read via `consume`.
-	consumer: moq_net::OriginConsumer,
+	consumer: moq_net::origin::Consumer,
 }
 
 #[wasm_bindgen]
@@ -95,7 +95,7 @@ impl Session {
 /// A consumer handle for a single broadcast.
 #[wasm_bindgen]
 pub struct Broadcast {
-	inner: moq_net::BroadcastConsumer,
+	inner: moq_net::broadcast::Consumer,
 }
 
 #[wasm_bindgen]
@@ -118,7 +118,7 @@ pub struct Track {
 	// the cell for the duration of the await rather than holding a borrow across
 	// it (which would make the future self-referential). One in-flight call at a
 	// time; a re-entrant call while one is pending errors instead of aliasing.
-	inner: Rc<RefCell<Option<moq_net::TrackSubscriber>>>,
+	inner: Rc<RefCell<Option<moq_net::track::Subscriber>>>,
 }
 
 #[wasm_bindgen]
@@ -146,7 +146,7 @@ impl Track {
 #[wasm_bindgen]
 pub struct Group {
 	sequence: u64,
-	inner: Rc<RefCell<Option<moq_net::GroupConsumer>>>,
+	inner: Rc<RefCell<Option<moq_net::group::Consumer>>>,
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
## Summary

Splits moq-net's flat `BroadcastConsumer` / `TrackProducer` / … type names into public **role modules** that own short names. This is the change discussed in [the design question](https://github.com/moq-dev/moq): the prefix on every type (`Track*`, `Broadcast*`, …) was a hand-rolled namespace, so the module now supplies it.

| Module | Types |
|---|---|
| `broadcast` | `Producer, Consumer, Info, Dynamic` |
| `track` | `Producer, Consumer, Info, Subscribe, Subscriber, Fetch, Dynamic, Demand, Request, InfoQuery, GroupRequest` |
| `group` | `Producer, Consumer, Info, Fetch` |
| `frame` | `Producer, Consumer, Info` |
| `origin` | `Producer, Consumer, Publish, Broadcast, Dynamic, Request, Requested` |
| `announce` | `Producer, Consumer, Event, Update` |

`Origin`, `OriginList`, `Consume`, and the error types stay flat at the crate root.

### origin + announce

They share one broadcast-tree implementation (the node plumbing is common), so `origin.rs` stays a single **private** `mod origin_impl` (via `#[path]`) surfaced through two curated `pub mod` facades in `model/mod.rs`. This keeps the shared plumbing out of the public surface and avoids exposing each type at two paths. `broadcast`/`track`/`group`/`frame` are genuine per-file modules.

## Public API changes (breaking)

Every `pub` type listed above is renamed/re-pathed — a breaking change to `moq-net`'s public surface, hence **this targets `dev`**. The **wire protocol is unchanged**.

## Cross-package sync

- **All downstream Rust crates** updated to the new module paths (moq-mux, moq-relay, moq-native, hang, moq-srt, moq-rtmp, moq-rtc, moq-cli, moq-gst, moq-hls, moq-audio, moq-boy, moq-bench, moq-json, moq-video, moq-wasm, libmoq, moq-ffi).
- **FFI / bindings insulated:** `moq-ffi`, `libmoq`, and the py/swift/kt/go wrappers keep their own `Moq*` / de-prefixed names, so only the Rust-API docs changed (`rs/CLAUDE.md`, `doc/lib/rs/*`, moq-boy demo docs). The py/swift/kt binding docs were intentionally left as-is.
- **js/net mirror deferred** to a follow-up. `@moq/net` already diverges structurally (flat `Broadcast`/`Group`/`TrackConsumer`, no uniform Producer/Consumer split), and with the wire unchanged, mirroring is a deliberate breaking TS redesign (namespace exports) rather than a mechanical sync.

## Test plan

- [x] `cargo check --workspace --all-targets --all-features` — 0 errors
- [x] moq-net: 410 tests pass; clippy clean
- [x] 855 tests pass across the consumer crates (moq-mux, hang, moq-relay, moq-token, moq-native, moq-srt, moq-rtmp, moq-rtc, moq-ffi, moq-loc, moq-audio)
- [x] `cargo fmt --all --check` clean
- Pre-existing, unrelated: `moq-nvenc` doc-tests reference the upstream `nvidia_video_codec_sdk` crate name (stale in the vendored fork); its lib compiles fine.

## Reviewer note

`GroupRequest` was kept in the `track` module (`track::GroupRequest`) rather than moved to `group::Request`, because it's welded to track's private `TrackState`; moving it would leak that state across modules. Easy follow-up if you'd prefer it in `group`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)