### PR TITLE
Route subscribes through dynamic origins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4845,9 +4845,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -139,7 +139,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		// Prefer an announced broadcast, but allow a dynamic origin to serve
 		// unannounced namespaces such as edge-local dashboard stats.
-		let broadcast = match self.origin.request_broadcast(&msg.track_namespace).await {
+		let broadcast = self.origin.request_broadcast(&msg.track_namespace);
+		let broadcast = std::pin::pin!(broadcast);
+		let broadcast = match broadcast.await {
 			Ok(broadcast) => broadcast,
 			Err(err) => {
 				self.write_subscribe_error(&mut stream.writer, request_id, 404, &err.to_string())

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -137,12 +137,15 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// validated and active, below.
 		let track_stats = std::sync::Arc::new(self.stats.broadcast(&absolute).publisher_track(&track_name));
 
-		// We just received a subscribe for this exact namespace, so the peer must have already
-		// seen the announcement — synchronous lookup is appropriate here.
-		let Some(broadcast) = self.origin.get_broadcast(&msg.track_namespace) else {
-			self.write_subscribe_error(&mut stream.writer, request_id, 404, "Broadcast not found")
-				.await?;
-			return Ok(());
+		// Prefer an announced broadcast, but allow a dynamic origin to serve
+		// unannounced namespaces such as edge-local dashboard stats.
+		let broadcast = match self.origin.request_broadcast(&msg.track_namespace).await {
+			Ok(broadcast) => broadcast,
+			Err(err) => {
+				self.write_subscribe_error(&mut stream.writer, request_id, 404, &err.to_string())
+					.await?;
+				return Ok(());
+			}
 		};
 
 		let track = Track {

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -139,9 +139,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		// Prefer an announced broadcast, but allow a dynamic origin to serve
 		// unannounced namespaces such as edge-local dashboard stats.
-		let broadcast = self.origin.request_broadcast(&msg.track_namespace);
-		let broadcast = std::pin::pin!(broadcast);
-		let broadcast = match broadcast.await {
+		let broadcast = match self.origin.request_broadcast(&msg.track_namespace).await {
 			Ok(broadcast) => broadcast,
 			Err(err) => {
 				self.write_subscribe_error(&mut stream.writer, request_id, 404, &err.to_string())

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -139,13 +139,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		// Prefer an announced broadcast, but allow a dynamic origin to serve
 		// unannounced namespaces such as edge-local dashboard stats.
-		let broadcast = match self.origin.request_broadcast(&msg.track_namespace).await {
-			Ok(broadcast) => broadcast,
-			Err(err) => {
-				self.write_subscribe_error(&mut stream.writer, request_id, 404, &err.to_string())
-					.await?;
-				return Ok(());
-			}
+		let Ok(broadcast) = self.origin.request_broadcast(&msg.track_namespace).await else {
+			self.write_subscribe_error(&mut stream.writer, request_id, 404, "Broadcast not found")
+				.await?;
+			return Ok(());
 		};
 
 		let track = Track {

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -424,7 +424,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		consumer: kio::Pending<BroadcastRequested>,
 		name: String,
 	) -> Result<(), Error> {
-		let consumer = std::pin::pin!(consumer);
 		let broadcast = consumer.await?;
 		// Resolve the track to read its publisher properties. The query carries no
 		// priority; a reused producer reports its own authored value.
@@ -462,7 +461,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			priority: subscribe.priority,
 		};
 
-		let consumer = std::pin::pin!(consumer);
 		let broadcast = consumer.await?;
 		let mut track = broadcast.subscribe_track(&track)?;
 

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -5,7 +5,7 @@ use web_async::FuturesExt;
 use web_transport_trait::Stats;
 
 use crate::{
-	AsPath, BroadcastConsumer, Error, Origin, OriginConsumer, OriginList, StatsHandle as MoqStats, Track,
+	AsPath, BroadcastRequested, Error, Origin, OriginConsumer, OriginList, StatsHandle as MoqStats, Track,
 	TrackConsumer,
 	coding::{Stream, Writer},
 	lite::{
@@ -374,7 +374,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				session,
 				&mut stream,
 				&subscribe,
-				broadcast.await,
+				broadcast,
 				priority,
 				(track_stats, broadcasts, absolute.clone()),
 				version,
@@ -410,7 +410,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let broadcast = self.origin.request_broadcast(&msg.broadcast);
 
 		web_async::spawn(async move {
-			if let Err(err) = Self::run_track_info(&mut stream, broadcast.await, name).await {
+			if let Err(err) = Self::run_track_info(&mut stream, broadcast, name).await {
 				tracing::debug!(broadcast = %absolute, %err, "track info error");
 				stream.writer.abort(&err);
 			}
@@ -421,10 +421,11 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 	async fn run_track_info(
 		stream: &mut Stream<S, Version>,
-		consumer: Result<BroadcastConsumer, Error>,
+		consumer: kio::Pending<BroadcastRequested>,
 		name: String,
 	) -> Result<(), Error> {
-		let broadcast = consumer?;
+		let consumer = std::pin::pin!(consumer);
+		let broadcast = consumer.await?;
 		// Resolve the track to read its publisher properties. The query carries no
 		// priority; a reused producer reports its own authored value.
 		let track = broadcast.subscribe_track(&Track { name, priority: 0 })?;
@@ -447,7 +448,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		session: S,
 		stream: &mut Stream<S, Version>,
 		subscribe: &lite::Subscribe<'_>,
-		consumer: Result<BroadcastConsumer, Error>,
+		consumer: kio::Pending<BroadcastRequested>,
 		priority: PriorityQueue,
 		// The track guard (bumps `subscriptions`), the per-session broadcast
 		// tracker, and the broadcast path. The `broadcasts` sentinel is taken
@@ -461,7 +462,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			priority: subscribe.priority,
 		};
 
-		let broadcast = consumer?;
+		let consumer = std::pin::pin!(consumer);
+		let broadcast = consumer.await?;
 		let mut track = broadcast.subscribe_track(&track)?;
 
 		// Subscription is now active: count this session as a viewer of the

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -355,9 +355,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		tracing::info!(%id, broadcast = %absolute, %track, "subscribed started");
 
-		// We just received a subscribe for this exact path, so by definition the peer has
-		// already seen an announcement for it — synchronous lookup is appropriate here.
-		let broadcast = self.origin.get_broadcast(&subscribe.broadcast);
+		// Prefer an announced broadcast, but allow a dynamic origin to serve
+		// unannounced paths such as edge-local dashboard stats.
+		let broadcast = self.origin.request_broadcast(&subscribe.broadcast);
 		let priority = self.priority.clone();
 		let version = self.version;
 
@@ -374,7 +374,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				session,
 				&mut stream,
 				&subscribe,
-				broadcast,
+				broadcast.await,
 				priority,
 				(track_stats, broadcasts, absolute.clone()),
 				version,
@@ -407,10 +407,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let name = msg.track.to_string();
 		tracing::debug!(broadcast = %absolute, track = %name, "track info requested");
 
-		let broadcast = self.origin.get_broadcast(&msg.broadcast);
+		let broadcast = self.origin.request_broadcast(&msg.broadcast);
 
 		web_async::spawn(async move {
-			if let Err(err) = Self::run_track_info(&mut stream, broadcast, name).await {
+			if let Err(err) = Self::run_track_info(&mut stream, broadcast.await, name).await {
 				tracing::debug!(broadcast = %absolute, %err, "track info error");
 				stream.writer.abort(&err);
 			}
@@ -421,10 +421,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 	async fn run_track_info(
 		stream: &mut Stream<S, Version>,
-		consumer: Option<BroadcastConsumer>,
+		consumer: Result<BroadcastConsumer, Error>,
 		name: String,
 	) -> Result<(), Error> {
-		let broadcast = consumer.ok_or(Error::NotFound)?;
+		let broadcast = consumer?;
 		// Resolve the track to read its publisher properties. The query carries no
 		// priority; a reused producer reports its own authored value.
 		let track = broadcast.subscribe_track(&Track { name, priority: 0 })?;
@@ -447,7 +447,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		session: S,
 		stream: &mut Stream<S, Version>,
 		subscribe: &lite::Subscribe<'_>,
-		consumer: Option<BroadcastConsumer>,
+		consumer: Result<BroadcastConsumer, Error>,
 		priority: PriorityQueue,
 		// The track guard (bumps `subscriptions`), the per-session broadcast
 		// tracker, and the broadcast path. The `broadcasts` sentinel is taken
@@ -461,7 +461,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			priority: subscribe.priority,
 		};
 
-		let broadcast = consumer.ok_or(Error::NotFound)?;
+		let broadcast = consumer?;
 		let mut track = broadcast.subscribe_track(&track)?;
 
 		// Subscription is now active: count this session as a viewer of the


### PR DESCRIPTION
## Summary

- Route Lite `SUBSCRIBE` and `TRACK` lookups through `OriginConsumer::request_broadcast`.
- Route IETF `SUBSCRIBE` lookups through `OriginConsumer::request_broadcast`.
- Pass `kio::Pending<BroadcastRequested>` into the Lite per-subscribe/per-track tasks so the dynamic request is awaited inside the task.
- Update the yanked `num-bigint` lockfile entry that was failing CI.

Note: `kio::Pending` handles the pinning internally, so the task only needs to own and await the pending request.

## Why

`OriginProducer::dynamic()` serves broadcasts on demand without announcing them. The publisher subscribe paths were doing synchronous `get_broadcast` lookups, so a valid dynamic broadcast such as `.dash/<pid>` could return not found unless it had also been announced. Dashboard stats for idle projects depend on dynamic serving because there may be no active project broadcasts to announce.

## get_broadcast audit

I checked the other `get_broadcast` call sites:

- `rs/libmoq/src/origin.rs` is a deliberately synchronous FFI/API lookup, with `consume_announced` available for waiting.
- `rs/moq-net/src/model/origin.rs` contains the `get_broadcast` implementation, the announced-first branch inside `request_broadcast`, and tests for synchronous lookup semantics.
- The Lite and IETF publisher subscribe/request paths were the request-time lookups that needed dynamic fallback and are updated here.

## Validation

- `cargo fmt -p moq-net --check`
- `cargo check -p moq-net`
- `cargo deny check advisories`
- Downstream dashboard checked against this commit with `cargo check -p edge -p stats`.
- Downstream dashboard CDN pin check passed with `just cdn check`.
