### PR TITLE
chore(js): upgrade TypeScript to stable 7.0.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,7 +27,7 @@
       },
       "devDependencies": {
         "esbuild": "^0.28.1",
-        "typescript": "7.0.1-rc",
+        "typescript": "7.0.2",
         "vite": "^8.0.16",
         "vite-plugin-solid": "^2.11.12",
       },
@@ -49,7 +49,7 @@
         "solid-element": "^1.9.1",
         "solid-js": "^1.9.13",
         "tailwindcss": "^4.1.13",
-        "typescript": "7.0.1-rc",
+        "typescript": "7.0.2",
         "vite": "^8.0.16",
         "vite-plugin-solid": "^2.11.12",
       },
@@ -75,7 +75,7 @@
       },
       "devDependencies": {
         "@types/node": "^26.0.0",
-        "typescript": "7.0.1-rc",
+        "typescript": "7.0.2",
       },
     },
     "js/flate": {
@@ -88,7 +88,7 @@
         "@types/bun": "^1.3.14",
         "fflate": "^0.8.2",
         "rimraf": "^6.1.3",
-        "typescript": "7.0.1-rc",
+        "typescript": "7.0.2",
       },
     },
     "js/hang": {
@@ -110,7 +110,7 @@
         "@typescript/lib-dom": "npm:@types/web@^0.0.350",
         "fast-glob": "^3.3.3",
         "rimraf": "^6.1.3",
-        "typescript": "7.0.1-rc",
+        "typescript": "7.0.2",
       },
     },
     "js/json": {
@@ -124,7 +124,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "rimraf": "^6.1.3",
-        "typescript": "7.0.1-rc",
+        "typescript": "7.0.2",
       },
       "peerDependencies": {
         "zod": "^4.0.0",
@@ -139,7 +139,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.14",
         "rimraf": "^6.1.3",
-        "typescript": "7.0.1-rc",
+        "typescript": "7.0.2",
       },
     },
     "js/moq-boy": {
@@ -157,7 +157,7 @@
         "esbuild": "^0.28.1",
         "rimraf": "^6.1.3",
         "solid-js": "^1.9.13",
-        "typescript": "7.0.1-rc",
+        "typescript": "7.0.2",
         "vite": "^8.0.16",
         "vite-plugin-solid": "^2.11.12",
       },
@@ -171,7 +171,7 @@
       },
       "devDependencies": {
         "rimraf": "^6.1.3",
-        "typescript": "7.0.1-rc",
+        "typescript": "7.0.2",
       },
     },
     "js/net": {
@@ -187,7 +187,7 @@
         "@types/node": "^26.0.0",
         "@typescript/lib-dom": "npm:@types/web@^0.0.350",
         "rimraf": "^6.1.3",
-        "typescript": "7.0.1-rc",
+        "typescript": "7.0.2",
         "vite-plugin-html": "^3.2.2",
       },
       "peerDependencies": {
@@ -209,7 +209,7 @@
         "@typescript/lib-dom": "npm:@types/web@^0.0.350",
         "esbuild": "^0.28.1",
         "rimraf": "^6.1.3",
-        "typescript": "7.0.1-rc",
+        "typescript": "7.0.2",
         "vite": "^8.0.16",
       },
     },
@@ -222,7 +222,7 @@
         "react": "^19.0.0",
         "rimraf": "^6.1.3",
         "solid-js": "^1.9.13",
-        "typescript": "7.0.1-rc",
+        "typescript": "7.0.2",
       },
       "peerDependencies": {
         "@types/react": "^19.2.17",
@@ -251,7 +251,7 @@
         "@types/bun": "^1.3.14",
         "@types/node": "^26.0.0",
         "rimraf": "^6.1.3",
-        "typescript": "7.0.1-rc",
+        "typescript": "7.0.2",
       },
     },
     "js/wasm": {
@@ -274,7 +274,7 @@
         "@typescript/lib-dom": "npm:@types/web@^0.0.350",
         "esbuild": "^0.28.1",
         "rimraf": "^6.1.3",
-        "typescript": "7.0.1-rc",
+        "typescript": "7.0.2",
         "vite": "^8.0.16",
       },
     },
@@ -831,45 +831,45 @@
 
     "@typescript/lib-dom": ["@types/web@0.0.350", "", {}, "sha512-XFISASo1wPsKKtI5v1nJ51YuZYkjUE9kduDFpfHCOKEMbHtRLHX0k3V3bpBeQx2L1VvcxTIECHvC3r3Rfmu0YA=="],
 
