### PR TITLE
refactor(js/net)!: PascalCase the role-module namespaces

### DIFF
--- a/js/clock/src/main.ts
+++ b/js/clock/src/main.ts
@@ -76,7 +76,7 @@ async function publish(config: Config) {
 	console.log("✅ Connected to relay:", config.url);
 
 	// Create a new "broadcast", which is a collection of tracks.
-	const broadcast = new Moq.broadcast.Producer();
+	const broadcast = new Moq.Broadcast.Producer();
 	connection.publish(Moq.Path.from(config.broadcast), broadcast);
 
 	console.log("✅ Published broadcast:", config.broadcast);
@@ -96,7 +96,7 @@ async function publish(config: Config) {
 	}
 }
 
-async function publishTrack(track: Moq.track.Producer) {
+async function publishTrack(track: Moq.Track.Producer) {
 	// Send timestamps over the wire, matching the Rust implementation format
 	console.log("✅ Publishing clock data on track:", track.name);
 

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { group as NetGroup, track as NetTrack, Time, Varint } from "@moq/net";
+import { Group, Time, Track, Varint } from "@moq/net";
 import type { InitSegment } from "./cmaf/decode.ts";
 import { encodeDataSegment } from "./cmaf/encode.ts";
 import { Format as CmafFormat } from "./cmaf/format.ts";
@@ -135,8 +135,8 @@ function encodeLegacy(timestamp: Time.Micro): Uint8Array {
 	return data;
 }
 
-function writeGroupWithLegacyFrames(track: NetTrack.Producer, sequence: number, timestamps: Time.Micro[]) {
-	const group = new NetGroup.Producer(sequence);
+function writeGroupWithLegacyFrames(track: Track.Producer, sequence: number, timestamps: Time.Micro[]) {
+	const group = new Group.Producer(sequence);
 	for (const ts of timestamps) {
 		group.writeFrame({ data: encodeLegacy(ts), timestamp: Time.Timestamp.now() });
 	}
@@ -163,7 +163,7 @@ async function drainFrames(
 }
 
 test("Consumer delivers frames from a single group", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro, 33_000 as Time.Micro]);
@@ -177,7 +177,7 @@ test("Consumer delivers frames from a single group", async () => {
 });
 
 test("Consumer forces keyframe true at index 0", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro, 33_000 as Time.Micro]);
@@ -201,10 +201,10 @@ test("Consumer index spans MoQ frames for keyframe detection", async () => {
 		},
 	};
 
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: multiFormat, latency: 500 as Time.Milli });
 
-	const group = new NetGroup.Producer(0);
+	const group = new Group.Producer(0);
 	group.writeFrame({ data: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() }); // first MoQ frame → 3 samples
 	group.writeFrame({ data: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() }); // second MoQ frame → 3 samples
 	group.close();
@@ -229,19 +229,19 @@ test("Consumer keeps frames decoded before an error (truncated GoP)", async () =
 		},
 	};
 
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: truncatingFormat, latency: 500 as Time.Milli });
 
-	// NetGroup.Producer 0: 2 valid frames then a tail-truncating error.
-	const g0 = new NetGroup.Producer(0);
+	// Group.Producer 0: 2 valid frames then a tail-truncating error.
+	const g0 = new Group.Producer(0);
 	g0.writeFrame({ data: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() });
 	g0.writeFrame({ data: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() });
 	g0.writeFrame({ data: new Uint8Array([0xff]), timestamp: Time.Timestamp.now() });
 	g0.close();
 	track.writeGroup(g0);
 
-	// NetGroup.Producer 1 decodes cleanly.
-	const g1 = new NetGroup.Producer(1);
+	// Group.Producer 1 decodes cleanly.
+	const g1 = new Group.Producer(1);
 	g1.writeFrame({ data: new Uint8Array([0x04]), timestamp: Time.Timestamp.now() });
 	g1.close();
 	track.writeGroup(g1);
@@ -256,7 +256,7 @@ test("Consumer keeps frames decoded before an error (truncated GoP)", async () =
 });
 
 test("Consumer close returns undefined from next()", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	const promise = consumer.next();
@@ -267,7 +267,7 @@ test("Consumer close returns undefined from next()", async () => {
 });
 
 test("Consumer throws on concurrent next() calls", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	// First call blocks waiting for data
@@ -279,7 +279,7 @@ test("Consumer throws on concurrent next() calls", async () => {
 });
 
 test("Consumer skips groups via PTS-span when over latency", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	// Zero latency = skip everything that's not the latest
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 0 as Time.Milli });
 
@@ -299,7 +299,7 @@ test("Consumer skips groups via PTS-span when over latency", async () => {
 // --- Ordering ---
 
 test("Consumer delivers groups in sequence order regardless of arrival order", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 2, [60_000 as Time.Micro]);
@@ -318,16 +318,16 @@ test("Consumer delivers groups in sequence order regardless of arrival order", a
 });
 
 test("Consumer rejects stale groups", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
-	// NetGroup.Producer 5 arrives first (sets active = 5)
+	// Group.Producer 5 arrives first (sets active = 5)
 	writeGroupWithLegacyFrames(track, 5, [0 as Time.Micro]);
 	await new Promise((resolve) => setTimeout(resolve, 50));
 
-	// NetGroup.Producer 3 is stale
+	// Group.Producer 3 is stale
 	writeGroupWithLegacyFrames(track, 3, [100_000 as Time.Micro]);
-	// NetGroup.Producer 6 is valid
+	// Group.Producer 6 is valid
 	writeGroupWithLegacyFrames(track, 6, [30_000 as Time.Micro]);
 	track.close();
 
@@ -340,10 +340,10 @@ test("Consumer rejects stale groups", async () => {
 	consumer.close();
 });
 
-// --- NetGroup.Producer boundary signals ---
+// --- Group.Producer boundary signals ---
 
 test("Consumer next() returns group-done signals", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro, 33_000 as Time.Micro]);
@@ -374,7 +374,7 @@ test("Consumer next() returns group-done signals", async () => {
 // --- Buffered signal ---
 
 test("Consumer buffered signal updates as frames arrive", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 500 as Time.Milli });
 
 	expect(consumer.buffered.peek()).toEqual([]);
@@ -396,7 +396,7 @@ test("Consumer buffered signal updates as frames arrive", async () => {
 // --- Gap recovery ---
 
 test("Consumer recovers from gap in group sequence numbers", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 100 as Time.Milli });
 
 	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro, 20_000 as Time.Micro]);
@@ -426,10 +426,10 @@ test("Consumer handles empty decode result without deadlock", async () => {
 		},
 	};
 
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: emptyThenValid, latency: 500 as Time.Milli });
 
