### PR TITLE
feat(moq-native): optional client TLS host_name (SNI) override

### DIFF
--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -782,6 +782,26 @@ mod tests {
 	}
 
 	#[test]
+	fn test_toml_server_name_survives_update_from() {
+		let toml = r#"
+			tls.server_name = "example.host"
+		"#;
+
+		let mut config: ClientConfig = toml::from_str(toml).unwrap();
+		assert_eq!(config.tls.server_name.as_deref(), Some("example.host"));
+
+		// Simulate: TOML loaded, then CLI args re-applied (no --client-tls-server-name flag).
+		config.update_from(["test"]);
+		assert_eq!(config.tls.server_name.as_deref(), Some("example.host"));
+	}
+
+	#[test]
+	fn test_cli_server_name() {
+		let config = ClientConfig::parse_from(["test", "--client-tls-server-name", "override.example"]);
+		assert_eq!(config.tls.server_name.as_deref(), Some("override.example"));
+	}
+
+	#[test]
 	fn test_cli_no_version_defaults_to_all() {
 		let config = ClientConfig::parse_from(["test"]);
 		assert!(config.version.is_empty());

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -782,23 +782,23 @@ mod tests {
 	}
 
 	#[test]
-	fn test_toml_server_name_survives_update_from() {
+	fn test_toml_host_name_survives_update_from() {
 		let toml = r#"
-			tls.server_name = "example.host"
+			tls.host_name = "example.host"
 		"#;
 
 		let mut config: ClientConfig = toml::from_str(toml).unwrap();
-		assert_eq!(config.tls.server_name.as_deref(), Some("example.host"));
+		assert_eq!(config.tls.host_name.as_deref(), Some("example.host"));
 
-		// Simulate: TOML loaded, then CLI args re-applied (no --client-tls-server-name flag).
+		// Simulate: TOML loaded, then CLI args re-applied (no --client-tls-host-name flag).
 		config.update_from(["test"]);
-		assert_eq!(config.tls.server_name.as_deref(), Some("example.host"));
+		assert_eq!(config.tls.host_name.as_deref(), Some("example.host"));
 	}
 
 	#[test]
-	fn test_cli_server_name() {
-		let config = ClientConfig::parse_from(["test", "--client-tls-server-name", "override.example"]);
-		assert_eq!(config.tls.server_name.as_deref(), Some("override.example"));
+	fn test_cli_host_name() {
+		let config = ClientConfig::parse_from(["test", "--client-tls-host-name", "override.example"]);
+		assert_eq!(config.tls.host_name.as_deref(), Some("override.example"));
 	}
 
 	#[test]

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -122,7 +122,7 @@ pub(crate) struct NoqClient {
 	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
 	pub http_bootstrap: bool,
 	/// Optional TLS SNI / verification hostname override (from config).
-	pub server_name: Option<String>,
+	pub host_name: Option<String>,
 }
 
 impl NoqClient {
@@ -153,7 +153,7 @@ impl NoqClient {
 			quic,
 			transport,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
-			server_name: config.tls.server_name.clone(),
+			host_name: config.tls.host_name.clone(),
 		})
 	}
 
@@ -228,10 +228,10 @@ impl NoqClient {
 
 		tracing::debug!(%url, %ip, "connecting");
 
-		// Use the configured server_name override for SNI + cert verification, else the URL host.
-		let server_name = self.server_name.clone().unwrap_or(host);
+		// Use the configured host_name override for SNI + cert verification, else the URL host.
+		let host_name = self.host_name.clone().unwrap_or(host);
 
-		let connection = self.quic.connect_with(config, ip, &server_name)?.await?;
+		let connection = self.quic.connect_with(config, ip, &host_name)?.await?;
 		tracing::Span::current().record("id", connection.stable_id());
 
 		let mut request = web_transport_noq::proto::ConnectRequest::new(url.clone());

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -121,6 +121,8 @@ pub(crate) struct NoqClient {
 	pub transport: Arc<noq::TransportConfig>,
 	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
 	pub http_bootstrap: bool,
+	/// Optional TLS SNI / verification hostname override (from config).
+	pub server_name: Option<String>,
 }
 
 impl NoqClient {
@@ -151,6 +153,7 @@ impl NoqClient {
 			quic,
 			transport,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
+			server_name: config.tls.server_name.clone(),
 		})
 	}
 
@@ -225,7 +228,10 @@ impl NoqClient {
 
 		tracing::debug!(%url, %ip, "connecting");
 
-		let connection = self.quic.connect_with(config, ip, &host)?.await?;
+		// Use the configured server_name override for SNI + cert verification, else the URL host.
+		let server_name = self.server_name.clone().unwrap_or(host);
+
+		let connection = self.quic.connect_with(config, ip, &server_name)?.await?;
 		tracing::Span::current().record("id", connection.stable_id());
 
 		let mut request = web_transport_noq::proto::ConnectRequest::new(url.clone());

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -108,6 +108,8 @@ pub(crate) struct QuicheClient {
 	pub verification: crate::tls::Verification,
 	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
 	pub http_bootstrap: bool,
+	/// Optional TLS SNI / verification hostname override (from config).
+	pub server_name: Option<String>,
 	pub max_streams: u64,
 }
 
@@ -117,6 +119,7 @@ impl QuicheClient {
 			bind: config.bind,
 			verification: config.tls.verification()?,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
+			server_name: config.tls.server_name.clone(),
 			max_streams: config.max_streams.unwrap_or(crate::DEFAULT_MAX_STREAMS),
 		})
 	}
@@ -191,6 +194,25 @@ impl QuicheClient {
 			}
 		}
 
