### PR TITLE
docs: update Discord URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 ![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)
-[![Discord](https://img.shields.io/discord/1124083992740761730)](https://discord.gg/FCYF3p99mr)
+[![Discord](https://img.shields.io/discord/1124083992740761730)](https://discord.moq.dev)
 [![Crates.io](https://img.shields.io/crates/v/moq-net)](https://crates.io/crates/moq-net)
 [![npm](https://img.shields.io/npm/v/@moq/net)](https://www.npmjs.com/package/@moq/net)
 

--- a/doc/concept/standard/index.md
+++ b/doc/concept/standard/index.md
@@ -44,4 +44,4 @@ They are too early/unstable to be useful, so we're using a custom [hang](/concep
 - [Website](https://moq.dev)
 - [GitHub](https://github.com/moq-dev/moq)
 - [Documentation](https://doc.moq.dev)
-- [Discord](https://discord.gg/FCYF3p99mr)
+- [Discord](https://discord.moq.dev)


### PR DESCRIPTION
Summary:
- Update public Discord links to https://discord.moq.dev.

Tests:
- nix develop --command just fix
- nix develop --command just ci

(Written by GPT-5)