### PR TITLE
feat: moq-transcode, just-in-time transcoding for hang broadcasts (NVENC-capable)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dtoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,6 +2083,18 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fast_image_resize"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc7fe45cf92b43817ff62a3723e862b85bd1d06288f63007f7645d1d2f7a060"
+dependencies = [
+ "cfg-if",
+ "document-features",
+ "num-traits",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3865,6 +3886,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "local-ip-address"
 version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4452,6 +4479,25 @@ dependencies = [
  "anyhow",
  "clap",
  "moq-token",
+]
+
+[[package]]
+name = "moq-transcode"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "clap",
+ "fast_image_resize",
+ "hang",
+ "moq-mux",
+ "moq-native",
+ "moq-net",
+ "moq-video",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "rs/moq-srt",
     "rs/moq-token",
     "rs/moq-token-cli",
+    "rs/moq-transcode",
     "rs/moq-video",
     "rs/moq-wasm",
 ]
@@ -52,7 +53,7 @@ default-members = [
     "rs/moq-srt",
     "rs/moq-token",
     "rs/moq-token-cli",
-    # "rs/moq-wasm",  # wasm32-unknown-unknown target only
+    "rs/moq-transcode",
     "rs/moq-video",
     # "rs/moq-wasm",  # wasm32-unknown-unknown target only
 ]

--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -26,7 +26,8 @@ Layered roughly transport -> container/format -> media -> apps/bindings.
 
 - `moq-mux` (lib): the conversion layer. File/stream formats (`container/`: fmp4, flv, mkv, ts, loc) and codec parsers (`codec/`: h264, h265, av1, vp8/9, opus, aac, ...) <-> hang broadcasts. `Container` trait + generic `Producer<C>`/`Consumer<C>`. Dual catalog (`catalog::hang`, `catalog::msf`).
 - `moq-audio` (lib): native PCM <-> Opus (`unsafe-libopus`). `AudioProducer`/`AudioConsumer`, `Encoder`/`Decoder`, `AudioFormat`. Optional `capture` feature (cpal microphone), `resample`.
-- `moq-video` (lib): native webcam capture + H.264 via `ffmpeg-next`. `capture::Config`, `encode::{Encoder, Producer, publish_capture}`. ffmpeg types kept out of the public signature (see `error/`).
+- `moq-video` (lib): native video capture, H.264/H.265 encode, and decode; no ffmpeg. Hardware backends (VideoToolbox / Media Foundation / NVENC / VAAPI) with openh264 as the software H.264 fallback. `capture::Config`, `encode::{Encoder, Producer, publish_capture}`, `decode::{Consumer, Decoder}`.
+- `moq-transcode` (lib): just-in-time live transcoding of hang broadcasts. `run(source, output, config)` publishes a derivative catalog (ladder rungs + relative refs to the source) and encodes each rung only while subscribed/fetched, via `moq-video`. Output groups mirror source group sequences 1:1.
 
 **Apps / binaries**
 

--- a/rs/moq-transcode/CHANGELOG.md
+++ b/rs/moq-transcode/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Initial release: just-in-time live transcoding of hang broadcasts.
+  `run(source, output, config)` publishes a derivative catalog (ladder rungs
+  strictly below the source, plus relative references to the source renditions)
+  and encodes each rung only while it is subscribed or fetched. Output groups
+  mirror source group sequence numbers, so specific-group fetches map 1:1 to
+  source groups. Encoding via `moq-video` (NVENC/VideoToolbox/Media Foundation
+  hardware, openh264 fallback) with CPU I420 scaling.

