### PR TITLE
Use container timestamps for media PTS; rename lite-05 Lite05Wip -> Lite05

### DIFF
--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -143,10 +143,10 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 		setupVersion = Ietf.Version.DRAFT_16;
 	} else if (protocol === Ietf.ALPN.DRAFT_15) {
 		setupVersion = Ietf.Version.DRAFT_15;
-	} else if (protocol === Lite.ALPN_05_WIP) {
+	} else if (protocol === Lite.ALPN_05) {
 		// moq-lite draft-05 exchanges SETUP on a dedicated unidirectional stream
 		// (handled inside Connection), not the session compat stream.
-		return new Lite.Connection(url, session, Lite.Version.DRAFT_05_WIP, undefined);
+		return new Lite.Connection(url, session, Lite.Version.DRAFT_05, undefined);
 	} else if (protocol === Lite.ALPN_04) {
 		// moq-lite draft-04 doesn't use a session stream, so we return immediately.
 		return new Lite.Connection(url, session, Lite.Version.DRAFT_04, undefined);
@@ -231,8 +231,8 @@ async function connectTransport(url: URL, session: WebTransport): Promise<Establ
 		setupVersion = Ietf.Version.DRAFT_16;
 	} else if (protocol === Ietf.ALPN.DRAFT_15) {
 		setupVersion = Ietf.Version.DRAFT_15;
-	} else if (protocol === Lite.ALPN_05_WIP) {
-		return new Lite.Connection(url, session, Lite.Version.DRAFT_05_WIP, undefined);
+	} else if (protocol === Lite.ALPN_05) {
+		return new Lite.Connection(url, session, Lite.Version.DRAFT_05, undefined);
 	} else if (protocol === Lite.ALPN_04) {
 		return new Lite.Connection(url, session, Lite.Version.DRAFT_04, undefined);
 	} else if (protocol === Lite.ALPN_03) {

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -292,6 +292,8 @@ export class Publisher {
 			try {
 				// moq-lite-05+ stamps each frame with a wall-clock millisecond timestamp, sent
 				// as a zigzag delta from the previous frame (the first frame is a delta from 0).
+				// This is a placeholder: consumers read the presentation timestamp from the
+				// container payload, not from here, so the value is not yet load-bearing.
 				let prevTimestamp = 0n;
 
 				for (;;) {

--- a/js/net/src/lite/subscribe.ts
+++ b/js/net/src/lite/subscribe.ts
@@ -198,7 +198,7 @@ export class SubscribeOk {
 			case Version.DRAFT_01:
 				await w.u8(this.priority ?? 0);
 				break;
-			case Version.DRAFT_05_WIP:
+			case Version.DRAFT_05:
 				// moq-lite-05+: just the resolved absolute start group (raw, 0 is valid).
 				await w.u53(this.startGroup ?? 0);
 				break;
@@ -226,7 +226,7 @@ export class SubscribeOk {
 			case Version.DRAFT_01:
 				priority = await r.u8();
 				break;
-			case Version.DRAFT_05_WIP:
+			case Version.DRAFT_05:
 				// moq-lite-05+: just the resolved absolute start group (raw).
 				return new SubscribeOk({ startGroup: await r.u53() });
 			default:
@@ -340,7 +340,7 @@ export async function encodeSubscribeResponse(w: Writer, resp: SubscribeResponse
 				throw new Error("only SUBSCRIBE_OK is supported for this version");
 			}
 			break;
-		case Version.DRAFT_05_WIP:
+		case Version.DRAFT_05:
 			// moq-lite-05+: 0x0 OK, 0x1 END, 0x2 DROP.
 			if ("ok" in resp) {
 				await w.u53(0x0);
@@ -373,7 +373,7 @@ async function decodeResponse(r: Reader, version: Version): Promise<SubscribeRes
 		case Version.DRAFT_01:
 		case Version.DRAFT_02:
 			return { ok: await SubscribeOk.decode(r, version) };
-		case Version.DRAFT_05_WIP: {
+		case Version.DRAFT_05: {
 			const typ = await r.u53();
 			switch (typ) {
 				case 0x0:

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -309,8 +309,9 @@ export class Subscriber {
 				if (done !== false) break;
 
 				if (hasTrackStream(this.version)) {
-					// moq-lite-05+ prefixes each frame with a zigzag timestamp delta. Decode it
-					// to stay aligned with the wire, but don't surface it yet.
+					// moq-lite-05+ prefixes each frame with a zigzag timestamp delta. It is not
+					// load-bearing: the presentation timestamp comes from the container payload,
+					// so we decode this only to stay aligned with the wire and discard it.
 					await stream.u62();
 				}
 

--- a/js/net/src/lite/track.test.ts
+++ b/js/net/src/lite/track.test.ts
@@ -33,8 +33,8 @@ test("TrackInfo round-trips on draft-05", async () => {
 		maxLatency: 2000,
 		timescale: 90000,
 	});
-	const reader = new Reader(undefined, await bytes((w) => info.encode(w, Version.DRAFT_05_WIP)));
-	const got = await TrackInfo.decode(reader, Version.DRAFT_05_WIP);
+	const reader = new Reader(undefined, await bytes((w) => info.encode(w, Version.DRAFT_05)));
+	const got = await TrackInfo.decode(reader, Version.DRAFT_05);
 	expect(got.priority).toBe(7);
 	expect(got.ordered).toBe(false);
 	expect(got.maxLatency).toBe(2000);
@@ -43,8 +43,8 @@ test("TrackInfo round-trips on draft-05", async () => {
 
 test("Track request round-trips on draft-05", async () => {
 	const msg = new Track({ broadcast: Path.from("room"), track: "video" });
-	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, Version.DRAFT_05_WIP)));
-	const got = await Track.decode(reader, Version.DRAFT_05_WIP);
+	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, Version.DRAFT_05)));
+	const got = await Track.decode(reader, Version.DRAFT_05);
 	expect(got.broadcast).toBe(Path.from("room"));
 	expect(got.track).toBe("video");
 });

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -3,9 +3,9 @@ export const Version = {
 	DRAFT_02: 0xff0dad02,
 	DRAFT_03: 0xff0dad03,
 	DRAFT_04: 0xff0dad04,
-	/// Work-in-progress placeholder for lite-05. Not advertised as a
-	/// WebTransport subprotocol; callers must opt in explicitly.
-	DRAFT_05_WIP: 0xff0dad05,
+	/// moq-lite-05. Not advertised as a WebTransport subprotocol; callers must
+	/// opt in explicitly.
+	DRAFT_05: 0xff0dad05,
 } as const;
 
 export type Version = (typeof Version)[keyof typeof Version];
@@ -20,16 +20,16 @@ export const ALPN_03 = "moq-lite-03";
 /// The ALPN string for Draft04, which uses ALPN-based version negotiation.
 export const ALPN_04 = "moq-lite-04";
 
-/// The ALPN string for the work-in-progress Draft05. Intentionally not
-/// included in the default WebTransport `protocols` list.
-export const ALPN_05_WIP = "moq-lite-05-wip";
+/// The ALPN string for Draft05. Intentionally not included in the default
+/// WebTransport `protocols` list.
+export const ALPN_05 = "moq-lite-05";
 
 const VERSION_NAMES: Record<number, string> = {
 	[Version.DRAFT_01]: "moq-lite-01",
 	[Version.DRAFT_02]: "moq-lite-02",
 	[Version.DRAFT_03]: "moq-lite-03",
 	[Version.DRAFT_04]: "moq-lite-04",
-	[Version.DRAFT_05_WIP]: "moq-lite-05-wip",
+	[Version.DRAFT_05]: "moq-lite-05",
 };
 
 export function versionName(v: Version): string {
@@ -38,12 +38,12 @@ export function versionName(v: Version): string {
 
 /// Whether this version uses a unidirectional Setup stream (moq-lite-05+).
 export function hasSetupStream(v: Version): boolean {
-	return v === Version.DRAFT_05_WIP;
+	return v === Version.DRAFT_05;
 }
 
 /// Whether this version uses the moq-lite-05 framing bundle: the Track stream
 /// (TRACK/TRACK_INFO), a SUBSCRIBE_OK trimmed to the resolved start group plus a
 /// distinct SUBSCRIBE_END, and a per-frame timestamp delta.
 export function hasTrackStream(v: Version): boolean {
-	return v === Version.DRAFT_05_WIP;
+	return v === Version.DRAFT_05;
 }

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -708,7 +708,7 @@ async fn serve_session(request: Request) -> crate::Result<()> {
 #[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
 fn stream_versions(base: &moq_net::Versions) -> moq_net::Versions {
 	let mut versions: Vec<moq_net::Version> = base.iter().copied().collect();
-	if let Ok(lite05) = "moq-lite-05-wip".parse::<moq_net::Version>() {
+	if let Ok(lite05) = "moq-lite-05".parse::<moq_net::Version>() {
 		if !versions.contains(&lite05) {
 			versions.push(lite05);
 		}

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -1,6 +1,6 @@
 use crate::{
-	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP,
-	Error, NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
+	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05, Error,
+	NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
 	coding::{self, Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -163,9 +163,9 @@ impl Client {
 					.ok_or(Error::Version)?;
 				(v, v.into())
 			}
-			Some(ALPN_LITE_05_WIP) => {
+			Some(ALPN_LITE_05) => {
 				self.versions
-					.select(Version::Lite(lite::Version::Lite05Wip))
+					.select(Version::Lite(lite::Version::Lite05))
 					.ok_or(Error::Version)?;
 
 				let setup = lite::Setup {
@@ -177,11 +177,11 @@ impl Client {
 					self.publish.clone(),
 					self.consume.clone(),
 					self.stats.clone(),
-					lite::Version::Lite05Wip,
+					lite::Version::Lite05,
 					setup,
 				)?;
 
-				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw));
+				return Ok(Session::new(session, lite::Version::Lite05.into(), recv_bw));
 			}
 			Some(ALPN_LITE_04) => {
 				self.versions

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -609,7 +609,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		track_stats.group();
 
 		// moq-lite-05+ stamps each frame with a wall-clock millisecond timestamp, sent as a
-		// zigzag delta from the previous frame (the first frame is a delta from 0).
+		// zigzag delta from the previous frame (the first frame is a delta from 0). This is a
+		// placeholder: consumers read the presentation timestamp from the container payload, not
+		// from here, so the value is not yet load-bearing.
 		let mut prev_timestamp: i64 = 0;
 
 		loop {

--- a/rs/moq-net/src/lite/setup.rs
+++ b/rs/moq-net/src/lite/setup.rs
@@ -109,9 +109,9 @@ mod tests {
 
 	fn roundtrip(setup: &Setup) -> Setup {
 		let mut buf = BytesMut::new();
-		setup.encode(&mut buf, Version::Lite05Wip).unwrap();
+		setup.encode(&mut buf, Version::Lite05).unwrap();
 		let mut slice = &buf[..];
-		let decoded = Setup::decode(&mut slice, Version::Lite05Wip).unwrap();
+		let decoded = Setup::decode(&mut slice, Version::Lite05).unwrap();
 		assert!(bytes::Buf::remaining(&slice) == 0, "trailing bytes after decode");
 		decoded
 	}
@@ -137,7 +137,7 @@ mod tests {
 			Setup {
 				path: Some("foo".into())
 			}
-			.encode(&mut buf, Version::Lite05Wip),
+			.encode(&mut buf, Version::Lite05),
 			Err(EncodeError::InvalidState)
 		));
 
@@ -145,12 +145,12 @@ mod tests {
 		let mut params = Parameters::default();
 		params.set(PARAM_PATH, b"foo".to_vec());
 		let mut body = BytesMut::new();
-		params.encode(&mut body, Version::Lite05Wip).unwrap();
+		params.encode(&mut body, Version::Lite05).unwrap();
 		let mut framed = BytesMut::new();
-		(body.len() as u64).encode(&mut framed, Version::Lite05Wip).unwrap();
+		(body.len() as u64).encode(&mut framed, Version::Lite05).unwrap();
 		framed.extend_from_slice(&body);
 		assert!(matches!(
-			Setup::decode(&mut framed, Version::Lite05Wip),
+			Setup::decode(&mut framed, Version::Lite05),
 			Err(DecodeError::InvalidValue)
 		));
 	}
@@ -172,14 +172,14 @@ mod tests {
 		params.set(0xbeef, b"whatever".to_vec());
 
 		let mut body = BytesMut::new();
-		params.encode(&mut body, Version::Lite05Wip).unwrap();
+		params.encode(&mut body, Version::Lite05).unwrap();
 
 		// Wrap with the message size prefix the Message impl expects.
 		let mut buf = BytesMut::new();
-		(body.len() as u64).encode(&mut buf, Version::Lite05Wip).unwrap();
+		(body.len() as u64).encode(&mut buf, Version::Lite05).unwrap();
 		buf.extend_from_slice(&body);
 
-		let decoded = Setup::decode(&mut buf, Version::Lite05Wip).unwrap();
+		let decoded = Setup::decode(&mut buf, Version::Lite05).unwrap();
 		assert_eq!(decoded.path.as_deref(), Some("/foo"));
 	}
 }

--- a/rs/moq-net/src/lite/subscribe.rs
+++ b/rs/moq-net/src/lite/subscribe.rs
@@ -421,7 +421,7 @@ mod tests {
 			start_group: Some(42),
 			end_group: None,
 		});
-		match response_roundtrip(&resp, Version::Lite05Wip) {
+		match response_roundtrip(&resp, Version::Lite05) {
 			SubscribeResponse::Ok(ok) => assert_eq!(ok.start_group, Some(42)),
 			other => panic!("expected Ok, got {other:?}"),
 		}
@@ -430,7 +430,7 @@ mod tests {
 	#[test]
 	fn lite05_subscribe_end() {
 		let resp = SubscribeResponse::End(SubscribeEnd { group: 7 });
-		match response_roundtrip(&resp, Version::Lite05Wip) {
+		match response_roundtrip(&resp, Version::Lite05) {
 			SubscribeResponse::End(end) => assert_eq!(end.group, 7),
 			other => panic!("expected End, got {other:?}"),
 		}
@@ -443,7 +443,7 @@ mod tests {
 			end: 3,
 			error: 0,
 		});
-		match response_roundtrip(&resp, Version::Lite05Wip) {
+		match response_roundtrip(&resp, Version::Lite05) {
 			SubscribeResponse::Drop(d) => {
 				assert_eq!(d.start, 1);
 				assert_eq!(d.end, 3);

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -476,7 +476,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 	async fn recv_setup(&self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {
 		// The Setup stream only exists in moq-lite-05+; reject it on older versions.
-		if self.version != Version::Lite05Wip {
+		if self.version != Version::Lite05 {
 			return Err(Error::UnexpectedStream);
 		}
 
@@ -533,8 +533,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	) -> Result<(), Error> {
 		loop {
 			let size = if self.version.has_track_stream() {
-				// moq-lite-05+: each frame is prefixed with a zigzag timestamp delta. We
-				// decode it to stay aligned with the wire, but don't surface it yet.
+				// moq-lite-05+: each frame is prefixed with a zigzag timestamp delta. It is
+				// not load-bearing: the presentation timestamp comes from the container payload,
+				// so we decode this only to stay aligned with the wire and discard it.
 				let Some(_timestamp_delta) = stream.decode_maybe::<u64>().await? else {
 					break;
 				};

--- a/rs/moq-net/src/lite/track.rs
+++ b/rs/moq-net/src/lite/track.rs
@@ -104,9 +104,9 @@ mod tests {
 
 	fn roundtrip(info: &TrackInfo) -> TrackInfo {
 		let mut buf = BytesMut::new();
-		info.encode(&mut buf, Version::Lite05Wip).unwrap();
+		info.encode(&mut buf, Version::Lite05).unwrap();
 		let mut slice = &buf[..];
-		let decoded = TrackInfo::decode(&mut slice, Version::Lite05Wip).unwrap();
+		let decoded = TrackInfo::decode(&mut slice, Version::Lite05).unwrap();
 		assert!(bytes::Buf::remaining(&slice) == 0, "trailing bytes after decode");
 		decoded
 	}
@@ -132,7 +132,7 @@ mod tests {
 				max_latency: Duration::ZERO,
 				timescale: 0,
 			}
-			.encode(&mut buf, Version::Lite05Wip),
+			.encode(&mut buf, Version::Lite05),
 			Err(EncodeError::InvalidState)
 		));
 	}
@@ -144,9 +144,9 @@ mod tests {
 			track: Cow::Borrowed("video"),
 		};
 		let mut buf = BytesMut::new();
-		track.encode(&mut buf, Version::Lite05Wip).unwrap();
+		track.encode(&mut buf, Version::Lite05).unwrap();
 		let mut slice = &buf[..];
-		let decoded = Track::decode(&mut slice, Version::Lite05Wip).unwrap();
+		let decoded = Track::decode(&mut slice, Version::Lite05).unwrap();
 		assert!(bytes::Buf::remaining(&slice) == 0, "trailing bytes after decode");
 		assert_eq!(decoded.broadcast, track.broadcast);
 		assert_eq!(decoded.track, track.track);

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -7,9 +7,9 @@ pub enum Version {
 	Lite02,
 	Lite03,
 	Lite04,
-	/// Work-in-progress placeholder for lite-05. Not advertised over ALPN or
-	/// included in default version sets; callers must opt in explicitly.
-	Lite05Wip,
+	/// moq-lite-05. Not advertised over ALPN or included in default version sets;
+	/// callers must opt in explicitly.
+	Lite05,
 }
 
 impl Version {
@@ -17,7 +17,7 @@ impl Version {
 	///
 	/// Earlier versions negotiate purely via ALPN and exchange no SETUP message.
 	pub fn has_setup_stream(self) -> bool {
-		matches!(self, Self::Lite05Wip)
+		matches!(self, Self::Lite05)
 	}
 
 	/// Whether this version uses the moq-lite-05 framing bundle: the Track stream
@@ -25,7 +25,7 @@ impl Version {
 	/// distinct SUBSCRIBE_END, and a per-frame timestamp delta. Earlier versions carry
 	/// publisher properties inline in SUBSCRIBE_OK and frames without a timestamp.
 	pub fn has_track_stream(self) -> bool {
-		matches!(self, Self::Lite05Wip)
+		matches!(self, Self::Lite05)
 	}
 }
 
@@ -36,7 +36,7 @@ impl fmt::Display for Version {
 			Self::Lite02 => write!(f, "moq-lite-02"),
 			Self::Lite03 => write!(f, "moq-lite-03"),
 			Self::Lite04 => write!(f, "moq-lite-04"),
-			Self::Lite05Wip => write!(f, "moq-lite-05-wip"),
+			Self::Lite05 => write!(f, "moq-lite-05"),
 		}
 	}
 }
@@ -48,7 +48,7 @@ impl From<Version> for crate::Version {
 			Version::Lite02 => crate::Version::Lite(Version::Lite02),
 			Version::Lite03 => crate::Version::Lite(Version::Lite03),
 			Version::Lite04 => crate::Version::Lite(Version::Lite04),
-			Version::Lite05Wip => crate::Version::Lite(Version::Lite05Wip),
+			Version::Lite05 => crate::Version::Lite(Version::Lite05),
 		}
 	}
 }

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1,6 +1,6 @@
 use crate::{
-	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05_WIP,
-	Error, NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
+	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05, Error,
+	NEGOTIATED, OriginConsumer, OriginProducer, Session, StatsHandle, Version, Versions,
 	coding::{Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -126,14 +126,14 @@ impl Server {
 					.ok_or(Error::Version)?;
 				(v, v.into())
 			}
-			Some(ALPN_LITE_05_WIP) => {
+			Some(ALPN_LITE_05) => {
 				self.versions
-					.select(Version::Lite(lite::Version::Lite05Wip))
+					.select(Version::Lite(lite::Version::Lite05))
 					.ok_or(Error::Version)?;
 
 				// Gate on the client's SETUP: read it before serving so the caller can
 				// scope by the advertised path.
-				let client_setup = lite::accept_setup(&session, lite::Version::Lite05Wip).await?;
+				let client_setup = lite::accept_setup(&session, lite::Version::Lite05).await?;
 				return Ok(Request {
 					server: self.clone(),
 					path: client_setup.path,
@@ -302,10 +302,10 @@ impl<S: web_transport_trait::Session> Request<S> {
 					server.publish,
 					server.consume,
 					server.stats,
-					lite::Version::Lite05Wip,
+					lite::Version::Lite05,
 					lite::Setup::default(),
 				)?;
-				return Ok(Session::new(session, lite::Version::Lite05Wip.into(), recv_bw));
+				return Ok(Session::new(session, lite::Version::Lite05.into(), recv_bw));
 			}
 			Handshake::Legacy {
 				session,
@@ -498,7 +498,7 @@ mod tests {
 
 	/// Encode a lite-05 Setup stream: the `DataType::Setup` tag then the SETUP message.
 	fn lite05_setup(path: Option<&str>) -> Vec<u8> {
-		let v = lite::Version::Lite05Wip;
+		let v = lite::Version::Lite05;
 		let mut buf = Vec::new();
 		lite::DataType::Setup.encode(&mut buf, v).unwrap();
 		lite::Setup {
@@ -512,17 +512,15 @@ mod tests {
 	/// Encode a lite-05 Group uni stream header (just the `DataType::Group` tag).
 	fn lite05_group() -> Vec<u8> {
 		let mut buf = Vec::new();
-		lite::DataType::Group
-			.encode(&mut buf, lite::Version::Lite05Wip)
-			.unwrap();
+		lite::DataType::Group.encode(&mut buf, lite::Version::Lite05).unwrap();
 		buf
 	}
 
 	#[tokio::test(start_paused = true)]
 	async fn accept_request_reads_lite05_path() {
-		let session = FakeSession::new(ALPN_LITE_05_WIP, [lite05_setup(Some("/team/room"))]);
+		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(Some("/team/room"))]);
 		let request = Server::new()
-			.with_versions(Version::Lite(lite::Version::Lite05Wip).into())
+			.with_versions(Version::Lite(lite::Version::Lite05).into())
 			.accept_request(session)
 			.await
 			.unwrap();
@@ -531,9 +529,9 @@ mod tests {
 
 	#[tokio::test(start_paused = true)]
 	async fn accept_request_lite05_without_path_is_none() {
-		let session = FakeSession::new(ALPN_LITE_05_WIP, [lite05_setup(None)]);
+		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(None)]);
 		let request = Server::new()
-			.with_versions(Version::Lite(lite::Version::Lite05Wip).into())
+			.with_versions(Version::Lite(lite::Version::Lite05).into())
 			.accept_request(session)
 			.await
 			.unwrap();
@@ -544,9 +542,9 @@ mod tests {
 	async fn accept_request_skips_uni_stream_before_setup() {
 		// A Group racing ahead of the SETUP is reset and skipped; the gate keeps
 		// reading until it finds the SETUP.
-		let session = FakeSession::new(ALPN_LITE_05_WIP, [lite05_group(), lite05_setup(Some("/team/room"))]);
+		let session = FakeSession::new(ALPN_LITE_05, [lite05_group(), lite05_setup(Some("/team/room"))]);
 		let request = Server::new()
-			.with_versions(Version::Lite(lite::Version::Lite05Wip).into())
+			.with_versions(Version::Lite(lite::Version::Lite05).into())
 			.accept_request(session)
 			.await
 			.unwrap();

--- a/rs/moq-net/src/version.rs
+++ b/rs/moq-net/src/version.rs
@@ -16,9 +16,9 @@ pub(crate) const NEGOTIATED: [Version; 3] = [
 
 /// ALPN strings for supported versions.
 ///
-/// Intentionally excludes `ALPN_LITE_05_WIP`: lite-05 is still work-in-progress
-/// and must not be advertised by default. Callers can opt in by including
-/// `Version::Lite(lite::Version::Lite05Wip)` in their [`Versions`] explicitly.
+/// Intentionally excludes `ALPN_LITE_05`: lite-05 is not advertised by default.
+/// Callers can opt in by including `Version::Lite(lite::Version::Lite05)` in
+/// their [`Versions`] explicitly.
 pub const ALPNS: &[&str] = &[
 	ALPN_LITE_04,
 	ALPN_LITE_03,
@@ -35,7 +35,7 @@ pub const ALPNS: &[&str] = &[
 pub(crate) const ALPN_LITE: &str = "moql";
 pub(crate) const ALPN_LITE_03: &str = "moq-lite-03";
 pub(crate) const ALPN_LITE_04: &str = "moq-lite-04";
-pub(crate) const ALPN_LITE_05_WIP: &str = "moq-lite-05-wip";
+pub(crate) const ALPN_LITE_05: &str = "moq-lite-05";
 pub(crate) const ALPN_14: &str = "moq-00";
 pub(crate) const ALPN_15: &str = "moqt-15";
 pub(crate) const ALPN_16: &str = "moqt-16";
@@ -59,7 +59,7 @@ impl Version {
 			0xff0dad02 => Some(Self::Lite(lite::Version::Lite02)),
 			0xff0dad03 => Some(Self::Lite(lite::Version::Lite03)),
 			0xff0dad04 => Some(Self::Lite(lite::Version::Lite04)),
-			0xff0dad05 => Some(Self::Lite(lite::Version::Lite05Wip)),
+			0xff0dad05 => Some(Self::Lite(lite::Version::Lite05)),
 			0xff00000e => Some(Self::Ietf(ietf::Version::Draft14)),
 			0xff00000f => Some(Self::Ietf(ietf::Version::Draft15)),
 			0xff000010 => Some(Self::Ietf(ietf::Version::Draft16)),
@@ -77,7 +77,7 @@ impl Version {
 			Self::Lite(lite::Version::Lite02) => 0xff0dad02,
 			Self::Lite(lite::Version::Lite03) => 0xff0dad03,
 			Self::Lite(lite::Version::Lite04) => 0xff0dad04,
-			Self::Lite(lite::Version::Lite05Wip) => 0xff0dad05,
+			Self::Lite(lite::Version::Lite05) => 0xff0dad05,
 			Self::Ietf(ietf::Version::Draft14) => 0xff00000e,
 			Self::Ietf(ietf::Version::Draft15) => 0xff00000f,
 			Self::Ietf(ietf::Version::Draft16) => 0xff000010,
@@ -96,7 +96,7 @@ impl Version {
 			ALPN_LITE => None, // Multiple versions share this ALPN, need SETUP negotiation
 			ALPN_LITE_03 => Some(Self::Lite(lite::Version::Lite03)),
 			ALPN_LITE_04 => Some(Self::Lite(lite::Version::Lite04)),
-			ALPN_LITE_05_WIP => Some(Self::Lite(lite::Version::Lite05Wip)),
+			ALPN_LITE_05 => Some(Self::Lite(lite::Version::Lite05)),
 			ALPN_14 => Some(Self::Ietf(ietf::Version::Draft14)),
 			ALPN_15 => Some(Self::Ietf(ietf::Version::Draft15)),
 			ALPN_16 => Some(Self::Ietf(ietf::Version::Draft16)),
@@ -110,7 +110,7 @@ impl Version {
 	/// Returns the ALPN string for this version.
 	pub fn alpn(&self) -> &'static str {
 		match self {
-			Self::Lite(lite::Version::Lite05Wip) => ALPN_LITE_05_WIP,
+			Self::Lite(lite::Version::Lite05) => ALPN_LITE_05,
 			Self::Lite(lite::Version::Lite04) => ALPN_LITE_04,
 			Self::Lite(lite::Version::Lite03) => ALPN_LITE_03,
 			Self::Lite(lite::Version::Lite01 | lite::Version::Lite02) => ALPN_LITE,
@@ -167,7 +167,7 @@ impl FromStr for Version {
 			"moq-lite-02" => Ok(Self::Lite(lite::Version::Lite02)),
 			"moq-lite-03" => Ok(Self::Lite(lite::Version::Lite03)),
 			"moq-lite-04" => Ok(Self::Lite(lite::Version::Lite04)),
-			"moq-lite-05-wip" => Ok(Self::Lite(lite::Version::Lite05Wip)),
+			"moq-lite-05" => Ok(Self::Lite(lite::Version::Lite05)),
 			"moq-transport-14" => Ok(Self::Ietf(ietf::Version::Draft14)),
 			"moq-transport-15" => Ok(Self::Ietf(ietf::Version::Draft15)),
 			"moq-transport-16" => Ok(Self::Ietf(ietf::Version::Draft16)),


### PR DESCRIPTION
## What

Follow-up to #2143. Two related changes:

1. **Codify that media presentation timestamps come from the container**, not the moq-lite-05 transport timestamp.
2. **Rename the lite-05 version** `Lite05Wip` -> `Lite05` (`DRAFT_05_WIP` -> `DRAFT_05` in JS).

## Why

Issue #2143 reports `MoqMediaConsumer` returning `timestampUs = 0`. There are now two timestamp concepts and they were easy to conflate:

- **Container PTS** — the presentation timestamp carried in the container payload (legacy varint prefix, CMAF, or LOC), decoded by the moq-mux / hang container consumers. This is the source of truth.
- **moq-lite-05 wire timestamp** — a per-frame timestamp delta added in lite-05. The publisher stamps it with the wall clock; the subscriber decodes it only to stay aligned with the wire and then discards it.

Per the issue direction: everything should use the container timestamp and treat the transport timestamp as if it does not exist (it is not load-bearing yet).

## Audit

Confirmed across both languages that every media path already reads the PTS from the container and the transport timestamp is dropped at the net layer:

- `rs/moq-net` `subscriber.rs` and `js/net` `subscriber.ts` decode-and-discard the per-frame delta; neither `moq_net::Frame` nor the JS net frame carries a timestamp field.
- `moq-mux` `container::Consumer`, `moq-audio` `AudioConsumer`, the FFI `MoqMediaConsumer`, and the JS `hang` container consumer all take the timestamp from the decoded container frame.

So no consumer behavior change was needed. The change makes the guarantee explicit in comments on both the subscriber (discard) and publisher (placeholder) sides, in `moq-net` and `js/net`.

## Rename

`Lite05Wip` -> `Lite05`, `DRAFT_05_WIP` -> `DRAFT_05`, `ALPN_LITE_05_WIP`/`ALPN_05_WIP` -> `ALPN_LITE_05`/`ALPN_05`, and the wire string `moq-lite-05-wip` -> `moq-lite-05`. lite-05 stays out of `ALPNS`, `NEGOTIATED`, and `Versions::all()`, so it is still unadvertised and opt-in only. The `0xff0dad05` wire code is unchanged.

## Not in this PR

Plumbing the real PTS into the moq-lite-05 wire timestamp (so it matches the container instead of the wall clock) requires adding a timestamp to the `moq_net::Frame` API and lands separately on `dev`.

## Cross-package sync

`rs/moq-net` wire/API paired with `js/net` (both updated). No `doc/` pages referenced the old `moq-lite-05-wip` name.

## Testing

- `cargo build -p moq-net -p moq-native`, `cargo test -p moq-net --lib` (378 pass), `cargo fmt --check`, `cargo clippy -p moq-net` clean.
- `@moq/net` `tsc` typecheck, `bun test` (159 pass), `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)

---
_Generated by [Claude Code](https://claude.ai/code/session_018yUuPA47saK7xdiWnoftCv)_