### PR TITLE
[codex] Add catalog reservation gating

### DIFF
--- a/js/publish/src/catalog.test.ts
+++ b/js/publish/src/catalog.test.ts
@@ -125,34 +125,6 @@ test("untouched reservations do not publish an empty catalog", async () => {
 	effect.close();
 });
 
-test("removing the last rendition keeps a section with display metadata", async () => {
-	const catalog = new CatalogProducer();
-	const reserved = catalog.reserve();
-	const video = reserved.video("video/hd");
-	reserved.close();
-
-	const effect = new Effect();
-	const track = new TrackProducer("catalog.json");
-	catalog.serve(track, effect);
-	const consumer = new Json.Consumer<Catalog.Root>(track.subscribe());
-	const first = consumer.next();
-
-	video.set(videoConfig);
-	await first;
-
-	// Display metadata lives outside the rendition guard, so removing the last rendition must keep it.
-	const display = { width: Catalog.u53(1920), height: Catalog.u53(1080) };
-	catalog.mutate((c) => {
-		c.video = { renditions: { "video/hd": videoConfig }, display };
-	});
-	await consumer.next();
-
-	video.close();
-	expect(await consumer.next()).toEqual({ video: { renditions: {}, display } });
-
-	effect.close();
-});
-
 test("catalog producer publishes every update as a snapshot group", async () => {
 	const catalog = new CatalogProducer();
 	catalog.mutate((c) => {

--- a/js/publish/src/catalog.test.ts
+++ b/js/publish/src/catalog.test.ts
@@ -125,6 +125,37 @@ test("untouched reservations do not publish an empty catalog", async () => {
 	effect.close();
 });
 
+test("removing the last rendition keeps a section with display metadata", async () => {
+	const catalog = new CatalogProducer();
+	const reserved = catalog.reserve();
+	const video = reserved.video("video/hd");
+	reserved.close();
+
+	const effect = new Effect();
+	const track = new TrackProducer("catalog.json");
+	catalog.serve(track, effect);
+	const consumer = new Json.Consumer<Catalog.Root>(track.subscribe());
+	const first = consumer.next();
+
+	video.set(videoConfig);
+	await first;
+
+	// Display metadata lives outside the rendition guard, so removing the last rendition must keep it.
+	catalog.mutate((c) => {
+		const section = c.video as {
+			renditions: Record<string, Catalog.VideoConfig>;
+			display: { width: number; height: number };
+		};
+		section.display = { width: 1920, height: 1080 };
+	});
+	await consumer.next();
+
+	video.close();
+	expect(await consumer.next()).toEqual({ video: { renditions: {}, display: { width: 1920, height: 1080 } } });
+
+	effect.close();
+});
+
 test("catalog producer publishes every update as a snapshot group", async () => {
 	const catalog = new CatalogProducer();
 	catalog.mutate((c) => {

--- a/js/publish/src/catalog.test.ts
+++ b/js/publish/src/catalog.test.ts
@@ -1,9 +1,27 @@
 import { expect, test } from "bun:test";
-import type * as Catalog from "@moq/hang/catalog";
+import * as Catalog from "@moq/hang/catalog";
 import * as Json from "@moq/json";
 import { TrackProducer } from "@moq/net";
 import { Effect } from "@moq/signals";
 import { CatalogProducer } from "./catalog.ts";
+
+const videoConfig: Catalog.VideoConfig = {
+	codec: "vp8",
+	container: { kind: "legacy" },
+	codedWidth: Catalog.u53(1280),
+	codedHeight: Catalog.u53(720),
+};
+
+const audioConfig: Catalog.AudioConfig = {
+	codec: "opus",
+	container: { kind: "legacy" },
+	sampleRate: Catalog.u53(48_000),
+	numberOfChannels: Catalog.u53(2),
+};
+
+async function settled<T>(promise: Promise<T>): Promise<"pending" | T> {
+	return await Promise.race([promise, new Promise<"pending">((resolve) => setTimeout(() => resolve("pending"), 0))]);
+}
 
 test("catalog producer seeds subscribers and fans out edits", async () => {
 	const catalog = new CatalogProducer();
@@ -28,6 +46,81 @@ test("catalog producer seeds subscribers and fans out edits", async () => {
 	const update = await consumer.next();
 	expect(update?.video).toEqual({ renditions: {} });
 	expect(update?.scte35).toEqual({ splices: [] });
+
+	effect.close();
+});
+
+test("catalog reservation withholds the first snapshot", async () => {
+	const catalog = new CatalogProducer();
+	const reserved = catalog.reserve();
+
+	const effect = new Effect();
+	const track = new TrackProducer("catalog.json");
+	catalog.serve(track, effect);
+	const consumer = new Json.Consumer<Catalog.Root>(track.subscribe());
+	const next = consumer.next();
+
+	catalog.mutate((c) => {
+		c.video = { renditions: { "video/hd": videoConfig } };
+	});
+	expect(await settled(next)).toBe("pending");
+
+	reserved.close();
+	expect((await next)?.video).toEqual({ renditions: { "video/hd": videoConfig } });
+
+	effect.close();
+});
+
+test("reserved renditions publish one complete first snapshot", async () => {
+	const catalog = new CatalogProducer();
+	const reserved = catalog.reserve();
+	const video = reserved.video("video/hd");
+	const audio = reserved.audio("audio/data");
+	reserved.close();
+
+	const effect = new Effect();
+	const track = new TrackProducer("catalog.json");
+	catalog.serve(track, effect);
+	const consumer = new Json.Consumer<Catalog.Root>(track.subscribe());
+	const next = consumer.next();
+
+	video.set(videoConfig);
+	expect(await settled(next)).toBe("pending");
+
+	audio.set(audioConfig);
+	const first = await next;
+	expect(first?.video).toEqual({ renditions: { "video/hd": videoConfig } });
+	expect(first?.audio).toEqual({ renditions: { "audio/data": audioConfig } });
+
+	video.update((config) => {
+		config.bitrate = Catalog.u53(1_000_000);
+	});
+	expect((await consumer.next())?.video?.renditions["video/hd"]?.bitrate).toBe(Catalog.u53(1_000_000));
+
+	audio.close();
+	expect((await consumer.next())?.audio).toBeUndefined();
+
+	video.close();
+	effect.close();
+});
+
+test("untouched reservations do not publish an empty catalog", async () => {
+	const catalog = new CatalogProducer();
+	const reserved = catalog.reserve();
+
+	const effect = new Effect();
+	const track = new TrackProducer("catalog.json");
+	catalog.serve(track, effect);
+	const consumer = new Json.Consumer<Catalog.Root>(track.subscribe());
+	const next = consumer.next();
+
+	reserved.close();
+	expect(await settled(next)).toBe("pending");
+
+	catalog.mutate((c) => {
+		c.scte35 = { splices: [] };
+	});
+	expect(await next).toEqual({ scte35: { splices: [] } });
 
 	effect.close();
 });

--- a/js/publish/src/catalog.test.ts
+++ b/js/publish/src/catalog.test.ts
@@ -141,17 +141,17 @@ test("removing the last rendition keeps a section with display metadata", async 
 	await first;
 
 	// Display metadata lives outside the rendition guard, so removing the last rendition must keep it.
+	const display = { width: Catalog.u53(1920), height: Catalog.u53(1080) };
 	catalog.mutate((c) => {
-		const section = c.video as {
-			renditions: Record<string, Catalog.VideoConfig>;
-			display: { width: number; height: number };
-		};
-		section.display = { width: 1920, height: 1080 };
+		const section = c.video;
+		if (section && "renditions" in section) {
+			(section as { display?: typeof display }).display = display;
+		}
 	});
 	await consumer.next();
 
 	video.close();
-	expect(await consumer.next()).toEqual({ video: { renditions: {}, display: { width: 1920, height: 1080 } } });
+	expect(await consumer.next()).toEqual({ video: { renditions: {}, display } });
 
 	effect.close();
 });

--- a/js/publish/src/catalog.test.ts
+++ b/js/publish/src/catalog.test.ts
@@ -143,10 +143,7 @@ test("removing the last rendition keeps a section with display metadata", async 
 	// Display metadata lives outside the rendition guard, so removing the last rendition must keep it.
 	const display = { width: Catalog.u53(1920), height: Catalog.u53(1080) };
 	catalog.mutate((c) => {
-		const section = c.video;
-		if (section && "renditions" in section) {
-			(section as { display?: typeof display }).display = display;
-		}
+		c.video = { renditions: { "video/hd": videoConfig }, display };
 	});
 	await consumer.next();
 

--- a/js/publish/src/catalog.ts
+++ b/js/publish/src/catalog.ts
@@ -3,6 +3,42 @@ import * as Json from "@moq/json";
 import type * as Moq from "@moq/net";
 import type { Effect } from "@moq/signals";
 
+/** A closeable reservation that gates the first catalog snapshot. */
+export interface CatalogReservation {
+	/** Create another reservation on the same catalog gate. */
+	clone(): CatalogReservation;
+
+	/** Reserve a video rendition by track name until its config is set or the guard is closed. */
+	video(name: string): ReservedRendition<Catalog.VideoConfig>;
+
+	/** Reserve an audio rendition by track name until its config is set or the guard is closed. */
+	audio(name: string): ReservedRendition<Catalog.AudioConfig>;
+
+	/** Release this reservation. */
+	close(): void;
+}
+
+/** A reserved catalog rendition that writes its config when it becomes known. */
+export interface ReservedRendition<T> {
+	/** The track name this rendition occupies in the catalog. */
+	readonly name: string;
+
+	/** Insert or replace the rendition config, releasing its initial catalog gate. */
+	set(config: T): void;
+
+	/** Edit the rendition config in place if it has already been set. */
+	update(fn: (config: T) => void): void;
+
+	/** Remove the rendition if present and release its initial catalog gate. */
+	close(): void;
+}
+
+type RenditionOps<T> = {
+	insert(catalog: Catalog.Root, name: string, config: T): void;
+	update(catalog: Catalog.Root, name: string, fn: (config: T) => void): void;
+	remove(catalog: Catalog.Root, name: string): void;
+};
+
 /**
  * A stable catalog producer that fans out to on-demand subscription tracks.
  *
@@ -10,18 +46,48 @@ import type { Effect } from "@moq/signals";
  * with {@link mutate}, and each subscriber (including a relay that reconnects) is seeded with the
  * current catalog before receiving updates. Independent owners (the base `video`/`audio` and an
  * application's own sections, e.g. `scte35`) each edit only their own keys, so their sections
- * compose instead of clobbering one another.
+ * compose instead of clobbering one another. Use {@link reserve} when the first snapshot should wait
+ * for an initial set of async track configs to resolve.
  */
 export class CatalogProducer {
 	#value: Catalog.Root = {};
 	#outputs = new Set<Json.Producer<Catalog.Root>>();
+	#reservations = 0;
+	#pending = false;
+	#published = false;
+	#reserved = false;
 
 	/** Edit the catalog in place; the result is published to all current subscribers. */
 	mutate(fn: (catalog: Catalog.Root) => void): void {
 		const value = structuredClone(this.#value);
 		fn(value);
 		this.#value = value;
-		for (const output of this.#outputs) output.update(value);
+		this.#publish();
+	}
+
+	/**
+	 * Gate the first catalog snapshot until the returned reservation is closed.
+	 *
+	 * Callers can clone the reservation, or reserve individual audio/video renditions from it, while
+	 * discovering the initial track set. Mutations made while the initial gate is open are buffered and
+	 * published as one complete snapshot when the last reservation closes. If no mutation was made, no
+	 * empty catalog is emitted.
+	 */
+	reserve(): CatalogReservation {
+		this.#reserved = true;
+		this.#reservations += 1;
+		return new Reservation(this, () => this.#release());
+	}
+
+	#publish(): void {
+		if (!this.#published && this.#reservations > 0) {
+			this.#pending = true;
+			return;
+		}
+
+		this.#pending = false;
+		this.#published = true;
+		for (const output of this.#outputs) output.update(this.#value);
 	}
 
 	/**
@@ -35,7 +101,10 @@ export class CatalogProducer {
 			compression: opts?.compression,
 			deltaRatio: 0,
 		});
-		output.update(this.#value);
+		if (this.#published || !this.#reserved) {
+			this.#published = true;
+			output.update(this.#value);
+		}
 
 		this.#outputs.add(output);
 		effect.cleanup(() => {
@@ -43,4 +112,159 @@ export class CatalogProducer {
 			output.finish();
 		});
 	}
+
+	#release(): void {
+		this.#reservations = Math.max(0, this.#reservations - 1);
+		if (this.#published || this.#reservations !== 0 || !this.#pending) return;
+
+		this.#publish();
+	}
+}
+
+class Reservation implements CatalogReservation {
+	#catalog: CatalogProducer;
+	#release: () => void;
+	#closed = false;
+
+	constructor(catalog: CatalogProducer, release: () => void) {
+		this.#catalog = catalog;
+		this.#release = release;
+	}
+
+	clone(): CatalogReservation {
+		if (this.#closed) throw new Error("reservation is closed");
+		return this.#catalog.reserve();
+	}
+
+	video(name: string): ReservedRendition<Catalog.VideoConfig> {
+		return new Rendition(name, this.#catalog, this.clone(), VIDEO_OPS);
+	}
+
+	audio(name: string): ReservedRendition<Catalog.AudioConfig> {
+		return new Rendition(name, this.#catalog, this.clone(), AUDIO_OPS);
+	}
+
+	close(): void {
+		if (this.#closed) return;
+		this.#closed = true;
+		this.#release();
+	}
+}
+
+class Rendition<T> implements ReservedRendition<T> {
+	readonly name: string;
+	#catalog: CatalogProducer;
+	#gate: CatalogReservation | undefined;
+	#ops: RenditionOps<T>;
+	#present = false;
+
+	constructor(name: string, catalog: CatalogProducer, gate: CatalogReservation, ops: RenditionOps<T>) {
+		this.name = name;
+		this.#catalog = catalog;
+		this.#gate = gate;
+		this.#ops = ops;
+	}
+
+	set(config: T): void {
+		this.#catalog.mutate((catalog) => this.#ops.insert(catalog, this.name, config));
+		this.#present = true;
+		this.#gate?.close();
+		this.#gate = undefined;
+	}
+
+	update(fn: (config: T) => void): void {
+		if (!this.#present) return;
+		this.#catalog.mutate((catalog) => this.#ops.update(catalog, this.name, fn));
+	}
+
+	close(): void {
+		if (this.#present) {
+			this.#catalog.mutate((catalog) => this.#ops.remove(catalog, this.name));
+			this.#present = false;
+		}
+		this.#gate?.close();
+		this.#gate = undefined;
+	}
+}
+
+type VideoSection = {
+	renditions: Record<string, Catalog.VideoConfig>;
+	display?: { width: number; height: number };
+	rotation?: number;
+	flip?: boolean;
+};
+
+type AudioSection = {
+	renditions: Record<string, Catalog.AudioConfig>;
+};
+
+const VIDEO_OPS: RenditionOps<Catalog.VideoConfig> = {
+	insert(catalog, name, config) {
+		videoSection(catalog).renditions[name] = config;
+	},
+	update(catalog, name, fn) {
+		const video = currentVideo(catalog);
+		const config = video?.renditions[name];
+		if (config) fn(config);
+	},
+	remove(catalog, name) {
+		const video = currentVideo(catalog);
+		if (!video) return;
+
+		delete video.renditions[name];
+		if (
+			Object.keys(video.renditions).length === 0 &&
+			video.display === undefined &&
+			video.rotation === undefined &&
+			video.flip === undefined
+		) {
+			delete catalog.video;
+		}
+	},
+};
+
+const AUDIO_OPS: RenditionOps<Catalog.AudioConfig> = {
+	insert(catalog, name, config) {
+		audioSection(catalog).renditions[name] = config;
+	},
+	update(catalog, name, fn) {
+		const audio = currentAudio(catalog);
+		const config = audio?.renditions[name];
+		if (config) fn(config);
+	},
+	remove(catalog, name) {
+		const audio = currentAudio(catalog);
+		if (!audio) return;
+
+		delete audio.renditions[name];
+		if (Object.keys(audio.renditions).length === 0) delete catalog.audio;
+	},
+};
+
+function videoSection(catalog: Catalog.Root): VideoSection {
+	const current = currentVideo(catalog);
+	if (current) return current;
+
+	const video: VideoSection = { renditions: {} };
+	catalog.video = video as Catalog.Video;
+	return video;
+}
+
+function currentVideo(catalog: Catalog.Root): VideoSection | undefined {
+	if (!catalog.video || !("renditions" in catalog.video)) return undefined;
+	return catalog.video as VideoSection;
+}
+
+function audioSection(catalog: Catalog.Root): AudioSection {
+	const current = currentAudio(catalog);
+	if (current) return current;
+
+	const audio: AudioSection = { renditions: {} };
+	catalog.audio = audio as Catalog.Audio;
+	return audio;
+}
+
+function currentAudio(catalog: Catalog.Root): AudioSection | undefined {
+	if (!catalog.audio || !("renditions" in catalog.audio)) return undefined;
+	return catalog.audio as AudioSection;
 }

--- a/js/publish/src/catalog.ts
+++ b/js/publish/src/catalog.ts
@@ -212,7 +212,14 @@ const VIDEO_OPS: RenditionOps<Catalog.VideoConfig> = {
 		if (!video) return;
 
 		delete video.renditions[name];
-		if (sectionIsEmpty(video)) delete catalog.video;
+		if (
+			Object.keys(video.renditions).length === 0 &&
+			video.display === undefined &&
+			video.rotation === undefined &&
+			video.flip === undefined
+		) {
+			delete catalog.video;
+		}
 	},
 };
 
@@ -230,7 +237,7 @@ const AUDIO_OPS: RenditionOps<Catalog.AudioConfig> = {
 		if (!audio) return;
 
 		delete audio.renditions[name];
-		if (sectionIsEmpty(audio)) delete catalog.audio;
+		if (Object.keys(audio.renditions).length === 0) delete catalog.audio;
 	},
 };
 
@@ -260,15 +267,4 @@ function audioSection(catalog: Catalog.Root): AudioSection {
 function currentAudio(catalog: Catalog.Root): AudioSection | undefined {
 	if (!catalog.audio || !("renditions" in catalog.audio)) return undefined;
 	return catalog.audio as AudioSection;
-}
-
-/**
- * Whether a media section has nothing left worth keeping: no renditions and no other field carrying
- * a value. `structuredClone` preserves keys whose value is `undefined`, so this inspects values
- * rather than keys, and stays correct if the section gains fields later (e.g. video display or
- * rotation): any defined field keeps the section alive.
- */
-function sectionIsEmpty(section: { renditions: Record<string, unknown> }): boolean {
-	if (Object.keys(section.renditions).length > 0) return false;
-	return Object.entries(section).every(([key, value]) => key === "renditions" || value === undefined);
 }

--- a/js/publish/src/catalog.ts
+++ b/js/publish/src/catalog.ts
@@ -212,14 +212,7 @@ const VIDEO_OPS: RenditionOps<Catalog.VideoConfig> = {
 		if (!video) return;
 
 		delete video.renditions[name];
-		if (
-			Object.keys(video.renditions).length === 0 &&
-			video.display === undefined &&
-			video.rotation === undefined &&
-			video.flip === undefined
-		) {
-			delete catalog.video;
-		}
+		if (sectionIsEmpty(video)) delete catalog.video;
 	},
 };
 
@@ -237,7 +230,7 @@ const AUDIO_OPS: RenditionOps<Catalog.AudioConfig> = {
 		if (!audio) return;
 
 		delete audio.renditions[name];
-		if (Object.keys(audio.renditions).length === 0) delete catalog.audio;
+		if (sectionIsEmpty(audio)) delete catalog.audio;
 	},
 };
 
@@ -267,4 +260,15 @@ function audioSection(catalog: Catalog.Root): AudioSection {
 function currentAudio(catalog: Catalog.Root): AudioSection | undefined {
 	if (!catalog.audio || !("renditions" in catalog.audio)) return undefined;
 	return catalog.audio as AudioSection;
+}
+
+/**
+ * Whether a media section has nothing left worth keeping: no renditions and no other field carrying
+ * a value. `structuredClone` preserves keys whose value is `undefined`, so this inspects values
+ * rather than keys, and stays correct if the section gains fields later (e.g. video display or
+ * rotation): any defined field keeps the section alive.
+ */
+function sectionIsEmpty(section: { renditions: Record<string, unknown> }): boolean {
+	if (Object.keys(section.renditions).length > 0) return false;
+	return Object.entries(section).every(([key, value]) => key === "renditions" || value === undefined);
 }

--- a/js/publish/src/index.ts
+++ b/js/publish/src/index.ts
@@ -4,6 +4,7 @@ export * as Net from "@moq/net";
 export * as Signals from "@moq/signals";
 export * as Audio from "./audio";
 export * from "./broadcast";
+export * from "./catalog";
 export * as Preview from "./preview";
 export * as Source from "./source";
 export * as Video from "./video";


### PR DESCRIPTION
## Summary

- Add opt-in first-snapshot reservation gating to the publish catalog producer.
- Add closeable audio and video rendition guards that insert configs, release the initial gate, update set configs, and remove their catalog entries on close.
- Export the catalog producer API from `@moq/publish` and cover reserved initial publish behavior in tests.

## Public API

- New `CatalogReservation` interface in `@moq/publish`.
- New `ReservedRendition<T>` interface in `@moq/publish`.
- New `CatalogProducer.reserve()` method.
- New root export for `./catalog` from `@moq/publish`.

## Testing

- `env TMPDIR=/private/tmp bun run --filter='@moq/publish' test`
- `env TMPDIR=/private/tmp bun run --filter='@moq/publish' check`
- `env TMPDIR=/private/tmp bun run --filter='@moq/publish' build`
- `env TMPDIR=/private/tmp bun run --filter='*' check`
- `env TMPDIR=/private/tmp bun biome check js/publish/src/catalog.ts js/publish/src/catalog.test.ts js/publish/src/index.ts`
- `git diff --check`

Fixes #2075.

(Written by GPT-5)