### PR TITLE
[codex] fix ffi producer owner lifetimes

### DIFF
--- a/rs/moq-ffi/src/audio.rs
+++ b/rs/moq-ffi/src/audio.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use crate::consumer::MoqBroadcastConsumer;
 use crate::error::MoqError;
 use crate::ffi::Task;
-use crate::producer::MoqBroadcastProducer;
+use crate::producer::{BroadcastOwner, MoqBroadcastProducer};
 
 /// Raw PCM sample format, mirroring WebCodecs `AudioData.format`.
 ///
@@ -138,6 +138,7 @@ impl From<MoqAudioFrame> for moq_audio::Frame {
 #[derive(uniffi::Object)]
 pub struct MoqAudioProducer {
 	inner: std::sync::Mutex<Option<moq_audio::AudioProducer<moq_mux::catalog::hang::Extra>>>,
+	_owner: BroadcastOwner,
 }
 
 #[uniffi::export]
@@ -191,9 +192,15 @@ impl MoqBroadcastProducer {
 			)
 			.map_err(Into::into)
 		})?;
+		let owner = self.with_state(|state| {
+			Ok(BroadcastOwner {
+				_inner: state.broadcast.clone(),
+			})
+		})?;
 
 		Ok(Arc::new(MoqAudioProducer {
 			inner: std::sync::Mutex::new(Some(producer)),
+			_owner: owner,
 		}))
 	}
 }
@@ -214,6 +221,7 @@ impl ConsumerInner {
 #[derive(uniffi::Object)]
 pub struct MoqAudioConsumer {
 	task: Task<ConsumerInner>,
+	_owner: MoqBroadcastConsumer,
 }
 
 #[uniffi::export]
@@ -264,6 +272,7 @@ impl MoqBroadcastConsumer {
 
 		Ok(Arc::new(MoqAudioConsumer {
 			task: Task::new(ConsumerInner { consumer }),
+			_owner: self.clone(),
 		}))
 	}
 }

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -5,15 +5,24 @@ use bytes::Buf;
 use crate::error::MoqError;
 use crate::ffi::Task;
 use crate::media::*;
