### PR TITLE
fix(publish): announce="source" waits for captured media, not source selection

### DIFF
--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -9,7 +9,8 @@ type Observed = (typeof OBSERVED)[number];
 
 type SourceType = "camera" | "screen" | "file";
 
-// "always" announces immediately, "never" never announces, "source" waits until a source is selected.
+// "always" announces immediately, "never" never announces, "source" waits until media is
+// actually being captured (a live audio/video track, i.e. permission granted).
 // Defaults to "source" so we don't announce an empty broadcast with no audio/video.
 type AnnounceMode = "always" | "source" | "never";
 
@@ -90,8 +91,14 @@ export default class MoqPublish extends HTMLElement {
 		this.signals.run((effect) => {
 			const enabled = effect.get(this.#enabled);
 			const announce = effect.get(this.state.announce);
-			const hasSource = effect.get(this.state.source) !== undefined;
-			const announcing = announce === "always" || (announce === "source" && hasSource);
+			// "source" waits until media is actually being captured -- a live audio or
+			// video track exists -- not merely a source *type* selected. Otherwise we'd
+			// announce an empty broadcast while the getUserMedia/getDisplayMedia
+			// permission prompt is still pending (or after the user denies it).
+			const hasMedia =
+				effect.get(this.broadcast.video.source) !== undefined ||
+				effect.get(this.broadcast.audio.source) !== undefined;
+			const announcing = announce === "always" || (announce === "source" && hasMedia);
 			this.#publishEnabled.set(enabled && announcing);
 		});
 


### PR DESCRIPTION
## Problem

`<moq-publish announce="source">` announces (publishes) the broadcast the instant a source *type* is selected, because it gates on `state.source !== undefined`. `state.source` is set the moment the user clicks **Camera / Screen / File** — *before* the `getUserMedia`/`getDisplayMedia` permission prompt resolves.

So the broadcast is announced and shows up as "live" to subscribers while the permission prompt is still open, or even after the user denies it. (Concretely, this made a consuming dashboard fire a "you're live!" celebration before the user had granted camera access.)

## Fix

Gate `announce="source"` on the actual captured track instead of the selected source type — announce once `broadcast.video.source` or `broadcast.audio.source` is set, i.e. media is really flowing:

```ts
const hasMedia =
    effect.get(this.broadcast.video.source) !== undefined ||
    effect.get(this.broadcast.audio.source) !== undefined;
const announcing = announce === "always" || (announce === "source" && hasMedia);
```

Those signals are only set after `getUserMedia`/`getDisplayMedia` resolves, so we announce exactly when capture starts. This matches the documented intent of the mode ("so we don't announce an empty broadcast with no audio/video"). `"always"` and `"never"` are unchanged.

## Verification

Built the package and exercised it in a real browser:
- **Permission pending / denied** (no track): `broadcast.enabled` stays **false** — no announce. (Before this change it was `true`.)
- **Track present** (permission granted): flips **false → true** — announces.

`tsc --noEmit` and `vite build` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)