### PR TITLE
refactor(kio)!: delete Consumer write access, add role-less Shared for reverse queues

### DIFF
--- a/rs/kio/src/consumer.rs
+++ b/rs/kio/src/consumer.rs
@@ -3,19 +3,14 @@ use std::{
 	task::Poll,
 };
 
-use crate::{
-	Counts, Mut, State, Weak,
-	lock::*,
-	producer::{Producer, Ref},
-	waiter::*,
-};
+use crate::{Counts, State, lock::*, producer::Ref, waiter::*, weak::ConsumerWeak};
 
 /// The consuming side of a shared state channel.
 ///
 /// Consumers have read-only access to the shared value and are notified when
 /// a producer modifies it. Cloning a consumer increments the consumer reference
 /// count. When the last consumer is dropped, the consumer-count waiters
-/// (e.g. [`Producer::unused`]) are notified.
+/// (e.g. [`Producer::unused`](crate::Producer::unused)) are notified.
 #[derive(Debug)]
 pub struct Consumer<T> {
 	pub(crate) state: Lock<State<T>>,
@@ -79,43 +74,10 @@ impl<T> Consumer<T> {
 		crate::wait(move |waiter| self.poll_closed(waiter)).await
 	}
 
-	/// Upgrade to a Producer, returning `None` if the state is already closed.
-	pub fn produce(&self) -> Option<Producer<T>> {
-		// Increment first to prevent the last Producer::drop from
-		// closing the state between our check and the return.
-		self.counts.producers.fetch_add(1, Ordering::Relaxed);
-
-		{
-			let state = self.state.lock();
-			if state.closed {
-				self.counts.producers.fetch_sub(1, Ordering::Relaxed);
-				return None;
-			}
-		}
-
-		Some(Producer {
-			state: self.state.clone(),
-			counts: self.counts.clone(),
-		})
-	}
-
 	/// Get read-only access to the shared state.
 	pub fn read(&self) -> Ref<'_, T> {
 		Ref {
 			state: self.state.lock(),
-		}
-	}
-
-	/// Acquire mutable access to the shared state.
-	///
-	/// Returns `Ok(Mut)` if the channel is open, or `Err(Ref)` with
-	/// read-only access if closed. Only locks once.
-	pub fn write(&self) -> Result<Mut<'_, T>, Ref<'_, T>> {
-		let state = self.state.lock();
-		if state.closed {
-			Err(Ref { state })
-		} else {
-			Ok(Mut::new(state))
 		}
 	}
 
@@ -129,12 +91,13 @@ impl<T> Consumer<T> {
 		self.state.is_clone(&other.state)
 	}
 
-	/// Create a [`Weak`] reference to this state.
+	/// Create a [`ConsumerWeak`] reference to this state.
 	///
 	/// Does not affect ref counts, so it won't prevent auto-close when all
