### PR TITLE
fix(js/net): drop ineffective dynamic imports in ietf subscriber

### DIFF
--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -8,9 +8,9 @@ import { error } from "../util/error.ts";
 import type { Session } from "./adapter.ts";
 import { Frame, type Group as GroupMessage } from "./object.ts";
 import { type Publish, PublishError } from "./publish.ts";
-import type { PublishNamespace } from "./publish_namespace.ts";
+import { type PublishNamespace, PublishNamespaceError, PublishNamespaceOk } from "./publish_namespace.ts";
 import { RequestError, RequestOk } from "./request.ts";
-import { Subscribe, SubscribeOk, Unsubscribe } from "./subscribe.ts";
+import { Subscribe, SubscribeError, SubscribeOk, Unsubscribe } from "./subscribe.ts";
 import {
 	PublishBlocked,
 	SubscribeNamespace,
@@ -272,10 +272,7 @@ export class Subscriber {
 							// SubscribeError (v14) or RequestError (v15+)
 							const err =
 								version === Version.DRAFT_14
-									? await (await import("./subscribe.ts")).SubscribeError.decode(
-											stream.reader,
-											version,
-										)
+									? await SubscribeError.decode(stream.reader, version)
 									: await RequestError.decode(stream.reader, version);
 							reasonPhrase = `code=${err.errorCode} reason=${err.reasonPhrase}`;
 						}
@@ -311,7 +308,6 @@ export class Subscriber {
 		if (this.#announced.has(path)) {
 			console.warn("duplicate PublishNamespace");
 			if (version === Version.DRAFT_14) {
-				const { PublishNamespaceError } = await import("./publish_namespace.ts");
 				await stream.writer.u53(PublishNamespaceError.id);
 				const err = new PublishNamespaceError({
 					requestId: msg.requestId,
@@ -339,7 +335,6 @@ export class Subscriber {
 			// because consumers may trigger Subscribe writes that would
 			// interleave with our OK on the control stream.
 			if (version === Version.DRAFT_14) {
-				const { PublishNamespaceOk } = await import("./publish_namespace.ts");
 				await stream.writer.u53(PublishNamespaceOk.id);
 				const ok = new PublishNamespaceOk({ requestId: msg.requestId });
 				await ok.encode(stream.writer, version);


### PR DESCRIPTION
## Summary

The `@moq/demo` build emitted `INEFFECTIVE_DYNAMIC_IMPORT` warnings for `js/net/src/ietf/subscriber.ts`:

```
[INEFFECTIVE_DYNAMIC_IMPORT] .../ietf/publish_namespace.ts is dynamically imported by
.../ietf/subscriber.ts but also statically imported by connection.ts, control.ts,
index.ts, publisher.ts — dynamic import will not move module into another chunk.
[INEFFECTIVE_DYNAMIC_IMPORT] .../ietf/subscribe.ts ... (same)
```

`subscriber.ts` had four `await import(...)` calls, all on the `Version.DRAFT_14` legacy path, for `SubscribeError`, `PublishNamespaceError`, and `PublishNamespaceOk`. Those modules are already **statically** imported by sibling files (`connection.ts`, `control.ts`, `publisher.ts`, `index.ts`), so they're in the same bundle chunk. The dynamic imports never split anything off. They only deferred a lookup of already-loaded code, which is exactly what the warning called out.

This converts the four dynamic imports to static ones (widening the existing top-of-file imports; the `publish_namespace.ts` import was previously type-only).

## Why it's safe

- Neither `subscribe.ts` nor `publish_namespace.ts` imports `subscriber.ts`, directly or transitively — both only pull in leaf modules. So there was no circular-import reason for the laziness.
- Biome's `noImportCycles` lint (part of `just js check`) passes clean after the change, confirming no cycle was introduced by promoting the type-only import to a value import.
- Behavior is identical; only module-resolution timing changed, and since these modules are always resolved anyway that's not observable.

The two remaining `import()` sites in `js/` are intentional and left as-is: a type-only `import("@moq/net").Time.Milli` expression in moq-boy (erased at compile time), and the WebCodecs Opus polyfill in `hang/src/util/libav.ts` (a genuine, guarded lazy load of a heavy WASM codec).

## Branch targeting

Targets `main`: internal-only cleanup, no public API or wire-protocol change.

## Test plan

- [x] `just js check` passes across all packages (`@moq/net` and `@moq/demo` clean)
- [x] No `INEFFECTIVE_DYNAMIC_IMPORT` warnings expected from the demo build

(Written by Claude Opus 4.8)