### PR TITLE
feat(moq-native): add quic::Client/quic::Server transport config

### DIFF
--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -59,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
 
 	let net = Net {
 		#[cfg(feature = "iroh")]
-		iroh: cli.moq.iroh.clone().bind().await?,
+		iroh: cli.moq.iroh.clone().bind(&cli.moq.client.quic).await?,
 	};
 
 	match cli.direction {

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -34,14 +34,10 @@ pub struct ClientConfig {
 	#[arg(id = "client-backend", long = "client-backend", env = "MOQ_CLIENT_BACKEND")]
 	pub backend: Option<QuicBackend>,
 
-	/// Maximum number of concurrent QUIC streams per connection (both bidi and uni).
-	#[serde(skip_serializing_if = "Option::is_none")]
-	#[arg(
-		id = "client-max-streams",
-		long = "client-max-streams",
-		env = "MOQ_CLIENT_MAX_STREAMS"
-	)]
-	pub max_streams: Option<u64>,
+	/// QUIC transport tuning (`--client-quic-*`): stream limits, GSO, timeouts.
+	#[command(flatten)]
+	#[serde(default)]
+	pub quic: crate::quic::Client,
 
 	/// Restrict the client to specific MoQ protocol version(s).
 	///
@@ -89,7 +85,7 @@ impl Default for ClientConfig {
 			connect: None,
 			bind: "[::]:0".parse().unwrap(),
 			backend: None,
-			max_streams: None,
+			quic: crate::quic::Client::default(),
 			version: Vec::new(),
 			tls: crate::tls::Client::default(),
 			backoff: Backoff::default(),

--- a/rs/moq-native/src/iroh.rs
+++ b/rs/moq-native/src/iroh.rs
@@ -65,6 +65,9 @@ pub enum Error {
 
 	#[error("failed to receive WebTransport request")]
 	RecvRequest(#[source] web_transport_iroh::ServerError),
+
+	#[error("the iroh backend cannot disable GSO; drop --quic-gso=false or use the quinn backend")]
+	GsoUnsupported,
 }
 
 type Result<T> = std::result::Result<T, Error>;
@@ -114,9 +117,21 @@ pub struct EndpointConfig {
 }
 
 impl EndpointConfig {
-	pub async fn bind(self) -> Result<Option<Endpoint>> {
+	/// Bind the iroh endpoint, applying the per-connection [`crate::quic::Client`] knobs.
+	///
+	/// iroh is a single P2P endpoint shared by both roles, so it takes the client
+	/// section (the per-connection knobs are symmetric). It only honors the knobs
+	/// its transport-config builder exposes (stream limits, idle timeout, MTU
+	/// discovery); it has no keep-alive knob and cannot disable GSO, so `gso = false`
+	/// fails with [`Error::GsoUnsupported`].
+	pub async fn bind(self, quic: &crate::quic::Client) -> Result<Option<Endpoint>> {
 		if !self.enabled.unwrap_or(false) {
 			return Ok(None);
+		}
+
+		let quic = quic.resolve();
+		if quic.gso_disabled() {
+			return Err(Error::GsoUnsupported);
 		}
 
 		// If the secret matches the expected format (hex encoded), use it directly.
@@ -143,13 +158,25 @@ impl EndpointConfig {
 		let mut alpns: Vec<Vec<u8>> = moq_net::ALPNS.iter().map(|alpn| alpn.as_bytes().to_vec()).collect();
 		alpns.push(web_transport_iroh::ALPN_H3.as_bytes().to_vec());
 
+		// MoQ opens a stream per group, so raise the low default; also carry the
+		// shared idle-timeout / MTU knobs onto iroh's own transport config.
+		let max_streams = iroh::endpoint::VarInt::from_u64(quic.max_streams).unwrap_or(iroh::endpoint::VarInt::MAX);
+		let mut transport = iroh::endpoint::QuicTransportConfig::builder()
+			.max_concurrent_bidi_streams(max_streams)
+			.max_concurrent_uni_streams(max_streams)
+			.max_idle_timeout(Some(quic.idle_timeout.try_into().expect("idle timeout out of range")));
+		if !quic.mtu_discovery {
+			transport = transport.mtu_discovery_config(None);
+		}
+
 		let mut builder = if self.disable_relay.unwrap_or(false) {
 			Endpoint::builder(iroh::endpoint::presets::N0DisableRelay)
 		} else {
 			Endpoint::builder(iroh::endpoint::presets::N0)
 		}
 		.secret_key(secret_key)
-		.alpns(alpns);
+		.alpns(alpns)
+		.transport_config(transport.build());
 		if let Some(addr) = self.bind_v4 {
 			builder = builder.bind_addr(addr)?;
 		}

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -10,9 +10,6 @@
 //!
 //! See [`Client`] for connecting to relays and [`Server`] for accepting connections.
 
-/// Default maximum number of concurrent QUIC streams (bidi and uni) per connection.
-pub(crate) const DEFAULT_MAX_STREAMS: u64 = 1024;
-
 pub mod bind;
 mod client;
 mod connect;
@@ -23,6 +20,7 @@ pub mod jemalloc;
 mod log;
 #[cfg(feature = "noq")]
 pub mod noq;
+pub mod quic;
 #[cfg(feature = "quinn")]
 pub mod quinn;
 mod reconnect;

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -1,14 +1,34 @@
 use crate::client::ClientConfig;
+use crate::quic::Resolved;
 use crate::server::{ServerConfig, ServerId};
 use crate::tls::{FingerprintVerifier, ServeCerts};
+use std::net;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use std::{net, time};
 use url::Url;
 
 use web_transport_noq::noq;
 
 pub use web_transport_noq;
+
+/// Apply the resolved quic knobs to a noq transport config.
+fn apply_transport(transport: &mut noq::TransportConfig, quic: Resolved) {
+	transport.max_idle_timeout(Some(quic.idle_timeout.try_into().expect("idle timeout out of range")));
+	transport.keep_alive_interval(quic.keep_alive);
+
+	// noq enables MTU discovery by default; disable it unless asked.
+	if !quic.mtu_discovery {
+		transport.mtu_discovery_config(None);
+	}
+
+	let max_streams = noq::VarInt::from_u64(quic.max_streams).unwrap_or(noq::VarInt::MAX);
+	transport.max_concurrent_bidi_streams(max_streams);
+	transport.max_concurrent_uni_streams(max_streams);
+
+	if let Some(gso) = quic.gso {
+		transport.enable_segmentation_offload(gso);
+	}
+}
 
 /// Errors specific to the noq QUIC backend.
 #[derive(Debug, thiserror::Error)]
@@ -130,16 +150,8 @@ impl NoqClient {
 		let socket = crate::bind::udp(config.bind).map_err(Error::BindSocket)?;
 
 		let mut transport = noq::TransportConfig::default();
-		transport.max_idle_timeout(Some(time::Duration::from_secs(30).try_into().unwrap()));
-		transport.keep_alive_interval(Some(time::Duration::from_secs(5)));
-		transport.mtu_discovery_config(None); // Disable MTU discovery
 		transport.congestion_controller_factory(Arc::new(noq::congestion::Bbr3Config::default()));
-
-		let max_streams = config.max_streams.unwrap_or(crate::DEFAULT_MAX_STREAMS);
-		let max_streams = noq::VarInt::from_u64(max_streams).unwrap_or(noq::VarInt::MAX);
-		transport.max_concurrent_bidi_streams(max_streams);
-		transport.max_concurrent_uni_streams(max_streams);
-
+		apply_transport(&mut transport, config.quic.resolve());
 		let transport = Arc::new(transport);
 
 		// There's a bit more boilerplate to make a generic endpoint.
@@ -316,16 +328,8 @@ pub(crate) struct NoqServer {
 impl NoqServer {
 	pub fn new(config: ServerConfig) -> Result<Self> {
 		let mut transport = noq::TransportConfig::default();
-		transport.max_idle_timeout(Some(Duration::from_secs(30).try_into().unwrap()));
-		transport.keep_alive_interval(Some(Duration::from_secs(5)));
-		transport.mtu_discovery_config(None); // Disable MTU discovery
 		transport.congestion_controller_factory(Arc::new(noq::congestion::Bbr3Config::default()));
-
-		let max_streams = config.max_streams.unwrap_or(crate::DEFAULT_MAX_STREAMS);
-		let max_streams = noq::VarInt::from_u64(max_streams).unwrap_or(noq::VarInt::MAX);
-		transport.max_concurrent_bidi_streams(max_streams);
-		transport.max_concurrent_uni_streams(max_streams);
-
+		apply_transport(&mut transport, config.quic.resolve());
 		let transport = Arc::new(transport);
 
 		let provider = crate::crypto::provider();
@@ -369,10 +373,10 @@ impl NoqServer {
 
 		// Advertise the preferred_address transport parameter (RFC 9000 §9.6).
 		// noq allocates a fresh CID + reset token for the address during the handshake.
-		if let Some(addr) = config.preferred_v4 {
+		if let Some(addr) = config.quic.preferred_v4 {
 			tls.preferred_address_v4(Some(addr));
 		}
-		if let Some(addr) = config.preferred_v6 {
+		if let Some(addr) = config.quic.preferred_v6 {
 			tls.preferred_address_v6(Some(addr));
 		}
 
@@ -384,8 +388,8 @@ impl NoqServer {
 
 		// Configure connection ID generator with server ID if provided
 		let mut endpoint_config = noq::EndpointConfig::default();
-		if let Some(server_id) = config.quic_lb_id {
-			let nonce_len = config.quic_lb_nonce.unwrap_or(8);
+		if let Some(server_id) = config.quic.quic_lb_id {
+			let nonce_len = config.quic.quic_lb_nonce.unwrap_or(8);
 			if nonce_len < 4 {
 				return Err(Error::QuicLbNonceTooSmall);
 			}

--- a/rs/moq-native/src/quic.rs
+++ b/rs/moq-native/src/quic.rs
@@ -1,0 +1,374 @@
+//! QUIC transport tuning, split by role.
+//!
+//! [`Client`] (`--client-quic-*`) and [`Server`] (`--server-quic-*`) carry the
+//! per-connection knobs (stream limits, GSO, timeouts) that each backend applies.
+//! [`Server`] additionally owns the knobs that only make sense when accepting
+//! connections: the QUIC preferred address and the QUIC-LB connection-ID encoding.
+//!
+//! Each is flattened directly onto [`crate::ClientConfig`] / [`crate::ServerConfig`],
+//! so the args parse straight into the config the endpoint is built from. Not
+//! every backend honors every knob, see the field docs.
+
+use std::net;
+use std::time::Duration;
+
+use crate::ServerId;
+
+/// Default maximum number of concurrent QUIC streams (bidi and uni) per connection.
+pub(crate) const DEFAULT_MAX_STREAMS: u64 = 1024;
+
+/// Default idle timeout before an inactive connection is dropped.
+pub(crate) const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default keep-alive ping interval.
+pub(crate) const DEFAULT_KEEP_ALIVE: Duration = Duration::from_secs(5);
+
+/// The `--client-quic-*` transport section.
+#[derive(Clone, Debug, Default, clap::Args, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
+pub struct Client {
+	/// Maximum number of concurrent QUIC streams per connection (both bidi and uni).
+	/// Defaults to 1024. MoQ opens a stream per group, so busy endpoints want this high.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[arg(
+		id = "client-quic-max-streams",
+		long = "client-quic-max-streams",
+		alias = "client-max-streams",
+		env = "MOQ_CLIENT_QUIC_MAX_STREAMS"
+	)]
+	pub max_streams: Option<u64>,
+
+	/// Enable UDP generic segmentation offload (GSO).
+	///
+	/// GSO batches sends into one syscall for throughput, but some NICs and
+	/// middleboxes mangle segmented packets. Defaults to on. Only the quinn and
+	/// noq backends can turn it off; setting `false` errors at init on quiche/iroh.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[arg(
+		id = "client-quic-gso",
+		long = "client-quic-gso",
+		env = "MOQ_CLIENT_QUIC_GSO",
+		default_missing_value = "true",
+		num_args = 0..=1,
+		require_equals = true,
+		value_parser = clap::value_parser!(bool),
+	)]
+	pub gso: Option<bool>,
+
+	/// Idle timeout before an inactive connection is dropped. Defaults to 30s.
+	#[serde(default, skip_serializing_if = "Option::is_none", with = "humantime_serde::option")]
+	#[arg(
+		id = "client-quic-idle-timeout",
+		long = "client-quic-idle-timeout",
+		env = "MOQ_CLIENT_QUIC_IDLE_TIMEOUT",
+		value_parser = humantime::parse_duration,
+	)]
+	pub idle_timeout: Option<Duration>,
+
+	/// Keep-alive ping interval. Defaults to 5s; set `0s` to disable.
+	/// Ignored by the quiche and iroh backends, which have no keep-alive knob.
+	#[serde(default, skip_serializing_if = "Option::is_none", with = "humantime_serde::option")]
+	#[arg(
+		id = "client-quic-keep-alive",
+		long = "client-quic-keep-alive",
+		env = "MOQ_CLIENT_QUIC_KEEP_ALIVE",
+		value_parser = humantime::parse_duration,
+	)]
+	pub keep_alive: Option<Duration>,
+
+	/// Enable path MTU discovery. Defaults to off.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[arg(
+		id = "client-quic-mtu-discovery",
+		long = "client-quic-mtu-discovery",
+		env = "MOQ_CLIENT_QUIC_MTU_DISCOVERY",
+		default_missing_value = "true",
+		num_args = 0..=1,
+		require_equals = true,
+		value_parser = clap::value_parser!(bool),
+	)]
+	pub mtu_discovery: Option<bool>,
+}
+
+impl Client {
+	/// The per-connection knobs with defaults applied, ready to hand to a backend.
+	pub(crate) fn resolve(&self) -> Resolved {
+		Resolved::new(
+			self.max_streams,
+			self.gso,
+			self.idle_timeout,
+			self.keep_alive,
+			self.mtu_discovery,
+		)
+	}
+}
+
+/// The `--server-quic-*` transport section.
+///
+/// Carries the same per-connection knobs as [`Client`] plus the accept-side knobs
+/// (preferred address, QUIC-LB connection IDs).
+#[derive(Clone, Debug, Default, clap::Args, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
+pub struct Server {
+	/// Maximum number of concurrent QUIC streams per connection (both bidi and uni).
+	/// Defaults to 1024. MoQ opens a stream per group, so busy endpoints want this high.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[arg(
+		id = "server-quic-max-streams",
+		long = "server-quic-max-streams",
+		alias = "server-max-streams",
+		env = "MOQ_SERVER_QUIC_MAX_STREAMS"
+	)]
+	pub max_streams: Option<u64>,
+
+	/// Enable UDP generic segmentation offload (GSO). See [`Client::gso`].
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[arg(
+		id = "server-quic-gso",
+		long = "server-quic-gso",
+		env = "MOQ_SERVER_QUIC_GSO",
+		default_missing_value = "true",
+		num_args = 0..=1,
+		require_equals = true,
+		value_parser = clap::value_parser!(bool),
+	)]
+	pub gso: Option<bool>,
+
+	/// Idle timeout before an inactive connection is dropped. Defaults to 30s.
+	#[serde(default, skip_serializing_if = "Option::is_none", with = "humantime_serde::option")]
+	#[arg(
+		id = "server-quic-idle-timeout",
+		long = "server-quic-idle-timeout",
+		env = "MOQ_SERVER_QUIC_IDLE_TIMEOUT",
+		value_parser = humantime::parse_duration,
+	)]
+	pub idle_timeout: Option<Duration>,
+
+	/// Keep-alive ping interval. Defaults to 5s; set `0s` to disable.
+	/// Ignored by the quiche backend, which has no keep-alive knob.
+	#[serde(default, skip_serializing_if = "Option::is_none", with = "humantime_serde::option")]
+	#[arg(
+		id = "server-quic-keep-alive",
+		long = "server-quic-keep-alive",
+		env = "MOQ_SERVER_QUIC_KEEP_ALIVE",
+		value_parser = humantime::parse_duration,
+	)]
+	pub keep_alive: Option<Duration>,
+
+	/// Enable path MTU discovery. Defaults to off.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[arg(
+		id = "server-quic-mtu-discovery",
+		long = "server-quic-mtu-discovery",
+		env = "MOQ_SERVER_QUIC_MTU_DISCOVERY",
+		default_missing_value = "true",
+		num_args = 0..=1,
+		require_equals = true,
+		value_parser = clap::value_parser!(bool),
+	)]
+	pub mtu_discovery: Option<bool>,
+
+	/// IPv4 address advertised as the QUIC preferred_address.
+	///
+	/// Supporting clients (Chrome M131+, native Quinn) migrate to this address
+	/// shortly after the handshake completes. Typical use: handshake on an
+	/// anycast IP, steady-state on this host's unicast IP.
+	///
+	/// Honored by the Quinn and noq backends.
+	#[arg(
+		id = "server-preferred-v4",
+		long = "server-preferred-v4",
+		env = "MOQ_SERVER_PREFERRED_V4"
+	)]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub preferred_v4: Option<net::SocketAddrV4>,
+
+	/// IPv6 address advertised as the QUIC preferred_address. See [`Self::preferred_v4`].
+	#[arg(
+		id = "server-preferred-v6",
+		long = "server-preferred-v6",
+		env = "MOQ_SERVER_PREFERRED_V6"
+	)]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub preferred_v6: Option<net::SocketAddrV6>,
+
+	/// Server ID to embed in connection IDs for QUIC-LB compatibility.
+	/// If set, connection IDs will be derived semi-deterministically.
+	#[arg(id = "server-quic-lb-id", long = "server-quic-lb-id", env = "MOQ_SERVER_QUIC_LB_ID")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub quic_lb_id: Option<ServerId>,
+
+	/// Number of random nonce bytes in QUIC-LB connection IDs.
+	/// Must be at least 4, and server_id + nonce + 1 must not exceed 20.
+	#[arg(
+		id = "server-quic-lb-nonce",
+		long = "server-quic-lb-nonce",
+		requires = "server-quic-lb-id",
+		env = "MOQ_SERVER_QUIC_LB_NONCE"
+	)]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub quic_lb_nonce: Option<usize>,
+}
+
+impl Server {
+	/// The per-connection knobs with defaults applied, ready to hand to a backend.
+	pub(crate) fn resolve(&self) -> Resolved {
+		Resolved::new(
+			self.max_streams,
+			self.gso,
+			self.idle_timeout,
+			self.keep_alive,
+			self.mtu_discovery,
+		)
+	}
+}
+
+/// A resolved view of the per-connection knobs (defaults filled in), shared by
+/// [`Client`] and [`Server`] so backends apply them the same way regardless of role.
+///
+/// Internal: the backends consume it and [`crate::iroh::EndpointConfig::bind`]
+/// resolves it from a [`Client`], so it never appears in the public surface.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct Resolved {
+	/// Max concurrent streams (bidi and uni).
+	pub max_streams: u64,
+	/// GSO override, or `None` to leave the backend default (on).
+	pub gso: Option<bool>,
+	/// Idle timeout.
+	pub idle_timeout: Duration,
+	/// Keep-alive interval, or `None` when disabled.
+	pub keep_alive: Option<Duration>,
+	/// Whether to run path MTU discovery.
+	pub mtu_discovery: bool,
+}
+
+impl Resolved {
+	fn new(
+		max_streams: Option<u64>,
+		gso: Option<bool>,
+		idle_timeout: Option<Duration>,
+		keep_alive: Option<Duration>,
+		mtu_discovery: Option<bool>,
+	) -> Self {
+		// A zero keep-alive means "disabled"; anything else (including unset) keeps
+		// the connection warm, defaulting to 5s.
+		let keep_alive = match keep_alive {
+			Some(d) if d.is_zero() => None,
+			Some(d) => Some(d),
+			None => Some(DEFAULT_KEEP_ALIVE),
+		};
+
+		Self {
+			max_streams: max_streams.unwrap_or(DEFAULT_MAX_STREAMS),
+			gso,
+			idle_timeout: idle_timeout.unwrap_or(DEFAULT_IDLE_TIMEOUT),
+			keep_alive,
+			mtu_discovery: mtu_discovery.unwrap_or(false),
+		}
+	}
+
+	/// Whether the config asks to turn GSO off, which not every backend can honor.
+	pub(crate) fn gso_disabled(&self) -> bool {
+		self.gso == Some(false)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use clap::Parser;
+
+	/// Minimal parsers so we can exercise the `--client-quic-*` / `--server-quic-*`
+	/// args in isolation (and together, the way relay/cli flatten both).
+	#[derive(Parser)]
+	struct Both {
+		#[command(flatten)]
+		client: Client,
+		#[command(flatten)]
+		server: Server,
+	}
+
+	fn parse(args: &[&str]) -> Both {
+		let mut full = vec!["test"];
+		full.extend_from_slice(args);
+		Both::parse_from(full)
+	}
+
+	#[test]
+	fn defaults_apply_when_unset() {
+		let quic = Client::default().resolve();
+		assert_eq!(quic.max_streams, DEFAULT_MAX_STREAMS);
+		assert_eq!(quic.idle_timeout, DEFAULT_IDLE_TIMEOUT);
+		assert_eq!(quic.keep_alive, Some(DEFAULT_KEEP_ALIVE));
+		assert!(!quic.mtu_discovery);
+		assert_eq!(quic.gso, None);
+		assert!(!quic.gso_disabled());
+	}
+
+	#[test]
+	fn zero_keep_alive_disables_it() {
+		let disabled = Server {
+			keep_alive: Some(Duration::ZERO),
+			..Default::default()
+		};
+		assert_eq!(disabled.resolve().keep_alive, None);
+
+		let explicit = Client {
+			keep_alive: Some(Duration::from_secs(2)),
+			..Default::default()
+		};
+		assert_eq!(explicit.resolve().keep_alive, Some(Duration::from_secs(2)));
+	}
+
+	#[test]
+	fn gso_disabled_only_on_explicit_false() {
+		let off = Client {
+			gso: Some(false),
+			..Default::default()
+		};
+		assert!(off.resolve().gso_disabled());
+		let on = Client {
+			gso: Some(true),
+			..Default::default()
+		};
+		assert!(!on.resolve().gso_disabled());
+	}
+
+	#[test]
+	fn client_and_server_flags_are_distinct() {
+		let both = parse(&["--client-quic-max-streams", "5000", "--server-quic-max-streams", "9000"]);
+		assert_eq!(both.client.max_streams, Some(5000));
+		assert_eq!(both.server.max_streams, Some(9000));
+	}
+
+	#[test]
+	fn server_only_knobs_parse() {
+		let both = parse(&["--server-preferred-v4", "192.0.2.1:443", "--server-quic-lb-id", "ab"]);
+		assert_eq!(both.server.preferred_v4, Some("192.0.2.1:443".parse().unwrap()));
+		assert!(both.server.quic_lb_id.is_some());
+		// The accept-side knobs live only on the server section.
+		assert_eq!(both.client.max_streams, None);
+	}
+
+	#[test]
+	fn deprecated_max_streams_aliases() {
+		let both = parse(&["--client-max-streams", "2048", "--server-max-streams", "4096"]);
+		assert_eq!(both.client.max_streams, Some(2048));
+		assert_eq!(both.server.max_streams, Some(4096));
+	}
+
+	#[test]
+	fn toml_round_trips() {
+		let toml = r#"
+			max_streams = 7000
+			gso = false
+			preferred_v4 = "192.0.2.1:443"
+		"#;
+		let quic: Server = toml::from_str(toml).unwrap();
+		assert_eq!(quic.max_streams, Some(7000));
+		assert_eq!(quic.gso, Some(false));
+		assert_eq!(quic.preferred_v4, Some("192.0.2.1:443".parse().unwrap()));
+	}
+}

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -1,5 +1,6 @@
 use crate::client::ClientConfig;
 use crate::crypto;
+use crate::quic::Resolved;
 use crate::server::ServerConfig;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
@@ -47,6 +48,9 @@ pub enum Error {
 
 	#[error("client tls host_name override is not supported with the quiche backend")]
 	HostNameUnsupported,
+
+	#[error("the quiche backend cannot disable GSO; drop --*-quic-gso=false or use the quinn backend")]
+	GsoUnsupported,
 
 	#[error("missing ALPN")]
 	MissingAlpn,
@@ -102,6 +106,17 @@ pub enum Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
+/// Apply the resolved quic knobs quiche can honor to its settings.
+///
+/// quiche has no keep-alive interval knob, so [`Resolved::keep_alive`] is ignored;
+/// GSO is probed from the socket and rejected up front (see [`Error::GsoUnsupported`]).
+fn apply_settings(settings: &mut web_transport_quiche::Settings, quic: Resolved) {
+	settings.initial_max_streams_bidi = quic.max_streams;
+	settings.initial_max_streams_uni = quic.max_streams;
+	settings.max_idle_timeout = Some(quic.idle_timeout);
+	settings.discover_path_mtu = quic.mtu_discovery;
+}
+
 // ── Client ──────────────────────────────────────────────────────────
 
 #[derive(Clone)]
@@ -111,7 +126,7 @@ pub(crate) struct QuicheClient {
 	pub verification: crate::tls::Verification,
 	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
 	pub http_bootstrap: bool,
-	pub max_streams: u64,
+	pub quic: Resolved,
 }
 
 impl QuicheClient {
@@ -124,11 +139,17 @@ impl QuicheClient {
 			return Err(Error::HostNameUnsupported);
 		}
 
+		let quic = config.quic.resolve();
+		// quiche probes GSO from the socket and has no knob to force it off.
+		if quic.gso_disabled() {
+			return Err(Error::GsoUnsupported);
+		}
+
 		Ok(Self {
 			bind: config.bind,
 			verification: config.tls.verification()?,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
-			max_streams: config.max_streams.unwrap_or(crate::DEFAULT_MAX_STREAMS),
+			quic,
 		})
 	}
 
@@ -169,8 +190,7 @@ impl QuicheClient {
 		let mut settings = web_transport_quiche::Settings::default();
 		settings.verify_peer = !matches!(verification, Verification::Disabled);
 		settings.alpn = alpns;
-		settings.initial_max_streams_bidi = self.max_streams;
-		settings.initial_max_streams_uni = self.max_streams;
+		apply_settings(&mut settings, self.quic);
 
 		let mut builder = web_transport_quiche::ez::ClientBuilder::default()
 			.with_settings(settings)
@@ -319,8 +339,14 @@ pub(crate) struct QuicheServer {
 
 impl QuicheServer {
 	pub fn new(config: ServerConfig) -> Result<Self> {
-		if config.quic_lb_id.is_some() {
+		if config.quic.quic_lb_id.is_some() {
 			tracing::warn!("QUIC-LB is not supported with the quiche backend; ignoring server ID");
+		}
+
+		let quic = config.quic.resolve();
+		// quiche probes GSO from the socket and has no knob to force it off.
+		if quic.gso_disabled() {
+			return Err(Error::GsoUnsupported);
 		}
 
 		let listen =
@@ -362,12 +388,9 @@ impl QuicheServer {
 			.collect();
 		alpns.push(b"h3".to_vec());
 
-		let max_streams = config.max_streams.unwrap_or(crate::DEFAULT_MAX_STREAMS);
-
 		let mut settings = web_transport_quiche::Settings::default();
 		settings.alpn = alpns;
-		settings.initial_max_streams_bidi = max_streams;
-		settings.initial_max_streams_uni = max_streams;
+		apply_settings(&mut settings, quic);
 
 		let server = web_transport_quiche::ez::ServerBuilder::default()
 			.with_settings(settings)

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -1,12 +1,33 @@
 use crate::client::ClientConfig;
+use crate::quic::Resolved;
 use crate::server::{ServerConfig, ServerId};
 use crate::tls::{FingerprintVerifier, ServeCerts};
+use std::net;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
-use std::{net, time};
 use url::Url;
 
 pub use web_transport_quinn;
+
+/// Apply the resolved quic knobs to a quinn transport config.
+fn apply_transport(transport: &mut quinn::TransportConfig, quic: Resolved) {
+	transport.max_idle_timeout(Some(quic.idle_timeout.try_into().expect("idle timeout out of range")));
+	transport.keep_alive_interval(quic.keep_alive);
+
+	// quinn enables MTU discovery by default; disable it unless asked.
+	if !quic.mtu_discovery {
+		transport.mtu_discovery_config(None);
+	}
+
+	let max_streams = quinn::VarInt::from_u64(quic.max_streams).unwrap_or(quinn::VarInt::MAX);
+	transport.max_concurrent_bidi_streams(max_streams);
+	transport.max_concurrent_uni_streams(max_streams);
+
+	// GSO is on by default; only the quinn/noq backends can turn it off.
+	if let Some(gso) = quic.gso {
+		transport.enable_segmentation_offload(gso);
+	}
+}
 
 /// Errors specific to the quinn QUIC backend.
 #[derive(Debug, thiserror::Error)]
@@ -129,15 +150,7 @@ impl QuinnClient {
 
 		// TODO Validate the BBR implementation before enabling it
 		let mut transport = quinn::TransportConfig::default();
-		transport.max_idle_timeout(Some(time::Duration::from_secs(30).try_into().unwrap()));
-		transport.keep_alive_interval(Some(time::Duration::from_secs(5)));
-		transport.mtu_discovery_config(None); // Disable MTU discovery
-
-		let max_streams = config.max_streams.unwrap_or(crate::DEFAULT_MAX_STREAMS);
-		let max_streams = quinn::VarInt::from_u64(max_streams).unwrap_or(quinn::VarInt::MAX);
-		transport.max_concurrent_bidi_streams(max_streams);
-		transport.max_concurrent_uni_streams(max_streams);
-
+		apply_transport(&mut transport, config.quic.resolve());
 		let transport = Arc::new(transport);
 
 		// There's a bit more boilerplate to make a generic endpoint.
@@ -316,15 +329,7 @@ impl QuinnServer {
 		// Enable BBR congestion control
 		// TODO Validate the BBR implementation before enabling it
 		let mut transport = quinn::TransportConfig::default();
-		transport.max_idle_timeout(Some(Duration::from_secs(30).try_into().unwrap()));
-		transport.keep_alive_interval(Some(Duration::from_secs(5)));
-		transport.mtu_discovery_config(None); // Disable MTU discovery
-
-		let max_streams = config.max_streams.unwrap_or(crate::DEFAULT_MAX_STREAMS);
-		let max_streams = quinn::VarInt::from_u64(max_streams).unwrap_or(quinn::VarInt::MAX);
-		transport.max_concurrent_bidi_streams(max_streams);
-		transport.max_concurrent_uni_streams(max_streams);
-
+		apply_transport(&mut transport, config.quic.resolve());
 		let transport = Arc::new(transport);
 
 		let provider = crate::crypto::provider();
@@ -368,10 +373,10 @@ impl QuinnServer {
 
 		// Advertise the preferred_address transport parameter (RFC 9000 §9.6).
 		// Quinn allocates a fresh CID + reset token for the address during the handshake.
-		if let Some(addr) = config.preferred_v4 {
+		if let Some(addr) = config.quic.preferred_v4 {
 			tls.preferred_address_v4(Some(addr));
 		}
-		if let Some(addr) = config.preferred_v6 {
+		if let Some(addr) = config.quic.preferred_v6 {
 			tls.preferred_address_v6(Some(addr));
 		}
 
@@ -383,8 +388,8 @@ impl QuinnServer {
 
 		// Configure connection ID generator with server ID if provided
 		let mut endpoint_config = quinn::EndpointConfig::default();
-		if let Some(server_id) = config.quic_lb_id {
-			let nonce_len = config.quic_lb_nonce.unwrap_or(8);
+		if let Some(server_id) = config.quic.quic_lb_id {
+			let nonce_len = config.quic.quic_lb_nonce.unwrap_or(8);
 			if nonce_len < 4 {
 				return Err(Error::QuicLbNonceTooSmall);
 			}

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -49,57 +49,11 @@ pub struct ServerConfig {
 	#[arg(id = "server-backend", long = "server-backend", env = "MOQ_SERVER_BACKEND")]
 	pub backend: Option<QuicBackend>,
 
-	/// Server ID to embed in connection IDs for QUIC-LB compatibility.
-	/// If set, connection IDs will be derived semi-deterministically.
-	#[arg(id = "server-quic-lb-id", long = "server-quic-lb-id", env = "MOQ_SERVER_QUIC_LB_ID")]
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub quic_lb_id: Option<ServerId>,
-
-	/// Number of random nonce bytes in QUIC-LB connection IDs.
-	/// Must be at least 4, and server_id + nonce + 1 must not exceed 20.
-	#[arg(
-		id = "server-quic-lb-nonce",
-		long = "server-quic-lb-nonce",
-		requires = "server-quic-lb-id",
-		env = "MOQ_SERVER_QUIC_LB_NONCE"
-	)]
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub quic_lb_nonce: Option<usize>,
-
-	/// IPv4 address advertised as the QUIC preferred_address.
-	///
-	/// Supporting clients (Chrome M131+, native Quinn) migrate to this address
-	/// shortly after the handshake completes. Typical use: handshake on an
-	/// anycast IP, steady-state on this host's unicast IP.
-	///
-	/// Honored by the Quinn and noq backends.
-	#[arg(
-		id = "server-preferred-v4",
-		long = "server-preferred-v4",
-		env = "MOQ_SERVER_PREFERRED_V4"
-	)]
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub preferred_v4: Option<net::SocketAddrV4>,
-
-	/// IPv6 address advertised as the QUIC preferred_address.
-	///
-	/// See [`Self::preferred_v4`].
-	#[arg(
-		id = "server-preferred-v6",
-		long = "server-preferred-v6",
-		env = "MOQ_SERVER_PREFERRED_V6"
-	)]
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub preferred_v6: Option<net::SocketAddrV6>,
-
-	/// Maximum number of concurrent QUIC streams per connection (both bidi and uni).
-	#[serde(skip_serializing_if = "Option::is_none")]
-	#[arg(
-		id = "server-max-streams",
-		long = "server-max-streams",
-		env = "MOQ_SERVER_MAX_STREAMS"
-	)]
-	pub max_streams: Option<u64>,
+	/// QUIC transport tuning (`--server-quic-*`): stream limits, GSO, timeouts,
+	/// plus the accept-side knobs (preferred address, QUIC-LB connection IDs).
+	#[command(flatten)]
+	#[serde(default)]
+	pub quic: crate::quic::Server,
 
 	/// Restrict the server to specific MoQ protocol version(s).
 	///

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -262,7 +262,7 @@ async fn iroh_connect() {
 	let mut server_iroh_config = EndpointConfig::default();
 	server_iroh_config.enabled = Some(true);
 	let server_endpoint = server_iroh_config
-		.bind()
+		.bind(&moq_native::quic::Client::default())
 		.await
 		.expect("failed to bind server iroh endpoint")
 		.expect("server iroh endpoint not enabled");
@@ -291,7 +291,7 @@ async fn iroh_connect() {
 	let mut client_iroh_config = EndpointConfig::default();
 	client_iroh_config.enabled = Some(true);
 	let client_endpoint = client_iroh_config
-		.bind()
+		.bind(&moq_native::quic::Client::default())
 		.await
 		.expect("failed to bind client iroh endpoint")
 		.expect("client iroh endpoint not enabled");

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -180,7 +180,7 @@ depth = 2
 		}
 
 		let toml = r#"
-[server]
+[server.quic]
 preferred_v4 = "192.0.2.1:443"
 preferred_v6 = "[2001:db8::1]:443"
 "#;
@@ -193,14 +193,14 @@ preferred_v6 = "[2001:db8::1]:443"
 		let config = Config::parse_and_merge(args).expect("config load");
 
 		assert_eq!(
-			config.server.preferred_v4,
+			config.server.quic.preferred_v4,
 			Some("192.0.2.1:443".parse().unwrap()),
-			"TOML's server.preferred_v4 must not be clobbered by the CLI re-parse"
+			"TOML's server.quic.preferred_v4 must not be clobbered by the CLI re-parse"
 		);
 		assert_eq!(
-			config.server.preferred_v6,
+			config.server.quic.preferred_v6,
 			Some("[2001:db8::1]:443".parse().unwrap()),
-			"TOML's server.preferred_v6 must not be clobbered by the CLI re-parse"
+			"TOML's server.quic.preferred_v6 must not be clobbered by the CLI re-parse"
 		);
 	}
 

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -16,8 +16,8 @@ async fn main() -> anyhow::Result<()> {
 
 	let mut config = Config::load()?;
 
-	config.client.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
-	config.server.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
+	config.client.quic.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
+	config.server.quic.max_streams.get_or_insert(DEFAULT_MAX_STREAMS);
 
 	let mtls_enabled = !config.server.tls.root.is_empty();
 
@@ -34,7 +34,7 @@ async fn main() -> anyhow::Result<()> {
 
 	#[cfg(feature = "iroh")]
 	let (server, client) = {
-		let iroh = config.iroh.bind().await?;
+		let iroh = config.iroh.bind(&config.client.quic).await?;
 		(server.with_iroh(iroh.clone()), client.with_iroh(iroh))
 	};
 


### PR DESCRIPTION
## Summary

Adds role-split QUIC transport tuning: `quic::Client` (`--client-quic-*`) and `quic::Server` (`--server-quic-*`), each flattened directly onto `ClientConfig` / `ServerConfig`. Knobs: `max_streams`, `gso`, `idle_timeout`, `keep_alive`, `mtu_discovery` — the last three were previously hardcoded in the quinn/noq backends.

Because the args parse straight into the role config the endpoint is built from, there's **no separate section to remember to pipe through**: `--client-quic-*` lands in `ClientConfig::quic` and `--server-quic-*` in `ServerConfig::quic` automatically.

The split is meaningful, not cosmetic: the server owns accept-only knobs the client has no use for. The **QUIC preferred address** and **QUIC-LB connection-ID** fields move off `ServerConfig`'s top level into `quic::Server`, so all of a server's QUIC tuning lives in one place. Their CLI flags/env vars are unchanged (`--server-preferred-v4`, `--server-quic-lb-id`, ...); only the TOML path moves under `[server.quic]`.

## Backend support

| Knob | quinn | noq | quiche | iroh |
|---|---|---|---|---|
| max streams | ✅ | ✅ | ✅ | ✅ (newly wired) |
| idle timeout | ✅ | ✅ | ✅ | ✅ |
| keep-alive | ✅ | ✅ | ignored | ignored |
| MTU discovery | ✅ | ✅ | ✅ | ✅ |
| disable GSO | ✅ | ✅ | init error | init error |
| preferred addr / QUIC-LB | ✅ | ✅ | — | — |

- **GSO** can only be turned off on quinn/noq (`TransportConfig::enable_segmentation_offload`). quiche and iroh probe GSO from the socket with no public setter, so `--*-quic-gso=false` returns a backend `GsoUnsupported` error at init rather than silently ignoring the flag.
- **iroh** previously ignored transport config entirely (endpoint presets only). It now applies `max_streams` (plus idle timeout and MTU) via its endpoint transport config — MoQ opens a stream per group and iroh's default of ~100 is far too low. iroh uses the client-side quic knobs (single P2P endpoint, per-connection knobs are symmetric).

## Notes for reviewers

- **Public API (moq-native):**
  - `--client-max-streams` / `--server-max-streams` are folded into the new `--client-quic-max-streams` / `--server-quic-max-streams`, with the old spellings kept as **hidden clap aliases** (no breakage).
  - `ServerConfig::preferred_v4/v6` and `quic_lb_id/nonce` move to `ServerConfig::quic` (a `quic::Server`). CLI/env unchanged; TOML moves from `[server]` to `[server.quic]`.
  - Targets `main` (moq-native is not in the dev breaking-change list).
- `iroh::EndpointConfig::bind` now takes the resolved quic knobs; callers (relay, cli) pass the client-side section.
- No `/doc` or `demo/` files referenced the old flags, so nothing to sync there.

## Test plan

- [x] `cargo test` for moq-native, moq-relay, moq-bench, moq-cli (incl. new tests: `--client-quic-*` vs `--server-quic-*` distinctness, server-only knobs, deprecated aliases, TOML round-trip, GSO gating; relay `[server.quic]` clobber regression updated)
- [x] Builds across all backends: quinn, noq, quiche, iroh, and combos (quiche+iroh+quinn via nix)
- [x] `clippy --all-targets` clean; `RUSTDOCFLAGS=-D warnings cargo doc` clean; formatted via nix
- [x] `moq-relay --help` shows `--client-quic-*`, `--server-quic-*`, and the server-only `--server-preferred-*` / `--server-quic-lb-*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)