### PR TITLE
[codex] rename moq token binary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ Changes in one area usually need matching updates elsewhere, including docs. If 
 | `rs/libmoq` C ABI (`moq.h`) | `cpp/obs/src`, `doc/bin/obs.md` |
 | `js/{watch,publish}` UI/API | `demo/web` if it consumes the API |
 
-**When a command-line tool's interface changes (a flag, argument, subcommand, or positional renamed/added/removed/reordered), update every doc that shows an example invocation, not just the tool's primary page.** Sample commands for `moq-cli`, `moq-relay`, and `moq-token-cli` are scattered across `doc/bin/`, `doc/lib/`, `doc/setup/`, and `doc/concept/`, plus the `justfile`s under `demo/`. Grep the whole repo for the binary name and reconcile each hit against the binary's `--help`. A stale example that no longer parses is worse than no example.
+**When a command-line tool's interface changes (a flag, argument, subcommand, or positional renamed/added/removed/reordered), update every doc that shows an example invocation, not just the tool's primary page.** Sample commands for `moq-cli`, `moq-relay`, and `moq-token` are scattered across `doc/bin/`, `doc/lib/`, `doc/setup/`, and `doc/concept/`, plus the `justfile`s under `demo/`. Grep the whole repo for the binary name and reconcile each hit against the binary's `--help`. A stale example that no longer parses is worse than no example.
 
 ## Branch Targeting
 

--- a/demo/relay/justfile
+++ b/demo/relay/justfile
@@ -72,7 +72,7 @@ key:
 
     [ -f root.jwk ] && exit 0
     rm -f *.jwt
-    cargo run --bin moq-token-cli -- generate --out root.jwk
+    cargo run --bin moq-token -- generate --out root.jwk
 
 # Generate authentication tokens for local development.
 token: key
@@ -81,13 +81,13 @@ token: key
     umask 077
 
     if [ ! -f demo-web.jwt ]; then
-    	cargo run --quiet --bin moq-token-cli -- sign --key root.jwk \
+        cargo run --quiet --bin moq-token -- sign --key root.jwk \
     		--root demo --subscribe "" --publish me \
     		> demo-web.jwt
     fi
 
     if [ ! -f demo-cli.jwt ]; then
-    	cargo run --quiet --bin moq-token-cli -- sign --key root.jwk \
+        cargo run --quiet --bin moq-token -- sign --key root.jwk \
     		--root demo --publish "" \
     		> demo-cli.jwt
     fi

--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -33,16 +33,16 @@ Using the Rust CLI:
 
 ```bash
 # Symmetric key (simpler, key must stay secret)
-moq-token-cli generate --out my-key.jwk
+moq-token generate --out my-key.jwk
 
 # Save to a directory as {kid}.jwk
-moq-token-cli generate --out-dir ./keys/
+moq-token generate --out-dir ./keys/
 
 # Asymmetric key (private signs, public verifies)
-moq-token-cli generate --algorithm ES256 --out private.jwk --public public.jwk
+moq-token generate --algorithm ES256 --out private.jwk --public public.jwk
 
 # Asymmetric key, both saved to directories as {kid}.jwk
-moq-token-cli generate --algorithm ES256 --out-dir ./private/ --public-dir ./keys/
+moq-token generate --algorithm ES256 --out-dir ./private/ --public-dir ./keys/
 ```
 
 A random key ID is generated if `--id` is not specified.
@@ -76,7 +76,7 @@ key_dir = "https://api.example.com/keys"
 
 ```bash
 # Allow publishing to demo/my-stream and subscribing to anything under demo/
-moq-token-cli sign --key my-key.jwk --root demo --publish my-stream --subscribe ""
+moq-token sign --key my-key.jwk --root demo --publish my-stream --subscribe ""
 ```
 
 The client connects with the token. The connection path can be the root or any parent:

--- a/doc/lib/js/@moq/token.md
+++ b/doc/lib/js/@moq/token.md
@@ -13,7 +13,7 @@ JWT token generation and verification for MoQ in browsers.
 
 - Generate signing keys (HMAC, RSA, ECDSA, EdDSA)
 - Sign and verify JWT tokens
-- Compatible with moq-relay authentication and `moq-token-cli`
+- Compatible with moq-relay authentication and `moq-token`
 
 ## Installation
 

--- a/doc/lib/rs/crate/moq-token.md
+++ b/doc/lib/rs/crate/moq-token.md
@@ -35,23 +35,23 @@ moq-token = "0.1"
 cargo install moq-token-cli
 ```
 
-The binary is named `moq-token-cli`.
+The binary is named `moq-token`.
 
 #### Using Nix
 
 ```bash
 # Run directly
