### PR TITLE
fix(moq-mux): match per-rendition init track id to its fragments

### DIFF
--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -394,7 +394,7 @@ impl<S: Stream> Export<S> {
 				.ok_or_else(|| Error::MissingVideoTrack(name.clone()))?;
 			match &config.container {
 				Container::Cmaf { init, .. } => {
-					extract_init(init, &mut ftyp_data, &mut traks, &mut trexs)?;
+					extract_init(init, track.track_id, &mut ftyp_data, &mut traks, &mut trexs)?;
 				}
 				Container::Legacy | Container::Loc => {
 					// H.264/H.265 need a synthesized config record here; VP8 has none.
@@ -422,7 +422,7 @@ impl<S: Stream> Export<S> {
 				.ok_or_else(|| Error::MissingAudioTrack(name.clone()))?;
 			match &config.container {
 				Container::Cmaf { init, .. } => {
-					extract_init(init, &mut ftyp_data, &mut traks, &mut trexs)?;
+					extract_init(init, track.track_id, &mut ftyp_data, &mut traks, &mut trexs)?;
 				}
 				Container::Legacy | Container::Loc => {
 					let trak = crate::container::fmp4::synthesize_audio_trak(track.track_id, track.timescale, config)?;
@@ -468,10 +468,18 @@ impl<S: Stream> Export<S> {
 }
 
 /// Pull ftyp + moov from a single-track CMAF init segment and merge into the
-/// caller's accumulators. Original track ids are preserved so passthrough
-/// fragments keep matching their moov entries.
+/// caller's accumulators, rewriting the track id to `track_id`.
+///
+/// The source init carries whatever id the track had in ITS broadcast (e.g. an
+/// audio track that was second in the source is `2`), but our fragments are always
+/// re-encoded with the exporter's own `track.track_id` (see [`encode_fragment`]) --
+/// nothing is passed through. So the moov MUST adopt that same id, or a player
+/// loads an init declaring track N and then a fragment claiming a different track
+/// and rejects it ("no tfhd for track"). It also keeps a merged multi-track moov
+/// from colliding when two single-track source inits both used id `1`.
 fn extract_init(
 	init: &Bytes,
+	track_id: u32,
 	ftyp_data: &mut Option<mp4_atom::Ftyp>,
 	traks: &mut Vec<mp4_atom::Trak>,
 	trexs: &mut Vec<mp4_atom::Trex>,
@@ -483,11 +491,13 @@ fn extract_init(
 				*ftyp_data = Some(f);
 			}
 			mp4_atom::Any::Moov(moov) => {
-				for trak in moov.trak {
+				for mut trak in moov.trak {
+					trak.tkhd.track_id = track_id;
 					traks.push(trak);
 				}
 				if let Some(mvex) = moov.mvex {
-					for trex in mvex.trex {
+					for mut trex in mvex.trex {
+						trex.track_id = track_id;
 						trexs.push(trex);
 					}
 				}

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -508,6 +508,80 @@ async fn cmaf_source_to_cmaf_export_passthrough() {
 	moov.encode(&mut buf).expect("encode merged moov");
 }
 
+/// Per-rendition export (a single non-first source track, e.g. moq-hls exporting
+/// the audio rendition alone) must give the init moov the SAME track id its
+/// re-encoded fragments carry.
+///
+/// bbb.mp4's audio is the second track, so its source CMAF init declares track id
+/// 2, but an audio-only export re-encodes fragments as track 1 (the exporter's own
+/// per-export numbering). If the moov kept the source id (2) while the moof said 1,
+/// a player would reject every segment ("no tfhd for track") and stall -- the VOD
+/// audio-playback bug this guards against.
+#[tokio::test(start_paused = true)]
+async fn single_track_export_init_matches_fragment_track_id() {
+	use crate::catalog::Stream;
+
+	let data = include_bytes!("test_data/bbb.mp4");
+
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let consumer = producer.consume();
+
+	let catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let mut importer = crate::container::fmp4::Import::new(producer, catalog);
+	let buf = BytesMut::from(data.as_slice());
+	let _ = importer.decode(&buf);
+
+	// Audio only: unselected video is dropped, so this is a single-track export.
+	let catalog_stream =
+		crate::catalog::Consumer::<()>::new(&consumer, crate::catalog::CatalogFormat::Hang).expect("catalog consumer");
+	let selected = catalog_stream.select(crate::select::Broadcast::default().audio(crate::select::Audio::default()));
+	let mut exporter = crate::container::fmp4::Export::new(consumer, selected);
+
+	let init = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
+		.await
+		.expect("exporter timed out")
+		.expect("exporter result")
+		.expect("expected init bytes");
+
+	// The next non-init fragment is a moof+mdat for the same (only) track.
+	let fragment = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
+		.await
+		.expect("exporter timed out")
+		.expect("exporter result")
+		.expect("expected a fragment");
+
+	drop(importer);
+
+	// init moov: exactly one trak, whose id must equal its trex id.
+	let mut cursor = Cursor::new(init.as_ref());
+	let mut moov: Option<mp4_atom::Moov> = None;
+	while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).expect("decode init") {
+		if let mp4_atom::Any::Moov(m) = atom {
+			moov = Some(m);
+		}
+	}
+	let moov = moov.expect("moov");
+	assert_eq!(moov.trak.len(), 1, "audio-only export has one track");
+	let init_id = moov.trak[0].tkhd.track_id;
+	let mvex = moov.mvex.as_ref().expect("mvex");
+	assert_eq!(mvex.trex[0].track_id, init_id, "trex id must match its trak");
+
+	// fragment moof: the tfhd track id must match the init.
+	let mut cursor = Cursor::new(fragment.as_ref());
+	let mut moof: Option<mp4_atom::Moof> = None;
+	while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).expect("decode fragment") {
+		if let mp4_atom::Any::Moof(m) = atom {
+			moof = Some(m);
+		}
+	}
+	let moof = moof.expect("moof");
+	assert_eq!(
+		moof.traf[0].tfhd.track_id, init_id,
+		"fragment track id must match the init moov, or players reject the segment"
+	);
+}
+
 /// `next_fragment` reports the init flag, per-fragment sync-sample independence,
 /// and a positive duration. With a sub-GOP fragment cap, a part in the middle of
 /// a GOP is reported as non-independent while the GOP's leading part stays


### PR DESCRIPTION
## Problem

VOD (and any per-rendition fMP4 export) produced **unplayable audio**: the player loads the audio init, gets segments whose `moof` declares a different track id, rejects every one (`trun track id unknown, no tfhd was found`), never appends audio, then stalls and re-requests segments forever.

Observed on a real recording (video plays, audio silent + segment-request spam):

| rendition | init `moov` `track_id` | segment `moof` `track_id` | |
|---|:---:|:---:|:---:|
| video | 1 | 1 | ✅ |
| audio | **2** | **1** | ❌ |

## Root cause

The exporter re-encodes **every** fragment with its own per-export track id (`encode_fragment(track.track_id, …)`) — nothing is passed through. But `build_init`'s CMAF branch merged the **source** init's original track id verbatim via `extract_init`.

moq-hls exports each rendition on its own axis (one track per `Export`), so an audio track that was *second* in its source broadcast keeps init `track_id = 2`, while its re-encoded fragments are numbered `1`. Video only works by luck (track 1 in both). A merged multi-track export avoided the bug only because the source ids happened to match the assignment order — but two single-track source inits that both used id `1` would have collided in the merged `moov`.

The old `extract_init` comment even claimed fragments were "passthrough"; they aren't.

## Fix

`extract_init` now rewrites the merged `trak.tkhd.track_id` and `trex.track_id` to the exporter's assigned `track.track_id`, so the init always agrees with the fragments (and merged exports get distinct per-track ids).

## Test

New regression test `single_track_export_init_matches_fragment_track_id` exports bbb.mp4's audio alone and asserts the init `moov` track id equals the fragment `moof` track id. It fails on `main` (`left: 1, right: 2`) and passes with the fix. Full `moq-mux` (349) and `moq-hls` (19) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
