### PR TITLE
Add origin options and dynamic FFI

### DIFF
--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -153,7 +153,7 @@ for request, err := range dynamic.All(ctx) {
 		log.Fatal(err)
 	}
 	if path != "events" {
-		if err := request.Reject(404); err != nil {
+		if err := request.Abort(404); err != nil {
 			log.Fatal(err)
 		}
 		continue
@@ -176,7 +176,7 @@ for request, err := range dynamic.All(ctx) {
 }
 ```
 
-The served broadcast is not announced. It only resolves consumers that call `RequestBroadcast(path)`. Each request arrives as a `BroadcastRequest`; call `Accept(broadcast)` to serve it, or `Reject(code)` to fail the requester.
+The served broadcast is not announced. It only resolves consumers that call `RequestBroadcast(path)`. Each request arrives as a `BroadcastRequest`; call `Accept(broadcast)` to serve it, or `Abort(code)` to fail the requester.
 
 ## Local development
 

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -127,6 +127,57 @@ _ = producer.Finish()
 
 Call `request.Abort(code)` when the requested group cannot be produced. Fetch is currently a single-group operation and is supported by the moq-lite 05+ FETCH wire path.
 
+## On-demand broadcasts
+
+Use a dynamic origin when consumers should be able to request whole broadcasts that are not announced:
+
+```go
+capacity := uint64(256 * 1024 * 1024)
+origin := moq.NewOriginProducerWithOptions(moq.OriginOptions{
+	CacheCapacityBytes: &capacity,
+})
+
+dynamic := origin.Dynamic()
+defer dynamic.Cancel()
+
+for request, err := range dynamic.All(ctx) {
+	if err != nil {
+		if moq.IsShutdown(err) {
+			break
+		}
+		log.Fatal(err)
+	}
+
+	path, err := request.Path()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if path != "events" {
+		if err := request.Reject(404); err != nil {
+			log.Fatal(err)
+		}
+		continue
+	}
+
+	broadcast, err := moq.NewBroadcastProducer()
+	if err != nil {
+		log.Fatal(err)
+	}
+	track, err := broadcast.PublishTrack("status", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := request.Accept(broadcast); err != nil {
+		log.Fatal(err)
+	}
+	if err := track.WriteFrame([]byte("ready")); err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+The served broadcast is not announced. It only resolves consumers that call `RequestBroadcast(path)`. Each request arrives as a `BroadcastRequest`; call `Accept(broadcast)` to serve it, or `Reject(code)` to fail the requester.
+
 ## Local development
 
 The in-tree `go/wrapper/` directory is the source skeleton; CI publishes it to the [moq-dev/moq-go](https://github.com/moq-dev/moq-go) mirror. To exercise it locally:

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -145,6 +145,30 @@ Moq.connect("https://relay.example.com").use { moq ->
 
 Each requested track arrives as a `TrackRequest`; call `accept(info)` to turn it into a `TrackProducer` (pass `null` for defaults), or `abort(code)` to reject the subscriber.
 
+### On-demand broadcasts
+
+Use a dynamic origin when consumers should be able to request whole broadcasts that are not announced:
+
+```kotlin
+import dev.moq.*
+
+val origin = OriginProducer(OriginOptions(cacheCapacityBytes = 256UL * 1024UL * 1024UL))
+val dynamic = origin.dynamic()
+
+dynamic.requestedBroadcasts().collect { request ->
+    if (request.path() == "events") {
+        val broadcast = BroadcastProducer()
+        val track = broadcast.publishTrack("status", null)
+        request.accept(broadcast)
+        track.writeFrame("ready".encodeToByteArray())
+    } else {
+        request.reject(404)
+    }
+}
+```
+
+The served broadcast is not announced. It only resolves consumers that call `requestBroadcast(path)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast)` to serve it, or `reject(code)` to fail the requester.
+
 ## Cancellation
 
 The wrapper exposes consumers as Kotlin `Flow`s. Cancelling the collector's coroutine scope calls `cancel()` on the native side via the wrapper's `onCompletion` hook, releasing resources promptly:

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -162,12 +162,12 @@ dynamic.requestedBroadcasts().collect { request ->
         request.accept(broadcast)
         track.writeFrame("ready".encodeToByteArray())
     } else {
-        request.reject(404)
+        request.abort(404)
     }
 }
 ```
 
-The served broadcast is not announced. It only resolves consumers that call `requestBroadcast(path)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast)` to serve it, or `reject(code)` to fail the requester.
+The served broadcast is not announced. It only resolves consumers that call `requestBroadcast(path)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast)` to serve it, or `abort(code)` to fail the requester.
 
 ## Cancellation
 

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -167,6 +167,24 @@ async for request in dynamic:
 
 Missing track subscriptions are accepted while the `BroadcastDynamic` object is alive. Each one arrives as a `TrackRequest`; call `accept()` to turn it into a `TrackProducer` (or `abort(code)` to reject the subscriber).
 
+### On-demand broadcasts
+
+Use a dynamic origin when consumers should be able to request whole broadcasts that are not announced:
+
+```python
+origin = moq.OriginProducer(cache_capacity_bytes=256 * 1024 * 1024)
+dynamic = origin.dynamic()
+
+async for request in dynamic:
+    if request.path == "events":
+        broadcast = moq.BroadcastProducer()
+        track = broadcast.publish_track("status")
+        request.accept(broadcast)
+        track.write_frame(b"ready")
+```
+
+The served broadcast is not announced. It only resolves consumers that call `request_broadcast(path)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast)` to serve it, or `reject(code)` to fail the requester.
+
 ### Discovering broadcasts
 
 ```python

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -183,7 +183,7 @@ async for request in dynamic:
         track.write_frame(b"ready")
 ```
 
-The served broadcast is not announced. It only resolves consumers that call `request_broadcast(path)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast)` to serve it, or `reject(code)` to fail the requester.
+The served broadcast is not announced. It only resolves consumers that call `request_broadcast(path)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast)` to serve it, or `abort(code)` to fail the requester.
 
 ### Discovering broadcasts
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -147,6 +147,28 @@ for try await request in dynamic {
 
 Each request arrives as a `TrackRequest`; call `accept(info:)` to turn it into a `TrackProducer` (omit `info` for defaults), or `abort(errorCode:)` to reject the subscriber.
 
+### On-demand broadcasts
+
+Use a dynamic origin when consumers should be able to request whole broadcasts that are not announced:
+
+```swift
+let origin = OriginProducer(cacheCapacityBytes: 256 * 1024 * 1024)
+let dynamic = origin.dynamic()
+
+for try await request in dynamic {
+    if try request.path == "events" {
+        let broadcast = try BroadcastProducer()
+        let track = try broadcast.publishTrack(name: "status")
+        try request.accept(broadcast: broadcast)
+        try track.writeFrame(Data("ready".utf8))
+    } else {
+        try request.reject(errorCode: 404)
+    }
+}
+```
+
+The served broadcast is not announced. It only resolves consumers that call `requestBroadcast(path:)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast:)` to serve it, or `reject(errorCode:)` to fail the requester.
+
 ## Cancellation
 
 All async sequences cooperate with structured concurrency. Cancelling the surrounding `Task` propagates to the underlying `cancel()` on the consumer:

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -162,12 +162,12 @@ for try await request in dynamic {
         try request.accept(broadcast: broadcast)
         try track.writeFrame(Data("ready".utf8))
     } else {
-        try request.reject(errorCode: 404)
+        try request.abort(errorCode: 404)
     }
 }
 ```
 
