### PR TITLE
refactor(moq-net)!: drop vestigial serde + delete the legacy `serde` feature

### DIFF
--- a/rs/hang/Cargo.toml
+++ b/rs/hang/Cargo.toml
@@ -20,7 +20,7 @@ doctest = false
 bytes = "1"
 hex = "0.4"
 lazy_static = "1"
-moq-net = { workspace = true, features = ["serde"] }
+moq-net = { workspace = true }
 regex = "1"
 serde = { workspace = true }
 serde_json = "1"

--- a/rs/libmoq/Cargo.toml
+++ b/rs/libmoq/Cargo.toml
@@ -23,7 +23,7 @@ hang = { workspace = true }
 moq-audio = { workspace = true }
 moq-mux = { workspace = true }
 moq-native = { workspace = true, default-features = true }
-moq-net = { workspace = true, features = ["serde"] }
+moq-net = { workspace = true }
 # Enable the NVENC / VAAPI hardware encoders (default-off at the workspace level).
 moq-video = { workspace = true, features = ["nvenc", "vaapi"] }
 serde_json = "1"

--- a/rs/moq-bench/Cargo.toml
+++ b/rs/moq-bench/Cargo.toml
@@ -33,7 +33,7 @@ clap = { version = "4", features = ["derive", "env"] }
 humantime = "2.3"
 humantime-serde = "1.1"
 moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs"] }
-moq-net = { workspace = true, features = ["serde"] }
+moq-net = { workspace = true }
 rand = "0.10.1"
 rustls = { version = "0.23", features = ["aws-lc-rs"], default-features = false }
 serde = { version = "1", features = ["derive"] }

--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -28,7 +28,7 @@ hang = { workspace = true }
 moq-audio = { workspace = true }
 moq-mux = { workspace = true }
 moq-native = { workspace = true, default-features = true }
-moq-net = { workspace = true, features = ["serde"] }
+moq-net = { workspace = true }
 serde_json = "1"
 thiserror = "2"
 tokio = { workspace = true, features = ["macros"] }

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -27,7 +27,7 @@ memchr = "2"
 moq-json = { workspace = true }
 moq-loc = { workspace = true }
 moq-msf = { workspace = true }
-moq-net = { workspace = true, features = ["serde"] }
+moq-net = { workspace = true }
 mp4-atom = { version = "0.12", features = ["tokio", "bytes", "serde"] }
 mpeg2ts = "0.6.0"
 num_enum = "0.7"

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -43,7 +43,7 @@ hex = "0.4"
 humantime = "2.3"
 humantime-serde = "1.1"
 
-moq-net = { workspace = true, features = ["serde"] }
+moq-net = { workspace = true }
 notify = { version = "8", optional = true }
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 qmux = { workspace = true, features = ["wss", "tls", "tcp"], optional = true }

--- a/rs/moq-net/Cargo.toml
+++ b/rs/moq-net/Cargo.toml
@@ -15,17 +15,13 @@ categories = ["multimedia", "network-programming", "web-programming"]
 [package.metadata.cargo-shear]
 ignored = ["getrandom"]
 
-[features]
-# Legacy no-op: serde is now unconditional (stats publishing requires it).
-serde = []
-
 [dependencies]
 bytes = "1"
 futures = "0.3"
 kio = { workspace = true }
 num_enum = "0.7"
 rand = "0.10.1"
-serde = { workspace = true, features = ["rc"] }
+serde = { workspace = true }
 serde_json = "1"
 thiserror = "2"
 tokio = { workspace = true, features = ["macros", "io-util", "sync", "time"] }

