### PR TITLE
[codex] fix AAC catalog description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4845,9 +4845,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -193,6 +193,33 @@ async fn media_track_activity_and_name() {
 		.unwrap();
 }
 
+#[tokio::test]
+async fn publish_media_aac_populates_description() {
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let config = moq_mux::codec::aac::Config {
+		profile: 2,
+		sample_rate: 44_100,
+		channel_count: 2,
+	};
+	let init = config.encode();
+	let _media = broadcast.publish_media("aac".into(), init.to_vec()).unwrap();
+
+	let consumer = broadcast.consume().unwrap();
+	let catalog_consumer = consumer.subscribe_catalog().unwrap();
+	let catalog = tokio::time::timeout(TIMEOUT, catalog_consumer.next())
+		.await
+		.expect("timed out waiting for catalog")
+		.unwrap()
+		.expect("expected a catalog");
+
+	assert_eq!(catalog.audio.len(), 1);
+	let audio = catalog.audio.values().next().unwrap();
+	assert_eq!(audio.codec, "mp4a.40.2");
+	assert_eq!(audio.sample_rate, config.sample_rate);
+	assert_eq!(audio.channel_count, config.channel_count);
+	assert_eq!(audio.description.as_deref(), Some(init.as_ref()));
+}
+
 #[test]
 fn unknown_format() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -30,6 +30,7 @@ impl<E: CatalogExt> Import<E> {
 			config.channel_count,
 		);
 		audio_config.container = hang::catalog::Container::Legacy;
+		audio_config.description = Some(config.encode());
 
 		tracing::debug!(name = ?track.name(), config = ?audio_config, "starting track");
 

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -543,6 +543,28 @@ mod tests {
 	}
 
 	#[tokio::test(start_paused = true)]
+	async fn aac_import_attaches_audio_specific_config() {
+		let (mut broadcast, catalog) = new_broadcast();
+		let config = crate::codec::aac::Config {
+			profile: 2,
+			sample_rate: 44_100,
+			channel_count: 2,
+		};
+		let init = config.encode();
+		let request = broadcast.create_track(moq_net::Track::new("audio")).unwrap();
+
+		let import = Track::new(request, catalog.clone(), "aac", init.as_ref()).unwrap();
+
+		assert_eq!(import.name(), "audio");
+		let snapshot = catalog.snapshot();
+		let audio = snapshot.audio.renditions.get("audio").unwrap();
+		assert_eq!(audio.codec.to_string(), "mp4a.40.2");
+		assert_eq!(audio.sample_rate, config.sample_rate);
+		assert_eq!(audio.channel_count, config.channel_count);
+		assert_eq!(audio.description.as_deref(), Some(init.as_ref()));
+	}
+
+	#[tokio::test(start_paused = true)]
 	async fn unique_track_opus_attaches_catalog_and_retires_on_drop() {
 		let (mut broadcast, catalog) = new_broadcast();
 


### PR DESCRIPTION
## Summary

- Populate AAC catalog `description` inside the AAC importer from the configured track metadata.
- Add mux and FFI regressions that verify AAC publishes `mp4a.40.2`, sample metadata, and a matching AudioSpecificConfig description.
- Update the yanked `num-bigint` lockfile entry from `0.4.7` to `0.4.8` so `cargo deny` passes in CI.

## Root Cause

The AAC importer parsed the AudioSpecificConfig to populate codec, sample rate, and channel count, but it left the catalog `description` empty. Downstream consumers such as `moq-cli` require an AudioSpecificConfig description to initialize AAC decoding.

## Issue

Part of #2087. This fixes the AAC catalog/AudioSpecificConfig bug, but does not address the separate broadcast lifetime behavior discussed in the issue.

## Public API Changes

None. This preserves existing API shape and fixes catalog contents.

## Cross-Package Sync

No wrapper or docs update needed because this is behavior inside the shared Rust `moq-ffi`/`moq-mux` implementation. The Go, Python, Swift, and Kotlin bindings use this same path.

## Tests

- `cargo test -p moq-ffi`
- `cargo test -p moq-mux`
- `cargo test -p moq-mux -p moq-ffi`
- `cargo deny check --show-stats`
- `git diff --check`

(Written by GPT-5)
