### PR TITLE
test(ts): dump round-trip logs when the compliance verdict fails

### DIFF
--- a/test/ts/run.sh
+++ b/test/ts/run.sh
@@ -202,20 +202,36 @@ timeout -k 3 $((DURATION + 20)) bash -c '
 ' _ "$SRC_TS" "$MOQ" "$URL" "$BROADCAST" >"$TMP/pub.log" 2>&1 &
 PUB_PID=$!
 
-wait "$PUB_PID" 2>/dev/null || true
+# Keep the publisher's exit status: `timeout` returns 124 when it had to kill a
+# stalled `moq import ts`, non-zero/non-124 means the import itself errored. Both
+# explain a truncated capture, so surface it alongside the logs on failure.
+wait "$PUB_PID" 2>/dev/null && PUB_RC=0 || PUB_RC=$?
 PUB_PID=""
 sleep 3
 kill_tree "$SUB_PID" 2>/dev/null || true
 SUB_PID=""
 
-if [[ ! -s "$SUB_TS" ]]; then
-    echo "error: subscriber captured no data" >&2
+# shellcheck disable=SC2329  # invoked from multiple failure paths below
+dump_logs() {
+    echo "  publisher exit status: $PUB_RC" >&2
     sed 's/^/  pub: /' "$TMP/pub.log" >&2 || true
     sed 's/^/  sub: /' "$TMP/sub.log" >&2 || true
+}
+
+if [[ ! -s "$SUB_TS" ]]; then
+    echo "error: subscriber captured no data" >&2
+    dump_logs
     exit 1
 fi
 
 echo "### captured $(wc -c <"$SUB_TS" | tr -d ' ') bytes -> analyzing"
 echo
-# Pass the source so duration-fidelity can pin the exported stream's rate.
-analyze "$SUB_TS" "$SRC_TS"
+# Pass the source so duration-fidelity can pin the exported stream's rate. A tiny
+# capture still parses, so the round-trip can fail here with a non-empty file;
+# dump the logs and publisher status so the failure is diagnosable, not a mystery.
+if ! analyze "$SUB_TS" "$SRC_TS"; then
+    echo >&2
+    echo "error: compliance analysis failed (see round-trip logs below)" >&2
+    dump_logs
+    exit 1
+fi


### PR DESCRIPTION
## Summary

The nightly `Smoke` / `ts` (TS/IRD compliance) step failed in [run 28934850529](https://github.com/moq-dev/moq/actions/runs/28934850529): the `import ts` → relay → `export ts` round-trip delivered only ~13 KB, so `duration-fidelity` reported `captured 0.0s vs source 19.9s` and failed hard. But the harness gave **no diagnostics** to explain why: `pub.log`/`sub.log` were only dumped on an *empty* capture (`! -s`), and the publisher's exit status was discarded (`wait "$PUB_PID" ... || true`). A tiny-but-non-empty capture failed the verdict with nothing to bisect.

This change:
- Keeps the publisher's exit status from `wait` (124 = `timeout` killed a stalled `moq import ts`; other non-zero = the import itself errored) and prints it on failure.
- Dumps both round-trip logs whenever the compliance analysis fails, not just on an empty capture, via a shared `dump_logs` helper.

Test-only, additive diagnostics; no behavior change to the pass path. `bash -n` and `shellcheck` are clean.

## What it uncovered

With these diagnostics, the failure reproduced on this PR's own Smoke run and the subscriber log pinned the real cause (it is **not** a flake):

```
sub: Error: TS track layout changed after PAT/PMT was emitted: '0.aac' added
publisher exit status: 0
```

The `export ts` muxer builds PAT/PMT as soon as the video keyframe is buffered; if the `import ts` side has only published a video-only catalog snapshot at that instant, the audio track (`0.aac`) arriving in a later snapshot is rejected as a post-PMT layout change and the exporter aborts. It is a catalog-completeness race, already fixed on `dev` by #2072 ("gate initial catalog publish until reserved tracks resolve") and will reach `main` at the next dev→main merge. This PR does not touch that path; it just makes the failure diagnosable.

## Test plan
- [x] `bash -n test/ts/run.sh`
- [x] `shellcheck test/ts/run.sh`
- [x] Diagnostics confirmed working: the PR's Smoke run printed the publisher exit status + pub/sub logs, which identified the root cause above.

(Written by Claude Opus 4.8)