-nix run github:moq-dev/moq#moq-token-cli
+nix run github:moq-dev/moq#moq-token
 
 # Or build and find the binary in ./result/bin/
-nix build github:moq-dev/moq#moq-token-cli
+nix build github:moq-dev/moq#moq-token
 ```
 
 #### Using Docker
 
 ```bash
 docker pull moqdev/moq-token-cli
-docker run -v "$(pwd):/app" -w /app moqdev/moq-token-cli generate --out root.jwk
+docker run -v "$(pwd):/app" -w /app moqdev/moq-token-cli:latest generate --out root.jwk
 ```
 
 Multi-arch images (`linux/amd64` and `linux/arm64`) are published to [Docker Hub](https://hub.docker.com/r/moqdev/moq-token-cli).
@@ -62,19 +62,19 @@ Multi-arch images (`linux/amd64` and `linux/arm64`) are published to [Docker Hub
 
 ```bash
 # Symmetric key (HMAC)
-moq-token-cli generate --out root.jwk --algorithm HS256
+moq-token generate --out root.jwk --algorithm HS256
 
 # Asymmetric key pair (RSA)
-moq-token-cli generate --algorithm RS256 --out private.jwk --public public.jwk
+moq-token generate --algorithm RS256 --out private.jwk --public public.jwk
 
 # Asymmetric key pair (EdDSA)
-moq-token-cli generate --algorithm EdDSA --out private.jwk --public public.jwk
+moq-token generate --algorithm EdDSA --out private.jwk --public public.jwk
 ```
 
 ### Sign a Token
 
 ```bash
-moq-token-cli sign --key root.jwk \
+moq-token sign --key root.jwk \
   --root "rooms/123" \
   --publish "alice" \
   --subscribe "" \
@@ -84,7 +84,7 @@ moq-token-cli sign --key root.jwk \
 ### Verify a Token
 
 ```bash
-moq-token-cli verify --key root.jwk < alice.jwt
+moq-token verify --key root.jwk < alice.jwt
 ```
 
 ## Supported Algorithms

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -133,9 +133,9 @@ ffmpeg -i input.mp4 -f mpegts - | \
 
 [Learn more](/bin/cli)
 
-### moq-token-cli
+### moq-token CLI
 
-Command-line tool for JWT token management (binary name: `moq-token-cli`).
+Command-line tool for JWT token management (binary name: `moq-token`).
 
 **Installation:**
 
