### PR TITLE
feat(moq-net): global LRU cache pool for group memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -992,7 +992,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1280,8 +1280,8 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "web-sys",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -2428,8 +2428,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -2920,7 +2920,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3140,7 +3140,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -3357,7 +3357,7 @@ dependencies = [
  "socket2 0.6.4",
  "widestring",
  "windows-registry",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-sys 0.61.2",
 ]
 
@@ -3630,7 +3630,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3801,7 +3801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -3811,7 +3811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4496,7 +4496,7 @@ dependencies = [
  "tokio",
  "tracing",
  "v4l",
- "windows 0.62.2",
+ "windows",
  "yuv",
  "zune-jpeg",
 ]
@@ -4775,8 +4775,8 @@ dependencies = [
  "tokio-util",
  "tracing",
  "web-sys",
- "windows 0.62.2",
- "windows-result 0.4.1",
+ "windows",
+ "windows-result",
  "wmi",
 ]
 
@@ -5629,7 +5629,7 @@ dependencies = [
  "petgraph",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -7620,16 +7620,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.36.1"
+version = "0.39.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.61.3",
+ "windows",
 ]
 
 [[package]]
@@ -9145,36 +9145,14 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.61.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
-dependencies = [
- "windows-collections 0.2.0",
- "windows-core 0.61.2",
- "windows-future 0.2.1",
- "windows-link 0.1.3",
- "windows-numerics 0.2.0",
-]
-
-[[package]]
-name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections 0.3.2",
- "windows-core 0.62.2",
- "windows-future 0.3.2",
- "windows-numerics 0.3.1",
-]
-
-[[package]]
-name = "windows-collections"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
-dependencies = [
- "windows-core 0.61.2",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
@@ -9183,20 +9161,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.62.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -9207,20 +9172,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
- "windows-threading 0.1.0",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -9229,9 +9183,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
- "windows-threading 0.2.1",
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -9258,25 +9212,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-numerics"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
-dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
-]
 
 [[package]]
 name = "windows-numerics"
@@ -9284,8 +9222,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.62.2",
- "windows-link 0.2.1",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -9294,18 +9232,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -9314,16 +9243,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -9332,7 +9252,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -9377,7 +9297,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -9417,7 +9337,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -9430,20 +9350,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
-dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -9642,8 +9553,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows 0.62.2",
- "windows-core 0.62.2",
+ "windows",
+ "windows-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -798,6 +798,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytesize"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
+
+[[package]]
 name = "bytestring"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -986,7 +992,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1274,8 +1280,8 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "web-sys",
- "windows",
- "windows-core",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2422,8 +2428,8 @@ dependencies = [
  "libc",
  "log",
  "rustversion",
- "windows-link",
- "windows-result",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
 ]
 
 [[package]]