+use crate::producer::BroadcastOwner;
 
 #[derive(Clone, uniffi::Object)]
 pub struct MoqBroadcastConsumer {
 	inner: moq_net::BroadcastConsumer,
+	_owner: Option<BroadcastOwner>,
 }
 
 impl MoqBroadcastConsumer {
 	pub(crate) fn new(inner: moq_net::BroadcastConsumer) -> Self {
-		Self { inner }
+		Self { inner, _owner: None }
+	}
+
+	pub(crate) fn new_with_owner(inner: moq_net::BroadcastConsumer, owner: BroadcastOwner) -> Self {
+		Self {
+			inner,
+			_owner: Some(owner),
+		}
 	}
 
 	/// Access the underlying `moq_net::BroadcastConsumer` for sibling
@@ -26,6 +35,7 @@ impl MoqBroadcastConsumer {
 #[derive(uniffi::Object)]
 pub struct MoqCatalogConsumer {
 	task: Task<Catalog>,
+	_owner: MoqBroadcastConsumer,
 }
 
 struct Catalog {
@@ -45,6 +55,7 @@ impl Catalog {
 #[derive(uniffi::Object)]
 pub struct MoqMediaConsumer {
 	task: Task<Media>,
+	_owner: MoqBroadcastConsumer,
 }
 
 struct Media {
@@ -87,6 +98,7 @@ impl MoqBroadcastConsumer {
 		let consumer = moq_mux::catalog::hang::Consumer::<moq_mux::catalog::hang::Extra>::from(track);
 		Ok(Arc::new(MoqCatalogConsumer {
 			task: Task::new(Catalog { inner: consumer }),
+			_owner: self.clone(),
 		}))
 	}
 
@@ -96,7 +108,10 @@ impl MoqBroadcastConsumer {
 	pub fn subscribe_track(&self, name: String) -> Result<Arc<MoqTrackConsumer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let track = self.inner.subscribe_track(&moq_net::Track::new(name))?;
-		Ok(Arc::new(MoqTrackConsumer::new(track)))
+		Ok(Arc::new(MoqTrackConsumer::new_with_broadcast_owner(
+			track,
+			self.clone(),
+		)))
 	}
 
 	/// Subscribe to a track by name, delivering frames in decode order.
@@ -121,6 +136,7 @@ impl MoqBroadcastConsumer {
 		let consumer = moq_mux::container::Consumer::new(track, media).with_latency(latency);
 		Ok(Arc::new(MoqMediaConsumer {
 			task: Task::new(Media { inner: consumer }),
+			_owner: self.clone(),
 		}))
 	}
 }
@@ -148,12 +164,31 @@ impl TrackInner {
 #[derive(uniffi::Object)]
 pub struct MoqTrackConsumer {
 	task: Task<TrackInner>,
+	_broadcast_consumer_owner: Option<MoqBroadcastConsumer>,
+	_broadcast_owner: Option<BroadcastOwner>,
+	_track_owner: Option<moq_net::TrackProducer>,
 }
 
 impl MoqTrackConsumer {
-	pub(crate) fn new(track: moq_net::TrackConsumer) -> Self {
+	pub(crate) fn new_with_broadcast_owner(track: moq_net::TrackConsumer, owner: MoqBroadcastConsumer) -> Self {
 		Self {
 			task: Task::new(TrackInner { track }),
+			_broadcast_consumer_owner: Some(owner),
+			_broadcast_owner: None,
+			_track_owner: None,
+		}
+	}
+
+	pub(crate) fn new_with_track_owner(
+		track: moq_net::TrackConsumer,
+		track_owner: moq_net::TrackProducer,
+		broadcast_owner: Option<BroadcastOwner>,
+	) -> Self {
+		Self {
+			task: Task::new(TrackInner { track }),
+			_broadcast_consumer_owner: None,
+			_broadcast_owner: broadcast_owner,
+			_track_owner: Some(track_owner),
 		}
 	}
 }
@@ -171,6 +206,7 @@ impl MoqTrackConsumer {
 					Arc::new(MoqGroupConsumer {
 						sequence: group.sequence,
 						task: Task::new(GroupInner { group }),
+						_owner: None,
 					})
 				}))
 			})
@@ -186,6 +222,7 @@ impl MoqTrackConsumer {
 					Arc::new(MoqGroupConsumer {
 						sequence: group.sequence,
 						task: Task::new(GroupInner { group }),
+						_owner: None,
 					})
 				}))
 			})