-	const group = new NetGroup.Producer(0);
+	const group = new Group.Producer(0);
 	group.writeFrame({ data: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() }); // empty decode
 	group.writeFrame({ data: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() }); // valid decode
 	group.close();
@@ -449,13 +449,13 @@ test("Consumer handles empty decode result without deadlock", async () => {
 // --- CMAF through Consumer ---
 
 test("Consumer with CmafFormat delivers correct timestamps", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), {
 		format: new CmafFormat(TEST_INIT),
 		latency: 500 as Time.Milli,
 	});
 
-	const group = new NetGroup.Producer(0);
+	const group = new Group.Producer(0);
 	group.writeFrame({
 		data: encodeDataSegment({
 			data: new Uint8Array([0xca, 0xfe]),
@@ -521,16 +521,16 @@ const durationFormat: ContainerFormat = {
 };
 
 test("Consumer duration-skips a stalled group once it is covered", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	// Latency dwarfs the gap, so only duration coverage can trigger the skip.
 	const consumer = new Consumer(track.subscribe(), { format: durationFormat, latency: 10_000 as Time.Milli });
 
-	// NetGroup.Producer 0: one frame at ts=0 lasting 33ms, never closed (stalled).
-	const g0 = new NetGroup.Producer(0);
+	// Group.Producer 0: one frame at ts=0 lasting 33ms, never closed (stalled).
+	const g0 = new Group.Producer(0);
 	g0.writeFrame({ data: new Uint8Array([0]), timestamp: Time.Timestamp.now() });
 
-	// NetGroup.Producer 1: closed, starts exactly where group 0's frame ends.
-	const g1 = new NetGroup.Producer(1);
+	// Group.Producer 1: closed, starts exactly where group 0's frame ends.
+	const g1 = new Group.Producer(1);
 	g1.writeFrame({ data: new Uint8Array([33]), timestamp: Time.Timestamp.now() });
 	g1.close();
 
@@ -559,15 +559,15 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 		},
 	};
 
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const consumer = new Consumer(track.subscribe(), { format: shortFormat, latency: 10_000 as Time.Milli });
 
-	// NetGroup.Producer 0 stays open and later receives a second frame; nothing covers the gap,
+	// Group.Producer 0 stays open and later receives a second frame; nothing covers the gap,
 	// so that late frame must survive rather than being skipped.
-	const g0 = new NetGroup.Producer(0);
+	const g0 = new Group.Producer(0);
 	g0.writeFrame({ data: new Uint8Array([0]), timestamp: Time.Timestamp.now() });
 
-	const g1 = new NetGroup.Producer(1);
+	const g1 = new Group.Producer(1);
 	g1.writeFrame({ data: new Uint8Array([33]), timestamp: Time.Timestamp.now() });
 	g1.close();
 

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -15,7 +15,7 @@ export interface ConsumerProps {
 }
 
 interface Group {
-	consumer: Moq.group.Consumer;
+	consumer: Moq.Group.Consumer;
 	frames: Frame[]; // decode order
 	latest?: Time.Micro; // The timestamp of the latest known frame
 	end?: Time.Micro; // The furthest presentation point so far, i.e. max(timestamp + duration)
@@ -76,7 +76,7 @@ class Rewind {
 
 /** Reads frames from a MoQ track in order, buffering groups and skipping slow ones to meet the latency target. */
 export class Consumer {
-	#track: Moq.track.Subscriber;
+	#track: Moq.Track.Subscriber;
 	#format: Format;
 	#latency: Getter<Time.Milli>;
 	#groups: Group[] = [];
@@ -93,7 +93,7 @@ export class Consumer {
 	#signals = new Effect();
 
 	/** Start consuming the given track, decoding frames with `props.format`. */
-	constructor(track: Moq.track.Subscriber, props: ConsumerProps) {
+	constructor(track: Moq.Track.Subscriber, props: ConsumerProps) {
 		this.#track = track;
 		this.#format = props.format;
 		this.#latency = getter(props.latency ?? Moq.Time.Milli.zero);

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -40,11 +40,11 @@ export function encodeFrame(source: Uint8Array | Source, timestamp: Time.Micro):
 
 /** Writes legacy-container frames into a MoQ track, starting a new group on each keyframe. */
 export class Producer {
-	#track: Moq.track.Producer;
-	#group?: Moq.group.Producer;
+	#track: Moq.Track.Producer;
+	#group?: Moq.Group.Producer;
 
 	/** Wrap a track to publish legacy-container frames into it. */
-	constructor(track: Moq.track.Producer) {
+	constructor(track: Moq.Track.Producer) {
 		this.#track = track;
 	}
 

--- a/js/json/src/compression.test.ts
+++ b/js/json/src/compression.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { Decoder } from "@moq/flate";
-import { track as NetTrack } from "@moq/net";
+import { Track } from "@moq/net";
 import { Consumer } from "./consumer.ts";
 import { Producer } from "./producer.ts";
 
@@ -10,14 +10,14 @@ const enc = new TextEncoder();
 const dec = new TextDecoder();
 
 // Reconstruct every value a compressed consumer yields, in order.
-async function drainCompressed(track: NetTrack.Subscriber): Promise<Value[]> {
+async function drainCompressed(track: Track.Subscriber): Promise<Value[]> {
 	const out: Value[] = [];
 	for await (const value of new Consumer<Value>(track, { compression: true })) out.push(value);
 	return out;
 }
 
 // The raw (stored) bytes of a track's first frame, without reconstructing JSON.
-async function firstFrame(track: NetTrack.Subscriber): Promise<Uint8Array> {
+async function firstFrame(track: Track.Subscriber): Promise<Uint8Array> {
 	const group = await track.nextGroup();
 	if (!group) throw new Error("expected a group");
 	const frame = await group.readFrame();
@@ -26,7 +26,7 @@ async function firstFrame(track: NetTrack.Subscriber): Promise<Uint8Array> {
 }
 
 // Count the groups a (finished) track published, draining each so the reads terminate.
-async function groupCount(track: NetTrack.Subscriber): Promise<number> {
+async function groupCount(track: Track.Subscriber): Promise<number> {
 	let groups = 0;
 	for (;;) {
 		const group = await track.nextGroup();
@@ -37,7 +37,7 @@ async function groupCount(track: NetTrack.Subscriber): Promise<number> {
 }
 
 test("compressed snapshot per group round-trips", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 0, compression: true });
 	producer.update({ a: 1 });
 	producer.update({ a: 2 });
@@ -49,7 +49,7 @@ test("compressed snapshot per group round-trips", async () => {
 
 test("compressed live consumer sees each update in order", async () => {
 	// A live consumer reconstructs each update in order from the shared per-group stream.
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100, compression: true });
 	const consumer = new Consumer<Value>(track.subscribe(), { compression: true });
 
@@ -60,7 +60,7 @@ test("compressed live consumer sees each update in order", async () => {
 });
 
 test("compressed deltas share one group and reconstruct", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100, compression: true });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
@@ -71,7 +71,7 @@ test("compressed deltas share one group and reconstruct", async () => {
 });
 
 test("compressed late joiner reconstructs from snapshot + deltas", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100, compression: true });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
@@ -85,7 +85,7 @@ test("compressed late joiner reconstructs from snapshot + deltas", async () => {
 test("a group's snapshot decodes from a fresh decoder", async () => {
 	// Frame 0 opens a cold window, so a brand-new decoder reconstructs it, which is what lets a late
 	// joiner (or the Rust consumer) start mid-stream at any group boundary.
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 0, compression: true });
 	producer.update({ hello: "world" });
 	producer.finish();
@@ -96,7 +96,7 @@ test("a group's snapshot decodes from a fresh decoder", async () => {
 
 test("compressed deltas reuse the window", async () => {
 	// The shared per-group window is the point: a delta restating snapshot content shrinks sharply.
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100, compression: true });
 	const phrase = "Media over QUIC delivers real-time latency at massive scale";
 	producer.update({ note: phrase });
@@ -116,9 +116,9 @@ test("compressed deltas reuse the window", async () => {
 test("compression shrinks a repetitive frame", async () => {
 	const value = { renditions: Array(3).fill("video".repeat(50)) };
 
-	const plain = new NetTrack.Producer("plain");
+	const plain = new Track.Producer("plain");
 	new Producer<Value>(plain, { deltaRatio: 0 }).update(value);
-	const compressed = new NetTrack.Producer("compressed");
+	const compressed = new Track.Producer("compressed");
 	new Producer<Value>(compressed, { deltaRatio: 0, compression: true }).update(value);
 
 	const plainLen = (await firstFrame(plain.subscribe())).length;
@@ -132,18 +132,18 @@ test("compressed deltas roll on the compressed budget", async () => {
 	// roll more than one group, and a late joiner must still rebuild the final value across the
 	// compressed group boundary. Guards against the budget regressing to raw lengths. Two identical
 	// producers (deterministic output) keep the group-count and reconstruction reads independent.
-	const fill = (track: NetTrack.Producer) => {
+	const fill = (track: Track.Producer) => {
 		const producer = new Producer<Value>(track, { deltaRatio: 2, compression: true });
 		for (let n = 0; n <= 40; n++) producer.update({ n });
 		producer.finish();
 	};
 
-	const layout = new NetTrack.Producer("layout");
+	const layout = new Track.Producer("layout");
 	const layoutSub = layout.subscribe();
 	fill(layout);
 	expect(await groupCount(layoutSub)).toBeGreaterThan(1);
 
-	const reconstruct = new NetTrack.Producer("reconstruct");
+	const reconstruct = new Track.Producer("reconstruct");
 	const reconstructSub = reconstruct.subscribe();
 	fill(reconstruct);
 	expect((await drainCompressed(reconstructSub)).at(-1)).toEqual({ n: 40 });

--- a/js/json/src/consumer.ts
+++ b/js/json/src/consumer.ts
@@ -12,18 +12,18 @@ import type { Config } from "./producer.ts";
  * collapses the buffered backlog and yields only the latest value. See {@link next}.
  */
 export class Consumer<T> {
-	#track: Moq.track.Subscriber;
+	#track: Moq.Track.Subscriber;
 	#schema?: z.ZodMiniType<T>;
 	// Whether frames are `deflate-raw` compressed. Must match the producer's {@link Config.compression}.
 	#decompress: boolean;
 
-	#group?: Moq.group.Consumer;
+	#group?: Moq.Group.Consumer;
 	// Per-group DEFLATE decoder, built lazily on the first frame of a group and reset at each boundary.
 	#decoder?: Decoder;
 	#current?: unknown;
 	#framesRead = 0;
 
-	constructor(track: Moq.track.Subscriber, config: Config<T> = {}) {
+	constructor(track: Moq.Track.Subscriber, config: Config<T> = {}) {
 		this.#track = track;
 		this.#schema = config.schema;
 		this.#decompress = config.compression ?? false;
@@ -61,7 +61,7 @@ export class Consumer<T> {
 			if (advanced) return value;
 
 			// Nothing buffered: block for the next frame (or the group's end).
-			let frame: Moq.group.Frame | undefined;
+			let frame: Moq.Group.Frame | undefined;
 			try {
 				frame = await this.#group.readFrame();
 			} catch {

--- a/js/json/src/json.test.ts
+++ b/js/json/src/json.test.ts
@@ -1,12 +1,12 @@
 import { expect, test } from "bun:test";
-import { track as NetTrack } from "@moq/net";
+import { Track } from "@moq/net";
 import { Consumer } from "./consumer.ts";
 import { Producer } from "./producer.ts";
 
 type Value = Record<string, unknown>;
 
 // Reconstruct every value a consumer yields, in order.
-async function drain(track: NetTrack.Subscriber): Promise<Value[]> {
+async function drain(track: Track.Subscriber): Promise<Value[]> {
 	const out: Value[] = [];
 	for await (const value of new Consumer<Value>(track)) out.push(value);
 	return out;
@@ -14,7 +14,7 @@ async function drain(track: NetTrack.Subscriber): Promise<Value[]> {
 
 // Inspect the published layout via the public API: the frame count of each group, in order.
 // The track must be finished first so group/frame reads terminate.
-async function structure(track: NetTrack.Subscriber): Promise<number[]> {
+async function structure(track: Track.Subscriber): Promise<number[]> {
 	const counts: number[] = [];
 	for (;;) {
 		const group = await track.nextGroup();
@@ -28,7 +28,7 @@ async function structure(track: NetTrack.Subscriber): Promise<number[]> {
 }
 
 test("deltas off: a snapshot group per change", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 0 });
 	producer.update({ a: 1 });
 	producer.update({ a: 2 });
@@ -39,7 +39,7 @@ test("deltas off: a snapshot group per change", async () => {
 });
 
 test("deltaRatio 0 disables deltas, like off", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 0 });
 	producer.update({ a: 1 });
 	producer.update({ a: 2 });
@@ -51,7 +51,7 @@ test("deltaRatio 0 disables deltas, like off", async () => {
 });
 
 test("live consumer sees each update", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track);
 	const consumer = new Consumer<Value>(track.subscribe());
 
@@ -62,7 +62,7 @@ test("live consumer sees each update", async () => {
 });
 
 test("unchanged value writes nothing", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track);
 	producer.update({ a: 1 });
 	producer.update({ a: 1 });
@@ -72,7 +72,7 @@ test("unchanged value writes nothing", async () => {
 });
 
 test("deltas share one group", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100 });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
@@ -84,7 +84,7 @@ test("deltas share one group", async () => {
 });
 
 test("deltas reconstruct to the final value", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100 });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
@@ -98,7 +98,7 @@ test("deltas reconstruct to the final value", async () => {
 // keys, and each call publishes. This is how the catalog producer is extended (e.g. an scte35
 // section) without a single owner having to rebuild the whole document.
 test("mutate composes independent owners", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { initial: {} });
 	const consumer = new Consumer<Value>(track.subscribe());
 
@@ -115,7 +115,7 @@ test("mutate composes independent owners", async () => {
 });
 
 test("mutate starts from the configured initial value", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { initial: {} });
 	const consumer = new Consumer<Value>(track.subscribe());
 
@@ -126,14 +126,14 @@ test("mutate starts from the configured initial value", async () => {
 });
 
 test("mutate without a prior value or initial throws", () => {
-	const producer = new Producer<Value>(new NetTrack.Producer("test"));
+	const producer = new Producer<Value>(new Track.Producer("test"));
 	expect(() => producer.mutate(() => {})).toThrow();
 });
 
 // Removing a section drops it from the reconstructed value, so a consumer detects the removal.
 // Exercised with deltas on to cover the merge-patch null-deletion path.
 test("mutate removes a section", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100, initial: {} });
 	const consumer = new Consumer<Value>(track.subscribe());
 
@@ -150,7 +150,7 @@ test("mutate removes a section", async () => {
 });
 
 test("tight ratio rolls snapshots", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	// A ratio of 1 budgets deltas up to one snapshot (equal 7-byte frames => 7 bytes). The gate checks
 	// the deltas already written, so the delta that tips the group over budget still lands (a one-frame
 	// overshoot): group 0 takes two deltas (14 bytes) before the fourth update rolls group 1.
@@ -165,7 +165,7 @@ test("tight ratio rolls snapshots", async () => {
 });
 
 test("deltas stay within ratio times snapshot", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	// The budget covers only the deltas, not the snapshot frame, measured against the group's snapshot
 	// size. Single-digit values keep every frame at a constant 7 bytes (`{"n":N}`), so a ratio of 8
 	// budgets 56 bytes of deltas. The gate checks the deltas already written, so the group keeps filling
@@ -179,7 +179,7 @@ test("deltas stay within ratio times snapshot", async () => {
 });
 
 test("array change is a wholesale delta", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100 });
 	producer.update({ list: [1, 2] });
 	producer.update({ list: [1, 2, 3] });
@@ -190,7 +190,7 @@ test("array change is a wholesale delta", async () => {
 });
 
 test("late joiner collapses a buffered backlog to the latest value", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 100 });
 	const subscriber = track.subscribe();
 	for (let n = 0; n <= 20; n++) {
@@ -204,7 +204,7 @@ test("late joiner collapses a buffered backlog to the latest value", async () =>
 });
 
 test("frame cap rolls snapshot", async () => {
-	const track = new NetTrack.Producer("test");
+	const track = new Track.Producer("test");
 	const producer = new Producer<Value>(track, { deltaRatio: 1_000_000 });
 	// First update is the snapshot; deltas fill the group until the frame cap forces a roll.
 	for (let i = 0; i <= 256; i++) {

--- a/js/json/src/producer.ts
+++ b/js/json/src/producer.ts
@@ -44,10 +44,10 @@ export interface Config<T> {
 
 /** Publishes a JSON value over a track, choosing snapshots and deltas automatically. */
 export class Producer<T> {
-	#track: Moq.track.Producer;
+	#track: Moq.Track.Producer;
 	#config: Config<T>;
 
-	#group?: Moq.group.Producer;
+	#group?: Moq.Group.Producer;
 	#last?: unknown;
 	// Bytes of deltas already written to the current group, excluding the snapshot frame. Compressed
 	// frame sizes when compressing, raw otherwise, matching {@link #snapshotLen} so the budget check is
@@ -63,7 +63,7 @@ export class Producer<T> {
 	#compress = false;
 	#encoder?: Encoder;
 
-	constructor(track: Moq.track.Producer, config: Config<T> = {}) {
+	constructor(track: Moq.Track.Producer, config: Config<T> = {}) {
 		this.#track = track;
 		this.#config = config;
 		this.#compress = config.compression ?? false;
@@ -174,7 +174,7 @@ export class Producer<T> {
 
 	// Write a group's snapshot (frame 0), returning the bytes written. On the compressed path this opens
 	// a fresh per-group encoder (cold window), so the snapshot and its deltas share one DEFLATE stream.
-	#writeSnapshot(group: Moq.group.Producer, frame: Uint8Array): number {
+	#writeSnapshot(group: Moq.Group.Producer, frame: Uint8Array): number {
 		let data = frame;
 		if (this.#compress) {
 			this.#encoder = new Encoder();
@@ -186,7 +186,7 @@ export class Producer<T> {
 
 	// Write a delta frame, compressed against the current group's encoder when compressing. Returns the
 	// bytes written.
-	#writeDelta(group: Moq.group.Producer, frame: Uint8Array): number {
+	#writeDelta(group: Moq.Group.Producer, frame: Uint8Array): number {
 		let data = frame;
 		if (this.#compress) {
 			if (!this.#encoder) throw new Error("compressed delta requires an open group");

--- a/js/loc/src/index.ts
+++ b/js/loc/src/index.ts
@@ -101,10 +101,10 @@ export interface Source {
  * bitstream payload.
  */
 export class Producer {
-	#track: Moq.track.Producer;
-	#group?: Moq.group.Producer;
+	#track: Moq.Track.Producer;
+	#group?: Moq.Group.Producer;
 
-	constructor(track: Moq.track.Producer) {
+	constructor(track: Moq.Track.Producer) {
 		this.#track = track;
 	}
 

--- a/js/moq-boy/src/game.ts
+++ b/js/moq-boy/src/game.ts
@@ -291,7 +291,7 @@ export class Game {
 		const viewerId = Math.random().toString(36).slice(2, 8);
 		this.viewerId.set(viewerId);
 
-		const viewerBroadcast = new Moq.broadcast.Producer();
+		const viewerBroadcast = new Moq.Broadcast.Producer();
 		conn.publish(Moq.Path.from(`${this.#viewerPrefix}/${this.sessionId}/${viewerId}`), viewerBroadcast);
 		effect.cleanup(() => {
 			viewerBroadcast.close();
@@ -315,7 +315,7 @@ export class Game {
 	}
 
 	#runCommandTrack(
-		track: Moq.track.Producer,
+		track: Moq.Track.Producer,
 		producer: Json.Producer<Record<string, unknown>>,
 		effect: Moq.Signals.Effect,
 	) {

--- a/js/msf/src/catalog.ts
+++ b/js/msf/src/catalog.ts
@@ -147,7 +147,7 @@ export function decode(raw: Uint8Array): Catalog {
 }
 
 /** Read and decode the next catalog frame from a track, or undefined if the track ended. */
-export async function fetch(track: Moq.track.Subscriber): Promise<Catalog | undefined> {
+export async function fetch(track: Moq.Track.Subscriber): Promise<Catalog | undefined> {
 	const frame = await track.readFrame();
 	if (!frame) return undefined;
 	return decode(frame);

--- a/js/net/examples/publish.ts
+++ b/js/net/examples/publish.ts
@@ -5,7 +5,7 @@ async function main() {
 	const connection = await Moq.Connection.connect(url);
 
 	// Create a broadcast (a collection of tracks)
-	const broadcast = new Moq.broadcast.Producer();
+	const broadcast = new Moq.Broadcast.Producer();
 
 	// Insert the "chat" track up front. A subscriber is served directly from this
 	// track, no requested() round-trip needed. Mirrors the Rust createTrack/insertTrack.
@@ -26,7 +26,7 @@ async function main() {
 	}
 }
 
-async function publishTrack(track: Moq.track.Producer) {
+async function publishTrack(track: Moq.Track.Producer) {
 	console.log("Publishing to track:", track.name);
 
 	// Create a group (e.g., keyframe boundary)

--- a/js/net/src/index.ts
+++ b/js/net/src/index.ts
@@ -8,20 +8,20 @@
 /** Re-export of {@link https://jsr.io/@moq/signals | @moq/signals}, the reactive primitives used throughout this package. */
 export * as Signals from "@moq/signals";
 /** Broadcast announcement streams. */
-export * as announce from "./announced.ts";
+export * as Announce from "./announced.ts";
 export * from "./bandwidth.ts";
 /** Broadcast role handles. */
-export * as broadcast from "./broadcast.ts";
+export * as Broadcast from "./broadcast.ts";
 /** Connection helpers: connect to or accept a MoQ session and reconnect on failure. */
 export * as Connection from "./connection/index.ts";
 export * from "./datagram.ts";
 /** Group role handles and frame helpers. */
-export * as group from "./group.ts";
+export * as Group from "./group.ts";
 /** Broadcast path utilities with delimiter-aware prefix matching. */
 export * as Path from "./path.ts";
 /** Branded time types (nanoseconds, microseconds, milliseconds, seconds) with conversions. */
 export * as Time from "./time.ts";
 /** Track role handles. */
-export * as track from "./track.ts";
+export * as Track from "./track.ts";
 /** QUIC variable-length integer encoding and decoding. */
 export * as Varint from "./varint.ts";

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -54,7 +54,7 @@ export function infoDefaults(info: Partial<Info> = {}): Info {
 }
 
 /**
- * A request for a track the peer wants, yielded by `broadcast.Producer.requested`.
+ * A request for a track the peer wants, yielded by `Broadcast.Producer.requested`.
  *
  * @public
  */
@@ -432,7 +432,7 @@ export class Producer {
 /**
  * The read side of a live track subscription, mirroring the Rust `Subscriber`.
  *
- * Obtained from `broadcast.Consumer.subscribe` / `track.Consumer.subscribe`, or from
+ * Obtained from `Broadcast.Consumer.subscribe` / `Track.Consumer.subscribe`, or from
  * {@link Producer.subscribe} for an in-process track. Reads the groups a
  * {@link Producer} on the same underlying state writes.
  */

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -273,7 +273,7 @@ export class Encoder {
 		}
 	}
 
-	serve(track: Moq.track.Producer, effect: Effect): void {
+	serve(track: Moq.Track.Producer, effect: Effect): void {
 		const values = effect.getAll([this.enabled, this.#worklet]);
 		if (!values) return;
 		const [_, worklet] = values;

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -34,7 +34,7 @@ export class Broadcast {
 	// offline. Exposed so an application can serve its own tracks alongside the built-in
 	// catalog/audio/video, e.g. `net.createTrack("meta.json")` plus a matching `catalog` section.
 	// Reacquire it via an effect, since reconnecting swaps in a fresh producer.
-	readonly net = new Signal<Moq.broadcast.Producer | undefined>(undefined);
+	readonly net = new Signal<Moq.Broadcast.Producer | undefined>(undefined);
 
 	signals = new Effect();
 
@@ -77,7 +77,7 @@ export class Broadcast {
 			);
 		}
 
-		const broadcast = new Moq.broadcast.Producer();
+		const broadcast = new Moq.Broadcast.Producer();
 		effect.cleanup(() => broadcast.close());
 
 		// Publish it before serving so an application reacting to `net` can insert its own tracks.
@@ -91,14 +91,14 @@ export class Broadcast {
 		effect.spawn(this.#runBroadcast.bind(this, broadcast, effect));
 	}
 
-	async #runBroadcast(broadcast: Moq.broadcast.Producer, effect: Effect) {
+	async #runBroadcast(broadcast: Moq.Broadcast.Producer, effect: Effect) {
 		for (;;) {
 			const request = await broadcast.requested();
 			if (!request) break;
 
 			// dev's reshape hands back a TrackRequest: switch on its name, reject unknown
 			// tracks, and accept the rest into a producer to serve.
-			let serve: ((track: Moq.track.Producer, effect: Effect) => void) | undefined;
+			let serve: ((track: Moq.Track.Producer, effect: Effect) => void) | undefined;
 			switch (request.name) {
 				case Broadcast.CATALOG_TRACK:
 					serve = (track, effect) => this.catalog.serve(track, effect);

--- a/js/publish/src/catalog.test.ts
+++ b/js/publish/src/catalog.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test";
 import type * as Catalog from "@moq/hang/catalog";
 import * as Json from "@moq/json";
-import { track as NetTrack } from "@moq/net";
+import { Track } from "@moq/net";
 import { Effect } from "@moq/signals";
 import { CatalogProducer } from "./catalog.ts";
 
@@ -14,7 +14,7 @@ test("catalog producer seeds subscribers and fans out edits", async () => {
 	});
 
 	const effect = new Effect();
-	const track = new NetTrack.Producer("catalog.json");
+	const track = new Track.Producer("catalog.json");
 	catalog.serve(track, effect);
 	const consumer = new Json.Consumer<Catalog.Root>(track.subscribe());
 
@@ -39,7 +39,7 @@ test("catalog producer publishes every update as a snapshot group", async () => 
 	});
 
 	const effect = new Effect();
-	const track = new NetTrack.Producer("catalog.json");
+	const track = new Track.Producer("catalog.json");
 	catalog.serve(track, effect);
 	const subscriber = track.subscribe();
 
@@ -69,12 +69,12 @@ test("a reconnecting subscriber is seeded with the full current catalog", async 
 
 	// The first subscription drains and ends...
 	const first = new Effect();
-	catalog.serve(new NetTrack.Producer("catalog.json"), first);
+	catalog.serve(new Track.Producer("catalog.json"), first);
 	first.close();
 
 	// ...and a fresh subscription still gets the current catalog, not nothing.
 	const effect = new Effect();
-	const track = new NetTrack.Producer("catalog.json");
+	const track = new Track.Producer("catalog.json");
 	catalog.serve(track, effect);
 	const seeded = await new Json.Consumer<Catalog.Root>(track.subscribe()).next();
 	expect(seeded?.video).toEqual({ renditions: {} });

--- a/js/publish/src/catalog.ts
+++ b/js/publish/src/catalog.ts
@@ -30,7 +30,7 @@ export class CatalogProducer {
 	 * Pass `opts.compression` to DEFLATE-compress this subscriber's frames, so the same catalog can be
 	 * served both plaintext and compressed (e.g. `catalog.json` and `catalog.json.z`).
 	 */
-	serve(track: Moq.track.Producer, effect: Effect, opts?: { compression?: boolean }): void {
+	serve(track: Moq.Track.Producer, effect: Effect, opts?: { compression?: boolean }): void {
 		const output = new Json.Producer<Catalog.Root>(track, {
 			compression: opts?.compression,
 			deltaRatio: 0,

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -88,7 +88,7 @@ export class Encoder {
 		this.#signals.run(this.#runDimensions.bind(this));
 	}
 
-	serve(track: Moq.track.Producer, effect: Effect): void {
+	serve(track: Moq.Track.Producer, effect: Effect): void {
 		if (!effect.get(this.enabled)) return;
 
 		const producer = new Container.Legacy.Producer(track);

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -219,7 +219,7 @@ export class Decoder {
 		}
 	}
 
-	#runLegacyDecoder(effect: Effect, sub: Moq.track.Subscriber, config: Catalog.AudioConfig): void {
+	#runLegacyDecoder(effect: Effect, sub: Moq.Track.Subscriber, config: Catalog.AudioConfig): void {
 		const format = config.container.kind === "loc" ? new Container.Loc.Format() : new Container.Legacy.Format();
 		// Create consumer with slightly less latency than the render worklet to avoid underflowing.
 		// TODO include JITTER_UNDERHEAD
@@ -303,7 +303,7 @@ export class Decoder {
 		});
 	}
 
-	#runCmafDecoder(effect: Effect, sub: Moq.track.Subscriber, config: Catalog.AudioConfig): void {
+	#runCmafDecoder(effect: Effect, sub: Moq.Track.Subscriber, config: Catalog.AudioConfig): void {
 		if (config.container.kind !== "cmaf") return; // just to help typescript
 
 		const initSegment = base64ToBytes(config.container.init);

--- a/js/watch/src/audio/mse.ts
+++ b/js/watch/src/audio/mse.ts
@@ -109,7 +109,7 @@ export class Mse implements Backend {
 
 	#runCmafMedia(
 		effect: Effect,
-		sub: Moq.track.Subscriber,
+		sub: Moq.Track.Subscriber,
 		config: Catalog.AudioConfig,
 		sourceBuffer: SourceBuffer,
 		element: HTMLMediaElement,
@@ -131,7 +131,7 @@ export class Mse implements Backend {
 				} catch (err) {
 					// Falling behind a group's eviction window drops frames; resync from
 					// the next group (a keyframe segment) rather than stopping playback.
-					if (err instanceof Moq.group.CacheFull) continue;
+					if (err instanceof Moq.Group.CacheFull) continue;
 					throw err;
 				}
 				if (!frame) return;
@@ -152,7 +152,7 @@ export class Mse implements Backend {
 
 	#runLegacyMedia(
 		effect: Effect,
-		sub: Moq.track.Subscriber,
+		sub: Moq.Track.Subscriber,
 		config: Catalog.AudioConfig,
 		sourceBuffer: SourceBuffer,
 		element: HTMLMediaElement,

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -51,7 +51,7 @@ type BroadcastInput = {
 
 type BroadcastOutput = {
 	status: Signal<Status>;
-	active: Signal<Moq.broadcast.Consumer | undefined>;
+	active: Signal<Moq.Broadcast.Consumer | undefined>;
 
 	// The effective catalog: the fetched one, or a copy of input.catalog in manual mode.
 	catalog: Signal<Catalog.Root | undefined>;
@@ -63,7 +63,7 @@ export class Broadcast {
 
 	readonly #output: BroadcastOutput = {
 		status: new Signal<Status>("offline"),
-		active: new Signal<Moq.broadcast.Consumer | undefined>(undefined),
+		active: new Signal<Moq.Broadcast.Consumer | undefined>(undefined),
 		catalog: new Signal<Catalog.Root | undefined>(undefined),
 	};
 	readonly output = readonlys(this.#output);

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -98,7 +98,7 @@ export class Decoder implements Backend {
 		}
 		const [_, broadcast, track, config] = values;
 
-		const active: Moq.broadcast.Consumer | undefined = effect.get(broadcast.output.active);
+		const active: Moq.Broadcast.Consumer | undefined = effect.get(broadcast.output.active);
 		if (!active) {
 			// Going offline should clear the last rendered frame.
 			this.#active.set(undefined);
@@ -215,7 +215,7 @@ export class Decoder implements Backend {
 
 interface DecoderTrackProps {
 	sync: Sync;
-	broadcast: Moq.broadcast.Consumer;
+	broadcast: Moq.Broadcast.Consumer;
 	track: string;
 	config: Catalog.VideoConfig;
 
@@ -224,7 +224,7 @@ interface DecoderTrackProps {
 
 class DecoderTrack {
 	sync: Sync;
-	broadcast: Moq.broadcast.Consumer;
+	broadcast: Moq.Broadcast.Consumer;
 	track: string;
 	config: RequiredDecoderConfig;
 	stats: Signal<Stats | undefined>;
@@ -321,7 +321,7 @@ class DecoderTrack {
 		}
 	}
 
-	#runLegacy(effect: Effect, sub: Moq.track.Subscriber, decoder: VideoDecoder): void {
+	#runLegacy(effect: Effect, sub: Moq.Track.Subscriber, decoder: VideoDecoder): void {
 		const format =
 			this.config.container.kind === "loc" ? new Container.Loc.Format() : new Container.Legacy.Format();
 		// Create consumer that reorders groups/frames up to the provided latency.
@@ -401,7 +401,7 @@ class DecoderTrack {
 		});
 	}
 
-	#runCmaf(effect: Effect, sub: Moq.track.Subscriber, decoder: VideoDecoder): void {
+	#runCmaf(effect: Effect, sub: Moq.Track.Subscriber, decoder: VideoDecoder): void {
 		if (this.config.container.kind !== "cmaf") return;
 
 		const initSegment = base64ToBytes(this.config.container.init);

--- a/js/watch/src/video/mse.ts
+++ b/js/watch/src/video/mse.ts
@@ -102,7 +102,7 @@ export class Mse implements Backend {
 
 	#runCmafMedia(
 		effect: Effect,
-		active: Moq.broadcast.Consumer,
+		active: Moq.Broadcast.Consumer,
 		track: string,
 		config: Catalog.VideoConfig,
 		sourceBuffer: SourceBuffer,
@@ -131,7 +131,7 @@ export class Mse implements Backend {
 				} catch (err) {
 					// Falling behind a group's eviction window drops frames; resync from
 					// the next group (a keyframe segment) rather than stopping playback.
-					if (err instanceof Moq.group.CacheFull) continue;
+					if (err instanceof Moq.Group.CacheFull) continue;
 					throw err;
 				}
 				if (!frame) return;
@@ -152,7 +152,7 @@ export class Mse implements Backend {
 
 	#runLegacyMedia(
 		effect: Effect,
-		active: Moq.broadcast.Consumer,
+		active: Moq.Broadcast.Consumer,
 		track: string,
 		config: Catalog.VideoConfig,
 		sourceBuffer: SourceBuffer,


### PR DESCRIPTION
## Summary

The `@moq/net` entrypoint mixed two casing conventions for its namespace exports: the utility namespaces (`Signals`, `Connection`, `Path`, `Time`, `Varint`) were PascalCase, while the four role modules that mirror the Rust crate (`broadcast`, `track`, `group`, `announce`) were lowercase. This PascalCases the role modules so the whole public surface is consistent:

| before | after |
|---|---|
| `Moq.broadcast` | `Moq.Broadcast` |
| `Moq.track` | `Moq.Track` |
| `Moq.group` | `Moq.Group` |
| `Moq.announce` | `Moq.Announce` |

- Only the public export names in `js/net/src/index.ts` change. The internal `import * as broadcast from "./broadcast.ts"` relative-import aliases inside `js/net/src` stay lowercase, since they match their filenames and aren't public surface.
- Every consumer is updated: `hang`, `json`, `loc`, `msf`, `publish`, `watch`, `moq-boy`, `clock`, and `net/examples`.
- Two published doc-comment cross-references in `track.ts` updated to the new names.
- The test files that imported `{ track as NetTrack }` / `{ group as NetGroup }` only aliased to avoid a collision with the old lowercase namespace and a local `track`/`group` variable. With the capitalized names there's no collision, so they now import `{ Track }` / `{ Group }` directly.

## Public API changes (breaking)

Renamed `@moq/net` namespace exports: `broadcast` → `Broadcast`, `track` → `Track`, `group` → `Group`, `announce` → `Announce`. This renames existing public exports, so per the branch-targeting rules it targets **`dev`**.

No Rust change: the Rust side keeps `broadcast::Consumer` etc. (snake_case is the correct Rust module convention). This was purely JS namespace casing, with no wire or catalog impact.

## Test plan

- [x] `@moq/net` type-checks + biome clean.
- [x] All 13 JS packages type-check green under worktree-consistent resolution (worked around the shared-`node_modules` limitation where this worktree otherwise resolves `@moq/net` to the main checkout).
- [x] Biome clean on all 24 changed files.
- [ ] CI runs the unit tests (they hit the same shared-`node_modules` resolution locally, so they're validated in CI).

(Written by Claude Opus 4.8)