### PR TITLE
Avoid moq-net and hang release breakage

### DIFF
--- a/rs/hang/src/catalog/audio/codec.rs
+++ b/rs/hang/src/catalog/audio/codec.rs
@@ -62,9 +62,9 @@ pub enum AudioCodec {
 pub enum AudioCodecKind {
 	AAC,
 	Opus,
+	Unknown,
 	Flac,
 	Mp3,
-	Unknown,
 }
 
 impl AudioCodec {

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -12,7 +12,6 @@ use super::{OriginList, Track};
 ///
 /// Create via [`Broadcast::produce`] to obtain both [`BroadcastProducer`] and [`BroadcastConsumer`] pair.
 #[derive(Clone, Debug, Default)]
-#[non_exhaustive]
 pub struct Broadcast {
 	/// The chain of origins the broadcast has traversed. Each relay appends its own
 	/// [`crate::Origin`] when forwarding, so the list is used for loop detection and

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -29,7 +29,6 @@ const MAX_GROUP_AGE: Duration = Duration::from_secs(5);
 /// A track is a collection of groups, delivered out-of-order until expired.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[non_exhaustive]
 pub struct Track {
 	/// Identifier within a broadcast. Unique per [`crate::Broadcast`].
 	pub name: String,


### PR DESCRIPTION
Summary:
- Keep moq-net Broadcast and Track constructible with external struct literals.
- Keep hang AudioCodecKind::Unknown at its previous discriminant while leaving FLAC and MP3 as additive variants.

Tests:
- cargo fmt --check
- cargo test -p hang -p moq-net
- cargo semver-checks -p moq-net --baseline-version 0.1.13
- cargo semver-checks -p hang --baseline-version 0.19.3

(Written by GPT-5)