### PR TITLE
fix(moq-native): compile for target_os="android" under jni 0.22

### DIFF
--- a/rs/moq-ffi/src/android.rs
+++ b/rs/moq-ffi/src/android.rs
@@ -8,43 +8,41 @@
 
 use std::ffi::c_void;
 
-use moq_native::jni::sys::{JNI_VERSION_1_6, jint};
-use moq_native::jni::{JNIEnv, JavaVM};
+use moq_native::jni::sys::{self, JNI_VERSION_1_6, jint};
+use moq_native::jni::{Env, JavaVM, jni_sig, jni_str};
 
 /// Called by the JVM on `System.loadLibrary("moq_ffi")`. The name is fixed by
 /// the JNI spec, so it can't follow Rust's snake_case convention.
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "system" fn JNI_OnLoad(vm: JavaVM, _reserved: *mut c_void) -> jint {
+pub extern "system" fn JNI_OnLoad(vm: *mut sys::JavaVM, _reserved: *mut c_void) -> jint {
+	// SAFETY: per the JNI spec the JVM hands `JNI_OnLoad` a valid `JavaVM` pointer.
+	let vm = unsafe { JavaVM::from_raw(vm) };
 	if let Err(err) = init_platform_tls(&vm) {
 		tracing::warn!(%err, "could not auto-initialize the Android platform TLS verifier; using bundled roots");
 	}
 	JNI_VERSION_1_6
 }
 
-/// Attach the loader thread, run the init, and clear any pending Java exception
-/// a failed JNI call may have left behind.
+/// Attach the loader thread and run the init. A Java exception thrown inside the
+/// callback is caught and cleared by `attach_current_thread`, so it can't surface
+/// as a `System.loadLibrary` failure or leak into the next JNI call; the
+/// bundled-roots fallback already covers the init failure.
 fn init_platform_tls(vm: &JavaVM) -> Result<(), Box<dyn std::error::Error>> {
-	let mut env = vm.attach_current_thread()?;
-	let result = discover_context_and_init(&mut env);
-	if result.is_err() {
-		// Clear here (before JNI_OnLoad logs and returns) so a pending exception
-		// can't surface as a System.loadLibrary failure or abort the next JNI
-		// call; the bundled-roots fallback already covers the init failure.
-		let _ = env.exception_clear();
-	}
-	result
+	vm.attach_current_thread(discover_context_and_init)
 }
 
 /// Reflectively fetch the application `Context` and hand it to moq-native.
-fn discover_context_and_init(env: &mut JNIEnv) -> Result<(), Box<dyn std::error::Error>> {
+fn discover_context_and_init(env: &mut Env) -> Result<(), Box<dyn std::error::Error>> {
 	// The app Context isn't passed to native code, so fetch it from
 	// android.app.ActivityThread.currentApplication() (a long-stable internal API).
+	// The `jni = ...` override points the compile-time encoders at moq-native's
+	// re-export, since moq-ffi has no direct `jni` dependency of its own.
 	let app = env
 		.call_static_method(
-			"android/app/ActivityThread",
-			"currentApplication",
-			"()Landroid/app/Application;",
+			jni_str!(jni = moq_native::jni, "android/app/ActivityThread"),
+			jni_str!(jni = moq_native::jni, "currentApplication"),
+			jni_sig!(jni = moq_native::jni, "()Landroid/app/Application;"),
 			&[],
 		)?
 		.l()?;

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -54,8 +54,8 @@ pub use rustls;
 #[cfg(feature = "watch")]
 pub use notify;
 
-/// Re-exported because [`tls::init_android`] takes `jni` handles; a major `jni`
-/// bump is therefore a breaking change for this crate.
+/// Re-exported because [`tls::init_android`] takes a `jni::Env` handle; a major
+/// `jni` bump is therefore a breaking change for this crate.
 #[cfg(target_os = "android")]
 pub use jni;
 

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -508,14 +508,15 @@ static ANDROID_INITIALIZED: std::sync::atomic::AtomicBool = std::sync::atomic::A
 ///
 /// On Android the OS trust store is only reachable through the JVM, so the
 /// platform verifier needs a JNI handle to the application `Context` before it
-/// can be used. Call this once at startup (e.g. from `JNI_OnLoad`) with a
-/// `JNIEnv` for the calling thread and the application `Context`. The `moq-ffi`
-/// bindings call it automatically, so most consumers never touch this directly.
+/// can be used. Call this once at startup (e.g. from `JNI_OnLoad`) with an
+/// attached [`jni::Env`] for the calling thread and the application `Context`.
+/// The `moq-ffi` bindings call it automatically, so most consumers never touch
+/// this directly.
 ///
 /// Until it succeeds, clients fall back to the bundled Mozilla roots, so a
 /// missing or failed init degrades to webpki verification rather than failing.
 #[cfg(target_os = "android")]
-pub fn init_android(env: &mut jni::JNIEnv, context: jni::objects::JObject) -> Result<()> {
+pub fn init_android(env: &mut jni::Env, context: jni::objects::JObject) -> Result<()> {
 	rustls_platform_verifier::android::init_with_env(env, context).map_err(Error::AndroidInit)?;
 	ANDROID_INITIALIZED.store(true, std::sync::atomic::Ordering::Release);
 	Ok(())


### PR DESCRIPTION
## Summary

`moq-native` 0.17.7 (and `main`) does not compile for any `target_os = "android"` target, so **any** crate depending on it with default features fails to build for Android (issue #2103).

The root cause is a set of breaking changes in `jni` 0.22:

- The env type was split into `EnvUnowned` (just-received from JNI, unattached) and `Env` (attached). All the `call_*` / `exception_*` methods now live on `Env`. `jni::JNIEnv` is now an alias for `EnvUnowned`.
- `JavaVM::attach_current_thread` is now **callback-based** (`|env: &mut Env| -> Result<_, E>`) instead of returning an `AttachGuard`.
- `call_static_method` takes compile-time-encoded `JNIStr` / `MethodSignature` instead of `&str`.

The issue reporter's minimal repro only depended on `moq-native`, so it surfaced a single `E0308` in `tls.rs`. But `moq-ffi/src/android.rs` (also `#[cfg(target_os = "android")]`, never in CI) was broken by the same `jni` bump and is fixed here too.

## Changes

- **`moq-native/src/tls.rs`**: `init_android` takes `&mut jni::Env` (was `&mut jni::JNIEnv` = `EnvUnowned`), mirroring `rustls_platform_verifier::android::init_with_env(&mut Env, …)` exactly with no wrapping. The FFI caller gets an `Env` naturally from the attach callback.
- **`moq-ffi/src/android.rs`**:
  - `JNI_OnLoad` takes the raw `*mut sys::JavaVM` + `JavaVM::from_raw` (FFI-safe; the old by-value `JavaVM` tripped `improper_ctypes_definitions`).
  - Drives init through the new callback-based `attach_current_thread`, which auto-catches and clears any pending Java exception (default `PreReThrowPostCatch` policy), so the manual `exception_clear()` is gone.
  - `call_static_method` args use `jni_str!` / `jni_sig!` with the `jni = moq_native::jni` path override (moq-ffi has no direct `jni` dep of its own).
- **`moq-native/src/lib.rs`**: doc tweak on the `jni` re-export.

## Why `main` and not `dev`

This is a bug fix that makes Android compile at all. The `init_android` public-signature change is on a symbol that was completely non-functional (it did not compile), so no consumer could have depended on it.

## Test plan

- [x] `cargo ndk -t arm64-v8a build -p moq-ffi` (pulls in `moq-native`) — clean, no warnings, against real NDK r29 + jni 0.22.4 + rustls-platform-verifier 0.7.0
- [x] Host `cargo check -p moq-ffi -p moq-native` — unaffected (every edit is `#[cfg(target_os = "android")]`-gated)
- [x] `cargo fmt --check` via nix — clean

## Note

CI never cross-compiles the Android target (`just kt ci` builds `moq-ffi` for the host only; the Android target is first built at `moq-ffi-v*` release time), which is why this and a prior Android-only regression shipped. Adding a lightweight `cargo ndk check` gate is a worthwhile follow-up.

Closes #2103

(Written by Claude Opus 4.8)