### PR TITLE
feat(moq-net): require broadcast close() + propagate real errors on abrupt teardown (#2087)

### DIFF
--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -66,6 +66,29 @@ if moq.IsAuthError(err) {
 }
 ```
 
+## Publishing lifetime
+
+A broadcast stays live only while you hold its `MoqBroadcastProducer`. The origin keeps a consumer, not the producer, so publishing does not keep it alive: once the producer is garbage-collected the broadcast is torn down and subscribers get a reset mid-stream. This bites when the producer goes out of scope while a background goroutine is still writing to its tracks.
+
+Keep a reference for as long as you are publishing, then close it explicitly when done:
+
+```go
+mediaProducer, err := broadcast.PublishMedia("aac", asc)
+if err != nil {
+    // handle error
+}
+origin.Publish("my-broadcast.hang", broadcast)
+
+// Keep `broadcast` reachable while producing (e.g. store it on a struct the
+// publishing goroutine owns). Don't let it fall out of scope here.
+produceAudio(mediaProducer)
+
+// Finish() closes the broadcast cleanly so subscribers see a normal end.
+broadcast.Finish()
+```
+
+If a producer is collected without `Finish()`, the underlying library logs a warning (`broadcast::Producer dropped without close()`) to help you spot the leak.
+
 ## Local development
 
 The in-tree `go/wrapper/` directory is the source skeleton; CI publishes it to the [moq-dev/moq-go](https://github.com/moq-dev/moq-go) mirror. To exercise it locally:

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -61,8 +61,15 @@ impl Publish {
 		Ok((broadcast, catalog))
 	}
 
+	/// Finalize the catalog stream and cleanly close the broadcast, so subscribers
+	/// see a normal end rather than [`moq_net::Error::Dropped`].
 	pub fn close(&mut self, broadcast: Id) -> Result<(), Error> {
-		self.broadcasts.remove(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let (broadcast, mut catalog) = self.broadcasts.remove(broadcast).ok_or(Error::BroadcastNotFound)?;
+		// Close the broadcast even if finalizing the catalog fails, so the clean end
+		// still reaches subscribers.
+		let result = catalog.finish();
+		broadcast.close();
+		result?;
 		Ok(())
 	}
 

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -61,15 +61,14 @@ impl Publish {
 		Ok((broadcast, catalog))
 	}
 
-	/// Finalize the catalog stream and cleanly close the broadcast, so subscribers
+	/// Cleanly close the broadcast and finalize the catalog stream, so subscribers
 	/// see a normal end rather than [`moq_net::Error::Dropped`].
 	pub fn close(&mut self, broadcast: Id) -> Result<(), Error> {
 		let (broadcast, mut catalog) = self.broadcasts.remove(broadcast).ok_or(Error::BroadcastNotFound)?;
-		// Close the broadcast even if finalizing the catalog fails, so the clean end
-		// still reaches subscribers.
-		let result = catalog.finish();
+		// Close the broadcast first so the clean end reaches subscribers even if
+		// finalizing the catalog fails.
 		broadcast.close();
-		result?;
+		catalog.finish()?;
 		Ok(())
 	}
 

--- a/rs/moq-audio/src/producer.rs
+++ b/rs/moq-audio/src/producer.rs
@@ -181,6 +181,12 @@ impl<E: CatalogExt> AudioProducer<E> {
 		self.track.finish()?;
 		Ok(())
 	}
+
+	/// Abort the track with `err` instead of finishing it, so subscribers see the
+	/// real cause rather than [`moq_net::Error::Dropped`]. Pending samples are dropped.
+	pub fn abort(mut self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
 }
 
 impl<E: CatalogExt> Drop for AudioProducer<E> {

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -278,11 +278,21 @@ async fn run(config: &Config) -> Result<()> {
 		move || run_emulator(session, &rom_path, audio_encoder, status_publisher, cmd_rx)
 	});
 
-	tokio::select! {
-		res = emulator_handle => res?.context("emulator error"),
-		res = reconnect.closed() => Ok(res?),
+	// Keep the result out of the `select!` arms (a `?` there would return before
+	// the close below runs), so the broadcast is always closed on shutdown.
+	let result = tokio::select! {
+		res = emulator_handle => match res {
+			Ok(inner) => inner.context("emulator error"),
+			Err(join) => Err(join.into()),
+		},
+		res = reconnect.closed() => res.map_err(Into::into),
 		res = input::handle_viewers(&mut viewer_consumer, &cmd_tx) => res,
-	}
+	};
+
+	// Cleanly close the broadcast so subscribers see a normal end rather than
+	// Error::Dropped.
+	broadcast.close();
+	result
 }
 
 /// The main emulator loop, running on a blocking thread.

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -141,6 +141,17 @@ impl PublishDecoder {
 		}
 		Ok(())
 	}
+
+	/// Abort the tracks with `err` instead of finishing, so subscribers see the
+	/// real cause rather than `Error::Dropped`.
+	fn abort(&mut self, err: moq_net::Error) {
+		match self {
+			Self::Avc3 { import, .. } => import.abort(err),
+			Self::Fmp4(d) => d.abort(err),
+			Self::Ts(d) => d.abort(err),
+			Self::Flv(d) => d.abort(err),
+		}
+	}
 }
 
 // Exactly one Source exists per process, so the size gap between the small
@@ -242,16 +253,27 @@ impl Publish {
 				let mut stdin = tokio::io::stdin();
 				let mut buffer = bytes::BytesMut::new();
 
-				loop {
-					buffer.clear();
-					let n = tokio::io::AsyncReadExt::read_buf(&mut stdin, &mut buffer).await?;
-					if n == 0 {
-						// EOF: flush the importer's buffered trailing frame and close the tracks.
-						decoder.finish()?;
-						return Ok(());
+				// Run the read/decode loop so an error surfaces here rather than
+				// dropping the decoder (and its tracks) with a bare Error::Dropped.
+				let result: anyhow::Result<()> = async {
+					loop {
+						buffer.clear();
+						let n = tokio::io::AsyncReadExt::read_buf(&mut stdin, &mut buffer).await?;
+						if n == 0 {
+							return Ok(()); // EOF
+						}
+						decoder.decode_chunk(&buffer)?;
 					}
-					decoder.decode_chunk(&buffer)?;
 				}
+				.await;
+
+				match &result {
+					// EOF: flush the importer's buffered trailing frame and close the tracks.
+					Ok(()) => decoder.finish()?,
+					// A read/decode error: abort with the real cause so subscribers see it.
+					Err(err) => decoder.abort(moq_net::Error::Transport(err.to_string())),
+				}
+				result
 			}
 			#[cfg(feature = "capture")]
 			Source::Capture { catalog, video, audio } => {

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -267,13 +267,14 @@ impl Publish {
 				}
 				.await;
 
-				match &result {
-					// EOF: flush the importer's buffered trailing frame and close the tracks.
-					Ok(()) => decoder.finish()?,
-					// A read/decode error: abort with the real cause so subscribers see it.
-					Err(err) => decoder.abort(moq_net::Error::Transport(err.to_string())),
+				// Flush on a clean EOF; on any error (read, decode, or the flush
+				// itself) abort with the real cause so subscribers see it instead of
+				// a bare Error::Dropped.
+				let outcome = result.and_then(|()| decoder.finish());
+				if let Err(err) = &outcome {
+					decoder.abort(moq_net::Error::Transport(err.to_string()));
 				}
-				result
+				outcome
 			}
 			#[cfg(feature = "capture")]
 			Source::Capture { catalog, video, audio } => {

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -361,12 +361,17 @@ impl MoqBroadcastProducer {
 		}))
 	}
 
-	/// Finish this publisher, finalizing the catalog stream.
+	/// Finish this publisher, finalizing the catalog stream and cleanly closing the
+	/// broadcast so subscribers see a normal end rather than `Error::Dropped`.
 	pub fn finish(&self) -> Result<(), MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let mut guard = self.state.lock().unwrap();
-		let mut state = guard.take().ok_or_else(|| MoqError::Closed)?;
-		state.catalog.finish()?;
+		let mut state = guard.take().ok_or(MoqError::Closed)?;
+		// Close the broadcast even if finalizing the catalog fails, so the clean end
+		// still reaches subscribers.
+		let result = state.catalog.finish();
+		state.broadcast.close();
+		result?;
 		Ok(())
 	}
 }

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -367,11 +367,10 @@ impl MoqBroadcastProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let mut guard = self.state.lock().unwrap();
 		let mut state = guard.take().ok_or(MoqError::Closed)?;
-		// Close the broadcast even if finalizing the catalog fails, so the clean end
-		// still reaches subscribers.
-		let result = state.catalog.finish();
+		// Close the broadcast first so the clean end reaches subscribers even if
+		// finalizing the catalog fails.
 		state.broadcast.close();
-		result?;
+		state.catalog.finish()?;
 		Ok(())
 	}
 }

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -97,20 +97,6 @@ pub struct Import {
 	audio: Option<TrackState>,
 }
 
-impl Drop for Import {
-	fn drop(&mut self) {
-		// The HLS import loop ends by cancellation (or after a VOD playlist ends);
-		// an async `Drop` can't `finish()`, so abort the importers explicitly with a
-		// real Cancel rather than letting their tracks surface a bare Error::Dropped.
-		for importer in &mut self.video_importers {
-			importer.abort(moq_net::Error::Cancel);
-		}
-		if let Some(importer) = &mut self.audio_importer {
-			importer.abort(moq_net::Error::Cancel);
-		}
-	}
-}
-
 #[derive(Debug, Clone, Copy)]
 enum TrackKind {
 	Video(usize),
@@ -214,6 +200,19 @@ impl Import {
 			);
 
 			tokio::time::sleep(delay).await;
+		}
+	}
+
+	/// Abort every importer's tracks with `err` so subscribers see the real cause.
+	///
+	/// Call this when the import is torn down with a known error; simply dropping the
+	/// [`Import`] instead lets its tracks end as [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		for importer in &mut self.video_importers {
+			importer.abort(err.clone());
+		}
+		if let Some(importer) = &mut self.audio_importer {
+			importer.abort(err.clone());
 		}
 	}
 

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -97,6 +97,20 @@ pub struct Import {
 	audio: Option<TrackState>,
 }
 
+impl Drop for Import {
+	fn drop(&mut self) {
+		// The HLS import loop ends by cancellation (or after a VOD playlist ends);
+		// an async `Drop` can't `finish()`, so abort the importers explicitly with a
+		// real Cancel rather than letting their tracks surface a bare Error::Dropped.
+		for importer in &mut self.video_importers {
+			importer.abort(moq_net::Error::Cancel);
+		}
+		if let Some(importer) = &mut self.audio_importer {
+			importer.abort(moq_net::Error::Cancel);
+		}
+	}
+}
+
 #[derive(Debug, Clone, Copy)]
 enum TrackKind {
 	Video(usize),

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -67,6 +67,12 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Abort the track with `err` instead of finishing it cleanly, so subscribers
+	/// see the real cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -205,6 +205,12 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Abort the track with `err` instead of finishing it cleanly, so subscribers
+	/// see the real cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/flac/import.rs
+++ b/rs/moq-mux/src/codec/flac/import.rs
@@ -55,6 +55,12 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Abort the track with `err` instead of finishing it cleanly, so subscribers
+	/// see the real cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -126,6 +126,12 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Abort the track with `err` instead of finishing it cleanly, so subscribers
+	/// see the real cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -88,6 +88,12 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Abort the track with `err` instead of finishing it cleanly, so subscribers
+	/// see the real cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/legacy.rs
+++ b/rs/moq-mux/src/codec/legacy.rs
@@ -157,6 +157,12 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Abort the track with `err` instead of finishing it cleanly, so subscribers
+	/// see the real cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/mp3.rs
+++ b/rs/moq-mux/src/codec/mp3.rs
@@ -138,6 +138,12 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Abort the track with `err` instead of finishing it cleanly, so subscribers
+	/// see the real cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -57,6 +57,12 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Abort the track with `err` instead of finishing it cleanly, so subscribers
+	/// see the real cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -104,6 +104,12 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Abort the track with `err` instead of finishing it cleanly, so subscribers
+	/// see the real cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -104,6 +104,12 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Abort the track with `err` instead of finishing it cleanly, so subscribers
+	/// see the real cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -582,11 +582,11 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	/// generic [`moq_net::Error::Dropped`] a bare drop surfaces. The counterpart to
 	/// [`Self::finish`] for a failed teardown (e.g. the RTMP client disconnected).
 	pub fn abort(&mut self, err: moq_net::Error) {
-		if let Some(stream) = self.video.as_mut() {
+		for stream in self.video.values_mut() {
 			stream.track.abort(err.clone());
 		}
-		if let Some(stream) = self.audio.as_mut() {
-			stream.track.abort(err);
+		for stream in self.audio.values_mut() {
+			stream.track.abort(err.clone());
 		}
 	}
 }

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -577,6 +577,18 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		}
 		Ok(())
 	}
+
+	/// Abort every track with `err`, so consumers see the real cause instead of the
+	/// generic [`moq_net::Error::Dropped`] a bare drop surfaces. The counterpart to
+	/// [`Self::finish`] for a failed teardown (e.g. the RTMP client disconnected).
+	pub fn abort(&mut self, err: moq_net::Error) {
+		if let Some(stream) = self.video.as_mut() {
+			stream.track.abort(err.clone());
+		}
+		if let Some(stream) = self.audio.as_mut() {
+			stream.track.abort(err);
+		}
+	}
 }
 
 impl<E: crate::catalog::hang::CatalogExt> Drop for Import<E> {

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -787,6 +787,17 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Abort all tracks with `err` instead of finishing, so subscribers see the real
+	/// cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		for track in self.tracks.values_mut() {
+			if let Some(mut g) = track.group.take() {
+				let _ = g.abort(err.clone());
+			}
+			let _ = track.track.abort(err.clone());
+		}
+	}
+
 	/// Close the current group on every track and open the next one at `sequence`.
 	///
 	/// Broadcast-wide: every track inside this fMP4 import advances together; per-track

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -404,6 +404,17 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		}
 		Ok(())
 	}
+
+	/// Abort all tracks with `err` instead of finishing, so subscribers see the real
+	/// cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		for track in self.tracks.values_mut() {
+			if let Some(mut g) = track.group.take() {
+				let _ = g.abort(err.clone());
+			}
+			track.track.abort(err.clone());
+		}
+	}
 }
 
 impl<E: crate::catalog::hang::CatalogExt> Drop for Import<E> {

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -194,6 +194,20 @@ impl<C: Container> Producer<C> {
 		Ok(())
 	}
 
+	/// Abort the track and any open group with the given error.
+	///
+	/// The counterpart to [`Self::finish`] for a failed teardown: consumers observe
+	/// `err` instead of the generic [`moq_net::Error::Dropped`] a bare drop surfaces,
+	/// so the real cause (a disconnect, a decode failure) reaches them. Any buffered
+	/// frames are discarded, not flushed.
+	pub fn abort(&mut self, err: moq_net::Error) {
+		self.buffer.clear();
+		if let Some(mut group) = self.group.take() {
+			let _ = group.abort(err.clone());
+		}
+		let _ = self.inner.abort(err);
+	}
+
 	/// Create a consumer for this track.
 	pub fn consume(&self) -> moq_net::track::Subscriber {
 		self.inner.subscribe(None)

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -590,6 +590,17 @@ impl<E: catalog::Catalog> Import<E> {
 		}
 		Ok(())
 	}
+
+	/// Abort every track with `err` instead of finishing, so subscribers see the
+	/// real cause rather than [`moq_net::Error::Dropped`]. Buffered PES is discarded.
+	pub fn abort(&mut self, err: moq_net::Error) {
+		for stream in self.streams.values_mut() {
+			stream.abort(err.clone());
+		}
+		for section in self.sections.values_mut() {
+			section.abort(err.clone());
+		}
+	}
 }
 
 /// A reassembled PES packet awaiting routing to its codec importer.
@@ -735,6 +746,10 @@ impl<E: catalog::Catalog> SectionStream<E> {
 		self.track.finish()?;
 		Ok(())
 	}
+
+	fn abort(&mut self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
 }
 
 impl<E: catalog::Catalog> Drop for SectionStream<E> {
@@ -817,6 +832,10 @@ impl<E: catalog::Catalog> VerbatimStream<E> {
 	fn finish(&mut self) -> anyhow::Result<()> {
 		self.track.finish()?;
 		Ok(())
+	}
+
+	fn abort(&mut self, err: moq_net::Error) {
+		self.track.abort(err);
 	}
 }
 
@@ -1071,6 +1090,18 @@ impl<E: catalog::Catalog> Stream<E> {
 		}
 	}
 
+	fn abort(&mut self, err: moq_net::Error) {
+		match self {
+			Stream::H264 { import, .. } => import.abort(err),
+			Stream::H265 { import, .. } => import.abort(err),
+			Stream::Aac(stream) => stream.abort(err),
+			Stream::Opus(stream) => stream.abort(err),
+			Stream::Legacy(stream) => stream.abort(err),
+			Stream::Verbatim(stream) => stream.abort(err),
+			Stream::Clock | Stream::Ignored => {}
+		}
+	}
+
 	/// The MoQ track name of a decoded media stream, once its (lazily created) track
 	/// exists. `None` for verbatim/clock/ignored streams (verbatim self-registers).
 	fn media_track_name(&self) -> Option<String> {
@@ -1208,6 +1239,12 @@ impl<E: CatalogExt> AacStream<E> {
 		}
 		Ok(())
 	}
+
+	fn abort(&mut self, err: moq_net::Error) {
+		if let Some(import) = &mut self.import {
+			import.abort(err);
+		}
+	}
 }
 
 /// One Opus elementary stream. The channels come from the PMT descriptors and the rate
@@ -1258,6 +1295,10 @@ impl<E: CatalogExt> OpusStream<E> {
 
 	fn finish(&mut self) -> anyhow::Result<()> {
 		Ok(self.import.finish()?)
+	}
+
+	fn abort(&mut self, err: moq_net::Error) {
+		self.import.abort(err);
 	}
 }
 
@@ -1457,6 +1498,12 @@ impl<E: CatalogExt> LegacyStream<E> {
 			import.finish()?;
 		}
 		Ok(())
+	}
+
+	fn abort(&mut self, err: moq_net::Error) {
+		if let Some(import) = &mut self.import {
+			import.abort(err);
+		}
 	}
 }
 

--- a/rs/moq-mux/src/import/container.rs
+++ b/rs/moq-mux/src/import/container.rs
@@ -53,6 +53,15 @@ impl<E: crate::container::ts::catalog::Catalog> ContainerImpl<E> {
 		}
 	}
 
+	fn abort(&mut self, err: moq_net::Error) {
+		match self {
+			ContainerImpl::Fmp4(decoder) => decoder.abort(err),
+			ContainerImpl::Mkv(decoder) => decoder.abort(err),
+			ContainerImpl::Ts(decoder) => decoder.abort(err),
+			ContainerImpl::Flv(decoder) => decoder.abort(err),
+		}
+	}
+
 	fn seek(&mut self, sequence: u64) -> Result<()> {
 		match self {
 			ContainerImpl::Fmp4(decoder) => decoder.seek(sequence),
@@ -100,6 +109,12 @@ impl<E: crate::container::ts::catalog::Catalog> Container<E> {
 		self.inner.finish()
 	}
 
+	/// Abort every published track with `err`, so subscribers see the real cause
+	/// rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		self.inner.abort(err)
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.inner.seek(sequence)
@@ -143,6 +158,12 @@ impl<E: crate::container::ts::catalog::Catalog> ContainerStream<E> {
 	/// Finish the importer, flushing any buffered data.
 	pub fn finish(&mut self) -> Result<()> {
 		self.inner.finish()
+	}
+
+	/// Abort every published track with `err`, so subscribers see the real cause
+	/// rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		self.inner.abort(err)
 	}
 
 	/// Close the current group and open the next one at `sequence`.

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -247,6 +247,23 @@ impl<E: CatalogExt> Track<E> {
 		}
 	}
 
+	/// Abort the track with `err` instead of finishing it cleanly, so subscribers
+	/// see the real cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		match self.kind {
+			TrackKind::Avc3 { ref mut import, .. } => import.abort(err),
+			TrackKind::Avc1 { ref mut import, .. } => import.abort(err),
+			TrackKind::Hev1 { ref mut import, .. } => import.abort(err),
+			TrackKind::Av01 { ref mut import, .. } => import.abort(err),
+			TrackKind::Vp8(ref mut import) => import.abort(err),
+			TrackKind::Vp9(ref mut import) => import.abort(err),
+			TrackKind::Aac(ref mut import) => import.abort(err),
+			TrackKind::Opus(ref mut import) => import.abort(err),
+			TrackKind::Mp3(ref mut import) => import.abort(err),
+			TrackKind::Flac(ref mut import) => import.abort(err),
+		}
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		match self.kind {
@@ -481,6 +498,16 @@ impl<E: CatalogExt> TrackStream<E> {
 				import.decode(tail)?;
 				import.finish()
 			}
+		}
+	}
+
+	/// Abort the track with `err` instead of finishing it cleanly, so subscribers
+	/// see the real cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		match self.kind {
+			TrackStreamKind::Avc3 { ref mut import, .. } => import.abort(err),
+			TrackStreamKind::Hev1 { ref mut import, .. } => import.abort(err),
+			TrackStreamKind::Av01 { ref mut import, .. } => import.abort(err),
 		}
 	}
 

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -74,5 +74,10 @@ async fn run_broadcast(origin: moq_net::origin::Producer) -> anyhow::Result<()> 
 	// Sleep before exiting and closing the broadcast.
 	tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
 
+	// Cleanly close the broadcast so subscribers see a normal end. Dropping the
+	// producer works too, but closing is explicit (and dropping it by accident
+	// while still publishing is a common bug this makes obvious).
+	broadcast.close();
+
 	Ok(())
 }

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -76,10 +76,17 @@ async fn main() -> anyhow::Result<()> {
 
 			let reconnect = client.with_publisher(&origin).reconnect(config.url);
 
-			tokio::select! {
-				res = reconnect.closed() => Ok(res?),
+			// Keep the result out of the `select!` arm (a `?` there would return
+			// before the close below runs), so the broadcast is always closed.
+			let result = tokio::select! {
+				res = reconnect.closed() => res.map_err(Into::into),
 				_ = clock.run() => Ok(()),
-			}
+			};
+
+			// Cleanly close the broadcast on exit so subscribers see a normal end
+			// rather than Error::Dropped.
+			broadcast.close();
+			result
 		}
 		Command::Subscribe => {
 			let reconnect = client.with_subscriber(origin.clone()).reconnect(config.url);

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -37,6 +37,9 @@ impl Info {
 
 	/// Consume this [Info] to create a producer that carries its metadata
 	/// (including the hop chain).
+	///
+	/// Keep the returned [`Producer`] alive for as long as the broadcast should stay
+	/// available, and end it with [`Producer::close`]. See the note on [`Producer`].
 	pub fn produce(self) -> Producer {
 		Producer::new(self)
 	}
@@ -59,6 +62,10 @@ struct BroadcastState {
 	// The current number of dynamic producers.
 	// If this is 0, requests must be empty.
 	dynamic: usize,
+
+	// Set by an explicit `Producer::close()` so `Drop` can tell a deliberate
+	// shutdown apart from a producer that was dropped by accident.
+	closed: bool,
 }
 
 impl BroadcastState {
@@ -90,6 +97,21 @@ impl BroadcastState {
 /// Create tracks up front with [Self::create_track], reserve a name to fill in
 /// later with [Self::reserve_track], or handle on-demand consumer requests via
 /// [Self::dynamic].
+///
+/// # Lifetime
+///
+/// **You must keep this producer alive for as long as the broadcast should stay
+/// available.** A broadcast lives as long as at least one [`Producer`] exists;
+/// children do *not* keep it alive (cloning a [`Consumer`], holding a
+/// [`track::Producer`], or holding the [`crate::origin::Publish`] guard does
+/// nothing for the broadcast's lifetime). When the last producer goes away every
+/// consumer observes [`Error::Dropped`].
+///
+/// End the broadcast with [`Self::close`] rather than dropping it. Dropping is an
+/// easy footgun in garbage-collected bindings (Go, Python, ...), where the handle
+/// can be collected the moment it falls out of scope even while you are still
+/// publishing, tearing the stream down mid-broadcast. Dropping the last producer
+/// without [`Self::close`] logs a warning.
 #[derive(Clone)]
 pub struct Producer {
 	// Held behind an Arc so each track born from this broadcast can inherit a shared
@@ -189,9 +211,43 @@ impl Producer {
 		}
 	}
 
+	/// Cleanly close the broadcast once you are done publishing.
+	///
+	/// Marks the broadcast as deliberately finished so consumers observe a normal
+	/// end. Prefer this over dropping the producer: an accidental drop (see the note
+	/// on [`Producer`]) logs a warning, whereas a `close()` is silent.
+	///
+	/// Only marks intent; the broadcast actually ends once every producer clone is
+	/// gone, so a clone that outlives this call keeps it alive until it too is
+	/// dropped or closed.
+	pub fn close(self) {
+		if let Ok(mut state) = self.state.write() {
+			state.closed = true;
+		}
+	}
+
 	/// Return true if this is the same broadcast instance.
 	pub fn is_clone(&self, other: &Self) -> bool {
 		self.state.same_channel(&other.state)
+	}
+}
+
+impl Drop for Producer {
+	fn drop(&mut self) {
+		// Only the last producer ending the broadcast matters; a clone dropping
+		// leaves it live. Warn if that last exit wasn't an explicit close(), since
+		// consumers will then see Error::Dropped (classically a GC-collected handle
+		// in a language binding that tears the stream down mid-publish).
+		if !self.state.is_last() {
+			return;
+		}
+		if let Ok(state) = self.state.write()
+			&& !state.closed
+		{
+			tracing::warn!(
+				"broadcast::Producer dropped without close(); consumers will see Error::Dropped. Keep the producer alive while publishing, then call close()."
+			);
+		}
 	}
 }
 

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -245,7 +245,7 @@ impl Drop for Producer {
 			&& !state.closed
 		{
 			tracing::warn!(
-				"broadcast::Producer dropped without close(); consumers will see Error::Dropped. Keep the producer alive while publishing, then call close()."
+				"broadcast::Producer dropped without close(). Keep the producer alive while publishing, then call close()."
 			);
 		}
 	}

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -312,6 +312,10 @@ impl Drop for Producer<'_> {
 		if !self.done {
 			// An unfinished frame leaves the group stream broken; fail the group so
 			// consumers surface an error instead of hanging on the partial forever.
+			tracing::warn!(
+				group = self.group.info().sequence,
+				"frame::Producer dropped before writing all bytes"
+			);
 			self.group.frame_abort(Error::Dropped);
 		}
 	}

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -398,6 +398,12 @@ impl Drop for Producer {
 		if let Ok(mut state) = modify(&self.state)
 			&& !state.fin
 		{
+			// Dropped without finish() or abort(), so consumers will see
+			// Error::Dropped mid-group. Deliberate ends go through finish()/abort().
+			tracing::warn!(
+				sequence = self.info.sequence,
+				"group::Producer dropped without finish() or abort(); consumers will see Error::Dropped"
+			);
 			state.frames.clear();
 			state.partial = None;
 			state.cache = 0;

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -402,7 +402,7 @@ impl Drop for Producer {
 			// Error::Dropped mid-group. Deliberate ends go through finish()/abort().
 			tracing::warn!(
 				sequence = self.info.sequence,
-				"group::Producer dropped without finish() or abort(); consumers will see Error::Dropped"
+				"group::Producer dropped without finish() or abort()"
 			);
 			state.frames.clear();
 			state.partial = None;

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1033,7 +1033,7 @@ impl Drop for Producer {
 			// finish()/abort().
 			tracing::warn!(
 				track = %self.name(),
-				"track::Producer dropped without finish() or abort(); consumers will see Error::Dropped"
+				"track::Producer dropped without finish() or abort()"
 			);
 			state.groups.clear();
 			state.datagrams.clear();

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1028,6 +1028,13 @@ impl Drop for Producer {
 		if let Ok(mut state) = self.state.write()
 			&& state.final_sequence.is_none()
 		{
+			// Dropped without finish() or abort(), so consumers will see
+			// Error::Dropped instead of a clean end. Deliberate ends go through
+			// finish()/abort().
+			tracing::warn!(
+				track = %self.name(),
+				"track::Producer dropped without finish() or abort(); consumers will see Error::Dropped"
+			);
 			state.groups.clear();
 			state.datagrams.clear();
 			state.duplicates.clear();

--- a/rs/moq-rtc/src/codec/h264.rs
+++ b/rs/moq-rtc/src/codec/h264.rs
@@ -31,4 +31,8 @@ impl codec::Bridge for Bridge {
 		self.import.decode(frames)?;
 		Ok(())
 	}
+
+	fn abort(&mut self, err: moq_net::Error) {
+		self.import.abort(err);
+	}
 }

--- a/rs/moq-rtc/src/codec/mod.rs
+++ b/rs/moq-rtc/src/codec/mod.rs
@@ -41,6 +41,10 @@ pub struct Frame {
 /// moq-mux importer.
 pub trait Bridge: Send {
 	fn push(&mut self, frame: Frame) -> Result<()>;
+
+	/// Abort the published track with `err` so subscribers see the real cause
+	/// (the peer disconnected, an ICE failure) rather than a bare `Error::Dropped`.
+	fn abort(&mut self, err: moq_net::Error);
 }
 
 /// One RTP-ready codec frame produced by an egress [`Track`].

--- a/rs/moq-rtc/src/codec/opus.rs
+++ b/rs/moq-rtc/src/codec/opus.rs
@@ -33,4 +33,8 @@ impl codec::Bridge for Bridge {
 		self.import.decode(&frame.payload, Some(pts))?;
 		Ok(())
 	}
+
+	fn abort(&mut self, err: moq_net::Error) {
+		self.import.abort(err);
+	}
 }

--- a/rs/moq-rtc/src/codec/vp8.rs
+++ b/rs/moq-rtc/src/codec/vp8.rs
@@ -60,6 +60,10 @@ impl codec::Bridge for Bridge {
 			.map_err(|err| crate::Error::Other(anyhow::anyhow!("vp8 track write failed: {err}")))?;
 		Ok(())
 	}
+
+	fn abort(&mut self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
 }
 
 impl Drop for Bridge {

--- a/rs/moq-rtc/src/codec/vp9.rs
+++ b/rs/moq-rtc/src/codec/vp9.rs
@@ -58,6 +58,10 @@ impl codec::Bridge for Bridge {
 			.map_err(|err| crate::Error::Other(anyhow::anyhow!("vp9 track write failed: {err}")))?;
 		Ok(())
 	}
+
+	fn abort(&mut self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
 }
 
 /// Detect a VP9 keyframe from the uncompressed header's first byte (VP9 spec

--- a/rs/moq-rtc/src/ingest.rs
+++ b/rs/moq-rtc/src/ingest.rs
@@ -61,13 +61,8 @@ impl session::MediaSink for IngestSink {
 	fn on_frame(&mut self, mid: str0m::media::Mid, frame: codec::Frame) -> Result<()> {
 		self.bridges.push(mid, frame)
 	}
-}
 
-impl Drop for IngestSink {
-	fn drop(&mut self) {
-		// The RTP flow ended (the peer left / ICE dropped); an async `Drop` can't
-		// finish, so abort the bridge tracks with a real Cancel rather than letting
-		// them surface a bare Error::Dropped.
-		self.bridges.abort(moq_net::Error::Cancel);
+	fn abort(&mut self, err: moq_net::Error) {
+		self.bridges.abort(err);
 	}
 }

--- a/rs/moq-rtc/src/ingest.rs
+++ b/rs/moq-rtc/src/ingest.rs
@@ -62,3 +62,12 @@ impl session::MediaSink for IngestSink {
 		self.bridges.push(mid, frame)
 	}
 }
+
+impl Drop for IngestSink {
+	fn drop(&mut self) {
+		// The RTP flow ended (the peer left / ICE dropped); an async `Drop` can't
+		// finish, so abort the bridge tracks with a real Cancel rather than letting
+		// them surface a bare Error::Dropped.
+		self.bridges.abort(moq_net::Error::Cancel);
+	}
+}

--- a/rs/moq-rtc/src/session.rs
+++ b/rs/moq-rtc/src/session.rs
@@ -418,6 +418,14 @@ impl Bridges {
 		}
 		Ok(())
 	}
+
+	/// Abort every bridge's track with `err` so subscribers see the real cause
+	/// rather than a bare `Error::Dropped`.
+	pub fn abort(&mut self, err: moq_net::Error) {
+		for bridge in self.inner.values_mut() {
+			bridge.abort(err.clone());
+		}
+	}
 }
 
 /// Build a [`Rtc`] with `CodecConfig` restricted to the supplied codecs.

--- a/rs/moq-rtc/src/session.rs
+++ b/rs/moq-rtc/src/session.rs
@@ -72,6 +72,10 @@ pub trait MediaSink: Send {
 	/// Called on each [`MediaData`](str0m::media::MediaData) event. The session
 	/// loop has already converted the timestamp to microseconds.
 	fn on_frame(&mut self, mid: str0m::media::Mid, frame: codec::Frame) -> Result<()>;
+
+	/// Called once when the session ends with a genuine failure, so the sink can
+	/// abort its tracks with the real cause instead of a bare `Error::Dropped`.
+	fn abort(&mut self, err: moq_net::Error);
 }
 
 /// What the session does with the negotiated media stream.
@@ -160,6 +164,20 @@ impl Session {
 	}
 
 	pub async fn run(mut self) -> Result<()> {
+		let result = self.run_loop().await;
+		// A genuine failure (not a normal peer disconnect or an unconnected offer)
+		// propagates to subscribers as the real cause; the normal ends just let the
+		// sink's tracks close as Dropped.
+		if let Err(err) = &result
+			&& !matches!(err, Error::SessionClosed | Error::IceTimeout)
+			&& let MediaRole::Ingest(sink) = &mut self.role
+		{
+			sink.abort(moq_net::Error::Transport(err.to_string()));
+		}
+		result
+	}
+
+	async fn run_loop(&mut self) -> Result<()> {
 		let started = Instant::now();
 		let mut connected = false;
 		loop {

--- a/rs/moq-rtmp/src/dial.rs
+++ b/rs/moq-rtmp/src/dial.rs
@@ -243,12 +243,33 @@ impl<S: Stream> Client<S> {
 		tracing::info!(%stream_key, %path, "rtmp play accepted by remote");
 
 		let mut publisher = Publisher::new(origin, path)?;
+
+		let result = self.pull_media(&mut publisher).await;
+		match &result {
+			// Clean end: flush so the final groups close cleanly before unannouncing.
+			Ok(()) => {
+				if let Err(err) = publisher.finish() {
+					tracing::debug!(%err, "error finishing RTMP pull");
+				}
+			}
+			// The read loop failed (the remote dropped, a protocol error): abort with
+			// the real cause so subscribers see it instead of a bare drop's Error::Dropped.
+			Err(err) => publisher.abort(moq_net::Error::Transport(err.to_string())),
+		}
+		Ok(result?)
+	}
+
+	/// Read FLV tags from the remote and feed them to `publisher` until EOF.
+	///
+	/// Split out from [`Self::pull`] so a read/demux error propagates to the caller,
+	/// which aborts the publisher with the cause rather than dropping it silently.
+	async fn pull_media(&mut self, publisher: &mut Publisher) -> anyhow::Result<()> {
 		let mut buffer = [0u8; READ_BUFFER];
 
 		// Drain anything queued alongside the play-accepted event (the server can bundle
 		// the first media messages in the same read), then keep reading.
 		let queued = std::mem::take(&mut self.work);
-		self.pull_results(queued, &mut publisher).await?;
+		self.pull_results(queued, publisher).await?;
 		loop {
 			let n = self.stream.read(&mut buffer).await?;
 			if n == 0 {
@@ -258,11 +279,7 @@ impl<S: Stream> Client<S> {
 				.session
 				.handle_input(&buffer[..n])
 				.map_err(|e| anyhow::anyhow!("rtmp handle_input: {e:?}"))?;
-			self.pull_results(results, &mut publisher).await?;
-		}
-
-		if let Err(err) = publisher.finish() {
-			tracing::debug!(%err, "error finishing RTMP pull");
+			self.pull_results(results, publisher).await?;
 		}
 		Ok(())
 	}
@@ -449,6 +466,12 @@ impl Publisher {
 
 	fn finish(&mut self) -> anyhow::Result<()> {
 		Ok(self.importer.finish()?)
+	}
+
+	/// Abort the published tracks with `err` so subscribers see the real cause
+	/// (the remote dropped, a protocol error) rather than a generic `Error::Dropped`.
+	fn abort(&mut self, err: moq_net::Error) {
+		self.importer.abort(err);
 	}
 }
 

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -463,9 +463,16 @@ impl<S: Stream> Publish<S> {
 		)
 		.await;
 
-		// Flush the importer so the final groups close cleanly before unannouncing.
-		if let Err(err) = publisher.finish() {
-			tracing::debug!(peer = %self.peer, %err, "error finishing RTMP publish");
+		match &result {
+			// Clean end: flush so the final groups close cleanly before unannouncing.
+			Ok(()) => {
+				if let Err(err) = publisher.finish() {
+					tracing::debug!(peer = %self.peer, %err, "error finishing RTMP publish");
+				}
+			}
+			// The pump failed (e.g. the client dropped mid-stream): abort with the
+			// real cause so subscribers see it instead of a bare drop's Error::Dropped.
+			Err(err) => publisher.abort(moq_net::Error::Transport(err.to_string())),
 		}
 
 		Ok(result?)
@@ -1065,6 +1072,13 @@ impl Publisher {
 	/// Flush any buffered media and close out the broadcast's open groups.
 	fn finish(&mut self) -> anyhow::Result<()> {
 		Ok(self.importer.finish()?)
+	}
+
+	/// Abort the published tracks with `err` so subscribers see the real cause
+	/// (the client disconnected, a protocol error) rather than a generic
+	/// `Error::Dropped` from the importer being dropped.
+	fn abort(&mut self, err: moq_net::Error) {
+		self.importer.abort(err);
 	}
 }
 

--- a/rs/moq-srt/src/server.rs
+++ b/rs/moq-srt/src/server.rs
@@ -277,11 +277,24 @@ pub(crate) async fn serve_publish(origin: &origin::Producer, path: &str, mut soc
 	use futures::TryStreamExt;
 
 	let mut publisher = crate::ts::Publisher::new(origin, path)?;
-	while let Some((_instant, bytes)) = socket.try_next().await? {
-		publisher.feed(bytes)?;
+
+	// Run the read/feed loop so an error surfaces here instead of unwinding past
+	// the publisher, which would drop it (and its tracks) with a bare Error::Dropped.
+	let result: Result<()> = async {
+		while let Some((_instant, bytes)) = socket.try_next().await? {
+			publisher.feed(bytes)?;
+		}
+		Ok(())
 	}
-	publisher.finish()?;
-	Ok(())
+	.await;
+
+	match &result {
+		// Clean end (the caller closed): flush the final groups.
+		Ok(()) => publisher.finish()?,
+		// The socket or demux failed: abort with the real cause so subscribers see it.
+		Err(err) => publisher.abort(moq_net::Error::Transport(err.to_string())),
+	}
+	result
 }
 
 /// Mux the requested broadcast back to MPEG-TS and stream it to the SRT caller

--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -58,6 +58,12 @@ impl Publisher {
 	pub fn finish(&mut self) -> Result<()> {
 		Ok(self.importer.finish()?)
 	}
+
+	/// Abort the published tracks with `err` so subscribers see the real cause
+	/// (the SRT caller dropped, a demux error) rather than a generic `Error::Dropped`.
+	pub fn abort(&mut self, err: moq_net::Error) {
+		self.importer.abort(err);
+	}
 }
 
 /// Muxes a single MoQ broadcast back into an MPEG-TS byte stream for egress.

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -108,6 +108,15 @@ impl Producer {
 		}
 		Ok(())
 	}
+
+	/// Abort the track with `err` instead of finishing it cleanly, so subscribers
+	/// see the real cause rather than [`moq_net::Error::Dropped`].
+	pub fn abort(&mut self, err: moq_net::Error) {
+		match &mut self.codecs {
+			Codecs::H264 { import, .. } => import.abort(err),
+			Codecs::H265 { import, .. } => import.abort(err),
+		}
+	}
 }
 
 /// Source-agnostic encode knobs for [`publish_capture`], where the geometry
@@ -153,11 +162,18 @@ pub async fn publish_capture(
 
 	let result = capture_loop(&mut producer, &demand, &capture, &encode, &clock).await;
 
-	// Best-effort clean close. This runs only when the loop ends on its own (the
-	// track is usually already going away by then); a Ctrl+C cancels the future
-	// before this point, since async `Drop` can't finalize the track.
-	if let Err(err) = producer.finish() {
-		tracing::debug!(error = %err, "video track finish after capture ended");
+	// This runs only when the loop ends on its own (the track is usually already
+	// going away by then); a Ctrl+C cancels the future before this point, since
+	// async `Drop` can't finalize the track.
+	match &result {
+		// Clean end (the track was dropped): best-effort finish.
+		Ok(()) => {
+			if let Err(err) = producer.finish() {
+				tracing::debug!(error = %err, "video track finish after capture ended");
+			}
+		}
+		// The capture loop failed: abort with the real cause so subscribers see it.
+		Err(err) => producer.abort(moq_net::Error::Transport(err.to_string())),
 	}
 	result
 }


### PR DESCRIPTION
## Summary

Addresses #2087 and the broader problem that **relying on `Drop` to end a producer is a bug — it surfaces a generic `Error::Dropped` and throws away the real cause.**

### 1. Require an explicit `broadcast::Producer::close()`

On `dev` a broadcast ends purely when its last producer drops. Per maintainer direction (the RAII `origin::Publish` guard only invites accidental teardown), require an explicit close:

- `broadcast::Producer::close()` — clean `self`-consuming shutdown; dropping the last producer without it logs a warning. Lifetime docs on `broadcast::Producer` + `Info::produce`.

### 2. Warn when any producer is dropped without a clean end

`track` / `group` / `frame` producers each warn when dropped without `finish()`/`abort()` (frame: before all bytes written), gated on their existing abrupt-teardown condition so a proper finish/abort stays silent.

### 3. Pipe `abort(err)` through the whole muxer stack + gateways

The muxers only had `finish()` — no way to convey an error. Added `abort(err)` everywhere and migrated the gateways so the real cause reaches subscribers:

- **moq-mux (complete):** every codec importer (h264, h265, av1, vp8, vp9, aac, opus, mp3, flac, legacy), every container importer (fmp4, mkv, ts + its per-codec substreams/sections/verbatim, flv), and the `import::{Track, TrackStream, Container, ContainerStream}` wrappers.
- **Gateways migrated to `finish()` on clean end / `abort(err)` on failure:** RTMP (ingest + pull), SRT, moq-cli publish, moq-video capture.
- **Teardowns that are genuinely at drop** (WebRTC disconnect, HLS cancellation — an async `Drop` can't `finish()`): moq-rtc `IngestSink` and moq-hls `Import` abort with `Cancel` (a real code, not the implicit `Dropped`). moq-rtc's `codec::Bridge` gains `abort()`; moq-audio/moq-video gain `abort()`.

## Remaining / follow-ups

- **Revert the RAII `origin::Publish` guard** (owner: @kixelated, separate session) so `close()` is the canonical broadcast end. Broadcast has no error channel on dev, so gateway broadcast-close is coupled to that work.
- **moq-gst** (the plugin's clean EOS path already finishes) and the **FFI/libmoq** boundary are the last two consumers; the `abort()` primitive is in place for them.

## Branch targeting

`dev` — coordinated with the broadcast-model rework there.

## Test plan

- [x] `cargo test` green: moq-net (426), moq-mux (354), moq-rtmp (18), moq-srt, moq-cli, moq-rtc, moq-hls, moq-audio
- [x] `cargo clippy` + `cargo fmt --check` clean on touched crates
- [x] Full-workspace build (moq-video's openh264-sys2 native build fails in this env — a pre-existing toolchain issue, unrelated to the change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)