### PR TITLE
feat(moq-net)!: unify the latency budget as latency_max

### DIFF
--- a/demo/web/src/publish.ts
+++ b/demo/web/src/publish.ts
@@ -400,7 +400,7 @@ meta.run((effect) => {
 	if (!net) return;
 
 	// A day-long cache so a viewer joining long after the last edit still replays the value.
-	const track = net.createTrack(META_TRACK, { cache: 86_400_000 });
+	const track = net.createTrack(META_TRACK, { latencyMax: 86_400_000 });
 	effect.cleanup(() => track.close());
 
 	const producer = new Json.Snapshot.Producer<unknown>(track);

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -151,8 +151,8 @@ network.
 struct moq_track_info info = {0};
 info.priority = 3;
 info.ordered = true;
-info.cache_ms = 1000;
-info.cache_valid = true;
+info.latency_max_ms = 1000;
+info.latency_max_valid = true;
 info.timescale = 1000000;
 info.timescale_valid = true;
 
@@ -171,7 +171,7 @@ Fields ending in `_valid` decide whether the matching optional value is present:
 struct moq_subscription sub = {0};
 sub.priority = 5;
 sub.ordered = true;
-sub.stale_ms = 25;
+sub.latency_max_ms = 25;
 sub.group_start = 10;
 sub.group_start_valid = true;
 

--- a/go/wrapper/moq/moq_test.go
+++ b/go/wrapper/moq/moq_test.go
@@ -276,7 +276,7 @@ func TestLocalPublishConsumeAudio(t *testing.T) {
 		t.Fatalf("audio = %+v, want opus/48000/2", audio)
 	}
 
-	mediaConsumer, err := ann.Broadcast().SubscribeMedia(trackName, audio.Container, 10_000, nil)
+	mediaConsumer, err := ann.Broadcast().SubscribeMedia(trackName, audio.Container, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -564,7 +564,7 @@ func TestDynamicTrackRequestCanPublishMedia(t *testing.T) {
 	}
 	subscribe := make(chan subscribeResult, 1)
 	go func() {
-		media, err := consumer.SubscribeMedia("requested-audio", moq.LegacyContainer(), 10_000, nil)
+		media, err := consumer.SubscribeMedia("requested-audio", moq.LegacyContainer(), nil)
 		subscribe <- subscribeResult{media: media, err: err}
 	}()
 

--- a/go/wrapper/moq/subscribe.go
+++ b/go/wrapper/moq/subscribe.go
@@ -42,10 +42,11 @@ func (b *BroadcastConsumer) FetchGroup(name string, sequence uint64, options *Fe
 }
 
 // SubscribeMedia subscribes to a media track, decoded with the given container.
-// maxLatencyMs bounds buffering before a stalled group is skipped. subscription
-// tunes delivery priority, group ordering priority, and group range; pass nil for defaults.
-func (b *BroadcastConsumer) SubscribeMedia(name string, container Container, maxLatencyMs uint64, subscription *Subscription) (*MediaConsumer, error) {
-	inner, err := b.inner.SubscribeMedia(name, container, maxLatencyMs, subscription)
+// subscription tunes delivery priority, group ordering priority, group range, and
+// the latency budget; pass nil for defaults. Raise Subscription.LatencyMaxMs to
+// buffer instead of skipping a stalled group.
+func (b *BroadcastConsumer) SubscribeMedia(name string, container Container, subscription *Subscription) (*MediaConsumer, error) {
+	inner, err := b.inner.SubscribeMedia(name, container, subscription)
 	if err != nil {
 		return nil, err
 	}

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -183,7 +183,7 @@ test("a stalled consumer does not pin evicted groups", async () => {
 		setSystemTime(new Date(10_000));
 
 		const broadcast = new BroadcastProducer();
-		const producer = broadcast.createTrack("video", { cache: 1000 });
+		const producer = broadcast.createTrack("video", { latencyMax: 1000 });
 
 		// A subscriber that never reads. Its sink must not grow without bound.
 		const stalled = broadcast.track("video").subscribe();
@@ -212,11 +212,11 @@ test("a stalled consumer does not pin evicted groups", async () => {
 test("createTrack commits info up front", async () => {
 	const broadcast = new BroadcastProducer();
 
-	const producer = broadcast.createTrack("video", { cache: 2000, priority: 3 });
+	const producer = broadcast.createTrack("video", { latencyMax: 2000, priority: 3 });
 	expect(producer.name).toBe("video");
 
 	const info = await broadcast.track("video").info();
-	expect(info.cache).toBe(2000);
+	expect(info.latencyMax).toBe(2000);
 	expect(info.priority).toBe(3);
 });
 

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -438,7 +438,7 @@ export class Publisher {
 				ordered: info.ordered,
 				// Publisher Max Latency: the publisher's retention bound, advertised so
 				// relays re-serve with the same window.
-				cache: info.cache,
+				latencyMax: info.latencyMax,
 				// Lite05 mandates per-frame timestamps. Advertise the track's timescale;
 				// `#runGroup` emits each frame converted to it.
 				timescale: info.timescale,

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -446,7 +446,7 @@ export class Subscriber {
 			timescale: Time.Timescale(info.timescale),
 			// Publisher Max Latency rides on the wire, so the local retention window
 			// matches what the upstream advertises (relays re-serve with the same bound).
-			cache: info.cache,
+			latencyMax: info.latencyMax,
 			priority: info.priority,
 			ordered: info.ordered,
 		};

--- a/js/net/src/lite/track.test.ts
+++ b/js/net/src/lite/track.test.ts
@@ -31,14 +31,14 @@ test("TrackInfo round-trips on draft-05", async () => {
 	const info = new TrackInfo({
 		priority: 7,
 		ordered: false,
-		cache: 2000,
+		latencyMax: 2000,
 		timescale: 90000,
 	});
 	const reader = new Reader(undefined, await bytes((w) => info.encode(w, Version.DRAFT_05)));
 	const got = await TrackInfo.decode(reader, Version.DRAFT_05);
 	expect(got.priority).toBe(7);
 	expect(got.ordered).toBe(false);
-	expect(got.cache).toBe(2000);
+	expect(got.latencyMax).toBe(2000);
 	expect(got.timescale).toBe(90000);
 });
 

--- a/js/net/src/lite/track.ts
+++ b/js/net/src/lite/track.ts
@@ -68,7 +68,7 @@ export class TrackInfo {
 	 * Publisher Max Latency: an upper bound (milliseconds) on how long the publisher
 	 * caches a non-latest group past the arrival of a newer one.
 	 */
-	cache: number;
+	latencyMax: number;
 	/**
 	 * Per-frame timestamp scale (units per second). Mandatory on Lite05: a real
 	 * (non-zero) scale, and every frame on the wire is prefixed with a zigzag-delta
@@ -79,36 +79,36 @@ export class TrackInfo {
 	constructor({
 		priority = 0,
 		ordered = false,
-		cache = 0,
+		latencyMax = 0,
 		timescale = 0,
 	}: {
 		priority?: number;
 		ordered?: boolean;
-		cache?: number;
+		latencyMax?: number;
 		timescale?: number;
 	}) {
 		this.priority = priority;
 		this.ordered = ordered;
-		this.cache = cache;
+		this.latencyMax = latencyMax;
 		this.timescale = timescale;
 	}
 
 	async #encode(w: Writer) {
 		await w.u8(this.priority);
 		await w.bool(this.ordered);
-		await w.u53(this.cache);
+		await w.u53(this.latencyMax);
 		await w.u53(this.timescale);
 	}
 
 	static async #decode(r: Reader): Promise<TrackInfo> {
 		const priority = await r.u8();
 		const ordered = await r.bool();
-		const cache = await r.u53();
+		const latencyMax = await r.u53();
 		const timescale = await r.u53();
 		// Mandatory on Lite05: a zero scale is invalid (mirrors Rust's Timescale::new rejection),
 		// and would otherwise throw later when wrapped in Timescale().
 		if (timescale === 0) throw new Error("track timescale must be non-zero");
-		return new TrackInfo({ priority, ordered, cache, timescale });
+		return new TrackInfo({ priority, ordered, latencyMax, timescale });
 	}
 
 	async encode(w: Writer, version: Version): Promise<void> {

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -11,8 +11,8 @@ import { Timescale, type Timestamp } from "./time.ts";
 
 export type { Datagram } from "./datagram.ts";
 
-/** Default {@link Info.cache} window (milliseconds) when the publisher doesn't set one. */
-export const DEFAULT_CACHE_MS = 5000;
+/** Default {@link Info.latencyMax} window (milliseconds) when the publisher does not set one. */
+export const DEFAULT_LATENCY_MAX_MS = 5000;
 
 /**
  * How long (milliseconds) a datagram stays in the per-subscriber buffer before it is dropped.
@@ -48,10 +48,11 @@ export interface Info {
 	 */
 	timescale: Timescale;
 	/**
-	 * Publisher Max Latency: how long (milliseconds) old groups stay available before
-	 * eviction. Reported in TRACK_INFO (Lite05+) so relays re-serve with the same bound.
+	 * Publisher Max Latency: the maximum age (milliseconds) of a non-latest group before
+	 * the publisher evicts it. Reported in TRACK_INFO (Lite05+) so relays re-serve with the
+	 * same bound. The publisher-side half of the budget a subscriber sets for itself.
 	 */
-	cache: number;
+	latencyMax: number;
 	/** Tie-break priority between subscriptions of equal subscriber priority. */
 	priority: number;
 	/**
@@ -65,7 +66,7 @@ export interface Info {
 export function infoDefaults(info: Partial<Info> = {}): Info {
 	return {
 		timescale: info.timescale ?? Timescale.MILLI,
-		cache: info.cache ?? DEFAULT_CACHE_MS,
+		latencyMax: info.latencyMax ?? DEFAULT_LATENCY_MAX_MS,
 		priority: info.priority ?? 0,
 		ordered: info.ordered ?? false,
 	};
@@ -238,7 +239,7 @@ let makeSubscriber: (name: string, state: TrackState) => Subscriber;
  * subscription the publisher serves from it) gets an independent
  * {@link Subscriber} that receives a full copy of the groups, each with its own
  * read cursor. Groups are mirrored into every live subscriber and retained for the
- * track's `cache` window so a late subscriber replays the recent groups.
+ * track's `latencyMax` window so a late subscriber replays the recent groups.
  *
  * Obtained from {@link Request.accept} (the wire asks the application for a track to
  * serve) or constructed directly for an in-process track.
@@ -363,8 +364,8 @@ export class Producer {
 	// Evict cached groups that are closed and older than the cache window, dropping
 	// each evicted group's mirror from every sink so no consumer can pin it.
 	#prune(): void {
-		const cacheMs = this.#state.info.peek()?.cache ?? DEFAULT_CACHE_MS;
-		const cutoff = Date.now() - cacheMs;
+		const latencyMaxMs = this.#state.info.peek()?.latencyMax ?? DEFAULT_LATENCY_MAX_MS;
+		const cutoff = Date.now() - latencyMaxMs;
 
 		const retained: CachedGroup[] = [];
 		for (const entry of this.#cache) {

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -148,7 +148,7 @@ client = moq.Client(
 - **`BroadcastConsumer`**. Subscribe to tracks within a broadcast.
   - `await .subscribe_catalog() → CatalogConsumer`
   - `await .subscribe_track(name, subscription=None) → TrackConsumer`
-  - `await .subscribe_media(name, track, max_latency_ms=10000, subscription=None) → MediaConsumer`. `track` is the catalog record (e.g. `catalog.video[name]`); its container tells the decoder how to parse the bitstream.
+  - `await .subscribe_media(name, track, subscription=None) → MediaConsumer`. `track` is the catalog record (e.g. `catalog.video[name]`); its container tells the decoder how to parse the bitstream.
   - `await .catalog() → Catalog` (convenience)
 - **`CatalogConsumer`**. Async iterator of `Catalog`.
 - **`MediaConsumer`**. Async iterator of `Frame`.

--- a/py/moq-rs/moq/subscribe.py
+++ b/py/moq-rs/moq/subscribe.py
@@ -319,7 +319,6 @@ class BroadcastConsumer:
         self,
         name: str,
         track: Video | Audio | Container,
-        max_latency_ms: int = 10000,
         subscription: Subscription | None = None,
     ) -> MediaConsumer:
         """Subscribe to a media track, delivering frames in decode order.
@@ -328,11 +327,13 @@ class BroadcastConsumer:
         ``catalog.video[name]``), whose ``container`` describes how to parse the
         bitstream, or a :class:`Container` directly. Pass a bare container for the
         dynamic flow, where you subscribe before the catalog exists.
-        ``max_latency_ms`` bounds buffering before a stalled GoP is skipped.
-        ``subscription`` tunes delivery priority, group ordering priority, and group range; omit for defaults.
+        ``subscription`` tunes delivery priority, group ordering priority, group
+        range, and the latency budget; omit for defaults. Raise
+        :attr:`Subscription.latency_max_ms` to buffer instead of skipping a
+        stalled group.
         """
         container = track if isinstance(track, Container) else track.container
-        return MediaConsumer(await self._inner.subscribe_media(name, container, max_latency_ms, subscription))
+        return MediaConsumer(await self._inner.subscribe_media(name, container, subscription))
 
     async def subscribe_audio(
         self,

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -112,7 +112,7 @@ async def test_local_publish_consume_audio():
         assert audio.sample_rate == 48000
         assert audio.channel_count == 2
 
-        media_consumer = await announcement.broadcast.subscribe_media(track_name, audio, 10_000)
+        media_consumer = await announcement.broadcast.subscribe_media(track_name, audio)
 
         payload = b"opus audio payload data"
         media.write_frame(payload, 1_000_000)
@@ -146,7 +146,7 @@ async def test_video_publish_consume():
         assert video.coded.width == 1280
         assert video.coded.height == 720
 
-        media_consumer = await announcement.broadcast.subscribe_media(track_name, video, 10_000)
+        media_consumer = await announcement.broadcast.subscribe_media(track_name, video)
 
         keyframe = bytes([0x00, 0x00, 0x00, 0x01, 0x65, 0xAA, 0xBB, 0xCC])
         media.write_frame(keyframe, 0)
@@ -171,7 +171,7 @@ async def test_multiple_frames_ordering():
         catalog = await announcement.broadcast.catalog()
         track_name = list(catalog.audio.keys())[0]
         audio = catalog.audio[track_name]
-        media_consumer = await announcement.broadcast.subscribe_media(track_name, audio, 10_000)
+        media_consumer = await announcement.broadcast.subscribe_media(track_name, audio)
 
         timestamps = [0, 20_000, 40_000, 60_000, 80_000]
         for i, ts in enumerate(timestamps):
@@ -243,7 +243,7 @@ def test_publish_lifecycle():
 async def test_publish_track_info_and_subscription():
     """Raw track published with explicit TrackInfo, consumed with a Subscription."""
     broadcast = moq.BroadcastProducer()
-    info = moq.TrackInfo(priority=5, cache_ms=2_000)
+    info = moq.TrackInfo(priority=5, latency_max_ms=2_000)
     track = broadcast.publish_track("status", info)
 
     consumer = track.consume(moq.Subscription(priority=3))
@@ -345,7 +345,7 @@ async def test_dynamic_track_request_can_publish_media():
     # publish_media_on_track accepts the request (at the media timescale), which is what
     # unblocks subscribe_media, so run the subscribe concurrently until then.
     subscribe = asyncio.create_task(
-        consumer.subscribe_media("requested-audio", cast(moq.Container, moq.Container.LEGACY()), 10_000)
+        consumer.subscribe_media("requested-audio", cast(moq.Container, moq.Container.LEGACY()))
     )
 
     track = await asyncio.wait_for(dynamic.requested_track(), timeout=5.0)

--- a/py/moq-rs/tests/test_server.py
+++ b/py/moq-rs/tests/test_server.py
@@ -52,7 +52,7 @@ async def test_server_client_roundtrip():
                     track_name, audio = next(iter(catalog.audio.items()))
                     assert audio.codec == "opus"
 
-                    media_consumer = await announcement.broadcast.subscribe_media(track_name, audio, 10_000)
+                    media_consumer = await announcement.broadcast.subscribe_media(track_name, audio)
 
                     payload = b"hello over the wire"
                     media.write_frame(payload, 1_000_000)

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -131,10 +131,11 @@ pub struct moq_track_info {
 	/// Groups may always arrive out-of-order (or not at all) over the network.
 	pub ordered: bool,
 
-	/// How long the relay should cache past groups, in milliseconds.
-	pub cache_ms: u64,
-	/// Whether `cache_ms` should override the default cache setting.
-	pub cache_valid: bool,
+	/// Maximum age of a non-latest group before the publisher evicts it, in milliseconds.
+	/// The publisher-side half of `moq_subscription.latency_max_ms`.
+	pub latency_max_ms: u64,
+	/// Whether `latency_max_ms` should override the default.
+	pub latency_max_valid: bool,
 
 	/// Per-frame timescale in ticks per second.
 	pub timescale: u64,
@@ -152,8 +153,8 @@ impl TryFrom<&moq_track_info> for moq_net::track::Info {
 			.with_timescale(moq_net::Timescale::MICRO)
 			.with_priority(info.priority)
 			.with_ordered(info.ordered);
-		if info.cache_valid {
-			out = out.with_cache(std::time::Duration::from_millis(info.cache_ms));
+		if info.latency_max_valid {
+			out = out.with_latency_max(std::time::Duration::from_millis(info.latency_max_ms));
 		}
 		if info.timescale_valid {
 			out = out.with_timescale(moq_net::Timescale::new(info.timescale)?);
@@ -176,8 +177,9 @@ pub struct moq_subscription {
 	/// Groups may always arrive out-of-order (or not at all) over the network.
 	pub ordered: bool,
 
-	/// How long to wait for an older group once a newer group has arrived, in milliseconds.
-	pub stale_ms: u64,
+	/// Maximum age of a non-latest group before it is skipped, in milliseconds.
+	/// Zero skips immediately. Enforced by the publisher's cache and by any local buffering.
+	pub latency_max_ms: u64,
 
 	/// First group to deliver.
 	pub group_start: u64,
@@ -195,7 +197,7 @@ impl From<&moq_subscription> for moq_net::track::Subscription {
 		let mut out = moq_net::track::Subscription::default()
 			.with_priority(subscription.priority)
 			.with_ordered(subscription.ordered)
-			.with_stale(std::time::Duration::from_millis(subscription.stale_ms));
+			.with_latency_max(std::time::Duration::from_millis(subscription.latency_max_ms));
 		if subscription.group_start_valid {
 			out = out.with_group_start(subscription.group_start);
 		}

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -498,8 +498,8 @@ fn publish_track_invalid_broadcast() {
 	let info = moq_track_info {
 		priority: 1,
 		ordered: true,
-		cache_ms: 0,
-		cache_valid: false,
+		latency_max_ms: 0,
+		latency_max_valid: false,
 		timescale: 0,
 		timescale_valid: false,
 	};
@@ -513,7 +513,7 @@ fn publish_track_invalid_broadcast() {
 	let subscription = moq_subscription {
 		priority: 1,
 		ordered: true,
-		stale_ms: 0,
+		latency_max_ms: 0,
 		group_start: 0,
 		group_start_valid: false,
 		group_end: 0,
@@ -529,8 +529,8 @@ fn publish_track_with_info_rejects_invalid_timescale() {
 	let info = moq_track_info {
 		priority: 0,
 		ordered: false,
-		cache_ms: 0,
-		cache_valid: false,
+		latency_max_ms: 0,
+		latency_max_valid: false,
 		timescale: 0,
 		timescale_valid: true,
 	};
@@ -544,8 +544,8 @@ fn raw_track_options_preserve_ordering_priority() {
 	let mut info = moq_track_info {
 		priority: 0,
 		ordered: false,
-		cache_ms: 0,
-		cache_valid: false,
+		latency_max_ms: 0,
+		latency_max_valid: false,
 		timescale: 0,
 		timescale_valid: false,
 	};
@@ -557,7 +557,7 @@ fn raw_track_options_preserve_ordering_priority() {
 	let mut subscription = moq_subscription {
 		priority: 0,
 		ordered: false,
-		stale_ms: 0,
+		latency_max_ms: 0,
 		group_start: 0,
 		group_start_valid: false,
 		group_end: 0,
@@ -766,8 +766,8 @@ fn raw_track_subscription_options_and_update() {
 	let info = moq_track_info {
 		priority: 3,
 		ordered: false,
-		cache_ms: 1_000,
-		cache_valid: true,
+		latency_max_ms: 1_000,
+		latency_max_valid: true,
 		timescale: 1_000_000,
 		timescale_valid: true,
 	};
@@ -790,7 +790,7 @@ fn raw_track_subscription_options_and_update() {
 	let subscription = moq_subscription {
 		priority: 5,
 		ordered: true,
-		stale_ms: 25,
+		latency_max_ms: 25,
 		group_start: 1,
 		group_start_valid: true,
 		group_end: 1,

--- a/rs/moq-ffi/src/audio.rs
+++ b/rs/moq-ffi/src/audio.rs
@@ -89,11 +89,11 @@ pub struct MoqAudioDecoderOutput {
 	pub channels: Option<u32>,
 	/// Upper bound on buffering before skipping a stalled group, in
 	/// milliseconds. Same congestion-control knob as
-	/// [`MoqBroadcastConsumer::subscribe_media`](crate::consumer::MoqBroadcastConsumer::subscribe_media)'s
-	/// `max_latency_ms`: when a group stalls and a newer group is more
-	/// than this far ahead, the consumer skips. `None` keeps the
-	/// moq-mux default of zero (skip aggressively). Named `_max` to
-	/// leave room for a future `latency_min_ms` (jitter buffer).
+	/// [`MoqSubscription::latency_max_ms`](crate::consumer::MoqSubscription::latency_max_ms):
+	/// when a group stalls and a newer group is more than this far ahead,
+	/// the consumer skips. `None` keeps the moq-mux default of zero (skip
+	/// aggressively). Named `_max` to leave room for a future
+	/// `latency_min_ms` (jitter buffer).
 	pub latency_max_ms: Option<u64>,
 }
 

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -37,10 +37,13 @@ pub struct MoqSubscription {
 	/// aggregate is ordered only when every subscriber asks for it.
 	#[uniffi(default = false)]
 	pub ordered: bool,
-	/// How long to wait for an older group once a newer one has arrived before
-	/// skipping it, in milliseconds. `0` skips immediately.
+	/// Maximum age of a non-latest group before it is skipped, in milliseconds.
+	/// `0` skips immediately; a larger value tolerates that much reordering.
+	///
+	/// Enforced both by the publisher's cache (sent on the wire) and by any local
+	/// buffering, such as `subscribe_media`'s jitter buffer.
 	#[uniffi(default = 0)]
-	pub stale_ms: u64,
+	pub latency_max_ms: u64,
 	/// First group to deliver, or null to start at the latest group.
 	#[uniffi(default = None)]
 	pub group_start: Option<u64>,
@@ -68,7 +71,7 @@ impl From<MoqSubscription> for moq_net::track::Subscription {
 		moq_net::track::Subscription::default()
 			.with_priority(s.priority)
 			.with_ordered(s.ordered)
-			.with_stale(std::time::Duration::from_millis(s.stale_ms))
+			.with_latency_max(std::time::Duration::from_millis(s.latency_max_ms))
 			.with_group_start(s.group_start)
 			.with_group_end(s.group_end)
 	}
@@ -193,13 +196,14 @@ impl MoqBroadcastConsumer {
 	/// Subscribe to a track by name, delivering frames in decode order.
 	///
 	/// `container` is the track container from the catalog.
-	/// `max_latency_ms` controls the maximum buffering before skipping a GoP.
 	/// `subscription` tunes delivery priority, group ordering priority, and group range; omit for defaults.
+	///
+	/// [`MoqSubscription::latency_max_ms`] bounds the local jitter buffer as well as
+	/// the publisher's cache, so both ends skip a stalled group on the same budget.
 	pub async fn subscribe_media(
 		&self,
 		name: String,
 		container: Container,
-		max_latency_ms: u64,
 		subscription: Option<MoqSubscription>,
 	) -> Result<Arc<MoqMediaConsumer>, MoqError> {
 		// Parse the container before subscribing so we don't leave a dangling
@@ -208,9 +212,9 @@ impl MoqBroadcastConsumer {
 		let media: moq_mux::catalog::hang::Container = (&container)
 			.try_into()
 			.map_err(|e| MoqError::Codec(format!("invalid container: {e}")))?;
-		let subscription = subscription.map(moq_net::track::Subscription::from);
+		let subscription = subscription.map(moq_net::track::Subscription::from).unwrap_or_default();
+		let latency = subscription.latency_max;
 		let track = self.inner.track(&name)?.subscribe(subscription).await?;
-		let latency = std::time::Duration::from_millis(max_latency_ms);
 		let consumer = moq_mux::container::Consumer::new(track, media).with_latency(latency);
 		Ok(Arc::new(MoqMediaConsumer {
 			task: Task::new(Media { inner: consumer }),

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -10,7 +10,7 @@ use crate::media::MoqInit;
 /// Publisher-side track properties, mirroring [`moq_net::track::Info`].
 ///
 /// Construct with the fields you care about; the rest use raw-track defaults
-/// (priority 0, unordered, default cache, microsecond timescale).
+/// (priority 0, unordered, default latency budget, microsecond timescale).
 #[derive(Clone, uniffi::Record)]
 pub struct MoqTrackInfo {
 	/// Priority, used only to break ties between subscriptions of equal subscriber priority.
@@ -20,9 +20,11 @@ pub struct MoqTrackInfo {
 	/// out-of-order (or not at all) over the network. Defaults to false.
 	#[uniffi(default = false)]
 	pub ordered: bool,
-	/// How long the relay should cache past groups, in milliseconds. Null uses the default.
+	/// Maximum age of a non-latest group before the publisher evicts it, in
+	/// milliseconds. Null uses the default. This is the publisher-side half of
+	/// [`MoqSubscription::latency_max_ms`](crate::consumer::MoqSubscription::latency_max_ms).
 	#[uniffi(default = None)]
-	pub cache_ms: Option<u64>,
+	pub latency_max_ms: Option<u64>,
 	/// Per-frame timescale in ticks per second. Null uses microseconds.
 	#[uniffi(default = None)]
 	pub timescale: Option<u64>,
@@ -36,8 +38,8 @@ impl TryFrom<MoqTrackInfo> for moq_net::track::Info {
 			.with_timescale(moq_net::Timescale::MICRO)
 			.with_priority(info.priority)
 			.with_ordered(info.ordered);
-		if let Some(ms) = info.cache_ms {
-			out = out.with_cache(std::time::Duration::from_millis(ms));
+		if let Some(ms) = info.latency_max_ms {
+			out = out.with_latency_max(std::time::Duration::from_millis(ms));
 		}
 		if let Some(ticks) = info.timescale {
 			let scale =
@@ -58,12 +60,12 @@ impl TryFrom<&moq_net::track::Info> for MoqTrackInfo {
 	type Error = MoqError;
 
 	fn try_from(info: &moq_net::track::Info) -> Result<Self, MoqError> {
-		let cache_ms = u64::try_from(info.cache.as_millis())
-			.map_err(|_| MoqError::Codec("track cache duration overflow".into()))?;
+		let latency_max_ms = u64::try_from(info.latency_max.as_millis())
+			.map_err(|_| MoqError::Codec("track latency_max duration overflow".into()))?;
 		Ok(Self {
 			priority: info.priority,
 			ordered: info.ordered,
-			cache_ms: Some(cache_ms),
+			latency_max_ms: Some(latency_max_ms),
 			timescale: Some(info.timescale.as_u64()),
 		})
 	}
@@ -401,7 +403,7 @@ impl MoqBroadcastProducer {
 	///
 	/// Same pattern as moq-boy's `status` and `command` tracks: raw UTF-8/JSON
 	/// bytes written directly to moq-lite groups with no media framing. `info` sets
-	/// track properties (priority, cache, timescale); omit for defaults.
+	/// track properties (priority, latency_max, timescale); omit for defaults.
 	pub fn publish_track(&self, name: String, info: Option<MoqTrackInfo>) -> Result<Arc<MoqTrackProducer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.state.lock().unwrap();

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -101,7 +101,7 @@ async fn raw_track_datagram_roundtrip() {
 			Some(MoqTrackInfo {
 				priority: 0,
 				ordered: true,
-				cache_ms: None,
+				latency_max_ms: None,
 				timescale: Some(1_000_000),
 			}),
 		)
@@ -127,7 +127,7 @@ async fn raw_track_info_reports_publisher_properties() {
 	let info = MoqTrackInfo {
 		priority: 7,
 		ordered: false,
-		cache_ms: Some(2_500),
+		latency_max_ms: Some(2_500),
 		timescale: Some(90_000),
 	};
 	let track = broadcast.publish_track("status".into(), Some(info)).unwrap();
@@ -136,7 +136,7 @@ async fn raw_track_info_reports_publisher_properties() {
 	let got = consumer.info().await.unwrap();
 	assert_eq!(got.priority, 7);
 	assert!(!got.ordered);
-	assert_eq!(got.cache_ms, Some(2_500));
+	assert_eq!(got.latency_max_ms, Some(2_500));
 	assert_eq!(got.timescale, Some(90_000));
 }
 
@@ -163,7 +163,7 @@ async fn raw_track_update_does_not_wait_for_pending_read() {
 	consumer.update(MoqSubscription {
 		priority: 10,
 		ordered: false,
-		stale_ms: 25,
+		latency_max_ms: 25,
 		group_start: Some(0),
 		group_end: None,
 	});
@@ -529,7 +529,7 @@ async fn dynamic_track_request_can_publish_media() {
 		let consumer = consumer.clone();
 		tokio::spawn(async move {
 			consumer
-				.subscribe_media("requested-audio".into(), crate::media::Container::Legacy, 10_000, None)
+				.subscribe_media("requested-audio".into(), crate::media::Container::Legacy, None)
 				.await
 		})
 	};
@@ -685,7 +685,7 @@ async fn local_publish_consume_audio() {
 	assert!(catalog.video.is_empty());
 
 	let media_consumer = broadcast_consumer
-		.subscribe_media(track_name.clone(), audio.container.clone(), 10_000, None)
+		.subscribe_media(track_name.clone(), audio.container.clone(), None)
 		.await
 		.unwrap();
 
@@ -741,7 +741,7 @@ async fn video_publish_consume() {
 	assert!(catalog.audio.is_empty());
 
 	let media_consumer = broadcast_consumer
-		.subscribe_media(track_name.clone(), video.container.clone(), 10_000, None)
+		.subscribe_media(track_name.clone(), video.container.clone(), None)
 		.await
 		.unwrap();
 
@@ -784,7 +784,7 @@ async fn multiple_frames_ordering() {
 
 	let (track_name, audio) = catalog.audio.iter().next().unwrap();
 	let media_consumer = broadcast_consumer
-		.subscribe_media(track_name.clone(), audio.container.clone(), 10_000, None)
+		.subscribe_media(track_name.clone(), audio.container.clone(), None)
 		.await
 		.unwrap();
 
@@ -1048,7 +1048,7 @@ async fn server_client_roundtrip() {
 		.expect("expected a catalog");
 	let (track_name, audio) = catalog.audio.iter().next().unwrap();
 	let media_consumer = bc
-		.subscribe_media(track_name.clone(), audio.container.clone(), 10_000, None)
+		.subscribe_media(track_name.clone(), audio.container.clone(), None)
 		.await
 		.unwrap();
 

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -462,7 +462,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			.encode(&lite::TrackInfo {
 				priority: info.priority,
 				ordered: info.ordered,
-				cache: info.cache,
+				latency_max: info.latency_max,
 				timescale: info.timescale,
 			})
 			.await?;
@@ -536,7 +536,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let subscription = crate::track::Subscription {
 			priority: subscribe.priority,
 			ordered: subscribe.ordered,
-			stale: subscribe.max_latency,
+			latency_max: subscribe.max_latency,
 			group_start: subscribe.start_group,
 			group_end: subscribe.end_group,
 		};
@@ -989,7 +989,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 					let _ = track.update(crate::track::Subscription {
 						priority: upd.priority,
 						ordered: upd.ordered,
-						stale: upd.max_latency,
+						latency_max: upd.max_latency,
 						group_start: upd.start_group,
 						group_end: upd.end_group,
 						..Default::default()

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1032,7 +1032,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		// `Request::accept`, which stamps the track's real broadcast.
 		let model = track::Info::default()
 			.with_timescale(info.timescale)
-			.with_cache(info.cache)
+			.with_latency_max(info.latency_max)
 			.with_priority(info.priority)
 			.with_ordered(info.ordered);
 		Ok(model)
@@ -1071,7 +1071,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 					active.paused = false;
 					active.priority = subscription.priority;
 					active.ordered = subscription.ordered;
-					active.max_latency = subscription.stale;
+					active.max_latency = subscription.latency_max;
 					active.start_group = subscription.group_start;
 					self.send_update(active, subscription.group_end).await?;
 					tracing::info!(track = %self.name, "subscribe resumed");
@@ -1081,7 +1081,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 					// SUBSCRIBE_UPDATE (Lite03+ only; older peers can't carry one).
 					active.priority = subscription.priority;
 					active.ordered = subscription.ordered;
-					active.max_latency = subscription.stale;
+					active.max_latency = subscription.latency_max;
 					active.start_group = subscription.group_start;
 					if supports_linger {
 						self.send_update(active, subscription.group_end).await?;
@@ -1135,7 +1135,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			track: self.name.as_str().into(),
 			priority: subscription.priority,
 			ordered: subscription.ordered,
-			max_latency: subscription.stale,
+			max_latency: subscription.latency_max,
 			start_group: subscription.group_start,
 			end_group: subscription.group_end,
 		};
@@ -1196,7 +1196,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			id,
 			paused: false,
 			ordered: subscription.ordered,
-			max_latency: subscription.stale,
+			max_latency: subscription.latency_max,
 			start_group: subscription.group_start,
 			priority: subscription.priority,
 			_broadcast_sub: broadcast_sub,

--- a/rs/moq-net/src/lite/track.rs
+++ b/rs/moq-net/src/lite/track.rs
@@ -54,7 +54,7 @@ pub struct TrackInfo {
 	pub ordered: bool,
 	/// Publisher Max Latency: an upper bound on how long the publisher caches a
 	/// non-latest group past the arrival of a newer one. Encoded as milliseconds.
-	pub cache: Duration,
+	pub latency_max: Duration,
 	/// Per-frame timestamp scale (units per second). Mandatory on Lite05+: every track
 	/// is timed, so this is always a real scale on the wire (never zero).
 	pub timescale: Timescale,
@@ -68,13 +68,13 @@ impl Message for TrackInfo {
 
 		let priority = u8::decode(r, version)?;
 		let ordered = u8::decode(r, version)? != 0;
-		let cache = Duration::decode(r, version)?;
+		let latency_max = Duration::decode(r, version)?;
 		let timescale = Timescale::new(u64::decode(r, version)?).map_err(|_| DecodeError::InvalidValue)?;
 
 		Ok(Self {
 			priority,
 			ordered,
-			cache,
+			latency_max,
 			timescale,
 		})
 	}
@@ -86,7 +86,7 @@ impl Message for TrackInfo {
 
 		self.priority.encode(w, version)?;
 		(self.ordered as u8).encode(w, version)?;
-		self.cache.encode(w, version)?;
+		self.latency_max.encode(w, version)?;
 		u64::from(self.timescale).encode(w, version)?;
 		Ok(())
 	}
@@ -100,7 +100,7 @@ mod test {
 		TrackInfo {
 			priority: 7,
 			ordered: false,
-			cache: Duration::from_millis(2000),
+			latency_max: Duration::from_millis(2000),
 			timescale: Timescale::MICRO,
 		}
 	}
@@ -117,7 +117,7 @@ mod test {
 		let got = info_roundtrip(Version::Lite05, &info_sample());
 		assert_eq!(got.priority, 7);
 		assert!(!got.ordered);
-		assert_eq!(got.cache, Duration::from_millis(2000));
+		assert_eq!(got.latency_max, Duration::from_millis(2000));
 		assert_eq!(got.timescale, Timescale::MICRO);
 	}
 
@@ -134,7 +134,7 @@ mod test {
 		let info = TrackInfo {
 			priority: info.priority,
 			ordered: info.ordered,
-			cache: info.cache,
+			latency_max: info.latency_max,
 			timescale: info.timescale,
 		};
 		let mut buf = Vec::new();

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -198,7 +198,7 @@ impl Producer {
 	///
 	/// Returns a fresh name like `0{suffix}`, `1{suffix}`, etc. Use this when
 	/// you need to set non-default Track properties (e.g. `with_timescale`,
-	/// `with_cache`) before handing the Track to [`Self::create_track`].
+	/// `with_latency_max`) before handing the Track to [`Self::create_track`].
 	pub fn unique_name(&self, suffix: &str) -> String {
 		let state = self.state.read();
 		(0u16..)

--- a/rs/moq-net/src/model/subscription.rs
+++ b/rs/moq-net/src/model/subscription.rs
@@ -15,11 +15,14 @@ pub struct Subscription {
 	/// out-of-order (or not at all) over the network. Defaults to `false`; the
 	/// aggregate is ordered only when every live subscriber asks for it.
 	pub ordered: bool,
-	/// How long to wait for a group before skipping it once a newer group has
-	/// arrived. `Duration::ZERO` skips immediately (e.g. group 8 arriving means
-	/// group 7 is skipped); a larger value tolerates that much reordering before
-	/// giving up on the older group.
-	pub stale: Duration,
+	/// The maximum age of a non-latest group before it is skipped. `Duration::ZERO`
+	/// skips immediately (e.g. group 8 arriving means group 7 is skipped); a larger
+	/// value tolerates that much reordering before giving up on the older group.
+	///
+	/// This is the `Subscriber Max Latency` on the wire, enforced by the publisher's
+	/// cache. Receivers that buffer (e.g. a jitter buffer) enforce the same budget
+	/// locally, and a group is skipped once either measure exceeds it.
+	pub latency_max: Duration,
 	/// First group to deliver, or `None` to start at the latest group.
 	pub group_start: Option<u64>,
 	/// Last group to deliver (inclusive), or `None` for no end.
@@ -31,7 +34,7 @@ impl Default for Subscription {
 		Self {
 			priority: 0,
 			ordered: false,
-			stale: Duration::ZERO,
+			latency_max: Duration::ZERO,
 			group_start: None,
 			group_end: None,
 		}
@@ -52,9 +55,10 @@ impl Subscription {
 		self
 	}
 
-	/// Set how long to wait for a group before skipping it, returning `self` for chaining.
-	pub fn with_stale(mut self, stale: Duration) -> Self {
-		self.stale = stale;
+	/// Set the maximum age of a non-latest group before it is skipped, returning
+	/// `self` for chaining.
+	pub fn with_latency_max(mut self, latency_max: Duration) -> Self {
+		self.latency_max = latency_max;
 		self
 	}
 
@@ -82,7 +86,7 @@ impl Subscription {
 			priority: self.priority.max(combined.priority),
 			// Sequence-first prioritization is enabled only when every subscriber wants it.
 			ordered: self.ordered && combined.ordered,
-			stale: self.stale.max(combined.stale),
+			latency_max: self.latency_max.max(combined.latency_max),
 			group_start: min_some(self.group_start, combined.group_start),
 			group_end: max_unbounded(self.group_end, combined.group_end),
 		};

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -27,8 +27,8 @@ use std::{
 	time::Duration,
 };
 
-/// Default [`Info::cache`] age when the publisher doesn't set one.
-pub const DEFAULT_CACHE: Duration = Duration::from_secs(5);
+/// Default [`Info::latency_max`] age when the publisher doesn't set one.
+pub const DEFAULT_LATENCY_MAX: Duration = Duration::from_secs(5);
 
 /// How long a datagram stays in the per-track buffer before it is dropped.
 ///
@@ -55,12 +55,15 @@ pub struct Info {
 	/// timestamps at this scale on the wire. Protocols whose wire can't carry it
 	/// (pre-Lite05 moq-lite, IETF moq-transport) fall back to local monotonic milliseconds.
 	pub timescale: Timescale,
-	/// How long the publisher keeps old groups available before evicting them
-	/// (the newest group is always retained). A subscriber's
-	/// [`Subscription::stale`] window is clamped to this, since a group can't be
+	/// The maximum age of a non-latest group before the publisher evicts it (the
+	/// newest group is always retained). A subscriber's
+	/// [`Subscription::latency_max`] window is clamped to this, since a group can't be
 	/// waited for longer than it's kept around. Reported in TRACK_INFO so
-	/// relays re-serve with the same window. Defaults to [`DEFAULT_CACHE`].
-	pub cache: Duration,
+	/// relays re-serve with the same window. Defaults to [`DEFAULT_LATENCY_MAX`].
+	///
+	/// This is the `Publisher Max Latency` on the wire, the publisher-side half of
+	/// the same budget [`Subscription::latency_max`] sets for a subscriber.
+	pub latency_max: Duration,
 	/// The publisher's priority for this track, used only to break ties between
 	/// subscriptions of equal subscriber priority. Reported in TRACK_INFO (Lite05+).
 	pub priority: u8,
@@ -90,7 +93,7 @@ impl Default for Info {
 	fn default() -> Self {
 		Self {
 			timescale: Timescale::default(),
-			cache: DEFAULT_CACHE,
+			latency_max: DEFAULT_LATENCY_MAX,
 			priority: 0,
 			ordered: false,
 			broadcast: default_broadcast(),
@@ -108,9 +111,9 @@ impl Info {
 		self
 	}
 
-	/// Set how long old groups stay available before eviction, returning `self` for chaining.
-	pub fn with_cache(mut self, cache: Duration) -> Self {
-		self.cache = cache;
+	/// Set the maximum age of a non-latest group before eviction, returning `self` for chaining.
+	pub fn with_latency_max(mut self, latency_max: Duration) -> Self {
+		self.latency_max = latency_max;
 		self
 	}
 
@@ -128,11 +131,11 @@ impl Info {
 		self
 	}
 
-	/// Clamp a subscriber's stale window to this track's [`Self::cache`]: a
+	/// Clamp a subscriber's latency budget to this track's [`Self::latency_max`]: a
 	/// subscriber can't wait for a late group longer than the publisher keeps it.
 	/// `Duration::ZERO` (skip immediately) is left untouched by the `min`.
-	fn clamp_stale(&self, stale: Duration) -> Duration {
-		stale.min(self.cache)
+	fn clamp_latency_max(&self, latency_max: Duration) -> Duration {
+		latency_max.min(self.latency_max)
 	}
 }
 
@@ -622,12 +625,12 @@ impl TrackState {
 				.unwrap_or(Err(Error::Duplicate));
 		}
 
-		let cache = info.cache;
+		let latency_max = info.latency_max;
 		let group = group::Producer::new(group::Info { sequence }, info);
 		self.max_sequence = Some(self.max_sequence.unwrap_or(0).max(sequence));
 		self.groups.push_back(Some((group.clone(), now)));
 		self.pin_latest(&group);
-		self.evict_expired(now, cache);
+		self.evict_expired(now, latency_max);
 		Ok(group)
 	}
 }
@@ -689,7 +692,7 @@ impl Producer {
 		}
 		let info = state.info.as_ref().unwrap();
 		let track = info.clone();
-		let cache = info.cache;
+		let latency_max = info.latency_max;
 		let now = web_async::time::Instant::now();
 
 		if !state.duplicates.insert(group.sequence) {
@@ -703,7 +706,7 @@ impl Producer {
 		state.max_sequence = Some(state.max_sequence.unwrap_or(0).max(group.sequence));
 		state.groups.push_back(Some((group.clone(), now)));
 		state.pin_latest(&group);
-		state.evict_expired(now, cache);
+		state.evict_expired(now, latency_max);
 
 		Ok(group)
 	}
@@ -723,7 +726,7 @@ impl Producer {
 
 		let info = state.info.as_ref().unwrap();
 		let track = info.clone();
-		let cache = info.cache;
+		let latency_max = info.latency_max;
 
 		let group = group::Producer::new(group::Info { sequence }, track);
 
@@ -732,7 +735,7 @@ impl Producer {
 		state.max_sequence = Some(sequence);
 		state.groups.push_back(Some((group.clone(), now)));
 		state.pin_latest(&group);
-		state.evict_expired(now, cache);
+		state.evict_expired(now, latency_max);
 
 		Ok(group)
 	}
@@ -941,7 +944,7 @@ impl Producer {
 	/// Subscribing to this in-process track, resolving synchronously.
 	///
 	/// The info is fixed at creation, so there's nothing to wait for (no
-	/// SUBSCRIBE_OK round trip). The subscriber's stale window is clamped to the
+	/// SUBSCRIBE_OK round trip). The subscriber's latency budget is clamped to the
 	/// track's cache. Pass `None` for [`Subscription::default`].
 	pub fn subscribe(&self, subscription: impl Into<Option<Subscription>>) -> Subscriber {
 		let mut preferences = subscription.into().unwrap_or_default();
@@ -957,7 +960,7 @@ impl Producer {
 			.as_ref()
 			.expect("producer always has info")
 			.clone();
-		preferences.stale = info.clamp_stale(preferences.stale);
+		preferences.latency_max = info.clamp_latency_max(preferences.latency_max);
 		let subscription = kio::Producer::new(preferences);
 		register_subscription(self.state.read(), &subscription);
 
@@ -1825,11 +1828,11 @@ impl Subscriber {
 	}
 
 	///
-	/// The stale window is clamped to the track's cache, like the initial subscribe.
+	/// The latency budget is clamped to the track's cache, like the initial subscribe.
 	/// Returns [`Error::Closed`] if the track already ended; the update is
 	/// meaningless at that point and can usually be ignored.
 	pub fn update(&mut self, mut subscription: Subscription) -> Result<()> {
-		subscription.stale = self.info.clamp_stale(subscription.stale);
+		subscription.latency_max = self.info.clamp_latency_max(subscription.latency_max);
 		let mut state = self.subscription.write().map_err(|_| Error::Closed)?;
 		*state = subscription;
 		Ok(())
@@ -2258,7 +2261,7 @@ mod test {
 		}
 
 		// Advance time past the eviction threshold.
-		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
 
 		// Append a new group to trigger eviction.
 		producer.append_group().unwrap(); // seq 3
@@ -2285,7 +2288,7 @@ mod test {
 		producer.append_group().unwrap(); // seq 0
 
 		// Advance time past threshold.
-		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
 
 		// Append another group; seq 0 is expired and evicted.
 		producer.append_group().unwrap(); // seq 1
@@ -2323,7 +2326,7 @@ mod test {
 
 		let mut consumer = producer.subscribe(None);
 
-		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
 		producer.append_group().unwrap(); // seq 1
 
 		// Group 0 was evicted. Consumer should get group 1.
@@ -2336,10 +2339,10 @@ mod test {
 		tokio::time::pause();
 
 		// A shorter cache evicts sooner than the default.
-		let mut producer = track_producer("test", Info::default().with_cache(Duration::from_secs(1)));
+		let mut producer = track_producer("test", Info::default().with_latency_max(Duration::from_secs(1)));
 		producer.append_group().unwrap(); // seq 0
 
-		// Past the custom cache but well within DEFAULT_CACHE.
+		// Past the custom budget but well within DEFAULT_LATENCY_MAX.
 		tokio::time::advance(Duration::from_secs(2)).await;
 		producer.append_group().unwrap(); // seq 1
 
@@ -2350,24 +2353,24 @@ mod test {
 	}
 
 	#[test]
-	fn stale_clamped_to_cache() {
-		let producer = track_producer("test", Info::default().with_cache(Duration::from_secs(2)));
+	fn latency_max_clamped_to_cache() {
+		let producer = track_producer("test", Info::default().with_latency_max(Duration::from_secs(2)));
 
-		// A stale window beyond the cache is capped to the cache; a group can't be
+		// A latency budget beyond the cache is capped to the cache; a group can't be
 		// waited for longer than the publisher keeps it.
-		let mut subscriber = producer.subscribe(Subscription::default().with_stale(Duration::from_secs(10)));
-		assert_eq!(subscriber.subscription().stale, Duration::from_secs(2));
+		let mut subscriber = producer.subscribe(Subscription::default().with_latency_max(Duration::from_secs(10)));
+		assert_eq!(subscriber.subscription().latency_max, Duration::from_secs(2));
 
-		// A window within the cache is left alone, and ZERO (skip immediately) stays ZERO.
+		// A budget within the cache is left alone, and ZERO (skip immediately) stays ZERO.
 		subscriber
-			.update(Subscription::default().with_stale(Duration::from_millis(500)))
+			.update(Subscription::default().with_latency_max(Duration::from_millis(500)))
 			.unwrap();
-		assert_eq!(subscriber.subscription().stale, Duration::from_millis(500));
+		assert_eq!(subscriber.subscription().latency_max, Duration::from_millis(500));
 
 		subscriber
-			.update(Subscription::default().with_stale(Duration::ZERO))
+			.update(Subscription::default().with_latency_max(Duration::ZERO))
 			.unwrap();
-		assert_eq!(subscriber.subscription().stale, Duration::ZERO);
+		assert_eq!(subscriber.subscription().latency_max, Duration::ZERO);
 	}
 
 	#[test]
@@ -2406,7 +2409,7 @@ mod test {
 		}
 
 		// Expire all three groups.
-		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
 
 		// Append seq 6 (becomes new max_sequence).
 		producer.append_group().unwrap(); // seq 6
@@ -2433,7 +2436,7 @@ mod test {
 		// Arrive: seq 5, then seq 3.
 		producer.create_group(group::Info { sequence: 5 }).unwrap();
 
-		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
 
 		// Seq 3 arrives late; max_sequence is still 5 (at front).
 		producer.create_group(group::Info { sequence: 3 }).unwrap();
@@ -2447,7 +2450,7 @@ mod test {
 		}
 
 		// Expire seq 3 as well.
-		tokio::time::advance(DEFAULT_CACHE + Duration::from_secs(1)).await;
+		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
 
 		// Seq 2 arrives late, triggering eviction.
 		producer.create_group(group::Info { sequence: 2 }).unwrap();

--- a/swift/Sources/Moq/AsyncStream.swift
+++ b/swift/Sources/Moq/AsyncStream.swift
@@ -5,7 +5,7 @@ import MoqFFI
 ///
 /// Pull-per-demand: `next` is called only when the consumer asks for the next
 /// element, never ahead of it. This is what preserves the FFI jitter buffer's
-/// fall-behind skipping (`maxLatencyMs` GoP-skipping): draining eagerly would
+/// fall-behind skipping (`latencyMaxMs` GoP-skipping): draining eagerly would
 /// move the backlog into an unbounded Swift buffer, so a slow consumer would
 /// grow memory and receive stale groups instead of skipping forward.
 ///

--- a/swift/Sources/Moq/Broadcast.swift
+++ b/swift/Sources/Moq/Broadcast.swift
@@ -32,17 +32,17 @@ public final class BroadcastConsumer: Sendable {
     }
 
     /// Subscribe to a media track, delivering frames in decode order. `container`
-    /// comes from the catalog; `maxLatencyMs` bounds buffering before skipping a GoP.
-    /// `subscription` tunes delivery priority, group ordering priority, and group range; omit for defaults.
+    /// comes from the catalog. `subscription` tunes delivery priority, group ordering
+    /// priority, group range, and the latency budget; omit for defaults. Raise
+    /// `Subscription.latencyMaxMs` to buffer instead of skipping a stalled group.
     public func subscribeMedia(
         name: String,
         container: Container,
-        maxLatencyMs: UInt64,
         subscription: Subscription? = nil
     ) async throws -> MediaConsumer {
         MediaConsumer(
             try await ffi.subscribeMedia(
-                name: name, container: container, maxLatencyMs: maxLatencyMs, subscription: subscription))
+                name: name, container: container, subscription: subscription))
     }
 
     /// Subscribe to a raw-audio track, decoding to PCM in the layout `output`

--- a/test/smoke/clients/python/smoke.py
+++ b/test/smoke/clients/python/smoke.py
@@ -16,7 +16,7 @@ import sys
 import moq
 
 READ_CHUNK = 64 * 1024
-MAX_LATENCY_MS = 1_000  # subscribe_media congestion-control / lookahead window
+LATENCY_MAX_MS = 1_000  # subscribe_media congestion-control / lookahead window
 
 
 async def publish(url: str, broadcast: str) -> None:
@@ -62,7 +62,9 @@ async def subscribe(url: str, broadcast: str, timeout: float) -> None:
         track_name = next(iter(catalog.video))
         video = catalog.video[track_name]
 
-        media = await consumer.subscribe_media(track_name, video.container, MAX_LATENCY_MS)
+        media = await consumer.subscribe_media(
+            track_name, video.container, moq.Subscription(latency_max_ms=LATENCY_MAX_MS)
+        )
 
         total = 0
 


### PR DESCRIPTION
## Summary

Closes #2164.

The subscriber budget and the publisher's retention window were the same maximum latency under three names: `Subscription::stale`, `track::Info::cache`, and `subscribe_media`'s `max_latency_ms`. Nothing tied them together, so they could disagree.

**They did disagree.** `subscribe_media` buffered 10s locally while sending `stale = 0`, which tells the publisher to expire any non-latest group the moment a newer one exists. Per moq-lite a group's effective lifetime is the *minimum* of the two, so the sender won and the 10s jitter buffer could never do what it advertised. Unifying the vocabulary fixes it.

This supersedes the original approach on this PR (a `MoqMediaConfig` record holding `max_latency_ms`); a third name for one budget was the wrong shape.

## Changes

- **`rs/moq-net`**: `Subscription::stale` -> `latency_max` (the wire's `Subscriber Max Latency`); `track::Info::cache` -> `latency_max` (the wire's `Publisher Max Latency`), `DEFAULT_CACHE` -> `DEFAULT_LATENCY_MAX`. Wire encoding unchanged.
- **`rs/moq-ffi`**: `MoqSubscription::stale_ms` -> `latency_max_ms`, `MoqTrackInfo::cache_ms` -> `latency_max_ms`. `subscribe_media(name, container, subscription)` derives its jitter buffer from the subscription, so one value drives both ends. No `MoqMediaConfig`, and no positional latency knob (what #2164 asked for).
- **`rs/libmoq`**: `moq_subscription.stale_ms` -> `latency_max_ms`; `moq_track_info.cache_ms`/`cache_valid` -> `latency_max_ms`/`latency_max_valid`. `cpp/obs` uses neither.
- **`js/net`**: `Info.cache` -> `latencyMax`, `DEFAULT_CACHE_MS` -> `DEFAULT_LATENCY_MAX_MS` (+ `demo/web`).
- **Wrappers** (py/swift/kt/go): the flat `max_latency_ms` / `maxLatencyMs` parameter is gone; callers set `Subscription.latency_max_ms`. Keeping both would be two ways to set one value.
- **Docs / tests**: `doc/lib/c`, `py/moq-rs/README.md`, and the smoke client, which now demonstrates the new path.

## Naming

`stale` and `cache` were the outliers. The wire (`Subscriber`/`Publisher Max Latency`), the draft, `js/net` (`maxLatency`), `moq-audio` (`latency_max`), and `MoqAudioDecoderOutput` (`latency_max_ms`) already agreed. `cache` was also ambiguous against `moq_net::cache::Pool`, an unrelated *byte* budget. `_max` leaves room for a future `latency_min` (jitter buffer), matching the existing convention.

## Defaults

Unchanged: `0` for a subscription (skip aggressively), 5s for a publisher. `subscribe_media`'s old 10s default is gone, so its default behavior does change.

## Why breaking (targets `dev`)

Renames public `moq-net` API, `js/net`'s `Info`, the generated moq-ffi bindings, and the libmoq C ABI.

## Test plan

- [x] `cargo test -p moq-net -p moq-ffi -p libmoq` (558 passed)
- [x] `cargo clippy --workspace --all-targets` clean (confirms no other crate used `Info::cache`)
- [x] `cargo fmt` + `RUSTDOCFLAGS=-D warnings cargo doc` clean (renamed doc links resolve)
- [x] `bun run check` clean across every js package (tsc caught the `demo/web` + `lite/subscriber` call sites)
- [ ] CI regenerates the py/swift/kt/go bindings and builds the wrappers

Full `just check` could not complete locally: a concurrent `cargo-hack --feature-powerset` from another worktree kept poisoning the shared Cargo target (`E0460` / spurious `E0599` in untouched code). Verified the affected crates, the js workspace, rustdoc, clippy, and fmt directly instead.

## Follow-ups (deliberately not here)

- `subscribe_media` feeds the *requested* `latency_max` to the local buffer while the wire value is clamped to the publisher's window. Harmless, but reading the clamped value back would make both ends strictly identical.
- The private `lite` module's wire structs now read `latency_max` (TRACK_INFO) next to `max_latency` (SUBSCRIBE). Both internal, worth unifying.
- `subscribe_audio` has no `subscription` parameter, so `MoqAudioDecoderOutput::latency_max_ms` has nothing to fold into.
- libmoq's separate `moq_consume_{video,audio}_ordered` per-codec `max_latency_ms` (#2152).