@@ -147,10 +147,10 @@ cargo install moq-token-cli
 
 ```bash
 # Generate a key
-moq-token-cli generate --out root.jwk
+moq-token generate --out root.jwk
 
 # Sign a token
-moq-token-cli sign --key root.jwk \
+moq-token sign --key root.jwk \
   --root "rooms/123" \
   --publish "alice" \
   --expires 1735689600

--- a/flake.nix
+++ b/flake.nix
@@ -196,7 +196,7 @@
             paths = [
               moq-relay
               moq-cli
-              moq-token-cli
+              moq-token
             ];
           };
 
@@ -204,6 +204,7 @@
           inherit (overlayPkgs)
             moq-relay
             moq-cli
+            moq-token
             moq-token-cli
             moq-boy
             libmoq
@@ -226,6 +227,7 @@
           inherit (overlayPkgs)
             moq-relay-x86_64-apple-darwin
             moq-cli-x86_64-apple-darwin
+            moq-token-x86_64-apple-darwin
             moq-token-cli-x86_64-apple-darwin
             libmoq-x86_64-apple-darwin
             moq-gst-plugin-x86_64-apple-darwin

--- a/js/token/src/interop.test.ts
+++ b/js/token/src/interop.test.ts
@@ -6,7 +6,7 @@ import { load, loadPublic, sign, verify } from "./key.ts";
 // moq-token crate and verify tokens signed by Rust, and vice versa.
 
 describe("Rust-generated fixtures", () => {
-	// cargo run -p moq-token-cli -- generate --out /tmp/rust-hs256.jwk
+	// cargo run --bin moq-token -- generate --out /tmp/rust-hs256.jwk
 	const RUST_HS256_KEY = JSON.stringify({
 		alg: "HS256",
 		key_ops: ["verify", "sign"],
@@ -15,11 +15,11 @@ describe("Rust-generated fixtures", () => {
 		kid: "d55b1f13e6bda281",
 	});
 
-	// cargo run -p moq-token-cli -- sign --key /tmp/rust-hs256.jwk --root demo --publish alice --subscribe bob
+	// cargo run --bin moq-token -- sign --key /tmp/rust-hs256.jwk --root demo --publish alice --subscribe bob
 	const RUST_HS256_TOKEN =
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6ImQ1NWIxZjEzZTZiZGEyODEifQ.eyJyb290IjoiZGVtbyIsInB1dCI6WyJhbGljZSJdLCJnZXQiOlsiYm9iIl19.eyOkZtTtj_MDkLF4Eu11cygb7B_6DyP-6e0TtwVE4UE";
 
-	// cargo run -p moq-token-cli -- generate --algorithm EdDSA --out /tmp/rust-eddsa-private.jwk --public /tmp/rust-eddsa-public.jwk
+	// cargo run --bin moq-token -- generate --algorithm EdDSA --out /tmp/rust-eddsa-private.jwk --public /tmp/rust-eddsa-public.jwk
 	const RUST_EDDSA_PRIVATE_KEY = JSON.stringify({
 		alg: "EdDSA",
 		key_ops: ["sign", "verify"],
@@ -39,7 +39,7 @@ describe("Rust-generated fixtures", () => {
 		kid: "dfab9113ea85dc27",
 	});
 
-	// cargo run -p moq-token-cli -- sign --key /tmp/rust-eddsa-private.jwk --root room --publish stream1 --publish stream2 --subscribe feed1
+	// cargo run --bin moq-token -- sign --key /tmp/rust-eddsa-private.jwk --root room --publish stream1 --publish stream2 --subscribe feed1
 	const RUST_EDDSA_TOKEN =
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRmYWI5MTEzZWE4NWRjMjcifQ.eyJyb290Ijoicm9vbSIsInB1dCI6WyJzdHJlYW0xIiwic3RyZWFtMiJdLCJnZXQiOlsiZmVlZDEiXX0.jezhAgTHQHdYkc15CBZP8zPKKJ0z5oVRwON4wPHeQ6xvIhoM5IkCs_4YRCEoG74t99pdVTQrwAMNrlfKm2O6DA";
 
@@ -96,7 +96,7 @@ describe("Rust-generated fixtures", () => {
 });
 
 describe("wrong key rejects token", () => {
-	// cargo run -p moq-token-cli -- generate --out /tmp/rust-hs256.jwk
+	// cargo run --bin moq-token -- generate --out /tmp/rust-hs256.jwk
 	const RUST_HS256_KEY = JSON.stringify({
 		alg: "HS256",
 		key_ops: ["verify", "sign"],
@@ -105,7 +105,7 @@ describe("wrong key rejects token", () => {
 		kid: "d55b1f13e6bda281",
 	});
 
-	// cargo run -p moq-token-cli -- sign --key /tmp/rust-hs256.jwk --root demo --publish alice --subscribe bob
+	// cargo run --bin moq-token -- sign --key /tmp/rust-hs256.jwk --root demo --publish alice --subscribe bob
 	const RUST_HS256_TOKEN =
 		"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6ImQ1NWIxZjEzZTZiZGEyODEifQ.eyJyb290IjoiZGVtbyIsInB1dCI6WyJhbGljZSJdLCJnZXQiOlsiYm9iIl19.eyOkZtTtj_MDkLF4Eu11cygb7B_6DyP-6e0TtwVE4UE";
 
@@ -128,7 +128,7 @@ describe("wrong key rejects token", () => {
 
 	test("EdDSA token rejected by HS256 key", async () => {
 		const key = load(RUST_HS256_KEY);
-		// cargo run -p moq-token-cli -- sign --key /tmp/rust-eddsa-private.jwk --root room --publish stream1 --publish stream2 --subscribe feed1
+		// cargo run --bin moq-token -- sign --key /tmp/rust-eddsa-private.jwk --root room --publish stream1 --publish stream2 --subscribe feed1
 		const eddsaToken =
 			"eyJ0eXAiOiJKV1QiLCJhbGciOiJFZERTQSIsImtpZCI6ImRmYWI5MTEzZWE4NWRjMjcifQ.eyJyb290Ijoicm9vbSIsInB1dCI6WyJzdHJlYW0xIiwic3RyZWFtMiJdLCJnZXQiOlsiZmVlZDEiXX0.jezhAgTHQHdYkc15CBZP8zPKKJ0z5oVRwON4wPHeQ6xvIhoM5IkCs_4YRCEoG74t99pdVTQrwAMNrlfKm2O6DA";
 		await expect(verify(key, eddsaToken, "room")).rejects.toThrow();

--- a/nix/modules/moq-relay.nix
+++ b/nix/modules/moq-relay.nix
@@ -171,7 +171,7 @@ in
         # Generate auth key if needed
         ${lib.optionalString (cfg.auth.enable && cfg.auth.keyFile == null) ''
           if [ ! -f "${cfg.stateDir}/root.jwk" ]; then
-            ${pkgs.moq-token-cli}/bin/moq-token-cli --key "${cfg.stateDir}/root.jwk" generate
+            ${pkgs.moq-token}/bin/moq-token generate --out "${cfg.stateDir}/root.jwk"
             chown ${cfg.user}:${cfg.group} "${cfg.stateDir}/root.jwk"
             chmod 600 "${cfg.stateDir}/root.jwk"
           fi
@@ -185,7 +185,7 @@ in
               keyPath = if cfg.auth.keyFile != null then cfg.auth.keyFile else "${cfg.stateDir}/root.jwk";
             in
             ''
-              ${pkgs.moq-token-cli}/bin/moq-token-cli --key "${keyPath}" sign \
+              ${pkgs.moq-token}/bin/moq-token sign --key "${keyPath}" \
                 --subscribe "" --publish "" --cluster \
                 > "${cfg.stateDir}/cluster.jwt"
               chown ${cfg.user}:${cfg.group} "${cfg.stateDir}/cluster.jwt"

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -64,8 +64,11 @@ let
   moqTokenCliArgs = crateInfo ../rs/moq-token-cli/Cargo.toml // {
     src = craneLib.cleanCargoSource ../.;
     cargoExtraArgs = "-p moq-token-cli";
-    meta.mainProgram = "moq-token-cli";
+    # The crate is `moq-token-cli`, but its `[[bin]]` ships as `moq-token`.
+    meta.mainProgram = "moq-token";
   };
+  moqTokenPackage = craneLib.buildPackage moqTokenCliArgs;
+  moqTokenX86DarwinPackage = craneLib.buildPackage (crossX86Darwin moqTokenCliArgs);
 
   libmoqInfo = crateInfo ../rs/libmoq/Cargo.toml;
   libmoqArgs = libmoqInfo // {
@@ -224,8 +227,10 @@ in
   moq-cli = craneLib.buildPackage moqCliArgs;
   moq-cli-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqCliArgs);
 
-  moq-token-cli = craneLib.buildPackage moqTokenCliArgs;
-  moq-token-cli-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqTokenCliArgs);
+  moq-token = moqTokenPackage;
+  moq-token-cli = moqTokenPackage;
+  moq-token-x86_64-apple-darwin = moqTokenX86DarwinPackage;
+  moq-token-cli-x86_64-apple-darwin = moqTokenX86DarwinPackage;
 
   moq-boy = craneLib.buildPackage (
     crateInfo ../rs/moq-boy/Cargo.toml

--- a/packaging/moq-relay/relay.toml
+++ b/packaging/moq-relay/relay.toml
@@ -28,7 +28,7 @@ key = "/var/lib/moq-relay/key.pem"
 # [web.http]
 # listen = "[::]:80"
 
-# JWT authentication. Generate a key with `moq-token-cli`.
+# JWT authentication. Generate a key with `moq-token`.
 # See https://moq.dev/docs/auth for the full reference.
 [auth]
 key = "/var/lib/moq-relay/root.jwk"

--- a/packaging/moq-token-cli/nfpm.yaml
+++ b/packaging/moq-token-cli/nfpm.yaml
@@ -19,7 +19,7 @@ license: MIT OR Apache-2.0
 
 contents:
   - src: ${BINARY_PATH}
-    dst: /usr/bin/moq-token-cli
+    dst: /usr/bin/moq-token
     file_info:
       mode: 0755
 

--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -37,7 +37,7 @@ Layered roughly transport -> container/format -> media -> apps/bindings.
 - `moq-srt` (lib): bidirectional SRT gateway (MPEG-TS via `srt-tokio` + `moq-mux`).
 - `moq-bench` (bin): relay load generator. `JoinSet`-spawned staggered connections, rand sampling.
 - `moq-boy` (bin): crowd-controlled Game Boy emulator publisher (blocking emulator thread + async monitor tasks).
-- `moq-token` (lib) / `moq-token-cli` (bin): JWT auth. `Claims`, `Algorithm`, `KeyType` (EC/RSA/OCT/OKP), JWKS. CLI does generate/sign/verify.
+- `moq-token` (lib) / `moq-token` (bin from the `moq-token-cli` crate): JWT auth. `Claims`, `Algorithm`, `KeyType` (EC/RSA/OCT/OKP), JWKS. CLI does generate/sign/verify.
 
 **Bindings**
 

--- a/rs/justfile
+++ b/rs/justfile
@@ -110,7 +110,7 @@ package crate packager:
     case "{{ crate }}" in
     	moq-relay)      bin=moq-relay  ;;
     	moq-cli)        bin=moq        ;;
-    	moq-token-cli)  bin=moq-token-cli ;;
+        moq-token-cli)  bin=moq-token  ;;
     	*) echo "Unknown crate: {{ crate }} (use moq-relay, moq-cli, or moq-token-cli)" >&2; exit 1 ;;
     esac
     case "{{ packager }}" in

--- a/rs/moq-token-cli/Cargo.toml
+++ b/rs/moq-token-cli/Cargo.toml
@@ -9,6 +9,11 @@ version = "0.5.32"
 edition = "2024"
 rust-version.workspace = true
 
+# The package is `moq-token-cli`, but the binary it ships is `moq-token`.
+[[bin]]
+name = "moq-token"
+path = "src/main.rs"
+
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }

--- a/rs/moq-token-cli/README.md
+++ b/rs/moq-token-cli/README.md
@@ -20,20 +20,20 @@ Multi-arch images (`linux/amd64` and `linux/arm64`) are published to [Docker Hub
 
 ```bash
 # generate secret key
