### PR TITLE
feat(moq-video): NVDEC hardware decode, zero-copy NVDEC -> NVENC transcode

### DIFF
--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -26,7 +26,7 @@ Layered roughly transport -> container/format -> media -> apps/bindings.
 
 - `moq-mux` (lib): the conversion layer. File/stream formats (`container/`: fmp4, flv, mkv, ts, loc) and codec parsers (`codec/`: h264, h265, av1, vp8/9, opus, aac, ...) <-> hang broadcasts. `Container` trait + generic `Producer<C>`/`Consumer<C>`. Dual catalog (`catalog::hang`, `catalog::msf`).
 - `moq-audio` (lib): native PCM <-> Opus (`unsafe-libopus`). `AudioProducer`/`AudioConsumer`, `Encoder`/`Decoder`, `AudioFormat`. Optional `capture` feature (cpal microphone), `resample`.
-- `moq-video` (lib): native video capture, H.264/H.265 encode, and decode; no ffmpeg. Hardware backends (VideoToolbox / Media Foundation / NVENC / VAAPI) with openh264 as the software H.264 fallback. `capture::Config`, `encode::{Encoder, Producer, publish_capture}`, `decode::{Consumer, Decoder}`.
+- `moq-video` (lib): native video capture, H.264/H.265 encode, and decode; no ffmpeg. Hardware backends (VideoToolbox / Media Foundation / NVENC / VAAPI / NVDEC) with openh264 as the software H.264 fallback; NVDEC frames stay in CUDA memory and feed NVENC zero-copy. `capture::Config`, `encode::{Encoder, Producer, publish_capture}`, `decode::{Consumer, Decoder}`.
 - `moq-transcode` (lib): just-in-time live transcoding of hang broadcasts. `run(source, output, config)` publishes a derivative catalog (ladder rungs + relative refs to the source) and encodes each rung only while subscribed/fetched, via `moq-video`. Output groups mirror source group sequences 1:1.
 
 **Apps / binaries**

--- a/rs/libmoq/Cargo.toml
+++ b/rs/libmoq/Cargo.toml
@@ -24,8 +24,8 @@ moq-audio = { workspace = true }
 moq-mux = { workspace = true }
 moq-native = { workspace = true, default-features = true }
 moq-net = { workspace = true }
-# Enable the NVENC / VAAPI hardware encoders (default-off at the workspace level).
-moq-video = { workspace = true, features = ["nvenc", "vaapi"] }
+# Enable the NVENC / VAAPI / NVDEC hardware codecs (default-off at the workspace level).
+moq-video = { workspace = true, features = ["nvenc", "vaapi", "nvdec"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { workspace = true, features = ["macros"] }

--- a/rs/libmoq/src/video.rs
+++ b/rs/libmoq/src/video.rs
@@ -57,7 +57,17 @@ pub struct moq_video_frame {
 #[derive(Default)]
 pub struct Video {
 	consumer_tasks: NonZeroSlab<Option<VideoTaskEntry>>,
-	frames: NonZeroSlab<moq_video::decode::Frame>,
+	frames: NonZeroSlab<VideoFrame>,
+}
+
+/// A delivered frame, flattened to CPU I420 at delivery time: the C ABI hands
+/// out a stable byte pointer, so a GPU-decoded frame (e.g. NVDEC) is downloaded
+/// exactly once here.
+struct VideoFrame {
+	timestamp_us: u64,
+	width: u32,
+	height: u32,
+	data: bytes::Bytes,
 }
 
 /// A spawned task entry: `close` signals shutdown, `callback` delivers status.
@@ -127,7 +137,14 @@ impl Video {
 				},
 			};
 
-			// Hold the lock only to buffer the frame; release it before the callback.
+			// Flatten to CPU bytes outside the lock (a GPU frame downloads here),
+			// then hold the lock only to buffer it; release before the callback.
+			let frame = VideoFrame {
+				timestamp_us: frame.timestamp_us,
+				width: frame.width,
+				height: frame.height,
+				data: frame.into_i420()?,
+			};
 			let frame_id = State::lock().video.frames.insert(frame)?;
 			callback.call(Ok(frame_id));
 		}

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -18,7 +18,7 @@ name = "moq"
 path = "src/main.rs"
 
 [features]
-default = ["iroh", "noq", "websocket", "nvenc", "vaapi"]
+default = ["iroh", "noq", "websocket", "nvenc", "vaapi", "nvdec"]
 iroh = ["moq-native/iroh"]
 noq = ["moq-native/noq"]
 quinn = ["moq-native/quinn"]
@@ -31,12 +31,13 @@ websocket = ["moq-native/websocket"]
 # extra install. H.264 is vendored static (openh264), so no system ffmpeg/libav.
 # Enable with `cargo build -p moq-cli --features capture`.
 capture = ["dep:moq-video", "dep:moq-audio", "moq-audio/capture"]
-# NVENC / VAAPI hardware encoders for `capture` (Linux), on by default. Each just
-# turns on the matching moq-video feature, and only bites when `capture` pulls in
-# moq-video. For a `capture` build with no CUDA / libva system deps, drop them, e.g.
+# NVENC / VAAPI / NVDEC hardware codecs for `capture` (Linux), on by default. Each
+# just turns on the matching moq-video feature, and only bites when `capture` pulls
+# in moq-video. For a `capture` build with no CUDA / libva system deps, drop them, e.g.
 #   cargo build -p moq-cli --no-default-features --features "iroh noq websocket capture"
 nvenc = ["moq-video?/nvenc"]
 vaapi = ["moq-video?/vaapi"]
+nvdec = ["moq-video?/nvdec"]
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }

--- a/rs/moq-nvenc/README.md
+++ b/rs/moq-nvenc/README.md
@@ -1,12 +1,13 @@
 # moq-nvenc
 
-Safe-ish Rust bindings for the NVIDIA Video Codec SDK (NVENC), vendored for the
-MoQ workspace. `moq-video` uses the encoder path to hardware-encode H.264/H.265
-on Linux.
+Safe-ish Rust bindings for the NVIDIA Video Codec SDK (NVENC + NVDEC), vendored
+for the MoQ workspace. `moq-video` uses the encoder path to hardware-encode
+H.264/H.265 on Linux, and the `cuvid` table to hardware-decode via NVDEC.
 
 This is a fork of [`nvidia-video-codec-sdk`](https://github.com/ViliamVadocz/nvidia-video-codec-sdk)
-(MIT, Copyright Viliam Vadocz), trimmed to a single mode: it always dlopens
-`libnvidia-encode` at runtime rather than linking it. So a binary built without
+(MIT, Copyright Viliam Vadocz), trimmed to a single mode: it always dlopens the
+driver libraries at runtime (`libnvidia-encode` for NVENC, `libnvcuvid` for
+NVDEC) rather than linking them. So a binary built without
 the NVIDIA driver still links on a GPU-less builder and starts on machines that
 lack the driver (falling back to another encoder); the build needs no CUDA
 toolkit or driver libs present.

--- a/rs/moq-nvenc/src/cuvid.rs
+++ b/rs/moq-nvenc/src/cuvid.rs
@@ -90,8 +90,10 @@ impl Api {
 			// SAFETY: each symbol is resolved by the exact name and signature the
 			// vendored `sys` bindings declare for it.
 			unsafe fn sym<T: Copy>(library: &'static libloading::Library, name: &str) -> Result<T, String> {
-				let symbol: libloading::Symbol<T> = unsafe { library.get(name.as_bytes()) }
-					.map_err(|e| format!("symbol {name} missing from the NVIDIA decode library: {e}"))?;
+				let symbol: libloading::Symbol<T> = unsafe { library.get(name.as_bytes()) }.map_err(|e| {
+					let name = name.trim_end_matches('\0');
+					format!("symbol {name} missing from the NVIDIA decode library: {e}")
+				})?;
 				Ok(*symbol)
 			}
 

--- a/rs/moq-nvenc/src/cuvid.rs
+++ b/rs/moq-nvenc/src/cuvid.rs
@@ -1,0 +1,111 @@
+//! Dynamically-loaded NVDEC (CUVID) entry points.
+//!
+//! The decoder API lives in `libnvcuvid` (part of the NVIDIA driver), a separate
+//! library from the encoder's `libnvidia-encode`. The raw bindings in
+//! [`sys`](crate::sys) declare the functions in an `extern "C"` block, but
+//! calling those directly would make the *linker* require `libnvcuvid`, which a
+//! GPU-less build machine doesn't have. So, like the encode side, everything is
+//! resolved at runtime with dlopen. Unlike the encode side's lazy static (which
+//! panics when the driver is absent), [`Api::get`] returns an error so callers
+//! can fall back to another decoder.
+
+use core::ffi::{c_int, c_uint, c_ulonglong};
+use std::sync::OnceLock;
+
+use cudarc::driver::sys::CUresult;
+
+use crate::sys::cuviddec::{CUvideodecoder, CUVIDDECODECAPS, CUVIDDECODECREATEINFO, CUVIDPICPARAMS, CUVIDPROCPARAMS};
+use crate::sys::nvcuvid::{CUvideoparser, CUVIDPARSERPARAMS, CUVIDSOURCEDATAPACKET};
+
+// Function type aliases matching the declarations in `sys`.
+type CreateVideoParser = unsafe extern "C" fn(*mut CUvideoparser, *mut CUVIDPARSERPARAMS) -> CUresult;
+type ParseVideoData = unsafe extern "C" fn(CUvideoparser, *mut CUVIDSOURCEDATAPACKET) -> CUresult;
+type DestroyVideoParser = unsafe extern "C" fn(CUvideoparser) -> CUresult;
+type GetDecoderCaps = unsafe extern "C" fn(*mut CUVIDDECODECAPS) -> CUresult;
+type CreateDecoder = unsafe extern "C" fn(*mut CUvideodecoder, *mut CUVIDDECODECREATEINFO) -> CUresult;
+type DestroyDecoder = unsafe extern "C" fn(CUvideodecoder) -> CUresult;
+type DecodePicture = unsafe extern "C" fn(CUvideodecoder, *mut CUVIDPICPARAMS) -> CUresult;
+type MapVideoFrame64 =
+	unsafe extern "C" fn(CUvideodecoder, c_int, *mut c_ulonglong, *mut c_uint, *mut CUVIDPROCPARAMS) -> CUresult;
+type UnmapVideoFrame64 = unsafe extern "C" fn(CUvideodecoder, c_ulonglong) -> CUresult;
+
+/// The NVDEC entry points, resolved from `libnvcuvid` at runtime.
+///
+/// A caller drives the usual CUVID flow: create a parser
+/// ([`create_video_parser`](Self::create_video_parser)), feed it bitstream
+/// packets, and inside the parser callbacks create a decoder, decode pictures,
+/// and map/unmap the decoded frames. All calls require a current CUDA context.
+#[allow(missing_debug_implementations)]
+pub struct Api {
+	#[doc(alias = "cuvidCreateVideoParser")]
+	pub create_video_parser: CreateVideoParser,
+	#[doc(alias = "cuvidParseVideoData")]
+	pub parse_video_data: ParseVideoData,
+	#[doc(alias = "cuvidDestroyVideoParser")]
+	pub destroy_video_parser: DestroyVideoParser,
+	#[doc(alias = "cuvidGetDecoderCaps")]
+	pub get_decoder_caps: GetDecoderCaps,
+	#[doc(alias = "cuvidCreateDecoder")]
+	pub create_decoder: CreateDecoder,
+	#[doc(alias = "cuvidDestroyDecoder")]
+	pub destroy_decoder: DestroyDecoder,
+	#[doc(alias = "cuvidDecodePicture")]
+	pub decode_picture: DecodePicture,
+	#[doc(alias = "cuvidMapVideoFrame64")]
+	pub map_video_frame: MapVideoFrame64,
+	#[doc(alias = "cuvidUnmapVideoFrame64")]
+	pub unmap_video_frame: UnmapVideoFrame64,
+}
+
+impl Api {
+	/// The dlopen'd NVDEC API, or an error when `libnvcuvid` (or one of its
+	/// symbols) is unavailable, i.e. the NVIDIA driver is not installed.
+	pub fn get() -> Result<&'static Api, &'static str> {
+		static API: OnceLock<Result<Api, String>> = OnceLock::new();
+		API.get_or_init(Api::load).as_ref().map_err(|e| e.as_str())
+	}
+
+	fn load() -> Result<Api, String> {
+		// `.so.1` is the versioned SONAME present at runtime; `.so` is the dev
+		// symlink. Windows ships the DLL with the NVIDIA driver.
+		#[cfg(target_os = "linux")]
+		const CANDIDATES: &[&str] = &["libnvcuvid.so.1", "libnvcuvid.so"];
+		#[cfg(target_os = "windows")]
+		const CANDIDATES: &[&str] = &["nvcuvid.dll"];
+		// No NVDEC library exists on other platforms (e.g. macOS); loading
+		// always fails there with a clear error.
+		#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+		const CANDIDATES: &[&str] = &[];
+
+		// SAFETY: loading the NVIDIA driver library runs its initializers, which
+		// is sound for driver libs. The handle is leaked so the resolved function
+		// pointers stay valid for the process lifetime.
+		unsafe {
+			let library = CANDIDATES
+				.iter()
+				.find_map(|name| libloading::Library::new(*name).ok())
+				.ok_or_else(|| format!("failed to dlopen the NVIDIA decode library (tried {CANDIDATES:?})"))?;
+			let library: &'static libloading::Library = Box::leak(Box::new(library));
+
+			// SAFETY: each symbol is resolved by the exact name and signature the
+			// vendored `sys` bindings declare for it.
+			unsafe fn sym<T: Copy>(library: &'static libloading::Library, name: &str) -> Result<T, String> {
+				let symbol: libloading::Symbol<T> = unsafe { library.get(name.as_bytes()) }
+					.map_err(|e| format!("symbol {name} missing from the NVIDIA decode library: {e}"))?;
+				Ok(*symbol)
+			}
+
+			Ok(Api {
+				create_video_parser: sym(library, "cuvidCreateVideoParser\0")?,
+				parse_video_data: sym(library, "cuvidParseVideoData\0")?,
+				destroy_video_parser: sym(library, "cuvidDestroyVideoParser\0")?,
+				get_decoder_caps: sym(library, "cuvidGetDecoderCaps\0")?,
+				create_decoder: sym(library, "cuvidCreateDecoder\0")?,
+				destroy_decoder: sym(library, "cuvidDestroyDecoder\0")?,
+				decode_picture: sym(library, "cuvidDecodePicture\0")?,
+				map_video_frame: sym(library, "cuvidMapVideoFrame64\0")?,
+				unmap_video_frame: sym(library, "cuvidUnmapVideoFrame64\0")?,
+			})
+		}
+	}
+}

--- a/rs/moq-nvenc/src/lib.rs
+++ b/rs/moq-nvenc/src/lib.rs
@@ -24,13 +24,15 @@
 //!
 //! # Decoding
 //!
-//! There is no safe wrapper yet.
+//! [`cuvid`] exposes the NVDEC (CUVID) entry points as a dlopen'd function
+//! table; there is no higher-level safe wrapper yet.
 
 // Vendored third-party bindings: keep the workspace's `clippy -D warnings` and
 // `rustdoc -D warnings` from churning upstream code (broken intra-doc links, the
 // strict clippy lints the crate opted into, etc.).
 #![allow(clippy::all, clippy::pedantic, rustdoc::all)]
 
+pub mod cuvid;
 pub mod safe;
 pub mod sys;
 

--- a/rs/moq-transcode/CHANGELOG.md
+++ b/rs/moq-transcode/CHANGELOG.md
@@ -15,4 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and encodes each rung only while it is subscribed or fetched. Output groups
   mirror source group sequence numbers, so specific-group fetches map 1:1 to
   source groups. Encoding via `moq-video` (NVENC/VideoToolbox/Media Foundation
-  hardware, openh264 fallback) with CPU I420 scaling.
+  hardware, openh264 fallback). On an NVIDIA GPU the pipeline is zero-copy:
+  NVDEC decodes and scales in hardware and NVENC encodes the CUDA frame in
+  place; other decoders scale I420 on the CPU.

--- a/rs/moq-transcode/Cargo.toml
+++ b/rs/moq-transcode/Cargo.toml
@@ -16,18 +16,22 @@ categories = ["multimedia", "multimedia::video", "multimedia::encoding"]
 doctest = false
 
 [features]
-# Hardware encoders on by default, mirroring moq-video: NVENC is the whole point
-# of a GPU transcode fleet. Disable for a slimmer self-compiled Linux build.
-default = ["nvenc", "vaapi"]
+# Hardware codecs on by default, mirroring moq-video: NVDEC -> NVENC is the whole
+# point of a GPU transcode fleet. Disable for a slimmer self-compiled Linux build.
+default = ["nvenc", "vaapi", "nvdec"]
 # NVIDIA NVENC hardware encoder (Linux, dlopen'd at runtime; a no-op elsewhere).
 nvenc = ["moq-video/nvenc"]
 # Intel/AMD VAAPI hardware encoder (Linux; links libva at build time).
 vaapi = ["moq-video/vaapi"]
+# NVIDIA NVDEC hardware decoder (Linux, dlopen'd at runtime; a no-op elsewhere).
+# With `nvenc` this is the zero-copy GPU pipeline: NVDEC decodes and scales in
+# hardware, and NVENC encodes the CUDA frame in place.
+nvdec = ["moq-video/nvdec"]
 
 [dependencies]
 bytes = "1"
-# CPU I420 scaling between decode and re-encode (SIMD per-plane resize). The
-# GPU-resident scale (CUDA/NPP) is a follow-up tracked in #1837.
+# CPU I420 scaling between decode and re-encode (SIMD per-plane resize), for
+# decoders without a built-in scaler; NVDEC scales in hardware instead.
 fast_image_resize = "5"
 hang = { workspace = true }
 moq-mux = { workspace = true }

--- a/rs/moq-transcode/README.md
+++ b/rs/moq-transcode/README.md
@@ -17,11 +17,11 @@ Nothing is encoded until someone asks, Cloudflare-style just-in-time per rung:
   sequence numbers 1:1, so group N of every rung is the same content as source
   group N and rendition switches land cleanly.
 
-The codec work is [`moq-video`](../moq-video): hardware where available (NVENC
-on Linux, VideoToolbox on macOS, Media Foundation on Windows), openh264 as the
-H.264 software fallback. Scaling runs on the CPU; the GPU-resident
-NVDEC -> scale -> NVENC pipeline is tracked in
-[#1837](https://github.com/moq-dev/moq/issues/1837).
+The codec work is [`moq-video`](../moq-video): hardware where available (NVDEC +
+NVENC on Linux, VideoToolbox on macOS, Media Foundation on Windows), openh264 as
+the H.264 software fallback. On an NVIDIA GPU the pipeline is fully GPU-resident:
+NVDEC decodes and scales in hardware and NVENC encodes the CUDA frame in place,
+with no CPU copies. Other decoders fall back to CPU scaling.
 
 ## Library
 

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -13,10 +13,11 @@
 //!   transcodes just that group. Output groups mirror source sequence numbers
 //!   1:1, so group N of every rung is the same content as source group N.
 //!
-//! The codec work is `moq-video`: hardware where available (NVENC on Linux,
-//! VideoToolbox on macOS, Media Foundation on Windows) with openh264 as the
-//! H.264 software fallback. Scaling runs on the CPU; the GPU-resident
-//! NVDEC -> scale -> NVENC pipeline is tracked in moq-dev/moq#1837.
+//! The codec work is `moq-video`: hardware where available (NVDEC + NVENC on
+//! Linux, VideoToolbox on macOS, Media Foundation on Windows) with openh264 as
+//! the H.264 software fallback. On an NVIDIA GPU the whole pipeline is
+//! GPU-resident: NVDEC decodes and scales in hardware and NVENC encodes the
+//! CUDA frame in place, with no CPU copies. Other decoders scale on the CPU.
 
 mod catalog;
 mod config;
@@ -198,6 +199,72 @@ mod tests {
 			_catalog: catalog,
 			_track: track,
 		}
+	}
+
+	/// Whether a hardware decoder AND encoder are usable here (e.g. a Linux box
+	/// with the NVIDIA driver). Probed through the public API so the hardware
+	/// test skips cleanly on GPU-less CI.
+	fn hardware_available() -> bool {
+		let mut encode = moq_video::encode::Config::new(160, 120, 30);
+		encode.kind = moq_video::encode::Kind::Hardware;
+		if moq_video::encode::Encoder::new(&encode).is_err() {
+			return false;
+		}
+
+		let video = hang::catalog::VideoConfig::new(hang::catalog::H264 {
+			inline: true,
+			profile: 0x42,
+			constraints: 0,
+			level: 30,
+		});
+		let mut decode = moq_video::decode::Config::new();
+		decode.kind = moq_video::decode::Kind::Hardware;
+		moq_video::decode::Decoder::new(&video, &decode).is_ok()
+	}
+
+	/// The GPU pipeline end to end: hardware decode (NVDEC, scaling in the
+	/// decoder) into hardware encode (NVENC, consuming the CUDA frame in place).
+	/// Skips on machines without both; on a Linux + NVIDIA box this is the
+	/// zero-copy transcode path under the real broadcast plumbing.
+	#[tokio::test]
+	async fn end_to_end_hardware() {
+		if !hardware_available() {
+			eprintln!("skipping: no hardware decoder + encoder available");
+			return;
+		}
+
+		let source = source_broadcast(2, 5);
+		let config = Config {
+			rungs: vec![Rung::new(120, 100_000)],
+			encoder: moq_video::encode::Kind::Hardware,
+			decoder: moq_video::decode::Kind::Hardware,
+			source: None,
+		};
+
+		let output = moq_net::broadcast::Info::default().produce();
+		let consumer = output.consume();
+		let transcoder = tokio::spawn(run(source.broadcast.consume(), output, config));
+
+		// Fetch a specific group: runs a one-shot pipeline to completion, so all
+		// 5 source frames must come through the GPU path.
+		let track = loop {
+			match consumer.track("video/120p") {
+				Ok(track) => break track,
+				Err(moq_net::Error::NotFound) => tokio::task::yield_now().await,
+				Err(err) => panic!("rung track: {err}"),
+			}
+		};
+		let mut fetched = track.fetch_group(0, None).await.unwrap();
+		let payload = fetched.read_frame().await.unwrap().unwrap();
+		let frame = hang::container::Frame::decode(payload).unwrap();
+		assert!(
+			frame.payload.starts_with(&[0, 0, 0, 1]) || frame.payload.starts_with(&[0, 0, 1]),
+			"hardware rung output is not Annex-B"
+		);
+		let total = fetched.finished().await.unwrap();
+		assert_eq!(total, 5, "hardware transcode dropped frames");
+
+		transcoder.abort();
 	}
 
 	#[tokio::test]

--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -309,6 +309,12 @@ fn write(output: &mut moq_net::group::Producer, packets: Vec<(u64, Bytes)>) -> R
 }
 
 /// Decode -> scale -> encode for one rung.
