### PR TITLE
Update libmoq raw track C ABI

### DIFF
--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -88,9 +88,9 @@ generated header at `../../target/release/moq.h`.
 
 Any function that registers a callback (`moq_session_connect`, `moq_origin_announced`, `moq_origin_consume_announced`, `moq_origin_request`, `moq_consume_catalog`, `moq_consume_video_ordered`, `moq_consume_audio_ordered`, `moq_consume_track`, `moq_consume_video_raw`, `moq_consume_audio_raw`) takes a `void *user_data` pointer that libmoq passes back to every callback invocation. The status code carries the lifecycle:
 
-- **`> 0`** — a live result you can use: a frame, catalog, or announce ID (or `1` to mean "session connected"). May fire any number of times.
-- **`0`** — closed cleanly. **Terminal.**
-- **`< 0`** — closed with an error. **Terminal.**
+- **`> 0`**: a live result you can use: a frame, catalog, or announce ID (or `1` to mean "session connected"). May fire any number of times.
+- **`0`**: closed cleanly. **Terminal.**
+- **`< 0`**: closed with an error. **Terminal.**
 
 A positive result that is itself a handle must be freed once you're done with it (e.g. a broadcast from `moq_origin_request` via `moq_consume_close`). `moq_origin_announced` is the notable repeat case: it delivers a fresh announce ID for *every* announce / unannounce event, so free each one with `moq_origin_announced_free` after reading it with `moq_origin_announced_info`, or they accumulate for the life of the listener.
 
