### PR TITLE
feat(moq-rtmp,moq-srt): less aggressive default egress latency

### DIFF
--- a/rs/moq-cli/src/srt.rs
+++ b/rs/moq-cli/src/srt.rs
@@ -25,7 +25,7 @@ pub struct Args {
 	pub listen: Option<SocketAddr>,
 
 	/// SRT receive latency: the buffering delay traded for loss-recovery headroom.
-	#[arg(long, default_value = "200ms", value_parser = humantime::parse_duration)]
+	#[arg(long, default_value = "500ms", value_parser = humantime::parse_duration)]
 	pub latency: Duration,
 }
 

--- a/rs/moq-rtmp/src/dial.rs
+++ b/rs/moq-rtmp/src/dial.rs
@@ -66,7 +66,7 @@ pub struct Client<S = TcpStream> {
 	/// Session results queued during connect, drained by the first publish/pull.
 	work: VecDeque<ClientSessionResult>,
 	/// How long [`publish`](Self::publish)'s FLV muxer waits for a stalled group
-	/// before skipping. Zero (the default) drops stale groups aggressively.
+	/// before skipping. Defaults to [`DEFAULT_LATENCY`](crate::DEFAULT_LATENCY).
 	latency: Duration,
 }
 
@@ -145,13 +145,14 @@ impl<S: Stream> Client<S> {
 			stream,
 			session,
 			work,
-			latency: Duration::ZERO,
+			latency: crate::DEFAULT_LATENCY,
 		})
 	}
 
 	/// Set how long [`publish`](Self::publish)'s FLV muxer waits for a stalled group
 	/// before skipping to a newer one (the moq-level frame-drop latency). Defaults
-	/// to zero, which drops stale groups aggressively.
+	/// to [`DEFAULT_LATENCY`](crate::DEFAULT_LATENCY); pass [`Duration::ZERO`] to
+	/// drop stale groups aggressively.
 	pub fn with_latency(mut self, latency: Duration) -> Self {
 		self.latency = latency;
 		self

--- a/rs/moq-rtmp/src/lib.rs
+++ b/rs/moq-rtmp/src/lib.rs
@@ -59,6 +59,8 @@
 //! the vendored `rml` module (a fork of `rml_rtmp`), with no librtmp or ffmpeg
 //! dependency.
 
+use std::time::Duration;
+
 mod dial;
 mod error;
 mod flv;
@@ -66,6 +68,16 @@ mod listen;
 // Vendored fork of rml_rtmp; see the module docs.
 mod rml;
 mod server;
+
+/// Default FLV muxer latency: how long a stalled group is held before skipping to
+/// a newer one (the moq-level frame-drop latency).
+///
+/// RTMP is unpaced (tags go out as fast as the socket accepts them), so this
+/// bounds buffering rather than the wire rate. Zero would drop stale groups the
+/// instant a newer one arrives, which is too aggressive for RTMP's typical jitter,
+/// so the default holds a couple of seconds. Override per request with
+/// [`Play::with_latency`] / [`Client::with_latency`] or via [`Config::latency`].
+pub const DEFAULT_LATENCY: Duration = Duration::from_secs(2);
 
 pub use dial::Client;
 pub use error::{Error, Result};

--- a/rs/moq-rtmp/src/listen.rs
+++ b/rs/moq-rtmp/src/listen.rs
@@ -34,7 +34,7 @@ use crate::server::{Request, Server};
 /// options stay additive. Ingest is disabled (and [`run`] stays pending) unless
 /// [`listen`](Config::listen) is set, letting an embedding relay run without
 /// RTMP until it's configured.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct Config {
 	/// Address to listen on for RTMP ingest (e.g. `0.0.0.0:1935`). When `None`,
@@ -46,7 +46,8 @@ pub struct Config {
 	pub prefix: String,
 
 	/// How long a play's FLV muxer waits for a stalled group before skipping to a
-	/// newer one (the moq-level frame-drop latency). Zero (the default) drops
+	/// newer one (the moq-level frame-drop latency). Defaults to
+	/// [`DEFAULT_LATENCY`](crate::DEFAULT_LATENCY); set [`Duration::ZERO`] to drop
 	/// stale groups aggressively. Only affects egress (plays); ingest ignores it.
 	pub latency: Duration,
 
@@ -62,6 +63,19 @@ pub struct Config {
 	pub tls: Option<std::sync::Arc<rustls::ServerConfig>>,
 
 	active: ActivePaths,
+}
+
+impl Default for Config {
+	fn default() -> Self {
+		Self {
+			listen: None,
+			prefix: String::new(),
+			latency: crate::DEFAULT_LATENCY,
+			#[cfg(feature = "tls")]
+			tls: None,
+			active: ActivePaths::default(),
+		}
+	}
 }
 
 /// Run the RTMP listener until it fails, bridging each connection to `origin`:

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -502,7 +502,7 @@ pub struct Play<S = Conn> {
 	stream_key: String,
 	peer: SocketAddr,
 	/// How long the FLV muxer waits for a stalled group before skipping to a newer
-	/// one. Zero (the default) drops stale groups aggressively; raise it with
+	/// one. Defaults to [`DEFAULT_LATENCY`](crate::DEFAULT_LATENCY); override with
 	/// [`with_latency`](Self::with_latency).
 	latency: Duration,
 	/// Whether the player advertised enhanced-RTMP multitrack support (connect
@@ -531,9 +531,10 @@ impl<S: Stream> Play<S> {
 	}
 
 	/// Set how long the FLV muxer waits for a stalled group before skipping to a
-	/// newer one (the moq-level frame-drop latency). Defaults to zero, which drops
-	/// stale groups aggressively. RTMP is unpaced (tags go out as fast as the
-	/// socket accepts them), so this bounds buffering, not the wire rate.
+	/// newer one (the moq-level frame-drop latency). Defaults to
+	/// [`DEFAULT_LATENCY`](crate::DEFAULT_LATENCY). RTMP is unpaced (tags go out as
+	/// fast as the socket accepts them), so this bounds buffering, not the wire
+	/// rate. Pass [`Duration::ZERO`] to drop stale groups aggressively.
 	pub fn with_latency(mut self, latency: Duration) -> Self {
 		self.latency = latency;
 		self
@@ -736,7 +737,7 @@ async fn accept_until_request<S: Stream>(mut stream: S, peer: SocketAddr) -> any
 							app: app_name,
 							stream_key,
 							peer,
-							latency: Duration::ZERO,
+							latency: crate::DEFAULT_LATENCY,
 							multitrack: client_multitrack,
 						})));
 					}

