### PR TITLE
Add RTC H.265 and AV1 ingest bridges

### DIFF
--- a/rs/moq-rtc/src/codec/av1.rs
+++ b/rs/moq-rtc/src/codec/av1.rs
@@ -1,0 +1,35 @@
+//! AV1 bridge.
+//!
+//! str0m hands us complete AV1 temporal units (OBU-framed, with inline sequence
+//! headers). This feeds the moq-mux AV1 splitter/importer so catalog config and
+//! keyframe detection stay shared with the other ingest paths.
+
+use crate::{Result, codec};
+
+/// Bridges str0m AV1 temporal units into a MoQ AV1 track.
+pub struct Bridge {
+	split: moq_mux::codec::av1::Split,
+	import: moq_mux::codec::av1::Import,
+}
+
+impl Bridge {
+	/// Publish an `.av1` track on `broadcast`, adding the catalog rendition once config is known.
+	pub fn new(mut broadcast: moq_net::BroadcastProducer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
+		let track = moq_mux::import::unique_track(&mut broadcast, ".av1")?;
+		let import = moq_mux::codec::av1::Import::new(track, catalog);
+		let split = moq_mux::codec::av1::Split::new();
+		Ok(Self { split, import })
+	}
+}
+
+impl codec::Bridge for Bridge {
+	fn push(&mut self, frame: codec::Frame) -> Result<()> {
+		let pts = moq_mux::container::Timestamp::from_micros(frame.timestamp_us)
+			.map_err(|err| crate::Error::Other(anyhow::anyhow!("invalid timestamp: {err}")))?;
+		// str0m hands over one whole temporal unit per frame, so flush to emit it.
+		let mut frames = self.split.decode(&frame.payload, Some(pts))?;
+		frames.extend(self.split.flush(Some(pts))?);
+		self.import.decode(frames)?;
+		Ok(())
+	}
+}

--- a/rs/moq-rtc/src/codec/h265.rs
+++ b/rs/moq-rtc/src/codec/h265.rs
@@ -1,0 +1,36 @@
+//! H.265 bridge.
+//!
+//! str0m hands us reassembled Annex-B frames (start-code prefixed NALs with
+//! inline VPS/SPS/PPS), which is the `hev1` shape
+//! [`moq_mux::codec::h265::Import`] wants. We convert timestamps and stream
+//! NALs through the shared splitter/importer.
+
+use crate::{Result, codec};
+
+/// Bridges str0m H.265 Annex-B access units into a MoQ H.265 track.
+pub struct Bridge {
+	split: moq_mux::codec::h265::Split,
+	import: moq_mux::codec::h265::Import,
+}
+
+impl Bridge {
+	/// Publish a `.hev1` track on `broadcast`, adding the catalog rendition once config is known.
+	pub fn new(mut broadcast: moq_net::BroadcastProducer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
+		let track = moq_mux::import::unique_track(&mut broadcast, ".hev1")?;
+		let import = moq_mux::codec::h265::Import::new(track, catalog);
+		let split = moq_mux::codec::h265::Split::new();
+		Ok(Self { split, import })
+	}
+}
+
+impl codec::Bridge for Bridge {
+	fn push(&mut self, frame: codec::Frame) -> Result<()> {
+		let pts = moq_mux::container::Timestamp::from_micros(frame.timestamp_us)
+			.map_err(|err| crate::Error::Other(anyhow::anyhow!("invalid timestamp: {err}")))?;
+		// str0m hands over one whole access unit per frame, so flush to emit it.
+		let mut frames = self.split.decode(&frame.payload, Some(pts))?;
+		frames.extend(self.split.flush(Some(pts))?);
+		self.import.decode(frames)?;
+		Ok(())
+	}
+}

--- a/rs/moq-rtc/src/codec/mod.rs
+++ b/rs/moq-rtc/src/codec/mod.rs
@@ -8,7 +8,9 @@
 //!   broadcast and the track yields RTP-ready codec frames that the
 //!   session loop hands to [`str0m::media::Writer::write`].
 
+pub mod av1;
 pub mod h264;
+pub mod h265;
 pub mod opus;
 pub mod vp8;
 pub mod vp9;

--- a/rs/moq-rtc/src/ingest.rs
+++ b/rs/moq-rtc/src/ingest.rs
@@ -46,11 +46,17 @@ impl session::MediaSink for IngestSink {
 			str0m::format::Codec::H264 => {
 				Box::new(codec::h264::Bridge::new(self.broadcast.clone(), self.catalog.clone())?)
 			}
+			str0m::format::Codec::H265 => {
+				Box::new(codec::h265::Bridge::new(self.broadcast.clone(), self.catalog.clone())?)
+			}
 			str0m::format::Codec::Vp8 => {
 				Box::new(codec::vp8::Bridge::new(self.broadcast.clone(), self.catalog.clone())?)
 			}
 			str0m::format::Codec::Vp9 => {
 				Box::new(codec::vp9::Bridge::new(self.broadcast.clone(), self.catalog.clone())?)
+			}
+			str0m::format::Codec::Av1 => {
+				Box::new(codec::av1::Bridge::new(self.broadcast.clone(), self.catalog.clone())?)
 			}
 			other => return Err(Error::UnsupportedCodec(format!("{other:?}"))),
 		};

--- a/rs/moq-rtc/src/lib.rs
+++ b/rs/moq-rtc/src/lib.rs
@@ -32,10 +32,10 @@
 //!
 //! ## Bitstream gotcha
 //!
-//! The WebRTC ↔ MoQ shape conversion for H.264 is handled by `moq-mux`'s
-//! `Avc3` importer: str0m hands us Annex-B (start-code NALs with inline
-//! SPS/PPS) and that's exactly what the importer wants, so no extra
-//! transform is needed in the gateway. Opus, VP8, and VP9 pass through.
+//! The WebRTC ↔ MoQ shape conversion for H.264 and H.265 is handled by
+//! `moq-mux` importers: str0m hands us Annex-B (start-code NALs with inline
+//! parameter sets) and that's exactly what the importers want. AV1 uses the
+//! shared OBU splitter/importer. Opus, VP8, and VP9 pass through.
 
 pub mod client;
 pub mod codec;


### PR DESCRIPTION
## Summary

- Add H.265 and AV1 codec bridge modules for `moq-rtc` WHIP ingest.
- Wire `str0m::format::Codec::H265` and `Codec::Av1` into ingest track dispatch.
- Update the crate bitstream notes to include the shared H.265 and AV1 mux importer paths.

## Public API changes

- Adds exported `moq_rtc::codec::h265` and `moq_rtc::codec::av1` modules, each with a `Bridge` type matching the existing ingest bridge pattern.
- No existing public API is renamed, removed, or signature-changed. This is additive and targets `main`.

## Validation

- `cargo check -p moq-rtc`
- `nix develop --command just fix`
- `nix develop --command just check`

Closes #2133

(Written by GPT-5)