### PR TITLE
Path memory sharing + 32 max parts enforcement

### DIFF
--- a/js/net/src/ietf/namespace.ts
+++ b/js/net/src/ietf/namespace.ts
@@ -2,12 +2,13 @@ import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
 
 export async function encode(w: Writer, namespace: Path.Valid): Promise<void> {
-	if (namespace === "") {
-		await w.u53(0);
-		return;
+	const parts = Path.parts(namespace);
+
+	// The IETF draft limits namespaces to 32 parts.
+	if (parts.length > Path.MAX_PARTS) {
+		throw new Error(`namespace exceeds ${Path.MAX_PARTS} parts`);
 	}
 
-	const parts = namespace.split("/");
 	await w.u53(parts.length);
 	for (const part of parts) {
 		await w.string(part);
@@ -15,8 +16,15 @@ export async function encode(w: Writer, namespace: Path.Valid): Promise<void> {
 }
 
 export async function decode(r: Reader): Promise<Path.Valid> {
-	const parts: string[] = [];
 	const count = await r.u53();
+
+	// The IETF draft limits namespaces to 32 parts. Reject before reading them so a
+	// hostile count can't make us buffer unbounded parts.
+	if (count > Path.MAX_PARTS) {
+		throw new Error(`namespace exceeds ${Path.MAX_PARTS} parts`);
+	}
+
+	const parts: string[] = [];
 	for (let i = 0; i < count; i++) {
 		parts.push(await r.string());
 	}

--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -46,7 +46,7 @@ export class Announce {
 
 	static async #decode(r: Reader, version: Version): Promise<Announce> {
 		const active = await r.bool();
-		const suffix = Path.from(await r.string());
+		const suffix = Path.decode(await r.string());
 
 		let hops: Origin[] = [];
 		switch (version) {
@@ -116,7 +116,7 @@ export class AnnounceInterest {
 	}
 
 	static async #decode(r: Reader, version: Version): Promise<AnnounceInterest> {
-		const prefix = Path.from(await r.string());
+		const prefix = Path.decode(await r.string());
 		let excludeHop = 0n;
 		switch (version) {
 			case Version.DRAFT_01:
@@ -170,7 +170,7 @@ export class AnnounceInit {
 		const count = await r.u53();
 		const suffixes: Path.Valid[] = [];
 		for (let i = 0; i < count; i++) {
-			suffixes.push(Path.from(await r.string()));
+			suffixes.push(Path.decode(await r.string()));
 		}
 		return new AnnounceInit(suffixes);
 	}

--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -25,7 +25,7 @@ export class Announce {
 
 	async #encode(w: Writer, version: Version) {
 		await w.bool(this.active);
-		await w.string(this.suffix);
+		await w.string(Path.encode(this.suffix));
 
 		switch (version) {
 			case Version.DRAFT_01:
@@ -102,7 +102,7 @@ export class AnnounceInterest {
 	}
 
 	async #encode(w: Writer, version: Version) {
-		await w.string(this.prefix);
+		await w.string(Path.encode(this.prefix));
 		switch (version) {
 			case Version.DRAFT_01:
 			case Version.DRAFT_02:
@@ -162,7 +162,7 @@ export class AnnounceInit {
 	async #encode(w: Writer) {
 		await w.u53(this.suffixes.length);
 		for (const path of this.suffixes) {
-			await w.string(path);
+			await w.string(Path.encode(path));
 		}
 	}
 

--- a/js/net/src/lite/fetch.ts
+++ b/js/net/src/lite/fetch.ts
@@ -27,7 +27,7 @@ export class Fetch {
 	}
 
 	async #encode(w: Writer) {
-		await w.string(this.broadcast);
+		await w.string(Path.encode(this.broadcast));
 		await w.string(this.track);
 		await w.u8(this.priority);
 		await w.u53(this.group);

--- a/js/net/src/lite/fetch.ts
+++ b/js/net/src/lite/fetch.ts
@@ -34,7 +34,7 @@ export class Fetch {
 	}
 
 	static async #decode(r: Reader): Promise<Fetch> {
-		const broadcast = Path.from(await r.string());
+		const broadcast = Path.decode(await r.string());
 		const track = await r.string();
 		const priority = await r.u8();
 		const group = await r.u53();

--- a/js/net/src/lite/subscribe.ts
+++ b/js/net/src/lite/subscribe.ts
@@ -108,7 +108,7 @@ export class Subscribe {
 
 	async #encode(w: Writer, version: Version) {
 		await w.u62(this.id);
-		await w.string(this.broadcast);
+		await w.string(Path.encode(this.broadcast));
 		await w.string(this.track);
 		await w.u8(this.priority);
 

--- a/js/net/src/lite/subscribe.ts
+++ b/js/net/src/lite/subscribe.ts
@@ -127,7 +127,7 @@ export class Subscribe {
 
 	static async #decode(r: Reader, version: Version): Promise<Subscribe> {
 		const id = await r.u62();
-		const broadcast = Path.from(await r.string());
+		const broadcast = Path.decode(await r.string());
 		const track = await r.string();
 		const priority = await r.u8();
 

--- a/js/net/src/lite/track.ts
+++ b/js/net/src/lite/track.ts
@@ -17,7 +17,7 @@ export class Track {
 	}
 
 	async #encode(w: Writer) {
-		await w.string(this.broadcast);
+		await w.string(Path.encode(this.broadcast));
 		await w.string(this.track);
 	}
 

--- a/js/net/src/lite/track.ts
+++ b/js/net/src/lite/track.ts
@@ -22,7 +22,7 @@ export class Track {
 	}
 
 	static async #decode(r: Reader): Promise<Track> {
-		const broadcast = Path.from(await r.string());
+		const broadcast = Path.decode(await r.string());
 		const track = await r.string();
 		return new Track({ broadcast, track });
 	}

--- a/js/net/src/path.test.ts
+++ b/js/net/src/path.test.ts
@@ -201,3 +201,9 @@ test("decode enforces the max part count", () => {
 	expect(Path.decode(atLimit)).toBe(atLimit as Path.Valid);
 	expect(() => Path.decode(`${atLimit}/extra`)).toThrow();
 });
+
+test("encode enforces the max part count", () => {
+	const atLimit = Array.from({ length: Path.MAX_PARTS }, (_, i) => `${i}`).join("/") as Path.Valid;
+	expect(Path.encode(atLimit)).toBe(atLimit);
+	expect(() => Path.encode(`${atLimit}/extra` as Path.Valid)).toThrow();
+});

--- a/js/net/src/path.test.ts
+++ b/js/net/src/path.test.ts
@@ -189,3 +189,15 @@ test("from sanitizes multiple arguments with slashes", () => {
 	expect(Path.from("/foo/", "/bar/", "/baz/")).toBe("foo/bar/baz" as Path.Valid);
 	expect(Path.from("foo//", "//bar", "baz")).toBe("foo/bar/baz" as Path.Valid);
 });
+
+test("parts splits a path into its components", () => {
+	expect(Path.parts(Path.from(""))).toEqual([]);
+	expect(Path.parts(Path.from("foo"))).toEqual(["foo"]);
+	expect(Path.parts(Path.from("/foo//bar/"))).toEqual(["foo", "bar"]);
+});
+
+test("decode enforces the max part count", () => {
+	const atLimit = Array.from({ length: Path.MAX_PARTS }, (_, i) => `${i}`).join("/");
+	expect(Path.decode(atLimit)).toBe(atLimit as Path.Valid);
+	expect(() => Path.decode(`${atLimit}/extra`)).toThrow();
+});

--- a/js/net/src/path.ts
+++ b/js/net/src/path.ts
@@ -57,6 +57,16 @@ export function parts(path: Valid): string[] {
  */
 export function decode(raw: string): Valid {
 	const path = from(raw);
+	return encode(path);
+}
+
+/**
+ * Validate a path before writing it to the wire, enforcing {@link MAX_PARTS}.
+ *
+ * Throws when the path has too many parts; use at wire encode sites so we never
+ * emit a path the remote side is required to reject.
+ */
+export function encode(path: Valid): Valid {
 	if (parts(path).length > MAX_PARTS) {
 		throw new Error(`path exceeds ${MAX_PARTS} parts`);
 	}

--- a/js/net/src/path.ts
+++ b/js/net/src/path.ts
@@ -30,11 +30,37 @@
  */
 export type Valid = string & { __brand: "Name" };
 
+/**
+ * Maximum number of slash-separated parts in a path.
+ *
+ * Matches the IETF moq-transport limit of 32 fields in a namespace tuple.
+ * moq-lite enforces the same bound when decoding paths off the wire.
+ */
+export const MAX_PARTS = 32;
+
 /** Build a path from one or more components, joining with "/" and trimming redundant slashes. */
 export function from(...paths: string[]): Valid {
 	// Join paths with "/" and then remove leading and trailing slashes, and collapse multiple slashes into one.
 	const joined = paths.join("/");
 	return joined.replace(/\/+/g, "/").replace(/^\/+/, "").replace(/\/+$/, "") as Valid;
+}
+
+/** Split a path into its slash-separated parts. The empty path has no parts. */
+export function parts(path: Valid): string[] {
+	return path === "" ? [] : path.split("/");
+}
+
+/**
+ * Validate an untrusted wire string as a path, enforcing {@link MAX_PARTS}.
+ *
+ * Throws when the path has too many parts; use at wire decode sites.
+ */
+export function decode(raw: string): Valid {
+	const path = from(raw);
+	if (parts(path).length > MAX_PARTS) {
+		throw new Error(`path exceeds ${MAX_PARTS} parts`);
+	}
+	return path;
 }
 
 /**

--- a/rs/moq-net/src/ietf/namespace.rs
+++ b/rs/moq-net/src/ietf/namespace.rs
@@ -4,22 +4,16 @@ use super::Version;
 
 /// Helper function to encode namespace as tuple of strings
 pub fn encode_namespace<W: bytes::BufMut>(w: &mut W, namespace: &Path, version: Version) -> Result<(), EncodeError> {
-	// Split the path by '/' to get individual parts
-	let path_str = namespace.as_str();
-	if path_str.is_empty() {
-		0u64.encode(w, version)?;
-	} else {
-		let parts: Vec<&str> = path_str.split('/').collect();
+	let parts: Vec<&str> = namespace.parts().collect();
 
-		// The IETF draft limits namespaces to 32 parts.
-		if parts.len() > 32 {
-			return Err(BoundsExceeded.into());
-		}
+	// The IETF draft limits namespaces to 32 parts.
+	if parts.len() > Path::MAX_PARTS {
+		return Err(BoundsExceeded.into());
+	}
 
-		(parts.len() as u64).encode(w, version)?;
-		for part in parts {
-			part.encode(w, version)?;
-		}
+	(parts.len() as u64).encode(w, version)?;
+	for part in parts {
+		part.encode(w, version)?;
 	}
 	Ok(())
 }
@@ -33,7 +27,7 @@ pub fn decode_namespace<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Pa
 	}
 
 	// The IETF draft limits namespaces to 32 parts.
-	if count > 32 {
+	if count > Path::MAX_PARTS as u64 {
 		return Err(DecodeError::BoundsExceeded);
 	}
 

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -732,7 +732,8 @@ impl OriginProducer {
 	/// When the active broadcast closes, the backup that wins the same ordering is promoted and
 	/// reannounced. Backups that close before being promoted are silently dropped.
 	///
-	/// Returns false if the broadcast is not allowed to be published.
+	/// Returns false if the broadcast is not allowed to be published, or if the full
+	/// path exceeds [`Path::MAX_PARTS`].
 	pub fn publish_broadcast(&self, path: impl AsPath, broadcast: BroadcastConsumer) -> bool {
 		let path = path.as_path();
 
@@ -747,6 +748,13 @@ impl OriginProducer {
 		};
 
 		let full = self.root.join(&path);
+
+		// A decoded announce prefix and suffix are each within the wire limit, but their
+		// join might not be. Enforcing here bounds the tree depth and guarantees the path
+		// can be re-encoded when forwarded.
+		if full.parts().count() > Path::MAX_PARTS {
+			return false;
+		}
 
 		root.lock().publish(&full, &broadcast, &rest);
 		let root = root.clone();
@@ -1716,6 +1724,25 @@ mod tests {
 		assert!(!limited_producer.publish_broadcast("notallowed", broadcast.consume()));
 		assert!(!limited_producer.publish_broadcast("allowed", broadcast.consume())); // Parent of allowed path
 		assert!(!limited_producer.publish_broadcast("other/path", broadcast.consume()));
+	}
+
+	#[tokio::test]
+	async fn test_publish_max_parts() {
+		let origin = Origin::random().produce();
+		let broadcast = Broadcast::new().produce();
+
+		let at_limit = (0..Path::MAX_PARTS)
+			.map(|i| i.to_string())
+			.collect::<Vec<_>>()
+			.join("/");
+		assert!(origin.publish_broadcast(at_limit.as_str(), broadcast.consume()));
+
+		let too_deep = format!("{at_limit}/extra");
+		assert!(!origin.publish_broadcast(too_deep.as_str(), broadcast.consume()));
+
+		// The root counts toward the limit; a joined path past 32 parts is rejected.
+		let rooted = origin.with_root("root").expect("wildcard allows any root");
+		assert!(!rooted.publish_broadcast(at_limit.as_str(), broadcast.consume()));
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/path.rs
+++ b/rs/moq-net/src/path.rs
@@ -1,5 +1,5 @@
-use std::borrow::Cow;
 use std::fmt::{self, Display};
+use std::sync::Arc;
 
 use crate::coding::{Decode, DecodeError, Encode, EncodeError};
 
@@ -9,7 +9,7 @@ pub type PathOwned = Path<'static>;
 /// A trait for types that can be converted to a `Path`.
 ///
 /// When providing a String/str, any leading/trailing slashes are trimmed and multiple consecutive slashes are collapsed.
-/// When already a Path, normalization is skipped as a reference is returned.
+/// When already a Path, normalization is skipped and the underlying buffer is reused without copying.
 pub trait AsPath {
 	fn as_path(&self) -> Path<'_>;
 }
@@ -22,14 +22,14 @@ impl<'a> AsPath for &'a str {
 
 impl<'a> AsPath for &'a Path<'a> {
 	fn as_path(&self) -> Path<'a> {
-		// We don't normalize again nor do we make a copy.
-		Path(Cow::Borrowed(self.as_str()))
+		// We don't normalize again nor do we copy the bytes.
+		self.borrow()
 	}
 }
 
 impl AsPath for Path<'_> {
 	fn as_path(&self) -> Path<'_> {
-		Path(Cow::Borrowed(self.0.as_ref()))
+		self.borrow()
 	}
 }
 
@@ -45,14 +45,29 @@ impl<'a> AsPath for &'a String {
 	}
 }
 
+/// A borrowed slice of the path, or a suffix of a shared reference-counted buffer.
+///
+/// The `Shared` variant is what makes owned paths cheap: cloning bumps a refcount and
+/// suffix operations (strip_prefix, next_part) only advance `start`, so one allocation
+/// serves every copy of a path as it fans out to consumers.
+#[derive(Clone)]
+enum Repr<'a> {
+	Borrowed(&'a str),
+	Shared { buf: Arc<str>, start: usize },
+}
+
 /// A broadcast path that provides safe prefix matching operations.
 ///
-/// This type wraps a String but provides path-aware operations that respect
+/// This type wraps a string but provides path-aware operations that respect
 /// delimiter boundaries, preventing issues like "foo" matching "foobar".
 ///
 /// Paths are automatically trimmed of leading and trailing slashes on creation,
 /// making all slashes implicit at boundaries.
 /// All paths are RELATIVE; you cannot join with a leading slash to make an absolute path.
+///
+/// Owned paths ([`PathOwned`]) share one reference-counted allocation: cloning, converting
+/// a shared path with [`Path::to_owned`], and suffix operations like [`Path::strip_prefix`]
+/// do not copy the underlying bytes.
 ///
 /// # Examples
 /// ```
@@ -71,9 +86,8 @@ impl<'a> AsPath for &'a String {
 /// let joined = base.join("users");
 /// assert_eq!(joined.as_str(), "api/v1/users");
 /// ```
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
-pub struct Path<'a>(Cow<'a, str>);
+#[derive(Clone)]
+pub struct Path<'a>(Repr<'a>);
 
 impl<'a> Path<'a> {
 	/// Create a new Path from a string slice.
@@ -91,10 +105,24 @@ impl<'a> Path<'a> {
 				.filter(|s| !s.is_empty())
 				.collect::<Vec<_>>()
 				.join("/");
-			Self(Cow::Owned(normalized))
+			Self(Repr::Shared {
+				buf: normalized.into(),
+				start: 0,
+			})
 		} else {
 			// No normalization needed - use borrowed string
-			Self(Cow::Borrowed(trimmed))
+			Self(Repr::Borrowed(trimmed))
+		}
+	}
+
+	// A copy of this path skipping the first `n` bytes, reusing the shared buffer when possible.
+	fn slice_from(&'a self, n: usize) -> Path<'a> {
+		match &self.0 {
+			Repr::Borrowed(s) => Path(Repr::Borrowed(&s[n..])),
+			Repr::Shared { buf, start } => Path(Repr::Shared {
+				buf: buf.clone(),
+				start: start + n,
+			}),
 		}
 	}
 
@@ -126,17 +154,18 @@ impl<'a> Path<'a> {
 			return true;
 		}
 
-		if !self.0.starts_with(prefix.as_str()) {
+		let s = self.as_str();
+		if !s.starts_with(prefix.as_str()) {
 			return false;
 		}
 
 		// Check if the prefix is the exact match
-		if self.0.len() == prefix.len() {
+		if s.len() == prefix.len() {
 			return true;
 		}
 
 		// Otherwise, ensure the character after the prefix is a delimiter
-		self.0.as_bytes().get(prefix.len()) == Some(&b'/')
+		s.as_bytes().get(prefix.len()) == Some(&b'/')
 	}
 
 	pub fn strip_prefix(&'a self, prefix: impl AsPath) -> Option<Path<'a>> {
@@ -146,64 +175,85 @@ impl<'a> Path<'a> {
 			return Some(self.borrow());
 		}
 
-		if !self.0.starts_with(prefix.as_str()) {
+		let s = self.as_str();
+		if !s.starts_with(prefix.as_str()) {
 			return None;
 		}
 
 		// Check if the prefix is the exact match
-		if self.0.len() == prefix.len() {
-			return Some(Path(Cow::Borrowed("")));
+		if s.len() == prefix.len() {
+			return Some(Path::empty());
 		}
 
 		// Otherwise, ensure the character after the prefix is a delimiter
-		if self.0.as_bytes().get(prefix.len()) != Some(&b'/') {
+		if s.as_bytes().get(prefix.len()) != Some(&b'/') {
 			return None;
 		}
 
-		Some(Path(Cow::Borrowed(&self.0[prefix.len() + 1..])))
+		Some(self.slice_from(prefix.len() + 1))
 	}
 
 	/// Strip the directory component of the path, if any, and return the rest of the path.
 	pub fn next_part(&'a self) -> Option<(&'a str, Path<'a>)> {
-		if self.0.is_empty() {
+		let s = self.as_str();
+		if s.is_empty() {
 			return None;
 		}
 
-		if let Some(i) = self.0.find('/') {
-			let dir = &self.0[..i];
-			let rest = Path(Cow::Borrowed(&self.0[i + 1..]));
-			Some((dir, rest))
+		if let Some(i) = s.find('/') {
+			Some((&s[..i], self.slice_from(i + 1)))
 		} else {
-			Some((&self.0, Path(Cow::Borrowed(""))))
+			Some((s, Path::empty()))
 		}
 	}
 
 	pub fn as_str(&self) -> &str {
-		&self.0
+		match &self.0 {
+			Repr::Borrowed(s) => s,
+			Repr::Shared { buf, start } => &buf[*start..],
+		}
 	}
 
 	pub fn empty() -> Path<'static> {
-		Path(Cow::Borrowed(""))
+		Path(Repr::Borrowed(""))
 	}
 
 	pub fn is_empty(&self) -> bool {
-		self.0.is_empty()
+		self.as_str().is_empty()
 	}
 
 	pub fn len(&self) -> usize {
-		self.0.len()
+		self.as_str().len()
 	}
 
 	pub fn to_owned(&self) -> PathOwned {
-		Path(Cow::Owned(self.0.to_string()))
+		match &self.0 {
+			Repr::Borrowed("") => Path::empty(),
+			Repr::Borrowed(s) => Path(Repr::Shared {
+				buf: Arc::from(*s),
+				start: 0,
+			}),
+			Repr::Shared { buf, start } => Path(Repr::Shared {
+				buf: buf.clone(),
+				start: *start,
+			}),
+		}
 	}
 
 	pub fn into_owned(self) -> PathOwned {
-		Path(Cow::Owned(self.0.to_string()))
+		match self.0 {
+			Repr::Borrowed("") => Path::empty(),
+			Repr::Borrowed(s) => Path(Repr::Shared {
+				buf: Arc::from(s),
+				start: 0,
+			}),
+			Repr::Shared { buf, start } => Path(Repr::Shared { buf, start }),
+		}
 	}
 
+	/// A copy of this path bound to `self`'s lifetime, without copying the underlying bytes.
 	pub fn borrow(&'a self) -> Path<'a> {
-		Path(Cow::Borrowed(&self.0))
+		self.slice_from(0)
 	}
 
 	/// Join this path with another path component.
@@ -222,15 +272,58 @@ impl<'a> Path<'a> {
 	pub fn join(&self, other: impl AsPath) -> PathOwned {
 		let other = other.as_path();
 
-		if self.0.is_empty() {
-			Path(Cow::Owned(other.0.to_string()))
+		if self.is_empty() {
+			other.to_owned()
 		} else if other.is_empty() {
-			// Technically, we could avoid allocating here, but it's nicer to return a PathOwned.
 			self.to_owned()
 		} else {
 			// Since paths are trimmed, we always need to add a slash
-			Path(Cow::Owned(format!("{}/{}", self.0, other.as_str())))
+			Path(Repr::Shared {
+				buf: format!("{}/{}", self.as_str(), other.as_str()).into(),
+				start: 0,
+			})
 		}
+	}
+}
+
+// Comparisons, ordering, and hashing all go through `as_str()` so a borrowed and a
+// shared path with the same content behave identically (e.g. as map keys).
+impl<'b> PartialEq<Path<'b>> for Path<'_> {
+	fn eq(&self, other: &Path<'b>) -> bool {
+		self.as_str() == other.as_str()
+	}
+}
+
+impl Eq for Path<'_> {}
+
+impl PartialOrd for Path<'_> {
+	fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+		Some(self.cmp(other))
+	}
+}
+
+impl Ord for Path<'_> {
+	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+		self.as_str().cmp(other.as_str())
+	}
+}
+
+impl std::hash::Hash for Path<'_> {
+	fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+		self.as_str().hash(state)
+	}
+}
+
+impl fmt::Debug for Path<'_> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_tuple("Path").field(&self.as_str()).finish()
+	}
+}
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for Path<'_> {
+	fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+		serializer.serialize_str(self.as_str())
 	}
 }
 
@@ -249,43 +342,25 @@ impl<'a> From<&'a String> for Path<'a> {
 
 impl Default for Path<'_> {
 	fn default() -> Self {
-		Self(Cow::Borrowed(""))
+		Path::empty()
 	}
 }
 
 impl From<String> for Path<'_> {
 	fn from(s: String) -> Self {
-		// It's annoying that this logic is duplicated, but I couldn't figure out how to reuse Path::new.
-		let trimmed = s.trim_start_matches('/').trim_end_matches('/');
-
-		// Check if we need to normalize (has multiple consecutive slashes)
-		if trimmed.contains("//") {
-			// Only allocate if we actually need to normalize
-			let normalized = trimmed
-				.split('/')
-				.filter(|s| !s.is_empty())
-				.collect::<Vec<_>>()
-				.join("/");
-			Self(Cow::Owned(normalized))
-		} else if trimmed == s {
-			// String is already trimmed and normalized, use it directly
-			Self(Cow::Owned(s))
-		} else {
-			// Need to trim but don't need to normalize internal slashes
-			Self(Cow::Owned(trimmed.to_string()))
-		}
+		Path::new(&s).into_owned()
 	}
 }
 
 impl AsRef<str> for Path<'_> {
 	fn as_ref(&self) -> &str {
-		&self.0
+		self.as_str()
 	}
 }
 
 impl Display for Path<'_> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "{}", self.0)
+		write!(f, "{}", self.as_str())
 	}
 }
 
@@ -954,6 +1029,50 @@ mod tests {
 		let list = PathPrefixes::new(["demo", "anon"]);
 		// Canonical order: sorted by length, then lexicographically
 		assert_eq!(list, vec!["anon".as_path(), "demo".as_path()]);
+	}
+
+	// Pointer-equality checks that owned paths share one allocation through the
+	// clone / to_owned / strip_prefix flow used by origin announce fan-out.
+	#[test]
+	fn test_owned_paths_share_allocation() {
+		let path = Path::new("customer/room/broadcast").to_owned();
+
+		// Cloning an owned path shares the buffer.
+		let cloned = path.clone();
+		assert_eq!(path.as_str().as_ptr(), cloned.as_str().as_ptr());
+
+		// as_path + to_owned (how notify queues a path per consumer) shares too.
+		let requeued = path.as_path().to_owned();
+		assert_eq!(path.as_str().as_ptr(), requeued.as_str().as_ptr());
+
+		// Stripping a prefix from an owned path is offset arithmetic, not a copy.
+		let stripped = path.strip_prefix("customer").unwrap().to_owned();
+		assert_eq!(stripped.as_str(), "room/broadcast");
+		assert_eq!(stripped.as_str().as_ptr(), path.as_str()["customer/".len()..].as_ptr());
+
+		// next_part shares the rest as well.
+		let (dir, rest) = path.next_part().unwrap();
+		assert_eq!(dir, "customer");
+		let rest = rest.to_owned();
+		assert_eq!(rest.as_str().as_ptr(), stripped.as_str().as_ptr());
+
+		// join produces an owned path whose clones share.
+		let joined = path.join("alice");
+		let joined2 = joined.clone();
+		assert_eq!(joined.as_str(), "customer/room/broadcast/alice");
+		assert_eq!(joined.as_str().as_ptr(), joined2.as_str().as_ptr());
+	}
+
+	#[test]
+	fn test_owned_empty_paths() {
+		// Empty paths never allocate and stay well-behaved.
+		let empty = Path::new("").to_owned();
+		assert!(empty.is_empty());
+		assert_eq!(empty, Path::empty());
+
+		let path = Path::new("foo").to_owned();
+		let rest = path.strip_prefix("foo").unwrap().to_owned();
+		assert!(rest.is_empty());
 	}
 
 	#[test]

--- a/rs/moq-net/src/path.rs
+++ b/rs/moq-net/src/path.rs
@@ -90,6 +90,13 @@ enum Repr<'a> {
 pub struct Path<'a>(Repr<'a>);
 
 impl<'a> Path<'a> {
+	/// Maximum number of slash-separated parts in a path.
+	///
+	/// Matches the IETF moq-transport limit of 32 fields in a namespace tuple.
+	/// moq-lite enforces the same bound: encoding or decoding a deeper path fails,
+	/// and publishing one to an origin is rejected.
+	pub const MAX_PARTS: usize = 32;
+
 	/// Create a new Path from a string slice.
 	///
 	/// Leading and trailing slashes are automatically trimmed.
@@ -191,6 +198,24 @@ impl<'a> Path<'a> {
 		}
 
 		Some(self.slice_from(prefix.len() + 1))
+	}
+
+	/// Iterate over the slash-separated parts of the path.
+	///
+	/// The empty path has no parts.
+	///
+	/// # Examples
+	/// ```
+	/// use moq_net::Path;
+	///
+	/// let path = Path::new("foo/bar/baz");
+	/// assert_eq!(path.parts().collect::<Vec<_>>(), ["foo", "bar", "baz"]);
+	/// assert_eq!(Path::empty().parts().count(), 0);
+	/// ```
+	pub fn parts(&self) -> impl Iterator<Item = &str> {
+		// Paths are normalized on creation so there are no empty parts to filter,
+		// except that splitting the empty path yields one empty item.
+		self.as_str().split('/').filter(|part| !part.is_empty())
 	}
 
 	/// Strip the directory component of the path, if any, and return the rest of the path.
@@ -369,7 +394,11 @@ where
 	String: Decode<V>,
 {
 	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
-		Ok(String::decode(r, version)?.into())
+		let path: Path = String::decode(r, version)?.into();
+		if path.parts().count() > Path::MAX_PARTS {
+			return Err(DecodeError::BoundsExceeded);
+		}
+		Ok(path)
 	}
 }
 
@@ -378,6 +407,9 @@ where
 	for<'a> &'a str: Encode<V>,
 {
 	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) -> Result<(), EncodeError> {
+		if self.parts().count() > Path::MAX_PARTS {
+			return Err(EncodeError::BoundsExceeded);
+		}
 		self.as_str().encode(w, version)?;
 		Ok(())
 	}
@@ -1061,6 +1093,44 @@ mod tests {
 		let joined2 = joined.clone();
 		assert_eq!(joined.as_str(), "customer/room/broadcast/alice");
 		assert_eq!(joined.as_str().as_ptr(), joined2.as_str().as_ptr());
+	}
+
+	#[test]
+	fn test_parts() {
+		assert_eq!(Path::empty().parts().count(), 0);
+		assert_eq!(Path::new("foo").parts().collect::<Vec<_>>(), ["foo"]);
+		assert_eq!(Path::new("/foo//bar/").parts().collect::<Vec<_>>(), ["foo", "bar"]);
+	}
+
+	#[test]
+	fn test_wire_max_parts() {
+		use crate::lite::Version;
+
+		let ok = (0..Path::MAX_PARTS)
+			.map(|i| i.to_string())
+			.collect::<Vec<_>>()
+			.join("/");
+		let too_deep = format!("{ok}/extra");
+
+		// Encode enforces the limit.
+		let mut buf = bytes::BytesMut::new();
+		Path::new(&ok).encode(&mut buf, Version::Lite04).unwrap();
+		assert!(matches!(
+			Path::new(&too_deep).encode(&mut bytes::BytesMut::new(), Version::Lite04),
+			Err(EncodeError::BoundsExceeded)
+		));
+
+		// Decode round-trips at the limit.
+		let decoded = Path::decode(&mut buf.freeze(), Version::Lite04).unwrap();
+		assert_eq!(decoded.as_str(), ok);
+
+		// Decode enforces the limit on a raw string that encode would have refused.
+		let mut buf = bytes::BytesMut::new();
+		too_deep.as_str().encode(&mut buf, Version::Lite04).unwrap();
+		assert!(matches!(
+			Path::decode(&mut buf.freeze(), Version::Lite04),
+			Err(DecodeError::BoundsExceeded)
+		));
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

Two changes to `Path` aimed at `OriginProducer`/`OriginConsumer` memory usage and bounds.

### 1. Share one allocation across owned Path copies

Every owned path was its own `String`, and the origin announce fan-out copies the same path many times: the trie leaf (`OriginBroadcast.path`), the cleanup task closure, one pending-map key per consumer, and then every session-layer map downstream (`stats_guards`, subscriber `producers`, ietf `namespaces`, stats entries). That multiplies to O(broadcasts x consumers) heap strings on a relay.

`Path`'s owned representation is now a suffix of a shared `Arc<str>` (buffer + start offset):

- `clone()` and `to_owned()` on an owned path bump a refcount instead of copying.
- `strip_prefix` / `next_part` (the per-consumer root strip in announce fan-out) are offset arithmetic on the shared buffer.
- One `publish_broadcast` allocates the full path once; everything downstream shares it. No changes were needed outside `path.rs`.

Measured with 10k broadcasts x 50 announce consumers (counting allocator, release build):

| | main | this PR |
|---|---|---|
| live heap after publish | 96.3 MiB | 77.7 MiB (-19%) |
| live heap with announces held | 70.7 MiB | 52.1 MiB (-26%) |
| total allocated | 147.9 MiB | 110.6 MiB (-25%) |

Rejected alternatives: `Vec<Arc<String>>` segments (loses contiguous `as_str()` for wire/Ord/Hash; per-part Arc overhead; the `OriginNode` trie already interns segments structurally), global interner (needs GC for churning broadcasts; the dominant waste was same-value copies), tinyvec/array (does not remove the string allocations).

### 2. Enforce 32 max path parts in moq-lite, matching moq-transport

moq-transport caps namespace tuples at 32 fields; moq-lite paths had no depth limit, so a peer could announce arbitrarily deep paths and grow the origin tree without bound.

- `Path::MAX_PARTS` (32) is now shared by both protocols; `Path::parts()` is a new public iterator.
- The lite `Encode`/`Decode` impls reject deeper paths (covers announce/subscribe/fetch/setup uniformly).
- `publish_broadcast` refuses a joined path past the limit: a decoded announce prefix and suffix are each within the wire bound, but their join may not be. This also bounds trie depth and guarantees forwarded paths can re-encode.
- The ietf namespace codec reuses the constant.
- **js/net mirror**: `Path.MAX_PARTS`, `Path.parts`, and a `Path.decode` validator used at every lite wire read site. The JS ietf namespace decoder previously looped an attacker-controlled count with **no bound at all**; it now rejects before reading parts.

**Branch-targeting note**: the lite depth limit rejects wire input that was previously accepted. The ietf side already enforced it (spec compliance), and this reads as DoS hardening, so it targets `main` per "when in doubt"; redirect to `dev` if you consider it a lite contract change. The moq-lite draft should probably document the limit as well (not part of this PR).

## Public API changes

- `Path::MAX_PARTS` (new pub const) and `Path::parts()` (new method): additive.
- `Path` internals reshaped (field was already private); all existing methods keep their signatures. Derived `PartialEq`/`Eq`/`Ord`/`Hash`/`Debug`/`Serialize` replaced with manual impls that go through `as_str()`, matching the previous `Cow` forwarding behavior.
- js/net: `Path.MAX_PARTS`, `Path.parts`, `Path.decode` (all additive).
- Behavior change (both languages): paths deeper than 32 parts now fail wire encode/decode, and `publish_broadcast` returns false for them.

## Test plan

- [x] `cargo test -p moq-net` (383 tests) + doc tests; new tests pin Arc sharing via pointer equality, wire limit round-trip at/past 32 parts, and publish rejection (including root+path join)
- [x] `bun test` js/net (161 tests) incl. new `parts`/`decode` tests; `tsc -b` and biome clean
- [x] `cargo check --workspace`, clippy clean, `RUSTDOCFLAGS=-D warnings cargo doc`
- [x] Before/after memory measurement (table above)

(Written by Claude Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)