-	/// producers are dropped.
-	pub fn weak(&self) -> Weak<T> {
-		Weak {
+	/// producers are dropped. The weak can only mint more consumers, never a
+	/// producer, so read-only access stays read-only.
+	pub fn weak(&self) -> ConsumerWeak<T> {
+		ConsumerWeak {
 			state: self.state.clone(),
 			counts: self.counts.clone(),
 		}

--- a/rs/kio/src/lib.rs
+++ b/rs/kio/src/lib.rs
@@ -4,6 +4,10 @@
 //! a mutex-protected value. Producers can modify the state and consumers are
 //! automatically notified via async wakers. The channel auto-closes when all
 //! producers are dropped.
+//!
+//! For state that both sides legitimately mutate (e.g. a reverse request queue),
+//! [`Shared`] is a role-less sibling: every handle can lock, read, or park on a
+//! predicate, with no liveness of its own.
 
 use std::{
 	ops::{Deref, DerefMut},
@@ -16,6 +20,7 @@ mod waiter;
 mod consumer;
 mod future;
 mod producer;
+mod shared;
 mod weak;
 
 #[cfg(feature = "tokio")]
@@ -27,8 +32,9 @@ mod tests;
 pub use consumer::Consumer;
 pub use future::{Future, Pending};
 pub use producer::{Mut, Producer, Ref};
+pub use shared::Shared;
 pub use waiter::{Waiter, WaiterList, wait};
-pub use weak::Weak;
+pub use weak::{ConsumerWeak, ProducerWeak};
 
 /// Waiters split by what they're waiting on, so an event only wakes the
 /// waiters that care about it. The big win is per-modification writes (the hot

--- a/rs/kio/src/producer.rs
+++ b/rs/kio/src/producer.rs
@@ -4,7 +4,7 @@ use std::{
 	task::Poll,
 };
 
-use crate::{Counts, State, consumer::Consumer, lock::*, waiter::*, weak::Weak};
+use crate::{Counts, State, consumer::Consumer, lock::*, waiter::*, weak::ProducerWeak};
 
 /// The producing side of a shared state channel.
 ///
@@ -145,7 +145,9 @@ impl<T> Producer<T> {
 		crate::wait(move |waiter| self.poll_closed(waiter)).await
 	}
 
-	fn poll_closed(&self, waiter: &Waiter) -> Poll<()> {
+	/// Poll for channel closure (an explicit [`Mut::close`], e.g. an abort),
+	/// registering the waiter if still open.
+	pub fn poll_closed(&self, waiter: &Waiter) -> Poll<()> {
 		let mut state = self.state.lock();
 		if state.closed {
 			return Poll::Ready(());
@@ -234,16 +236,16 @@ impl<T> Producer<T> {
 	/// Returns `true` if this is the only remaining producer.
 	///
 	/// Inherently racy if other handles may clone this producer or upgrade a
-	/// [`Weak`] / [`Consumer`] concurrently. Intended for a producer's own
+	/// [`ProducerWeak`] concurrently. Intended for a producer's own
 	/// `Drop`, where this handle has not yet been counted out, to gate
 	/// last-producer cleanup.
 	pub fn is_last(&self) -> bool {
 		self.counts.producers.load(Ordering::Acquire) == 1
 	}
 
-	/// Create a [`Weak`] reference that doesn't affect the producer/consumer ref counts.
-	pub fn weak(&self) -> Weak<T> {
-		Weak {
+	/// Create a [`ProducerWeak`] reference that doesn't affect the producer/consumer ref counts.
+	pub fn weak(&self) -> ProducerWeak<T> {
+		ProducerWeak {
 			state: self.state.clone(),
 			counts: self.counts.clone(),
 		}

--- a/rs/kio/src/shared.rs
+++ b/rs/kio/src/shared.rs
@@ -1,0 +1,205 @@
+use std::task::Poll;
+
+use crate::{
+	State,
+	lock::Lock,
+	producer::{Mut, Ref},
+	waiter::*,
+};
+
+/// A cloneable, lock-guarded value with waker notification.
+///
+/// Unlike the [`Producer`](crate::Producer) / [`Consumer`](crate::Consumer) watch channel,
+/// every handle is equal: any clone can mutate ([`lock`](Self::lock)), read
+/// ([`read`](Self::read)), or park until a predicate holds ([`poll`](Self::poll)).
+/// Mutating through the guard wakes the parked polls.
+///
+/// This is the primitive for state that two sides legitimately mutate, e.g. a request
+/// queue where consumers enqueue (coalescing against what's already there) and a handler
+/// drains, all under one lock so the dedup is a plain lookup rather than a race. It has
+/// no liveness of its own: encode "the other side is gone" as plain state (a counter or
+/// flag inside `T`, maintained by the owning handles' `Clone`/`Drop` under the same lock).
+#[derive(Debug)]
+pub struct Shared<T> {
+	state: Lock<State<T>>,
+}
+
+impl<T: Default> Default for Shared<T> {
+	fn default() -> Self {
+		Self::new(T::default())
+	}
+}
+
+impl<T> Shared<T> {
+	/// Create a new shared value.
+	pub fn new(value: T) -> Self {
+		Self {
+			state: Lock::new(State::new(value)),
+		}
+	}
+
+	/// Lock the value for reading and writing.
+	///
+	/// Never blocks on anything but the mutex itself. Mutating through the returned
+	/// [`Mut`] wakes every parked [`poll`](Self::poll) on drop; a guard that was only
+	/// read from wakes nobody.
+	pub fn lock(&self) -> Mut<'_, T> {
+		Mut::new(self.state.lock())
+	}
+
+	/// Lock the value for reading only, never waking anyone.
+	pub fn read(&self) -> Ref<'_, T> {
+		Ref {
+			state: self.state.lock(),
+		}
+	}
+
+	/// Poll a read-only predicate; once it holds, hand back a [`Mut`] with the lock
+	/// still held, so the caller can inspect and mutate atomically.
+	///
+	/// Mirrors [`Producer::poll`](crate::Producer::poll): the predicate only sees a
+	/// [`Ref`], so it can't flag the state modified and spuriously wake this poll's own
+	/// waiter. Registers `waiter` while pending; any mutation through a [`lock`](Self::lock)
+	/// guard re-polls it.
+	pub fn poll<F>(&self, waiter: &Waiter, mut f: F) -> Poll<Mut<'_, T>>
+	where
+		F: FnMut(&Ref<'_, T>) -> Poll<()>,
+	{
+		let mut guard = Ref {
+			state: self.state.lock(),
+		};
+		match f(&guard) {
+			// Upgrade the Ref to a Mut, keeping the same lock guard.
+			Poll::Ready(()) => Poll::Ready(Mut::new(guard.state)),
+			Poll::Pending => {
+				waiter.register(&mut guard.state.waiters_value);
+				Poll::Pending
+			}
+		}
+	}
+
+	/// Returns `true` if both handles share the same underlying state.
+	pub fn same_channel(&self, other: &Self) -> bool {
+		self.state.is_clone(&other.state)
+	}
+}
+
+impl<T> Clone for Shared<T> {
+	fn clone(&self) -> Self {
+		Self {
+			state: self.state.clone(),
+		}
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use std::{
+		future::Future,
+		sync::{
+			Arc,
+			atomic::{AtomicUsize, Ordering},
+		},
+		task::{Context, Wake, Waker},
+	};
+
+	use super::*;
+
+	/// A waker that counts how many times it was woken (mirrors `tests.rs`).
+	struct CountWaker(AtomicUsize);
+	impl CountWaker {
+		fn count(&self) -> usize {
+			self.0.load(Ordering::SeqCst)
+		}
+	}
+	impl Wake for CountWaker {
+		fn wake(self: Arc<Self>) {
+			self.0.fetch_add(1, Ordering::SeqCst);
+		}
+		fn wake_by_ref(self: &Arc<Self>) {
+			self.0.fetch_add(1, Ordering::SeqCst);
+		}
+	}
+	fn counting() -> (Arc<CountWaker>, Waker) {
+		let waker = Arc::new(CountWaker(AtomicUsize::new(0)));
+		let w = Waker::from(waker.clone());
+		(waker, w)
+	}
+
+	/// Ready once the queue has something to drain.
+	fn nonempty(queue: &Ref<'_, Vec<u32>>) -> Poll<()> {
+		if queue.is_empty() {
+			Poll::Pending
+		} else {
+			Poll::Ready(())
+		}
+	}
+
+	#[test]
+	fn enqueue_then_drain() {
+		let shared = Shared::<Vec<u32>>::default();
+		let drain = shared.clone();
+		let waiter = Waiter::noop();
+
+		// Nothing queued yet.
+		assert!(drain.poll(&waiter, nonempty).is_pending());
+
+		// One side enqueues.
+		shared.lock().push(1);
+
+		// The other side drains it, inspecting and mutating under one lock.
+		let Poll::Ready(mut guard) = drain.poll(&waiter, nonempty) else {
+			panic!("expected a drainable guard");
+		};
+		assert_eq!(guard.pop(), Some(1));
+	}
+
+	#[test]
+	fn mutation_wakes_parked_poll() {
+		let shared = Shared::<Vec<u32>>::default();
+		let drain = shared.clone();
+
+		let (waker, w) = counting();
+		let mut cx = Context::from_waker(&w);
+
+		let mut fut = Box::pin(crate::wait(|waiter| drain.poll(waiter, nonempty)));
+		assert!(fut.as_mut().poll(&mut cx).is_pending(), "pending until enqueue");
+
+		shared.lock().push(7);
+		assert!(waker.count() >= 1, "enqueue should wake the parked poll");
+
+		let Poll::Ready(mut guard) = fut.as_mut().poll(&mut cx) else {
+			panic!("expected a drainable guard after enqueue");
+		};
+		assert_eq!(guard.pop(), Some(7));
+	}
+
+	#[test]
+	fn read_does_not_wake() {
+		let shared = Shared::<Vec<u32>>::default();
+		let drain = shared.clone();
+
+		let (waker, w) = counting();
+		let mut cx = Context::from_waker(&w);
+
+		let mut fut = Box::pin(crate::wait(|waiter| drain.poll(waiter, nonempty)));
+		assert!(fut.as_mut().poll(&mut cx).is_pending());
+
+		// Read-only access (and an unmutated lock) must not wake the parked poll.
+		assert!(shared.read().is_empty());
+		let guard = shared.lock();
+		assert!(guard.is_empty());
+		drop(guard);
+		assert_eq!(waker.count(), 0, "reads spuriously woke a parked poll");
+	}
+
+	#[test]
+	fn same_channel_tracks_identity() {
+		let shared = Shared::<Vec<u32>>::default();
+		let clone = shared.clone();
+		let other = Shared::<Vec<u32>>::default();
+
+		assert!(shared.same_channel(&clone));
+		assert!(!shared.same_channel(&other));
+	}
+}

--- a/rs/kio/src/weak.rs
+++ b/rs/kio/src/weak.rs
@@ -7,21 +7,21 @@ use crate::{
 	Counts, State,
 	consumer::Consumer,
 	lock::*,
-	producer::{Mut, Producer, Ref},
+	producer::{Producer, Ref},
 	waiter::*,
 };
 
-/// A weak reference to a Producer/Consumer state.
+/// A weak handle from the producing side ([`Producer::weak`](crate::Producer::weak)).
 ///
-/// Does not affect ref counts, so it won't prevent auto-close when all Producers are dropped.
-/// Can be upgraded to a full Producer or Consumer.
+/// Holds no ref count, so it never keeps the channel open. Upgrade it back to a [`Producer`]
+/// (write access) or a [`Consumer`] (read access) while the channel is still live.
 #[derive(Debug)]
-pub struct Weak<T> {
+pub struct ProducerWeak<T> {
 	pub(crate) state: Lock<State<T>>,
 	pub(crate) counts: Arc<Counts>,
 }
 
-impl<T> Weak<T> {
+impl<T> ProducerWeak<T> {
 	/// Upgrade to a [`Producer`], returning `None` if the channel is already closed.
 	pub fn produce(&self) -> Option<Producer<T>> {
 		// Increment first to prevent the last Producer::drop from
@@ -55,19 +55,6 @@ impl<T> Weak<T> {
 		Consumer {
 			state: self.state.clone(),
 			counts: self.counts.clone(),
-		}
-	}
-
-	/// Acquire mutable access to the shared state without upgrading to a full [`Producer`].
-	///
-	/// Returns `Ok(Mut)` if the channel is open, or `Err(Ref)` with
-	/// read-only access if closed. Only locks once.
-	pub fn write(&self) -> Result<Mut<'_, T>, Ref<'_, T>> {
-		let state = self.state.lock();
-		if state.closed {
-			Err(Ref { state })
-		} else {
-			Ok(Mut::new(state))
 		}
 	}
 
@@ -159,13 +146,60 @@ impl<T> Weak<T> {
 		Poll::Pending
 	}
 
-	/// Returns `true` if both weak references share the same underlying state.
+	/// Returns `true` if both handles share the same underlying state.
 	pub fn same_channel(&self, other: &Self) -> bool {
 		self.state.is_clone(&other.state)
 	}
 }
 
-impl<T> Clone for Weak<T> {
+impl<T> Clone for ProducerWeak<T> {
+	fn clone(&self) -> Self {
+		Self {
+			state: self.state.clone(),
+			counts: self.counts.clone(),
+		}
+	}
+}
+
+/// A weak handle from the consuming side ([`Consumer::weak`](crate::Consumer::weak)).
+///
+/// Holds no ref count, so it never keeps the channel open. Unlike [`ProducerWeak`] it can
+/// only mint more [`Consumer`]s, so a read-only handle can never grow write access.
+#[derive(Debug)]
+pub struct ConsumerWeak<T> {
+	pub(crate) state: Lock<State<T>>,
+	pub(crate) counts: Arc<Counts>,
+}
+
+impl<T> ConsumerWeak<T> {
+	/// Create a new [`Consumer`] that shares this state.
+	pub fn consume(&self) -> Consumer<T> {
+		let prev = self.counts.consumers.fetch_add(1, Ordering::AcqRel);
+
+		// Wake `used()` waiters when the first consumer appears.
+		if prev == 0 {
+			let mut waiters = self.state.lock().waiters_consumer.take();
+			waiters.wake();
+		}
+
+		Consumer {
+			state: self.state.clone(),
+			counts: self.counts.clone(),
+		}
+	}
+
+	/// Returns `true` if the channel has been closed.
+	pub fn is_closed(&self) -> bool {
+		self.state.lock().closed
+	}
+
+	/// Returns `true` if both handles share the same underlying state.
+	pub fn same_channel(&self, other: &Self) -> bool {
+		self.state.is_clone(&other.state)
+	}
+}
+
+impl<T> Clone for ConsumerWeak<T> {
 	fn clone(&self) -> Self {
 		Self {
 			state: self.state.clone(),

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -79,10 +79,6 @@ struct BroadcastState {
 }
 
 impl BroadcastState {
-	fn modify(state: &kio::Producer<Self>) -> Result<kio::Mut<'_, Self>, Error> {
-		state.write().map_err(|_| Error::Dropped)
-	}
-
 	/// Insert a track weak handle into the lookup, returning an error if a live
 	/// track already holds the name. A closed entry under the name is reclaimed.
 	fn insert_track(&mut self, weak: track::TrackWeak) -> Result<(), Error> {
@@ -127,7 +123,14 @@ pub struct Producer {
 	// Held behind an Arc so each track born from this broadcast can inherit a shared
 	// handle (threaded down by [`Self::create_track`] / [`Self::reserve_track`]).
 	info: Arc<Info>,
-	state: kio::Producer<BroadcastState>,
+
+	// Broadcast liveness. Consumers watch this (read-only) for close; dropping every
+	// producer (this handle and every `Dynamic`) ends the broadcast.
+	alive: kio::Producer<()>,
+
+	// Track registry plus the dynamic request queue, mutated by producers and
+	// consumers alike under one lock.
+	state: kio::Shared<BroadcastState>,
 }
 
 impl Producer {
@@ -135,6 +138,7 @@ impl Producer {
 	pub fn new(info: Info) -> Self {
 		Self {
 			info: Arc::new(info),
+			alive: Default::default(),
 			state: Default::default(),
 		}
 	}
@@ -145,8 +149,7 @@ impl Producer {
 
 	/// Remove a track from the lookup.
 	pub fn remove_track(&mut self, name: &str) -> Result<(), Error> {
-		let mut state = BroadcastState::modify(&self.state)?;
-		state.tracks.remove(name).ok_or(Error::NotFound)?;
+		self.state.lock().tracks.remove(name).ok_or(Error::NotFound)?;
 		Ok(())
 	}
 
@@ -161,9 +164,7 @@ impl Producer {
 	) -> Result<track::Producer, Error> {
 		let info = info.into().unwrap_or_default();
 		let track = track::Producer::new(self.info.clone(), name, info);
-		let mut state = BroadcastState::modify(&self.state)?;
-		state.insert_track(track.weak())?;
-		drop(state);
+		self.state.lock().insert_track(track.weak())?;
 		Ok(track)
 	}
 
@@ -176,9 +177,7 @@ impl Producer {
 	/// [`Dynamic::requested_track`].
 	pub fn reserve_track(&mut self, name: impl Into<Arc<str>>) -> Result<track::Request, Error> {
 		let request = track::Request::new(self.info.clone(), name);
-		let mut state = BroadcastState::modify(&self.state)?;
-		state.insert_track(request.weak())?;
-		drop(state);
+		self.state.lock().insert_track(request.weak())?;
 		Ok(request)
 	}
 
@@ -210,14 +209,15 @@ impl Producer {
 
 	/// Create a dynamic producer that handles on-demand track requests from consumers.
 	pub fn dynamic(&self) -> Dynamic {
-		Dynamic::new(self.info.clone(), self.state.clone())
+		Dynamic::new(self.info.clone(), self.alive.clone(), self.state.clone())
 	}
 
 	/// Create a consumer that can subscribe to tracks in this broadcast.
 	pub fn consume(&self) -> Consumer {
 		Consumer {
 			info: self.info.clone(),
-			state: self.state.consume(),
+			alive: self.alive.consume(),
+			state: self.state.clone(),
 		}
 	}
 
@@ -231,9 +231,7 @@ impl Producer {
 	/// gone, so a clone that outlives this call keeps it alive until it too is
 	/// dropped or finished.
 	pub fn finish(self) {
-		if let Ok(mut state) = self.state.write() {
-			state.closed = true;
-		}
+		self.state.lock().closed = true;
 	}
 
 	/// Return true if this is the same broadcast instance.
@@ -245,15 +243,14 @@ impl Producer {
 impl Drop for Producer {
 	fn drop(&mut self) {
 		// Only the last producer ending the broadcast matters; a clone dropping
-		// leaves it live. Warn if that last exit wasn't an explicit finish(), since
-		// consumers will then see Error::Dropped (classically a GC-collected handle
-		// in a language binding that tears the stream down mid-publish).
-		if !self.state.is_last() {
+		// leaves it live (`alive` is shared with every `Dynamic` too). Warn if that
+		// last exit wasn't an explicit finish(), since consumers will then see
+		// Error::Dropped (classically a GC-collected handle in a language binding
+		// that tears the stream down mid-publish).
+		if !self.alive.is_last() {
 			return;
 		}
-		if let Ok(state) = self.state.write()
-			&& !state.closed
-		{
+		if !self.state.read().closed {
 			tracing::warn!(
 				"broadcast::Producer dropped without finish(). Keep the producer alive while publishing, then call finish()."
 			);
@@ -281,7 +278,9 @@ impl Producer {
 /// are automatically aborted.
 pub struct Dynamic {
 	info: Arc<Info>,
-	state: kio::Producer<BroadcastState>,
+	// Keeps the broadcast alive while a handler exists (mirrors a producer).
+	alive: kio::Producer<()>,
+	state: kio::Shared<BroadcastState>,
 }
 
 impl Clone for Dynamic {
@@ -290,52 +289,36 @@ impl Clone for Dynamic {
 		// Without this, deriving Clone would let `Drop` decrement past `new`'s
 		// single increment and prematurely flip `dynamic` to zero, causing
 		// future `track` calls to return `NotFound`.
-		if let Ok(mut state) = self.state.write() {
-			state.dynamic += 1;
-		}
+		self.state.lock().dynamic += 1;
 
 		Self {
 			info: self.info.clone(),
+			alive: self.alive.clone(),
 			state: self.state.clone(),
 		}
 	}
 }
 
 impl Dynamic {
-	fn new(info: Arc<Info>, state: kio::Producer<BroadcastState>) -> Self {
-		if let Ok(mut state) = state.write() {
-			// If the broadcast is already closed, we can't handle any new requests.
-			state.dynamic += 1;
-		}
+	fn new(info: Arc<Info>, alive: kio::Producer<()>, state: kio::Shared<BroadcastState>) -> Self {
+		state.lock().dynamic += 1;
 
-		Self { info, state }
+		Self { info, alive, state }
 	}
 
 	pub fn info(&self) -> &Info {
 		&self.info
 	}
 
-	// A helper to automatically apply Dropped if the state is closed. The predicate is
-	// read-only and just gates readiness; mutate through the returned `Mut`.
-	fn poll<F>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<kio::Mut<'_, BroadcastState>, Error>>
-	where
-		F: FnMut(&kio::Ref<'_, BroadcastState>) -> Poll<()>,
-	{
-		Poll::Ready(match ready!(self.state.poll(waiter, f)) {
-			Ok(state) => Ok(state),
-			Err(_) => Err(Error::Dropped),
-		})
-	}
-
 	/// Poll for the next consumer-requested track, without blocking.
 	pub fn poll_requested_track(&mut self, waiter: &kio::Waiter) -> Poll<Result<track::Request, Error>> {
-		let mut state = ready!(self.poll(waiter, |state| {
+		let mut state = ready!(self.state.poll(waiter, |state| {
 			if state.request_order.is_empty() {
 				Poll::Pending
 			} else {
 				Poll::Ready(())
 			}
-		}))?;
+		}));
 
 		let name = state.request_order.pop_front().expect("predicate guaranteed a request");
 		let pending = state.requests.remove(&name).expect("request_order out of sync");
@@ -354,13 +337,14 @@ impl Dynamic {
 	pub fn consume(&self) -> Consumer {
 		Consumer {
 			info: self.info.clone(),
-			state: self.state.consume(),
+			alive: self.alive.consume(),
+			state: self.state.clone(),
 		}
 	}
 
 	/// Block until the broadcast is closed (every producer dropped), returning the cause.
 	pub async fn closed(&self) -> Error {
-		self.state.closed().await;
+		self.alive.closed().await;
 		Error::Dropped
 	}
 
@@ -372,16 +356,16 @@ impl Dynamic {
 
 impl Drop for Dynamic {
 	fn drop(&mut self) {
-		if let Ok(mut state) = self.state.write() {
-			// We do a saturating sub so Producer::dynamic() can avoid returning an error.
-			state.dynamic = state.dynamic.saturating_sub(1);
-			if state.dynamic != 0 {
-				return;
-			}
-
-			// No dynamic handlers left to fulfill pending requests; reject them.
-			state.reject_requests(Error::Dropped);
+		// Decrement and reject under one lock, so a `track` call that saw
+		// `dynamic > 0` through the same lock can't slip a request past the rejection.
+		let mut state = self.state.lock();
+		state.dynamic -= 1;
+		if state.dynamic != 0 {
+			return;
 		}
+
+		// No dynamic handlers left to fulfill pending requests; reject them.
+		state.reject_requests(Error::Dropped);
 	}
 }
 
@@ -406,7 +390,10 @@ impl Dynamic {
 #[derive(Clone)]
 pub struct Consumer {
 	info: Arc<Info>,
-	state: kio::Consumer<BroadcastState>,
+	// Broadcast liveness (read-only): watched for close.
+	alive: kio::Consumer<()>,
+	// Track registry plus request queue; `track()` reads the registry and enqueues requests.
+	state: kio::Shared<BroadcastState>,
 }
 
 impl Consumer {
@@ -416,11 +403,12 @@ impl Consumer {
 
 	/// Get a handle to a track on this broadcast.
 	pub fn track(&self, name: &str) -> Result<track::Consumer, Error> {
-		// Upgrade to a temporary producer so we can modify the state.
-		let mut state = match self.state.write() {
-			Ok(state) => state,
-			Err(_) => return Err(Error::Dropped),
-		};
+		// A closed broadcast (every producer and handler gone) serves nothing.
+		if self.is_closed() {
+			return Err(Error::Dropped);
+		}
+
+		let mut state = self.state.lock();
 
 		// Reuse a live producer if one is already publishing the track. `get` drops a
 		// closed entry and returns `None`, so we fall through to a fresh request.
@@ -455,13 +443,13 @@ impl Consumer {
 	/// Always returns [`Error::Dropped`]: a broadcast is just a collection of tracks, so it
 	/// only ends when every producer is gone. There is no way to abort it with a code.
 	pub async fn closed(&self) -> Error {
-		self.state.closed().await;
+		self.alive.closed().await;
 		Error::Dropped
 	}
 
 	/// Returns true if every [`Producer`] has been dropped.
 	pub fn is_closed(&self) -> bool {
-		self.state.read().is_closed()
+		self.alive.is_closed()
 	}
 
 	/// Register a [`kio::Waiter`] that fires when the broadcast closes.
@@ -470,7 +458,7 @@ impl Consumer {
 	/// arming the waiter. Useful for composing close-detection into a larger poll
 	/// without spawning a task per broadcast.
 	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<()> {
-		self.state.poll_closed(waiter)
+		self.alive.poll_closed(waiter)
 	}
 
 	/// Check if this is the exact same instance of a broadcast.
@@ -485,7 +473,8 @@ impl Consumer {
 	pub(crate) fn weak(&self) -> WeakConsumer {
 		WeakConsumer {
 			info: self.info.clone(),
-			state: self.state.weak(),
+			alive: self.alive.weak(),
+			state: self.state.clone(),
 		}
 	}
 }
@@ -494,10 +483,13 @@ impl Consumer {
 ///
 /// Mirrors [`track::TrackWeak`]: held by the origin's dynamic cache to share one
 /// dynamically-served broadcast across repeat requests without pinning it alive.
+/// Only the `alive` handle needs to be weak; a [`kio::Shared`] carries no liveness,
+/// so holding the state outright pins nothing.
 #[derive(Clone)]
 pub(crate) struct WeakConsumer {
 	info: Arc<Info>,
-	state: kio::Weak<BroadcastState>,
+	alive: kio::ConsumerWeak<()>,
+	state: kio::Shared<BroadcastState>,
 }
 
 impl WeakConsumer {
@@ -505,14 +497,15 @@ impl WeakConsumer {
 	pub fn consume(&self) -> Consumer {
 		Consumer {
 			info: self.info.clone(),
-			state: self.state.consume(),
+			alive: self.alive.consume(),
+			state: self.state.clone(),
 		}
 	}
 }
 
 impl super::WeakEntry for WeakConsumer {
 	fn is_closed(&self) -> bool {
-		self.state.is_closed()
+		self.alive.is_closed()
 	}
 
 	fn same_channel(&self, other: &Self) -> bool {

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -190,8 +190,10 @@ fn modify(state: &kio::Producer<GroupState>) -> Result<kio::Mut<'_, GroupState>>
 
 /// The pool's eviction hook: abort the group with [`Error::Evicted`], freeing its
 /// frames immediately. A no-op once the group is already aborted or fully dropped.
-fn evict(state: &kio::Weak<GroupState>) {
-	let Ok(mut state) = state.write() else { return };
+fn evict(weak: &kio::ProducerWeak<GroupState>) {
+	// Upgrade to write; a closed (finished or fully dropped) group has nothing to free.
+	let Some(producer) = weak.produce() else { return };
+	let Ok(mut state) = producer.write() else { return };
 	if state.abort.is_some() {
 		return;
 	}

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -841,7 +841,7 @@ pub struct Producer {
 	// Fallback request queue, shared with every derived consumer. Separate from
 	// `nodes` because dynamic broadcasts are never announced: they only resolve a
 	// consumer's `request_broadcast` when no live announcement exists.
-	dynamic: kio::Producer<OriginDynamicState>,
+	dynamic: kio::Shared<OriginDynamicState>,
 
 	// The cache pool inherited by broadcasts created under this origin (sessions
 	// mint their remote broadcasts with it). Unbounded by default.
@@ -865,7 +865,7 @@ impl Producer {
 			info: info.id,
 			nodes: OriginNodes::default(),
 			root: PathOwned::default(),
-			dynamic: kio::Producer::default(),
+			dynamic: kio::Shared::default(),
 			pool: info.pool,
 		}
 	}
@@ -888,7 +888,7 @@ impl Producer {
 			info,
 			nodes: OriginNodes { nodes: Vec::new() },
 			root: PathOwned::default(),
-			dynamic: kio::Producer::default(),
+			dynamic: kio::Shared::default(),
 			pool: cache::Pool::default(),
 		}
 	}
@@ -998,7 +998,7 @@ impl Producer {
 	/// Use [`Consumer::announced`] to register interest and start receiving
 	/// announcement events; the consumer itself does not allocate any channels.
 	pub fn consume(&self) -> Consumer {
-		Consumer::new(self.info, self.root.clone(), self.nodes.clone(), self.dynamic.consume())
+		Consumer::new(self.info, self.root.clone(), self.nodes.clone(), self.dynamic.clone())
 	}
 
 	/// Handle to the announcement stream for this producer's subtree.
@@ -1107,7 +1107,8 @@ impl std::ops::DerefMut for Broadcast {
 /// Shared fallback request queue for an origin.
 ///
 /// Lives off to the side of the announce tree because dynamically served broadcasts
-/// are never announced. Mirrors the `dynamic`/`requests`/`request_order` fields of the
+/// are never announced. Carried in a [`kio::Shared`], so consumers enqueue and handlers
+/// drain under one lock. Mirrors the `dynamic`/`requests`/`request_order` fields of the
 /// broadcast and track models.
 #[derive(Default)]
 struct OriginDynamicState {
@@ -1165,7 +1166,7 @@ struct PendingBroadcast {
 pub struct Dynamic {
 	info: Origin,
 	root: PathOwned,
-	state: kio::Producer<OriginDynamicState>,
+	state: kio::Shared<OriginDynamicState>,
 }
 
 impl Clone for Dynamic {
@@ -1173,9 +1174,7 @@ impl Clone for Dynamic {
 		// Mirror `new`: bump `dynamic` so each live handle is counted. Without this,
 		// dropping a clone would decrement past `new`'s increment and prematurely flip
 		// `dynamic` to zero, making future `request_broadcast` calls return `Unroutable`.
-		if let Ok(mut state) = self.state.write() {
-			state.dynamic += 1;
-		}
+		self.state.lock().dynamic += 1;
 
 		Self {
 			info: self.info,
@@ -1186,10 +1185,8 @@ impl Clone for Dynamic {
 }
 
 impl Dynamic {
-	fn new(info: Origin, root: PathOwned, state: kio::Producer<OriginDynamicState>) -> Self {
-		if let Ok(mut state) = state.write() {
-			state.dynamic += 1;
-		}
+	fn new(info: Origin, root: PathOwned, state: kio::Shared<OriginDynamicState>) -> Self {
+		state.lock().dynamic += 1;
 
 		Self { info, root, state }
 	}
@@ -1199,26 +1196,15 @@ impl Dynamic {
 		&self.info
 	}
 
-	// Gate readiness on a queued request; mutate through the returned `Mut`.
-	fn poll<F>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<kio::Mut<'_, OriginDynamicState>, Error>>
-	where
-		F: FnMut(&kio::Ref<'_, OriginDynamicState>) -> Poll<()>,
-	{
-		Poll::Ready(match ready!(self.state.poll(waiter, f)) {
-			Ok(state) => Ok(state),
-			Err(_) => Err(Error::Dropped),
-		})
-	}
-
 	/// Poll for the next requested broadcast, without blocking.
 	pub fn poll_requested_broadcast(&mut self, waiter: &kio::Waiter) -> Poll<Result<Request, Error>> {
-		let mut state = ready!(self.poll(waiter, |state| {
+		let mut state = ready!(self.state.poll(waiter, |state| {
 			if state.request_order.is_empty() {
 				Poll::Pending
 			} else {
 				Poll::Ready(())
 			}
-		}))?;
+		}));
 
 		let path = state.request_order.pop_front().expect("predicate guaranteed a request");
 		// Leave the request in `requests` (only drain it from `request_order`) so a repeat
@@ -1248,13 +1234,13 @@ impl Dynamic {
 
 impl Drop for Dynamic {
 	fn drop(&mut self) {
-		if let Ok(mut state) = self.state.write() {
-			// Saturating sub so `Producer::dynamic` can stay infallible.
-			state.dynamic = state.dynamic.saturating_sub(1);
-			if state.dynamic == 0 {
-				// No handlers left to fulfill queued requests; close them.
-				state.reject_requests();
-			}
+		// Decrement and reject under one lock, so a `request_broadcast` that saw
+		// `dynamic > 0` through the same lock can't slip a request past the rejection.
+		let mut state = self.state.lock();
+		state.dynamic -= 1;
+		if state.dynamic == 0 {
+			// No handlers left to fulfill queued requests; close them.
+			state.reject_requests();
 		}
 	}
 }
@@ -1274,7 +1260,7 @@ pub struct Request {
 	producer: kio::Producer<PendingBroadcast>,
 
 	// Shared dynamic state, so `accept` can cache the served broadcast for repeat requests.
-	state: kio::Producer<OriginDynamicState>,
+	state: kio::Shared<OriginDynamicState>,
 }
 
 impl Request {
@@ -1296,12 +1282,11 @@ impl Request {
 		// (and subscribe upstream) again. Re-check under the lock: if a live broadcast was already
 		// served for this path while we were fetching upstream, dedup onto it and drop ours rather
 		// than replace a good entry with a duplicate subscription.
-		let resolved = if let Ok(mut state) = self.state.write() {
+		let resolved = {
+			let mut state = self.state.lock();
 			let existing = state.served.insert(self.path.clone(), broadcast.weak());
 			state.requests.remove(&self.path);
 			existing.map(|weak| weak.consume()).unwrap_or(broadcast)
-		} else {
-			broadcast
 		};
 
 		if let Ok(mut pending) = self.producer.write() {
@@ -1312,9 +1297,7 @@ impl Request {
 
 	/// Reject the request, resolving every awaiting requester with `err`.
 	pub fn reject(self, err: Error) {
-		if let Ok(mut state) = self.state.write() {
-			state.requests.remove(&self.path);
-		}
+		self.state.lock().requests.remove(&self.path);
 		if let Ok(mut state) = self.producer.write() {
 			state.resolved = Some(Err(err));
 		}
@@ -1331,11 +1314,11 @@ impl Drop for Request {
 		// lock before we run, so a concurrent request for the same path may have registered a
 		// *new* one here. Removing unconditionally would clobber it (stranding its requesters and
 		// desyncing `request_order` from `requests`), so only remove while it's still ours.
-		if let Ok(mut state) = self.state.write()
-			&& state
-				.requests
-				.get(&self.path)
-				.is_some_and(|producer| producer.same_channel(&self.producer))
+		let mut state = self.state.lock();
+		if state
+			.requests
+			.get(&self.path)
+			.is_some_and(|producer| producer.same_channel(&self.producer))
 		{
 			state.requests.remove(&self.path);
 		}
@@ -1355,8 +1338,8 @@ pub struct Requesting {
 enum RequestState {
 	// Already announced: resolves immediately with a clone of this broadcast.
 	Ready(broadcast::Consumer),
-	// Unroutable at request time, or the origin was already dropped: resolves immediately
-	// with this error. Baked in so `request_broadcast` itself stays infallible.
+	// Unroutable at request time: resolves immediately with this error. Baked in so
+	// `request_broadcast` itself stays infallible.
 	Failed(Error),
 	// Awaiting a handler: resolves when the request's result channel is written.
 	Pending(kio::Consumer<PendingBroadcast>),
@@ -1430,7 +1413,7 @@ impl Consume<Consumer> for Producer {
 	fn consume(&self) -> Consumer {
 		// Mirrors the inherent `Producer::consume`; inlined to avoid the
 		// inherent-vs-trait `consume` ambiguity.
-		Consumer::new(self.info, self.root.clone(), self.nodes.clone(), self.dynamic.consume())
+		Consumer::new(self.info, self.root.clone(), self.nodes.clone(), self.dynamic.clone())
 	}
 }
 
@@ -1481,7 +1464,7 @@ pub struct Consumer {
 
 	// Shared fallback request queue, fed to any `Dynamic` handler on the
 	// producer side. Used only by `request_broadcast`; announced lookups ignore it.
-	dynamic: kio::Consumer<OriginDynamicState>,
+	dynamic: kio::Shared<OriginDynamicState>,
 }
 
 impl std::ops::Deref for Consumer {
@@ -1493,7 +1476,7 @@ impl std::ops::Deref for Consumer {
 }
 
 impl Consumer {
-	fn new(info: Origin, root: PathOwned, nodes: OriginNodes, dynamic: kio::Consumer<OriginDynamicState>) -> Self {
+	fn new(info: Origin, root: PathOwned, nodes: OriginNodes, dynamic: kio::Shared<OriginDynamicState>) -> Self {
 		Self {
 			info,
 			nodes,
@@ -1612,10 +1595,9 @@ impl Consumer {
 	/// long as it stays live; a closed one is re-served on the next request.
 	///
 	/// The returned future resolves to [`Error::Unroutable`] when the path is not announced and no
-	/// dynamic handler exists, or [`Error::Dropped`] once the origin is gone. A request that is
-	/// registered while a handler is live but then loses every handler before being served also
-	/// resolves to [`Error::Unroutable`]. Unlike an announced broadcast, a dynamically served one
-	/// is never visible to [`Self::announced`].
+	/// dynamic handler exists. A request that is registered while a handler is live but then loses
+	/// every handler before being served also resolves to [`Error::Unroutable`]. Unlike an announced
+	/// broadcast, a dynamically served one is never visible to [`Self::announced`].
 	pub fn request_broadcast(&self, path: impl AsPath) -> kio::Pending<Requesting> {
 		let path = path.as_path();
 
@@ -1628,9 +1610,7 @@ impl Consumer {
 		// (which may have a different root) agree on the same entry.
 		let absolute = self.root.join(&path).to_owned();
 
-		let Ok(mut state) = self.dynamic.write() else {
-			return kio::Pending::new(Requesting::failed(Error::Dropped));
-		};
+		let mut state = self.dynamic.lock();
 
 		// Reuse a still-live broadcast a handler already served for this path, so repeat
 		// requests share one upstream subscription. A closed entry is stale; `get` drops it

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -181,24 +181,57 @@ struct TrackState {
 	// The error that caused the track to be aborted, if any.
 	abort: Option<Error>,
 
-	// Active subscriptions.
-	subscriptions: Vec<kio::Consumer<Subscription>>,
+	// Active subscriptions, in their own [`kio::Shared`] so a read-only `Consumer`
+	// registers under that lock instead of writing back into the track state.
+	// Kept here (rather than threaded through every handle) so any holder reaches it.
+	subscriptions: kio::Shared<Subscriptions>,
 
+	// The reverse fetch queue (see [`FetchState`]), same reasoning: cache-miss
+	// `fetch_group` calls enqueue here and a `Dynamic` drains.
+	fetch: kio::Shared<FetchState>,
+}
+
+/// The registered subscriptions, aggregated by the producer.
+type Subscriptions = Vec<kio::Consumer<Subscription>>;
+
+/// Reverse state for [`Consumer::fetch_group`], beside the track state in its own
+/// [`kio::Shared`]: consumers enqueue and [`Dynamic`] handlers drain under one lock,
+/// without write access to the track itself.
+#[derive(Default)]
+struct FetchState {
 	// Specific groups requested via `fetch` that aren't cached yet, FIFO for a
 	// `Dynamic` to serve (see `Dynamic::requested_group`).
-	fetches: VecDeque<GroupRequested>,
+	queue: VecDeque<GroupRequested>,
 
 	// Monotonic IDs for fetches that reached a dynamic handler.
-	next_fetch: u64,
+	next: u64,
 
 	// Per-request failures for popped fetches. Keyed by request ID so rejecting one
 	// transient attempt doesn't poison future retries for the same sequence.
-	fetch_rejections: HashMap<u64, Error>,
+	rejections: HashMap<u64, Error>,
 
 	// Number of live `Dynamic` handles. While zero, the track serves no
 	// uncached groups, so a cache-miss `fetch` on an accepted track fails fast
 	// instead of blocking forever (mirrors `BroadcastState::dynamic`).
 	dynamic: usize,
+}
+
+impl FetchState {
+	fn reject(&mut self, id: u64, err: Error) {
+		self.rejections.entry(id).or_insert(err);
+	}
+
+	/// Ready once the fetch can never be served from here: a handler rejected this
+	/// request, or no handler exists at all. The caller reads the rejection (if any)
+	/// through the returned guard.
+	fn poll_unservable(&self, request_id: Option<u64>) -> Poll<()> {
+		let rejected = request_id.is_some_and(|id| self.rejections.contains_key(&id));
+		if rejected || self.dynamic == 0 {
+			Poll::Ready(())
+		} else {
+			Poll::Pending
+		}
+	}
 }
 
 impl TrackState {
@@ -406,15 +439,12 @@ impl TrackState {
 		Poll::Pending
 	}
 
-	/// Resolve a one-shot fetch: the cached group, or an [`Error`] once it can never
-	/// be served. Unlike [`Self::poll_get_group`] there's no `Ok(None)`, since a
-	/// missing group is a failure ([`Error::NotFound`]), not an end-of-stream.
-	///
-	/// A miss is unservable when the group is past the final sequence, or when no
-	/// [`Dynamic`] exists to fetch old content (`dynamic == 0`). On-demand tracks
-	/// (from a [`Request`]) are dynamic from creation, so a relay's fetch waits to
-	/// be served rather than racing the handler into existence.
-	fn poll_fetch(&self, sequence: u64, request_id: Option<u64>) -> Poll<Result<group::Consumer>> {
+	/// Resolve a one-shot fetch from the track side: the cached group, or an [`Error`]
+	/// once it can never be served. Unlike [`Self::poll_get_group`] there's no
+	/// `Ok(None)`, since a missing group is a failure ([`Error::NotFound`]), not an
+	/// end-of-stream. The handler side (a rejection, or no [`Dynamic`] at all) lives
+	/// in [`FetchState`]; [`Fetching`] polls both.
+	fn poll_fetch_cached(&self, sequence: u64) -> Poll<Result<group::Consumer>> {
 		if let Some(group) = self.cached_group(sequence) {
 			return Poll::Ready(Ok(group));
 		}
@@ -423,15 +453,8 @@ impl TrackState {
 			return Poll::Ready(Err(err.clone()));
 		}
 
-		if let Some(id) = request_id
-			&& let Some(err) = self.fetch_rejections.get(&id)
-		{
-			return Poll::Ready(Err(err.clone()));
-		}
-
-		// Past the final sequence, or no handler to serve old content: unservable.
-		let past_final = self.final_sequence.is_some_and(|fin| sequence >= fin);
-		if past_final || self.dynamic == 0 {
+		// Past the final sequence: the group can never exist.
+		if self.final_sequence.is_some_and(|fin| sequence >= fin) {
 			return Poll::Ready(Err(Error::NotFound));
 		}
 
@@ -606,14 +629,6 @@ impl TrackState {
 		self.pin_latest(&group);
 		self.evict_expired(now, cache);
 		Ok(group)
-	}
-
-	fn reject_group_request(&mut self, id: u64, err: Error) {
-		self.fetch_rejections.entry(id).or_insert(err);
-	}
-
-	fn clear_group_request_rejection(&mut self, id: u64) {
-		self.fetch_rejections.remove(&id);
 	}
 }
 
@@ -936,9 +951,7 @@ impl Producer {
 			.clone();
 		preferences.stale = info.clamp_stale(preferences.stale);
 		let subscription = kio::Producer::new(preferences);
-		if let Ok(mut state) = self.state.write() {
-			state.subscriptions.push(subscription.consume());
-		}
+		register_subscription(self.state.read(), &subscription);
 
 		Subscriber {
 			name: self.name.clone(),
@@ -966,21 +979,23 @@ impl Producer {
 	/// when there are no live subscribers. Unlike [`Self::subscription`], this
 	/// doesn't wait for a change or advance the change cursor.
 	pub fn subscription(&self) -> Option<Subscription> {
-		let state = self.state.read();
-		let mut combined: Option<Subscription> = None;
-		for sub in &state.subscriptions {
-			if let Poll::Ready(merged) = sub.read().poll_combined(&combined) {
-				combined = Some(merged);
-			}
-		}
-		combined
+		let subs = self.state.read().subscriptions.clone();
+		snapshot_subscription(&subs)
 	}
 
 	pub fn poll_subscription_changed(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Subscription>>> {
+		// Surface an abort as the stream ending. `poll_closed` parks on the closed
+		// waiters, so per-group churn on the track state never wakes this poll.
+		if self.state.poll_closed(waiter).is_ready() {
+			let abort = self.state.read().abort.clone();
+			return Poll::Ready(Err(abort.unwrap_or(Error::Dropped)));
+		}
+
+		let subs = self.state.read().subscriptions.clone();
 		let prev = &self.prev_subscription;
 		let mut combined = None;
-		let mut state = match self.state.poll(waiter, |state| {
-			let next = combined_subscription(state, waiter);
+		let mut guard = match subs.poll(waiter, |subs| {
+			let next = combined_subscription(subs, waiter);
 			if &next == prev {
 				Poll::Pending
 			} else {
@@ -988,13 +1003,12 @@ impl Producer {
 				Poll::Ready(())
 			}
 		}) {
-			Poll::Ready(Ok(state)) => state,
-			Poll::Ready(Err(state)) => return Poll::Ready(Err(state.abort.clone().unwrap_or(Error::Dropped))),
+			Poll::Ready(guard) => guard,
 			Poll::Pending => return Poll::Pending,
 		};
 		// The aggregate changed: prune any closed subscribers now that we hold the lock.
-		state.subscriptions.retain(|sub| !sub.is_closed());
-		drop(state);
+		guard.retain(|sub| !sub.is_closed());
+		drop(guard);
 		self.prev_subscription = combined.clone();
 		Poll::Ready(Ok(combined))
 	}
@@ -1016,33 +1030,43 @@ impl Producer {
 	}
 }
 
-/// Pop the next queued group fetch off the shared state and wrap it in a
+/// Pop the next queued group fetch off the fetch queue and wrap it in a
 /// [`GroupRequest`] bound to a fresh producer handle. Shared by every
 /// [`Dynamic`] handle on the track.
-fn poll_requested_group(state: &kio::Producer<TrackState>, waiter: &kio::Waiter) -> Poll<Result<GroupRequest>> {
-	// Read-only predicate: ready once there's a request to pop, or the track aborted.
-	let mut guard = ready!(state.poll(waiter, |state| {
-		if state.fetches.is_empty() && state.abort.is_none() {
+fn poll_requested_group(
+	state: &kio::Producer<TrackState>,
+	fetch: &kio::Shared<FetchState>,
+	waiter: &kio::Waiter,
+) -> Poll<Result<GroupRequest>> {
+	// Prefer serving a queued fetch, even if the track has since aborted.
+	if let Poll::Ready(mut guard) = fetch.poll(waiter, |fetch| {
+		if fetch.queue.is_empty() {
 			Poll::Pending
 		} else {
 			Poll::Ready(())
 		}
-	}))
-	.map_err(|state| state.abort.clone().unwrap_or(Error::Dropped))?;
+	}) {
+		let req = guard.queue.pop_front().expect("predicate guaranteed a request");
+		drop(guard);
+		return Poll::Ready(Ok(GroupRequest {
+			state: state.clone(),
+			fetch: fetch.clone(),
+			id: req.id,
+			sequence: req.sequence,
+			priority: req.priority,
+			done: false,
+		}));
+	}
 
-	let req = match guard.fetches.pop_front() {
-		Some(req) => req,
-		// Woke because the track aborted while the fetch queue was empty.
-		None => return Poll::Ready(Err(guard.abort.clone().unwrap_or(Error::Dropped))),
-	};
-
-	Poll::Ready(Ok(GroupRequest {
-		state: state.clone(),
-		id: req.id,
-		sequence: req.sequence,
-		priority: req.priority,
-		done: false,
-	}))
+	// No fetch queued: surface a track abort so the handler loop can exit.
+	match state.poll_ref(waiter, |state| match &state.abort {
+		Some(err) => Poll::Ready(err.clone()),
+		None => Poll::Pending,
+	}) {
+		Poll::Ready(Ok(err)) => Poll::Ready(Err(err)),
+		Poll::Ready(Err(closed)) => Poll::Ready(Err(closed.abort.clone().unwrap_or(Error::Dropped))),
+		Poll::Pending => Poll::Pending,
+	}
 }
 
 /// Serves on-demand fetches of uncached (old) groups for a track, the group-level
@@ -1056,15 +1080,17 @@ fn poll_requested_group(state: &kio::Producer<TrackState>, waiter: &kio::Waiter)
 /// miss fails fast with [`Error::NotFound`].
 pub struct Dynamic {
 	name: Arc<str>,
+	// Kept to insert served groups into the cache and observe track abort.
 	state: kio::Producer<TrackState>,
+	// The fetch queue this handle drains; its `dynamic` count gates `fetch_group`.
+	fetch: kio::Shared<FetchState>,
 }
 
 impl Dynamic {
 	fn new(name: Arc<str>, state: kio::Producer<TrackState>) -> Self {
-		if let Ok(mut state) = state.write() {
-			state.dynamic += 1;
-		}
-		Self { name, state }
+		let fetch = state.read().fetch.clone();
+		fetch.lock().dynamic += 1;
+		Self { name, state, fetch }
 	}
 
 	pub fn name(&self) -> &str {
@@ -1081,7 +1107,7 @@ impl Dynamic {
 	}
 
 	pub fn poll_requested_group(&self, waiter: &kio::Waiter) -> Poll<Result<GroupRequest>> {
-		poll_requested_group(&self.state, waiter)
+		poll_requested_group(&self.state, &self.fetch, waiter)
 	}
 
 	/// Poll for the track becoming unused (every consumer dropped).
@@ -1093,12 +1119,11 @@ impl Dynamic {
 impl Clone for Dynamic {
 	fn clone(&self) -> Self {
 		// Bump `dynamic` so each live handle is counted (mirrors `broadcast::Dynamic`).
-		if let Ok(mut state) = self.state.write() {
-			state.dynamic += 1;
-		}
+		self.fetch.lock().dynamic += 1;
 		Self {
 			name: self.name.clone(),
 			state: self.state.clone(),
+			fetch: self.fetch.clone(),
 		}
 	}
 }
@@ -1107,10 +1132,9 @@ impl Drop for Dynamic {
 	fn drop(&mut self) {
 		// Unlike `broadcast::Dynamic`, dropping the last handle doesn't abort the track:
 		// a live `Producer` may still be serving the subscription. It just stops
-		// fetch serving, after which an accepted track's cache miss fails fast.
-		if let Ok(mut state) = self.state.write() {
-			state.dynamic = state.dynamic.saturating_sub(1);
-		}
+		// fetch serving, after which an accepted track's cache miss fails fast (the
+		// decrement wakes every parked `Fetching`, which observes `dynamic == 0`).
+		self.fetch.lock().dynamic -= 1;
 	}
 }
 
@@ -1143,14 +1167,12 @@ impl Drop for Producer {
 
 /// Aggregate every live subscriber's preferences into the most demanding request.
 ///
-/// Read-only: iterates `subscriptions` immutably and registers `waiter` on each, so it
-/// never flags the [`TrackState`] as modified. Marking it modified would drain and wake
-/// unrelated waiters on the channel (e.g. a [`Subscribing`] parked on track info),
-/// which races with [`Request::accept`] and can drop that wakeup. Callers decide
+/// Read-only: iterates the subscriptions immutably and registers `waiter` on each, so a
+/// preference update (or a subscriber dropping) wakes the caller's poll. Callers decide
 /// readiness from the returned value, then prune closed subscribers through the `Mut`.
-fn combined_subscription(state: &TrackState, waiter: &kio::Waiter) -> Option<Subscription> {
+fn combined_subscription(subs: &Subscriptions, waiter: &kio::Waiter) -> Option<Subscription> {
 	let mut combined = None;
-	for sub in state.subscriptions.iter() {
+	for sub in subs.iter() {
 		if let Poll::Ready(Ok(sub)) = sub.poll(waiter, |sub| sub.poll_combined(&combined)) {
 			combined = Some(sub);
 		}
@@ -1158,11 +1180,34 @@ fn combined_subscription(state: &TrackState, waiter: &kio::Waiter) -> Option<Sub
 	combined
 }
 
+/// A non-blocking aggregate of the current subscriptions, without arming any waiter.
+fn snapshot_subscription(subs: &kio::Shared<Subscriptions>) -> Option<Subscription> {
+	let mut combined: Option<Subscription> = None;
+	for sub in subs.read().iter() {
+		if let Poll::Ready(merged) = sub.read().poll_combined(&combined) {
+			combined = Some(merged);
+		}
+	}
+	combined
+}
+
+/// Register a subscription if the track is live: clone the shared list out of the
+/// state, release the track lock, then push under the list's own lock. A closed
+/// track skips the push; nothing aggregates the preferences anymore.
+fn register_subscription(state: kio::Ref<'_, TrackState>, subscription: &kio::Producer<Subscription>) {
+	if state.is_closed() {
+		return;
+	}
+	let subs = state.subscriptions.clone();
+	drop(state);
+	subs.lock().push(subscription.consume());
+}
+
 /// A weak reference to a track that doesn't prevent auto-close.
 #[derive(Clone)]
 pub(crate) struct TrackWeak {
 	name: Arc<str>,
-	state: kio::Weak<TrackState>,
+	state: kio::ProducerWeak<TrackState>,
 }
 
 impl TrackWeak {
@@ -1201,7 +1246,7 @@ impl super::WeakEntry for TrackWeak {
 #[derive(Clone)]
 pub struct Demand {
 	name: Arc<str>,
-	state: kio::Weak<TrackState>,
+	state: kio::ProducerWeak<TrackState>,
 }
 
 impl Demand {
@@ -1261,9 +1306,7 @@ impl Consumer {
 
 		// Register the subscription if the track is live. If it is already closed, the returned
 		// future resolves to the abort error via `Subscribing::poll_ok`.
-		if let Ok(mut state) = self.state.write() {
-			state.subscriptions.push(subscription.consume());
-		}
+		register_subscription(self.state.read(), &subscription);
 
 		kio::Pending::new(Subscribing {
 			name: self.name.clone(),
@@ -1293,14 +1336,23 @@ impl Consumer {
 		let options = options.into().unwrap_or_default();
 		let mut request_id = None;
 
-		// Queue a request only when a handler can serve it but the group isn't cached yet. A cached
-		// group, an unservable sequence (NotFound), or a closed track all resolve through
-		// `Fetching::poll` without a queue entry.
-		if let Ok(mut state) = self.state.write() {
-			if state.poll_fetch(sequence, None).is_pending() {
-				let id = state.next_fetch;
-				state.next_fetch = state.next_fetch.wrapping_add(1);
-				state.fetches.push_back(GroupRequested {
+		// Queue a request only when the group isn't already resolvable from the track
+		// (cached, aborted, or past-final all resolve through `Fetching::poll` without
+		// a queue entry).
+		let (fetch, unresolved) = {
+			let state = self.state.read();
+			(state.fetch.clone(), state.poll_fetch_cached(sequence).is_pending())
+		};
+
+		if unresolved {
+			// Gate on a live handler, checked and pushed under the fetch lock so the
+			// check is atomic with a handler dropping (no fetch stranded on a queue
+			// nobody drains). With no handler, `Fetching::poll` fails fast instead.
+			let mut fetch = fetch.lock();
+			if fetch.dynamic > 0 {
+				let id = fetch.next;
+				fetch.next = fetch.next.wrapping_add(1);
+				fetch.queue.push_back(GroupRequested {
 					id,
 					sequence,
 					priority: options.priority,
@@ -1311,6 +1363,7 @@ impl Consumer {
 
 		kio::Pending::new(Fetching {
 			state: self.state.clone(),
+			fetch,
 			sequence,
 			request_id,
 		})
@@ -1414,6 +1467,8 @@ struct GroupRequested {
 /// the same whether or not the track has been accepted yet.
 pub struct GroupRequest {
 	state: kio::Producer<TrackState>,
+	// Rejections route back to the waiting `Fetching` through the fetch state.
+	fetch: kio::Shared<FetchState>,
 	id: u64,
 	sequence: u64,
 	priority: u8,
@@ -1446,9 +1501,7 @@ impl GroupRequest {
 	/// Reject the fetch, resolving the waiting [`Consumer::fetch_group`] with `err`.
 	pub fn reject(mut self, err: Error) {
 		self.done = true;
-		if let Ok(mut state) = self.state.write() {
-			state.reject_group_request(self.id, err);
-		}
+		self.fetch.lock().reject(self.id, err);
 	}
 }
 
@@ -1457,9 +1510,7 @@ impl Drop for GroupRequest {
 		if self.done {
 			return;
 		}
-		if let Ok(mut state) = self.state.write() {
-			state.reject_group_request(self.id, Error::Dropped);
-		}
+		self.fetch.lock().reject(self.id, Error::Dropped);
 	}
 }
 
@@ -1470,6 +1521,7 @@ impl Drop for GroupRequest {
 /// or produced after a wire FETCH), or [`Error::NotFound`] if it can never exist.
 pub struct Fetching {
 	state: kio::Consumer<TrackState>,
+	fetch: kio::Shared<FetchState>,
 	sequence: u64,
 	request_id: Option<u64>,
 }
@@ -1478,23 +1530,29 @@ impl kio::Future for Fetching {
 	type Output = Result<group::Consumer>;
 
 	fn poll(&self, waiter: &kio::Waiter) -> Poll<Self::Output> {
-		// `poll_fetch` already yields a `Result<group::Consumer>` (group, or NotFound /
-		// abort); the outer error is the channel closing without one.
-		let res = match ready!(
-			self.state
-				.poll(waiter, |state| state.poll_fetch(self.sequence, self.request_id))
-		) {
-			Ok(res) => res,
-			Err(closed) => return Poll::Ready(Err(closed.abort.clone().unwrap_or(Error::Dropped))),
-		};
-
-		if let Some(id) = self.request_id
-			&& let Ok(mut state) = self.state.write()
-		{
-			state.clear_group_request_rejection(id);
+		// Track side: the cached group, the abort error, or past-final. The outer
+		// error is the channel closing without any of those.
+		match self.state.poll(waiter, |state| state.poll_fetch_cached(self.sequence)) {
+			Poll::Ready(Ok(res)) => {
+				// Resolved through the track: drop any stale rejection for this request.
+				if let Some(id) = self.request_id {
+					self.fetch.lock().rejections.remove(&id);
+				}
+				return Poll::Ready(res);
+			}
+			Poll::Ready(Err(closed)) => {
+				return Poll::Ready(Err(closed.abort.clone().unwrap_or(Error::Dropped)));
+			}
+			Poll::Pending => {}
 		}
 
-		Poll::Ready(res)
+		// Handler side: a rejection for this request, or no handler to serve it at all.
+		let mut fetch = ready!(self.fetch.poll(waiter, |fetch| fetch.poll_unservable(self.request_id)));
+		let err = self
+			.request_id
+			.and_then(|id| fetch.rejections.remove(&id))
+			.unwrap_or(Error::NotFound);
+		Poll::Ready(Err(err))
 	}
 }
 
@@ -1857,14 +1915,8 @@ impl Request {
 	}
 
 	pub fn subscription(&self) -> Option<Subscription> {
-		let state = self.state.read();
-		let mut combined: Option<Subscription> = None;
-		for sub in &state.subscriptions {
-			if let Poll::Ready(merged) = sub.read().poll_combined(&combined) {
-				combined = Some(merged);
-			}
-		}
-		combined
+		let subs = self.state.read().subscriptions.clone();
+		snapshot_subscription(&subs)
 	}
 
 	pub async fn subscription_changed(&mut self) -> Option<Subscription> {
@@ -1872,24 +1924,21 @@ impl Request {
 	}
 
 	pub fn poll_subscription_changed(&mut self, waiter: &kio::Waiter) -> Poll<Option<Subscription>> {
+		let subs = self.state.read().subscriptions.clone();
 		let prev = &self.prev_subscription;
 		let mut combined = None;
-		// The request owns the only producer, so the channel can't be closed here.
-		let mut state = match ready!(self.state.poll(waiter, |state| {
-			let next = combined_subscription(state, waiter);
+		let mut guard = ready!(subs.poll(waiter, |subs| {
+			let next = combined_subscription(subs, waiter);
 			if &next == prev {
 				Poll::Pending
 			} else {
 				combined = next;
 				Poll::Ready(())
 			}
-		})) {
-			Ok(state) => state,
-			Err(_) => unreachable!("a Request holds the only producer"),
-		};
+		}));
 		// The aggregate changed: prune any closed subscribers now that we hold the lock.
-		state.subscriptions.retain(|sub| !sub.is_closed());
-		drop(state);
+		guard.retain(|sub| !sub.is_closed());
+		drop(guard);
 		self.prev_subscription = combined.clone();
 		Poll::Ready(combined)
 	}
@@ -3103,7 +3152,8 @@ mod test {
 
 		req.reject(Error::Cancel);
 		assert!(matches!(pending.await, Err(Error::Cancel)));
-		assert!(producer.state.read().fetch_rejections.is_empty());
+		let fetch = producer.state.read().fetch.clone();
+		assert!(fetch.read().rejections.is_empty());
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
## Summary

`kio::Consumer` documents itself as read-only but exposed `write()` and `produce()`, mutable back-doors that also re-exposed the `Mut::deref_mut`-marks-modified wake footgun (the one behind the wasm consume freeze) to external users. moq-net leaned on those back-doors for every reverse queue: broadcast track requests, origin dynamic requests, track fetches, and subscription registration all wrote back into the forward watch state through consumer handles.

This deletes the back-doors and gives the reverse queues a home that doesn't need them. Rebuilt from scratch on current `dev` (the earlier revision of this PR proposed a counted `Sender`/`Receiver` pair with a `with_cleanup` drop hook; both are gone, see Design below).

## kio

- **Delete `Consumer::write()` / `Consumer::produce()`.** A read handle can no longer mutate or upgrade.
- **Split `Weak` by role.** `Producer::weak()` returns `ProducerWeak` (can `produce()` and `consume()`; its `write()` is dropped, upgrade via `produce()` to write). `Consumer::weak()` returns a new `ConsumerWeak` (can only `consume()`), so there is no path from read-only to write access, direct or through a weak.
- **Add `kio::Shared<T>`**: a clone-able, lock-guarded value with waker notification. Every handle is equal: `lock()` (mutate, wakes parked polls), `read()`, and `poll(waiter, predicate) -> Mut` (park until the predicate holds, then inspect and mutate under the same lock). ~80 lines on top of kio's existing `State`/`Mut`/`Ref`/waiters.
- `Producer::poll_closed()` is now pub (it already was on `Consumer`).

## Design: no callbacks, no counting in the primitive

`Shared` deliberately has **no liveness of its own**: no sender/receiver roles, no ref counts, no `Drop` impls, and no cleanup hooks. All of that is policy, and it lives with the callers as plain state inside `T`:

- **Handler liveness is a `dynamic: usize` field inside the locked state** (the shape `dev` already uses), bumped by `Dynamic::clone`, decremented in `Dynamic::drop`. Because the count, the enqueue gate (`if state.dynamic == 0 { fail fast }`), and the last-handler rejection all run under the *same* lock, a request can never slip past a handler mid-teardown. This is the atomicity the earlier `with_cleanup` hook was buying; owning the state directly gets it for free.
- **Rejection stays Drop-driven.** Each queued request carries its own kio one-shot (`PendingBroadcast`, `track::Request`, the fetch rejection map); the last handler's teardown just clears the queue and the dropped one-shots resolve every waiting requester. No hook anywhere.
- **"Every requester is gone" needs no channel semantics either**: no current caller relies on it (handler loops exit via `select!` on session close or track abort, same as `dev`), and a counted sender would have actively broken the origin's new `WeakConsumer` dedup cache, which must hold the state without pinning anything. A `Shared` handle pins nothing, so the weak cache holds it outright and only the broadcast's `alive` channel needs a true weak.

## moq-net

Ported 1:1 from `dev`'s current semantics, with the reverse state moved out of the forward watch channels:

- **origin**: `OriginDynamicState` (requests, FIFO, served-cache, `dynamic` count) moves into a `Shared`. `Producer`, `Consumer`, `Dynamic`, and `Request` all hold it directly; the `if let Ok(state) = ... write()` dances become plain infallible `lock()`s.
- **broadcast**: `BroadcastState` (track registry + request queue + `dynamic`) becomes a `Shared`, and the broadcast grows an `alive: kio::Producer<()>` watch channel for what `Shared` deliberately lacks: consumer-visible close detection and the `finish()` drop warning. `Dynamic::poll_requested_track` still moves a popped request into the registry atomically with the drain.
- **track**: `TrackState` keeps the hot forward path untouched and gains two `Shared` side-states: `fetch` (queue + request ids + rejection map + `dynamic`) and `subscriptions` (the registration list, so `subscribe` pushes under that lock instead of writing into the track). `Fetching::poll` polls the track side (cached group / abort / past-final) and the fetch side (rejection / no handler) with one waiter. As a bonus, the producer's `poll_subscription_changed` now parks on the subscription list plus the closed-waiter list instead of the track's value waiters, so per-group churn no longer wakes it.
- **group**: the pool-eviction hook upgrades its `ProducerWeak` via `produce()` instead of the deleted `Weak::write()`; `produce()` fails exactly when `write()` used to (channel closed), so eviction semantics are unchanged.

## Compatibility

The moq-net public surface is unchanged (same types, same signatures), so js/net, the FFI wrappers, and the docs need no matching change. One behavioral delta: `origin::Consumer::request_broadcast` on a fully-dropped origin now resolves `Unroutable` instead of `Dropped` (no handler means unroutable; the shared state has no closed latch to distinguish why).

## Testing

`cargo test -p kio -p moq-net -p hang -p moq-relay -p moq-mux --lib` (12 + 473 + 26 + 141 + 384, all green), `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets`, `RUSTDOCFLAGS="-D warnings" cargo doc -p kio -p moq-net --no-deps`, `cargo fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