+///
+/// The decoder is asked to emit frames at the rung's resolution
+/// (`decode::Config::resize`). A decoder with a hardware scaler (NVDEC) does,
+/// and its GPU frames feed the encoder in place: the NVDEC -> NVENC path never
+/// touches the CPU. Frames that come back at any other size (software decode,
+/// or a hardware decoder without a scaler) fall back to the CPU [`Scaler`].
 struct Pipeline {
 	decoder: moq_video::decode::Decoder,
 	scaler: Scaler,
@@ -319,7 +325,10 @@ struct Pipeline {
 
 impl Pipeline {
 	fn new(rung: &Rung) -> Result<Self, Error> {
-		let decoder = moq_video::decode::Decoder::new(&rung.config, &rung.decoder)?;
+		let mut decode = moq_video::decode::Config::new();
+		decode.kind = rung.decoder.clone();
+		decode.resize = Some((rung.info.width, rung.info.height));
+		let decoder = moq_video::decode::Decoder::new(&rung.config, &decode)?;
 
 		let mut config = moq_video::encode::Config::new(rung.info.width, rung.info.height, rung.info.framerate);
 		config.bitrate = Some(rung.info.bitrate);
@@ -343,9 +352,18 @@ impl Pipeline {
 	fn process(&mut self, payload: &Bytes, timestamp: u64, keyframe: bool) -> Result<Vec<(u64, Bytes)>, Error> {
 		let mut packets = Vec::new();
 		for raw in self.decoder.decode(payload, timestamp, keyframe)? {
-			let scaled = self.scaler.scale(&raw.data, raw.width, raw.height)?;
-			for packet in self.encoder.encode_i420(scaled, self.width, self.height, keyframe)? {
-				packets.push((raw.timestamp_us, packet));
+			let raw_timestamp = raw.timestamp_us;
+			let encoded = if (raw.width, raw.height) == (self.width, self.height) {
+				// Already at the rung size (the decoder scaled): feed the frame
+				// through as-is, keeping a GPU frame on the GPU.
+				self.encoder.encode(&raw, keyframe)?
+			} else {
+				let (width, height) = (raw.width, raw.height);
+				let scaled = self.scaler.scale(&raw.into_i420()?, width, height)?;
+				self.encoder.encode_i420(scaled, self.width, self.height, keyframe)?
+			};
+			for packet in encoded {
+				packets.push((raw_timestamp, packet));
 			}
 		}
 		Ok(packets)

--- a/rs/moq-transcode/src/scale.rs
+++ b/rs/moq-transcode/src/scale.rs
@@ -7,9 +7,10 @@ use crate::Error;
 
 /// Scales tightly-packed I420 frames to a fixed output resolution.
 ///
-/// Per-plane SIMD resize: Y at full size, U/V at quarter size. This is the CPU
-/// stage of the pipeline; the GPU-resident scale (CUDA/NPP) is tracked in
-/// moq-dev/moq#1837.
+/// Per-plane SIMD resize: Y at full size, U/V at quarter size. The fallback for
+/// decoders without a built-in scaler (openh264, VideoToolbox, Media
+/// Foundation); NVDEC scales on the GPU during decode instead, so its frames
+/// never come through here.
 pub(crate) struct Scaler {
 	resizer: Resizer,
 	options: ResizeOptions,

--- a/rs/moq-video/CHANGELOG.md
+++ b/rs/moq-video/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- H.264 / H.265 hardware decode on Linux via NVIDIA NVDEC, behind the
+  default-on `nvdec` feature. Decoded frames stay in CUDA device memory and
+  feed the NVENC encoder zero-copy through the new
+  `encode::Encoder::encode(frame)` entry point; `decode::Config::resize` scales
+  in the decoder for free. Like NVENC, everything is dlopen'd at runtime, so a
+  driverless host falls back to the next decoder.
+- `decode::Frame` pixels are now private: `into_i420()` returns the packed
+  I420 bytes (downloading a GPU frame), replacing the public `data` field, and
+  each frame's `timestamp_us` now rides the decoder (correct across reordering)
+  instead of echoing the input.
+- `decode::Decoder::new` takes the full `decode::Config` instead of just the
+  `Kind`, so decoder knobs (like `resize`) stay additive.
+
 - `decode::Decoder` is public: the payload-in, frames-out layer under
   `decode::Consumer`, for callers that don't read from a plain track
   subscription (e.g. a transcoder decoding individually fetched groups).

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -16,16 +16,21 @@ categories = ["multimedia", "multimedia::video", "multimedia::encoding"]
 doctest = false
 
 [features]
-# Hardware encoders are enabled by default. Disable them (e.g. `--no-default-features`)
+# Hardware codecs are enabled by default. Disable them (e.g. `--no-default-features`)
 # for a slimmer self-compiled Linux build that drops the CUDA / libva deps: openh264
-# stays as the always-compiled software fallback and V4L2 capture is unaffected. Both
-# features are no-ops off Linux (their deps are Linux-only).
-default = ["nvenc", "vaapi"]
+# stays as the always-compiled software fallback and V4L2 capture is unaffected. All
+# three features are no-ops off Linux (their deps are Linux-only).
+default = ["nvenc", "vaapi", "nvdec"]
 # NVIDIA NVENC hardware encoder (Linux). dlopen'd at runtime (cudarc + moq-nvenc,
 # which loads libnvidia-encode), with a libloading probe for the driver libs, so
 # an nvenc build still links GPU-less and starts driverless, falling back to the
 # next encoder.
 nvenc = ["dep:cudarc", "dep:moq-nvenc", "dep:libloading"]
+# NVIDIA NVDEC hardware decoder (Linux). Same runtime story as `nvenc`: cudarc
+# loads libcuda and moq-nvenc's cuvid table loads libnvcuvid, so an nvdec build
+# links GPU-less and starts driverless, falling back to the next decoder. Decoded
+# frames stay in CUDA memory and feed NVENC zero-copy (the transcode path).
+nvdec = ["dep:cudarc", "dep:moq-nvenc", "dep:libloading"]
 # Intel/AMD VAAPI hardware encoder (Linux). moq-vaapi 0.0.2 hard-links libva (the
 # binary carries NEEDED libva.so.2 / libva-drm.so.2), so disable this feature for a
 # build with no libva dependency. See #1837.

--- a/rs/moq-video/src/decode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/decode/backend/mediafoundation.rs
@@ -41,10 +41,10 @@ use windows::Win32::Media::MediaFoundation::{
 };
 use windows::core::{GUID, Interface};
 
-use super::{Backend, Codec};
+use super::{Backend, Codec, Config, Decoded};
 use crate::Error;
-use crate::frame::I420;
 use crate::frame::d3d11::Texture;
+use crate::frame::{Frame, I420};
 use crate::mf::{ComGuard, create_d3d_device, mf_err, unpack_2x32};
 
 pub(crate) const NAME: &str = "mediafoundation";
@@ -87,7 +87,9 @@ pub(crate) struct MediaFoundation {
 unsafe impl Send for MediaFoundation {}
 
 impl MediaFoundation {
-	pub(crate) fn open(codec: Codec) -> Result<Box<dyn Backend>, Error> {
+	/// `config` is accepted for signature parity; the decoder MFT emits frames
+	/// at the stream's native size (callers scale the frames themselves).
+	pub(crate) fn open(codec: Codec, _config: &Config) -> Result<Box<dyn Backend>, Error> {
 		let (input_subtype, label) = match codec {
 			Codec::H264 => (MFVideoFormat_H264, "H.264"),
 			Codec::H265 => (MFVideoFormat_HEVC, "H.265"),
@@ -351,7 +353,7 @@ impl MediaFoundation {
 }
 
 impl Backend for MediaFoundation {
-	fn decode(&mut self, access_unit: Bytes, _keyframe: bool) -> Result<Vec<I420>, Error> {
+	fn decode(&mut self, access_unit: Bytes, timestamp_us: u64, _keyframe: bool) -> Result<Vec<Decoded>, Error> {
 		let mut out = Vec::new();
 
 		let sample = self.build_sample(&access_unit)?;
@@ -376,7 +378,15 @@ impl Backend for MediaFoundation {
 		}
 
 		self.drain_output(&mut out)?;
-		Ok(out)
+		// The synchronous MFT drains within the call, so every output frame
+		// belongs to the access unit just submitted.
+		Ok(out
+			.into_iter()
+			.map(|i420| Decoded {
+				timestamp_us,
+				frame: Frame::I420(i420),
+			})
+			.collect())
 	}
 
 	fn name(&self) -> &str {

--- a/rs/moq-video/src/decode/backend/mod.rs
+++ b/rs/moq-video/src/decode/backend/mod.rs
@@ -7,18 +7,18 @@
 //! keyframe: SPS/PPS for H.264, VPS/SPS/PPS for H.265) and returns zero or more
 //! decoded [`I420`] frames.
 //!
-//! [`open`] picks the best backend for a ([`Codec`], [`Kind`](super::Kind)) pair,
-//! trying hardware candidates (platform-gated: VideoToolbox on macOS, Media
-//! Foundation / DXVA on Windows) before the openh264 software fallback, exactly
-//! like the encode side. Only backends that support the requested codec are
-//! considered: there is no software H.265 decoder, so an H.265 track has no
+//! [`open`] picks the best backend for a [`Codec`] and [`Config`], trying
+//! hardware candidates (platform-gated: VideoToolbox on macOS, Media Foundation
+//! / DXVA on Windows, NVDEC on Linux) before the openh264 software fallback,
+//! exactly like the encode side. Only backends that support the requested codec
+//! are considered: there is no software H.265 decoder, so an H.265 track has no
 //! fallback below the hardware path.
 
 use bytes::Bytes;
 
-use super::decoder::Kind;
+use super::decoder::{Config, Kind};
 use crate::Error;
-use crate::frame::I420;
+use crate::frame::Frame;
 
 mod openh264;
 
@@ -27,6 +27,9 @@ mod videotoolbox;
 
 #[cfg(target_os = "windows")]
 mod mediafoundation;
+
+#[cfg(all(target_os = "linux", feature = "nvdec"))]
+mod nvdec;
 
 /// The video codec a decoder handles. Derived from the catalog, not chosen by the
 /// caller.
@@ -45,24 +48,39 @@ impl Codec {
 	}
 }
 
+/// One decoded picture: the raw frame plus its presentation timestamp.
+pub(crate) struct Decoded {
+	/// Presentation timestamp in microseconds. Backends that decode one-in
+	/// one-out echo the input timestamp; NVDEC threads timestamps through its
+	/// parser, so they survive decoder delay and frame reordering.
+	pub timestamp_us: u64,
+	/// The decoded picture: CPU I420, or a GPU frame the encode side can consume
+	/// without a CPU round trip.
+	pub frame: Frame,
+}
+
 /// An opened decoder. Feed it Annex-B access units in decode order; get back zero
-/// or more raw I420 frames (zero while the decoder is still buffering, e.g. before
+/// or more decoded frames (zero while the decoder is still buffering, e.g. before
 /// the first keyframe's parameter sets).
 pub(crate) trait Backend: Send {
-	/// Decode one Annex-B access unit. `keyframe` marks a keyframe (parameter sets
-	/// are inline ahead of it). Takes an owned [`Bytes`] so a backend can split
-	/// out NAL slices without copying.
-	fn decode(&mut self, access_unit: Bytes, keyframe: bool) -> Result<Vec<I420>, Error>;
+	/// Decode one Annex-B access unit stamped with its presentation time in
+	/// microseconds. `keyframe` marks a keyframe (parameter sets are inline ahead
+	/// of it). Takes an owned [`Bytes`] so a backend can split out NAL slices
+	/// without copying.
+	fn decode(&mut self, access_unit: Bytes, timestamp_us: u64, keyframe: bool) -> Result<Vec<Decoded>, Error>;
 
 	/// The decoder name in use, e.g. `"videotoolbox"` (for logging).
 	fn name(&self) -> &str;
 }
 
+/// A backend opener: builds a decoder for a codec and config.
+type Open = fn(Codec, &Config) -> Result<Box<dyn Backend>, Error>;
+
 /// A backend constructor: name, the codecs it can decode, and an opener.
 struct Candidate {
 	name: &'static str,
 	supports: fn(Codec) -> bool,
-	open: fn(Codec) -> Result<Box<dyn Backend>, Error>,
+	open: Open,
 }
 
 /// Hardware backends, in priority order. Platform-gated so only the ones that
@@ -80,6 +98,12 @@ const HARDWARE: &[Candidate] = &[
 		supports: |_| true,
 		open: mediafoundation::MediaFoundation::open,
 	},
+	#[cfg(all(target_os = "linux", feature = "nvdec"))]
+	Candidate {
+		name: nvdec::NAME,
+		supports: |c| matches!(c, Codec::H264 | Codec::H265),
+		open: nvdec::Nvdec::open,
+	},
 ];
 
 const SOFTWARE: Candidate = Candidate {
@@ -88,11 +112,11 @@ const SOFTWARE: Candidate = Candidate {
 	open: openh264::Openh264::open,
 };
 
-/// Open the best decoder for `codec` and `kind`, trying candidates in priority
+/// Open the best decoder for `codec` and `config`, trying candidates in priority
 /// order and falling back until one succeeds. Candidates that don't support the
 /// codec are skipped before they're even tried.
-pub(crate) fn open(codec: Codec, kind: &Kind) -> Result<Box<dyn Backend>, Error> {
-	let candidates: Vec<&Candidate> = match kind {
+pub(crate) fn open(codec: Codec, config: &Config) -> Result<Box<dyn Backend>, Error> {
+	let candidates: Vec<&Candidate> = match &config.kind {
 		Kind::Auto => HARDWARE.iter().chain(std::iter::once(&SOFTWARE)).collect(),
 		Kind::Hardware => HARDWARE.iter().collect(),
 		Kind::Software => vec![&SOFTWARE],
@@ -108,7 +132,7 @@ pub(crate) fn open(codec: Codec, kind: &Kind) -> Result<Box<dyn Backend>, Error>
 			continue;
 		}
 		tried.push(candidate.name);
-		match (candidate.open)(codec) {
+		match (candidate.open)(codec, config) {
 			Ok(backend) => return Ok(backend),
 			Err(e) => tracing::debug!(decoder = candidate.name, error = %e, "decoder unavailable, trying next"),
 		}

--- a/rs/moq-video/src/decode/backend/mod.rs
+++ b/rs/moq-video/src/decode/backend/mod.rs
@@ -5,7 +5,7 @@
 //! gating, owned by [`Decoder`](super::Decoder)) and the codec itself. Every
 //! backend takes one **Annex-B** access unit (parameter sets inline ahead of each
 //! keyframe: SPS/PPS for H.264, VPS/SPS/PPS for H.265) and returns zero or more
-//! decoded [`I420`] frames.
+//! [`Decoded`] pictures (a raw CPU or GPU frame plus its timestamp).
 //!
 //! [`open`] picks the best backend for a [`Codec`] and [`Config`], trying
 //! hardware candidates (platform-gated: VideoToolbox on macOS, Media Foundation

--- a/rs/moq-video/src/decode/backend/nvdec.rs
+++ b/rs/moq-video/src/decode/backend/nvdec.rs
@@ -1,0 +1,682 @@
+//! Hardware H.264 / H.265 decode via NVIDIA NVDEC (`moq-nvenc`'s cuvid table).
+//!
+//! Linux only, behind the default-on `nvdec` feature. Everything is dlopen'd at
+//! runtime (cudarc loads libcuda, the cuvid table loads libnvcuvid), so the
+//! binary links on a GPU-less builder and a driverless host falls back to the
+//! next decoder (see [`backend::open`](super::open)).
+//!
+//! Decoded frames come back as NV12 in CUDA device memory ([`Frame::Cuda`]).
+//! Each mapped cuvid surface is copied device-to-device into an owned buffer
+//! (surfaces come from a small fixed pool, so holding them across calls would
+//! stall the decoder), which the NVENC encode backend then registers directly:
+//! the decode -> scale -> encode transcode path never touches the CPU. Scaling
+//! rides the decoder itself: [`Config::resize`] maps to cuvid's target size, so
+//! the hardware emits frames already at the output resolution.
+//!
+//! The cuvid parser is driven synchronously: each access unit is pushed with
+//! `CUVID_PKT_ENDOFPICTURE` and zero display delay, so its callbacks (sequence /
+//! decode / display) all fire inside `cuvidParseVideoData` on the calling
+//! thread, and the display queue is drained before `decode` returns. Timestamps
+//! are threaded through the parser (`ulClockRate` is set to microseconds), so
+//! output frames keep correct presentation times even across reordering.
+
+use core::ffi::{c_int, c_uint, c_ulong, c_ulonglong, c_void};
+use std::ptr;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use cudarc::driver::CudaContext;
+use moq_nvenc::cuvid;
+use moq_nvenc::sys::cuviddec::{
+	CUVIDDECODECAPS, CUVIDDECODECREATEINFO, CUVIDPICPARAMS, CUVIDPROCPARAMS, CUvideodecoder, cudaVideoChromaFormat,
+	cudaVideoCodec, cudaVideoCreateFlags, cudaVideoDeinterlaceMode, cudaVideoSurfaceFormat,
+};
+use moq_nvenc::sys::nvcuvid::{
+	CUVIDEOFORMAT, CUVIDPARSERDISPINFO, CUVIDPARSERPARAMS, CUVIDSOURCEDATAPACKET, CUvideopacketflags, CUvideoparser,
+};
+
+use super::{Backend, Codec, Decoded};
+use crate::Error;
+use crate::frame::{Frame, cuda};
+
+pub(crate) const NAME: &str = "nvdec";
+
+fn codec_err(msg: String) -> Error {
+	Error::Codec(anyhow::anyhow!(msg))
+}
+
+pub(crate) struct Nvdec {
+	parser: CUvideoparser,
+	/// Boxed so its address is stable: the parser holds a raw pointer to it for
+	/// the lifetime of the parser (callbacks dereference it during parse).
+	state: Box<State>,
+}
+
+// Used from one thread at a time (the decode loop); the CUDA context is rebound
+// to the current thread on every call.
+unsafe impl Send for Nvdec {}
+
+/// State shared with the parser's C callbacks via the user-data pointer.
+struct State {
+	api: &'static cuvid::Api,
+	ctx: Arc<CudaContext>,
+	/// Requested output size; `None` decodes at the stream's display size.
+	resize: Option<(u32, u32)>,
+	decoder: Option<Decoder>,
+	/// Pictures the display callback queued, in presentation order. Drained
+	/// (mapped and copied out) after each parse call.
+	ready: Vec<CUVIDPARSERDISPINFO>,
+	/// First error hit inside a callback; callbacks can only return an int, so
+	/// the error is surfaced by `decode` after the parse call.
+	error: Option<String>,
+}
+
+/// An open cuvid decoder plus the output geometry it was created for.
+struct Decoder {
+	api: &'static cuvid::Api,
+	handle: CUvideodecoder,
+	/// The coded (not display) size it was created for, to detect reconfigures.
+	coded: (u32, u32),
+	/// Output size: cuvid scales to this while writing the output surface.
+	width: u32,
+	height: u32,
+}
+
+impl Drop for Decoder {
+	fn drop(&mut self) {
+		// SAFETY: the handle is valid and no frame is mapped (every map is
+		// paired with an unmap before decode returns). The caller keeps the CUDA
+		// context bound.
+		unsafe { (self.api.destroy_decoder)(self.handle) };
+	}
+}
+
+impl Nvdec {
+	pub(crate) fn open(codec: Codec, config: &super::Config) -> Result<Box<dyn Backend>, Error> {
+		// cudarc panics (aborting under release `panic = "abort"`) when libcuda
+		// is missing, so probe it and turn a missing driver into a recoverable
+		// error; the cuvid table already loads fallibly.
+		if !driver_libs_present() {
+			return Err(codec_err(
+				"NVIDIA driver libraries not found (libcuda); NVDEC unavailable".into(),
+			));
+		}
+		let api = cuvid::Api::get().map_err(|e| codec_err(format!("NVDEC unavailable: {e}")))?;
+
+		if let Some((w, h)) = config.resize {
+			// NV12 output: chroma is 2x2 subsampled, so the target must be even.
+			if w == 0 || h == 0 || w % 2 != 0 || h % 2 != 0 {
+				return Err(codec_err(format!("NVDEC resize {w}x{h} must be even and non-zero")));
+			}
+		}
+
+		let cuda_codec = match codec {
+			Codec::H264 => cudaVideoCodec::cudaVideoCodec_H264,
+			Codec::H265 => cudaVideoCodec::cudaVideoCodec_HEVC,
+		};
+
+		// `CudaContext::new` retains the device's primary context, the same one
+		// the NVENC backend uses, so frames pass between them without a copy.
+		let ctx = CudaContext::new(0).map_err(|e| codec_err(format!("CUDA init: {e:?}")))?;
+
+		let mut state = Box::new(State {
+			api,
+			ctx,
+			resize: config.resize,
+			decoder: None,
+			ready: Vec::new(),
+			error: None,
+		});
+
+		let mut params = CUVIDPARSERPARAMS {
+			CodecType: cuda_codec,
+			// Placeholder until the sequence callback reports the real minimum.
+			ulMaxNumDecodeSurfaces: 1,
+			// Packet timestamps are in microseconds (default is a 10 MHz clock).
+			ulClockRate: 1_000_000,
+			// Emit each picture as soon as it decodes (live path, no lookahead).
+			ulMaxDisplayDelay: 0,
+			pUserData: &mut *state as *mut State as *mut c_void,
+			pfnSequenceCallback: Some(sequence_callback),
+			pfnDecodePicture: Some(decode_callback),
+			pfnDisplayPicture: Some(display_callback),
+			..Default::default()
+		};
+
+		let mut parser: CUvideoparser = ptr::null_mut();
+		// SAFETY: params points at a fully-initialized struct and outlives the
+		// call; the user-data pointer stays valid because `state` is boxed and
+		// owned by the returned backend alongside the parser.
+		let result = unsafe { (api.create_video_parser)(&mut parser, &mut params) };
+		if result != cudarc::driver::sys::CUresult::CUDA_SUCCESS {
+			return Err(codec_err(format!("cuvidCreateVideoParser: {result:?}")));
+		}
+
+		tracing::info!(decoder = NAME, codec = ?codec, resize = ?config.resize, "opened video decoder");
+		Ok(Box::new(Self { parser, state }))
+	}
+}
+
+impl Backend for Nvdec {
+	fn decode(&mut self, access_unit: Bytes, timestamp_us: u64, _keyframe: bool) -> Result<Vec<Decoded>, Error> {
+		// The parser callbacks (decoder create, decode) and the map/copy below
+		// all need the CUDA context current on this thread.
+		self.state
+			.ctx
+			.bind_to_thread()
+			.map_err(|e| codec_err(format!("CUDA bind: {e:?}")))?;
+
+		let mut packet = CUVIDSOURCEDATAPACKET {
+			// ENDOFPICTURE: each payload is one complete access unit, so the
+			// parser emits it immediately instead of waiting for the next AU to
+			// detect the picture boundary (one-in one-out latency).
+			flags: (CUvideopacketflags::CUVID_PKT_TIMESTAMP as c_ulong)
+				| (CUvideopacketflags::CUVID_PKT_ENDOFPICTURE as c_ulong),
+			payload_size: access_unit.len() as c_ulong,
+			payload: access_unit.as_ptr(),
+			timestamp: timestamp_us as i64,
+		};
+
+		// SAFETY: parser and packet are valid; the payload outlives the call
+		// (the parser copies what it needs before returning).
+		let result = unsafe { (self.state.api.parse_video_data)(self.parser, &mut packet) };
+		if let Some(error) = self.state.error.take() {
+			return Err(codec_err(error));
+		}
+		if result != cudarc::driver::sys::CUresult::CUDA_SUCCESS {
+			return Err(codec_err(format!("cuvidParseVideoData: {result:?}")));
+		}
+
+		let ready = std::mem::take(&mut self.state.ready);
+		ready.iter().map(|disp| self.state.map_frame(disp)).collect()
+	}
+
+	fn name(&self) -> &str {
+		NAME
+	}
+}
+
+impl Drop for Nvdec {
+	fn drop(&mut self) {
+		// Drop may run on a different thread than decode; the destroy calls
+		// (parser here, decoder via `state`) need the context current.
+		let _ = self.state.ctx.bind_to_thread();
+		// SAFETY: the parser is valid and no parse call is in flight (&mut self).
+		unsafe { (self.state.api.destroy_video_parser)(self.parser) };
+	}
+}
+
+impl State {
+	/// Sequence callback body: (re)create the decoder for the reported format.
+	/// Returns the decode-surface count the parser should allocate for.
+	fn on_sequence(&mut self, format: &CUVIDEOFORMAT) -> Result<c_int, String> {
+		if format.chroma_format != cudaVideoChromaFormat::cudaVideoChromaFormat_420 {
+			return Err(format!("unsupported chroma format {:?}", format.chroma_format));
+		}
+		if format.bit_depth_luma_minus8 != 0 || format.bit_depth_chroma_minus8 != 0 {
+			return Err(format!(
+				"unsupported bit depth {} (only 8-bit is supported)",
+				format.bit_depth_luma_minus8 + 8
+			));
+		}
+
+		let mut caps = CUVIDDECODECAPS {
+			eCodecType: format.codec,
+			eChromaFormat: format.chroma_format,
+			nBitDepthMinus8: 0,
+			..Default::default()
+		};
+		// SAFETY: caps is fully initialized and the CUDA context is current (the
+		// callback runs inside `decode`, which binds it).
+		let result = unsafe { (self.api.get_decoder_caps)(&mut caps) };
+		if result != cudarc::driver::sys::CUresult::CUDA_SUCCESS {
+			return Err(format!("cuvidGetDecoderCaps: {result:?}"));
+		}
+		if caps.bIsSupported == 0 {
+			return Err(format!("this GPU cannot decode {:?}", format.codec));
+		}
+		if caps.nOutputFormatMask & (1 << cudaVideoSurfaceFormat::cudaVideoSurfaceFormat_NV12 as u16) == 0 {
+			return Err("this GPU cannot output NV12".into());
+		}
+		if format.coded_width > caps.nMaxWidth || format.coded_height > caps.nMaxHeight {
+			return Err(format!(
+				"{}x{} exceeds this GPU's {}x{} decode limit",
+				format.coded_width, format.coded_height, caps.nMaxWidth, caps.nMaxHeight
+			));
+		}
+
+		// Output size: the requested resize, or the display area (the coded size
+		// minus cropping). Rounded down to even for NV12.
+		let display = (
+			(format.display_area.right - format.display_area.left).max(2) as u32 & !1,
+			(format.display_area.bottom - format.display_area.top).max(2) as u32 & !1,
+		);
+		let (width, height) = self.resize.unwrap_or(display);
+		let coded = (format.coded_width, format.coded_height);
+
+		let surfaces = c_int::from(format.min_num_decode_surfaces.max(1));
+
+		// A repeated sequence header with unchanged geometry (common at every
+		// keyframe) keeps the existing decoder.
+		if let Some(decoder) = &self.decoder {
+			if decoder.coded == coded && (decoder.width, decoder.height) == (width, height) {
+				return Ok(surfaces);
+			}
+		}
+		self.decoder = None;
+
+		let mut info = CUVIDDECODECREATEINFO {
+			ulWidth: format.coded_width as c_ulong,
+			ulHeight: format.coded_height as c_ulong,
+			ulNumDecodeSurfaces: surfaces as c_ulong,
+			CodecType: format.codec,
+			ChromaFormat: format.chroma_format,
+			ulCreationFlags: cudaVideoCreateFlags::cudaVideoCreate_PreferCUVID as c_ulong,
+			bitDepthMinus8: 0,
+			// We recreate on geometry changes instead of reconfiguring, so no
+			// headroom beyond the current coded size is needed.
+			ulMaxWidth: format.coded_width as c_ulong,
+			ulMaxHeight: format.coded_height as c_ulong,
+			OutputFormat: cudaVideoSurfaceFormat::cudaVideoSurfaceFormat_NV12,
+			// moq sources are progressive; Weave passes frames through untouched.
+			DeinterlaceMode: cudaVideoDeinterlaceMode::cudaVideoDeinterlaceMode_Weave,
+			ulTargetWidth: width as c_ulong,
+			ulTargetHeight: height as c_ulong,
+			// Each output surface is copied out and unmapped before the next map,
+			// so 2 is plenty (1 in flight + 1 being post-processed).
+			ulNumOutputSurfaces: 2,
+			..Default::default()
+		};
+		info.display_area.left = format.display_area.left as i16;
+		info.display_area.top = format.display_area.top as i16;
+		info.display_area.right = format.display_area.right as i16;
+		info.display_area.bottom = format.display_area.bottom as i16;
+		info.target_rect.right = width as i16;
+		info.target_rect.bottom = height as i16;
+
+		let mut handle: CUvideodecoder = ptr::null_mut();
+		// SAFETY: info is fully initialized and the CUDA context is current.
+		let result = unsafe { (self.api.create_decoder)(&mut handle, &mut info) };
+		if result != cudarc::driver::sys::CUresult::CUDA_SUCCESS {
+			return Err(format!("cuvidCreateDecoder: {result:?}"));
+		}
+
+		tracing::debug!(
+			decoder = NAME,
+			coded_width = format.coded_width,
+			coded_height = format.coded_height,
+			width,
+			height,
+			"created cuvid decoder"
+		);
+		self.decoder = Some(Decoder {
+			api: self.api,
+			handle,
+			coded,
+			width,
+			height,
+		});
+		Ok(surfaces)
+	}
+
+	/// Map one decoded picture and copy it device-to-device into an owned CUDA
+	/// buffer, so the fixed surface pool is released before the next decode.
+	fn map_frame(&self, disp: &CUVIDPARSERDISPINFO) -> Result<Decoded, Error> {
+		let decoder = self
+			.decoder
+			.as_ref()
+			.ok_or_else(|| codec_err("display callback fired before a decoder exists".into()))?;
+
+		let mut proc_params = CUVIDPROCPARAMS {
+			progressive_frame: disp.progressive_frame,
+			top_field_first: disp.top_field_first,
+			..Default::default()
+		};
+
+		let mut dev_ptr: c_ulonglong = 0;
+		let mut pitch: c_uint = 0;
+		// SAFETY: the decoder handle is valid, the picture index came from the
+		// display callback, and the CUDA context is current.
+		let result = unsafe {
+			(self.api.map_video_frame)(
+				decoder.handle,
+				disp.picture_index,
+				&mut dev_ptr,
+				&mut pitch,
+				&mut proc_params,
+			)
+		};
+		if result != cudarc::driver::sys::CUresult::CUDA_SUCCESS {
+			return Err(codec_err(format!("cuvidMapVideoFrame: {result:?}")));
+		}
+
+		// The mapped surface is NV12 at the decoder's target size: `height` luma
+		// rows of `pitch` bytes, then `height / 2` interleaved-UV rows. Copy it
+		// linearly into an owned buffer with the identical layout.
+		let copied = (|| -> Result<cuda::Frame, Error> {
+			let frame = cuda::Frame::alloc(&self.ctx, decoder.width, decoder.height, pitch)?;
+			let len = pitch as usize * decoder.height as usize * 3 / 2;
+			// SAFETY: both regions are `len` bytes of device memory: the mapped
+			// surface by cuvid's layout above, the destination by `alloc`.
+			unsafe { cudarc::driver::result::memcpy_dtod_sync(frame.device_ptr(), dev_ptr, len) }
+				.map_err(|e| codec_err(format!("CUDA device copy: {e:?}")))?;
+			Ok(frame)
+		})();
+
+		// SAFETY: unmapping the pointer we just mapped, always, even when the
+		// copy failed; a leaked mapping would starve the output-surface pool.
+		unsafe { (self.api.unmap_video_frame)(decoder.handle, dev_ptr) };
+
+		Ok(Decoded {
+			// Timestamps rode the parser from `decode` (microseconds, unsigned).
+			timestamp_us: disp.timestamp.max(0) as u64,
+			frame: Frame::Cuda(copied?),
+		})
+	}
+}
+
+/// Sequence callback: a new (or repeated) sequence header. Returns the number of
+/// decode surfaces the parser should assume, or 0 on failure.
+unsafe extern "C" fn sequence_callback(user: *mut c_void, format: *mut CUVIDEOFORMAT) -> c_int {
+	// SAFETY: `user` is the boxed State passed at parser creation, and cuvid
+	// invokes callbacks synchronously inside the parse call, so no other
+	// reference to it is live.
+	let state = unsafe { &mut *(user as *mut State) };
+	let format = unsafe { &*format };
+	match state.on_sequence(format) {
+		Ok(surfaces) => surfaces,
+		Err(e) => {
+			state.error.get_or_insert(e);
+			0
+		}
+	}
+}
+
+/// Decode callback: a picture is ready to be submitted to the hardware.
+unsafe extern "C" fn decode_callback(user: *mut c_void, pic: *mut CUVIDPICPARAMS) -> c_int {
+	// SAFETY: see `sequence_callback`.
+	let state = unsafe { &mut *(user as *mut State) };
+	let Some(decoder) = &state.decoder else {
+		state
+			.error
+			.get_or_insert("decode callback fired before a decoder exists".into());
+		return 0;
+	};
+	// SAFETY: the decoder handle is valid and `pic` comes straight from cuvid.
+	let result = unsafe { (state.api.decode_picture)(decoder.handle, pic) };
+	if result != cudarc::driver::sys::CUresult::CUDA_SUCCESS {
+		state.error.get_or_insert(format!("cuvidDecodePicture: {result:?}"));
+		return 0;
+	}
+	1
+}
+
+/// Display callback: a decoded picture is ready for output, in presentation
+/// order. Queue it; `decode` maps and copies it out after the parse call.
+unsafe extern "C" fn display_callback(user: *mut c_void, disp: *mut CUVIDPARSERDISPINFO) -> c_int {
+	// SAFETY: see `sequence_callback`.
+	let state = unsafe { &mut *(user as *mut State) };
+	if disp.is_null() {
+		// End-of-stream marker; nothing to queue.
+		return 1;
+	}
+	// SAFETY: non-null `disp` points at a valid dispinfo for this call.
+	state.ready.push(unsafe { *disp });
+	1
+}
+
+/// Whether libcuda can be dlopen'd. cudarc loads it lazily and panics if it's
+/// absent, so probe first and turn a missing driver into a recoverable `Err`
+/// (libnvcuvid is probed by the cuvid table itself).
+fn driver_libs_present() -> bool {
+	const CUDA: &[&str] = &["libcuda.so.1", "libcuda.so"];
+	// SAFETY: we only open the library to test presence and immediately drop the
+	// handle; loading runs the driver lib's initializers, which is sound.
+	CUDA.iter()
+		.any(|name| unsafe { libloading::Library::new(*name) }.is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::decode::{Config as DecodeConfig, Kind as DecodeKind};
+	use crate::encode::{Codec as EncodeCodec, Config as EncodeConfig, Encoder, Kind as EncodeKind};
+	use crate::frame::I420;
+
+	/// Real hardware only: skip (return) on a box without the NVIDIA driver, so
+	/// these are no-ops on GPU-less CI and validate on a Linux + NVIDIA box.
+	fn hw_available() -> bool {
+		driver_libs_present() && cuvid::Api::get().is_ok()
+	}
+
+	/// On a host without the NVIDIA driver, opening NVDEC must return an `Err`
+	/// (so `Kind::Auto` falls back to openh264) rather than panicking in cudarc
+	/// or the cuvid loader. On a box that does have the driver this is a no-op.
+	#[test]
+	fn missing_driver_errors_instead_of_panicking() {
+		if hw_available() {
+			return;
+		}
+		assert!(Nvdec::open(Codec::H264, &decode_config(None)).is_err());
+	}
+
+	fn decode_config(resize: Option<(u32, u32)>) -> DecodeConfig {
+		DecodeConfig {
+			kind: DecodeKind::Named(NAME.into()),
+			resize,
+			..DecodeConfig::new()
+		}
+	}
+
+	/// A static RGBA gradient that varies in both axes, so the chroma planes have
+	/// spatial structure and a pitch/layout bug corrupts the decoded image.
+	fn gradient_rgba(width: u32, height: u32) -> Vec<u8> {
+		let (w, h) = (width as usize, height as usize);
+		let mut buf = vec![0u8; w * h * 4];
+		for y in 0..h {
+			for x in 0..w {
+				let i = (y * w + x) * 4;
+				buf[i] = (x * 255 / w) as u8;
+				buf[i + 1] = (y * 255 / h) as u8;
+				buf[i + 2] = ((x + y) * 255 / (w + h)) as u8;
+				buf[i + 3] = 255;
+			}
+		}
+		buf
+	}
+
+	/// Mean absolute error between two equal-length planes.
+	fn mae(a: &[u8], b: &[u8]) -> u64 {
+		assert_eq!(a.len(), b.len());
+		a.iter().zip(b).map(|(x, y)| x.abs_diff(*y) as u64).sum::<u64>() / a.len() as u64
+	}
+
+	/// Encode `frames` gradient frames with `encoder` and decode them through
+	/// NVDEC, returning the downloaded I420 pictures with their timestamps.
+	fn round_trip(mut encoder: Encoder, mut decoder: Box<dyn Backend>, w: u32, h: u32) -> Vec<(u64, I420)> {
+		let rgba = gradient_rgba(w, h);
+		let mut out = Vec::new();
+		for i in 0..10u64 {
+			for packet in encoder.encode_rgba(&rgba, w, h, i == 0).unwrap() {
+				for decoded in decoder.decode(packet, i * 33_333, i == 0).unwrap() {
+					let i420 = decoded.frame.to_i420().unwrap().into_owned();
+					out.push((decoded.timestamp_us, i420));
+				}
+			}
+		}
+		assert!(!out.is_empty(), "NVDEC produced no frames");
+		out
+	}
+
+	/// H.264 through the real hardware: openh264 encodes a gradient (Annex-B,
+	/// inline SPS/PPS) and NVDEC decodes it. Asserts the downloaded NV12 -> I420
+	/// picture matches the input (a layout bug shears a plane and blows the MAE)
+	/// and that timestamps ride the parser through 1:1.
+	#[test]
+	fn nvdec_h264_round_trip() {
+		if !hw_available() {
+			return;
+		}
+		let (w, h) = (320u32, 240u32);
+		let encoder = Encoder::new(&EncodeConfig {
+			kind: EncodeKind::Software,
+			..EncodeConfig::new(w, h, 30)
+		})
+		.unwrap();
+		let decoder = Nvdec::open(Codec::H264, &decode_config(None)).expect("NVDEC H.264 decoder");
+
+		let expected = I420::from_rgba(&gradient_rgba(w, h), w, h).unwrap();
+		let decoded = round_trip(encoder, decoder, w, h);
+
+		for (i, (timestamp, i420)) in decoded.iter().enumerate() {
+			// Zero display delay and no B-frames: one-in one-out, in order.
+			assert_eq!(*timestamp, i as u64 * 33_333, "timestamp did not ride the parser");
+			assert_eq!((i420.width, i420.height), (w, h));
+			assert!(mae(i420.y(), expected.y()) < 8, "Y plane corrupt");
+			assert!(mae(i420.u(), expected.u()) < 8, "U plane corrupt");
+			assert!(mae(i420.v(), expected.v()) < 8, "V plane corrupt");
+		}
+	}
+
+	/// The decoder-side scaler: decode 320x240 at a 160x120 target and compare
+	/// against a CPU downscale of the input. Loose MAE bound (two different
+	/// scaling kernels), but a plane swap or a pitch bug still blows it up.
+	#[test]
+	fn nvdec_resize_scales_output() {
+		if !hw_available() {
+			return;
+		}
+		let (w, h) = (320u32, 240u32);
+		let encoder = Encoder::new(&EncodeConfig {
+			kind: EncodeKind::Software,
+			..EncodeConfig::new(w, h, 30)
+		})
+		.unwrap();
+		let decoder = Nvdec::open(Codec::H264, &decode_config(Some((160, 120)))).expect("NVDEC H.264 decoder");
+
+		// Nearest-neighbor reference downscale of the expected picture.
+		let full = I420::from_rgba(&gradient_rgba(w, h), w, h).unwrap();
+		let sample = |plane: &[u8], pw: usize, x: usize, y: usize| plane[y * 2 * pw + x * 2];
+		let mut expected_y = vec![0u8; 160 * 120];
+		for y in 0..120 {
+			for x in 0..160 {
+				expected_y[y * 160 + x] = sample(full.y(), w as usize, x, y);
+			}
+		}
+
+		let decoded = round_trip(encoder, decoder, w, h);
+		for (_, i420) in &decoded {
+			assert_eq!((i420.width, i420.height), (160, 120), "resize was not applied");
+			assert!(mae(i420.y(), &expected_y) < 12, "scaled Y plane corrupt");
+		}
+	}
+
+	/// H.265 has no software encoder, so the HEVC round trip rides NVENC on the
+	/// encode side and NVDEC on the decode side.
+	#[test]
+	fn nvdec_h265_round_trip() {
+		if !hw_available() {
+			return;
+		}
+		let (w, h) = (320u32, 240u32);
+		let Ok(encoder) = Encoder::new(&EncodeConfig {
+			codec: EncodeCodec::H265,
+			kind: EncodeKind::Named("nvenc".into()),
+			..EncodeConfig::new(w, h, 30)
+		}) else {
+			// Driver present but NVENC unusable (e.g. GPU busy); don't fail.
+			return;
+		};
+		let decoder = Nvdec::open(Codec::H265, &decode_config(None)).expect("NVDEC H.265 decoder");
+
+		let expected = I420::from_rgba(&gradient_rgba(w, h), w, h).unwrap();
+		let decoded = round_trip(encoder, decoder, w, h);
+		for (_, i420) in &decoded {
+			assert_eq!((i420.width, i420.height), (w, h));
+			assert!(mae(i420.y(), expected.y()) < 8, "Y plane corrupt");
+			assert!(mae(i420.u(), expected.u()) < 8, "U plane corrupt");
+			assert!(mae(i420.v(), expected.v()) < 8, "V plane corrupt");
+		}
+	}
+
+	/// The full zero-copy loop: NVDEC decodes to CUDA frames, NVENC re-encodes
+	/// them straight from device memory (the registered-resource path), and a
+	/// software decode of the re-encoded stream still matches the original
+	/// picture. No CPU pixels exist between NVDEC and NVENC.
+	#[test]
+	fn nvdec_to_nvenc_zero_copy() {
+		if !hw_available() {
+			return;
+		}
+		let (w, h) = (320u32, 240u32);
+		// Source stream: software-encoded gradient.
+		let source = Encoder::new(&EncodeConfig {
+			kind: EncodeKind::Software,
+			..EncodeConfig::new(w, h, 30)
+		})
+		.unwrap();
+		// Decode at half size so the hardware scaler is in the loop too.
+		let decoder = Nvdec::open(Codec::H264, &decode_config(Some((160, 120)))).expect("NVDEC decoder");
+
+		let mut nvenc = Encoder::new(&EncodeConfig {
+			kind: EncodeKind::Named("nvenc".into()),
+			..EncodeConfig::new(160, 120, 30)
+		})
+		.expect("NVENC encoder");
+
+		// GPU transcode: every decoded frame must be CUDA-resident.
+		let decoded = {
+			let rgba = gradient_rgba(w, h);
+			let mut source = source;
+			let mut decoder = decoder;
+			let mut frames = Vec::new();
+			for i in 0..10u64 {
+				for packet in source.encode_rgba(&rgba, w, h, i == 0).unwrap() {
+					frames.extend(decoder.decode(packet, i * 33_333, i == 0).unwrap());
+				}
+			}
+			frames
+		};
+		assert!(!decoded.is_empty());
+
+		let mut packets = Vec::new();
+		for (i, out) in decoded.iter().enumerate() {
+			assert!(
+				matches!(out.frame, Frame::Cuda(_)),
+				"NVDEC produced a non-CUDA frame; the zero-copy path is not exercised"
+			);
+			packets.extend(nvenc.encode_raw(&out.frame, i == 0).unwrap());
+		}
+		packets.extend(nvenc.finish().unwrap());
+		assert!(!packets.is_empty(), "NVENC produced no packets from CUDA frames");
+
+		// Decode the re-encoded stream in software and compare to the source.
+		let expected = {
+			let full = I420::from_rgba(&gradient_rgba(w, h), w, h).unwrap();
+			let mut y = vec![0u8; 160 * 120];
+			for row in 0..120 {
+				for col in 0..160 {
+					y[row * 160 + col] = full.y()[row * 2 * w as usize + col * 2];
+				}
+			}
+			y
+		};
+		let mut check = crate::decode::backend::open(
+			crate::decode::backend::Codec::H264,
+			&DecodeConfig {
+				kind: DecodeKind::Software,
+				..DecodeConfig::new()
+			},
+		)
+		.unwrap();
+		let mut last = None;
+		for (i, packet) in packets.into_iter().enumerate() {
+			for out in check.decode(packet, i as u64, i == 0).unwrap() {
+				last = Some(out.frame.to_i420().unwrap().into_owned());
+			}
+		}
+		let last = last.expect("software decoder produced no frames");
+		assert_eq!((last.width, last.height), (160, 120));
+		assert!(mae(last.y(), &expected) < 16, "transcoded Y plane corrupt");
+	}
+}

--- a/rs/moq-video/src/decode/backend/nvdec.rs
+++ b/rs/moq-video/src/decode/backend/nvdec.rs
@@ -75,8 +75,11 @@ struct State {
 struct Decoder {
 	api: &'static cuvid::Api,
 	handle: CUvideodecoder,
-	/// The coded (not display) size it was created for, to detect reconfigures.
+	/// The coded size it was created for, to detect reconfigures.
 	coded: (u32, u32),
+	/// The display crop (left, top, right, bottom) it was created for; a crop
+	/// change alone also requires a new decoder.
+	display_area: (i32, i32, i32, i32),
 	/// Output size: cuvid scales to this while writing the output surface.
 	width: u32,
 	height: u32,
@@ -253,13 +256,24 @@ impl State {
 		);
 		let (width, height) = self.resize.unwrap_or(display);
 		let coded = (format.coded_width, format.coded_height);
+		let display_area = (
+			format.display_area.left,
+			format.display_area.top,
+			format.display_area.right,
+			format.display_area.bottom,
+		);
 
 		let surfaces = c_int::from(format.min_num_decode_surfaces.max(1));
 
 		// A repeated sequence header with unchanged geometry (common at every
-		// keyframe) keeps the existing decoder.
+		// keyframe) keeps the existing decoder. The display crop matters even at
+		// the same coded and target sizes: it selects the source rect the scaler
+		// reads from.
 		if let Some(decoder) = &self.decoder {
-			if decoder.coded == coded && (decoder.width, decoder.height) == (width, height) {
+			if decoder.coded == coded
+				&& decoder.display_area == display_area
+				&& (decoder.width, decoder.height) == (width, height)
+			{
 				return Ok(surfaces);
 			}
 		}
@@ -313,6 +327,7 @@ impl State {
 			api: self.api,
 			handle,
 			coded,
+			display_area,
 			width,
 			height,
 		});

--- a/rs/moq-video/src/decode/backend/openh264.rs
+++ b/rs/moq-video/src/decode/backend/openh264.rs
@@ -9,9 +9,9 @@ use openh264::OpenH264API;
 use openh264::decoder::{Decoder, DecoderConfig};
 use openh264::formats::YUVSource;
 
-use super::{Backend, Codec};
+use super::{Backend, Codec, Config, Decoded};
 use crate::Error;
-use crate::frame::I420;
+use crate::frame::{Frame, I420};
 
 pub(crate) const NAME: &str = "openh264";
 
@@ -21,8 +21,9 @@ pub(crate) struct Openh264 {
 
 impl Openh264 {
 	/// openh264 decodes H.264 only; the backend selector never routes another
-	/// codec here, so `codec` is accepted for signature parity and ignored.
-	pub(crate) fn open(_codec: Codec) -> Result<Box<dyn Backend>, Error> {
+	/// codec here, so `codec` is accepted for signature parity and ignored, as is
+	/// `config` (no hardware scaler; callers scale the CPU frames themselves).
+	pub(crate) fn open(_codec: Codec, _config: &Config) -> Result<Box<dyn Backend>, Error> {
 		let decoder = Decoder::with_api_config(OpenH264API::from_source(), DecoderConfig::new())
 			.map_err(|e| Error::Codec(anyhow::anyhow!("openh264 decoder init: {e}")))?;
 
@@ -32,7 +33,7 @@ impl Openh264 {
 }
 
 impl Backend for Openh264 {
-	fn decode(&mut self, access_unit: Bytes, _keyframe: bool) -> Result<Vec<I420>, Error> {
+	fn decode(&mut self, access_unit: Bytes, timestamp_us: u64, _keyframe: bool) -> Result<Vec<Decoded>, Error> {
 		let decoded = self
 			.decoder
 			.decode(&access_unit)
@@ -61,7 +62,11 @@ impl Backend for Openh264 {
 			width as u32,
 			height as u32,
 		);
-		Ok(vec![frame])
+		// openh264 is one-in one-out, so the input timestamp is the output's.
+		Ok(vec![Decoded {
+			timestamp_us,
+			frame: Frame::I420(frame),
+		}])
 	}
 
 	fn name(&self) -> &str {

--- a/rs/moq-video/src/decode/backend/videotoolbox.rs
+++ b/rs/moq-video/src/decode/backend/videotoolbox.rs
@@ -35,9 +35,9 @@ use objc2_video_toolbox::{
 	VTDecodeFrameFlags, VTDecodeInfoFlags, VTDecompressionOutputCallbackRecord, VTDecompressionSession,
 };
 
-use super::{Backend, Codec};
+use super::{Backend, Codec, Config, Decoded};
 use crate::Error;
-use crate::frame::I420;
+use crate::frame::{Frame, I420};
 
 pub(crate) const NAME: &str = "videotoolbox";
 
@@ -84,7 +84,9 @@ unsafe impl Send for VideoToolbox {}
 impl VideoToolbox {
 	/// Open a decoder for `codec` (H.264 or H.265). The session is built lazily
 	/// once the first keyframe's parameter sets arrive.
-	pub(crate) fn open(codec: Codec) -> Result<Box<dyn Backend>, Error> {
+	/// `config` is accepted for signature parity; VideoToolbox decodes at the
+	/// stream's native size (callers scale the frames themselves).
+	pub(crate) fn open(codec: Codec, _config: &Config) -> Result<Box<dyn Backend>, Error> {
 		tracing::info!(decoder = NAME, codec = ?codec, "opened video decoder");
 		Ok(Box::new(Self {
 			codec,
@@ -164,7 +166,7 @@ impl VideoToolbox {
 }
 
 impl Backend for VideoToolbox {
-	fn decode(&mut self, access_unit: Bytes, _keyframe: bool) -> Result<Vec<I420>, Error> {
+	fn decode(&mut self, access_unit: Bytes, timestamp_us: u64, _keyframe: bool) -> Result<Vec<Decoded>, Error> {
 		// Split the Annex-B access unit, pull out any parameter sets, and gather
 		// the slices into length-prefixed (4-byte) form. `NalIterator` yields the
 		// parameter-set NALs as zero-copy `Bytes` (sub-slices of `access_unit`), so
@@ -223,7 +225,15 @@ impl Backend for VideoToolbox {
 				"VideoToolbox decode callback failed: {error}"
 			)));
 		}
-		Ok(std::mem::take(&mut self.sink.frames))
+		// The decode callback fires synchronously inside `decode_frame`, so
+		// every output frame belongs to the access unit just submitted.
+		Ok(std::mem::take(&mut self.sink.frames)
+			.into_iter()
+			.map(|i420| Decoded {
+				timestamp_us,
+				frame: Frame::I420(i420),
+			})
+			.collect())
 	}
 
 	fn name(&self) -> &str {

--- a/rs/moq-video/src/decode/consumer.rs
+++ b/rs/moq-video/src/decode/consumer.rs
@@ -30,7 +30,7 @@ impl Consumer {
 		name: impl Into<String>,
 		config: Config,
 	) -> Result<Self, Error> {
-		let decoder = Decoder::new(catalog, &config.kind)?;
+		let decoder = Decoder::new(catalog, &config)?;
 
 		let name = name.into();
 		let track = broadcast.track(&name)?.subscribe(None).await?;

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -29,7 +29,8 @@ pub enum Kind {
 	Hardware,
 	/// Software (openh264) only.
 	Software,
-	/// A specific backend by name, e.g. `"videotoolbox"`, `"openh264"`.
+	/// A specific backend by name, e.g. `"videotoolbox"`, `"nvdec"`,
+	/// `"openh264"`.
 	Named(String),
 }
 
@@ -46,6 +47,12 @@ pub struct Config {
 	/// the moq-mux default (skip aggressively); set it to your playout buffer for
 	/// a softer skip. Forwarded to the container consumer's `with_latency`.
 	pub latency_max: Option<Duration>,
+	/// Ask the decoder to emit frames at this `(width, height)` (both even)
+	/// instead of the stream's native size. Best effort: a hardware decoder with
+	/// a built-in scaler (NVDEC) honors it for free, other backends ignore it.
+	/// Check each [`Frame`](super::Frame)'s dimensions and scale the remainder
+	/// yourself.
+	pub resize: Option<(u32, u32)>,
 }
 
 impl Config {
@@ -82,7 +89,7 @@ pub struct Decoder {
 impl Decoder {
 	/// Build a decoder for the catalog's video config. Errors if the codec is
 	/// neither H.264 nor H.265 (the codecs the native backends support).
-	pub fn new(catalog: &VideoConfig, kind: &Kind) -> Result<Self, Error> {
+	pub fn new(catalog: &VideoConfig, config: &Config) -> Result<Self, Error> {
 		let (codec, conversion) = match &catalog.codec {
 			VideoCodec::H264(h264) => {
 				let conversion = if h264.inline {
@@ -120,7 +127,7 @@ impl Decoder {
 			other => return Err(Error::UnsupportedCodec(other.to_string())),
 		};
 
-		let backend = backend::open(codec, kind)?;
+		let backend = backend::open(codec, config)?;
 		tracing::debug!(decoder = backend.name(), "opened video decoder");
 		Ok(Self {
 			backend,
@@ -160,13 +167,13 @@ impl Decoder {
 
 		Ok(self
 			.backend
-			.decode(annexb, keyframe)?
+			.decode(annexb, timestamp_us, keyframe)?
 			.into_iter()
-			.map(|i420| Frame {
-				timestamp_us,
-				width: i420.width,
-				height: i420.height,
-				data: Bytes::from(i420.data),
+			.map(|decoded| Frame {
+				timestamp_us: decoded.timestamp_us,
+				width: decoded.frame.width(),
+				height: decoded.frame.height(),
+				inner: decoded.frame,
 			})
 			.collect())
 	}
@@ -211,16 +218,24 @@ mod tests {
 
 		let frame = gray_rgba(320, 240);
 		let mut decoded = Vec::new();
-		for i in 0..10 {
+		for i in 0..10u64 {
 			let keyframe = i == 0;
 			for packet in encoder.encode_rgba(&frame, 320, 240, keyframe).unwrap() {
-				decoded.extend(decoder.decode(packet, keyframe).unwrap());
+				decoded.extend(decoder.decode(packet, i * 33_333, keyframe).unwrap());
 			}
 		}
 
 		assert!(!decoded.is_empty(), "decoder produced no frames");
-		for i420 in &decoded {
-			assert_gray(i420, 320, 240);
+		for out in &decoded {
+			assert_gray(&out.frame.to_i420().unwrap(), 320, 240);
+		}
+	}
+
+	/// A decoder config selecting one backend by kind.
+	fn decode_config(kind: super::Kind) -> super::Config {
+		super::Config {
+			kind,
+			..super::Config::new()
 		}
 	}
 
@@ -235,15 +250,15 @@ mod tests {
 
 	#[test]
 	fn openh264_round_trip() {
-		let decoder = backend::open(Codec::H264, &super::Kind::Software).expect("openh264 decoder");
+		let decoder = backend::open(Codec::H264, &decode_config(super::Kind::Software)).expect("openh264 decoder");
 		round_trip(h264_software_encoder(), decoder, "openh264");
 	}
 
 	#[cfg(target_os = "macos")]
 	#[test]
 	fn videotoolbox_round_trip() {
-		let decoder =
-			backend::open(Codec::H264, &super::Kind::Named("videotoolbox".into())).expect("videotoolbox decoder");
+		let decoder = backend::open(Codec::H264, &decode_config(super::Kind::Named("videotoolbox".into())))
+			.expect("videotoolbox decoder");
 		round_trip(h264_software_encoder(), decoder, "videotoolbox");
 	}
 
@@ -263,8 +278,8 @@ mod tests {
 			eprintln!("skipping: no VideoToolbox H.265 hardware encoder available");
 			return;
 		};
-		let decoder =
-			backend::open(Codec::H265, &super::Kind::Named("videotoolbox".into())).expect("videotoolbox H.265 decoder");
+		let decoder = backend::open(Codec::H265, &decode_config(super::Kind::Named("videotoolbox".into())))
+			.expect("videotoolbox H.265 decoder");
 		round_trip(encoder, decoder, "videotoolbox");
 	}
 
@@ -273,7 +288,10 @@ mod tests {
 	fn mediafoundation_round_trip() {
 		// Requires a hardware decoder MFT (GPU). Skip on machines without one
 		// rather than fail: CI runners are often headless.
-		let Ok(decoder) = backend::open(Codec::H264, &super::Kind::Named("mediafoundation".into())) else {
+		let Ok(decoder) = backend::open(
+			Codec::H264,
+			&decode_config(super::Kind::Named("mediafoundation".into())),
+		) else {
 			eprintln!("skipping: no Media Foundation H.264 hardware decoder available");
 			return;
 		};
@@ -296,7 +314,10 @@ mod tests {
 			eprintln!("skipping: no Media Foundation H.265 hardware encoder available");
 			return;
 		};
-		let Ok(decoder) = backend::open(Codec::H265, &super::Kind::Named("mediafoundation".into())) else {
+		let Ok(decoder) = backend::open(
+			Codec::H265,
+			&decode_config(super::Kind::Named("mediafoundation".into())),
+		) else {
 			eprintln!("skipping: no Media Foundation H.265 hardware decoder available");
 			return;
 		};

--- a/rs/moq-video/src/decode/mod.rs
+++ b/rs/moq-video/src/decode/mod.rs
@@ -3,14 +3,16 @@
 //! The decode counterpart to [`encode`](crate::encode), and the mirror of
 //! `moq-audio`'s `AudioConsumer`. [`Consumer`] subscribes to a moq-mux H.264 or
 //! H.265 track and hands back decoded [`Frame`]s; a native backend does the work
-//! (VideoToolbox on macOS, Media Foundation / DXVA on Windows, openh264
-//! everywhere as the software fallback for H.264).
+//! (VideoToolbox on macOS, Media Foundation / DXVA on Windows, NVDEC on Linux,
+//! openh264 everywhere as the software fallback for H.264).
 //!
 //! H.264 and H.265 are supported, symmetric with what [`encode`](crate::encode)
 //! produces. H.265 is hardware-only (no software fallback). Any other codec
 //! yields [`Error::UnsupportedCodec`](crate::Error).
 
 use bytes::Bytes;
+
+use crate::Error;
 
 // Crate-visible so the NVENC encode backend's round-trip test can decode its
 // output with the software decoder (an in-crate, ffmpeg-free encode->decode
@@ -22,12 +24,13 @@ mod decoder;
 pub use consumer::Consumer;
 pub use decoder::{Config, Decoder, Kind};
 
-/// A decoded raw video frame in tightly-packed I420 (YUV 4:2:0), BT.601 limited
-/// range (studio swing, what H.264 carries by default).
+/// A decoded raw video frame: CPU I420, or a GPU frame when a hardware decoder
+/// produced one (NVDEC on Linux).
 ///
-/// `data` holds the three planes contiguously: Y (`width * height` bytes), then
-/// U, then V (`width/2 * height/2` bytes each), no row padding. `width` and
-/// `height` are even.
+/// A GPU frame stays on the GPU until something needs bytes: feeding it to
+/// [`encode::Encoder::encode`](crate::encode::Encoder::encode) keeps it there
+/// (the zero-copy transcode path), while [`into_i420`](Self::into_i420)
+/// downloads it.
 pub struct Frame {
 	/// Presentation timestamp in microseconds (from the container).
 	pub timestamp_us: u64,
@@ -35,6 +38,24 @@ pub struct Frame {
 	pub width: u32,
 	/// Frame height in pixels (even).
 	pub height: u32,
-	/// Packed I420 plane data (Y, then U, then V).
-	pub data: Bytes,
+	/// The pixels: CPU I420 or a GPU surface.
+	pub(crate) inner: crate::frame::Frame,
+}
+
+impl Frame {
+	/// The frame as tightly-packed I420 (YUV 4:2:0, BT.601 limited range): Y
+	/// (`width * height` bytes), then U, then V (`width/2 * height/2` bytes
+	/// each), no row padding. Free for a CPU frame; downloads a GPU frame.
+	///
+	/// Consumes the frame: transcoders should instead pass it to
+	/// [`encode::Encoder::encode`](crate::encode::Encoder::encode), which keeps
+	/// a GPU frame on the GPU.
+	pub fn into_i420(self) -> Result<Bytes, Error> {
+		match self.inner {
+			crate::frame::Frame::I420(i420) => Ok(Bytes::from(i420.data)),
+			// GPU frames (CUDA / CVPixelBuffer / D3D11): download and pack.
+			#[allow(unreachable_patterns)]
+			other => Ok(Bytes::from(other.to_i420()?.into_owned().data)),
+		}
+	}
 }

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -26,14 +26,16 @@
 //! NVDEC output, already NV12) is registered as an external resource and encoded
 //! in place, so the NVDEC -> NVENC transcode path never touches the CPU.
 
-use std::ffi::c_void;
 use std::sync::Arc;
 
 use bytes::Bytes;
 use cudarc::driver::CudaContext;
+// The CUDA zero-copy input path only exists when NVDEC (its producer) is on.
+#[cfg(feature = "nvdec")]
+use moq_nvenc::sys::nvEncodeAPI::NV_ENC_INPUT_RESOURCE_TYPE;
 use moq_nvenc::sys::nvEncodeAPI::{
-	GUID, NV_ENC_BUFFER_FORMAT, NV_ENC_CODEC_H264_GUID, NV_ENC_CODEC_HEVC_GUID, NV_ENC_INPUT_RESOURCE_TYPE,
-	NV_ENC_PARAMS_RC_MODE, NV_ENC_PRESET_P4_GUID, NV_ENC_TUNING_INFO,
+	GUID, NV_ENC_BUFFER_FORMAT, NV_ENC_CODEC_H264_GUID, NV_ENC_CODEC_HEVC_GUID, NV_ENC_PARAMS_RC_MODE,
+	NV_ENC_PRESET_P4_GUID, NV_ENC_TUNING_INFO,
 };
 use moq_nvenc::{Encoder, EncoderInitParams, Session};
 
@@ -168,19 +170,24 @@ impl Backend for Nvenc {
 		};
 		self.timestamp += 1;
 
-		match frame {
+		// Each arm drains the output *before* releasing its input (the registered
+		// resource / input buffer): the synchronous bitstream lock is what
+		// guarantees NVENC is done reading the input, so releasing the input
+		// first would race the encoder.
+		let data = match frame {
 			// A CUDA frame is already NV12 in device memory (NVDEC output):
 			// register its buffer as an external NVENC resource and encode in
 			// place, no CPU round trip and no GPU copy.
+			#[cfg(feature = "nvdec")]
 			Frame::Cuda(cuda) => {
 				// Registration keeps a raw pointer into the frame; the frame
-				// outlives it (`resource` drops inside this arm, unregistering).
+				// (borrowed) outlives the registration.
 				let mut resource = self
 					.session
 					.register_generic_resource(
 						(),
 						NV_ENC_INPUT_RESOURCE_TYPE::NV_ENC_INPUT_RESOURCE_TYPE_CUDADEVICEPTR,
-						cuda.device_ptr() as *mut c_void,
+						cuda.device_ptr() as *mut std::ffi::c_void,
 						cuda.pitch,
 					)
 					.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC register CUDA frame: {e}")))?;
@@ -188,6 +195,8 @@ impl Backend for Nvenc {
 				self.session
 					.encode_picture(&mut resource, &mut output, params)
 					.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC encode: {e}")))?;
+
+				drain_output(&mut output)?
 			}
 			// Everything else goes through a CPU NV12 input buffer.
 			frame => {
@@ -222,14 +231,10 @@ impl Backend for Nvenc {
 				self.session
 					.encode_picture(&mut input, &mut output, params)
 					.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC encode: {e}")))?;
-			}
-		}
 
-		let data = output
-			.lock()
-			.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC lock output: {e}")))?
-			.data()
-			.to_vec();
+				drain_output(&mut output)?
+			}
+		};
 
 		Ok(if data.is_empty() {
 			Vec::new()
@@ -246,6 +251,17 @@ impl Backend for Nvenc {
 	fn name(&self) -> &str {
 		NAME
 	}
+}
+
+/// Block on the output bitstream and copy it out. The lock returning is also
+/// what guarantees NVENC finished reading the frame's input resource, so call
+/// this while that input is still alive.
+fn drain_output(output: &mut moq_nvenc::Bitstream) -> Result<Vec<u8>, Error> {
+	Ok(output
+		.lock()
+		.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC lock output: {e}")))?
+		.data()
+		.to_vec())
 }
 
 /// Whether both NVIDIA driver libraries NVENC needs can be dlopen'd: libcuda

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -20,21 +20,27 @@
 //!      pitch is aligned (e.g. 512 for a 320-wide buffer) and usually exceeds the
 //!      width, so a flat copy would shear the image; [`Nvenc::encode`] writes
 //!      each plane pitched, which works for any (even) width.
+//!
+//! The session's input format is NV12 (NVENC's native layout). A CPU I420 frame
+//! is interleaved into an NVENC input buffer; a CUDA frame ([`Frame::Cuda`],
+//! NVDEC output, already NV12) is registered as an external resource and encoded
+//! in place, so the NVDEC -> NVENC transcode path never touches the CPU.
 
+use std::ffi::c_void;
 use std::sync::Arc;
 
 use bytes::Bytes;
 use cudarc::driver::CudaContext;
 use moq_nvenc::sys::nvEncodeAPI::{
-	GUID, NV_ENC_BUFFER_FORMAT, NV_ENC_CODEC_H264_GUID, NV_ENC_CODEC_HEVC_GUID, NV_ENC_PARAMS_RC_MODE,
-	NV_ENC_PRESET_P4_GUID, NV_ENC_TUNING_INFO,
+	GUID, NV_ENC_BUFFER_FORMAT, NV_ENC_CODEC_H264_GUID, NV_ENC_CODEC_HEVC_GUID, NV_ENC_INPUT_RESOURCE_TYPE,
+	NV_ENC_PARAMS_RC_MODE, NV_ENC_PRESET_P4_GUID, NV_ENC_TUNING_INFO,
 };
 use moq_nvenc::{Encoder, EncoderInitParams, Session};
 
 use super::super::encoder::{Codec, Config};
 use super::Backend;
 use crate::Error;
-use crate::frame::Frame;
+use crate::frame::{Frame, interleave_uv};
 
 pub(crate) const NAME: &str = "nvenc";
 
@@ -127,8 +133,10 @@ impl Nvenc {
 			.enable_picture_type_decision()
 			.encode_config(cfg);
 
+		// NV12 is NVENC's native input layout and what NVDEC emits, so a CUDA
+		// frame registers directly; the CPU path interleaves I420 chroma on write.
 		let session = encoder
-			.start_session(NV_ENC_BUFFER_FORMAT::NV_ENC_BUFFER_FORMAT_IYUV, init)
+			.start_session(NV_ENC_BUFFER_FORMAT::NV_ENC_BUFFER_FORMAT_NV12, init)
 			.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC start session: {e}")))?;
 
 		tracing::info!(
@@ -148,37 +156,10 @@ impl Nvenc {
 
 impl Backend for Nvenc {
 	fn encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
-		let mut input = self
-			.session
-			.create_input_buffer()
-			.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC input buffer: {e}")))?;
 		let mut output = self
 			.session
 			.create_output_bitstream()
 			.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC output bitstream: {e}")))?;
-
-		// NVENC takes CPU I420; download a surface if capture handed us one.
-		let i420 = frame.to_i420()?;
-
-		// Copy the tightly-packed I420 planes into the input buffer honoring
-		// NVENC's chosen row stride: the buffer pitch can exceed the width even
-		// for aligned widths, so a flat write would shear the image. For IYUV the
-		// chroma planes use half the luma pitch.
-		let mut lock = input
-			.lock()
-			.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC lock input: {e}")))?;
-		let pitch = lock.pitch() as usize;
-		let (w, h) = (i420.width as usize, i420.height as usize);
-		let (cw, ch) = (w / 2, h / 2);
-		let cpitch = pitch / 2;
-		// SAFETY: offsets stay within the pitch*height*3/2 IYUV buffer and each
-		// source plane is exactly row_bytes * rows.
-		unsafe {
-			lock.write_rows(0, pitch, i420.y(), w, h);
-			lock.write_rows(pitch * h, cpitch, i420.u(), cw, ch);
-			lock.write_rows(pitch * h + cpitch * ch, cpitch, i420.v(), cw, ch);
-		}
-		drop(lock);
 
 		let params = moq_nvenc::EncodePictureParams {
 			input_timestamp: self.timestamp,
@@ -187,9 +168,62 @@ impl Backend for Nvenc {
 		};
 		self.timestamp += 1;
 
-		self.session
-			.encode_picture(&mut input, &mut output, params)
-			.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC encode: {e}")))?;
+		match frame {
+			// A CUDA frame is already NV12 in device memory (NVDEC output):
+			// register its buffer as an external NVENC resource and encode in
+			// place, no CPU round trip and no GPU copy.
+			Frame::Cuda(cuda) => {
+				// Registration keeps a raw pointer into the frame; the frame
+				// outlives it (`resource` drops inside this arm, unregistering).
+				let mut resource = self
+					.session
+					.register_generic_resource(
+						(),
+						NV_ENC_INPUT_RESOURCE_TYPE::NV_ENC_INPUT_RESOURCE_TYPE_CUDADEVICEPTR,
+						cuda.device_ptr() as *mut c_void,
+						cuda.pitch,
+					)
+					.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC register CUDA frame: {e}")))?;
+
+				self.session
+					.encode_picture(&mut resource, &mut output, params)
+					.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC encode: {e}")))?;
+			}
+			// Everything else goes through a CPU NV12 input buffer.
+			frame => {
+				let mut input = self
+					.session
+					.create_input_buffer()
+					.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC input buffer: {e}")))?;
+
+				let i420 = frame.to_i420()?;
+
+				// Interleave the I420 chroma planes into NV12's single UV plane.
+				let (w, h) = (i420.width as usize, i420.height as usize);
+				let mut uv = vec![0u8; w * h / 2];
+				interleave_uv(i420.u(), i420.v(), &mut uv);
+
+				// Write both planes honoring NVENC's chosen row stride: the
+				// buffer pitch can exceed the width even for aligned widths, so a
+				// flat write would shear the image. NV12 chroma rows are full
+				// width (interleaved U+V) at the luma pitch.
+				let mut lock = input
+					.lock()
+					.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC lock input: {e}")))?;
+				let pitch = lock.pitch() as usize;
+				// SAFETY: offsets stay within the pitch*height*3/2 NV12 buffer and
+				// each source plane is exactly row_bytes * rows.
+				unsafe {
+					lock.write_rows(0, pitch, i420.y(), w, h);
+					lock.write_rows(pitch * h, pitch, &uv, w, h / 2);
+				}
+				drop(lock);
+
+				self.session
+					.encode_picture(&mut input, &mut output, params)
+					.map_err(|e| Error::Codec(anyhow::anyhow!("NVENC encode: {e}")))?;
+			}
+		}
 
 		let data = output
 			.lock()
@@ -456,16 +490,19 @@ mod tests {
 		let rgba = gradient_rgba(w, h);
 		let expected = crate::frame::I420::from_rgba(&rgba, w, h).unwrap();
 
-		let mut decoder =
-			crate::decode::backend::open(crate::decode::backend::Codec::H264, &crate::decode::Kind::Software).unwrap();
+		let decode_config = crate::decode::Config {
+			kind: crate::decode::Kind::Software,
+			..crate::decode::Config::new()
+		};
+		let mut decoder = crate::decode::backend::open(crate::decode::backend::Codec::H264, &decode_config).unwrap();
 
 		// A static image, so every decoded frame equals the input regardless of
 		// decoder latency or frame reordering.
 		let mut decoded = None;
-		for i in 0..10u32 {
+		for i in 0..10u64 {
 			for packet in encoder.encode_rgba(&rgba, w, h, i == 0).unwrap() {
-				for frame in decoder.decode(packet, i == 0).unwrap() {
-					decoded = Some(frame);
+				for out in decoder.decode(packet, i * 33_333, i == 0).unwrap() {
+					decoded = Some(out.frame.to_i420().unwrap().into_owned());
 				}
 			}
 		}

--- a/rs/moq-video/src/encode/encoder.rs
+++ b/rs/moq-video/src/encode/encoder.rs
@@ -175,7 +175,7 @@ impl Encoder {
 		}
 
 		let frame = Frame::I420(I420::from_rgba(rgba, width, height)?);
-		self.encode(&frame, keyframe)
+		self.encode_raw(&frame, keyframe)
 	}
 
 	/// Encode one tightly-packed I420 frame (`width * height * 3 / 2` bytes: Y
@@ -203,12 +203,22 @@ impl Encoder {
 		}
 
 		let frame = Frame::I420(I420 { width, height, data });
-		self.encode(&frame, keyframe)
+		self.encode_raw(&frame, keyframe)
+	}
+
+	/// Encode a decoded [`Frame`](crate::decode::Frame), the transcode input
+	/// path: a hardware frame feeds a hardware encoder on the same device
+	/// directly (NVDEC -> NVENC stays on the GPU); everything else falls back to
+	/// a CPU I420 upload. The frame must already be at the encoder's resolution;
+	/// decode with [`decode::Config::resize`](crate::decode::Config) (or scale
+	/// yourself) first.
+	pub fn encode(&mut self, frame: &crate::decode::Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+		self.encode_raw(&frame.inner, keyframe)
 	}
 
 	/// Encode a captured [`Frame`] (a GPU surface or CPU I420). The frame must
 	/// already be at the encoder's resolution.
-	pub(crate) fn encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+	pub(crate) fn encode_raw(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
 		if frame.width() != self.width || frame.height() != self.height {
 			return Err(Error::Codec(anyhow::anyhow!(
 				"frame {}x{} does not match encoder {}x{}",
@@ -455,7 +465,7 @@ mod tests {
 		let mut packets = Vec::new();
 		for i in 0..10 {
 			let frame = Frame::Surface(nv12_surface(320, 240));
-			packets.extend(encoder.encode(&frame, i == 0).unwrap());
+			packets.extend(encoder.encode_raw(&frame, i == 0).unwrap());
 		}
 		packets.extend(encoder.finish().unwrap());
 
@@ -479,7 +489,7 @@ mod tests {
 		let mut encoder = Encoder::new(&config).unwrap();
 
 		let frame = Frame::Surface(nv12_surface(320, 240));
-		let mut packets = encoder.encode(&frame, true).unwrap();
+		let mut packets = encoder.encode_raw(&frame, true).unwrap();
 		packets.extend(encoder.finish().unwrap());
 
 		assert!(!packets.is_empty());
@@ -595,7 +605,7 @@ mod tests {
 			if matches!(frame, Frame::Texture(_)) {
 				textures += 1;
 			}
-			packets.extend(encoder.encode(&frame, i == 0).unwrap());
+			packets.extend(encoder.encode_raw(&frame, i == 0).unwrap());
 		}
 		packets.extend(encoder.finish().unwrap());
 

--- a/rs/moq-video/src/encode/sink.rs
+++ b/rs/moq-video/src/encode/sink.rs
@@ -74,7 +74,7 @@ mod threaded {
 				// Encode each request in arrival order. The encoder and its COM /
 				// MFT handles are created, used, and dropped only on this thread.
 				while let Some(req) = req_rx.blocking_recv() {
-					let result = encoder.encode(&req.frame, req.keyframe);
+					let result = encoder.encode_raw(&req.frame, req.keyframe);
 					let _ = req.resp.send(result);
 				}
 				// `encoder` drops here, on this thread, balancing the COM apartment.
@@ -153,7 +153,7 @@ mod inline {
 		}
 
 		pub(in crate::encode) async fn encode(&mut self, frame: Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
-			self.0.encode(&frame, keyframe)
+			self.0.encode_raw(&frame, keyframe)
 		}
 	}
 }

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -27,8 +27,9 @@ pub(crate) enum Frame {
 	/// Zero-copy GPU texture (Windows Direct3D11 NV12).
 	#[cfg(target_os = "windows")]
 	Texture(d3d11::Texture),
-	/// Zero-copy GPU buffer (Linux CUDA NV12, NVDEC output / NVENC input).
-	#[cfg(all(target_os = "linux", any(feature = "nvenc", feature = "nvdec")))]
+	/// Zero-copy GPU buffer (Linux CUDA NV12). Produced only by the NVDEC
+	/// decoder, consumed in place by the NVENC encoder.
+	#[cfg(all(target_os = "linux", feature = "nvdec"))]
 	Cuda(cuda::Frame),
 	/// CPU-resident planar I420.
 	I420(I420),
@@ -41,7 +42,7 @@ impl Frame {
 			Frame::Surface(s) => s.width,
 			#[cfg(target_os = "windows")]
 			Frame::Texture(t) => t.width,
-			#[cfg(all(target_os = "linux", any(feature = "nvenc", feature = "nvdec")))]
+			#[cfg(all(target_os = "linux", feature = "nvdec"))]
 			Frame::Cuda(c) => c.width,
 			Frame::I420(i) => i.width,
 		}
@@ -53,7 +54,7 @@ impl Frame {
 			Frame::Surface(s) => s.height,
 			#[cfg(target_os = "windows")]
 			Frame::Texture(t) => t.height,
-			#[cfg(all(target_os = "linux", any(feature = "nvenc", feature = "nvdec")))]
+			#[cfg(all(target_os = "linux", feature = "nvdec"))]
 			Frame::Cuda(c) => c.height,
 			Frame::I420(i) => i.height,
 		}
@@ -66,7 +67,7 @@ impl Frame {
 			Frame::Surface(s) => Ok(Cow::Owned(s.download_i420()?)),
 			#[cfg(target_os = "windows")]
 			Frame::Texture(t) => Ok(Cow::Owned(t.download_i420()?)),
-			#[cfg(all(target_os = "linux", any(feature = "nvenc", feature = "nvdec")))]
+			#[cfg(all(target_os = "linux", feature = "nvdec"))]
 			Frame::Cuda(c) => Ok(Cow::Owned(c.download_i420()?)),
 			Frame::I420(i) => Ok(Cow::Borrowed(i)),
 		}
@@ -371,7 +372,7 @@ pub(crate) mod macos {
 	}
 }
 
-#[cfg(all(target_os = "linux", any(feature = "nvenc", feature = "nvdec")))]
+#[cfg(all(target_os = "linux", feature = "nvdec"))]
 pub(crate) mod cuda {
 	use std::sync::Arc;
 

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -27,6 +27,9 @@ pub(crate) enum Frame {
 	/// Zero-copy GPU texture (Windows Direct3D11 NV12).
 	#[cfg(target_os = "windows")]
 	Texture(d3d11::Texture),
+	/// Zero-copy GPU buffer (Linux CUDA NV12, NVDEC output / NVENC input).
+	#[cfg(all(target_os = "linux", any(feature = "nvenc", feature = "nvdec")))]
+	Cuda(cuda::Frame),
 	/// CPU-resident planar I420.
 	I420(I420),
 }
@@ -38,6 +41,8 @@ impl Frame {
 			Frame::Surface(s) => s.width,
 			#[cfg(target_os = "windows")]
 			Frame::Texture(t) => t.width,
+			#[cfg(all(target_os = "linux", any(feature = "nvenc", feature = "nvdec")))]
+			Frame::Cuda(c) => c.width,
 			Frame::I420(i) => i.width,
 		}
 	}
@@ -48,6 +53,8 @@ impl Frame {
 			Frame::Surface(s) => s.height,
 			#[cfg(target_os = "windows")]
 			Frame::Texture(t) => t.height,
+			#[cfg(all(target_os = "linux", any(feature = "nvenc", feature = "nvdec")))]
+			Frame::Cuda(c) => c.height,
 			Frame::I420(i) => i.height,
 		}
 	}
@@ -59,6 +66,8 @@ impl Frame {
 			Frame::Surface(s) => Ok(Cow::Owned(s.download_i420()?)),
 			#[cfg(target_os = "windows")]
 			Frame::Texture(t) => Ok(Cow::Owned(t.download_i420()?)),
+			#[cfg(all(target_os = "linux", any(feature = "nvenc", feature = "nvdec")))]
+			Frame::Cuda(c) => Ok(Cow::Owned(c.download_i420()?)),
 			Frame::I420(i) => Ok(Cow::Borrowed(i)),
 		}
 	}
@@ -248,7 +257,7 @@ impl I420 {
 
 /// Interleave separate U and V planes into a packed NV12 chroma plane
 /// (`u[i], v[i]` -> `uv[2i], uv[2i+1]`). `uv` must be twice the length of `u`.
-#[cfg(target_os = "windows")]
+#[cfg(any(target_os = "windows", all(target_os = "linux", feature = "nvenc")))]
 pub(crate) fn interleave_uv(u: &[u8], v: &[u8], uv: &mut [u8]) {
 	for (pair, (u, v)) in uv.chunks_exact_mut(2).zip(u.iter().zip(v)) {
 		pair[0] = *u;
@@ -358,6 +367,123 @@ pub(crate) mod macos {
 	impl Drop for UnlockGuard<'_> {
 		fn drop(&mut self) {
 			unsafe { CVPixelBufferUnlockBaseAddress(self.0, LOCK_READ_ONLY) };
+		}
+	}
+}
+
+#[cfg(all(target_os = "linux", any(feature = "nvenc", feature = "nvdec")))]
+pub(crate) mod cuda {
+	use std::sync::Arc;
+
+	use cudarc::driver::{CudaContext, result};
+
+	use super::I420;
+	use crate::Error;
+
+	/// An owned device allocation. Plain `cuMemAlloc` on purpose: NVENC's
+	/// resource registration rejects stream-ordered pool memory
+	/// (`cuMemAllocAsync`), which is what cudarc's `CudaSlice` uses on any GPU
+	/// with memory-pool support.
+	struct Buffer {
+		ctx: Arc<CudaContext>,
+		ptr: cudarc::driver::sys::CUdeviceptr,
+		len: usize,
+	}
+
+	impl Drop for Buffer {
+		fn drop(&mut self) {
+			// Drop may run on any thread; freeing needs the context current.
+			if self.ctx.bind_to_thread().is_ok() {
+				// SAFETY: the pointer came from `malloc_sync` and is freed once.
+				let _ = unsafe { result::free_sync(self.ptr) };
+			}
+		}
+	}
+
+	/// A GPU NV12 frame in CUDA device memory: NVDEC's output and NVENC's
+	/// zero-copy input. One buffer holds both planes at a shared row `pitch`:
+	/// `height` luma rows, then `height / 2` interleaved-UV rows. Cloning bumps
+	/// refcounts (no pixel copy), which keeps decode -> encode on the GPU.
+	///
+	/// Both codecs use the device's primary CUDA context (`CudaContext::new`
+	/// retains it), so a frame decoded by NVDEC is directly addressable by NVENC.
+	#[derive(Clone)]
+	pub(crate) struct Frame {
+		buf: Arc<Buffer>,
+		pub(crate) width: u32,
+		pub(crate) height: u32,
+		/// Row pitch in bytes of both planes (>= `width`).
+		pub(crate) pitch: u32,
+	}
+
+	impl Frame {
+		/// Allocate an NV12 buffer for `width` x `height` (both even) at row
+		/// pitch `pitch`. Uninitialized: the caller copies the full extent in.
+		pub(crate) fn alloc(ctx: &Arc<CudaContext>, width: u32, height: u32, pitch: u32) -> Result<Self, Error> {
+			debug_assert!(pitch >= width && width % 2 == 0 && height % 2 == 0);
+			let len = pitch as usize * height as usize * 3 / 2;
+			ctx.bind_to_thread()
+				.map_err(|e| Error::Codec(anyhow::anyhow!("CUDA bind: {e:?}")))?;
+			// SAFETY: a plain device allocation; ownership lands in `Buffer`,
+			// whose Drop frees it exactly once.
+			let ptr = unsafe { result::malloc_sync(len) }
+				.map_err(|e| Error::Codec(anyhow::anyhow!("CUDA alloc of {len} bytes: {e:?}")))?;
+			Ok(Self {
+				buf: Arc::new(Buffer {
+					ctx: ctx.clone(),
+					ptr,
+					len,
+				}),
+				width,
+				height,
+				pitch,
+			})
+		}
+
+		/// The raw device pointer, for FFI (the NVDEC copy destination, the
+		/// NVENC resource registration). Valid while `self` is alive.
+		pub(crate) fn device_ptr(&self) -> u64 {
+			self.buf.ptr
+		}
+
+		/// Download and de-pitch to packed I420 (the CPU fallback: a software
+		/// encoder, or a caller that wants bytes).
+		pub(crate) fn download_i420(&self) -> Result<I420, Error> {
+			self.buf
+				.ctx
+				.bind_to_thread()
+				.map_err(|e| Error::Codec(anyhow::anyhow!("CUDA bind: {e:?}")))?;
+			let mut host = vec![0u8; self.buf.len];
+			// SAFETY: the buffer is `len` bytes of device memory and stays alive
+			// for the synchronous copy.
+			unsafe { result::memcpy_dtoh_sync(&mut host, self.buf.ptr) }
+				.map_err(|e| Error::Codec(anyhow::anyhow!("CUDA download: {e:?}")))?;
+
+			let (w, h) = (self.width as usize, self.height as usize);
+			let (cw, ch) = (w / 2, h / 2);
+			let pitch = self.pitch as usize;
+
+			let mut data = vec![0u8; I420::len(self.width, self.height)];
+			let (luma, chroma) = data.split_at_mut(w * h);
+			let (u_dst, v_dst) = chroma.split_at_mut(cw * ch);
+
+			for row in 0..h {
+				luma[row * w..row * w + w].copy_from_slice(&host[row * pitch..row * pitch + w]);
+			}
+			let uv_base = pitch * h;
+			for row in 0..ch {
+				let src = &host[uv_base + row * pitch..uv_base + row * pitch + w];
+				for col in 0..cw {
+					u_dst[row * cw + col] = src[col * 2];
+					v_dst[row * cw + col] = src[col * 2 + 1];
+				}
+			}
+
+			Ok(I420 {
+				width: self.width,
+				height: self.height,
+				data,
+			})
 		}
 	}
 }

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -18,20 +18,24 @@
 //!     front, but the camera opens only while a subscriber is watching and is
 //!     released when the last one leaves.
 //!   - [`encode::Producer`] publishes packets you encoded yourself.
-//! - [`decode`] subscribes to an H.264 or H.265 track and decodes it to raw I420
-//!   frames with a native backend (VideoToolbox on macOS, Media Foundation / DXVA
-//!   on Windows, openh264 software fallback for H.264). [`decode::Consumer`] is
-//!   the mirror of `moq-audio`'s `AudioConsumer`.
+//! - [`decode`] subscribes to an H.264 or H.265 track and decodes it to raw
+//!   frames with a native backend (VideoToolbox on macOS, Media Foundation /
+//!   DXVA on Windows, NVDEC on Linux, openh264 software fallback for H.264).
+//!   [`decode::Consumer`] is the mirror of `moq-audio`'s `AudioConsumer`. An
+//!   NVDEC frame stays in CUDA memory and feeds [`encode::Encoder::encode`]
+//!   zero-copy (the transcode path), scaled in hardware via
+//!   [`decode::Config::resize`].
 //!
 //! ## API stability
 //!
 //! The public API is codec-agnostic: no public type, signature, or error
-//! variant names a backend (openh264 / VideoToolbox / NVENC) or a capture
-//! implementation. [`encode::Encoder`] takes raw RGBA bytes, [`decode::Consumer`]
-//! returns raw I420, and the camera capture path stays internal. So swapping or
-//! bumping any backend crate is not a breaking change for consumers. Config
-//! structs are `#[non_exhaustive]`: build them via `default()`/`new()` and set
-//! fields, so new options stay additive.
+//! variant names a backend (openh264 / VideoToolbox / NVENC / NVDEC) or a
+//! capture implementation. [`encode::Encoder`] takes raw RGBA bytes,
+//! [`decode::Consumer`] returns opaque [`decode::Frame`]s (CPU I420 on demand,
+//! GPU-resident when hardware decoded), and the camera capture path stays
+//! internal. So swapping or bumping any backend crate is not a breaking change
+//! for consumers. Config structs are `#[non_exhaustive]`: build them via
+//! `default()`/`new()` and set fields, so new options stay additive.
 
 pub mod capture;
 pub mod decode;


### PR DESCRIPTION
Follow-up to #2140 (now merged into dev). Adds NVDEC hardware decode to `moq-video` and keeps the transcode pipeline fully GPU-resident: on an NVIDIA GPU, NVDEC decodes and scales in hardware and NVENC encodes the CUDA frame in place. No CPU copies anywhere between decode and encode.

## How it works

- **`moq-nvenc`**: new `cuvid` module, a dlopen'd NVDEC function table (`cuvid::Api::get()`). The vendored `sys` bindings declare the cuvid functions in an `extern "C"` block, which would make the linker require `libnvcuvid`; the table resolves them at runtime instead, so GPU-less builders still link and driverless hosts fall back. Unlike the encode side's panicking lazy static, `Api::get()` returns a `Result`.
- **`nvdec` decode backend** (new default-on `nvdec` feature in `moq-video`): drives the cuvid parser synchronously (`CUVID_PKT_ENDOFPICTURE` + zero display delay, so callbacks fire inside the parse call and one AU in means one frame out). Timestamps ride the parser (`ulClockRate` = 1 MHz), so they stay correct across reordering. Scaling happens **in the decoder**: `decode::Config::resize` maps to cuvid's target size, so frames come out already at the rung resolution for free.
- **Frame lifetime**: each mapped cuvid surface is copied device-to-device into an owned buffer and unmapped immediately (the surface pool is small and fixed). The buffer is a plain `cuMemAlloc`: NVENC's `NvEncRegisterResource` rejects stream-ordered pool memory (`cuMemAllocAsync`), which is what cudarc's `CudaSlice` uses on modern GPUs. Decode and encode share the device primary CUDA context, so no cross-context copies.
- **NVENC**: the session input format switches from IYUV to NV12 (NVENC's native layout, and what NVDEC emits). A `Frame::Cuda` is registered as an external resource and encoded in place; the CPU path interleaves I420 chroma during the pitched write as before.
- **`moq-transcode`**: the pipeline asks the decoder for the rung size and only falls back to the CPU `Scaler` when frames come back at another size (software decode, VT/MF). GPU frames flow `decoder.decode() -> encoder.encode()` untouched.
- **`libmoq`**: flattens each delivered frame to CPU I420 once at delivery (the C ABI hands out a stable byte pointer), so NVDEC offload works for C consumers too. The C ABI itself is unchanged.

## Public API changes (unreleased crates, hence dev)

- `moq_video::decode::Frame.data` (pub field) **removed**; pixels are now private. New `decode::Frame::into_i420(self) -> Result<Bytes>` downloads/packs on demand. **Breaking**, but the decode surface shipped on dev and is unreleased.
- `moq_video::decode::Decoder::new(catalog, &Kind)` -> `new(catalog, &Config)` (**breaking**), so decoder knobs stay additive.
- `moq_video::decode::Config` gains `resize: Option<(u32, u32)>` (additive, `#[non_exhaustive]`).
- New `moq_video::encode::Encoder::encode(&mut self, frame: &decode::Frame, keyframe: bool)`, the transcode input path.
- `moq-nvenc` gains the public `cuvid` module.
- New cargo features: `moq-video/nvdec` (default-on; forwarded in `moq-transcode`, `moq-cli`, enabled in `libmoq`).

`pub(crate)` internals (the decode `Backend` trait now carries timestamps and returns GPU-capable frames, `frame::Frame::Cuda`, `Encoder::encode_raw`) are not public surface.

## Testing (validated on a Linux RTX 3070 Ti, driver 595.71.05)

- `nvdec_h264_round_trip`: openh264 -> NVDEC, per-plane MAE vs the input picture, timestamps assert 1:1 passthrough.
- `nvdec_resize_scales_output`: decoder-side scaling vs a reference downscale.
- `nvdec_h265_round_trip`: NVENC HEVC -> NVDEC.
- `nvdec_to_nvenc_zero_copy`: asserts every decoded frame is CUDA-resident, re-encodes via the registered-resource path, and verifies the result with a software decode.
- `moq-transcode::end_to_end_hardware`: the full broadcast pipeline with `Kind::Hardware` on both ends (fetch path, all 5 frames through).
- All tests skip cleanly without the NVIDIA driver (verified by running without `LD_LIBRARY_PATH` in the Nix shell, where the driver libs are invisible); `missing_driver_errors_instead_of_panicking` covers the fallback.
- Workspace `cargo clippy --all-targets -D warnings` and `cargo fmt --check` pass. The macOS/Windows decode backends were updated for the trait change and need CI to compile-check.

(Written by Claude Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)