### PR TITLE
moq-relay: expose a Prometheus /metrics endpoint for node traffic

### DIFF
--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -253,6 +253,145 @@ impl Tier {
 			Tier::Internal => 1,
 		}
 	}
+
+	/// Lowercase label for this tier (`"external"` / `"internal"`), e.g. for a
+	/// metrics label or a track-name prefix.
+	pub fn as_str(self) -> &'static str {
+		match self {
+			Tier::External => "external",
+			Tier::Internal => "internal",
+		}
+	}
+}
+
+/// Publisher (egress) vs subscriber (ingress) side of a broadcast, used as a
+/// label on a [`StatsSnapshot`] traffic row. The internal bump paths track the
+/// side statically, so this only surfaces on the aggregate read side.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Role {
+	Publisher,
+	Subscriber,
+}
+
+impl Role {
+	fn idx(self) -> usize {
+		match self {
+			Role::Publisher => 0,
+			Role::Subscriber => 1,
+		}
+	}
+
+	/// Lowercase label for this role (`"publisher"` / `"subscriber"`).
+	pub fn as_str(self) -> &'static str {
+		match self {
+			Role::Publisher => "publisher",
+			Role::Subscriber => "subscriber",
+		}
+	}
+}
+
+/// Summed traffic counters for one `(tier, role)` slice, aggregated across
+/// every broadcast this node is currently tracking. The host-level rollup of
+/// [`Counters`]: per-broadcast detail is collapsed away (it lives on the
+/// published `.stats` broadcast, not here). Every counter is cumulative, so a
+/// rate is `delta / delta_t` and a live count is `open - closed`.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct CounterTotals {
+	pub announced: u64,
+	pub announced_closed: u64,
+	pub announced_bytes: u64,
+	pub subscriptions: u64,
+	pub subscriptions_closed: u64,
+	pub broadcasts: u64,
+	pub broadcasts_closed: u64,
+	pub bytes: u64,
+	pub frames: u64,
+	pub groups: u64,
+}
+
+impl CounterTotals {
+	/// Fold one broadcast slot's raw readout into the running total.
+	fn add(&mut self, raw: RawCounts) {
+		self.announced += raw.announced;
+		self.announced_closed += raw.announced_closed;
+		self.announced_bytes += raw.announced_bytes;
+		self.subscriptions += raw.subscriptions;
+		self.subscriptions_closed += raw.subscriptions_closed;
+		self.broadcasts += raw.broadcasts;
+		self.broadcasts_closed += raw.broadcasts_closed;
+		self.bytes += raw.bytes;
+		self.frames += raw.frames;
+		self.groups += raw.groups;
+	}
+}
+
+/// Connected-session presence for one tier: cumulative connects and
+/// disconnects summed over every auth root. `sessions - sessions_closed` is the
+/// current live session count.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SessionTotals {
+	pub sessions: u64,
+	pub sessions_closed: u64,
+}
+
+/// A point-in-time, host-level rollup of this node's stats counters, returned
+/// by [`Stats::snapshot`].
+///
+/// Every counter is summed across all broadcasts the node is tracking and split
+/// by tier and role, plus per-tier connected-session presence. Intended for a
+/// scrape / `/metrics`-style endpoint where per-broadcast cardinality is
+/// unwanted; the per-broadcast breakdown lives on the published `.stats`
+/// broadcast instead. A no-op aggregator (stats disabled) yields all zeros.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct StatsSnapshot {
+	/// Traffic totals indexed `[tier][role]`; read via [`Self::traffic`].
+	traffic: [[CounterTotals; 2]; 2],
+	/// Session presence per tier; read via [`Self::sessions`].
+	sessions: [SessionTotals; 2],
+}
+
+impl StatsSnapshot {
+	/// The four `(tier, role, totals)` traffic rows, in a stable order
+	/// (external before internal, publisher before subscriber).
+	pub fn traffic(&self) -> [(Tier, Role, CounterTotals); 4] {
+		[
+			(
+				Tier::External,
+				Role::Publisher,
+				self.slot(Tier::External, Role::Publisher),
+			),
+			(
+				Tier::External,
+				Role::Subscriber,
+				self.slot(Tier::External, Role::Subscriber),
+			),
+			(
+				Tier::Internal,
+				Role::Publisher,
+				self.slot(Tier::Internal, Role::Publisher),
+			),
+			(
+				Tier::Internal,
+				Role::Subscriber,
+				self.slot(Tier::Internal, Role::Subscriber),
+			),
+		]
+	}
+
+	/// The two `(tier, sessions)` presence rows, external before internal.
+	pub fn sessions(&self) -> [(Tier, SessionTotals); 2] {
+		[
+			(Tier::External, self.sessions[Tier::External.idx()]),
+			(Tier::Internal, self.sessions[Tier::Internal.idx()]),
+		]
+	}
+
+	fn slot(&self, tier: Tier, role: Role) -> CounterTotals {
+		self.traffic[tier.idx()][role.idx()]
+	}
 }
 
 /// Settings for a [`Stats`] aggregator. Construct with [`StatsConfig::new`]
@@ -545,6 +684,39 @@ impl Stats {
 		let owned = root.as_path().to_owned();
 		let mut sessions = shared.sessions[tier.idx()].lock();
 		Some(sessions.entry(owned).or_default().clone())
+	}
+
+	/// Take a host-level [`StatsSnapshot`]: every counter summed across all
+	/// tracked broadcasts, split by tier and role, plus per-tier session
+	/// presence. Briefly takes the entry then the session locks. Returns an
+	/// all-zero snapshot for a no-op aggregator (stats disabled).
+	///
+	/// Unlike the published `.stats` broadcast, this collapses per-broadcast
+	/// detail into node totals, which is what a `/metrics`-style scrape wants.
+	pub fn snapshot(&self) -> StatsSnapshot {
+		let mut snap = StatsSnapshot::default();
+		let Some(shared) = self.shared.as_ref() else {
+			return snap;
+		};
+		{
+			let entries = shared.entries.lock();
+			for entry in entries.values() {
+				for tier in [Tier::External, Tier::Internal] {
+					snap.traffic[tier.idx()][Role::Publisher.idx()].add(entry.publisher[tier.idx()].snapshot());
+					snap.traffic[tier.idx()][Role::Subscriber.idx()].add(entry.subscriber[tier.idx()].snapshot());
+				}
+			}
+		}
+		for tier in [Tier::External, Tier::Internal] {
+			let sessions = shared.sessions[tier.idx()].lock();
+			let totals = &mut snap.sessions[tier.idx()];
+			for counters in sessions.values() {
+				let (open, closed) = counters.snapshot();
+				totals.sessions += open;
+				totals.sessions_closed += closed;
+			}
+		}
+		snap
 	}
 }
 
