### PR TITLE
Add moq-ffi track info and update

### DIFF
--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -166,6 +166,28 @@ broadcast.Finish()
 
 If a producer is collected without `Finish()`, the underlying library logs a warning (`broadcast::Producer dropped without close()`) to help you spot the leak.
 
+## Raw Track Controls
+
+Raw track subscribers can query the publisher's track properties and change their own delivery preferences without resubscribing:
+
+```go
+subscription := moq.Subscription{Priority: 10, Ordered: true}
+track, err := broadcast.SubscribeTrack("events", &subscription)
+if err != nil {
+	log.Fatal(err)
+}
+
+info, err := track.Info(ctx)
+if err != nil {
+	log.Fatal(err)
+}
+if info.Timescale != nil {
+	fmt.Println("timescale", *info.Timescale)
+}
+
+track.Update(moq.Subscription{Priority: 20, Ordered: false})
+```
+
 ## Fetching raw groups
 
 Fetch retrieves one group by track name and group sequence without keeping a live subscription:

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -71,6 +71,17 @@ Moq.connect("https://relay.example.com").use { moq ->
 }
 ```
 
+Raw track subscribers can query the publisher's track properties and change their own delivery preferences without resubscribing:
+
+```kotlin
+val track = announcement.broadcast().subscribeTrack(
+    "events",
+    Subscription(priority = 10u.toUByte()),
+)
+val info = track.info()
+track.update(Subscription(priority = 20u.toUByte(), ordered = false))
+```
+
 ## Publish
 
 ```kotlin

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -114,13 +114,19 @@ track.write_frame(b'{"cmd": "ready"}')
 track.finish()
 
 # Subscribe
-track = await broadcast_consumer.subscribe_track("events")
+track = await broadcast_consumer.subscribe_track(
+    "events",
+    subscription=moq.Subscription(priority=10),
+)
+info = await track.info()
+track.update(moq.Subscription(priority=20, ordered=False))
 async for group in track:
     async for frame in group:
         print(frame)
 ```
 
 `write_frame` on a track creates a one-frame group by default. Use `append_group()` for multi-frame groups (e.g., a video GOP).
+`TrackConsumer.info()` returns the publisher's track properties (timescale, cache, priority, ordering), and `update()` changes this subscriber's delivery preferences without resubscribing.
 
 ### Fetching raw groups
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -81,6 +81,16 @@ for try await announcement in announced {
 }
 ```
 
+Raw track subscribers can query the publisher's track properties and change their own delivery preferences without resubscribing:
+
+```swift
+let track = try await announcement.broadcast.subscribeTrack(
+    name: "events",
+    subscription: Subscription(priority: 10))
+let info = try await track.info()
+track.update(subscription: Subscription(priority: 20, ordered: false))
+```
+
 ## Publish
 
 ```swift

--- a/go/wrapper/moq/subscribe.go
+++ b/go/wrapper/moq/subscribe.go
@@ -193,6 +193,16 @@ func (t *TrackConsumer) ReadFrame(ctx context.Context) ([]byte, error) {
 	return *res, nil
 }
 
+// Info returns the publisher-side track properties learned during subscription.
+func (t *TrackConsumer) Info(ctx context.Context) (TrackInfo, error) {
+	return runCancellable(ctx, nil, t.inner.Info)
+}
+
+// Update changes this subscriber's delivery preferences.
+func (t *TrackConsumer) Update(subscription Subscription) {
+	t.inner.Update(subscription)
+}
+
 // Groups ranges over groups in sequence order.
 func (t *TrackConsumer) Groups(ctx context.Context) iter.Seq2[*GroupConsumer, error] {
 	return streamSeq(ctx, t.NextGroup)

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -139,11 +139,14 @@ client = moq.Client(
 
 - **`BroadcastConsumer`**. Subscribe to tracks within a broadcast.
   - `await .subscribe_catalog() → CatalogConsumer`
-  - `await .subscribe_track(name) → TrackConsumer`
-  - `await .subscribe_media(name, track, max_latency_ms=10000) → MediaConsumer`. `track` is the catalog record (e.g. `catalog.video[name]`); its container tells the decoder how to parse the bitstream.
+  - `await .subscribe_track(name, subscription=None) → TrackConsumer`
+  - `await .subscribe_media(name, track, max_latency_ms=10000, subscription=None) → MediaConsumer`. `track` is the catalog record (e.g. `catalog.video[name]`); its container tells the decoder how to parse the bitstream.
   - `await .catalog() → Catalog` (convenience)
 - **`CatalogConsumer`**. Async iterator of `Catalog`.
 - **`MediaConsumer`**. Async iterator of `Frame`.
+- **`TrackConsumer`**. Async iterator of raw groups.
+  - `await .info() → TrackInfo`
+  - `.update(subscription)`. Change priority, ordering, staleness, or group range after subscribing.
 
 All consumers (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsumer`, `GroupConsumer`) are async context managers; exiting `async with` cancels the subscription.
 
