### PR TITLE
refactor(moq-net): close request_broadcast dedup gap like request_track

### DIFF
--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1150,7 +1150,12 @@ impl Dynamic {
 		}))?;
 
 		let path = state.request_order.pop_front().expect("predicate guaranteed a request");
-		let producer = state.requests.remove(&path).expect("request_order out of sync");
+		// Leave the request in `requests` (only drain it from `request_order`) so a repeat
+		// request in the window between hand-off and accept coalesces onto it instead of
+		// re-invoking the handler. The producer is a shared clone; `Request::{accept, reject,
+		// drop}` removes the entry. This mirrors how `poll_requested_track` keeps a served
+		// track discoverable via the weak cache across the same window.
+		let producer = state.requests.get(&path).expect("request_order out of sync").clone();
 		Poll::Ready(Ok(Request {
 			path,
 			producer,
@@ -1215,10 +1220,12 @@ impl Request {
 	pub fn accept(self, broadcast: impl Consume<broadcast::Consumer>) {
 		let broadcast = broadcast.consume();
 
-		// Cache it weakly so repeat requests for this path share the same broadcast instead
-		// of asking the handler to serve (and subscribe upstream) again.
+		// Move the entry out of the in-flight queue and into the weak `served` cache, so repeat
+		// requests for this path share the same broadcast instead of asking the handler to serve
+		// (and subscribe upstream) again.
 		if let Ok(mut state) = self.state.write() {
 			state.served.insert(self.path.clone(), broadcast.weak());
+			state.requests.remove(&self.path);
 		}
 
 		if let Ok(mut pending) = self.producer.write() {
@@ -1229,8 +1236,22 @@ impl Request {
 
 	/// Reject the request, resolving every awaiting requester with `err`.
 	pub fn reject(self, err: Error) {
+		if let Ok(mut state) = self.state.write() {
+			state.requests.remove(&self.path);
+		}
 		if let Ok(mut state) = self.producer.write() {
 			state.resolved = Some(Err(err));
+		}
+	}
+}
+
+impl Drop for Request {
+	fn drop(&mut self) {
+		// Handed off but neither accepted nor rejected: drop the still-queued entry so its
+		// producer clone (plus this one) closes the channel, resolving coalesced requesters to
+		// `Unroutable` rather than hanging. A no-op after `accept`/`reject` already removed it.
+		if let Ok(mut state) = self.state.write() {
+			state.requests.remove(&self.path);
 		}
 	}
 }
@@ -3190,6 +3211,49 @@ mod tests {
 		assert_eq!(request.path(), &Path::new("fallback"));
 		request.accept(&served);
 		assert!(request_fut.await.unwrap().is_clone(&served.consume()));
+	}
+
+	// A repeat request in the window after the handler picks one up but before it accepts
+	// coalesces onto the in-flight request instead of queuing a duplicate.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_coalesces_after_handoff() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		let f1 = consumer.request_broadcast("fallback");
+		// Handler drains the request but has not accepted yet.
+		let request = dynamic.requested_broadcast().await.unwrap();
+
+		// A second request in this window must not queue another handler request.
+		let f2 = consumer.request_broadcast("fallback");
+		assert!(
+			dynamic.requested_broadcast().now_or_never().is_none(),
+			"a repeat request during hand-off must coalesce, not re-queue"
+		);
+
+		// Accepting resolves both awaiting requesters with the same broadcast.
+		let served = broadcast::Info::new().produce();
+		request.accept(&served);
+		assert!(f1.await.unwrap().is_clone(&served.consume()));
+		assert!(f2.await.unwrap().is_clone(&served.consume()));
+	}
+
+	// Dropping a handed-off request without accept/reject rejects every coalesced requester.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_dropped_after_handoff() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		let f1 = consumer.request_broadcast("fallback");
+		let request = dynamic.requested_broadcast().await.unwrap();
+		let f2 = consumer.request_broadcast("fallback");
+
+		// Abandon it; both requesters resolve to Unroutable instead of hanging.
+		drop(request);
+		assert!(matches!(f1.await, Err(Error::Unroutable)));
+		assert!(matches!(f2.await, Err(Error::Unroutable)));
 	}
 
 	// Rejecting a request resolves the requester with the error.

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1249,8 +1249,18 @@ impl Drop for Request {
 	fn drop(&mut self) {
 		// Handed off but neither accepted nor rejected: drop the still-queued entry so its
 		// producer clone (plus this one) closes the channel, resolving coalesced requesters to
-		// `Unroutable` rather than hanging. A no-op after `accept`/`reject` already removed it.
-		if let Ok(mut state) = self.state.write() {
+		// `Unroutable` rather than hanging.
+		//
+		// Guard on channel identity: `accept`/`reject` already removed our entry and released the
+		// lock before we run, so a concurrent request for the same path may have registered a
+		// *new* one here. Removing unconditionally would clobber it (stranding its requesters and
+		// desyncing `request_order` from `requests`), so only remove while it's still ours.
+		if let Ok(mut state) = self.state.write()
+			&& state
+				.requests
+				.get(&self.path)
+				.is_some_and(|producer| producer.same_channel(&self.producer))
+		{
 			state.requests.remove(&self.path);
 		}
 	}
@@ -3269,6 +3279,28 @@ mod tests {
 		request.reject(Error::Cancel);
 
 		assert!(matches!(request_fut.await, Err(Error::Cancel)));
+	}
+
+	// After a rejected hand-off, a fresh request for the same path reaches the handler again:
+	// the rejected `Request`'s removal + `Drop` leave `requests` and `request_order` consistent
+	// (a stale/clobbered entry would strand this request or panic the handler).
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_rerequest_after_reject() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		let f1 = consumer.request_broadcast("fallback");
+		dynamic.requested_broadcast().await.unwrap().reject(Error::Unroutable);
+		assert!(matches!(f1.await, Err(Error::Unroutable)));
+
+		// A fresh request re-reaches the handler and can be served.
+		let f2 = consumer.request_broadcast("fallback");
+		let request = dynamic.requested_broadcast().await.unwrap();
+		assert_eq!(request.path(), &Path::new("fallback"));
+		let served = broadcast::Info::new().produce();
+		request.accept(&served);
+		assert!(f2.await.unwrap().is_clone(&served.consume()));
 	}
 
 	// Dropping the last handler resolves queued requests with an error and reverts to


### PR DESCRIPTION
Follow-up to #1371 (which merged before this landed).

#1371 made `origin::Consumer::request_broadcast` weakly cache dynamically-served broadcasts by path (so the catalog and every rendition share one upstream subscription). This tightens that cache to match the `request_track` / `request_group` idiom.

## Problem

`request_broadcast` checked the weak `served` cache (like `broadcast::Consumer::track` checks `tracks`), but it removed the request from `requests` at hand-off (`poll_requested_broadcast`) and only populated `served` at accept. That left a window: a repeat request for the same path arriving between hand-off and accept found nothing in `requests` (removed) and nothing in `served` (not yet accepted), so it re-queued a duplicate handler request.

`poll_requested_track` avoids this by inserting the served track's weak into the cache **at hand-off**, so the dedup window never opens.

## Fix

Broadcasts are provided by the handler at accept (there's no pending broadcast state at hand-off to weak-reference, unlike a pending track). So instead of inserting a weak early, keep the request in `requests` until it's served:

- `poll_requested_broadcast` drains `request_order` but leaves the entry in `requests` (the producer is a shared `kio::Producer` clone), so a repeat request in the hand-off→accept window coalesces onto the in-flight one.
- `Request::accept` moves the entry into the weak `served` cache and removes it from `requests`; `Request::reject` removes it.
- `Request`'s new `Drop` removes a still-queued entry, so a request that's handed off but abandoned (neither accepted nor rejected) resolves coalesced requesters to `Unroutable` instead of hanging.

## Test plan

- [x] `dynamic_request_coalesces_after_handoff`: a repeat request after hand-off, before accept, coalesces (handler sees no second request); accept resolves both.
- [x] `dynamic_request_dropped_after_handoff`: abandoning a handed-off request rejects every coalesced requester with `Unroutable`.
- [x] Existing `dynamic_request_*` (coalesce, handler-dropped, accept-after-handler-dropped, dedups-served, reserves-after-close) still pass — 11 total.
- [x] `cargo test -p moq-net` (429) + clippy clean.

(Written by Claude Opus 4.8)