--- a/rs/moq-transcode/Cargo.toml
+++ b/rs/moq-transcode/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "moq-transcode"
+description = "Just-in-time live transcoding for hang broadcasts over Media over QUIC"
+authors = ["Luke Curley <kixelated@gmail.com>"]
+repository = "https://github.com/moq-dev/moq"
+license = "MIT OR Apache-2.0"
+
+version = "0.0.1"
+edition = "2024"
+rust-version.workspace = true
+
+keywords = ["quic", "http3", "webtransport", "media", "video"]
+categories = ["multimedia", "multimedia::video", "multimedia::encoding"]
+
+[lib]
+doctest = false
+
+[features]
+# Hardware encoders on by default, mirroring moq-video: NVENC is the whole point
+# of a GPU transcode fleet. Disable for a slimmer self-compiled Linux build.
+default = ["nvenc", "vaapi"]
+# NVIDIA NVENC hardware encoder (Linux, dlopen'd at runtime; a no-op elsewhere).
+nvenc = ["moq-video/nvenc"]
+# Intel/AMD VAAPI hardware encoder (Linux; links libva at build time).
+vaapi = ["moq-video/vaapi"]
+
+[dependencies]
+bytes = "1"
+# CPU I420 scaling between decode and re-encode (SIMD per-plane resize). The
+# GPU-resident scale (CUDA/NPP) is a follow-up tracked in #1837.
+fast_image_resize = "5"
+hang = { workspace = true }
+moq-mux = { workspace = true }
+moq-net = { workspace = true }
+moq-video = { workspace = true }
+thiserror = "2"
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
+tracing = "0.1"
+
+[dev-dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+# Default features on (unlike the workspace entry) so the example gets a QUIC backend.
+moq-native = { path = "../moq-native" }
+tokio = { workspace = true, features = ["full"] }
+url = "2"

--- a/rs/moq-transcode/README.md
+++ b/rs/moq-transcode/README.md
@@ -1,0 +1,59 @@
+# moq-transcode
+
+Just-in-time live transcoding for hang broadcasts.
+
+Consume a source broadcast, publish a derivative broadcast next to it: the
+derivative catalog advertises lower renditions (rungs) of the source video plus
+relative references back to the source renditions, so a player picks from the
+combined ladder and the transcoder never proxies what it doesn't re-encode.
+
+Nothing is encoded until someone asks, Cloudflare-style just-in-time per rung:
+
+- **Subscribe** to a rung and the transcoder subscribes to the source track,
+  decoding, scaling, and re-encoding group for group until the last subscriber
+  leaves.
+- **Fetch** a specific group and the transcoder fetches that same group from
+  the source and transcodes just that group. Output groups mirror source group
+  sequence numbers 1:1, so group N of every rung is the same content as source
+  group N and rendition switches land cleanly.
+
+The codec work is [`moq-video`](../moq-video): hardware where available (NVENC
+on Linux, VideoToolbox on macOS, Media Foundation on Windows), openh264 as the
+H.264 software fallback. Scaling runs on the CPU; the GPU-resident
+NVDEC -> scale -> NVENC pipeline is tracked in
+[#1837](https://github.com/moq-dev/moq/issues/1837).
+
+## Library
+
+One entry point: `run(source, output, config)`. The caller owns session setup
+and where the derivative is announced; the transcoder only fills the output
+broadcast.
+
+```rust
+let mut config = moq_transcode::Config::default();
+// The derivative is announced at `<source>/transcode.hang`, so the source
+// renditions are referenced one level up.
+config.source = Some(moq_net::PathRelativeOwned::from("..".to_string()));
+
+let output = moq_net::broadcast::Info::default().produce();
+let announce = origin.publish_broadcast(format!("{path}/transcode.hang"), &output)?;
+
+moq_transcode::run(source, output, config).await?;
+drop(announce);
+```
+
+Only renditions strictly below the source survive the ladder: a 480p source is
+never transcoded up to 720p, and a same-height rung is only offered when it
+undercuts a known source bitrate.
+
+## Example
+
+Publish something first (e.g. `moq publish camera` from
+[`moq-cli`](../moq-cli)), then:
+
+```bash
+cargo run -p moq-transcode --example transcode -- \
+    --url http://localhost:4443/anon --source my-broadcast
+```
+
+The derivative appears at `my-broadcast/transcode.hang`.

--- a/rs/moq-transcode/examples/transcode.rs
+++ b/rs/moq-transcode/examples/transcode.rs
@@ -1,0 +1,73 @@
+// Consume a hang broadcast from a relay and publish a just-in-time transcoded
+// derivative next to it.
+//
+// Publish something first (e.g. `moq publish camera` from moq-cli), then:
+//
+//     cargo run -p moq-transcode --example transcode -- \
+//         --url http://localhost:4443/anon --source my-broadcast
+//
+// The derivative appears at `<source>/transcode.hang`: its catalog references
+// the source renditions via a relative `broadcast: ".."` pointer and adds the
+// ladder rungs, which are only encoded while someone watches (or fetches) them.
+
+use anyhow::Context;
+use clap::Parser;
+
+#[derive(Parser)]
+struct Args {
+	/// The relay URL, including any auth path prefix.
+	#[arg(long, default_value = "http://localhost:4443/anon")]
+	url: url::Url,
+
+	/// The source broadcast path within the origin.
+	#[arg(long)]
+	source: String,
+
+	/// The derivative broadcast path. Defaults to `<source>/transcode.hang`.
+	#[arg(long)]
+	output: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+	moq_native::Log::new(tracing::Level::INFO).init()?;
+	let args = Args::parse();
+	let output_path = args
+		.output
+		.clone()
+		.unwrap_or_else(|| format!("{}/transcode.hang", args.source));
+
+	// Publish the derivative through one origin and consume the source through
+	// another, over a single auto-reconnecting session.
+	let publish = moq_net::Origin::random().produce();
+	let remote = moq_net::Origin::random().produce();
+
+	let client = moq_native::ClientConfig::default().init()?;
+	let session = client
+		.with_publisher(&publish)
+		.with_subscriber(remote.clone())
+		.reconnect(args.url.clone());
+
+	// Request the source broadcast; the session subscribes upstream on demand.
+	let source = remote
+		.consume()
+		.request_broadcast(&args.source)
+		.await
+		.context("source broadcast unavailable")?;
+
+	let mut config = moq_transcode::Config::default();
+	// The derivative lives one level below the source, so the source is `..`.
+	// The default ladder and encoder (hardware first: NVENC on Linux) apply.
+	config.source = Some(moq_net::PathRelativeOwned::from("..".to_string()));
+
+	let output = moq_net::broadcast::Info::default().produce();
+	let _announce = publish
+		.publish_broadcast(&output_path, &output)
+		.context("failed to publish the derivative broadcast")?;
+	tracing::info!(source = %args.source, output = %output_path, "transcoding");
+
+	tokio::select! {
+		res = moq_transcode::run(source, output, config) => Ok(res?),
+		res = session.closed() => Ok(res?),
+	}
+}

--- a/rs/moq-transcode/src/catalog.rs
+++ b/rs/moq-transcode/src/catalog.rs
@@ -1,0 +1,298 @@
+//! Derivative catalog construction: pick the source rendition, size the ladder
+//! against it, and fill the output catalog with rung + passthrough entries.
+
+use hang::catalog::{H264, Video, VideoCodec, VideoConfig};
+use moq_net::PathRelativeOwned;
+
+use crate::{Error, Rung};
+
+/// A rung resolved against the source: concrete geometry and encoder settings.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct Resolved {
+	/// The rendition/track name, e.g. `video/360p`.
+	pub name: String,
+	pub width: u32,
+	pub height: u32,
+	pub bitrate: u64,
+	pub framerate: u32,
+}
+
+/// Pick the rendition to transcode from: the highest-resolution decodable
+/// (H.264/H.265) rendition local to the source broadcast.
+pub(crate) fn choose_source(video: &Video) -> Result<(String, VideoConfig), Error> {
+	video
+		.renditions
+		.iter()
+		// A rendition that itself lives in another broadcast can't be subscribed
+		// through this one; composing relative references is a follow-up.
+		.filter(|(_, config)| config.broadcast.is_none())
+		.filter(|(_, config)| matches!(config.codec, VideoCodec::H264(_) | VideoCodec::H265(_)))
+		.max_by_key(|(_, config)| (config.coded_height, config.coded_width, config.bitrate))
+		.map(|(name, config)| (name.clone(), config.clone()))
+		.ok_or(Error::NoSource)
+}
+
+/// Resolve the configured rungs against the source: derive geometry from the
+/// source aspect ratio and drop any rung that isn't strictly below the source.
+pub(crate) fn resolve_rungs(rungs: &[Rung], source_name: &str, source: &VideoConfig) -> Result<Vec<Resolved>, Error> {
+	let (source_width, source_height) = match (source.coded_width, source.coded_height) {
+		(Some(w), Some(h)) if w > 0 && h > 0 => (w as u64, h as u64),
+		_ => return Err(Error::SourceDimensions(source_name.to_string())),
+	};
+	let framerate = source
+		.framerate
+		.map(|f| f.round() as u32)
+		.filter(|f| *f > 0)
+		.unwrap_or(30);
+
+	let mut resolved: Vec<Resolved> = Vec::new();
+	for rung in rungs {
+		let height = (rung.height & !1) as u64;
+		if height == 0 || height > source_height {
+			// Never upscale.
+			continue;
+		}
+		// A same-height rung is only useful at a lower bitrate, and an unknown
+		// source bitrate can't prove that.
+		if height == source_height && source.bitrate.is_none() {
+			continue;
+		}
+		if source.bitrate.is_some_and(|bitrate| rung.bitrate >= bitrate) {
+			continue;
+		}
+		// Preserve the source aspect ratio, rounded to even for I420 chroma.
+		let width = ((source_width * height + source_height / 2) / source_height) & !1;
+		if width == 0 {
+			continue;
+		}
+
+		let rung = Resolved {
+			name: format!("video/{height}p"),
+			width: width as u32,
+			height: height as u32,
+			bitrate: rung.bitrate,
+			framerate,
+		};
+		// Duplicate heights in the config would collide on the track name.
+		if resolved.iter().any(|other| other.name == rung.name) {
+			continue;
+		}
+		resolved.push(rung);
+	}
+	Ok(resolved)
+}
+
+/// The catalog entry for a resolved rung.
+///
+/// The codec string is computed from the ladder, not the bitstream, so the
+/// catalog can be published before any encoder exists and stays deterministic:
+/// avc3 (in-band parameter sets, matching what every `moq-video` backend
+/// emits), High profile (a superset of what any backend produces, so decoder
+/// capability checks pass), and the level from the Table A-1 lookup.
+pub(crate) fn rung_entry(rung: &Resolved, source: &VideoConfig) -> VideoConfig {
+	let mut config = VideoConfig::new(H264 {
+		inline: true,
+		profile: 0x64,
+		constraints: 0,
+		level: h264_level(rung.width, rung.height, rung.framerate, rung.bitrate),
+	});
+	config.coded_width = Some(rung.width);
+	config.coded_height = Some(rung.height);
+	config.bitrate = Some(rung.bitrate);
+	config.framerate = Some(rung.framerate as f64);
+	config.optimize_for_latency = source.optimize_for_latency;
+	config
+}
+
+/// Fill the derivative catalog: rung entries plus, when `source_rel` is set,
+/// every source rendition referenced through it (so players fetch those tracks
+/// from the source broadcast directly). Called again on each source catalog
+/// update; the rung entries are fixed, the passthrough entries track the source.
+pub(crate) fn populate(
+	out: &mut moq_mux::catalog::hang::Catalog,
+	source: &moq_mux::catalog::hang::Catalog,
+	rungs: &[(String, VideoConfig)],
+	source_rel: Option<&PathRelativeOwned>,
+) -> Result<(), Error> {
+	out.video = Video::default();
+	out.audio = hang::catalog::Audio::default();
+
+	// Display metadata applies to the rungs too (same picture, smaller).
+	out.video.display = source.video.display.clone();
+	out.video.rotation = source.video.rotation;
+	out.video.flip = source.video.flip;
+
+	for (name, config) in rungs {
+		out.video.insert(name, config.clone())?;
+	}
+
+	let Some(rel) = source_rel else {
+		return Ok(());
+	};
+
+	for (name, config) in &source.video.renditions {
+		if config.broadcast.is_some() {
+			// Already a reference into another broadcast; composing relative
+			// paths is a follow-up.
+			continue;
+		}
+		let mut config = config.clone();
+		config.broadcast = Some(rel.clone());
+		if out.video.insert(name, config).is_err() {
+			tracing::warn!(rendition = %name, "source video rendition collides with a rung name; skipping");
+		}
+	}
+
+	for (name, config) in &source.audio.renditions {
+		if config.broadcast.is_some() {
+			continue;
+		}
+		let mut config = config.clone();
+		config.broadcast = Some(rel.clone());
+		if out.audio.insert(name, config).is_err() {
+			tracing::warn!(rendition = %name, "duplicate source audio rendition; skipping");
+		}
+	}
+
+	Ok(())
+}
+
+/// The smallest H.264 level (Table A-1) that fits the given geometry, frame
+/// rate, and bitrate, as a `level_idc` (level 3.1 -> 31, printed `1f` in the
+/// codec string).
+fn h264_level(width: u32, height: u32, framerate: u32, bitrate: u64) -> u8 {
+	// (level_idc, MaxMBPS, MaxFS, MaxBR in kbit/s at the Baseline/Main factor).
+	const LEVELS: &[(u8, u64, u64, u64)] = &[
+		(10, 1_485, 99, 64),
+		(11, 3_000, 396, 192),
+		(12, 6_000, 396, 384),
+		(13, 11_880, 396, 768),
+		(20, 11_880, 396, 2_000),
+		(21, 19_800, 792, 4_000),
+		(22, 20_250, 1_620, 4_000),
+		(30, 40_500, 1_620, 10_000),
+		(31, 108_000, 3_600, 14_000),
+		(32, 216_000, 5_120, 20_000),
+		(40, 245_760, 8_192, 20_000),
+		(41, 245_760, 8_192, 50_000),
+		(42, 522_240, 8_704, 50_000),
+		(50, 589_824, 22_080, 135_000),
+		(51, 983_040, 36_864, 240_000),
+		(52, 2_073_600, 36_864, 240_000),
+	];
+
+	let macroblocks = width.div_ceil(16) as u64 * height.div_ceil(16) as u64;
+	let macroblocks_per_sec = macroblocks * framerate as u64;
+	for &(idc, max_mbps, max_fs, max_br) in LEVELS {
+		// High profile raises the bitrate cap by cpbBrVclFactor 1250/1000.
+		if macroblocks <= max_fs && macroblocks_per_sec <= max_mbps && bitrate <= max_br * 1250 {
+			return idc;
+		}
+	}
+	52
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn source(width: u32, height: u32, bitrate: Option<u64>) -> VideoConfig {
+		let mut config = VideoConfig::new(H264 {
+			inline: true,
+			profile: 0x64,
+			constraints: 0,
+			level: 40,
+		});
+		config.coded_width = Some(width);
+		config.coded_height = Some(height);
+		config.bitrate = bitrate;
+		config.framerate = Some(30.0);
+		config
+	}
+
+	#[test]
+	fn rungs_never_upscale() {
+		let rungs = crate::Config::default().rungs;
+		let resolved = resolve_rungs(&rungs, "video", &source(854, 480, Some(2_000_000))).unwrap();
+		let names: Vec<_> = resolved.iter().map(|r| r.name.as_str()).collect();
+		// A 480p source keeps only the strictly-lower rungs: the 480p rung is
+		// admitted only because its bitrate (1.2M) undercuts the source (2M).
+		assert_eq!(names, ["video/480p", "video/360p", "video/240p"]);
+	}
+
+	#[test]
+	fn same_height_needs_lower_bitrate() {
+		let rungs = vec![Rung::new(480, 1_200_000)];
+		// Unknown source bitrate: a same-height rung can't prove it's below.
+		assert!(
+			resolve_rungs(&rungs, "video", &source(854, 480, None))
+				.unwrap()
+				.is_empty()
+		);
+		// Source bitrate below the rung: dropped too.
+		assert!(
+			resolve_rungs(&rungs, "video", &source(854, 480, Some(1_000_000)))
+				.unwrap()
+				.is_empty()
+		);
+	}
+
+	#[test]
+	fn rung_geometry_follows_source_aspect() {
+		let resolved = resolve_rungs(
+			&[Rung::new(360, 600_000)],
+			"video",
+			&source(1920, 1080, Some(6_000_000)),
+		)
+		.unwrap();
+		assert_eq!(resolved.len(), 1);
+		assert_eq!((resolved[0].width, resolved[0].height), (640, 360));
+
+		// Vertical video: aspect preserved, width rounded to even.
+		let resolved = resolve_rungs(
+			&[Rung::new(360, 600_000)],
+			"video",
+			&source(1080, 1920, Some(6_000_000)),
+		)
+		.unwrap();
+		assert_eq!((resolved[0].width, resolved[0].height), (202, 360));
+	}
+
+	#[test]
+	fn source_needs_dimensions() {
+		let mut config = source(0, 0, Some(1_000_000));
+		config.coded_width = None;
+		config.coded_height = None;
+		assert!(matches!(
+			resolve_rungs(&[Rung::new(360, 600_000)], "video", &config),
+			Err(Error::SourceDimensions(_))
+		));
+	}
+
+	#[test]
+	fn level_lookup() {
+		// 640x360 @ 30fps is 920 MBs * 30 = 27600 MB/s: past level 2.2's 20250,
+		// so it lands on level 3.0.
+		assert_eq!(h264_level(640, 360, 30, 600_000), 30);
+		// 1080p30 at 5 Mbit/s needs level 4.0 for the frame size.
+		assert_eq!(h264_level(1920, 1080, 30, 5_000_000), 40);
+		// 1080p60 pushes the MB rate past level 4.0 into 4.2.
+		assert_eq!(h264_level(1920, 1080, 60, 5_000_000), 42);
+		// Absurd input clamps to the highest level.
+		assert_eq!(h264_level(8192, 8192, 120, u64::MAX), 52);
+	}
+
+	#[test]
+	fn chooses_highest_local_rendition() {
+		let mut video = Video::default();
+		video.insert("low", source(640, 360, None)).unwrap();
+		video.insert("high", source(1920, 1080, None)).unwrap();
+		let mut remote = source(3840, 2160, None);
+		remote.broadcast = Some(PathRelativeOwned::from("../other".to_string()));
+		video.insert("remote", remote).unwrap();
+
+		let (name, config) = choose_source(&video).unwrap();
+		assert_eq!(name, "high");
+		assert_eq!(config.coded_height, Some(1080));
+	}
+}

--- a/rs/moq-transcode/src/config.rs
+++ b/rs/moq-transcode/src/config.rs
@@ -1,0 +1,77 @@
+//! Transcoder configuration: the rung ladder and catalog wiring.
+
+use moq_net::PathRelativeOwned;
+
+/// One candidate output rendition: a target resolution (by height) and bitrate.
+///
+/// The width is derived from the source aspect ratio at runtime, and a rung is
+/// only offered when it is strictly below the source (see [`Config::rungs`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Rung {
+	/// Output height in pixels. Rounded down to even (I420 chroma is 2x2).
+	pub height: u32,
+
+	/// Target bitrate in bits per second: the CBR target and the bitrate
+	/// advertised in the derivative catalog.
+	pub bitrate: u64,
+}
+
+impl Rung {
+	/// A rung at `height` pixels and `bitrate` bits per second.
+	pub fn new(height: u32, bitrate: u64) -> Self {
+		Self { height, bitrate }
+	}
+}
+
+/// Transcoder configuration for [`run`](crate::run).
+///
+/// `#[non_exhaustive]`: build via `Config::default()` and set fields, so future
+/// knobs don't break callers.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct Config {
+	/// Candidate output renditions. Only rungs strictly below the source
+	/// survive: a rung is dropped when its height exceeds the source, when its
+	/// bitrate is not below the source bitrate (when known), or when it matches
+	/// the source height without a known source bitrate to undercut. A 480p
+	/// source is never transcoded up to 720p.
+	pub rungs: Vec<Rung>,
+
+	/// Where the source broadcast lives relative to the output broadcast, e.g.
+	/// `".."` when the output is published at `<source>/transcode.hang`. When
+	/// set, the derivative catalog references the source renditions (all video
+	/// and audio) through this path so players fetch them from the source
+	/// directly; the transcoder never proxies or subscribes them. `None` omits
+	/// them from the derivative catalog.
+	pub source: Option<PathRelativeOwned>,
+
+	/// Which video encoder implementation encodes the rungs. The default
+	/// prefers hardware (NVENC on Linux, VideoToolbox on macOS, Media
+	/// Foundation on Windows) and falls back to openh264.
+	pub encoder: moq_video::encode::Kind,
+
+	/// Which video decoder implementation decodes the source. The default
+	/// prefers hardware and falls back to openh264 (H.264 only; H.265 sources
+	/// need a hardware decoder).
+	pub decoder: moq_video::decode::Kind,
+}
+
+impl Default for Config {
+	fn default() -> Self {
+		Self {
+			// The default ladder, top rung first, filtered against the source at
+			// runtime so only strictly-lower renditions are offered.
+			rungs: vec![
+				Rung::new(1080, 5_000_000),
+				Rung::new(720, 2_500_000),
+				Rung::new(480, 1_200_000),
+				Rung::new(360, 600_000),
+				Rung::new(240, 350_000),
+			],
+			source: None,
+			encoder: moq_video::encode::Kind::default(),
+			decoder: moq_video::decode::Kind::default(),
+		}
+	}
+}

