### PR TITLE
fix(moq-net): reclaim closed dynamic-cache entries with amortized GC

### DIFF
--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -1,13 +1,13 @@
 use crate::track;
 use std::{
-	collections::{HashMap, VecDeque, hash_map},
+	collections::{HashMap, VecDeque},
 	sync::Arc,
 	task::{Poll, ready},
 };
 
 use crate::Error;
 
-use super::OriginList;
+use super::{OriginList, WeakCache};
 
 /// A collection of media tracks that can be published and subscribed to.
 ///
@@ -57,7 +57,9 @@ impl Info {
 struct BroadcastState {
 	// Weak references for deduplication. Doesn't prevent track auto-close.
 	// Keyed by the track's shared `Arc<str>` name (the same Arc the handle holds).
-	tracks: HashMap<Arc<str>, track::TrackWeak>,
+	// The cache reclaims closed entries incrementally on insert so a long-lived
+	// broadcast churning distinct track names stays bounded by the live count.
+	tracks: WeakCache<Arc<str>, track::TrackWeak>,
 
 	// Pending requests keyed by track name, waiting for the dynamic handler to
 	// accept or deny them.
@@ -81,13 +83,13 @@ impl BroadcastState {
 		state.write().map_err(|_| Error::Dropped)
 	}
 
-	/// Insert a track weak handle into the lookup, returning an error on duplicate.
+	/// Insert a track weak handle into the lookup, returning an error if a live
+	/// track already holds the name. A closed entry under the name is reclaimed.
 	fn insert_track(&mut self, weak: track::TrackWeak) -> Result<(), Error> {
-		let hash_map::Entry::Vacant(entry) = self.tracks.entry(weak.name().clone()) else {
-			return Err(Error::Duplicate);
-		};
-		entry.insert(weak);
-		Ok(())
+		match self.tracks.insert(weak.name().clone(), weak) {
+			Some(_) => Err(Error::Duplicate),
+			None => Ok(()),
+		}
 	}
 
 	/// Reject any pending dynamic track requests. Called when the last dynamic handler
@@ -337,7 +339,9 @@ impl Dynamic {
 
 		let name = state.request_order.pop_front().expect("predicate guaranteed a request");
 		let pending = state.requests.remove(&name).expect("request_order out of sync");
-		state.tracks.insert(name, pending.weak());
+		// Cache the served track so concurrent lookups coalesce onto it. If a live track already
+		// holds the name (a publish raced the request), `insert` keeps it rather than shadowing it.
+		let _ = state.tracks.insert(name, pending.weak());
 		Poll::Ready(Ok(pending))
 	}
 
@@ -418,13 +422,10 @@ impl Consumer {
 			Err(_) => return Err(Error::Dropped),
 		};
 
-		// Reuse a live producer if one is already publishing the track.
+		// Reuse a live producer if one is already publishing the track. `get` drops a
+		// closed entry and returns `None`, so we fall through to a fresh request.
 		if let Some(weak) = state.tracks.get(name) {
-			if !weak.is_closed() {
-				return Ok(weak.consume());
-			}
-			// Drop the stale entry and fall through to a fresh request.
-			state.tracks.remove(name);
+			return Ok(weak.consume());
 		}
 
 		if let Some(pending) = state.requests.get_mut(name) {
@@ -500,17 +501,22 @@ pub(crate) struct WeakConsumer {
 }
 
 impl WeakConsumer {
-	/// True once every [`Producer`] has been dropped.
-	pub fn is_closed(&self) -> bool {
-		self.state.is_closed()
-	}
-
 	/// Upgrade to a full [`Consumer`] sharing the same broadcast state.
 	pub fn consume(&self) -> Consumer {
 		Consumer {
 			info: self.info.clone(),
 			state: self.state.consume(),
 		}
+	}
+}
+
+impl super::WeakEntry for WeakConsumer {
+	fn is_closed(&self) -> bool {
+		self.state.is_closed()
+	}
+
+	fn same_channel(&self, other: &Self) -> bool {
+		self.state.same_channel(&other.state)
 	}
 }
 

--- a/rs/moq-net/src/model/mod.rs
+++ b/rs/moq-net/src/model/mod.rs
@@ -15,6 +15,9 @@ mod bytes;
 mod datagram;
 mod subscription;
 mod time;
+mod weak_cache;
+
+pub(crate) use weak_cache::{WeakCache, WeakEntry};
 
 pub use bandwidth::*;
 pub use bytes::*;

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -9,6 +9,7 @@ use std::{
 use rand::RngExt;
 use web_async::Lock;
 
+use super::WeakCache;
 use crate::{
 	AsPath, Error, Path, PathOwned, PathPrefixes,
 	coding::{Decode, DecodeError, Encode, EncodeError},
@@ -1104,8 +1105,9 @@ struct OriginDynamicState {
 	// Broadcasts a handler has already served, kept weakly so a repeat request for the
 	// same path resolves to a shared clone instead of re-invoking the handler (which would
 	// open a duplicate upstream subscription). Weak so a served broadcast still closes once
-	// its real consumers drop; a stale (closed) entry is evicted lazily on the next request.
-	served: HashMap<PathOwned, broadcast::WeakConsumer>,
+	// its real consumers drop. The cache reclaims closed entries incrementally on insert, so a
+	// long-lived origin serving many distinct one-shot paths stays bounded by the live count.
+	served: WeakCache<PathOwned, broadcast::WeakConsumer>,
 
 	// The number of live `Dynamic` handlers. While zero, `request_broadcast`
 	// fails fast with `Unroutable` rather than queueing a request nobody will serve.
@@ -1273,14 +1275,19 @@ impl Request {
 
 		// Move the entry out of the in-flight queue and into the weak `served` cache, so repeat
 		// requests for this path share the same broadcast instead of asking the handler to serve
-		// (and subscribe upstream) again.
-		if let Ok(mut state) = self.state.write() {
-			state.served.insert(self.path.clone(), broadcast.weak());
+		// (and subscribe upstream) again. Re-check under the lock: if a live broadcast was already
+		// served for this path while we were fetching upstream, dedup onto it and drop ours rather
+		// than replace a good entry with a duplicate subscription.
+		let resolved = if let Ok(mut state) = self.state.write() {
+			let existing = state.served.insert(self.path.clone(), broadcast.weak());
 			state.requests.remove(&self.path);
-		}
+			existing.map(|weak| weak.consume()).unwrap_or(broadcast)
+		} else {
+			broadcast
+		};
 
 		if let Ok(mut pending) = self.producer.write() {
-			pending.resolved = Some(Ok(broadcast));
+			pending.resolved = Some(Ok(resolved));
 		}
 		// `self.producer` drops here, closing the channel; the value is still observable.
 	}
@@ -1604,13 +1611,10 @@ impl Consumer {
 		};
 
 		// Reuse a still-live broadcast a handler already served for this path, so repeat
-		// requests share one upstream subscription. A closed entry is stale; drop it and
-		// re-serve below.
+		// requests share one upstream subscription. A closed entry is stale; `get` drops it
+		// and returns `None`, so we fall through and re-serve below.
 		if let Some(weak) = state.served.get(&absolute) {
-			if !weak.is_closed() {
-				return kio::Pending::new(Requested::ready(weak.consume()));
-			}
-			state.served.remove(&absolute);
+			return kio::Pending::new(Requested::ready(weak.consume()));
 		}
 
 		// Coalesce onto a queued request for the same path; otherwise register a new one.
@@ -3278,6 +3282,34 @@ mod tests {
 		assert_eq!(request.path(), &Path::new("fallback"));
 		request.accept(&served);
 		assert!(request_fut.await.unwrap().is_clone(&served.consume()));
+	}
+
+	// Serving many distinct one-shot paths that each close must not grow the `served` cache
+	// unboundedly: the amortized GC on `accept` reclaims the stale entries left by closed ones.
+	#[tokio::test(start_paused = true)]
+	async fn dynamic_request_served_cache_bounded() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+		let consumer = origin.consume();
+
+		for i in 0..100 {
+			let path = format!("one-shot/{i}");
+			let request_fut = consumer.request_broadcast(&path);
+			let served = broadcast::Info::new().produce();
+			let request = dynamic.requested_broadcast().await.unwrap();
+			request.accept(&served);
+			request_fut.await.unwrap();
+			// Close the served broadcast; its cache entry is now stale.
+			drop(served);
+		}
+
+		// The GC keeps the map bounded by the live count (zero here) plus a small probe window,
+		// rather than one entry per distinct path.
+		assert!(
+			origin.dynamic.read().served.len() <= 4,
+			"stale served entries must be reclaimed, not accumulate per distinct path: {}",
+			origin.dynamic.read().served.len()
+		);
 	}
 
 	// A repeat request in the window after the handler picks one up but before it accepts

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1142,10 +1142,6 @@ pub(crate) struct TrackWeak {
 }
 
 impl TrackWeak {
-	pub fn is_closed(&self) -> bool {
-		self.state.is_closed()
-	}
-
 	pub fn consume(&self) -> Consumer {
 		Consumer {
 			name: self.name.clone(),
@@ -1157,6 +1153,16 @@ impl TrackWeak {
 	/// refcount bump, and the same `Arc` is shared with the track's handles).
 	pub(crate) fn name(&self) -> &Arc<str> {
 		&self.name
+	}
+}
+
+impl super::WeakEntry for TrackWeak {
+	fn is_closed(&self) -> bool {
+		self.state.is_closed()
+	}
+
+	fn same_channel(&self, other: &Self) -> bool {
+		self.state.same_channel(&other.state)
 	}
 }
 

--- a/rs/moq-net/src/model/weak_cache.rs
+++ b/rs/moq-net/src/model/weak_cache.rs
@@ -1,0 +1,270 @@
+//! A keyed cache of weak handles with amortized garbage collection.
+
+use std::{
+	borrow::Borrow,
+	collections::{HashMap, VecDeque},
+	hash::Hash,
+};
+
+/// A weak handle whose liveness and identity the cache can probe.
+///
+/// Implemented by the weak consumer handles cached for dynamic dedup
+/// ([`super::broadcast::WeakConsumer`], [`super::track::TrackWeak`]).
+pub(crate) trait WeakEntry {
+	/// True once the underlying channel has closed (every producer dropped).
+	fn is_closed(&self) -> bool;
+
+	/// True if `self` and `other` reference the same underlying channel.
+	///
+	/// Used to tell a live entry apart from a superseded twin: the same key can
+	/// hold a fresh handle after an older one closed, leaving a stale copy in the
+	/// probe ring.
+	fn same_channel(&self, other: &Self) -> bool;
+}
+
+/// Number of ring slots probed per insert. A small constant keeps each insert
+/// O(1) while the rotating window covers the whole cache over successive inserts.
+/// Mirrors the bound in kio's `WaiterList`.
+const GC_PROBE: usize = 2;
+
+/// A map of weak handles that reclaims closed entries incrementally.
+///
+/// Deduplicates dynamically-served handles by key: [`get`](Self::get) returns a
+/// live handle and drops a closed one, so a stale entry never resolves. The catch
+/// is that a key requested once and never again would otherwise linger forever
+/// (its handle closes but nothing re-looks-it-up), so a long-lived cache accreting
+/// distinct one-shot keys leaks one dead entry per key.
+///
+/// Rather than an O(n) sweep on every insert, each [`insert`](Self::insert) probes
+/// a bounded, rotating slice of the keys (like Redis sampling expired keys, or the
+/// rotating cursor in kio's `WaiterList`) and drops any that have closed or been
+/// superseded. The cache stays bounded by the number of currently-live handles
+/// without ever scanning all of it.
+pub(crate) struct WeakCache<K, V> {
+	map: HashMap<K, V>,
+
+	// Rotating probe queue, one entry per key plus transient junk: keys already
+	// removed from `map`, and superseded duplicates (a key re-inserted with a fresh
+	// handle after the old one closed). GC discards both when it reaches them,
+	// telling a live entry from its superseded twin via `same_channel`, so the ring
+	// stays bounded by `map`'s size.
+	ring: VecDeque<(K, V)>,
+}
+
+impl<K, V> Default for WeakCache<K, V> {
+	fn default() -> Self {
+		Self {
+			map: HashMap::new(),
+			ring: VecDeque::new(),
+		}
+	}
+}
+
+impl<K, V> WeakCache<K, V>
+where
+	K: Clone + Eq + Hash,
+	V: WeakEntry + Clone,
+{
+	/// Return a live handle for `key`, dropping and ignoring a closed one.
+	pub fn get<Q>(&mut self, key: &Q) -> Option<V>
+	where
+		K: Borrow<Q>,
+		Q: Hash + Eq + ?Sized,
+	{
+		match self.map.get(key) {
+			Some(v) if !v.is_closed() => Some(v.clone()),
+			Some(_) => {
+				self.map.remove(key);
+				None
+			}
+			None => None,
+		}
+	}
+
+	/// Insert `value` under `key`, unless a *live* entry already holds it.
+	///
+	/// Returns the existing live handle (leaving it in place) when the key is
+	/// already live, so a caller racing to serve the same key can dedup onto it
+	/// rather than replace a good entry. Otherwise inserts `value` (replacing a
+	/// closed entry), runs a bounded GC pass, and returns `None`.
+	pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+		if let Some(existing) = self.map.get(&key)
+			&& !existing.is_closed()
+		{
+			return Some(existing.clone());
+		}
+
+		self.map.insert(key.clone(), value.clone());
+		self.gc();
+		self.ring.push_back((key, value));
+		None
+	}
+
+	/// Remove and return the entry for `key`, if any.
+	pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+	where
+		K: Borrow<Q>,
+		Q: Hash + Eq + ?Sized,
+	{
+		self.map.remove(key)
+	}
+
+	/// True if `key` has an entry, whether live or closed-but-not-yet-reclaimed.
+	pub fn contains_key<Q>(&self, key: &Q) -> bool
+	where
+		K: Borrow<Q>,
+		Q: Hash + Eq + ?Sized,
+	{
+		self.map.contains_key(key)
+	}
+
+	/// Probe a bounded, rotating window of the ring, reclaiming dead entries.
+	fn gc(&mut self) {
+		for _ in 0..self.ring.len().min(GC_PROBE) {
+			let Some((key, entry)) = self.ring.pop_front() else {
+				break;
+			};
+
+			enum Probe {
+				// Live and still the current handle for its key: rotate to the back.
+				Keep,
+				// Closed: reclaim the map entry.
+				Reclaim,
+				// Already removed, or superseded by a newer handle: drop the ring entry.
+				Drop,
+			}
+
+			let probe = match self.map.get(&key) {
+				Some(cur) if !cur.same_channel(&entry) => Probe::Drop,
+				Some(cur) if cur.is_closed() => Probe::Reclaim,
+				Some(_) => Probe::Keep,
+				None => Probe::Drop,
+			};
+
+			match probe {
+				Probe::Keep => self.ring.push_back((key, entry)),
+				Probe::Reclaim => {
+					self.map.remove(&key);
+				}
+				Probe::Drop => {}
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+impl<K, V> WeakCache<K, V> {
+	/// Number of entries currently in the map (live or not-yet-reclaimed).
+	pub fn len(&self) -> usize {
+		self.map.len()
+	}
+
+	/// Number of entries retained in the probe ring.
+	pub fn ring_len(&self) -> usize {
+		self.ring.len()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::sync::{
+		Arc,
+		atomic::{AtomicBool, Ordering},
+	};
+
+	// A fake weak handle: liveness is a shared flag, identity is the `Arc` pointer.
+	#[derive(Clone)]
+	struct Fake(Arc<AtomicBool>);
+
+	impl Fake {
+		fn open() -> Self {
+			Self(Arc::new(AtomicBool::new(false)))
+		}
+
+		fn close(&self) {
+			self.0.store(true, Ordering::SeqCst);
+		}
+	}
+
+	impl WeakEntry for Fake {
+		fn is_closed(&self) -> bool {
+			self.0.load(Ordering::SeqCst)
+		}
+
+		fn same_channel(&self, other: &Self) -> bool {
+			Arc::ptr_eq(&self.0, &other.0)
+		}
+	}
+
+	#[test]
+	fn get_drops_closed() {
+		let mut cache = WeakCache::default();
+		let entry = Fake::open();
+		cache.insert("a", entry.clone());
+		assert!(cache.get("a").is_some());
+
+		entry.close();
+		assert!(cache.get("a").is_none(), "a closed entry must not resolve");
+		assert_eq!(cache.len(), 0, "the closed entry is dropped on lookup");
+	}
+
+	#[test]
+	fn distinct_one_shot_paths_stay_bounded() {
+		// The reported leak: many distinct keys, each served once then closed and never
+		// requested again. Amortized GC must keep the map bounded rather than growing per key.
+		let mut cache = WeakCache::default();
+		for i in 0..1000 {
+			let entry = Fake::open();
+			cache.insert(i, entry.clone());
+			entry.close();
+		}
+		assert!(cache.len() <= GC_PROBE + 1, "map grew unbounded: {}", cache.len());
+		assert!(
+			cache.ring_len() <= GC_PROBE + 1,
+			"ring grew unbounded: {}",
+			cache.ring_len()
+		);
+	}
+
+	#[test]
+	fn same_key_churn_does_not_leak() {
+		// Re-serving the same key with a fresh handle after the old one closed leaves a stale
+		// twin in the ring. `same_channel` must let GC discard it; a key-only ring would keep
+		// rotating the twin forever (it points at a now-live key) and grow without bound.
+		let mut cache = WeakCache::default();
+		for _ in 0..1000 {
+			let entry = Fake::open();
+			cache.insert("hot", entry.clone());
+			entry.close();
+		}
+		assert_eq!(cache.len(), 1, "one key must map to at most one entry");
+		assert!(
+			cache.ring_len() <= 2,
+			"superseded twins must not accumulate: {}",
+			cache.ring_len()
+		);
+	}
+
+	#[test]
+	fn insert_dedups_live_replaces_closed() {
+		let mut cache = WeakCache::default();
+		let first = Fake::open();
+		assert!(
+			cache.insert("a", first.clone()).is_none(),
+			"first insert takes the slot"
+		);
+
+		// A live entry is kept: the racing insert gets it back and is not applied.
+		let second = Fake::open();
+		let existing = cache.insert("a", second.clone()).expect("live entry returned");
+		assert!(existing.same_channel(&first), "the existing live entry wins");
+		assert!(cache.get("a").expect("still present").same_channel(&first));
+
+		// Once the live entry closes, the name is free and a fresh insert replaces it.
+		first.close();
+		let third = Fake::open();
+		assert!(cache.insert("a", third.clone()).is_none(), "closed entry is replaced");
+		assert!(cache.get("a").expect("present").same_channel(&third));
+	}
+}

--- a/rs/moq-net/src/model/weak_cache.rs
+++ b/rs/moq-net/src/model/weak_cache.rs
@@ -47,7 +47,9 @@ pub(crate) struct WeakCache<K, V> {
 	// removed from `map`, and superseded duplicates (a key re-inserted with a fresh
 	// handle after the old one closed). GC discards both when it reaches them,
 	// telling a live entry from its superseded twin via `same_channel`, so the ring
-	// stays bounded by `map`'s size.
+	// stays bounded by the live-handle count. It can reach ~2x the map when one key
+	// churns behind many live keys (its twins wait their turn under the probe cursor),
+	// but that is still O(live), not a per-key leak.
 	ring: VecDeque<(K, V)>,
 }
 

--- a/rs/moq-net/src/model/weak_cache.rs
+++ b/rs/moq-net/src/model/weak_cache.rs
@@ -108,6 +108,10 @@ where
 		K: Borrow<Q>,
 		Q: Hash + Eq + ?Sized,
 	{
+		// Prune the ring too. Unlike a lazily-dropped closed entry (which a later insert's GC
+		// sweeps), an explicit remove has no follow-up insert to rely on, so scan it out now
+		// rather than pin the handle (and its kio state) until one happens to arrive.
+		self.ring.retain(|(k, _)| k.borrow() != key);
 		self.map.remove(key)
 	}
 
@@ -209,6 +213,21 @@ mod tests {
 		entry.close();
 		assert!(cache.get("a").is_none(), "a closed entry must not resolve");
 		assert_eq!(cache.len(), 0, "the closed entry is dropped on lookup");
+	}
+
+	#[test]
+	fn remove_prunes_ring() {
+		// An explicit remove must free the handle from the ring too, not just the map, so a
+		// batch of removes with no follow-up insert doesn't pin the handles until GC runs.
+		let mut cache = WeakCache::default();
+		cache.insert("a", Fake::open());
+		cache.insert("b", Fake::open());
+		assert_eq!(cache.ring_len(), 2);
+
+		assert!(cache.remove("a").is_some());
+		assert_eq!(cache.len(), 1);
+		assert_eq!(cache.ring_len(), 1, "remove must prune the ring, not just the map");
+		assert!(cache.remove("a").is_none(), "already removed");
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

Fixes #2125.

The origin's `served` cache (`HashMap<PathOwned, broadcast::WeakConsumer>`, from the dedup cache in #1371) and a broadcast's `tracks` cache (`HashMap<Arc<str>, track::TrackWeak>`) both deduplicate dynamically-served handles by key, keeping each weakly. A closed entry was only ever evicted **lazily**, when its exact key was requested again. So a long-lived origin serving many *distinct* one-shot paths (each requested once, then never again) accumulated one dead entry per path for the origin's lifetime — each pinning a kio state allocation plus the map entry and key. The same shape applies to a long-lived broadcast churning distinct track names.

### Approach

Rather than an O(n) full sweep on every insert, this introduces `WeakCache<K, V>` — a keyed weak-handle map that reclaims closed entries **incrementally**. Each insert probes a small, bounded, rotating slice of the keys (like Redis sampling expired keys, or the rotating-cursor GC in kio's `WaiterList`) and drops any that have closed or been superseded. The map stays bounded by the number of currently-live handles without ever scanning all of it, and per-insert cost stays O(1).

**Churn-safety:** re-serving a key with a fresh handle after the old one closed leaves a stale twin in the probe ring. A key-only ring would rotate that twin forever (it now points at a live key) and grow without bound, so entries are disambiguated by identity via `same_channel` (exposed on `kio::Weak`) — the same "each entry has a unique identity" property kio's `WaiterList` relies on.

**Insert checks the existing entry.** `insert` no longer blindly overwrites: if a still-*live* entry already holds the key, it keeps and returns it instead of replacing a good handle. `origin::Request::accept` uses this to re-check under the lock — if a live broadcast was already served for the path while this handler was fetching upstream, it dedups onto the existing one and drops its own rather than installing a duplicate upstream subscription. A closed entry is still replaced.

**Explicit remove prunes the ring.** `WeakCache::remove` (used by `Producer::remove_track`) scans the matching entries out of the probe ring, not just the map, so removing a batch of tracks with no follow-up insert frees each handle immediately rather than pinning it (and its kio state) until GC happens to sweep it. It's a cold path, so the O(ring) walk is fine.

This replaces an earlier version of this PR that did a full `retain` sweep on insert.

### Changes

- New `model/weak_cache.rs`: `WeakCache<K, V>` + the `WeakEntry` trait (`is_closed` + `same_channel`), both `pub(crate)`.
- `broadcast::WeakConsumer` and `track::TrackWeak` implement `WeakEntry` (their now-redundant inherent `is_closed` methods are removed).
- `origin::served` and `broadcast::tracks` switch from `HashMap` to `WeakCache`; `origin::Request::accept` dedups onto a live existing entry; `remove` prunes the ring.
- Side effect: recreating a track whose previous handle already closed now succeeds instead of returning `Duplicate` (a closed name is reclaimable). Previously it depended on whether the closed entry had been lazily evicted yet; now it's deterministic.

## Public API

No public API changes. `WeakConsumer`/`TrackWeak` are `pub(crate)`; `WeakCache`/`WeakEntry` are `pub(crate)`. The observable behavior changes (recreate-after-close succeeding; accept deduping a raced live entry) are on internal state, not a signature.

## Cross-package sync

No `js/net` counterpart: the dynamic served-broadcast/track dedup caches are Rust-relay-internal (no `origin.ts` request-broadcast path in `js/net`). No wire or doc changes.

## Test plan

- [x] `weak_cache` unit tests: `get` drops closed; distinct one-shot keys stay bounded (1000 inserts -> map ≤ `GC_PROBE + 1`); same-key churn doesn't leak the ring (identity disambiguation); `insert` dedups a live entry and replaces a closed one; `remove` prunes the ring.
- [x] `dynamic_request_served_cache_bounded`: 100 distinct one-shot origin paths that each close -> `served.len() <= 4` (was 100).
- [x] `cargo test -p moq-net --lib` (450 passed)
- [x] `cargo clippy -p moq-net --all-targets` clean
- [x] `cargo fmt -p moq-net -- --check` clean (via the nix toolchain)
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps` clean
- [x] `moq-relay` / `hang` / `moq-mux` build clean

Targets `dev` because the origin `served` cache (#1371) currently lives only on `dev`.

(Written by Claude Opus 4.8)