### PR TITLE
reject unsupported RTMP FourCC plays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4309,6 +4309,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "futures",
+ "hang",
  "hmac 0.13.0",
  "moq-mux",
  "moq-native",

--- a/rs/moq-rtmp/Cargo.toml
+++ b/rs/moq-rtmp/Cargo.toml
@@ -36,6 +36,7 @@ anyhow = { version = "1", features = ["backtrace"] }
 byteorder = "1"
 bytes = "1"
 futures = "0.3"
+hang = { workspace = true }
 hmac = "0.13"
 moq-mux = { workspace = true }
 moq-net = { workspace = true }

--- a/rs/moq-rtmp/src/lib.rs
+++ b/rs/moq-rtmp/src/lib.rs
@@ -17,8 +17,8 @@
 //! Both legacy RTMP (H.264 + AAC, plus MP3) and enhanced RTMP (E-RTMP: the HEVC,
 //! AV1, VP9, Opus, AC-3, and MP3 FourCC payloads) are supported in each direction,
 //! because the codec handling lives entirely in the [`moq_mux`] FLV demuxer/muxer;
-//! this crate only translates the RTMP transport. Legacy players that speak only
-//! H.264 + AAC will of course reject the E-RTMP codecs on the play path.
+//! this crate only translates the RTMP transport. On the play path, enhanced
+//! codecs are sent only to clients that advertised the matching FourCC support.
 //!
 //! Two entry points, depending on how much control you need over each request:
 //!

--- a/rs/moq-rtmp/src/rml/sessions/mod.rs
+++ b/rs/moq-rtmp/src/rml/sessions/mod.rs
@@ -23,6 +23,7 @@ pub use self::client::ClientSessionResult;
 pub use self::client::ClientState;
 pub use self::client::PublishRequestType;
 
+pub use self::server::FourCcSupport;
 pub use self::server::PublishMode;
 pub use self::server::ServerSession;
 pub use self::server::ServerSessionConfig;

--- a/rs/moq-rtmp/src/rml/sessions/server/events.rs
+++ b/rs/moq-rtmp/src/rml/sessions/server/events.rs
@@ -4,6 +4,15 @@ use crate::rml::time::RtmpTimestamp;
 use bytes::Bytes;
 use rml_amf0::Amf0Value;
 