--- a/rs/moq-srt/src/dial.rs
+++ b/rs/moq-srt/src/dial.rs
@@ -31,7 +31,7 @@ use crate::server::{DEFAULT_LATENCY, serve_publish, serve_subscribe};
 /// `origin` to MPEG-TS, and send it until the broadcast ends.
 ///
 /// `latency` is the SRT receive latency negotiated at handshake time; pass `None`
-/// for the default (200ms). This future resolves when the broadcast ends, so
+/// for the default (500ms). This future resolves when the broadcast ends, so
 /// callers usually run it on its own task.
 pub async fn publish(
 	addr: SocketAddr,
@@ -50,7 +50,7 @@ pub async fn publish(
 /// publish the result at `path` until the remote ends.
 ///
 /// `latency` is the SRT receive latency negotiated at handshake time; pass `None`
-/// for the default (200ms). This future resolves when the remote stream ends, so
+/// for the default (500ms). This future resolves when the remote stream ends, so
 /// callers usually run it on its own task.
 pub async fn pull(
 	addr: SocketAddr,

--- a/rs/moq-srt/src/server.rs
+++ b/rs/moq-srt/src/server.rs
@@ -34,7 +34,7 @@ use crate::Result;
 
 /// Default SRT receive latency: the negotiated buffer that trades delay for loss
 /// recovery. Override per-server with [`Server::bind`]'s `latency` argument.
-pub(crate) const DEFAULT_LATENCY: Duration = Duration::from_millis(200);
+pub(crate) const DEFAULT_LATENCY: Duration = Duration::from_millis(500);
 
 /// SRT payload size for egress: 7 MPEG-TS packets (7 x 188), the de-facto
 /// standard for TS-over-SRT and a clean fit under the typical SRT MTU.
@@ -59,7 +59,7 @@ impl Server {
 	/// Bind an SRT listener on `addr` (SRT has no well-known port; 9000 is common).
 	///
 	/// `latency` is the SRT receive latency, negotiated at handshake time; pass
-	/// `None` for a sensible default (200ms). It doubles as the egress skip
+	/// `None` for a sensible default (500ms). It doubles as the egress skip
 	/// threshold for [`Subscribe`] requests.
 	pub async fn bind(addr: SocketAddr, latency: impl Into<Option<Duration>>) -> Result<Self> {
 		let latency = latency.into().unwrap_or(DEFAULT_LATENCY);


### PR DESCRIPTION
## Summary

Live egress over RTMP and SRT was defaulting to latency budgets aggressive enough to skip groups under normal network jitter. This raises the defaults to sane values.

- **moq-rtmp**: the FLV muxer latency (how long a stalled group is held before skipping to a newer one) defaulted to `0s`, which drops a group the instant a newer one arrives. Too aggressive for RTMP's typical jitter. Now defaults to **2s** via a new documented `DEFAULT_LATENCY` const, applied uniformly to `Play` (egress), `Client` (dial-out publish), and `Config`. The derived `Default` on `Config` was silently giving `Duration::ZERO`, so it was replaced with a manual impl. Callers can still pass `Duration::ZERO` to opt back into aggressive dropping.
- **moq-srt**: raised `DEFAULT_LATENCY` from `200ms` to **500ms** (the SRT receive buffer, which doubles as the egress skip threshold), and bumped the `moq-cli` `--latency` default to match. Stale `(200ms)` mentions in doc comments updated.

## Why

`0s` (RTMP) and `200ms` (SRT) leave no headroom for jitter, so plays skip groups under normal network variance. `2s` / `500ms` trade a touch of latency for resilience, matching what RTMP/SRT players actually buffer.

## API changes

- **New (additive)**: `pub const moq_rtmp::DEFAULT_LATENCY`.
- No renamed/removed/signature-changed `pub` items. `moq-srt`'s `DEFAULT_LATENCY` is `pub(crate)`.
- Behavior-only default-value changes; no wire/protocol changes.

Per Branch Targeting this is additive/behavior (no broken contract), so it targets `main`.

## Test plan

- [x] `cargo build` across the workspace (`moq-rtmp`, `moq-srt`, `moq-cli`, `moq-mux`) green
- [x] `cargo clippy -p moq-rtmp -p moq-srt --all-targets` clean
- [x] `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)