-    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.1-rc", "", { "os": "aix", "cpu": "ppc64" }, "sha512-oqq2ZfEJ7BQuufcC3QBQndZLPNyamYNHLao8lKRBeeSkZKypBqxPSgkzrcFZtbYcIaBvpiyUnQP9MT7DEYHWbw=="],
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
-    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.1-rc", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Slc0yTftT2F/uGDmtPst8ijydneL6uZaLEyr2UjahxZpbhTjHFBJ5agXtVz/TL4A+ldxzjzj+E8QtLZlh/5mXw=="],
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
 
-    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.1-rc", "", { "os": "darwin", "cpu": "x64" }, "sha512-h68iFW/LbA1/BsGgSRGFw981/3s1f/rY27YrmeZNuN+ly7dI+fiDduwT9ZT9866x2onoKNRq7PTyxSKyKDzfAQ=="],
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
 
-    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.1-rc", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-DE+ppd8Ix2c6OMuRkKY4PJ4hngMGJ9M95OQUP17p9xL/1IKXof7npIeuusMN/bgL5o5JzMfSGh+N+5scTYRg0Q=="],
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
 
-    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.1-rc", "", { "os": "freebsd", "cpu": "x64" }, "sha512-ST1ozHMw0u+CLOnWkcTyWDMV4Qn9osZ6fd1V1lnKDM1t0hZIp81mdGpdHxyHJjd7jdGrb6Gb/QXcZ1uqZ0t5zw=="],
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
 
-    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.1-rc", "", { "os": "linux", "cpu": "arm" }, "sha512-gHmHwT5Naq5CKM8g9bbaGeEpnwQEvWCLn3fwP4K2m61VQdDKkPk0Dhab/OoZ4LV2SrMddmclYXTzpyg23YGt5g=="],
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
 
-    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.1-rc", "", { "os": "linux", "cpu": "arm64" }, "sha512-N46pRihK3t5zD5MUtTQcdmQUqr1WI4U2nxno1gLwOtRSsB4krFkRjPHcQNG7h2DtRkX64rQiReX6WKwg2wprMA=="],
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
 
-    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.1-rc", "", { "os": "linux", "cpu": "none" }, "sha512-G17Sao312rgiPBTh2F4nOpLpa3CcnBSaNhqNghZk2LNhnsp1RaMO5HMq2me21gqu9xLpc6CIgHtOzU6JBgNlfg=="],
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
 
-    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.1-rc", "", { "os": "linux", "cpu": "none" }, "sha512-0FQspOb5UsQ4tQKvWgUO3pS9OIWkP7/8dPRWq+CRazJUeQZ4LBjtYK52jg5iIOrvItrVl2CwvRtrU3/9OihwJg=="],
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
 
-    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.1-rc", "", { "os": "linux", "cpu": "ppc64" }, "sha512-SUmwfVBEv6A2Ld0eWfcvW0FqrgemfQL8jFGOmV1qYxsDqumjE5DekHXqbstgmbE4SHr4rrjHjvmuGCY+kTH/vw=="],
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
 
-    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.1-rc", "", { "os": "linux", "cpu": "none" }, "sha512-rxeqnNnGiYzv/LlPHi/3+4p0ooR1cNJLjRIHXKovtiVmxXGJq6gtw8VSpbHuWPekyFMXgIAoLCZN0SQ51rAALQ=="],
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
 
-    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.1-rc", "", { "os": "linux", "cpu": "s390x" }, "sha512-RYWCHCiPypxajdRHM2CNK/eM22e4Ex5TTjV2pXf7PTtBowGr0xX8i8kIMknyZS0LX2QfleYHouaoMVsFDSle3g=="],
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
 
-    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.1-rc", "", { "os": "linux", "cpu": "x64" }, "sha512-PfLJSu0JzroDkqw2m4nqflPEcn8yev0m/vHFQlY9EzHorzjR6QG0wL8AJHvnD1e6h1s76AZngJ5u+z1K/D/HKw=="],
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
 
-    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.1-rc", "", { "os": "none", "cpu": "arm64" }, "sha512-FfbPxH3dTfp8yVIaNM7bdWTixXuyxpzoemluqcqMROSIz+ImpCG3Q9HO9Ptzp9/giv+P9YYEnCMSXh61migj2w=="],
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
 
-    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.1-rc", "", { "os": "none", "cpu": "x64" }, "sha512-FzdTfSzhRYb6hlav6K3cI5RVgcvCTvNAu/vc+t7B6AmZkThQ+t/1ntnvT5fnHmY1Az2RIBw7/b+qtCEG61HJTQ=="],
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
 
-    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.1-rc", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-PQGhlxfNig+0YQ9Wwzd0USPBkt6w/ZqkBQWsU7G/0JkTzunJel+jSWwhKw4947pak/m7hGSeYiI04xReDLGZww=="],
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
 
-    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.1-rc", "", { "os": "openbsd", "cpu": "x64" }, "sha512-WJ7NYgO2mHmLUkI/tZ+hl8lFd26QPJqO8ONOHNuYbdsybLvSB6B6sep222JIVrOfPRDGvFinbGGB+l3m1FWRWA=="],
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
 