@@ -116,6 +116,55 @@ if (rc < 0) {
 A server can reject the connection on auth grounds: unauthorized (HTTP 401) or forbidden (HTTP 403). Each returns its own distinct negative code (with `moq_error()` reporting `"unauthorized"` / `"forbidden"`). These are terminal, so distinguish them from a transient transport failure and stop rather than reconnecting.
 
 Failed calls are reported only through the return code and `moq_error()`, not logged. To surface libmoq's internal logs (moq-net / QUIC activity), call `moq_log_level("debug")` (or `"trace"`, `"info"`, etc.) to install a tracing subscriber.
+
+## Raw Track Options
+
+`moq_publish_track` accepts optional publisher-side track properties:
+
+```c
+struct moq_track_info info = {0};
+info.priority = 3;
+info.ordered = true;
+info.ordered_valid = true;
+info.cache_ms = 1000;
+info.cache_valid = true;
+info.timescale = 1000000;
+info.timescale_valid = true;
+
+int track = moq_publish_track(
+    broadcast,
+    name,
+    name_len,
+    &info);
+```
+
+`moq_consume_track` accepts optional subscriber delivery preferences.
+`moq_consume_track_update` changes them while the callback task is running.
+Fields ending in `_valid` decide whether the matching value overrides the default:
+
+```c
+struct moq_subscription sub = {0};
+sub.priority = 5;
+sub.ordered = true;
+sub.ordered_valid = true;
+sub.stale_ms = 25;
+sub.group_start = 10;
+sub.group_start_valid = true;
+
+int consumer = moq_consume_track(
+    broadcast,
+    name,
+    name_len,
+    &sub,
+    on_frame,
+    user_data);
+
+sub.group_end = 20;
+sub.group_end_valid = true;
+moq_consume_track_update(consumer, &sub);
+```
+
+Pass `NULL` for either options pointer to use the moq-net defaults.
 
 ## Use cases
 

--- a/rs/libmoq/CHANGELOG.md
+++ b/rs/libmoq/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Raw track options for the C ABI: `moq_publish_track` now accepts
+  `moq_track_info`, and `moq_consume_track` now accepts `moq_subscription`;
+  subscriptions can be updated with `moq_consume_track_update`.
 - Native video decode C API: `moq_consume_video_raw` (+ `_close`, `_frame`,
   `_frame_free`) subscribes to an H.264 track and hands back decoded I420 frames,
   the video counterpart to `moq_consume_audio_raw`. Decoding happens inside

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -68,6 +68,98 @@ pub struct moq_frame {
 	pub keyframe: bool,
 }
 
+/// Publisher-side raw track properties.
+///
+/// A null [moq_publish_track] `info` pointer uses the moq-net defaults.
+/// A zero-initialized struct also uses those defaults, except `priority` where
+/// zero is the default itself.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct moq_track_info {
+	/// Priority, used to break ties between subscriptions of equal subscriber priority.
+	pub priority: u8,
+
+	/// Whether groups are delivered in sequence order when `ordered_valid` is true.
+	pub ordered: bool,
+	/// Whether `ordered` should override the default ordered setting.
+	pub ordered_valid: bool,
+
+	/// How long the relay should cache past groups, in milliseconds.
+	pub cache_ms: u64,
+	/// Whether `cache_ms` should override the default cache setting.
+	pub cache_valid: bool,
+
+	/// Per-frame timescale in ticks per second.
+	pub timescale: u64,
+	/// Whether `timescale` should override the default millisecond timescale.
+	pub timescale_valid: bool,
+}
+
+impl TryFrom<&moq_track_info> for moq_net::track::Info {
+	type Error = Error;
+
+	fn try_from(info: &moq_track_info) -> Result<Self, Self::Error> {
+		let mut out = moq_net::track::Info::default().with_priority(info.priority);
+		if info.ordered_valid {
+			out = out.with_ordered(info.ordered);
+		}
+		if info.cache_valid {
+			out = out.with_cache(std::time::Duration::from_millis(info.cache_ms));
+		}
+		if info.timescale_valid {
+			out = out.with_timescale(moq_net::Timescale::new(info.timescale)?);
+		}
+		Ok(out)
+	}
+}
+
+/// Subscriber-side raw track delivery preferences.
+///
+/// A null [moq_consume_track] or [moq_consume_track_update] `subscription`
+/// pointer uses the moq-net defaults.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub struct moq_subscription {
+	/// Delivery priority. Higher values preempt lower ones under contention.
+	pub priority: u8,
+
+	/// Whether groups are delivered in sequence order when `ordered_valid` is true.
+	pub ordered: bool,
+	/// Whether `ordered` should override the default ordered setting.
+	pub ordered_valid: bool,
+
+	/// How long to wait for an older group once a newer group has arrived, in milliseconds.
+	pub stale_ms: u64,
+
+	/// First group to deliver.
+	pub group_start: u64,
+	/// Whether `group_start` is present. When false, delivery starts at the latest group.
+	pub group_start_valid: bool,
+
+	/// Last group to deliver, inclusive.
+	pub group_end: u64,
+	/// Whether `group_end` is present. When false, there is no end cap.
+	pub group_end_valid: bool,
+}
+
+impl From<&moq_subscription> for moq_net::Subscription {
+	fn from(subscription: &moq_subscription) -> Self {
+		let mut out = moq_net::Subscription::default()
+			.with_priority(subscription.priority)
+			.with_stale(std::time::Duration::from_millis(subscription.stale_ms));
+		if subscription.ordered_valid {
+			out = out.with_ordered(subscription.ordered);
+		}
+		if subscription.group_start_valid {
+			out = out.with_group_start(subscription.group_start);
+		}
+		if subscription.group_end_valid {
+			out = out.with_group_end(subscription.group_end);
+		}
+		out
+	}
+}
+
 /// A borrowed UTF-8 string slice, NOT NULL terminated.
 ///
 /// Used to hand a C caller a JSON document that lives inside libmoq's storage.
