### PR TITLE
fix(moq-nvenc): repair vendored doc-tests after crate rename

### DIFF
--- a/rs/moq-nvenc/src/safe/buffer.rs
+++ b/rs/moq-nvenc/src/safe/buffer.rs
@@ -42,9 +42,9 @@ impl Session {
 	///
 	/// # Examples
 	///
-	/// ```
+	/// ```no_run
 	/// # use cudarc::driver::CudaContext;
-	/// # use nvidia_video_codec_sdk::{
+	/// # use moq_nvenc::{
 	/// #     sys::nvEncodeAPI::{
 	/// #         NV_ENC_BUFFER_FORMAT::NV_ENC_BUFFER_FORMAT_ARGB,
 	/// #         NV_ENC_CODEC_H264_GUID,
@@ -110,9 +110,9 @@ impl Session {
 	///
 	/// # Examples
 	///
-	/// ```
+	/// ```no_run
 	/// # use cudarc::driver::CudaContext;
-	/// # use nvidia_video_codec_sdk::{
+	/// # use moq_nvenc::{
 	/// #     sys::nvEncodeAPI::{
 	/// #         NV_ENC_BUFFER_FORMAT::NV_ENC_BUFFER_FORMAT_ARGB,
 	/// #         NV_ENC_CODEC_H264_GUID,
@@ -278,9 +278,9 @@ impl<'a> Buffer<'a> {
 	///
 	/// # Examples
 	///
-	/// ```
+	/// ```no_run
 	/// # use cudarc::driver::CudaContext;
-	/// # use nvidia_video_codec_sdk::{
+	/// # use moq_nvenc::{
 	/// #     sys::nvEncodeAPI::{
 	/// #         NV_ENC_BUFFER_FORMAT::NV_ENC_BUFFER_FORMAT_ARGB,
 	/// #         NV_ENC_CODEC_H264_GUID,

--- a/rs/moq-nvenc/src/safe/encoder.rs
+++ b/rs/moq-nvenc/src/safe/encoder.rs
@@ -72,9 +72,9 @@ impl Encoder {
 	///
 	/// # Examples
 	///
-	/// ```
+	/// ```no_run
 	/// # use cudarc::driver::CudaContext;
-	/// # use nvidia_video_codec_sdk::Encoder;
+	/// # use moq_nvenc::Encoder;
 	/// let cuda_ctx = CudaContext::new(0).unwrap();
 	/// let encoder = Encoder::initialize_with_cuda(cuda_ctx).unwrap();
 	/// ```
@@ -122,9 +122,9 @@ impl Encoder {
 	///
 	/// # Examples
 	///
-	/// ```
+	/// ```no_run
 	/// # use cudarc::driver::CudaContext;
-	/// # use nvidia_video_codec_sdk::{sys::nvEncodeAPI::NV_ENC_CODEC_H264_GUID, Encoder};
+	/// # use moq_nvenc::{sys::nvEncodeAPI::NV_ENC_CODEC_H264_GUID, Encoder};
 	/// # let cuda_ctx = CudaContext::new(0).unwrap();
 	/// let encoder = Encoder::initialize_with_cuda(cuda_ctx).unwrap();
 	/// let encode_guids = encoder.get_encode_guids().unwrap();
@@ -161,9 +161,9 @@ impl Encoder {
 	///
 	/// # Examples
 	///
-	/// ```
+	/// ```no_run
 	/// # use cudarc::driver::CudaContext;
-	/// # use nvidia_video_codec_sdk::{
+	/// # use moq_nvenc::{
 	/// #     sys::nvEncodeAPI::{NV_ENC_CODEC_H264_GUID, NV_ENC_PRESET_P1_GUID},
 	/// #     Encoder,
 	/// # };
@@ -214,9 +214,9 @@ impl Encoder {
 	///
 	/// # Examples
 	///
-	/// ```
+	/// ```no_run
 	/// # use cudarc::driver::CudaContext;
-	/// # use nvidia_video_codec_sdk::{
+	/// # use moq_nvenc::{
 	/// #     sys::nvEncodeAPI::{NV_ENC_CODEC_H264_GUID, NV_ENC_H264_PROFILE_HIGH_GUID},
 	/// #     Encoder,
 	/// # };
@@ -268,9 +268,9 @@ impl Encoder {
 	///
 	/// # Examples
 	///
-	/// ```
+	/// ```no_run
 	/// # use cudarc::driver::CudaContext;
-	/// # use nvidia_video_codec_sdk::{
+	/// # use moq_nvenc::{
 	/// #     sys::nvEncodeAPI::{NV_ENC_BUFFER_FORMAT, NV_ENC_CODEC_H264_GUID},
 	/// #     Encoder,
 	/// # };
@@ -327,9 +327,9 @@ impl Encoder {
 	///
 	/// # Examples
 	///
-	/// ```
+	/// ```no_run
 	/// # use cudarc::driver::CudaContext;
-	/// # use nvidia_video_codec_sdk::{
+	/// # use moq_nvenc::{
 	/// #     sys::nvEncodeAPI::{
 	/// #         NV_ENC_CODEC_H264_GUID,
 	/// #         NV_ENC_PRESET_P1_GUID,
@@ -397,9 +397,9 @@ impl Encoder {
 	///
 	/// # Examples
 	///
-	/// ```
+	/// ```no_run
 	/// # use cudarc::driver::CudaContext;
-	/// # use nvidia_video_codec_sdk::{
+	/// # use moq_nvenc::{
 	/// #     sys::nvEncodeAPI::{
 	/// #         NV_ENC_BUFFER_FORMAT::NV_ENC_BUFFER_FORMAT_ARGB,
 	/// #         NV_ENC_CODEC_H264_GUID,

--- a/rs/moq-nvenc/src/safe/result.rs
+++ b/rs/moq-nvenc/src/safe/result.rs
@@ -195,9 +195,9 @@ impl NVENCSTATUS {
 	///
 	/// # Examples
 	///
-	/// ```
+	/// ```no_run
 	/// # use cudarc::driver::CudaContext;
-	/// # use nvidia_video_codec_sdk::{sys::nvEncodeAPI::GUID, EncodeError, Encoder, ErrorKind};
+	/// # use moq_nvenc::{sys::nvEncodeAPI::GUID, EncodeError, Encoder, ErrorKind};
 	/// # let cuda_ctx = CudaContext::new(0).unwrap();
 	/// let encoder = Encoder::initialize_with_cuda(cuda_ctx).unwrap();
 	/// // Cause an error by passing in an invalid GUID.

--- a/rs/moq-nvenc/src/safe/session.rs
+++ b/rs/moq-nvenc/src/safe/session.rs
@@ -39,9 +39,9 @@ impl Session {
 	///
 	/// # Examples
 	///
-	/// ```
+	/// ```no_run
 	/// # use cudarc::driver::CudaContext;
-	/// # use nvidia_video_codec_sdk::{
+	/// # use moq_nvenc::{
 	/// #     sys::nvEncodeAPI::{
 	/// #         NV_ENC_BUFFER_FORMAT::NV_ENC_BUFFER_FORMAT_ARGB,
 	/// #         NV_ENC_CODEC_H264_GUID,
@@ -99,9 +99,9 @@ impl Session {
 	///
 	/// # Examples
 	///
-	/// ```
+	/// ```no_run
 	/// # use cudarc::driver::CudaContext;
-	/// # use nvidia_video_codec_sdk::{
+	/// # use moq_nvenc::{
 	/// #     sys::nvEncodeAPI::{
 	/// #         NV_ENC_BUFFER_FORMAT::NV_ENC_BUFFER_FORMAT_ARGB,
 	/// #         NV_ENC_CODEC_H264_GUID,


### PR DESCRIPTION
## Summary

`cargo test -p moq-nvenc --doc` failed with all 13 doc-tests broken. Two layered causes, both from vendoring the NVENC fork in-tree as `moq-nvenc`:

1. **Rename broke the imports.** rustdoc links each doc-test against the library by its *package name*. The vendored `safe` module examples still did `use nvidia_video_codec_sdk::…`; after the rename to `moq-nvenc` the lib name became `moq_nvenc`, so those imports no longer resolved. `cargo check` stayed green because those imports live on hidden `#`-prefixed example lines that only the doc-tests compile. Renamed the 13 references to `moq_nvenc`.

2. **The examples were being executed.** Once they compiled, they panicked in `cudarc` trying to `dlopen` libcuda, which fails on any host without an NVIDIA GPU (macOS, GPU-less CI). Marked their opening fences ` ```no_run ` so they compile-check but don't run. This is also why the crate merged green originally: its doc-tests aren't run in CI.

Doc-comment edits only, no code changes.

## Test plan

- [x] `cargo check -p moq-nvenc` — pass
- [x] `cargo test -p moq-nvenc --lib` — 104 pass
- [x] `cargo test -p moq-nvenc --doc` — 13 pass (compile-only)

(Written by Claude Opus 4.8)