-    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.1-rc", "", { "os": "sunos", "cpu": "x64" }, "sha512-UYjDeUxd765V9qcwlUPk4pEXyL0i3G76CJm9baK4i99u1pGO1psf3nXDw4MMmElVOPvGbZag99ZR/O59E2OX6w=="],
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
 
-    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.1-rc", "", { "os": "win32", "cpu": "arm64" }, "sha512-KzXzFSXZOm7zvEt2Aw0MsB2LbTL88znAiVqTDNAOHdlEb7brgmUQh/X2wM/8Be+N0fjEqWKl65cBKNwpWEbJiw=="],
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
 
-    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.1-rc", "", { "os": "win32", "cpu": "x64" }, "sha512-98R3+OqDr/r0/PLWEoXu88AE0lGVLNd335Ew8ONgzK1JWkNs4ou/5BGt3Or1ij4iXjH+c7PRL+jFjCbtWze+EA=="],
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/global-this": ["@ungap/global-this@0.4.4", "", {}, "sha512-mHkm6FvepJECMNthFuIgpAEFmPOk71UyXuIxYfjytvFTnSDBIz7jmViO+LfHI/AjrazWije0PnSP3+/NlwzqtA=="],
 
@@ -1679,7 +1679,7 @@
 
     "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
 
-    "typescript": ["typescript@7.0.1-rc", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.1-rc", "@typescript/typescript-darwin-arm64": "7.0.1-rc", "@typescript/typescript-darwin-x64": "7.0.1-rc", "@typescript/typescript-freebsd-arm64": "7.0.1-rc", "@typescript/typescript-freebsd-x64": "7.0.1-rc", "@typescript/typescript-linux-arm": "7.0.1-rc", "@typescript/typescript-linux-arm64": "7.0.1-rc", "@typescript/typescript-linux-loong64": "7.0.1-rc", "@typescript/typescript-linux-mips64el": "7.0.1-rc", "@typescript/typescript-linux-ppc64": "7.0.1-rc", "@typescript/typescript-linux-riscv64": "7.0.1-rc", "@typescript/typescript-linux-s390x": "7.0.1-rc", "@typescript/typescript-linux-x64": "7.0.1-rc", "@typescript/typescript-netbsd-arm64": "7.0.1-rc", "@typescript/typescript-netbsd-x64": "7.0.1-rc", "@typescript/typescript-openbsd-arm64": "7.0.1-rc", "@typescript/typescript-openbsd-x64": "7.0.1-rc", "@typescript/typescript-sunos-x64": "7.0.1-rc", "@typescript/typescript-win32-arm64": "7.0.1-rc", "@typescript/typescript-win32-x64": "7.0.1-rc" }, "bin": { "tsc": "bin/tsc" } }, "sha512-drEP77wK7CCDlPfXZH4e008UUQOsw1DFmHmZOZjuNA+yoDLLnSNMZRXi90NbV/1LVo7SbNLq1bs3jjvk49TEqQ=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
 

--- a/demo/boy/package.json
+++ b/demo/boy/package.json
@@ -13,7 +13,7 @@
 	},
 	"devDependencies": {
 		"esbuild": "^0.28.1",
-		"typescript": "7.0.1-rc",
+		"typescript": "7.0.2",
 		"vite": "^8.0.16",
 		"vite-plugin-solid": "^2.11.12"
 	}

--- a/demo/web/package.json
+++ b/demo/web/package.json
@@ -26,7 +26,7 @@
 		"solid-element": "^1.9.1",
 		"solid-js": "^1.9.13",
 		"tailwindcss": "^4.1.13",
-		"typescript": "7.0.1-rc",
+		"typescript": "7.0.2",
 		"vite": "^8.0.16",
 		"vite-plugin-solid": "^2.11.12"
 	}

--- a/infra/apt/package.json
+++ b/infra/apt/package.json
@@ -6,7 +6,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4",
-		"typescript": "7.0.1-rc",
+		"typescript": "7.0.2",
 		"wrangler": "^4"
 	}
 }

--- a/infra/rpm/package.json
+++ b/infra/rpm/package.json
@@ -6,7 +6,7 @@
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4",
-		"typescript": "7.0.1-rc",
+		"typescript": "7.0.2",
 		"wrangler": "^4"
 	}
 }

--- a/js/clock/package.json
+++ b/js/clock/package.json
@@ -23,6 +23,6 @@
 	},
 	"devDependencies": {
 		"@types/node": "^26.0.0",
-		"typescript": "7.0.1-rc"
+		"typescript": "7.0.2"
 	}
 }

