### PR TITLE
auto-detect catalog bitrate (metrics owned by the generic Rendition)

### DIFF
--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -67,6 +67,19 @@ impl Callback {
 		assert!(code <= 0, "expected terminal code <= 0, got {code}");
 		code
 	}
+
+	/// Like [`recv_terminal`](Self::recv_terminal), but first drains any mid-stream catalog
+	/// snapshot ids, freeing each. Auto-detected metrics (jitter, bitrate) republish the catalog
+	/// while frames flow, so the callback delivers extra snapshots before the terminal.
+	fn recv_catalog_terminal(&self) -> i32 {
+		loop {
+			let code = self.recv();
+			if code <= 0 {
+				return code;
+			}
+			assert_eq!(moq_consume_catalog_free(id(code)), 0);
+		}
+	}
 }
 
 impl Drop for Callback {
@@ -1237,7 +1250,11 @@ fn multiple_frames_ordering() {
 	assert_eq!(frame_cb.recv_terminal(), 0, "audio close delivers terminal 0");
 	assert_eq!(moq_consume_catalog_free(catalog_id), 0);
 	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
-	assert_eq!(catalog_cb.recv_terminal(), 0, "catalog close delivers terminal 0");
+	assert_eq!(
+		catalog_cb.recv_catalog_terminal(),
+		0,
+		"catalog close delivers terminal 0"
+	);
 	assert_eq!(moq_consume_close(consume), 0);
 	assert_eq!(moq_publish_media_close(media), 0);
 	assert_eq!(moq_publish_close(broadcast), 0);

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -1,7 +1,11 @@
 use std::marker::PhantomData;
+use std::time::Duration;
+
+use moq_net::Timestamp;
 
 use super::Producer;
 use super::hang::{Catalog, CatalogExt};
+use crate::container::jitter::Metrics;
 
 mod sealed {
 	pub trait Sealed {}
@@ -22,6 +26,13 @@ pub trait Kind: sealed::Sealed + 'static {
 	fn with_mut<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str, f: impl FnOnce(&mut Self::Config));
 	#[doc(hidden)]
 	fn remove<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str);
+
+	/// The config's detected-jitter field, so [`Rendition`] can update it generically.
+	#[doc(hidden)]
+	fn jitter_mut(config: &mut Self::Config) -> &mut Option<Duration>;
+	/// The config's bitrate field, so [`Rendition`] can update it generically.
+	#[doc(hidden)]
+	fn bitrate_mut(config: &mut Self::Config) -> &mut Option<u64>;
 }
 
 /// Video rendition marker for [`Rendition`] / [`Reserved::init`].
@@ -46,6 +57,13 @@ impl Kind for Video {
 	fn remove<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str) {
 		catalog.video.renditions.remove(name);
 	}
+
+	fn jitter_mut(config: &mut Self::Config) -> &mut Option<Duration> {
+		&mut config.jitter
+	}
+	fn bitrate_mut(config: &mut Self::Config) -> &mut Option<u64> {
+		&mut config.bitrate
+	}
 }
 
 impl Kind for Audio {
@@ -61,6 +79,13 @@ impl Kind for Audio {
 	}
 	fn remove<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str) {
 		catalog.audio.renditions.remove(name);
+	}
+
+	fn jitter_mut(config: &mut Self::Config) -> &mut Option<Duration> {
+		&mut config.jitter
+	}
+	fn bitrate_mut(config: &mut Self::Config) -> &mut Option<u64> {
+		&mut config.bitrate
 	}
 }
 
@@ -146,6 +171,8 @@ pub struct Rendition<E: CatalogExt, K: Kind> {
 	/// Whether a config has been published, so a lazily-configured importer (e.g. H.264 before its
 	/// SPS) holds the handle without a catalog entry, and drops without a spurious removal.
 	present: bool,
+	/// Detects jitter and bitrate from the frames fed in, keeping the config's fields current.
+	metrics: Metrics,
 	_kind: PhantomData<fn() -> K>,
 }
 
@@ -161,6 +188,7 @@ impl<E: CatalogExt, K: Kind> Rendition<E, K> {
 			gate: Some(reserved),
 			name: name.into(),
 			present: false,
+			metrics: Metrics::new(),
 			_kind: PhantomData,
 		}
 	}
@@ -176,7 +204,17 @@ impl<E: CatalogExt, K: Kind> Rendition<E, K> {
 	}
 
 	/// Insert or replace the rendition, fulfilling the reservation and publishing the catalog.
