### PR TITLE
js/net: model subscription priority as an options object

### DIFF
--- a/demo/web/src/stats.ts
+++ b/demo/web/src/stats.ts
@@ -151,7 +151,7 @@ function subscribeNode(effect: Signals.Effect, conn: Net.Connection.Established,
 	effect.cleanup(() => consumer.close());
 
 	const sub = <K extends keyof NodeStats>(trackName: string, key: K) => {
-		const track = consumer.subscribe(trackName, 0);
+		const track = consumer.subscribe(trackName, { priority: 0 });
 		effect.cleanup(() => track.close());
 		effect.spawn(async () => {
 			for (;;) {

--- a/js/moq-boy/src/game.ts
+++ b/js/moq-boy/src/game.ts
@@ -249,7 +249,7 @@ export class Game {
 		const active = effect.get(this.broadcast.output.active);
 		if (!active) return;
 
-		const statusTrack = active.subscribe("status", 10);
+		const statusTrack = active.subscribe("status", { priority: 10 });
 		effect.cleanup(() => statusTrack.close());
 
 		// Reconstruct each status from snapshots and deltas, validated against the schema.

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -18,7 +18,7 @@ test("consumer dedupes repeat subscriptions onto one upstream request", async ()
 
 	// Two subscriptions to the same track share one upstream subscription...
 	const a = consumer.track("video").subscribe();
-	const b = consumer.subscribe("video", 0);
+	const b = consumer.subscribe("video", { priority: 0 });
 
 	const request = await pendingRequest(consumer);
 	expect(request?.name).toBe("video");
@@ -33,12 +33,12 @@ test("consumer dedupes repeat subscriptions onto one upstream request", async ()
 	expect(await b.readString()).toBe("hello");
 
 	// A different track still opens its own request.
-	consumer.subscribe("audio", 0);
+	consumer.subscribe("audio", { priority: 0 });
 	expect((await pendingRequest(consumer))?.name).toBe("audio");
 
 	// Once the shared track closes, a later subscribe re-opens it.
 	producer.close();
-	consumer.subscribe("video", 0);
+	consumer.subscribe("video", { priority: 0 });
 	expect((await pendingRequest(consumer))?.name).toBe("video");
 });
 
@@ -75,8 +75,8 @@ test("consumer track subscriptions fan out and close independently", async () =>
 	const consumer = new BroadcastConsumer();
 
 	// Two subscriptions to one track dedupe onto a single upstream request...
-	const a = consumer.subscribe("video", 0);
-	const b = consumer.subscribe("video", 0);
+	const a = consumer.subscribe("video", { priority: 0 });
+	const b = consumer.subscribe("video", { priority: 0 });
 
 	const request = await pendingRequest(consumer);
 	if (!request) throw new Error("expected request");

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -38,7 +38,12 @@ function closeState(state: BroadcastState, abort?: Error) {
 // subscription instead of opening a new one, mirroring the Rust `broadcast::Consumer::track`
 // weak-dedup. The publishing side leaves it false: `state.tracks` there holds only the tracks
 // the app inserted, and a dynamic serve stays one request per peer subscription.
-function subscribe(state: BroadcastState, name: string, priority: number, register = false): track.Subscriber {
+function subscribe(
+	state: BroadcastState,
+	name: string,
+	options: track.SubscribeOptions = {},
+	register = false,
+): track.Subscriber {
 	if (state.closed.peek()) {
 		throw new Error(`broadcast is closed: ${state.closed.peek()}`);
 	}
@@ -61,7 +66,7 @@ function subscribe(state: BroadcastState, name: string, priority: number, regist
 	}
 
 	state.requested.mutate((requested) => {
-		requested.push(new track.Request(name, producer, priority));
+		requested.push(new track.Request(name, producer, options.priority ?? 0));
 		requested.sort((a, b) => a.priority - b.priority);
 	});
 
@@ -100,7 +105,7 @@ async function fetchGroup(
 	sequence: number,
 	options: track.FetchGroupOptions = {},
 ): Promise<GroupConsumer> {
-	const subscriber = subscribe(state, name, options.priority ?? 0);
+	const subscriber = subscribe(state, name, { priority: options.priority ?? 0 });
 	try {
 		for (;;) {
 			const group = await subscriber.recvGroup();
@@ -189,8 +194,8 @@ export class Producer implements track.Broadcast {
 	}
 
 	/** Open a live subscription to a track. Used by the publishing wire layer. */
-	subscribe(name: string, priority: number): track.Subscriber {
-		return subscribe(this.#state, name, priority);
+	subscribe(name: string, options?: track.SubscribeOptions): track.Subscriber {
+		return subscribe(this.#state, name, options);
 	}
 
 	/** Resolve a track's immutable info. Used by the publishing wire layer. */
@@ -268,8 +273,8 @@ export class Consumer implements track.Broadcast {
 	}
 
 	/** Open a live subscription to a track. Used by the subscribing wire layer. Repeat subscriptions to the same track share one upstream subscription. */
-	subscribe(name: string, priority: number): track.Subscriber {
-		return subscribe(this.#state, name, priority, true);
+	subscribe(name: string, options?: track.SubscribeOptions): track.Subscriber {
+		return subscribe(this.#state, name, options, true);
 	}
 
 	/** Return the next track requested by the local consumer. Used by the subscribing wire layer. */

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -150,7 +150,7 @@ export class Publisher {
 			return;
 		}
 
-		const track = broadcast.subscribe(msg.trackName, msg.subscriberPriority);
+		const track = broadcast.subscribe(msg.trackName, { priority: msg.subscriberPriority });
 
 		try {
 			// Send SUBSCRIBE_OK

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -384,7 +384,7 @@ test("integration: subscribe to non-existent broadcast", async () => {
 
 	// Client tries to consume a broadcast that nobody is publishing
 	const remote = client.consume(Path.from("nonexistent"));
-	const track = remote.subscribe("video", 0);
+	const track = remote.subscribe("video", { priority: 0 });
 
 	// Reading should eventually error since the broadcast doesn't exist
 	await expect(

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -230,7 +230,7 @@ export class Publisher {
 			return;
 		}
 
-		const track = broadcast.subscribe(msg.track, msg.priority);
+		const track = broadcast.subscribe(msg.track, { priority: msg.priority });
 
 		// The best-effort datagram loop, started once serving begins. It parks when the
 		// track finishes (recvDatagram returns undefined), so #runTrack alone ends the

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -90,6 +90,16 @@ export interface FetchGroupOptions {
 }
 
 /**
+ * Subscriber-side preferences for a subscription.
+ *
+ * @public
+ */
+export interface SubscribeOptions {
+	/** Delivery priority for this subscription. Higher values are served first when constrained. Defaults to `0`. */
+	priority?: number;
+}
+
+/**
  * The per-track operations a lazy {@link Consumer} delegates to the broadcast it came from.
  *
  * Implemented by `broadcast.Producer` / `broadcast.Consumer` (and the wire-layer subclasses
@@ -98,7 +108,7 @@ export interface FetchGroupOptions {
  */
 export interface Broadcast {
 	/** Open a live subscription to the named track. */
-	subscribe(name: string, priority: number): Subscriber;
+	subscribe(name: string, options?: SubscribeOptions): Subscriber;
 	/** Resolve the named track's immutable info. */
 	resolveTrackInfo(name: string): Promise<Info>;
 	/** Fetch a single group of the named track by sequence. */
@@ -122,8 +132,8 @@ export class Consumer {
 	}
 
 	/** Open a live subscription to the track. */
-	subscribe(options?: { priority?: number }): Subscriber {
-		return this.#broadcast.subscribe(this.name, options?.priority ?? 0);
+	subscribe(options?: SubscribeOptions): Subscriber {
+		return this.#broadcast.subscribe(this.name, options);
 	}
 
 	/** Fetch the track's immutable publisher properties without subscribing. */

--- a/test/smoke/clients/js-native/subscribe.ts
+++ b/test/smoke/clients/js-native/subscribe.ts
@@ -66,7 +66,7 @@ async function run(): Promise<void> {
 		// The .hang catalog lives on the "catalog.json" track. It's a @moq/json
 		// snapshot+delta value, reconstructed by Json.Consumer. A lazy publisher may
 		// announce video in a later update, so keep reading until one has it.
-		const track = bc.subscribe("catalog.json", Catalog.PRIORITY.catalog);
+		const track = bc.subscribe("catalog.json", { priority: Catalog.PRIORITY.catalog });
 		const catalog = new Json.Consumer<Catalog.Root>(track, { schema: Catalog.RootSchema });
 		let videoTrack: string | undefined;
 		while (!videoTrack) {
@@ -76,7 +76,7 @@ async function run(): Promise<void> {
 			if (renditions) videoTrack = Object.keys(renditions)[0];
 		}
 
-		const video = bc.subscribe(videoTrack, 0);
+		const video = bc.subscribe(videoTrack, { priority: 0 });
 		let total = 0;
 		for (;;) {
 			const group = await video.recvGroup();

--- a/test/smoke/clients/js-native/subscribe.ts
+++ b/test/smoke/clients/js-native/subscribe.ts
@@ -50,12 +50,16 @@ async function run(): Promise<void> {
 		// which resets the catalog stream (RESET_STREAM). The Rust API folds this
 		// wait into consume(); the JS API leaves it to the caller. The outer timeout
 		// below bounds how long we wait.
+		//
+		// `announced(path)` is scoped to `path`, so each entry's `path` is relative to it
+		// (empty for the broadcast at `path` itself). Any active entry means a matching
+		// broadcast is up, so wait for one.
 		const announced = connection.announced(path);
 		try {
 			for (;;) {
 				const entry = await announced.next();
 				if (!entry) throw new Error("connection closed before broadcast was announced");
-				if (entry.active && Moq.Path.hasPrefix(path, entry.path)) break;
+				if (entry.active) break;
 			}
 		} finally {
 			announced.close();


### PR DESCRIPTION
## Summary

Replace the positional `priority: number` argument on `Broadcast.subscribe` (and the `Broadcast.Producer` / `Broadcast.Consumer` implementations) with a `SubscribeOptions` bag, so the subscribe surface matches `Track.Consumer.subscribe` (which already takes `{ priority }`) and can gain future subscription knobs without another breaking signature change.

This is the **shape** half of #2155, kept deliberately small. The full `Subscription` model (ordered / stale / group-range plumbing and `Subscriber.update()`) is **deferred to a follow-up** so it can land additively once it is wired end-to-end and verified green against a real relay. The previous version of this PR plumbed those fields eagerly along with a receive-path/aggregation rework; that is pulled out until it is correct.

## Public API Changes

- Added `Track.SubscribeOptions` (`{ priority?: number }`).
- Changed `Broadcast.subscribe`, `Broadcast.Producer.subscribe`, and `Broadcast.Consumer.subscribe` to take `SubscribeOptions` instead of a positional `priority`. Breaking for callers of the positional argument, so this targets `dev`.
- `Track.Consumer.subscribe` keeps its `{ priority }` options shape (now typed as `SubscribeOptions`).

Deferred to the follow-up (not in this PR, #2155 stays open): `Track.Subscription`, group-range / stale / ordered plumbing, and `Subscriber.updatePriority` -> `update()`.

## Also: smoke test fix (separate commit)

`test(smoke): fix native-JS announce wait after prefix stripping` fixes a **pre-existing `dev` breakage** unrelated to the reshape. #2088 ("Strip announced prefixes in JS") made `Connection.announced(prefix)` yield entry paths relative to the prefix, but the native-JS smoke subscriber still matched against the absolute path, so every `* -> js-native-{node,bun}` leg had been timing out on `dev`. Included here because it blocks this PR's Smoke check and is a one-liner in a file this PR already touches; happy to split it out if preferred.

## Tests

- `bun test js/net/src` (231 pass)
- `just js check` (typecheck + biome, all packages clean)
- `test/smoke/smoke.sh --publishers rust --subscribers js-native-node` -> `PASS` (was timing out before the announce fix)

The reshape is behaviorally identical to `dev` at runtime (priority flows through unchanged).

(Written by Claude Opus 4.8)