--- a/js/flate/package.json
+++ b/js/flate/package.json
@@ -22,6 +22,6 @@
 		"@types/bun": "^1.3.14",
 		"fflate": "^0.8.2",
 		"rimraf": "^6.1.3",
-		"typescript": "7.0.1-rc"
+		"typescript": "7.0.2"
 	}
 }

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -33,6 +33,6 @@
 		"@typescript/lib-dom": "npm:@types/web@^0.0.350",
 		"fast-glob": "^3.3.3",
 		"rimraf": "^6.1.3",
-		"typescript": "7.0.1-rc"
+		"typescript": "7.0.2"
 	}
 }

--- a/js/json/package.json
+++ b/js/json/package.json
@@ -26,6 +26,6 @@
 	"devDependencies": {
 		"@types/bun": "^1.3.14",
 		"rimraf": "^6.1.3",
-		"typescript": "7.0.1-rc"
+		"typescript": "7.0.2"
 	}
 }

--- a/js/loc/package.json
+++ b/js/loc/package.json
@@ -20,6 +20,6 @@
 	"devDependencies": {
 		"@types/bun": "^1.3.14",
 		"rimraf": "^6.1.3",
-		"typescript": "7.0.1-rc"
+		"typescript": "7.0.2"
 	}
 }

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -35,7 +35,7 @@
 		"esbuild": "^0.28.1",
 		"rimraf": "^6.1.3",
 		"solid-js": "^1.9.13",
-		"typescript": "7.0.1-rc",
+		"typescript": "7.0.2",
 		"vite": "^8.0.16",
 		"vite-plugin-solid": "^2.11.12"
 	}

--- a/js/msf/package.json
+++ b/js/msf/package.json
@@ -20,6 +20,6 @@
 	},
 	"devDependencies": {
 		"rimraf": "^6.1.3",
-		"typescript": "7.0.1-rc"
+		"typescript": "7.0.2"
 	}
 }

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -29,7 +29,7 @@
 		"@types/node": "^26.0.0",
 		"@typescript/lib-dom": "npm:@types/web@^0.0.350",
 		"rimraf": "^6.1.3",
-		"typescript": "7.0.1-rc",
+		"typescript": "7.0.2",
 		"vite-plugin-html": "^3.2.2"
 	}
 }

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -36,7 +36,7 @@
 		"@typescript/lib-dom": "npm:@types/web@^0.0.350",
 		"esbuild": "^0.28.1",
 		"rimraf": "^6.1.3",
-		"typescript": "7.0.1-rc",
+		"typescript": "7.0.2",
 		"vite": "^8.0.16"
 	}
 }

--- a/js/signals/package.json
+++ b/js/signals/package.json
@@ -19,7 +19,7 @@
 		"release": "bun ../common/release.ts"
 	},
 	"devDependencies": {
-		"typescript": "7.0.1-rc",
+		"typescript": "7.0.2",
 		"rimraf": "^6.1.3",
 		"@types/bun": "^1.3.11",
 		"@types/react": "^19.2.17",

--- a/js/token/package.json
+++ b/js/token/package.json
@@ -28,6 +28,6 @@
 		"@types/bun": "^1.3.14",
 		"@types/node": "^26.0.0",
 		"rimraf": "^6.1.3",
-		"typescript": "7.0.1-rc"
+		"typescript": "7.0.2"
 	}
 }

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -37,7 +37,7 @@
 		"@typescript/lib-dom": "npm:@types/web@^0.0.350",
 		"esbuild": "^0.28.1",
 		"rimraf": "^6.1.3",
-		"typescript": "7.0.1-rc",
+		"typescript": "7.0.2",
 		"vite": "^8.0.16"
 	}
 }


### PR DESCRIPTION
## Summary

TypeScript 7 shipped as a stable release (`7.0.2` is now the npm `latest` tag). This moves every JS workspace off the `7.0.1-rc` prerelease onto stable.

- Bumped `"typescript"` from `7.0.1-rc` to `7.0.2` across all 16 `package.json` files (13 `js/*` workspaces plus `demo/boy`, `demo/web`, and the `infra/apt` + `infra/rpm` helpers).
- Refreshed `bun.lock` via `bun install`.

Kept the exact-pin convention the RC used (not a `^7.0.2` caret): TypeScript minor releases routinely tighten inference, and an exact pin avoids surprise type-check breakage on unrelated PRs.

## Why `main`

Additive dependency bump with no public-API or wire-protocol changes, so it targets `main` per the branch-targeting rules.

## Test plan

- [x] `bun run check` — every workspace typechecks and tests pass (exit 0)
- [x] `tsc --version` → `Version 7.0.2`

Note: the full `nix develop --command just check` was skipped because the nix dev shell currently fails to build on macOS arm64 (tsduck `-Werror`); the JS checks were run directly via `bun`, which is what the TS check ultimately invokes.

(Written by Claude Opus 4.8)