@@ -824,18 +916,27 @@ pub unsafe extern "C" fn moq_remove_catalog_section(broadcast: u32, name: *const
 /// as-is to subscribers using [moq_consume_track]. Use it for non-media tracks
 /// (control channels, JSON metadata, etc.), or pair it with
 /// [moq_publish_video_config] / [moq_publish_audio_config] to also describe the
-/// track in the catalog.
+/// track in the catalog. Pass NULL for `info` to use moq-net defaults.
 ///
 /// Returns a non-zero handle to the track on success, or a negative code on failure.
 ///
 /// # Safety
 /// - The caller must ensure that name is a valid pointer to name_len bytes of data.
+/// - The caller must ensure that info is either NULL or a valid pointer to a [moq_track_info] struct.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn moq_publish_track(broadcast: u32, name: *const c_char, name_len: usize) -> i32 {
+pub unsafe extern "C" fn moq_publish_track(
+	broadcast: u32,
+	name: *const c_char,
+	name_len: usize,
+	info: *const moq_track_info,
+) -> i32 {
 	ffi::enter(move || {
 		let broadcast = ffi::parse_id(broadcast)?;
 		let name = unsafe { ffi::parse_str(name, name_len)? };
-		State::lock().publish.track(broadcast, name)
+		let info = unsafe { info.as_ref() }
+			.map(moq_net::track::Info::try_from)
+			.transpose()?;
+		State::lock().publish.track(broadcast, name, info)
 	})
 }
 
@@ -1205,31 +1306,52 @@ pub extern "C" fn moq_consume_close(consume: u32) -> i32 {
 ///
 /// This is the counterpart to [moq_publish_track]: no catalog lookup or
 /// container parsing. `on_frame` is called with a positive raw frame ID for each
-/// frame in arrival order, then exactly once more with a terminal code: `0`
+/// frame in sequence order, then exactly once more with a terminal code: `0`
 /// (closed cleanly) or a negative error. After the terminal (`<= 0`) callback,
 /// `on_frame` is never called again and `user_data` is never touched again, so
 /// release `user_data` there. The terminal callback fires even after
 /// [moq_consume_track_close]. Read each frame with [moq_consume_track_frame] and
-/// release it with [moq_consume_track_frame_close].
+/// release it with [moq_consume_track_frame_close]. Pass NULL for `subscription`
+/// to use moq-net defaults.
 ///
 /// Returns a non-zero handle to the track on success, or a negative code on failure.
 ///
 /// # Safety
 /// - The caller must ensure that name is a valid pointer to name_len bytes of data.
+/// - The caller must ensure that subscription is either NULL or a valid pointer to a [moq_subscription] struct.
 /// - The caller must keep `user_data` valid until the terminal (`<= 0`) `on_frame` callback.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn moq_consume_track(
 	broadcast: u32,
 	name: *const c_char,
 	name_len: usize,
+	subscription: *const moq_subscription,
 	on_frame: Option<extern "C" fn(user_data: *mut c_void, frame: i32)>,
 	user_data: *mut c_void,
 ) -> i32 {
 	ffi::enter(move || {
 		let broadcast = ffi::parse_id(broadcast)?;
 		let name = unsafe { ffi::parse_str(name, name_len)? };
+		let subscription = unsafe { subscription.as_ref() }.map(moq_net::Subscription::from);
 		let on_frame = unsafe { ffi::OnStatus::new(user_data, on_frame) };
-		State::lock().consume.raw_track(broadcast, name, on_frame)
+		State::lock().consume.raw_track(broadcast, name, subscription, on_frame)
+	})
+}
+
+/// Update a raw track subscription's delivery preferences.
+///
+/// Pass NULL for `subscription` to reset to moq-net defaults.
+///
+/// Returns a zero on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that subscription is either NULL or a valid pointer to a [moq_subscription] struct.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_consume_track_update(track: u32, subscription: *const moq_subscription) -> i32 {
+	ffi::enter(move || {
+		let track = ffi::parse_id(track)?;
+		let subscription = unsafe { subscription.as_ref() }.map(moq_net::Subscription::from);
+		State::lock().consume.raw_track_update(track, subscription)
 	})
 }
 

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -1,5 +1,5 @@
-use std::ffi::c_char;
-use tokio::sync::oneshot;
+use std::{ffi::c_char, future::Future, pin::Pin, task::Poll};
+use tokio::sync::{mpsc, oneshot};
 
 use crate::ffi::OnStatus;
 use crate::{Error, Id, NonZeroSlab, State, moq_audio_config, moq_frame, moq_section, moq_string, moq_video_config};
@@ -31,6 +31,13 @@ struct TaskEntry {
 	callback: OnStatus,
 }
 
