### PR TITLE
[codex] Strip announced prefixes in JS

### DIFF
--- a/demo/web/src/index.ts
+++ b/demo/web/src/index.ts
@@ -168,7 +168,8 @@ discovery.run((effect) => {
 	broadcasts.set([]);
 	if (!conn) return;
 
-	const announced = conn.announced(prefixPath(effect.get(prefixInput)));
+	const prefix = prefixPath(effect.get(prefixInput));
+	const announced = conn.announced(prefix);
 	effect.cleanup(() => announced.close());
 
 	const live = new Set<string>();
@@ -176,11 +177,12 @@ discovery.run((effect) => {
 		for (;;) {
 			const entry = await Promise.race([effect.cancel, announced.next()]);
 			if (!entry) break;
+			const path = Net.Path.join(prefix, entry.path);
 			// Only `.hang` broadcasts are watchable streams; this skips the relay's
 			// `.stats` broadcast (see the stats dashboard demo for that one).
-			if (!entry.path.endsWith(".hang")) continue;
-			if (entry.active) live.add(entry.path);
-			else live.delete(entry.path);
+			if (!path.endsWith(".hang")) continue;
+			if (entry.active) live.add(path);
+			else live.delete(path);
 			broadcasts.set([...live].sort());
 		}
 	});

--- a/demo/web/src/stats.ts
+++ b/demo/web/src/stats.ts
@@ -115,14 +115,15 @@ discovery.run((effect) => {
 		for (;;) {
 			const entry = await Promise.race([effect.cancel, announced.next()]);
 			if (!entry) break;
-			const node = (Net.Path.stripPrefix(prefix, entry.path) ?? entry.path) as string;
+			const node = entry.path as string;
 			if (!node) continue;
+			const path = Net.Path.join(prefix, entry.path);
 
 			if (entry.active) {
 				if (subs.has(node)) continue;
 				const ne = new Signals.Effect();
 				subs.set(node, ne);
-				subscribeNode(ne, conn, entry.path, node);
+				subscribeNode(ne, conn, path, node);
 			} else {
 				subs.get(node)?.close();
 				subs.delete(node);

--- a/js/moq-boy/src/element.tsx
+++ b/js/moq-boy/src/element.tsx
@@ -129,8 +129,8 @@ export default class MoqBoy extends HTMLElement {
 				const entry = await Promise.race([effect.cancel, announced.next()]);
 				if (!entry) break;
 
-				// Strip prefix, skip nested paths (e.g. "viewer/..." sub-broadcasts).
-				const suffix = Moq.Path.stripPrefix(prefix, entry.path);
+				// Skip nested paths (e.g. "viewer/..." sub-broadcasts).
+				const suffix = entry.path;
 				if (!suffix || suffix.includes("/")) continue;
 
 				const id = suffix;

--- a/js/net/src/announced.ts
+++ b/js/net/src/announced.ts
@@ -7,7 +7,9 @@ import * as Path from "./path.js";
  * @public
  */
 export interface AnnouncedEntry {
+	/** Broadcast path relative to the prefix passed to `announced()`. */
 	path: Path.Valid;
+	/** True when the broadcast is available, false when it was removed. */
 	active: boolean;
 }
 

--- a/js/net/src/connection/established.ts
+++ b/js/net/src/connection/established.ts
@@ -22,7 +22,7 @@ export interface Established {
 	/** RTT in milliseconds from PROBE (moq-lite-04+ only). */
 	readonly rtt?: Signal<Time.Milli | undefined>;
 
-	/** Subscribe to broadcast announcements under an optional path prefix. */
+	/** Subscribe to broadcast announcements under an optional path prefix, returning paths relative to that prefix. */
 	announced(prefix?: Path.Valid): Announced;
 
 	/** Publish a broadcast at the given path. */

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -72,8 +72,9 @@ export class Subscriber {
 	announced(prefix = Path.empty()): Announced {
 		const announced = new Announced(prefix);
 		for (const active of this.#announced) {
-			if (!Path.hasPrefix(prefix, active)) continue;
-			announced.append({ path: active, active: true });
+			const suffix = Path.stripPrefix(prefix, active);
+			if (suffix === null) continue;
+			announced.append({ path: suffix, active: true });
 		}
 		this.#announcedConsumers.add(announced);
 
@@ -144,8 +145,9 @@ export class Subscriber {
 
 							this.#announced.add(path);
 							for (const consumer of this.#announcedConsumers) {
-								if (!Path.hasPrefix(consumer.prefix, path)) continue;
-								consumer.append({ path, active: true });
+								const suffix = Path.stripPrefix(consumer.prefix, path);
+								if (suffix === null) continue;
+								consumer.append({ path: suffix, active: true });
 							}
 						} else if (msgType === SubscribeNamespaceEntryDone.id) {
 							const entry = await SubscribeNamespaceEntryDone.decode(stream.reader, version);
@@ -154,8 +156,9 @@ export class Subscriber {
 
 							this.#announced.delete(path);
 							for (const consumer of this.#announcedConsumers) {
-								if (!Path.hasPrefix(consumer.prefix, path)) continue;
-								consumer.append({ path, active: false });
+								const suffix = Path.stripPrefix(consumer.prefix, path);
+								if (suffix === null) continue;
+								consumer.append({ path: suffix, active: false });
 							}
 						} else if (msgType === PublishBlocked.id && version === Version.DRAFT_17) {
 							const blocked = await PublishBlocked.decode(stream.reader, version);
@@ -407,7 +410,7 @@ export class Subscriber {
 			for (const consumer of this.#announcedConsumers) {
 				const suffix = Path.stripPrefix(consumer.prefix, path);
 				if (suffix === null) continue;
-				consumer.append({ path, active: true });
+				consumer.append({ path: suffix, active: true });
 			}
 
 			// Wait for stream close (= PublishNamespaceDone)
@@ -422,7 +425,7 @@ export class Subscriber {
 				const suffix = Path.stripPrefix(consumer.prefix, path);
 				if (suffix === null) continue;
 				try {
-					consumer.append({ path, active: false });
+					consumer.append({ path: suffix, active: false });
 				} catch {
 					// Consumer already closed, will be cleaned up
 				}

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -22,6 +22,8 @@ async function runPublishSubscribeFlow(protocol: string, version?: number) {
 	// Server publishes a broadcast
 	const broadcast = new Broadcast();
 	server.publish(Path.from("test"), broadcast);
+	const prefixedBroadcast = new Broadcast();
+	server.publish(Path.from("root/child"), prefixedBroadcast);
 
 	// Serve every requested "video" track. On lite-05+ a subscribe is preceded by
 	// a TRACK info lookup, which the publisher answers by requesting the track too,
@@ -47,6 +49,13 @@ async function runPublishSubscribeFlow(protocol: string, version?: number) {
 	expect(entry.path).toBe("test" as Path.Valid);
 	expect(entry.active).toBe(true);
 
+	// Prefix-scoped discovery returns paths relative to the requested prefix.
+	const prefixed = client.announced(Path.from("root"));
+	const prefixedEntry = await prefixed.next();
+	if (!prefixedEntry) throw new Error("expected prefixed entry");
+	expect(prefixedEntry.path).toBe("child" as Path.Valid);
+	expect(prefixedEntry.active).toBe(true);
+
 	// Client consumes the broadcast and subscribes to a track
 	const remote = client.consume(Path.from("test"));
 	const track = remote.track("video").subscribe();
@@ -58,8 +67,10 @@ async function runPublishSubscribeFlow(protocol: string, version?: number) {
 
 	// Cleanup
 	broadcast.close();
+	prefixedBroadcast.close();
 	await serving;
 	announced.close();
+	prefixed.close();
 	remote.close();
 	client.close();
 	server.close();

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -135,7 +135,7 @@ export class Subscriber {
 	 * this connection's {@link origin}.
 	 */
 	announced(prefix = Path.empty(), options: AnnouncedOptions = {}): Announced {
-		const announced = new Announced();
+		const announced = new Announced(prefix);
 		void this.#runAnnounced(announced, prefix, options);
 		return announced;
 	}
@@ -172,7 +172,7 @@ export class Subscriber {
 					for (const suffix of init.suffixes) {
 						const path = Path.join(prefix, suffix);
 						console.debug(`announced: broadcast=${path} active=true`);
-						announced.append({ path, active: true });
+						announced.append({ path: suffix, active: true });
 					}
 					break;
 				}
@@ -202,7 +202,7 @@ export class Subscriber {
 				const path = Path.join(prefix, announce.suffix);
 
 				console.debug(`announced: broadcast=${path} active=${announce.active}`);
-				announced.append({ path, active: announce.active });
+				announced.append({ path: announce.suffix, active: announce.active });
 			}
 
 			announced.close();


### PR DESCRIPTION
## Summary

- Return `announced(prefix)` entries relative to the requested prefix in both JS lite and IETF subscribers.
- Update JS callers that previously stripped the prefix themselves, and rejoin prefixes where callers need the full path for `consume()` or `<moq-watch>.name`.
- Document the relative-path contract and add integration coverage across the existing protocol matrix.

## Public API changes

- `@moq/net` `AnnouncedEntry.path` now documents and returns the path relative to the prefix passed to `announced()`.
- `Established.announced(prefix)` now documents that returned entries are relative to `prefix`.

This is a breaking JS behavior change for callers that expected full broadcast paths from a prefixed announcement subscription, so this PR targets `dev`.

## Validation

- `bun run --filter='@moq/net' test`
- `bun run --filter='@moq/net' check`
- `bun run --filter='@moq/boy' check`
- `bun run --filter='@moq/demo' check`
- `bun biome check demo/web/src/index.ts demo/web/src/stats.ts js/net/src/announced.ts js/net/src/connection/established.ts js/net/src/lite/subscriber.ts js/net/src/ietf/subscriber.ts js/net/src/integration.test.ts js/moq-boy/src/element.tsx`
- `git diff --check`

(Written by GPT-5)