-The served broadcast is not announced. It only resolves consumers that call `requestBroadcast(path:)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast:)` to serve it, or `reject(errorCode:)` to fail the requester.
+The served broadcast is not announced. It only resolves consumers that call `requestBroadcast(path:)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast:)` to serve it, or `abort(errorCode:)` to fail the requester.
 
 ## Cancellation
 

--- a/go/wrapper/moq/moq_test.go
+++ b/go/wrapper/moq/moq_test.go
@@ -29,6 +29,85 @@ func opusHead() []byte {
 func TestOriginLifecycle(t *testing.T) {
 	origin := moq.NewOriginProducer()
 	_ = origin.Consume()
+	origin.Dynamic().Cancel()
+}
+
+func TestDynamicBroadcastRequest(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	origin := moq.NewOriginProducer()
+	dynamic := origin.Dynamic()
+	defer dynamic.Cancel()
+
+	type result struct {
+		broadcast *moq.BroadcastConsumer
+		err       error
+	}
+	requested := make(chan result, 1)
+	go func() {
+		broadcast, err := origin.Consume().RequestBroadcast("dynamic/broadcast")
+		requested <- result{broadcast: broadcast, err: err}
+	}()
+
+	request, err := dynamic.RequestedBroadcast(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path, err := request.Path()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != "dynamic/broadcast" {
+		t.Fatalf("path = %q, want %q", path, "dynamic/broadcast")
+	}
+
+	served, err := moq.NewBroadcastProducer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	track, err := served.PublishTrack("status", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := request.Accept(served); err != nil {
+		t.Fatal(err)
+	}
+
+	var res result
+	select {
+	case res = <-requested:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	if res.err != nil {
+		t.Fatal(res.err)
+	}
+
+	trackConsumer, err := res.broadcast.SubscribeTrack("status", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer trackConsumer.Cancel()
+
+	payload := []byte("served dynamically")
+	if err := track.WriteFrame(payload); err != nil {
+		t.Fatal(err)
+	}
+	frame, err := trackConsumer.ReadFrame(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(frame) != string(payload) {
+		t.Fatalf("frame = %q, want %q", frame, payload)
+	}
+
+	if err := track.Finish(); err != nil {
+		t.Fatal(err)
+	}
+	if err := served.Finish(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestPublishMediaLifecycle(t *testing.T) {

--- a/go/wrapper/moq/origin.go
+++ b/go/wrapper/moq/origin.go
@@ -17,12 +17,22 @@ type OriginProducer struct {
 
 // NewOriginProducer creates an empty origin.
 func NewOriginProducer() *OriginProducer {
-	return &OriginProducer{inner: ffi.NewMoqOriginProducer()}
+	return NewOriginProducerWithOptions(OriginOptions{})
+}
+
+// NewOriginProducerWithOptions creates an origin with explicit options.
+func NewOriginProducerWithOptions(options OriginOptions) *OriginProducer {
+	return &OriginProducer{inner: ffi.NewMoqOriginProducer(options)}
 }
 
 // Consume returns a consumer that observes broadcasts published to this origin.
 func (o *OriginProducer) Consume() *OriginConsumer {
 	return &OriginConsumer{inner: o.inner.Consume()}
+}
+
+// Dynamic serves broadcasts that consumers request without an announcement.
+func (o *OriginProducer) Dynamic() *OriginDynamic {
+	return &OriginDynamic{inner: o.inner.Dynamic()}
 }
 
 // Announce advertises a broadcast at the given path so subscribers can discover it.
@@ -36,6 +46,53 @@ func (o *OriginProducer) Announce(path string, broadcast *BroadcastProducer) err
 // Deprecated: use Announce.
 func (o *OriginProducer) Publish(path string, broadcast *BroadcastProducer) error {
 	return o.Announce(path, broadcast)
+}
+
+// OriginDynamic streams broadcast requests for paths that are not announced.
+type OriginDynamic struct {
+	inner *ffi.MoqOriginDynamic
+}
+
+// RequestedBroadcast blocks until a consumer requests an unannounced broadcast.
+func (d *OriginDynamic) RequestedBroadcast(ctx context.Context) (*BroadcastRequest, error) {
+	inner, err := runCancellable(ctx, d.inner.Cancel, d.inner.RequestedBroadcast)
+	if err != nil {
+		return nil, err
+	}
+	return &BroadcastRequest{inner: inner}, nil
+}
+
+// All ranges over requested broadcasts until the stream errors or the loop breaks.
+func (d *OriginDynamic) All(ctx context.Context) iter.Seq2[*BroadcastRequest, error] {
+	return streamSeq(ctx, d.RequestedBroadcast)
+}
+
+// Cancel stops serving requested broadcasts.
+func (d *OriginDynamic) Cancel() {
+	d.inner.Cancel()
+}
+
+// BroadcastRequest is a requested broadcast that has not been accepted yet.
+type BroadcastRequest struct {
+	inner *ffi.MoqBroadcastRequest
+}
+
+// Path returns the requested broadcast path.
+func (r *BroadcastRequest) Path() (string, error) {
+	return r.inner.Path()
+}
+
+// Accept serves the request with an unannounced broadcast.
+func (r *BroadcastRequest) Accept(broadcast *BroadcastProducer) error {
+	if broadcast == nil {
+		return errors.New("moq: nil broadcast producer")
+	}
+	return r.inner.Accept(broadcast.inner)
+}
+
+// Reject fails the request with an application error code.
+func (r *BroadcastRequest) Reject(errorCode int32) error {
+	return r.inner.Reject(errorCode)
 }
 
 // OriginConsumer discovers broadcasts announced to an origin.

--- a/go/wrapper/moq/origin.go
+++ b/go/wrapper/moq/origin.go
@@ -90,9 +90,9 @@ func (r *BroadcastRequest) Accept(broadcast *BroadcastProducer) error {
 	return r.inner.Accept(broadcast.inner)
 }
 
-// Reject fails the request with an application error code.
-func (r *BroadcastRequest) Reject(errorCode int32) error {
-	return r.inner.Reject(errorCode)
+// Abort fails the request with an application error code.
+func (r *BroadcastRequest) Abort(errorCode int32) error {
+	return r.inner.Abort(errorCode)
 }
 
 // OriginConsumer discovers broadcasts announced to an origin.

--- a/go/wrapper/moq/types.go
+++ b/go/wrapper/moq/types.go
@@ -17,6 +17,7 @@ type (
 	Dimensions         = ffi.MoqDimensions
 	Frame              = ffi.MoqFrame
 	FetchGroupOptions  = ffi.MoqFetchGroupOptions
+	OriginOptions      = ffi.MoqOriginOptions
 	Subscription       = ffi.MoqSubscription
 	TrackInfo          = ffi.MoqTrackInfo
 	Video              = ffi.MoqVideo

--- a/kt/moq-ffi/src/jvmAndAndroidTest/kotlin/dev/moq/ffi/BindingsSmokeTest.kt
+++ b/kt/moq-ffi/src/jvmAndAndroidTest/kotlin/dev/moq/ffi/BindingsSmokeTest.kt
@@ -3,6 +3,7 @@ package dev.moq.ffi
 import kotlinx.coroutines.test.runTest
 import uniffi.moq.MoqClient
 import uniffi.moq.MoqException
+import uniffi.moq.MoqOriginOptions
 import uniffi.moq.MoqOriginProducer
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -25,7 +26,7 @@ class BindingsSmokeTest {
 
     @Test
     fun `origin producer constructs and consumes`() = runTest {
-        MoqOriginProducer().use { origin ->
+        MoqOriginProducer(MoqOriginOptions()).use { origin ->
             origin.consume().use { /* lifecycle smoke */ }
         }
     }

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -15,7 +15,10 @@ typealias Request = uniffi.moq.MoqRequest
 
 // Origin (broadcast discovery / announcement).
 typealias OriginProducer = uniffi.moq.MoqOriginProducer
+typealias OriginOptions = uniffi.moq.MoqOriginOptions
 typealias OriginConsumer = uniffi.moq.MoqOriginConsumer
+typealias OriginDynamic = uniffi.moq.MoqOriginDynamic
+typealias BroadcastRequest = uniffi.moq.MoqBroadcastRequest
 typealias Announced = uniffi.moq.MoqAnnounced
 typealias AnnouncedBroadcast = uniffi.moq.MoqAnnouncedBroadcast
 typealias Announcement = uniffi.moq.MoqAnnouncement

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Flows.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Flows.kt
@@ -11,6 +11,7 @@ import uniffi.moq.MoqAudioConsumer
 import uniffi.moq.MoqAudioFrame
 import uniffi.moq.MoqBroadcastConsumer
 import uniffi.moq.MoqBroadcastDynamic
+import uniffi.moq.MoqBroadcastRequest
 import uniffi.moq.MoqCatalog
 import uniffi.moq.MoqCatalogConsumer
 import uniffi.moq.MoqException
@@ -19,6 +20,7 @@ import uniffi.moq.MoqGroupConsumer
 import uniffi.moq.MoqGroupRequest
 import uniffi.moq.MoqMediaConsumer
 import uniffi.moq.MoqOriginConsumer
+import uniffi.moq.MoqOriginDynamic
 import uniffi.moq.MoqTrackConsumer
 import uniffi.moq.MoqTrackDynamic
 import uniffi.moq.MoqTrackRequest
@@ -111,6 +113,16 @@ fun MoqTrackDynamic.requestedGroups(): Flow<MoqGroupRequest> = flow {
     while (true) {
         currentCoroutineContext().ensureActive()
         emit(requestedGroup())
+    }
+}.onCompletion { cause ->
+    if (cause is CancellationException) cancel()
+}
+
+/** Stream of broadcasts requested by consumers. */
+fun MoqOriginDynamic.requestedBroadcasts(): Flow<MoqBroadcastRequest> = flow {
+    while (true) {
+        currentCoroutineContext().ensureActive()
+        emit(requestedBroadcast())
     }
 }.onCompletion { cause ->
     if (cause is CancellationException) cancel()

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import uniffi.moq.MoqAnnounced
 import uniffi.moq.MoqAnnouncement
 import uniffi.moq.MoqClient
+import uniffi.moq.MoqOriginOptions
 import uniffi.moq.MoqOriginProducer
 import uniffi.moq.MoqSession
 
@@ -67,7 +68,7 @@ class Moq internal constructor(
             // broadcast published on this connection is discoverable via its own
             // announcements() (loopback). Otherwise honor what the caller passed
             // and let the FFI auto-create any side left null.
-            val shared = if (publish == null && subscribe == null) MoqOriginProducer() else null
+            val shared = if (publish == null && subscribe == null) MoqOriginProducer(MoqOriginOptions()) else null
             val publishOrigin = publish ?: shared
             val subscribeOrigin = subscribe ?: shared
 

--- a/kt/moq/src/jvmAndAndroidTest/kotlin/dev/moq/SmokeTest.kt
+++ b/kt/moq/src/jvmAndAndroidTest/kotlin/dev/moq/SmokeTest.kt
@@ -32,8 +32,9 @@ class SmokeTest {
      */
     @Test
     fun `origin alias constructs and consumes`() = runTest {
-        OriginProducer().use { origin ->
+        OriginProducer(OriginOptions()).use { origin ->
             origin.consume().use { /* lifecycle smoke */ }
+            origin.dynamic().use { /* dynamic origin smoke */ }
         }
     }
 

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -149,9 +149,13 @@ All consumers (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsum
 
 ### Origin (advanced)
 
-- **`OriginProducer()`**. Manage broadcast announcements.
+- **`OriginProducer(cache_capacity_bytes=None)`**. Manage broadcast announcements. Set `cache_capacity_bytes` to bound cached groups under this origin.
   - `.consume() → OriginConsumer`
+  - `.dynamic() → OriginDynamic`
   - `.announce(path, broadcast)`
+- **`OriginDynamic`**. Async source of broadcasts requested by consumers.
+  - `await .requested_broadcast() → BroadcastRequest`. Call `.accept(broadcast)` to serve it, or `.reject(code)` to fail the requester.
+  - Async iterator yielding `BroadcastRequest`
 - **`OriginConsumer`**. Discover broadcasts.
   - `.announced(prefix) → Announced` (async iterator)
   - `.announced_broadcast(path) → AnnouncedBroadcast` (awaitable, waits for a future announcement)

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -154,7 +154,7 @@ All consumers (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsum
   - `.dynamic() → OriginDynamic`
   - `.announce(path, broadcast)`
 - **`OriginDynamic`**. Async source of broadcasts requested by consumers.
-  - `await .requested_broadcast() → BroadcastRequest`. Call `.accept(broadcast)` to serve it, or `.reject(code)` to fail the requester.
+  - `await .requested_broadcast() → BroadcastRequest`. Call `.accept(broadcast)` to serve it, or `.abort(code)` to fail the requester.
   - Async iterator yielding `BroadcastRequest`
 - **`OriginConsumer`**. Discover broadcasts.
   - `.announced(prefix) → Announced` (async iterator)

--- a/py/moq-rs/moq/__init__.py
+++ b/py/moq-rs/moq/__init__.py
@@ -7,7 +7,15 @@ from moq_ffi import MoqError as Error
 
 from .client import Client, connect
 from .log import log_level
-from .origin import Announced, AnnouncedBroadcast, Announcement, OriginConsumer, OriginProducer
+from .origin import (
+    Announced,
+    AnnouncedBroadcast,
+    Announcement,
+    BroadcastRequest,
+    OriginConsumer,
+    OriginDynamic,
+    OriginProducer,
+)
 from .publish import (
     AudioProducer,
     BroadcastDynamic,
@@ -66,6 +74,7 @@ __all__ = [
     "BroadcastConsumer",
     "BroadcastDynamic",
     "BroadcastProducer",
+    "BroadcastRequest",
     "Catalog",
     "CatalogConsumer",
     "Client",
@@ -82,6 +91,7 @@ __all__ = [
     "MediaProducer",
     "MediaStreamProducer",
     "OriginConsumer",
+    "OriginDynamic",
     "OriginProducer",
     "Request",
     "Server",

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -99,9 +99,9 @@ class BroadcastRequest:
         """Serve the request with an unannounced broadcast."""
         self._inner.accept(broadcast._inner)
 
-    def reject(self, error_code: int) -> None:
-        """Reject the request with an application error code."""
-        self._inner.reject(error_code)
+    def abort(self, error_code: int) -> None:
+        """Abort the request with an application error code."""
+        self._inner.abort(error_code)
 
 
 class OriginDynamic:

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -150,9 +150,7 @@ class OriginProducer:
     """Wraps MoqOriginProducer for publishing broadcasts."""
 
     def __init__(self, *, cache_capacity_bytes: int | None = None) -> None:
-        self._inner = MoqOriginProducer(
-            MoqOriginOptions(cache_capacity_bytes=cache_capacity_bytes)
-        )
+        self._inner = MoqOriginProducer(MoqOriginOptions(cache_capacity_bytes=cache_capacity_bytes))
 
     @classmethod
     def _from_inner(cls, inner: MoqOriginProducer) -> OriginProducer:

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-from moq_ffi import MoqAnnounced, MoqAnnouncedBroadcast, MoqAnnouncement, MoqOriginConsumer, MoqOriginProducer
+from moq_ffi import (
+    MoqAnnounced,
+    MoqAnnouncedBroadcast,
+    MoqAnnouncement,
+    MoqBroadcastRequest,
+    MoqOriginConsumer,
+    MoqOriginDynamic,
+    MoqOriginOptions,
+    MoqOriginProducer,
+)
 
 from .publish import BroadcastProducer
 from .subscribe import BroadcastConsumer
@@ -75,6 +84,45 @@ class AnnouncedBroadcast:
         self._inner.cancel()
 
 
+class BroadcastRequest:
+    """A requested broadcast that has not been accepted yet."""
+
+    def __init__(self, inner: MoqBroadcastRequest) -> None:
+        self._inner = inner
+
+    @property
+    def path(self) -> str:
+        """The requested broadcast path."""
+        return self._inner.path()
+
+    def accept(self, broadcast: BroadcastProducer) -> None:
+        """Serve the request with an unannounced broadcast."""
+        self._inner.accept(broadcast._inner)
+
+    def reject(self, error_code: int) -> None:
+        """Reject the request with an application error code."""
+        self._inner.reject(error_code)
+
+
+class OriginDynamic:
+    """Async source of broadcasts requested by consumers."""
+
+    def __init__(self, inner: MoqOriginDynamic) -> None:
+        self._inner = inner
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> BroadcastRequest:
+        return await self.requested_broadcast()
+
+    async def requested_broadcast(self) -> BroadcastRequest:
+        return BroadcastRequest(await self._inner.requested_broadcast())
+
+    def cancel(self) -> None:
+        self._inner.cancel()
+
+
 class OriginConsumer:
     """Wraps MoqOriginConsumer for discovering broadcasts."""
 
@@ -101,8 +149,10 @@ class OriginConsumer:
 class OriginProducer:
     """Wraps MoqOriginProducer for publishing broadcasts."""
 
-    def __init__(self) -> None:
-        self._inner = MoqOriginProducer()
+    def __init__(self, *, cache_capacity_bytes: int | None = None) -> None:
+        self._inner = MoqOriginProducer(
+            MoqOriginOptions(cache_capacity_bytes=cache_capacity_bytes)
+        )
 
     @classmethod
     def _from_inner(cls, inner: MoqOriginProducer) -> OriginProducer:
@@ -113,6 +163,10 @@ class OriginProducer:
 
     def consume(self) -> OriginConsumer:
         return OriginConsumer(self._inner.consume())
+
+    def dynamic(self) -> OriginDynamic:
+        """Serve broadcasts that consumers request without an announcement."""
+        return OriginDynamic(self._inner.dynamic())
 
     def announce(self, path: str, broadcast: BroadcastProducer) -> None:
         """Advertise ``broadcast`` at ``path`` so subscribers can discover it."""

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -344,6 +344,50 @@ async def test_dynamic_track_request_can_publish_media():
     media.finish()
 
 
+async def test_dynamic_broadcast_request():
+    origin = moq.OriginProducer(cache_capacity_bytes=4096)
+    dynamic = origin.dynamic()
+    consumer = origin.consume()
+
+    request_broadcast = asyncio.create_task(consumer.request_broadcast("dynamic/broadcast"))
+
+    request = await asyncio.wait_for(dynamic.requested_broadcast(), timeout=5.0)
+    assert request.path == "dynamic/broadcast"
+
+    served = moq.BroadcastProducer()
+    track = served.publish_track("status")
+    request.accept(served)
+    with pytest.raises(Exception):
+        _ = request.path
+
+    broadcast = await asyncio.wait_for(request_broadcast, timeout=5.0)
+    track_consumer = await broadcast.subscribe_track("status")
+    payload = b"served dynamically"
+    track.write_frame(payload)
+
+    frame = await asyncio.wait_for(track_consumer.read_frame(), timeout=5.0)
+    assert frame == payload
+    track.finish()
+    served.finish()
+
+
+async def test_dynamic_broadcast_request_can_reject():
+    origin = moq.OriginProducer()
+    dynamic = origin.dynamic()
+    consumer = origin.consume()
+
+    request_broadcast = asyncio.create_task(consumer.request_broadcast("missing"))
+    request = await asyncio.wait_for(dynamic.requested_broadcast(), timeout=5.0)
+    assert request.path == "missing"
+
+    request.reject(404)
+    with pytest.raises(Exception):
+        _ = request.path
+
+    with pytest.raises(Exception):
+        await asyncio.wait_for(request_broadcast, timeout=5.0)
+
+
 def test_raw_append_group_sequence_increments():
     """append_group hands out monotonically increasing sequence numbers."""
     broadcast = moq.BroadcastProducer()

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -380,7 +380,7 @@ async def test_dynamic_broadcast_request_can_reject():
     request = await asyncio.wait_for(dynamic.requested_broadcast(), timeout=5.0)
     assert request.path == "missing"
 
-    request.reject(404)
+    request.abort(404)
     with pytest.raises(Exception):
         _ = request.path
 

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -223,7 +223,7 @@ impl MoqOriginConsumer {
 impl MoqOriginDynamic {
 	/// Wait for the next requested broadcast that is not announced.
 	///
-	/// Returns a [`MoqBroadcastRequest`]: accept it with a broadcast producer or reject
+	/// Returns a [`MoqBroadcastRequest`]: accept it with a broadcast producer or abort
 	/// it with an application error code. The requesting consumer stays pending until then.
 	pub async fn requested_broadcast(&self) -> Result<Arc<MoqBroadcastRequest>, MoqError> {
 		self.task
@@ -269,8 +269,8 @@ impl MoqBroadcastRequest {
 		Ok(())
 	}
 
-	/// Reject the request with an application error code.
-	pub fn reject(&self, error_code: i32) -> Result<(), MoqError> {
+	/// Abort the request with an application error code.
+	pub fn abort(&self, error_code: i32) -> Result<(), MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let error_code = u16::try_from(error_code).map_err(|_| MoqError::InvalidErrorCode(error_code))?;
 		let request = self.take()?;

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -5,6 +5,14 @@ use crate::error::MoqError;
 use crate::ffi::Task;
 use crate::producer::MoqBroadcastProducer;
 
+/// Options used when creating an origin.
+#[derive(Clone, Default, uniffi::Record)]
+pub struct MoqOriginOptions {
+	/// Maximum cached group bytes across broadcasts under this origin. Null is unbounded.
+	#[uniffi(default = None)]
+	pub cache_capacity_bytes: Option<u64>,
+}
+
 #[derive(uniffi::Object)]
 pub struct MoqOriginProducer {
 	inner: moq_net::origin::Producer,
@@ -20,8 +28,29 @@ pub struct MoqAnnounced {
 	task: Task<Announced>,
 }
 
+#[derive(uniffi::Object)]
+pub struct MoqOriginDynamic {
+	task: Task<OriginDynamic>,
+}
+
+#[derive(uniffi::Object)]
+pub struct MoqBroadcastRequest {
+	inner: std::sync::Mutex<Option<moq_net::origin::Request>>,
+}
+
 struct Announced {
 	inner: moq_net::announce::Consumer,
+}
+
+struct OriginDynamic {
+	inner: moq_net::origin::Dynamic,
+}
+
+impl OriginDynamic {
+	async fn requested_broadcast(&mut self) -> Result<Arc<MoqBroadcastRequest>, MoqError> {
+		let request = self.inner.requested_broadcast().await?;
+		Ok(Arc::new(MoqBroadcastRequest::new(request)))
+	}
 }
 
 impl Announced {
@@ -83,6 +112,15 @@ impl MoqOriginProducer {
 	pub(crate) fn from_inner(inner: moq_net::origin::Producer) -> Self {
 		Self { inner }
 	}
+
+	fn from_options(options: MoqOriginOptions) -> Self {
+		let mut info = moq_net::origin::Info::new(moq_net::Origin::random());
+		if let Some(capacity) = options.cache_capacity_bytes {
+			info = info.with_pool(moq_net::cache::Pool::new(capacity));
+		}
+
+		Self { inner: info.produce() }
+	}
 }
 
 impl MoqOriginConsumer {
@@ -95,11 +133,9 @@ impl MoqOriginConsumer {
 impl MoqOriginProducer {
 	/// Create a new origin for publishing and/or consuming broadcasts.
 	#[uniffi::constructor]
-	pub fn new() -> Arc<Self> {
+	pub fn new(options: MoqOriginOptions) -> Arc<Self> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		Arc::new(Self {
-			inner: moq_net::Origin::random().produce(),
-		})
+		Arc::new(Self::from_options(options))
 	}
 
 	/// Create a consumer for this origin.
@@ -107,6 +143,19 @@ impl MoqOriginProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		Arc::new(MoqOriginConsumer {
 			inner: self.inner.consume(),
+		})
+	}
+
+	/// Create a dynamic handler for serving unannounced broadcasts on request.
+	///
+	/// Hold the returned object while missing broadcast requests should be accepted.
+	/// Dropping it makes future requests to unknown broadcasts fail.
+	pub fn dynamic(&self) -> Arc<MoqOriginDynamic> {
+		let _guard = crate::ffi::RUNTIME.enter();
+		Arc::new(MoqOriginDynamic {
+			task: Task::new(OriginDynamic {
+				inner: self.inner.dynamic(),
+			}),
 		})
 	}
 
@@ -165,6 +214,68 @@ impl MoqOriginConsumer {
 	pub async fn request_broadcast(&self, path: String) -> Result<Arc<MoqBroadcastConsumer>, MoqError> {
 		let broadcast = self.inner.request_broadcast(path.as_str()).await?;
 		Ok(Arc::new(MoqBroadcastConsumer::new(broadcast)))
+	}
+}
+
+// ---- MoqOriginDynamic ----
+
+#[uniffi::export]
+impl MoqOriginDynamic {
+	/// Wait for the next requested broadcast that is not announced.
+	///
+	/// Returns a [`MoqBroadcastRequest`]: accept it with a broadcast producer or reject
+	/// it with an application error code. The requesting consumer stays pending until then.
+	pub async fn requested_broadcast(&self) -> Result<Arc<MoqBroadcastRequest>, MoqError> {
+		self.task
+			.run(|mut state| async move { state.requested_broadcast().await })
+			.await
+	}
+
+	/// Cancel all current and future `requested_broadcast()` calls.
+	pub fn cancel(&self) {
+		self.task.cancel();
+	}
+}
+
+// ---- MoqBroadcastRequest ----
+
+impl MoqBroadcastRequest {
+	fn new(request: moq_net::origin::Request) -> Self {
+		Self {
+			inner: std::sync::Mutex::new(Some(request)),
+		}
+	}
+
+	fn take(&self) -> Result<moq_net::origin::Request, MoqError> {
+		self.inner.lock().unwrap().take().ok_or(MoqError::Closed)
+	}
+}
+
+#[uniffi::export]
+impl MoqBroadcastRequest {
+	/// The requested broadcast path.
+	pub fn path(&self) -> Result<String, MoqError> {
+		let guard = self.inner.lock().unwrap();
+		let request = guard.as_ref().ok_or(MoqError::Closed)?;
+		Ok(request.path().to_string())
+	}
+
+	/// Accept the request with an unannounced broadcast.
+	pub fn accept(&self, broadcast: &MoqBroadcastProducer) -> Result<(), MoqError> {
+		let _guard = crate::ffi::RUNTIME.enter();
+		let consumer = broadcast.consume_inner()?;
+		let request = self.take()?;
+		request.accept(&consumer);
+		Ok(())
+	}
+
+	/// Reject the request with an application error code.
+	pub fn reject(&self, error_code: i32) -> Result<(), MoqError> {
+		let _guard = crate::ffi::RUNTIME.enter();
+		let error_code = u16::try_from(error_code).map_err(|_| MoqError::InvalidErrorCode(error_code))?;
+		let request = self.take()?;
+		request.reject(moq_net::Error::App(error_code));
+		Ok(())
 	}
 }
 

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -716,7 +716,7 @@ async fn dynamic_broadcast_request_can_reject() {
 		.unwrap();
 	assert_eq!(request.path().unwrap(), "missing");
 
-	request.reject(404).unwrap();
+	request.abort(404).unwrap();
 	assert!(matches!(request.path(), Err(MoqError::Closed)));
 
 	let result = tokio::time::timeout(TIMEOUT, request_broadcast)

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -49,8 +49,16 @@ fn h264_init() -> Vec<u8> {
 
 #[test]
 fn origin_lifecycle() {
-	let origin = MoqOriginProducer::new();
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
 	let _consumer = origin.consume();
+}
+
+#[test]
+fn origin_options_set_cache_capacity() {
+	let origin = MoqOriginProducer::new(MoqOriginOptions {
+		cache_capacity_bytes: Some(4096),
+	});
+	assert_eq!(origin.inner().info().pool.capacity(), Some(4096));
 }
 
 #[test]
@@ -423,7 +431,7 @@ fn unknown_format() {
 
 #[tokio::test]
 async fn local_publish_consume_audio() {
-	let origin = MoqOriginProducer::new();
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let media = broadcast.publish_media(media_init("opus", init)).unwrap();
@@ -476,7 +484,7 @@ async fn local_publish_consume_audio() {
 
 #[tokio::test]
 async fn video_publish_consume() {
-	let origin = MoqOriginProducer::new();
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = h264_init();
 	let media = broadcast.publish_media(media_init("avc3", init)).unwrap();
@@ -532,7 +540,7 @@ async fn video_publish_consume() {
 
 #[tokio::test]
 async fn multiple_frames_ordering() {
-	let origin = MoqOriginProducer::new();
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let media = broadcast.publish_media(media_init("opus", init)).unwrap();
@@ -581,7 +589,7 @@ async fn multiple_frames_ordering() {
 
 #[tokio::test]
 async fn catalog_update_on_new_track() {
-	let origin = MoqOriginProducer::new();
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let _media1 = broadcast.publish_media(media_init("opus", init.clone())).unwrap();
@@ -631,7 +639,7 @@ fn finish_closes_producer() {
 
 #[tokio::test]
 async fn announced_broadcast() {
-	let origin = MoqOriginProducer::new();
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	origin.announce("test/broadcast".into(), &broadcast).unwrap();
 
@@ -648,10 +656,80 @@ async fn announced_broadcast() {
 	let _catalog = announcement.broadcast().subscribe_catalog().await.unwrap();
 }
 
+#[tokio::test]
+async fn dynamic_broadcast_request() {
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
+	let dynamic = origin.dynamic();
+	let consumer = origin.consume();
+
+	let request_broadcast = {
+		let consumer = consumer.clone();
+		tokio::spawn(async move { consumer.request_broadcast("dynamic/broadcast".into()).await })
+	};
+
+	let request = tokio::time::timeout(TIMEOUT, dynamic.requested_broadcast())
+		.await
+		.expect("timed out waiting for requested broadcast")
+		.unwrap();
+	assert_eq!(request.path().unwrap(), "dynamic/broadcast");
+
+	let served = MoqBroadcastProducer::new().unwrap();
+	let track = served.publish_track("status".into(), None).unwrap();
+	request.accept(&served).unwrap();
+	assert!(matches!(request.path(), Err(MoqError::Closed)));
+
+	let broadcast = tokio::time::timeout(TIMEOUT, request_broadcast)
+		.await
+		.expect("timed out waiting for requested broadcast result")
+		.expect("request task panicked")
+		.unwrap();
+
+	let track_consumer = broadcast.subscribe_track("status".into(), None).await.unwrap();
+	let payload = b"served dynamically".to_vec();
+	track.write_frame(payload.clone()).unwrap();
+
+	let frame = tokio::time::timeout(TIMEOUT, track_consumer.read_frame())
+		.await
+		.expect("timed out waiting for dynamic broadcast frame")
+		.unwrap()
+		.expect("expected a frame");
+	assert_eq!(frame, payload);
+
+	track.finish().unwrap();
+	served.finish().unwrap();
+}
+
+#[tokio::test]
+async fn dynamic_broadcast_request_can_reject() {
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
+	let dynamic = origin.dynamic();
+	let consumer = origin.consume();
+
+	let request_broadcast = {
+		let consumer = consumer.clone();
+		tokio::spawn(async move { consumer.request_broadcast("missing".into()).await })
+	};
+
+	let request = tokio::time::timeout(TIMEOUT, dynamic.requested_broadcast())
+		.await
+		.expect("timed out waiting for requested broadcast")
+		.unwrap();
+	assert_eq!(request.path().unwrap(), "missing");
+
+	request.reject(404).unwrap();
+	assert!(matches!(request.path(), Err(MoqError::Closed)));
+
+	let result = tokio::time::timeout(TIMEOUT, request_broadcast)
+		.await
+		.expect("timed out waiting for rejected broadcast")
+		.expect("request task panicked");
+	assert!(result.is_err(), "request for a rejected broadcast should fail");
+}
+
 #[test]
 fn without_runtime() {
 	std::thread::spawn(|| {
-		let origin = MoqOriginProducer::new();
+		let origin = MoqOriginProducer::new(MoqOriginOptions::default());
 		let consumer = origin.consume();
 
 		let broadcast = MoqBroadcastProducer::new().unwrap();
@@ -685,7 +763,7 @@ fn without_runtime() {
 #[tokio::test]
 async fn server_client_roundtrip() {
 	// Server side: bind, set a publish origin, accept incoming sessions.
-	let server_origin = MoqOriginProducer::new();
+	let server_origin = MoqOriginProducer::new(MoqOriginOptions::default());
 	let server = MoqServer::new();
 	server.set_bind("127.0.0.1:0".into()).unwrap();
 	server.set_tls_generate(vec!["localhost".into()]);
@@ -708,7 +786,7 @@ async fn server_client_roundtrip() {
 	});
 
 	// Client side: connect, subscribe via a consume origin.
-	let client_origin = MoqOriginProducer::new();
+	let client_origin = MoqOriginProducer::new(MoqOriginOptions::default());
 	let client = MoqClient::new();
 	client.set_tls_disable_verify(true);
 	client.set_bind("127.0.0.1:0".into()).unwrap();
@@ -778,7 +856,7 @@ async fn server_client_roundtrip_auto_origin() {
 	// Same shape as `server_client_roundtrip` but the client never calls
 	// `set_publish` / `set_consume`: the auto-created origin sides on
 	// `MoqClientSession` are what drive publishing and subscribing.
-	let server_origin = MoqOriginProducer::new();
+	let server_origin = MoqOriginProducer::new(MoqOriginOptions::default());
 	let server = MoqServer::new();
 	server.set_bind("127.0.0.1:0".into()).unwrap();
 	server.set_tls_generate(vec!["localhost".into()]);
@@ -800,7 +878,7 @@ async fn server_client_roundtrip_auto_origin() {
 		request.ok().await.expect("handshake failed")
 	});
 
-	// No set_publish / set_consume — auto-origin path.
+	// No set_publish / set_consume; auto-origin path.
 	let client = MoqClient::new();
 	client.set_tls_disable_verify(true);
 	client.set_bind("127.0.0.1:0".into()).unwrap();
@@ -941,7 +1019,7 @@ async fn request_per_session_publish_override() {
 	let addr = server.listen().await.expect("listen failed");
 	let url = format!("https://{addr}");
 
-	let override_origin = MoqOriginProducer::new();
+	let override_origin = MoqOriginProducer::new(MoqOriginOptions::default());
 	let override_for_task = override_origin.clone();
 
 	let accept_server = server.clone();
@@ -956,7 +1034,7 @@ async fn request_per_session_publish_override() {
 		request.ok().await.expect("ok succeeds")
 	});
 
-	let client_origin = MoqOriginProducer::new();
+	let client_origin = MoqOriginProducer::new(MoqOriginOptions::default());
 	let client = MoqClient::new();
 	client.set_tls_disable_verify(true);
 	client.set_bind("127.0.0.1:0".into()).unwrap();

--- a/swift/Sources/Moq/Origin.swift
+++ b/swift/Sources/Moq/Origin.swift
@@ -47,9 +47,9 @@ public final class BroadcastRequest: Sendable {
         try ffi.accept(broadcast: broadcast.ffi)
     }
 
-    /// Reject the request with an application error code.
-    public func reject(errorCode: Int32) throws {
-        try ffi.reject(errorCode: errorCode)
+    /// Abort the request with an application error code.
+    public func abort(errorCode: Int32) throws {
+        try ffi.abort(errorCode: errorCode)
     }
 }
 

--- a/swift/Sources/Moq/Origin.swift
+++ b/swift/Sources/Moq/Origin.swift
@@ -5,8 +5,8 @@ import MoqFFI
 public final class OriginProducer: Sendable {
     let ffi: MoqOriginProducer
 
-    public init() {
-        ffi = MoqOriginProducer()
+    public init(cacheCapacityBytes: UInt64? = nil) {
+        ffi = MoqOriginProducer(options: MoqOriginOptions(cacheCapacityBytes: cacheCapacityBytes))
     }
 
     init(_ ffi: MoqOriginProducer) {
@@ -18,9 +18,67 @@ public final class OriginProducer: Sendable {
         OriginConsumer(ffi.consume())
     }
 
+    /// Serve broadcasts that consumers request without an announcement.
+    public func dynamic() -> OriginDynamic {
+        OriginDynamic(ffi.dynamic())
+    }
+
     /// Announce a broadcast under the given path so subscribers can find it.
     public func announce(path: String, broadcast: BroadcastProducer) throws {
         try ffi.announce(path: path, broadcast: broadcast.ffi)
+    }
+}
+
+/// A requested broadcast that has not been accepted yet.
+public final class BroadcastRequest: Sendable {
+    let ffi: MoqBroadcastRequest
+
+    init(_ ffi: MoqBroadcastRequest) {
+        self.ffi = ffi
+    }
+
+    /// The requested broadcast path.
+    public var path: String {
+        get throws { try ffi.path() }
+    }
+
+    /// Serve the request with an unannounced broadcast.
+    public func accept(broadcast: BroadcastProducer) throws {
+        try ffi.accept(broadcast: broadcast.ffi)
+    }
+
+    /// Reject the request with an application error code.
+    public func reject(errorCode: Int32) throws {
+        try ffi.reject(errorCode: errorCode)
+    }
+}
+
+/// A stream of broadcasts requested by consumers. Iterate directly:
+/// `for try await request in dynamic { ... }`. Hold this while missing
+/// broadcasts should be served; cancelling the consuming task stops serving.
+public final class OriginDynamic: AsyncSequence, Sendable {
+    public typealias Element = BroadcastRequest
+
+    let ffi: MoqOriginDynamic
+
+    init(_ ffi: MoqOriginDynamic) {
+        self.ffi = ffi
+    }
+
+    /// The next requested broadcast. Throws `Closed` once the origin closes.
+    public func requestedBroadcast() async throws -> BroadcastRequest {
+        BroadcastRequest(try await ffi.requestedBroadcast())
+    }
+
+    /// Cancel all current and future `requestedBroadcast()` calls.
+    public func cancel() {
+        ffi.cancel()
+    }
+
+    public func makeAsyncIterator() -> AsyncThrowingStream<BroadcastRequest, Swift.Error>.Iterator {
+        moqStream(cancel: { [ffi] in ffi.cancel() }) { [ffi] in
+            BroadcastRequest(try await ffi.requestedBroadcast())
+        }.makeAsyncIterator()
     }
 }
 

--- a/swift/Tests/MoqTests/SmokeTests.swift
+++ b/swift/Tests/MoqTests/SmokeTests.swift
@@ -27,8 +27,9 @@ final class SmokeTests: XCTestCase {
     }
 
     func testOriginProducerIsConstructible() {
-        let origin = OriginProducer()
+        let origin = OriginProducer(cacheCapacityBytes: 4096)
         _ = origin.consume()
+        _ = origin.dynamic()
     }
 
     func testBroadcastProducerOpensTracks() throws {


### PR DESCRIPTION
Fixes #2151.

## Summary

- add `MoqOriginOptions` so the raw FFI origin can configure cache capacity through `origin::Info`
- make the raw FFI `MoqOriginProducer` constructor take options directly
- expose dynamic broadcast serving on origins and mirror it through Python, Swift, Kotlin, and Go wrappers and docs

## Public API changes

- Added raw FFI `MoqOriginOptions`
- Changed the raw FFI `MoqOriginProducer` constructor to require `MoqOriginOptions`
- Added `MoqOriginProducer.dynamic()`, `MoqOriginDynamic`, and `MoqBroadcastRequest`
- Added wrapper equivalents in Python, Swift, Kotlin, and Go
- Breaking: callers of the raw FFI constructor must pass options. This intentionally targets `dev`.

## Tests

- `nix develop --command just fix` reached JS/Biome successfully, then failed in Rust clippy-fix because the shared Cargo target cache had conflicting artifacts from another build
- `cargo fmt --check`
- `gofmt -w go/wrapper/moq/origin.go go/wrapper/moq/types.go go/wrapper/moq/moq_test.go`
- `python3 -m compileall py/moq-rs/moq py/moq-rs/tests`
- `cargo check --target-dir target/codex -p moq-ffi`
- `cargo test --target-dir target/codex -p moq-ffi origin_options_set_cache_capacity`
- `cargo test --target-dir target/codex -p moq-ffi dynamic_broadcast_request`
- generated temporary Python, Swift, Kotlin, and Go bindings to confirm constructor and method names

(Written by GPT-5)