@@ -1539,6 +1711,61 @@ mod tests {
 		assert_eq!(entry.subscriber[Tier::External.idx()].bytes.load(Relaxed), 0);
 		assert_eq!(entry.publisher[Tier::Internal.idx()].bytes.load(Relaxed), 0);
 		assert_eq!(entry.subscriber[Tier::Internal.idx()].bytes.load(Relaxed), 7);
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn snapshot_rolls_up_by_tier_role_and_sessions() {
+		let (stats, _origin) = test_stats(Some("sjc"));
+		let ext = stats.tier(Tier::External);
+		let int = stats.tier(Tier::Internal);
+
+		// External egress across two broadcasts; the snapshot sums them.
+		let pub_a = ext.broadcast("demo/aaa").publisher().track("video");
+		pub_a.bytes(100);
+		pub_a.frame();
+		pub_a.group();
+		let pub_b = ext.broadcast("demo/bbb").publisher().track("video");
+		pub_b.bytes(50);
+		// Internal ingress on a different tier/role stays isolated.
+		let sub_a = int.broadcast("demo/aaa").subscriber().track("audio");
+		sub_a.bytes(7);
+
+		// Hold session guards so `sessions_closed` stays zero.
+		let _s1 = ext.session("acme");
+		let _s2 = ext.session("acme");
+		let _s3 = int.session("peer");
+
+		let snap = stats.snapshot();
+
+		let slot = |tier, role| {
+			snap.traffic()
+				.into_iter()
+				.find(|(t, r, _)| *t == tier && *r == role)
+				.map(|(_, _, c)| c)
+				.expect("row present")
+		};
+
+		let ext_pub = slot(Tier::External, Role::Publisher);
+		assert_eq!(ext_pub.bytes, 150, "external egress bytes sum across broadcasts");
+		assert_eq!(ext_pub.frames, 1);
+		assert_eq!(ext_pub.groups, 1);
+
+		let int_sub = slot(Tier::Internal, Role::Subscriber);
+		assert_eq!(int_sub.bytes, 7, "internal ingress isolated by tier/role");
+		assert_eq!(slot(Tier::External, Role::Subscriber).bytes, 0);
+		assert_eq!(slot(Tier::Internal, Role::Publisher).bytes, 0);
+
+		let sessions = |tier| {
+			snap.sessions()
+				.into_iter()
+				.find(|(t, _)| *t == tier)
+				.map(|(_, s)| s)
+				.expect("tier present")
+		};
+		let ext_sessions = sessions(Tier::External);
+		assert_eq!(ext_sessions.sessions, 2, "two external sessions under one root");
+		assert_eq!(ext_sessions.sessions_closed, 0, "guards still held");
+		assert_eq!(sessions(Tier::Internal).sessions, 1);
 	}
 
 	#[tokio::test(start_paused = true)]

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -254,11 +254,15 @@ impl Tier {
 		}
 	}
 
-	/// Lowercase label for this tier (`"external"` / `"internal"`), e.g. for a
-	/// metrics label or a track-name prefix.
+	/// Label for this tier, e.g. a metrics label. The default (external /
+	/// customer) tier is the empty string `""`; cluster-peer traffic is
+	/// `"internal"`. This mirrors the `.stats` wire convention, where the
+	/// default tier is unprefixed (`publisher.json`) and the internal tier is
+	/// `internal/`-prefixed, and leaves room for the default to become one of
+	/// several configurable tier names later.
 	pub fn as_str(self) -> &'static str {
 		match self {
-			Tier::External => "external",
+			Tier::External => "",
 			Tier::Internal => "internal",
 		}
 	}

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 
-use crate::{AuthConfig, ClusterConfig, StatsConfig, WebConfig};
+use crate::{AuthConfig, ClusterConfig, MetricsConfig, StatsConfig, WebConfig};
 
 /// Top-level relay configuration, loadable from CLI arguments, environment
 /// variables, or a TOML file.
@@ -44,6 +44,11 @@ pub struct Config {
 	#[command(flatten)]
 	#[serde(default)]
 	pub stats: StatsConfig,
+
+	/// Internal metrics/health listener. Disabled unless `metrics.listen` is set.
+	#[command(flatten)]
+	#[serde(default)]
+	pub metrics: MetricsConfig,
 
 	/// If provided, load the configuration from this file.
 	#[serde(default)]

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use serde::{Deserialize, Serialize};
 
-use crate::{AuthConfig, ClusterConfig, MetricsConfig, StatsConfig, WebConfig};
+use crate::{AuthConfig, ClusterConfig, InternalConfig, StatsConfig, WebConfig};
 
 /// Top-level relay configuration, loadable from CLI arguments, environment
 /// variables, or a TOML file.
@@ -45,10 +45,11 @@ pub struct Config {
 	#[serde(default)]
 	pub stats: StatsConfig,
 
-	/// Internal metrics/health listener. Disabled unless `metrics.listen` is set.
+	/// Internal (ops) listener for `/metrics`, `/health`, etc. Disabled unless
+	/// `internal.listen` is set.
 	#[command(flatten)]
 	#[serde(default)]
-	pub metrics: MetricsConfig,
+	pub internal: InternalConfig,
 
 	/// If provided, load the configuration from this file.
 	#[serde(default)]

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -446,4 +446,36 @@ uid = [1001]
 		let config = Config::parse_and_merge(args).expect("config load");
 		assert_eq!(config.cluster.id, Some(67890));
 	}
+
+	/// Serializes tests that touch `MOQ_INTERNAL_LISTEN`. Same rationale as
+	/// `STATS_ENV_LOCK`.
+	static INTERNAL_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+	/// Regression test for the same clap+TOML clobber bug on `internal.listen`
+	/// (the `--internal-listen` / `MOQ_INTERNAL_LISTEN` ops listener). It's an
+	/// `Option<SocketAddr>`, so an absent CLI flag must leave the TOML value
+	/// intact; if it were ever re-typed to a bare `SocketAddr`, the `update_from`
+	/// re-parse would overwrite a TOML-configured listener with the default.
+	#[test]
+	fn cli_does_not_clobber_toml_internal_listen() {
+		let _guard = INTERNAL_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+		// SAFETY: INTERNAL_ENV_LOCK serializes this with any sibling test
+		// touching the same env var.
+		unsafe { std::env::remove_var("MOQ_INTERNAL_LISTEN") };
+
+		let toml = "[internal]\nlisten = \"127.0.0.1:9101\"\n";
+		let dir = std::env::temp_dir().join("moq-relay-config-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("internal-listen-toml-wins.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
+		let config = Config::parse_and_merge(args).expect("config load");
+
+		assert_eq!(
+			config.internal.listen,
+			Some("127.0.0.1:9101".parse().unwrap()),
+			"TOML's internal.listen must not be clobbered by the CLI re-parse"
+		);
+	}
 }

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -239,15 +239,15 @@ mod tests {
 			"type header:\n{body}"
 		);
 		assert!(
-			body.contains("moq_relay_bytes_total{tier=\"external\",role=\"publisher\"} 1234"),
-			"external egress bytes:\n{body}"
+			body.contains("moq_relay_bytes_total{tier=\"\",role=\"publisher\"} 1234"),
+			"default-tier egress bytes (empty tier label):\n{body}"
 		);
 		assert!(
 			body.contains("moq_relay_bytes_total{tier=\"internal\",role=\"subscriber\"} 0"),
 			"idle tier still emitted:\n{body}"
 		);
 		assert!(
-			body.contains("moq_relay_sessions_opened_total{tier=\"external\"} 1"),
+			body.contains("moq_relay_sessions_opened_total{tier=\"\"} 1"),
 			"session presence:\n{body}"
 		);
 	}

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -87,10 +87,10 @@ impl Internal {
 
 		let router = self.routes().into_make_service();
 		let listener = moq_native::bind::tcp(listen).context("failed to bind internal listener")?;
-		axum_server::from_tcp(listener)?
-			.serve(router)
-			.await
-			.context("internal server failed")
+		// No blanket "…server failed" context here: the caller (main.rs) adds
+		// that single top-level layer, matching `Web::serve` / `Cluster::run`.
+		axum_server::from_tcp(listener)?.serve(router).await?;
+		Ok(())
 	}
 }
 

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -1,15 +1,25 @@
-//! Internal metrics/observability listener.
+//! Internal (ops) listener.
 //!
 //! A tiny plain-HTTP server, separate from the customer-facing [`Web`](crate::Web)
