### PR TITLE
fix(moq-video): make decode Frame/Consumer Send on macOS

### DIFF
--- a/rs/moq-video/src/capture/channel.rs
+++ b/rs/moq-video/src/capture/channel.rs
@@ -18,12 +18,6 @@ use crate::frame::Frame;
 /// Bounded depth; the oldest frame is dropped to favor latency over completeness.
 const DEPTH: usize = 4;
 
-/// A [`Frame`] is only `!Send` because of its macOS `CVPixelBuffer` (a
-/// reference-counted IOSurface wrapper that is in fact safe to move between
-/// threads). Producers run on a foreign thread; `recv` consumes on the runtime.
-struct SendFrame(Frame);
-unsafe impl Send for SendFrame {}
-
 /// The producer/consumer rendezvous for a single capture session.
 pub(super) struct FrameChannel {
 	state: Mutex<State>,
@@ -31,7 +25,7 @@ pub(super) struct FrameChannel {
 }
 
 struct State {
-	frames: VecDeque<SendFrame>,
+	frames: VecDeque<Frame>,
 	closed: bool,
 }
 
@@ -57,7 +51,7 @@ impl FrameChannel {
 			if state.frames.len() >= DEPTH {
 				state.frames.pop_front();
 			}
-			state.frames.push_back(SendFrame(frame));
+			state.frames.push_back(frame);
 		}
 		self.notify.notify_one();
 	}
@@ -77,7 +71,7 @@ impl FrameChannel {
 			{
 				let mut state = self.state.lock().unwrap();
 				if let Some(frame) = state.frames.pop_front() {
-					return Some(frame.0);
+					return Some(frame);
 				}
 				if state.closed {
 					return None;

--- a/rs/moq-video/src/decode/mod.rs
+++ b/rs/moq-video/src/decode/mod.rs
@@ -59,3 +59,16 @@ impl Frame {
 		}
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	/// Callers (libmoq, moq-transcode) hold these across `.await`s in spawned
+	/// tasks, so they must stay `Send` even when a platform's frame wraps a GPU
+	/// handle. Compile-time check; fails per-platform if a variant regresses.
+	#[test]
+	fn frame_and_consumer_are_send() {
+		fn assert_send<T: Send>() {}
+		assert_send::<super::Frame>();
+		assert_send::<super::Consumer>();
+	}
+}

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -302,6 +302,13 @@ pub(crate) mod macos {
 		pub(crate) height: u32,
 	}
 
+	// SAFETY: CVPixelBuffer is a reference-counted CoreFoundation wrapper around
+	// an IOSurface. Retain/release are thread-safe and the pixel data is only
+	// touched under CVPixelBufferLockBaseAddress, so the handle can move between
+	// threads (capture delegate -> encode loop, decode task -> caller). objc2
+	// leaves CoreVideo types !Send out of conservatism.
+	unsafe impl Send for Surface {}
+
 	impl Surface {
 		pub(crate) fn new(buffer: CFRetained<CVPixelBuffer>, width: u32, height: u32) -> Self {
 			Self { buffer, width, height }


### PR DESCRIPTION
## Summary

The NVDEC merge (#2145) broke `cargo check -p libmoq` on macOS with *"future cannot be sent between threads safely"*. Linux-only CI didn't catch it.

That PR reshaped the public `decode::Frame` to hold the internal `frame::Frame` enum so a GPU-decoded frame can flow zero-copy into NVENC. On macOS that enum has a `Surface` variant wrapping `CFRetained<CVPixelBuffer>`, which objc2 conservatively leaves `!Send`. The non-Send-ness propagated up through `decode::Consumer`, and libmoq's `tokio::spawn` of its decode loop requires a `Send` future, so the crate stopped compiling on macOS.

## Changes

- **`frame.rs`**: `unsafe impl Send for macos::Surface`, with the safety justification the crate already relied on (CVPixelBuffer is a refcounted IOSurface wrapper; retain/release are thread-safe; pixels are only touched under `CVPixelBufferLockBaseAddress`).
- **`capture/channel.rs`**: removed the `SendFrame` newtype that asserted the same fact locally at the capture boundary. The `unsafe` now lives once, on the type itself, and both the capture and decode paths inherit it.
- **`decode/mod.rs`**: added a compile-time `Send` assertion test for `decode::Frame` and `decode::Consumer`, so a future non-Send variant fails `cargo test` on the affected platform instead of only surfacing downstream.

## Public API changes

None. `macos::Surface` and `SendFrame` are private (`pub(crate)` / private); no exported signatures change. Not a breaking change.

## Test plan

- [x] `cargo check -p libmoq` (macOS)
- [x] `cargo check -p moq-video --all-features` (macOS)
- [x] new `decode::tests::frame_and_consumer_are_send` passes
- [x] `nix develop --command just check` (exit 0)

Targets `dev` because it sits on top of the dev-only NVDEC work.

(Written by Claude Fable 5)