@@ -219,13 +256,15 @@ impl GroupInner {
 pub struct MoqGroupConsumer {
 	sequence: u64,
 	task: Task<GroupInner>,
+	_owner: Option<moq_net::GroupProducer>,
 }
 
 impl MoqGroupConsumer {
-	pub(crate) fn new(group: moq_net::GroupConsumer) -> Self {
+	pub(crate) fn new_with_owner(group: moq_net::GroupConsumer, owner: moq_net::GroupProducer) -> Self {
 		Self {
 			sequence: group.sequence,
 			task: Task::new(GroupInner { group }),
+			_owner: Some(owner),
 		}
 	}
 }

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -8,6 +8,11 @@ use crate::ffi::Task;
 
 // ---- UniFFI Objects ----
 
+#[derive(Clone)]
+pub(crate) struct BroadcastOwner {
+	pub(crate) _inner: moq_net::BroadcastProducer,
+}
+
 pub(crate) struct BroadcastProducer {
 	pub(crate) broadcast: moq_net::BroadcastProducer,
 	pub(crate) catalog: moq_mux::catalog::Producer<Extra>,
@@ -85,15 +90,26 @@ pub struct MoqBroadcastDynamic {
 }
 
 struct DynamicProducer {
-	inner: moq_net::BroadcastDynamic,
+	inner: Option<moq_net::BroadcastDynamic>,
+	owner: moq_net::BroadcastProducer,
 }
 
 impl DynamicProducer {
 	async fn requested_track(&mut self) -> Result<Arc<MoqTrackProducer>, MoqError> {
-		let track = self.inner.requested_track().await?;
+		let mut inner = self.inner.take().ok_or(MoqError::Closed)?;
+		let track = inner.requested_track().await;
+		self.inner = Some(inner);
+		let track = track?;
 		Ok(Arc::new(MoqTrackProducer {
 			inner: std::sync::Mutex::new(Some(track)),
+			_owner: Some(BroadcastOwner {
+				_inner: self.owner.clone(),
+			}),
 		}))
+	}
+
+	fn close(&mut self) {
+		self.inner.take();
 	}
 }
 
@@ -120,11 +136,13 @@ impl MoqBroadcastProducer {
 #[derive(uniffi::Object)]
 pub struct MoqMediaProducer {
 	inner: std::sync::Mutex<Option<MediaProducer>>,
+	_owner: BroadcastOwner,
 }
 
 #[derive(uniffi::Object)]
 pub struct MoqMediaStreamProducer {
 	inner: std::sync::Mutex<Option<MediaStreamProducer>>,
+	_owner: BroadcastOwner,
 }
 
 #[uniffi::export]
@@ -132,7 +150,14 @@ impl MoqBroadcastProducer {
 	/// Create a consumer that reads from this broadcast's tracks.
 	pub fn consume(&self) -> Result<Arc<MoqBroadcastConsumer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		Ok(Arc::new(MoqBroadcastConsumer::new(self.consume_inner()?)))
+		let guard = self.state.lock().unwrap();
+		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
+		Ok(Arc::new(MoqBroadcastConsumer::new_with_owner(
+			state.broadcast.consume(),
+			BroadcastOwner {
+				_inner: state.broadcast.clone(),
+			},
+		)))
 	}
 
 	/// Create a dynamic producer that yields tracks requested by subscribers.
@@ -145,7 +170,8 @@ impl MoqBroadcastProducer {
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
 		Ok(Arc::new(MoqBroadcastDynamic {
 			task: Task::new(DynamicProducer {
-				inner: state.broadcast.dynamic(),
+				inner: Some(state.broadcast.dynamic()),
+				owner: state.broadcast.clone(),
 			}),
 		}))
 	}
@@ -174,6 +200,9 @@ impl MoqBroadcastProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
+		let owner = BroadcastOwner {
+			_inner: state.broadcast.clone(),
+		};
 		// A container may publish several tracks; a single codec fills one minted
 		// track. Try the container first so a codec format doesn't mint a stray
 		// track on the way to being recognized.
@@ -200,6 +229,7 @@ impl MoqBroadcastProducer {
 
 		Ok(Arc::new(MoqMediaProducer {
 			inner: std::sync::Mutex::new(Some(MediaProducer { decoder, demand })),
+			_owner: owner,
 		}))
 	}
 
@@ -217,6 +247,9 @@ impl MoqBroadcastProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
+		let owner = BroadcastOwner {
+			_inner: state.broadcast.clone(),
+		};
 		let track_clone = {
 			let guard = track.inner.lock().unwrap();
 			guard.as_ref().ok_or_else(|| MoqError::Closed)?.clone()
@@ -234,6 +267,7 @@ impl MoqBroadcastProducer {
 				decoder: MediaDecoder::Track(Box::new(import)),
 				demand: Some(demand),
 			})),
+			_owner: owner,
 		}))
 	}
 
@@ -247,6 +281,9 @@ impl MoqBroadcastProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.state.lock().unwrap();
 		let state = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
+		let owner = BroadcastOwner {
+			_inner: state.broadcast.clone(),
+		};
 		// A container stream may publish several tracks; a single codec fills one
 		// minted track. Try the container first so a codec format doesn't mint a
 		// stray track on the way to being recognized.
@@ -270,6 +307,7 @@ impl MoqBroadcastProducer {
 
 		Ok(Arc::new(MoqMediaStreamProducer {
 			inner: std::sync::Mutex::new(Some(MediaStreamProducer { decoder })),
+			_owner: owner,
 		}))
 	}
 
@@ -287,6 +325,9 @@ impl MoqBroadcastProducer {
 		let producer = broadcast.create_track(track)?;
 		Ok(Arc::new(MoqTrackProducer {
 			inner: std::sync::Mutex::new(Some(producer)),
+			_owner: Some(BroadcastOwner {
+				_inner: state.broadcast.clone(),
+			}),
 		}))
 	}
 
