### PR TITLE
feat(moq-net,js/net): add moq-transport draft-19 (moqt-19)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,9 +1336,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/doc/concept/standard/interop.md
+++ b/doc/concept/standard/interop.md
@@ -47,4 +47,4 @@ If it plays, you interop. That's the whole test.
 - **Subscriber sees nothing?** If your relay doesn't replay existing
   announcements, start the subscriber before the publisher.
 - **Verbose logs:** prefix with `RUST_LOG=info,moq_net=debug`. It prints the
-  negotiated version (e.g. `connected version=moq-transport-18`).
+  negotiated version (e.g. `connected version=moq-transport-19`).

--- a/doc/concept/standard/interop.md
+++ b/doc/concept/standard/interop.md
@@ -5,7 +5,7 @@ description: Publish and subscribe to a moq-transport relay with moq-cli
 
 # Interoperability
 
-`moq-cli` speaks moq-transport drafts **14 through 18**, negotiated over ALPN at
+`moq-cli` speaks moq-transport drafts **14 through 19**, negotiated over ALPN at
 connect. Point it at your relay and it picks the newest version you both
 support. (You should try [moq-lite](/concept/layer/moq-lite) too, btw.)
 

--- a/js/net/src/connection/accept.ts
+++ b/js/net/src/connection/accept.ts
@@ -22,7 +22,9 @@ export async function accept(transport: WebTransport, url: URL, props?: AcceptPr
 	// @ts-expect-error - TODO: add protocol to WebTransport
 	const protocol: string | undefined = transport.protocol;
 
-	if (protocol === Ietf.ALPN.DRAFT_18) {
+	if (protocol === Ietf.ALPN.DRAFT_19) {
+		return acceptAlpn(transport, url, Ietf.Version.DRAFT_19);
+	} else if (protocol === Ietf.ALPN.DRAFT_18) {
 		return acceptAlpn(transport, url, Ietf.Version.DRAFT_18);
 	} else if (protocol === Ietf.ALPN.DRAFT_17) {
 		return acceptAlpn(transport, url, Ietf.Version.DRAFT_17);

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -130,11 +130,13 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	// Choose setup encoding based on negotiated WebTransport protocol (if any).
 	let setupVersion: Ietf.Version;
 	const modernVersion =
-		protocol === Ietf.ALPN.DRAFT_18
-			? Ietf.Version.DRAFT_18
-			: protocol === Ietf.ALPN.DRAFT_17
-				? Ietf.Version.DRAFT_17
-				: undefined;
+		protocol === Ietf.ALPN.DRAFT_19
+			? Ietf.Version.DRAFT_19
+			: protocol === Ietf.ALPN.DRAFT_18
+				? Ietf.Version.DRAFT_18
+				: protocol === Ietf.ALPN.DRAFT_17
+					? Ietf.Version.DRAFT_17
+					: undefined;
 	if (modernVersion !== undefined) {
 		return await handshakeAlpn(url, session as WebTransport, modernVersion);
 	} else if (protocol === Ietf.ALPN.DRAFT_16) {
@@ -216,11 +218,13 @@ async function connectTransport(url: URL, session: WebTransport): Promise<Establ
 	// Choose setup encoding based on negotiated WebTransport protocol (if any).
 	let setupVersion: Ietf.Version;
 	const modernVersion =
-		protocol === Ietf.ALPN.DRAFT_18
-			? Ietf.Version.DRAFT_18
-			: protocol === Ietf.ALPN.DRAFT_17
-				? Ietf.Version.DRAFT_17
-				: undefined;
+		protocol === Ietf.ALPN.DRAFT_19
+			? Ietf.Version.DRAFT_19
+			: protocol === Ietf.ALPN.DRAFT_18
+				? Ietf.Version.DRAFT_18
+				: protocol === Ietf.ALPN.DRAFT_17
+					? Ietf.Version.DRAFT_17
+					: undefined;
 	if (modernVersion !== undefined) {
 		return await handshakeAlpn(url, session, modernVersion);
 	} else if (protocol === Ietf.ALPN.DRAFT_16) {
@@ -361,6 +365,7 @@ async function connectWebTransport(
 			Lite.ALPN_04,
 			Lite.ALPN_03,
 			Lite.ALPN,
+			Ietf.ALPN.DRAFT_19,
 			Ietf.ALPN.DRAFT_18,
 			Ietf.ALPN.DRAFT_17,
 			Ietf.ALPN.DRAFT_16,

--- a/js/net/src/ietf/connection.ts
+++ b/js/net/src/ietf/connection.ts
@@ -70,7 +70,7 @@ export class Connection implements Established {
 		this.#quic = quic;
 
 		// Two-path dispatch: v14-v16 uses adapter, v17+ uses native bidi streams
-		if (version === Version.DRAFT_17 || version === Version.DRAFT_18) {
+		if (version >= Version.DRAFT_17) {
 			this.#session = new NativeSession(quic, version);
 			// v17+: control/setup stream only carries GoAway
 			void this.#runGoAway(control, version);

--- a/js/net/src/ietf/control.ts
+++ b/js/net/src/ietf/control.ts
@@ -141,6 +141,10 @@ const MessagesV17 = {
 // * #1542 splits SUBSCRIBE_NAMESPACE into SUBSCRIBE_NAMESPACE + SUBSCRIBE_TRACKS (0x51).
 //   moq-lite does not implement track subscription via PUBLISH replication, so 0x51
 //   is rejected as an explicit error rather than silently ignored.
+//
+// draft-19 (#1765 range filters, #1613 MAX_REQUEST_UPDATES, GOAWAY request-id
+// removal, etc.) makes no wire changes to the messages moq-lite exchanges, so it
+// reuses the same map.
 const MessagesV18 = MessagesV17;
 
 type V14MessageType = (typeof MessagesV14)[keyof typeof MessagesV14];
@@ -208,10 +212,10 @@ export class Stream {
 		return await this.#readLock.runExclusive(async () => {
 			const messageType = await this.stream.reader.u53();
 
-			// Draft-18 (#1542) splits SUBSCRIBE_NAMESPACE into SUBSCRIBE_NAMESPACE +
+			// Draft-18+ (#1542) splits SUBSCRIBE_NAMESPACE into SUBSCRIBE_NAMESPACE +
 			// SUBSCRIBE_TRACKS (0x51). moq-lite does not support track subscription
 			// via PUBLISH replication, so reject loudly rather than wait forever.
-			if (this.version === Version.DRAFT_18 && messageType === SUBSCRIBE_TRACKS_ID) {
+			if (this.version >= Version.DRAFT_18 && messageType === SUBSCRIBE_TRACKS_ID) {
 				throw new Error("SUBSCRIBE_TRACKS (0x51) is not supported in moq-lite (no PUBLISH replication)");
 			}
 

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -555,6 +555,14 @@ test("Reader#u62: accepts 0xFC 7-byte form on draft-18", async () => {
 	expect(await reader.done()).toBe(true);
 });
 
+test("Reader#u62: accepts 0xFC 7-byte form on draft-19", async () => {
+	const value = 0x12_3456_789a_bcn;
+	const bytes = new Uint8Array([0xfc, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc]);
+	const reader = new Reader(undefined, bytes, Version.DRAFT_19);
+	expect(await reader.u62()).toBe(value);
+	expect(await reader.done()).toBe(true);
+});
+
 test("Leading-ones varint: 7-byte form round-trips on draft-18", () => {
 	// Encode 7 bytes manually: 1111110_0 (prefix bit 48 = 0) + 6 bytes payload
 	const value = 0x12_3456_789a_bcn;

--- a/js/net/src/ietf/version.ts
+++ b/js/net/src/ietf/version.ts
@@ -37,6 +37,12 @@ export const Version = {
 	 * https://www.ietf.org/archive/id/draft-ietf-moq-transport-18.txt
 	 */
 	DRAFT_18: 0xff000012,
+
+	/**
+	 * draft-ietf-moq-transport-19
+	 * https://www.ietf.org/archive/id/draft-ietf-moq-transport-19.txt
+	 */
+	DRAFT_19: 0xff000013,
 } as const;
 
 export type Version = (typeof Version)[keyof typeof Version];
@@ -48,6 +54,7 @@ export const ALPN = {
 	DRAFT_16: "moqt-16",
 	DRAFT_17: "moqt-17",
 	DRAFT_18: "moqt-18",
+	DRAFT_19: "moqt-19",
 } as const;
 
 /**
@@ -59,7 +66,8 @@ export type IetfVersion =
 	| typeof Version.DRAFT_15
 	| typeof Version.DRAFT_16
 	| typeof Version.DRAFT_17
-	| typeof Version.DRAFT_18;
+	| typeof Version.DRAFT_18
+	| typeof Version.DRAFT_19;
 
 const VERSION_NAMES: Record<number, string> = {
 	[Version.DRAFT_07]: "moq-transport-07",
@@ -68,6 +76,7 @@ const VERSION_NAMES: Record<number, string> = {
 	[Version.DRAFT_16]: "moq-transport-16",
 	[Version.DRAFT_17]: "moq-transport-17",
 	[Version.DRAFT_18]: "moq-transport-18",
+	[Version.DRAFT_19]: "moq-transport-19",
 };
 
 export function versionName(v: Version): string {

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -84,6 +84,10 @@ test("integration: ietf draft-18", async () => {
 	await runPublishSubscribeFlow(Ietf.ALPN.DRAFT_18);
 });
 
+test("integration: ietf draft-19", async () => {
+	await runPublishSubscribeFlow(Ietf.ALPN.DRAFT_19);
+});
+
 test("integration: subscribe to non-existent broadcast", async () => {
 	const pair = createMockTransportPair("");
 

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -201,13 +201,13 @@ fn websocket_subprotocols(alpns: &[&str]) -> Vec<String> {
 	// newest first, then the bare qmux fallbacks. Mirrors qmux's own ALPN
 	// builder, which isn't public.
 	//
-	// `qmux-00.moqt-18` is excluded: moq-transport-18 requires qmux-01, so that
-	// pair is illegal (matches the relay and js/net's connect.ts).
+	// `qmux-00.moqt-1{8,9}` is excluded: moq-transport-18 and -19 require qmux-01, so
+	// those pairs are illegal (matches the relay and js/net's connect.ts).
 	let versions = [qmux::Version::QMux01, qmux::Version::QMux00];
 	let mut protocols = Vec::with_capacity(versions.len() * alpns.len() + qmux::ALPNS.len());
 	for &alpn in alpns {
 		for version in versions {
-			if version == qmux::Version::QMux00 && alpn == "moqt-18" {
+			if version == qmux::Version::QMux00 && matches!(alpn, "moqt-18" | "moqt-19") {
 				continue;
 			}
 			protocols.push(format!("{}{alpn}", version.prefix()));

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -196,18 +196,21 @@ pub(crate) async fn connect(
 	Ok(session)
 }
 
+/// moq-transport-18 and -19 require qmux-01, so we never pair them with qmux-00.
+/// Mirrors the relay's `QMUX01_ONLY_ALPNS` and js/net's `connect.ts`.
+const QMUX01_ONLY_ALPNS: &[&str] = &["moqt-18", "moqt-19"];
+
 fn websocket_subprotocols(alpns: &[&str]) -> Vec<String> {
 	// Each moq ALPN under every QMux wire version (`qmux-01.moq-lite-04`, ...),
 	// newest first, then the bare qmux fallbacks. Mirrors qmux's own ALPN
 	// builder, which isn't public.
 	//
-	// `qmux-00.moqt-1{8,9}` is excluded: moq-transport-18 and -19 require qmux-01, so
-	// those pairs are illegal (matches the relay and js/net's connect.ts).
+	// `qmux-00.moqt-1{8,9}` is excluded as an illegal pair (see QMUX01_ONLY_ALPNS).
 	let versions = [qmux::Version::QMux01, qmux::Version::QMux00];
 	let mut protocols = Vec::with_capacity(versions.len() * alpns.len() + qmux::ALPNS.len());
 	for &alpn in alpns {
 		for version in versions {
-			if version == qmux::Version::QMux00 && matches!(alpn, "moqt-18" | "moqt-19") {
+			if version == qmux::Version::QMux00 && QMUX01_ONLY_ALPNS.contains(&alpn) {
 				continue;
 			}
 			protocols.push(format!("{}{alpn}", version.prefix()));

--- a/rs/moq-native/tests/alpn.rs
+++ b/rs/moq-native/tests/alpn.rs
@@ -2,7 +2,7 @@
 //! successful MoQ handshake between a Quinn server and client.
 //!
 //! This covers both ALPN-based version negotiation (moq-lite-03/04,
-//! moqt-15/16/17/18) and SETUP-based version negotiation (moql, moq-00) used
+//! moqt-15/16/17/18/19) and SETUP-based version negotiation (moql, moq-00) used
 //! by older protocol versions like moq-transport-14 and moq-lite-01/02.
 //!
 //! It also tests WebTransport, which uses sub-protocols in the HTTP CONNECT
@@ -163,6 +163,12 @@ async fn version_moq_transport_18() {
 	connect_with_version("moq-transport-18").await;
 }
 
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn version_moq_transport_19() {
+	connect_with_version("moq-transport-19").await;
+}
+
 // ── WebTransport: sub-protocol negotiation ──────────────────────────
 // Browser clients use WebTransport (h3 ALPN) and negotiate the MoQ
 // protocol version via sub-protocols in the HTTP CONNECT request.
@@ -219,4 +225,10 @@ async fn webtransport_moq_transport_17() {
 #[tokio::test]
 async fn webtransport_moq_transport_18() {
 	connect_with_webtransport(Some("moq-transport-18")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn webtransport_moq_transport_19() {
+	connect_with_webtransport(Some("moq-transport-19")).await;
 }

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -165,6 +165,12 @@ async fn broadcast_moq_transport_18() {
 	broadcast_test("moqt", Some("moq-transport-18"), Some("moq-transport-18")).await;
 }
 
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_moq_transport_19() {
+	broadcast_test("moqt", Some("moq-transport-19"), Some("moq-transport-19")).await;
+}
+
 // ── Raw QUIC – server supports all versions, client pins one ─────────
 
 #[tracing_test::traced_test]
@@ -215,6 +221,12 @@ async fn broadcast_negotiate_server_all_client_transport_18() {
 	broadcast_test("moqt", Some("moq-transport-18"), None).await;
 }
 
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_negotiate_server_all_client_transport_19() {
+	broadcast_test("moqt", Some("moq-transport-19"), None).await;
+}
+
 // ── Raw QUIC – client supports all versions, server pins one ─────────
 
 #[tracing_test::traced_test]
@@ -263,6 +275,12 @@ async fn broadcast_negotiate_client_all_server_transport_17() {
 #[tokio::test]
 async fn broadcast_negotiate_client_all_server_transport_18() {
 	broadcast_test("moqt", None, Some("moq-transport-18")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_negotiate_client_all_server_transport_19() {
+	broadcast_test("moqt", None, Some("moq-transport-19")).await;
 }
 
 // ── WebTransport (https://) – same version on both sides ────────────
@@ -321,6 +339,12 @@ async fn broadcast_webtransport_moq_transport_18() {
 	broadcast_test("https", Some("moq-transport-18"), Some("moq-transport-18")).await;
 }
 
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_webtransport_moq_transport_19() {
+	broadcast_test("https", Some("moq-transport-19"), Some("moq-transport-19")).await;
+}
+
 // ── WebTransport – server supports all, client pins one ─────────────
 
 #[tracing_test::traced_test]
@@ -371,6 +395,12 @@ async fn broadcast_webtransport_negotiate_server_all_client_transport_18() {
 	broadcast_test("https", Some("moq-transport-18"), None).await;
 }
 
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_webtransport_negotiate_server_all_client_transport_19() {
+	broadcast_test("https", Some("moq-transport-19"), None).await;
+}
+
 // ── WebTransport – client supports all, server pins one ─────────────
 
 #[tracing_test::traced_test]
@@ -419,6 +449,12 @@ async fn broadcast_webtransport_negotiate_client_all_server_transport_17() {
 #[tokio::test]
 async fn broadcast_webtransport_negotiate_client_all_server_transport_18() {
 	broadcast_test("https", None, Some("moq-transport-18")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_webtransport_negotiate_client_all_server_transport_19() {
+	broadcast_test("https", None, Some("moq-transport-19")).await;
 }
 
 // ── WebSocket (ws://) ───────────────────────────────────────────────

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -1,6 +1,6 @@
 use crate::{
-	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Error,
-	NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
+	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP,
+	Error, NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
 	coding::{self, Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -79,6 +79,27 @@ impl Client {
 		// If ALPN was used to negotiate the version, use the appropriate encoding.
 		// Default to IETF 14 if no ALPN was used and we'll negotiate the version later.
 		let (encoding, supported) = match session.protocol() {
+			Some(ALPN_19) => {
+				let v = self
+					.versions
+					.select(Version::Ietf(ietf::Version::Draft19))
+					.ok_or(Error::Version)?;
+
+				// Draft-17+: SETUP is exchanged in the background by the session.
+				ietf::start(
+					session.clone(),
+					None,
+					None,
+					true,
+					self.publish.clone(),
+					self.consume.clone(),
+					self.stats.clone(),
+					ietf::Version::Draft19,
+				)?;
+
+				tracing::debug!(version = ?v, "connected");
+				return Ok(Session::new(session, v, None));
+			}
 			Some(ALPN_18) => {
 				let v = self
 					.versions

--- a/rs/moq-net/src/ietf/goaway.rs
+++ b/rs/moq-net/src/ietf/goaway.rs
@@ -127,6 +127,25 @@ mod tests {
 		assert_eq!(decoded.timeout, 5000);
 	}
 
+	/// Draft-19 (#1623) removed the Request ID again: the body is just URI + timeout,
+	/// same bytes we already emit. Round-trip to lock that in.
+	#[test]
+	fn test_goaway_v19_timeout() {
+		let msg = GoAway {
+			new_session_uri: "moqt://relay.example/".into(),
+			timeout: 5000,
+		};
+
+		let mut buf = BytesMut::new();
+		msg.encode_msg(&mut buf, Version::Draft19).unwrap();
+
+		let mut bytes = bytes::Bytes::from(buf.to_vec());
+		let decoded: GoAway = GoAway::decode_msg(&mut bytes, Version::Draft19).unwrap();
+
+		assert_eq!(decoded.new_session_uri, "moqt://relay.example/");
+		assert_eq!(decoded.timeout, 5000);
+	}
+
 	/// Draft-18 added an optional trailing Request ID (#1559). A peer that emits
 	/// one must not break our decoder; we drain and discard it.
 	#[test]

--- a/rs/moq-net/src/ietf/group.rs
+++ b/rs/moq-net/src/ietf/group.rs
@@ -386,6 +386,27 @@ mod tests {
 		assert!(GroupFlags::decode(v17 | GroupFlags::FIRST_OBJECT_BIT, Version::Draft17).is_err());
 	}
 
+	/// Draft-19 makes no changes to the subgroup header wire format, so the flags
+	/// byte must be byte-identical to draft-18 on both encode and decode.
+	#[test]
+	fn test_draft19_matches_draft18() {
+		for flags in [
+			GroupFlags::default(),
+			GroupFlags {
+				has_subgroup: true,
+				has_extensions: true,
+				has_end: true,
+				has_subgroup_object: false,
+				has_priority: false,
+			},
+		] {
+			let v18 = flags.encode(Version::Draft18).unwrap();
+			let v19 = flags.encode(Version::Draft19).unwrap();
+			assert_eq!(v18, v19, "draft-19 must encode the subgroup header like draft-18");
+			assert_eq!(GroupFlags::decode(v19, Version::Draft19).unwrap(), flags);
+		}
+	}
+
 	/// Draft-18 byte 0x70..=0x7D should decode to the same flags as 0x30..=0x3D.
 	#[test]
 	fn test_draft18_extended_range() {

--- a/rs/moq-net/src/ietf/version.rs
+++ b/rs/moq-net/src/ietf/version.rs
@@ -8,6 +8,7 @@ pub enum Version {
 	Draft16,
 	Draft17,
 	Draft18,
+	Draft19,
 }
 
 impl fmt::Display for Version {
@@ -18,6 +19,7 @@ impl fmt::Display for Version {
 			Self::Draft16 => write!(f, "moq-transport-16"),
 			Self::Draft17 => write!(f, "moq-transport-17"),
 			Self::Draft18 => write!(f, "moq-transport-18"),
+			Self::Draft19 => write!(f, "moq-transport-19"),
 		}
 	}
 }

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1,6 +1,6 @@
 use crate::{
-	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP, Error,
-	NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
+	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP,
+	Error, NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
 	coding::{Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -78,6 +78,15 @@ impl Server {
 		};
 
 		let (encoding, supported) = match session.protocol() {
+			Some(ALPN_19) => {
+				self.versions
+					.select(Version::Ietf(ietf::Version::Draft19))
+					.ok_or(Error::Version)?;
+				return Ok(deferred(Handshake::IetfModern {
+					session,
+					version: ietf::Version::Draft19,
+				}));
+			}
 			Some(ALPN_18) => {
 				self.versions
 					.select(Version::Ietf(ietf::Version::Draft18))

--- a/rs/moq-net/src/setup.rs
+++ b/rs/moq-net/src/setup.rs
@@ -74,7 +74,9 @@ impl SetupVersion {
 		match v {
 			Version::Ietf(ietf::Version::Draft14) => Self::Draft14,
 			Version::Ietf(ietf::Version::Draft15) | Version::Ietf(ietf::Version::Draft16) => Self::Draft15Plus,
-			Version::Ietf(ietf::Version::Draft17) | Version::Ietf(ietf::Version::Draft18) => Self::Modern,
+			Version::Ietf(ietf::Version::Draft17)
+			| Version::Ietf(ietf::Version::Draft18)
+			| Version::Ietf(ietf::Version::Draft19) => Self::Modern,
 			Version::Lite(lite::Version::Lite01) | Version::Lite(lite::Version::Lite02) => Self::LiteLegacy,
 			Version::Lite(_) => Self::Unsupported,
 		}

--- a/rs/moq-net/src/version.rs
+++ b/rs/moq-net/src/version.rs
@@ -23,6 +23,7 @@ pub const ALPNS: &[&str] = &[
 	ALPN_LITE_04,
 	ALPN_LITE_03,
 	ALPN_LITE,
+	ALPN_19,
 	ALPN_18,
 	ALPN_17,
 	ALPN_16,
@@ -40,6 +41,7 @@ pub(crate) const ALPN_15: &str = "moqt-15";
 pub(crate) const ALPN_16: &str = "moqt-16";
 pub(crate) const ALPN_17: &str = "moqt-17";
 pub(crate) const ALPN_18: &str = "moqt-18";
+pub(crate) const ALPN_19: &str = "moqt-19";
 
 /// A MoQ protocol version.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -63,6 +65,7 @@ impl Version {
 			0xff000010 => Some(Self::Ietf(ietf::Version::Draft16)),
 			0xff000011 => Some(Self::Ietf(ietf::Version::Draft17)),
 			0xff000012 => Some(Self::Ietf(ietf::Version::Draft18)),
+			0xff000013 => Some(Self::Ietf(ietf::Version::Draft19)),
 			_ => None,
 		}
 	}
@@ -80,6 +83,7 @@ impl Version {
 			Self::Ietf(ietf::Version::Draft16) => 0xff000010,
 			Self::Ietf(ietf::Version::Draft17) => 0xff000011,
 			Self::Ietf(ietf::Version::Draft18) => 0xff000012,
+			Self::Ietf(ietf::Version::Draft19) => 0xff000013,
 		}
 	}
 
@@ -98,6 +102,7 @@ impl Version {
 			ALPN_16 => Some(Self::Ietf(ietf::Version::Draft16)),
 			ALPN_17 => Some(Self::Ietf(ietf::Version::Draft17)),
 			ALPN_18 => Some(Self::Ietf(ietf::Version::Draft18)),
+			ALPN_19 => Some(Self::Ietf(ietf::Version::Draft19)),
 			_ => None,
 		}
 	}
@@ -114,6 +119,7 @@ impl Version {
 			Self::Ietf(ietf::Version::Draft16) => ALPN_16,
 			Self::Ietf(ietf::Version::Draft17) => ALPN_17,
 			Self::Ietf(ietf::Version::Draft18) => ALPN_18,
+			Self::Ietf(ietf::Version::Draft19) => ALPN_19,
 		}
 	}
 
@@ -167,6 +173,7 @@ impl FromStr for Version {
 			"moq-transport-16" => Ok(Self::Ietf(ietf::Version::Draft16)),
 			"moq-transport-17" => Ok(Self::Ietf(ietf::Version::Draft17)),
 			"moq-transport-18" => Ok(Self::Ietf(ietf::Version::Draft18)),
+			"moq-transport-19" => Ok(Self::Ietf(ietf::Version::Draft19)),
 			_ => Err(format!("unknown version: {s}")),
 		}
 	}
@@ -232,6 +239,7 @@ impl Versions {
 			Version::Lite(lite::Version::Lite03),
 			Version::Lite(lite::Version::Lite02),
 			Version::Lite(lite::Version::Lite01),
+			Version::Ietf(ietf::Version::Draft19),
 			Version::Ietf(ietf::Version::Draft18),
 			Version::Ietf(ietf::Version::Draft17),
 			Version::Ietf(ietf::Version::Draft16),

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -120,9 +120,9 @@ where
 /// Newest first so axum's exact-string match picks the freshest one.
 const QMUX_VERSIONS: &[qmux::Version] = &[qmux::Version::QMux01, qmux::Version::QMux00];
 
-/// moq-transport-18 requires qmux-01, so we never pair it with qmux-00.
-/// Mirrors `js/net`'s `connect.ts` and moq-native's `qmux_versions_for`.
-const QMUX01_ONLY_ALPN: &str = "moqt-18";
+/// moq-transport-18 and -19 require qmux-01, so we never pair them with qmux-00.
+/// Mirrors `js/net`'s `connect.ts` and moq-native's `websocket_subprotocols`.
+const QMUX01_ONLY_ALPNS: &[&str] = &["moqt-18", "moqt-19"];
 
 /// Subprotocols to advertise on the WebSocket upgrade.
 ///
@@ -133,13 +133,13 @@ const QMUX01_ONLY_ALPN: &str = "moqt-18";
 /// resolve a moq version from it, and the relay silently downgrades clients to
 /// Lite02 via SETUP-based negotiation.
 ///
-/// `qmux-00.moqt-18` is excluded: moq-transport-18 requires qmux-01, so that
-/// pair is illegal.
+/// `qmux-00.moqt-1{8,9}` is excluded: moq-transport-18 and -19 require qmux-01, so
+/// those pairs are illegal.
 fn supported_subprotocols() -> Vec<String> {
 	let mut out = Vec::with_capacity(QMUX_VERSIONS.len() * moq_net::ALPNS.len() + qmux::ALPNS.len());
 	for &version in QMUX_VERSIONS {
 		for &alpn in moq_net::ALPNS {
-			if version == qmux::Version::QMux00 && alpn == QMUX01_ONLY_ALPN {
+			if version == qmux::Version::QMux00 && QMUX01_ONLY_ALPNS.contains(&alpn) {
 				continue;
 			}
 			out.push(format!("{}{alpn}", version.prefix()));
@@ -218,10 +218,14 @@ mod tests {
 
 	#[test]
 	fn supported_subprotocols_lists_full_matrix() {
-		// Guard the literal: it must stay the IETF draft-18 ALPN (wire 0xff000012).
+		// Guard the literals: they must stay the IETF draft-18/19 ALPNs
+		// (wire 0xff000012 / 0xff000013).
 		assert_eq!(
-			moq_net::Version::from_alpn(QMUX01_ONLY_ALPN).map(|v| v.code()),
-			Some(0xff000012)
+			QMUX01_ONLY_ALPNS
+				.iter()
+				.map(|&a| moq_net::Version::from_alpn(a).map(|v| v.code()))
+				.collect::<Vec<_>>(),
+			vec![Some(0xff000012), Some(0xff000013)]
 		);
 
 		let list = supported_subprotocols();
@@ -232,11 +236,11 @@ mod tests {
 		assert_eq!(list.first().map(String::as_str), Some(expected_first.as_str()));
 
 		// Every moq ALPN must appear under every qmux wire version, except the
-		// illegal `qmux-00.moqt-18` pair (moq-transport-18 needs qmux-01).
+		// illegal `qmux-00.moqt-1{8,9}` pairs (moq-transport-18/19 need qmux-01).
 		for &version in QMUX_VERSIONS {
 			for &alpn in moq_net::ALPNS {
 				let entry = format!("{}{alpn}", version.prefix());
-				if version == qmux::Version::QMux00 && alpn == QMUX01_ONLY_ALPN {
+				if version == qmux::Version::QMux00 && QMUX01_ONLY_ALPNS.contains(&alpn) {
 					assert!(!list.contains(&entry), "illegal pair {entry} must not be advertised");
 					continue;
 				}


### PR DESCRIPTION
## Summary

Adds IETF **moq-transport draft-19** (ALPN `moqt-19`, wire code `0xff000013`) alongside drafts 14-18, in both `moq-net` (Rust) and `@moq/net` (JS). It is advertised by default now that draft-19 is published.

The 18→19 delta is **additive for the subset we implement**, so this is version registration rather than new message logic:

- Range filters (#1765) and the `MAX_REQUEST_UPDATES` setup option (#1613) are ignored params.
- GOAWAY dropped its request id (#1623), which our decoder already drains.
- SETUP and the subgroup data plane are byte-identical to draft-18.

The `_ => newest draft` dispatch used throughout `ietf/` absorbs the rest, so draft-19 falls forward automatically. Scope is unchanged from draft-18 ("just enough for compat"): FETCH, incoming TRACK_STATUS, SUBSCRIBE_TRACKS, absolute subscribe, and range filters remain unsupported/ignored, same posture as before.

## Changes

- **`rs/moq-net`**: `ietf::Version::Draft19`, ALPN `moqt-19`, code `0xff000013`, threaded through `version.rs`/`setup.rs`; new `Some(ALPN_19)` arms in the client/server ALPN dispatch (string match, not an enum match, so the compiler doesn't flag a missing one).
- **`rs/moq-native`, `rs/moq-relay`**: `moqt-19` pins to qmux-01 like `moqt-18` in the WebSocket subprotocol wiring.
- **`js/net`**: mirror in `version.ts`, `control.ts`, `connect.ts`, `accept.ts`, `connection.ts`.
- **`doc/concept/standard/interop.md`**: "14 through 19".

## Public API

- `moq_net::Version` is `#[non_exhaustive]` and `ietf::Version` is a private module, so adding the draft is non-breaking for every binding and downstream consumer. No renamed/removed/signature-changed `pub` items. Targets `main` accordingly.

## Also included (separate commit)

- **`build(deps): bump crossbeam-epoch to 0.9.20`** — a newly published advisory `RUSTSEC-2026-0204` (invalid pointer dereference in crossbeam-epoch's `fmt::Pointer` impl) started failing `cargo deny` in `just ci` on every branch. Lock-only transitive bump to the fixed version, unrelated to draft-19; kept as its own commit so it can be split out or squashed cleanly.

## Test plan

- [x] `moq-net` unit tests, incl. new draft-19 GOAWAY and subgroup-header round-trips
- [x] `moq-native` per-version loopback handshake tests for draft-19 (raw QUIC + WebTransport, full modern SETUP)
- [x] `moq-relay` WebSocket subprotocol-matrix test covers the `moqt-19` qmux-01 pin
- [x] `@moq/net` typecheck + biome + unit/integration tests (incl. draft-19)
- [x] `cargo fmt --check` and `clippy` clean on the affected crates

_Note: full `just check` could not run in this environment (nix devshell fails to build locally); relied on targeted `cargo`/`bun` equivalents. CI is the gate._

(Written by Claude Opus 4.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)