+/// The enhanced-RTMP FourCCs a peer advertised for one media kind.
+#[derive(Debug, PartialEq, Clone, Default)]
+pub struct FourCcSupport {
+	/// Whether the peer advertised the `*` wildcard.
+	pub any: bool,
+	/// The explicit FourCC allow-list.
+	pub fourccs: Vec<[u8; 4]>,
+}
+
 /// Represents where RTMP playback should start from
 #[derive(PartialEq, Debug, Clone)]
 pub enum PlayStartValue {
@@ -26,11 +35,15 @@ pub enum ServerSessionEvent {
 
 	/// The client is requesting a connection on the specified RTMP application name.
 	/// `caps_ex` is the enhanced-RTMP `capsEx` capability bitmask the client
-	/// advertised in its `connect` command object (0 if absent).
+	/// advertised in its `connect` command object (0 if absent). The FourCC
+	/// support fields combine `fourCcList` with any per-kind `*FourCcInfoMap`
+	/// entries that set the `CanDecode` bit.
 	ConnectionRequested {
 		request_id: u32,
 		app_name: String,
 		caps_ex: u32,
+		video_fourccs: FourCcSupport,
+		audio_fourccs: FourCcSupport,
 	},
 
 	/// The client is requesting a stream key be released for use.

--- a/rs/moq-rtmp/src/rml/sessions/server/mod.rs
+++ b/rs/moq-rtmp/src/rml/sessions/server/mod.rs
@@ -22,9 +22,11 @@ use rml_amf0::Amf0Value;
 use std::collections::HashMap;
 use std::time::SystemTime;
 
+const FOURCC_CAN_DECODE: u32 = 0x01;
+
 pub use self::config::ServerSessionConfig;
 pub use self::errors::ServerSessionError;
-pub use self::events::{PlayStartValue, ServerSessionEvent};
+pub use self::events::{FourCcSupport, PlayStartValue, ServerSessionEvent};
 pub use self::publish_mode::PublishMode;
 pub use self::result::ServerSessionResult;
 
@@ -509,6 +511,18 @@ impl ServerSession {
 			Some(Amf0Value::Number(number)) if number >= 0.0 => number as u32,
 			_ => 0,
 		};
+		let combined_fourccs = properties
+			.remove("fourCcList")
+			.map(Self::parse_fourcc_list)
+			.unwrap_or_default();
+		let mut video_fourccs = combined_fourccs.clone();
+		let mut audio_fourccs = combined_fourccs;
+		if let Some(value) = properties.remove("videoFourCcInfoMap") {
+			Self::merge_fourcc_support(&mut video_fourccs, Self::parse_fourcc_info_map(value));
+		}
+		if let Some(value) = properties.remove("audioFourCcInfoMap") {
+			Self::merge_fourcc_support(&mut audio_fourccs, Self::parse_fourcc_info_map(value));
+		}
 
 		let request = OutstandingRequest::ConnectionRequest {
 			app_name: app_name.clone(),
@@ -523,9 +537,76 @@ impl ServerSession {
 			app_name: app_name,
 			request_id: request_number,
 			caps_ex,
+			video_fourccs,
+			audio_fourccs,
 		};
 
 		Ok(vec![ServerSessionResult::RaisedEvent(event)])
+	}
+
+	fn parse_fourcc_list(value: Amf0Value) -> FourCcSupport {
+		let mut support = FourCcSupport::default();
+		match value {
+			Amf0Value::StrictArray(values) => {
+				for value in values {
+					if let Amf0Value::Utf8String(name) = value {
+						Self::add_fourcc(&mut support, &name);
+					}
+				}
+			}
+			Amf0Value::Object(properties) => {
+				for (key, value) in properties {
+					Self::add_fourcc(&mut support, &key);
+					if let Amf0Value::Utf8String(name) = value {
+						Self::add_fourcc(&mut support, &name);
+					}
+				}
+			}
+			Amf0Value::Utf8String(s) => {
+				for part in s.split(|c: char| c == ',' || c == ';' || c.is_whitespace()) {
+					Self::add_fourcc(&mut support, part);
+				}
+			}
+			_ => {}
+		}
+		support
+	}
+
+	fn parse_fourcc_info_map(value: Amf0Value) -> FourCcSupport {
+		let mut support = FourCcSupport::default();
+		let Amf0Value::Object(properties) = value else {
+			return support;
+		};
+		for (name, value) in properties {
+			if let Amf0Value::Number(mask) = value
+				&& (mask as u32) & FOURCC_CAN_DECODE != 0
+			{
+				Self::add_fourcc(&mut support, &name);
+			}
+		}
+		support
+	}
+
+	fn add_fourcc(support: &mut FourCcSupport, name: &str) {
+		if name == "*" {
+			support.any = true;
+			return;
+		}
+		if name.as_bytes().len() == 4 {
+			let fourcc = name.as_bytes().try_into().expect("checked length");
+			if !support.fourccs.contains(&fourcc) {
+				support.fourccs.push(fourcc);
+			}
+		}
+	}
+
+	fn merge_fourcc_support(target: &mut FourCcSupport, source: FourCcSupport) {
+		target.any |= source.any;
+		for fourcc in source.fourccs {
+			if !target.fourccs.contains(&fourcc) {
+				target.fourccs.push(fourcc);
+			}
+		}
 	}
 
 	fn handle_command_close_stream(

--- a/rs/moq-rtmp/src/rml/sessions/server/tests.rs
+++ b/rs/moq-rtmp/src/rml/sessions/server/tests.rs
@@ -282,6 +282,90 @@ fn accepted_connection_responds_with_same_object_encoding_value_as_connection_re
 }
 
 #[test]
+fn connect_request_reports_fourcc_list() {
+	let (mut deserializer, mut serializer, mut session) = common_basic_setup();
+	let payload = RtmpMessage::Amf0Command {
+		command_name: "connect".to_string(),
+		transaction_id: 1.0,
+		command_object: Amf0Value::Object(HashMap::from([
+			("app".to_string(), Amf0Value::Utf8String("some_app".to_string())),
+			("capsEx".to_string(), Amf0Value::Number(2.0)),
+			(
+				"fourCcList".to_string(),
+				Amf0Value::StrictArray(vec![
+					Amf0Value::Utf8String("hvc1".to_string()),
+					Amf0Value::Utf8String("Opus".to_string()),
+				]),
+			),
+		])),
+		additional_arguments: vec![],
+	}
+	.into_message_payload(RtmpTimestamp::new(15), 0)
+	.unwrap();
+	let packet = serializer.serialize(&payload, true, false).unwrap();
+	let results = session.handle_input(&packet.bytes[..]).unwrap();
+
+	let (_, events) = split_results(&mut deserializer, results);
+	assert_eq!(events.len(), 1, "Unexpected number of events returned");
+	match &events[0] {
+		ServerSessionEvent::ConnectionRequested {
+			caps_ex,
+			video_fourccs,
+			audio_fourccs,
+			..
+		} => {
+			assert_eq!(*caps_ex, 2);
+			assert_eq!(video_fourccs.fourccs, vec![*b"hvc1", *b"Opus"]);
+			assert_eq!(audio_fourccs.fourccs, vec![*b"hvc1", *b"Opus"]);
+		}
+		_ => panic!("First event was not as expected: {:?}", events[0]),
+	}
+}
+
+#[test]
+fn connect_request_reports_decodable_fourcc_maps() {
+	let (mut deserializer, mut serializer, mut session) = common_basic_setup();
+	let payload = RtmpMessage::Amf0Command {
+		command_name: "connect".to_string(),
+		transaction_id: 1.0,
+		command_object: Amf0Value::Object(HashMap::from([
+			("app".to_string(), Amf0Value::Utf8String("some_app".to_string())),
+			(
+				"videoFourCcInfoMap".to_string(),
+				Amf0Value::Object(HashMap::from([
+					("vp09".to_string(), Amf0Value::Number(1.0)),
+					("hvc1".to_string(), Amf0Value::Number(4.0)),
+				])),
+			),
+			(
+				"audioFourCcInfoMap".to_string(),
+				Amf0Value::Object(HashMap::from([("*".to_string(), Amf0Value::Number(1.0))])),
+			),
+		])),
+		additional_arguments: vec![],
+	}
+	.into_message_payload(RtmpTimestamp::new(15), 0)
+	.unwrap();
+	let packet = serializer.serialize(&payload, true, false).unwrap();
+	let results = session.handle_input(&packet.bytes[..]).unwrap();
+
+	let (_, events) = split_results(&mut deserializer, results);
+	assert_eq!(events.len(), 1, "Unexpected number of events returned");
+	match &events[0] {
+		ServerSessionEvent::ConnectionRequested {
+			video_fourccs,
+			audio_fourccs,
+			..
+		} => {
+			assert_eq!(video_fourccs.fourccs, vec![*b"vp09"]);
+			assert!(!video_fourccs.fourccs.contains(b"hvc1"));
+			assert!(audio_fourccs.any);
+		}
+		_ => panic!("First event was not as expected: {:?}", events[0]),
+	}
+}
+
+#[test]
 fn can_create_stream_on_connected_session() {
 	let (mut deserializer, mut serializer, mut session) = common_basic_setup();
 	perform_connection("some_app", &mut session, &mut serializer, &mut deserializer);

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -33,11 +33,15 @@ use std::time::Duration;
 
 use crate::rml::handshake::{Handshake, HandshakeProcessResult, PeerType};
 use crate::rml::rml_amf0::Amf0Value;
-use crate::rml::sessions::{ServerSession, ServerSessionConfig, ServerSessionEvent, ServerSessionResult};
+use crate::rml::sessions::{
+	FourCcSupport, ServerSession, ServerSessionConfig, ServerSessionEvent, ServerSessionResult,
+};
 use crate::rml::time::RtmpTimestamp;
 use futures::StreamExt;
 use futures::future::BoxFuture;
 use futures::stream::FuturesUnordered;
+use hang::catalog::{AudioCodec, VideoCodec};
+use moq_mux::catalog::{CatalogFormat, Stream as CatalogStream};
 use moq_mux::container::flv::{Export as FlvExport, Import as FlvImport};
 use moq_net::{Broadcast, OriginConsumer, OriginProducer};
 use socket2::{SockRef, TcpKeepalive};
@@ -90,6 +94,31 @@ const CAPS_EX_MULTITRACK: u32 = 0x02;
 /// multitrack on both ingest (demux several tracks) and egress (mux several
 /// renditions); reconnect and the ModEx timestamp extensions are not supported.
 const SUPPORTED_CAPS_EX: u32 = CAPS_EX_MULTITRACK;
+
+#[derive(Clone, Debug, Default)]
+struct ClientCapabilities {
+	multitrack: bool,
+	video: FourCcSupport,
+	audio: FourCcSupport,
+}
+
+impl ClientCapabilities {
+	fn new(caps_ex: u32, video: FourCcSupport, audio: FourCcSupport) -> Self {
+		Self {
+			multitrack: caps_ex & CAPS_EX_MULTITRACK != 0,
+			video,
+			audio,
+		}
+	}
+
+	fn supports_video(&self, fourcc: &[u8; 4]) -> bool {
+		self.video.any || self.video.fourccs.contains(fourcc)
+	}
+
+	fn supports_audio(&self, fourcc: &[u8; 4]) -> bool {
+		self.audio.any || self.audio.fourccs.contains(fourcc)
+	}
+}
 
 /// Enhanced-RTMP capabilities to echo in the connect `_result` command object, so
 /// an enhanced encoder knows it may send these FourCC codecs on ingest and that
@@ -505,10 +534,8 @@ pub struct Play<S = Conn> {
 	/// one. Defaults to [`DEFAULT_LATENCY`](crate::DEFAULT_LATENCY); override with
 	/// [`with_latency`](Self::with_latency).
 	latency: Duration,
-	/// Whether the player advertised enhanced-RTMP multitrack support (connect
-	/// `capsEx`). When set, every rendition is muxed as a multitrack track;
-	/// otherwise only the first video + first audio rendition is sent.
-	multitrack: bool,
+	/// Enhanced-RTMP capabilities advertised by the player in its connect object.
+	capabilities: ClientCapabilities,
 }
 
 impl<S: Stream> Play<S> {
@@ -573,10 +600,39 @@ impl<S: Stream> Play<S> {
 			return self.reject("stream not found").await;
 		};
 
+		let mut catalog = moq_mux::catalog::Consumer::new(&broadcast, CatalogFormat::default())
+			.map_err(|e| anyhow::anyhow!("init catalog check: {e}"))?;
+		let catalog = tokio::select! {
+			biased;
+			res = feed_input(&mut self.stream, &mut self.session, &mut self.work) => {
+				res?;
+				tracing::debug!(peer = %self.peer, %path, "viewer disconnected before play started");
+				return Ok(());
+			}
+			catalog = tokio::time::timeout(PLAY_RESOLVE_TIMEOUT, CatalogStream::next(&mut catalog)) => {
+				match catalog {
+					Ok(Ok(Some(catalog))) => catalog,
+					Ok(Ok(None)) => {
+						tracing::debug!(peer = %self.peer, %path, "play catalog ended before a snapshot");
+						return self.reject("stream not available").await;
+					}
+					Ok(Err(e)) => return Err(anyhow::anyhow!("play catalog: {e}").into()),
+					Err(_) => {
+						tracing::debug!(peer = %self.peer, %path, "play catalog resolve timed out");
+						return self.reject("stream not available").await;
+					}
+				}
+			}
+		};
+		if let Err(reason) = check_play_capabilities(&catalog, &self.capabilities) {
+			tracing::debug!(peer = %self.peer, %path, %reason, "rejecting RTMP play: unsupported client capabilities");
+			return self.reject(&reason).await;
+		}
+
 		let mut export = FlvExport::new(broadcast)
 			.map_err(|e| anyhow::anyhow!("init FLV export: {e}"))?
 			.with_latency(self.latency)
-			.with_multitrack(self.multitrack);
+			.with_multitrack(self.capabilities.multitrack);
 
 		// Resolve the catalog and codec headers before Play.Start, too. Otherwise a
 		// broadcast that never produces a playable FLV header looks successful to the
@@ -657,6 +713,66 @@ impl<S: Stream> Play<S> {
 	}
 }
 
+fn check_play_capabilities(
+	catalog: &moq_mux::catalog::hang::Catalog,
+	capabilities: &ClientCapabilities,
+) -> std::result::Result<(), String> {
+	let limit = if capabilities.multitrack { usize::MAX } else { 1 };
+
+	for config in catalog.video.renditions.values().take(limit) {
+		let Some(fourcc) = video_fourcc(&config.codec, capabilities.multitrack) else {
+			continue;
+		};
+		if !capabilities.supports_video(&fourcc) {
+			return Err(format!(
+				"client did not advertise required RTMP FourCC {}",
+				fourcc_label(&fourcc)
+			));
+		}
+	}
+
+	for config in catalog.audio.renditions.values().take(limit) {
+		let Some(fourcc) = audio_fourcc(&config.codec, capabilities.multitrack) else {
+			continue;
+		};
+		if !capabilities.supports_audio(&fourcc) {
+			return Err(format!(
+				"client did not advertise required RTMP FourCC {}",
+				fourcc_label(&fourcc)
+			));
+		}
+	}
+
+	Ok(())
+}
+
+fn video_fourcc(codec: &VideoCodec, multitrack: bool) -> Option<[u8; 4]> {
+	match codec {
+		VideoCodec::H264(_) if multitrack => Some(*b"avc1"),
+		VideoCodec::H265(_) => Some(*b"hvc1"),
+		VideoCodec::AV1(_) => Some(*b"av01"),
+		VideoCodec::VP9(_) => Some(*b"vp09"),
+		VideoCodec::H264(_) | VideoCodec::VP8 | VideoCodec::Unknown(_) => None,
+		_ => None,
+	}
+}
+
+fn audio_fourcc(codec: &AudioCodec, multitrack: bool) -> Option<[u8; 4]> {
+	match codec {
+		AudioCodec::AAC(_) if multitrack => Some(*b"mp4a"),
+		AudioCodec::Mp3 if multitrack => Some(*b".mp3"),
+		AudioCodec::Opus => Some(*b"Opus"),
+		AudioCodec::Ac3 => Some(*b"ac-3"),
+		AudioCodec::Ec3 => Some(*b"ec-3"),
+		AudioCodec::AAC(_) | AudioCodec::Mp3 | AudioCodec::Flac | AudioCodec::Mp2 | AudioCodec::Unknown(_) => None,
+		_ => None,
+	}
+}
+
+fn fourcc_label(fourcc: &[u8; 4]) -> String {
+	String::from_utf8_lossy(fourcc).into_owned()
+}
+
 /// Run one connection's handshake and connect exchange, returning a [`Request`]
 /// once the client issues `publish` or `play` (or `None` if it disconnects first).
 async fn accept_until_request<S: Stream>(mut stream: S, peer: SocketAddr) -> anyhow::Result<Option<Request<S>>> {
@@ -674,10 +790,7 @@ async fn accept_until_request<S: Stream>(mut stream: S, peer: SocketAddr) -> any
 		work.extend(results);
 	}
 
-	// Whether the client advertised enhanced-RTMP multitrack support in its
-	// connect `capsEx`. Set at connect time and carried into a later play so the
-	// FLV muxer only emits multitrack tags to a player that can parse them.
-	let mut client_multitrack = false;
+	let mut client_capabilities = ClientCapabilities::default();
 
 	let mut buffer = [0u8; READ_BUFFER];
 	loop {
@@ -692,9 +805,19 @@ async fn accept_until_request<S: Stream>(mut stream: S, peer: SocketAddr) -> any
 						request_id,
 						app_name,
 						caps_ex,
+						video_fourccs,
+						audio_fourccs,
 					} => {
-						client_multitrack = caps_ex & CAPS_EX_MULTITRACK != 0;
-						tracing::debug!(%peer, %app_name, caps_ex, client_multitrack, "rtmp connect");
+						client_capabilities = ClientCapabilities::new(caps_ex, video_fourccs, audio_fourccs);
+						tracing::debug!(
+							%peer,
+							%app_name,
+							caps_ex,
+							client_multitrack = client_capabilities.multitrack,
+							client_video_fourccs = client_capabilities.video.fourccs.len(),
+							client_audio_fourccs = client_capabilities.audio.fourccs.len(),
+							"rtmp connect"
+						);
 						// Advertise the enhanced-RTMP codecs we ingest, and our capsEx, in
 						// the connect _result.
 						session.set_connect_response_properties(advertised_connect_properties());
@@ -738,7 +861,7 @@ async fn accept_until_request<S: Stream>(mut stream: S, peer: SocketAddr) -> any
 							stream_key,
 							peer,
 							latency: crate::DEFAULT_LATENCY,
-							multitrack: client_multitrack,
+							capabilities: client_capabilities.clone(),
 						})));
 					}
 					other => tracing::trace!(%peer, ?other, "ignoring RTMP event before publish/play"),
