### PR TITLE
feat(moq-net,js/net): finalize moq-lite-05 and fix FETCH framing

### DIFF
--- a/js/net/src/connection/accept.ts
+++ b/js/net/src/connection/accept.ts
@@ -32,8 +32,8 @@ export async function accept(transport: WebTransport, url: URL, props?: AcceptPr
 		return acceptSetup(transport, url, Ietf.Version.DRAFT_16);
 	} else if (protocol === Ietf.ALPN.DRAFT_15) {
 		return acceptSetup(transport, url, Ietf.Version.DRAFT_15);
-	} else if (protocol === Lite.ALPN_05_WIP) {
-		return new Lite.Connection(url, transport, Lite.Version.DRAFT_05_WIP, undefined);
+	} else if (protocol === Lite.ALPN_05) {
+		return new Lite.Connection(url, transport, Lite.Version.DRAFT_05, undefined);
 	} else if (protocol === Lite.ALPN_04) {
 		return new Lite.Connection(url, transport, Lite.Version.DRAFT_04, undefined);
 	} else if (protocol === Lite.ALPN_03) {

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -143,9 +143,9 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 		setupVersion = Ietf.Version.DRAFT_16;
 	} else if (protocol === Ietf.ALPN.DRAFT_15) {
 		setupVersion = Ietf.Version.DRAFT_15;
-	} else if (protocol === Lite.ALPN_05_WIP) {
-		// moq-lite draft-05 (WIP) doesn't use a session stream, so we return immediately.
-		return new Lite.Connection(url, session, Lite.Version.DRAFT_05_WIP, undefined);
+	} else if (protocol === Lite.ALPN_05) {
+		// moq-lite draft-05 doesn't use a session stream, so we return immediately.
+		return new Lite.Connection(url, session, Lite.Version.DRAFT_05, undefined);
 	} else if (protocol === Lite.ALPN_04) {
 		// moq-lite draft-04 doesn't use a session stream, so we return immediately.
 		return new Lite.Connection(url, session, Lite.Version.DRAFT_04, undefined);
@@ -230,8 +230,8 @@ async function connectTransport(url: URL, session: WebTransport): Promise<Establ
 		setupVersion = Ietf.Version.DRAFT_16;
 	} else if (protocol === Ietf.ALPN.DRAFT_15) {
 		setupVersion = Ietf.Version.DRAFT_15;
-	} else if (protocol === Lite.ALPN_05_WIP) {
-		return new Lite.Connection(url, session, Lite.Version.DRAFT_05_WIP, undefined);
+	} else if (protocol === Lite.ALPN_05) {
+		return new Lite.Connection(url, session, Lite.Version.DRAFT_05, undefined);
 	} else if (protocol === Lite.ALPN_04) {
 		return new Lite.Connection(url, session, Lite.Version.DRAFT_04, undefined);
 	} else if (protocol === Lite.ALPN_03) {
@@ -361,7 +361,7 @@ async function connectWebTransport(
 		allowPooling: false,
 		congestionControl: "low-latency",
 		protocols: [
-			Lite.ALPN_05_WIP,
+			Lite.ALPN_05,
 			Lite.ALPN_04,
 			Lite.ALPN_03,
 			Lite.ALPN,
@@ -439,7 +439,7 @@ async function connectWebSocket(url: URL, delay: number, cancel: Promise<void>):
 	// advertises every QMux draft it knows about and the server picks one.
 	// Insertion order is the negotiation preference on the wire.
 	const versions = {
-		[Lite.ALPN_05_WIP]: null,
+		[Lite.ALPN_05]: null,
 		[Lite.ALPN_04]: null,
 		[Lite.ALPN_03]: null,
 		[Lite.ALPN]: null,

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -88,16 +88,16 @@ test("integration: lite draft-03", async () => {
 	await runPublishSubscribeFlow(Lite.ALPN_03);
 });
 
-test("integration: lite draft-05-wip", async () => {
+test("integration: lite draft-05", async () => {
 	// Exercises AnnounceOk: the announce flow only completes if the subscriber
 	// reads the publisher's AnnounceOk before the initial Announce messages.
-	await runPublishSubscribeFlow(Lite.ALPN_05_WIP);
+	await runPublishSubscribeFlow(Lite.ALPN_05);
 });
 
-test("integration: lite draft-05-wip datagram delivery", async () => {
+test("integration: lite draft-05 datagram delivery", async () => {
 	const enc = new TextEncoder();
 	const dec = new TextDecoder();
-	const pair = createMockTransportPair(Lite.ALPN_05_WIP);
+	const pair = createMockTransportPair(Lite.ALPN_05);
 
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 
@@ -133,11 +133,11 @@ test("integration: lite draft-05-wip datagram delivery", async () => {
 	server.close();
 });
 
-test("integration: lite draft-05-wip datagrams not sent on a non-datagram transport", async () => {
+test("integration: lite draft-05 datagrams not sent on a non-datagram transport", async () => {
 	const enc = new TextEncoder();
 	// maxDatagramSize 0 simulates a qmux/WebSocket session: the publisher must fall back to
 	// not sending datagrams (there is no group fallback), while groups still flow.
-	const pair = createMockTransportPair(Lite.ALPN_05_WIP, { datagrams: false });
+	const pair = createMockTransportPair(Lite.ALPN_05, { datagrams: false });
 
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 

--- a/js/net/src/lite/announce.test.ts
+++ b/js/net/src/lite/announce.test.ts
@@ -35,24 +35,24 @@ async function roundTrip(msg: AnnounceBroadcast, version: Version): Promise<Anno
 test("AnnounceBroadcast round-trips on draft-05", async () => {
 	const hops = [OriginSchema.parse(7n)];
 	const active = new AnnounceBroadcast({ suffix: Path.from("room/cam"), active: true, hops });
-	const gotActive = await roundTrip(active, Version.DRAFT_05_WIP);
+	const gotActive = await roundTrip(active, Version.DRAFT_05);
 	expect(gotActive.active).toBe(true);
 	expect(gotActive.suffix).toBe(Path.from("room/cam"));
 	expect(gotActive.hops).toEqual(hops);
 
 	const ended = new AnnounceBroadcast({ suffix: Path.from("room/cam"), active: false });
-	const gotEnded = await roundTrip(ended, Version.DRAFT_05_WIP);
+	const gotEnded = await roundTrip(ended, Version.DRAFT_05);
 	expect(gotEnded.active).toBe(false);
 	expect(gotEnded.suffix).toBe(Path.from("room/cam"));
 });
 
 test("AnnounceBroadcast accepts explicit restart status on draft-05", async () => {
 	const wire = await bytes((w) =>
-		new AnnounceBroadcast({ suffix: Path.from("room/cam"), active: true }).encode(w, Version.DRAFT_05_WIP),
+		new AnnounceBroadcast({ suffix: Path.from("room/cam"), active: true }).encode(w, Version.DRAFT_05),
 	);
 	wire[1] = 2;
 
-	const got = await AnnounceBroadcast.decode(new Reader(undefined, wire), Version.DRAFT_05_WIP);
+	const got = await AnnounceBroadcast.decode(new Reader(undefined, wire), Version.DRAFT_05);
 	expect(got.active).toBe(true);
 	expect(got.suffix).toBe(Path.from("room/cam"));
 });

--- a/js/net/src/lite/fetch.test.ts
+++ b/js/net/src/lite/fetch.test.ts
@@ -32,23 +32,15 @@ async function roundtrip(version: Version, fetch: Fetch): Promise<Fetch> {
 }
 
 function sample(): Fetch {
-	return new Fetch(Path.from("room/1"), "video", 3, 42, 7);
+	return new Fetch(Path.from("room/1"), "video", 3, 42);
 }
 
-test("Fetch: frameStart round-trips on draft-05", async () => {
-	const got = await roundtrip(Version.DRAFT_05_WIP, sample());
-	expect(got.group).toBe(42);
-	expect(got.frameStart).toBe(7);
-});
-
-test("Fetch: frameStart is absent before draft-05", async () => {
-	// draft-03/draft-04 don't carry the frame start varint, so it decodes to 0.
-	const got = await roundtrip(Version.DRAFT_04, sample());
-	expect(got.group).toBe(42);
-	expect(got.frameStart).toBe(0);
-
-	// The draft-04 encoding is strictly shorter (no trailing frame start varint).
-	const buf04 = await encode(Version.DRAFT_04, sample());
-	const buf05 = await encode(Version.DRAFT_05_WIP, sample());
-	expect(buf05.byteLength).toBeGreaterThan(buf04.byteLength);
+test("Fetch round-trips on draft-03/04/05", async () => {
+	for (const version of [Version.DRAFT_03, Version.DRAFT_04, Version.DRAFT_05]) {
+		const got = await roundtrip(version, sample());
+		expect(got.broadcast).toBe(Path.from("room/1"));
+		expect(got.track).toBe("video");
+		expect(got.priority).toBe(3);
+		expect(got.group).toBe(42);
+	}
 });

--- a/js/net/src/lite/fetch.ts
+++ b/js/net/src/lite/fetch.ts
@@ -18,54 +18,28 @@ export class Fetch {
 	track: string;
 	priority: number;
 	group: number;
-	/**
-	 * The 0-based index of the first frame to return; the publisher skips all
-	 * earlier frames. `0` returns the entire group. Draft-05+ only; older drafts
-	 * always return the whole group.
-	 */
-	frameStart: number;
 
-	constructor(broadcast: Path.Valid, track: string, priority: number, group: number, frameStart = 0) {
+	constructor(broadcast: Path.Valid, track: string, priority: number, group: number) {
 		this.broadcast = broadcast;
 		this.track = track;
 		this.priority = priority;
 		this.group = group;
-		this.frameStart = frameStart;
 	}
 
-	async #encode(w: Writer, version: Version) {
+	async #encode(w: Writer, _version: Version) {
 		await w.string(this.broadcast);
 		await w.string(this.track);
 		await w.u8(this.priority);
 		await w.u53(this.group);
-
-		switch (version) {
-			case Version.DRAFT_03:
-			case Version.DRAFT_04:
-				break;
-			default:
-				await w.u53(this.frameStart);
-				break;
-		}
 	}
 
-	static async #decode(r: Reader, version: Version): Promise<Fetch> {
+	static async #decode(r: Reader, _version: Version): Promise<Fetch> {
 		const broadcast = Path.from(await r.string());
 		const track = await r.string();
 		const priority = await r.u8();
 		const group = await r.u53();
 
-		let frameStart = 0;
-		switch (version) {
-			case Version.DRAFT_03:
-			case Version.DRAFT_04:
-				break;
-			default:
-				frameStart = await r.u53();
-				break;
-		}
-
-		return new Fetch(broadcast, track, priority, group, frameStart);
+		return new Fetch(broadcast, track, priority, group);
 	}
 
 	async encode(w: Writer, version: Version): Promise<void> {

--- a/js/net/src/lite/setup.test.ts
+++ b/js/net/src/lite/setup.test.ts
@@ -27,8 +27,8 @@ async function bytes(f: (w: Writer) => Promise<void>): Promise<Uint8Array> {
 }
 
 async function roundTrip(msg: Setup): Promise<Setup> {
-	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, Version.DRAFT_05_WIP)));
-	const got = await Setup.decode(reader, Version.DRAFT_05_WIP);
+	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, Version.DRAFT_05)));
+	const got = await Setup.decode(reader, Version.DRAFT_05);
 	expect(await reader.done()).toBe(true);
 	return got;
 }
@@ -69,7 +69,7 @@ test("unknown probe level saturates to Increase", async () => {
 		await w.write(body);
 	});
 
-	const got = await Setup.decode(new Reader(undefined, framed), Version.DRAFT_05_WIP);
+	const got = await Setup.decode(new Reader(undefined, framed), Version.DRAFT_05);
 	expect(got.probe).toBe(ProbeLevel.Increase);
 });
 
@@ -78,7 +78,7 @@ test("SETUP is rejected before draft-05", async () => {
 });
 
 test("SETUP decode is rejected before draft-05", async () => {
-	const framed = await bytes((w) => new Setup().encode(w, Version.DRAFT_05_WIP));
+	const framed = await bytes((w) => new Setup().encode(w, Version.DRAFT_05));
 	await expect(Setup.decode(new Reader(undefined, framed), Version.DRAFT_04)).rejects.toThrow();
 });
 
@@ -93,5 +93,5 @@ test("empty path is rejected on decode", async () => {
 		await w.u53(body.byteLength);
 		await w.write(body);
 	});
-	await expect(Setup.decode(new Reader(undefined, framed), Version.DRAFT_05_WIP)).rejects.toThrow();
+	await expect(Setup.decode(new Reader(undefined, framed), Version.DRAFT_05)).rejects.toThrow();
 });

--- a/js/net/src/lite/subscribe.test.ts
+++ b/js/net/src/lite/subscribe.test.ts
@@ -50,14 +50,14 @@ test("SubscribeOk round-trips priority/ordered/groups on draft-04", async () => 
 });
 
 test("SubscribeStart round-trips on draft-05", async () => {
-	const got = await responseRoundtrip(Version.DRAFT_05_WIP, { start: new SubscribeStart(42) });
+	const got = await responseRoundtrip(Version.DRAFT_05, { start: new SubscribeStart(42) });
 	expect("start" in got).toBe(true);
 	if (!("start" in got)) throw new Error("expected start");
 	expect(got.start.group).toBe(42);
 });
 
 test("SubscribeEnd round-trips on draft-05", async () => {
-	const got = await responseRoundtrip(Version.DRAFT_05_WIP, { end: new SubscribeEnd(7) });
+	const got = await responseRoundtrip(Version.DRAFT_05, { end: new SubscribeEnd(7) });
 	expect("end" in got).toBe(true);
 	if (!("end" in got)) throw new Error("expected end");
 	expect(got.end.group).toBe(7);
@@ -66,18 +66,18 @@ test("SubscribeEnd round-trips on draft-05", async () => {
 test("SubscribeDrop is type 0x2 on draft-05 and 0x1 on draft-04", async () => {
 	const drop: SubscribeResponse = { drop: new SubscribeDrop({ start: 1, end: 3, error: 0 }) };
 
-	const wire05 = await encode(Version.DRAFT_05_WIP, drop);
+	const wire05 = await encode(Version.DRAFT_05, drop);
 	expect(wire05[0]).toBe(2);
 
 	const wire04 = await encode(Version.DRAFT_04, drop);
 	expect(wire04[0]).toBe(1);
 
-	const got = await responseRoundtrip(Version.DRAFT_05_WIP, drop);
+	const got = await responseRoundtrip(Version.DRAFT_05, drop);
 	expect("drop" in got).toBe(true);
 	if (!("drop" in got)) throw new Error("expected drop");
 	expect([got.drop.start, got.drop.end]).toEqual([1, 3]);
 });
 
 test("SUBSCRIBE_OK is rejected on draft-05", async () => {
-	await expect(encode(Version.DRAFT_05_WIP, { ok: new SubscribeOk({ priority: 1 }) })).rejects.toThrow();
+	await expect(encode(Version.DRAFT_05, { ok: new SubscribeOk({ priority: 1 }) })).rejects.toThrow();
 });

--- a/js/net/src/lite/track.test.ts
+++ b/js/net/src/lite/track.test.ts
@@ -33,8 +33,8 @@ test("TrackInfo round-trips on draft-05", async () => {
 		cache: 2000,
 		timescale: 90000,
 	});
-	const reader = new Reader(undefined, await bytes((w) => info.encode(w, Version.DRAFT_05_WIP)));
-	const got = await TrackInfo.decode(reader, Version.DRAFT_05_WIP);
+	const reader = new Reader(undefined, await bytes((w) => info.encode(w, Version.DRAFT_05)));
+	const got = await TrackInfo.decode(reader, Version.DRAFT_05);
 	expect(got.priority).toBe(7);
 	expect(got.ordered).toBe(false);
 	expect(got.cache).toBe(2000);
@@ -43,8 +43,8 @@ test("TrackInfo round-trips on draft-05", async () => {
 
 test("Track request round-trips on draft-05", async () => {
 	const msg = new Track(Path.from("room"), "video");
-	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, Version.DRAFT_05_WIP)));
-	const got = await Track.decode(reader, Version.DRAFT_05_WIP);
+	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, Version.DRAFT_05)));
+	const got = await Track.decode(reader, Version.DRAFT_05);
 	expect(got.broadcast).toBe(Path.from("room"));
 	expect(got.track).toBe("video");
 });

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -3,10 +3,8 @@ export const Version = {
 	DRAFT_02: 0xff0dad02,
 	DRAFT_03: 0xff0dad03,
 	DRAFT_04: 0xff0dad04,
-	/// Work-in-progress lite-05, advertised as the preferred WebTransport
-	/// subprotocol so the demo and tests negotiate it. Still WIP; revisit before
-	/// promoting to `main`.
-	DRAFT_05_WIP: 0xff0dad05,
+	/// lite-05, advertised as the preferred WebTransport subprotocol.
+	DRAFT_05: 0xff0dad05,
 } as const;
 
 export type Version = (typeof Version)[keyof typeof Version];
@@ -66,16 +64,16 @@ export const ALPN_03 = "moq-lite-03";
 /// The ALPN string for Draft04, which uses ALPN-based version negotiation.
 export const ALPN_04 = "moq-lite-04";
 
-/// The ALPN string for the work-in-progress Draft05, offered first in the
-/// default WebTransport `protocols` list so lite-05 is the preferred version.
-export const ALPN_05_WIP = "moq-lite-05-wip";
+/// The ALPN string for Draft05, offered first in the default WebTransport
+/// `protocols` list so lite-05 is the preferred version.
+export const ALPN_05 = "moq-lite-05";
 
 const VERSION_NAMES: Record<number, string> = {
 	[Version.DRAFT_01]: "moq-lite-01",
 	[Version.DRAFT_02]: "moq-lite-02",
 	[Version.DRAFT_03]: "moq-lite-03",
 	[Version.DRAFT_04]: "moq-lite-04",
-	[Version.DRAFT_05_WIP]: "moq-lite-05-wip",
+	[Version.DRAFT_05]: "moq-lite-05",
 };
 
 export function versionName(v: Version): string {

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -719,7 +719,7 @@ async fn serve_session(request: Request) -> crate::Result<()> {
 #[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
 fn stream_versions(base: &moq_net::Versions) -> moq_net::Versions {
 	let mut versions: Vec<moq_net::Version> = base.iter().copied().collect();
-	if let Ok(lite05) = "moq-lite-05-wip".parse::<moq_net::Version>() {
+	if let Ok(lite05) = "moq-lite-05".parse::<moq_net::Version>() {
 		if !versions.contains(&lite05) {
 			versions.push(lite05);
 		}

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -153,7 +153,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 	let mut server_config = moq_native::ServerConfig::default();
 	server_config.bind = Some("[::]:0".to_string());
 	server_config.tls.generate = vec!["localhost".into()];
-	server_config.version = vec!["moq-lite-05-wip".parse().unwrap()];
+	server_config.version = vec!["moq-lite-05".parse().unwrap()];
 	let mut server = server_config.init().expect("failed to init server");
 	let addr = server.local_addr().expect("failed to get local addr");
 
@@ -162,7 +162,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 
 	let mut client_config = moq_native::ClientConfig::default();
 	client_config.tls.disable_verify = Some(true);
-	client_config.version = vec!["moq-lite-05-wip".parse().unwrap()];
+	client_config.version = vec!["moq-lite-05".parse().unwrap()];
 	let client = client_config.init().expect("failed to init client");
 	let url: url::Url = format!("{scheme}://localhost:{}", addr.port()).parse().unwrap();
 
@@ -267,7 +267,7 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 	let mut server_config = moq_native::ServerConfig::default();
 	server_config.bind = Some("[::]:0".to_string());
 	server_config.tls.generate = vec!["localhost".into()];
-	server_config.version = vec!["moq-lite-05-wip".parse().unwrap()];
+	server_config.version = vec!["moq-lite-05".parse().unwrap()];
 	let mut server = server_config.init().expect("failed to init server");
 	let addr = server.local_addr().expect("failed to get local addr");
 
@@ -276,7 +276,7 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 
 	let mut client_config = moq_native::ClientConfig::default();
 	client_config.tls.disable_verify = Some(true);
-	client_config.version = vec!["moq-lite-05-wip".parse().unwrap()];
+	client_config.version = vec!["moq-lite-05".parse().unwrap()];
 	let client = client_config.init().expect("failed to init client");
 	let url: url::Url = format!("{scheme}://localhost:{}", addr.port()).parse().unwrap();
 
@@ -388,7 +388,7 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 	let mut server_config = moq_native::ServerConfig::default();
 	server_config.bind = Some("[::]:0".to_string());
 	server_config.tls.generate = vec!["localhost".into()];
-	server_config.version = vec!["moq-lite-05-wip".parse().unwrap()];
+	server_config.version = vec!["moq-lite-05".parse().unwrap()];
 	let mut server = server_config.init().expect("failed to init server");
 	let addr = server.local_addr().expect("failed to get local addr");
 
@@ -397,7 +397,7 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 
 	let mut client_config = moq_native::ClientConfig::default();
 	client_config.tls.disable_verify = Some(true);
-	client_config.version = vec!["moq-lite-05-wip".parse().unwrap()];
+	client_config.version = vec!["moq-lite-05".parse().unwrap()];
 	let client = client_config.init().expect("failed to init client");
 	let url: url::Url = format!("{scheme}://localhost:{}", addr.port()).parse().unwrap();
 
@@ -490,7 +490,7 @@ async fn broadcast_moq_lite_05_default_timescale() {
 	let mut server_config = moq_native::ServerConfig::default();
 	server_config.bind = Some("[::]:0".to_string());
 	server_config.tls.generate = vec!["localhost".into()];
-	server_config.version = vec!["moq-lite-05-wip".parse().unwrap()];
+	server_config.version = vec!["moq-lite-05".parse().unwrap()];
 	let mut server = server_config.init().expect("init server");
 	let addr = server.local_addr().expect("local addr");
 
@@ -499,7 +499,7 @@ async fn broadcast_moq_lite_05_default_timescale() {
 
 	let mut client_config = moq_native::ClientConfig::default();
 	client_config.tls.disable_verify = Some(true);
-	client_config.version = vec!["moq-lite-05-wip".parse().unwrap()];
+	client_config.version = vec!["moq-lite-05".parse().unwrap()];
 	let client = client_config.init().expect("init client");
 	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
 
@@ -1113,7 +1113,7 @@ async fn broadcast_websocket_fallback() {
 ///
 /// Bump this whenever [`moq_net::Versions::all`] gains a newer Lite variant
 /// so the regression tests below keep tracking "the newest", not a frozen value.
-const NEWEST_LITE: &str = "moq-lite-05-wip";
+const NEWEST_LITE: &str = "moq-lite-05";
 
 /// Regression guard for the WebSocket ALPN path. Lite02 over WebSocket means
 /// the qmux subprotocol negotiation produced a bare `moql` (or no match)

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -1,7 +1,7 @@
 use crate::origin;
 use crate::{
-	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP,
-	Consume, Error, NEGOTIATED, Session, StatsHandle, Version, Versions,
+	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05, Consume,
+	Error, NEGOTIATED, Session, StatsHandle, Version, Versions,
 	coding::{self, Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -182,9 +182,9 @@ impl Client {
 					.ok_or(Error::Version)?;
 				(v, v.into())
 			}
-			Some(ALPN_LITE_05_WIP) => {
+			Some(ALPN_LITE_05) => {
 				self.versions
-					.select(Version::Lite(lite::Version::Lite05Wip))
+					.select(Version::Lite(lite::Version::Lite05))
 					.ok_or(Error::Version)?;
 
 				// Advertise our capabilities (we report send bitrate; we don't pad) plus
@@ -200,7 +200,7 @@ impl Client {
 					self.publish.clone(),
 					self.subscribe.clone(),
 					self.stats.clone(),
-					lite::Version::Lite05Wip,
+					lite::Version::Lite05,
 					our_setup,
 					None,
 				)?;
@@ -210,7 +210,7 @@ impl Client {
 				// immediately instead of racing announcement gossip.
 				connecting.ready().await;
 
-				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw));
+				return Ok(Session::new(session, lite::Version::Lite05.into(), recv_bw));
 			}
 			Some(ALPN_LITE_04) => {
 				self.versions

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -265,7 +265,7 @@ mod tests {
 	// subscriber turns it into a restart for an already-announced path).
 	#[test]
 	fn decodes_explicit_restart_status_as_active_on_lite05() {
-		let version = Version::Lite05Wip;
+		let version = Version::Lite05;
 		let mut slice = encode_forged_restart(version);
 		let decoded = AnnounceBroadcast::decode(&mut slice, version).expect("explicit restart must decode");
 		assert!(!slice.has_remaining(), "trailing bytes after decode");
@@ -291,9 +291,9 @@ mod tests {
 
 	fn round_trip(msg: &AnnounceOk) -> AnnounceOk {
 		let mut buf = bytes::BytesMut::new();
-		msg.encode(&mut buf, Version::Lite05Wip).unwrap();
+		msg.encode(&mut buf, Version::Lite05).unwrap();
 		let mut slice = &buf[..];
-		let got = AnnounceOk::decode(&mut slice, Version::Lite05Wip).unwrap();
+		let got = AnnounceOk::decode(&mut slice, Version::Lite05).unwrap();
 		assert!(slice.is_empty(), "trailing bytes after decode");
 		got
 	}
@@ -343,13 +343,13 @@ mod tests {
 			suffix: Path::new("room/cam"),
 			hops: hops.clone(),
 		};
-		assert_eq!(broadcast_round_trip(&msg, Version::Lite05Wip), msg);
+		assert_eq!(broadcast_round_trip(&msg, Version::Lite05), msg);
 
 		let ended = AnnounceBroadcast::Ended {
 			suffix: Path::new("room/cam"),
 			hops: OriginList::new(),
 		};
-		assert_eq!(broadcast_round_trip(&ended, Version::Lite05Wip), ended);
+		assert_eq!(broadcast_round_trip(&ended, Version::Lite05), ended);
 	}
 
 	#[test]
@@ -373,7 +373,7 @@ mod tests {
 			origin: Origin::new(1).unwrap(),
 			active: 0,
 		}
-		.encode(&mut buf, Version::Lite05Wip)
+		.encode(&mut buf, Version::Lite05)
 		.unwrap();
 		// origin id 1 sits right after the size prefix; rewrite it to 0.
 		let bytes = &buf[..];
@@ -381,7 +381,7 @@ mod tests {
 		// size(1 byte) | origin varint(1 byte = 0x01) | active varint(1 byte)
 		patched[1] = 0x00;
 		let mut slice = &patched[..];
-		let got = AnnounceOk::decode(&mut slice, Version::Lite05Wip).unwrap();
+		let got = AnnounceOk::decode(&mut slice, Version::Lite05).unwrap();
 		assert_eq!(got.origin.id(), 0);
 		assert_eq!(got.active, 0);
 	}

--- a/rs/moq-net/src/lite/datagram.rs
+++ b/rs/moq-net/src/lite/datagram.rs
@@ -78,9 +78,9 @@ mod test {
 			payload: Bytes::from_static(b"hello"),
 		};
 		let mut buf = BytesMut::new();
-		original.encode(&mut buf, Version::Lite05Wip).unwrap();
+		original.encode(&mut buf, Version::Lite05).unwrap();
 		let mut slice = &buf[..];
-		let decoded = Datagram::decode(&mut slice, Version::Lite05Wip).unwrap();
+		let decoded = Datagram::decode(&mut slice, Version::Lite05).unwrap();
 		assert_eq!(decoded, original);
 		assert!(!slice.has_remaining(), "payload has no trailing length prefix");
 	}
@@ -94,9 +94,9 @@ mod test {
 			payload: Bytes::new(),
 		};
 		let mut buf = BytesMut::new();
-		original.encode(&mut buf, Version::Lite05Wip).unwrap();
+		original.encode(&mut buf, Version::Lite05).unwrap();
 		let mut slice = &buf[..];
-		let decoded = Datagram::decode(&mut slice, Version::Lite05Wip).unwrap();
+		let decoded = Datagram::decode(&mut slice, Version::Lite05).unwrap();
 		assert_eq!(decoded, original);
 	}
 
@@ -110,7 +110,7 @@ mod test {
 			timestamp: 3,
 			payload: Bytes::from_static(b"world"),
 		};
-		let buf = dg.encode_bytes(Version::Lite05Wip).unwrap();
+		let buf = dg.encode_bytes(Version::Lite05).unwrap();
 		// 1 + 1 + 1 (single-byte varints) + 5 payload = 8 bytes, no length byte.
 		assert_eq!(buf.len(), 8);
 		assert_eq!(&buf[3..], b"world");

--- a/rs/moq-net/src/lite/fetch.rs
+++ b/rs/moq-net/src/lite/fetch.rs
@@ -16,10 +16,6 @@ pub struct Fetch<'a> {
 	pub track: Cow<'a, str>,
 	pub priority: u8,
 	pub group: u64,
-	/// The 0-based index of the first frame to return; the publisher skips all
-	/// earlier frames. `0` returns the entire group. Lite05+ only; older drafts
-	/// always return the whole group.
-	pub frame_start: u64,
 }
 
 impl Message for Fetch<'_> {
@@ -35,17 +31,12 @@ impl Message for Fetch<'_> {
 		let track = Cow::<str>::decode(r, version)?;
 		let priority = u8::decode(r, version)?;
 		let group = u64::decode(r, version)?;
-		let frame_start = match version {
-			Version::Lite03 | Version::Lite04 => 0,
-			_ => u64::decode(r, version)?,
-		};
 
 		Ok(Self {
 			broadcast,
 			track,
 			priority,
 			group,
-			frame_start,
 		})
 	}
 
@@ -61,10 +52,6 @@ impl Message for Fetch<'_> {
 		self.track.encode(w, version)?;
 		self.priority.encode(w, version)?;
 		self.group.encode(w, version)?;
-		match version {
-			Version::Lite03 | Version::Lite04 => {}
-			_ => self.frame_start.encode(w, version)?,
-		}
 		Ok(())
 	}
 }
@@ -79,7 +66,6 @@ mod test {
 			track: Cow::Borrowed("video"),
 			priority: 3,
 			group: 7,
-			frame_start: 5,
 		}
 	}
 
@@ -91,25 +77,19 @@ mod test {
 	}
 
 	#[test]
-	fn fetch_frame_start_roundtrips_on_lite05() {
-		assert_eq!(fetch_roundtrip(Version::Lite05Wip, &fetch_sample()).frame_start, 5);
+	fn fetch_roundtrips() {
+		for version in [Version::Lite03, Version::Lite04, Version::Lite05] {
+			let got = fetch_roundtrip(version, &fetch_sample());
+			assert_eq!(got.broadcast, Path::new("room"));
+			assert_eq!(got.track, "video");
+			assert_eq!(got.priority, 3);
+			assert_eq!(got.group, 7);
+		}
 	}
 
 	#[test]
-	fn fetch_frame_start_absent_before_lite05() {
-		let msg = fetch_sample();
-
-		// The frame_start varint only exists on lite-05+, so the older encoding is
-		// strictly shorter and always decodes back as 0.
-		let mut buf04 = Vec::new();
-		msg.encode_msg(&mut buf04, Version::Lite04).unwrap();
-		let mut buf05 = Vec::new();
-		msg.encode_msg(&mut buf05, Version::Lite05Wip).unwrap();
-		assert!(
-			buf05.len() > buf04.len(),
-			"lite-05 carries the extra frame_start varint"
-		);
-
-		assert_eq!(fetch_roundtrip(Version::Lite04, &msg).frame_start, 0);
+	fn fetch_rejected_before_lite03() {
+		let mut buf = Vec::new();
+		assert!(fetch_sample().encode_msg(&mut buf, Version::Lite02).is_err());
 	}
 }

--- a/rs/moq-net/src/lite/parameters.rs
+++ b/rs/moq-net/src/lite/parameters.rs
@@ -27,9 +27,7 @@ impl Parameters {
 	pub fn set_varint(&mut self, id: u64, value: u64) {
 		let mut buf = Vec::new();
 		// Infallible: writing into a Vec never runs short.
-		value
-			.encode(&mut buf, Version::Lite05Wip)
-			.expect("varint encode into Vec");
+		value.encode(&mut buf, Version::Lite05).expect("varint encode into Vec");
 		self.0.insert(id, buf);
 	}
 
@@ -38,7 +36,7 @@ impl Parameters {
 		let Some(mut bytes) = self.0.get(&id).map(Vec::as_slice) else {
 			return Ok(None);
 		};
-		let value = u64::decode(&mut bytes, Version::Lite05Wip)?;
+		let value = u64::decode(&mut bytes, Version::Lite05)?;
 		if !bytes.is_empty() {
 			return Err(DecodeError::Long);
 		}

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -695,10 +695,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// the timescale from TRACK_INFO and the group sequence from its request.
 		track_stats.group();
 
-		// Honor frame_start: skip earlier frames, then stream the rest in order. The
-		// delta-timestamp baseline resets to 0, so the first served frame's delta is
-		// its absolute timestamp (the subscriber decodes against the same baseline).
-		let mut index = fetch.frame_start as usize;
+		// Stream the whole group in order. The delta-timestamp baseline starts at 0, so
+		// the first frame's delta is its absolute timestamp (the subscriber decodes
+		// against the same baseline).
+		let mut index = 0usize;
 		let mut prev_ts: u64 = 0;
 		while let Some(mut frame) = group.get_frame(index).await? {
 			write_fetch_frame(&mut stream.writer, &mut frame, timescale, &mut prev_ts, &track_stats).await?;

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -83,7 +83,7 @@ pub fn start<S: web_transport_trait::Session>(
 	// `Connecting::ready` resolve immediately. An empty subscribe origin also resolves
 	// immediately because the subscriber arms with a prefix count of zero.
 	let (connecting_producer, connecting) = Connecting::new();
-	let sub_connecting = if matches!(version, Version::Lite01 | Version::Lite02 | Version::Lite05Wip) {
+	let sub_connecting = if matches!(version, Version::Lite01 | Version::Lite02 | Version::Lite05) {
 		Some(connecting_producer)
 	} else {
 		None

--- a/rs/moq-net/src/lite/setup.rs
+++ b/rs/moq-net/src/lite/setup.rs
@@ -149,9 +149,9 @@ mod tests {
 
 	fn round_trip(msg: &Setup) -> Setup {
 		let mut buf = bytes::BytesMut::new();
-		msg.encode(&mut buf, Version::Lite05Wip).unwrap();
+		msg.encode(&mut buf, Version::Lite05).unwrap();
 		let mut slice = &buf[..];
-		let got = Setup::decode(&mut slice, Version::Lite05Wip).unwrap();
+		let got = Setup::decode(&mut slice, Version::Lite05).unwrap();
 		assert!(bytes::Buf::remaining(&slice) == 0, "trailing bytes after decode");
 		got
 	}
@@ -186,14 +186,14 @@ mod tests {
 		let mut params = Parameters::default();
 		params.set_varint(PARAM_PROBE, 99);
 		let mut body = Vec::new();
-		params.encode(&mut body, Version::Lite05Wip).unwrap();
+		params.encode(&mut body, Version::Lite05).unwrap();
 
 		let mut buf = bytes::BytesMut::new();
-		body.len().encode(&mut buf, Version::Lite05Wip).unwrap();
+		body.len().encode(&mut buf, Version::Lite05).unwrap();
 		buf.extend_from_slice(&body);
 
 		let mut slice = &buf[..];
-		let got = Setup::decode(&mut slice, Version::Lite05Wip).unwrap();
+		let got = Setup::decode(&mut slice, Version::Lite05).unwrap();
 		assert_eq!(got.probe, ProbeLevel::Increase);
 	}
 
@@ -215,15 +215,15 @@ mod tests {
 		params.set_bytes(0xbeef, b"whatever".to_vec());
 
 		let mut body = Vec::new();
-		params.encode(&mut body, Version::Lite05Wip).unwrap();
+		params.encode(&mut body, Version::Lite05).unwrap();
 
 		// Wrap with the message size prefix the Message impl expects.
 		let mut buf = bytes::BytesMut::new();
-		body.len().encode(&mut buf, Version::Lite05Wip).unwrap();
+		body.len().encode(&mut buf, Version::Lite05).unwrap();
 		buf.extend_from_slice(&body);
 
 		let mut slice = &buf[..];
-		let got = Setup::decode(&mut slice, Version::Lite05Wip).unwrap();
+		let got = Setup::decode(&mut slice, Version::Lite05).unwrap();
 		assert_eq!(got.path.as_deref(), Some("/foo"));
 	}
 }

--- a/rs/moq-net/src/lite/subscribe.rs
+++ b/rs/moq-net/src/lite/subscribe.rs
@@ -413,9 +413,9 @@ mod test {
 	fn subscribe_start_roundtrips_on_lite05() {
 		let resp = SubscribeResponse::Start(SubscribeStart { group: 42 });
 		let mut buf = Vec::new();
-		resp.encode(&mut buf, Version::Lite05Wip).unwrap();
+		resp.encode(&mut buf, Version::Lite05).unwrap();
 		let mut slice = buf.as_slice();
-		match SubscribeResponse::decode(&mut slice, Version::Lite05Wip).unwrap() {
+		match SubscribeResponse::decode(&mut slice, Version::Lite05).unwrap() {
 			SubscribeResponse::Start(start) => assert_eq!(start.group, 42),
 			other => panic!("expected Start, got {other:?}"),
 		}
@@ -425,9 +425,9 @@ mod test {
 	fn subscribe_end_roundtrips_on_lite05() {
 		let resp = SubscribeResponse::End(SubscribeEnd { group: 7 });
 		let mut buf = Vec::new();
-		resp.encode(&mut buf, Version::Lite05Wip).unwrap();
+		resp.encode(&mut buf, Version::Lite05).unwrap();
 		let mut slice = buf.as_slice();
-		match SubscribeResponse::decode(&mut slice, Version::Lite05Wip).unwrap() {
+		match SubscribeResponse::decode(&mut slice, Version::Lite05).unwrap() {
 			SubscribeResponse::End(end) => assert_eq!(end.group, 7),
 			other => panic!("expected End, got {other:?}"),
 		}
@@ -441,12 +441,12 @@ mod test {
 			error: 0,
 		});
 		let mut buf = Vec::new();
-		resp.encode(&mut buf, Version::Lite05Wip).unwrap();
+		resp.encode(&mut buf, Version::Lite05).unwrap();
 		// Type discriminator is the first varint; on Lite05 DROP is 0x2.
 		assert_eq!(buf[0], 2);
 
 		let mut slice = buf.as_slice();
-		match SubscribeResponse::decode(&mut slice, Version::Lite05Wip).unwrap() {
+		match SubscribeResponse::decode(&mut slice, Version::Lite05).unwrap() {
 			SubscribeResponse::Drop(drop) => assert_eq!((drop.start, drop.end), (1, 3)),
 			other => panic!("expected Drop, got {other:?}"),
 		}
@@ -474,6 +474,6 @@ mod test {
 			end_group: None,
 		});
 		let mut buf = Vec::new();
-		assert!(resp.encode(&mut buf, Version::Lite05Wip).is_err());
+		assert!(resp.encode(&mut buf, Version::Lite05).is_err());
 	}
 }

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1225,7 +1225,6 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 				track: name.as_str().into(),
 				priority: request.priority(),
 				group,
-				frame_start: 0,
 			};
 			stream.writer.encode(&lite::ControlType::Fetch).await?;
 			stream.writer.encode(&msg).await

--- a/rs/moq-net/src/lite/track.rs
+++ b/rs/moq-net/src/lite/track.rs
@@ -113,7 +113,7 @@ mod test {
 
 	#[test]
 	fn track_info_roundtrips_on_lite05() {
-		let got = info_roundtrip(Version::Lite05Wip, &info_sample());
+		let got = info_roundtrip(Version::Lite05, &info_sample());
 		assert_eq!(got.priority, 7);
 		assert!(!got.ordered);
 		assert_eq!(got.cache, Duration::from_millis(2000));
@@ -124,7 +124,7 @@ mod test {
 	fn track_info_default_timescale_roundtrips() {
 		let mut info = info_sample();
 		info.timescale = Timescale::default();
-		assert_eq!(info_roundtrip(Version::Lite05Wip, &info).timescale, Timescale::MILLI);
+		assert_eq!(info_roundtrip(Version::Lite05, &info).timescale, Timescale::MILLI);
 	}
 
 	#[test]
@@ -140,9 +140,9 @@ mod test {
 			track: Cow::Borrowed("video"),
 		};
 		let mut buf = Vec::new();
-		msg.encode_msg(&mut buf, Version::Lite05Wip).unwrap();
+		msg.encode_msg(&mut buf, Version::Lite05).unwrap();
 		let mut slice = buf.as_slice();
-		let got = Track::decode_msg(&mut slice, Version::Lite05Wip).unwrap();
+		let got = Track::decode_msg(&mut slice, Version::Lite05).unwrap();
 		assert_eq!(got.broadcast, Path::new("room"));
 		assert_eq!(got.track, "video");
 	}

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -7,12 +7,11 @@ pub enum Version {
 	Lite02,
 	Lite03,
 	Lite04,
-	/// Work-in-progress lite-05. Adds the TRACK stream (immutable per-track
-	/// properties incl. timescale), zigzag-delta timestamps in per-frame headers,
-	/// and drops SUBSCRIBE_OK/FETCH_OK. Advertised over ALPN and included in the
-	/// default version sets as the preferred version; still WIP, revisit before
-	/// promoting the branch to `main`.
-	Lite05Wip,
+	/// lite-05. Adds the TRACK stream (immutable per-track properties incl.
+	/// timescale), zigzag-delta timestamps in per-frame headers, and drops
+	/// SUBSCRIBE_OK/FETCH_OK. Advertised over ALPN and the preferred version in the
+	/// default version sets.
+	Lite05,
 }
 
 impl Version {
@@ -74,7 +73,7 @@ impl fmt::Display for Version {
 			Self::Lite02 => write!(f, "moq-lite-02"),
 			Self::Lite03 => write!(f, "moq-lite-03"),
 			Self::Lite04 => write!(f, "moq-lite-04"),
-			Self::Lite05Wip => write!(f, "moq-lite-05-wip"),
+			Self::Lite05 => write!(f, "moq-lite-05"),
 		}
 	}
 }
@@ -86,7 +85,7 @@ impl From<Version> for crate::Version {
 			Version::Lite02 => crate::Version::Lite(Version::Lite02),
 			Version::Lite03 => crate::Version::Lite(Version::Lite03),
 			Version::Lite04 => crate::Version::Lite(Version::Lite04),
-			Version::Lite05Wip => crate::Version::Lite(Version::Lite05Wip),
+			Version::Lite05 => crate::Version::Lite(Version::Lite05),
 		}
 	}
 }

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1763,7 +1763,7 @@ mod tests {
 
 		let mut zero = [0u8].as_slice();
 		assert_eq!(
-			Origin::decode(&mut zero, crate::lite::Version::Lite05Wip).unwrap(),
+			Origin::decode(&mut zero, crate::lite::Version::Lite05).unwrap(),
 			Origin::UNKNOWN
 		);
 	}

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1997,7 +1997,7 @@ mod test {
 		use crate::coding::{Decode, Encode};
 		use crate::lite;
 
-		let version = lite::Version::Lite05Wip;
+		let version = lite::Version::Lite05;
 
 		// Origin publishes a datagram; the publisher reads it and encodes the wire body.
 		let mut origin = track_producer("test", None);

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1,7 +1,7 @@
 use crate::origin;
 use crate::{
-	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP,
-	Consume, Error, NEGOTIATED, Session, StatsHandle, Version, Versions,
+	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05, Consume,
+	Error, NEGOTIATED, Session, StatsHandle, Version, Versions,
 	coding::{Decode, Encode, Reader, Stream},
 	ietf, lite, setup,
 };
@@ -133,15 +133,15 @@ impl Server {
 					.ok_or(Error::Version)?;
 				(v, v.into())
 			}
-			Some(ALPN_LITE_05_WIP) => {
+			Some(ALPN_LITE_05) => {
 				self.versions
-					.select(Version::Lite(lite::Version::Lite05Wip))
+					.select(Version::Lite(lite::Version::Lite05))
 					.ok_or(Error::Version)?;
 
 				// Gate on the client's SETUP: read it before serving so the caller can
 				// scope by the advertised path. Seeded back into `start` on `ok()` so
 				// PROBE gating resolves without re-reading the (consumed) Setup Stream.
-				let client_setup = lite::accept_setup(&session, lite::Version::Lite05Wip).await?;
+				let client_setup = lite::accept_setup(&session, lite::Version::Lite05).await?;
 				return Ok(Request {
 					server: self.clone(),
 					path: client_setup.path.clone(),
@@ -359,11 +359,11 @@ impl<S: web_transport_trait::Session> Request<S> {
 					server.publish,
 					server.subscribe,
 					server.stats,
-					lite::Version::Lite05Wip,
+					lite::Version::Lite05,
 					our_setup,
 					Some(client_setup),
 				)?;
-				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw));
+				return Ok(Session::new(session, lite::Version::Lite05.into(), recv_bw));
 			}
 			Handshake::Legacy {
 				session,
@@ -448,7 +448,7 @@ mod tests {
 		sync::{Arc, Mutex},
 	};
 
-	use crate::ALPN_LITE_05_WIP;
+	use crate::ALPN_LITE_05;
 	use bytes::Bytes;
 
 	#[derive(Debug, Clone, Default)]
@@ -562,7 +562,7 @@ mod tests {
 
 	/// Encode a lite-05 Setup Stream: the `DataType::Setup` tag then the SETUP message.
 	fn lite05_setup(path: Option<&str>) -> Vec<u8> {
-		let v = lite::Version::Lite05Wip;
+		let v = lite::Version::Lite05;
 		let mut buf = Vec::new();
 		lite::DataType::Setup.encode(&mut buf, v).unwrap();
 		lite::Setup {
@@ -577,22 +577,20 @@ mod tests {
 	/// Encode a lite-05 GROUP uni stream header (just the `DataType::Group` tag).
 	fn lite05_group() -> Vec<u8> {
 		let mut buf = Vec::new();
-		lite::DataType::Group
-			.encode(&mut buf, lite::Version::Lite05Wip)
-			.unwrap();
+		lite::DataType::Group.encode(&mut buf, lite::Version::Lite05).unwrap();
 		buf
 	}
 
 	#[tokio::test(start_paused = true)]
 	async fn accept_request_reads_lite05_path() {
-		let session = FakeSession::new(ALPN_LITE_05_WIP, [lite05_setup(Some("/team/room"))]);
+		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(Some("/team/room"))]);
 		let request = Server::new().accept_request(session).await.unwrap();
 		assert_eq!(request.path(), Some("/team/room"));
 	}
 
 	#[tokio::test(start_paused = true)]
 	async fn accept_request_lite05_without_path_is_none() {
-		let session = FakeSession::new(ALPN_LITE_05_WIP, [lite05_setup(None)]);
+		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(None)]);
 		let request = Server::new().accept_request(session).await.unwrap();
 		assert_eq!(request.path(), None);
 	}
@@ -601,7 +599,7 @@ mod tests {
 	async fn accept_request_skips_uni_stream_before_setup() {
 		// A GROUP racing ahead of the SETUP is STOP_SENDING-ed and skipped; the gate
 		// keeps reading until it finds the SETUP.
-		let session = FakeSession::new(ALPN_LITE_05_WIP, [lite05_group(), lite05_setup(Some("/team/room"))]);
+		let session = FakeSession::new(ALPN_LITE_05, [lite05_group(), lite05_setup(Some("/team/room"))]);
 		let request = Server::new().accept_request(session).await.unwrap();
 		assert_eq!(request.path(), Some("/team/room"));
 	}

--- a/rs/moq-net/src/version.rs
+++ b/rs/moq-net/src/version.rs
@@ -16,12 +16,8 @@ pub(crate) const NEGOTIATED: [Version; 3] = [
 
 /// ALPN strings for supported versions, most-preferred first. `ALPNS[0]` is the
 /// newest moq-lite ALPN that both sides converge on.
-///
-/// Includes `ALPN_LITE_05_WIP` so the demo and end-to-end tests negotiate lite-05
-/// by default. lite-05 is still work-in-progress; revisit this default before
-/// promoting the branch to `main`.
 pub const ALPNS: &[&str] = &[
-	ALPN_LITE_05_WIP,
+	ALPN_LITE_05,
 	ALPN_LITE_04,
 	ALPN_LITE_03,
 	ALPN_LITE,
@@ -37,7 +33,7 @@ pub const ALPNS: &[&str] = &[
 pub(crate) const ALPN_LITE: &str = "moql";
 pub(crate) const ALPN_LITE_03: &str = "moq-lite-03";
 pub(crate) const ALPN_LITE_04: &str = "moq-lite-04";
-pub(crate) const ALPN_LITE_05_WIP: &str = "moq-lite-05-wip";
+pub(crate) const ALPN_LITE_05: &str = "moq-lite-05";
 pub(crate) const ALPN_14: &str = "moq-00";
 pub(crate) const ALPN_15: &str = "moqt-15";
 pub(crate) const ALPN_16: &str = "moqt-16";
@@ -61,7 +57,7 @@ impl Version {
 			0xff0dad02 => Some(Self::Lite(lite::Version::Lite02)),
 			0xff0dad03 => Some(Self::Lite(lite::Version::Lite03)),
 			0xff0dad04 => Some(Self::Lite(lite::Version::Lite04)),
-			0xff0dad05 => Some(Self::Lite(lite::Version::Lite05Wip)),
+			0xff0dad05 => Some(Self::Lite(lite::Version::Lite05)),
 			0xff00000e => Some(Self::Ietf(ietf::Version::Draft14)),
 			0xff00000f => Some(Self::Ietf(ietf::Version::Draft15)),
 			0xff000010 => Some(Self::Ietf(ietf::Version::Draft16)),
@@ -79,7 +75,7 @@ impl Version {
 			Self::Lite(lite::Version::Lite02) => 0xff0dad02,
 			Self::Lite(lite::Version::Lite03) => 0xff0dad03,
 			Self::Lite(lite::Version::Lite04) => 0xff0dad04,
-			Self::Lite(lite::Version::Lite05Wip) => 0xff0dad05,
+			Self::Lite(lite::Version::Lite05) => 0xff0dad05,
 			Self::Ietf(ietf::Version::Draft14) => 0xff00000e,
 			Self::Ietf(ietf::Version::Draft15) => 0xff00000f,
 			Self::Ietf(ietf::Version::Draft16) => 0xff000010,
@@ -98,7 +94,7 @@ impl Version {
 			ALPN_LITE => None, // Multiple versions share this ALPN, need SETUP negotiation
 			ALPN_LITE_03 => Some(Self::Lite(lite::Version::Lite03)),
 			ALPN_LITE_04 => Some(Self::Lite(lite::Version::Lite04)),
-			ALPN_LITE_05_WIP => Some(Self::Lite(lite::Version::Lite05Wip)),
+			ALPN_LITE_05 => Some(Self::Lite(lite::Version::Lite05)),
 			ALPN_14 => Some(Self::Ietf(ietf::Version::Draft14)),
 			ALPN_15 => Some(Self::Ietf(ietf::Version::Draft15)),
 			ALPN_16 => Some(Self::Ietf(ietf::Version::Draft16)),
@@ -112,7 +108,7 @@ impl Version {
 	/// Returns the ALPN string for this version.
 	pub fn alpn(&self) -> &'static str {
 		match self {
-			Self::Lite(lite::Version::Lite05Wip) => ALPN_LITE_05_WIP,
+			Self::Lite(lite::Version::Lite05) => ALPN_LITE_05,
 			Self::Lite(lite::Version::Lite04) => ALPN_LITE_04,
 			Self::Lite(lite::Version::Lite03) => ALPN_LITE_03,
 			Self::Lite(lite::Version::Lite01 | lite::Version::Lite02) => ALPN_LITE,
@@ -169,7 +165,7 @@ impl FromStr for Version {
 			"moq-lite-02" => Ok(Self::Lite(lite::Version::Lite02)),
 			"moq-lite-03" => Ok(Self::Lite(lite::Version::Lite03)),
 			"moq-lite-04" => Ok(Self::Lite(lite::Version::Lite04)),
-			"moq-lite-05-wip" => Ok(Self::Lite(lite::Version::Lite05Wip)),
+			"moq-lite-05" => Ok(Self::Lite(lite::Version::Lite05)),
 			"moq-transport-14" => Ok(Self::Ietf(ietf::Version::Draft14)),
 			"moq-transport-15" => Ok(Self::Ietf(ietf::Version::Draft15)),
 			"moq-transport-16" => Ok(Self::Ietf(ietf::Version::Draft16)),
@@ -237,7 +233,7 @@ impl Versions {
 	/// All supported versions exposed by default.
 	pub fn all() -> Self {
 		Self(vec![
-			Version::Lite(lite::Version::Lite05Wip),
+			Version::Lite(lite::Version::Lite05),
 			Version::Lite(lite::Version::Lite04),
 			Version::Lite(lite::Version::Lite03),
 			Version::Lite(lite::Version::Lite02),

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -605,7 +605,7 @@ async fn internal_unix_round_trip() {
 /// the bidi stream for 14-16 and the uni Setup Stream for 17-18).
 fn path_versions() -> Vec<moq_net::Version> {
 	[
-		"moq-lite-05-wip",
+		"moq-lite-05",
 		"moq-transport-14",
 		"moq-transport-15",
 		"moq-transport-16",


### PR DESCRIPTION
## Summary

Promotes the work-in-progress `moq-lite-05` to its final, advertised form and fixes a wire-framing bug in FETCH found while reviewing the implementation against [draft-lcurley-moq-lite-05](https://www.ietf.org/archive/id/draft-lcurley-moq-lite-05.txt).

### 1. Remove `-wip`, advertise the real ALPN

Renames the provisional identifiers to the published names across Rust and JS:

- ALPN `moq-lite-05-wip` → **`moq-lite-05`** (`ALPN_LITE_05_WIP` → `ALPN_LITE_05`; JS `ALPN_05_WIP` → `ALPN_05`)
- Enum `lite::Version::Lite05Wip` → **`Lite05`** (JS `DRAFT_05_WIP` → `DRAFT_05`)
- Wire version code `0xff0dad05` unchanged
- lite-05 stays first in `ALPNS` / `Versions::all()` / the JS WebTransport `protocols` list, so it is negotiated by default

Clean cutover with **no `-wip` alias** kept: it was an explicitly temporary experimental ALPN, so a peer speaking the old string simply won't negotiate.

### 2. Fix FETCH to match draft-05 §7.14

Our lite-05 FETCH encoded a 5th `frame_start` / `frameStart` varint that the spec does not define. §7.14 is exactly:

```
FETCH { Broadcast Path (s), Track Name (s), Subscriber Priority (8), Group Sequence (i) }
```

`frame_start` was a half-wired partial-fetch WIP feature: the wire field and the server-side skip loop existed, but the client always sent `0` and no public API ever set it. A relay speaking real `moq-lite-05` would have mis-framed every FETCH. Removed the field, its wire encode/decode, and the publisher skip logic; the publisher now streams the whole group (first-frame delta baseline from 0). The public `fetch_group` / `group::Fetch` surface and `group::get_frame` (used by the relay HTTP API) are unchanged.

### 3. Full spec re-review

Every other lite-05 message was reviewed directly against draft-05 and matches: SETUP (+Probe/Path params), ANNOUNCE_REQUEST/OK/BROADCAST, SUBSCRIBE, SUBSCRIBE_UPDATE, SUBSCRIBE_OK/END/DROP, TRACK, TRACK_INFO, PROBE, GOAWAY, GROUP, FRAME, DATAGRAM — plus the shared codecs: `Option<u64>` `+1` group mapping, `Duration` = milliseconds, zigzag timestamp deltas, and varint (not fixed-width) Hop IDs.

Two cosmetic, non-wire notes (no change made): the type-0x0 subscribe response is named `SubscribeStart` internally (spec calls it SUBSCRIBE_OK; wire-identical), and `ANNOUNCE_BROADCAST` status is read as a raw `u8` (byte-identical to the spec's `(i)` for values 0–2).

## Branch targeting

Targets **`dev`**: the ALPN rename and the `lite::Version::Lite05` public enum rename break existing published contracts (wire + public API), per the branch-targeting rules.

## Cross-package sync

`rs/moq-net` wire change is mirrored in `js/net` (ALPN/version rename + FETCH). Docs under `doc/` already use the `moq-lite-05` name and reference no frame offset, so no doc changes were needed.

## Test plan

- [x] `cargo test -p moq-net` — 429 pass (incl. rewritten `lite::fetch` round-trips)
- [x] `cargo test -p moq-native` ALPN + broadcast (incl. `broadcast_moq_lite_05_fetch_*` e2e over WebTransport, whole-group fetch with a negative zigzag delta)
- [x] `bun test` js/net `lite/` — pass; `fetch.test.ts` rewritten
- [x] rustfmt + biome clean
- [ ] `just check` not run locally (nix dev shell is broken on macOS via tsduck); relies on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)