### PR TITLE
feat(js/net): dedupe conn.consume() per path so repeat subscribes share one broadcast

### DIFF
--- a/js/CLAUDE.md
+++ b/js/CLAUDE.md
@@ -66,6 +66,7 @@ Plain custom elements built directly on `@moq/signals`, no framework (except moq
 
 ## Conventions
 
+- **Avoid callback parameters.** A function taking a `fn`/`create`/`onXxx` to invoke later reads poorly and hides control flow. Prefer returning a value the caller acts on, exposing a method or getter, or splitting into a couple of small calls the caller sequences itself (e.g. a cache `get()` then `insert(value)`, not `getOrCreate(key, () => value)`). Reserve callbacks for genuine event/subscription sinks where there is no alternative (`effect.subscribe`, DOM listeners, `Signal` subscriptions).
 - ESM only (`"type": "module"`). Relative imports include the `.ts`/`.tsx` extension in the lower-level packages (`net`, `signals`, `hang`); `rewriteRelativeImportExtensions` in `tsconfig.json` rewrites them to `.js` on build. Some higher-level packages (watch/publish) still omit extensions, so match the file you are editing.
 - Document every exported symbol and add a top-of-file `@module` doc block to each entrypoint (root convention; the published JSR/`.d.ts` docs render these). Use `@public` on the load-bearing classes.
 - **Deprecation mechanics** (root Deprecation explains the why): mark a deprecated export `@internal` or drop it from the entrypoint re-exports so it falls off the published JSR/`.d.ts` docs. No "deprecated, use X" note in its doc comment.

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -57,6 +57,42 @@ test("a consumer clone shares the broadcast until every handle closes", () => {
 	expect(clone.closedSignal.peek()).toBeTruthy();
 });
 
+test("double-closing a consumer handle does not prematurely close the broadcast", () => {
+	const consumer = new BroadcastConsumer();
+	const clone = consumer.clone();
+
+	// The double close must decrement the shared count only once...
+	clone.close();
+	clone.close();
+	expect(consumer.closedSignal.peek()).toBeFalsy();
+
+	// ...so the broadcast still stays live until the other handle closes.
+	consumer.close();
+	expect(consumer.closedSignal.peek()).toBeTruthy();
+});
+
+test("consumer track subscriptions fan out and close independently", async () => {
+	const consumer = new BroadcastConsumer();
+
+	// Two subscriptions to one track dedupe onto a single upstream request...
+	const a = consumer.subscribe("video", 0);
+	const b = consumer.subscribe("video", 0);
+
+	const request = await pendingRequest(consumer);
+	if (!request) throw new Error("expected request");
+	expect(await pendingRequest(consumer)).toBeUndefined();
+
+	const producer = request.accept();
+	producer.writeString("one");
+	expect(await a.readString()).toBe("one");
+	expect(await b.readString()).toBe("one");
+
+	// ...and closing one subscriber leaves the other (and the shared upstream) delivering.
+	a.close();
+	producer.writeString("two");
+	expect(await b.readString()).toBe("two");
+});
+
 test("subscribe serves a statically inserted track without a request", async () => {
 	const broadcast = new BroadcastProducer();
 

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -7,11 +7,55 @@ import { Producer as TrackProducer } from "./track.ts";
 
 // Observe whether an on-demand track request is pending without blocking: returns the
 // next request if one has already been emitted, or undefined if none is (yet) waiting.
-async function pendingRequest(broadcast: BroadcastProducer): Promise<TrackRequest | undefined> {
+async function pendingRequest(broadcast: Pick<BroadcastProducer, "requested">): Promise<TrackRequest | undefined> {
 	const none = Symbol("none");
 	const result = await Promise.race([broadcast.requested(), Promise.resolve(none)]);
 	return result === none ? undefined : (result as TrackRequest | undefined);
 }
+
+test("consumer dedupes repeat subscriptions onto one upstream request", async () => {
+	const consumer = new BroadcastConsumer();
+
+	// Two subscriptions to the same track share one upstream subscription...
+	const a = consumer.track("video").subscribe();
+	const b = consumer.subscribe("video", 0);
+
+	const request = await pendingRequest(consumer);
+	expect(request?.name).toBe("video");
+	// ...so only one on-demand request is emitted for it.
+	expect(await pendingRequest(consumer)).toBeUndefined();
+
+	// Serving that single request fans out to both subscribers.
+	if (!request) throw new Error("expected request");
+	const producer = request.accept();
+	producer.writeString("hello");
+	expect(await a.readString()).toBe("hello");
+	expect(await b.readString()).toBe("hello");
+
+	// A different track still opens its own request.
+	consumer.subscribe("audio", 0);
+	expect((await pendingRequest(consumer))?.name).toBe("audio");
+
+	// Once the shared track closes, a later subscribe re-opens it.
+	producer.close();
+	consumer.subscribe("video", 0);
+	expect((await pendingRequest(consumer))?.name).toBe("video");
+});
+
+test("a consumer clone shares the broadcast until every handle closes", () => {
+	const consumer = new BroadcastConsumer();
+	const clone = consumer.clone();
+
+	// Closing one handle leaves the shared broadcast live for the other...
+	consumer.close();
+	expect(consumer.closedSignal.peek()).toBeFalsy();
+	expect(clone.closedSignal.peek()).toBeFalsy();
+
+	// ...and closing the last handle closes it for both.
+	clone.close();
+	expect(consumer.closedSignal.peek()).toBeTruthy();
+	expect(clone.closedSignal.peek()).toBeTruthy();
+});
 
 test("subscribe serves a statically inserted track without a request", async () => {
 	const broadcast = new BroadcastProducer();

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -7,6 +7,9 @@ class BroadcastState {
 	requested = new Signal<track.Request[]>([]);
 	closed = new Signal<boolean | Error>(false);
 	tracks = new Map<string, track.Producer>();
+	// Live consumer handles sharing this state (see {@link Consumer.clone}). The broadcast
+	// closes once the last one closes, so a shared consumer can be handed to several callers.
+	consumers = 0;
 }
 
 function closedPromise(state: BroadcastState): Promise<Error | undefined> {
@@ -30,7 +33,12 @@ function closeState(state: BroadcastState, abort?: Error) {
 	});
 }
 
-function subscribe(state: BroadcastState, name: string, priority: number): track.Subscriber {
+// `register` is set on the subscribing (consumer) side: the fresh producer is cached in
+// `state.tracks` so repeat subscriptions to the same track fan out from one upstream
+// subscription instead of opening a new one, mirroring the Rust `broadcast::Consumer::track`
+// weak-dedup. The publishing side leaves it false: `state.tracks` there holds only the tracks
+// the app inserted, and a dynamic serve stays one request per peer subscription.
+function subscribe(state: BroadcastState, name: string, priority: number, register = false): track.Subscriber {
 	if (state.closed.peek()) {
 		throw new Error(`broadcast is closed: ${state.closed.peek()}`);
 	}
@@ -43,6 +51,15 @@ function subscribe(state: BroadcastState, name: string, priority: number): track
 
 	const producer = new track.Producer(name);
 	const subscriber = producer.subscribe();
+
+	if (register) {
+		state.tracks.set(name, producer);
+		// Drop the cache entry once the subscription closes, so a later subscribe re-opens it.
+		void producer.closed.finally(() => {
+			if (state.tracks.get(name) === producer) state.tracks.delete(name);
+		});
+	}
+
 	state.requested.mutate((requested) => {
 		requested.push(new track.Request(name, producer, priority));
 		requested.sort((a, b) => a.priority - b.priority);
@@ -205,23 +222,54 @@ export class Producer implements track.Broadcast {
 export class Consumer implements track.Broadcast {
 	#state: BroadcastState;
 
+	// Guards against a double close() on this handle over-decrementing the consumer count.
+	#closed = false;
+
 	/** Resolves with the abort error (or undefined) once closed. */
 	readonly closed: Promise<Error | undefined>;
 
 	constructor(state?: never);
 	constructor(state?: BroadcastState) {
 		this.#state = state ?? new BroadcastState();
+		this.#state.consumers++;
 		this.closed = closedPromise(this.#state);
 	}
 
-	/** Get a lazy handle for a track on this broadcast. */
+	/**
+	 * Reactive closed state: `false` while open, `true` or the abort `Error` once closed.
+	 * Await {@link closed} (the promise) to block on it instead. The subscribing wire layer
+	 * reads this to evict a closed entry from its per-path consume cache.
+	 */
+	get closedSignal(): Signal<boolean | Error> {
+		return this.#state.closed;
+	}
+
+	/**
+	 * Return another handle to the same broadcast, reference-counted with this one.
+	 *
+	 * Both handles read the same tracks and share one {@link closed} state; the broadcast
+	 * closes only once *every* handle has {@link close}d. Used by the connection's per-path
+	 * consume cache to share one subscription across callers. Subclasses that resolve info over
+	 * the wire override this to preserve their type (see the wire layer's consumed broadcast).
+	 */
+	clone(): Consumer {
+		return new Consumer(this.shareState());
+	}
+
+	// Hand this consumer's backing state to a clone. Opaque (`never`) so the state type stays
+	// unexported; a subclass passes it straight back into its own `super(...)`.
+	protected shareState(): never {
+		return this.#state as never;
+	}
+
+	/** Get a lazy handle for a track on this broadcast. Repeat subscriptions dedupe onto one upstream subscription. */
 	track(name: string): track.Consumer {
 		return new track.Consumer(name, this);
 	}
 
-	/** Open a live subscription to a track. Used by the subscribing wire layer. */
+	/** Open a live subscription to a track. Used by the subscribing wire layer. Repeat subscriptions to the same track share one upstream subscription. */
 	subscribe(name: string, priority: number): track.Subscriber {
-		return subscribe(this.#state, name, priority);
+		return subscribe(this.#state, name, priority, true);
 	}
 
 	/** Return the next track requested by the local consumer. Used by the subscribing wire layer. */
@@ -255,8 +303,14 @@ export class Consumer implements track.Broadcast {
 		return fetchGroup(this.#state, name, sequence, options);
 	}
 
-	/** Close the broadcast, optionally with an error to abort waiters. */
+	/**
+	 * Release this handle. The broadcast is closed (optionally with an error to abort waiters)
+	 * once this was the last live handle; while other {@link clone}s remain open it stays live.
+	 */
 	close(abort?: Error) {
+		if (this.#closed) return;
+		this.#closed = true;
+		if (--this.#state.consumers > 0) return;
 		closeState(this.#state, abort);
 	}
 }

--- a/js/net/src/consume.ts
+++ b/js/net/src/consume.ts
@@ -1,0 +1,43 @@
+import type * as broadcast from "./broadcast.ts";
+import type * as Path from "./path.ts";
+
+/**
+ * Per-path dedup cache for consumed broadcasts, shared by the moq-lite and moq-ietf
+ * subscribers.
+ *
+ * `Connection.consume(path)` must not mint a fresh subscription per call: repeat requests
+ * for the same path (e.g. several renditions referencing one `broadcast: "../source"`) should
+ * share a single upstream subscription. This mirrors the Rust `origin::Consumer` weak-cache:
+ * a still-live path resolves to a shared {@link broadcast.Consumer.clone}, a closed one is
+ * re-consumed on the next request. Each handle is reference-counted, so the shared broadcast
+ * closes once every caller has closed its handle.
+ *
+ * @internal
+ */
+export class BroadcastCache {
+	// The base handle per path; callers get reference-counted clones of it.
+	#cache = new Map<Path.Valid, broadcast.Consumer>();
+
+	/** A shared handle to the live broadcast cached for `path`, or `undefined` on a miss. */
+	get(path: Path.Valid): broadcast.Consumer | undefined {
+		const base = this.#cache.get(path);
+		if (base && !base.closedSignal.peek()) return base.clone();
+		return undefined;
+	}
+
+	/**
+	 * Cache `consumer` as the base handle for `path` (evicting it once it closes) and return it.
+	 * Call on a {@link get} miss, after wiring up the fresh consumer's subscribe loop.
+	 */
+	insert(path: Path.Valid, consumer: broadcast.Consumer): broadcast.Consumer {
+		this.#cache.set(path, consumer);
+
+		// Drop the entry once the broadcast closes (every handle released), so the next request
+		// re-consumes rather than cloning a dead handle. Guard against a newer entry for the path.
+		void consumer.closed.finally(() => {
+			if (this.#cache.get(path) === consumer) this.#cache.delete(path);
+		});
+
+		return consumer;
+	}
+}

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -1,5 +1,6 @@
 import * as announce from "../announced.ts";
 import * as broadcast from "../broadcast.ts";
+import { BroadcastCache } from "../consume.ts";
 import * as netGroup from "../group.ts";
 import * as Path from "../path.ts";
 import type { Reader, Stream } from "../stream.ts";
@@ -49,6 +50,9 @@ export class Subscriber {
 	// Our subscribed tracks, keyed by trackAlias for group routing.
 	// trackAlias -> the write side; incoming object streams are routed here.
 	#subscribes = new Map<bigint, track.Producer>();
+
+	// Dedup consumed broadcasts per path: repeat consume() calls share one subscription.
+	#consumes = new BroadcastCache();
 
 	// Any currently active announcements.
 	#announced = new Set<Path.Valid>();
@@ -198,8 +202,16 @@ export class Subscriber {
 
 	/**
 	 * Consumes a broadcast from the connection.
+	 *
+	 * Deduplicated per path: repeat calls for the same still-live path share one reference-counted
+	 * broadcast (and one upstream subscription). The shared broadcast closes once every caller has
+	 * closed its handle, so callers close normally.
 	 */
 	consume(path: Path.Valid): broadcast.Consumer {
+		return this.#consumes.get(path) ?? this.#consumes.insert(path, this.#createConsume(path));
+	}
+
+	#createConsume(path: Path.Valid): broadcast.Consumer {
 		// moq-transport has no one-shot group fetch; ConsumeBroadcast rejects it. Track info
 		// is resolved by the subscribe path (the inherited resolveTrackInfo).
 		const consumer = new ConsumeBroadcast();
@@ -511,6 +523,11 @@ export class Subscriber {
  * group fetch, so `track.Consumer.fetchGroup()` is rejected.
  */
 class ConsumeBroadcast extends broadcast.Consumer {
+	// Preserve the subclass when the consume cache shares this broadcast across callers.
+	override clone(): ConsumeBroadcast {
+		return new ConsumeBroadcast(this.shareState());
+	}
+
 	override fetchGroup(): Promise<netGroup.Consumer> {
 		return Promise.reject(new Error("fetch group is not supported for moq-transport"));
 	}

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -246,6 +246,12 @@ test("integration: lite draft-05 coalesces concurrent fetches of one group", asy
 		expect(await fetched.readFrame()).toBeUndefined();
 	}
 
+	// After the coalesced fetch completes and its cache entry evicts, the same group re-fetches.
+	const again = await trackConsumer.fetchGroup(0);
+	expect(dec.decode((await again.readFrame())?.data)).toBe("alpha");
+	expect(dec.decode((await again.readFrame())?.data)).toBe("beta");
+	expect(await again.readFrame()).toBeUndefined();
+
 	broadcast.close();
 	remote.close();
 	client.close();

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -217,6 +217,41 @@ test("integration: lite draft-05 fetches a cached group", async () => {
 	server.close();
 });
 
+test("integration: lite draft-05 coalesces concurrent fetches of one group", async () => {
+	const enc = new TextEncoder();
+	const dec = new TextDecoder();
+	const pair = createMockTransportPair(Lite.ALPN_05);
+
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	const broadcast = new BroadcastProducer();
+	const producer = broadcast.createTrack("video");
+	server.publish(Path.from("test"), broadcast);
+
+	const group0 = producer.appendGroup();
+	group0.writeFrame({ data: enc.encode("alpha"), timestamp: Timestamp.fromMillis(10) });
+	group0.writeFrame({ data: enc.encode("beta"), timestamp: Timestamp.fromMillis(15) });
+	group0.close();
+
+	const remote = client.consume(Path.from("test"));
+	const trackConsumer = remote.track("video");
+
+	// Two concurrent fetches of the same group coalesce onto one FETCH stream; each reads an
+	// independent mirror that still sees the full group.
+	const [a, b] = await Promise.all([trackConsumer.fetchGroup(0), trackConsumer.fetchGroup(0)]);
+
+	for (const fetched of [a, b]) {
+		expect(dec.decode((await fetched.readFrame())?.data)).toBe("alpha");
+		expect(dec.decode((await fetched.readFrame())?.data)).toBe("beta");
+		expect(await fetched.readFrame()).toBeUndefined();
+	}
+
+	broadcast.close();
+	remote.close();
+	client.close();
+	server.close();
+});
+
 test("integration: lite draft-05 fetches an in-progress group", async () => {
 	const enc = new TextEncoder();
 	const dec = new TextDecoder();

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -290,6 +290,49 @@ test("integration: ietf draft-19", async () => {
 	await runPublishSubscribeFlow(Ietf.ALPN.DRAFT_19);
 });
 
+// consume(path) dedupes per path: repeat calls for a still-live path share one reference-counted
+// broadcast, so it stays live until every handle closes and a closed path re-consumes fresh.
+async function runConsumeDedup(protocol: string, version?: number) {
+	const pair = createMockTransportPair(protocol);
+	const [client, server] = await Promise.all([
+		connect(url, { transport: pair.client }),
+		accept(pair.server, url, version !== undefined ? { version } : undefined),
+	]);
+
+	// Two handles to the same path share one broadcast: closing the first leaves it live...
+	const first = client.consume(Path.from("shared"));
+	const second = client.consume(Path.from("shared"));
+	first.close();
+	expect(first.closedSignal.peek()).toBeFalsy();
+	expect(second.closedSignal.peek()).toBeFalsy();
+
+	// ...and closing the last handle closes the shared broadcast (both handles observe it).
+	second.close();
+	expect(first.closedSignal.peek()).toBeTruthy();
+	expect(second.closedSignal.peek()).toBeTruthy();
+
+	// A different path is independent: a lone handle closes the broadcast immediately.
+	const other = client.consume(Path.from("other"));
+	other.close();
+	expect(other.closedSignal.peek()).toBeTruthy();
+
+	// Once closed, the path re-consumes fresh (a new live handle).
+	const third = client.consume(Path.from("shared"));
+	expect(third.closedSignal.peek()).toBeFalsy();
+	third.close();
+
+	client.close();
+	server.close();
+}
+
+test("integration: lite consume dedup", async () => {
+	await runConsumeDedup(Lite.ALPN_05);
+});
+
+test("integration: ietf consume dedup", async () => {
+	await runConsumeDedup(Ietf.ALPN.DRAFT_17);
+});
+
 test("integration: subscribe to non-existent broadcast", async () => {
 	const pair = createMockTransportPair("");
 

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -96,6 +96,11 @@ export class Subscriber {
 	// Dedup consumed broadcasts per path: repeat consume() calls share one subscription.
 	#consumes = new BroadcastCache();
 
+	// Dedup in-flight one-shot fetches, keyed by [broadcast, track, sequence]. Concurrent (or
+	// repeat, while still open) fetchGroup() calls for the same group share one FETCH stream and
+	// each get an independent mirror; the entry is evicted once the group closes.
+	#fetches = new Map<string, netGroup.Producer>();
+
 	// Recv bandwidth producer (Lite03+ only).
 	#recvBandwidth?: Bandwidth;
 
@@ -410,33 +415,61 @@ export class Subscriber {
 
 	// Open a FETCH stream for one group and stream its bare frames into a group, for the
 	// ConsumeBroadcast backing track.Consumer.fetchGroup() (lite-05+).
-	async fetchGroup(
+	fetchGroup(
 		broadcast: Path.Valid,
 		track: string,
 		sequence: number,
 		options: track.FetchGroupOptions = {},
 	): Promise<netGroup.Consumer> {
-		if (!supportsTrackStream(this.version)) {
-			throw new Error("fetch group requires moq-lite-05 or newer");
-		}
+		// Coalesce onto a still-open fetch of the same group so we don't open a second FETCH
+		// stream (and re-download it); each caller reads an independent mirror.
+		const key = JSON.stringify([broadcast, track, sequence]);
+		const existing = this.#fetches.get(key);
+		if (existing && !existing.isClosed) return Promise.resolve(existing.mirror());
 
-		const info = await this.#trackInfo(broadcast, track);
-		const priority = options.priority ?? 0;
-		const stream = await Stream.open(this.#quic, undefined, priority);
+		// Create and cache the group synchronously (before any await) so a concurrent fetch for
+		// the same group finds it and coalesces rather than racing to open its own stream.
 		const group = new netGroup.Producer(sequence);
+		this.#fetches.set(key, group);
+		void group.closed.then(() => {
+			if (this.#fetches.get(key) === group) this.#fetches.delete(key);
+		});
 
+		return this.#runFetch(broadcast, track, sequence, options, group);
+	}
+
+	// Open the FETCH stream and pump the response into the shared group. Setup errors close the
+	// group (so coalesced mirrors observe them and the entry evicts) and reject this caller.
+	async #runFetch(
+		broadcast: Path.Valid,
+		track: string,
+		sequence: number,
+		options: track.FetchGroupOptions,
+		group: netGroup.Producer,
+	): Promise<netGroup.Consumer> {
 		try {
-			await stream.writer.u53(StreamId.Fetch);
-			await new FetchMessage(broadcast, track, priority, sequence).encode(stream.writer, this.version);
-		} catch (err: unknown) {
-			const e = error(err);
-			group.close(e);
-			stream.abort(e);
-			throw e;
-		}
+			if (!supportsTrackStream(this.version)) {
+				throw new Error("fetch group requires moq-lite-05 or newer");
+			}
 
-		void this.#runFetchResponse(stream, group, Time.Timescale(info.timescale));
-		return group.consume();
+			const info = await this.#trackInfo(broadcast, track);
+			const priority = options.priority ?? 0;
+			const stream = await Stream.open(this.#quic, undefined, priority);
+
+			try {
+				await stream.writer.u53(StreamId.Fetch);
+				await new FetchMessage(broadcast, track, priority, sequence).encode(stream.writer, this.version);
+			} catch (err: unknown) {
+				stream.abort(error(err));
+				throw err;
+			}
+
+			void this.#runFetchResponse(stream, group, Time.Timescale(info.timescale));
+			return group.mirror();
+		} catch (err: unknown) {
+			group.close(error(err));
+			throw err;
+		}
 	}
 
 	// Read the FETCH response (bare zigzag-delta-timestamped frames) into the group, then

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -2,6 +2,7 @@ import { Signal } from "@moq/signals";
 import * as announce from "../announced.ts";
 import type { Bandwidth } from "../bandwidth.ts";
 import * as broadcast from "../broadcast.ts";
+import { BroadcastCache } from "../consume.ts";
 import * as netGroup from "../group.ts";
 import * as Path from "../path.ts";
 import { type Reader, Stream } from "../stream.ts";
@@ -91,6 +92,9 @@ export class Subscriber {
 	// before decoding any frame, since a group's QUIC stream can race ahead.
 	#subscribes = new Map<bigint, SubscribeEntry>();
 	#subscribeNext = 0n;
+
+	// Dedup consumed broadcasts per path: repeat consume() calls share one subscription.
+	#consumes = new BroadcastCache();
 
 	// Recv bandwidth producer (Lite03+ only).
 	#recvBandwidth?: Bandwidth;
@@ -215,10 +219,18 @@ export class Subscriber {
 	/**
 	 * Consumes a broadcast from the connection.
 	 *
+	 * Deduplicated per path: repeat calls for the same still-live path share one reference-counted
+	 * broadcast (and one upstream subscription). The shared broadcast closes once every caller has
+	 * closed its handle, so callers close normally.
+	 *
 	 * @param name - The name of the broadcast to consume
 	 * @returns A Broadcast instance
 	 */
 	consume(path: Path.Valid): broadcast.Consumer {
+		return this.#consumes.get(path) ?? this.#consumes.insert(path, this.#createConsume(path));
+	}
+
+	#createConsume(path: Path.Valid): broadcast.Consumer {
 		// A consumed broadcast resolves info() and fetchGroup() over the wire by reaching
 		// back into this Subscriber (see ConsumeBroadcast below), rather than the wire
 		// installing callbacks on the broadcast.
@@ -713,10 +725,16 @@ class ConsumeBroadcast extends broadcast.Consumer {
 	#subscriber: Subscriber;
 	#path: Path.Valid;
 
-	constructor(subscriber: Subscriber, path: Path.Valid) {
-		super();
+	constructor(subscriber: Subscriber, path: Path.Valid, state?: never) {
+		super(state);
 		this.#subscriber = subscriber;
 		this.#path = path;
+	}
+
+	// Preserve the subclass (and its wire-backed info/fetchGroup) when the consume cache shares
+	// this broadcast across callers.
+	override clone(): ConsumeBroadcast {
+		return new ConsumeBroadcast(this.#subscriber, this.#path, this.shareState());
 	}
 
 	override resolveTrackInfo(name: string): Promise<track.Info> {


### PR DESCRIPTION
Closes #2121. Follow-up to #1371 (relative broadcast paths) and the JS mirror of the Rust weak-cache (`36a5d7c1b`).

## Problem

Consuming from `@moq/net` didn't deduplicate, unlike Rust (`origin::Consumer::request_broadcast` weak-cache + `broadcast::Consumer::track` weak-dedup): `Connection.consume(path)` minted a fresh consumer per call, `broadcast.track(name).subscribe()` opened a fresh upstream `SUBSCRIBE` per call, and concurrent `track.fetchGroup(seq)` opened a fresh FETCH stream per call.

## Change — dedup the whole ladder

**Broadcast (reference-counted).** Shared `BroadcastCache` (`js/net/src/consume.ts`) used by the `lite/` and `ietf/` subscribers: one base consumer per path; `get()` returns a `clone()` on a live hit, `insert()` caches + evicts-on-close (no callback). `broadcast.Consumer` is reference-counted: `clone()` shares one `BroadcastState`, `close()` decrements a shared count and tears down only at the last handle (a standalone consumer, count 1, unchanged). Callers keep closing normally. The wire-backed `ConsumeBroadcast` subclasses override `clone()` so shared handles keep resolving `info()`/`fetchGroup()` over the wire. Added `Consumer.closedSignal` for the cache's synchronous liveness check.

**Track.** The consumer side never registered its per-track producer into `state.tracks`, so the reuse check in `subscribe()` only fired for publisher-inserted tracks. Register consumer-created producers (scoped via a `register` flag so the publisher's dynamic-serve path is unchanged), evicting on close, so repeat subscriptions fan out from one producer / one upstream subscription; a closed track re-opens next subscribe.

**Groups.** Live groups already fan out to every track subscriber via the producer's mirror (frame bytes shared by reference), so track dedup covers them. The one duplicate path was the lite one-shot FETCH: cache the in-flight fetch producer per `[broadcast, track, sequence]` (created synchronously before the first await so a concurrent fetch coalesces), and hand each caller an independent `mirror()`; evict on close. moq-transport has no one-shot fetch.

**Frames** need no dedup: read sequentially within a group, and group fan-out already shares frame bytes by reference.

Also adds a `js/CLAUDE.md` convention to avoid callback parameters.

## Public API (`@moq/net`, additive)

`Broadcast.Consumer.clone()` and `Broadcast.Consumer.closedSignal`. `Connection.consume(path)` returns a reference-counted shared handle per live path; `broadcast.track(name).subscribe()` dedupes onto one upstream subscription; concurrent `track.fetchGroup(seq)` coalesce onto one FETCH. Targets `dev` (builds on #1371 / the `dev`-only #2120, #2032).

## Test plan

- [x] `bun test` in `js/net` (435 pass). New: `broadcast.test.ts` — repeat track subscriptions yield one request + clone refcount sharing; `integration.test.ts` — `lite`/`ietf consume dedup` (refcounted broadcast lifetime) and `lite` "coalesces concurrent fetches of one group" (two concurrent `fetchGroup(0)` both read the full group via independent mirrors).
- [x] `@moq/net` `check` (biome + tsc + tests) green.
- [ ] `@moq/watch` full typecheck fails **locally only** (worktree resolves `@moq/net` to the main repo's stale copy); passes in CI.

(Written by Claude Opus 4.8)