### PR TITLE
[codex] moq-rtc: share catalog reservation across ingest bridges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4424,6 +4424,7 @@ dependencies = [
  "axum",
  "bytes",
  "hang",
+ "kio",
  "moq-mux",
  "moq-net",
  "reqwest",

--- a/rs/moq-rtc/Cargo.toml
+++ b/rs/moq-rtc/Cargo.toml
@@ -34,4 +34,5 @@ url = "2"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
+kio = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }

--- a/rs/moq-rtc/src/client/whep.rs
+++ b/rs/moq-rtc/src/client/whep.rs
@@ -18,8 +18,6 @@ use url::Url;
 use crate::{Error, Result, client::Client, ingest::IngestSink, session};
 
 pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::broadcast::Producer) -> Result<()> {
-	let sink = Box::new(IngestSink::new(broadcast)?);
-
 	let (socket, candidates) = session::bind_udp(&client.config().ice_candidates).await?;
 	let mut rtc = Rtc::new(Instant::now());
 	for addr in &candidates {
@@ -57,6 +55,7 @@ pub(crate) async fn dial(client: &Client, url: Url, broadcast: moq_net::broadcas
 	let answer = SdpAnswer::from_sdp_string(&body).map_err(|err| Error::InvalidSdp(err.to_string()))?;
 
 	rtc.sdp_api().accept_answer(pending, answer).map_err(Error::Rtc)?;
+	let sink = Box::new(IngestSink::new(broadcast, crate::sdp::count_remote_send(&body))?);
 	tracing::info!(%url, "whep client connected");
 
 	// 1:1 socket (no demux on the client): pump its datagrams into the session.

--- a/rs/moq-rtc/src/codec/bitstream_test.rs
+++ b/rs/moq-rtc/src/codec/bitstream_test.rs
@@ -41,7 +41,7 @@ async fn h264_annexb_frame_publishes_catalog_entry() {
 	let mut producer = broadcast.produce();
 	let catalog = moq_mux::catalog::Producer::new(&mut producer).expect("catalog");
 
-	let mut bridge = codec::h264::Bridge::new(producer, catalog.clone()).expect("bridge");
+	let mut bridge = codec::h264::Bridge::new(producer, catalog.reserve()).expect("bridge");
 
 	let codec_frame = Frame {
 		timestamp_us: 0,
@@ -71,7 +71,7 @@ async fn opus_frame_publishes_catalog_entry() {
 	let mut producer = broadcast.produce();
 	let catalog = moq_mux::catalog::Producer::new(&mut producer).expect("catalog");
 
-	let mut bridge = codec::opus::Bridge::new(producer, catalog.clone(), 48_000, 2).expect("bridge");
+	let mut bridge = codec::opus::Bridge::new(producer, catalog.reserve(), 48_000, 2).expect("bridge");
 
 	let payload = Bytes::from_static(&[0xfc, 0xff, 0xfe]); // arbitrary 3-byte Opus packet
 	let codec_frame = Frame {
@@ -94,7 +94,7 @@ async fn vp9_keyframe_flag_from_uncompressed_header() {
 	let mut producer = broadcast.produce();
 	let catalog = moq_mux::catalog::Producer::new(&mut producer).expect("catalog");
 
-	let mut bridge = codec::vp9::Bridge::new(producer, catalog.clone()).expect("bridge");
+	let mut bridge = codec::vp9::Bridge::new(producer, catalog.reserve()).expect("bridge");
 
 	// VP9 uncompressed header: frame_type is bit 2. 0 = keyframe, 1 = inter.
 	// Byte with bit 2 cleared is a keyframe; with bit 2 set is an inter frame.
@@ -144,7 +144,7 @@ async fn egress_opus_passthrough() {
 	let broadcast = moq_net::broadcast::Info::new();
 	let mut producer = broadcast.produce();
 	let catalog = moq_mux::catalog::Producer::new(&mut producer).expect("catalog");
-	let mut bridge = codec::opus::Bridge::new(producer.clone(), catalog.clone(), 48_000, 2).expect("bridge");
+	let mut bridge = codec::opus::Bridge::new(producer.clone(), catalog.reserve(), 48_000, 2).expect("bridge");
 
 	let payload = Bytes::from_static(&[0xfc, 0xff, 0xfe]);
 	Bridge::push(
@@ -181,7 +181,7 @@ async fn egress_h264_avc3_passthrough() {
 	let mut producer = broadcast.produce();
 	let catalog = moq_mux::catalog::Producer::new(&mut producer).expect("catalog");
 
-	let mut bridge = codec::h264::Bridge::new(producer.clone(), catalog.clone()).expect("bridge");
+	let mut bridge = codec::h264::Bridge::new(producer.clone(), catalog.reserve()).expect("bridge");
 	Bridge::push(
 		&mut bridge,
 		Frame {

--- a/rs/moq-rtc/src/codec/h264.rs
+++ b/rs/moq-rtc/src/codec/h264.rs
@@ -13,9 +13,9 @@ pub struct Bridge {
 }
 
 impl Bridge {
-	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
+	pub fn new(mut broadcast: moq_net::broadcast::Producer, reserved: moq_mux::catalog::Reserved) -> Result<Self> {
 		let track = moq_mux::import::unique_track(&mut broadcast, ".avc3")?;
-		let import = moq_mux::codec::h264::Import::new(track, catalog.reserve());
+		let import = moq_mux::codec::h264::Import::new(track, reserved);
 		let split = moq_mux::codec::h264::Split::new();
 		Ok(Self { split, import })
 	}

--- a/rs/moq-rtc/src/codec/opus.rs
+++ b/rs/moq-rtc/src/codec/opus.rs
@@ -12,7 +12,7 @@ pub struct Bridge {
 impl Bridge {
 	pub fn new(
 		mut broadcast: moq_net::broadcast::Producer,
-		catalog: moq_mux::catalog::Producer,
+		reserved: moq_mux::catalog::Reserved,
 		sample_rate: u32,
 		channel_count: u32,
 	) -> Result<Self> {
@@ -21,7 +21,7 @@ impl Bridge {
 			channel_count,
 		};
 		let track = moq_mux::import::unique_track(&mut broadcast, ".opus")?;
-		let import = moq_mux::codec::opus::Import::new(track, catalog.reserve(), config)?;
+		let import = moq_mux::codec::opus::Import::new(track, reserved, config)?;
 		Ok(Self { import })
 	}
 }

--- a/rs/moq-rtc/src/codec/vp8.rs
+++ b/rs/moq-rtc/src/codec/vp8.rs
@@ -9,20 +9,23 @@ use crate::{Result, codec};
 /// Forwards str0m's VP8 frames to a `.vp8` track, detecting keyframes inline.
 pub struct Bridge {
 	catalog: moq_mux::catalog::Producer,
+	reserved: Option<moq_mux::catalog::Reserved>,
 	track: moq_mux::container::Producer<moq_mux::catalog::hang::Container>,
 	announced: bool,
 }
 
 impl Bridge {
 	/// Publish a `.vp8` track on `broadcast`; the catalog rendition is added on the first frame.
-	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
+	pub fn new(mut broadcast: moq_net::broadcast::Producer, reserved: moq_mux::catalog::Reserved) -> Result<Self> {
 		let track = broadcast.create_track(
 			broadcast.unique_name(".vp8"),
 			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)?;
 		let producer = moq_mux::container::Producer::new(track, moq_mux::catalog::hang::Container::Legacy);
+		let catalog = reserved.producer();
 		Ok(Self {
 			catalog,
+			reserved: Some(reserved),
 			track: producer,
 			announced: false,
 		})
@@ -34,11 +37,14 @@ impl Bridge {
 		}
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		config.container = hang::catalog::Container::Legacy;
-		self.catalog
-			.lock()
-			.video
-			.renditions
-			.insert(self.track.track().name().to_string(), config);
+		{
+			self.catalog
+				.lock()
+				.video
+				.renditions
+				.insert(self.track.track().name().to_string(), config);
+		}
+		self.reserved = None;
 		self.announced = true;
 	}
 }

--- a/rs/moq-rtc/src/codec/vp9.rs
+++ b/rs/moq-rtc/src/codec/vp9.rs
@@ -8,20 +8,23 @@ use crate::{Result, codec};
 /// Forwards str0m's VP9 frames to a `.vp9` track, detecting keyframes inline.
 pub struct Bridge {
 	catalog: moq_mux::catalog::Producer,
+	reserved: Option<moq_mux::catalog::Reserved>,
 	track: moq_mux::container::Producer<moq_mux::catalog::hang::Container>,
 	announced: bool,
 }
 
 impl Bridge {
 	/// Publish a `.vp9` track on `broadcast`; the catalog rendition is added on the first frame.
-	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
+	pub fn new(mut broadcast: moq_net::broadcast::Producer, reserved: moq_mux::catalog::Reserved) -> Result<Self> {
 		let track = broadcast.create_track(
 			broadcast.unique_name(".vp9"),
 			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
 		)?;
 		let producer = moq_mux::container::Producer::new(track, moq_mux::catalog::hang::Container::Legacy);
+		let catalog = reserved.producer();
 		Ok(Self {
 			catalog,
+			reserved: Some(reserved),
 			track: producer,
 			announced: false,
 		})
@@ -33,11 +36,14 @@ impl Bridge {
 		}
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VP9::default());
 		config.container = hang::catalog::Container::Legacy;
-		self.catalog
-			.lock()
-			.video
-			.renditions
-			.insert(self.track.track().name().to_string(), config);
+		{
+			self.catalog
+				.lock()
+				.video
+				.renditions
+				.insert(self.track.track().name().to_string(), config);
+		}
+		self.reserved = None;
 		self.announced = true;
 	}
 }

--- a/rs/moq-rtc/src/ingest.rs
+++ b/rs/moq-rtc/src/ingest.rs
@@ -11,17 +11,36 @@ use crate::{Error, Result, codec, session};
 pub struct IngestSink {
 	broadcast: moq_net::broadcast::Producer,
 	catalog: moq_mux::catalog::Producer,
+	reserved: Option<moq_mux::catalog::Reserved>,
+	pending_bridges: usize,
 	bridges: session::Bridges,
 }
 
 impl IngestSink {
-	pub fn new(mut broadcast: moq_net::broadcast::Producer) -> Result<Self> {
+	pub fn new(mut broadcast: moq_net::broadcast::Producer, expected_bridges: usize) -> Result<Self> {
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
+		let reserved = (expected_bridges > 0).then(|| catalog.reserve());
 		Ok(Self {
 			broadcast,
 			catalog,
+			reserved,
+			pending_bridges: expected_bridges,
 			bridges: session::Bridges::new(),
 		})
+	}
+
+	fn reserve(&self) -> moq_mux::catalog::Reserved {
+		self.reserved
+			.as_ref()
+			.cloned()
+			.unwrap_or_else(|| self.catalog.reserve())
+	}
+
+	fn finish_bridge(&mut self) {
+		self.pending_bridges = self.pending_bridges.saturating_sub(1);
+		if self.pending_bridges == 0 {
+			self.reserved = None;
+		}
 	}
 }
 
@@ -38,27 +57,80 @@ impl session::MediaSink for IngestSink {
 				let (sample_rate, channels) = audio_params.unwrap_or((48_000, 2));
 				Box::new(codec::opus::Bridge::new(
 					self.broadcast.clone(),
-					self.catalog.clone(),
+					self.reserve(),
 					sample_rate,
 					channels,
 				)?)
 			}
-			str0m::format::Codec::H264 => {
-				Box::new(codec::h264::Bridge::new(self.broadcast.clone(), self.catalog.clone())?)
-			}
-			str0m::format::Codec::Vp8 => {
-				Box::new(codec::vp8::Bridge::new(self.broadcast.clone(), self.catalog.clone())?)
-			}
-			str0m::format::Codec::Vp9 => {
-				Box::new(codec::vp9::Bridge::new(self.broadcast.clone(), self.catalog.clone())?)
-			}
+			str0m::format::Codec::H264 => Box::new(codec::h264::Bridge::new(self.broadcast.clone(), self.reserve())?),
+			str0m::format::Codec::Vp8 => Box::new(codec::vp8::Bridge::new(self.broadcast.clone(), self.reserve())?),
+			str0m::format::Codec::Vp9 => Box::new(codec::vp9::Bridge::new(self.broadcast.clone(), self.reserve())?),
 			other => return Err(Error::UnsupportedCodec(format!("{other:?}"))),
 		};
 		self.bridges.insert(mid, bridge);
+		self.finish_bridge();
 		Ok(())
 	}
 
 	fn on_frame(&mut self, mid: str0m::media::Mid, frame: codec::Frame) -> Result<()> {
 		self.bridges.push(mid, frame)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::task::Poll;
+
+	use crate::session::MediaSink;
+
+	use super::*;
+
+	#[test]
+	fn shared_reservation_waits_for_all_bridges_and_lazy_video_config() {
+		let broadcast = moq_net::broadcast::Info::new().produce();
+		let mut sink = IngestSink::new(broadcast, 2).unwrap();
+		let mut consumer = sink.catalog.consume().unwrap();
+		let waiter = kio::Waiter::noop();
+
+		sink.on_track(
+			str0m::media::Mid::from("audio"),
+			str0m::media::MediaKind::Audio,
+			str0m::format::Codec::Opus,
+			Some((48_000, 2)),
+		)
+		.unwrap();
+		assert!(
+			matches!(consumer.poll_next(&waiter), Poll::Pending),
+			"audio must wait for the negotiated video bridge"
+		);
+
+		sink.on_track(
+			str0m::media::Mid::from("video"),
+			str0m::media::MediaKind::Video,
+			str0m::format::Codec::Vp8,
+			None,
+		)
+		.unwrap();
+		assert!(
+			matches!(consumer.poll_next(&waiter), Poll::Pending),
+			"lazy VP8 config must still gate the first catalog"
+		);
+
+		sink.on_frame(
+			str0m::media::Mid::from("video"),
+			codec::Frame {
+				timestamp_us: 0,
+				payload: bytes::Bytes::from_static(&[0]),
+			},
+		)
+		.unwrap();
+
+		let snapshot = match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(catalog))) => catalog,
+			other => panic!("expected a complete catalog, got {other:?}"),
+		};
+		assert_eq!(snapshot.audio.renditions.len(), 1);
+		assert_eq!(snapshot.video.renditions.len(), 1);
+		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
 	}
 }

--- a/rs/moq-rtc/src/sdp.rs
+++ b/rs/moq-rtc/src/sdp.rs
@@ -37,6 +37,96 @@ pub fn render_answer(answer: &str0m::change::SdpAnswer) -> String {
 		.join("\r\n")
 }
 
+/// Count accepted audio/video m-lines where this endpoint receives RTP.
+pub fn count_local_recv(sdp: &str) -> usize {
+	count_media(sdp, Direction::receives)
+}
+
+/// Count accepted audio/video m-lines where the remote endpoint sends RTP.
+pub fn count_remote_send(sdp: &str) -> usize {
+	count_media(sdp, Direction::sends)
+}
+
+#[derive(Clone, Copy)]
+enum Direction {
+	SendOnly,
+	RecvOnly,
+	SendRecv,
+	Inactive,
+}
+
+impl Direction {
+	fn parse(line: &str) -> Option<Self> {
+		match line {
+			"a=sendonly" => Some(Self::SendOnly),
+			"a=recvonly" => Some(Self::RecvOnly),
+			"a=sendrecv" => Some(Self::SendRecv),
+			"a=inactive" => Some(Self::Inactive),
+			_ => None,
+		}
+	}
+
+	fn sends(self) -> bool {
+		matches!(self, Self::SendOnly | Self::SendRecv)
+	}
+
+	fn receives(self) -> bool {
+		matches!(self, Self::RecvOnly | Self::SendRecv)
+	}
+}
+
+struct Media {
+	audio_or_video: bool,
+	accepted: bool,
+	direction: Direction,
+}
+
+fn count_media(sdp: &str, matches_direction: fn(Direction) -> bool) -> usize {
+	let mut count = 0;
+	let mut session_direction = Direction::SendRecv;
+	let mut media = None;
+
+	for line in sdp.lines() {
+		let line = line.trim();
+		if line.starts_with("m=") {
+			finish_media(&mut count, media.take(), matches_direction);
+			media = Some(parse_media(line, session_direction));
+			continue;
+		}
+
+		let Some(direction) = Direction::parse(line) else {
+			continue;
+		};
+		match &mut media {
+			Some(media) => media.direction = direction,
+			None => session_direction = direction,
+		}
+	}
+
+	finish_media(&mut count, media, matches_direction);
+	count
+}
+
+fn parse_media(line: &str, direction: Direction) -> Media {
+	let mut parts = line.split_whitespace();
+	let kind = parts.next().unwrap_or_default().trim_start_matches("m=");
+	let port = parts.next().unwrap_or_default();
+	Media {
+		audio_or_video: matches!(kind, "audio" | "video"),
+		accepted: !port.is_empty() && port != "0",
+		direction,
+	}
+}
+
+fn finish_media(count: &mut usize, media: Option<Media>, matches_direction: fn(Direction) -> bool) {
+	let Some(media) = media else {
+		return;
+	};
+	if media.audio_or_video && media.accepted && matches_direction(media.direction) {
+		*count += 1;
+	}
+}
+
 /// Give an `m=` line a placeholder format payload when it has none (see
 /// [`render_answer`]); every other line passes through untouched.
 fn ensure_media_format(line: &str) -> Cow<'_, str> {
@@ -69,7 +159,7 @@ pub fn parse_resource_id(path: &str) -> Result<uuid::Uuid> {
 
 #[cfg(test)]
 mod tests {
-	use super::ensure_media_format;
+	use super::{count_local_recv, count_remote_send, ensure_media_format};
 
 	#[test]
 	fn rejected_mline_with_no_format_gets_placeholder() {
@@ -90,5 +180,23 @@ mod tests {
 		assert_eq!(ensure_media_format(video), video);
 		let attr = "a=ice-ufrag:abcd";
 		assert_eq!(ensure_media_format(attr), attr);
+	}
+
+	#[test]
+	fn counts_only_accepted_receiving_media() {
+		let sdp = concat!(
+			"v=0\r\n",
+			"a=sendrecv\r\n",
+			"m=audio 9 UDP/TLS/RTP/SAVPF 111\r\n",
+			"a=recvonly\r\n",
+			"m=video 0 UDP/TLS/RTP/SAVPF 96\r\n",
+			"a=recvonly\r\n",
+			"m=application 9 UDP/DTLS/SCTP webrtc-datachannel\r\n",
+			"a=sendrecv\r\n",
+			"m=video 9 UDP/TLS/RTP/SAVPF 97\r\n",
+			"a=sendonly\r\n",
+		);
+		assert_eq!(count_local_recv(sdp), 1);
+		assert_eq!(count_remote_send(sdp), 1);
 	}
 }

--- a/rs/moq-rtc/src/server/whip.rs
+++ b/rs/moq-rtc/src/server/whip.rs
@@ -104,8 +104,6 @@ pub async fn accept(
 		.publish_broadcast(broadcast, &consumer)
 		.map_err(|err| Error::Other(anyhow::anyhow!("failed to publish broadcast: {err}")))?;
 
-	let sink = Box::new(IngestSink::new(producer)?);
-
 	// Register a session on the shared media mux: known ICE credentials (so the
 	// demux routes this peer's STUN by ufrag), an inbox to read datagrams from,
 	// and a guard the session task holds for its lifetime (unregisters on exit).
@@ -120,6 +118,8 @@ pub async fn accept(
 	}
 
 	let answer = rtc.sdp_api().accept_offer(offer).map_err(Error::Rtc)?;
+	let answer = sdp::render_answer(&answer);
+	let sink = Box::new(IngestSink::new(producer, sdp::count_local_recv(&answer))?);
 	let resource_id = sdp::new_resource_id();
 	let session = session::Session::ingest(rtc, mux.socket(), mux.candidates().to_vec(), inbound, sink);
 
@@ -129,7 +129,7 @@ pub async fn accept(
 
 	Ok(Response {
 		resource_id: resource_id.clone(),
-		answer: sdp::render_answer(&answer),
+		answer,
 		session: crate::server::AcceptedSession {
 			server: server.clone(),
 			resource_id,


### PR DESCRIPTION
## Summary

- Share one `moq_mux::catalog::Reserved` gate across a WebRTC ingest session codec bridges.
- Count accepted ingest m-lines from SDP answers so rejected or inactive media does not hold the catalog gate.
- Update Opus, H.264, VP8, and VP9 bridge constructors to take a reservation, with VP8/VP9 holding it until their lazy first-frame catalog entry resolves.
- Add a regression test that prevents an audio-only first catalog snapshot when negotiated video has not resolved yet.

## Root Cause

`IngestSink::on_track` built each codec bridge from an independent catalog reservation, so a WHIP/WHEP ingest session could publish the first catalog snapshot as soon as one bridge resolved. A downstream one-shot muxer could therefore see an incomplete first catalog.

## Public API Changes

None. The changed bridge constructors are in crate-private `moq-rtc` modules.

## Cross-Package Sync

`rs/moq-rtc` only. Wire format, `moq-net`, `hang`, JS packages, and docs are unchanged.

## Validation

- `cargo fmt`
- `cargo test -p moq-rtc`
- `git diff --check`

Fixes #2076.

(Written by GPT-5)