-//! server, that exposes this node's own traffic counters as Prometheus text
-//! exposition at `/metrics` (plus a `/health` liveness mirror). It's a distinct
-//! plane from both the customer `web` surface and the MoQ `.stats` broadcast:
-//! the same underlying atomics, but a different transport and audience (an ops
-//! scraper, not a customer or the dashboard/billing aggregators).
+//! server, for endpoints that should never touch the public port. It's a
+//! trusted-plane surface named for WHO may reach it, not for any single
+//! endpoint, so it's the home for operational endpoints in general.
 //!
-//! The endpoint is unauthenticated, so bind it only to a trusted plane -
+//! Today it serves:
+//! - `/metrics` - this node's own traffic counters as Prometheus text
+//!   exposition. A distinct plane from both the customer `web` surface and the
+//!   MoQ `.stats` broadcast: the same atomics, but a different transport and
+//!   audience (an ops scraper, not a customer or the dashboard/billing
+//!   aggregators).
+//! - `/health` - a liveness mirror of the public probe, for internal checks
+//!   that don't want to hit the customer port.
+//!
+//! Everything here is unauthenticated, so bind it only to a trusted plane -
 //! loopback for a co-located scraper/agent, or a private overlay address; see
-//! [`MetricsConfig::listen`]. Unset by default (opt-in).
+//! [`InternalConfig::listen`]. Unset by default (opt-in). Any future endpoint
+//! added here inherits that "unauthenticated, trusted-plane-only" contract; a
+//! mutating/control endpoint would need its own auth and doesn't belong on an
+//! unauthenticated bind as-is.
 
 use std::net;
 
@@ -23,41 +33,40 @@ use axum::{
 };
 use clap::Parser;
 
-/// Configuration for the internal metrics/health listener.
+/// Configuration for the internal (ops) listener.
 #[derive(Parser, Clone, Debug, serde::Deserialize, serde::Serialize, Default)]
 #[serde(deny_unknown_fields, default)]
 #[non_exhaustive]
