### PR TITLE
[codex] Keep parent models alive from children

### DIFF
--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -716,7 +716,8 @@ mod test {
 	use crate::{Timestamp, broadcast};
 
 	fn track_producer(name: impl Into<Arc<str>>) -> track::Producer {
-		track::Producer::new(Arc::new(broadcast::Info::default()), name, None)
+		let broadcast = broadcast::Info::default().produce();
+		track::Producer::new(broadcast.keepalive(), name, None)
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -128,7 +128,7 @@ impl Producer {
 		info: impl Into<Option<track::Info>>,
 	) -> Result<track::Producer, Error> {
 		let info = info.into().unwrap_or_default();
-		let track = track::Producer::new(self.info.clone(), name, info);
+		let track = track::Producer::new(self.keepalive(), name, info);
 		let mut state = BroadcastState::modify(&self.state)?;
 		state.insert_track(track.weak())?;
 		drop(state);
@@ -143,7 +143,7 @@ impl Producer {
 	/// inspected the media, the same shape as a consumer-driven
 	/// [`Dynamic::requested_track`].
 	pub fn reserve_track(&mut self, name: impl Into<Arc<str>>) -> Result<track::Request, Error> {
-		let request = track::Request::new(self.info.clone(), name);
+		let request = track::Request::new(self.keepalive(), name);
 		let mut state = BroadcastState::modify(&self.state)?;
 		state.insert_track(request.weak())?;
 		drop(state);
@@ -192,6 +192,61 @@ impl Producer {
 	/// Return true if this is the same broadcast instance.
 	pub fn is_clone(&self, other: &Self) -> bool {
 		self.state.same_channel(&other.state)
+	}
+
+	pub(crate) fn keepalive(&self) -> Keepalive {
+		Keepalive {
+			info: self.info.clone(),
+			_state: self.state.clone(),
+		}
+	}
+}
+
+#[derive(Clone)]
+pub(crate) struct Keepalive {
+	info: Arc<Info>,
+	_state: kio::Producer<BroadcastState>,
+}
+
+impl Keepalive {
+	pub(crate) fn info(&self) -> &Info {
+		&self.info
+	}
+}
+
+#[derive(Clone)]
+pub(crate) struct KeepaliveWeak {
+	info: Arc<Info>,
+	state: kio::Weak<BroadcastState>,
+}
+
+#[derive(Clone)]
+pub(crate) enum KeepaliveRef {
+	Strong(Keepalive),
+	Weak(KeepaliveWeak),
+}
+
+impl KeepaliveRef {
+	pub(crate) fn upgrade(&self) -> Result<Keepalive, Error> {
+		Ok(match self {
+			Self::Strong(parent) => parent.clone(),
+			Self::Weak(parent) => Keepalive {
+				info: parent.info.clone(),
+				_state: parent.state.produce().ok_or(Error::Dropped)?,
+			},
+		})
+	}
+}
+
+impl From<Keepalive> for KeepaliveRef {
+	fn from(value: Keepalive) -> Self {
+		Self::Strong(value)
+	}
+}
+
+impl From<KeepaliveWeak> for KeepaliveRef {
+	fn from(value: KeepaliveWeak) -> Self {
+		Self::Weak(value)
 	}
 }
 
@@ -272,7 +327,11 @@ impl Dynamic {
 		}))?;
 
 		let name = state.request_order.pop_front().expect("predicate guaranteed a request");
-		let pending = state.requests.remove(&name).expect("request_order out of sync");
+		let mut pending = state.requests.remove(&name).expect("request_order out of sync");
+		pending.strengthen_parent(Keepalive {
+			info: self.info.clone(),
+			_state: self.state.clone(),
+		});
 		state.tracks.insert(name, pending.weak());
 		Poll::Ready(Ok(pending))
 	}
@@ -346,6 +405,13 @@ impl Consumer {
 		&self.info
 	}
 
+	fn weak_keepalive(&self) -> KeepaliveWeak {
+		KeepaliveWeak {
+			info: self.info.clone(),
+			state: self.state.weak(),
+		}
+	}
+
 	/// Get a handle to a track on this broadcast.
 	pub fn track(&self, name: &str) -> Result<track::Consumer, Error> {
 		// Upgrade to a temporary producer so we can modify the state.
@@ -375,7 +441,7 @@ impl Consumer {
 		// Allocate the name once and share the same Arc across the request, the
 		// requests map, and the FIFO order.
 		let name: Arc<str> = name.into();
-		let request = track::Request::new(self.info.clone(), name.clone());
+		let request = track::Request::new(self.weak_keepalive(), name.clone());
 		let consumer = request.consume();
 
 		state.requests.insert(name.clone(), request);
@@ -491,6 +557,19 @@ mod test {
 		// track1's producer is held outside the broadcast, so it survives.
 		assert!(!track1.is_closed());
 		track1c.assert_not_closed();
+	}
+
+	#[tokio::test]
+	async fn active_track_keeps_broadcast_alive() {
+		let mut producer = Info::new().produce();
+		let consumer = producer.consume();
+		let track = producer.assert_create_track("track", None);
+
+		drop(producer);
+		consumer.assert_not_closed();
+
+		drop(track);
+		consumer.assert_closed();
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -391,6 +391,9 @@ impl Producer {
 	}
 
 	fn abort_inner(&mut self, err: Error) -> Result<()> {
+		if matches!(&err, Error::Dropped) {
+			super::warn_dropped_abort("frame");
+		}
 		let mut guard = self.modify()?;
 		guard.abort = Some(err);
 		guard.close();

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -1,7 +1,9 @@
 use crate::group;
-use std::sync::Arc;
 use std::sync::OnceLock;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{
+	Arc,
+	atomic::{AtomicBool, AtomicUsize, Ordering},
+};
 use std::task::{Poll, ready};
 
 use bytes::Bytes;
@@ -185,6 +187,12 @@ struct FrameState {
 	abort: Option<Error>,
 }
 
+#[derive(Default)]
+struct WriterState {
+	writers: AtomicUsize,
+	terminal: AtomicBool,
+}
+
 /// Writes a frame's payload in one or more chunks.
 ///
 /// The total bytes written must exactly match [Info::size].
@@ -193,20 +201,16 @@ struct FrameState {
 /// A single whole-frame [`write`](Self::write) keeps the caller's allocation
 /// (zero-copy); chunked writes copy into one buffer sized to the declared frame.
 pub struct Producer {
-	info: Info,
-	// The parent group's info, inherited from [`group::Producer::create_frame`]
-	// so the ownership chain reaches the leaf. A small `Copy` value; carried for
-	// identity/debugging (the timestamp-vs-timescale check lives on the group).
-	group: group::Info,
-	state: kio::Producer<FrameState>,
-	buf: FrameBuf,
+	cache: Cache,
+	parent: Option<group::Keepalive>,
+	writers: Arc<WriterState>,
 }
 
 impl std::ops::Deref for Producer {
 	type Target = Info;
 
 	fn deref(&self) -> &Self::Target {
-		&self.info
+		&self.cache.info
 	}
 }
 
@@ -216,27 +220,59 @@ impl Producer {
 	/// The payload storage chokepoint: rejects a frame whose declared
 	/// [`Info::size`] exceeds [`MAX_FRAME_SIZE`] with [`Error::FrameTooLarge`]
 	/// before storing the untrusted payload.
+	#[cfg(test)]
 	pub(crate) fn new(info: Info, group: group::Info) -> Result<Self> {
 		if info.size > MAX_FRAME_SIZE {
 			return Err(Error::FrameTooLarge);
 		}
 		let buf = FrameBuf::new(info.size as usize);
 		Ok(Self {
-			info,
-			group,
-			state: kio::Producer::new(FrameState::default()),
-			buf,
+			cache: Cache {
+				info,
+				group,
+				state: kio::Producer::new(FrameState::default()),
+				buf,
+			},
+			parent: None,
+			writers: Arc::new(WriterState {
+				writers: AtomicUsize::new(1),
+				terminal: AtomicBool::new(false),
+			}),
 		})
+	}
+
+	pub(crate) fn with_parent(info: Info, group: group::Info, parent: group::Keepalive) -> Result<Self> {
+		if info.size > MAX_FRAME_SIZE {
+			return Err(Error::FrameTooLarge);
+		}
+		let buf = FrameBuf::new(info.size as usize);
+		Ok(Self {
+			cache: Cache {
+				info,
+				group,
+				state: kio::Producer::new(FrameState::default()),
+				buf,
+			},
+			parent: Some(parent),
+			writers: Arc::new(WriterState {
+				writers: AtomicUsize::new(1),
+				terminal: AtomicBool::new(false),
+			}),
+		})
+	}
+
+	pub(crate) fn cache(&self) -> Cache {
+		self.cache.clone()
 	}
 
 	/// The parent group this frame belongs to.
 	pub fn group(&self) -> &group::Info {
-		&self.group
+		&self.cache.group
 	}
 
 	/// Bytes still needed to complete the frame.
 	pub fn remaining(&self) -> usize {
-		self.buf.capacity() - self.buf.written(Ordering::Acquire)
+		self.cache.buf.capacity() - self.cache.buf.written(Ordering::Acquire)
 	}
 
 	/// Write a chunk of data to the frame.
@@ -250,13 +286,13 @@ impl Producer {
 		// Surface aborts before writing.
 		self.bail_if_aborted()?;
 		// Fast path: a single whole-frame write keeps the caller's allocation.
-		if len == self.buf.capacity() && self.buf.written(Ordering::Acquire) == 0 {
-			match self.buf.try_set_bytes(chunk.into_bytes()) {
+		if len == self.cache.buf.capacity() && self.cache.buf.written(Ordering::Acquire) == 0 {
+			match self.cache.buf.try_set_bytes(chunk.into_bytes()) {
 				Ok(()) => {
-					let cap = self.buf.capacity();
+					let cap = self.cache.buf.capacity();
 					// Safety: `try_set_bytes` checked that the buffer exactly matches
 					// the declared size, so publishing all bytes is within bounds.
-					unsafe { self.buf.store_written(cap) };
+					unsafe { self.cache.buf.store_written(cap) };
 					self.notify_written(cap);
 					return Ok(());
 				}
@@ -276,8 +312,8 @@ impl Producer {
 		if src.is_empty() {
 			return;
 		}
-		let prev = self.buf.written(Ordering::Relaxed);
-		let Some(buf) = self.buf.mutable() else {
+		let prev = self.cache.buf.written(Ordering::Relaxed);
+		let Some(buf) = self.cache.buf.mutable() else {
 			// Only reachable if the frame is already complete, which `write` rejects
 			// for a non-empty chunk. Nothing to copy.
 			return;
@@ -286,7 +322,7 @@ impl Producer {
 		// remaining capacity, and consumers only read `[..written]`.
 		unsafe {
 			std::ptr::copy_nonoverlapping(src.as_ptr(), buf.data.add(prev), src.len());
-			self.buf.store_written(prev + src.len());
+			self.cache.buf.store_written(prev + src.len());
 		}
 		self.notify_written(prev + src.len());
 	}
@@ -295,50 +331,48 @@ impl Producer {
 	///
 	/// Returns [Error::WrongSize] if the bytes written don't match [Info::size].
 	pub fn finish(&mut self) -> Result<()> {
-		let written = self.buf.written(Ordering::Acquire);
-		if written != self.buf.capacity() {
+		let written = self.cache.buf.written(Ordering::Acquire);
+		if written != self.cache.buf.capacity() {
 			return Err(Error::WrongSize);
 		}
 		// Mark fin (idempotent if the last write already set it on the final byte).
 		let mut state = self.modify()?;
 		state.fin = true;
+		drop(state);
+		self.writers.terminal.store(true, Ordering::Release);
 		Ok(())
 	}
 
 	/// Abort the frame with the given error.
 	pub fn abort(&mut self, err: Error) -> Result<()> {
-		let mut guard = self.modify()?;
-		guard.abort = Some(err);
-		guard.close();
+		self.abort_inner(err)?;
+		self.writers.terminal.store(true, Ordering::Release);
 		Ok(())
 	}
 
 	/// Create a new consumer for the frame.
 	pub fn consume(&self) -> Consumer {
-		Consumer {
-			info: self.info,
-			state: self.state.consume(),
-			buf: self.buf.clone(),
-			read_idx: 0,
-		}
+		self.cache.consume()
 	}
 
 	/// Block until there are no active consumers.
 	pub async fn unused(&self) -> Result<()> {
-		self.state
+		self.cache
+			.state
 			.unused()
 			.await
 			.map_err(|r| r.abort.clone().unwrap_or(Error::Dropped))
 	}
 
 	fn modify(&mut self) -> Result<kio::Mut<'_, FrameState>> {
-		self.state
+		self.cache
+			.state
 			.write()
 			.map_err(|r| r.abort.clone().unwrap_or(Error::Dropped))
 	}
 
 	fn bail_if_aborted(&self) -> Result<()> {
-		let state = self.state.read();
+		let state = self.cache.state.read();
 		if let Some(err) = &state.abort {
 			return Err(err.clone());
 		}
@@ -348,21 +382,69 @@ impl Producer {
 	fn notify_written(&mut self, written: usize) {
 		// Briefly take the kio write lock to wake waiters; drop of `Mut` triggers
 		// kio's notify. Also flip `fin` if we just filled the buffer.
-		if let Ok(mut state) = self.state.write()
-			&& written == self.buf.capacity()
+		if let Ok(mut state) = self.cache.state.write()
+			&& written == self.cache.buf.capacity()
 		{
 			state.fin = true;
+			self.writers.terminal.store(true, Ordering::Release);
 		}
+	}
+
+	fn abort_inner(&mut self, err: Error) -> Result<()> {
+		let mut guard = self.modify()?;
+		guard.abort = Some(err);
+		guard.close();
+		Ok(())
 	}
 }
 
 impl Clone for Producer {
 	fn clone(&self) -> Self {
+		self.writers.writers.fetch_add(1, Ordering::Relaxed);
 		Self {
+			cache: self.cache.clone(),
+			parent: self.parent.clone(),
+			writers: self.writers.clone(),
+		}
+	}
+}
+
+impl Drop for Producer {
+	fn drop(&mut self) {
+		let prev = self.writers.writers.fetch_sub(1, Ordering::AcqRel);
+		if prev > 1 || self.writers.terminal.load(Ordering::Acquire) {
+			return;
+		}
+		let _ = self.abort_inner(Error::Dropped);
+	}
+}
+
+#[derive(Clone)]
+pub(crate) struct Cache {
+	info: Info,
+	// The parent group's info, inherited from [`group::Producer::create_frame`]
+	// so the ownership chain reaches the leaf. A small `Copy` value; carried for
+	// identity/debugging (the timestamp-vs-timescale check lives on the group).
+	group: group::Info,
+	state: kio::Producer<FrameState>,
+	buf: FrameBuf,
+}
+
+impl std::ops::Deref for Cache {
+	type Target = Info;
+
+	fn deref(&self) -> &Self::Target {
+		&self.info
+	}
+}
+
+impl Cache {
+	pub(crate) fn consume(&self) -> Consumer {
+		Consumer {
 			info: self.info,
-			group: self.group,
-			state: self.state.clone(),
+			state: self.state.consume(),
 			buf: self.buf.clone(),
+			read_idx: 0,
 		}
 	}
 }

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -9,6 +9,10 @@
 //! The stream is closed with [Error] when all writers or readers are dropped.
 use crate::{frame, track};
 use std::collections::VecDeque;
+use std::sync::{
+	Arc,
+	atomic::{AtomicBool, AtomicUsize, Ordering},
+};
 use std::task::{Poll, ready};
 
 use bytes::Bytes;
@@ -80,7 +84,7 @@ impl From<u16> for Info {
 struct GroupState {
 	// The frames currently cached in the group.
 	// Evicted frames are popped from the front; `offset` tracks how many.
-	frames: VecDeque<frame::Producer>,
+	frames: VecDeque<frame::Cache>,
 
 	// The number of frames evicted from the front of the group.
 	offset: usize,
@@ -136,32 +140,28 @@ fn modify(state: &kio::Producer<GroupState>) -> Result<kio::Mut<'_, GroupState>>
 	state.write().map_err(|r| r.abort.clone().unwrap_or(Error::Dropped))
 }
 
+#[derive(Default)]
+struct WriterState {
+	writers: AtomicUsize,
+	terminal: AtomicBool,
+}
+
 /// Writes frames to a group in order.
 ///
 /// Each group is delivered independently over a QUIC stream.
 /// Use [Self::write_frame] for simple single-buffer frames,
 /// or [Self::create_frame] for multi-chunk streaming writes.
 pub struct Producer {
-	// Mutable stream state.
-	state: kio::Producer<GroupState>,
-
-	// The group header containing the sequence number. A small `Copy` value,
-	// inherited by each frame (see [`Self::create_frame`]).
-	info: Info,
-
-	// The parent track's info, inherited rather than passed piecemeal. Its
-	// `timescale` is used by [`Self::create_frame`] to normalize every frame's
-	// timestamp into the track scale before it enters the stream, and enforced in
-	// [`Self::append_frame`]. Threaded down by value from
-	// [`track::Producer::create_group`] / `append_group`.
-	track: track::Info,
+	cache: Cache,
+	parent: Option<track::Keepalive>,
+	writers: Arc<WriterState>,
 }
 
 impl std::ops::Deref for Producer {
 	type Target = Info;
 
 	fn deref(&self) -> &Self::Target {
-		&self.info
+		&self.cache.info
 	}
 }
 
@@ -172,17 +172,44 @@ impl Producer {
 	/// which threads its [`track::Info`] down so properties like the timescale are
 	/// inherited rather than passed in. Every frame added to this group is
 	/// normalized to the track's timescale by [`Self::create_frame`].
+	#[cfg(test)]
 	pub(crate) fn new(info: Info, track: track::Info) -> Self {
 		Self {
-			info,
-			state: kio::Producer::default(),
-			track,
+			cache: Cache {
+				info,
+				state: kio::Producer::default(),
+				track,
+			},
+			parent: None,
+			writers: Arc::new(WriterState {
+				writers: AtomicUsize::new(1),
+				terminal: AtomicBool::new(false),
+			}),
 		}
+	}
+
+	pub(crate) fn with_parent(info: Info, track: track::Info, parent: track::Keepalive) -> Self {
+		Self {
+			cache: Cache {
+				info,
+				state: kio::Producer::default(),
+				track,
+			},
+			parent: Some(parent),
+			writers: Arc::new(WriterState {
+				writers: AtomicUsize::new(1),
+				terminal: AtomicBool::new(false),
+			}),
+		}
+	}
+
+	pub(crate) fn cache(&self) -> Cache {
+		self.cache.clone()
 	}
 
 	/// The parent track's timescale.
 	pub fn timescale(&self) -> Timescale {
-		self.track.timescale
+		self.cache.track.timescale
 	}
 
 	/// A helper method to write a frame from a single byte buffer.
@@ -220,10 +247,10 @@ impl Producer {
 		let mut frame = frame;
 		frame.timestamp = frame
 			.timestamp
-			.convert(self.track.timescale)
+			.convert(self.cache.track.timescale)
 			.map_err(|_| Error::TimestampMismatch)?;
 
-		let frame = frame::Producer::new(frame, self.info)?;
+		let frame = frame::Producer::with_parent(frame, self.cache.info, self.keepalive())?;
 		self.append_frame(frame.clone())?;
 		Ok(frame)
 	}
@@ -246,30 +273,31 @@ impl Producer {
 		// Catch the contract violation here, at the model layer, so peers that
 		// downstream-encode (e.g. the lite publisher's `serve_frame`) can rely
 		// on the invariant instead of re-validating per byte.
-		if frame.timestamp.scale() != self.track.timescale {
+		if frame.timestamp.scale() != self.cache.track.timescale {
 			return Err(Error::TimestampMismatch);
 		}
 
-		let mut state = modify(&self.state)?;
+		let mut state = modify(&self.cache.state)?;
 		if state.fin {
 			return Err(Error::Closed);
 		}
 		state.cache += frame.size;
-		state.frames.push_back(frame);
+		state.frames.push_back(frame.cache());
 		state.evict();
 		Ok(())
 	}
 
 	/// Return the number of frames written so far.
 	pub fn frame_count(&self) -> usize {
-		let state = self.state.read();
+		let state = self.cache.state.read();
 		state.offset + state.frames.len()
 	}
 
 	/// Mark the group as complete; no more frames will be written.
 	pub fn finish(&mut self) -> Result<()> {
-		let mut state = modify(&self.state)?;
+		let mut state = modify(&self.cache.state)?;
 		state.fin = true;
+		self.writers.terminal.store(true, Ordering::Release);
 		Ok(())
 	}
 
@@ -281,7 +309,33 @@ impl Producer {
 	/// Child frames are independent: a consumer that already pulled a
 	/// [`frame::Consumer`] keeps its own handle and can finish reading it.
 	pub fn abort(&mut self, err: Error) -> Result<()> {
-		let mut guard = modify(&self.state)?;
+		self.abort_inner(err)?;
+		self.writers.terminal.store(true, Ordering::Release);
+		Ok(())
+	}
+
+	/// Create a new consumer for the group.
+	pub fn consume(&self) -> Consumer {
+		self.cache.consume()
+	}
+
+	/// Block until the group is closed or aborted.
+	pub async fn closed(&self) -> Error {
+		self.cache.state.closed().await;
+		self.cache.state.read().abort.clone().unwrap_or(Error::Dropped)
+	}
+
+	/// Block until there are no active consumers.
+	pub async fn unused(&self) -> Result<()> {
+		self.cache
+			.state
+			.unused()
+			.await
+			.map_err(|r| r.abort.clone().unwrap_or(Error::Dropped))
+	}
+
+	fn abort_inner(&mut self, err: Error) -> Result<()> {
+		let mut guard = modify(&self.cache.state)?;
 		guard.abort = Some(err);
 		guard.frames.clear();
 		guard.cache = 0;
@@ -289,46 +343,27 @@ impl Producer {
 		Ok(())
 	}
 
-	/// Create a new consumer for the group.
-	pub fn consume(&self) -> Consumer {
-		Consumer {
-			info: self.info,
-			state: self.state.consume(),
-			track: self.track,
-			index: 0,
+	fn keepalive(&self) -> Keepalive {
+		Keepalive {
+			state: self.cache.state.clone(),
 		}
-	}
-
-	/// Block until the group is closed or aborted.
-	pub async fn closed(&self) -> Error {
-		self.state.closed().await;
-		self.state.read().abort.clone().unwrap_or(Error::Dropped)
-	}
-
-	/// Block until there are no active consumers.
-	pub async fn unused(&self) -> Result<()> {
-		self.state
-			.unused()
-			.await
-			.map_err(|r| r.abort.clone().unwrap_or(Error::Dropped))
 	}
 }
 
-impl Clone for Producer {
+pub(crate) struct Keepalive {
+	state: kio::Producer<GroupState>,
+}
+
+impl Clone for Keepalive {
 	fn clone(&self) -> Self {
 		Self {
-			info: self.info,
 			state: self.state.clone(),
-			track: self.track,
 		}
 	}
 }
 
-impl Drop for Producer {
+impl Drop for Keepalive {
 	fn drop(&mut self) {
-		// See track::Producer::drop: the last producer dropping without a clean
-		// finish releases the cached frames so a stale consumer can't pin their
-		// buffers forever. A finished group keeps its cache so consumers can drain.
 		if !self.state.is_last() {
 			return;
 		}
@@ -338,6 +373,71 @@ impl Drop for Producer {
 			state.frames.clear();
 			state.cache = 0;
 		}
+	}
+}
+
+impl Clone for Producer {
+	fn clone(&self) -> Self {
+		self.writers.writers.fetch_add(1, Ordering::Relaxed);
+		Self {
+			cache: self.cache.clone(),
+			parent: self.parent.clone(),
+			writers: self.writers.clone(),
+		}
+	}
+}
+
+impl Drop for Producer {
+	fn drop(&mut self) {
+		let prev = self.writers.writers.fetch_sub(1, Ordering::AcqRel);
+		if prev > 1 || self.writers.terminal.load(Ordering::Acquire) {
+			return;
+		}
+		let _ = self.abort_inner(Error::Dropped);
+	}
+}
+
+#[derive(Clone)]
+pub(crate) struct Cache {
+	// Mutable stream state.
+	state: kio::Producer<GroupState>,
+
+	// The group header containing the sequence number. A small `Copy` value,
+	// inherited by each frame (see [`Producer::create_frame`]).
+	info: Info,
+
+	// The parent track's info, inherited rather than passed piecemeal. Its
+	// `timescale` is used by [`Producer::create_frame`] to normalize every frame's
+	// timestamp into the track scale before it enters the stream, and enforced in
+	// [`Producer::append_frame`].
+	track: track::Info,
+}
+
+impl std::ops::Deref for Cache {
+	type Target = Info;
+
+	fn deref(&self) -> &Self::Target {
+		&self.info
+	}
+}
+
+impl Cache {
+	pub(crate) fn consume(&self) -> Consumer {
+		Consumer {
+			info: self.info,
+			state: self.state.consume(),
+			track: self.track,
+			index: 0,
+		}
+	}
+
+	pub(crate) fn abort(&self, err: Error) -> Result<()> {
+		let mut guard = modify(&self.state)?;
+		guard.abort = Some(err);
+		guard.frames.clear();
+		guard.cache = 0;
+		guard.close();
+		Ok(())
 	}
 }
 
@@ -568,11 +668,11 @@ mod test {
 
 		// A stale consumer that never reads must not pin the cached frames.
 		let _consumer = producer.consume();
-		assert_eq!(producer.state.read().frames.len(), 1);
+		assert_eq!(producer.cache.state.read().frames.len(), 1);
 
 		producer.abort(crate::Error::Cancel).unwrap();
 
-		let state = producer.state.read();
+		let state = producer.cache.state.read();
 		assert!(state.frames.is_empty(), "cached frames should be dropped on abort");
 		assert_eq!(state.cache, 0);
 	}
@@ -585,7 +685,7 @@ mod test {
 
 		// A stale consumer keeps the channel (and thus the cache) alive.
 		let mut consumer = producer.consume();
-		assert_eq!(producer.state.read().frames.len(), 1);
+		assert_eq!(producer.cache.state.read().frames.len(), 1);
 
 		// Drop every producer without finishing: the cache is released.
 		drop(writer);

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -335,6 +335,9 @@ impl Producer {
 	}
 
 	fn abort_inner(&mut self, err: Error) -> Result<()> {
+		if matches!(&err, Error::Dropped) {
+			super::warn_dropped_abort("group");
+		}
 		let mut guard = modify(&self.cache.state)?;
 		guard.abort = Some(err);
 		guard.frames.clear();
@@ -432,6 +435,9 @@ impl Cache {
 	}
 
 	pub(crate) fn abort(&self, err: Error) -> Result<()> {
+		if matches!(&err, Error::Dropped) {
+			super::warn_dropped_abort("group");
+		}
 		let mut guard = modify(&self.state)?;
 		guard.abort = Some(err);
 		guard.frames.clear();

--- a/rs/moq-net/src/model/mod.rs
+++ b/rs/moq-net/src/model/mod.rs
@@ -38,3 +38,10 @@ pub mod announce {
 // Origin identity and the `Consume` conversion trait aren't part of a role
 // module; keep them flat at the crate root.
 pub use origin_impl::{Consume, InvalidOrigin, Origin, OriginList, TooManyOrigins};
+
+pub(crate) fn warn_dropped_abort(producer: &'static str) {
+	tracing::warn!(
+		producer,
+		"aborting with Error::Dropped; call finish or abort before dropping producer"
+	);
+}

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -157,7 +157,7 @@ struct TrackState {
 	info: Option<Info>,
 
 	// Groups in arrival order. `None` entries are tombstones for evicted groups.
-	groups: VecDeque<Option<(group::Producer, web_async::time::Instant)>>,
+	groups: VecDeque<Option<(group::Cache, web_async::time::Instant)>>,
 
 	// Datagrams in arrival order paired with their arrival time, a best-effort send buffer
 	// evicted by age (see `MAX_DATAGRAM_AGE`). Shares the group `max_sequence` namespace but
@@ -339,7 +339,7 @@ impl TrackState {
 			return Poll::Pending;
 		}
 
-		let mut best: Option<&group::Producer> = None;
+		let mut best: Option<&group::Cache> = None;
 		for (group, _) in self.groups.iter().flatten() {
 			if group.sequence < next_sequence {
 				continue;
@@ -496,7 +496,12 @@ impl TrackState {
 	/// fetch can serve an as-yet-unaccepted track (e.g. a relay with no live
 	/// subscription). The group lands in the cache so a waiting
 	/// [`Fetch`] resolves via [`Self::poll_fetch`].
-	fn insert_group_request(&mut self, sequence: u64, info: Option<Info>) -> Result<group::Producer> {
+	fn insert_group_request(
+		&mut self,
+		sequence: u64,
+		info: Option<Info>,
+		parent: Keepalive,
+	) -> Result<group::Producer> {
 		if let Some(err) = &self.abort {
 			return Err(err.clone());
 		}
@@ -512,11 +517,11 @@ impl TrackState {
 		// Adopt the supplied info only if the track hasn't been accepted yet.
 		let info = *self.info.get_or_insert_with(|| info.unwrap_or_default());
 
-		let group = group::Producer::new(group::Info { sequence }, info);
+		let group = group::Producer::with_parent(group::Info { sequence }, info, parent);
 		let cache = info.cache;
 		let now = web_async::time::Instant::now();
 		self.max_sequence = Some(self.max_sequence.unwrap_or(0).max(sequence));
-		self.groups.push_back(Some((group.clone(), now)));
+		self.groups.push_back(Some((group.cache(), now)));
 		self.evict_expired(now, cache);
 		Ok(group)
 	}
@@ -534,9 +539,8 @@ impl TrackState {
 #[derive(Clone)]
 pub struct Producer {
 	name: Arc<str>,
-	// The parent broadcast's info, inherited from [`broadcast::Producer::create_track`].
-	// Top link of the ownership chain; carried for identity and future inheritance.
-	broadcast: Arc<broadcast::Info>,
+	// Keeps the parent broadcast alive while this track is externally produced.
+	broadcast: broadcast::Keepalive,
 	state: kio::Producer<TrackState>,
 	prev_subscription: Option<Subscription>,
 }
@@ -546,10 +550,10 @@ impl Producer {
 	///
 	/// Crate-private: tracks are born from their broadcast via
 	/// [`broadcast::Producer::create_track`] (or served on demand through a
-	/// [`Request`]), which threads the broadcast's `Arc<broadcast::Info>` down so
-	/// the broadcast owns the namespace and there's a single way to mint a track.
+	/// [`Request`]), which threads the broadcast keepalive down so the broadcast
+	/// owns the namespace and there's a single way to mint a track.
 	pub(crate) fn new(
-		broadcast: Arc<broadcast::Info>,
+		broadcast: broadcast::Keepalive,
 		name: impl Into<Arc<str>>,
 		info: impl Into<Option<Info>>,
 	) -> Self {
@@ -571,7 +575,7 @@ impl Producer {
 
 	/// The parent broadcast this track belongs to.
 	pub fn broadcast(&self) -> &broadcast::Info {
-		&self.broadcast
+		self.broadcast.info()
 	}
 
 	/// Create a new group with the given sequence number.
@@ -586,14 +590,14 @@ impl Producer {
 		let track = *info;
 		let cache = info.cache;
 
-		let group = group::Producer::new(group, track);
+		let group = group::Producer::with_parent(group, track, self.keepalive());
 		if !state.duplicates.insert(group.sequence) {
 			return Err(Error::Duplicate);
 		}
 
 		let now = web_async::time::Instant::now();
 		state.max_sequence = Some(state.max_sequence.unwrap_or(0).max(group.sequence));
-		state.groups.push_back(Some((group.clone(), now)));
+		state.groups.push_back(Some((group.cache(), now)));
 		state.evict_expired(now, cache);
 
 		Ok(group)
@@ -616,12 +620,12 @@ impl Producer {
 		let track = *info;
 		let cache = info.cache;
 
-		let group = group::Producer::new(group::Info { sequence }, track);
+		let group = group::Producer::with_parent(group::Info { sequence }, track, self.keepalive());
 
 		let now = web_async::time::Instant::now();
 		state.duplicates.insert(sequence);
 		state.max_sequence = Some(sequence);
-		state.groups.push_back(Some((group.clone(), now)));
+		state.groups.push_back(Some((group.cache(), now)));
 		state.evict_expired(now, cache);
 
 		Ok(group)
@@ -915,6 +919,39 @@ impl Producer {
 
 	fn modify(&self) -> Result<kio::Mut<'_, TrackState>> {
 		TrackState::modify(&self.state)
+	}
+
+	fn keepalive(&self) -> Keepalive {
+		Keepalive {
+			state: self.state.clone(),
+		}
+	}
+}
+
+pub(crate) struct Keepalive {
+	state: kio::Producer<TrackState>,
+}
+
+impl Clone for Keepalive {
+	fn clone(&self) -> Self {
+		Self {
+			state: self.state.clone(),
+		}
+	}
+}
+
+impl Drop for Keepalive {
+	fn drop(&mut self) {
+		if !self.state.is_last() {
+			return;
+		}
+		if let Ok(mut state) = self.state.write()
+			&& state.final_sequence.is_none()
+		{
+			state.groups.clear();
+			state.datagrams.clear();
+			state.duplicates.clear();
+		}
 	}
 }
 
@@ -1327,7 +1364,10 @@ impl GroupRequest {
 	/// already present, or the track's abort error if it closed while pending.
 	pub fn accept(mut self, info: impl Into<Option<Info>>) -> Result<group::Producer> {
 		self.done = true;
-		TrackState::modify(&self.state)?.insert_group_request(self.sequence, info.into())
+		let parent = Keepalive {
+			state: self.state.clone(),
+		};
+		TrackState::modify(&self.state)?.insert_group_request(self.sequence, info.into(), parent)
 	}
 
 	/// Reject the fetch, resolving the waiting [`Consumer::fetch_group`] with `err`.
@@ -1634,7 +1674,7 @@ impl Subscriber {
 pub struct Request {
 	name: Arc<str>,
 	// The parent broadcast's info, threaded into the [`Producer`] on accept.
-	broadcast: Arc<broadcast::Info>,
+	broadcast: broadcast::KeepaliveRef,
 	state: kio::Producer<TrackState>,
 
 	// The previous subscription that was combined, used to detect changes.
@@ -1648,17 +1688,21 @@ pub struct Request {
 }
 
 impl Request {
-	pub(crate) fn new(broadcast: Arc<broadcast::Info>, name: impl Into<Arc<str>>) -> Self {
+	pub(crate) fn new(broadcast: impl Into<broadcast::KeepaliveRef>, name: impl Into<Arc<str>>) -> Self {
 		let name = name.into();
 		let state = kio::Producer::<TrackState>::default();
 		let dynamic = Dynamic::new(name.clone(), state.clone());
 		Self {
 			name,
-			broadcast,
+			broadcast: broadcast.into(),
 			state,
 			prev_subscription: None,
 			_dynamic: dynamic,
 		}
+	}
+
+	pub(crate) fn strengthen_parent(&mut self, parent: broadcast::Keepalive) {
+		self.broadcast = parent.into();
 	}
 
 	/// The requested track name.
@@ -1694,7 +1738,7 @@ impl Request {
 		self.state.write().ok().unwrap().info = Some(info.into().unwrap_or_default());
 		Producer {
 			name: self.name,
-			broadcast: self.broadcast,
+			broadcast: self.broadcast.upgrade().expect("request parent should be live"),
 			state: self.state,
 			prev_subscription: None,
 		}
@@ -1805,7 +1849,8 @@ mod test {
 	/// Mint a track for tests with a default parent broadcast, since tracks are
 	/// normally born from a [`broadcast::Producer`].
 	fn track_producer(name: impl Into<Arc<str>>, info: impl Into<Option<Info>>) -> Producer {
-		Producer::new(Arc::new(broadcast::Info::default()), name, info)
+		let broadcast = broadcast::Info::default().produce();
+		Producer::new(broadcast.keepalive(), name, info)
 	}
 
 	/// Helper: count non-tombstoned groups in state.
@@ -1852,6 +1897,19 @@ mod test {
 		assert_eq!(got.sequence, seq);
 		assert_eq!(got.timestamp, ts);
 		assert_eq!(&got.payload[..], b"hello");
+	}
+
+	#[tokio::test]
+	async fn active_group_keeps_track_alive() {
+		let mut producer = track_producer("test", None);
+		let subscriber = producer.subscribe(None);
+		let group = producer.append_group().unwrap();
+
+		drop(producer);
+		subscriber.assert_not_closed();
+
+		drop(group);
+		subscriber.assert_closed();
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -752,6 +752,9 @@ impl Producer {
 	/// independent: a consumer that already pulled a [`group::Consumer`] keeps its
 	/// own handle and can finish reading it.
 	pub fn abort(&mut self, err: Error) -> Result<()> {
+		if matches!(&err, Error::Dropped) {
+			super::warn_dropped_abort("track");
+		}
 		let mut guard = self.modify()?;
 		guard.abort = Some(err);
 		guard.groups.clear();


### PR DESCRIPTION
## Summary
- Add private parent keepalive handles so active tracks keep broadcasts open and active groups keep tracks open.
- Split cached group and frame state from public writer handles with private cache handles, so the cache can retain readable state without retaining the public producer.
- Keep dynamic track requests weak while they are queued in `BroadcastState`, then strengthen the parent handle when the request is handed to the dynamic publisher.
- Warn when a producer abort path uses `Error::Dropped`, which catches implicit dropped-producer aborts.

## Impact
This fixes the lifecycle footgun where dropping a parent producer could close the broadcast or track even while an active child was still being produced. The public model surface stays unchanged; the new handle types are crate-private.

## Validation
- `cargo test -p moq-net`
- `cargo check -p moq-net`
- `cargo fmt --package moq-net`

(Written by GPT-5)
