### PR TITLE
chore(js): bump package versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -93,7 +93,7 @@
     },
     "js/hang": {
       "name": "@moq/hang",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
         "@libav.js/variant-opus-af": "^6.8.8",
@@ -115,7 +115,7 @@
     },
     "js/json": {
       "name": "@moq/json",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@moq/flate": "workspace:^",
         "@moq/net": "workspace:^",
@@ -132,7 +132,7 @@
     },
     "js/loc": {
       "name": "@moq/loc",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@moq/net": "workspace:^",
       },
@@ -144,7 +144,7 @@
     },
     "js/moq-boy": {
       "name": "@moq/boy",
-      "version": "0.2.11",
+      "version": "0.2.12",
       "dependencies": {
         "@moq/json": "workspace:^",
         "@moq/net": "workspace:^",
@@ -164,7 +164,7 @@
     },
     "js/msf": {
       "name": "@moq/msf",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@moq/net": "workspace:^",
         "zod": "^4.4.3",
@@ -176,7 +176,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "dependencies": {
         "@moq/qmux": "^0.1.3",
         "@moq/signals": "workspace:*",
@@ -196,7 +196,7 @@
     },
     "js/publish": {
       "name": "@moq/publish",
-      "version": "0.2.16",
+      "version": "0.2.17",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/json": "workspace:^",
@@ -260,7 +260,7 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.2.18",
+      "version": "0.2.19",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/json": "workspace:^",

--- a/js/flate/package.json
+++ b/js/flate/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/flate",
 	"type": "module",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Group-scoped DEFLATE: a stream of self-delimited frames sharing one compression window.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/json/package.json
+++ b/js/json/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/json",
 	"type": "module",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "JSON publishing over MoQ tracks: snapshot/delta (RFC 7396 merge patch) objects, or append-log NDJSON streams.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/loc/package.json
+++ b/js/loc/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/loc",
 	"type": "module",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Low Overhead Container (LOC) frame encoding for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/boy",
 	"type": "module",
-	"version": "0.2.11",
+	"version": "0.2.12",
 	"jsr": false,
 	"description": "MoQ Boy - Crowd-controlled Game Boy streaming via MoQ",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/msf/package.json
+++ b/js/msf/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/msf",
 	"type": "module",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"description": "MSF (MOQT Streaming Format) catalog types for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.2.16",
+	"version": "0.2.17",
 	"jsr": false,
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.2.18",
+	"version": "0.2.19",
 	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",


### PR DESCRIPTION
## Summary

- Bump JS package versions for packages with unreleased runtime changes.
- Keep every bump at patch level because there are no package-exported public API additions.
- Update `bun.lock` workspace metadata to match the package manifests.

## Public API changes

None. I checked the apparent protocol submodule additions in `@moq/net`, but they are not exposed by the package export map, so the published package surface does not gain a new public API.

## Validation

- `git diff --check`

(Written by GPT-5)
