### PR TITLE
docs: add site-wide notice about evolving APIs and AI-generated content

### DIFF
--- a/doc/.vitepress/theme/Banner.vue
+++ b/doc/.vitepress/theme/Banner.vue
@@ -2,22 +2,17 @@
 /**
  * Site-wide notice shown at the top of every page.
  *
- * Two standing caveats for readers:
- * 1. The APIs and protocols are pre-1.0 and still change between releases.
- * 2. Most of these pages are AI generated and may be inaccurate.
+ * Reminds readers that MoQ is pre-1.0, so both the APIs/protocols and these
+ * (mostly AI-generated) docs are still in flux.
  */
 </script>
 
 <template>
 	<div class="moq-banner">
 		<p>
-			<strong>Heads up:</strong> MoQ is under active development. The APIs and
-			protocols are still evolving and subject to change without notice.
-		</p>
-		<p>
-			Most of this documentation is currently AI generated and may be
-			incomplete or inaccurate. Please
-			<a href="https://github.com/moq-dev/moq/issues">report anything wrong</a>.
+			<strong>btw:</strong> MoQ is under active development. The APIs and
+			protocols are still evolving and will change. Most of this documentation
+			is AI generated until things get more stable.
 		</p>
 	</div>
 </template>

--- a/doc/.vitepress/theme/Banner.vue
+++ b/doc/.vitepress/theme/Banner.vue
@@ -1,0 +1,43 @@
+<script setup>
+/**
+ * Site-wide notice shown at the top of every page.
+ *
+ * Two standing caveats for readers:
+ * 1. The APIs and protocols are pre-1.0 and still change between releases.
+ * 2. Most of these pages are AI generated and may be inaccurate.
+ */
+</script>
+
+<template>
+	<div class="moq-banner">
+		<p>
+			<strong>Heads up:</strong> MoQ is under active development. The APIs and
+			protocols are still evolving and subject to change without notice.
+		</p>
+		<p>
+			Most of this documentation is currently AI generated and may be
+			incomplete or inaccurate. Please
+			<a href="https://github.com/moq-dev/moq/issues">report anything wrong</a>.
+		</p>
+	</div>
+</template>
+
+<style scoped>
+.moq-banner {
+	border-bottom: 1px solid var(--vp-c-divider);
+	background-color: var(--vp-c-brand-soft);
+	padding: 0.5rem 1.5rem;
+	text-align: center;
+	font-size: 0.85rem;
+	line-height: 1.4;
+}
+
+.moq-banner p {
+	margin: 0.15rem 0;
+	color: var(--vp-c-text-2);
+}
+
+.moq-banner strong {
+	color: var(--vp-c-brand-1);
+}
+</style>

--- a/doc/.vitepress/theme/index.js
+++ b/doc/.vitepress/theme/index.js
@@ -1,4 +1,14 @@
+import { h } from "vue";
 import DefaultTheme from "vitepress/theme";
+import Banner from "./Banner.vue";
 import "./custom.css";
 
-export default DefaultTheme;
+export default {
+	extends: DefaultTheme,
+	Layout() {
+		// Render the site-wide notice above every page via the layout-top slot.
+		return h(DefaultTheme.Layout, null, {
+			"layout-top": () => h(Banner),
+		});
+	},
+};


### PR DESCRIPTION
## Summary

Adds a site-wide banner to the documentation, shown at the top of **every** page:

> **btw:** MoQ is under active development. The APIs and protocols are still evolving and will change. Most of this documentation is AI generated until things get more stable.

## Implementation

Rather than editing every markdown file (and having to remember to add it to new ones), the notice is injected globally through the VitePress theme's `layout-top` slot:

- `doc/.vitepress/theme/Banner.vue` — the banner component, styled with the existing theme variables (`--vp-c-brand-soft`, etc.) so it matches the dark slate look.
- `doc/.vitepress/theme/index.js` — extends the default theme and renders `Banner` in the `layout-top` slot so it appears above every page, including the home page.

## Test plan

- [x] `bun run build` succeeds.
- [x] Verified the banner text renders into the built HTML across the home, setup, concept, bin, lib, and demo pages.

Base is `main` per the branch-targeting rules: this is docs-only and purely additive, with no public/wire contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)