@@ -163,6 +166,8 @@ All consumers (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsum
 - **`Frame`**. `.payload: bytes`, `.timestamp_us: int`, `.keyframe: bool`.
 - **`Audio`**. `.codec`, `.sample_rate`, `.channel_count`, `.bitrate`, `.description`.
 - **`Video`**. `.codec`, `.coded: Dimensions`, `.display_aspect`, `.bitrate`, `.framerate`, `.description`.
+- **`Subscription`**. Subscriber delivery preferences: priority, ordering, staleness, and optional group range.
+- **`TrackInfo`**. Publisher track properties: priority, ordering, cache window, and timescale.
 - **`Dimensions`**. `.width: int`, `.height: int`.
 - **`Container`**. The catalog container enum, carried on each `Video`/`Audio` record.
 

--- a/py/moq-rs/moq/subscribe.py
+++ b/py/moq-rs/moq/subscribe.py
@@ -20,6 +20,7 @@ from .types import (
     FetchGroupOptions,
     Frame,
     Subscription,
+    TrackInfo,
     Video,
 )
 
@@ -134,6 +135,14 @@ class TrackConsumer:
         status/command tracks). Returns `None` when the track ends.
         """
         return await self._inner.read_frame()
+
+    async def info(self) -> TrackInfo:
+        """Return the publisher-side track properties."""
+        return await self._inner.info()
+
+    def update(self, subscription: Subscription) -> None:
+        """Change this subscriber's delivery preferences."""
+        self._inner.update(subscription)
 
     def cancel(self) -> None:
         self._inner.cancel()

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -5,6 +5,7 @@ use bytes::Buf;
 use crate::error::MoqError;
 use crate::ffi::Task;
 use crate::media::*;
+use crate::producer::MoqTrackInfo;
 
 /// Subscriber-side delivery preferences, mirroring [`moq_net::Subscription`].
 ///
