### PR TITLE
Expose moq-bench as a flake package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -218,6 +218,7 @@
           inherit (overlayPkgs)
             moq-relay
             moq-cli
+            moq-bench
             moq-token
             moq-token-cli
             moq-boy
@@ -241,6 +242,7 @@
           inherit (overlayPkgs)
             moq-relay-x86_64-apple-darwin
             moq-cli-x86_64-apple-darwin
+            moq-bench-x86_64-apple-darwin
             moq-token-x86_64-apple-darwin
             moq-token-cli-x86_64-apple-darwin
             libmoq-x86_64-apple-darwin

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -70,6 +70,11 @@ let
   moqTokenPackage = craneLib.buildPackage moqTokenCliArgs;
   moqTokenX86DarwinPackage = craneLib.buildPackage (crossX86Darwin moqTokenCliArgs);
 
+  moqBenchArgs = crateInfo ../rs/moq-bench/Cargo.toml // {
+    src = craneLib.cleanCargoSource ../.;
+    cargoExtraArgs = "-p moq-bench";
+  };
+
   libmoqInfo = crateInfo ../rs/libmoq/Cargo.toml;
   libmoqArgs = libmoqInfo // {
     # libmoq's build.rs reads moq.pc.in at compile time to generate the
@@ -226,6 +231,9 @@ in
 
   moq-cli = craneLib.buildPackage moqCliArgs;
   moq-cli-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqCliArgs);
+
+  moq-bench = craneLib.buildPackage moqBenchArgs;
+  moq-bench-x86_64-apple-darwin = craneLib.buildPackage (crossX86Darwin moqBenchArgs);
 
   moq-token = moqTokenPackage;
   moq-token-cli = moqTokenPackage;


### PR DESCRIPTION
## Summary
- add moq-bench to the Nix overlay package set
- expose moq-bench from the root flake outputs
- include the existing x86_64 Darwin cross package variant

## Validation
- `nix develop /private/tmp/moq-bench-flake --command nixfmt /private/tmp/moq-bench-flake/flake.nix /private/tmp/moq-bench-flake/nix/overlay.nix`
- `nix eval --raw /private/tmp/moq-bench-flake#moq-bench.name`
- `nix build /private/tmp/moq-bench-flake#moq-bench --no-link`
- `nix run /private/tmp/moq-bench-flake#moq-bench -- --help`