-moq-token-cli generate --out key.jwk
+moq-token generate --out key.jwk
 # sign a new JWT
-moq-token-cli sign --key key.jwk --root demo --publish bbb > token.jwt
+moq-token sign --key key.jwk --root demo --publish bbb > token.jwt
 # verify the JWT
-moq-token-cli verify --key key.jwk < token.jwt
+moq-token verify --key key.jwk < token.jwt
 ```
 
 ## Quick Usage (asymmetric keys)
 
 ```bash
 # generate private and public keys
-moq-token-cli generate --algorithm RS256 --out private.jwk --public public.jwk
+moq-token generate --algorithm RS256 --out private.jwk --public public.jwk
 # sign a new JWT (using private key)
-moq-token-cli sign --key private.jwk --root demo --publish bbb > token.jwt
+moq-token sign --key private.jwk --root demo --publish bbb > token.jwt
 # verify the JWT (using public key)
-moq-token-cli verify --key public.jwk < token.jwt
+moq-token verify --key public.jwk < token.jwt
 ```

--- a/rs/moq-token/README.md
+++ b/rs/moq-token/README.md
@@ -9,20 +9,20 @@ For comprehensive documentation including token structure, authorization rules, 
 
 ```bash
 # generate secret key
-moq-token-cli --key key.jwk generate
+moq-token generate --out key.jwk
 # sign a new JWT