@@ -2914,7 +2920,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3134,7 +3140,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -3351,7 +3357,7 @@ dependencies = [
  "socket2 0.6.4",
  "widestring",
  "windows-registry",
- "windows-result",
+ "windows-result 0.4.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3624,7 +3630,7 @@ dependencies = [
  "simd_cesu8",
  "thiserror 2.0.18",
  "walkdir",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3795,7 +3801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3805,7 +3811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4330,6 +4336,7 @@ dependencies = [
  "axum",
  "axum-server",
  "bytes",
+ "bytesize",
  "clap",
  "futures",
  "http-body",
@@ -4347,6 +4354,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -4488,7 +4496,7 @@ dependencies = [
  "tokio",
  "tracing",
  "v4l",
- "windows",
+ "windows 0.62.2",
  "yuv",
  "zune-jpeg",
 ]
@@ -4767,8 +4775,8 @@ dependencies = [
  "tokio-util",
  "tracing",
  "web-sys",
- "windows",
- "windows-result",
+ "windows 0.62.2",
+ "windows-result 0.4.1",
  "wmi",
 ]
 
@@ -4900,6 +4908,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -5260,6 +5277,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "objc2-io-surface"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5602,7 +5629,7 @@ dependencies = [
  "petgraph",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7592,6 +7619,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.3",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9104,14 +9145,36 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
+ "windows-link 0.1.3",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -9120,7 +9183,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
+ "windows-core 0.62.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -9131,9 +9207,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading 0.1.0",
 ]
 
 [[package]]
@@ -9142,9 +9229,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -9171,9 +9258,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-numerics"
@@ -9181,8 +9284,8 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9191,9 +9294,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -9202,7 +9314,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -9211,7 +9332,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9256,7 +9377,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9296,7 +9417,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -9309,11 +9430,20 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -9512,8 +9642,8 @@ dependencies = [
  "log",
  "serde",
  "thiserror 2.0.18",
- "windows",
- "windows-core",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -327,6 +327,36 @@ Every flag also accepts an equivalent CLI argument (`--stats-enabled`,
 environment variable (`MOQ_STATS_ENABLED`, `MOQ_STATS_PREFIX`,
 `MOQ_STATS_INTERVAL`, `MOQ_STATS_NODE`, `MOQ_STATS_DEPTH`).
 
+### \[cache]
+
+Memory budget for cached groups. Old (non-latest) groups stay cached until their
+track's TTL expires or the pool runs out of room, whichever comes first; under
+memory pressure the least-recently-read groups are evicted first. The latest
+group of every track is always retained. With neither knob set the cache is
+unbounded and only the per-track TTL limits memory.
+
+```toml
+[cache]
+# Maximum bytes of cached group payload. Accepts absolute sizes ("8GiB",
+# "512MB") or a percentage of memory ("75%", respecting the cgroup limit
+# inside containers). Unbounded when unset.
+capacity = "8GiB"
+
+# Keep at least this much system memory available ("2GiB" or "10%"). Enables a
+# background governor that re-sizes the cache every few seconds: it grows into
+# idle memory and shrinks (evicting) when the rest of the system needs it, so
+# the cache is effectively the lowest-priority user of RAM. Combine with
+# `capacity` to also cap the absolute size.
+headroom = "2GiB"
+```
+
+The `capacity` budget counts group payload bytes, not process RSS, so leave
+slack below physical memory (or just use `headroom`, which measures actual
+available memory).
+
+Both flags also accept CLI arguments (`--cache-capacity`, `--cache-headroom`)
+and environment variables (`MOQ_CACHE_CAPACITY`, `MOQ_CACHE_HEADROOM`).
+
 ### \[iroh]
 
 Experimental P2P support via iroh.

--- a/rs/moq-net/src/error.rs
+++ b/rs/moq-net/src/error.rs
@@ -101,6 +101,12 @@ pub enum Error {
 	#[error("frame timestamp doesn't match track timescale")]
 	TimestampMismatch,
 
+	/// The group was evicted from the cache under memory pressure (see
+	/// [`cache::Pool`](crate::cache::Pool)). Unlike [`Self::Old`], the group was
+	/// still within the publisher's window; it can be re-fetched.
+	#[error("evicted")]
+	Evicted,
+
 	/// A remote error received via a stream/session reset code.
 	#[error("remote error: code={0}")]
 	Remote(u32),
@@ -136,6 +142,7 @@ impl Error {
 			Self::FrameTooLarge => 27,
 			Self::TimestampMismatch => 29,
 			Self::Unroutable => 30,
+			Self::Evicted => 31,
 			Self::App(app) => *app as u32 + 64,
 			Self::Remote(code) => *code,
 		}

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -468,7 +468,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				let mut hops = crate::OriginList::new();
 				hops.push(self.session_origin)
 					.expect("an empty hop chain has room for one entry");
-				let broadcast = broadcast::Info { hops }.produce().with_pool(self.origin.pool());
+				let broadcast = broadcast::Info {
+					hops,
+					pool: self.origin.pool(),
+				}
+				.produce();
 
 				// Create the dynamic handler BEFORE publishing so consumers see
 				// dynamic >= 1 the moment they receive the announce. Otherwise a

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -470,7 +470,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					.expect("an empty hop chain has room for one entry");
 				let broadcast = broadcast::Info {
 					hops,
-					pool: self.origin.pool(),
+					origin: self.origin.info(),
 				}
 				.produce();
 

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -468,7 +468,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				let mut hops = crate::OriginList::new();
 				hops.push(self.session_origin)
 					.expect("an empty hop chain has room for one entry");
-				let broadcast = broadcast::Info { hops }.produce();
+				let broadcast = broadcast::Info {
+					hops,
+					pool: self.origin.pool(),
+				}
+				.produce();
 
 				// Create the dynamic handler BEFORE publishing so consumers see
 				// dynamic >= 1 the moment they receive the announce. Otherwise a

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -468,11 +468,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				let mut hops = crate::OriginList::new();
 				hops.push(self.session_origin)
 					.expect("an empty hop chain has room for one entry");
-				let broadcast = broadcast::Info {
-					hops,
-					pool: self.origin.pool(),
-				}
-				.produce();
+				let broadcast = broadcast::Info { hops }.produce().with_pool(self.origin.pool());
 
 				// Create the dynamic handler BEFORE publishing so consumers see
 				// dynamic >= 1 the moment they receive the announce. Otherwise a

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -711,15 +711,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 #[cfg(test)]
 mod test {
 	use super::*;
-	use crate::{Timestamp, broadcast, cache};
+	use crate::{Timestamp, broadcast};
 
 	fn track_producer(name: impl Into<Arc<str>>) -> track::Producer {
-		track::Producer::new(
-			Arc::new(broadcast::Info::default()),
-			name,
-			None,
-			&cache::Pool::default(),
-		)
+		track::Producer::new(Arc::new(broadcast::Info::default()), name, None)
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -711,10 +711,15 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 #[cfg(test)]
 mod test {
 	use super::*;
-	use crate::{Timestamp, broadcast};
+	use crate::{Timestamp, broadcast, cache};
 
 	fn track_producer(name: impl Into<Arc<str>>) -> track::Producer {
-		track::Producer::new(Arc::new(broadcast::Info::default()), name, None)
+		track::Producer::new(
+			Arc::new(broadcast::Info::default()),
+			name,
+			None,
+			&cache::Pool::default(),
+		)
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -446,7 +446,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "announce");
 
-		let broadcast = broadcast::Info { hops }.produce().with_pool(self.origin.pool());
+		let broadcast = broadcast::Info {
+			hops,
+			pool: self.origin.pool(),
+		}
+		.produce();
 
 		// Create the dynamic handler BEFORE publishing, so that consumers
 		// see dynamic >= 1 immediately when they receive the announcement.
@@ -498,7 +502,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "restart");
 
-		let broadcast = broadcast::Info { hops }.produce().with_pool(self.origin.pool());
+		let broadcast = broadcast::Info {
+			hops,
+			pool: self.origin.pool(),
+		}
+		.produce();
 		let dynamic = broadcast.dynamic();
 
 		// Publish the replacement first so the origin restarts atomically; the old broadcast is

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -446,11 +446,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "announce");
 
-		let broadcast = broadcast::Info {
-			hops,
-			pool: self.origin.pool(),
-		}
-		.produce();
+		let broadcast = broadcast::Info { hops }.produce().with_pool(self.origin.pool());
 
 		// Create the dynamic handler BEFORE publishing, so that consumers
 		// see dynamic >= 1 immediately when they receive the announcement.
@@ -502,11 +498,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "restart");
 
-		let broadcast = broadcast::Info {
-			hops,
-			pool: self.origin.pool(),
-		}
-		.produce();
+		let broadcast = broadcast::Info { hops }.produce().with_pool(self.origin.pool());
 		let dynamic = broadcast.dynamic();
 
 		// Publish the replacement first so the origin restarts atomically; the old broadcast is

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -446,7 +446,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "announce");
 
-		let broadcast = broadcast::Info { hops }.produce();
+		let broadcast = broadcast::Info {
+			hops,
+			pool: self.origin.pool(),
+		}
+		.produce();
 
 		// Create the dynamic handler BEFORE publishing, so that consumers
 		// see dynamic >= 1 immediately when they receive the announcement.
@@ -498,7 +502,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "restart");
 
-		let broadcast = broadcast::Info { hops }.produce();
+		let broadcast = broadcast::Info {
+			hops,
+			pool: self.origin.pool(),
+		}
+		.produce();
 		let dynamic = broadcast.dynamic();
 
 		// Publish the replacement first so the origin restarts atomically; the old broadcast is

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1013,11 +1013,14 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 
 		// Publisher Max Latency rides on the wire, so the local retention window
 		// matches what the upstream advertises (relays re-serve with the same bound).
+		// `broadcast` is left at its default here; the caller binds it via
+		// `Request::accept`, which stamps the track's real broadcast.
 		let model = track::Info {
 			timescale: info.timescale,
 			cache: info.cache,
 			priority: info.priority,
 			ordered: info.ordered,
+			..Default::default()
 		};
 		Ok(model)
 	}

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1015,13 +1015,11 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		// matches what the upstream advertises (relays re-serve with the same bound).
 		// `broadcast` is left at its default here; the caller binds it via
 		// `Request::accept`, which stamps the track's real broadcast.
-		let model = track::Info {
-			timescale: info.timescale,
-			cache: info.cache,
-			priority: info.priority,
-			ordered: info.ordered,
-			..Default::default()
-		};
+		let model = track::Info::default()
+			.with_timescale(info.timescale)
+			.with_cache(info.cache)
+			.with_priority(info.priority)
+			.with_ordered(info.ordered);
 		Ok(model)
 	}
 
@@ -1249,12 +1247,9 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		// Make the group available (resolving the downstream fetch) and fill it. The
 		// track::Info only takes effect if the track isn't accepted yet (a fetch with no
 		// live subscription); otherwise the group inherits the accepted timescale.
-		let group_info = track::Info {
-			// Relay-served FETCH is lite-05+, so `timescale` is `Some`; fall back to the
-			// default scale defensively rather than panicking.
-			timescale: timescale.unwrap_or_default(),
-			..Default::default()
-		};
+		// Relay-served FETCH is lite-05+, so `timescale` is `Some`; fall back to the
+		// default scale defensively rather than panicking.
+		let group_info = track::Info::default().with_timescale(timescale.unwrap_or_default());
 		let mut producer = match request.accept(group_info) {
 			Ok(producer) => producer,
 			Err(err) => {

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -448,7 +448,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		let broadcast = broadcast::Info {
 			hops,
-			pool: self.origin.pool(),
+			origin: self.origin.info(),
 		}
 		.produce();
 
@@ -504,7 +504,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		let broadcast = broadcast::Info {
 			hops,
-			pool: self.origin.pool(),
+			origin: self.origin.info(),
 		}
 		.produce();
 		let dynamic = broadcast.dynamic();

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -1,4 +1,4 @@
-use crate::track;
+use crate::{cache, track};
 use std::{
 	collections::{HashMap, VecDeque, hash_map},
 	sync::Arc,
@@ -19,12 +19,18 @@ pub struct Info {
 	/// [`crate::Origin`] when forwarding, so the list is used for loop detection and
 	/// shortest-path preference.
 	pub hops: OriginList,
+
+	/// The cache pool every group of every track in this broadcast registers with.
+	/// Unbounded by default; a relay shares one bounded [`cache::Pool`] across all
+	/// broadcasts so old groups are evicted under memory pressure.
+	pub pool: cache::Pool,
 }
 
 impl Default for Info {
 	fn default() -> Self {
 		Self {
 			hops: OriginList::new(),
+			pool: cache::Pool::default(),
 		}
 	}
 }
@@ -33,6 +39,13 @@ impl Info {
 	/// Create a new broadcast with an empty hop chain.
 	pub fn new() -> Self {
 		Self::default()
+	}
+
+	/// Set the cache pool this broadcast's groups register with, returning `self`
+	/// for chaining. Defaults to an unbounded pool.
+	pub fn with_pool(mut self, pool: crate::cache::Pool) -> Self {
+		self.pool = pool;
+		self
 	}
 
 	/// Consume this [Info] to create a producer that carries its metadata

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -19,12 +19,19 @@ pub struct Info {
 	/// [`crate::Origin`] when forwarding, so the list is used for loop detection and
 	/// shortest-path preference.
 	pub hops: OriginList,
+
+	// The cache pool every track (and its groups) under this broadcast inherits,
+	// threaded down the ownership chain via the `Arc<Info>` a track holds. Not part
+	// of the public surface: a relay configures it once on its `origin::Info` and it
+	// flows origin -> broadcast -> track -> group. Unbounded by default.
+	pub(crate) pool: cache::Pool,
 }
 
 impl Default for Info {
 	fn default() -> Self {
 		Self {
 			hops: OriginList::new(),
+			pool: cache::Pool::default(),
 		}
 	}
 }
@@ -36,8 +43,7 @@ impl Info {
 	}
 
 	/// Consume this [Info] to create a producer that carries its metadata
-	/// (including the hop chain), with an unbounded cache pool. Use
-	/// [`Producer::with_pool`] to register groups against a shared budget.
+	/// (including the hop chain).
 	///
 	/// Keep the returned [`Producer`] alive for as long as the broadcast should stay
 	/// available, and end it with [`Producer::close`]. See the note on [`Producer`].
@@ -67,12 +73,6 @@ struct BroadcastState {
 	// Set by an explicit `Producer::close()` so `Drop` can tell a deliberate
 	// shutdown apart from a producer that was dropped by accident.
 	closed: bool,
-
-	// The cache pool every track (and its groups) under this broadcast registers
-	// with, set by `Producer::with_pool`. In the shared state so both the producer
-	// and its consumers (on-demand track requests) mint tracks against one budget.
-	// Unbounded by default.
-	pool: cache::Pool,
 }
 
 impl BroadcastState {
@@ -128,8 +128,7 @@ pub struct Producer {
 }
 
 impl Producer {
-	/// Create a producer for the given broadcast metadata, with an unbounded cache
-	/// pool. Prefer [`Info::produce`].
+	/// Create a producer for the given broadcast metadata. Prefer [`Info::produce`].
 	pub fn new(info: Info) -> Self {
 		Self {
 			info: Arc::new(info),
@@ -137,27 +136,8 @@ impl Producer {
 		}
 	}
 
-	/// Set the [`cache::Pool`] groups under this broadcast register with, returning
-	/// `self` for chaining. Set before creating any track (a relay stamps the origin's
-	/// shared pool here so every cached group draws on one memory budget).
-	///
-	/// Lives in the shared state so both this producer and its [`Consumer`]s reach it
-	/// (a consumer's on-demand [`track`](Consumer::track) request registers its groups
-	/// with the same pool).
-	pub fn with_pool(self, pool: cache::Pool) -> Self {
-		if let Ok(mut state) = BroadcastState::modify(&self.state) {
-			state.pool = pool;
-		}
-		self
-	}
-
 	pub fn info(&self) -> &Info {
 		&self.info
-	}
-
-	/// The cache pool groups under this broadcast register with.
-	fn pool(&self) -> cache::Pool {
-		self.state.read().pool.clone()
 	}
 
 	/// Remove a track from the lookup.
@@ -177,7 +157,7 @@ impl Producer {
 		info: impl Into<Option<track::Info>>,
 	) -> Result<track::Producer, Error> {
 		let info = info.into().unwrap_or_default();
-		let track = track::Producer::new(self.info.clone(), name, info, &self.pool());
+		let track = track::Producer::new(self.info.clone(), name, info);
 		let mut state = BroadcastState::modify(&self.state)?;
 		state.insert_track(track.weak())?;
 		drop(state);
@@ -192,7 +172,7 @@ impl Producer {
 	/// inspected the media, the same shape as a consumer-driven
 	/// [`Dynamic::requested_track`].
 	pub fn reserve_track(&mut self, name: impl Into<Arc<str>>) -> Result<track::Request, Error> {
-		let request = track::Request::new(self.info.clone(), name, &self.pool());
+		let request = track::Request::new(self.info.clone(), name);
 		let mut state = BroadcastState::modify(&self.state)?;
 		state.insert_track(request.weak())?;
 		drop(state);
@@ -456,11 +436,10 @@ impl Consumer {
 		}
 
 		// Allocate the name once and share the same Arc across the request, the
-		// requests map, and the FIFO order. The request's groups register with the
-		// broadcast's shared pool, same as a producer-created track.
-		let pool = state.pool.clone();
+		// requests map, and the FIFO order. The request inherits the broadcast's
+		// cache pool through its `Arc<Info>`, same as a producer-created track.
 		let name: Arc<str> = name.into();
-		let request = track::Request::new(self.info.clone(), name.clone(), &pool);
+		let request = track::Request::new(self.info.clone(), name.clone());
 		let consumer = request.consume();
 
 		state.requests.insert(name.clone(), request);

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -19,18 +19,12 @@ pub struct Info {
 	/// [`crate::Origin`] when forwarding, so the list is used for loop detection and
 	/// shortest-path preference.
 	pub hops: OriginList,
-
-	/// The cache pool every group of every track in this broadcast registers with.
-	/// Unbounded by default; a relay shares one bounded [`cache::Pool`] across all
-	/// broadcasts so old groups are evicted under memory pressure.
-	pub pool: cache::Pool,
 }
 
 impl Default for Info {
 	fn default() -> Self {
 		Self {
 			hops: OriginList::new(),
-			pool: cache::Pool::default(),
 		}
 	}
 }
@@ -41,15 +35,9 @@ impl Info {
 		Self::default()
 	}
 
-	/// Set the cache pool this broadcast's groups register with, returning `self`
-	/// for chaining. Defaults to an unbounded pool.
-	pub fn with_pool(mut self, pool: crate::cache::Pool) -> Self {
-		self.pool = pool;
-		self
-	}
-
 	/// Consume this [Info] to create a producer that carries its metadata
-	/// (including the hop chain).
+	/// (including the hop chain), with an unbounded cache pool. Use
+	/// [`Producer::with_pool`] to register groups against a shared budget.
 	///
 	/// Keep the returned [`Producer`] alive for as long as the broadcast should stay
 	/// available, and end it with [`Producer::close`]. See the note on [`Producer`].
@@ -79,6 +67,12 @@ struct BroadcastState {
 	// Set by an explicit `Producer::close()` so `Drop` can tell a deliberate
 	// shutdown apart from a producer that was dropped by accident.
 	closed: bool,
+
+	// The cache pool every track (and its groups) under this broadcast registers
+	// with, set by `Producer::with_pool`. In the shared state so both the producer
+	// and its consumers (on-demand track requests) mint tracks against one budget.
+	// Unbounded by default.
+	pool: cache::Pool,
 }
 
 impl BroadcastState {
@@ -134,7 +128,8 @@ pub struct Producer {
 }
 
 impl Producer {
-	/// Create a producer for the given broadcast metadata. Prefer [`Info::produce`].
+	/// Create a producer for the given broadcast metadata, with an unbounded cache
+	/// pool. Prefer [`Info::produce`].
 	pub fn new(info: Info) -> Self {
 		Self {
 			info: Arc::new(info),
@@ -142,8 +137,27 @@ impl Producer {
 		}
 	}
 
+	/// Set the [`cache::Pool`] groups under this broadcast register with, returning
+	/// `self` for chaining. Set before creating any track (a relay stamps the origin's
+	/// shared pool here so every cached group draws on one memory budget).
+	///
+	/// Lives in the shared state so both this producer and its [`Consumer`]s reach it
+	/// (a consumer's on-demand [`track`](Consumer::track) request registers its groups
+	/// with the same pool).
+	pub fn with_pool(self, pool: cache::Pool) -> Self {
+		if let Ok(mut state) = BroadcastState::modify(&self.state) {
+			state.pool = pool;
+		}
+		self
+	}
+
 	pub fn info(&self) -> &Info {
 		&self.info
+	}
+
+	/// The cache pool groups under this broadcast register with.
+	fn pool(&self) -> cache::Pool {
+		self.state.read().pool.clone()
 	}
 
 	/// Remove a track from the lookup.
@@ -163,7 +177,7 @@ impl Producer {
 		info: impl Into<Option<track::Info>>,
 	) -> Result<track::Producer, Error> {
 		let info = info.into().unwrap_or_default();
-		let track = track::Producer::new(self.info.clone(), name, info);
+		let track = track::Producer::new(self.info.clone(), name, info, &self.pool());
 		let mut state = BroadcastState::modify(&self.state)?;
 		state.insert_track(track.weak())?;
 		drop(state);
@@ -178,7 +192,7 @@ impl Producer {
 	/// inspected the media, the same shape as a consumer-driven
 	/// [`Dynamic::requested_track`].
 	pub fn reserve_track(&mut self, name: impl Into<Arc<str>>) -> Result<track::Request, Error> {
-		let request = track::Request::new(self.info.clone(), name);
+		let request = track::Request::new(self.info.clone(), name, &self.pool());
 		let mut state = BroadcastState::modify(&self.state)?;
 		state.insert_track(request.weak())?;
 		drop(state);
@@ -442,9 +456,11 @@ impl Consumer {
 		}
 
 		// Allocate the name once and share the same Arc across the request, the
-		// requests map, and the FIFO order.
+		// requests map, and the FIFO order. The request's groups register with the
+		// broadcast's shared pool, same as a producer-created track.
+		let pool = state.pool.clone();
 		let name: Arc<str> = name.into();
-		let request = track::Request::new(self.info.clone(), name.clone());
+		let request = track::Request::new(self.info.clone(), name.clone(), &pool);
 		let consumer = request.consume();
 
 		state.requests.insert(name.clone(), request);

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -1,4 +1,4 @@
-use crate::{cache, track};
+use crate::track;
 use std::{
 	collections::{HashMap, VecDeque, hash_map},
 	sync::Arc,
@@ -20,18 +20,19 @@ pub struct Info {
 	/// shortest-path preference.
 	pub hops: OriginList,
 
-	// The cache pool every track (and its groups) under this broadcast inherits,
-	// threaded down the ownership chain via the `Arc<Info>` a track holds. Not part
-	// of the public surface: a relay configures it once on its `origin::Info` and it
-	// flows origin -> broadcast -> track -> group. Unbounded by default.
-	pub(crate) pool: cache::Pool,
+	/// The origin this broadcast belongs to (its identity, and the cache pool its
+	/// tracks and groups inherit). A track reaches its pool by walking up this link,
+	/// so the pool has a single home on the origin rather than being copied per
+	/// broadcast. Defaults to an unknown origin with an unbounded pool (a standalone
+	/// broadcast with no relay origin).
+	pub origin: super::origin::Info,
 }
 
 impl Default for Info {
 	fn default() -> Self {
 		Self {
 			hops: OriginList::new(),
-			pool: cache::Pool::default(),
+			origin: super::origin::Info::default(),
 		}
 	}
 }

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -1,9 +1,10 @@
 //! A shared byte budget for cached groups, reclaimed with LRU eviction.
 //!
 //! Every group registers its cached bytes in a [`Pool`]. When the pool exceeds its
-//! capacity, the least-recently-read groups are aborted with [`Error::Evicted`],
-//! freeing their frames immediately. The latest group of each track is pinned and
-//! never evicted, so the live edge always survives memory pressure.
+//! capacity, the least-recently-read groups are aborted with
+//! [`Error::Evicted`](crate::Error::Evicted), freeing their frames immediately. The
+//! latest group of each track is pinned and never evicted, so the live edge always
+//! survives memory pressure.
 //!
 //! A pool is inert by default ([`Pool::unbounded`]): publishers and subscribers that
 //! never set a capacity pay only a couple of atomic counters. A relay creates one
@@ -12,8 +13,10 @@
 
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap};
+use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+
+use web_async::Lock;
 
 /// Fixed bookkeeping charged per cached group on top of its frame payload bytes.
 ///
@@ -26,9 +29,9 @@ const ENTRY_OVERHEAD: u64 = 256;
 ///
 /// The pool tracks how many payload bytes are cached across every registered group
 /// and evicts the least-recently-read groups once `used` exceeds `capacity`.
-/// Eviction aborts the victim group with [`Error::Evicted`], which frees its frames
-/// immediately and wakes any parked readers. Pinned (latest) groups are never
-/// evicted but still count against the budget.
+/// Eviction aborts the victim group with [`Error::Evicted`](crate::Error::Evicted),
+/// which frees its frames immediately and wakes any parked readers. Pinned (latest)
+/// groups are never evicted but still count against the budget.
 ///
 /// Reads and writes only touch atomics; the internal lock is taken when a group
 /// registers/unregisters and when the pool is actually over budget.
@@ -44,7 +47,7 @@ struct Inner {
 	capacity: AtomicU64,
 	// Reference point for the coarse `last_access` clock.
 	epoch: web_async::time::Instant,
-	lru: Mutex<Lru>,
+	lru: Lock<Lru>,
 }
 
 impl Default for Inner {
@@ -53,7 +56,7 @@ impl Default for Inner {
 			used: AtomicU64::new(0),
 			capacity: AtomicU64::new(u64::MAX),
 			epoch: web_async::time::Instant::now(),
-			lru: Mutex::default(),
+			lru: Lock::default(),
 		}
 	}
 }
@@ -153,7 +156,7 @@ impl Pool {
 	pub(crate) fn register(&self, evict: Box<dyn Fn() + Send + Sync>) -> Charge {
 		let inner = self.inner.clone();
 		let entry = {
-			let mut lru = inner.lru.lock().unwrap();
+			let mut lru = inner.lru.lock();
 			let id = lru.next_id;
 			lru.next_id += 1;
 
@@ -190,7 +193,7 @@ impl Pool {
 
 		let mut victims = Vec::new();
 		{
-			let mut lru = inner.lru.lock().unwrap();
+			let mut lru = inner.lru.lock();
 			// Bytes the collected victims will release once aborted below.
 			let mut freed = 0u64;
 			// Pinned entries popped this pass; re-pushing them immediately would just
@@ -316,7 +319,7 @@ impl Drop for Charge {
 		let bytes = entry.bytes.swap(0, Ordering::Relaxed);
 		inner.used.fetch_sub(bytes, Ordering::Relaxed);
 		// The heap slot (if any) goes stale and is discarded on its next pop.
-		inner.lru.lock().unwrap().entries.remove(&entry.id);
+		inner.lru.lock().entries.remove(&entry.id);
 	}
 }
 

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -1,0 +1,487 @@
+//! A shared byte budget for cached groups, reclaimed with LRU eviction.
+//!
+//! Every group registers its cached bytes in a [`Pool`]. When the pool exceeds its
+//! capacity, the least-recently-read groups are aborted with [`Error::Evicted`],
+//! freeing their frames immediately. The latest group of each track is pinned and
+//! never evicted, so the live edge always survives memory pressure.
+//!
+//! A pool is inert by default ([`Pool::unbounded`]): publishers and subscribers that
+//! never set a capacity pay only a couple of atomic counters. A relay creates one
+//! bounded pool and shares it across every origin so the whole process caches into a
+//! single budget.
+
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+/// Fixed bookkeeping charged per cached group on top of its frame payload bytes.
+///
+/// Covers the group/track slot allocations so a track producing many tiny groups
+/// (e.g. one frame per group) is billed roughly for its real footprint instead of
+/// just its payload bytes.
+const ENTRY_OVERHEAD: u64 = 256;
+
+/// A shared byte budget that caches charge into; cloning shares the same budget.
+///
+/// The pool tracks how many payload bytes are cached across every registered group
+/// and evicts the least-recently-read groups once `used` exceeds `capacity`.
+/// Eviction aborts the victim group with [`Error::Evicted`], which frees its frames
+/// immediately and wakes any parked readers. Pinned (latest) groups are never
+/// evicted but still count against the budget.
+///
+/// Reads and writes only touch atomics; the internal lock is taken when a group
+/// registers/unregisters and when the pool is actually over budget.
+#[derive(Clone, Default)]
+pub struct Pool {
+	inner: Arc<Inner>,
+}
+
+struct Inner {
+	// Total bytes currently charged, including pinned entries and per-entry overhead.
+	used: AtomicU64,
+	// u64::MAX means unbounded.
+	capacity: AtomicU64,
+	// Reference point for the coarse `last_access` clock.
+	epoch: web_async::time::Instant,
+	lru: Mutex<Lru>,
+}
+
+impl Default for Inner {
+	fn default() -> Self {
+		Self {
+			used: AtomicU64::new(0),
+			capacity: AtomicU64::new(u64::MAX),
+			epoch: web_async::time::Instant::now(),
+			lru: Mutex::default(),
+		}
+	}
+}
+
+#[derive(Default)]
+struct Lru {
+	// Min-heap of (last_access snapshot, id). Snapshots go stale when an entry is
+	// touched; a popped entry whose current last_access differs is re-pushed with
+	// the fresh key instead of being evicted (lazy re-keying).
+	heap: BinaryHeap<Reverse<(u64, u64)>>,
+	// Live entries by id. An id popped from the heap that's no longer here was
+	// already evicted or dropped.
+	entries: HashMap<u64, Arc<Entry>>,
+	next_id: u64,
+}
+
+/// A single cached group's registration in the pool.
+///
+/// Holds only atomics plus the eviction hook, so touching recency or flipping the
+/// pin never takes a lock. The hook holds a weak handle to the group, so an entry
+/// never keeps its group alive.
+pub(crate) struct Entry {
+	id: u64,
+	// Payload bytes plus ENTRY_OVERHEAD currently charged by this entry.
+	bytes: AtomicU64,
+	// Coarse milliseconds since the pool epoch of the last read (or write).
+	last_access: AtomicU64,
+	// Pinned entries (the track's latest group) are skipped by eviction.
+	pinned: AtomicBool,
+	// Aborts the group with Error::Evicted. Called without any pool lock held.
+	evict: Box<dyn Fn() + Send + Sync>,
+	epoch: web_async::time::Instant,
+}
+
+impl Entry {
+	fn now(&self) -> u64 {
+		self.epoch.elapsed().as_millis() as u64
+	}
+
+	/// Record a read so eviction considers this group recently used.
+	pub(crate) fn touch(&self) {
+		self.last_access.store(self.now(), Ordering::Relaxed);
+	}
+
+	/// Pin or unpin this entry. Pinned entries are immune to eviction.
+	pub(crate) fn set_pinned(&self, pinned: bool) {
+		self.pinned.store(pinned, Ordering::Relaxed);
+	}
+}
+
+impl Pool {
+	/// Create a pool that evicts once `capacity` bytes are cached.
+	///
+	/// The budget counts frame payload bytes (plus a small fixed overhead per
+	/// group), not process RSS; leave headroom when sizing it from real memory.
+	pub fn new(capacity: u64) -> Self {
+		let pool = Self::default();
+		pool.inner.capacity.store(capacity, Ordering::Relaxed);
+		pool
+	}
+
+	/// Create a pool that never evicts. This is the [`Default`].
+	pub fn unbounded() -> Self {
+		Self::default()
+	}
+
+	/// The configured capacity in bytes, or `None` when unbounded.
+	pub fn capacity(&self) -> Option<u64> {
+		match self.inner.capacity.load(Ordering::Relaxed) {
+			u64::MAX => None,
+			capacity => Some(capacity),
+		}
+	}
+
+	/// Bytes currently cached across every registered group.
+	pub fn used(&self) -> u64 {
+		self.inner.used.load(Ordering::Relaxed)
+	}
+
+	/// Change the capacity, evicting immediately if the new capacity is exceeded.
+	/// `None` makes the pool unbounded.
+	pub fn resize(&self, capacity: impl Into<Option<u64>>) {
+		let capacity = capacity.into().unwrap_or(u64::MAX);
+		self.inner.capacity.store(capacity, Ordering::Relaxed);
+		self.evict();
+	}
+
+	/// Returns true if both handles share the same underlying pool.
+	pub fn same_pool(&self, other: &Self) -> bool {
+		Arc::ptr_eq(&self.inner, &other.inner)
+	}
+
+	/// Register a group, returning the [`Charge`] that tracks its bytes.
+	///
+	/// `evict` must abort the group (releasing its charge); it is invoked without
+	/// any pool lock held, and never after the returned charge is dropped.
+	pub(crate) fn register(&self, evict: Box<dyn Fn() + Send + Sync>) -> Charge {
+		let inner = self.inner.clone();
+		let entry = {
+			let mut lru = inner.lru.lock().unwrap();
+			let id = lru.next_id;
+			lru.next_id += 1;
+
+			let entry = Arc::new(Entry {
+				id,
+				bytes: AtomicU64::new(ENTRY_OVERHEAD),
+				last_access: AtomicU64::new(0),
+				pinned: AtomicBool::new(false),
+				evict,
+				epoch: inner.epoch,
+			});
+			entry.touch();
+
+			lru.entries.insert(id, entry.clone());
+			lru.heap.push(Reverse((entry.last_access.load(Ordering::Relaxed), id)));
+			entry
+		};
+
+		inner.used.fetch_add(ENTRY_OVERHEAD, Ordering::Relaxed);
+		Charge {
+			inner: Some((inner, entry)),
+		}
+	}
+
+	/// Evict least-recently-read groups until the pool is back under capacity.
+	///
+	/// Victims are collected under the lock but aborted after it's released, so an
+	/// eviction hook can freely take its group's lock.
+	pub(crate) fn evict(&self) {
+		let inner = &self.inner;
+		if inner.used.load(Ordering::Relaxed) <= inner.capacity.load(Ordering::Relaxed) {
+			return;
+		}
+
+		let mut victims = Vec::new();
+		{
+			let mut lru = inner.lru.lock().unwrap();
+			// Bytes the collected victims will release once aborted below.
+			let mut freed = 0u64;
+			// Pinned entries popped this pass; re-pushing them immediately would just
+			// pop them again (same key), so they're held aside until the pass ends.
+			let mut pinned = Vec::new();
+			// Bounding the pops guarantees termination: an entry needs at most two
+			// (one re-key of its stale snapshot, one settle). A concurrent touch can
+			// steal a slot, ending the pass early; the next write retries.
+			let mut budget = 2 * lru.heap.len();
+
+			while budget > 0
+				&& inner.used.load(Ordering::Relaxed).saturating_sub(freed) > inner.capacity.load(Ordering::Relaxed)
+			{
+				budget -= 1;
+				let Some(Reverse((snapshot, id))) = lru.heap.pop() else {
+					break;
+				};
+				let Some(entry) = lru.entries.get(&id) else {
+					// Already evicted or dropped; discard the stale heap slot.
+					continue;
+				};
+				let access = entry.last_access.load(Ordering::Relaxed);
+				if access != snapshot {
+					// Touched since this snapshot; re-key instead of evicting.
+					lru.heap.push(Reverse((access, id)));
+					continue;
+				}
+				if entry.pinned.load(Ordering::Relaxed) {
+					pinned.push(Reverse((access, id)));
+					continue;
+				}
+
+				let entry = lru.entries.remove(&id).unwrap();
+				freed += entry.bytes.load(Ordering::Relaxed);
+				victims.push(entry);
+			}
+
+			for slot in pinned {
+				lru.heap.push(slot);
+			}
+		}
+
+		for victim in victims {
+			(victim.evict)();
+		}
+	}
+}
+
+impl std::fmt::Debug for Pool {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Pool")
+			.field("used", &self.used())
+			.field("capacity", &self.capacity())
+			.finish()
+	}
+}
+
+/// The RAII side of a group's pool registration, owned by the group's state.
+///
+/// `add`/`sub` mirror the group's cached payload bytes into the pool with plain
+/// atomics; no lock is taken until the group unregisters. Dropping (or
+/// [`clear`](Self::clear)ing) the charge releases everything it holds. The default
+/// charge is detached: it belongs to no pool and every operation is a no-op.
+#[derive(Default)]
+pub(crate) struct Charge {
+	inner: Option<(Arc<Inner>, Arc<Entry>)>,
+}
+
+impl Charge {
+	/// Charge `n` more payload bytes and mark the group recently used.
+	///
+	/// Doesn't evict; callers trigger [`Pool::evict`] via [`Self::pool`] after
+	/// releasing their own locks.
+	pub(crate) fn add(&self, n: u64) {
+		if let Some((inner, entry)) = &self.inner {
+			entry.bytes.fetch_add(n, Ordering::Relaxed);
+			inner.used.fetch_add(n, Ordering::Relaxed);
+			entry.touch();
+		}
+	}
+
+	/// Release `n` payload bytes (a frame evicted by the group's own cap).
+	pub(crate) fn sub(&self, n: u64) {
+		if let Some((inner, entry)) = &self.inner {
+			entry.bytes.fetch_sub(n, Ordering::Relaxed);
+			inner.used.fetch_sub(n, Ordering::Relaxed);
+		}
+	}
+
+	/// Release everything this charge holds (bytes and overhead). Idempotent;
+	/// used when the group aborts and clears its frames.
+	pub(crate) fn clear(&self) {
+		if let Some((inner, entry)) = &self.inner {
+			let bytes = entry.bytes.swap(0, Ordering::Relaxed);
+			inner.used.fetch_sub(bytes, Ordering::Relaxed);
+		}
+	}
+
+	/// Mark the group recently used (a consumer read a frame).
+	pub(crate) fn touch(&self) {
+		if let Some((_, entry)) = &self.inner {
+			entry.touch();
+		}
+	}
+
+	/// The registration entry, for pinning. `None` when detached.
+	pub(crate) fn entry(&self) -> Option<Arc<Entry>> {
+		self.inner.as_ref().map(|(_, entry)| entry.clone())
+	}
+
+	/// A pool handle for triggering eviction outside the caller's locks.
+	/// `None` when detached.
+	pub(crate) fn pool(&self) -> Option<Pool> {
+		self.inner.as_ref().map(|(inner, _)| Pool { inner: inner.clone() })
+	}
+}
+
+impl Drop for Charge {
+	fn drop(&mut self) {
+		let Some((inner, entry)) = self.inner.take() else {
+			return;
+		};
+		let bytes = entry.bytes.swap(0, Ordering::Relaxed);
+		inner.used.fetch_sub(bytes, Ordering::Relaxed);
+		// The heap slot (if any) goes stale and is discarded on its next pop.
+		inner.lru.lock().unwrap().entries.remove(&entry.id);
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use std::time::Duration;
+
+	fn flag() -> (Arc<AtomicBool>, Box<dyn Fn() + Send + Sync>) {
+		let evicted = Arc::new(AtomicBool::new(false));
+		let hook = evicted.clone();
+		(
+			evicted,
+			Box::new(move || {
+				hook.store(true, Ordering::Relaxed);
+			}),
+		)
+	}
+
+	#[test]
+	fn unbounded_never_evicts() {
+		let pool = Pool::unbounded();
+		let (evicted, hook) = flag();
+		let charge = pool.register(hook);
+		charge.add(1 << 40);
+		pool.evict();
+		assert!(!evicted.load(Ordering::Relaxed));
+		assert_eq!(pool.used(), (1 << 40) + ENTRY_OVERHEAD);
+		drop(charge);
+		assert_eq!(pool.used(), 0);
+	}
+
+	#[test]
+	fn detached_charge_is_noop() {
+		let charge = Charge::default();
+		charge.add(123);
+		charge.sub(23);
+		charge.clear();
+		charge.touch();
+		assert!(charge.entry().is_none());
+		assert!(charge.pool().is_none());
+	}
+
+	#[tokio::test]
+	async fn evicts_least_recently_used() {
+		tokio::time::pause();
+
+		let pool = Pool::new(3 * ENTRY_OVERHEAD + 2500);
+		let (evicted_a, hook_a) = flag();
+		let (evicted_b, hook_b) = flag();
+		let (evicted_c, hook_c) = flag();
+
+		let a = pool.register(hook_a);
+		a.add(1000);
+		tokio::time::advance(Duration::from_millis(10)).await;
+		let b = pool.register(hook_b);
+		b.add(1000);
+		tokio::time::advance(Duration::from_millis(10)).await;
+
+		// Read A so B becomes the least recently used.
+		a.touch();
+		tokio::time::advance(Duration::from_millis(10)).await;
+
+		let c = pool.register(hook_c);
+		c.add(1000);
+		// Over budget by 500: evicting B (stalest) is enough once its charge clears.
+		pool.evict();
+
+		assert!(!evicted_a.load(Ordering::Relaxed));
+		assert!(evicted_b.load(Ordering::Relaxed));
+		assert!(!evicted_c.load(Ordering::Relaxed));
+
+		// The hook is responsible for releasing the charge (a real group aborts).
+		b.clear();
+		assert_eq!(pool.used(), 2 * (1000 + ENTRY_OVERHEAD));
+	}
+
+	#[tokio::test]
+	async fn pinned_entries_survive() {
+		tokio::time::pause();
+
+		let pool = Pool::new(ENTRY_OVERHEAD);
+		let (evicted_a, hook_a) = flag();
+		let (evicted_b, hook_b) = flag();
+
+		let a = pool.register(hook_a);
+		a.entry().unwrap().set_pinned(true);
+		a.add(1000);
+		tokio::time::advance(Duration::from_millis(10)).await;
+
+		let b = pool.register(hook_b);
+		b.add(1000);
+
+		pool.evict();
+		// A is older but pinned; B is the only eligible victim.
+		assert!(!evicted_a.load(Ordering::Relaxed));
+		assert!(evicted_b.load(Ordering::Relaxed));
+
+		// With B gone, everything left is pinned: eviction terminates without
+		// touching A even though the pool stays over budget.
+		b.clear();
+		drop(b);
+		pool.evict();
+		assert!(!evicted_a.load(Ordering::Relaxed));
+	}
+
+	#[tokio::test]
+	async fn resize_evicts() {
+		tokio::time::pause();
+
+		let pool = Pool::unbounded();
+		let (evicted_a, hook_a) = flag();
+		let a = pool.register(hook_a);
+		a.add(1000);
+
+		pool.evict();
+		assert!(!evicted_a.load(Ordering::Relaxed));
+
+		pool.resize(100);
+		assert!(evicted_a.load(Ordering::Relaxed));
+
+		// Back to unbounded: nothing more to do, and capacity() reports None.
+		pool.resize(None);
+		assert_eq!(pool.capacity(), None);
+	}
+
+	#[tokio::test]
+	async fn touched_entry_is_rekeyed_not_evicted() {
+		tokio::time::pause();
+
+		let pool = Pool::new(2 * ENTRY_OVERHEAD + 1500);
+		let (evicted_a, hook_a) = flag();
+		let (evicted_b, hook_b) = flag();
+
+		let a = pool.register(hook_a);
+		a.add(1000);
+		tokio::time::advance(Duration::from_millis(10)).await;
+		let b = pool.register(hook_b);
+		b.add(1000);
+		tokio::time::advance(Duration::from_millis(10)).await;
+
+		// A's heap snapshot is stale after this touch, so eviction re-keys A and
+		// picks B instead.
+		a.touch();
+		tokio::time::advance(Duration::from_millis(10)).await;
+		pool.evict();
+
+		assert!(!evicted_a.load(Ordering::Relaxed));
+		assert!(evicted_b.load(Ordering::Relaxed));
+	}
+
+	#[test]
+	fn dropped_charge_leaves_stale_heap_slot() {
+		let pool = Pool::new(0);
+		let (evicted_a, hook_a) = flag();
+		let a = pool.register(hook_a);
+		drop(a);
+
+		// The heap still has A's slot, but the entry is gone: eviction discards it
+		// without calling the hook.
+		let (evicted_b, hook_b) = flag();
+		let b = pool.register(hook_b);
+		b.add(1);
+		pool.evict();
+		assert!(!evicted_a.load(Ordering::Relaxed));
+		assert!(evicted_b.load(Ordering::Relaxed));
+	}
+}

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -287,8 +287,7 @@ pub(crate) struct Charge {
 impl Charge {
 	/// Charge `n` more payload bytes and mark the group recently used.
 	///
-	/// Doesn't evict; callers trigger [`Pool::evict`] via [`Self::pool`] after
-	/// releasing their own locks.
+	/// Doesn't evict; callers trigger [`Pool::evict`] after releasing their own locks.
 	pub(crate) fn add(&self, n: u64) {
 		if let Some((inner, entry)) = &self.inner {
 			entry.bytes.fetch_add(n, Ordering::Relaxed);

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -149,6 +149,28 @@ impl Pool {
 		Arc::ptr_eq(&self.inner, &other.inner)
 	}
 
+	/// Test-only snapshot of the live entries: (id, last_access ms, bytes, pinned),
+	/// plus the pool's current clock reading. For diagnosing eviction order.
+	#[cfg(test)]
+	pub(crate) fn debug_entries(&self) -> (u64, Vec<(u64, u64, u64, bool)>) {
+		let now = self.inner.epoch.elapsed().as_millis() as u64;
+		let lru = self.inner.lru.lock();
+		let mut entries: Vec<_> = lru
+			.entries
+			.values()
+			.map(|e| {
+				(
+					e.id,
+					e.last_access.load(Ordering::Relaxed),
+					e.bytes.load(Ordering::Relaxed),
+					e.pinned.load(Ordering::Relaxed),
+				)
+			})
+			.collect();
+		entries.sort_unstable();
+		(now, entries)
+	}
+
 	/// Register a group, returning the [`Charge`] that tracks its bytes.
 	///
 	/// `evict` must abort the group (releasing its charge); it is invoked without

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -325,12 +325,6 @@ impl Charge {
 	pub(crate) fn entry(&self) -> Option<Arc<Entry>> {
 		self.inner.as_ref().map(|(_, entry)| entry.clone())
 	}
-
-	/// A pool handle for triggering eviction outside the caller's locks.
-	/// `None` when detached.
-	pub(crate) fn pool(&self) -> Option<Pool> {
-		self.inner.as_ref().map(|(inner, _)| Pool { inner: inner.clone() })
-	}
 }
 
 impl Drop for Charge {
@@ -382,7 +376,6 @@ mod test {
 		charge.clear();
 		charge.touch();
 		assert!(charge.entry().is_none());
-		assert!(charge.pool().is_none());
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -7,8 +7,9 @@
 //! The reader can be cloned, in which case each reader receives a copy of each frame. (fanout)
 //!
 //! The stream is closed with [Error] when all writers or readers are dropped.
-use crate::{frame, track};
+use crate::{cache, frame, track};
 use std::collections::VecDeque;
+use std::sync::Arc;
 use std::task::{Poll, ready};
 
 use bytes::Bytes;
@@ -42,7 +43,7 @@ impl Info {
 	/// tests that don't exercise timestamps.
 	#[cfg(test)]
 	pub(crate) fn produce(self) -> Producer {
-		Producer::new(self, track::Info::default())
+		Producer::new(self, track::Info::default(), &cache::Pool::default())
 	}
 }
 
@@ -88,6 +89,10 @@ struct GroupState {
 	// The total size (in bytes) of all cached frames.
 	cache: u64,
 
+	// This group's registration in the track's cache pool; mirrors `cache` so the
+	// pool can evict the least-recently-read groups under memory pressure.
+	charge: cache::Charge,
+
 	// Whether the group has been finalized (no more frames).
 	fin: bool,
 
@@ -100,11 +105,15 @@ impl GroupState {
 		if index < self.offset {
 			Poll::Ready(Err(Error::CacheFull))
 		} else if let Some(frame) = self.frames.get(index - self.offset) {
+			self.charge.touch();
 			Poll::Ready(Ok(Some(frame.consume())))
+		} else if let Some(err) = &self.abort {
+			// Checked before `fin`: an evicted group is both finished and aborted,
+			// and a reader past the cleared frames must see the abort, not a clean
+			// end-of-group at the wrong index.
+			Poll::Ready(Err(err.clone()))
 		} else if self.fin {
 			Poll::Ready(Ok(None))
-		} else if let Some(err) = &self.abort {
-			Poll::Ready(Err(err.clone()))
 		} else {
 			Poll::Pending
 		}
@@ -131,10 +140,12 @@ impl GroupState {
 	}
 
 	fn poll_finished(&self) -> Poll<Result<u64>> {
-		if self.fin {
-			Poll::Ready(Ok((self.offset + self.frames.len()) as u64))
-		} else if let Some(err) = &self.abort {
+		if let Some(err) = &self.abort {
+			// Checked before `fin`: an evicted group is both finished and aborted,
+			// and its cleared frames would report a bogus count.
 			Poll::Ready(Err(err.clone()))
+		} else if self.fin {
+			Poll::Ready(Ok((self.offset + self.frames.len()) as u64))
 		} else {
 			Poll::Pending
 		}
@@ -147,6 +158,7 @@ impl GroupState {
 				break;
 			};
 			self.cache -= frame.size;
+			self.charge.sub(frame.size);
 			self.offset += 1;
 		}
 	}
@@ -154,6 +166,20 @@ impl GroupState {
 
 fn modify(state: &kio::Producer<GroupState>) -> Result<kio::Mut<'_, GroupState>> {
 	state.write().map_err(|r| r.abort.clone().unwrap_or(Error::Dropped))
+}
+
+/// The pool's eviction hook: abort the group with [`Error::Evicted`], freeing its
+/// frames immediately. A no-op once the group is already aborted or fully dropped.
+fn evict(state: &kio::Weak<GroupState>) {
+	let Ok(mut state) = state.write() else { return };
+	if state.abort.is_some() {
+		return;
+	}
+	state.abort = Some(Error::Evicted);
+	state.frames.clear();
+	state.cache = 0;
+	state.charge.clear();
+	state.close();
 }
 
 /// Writes frames to a group in order.
@@ -192,12 +218,15 @@ impl Producer {
 	/// which threads its [`track::Info`] down so properties like the timescale are
 	/// inherited rather than passed in. Every frame added to this group is
 	/// normalized to the track's timescale by [`Self::create_frame`].
-	pub(crate) fn new(info: Info, track: track::Info) -> Self {
-		Self {
-			info,
-			state: kio::Producer::default(),
-			track,
-		}
+	///
+	/// Registers the group in `pool` so its cached bytes count against the shared
+	/// budget and it can be evicted under memory pressure.
+	pub(crate) fn new(info: Info, track: track::Info, pool: &cache::Pool) -> Self {
+		let state = kio::Producer::<GroupState>::default();
+		let weak = state.weak();
+		let charge = pool.register(Box::new(move || evict(&weak)));
+		state.write().ok().expect("a new group is open").charge = charge;
+		Self { info, state, track }
 	}
 
 	/// The parent track's timescale.
@@ -275,8 +304,17 @@ impl Producer {
 			return Err(Error::Closed);
 		}
 		state.cache += frame.size;
+		state.charge.add(frame.size);
 		state.frames.push_back(frame);
 		state.evict();
+
+		// The pool evicts other groups' state, so trigger it only after releasing
+		// our own lock.
+		let pool = state.charge.pool();
+		drop(state);
+		if let Some(pool) = pool {
+			pool.evict();
+		}
 		Ok(())
 	}
 
@@ -305,8 +343,21 @@ impl Producer {
 		guard.abort = Some(err);
 		guard.frames.clear();
 		guard.cache = 0;
+		guard.charge.clear();
 		guard.close();
 		Ok(())
+	}
+
+	/// Whether the group has been aborted (including pool eviction). The track's
+	/// read paths treat an aborted cached group as absent.
+	pub(crate) fn is_aborted(&self) -> bool {
+		self.state.read().abort.is_some()
+	}
+
+	/// This group's cache pool registration, used by the track to pin the latest
+	/// group. `None` when the pool is detached (the unbounded default).
+	pub(crate) fn cache_entry(&self) -> Option<Arc<cache::Entry>> {
+		self.state.read().charge.entry()
 	}
 
 	/// Create a new consumer for the group.
@@ -357,6 +408,7 @@ impl Drop for Producer {
 		{
 			state.frames.clear();
 			state.cache = 0;
+			state.charge.clear();
 		}
 	}
 }
@@ -747,6 +799,7 @@ mod test {
 		let mut producer = Producer::new(
 			Info { sequence: 0 },
 			track::Info::default().with_timescale(Timescale::MICRO),
+			&cache::Pool::default(),
 		);
 		let frame = frame::Info {
 			size: 3,
@@ -765,6 +818,7 @@ mod test {
 		let mut producer = Producer::new(
 			Info { sequence: 0 },
 			track::Info::default().with_timescale(Timescale::MICRO),
+			&cache::Pool::default(),
 		);
 		let writer = producer.create_frame_now(3).unwrap();
 		assert_eq!(writer.timestamp.scale(), Timescale::MICRO);
@@ -779,6 +833,7 @@ mod test {
 		let mut producer = Producer::new(
 			Info { sequence: 0 },
 			track::Info::default().with_timescale(Timescale::MICRO),
+			&cache::Pool::default(),
 		);
 		let frame = frame::Info {
 			size: 1,
@@ -799,6 +854,7 @@ mod test {
 		let mut producer = Producer::new(
 			Info { sequence: 0 },
 			track::Info::default().with_timescale(Timescale::MICRO),
+			&cache::Pool::default(),
 		);
 		let frame = frame::Info {
 			size: 1,

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -45,7 +45,7 @@ impl Info {
 	/// tests that don't exercise timestamps.
 	#[cfg(test)]
 	pub(crate) fn produce(self) -> Producer {
-		Producer::new(self, track::Info::default(), &cache::Pool::default())
+		Producer::new(self, track::Info::default())
 	}
 }
 
@@ -233,17 +233,18 @@ impl std::ops::Deref for Producer {
 impl Producer {
 	/// Create a group producer bound to its parent track's [`track::Info`].
 	///
-	/// Crate-private: groups are only constructed via [`track::Producer`],
-	/// which threads its [`track::Info`] down so properties like the timescale are
-	/// inherited rather than passed in. Every frame added to this group is
-	/// normalized to the track's timescale by [`Self::create_frame`].
+	/// Crate-private: groups are only constructed via [`track::Producer`], which
+	/// threads its [`track::Info`] down so properties like the timescale are inherited
+	/// rather than passed in. Every frame added to this group is normalized to the
+	/// track's timescale by [`Self::create_frame`].
 	///
-	/// Registers the group in `pool` so its cached bytes count against the shared
-	/// budget and it can be evicted under memory pressure.
-	pub(crate) fn new(info: Info, track: track::Info, pool: &cache::Pool) -> Self {
+	/// Registers the group in the shared cache pool reached through the track's
+	/// broadcast (`track.broadcast.origin.pool`), so its cached bytes count against
+	/// the budget and it can be evicted under memory pressure.
+	pub(crate) fn new(info: Info, track: track::Info) -> Self {
 		let state = kio::Producer::<GroupState>::default();
 		let weak = state.weak();
-		let charge = pool.register(Box::new(move || evict(&weak)));
+		let charge = track.broadcast.origin.pool.register(Box::new(move || evict(&weak)));
 		state.write().ok().expect("a new group is open").charge = charge;
 		Self { info, state, track }
 	}
@@ -285,12 +286,10 @@ impl Producer {
 		state.frames.push_back(Frame { timestamp, payload });
 		state.evict();
 
-		// The pool evicts other groups' state, so trigger it only after releasing our lock.
-		let pool = state.charge.pool();
+		// The pool evicts other groups' state, so trigger it only after releasing our
+		// lock. Reached via the parent chain; a no-op when the pool is unbounded.
 		drop(state);
-		if let Some(pool) = pool {
-			pool.evict();
-		}
+		self.track.broadcast.origin.pool.evict();
 		Ok(())
 	}
 
@@ -332,12 +331,10 @@ impl Producer {
 		});
 		state.evict();
 
-		// The pool evicts other groups' state, so trigger it only after releasing our lock.
-		let pool = state.charge.pool();
+		// The pool evicts other groups' state, so trigger it only after releasing our
+		// lock. Reached via the parent chain; a no-op when the pool is unbounded.
 		drop(state);
-		if let Some(pool) = pool {
-			pool.evict();
-		}
+		self.track.broadcast.origin.pool.evict();
 
 		let info = frame::Info {
 			size: frame.size,
@@ -420,7 +417,7 @@ impl Producer {
 		Consumer {
 			info: self.info,
 			state: self.state.consume(),
-			track: self.track,
+			track: self.track.clone(),
 			index: 0,
 			prefetch: Prefetch::default(),
 		}
@@ -446,7 +443,7 @@ impl Clone for Producer {
 		Self {
 			info: self.info,
 			state: self.state.clone(),
-			track: self.track,
+			track: self.track.clone(),
 		}
 	}
 }
@@ -559,7 +556,7 @@ impl Clone for Consumer {
 		Self {
 			state: self.state.clone(),
 			info: self.info,
-			track: self.track,
+			track: self.track.clone(),
 			index: self.index,
 			prefetch: Prefetch::default(),
 		}
@@ -1019,7 +1016,6 @@ mod test {
 		let mut producer = Producer::new(
 			Info { sequence: 0 },
 			track::Info::default().with_timescale(Timescale::MICRO),
-			&cache::Pool::default(),
 		);
 		let frame = frame::Info {
 			size: 3,
@@ -1038,7 +1034,6 @@ mod test {
 		let mut producer = Producer::new(
 			Info { sequence: 0 },
 			track::Info::default().with_timescale(Timescale::MICRO),
-			&cache::Pool::default(),
 		);
 		let writer = producer.create_frame_now(3).unwrap();
 		assert_eq!(writer.timestamp.scale(), Timescale::MICRO);

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -130,10 +130,16 @@ impl GroupState {
 			return Poll::Ready(Err(Error::CacheFull));
 		}
 		match self.frames.get(index - self.offset) {
-			Some(frame) => Poll::Ready(Ok(Some(ready!(frame.poll_read_all(waiter))?))),
-			None if self.fin => Poll::Ready(Ok(None)),
+			Some(frame) => {
+				self.charge.touch();
+				Poll::Ready(Ok(Some(ready!(frame.poll_read_all(waiter))?)))
+			}
+			// `abort` is checked before `fin`: an evicted group is both finished and
+			// aborted with its frames cleared, and the reader must see the abort
+			// rather than a clean end-of-group at the wrong index.
 			None => match &self.abort {
 				Some(err) => Poll::Ready(Err(err.clone())),
+				None if self.fin => Poll::Ready(Ok(None)),
 				None => Poll::Pending,
 			},
 		}

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -162,6 +162,13 @@ impl GroupState {
 			self.offset += 1;
 		}
 	}
+
+	/// Drop the cached frames and release their pool charge.
+	fn release(&mut self) {
+		self.frames.clear();
+		self.cache = 0;
+		self.charge.clear();
+	}
 }
 
 fn modify(state: &kio::Producer<GroupState>) -> Result<kio::Mut<'_, GroupState>> {
@@ -176,9 +183,7 @@ fn evict(state: &kio::Weak<GroupState>) {
 		return;
 	}
 	state.abort = Some(Error::Evicted);
-	state.frames.clear();
-	state.cache = 0;
-	state.charge.clear();
+	state.release();
 	state.close();
 }
 
@@ -341,9 +346,7 @@ impl Producer {
 	pub fn abort(&mut self, err: Error) -> Result<()> {
 		let mut guard = modify(&self.state)?;
 		guard.abort = Some(err);
-		guard.frames.clear();
-		guard.cache = 0;
-		guard.charge.clear();
+		guard.release();
 		guard.close();
 		Ok(())
 	}
@@ -406,9 +409,7 @@ impl Drop for Producer {
 		if let Ok(mut state) = modify(&self.state)
 			&& !state.fin
 		{
-			state.frames.clear();
-			state.cache = 0;
-			state.charge.clear();
+			state.release();
 		}
 	}
 }

--- a/rs/moq-net/src/model/mod.rs
+++ b/rs/moq-net/src/model/mod.rs
@@ -1,4 +1,5 @@
 pub mod broadcast;
+pub mod cache;
 pub mod frame;
 pub mod group;
 pub mod track;

--- a/rs/moq-net/src/model/mod.rs
+++ b/rs/moq-net/src/model/mod.rs
@@ -26,7 +26,7 @@ pub use time::*;
 
 /// Publishing and consuming the set of broadcasts announced at an origin.
 pub mod origin {
-	pub use super::origin_impl::{Broadcast, Consumer, Dynamic, Producer, Publish, Request, Requested};
+	pub use super::origin_impl::{Broadcast, Consumer, Dynamic, Info, Producer, Publish, Request, Requested};
 }
 
 /// Subscribing to broadcast (un)announcements from an origin.

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -897,7 +897,11 @@ impl Producer {
 	/// unannounces the broadcast. See [`publish_broadcast`](Self::publish_broadcast) for the
 	/// error cases.
 	pub fn create_broadcast(&self, path: impl AsPath) -> Result<Broadcast, Error> {
-		let producer = broadcast::Info::new().produce().with_pool(self.pool.clone());
+		let producer = broadcast::Info {
+			pool: self.pool.clone(),
+			..Default::default()
+		}
+		.produce();
 		let publish = self.publish_broadcast(path, &producer)?;
 		Ok(Broadcast { producer, publish })
 	}
@@ -1992,6 +1996,7 @@ mod tests {
 		// `a` carries one hop; `b` has none, so `b` wins the route and replaces it.
 		let a = broadcast::Info {
 			hops: OriginList::try_from(vec![Origin::new(1u64).unwrap()]).unwrap(),
+			..Default::default()
 		}
 		.produce();
 		let b = broadcast::Info::new().produce();
@@ -2013,6 +2018,7 @@ mod tests {
 		// `a` carries one hop; `b` has none, so `b` wins the route and replaces it.
 		let a = broadcast::Info {
 			hops: OriginList::try_from(vec![Origin::new(1u64).unwrap()]).unwrap(),
+			..Default::default()
 		}
 		.produce();
 		let b = broadcast::Info::new().produce();
@@ -2063,7 +2069,11 @@ mod tests {
 					.collect::<Vec<_>>(),
 			)
 			.unwrap();
-			broadcast::Info { hops }.produce()
+			broadcast::Info {
+				hops,
+				..Default::default()
+			}
+			.produce()
 		}
 
 		// Resolve the active route for "test" after publishing both routes in the given order.

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -108,13 +108,15 @@ impl Origin {
 	}
 }
 
-/// Construction config for an [origin `Producer`](Producer): its wire identity plus
-/// the cache pool its broadcasts inherit.
+/// An origin's identity plus the cache pool its broadcasts inherit.
 ///
-/// The origin owns the [`cache::Pool`] every group in the tree registers with, so a
-/// relay configures one bounded pool here and every broadcast, track, and group
-/// beneath it shares that single memory budget. Defaults to an unbounded pool
-/// ([`Origin::produce`] is the shorthand for that).
+/// Doubles as the construction config for an [origin `Producer`](Producer) and as the
+/// parent handle every broadcast carries ([`broadcast::Info::origin`]): the origin owns
+/// the [`cache::Pool`] every group in the tree registers with, so a relay configures one
+/// bounded pool here and every broadcast, track, and group beneath it reaches that single
+/// budget by walking up the ownership chain. Defaults to an unbounded pool
+/// ([`Origin::produce`] is the shorthand for that). Cheap to clone (a `Copy` id plus an
+/// `Arc`-handle bump), so it's stored by value rather than behind another `Arc`.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Info {
@@ -122,9 +124,22 @@ pub struct Info {
 	/// detection and shortest-path routing.
 	pub id: Origin,
 
-	/// The cache pool broadcasts created under this origin register their groups
-	/// with. Unbounded by default.
-	pub pool: cache::Pool,
+	// The cache pool broadcasts under this origin register their groups with. Not
+	// public: a relay sets it via [`Self::with_pool`] and it flows down the ownership
+	// chain (origin -> broadcast -> track -> group), but consumers reading an
+	// `origin::Info` off a broadcast see only the identity. Unbounded by default.
+	pub(crate) pool: cache::Pool,
+}
+
+impl Default for Info {
+	/// An unknown origin (id `0`, no loop detection) with an unbounded pool. This is
+	/// what a standalone broadcast (no relay origin) inherits.
+	fn default() -> Self {
+		Self {
+			id: Origin::UNKNOWN,
+			pool: cache::Pool::default(),
+		}
+	}
 }
 
 impl Info {
@@ -871,9 +886,13 @@ impl Producer {
 		}
 	}
 
-	/// The cache pool broadcasts created under this origin inherit.
-	pub fn pool(&self) -> cache::Pool {
-		self.pool.clone()
+	/// This origin's [`Info`] (identity + cache pool), the parent handle a broadcast
+	/// created under this origin carries (see [`broadcast::Info::origin`]).
+	pub fn info(&self) -> Info {
+		Info {
+			id: self.info,
+			pool: self.pool.clone(),
+		}
 	}
 
 	/// A producer with *no* allowed prefixes: it can't publish anything and
@@ -898,7 +917,7 @@ impl Producer {
 	/// error cases.
 	pub fn create_broadcast(&self, path: impl AsPath) -> Result<Broadcast, Error> {
 		let producer = broadcast::Info {
-			pool: self.pool.clone(),
+			origin: self.info(),
 			..Default::default()
 		}
 		.produce();

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -97,11 +97,12 @@ pub struct Info {
 	/// detection and shortest-path routing.
 	pub id: Origin,
 
-	// The cache pool broadcasts under this origin register their groups with. Not
-	// public: a relay sets it via [`Self::with_pool`] and it flows down the ownership
-	// chain (origin -> broadcast -> track -> group), but consumers reading an
-	// `origin::Info` off a broadcast see only the identity. Unbounded by default.
-	pub(crate) pool: cache::Pool,
+	/// The cache pool broadcasts under this origin register their groups with. It
+	/// flows down the ownership chain (origin -> broadcast -> track -> group), so a
+	/// group reaches it via `track.broadcast.origin.pool`. Unbounded by default; a
+	/// relay sets a bounded one (via [`Self::with_pool`]) so cached groups across the
+	/// whole process share one memory budget.
+	pub pool: cache::Pool,
 }
 
 impl Default for Info {

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1,4 +1,4 @@
-use crate::{broadcast, track};
+use crate::{broadcast, cache, track};
 use std::{
 	collections::{BTreeMap, HashMap, VecDeque},
 	fmt,
@@ -802,6 +802,10 @@ pub struct Producer {
 	// `nodes` because dynamic broadcasts are never announced: they only resolve a
 	// consumer's `request_broadcast` when no live announcement exists.
 	dynamic: kio::Producer<OriginDynamicState>,
+
+	// The cache pool inherited by broadcasts created under this origin (sessions
+	// mint their remote broadcasts with it). Unbounded by default.
+	pool: cache::Pool,
 }
 
 impl std::ops::Deref for Producer {
@@ -821,7 +825,23 @@ impl Producer {
 			nodes: OriginNodes::default(),
 			root: PathOwned::default(),
 			dynamic: kio::Producer::default(),
+			pool: cache::Pool::default(),
 		}
+	}
+
+	/// Set the [`cache::Pool`] that broadcasts created under this origin register
+	/// their groups with, returning `self` for chaining.
+	///
+	/// A relay installs one bounded pool on its origin so every cached group in the
+	/// process shares a single memory budget. Defaults to an unbounded pool.
+	pub fn with_pool(mut self, pool: cache::Pool) -> Self {
+		self.pool = pool;
+		self
+	}
+
+	/// The cache pool broadcasts created under this origin inherit.
+	pub fn pool(&self) -> cache::Pool {
+		self.pool.clone()
 	}
 
 	/// A producer with *no* allowed prefixes: it can't publish anything and
@@ -834,6 +854,7 @@ impl Producer {
 			nodes: OriginNodes { nodes: Vec::new() },
 			root: PathOwned::default(),
 			dynamic: kio::Producer::default(),
+			pool: cache::Pool::default(),
 		}
 	}
 
@@ -844,7 +865,7 @@ impl Producer {
 	/// unannounces the broadcast. See [`publish_broadcast`](Self::publish_broadcast) for the
 	/// error cases.
 	pub fn create_broadcast(&self, path: impl AsPath) -> Result<Broadcast, Error> {
-		let producer = broadcast::Info::new().produce();
+		let producer = broadcast::Info::new().with_pool(self.pool.clone()).produce();
 		let publish = self.publish_broadcast(path, &producer)?;
 		Ok(Broadcast { producer, publish })
 	}
@@ -909,6 +930,7 @@ impl Producer {
 			nodes: self.nodes.select(&prefixes)?,
 			root: self.root.clone(),
 			dynamic: self.dynamic.clone(),
+			pool: self.pool.clone(),
 		})
 	}
 
@@ -953,6 +975,7 @@ impl Producer {
 			root: self.root.join(&prefix).to_owned(),
 			nodes: self.nodes.root(&prefix)?,
 			dynamic: self.dynamic.clone(),
+			pool: self.pool.clone(),
 		})
 	}
 
@@ -1937,6 +1960,7 @@ mod tests {
 		// `a` carries one hop; `b` has none, so `b` wins the route and replaces it.
 		let a = broadcast::Info {
 			hops: OriginList::try_from(vec![Origin::new(1u64).unwrap()]).unwrap(),
+			..Default::default()
 		}
 		.produce();
 		let b = broadcast::Info::new().produce();
@@ -1958,6 +1982,7 @@ mod tests {
 		// `a` carries one hop; `b` has none, so `b` wins the route and replaces it.
 		let a = broadcast::Info {
 			hops: OriginList::try_from(vec![Origin::new(1u64).unwrap()]).unwrap(),
+			..Default::default()
 		}
 		.produce();
 		let b = broadcast::Info::new().produce();
@@ -2008,7 +2033,11 @@ mod tests {
 					.collect::<Vec<_>>(),
 			)
 			.unwrap();
-			broadcast::Info { hops }.produce()
+			broadcast::Info {
+				hops,
+				..Default::default()
+			}
+			.produce()
 		}
 
 		// Resolve the active route for "test" after publishing both routes in the given order.

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -101,7 +101,48 @@ impl Origin {
 		self.id
 	}
 
-	/// Consume this [Origin] to create a producer that carries its id.
+	/// Consume this [Origin] to create a producer that carries its id, with an
+	/// unbounded cache pool. Use [`Info::produce`] to configure the pool.
+	pub fn produce(self) -> Producer {
+		Info::new(self).produce()
+	}
+}
+
+/// Construction config for an [origin `Producer`](Producer): its wire identity plus
+/// the cache pool its broadcasts inherit.
+///
+/// The origin owns the [`cache::Pool`] every group in the tree registers with, so a
+/// relay configures one bounded pool here and every broadcast, track, and group
+/// beneath it shares that single memory budget. Defaults to an unbounded pool
+/// ([`Origin::produce`] is the shorthand for that).
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct Info {
+	/// The origin's wire identity, appended to broadcast hop chains for loop
+	/// detection and shortest-path routing.
+	pub id: Origin,
+
+	/// The cache pool broadcasts created under this origin register their groups
+	/// with. Unbounded by default.
+	pub pool: cache::Pool,
+}
+
+impl Info {
+	/// Config for the given origin id with an unbounded cache pool.
+	pub fn new(id: Origin) -> Self {
+		Self {
+			id,
+			pool: cache::Pool::default(),
+		}
+	}
+
+	/// Set the cache pool this origin's broadcasts inherit, returning `self` for chaining.
+	pub fn with_pool(mut self, pool: cache::Pool) -> Self {
+		self.pool = pool;
+		self
+	}
+
+	/// Consume this config to create an origin [`Producer`].
 	pub fn produce(self) -> Producer {
 		Producer::new(self)
 	}
@@ -817,26 +858,17 @@ impl std::ops::Deref for Producer {
 }
 
 impl Producer {
-	/// Build a producer for the given origin id with no scoped prefix and no
-	/// pre-existing broadcasts. Prefer [`Origin::produce`].
-	pub fn new(info: Origin) -> Self {
+	/// Build a producer from an [`Info`] (identity + cache pool) with no scoped
+	/// prefix and no pre-existing broadcasts. Prefer [`Info::produce`] /
+	/// [`Origin::produce`].
+	pub fn new(info: Info) -> Self {
 		Self {
-			info,
+			info: info.id,
 			nodes: OriginNodes::default(),
 			root: PathOwned::default(),
 			dynamic: kio::Producer::default(),
-			pool: cache::Pool::default(),
+			pool: info.pool,
 		}
-	}
-
-	/// Set the [`cache::Pool`] that broadcasts created under this origin register
-	/// their groups with, returning `self` for chaining.
-	///
-	/// A relay installs one bounded pool on its origin so every cached group in the
-	/// process shares a single memory budget. Defaults to an unbounded pool.
-	pub fn with_pool(mut self, pool: cache::Pool) -> Self {
-		self.pool = pool;
-		self
 	}
 
 	/// The cache pool broadcasts created under this origin inherit.
@@ -865,7 +897,7 @@ impl Producer {
 	/// unannounces the broadcast. See [`publish_broadcast`](Self::publish_broadcast) for the
 	/// error cases.
 	pub fn create_broadcast(&self, path: impl AsPath) -> Result<Broadcast, Error> {
-		let producer = broadcast::Info::new().with_pool(self.pool.clone()).produce();
+		let producer = broadcast::Info::new().produce().with_pool(self.pool.clone());
 		let publish = self.publish_broadcast(path, &producer)?;
 		Ok(Broadcast { producer, publish })
 	}
@@ -1960,7 +1992,6 @@ mod tests {
 		// `a` carries one hop; `b` has none, so `b` wins the route and replaces it.
 		let a = broadcast::Info {
 			hops: OriginList::try_from(vec![Origin::new(1u64).unwrap()]).unwrap(),
-			..Default::default()
 		}
 		.produce();
 		let b = broadcast::Info::new().produce();
@@ -1982,7 +2013,6 @@ mod tests {
 		// `a` carries one hop; `b` has none, so `b` wins the route and replaces it.
 		let a = broadcast::Info {
 			hops: OriginList::try_from(vec![Origin::new(1u64).unwrap()]).unwrap(),
-			..Default::default()
 		}
 		.produce();
 		let b = broadcast::Info::new().produce();
@@ -2033,11 +2063,7 @@ mod tests {
 					.collect::<Vec<_>>(),
 			)
 			.unwrap();
-			broadcast::Info {
-				hops,
-				..Default::default()
-			}
-			.produce()
+			broadcast::Info { hops }.produce()
 		}
 
 		// Resolve the active route for "test" after publishing both routes in the given order.

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -42,7 +42,8 @@ const MAX_DATAGRAM_AGE: Duration = Duration::from_millis(50);
 /// [`broadcast::Consumer::track`](broadcast::Consumer::track),
 /// which returns the publisher's [`Info`] once the subscription is accepted.
 ///
-/// Not `Copy`: it carries a handle to its parent broadcast (see [`Self::broadcast`]).
+/// Not `Copy`: it carries a crate-internal handle to its parent broadcast (the link
+/// a group walks to reach the shared cache pool).
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Info {

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -555,6 +555,9 @@ impl TrackState {
 		}
 		let group = group::Producer::new(group::Info { sequence }, track, &self.pool);
 		*slot = Some((group.clone(), now));
+		// The replaced group can hold max_sequence when the publisher aborted the
+		// latest group itself; re-pin so the live edge stays eviction-immune.
+		self.pin_latest(&group);
 		Some(Ok(group))
 	}
 
@@ -3144,6 +3147,47 @@ mod test {
 		group0.write_frame_now(bytes::Bytes::from(vec![0u8; 4000])).unwrap();
 		assert!(pool.used() <= 3000, "growth on an old group triggers eviction");
 		assert!(matches!(group0.abort(Error::Cancel), Err(Error::Evicted)));
+	}
+
+	#[tokio::test]
+	async fn refetched_latest_group_is_repinned() {
+		tokio::time::pause();
+
+		let (mut producer, pool) = pooled_producer(3000);
+		let dynamic = producer.dynamic();
+
+		// Seq 0 stays open: the straggler used to apply memory pressure later.
+		let mut straggler = producer.append_group().unwrap();
+		straggler.write_frame_now(bytes::Bytes::from(vec![0u8; 1000])).unwrap();
+		tokio::time::advance(Duration::from_millis(10)).await;
+
+		// The publisher aborts its own latest group; the slot stays at max_sequence.
+		let mut latest = producer.append_group().unwrap(); // seq 1
+		latest.abort(Error::Cancel).unwrap();
+		tokio::time::advance(Duration::from_millis(10)).await;
+
+		// Re-fetch it: the replacement takes over max_sequence and must be
+		// re-pinned, or memory pressure could evict the live edge.
+		let consumer = producer.consume();
+		let pending = consumer.fetch_group(1, None);
+		let req = dynamic
+			.requested_group()
+			.now_or_never()
+			.expect("should not block")
+			.unwrap();
+		let mut group = req.accept(None).unwrap();
+		group.write_frame_now(bytes::Bytes::from(vec![0u8; 1000])).unwrap();
+		group.finish().unwrap();
+		pending.await.unwrap();
+		tokio::time::advance(Duration::from_millis(10)).await;
+
+		// Blow the budget with the straggler; the refetched latest is pinned, so
+		// the straggler itself is the only eligible victim.
+		straggler.write_frame_now(bytes::Bytes::from(vec![0u8; 4000])).unwrap();
+
+		assert!(pool.used() <= 3000);
+		let mut group = consumer.get_group(1).expect("refetched latest must stay pinned");
+		assert_eq!(group.read_frame().await.unwrap().unwrap().len(), 1000);
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -14,7 +14,7 @@
 //! The track is closed with [Error] when all writers or readers are dropped.
 
 use crate::{Error, Result, Subscription, Timescale, Timestamp, coding};
-use crate::{broadcast, group};
+use crate::{broadcast, cache, group};
 
 use super::{Datagram, MAX_DATAGRAM_PAYLOAD};
 
@@ -156,6 +156,16 @@ struct TrackState {
 	// A small `Copy` value, inherited by each group it creates.
 	info: Option<Info>,
 
+	// The shared cache pool every group registers with, inherited from the parent
+	// broadcast. Unbounded by default; a relay installs a bounded pool so old
+	// groups are evicted under memory pressure.
+	pool: cache::Pool,
+
+	// The pool registration of the current max_sequence group, pinned so the
+	// latest group is immune to pool eviction. `None` when the pool is detached
+	// or no group exists yet.
+	latest_entry: Option<Arc<cache::Entry>>,
+
 	// Groups in arrival order. `None` entries are tombstones for evicted groups.
 	groups: VecDeque<Option<(group::Producer, web_async::time::Instant)>>,
 
@@ -220,6 +230,7 @@ impl TrackState {
 		for (i, slot) in self.groups.iter().enumerate().skip(start) {
 			if let Some((group, _)) = slot
 				&& group.sequence >= min_sequence
+				&& !group.is_aborted()
 			{
 				return Poll::Ready(Ok(Some((group.consume(), self.offset + i))));
 			}
@@ -292,7 +303,9 @@ impl TrackState {
 					return Poll::Ready(Ok(Some((frame, self.offset + i, group.sequence))));
 				}
 				Poll::Ready(Ok(None)) => continue,
-				Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+				// A single group failing (aborted upstream, or evicted from the
+				// cache) doesn't poison the track; skip it like a gap.
+				Poll::Ready(Err(_)) => continue,
 				Poll::Pending => {
 					pending_seen = true;
 					continue;
@@ -349,6 +362,9 @@ impl TrackState {
 			{
 				continue;
 			}
+			if group.is_aborted() {
+				continue;
+			}
 			if best.is_none_or(|b| group.sequence < b.sequence) {
 				best = Some(group);
 			}
@@ -372,12 +388,14 @@ impl TrackState {
 		Poll::Pending
 	}
 
-	/// Find a cached group by sequence, skipping tombstones. Synchronous, never blocks.
+	/// Find a cached group by sequence, skipping tombstones and groups evicted from
+	/// the cache pool (a fetch treats those as a miss and re-fetches). Synchronous,
+	/// never blocks.
 	fn cached_group(&self, sequence: u64) -> Option<group::Consumer> {
 		self.groups
 			.iter()
 			.flatten()
-			.find(|(group, _)| group.sequence == sequence)
+			.find(|(group, _)| group.sequence == sequence && !group.is_aborted())
 			.map(|(group, _)| group.consume())
 	}
 
@@ -448,9 +466,21 @@ impl TrackState {
 	/// non-max_sequence group (everything after it arrived even later).
 	/// When max_sequence is at the front, we skip past it and tombstone expired groups
 	/// behind it.
+	///
+	/// Also reaps slots whose group the cache pool already evicted (walked before
+	/// the early exit); ones behind fresh groups stay as soft tombstones that every
+	/// read path skips, and are replaced in place if the sequence is re-fetched.
 	fn evict_expired(&mut self, now: web_async::time::Instant, max_age: Duration) {
 		for slot in self.groups.iter_mut() {
 			let Some((group, created_at)) = slot else { continue };
+
+			// Evicted by the pool: the frames are already gone, reclaim the slot
+			// and the sequence so a later fetch can re-insert it.
+			if group.is_aborted() {
+				self.duplicates.remove(&group.sequence);
+				*slot = None;
+				continue;
+			}
 
 			if Some(group.sequence) == self.max_sequence {
 				continue;
@@ -477,6 +507,21 @@ impl TrackState {
 		}
 	}
 
+	/// Pin `group` as the latest (immune to pool eviction) if it holds the track's
+	/// max_sequence, releasing the previous pin. Call after updating `max_sequence`.
+	fn pin_latest(&mut self, group: &group::Producer) {
+		if Some(group.sequence) != self.max_sequence {
+			return;
+		}
+		if let Some(prev) = self.latest_entry.take() {
+			prev.set_pinned(false);
+		}
+		if let Some(entry) = group.cache_entry() {
+			entry.set_pinned(true);
+			self.latest_entry = Some(entry);
+		}
+	}
+
 	fn poll_finished(&self) -> Poll<Result<u64>> {
 		if let Some(fin) = self.final_sequence {
 			Poll::Ready(Ok(fin))
@@ -489,6 +534,28 @@ impl TrackState {
 
 	fn modify(producer: &kio::Producer<Self>) -> Result<kio::Mut<'_, Self>> {
 		producer.write().map_err(|r| r.abort.clone().unwrap_or(Error::Dropped))
+	}
+
+	/// Replace the slot of a duplicate `sequence` whose group was evicted from the
+	/// cache pool, returning the fresh producer. `Err(Duplicate)` when the cached
+	/// group is still live; `None` when no slot holds the sequence.
+	fn replace_evicted(
+		&mut self,
+		sequence: u64,
+		track: Info,
+		now: web_async::time::Instant,
+	) -> Option<Result<group::Producer>> {
+		let slot = self
+			.groups
+			.iter_mut()
+			.find(|slot| matches!(slot, Some((group, _)) if group.sequence == sequence))?;
+		let (existing, _) = slot.as_ref().unwrap();
+		if !existing.is_aborted() {
+			return Some(Err(Error::Duplicate));
+		}
+		let group = group::Producer::new(group::Info { sequence }, track, &self.pool);
+		*slot = Some((group.clone(), now));
+		Some(Ok(group))
 	}
 
 	/// Insert a group fetched for a [`GroupRequest`], setting the track's [`Info`]
@@ -505,19 +572,23 @@ impl TrackState {
 		{
 			return Err(Error::Closed);
 		}
-		if !self.duplicates.insert(sequence) {
-			return Err(Error::Duplicate);
-		}
 
 		// Adopt the supplied info only if the track hasn't been accepted yet.
 		let info = *self.info.get_or_insert_with(|| info.unwrap_or_default());
-
-		let group = group::Producer::new(group::Info { sequence }, info);
-		let cache = info.cache;
 		let now = web_async::time::Instant::now();
+
+		if !self.duplicates.insert(sequence) {
+			// A pool-evicted group can be re-fetched into its old slot.
+			return self
+				.replace_evicted(sequence, info, now)
+				.unwrap_or(Err(Error::Duplicate));
+		}
+
+		let group = group::Producer::new(group::Info { sequence }, info, &self.pool);
 		self.max_sequence = Some(self.max_sequence.unwrap_or(0).max(sequence));
 		self.groups.push_back(Some((group.clone(), now)));
-		self.evict_expired(now, cache);
+		self.pin_latest(&group);
+		self.evict_expired(now, info.cache);
 		Ok(group)
 	}
 
@@ -554,11 +625,13 @@ impl Producer {
 		info: impl Into<Option<Info>>,
 	) -> Self {
 		let info = info.into().unwrap_or_default();
+		let pool = broadcast.pool.clone();
 		Self {
 			name: name.into(),
 			broadcast,
 			state: kio::Producer::new(TrackState {
 				info: Some(info),
+				pool,
 				..Default::default()
 			}),
 			prev_subscription: None,
@@ -585,15 +658,19 @@ impl Producer {
 		let info = state.info.as_ref().unwrap();
 		let track = *info;
 		let cache = info.cache;
+		let now = web_async::time::Instant::now();
 
-		let group = group::Producer::new(group, track);
 		if !state.duplicates.insert(group.sequence) {
-			return Err(Error::Duplicate);
+			// A pool-evicted group can be re-created into its old slot.
+			return state
+				.replace_evicted(group.sequence, track, now)
+				.unwrap_or(Err(Error::Duplicate));
 		}
 
-		let now = web_async::time::Instant::now();
+		let group = group::Producer::new(group, track, &state.pool);
 		state.max_sequence = Some(state.max_sequence.unwrap_or(0).max(group.sequence));
 		state.groups.push_back(Some((group.clone(), now)));
+		state.pin_latest(&group);
 		state.evict_expired(now, cache);
 
 		Ok(group)
@@ -616,12 +693,13 @@ impl Producer {
 		let track = *info;
 		let cache = info.cache;
 
-		let group = group::Producer::new(group::Info { sequence }, track);
+		let group = group::Producer::new(group::Info { sequence }, track, &state.pool);
 
 		let now = web_async::time::Instant::now();
 		state.duplicates.insert(sequence);
 		state.max_sequence = Some(sequence);
 		state.groups.push_back(Some((group.clone(), now)));
+		state.pin_latest(&group);
 		state.evict_expired(now, cache);
 
 		Ok(group)
@@ -753,6 +831,7 @@ impl Producer {
 		guard.groups.clear();
 		guard.datagrams.clear();
 		guard.duplicates.clear();
+		guard.latest_entry = None;
 		guard.close();
 		Ok(())
 	}
@@ -1031,6 +1110,7 @@ impl Drop for Producer {
 			state.groups.clear();
 			state.datagrams.clear();
 			state.duplicates.clear();
+			state.latest_entry = None;
 		}
 	}
 }
@@ -1650,7 +1730,10 @@ pub struct Request {
 impl Request {
 	pub(crate) fn new(broadcast: Arc<broadcast::Info>, name: impl Into<Arc<str>>) -> Self {
 		let name = name.into();
-		let state = kio::Producer::<TrackState>::default();
+		let state = kio::Producer::new(TrackState {
+			pool: broadcast.pool.clone(),
+			..Default::default()
+		});
 		let dynamic = Dynamic::new(name.clone(), state.clone());
 		Self {
 			name,
@@ -2938,6 +3021,164 @@ mod test {
 
 		// And it doesn't signal the dynamic handler.
 		assert!(dynamic.poll_requested_group(&kio::Waiter::noop()).is_pending());
+	}
+
+	/// Mint a track whose groups register with a bounded [`cache::Pool`].
+	fn pooled_producer(capacity: u64) -> (Producer, cache::Pool) {
+		let pool = cache::Pool::new(capacity);
+		let broadcast = broadcast::Info::default().with_pool(pool.clone());
+		(Producer::new(Arc::new(broadcast), "test", None), pool)
+	}
+
+	fn finished_group(producer: &mut Producer, size: usize) -> u64 {
+		let mut group = producer.append_group().unwrap();
+		group.write_frame_now(bytes::Bytes::from(vec![0u8; size])).unwrap();
+		group.finish().unwrap();
+		group.sequence
+	}
+
+	#[tokio::test]
+	async fn pool_evicts_oldest_group() {
+		tokio::time::pause();
+
+		// Fits two 1000-byte groups (plus per-group overhead) but not three.
+		let (mut producer, pool) = pooled_producer(3000);
+
+		finished_group(&mut producer, 1000); // seq 0
+		tokio::time::advance(Duration::from_millis(10)).await;
+		finished_group(&mut producer, 1000); // seq 1
+		tokio::time::advance(Duration::from_millis(10)).await;
+		finished_group(&mut producer, 1000); // seq 2, pinned as latest
+
+		// The write to seq 2 pushed the pool over budget: seq 0 (stalest, unpinned)
+		// was evicted and its bytes released.
+		assert!(pool.used() <= 3000, "pool should be back under budget");
+
+		let consumer = producer.consume();
+		assert!(consumer.get_group(0).is_none(), "evicted group is a cache miss");
+		assert!(consumer.get_group(1).is_some());
+		assert!(consumer.get_group(2).is_some());
+
+		// A fresh subscriber skips the evicted group entirely.
+		let mut subscriber = producer.subscribe(None);
+		assert_eq!(subscriber.assert_group().sequence, 1);
+		assert_eq!(subscriber.assert_group().sequence, 2);
+	}
+
+	#[tokio::test]
+	async fn pool_never_evicts_latest() {
+		tokio::time::pause();
+
+		// Far too small for even one group: the latest is pinned and survives anyway.
+		let (mut producer, pool) = pooled_producer(100);
+		finished_group(&mut producer, 1000);
+
+		assert!(pool.used() > 100, "pinned latest may exceed the budget");
+		let mut subscriber = producer.subscribe(None);
+		let mut group = subscriber.assert_group();
+		assert_eq!(group.read_frame().await.unwrap().unwrap().len(), 1000);
+	}
+
+	#[tokio::test]
+	async fn pool_reads_bump_recency() {
+		tokio::time::pause();
+
+		let (mut producer, _pool) = pooled_producer(3000);
+		let mut subscriber = producer.subscribe(None);
+
+		finished_group(&mut producer, 1000); // seq 0
+		tokio::time::advance(Duration::from_millis(10)).await;
+		finished_group(&mut producer, 1000); // seq 1
+		tokio::time::advance(Duration::from_millis(10)).await;
+
+		// Read seq 0 so seq 1 becomes the least recently used.
+		let mut group = subscriber.assert_group();
+		assert_eq!(group.sequence, 0);
+		group.read_frame().await.unwrap().unwrap();
+		tokio::time::advance(Duration::from_millis(10)).await;
+
+		// Over budget: seq 1 (stale) is the victim, the just-read seq 0 survives.
+		finished_group(&mut producer, 1000); // seq 2, pinned
+
+		let consumer = producer.consume();
+		assert!(consumer.get_group(0).is_some(), "recently read group survives");
+		assert!(consumer.get_group(1).is_none(), "stale group is evicted");
+	}
+
+	#[tokio::test]
+	async fn pool_eviction_aborts_readers() {
+		tokio::time::pause();
+
+		let (mut producer, _pool) = pooled_producer(3000);
+		let mut subscriber = producer.subscribe(None);
+
+		finished_group(&mut producer, 1000); // seq 0
+		let group0 = subscriber.assert_group();
+
+		tokio::time::advance(Duration::from_millis(10)).await;
+		finished_group(&mut producer, 1000); // seq 1
+		tokio::time::advance(Duration::from_millis(10)).await;
+		finished_group(&mut producer, 1000); // seq 2 evicts seq 0
+
+		// A consumer holding the evicted group surfaces the eviction, not a hang
+		// or a truncated clean end.
+		let mut group0 = group0;
+		assert!(matches!(group0.read_frame().await, Err(Error::Evicted)));
+	}
+
+	#[tokio::test]
+	async fn pool_growth_on_old_group_charges() {
+		tokio::time::pause();
+
+		let (mut producer, pool) = pooled_producer(3000);
+
+		// Seq 0 stays open (a straggler still being written).
+		let mut group0 = producer.append_group().unwrap();
+		tokio::time::advance(Duration::from_millis(10)).await;
+		// Seq 1 becomes the pinned latest; seq 0 is now evictable.
+		let _group1 = producer.append_group().unwrap();
+		tokio::time::advance(Duration::from_millis(10)).await;
+
+		// A late frame on the old group still counts against the budget, and can
+		// evict that very group once it blows past capacity.
+		group0.write_frame_now(bytes::Bytes::from(vec![0u8; 4000])).unwrap();
+		assert!(pool.used() <= 3000, "growth on an old group triggers eviction");
+		assert!(matches!(group0.abort(Error::Cancel), Err(Error::Evicted)));
+	}
+
+	#[tokio::test]
+	async fn pool_eviction_allows_refetch() {
+		tokio::time::pause();
+
+		let (mut producer, _pool) = pooled_producer(3000);
+		let dynamic = producer.dynamic();
+
+		finished_group(&mut producer, 1000); // seq 0
+		tokio::time::advance(Duration::from_millis(10)).await;
+		finished_group(&mut producer, 1000); // seq 1
+		tokio::time::advance(Duration::from_millis(10)).await;
+		finished_group(&mut producer, 1000); // seq 2 evicts seq 0
+
+		// The evicted group is a miss, so the fetch queues for the dynamic handler
+		// (a relay would issue a wire FETCH upstream).
+		let consumer = producer.consume();
+		assert!(consumer.get_group(0).is_none());
+		let pending = consumer.fetch_group(0, None);
+
+		let req = dynamic
+			.requested_group()
+			.now_or_never()
+			.expect("should not block")
+			.unwrap();
+		assert_eq!(req.sequence(), 0);
+
+		// Accept replaces the evicted slot in place (not Error::Duplicate).
+		let mut group = req.accept(None).unwrap();
+		group.write_frame_now(bytes::Bytes::from_static(b"refetched")).unwrap();
+		group.finish().unwrap();
+
+		let mut group = pending.await.unwrap();
+		assert_eq!(&group.read_frame().await.unwrap().unwrap()[..], b"refetched");
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -629,7 +629,7 @@ impl Producer {
 		info: impl Into<Option<Info>>,
 	) -> Self {
 		let info = info.into().unwrap_or_default();
-		let pool = broadcast.pool.clone();
+		let pool = broadcast.origin.pool.clone();
 		Self {
 			name: name.into(),
 			broadcast,
@@ -1742,7 +1742,7 @@ impl Request {
 	pub(crate) fn new(broadcast: Arc<broadcast::Info>, name: impl Into<Arc<str>>) -> Self {
 		let name = name.into();
 		let state = kio::Producer::new(TrackState {
-			pool: broadcast.pool.clone(),
+			pool: broadcast.origin.pool.clone(),
 			..Default::default()
 		});
 		let dynamic = Dynamic::new(name.clone(), state.clone());
@@ -3038,7 +3038,7 @@ mod test {
 	fn pooled_producer(capacity: u64) -> (Producer, cache::Pool) {
 		let pool = cache::Pool::new(capacity);
 		let broadcast = broadcast::Info {
-			pool: pool.clone(),
+			origin: crate::origin::Info::default().with_pool(pool.clone()),
 			..Default::default()
 		};
 		let producer = Producer::new(Arc::new(broadcast), "test", None);

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -3086,7 +3086,7 @@ mod test {
 	async fn pool_reads_bump_recency() {
 		tokio::time::pause();
 
-		let (mut producer, _pool) = pooled_producer(3000);
+		let (mut producer, pool) = pooled_producer(3000);
 		let mut subscriber = producer.subscribe(None);
 
 		finished_group(&mut producer, 1000); // seq 0
@@ -3104,15 +3104,23 @@ mod test {
 		finished_group(&mut producer, 1000); // seq 2, pinned
 
 		let consumer = producer.consume();
-		assert!(consumer.get_group(0).is_some(), "recently read group survives");
-		assert!(consumer.get_group(1).is_none(), "stale group is evicted");
+		assert!(
+			consumer.get_group(0).is_some(),
+			"recently read group survives: {:?}",
+			pool.debug_entries()
+		);
+		assert!(
+			consumer.get_group(1).is_none(),
+			"stale group is evicted: {:?}",
+			pool.debug_entries()
+		);
 	}
 
 	#[tokio::test]
 	async fn pool_eviction_aborts_readers() {
 		tokio::time::pause();
 
-		let (mut producer, _pool) = pooled_producer(3000);
+		let (mut producer, pool) = pooled_producer(3000);
 		let mut subscriber = producer.subscribe(None);
 
 		finished_group(&mut producer, 1000); // seq 0
@@ -3126,7 +3134,12 @@ mod test {
 		// A consumer holding the evicted group surfaces the eviction, not a hang
 		// or a truncated clean end.
 		let mut group0 = group0;
-		assert!(matches!(group0.read_frame().await, Err(Error::Evicted)));
+		let read = group0.read_frame().await;
+		assert!(
+			matches!(read, Err(Error::Evicted)),
+			"expected Evicted, got {read:?}: {:?}",
+			pool.debug_entries()
+		);
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -42,8 +42,7 @@ const MAX_DATAGRAM_AGE: Duration = Duration::from_millis(50);
 /// [`broadcast::Consumer::track`](broadcast::Consumer::track),
 /// which returns the publisher's [`Info`] once the subscription is accepted.
 ///
-/// Not `Copy`: it carries a crate-internal handle to its parent broadcast (the link
-/// a group walks to reach the shared cache pool).
+/// Not `Copy`: it carries a handle to its parent broadcast (see [`Self::broadcast`]).
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Info {
@@ -67,12 +66,12 @@ pub struct Info {
 	/// only to break ties. Reported in TRACK_INFO (Lite05+).
 	pub ordered: bool,
 
-	// The broadcast this track belongs to, bound when the track is created under a
-	// broadcast (create_track / reserve_track / Request::accept). Not public and not
-	// on the wire: it's the parent link a group walks to reach the shared cache pool
-	// (`track.broadcast.origin.pool`). Defaults to a standalone broadcast (unbounded
-	// pool) until bound.
-	pub(crate) broadcast: Arc<broadcast::Info>,
+	/// The broadcast this track belongs to, bound when the track is created under one
+	/// (`create_track` / `reserve_track` / `Request::accept`); until then it's a
+	/// standalone broadcast with an unbounded pool. Not on the wire. It's the parent
+	/// link a group walks to reach the shared cache pool
+	/// (`track.broadcast.origin.pool`); the pool itself stays crate-private.
+	pub broadcast: Arc<broadcast::Info>,
 }
 
 /// The shared parent for a not-yet-bound [`Info`]: a standalone broadcast with an

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -620,22 +620,22 @@ impl Producer {
 	///
 	/// Crate-private: tracks are born from their broadcast via
 	/// [`broadcast::Producer::create_track`] (or served on demand through a
-	/// [`Request`]), which threads the broadcast's `Arc<broadcast::Info>` and shared
-	/// [`cache::Pool`] down so the broadcast owns the namespace and there's a single
-	/// way to mint a track.
+	/// [`Request`]), which threads the broadcast's `Arc<broadcast::Info>` down so the
+	/// broadcast owns the namespace, and the track inherits its cache pool, from a
+	/// single link.
 	pub(crate) fn new(
 		broadcast: Arc<broadcast::Info>,
 		name: impl Into<Arc<str>>,
 		info: impl Into<Option<Info>>,
-		pool: &cache::Pool,
 	) -> Self {
 		let info = info.into().unwrap_or_default();
+		let pool = broadcast.pool.clone();
 		Self {
 			name: name.into(),
 			broadcast,
 			state: kio::Producer::new(TrackState {
 				info: Some(info),
-				pool: pool.clone(),
+				pool,
 				..Default::default()
 			}),
 			prev_subscription: None,
@@ -1739,10 +1739,10 @@ pub struct Request {
 }
 
 impl Request {
-	pub(crate) fn new(broadcast: Arc<broadcast::Info>, name: impl Into<Arc<str>>, pool: &cache::Pool) -> Self {
+	pub(crate) fn new(broadcast: Arc<broadcast::Info>, name: impl Into<Arc<str>>) -> Self {
 		let name = name.into();
 		let state = kio::Producer::new(TrackState {
-			pool: pool.clone(),
+			pool: broadcast.pool.clone(),
 			..Default::default()
 		});
 		let dynamic = Dynamic::new(name.clone(), state.clone());
@@ -1899,12 +1899,7 @@ mod test {
 	/// Mint a track for tests with a default parent broadcast, since tracks are
 	/// normally born from a [`broadcast::Producer`].
 	fn track_producer(name: impl Into<Arc<str>>, info: impl Into<Option<Info>>) -> Producer {
-		Producer::new(
-			Arc::new(broadcast::Info::default()),
-			name,
-			info,
-			&cache::Pool::default(),
-		)
+		Producer::new(Arc::new(broadcast::Info::default()), name, info)
 	}
 
 	/// Helper: count non-tombstoned groups in state.
@@ -3042,7 +3037,11 @@ mod test {
 	/// Mint a track whose groups register with a bounded [`cache::Pool`].
 	fn pooled_producer(capacity: u64) -> (Producer, cache::Pool) {
 		let pool = cache::Pool::new(capacity);
-		let producer = Producer::new(Arc::new(broadcast::Info::default()), "test", None, &pool);
+		let broadcast = broadcast::Info {
+			pool: pool.clone(),
+			..Default::default()
+		};
+		let producer = Producer::new(Arc::new(broadcast), "test", None);
 		(producer, pool)
 	}
 

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -620,21 +620,22 @@ impl Producer {
 	///
 	/// Crate-private: tracks are born from their broadcast via
 	/// [`broadcast::Producer::create_track`] (or served on demand through a
-	/// [`Request`]), which threads the broadcast's `Arc<broadcast::Info>` down so
-	/// the broadcast owns the namespace and there's a single way to mint a track.
+	/// [`Request`]), which threads the broadcast's `Arc<broadcast::Info>` and shared
+	/// [`cache::Pool`] down so the broadcast owns the namespace and there's a single
+	/// way to mint a track.
 	pub(crate) fn new(
 		broadcast: Arc<broadcast::Info>,
 		name: impl Into<Arc<str>>,
 		info: impl Into<Option<Info>>,
+		pool: &cache::Pool,
 	) -> Self {
 		let info = info.into().unwrap_or_default();
-		let pool = broadcast.pool.clone();
 		Self {
 			name: name.into(),
 			broadcast,
 			state: kio::Producer::new(TrackState {
 				info: Some(info),
-				pool,
+				pool: pool.clone(),
 				..Default::default()
 			}),
 			prev_subscription: None,
@@ -1738,10 +1739,10 @@ pub struct Request {
 }
 
 impl Request {
-	pub(crate) fn new(broadcast: Arc<broadcast::Info>, name: impl Into<Arc<str>>) -> Self {
+	pub(crate) fn new(broadcast: Arc<broadcast::Info>, name: impl Into<Arc<str>>, pool: &cache::Pool) -> Self {
 		let name = name.into();
 		let state = kio::Producer::new(TrackState {
-			pool: broadcast.pool.clone(),
+			pool: pool.clone(),
 			..Default::default()
 		});
 		let dynamic = Dynamic::new(name.clone(), state.clone());
@@ -1898,7 +1899,12 @@ mod test {
 	/// Mint a track for tests with a default parent broadcast, since tracks are
 	/// normally born from a [`broadcast::Producer`].
 	fn track_producer(name: impl Into<Arc<str>>, info: impl Into<Option<Info>>) -> Producer {
-		Producer::new(Arc::new(broadcast::Info::default()), name, info)
+		Producer::new(
+			Arc::new(broadcast::Info::default()),
+			name,
+			info,
+			&cache::Pool::default(),
+		)
 	}
 
 	/// Helper: count non-tombstoned groups in state.
@@ -3036,8 +3042,8 @@ mod test {
 	/// Mint a track whose groups register with a bounded [`cache::Pool`].
 	fn pooled_producer(capacity: u64) -> (Producer, cache::Pool) {
 		let pool = cache::Pool::new(capacity);
-		let broadcast = broadcast::Info::default().with_pool(pool.clone());
-		(Producer::new(Arc::new(broadcast), "test", None), pool)
+		let producer = Producer::new(Arc::new(broadcast::Info::default()), "test", None, &pool);
+		(producer, pool)
 	}
 
 	fn finished_group(producer: &mut Producer, size: usize) -> u64 {

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -41,7 +41,9 @@ const MAX_DATAGRAM_AGE: Duration = Duration::from_millis(50);
 /// while the track is alive. A subscriber learns them via
 /// [`broadcast::Consumer::track`](broadcast::Consumer::track),
 /// which returns the publisher's [`Info`] once the subscription is accepted.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+///
+/// Not `Copy`: it carries a handle to its parent broadcast (see [`Self::broadcast`]).
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Info {
 	/// Units per second for per-frame timestamps on this track.
@@ -63,6 +65,22 @@ pub struct Info {
 	/// The publisher's group ordering preference (newest-first when `false`), used
 	/// only to break ties. Reported in TRACK_INFO (Lite05+).
 	pub ordered: bool,
+
+	// The broadcast this track belongs to, bound when the track is created under a
+	// broadcast (create_track / reserve_track / Request::accept). Not public and not
+	// on the wire: it's the parent link a group walks to reach the shared cache pool
+	// (`track.broadcast.origin.pool`). Defaults to a standalone broadcast (unbounded
+	// pool) until bound.
+	pub(crate) broadcast: Arc<broadcast::Info>,
+}
+
+/// The shared parent for a not-yet-bound [`Info`]: a standalone broadcast with an
+/// unbounded pool. Cheap to hand out (one `Arc` clone) and replaced the moment the
+/// track is bound to a real broadcast.
+fn default_broadcast() -> Arc<broadcast::Info> {
+	static DEFAULT: std::sync::LazyLock<Arc<broadcast::Info>> =
+		std::sync::LazyLock::new(|| Arc::new(broadcast::Info::default()));
+	DEFAULT.clone()
 }
 
 impl Default for Info {
@@ -72,6 +90,7 @@ impl Default for Info {
 			cache: DEFAULT_CACHE,
 			priority: 0,
 			ordered: true,
+			broadcast: default_broadcast(),
 		}
 	}
 }
@@ -114,14 +133,14 @@ impl Info {
 
 #[derive(Default)]
 struct TrackState {
-	// The info for the track; always Some for Subscriber/Producer.
-	// A small `Copy` value, inherited by each group it creates.
+	// The info for the track; always Some for Subscriber/Producer. Inherited (cloned)
+	// by each group it creates, which reaches the cache pool through its `broadcast`.
 	info: Option<Info>,
 
-	// The shared cache pool every group registers with, inherited from the parent
-	// broadcast. Unbounded by default; a relay installs a bounded pool so old
-	// groups are evicted under memory pressure.
-	pool: cache::Pool,
+	// The broadcast this track belongs to, the source for stamping `Info::broadcast`
+	// on groups (and on a not-yet-accepted track's default info). Its
+	// `origin.pool` is the shared cache pool every group registers with.
+	broadcast: Arc<broadcast::Info>,
 
 	// The pool registration of the current max_sequence group, pinned so the
 	// latest group is immune to pool eviction. `None` when the pool is detached
@@ -178,7 +197,7 @@ struct TrackState {
 impl TrackState {
 	fn poll_info(&self) -> Poll<Result<Info>> {
 		if let Some(info) = &self.info {
-			Poll::Ready(Ok(*info))
+			Poll::Ready(Ok(info.clone()))
 		} else {
 			Poll::Pending
 		}
@@ -515,7 +534,7 @@ impl TrackState {
 		if !existing.is_aborted() {
 			return Some(Err(Error::Duplicate));
 		}
-		let group = group::Producer::new(group::Info { sequence }, track, &self.pool);
+		let group = group::Producer::new(group::Info { sequence }, track);
 		*slot = Some((group.clone(), now));
 		// The replaced group can hold max_sequence when the publisher aborted the
 		// latest group itself; re-pin so the live edge stays eviction-immune.
@@ -538,9 +557,18 @@ impl TrackState {
 			return Err(Error::Closed);
 		}
 
-		// Adopt the supplied info only if the track hasn't been accepted yet.
-		let info = *self.info.get_or_insert_with(|| info.unwrap_or_default());
+		// Adopt the supplied info only if the track hasn't been accepted yet, binding
+		// it to this track's broadcast so its groups reach the shared pool.
 		let now = web_async::time::Instant::now();
+		let broadcast = self.broadcast.clone();
+		let info = self
+			.info
+			.get_or_insert_with(|| {
+				let mut info = info.unwrap_or_default();
+				info.broadcast = broadcast;
+				info
+			})
+			.clone();
 
 		if !self.duplicates.insert(sequence) {
 			// A pool-evicted group can be re-fetched into its old slot.
@@ -549,11 +577,12 @@ impl TrackState {
 				.unwrap_or(Err(Error::Duplicate));
 		}
 
-		let group = group::Producer::new(group::Info { sequence }, info, &self.pool);
+		let cache = info.cache;
+		let group = group::Producer::new(group::Info { sequence }, info);
 		self.max_sequence = Some(self.max_sequence.unwrap_or(0).max(sequence));
 		self.groups.push_back(Some((group.clone(), now)));
 		self.pin_latest(&group);
-		self.evict_expired(now, info.cache);
+		self.evict_expired(now, cache);
 		Ok(group)
 	}
 
@@ -582,24 +611,24 @@ impl Producer {
 	///
 	/// Crate-private: tracks are born from their broadcast via
 	/// [`broadcast::Producer::create_track`] (or served on demand through a
-	/// [`Request`]), which threads the broadcast's `Arc<broadcast::Info>` down so the
-	/// broadcast owns the namespace, and the track inherits its cache pool, from a
-	/// single link.
+	/// [`Request`]), which threads the broadcast's `Arc<broadcast::Info>` down. The
+	/// track binds it onto its [`Info`] so every group reaches the shared cache pool
+	/// by walking `track.broadcast.origin.pool`.
 	pub(crate) fn new(
 		broadcast: Arc<broadcast::Info>,
 		name: impl Into<Arc<str>>,
 		info: impl Into<Option<Info>>,
 	) -> Self {
-		let info = info.into().unwrap_or_default();
-		let pool = broadcast.origin.pool.clone();
+		let mut info = info.into().unwrap_or_default();
+		info.broadcast = broadcast.clone();
 		Self {
 			name: name.into(),
-			broadcast,
 			state: kio::Producer::new(TrackState {
 				info: Some(info),
-				pool,
+				broadcast: broadcast.clone(),
 				..Default::default()
 			}),
+			broadcast,
 			prev_subscription: None,
 		}
 	}
@@ -622,7 +651,7 @@ impl Producer {
 			return Err(Error::Closed);
 		}
 		let info = state.info.as_ref().unwrap();
-		let track = *info;
+		let track = info.clone();
 		let cache = info.cache;
 		let now = web_async::time::Instant::now();
 
@@ -633,7 +662,7 @@ impl Producer {
 				.unwrap_or(Err(Error::Duplicate));
 		}
 
-		let group = group::Producer::new(group, track, &state.pool);
+		let group = group::Producer::new(group, track);
 		state.max_sequence = Some(state.max_sequence.unwrap_or(0).max(group.sequence));
 		state.groups.push_back(Some((group.clone(), now)));
 		state.pin_latest(&group);
@@ -656,10 +685,10 @@ impl Producer {
 		}
 
 		let info = state.info.as_ref().unwrap();
-		let track = *info;
+		let track = info.clone();
 		let cache = info.cache;
 
-		let group = group::Producer::new(group::Info { sequence }, track, &state.pool);
+		let group = group::Producer::new(group::Info { sequence }, track);
 
 		let now = web_async::time::Instant::now();
 		state.duplicates.insert(sequence);
@@ -881,7 +910,7 @@ impl Producer {
 		let mut preferences = subscription.into().unwrap_or_default();
 
 		let mut state = self.modify().expect("track producer state is never closed");
-		let info = *state.info.as_ref().expect("producer always has info");
+		let info = state.info.as_ref().expect("producer always has info").clone();
 		preferences.stale = info.clamp_stale(preferences.stale);
 		let subscription = kio::Producer::new(preferences);
 		state.subscriptions.push(subscription.consume());
@@ -1704,7 +1733,7 @@ impl Request {
 	pub(crate) fn new(broadcast: Arc<broadcast::Info>, name: impl Into<Arc<str>>) -> Self {
 		let name = name.into();
 		let state = kio::Producer::new(TrackState {
-			pool: broadcast.origin.pool.clone(),
+			broadcast: broadcast.clone(),
 			..Default::default()
 		});
 		let dynamic = Dynamic::new(name.clone(), state.clone());
@@ -1747,7 +1776,9 @@ impl Request {
 	/// The track's name must match [`Self::name`]. Returns [`Error::NotFound`] on
 	/// mismatch, or the broadcast's abort error if it closed while pending.
 	pub fn accept(self, info: impl Into<Option<Info>>) -> Producer {
-		self.state.write().ok().unwrap().info = Some(info.into().unwrap_or_default());
+		let mut info = info.into().unwrap_or_default();
+		info.broadcast = self.broadcast.clone();
+		self.state.write().ok().unwrap().info = Some(info);
 		Producer {
 			name: self.name,
 			broadcast: self.broadcast,

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -37,6 +37,7 @@ anyhow = { version = "1", features = ["backtrace"] }
 axum = { version = "0.8", features = ["tokio"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }
 bytes = "1"
+bytesize = { version = "2.4.2", default-features = false }
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"
 http-body = "1"
@@ -52,6 +53,7 @@ rustls = { version = "0.23", features = ["aws-lc-rs"], default-features = false 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = { version = "3", features = ["json", "base64"] }
+sysinfo = { version = "0.36.1", default-features = false, features = ["system"] }
 thiserror = "2"
 tokio = { workspace = true, features = ["full"] }
 tokio-rustls = { version = "0.26", default-features = false }

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -53,7 +53,7 @@ rustls = { version = "0.23", features = ["aws-lc-rs"], default-features = false 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = { version = "3", features = ["json", "base64"] }
-sysinfo = { version = "0.36.1", default-features = false, features = ["system"] }
+sysinfo = { version = "0.39", default-features = false, features = ["system"] }
 thiserror = "2"
 tokio = { workspace = true, features = ["full"] }
 tokio-rustls = { version = "0.26", default-features = false }

--- a/rs/moq-relay/src/cache.rs
+++ b/rs/moq-relay/src/cache.rs
@@ -1,0 +1,154 @@
+//! Relay-side cache pool configuration.
+//!
+//! The pool itself lives in [`moq_net::cache`]; this module resolves the relay's
+//! size knobs (absolute bytes, a percentage of memory, or a dynamic headroom
+//! governor) into a [`cache::Pool`] shared by every session.
+
+use std::time::Duration;
+
+use clap::Args;
+use moq_net::cache;
+use serde::{Deserialize, Serialize};
+
+/// How often the headroom governor re-samples system memory.
+const GOVERNOR_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Configuration for the relay's group cache.
+///
+/// Non-latest groups stay cached until their track's TTL expires or the pool
+/// runs out of room, whichever comes first (the latest group of every track is
+/// always retained). With neither knob set the pool is unbounded and only the
+/// per-track TTL bounds memory.
+#[derive(Args, Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+#[non_exhaustive]
+#[group(id = "cache-config")]
+pub struct CacheConfig {
+	/// Maximum bytes of cached group payload, e.g. "8GiB", "512MB", or a
+	/// percentage of memory like "75%" (respecting the cgroup limit when set).
+	/// Unbounded when unset.
+	///
+	/// The budget counts payload bytes, not process RSS; leave some slack below
+	/// physical memory or combine with `headroom`.
+	#[arg(long = "cache-capacity", env = "MOQ_CACHE_CAPACITY")]
+	pub capacity: Option<String>,
+
+	/// Keep at least this much system memory available, e.g. "2GiB" or "10%".
+	///
+	/// Enables a background governor that re-sizes the cache every few seconds
+	/// so the cache soaks up idle memory but is the first thing reclaimed when
+	/// the rest of the system needs it. Combine with `capacity` to also cap the
+	/// absolute size.
+	#[arg(long = "cache-headroom", env = "MOQ_CACHE_HEADROOM")]
+	pub headroom: Option<String>,
+}
+
+impl CacheConfig {
+	/// Build the shared [`cache::Pool`], spawning the headroom governor when
+	/// configured. Requires a tokio runtime.
+	pub fn init(&self) -> anyhow::Result<cache::Pool> {
+		let capacity = self.capacity.as_deref().map(parse_limit).transpose()?;
+		let pool = match capacity {
+			Some(bytes) => cache::Pool::new(bytes),
+			None => cache::Pool::unbounded(),
+		};
+
+		if let Some(headroom) = self.headroom.as_deref() {
+			let headroom = parse_limit(headroom)?;
+			anyhow::ensure!(headroom > 0, "cache headroom must be non-zero");
+			tracing::info!(?capacity, headroom, "cache governor enabled");
+			tokio::spawn(governor(pool.clone(), capacity, headroom));
+		} else if let Some(capacity) = capacity {
+			tracing::info!(capacity, "cache capacity set");
+		}
+
+		Ok(pool)
+	}
+}
+
+/// Parse a size limit: either absolute bytes ("8GiB", "512MB", "1073741824") or
+/// a percentage of total memory ("75%"), honoring the cgroup limit when set.
+fn parse_limit(value: &str) -> anyhow::Result<u64> {
+	let value = value.trim();
+	if let Some(percent) = value.strip_suffix('%') {
+		let percent: f64 = percent.trim().parse()?;
+		anyhow::ensure!(
+			percent > 0.0 && percent <= 100.0,
+			"memory percentage must be within (0, 100], got {percent}"
+		);
+		return Ok((total_memory() as f64 * percent / 100.0) as u64);
+	}
+	let size: bytesize::ByteSize = value
+		.parse()
+		.map_err(|err| anyhow::anyhow!("invalid size {value:?}: {err}"))?;
+	Ok(size.as_u64())
+}
+
+/// Total memory this process can use: the cgroup limit when confined (e.g. a
+/// container), otherwise physical memory.
+fn total_memory() -> u64 {
+	let mut sys = sysinfo::System::new();
+	sys.refresh_memory();
+	match sys.cgroup_limits() {
+		Some(limits) => limits.total_memory,
+		None => sys.total_memory(),
+	}
+}
+
+/// Re-size the pool periodically so at least `headroom` bytes of system memory
+/// stay available: the cache grows into idle memory and shrinks (evicting LRU
+/// groups) when the rest of the system needs it.
+async fn governor(pool: cache::Pool, capacity: Option<u64>, headroom: u64) {
+	let mut sys = sysinfo::System::new();
+	let mut interval = tokio::time::interval(GOVERNOR_INTERVAL);
+	interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+	loop {
+		interval.tick().await;
+		sys.refresh_memory();
+
+		let available = match sys.cgroup_limits() {
+			Some(limits) => limits.free_memory,
+			None => sys.available_memory(),
+		};
+
+		// Whatever is free beyond the headroom is the cache's to grow into; a
+		// deficit shrinks the target below the current usage, evicting until the
+		// headroom is restored.
+		let mut target = pool.used().saturating_add(available).saturating_sub(headroom);
+		if let Some(capacity) = capacity {
+			target = target.min(capacity);
+		}
+
+		tracing::trace!(used = pool.used(), available, target, "cache governor tick");
+		pool.resize(target);
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parse_limit_bytes() {
+		assert_eq!(parse_limit("8GiB").unwrap(), 8 * 1024 * 1024 * 1024);
+		assert_eq!(parse_limit("512MB").unwrap(), 512 * 1000 * 1000);
+		assert_eq!(parse_limit("1073741824").unwrap(), 1 << 30);
+	}
+
+	#[test]
+	fn parse_limit_percent() {
+		let half = parse_limit("50%").unwrap();
+		let full = parse_limit("100%").unwrap();
+		assert!(half > 0);
+		// Integer truncation makes 2*half at most `full`, never more.
+		assert!(half <= full && full <= 2 * (half + 1));
+	}
+
+	#[test]
+	fn parse_limit_rejects_garbage() {
+		assert!(parse_limit("lots").is_err());
+		assert!(parse_limit("0%").is_err());
+		assert!(parse_limit("150%").is_err());
+	}
+}

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -387,8 +387,12 @@ impl Cluster {
 	/// session's broadcasts cache into one memory budget. Call before deriving
 	/// any origin handles (e.g. [`with_stats`](Self::with_stats)) so they inherit
 	/// the pool.
+	///
+	/// Rebuilds the origin with the pool: safe because the cluster's origin is
+	/// still pristine here (no broadcasts published, no scopes derived).
 	pub fn with_cache(mut self, pool: moq_net::cache::Pool) -> Self {
-		self.origin = self.origin.with_pool(pool);
+		let id = *self.origin; // origin::Producer derefs to its Origin id.
+		self.origin = moq_net::origin::Info::new(id).with_pool(pool).produce();
 		self
 	}
 

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -383,6 +383,15 @@ impl Cluster {
 		})
 	}
 
+	/// Attach the shared group [`cache::Pool`](moq_net::cache::Pool) so every
+	/// session's broadcasts cache into one memory budget. Call before deriving
+	/// any origin handles (e.g. [`with_stats`](Self::with_stats)) so they inherit
+	/// the pool.
+	pub fn with_cache(mut self, pool: moq_net::cache::Pool) -> Self {
+		self.origin = self.origin.with_pool(pool);
+		self
+	}
+
 	/// Attach a QUIC client used to dial cluster peers.
 	///
 	/// Required when `config.connect` is non-empty; [`run`](Self::run) returns

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 
-use crate::{AuthConfig, ClusterConfig, StatsConfig, WebConfig};
+use crate::{AuthConfig, CacheConfig, ClusterConfig, StatsConfig, WebConfig};
 
 /// Top-level relay configuration, loadable from CLI arguments, environment
 /// variables, or a TOML file.
@@ -44,6 +44,12 @@ pub struct Config {
 	#[command(flatten)]
 	#[serde(default)]
 	pub stats: StatsConfig,
+
+	/// Group cache sizing. Unbounded unless `cache.capacity` or `cache.headroom`
+	/// is set.
+	#[command(flatten)]
+	#[serde(default)]
+	pub cache: CacheConfig,
 
 	/// If provided, load the configuration from this file.
 	#[serde(default)]
@@ -156,6 +162,44 @@ depth = 2
 		assert_eq!(config.stats.interval, Some(5));
 		assert_eq!(config.stats.node.as_deref(), Some("localhost"));
 		assert_eq!(config.stats.depth, Some(2));
+	}
+
+	/// Serializes tests that touch `MOQ_CACHE_*`. Same rationale as
+	/// `STATS_ENV_LOCK`.
+	static CACHE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+	/// Regression test for the clap+TOML clobber bug applied to `[cache]`. Both
+	/// fields are `Option<String>` so a TOML-configured cache size survives the
+	/// CLI re-parse when no `--cache-*` flag is passed.
+	#[test]
+	fn cli_does_not_clobber_toml_cache() {
+		let _guard = CACHE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+		// SAFETY: CACHE_ENV_LOCK ensures no other test in this binary touches
+		// these env vars concurrently.
+		unsafe {
+			std::env::remove_var("MOQ_CACHE_CAPACITY");
+			std::env::remove_var("MOQ_CACHE_HEADROOM");
+		}
+
+		let toml = r#"
+[cache]
+capacity = "8GiB"
+headroom = "10%"
+"#;
+		let dir = std::env::temp_dir().join("moq-relay-config-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("cache-toml-wins.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
+		let config = Config::parse_and_merge(args).expect("config load");
+
+		assert_eq!(
+			config.cache.capacity.as_deref(),
+			Some("8GiB"),
+			"TOML's cache.capacity must not be clobbered by the CLI re-parse"
+		);
+		assert_eq!(config.cache.headroom.as_deref(), Some("10%"));
 	}
 
 	/// Serializes tests that touch `MOQ_SERVER_PREFERRED_V4` / `_V6`. Same

--- a/rs/moq-relay/src/lib.rs
+++ b/rs/moq-relay/src/lib.rs
@@ -8,6 +8,7 @@
 //! See `main.rs` for a complete example of how these pieces fit together.
 
 mod auth;
+mod cache;
 mod cluster;
 mod config;
 mod connection;
@@ -33,6 +34,7 @@ fn trusted_tier(label: Option<String>) -> moq_net::Tier {
 }
 
 pub use auth::*;
+pub use cache::*;
 pub use cluster::*;
 pub use config::*;
 pub use connection::*;

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -55,7 +55,9 @@ async fn main() -> anyhow::Result<()> {
 		config.auth.init(&config.client.tls).await?
 	};
 
+	let cache = config.cache.init()?;
 	let cluster = Cluster::new(config.cluster)?
+		.with_cache(cache)
 		.with_client(client)
 		.with_client_tls(config.client.tls.build()?);
 	let stats = config.stats.build(cluster.origin.clone());


### PR DESCRIPTION
## Summary

Non-latest groups were cached per-track for a TTL (`track::Info::cache`, default 5s) with no global bound, so relay memory scaled with track count, and raising the TTL for FETCH would make it unbounded in time too. This adds a process-wide memory budget with LRU eviction, designed so the TTL and the LRU are two triggers for one primitive rather than two disjoint eviction mechanisms.

### Design (abort-as-tombstone)

- **Eviction = `group.abort(Evicted)`.** Frames are freed instantly and parked readers wake with the error. The pool never touches track state, so there is no cross-structure locking.
- The track's cached slot becomes a soft reference: every read path (`cached_group`, `poll_recv_group`, `poll_next_in_range`, `poll_read_frame`, fetch) treats an aborted group as absent. The existing on-append TTL sweep physically reaps aborted slots, and `fetch_group` on an evicted sequence is a clean miss that a `Dynamic` re-serves (the refetched group replaces its old slot in place).
- **The latest group of each track is pinned** (still charged, never a victim), so the live edge always survives. `cache = 0` tracks (e.g. a catalog) keep today's evict-on-next-append behavior.
- **Recency without a global lock**: readers do a relaxed store of a coarse last-access stamp; eviction pops a lazy min-heap of snapshots and re-keys entries touched since. Accounting follows group growth (late frames on old groups charge the pool and can trigger eviction), plus a fixed 256-byte overhead per group so many-tiny-group tracks are billed realistically.
- **Threading**: `cache::Pool` rides `origin::Info` -> `origin::Producer` -> the broadcast's shared state -> `TrackState` -> each group's RAII `Charge`. Defaults to unbounded, so publishers/browsers/wasm are unaffected. It deliberately does *not* live on `broadcast::Info` (that's cloneable wire metadata).

### Relay config

New `[cache]` section (`--cache-capacity` / `--cache-headroom`, `MOQ_CACHE_*`):

- `capacity`: absolute ("8GiB") or percentage of memory ("75%", cgroup-aware).
- `headroom`: keeps N bytes/percent of system memory available via a 5s governor that resizes the pool, so the cache soaks up idle RAM but is the first thing reclaimed under pressure.

## Public API changes (rs/moq-net, breaking -> targets dev)

- New module `moq_net::cache` with `cache::Pool` (`new`/`unbounded`/`capacity`/`used`/`resize`/`same_pool`). `Charge`/`Entry` are crate-private.
- New `origin::Info { id: Origin, pool: cache::Pool }` (`#[non_exhaustive]`, `new(id)` + `with_pool()` builders, `produce()`). The origin owns the shared pool; broadcasts created under it inherit it. `Origin::produce()` stays as the unbounded shorthand.
- `origin::Producer::new` now takes `origin::Info` instead of a bare `Origin` (**breaking** to that constructor; `Origin::produce()` / `Info::produce()` are the ergonomic paths). `origin::Producer::with_pool` (setter) removed; `pool()` getter kept.
- `broadcast::Info` is pure metadata again (just `hops`); the pool moved to the broadcast's shared state. `broadcast::Producer::with_pool` stamps it (reachable by both producer and consumers). This means `broadcast::Info` no longer leaks a runtime handle next to on-the-wire routing data.
- `Error::Evicted`, wire code 31 (additive; 28 stays retired, 30 is `Unroutable`).
- Behavior: track-level `poll_read_frame` now skips a group whose read errors instead of poisoning the whole track (consistent with moq-lite's no-cascading-abort rule), and new subscribers no longer receive already-aborted cached groups.
- moq-relay (patch-bump policy): `CacheConfig`, `Cluster::with_cache` (additive).

## Cross-package sync

- `doc/bin/relay/config.md`: new `[cache]` section.
- `js/net` mirror deferred (browser caches are small and there's no byte-budget need yet); follow-up issue to be filed. No wire change, so interop is unaffected.
- `doc/concept` has no caching page to update.

## Testing

- `cache.rs` unit tests: LRU order, pin immunity, lazy re-key, resize, detached charges, dropped-entry heap slots.
- `track.rs` integration tests: oldest-group eviction, latest immunity, read-recency bump, reader abort on eviction, growth-on-old-group accounting, fetch re-insert after eviction.
- `moq-relay`: `[cache]` TOML/CLI merge regression test, size parsing tests.
- Full workspace: `cargo test --workspace` green (37 binaries), `clippy -D warnings` clean, `cargo fmt --check` clean. Note: fmt ran with the system rustfmt because the nix dev shell is currently broken on macOS arm64 (tsduck).

(Written by Claude Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
