### PR TITLE
feat(moq-mux): gate initial catalog publish until reserved tracks resolve

### DIFF
--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -72,13 +72,13 @@ impl Publish {
 		// A container may publish several tracks; a single codec fills one reserved
 		// track. Try the container first so a codec format doesn't reserve a stray
 		// track on the way to being recognized.
-		let media = match import::Container::new(broadcast.clone(), catalog.clone(), format, init) {
+		let media = match import::Container::new(broadcast.clone(), catalog.reserve(), format, init) {
 			Ok(container) => Media::Container(container),
 			Err(moq_mux::Error::UnknownFormat(_)) => {
 				let mut broadcast = broadcast.clone();
 				let name = broadcast.unique_name(&format!(".{format}"));
 				let request = broadcast.reserve_track(name)?;
-				match import::Track::new(request, catalog.clone(), format, init) {
+				match import::Track::new(request, catalog.reserve(), format, init) {
 					Ok(track) => Media::Track(Box::new(track)),
 					Err(moq_mux::Error::UnknownFormat(_)) => return Err(Error::UnknownFormat(format.to_string())),
 					Err(err) => return Err(err.into()),

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -182,7 +182,7 @@ impl Publish {
 				&mut broadcast,
 				moq_mux::catalog::hang::Catalog::<ts::catalog::Ext>::default(),
 			)?;
-			let ts = ts::Import::new(broadcast.clone(), catalog);
+			let ts = ts::Import::new(broadcast.clone(), catalog.reserve());
 			return Ok(Self {
 				source: Source::Stream(PublishDecoder::Ts(Box::new(ts))),
 				broadcast,
@@ -193,7 +193,7 @@ impl Publish {
 		let source = match format {
 			PublishFormat::Avc3 => {
 				let track = moq_mux::import::unique_track(&mut broadcast, ".avc3")?;
-				let import = moq_mux::codec::h264::Import::new(track, catalog.clone());
+				let import = moq_mux::codec::h264::Import::new(track, catalog.reserve());
 				let split = Box::new(moq_mux::codec::h264::Split::new());
 				Source::Stream(PublishDecoder::Avc3 {
 					split,
@@ -201,12 +201,12 @@ impl Publish {
 				})
 			}
 			PublishFormat::Fmp4 => {
-				let fmp4 = fmp4::Import::new(broadcast.clone(), catalog.clone());
+				let fmp4 = fmp4::Import::new(broadcast.clone(), catalog.reserve());
 				Source::Stream(PublishDecoder::Fmp4(Box::new(fmp4)))
 			}
 			PublishFormat::Ts => unreachable!("TS is handled above with the mpegts catalog extension"),
 			PublishFormat::Flv => {
-				let flv = flv::Import::new(broadcast.clone(), catalog.clone());
+				let flv = flv::Import::new(broadcast.clone(), catalog.reserve());
 				Source::Stream(PublishDecoder::Flv(Box::new(flv)))
 			}
 		};
@@ -451,7 +451,7 @@ mod tests {
 		pes_producer.finish().unwrap();
 
 		// Add the real video/audio (moves `broadcast` into the importer).
-		let mut import = Import::new(broadcast, catalog.clone());
+		let mut import = Import::new(broadcast, catalog.reserve());
 		import.decode(&BytesMut::from(BBB)).unwrap();
 		import.finish().unwrap();
 
@@ -502,7 +502,7 @@ mod tests {
 		let consumer = broadcast.consume();
 		let catalog =
 			moq_mux::catalog::Producer::with_catalog(&mut broadcast, Catalog::<tscat::Ext>::default()).unwrap();
-		let mut import = Import::new(broadcast, catalog.clone());
+		let mut import = Import::new(broadcast, catalog.reserve());
 		import.decode(&BytesMut::from(&output[..])).unwrap();
 		import.finish().unwrap();
 		let snapshot = catalog.snapshot();

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -245,7 +245,7 @@ impl MoqBroadcastProducer {
 		// track. Try the container first so a codec format doesn't reserve a stray
 		// track on the way to being recognized.
 		let (decoder, demand) =
-			match moq_mux::import::Container::new(state.broadcast.clone(), state.catalog.clone(), &format, &init) {
+			match moq_mux::import::Container::new(state.broadcast.clone(), state.catalog.reserve(), &format, &init) {
 				Ok(container) => (MediaDecoder::Container(container), None),
 				Err(moq_mux::Error::UnknownFormat(_)) => {
 					let mut broadcast = state.broadcast.clone();
@@ -253,7 +253,7 @@ impl MoqBroadcastProducer {
 					let request = broadcast
 						.reserve_track(name)
 						.map_err(|err| MoqError::Codec(format!("init failed: {err}")))?;
-					match moq_mux::import::Track::new(request, state.catalog.clone(), &format, &init) {
+					match moq_mux::import::Track::new(request, state.catalog.reserve(), &format, &init) {
 						Ok(import) => {
 							let demand = import.demand();
 							(MediaDecoder::Track(Box::new(import)), Some(demand))
@@ -291,7 +291,7 @@ impl MoqBroadcastProducer {
 		// The importer accepts the request itself, which is where the track's timescale is set.
 		let request = request.take()?;
 
-		let import = moq_mux::import::Track::new(request, state.catalog.clone(), &format, &init)
+		let import = moq_mux::import::Track::new(request, state.catalog.reserve(), &format, &init)
 			.map_err(|err| MoqError::Codec(format!("init failed: {err}")))?;
 
 		let demand = import.demand();
@@ -319,7 +319,7 @@ impl MoqBroadcastProducer {
 		// track. Try the container first so a codec format doesn't reserve a stray
 		// track before being recognized.
 		let decoder =
-			match moq_mux::import::ContainerStream::new(state.broadcast.clone(), state.catalog.clone(), &format) {
+			match moq_mux::import::ContainerStream::new(state.broadcast.clone(), state.catalog.reserve(), &format) {
 				Ok(container) => StreamDecoder::Container(container),
 				Err(moq_mux::Error::UnknownFormat(_)) => {
 					let mut broadcast = state.broadcast.clone();
@@ -327,7 +327,7 @@ impl MoqBroadcastProducer {
 					let request = broadcast
 						.reserve_track(name)
 						.map_err(|err| MoqError::Codec(format!("init failed: {err}")))?;
-					match moq_mux::import::TrackStream::new(request, state.catalog.clone(), &format) {
+					match moq_mux::import::TrackStream::new(request, state.catalog.reserve(), &format) {
 						Ok(import) => StreamDecoder::Track(Box::new(import)),
 						Err(moq_mux::Error::UnknownFormat(_)) => {
 							return Err(MoqError::Codec(format!("unknown stream format: {format}")));

--- a/rs/moq-gst/src/sink/pad.rs
+++ b/rs/moq-gst/src/sink/pad.rs
@@ -119,7 +119,7 @@ impl Pad {
 				let request = broadcast.reserve_track(name)?;
 				let producer =
 					request.accept(moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE));
-				moq_mux::codec::mp3::Import::new(producer, catalog, config)?.into()
+				moq_mux::codec::mp3::Import::new(producer, catalog.reserve(), config)?.into()
 			}
 			"audio/mpeg" => {
 				// AAC: the AudioSpecificConfig rides in caps as codec_data, not in the bitstream.
@@ -151,7 +151,7 @@ impl Pad {
 				let request = broadcast.reserve_track(name)?;
 				let producer =
 					request.accept(moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE));
-				moq_mux::codec::opus::Import::new(producer, catalog, config)?.into()
+				moq_mux::codec::opus::Import::new(producer, catalog.reserve(), config)?.into()
 			}
 			other => anyhow::bail!("unsupported caps: {other}"),
 		};
@@ -171,7 +171,7 @@ impl Pad {
 	) -> Result<import::Track> {
 		let name = broadcast.unique_name(suffix);
 		let request = broadcast.reserve_track(name)?;
-		Ok(import::Track::new(request, catalog, format, init)?)
+		Ok(import::Track::new(request, catalog.reserve(), format, init)?)
 	}
 
 	/// Drops the producer (closing its track) and marks the pad failed so further buffers are dropped.

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -550,7 +550,7 @@ impl Import {
 	/// independent while still contributing to the same shared catalog.
 	fn ensure_video_importer_for(&mut self, index: usize, select: &select::Broadcast) -> &mut Fmp4 {
 		while self.video_importers.len() <= index {
-			let importer = Fmp4::new(self.broadcast.clone(), self.catalog.clone()).with_select(select.clone());
+			let importer = Fmp4::new(self.broadcast.clone(), self.catalog.reserve()).with_select(select.clone());
 			self.video_importers.push(importer);
 		}
 
@@ -563,7 +563,7 @@ impl Import {
 		let catalog = self.catalog.clone();
 		let select = select.clone();
 		self.audio_importer
-			.get_or_insert_with(|| Fmp4::new(broadcast, catalog).with_select(select))
+			.get_or_insert_with(|| Fmp4::new(broadcast, catalog.reserve()).with_select(select))
 	}
 
 	#[cfg(test)]

--- a/rs/moq-mux/src/catalog/mod.rs
+++ b/rs/moq-mux/src/catalog/mod.rs
@@ -35,4 +35,4 @@ pub use format::*;
 pub use producer::{Guard, Producer};
 pub use select::Select;
 pub use stream::Stream;
-pub use tracks::{AudioTrack, VideoTrack};
+pub use tracks::{Audio, AudioTrack, Kind, Rendition, Reserved, Video, VideoTrack};

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -5,6 +5,24 @@ use base64::Engine;
 
 use super::hang::{Catalog, CatalogExt, Consumer, Extra};
 
+/// Reservation bookkeeping shared across a producer's clones and its
+/// [`Reserved`](super::Reserved) handles.
+///
+/// The initial catalog snapshot is withheld from the broadcast until `reservers == 0`. A live
+/// `Reserved` counts as one reserver; a [`Rendition`](super::Rendition) holds its own `Reserved`
+/// clone until it's fulfilled (or dropped), so an unresolved rendition keeps the gate shut too. See
+/// [`Reserved`](super::Reserved).
+#[derive(Default)]
+struct Reservations {
+	/// Live `Reserved` handles (including the one each unfulfilled `Rendition` holds).
+	reservers: usize,
+	/// A catalog change was made while buffering and is awaiting the initial publish. Without this
+	/// we'd emit an empty snapshot when the gate opens on a catalog nobody ever touched.
+	pending: bool,
+	/// Whether the initial snapshot has been published (buffering is over).
+	published: bool,
+}
+
 /// Produces both a hang and MSF catalog track for a broadcast.
 ///
 /// Generic over the application extension `E` (defaulting to `()` for none). The catalog is a
@@ -27,6 +45,9 @@ pub struct Producer<E: CatalogExt = ()> {
 
 	current: Arc<Mutex<Catalog<E>>>,
 
+	/// Gates the initial catalog publish until all reservations resolve (see [`reserve`](Self::reserve)).
+	reservations: Arc<Mutex<Reservations>>,
+
 	/// Shared wall clock for the broadcast's tracks. Every importer on this catalog
 	/// gets a clone (a `Copy` of the same epoch), so timestamps they synthesize when
 	/// a caller has none land on one timeline and audio/video stay in sync.
@@ -41,6 +62,7 @@ impl<E: CatalogExt> Clone for Producer<E> {
 			hangz: self.hangz.clone(),
 			msf_track: self.msf_track.clone(),
 			current: self.current.clone(),
+			reservations: self.reservations.clone(),
 			clock: self.clock,
 		}
 	}
@@ -83,6 +105,7 @@ impl<E: CatalogExt> Producer<E> {
 			hangz,
 			msf_track,
 			current: Arc::new(Mutex::new(catalog)),
+			reservations: Arc::new(Mutex::new(Reservations::default())),
 			clock: crate::Clock::new(),
 		})
 	}
@@ -106,6 +129,7 @@ impl<E: CatalogExt> Producer<E> {
 			hang: &mut self.hang,
 			hangz: &mut self.hangz,
 			msf_track: &mut self.msf_track,
+			reservations: &self.reservations,
 			updated: false,
 		}
 	}
@@ -115,18 +139,50 @@ impl<E: CatalogExt> Producer<E> {
 		self.current.lock().unwrap().clone()
 	}
 
-	/// A handle for one importer to publish a video rendition, retired on drop.
+	/// Begin reserving the initial track set, returning a clonable [`Reserved`](super::Reserved).
 	///
-	/// See [`VideoTrack`](super::VideoTrack).
-	pub fn video_track(&self, name: impl Into<String>) -> super::VideoTrack<E> {
-		super::VideoTrack::new(self.clone(), name)
+	/// Hand it (or clones) to importers; each reserves its rendition via
+	/// [`Reserved::init`](super::Reserved::init). The catalog is withheld from the broadcast until
+	/// every `Reserved` is dropped, counting both the ones importers hold and the one each unfulfilled
+	/// [`Rendition`](super::Rendition) holds until its config resolves. So a one-shot muxer (fMP4,
+	/// MPEG-TS) sees the complete track list in the first snapshot instead of a half-converged one.
+	/// Producers that don't reserve publish incrementally as before.
+	pub fn reserve(&self) -> super::Reserved<E> {
+		super::Reserved::new(self.clone())
 	}
 
-	/// A handle for one importer to publish an audio rendition, retired on drop.
-	///
-	/// See [`AudioTrack`](super::AudioTrack).
-	pub fn audio_track(&self, name: impl Into<String>) -> super::AudioTrack<E> {
-		super::AudioTrack::new(self.clone(), name)
+	/// Register a live [`Reserved`](super::Reserved) handle.
+	pub(super) fn add_reserver(&self) {
+		self.reservations.lock().unwrap().reservers += 1;
+	}
+
+	/// Drop a [`Reserved`](super::Reserved) handle, flushing the initial snapshot if that was the
+	/// last thing gating it.
+	pub(super) fn release_reserver(&mut self) {
+		{
+			let mut r = self.reservations.lock().unwrap();
+			r.reservers = r.reservers.saturating_sub(1);
+		}
+		self.flush_if_ready();
+	}
+
+	/// Publish the buffered snapshot once, if buffering has just finished with a change staged.
+	pub(super) fn flush_if_ready(&mut self) {
+		{
+			let mut r = self.reservations.lock().unwrap();
+			if r.published || r.reservers != 0 {
+				return;
+			}
+			// Nothing was staged (e.g. every stream was ignored): stay unpublished so a later change
+			// still triggers the first emit, rather than publishing an empty catalog now.
+			if !r.pending {
+				return;
+			}
+			r.pending = false;
+			r.published = true;
+		}
+		let catalog = self.current.lock().unwrap().clone();
+		emit(&mut self.hang, &mut self.hangz, &mut self.msf_track, &catalog);
 	}
 
 	/// Create a consumer for this catalog, receiving updates as they're published.
@@ -154,6 +210,7 @@ pub struct Guard<'a, E: CatalogExt = ()> {
 	hang: &'a mut moq_json::Producer<Catalog<E>>,
 	hangz: &'a mut moq_json::Producer<Catalog<E>>,
 	msf_track: &'a mut moq_net::track::Producer,
+	reservations: &'a Mutex<Reservations>,
 	updated: bool,
 }
 
@@ -200,18 +257,38 @@ impl<E: CatalogExt> Drop for Guard<'_, E> {
 			return;
 		}
 
-		// Publish the hang catalog (one snapshot per group while deltas are disabled), plus its
-		// DEFLATE-compressed `.z` sibling carrying the identical catalog.
-		let catalog: &Catalog<E> = &self.catalog;
-		let _ = self.hang.update(catalog);
-		let _ = self.hangz.update(catalog);
-
-		// Publish the MSF catalog, derived from the base media sections.
-		let msf = to_msf(&self.catalog.media());
-		if let Ok(mut group) = self.msf_track.append_group() {
-			let _ = group.write_frame_now(msf.to_string().expect("invalid MSF catalog"));
-			let _ = group.finish();
+		{
+			let mut r = self.reservations.lock().unwrap();
+			// Withhold every emit while still buffering the initial reserved set; the mutation stays
+			// in `current` and `pending` marks it for the flush once the gate opens.
+			if !r.published && r.reservers != 0 {
+				r.pending = true;
+				return;
+			}
+			r.pending = false;
+			r.published = true;
 		}
+
+		emit(self.hang, self.hangz, self.msf_track, &self.catalog);
+	}
+}
+
+/// Emit the catalog to all tracks: hang (`catalog.json`), its DEFLATE-compressed `.z` sibling, and
+/// the MSF catalog (`catalog`) derived from the base media sections.
+fn emit<E: CatalogExt>(
+	hang: &mut moq_json::Producer<Catalog<E>>,
+	hangz: &mut moq_json::Producer<Catalog<E>>,
+	msf_track: &mut moq_net::track::Producer,
+	catalog: &Catalog<E>,
+) {
+	// One snapshot per group while deltas are disabled; the `.z` track carries the identical catalog.
+	let _ = hang.update(catalog);
+	let _ = hangz.update(catalog);
+
+	let msf = to_msf(&catalog.media());
+	if let Ok(mut group) = msf_track.append_group() {
+		let _ = group.write_frame_now(msf.to_string().expect("invalid MSF catalog"));
+		let _ = group.finish();
 	}
 }
 
@@ -346,6 +423,122 @@ mod test {
 
 		assert_eq!(got_plain, expected);
 		assert_eq!(got_compressed, expected);
+	}
+
+	fn h264_config() -> VideoConfig {
+		let mut config = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0x00,
+			level: 0x1f,
+			inline: true,
+		});
+		config.container = Container::Legacy;
+		config
+	}
+
+	// A reserved audio rendition that resolves before a reserved video rendition must not publish an
+	// audio-only catalog; the first snapshot a consumer sees carries the complete track set. This is
+	// the moq-dev/moq#1979 convergence race.
+	#[test]
+	fn reservation_gates_until_all_renditions_resolve() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = Producer::new(&mut broadcast).unwrap();
+		let mut consumer: Consumer = Consumer::new(catalog.hang.consume());
+		let waiter = kio::Waiter::noop();
+
+		let reserved = catalog.reserve();
+		let mut audio = reserved.audio("audio0");
+		let mut video = reserved.video("video0");
+		drop(reserved); // done reserving; both renditions still outstanding
+
+		// Audio resolves first: withheld, because video is still outstanding.
+		audio.set(AudioConfig::new(AudioCodec::Opus, 48_000, 2));
+		assert!(
+			matches!(consumer.poll_next(&waiter), Poll::Pending),
+			"an audio-only catalog must not publish while video is unresolved"
+		);
+
+		// Video resolves: the complete catalog publishes now, in one snapshot.
+		video.set(h264_config());
+		let snapshot = match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(c))) => c,
+			other => panic!("expected the complete catalog, got {other:?}"),
+		};
+		assert!(snapshot.audio.renditions.contains_key("audio0"));
+		assert!(snapshot.video.renditions.contains_key("video0"));
+		assert!(
+			matches!(consumer.poll_next(&waiter), Poll::Pending),
+			"only the one complete snapshot should be published"
+		);
+	}
+
+	// Dropping a reservation without fulfilling it (a stream that never produced a config) still opens
+	// the gate, publishing whatever did resolve.
+	#[test]
+	fn reservation_gate_opens_when_unresolved_reservation_is_dropped() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = Producer::new(&mut broadcast).unwrap();
+		let mut consumer: Consumer = Consumer::new(catalog.hang.consume());
+		let waiter = kio::Waiter::noop();
+
+		let reserved = catalog.reserve();
+		let mut audio = reserved.audio("audio0");
+		let video = reserved.video("video0");
+		drop(reserved);
+
+		audio.set(AudioConfig::new(AudioCodec::Opus, 48_000, 2));
+		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
+
+		// The video stream never resolves and is cancelled; the audio-only catalog publishes.
+		drop(video);
+		let snapshot = match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(c))) => c,
+			other => panic!("expected the audio catalog, got {other:?}"),
+		};
+		assert!(snapshot.audio.renditions.contains_key("audio0"));
+		assert!(!snapshot.video.renditions.contains_key("video0"));
+	}
+
+	// A change staged while a deferred importer still holds a reservation (mimicking a TS stream whose
+	// config resolves late, e.g. AAC) must not publish until that rendition resolves, so no incomplete
+	// intermediate snapshot leaks out.
+	#[test]
+	fn staged_change_waits_for_a_held_reservation() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = Producer::new(&mut broadcast).unwrap();
+		let mut consumer: Consumer = Consumer::new(catalog.hang.consume());
+		let waiter = kio::Waiter::noop();
+
+		// A deferred importer grabs a reservation up front and holds it until it can resolve.
+		let deferred = catalog.reserve();
+
+		// Meanwhile an eager rendition resolves and stages a catalog change. The importer keeps its
+		// rendition alive (dropping it would retire the track), so bind it.
+		let early = catalog.reserve();
+		let mut a0 = early.audio("audio0");
+		a0.set(AudioConfig::new(AudioCodec::Opus, 48_000, 2));
+		drop(early);
+		assert!(
+			matches!(consumer.poll_next(&waiter), Poll::Pending),
+			"the staged rendition must wait for the deferred importer's held reservation"
+		);
+
+		// The deferred importer finally builds its rendition and resolves it.
+		let mut late = deferred.audio("audio1");
+		drop(deferred); // the importer releases its own hold; only the rendition's remains
+		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
+		late.set(AudioConfig::new(AudioCodec::Opus, 48_000, 1));
+
+		let snapshot = match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(c))) => c,
+			other => panic!("expected one complete catalog, got {other:?}"),
+		};
+		assert!(snapshot.audio.renditions.contains_key("audio0"));
+		assert!(snapshot.audio.renditions.contains_key("audio1"));
+		assert!(
+			matches!(consumer.poll_next(&waiter), Poll::Pending),
+			"only the one complete snapshot should be published"
+		);
 	}
 
 	#[test]

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -1,28 +1,167 @@
-use super::Producer;
-use super::hang::CatalogExt;
+use std::marker::PhantomData;
 
-/// A single video track's catalog rendition, retired on drop.
-///
-/// Made via [`Producer::video_track`]. An importer holds one and publishes its
-/// rendition through it ([`set`](Self::set), refined in place with
-/// [`update`](Self::update)). When the importer drops, the rendition is removed
-/// from the shared catalog, so the broadcast catalog stays out of the importer's
-/// type while still being published into.
-pub struct VideoTrack<E: CatalogExt = ()> {
-	catalog: Producer<E>,
-	name: String,
-	/// Whether a config has been published yet, so a lazily-configured importer
-	/// (e.g. H.264 before its SPS) can hold the handle without a catalog entry, and
-	/// drop without a spurious removal.
-	present: bool,
+use super::Producer;
+use super::hang::{Catalog, CatalogExt};
+
+mod sealed {
+	pub trait Sealed {}
 }
 
-impl<E: CatalogExt> VideoTrack<E> {
-	pub(super) fn new(catalog: Producer<E>, name: impl Into<String>) -> Self {
+/// The media kind of a reserved rendition, selecting its config type and catalog slot.
+///
+/// Implemented only by [`Video`] and [`Audio`]; used as the `K` in
+/// [`Rendition`] and [`Reserved::init`].
+pub trait Kind: sealed::Sealed + 'static {
+	/// The catalog config type carried by this kind ([`VideoConfig`](hang::catalog::VideoConfig)
+	/// or [`AudioConfig`](hang::catalog::AudioConfig)).
+	type Config;
+
+	#[doc(hidden)]
+	fn insert<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str, config: Self::Config);
+	#[doc(hidden)]
+	fn with_mut<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str, f: impl FnOnce(&mut Self::Config));
+	#[doc(hidden)]
+	fn remove<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str);
+}
+
+/// Video rendition marker for [`Rendition`] / [`Reserved::init`].
+pub enum Video {}
+/// Audio rendition marker for [`Rendition`] / [`Reserved::init`].
+pub enum Audio {}
+
+impl sealed::Sealed for Video {}
+impl sealed::Sealed for Audio {}
+
+impl Kind for Video {
+	type Config = hang::catalog::VideoConfig;
+
+	fn insert<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str, config: Self::Config) {
+		catalog.video.renditions.insert(name.to_string(), config);
+	}
+	fn with_mut<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str, f: impl FnOnce(&mut Self::Config)) {
+		if let Some(config) = catalog.video.renditions.get_mut(name) {
+			f(config);
+		}
+	}
+	fn remove<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str) {
+		catalog.video.renditions.remove(name);
+	}
+}
+
+impl Kind for Audio {
+	type Config = hang::catalog::AudioConfig;
+
+	fn insert<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str, config: Self::Config) {
+		catalog.audio.renditions.insert(name.to_string(), config);
+	}
+	fn with_mut<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str, f: impl FnOnce(&mut Self::Config)) {
+		if let Some(config) = catalog.audio.renditions.get_mut(name) {
+			f(config);
+		}
+	}
+	fn remove<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str) {
+		catalog.audio.renditions.remove(name);
+	}
+}
+
+/// A clonable reservation context handed to importers so they declare their tracks up front.
+///
+/// Made via [`Producer::reserve`]. While any `Reserved` clone is alive the track set may still
+/// grow, so the catalog is withheld from the broadcast. Each [`init`](Self::init) reserves a
+/// rendition by name (config filled in later via the returned [`Rendition`] guard) and counts as
+/// outstanding until that guard is fulfilled or dropped. Once every clone is dropped *and* every
+/// reservation resolves, the first catalog snapshot is published atomically with the complete
+/// track list, so a one-shot muxer (fMP4, MPEG-TS) never sees a half-converged catalog.
+pub struct Reserved<E: CatalogExt = ()> {
+	catalog: Producer<E>,
+}
+
+impl<E: CatalogExt> Reserved<E> {
+	pub(super) fn new(catalog: Producer<E>) -> Self {
+		catalog.add_reserver();
+		Self { catalog }
+	}
+
+	/// Reserve a rendition of kind `K` under `name`, returning a guard to fill it in.
+	///
+	/// The guard holds its own `Reserved` clone, so the catalog stays withheld until the returned
+	/// [`Rendition`] is [`set`](Rendition::set) (or dropped). Prefer [`video`](Self::video) /
+	/// [`audio`](Self::audio) at call sites.
+	pub fn init<K: Kind>(&self, name: impl Into<String>) -> Rendition<E, K> {
+		Rendition::new(self.clone(), name)
+	}
+
+	/// Reserve a video rendition; shorthand for [`init::<Video>`](Self::init).
+	pub fn video(&self, name: impl Into<String>) -> Rendition<E, Video> {
+		self.init::<Video>(name)
+	}
+
+	/// Reserve an audio rendition; shorthand for [`init::<Audio>`](Self::init).
+	pub fn audio(&self, name: impl Into<String>) -> Rendition<E, Audio> {
+		self.init::<Audio>(name)
+	}
+
+	/// Resolve a timestamp on the broadcast's shared clock (see [`Producer::timestamp`]).
+	pub fn timestamp(&self, hint: Option<moq_net::Timestamp>) -> crate::Result<moq_net::Timestamp> {
+		self.catalog.timestamp(hint)
+	}
+
+	/// The underlying catalog [`Producer`], for edits that outlive this reservation.
+	///
+	/// A container importer holds one to edit the catalog directly (e.g. its per-frame reconcile, or
+	/// track removals after its initial set is declared) while the reservation itself is dropped to
+	/// open the gate. The returned handle does not gate: only live `Reserved`s do.
+	pub fn producer(&self) -> Producer<E> {
+		self.catalog.clone()
+	}
+}
+
+impl<E: CatalogExt> Clone for Reserved<E> {
+	fn clone(&self) -> Self {
+		self.catalog.add_reserver();
 		Self {
-			catalog,
+			catalog: self.catalog.clone(),
+		}
+	}
+}
+
+impl<E: CatalogExt> Drop for Reserved<E> {
+	fn drop(&mut self) {
+		self.catalog.release_reserver();
+	}
+}
+
+/// A reserved rendition of kind `K`, retired from the catalog on drop.
+///
+/// Made via [`Reserved::init`] (or [`video`](Reserved::video) / [`audio`](Reserved::audio)). Fill
+/// it in with [`set`](Self::set) and refine it in place with [`update`](Self::update). Until it's
+/// set (or dropped) it holds a [`Reserved`] clone, so an unresolved rendition keeps the initial
+/// catalog publish gated. On drop the rendition is removed from the shared catalog.
+pub struct Rendition<E: CatalogExt, K: Kind> {
+	catalog: Producer<E>,
+	name: String,
+	/// The reservation this rendition holds until its config is set (or it's dropped unfulfilled).
+	/// `Some` gates the initial publish; cleared by [`set`](Self::set).
+	gate: Option<Reserved<E>>,
+	/// Whether a config has been published, so a lazily-configured importer (e.g. H.264 before its
+	/// SPS) holds the handle without a catalog entry, and drops without a spurious removal.
+	present: bool,
+	_kind: PhantomData<fn() -> K>,
+}
+
+/// A single video track's catalog rendition. See [`Rendition`].
+pub type VideoTrack<E = ()> = Rendition<E, Video>;
+/// A single audio track's catalog rendition. See [`Rendition`].
+pub type AudioTrack<E = ()> = Rendition<E, Audio>;
+
+impl<E: CatalogExt, K: Kind> Rendition<E, K> {
+	fn new(reserved: Reserved<E>, name: impl Into<String>) -> Self {
+		Self {
+			catalog: reserved.catalog.clone(),
+			gate: Some(reserved),
 			name: name.into(),
 			present: false,
+			_kind: PhantomData,
 		}
 	}
 
@@ -36,83 +175,37 @@ impl<E: CatalogExt> VideoTrack<E> {
 		self.catalog.timestamp(hint)
 	}
 
-	/// Insert or replace the rendition, publishing the catalog.
-	pub fn set(&mut self, config: hang::catalog::VideoConfig) {
-		self.catalog.lock().video.renditions.insert(self.name.clone(), config);
+	/// Insert or replace the rendition, fulfilling the reservation and publishing the catalog.
+	pub fn set(&mut self, config: K::Config) {
+		// Write the config first (still withheld, since we're holding our reservation), then release
+		// the reservation. If this was the last one, the release flushes a complete snapshot.
+		{
+			let mut guard = self.catalog.lock();
+			K::insert(&mut guard, &self.name, config);
+		}
 		self.present = true;
+		self.gate = None;
 	}
 
 	/// Refine the rendition in place (e.g. observed jitter), publishing if present.
-	pub fn update(&mut self, f: impl FnOnce(&mut hang::catalog::VideoConfig)) {
+	pub fn update(&mut self, f: impl FnOnce(&mut K::Config)) {
 		if !self.present {
 			return;
 		}
 		let mut guard = self.catalog.lock();
-		if let Some(config) = guard.video.renditions.get_mut(&self.name) {
-			f(config);
-		}
+		K::with_mut(&mut guard, &self.name, f);
 	}
 }
 
-impl<E: CatalogExt> Drop for VideoTrack<E> {
+impl<E: CatalogExt, K: Kind> Drop for Rendition<E, K> {
 	fn drop(&mut self) {
 		if self.present {
-			self.catalog.lock().video.renditions.remove(&self.name);
+			// Removing mutates the catalog, so the guard publishes it (immediately if live, else it
+			// accumulates until the gate opens).
+			let mut guard = self.catalog.lock();
+			K::remove(&mut guard, &self.name);
 		}
-	}
-}
-
-/// A single audio track's catalog rendition, retired on drop.
-///
-/// The audio counterpart of [`VideoTrack`]; made via [`Producer::audio_track`].
-pub struct AudioTrack<E: CatalogExt = ()> {
-	catalog: Producer<E>,
-	name: String,
-	present: bool,
-}
-
-impl<E: CatalogExt> AudioTrack<E> {
-	pub(super) fn new(catalog: Producer<E>, name: impl Into<String>) -> Self {
-		Self {
-			catalog,
-			name: name.into(),
-			present: false,
-		}
-	}
-
-	/// The track name this rendition is keyed by.
-	pub fn name(&self) -> &str {
-		&self.name
-	}
-
-	/// Resolve a timestamp on the broadcast's shared clock (see [`Producer::timestamp`]).
-	pub fn timestamp(&self, hint: Option<moq_net::Timestamp>) -> crate::Result<moq_net::Timestamp> {
-		self.catalog.timestamp(hint)
-	}
-
-	/// Insert or replace the rendition, publishing the catalog.
-	pub fn set(&mut self, config: hang::catalog::AudioConfig) {
-		self.catalog.lock().audio.renditions.insert(self.name.clone(), config);
-		self.present = true;
-	}
-
-	/// Refine the rendition in place (e.g. a synthesized description or jitter),
-	/// publishing if present.
-	pub fn update(&mut self, f: impl FnOnce(&mut hang::catalog::AudioConfig)) {
-		if !self.present {
-			return;
-		}
-		let mut guard = self.catalog.lock();
-		if let Some(config) = guard.audio.renditions.get_mut(&self.name) {
-			f(config);
-		}
-	}
-}
-
-impl<E: CatalogExt> Drop for AudioTrack<E> {
-	fn drop(&mut self) {
-		if self.present {
-			self.catalog.lock().audio.renditions.remove(&self.name);
-		}
+		// Our reservation (`gate`) drops here. If still held (never set), its release flushes any
+		// staged change; if already released by `set`, this is a no-op.
 	}
 }

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -9,17 +9,17 @@ use crate::container::Frame;
 /// [`decode`](Self::decode) is published as one hang frame in its own group, so the relay can
 /// forward each frame without waiting for a group boundary. The codec's packet loss
 /// concealment handles drops. Build it with [`new`](Self::new), passing the track producer
-/// and the [`catalog::Producer`](crate::catalog::Producer) it publishes its rendition into.
+/// and the [`catalog::Reserved`](crate::catalog::Reserved) it reserves its rendition from.
 pub struct Import<E: CatalogExt = ()> {
 	track: crate::container::Producer<crate::catalog::hang::Container>,
 	rendition: crate::catalog::AudioTrack<E>,
 }
 
 impl<E: CatalogExt> Import<E> {
-	/// Publish on an existing track producer, registering the rendition in `catalog`.
+	/// Publish on an existing track producer, reserving the rendition from `reserved`.
 	pub fn new(
 		track: moq_net::track::Producer,
-		catalog: crate::catalog::Producer<E>,
+		reserved: crate::catalog::Reserved<E>,
 		config: Config,
 	) -> crate::Result<Self> {
 		let mut audio_config = hang::catalog::AudioConfig::new(
@@ -33,7 +33,7 @@ impl<E: CatalogExt> Import<E> {
 
 		tracing::debug!(name = ?track.name(), config = ?audio_config, "starting track");
 
-		let mut rendition = catalog.audio_track(track.name());
+		let mut rendition = reserved.audio(track.name());
 		rendition.set(audio_config);
 
 		Ok(Self {

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -24,7 +24,7 @@ use crate::container::jitter::Jitter;
 /// A pure-publisher importer for AV1 with inline sequence headers.
 ///
 /// Build it with [`new`](Self::new), passing the track producer and the
-/// [`catalog::Producer`](crate::catalog::Producer) it publishes into, and feed it
+/// [`catalog::Reserved`](crate::catalog::Reserved) it reserves its rendition from, and feed it
 /// frames a [`Split`](super::Split) produced via [`decode`](Self::decode). The
 /// catalog rendition fills in lazily once the config is known.
 pub struct Import<E: CatalogExt = ()> {
@@ -36,9 +36,9 @@ pub struct Import<E: CatalogExt = ()> {
 }
 
 impl<E: CatalogExt> Import<E> {
-	/// Publish on an existing track producer, registering the rendition in `catalog`.
-	pub fn new(track: moq_net::track::Producer, catalog: crate::catalog::Producer<E>) -> Self {
-		let rendition = catalog.video_track(track.name());
+	/// Publish on an existing track producer, reserving the rendition from `reserved`.
+	pub fn new(track: moq_net::track::Producer, reserved: crate::catalog::Reserved<E>) -> Self {
+		let rendition = reserved.video(track.name());
 		Self {
 			track: crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy),
 			rendition,

--- a/rs/moq-mux/src/codec/flac/import.rs
+++ b/rs/moq-mux/src/codec/flac/import.rs
@@ -6,7 +6,7 @@ use crate::container::Frame;
 ///
 /// Publishes raw FLAC frames to a single moq track. Build it with
 /// [`new`](Self::new), passing the track producer and the
-/// [`catalog::Producer`](crate::catalog::Producer) it publishes its rendition into.
+/// [`catalog::Reserved`](crate::catalog::Reserved) it reserves its rendition from.
 ///
 /// The STREAMINFO ([`Config`]) is required up front: it becomes the catalog
 /// `description` (the `fLaC` marker plus STREAMINFO) so a decoder can initialize
@@ -19,10 +19,10 @@ pub struct Import<E: CatalogExt = ()> {
 }
 
 impl<E: CatalogExt> Import<E> {
-	/// Publish on an existing track producer, registering the rendition in `catalog`.
+	/// Publish on an existing track producer, reserving the rendition from `reserved`.
 	pub fn new(
 		track: moq_net::track::Producer,
-		catalog: crate::catalog::Producer<E>,
+		reserved: crate::catalog::Reserved<E>,
 		config: Config,
 	) -> crate::Result<Self> {
 		let mut audio = hang::catalog::AudioConfig::new(
@@ -35,7 +35,7 @@ impl<E: CatalogExt> Import<E> {
 
 		tracing::debug!(name = ?track.name(), config = ?audio, "starting track");
 
-		let mut rendition = catalog.audio_track(track.name());
+		let mut rendition = reserved.audio(track.name());
 		rendition.set(audio);
 
 		Ok(Self {

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -23,7 +23,7 @@ use crate::container::jitter::Jitter;
 /// H.264 importer: a pure frame publisher that resolves the catalog rendition.
 ///
 /// Build it with [`new`](Self::new), passing the track producer and the
-/// [`catalog::Producer`](crate::catalog::Producer) it publishes its rendition into.
+/// [`catalog::Reserved`](crate::catalog::Reserved) it reserves its rendition from.
 /// Feed it frames a [`Split`](super::Split) produced via [`decode`](Self::decode).
 /// The catalog rendition fills in lazily once the codec config is known (avcC via
 /// [`initialize`](Self::initialize) for avc1, the first SPS for avc3).
@@ -39,9 +39,9 @@ pub struct Import<E: CatalogExt = ()> {
 }
 
 impl<E: CatalogExt> Import<E> {
-	/// Publish on an existing track producer, registering the rendition in `catalog`.
-	pub fn new(track: moq_net::track::Producer, catalog: crate::catalog::Producer<E>) -> Self {
-		let rendition = catalog.video_track(track.name());
+	/// Publish on an existing track producer, reserving the rendition from `reserved`.
+	pub fn new(track: moq_net::track::Producer, reserved: crate::catalog::Reserved<E>) -> Self {
+		let rendition = reserved.video(track.name());
 		Self {
 			avc1: false,
 			track: crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy),
@@ -276,7 +276,7 @@ mod tests {
 		avcc.extend_from_slice(&[0x01, 0x00, 0x04, 0x68, 0xce, 0x3c, 0x80]); // num_pps + pps
 
 		let (track, catalog) = setup("video");
-		let mut import = Import::new(track, catalog.clone());
+		let mut import = Import::new(track, catalog.reserve());
 		// initialize() must not consume the buffer (the split owns the consume).
 		let buf = bytes::BytesMut::from(avcc.as_slice());
 		import.initialize(&buf).expect("initialize avc1");
@@ -312,7 +312,7 @@ mod tests {
 
 		let mut split = Split::new();
 		let (track, catalog) = setup("video");
-		let mut import = Import::new(track, catalog.clone());
+		let mut import = Import::new(track, catalog.reserve());
 		assert!(
 			catalog.snapshot().video.renditions.is_empty(),
 			"no config before any frame"
@@ -345,7 +345,7 @@ mod tests {
 
 		let mut split = Split::new();
 		let (track, catalog) = setup("video");
-		let mut import = Import::new(track, catalog);
+		let mut import = Import::new(track, catalog.reserve());
 
 		let pts = moq_net::Timestamp::from_micros(0).unwrap();
 		let mut frames = split.decode(&annexb, pts).expect("split keyframe");
@@ -368,7 +368,7 @@ mod tests {
 
 		let mut split = Split::new();
 		let (track, catalog) = setup("video");
-		let mut import = Import::new(track, catalog.clone());
+		let mut import = Import::new(track, catalog.reserve());
 
 		let pts = moq_net::Timestamp::from_micros(0).unwrap();
 		let mut frames = split.decode(&annexb, pts).expect("split delta");

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -26,7 +26,7 @@ use crate::container::jitter::Jitter;
 /// Only supports single layer streams (VPS is cached but not parsed).
 ///
 /// Build it with [`new`](Self::new), passing the track producer and the
-/// [`catalog::Producer`](crate::catalog::Producer) it publishes into, and feed it
+/// [`catalog::Reserved`](crate::catalog::Reserved) it reserves its rendition from, and feed it
 /// frames a [`Split`](super::Split) produced via [`decode`](Self::decode). The
 /// catalog rendition fills in lazily once the first SPS is parsed.
 pub struct Import<E: CatalogExt = ()> {
@@ -38,9 +38,9 @@ pub struct Import<E: CatalogExt = ()> {
 }
 
 impl<E: CatalogExt> Import<E> {
-	/// Publish on an existing track producer, registering the rendition in `catalog`.
-	pub fn new(track: moq_net::track::Producer, catalog: crate::catalog::Producer<E>) -> Self {
-		let rendition = catalog.video_track(track.name());
+	/// Publish on an existing track producer, reserving the rendition from `reserved`.
+	pub fn new(track: moq_net::track::Producer, reserved: crate::catalog::Reserved<E>) -> Self {
+		let rendition = reserved.video(track.name());
 		Self {
 			track: crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy),
 			rendition,

--- a/rs/moq-mux/src/codec/legacy.rs
+++ b/rs/moq-mux/src/codec/legacy.rs
@@ -119,13 +119,13 @@ pub(crate) struct Import<E: CatalogExt = ()> {
 }
 
 impl<E: CatalogExt> Import<E> {
-	/// Publish on an existing track, registering the rendition in `catalog`. Mint the
+	/// Publish on an existing track, reserving the rendition from `reserved`. Mint the
 	/// track at the descriptor's suffix and the microsecond
 	/// [`hang::container::TIMESCALE`] (e.g. via [`crate::import::unique_track`]).
 	pub fn new(
 		descriptor: &'static Descriptor,
 		track: moq_net::track::Producer,
-		catalog: crate::catalog::Producer<E>,
+		reserved: crate::catalog::Reserved<E>,
 		config: Config,
 	) -> Self {
 		let mut audio_config =
@@ -137,7 +137,7 @@ impl<E: CatalogExt> Import<E> {
 
 		tracing::debug!(name = ?track.name(), config = ?audio_config, "starting track");
 
-		let mut rendition = catalog.audio_track(track.name());
+		let mut rendition = reserved.audio(track.name());
 		rendition.set(audio_config);
 
 		Self {

--- a/rs/moq-mux/src/codec/mp3.rs
+++ b/rs/moq-mux/src/codec/mp3.rs
@@ -94,8 +94,8 @@ impl Config {
 /// MP3 importer.
 ///
 /// Publishes raw MP3 frames to a single moq track. Build it with [`new`](Self::new),
-/// passing the track producer and the [`catalog::Producer`](crate::catalog::Producer)
-/// it publishes its rendition into.
+/// passing the track producer and the [`catalog::Reserved`](crate::catalog::Reserved)
+/// it reserves its rendition from.
 ///
 /// Each frame handed to [`decode`](Self::decode) is published in its own group so the
 /// relay can forward it immediately. MP3 carries its config in band, so the rendition
@@ -106,10 +106,10 @@ pub struct Import<E: CatalogExt = ()> {
 }
 
 impl<E: CatalogExt> Import<E> {
-	/// Publish on an existing track producer, registering the rendition in `catalog`.
+	/// Publish on an existing track producer, reserving the rendition from `reserved`.
 	pub fn new(
 		track: moq_net::track::Producer,
-		catalog: crate::catalog::Producer<E>,
+		reserved: crate::catalog::Reserved<E>,
 		config: Config,
 	) -> crate::Result<Self> {
 		let mut audio =
@@ -118,7 +118,7 @@ impl<E: CatalogExt> Import<E> {
 
 		tracing::debug!(name = ?track.name(), config = ?audio, "starting track");
 
-		let mut rendition = catalog.audio_track(track.name());
+		let mut rendition = reserved.audio(track.name());
 		rendition.set(audio);
 
 		Ok(Self {

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -6,7 +6,7 @@ use crate::container::Frame;
 ///
 /// Publishes raw Opus frames (no Ogg framing) to a single moq track. Build it with
 /// [`new`](Self::new), passing the track producer and the
-/// [`catalog::Producer`](crate::catalog::Producer) it publishes its rendition into.
+/// [`catalog::Reserved`](crate::catalog::Reserved) it reserves its rendition from.
 ///
 /// Each packet handed to [`decode`](Self::decode) is published in its own group so
 /// the relay can forward it immediately without waiting for a group boundary; Opus'
@@ -17,10 +17,10 @@ pub struct Import<E: CatalogExt = ()> {
 }
 
 impl<E: CatalogExt> Import<E> {
-	/// Publish on an existing track producer, registering the rendition in `catalog`.
+	/// Publish on an existing track producer, reserving the rendition from `reserved`.
 	pub fn new(
 		track: moq_net::track::Producer,
-		catalog: crate::catalog::Producer<E>,
+		reserved: crate::catalog::Reserved<E>,
 		config: Config,
 	) -> crate::Result<Self> {
 		let mut audio = hang::catalog::AudioConfig::new(
@@ -32,7 +32,7 @@ impl<E: CatalogExt> Import<E> {
 
 		tracing::debug!(name = ?track.name(), config = ?audio, "starting track");
 
-		let mut rendition = catalog.audio_track(track.name());
+		let mut rendition = reserved.audio(track.name());
 		rendition.set(audio);
 
 		Ok(Self {

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -12,7 +12,7 @@ use super::FrameHeader;
 /// frames, one per [`decode`](Self::decode). The first key frame's header supplies
 /// the catalog dimensions, so the rendition isn't published until then. Build it
 /// with [`new`](Self::new), passing the track producer and the
-/// [`catalog::Producer`](crate::catalog::Producer) it publishes into.
+/// [`catalog::Reserved`](crate::catalog::Reserved) it reserves its rendition from.
 pub struct Import<E: CatalogExt = ()> {
 	// The track being produced.
 	track: crate::container::Producer<crate::catalog::hang::Container>,
@@ -28,9 +28,9 @@ pub struct Import<E: CatalogExt = ()> {
 }
 
 impl<E: CatalogExt> Import<E> {
-	/// Publish on an existing track producer, registering the rendition in `catalog`.
-	pub fn new(track: moq_net::track::Producer, catalog: crate::catalog::Producer<E>) -> Self {
-		let rendition = catalog.video_track(track.name());
+	/// Publish on an existing track producer, reserving the rendition from `reserved`.
+	pub fn new(track: moq_net::track::Producer, reserved: crate::catalog::Reserved<E>) -> Self {
+		let rendition = reserved.video(track.name());
 		Self {
 			track: crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy),
 			rendition,
@@ -137,7 +137,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn imports_keyframe_then_interframe() {
 		let (track, catalog) = setup();
-		let mut import = super::Import::new(track, catalog.clone());
+		let mut import = super::Import::new(track, catalog.reserve());
 
 		// Empty init buffer: the catalog is filled on the first key frame.
 		import.initialize(&[]).unwrap();
@@ -168,7 +168,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn rejects_interframe_first() {
 		let (track, catalog) = setup();
-		let mut import = super::Import::new(track, catalog);
+		let mut import = super::Import::new(track, catalog.reserve());
 
 		let interframe = Bytes::from_static(&[0x31, 0x00, 0x00, 0xaa, 0xbb]);
 		assert!(

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -12,7 +12,7 @@ use super::FrameHeader;
 /// pass whole frames (or superframes), one per [`decode`](Self::decode). The first
 /// key frame's header supplies the catalog config, so the rendition isn't published
 /// until then. Build it with [`new`](Self::new), passing the track producer and the
-/// [`catalog::Producer`](crate::catalog::Producer) it publishes into.
+/// [`catalog::Reserved`](crate::catalog::Reserved) it reserves its rendition from.
 pub struct Import<E: CatalogExt = ()> {
 	// The track being produced.
 	track: crate::container::Producer<crate::catalog::hang::Container>,
@@ -28,9 +28,9 @@ pub struct Import<E: CatalogExt = ()> {
 }
 
 impl<E: CatalogExt> Import<E> {
-	/// Publish on an existing track producer, registering the rendition in `catalog`.
-	pub fn new(track: moq_net::track::Producer, catalog: crate::catalog::Producer<E>) -> Self {
-		let rendition = catalog.video_track(track.name());
+	/// Publish on an existing track producer, reserving the rendition from `reserved`.
+	pub fn new(track: moq_net::track::Producer, reserved: crate::catalog::Reserved<E>) -> Self {
+		let rendition = reserved.video(track.name());
 		Self {
 			track: crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy),
 			rendition,
@@ -138,7 +138,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn imports_keyframe_then_interframe() {
 		let (track, catalog) = setup();
-		let mut import = super::Import::new(track, catalog.clone());
+		let mut import = super::Import::new(track, catalog.reserve());
 
 		import.initialize(&[]).unwrap();
 		assert!(catalog.snapshot().video.renditions.is_empty());
@@ -164,7 +164,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn rejects_interframe_first() {
 		let (track, catalog) = setup();
-		let mut import = super::Import::new(track, catalog);
+		let mut import = super::Import::new(track, catalog.reserve());
 
 		let interframe = Bytes::from_static(&[0x84, 0x00, 0x00]);
 		assert!(

--- a/rs/moq-mux/src/container/flv/export_test.rs
+++ b/rs/moq-mux/src/container/flv/export_test.rs
@@ -128,7 +128,7 @@ async fn export_roundtrips_through_import() {
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer.decode(&bytes::BytesMut::from(synth_flv().as_slice())).unwrap();
 	catalog.finish().unwrap();
 
@@ -141,7 +141,7 @@ async fn export_roundtrips_through_import() {
 	// Re-import the exported bytes and confirm the catalog rebuilds identically.
 	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
-	let mut imp2 = Import::new(bcast2, cat2.clone());
+	let mut imp2 = Import::new(bcast2, cat2.reserve());
 	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
 	imp2.finish().unwrap();
 
@@ -165,7 +165,7 @@ async fn export_emits_sequence_headers_and_frames() {
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer.decode(&bytes::BytesMut::from(synth_flv().as_slice())).unwrap();
 	catalog.finish().unwrap();
 
@@ -247,7 +247,7 @@ async fn export_roundtrips_enhanced() {
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer
 		.decode(&bytes::BytesMut::from(synth_enhanced_flv().as_slice()))
 		.unwrap();
@@ -275,7 +275,7 @@ async fn export_roundtrips_enhanced() {
 	// Re-import the exported bytes and confirm the codecs rebuild.
 	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
-	let mut imp2 = Import::new(bcast2, cat2.clone());
+	let mut imp2 = Import::new(bcast2, cat2.reserve());
 	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
 	imp2.finish().unwrap();
 
@@ -312,7 +312,7 @@ async fn export_roundtrips_mp3() {
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer.decode(&bytes::BytesMut::from(flv.as_slice())).unwrap();
 	catalog.finish().unwrap();
 
@@ -330,7 +330,7 @@ async fn export_roundtrips_mp3() {
 	// Re-import and confirm the codec rebuilds.
 	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
-	let mut imp2 = Import::new(bcast2, cat2.clone());
+	let mut imp2 = Import::new(bcast2, cat2.reserve());
 	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
 	imp2.finish().unwrap();
 
@@ -363,7 +363,7 @@ async fn export_roundtrips_av1() {
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer
 		.decode(&bytes::BytesMut::from(synth_av1_flv().as_slice()))
 		.unwrap();
@@ -390,7 +390,7 @@ async fn export_roundtrips_av1() {
 
 	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
-	let mut imp2 = Import::new(bcast2, cat2.clone());
+	let mut imp2 = Import::new(bcast2, cat2.reserve());
 	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
 	imp2.finish().unwrap();
 
@@ -416,7 +416,7 @@ async fn export_roundtrips_ac3() {
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer
 		.decode(&bytes::BytesMut::from(
 			synth_enhanced_audio_flv(b"ac-3", &AC3_FRAME).as_slice(),
@@ -435,7 +435,7 @@ async fn export_roundtrips_ac3() {
 
 	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
-	let mut imp2 = Import::new(bcast2, cat2.clone());
+	let mut imp2 = Import::new(bcast2, cat2.reserve());
 	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
 	imp2.finish().unwrap();
 	assert!(matches!(
@@ -450,7 +450,7 @@ async fn export_roundtrips_eac3() {
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer
 		.decode(&bytes::BytesMut::from(
 			synth_enhanced_audio_flv(b"ec-3", &EAC3_FRAME).as_slice(),
@@ -469,7 +469,7 @@ async fn export_roundtrips_eac3() {
 
 	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
-	let mut imp2 = Import::new(bcast2, cat2.clone());
+	let mut imp2 = Import::new(bcast2, cat2.reserve());
 	imp2.decode(&bytes::BytesMut::from(exported.as_slice())).unwrap();
 	imp2.finish().unwrap();
 	assert!(matches!(
@@ -514,7 +514,7 @@ async fn export_preserves_timestamps() {
 	let consumer = producer.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer.decode(&bytes::BytesMut::from(synth_flv().as_slice())).unwrap();
 	catalog.finish().unwrap();
 

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -49,6 +49,11 @@ pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
 	broadcast: moq_net::broadcast::Producer,
 	catalog: crate::catalog::Producer<E>,
 
+	/// Held until the first media frame, by which point all sequence headers (hence renditions) have
+	/// been declared, so the catalog is withheld until the track set is known (and, when composed with
+	/// other importers, until they finish too).
+	initial_reservation: Option<crate::catalog::Reserved<E>>,
+
 	/// Accumulated unparsed input. Whole tags are drained out; a trailing partial
 	/// tag is retained for the next [`decode`](Self::decode) call.
 	buffer: BytesMut,
@@ -74,10 +79,11 @@ struct AudioStream {
 
 impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	/// Create a demuxer publishing into `broadcast` with renditions announced on `catalog`.
-	pub fn new(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
+	pub fn new(broadcast: moq_net::broadcast::Producer, reserved: crate::catalog::Reserved<E>) -> Self {
 		Self {
 			broadcast,
-			catalog,
+			catalog: reserved.producer(),
+			initial_reservation: Some(reserved),
 			buffer: BytesMut::new(),
 			header_seen: false,
 			video: None,
@@ -316,10 +322,14 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	/// Write one decoded video sample, dropping a leading delta before the first
 	/// keyframe (a mid-GOP join) rather than aborting.
 	fn write_video(&mut self, data: &[u8], dts: u64, composition_time: i32, keyframe: bool) -> anyhow::Result<()> {
-		let Some(stream) = self.video.as_mut() else {
+		if self.video.is_none() {
 			tracing::debug!("video frame before sequence header, dropping");
 			return Ok(());
-		};
+		}
+		// A media frame means every sequence header has arrived (FLV sends config before data), so
+		// the track set is declared; release the reservation to publish.
+		self.initial_reservation = None;
+		let stream = self.video.as_mut().expect("video stream present");
 		// FLV stores DTS in the tag; PTS is DTS plus the composition offset.
 		let pts_ms = (dts as i64) + (composition_time as i64);
 		if pts_ms < 0 {
@@ -342,10 +352,14 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 	/// Write one audio frame as its own group, so the relay can forward it immediately.
 	fn write_audio(&mut self, data: &[u8], timestamp: u64) -> anyhow::Result<()> {
-		let Some(stream) = self.audio.as_mut() else {
+		if self.audio.is_none() {
 			tracing::debug!("audio frame before config, dropping");
 			return Ok(());
-		};
+		}
+		// A media frame means every sequence header has arrived (FLV sends config before data), so
+		// the track set is declared; release the reservation to publish.
+		self.initial_reservation = None;
+		let stream = self.audio.as_mut().expect("audio stream present");
 		stream.track.write(Frame {
 			timestamp: Timestamp::from_millis(timestamp)?,
 			duration: None,

--- a/rs/moq-mux/src/container/flv/import_test.rs
+++ b/rs/moq-mux/src/container/flv/import_test.rs
@@ -91,7 +91,7 @@ async fn import_populates_catalog() {
 	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	let buf = bytes::BytesMut::from(synth_flv().as_slice());
 	importer.decode(&buf).unwrap();
 	importer.finish().unwrap();
@@ -117,7 +117,7 @@ async fn import_emits_frames() {
 	let consumer = producer.consume();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	let buf = bytes::BytesMut::from(synth_flv().as_slice());
 	importer.decode(&buf).unwrap();
 	importer.finish().unwrap();
@@ -146,7 +146,7 @@ async fn import_handles_split_input() {
 	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer.decode(&bytes::BytesMut::from(head)).unwrap();
 	importer.decode(&bytes::BytesMut::from(tail)).unwrap();
 	importer.finish().unwrap();
@@ -179,7 +179,7 @@ async fn import_enhanced_vp9() {
 
 	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
 	importer.finish().unwrap();
 
@@ -223,7 +223,7 @@ async fn import_enhanced_opus() {
 
 	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
 	importer.finish().unwrap();
 
@@ -258,7 +258,7 @@ async fn import_legacy_mp3() {
 
 	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
 	importer.finish().unwrap();
 
@@ -289,7 +289,7 @@ async fn import_enhanced_av1() {
 	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
 	importer.finish().unwrap();
 
@@ -316,7 +316,7 @@ async fn import_enhanced_ac3() {
 
 	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
 	importer.finish().unwrap();
 
@@ -338,7 +338,7 @@ async fn import_enhanced_eac3() {
 
 	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
 	importer.finish().unwrap();
 
@@ -387,7 +387,7 @@ async fn import_reports_negative_pts_and_can_resume() {
 	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	let err = importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap_err();
 	assert!(matches!(
 		err,
@@ -428,7 +428,7 @@ async fn import_enhanced_hvc1_applies_composition_time() {
 	let mut producer = moq_net::broadcast::Info::new().produce();
 	let consumer = producer.consume();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let mut importer = Import::new(producer, catalog.clone());
+	let mut importer = Import::new(producer, catalog.reserve());
 	importer.decode(&bytes::BytesMut::from(out.as_slice())).unwrap();
 	importer.finish().unwrap();
 
@@ -446,7 +446,7 @@ async fn import_rejects_non_flv() {
 	let mut producer = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 
-	let mut importer = Import::new(producer, catalog);
+	let mut importer = Import::new(producer, catalog.reserve());
 	let buf = bytes::BytesMut::from(&b"NOTFLV\x00\x00\x00"[..]);
 	assert!(importer.decode(&buf).is_err());
 }

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -491,7 +491,7 @@ async fn cmaf_source_to_cmaf_export_passthrough() {
 	let consumer = producer.consume();
 
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let mut importer = crate::container::fmp4::Import::new(producer, catalog);
+	let mut importer = crate::container::fmp4::Import::new(producer, catalog.reserve());
 	let buf = BytesMut::from(data.as_slice());
 	let _ = importer.decode(&buf);
 

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -32,6 +32,11 @@ pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
 	/// The catalog being produced
 	catalog: crate::catalog::Producer<E>,
 
+	/// Held until the moov's track set is declared, so the catalog is withheld from the broadcast
+	/// until every rendition is in (and, when composed with other importers, until they finish too).
+	/// Dropped in [`init`](Self::init).
+	initial_reservation: Option<crate::catalog::Reserved<E>>,
+
 	// Which track roles to publish. `None` imports every supported track.
 	select: Option<crate::select::Broadcast>,
 
@@ -83,9 +88,10 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	/// Create a new CMAF importer that will write to the given broadcast.
 	///
 	/// The broadcast will be populated with tracks as they're discovered in the fMP4 file.
-	pub fn new(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
+	pub fn new(broadcast: moq_net::broadcast::Producer, reserved: crate::catalog::Reserved<E>) -> Self {
 		Self {
-			catalog,
+			catalog: reserved.producer(),
+			initial_reservation: Some(reserved),
 			select: None,
 			tracks: HashMap::default(),
 			skipped: HashSet::default(),
@@ -241,6 +247,9 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		}
 
 		drop(catalog);
+
+		// The moov's full track set is declared now; release the reservation so the catalog publishes.
+		self.initial_reservation = None;
 
 		self.moov = Some(moov);
 

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -17,7 +17,7 @@ fn run_fmp4(data: &[u8]) -> crate::catalog::hang::Catalog {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
-	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.clone());
+	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.reserve());
 
 	let buf = bytes::BytesMut::from(data);
 	// Ignore errors from incomplete/malformed trailing fragments in test files.
@@ -30,7 +30,7 @@ fn run_fmp4_select(data: &[u8], select: crate::select::Broadcast) -> crate::cata
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
-	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.clone()).with_select(select);
+	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.reserve()).with_select(select);
 
 	// A dropped track's moof fragments must be skipped, not raise `UnknownTrack`.
 	// (The test files end on a malformed fragment, so other decode errors are expected
@@ -201,7 +201,7 @@ async fn test_seek_sets_initial_sequence() {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let broadcast_consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.clone());
+	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.reserve());
 
 	let data = include_bytes!("test_data/bbb.mp4");
 
@@ -267,7 +267,7 @@ async fn test_msf_catalog_roundtrip() {
 	// MSF catalog track has been created by `catalog::Producer::new`.
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog);
+	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.reserve());
 
 	let data = include_bytes!("test_data/bbb.mp4");
 	let buf = bytes::BytesMut::from(&data[..]);

--- a/rs/moq-mux/src/container/mkv/export_test.rs
+++ b/rs/moq-mux/src/container/mkv/export_test.rs
@@ -22,7 +22,7 @@ async fn export_header_roundtrip_vp9_opus() {
 	let consumer = producer.consume();
 
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let mut importer = crate::container::mkv::Import::new(producer, catalog.clone());
+	let mut importer = crate::container::mkv::Import::new(producer, catalog.reserve());
 	let buf = bytes::BytesMut::from(import_bytes.as_slice());
 	importer.decode(&buf).unwrap();
 	importer.finish().unwrap();
@@ -125,7 +125,7 @@ async fn export_header_roundtrip_vp9_opus() {
 	// to populate the catalog).
 	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 	let catalog2 = crate::catalog::Producer::new(&mut broadcast2).unwrap();
-	let mut importer2 = crate::container::mkv::Import::new(broadcast2, catalog2.clone());
+	let mut importer2 = crate::container::mkv::Import::new(broadcast2, catalog2.reserve());
 	let hbuf = bytes::BytesMut::from(header.as_ref());
 	importer2.decode(&hbuf).unwrap();
 	let snap = catalog2.snapshot();
@@ -202,7 +202,7 @@ async fn export_header_roundtrip_mp3() {
 	let consumer = producer.consume();
 
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let mut importer = crate::container::mkv::Import::new(producer, catalog.clone());
+	let mut importer = crate::container::mkv::Import::new(producer, catalog.reserve());
 	importer
 		.decode(&bytes::BytesMut::from(import_bytes.as_slice()))
 		.unwrap();
@@ -222,7 +222,7 @@ async fn export_header_roundtrip_mp3() {
 	// Re-import the exported header and confirm the codec rebuilds.
 	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 	let catalog2 = crate::catalog::Producer::new(&mut broadcast2).unwrap();
-	let mut importer2 = crate::container::mkv::Import::new(broadcast2, catalog2.clone());
+	let mut importer2 = crate::container::mkv::Import::new(broadcast2, catalog2.reserve());
 	importer2.decode(&bytes::BytesMut::from(header.as_ref())).unwrap();
 
 	let snap = catalog2.snapshot();
@@ -315,7 +315,7 @@ async fn export_emits_blocks_for_each_frame() {
 	let consumer = producer.consume();
 
 	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let mut importer = crate::container::mkv::Import::new(producer, catalog.clone());
+	let mut importer = crate::container::mkv::Import::new(producer, catalog.reserve());
 	let buf = bytes::BytesMut::from(import_bytes.as_slice());
 	importer.decode(&buf).unwrap();
 	importer.finish().unwrap();
@@ -364,7 +364,7 @@ async fn export_emits_blocks_for_each_frame() {
 	// and check the catalog repopulates with the same codecs.
 	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
-	let mut imp2 = crate::container::mkv::Import::new(bcast2, cat2.clone());
+	let mut imp2 = crate::container::mkv::Import::new(bcast2, cat2.reserve());
 	let rt = bytes::BytesMut::from(exported.as_slice());
 	imp2.decode(&rt).unwrap();
 	imp2.finish().unwrap();
@@ -601,7 +601,7 @@ async fn export_avc3_source_synthesizes_avcc_and_length_prefixes() {
 	// pass even when the record as a whole is malformed.
 	let mut bcast2 = moq_net::broadcast::Info::new().produce();
 	let cat2 = crate::catalog::Producer::new(&mut bcast2).unwrap();
-	let mut imp2 = crate::container::mkv::Import::new(bcast2, cat2.clone());
+	let mut imp2 = crate::container::mkv::Import::new(bcast2, cat2.reserve());
 	let rt = bytes::BytesMut::from(exported.as_slice());
 	imp2.decode(&rt).unwrap();
 	imp2.finish().unwrap();
@@ -627,7 +627,7 @@ async fn export_fragment_duration_batches_blocks() {
 	let consumer = producer.consume();
 
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let mut importer = crate::container::mkv::Import::new(producer, catalog.clone());
+	let mut importer = crate::container::mkv::Import::new(producer, catalog.reserve());
 	let buf = bytes::BytesMut::from(import_bytes.as_slice());
 	importer.decode(&buf).unwrap();
 	importer.finish().unwrap();

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -42,6 +42,10 @@ pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
 	broadcast: moq_net::broadcast::Producer,
 	catalog: crate::catalog::Producer<E>,
 
+	/// Held until the Tracks element is processed, so the catalog is withheld from the broadcast
+	/// until every rendition is in (and, when composed with other importers, until they finish too).
+	initial_reservation: Option<crate::catalog::Reserved<E>>,
+
 	/// Accumulated unparsed input.
 	buffer: BytesMut,
 	/// Whether the Tracks element has been processed.
@@ -72,10 +76,11 @@ struct MkvTrack {
 }
 
 impl<E: crate::catalog::hang::CatalogExt> Import<E> {
-	pub fn new(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
+	pub fn new(broadcast: moq_net::broadcast::Producer, reserved: crate::catalog::Reserved<E>) -> Self {
 		Self {
 			broadcast,
-			catalog,
+			catalog: reserved.producer(),
+			initial_reservation: Some(reserved),
 			buffer: BytesMut::new(),
 			tracks_seen: false,
 			timestamp_scale_ns: DEFAULT_TIMESTAMP_SCALE_NS,
@@ -184,6 +189,8 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			MatroskaSpec::Tracks(Master::Full(children)) if !self.tracks_seen => {
 				self.handle_tracks(children)?;
 				self.tracks_seen = true;
+				// The full track set is declared now; release the reservation so the catalog publishes.
+				self.initial_reservation = None;
 			}
 			MatroskaSpec::Cluster(Master::Start) => {
 				self.cluster_timestamp = 0;

--- a/rs/moq-mux/src/container/mkv/import_test.rs
+++ b/rs/moq-mux/src/container/mkv/import_test.rs
@@ -181,7 +181,7 @@ fn track_entry_video_vp9(number: u64, width: u64, height: u64) -> MatroskaSpec {
 fn run(data: &[u8]) -> crate::catalog::hang::Catalog {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut mkv = crate::container::mkv::Import::new(broadcast, catalog.clone());
+	let mut mkv = crate::container::mkv::Import::new(broadcast, catalog.reserve());
 	let buf = bytes::BytesMut::from(data);
 	mkv.decode(&buf).expect("decode");
 	mkv.finish().expect("finish");
@@ -312,7 +312,7 @@ fn test_chunked_decode_dedup() {
 
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut mkv = crate::container::mkv::Import::new(broadcast, catalog.clone());
+	let mut mkv = crate::container::mkv::Import::new(broadcast, catalog.reserve());
 
 	// Feed in 16-byte chunks to stress the chunked-restart code path.
 	for chunk in data.chunks(16) {

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -505,7 +505,7 @@ async fn export_bframe_video_authors_dts() {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 	import.decode(&BytesMut::from(&data[..])).unwrap();
 	import.finish().unwrap();
 
@@ -609,7 +609,7 @@ async fn export_scte35_roundtrip() {
 	scte_producer.finish().unwrap();
 
 	// Now add the real video/audio by importing bbb.ts (this moves `broadcast`).
-	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 	import.decode(&BytesMut::from(&data[..])).unwrap();
 	import.finish().unwrap();
 
@@ -651,7 +651,7 @@ async fn export_scte35_roundtrip() {
 	let catalog2 =
 		crate::catalog::Producer::with_catalog(&mut broadcast2, crate::catalog::hang::Catalog::<tscat::Ext>::default())
 			.unwrap();
-	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.clone());
+	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.reserve());
 	import2.decode(&BytesMut::from(ts.as_ref())).unwrap();
 	import2.finish().unwrap();
 
@@ -724,7 +724,7 @@ async fn export_pes_verbatim_roundtrip() {
 	data_producer.finish().unwrap();
 
 	// Real video/audio supplies the media clock (moves `broadcast`).
-	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 	import.decode(&BytesMut::from(&data[..])).unwrap();
 	import.finish().unwrap();
 
@@ -743,7 +743,7 @@ async fn export_pes_verbatim_roundtrip() {
 	let catalog2 =
 		crate::catalog::Producer::with_catalog(&mut broadcast2, crate::catalog::hang::Catalog::<tscat::Ext>::default())
 			.unwrap();
-	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.clone());
+	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.reserve());
 	import2.decode(&BytesMut::from(ts.as_ref())).unwrap();
 	import2.finish().unwrap();
 
@@ -853,7 +853,7 @@ async fn mp2_kyrion_roundtrip_byte_exact() {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 	import.decode(&BytesMut::from(&data[..])).unwrap();
 	import.finish().unwrap();
 
@@ -889,7 +889,7 @@ async fn mp2_kyrion_roundtrip_byte_exact() {
 	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 	let consumer2 = broadcast2.consume();
 	let catalog2 = crate::catalog::Producer::new(&mut broadcast2).unwrap();
-	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.clone());
+	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.reserve());
 	import2.decode(&BytesMut::from(ts.as_ref())).unwrap();
 	import2.finish().unwrap();
 
@@ -922,7 +922,7 @@ async fn ac3_roundtrip_byte_exact() {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 	import.decode(&BytesMut::from(&data[..])).unwrap();
 	import.finish().unwrap();
 
@@ -966,7 +966,7 @@ async fn ac3_roundtrip_byte_exact() {
 	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 	let consumer2 = broadcast2.consume();
 	let catalog2 = crate::catalog::Producer::new(&mut broadcast2).unwrap();
-	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.clone());
+	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.reserve());
 	import2.decode(&BytesMut::from(ts.as_ref())).unwrap();
 	import2.finish().unwrap();
 
@@ -992,7 +992,7 @@ async fn eac3_roundtrip_byte_exact() {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 	import.decode(&BytesMut::from(&data[..])).unwrap();
 	import.finish().unwrap();
 
@@ -1039,7 +1039,7 @@ async fn eac3_roundtrip_byte_exact() {
 	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 	let consumer2 = broadcast2.consume();
 	let catalog2 = crate::catalog::Producer::new(&mut broadcast2).unwrap();
-	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.clone());
+	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.reserve());
 	import2.decode(&BytesMut::from(ts.as_ref())).unwrap();
 	import2.finish().unwrap();
 
@@ -1079,7 +1079,7 @@ async fn kyrion_ac3_mp2_roundtrip_byte_exact() {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 	import.decode(&BytesMut::from(&data[..])).unwrap();
 	import.finish().unwrap();
 
@@ -1127,7 +1127,7 @@ async fn kyrion_ac3_mp2_roundtrip_byte_exact() {
 	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
 	let consumer2 = broadcast2.consume();
 	let catalog2 = crate::catalog::Producer::new(&mut broadcast2).unwrap();
-	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.clone());
+	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.reserve());
 	import2.decode(&BytesMut::from(ts.as_ref())).unwrap();
 	import2.finish().unwrap();
 
@@ -1220,7 +1220,7 @@ async fn scte35_fixtures_survive_roundtrip() {
 			crate::catalog::hang::Catalog::<tscat::Ext>::default(),
 		)
 		.unwrap();
-		let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+		let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 		import.decode(&BytesMut::from(&data[..])).unwrap();
 		import.finish().unwrap();
 
@@ -1276,7 +1276,7 @@ async fn scte35_fixtures_survive_roundtrip() {
 			crate::catalog::hang::Catalog::<tscat::Ext>::default(),
 		)
 		.unwrap();
-		let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.clone());
+		let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.reserve());
 		import2.decode(&BytesMut::from(ts.as_ref())).unwrap();
 		import2.finish().unwrap();
 		let name2 = scte_track(&catalog2.snapshot()).expect("a scte35 track");
@@ -1446,7 +1446,7 @@ async fn opus_export_import_roundtrip() {
 	let mut imported = moq_net::broadcast::Info::new().produce();
 	let imported_consumer = imported.consume();
 	let import_catalog = crate::catalog::Producer::new(&mut imported).unwrap();
-	let mut import = crate::container::ts::Import::new(imported, import_catalog.clone());
+	let mut import = crate::container::ts::Import::new(imported, import_catalog.reserve());
 	import.decode(&ts).unwrap();
 	import.finish().unwrap();
 

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -44,6 +44,12 @@ pub struct Import<E: catalog::Catalog = ()> {
 	broadcast: moq_net::broadcast::Producer,
 	catalog: crate::catalog::Producer<E>,
 
+	/// Held while the first PMT is parsed so the catalog is withheld from the broadcast until every
+	/// stream in the initial program has reserved its rendition. Dropped once the PMT is fully
+	/// processed, so a one-shot muxer (fMP4, TS re-export) sees the complete track list in the first
+	/// snapshot rather than a half-converged one. See [`Reserved`](crate::catalog::Reserved).
+	initial_reservation: Option<crate::catalog::Reserved<E>>,
+
 	/// Shared, refillable byte source the persistent reader pulls whole packets
 	/// from. Kept beside the reader so [`decode`](Self::decode) can append bytes
 	/// between reads without recreating the reader (which holds PAT/PMT state).
@@ -100,8 +106,11 @@ pub struct Import<E: catalog::Catalog = ()> {
 }
 
 impl<E: catalog::Catalog> Import<E> {
-	pub fn new(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
+	pub fn new(broadcast: moq_net::broadcast::Producer, reserved: crate::catalog::Reserved<E>) -> Self {
 		let feed = Feed::default();
+		// A long-lived producer handle for catalog edits (mpegts sections, later PMTs); the passed
+		// reservation gates the initial publish and is dropped once the first PMT is parsed.
+		let catalog = reserved.producer();
 		// Sample the real catalog once at construction, not E::default(): an extension
 		// may carry the section by value, and a snapshot clones under the mutex (no publish).
 		let mut snapshot = catalog.snapshot();
@@ -109,6 +118,7 @@ impl<E: catalog::Catalog> Import<E> {
 		Self {
 			broadcast,
 			catalog,
+			initial_reservation: Some(reserved),
 			reader: TsPacketReader::new(feed.clone()),
 			feed,
 			pmt_pids: HashSet::new(),
@@ -260,6 +270,10 @@ impl<E: catalog::Catalog> Import<E> {
 						self.ensure_stream(es.elementary_pid, es.stream_type, &es.descriptors)?;
 					}
 				}
+
+				// Every stream in the initial program is registered now; release the reservation
+				// so the catalog publishes once each rendition's config resolves, not before.
+				self.initial_reservation = None;
 			}
 			Some(TsPayload::PesStart(pes)) => self.handle_pes_start(pid, pes)?,
 			Some(TsPayload::PesContinuation(bytes)) => self.handle_pes_continuation(pid, &bytes)?,
@@ -297,7 +311,7 @@ impl<E: catalog::Catalog> Import<E> {
 				let track = crate::import::unique_track(&mut self.broadcast, ".avc3")?;
 				Stream::H264 {
 					split: h264::Split::new(),
-					import: Box::new(h264::Import::new(track, self.catalog.clone())),
+					import: Box::new(h264::Import::new(track, self.catalog.reserve())),
 					unwrap: PtsUnwrap::default(),
 				}
 			}
@@ -305,7 +319,7 @@ impl<E: catalog::Catalog> Import<E> {
 				let track = crate::import::unique_track(&mut self.broadcast, ".hev1")?;
 				Stream::H265 {
 					split: h265::Split::new(),
-					import: Box::new(h265::Import::new(track, self.catalog.clone())),
+					import: Box::new(h265::Import::new(track, self.catalog.reserve())),
 					unwrap: PtsUnwrap::default(),
 				}
 			}
@@ -314,7 +328,7 @@ impl<E: catalog::Catalog> Import<E> {
 			StreamType::AdtsAac => Stream::Aac(Box::new(AacStream {
 				import: None,
 				broadcast: self.broadcast.clone(),
-				catalog: self.catalog.clone(),
+				reserved: Some(self.catalog.reserve()),
 				unwrap: PtsUnwrap::default(),
 				jitter: None,
 			})),
@@ -335,7 +349,7 @@ impl<E: catalog::Catalog> Import<E> {
 					channel_count,
 				};
 				Stream::Opus(Box::new(OpusStream {
-					import: opus::Import::new(track, self.catalog.clone(), config)?,
+					import: opus::Import::new(track, self.catalog.reserve(), config)?,
 					unwrap: PtsUnwrap::default(),
 				}))
 			}
@@ -380,7 +394,7 @@ impl<E: catalog::Catalog> Import<E> {
 			descriptor,
 			import: None,
 			broadcast: self.broadcast.clone(),
-			catalog: self.catalog.clone(),
+			reserved: Some(self.catalog.reserve()),
 			unwrap: PtsUnwrap::default(),
 			tail: Vec::new(),
 			tail_pts: None,
@@ -1077,7 +1091,10 @@ impl<E: catalog::Catalog> Stream<E> {
 struct AacStream<E: CatalogExt = ()> {
 	import: Option<aac::Import<E>>,
 	broadcast: moq_net::broadcast::Producer,
-	catalog: crate::catalog::Producer<E>,
+	/// Reservation held from the PMT until the first frame builds the importer, so the catalog stays
+	/// withheld until this deferred rendition resolves (config comes from the first ADTS header).
+	/// Consumed when `import` is built.
+	reserved: Option<crate::catalog::Reserved<E>>,
 	unwrap: PtsUnwrap,
 	/// Largest audio burst span seen, published as the catalog jitter.
 	jitter: Option<Timestamp>,
@@ -1111,7 +1128,9 @@ impl<E: CatalogExt> AacStream<E> {
 					// WebCodecs) can configure the decoder. TS itself carries it inline.
 					let description = config.encode();
 					let track = crate::import::unique_track(&mut self.broadcast, ".aac")?;
-					let mut aac = aac::Import::new(track, self.catalog.clone(), config)?;
+					// Consume the reservation held since the PMT: this resolves the gated rendition.
+					let reserved = self.reserved.take().expect("aac reservation already consumed");
+					let mut aac = aac::Import::new(track, reserved, config)?;
 					aac.update_rendition(|rendition| rendition.description = Some(description));
 					self.import.insert(aac)
 				}
@@ -1319,7 +1338,10 @@ struct LegacyStream<E: CatalogExt = ()> {
 	descriptor: &'static legacy::Descriptor,
 	import: Option<legacy::Import<E>>,
 	broadcast: moq_net::broadcast::Producer,
-	catalog: crate::catalog::Producer<E>,
+	/// Reservation held from the PMT until the first frame builds the importer, so the catalog stays
+	/// withheld until this deferred rendition resolves (config comes from the first frame header).
+	/// Consumed when `import` is built.
+	reserved: Option<crate::catalog::Reserved<E>>,
 	unwrap: PtsUnwrap,
 	/// Partial frame left at the end of the previous PES. ISO 13818-1 doesn't
 	/// require audio frames to align with PES boundaries, so a legitimate mux can
@@ -1377,7 +1399,9 @@ impl<E: CatalogExt> LegacyStream<E> {
 						channel_count: header.channel_count,
 					};
 					let track = crate::import::unique_track(&mut self.broadcast, self.descriptor.track_suffix)?;
-					let legacy = legacy::Import::new(self.descriptor, track, self.catalog.clone(), config);
+					// Consume the reservation held since the PMT: this resolves the gated rendition.
+					let reserved = self.reserved.take().expect("legacy reservation already consumed");
+					let legacy = legacy::Import::new(self.descriptor, track, reserved, config);
 					self.import.insert(legacy)
 				}
 			};
@@ -1773,7 +1797,7 @@ mod test {
 
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::with_catalog(&mut broadcast, Catalog::<Ext>::default()).unwrap();
-		let mut import = super::Import::new(broadcast, catalog.clone());
+		let mut import = super::Import::new(broadcast, catalog.reserve());
 
 		let mut bytes = bytes::BytesMut::new();
 		bytes.extend_from_slice(&synth_pmt(&[(StreamType::Dts8ChannelLosslessAudio, 0x21)], true));
@@ -1796,7 +1820,7 @@ mod test {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 		let mut updates = catalog.consume().unwrap();
-		let mut import = super::Import::new(broadcast, catalog.clone());
+		let mut import = super::Import::new(broadcast, catalog.reserve());
 
 		let mut bytes = bytes::BytesMut::new();
 		bytes.extend_from_slice(&synth_pmt(&[(StreamType::Dts8ChannelLosslessAudio, 0x21)], true));
@@ -1840,7 +1864,7 @@ mod test {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let consumer = broadcast.consume();
 		let catalog = crate::catalog::Producer::with_catalog(&mut broadcast, Catalog::<Ext>::default()).unwrap();
-		let mut import = super::Import::new(broadcast, catalog.clone());
+		let mut import = super::Import::new(broadcast, catalog.reserve());
 
 		// First PMT lacks CUEI: the 0x86 PID is ambiguous and routes to Ignored.
 		let mut bytes = bytes::BytesMut::new();
@@ -1922,7 +1946,7 @@ mod test {
 
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-		let mut import = super::Import::new(broadcast, catalog);
+		let mut import = super::Import::new(broadcast, catalog.reserve());
 
 		let mut bytes = bytes::BytesMut::new();
 		bytes.extend_from_slice(&synth_pmt(
@@ -1997,7 +2021,7 @@ mod test {
 
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-		let mut import = super::Import::new(broadcast, catalog.clone());
+		let mut import = super::Import::new(broadcast, catalog.reserve());
 
 		let mut bytes = bytes::BytesMut::new();
 		bytes.extend_from_slice(&synth_pmt(
@@ -2067,7 +2091,7 @@ mod test {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let consumer = broadcast.consume();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-		let mut import = super::Import::new(broadcast, catalog.clone());
+		let mut import = super::Import::new(broadcast, catalog.reserve());
 
 		let pmt = synth_pmt(&[(StreamType::Mpeg1Audio, MP2_PID)], false);
 		import.decode(&bytes::BytesMut::from(&pmt[..])).unwrap();
@@ -2113,7 +2137,7 @@ mod test {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let consumer = broadcast.consume();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-		let mut import = super::Import::new(broadcast, catalog.clone());
+		let mut import = super::Import::new(broadcast, catalog.reserve());
 
 		let pmt = synth_pmt(&[(StreamType::Mpeg1Audio, MP2_PID)], false);
 		import.decode(&bytes::BytesMut::from(&pmt[..])).unwrap();
@@ -2161,7 +2185,7 @@ mod test {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let consumer = broadcast.consume();
 		let catalog = crate::catalog::Producer::with_catalog(&mut broadcast, Catalog::<Ext>::default()).unwrap();
-		let mut import = super::Import::new(broadcast, catalog.clone());
+		let mut import = super::Import::new(broadcast, catalog.reserve());
 
 		let mut bytes = bytes::BytesMut::new();
 		bytes.extend_from_slice(&synth_pmt(
@@ -2212,7 +2236,7 @@ mod test {
 		// catalog::Ext (not the base catalog) makes a wrong ensure_scte() observable: it
 		// would create a rendition, which the base catalog silently drops.
 		let catalog = crate::catalog::Producer::with_catalog(&mut broadcast, Catalog::<Ext>::default()).unwrap();
-		let mut import = super::Import::new(broadcast, catalog.clone());
+		let mut import = super::Import::new(broadcast, catalog.reserve());
 
 		let mut bytes = bytes::BytesMut::new();
 		// PMT WITHOUT CUEI: the 0x86 PID must not be recognized as SCTE-35.
@@ -2283,7 +2307,7 @@ mod test {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let consumer = broadcast.consume();
 		let catalog = crate::catalog::Producer::with_catalog(&mut broadcast, Catalog::<Ext>::default()).unwrap();
-		let mut import = super::Import::new(broadcast, catalog.clone());
+		let mut import = super::Import::new(broadcast, catalog.reserve());
 
 		let mut bytes = bytes::BytesMut::new();
 		bytes.extend_from_slice(&synth_pmt(

--- a/rs/moq-mux/src/container/ts/import_test.rs
+++ b/rs/moq-mux/src/container/ts/import_test.rs
@@ -10,7 +10,7 @@ fn import_ts(data: &[u8]) -> crate::catalog::hang::Catalog {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
-	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 	let buf = BytesMut::from(data);
 	import.decode(&buf).unwrap();
 	import.finish().unwrap();
@@ -129,7 +129,7 @@ async fn import_opus_frames() {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 	import.decode(&BytesMut::from(&data[..])).unwrap();
 	import.finish().unwrap();
 
@@ -248,7 +248,7 @@ fn resyncs_across_chunk_boundaries() {
 
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 	for chunk in misaligned.chunks(100) {
 		import.decode(&BytesMut::from(chunk)).unwrap();
 	}
@@ -275,7 +275,7 @@ async fn import_export_import_roundtrip() {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 	let buf = BytesMut::from(&data[..]);
 	import.decode(&buf).unwrap();
 	import.finish().unwrap();
@@ -322,7 +322,7 @@ async fn survives_midstream_join() {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 	import
 		.decode(&BytesMut::from(&buf[..]))
 		.expect("a mid-stream join must not abort the demux");
@@ -361,7 +361,7 @@ async fn kyrion_dirtystart_extracts_real_cues() {
 		crate::catalog::hang::Catalog::<crate::container::ts::catalog::Ext>::default(),
 	)
 	.unwrap();
-	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 	import
 		.decode(&BytesMut::from(&data[..]))
 		.expect("a dirty mid-stream join must not abort the demux");
@@ -409,7 +409,7 @@ fn import_handles_unaligned_chunks() {
 
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-	let mut import = crate::container::ts::Import::new(broadcast, catalog.clone());
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
 
 	for chunk in data.chunks(100) {
 		let buf = BytesMut::from(chunk);

--- a/rs/moq-mux/src/import/container.rs
+++ b/rs/moq-mux/src/import/container.rs
@@ -19,20 +19,20 @@ enum ContainerImpl<E: crate::container::ts::catalog::Catalog = ()> {
 }
 
 impl<E: crate::container::ts::catalog::Catalog> ContainerImpl<E> {
-	fn fmp4(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
-		ContainerImpl::Fmp4(Box::new(crate::container::fmp4::Import::new(broadcast, catalog)))
+	fn fmp4(broadcast: moq_net::broadcast::Producer, reserved: crate::catalog::Reserved<E>) -> Self {
+		ContainerImpl::Fmp4(Box::new(crate::container::fmp4::Import::new(broadcast, reserved)))
 	}
 
-	fn mkv(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
-		ContainerImpl::Mkv(Box::new(crate::container::mkv::Import::new(broadcast, catalog)))
+	fn mkv(broadcast: moq_net::broadcast::Producer, reserved: crate::catalog::Reserved<E>) -> Self {
+		ContainerImpl::Mkv(Box::new(crate::container::mkv::Import::new(broadcast, reserved)))
 	}
 
-	fn ts(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
-		ContainerImpl::Ts(Box::new(crate::container::ts::Import::new(broadcast, catalog)))
+	fn ts(broadcast: moq_net::broadcast::Producer, reserved: crate::catalog::Reserved<E>) -> Self {
+		ContainerImpl::Ts(Box::new(crate::container::ts::Import::new(broadcast, reserved)))
 	}
 
-	fn flv(broadcast: moq_net::broadcast::Producer, catalog: crate::catalog::Producer<E>) -> Self {
-		ContainerImpl::Flv(Box::new(crate::container::flv::Import::new(broadcast, catalog)))
+	fn flv(broadcast: moq_net::broadcast::Producer, reserved: crate::catalog::Reserved<E>) -> Self {
+		ContainerImpl::Flv(Box::new(crate::container::flv::Import::new(broadcast, reserved)))
 	}
 
 	fn decode(&mut self, data: &[u8]) -> Result<()> {
@@ -75,15 +75,15 @@ impl<E: crate::container::ts::catalog::Catalog> Container<E> {
 	/// Create a new container importer, decoding the initial chunk.
 	pub fn new(
 		broadcast: moq_net::broadcast::Producer,
-		catalog: crate::catalog::Producer<E>,
+		reserved: crate::catalog::Reserved<E>,
 		format: &str,
 		init: &[u8],
 	) -> Result<Self> {
 		let mut inner = match format {
-			"fmp4" | "cmaf" => ContainerImpl::fmp4(broadcast, catalog),
-			"mkv" | "webm" | "matroska" => ContainerImpl::mkv(broadcast, catalog),
-			"ts" | "mpegts" | "mpeg2ts" | "m2ts" => ContainerImpl::ts(broadcast, catalog),
-			"flv" => ContainerImpl::flv(broadcast, catalog),
+			"fmp4" | "cmaf" => ContainerImpl::fmp4(broadcast, reserved),
+			"mkv" | "webm" | "matroska" => ContainerImpl::mkv(broadcast, reserved),
+			"ts" | "mpegts" | "mpeg2ts" | "m2ts" => ContainerImpl::ts(broadcast, reserved),
+			"flv" => ContainerImpl::flv(broadcast, reserved),
 			_ => return Err(crate::Error::UnknownFormat(format.to_string())),
 		};
 		inner.decode(init)?;
@@ -118,7 +118,7 @@ impl<E: crate::container::ts::catalog::Catalog> ContainerStream<E> {
 	/// Create a new container stream importer.
 	pub fn new(
 		broadcast: moq_net::broadcast::Producer,
-		catalog: crate::catalog::Producer<E>,
+		reserved: crate::catalog::Reserved<E>,
 		format: &str,
 	) -> Result<Self> {
 		// A separate list from [`Container::new`]: only containers that can be
@@ -126,10 +126,10 @@ impl<E: crate::container::ts::catalog::Catalog> ContainerStream<E> {
 		// but a non-streamable container (e.g. RTP) would be added to `Container`
 		// alone.
 		let inner = match format {
-			"fmp4" | "cmaf" => ContainerImpl::fmp4(broadcast, catalog),
-			"mkv" | "webm" | "matroska" => ContainerImpl::mkv(broadcast, catalog),
-			"ts" | "mpegts" | "mpeg2ts" | "m2ts" => ContainerImpl::ts(broadcast, catalog),
-			"flv" => ContainerImpl::flv(broadcast, catalog),
+			"fmp4" | "cmaf" => ContainerImpl::fmp4(broadcast, reserved),
+			"mkv" | "webm" | "matroska" => ContainerImpl::mkv(broadcast, reserved),
+			"ts" | "mpegts" | "mpeg2ts" | "m2ts" => ContainerImpl::ts(broadcast, reserved),
+			"flv" => ContainerImpl::flv(broadcast, reserved),
 			_ => return Err(crate::Error::UnknownFormat(format.to_string())),
 		};
 		Ok(Self { inner })

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -15,10 +15,10 @@ use crate::catalog::hang::CatalogExt;
 /// init buffer are published.
 fn build_h264_avc3<E: CatalogExt>(
 	track: moq_net::track::Producer,
-	catalog: crate::catalog::Producer<E>,
+	reserved: crate::catalog::Reserved<E>,
 	init: &[u8],
 ) -> Result<(crate::codec::h264::Split, crate::codec::h264::Import<E>)> {
-	let mut import = crate::codec::h264::Import::new(track, catalog);
+	let mut import = crate::codec::h264::Import::new(track, reserved);
 	import.initialize(init)?;
 	let mut split = crate::codec::h264::Split::new();
 	let frames = split.decode(init, None)?;
@@ -31,10 +31,10 @@ fn build_h264_avc3<E: CatalogExt>(
 /// [`crate::codec::h264::avc1_frame`].
 fn build_h264_avc1<E: CatalogExt>(
 	track: moq_net::track::Producer,
-	catalog: crate::catalog::Producer<E>,
+	reserved: crate::catalog::Reserved<E>,
 	init: &[u8],
 ) -> Result<(usize, crate::codec::h264::Import<E>)> {
-	let mut import = crate::codec::h264::Import::new(track, catalog);
+	let mut import = crate::codec::h264::Import::new(track, reserved);
 	import.initialize(init)?;
 	let length_size = crate::codec::h264::Avcc::parse(init)?.length_size;
 	Ok((length_size, import))
@@ -43,10 +43,10 @@ fn build_h264_avc1<E: CatalogExt>(
 /// Build an H.265 split + import pair, resolving the config from `init`.
 fn build_h265<E: CatalogExt>(
 	track: moq_net::track::Producer,
-	catalog: crate::catalog::Producer<E>,
+	reserved: crate::catalog::Reserved<E>,
 	init: &[u8],
 ) -> Result<(crate::codec::h265::Split, crate::codec::h265::Import<E>)> {
-	let mut import = crate::codec::h265::Import::new(track, catalog);
+	let mut import = crate::codec::h265::Import::new(track, reserved);
 	import.initialize(init)?;
 	let mut split = crate::codec::h265::Split::new();
 	let frames = split.decode(init, None)?;
@@ -57,10 +57,10 @@ fn build_h265<E: CatalogExt>(
 /// Build an AV1 split + import pair, resolving the config from `init`.
 fn build_av1<E: CatalogExt>(
 	track: moq_net::track::Producer,
-	catalog: crate::catalog::Producer<E>,
+	reserved: crate::catalog::Reserved<E>,
 	init: &[u8],
 ) -> Result<(crate::codec::av1::Split, crate::codec::av1::Import<E>)> {
-	let mut import = crate::codec::av1::Import::new(track, catalog);
+	let mut import = crate::codec::av1::Import::new(track, reserved);
 	import.initialize(init)?;
 	let mut split = crate::codec::av1::Split::new();
 	// av1C (leading 0x81, ISO/IEC 14496-15) is an out-of-band config record, not an
@@ -123,7 +123,7 @@ impl<E: CatalogExt> Track<E> {
 	/// The catalog rendition is registered once the codec config is resolved.
 	pub fn new(
 		request: moq_net::track::Request,
-		catalog: crate::catalog::Producer<E>,
+		reserved: crate::catalog::Reserved<E>,
 		format: &str,
 		init: &[u8],
 	) -> Result<Self> {
@@ -133,48 +133,48 @@ impl<E: CatalogExt> Track<E> {
 		let track = request.accept(moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE));
 		let kind = match format {
 			"avc1" | "avcc" => {
-				let (length_size, import) = build_h264_avc1(track, catalog, init)?;
+				let (length_size, import) = build_h264_avc1(track, reserved, init)?;
 				TrackKind::Avc1 { length_size, import }
 			}
 			"avc3" | "h264" => {
-				let (split, import) = build_h264_avc3(track, catalog, init)?;
+				let (split, import) = build_h264_avc3(track, reserved, init)?;
 				TrackKind::Avc3 { split, import }
 			}
 			"hev1" => {
-				let (split, import) = build_h265(track, catalog, init)?;
+				let (split, import) = build_h265(track, reserved, init)?;
 				TrackKind::Hev1 { split, import }
 			}
 			"av01" | "av1" | "av1c" | "av1C" => {
-				let (split, import) = build_av1(track, catalog, init)?;
+				let (split, import) = build_av1(track, reserved, init)?;
 				TrackKind::Av01 { split, import }
 			}
 			"vp8" | "vp08" => {
-				let mut import = crate::codec::vp8::Import::new(track, catalog);
+				let mut import = crate::codec::vp8::Import::new(track, reserved);
 				import.initialize(init)?;
 				TrackKind::Vp8(import)
 			}
 			"vp9" | "vp09" => {
-				let mut import = crate::codec::vp9::Import::new(track, catalog);
+				let mut import = crate::codec::vp9::Import::new(track, reserved);
 				import.initialize(init)?;
 				TrackKind::Vp9(import)
 			}
 			"aac" => {
 				let mut data = init;
 				let config = crate::codec::aac::Config::parse(&mut data)?;
-				let import = crate::codec::aac::Import::new(track, catalog, config)?;
+				let import = crate::codec::aac::Import::new(track, reserved, config)?;
 				TrackKind::Aac(import)
 			}
 			"opus" => {
 				let mut data = init;
 				let config = crate::codec::opus::Config::parse(&mut data)?;
-				let import = crate::codec::opus::Import::new(track, catalog, config)?;
+				let import = crate::codec::opus::Import::new(track, reserved, config)?;
 				TrackKind::Opus(import)
 			}
 			"flac" => {
 				// `init` is a FLAC header: the `fLaC` marker plus the STREAMINFO block.
 				let mut data = init;
 				let config = crate::codec::flac::Config::parse(&mut data)?;
-				let import = crate::codec::flac::Import::new(track, catalog, config)?;
+				let import = crate::codec::flac::Import::new(track, reserved, config)?;
 				TrackKind::Flac(import)
 			}
 			_ => return Err(crate::Error::UnknownFormat(format.to_string())),
@@ -365,21 +365,21 @@ impl<E: CatalogExt> TrackStream<E> {
 	/// [`BroadcastProducer::reserve_track`](moq_net::broadcast::Producer::reserve_track);
 	/// the importer accepts it here at the legacy microsecond timescale (where a
 	/// codec-specific timescale would be chosen).
-	pub fn new(request: moq_net::track::Request, catalog: crate::catalog::Producer<E>, format: &str) -> Result<Self> {
+	pub fn new(request: moq_net::track::Request, reserved: crate::catalog::Reserved<E>, format: &str) -> Result<Self> {
 		let track = request.accept(moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE));
 		// Only the self-delimiting codecs can be recovered from a raw byte stream.
 		let kind = match format {
 			"avc3" | "h264" => TrackStreamKind::Avc3 {
 				split: crate::codec::h264::Split::new(),
-				import: crate::codec::h264::Import::new(track, catalog),
+				import: crate::codec::h264::Import::new(track, reserved),
 			},
 			"hev1" => TrackStreamKind::Hev1 {
 				split: crate::codec::h265::Split::new(),
-				import: crate::codec::h265::Import::new(track, catalog),
+				import: crate::codec::h265::Import::new(track, reserved),
 			},
 			"av01" | "av1" | "av1c" | "av1C" => TrackStreamKind::Av01 {
 				split: crate::codec::av1::Split::new(),
-				import: crate::codec::av1::Import::new(track, catalog),
+				import: crate::codec::av1::Import::new(track, reserved),
 			},
 			_ => return Err(crate::Error::UnknownFormat(format.to_string())),
 		};
@@ -568,7 +568,7 @@ mod tests {
 		let (mut broadcast, catalog) = new_broadcast();
 		// The importer accepts the reserved track, setting its (microsecond) timescale.
 		let request = broadcast.reserve_track("requested-audio").unwrap();
-		let mut import = Track::new(request, catalog.clone(), "opus", &opus_head()).unwrap();
+		let mut import = Track::new(request, catalog.reserve(), "opus", &opus_head()).unwrap();
 
 		assert_eq!(import.name(), "requested-audio");
 		let snapshot = catalog.snapshot();
@@ -589,7 +589,7 @@ mod tests {
 		// A freshly reserved track attaches its catalog rendition on init.
 		let name = broadcast.unique_name(".opus");
 		let request = broadcast.reserve_track(name).unwrap();
-		let mut import = Track::new(request, catalog.clone(), "opus", &opus_head()).unwrap();
+		let mut import = Track::new(request, catalog.reserve(), "opus", &opus_head()).unwrap();
 
 		assert_eq!(import.name(), "0.opus");
 		assert!(catalog.snapshot().audio.renditions.contains_key("0.opus"));
@@ -619,7 +619,7 @@ mod tests {
 			sample_rate: 48_000,
 			channel_count: 2,
 		};
-		let mut import = crate::codec::opus::Import::new(track, catalog.clone(), config).unwrap();
+		let mut import = crate::codec::opus::Import::new(track, catalog.reserve(), config).unwrap();
 		assert!(catalog.snapshot().audio.renditions.contains_key("audio"));
 
 		let mut media = crate::container::Consumer::new(subscriber, crate::catalog::hang::Container::Legacy);
@@ -645,7 +645,7 @@ mod tests {
 		let (mut broadcast, catalog) = new_broadcast();
 		let request = broadcast.reserve_track("camera").unwrap();
 
-		let import = Track::new(request, catalog.clone(), "avc3", &h264_init()).unwrap();
+		let import = Track::new(request, catalog.reserve(), "avc3", &h264_init()).unwrap();
 
 		assert_eq!(import.name(), "camera");
 		let snapshot = catalog.snapshot();
@@ -661,7 +661,7 @@ mod tests {
 	async fn reconfiguration_updates_in_place() {
 		let (mut broadcast, catalog) = new_broadcast();
 		let request = broadcast.reserve_track("video").unwrap();
-		let mut import = Track::new(request, catalog, "vp8", &[]).unwrap();
+		let mut import = Track::new(request, catalog.reserve(), "vp8", &[]).unwrap();
 
 		import
 			.decode(

--- a/rs/moq-rtc/src/codec/h264.rs
+++ b/rs/moq-rtc/src/codec/h264.rs
@@ -15,7 +15,7 @@ pub struct Bridge {
 impl Bridge {
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
 		let track = moq_mux::import::unique_track(&mut broadcast, ".avc3")?;
-		let import = moq_mux::codec::h264::Import::new(track, catalog);
+		let import = moq_mux::codec::h264::Import::new(track, catalog.reserve());
 		let split = moq_mux::codec::h264::Split::new();
 		Ok(Self { split, import })
 	}

--- a/rs/moq-rtc/src/codec/opus.rs
+++ b/rs/moq-rtc/src/codec/opus.rs
@@ -21,7 +21,7 @@ impl Bridge {
 			channel_count,
 		};
 		let track = moq_mux::import::unique_track(&mut broadcast, ".opus")?;
-		let import = moq_mux::codec::opus::Import::new(track, catalog, config)?;
+		let import = moq_mux::codec::opus::Import::new(track, catalog.reserve(), config)?;
 		Ok(Self { import })
 	}
 }

--- a/rs/moq-rtmp/src/dial.rs
+++ b/rs/moq-rtmp/src/dial.rs
@@ -423,7 +423,7 @@ impl Publisher {
 	fn new(origin: &origin::Producer, path: &str) -> anyhow::Result<Self> {
 		let mut broadcast = broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
-		let mut importer = FlvImport::new(broadcast.clone(), catalog);
+		let mut importer = FlvImport::new(broadcast.clone(), catalog.reserve());
 
 		let publish = origin
 			.publish_broadcast(path, broadcast.consume())
@@ -481,7 +481,7 @@ mod tests {
 		let server_origin = moq_net::Origin::random().produce();
 		let mut broadcast = broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
-		let mut importer = FlvImport::new(broadcast.clone(), catalog);
+		let mut importer = FlvImport::new(broadcast.clone(), catalog.reserve());
 		let _publish = server_origin
 			.publish_broadcast("live/cam0", broadcast.consume())
 			.unwrap();

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -972,7 +972,7 @@ impl Publisher {
 	fn new(origin: &origin::Producer, path: &str) -> anyhow::Result<Self> {
 		let mut broadcast = broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
-		let mut importer = FlvImport::new(broadcast.clone(), catalog);
+		let mut importer = FlvImport::new(broadcast.clone(), catalog.reserve());
 
 		let publish = origin.publish_broadcast(path, broadcast.consume())?;
 
@@ -1184,7 +1184,7 @@ mod tests {
 		let origin = moq_net::Origin::random().produce();
 		let mut broadcast = broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
-		let mut importer = FlvImport::new(broadcast.clone(), catalog);
+		let mut importer = FlvImport::new(broadcast.clone(), catalog.reserve());
 		let _publish = origin.publish_broadcast("live/cam0", broadcast.consume()).unwrap();
 		importer.decode(&flv::file_header()).unwrap();
 		importer.decode(&flv::tag(flv::TAG_VIDEO, 0, &vseq)).unwrap();

--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -35,7 +35,7 @@ impl Publisher {
 	pub fn new(origin: &origin::Producer, path: &str) -> Result<Self> {
 		let mut broadcast = broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
-		let importer = ts::Import::new(broadcast.clone(), catalog);
+		let importer = ts::Import::new(broadcast.clone(), catalog.reserve());
 
 		let publish = origin.publish_broadcast(path, broadcast.consume())?;
 		tracing::info!(%path, "publishing ingest broadcast");

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -55,14 +55,14 @@ impl Producer {
 				let track = moq_mux::import::unique_track(&mut broadcast, ".avc3")?;
 				Codecs::H264 {
 					split: moq_mux::codec::h264::Split::new(),
-					import: moq_mux::codec::h264::Import::new(track, catalog),
+					import: moq_mux::codec::h264::Import::new(track, catalog.reserve()),
 				}
 			}
 			Codec::H265 => {
 				let track = moq_mux::import::unique_track(&mut broadcast, ".hev1")?;
 				Codecs::H265 {
 					split: moq_mux::codec::h265::Split::new(),
-					import: moq_mux::codec::h265::Import::new(track, catalog),
+					import: moq_mux::codec::h265::Import::new(track, catalog.reserve()),
 				}
 			}
 		};


### PR DESCRIPTION
## Summary

One-shot container muxers (fMP4, MPEG-TS) emit their header exactly once, so they need the *complete* track set before they lock it in. Today the catalog publishes incrementally as each rendition resolves, and codecs resolve at different times (AAC on the first PES, H.264 only on the first keyframe's inline SPS). A subscriber can therefore see an **audio-only** catalog snapshot before the video rendition's config lands, and the TS exporter trips `TS track layout changed after PAT/PMT was emitted` — the convergence race in #1979.

This fixes it entirely **publisher-side**: the first catalog snapshot a subscriber ever sees is already complete. No wire-format or catalog-schema change.

## Approach

- `catalog::Producer::reserve()` returns a clonable `Reserved`. Importers reserve their rendition via `Reserved::init` (with `.video()` / `.audio()` shorthands), which returns a `Rendition` guard.
- The guard **holds its own `Reserved` clone** until its config is `set()` (or it's dropped). The catalog is withheld from the broadcast until every `Reserved` is gone, so an unresolved rendition keeps the gate shut. When the last one resolves, exactly one complete snapshot publishes. A single counter (`reservers`) drives this; a `pending` flag avoids emitting an empty snapshot for a catalog nobody touched.
- Producers that don't reserve publish incrementally, exactly as before.

## Container importers own the reservation

A container importer is the orchestrator that discovers its full track set, so it owns the reservation across discovery — and taking a `Reserved` is the only way to **compose** several importers into one broadcast under one gate (e.g. an fMP4 video source + a separate audio source, or WebRTC's video+audio bridges). Previously each importer reserved internally and gated independently.

- `Reserved::producer()` yields the underlying (non-gating) catalog handle for edits that outlive the reservation.
- `container::{fmp4, ts, flv, mkv}::Import::new` and `import::{Container, ContainerStream, Track, TrackStream}::new` take a `Reserved`. Each holds it across discovery and drops it when its initial set is declared: fMP4 after the moov's traks, MKV after the Tracks element, TS after the first PMT, FLV on the first media frame (all sequence headers precede media data).
- Single-source callers pass `catalog.reserve()`; a caller composing multiple importers passes clones of one `catalog.reserve()` for a shared gate.

### TS deferred substreams

`ts::Import` holds a reservation across the first PMT (bridging the ES loop). **Deferred substreams** (AAC, legacy MP2/AC3/EAC3) whose config comes from the first frame hold *their own* reservation from the PMT until they build the importer, so even audio-only programs converge to a single complete snapshot.

### API

- `VideoTrack<E>` / `AudioTrack<E>` are now aliases of a unified `Rendition<E, K>` over a sealed `Kind` (`Video` / `Audio`).
- Codec-importer constructors take `catalog::Reserved` instead of `catalog::Producer`.

## Public API changes (moq-mux, targets `dev`)

New: `catalog::{Reserved, Rendition, Kind, Video, Audio}`, `Producer::reserve()`, `Reserved::producer()`.
Changed (breaking): `Producer::video_track`/`audio_track` removed; `codec::*::Import::new`, `container::*::Import::new`, and `import::{Container, ContainerStream, Track, TrackStream}::new` take `Reserved` instead of `Producer`. `VideoTrack`/`AudioTrack` retained as aliases.

## Test plan

- [x] `cargo test -p moq-mux` — 354 pass, including gating tests at the `catalog::Producer` level:
  - `reservation_gates_until_all_renditions_resolve` (the #1979 race)
  - `reservation_gate_opens_when_unresolved_reservation_is_dropped`
  - `staged_change_waits_for_a_held_reservation` (deferred / composition case)
  - all fMP4/TS/FLV/MKV round-trip tests exercise container reserve → declare → publish
- [x] clippy / rustfmt / rustdoc clean on moq-mux
- [x] `moq-srt`, `moq-rtc`, `moq-rtmp` build; `moq-ffi`/`libmoq`/`moq-cli` unblocked (local openh264 toolchain issue is environmental)
- [ ] Not runtime-tested against a live SRT → relay → `moq subscribe --format ts` pipeline

## Follow-ups

- **Composition wiring** for `moq-rtc` (share one `Reserved` across a WHIP session's codec bridges) and `moq-gst` (across pads). Both currently reserve per-track, which is correct but gates each track independently; a shared gate needs a per-crate "all tracks negotiated" signal (WebRTC/GStreamer have no clean one — likely drop-on-first-frame).
- `js/hang` catalog Producer parity (wire unchanged, so not required for correctness).

Fixes #1979

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)