--- a/rs/moq-transcode/src/error.rs
+++ b/rs/moq-transcode/src/error.rs
@@ -1,0 +1,40 @@
+//! Error type for the transcoder.
+
+/// Errors returned by `moq-transcode`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+	/// The source catalog has no rendition the transcoder can decode: it needs
+	/// an H.264 or H.265 rendition local to the source broadcast.
+	#[error("no transcodable video rendition in the source catalog")]
+	NoSource,
+
+	/// The chosen source rendition doesn't declare coded dimensions, so rungs
+	/// can't be sized or gated against it.
+	#[error("source rendition {0:?} is missing codedWidth/codedHeight")]
+	SourceDimensions(String),
+
+	/// moq-net transport error.
+	#[error(transparent)]
+	Net(#[from] moq_net::Error),
+
+	/// moq-mux container/catalog error.
+	#[error(transparent)]
+	Mux(#[from] moq_mux::Error),
+
+	/// hang catalog/container error.
+	#[error(transparent)]
+	Hang(#[from] hang::Error),
+
+	/// Video decode/encode error.
+	#[error(transparent)]
+	Video(#[from] moq_video::Error),
+
+	/// Timestamp overflow converting to the moq microsecond timescale.
+	#[error(transparent)]
+	TimeOverflow(#[from] moq_net::TimeOverflow),
+
+	/// Frame scaling failure.
+	#[error("scale failed: {0}")]
+	Scale(String),
+}

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -124,15 +124,13 @@ pub async fn run(
 		}
 	}
 
-	// The rungs notice the source closing themselves; wait for them so every
-	// output track ends cleanly before the broadcast closes.
-	while let Some(result) = tasks.join_next().await {
-		match result {
-			Ok(Ok(())) => {}
-			Ok(Err(err)) => tracing::warn!(%err, "rung failed"),
-			Err(err) => tracing::warn!(%err, "rung panicked"),
-		}
-	}
+	// Wind the rungs down. On a clean source end they are already finishing on
+	// their own (the live path saw the source track end), so `shutdown` just
+	// joins them. But `run` also breaks on a catalog-track error while the
+	// source media and viewers are still live, and a rung task only self-ends on
+	// source-media-end or broadcast-close, not catalog-end. Aborting rather than
+	// awaiting keeps that case from hanging forever here.
+	tasks.shutdown().await;
 
 	derived.finish()?;
 	output.close();
@@ -276,5 +274,42 @@ mod tests {
 		assert_eq!(total, 5);
 
 		transcoder.abort();
+	}
+
+	/// `run` must terminate (not hang in its shutdown drain) when the source
+	/// broadcast goes away, even with a rung task that was never subscribed.
+	#[tokio::test]
+	async fn shuts_down_on_source_end() {
+		let source = source_broadcast(1, 3);
+
+		let config = Config {
+			rungs: vec![Rung::new(120, 100_000)],
+			encoder: moq_video::encode::Kind::Software,
+			decoder: moq_video::decode::Kind::Software,
+			source: None,
+		};
+
+		let output = moq_net::broadcast::Info::default().produce();
+		let consumer = output.consume();
+		let transcoder = tokio::spawn(run(source.broadcast.consume(), output, config));
+
+		// Wait until the derivative catalog is up, so the transcoder is past
+		// startup and into its serve loop.
+		let track = loop {
+			match consumer.track(hang::Catalog::DEFAULT_NAME) {
+				Ok(track) => break track,
+				Err(moq_net::Error::NotFound) => tokio::task::yield_now().await,
+				Err(err) => panic!("catalog track: {err}"),
+			}
+		};
+		let mut catalogs = moq_mux::catalog::hang::Consumer::<()>::new(track.subscribe(None).await.unwrap());
+		catalogs.next().await.unwrap().unwrap();
+
+		// Drop the source: the catalog track ends and the broadcast closes, so
+		// `run` should observe the end and return rather than block in the drain.
+		drop(source);
+
+		let result = tokio::time::timeout(std::time::Duration::from_secs(5), transcoder).await;
+		result.expect("run did not shut down within 5s").unwrap().unwrap();
 	}
 }

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -1,0 +1,280 @@
+//! Just-in-time live transcoding for hang broadcasts.
+//!
+//! [`run`] consumes a source broadcast and fills a derivative broadcast: a
+//! catalog advertising lower renditions (rungs) of the source video plus
+//! references back to the source renditions, and one output video track per
+//! rung. The catalog is published immediately and deterministically (codec
+//! strings are computed from the ladder, not the bitstream), but nothing is
+//! encoded until a subscriber actually asks:
+//!
+//! - Subscribing to a rung subscribes to the source track and transcodes live,
+//!   group for group, stopping when the last subscriber leaves.
+//! - Fetching a specific group fetches that same group from the source and
+//!   transcodes just that group. Output groups mirror source sequence numbers
+//!   1:1, so group N of every rung is the same content as source group N.
+//!
+//! The codec work is `moq-video`: hardware where available (NVENC on Linux,
+//! VideoToolbox on macOS, Media Foundation on Windows) with openh264 as the
+//! H.264 software fallback. Scaling runs on the CPU; the GPU-resident
+//! NVDEC -> scale -> NVENC pipeline is tracked in moq-dev/moq#1837.
+
+mod catalog;
+mod config;
+mod error;
+mod rung;
+mod scale;
+
+pub use config::{Config, Rung};
+pub use error::Error;
+
+/// Transcode `source` into `output` until the source broadcast ends.
+///
+/// Reads the source catalog, publishes the derivative catalog (rungs strictly
+/// below the source, plus source renditions referenced via [`Config::source`]),
+/// and serves each rung just-in-time: a rung track only materializes when a
+/// consumer asks for it, and only encodes while consumed. Where `output` is
+/// announced (and how its path relates to the source) is the caller's business.
+///
+/// The catalog tracks and the on-demand rung handler are registered
+/// synchronously, before the first `await`, so a consumer may race the rest of
+/// the setup safely: call `run` before announcing `output`.
+pub async fn run(
+	source: moq_net::broadcast::Consumer,
+	mut output: moq_net::broadcast::Producer,
+	config: Config,
+) -> Result<(), Error> {
+	// The catalog starts empty and fills in below, exactly like a media
+	// importer that hasn't seen parameter sets yet.
+	let mut derived = moq_mux::catalog::Producer::new(&mut output)?;
+	// Consumers asking for a rung before (or after) it exists queue here.
+	let mut dynamic = output.dynamic();
+
+	// The source catalog drives everything; wait for a snapshot with a usable
+	// video rendition (the first may precede the source publishing its video).
+	let track = source
+		.track(hang::Catalog::DEFAULT_NAME)?
+		.subscribe(hang::Catalog::default_subscription())
+		.await?;
+	let mut catalogs = moq_mux::catalog::hang::Consumer::<()>::new(track);
+	let (source_name, source_config, snapshot) = loop {
+		let Some(snapshot) = catalogs.next().await? else {
+			return Err(Error::NoSource);
+		};
+		match catalog::choose_source(&snapshot.video) {
+			Ok((name, config)) => break (name, config, snapshot),
+			Err(_) => tracing::debug!("no transcodable rendition yet; waiting for a catalog update"),
+		}
+	};
+	let rungs = catalog::resolve_rungs(&config.rungs, &source_name, &source_config)?;
+	tracing::info!(source = %source_name, rungs = rungs.len(), "transcoding");
+
+	// Publish the derivative catalog before any encoder exists, so subscribers
+	// can pick a rung immediately.
+	let entries: Vec<_> = rungs
+		.iter()
+		.map(|rung| (rung.name.clone(), catalog::rung_entry(rung, &source_config)))
+		.collect();
+	{
+		let mut guard = derived.lock();
+		catalog::populate(&mut guard, &snapshot, &entries, config.source.as_ref())?;
+	}
+
+	// Serve rung requests and follow source catalog updates until the source
+	// ends. The rung set is fixed at startup: a source that changes resolution
+	// mid-stream keeps the ladder it started with, but the passthrough entries
+	// track the source.
+	let mut tasks = tokio::task::JoinSet::new();
+	loop {
+		tokio::select! {
+			request = dynamic.requested_track() => {
+				// Err means the broadcast closed; nothing left to serve.
+				let Ok(request) = request else { break };
+				match rungs.iter().find(|rung| rung.name == request.name()) {
+					Some(info) => {
+						let rung = rung::Rung {
+							source: source.track(&source_name)?,
+							broadcast: source.clone(),
+							config: source_config.clone(),
+							encoder: config.encoder.clone(),
+							decoder: config.decoder.clone(),
+							info: info.clone(),
+						};
+						tasks.spawn(rung::serve(rung, request));
+					}
+					None => request.reject(moq_net::Error::NotFound),
+				}
+			},
+			update = catalogs.next() => match update {
+				Ok(Some(snapshot)) => {
+					let mut guard = derived.lock();
+					catalog::populate(&mut guard, &snapshot, &entries, config.source.as_ref())?;
+				}
+				// The source ended (or its catalog track died): wind down.
+				Ok(None) => break,
+				Err(err) => {
+					tracing::debug!(%err, "source catalog ended");
+					break;
+				}
+			},
+			Some(result) = tasks.join_next() => match result {
+				Ok(Ok(())) => {}
+				Ok(Err(err)) => tracing::warn!(%err, "rung failed"),
+				Err(err) => tracing::warn!(%err, "rung panicked"),
+			}
+		}
+	}
+
+	// The rungs notice the source closing themselves; wait for them so every
+	// output track ends cleanly before the broadcast closes.
+	while let Some(result) = tasks.join_next().await {
+		match result {
+			Ok(Ok(())) => {}
+			Ok(Err(err)) => tracing::warn!(%err, "rung failed"),
+			Err(err) => tracing::warn!(%err, "rung panicked"),
+		}
+	}
+
+	derived.finish()?;
+	output.close();
+	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// A live source broadcast; the producers are kept so the tracks stay open
+	/// for the duration of the test.
+	struct Source {
+		broadcast: moq_net::broadcast::Producer,
+		_catalog: moq_mux::catalog::Producer,
+		_track: moq_net::track::Producer,
+	}
+
+	/// Build a 320x240 avc3 source broadcast: a catalog plus a video track with
+	/// `groups` groups of `frames` gray frames each, encoded with openh264.
+	fn source_broadcast(groups: u64, frames: u64) -> Source {
+		let mut broadcast = moq_net::broadcast::Info::default().produce();
+		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+
+		let mut video = hang::catalog::VideoConfig::new(hang::catalog::H264 {
+			inline: true,
+			profile: 0x42,
+			constraints: 0,
+			level: 30,
+		});
+		video.coded_width = Some(320);
+		video.coded_height = Some(240);
+		video.bitrate = Some(1_000_000);
+		video.framerate = Some(30.0);
+		catalog.lock().video.insert("video", video).unwrap();
+
+		let info = moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE);
+		let mut track = broadcast.create_track("video", info).unwrap();
+
+		let mut encoder = moq_video::encode::Encoder::new(&{
+			let mut config = moq_video::encode::Config::new(320, 240, 30);
+			config.kind = moq_video::encode::Kind::Software;
+			config
+		})
+		.unwrap();
+		let gray = vec![0x80u8; 320 * 240 * 4];
+
+		for sequence in 0..groups {
+			let mut group = track.create_group(sequence.into()).unwrap();
+			for index in 0..frames {
+				let timestamp = (sequence * frames + index) * 33_333;
+				for payload in encoder.encode_rgba(&gray, 320, 240, index == 0).unwrap() {
+					let frame = hang::container::Frame {
+						timestamp: moq_net::Timestamp::from_micros(timestamp).unwrap(),
+						payload,
+					};
+					frame.encode(&mut group).unwrap();
+				}
+			}
+			group.finish().unwrap();
+		}
+
+		Source {
+			broadcast,
+			_catalog: catalog,
+			_track: track,
+		}
+	}
+
+	#[tokio::test]
+	async fn end_to_end() {
+		let source = source_broadcast(2, 5);
+
+		let config = Config {
+			rungs: vec![Rung::new(120, 100_000)],
+			encoder: moq_video::encode::Kind::Software,
+			decoder: moq_video::decode::Kind::Software,
+			source: Some(moq_net::PathRelativeOwned::from("..".to_string())),
+		};
+
+		let output = moq_net::broadcast::Info::default().produce();
+		let consumer = output.consume();
+		let transcoder = tokio::spawn(run(source.broadcast.consume(), output, config));
+
+		// The derivative catalog appears before anything is encoded, with the
+		// rung sized against the source and the passthrough reference. Yield
+		// until the spawned transcoder has run its synchronous prologue (the
+		// catalog tracks and dynamic handler register before its first await).
+		let track = loop {
+			match consumer.track(hang::Catalog::DEFAULT_NAME) {
+				Ok(track) => break track,
+				Err(moq_net::Error::NotFound) => tokio::task::yield_now().await,
+				Err(err) => panic!("catalog track: {err}"),
+			}
+		};
+		let track = track.subscribe(None).await.unwrap();
+		let mut catalogs = moq_mux::catalog::hang::Consumer::<()>::new(track);
+		// The catalog track exists from the start but may open empty; the rung
+		// appears once the transcoder has read the source catalog.
+		let derived = loop {
+			let snapshot = catalogs.next().await.unwrap().unwrap();
+			if snapshot.video.renditions.contains_key("video/120p") {
+				break snapshot;
+			}
+		};
+
+		let rung = derived.video.renditions.get("video/120p").expect("rung missing");
+		assert_eq!(rung.coded_width, Some(160));
+		assert_eq!(rung.coded_height, Some(120));
+		assert_eq!(rung.bitrate, Some(100_000));
+		assert!(rung.codec.to_string().starts_with("avc3."));
+
+		let passthrough = derived.video.renditions.get("video").expect("passthrough missing");
+		assert_eq!(passthrough.broadcast.as_ref().map(|b| b.as_ref()), Some(".."));
+
+		// Subscribing to the rung starts the live loop, which mirrors source
+		// group sequences 1:1.
+		let mut subscriber = consumer.track("video/120p").unwrap().subscribe(None).await.unwrap();
+		let mut group = subscriber.next_group().await.unwrap().unwrap();
+		assert!(group.sequence <= 1, "unexpected sequence {}", group.sequence);
+		let payload = group.read_frame().await.unwrap().unwrap();
+		let frame = hang::container::Frame::decode(payload).unwrap();
+		assert!(
+			frame.payload.starts_with(&[0, 0, 0, 1]) || frame.payload.starts_with(&[0, 0, 1]),
+			"rung output is not Annex-B"
+		);
+
+		// Fetching a specific past group transcodes source group 0 on demand.
+		let mut fetched = consumer
+			.track("video/120p")
+			.unwrap()
+			.fetch_group(0, None)
+			.await
+			.unwrap();
+		let payload = fetched.read_frame().await.unwrap().unwrap();
+		let frame = hang::container::Frame::decode(payload).unwrap();
+		assert!(!frame.payload.is_empty());
+		// The fetched group is complete: the source group had 5 frames, and a
+		// finished transcode carries them all through.
+		let total = fetched.finished().await.unwrap();
+		assert_eq!(total, 5);
+
+		transcoder.abort();
+	}
+}

--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -13,13 +13,24 @@
 //! output group N maps to source group N and a player switching renditions
 //! lands on the same content.
 
+use std::sync::Arc;
+
 use bytes::Bytes;
 use hang::catalog::VideoConfig;
 use moq_mux::container::Container as _;
+use tokio::sync::Semaphore;
 
 use crate::Error;
 use crate::catalog::Resolved;
 use crate::scale::Scaler;
+
+/// Cap on transcode pipelines a single rung builds concurrently for on-demand
+/// group fetches. Each pipeline holds a decoder + encoder session, and hardware
+/// encoders expose only a few simultaneous sessions, so an unbounded fetch burst
+/// (a rendition-switching player requesting many past groups at once) would
+/// exhaust them and fail live viewers too. Global admission across rungs and
+/// nodes is the fleet's concern; this is the local backstop.
+const MAX_CONCURRENT_FETCHES: usize = 4;
 
 /// Everything a rung needs to build transcoding pipelines on demand.
 #[derive(Clone)]
@@ -105,7 +116,15 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 					let info = moq_net::group::Info { sequence: source.sequence };
 					let mut output = match producer.create_group(info) {
 						Ok(output) => output,
-						// A fetch already produced this group; skip it.
+						// A fetch task is already serving this sequence (a consumer
+						// fetched a group at the live edge before the live loop
+						// reached it). The fetch is authoritative and its group
+						// reaches every subscriber through the shared track cache,
+						// so skip it here. Residual: if that fetch then fails and
+						// aborts the group, this rung skips one GOP until the next
+						// keyframe. Unifying live + fetch into one cache-backed
+						// serving loop (like the relay) would remove the two-writer
+						// race entirely; tracked as a follow-up.
 						Err(moq_net::Error::Duplicate) => continue,
 						Err(err) => return Err(err.into()),
 					};
@@ -124,14 +143,36 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 }
 
 /// The fetch path: serve requests for specific (past) groups.