+/// A raw track task also accepts subscription updates while it is running.
+struct RawTaskEntry {
+	close: Option<oneshot::Sender<()>>,
+	update: mpsc::UnboundedSender<Option<moq_net::Subscription>>,
+	callback: OnStatus,
+}
+
 #[derive(Default)]
 pub struct Consume {
 	/// Active broadcast consumers.
@@ -49,7 +56,7 @@ pub struct Consume {
 	frame: NonZeroSlab<moq_mux::container::Frame>,
 
 	/// Raw track consumer tasks (no media/container framing).
-	raw_task: NonZeroSlab<Option<TaskEntry>>,
+	raw_task: NonZeroSlab<Option<RawTaskEntry>>,
 
 	/// Buffered raw frames ready for consumption.
 	raw_frame: NonZeroSlab<bytes::Bytes>,
@@ -419,7 +426,7 @@ impl Consume {
 
 	/// Read the payload of a frame as a single contiguous slice.
 	///
-	/// Frames are not chunked — the payload pointer is valid until the frame is closed
+	/// Frames are not chunked. The payload pointer is valid until the frame is closed
 	/// via [`Self::frame_close`].
 	pub fn frame(&self, frame: Id, dst: &mut moq_frame) -> Result<(), Error> {
 		let f = self.frame.get(frame).ok_or(Error::FrameNotFound)?;
@@ -450,14 +457,22 @@ impl Consume {
 	///
 	/// No catalog lookup or container parsing. This is the moq-net primitive for
 	/// non-media tracks. `on_frame` is called with a raw frame ID for each frame,
-	/// in arrival order. Frames must be released with [`Self::raw_frame_close`].
-	pub fn raw_track(&mut self, broadcast: Id, name: &str, on_frame: OnStatus) -> Result<Id, Error> {
+	/// in sequence order. Frames must be released with [`Self::raw_frame_close`].
+	pub fn raw_track(
+		&mut self,
+		broadcast: Id,
+		name: &str,
+		subscription: Option<moq_net::Subscription>,
+		on_frame: OnStatus,
+	) -> Result<Id, Error> {
 		let broadcast = self.broadcast.get(broadcast).ok_or(Error::BroadcastNotFound)?.clone();
 		let name = name.to_string();
 
 		let channel = oneshot::channel();
-		let entry = TaskEntry {
+		let (update, updates) = mpsc::unbounded_channel();
+		let entry = RawTaskEntry {
 			close: Some(channel.0),
+			update,
 			callback: on_frame,
 		};
 		let id = self.raw_task.insert(Some(entry))?;
@@ -465,8 +480,9 @@ impl Consume {
 		// `subscribe` blocks on SUBSCRIBE_OK, so run it inside the task.
 		tokio::spawn(async move {
 			let res = async move {
-				let track = broadcast.track(&name)?.subscribe(None).await?;
-				Self::run_raw(on_frame, track, channel.1).await
+				let mut track = broadcast.track(&name)?.subscribe(subscription.clone()).await?;
+				Self::apply_raw_subscription(&mut track, subscription);
+				Self::run_raw(on_frame, track, channel.1, updates).await
 			}
 			.await;
 
@@ -481,34 +497,76 @@ impl Consume {
 		Ok(id)
 	}
 
+	fn apply_raw_subscription(track: &mut moq_net::track::Subscriber, subscription: Option<moq_net::Subscription>) {
+		let subscription = subscription.unwrap_or_default();
+		if let Some(start) = subscription.group_start.or_else(|| track.latest()) {
+			track.start_at(start);
+		}
+		track.end_at(subscription.group_end);
+		track.update(subscription);
+	}
+
 	async fn run_raw(
 		callback: OnStatus,
 		mut track: moq_net::track::Subscriber,
 		mut close: oneshot::Receiver<()>,
+		mut updates: mpsc::UnboundedReceiver<Option<moq_net::Subscription>>,
 	) -> Result<(), Error> {
 		// Deliver every frame in sequence order, reading all frames within each
 		// group rather than the one-frame-per-group convenience. This is the
 		// "raw track contents" model: the consumer sees exactly what the
 		// producer wrote, regardless of how it was grouped.
 		loop {
-			// `biased` so a pending close always wins over a ready group.
-			let mut group = tokio::select! {
-				biased;
-				_ = &mut close => return Ok(()),
-				group = track.next_group() => match group? {
-					Some(group) => group,
-					None => return Ok(()),
-				},
+			let Some(mut group) =
+				moq_net::kio::wait(|waiter| -> Poll<Result<Option<moq_net::group::Consumer>, Error>> {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					if Pin::new(&mut close).poll(&mut cx).is_ready() {
+						return Poll::Ready(Ok(None));
+					}
+
+					loop {
+						match updates.poll_recv(&mut cx) {
+							Poll::Ready(Some(subscription)) => Self::apply_raw_subscription(&mut track, subscription),
+							Poll::Ready(None) => return Poll::Ready(Ok(None)),
+							Poll::Pending => break,
+						}
+					}
+
+					match track.poll_next_group(waiter) {
+						Poll::Ready(Ok(group)) => Poll::Ready(Ok(group)),
+						Poll::Ready(Err(err)) => Poll::Ready(Err(err.into())),
+						Poll::Pending => Poll::Pending,
+					}
+				})
+				.await?
+			else {
+				return Ok(());
 			};
 
 			loop {
-				let payload = tokio::select! {
-					biased;
-					_ = &mut close => return Ok(()),
-					payload = group.read_frame() => match payload? {
-						Some(payload) => payload,
-						None => break,
-					},
+				let Some(payload) = moq_net::kio::wait(|waiter| -> Poll<Result<Option<bytes::Bytes>, Error>> {
+					let mut cx = std::task::Context::from_waker(waiter.waker());
+					if Pin::new(&mut close).poll(&mut cx).is_ready() {
+						return Poll::Ready(Ok(None));
+					}
+
+					loop {
+						match updates.poll_recv(&mut cx) {
+							Poll::Ready(Some(subscription)) => Self::apply_raw_subscription(&mut track, subscription),
+							Poll::Ready(None) => return Poll::Ready(Ok(None)),
+							Poll::Pending => break,
+						}
+					}
+
+					match group.poll_read_frame(waiter) {
+						Poll::Ready(Ok(payload)) => Poll::Ready(Ok(payload)),
+						Poll::Ready(Err(err)) => Poll::Ready(Err(err.into())),
+						Poll::Pending => Poll::Pending,
+					}
+				})
+				.await?
+				else {
+					break;
 				};
 
 				// Hold the lock only to buffer the frame; release it before the callback.
@@ -516,6 +574,16 @@ impl Consume {
 				callback.call(Ok(frame_id));
 			}
 		}
+	}
+
+	pub fn raw_track_update(&mut self, track: Id, subscription: Option<moq_net::Subscription>) -> Result<(), Error> {
+		let entry = self
+			.raw_task
+			.get_mut(track)
+			.and_then(|entry| entry.as_mut())
+			.ok_or(Error::TrackNotFound)?;
+		entry.update.send(subscription).map_err(|_| Error::TrackNotFound)?;
+		Ok(())
 	}
 
 	pub fn raw_track_close(&mut self, track: Id) -> Result<(), Error> {
@@ -551,7 +619,7 @@ impl Consume {
 	}
 
 	/// Look up a video rendition by catalog index, returning the
-	/// (broadcast, config, name) tuple needed to subscribe — mirrors
+	/// (broadcast, config, name) tuple needed to subscribe. Mirrors
 	/// the index-based selection in `video_ordered`.
 	pub fn video_rendition(
 		&self,
@@ -570,7 +638,7 @@ impl Consume {
 	}
 
 	/// Look up an audio rendition by catalog index, returning the
-	/// (broadcast, config, name) tuple needed to subscribe — mirrors
+	/// (broadcast, config, name) tuple needed to subscribe. Mirrors
 	/// the index-based selection in `audio_ordered`.
 	pub fn audio_rendition(
 		&self,

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -38,6 +38,16 @@ struct RawTaskEntry {
 	callback: OnStatus,
 }
 
+/// Outcome of polling a raw track source alongside its control channels.
+enum RawStep<T> {
+	/// A delivered value: the next group, or the next frame within a group.
+	Item(T),
+	/// The source is exhausted: the track finished, or the group was fully read.
+	End,
+	/// The consumer was closed; the task must unwind without re-polling `close`.
+	Stop,
+}
+
 #[derive(Default)]
 pub struct Consume {
 	/// Active broadcast consumers.
@@ -516,62 +526,80 @@ impl Consume {
 		// group rather than the one-frame-per-group convenience. This is the
 		// "raw track contents" model: the consumer sees exactly what the
 		// producer wrote, regardless of how it was grouped.
+		//
+		// `close` is a oneshot that panics if polled after completion, so a `Stop`
+		// must unwind the whole task rather than fall through to the outer loop.
 		loop {
-			let Some(mut group) =
-				moq_net::kio::wait(|waiter| -> Poll<Result<Option<moq_net::group::Consumer>, Error>> {
-					let mut cx = std::task::Context::from_waker(waiter.waker());
-					if Pin::new(&mut close).poll(&mut cx).is_ready() {
-						return Poll::Ready(Ok(None));
+			let mut group =
+				match moq_net::kio::wait(|waiter| -> Poll<Result<RawStep<moq_net::group::Consumer>, Error>> {
+					if Self::poll_raw_control(&mut close, &mut updates, &mut track, waiter) {
+						return Poll::Ready(Ok(RawStep::Stop));
 					}
-
-					loop {
-						match updates.poll_recv(&mut cx) {
-							Poll::Ready(Some(subscription)) => Self::apply_raw_subscription(&mut track, subscription),
-							Poll::Ready(None) => return Poll::Ready(Ok(None)),
-							Poll::Pending => break,
-						}
-					}
-
 					match track.poll_next_group(waiter) {
-						Poll::Ready(Ok(group)) => Poll::Ready(Ok(group)),
+						Poll::Ready(Ok(Some(group))) => Poll::Ready(Ok(RawStep::Item(group))),
+						Poll::Ready(Ok(None)) => Poll::Ready(Ok(RawStep::End)),
 						Poll::Ready(Err(err)) => Poll::Ready(Err(err.into())),
 						Poll::Pending => Poll::Pending,
 					}
 				})
 				.await?
-			else {
-				return Ok(());
-			};
+				{
+					RawStep::Item(group) => group,
+					// Track finished or the consumer was closed: nothing left to deliver.
+					RawStep::End | RawStep::Stop => return Ok(()),
+				};
 
 			loop {
-				let Some(payload) = moq_net::kio::wait(|waiter| -> Poll<Result<Option<bytes::Bytes>, Error>> {
-					let mut cx = std::task::Context::from_waker(waiter.waker());
-					if Pin::new(&mut close).poll(&mut cx).is_ready() {
-						return Poll::Ready(Ok(None));
+				let payload = match moq_net::kio::wait(|waiter| -> Poll<Result<RawStep<bytes::Bytes>, Error>> {
+					if Self::poll_raw_control(&mut close, &mut updates, &mut track, waiter) {
+						return Poll::Ready(Ok(RawStep::Stop));
 					}
-
-					loop {
-						match updates.poll_recv(&mut cx) {
-							Poll::Ready(Some(subscription)) => Self::apply_raw_subscription(&mut track, subscription),
-							Poll::Ready(None) => return Poll::Ready(Ok(None)),
-							Poll::Pending => break,
-						}
-					}
-
 					match group.poll_read_frame(waiter) {
-						Poll::Ready(Ok(payload)) => Poll::Ready(Ok(payload)),
+						Poll::Ready(Ok(Some(payload))) => Poll::Ready(Ok(RawStep::Item(payload))),
+						Poll::Ready(Ok(None)) => Poll::Ready(Ok(RawStep::End)),
 						Poll::Ready(Err(err)) => Poll::Ready(Err(err.into())),
 						Poll::Pending => Poll::Pending,
 					}
 				})
 				.await?
-				else {
-					break;
+				{
+					RawStep::Item(payload) => payload,
+					// Group fully read: advance to the next group.
+					RawStep::End => break,
+					// Consumer closed mid-group: terminate without touching `close` again.
+					RawStep::Stop => return Ok(()),
 				};
 
 				// Hold the lock only to buffer the frame; release it before the callback.
 				let frame_id = State::lock().consume.raw_frame.insert(payload)?;
 				callback.call(Ok(frame_id));
+			}
+		}
+	}
+
+	/// Poll the close and update channels, applying any subscription updates inline.
+	///
+	/// Returns `true` when the task must stop: either the consumer was closed
+	/// (`close` fired) or the update channel was dropped. The caller must then
+	/// unwind rather than poll `close` again, since a completed oneshot panics if
+	/// re-polled. Borrows `track` only for the duration of the call so the caller
+	/// can poll a track/group source afterwards.
+	fn poll_raw_control(
+		close: &mut oneshot::Receiver<()>,
+		updates: &mut mpsc::UnboundedReceiver<Option<moq_net::Subscription>>,
+		track: &mut moq_net::track::Subscriber,
+		waiter: &moq_net::kio::Waiter,
+	) -> bool {
+		let mut cx = std::task::Context::from_waker(waiter.waker());
+		if Pin::new(close).poll(&mut cx).is_ready() {
+			return true;
+		}
+
+		loop {
+			match updates.poll_recv(&mut cx) {
+				Poll::Ready(Some(subscription)) => Self::apply_raw_subscription(track, subscription),
+				Poll::Ready(None) => return true,
+				Poll::Pending => return false,
 			}
 		}
 	}

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -177,9 +177,9 @@ impl Publish {
 	/// No codec, container, or catalog framing. This is the moq-net primitive
 	/// for non-media tracks. Pair it with [`Self::video_config`] / [`Self::audio_config`]
 	/// if you want to describe the track in the catalog as well.
-	pub fn track(&mut self, broadcast: Id, name: &str) -> Result<Id, Error> {
+	pub fn track(&mut self, broadcast: Id, name: &str, info: Option<moq_net::track::Info>) -> Result<Id, Error> {
 		let (broadcast, _) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
-		let track = broadcast.create_track(name, None)?;
+		let track = broadcast.create_track(name, info)?;
 		self.tracks.insert(track)
 	}
 

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -494,12 +494,52 @@ fn catalog_section_roundtrip() {
 #[test]
 fn publish_track_invalid_broadcast() {
 	let name = b"data";
-	assert!(unsafe { moq_publish_track(0, name.as_ptr() as *const c_char, name.len()) } < 0);
+	assert!(unsafe { moq_publish_track(0, name.as_ptr() as *const c_char, name.len(), std::ptr::null()) } < 0);
+	let info = moq_track_info {
+		priority: 1,
+		ordered: true,
+		ordered_valid: true,
+		cache_ms: 0,
+		cache_valid: false,
+		timescale: 0,
+		timescale_valid: false,
+	};
+	assert!(unsafe { moq_publish_track(0, name.as_ptr() as *const c_char, name.len(), &info) } < 0);
 	assert!(moq_publish_track_group(9999) < 0);
 	assert!(unsafe { moq_publish_track_frame(9999, name.as_ptr(), name.len()) } < 0);
 	assert!(unsafe { moq_publish_group_frame(9999, name.as_ptr(), name.len()) } < 0);
 	assert!(moq_publish_track_close(9999) < 0);
 	assert!(moq_publish_group_close(9999) < 0);
+
+	let subscription = moq_subscription {
+		priority: 1,
+		ordered: true,
+		ordered_valid: true,
+		stale_ms: 0,
+		group_start: 0,
+		group_start_valid: false,
+		group_end: 0,
+		group_end_valid: false,
+	};
+	assert!(unsafe { moq_consume_track_update(9999, &subscription) } < 0);
+}
+
+#[test]
+fn publish_track_with_info_rejects_invalid_timescale() {
+	let broadcast = id(moq_publish_create());
+	let name = b"data";
+	let info = moq_track_info {
+		priority: 0,
+		ordered: false,
+		ordered_valid: false,
+		cache_ms: 0,
+		cache_valid: false,
+		timescale: 0,
+		timescale_valid: true,
+	};
+
+	assert!(unsafe { moq_publish_track(broadcast, name.as_ptr() as *const c_char, name.len(), &info) } < 0);
+	assert_eq!(moq_publish_close(broadcast), 0);
 }
 
 #[test]
@@ -509,7 +549,14 @@ fn raw_track_publish_consume() {
 
 	// A raw, non-media track: arbitrary bytes, no codec/container/catalog.
 	let track_name = b"data";
-	let track = id(unsafe { moq_publish_track(broadcast, track_name.as_ptr() as *const c_char, track_name.len()) });
+	let track = id(unsafe {
+		moq_publish_track(
+			broadcast,
+			track_name.as_ptr() as *const c_char,
+			track_name.len(),
+			std::ptr::null(),
+		)
+	});
 
 	let path = b"raw-track";
 	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
@@ -522,6 +569,7 @@ fn raw_track_publish_consume() {
 			consume,
 			track_name.as_ptr() as *const c_char,
 			track_name.len(),
+			std::ptr::null(),
 			Some(channel_callback),
 			frame_cb.ptr,
 		)
@@ -577,6 +625,96 @@ fn raw_track_publish_consume() {
 	assert!(moq_consume_track_close(consumer) < 0, "double-close should fail");
 	assert_eq!(moq_publish_track_close(track), 0);
 	assert!(moq_publish_track_close(track) < 0, "double-close should fail");
+	assert_eq!(moq_consume_close(consume), 0);
+	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_origin_close(origin), 0);
+}
+
+#[test]
+fn raw_track_subscription_options_and_update() {
+	let origin = id(moq_origin_create());
+	let broadcast = id(moq_publish_create());
+
+	let track_name = b"data";
+	let info = moq_track_info {
+		priority: 3,
+		ordered: false,
+		ordered_valid: true,
+		cache_ms: 1_000,
+		cache_valid: true,
+		timescale: 1_000_000,
+		timescale_valid: true,
+	};
+	let track =
+		id(unsafe { moq_publish_track(broadcast, track_name.as_ptr() as *const c_char, track_name.len(), &info) });
+
+	let payloads: [&[u8]; 3] = [b"zero", b"one", b"two"];
+	for payload in payloads {
+		assert_eq!(
+			unsafe { moq_publish_track_frame(track, payload.as_ptr(), payload.len()) },
+			0
+		);
+	}
+
+	let path = b"raw-track-options";
+	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let consume = request_broadcast(origin, path);
+
+	let frame_cb = Callback::new();
+	let subscription = moq_subscription {
+		priority: 5,
+		ordered: true,
+		ordered_valid: true,
+		stale_ms: 25,
+		group_start: 1,
+		group_start_valid: true,
+		group_end: 1,
+		group_end_valid: true,
+	};
+	let consumer = id(unsafe {
+		moq_consume_track(
+			consume,
+			track_name.as_ptr() as *const c_char,
+			track_name.len(),
+			&subscription,
+			Some(channel_callback),
+			frame_cb.ptr,
+		)
+	});
+
+	let frame_id = id(frame_cb.recv());
+	let mut frame = moq_frame {
+		payload: std::ptr::null(),
+		payload_size: 0,
+		timestamp_us: 0,
+		keyframe: false,
+	};
+	assert_eq!(unsafe { moq_consume_track_frame(frame_id, &mut frame) }, 0);
+	let received = unsafe { std::slice::from_raw_parts(frame.payload, frame.payload_size) };
+	assert_eq!(received, b"one");
+	assert_eq!(moq_consume_track_frame_close(frame_id), 0);
+
+	let update = moq_subscription {
+		group_end: 2,
+		..subscription
+	};
+	assert_eq!(unsafe { moq_consume_track_update(consumer, &update) }, 0);
+
+	let frame_id = id(frame_cb.recv());
+	let mut frame = moq_frame {
+		payload: std::ptr::null(),
+		payload_size: 0,
+		timestamp_us: 0,
+		keyframe: false,
+	};
+	assert_eq!(unsafe { moq_consume_track_frame(frame_id, &mut frame) }, 0);
+	let received = unsafe { std::slice::from_raw_parts(frame.payload, frame.payload_size) };
+	assert_eq!(received, b"two");
+	assert_eq!(moq_consume_track_frame_close(frame_id), 0);
+
+	assert_eq!(moq_consume_track_close(consumer), 0);
+	assert_eq!(frame_cb.recv_terminal(), 0);
+	assert_eq!(moq_publish_track_close(track), 0);
 	assert_eq!(moq_consume_close(consume), 0);
 	assert_eq!(moq_publish_close(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);


### PR DESCRIPTION
## Summary

- Change the raw-track C ABI for dev so `moq_publish_track` accepts optional `moq_track_info` and `moq_consume_track` accepts optional `moq_subscription`.
- Add `moq_consume_track_update` for mid-stream subscription changes.
- Update the raw-track tests, C docs, and libmoq changelog for the breaking dev-targeted API.

## Notes

This addresses a focused slice of #2152. The older compatibility aliases were intentionally not kept because this PR targets `dev`.

## Tests

- `cargo fmt --package libmoq -- --check`
- `cargo test -p libmoq raw_track_subscription_options_and_update -- --nocapture`

(Written by GPT-5)