+		// The server_name override affects ONLY the TLS SNI / cert-verification
+		// name, never the dial target. The dial target is always resolved from the
+		// URL host (consistent with the quinn and noq backends).
+		//
+		// NOTE: web-transport-quiche's ClientBuilder::connect(host, port) uses its
+		// `host` parameter for BOTH DNS resolution (dial target) AND TLS SNI — the
+		// API does not allow separating them. We therefore pass the URL host to
+		// ensure the correct dial target, matching quinn/noq behavior. When a
+		// server_name override is configured, it cannot be applied to the quiche
+		// backend without upstream API changes to ClientBuilder.
+		if let Some(ref override_name) = self.server_name {
+			tracing::warn!(
+				server_name = %override_name,
+				host = %host,
+				"client tls server_name override is not supported on the quiche backend; using URL host for SNI"
+			);
+		}
+		let dial_host = &host;
+
 		tracing::debug!(%url, "connecting via quiche");
 
 		let mut request = web_transport_quiche::proto::ConnectRequest::new(url.clone());
@@ -202,7 +224,7 @@ impl QuicheClient {
 			"https" => {
 				// WebTransport over HTTP/3
 				let conn = builder
-					.connect(&host, port)
+					.connect(dial_host, port)
 					.await
 					.map_err(Error::Connect)?
 					.established()
@@ -216,7 +238,7 @@ impl QuicheClient {
 			"moqt" | "moql" => {
 				// Raw QUIC mode
 				let conn = builder
-					.connect(&host, port)
+					.connect(dial_host, port)
 					.await
 					.map_err(Error::Connect)?
 					.established()

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -45,6 +45,9 @@ pub enum Error {
 	#[error("url scheme must be 'https', 'moqt', or 'moql'")]
 	InvalidScheme,
 
+	#[error("client tls host_name override is not supported with the quiche backend")]
+	HostNameUnsupported,
+
 	#[error("missing ALPN")]
 	MissingAlpn,
 
@@ -108,18 +111,23 @@ pub(crate) struct QuicheClient {
 	pub verification: crate::tls::Verification,
 	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
 	pub http_bootstrap: bool,
-	/// Optional TLS SNI / verification hostname override (from config).
-	pub server_name: Option<String>,
 	pub max_streams: u64,
 }
 
 impl QuicheClient {
 	pub fn new(config: &ClientConfig) -> Result<Self> {
+		// web-transport-quiche's ClientBuilder::connect(host, port) uses `host` for BOTH
+		// DNS resolution (the dial target) AND the TLS SNI, so a host_name override that
+		// decouples them can't be applied without an upstream API change. Fail fast at
+		// init rather than silently ignoring the override on the first connect.
+		if config.tls.host_name.is_some() {
+			return Err(Error::HostNameUnsupported);
+		}
+
 		Ok(Self {
 			bind: config.bind,
 			verification: config.tls.verification()?,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
-			server_name: config.tls.server_name.clone(),
 			max_streams: config.max_streams.unwrap_or(crate::DEFAULT_MAX_STREAMS),
 		})
 	}
@@ -194,25 +202,6 @@ impl QuicheClient {
 			}
 		}
 
-		// The server_name override affects ONLY the TLS SNI / cert-verification
-		// name, never the dial target. The dial target is always resolved from the
-		// URL host (consistent with the quinn and noq backends).
-		//
-		// NOTE: web-transport-quiche's ClientBuilder::connect(host, port) uses its
-		// `host` parameter for BOTH DNS resolution (dial target) AND TLS SNI — the
-		// API does not allow separating them. We therefore pass the URL host to
-		// ensure the correct dial target, matching quinn/noq behavior. When a
-		// server_name override is configured, it cannot be applied to the quiche
-		// backend without upstream API changes to ClientBuilder.
-		if let Some(ref override_name) = self.server_name {
-			tracing::warn!(
-				server_name = %override_name,
-				host = %host,
-				"client tls server_name override is not supported on the quiche backend; using URL host for SNI"
-			);
-		}
-		let dial_host = &host;
-
 		tracing::debug!(%url, "connecting via quiche");
 
 		let mut request = web_transport_quiche::proto::ConnectRequest::new(url.clone());
@@ -224,7 +213,7 @@ impl QuicheClient {
 			"https" => {
 				// WebTransport over HTTP/3
 				let conn = builder
-					.connect(dial_host, port)
+					.connect(&host, port)
 					.await
 					.map_err(Error::Connect)?
 					.established()
@@ -238,7 +227,7 @@ impl QuicheClient {
 			"moqt" | "moql" => {
 				// Raw QUIC mode
 				let conn = builder
-					.connect(dial_host, port)
+					.connect(&host, port)
 					.await
 					.map_err(Error::Connect)?
 					.established()

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -120,7 +120,7 @@ pub(crate) struct QuinnClient {
 	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
 	pub http_bootstrap: bool,
 	/// Optional TLS SNI / verification hostname override (from config).
-	pub server_name: Option<String>,
+	pub host_name: Option<String>,
 }
 
 impl QuinnClient {
@@ -151,7 +151,7 @@ impl QuinnClient {
 			quic,
 			transport,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
-			server_name: config.tls.server_name.clone(),
+			host_name: config.tls.host_name.clone(),
 		})
 	}
 
@@ -226,10 +226,10 @@ impl QuinnClient {
 
 		tracing::debug!(%url, %ip, "connecting");
 
-		// Use the configured server_name override for SNI + cert verification, else the URL host.
-		let server_name = self.server_name.clone().unwrap_or(host);
+		// Use the configured host_name override for SNI + cert verification, else the URL host.
+		let host_name = self.host_name.clone().unwrap_or(host);
 
-		let connection = self.quic.connect_with(config, ip, &server_name)?.await?;
+		let connection = self.quic.connect_with(config, ip, &host_name)?.await?;
 		tracing::Span::current().record("id", connection.stable_id());
 
 		let mut request = web_transport_quinn::proto::ConnectRequest::new(url.clone());

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -119,6 +119,8 @@ pub(crate) struct QuinnClient {
 	pub transport: Arc<quinn::TransportConfig>,
 	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
 	pub http_bootstrap: bool,
+	/// Optional TLS SNI / verification hostname override (from config).
+	pub server_name: Option<String>,
 }
 
 impl QuinnClient {
@@ -149,6 +151,7 @@ impl QuinnClient {
 			quic,
 			transport,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
+			server_name: config.tls.server_name.clone(),
 		})
 	}
 
@@ -223,7 +226,10 @@ impl QuinnClient {
 
 		tracing::debug!(%url, %ip, "connecting");
 
-		let connection = self.quic.connect_with(config, ip, &host)?.await?;
+		// Use the configured server_name override for SNI + cert verification, else the URL host.
+		let server_name = self.server_name.clone().unwrap_or(host);
+
+		let connection = self.quic.connect_with(config, ip, &server_name)?.await?;
 		tracing::Span::current().record("id", connection.stable_id());
 
 		let mut request = web_transport_quinn::proto::ConnectRequest::new(url.clone());

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -199,6 +199,18 @@ pub struct Client {
 	)]
 	pub disable_verify: Option<bool>,
 
+	/// Override the TLS SNI and certificate verification hostname for outbound connections.
+	///
+	/// When unset, the connect URL's host is used (default behavior). Useful when dialing a
+	/// raw IP address but needing to present/verify a DNS name the server certificate covers.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[arg(
+		id = "client-tls-server-name",
+		long = "client-tls-server-name",
+		env = "MOQ_CLIENT_TLS_SERVER_NAME"
+	)]
+	pub server_name: Option<String>,
+
 	/// Deprecated `--tls-*` spellings, folded into the canonical fields above with
 	/// a warning. Private and hidden so they stay off the public surface; not a
 	/// TOML field (config files use the canonical names).

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -205,11 +205,11 @@ pub struct Client {
 	/// raw IP address but needing to present/verify a DNS name the server certificate covers.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(
-		id = "client-tls-server-name",
-		long = "client-tls-server-name",
-		env = "MOQ_CLIENT_TLS_SERVER_NAME"
+		id = "client-tls-host-name",
+		long = "client-tls-host-name",
+		env = "MOQ_CLIENT_TLS_HOST_NAME"
 	)]
-	pub server_name: Option<String>,
+	pub host_name: Option<String>,
 
 	/// Deprecated `--tls-*` spellings, folded into the canonical fields above with
 	/// a warning. Private and hidden so they stay off the public surface; not a


### PR DESCRIPTION
## What

Adds an optional `host_name` field to the moq-native client TLS config (`tls::Client`) that overrides the TLS **SNI / certificate-verification hostname** used for outbound connections, independent of the connect URL host.

- Exposed the standard three ways: env `MOQ_CLIENT_TLS_HOST_NAME`, CLI `--client-tls-host-name`, TOML `[client.tls] host_name`.
- When set, it is used as **both** the TLS SNI extension and the rustls verification name at the connect site.
- When unset, behavior is unchanged (the URL host is used) — fully backwards-compatible.

## Why

We run our own clustering and resolve the exact backend node to dial *by IP* (a load-balanced DNS name wouldn't reliably reach the specific node). But when a client connects by **raw IP** (e.g. `moqt://10.0.1.5:4443`), there is no DNS hostname available for the TLS SNI or for certificate verification.

Per **RFC 6066 §3**, the SNI `HostName` must be a DNS FQDN — *"Literal IPv4 and IPv6 addresses are not permitted in 'HostName'."* A correct TLS stack (rustls included) therefore omits SNI entirely when the dial target is an IP literal. The result: the server can't select a certificate by SNI, and the client has no hostname to verify the peer certificate against.

This override lets the caller supply a valid DNS hostname (e.g. `service.example.com`) as the SNI + verification name while still dialing the resolved IP. That is a **spec-compliant** SNI value — a DNS name, not an IP — so the connection keeps **full certificate verification** rather than disabling it. The dial target (IP) and the TLS identity (hostname) are decoupled by design, as with connection reuse, load-balancer VIPs, or `curl --resolve` / `--connect-to`.

## How

Threads the optional `host_name` from `tls::Client` onto the backend client structs and computes the effective name as `self.host_name.clone().unwrap_or(host)` at the connect site, so the SNI/verification name is the override when present and the URL host otherwise. The **dial target is still resolved from the URL host** in all cases — only the SNI/verification name changes.

## Backends

- **quinn / noq:** full support — dial the IP resolved from the URL host, SNI/verify name = override.
- **quiche:** `web-transport-quiche`'s `ClientBuilder::connect(host, port)` couples DNS resolution and SNI, so the override can't be applied there without an upstream API change. Rather than silently ignoring it, the quiche backend **rejects the override at init** (`ClientConfig::init`) with `Error::HostNameUnsupported`, mirroring the existing `Error::MtlsUnsupported` precedent. Behavior is unchanged when the override is unset.

## Backwards compatibility

Non-breaking: with `host_name` unset (the default), the connect path produces byte-for-byte the same value as before across all three backends.

## Testing

Deployed and validated end-to-end: an egress relay dialing an ingest relay **by private IP** now completes the QUIC/TLS handshake (`moq-lite-04`) with **full certificate verification** — the server presents a wildcard cert covering the override name — and streams media. Prior to this change the same connection failed (no SNI → server could not select a cert / client could not verify against the IP).

---

*Maintainer edit: renamed the option from `server_name` to `host_name` (so the flag no longer pairs `client` and `server` in one name), and made the quiche backend fail fast at init instead of warning on every connect. (Written by Claude Opus 4.8)*