-moq-token-cli --key key.jwk sign --root demo --publish bbb > token.jwt
+moq-token sign --key key.jwk --root demo --publish bbb > token.jwt
 # verify the JWT
-moq-token-cli --key key.jwk verify < token.jwt
+moq-token verify --key key.jwk < token.jwt
 ```
 
 ## Quick Usage (asymmetric keys)
 
 ```bash
 # generate private and public keys
-moq-token-cli --key private.jwk generate --algorithm RS256 --public public.jwk
+moq-token generate --algorithm RS256 --out private.jwk --public public.jwk
 # sign a new JWT (using private key)
-moq-token-cli --key private.jwk sign --root demo --publish bbb > token.jwt
+moq-token sign --key private.jwk --root demo --publish bbb > token.jwt
 # verify the JWT (using public key)
-moq-token-cli --key public.jwk verify < token.jwt
+moq-token verify --key public.jwk < token.jwt
 ```


### PR DESCRIPTION
## Summary

- Ship the `moq-token-cli` crate binary as `moq-token` via an explicit Cargo `[[bin]]`.
- Update Nix, nfpm packaging, demo justfiles, and the NixOS module to install or invoke `moq-token`.
- Refresh docs and interop comments so command examples use `moq-token` while crate/package install names remain `moq-token-cli` where appropriate.

## Public API changes

- No Rust or JS library public API changes.
- CLI binary name changes from `moq-token-cli` to `moq-token`.

## Validation

- `cargo check -p moq-token-cli`
- `cargo run --quiet --bin moq-token -- --help`
- `git diff --check`
- `nix eval .#packages.$(nix eval --raw --impure --expr builtins.currentSystem).moq-token.meta.mainProgram`
- `nix eval .#packages.$(nix eval --raw --impure --expr builtins.currentSystem).moq-token-cli.meta.mainProgram`
- Exact grep for old executable paths and examples returned no matches.

(Written by GPT-5)