@@ -335,16 +376,25 @@ impl MoqBroadcastProducer {
 impl MoqBroadcastDynamic {
 	/// Wait for the next subscriber-requested track.
 	///
-	/// Returns an error once the broadcast is closed or aborted.
+	/// Returns an error once the broadcast is closed, aborted, or the dynamic
+	/// producer is closed.
 	pub async fn requested_track(&self) -> Result<Arc<MoqTrackProducer>, MoqError> {
 		self.task
 			.run(|mut state| async move { state.requested_track().await })
 			.await
 	}
 
+	/// Close the dynamic producer and cancel all current and future `requested_track()` calls.
+	pub fn close(&self) {
+		self.task.cancel();
+		if let Some(mut state) = self.task.lock() {
+			state.close();
+		}
+	}
+
 	/// Cancel all current and future `requested_track()` calls.
 	pub fn cancel(&self) {
-		self.task.cancel();
+		self.close();
 	}
 }
 
@@ -353,6 +403,7 @@ impl MoqBroadcastDynamic {
 #[derive(uniffi::Object)]
 pub struct MoqTrackProducer {
 	inner: std::sync::Mutex<Option<moq_net::TrackProducer>>,
+	_owner: Option<BroadcastOwner>,
 }
 
 #[uniffi::export]
@@ -392,7 +443,11 @@ impl MoqTrackProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.inner.lock().unwrap();
 		let track = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
-		Ok(Arc::new(MoqTrackConsumer::new(track.consume())))
+		Ok(Arc::new(MoqTrackConsumer::new_with_track_owner(
+			track.consume(),
+			track.clone(),
+			self._owner.clone(),
+		)))
 	}
 
 	/// Append a new group to the track, returning a producer for writing frames into it.
@@ -403,6 +458,8 @@ impl MoqTrackProducer {
 		let group = track.append_group()?;
 		Ok(Arc::new(MoqGroupProducer {
 			sequence: group.sequence,
+			_track_owner: track.clone(),
+			_broadcast_owner: self._owner.clone(),
 			inner: std::sync::Mutex::new(Some(group)),
 		}))
 	}
@@ -439,6 +496,8 @@ impl MoqTrackProducer {
 #[derive(uniffi::Object)]
 pub struct MoqGroupProducer {
 	sequence: u64,
+	_track_owner: moq_net::TrackProducer,
+	_broadcast_owner: Option<BroadcastOwner>,
 	inner: std::sync::Mutex<Option<moq_net::GroupProducer>>,
 }
 
@@ -454,7 +513,10 @@ impl MoqGroupProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.inner.lock().unwrap();
 		let group = guard.as_ref().ok_or_else(|| MoqError::Closed)?;
-		Ok(Arc::new(MoqGroupConsumer::new(group.consume())))
+		Ok(Arc::new(MoqGroupConsumer::new_with_owner(
+			group.consume(),
+			group.clone(),
+		)))
 	}
 
 	/// Write a frame into this group.

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -115,6 +115,21 @@ async fn dynamic_track_request_can_abort() {
 }
 
 #[tokio::test]
+async fn dynamic_close_rejects_unknown_tracks() {
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let dynamic = broadcast.dynamic().unwrap();
+	let consumer = broadcast.consume().unwrap();
+
+	dynamic.close();
+
+	let err = consumer
+		.subscribe_track("unknown".into())
+		.err()
+		.expect("unknown track should be rejected after dynamic close");
+	assert!(matches!(err, MoqError::Protocol(moq_net::Error::NotFound)));
+}
+
+#[tokio::test]
 async fn dynamic_track_request_can_publish_media() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let dynamic = broadcast.dynamic().unwrap();
@@ -256,6 +271,102 @@ async fn local_publish_consume_audio() {
 
 	assert_eq!(frame.payload, payload);
 	assert_eq!(frame.timestamp_us, 1_000_000);
+}
+
+#[tokio::test]
+async fn published_media_keeps_catalog_available_after_broadcast_drop() {
+	let origin = MoqOriginProducer::new();
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let media = broadcast.publish_media("opus".into(), opus_head()).unwrap();
+	origin.publish("live".into(), &broadcast).unwrap();
+	drop(broadcast);
+
+	let consumer = origin.consume();
+	let announced = consumer.announced_broadcast("live".into()).unwrap();
+	let broadcast_consumer = tokio::time::timeout(TIMEOUT, announced.available())
+		.await
+		.expect("timed out waiting for announcement")
+		.unwrap();
+	let catalog_consumer = broadcast_consumer.subscribe_catalog().unwrap();
+	let catalog = tokio::time::timeout(TIMEOUT, catalog_consumer.next())
+		.await
+		.expect("timed out waiting for catalog")
+		.unwrap()
+		.expect("expected a catalog");
+
+	assert_eq!(catalog.audio.len(), 1);
+	let (track_name, audio) = catalog.audio.iter().next().unwrap();
+	let media_consumer = broadcast_consumer
+		.subscribe_media(track_name.clone(), audio.container.clone(), 10_000)
+		.unwrap();
+
+	let payload = b"opus audio payload data".to_vec();
+	media.write_frame(payload.clone(), 2_000_000).unwrap();
+	let frame = tokio::time::timeout(TIMEOUT, media_consumer.next())
+		.await
+		.expect("timed out waiting for frame")
+		.unwrap()
+		.expect("expected a frame");
+
+	assert_eq!(frame.payload, payload);
+	assert_eq!(frame.timestamp_us, 2_000_000);
+}
+
+#[tokio::test]
+async fn published_track_stays_subscribable_after_broadcast_drop() {
+	let origin = MoqOriginProducer::new();
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let track = broadcast.publish_track("status".into()).unwrap();
+	origin.publish("live".into(), &broadcast).unwrap();
+	drop(broadcast);
+
+	let consumer = origin.consume();
+	let announced = consumer.announced_broadcast("live".into()).unwrap();
+	let broadcast_consumer = tokio::time::timeout(TIMEOUT, announced.available())
+		.await
+		.expect("timed out waiting for announcement")
+		.unwrap();
+	let track_consumer = broadcast_consumer.subscribe_track("status".into()).unwrap();
+
+	let payload = b"online".to_vec();
+	track.write_frame(payload.clone()).unwrap();
+	let frame = tokio::time::timeout(TIMEOUT, track_consumer.read_frame())
+		.await
+		.expect("timed out waiting for frame")
+		.unwrap()
+		.expect("expected a frame");
+
+	assert_eq!(frame, payload);
+}
+
+#[tokio::test]
+async fn appended_group_keeps_track_subscribable_after_parent_drops() {
+	let origin = MoqOriginProducer::new();
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let track = broadcast.publish_track("status".into()).unwrap();
+	let group = track.append_group().unwrap();
+	origin.publish("live".into(), &broadcast).unwrap();
+	drop(track);
+	drop(broadcast);
+
+	let consumer = origin.consume();
+	let announced = consumer.announced_broadcast("live".into()).unwrap();
+	let broadcast_consumer = tokio::time::timeout(TIMEOUT, announced.available())
+		.await
+		.expect("timed out waiting for announcement")
+		.unwrap();
+	let track_consumer = broadcast_consumer.subscribe_track("status".into()).unwrap();
+
+	let payload = b"online".to_vec();
+	group.write_frame(payload.clone()).unwrap();
+	group.finish().unwrap();
+	let frame = tokio::time::timeout(TIMEOUT, track_consumer.read_frame())
+		.await
+		.expect("timed out waiting for frame")
+		.unwrap()
+		.expect("expected a frame");
+
+	assert_eq!(frame, payload);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- keep `moq-ffi` child producer and consumer handles alive with the `BroadcastProducer` owner they depend on
- add `MoqBroadcastDynamic.close()` and make `cancel()` close the dynamic handler so unknown tracks return `NotFound` immediately
- add regressions for dropped parent broadcast handles and dynamic close behavior

## Root Cause
FFI child handles could outlive the visible parent wrapper in GC/ARC languages. When the parent `MoqBroadcastProducer` was collected, the underlying broadcast lookup could be dropped even though media, audio, raw track, or group producers were still active. That made tracks such as `catalog.json` disappear mid-stream. Dynamic handlers are intentionally not retained by children because their existence changes unknown-track routing semantics.

## Validation
- `CARGO_TARGET_DIR=target cargo test -p moq-ffi`
- `CARGO_TARGET_DIR=target cargo check --all-targets -p moq-ffi`
- `CARGO_TARGET_DIR=target cargo clippy --all-targets -p moq-ffi -- -D warnings`
- `cargo fmt --all --check`
- `CARGO_TARGET_DIR=target RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moq-ffi`

(Written by GPT-5)