+///
+/// Fetch tasks run under a local [`JoinSet`](tokio::task::JoinSet) rather than
+/// detached: when `serve` cancels this future (the live path ended, or the
+/// output track closed), dropping the set aborts every in-flight fetch, so none
+/// keep a source subscription or an encoder session alive past teardown. A
+/// semaphore bounds how many run at once.
 async fn fetches(rung: &Rung, dynamic: &moq_net::track::Dynamic) -> Result<(), Error> {
+	let limit = Arc::new(Semaphore::new(MAX_CONCURRENT_FETCHES));
+	let mut tasks = tokio::task::JoinSet::new();
+
 	loop {
+		// Reap finished fetches so the set doesn't grow without bound.
+		while tasks.try_join_next().is_some() {}
+
 		let Ok(request) = dynamic.requested_group().await else {
 			// The output track closed; nothing more to serve.
 			return Ok(());
 		};
+
+		// Take a slot before spawning the transcode. Under a burst this blocks
+		// here, so further requests queue in the dynamic handler (backpressure)
+		// instead of spawning unbounded pipelines. The semaphore is never closed,
+		// so acquire only fails if we drop it first.
+		let Ok(permit) = limit.clone().acquire_owned().await else {
+			return Ok(());
+		};
+
 		let rung = rung.clone();
-		tokio::spawn(async move {
+		tasks.spawn(async move {
+			let _permit = permit;
 			let sequence = request.sequence();
 			if let Err(err) = fetch(rung, request).await {
 				tracing::warn!(%err, sequence, "transcode fetch failed");
@@ -141,6 +182,11 @@ async fn fetches(rung: &Rung, dynamic: &moq_net::track::Dynamic) -> Result<(), E
 }
 
 /// Transcode one specifically requested group, fetching it from the source.
+///
+/// Every early exit rejects the request with a real error: dropping a
+/// `GroupRequest` auto-rejects with [`moq_net::Error::Dropped`], which reads as
+/// "the handler vanished" and hides the actual decode/encode/source failure from
+/// the waiting consumer.
 async fn fetch(rung: Rung, request: moq_net::track::GroupRequest) -> Result<(), Error> {
 	let options = moq_net::group::Fetch::default().with_priority(request.priority());
 	let mut source = match rung.source.fetch_group(request.sequence(), options).await {
@@ -153,9 +199,18 @@ async fn fetch(rung: Rung, request: moq_net::track::GroupRequest) -> Result<(), 
 
 	// A fresh pipeline per fetched group: groups are independently decodable,
 	// so the encoder starts clean at the group's keyframe.
-	let mut pipeline = rung.pipeline()?;
-	let container = rung.container()?;
-	let mut output = request.accept(None)?;
+	let (mut pipeline, container) = match rung.pipeline().and_then(|p| rung.container().map(|c| (p, c))) {
+		Ok(built) => built,
+		Err(err) => {
+			request.reject(moq_net::Error::Cancel);
+			return Err(err);
+		}
+	};
+
+	let mut output = match request.accept(None) {
+		Ok(output) => output,
+		Err(err) => return Err(err.into()),
+	};
 	transcode_group(&mut pipeline, &container, &mut source, &mut output, None).await?;
 	Ok(())
 }
@@ -220,8 +275,13 @@ async fn transcode_group_inner(
 				.map_err(|_| moq_net::TimeOverflow)?;
 			last_timestamp = last_timestamp.max(timestamp);
 
-			// The first frame of a group is a keyframe by construction; force
-			// an IDR there so every output group opens self-contained.
+			// A group opens on a keyframe by construction, so the first frame is
+			// an IDR. The low-level `Container::read` the transcoder uses does not
+			// reconstruct the keyframe bit for legacy sources (that lives in the
+			// higher-level container consumer), so `first` is the reliable signal;
+			// OR in the container's own flag so CMAF mid-group keyframes still
+			// force an output IDR. This flag drives both the decoder (keyframe
+			// gating + parameter-set injection) and the encoder (forced IDR).
 			let keyframe = frame.keyframe || first;
 			first = false;
 

--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -1,0 +1,303 @@
+//! Per-rung serving: just-in-time encoding of one output rendition.
+//!
+//! Nothing is encoded until someone asks, via the two demand paths moq-net
+//! exposes on the output track:
+//!
+//! - A live subscription (`used`) starts a live loop that subscribes to the
+//!   source track (mirroring the aggregate subscription) and transcodes group
+//!   for group until the track goes `unused` again.
+//! - A fetch of a specific group (`requested_group`) fetches that same group
+//!   from the source and transcodes just that group with a fresh encoder.
+//!
+//! Output groups mirror the source group sequence numbers 1:1, so a fetch for
+//! output group N maps to source group N and a player switching renditions
+//! lands on the same content.
+
+use bytes::Bytes;
+use hang::catalog::VideoConfig;
+use moq_mux::container::Container as _;
+
+use crate::Error;
+use crate::catalog::Resolved;
+use crate::scale::Scaler;
+
+/// Everything a rung needs to build transcoding pipelines on demand.
+#[derive(Clone)]
+pub(crate) struct Rung {
+	pub info: Resolved,
+	/// The source media track (not yet subscribed; demand drives that).
+	pub source: moq_net::track::Consumer,
+	/// The source broadcast, to notice it closing while idle.
+	pub broadcast: moq_net::broadcast::Consumer,
+	/// The source rendition's catalog entry (codec + container).
+	pub config: VideoConfig,
+	/// Which encoder implementation to use.
+	pub encoder: moq_video::encode::Kind,
+	/// Which decoder implementation to use.
+	pub decoder: moq_video::decode::Kind,
+}
+
+impl Rung {
+	fn pipeline(&self) -> Result<Pipeline, Error> {
+		Pipeline::new(self)
+	}
+
+	fn container(&self) -> Result<moq_mux::catalog::hang::Container, Error> {
+		Ok(moq_mux::catalog::hang::Container::try_from(&self.config.container)?)
+	}
+}
+
+/// Serve one requested rung track until it closes or the source ends.
+pub(crate) async fn serve(rung: Rung, request: moq_net::track::Request) -> Result<(), Error> {
+	// Grab the group-request handle before accepting: a Request is dynamic from
+	// birth, so a fetch racing the acceptance queues instead of failing.
+	let dynamic = request.dynamic();
+	let info = moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE);
+	let mut producer = request.accept(info);
+
+	let result = tokio::select! {
+		res = live(&rung, &mut producer) => res,
+		res = fetches(&rung, &dynamic) => res,
+	};
+	if result.is_err() {
+		// End the track so subscribers see an error rather than a stall.
+		let _ = producer.abort(moq_net::Error::Cancel);
+	}
+	result
+}
+
+/// The live path: wait for demand, mirror the aggregate subscription upstream,
+/// and transcode group for group until demand goes away.
+async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<(), Error> {
+	let demand = producer.demand();
+	loop {
+		tokio::select! {
+			used = demand.used() => if used.is_err() {
+				// The output track closed; nothing more to serve.
+				return Ok(());
+			},
+			err = rung.broadcast.closed() => {
+				// The source went away while idle; end the rung with it.
+				producer.abort(err)?;
+				return Ok(());
+			}
+		}
+
+		// Mirror the downstream demand upstream (priority, ordering, start).
+		let subscription = producer.subscription().unwrap_or_default();
+		let mut subscriber = rung.source.subscribe(subscription).await?;
+
+		// One pipeline per demand session: rate control persists across groups,
+		// while every group still opens with a forced IDR.
+		let mut pipeline = rung.pipeline()?;
+		let container = rung.container()?;
+
+		'session: loop {
+			tokio::select! {
+				group = subscriber.next_group() => {
+					let Some(mut source) = group? else {
+						// The source track ended: the derivative ends with it.
+						producer.finish()?;
+						return Ok(());
+					};
+					// Mirror the source sequence so fetches and rendition
+					// switches map 1:1.
+					let info = moq_net::group::Info { sequence: source.sequence };
+					let mut output = match producer.create_group(info) {
+						Ok(output) => output,
+						// A fetch already produced this group; skip it.
+						Err(moq_net::Error::Duplicate) => continue,
+						Err(err) => return Err(err.into()),
+					};
+					let done = transcode_group(&mut pipeline, &container, &mut source, &mut output, Some(&demand)).await?;
+					if !done {
+						// Demand disappeared mid-group; back to waiting.
+						break 'session;
+					}
+				}
+				_ = demand.unused() => break 'session,
+			}
+		}
+		// Dropping the subscriber releases the upstream subscription (and the
+		// encoder) until someone subscribes again.
+	}
+}
+
+/// The fetch path: serve requests for specific (past) groups.
+async fn fetches(rung: &Rung, dynamic: &moq_net::track::Dynamic) -> Result<(), Error> {
+	loop {
+		let Ok(request) = dynamic.requested_group().await else {
+			// The output track closed; nothing more to serve.
+			return Ok(());
+		};
+		let rung = rung.clone();
+		tokio::spawn(async move {
+			let sequence = request.sequence();
+			if let Err(err) = fetch(rung, request).await {
+				tracing::warn!(%err, sequence, "transcode fetch failed");
+			}
+		});
+	}
+}
+
+/// Transcode one specifically requested group, fetching it from the source.
+async fn fetch(rung: Rung, request: moq_net::track::GroupRequest) -> Result<(), Error> {
+	let options = moq_net::group::Fetch::default().with_priority(request.priority());
+	let mut source = match rung.source.fetch_group(request.sequence(), options).await {
+		Ok(source) => source,
+		Err(err) => {
+			request.reject(err.clone());
+			return Err(err.into());
+		}
+	};
+
+	// A fresh pipeline per fetched group: groups are independently decodable,
+	// so the encoder starts clean at the group's keyframe.
+	let mut pipeline = rung.pipeline()?;
+	let container = rung.container()?;
+	let mut output = request.accept(None)?;
+	transcode_group(&mut pipeline, &container, &mut source, &mut output, None).await?;
+	Ok(())
+}
+
+/// Transcode one source group into one output group.
+///
+/// With a `demand` handle (the live path) the group is abandoned as soon as the
+/// track goes unused, returning `Ok(false)`; without one (the fetch path) the
+/// group always runs to completion and the encoder is drained at the end.
+async fn transcode_group(
+	pipeline: &mut Pipeline,
+	container: &moq_mux::catalog::hang::Container,
+	source: &mut moq_net::group::Consumer,
+	output: &mut moq_net::group::Producer,
+	demand: Option<&moq_net::track::Demand>,
+) -> Result<bool, Error> {
+	match transcode_group_inner(pipeline, container, source, output, demand).await {
+		Ok(done) => {
+			if done {
+				output.finish()?;
+			} else {
+				// Demand disappeared mid-group: signal downstream that the
+				// group is incomplete rather than leaving it short-but-finished.
+				output.abort(moq_net::Error::Cancel)?;
+			}
+			Ok(done)
+		}
+		Err(err) => {
+			let _ = output.abort(moq_net::Error::Cancel);
+			Err(err)
+		}
+	}
+}
+
+async fn transcode_group_inner(
+	pipeline: &mut Pipeline,
+	container: &moq_mux::catalog::hang::Container,
+	source: &mut moq_net::group::Consumer,
+	output: &mut moq_net::group::Producer,
+	demand: Option<&moq_net::track::Demand>,
+) -> Result<bool, Error> {
+	let mut first = true;
+	let mut last_timestamp = 0u64;
+
+	loop {
+		let frames = match demand {
+			Some(demand) => tokio::select! {
+				frames = container.read(source) => frames,
+				_ = demand.unused() => return Ok(false),
+			},
+			None => container.read(source).await,
+		};
+		let Some(frames) = frames? else {
+			break;
+		};
+
+		for frame in frames {
+			let timestamp: u64 = frame
+				.timestamp
+				.as_micros()
+				.try_into()
+				.map_err(|_| moq_net::TimeOverflow)?;
+			last_timestamp = last_timestamp.max(timestamp);
+
+			// The first frame of a group is a keyframe by construction; force
+			// an IDR there so every output group opens self-contained.
+			let keyframe = frame.keyframe || first;
+			first = false;
+
+			write(output, pipeline.process(&frame.payload, timestamp, keyframe)?)?;
+		}
+	}
+
+	if demand.is_none() {
+		// One-shot group: drain whatever the encoder still buffers.
+		write(output, pipeline.finish(last_timestamp)?)?;
+	}
+	Ok(true)
+}
+
+/// Append encoded packets to the output group in the legacy hang framing.
+fn write(output: &mut moq_net::group::Producer, packets: Vec<(u64, Bytes)>) -> Result<(), Error> {
+	for (timestamp, payload) in packets {
+		let frame = hang::container::Frame {
+			timestamp: moq_net::Timestamp::from_micros(timestamp)?,
+			payload,
+		};
+		frame.encode(output)?;
+	}
+	Ok(())
+}
+
+/// Decode -> scale -> encode for one rung.
+struct Pipeline {
+	decoder: moq_video::decode::Decoder,
+	scaler: Scaler,
+	encoder: moq_video::encode::Encoder,
+	width: u32,
+	height: u32,
+}
+
+impl Pipeline {
+	fn new(rung: &Rung) -> Result<Self, Error> {
+		let decoder = moq_video::decode::Decoder::new(&rung.config, &rung.decoder)?;
+
+		let mut config = moq_video::encode::Config::new(rung.info.width, rung.info.height, rung.info.framerate);
+		config.bitrate = Some(rung.info.bitrate);
+		config.kind = rung.encoder.clone();
+		// Keyframes are forced at every group boundary; the GOP is only a
+		// backstop against pathologically long source groups.
+		config.gop = rung.info.framerate.saturating_mul(8).max(1);
+		let encoder = moq_video::encode::Encoder::new(&config)?;
+
+		Ok(Self {
+			decoder,
+			scaler: Scaler::new(rung.info.width, rung.info.height),
+			encoder,
+			width: rung.info.width,
+			height: rung.info.height,
+		})
+	}
+
+	/// Transcode one container payload into zero or more encoded packets, each
+	/// paired with its presentation timestamp in microseconds.
+	fn process(&mut self, payload: &Bytes, timestamp: u64, keyframe: bool) -> Result<Vec<(u64, Bytes)>, Error> {
+		let mut packets = Vec::new();
+		for raw in self.decoder.decode(payload, timestamp, keyframe)? {
+			let scaled = self.scaler.scale(&raw.data, raw.width, raw.height)?;
+			for packet in self.encoder.encode_i420(scaled, self.width, self.height, keyframe)? {
+				packets.push((raw.timestamp_us, packet));
+			}
+		}
+		Ok(packets)
+	}
+
+	/// Drain the encoder, pairing any buffered packets with `timestamp`.
+	fn finish(&mut self, timestamp: u64) -> Result<Vec<(u64, Bytes)>, Error> {
+		Ok(self
+			.encoder
+			.finish()?
+			.into_iter()
+			.map(|packet| (timestamp, packet))
+			.collect())
+	}
+}

--- a/rs/moq-transcode/src/scale.rs
+++ b/rs/moq-transcode/src/scale.rs
@@ -1,0 +1,136 @@
+//! CPU I420 scaling between decode and re-encode.
+
+use fast_image_resize::images::{Image, ImageRef};
+use fast_image_resize::{FilterType, PixelType, ResizeAlg, ResizeOptions, Resizer};
+
+use crate::Error;
+
+/// Scales tightly-packed I420 frames to a fixed output resolution.
+///
+/// Per-plane SIMD resize: Y at full size, U/V at quarter size. This is the CPU
+/// stage of the pipeline; the GPU-resident scale (CUDA/NPP) is tracked in
+/// moq-dev/moq#1837.
+pub(crate) struct Scaler {
+	resizer: Resizer,
+	options: ResizeOptions,
+	width: u32,
+	height: u32,
+}
+
+impl Scaler {
+	/// A scaler producing `width` x `height` output (both even).
+	pub fn new(width: u32, height: u32) -> Self {
+		Self {
+			resizer: Resizer::new(),
+			// Bilinear: the cheapest convolution, fine for live downscaling.
+			options: ResizeOptions::new().resize_alg(ResizeAlg::Convolution(FilterType::Bilinear)),
+			width,
+			height,
+		}
+	}
+
+	/// Scale one packed I420 frame (Y then U then V, no row padding, even
+	/// dimensions) to the output resolution.
+	pub fn scale(&mut self, src: &[u8], src_width: u32, src_height: u32) -> Result<Vec<u8>, Error> {
+		let src_luma = src_width as usize * src_height as usize;
+		if src.len() < src_luma * 3 / 2 {
+			return Err(Error::Scale(format!(
+				"I420 buffer is {} bytes, expected {} for {src_width}x{src_height}",
+				src.len(),
+				src_luma * 3 / 2
+			)));
+		}
+
+		let dst_luma = self.width as usize * self.height as usize;
+		let mut dst = vec![0u8; dst_luma * 3 / 2];
+		let (dst_y, dst_chroma) = dst.split_at_mut(dst_luma);
+		let (dst_u, dst_v) = dst_chroma.split_at_mut(dst_luma / 4);
+
+		let src_chroma = src_luma / 4;
+		let (src_w2, src_h2) = (src_width / 2, src_height / 2);
+		let (dst_w2, dst_h2) = (self.width / 2, self.height / 2);
+
+		plane(
+			&mut self.resizer,
+			&self.options,
+			&src[..src_luma],
+			src_width,
+			src_height,
+			dst_y,
+			self.width,
+			self.height,
+		)?;
+		plane(
+			&mut self.resizer,
+			&self.options,
+			&src[src_luma..src_luma + src_chroma],
+			src_w2,
+			src_h2,
+			dst_u,
+			dst_w2,
+			dst_h2,
+		)?;
+		plane(
+			&mut self.resizer,
+			&self.options,
+			&src[src_luma + src_chroma..src_luma + 2 * src_chroma],
+			src_w2,
+			src_h2,
+			dst_v,
+			dst_w2,
+			dst_h2,
+		)?;
+
+		Ok(dst)
+	}
+}
+
+/// Resize one 8-bit plane.
+#[allow(clippy::too_many_arguments)]
+fn plane(
+	resizer: &mut Resizer,
+	options: &ResizeOptions,
+	src: &[u8],
+	src_width: u32,
+	src_height: u32,
+	dst: &mut [u8],
+	dst_width: u32,
+	dst_height: u32,
+) -> Result<(), Error> {
+	let src = ImageRef::new(src_width, src_height, src, PixelType::U8).map_err(|e| Error::Scale(e.to_string()))?;
+	let mut dst =
+		Image::from_slice_u8(dst_width, dst_height, dst, PixelType::U8).map_err(|e| Error::Scale(e.to_string()))?;
+	resizer
+		.resize(&src, &mut dst, options)
+		.map_err(|e| Error::Scale(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn downscale_preserves_flat_planes() {
+		// A flat frame stays flat through any correct per-plane resize.
+		let (w, h) = (320u32, 240u32);
+		let luma = (w * h) as usize;
+		let mut src = vec![0u8; luma * 3 / 2];
+		src[..luma].fill(120);
+		src[luma..luma + luma / 4].fill(90);
+		src[luma + luma / 4..].fill(200);
+
+		let mut scaler = Scaler::new(160, 120);
+		let dst = scaler.scale(&src, w, h).unwrap();
+		let dst_luma = 160 * 120;
+		assert_eq!(dst.len(), dst_luma * 3 / 2);
+		assert!(dst[..dst_luma].iter().all(|&b| b == 120));
+		assert!(dst[dst_luma..dst_luma + dst_luma / 4].iter().all(|&b| b == 90));
+		assert!(dst[dst_luma + dst_luma / 4..].iter().all(|&b| b == 200));
+	}
+
+	#[test]
+	fn rejects_short_buffer() {
+		let mut scaler = Scaler::new(160, 120);
+		assert!(matches!(scaler.scale(&[0u8; 16], 320, 240), Err(Error::Scale(_))));
+	}
+}

--- a/rs/moq-video/CHANGELOG.md
+++ b/rs/moq-video/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `decode::Decoder` is public: the payload-in, frames-out layer under
+  `decode::Consumer`, for callers that don't read from a plain track
+  subscription (e.g. a transcoder decoding individually fetched groups).
+- `encode::Encoder::encode_i420`: encode a tightly-packed I420 frame directly,
+  the zero-conversion input path for callers that already hold I420 (decoder
+  output), alongside the existing `encode_rgba`.
 - Native H.264 decode: a `decode` module mirroring `encode`, with a
   `decode::Consumer` (the counterpart to `moq-audio`'s `AudioConsumer`) that
   subscribes to an H.264 track and returns raw I420 frames. Backends are

--- a/rs/moq-video/src/decode/consumer.rs
+++ b/rs/moq-video/src/decode/consumer.rs
@@ -2,7 +2,6 @@
 
 use std::collections::VecDeque;
 
-use bytes::Bytes;
 use hang::catalog::VideoConfig;
 
 use super::Frame;
@@ -68,14 +67,10 @@ impl Consumer {
 				.try_into()
 				.map_err(|_| moq_net::TimeOverflow)?;
 
-			for i420 in self.decoder.decode(&mux_frame.payload, mux_frame.keyframe)? {
-				self.pending.push_back(Frame {
-					timestamp_us,
-					width: i420.width,
-					height: i420.height,
-					data: Bytes::from(i420.data),
-				});
-			}
+			self.pending.extend(
+				self.decoder
+					.decode(&mux_frame.payload, timestamp_us, mux_frame.keyframe)?,
+			);
 		}
 	}
 }

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -13,9 +13,9 @@ use bytes::Bytes;
 use hang::catalog::{VideoCodec, VideoConfig};
 use moq_mux::codec::{annexb, h264, h265};
 
+use super::Frame;
 use super::backend::{self, Backend, Codec};
 use crate::Error;
-use crate::frame::I420;
 
 /// Which decoder implementation to use. `#[non_exhaustive]` so new selection
 /// strategies can be added without breaking external `match`es.
@@ -66,8 +66,14 @@ enum Conversion {
 	LengthPrefixed { length_size: usize, keyframe_prefix: Bytes },
 }
 
-/// Drives a [`Backend`] from container frames.
-pub(crate) struct Decoder {
+/// Decodes container payloads (the codec bitstream) into raw [`Frame`]s.
+///
+/// The bring-your-own-payload layer under [`Consumer`](super::Consumer): use it
+/// when the frames don't come from a plain track subscription, e.g. a transcoder
+/// serving individually fetched groups. Feed it the payload of each container
+/// frame in decode order; it handles avc1/hvc1 -> Annex-B conversion and gates
+/// output until the first keyframe.
+pub struct Decoder {
 	backend: Box<dyn Backend>,
 	conversion: Conversion,
 	got_keyframe: bool,
@@ -76,7 +82,7 @@ pub(crate) struct Decoder {
 impl Decoder {
 	/// Build a decoder for the catalog's video config. Errors if the codec is
 	/// neither H.264 nor H.265 (the codecs the native backends support).
-	pub(crate) fn new(catalog: &VideoConfig, kind: &Kind) -> Result<Self, Error> {
+	pub fn new(catalog: &VideoConfig, kind: &Kind) -> Result<Self, Error> {
 		let (codec, conversion) = match &catalog.codec {
 			VideoCodec::H264(h264) => {
 				let conversion = if h264.inline {
@@ -124,12 +130,13 @@ impl Decoder {
 	}
 
 	/// The decoder backend name in use, e.g. `"videotoolbox"`.
-	pub(crate) fn name(&self) -> &str {
+	pub fn name(&self) -> &str {
 		self.backend.name()
 	}
 
-	/// Decode one container frame, returning zero or more raw I420 frames.
-	pub(crate) fn decode(&mut self, payload: &Bytes, keyframe: bool) -> Result<Vec<I420>, Error> {
+	/// Decode one container frame, returning zero or more raw frames stamped with
+	/// `timestamp_us` (the container frame's presentation time in microseconds).
+	pub fn decode(&mut self, payload: &Bytes, timestamp_us: u64, keyframe: bool) -> Result<Vec<Frame>, Error> {
 		// Wait for the first keyframe: a decoder started mid-GOP can't decode
 		// delta frames, and the parameter sets ride along with the keyframe.
 		if !self.got_keyframe {
@@ -151,7 +158,17 @@ impl Decoder {
 			}
 		};
 
-		self.backend.decode(annexb, keyframe)
+		Ok(self
+			.backend
+			.decode(annexb, keyframe)?
+			.into_iter()
+			.map(|i420| Frame {
+				timestamp_us,
+				width: i420.width,
+				height: i420.height,
+				data: Bytes::from(i420.data),
+			})
+			.collect())
 	}
 }
 

--- a/rs/moq-video/src/decode/mod.rs
+++ b/rs/moq-video/src/decode/mod.rs
@@ -20,7 +20,7 @@ mod consumer;
 mod decoder;
 
 pub use consumer::Consumer;
-pub use decoder::{Config, Kind};
+pub use decoder::{Config, Decoder, Kind};
 
 /// A decoded raw video frame in tightly-packed I420 (YUV 4:2:0), BT.601 limited
 /// range (studio swing, what H.264 carries by default).

--- a/rs/moq-video/src/encode/encoder.rs
+++ b/rs/moq-video/src/encode/encoder.rs
@@ -178,6 +178,34 @@ impl Encoder {
 		self.encode(&frame, keyframe)
 	}
 
+	/// Encode one tightly-packed I420 frame (`width * height * 3 / 2` bytes: Y
+	/// then U then V, no row padding, BT.601 limited range), returning zero or
+	/// more encoded packets in the codec's framing. Set `keyframe` to force an
+	/// IDR. The frame must already be at the encoder's resolution.
+	///
+	/// The zero-conversion input path for callers that already hold I420, e.g. a
+	/// transcoder feeding decoder output back in; [`encode_rgba`](Self::encode_rgba)
+	/// is the convenience path for RGBA sources.
+	pub fn encode_i420(&mut self, data: Vec<u8>, width: u32, height: u32, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+		if width != self.width || height != self.height {
+			return Err(Error::Codec(anyhow::anyhow!(
+				"frame {width}x{height} does not match encoder {}x{}",
+				self.width,
+				self.height
+			)));
+		}
+		let expected = I420::len(width, height);
+		if data.len() != expected {
+			return Err(Error::Codec(anyhow::anyhow!(
+				"I420 buffer is {} bytes, expected {expected} for {width}x{height}",
+				data.len()
+			)));
+		}
+
+		let frame = Frame::I420(I420 { width, height, data });
+		self.encode(&frame, keyframe)
+	}
+
 	/// Encode a captured [`Frame`] (a GPU surface or CPU I420). The frame must
 	/// already be at the encoder's resolution.
 	pub(crate) fn encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
@@ -250,6 +278,34 @@ mod tests {
 		packets.extend(encoder.finish().unwrap());
 		assert!(!packets.is_empty());
 		assert!(packets[0].starts_with(&[0, 0, 0, 1]) || packets[0].starts_with(&[0, 0, 1]));
+	}
+
+	#[test]
+	fn encode_i420_emits_annexb() {
+		let config = Config {
+			kind: Kind::Software,
+			..Config::new(320, 240, 30)
+		};
+		let mut encoder = Encoder::new(&config).unwrap();
+
+		// A mid-gray I420 frame: flat 0x80 across all three planes.
+		let data = vec![0x80u8; I420::len(320, 240)];
+		let mut packets = encoder.encode_i420(data, 320, 240, true).unwrap();
+		packets.extend(encoder.finish().unwrap());
+		assert!(!packets.is_empty());
+		assert!(packets[0].starts_with(&[0, 0, 0, 1]) || packets[0].starts_with(&[0, 0, 1]));
+	}
+
+	#[test]
+	fn encode_i420_rejects_wrong_size() {
+		let Ok(mut encoder) = Encoder::new(&Config::new(320, 240, 30)) else {
+			return;
+		};
+		// Not width * height * 3 / 2: must error, not feed a short buffer to a backend.
+		assert!(matches!(
+			encoder.encode_i420(vec![0u8; 16], 320, 240, false),
+			Err(Error::Codec(_))
+		));
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

A new `rs/moq-transcode` crate implementing the open-source half of the live-transcoding plan (WS3): `run(source: broadcast::Consumer, output: broadcast::Producer, config)` consumes a hang broadcast and fills a derivative broadcast next to it. Orchestration (where the output is announced, routing, admission, billing) stays with the caller.

**Catalog, built on demand from the source catalog:**
- Published immediately and deterministically, before any encoder exists: H.264 codec strings are computed from the ladder (High profile + a Table A-1 level lookup, avc3 in-band parameter sets), not from the bitstream.
- Ladder rungs are filtered to strictly below the source: never upscale (a 480p source is never offered at 720p), and a rung must undercut a known source bitrate. Rung geometry follows the source aspect ratio.
- Source renditions (all video and audio) are referenced through a relative `broadcast` pointer (#1371), e.g. `..` when the derivative lives at `<source>/transcode.hang`, so the transcoder never proxies or subscribes what it does not re-encode. Passthrough entries track source catalog updates.

**Just-in-time encoding, per rung, using the demand surfaces already on dev (no moq-net changes):**
- A rung track only materializes via `broadcast::Dynamic::requested_track`. A SUBSCRIBE on a rung starts a live loop that SUBSCRIBEs the source track (mirroring the aggregate subscription: priority, ordering, start) and transcodes group for group until the track goes `unused`.
- A FETCH of output group N (`track::Dynamic::requested_group`) triggers `fetch_group(N)` on the source and transcodes just that group with a fresh encoder. Output groups mirror source group sequence numbers 1:1, so group N of every rung is the same content as source group N and rendition switches land cleanly.
- The catalog tracks and the dynamic handler register synchronously before the first await, so consumers racing setup queue instead of hitting NotFound.

**Pipeline:** hang container read -> `moq_video::decode::Decoder` (VideoToolbox / Media Foundation / DXVA hardware, openh264 fallback) -> CPU I420 scale (`fast_image_resize`, per-plane SIMD) -> `moq_video::encode::Encoder` (NVENC on Linux with forced-IDR per group boundary and CBR at the rung bitrate; VideoToolbox / Media Foundation elsewhere; openh264 fallback) -> legacy hang frames, timestamps passed through in microseconds.

**Additive moq-video API (public surface):**
- `decode::Decoder` is now `pub` (was `pub(crate)`): the payload-in, frames-out layer under `decode::Consumer`, needed to decode individually fetched groups rather than a track subscription. Its `decode()` gained a `timestamp_us` parameter and now returns the public `decode::Frame` (internal `Consumer` updated accordingly).
- `encode::Encoder::encode_i420`: encode a tightly-packed I420 frame directly, skipping the RGBA round trip (decoders emit I420 and NVENC consumes IYUV).
- `moq-transcode` forwards default-on `nvenc`/`vaapi` features to `moq-video`, mirroring `moq-cli`.

## Review (high-effort, applied)

A multi-angle review ran on the diff. Fixes applied in the second commit:

- **Fetch task lifecycle**: fetch tasks were detached via bare `tokio::spawn` and orphaned on teardown (holding a source subscription + encoder session past shutdown). They now run under a `JoinSet` scoped to the fetch loop (cancelling `serve` aborts them), and a semaphore (`MAX_CONCURRENT_FETCHES`) bounds concurrent transcode pipelines so a fetch burst can't exhaust the few hardware encoder sessions and starve live viewers.
- **Fetch error masking**: `fetch()` dropped the `GroupRequest` on a pipeline/encoder init failure, auto-rejecting the consumer with `Error::Dropped` and hiding the real error. It now rejects explicitly on every early exit.
- **Shutdown drain hang**: `run()`'s post-loop drain awaited the rung `JoinSet` unconditionally, but a rung task only self-ends on source-media-end / broadcast-close, not the catalog-track end that can break the main loop, so a transient catalog error with live viewers could hang forever. It now aborts via `JoinSet::shutdown` (also removes a duplicated drain-match). Covered by a new shutdown regression test.

Reviewed and dismissed: the "keyframe flag conflation" finding was a false positive. The low-level `Container::read` the transcoder uses does not reconstruct the legacy keyframe bit, so the group-boundary `first` flag is the required keyframe signal for the decoder, and a group always opens on a keyframe by construction (confirmed by test: passing only the container flag starves the decoder).

## Not in this PR (deliberate, tracked)

- **NVDEC decode / GPU-resident scaling**: moq-nvenc has no NVDEC safe wrapper today; decode on a Linux NVENC box falls back to openh264 (software) until the NVDEC backend lands. Tracked on #1837 ("GPU transcode pipeline primitives"), which also tracks VBV/initial-QP/`NvEncReconfigureEncoder` knobs.
- **B-frame / reordering source timestamps**: `moq-video`'s `decode` backends return frames without per-output PTS, so a reordering (B-frame) H.264 source decoded via `Decoder`/`decode::Consumer` stamps outputs with the input access-unit timestamp. This is a pre-existing `decode::Consumer` limitation the transcoder inherits, not introduced here; the shipped `moq-video` encoders are B-frame-free low-latency, and the transcode test path has no reordering. Fixing it properly means threading PTS through all three platform decode backends (VideoToolbox / Media Foundation / openh264) with hardware validation, so it's a scoped `moq-video` follow-up rather than a blind change in this merge.
- **Live/fetch two-writer race**: a group fetched at the live edge can be skipped by the live loop's `create_group` `Duplicate` handling; harmless (the fetch's group reaches subscribers via the shared track cache) unless that fetch then fails, costing one recoverable GOP. Removing it entirely means unifying the live + fetch paths into a single cache-backed serving loop (like the relay); documented inline as a follow-up.
- **Timeline track**: #2109 is main-only while the main->dev merge is in flight. Group durations are not needed for v1 rate control (strict CBR; IDR cadence mirrors source groups), and the transcoder reads every frame timestamp anyway. Consuming/publishing timeline tracks (and a possible `maxGroupDuration` catalog field for HLS) is a natural follow-up once the merge lands.
- **H.265 output rungs, compat fixed-GOP mode, shared-decoder fan-out**: follow-ups per the plan.

## Testing

- In-process end-to-end test: openh264 source broadcast -> derivative catalog assertions (rung geometry, codec string, `broadcast: ".."` refs) -> live subscribe (group sequence mirroring, Annex-B output) -> specific-group fetch (complete 5-frame group transcoded on demand).
- Unit tests: ladder filtering (never upscale, same-height needs lower bitrate), aspect-ratio geometry (including vertical video), H.264 level table, I420 scaler, `encode_i420` validation.
- `just check` passes; `RUSTDOCFLAGS="-D warnings" cargo doc` clean for both crates. NVENC itself is compile-checked on macOS (dlopen-only); on-GPU validation of the transcode path is pending, like the rest of #1837's hardware checklist.

## Public API changes

- `moq-video` (additive): `decode::Decoder` newly `pub` with `new(catalog, kind)` / `name()` / `decode(payload, timestamp_us, keyframe) -> Vec<decode::Frame>`; new `encode::Encoder::encode_i420(data, width, height, keyframe)`.
- `moq-transcode` (new crate): `Config` (`rungs`, `source`, `encoder`, `decoder`; `#[non_exhaustive]`), `Rung` (`#[non_exhaustive]`), `Error` (`#[non_exhaustive]`), `run(source, output, config)`.
- No changes to `moq-net`, `hang` formats, or the wire protocol; nothing breaking, targeting dev because the crates it builds on (moq-video/moq-nvenc current state) live there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Fable 5)
