### PR TITLE
[codex] Mirror @moq/net role modules

### DIFF
--- a/js/clock/src/main.ts
+++ b/js/clock/src/main.ts
@@ -76,7 +76,7 @@ async function publish(config: Config) {
 	console.log("✅ Connected to relay:", config.url);
 
 	// Create a new "broadcast", which is a collection of tracks.
-	const broadcast = new Moq.Broadcast();
+	const broadcast = new Moq.broadcast.Producer();
 	connection.publish(Moq.Path.from(config.broadcast), broadcast);
 
 	console.log("✅ Published broadcast:", config.broadcast);
@@ -96,7 +96,7 @@ async function publish(config: Config) {
 	}
 }
 
-async function publishTrack(track: Moq.TrackProducer) {
+async function publishTrack(track: Moq.track.Producer) {
 	// Send timestamps over the wire, matching the Rust implementation format
 	console.log("✅ Publishing clock data on track:", track.name);
 

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { Group, Time, TrackProducer, Varint } from "@moq/net";
+import { group as NetGroup, track as NetTrack, Time, Varint } from "@moq/net";
 import type { InitSegment } from "./cmaf/decode.ts";
 import { encodeDataSegment } from "./cmaf/encode.ts";
 import { Format as CmafFormat } from "./cmaf/format.ts";
@@ -135,8 +135,8 @@ function encodeLegacy(timestamp: Time.Micro): Uint8Array {
 	return data;
 }
 
-function writeGroupWithLegacyFrames(track: TrackProducer, sequence: number, timestamps: Time.Micro[]) {
-	const group = new Group(sequence);
+function writeGroupWithLegacyFrames(track: NetTrack.Producer, sequence: number, timestamps: Time.Micro[]) {
+	const group = new NetGroup.Producer(sequence);
 	for (const ts of timestamps) {
 		group.writeFrame({ data: encodeLegacy(ts), timestamp: Time.Timestamp.now() });
 	}
@@ -163,7 +163,7 @@ async function drainFrames(
 }
 
 test("Consumer delivers frames from a single group", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro, 33_000 as Time.Micro]);
@@ -177,7 +177,7 @@ test("Consumer delivers frames from a single group", async () => {
 });
 
 test("Consumer forces keyframe true at index 0", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro, 33_000 as Time.Micro]);
@@ -201,10 +201,10 @@ test("Consumer index spans MoQ frames for keyframe detection", async () => {
 		},
 	};
 
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: multiFormat, latency: 500 as Time.Milli });
 
-	const group = new Group(0);
+	const group = new NetGroup.Producer(0);
 	group.writeFrame({ data: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() }); // first MoQ frame → 3 samples
 	group.writeFrame({ data: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() }); // second MoQ frame → 3 samples
 	group.close();
@@ -229,19 +229,19 @@ test("Consumer keeps frames decoded before an error (truncated GoP)", async () =
 		},
 	};
 
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: truncatingFormat, latency: 500 as Time.Milli });
 
-	// Group 0: 2 valid frames then a tail-truncating error.
-	const g0 = new Group(0);
+	// NetGroup.Producer 0: 2 valid frames then a tail-truncating error.
+	const g0 = new NetGroup.Producer(0);
 	g0.writeFrame({ data: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() });
 	g0.writeFrame({ data: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() });
 	g0.writeFrame({ data: new Uint8Array([0xff]), timestamp: Time.Timestamp.now() });
 	g0.close();
 	track.writeGroup(g0);
 
-	// Group 1 decodes cleanly.
-	const g1 = new Group(1);
+	// NetGroup.Producer 1 decodes cleanly.
+	const g1 = new NetGroup.Producer(1);
 	g1.writeFrame({ data: new Uint8Array([0x04]), timestamp: Time.Timestamp.now() });
 	g1.close();
 	track.writeGroup(g1);