-pub struct MetricsConfig {
-	/// Socket address for the internal metrics listener (plain HTTP), serving
-	/// `/metrics` and `/health`.
+pub struct InternalConfig {
+	/// Socket address for the internal listener (plain HTTP), serving the ops
+	/// endpoints (`/metrics`, `/health`).
 	///
-	/// This endpoint is unauthenticated, so bind it only to a trusted plane:
+	/// These endpoints are unauthenticated, so bind it only to a trusted plane:
 	/// loopback (e.g. `127.0.0.1:9101`) for a co-located scraper/agent, or a
 	/// private overlay address. Never the public internet. Plain HTTP is
 	/// intentional: on loopback there's nothing to encrypt, and a private
 	/// overlay (e.g. a mesh VPN) already provides transport encryption and peer
-	/// identity. Unset (the default) disables the listener, and `/metrics` is
-	/// then not served anywhere.
-	#[arg(long = "metrics-listen", env = "MOQ_METRICS_LISTEN")]
+	/// identity. Unset (the default) disables the listener entirely.
+	#[arg(long = "internal-listen", env = "MOQ_INTERNAL_LISTEN")]
 	pub listen: Option<net::SocketAddr>,
 }
 
-/// The internal metrics service: a plain-HTTP server over the node's [`Stats`].
+/// The internal (ops) service: a plain-HTTP server over the node's [`Stats`].
 ///
 /// [`Stats`]: moq_net::Stats
-pub struct Metrics {
-	config: MetricsConfig,
+pub struct Internal {
+	config: InternalConfig,
 	stats: moq_net::Stats,
 }
 
-impl Metrics {
+impl Internal {
 	/// Create the service from its config and the node's stats handle.
-	pub fn new(config: MetricsConfig, stats: moq_net::Stats) -> Self {
+	pub fn new(config: InternalConfig, stats: moq_net::Stats) -> Self {
 		Self { config, stats }
 	}
 
-	/// Build the router (`/metrics` + `/health`), with the stats handle applied
-	/// as state. Exposed so embedders can mount it on their own listener.
+	/// Build the ops router (`/metrics` + `/health`), with the stats handle
+	/// applied as state. Exposed so embedders can mount it on their own listener.
 	pub fn routes(&self) -> Router {
 		Router::new()
 			.route("/metrics", get(serve_metrics))
@@ -65,7 +74,7 @@ impl Metrics {
 			.with_state(self.stats.clone())
 	}
 
-	/// Serve on [`MetricsConfig::listen`] until it shuts down.
+	/// Serve on [`InternalConfig::listen`] until it shuts down.
 	///
 	/// When no listen address is configured the future stays pending (never
 	/// resolves), so it drops cleanly into a `select!` as a disabled no-op -
@@ -77,11 +86,11 @@ impl Metrics {
 		};
 
 		let router = self.routes().into_make_service();
-		let listener = moq_native::bind::tcp(listen).context("failed to bind metrics listener")?;
+		let listener = moq_native::bind::tcp(listen).context("failed to bind internal listener")?;
 		axum_server::from_tcp(listener)?
 			.serve(router)
 			.await
-			.context("metrics server failed")
+			.context("internal server failed")
 	}
 }
 

--- a/rs/moq-relay/src/lib.rs
+++ b/rs/moq-relay/src/lib.rs
@@ -12,7 +12,7 @@ mod cluster;
 mod config;
 mod connection;
 mod http_client;
-mod metrics;
+mod internal;
 mod stats;
 mod web;
 #[cfg(feature = "websocket")]
@@ -26,6 +26,6 @@ pub use auth::*;
 pub use cluster::*;
 pub use config::*;
 pub use connection::*;
-pub use metrics::*;
+pub use internal::*;
 pub use stats::*;
 pub use web::*;

--- a/rs/moq-relay/src/lib.rs
+++ b/rs/moq-relay/src/lib.rs
@@ -12,6 +12,7 @@ mod cluster;
 mod config;
 mod connection;
 mod http_client;
+mod metrics;
 mod stats;
 mod web;
 #[cfg(feature = "websocket")]
@@ -25,5 +26,6 @@ pub use auth::*;
 pub use cluster::*;
 pub use config::*;
 pub use connection::*;
+pub use metrics::*;
 pub use stats::*;
 pub use web::*;

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -60,9 +60,10 @@ async fn main() -> anyhow::Result<()> {
 	let stats = config.stats.build(cluster.origin.clone());
 	let cluster = cluster.with_stats(stats);
 
-	// Internal metrics/health listener (plain HTTP, opt-in via `--metrics-listen`),
-	// separate from the customer-facing web server. No-op when unconfigured.
-	let metrics = Metrics::new(config.metrics, cluster.stats.clone());
+	// Internal (ops) listener (plain HTTP, opt-in via `--internal-listen`) for
+	// /metrics + /health, separate from the customer-facing web server. No-op
+	// when unconfigured.
+	let internal = Internal::new(config.internal, cluster.stats.clone());
 
 	// Create a web server too. mTLS for HTTPS is opt-in via `--web-https-root`.
 	let web = Web::new(
@@ -92,7 +93,7 @@ async fn main() -> anyhow::Result<()> {
 	tokio::select! {
 		Err(err) = cluster.clone().run() => return Err(err).context("cluster failed"),
 		Err(err) = web.run() => return Err(err).context("web server failed"),
-		Err(err) = metrics.run() => return Err(err).context("metrics server failed"),
+		Err(err) = internal.run() => return Err(err).context("internal server failed"),
 		Err(err) = serve(server, cluster, auth) => return Err(err).context("server failed"),
 		Err(err) = jemalloc => return Err(err).context("jemalloc profiler failed"),
 		else => Ok(()),

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -60,6 +60,10 @@ async fn main() -> anyhow::Result<()> {
 	let stats = config.stats.build(cluster.origin.clone());
 	let cluster = cluster.with_stats(stats);
 
+	// Internal metrics/health listener (plain HTTP, opt-in via `--metrics-listen`),
+	// separate from the customer-facing web server. No-op when unconfigured.
+	let metrics = Metrics::new(config.metrics, cluster.stats.clone());
+
 	// Create a web server too. mTLS for HTTPS is opt-in via `--web-https-root`.
 	let web = Web::new(
 		WebState {
@@ -88,6 +92,7 @@ async fn main() -> anyhow::Result<()> {
 	tokio::select! {
 		Err(err) = cluster.clone().run() => return Err(err).context("cluster failed"),
 		Err(err) = web.run() => return Err(err).context("web server failed"),
+		Err(err) = metrics.run() => return Err(err).context("metrics server failed"),
 		Err(err) = serve(server, cluster, auth) => return Err(err).context("server failed"),
 		Err(err) = jemalloc => return Err(err).context("jemalloc profiler failed"),
 		else => Ok(()),

--- a/rs/moq-relay/src/metrics.rs
+++ b/rs/moq-relay/src/metrics.rs
@@ -1,0 +1,245 @@
+//! Internal metrics/observability listener.
+//!
+//! A tiny plain-HTTP server, separate from the customer-facing [`Web`](crate::Web)
+//! server, that exposes this node's own traffic counters as Prometheus text
+//! exposition at `/metrics` (plus a `/health` liveness mirror). It's a distinct
+//! plane from both the customer `web` surface and the MoQ `.stats` broadcast:
+//! the same underlying atomics, but a different transport and audience (an ops
+//! scraper, not a customer or the dashboard/billing aggregators).
+//!
+//! The endpoint is unauthenticated, so bind it only to a trusted plane -
+//! loopback for a co-located scraper/agent, or a private overlay address; see
+//! [`MetricsConfig::listen`]. Unset by default (opt-in).
+
+use std::net;
+
+use anyhow::Context as _;
+use axum::{
+	Router,
+	extract::State,
+	http::{self, StatusCode},
+	response::{IntoResponse, Response},
+	routing::get,
+};
+use clap::Parser;
+
+/// Configuration for the internal metrics/health listener.
+#[derive(Parser, Clone, Debug, serde::Deserialize, serde::Serialize, Default)]
+#[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
+pub struct MetricsConfig {
+	/// Socket address for the internal metrics listener (plain HTTP), serving
+	/// `/metrics` and `/health`.
+	///
+	/// This endpoint is unauthenticated, so bind it only to a trusted plane:
+	/// loopback (e.g. `127.0.0.1:9101`) for a co-located scraper/agent, or a
+	/// private overlay address. Never the public internet. Plain HTTP is
+	/// intentional: on loopback there's nothing to encrypt, and a private
+	/// overlay (e.g. a mesh VPN) already provides transport encryption and peer
+	/// identity. Unset (the default) disables the listener, and `/metrics` is
+	/// then not served anywhere.
+	#[arg(long = "metrics-listen", env = "MOQ_METRICS_LISTEN")]
+	pub listen: Option<net::SocketAddr>,
+}
+
+/// The internal metrics service: a plain-HTTP server over the node's [`Stats`].
+///
+/// [`Stats`]: moq_net::Stats
+pub struct Metrics {
+	config: MetricsConfig,
+	stats: moq_net::Stats,
+}
+
+impl Metrics {
+	/// Create the service from its config and the node's stats handle.
+	pub fn new(config: MetricsConfig, stats: moq_net::Stats) -> Self {
+		Self { config, stats }
+	}
+
+	/// Build the router (`/metrics` + `/health`), with the stats handle applied
+	/// as state. Exposed so embedders can mount it on their own listener.
+	pub fn routes(&self) -> Router {
+		Router::new()
+			.route("/metrics", get(serve_metrics))
+			.route("/health", get(serve_health))
+			.with_state(self.stats.clone())
+	}
+
+	/// Serve on [`MetricsConfig::listen`] until it shuts down.
+	///
+	/// When no listen address is configured the future stays pending (never
+	/// resolves), so it drops cleanly into a `select!` as a disabled no-op -
+	/// mirroring how the relay treats other optional services.
+	pub async fn run(self) -> anyhow::Result<()> {
+		let Some(listen) = self.config.listen else {
+			std::future::pending::<()>().await;
+			return Ok(());
+		};
+
+		let router = self.routes().into_make_service();
+		let listener = moq_native::bind::tcp(listen).context("failed to bind metrics listener")?;
+		axum_server::from_tcp(listener)?
+			.serve(router)
+			.await
+			.context("metrics server failed")
+	}
+}
+
+/// Liveness probe mirror for the internal listener. Always `200 ok`. The
+/// customer-facing [`Web`](crate::Web) server serves its own public `/health`;
+/// this one lets an internal prober check the process over the trusted plane
+/// without touching the public port.
+async fn serve_health() -> Response {
+	(StatusCode::OK, "ok\n").into_response()
+}
+
+/// Prometheus text-exposition metrics for this node's own MoQ traffic counters
+/// (bytes/frames/groups, subscriptions, viewers, and connected sessions),
+/// summed across broadcasts and split by `tier`/`role`.
+///
+/// Unauthenticated, which is why it lives on the internal listener rather than
+/// the public web one; a scraper needs no JWT. Host system metrics
+/// (CPU/memory/disk/network) are deliberately out of scope: run a dedicated node
+/// exporter for those, per the relay's separation of concerns. Returns the
+/// current cumulative snapshot; a downstream scraper derives rates and live
+/// counts (`open - closed`).
+async fn serve_metrics(State(stats): State<moq_net::Stats>) -> Response {
+	let body = render_metrics(&stats.snapshot());
+	([(http::header::CONTENT_TYPE, "text/plain; version=0.0.4")], body).into_response()
+}
+
+/// Render a [`moq_net::StatsSnapshot`] as Prometheus text exposition (v0.0.4).
+///
+/// Hand-formatted rather than pulling in a metrics registry crate: the atomics
+/// already are the registry, and a snapshot is a fixed handful of labeled
+/// counters, so a registry would only add a second source of truth to keep in
+/// sync.
+fn render_metrics(snap: &moq_net::StatsSnapshot) -> String {
+	use std::fmt::Write as _;
+
+	let traffic = snap.traffic();
+	let mut out = String::new();
+
+	// One HELP/TYPE header followed by the four (tier, role) rows for a counter
+	// selected out of `CounterTotals` by `field`.
+	let counter = |out: &mut String, name: &str, help: &str, field: fn(&moq_net::CounterTotals) -> u64| {
+		let _ = writeln!(out, "# HELP {name} {help}");
+		let _ = writeln!(out, "# TYPE {name} counter");
+		for (tier, role, totals) in &traffic {
+			let _ = writeln!(
+				out,
+				"{name}{{tier=\"{}\",role=\"{}\"}} {}",
+				tier.as_str(),
+				role.as_str(),
+				field(totals)
+			);
+		}
+	};
+
+	counter(
+		&mut out,
+		"moq_relay_bytes_total",
+		"Media payload bytes transferred.",
+		|c| c.bytes,
+	);
+	counter(&mut out, "moq_relay_frames_total", "Media frames transferred.", |c| {
+		c.frames
+	});
+	counter(&mut out, "moq_relay_groups_total", "Media groups transferred.", |c| {
+		c.groups
+	});
+	counter(
+		&mut out,
+		"moq_relay_subscriptions_opened_total",
+		"Track subscriptions opened.",
+		|c| c.subscriptions,
+	);
+	counter(
+		&mut out,
+		"moq_relay_subscriptions_closed_total",
+		"Track subscriptions closed; subtract from opened for live subscriptions.",
+		|c| c.subscriptions_closed,
+	);
+	counter(
+		&mut out,
+		"moq_relay_viewers_opened_total",
+		"Distinct (broadcast, session) subscriptions opened.",
+		|c| c.broadcasts,
+	);
+	counter(
+		&mut out,
+		"moq_relay_viewers_closed_total",
+		"Distinct (broadcast, session) subscriptions closed; subtract from opened for live viewers.",
+		|c| c.broadcasts_closed,
+	);
+
+	// Sessions are per-tier only (no role), so they don't fit the helper above.
+	let _ = writeln!(out, "# HELP moq_relay_sessions_opened_total Connected sessions opened.");
+	let _ = writeln!(out, "# TYPE moq_relay_sessions_opened_total counter");
+	for (tier, sessions) in &snap.sessions() {
+		let _ = writeln!(
+			out,
+			"moq_relay_sessions_opened_total{{tier=\"{}\"}} {}",
+			tier.as_str(),
+			sessions.sessions
+		);
+	}
+	let _ = writeln!(
+		out,
+		"# HELP moq_relay_sessions_closed_total Connected sessions closed; subtract from opened for live sessions."
+	);
+	let _ = writeln!(out, "# TYPE moq_relay_sessions_closed_total counter");
+	for (tier, sessions) in &snap.sessions() {
+		let _ = writeln!(
+			out,
+			"moq_relay_sessions_closed_total{{tier=\"{}\"}} {}",
+			tier.as_str(),
+			sessions.sessions_closed
+		);
+	}
+
+	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// The `/metrics` renderer emits well-formed Prometheus exposition: a
+	/// HELP/TYPE header per metric and a labeled line carrying the live counter
+	/// value, summed across broadcasts.
+	#[tokio::test]
+	async fn metrics_render_exposition() {
+		use moq_net::{Origin, Stats, StatsConfig, Tier};
+
+		let origin = Origin::random().produce();
+		let stats = Stats::new(StatsConfig::new().with_origin(origin));
+
+		let track = stats
+			.tier(Tier::External)
+			.broadcast("demo/x")
+			.publisher()
+			.track("video");
+		track.bytes(1234);
+		let _session = stats.tier(Tier::External).session("acme");
+
+		let body = render_metrics(&stats.snapshot());
+
+		assert!(
+			body.contains("# TYPE moq_relay_bytes_total counter"),
+			"type header:\n{body}"
+		);
+		assert!(
+			body.contains("moq_relay_bytes_total{tier=\"external\",role=\"publisher\"} 1234"),
+			"external egress bytes:\n{body}"
+		);
+		assert!(
+			body.contains("moq_relay_bytes_total{tier=\"internal\",role=\"subscriber\"} 0"),
+			"idle tier still emitted:\n{body}"
+		);
+		assert!(
+			body.contains("moq_relay_sessions_opened_total{tier=\"external\"} 1"),
+			"session presence:\n{body}"
+		);
+	}
+}

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -45,6 +45,11 @@ pub struct WebConfig {
 	#[serde(default)]
 	pub https: HttpsConfig,
 
+	/// Internal operational listener for `/metrics` and `/health`.
+	#[command(flatten)]
+	#[serde(default)]
+	pub internal: InternalConfig,
+
 	/// If true (default), expose a WebTransport compatible WebSocket polyfill.
 	#[arg(long = "web-ws", env = "MOQ_WEB_WS", default_value = "true")]
 	#[serde(default = "default_true")]
@@ -58,6 +63,29 @@ pub struct WebConfig {
 pub struct HttpConfig {
 	/// Socket address to bind the HTTP listener to.
 	#[arg(long = "web-http-listen", id = "http-listen", env = "MOQ_WEB_HTTP_LISTEN")]
+	pub listen: Option<net::SocketAddr>,
+}
+
+/// Internal operational listener configuration (plain HTTP).
+#[derive(clap::Args, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
+pub struct InternalConfig {
+	/// Socket address for the internal plain-HTTP listener serving `/metrics`
+	/// and `/health`.
+	///
+	/// This endpoint is unauthenticated, so bind it only to a trusted plane:
+	/// loopback (e.g. `127.0.0.1:9100`) for a co-located scraper/agent, or a
+	/// private overlay address. Never the public internet. Plain HTTP is
+	/// intentional: on loopback there's nothing to encrypt, and a private
+	/// overlay (e.g. a mesh VPN) already provides transport encryption and peer
+	/// identity. Unset (the default) disables the listener, and `/metrics` is
+	/// then not served anywhere.
+	#[arg(
+		long = "web-internal-listen",
+		id = "web-internal-listen",
+		env = "MOQ_WEB_INTERNAL_LISTEN"
+	)]
 	pub listen: Option<net::SocketAddr>,
 }
 
@@ -170,12 +198,16 @@ impl Web {
 
 	/// Build the default relay web router.
 	///
+	/// This is the public-facing router (customer media routes plus a liveness
+	/// probe). `/metrics` is deliberately NOT here: it rides the separate
+	/// internal listener ([`internal_routes`](Self::internal_routes)) so node
+	/// counters are never exposed on the public listener.
+	///
 	/// The returned router already has relay state applied, so embedders can
 	/// merge in their own state-applied routers before calling [`serve`](Self::serve).
 	pub fn routes(&self) -> Router {
 		let app = Router::new()
 			.route("/health", get(serve_health))
-			.route("/metrics", get(serve_metrics))
 			.route("/certificate.sha256", get(serve_fingerprint))
 			.route("/announced", get(serve_announced))
 			.route("/announced/{*prefix}", get(serve_announced))
@@ -197,6 +229,19 @@ impl Web {
 		};
 
 		app.layer(CorsLayer::new().allow_origin(Any).allow_methods([Method::GET]))
+			.with_state(self.state.clone())
+	}
+
+	/// Build the internal operational router served on [`InternalConfig::listen`].
+	///
+	/// Carries `/metrics` (this node's traffic counters) and a `/health` mirror.
+	/// Both are unauthenticated, which is why this router belongs on a listener
+	/// bound to a trusted plane (loopback or a private overlay), never the
+	/// public one.
+	pub fn internal_routes(&self) -> Router {
+		Router::new()
+			.route("/health", get(serve_health))
+			.route("/metrics", get(serve_metrics))
 			.with_state(self.state.clone())
 	}
 
@@ -242,9 +287,22 @@ impl Web {
 			None
 		};
 
+		// Separate plain-HTTP listener for operational endpoints (`/metrics`,
+		// `/health`), kept off the public listeners. Serves the internal router
+		// only, not the embedder-merged `app`.
+		let internal = if let Some(listen) = self.config.internal.listen {
+			let router = self.internal_routes().into_make_service();
+			let listener = moq_native::bind::tcp(listen).context("failed to bind internal listener")?;
+			let server = axum_server::from_tcp(listener)?;
+			Some(server.serve(router))
+		} else {
+			None
+		};
+
 		tokio::select! {
 			Some(res) = async move { Some(http?.await) } => res?,
 			Some(res) = async move { Some(https?.await) } => res?,
+			Some(res) = async move { Some(internal?.await) } => res?,
 			else => {},
 		};
 
@@ -425,12 +483,12 @@ async fn serve_health() -> Response {
 /// (bytes/frames/groups, subscriptions, viewers, and connected sessions),
 /// summed across broadcasts and split by `tier`/`role`.
 ///
-/// Unauthenticated like `/health`, so a scraper needs no JWT; expose the web
-/// listener only where that's acceptable (e.g. a private metrics plane). Host
-/// system metrics (CPU/memory/disk/network) are deliberately out of scope: run
-/// a dedicated node exporter for those, per the relay's separation of concerns.
-/// Returns the current cumulative snapshot; a downstream scraper derives rates
-/// and live counts (`open - closed`).
+/// Unauthenticated, so it's served only on the internal listener
+/// ([`InternalConfig::listen`]), never the public one; a scraper needs no JWT.
+/// Host system metrics (CPU/memory/disk/network) are deliberately out of scope:
+/// run a dedicated node exporter for those, per the relay's separation of
+/// concerns. Returns the current cumulative snapshot; a downstream scraper
+/// derives rates and live counts (`open - closed`).
 async fn serve_metrics(State(state): State<Arc<WebState>>) -> Response {
 	let body = render_metrics(&state.cluster.stats.snapshot());
 	([(http::header::CONTENT_TYPE, "text/plain; version=0.0.4")], body).into_response()

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -45,11 +45,6 @@ pub struct WebConfig {
 	#[serde(default)]
 	pub https: HttpsConfig,
 
-	/// Internal operational listener for `/metrics` and `/health`.
-	#[command(flatten)]
-	#[serde(default)]
-	pub internal: InternalConfig,
-
 	/// If true (default), expose a WebTransport compatible WebSocket polyfill.
 	#[arg(long = "web-ws", env = "MOQ_WEB_WS", default_value = "true")]
 	#[serde(default = "default_true")]
@@ -63,29 +58,6 @@ pub struct WebConfig {
 pub struct HttpConfig {
 	/// Socket address to bind the HTTP listener to.
 	#[arg(long = "web-http-listen", id = "http-listen", env = "MOQ_WEB_HTTP_LISTEN")]
-	pub listen: Option<net::SocketAddr>,
-}
-
-/// Internal operational listener configuration (plain HTTP).
-#[derive(clap::Args, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields, default)]
-#[non_exhaustive]
-pub struct InternalConfig {
-	/// Socket address for the internal plain-HTTP listener serving `/metrics`
-	/// and `/health`.
-	///
-	/// This endpoint is unauthenticated, so bind it only to a trusted plane:
-	/// loopback (e.g. `127.0.0.1:9100`) for a co-located scraper/agent, or a
-	/// private overlay address. Never the public internet. Plain HTTP is
-	/// intentional: on loopback there's nothing to encrypt, and a private
-	/// overlay (e.g. a mesh VPN) already provides transport encryption and peer
-	/// identity. Unset (the default) disables the listener, and `/metrics` is
-	/// then not served anywhere.
-	#[arg(
-		long = "web-internal-listen",
-		id = "web-internal-listen",
-		env = "MOQ_WEB_INTERNAL_LISTEN"
-	)]
 	pub listen: Option<net::SocketAddr>,
 }
 
@@ -199,9 +171,9 @@ impl Web {
 	/// Build the default relay web router.
 	///
 	/// This is the public-facing router (customer media routes plus a liveness
-	/// probe). `/metrics` is deliberately NOT here: it rides the separate
-	/// internal listener ([`internal_routes`](Self::internal_routes)) so node
-	/// counters are never exposed on the public listener.
+	/// probe). `/metrics` is deliberately NOT here: node traffic counters ride
+	/// the separate internal listener ([`Metrics`](crate::Metrics)) so they're
+	/// never exposed on the public listener.
 	///
 	/// The returned router already has relay state applied, so embedders can
 	/// merge in their own state-applied routers before calling [`serve`](Self::serve).
@@ -229,19 +201,6 @@ impl Web {
 		};
 
 		app.layer(CorsLayer::new().allow_origin(Any).allow_methods([Method::GET]))
-			.with_state(self.state.clone())
-	}
-
-	/// Build the internal operational router served on [`InternalConfig::listen`].
-	///
-	/// Carries `/metrics` (this node's traffic counters) and a `/health` mirror.
-	/// Both are unauthenticated, which is why this router belongs on a listener
-	/// bound to a trusted plane (loopback or a private overlay), never the
-	/// public one.
-	pub fn internal_routes(&self) -> Router {
-		Router::new()
-			.route("/health", get(serve_health))
-			.route("/metrics", get(serve_metrics))
 			.with_state(self.state.clone())
 	}
 
@@ -287,22 +246,9 @@ impl Web {
 			None
 		};
 
-		// Separate plain-HTTP listener for operational endpoints (`/metrics`,
-		// `/health`), kept off the public listeners. Serves the internal router
-		// only, not the embedder-merged `app`.
-		let internal = if let Some(listen) = self.config.internal.listen {
-			let router = self.internal_routes().into_make_service();
-			let listener = moq_native::bind::tcp(listen).context("failed to bind internal listener")?;
-			let server = axum_server::from_tcp(listener)?;
-			Some(server.serve(router))
-		} else {
-			None
-		};
-
 		tokio::select! {
 			Some(res) = async move { Some(http?.await) } => res?,
 			Some(res) = async move { Some(https?.await) } => res?,
-			Some(res) = async move { Some(internal?.await) } => res?,
 			else => {},
 		};
 
@@ -477,114 +423,6 @@ async fn serve_landing() -> Response {
 /// process, not the relay.
 async fn serve_health() -> Response {
 	(StatusCode::OK, "ok\n").into_response()
-}
-
-/// Prometheus text-exposition metrics for this node's own MoQ traffic counters
-/// (bytes/frames/groups, subscriptions, viewers, and connected sessions),
-/// summed across broadcasts and split by `tier`/`role`.
-///
-/// Unauthenticated, so it's served only on the internal listener
-/// ([`InternalConfig::listen`]), never the public one; a scraper needs no JWT.
-/// Host system metrics (CPU/memory/disk/network) are deliberately out of scope:
-/// run a dedicated node exporter for those, per the relay's separation of
-/// concerns. Returns the current cumulative snapshot; a downstream scraper
-/// derives rates and live counts (`open - closed`).
-async fn serve_metrics(State(state): State<Arc<WebState>>) -> Response {
-	let body = render_metrics(&state.cluster.stats.snapshot());
-	([(http::header::CONTENT_TYPE, "text/plain; version=0.0.4")], body).into_response()
-}
-
-/// Render a [`moq_net::StatsSnapshot`] as Prometheus text exposition (v0.0.4).
-///
-/// Hand-formatted rather than pulling in a metrics registry crate: the atomics
-/// already are the registry, and a snapshot is a fixed handful of labeled
-/// counters, so a registry would only add a second source of truth to keep in
-/// sync.
-fn render_metrics(snap: &moq_net::StatsSnapshot) -> String {
-	use std::fmt::Write as _;
-
-	let traffic = snap.traffic();
-	let mut out = String::new();
-
-	// One HELP/TYPE header followed by the four (tier, role) rows for a counter
-	// selected out of `CounterTotals` by `field`.
-	let counter = |out: &mut String, name: &str, help: &str, field: fn(&moq_net::CounterTotals) -> u64| {
-		let _ = writeln!(out, "# HELP {name} {help}");
-		let _ = writeln!(out, "# TYPE {name} counter");
-		for (tier, role, totals) in &traffic {
-			let _ = writeln!(
-				out,
-				"{name}{{tier=\"{}\",role=\"{}\"}} {}",
-				tier.as_str(),
-				role.as_str(),
-				field(totals)
-			);
-		}
-	};
-
-	counter(
-		&mut out,
-		"moq_relay_bytes_total",
-		"Media payload bytes transferred.",
-		|c| c.bytes,
-	);
-	counter(&mut out, "moq_relay_frames_total", "Media frames transferred.", |c| {
-		c.frames
-	});
-	counter(&mut out, "moq_relay_groups_total", "Media groups transferred.", |c| {
-		c.groups
-	});
-	counter(
-		&mut out,
-		"moq_relay_subscriptions_opened_total",
-		"Track subscriptions opened.",
-		|c| c.subscriptions,
-	);
-	counter(
-		&mut out,
-		"moq_relay_subscriptions_closed_total",
-		"Track subscriptions closed; subtract from opened for live subscriptions.",
-		|c| c.subscriptions_closed,
-	);
-	counter(
-		&mut out,
-		"moq_relay_viewers_opened_total",
-		"Distinct (broadcast, session) subscriptions opened.",
-		|c| c.broadcasts,
-	);
-	counter(
-		&mut out,
-		"moq_relay_viewers_closed_total",
-		"Distinct (broadcast, session) subscriptions closed; subtract from opened for live viewers.",
-		|c| c.broadcasts_closed,
-	);
-
-	// Sessions are per-tier only (no role), so they don't fit the helper above.
-	let _ = writeln!(out, "# HELP moq_relay_sessions_opened_total Connected sessions opened.");
-	let _ = writeln!(out, "# TYPE moq_relay_sessions_opened_total counter");
-	for (tier, sessions) in &snap.sessions() {
-		let _ = writeln!(
-			out,
-			"moq_relay_sessions_opened_total{{tier=\"{}\"}} {}",
-			tier.as_str(),
-			sessions.sessions
-		);
-	}
-	let _ = writeln!(
-		out,
-		"# HELP moq_relay_sessions_closed_total Connected sessions closed; subtract from opened for live sessions."
-	);
-	let _ = writeln!(out, "# TYPE moq_relay_sessions_closed_total counter");
-	for (tier, sessions) in &snap.sessions() {
-		let _ = writeln!(
-			out,
-			"moq_relay_sessions_closed_total{{tier=\"{}\"}} {}",
-			tier.as_str(),
-			sessions.sessions_closed
-		);
-	}
-
-	out
 }
 
 async fn serve_fingerprint(State(state): State<Arc<WebState>>) -> String {
@@ -981,44 +819,6 @@ mod tests {
 		assert!(
 			res.is_err(),
 			"empty PEM must be rejected to avoid a silently disabled verifier"
-		);
-	}
-
-	/// The `/metrics` renderer emits well-formed Prometheus exposition: a
-	/// HELP/TYPE header per metric and a labeled line carrying the live counter
-	/// value, summed across broadcasts.
-	#[tokio::test]
-	async fn metrics_render_exposition() {
-		use moq_net::{Origin, Stats, StatsConfig, Tier};
-
-		let origin = Origin::random().produce();
-		let stats = Stats::new(StatsConfig::new().with_origin(origin));
-
-		let track = stats
-			.tier(Tier::External)
-			.broadcast("demo/x")
-			.publisher()
-			.track("video");
-		track.bytes(1234);
-		let _session = stats.tier(Tier::External).session("acme");
-
-		let body = render_metrics(&stats.snapshot());
-
-		assert!(
-			body.contains("# TYPE moq_relay_bytes_total counter"),
-			"type header:\n{body}"
-		);
-		assert!(
-			body.contains("moq_relay_bytes_total{tier=\"external\",role=\"publisher\"} 1234"),
-			"external egress bytes:\n{body}"
-		);
-		assert!(
-			body.contains("moq_relay_bytes_total{tier=\"internal\",role=\"subscriber\"} 0"),
-			"idle tier still emitted:\n{body}"
-		);
-		assert!(
-			body.contains("moq_relay_sessions_opened_total{tier=\"external\"} 1"),
-			"session presence:\n{body}"
 		);
 	}
 

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -172,7 +172,7 @@ impl Web {
 	///
 	/// This is the public-facing router (customer media routes plus a liveness
 	/// probe). `/metrics` is deliberately NOT here: node traffic counters ride
-	/// the separate internal listener ([`Metrics`](crate::Metrics)) so they're
+	/// the separate internal listener ([`Internal`](crate::Internal)) so they're
 	/// never exposed on the public listener.
 	///
 	/// The returned router already has relay state applied, so embedders can

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -175,6 +175,7 @@ impl Web {
 	pub fn routes(&self) -> Router {
 		let app = Router::new()
 			.route("/health", get(serve_health))
+			.route("/metrics", get(serve_metrics))
 			.route("/certificate.sha256", get(serve_fingerprint))
 			.route("/announced", get(serve_announced))
 			.route("/announced/{*prefix}", get(serve_announced))
@@ -418,6 +419,114 @@ async fn serve_landing() -> Response {
 /// process, not the relay.
 async fn serve_health() -> Response {
 	(StatusCode::OK, "ok\n").into_response()
+}
+
+/// Prometheus text-exposition metrics for this node's own MoQ traffic counters
+/// (bytes/frames/groups, subscriptions, viewers, and connected sessions),
+/// summed across broadcasts and split by `tier`/`role`.
+///
+/// Unauthenticated like `/health`, so a scraper needs no JWT; expose the web
+/// listener only where that's acceptable (e.g. a private metrics plane). Host
+/// system metrics (CPU/memory/disk/network) are deliberately out of scope: run
+/// a dedicated node exporter for those, per the relay's separation of concerns.
+/// Returns the current cumulative snapshot; a downstream scraper derives rates
+/// and live counts (`open - closed`).
+async fn serve_metrics(State(state): State<Arc<WebState>>) -> Response {
+	let body = render_metrics(&state.cluster.stats.snapshot());
+	([(http::header::CONTENT_TYPE, "text/plain; version=0.0.4")], body).into_response()
+}
+
+/// Render a [`moq_net::StatsSnapshot`] as Prometheus text exposition (v0.0.4).
+///
+/// Hand-formatted rather than pulling in a metrics registry crate: the atomics
+/// already are the registry, and a snapshot is a fixed handful of labeled
+/// counters, so a registry would only add a second source of truth to keep in
+/// sync.
+fn render_metrics(snap: &moq_net::StatsSnapshot) -> String {
+	use std::fmt::Write as _;
+
+	let traffic = snap.traffic();
+	let mut out = String::new();
+
+	// One HELP/TYPE header followed by the four (tier, role) rows for a counter
+	// selected out of `CounterTotals` by `field`.
+	let counter = |out: &mut String, name: &str, help: &str, field: fn(&moq_net::CounterTotals) -> u64| {
+		let _ = writeln!(out, "# HELP {name} {help}");
+		let _ = writeln!(out, "# TYPE {name} counter");
+		for (tier, role, totals) in &traffic {
+			let _ = writeln!(
+				out,
+				"{name}{{tier=\"{}\",role=\"{}\"}} {}",
+				tier.as_str(),
+				role.as_str(),
+				field(totals)
+			);
+		}
+	};
+
+	counter(
+		&mut out,
+		"moq_relay_bytes_total",
+		"Media payload bytes transferred.",
+		|c| c.bytes,
+	);
+	counter(&mut out, "moq_relay_frames_total", "Media frames transferred.", |c| {
+		c.frames
+	});
+	counter(&mut out, "moq_relay_groups_total", "Media groups transferred.", |c| {
+		c.groups
+	});
+	counter(
+		&mut out,
+		"moq_relay_subscriptions_opened_total",
+		"Track subscriptions opened.",
+		|c| c.subscriptions,
+	);
+	counter(
+		&mut out,
+		"moq_relay_subscriptions_closed_total",
+		"Track subscriptions closed; subtract from opened for live subscriptions.",
+		|c| c.subscriptions_closed,
+	);
+	counter(
+		&mut out,
+		"moq_relay_viewers_opened_total",
+		"Distinct (broadcast, session) subscriptions opened.",
+		|c| c.broadcasts,
+	);
+	counter(
+		&mut out,
+		"moq_relay_viewers_closed_total",
+		"Distinct (broadcast, session) subscriptions closed; subtract from opened for live viewers.",
+		|c| c.broadcasts_closed,
+	);
+
+	// Sessions are per-tier only (no role), so they don't fit the helper above.
+	let _ = writeln!(out, "# HELP moq_relay_sessions_opened_total Connected sessions opened.");
+	let _ = writeln!(out, "# TYPE moq_relay_sessions_opened_total counter");
+	for (tier, sessions) in &snap.sessions() {
+		let _ = writeln!(
+			out,
+			"moq_relay_sessions_opened_total{{tier=\"{}\"}} {}",
+			tier.as_str(),
+			sessions.sessions
+		);
+	}
+	let _ = writeln!(
+		out,
+		"# HELP moq_relay_sessions_closed_total Connected sessions closed; subtract from opened for live sessions."
+	);
+	let _ = writeln!(out, "# TYPE moq_relay_sessions_closed_total counter");
+	for (tier, sessions) in &snap.sessions() {
+		let _ = writeln!(
+			out,
+			"moq_relay_sessions_closed_total{{tier=\"{}\"}} {}",
+			tier.as_str(),
+			sessions.sessions_closed
+		);
+	}
+
+	out
 }
 
 async fn serve_fingerprint(State(state): State<Arc<WebState>>) -> String {
@@ -814,6 +923,44 @@ mod tests {
 		assert!(
 			res.is_err(),
 			"empty PEM must be rejected to avoid a silently disabled verifier"
+		);
+	}
+
+	/// The `/metrics` renderer emits well-formed Prometheus exposition: a
+	/// HELP/TYPE header per metric and a labeled line carrying the live counter
+	/// value, summed across broadcasts.
+	#[tokio::test]
+	async fn metrics_render_exposition() {
+		use moq_net::{Origin, Stats, StatsConfig, Tier};
+
+		let origin = Origin::random().produce();
+		let stats = Stats::new(StatsConfig::new().with_origin(origin));
+
+		let track = stats
+			.tier(Tier::External)
+			.broadcast("demo/x")
+			.publisher()
+			.track("video");
+		track.bytes(1234);
+		let _session = stats.tier(Tier::External).session("acme");
+
+		let body = render_metrics(&stats.snapshot());
+
+		assert!(
+			body.contains("# TYPE moq_relay_bytes_total counter"),
+			"type header:\n{body}"
+		);
+		assert!(
+			body.contains("moq_relay_bytes_total{tier=\"external\",role=\"publisher\"} 1234"),
+			"external egress bytes:\n{body}"
+		);
+		assert!(
+			body.contains("moq_relay_bytes_total{tier=\"internal\",role=\"subscriber\"} 0"),
+			"idle tier still emitted:\n{body}"
+		);
+		assert!(
+			body.contains("moq_relay_sessions_opened_total{tier=\"external\"} 1"),
+			"session presence:\n{body}"
 		);
 	}
 


### PR DESCRIPTION
## What

Adds a `/metrics` endpoint to the relay's web router that exposes this node's own MoQ traffic counters as Prometheus text exposition, so a relay is a first-class scrape target for a host/fleet metrics dashboard (VictoriaMetrics/Prometheus + Grafana, node_exporter alongside for system metrics).

Until now the atomic counters in `moq-net` had no public read API — the only way out was subscribing to the `.stats` MoQ broadcast (per-broadcast, JSON, aimed at the dashboard/billing aggregators). That's the wrong shape and cardinality for an ops scrape.

## Changes

**`moq-net`** — a public read API over the existing counter atomics:
- `Stats::snapshot() -> StatsSnapshot` rolls the per-broadcast `Counters` up into host-level totals split by `tier` (external/internal) × `role` (publisher/subscriber), plus per-tier connected-session presence.
- New public types `StatsSnapshot`, `CounterTotals`, `SessionTotals`, a public `Role`, and `Tier::as_str`. Per-broadcast detail is intentionally collapsed away — it still only rides the `.stats` broadcast.

**`moq-relay`** — a new **`internal` module** (peer to `web`/`stats`): an `InternalConfig` (`--internal-listen` / `MOQ_INTERNAL_LISTEN`) on the top-level `Config`, plus an `Internal` service that serves the node's ops endpoints on its **own plain-HTTP listener** over the `Stats` handle — currently an unauthenticated `/metrics` (+ a `/health` mirror). It's a trusted-plane surface named for who may reach it, not for one endpoint, so future ops endpoints (pprof, readiness, ...) live here too. Hand-formatted Prometheus text (no registry crate; the atomics already are the registry). Kept off the public HTTPS router so node counters never appear on the customer-facing port; the listener is unset by default (opt-in) and meant for a trusted plane only — loopback for a co-located scraper/agent, or a private overlay address. `main.rs` runs it in its `select!` (a no-op when unconfigured); embedders that call `Web::serve` spawn `Metrics::run` themselves. Sample:

```
# TYPE moq_relay_bytes_total counter
moq_relay_bytes_total{tier="",role="publisher"} 1234
moq_relay_sessions_opened_total{tier=""} 1
```

The default (customer) tier renders with an empty `tier=""` label (matching the `.stats` wire convention, where the default tier is unprefixed) and cluster-peer traffic is `tier="internal"`. Counters stay cumulative/monotonic; "live" values are derived downstream (`opened - closed`).

## Notes

- `/metrics` is unauthenticated and served only on the internal listener, never the public HTTPS one. Plain HTTP is intentional: nothing to encrypt on loopback, and a private overlay (mesh VPN) already provides transport encryption + peer identity. The recommended collection model is an agent (e.g. vmagent) co-located on each node scraping `127.0.0.1` and remote-writing outbound, so no inbound port is opened.
- System metrics (CPU/mem/disk/net) are deliberately out of scope, matching the relay's existing "host overload monitoring belongs in a separate process" stance — run a node exporter for those.

## Tests

- `moq-net`: `snapshot_rolls_up_by_tier_role_and_sessions` — aggregation across broadcasts + tier/role isolation + session presence.
- `moq-relay`: `metrics_render_exposition` — exposition format against a live `Stats`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