@@ -236,12 +237,18 @@ impl TrackInner {
 #[derive(uniffi::Object)]
 pub struct MoqTrackConsumer {
 	task: Task<TrackInner>,
+	control: moq_net::track::SubscriberControl,
+	info: moq_net::track::Info,
 }
 
 impl MoqTrackConsumer {
 	pub(crate) fn new(track: moq_net::track::Subscriber) -> Self {
+		let control = track.control();
+		let info = track.info().clone();
 		Self {
 			task: Task::new(TrackInner { track }),
+			control,
+			info,
 		}
 	}
 }
@@ -286,6 +293,16 @@ impl MoqTrackConsumer {
 	/// status/command tracks). Returns `None` when the track ends.
 	pub async fn read_frame(&self) -> Result<Option<Vec<u8>>, MoqError> {
 		self.task.run(|mut state| async move { state.read_frame().await }).await
+	}
+
+	/// Return the publisher-side track properties learned during subscription.
+	pub async fn info(&self) -> Result<MoqTrackInfo, MoqError> {
+		MoqTrackInfo::try_from(&self.info)
+	}
+
+	/// Change this subscriber's delivery preferences.
+	pub fn update(&self, subscription: MoqSubscription) {
+		self.control.update(subscription.into());
 	}
 
 	pub fn cancel(&self) {

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -48,6 +48,21 @@ impl TryFrom<MoqTrackInfo> for moq_net::track::Info {
 	}
 }
 
+impl TryFrom<&moq_net::track::Info> for MoqTrackInfo {
+	type Error = MoqError;
+
+	fn try_from(info: &moq_net::track::Info) -> Result<Self, MoqError> {
+		let cache_ms = u64::try_from(info.cache.as_millis())
+			.map_err(|_| MoqError::Codec("track cache duration overflow".into()))?;
+		Ok(Self {
+			priority: info.priority,
+			ordered: info.ordered,
+			cache_ms: Some(cache_ms),
+			timescale: Some(info.timescale.as_u64()),
+		})
+	}
+}
+
 // ---- UniFFI Objects ----
 
 pub(crate) struct BroadcastProducer {

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -3,6 +3,7 @@ use super::producer::*;
 use super::server::MoqServer;
 use super::session::MoqClient;
 use crate::consumer::MoqFetchGroupOptions;
+use crate::consumer::MoqSubscription;
 use crate::error::MoqError;
 use crate::media::MoqInit;
 
@@ -80,6 +81,56 @@ async fn raw_track_activity() {
 		.await
 		.expect("timed out waiting for raw track to become unused")
 		.unwrap();
+}
+
+#[tokio::test]
+async fn raw_track_info_reports_publisher_properties() {
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let info = MoqTrackInfo {
+		priority: 7,
+		ordered: false,
+		cache_ms: Some(2_500),
+		timescale: Some(90_000),
+	};
+	let track = broadcast.publish_track("status".into(), Some(info)).unwrap();
+	let consumer = track.consume(None).unwrap();
+
+	let got = consumer.info().await.unwrap();
+	assert_eq!(got.priority, 7);
+	assert!(!got.ordered);
+	assert_eq!(got.cache_ms, Some(2_500));
+	assert_eq!(got.timescale, Some(90_000));
+}
+
+#[tokio::test]
+async fn raw_track_update_does_not_wait_for_pending_read() {
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let track = broadcast.publish_track("status".into(), None).unwrap();
+	let consumer = track.consume(None).unwrap();
+
+	let read = {
+		let consumer = consumer.clone();
+		tokio::spawn(async move { consumer.read_frame().await })
+	};
+
+	consumer.update(MoqSubscription {
+		priority: 10,
+		ordered: false,
+		stale_ms: 25,
+		group_start: Some(0),
+		group_end: None,
+	});
+
+	let payload = b"updated subscription".to_vec();
+	track.write_frame(payload.clone()).unwrap();
+
+	let frame = tokio::time::timeout(TIMEOUT, read)
+		.await
+		.expect("timed out waiting for raw frame")
+		.expect("read task panicked")
+		.unwrap()
+		.expect("expected a frame");
+	assert_eq!(frame, payload);
 }
 
 #[tokio::test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1500,6 +1500,32 @@ pub struct Subscriber {
 	end_sequence: Option<u64>,
 }
 
+/// A cloneable handle to a subscriber's delivery preferences.
+///
+/// This updates the same subscription as the owning [`Subscriber`] without
+/// borrowing its read cursor, so callers can change priority, ordering, or
+/// group bounds while another task is waiting for groups.
+#[derive(Clone)]
+pub struct SubscriberControl {
+	subscription: kio::Producer<Subscription>,
+}
+
+impl SubscriberControl {
+	/// This subscriber's current preferences.
+	pub fn subscription(&self) -> Subscription {
+		self.subscription.read().clone()
+	}
+
+	/// Replace this subscriber's preferences, updating the producer's aggregate.
+	pub fn update(&self, subscription: Subscription) {
+		if let Ok(mut state) = self.subscription.write() {
+			*state = subscription;
+		} else {
+			panic!("subscription is closed");
+		}
+	}
+}
+
 impl Subscriber {
 	pub fn info(&self) -> &Info {
 		&self.info
@@ -1507,6 +1533,13 @@ impl Subscriber {
 
 	pub fn name(&self) -> &str {
 		&self.name
+	}
+
+	/// Create a handle for updating this subscriber's delivery preferences.
+	pub fn control(&self) -> SubscriberControl {
+		SubscriberControl {
+			subscription: self.subscription.clone(),
+		}
 	}
 
 	// A helper to automatically apply Dropped if the state is closed without an error.
@@ -1701,16 +1734,12 @@ impl Subscriber {
 
 	/// This subscriber's current preferences.
 	pub fn subscription(&self) -> Subscription {
-		self.subscription.read().clone()
+		self.control().subscription()
 	}
 
 	/// Replace this subscriber's preferences, updating the producer's aggregate.
 	pub fn update(&mut self, subscription: Subscription) {
-		if let Ok(mut state) = self.subscription.write() {
-			*state = subscription;
-		} else {
-			panic!("subscription is closed");
-		}
+		self.control().update(subscription);
 	}
 
 	/// Return the latest sequence number in the track.
@@ -2251,6 +2280,22 @@ mod test {
 
 		subscriber.update(Subscription::default().with_stale(Duration::ZERO));
 		assert_eq!(subscriber.subscription().stale, Duration::ZERO);
+	}
+
+	#[test]
+	fn subscriber_control_updates_while_read_future_is_pending() {
+		let producer = track_producer("test", None);
+		let mut subscriber = producer.subscribe(None);
+		let control = subscriber.control();
+
+		let mut recv = Box::pin(subscriber.recv_group());
+		assert!(recv.as_mut().now_or_never().is_none());
+
+		control.update(Subscription::default().with_priority(7).with_ordered(false));
+
+		let aggregate = producer.subscription().expect("expected an active subscription");
+		assert_eq!(aggregate.priority, 7);
+		assert!(!aggregate.ordered);
 	}
 
 	#[tokio::test]

--- a/swift/Sources/Moq/Track.swift
+++ b/swift/Sources/Moq/Track.swift
@@ -30,6 +30,16 @@ public final class TrackConsumer: AsyncSequence, Sendable {
         try await ffi.readFrame()
     }
 
+    /// The publisher-side properties learned during subscription.
+    public func info() async throws -> TrackInfo {
+        try await ffi.info()
+    }
+
+    /// Change this subscriber's delivery preferences.
+    public func update(subscription: Subscription) {
+        ffi.update(subscription: subscription)
+    }
+
     /// Cancel all current and future reads.
     public func cancel() {
         ffi.cancel()


### PR DESCRIPTION
## Summary

- Add a `SubscriberControl` handle in `moq-net` so subscription preferences can be updated without borrowing a subscriber's read cursor.
- Expose `MoqTrackConsumer.info()` and `MoqTrackConsumer.update(subscription)` through `moq-ffi`.
- Wire the new surface into the Python, Swift, and Go wrappers, with Kotlin receiving it through typealiases, and update the matching docs.

## Public API Changes

- New `moq_net::track::SubscriberControl` public type.
- New `moq_net::track::Subscriber::control()` method.
- New `MoqTrackConsumer.info() -> MoqTrackInfo` UniFFI method.
- New `MoqTrackConsumer.update(MoqSubscription)` UniFFI method.
- New wrapper methods:
  - Python `TrackConsumer.info()` / `TrackConsumer.update(...)`
  - Swift `TrackConsumer.info()` / `TrackConsumer.update(subscription:)`
  - Go `TrackConsumer.Info(ctx)` / `TrackConsumer.Update(...)`

These are additive. This PR targets `dev` because the required `moq-net` track info/subscription API is currently on `dev`.

## Tests

- `cargo test -p moq-ffi --target-dir /private/tmp/moq-target`
- `cargo test -p moq-net subscriber_control_updates_while_read_future_is_pending --target-dir /private/tmp/moq-target`
- `cargo fmt -p moq-ffi -p moq-net`
- `gofmt -w go/wrapper/moq/subscribe.go`
- `python3 -m py_compile py/moq-rs/moq/subscribe.py`
- `git diff --check`

Closes #2149

(Written by GPT-5)