@@ -256,7 +256,7 @@ test("Consumer keeps frames decoded before an error (truncated GoP)", async () =
 });
 
 test("Consumer close returns undefined from next()", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	const promise = consumer.next();
@@ -267,7 +267,7 @@ test("Consumer close returns undefined from next()", async () => {
 });
 
 test("Consumer throws on concurrent next() calls", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	// First call blocks waiting for data
@@ -279,7 +279,7 @@ test("Consumer throws on concurrent next() calls", async () => {
 });
 
 test("Consumer skips groups via PTS-span when over latency", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	// Zero latency = skip everything that's not the latest
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 0 as Time.Milli });
 
@@ -299,7 +299,7 @@ test("Consumer skips groups via PTS-span when over latency", async () => {
 // --- Ordering ---
 
 test("Consumer delivers groups in sequence order regardless of arrival order", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 2, [60_000 as Time.Micro]);
@@ -318,16 +318,16 @@ test("Consumer delivers groups in sequence order regardless of arrival order", a
 });
 
 test("Consumer rejects stale groups", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
-	// Group 5 arrives first (sets active = 5)
+	// NetGroup.Producer 5 arrives first (sets active = 5)
 	writeGroupWithLegacyFrames(track, 5, [0 as Time.Micro]);
 	await new Promise((resolve) => setTimeout(resolve, 50));
 
-	// Group 3 is stale
+	// NetGroup.Producer 3 is stale
 	writeGroupWithLegacyFrames(track, 3, [100_000 as Time.Micro]);
-	// Group 6 is valid
+	// NetGroup.Producer 6 is valid
 	writeGroupWithLegacyFrames(track, 6, [30_000 as Time.Micro]);
 	track.close();
 
@@ -340,10 +340,10 @@ test("Consumer rejects stale groups", async () => {
 	consumer.close();
 });
 
-// --- Group boundary signals ---
+// --- NetGroup.Producer boundary signals ---
 
 test("Consumer next() returns group-done signals", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro, 33_000 as Time.Micro]);
@@ -374,7 +374,7 @@ test("Consumer next() returns group-done signals", async () => {
 // --- Buffered signal ---
 
 test("Consumer buffered signal updates as frames arrive", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	expect(consumer.buffered.peek()).toEqual([]);
@@ -396,7 +396,7 @@ test("Consumer buffered signal updates as frames arrive", async () => {
 // --- Gap recovery ---
 
 test("Consumer recovers from gap in group sequence numbers", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 100 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro, 20_000 as Time.Micro]);
@@ -426,10 +426,10 @@ test("Consumer handles empty decode result without deadlock", async () => {
 		},
 	};
 
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: emptyThenValid, latency: 500 as Time.Milli });
 
-	const group = new Group(0);
+	const group = new NetGroup.Producer(0);
 	group.writeFrame({ data: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() }); // empty decode
 	group.writeFrame({ data: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() }); // valid decode
 	group.close();
@@ -449,13 +449,13 @@ test("Consumer handles empty decode result without deadlock", async () => {
 // --- CMAF through Consumer ---
 
 test("Consumer with CmafFormat delivers correct timestamps", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const consumer = new Consumer(track.subscribe(), {
 		format: new CmafFormat(TEST_INIT),
 		latency: 500 as Time.Milli,
 	});
 
-	const group = new Group(0);
+	const group = new NetGroup.Producer(0);
 	group.writeFrame({
 		data: encodeDataSegment({
 			data: new Uint8Array([0xca, 0xfe]),
@@ -521,16 +521,16 @@ const durationFormat: ContainerFormat = {
 };
 
 test("Consumer duration-skips a stalled group once it is covered", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	// Latency dwarfs the gap, so only duration coverage can trigger the skip.
 	const consumer = new Consumer(track.subscribe(), { format: durationFormat, latency: 10_000 as Time.Milli });
 
-	// Group 0: one frame at ts=0 lasting 33ms, never closed (stalled).
-	const g0 = new Group(0);
+	// NetGroup.Producer 0: one frame at ts=0 lasting 33ms, never closed (stalled).
+	const g0 = new NetGroup.Producer(0);
 	g0.writeFrame({ data: new Uint8Array([0]), timestamp: Time.Timestamp.now() });
 
-	// Group 1: closed, starts exactly where group 0's frame ends.
-	const g1 = new Group(1);
+	// NetGroup.Producer 1: closed, starts exactly where group 0's frame ends.
+	const g1 = new NetGroup.Producer(1);
 	g1.writeFrame({ data: new Uint8Array([33]), timestamp: Time.Timestamp.now() });
 	g1.close();
 
@@ -559,15 +559,15 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 		},
 	};
 
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: shortFormat, latency: 10_000 as Time.Milli });
 
-	// Group 0 stays open and later receives a second frame; nothing covers the gap,
+	// NetGroup.Producer 0 stays open and later receives a second frame; nothing covers the gap,
 	// so that late frame must survive rather than being skipped.
-	const g0 = new Group(0);
+	const g0 = new NetGroup.Producer(0);
 	g0.writeFrame({ data: new Uint8Array([0]), timestamp: Time.Timestamp.now() });
 
-	const g1 = new Group(1);
+	const g1 = new NetGroup.Producer(1);
 	g1.writeFrame({ data: new Uint8Array([33]), timestamp: Time.Timestamp.now() });
 	g1.close();
 

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -15,7 +15,7 @@ export interface ConsumerProps {
 }
 
 interface Group {
-	consumer: Moq.Group;
+	consumer: Moq.group.Consumer;
 	frames: Frame[]; // decode order
 	latest?: Time.Micro; // The timestamp of the latest known frame
 	end?: Time.Micro; // The furthest presentation point so far, i.e. max(timestamp + duration)
@@ -76,7 +76,7 @@ class Rewind {
 
 /** Reads frames from a MoQ track in order, buffering groups and skipping slow ones to meet the latency target. */
 export class Consumer {
-	#track: Moq.TrackSubscriber;
+	#track: Moq.track.Subscriber;
 	#format: Format;
 	#latency: Getter<Time.Milli>;
 	#groups: Group[] = [];
@@ -93,7 +93,7 @@ export class Consumer {
 	#signals = new Effect();
 
 	/** Start consuming the given track, decoding frames with `props.format`. */
-	constructor(track: Moq.TrackSubscriber, props: ConsumerProps) {
+	constructor(track: Moq.track.Subscriber, props: ConsumerProps) {
 		this.#track = track;
 		this.#format = props.format;
 		this.#latency = getter(props.latency ?? Moq.Time.Milli.zero);

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -40,11 +40,11 @@ export function encodeFrame(source: Uint8Array | Source, timestamp: Time.Micro):
 
 /** Writes legacy-container frames into a MoQ track, starting a new group on each keyframe. */
 export class Producer {
-	#track: Moq.TrackProducer;
-	#group?: Moq.Group;
+	#track: Moq.track.Producer;
+	#group?: Moq.group.Producer;
 
 	/** Wrap a track to publish legacy-container frames into it. */
-	constructor(track: Moq.TrackProducer) {
+	constructor(track: Moq.track.Producer) {
 		this.#track = track;
 	}
 

--- a/js/json/src/compression.test.ts
+++ b/js/json/src/compression.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { Decoder } from "@moq/flate";
-import { TrackProducer, type TrackSubscriber } from "@moq/net";
+import { track as NetTrack } from "@moq/net";
 import { Consumer } from "./consumer.ts";
 import { Producer } from "./producer.ts";
 
@@ -10,14 +10,14 @@ const enc = new TextEncoder();
 const dec = new TextDecoder();
 
 // Reconstruct every value a compressed consumer yields, in order.
-async function drainCompressed(track: TrackSubscriber): Promise<Value[]> {
+async function drainCompressed(track: NetTrack.Subscriber): Promise<Value[]> {
 	const out: Value[] = [];
 	for await (const value of new Consumer<Value>(track, { compression: true })) out.push(value);
 	return out;
 }
 
 // The raw (stored) bytes of a track's first frame, without reconstructing JSON.
-async function firstFrame(track: TrackSubscriber): Promise<Uint8Array> {
+async function firstFrame(track: NetTrack.Subscriber): Promise<Uint8Array> {
 	const group = await track.nextGroup();
 	if (!group) throw new Error("expected a group");
 	const frame = await group.readFrame();
@@ -26,7 +26,7 @@ async function firstFrame(track: TrackSubscriber): Promise<Uint8Array> {
 }
 
 // Count the groups a (finished) track published, draining each so the reads terminate.
-async function groupCount(track: TrackSubscriber): Promise<number> {
+async function groupCount(track: NetTrack.Subscriber): Promise<number> {
 	let groups = 0;
 	for (;;) {
 		const group = await track.nextGroup();
@@ -37,7 +37,7 @@ async function groupCount(track: TrackSubscriber): Promise<number> {
 }
 
 test("compressed snapshot per group round-trips", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 0, compression: true });
 	producer.update({ a: 1 });
 	producer.update({ a: 2 });
@@ -49,7 +49,7 @@ test("compressed snapshot per group round-trips", async () => {
 
 test("compressed live consumer sees each update in order", async () => {
 	// A live consumer reconstructs each update in order from the shared per-group stream.
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100, compression: true });
 	const consumer = new Consumer<Value>(track.subscribe(), { compression: true });
 
@@ -60,7 +60,7 @@ test("compressed live consumer sees each update in order", async () => {
 });
 
 test("compressed deltas share one group and reconstruct", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100, compression: true });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
@@ -71,7 +71,7 @@ test("compressed deltas share one group and reconstruct", async () => {
 });
 
 test("compressed late joiner reconstructs from snapshot + deltas", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100, compression: true });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
@@ -85,7 +85,7 @@ test("compressed late joiner reconstructs from snapshot + deltas", async () => {
 test("a group's snapshot decodes from a fresh decoder", async () => {
 	// Frame 0 opens a cold window, so a brand-new decoder reconstructs it, which is what lets a late
 	// joiner (or the Rust consumer) start mid-stream at any group boundary.
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 0, compression: true });
 	producer.update({ hello: "world" });
 	producer.finish();
@@ -96,7 +96,7 @@ test("a group's snapshot decodes from a fresh decoder", async () => {
 
 test("compressed deltas reuse the window", async () => {
 	// The shared per-group window is the point: a delta restating snapshot content shrinks sharply.
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100, compression: true });
 	const phrase = "Media over QUIC delivers real-time latency at massive scale";
 	producer.update({ note: phrase });
@@ -116,9 +116,9 @@ test("compressed deltas reuse the window", async () => {
 test("compression shrinks a repetitive frame", async () => {
 	const value = { renditions: Array(3).fill("video".repeat(50)) };
 
-	const plain = new TrackProducer("plain");
+	const plain = new NetTrack.Producer("plain");
 	new Producer<Value>(plain, { deltaRatio: 0 }).update(value);
-	const compressed = new TrackProducer("compressed");
+	const compressed = new NetTrack.Producer("compressed");
 	new Producer<Value>(compressed, { deltaRatio: 0, compression: true }).update(value);
 
 	const plainLen = (await firstFrame(plain.subscribe())).length;
@@ -132,18 +132,18 @@ test("compressed deltas roll on the compressed budget", async () => {
 	// roll more than one group, and a late joiner must still rebuild the final value across the
 	// compressed group boundary. Guards against the budget regressing to raw lengths. Two identical
 	// producers (deterministic output) keep the group-count and reconstruction reads independent.
-	const fill = (track: TrackProducer) => {
+	const fill = (track: NetTrack.Producer) => {
 		const producer = new Producer<Value>(track, { deltaRatio: 2, compression: true });
 		for (let n = 0; n <= 40; n++) producer.update({ n });
 		producer.finish();
 	};
 
-	const layout = new TrackProducer("layout");
+	const layout = new NetTrack.Producer("layout");
 	const layoutSub = layout.subscribe();
 	fill(layout);
 	expect(await groupCount(layoutSub)).toBeGreaterThan(1);
 
-	const reconstruct = new TrackProducer("reconstruct");
+	const reconstruct = new NetTrack.Producer("reconstruct");
 	const reconstructSub = reconstruct.subscribe();
 	fill(reconstruct);
 	expect((await drainCompressed(reconstructSub)).at(-1)).toEqual({ n: 40 });

--- a/js/json/src/consumer.ts
+++ b/js/json/src/consumer.ts
@@ -12,18 +12,18 @@ import type { Config } from "./producer.ts";
  * collapses the buffered backlog and yields only the latest value. See {@link next}.
  */
 export class Consumer<T> {
-	#track: Moq.TrackSubscriber;
+	#track: Moq.track.Subscriber;
 	#schema?: z.ZodMiniType<T>;
 	// Whether frames are `deflate-raw` compressed. Must match the producer's {@link Config.compression}.
 	#decompress: boolean;
 
-	#group?: Moq.Group;
+	#group?: Moq.group.Consumer;
 	// Per-group DEFLATE decoder, built lazily on the first frame of a group and reset at each boundary.
 	#decoder?: Decoder;
 	#current?: unknown;
 	#framesRead = 0;
 
-	constructor(track: Moq.TrackSubscriber, config: Config<T> = {}) {
+	constructor(track: Moq.track.Subscriber, config: Config<T> = {}) {
 		this.#track = track;
 		this.#schema = config.schema;
 		this.#decompress = config.compression ?? false;
@@ -61,7 +61,7 @@ export class Consumer<T> {
 			if (advanced) return value;
 
 			// Nothing buffered: block for the next frame (or the group's end).
-			let frame: Moq.Frame | undefined;
+			let frame: Moq.group.Frame | undefined;
 			try {
 				frame = await this.#group.readFrame();
 			} catch {

--- a/js/json/src/json.test.ts
+++ b/js/json/src/json.test.ts
@@ -1,12 +1,12 @@
 import { expect, test } from "bun:test";
-import { TrackProducer, type TrackSubscriber } from "@moq/net";
+import { track as NetTrack } from "@moq/net";
 import { Consumer } from "./consumer.ts";
 import { Producer } from "./producer.ts";
 
 type Value = Record<string, unknown>;
 
 // Reconstruct every value a consumer yields, in order.
-async function drain(track: TrackSubscriber): Promise<Value[]> {
+async function drain(track: NetTrack.Subscriber): Promise<Value[]> {
 	const out: Value[] = [];
 	for await (const value of new Consumer<Value>(track)) out.push(value);
 	return out;
@@ -14,7 +14,7 @@ async function drain(track: TrackSubscriber): Promise<Value[]> {
 
 // Inspect the published layout via the public API: the frame count of each group, in order.
 // The track must be finished first so group/frame reads terminate.
-async function structure(track: TrackSubscriber): Promise<number[]> {
+async function structure(track: NetTrack.Subscriber): Promise<number[]> {
 	const counts: number[] = [];
 	for (;;) {
 		const group = await track.nextGroup();
@@ -28,7 +28,7 @@ async function structure(track: TrackSubscriber): Promise<number[]> {
 }
 
 test("deltas off: a snapshot group per change", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 0 });
 	producer.update({ a: 1 });
 	producer.update({ a: 2 });
@@ -39,7 +39,7 @@ test("deltas off: a snapshot group per change", async () => {
 });
 
 test("deltaRatio 0 disables deltas, like off", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 0 });
 	producer.update({ a: 1 });
 	producer.update({ a: 2 });
@@ -51,7 +51,7 @@ test("deltaRatio 0 disables deltas, like off", async () => {
 });
 
 test("live consumer sees each update", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track);
 	const consumer = new Consumer<Value>(track.subscribe());
 
@@ -62,7 +62,7 @@ test("live consumer sees each update", async () => {
 });
 
 test("unchanged value writes nothing", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track);
 	producer.update({ a: 1 });
 	producer.update({ a: 1 });
@@ -72,7 +72,7 @@ test("unchanged value writes nothing", async () => {
 });
 
 test("deltas share one group", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100 });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
@@ -84,7 +84,7 @@ test("deltas share one group", async () => {
 });
 
 test("deltas reconstruct to the final value", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100 });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
@@ -98,7 +98,7 @@ test("deltas reconstruct to the final value", async () => {
 // keys, and each call publishes. This is how the catalog producer is extended (e.g. an scte35
 // section) without a single owner having to rebuild the whole document.
 test("mutate composes independent owners", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { initial: {} });
 	const consumer = new Consumer<Value>(track.subscribe());
 
@@ -115,7 +115,7 @@ test("mutate composes independent owners", async () => {
 });
 
 test("mutate starts from the configured initial value", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { initial: {} });
 	const consumer = new Consumer<Value>(track.subscribe());
 
@@ -126,14 +126,14 @@ test("mutate starts from the configured initial value", async () => {
 });
 
 test("mutate without a prior value or initial throws", () => {
-	const producer = new Producer<Value>(new TrackProducer("test"));
+	const producer = new Producer<Value>(new NetTrack.Producer("test"));
 	expect(() => producer.mutate(() => {})).toThrow();
 });
 
 // Removing a section drops it from the reconstructed value, so a consumer detects the removal.
 // Exercised with deltas on to cover the merge-patch null-deletion path.
 test("mutate removes a section", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100, initial: {} });
 	const consumer = new Consumer<Value>(track.subscribe());
 
@@ -150,7 +150,7 @@ test("mutate removes a section", async () => {
 });
 
 test("tight ratio rolls snapshots", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	// A ratio of 1 budgets deltas up to one snapshot (equal 7-byte frames => 7 bytes). The gate checks
 	// the deltas already written, so the delta that tips the group over budget still lands (a one-frame
 	// overshoot): group 0 takes two deltas (14 bytes) before the fourth update rolls group 1.
@@ -165,7 +165,7 @@ test("tight ratio rolls snapshots", async () => {
 });
 
 test("deltas stay within ratio times snapshot", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	// The budget covers only the deltas, not the snapshot frame, measured against the group's snapshot
 	// size. Single-digit values keep every frame at a constant 7 bytes (`{"n":N}`), so a ratio of 8
 	// budgets 56 bytes of deltas. The gate checks the deltas already written, so the group keeps filling
@@ -179,7 +179,7 @@ test("deltas stay within ratio times snapshot", async () => {
 });
 
 test("array change is a wholesale delta", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100 });
 	producer.update({ list: [1, 2] });
 	producer.update({ list: [1, 2, 3] });
@@ -190,7 +190,7 @@ test("array change is a wholesale delta", async () => {
 });
 
 test("late joiner collapses a buffered backlog to the latest value", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100 });
 	const subscriber = track.subscribe();
 	for (let n = 0; n <= 20; n++) {
@@ -204,7 +204,7 @@ test("late joiner collapses a buffered backlog to the latest value", async () =>
 });
 
 test("frame cap rolls snapshot", async () => {
-	const track = new TrackProducer("test");
+	const track = new NetTrack.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 1_000_000 });
 	// First update is the snapshot; deltas fill the group until the frame cap forces a roll.
 	for (let i = 0; i <= 256; i++) {

--- a/js/json/src/producer.ts
+++ b/js/json/src/producer.ts
@@ -44,10 +44,10 @@ export interface Config<T> {
 
 /** Publishes a JSON value over a track, choosing snapshots and deltas automatically. */
 export class Producer<T> {
-	#track: Moq.TrackProducer;
+	#track: Moq.track.Producer;
 	#config: Config<T>;
 
-	#group?: Moq.Group;
+	#group?: Moq.group.Producer;
 	#last?: unknown;
 	// Bytes of deltas already written to the current group, excluding the snapshot frame. Compressed
 	// frame sizes when compressing, raw otherwise, matching {@link #snapshotLen} so the budget check is
@@ -63,7 +63,7 @@ export class Producer<T> {
 	#compress = false;
 	#encoder?: Encoder;
 
-	constructor(track: Moq.TrackProducer, config: Config<T> = {}) {
+	constructor(track: Moq.track.Producer, config: Config<T> = {}) {
 		this.#track = track;
 		this.#config = config;
 		this.#compress = config.compression ?? false;
@@ -174,7 +174,7 @@ export class Producer<T> {
 
 	// Write a group's snapshot (frame 0), returning the bytes written. On the compressed path this opens
 	// a fresh per-group encoder (cold window), so the snapshot and its deltas share one DEFLATE stream.
-	#writeSnapshot(group: Moq.Group, frame: Uint8Array): number {
+	#writeSnapshot(group: Moq.group.Producer, frame: Uint8Array): number {
 		let data = frame;
 		if (this.#compress) {
 			this.#encoder = new Encoder();
@@ -186,7 +186,7 @@ export class Producer<T> {
 
 	// Write a delta frame, compressed against the current group's encoder when compressing. Returns the
 	// bytes written.
-	#writeDelta(group: Moq.Group, frame: Uint8Array): number {
+	#writeDelta(group: Moq.group.Producer, frame: Uint8Array): number {
 		let data = frame;
 		if (this.#compress) {
 			if (!this.#encoder) throw new Error("compressed delta requires an open group");

--- a/js/loc/src/index.ts
+++ b/js/loc/src/index.ts
@@ -101,10 +101,10 @@ export interface Source {
  * bitstream payload.
  */
 export class Producer {
-	#track: Moq.TrackProducer;
-	#group?: Moq.Group;
+	#track: Moq.track.Producer;
+	#group?: Moq.group.Producer;
 
-	constructor(track: Moq.TrackProducer) {
+	constructor(track: Moq.track.Producer) {
 		this.#track = track;
 	}
 

--- a/js/moq-boy/src/game.ts
+++ b/js/moq-boy/src/game.ts
@@ -55,7 +55,7 @@ export const KEY_MAP: Record<string, string> = {
 };
 
 /**
- * A Game Boy streaming session — the non-UI backend.
+ * A Game Boy streaming session for the non-UI backend.
  *
  * Manages video/audio playback, input commands, and status tracking
  * for a single game session. The UI layer (SolidJS components) reads
@@ -85,7 +85,7 @@ export class Game {
 	// The video rendition target, owned here and wired into the video source as an input.
 	readonly #target = new Moq.Signals.Signal<Watch.Video.Target | undefined>(undefined);
 
-	// Watch API objects — exposed so UI can access canvas, etc.
+	// Watch API objects exposed so UI can access canvas, etc.
 	readonly broadcast: Watch.Broadcast;
 	readonly sync: Watch.Sync;
 	readonly videoSource: Watch.Video.Source;
@@ -149,7 +149,7 @@ export class Game {
 		this.videoDecoder = new Watch.Video.Decoder(this.videoSource, this.sync, { enabled: videoEnabled });
 		this.#signals.cleanup(() => this.videoDecoder.close());
 
-		// Renderer needs a canvas — created by the UI layer, set via `canvas`.
+		// Renderer needs a canvas created by the UI layer, set via `canvas`.
 		this.videoRenderer = new Watch.Video.Renderer(this.videoDecoder, { canvas: this.canvas });
 		this.#signals.cleanup(() => this.videoRenderer.close());
 
@@ -157,7 +157,7 @@ export class Game {
 		// Reads the renderer's visibility, so it must run after the renderer exists.
 		this.#signals.run(this.#runVideoEnabled.bind(this, videoEnabled));
 
-		// Audio pipeline — the emitter stops the download when muted or paused.
+		// Audio pipeline. The emitter stops the download when muted or paused.
 		this.audioDecoder = new Watch.Audio.Decoder(this.audioSource, this.sync);
 		this.#signals.cleanup(() => this.audioDecoder.close());
 
@@ -291,7 +291,7 @@ export class Game {
 		const viewerId = Math.random().toString(36).slice(2, 8);
 		this.viewerId.set(viewerId);
 
-		const viewerBroadcast = new Moq.Broadcast();
+		const viewerBroadcast = new Moq.broadcast.Producer();
 		conn.publish(Moq.Path.from(`${this.#viewerPrefix}/${this.sessionId}/${viewerId}`), viewerBroadcast);
 		effect.cleanup(() => {
 			viewerBroadcast.close();
@@ -315,7 +315,7 @@ export class Game {
 	}
 
 	#runCommandTrack(
-		track: Moq.TrackProducer,
+		track: Moq.track.Producer,
 		producer: Json.Producer<Record<string, unknown>>,
 		effect: Moq.Signals.Effect,
 	) {

--- a/js/msf/src/catalog.ts
+++ b/js/msf/src/catalog.ts
@@ -147,7 +147,7 @@ export function decode(raw: Uint8Array): Catalog {
 }
 
 /** Read and decode the next catalog frame from a track, or undefined if the track ended. */
-export async function fetch(track: Moq.TrackSubscriber): Promise<Catalog | undefined> {
+export async function fetch(track: Moq.track.Subscriber): Promise<Catalog | undefined> {
 	const frame = await track.readFrame();
 	if (!frame) return undefined;
 	return decode(frame);

--- a/js/net/examples/publish.ts
+++ b/js/net/examples/publish.ts
@@ -5,7 +5,7 @@ async function main() {
 	const connection = await Moq.Connection.connect(url);
 
 	// Create a broadcast (a collection of tracks)
-	const broadcast = new Moq.Broadcast();
+	const broadcast = new Moq.broadcast.Producer();
 
 	// Insert the "chat" track up front. A subscriber is served directly from this
 	// track, no requested() round-trip needed. Mirrors the Rust createTrack/insertTrack.
@@ -26,7 +26,7 @@ async function main() {
 	}
 }
 
-async function publishTrack(track: Moq.TrackProducer) {
+async function publishTrack(track: Moq.track.Producer) {
 	console.log("Publishing to track:", track.name);
 
 	// Create a group (e.g., keyframe boundary)

--- a/js/net/src/announced.ts
+++ b/js/net/src/announced.ts
@@ -6,69 +6,93 @@ import * as Path from "./path.js";
  *
  * @public
  */
-export interface AnnouncedEntry {
+export interface Event {
+	/** Broadcast path. */
 	path: Path.Valid;
+	/** True when the broadcast is available. */
 	active: boolean;
 }
 
-/** Reactive backing state for an {@link Announced}: the pending queue plus a closed flag. */
-class AnnouncedState {
-	queue = new Signal<AnnouncedEntry[]>([]);
+/** Reactive backing state shared by announcement producers and consumers. */
+class AnnounceState {
+	queue = new Signal<Event[]>([]);
 	closed = new Signal<boolean | Error>(false);
 }
 
+function closedPromise(state: AnnounceState): Promise<Error | undefined> {
+	return new Promise((resolve) => {
+		const dispose = state.closed.subscribe((closed) => {
+			if (!closed) return;
+			resolve(closed instanceof Error ? closed : undefined);
+			dispose();
+		});
+	});
+}
+
 /**
- * Handles writing announcements to the announcement queue.
+ * The write side of an announcement stream.
  *
  * @public
  */
-export class Announced {
-	/** Reactive backing state. */
-	#state = new AnnouncedState();
-
+export class Producer {
 	/** Path prefix this stream is scoped to. */
 	prefix: Path.Valid;
+
+	#state = new AnnounceState();
 
 	/** Resolves with the abort error (or undefined) once closed. */
 	readonly closed: Promise<Error | undefined>;
 
 	constructor(prefix = Path.empty()) {
 		this.prefix = prefix;
-		this.closed = new Promise((resolve) => {
-			const dispose = this.#state.closed.subscribe((closed) => {
-				if (!closed) return;
-				resolve(closed instanceof Error ? closed : undefined);
-				dispose();
-			});
-		});
+		this.closed = closedPromise(this.#state);
 	}
 
-	/**
-	 * Writes an announcement to the queue.
-	 * @param announcement - The announcement to write
-	 */
-	append(announcement: AnnouncedEntry) {
-		if (this.#state.closed.peek()) throw new Error("announced is closed");
+	/** A read handle for this announcement stream. */
+	consume(): Consumer {
+		return new Consumer(this.prefix, this.#state as never);
+	}
+
+	/** Writes an announcement to the queue. */
+	append(event: Event) {
+		if (this.#state.closed.peek()) throw new Error("announcements are closed");
 		this.#state.queue.mutate((queue) => {
-			queue.push(announcement);
+			queue.push(event);
 		});
 	}
 
-	/**
-	 * Closes the writer.
-	 * @param abort - If provided, throw this exception instead of returning undefined.
-	 */
+	/** Closes the writer. */
 	close(abort?: Error) {
 		this.#state.closed.set(abort ?? true);
 		this.#state.queue.mutate((queue) => {
 			queue.length = 0;
 		});
 	}
+}
 
-	/**
-	 * Returns the next announcement.
-	 */
-	async next(): Promise<AnnouncedEntry | undefined> {
+/**
+ * The read side of an announcement stream.
+ *
+ * @public
+ */
+export class Consumer {
+	/** Path prefix this stream is scoped to. */
+	prefix: Path.Valid;
+
+	#state: AnnounceState;
+
+	/** Resolves with the abort error (or undefined) once closed. */
+	readonly closed: Promise<Error | undefined>;
+
+	constructor(prefix?: Path.Valid, state?: never);
+	constructor(prefix = Path.empty(), state?: AnnounceState) {
+		this.prefix = prefix;
+		this.#state = state ?? new AnnounceState();
+		this.closed = closedPromise(this.#state);
+	}
+
+	/** Returns the next announcement. */
+	async next(): Promise<Event | undefined> {
 		for (;;) {
 			const announce = this.#state.queue.peek().shift();
 			if (announce) return announce;
@@ -79,5 +103,13 @@ export class Announced {
 
 			await Signal.race(this.#state.queue, this.#state.closed);
 		}
+	}
+
+	/** Closes the reader. */
+	close(abort?: Error) {
+		this.#state.closed.set(abort ?? true);
+		this.#state.queue.mutate((queue) => {
+			queue.length = 0;
+		});
 	}
 }

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -1,19 +1,20 @@
 import { expect, setSystemTime, test } from "bun:test";
-import { Broadcast, type TrackRequest } from "./broadcast.ts";
+import { Producer as BroadcastProducer } from "./broadcast.ts";
 import { CacheFull, MAX_GROUP_FRAMES } from "./group.ts";
 import { Timestamp } from "./time.ts";
-import { TrackProducer } from "./track.ts";
+import type { Request as TrackRequest } from "./track.ts";
+import { Producer as TrackProducer } from "./track.ts";
 
 // Observe whether an on-demand track request is pending without blocking: returns the
 // next request if one has already been emitted, or undefined if none is (yet) waiting.
-async function pendingRequest(broadcast: Broadcast): Promise<TrackRequest | undefined> {
+async function pendingRequest(broadcast: BroadcastProducer): Promise<TrackRequest | undefined> {
 	const none = Symbol("none");
 	const result = await Promise.race([broadcast.requested(), Promise.resolve(none)]);
 	return result === none ? undefined : (result as TrackRequest | undefined);
 }
 
 test("subscribe serves a statically inserted track without a request", async () => {
-	const broadcast = new Broadcast();
+	const broadcast = new BroadcastProducer();
 
 	const track1 = new TrackProducer("track1").accept();
 	broadcast.insertTrack(track1);
@@ -36,7 +37,7 @@ test("subscribe serves a statically inserted track without a request", async () 
 });
 
 test("two subscribers to one inserted track each get a full copy", async () => {
-	const broadcast = new Broadcast();
+	const broadcast = new BroadcastProducer();
 	const producer = broadcast.createTrack("video");
 
 	const a = broadcast.track("video").subscribe();
@@ -53,7 +54,7 @@ test("two subscribers to one inserted track each get a full copy", async () => {
 });
 
 test("a late subscriber replays the cached window", async () => {
-	const broadcast = new Broadcast();
+	const broadcast = new BroadcastProducer();
 	const producer = broadcast.createTrack("video");
 
 	// Written before anyone subscribes; retained in the cache for replay.
@@ -67,7 +68,7 @@ test("a late subscriber replays the cached window", async () => {
 });
 
 test("a read throws CacheFull on a gap, then resyncs to the next group", async () => {
-	const broadcast = new Broadcast();
+	const broadcast = new BroadcastProducer();
 	const producer = broadcast.createTrack("video");
 	const sub = broadcast.track("video").subscribe();
 
@@ -92,7 +93,7 @@ test("a stalled consumer does not pin evicted groups", async () => {
 	try {
 		setSystemTime(new Date(10_000));
 
-		const broadcast = new Broadcast();
+		const broadcast = new BroadcastProducer();
 		const producer = broadcast.createTrack("video", { cache: 1000 });
 
 		// A subscriber that never reads. Its sink must not grow without bound.
@@ -120,7 +121,7 @@ test("a stalled consumer does not pin evicted groups", async () => {
 });
 
 test("createTrack commits info up front", async () => {
-	const broadcast = new Broadcast();
+	const broadcast = new BroadcastProducer();
 
 	const producer = broadcast.createTrack("video", { cache: 2000, priority: 3 });
 	expect(producer.name).toBe("video");
@@ -131,13 +132,13 @@ test("createTrack commits info up front", async () => {
 });
 
 test("insertTrack rejects a duplicate live name", () => {
-	const broadcast = new Broadcast();
+	const broadcast = new BroadcastProducer();
 	broadcast.createTrack("dup");
 	expect(() => broadcast.insertTrack(new TrackProducer("dup").accept())).toThrow();
 });
 
 test("a closed track is evicted and re-subscribing falls through to a request", async () => {
-	const broadcast = new Broadcast();
+	const broadcast = new BroadcastProducer();
 
 	const track1 = broadcast.createTrack("track1");
 	track1.close();
@@ -153,13 +154,13 @@ test("a closed track is evicted and re-subscribing falls through to a request", 
 
 test("removeTrack drops the static entry", async () => {
 	// While the static entry exists, subscribing takes the fast path: no on-demand request.
-	const kept = new Broadcast();
+	const kept = new BroadcastProducer();
 	kept.createTrack("track1");
 	kept.track("track1").subscribe();
 	expect(await pendingRequest(kept)).toBeUndefined();
 
 	// With the entry removed, subscribing falls through to an on-demand request.
-	const removed = new Broadcast();
+	const removed = new BroadcastProducer();
 	removed.createTrack("track1");
 	removed.removeTrack("track1");
 	removed.track("track1").subscribe();

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -1,5 +1,5 @@
 import { expect, setSystemTime, test } from "bun:test";
-import { Producer as BroadcastProducer } from "./broadcast.ts";
+import { Consumer as BroadcastConsumer, Producer as BroadcastProducer } from "./broadcast.ts";
 import { CacheFull, MAX_GROUP_FRAMES } from "./group.ts";
 import { Timestamp } from "./time.ts";
 import type { Request as TrackRequest } from "./track.ts";
@@ -165,4 +165,20 @@ test("removeTrack drops the static entry", async () => {
 	removed.removeTrack("track1");
 	removed.track("track1").subscribe();
 	expect((await pendingRequest(removed))?.name).toBe("track1");
+});
+
+test("close rejects a still-pending track request so its subscriber unblocks", async () => {
+	const broadcast = new BroadcastConsumer();
+
+	// Subscribing with no static entry queues an on-demand request; the subscriber
+	// blocks on info() until that request is answered.
+	const subscriber = broadcast.track("video").subscribe();
+	const info = subscriber.info();
+
+	// Closing must reject the still-queued request rather than silently dropping it,
+	// so the awaiting subscriber rejects instead of hanging on a producer that will
+	// never be served.
+	broadcast.close();
+
+	await expect(info).rejects.toThrow();
 });

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -1,118 +1,97 @@
 import { Signal } from "@moq/signals";
-import { type TrackInfo, TrackProducer, type TrackSubscriber } from "./track.ts";
+import * as track from "./track.ts";
 
-/**
- * A request for a track the peer wants, yielded by {@link Broadcast.requested}.
- *
- * The producer answers it with {@link accept}, declaring the track's immutable
- * publisher properties and receiving a {@link TrackProducer} to write groups into,
- * or {@link reject} to refuse it. The properties must be declared up front so the
- * wire layer can answer a TRACK request (lite-05+) and pick the frame codec before
- * any group is served. Mirrors the Rust `TrackRequest`.
- */
-export class TrackRequest {
-	readonly name: string;
-	readonly priority: number;
-	// The producer feeding the TrackSubscriber handed to the caller of Broadcast.subscribe.
-	#producer: TrackProducer;
-
-	constructor(name: string, producer: TrackProducer, priority: number) {
-		this.name = name;
-		this.#producer = producer;
-		this.priority = priority;
-	}
-
-	/**
-	 * Accept the request, committing the track's immutable {@link TrackInfo} and
-	 * returning a {@link TrackProducer} to write groups into. Any field left unset
-	 * keeps its default. Mirrors the Rust `TrackRequest::accept`.
-	 */
-	accept(info: Partial<TrackInfo> = {}): TrackProducer {
-		return this.#producer.accept(info);
-	}
-
-	/** Reject the request, closing the track (optionally with an error). */
-	reject(err?: Error): void {
-		this.#producer.close(err);
-	}
-}
-
-/**
- * A lazy handle to a track on a consumed broadcast, mirroring the Rust
- * `TrackConsumer`. Holding it sends nothing over the network; call {@link subscribe}
- * to open a live subscription or {@link info} to fetch the immutable publisher
- * properties (lite-05+).
- */
-export class TrackConsumer {
-	readonly name: string;
-	#broadcast: Broadcast;
-
-	constructor(broadcast: Broadcast, name: string) {
-		this.#broadcast = broadcast;
-		this.name = name;
-	}
-
-	/**
-	 * Open a live subscription, returning a {@link TrackSubscriber} streaming the
-	 * track's groups. `priority` defaults to `0`.
-	 */
-	subscribe(options?: { priority?: number }): TrackSubscriber {
-		return this.#broadcast.subscribe(this.name, options?.priority ?? 0);
-	}
-
-	/**
-	 * Fetch the track's immutable publisher properties without subscribing, via a
-	 * TRACK stream. Lite-05+ only; rejects on older drafts (which carry no TRACK
-	 * stream) and if the track does not exist.
-	 */
-	info(): Promise<TrackInfo> {
-		return this.#broadcast.resolveTrackInfo(this.name);
-	}
-}
-
-/** Reactive backing state for a {@link Broadcast}: requested tracks plus a closed flag. */
+/** Reactive backing state shared by broadcast producers and consumers. */
 class BroadcastState {
-	requested = new Signal<TrackRequest[]>([]);
+	requested = new Signal<track.Request[]>([]);
 	closed = new Signal<boolean | Error>(false);
-	// Statically inserted tracks, keyed by name. A subscribe for one of these fans out
-	// from the producer directly, skipping the on-demand request path.
-	tracks = new Map<string, TrackProducer>();
+	tracks = new Map<string, track.Producer>();
+	infoResolver?: (name: string) => Promise<track.Info>;
+}
+
+function closedPromise(state: BroadcastState): Promise<Error | undefined> {
+	return new Promise((resolve) => {
+		const dispose = state.closed.subscribe((closed) => {
+			if (!closed) return;
+			resolve(closed instanceof Error ? closed : undefined);
+			dispose();
+		});
+	});
+}
+
+function subscribe(state: BroadcastState, name: string, priority: number): track.Subscriber {
+	if (state.closed.peek()) {
+		throw new Error(`broadcast is closed: ${state.closed.peek()}`);
+	}
+
+	const existing = state.tracks.get(name);
+	if (existing) {
+		if (!existing.closedSignal.peek()) return existing.subscribe();
+		state.tracks.delete(name);
+	}
+
+	const producer = new track.Producer(name);
+	const subscriber = producer.subscribe();
+	state.requested.mutate((requested) => {
+		requested.push(new track.Request(name, producer, priority));
+		requested.sort((a, b) => a.priority - b.priority);
+	});
+
+	return subscriber;
+}
+
+async function resolveTrackInfo(state: BroadcastState, name: string): Promise<track.Info> {
+	if (state.infoResolver) {
+		return state.infoResolver(name);
+	}
+
+	const existing = state.tracks.get(name);
+	if (existing && !existing.closedSignal.peek()) {
+		return existing.info();
+	}
+
+	if (state.closed.peek()) {
+		return Promise.reject(new Error(`broadcast is closed: ${state.closed.peek()}`));
+	}
+
+	const producer = new track.Producer(name);
+	state.requested.mutate((requested) => {
+		requested.push(new track.Request(name, producer, 0));
+		requested.sort((a, b) => a.priority - b.priority);
+	});
+
+	try {
+		return await producer.info();
+	} finally {
+		producer.close();
+	}
 }
 
 /**
- * Handles writing and managing tracks in a broadcast.
+ * The write side of a broadcast.
  *
  * @public
  */
-export class Broadcast {
+export class Producer {
 	#state = new BroadcastState();
 
 	/** Resolves with the abort error (or undefined) once closed. */
 	readonly closed: Promise<Error | undefined>;
 
-	// Consume-side hook installed by the wire layer (Subscriber.consume) to resolve
-	// a track's immutable TRACK_INFO over a Track stream. Undefined on a published
-	// broadcast, where info comes from the producer's accept() instead.
-	#infoResolver?: (name: string) => Promise<TrackInfo>;
-
 	constructor() {
-		this.closed = new Promise((resolve) => {
-			const dispose = this.#state.closed.subscribe((closed) => {
-				if (!closed) return;
-				resolve(closed instanceof Error ? closed : undefined);
-				dispose();
-			});
-		});
+		this.closed = closedPromise(this.#state);
 	}
 
-	/**
-	 * A track requested over the network.
-	 */
-	async requested(): Promise<TrackRequest | undefined> {
+	/** A read handle for this broadcast. */
+	consume(): Consumer {
+		return new Consumer(this.#state as never);
+	}
+
+	/** Return the next track requested by a peer. */
+	async requested(): Promise<track.Request | undefined> {
 		for (;;) {
-			// We use pop instead of shift because it's slightly more efficient.
-			const track = this.#state.requested.peek().pop();
-			if (track) return track;
+			const request = this.#state.requested.peek().pop();
+			if (request) return request;
 
 			const closed = this.#state.closed.peek();
 			if (closed instanceof Error) throw closed;
@@ -122,31 +101,8 @@ export class Broadcast {
 		}
 	}
 
-	/**
-	 * Get a lazy {@link TrackConsumer} handle for a track on this broadcast.
-	 *
-	 * Sends nothing over the network until you call {@link TrackConsumer.subscribe}
-	 * or {@link TrackConsumer.info}. Mirrors the Rust `BroadcastConsumer::track`.
-	 */
-	track(name: string): TrackConsumer {
-		return new TrackConsumer(this, name);
-	}
-
-	/**
-	 * Insert a track that is served directly, without an on-demand {@link requested}
-	 * round-trip.
-	 *
-	 * Each {@link subscribe} for this name fans out from the producer, so a publisher
-	 * can push tracks proactively instead of waiting to be asked. The caller owns the
-	 * {@link TrackProducer} and writes its groups; when that producer closes, the entry
-	 * is removed automatically. Throws on a duplicate live name. Mirrors the Rust
-	 * `BroadcastProducer::insert_track`.
-	 *
-	 * The producer must commit its {@link TrackInfo} via `accept()` (or use
-	 * {@link createTrack}, which does it for you); otherwise a subscriber's
-	 * `info()` never resolves and the wire layer stalls before serving.
-	 */
-	insertTrack(track: TrackProducer): void {
+	/** Insert a track that is served directly, without an on-demand request round-trip. */
+	insertTrack(track: track.Producer): void {
 		if (this.#state.closed.peek()) {
 			throw new Error(`broadcast is closed: ${this.#state.closed.peek()}`);
 		}
@@ -158,7 +114,6 @@ export class Broadcast {
 
 		this.#state.tracks.set(track.name, track);
 
-		// Evict the entry once the track closes, unless it has since been replaced.
 		void track.closed.finally(() => {
 			if (this.#state.tracks.get(track.name) === track) {
 				this.#state.tracks.delete(track.name);
@@ -166,112 +121,106 @@ export class Broadcast {
 		});
 	}
 
-	/**
-	 * Create a track, insert it into the broadcast, and return its {@link TrackProducer}.
-	 *
-	 * Commits the immutable {@link TrackInfo} up front, so a subscriber resolves
-	 * {@link TrackConsumer.info} without an on-demand round-trip. Mirrors the Rust
-	 * `BroadcastProducer::create_track`.
-	 */
-	createTrack(name: string, info: Partial<TrackInfo> = {}): TrackProducer {
-		const track = new TrackProducer(name).accept(info);
-		this.insertTrack(track);
-		return track;
+	/** Create a track, insert it into the broadcast, and return its producer. */
+	createTrack(name: string, info: Partial<track.Info> = {}): track.Producer {
+		const producer = new track.Producer(name).accept(info);
+		this.insertTrack(producer);
+		return producer;
 	}
 
-	/** Remove a statically inserted track by name. Mirrors the Rust `BroadcastProducer::remove_track`. */
+	/** Remove a statically inserted track by name. */
 	removeTrack(name: string): void {
 		this.#state.tracks.delete(name);
 	}
 
-	/**
-	 * Open a live subscription to a track, returning the {@link TrackSubscriber} the
-	 * groups stream into. Called by the consuming application (usually via
-	 * {@link TrackConsumer.subscribe}) and by the publishing wire layer to ask the
-	 * application for a track to serve.
-	 */
-	subscribe(name: string, priority: number): TrackSubscriber {
-		if (this.#state.closed.peek()) {
-			throw new Error(`broadcast is closed: ${this.#state.closed.peek()}`);
-		}
-
-		// Fast path: a statically inserted track fans out a fresh subscriber, no
-		// request. A stale (closed) entry is evicted and falls through to on-demand.
-		const existing = this.#state.tracks.get(name);
-		if (existing) {
-			if (!existing.closedSignal.peek()) return existing.subscribe();
-			this.#state.tracks.delete(name);
-		}
-
-		// The request carries the producer (write side); the caller reads the
-		// subscriber it fans out. Accepting the request commits the info and starts
-		// serving groups.
-		const producer = new TrackProducer(name);
-		const subscriber = producer.subscribe();
-		this.#state.requested.mutate((requested) => {
-			requested.push(new TrackRequest(name, producer, priority));
-			// Sort the tracks by priority in ascending order (we will pop)
-			requested.sort((a, b) => a.priority - b.priority);
-		});
-
-		return subscriber;
+	/** Open a live subscription to a track. Used by the publishing wire layer. */
+	subscribe(name: string, priority: number): track.Subscriber {
+		return subscribe(this.#state, name, priority);
 	}
 
-	/**
-	 * Install the consume-side TRACK_INFO resolver (used by {@link TrackConsumer.info}).
-	 * Called once by the wire layer when this broadcast is consumed. Internal.
-	 */
-	onTrackInfo(resolver: (name: string) => Promise<TrackInfo>): void {
-		this.#infoResolver = resolver;
+	/** Resolve a track's immutable info. Used by the publishing wire layer. */
+	resolveTrackInfo(name: string): Promise<track.Info> {
+		return resolveTrackInfo(this.#state, name);
 	}
 
-	/** Resolve a track's immutable info, used by {@link TrackConsumer.info}. Internal. */
-	resolveTrackInfo(name: string): Promise<TrackInfo> {
-		// Consume side: a TRACK stream (lite-05+) answers it.
-		if (this.#infoResolver) {
-			return this.#infoResolver(name);
-		}
-
-		// A statically inserted track already committed its info; serve it directly.
-		const existing = this.#state.tracks.get(name);
-		if (existing && !existing.closedSignal.peek()) {
-			return existing.info();
-		}
-
-		// Publish side: ask the application by triggering a TrackRequest it answers
-		// with accept(TrackInfo); only the immutable properties are needed, so close
-		// the request once they're known rather than serving any groups.
-		if (this.#state.closed.peek()) {
-			return Promise.reject(new Error(`broadcast is closed: ${this.#state.closed.peek()}`));
-		}
-
-		const producer = new TrackProducer(name);
-		this.#state.requested.mutate((requested) => {
-			requested.push(new TrackRequest(name, producer, 0));
-			requested.sort((a, b) => a.priority - b.priority);
-		});
-
-		return (async () => {
-			try {
-				return await producer.info();
-			} finally {
-				producer.close();
-			}
-		})();
+	/** A lazy read handle for a track on this broadcast. */
+	track(name: string): track.Consumer {
+		return new track.Consumer(
+			name,
+			(priority) => subscribe(this.#state, name, priority),
+			() => resolveTrackInfo(this.#state, name),
+		);
 	}
 
-	/**
-	 * Closes the writer and all associated tracks.
-	 *
-	 * @param abort - If provided, throw this exception instead of returning undefined.
-	 */
+	/** Close the broadcast, optionally with an error to abort waiters. */
 	close(abort?: Error) {
 		this.#state.closed.set(abort ?? true);
-		for (const req of this.#state.requested.peek()) {
-			req.reject(abort);
+		this.#state.requested.mutate((requests) => {
+			requests.length = 0;
+		});
+	}
+}
+
+/**
+ * The read side of a broadcast.
+ *
+ * @public
+ */
+export class Consumer {
+	#state: BroadcastState;
+
+	/** Resolves with the abort error (or undefined) once closed. */
+	readonly closed: Promise<Error | undefined>;
+
+	constructor(state?: never);
+	constructor(state?: BroadcastState) {
+		this.#state = state ?? new BroadcastState();
+		this.closed = closedPromise(this.#state);
+	}
+
+	/** Get a lazy handle for a track on this broadcast. */
+	track(name: string): track.Consumer {
+		return new track.Consumer(
+			name,
+			(priority) => subscribe(this.#state, name, priority),
+			() => resolveTrackInfo(this.#state, name),
+		);
+	}
+
+	/** Open a live subscription to a track. Used by the subscribing wire layer. */
+	subscribe(name: string, priority: number): track.Subscriber {
+		return subscribe(this.#state, name, priority);
+	}
+
+	/** Return the next track requested by the local consumer. Used by the subscribing wire layer. */
+	async requested(): Promise<track.Request | undefined> {
+		for (;;) {
+			const request = this.#state.requested.peek().pop();
+			if (request) return request;
+
+			const closed = this.#state.closed.peek();
+			if (closed instanceof Error) throw closed;
+			if (closed) return undefined;
+
+			await Signal.race(this.#state.requested, this.#state.closed);
 		}
-		this.#state.requested.mutate((requested) => {
-			requested.length = 0;
+	}
+
+	/** Install the read-side TRACK_INFO resolver. Used by the wire layer. */
+	onTrackInfo(resolver: (name: string) => Promise<track.Info>): void {
+		this.#state.infoResolver = resolver;
+	}
+
+	/** Resolve a track's immutable info. Used by track handles. */
+	resolveTrackInfo(name: string): Promise<track.Info> {
+		return resolveTrackInfo(this.#state, name);
+	}
+
+	/** Close the broadcast, optionally with an error to abort waiters. */
+	close(abort?: Error) {
+		this.#state.closed.set(abort ?? true);
+		this.#state.requested.mutate((requests) => {
+			requests.length = 0;
 		});
 	}
 }

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -19,6 +19,17 @@ function closedPromise(state: BroadcastState): Promise<Error | undefined> {
 	});
 }
 
+// Close the broadcast and reject any requests still pending in the queue, so a
+// subscriber blocked on the track's info() or group reads is unblocked rather
+// than left waiting on a producer that will never be served.
+function closeState(state: BroadcastState, abort?: Error) {
+	state.closed.set(abort ?? true);
+	state.requested.mutate((requests) => {
+		for (const request of requests) request.reject(abort);
+		requests.length = 0;
+	});
+}
+
 function subscribe(state: BroadcastState, name: string, priority: number): track.Subscriber {
 	if (state.closed.peek()) {
 		throw new Error(`broadcast is closed: ${state.closed.peek()}`);
@@ -154,10 +165,7 @@ export class Producer {
 
 	/** Close the broadcast, optionally with an error to abort waiters. */
 	close(abort?: Error) {
-		this.#state.closed.set(abort ?? true);
-		this.#state.requested.mutate((requests) => {
-			requests.length = 0;
-		});
+		closeState(this.#state, abort);
 	}
 }
 
@@ -218,9 +226,6 @@ export class Consumer {
 
 	/** Close the broadcast, optionally with an error to abort waiters. */
 	close(abort?: Error) {
-		this.#state.closed.set(abort ?? true);
-		this.#state.requested.mutate((requests) => {
-			requests.length = 0;
-		});
+		closeState(this.#state, abort);
 	}
 }

--- a/js/net/src/connection/established.ts
+++ b/js/net/src/connection/established.ts
@@ -1,7 +1,7 @@
 import type { Signal } from "@moq/signals";
-import type { Announced } from "../announced.ts";
+import type * as announce from "../announced.ts";
 import type { Bandwidth } from "../bandwidth.ts";
-import type { Broadcast } from "../broadcast.ts";
+import type * as broadcast from "../broadcast.ts";
 import type * as Path from "../path.ts";
 import type * as Time from "../time.ts";
 
@@ -23,13 +23,13 @@ export interface Established {
 	readonly rtt?: Signal<Time.Milli | undefined>;
 
 	/** Subscribe to broadcast announcements under an optional path prefix. */
-	announced(prefix?: Path.Valid): Announced;
+	announced(prefix?: Path.Valid): announce.Consumer;
 
 	/** Publish a broadcast at the given path. */
-	publish(path: Path.Valid, broadcast: Broadcast): void;
+	publish(path: Path.Valid, broadcast: broadcast.Producer): void;
 
 	/** Consume the broadcast at the given path. */
-	consume(broadcast: Path.Valid): Broadcast;
+	consume(broadcast: Path.Valid): broadcast.Consumer;
 
 	/** Close the session. */
 	close(): void;

--- a/js/net/src/group.test.ts
+++ b/js/net/src/group.test.ts
@@ -1,20 +1,25 @@
 import { expect, test } from "bun:test";
-import { CacheFull, Group, MAX_GROUP_CACHE_BYTES, MAX_GROUP_FRAMES } from "./group.ts";
+import { CacheFull, MAX_GROUP_CACHE_BYTES, MAX_GROUP_FRAMES, Producer } from "./group.ts";
 import { Timestamp } from "./time.ts";
 
 const dec = new TextDecoder();
 
+function pair(sequence: number) {
+	const producer = new Producer(sequence);
+	return { producer, consumer: producer.consume() };
+}
+
 test("a group caps its frame count, dropping from the front", () => {
-	const group = new Group(0);
+	const { producer, consumer } = pair(0);
 
 	const extra = 100;
 	for (let i = 0; i < MAX_GROUP_FRAMES + extra; i++) {
-		group.writeFrame({ data: new Uint8Array([i & 0xff]), timestamp: Timestamp.now() });
+		producer.writeFrame({ data: new Uint8Array([i & 0xff]), timestamp: Timestamp.now() });
 	}
 
 	// Drain the buffered frames: exactly MAX_GROUP_FRAMES remain after eviction.
 	const frames: { sequence: number; data: Uint8Array }[] = [];
-	for (let f = group.tryReadFrameSequence(); f; f = group.tryReadFrameSequence()) frames.push(f);
+	for (let f = consumer.tryReadFrameSequence(); f; f = consumer.tryReadFrameSequence()) frames.push(f);
 	expect(frames.length).toBe(MAX_GROUP_FRAMES);
 	// Sequence numbers count every frame ever written (evicted included), so the first surviving
 	// frame is index `extra`, not 0: indices stay consistent across eviction.
@@ -23,107 +28,107 @@ test("a group caps its frame count, dropping from the front", () => {
 });
 
 test("a group caps its byte size, dropping from the front", () => {
-	const group = new Group(0);
+	const { producer, consumer } = pair(0);
 
 	// 40 x 1 MiB = 40 MiB, over the 32 MiB cap.
 	const oneMiB = 1024 * 1024;
 	for (let i = 0; i < 40; i++) {
-		group.writeFrame({ data: new Uint8Array(oneMiB), timestamp: Timestamp.now() });
+		producer.writeFrame({ data: new Uint8Array(oneMiB), timestamp: Timestamp.now() });
 	}
 
 	// Drain the buffered frames and sum their bytes: the cache stayed under the byte cap.
 	const frames: Uint8Array[] = [];
-	for (let f = group.tryReadFrame(); f; f = group.tryReadFrame()) frames.push(f);
+	for (let f = consumer.tryReadFrame(); f; f = consumer.tryReadFrame()) frames.push(f);
 	const bytes = frames.reduce((sum, f) => sum + f.byteLength, 0);
 	expect(bytes).toBeLessThanOrEqual(MAX_GROUP_CACHE_BYTES);
 	expect(frames.length).toBe(MAX_GROUP_CACHE_BYTES / oneMiB);
 });
 
 test("a caught-up reader does not trip the byte cache cap", async () => {
-	const group = new Group(0);
+	const { producer, consumer } = pair(0);
 
 	const oneMiB = 1024 * 1024;
 	const frames = MAX_GROUP_CACHE_BYTES / oneMiB + 8;
 	for (let i = 0; i < frames; i++) {
-		group.writeFrame({ data: new Uint8Array(oneMiB), timestamp: Timestamp.now() });
-		expect((await group.readFrame())?.data.byteLength).toBe(oneMiB);
+		producer.writeFrame({ data: new Uint8Array(oneMiB), timestamp: Timestamp.now() });
+		expect((await consumer.readFrame())?.data.byteLength).toBe(oneMiB);
 	}
 });
 
 test("reading a group whose frames were evicted throws CacheFull", async () => {
-	const group = new Group(0);
+	const { producer, consumer } = pair(0);
 
 	// Overflow the frame cap without reading, so the front frames are evicted.
 	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) {
-		group.writeFrame({ data: new Uint8Array([i & 0xff]), timestamp: Timestamp.now() });
+		producer.writeFrame({ data: new Uint8Array([i & 0xff]), timestamp: Timestamp.now() });
 	}
 
 	// The reader fell behind the eviction window: it must error, not skip the gap.
-	expect(group.readFrame()).rejects.toBeInstanceOf(CacheFull);
+	expect(consumer.readFrame()).rejects.toBeInstanceOf(CacheFull);
 });
 
 test("a group with no eviction reads every frame without error", async () => {
-	const group = new Group(0);
-	group.writeFrame({ data: new Uint8Array([1]), timestamp: Timestamp.now() });
-	group.writeFrame({ data: new Uint8Array([2]), timestamp: Timestamp.now() });
-	group.close();
+	const { producer, consumer } = pair(0);
+	producer.writeFrame({ data: new Uint8Array([1]), timestamp: Timestamp.now() });
+	producer.writeFrame({ data: new Uint8Array([2]), timestamp: Timestamp.now() });
+	producer.close();
 
-	expect((await group.readFrame())?.data[0]).toBe(1);
-	expect((await group.readFrame())?.data[0]).toBe(2);
-	expect(await group.readFrame()).toBeUndefined();
+	expect((await consumer.readFrame())?.data[0]).toBe(1);
+	expect((await consumer.readFrame())?.data[0]).toBe(2);
+	expect(await consumer.readFrame()).toBeUndefined();
 });
 
 test("tryReadFrame drains buffered frames then returns undefined", () => {
-	const group = new Group(0);
-	group.writeString("a");
-	group.writeString("b");
+	const { producer, consumer } = pair(0);
+	producer.writeString("a");
+	producer.writeString("b");
 
-	expect(dec.decode(group.tryReadFrame())).toBe("a");
-	expect(dec.decode(group.tryReadFrame())).toBe("b");
+	expect(dec.decode(consumer.tryReadFrame())).toBe("a");
+	expect(dec.decode(consumer.tryReadFrame())).toBe("b");
 	// Nothing buffered: undefined, and the group is not closed so this is not end-of-group.
-	expect(group.tryReadFrame()).toBeUndefined();
+	expect(consumer.tryReadFrame()).toBeUndefined();
 });
 
 test("tryReadFrameSequence reports per-frame sequence numbers", () => {
-	const group = new Group(7);
-	group.writeString("a");
-	group.writeString("b");
+	const { producer, consumer } = pair(7);
+	producer.writeString("a");
+	producer.writeString("b");
 
-	expect(group.tryReadFrameSequence()).toEqual({ sequence: 0, data: new TextEncoder().encode("a") });
-	expect(group.tryReadFrameSequence()).toEqual({ sequence: 1, data: new TextEncoder().encode("b") });
-	expect(group.tryReadFrameSequence()).toBeUndefined();
+	expect(consumer.tryReadFrameSequence()).toEqual({ sequence: 0, data: new TextEncoder().encode("a") });
+	expect(consumer.tryReadFrameSequence()).toEqual({ sequence: 1, data: new TextEncoder().encode("b") });
+	expect(consumer.tryReadFrameSequence()).toBeUndefined();
 });
 
 test("readFrameSequence reports per-frame sequence numbers", async () => {
-	const group = new Group(7);
-	group.writeString("a");
-	group.writeString("b");
+	const { producer, consumer } = pair(7);
+	producer.writeString("a");
+	producer.writeString("b");
 
-	expect(await group.readFrameSequence()).toEqual({ sequence: 0, data: new TextEncoder().encode("a") });
-	expect(await group.readFrameSequence()).toEqual({ sequence: 1, data: new TextEncoder().encode("b") });
+	expect(await consumer.readFrameSequence()).toEqual({ sequence: 0, data: new TextEncoder().encode("a") });
+	expect(await consumer.readFrameSequence()).toEqual({ sequence: 1, data: new TextEncoder().encode("b") });
 });
 
 test("done distinguishes a finished group from one that is merely empty", () => {
-	const group = new Group(0);
+	const { producer, consumer } = pair(0);
 	// Open and empty: not done (more frames may arrive), and tryReadFrame is undefined.
-	expect(group.tryReadFrame()).toBeUndefined();
-	expect(group.done).toBe(false);
+	expect(consumer.tryReadFrame()).toBeUndefined();
+	expect(consumer.done).toBe(false);
 
-	group.writeString("a");
+	producer.writeString("a");
 	// Buffered but closed: still not done until the frame is drained.
-	group.close();
-	expect(group.done).toBe(false);
+	producer.close();
+	expect(consumer.done).toBe(false);
 
-	group.tryReadFrame();
+	consumer.tryReadFrame();
 	// Drained and closed: now done.
-	expect(group.tryReadFrame()).toBeUndefined();
-	expect(group.done).toBe(true);
+	expect(consumer.tryReadFrame()).toBeUndefined();
+	expect(consumer.done).toBe(true);
 });
 
 test("readable resolves once a frame is buffered", async () => {
-	const group = new Group(0);
+	const { producer, consumer } = pair(0);
 	// No frame yet: readable() must stay pending for an empty, open group.
-	const readable = group.readable();
+	const readable = consumer.readable();
 	let settled = false;
 	void readable.then(() => {
 		settled = true;
@@ -132,25 +137,25 @@ test("readable resolves once a frame is buffered", async () => {
 	expect(settled).toBe(false);
 
 	// Writing makes it resolve.
-	group.writeString("hi");
+	producer.writeString("hi");
 	await readable; // must not hang
-	expect(dec.decode(group.tryReadFrame())).toBe("hi");
+	expect(dec.decode(consumer.tryReadFrame())).toBe("hi");
 });
 
 test("readable resolves once the group closes, even with nothing buffered", async () => {
-	const group = new Group(0);
-	const readable = group.readable();
-	group.close();
+	const { producer, consumer } = pair(0);
+	const readable = consumer.readable();
+	producer.close();
 	await readable; // resolves on close so callers don't wait forever
-	expect(group.tryReadFrame()).toBeUndefined();
+	expect(consumer.tryReadFrame()).toBeUndefined();
 });
 
 test("buffered frames are still readable after the group closes", async () => {
-	const group = new Group(0);
-	group.writeString("a");
-	group.close();
+	const { producer, consumer } = pair(0);
+	producer.writeString("a");
+	producer.close();
 
 	// Closing doesn't discard buffered frames; the blocking reader drains them before ending.
-	expect(await group.readString()).toBe("a");
-	expect(await group.readFrame()).toBeUndefined();
+	expect(await consumer.readString()).toBe("a");
+	expect(await consumer.readFrame()).toBeUndefined();
 });

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -8,7 +8,7 @@ export const MAX_GROUP_CACHE_BYTES = 32 * 1024 * 1024;
 export const MAX_GROUP_FRAMES = 1024;
 
 /**
- * A frame buffered in a {@link Group}: its presentation {@link Timestamp} and payload bytes.
+ * A frame buffered in a group: its presentation {@link Timestamp} and payload bytes.
  *
  * The timestamp carries its own scale, so a track can pick its units; the wire layer
  * converts it into the track's negotiated timescale.
@@ -23,11 +23,15 @@ export interface Frame {
 	timestamp: Timestamp;
 }
 
+/** Immutable group metadata. */
+export interface Info {
+	/** Sequence number of this group within its track. */
+	sequence: number;
+}
+
 /**
  * Thrown by a frame read when the reader fell behind the group's eviction window: frames
  * it had not yet read were dropped to stay under the cache cap, so the stream has a gap.
- * Mirrors the Rust `Error::CacheFull`. Skipping the gap silently would corrupt decoding,
- * so the reader must surface this instead.
  */
 export class CacheFull extends Error {
 	constructor() {
@@ -36,8 +40,9 @@ export class CacheFull extends Error {
 	}
 }
 
-/** Reactive backing state for a {@link Group}: buffered frames, a closed flag, and the running frame count. */
+/** Reactive backing state shared by the group producer and one consumer. */
 class GroupState {
+	readonly sequence: number;
 	frames = new Signal<Frame[]>([]);
 	closed = new Once<true | Error>();
 	total = new Signal<number>(0); // The total number of frames in the group thus far
@@ -45,23 +50,45 @@ class GroupState {
 	// Frames evicted from the front by the cache cap. A reader that had not consumed
 	// them has a gap, so its next read throws CacheFull rather than skipping silently.
 	offset = 0;
+	cacheBytes = 0;
+
+	constructor(sequence: number) {
+		this.sequence = sequence;
+	}
 }
 
-/** An ordered stream of frames within a track, delivered over a single QUIC stream. */
-export class Group {
+function appendFrame(state: GroupState, frame: Frame) {
+	if (state.closed.peek()) throw new Error("group is closed");
+
+	state.cacheBytes += frame.data.byteLength;
+	state.frames.mutate((frames) => {
+		frames.push(frame);
+
+		while (frames.length > MAX_GROUP_FRAMES || state.cacheBytes > MAX_GROUP_CACHE_BYTES) {
+			const evicted = frames.shift();
+			if (!evicted) break;
+			state.cacheBytes -= evicted.data.byteLength;
+			state.offset++;
+		}
+	});
+
+	state.total.update((total) => total + 1);
+}
+
+/**
+ * The write side of an ordered stream of frames within a track.
+ *
+ * @public
+ */
+export class Producer {
 	/** Sequence number of this group within its track. */
 	readonly sequence: number;
 
-	#state = new GroupState();
-
-	// Downstream copies that receive every frame written here, synchronously. Used by
-	// TrackProducer to fan one source group out to per-subscriber groups.
-	#mirrors?: Set<Group>;
-
-	// Running byte total of the frames currently cached, for the eviction cap.
-	#cacheBytes = 0;
+	#state: GroupState;
+	#mirrors?: Set<GroupState>;
 
 	constructor(sequence: number) {
+		this.#state = new GroupState(sequence);
 		this.sequence = sequence;
 	}
 
@@ -73,69 +100,43 @@ export class Group {
 		return this.#state.closed;
 	}
 
-	/** Writes a frame to the group. */
-	writeFrame(frame: Frame) {
-		if (this.#state.closed.peek()) throw new Error("group is closed");
-
-		const { data } = frame;
-
-		this.#cacheBytes += data.byteLength;
-		this.#state.frames.mutate((frames) => {
-			frames.push(frame);
-
-			// Bound an unbounded (e.g. never-closed) group: drop the oldest frames once
-			// over either cap. A consumer too far behind silently skips them.
-			while (frames.length > MAX_GROUP_FRAMES || this.#cacheBytes > MAX_GROUP_CACHE_BYTES) {
-				const evicted = frames.shift();
-				if (!evicted) break;
-				this.#cacheBytes -= evicted.data.byteLength;
-				this.#state.offset++;
-			}
-		});
-
-		this.#state.total.update((total) => total + 1);
-
-		// Tee into live mirrors, dropping any the consumer has already closed.
-		if (this.#mirrors) {
-			for (const mirror of this.#mirrors) {
-				if (mirror.#state.closed.peek()) this.#mirrors.delete(mirror);
-				else mirror.writeFrame(frame);
-			}
-		}
-	}
-
-	#readBufferedFrame(): { sequence: number; frame: Frame } | undefined {
-		const frames = this.#state.frames.peek();
-		const frame = frames.shift();
-		if (!frame) return undefined;
-
-		this.#cacheBytes -= frame.data.byteLength;
-		return { sequence: this.#state.total.peek() - frames.length - 1, frame };
+	/** A read handle for this group. */
+	consume(): Consumer {
+		return makeConsumer(this.#state);
 	}
 
 	/**
-	 * Create an independent copy that receives every frame written to this group.
+	 * Create an independent read handle that receives every frame written here.
 	 *
-	 * Frames written so far are replayed synchronously; later writes (and the close)
-	 * are teed in as they happen. The copy has its own read cursor, so consumers never
-	 * steal frames from each other. Internal to {@link TrackProducer} fan-out.
+	 * Frames written so far are replayed synchronously; later writes and close are teed
+	 * in as they happen. Internal to track fan-out.
 	 */
-	mirror(): Group {
-		const dst = new Group(this.sequence);
-		for (const frame of this.#state.frames.peek()) dst.writeFrame(frame);
-		// Inherit the evicted prefix: frames dropped before this copy was made are a gap
-		// for its reader too, so reading them throws CacheFull.
-		dst.#state.offset = this.#state.offset;
+	mirror(): Consumer {
+		const dst = new GroupState(this.sequence);
+		for (const frame of this.#state.frames.peek()) appendFrame(dst, frame);
+		dst.offset = this.#state.offset;
 
 		const closed = this.#state.closed.peek();
 		if (closed) {
-			dst.close(closed instanceof Error ? closed : undefined);
-			return dst;
+			dst.closed.set(closed);
+			return makeConsumer(dst);
 		}
 
 		this.#mirrors ??= new Set();
 		this.#mirrors.add(dst);
-		return dst;
+		return makeConsumer(dst);
+	}
+
+	/** Writes a frame to the group. */
+	writeFrame(frame: Frame) {
+		appendFrame(this.#state, frame);
+
+		if (this.#mirrors) {
+			for (const mirror of this.#mirrors) {
+				if (mirror.closed.peek()) this.#mirrors.delete(mirror);
+				else appendFrame(mirror, frame);
+			}
+		}
 	}
 
 	/** Write a string as a single UTF-8 encoded frame, stamped with wall-clock now. */
@@ -153,12 +154,76 @@ export class Group {
 		this.writeFrame({ data: new Uint8Array([bool ? 1 : 0]), timestamp: Timestamp.now() });
 	}
 
+	/** True once the group has been closed. */
+	get isClosed(): boolean {
+		return this.#state.closed.peek() !== undefined;
+	}
+
+	/** Closes the group, optionally with an error to abort readers. */
+	close(abort?: Error) {
+		if (this.#state.closed.peek() !== undefined) return;
+		this.#state.closed.set(abort ?? true);
+
+		if (this.#mirrors) {
+			for (const mirror of this.#mirrors) {
+				if (mirror.closed.peek() === undefined) mirror.closed.set(abort ?? true);
+			}
+			this.#mirrors.clear();
+		}
+	}
+}
+
+let makeConsumer: (state: GroupState) => Consumer;
+
+/**
+ * The read side of an ordered stream of frames within a track.
+ *
+ * @public
+ */
+export class Consumer {
+	/** Sequence number of this group within its track. */
+	readonly sequence: number;
+
+	#state: GroupState;
+
+	constructor(sequence: number);
+	constructor(sequenceOrState: number | GroupState) {
+		this.#state = typeof sequenceOrState === "number" ? new GroupState(sequenceOrState) : sequenceOrState;
+		this.sequence = this.#state.sequence;
+	}
+
+	/**
+	 * Settles once the group closes: `true` on a clean close, or the abort {@link Error}.
+	 * Peek it synchronously (`undefined` while open), observe it reactively, or `await` it.
+	 */
+	get closed(): GetPromise<true | Error> {
+		return this.#state.closed;
+	}
+
+	static {
+		makeConsumer = (state) => new Consumer(state as never);
+	}
+
+	#readBufferedFrame(): { sequence: number; frame: Frame } | undefined {
+		const frames = this.#state.frames.peek();
+		const frame = frames.shift();
+		if (!frame) return undefined;
+
+		this.#state.cacheBytes -= frame.data.byteLength;
+		return { sequence: this.#state.total.peek() - frames.length - 1, frame };
+	}
+
 	/** True once no further frames can be read: the group has closed and every buffered frame is read. */
 	get done(): boolean {
 		return this.#state.frames.peek().length === 0 && this.#state.closed.peek() !== undefined;
 	}
 
-	/** True if frames were evicted from the front of this group before being read (a gap). Used by a track reader to raise {@link CacheFull}. */
+	/** True once the group has been closed, regardless of whether buffered frames remain unread. Synchronous complement to the {@link closed} promise. */
+	get isClosed(): boolean {
+		return this.#state.closed.peek() !== undefined;
+	}
+
+	/** True if frames were evicted from the front of this group before being read. */
 	get skipped(): boolean {
 		return this.#state.offset > 0;
 	}
@@ -166,37 +231,21 @@ export class Group {
 	/**
 	 * Reads the next already-buffered frame's payload without blocking.
 	 *
-	 * Returns `undefined` when nothing is buffered right now. That is *not* by itself end-of-group:
-	 * check {@link done} to tell "no frame buffered yet" (more may arrive) from "the group finished".
-	 * Drain a backlog by looping until this returns `undefined`, then branch on {@link done}: if not
-	 * done, {@link readable} resolves when the next frame arrives.
-	 *
-	 * Non-throwing: unlike {@link readFrame} it does not raise {@link CacheFull} on an evicted prefix.
+	 * Returns `undefined` when nothing is buffered right now. That is not by itself
+	 * end-of-group: check {@link done} to tell "no frame buffered yet" from "finished".
 	 */
 	tryReadFrame(): Uint8Array | undefined {
 		return this.tryReadFrameSequence()?.data;
 	}
 
-	/**
-	 * Like {@link tryReadFrame} but also reports the frame's sequence number within the group.
-	 *
-	 * Non-throwing: it does not raise {@link CacheFull} on an evicted prefix. The eviction check
-	 * lives only in the blocking {@link readFrame}/{@link readFrameSequence} paths.
-	 */
+	/** Like {@link tryReadFrame} but also reports the frame's sequence number within the group. */
 	tryReadFrameSequence(): { sequence: number; data: Uint8Array } | undefined {
 		const read = this.#readBufferedFrame();
 		if (!read) return undefined;
 		return { sequence: read.sequence, data: read.frame.data };
 	}
 
-	/**
-	 * Resolves once {@link readFrame} would not block: a frame is buffered, or the group has closed.
-	 * Always settles (never hangs), so on a finished group it resolves immediately; pair it with
-	 * {@link done} to avoid re-waiting on a group that has nothing left.
-	 *
-	 * Lets a caller fold "this group has a frame" into a larger wait (e.g. racing it against a new
-	 * group arriving) without touching the group's internal signals.
-	 */
+	/** Resolves once {@link readFrame} would not block. */
 	async readable(): Promise<void> {
 		for (;;) {
 			if (this.#state.frames.peek().length > 0) return;
@@ -205,10 +254,7 @@ export class Group {
 		}
 	}
 
-	/**
-	 * Reads the next frame (timestamp + payload) from the group.
-	 * @returns A promise that resolves to the next frame or undefined
-	 */
+	/** Reads the next frame from the group. */
 	async readFrame(): Promise<Frame | undefined> {
 		for (;;) {
 			if (this.#state.offset > 0) throw new CacheFull();
@@ -262,10 +308,5 @@ export class Group {
 	close(abort?: Error) {
 		if (this.#state.closed.peek() !== undefined) return; // already closed
 		this.#state.closed.set(abort ?? true);
-
-		if (this.#mirrors) {
-			for (const mirror of this.#mirrors) mirror.close(abort);
-			this.#mirrors.clear();
-		}
 	}
 }

--- a/js/net/src/ietf/connection.ts
+++ b/js/net/src/ietf/connection.ts
@@ -1,5 +1,5 @@
-import type { Announced } from "../announced.ts";
-import type { Broadcast } from "../broadcast.ts";
+import type * as announce from "../announced.ts";
+import type * as broadcast from "../broadcast.ts";
 import type { Established } from "../connection/established.ts";
 import * as Path from "../path.ts";
 import { type Reader, Readers, type Stream } from "../stream.ts";
@@ -124,8 +124,8 @@ export class Connection implements Established {
 	 * @param name - The broadcast path to publish
 	 * @param broadcast - The broadcast to publish
 	 */
-	publish(path: Path.Valid, broadcast: Broadcast) {
-		this.#publisher.publish(path, broadcast);
+	publish(path: Path.Valid, producer: broadcast.Producer) {
+		this.#publisher.publish(path, producer);
 	}
 
 	/**
@@ -133,7 +133,7 @@ export class Connection implements Established {
 	 * @param prefix - The prefix for announcements
 	 * @returns An Announced instance
 	 */
-	announced(prefix = Path.empty()): Announced {
+	announced(prefix = Path.empty()): announce.Consumer {
 		return this.#subscriber.announced(prefix);
 	}
 
@@ -146,8 +146,8 @@ export class Connection implements Established {
 	 * @param broadcast - The path of the broadcast to consume
 	 * @returns A Broadcast instance
 	 */
-	consume(broadcast: Path.Valid): Broadcast {
-		return this.#subscriber.consume(broadcast);
+	consume(path: Path.Valid): broadcast.Consumer {
+		return this.#subscriber.consume(path);
 	}
 
 	/**
@@ -166,7 +166,7 @@ export class Connection implements Established {
 	}
 
 	/**
-	 * Unified bidi stream dispatch — reads typeId and routes to handler.
+	 * Unified bidi stream dispatch. Reads typeId and routes to handler.
 	 * Matches the lite module's runBidi pattern.
 	 */
 	async #runBidi(stream: Stream) {

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -1,6 +1,6 @@
-import { Announced } from "../announced.ts";
-import type { Broadcast } from "../broadcast.ts";
-import type { Group } from "../group.ts";
+import * as announce from "../announced.ts";
+import type * as broadcast from "../broadcast.ts";
+import type * as group from "../group.ts";
 import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
 import { error } from "../util/error.ts";
@@ -30,10 +30,10 @@ export class Publisher {
 	#session: Session;
 
 	// Our published broadcasts.
-	#broadcasts: Map<Path.Valid, Broadcast> = new Map();
+	#broadcasts: Map<Path.Valid, broadcast.Producer> = new Map();
 
 	// Any consumers that want each new announcement.
-	#announcedConsumers = new Set<Announced>();
+	#announcedConsumers = new Set<announce.Producer>();
 
 	/**
 	 * Creates a new Publisher instance.
@@ -51,13 +51,13 @@ export class Publisher {
 	 * Publishes a broadcast with any associated tracks.
 	 * Opens a bidi stream to send PublishNamespace and waits for response.
 	 */
-	publish(path: Path.Valid, broadcast: Broadcast) {
+	publish(path: Path.Valid, broadcast: broadcast.Producer) {
 		this.#broadcasts.set(path, broadcast);
 		this.#notifyConsumers(path, true);
 		void this.#runPublish(path, broadcast);
 	}
 
-	async #runPublish(path: Path.Valid, broadcast: Broadcast) {
+	async #runPublish(path: Path.Valid, broadcast: broadcast.Producer) {
 		try {
 			const requestId = await this.#session.nextRequestId();
 			if (requestId === undefined) return;
@@ -206,7 +206,7 @@ export class Publisher {
 	/**
 	 * Runs a group and sends its frames using ObjectStream (Subgroup delivery mode).
 	 */
-	async #runGroup(requestId: bigint, group: Group) {
+	async #runGroup(requestId: bigint, group: group.Consumer) {
 		try {
 			const stream = await Writer.open(this.#quic, this.#session.version);
 
@@ -268,14 +268,14 @@ export class Publisher {
 				await ok.encode(stream.writer, version);
 			}
 
-			// Create an Announced consumer and seed it with current broadcasts
-			const announced = new Announced(prefix);
+			const announced = new announce.Producer(prefix);
 			for (const name of this.#broadcasts.keys()) {
 				const suffix = Path.stripPrefix(prefix, name);
 				if (suffix === null) continue;
 				announced.append({ path: suffix, active: true });
 			}
 			this.#announcedConsumers.add(announced);
+			const consumer = announced.consume();
 
 			// Close the consumer when the stream closes
 			stream.reader.closed.then(
@@ -285,7 +285,7 @@ export class Publisher {
 
 			try {
 				for (;;) {
-					const entry = await announced.next();
+					const entry = await consumer.next();
 					if (!entry) break;
 
 					if (entry.active) {

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -1,10 +1,10 @@
-import { Announced } from "../announced.ts";
-import { Broadcast, type TrackRequest } from "../broadcast.ts";
-import { Group } from "../group.ts";
+import * as announce from "../announced.ts";
+import * as broadcast from "../broadcast.ts";
+import * as netGroup from "../group.ts";
 import * as Path from "../path.ts";
 import type { Reader, Stream } from "../stream.ts";
 import { Timestamp } from "../time.ts";
-import type { TrackProducer } from "../track.ts";
+import type * as track from "../track.ts";
 import { error } from "../util/error.ts";
 import { withTimeout } from "../util/timeout.ts";
 import type { Session } from "./adapter.ts";
@@ -46,15 +46,15 @@ type SubscribeSetupState = {
 export class Subscriber {
 	#session: Session;
 
-	// Our subscribed tracks — keyed by trackAlias for group routing
+	// Our subscribed tracks, keyed by trackAlias for group routing.
 	// trackAlias -> the write side; incoming object streams are routed here.
-	#subscribes = new Map<bigint, TrackProducer>();
+	#subscribes = new Map<bigint, track.Producer>();
 
 	// Any currently active announcements.
 	#announced = new Set<Path.Valid>();
 
 	// Any consumers that want each new announcement.
-	#announcedConsumers = new Set<Announced>();
+	#announcedConsumers = new Set<announce.Producer>();
 
 	/**
 	 * Creates a new Subscriber instance.
@@ -69,8 +69,8 @@ export class Subscriber {
 	/**
 	 * Gets an announced reader for the specified prefix.
 	 */
-	announced(prefix = Path.empty()): Announced {
-		const announced = new Announced(prefix);
+	announced(prefix = Path.empty()): announce.Consumer {
+		const announced = new announce.Producer(prefix);
 		for (const active of this.#announced) {
 			if (!Path.hasPrefix(prefix, active)) continue;
 			announced.append({ path: active, active: true });
@@ -82,10 +82,10 @@ export class Subscriber {
 			announced.close();
 		});
 
-		return announced;
+		return announced.consume();
 	}
 
-	async #runAnnounced(announced: Announced, prefix: Path.Valid) {
+	async #runAnnounced(announced: announce.Producer, prefix: Path.Valid) {
 		const version = this.#session.version;
 
 		// v14/v15: SubscribeNamespace on control stream (via adapter virtual stream)
@@ -196,21 +196,21 @@ export class Subscriber {
 	/**
 	 * Consumes a broadcast from the connection.
 	 */
-	consume(path: Path.Valid): Broadcast {
-		const broadcast = new Broadcast();
+	consume(path: Path.Valid): broadcast.Consumer {
+		const consumer = new broadcast.Consumer();
 
 		void (async () => {
 			for (;;) {
-				const request = await broadcast.requested();
+				const request = await consumer.requested();
 				if (!request) break;
 				void this.#runSubscribe(path, request);
 			}
 		})();
 
-		return broadcast;
+		return consumer;
 	}
 
-	async #runSubscribe(broadcast: Path.Valid, request: TrackRequest) {
+	async #runSubscribe(broadcast: Path.Valid, request: track.Request) {
 		const version = this.#session.version;
 		const requestId = await this.#session.nextRequestId();
 		if (requestId === undefined) {
@@ -299,8 +299,8 @@ export class Subscriber {
 	async #openSubscribe(
 		state: SubscribeSetupState,
 		broadcast: Path.Valid,
-		request: TrackRequest,
-		producer: TrackProducer,
+		request: track.Request,
+		producer: track.Producer,
 		requestId: bigint,
 	): Promise<{ stream: Stream; alias: bigint }> {
 		const version = this.#session.version;
@@ -385,7 +385,7 @@ export class Subscriber {
 		this.#announced.add(path);
 
 		try {
-			// Send OK first — must complete before notifying consumers,
+			// Send OK first. This must complete before notifying consumers,
 			// because consumers may trigger Subscribe writes that would
 			// interleave with our OK on the control stream.
 			if (version === Version.DRAFT_14) {
@@ -465,7 +465,7 @@ export class Subscriber {
 	 * @internal
 	 */
 	async handleGroup(group: GroupMessage, stream: Reader) {
-		const producer = new Group(group.groupId);
+		const producer = new netGroup.Producer(group.groupId);
 
 		if (group.subGroupId !== 0) {
 			throw new Error("subgroups are not supported");

--- a/js/net/src/index.ts
+++ b/js/net/src/index.ts
@@ -7,17 +7,21 @@
 
 /** Re-export of {@link https://jsr.io/@moq/signals | @moq/signals}, the reactive primitives used throughout this package. */
 export * as Signals from "@moq/signals";
-export * from "./announced.ts";
+/** Broadcast announcement streams. */
+export * as announce from "./announced.ts";
 export * from "./bandwidth.ts";
-export * from "./broadcast.ts";
+/** Broadcast role handles. */
+export * as broadcast from "./broadcast.ts";
 /** Connection helpers: connect to or accept a MoQ session and reconnect on failure. */
 export * as Connection from "./connection/index.ts";
 export * from "./datagram.ts";
-export * from "./group.ts";
+/** Group role handles and frame helpers. */
+export * as group from "./group.ts";
 /** Broadcast path utilities with delimiter-aware prefix matching. */
 export * as Path from "./path.ts";
 /** Branded time types (nanoseconds, microseconds, milliseconds, seconds) with conversions. */
 export * as Time from "./time.ts";
-export * from "./track.ts";
+/** Track role handles. */
+export * as track from "./track.ts";
 /** QUIC variable-length integer encoding and decoding. */
 export * as Varint from "./varint.ts";

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { Broadcast } from "./broadcast.ts";
+import { Producer as BroadcastProducer } from "./broadcast.ts";
 import { accept, connect } from "./connection/index.ts";
 import * as Ietf from "./ietf/index.ts";
 import * as Lite from "./lite/index.ts";
@@ -20,7 +20,7 @@ async function runPublishSubscribeFlow(protocol: string, version?: number) {
 	]);
 
 	// Server publishes a broadcast
-	const broadcast = new Broadcast();
+	const broadcast = new BroadcastProducer();
 	server.publish(Path.from("test"), broadcast);
 
 	// Serve every requested "video" track. On lite-05+ a subscribe is preceded by
@@ -91,7 +91,7 @@ test("integration: lite draft-05-wip datagram delivery", async () => {
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 
 	// A static track fans datagrams out to whoever subscribes.
-	const broadcast = new Broadcast();
+	const broadcast = new BroadcastProducer();
 	server.publish(Path.from("test"), broadcast);
 	const producer = broadcast.createTrack("video", { timescale: Timescale.MILLI });
 
@@ -130,7 +130,7 @@ test("integration: lite draft-05-wip datagrams not sent on a non-datagram transp
 
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 
-	const broadcast = new Broadcast();
+	const broadcast = new BroadcastProducer();
 	server.publish(Path.from("test"), broadcast);
 	const producer = broadcast.createTrack("video", { timescale: Timescale.MILLI });
 

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -1,7 +1,7 @@
 import { Signal } from "@moq/signals";
-import type { Announced } from "../announced.ts";
+import type * as announce from "../announced.ts";
 import { type Bandwidth, createBandwidth } from "../bandwidth.ts";
-import type { Broadcast } from "../broadcast.ts";
+import type * as broadcast from "../broadcast.ts";
 import type { Established } from "../connection/established.ts";
 import * as Path from "../path.ts";
 import { type Reader, Readers, Stream, Writer } from "../stream.ts";
@@ -155,16 +155,16 @@ export class Connection implements Established {
 		}
 	}
 
-	publish(path: Path.Valid, broadcast: Broadcast) {
-		this.#publisher.publish(path, broadcast);
+	publish(path: Path.Valid, producer: broadcast.Producer) {
+		this.#publisher.publish(path, producer);
 	}
 
-	announced(prefix = Path.empty()): Announced {
+	announced(prefix = Path.empty()): announce.Consumer {
 		return this.#subscriber.announced(prefix);
 	}
 
-	consume(broadcast: Path.Valid): Broadcast {
-		return this.#subscriber.consume(broadcast);
+	consume(path: Path.Valid): broadcast.Consumer {
+		return this.#subscriber.consume(path);
 	}
 
 	async #runSession() {

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -1,10 +1,10 @@
 import { type Dispose, Signal } from "@moq/signals";
-import type { Broadcast } from "../broadcast.ts";
-import type { Group } from "../group.ts";
+import type * as broadcast from "../broadcast.ts";
+import type * as group from "../group.ts";
 import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
 import { Timescale } from "../time.ts";
-import type { TrackSubscriber } from "../track.ts";
+import type * as track from "../track.ts";
 import { error } from "../util/error.ts";
 import { AnnounceBroadcast, AnnounceInit, AnnounceOk, type AnnounceRequest } from "./announce.ts";
 import { Datagram as DatagramMessage } from "./datagram.ts";
@@ -70,7 +70,7 @@ export class Publisher {
 
 	// Our published broadcasts.
 	// It's a signal so we can live update any announce streams.
-	#broadcasts = new Signal<Map<Path.Valid, Broadcast> | undefined>(new Map());
+	#broadcasts = new Signal<Map<Path.Valid, broadcast.Producer> | undefined>(new Map());
 
 	// TRACK_INFO is immutable per track, so resolve it from the application once
 	// (via a throwaway subscribe whose info() resolves when the app calls accept)
@@ -102,7 +102,7 @@ export class Publisher {
 	 * Publishes a broadcast with any associated tracks.
 	 * @param name - The broadcast to publish
 	 */
-	publish(path: Path.Valid, broadcast: Broadcast) {
+	publish(path: Path.Valid, broadcast: broadcast.Producer) {
 		this.#broadcasts.mutate((broadcasts) => {
 			if (!broadcasts) throw new Error("closed");
 			broadcasts.set(path, broadcast);
@@ -172,7 +172,7 @@ export class Publisher {
 		for (;;) {
 			// TODO Make a better helper within Signals.
 			let dispose!: Dispose;
-			const changed = new Promise<Map<Path.Valid, Broadcast> | undefined>((resolve) => {
+			const changed = new Promise<Map<Path.Valid, broadcast.Producer> | undefined>((resolve) => {
 				dispose = this.#broadcasts.changed(resolve);
 			});
 
@@ -304,7 +304,7 @@ export class Publisher {
 	 *
 	 * @internal
 	 */
-	async #runTrack(sub: bigint, broadcast: Path.Valid, track: TrackSubscriber, stream: Writer, timescale: Timescale) {
+	async #runTrack(sub: bigint, broadcast: Path.Valid, track: track.Subscriber, stream: Writer, timescale: Timescale) {
 		// Lite-05+ resolves the range on the subscribe stream: SUBSCRIBE_START once the
 		// first group is known, SUBSCRIBE_END when the track finishes.
 		const emitRange = supportsTrackStream(this.version);
@@ -402,7 +402,7 @@ export class Publisher {
 	 *
 	 * @internal
 	 */
-	async #runDatagrams(sub: bigint, track: TrackSubscriber, timescale: Timescale) {
+	async #runDatagrams(sub: bigint, track: track.Subscriber, timescale: Timescale) {
 		const writer = this.#datagramWriter;
 		if (!writer) return; // Only reached with a writer (see the #datagramWriter gate).
 		const maxSize = this.#quic.datagrams.maxDatagramSize;
@@ -435,7 +435,7 @@ export class Publisher {
 	 *
 	 * @internal
 	 */
-	async #runGroup(sub: bigint, group: Group, timescale: Timescale) {
+	async #runGroup(sub: bigint, group: group.Consumer, timescale: Timescale) {
 		const msg = new GroupMessage(sub, group.sequence);
 		try {
 			const stream = await Writer.open(this.#quic);

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -1,12 +1,12 @@
 import { Signal } from "@moq/signals";
-import { Announced } from "../announced.ts";
+import * as announce from "../announced.ts";
 import type { Bandwidth } from "../bandwidth.ts";
-import { Broadcast, type TrackRequest } from "../broadcast.ts";
-import { Group } from "../group.ts";
+import * as broadcast from "../broadcast.ts";
+import * as netGroup from "../group.ts";
 import * as Path from "../path.ts";
 import { type Reader, Stream } from "../stream.ts";
 import * as Time from "../time.ts";
-import type { TrackProducer } from "../track.ts";
+import type * as track from "../track.ts";
 import { error } from "../util/error.ts";
 import { withTimeout } from "../util/timeout.ts";
 import { AnnounceBroadcast, AnnounceInit, AnnounceOk, AnnounceRequest } from "./announce.ts";
@@ -60,8 +60,8 @@ export interface AnnouncedOptions {
 
 interface SubscribeEntry {
 	// The write side: incoming GROUP streams are routed here. The application reads
-	// the matching TrackSubscriber it got from Broadcast.subscribe.
-	track: TrackProducer;
+	// the matching track.Subscriber it got from broadcast.Consumer.subscribe.
+	track: track.Producer;
 	// Per-frame timestamp scale (0 = none). undefined until it's known (from TRACK_INFO
 	// on lite-05+, or implicit defaults on older drafts). A non-zero value means each
 	// frame on the group stream is prefixed with a zigzag-delta timestamp varint that
@@ -134,13 +134,13 @@ export class Subscriber {
 	 * Pass `{ ignoreSelf: true }` to skip announces that have already traversed
 	 * this connection's {@link origin}.
 	 */
-	announced(prefix = Path.empty(), options: AnnouncedOptions = {}): Announced {
-		const announced = new Announced();
+	announced(prefix = Path.empty(), options: AnnouncedOptions = {}): announce.Consumer {
+		const announced = new announce.Producer(prefix);
 		void this.#runAnnounced(announced, prefix, options);
-		return announced;
+		return announced.consume();
 	}
 
-	async #runAnnounced(announced: Announced, prefix: Path.Valid, options: AnnouncedOptions): Promise<void> {
+	async #runAnnounced(announced: announce.Producer, prefix: Path.Valid, options: AnnouncedOptions): Promise<void> {
 		console.debug(`announced: prefix=${prefix}`);
 		// Send our own session-level origin id so the peer can skip announces
 		// whose hop chain already passed through us. Matches the Rust subscriber's
@@ -217,12 +217,12 @@ export class Subscriber {
 	 * @param name - The name of the broadcast to consume
 	 * @returns A Broadcast instance
 	 */
-	consume(path: Path.Valid): Broadcast {
-		const broadcast = new Broadcast();
+	consume(path: Path.Valid): broadcast.Consumer {
+		const consumer = new broadcast.Consumer();
 
 		// Resolve TrackConsumer.info() via a TRACK stream (lite-05+). On older drafts
 		// there's no TRACK stream, so info() rejects rather than fabricating defaults.
-		broadcast.onTrackInfo(async (name) => {
+		consumer.onTrackInfo(async (name) => {
 			if (!supportsTrackStream(this.version)) {
 				throw new Error("track info requires moq-lite-05 or newer");
 			}
@@ -239,16 +239,16 @@ export class Subscriber {
 
 		void (async () => {
 			for (;;) {
-				const request = await broadcast.requested();
+				const request = await consumer.requested();
 				if (!request) break;
 				void this.#runSubscribe(path, request);
 			}
 		})();
 
-		return broadcast;
+		return consumer;
 	}
 
-	async #runSubscribe(broadcast: Path.Valid, request: TrackRequest) {
+	async #runSubscribe(broadcast: Path.Valid, request: track.Request) {
 		const id = this.#subscribeNext++;
 
 		// `timescale` stays undefined until TRACK_INFO (or, on older drafts,
@@ -264,7 +264,7 @@ export class Subscriber {
 		const state: { stream?: Stream } = {};
 		const setup = this.#openSubscribe(state, msg, request, id, timescale);
 
-		let opened: { stream: Stream; producer: TrackProducer };
+		let opened: { stream: Stream; producer: track.Producer };
 		try {
 			opened = await withTimeout(
 				setup,
@@ -323,7 +323,7 @@ export class Subscriber {
 	}
 
 	// Determine the track's immutable properties, accept the request (so the
-	// application's TrackSubscriber resolves and incoming groups have a producer to
+	// application's track.Subscriber resolves and incoming groups have a producer to
 	// write into), register it, then open the subscribe stream. `state.stream` is
 	// populated as soon as the subscribe stream opens so the caller can clean it up
 	// on timeout even before this promise settles.
@@ -334,11 +334,11 @@ export class Subscriber {
 	async #openSubscribe(
 		state: { stream?: Stream },
 		msg: Subscribe,
-		request: TrackRequest,
+		request: track.Request,
 		id: bigint,
 		timescale: Signal<number | undefined>,
-	): Promise<{ stream: Stream; producer: TrackProducer }> {
-		let producer: TrackProducer;
+	): Promise<{ stream: Stream; producer: track.Producer }> {
+		let producer: track.Producer;
 		let drainOk = false;
 
 		if (supportsTrackStream(this.version)) {
@@ -423,7 +423,7 @@ export class Subscriber {
 	async #runPriorityUpdates(
 		id: bigint,
 		broadcast: Path.Valid,
-		track: TrackProducer,
+		track: track.Producer,
 		msg: Subscribe,
 		stream: Stream,
 	): Promise<void> {
@@ -472,7 +472,7 @@ export class Subscriber {
 		}
 
 		const { track, timescale } = entry;
-		const producer = new Group(group.sequence);
+		const producer = new netGroup.Producer(group.sequence);
 		track.writeGroup(producer);
 
 		try {

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
 import { MAX_DATAGRAM_PAYLOAD } from "./datagram.ts";
-import { Group } from "./group.ts";
+import { Producer as GroupProducer } from "./group.ts";
 import { Timestamp } from "./time.ts";
-import { TrackProducer } from "./track.ts";
+import { Producer as TrackProducer } from "./track.ts";
 
 const enc = new TextEncoder();
 const dec = new TextDecoder();
@@ -50,8 +50,8 @@ test("recvDatagram advances the ordered group cursor", async () => {
 	expect((await track.recvDatagram())?.sequence).toBe(5);
 
 	// Ordered group reads treat lower sequences as late once a datagram used sequence 5.
-	producer.writeGroup(new Group(3));
-	producer.writeGroup(new Group(6));
+	producer.writeGroup(new GroupProducer(3));
+	producer.writeGroup(new GroupProducer(6));
 	expect((await track.nextGroup())?.sequence).toBe(6);
 });
 
@@ -64,15 +64,15 @@ test("nextGroup skips late arrivals", async () => {
 	const producer = new TrackProducer("test");
 	const track = producer.subscribe();
 
-	producer.writeGroup(new Group(5));
+	producer.writeGroup(new GroupProducer(5));
 
 	const first = await track.nextGroup();
 	expect(first?.sequence).toBe(5);
 
 	// Late arrivals with sequence <= last returned are skipped.
-	producer.writeGroup(new Group(3));
-	producer.writeGroup(new Group(4));
-	producer.writeGroup(new Group(7));
+	producer.writeGroup(new GroupProducer(3));
+	producer.writeGroup(new GroupProducer(4));
+	producer.writeGroup(new GroupProducer(7));
 
 	const next = await track.nextGroup();
 	expect(next?.sequence).toBe(7);
@@ -82,8 +82,8 @@ test("nextGroup returns buffered groups in sequence", async () => {
 	const producer = new TrackProducer("test");
 	const track = producer.subscribe();
 
-	producer.writeGroup(new Group(3));
-	producer.writeGroup(new Group(5));
+	producer.writeGroup(new GroupProducer(3));
+	producer.writeGroup(new GroupProducer(5));
 
 	expect((await track.nextGroup())?.sequence).toBe(3);
 	expect((await track.nextGroup())?.sequence).toBe(5);
@@ -93,14 +93,14 @@ test("recvGroup after nextGroup still returns late arrivals", async () => {
 	const producer = new TrackProducer("test");
 	const track = producer.subscribe();
 
-	producer.writeGroup(new Group(5));
+	producer.writeGroup(new GroupProducer(5));
 
 	// Ordered returns seq 5, advancing its cursor.
 	const ordered = await track.nextGroup();
 	expect(ordered?.sequence).toBe(5);
 
 	// recvGroup is independent of the ordered cursor: a late seq 3 still surfaces.
-	producer.writeGroup(new Group(3));
+	producer.writeGroup(new GroupProducer(3));
 	const recv = await track.recvGroup();
 	expect(recv?.sequence).toBe(3);
 });

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -1,9 +1,9 @@
 import { Signal } from "@moq/signals";
 import { type Datagram, MAX_DATAGRAM_PAYLOAD } from "./datagram.ts";
-import { CacheFull, type Frame, Group } from "./group.ts";
+import { CacheFull, type Frame, type Consumer as GroupConsumer, Producer as GroupProducer } from "./group.ts";
 import { Timescale, type Timestamp } from "./time.ts";
 
-/** Default {@link TrackInfo.cache} window (milliseconds) when the publisher doesn't set one. */
+/** Default {@link Info.cache} window (milliseconds) when the publisher doesn't set one. */
 export const DEFAULT_CACHE_MS = 5000;
 
 /**
@@ -21,11 +21,11 @@ type BufferedDatagram = { datagram: Datagram; time: number };
 /**
  * A track's immutable publisher properties, fixed for the lifetime of the track.
  *
- * A producer declares these once (via `TrackRequest.accept` or
- * {@link TrackProducer.accept}); a consumer awaits them via {@link TrackSubscriber.info}
+ * A producer declares these once (via {@link Request.accept} or
+ * {@link Producer.accept}); a consumer awaits them via {@link Subscriber.info}
  * (resolved from the wire TRACK_INFO on lite-05+). They map 1:1 onto TRACK_INFO.
  */
-export interface TrackInfo {
+export interface Info {
 	/**
 	 * Units per second for this track's frame timestamps (reported in TRACK_INFO on
 	 * Lite05+). Defaults to milliseconds; set it finer (e.g. {@link Timescale.MICRO})
@@ -43,8 +43,8 @@ export interface TrackInfo {
 	ordered: boolean;
 }
 
-/** Fill in any unset {@link TrackInfo} fields with their defaults. */
-export function trackInfoDefaults(info: Partial<TrackInfo> = {}): TrackInfo {
+/** Fill in any unset {@link Info} fields with their defaults. */
+export function infoDefaults(info: Partial<Info> = {}): Info {
 	return {
 		timescale: info.timescale ?? Timescale.MILLI,
 		cache: info.cache ?? DEFAULT_CACHE_MS,
@@ -53,16 +53,75 @@ export function trackInfoDefaults(info: Partial<TrackInfo> = {}): TrackInfo {
 	};
 }
 
-// The shared state behind a TrackProducer / TrackSubscriber pair. Package-internal
+/**
+ * A request for a track the peer wants, yielded by `broadcast.Producer.requested`.
+ *
+ * @public
+ */
+export class Request {
+	/** The requested track name. */
+	readonly name: string;
+	/** The subscriber's priority for this track. */
+	readonly priority: number;
+
+	#producer: Producer;
+
+	constructor(name: string, producer: Producer, priority: number) {
+		this.name = name;
+		this.#producer = producer;
+		this.priority = priority;
+	}
+
+	/** Accept the request, committing the track's immutable {@link Info}. */
+	accept(info: Partial<Info> = {}): Producer {
+		return this.#producer.accept(info);
+	}
+
+	/** Reject the request, closing the track optionally with an error. */
+	reject(err?: Error): void {
+		this.#producer.close(err);
+	}
+}
+
+/**
+ * A lazy handle to a track on a consumed broadcast.
+ *
+ * @public
+ */
+export class Consumer {
+	/** The track name. */
+	readonly name: string;
+
+	#subscribe: (priority: number) => Subscriber;
+	#info: () => Promise<Info>;
+
+	constructor(name: string, subscribe: (priority: number) => Subscriber, info: () => Promise<Info>) {
+		this.name = name;
+		this.#subscribe = subscribe;
+		this.#info = info;
+	}
+
+	/** Open a live subscription to the track. */
+	subscribe(options?: { priority?: number }): Subscriber {
+		return this.#subscribe(options?.priority ?? 0);
+	}
+
+	/** Fetch the track's immutable publisher properties without subscribing. */
+	info(): Promise<Info> {
+		return this.#info();
+	}
+}
+
+// The shared state behind a Producer / Subscriber pair. Package-internal
 // wiring, unexported so it never appears in the published type declarations.
 class TrackState {
-	groups = new Signal<Group[]>([]);
+	groups = new Signal<GroupConsumer[]>([]);
 	/** Best-effort datagram channel, parallel to {@link groups}; an age-evicted send buffer per subscriber. */
 	datagrams = new Signal<BufferedDatagram[]>([]);
 	closed = new Signal<boolean | Error>(false);
 	priority = new Signal<number | undefined>(undefined);
 	/** Resolved once the producer commits the immutable properties. */
-	info = new Signal<TrackInfo | undefined>(undefined);
+	info = new Signal<Info | undefined>(undefined);
 }
 
 // Build the closed promise from a state's closed signal: resolves with the abort error
@@ -81,7 +140,7 @@ function trackClosedPromise(state: TrackState): Promise<Error | undefined> {
 // On a producer this resolves once info is committed (at accept time); on a consumer
 // once the wire layer commits the TRACK_INFO it received (lite-05+) or defaults (older
 // drafts), so awaiting it never yields a placeholder.
-async function resolveTrackInfo(state: TrackState): Promise<TrackInfo> {
+async function resolveInfo(state: TrackState): Promise<Info> {
 	for (;;) {
 		const info = state.info.peek();
 		if (info) return info;
@@ -96,26 +155,26 @@ async function resolveTrackInfo(state: TrackState): Promise<TrackInfo> {
 
 // A source group retained in the producer cache, with the mirror handed to each sink
 // so eviction can drop them together.
-type CachedGroup = { group: Group; time: number; mirrors: Map<TrackState, Group> };
+type CachedGroup = { group: GroupProducer; time: number; mirrors: Map<TrackState, GroupConsumer> };
 
-// Constructs a TrackSubscriber from within this module without exposing a public
+// Constructs a Subscriber from within this module without exposing a public
 // constructor that would leak the unexported TrackState. Assigned in the class's
 // static block.
-let makeSubscriber: (name: string, state: TrackState) => TrackSubscriber;
+let makeSubscriber: (name: string, state: TrackState) => Subscriber;
 
 /**
- * The write side of a track, mirroring the Rust `TrackProducer`.
+ * The write side of a track, mirroring the Rust `Producer`.
  *
  * A producer is a fan-out source: every {@link subscribe} (including each wire
  * subscription the publisher serves from it) gets an independent
- * {@link TrackSubscriber} that receives a full copy of the groups, each with its own
+ * {@link Subscriber} that receives a full copy of the groups, each with its own
  * read cursor. Groups are mirrored into every live subscriber and retained for the
  * track's `cache` window so a late subscriber replays the recent groups.
  *
- * Obtained from `TrackRequest.accept` (the wire asks the application for a track to
+ * Obtained from {@link Request.accept} (the wire asks the application for a track to
  * serve) or constructed directly for an in-process track.
  */
-export class TrackProducer {
+export class Producer {
 	/** The track name. */
 	readonly name: string;
 
@@ -146,8 +205,8 @@ export class TrackProducer {
 	 * Resolve this track's immutable publisher properties, committed at accept time.
 	 * Rejects if the track is closed before the properties are known.
 	 */
-	info(): Promise<TrackInfo> {
-		return resolveTrackInfo(this.#state);
+	info(): Promise<Info> {
+		return resolveInfo(this.#state);
 	}
 
 	/** Reactive closed state: `false` while open, `true` or the abort `Error` once closed. Await {@link closed} (the promise) to block on it instead. */
@@ -155,22 +214,22 @@ export class TrackProducer {
 		return this.#state.closed;
 	}
 
-	/** Reactive subscriber priority; the wire layer watches this to emit SUBSCRIBE_UPDATE. `undefined` until first set via {@link TrackSubscriber.updatePriority}. */
+	/** Reactive subscriber priority; the wire layer watches this to emit SUBSCRIBE_UPDATE. `undefined` until first set via {@link Subscriber.updatePriority}. */
 	get prioritySignal(): Signal<number | undefined> {
 		return this.#state.priority;
 	}
 
 	/** Commit the immutable publisher properties, resolving {@link info}. Returns `this`. */
-	accept(info: Partial<TrackInfo> = {}): this {
-		const resolved = trackInfoDefaults(info);
+	accept(info: Partial<Info> = {}): this {
+		const resolved = infoDefaults(info);
 		this.#state.info.set(resolved);
 		// Propagate to any sink handed out before accept (the on-demand path).
 		for (const sink of this.#sinks) sink.info.set(resolved);
 		return this;
 	}
 
-	/** An independent {@link TrackSubscriber} receiving a full copy of this track's groups. */
-	subscribe(): TrackSubscriber {
+	/** An independent {@link Subscriber} receiving a full copy of this track's groups. */
+	subscribe(): Subscriber {
 		const sink = new TrackState();
 		this.#addSink(sink);
 		return makeSubscriber(this.name, sink);
@@ -251,18 +310,18 @@ export class TrackProducer {
 	}
 
 	// Retain a source group and fan it out to every live sink.
-	#publish(group: Group): void {
-		const entry: CachedGroup = { group, time: Date.now(), mirrors: new Map<TrackState, Group>() };
+	#publish(group: GroupProducer): void {
+		const entry: CachedGroup = { group, time: Date.now(), mirrors: new Map<TrackState, GroupConsumer>() };
 		this.#cache.push(entry);
 		this.#prune();
 		for (const sink of this.#sinks) this.#mirror(entry, sink);
 	}
 
 	/** Append a new group with the next sequence number. */
-	appendGroup(): Group {
+	appendGroup(): GroupProducer {
 		if (this.#state.closed.peek()) throw new Error("track is closed");
 
-		const group = new Group(this.#next ?? 0);
+		const group = new GroupProducer(this.#next ?? 0);
 		this.#next = group.sequence + 1;
 		this.#publish(group);
 
@@ -270,7 +329,7 @@ export class TrackProducer {
 	}
 
 	/** Insert an existing group into the track. */
-	writeGroup(group: Group) {
+	writeGroup(group: GroupProducer) {
 		if (this.#state.closed.peek()) throw new Error("track is closed");
 
 		// Only advance #next upward (for appendGroup auto-increment).
@@ -371,13 +430,13 @@ export class TrackProducer {
 }
 
 /**
- * The read side of a live track subscription, mirroring the Rust `TrackSubscriber`.
+ * The read side of a live track subscription, mirroring the Rust `Subscriber`.
  *
- * Obtained from `Broadcast.subscribe` / `TrackConsumer.subscribe`, or from
- * {@link TrackProducer.subscribe} for an in-process track. Reads the groups a
- * {@link TrackProducer} on the same underlying state writes.
+ * Obtained from `broadcast.Consumer.subscribe` / `track.Consumer.subscribe`, or from
+ * {@link Producer.subscribe} for an in-process track. Reads the groups a
+ * {@link Producer} on the same underlying state writes.
  */
-export class TrackSubscriber {
+export class Subscriber {
 	/** The track name. */
 	readonly name: string;
 
@@ -394,7 +453,7 @@ export class TrackSubscriber {
 	}
 
 	static {
-		makeSubscriber = (name, state) => new TrackSubscriber(name, state);
+		makeSubscriber = (name, state) => new Subscriber(name, state);
 	}
 
 	/**
@@ -404,11 +463,11 @@ export class TrackSubscriber {
 	 * defaults (older drafts), so awaiting it never yields a placeholder. Rejects if
 	 * the track is closed before the properties are known (e.g. a rejected subscription).
 	 */
-	info(): Promise<TrackInfo> {
-		return resolveTrackInfo(this.#state);
+	info(): Promise<Info> {
+		return resolveInfo(this.#state);
 	}
 
-	/** Reactive closed state; see {@link TrackProducer.closedSignal}. */
+	/** Reactive closed state; see {@link Producer.closedSignal}. */
 	get closedSignal(): Signal<boolean | Error> {
 		return this.#state.closed;
 	}
@@ -432,7 +491,7 @@ export class TrackSubscriber {
 	 * Groups may arrive out of order or with gaps due to network conditions.
 	 * Use {@link nextGroup} for sequence order, skipping those that arrive too late.
 	 */
-	async recvGroup(): Promise<Group | undefined> {
+	async recvGroup(): Promise<GroupConsumer | undefined> {
 		for (;;) {
 			const groups = this.#state.groups.peek();
 			if (groups.length > 0) {
@@ -451,7 +510,7 @@ export class TrackSubscriber {
 	 * Receive the next datagram in arrival order.
 	 *
 	 * Datagrams are a separate best-effort channel from groups (see
-	 * {@link TrackProducer.appendDatagram}); they share only the sequence namespace. A consumer
+	 * {@link Producer.appendDatagram}); they share only the sequence namespace. A consumer
 	 * that falls too far behind silently loses the oldest datagrams. Read this alongside
 	 * {@link recvGroup} (e.g. in a separate loop) to receive both channels concurrently. Returning
 	 * a datagram advances {@link nextGroup} past that sequence.
@@ -487,7 +546,7 @@ export class TrackSubscriber {
 	 * Late arrivals (sequence at or below the last returned) are silently skipped.
 	 * Use {@link recvGroup} to see every group in arrival order instead.
 	 */
-	async nextGroup(): Promise<Group | undefined> {
+	async nextGroup(): Promise<GroupConsumer | undefined> {
 		for (;;) {
 			const group = await this.recvGroup();
 			if (!group) return undefined;

--- a/js/net/src/zod.ts
+++ b/js/net/src/zod.ts
@@ -5,12 +5,12 @@
  */
 
 import type * as z from "zod/mini";
-import type { Group } from "./group.ts";
-import type { TrackProducer, TrackSubscriber } from "./track.ts";
+import type * as group from "./group.ts";
+import type * as track from "./track.ts";
 
 /** Read the next JSON frame and validate it against the schema. Returns undefined at end of stream. */
 export async function read<T = unknown>(
-	source: TrackSubscriber | Group,
+	source: track.Subscriber | group.Consumer,
 	schema: z.ZodMiniType<T>,
 ): Promise<T | undefined> {
 	const next = await source.readJson();
@@ -19,7 +19,7 @@ export async function read<T = unknown>(
 }
 
 /** Validate a value against the schema, then write it as a JSON frame. */
-export function write<T = unknown>(source: TrackProducer | Group, value: T, schema: z.ZodMiniType<T>) {
+export function write<T = unknown>(source: track.Producer | group.Producer, value: T, schema: z.ZodMiniType<T>) {
 	const valid = schema.parse(value);
 	source.writeJson(valid);
 }

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -273,7 +273,7 @@ export class Encoder {
 		}
 	}
 
-	serve(track: Moq.TrackProducer, effect: Effect): void {
+	serve(track: Moq.track.Producer, effect: Effect): void {
 		const values = effect.getAll([this.enabled, this.#worklet]);
 		if (!values) return;
 		const [_, worklet] = values;

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -34,7 +34,7 @@ export class Broadcast {
 	// offline. Exposed so an application can serve its own tracks alongside the built-in
 	// catalog/audio/video, e.g. `net.createTrack("meta.json")` plus a matching `catalog` section.
 	// Reacquire it via an effect, since reconnecting swaps in a fresh producer.
-	readonly net = new Signal<Moq.Broadcast | undefined>(undefined);
+	readonly net = new Signal<Moq.broadcast.Producer | undefined>(undefined);
 
 	signals = new Effect();
 
@@ -77,7 +77,7 @@ export class Broadcast {
 			);
 		}
 
-		const broadcast = new Moq.Broadcast();
+		const broadcast = new Moq.broadcast.Producer();
 		effect.cleanup(() => broadcast.close());
 
 		// Publish it before serving so an application reacting to `net` can insert its own tracks.
@@ -91,14 +91,14 @@ export class Broadcast {
 		effect.spawn(this.#runBroadcast.bind(this, broadcast, effect));
 	}
 
-	async #runBroadcast(broadcast: Moq.Broadcast, effect: Effect) {
+	async #runBroadcast(broadcast: Moq.broadcast.Producer, effect: Effect) {
 		for (;;) {
 			const request = await broadcast.requested();
 			if (!request) break;
 
 			// dev's reshape hands back a TrackRequest: switch on its name, reject unknown
 			// tracks, and accept the rest into a producer to serve.
-			let serve: ((track: Moq.TrackProducer, effect: Effect) => void) | undefined;
+			let serve: ((track: Moq.track.Producer, effect: Effect) => void) | undefined;
 			switch (request.name) {
 				case Broadcast.CATALOG_TRACK:
 					serve = (track, effect) => this.catalog.serve(track, effect);

--- a/js/publish/src/catalog.test.ts
+++ b/js/publish/src/catalog.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import type * as Catalog from "@moq/hang/catalog";
 import * as Json from "@moq/json";
-import { TrackProducer } from "@moq/net";
+import { track as NetTrack } from "@moq/net";
 import { Effect } from "@moq/signals";
 import { CatalogProducer } from "./catalog.ts";
 
@@ -14,7 +14,7 @@ test("catalog producer seeds subscribers and fans out edits", async () => {
 	});
 
 	const effect = new Effect();
-	const track = new TrackProducer("catalog.json");
+	const track = new NetTrack.Producer("catalog.json");
 	catalog.serve(track, effect);
 	const consumer = new Json.Consumer<Catalog.Root>(track.subscribe());
 
@@ -39,7 +39,7 @@ test("catalog producer publishes every update as a snapshot group", async () => 
 	});
 
 	const effect = new Effect();
-	const track = new TrackProducer("catalog.json");
+	const track = new NetTrack.Producer("catalog.json");
 	catalog.serve(track, effect);
 	const subscriber = track.subscribe();
 
@@ -69,12 +69,12 @@ test("a reconnecting subscriber is seeded with the full current catalog", async 
 
 	// The first subscription drains and ends...
 	const first = new Effect();
-	catalog.serve(new TrackProducer("catalog.json"), first);
+	catalog.serve(new NetTrack.Producer("catalog.json"), first);
 	first.close();
 
 	// ...and a fresh subscription still gets the current catalog, not nothing.
 	const effect = new Effect();
-	const track = new TrackProducer("catalog.json");
+	const track = new NetTrack.Producer("catalog.json");
 	catalog.serve(track, effect);
 	const seeded = await new Json.Consumer<Catalog.Root>(track.subscribe()).next();
 	expect(seeded?.video).toEqual({ renditions: {} });

--- a/js/publish/src/catalog.ts
+++ b/js/publish/src/catalog.ts
@@ -30,7 +30,7 @@ export class CatalogProducer {
 	 * Pass `opts.compression` to DEFLATE-compress this subscriber's frames, so the same catalog can be
 	 * served both plaintext and compressed (e.g. `catalog.json` and `catalog.json.z`).
 	 */
-	serve(track: Moq.TrackProducer, effect: Effect, opts?: { compression?: boolean }): void {
+	serve(track: Moq.track.Producer, effect: Effect, opts?: { compression?: boolean }): void {
 		const output = new Json.Producer<Catalog.Root>(track, {
 			compression: opts?.compression,
 			deltaRatio: 0,

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -88,7 +88,7 @@ export class Encoder {
 		this.#signals.run(this.#runDimensions.bind(this));
 	}
 
-	serve(track: Moq.TrackProducer, effect: Effect): void {
+	serve(track: Moq.track.Producer, effect: Effect): void {
 		if (!effect.get(this.enabled)) return;
 
 		const producer = new Container.Legacy.Producer(track);

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -134,7 +134,7 @@ export class Decoder {
 			if (context.state === "closed") return;
 
 			// Create the worklet node. outputChannelCount must be set explicitly
-			// so the process() callback receives a matching channel layout —
+			// so the process() callback receives a matching channel layout.
 			// Firefox defaults differently than Chrome otherwise.
 			const worklet = new AudioWorkletNode(context, "render", {
 				channelCount,
@@ -219,7 +219,7 @@ export class Decoder {
 		}
 	}
 
-	#runLegacyDecoder(effect: Effect, sub: Moq.TrackSubscriber, config: Catalog.AudioConfig): void {
+	#runLegacyDecoder(effect: Effect, sub: Moq.track.Subscriber, config: Catalog.AudioConfig): void {
 		const format = config.container.kind === "loc" ? new Container.Loc.Format() : new Container.Legacy.Format();
 		// Create consumer with slightly less latency than the render worklet to avoid underflowing.
 		// TODO include JITTER_UNDERHEAD
@@ -303,7 +303,7 @@ export class Decoder {
 		});
 	}
 
-	#runCmafDecoder(effect: Effect, sub: Moq.TrackSubscriber, config: Catalog.AudioConfig): void {
+	#runCmafDecoder(effect: Effect, sub: Moq.track.Subscriber, config: Catalog.AudioConfig): void {
 		if (config.container.kind !== "cmaf") return; // just to help typescript
 
 		const initSegment = base64ToBytes(config.container.init);

--- a/js/watch/src/audio/mse.ts
+++ b/js/watch/src/audio/mse.ts
@@ -109,7 +109,7 @@ export class Mse implements Backend {
 
 	#runCmafMedia(
 		effect: Effect,
-		sub: Moq.TrackSubscriber,
+		sub: Moq.track.Subscriber,
 		config: Catalog.AudioConfig,
 		sourceBuffer: SourceBuffer,
 		element: HTMLMediaElement,
@@ -131,7 +131,7 @@ export class Mse implements Backend {
 				} catch (err) {
 					// Falling behind a group's eviction window drops frames; resync from
 					// the next group (a keyframe segment) rather than stopping playback.
-					if (err instanceof Moq.CacheFull) continue;
+					if (err instanceof Moq.group.CacheFull) continue;
 					throw err;
 				}
 				if (!frame) return;
@@ -152,7 +152,7 @@ export class Mse implements Backend {
 
 	#runLegacyMedia(
 		effect: Effect,
-		sub: Moq.TrackSubscriber,
+		sub: Moq.track.Subscriber,
 		config: Catalog.AudioConfig,
 		sourceBuffer: SourceBuffer,
 		element: HTMLMediaElement,

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -51,7 +51,7 @@ type BroadcastInput = {
 
 type BroadcastOutput = {
 	status: Signal<Status>;
-	active: Signal<Moq.Broadcast | undefined>;
+	active: Signal<Moq.broadcast.Consumer | undefined>;
 
 	// The effective catalog: the fetched one, or a copy of input.catalog in manual mode.
 	catalog: Signal<Catalog.Root | undefined>;
@@ -63,7 +63,7 @@ export class Broadcast {
 
 	readonly #output: BroadcastOutput = {
 		status: new Signal<Status>("offline"),
-		active: new Signal<Moq.Broadcast | undefined>(undefined),
+		active: new Signal<Moq.broadcast.Consumer | undefined>(undefined),
 		catalog: new Signal<Catalog.Root | undefined>(undefined),
 	};
 	readonly output = readonlys(this.#output);

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -98,7 +98,7 @@ export class Decoder implements Backend {
 		}
 		const [_, broadcast, track, config] = values;
 
-		const active: Moq.Broadcast | undefined = effect.get(broadcast.output.active);
+		const active: Moq.broadcast.Consumer | undefined = effect.get(broadcast.output.active);
 		if (!active) {
 			// Going offline should clear the last rendered frame.
 			this.#active.set(undefined);
@@ -215,7 +215,7 @@ export class Decoder implements Backend {
 
 interface DecoderTrackProps {
 	sync: Sync;
-	broadcast: Moq.Broadcast;
+	broadcast: Moq.broadcast.Consumer;
 	track: string;
 	config: Catalog.VideoConfig;
 
@@ -224,7 +224,7 @@ interface DecoderTrackProps {
 
 class DecoderTrack {
 	sync: Sync;
-	broadcast: Moq.Broadcast;
+	broadcast: Moq.broadcast.Consumer;
 	track: string;
 	config: RequiredDecoderConfig;
 	stats: Signal<Stats | undefined>;
@@ -321,7 +321,7 @@ class DecoderTrack {
 		}
 	}
 
-	#runLegacy(effect: Effect, sub: Moq.TrackSubscriber, decoder: VideoDecoder): void {
+	#runLegacy(effect: Effect, sub: Moq.track.Subscriber, decoder: VideoDecoder): void {
 		const format =
 			this.config.container.kind === "loc" ? new Container.Loc.Format() : new Container.Legacy.Format();
 		// Create consumer that reorders groups/frames up to the provided latency.
@@ -401,7 +401,7 @@ class DecoderTrack {
 		});
 	}
 
-	#runCmaf(effect: Effect, sub: Moq.TrackSubscriber, decoder: VideoDecoder): void {
+	#runCmaf(effect: Effect, sub: Moq.track.Subscriber, decoder: VideoDecoder): void {
 		if (this.config.container.kind !== "cmaf") return;
 
 		const initSegment = base64ToBytes(this.config.container.init);

--- a/js/watch/src/video/mse.ts
+++ b/js/watch/src/video/mse.ts
@@ -102,7 +102,7 @@ export class Mse implements Backend {
 
 	#runCmafMedia(
 		effect: Effect,
-		active: Moq.Broadcast,
+		active: Moq.broadcast.Consumer,
 		track: string,
 		config: Catalog.VideoConfig,
 		sourceBuffer: SourceBuffer,
@@ -115,7 +115,7 @@ export class Mse implements Backend {
 
 		// Decode the catalog's authoritative init segment once and read the
 		// timescale out of it. The catalog also gives us the bytes to feed
-		// directly into MSE — no need to regenerate.
+		// directly into MSE. No need to regenerate.
 		const initSegment = base64ToBytes(config.container.init);
 		const init = Container.Cmaf.decodeInitSegment(initSegment);
 
@@ -131,7 +131,7 @@ export class Mse implements Backend {
 				} catch (err) {
 					// Falling behind a group's eviction window drops frames; resync from
 					// the next group (a keyframe segment) rather than stopping playback.
-					if (err instanceof Moq.CacheFull) continue;
+					if (err instanceof Moq.group.CacheFull) continue;
 					throw err;
 				}
 				if (!frame) return;
@@ -152,7 +152,7 @@ export class Mse implements Backend {
 
 	#runLegacyMedia(
 		effect: Effect,
-		active: Moq.Broadcast,
+		active: Moq.broadcast.Consumer,
 		track: string,
 		config: Catalog.VideoConfig,
 		sourceBuffer: SourceBuffer,


### PR DESCRIPTION
## Summary

- mirror the Rust role-module shape in `@moq/net` with `broadcast`, `track`, `group`, and `announce` namespaces
- split mixed JS handles into explicit producer and consumer roles for broadcasts, groups, and announcements
- update `@moq/net` consumers across JSON, HANG, LOC, watch, publish, clock, MoQ Boy, and the web demo

## Public API

This is a breaking `@moq/net` API change for JavaScript consumers. The root-level flat exports such as `Broadcast`, `Group`, `TrackProducer`, and `TrackSubscriber` move under role namespaces, for example `broadcast.Producer`, `broadcast.Consumer`, `group.Producer`, `group.Consumer`, `track.Producer`, and `track.Subscriber`.

## Validation

- `bun run --filter @moq/net check`
- `bun run --filter @moq/net test`
- `bun run --filter @moq/json check`
- `bun run --filter @moq/hang check`
- `bun run --filter @moq/loc check`
- `bun run --filter @moq/msf check`
- `bun run --filter @moq/publish check`
- `bun run --filter @moq/watch check`
- `bun run --filter @moq/clock check`
- `bun run --filter @moq/boy check`
- `bun run --filter @moq/demo check`

(Written by GPT-5)