-	pub fn set(&mut self, config: K::Config) {
+	///
+	/// Seeds `config` with any metrics already accumulated: a dirty start or a B-frame reorder
+	/// can feed observations before the rendition exists, which would otherwise be lost.
+	pub fn set(&mut self, mut config: K::Config) {
+		if let Some(jitter) = self.metrics.jitter() {
+			*K::jitter_mut(&mut config) = Some(jitter);
+		}
+		if let Some(bitrate) = self.metrics.bitrate() {
+			raise_bitrate(K::bitrate_mut(&mut config), bitrate);
+		}
+
 		// Write the config first (still withheld, since we're holding our reservation), then release
 		// the reservation. If this was the last one, the release flushes a complete snapshot.
 		{
@@ -187,13 +225,41 @@ impl<E: CatalogExt, K: Kind> Rendition<E, K> {
 		self.gate = None;
 	}
 
-	/// Refine the rendition in place (e.g. observed jitter), publishing if present.
+	/// Refine the rendition in place (e.g. a synthesized description), publishing if present.
 	pub fn update(&mut self, f: impl FnOnce(&mut K::Config)) {
 		if !self.present {
 			return;
 		}
 		let mut guard = self.catalog.lock();
 		K::with_mut(&mut guard, &self.name, f);
+	}
+
+	/// Record one frame (presentation timestamp + encoded size), republishing the jitter if it changed.
+	pub fn observe_frame(&mut self, ts: Timestamp, bytes: usize) {
+		if let Some(jitter) = self.metrics.observe_frame(ts, bytes) {
+			self.update(|config| *K::jitter_mut(config) = Some(jitter));
+		}
+	}
+
+	/// Record a frame's reorder delay (`PTS - DTS`), republishing the jitter if it changed.
+	pub fn observe_reorder(&mut self, reorder: Timestamp) {
+		if let Some(jitter) = self.metrics.observe_reorder(reorder) {
+			self.update(|config| *K::jitter_mut(config) = Some(jitter));
+		}
+	}
+
+	/// Close the current group (`next` is its end timestamp when known), republishing the bitrate if it rose.
+	pub fn finish_group(&mut self, next: Option<Timestamp>) {
+		if let Some(bitrate) = self.metrics.finish_group(next) {
+			self.update(|config| raise_bitrate(K::bitrate_mut(config), bitrate));
+		}
+	}
+}
+
+/// Raise a catalog `bitrate` field, never lowering a larger declared or previously seen value.
+fn raise_bitrate(field: &mut Option<u64>, bitrate: u64) {
+	if field.is_none_or(|current| bitrate > current) {
+		*field = Some(bitrate);
 	}
 }
 

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -173,6 +173,10 @@ pub struct Rendition<E: CatalogExt, K: Kind> {
 	present: bool,
 	/// Detects jitter and bitrate from the frames fed in, keeping the config's fields current.
 	metrics: Metrics,
+	/// Auto-fill `jitter` from the detector only while the config hasn't provided it.
+	detect_jitter: bool,
+	/// Auto-fill `bitrate` from the detector only while the config hasn't provided it.
+	detect_bitrate: bool,
 	_kind: PhantomData<fn() -> K>,
 }
 
@@ -189,6 +193,8 @@ impl<E: CatalogExt, K: Kind> Rendition<E, K> {
 			name: name.into(),
 			present: false,
 			metrics: Metrics::new(),
+			detect_jitter: true,
+			detect_bitrate: true,
 			_kind: PhantomData,
 		}
 	}
@@ -205,14 +211,22 @@ impl<E: CatalogExt, K: Kind> Rendition<E, K> {
 
 	/// Insert or replace the rendition, fulfilling the reservation and publishing the catalog.
 	///
-	/// Seeds `config` with any metrics already accumulated: a dirty start or a B-frame reorder
-	/// can feed observations before the rendition exists, which would otherwise be lost.
+	/// A field the caller already set (`jitter` or `bitrate`) is treated as authoritative and left
+	/// alone; only an absent field is auto-detected. Any metrics accumulated before the rendition
+	/// existed (a dirty start or a B-frame reorder) are seeded into the fields being detected.
 	pub fn set(&mut self, mut config: K::Config) {
-		if let Some(jitter) = self.metrics.jitter() {
+		self.detect_jitter = K::jitter_mut(&mut config).is_none();
+		self.detect_bitrate = K::bitrate_mut(&mut config).is_none();
+
+		if self.detect_jitter
+			&& let Some(jitter) = self.metrics.jitter()
+		{
 			*K::jitter_mut(&mut config) = Some(jitter);
 		}
-		if let Some(bitrate) = self.metrics.bitrate() {
-			raise_bitrate(K::bitrate_mut(&mut config), bitrate);
+		if self.detect_bitrate
+			&& let Some(bitrate) = self.metrics.bitrate()
+		{
+			*K::bitrate_mut(&mut config) = Some(bitrate);
 		}
 
 		// Write the config first (still withheld, since we're holding our reservation), then release
@@ -234,29 +248,38 @@ impl<E: CatalogExt, K: Kind> Rendition<E, K> {
 		K::with_mut(&mut guard, &self.name, f);
 	}
 
-	/// Record one frame (presentation timestamp + encoded size), republishing the jitter if it changed.
-	pub fn observe_frame(&mut self, ts: Timestamp, bytes: usize) {
-		if let Some(jitter) = self.metrics.observe_frame(ts, bytes) {
+	/// Record one frame (presentation timestamp + encoded size), auto-filling the jitter if the
+	/// config didn't provide it and the detected value changed.
+	pub fn record_frame(&mut self, ts: Timestamp, bytes: usize) {
+		if let Some(jitter) = self.metrics.record_frame(ts, bytes)
+			&& self.detect_jitter
+		{
 			self.update(|config| *K::jitter_mut(config) = Some(jitter));
 		}
 	}
 
-	/// Record a frame's reorder delay (`PTS - DTS`), republishing the jitter if it changed.
-	pub fn observe_reorder(&mut self, reorder: Timestamp) {
-		if let Some(jitter) = self.metrics.observe_reorder(reorder) {
+	/// Record a frame's reorder delay (`PTS - DTS`), auto-filling the jitter as for
+	/// [`record_frame`](Self::record_frame).
+	pub fn record_reorder(&mut self, reorder: Timestamp) {
+		if let Some(jitter) = self.metrics.record_reorder(reorder)
+			&& self.detect_jitter
+		{
 			self.update(|config| *K::jitter_mut(config) = Some(jitter));
 		}
 	}
 
-	/// Close the current group (`next` is its end timestamp when known), republishing the bitrate if it rose.
-	pub fn finish_group(&mut self, next: Option<Timestamp>) {
-		if let Some(bitrate) = self.metrics.finish_group(next) {
+	/// Close the current group (`next` is its end timestamp when known), auto-filling the bitrate
+	/// if the config didn't provide it and the detected maximum rose.
+	pub fn record_group_end(&mut self, next: Option<Timestamp>) {
+		if let Some(bitrate) = self.metrics.finish_group(next)
+			&& self.detect_bitrate
+		{
 			self.update(|config| raise_bitrate(K::bitrate_mut(config), bitrate));
 		}
 	}
 }
 
-/// Raise a catalog `bitrate` field, never lowering a larger declared or previously seen value.
+/// Raise a catalog `bitrate` field, never lowering a previously detected value.
 fn raise_bitrate(field: &mut Option<u64>, bitrate: u64) {
 	if field.is_none_or(|current| bitrate > current) {
 		*field = Some(bitrate);
@@ -273,5 +296,74 @@ impl<E: CatalogExt, K: Kind> Drop for Rendition<E, K> {
 		}
 		// Our reservation (`gate`) drops here. If still held (never set), its release flushes any
 		// staged change; if already released by `set`, this is a no-op.
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn video_track() -> (
+		moq_net::broadcast::Producer,
+		super::super::Producer,
+		Rendition<(), Video>,
+	) {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = super::super::Producer::new(&mut broadcast).unwrap();
+		let reserved = catalog.reserve();
+		let rendition = reserved.video("v");
+		// Drop the standalone reservation so only the rendition's own gate remains, which `set`
+		// clears; the broadcast handle is returned so the produced tracks outlive the catalog.
+		drop(reserved);
+		(broadcast, catalog, rendition)
+	}
+
+	fn config(bitrate: Option<u64>, jitter: Option<Duration>) -> hang::catalog::VideoConfig {
+		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		config.bitrate = bitrate;
+		config.jitter = jitter;
+		config
+	}
+
+	fn ts(micros: u64) -> Timestamp {
+		Timestamp::from_micros(micros).unwrap()
+	}
+
+	/// Feed ~40ms 100 kB frames (one per group) over more than the bitrate window.
+	fn feed(rendition: &mut Rendition<(), Video>) {
+		for i in 0..60u64 {
+			let t = ts(i * 40_000);
+			rendition.record_group_end(Some(t));
+			rendition.record_frame(t, 100_000);
+		}
+		rendition.record_group_end(None);
+	}
+
+	#[test]
+	fn detects_absent_jitter_and_bitrate() {
+		let (_broadcast, catalog, mut rendition) = video_track();
+		rendition.set(config(None, None));
+		feed(&mut rendition);
+
+		let snapshot = catalog.snapshot();
+		let config = snapshot.video.renditions.get("v").unwrap();
+		assert!(config.jitter.is_some(), "absent jitter should be auto-detected");
+		assert!(config.bitrate.is_some(), "absent bitrate should be auto-detected");
+	}
+
+	#[test]
+	fn keeps_provided_jitter_and_bitrate() {
+		let (_broadcast, catalog, mut rendition) = video_track();
+		rendition.set(config(Some(123), Some(Duration::from_millis(50))));
+		feed(&mut rendition);
+
+		let snapshot = catalog.snapshot();
+		let config = snapshot.video.renditions.get("v").unwrap();
+		assert_eq!(config.bitrate, Some(123), "a provided bitrate must not be overwritten");
+		assert_eq!(
+			config.jitter,
+			Some(Duration::from_millis(50)),
+			"a provided jitter must not be overwritten"
+		);
 	}
 }

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -63,7 +63,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> crate::Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -76,7 +76,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -84,7 +84,7 @@ impl<E: CatalogExt> Import<E> {
 	/// Publish one AAC packet as its own group, stamping `pts` or a wall clock when absent.
 	pub fn decode<B: moq_net::IntoBytes>(&mut self, frame: B, pts: Option<moq_net::Timestamp>) -> crate::Result<()> {
 		let timestamp = self.rendition.timestamp(pts)?;
-		self.rendition.finish_group(Some(timestamp));
+		self.rendition.record_group_end(Some(timestamp));
 		let bytes = frame.as_ref().len();
 		self.track.write(Frame {
 			timestamp,
@@ -93,7 +93,7 @@ impl<E: CatalogExt> Import<E> {
 			duration: None,
 		})?;
 		self.track.finish_group()?;
-		self.rendition.observe_frame(timestamp, bytes);
+		self.rendition.record_frame(timestamp, bytes);
 		Ok(())
 	}
 }

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -63,6 +63,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> crate::Result<()> {
+		self.rendition.finish_group(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -75,6 +76,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
+		self.rendition.finish_group(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -82,6 +84,8 @@ impl<E: CatalogExt> Import<E> {
 	/// Publish one AAC packet as its own group, stamping `pts` or a wall clock when absent.
 	pub fn decode<B: moq_net::IntoBytes>(&mut self, frame: B, pts: Option<moq_net::Timestamp>) -> crate::Result<()> {
 		let timestamp = self.rendition.timestamp(pts)?;
+		self.rendition.finish_group(Some(timestamp));
+		let bytes = frame.as_ref().len();
 		self.track.write(Frame {
 			timestamp,
 			payload: frame.into_bytes(),
@@ -89,6 +93,7 @@ impl<E: CatalogExt> Import<E> {
 			duration: None,
 		})?;
 		self.track.finish_group()?;
+		self.rendition.observe_frame(timestamp, bytes);
 		Ok(())
 	}
 }

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -19,7 +19,6 @@ use super::split::ObuIterator;
 use crate::Result;
 use crate::catalog::hang::CatalogExt;
 use crate::container::Frame;
-use crate::container::jitter::Jitter;
 
 /// A pure-publisher importer for AV1 with inline sequence headers.
 ///
@@ -32,7 +31,6 @@ pub struct Import<E: CatalogExt = ()> {
 	rendition: crate::catalog::VideoTrack<E>,
 	config: Option<hang::catalog::VideoConfig>,
 	last_seq: Option<Bytes>,
-	jitter: Jitter,
 }
 
 impl<E: CatalogExt> Import<E> {
@@ -44,7 +42,6 @@ impl<E: CatalogExt> Import<E> {
 			rendition,
 			config: None,
 			last_seq: None,
-			jitter: Jitter::new(),
 		}
 	}
 
@@ -201,6 +198,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> Result<()> {
+		self.rendition.finish_group(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -213,6 +211,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
+		self.rendition.finish_group(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -232,14 +231,18 @@ impl<E: CatalogExt> Import<E> {
 				return Err(Error::MissingSequenceHeader.into());
 			}
 
+			// A keyframe starts a new group: close the previous one for the bitrate detector.
+			if frame.keyframe {
+				self.rendition.finish_group(Some(frame.timestamp));
+			}
+
 			let pts = frame.timestamp;
+			let bytes = frame.payload.len();
 			// A pre-keyframe delta has no group to anchor it: the producer returns
 			// MissingKeyframe, which a caller joining mid-stream skips.
 			self.track.write(frame)?;
 
-			if let Some(jitter) = self.jitter.observe(pts) {
-				self.rendition.update(|c| c.jitter = Some(jitter));
-			}
+			self.rendition.observe_frame(pts, bytes);
 		}
 		Ok(())
 	}

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -198,7 +198,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -211,7 +211,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -233,7 +233,7 @@ impl<E: CatalogExt> Import<E> {
 
 			// A keyframe starts a new group: close the previous one for the bitrate detector.
 			if frame.keyframe {
-				self.rendition.finish_group(Some(frame.timestamp));
+				self.rendition.record_group_end(Some(frame.timestamp));
 			}
 
 			let pts = frame.timestamp;
@@ -242,7 +242,7 @@ impl<E: CatalogExt> Import<E> {
 			// MissingKeyframe, which a caller joining mid-stream skips.
 			self.track.write(frame)?;
 
-			self.rendition.observe_frame(pts, bytes);
+			self.rendition.record_frame(pts, bytes);
 		}
 		Ok(())
 	}

--- a/rs/moq-mux/src/codec/flac/import.rs
+++ b/rs/moq-mux/src/codec/flac/import.rs
@@ -51,6 +51,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> crate::Result<()> {
+		self.rendition.finish_group(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -63,6 +64,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
+		self.rendition.finish_group(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -70,6 +72,8 @@ impl<E: CatalogExt> Import<E> {
 	/// Publish one FLAC frame as its own group, stamping `pts` or a wall clock when absent.
 	pub fn decode<B: moq_net::IntoBytes>(&mut self, frame: B, pts: Option<moq_net::Timestamp>) -> crate::Result<()> {
 		let timestamp = self.rendition.timestamp(pts)?;
+		self.rendition.finish_group(Some(timestamp));
+		let bytes = frame.as_ref().len();
 		self.track.write(Frame {
 			timestamp,
 			payload: frame.into_bytes(),
@@ -77,6 +81,7 @@ impl<E: CatalogExt> Import<E> {
 			duration: None,
 		})?;
 		self.track.finish_group()?;
+		self.rendition.observe_frame(timestamp, bytes);
 		Ok(())
 	}
 }

--- a/rs/moq-mux/src/codec/flac/import.rs
+++ b/rs/moq-mux/src/codec/flac/import.rs
@@ -51,7 +51,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> crate::Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -64,7 +64,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -72,7 +72,7 @@ impl<E: CatalogExt> Import<E> {
 	/// Publish one FLAC frame as its own group, stamping `pts` or a wall clock when absent.
 	pub fn decode<B: moq_net::IntoBytes>(&mut self, frame: B, pts: Option<moq_net::Timestamp>) -> crate::Result<()> {
 		let timestamp = self.rendition.timestamp(pts)?;
-		self.rendition.finish_group(Some(timestamp));
+		self.rendition.record_group_end(Some(timestamp));
 		let bytes = frame.as_ref().len();
 		self.track.write(Frame {
 			timestamp,
@@ -81,7 +81,7 @@ impl<E: CatalogExt> Import<E> {
 			duration: None,
 		})?;
 		self.track.finish_group()?;
-		self.rendition.observe_frame(timestamp, bytes);
+		self.rendition.record_frame(timestamp, bytes);
 		Ok(())
 	}
 }

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -119,7 +119,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing any buffered data.
 	pub fn finish(&mut self) -> Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -132,7 +132,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -141,7 +141,7 @@ impl<E: CatalogExt> Import<E> {
 	/// B-frame reorder depth (the decode buffer a transmuxer/player must hold). The
 	/// container supplies this since the elementary stream alone carries no decode time.
 	pub fn observe_reorder(&mut self, reorder: moq_net::Timestamp) {
-		self.rendition.observe_reorder(reorder);
+		self.rendition.record_reorder(reorder);
 	}
 
 	/// Resolve the avc3 config from an inline SPS, updating it in place.
@@ -206,14 +206,14 @@ impl<E: CatalogExt> Import<E> {
 
 			// A keyframe starts a new group: close the previous one for the bitrate detector.
 			if frame.keyframe {
-				self.rendition.finish_group(Some(frame.timestamp));
+				self.rendition.record_group_end(Some(frame.timestamp));
 			}
 
 			let pts = frame.timestamp;
 			let bytes = frame.payload.len();
 			self.track.write(frame)?;
 
-			self.rendition.observe_frame(pts, bytes);
+			self.rendition.record_frame(pts, bytes);
 		}
 		Ok(())
 	}

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -18,7 +18,6 @@ use crate::Result;
 use crate::catalog::hang::CatalogExt;
 use crate::codec::annexb::NalIterator;
 use crate::container::Frame;
-use crate::container::jitter::Jitter;
 
 /// H.264 importer: a pure frame publisher that resolves the catalog rendition.
 ///
@@ -35,7 +34,6 @@ pub struct Import<E: CatalogExt = ()> {
 	rendition: crate::catalog::VideoTrack<E>,
 	config: Option<hang::catalog::VideoConfig>,
 	last_sps: Option<Bytes>,
-	jitter: Jitter,
 }
 
 impl<E: CatalogExt> Import<E> {
@@ -48,7 +46,6 @@ impl<E: CatalogExt> Import<E> {
 			rendition,
 			config: None,
 			last_sps: None,
-			jitter: Jitter::new(),
 		}
 	}
 
@@ -122,6 +119,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing any buffered data.
 	pub fn finish(&mut self) -> Result<()> {
+		self.rendition.finish_group(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -134,6 +132,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
+		self.rendition.finish_group(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -142,9 +141,7 @@ impl<E: CatalogExt> Import<E> {
 	/// B-frame reorder depth (the decode buffer a transmuxer/player must hold). The
 	/// container supplies this since the elementary stream alone carries no decode time.
 	pub fn observe_reorder(&mut self, reorder: moq_net::Timestamp) {
-		if let Some(jitter) = self.jitter.observe_reorder(reorder) {
-			self.rendition.update(|c| c.jitter = Some(jitter));
-		}
+		self.rendition.observe_reorder(reorder);
 	}
 
 	/// Resolve the avc3 config from an inline SPS, updating it in place.
@@ -181,12 +178,6 @@ impl<E: CatalogExt> Import<E> {
 		}
 		tracing::debug!(?config, "starting H.264 track");
 		self.rendition.set(config.clone());
-		// Seed jitter from whatever has accumulated: a dirty start (or a B-frame
-		// reorder observed via observe_reorder) can feed updates before this
-		// rendition exists, so those would otherwise be lost on (re)publish.
-		if let Some(jitter) = self.jitter.current() {
-			self.rendition.update(|c| c.jitter = Some(jitter));
-		}
 		self.config = Some(config);
 	}
 
@@ -213,12 +204,16 @@ impl<E: CatalogExt> Import<E> {
 				}
 			}
 
+			// A keyframe starts a new group: close the previous one for the bitrate detector.
+			if frame.keyframe {
+				self.rendition.finish_group(Some(frame.timestamp));
+			}
+
 			let pts = frame.timestamp;
+			let bytes = frame.payload.len();
 			self.track.write(frame)?;
 
-			if let Some(jitter) = self.jitter.observe(pts) {
-				self.rendition.update(|c| c.jitter = Some(jitter));
-			}
+			self.rendition.observe_frame(pts, bytes);
 		}
 		Ok(())
 	}

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -81,7 +81,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -94,7 +94,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -103,7 +103,7 @@ impl<E: CatalogExt> Import<E> {
 	/// B-frame reorder depth (the decode buffer a transmuxer/player must hold). The
 	/// container supplies this since the elementary stream alone carries no decode time.
 	pub fn observe_reorder(&mut self, reorder: moq_net::Timestamp) {
-		self.rendition.observe_reorder(reorder);
+		self.rendition.record_reorder(reorder);
 	}
 
 	/// Resolve the config from an inline SPS, updating the rendition in place on a
@@ -164,7 +164,7 @@ impl<E: CatalogExt> Import<E> {
 
 			// A keyframe starts a new group: close the previous one for the bitrate detector.
 			if frame.keyframe {
-				self.rendition.finish_group(Some(frame.timestamp));
+				self.rendition.record_group_end(Some(frame.timestamp));
 			}
 
 			let pts = frame.timestamp;
@@ -173,7 +173,7 @@ impl<E: CatalogExt> Import<E> {
 			// MissingKeyframe, which the caller (e.g. a TS mid-stream join) skips.
 			self.track.write(frame)?;
 
-			self.rendition.observe_frame(pts, bytes);
+			self.rendition.record_frame(pts, bytes);
 		}
 		Ok(())
 	}

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -20,7 +20,6 @@ use crate::Result;
 use crate::catalog::hang::CatalogExt;
 use crate::codec::annexb::NalIterator;
 use crate::container::Frame;
-use crate::container::jitter::Jitter;
 
 /// A pure-publisher importer for H.265 with inline VPS/SPS/PPS.
 /// Only supports single layer streams (VPS is cached but not parsed).
@@ -34,7 +33,6 @@ pub struct Import<E: CatalogExt = ()> {
 	rendition: crate::catalog::VideoTrack<E>,
 	config: Option<hang::catalog::VideoConfig>,
 	last_sps: Option<Bytes>,
-	jitter: Jitter,
 }
 
 impl<E: CatalogExt> Import<E> {
@@ -46,7 +44,6 @@ impl<E: CatalogExt> Import<E> {
 			rendition,
 			config: None,
 			last_sps: None,
-			jitter: Jitter::new(),
 		}
 	}
 
@@ -84,6 +81,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> Result<()> {
+		self.rendition.finish_group(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -96,6 +94,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
+		self.rendition.finish_group(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -104,9 +103,7 @@ impl<E: CatalogExt> Import<E> {
 	/// B-frame reorder depth (the decode buffer a transmuxer/player must hold). The
 	/// container supplies this since the elementary stream alone carries no decode time.
 	pub fn observe_reorder(&mut self, reorder: moq_net::Timestamp) {
-		if let Some(jitter) = self.jitter.observe_reorder(reorder) {
-			self.rendition.update(|c| c.jitter = Some(jitter));
-		}
+		self.rendition.observe_reorder(reorder);
 	}
 
 	/// Resolve the config from an inline SPS, updating the rendition in place on a
@@ -146,12 +143,6 @@ impl<E: CatalogExt> Import<E> {
 
 		tracing::debug!(name = ?self.track.name(), ?config, "starting track");
 		self.rendition.set(config.clone());
-		// Seed jitter from whatever has accumulated: a dirty start (or a B-frame
-		// reorder observed via observe_reorder) can feed updates before this
-		// rendition exists, so those would otherwise be lost on (re)publish.
-		if let Some(jitter) = self.jitter.current() {
-			self.rendition.update(|c| c.jitter = Some(jitter));
-		}
 		self.config = Some(config);
 		Ok(())
 	}
@@ -171,14 +162,18 @@ impl<E: CatalogExt> Import<E> {
 				return Err(Error::MissingSps.into());
 			}
 
+			// A keyframe starts a new group: close the previous one for the bitrate detector.
+			if frame.keyframe {
+				self.rendition.finish_group(Some(frame.timestamp));
+			}
+
 			let pts = frame.timestamp;
+			let bytes = frame.payload.len();
 			// A pre-keyframe delta has no group to anchor it: the producer returns
 			// MissingKeyframe, which the caller (e.g. a TS mid-stream join) skips.
 			self.track.write(frame)?;
 
-			if let Some(jitter) = self.jitter.observe(pts) {
-				self.rendition.update(|c| c.jitter = Some(jitter));
-			}
+			self.rendition.observe_frame(pts, bytes);
 		}
 		Ok(())
 	}

--- a/rs/moq-mux/src/codec/legacy.rs
+++ b/rs/moq-mux/src/codec/legacy.rs
@@ -153,7 +153,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> crate::Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -166,7 +166,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -174,7 +174,7 @@ impl<E: CatalogExt> Import<E> {
 	/// Publish one whole frame as a hang frame in its own group.
 	pub fn decode<B: moq_net::IntoBytes>(&mut self, frame: B, pts: Option<Timestamp>) -> crate::Result<()> {
 		let timestamp = self.rendition.timestamp(pts)?;
-		self.rendition.finish_group(Some(timestamp));
+		self.rendition.record_group_end(Some(timestamp));
 		let bytes = frame.as_ref().len();
 		self.track.write(Frame {
 			timestamp,
@@ -183,7 +183,7 @@ impl<E: CatalogExt> Import<E> {
 			keyframe: true,
 		})?;
 		self.track.finish_group()?;
-		self.rendition.observe_frame(timestamp, bytes);
+		self.rendition.record_frame(timestamp, bytes);
 		Ok(())
 	}
 }

--- a/rs/moq-mux/src/codec/legacy.rs
+++ b/rs/moq-mux/src/codec/legacy.rs
@@ -153,6 +153,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> crate::Result<()> {
+		self.rendition.finish_group(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -165,6 +166,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
+		self.rendition.finish_group(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -172,6 +174,8 @@ impl<E: CatalogExt> Import<E> {
 	/// Publish one whole frame as a hang frame in its own group.
 	pub fn decode<B: moq_net::IntoBytes>(&mut self, frame: B, pts: Option<Timestamp>) -> crate::Result<()> {
 		let timestamp = self.rendition.timestamp(pts)?;
+		self.rendition.finish_group(Some(timestamp));
+		let bytes = frame.as_ref().len();
 		self.track.write(Frame {
 			timestamp,
 			duration: None,
@@ -179,6 +183,7 @@ impl<E: CatalogExt> Import<E> {
 			keyframe: true,
 		})?;
 		self.track.finish_group()?;
+		self.rendition.observe_frame(timestamp, bytes);
 		Ok(())
 	}
 }

--- a/rs/moq-mux/src/codec/mp3.rs
+++ b/rs/moq-mux/src/codec/mp3.rs
@@ -134,7 +134,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> crate::Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -147,7 +147,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -155,7 +155,7 @@ impl<E: CatalogExt> Import<E> {
 	/// Publish one MP3 frame as its own group, stamping `pts` or a wall clock when absent.
 	pub fn decode<B: moq_net::IntoBytes>(&mut self, frame: B, pts: Option<Timestamp>) -> crate::Result<()> {
 		let timestamp = self.rendition.timestamp(pts)?;
-		self.rendition.finish_group(Some(timestamp));
+		self.rendition.record_group_end(Some(timestamp));
 		let bytes = frame.as_ref().len();
 		self.track.write(Frame {
 			timestamp,
@@ -164,7 +164,7 @@ impl<E: CatalogExt> Import<E> {
 			duration: None,
 		})?;
 		self.track.finish_group()?;
-		self.rendition.observe_frame(timestamp, bytes);
+		self.rendition.record_frame(timestamp, bytes);
 		Ok(())
 	}
 }

--- a/rs/moq-mux/src/codec/mp3.rs
+++ b/rs/moq-mux/src/codec/mp3.rs
@@ -134,6 +134,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> crate::Result<()> {
+		self.rendition.finish_group(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -146,6 +147,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
+		self.rendition.finish_group(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -153,6 +155,8 @@ impl<E: CatalogExt> Import<E> {
 	/// Publish one MP3 frame as its own group, stamping `pts` or a wall clock when absent.
 	pub fn decode<B: moq_net::IntoBytes>(&mut self, frame: B, pts: Option<Timestamp>) -> crate::Result<()> {
 		let timestamp = self.rendition.timestamp(pts)?;
+		self.rendition.finish_group(Some(timestamp));
+		let bytes = frame.as_ref().len();
 		self.track.write(Frame {
 			timestamp,
 			payload: frame.into_bytes(),
@@ -160,6 +164,7 @@ impl<E: CatalogExt> Import<E> {
 			duration: None,
 		})?;
 		self.track.finish_group()?;
+		self.rendition.observe_frame(timestamp, bytes);
 		Ok(())
 	}
 }

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -53,7 +53,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> crate::Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -66,7 +66,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -74,7 +74,7 @@ impl<E: CatalogExt> Import<E> {
 	/// Publish one Opus packet as its own group, stamping `pts` or a wall clock when absent.
 	pub fn decode<B: moq_net::IntoBytes>(&mut self, frame: B, pts: Option<moq_net::Timestamp>) -> crate::Result<()> {
 		let timestamp = self.rendition.timestamp(pts)?;
-		self.rendition.finish_group(Some(timestamp));
+		self.rendition.record_group_end(Some(timestamp));
 		let bytes = frame.as_ref().len();
 		self.track.write(Frame {
 			timestamp,
@@ -83,7 +83,7 @@ impl<E: CatalogExt> Import<E> {
 			duration: None,
 		})?;
 		self.track.finish_group()?;
-		self.rendition.observe_frame(timestamp, bytes);
+		self.rendition.record_frame(timestamp, bytes);
 		Ok(())
 	}
 }

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -53,6 +53,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> crate::Result<()> {
+		self.rendition.finish_group(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -65,6 +66,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
+		self.rendition.finish_group(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}
@@ -72,6 +74,8 @@ impl<E: CatalogExt> Import<E> {
 	/// Publish one Opus packet as its own group, stamping `pts` or a wall clock when absent.
 	pub fn decode<B: moq_net::IntoBytes>(&mut self, frame: B, pts: Option<moq_net::Timestamp>) -> crate::Result<()> {
 		let timestamp = self.rendition.timestamp(pts)?;
+		self.rendition.finish_group(Some(timestamp));
+		let bytes = frame.as_ref().len();
 		self.track.write(Frame {
 			timestamp,
 			payload: frame.into_bytes(),
@@ -79,6 +83,7 @@ impl<E: CatalogExt> Import<E> {
 			duration: None,
 		})?;
 		self.track.finish_group()?;
+		self.rendition.observe_frame(timestamp, bytes);
 		Ok(())
 	}
 }

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -76,7 +76,7 @@ impl<E: CatalogExt> Import<E> {
 		let pts = self.rendition.timestamp(pts)?;
 		// A key frame starts a new group: close the previous one for the bitrate detector.
 		if header.keyframe {
-			self.rendition.finish_group(Some(pts));
+			self.rendition.record_group_end(Some(pts));
 		}
 		let bytes = frame.as_ref().len();
 		self.track.write(Frame {
@@ -86,7 +86,7 @@ impl<E: CatalogExt> Import<E> {
 			duration: None,
 		})?;
 
-		self.rendition.observe_frame(pts, bytes);
+		self.rendition.record_frame(pts, bytes);
 
 		Ok(())
 	}
@@ -98,7 +98,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> crate::Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -111,7 +111,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -1,6 +1,5 @@
 use crate::catalog::hang::CatalogExt;
 use crate::container::Frame;
-use crate::container::jitter::Jitter;
 
 use super::FrameHeader;
 
@@ -20,9 +19,6 @@ pub struct Import<E: CatalogExt = ()> {
 
 	// The resolved config, used to detect resolution changes.
 	config: Option<hang::catalog::VideoConfig>,
-
-	// Tracks the minimum frame duration and updates the catalog `jitter` field.
-	jitter: Jitter,
 }
 
 impl<E: CatalogExt> Import<E> {
@@ -33,7 +29,6 @@ impl<E: CatalogExt> Import<E> {
 			track: crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy),
 			rendition,
 			config: None,
-			jitter: Jitter::new(),
 		}
 	}
 
@@ -79,6 +74,11 @@ impl<E: CatalogExt> Import<E> {
 		}
 
 		let pts = self.rendition.timestamp(pts)?;
+		// A key frame starts a new group: close the previous one for the bitrate detector.
+		if header.keyframe {
+			self.rendition.finish_group(Some(pts));
+		}
+		let bytes = frame.as_ref().len();
 		self.track.write(Frame {
 			timestamp: pts,
 			payload: frame.into_bytes(),
@@ -86,9 +86,7 @@ impl<E: CatalogExt> Import<E> {
 			duration: None,
 		})?;
 
-		if let Some(jitter) = self.jitter.observe(pts) {
-			self.rendition.update(|c| c.jitter = Some(jitter));
-		}
+		self.rendition.observe_frame(pts, bytes);
 
 		Ok(())
 	}
@@ -100,6 +98,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> crate::Result<()> {
+		self.rendition.finish_group(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -112,6 +111,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
+		self.rendition.finish_group(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -76,7 +76,7 @@ impl<E: CatalogExt> Import<E> {
 		let pts = self.rendition.timestamp(pts)?;
 		// A key frame starts a new group: close the previous one for the bitrate detector.
 		if header.keyframe {
-			self.rendition.finish_group(Some(pts));
+			self.rendition.record_group_end(Some(pts));
 		}
 		let bytes = frame.as_ref().len();
 		self.track.write(Frame {
@@ -86,7 +86,7 @@ impl<E: CatalogExt> Import<E> {
 			duration: None,
 		})?;
 
-		self.rendition.observe_frame(pts, bytes);
+		self.rendition.record_frame(pts, bytes);
 
 		Ok(())
 	}
@@ -98,7 +98,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> crate::Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -111,7 +111,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
-		self.rendition.finish_group(None);
+		self.rendition.record_group_end(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -1,6 +1,5 @@
 use crate::catalog::hang::CatalogExt;
 use crate::container::Frame;
-use crate::container::jitter::Jitter;
 
 use super::FrameHeader;
 
@@ -20,9 +19,6 @@ pub struct Import<E: CatalogExt = ()> {
 
 	// The resolved config, used to detect resolution / format changes.
 	config: Option<hang::catalog::VideoConfig>,
-
-	// Tracks the minimum frame duration and updates the catalog `jitter` field.
-	jitter: Jitter,
 }
 
 impl<E: CatalogExt> Import<E> {
@@ -33,7 +29,6 @@ impl<E: CatalogExt> Import<E> {
 			track: crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy),
 			rendition,
 			config: None,
-			jitter: Jitter::new(),
 		}
 	}
 
@@ -79,6 +74,11 @@ impl<E: CatalogExt> Import<E> {
 		}
 
 		let pts = self.rendition.timestamp(pts)?;
+		// A key frame starts a new group: close the previous one for the bitrate detector.
+		if header.keyframe {
+			self.rendition.finish_group(Some(pts));
+		}
+		let bytes = frame.as_ref().len();
 		self.track.write(Frame {
 			timestamp: pts,
 			payload: frame.into_bytes(),
@@ -86,9 +86,7 @@ impl<E: CatalogExt> Import<E> {
 			duration: None,
 		})?;
 
-		if let Some(jitter) = self.jitter.observe(pts) {
-			self.rendition.update(|c| c.jitter = Some(jitter));
-		}
+		self.rendition.observe_frame(pts, bytes);
 
 		Ok(())
 	}
@@ -100,6 +98,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Finish the track, flushing the current group.
 	pub fn finish(&mut self) -> crate::Result<()> {
+		self.rendition.finish_group(None);
 		self.track.finish()?;
 		Ok(())
 	}
@@ -112,6 +111,7 @@ impl<E: CatalogExt> Import<E> {
 
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
+		self.rendition.finish_group(None);
 		self.track.seek(sequence)?;
 		Ok(())
 	}

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -6,6 +6,7 @@ use std::collections::{HashMap, HashSet};
 
 use super::Error;
 use crate::Result;
+use crate::container::jitter::Metrics;
 
 /// Converts fMP4/CMAF files into MoQ broadcast streams using CMAF passthrough.
 ///
@@ -82,6 +83,13 @@ struct Fmp4Track {
 
 	// Sequence to use for the next group, set by `Import::seek`.
 	pending_sequence: Option<u64>,
+
+	// Detects the track bitrate from fragment sizes, used only when the CMAF descriptor didn't
+	// declare one. Jitter comes from the fragment timing above, not this detector.
+	metrics: Metrics,
+
+	// Whether the descriptor left the bitrate unset, so the detector should fill it.
+	detect_bitrate: bool,
 }
 
 impl<E: crate::catalog::hang::CatalogExt> Import<E> {
@@ -221,16 +229,20 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 				moq_net::track::Info::default().with_timescale(timescale),
 			)?;
 
-			match kind {
+			let detect_bitrate = match kind {
 				TrackKind::Video => {
 					let config = self.init_video(trak, &moov)?;
+					let detect = config.bitrate.is_none();
 					catalog.video.renditions.insert(track.name().to_string(), config);
+					detect
 				}
 				TrackKind::Audio => {
 					let config = self.init_audio(trak, &moov)?;
+					let detect = config.bitrate.is_none();
 					catalog.audio.renditions.insert(track.name().to_string(), config);
+					detect
 				}
-			}
+			};
 
 			self.tracks.insert(
 				track_id,
@@ -242,6 +254,8 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 					last_timestamp: None,
 					min_duration: None,
 					pending_sequence: None,
+					metrics: Metrics::new(),
+					detect_bitrate,
 				},
 			);
 		}
@@ -414,6 +428,8 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 					return Err(Error::UnsupportedMpeg2.into());
 				}
 
+				// The descriptor's bitrate is optional: a 0 means "unknown", so leave the field unset
+				// and let the frame-size detector fill it instead of publishing a bogus 0.
 				let bitrate = desc.avg_bitrate.max(desc.max_bitrate);
 				let profile = desc.dec_specific.profile;
 				let sample_rate = mp4a.audio.sample_rate.integer() as u32;
@@ -429,7 +445,9 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 				.encode();
 
 				let mut config = AudioConfig::new(AAC { profile }, sample_rate, channel_count);
-				config.bitrate = Some(bitrate.into());
+				if bitrate > 0 {
+					config.bitrate = Some(bitrate.into());
+				}
 				config.description = Some(description);
 				config.container = container;
 				config
@@ -732,6 +750,17 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			// in the track's native timescale. The relay reads it off the wire; the
 			// consumer still drives playback from the fragment's internal timing.
 			let timestamp = min_timestamp.ok_or(Error::MissingTrun)?;
+
+			// A keyframe fragment starts a new group: close the previous one for the bitrate
+			// detector (used only when the descriptor didn't declare a bitrate).
+			if track.detect_bitrate
+				&& contains_keyframe
+				&& let Some(bitrate) = track.metrics.finish_group(Some(timestamp))
+			{
+				set_detected_bitrate(&mut self.catalog, track, bitrate)?;
+			}
+			let fragment_len = fragment_bytes.len();
+
 			let mut frame = g.create_frame(moq_net::frame::Info {
 				size: fragment_bytes.len() as u64,
 				timestamp,
@@ -740,6 +769,10 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			frame.finish()?;
 
 			track.group = Some(g);
+
+			if track.detect_bitrate {
+				track.metrics.record_frame(timestamp, fragment_len);
+			}
 
 			if let (Some(min), Some(max), Some(min_duration)) = (min_timestamp, max_timestamp, track.min_duration) {
 				let jitter = max - min + min_duration;
@@ -779,6 +812,11 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	/// Finish all tracks, flushing current groups.
 	pub fn finish(&mut self) -> Result<()> {
 		for track in self.tracks.values_mut() {
+			if track.detect_bitrate
+				&& let Some(bitrate) = track.metrics.finish_group(None)
+			{
+				set_detected_bitrate(&mut self.catalog, track, bitrate)?;
+			}
 			if let Some(mut g) = track.group.take() {
 				g.finish()?;
 			}
@@ -804,6 +842,11 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	/// control is intentionally not exposed.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		for track in self.tracks.values_mut() {
+			if track.detect_bitrate
+				&& let Some(bitrate) = track.metrics.finish_group(None)
+			{
+				set_detected_bitrate(&mut self.catalog, track, bitrate)?;
+			}
 			if let Some(mut g) = track.group.take() {
 				g.finish()?;
 			}
@@ -811,6 +854,37 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		}
 		Ok(())
 	}
+}
+
+/// Apply a detector-supplied bitrate to a track's catalog config, keeping the maximum seen.
+fn set_detected_bitrate<E: crate::catalog::hang::CatalogExt>(
+	catalog: &mut crate::catalog::Producer<E>,
+	track: &Fmp4Track,
+	bitrate: u64,
+) -> Result<()> {
+	let mut catalog = catalog.lock();
+	let field = match track.kind {
+		TrackKind::Video => {
+			&mut catalog
+				.video
+				.renditions
+				.get_mut(track.track.name())
+				.ok_or_else(|| Error::MissingVideoTrack(track.track.name().to_string()))?
+				.bitrate
+		}
+		TrackKind::Audio => {
+			&mut catalog
+				.audio
+				.renditions
+				.get_mut(track.track.name())
+				.ok_or_else(|| Error::MissingAudioTrack(track.track.name().to_string()))?
+				.bitrate
+		}
+	};
+	if field.is_none_or(|current| bitrate > current) {
+		*field = Some(bitrate);
+	}
+	Ok(())
 }
 
 impl<E: crate::catalog::hang::CatalogExt> Drop for Import<E> {

--- a/rs/moq-mux/src/container/jitter.rs
+++ b/rs/moq-mux/src/container/jitter.rs
@@ -2,6 +2,149 @@ use std::time::Duration;
 
 use moq_net::Timestamp;
 
+/// The window over which bitrate is averaged before it is reported.
+const BITRATE_WINDOW: Duration = Duration::from_secs(1);
+
+/// Tracks catalog metrics (jitter and bitrate) for one media track.
+///
+/// Each event maps to a single catalog field: a frame can change the jitter, a finished group
+/// can raise the bitrate. Reporting bitrate only at group boundaries keeps a single large
+/// keyframe from being reported as the track bitrate on its own.
+///
+/// The importer feeds events; a change is reported back so the caller only republishes the
+/// catalog when a value actually moves. The [`jitter`](Self::jitter) / [`bitrate`](Self::bitrate)
+/// accessors expose the current values without change-detection, to seed a freshly published
+/// rendition with whatever has already accumulated.
+#[derive(Default)]
+pub struct Metrics {
+	jitter: Jitter,
+	bitrate: Bitrate,
+}
+
+impl Metrics {
+	/// Create an empty detector.
+	pub fn new() -> Self {
+		Self::default()
+	}
+
+	/// Record one frame's presentation timestamp and encoded byte count, returning the new
+	/// jitter if it changed. The bitrate is accumulated but only surfaces from
+	/// [`finish_group`](Self::finish_group).
+	pub fn observe_frame(&mut self, ts: Timestamp, bytes: usize) -> Option<Duration> {
+		self.bitrate.observe_frame(ts, bytes);
+		self.jitter.observe(ts)
+	}
+
+	/// Record a frame's reorder delay (`PTS - DTS`), returning the new jitter if it changed.
+	pub fn observe_reorder(&mut self, reorder: Timestamp) -> Option<Duration> {
+		self.jitter.observe_reorder(reorder)
+	}
+
+	/// Finish the current group (`next` is its end timestamp when known), returning the new
+	/// bitrate if it rose.
+	pub fn finish_group(&mut self, next: Option<Timestamp>) -> Option<u64> {
+		self.bitrate.finish_group(next)
+	}
+
+	/// The current jitter, without change-detection (to seed a freshly published rendition).
+	pub fn jitter(&self) -> Option<Duration> {
+		self.jitter.current()
+	}
+
+	/// The current bitrate, without change-detection (to seed a freshly published rendition).
+	pub fn bitrate(&self) -> Option<u64> {
+		self.bitrate.current()
+	}
+}
+
+/// Tracks the maximum bitrate in bits per second, averaged over whole groups.
+///
+/// A group's bytes are only counted once it is finished (a keyframe boundary for video, each
+/// packet for audio), and the average is taken over at least [`BITRATE_WINDOW`] of media so a
+/// lone keyframe doesn't spike the reported value.
+#[derive(Default)]
+struct Bitrate {
+	group: Option<Group>,
+	window_bytes: u64,
+	window_duration: Duration,
+	max: Option<u64>,
+	reported: Option<u64>,
+}
+
+impl Bitrate {
+	fn observe_frame(&mut self, ts: Timestamp, bytes: usize) {
+		let group = self.group.get_or_insert(Group {
+			start: ts,
+			max: ts,
+			bytes: 0,
+		});
+
+		if ts < group.start {
+			group.start = ts;
+		}
+		if ts > group.max {
+			group.max = ts;
+		}
+		group.bytes = group.bytes.saturating_add(bytes as u64);
+	}
+
+	fn finish_group(&mut self, next: Option<Timestamp>) -> Option<u64> {
+		let group = self.group.take()?;
+		let duration = next
+			.and_then(|next| next.checked_sub(group.start).ok())
+			.filter(|duration| !duration.is_zero())
+			.or_else(|| {
+				group
+					.max
+					.checked_sub(group.start)
+					.ok()
+					.filter(|duration| !duration.is_zero())
+			})?;
+
+		self.window_bytes = self.window_bytes.saturating_add(group.bytes);
+		self.window_duration += Duration::from(duration);
+
+		if self.window_duration < BITRATE_WINDOW {
+			return None;
+		}
+
+		let bitrate = bits_per_second(self.window_bytes, self.window_duration);
+		self.window_bytes = 0;
+		self.window_duration = Duration::ZERO;
+
+		if self.max.is_none_or(|max| bitrate > max) {
+			self.max = Some(bitrate);
+		}
+
+		if self.reported != self.max {
+			self.reported = self.max;
+			return self.max;
+		}
+
+		None
+	}
+
+	fn current(&self) -> Option<u64> {
+		self.max
+	}
+}
+
+struct Group {
+	start: Timestamp,
+	max: Timestamp,
+	bytes: u64,
+}
+
+fn bits_per_second(bytes: u64, duration: Duration) -> u64 {
+	let nanos = duration.as_nanos();
+	if nanos == 0 {
+		return 0;
+	}
+
+	let bits_per_second = (bytes as u128).saturating_mul(8).saturating_mul(1_000_000_000) / nanos;
+	bits_per_second.min(u64::MAX as u128) as u64
+}
+
 /// Tracks the catalog `jitter` for a video/audio track: the maximum delay before a frame can
 /// be emitted, so a player sizes its buffer to at least this much.
 ///
@@ -27,10 +170,6 @@ pub struct Jitter {
 }
 
 impl Jitter {
-	pub fn new() -> Self {
-		Self::default()
-	}
-
 	/// Record a frame's presentation timestamp (decode order), updating the minimum frame
 	/// duration. Returns the new jitter as a [`Duration`] if it changed, else `None`. The
 	/// first observation and non-monotonic timestamps (B-frames) only update state.
@@ -89,7 +228,7 @@ mod tests {
 
 	#[test]
 	fn reports_min_frame_spacing_once_it_changes() {
-		let mut jitter = Jitter::new();
+		let mut jitter = Jitter::default();
 
 		assert_eq!(jitter.observe(micros(1_000)), None);
 		assert_eq!(jitter.observe(micros(41_000)), Some(Duration::from_millis(40)));
@@ -100,7 +239,7 @@ mod tests {
 
 	#[test]
 	fn reorder_delay_wins_over_frame_spacing() {
-		let mut jitter = Jitter::new();
+		let mut jitter = Jitter::default();
 
 		assert_eq!(jitter.observe(micros(0)), None);
 		assert_eq!(jitter.observe(micros(16_000)), Some(Duration::from_millis(16)));
@@ -111,10 +250,42 @@ mod tests {
 
 	#[test]
 	fn ignores_non_monotonic_presentation_spacing() {
-		let mut jitter = Jitter::new();
+		let mut jitter = Jitter::default();
 
 		assert_eq!(jitter.observe(micros(100_000)), None);
 		assert_eq!(jitter.observe(micros(80_000)), None);
 		assert_eq!(jitter.observe(micros(120_000)), Some(Duration::from_millis(40)));
+	}
+
+	#[test]
+	fn bitrate_waits_for_group_boundaries_and_reports_max() {
+		let mut metrics = Metrics::new();
+
+		metrics.observe_frame(micros(0), 100_000);
+		metrics.observe_frame(micros(500_000), 100_000);
+		assert_eq!(metrics.finish_group(Some(micros(1_000_000))), Some(1_600_000));
+
+		metrics.observe_frame(micros(1_000_000), 25_000);
+		assert_eq!(metrics.finish_group(Some(micros(2_000_000))), None);
+		assert_eq!(metrics.bitrate(), Some(1_600_000));
+
+		metrics.observe_frame(micros(2_000_000), 250_000);
+		assert_eq!(metrics.finish_group(Some(micros(3_000_000))), Some(2_000_000));
+	}
+
+	#[test]
+	fn metrics_report_jitter_and_bitrate_independently() {
+		let mut metrics = Metrics::new();
+
+		assert_eq!(metrics.observe_frame(micros(0), 1), None);
+		assert_eq!(
+			metrics.observe_frame(micros(33_000), 1),
+			Some(Duration::from_millis(33))
+		);
+		assert_eq!(
+			metrics.observe_reorder(micros(100_000)),
+			Some(Duration::from_millis(100))
+		);
+		assert_eq!(metrics.jitter(), Some(Duration::from_millis(100)));
 	}
 }

--- a/rs/moq-mux/src/container/jitter.rs
+++ b/rs/moq-mux/src/container/jitter.rs
@@ -30,13 +30,13 @@ impl Metrics {
 	/// Record one frame's presentation timestamp and encoded byte count, returning the new
 	/// jitter if it changed. The bitrate is accumulated but only surfaces from
 	/// [`finish_group`](Self::finish_group).
-	pub fn observe_frame(&mut self, ts: Timestamp, bytes: usize) -> Option<Duration> {
+	pub fn record_frame(&mut self, ts: Timestamp, bytes: usize) -> Option<Duration> {
 		self.bitrate.observe_frame(ts, bytes);
 		self.jitter.observe(ts)
 	}
 
 	/// Record a frame's reorder delay (`PTS - DTS`), returning the new jitter if it changed.
-	pub fn observe_reorder(&mut self, reorder: Timestamp) -> Option<Duration> {
+	pub fn record_reorder(&mut self, reorder: Timestamp) -> Option<Duration> {
 		self.jitter.observe_reorder(reorder)
 	}
 
@@ -261,15 +261,15 @@ mod tests {
 	fn bitrate_waits_for_group_boundaries_and_reports_max() {
 		let mut metrics = Metrics::new();
 
-		metrics.observe_frame(micros(0), 100_000);
-		metrics.observe_frame(micros(500_000), 100_000);
+		metrics.record_frame(micros(0), 100_000);
+		metrics.record_frame(micros(500_000), 100_000);
 		assert_eq!(metrics.finish_group(Some(micros(1_000_000))), Some(1_600_000));
 
-		metrics.observe_frame(micros(1_000_000), 25_000);
+		metrics.record_frame(micros(1_000_000), 25_000);
 		assert_eq!(metrics.finish_group(Some(micros(2_000_000))), None);
 		assert_eq!(metrics.bitrate(), Some(1_600_000));
 
-		metrics.observe_frame(micros(2_000_000), 250_000);
+		metrics.record_frame(micros(2_000_000), 250_000);
 		assert_eq!(metrics.finish_group(Some(micros(3_000_000))), Some(2_000_000));
 	}
 
@@ -277,13 +277,10 @@ mod tests {
 	fn metrics_report_jitter_and_bitrate_independently() {
 		let mut metrics = Metrics::new();
 
-		assert_eq!(metrics.observe_frame(micros(0), 1), None);
+		assert_eq!(metrics.record_frame(micros(0), 1), None);
+		assert_eq!(metrics.record_frame(micros(33_000), 1), Some(Duration::from_millis(33)));
 		assert_eq!(
-			metrics.observe_frame(micros(33_000), 1),
-			Some(Duration::from_millis(33))
-		);
-		assert_eq!(
-			metrics.observe_reorder(micros(100_000)),
+			metrics.record_reorder(micros(100_000)),
 			Some(Duration::from_millis(100))
 		);
 		assert_eq!(metrics.jitter(), Some(Duration::from_millis(100)));


### PR DESCRIPTION
## Summary

Adds bitrate auto-detection to the catalog and reshapes metric detection onto dev's generic `Rendition<E, K>`.

- **Bitrate auto-detection.** `container::jitter` gains a `Metrics` type wrapping the existing `Jitter` plus a new `Bitrate` detector. Bitrate is averaged over whole groups (a keyframe boundary for video, each packet for audio) and reported only once at least a second of media has accumulated, so a lone large keyframe never spikes the value. Detection now also runs on the audio codecs (previously nothing).

- **The detector lives on the rendition.** `Rendition<E, K>` owns a `Metrics` and exposes `record_frame` / `record_reorder` / `record_group_end`. Importers just feed events (`self.rendition.record_frame(pts, bytes)`), dropping their per-importer `jitter: Jitter` field and the manual observe/update dance. The `Kind` trait gains `jitter_mut` / `bitrate_mut` accessors so the *one* generic rendition updates either config, with no per-kind duplication and no separate metrics trait.

- **Only auto-detect a field the config didn't provide.** At `set()` the rendition records whether `jitter` / `bitrate` were already set; a provided value is authoritative and is never overwritten, only an absent field is detected (and kept refined).

- **fMP4 bitrate fallback.** The CMAF descriptor's `avg_bitrate`/`max_bitrate` are often 0/absent, so a `0` is no longer published as if it were real, and the frame-size detector fills the gap. A descriptor-provided bitrate is kept as-is. fMP4 still derives its own jitter from fragment timing.

This supersedes #2100 (built the same feature on main's older two-struct `VideoTrack`/`AudioTrack` layout). Targeting `dev` because it touches the `Kind` trait / rendition surface.

## Public API changes

- `catalog::Rendition` gains `record_frame` / `record_reorder` / `record_group_end` (additive).
- `catalog::tracks::Kind` gains `jitter_mut` / `bitrate_mut` (both `#[doc(hidden)]`); `Kind` is sealed, so it can't be implemented downstream.
- No config/schema/wire changes: detected values land in the existing `jitter` / `bitrate` catalog fields.

## Validation

- `cargo test -p moq-mux` (372, incl. detect-when-absent and keep-when-provided rendition tests), `-p libmoq` (27), `-p moq-ffi` (24) all green
- `cargo clippy -p moq-mux --tests` clean
- The libmoq `multiple_frames_ordering` test drains mid-stream catalog snapshots before the terminal callback, since audio tracks republish the catalog as metrics are detected.

(Written by Claude Opus 4.8)