@@ -1145,10 +1268,35 @@ mod tests {
 	/// A received RTMP media message: `is_video` and the message body.
 	type Media = (bool, bytes::Bytes);
 
+	fn set_connect_capabilities(session: &mut ClientSession, caps_ex: u32, fourccs: &[&[u8; 4]]) {
+		let mut properties = HashMap::new();
+		if caps_ex != 0 {
+			properties.insert("capsEx".to_string(), Amf0Value::Number(caps_ex as f64));
+		}
+		if !fourccs.is_empty() {
+			properties.insert(
+				"fourCcList".to_string(),
+				Amf0Value::StrictArray(
+					fourccs
+						.iter()
+						.map(|fourcc| Amf0Value::Utf8String(String::from_utf8_lossy(*fourcc).into_owned()))
+						.collect(),
+				),
+			);
+		}
+		if !properties.is_empty() {
+			session.set_connect_request_properties(properties);
+		}
+	}
+
 	/// Drive an RTMP play client over `stream` through handshake -> connect(`live`)
 	/// -> play(`cam0`), collecting media messages until `want` have arrived.
-	/// `caps_ex` is advertised in the connect `capsEx` (0 for a legacy player).
-	async fn play_client_collect<S: Stream>(mut stream: S, want: usize, caps_ex: u32) -> Vec<Media> {
+	async fn play_client_collect<S: Stream>(
+		mut stream: S,
+		want: usize,
+		caps_ex: u32,
+		fourccs: &[&[u8; 4]],
+	) -> Vec<Media> {
 		// Handshake.
 		let mut handshake = Handshake::new(PeerType::Client);
 		stream
@@ -1181,12 +1329,7 @@ mod tests {
 		if !remaining.is_empty() {
 			work.extend(session.handle_input(&remaining).unwrap());
 		}
-		if caps_ex != 0 {
-			session.set_connect_request_properties(HashMap::from([(
-				"capsEx".to_string(),
-				Amf0Value::Number(caps_ex as f64),
-			)]));
-		}
+		set_connect_capabilities(&mut session, caps_ex, fourccs);
 		work.push_back(session.request_connection("live".to_string()).unwrap());
 
 		let mut media = Vec::new();
@@ -1214,6 +1357,105 @@ mod tests {
 			let n = stream.read(&mut buffer).await.unwrap();
 			if n == 0 {
 				return media;
+			}
+			work.extend(session.handle_input(&buffer[..n]).unwrap());
+		}
+	}
+
+	async fn play_client_first_status<S: Stream>(mut stream: S, caps_ex: u32, fourccs: &[&[u8; 4]]) -> Option<String> {
+		fn raw_status(deserializer: &mut crate::rml::chunk_io::ChunkDeserializer, bytes: &[u8]) -> Option<String> {
+			let mut input = bytes;
+			while let Some(payload) = deserializer.get_next_message(input).unwrap() {
+				input = &[];
+				match payload.to_rtmp_message() {
+					Ok(crate::rml::messages::RtmpMessage::SetChunkSize { size }) => {
+						deserializer.set_max_chunk_size(size as usize).unwrap();
+					}
+					Ok(crate::rml::messages::RtmpMessage::Amf0Command {
+						command_name,
+						additional_arguments,
+						..
+					}) if command_name == "onStatus" || command_name == "_error" => {
+						let Some(Amf0Value::Object(properties)) = additional_arguments.first() else {
+							continue;
+						};
+						let Some(Amf0Value::Utf8String(code)) = properties.get("code") else {
+							continue;
+						};
+						return Some(code.clone());
+					}
+					_ => {}
+				}
+			}
+			None
+		}
+
+		let mut handshake = Handshake::new(PeerType::Client);
+		stream
+			.write_all(&handshake.generate_outbound_p0_and_p1().unwrap())
+			.await
+			.unwrap();
+		let mut buffer = [0u8; 4096];
+		let remaining = loop {
+			let n = stream.read(&mut buffer).await.unwrap();
+			match handshake.process_bytes(&buffer[..n]).unwrap() {
+				HandshakeProcessResult::InProgress { response_bytes } => {
+					if !response_bytes.is_empty() {
+						stream.write_all(&response_bytes).await.unwrap();
+					}
+				}
+				HandshakeProcessResult::Completed {
+					response_bytes,
+					remaining_bytes,
+				} => {
+					if !response_bytes.is_empty() {
+						stream.write_all(&response_bytes).await.unwrap();
+					}
+					break remaining_bytes;
+				}
+			}
+		};
+
+		let (mut session, initial) = ClientSession::new(ClientSessionConfig::new()).unwrap();
+		let mut work: VecDeque<ClientSessionResult> = VecDeque::from(initial);
+		let mut deserializer = crate::rml::chunk_io::ChunkDeserializer::new();
+		if let Some(code) = raw_status(&mut deserializer, &remaining) {
+			return Some(code);
+		}
+		if !remaining.is_empty() {
+			work.extend(session.handle_input(&remaining).unwrap());
+		}
+		set_connect_capabilities(&mut session, caps_ex, fourccs);
+		work.push_back(session.request_connection("live".to_string()).unwrap());
+
+		loop {
+			while let Some(result) = work.pop_front() {
+				match result {
+					ClientSessionResult::OutboundResponse(packet) => {
+						stream.write_all(&packet.bytes).await.unwrap();
+					}
+					ClientSessionResult::RaisedEvent(ClientSessionEvent::ConnectionRequestAccepted) => {
+						work.push_back(session.request_playback("cam0".to_string()).unwrap());
+					}
+					ClientSessionResult::RaisedEvent(ClientSessionEvent::PlaybackRequestAccepted) => {
+						return Some("NetStream.Play.Start".to_string());
+					}
+					ClientSessionResult::RaisedEvent(ClientSessionEvent::UnhandleableOnStatusCode { code }) => {
+						return Some(code);
+					}
+					ClientSessionResult::RaisedEvent(ClientSessionEvent::VideoDataReceived { .. })
+					| ClientSessionResult::RaisedEvent(ClientSessionEvent::AudioDataReceived { .. }) => {
+						return Some("media".to_string());
+					}
+					_ => {}
+				}
+			}
+			let n = stream.read(&mut buffer).await.unwrap();
+			if n == 0 {
+				return None;
+			}
+			if let Some(code) = raw_status(&mut deserializer, &buffer[..n]) {
+				return Some(code);
 			}
 			work.extend(session.handle_input(&buffer[..n]).unwrap());
 		}
@@ -1264,7 +1506,7 @@ mod tests {
 		});
 
 		let stream = TcpStream::connect(addr).await.unwrap();
-		let media = tokio::time::timeout(Duration::from_secs(5), play_client_collect(stream, 2, 0))
+		let media = tokio::time::timeout(Duration::from_secs(5), play_client_collect(stream, 2, 0, &[]))
 			.await
 			.expect("play client timed out");
 
@@ -1282,6 +1524,94 @@ mod tests {
 		assert_eq!(media[1].1[1], 0x01);
 
 		server_task.abort();
+	}
+
+	#[tokio::test]
+	async fn play_enhanced_codec_rejects_legacy_client() {
+		const VP9_KEYFRAME_320X240: &[u8] = &[0x82, 0x49, 0x83, 0x42, 0x20, 0x13, 0xf0, 0x0e, 0xf0, 0x00];
+
+		let origin = moq_net::Origin::random().produce();
+		let mut broadcast = Broadcast::new().produce();
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let mut importer = FlvImport::new(broadcast.clone(), catalog);
+		assert!(origin.publish_broadcast("live/cam0", broadcast.consume()));
+		importer.decode(&flv::file_header()).unwrap();
+
+		// Enhanced video CodedFrames keyframe: ex-header, keyframe, packet type 1.
+		let mut vp9 = vec![0x80 | (1 << 4) | 1];
+		vp9.extend_from_slice(b"vp09");
+		vp9.extend_from_slice(VP9_KEYFRAME_320X240);
+		importer.decode(&flv::tag(flv::TAG_VIDEO, 0, &vp9)).unwrap();
+		importer.finish().unwrap();
+
+		let mut server = Server::bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+		let addr = server.local_addr().unwrap();
+		let consumer = origin.consume();
+
+		let server_task = tokio::spawn(async move {
+			let request = server.accept().await.expect("a request");
+			let Request::Play(play) = request else {
+				panic!("expected a play request");
+			};
+			play.accept(&consumer, "live/cam0").await.unwrap();
+		});
+
+		let stream = TcpStream::connect(addr).await.unwrap();
+		let status = tokio::time::timeout(Duration::from_secs(5), play_client_first_status(stream, 0, &[]))
+			.await
+			.expect("play client timed out");
+
+		assert_eq!(status.as_deref(), Some("NetStream.Play.Failed"));
+		server_task.await.unwrap();
+	}
+
+	#[test]
+	fn play_capability_check_uses_per_kind_decode_support() {
+		let mut catalog = moq_mux::catalog::hang::Catalog::default();
+		catalog.video.renditions.insert(
+			"video".to_string(),
+			hang::catalog::VideoConfig::new(hang::catalog::VP9 {
+				level: 10,
+				bit_depth: 8,
+				..Default::default()
+			}),
+		);
+
+		let video_support = FourCcSupport {
+			any: false,
+			fourccs: vec![*b"vp09"],
+		};
+		assert!(
+			check_play_capabilities(
+				&catalog,
+				&ClientCapabilities::new(0, video_support, FourCcSupport::default())
+			)
+			.is_ok()
+		);
+
+		let audio_support = FourCcSupport {
+			any: false,
+			fourccs: vec![*b"vp09"],
+		};
+		assert!(
+			check_play_capabilities(
+				&catalog,
+				&ClientCapabilities::new(0, FourCcSupport::default(), audio_support)
+			)
+			.is_err()
+		);
+
+		let wildcard = FourCcSupport {
+			any: true,
+			fourccs: Vec::new(),
+		};
+		assert!(
+			check_play_capabilities(
+				&catalog,
+				&ClientCapabilities::new(0, wildcard, FourCcSupport::default())
+			)
+			.is_ok()
+		);
 	}
 
 	/// End-to-end multitrack egress: publish a broadcast carrying two H.264
@@ -1349,7 +1679,7 @@ mod tests {
 		let stream = TcpStream::connect(addr).await.unwrap();
 		let media = tokio::time::timeout(
 			Duration::from_secs(5),
-			play_client_collect(stream, 4, CAPS_EX_MULTITRACK),
+			play_client_collect(stream, 4, CAPS_EX_MULTITRACK, &[b"avc1"]),
 		)
 		.await
 		.expect("play client timed out");


### PR DESCRIPTION
## Summary

- Parse RTMP play-client codec capability advertisements from `fourCcList`, `videoFourCcInfoMap`, and `audioFourCcInfoMap` during connect.
- Reject playback with `NetStream.Play.Failed` before `Play.Start` when the broadcast would require enhanced RTMP FourCC codecs the client did not advertise it can decode.
- Keep server-side ingest capability advertisement and multitrack gating in the current vendored `rml` flow, without adding new public `moq-mux` API.

Fixes #2007.
Supersedes #2017.

## Public API Changes

- Adds `FourCcSupport` to the vendored RTMP session event surface used by `moq-rtmp`.
- Extends `ServerSessionEvent::ConnectionRequested` with per-kind video/audio FourCC support instead of a single combined list.

These are internal to the vendored RTMP module inside `moq-rtmp`; no published MoQ wire protocol changes.

## Validation

- `cargo test -p moq-rtmp`
- `nix develop --command just check`
- `git diff --check`

(Written by GPT-5)