--- a/rs/moq-net/src/coding/varint.rs
+++ b/rs/moq-net/src/coding/varint.rs
@@ -20,7 +20,6 @@ pub struct BoundsExceeded;
 /// It would be neat if we could express to Rust that the top two bits are available for use as enum
 /// discriminants
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct VarInt(u64);
 
 impl VarInt {

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -20,18 +20,9 @@ pub fn restart_supported(version: Version) -> bool {
 ///
 /// Carries the broadcast path suffix and the hop chain. Renamed from ANNOUNCE in lite-05.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AnnounceBroadcast<'a> {
-	Active {
-		#[cfg_attr(feature = "serde", serde(borrow))]
-		suffix: Path<'a>,
-		hops: OriginList,
-	},
-	Ended {
-		#[cfg_attr(feature = "serde", serde(borrow))]
-		suffix: Path<'a>,
-		hops: OriginList,
-	},
+	Active { suffix: Path<'a>, hops: OriginList },
+	Ended { suffix: Path<'a>, hops: OriginList },
 }
 
 impl Message for AnnounceBroadcast<'_> {
@@ -153,10 +144,8 @@ impl Encode<Version> for AnnounceStatus {
 ///
 /// Used by Draft01/Draft02 only. Draft03 uses individual Announce messages instead.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AnnounceInit<'a> {
 	/// List of currently active broadcasts, encoded as suffixes to be combined with the prefix.
-	#[cfg_attr(feature = "serde", serde(borrow))]
 	pub suffixes: Vec<Path<'a>>,
 }
 
@@ -207,7 +196,6 @@ impl Message for AnnounceInit<'_> {
 /// publisher sends as the initial set immediately after this message, letting the
 /// receiver block until the initial set has arrived.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AnnounceOk {
 	pub origin: Origin,
 	pub active: u64,

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -20,7 +20,6 @@ use crate::{Error, IntoBytes, Result, Timestamp};
 /// This is just the header; the payload is carried separately (as a completed
 /// [`Frame`] or streamed via [`Producer`] / [`Consumer`]).
 #[derive(Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Info {
 	/// Total payload size in bytes. Declared up front so consumers can preallocate.
 	pub size: u64,

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -29,7 +29,6 @@ const MAX_GROUP_CACHE: u64 = 32 * 1024 * 1024; // 32 MB
 ///
 /// You can use [track::Producer::append_group] if you just want to +1 the sequence number.
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Info {
 	/// Per-track sequence number used to detect ordering and gaps. Higher numbers
 	/// supersede lower ones; consumers may skip late arrivals.

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -38,33 +38,6 @@ impl fmt::Display for InvalidOrigin {
 
 impl std::error::Error for InvalidOrigin {}
 
-#[cfg(feature = "serde")]
-impl serde::Serialize for Origin {
-	fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-		use serde::ser::SerializeStruct;
-
-		let mut state = serializer.serialize_struct("Origin", 1)?;
-		state.serialize_field("id", &self.id)?;
-		state.end()
-	}
-}
-
-#[cfg(feature = "serde")]
-impl<'de> serde::Deserialize<'de> for Origin {
-	fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-		#[derive(serde::Deserialize)]
-		struct OriginSerde {
-			id: u64,
-		}
-
-		let origin = <OriginSerde as serde::Deserialize>::deserialize(deserializer)?;
-		if origin.id >= 1u64 << 62 {
-			return Err(serde::de::Error::custom("origin id must be below 2^62"));
-		}
-		Ok(Self { id: origin.id })
-	}
-}
-
 impl Origin {
 	/// Placeholder for hop entries whose actual id is not on the wire (Lite03).
 	/// Also used for remote peers that choose the legal but loop-blind id 0.
@@ -155,7 +128,6 @@ pub(crate) const MAX_HOPS: usize = 32;
 /// Guarantees `len() <= MAX_HOPS`. Construct via [`OriginList::new`] +
 /// [`OriginList::push`], or fall back to the fallible [`TryFrom<Vec<Origin>>`].
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OriginList(Vec<Origin>);
 
 /// Returned when an operation would grow an [`OriginList`] past its hop-count cap.

--- a/rs/moq-net/src/model/time.rs
+++ b/rs/moq-net/src/model/time.rs
@@ -18,7 +18,6 @@ pub struct TimeOverflow;
 /// for runtime values, use [`Self::new`] which returns [`TimeOverflow`] for `0` or
 /// for values past the QUIC varint range.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Timescale(NonZero<u64>);
 
 impl Timescale {
@@ -126,7 +125,6 @@ impl std::fmt::Display for Timescale {
 /// etc.) are infallible. Use [`Option<Timestamp>`] at call sites that need a "missing" sentinel
 /// instead of relying on a magic value.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Timestamp {
 	value: VarInt,
 	scale: Timescale,

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -42,7 +42,6 @@ const MAX_DATAGRAM_AGE: Duration = Duration::from_millis(50);
 /// [`broadcast::Consumer::track`](broadcast::Consumer::track),
 /// which returns the publisher's [`Info`] once the subscription is accepted.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 pub struct Info {
 	/// Units per second for per-frame timestamps on this track.
@@ -51,58 +50,21 @@ pub struct Info {
 	/// reported in TRACK_INFO and the publisher zigzag-delta encodes per-frame
 	/// timestamps at this scale on the wire. Protocols whose wire can't carry it
 	/// (pre-Lite05 moq-lite, IETF moq-transport) fall back to wall-clock milliseconds.
-	#[cfg_attr(feature = "serde", serde(default))]
 	pub timescale: Timescale,
 	/// How long the publisher keeps old groups available before evicting them
 	/// (the newest group is always retained). A subscriber's
 	/// [`Subscription::stale`] window is clamped to this, since a group can't be
 	/// waited for longer than it's kept around. Reported in TRACK_INFO so
 	/// relays re-serve with the same window. Defaults to [`DEFAULT_CACHE`].
-	#[cfg_attr(
-		feature = "serde",
-		serde(
-			default = "default_cache",
-			skip_serializing_if = "is_default_cache",
-			with = "cache_millis"
-		)
-	)]
 	pub cache: Duration,
 	/// The publisher's priority for this track, used only to break ties between
-	/// subscriptions of equal subscriber priority. Reported in TRACK_INFO (Lite05+);
-	/// kept out of the catalog (a transport property, not media metadata).
-	#[cfg_attr(feature = "serde", serde(skip))]
+	/// subscriptions of equal subscriber priority. Reported in TRACK_INFO (Lite05+).
 	pub priority: u8,
 	/// The publisher's group ordering preference (newest-first when `false`), used
-	/// only to break ties. Reported in TRACK_INFO (Lite05+); kept out of the catalog.
-	#[cfg_attr(feature = "serde", serde(skip))]
+	/// only to break ties. Reported in TRACK_INFO (Lite05+).
 	pub ordered: bool,
 }
 
-#[cfg(feature = "serde")]
-fn default_cache() -> Duration {
-	DEFAULT_CACHE
-}
-
-#[cfg(feature = "serde")]
-fn is_default_cache(cache: &Duration) -> bool {
-	*cache == DEFAULT_CACHE
-}
-
-/// Serialize [`Info::cache`] as a bare integer of milliseconds, matching the
-/// catalog's other durations (and the wire), rather than serde's `{secs, nanos}`.
-#[cfg(feature = "serde")]
-mod cache_millis {
-	use std::time::Duration;
-
-	pub fn serialize<S: serde::Serializer>(cache: &Duration, s: S) -> Result<S::Ok, S::Error> {
-		s.serialize_u64(cache.as_millis() as u64)
-	}
-
-	pub fn deserialize<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
-		let ms = <u64 as serde::Deserialize>::deserialize(d)?;
-		Ok(Duration::from_millis(ms))
-	}
-}
 impl Default for Info {
 	fn default() -> Self {
 		Self {

--- a/rs/moq-net/src/path.rs
+++ b/rs/moq-net/src/path.rs
@@ -72,7 +72,6 @@ impl<'a> AsPath for &'a String {
 /// assert_eq!(joined.as_str(), "api/v1/users");
 /// ```
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Path<'a>(Cow<'a, str>);
 
 impl<'a> Path<'a> {
@@ -344,18 +343,6 @@ where
 	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) -> Result<(), EncodeError> {
 		self.as_str().encode(w, version)?;
 		Ok(())
-	}
-}
-
-// A custom deserializer is needed in order to sanitize
-#[cfg(feature = "serde")]
-impl<'de: 'a, 'a> serde::Deserialize<'de> for Path<'a> {
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-	where
-		D: serde::Deserializer<'de>,
-	{
-		let s = <&'a str as serde::Deserialize<'de>>::deserialize(deserializer)?;
-		Ok(Path::new(s))
 	}
 }
 

--- a/rs/moq-net/src/version.rs
+++ b/rs/moq-net/src/version.rs
@@ -177,14 +177,12 @@ impl FromStr for Version {
 	}
 }
 
-#[cfg(feature = "serde")]
 impl serde::Serialize for Version {
 	fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
 		serializer.serialize_str(&self.to_string())
 	}
 }
 
-#[cfg(feature = "serde")]
 impl<'de> serde::Deserialize<'de> for Version {
 	fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
 		let s = String::deserialize(deserializer)?;

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -43,7 +43,7 @@ http-body = "1"
 http-cache-reqwest = { version = "1.0.0-alpha.6", features = ["manager-moka", "url-standard"], default-features = false }
 jsonwebtoken = "10"
 moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs", "watch", "tcp"] }
-moq-net = { workspace = true, features = ["serde"] }
+moq-net = { workspace = true }
 moq-token = { workspace = true, features = ["tokio"] }
 qmux = { workspace = true, features = ["ws"], optional = true }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }

--- a/rs/moq-wasm/Cargo.toml
+++ b/rs/moq-wasm/Cargo.toml
@@ -29,7 +29,7 @@ bytes = "1"
 console_error_panic_hook = "0.1"
 getrandom = { version = "0.4", features = ["wasm_js"] } # wasm_js backend for rand-via-moq-net; cfg flag in .cargo/config.toml
 js-sys = "0.3"
-moq-net = { workspace = true, features = ["serde"] }
+moq-net = { workspace = true }
 thiserror = "2"
 tracing-wasm = "0.2"
 url = "2"


### PR DESCRIPTION
## Summary

`track::Info`/`group::Info` (and `frame::Info`) still derived `Serialize`/`Deserialize`, a holdover from when the catalog embedded the track timescale/cache. Once that moved onto the wire (`lite::TrackInfo`) and out of the catalog (#1156), nothing serialized the model `Info` types anymore. This PR makes the model layer carry only data, not an encoding, and then removes the rest of the vestigial serde that fell out of that.

Follow-up to #2126.

### Removed (all proven dead by compiling `--workspace --tests` without them)

- **Model `Info` types**: `track::Info`, `group::Info`, `frame::Info`. For `track::Info` this also drops the catalog-shaping cruft it dragged along: the `#[serde(skip)]` on `priority`/`ordered`, the `skip_serializing_if`/`default` on `cache`, and the custom `cache_millis` module.
- **Timing/coding primitives** the Info types pulled serde in for: `Timescale`, `Timestamp`, `VarInt`.
- **`Origin` / `OriginList`** (including the custom `2^62`-validating deserializer).
- **The lite `announce` wire messages** (`AnnounceBroadcast`, `AnnounceInit`, `AnnounceOk`) and borrowed **`Path<'a>`** serde, whose only consumer was those announce messages.

### The `feature = "serde"` flag is deleted

serde is an **unconditional** dependency of moq-net (stats publishing serializes JSON), so the `feature = "serde"` flag was a documented "legacy no-op" that gated nothing meaningful. With the vestigial impls gone, the only three genuine consumers remain, all unconditional:

- `stats.rs` — publishes `publisher.json` / `sessions.json`.
- `PathRelative` — the catalog `broadcast` field.
- `Version` — moq-native client/server config (made unconditional here).

Deleted `serde = []` from `rs/moq-net/Cargo.toml`, dropped `features = ["serde"]` from all 8 consumers, and dropped the unused serde `rc` feature.

## Breaking?

Yes, hence `dev`: removes public `Serialize`/`Deserialize` impls and a Cargo feature. No wire change, no runtime behavior change.

## Cross-package sync

- **js/net**: already in the target shape (model `interface Info` separate from the wire `class TrackInfo` with its own encode/decode). No mirror needed.
- **doc/concept**: no doc referenced the moq-net serde feature or catalog-serialized track info. Nothing to update.

## Test plan

- [x] `cargo check --workspace --tests` clean
- [x] `cargo test`: moq-net 430, hang 21, moq-native 53, moq-relay 134, moq-mux 368 pass
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `taplo format --check` clean

(Written by Claude Opus 4.8)
