### PR TITLE
[codex] Fix Codex devshell hook

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -5,7 +5,7 @@
 				"hooks": [
 					{
 						"type": "command",
-						"command": "bash -lc 'project_dir=\"${CODEX_PROJECT_DIR:-${CLAUDE_PROJECT_DIR:-$PWD}}\"; exec bash \"$project_dir/.codex/hooks/direnv.sh\"'"
+						"command": "bash -lc 'project_dir=\"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"; exec bash \"$project_dir/.codex/hooks/direnv.sh\"'"
 					}
 				]
 			}

--- a/.codex/hooks/direnv.sh
+++ b/.codex/hooks/direnv.sh
@@ -23,12 +23,32 @@ project_dir="${CODEX_PROJECT_DIR:-${CLAUDE_PROJECT_DIR:-${PWD:-}}}"
 cd "$project_dir" || exit 0
 [ -f .envrc ] || exit 0
 
+# Keep direnv's config and allow/deny state inside the worktree. Codex sessions
+# usually cannot write to ~/.config/direnv or ~/.local/share/direnv while sandboxed.
+export XDG_CONFIG_HOME="$PWD/.direnv/config"
+export XDG_CACHE_HOME="$PWD/.direnv/cache"
+export XDG_DATA_HOME="$PWD/.direnv/share"
+export DIRENV_CONFIG="$XDG_CONFIG_HOME/direnv"
+mkdir -p "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME"
+
+# Codex only needs the flake dev shell environment, so avoid depending on
+# nix-direnv's remote bootstrap when Nix can emit the shell exports directly.
+if command -v nix >/dev/null 2>&1 && [ -f flake.nix ]; then
+    nix_env="$(mktemp)"
+    if nix print-dev-env --profile "$PWD/.direnv/codex-profile" .#default >"$nix_env" 2>"$PWD/.direnv/codex-hook.log"; then
+        cat "$nix_env" >>"$env_file"
+        rm -f "$nix_env"
+        exit 0
+    fi
+    rm -f "$nix_env"
+fi
+
 # Clear any inherited direnv state so `export` recomputes the full diff. Without
 # this, a stale DIRENV_DIFF from the parent process makes direnv assume the env
 # is already loaded and emit nothing.
 unset DIRENV_DIR DIRENV_DIFF DIRENV_WATCHES DIRENV_FILE DIRENV_LAYOUT
 
-direnv allow . 2>/dev/null
-direnv export bash >>"$env_file" 2>/dev/null
+direnv allow . 2>>"$PWD/.direnv/codex-hook.log"
+direnv export bash >>"$env_file" 2>>"$PWD/.direnv/codex-hook.log"
 
 exit 0


### PR DESCRIPTION
## Summary

- Resolve Codex hook paths from the git root so subdirectory sessions find the repo hook.
- Keep direnv/Nix config, cache, and allow state under `.direnv` so sandboxed Codex sessions can write it.
- Prefer `nix print-dev-env` before falling back to `direnv export bash`, avoiding the remote nix-direnv bootstrap path when possible.

## Validation

- `bash -n .codex/hooks/direnv.sh`
- Parsed `.codex/hooks.json` as JSON
- `git diff --check -- .codex/hooks.json .codex/hooks/direnv.sh`

(Written by GPT-5)