### PR TITLE
moq-video: add NVDEC AV1 decode support

### DIFF
--- a/rs/moq-transcode/CHANGELOG.md
+++ b/rs/moq-transcode/CHANGELOG.md
@@ -18,3 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hardware, openh264 fallback). On an NVIDIA GPU the pipeline is zero-copy:
   NVDEC decodes and scales in hardware and NVENC encodes the CUDA frame in
   place; other decoders scale I420 on the CPU.
+- AV1 source renditions are eligible for transcoding when a native decoder is
+  available. On Linux with NVDEC, AV1 sources can feed existing H.264/H.265
+  output rungs.

--- a/rs/moq-transcode/CHANGELOG.md
+++ b/rs/moq-transcode/CHANGELOG.md
@@ -18,6 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hardware, openh264 fallback). On an NVIDIA GPU the pipeline is zero-copy:
   NVDEC decodes and scales in hardware and NVENC encodes the CUDA frame in
   place; other decoders scale I420 on the CPU.
-- AV1 source renditions are eligible for transcoding when a native decoder is
-  available. On Linux with NVDEC, AV1 sources can feed existing H.264/H.265
-  output rungs.
+- 8-bit 4:2:0 AV1 source renditions are eligible for transcoding when a native
+  decoder is available. On Linux with NVDEC, AV1 sources can feed existing
+  H.264/H.265 output rungs.

--- a/rs/moq-transcode/README.md
+++ b/rs/moq-transcode/README.md
@@ -19,9 +19,10 @@ Nothing is encoded until someone asks, Cloudflare-style just-in-time per rung:
 
 The codec work is [`moq-video`](../moq-video): hardware where available (NVDEC +
 NVENC on Linux, VideoToolbox on macOS, Media Foundation on Windows), openh264 as
-the H.264 software fallback. On an NVIDIA GPU the pipeline is fully GPU-resident:
-NVDEC decodes and scales in hardware and NVENC encodes the CUDA frame in place,
-with no CPU copies. Other decoders fall back to CPU scaling.
+the H.264 software fallback. H.264, H.265, and AV1 source renditions are eligible
+when a matching decoder is available. On an NVIDIA GPU the pipeline is fully
+GPU-resident: NVDEC decodes and scales in hardware and NVENC encodes the CUDA
+frame in place, with no CPU copies. Other decoders fall back to CPU scaling.
 
 ## Library
 

--- a/rs/moq-transcode/README.md
+++ b/rs/moq-transcode/README.md
@@ -19,10 +19,10 @@ Nothing is encoded until someone asks, Cloudflare-style just-in-time per rung:
 
 The codec work is [`moq-video`](../moq-video): hardware where available (NVDEC +
 NVENC on Linux, VideoToolbox on macOS, Media Foundation on Windows), openh264 as
-the H.264 software fallback. H.264, H.265, and AV1 source renditions are eligible
-when a matching decoder is available. On an NVIDIA GPU the pipeline is fully
-GPU-resident: NVDEC decodes and scales in hardware and NVENC encodes the CUDA
-frame in place, with no CPU copies. Other decoders fall back to CPU scaling.
+the H.264 software fallback. H.264, H.265, and 8-bit 4:2:0 AV1 source renditions
+are eligible when a matching decoder is available. On an NVIDIA GPU the pipeline
+is fully GPU-resident: NVDEC decodes and scales in hardware and NVENC encodes the
+CUDA frame in place, with no CPU copies. Other decoders fall back to CPU scaling.
 
 ## Library
 

--- a/rs/moq-transcode/src/catalog.rs
+++ b/rs/moq-transcode/src/catalog.rs
@@ -18,7 +18,7 @@ pub(crate) struct Resolved {
 }
 
 /// Pick the rendition to transcode from: the highest-resolution decodable
-/// (H.264/H.265) rendition local to the source broadcast.
+/// (H.264/H.265/AV1) rendition local to the source broadcast.
 pub(crate) fn choose_source(video: &Video) -> Result<(String, VideoConfig), Error> {
 	video
 		.renditions
@@ -26,7 +26,12 @@ pub(crate) fn choose_source(video: &Video) -> Result<(String, VideoConfig), Erro
 		// A rendition that itself lives in another broadcast can't be subscribed
 		// through this one; composing relative references is a follow-up.
 		.filter(|(_, config)| config.broadcast.is_none())
-		.filter(|(_, config)| matches!(config.codec, VideoCodec::H264(_) | VideoCodec::H265(_)))
+		.filter(|(_, config)| {
+			matches!(
+				config.codec,
+				VideoCodec::H264(_) | VideoCodec::H265(_) | VideoCodec::AV1(_)
+			)
+		})
 		.max_by_key(|(_, config)| (config.coded_height, config.coded_width, config.bitrate))
 		.map(|(name, config)| (name.clone(), config.clone()))
 		.ok_or(Error::NoSource)
@@ -294,5 +299,18 @@ mod tests {
 		let (name, config) = choose_source(&video).unwrap();
 		assert_eq!(name, "high");
 		assert_eq!(config.coded_height, Some(1080));
+	}
+
+	#[test]
+	fn chooses_av1_source() {
+		let mut video = Video::default();
+		let mut av1 = VideoConfig::new(hang::catalog::AV1::default());
+		av1.coded_width = Some(1920);
+		av1.coded_height = Some(1080);
+		video.insert("av1", av1).unwrap();
+
+		let (name, config) = choose_source(&video).unwrap();
+		assert_eq!(name, "av1");
+		assert!(matches!(config.codec, VideoCodec::AV1(_)));
 	}
 }

--- a/rs/moq-transcode/src/catalog.rs
+++ b/rs/moq-transcode/src/catalog.rs
@@ -1,7 +1,7 @@
 //! Derivative catalog construction: pick the source rendition, size the ladder
 //! against it, and fill the output catalog with rung + passthrough entries.
 
-use hang::catalog::{H264, Video, VideoCodec, VideoConfig};
+use hang::catalog::{AV1, H264, Video, VideoCodec, VideoConfig};
 use moq_net::PathRelativeOwned;
 
 use crate::{Error, Rung};
@@ -26,15 +26,22 @@ pub(crate) fn choose_source(video: &Video) -> Result<(String, VideoConfig), Erro
 		// A rendition that itself lives in another broadcast can't be subscribed
 		// through this one; composing relative references is a follow-up.
 		.filter(|(_, config)| config.broadcast.is_none())
-		.filter(|(_, config)| {
-			matches!(
-				config.codec,
-				VideoCodec::H264(_) | VideoCodec::H265(_) | VideoCodec::AV1(_)
-			)
-		})
+		.filter(|(_, config)| can_decode(config))
 		.max_by_key(|(_, config)| (config.coded_height, config.coded_width, config.bitrate))
 		.map(|(name, config)| (name.clone(), config.clone()))
 		.ok_or(Error::NoSource)
+}
+
+fn can_decode(config: &VideoConfig) -> bool {
+	match &config.codec {
+		VideoCodec::H264(_) | VideoCodec::H265(_) => true,
+		VideoCodec::AV1(av1) => is_supported_av1(av1),
+		_ => false,
+	}
+}
+
+fn is_supported_av1(av1: &AV1) -> bool {
+	av1.bitdepth == 8 && !av1.mono_chrome && av1.chroma_subsampling_x && av1.chroma_subsampling_y
 }
 
 /// Resolve the configured rungs against the source: derive geometry from the
@@ -312,5 +319,22 @@ mod tests {
 		let (name, config) = choose_source(&video).unwrap();
 		assert_eq!(name, "av1");
 		assert!(matches!(config.codec, VideoCodec::AV1(_)));
+	}
+
+	#[test]
+	fn skips_unsupported_av1_source() {
+		let mut video = Video::default();
+		let mut av1 = VideoConfig::new(hang::catalog::AV1 {
+			bitdepth: 10,
+			..hang::catalog::AV1::default()
+		});
+		av1.coded_width = Some(3840);
+		av1.coded_height = Some(2160);
+		video.insert("av1", av1).unwrap();
+		video.insert("h264", source(1920, 1080, None)).unwrap();
+
+		let (name, config) = choose_source(&video).unwrap();
+		assert_eq!(name, "h264");
+		assert!(matches!(config.codec, VideoCodec::H264(_)));
 	}
 }

--- a/rs/moq-transcode/src/error.rs
+++ b/rs/moq-transcode/src/error.rs
@@ -5,7 +5,7 @@
 #[non_exhaustive]
 pub enum Error {
 	/// The source catalog has no rendition the transcoder can decode: it needs
-	/// an H.264 or H.265 rendition local to the source broadcast.
+	/// an H.264, H.265, or AV1 rendition local to the source broadcast.
 	#[error("no transcodable video rendition in the source catalog")]
 	NoSource,
 

--- a/rs/moq-video/CHANGELOG.md
+++ b/rs/moq-video/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `encode::Encoder::encode(frame)` entry point; `decode::Config::resize` scales
   in the decoder for free. Like NVENC, everything is dlopen'd at runtime, so a
   driverless host falls back to the next decoder.
+- AV1 hardware decode on Linux via NVDEC for 8-bit 4:2:0 sources. AV1 is
+  decode-only and emits the same CUDA NV12 frame type as H.264/H.265, so it can
+  feed existing NVENC H.264/H.265 transcode output.
 - `decode::Frame` pixels are now private: `into_i420()` returns the packed
   I420 bytes (downloading a GPU frame), replacing the public `data` field, and
   each frame's `timestamp_us` now rides the decoder (correct across reordering)

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -52,19 +52,22 @@ GPU-less builder and still starts on a GPU-less machine.
 ## Decode
 
 `decode::Consumer` (the mirror of `moq-audio`'s `AudioConsumer`) subscribes to an
-H.264 or H.265 track and returns raw I420 frames. Backends are tried
+H.264, H.265, or AV1 track and returns raw I420 frames. Backends are tried
 hardware-first, like encode:
 
 | Codec | Software | macOS | Windows | Linux |
 |---|---|---|---|---|
-| H.264 | openh264 (vendored, static) | VideoToolbox | Media Foundation (DXVA) | openh264 |
-| H.265 | none | VideoToolbox | Media Foundation (DXVA) | none |
+| H.264 | openh264 (vendored, static) | VideoToolbox | Media Foundation (DXVA) | NVDEC (`nvdec`) |
+| H.265 | none | VideoToolbox | Media Foundation (DXVA) | NVDEC (`nvdec`) |
+| AV1 | none | none | none | NVDEC (`nvdec`) |
 
-On macOS VideoToolbox decodes both codecs on hardware, pulling the parameter sets
-(SPS/PPS, plus VPS for H.265) out of each keyframe to build the format
+On macOS VideoToolbox decodes H.264 and H.265 on hardware, pulling the parameter
+sets (SPS/PPS, plus VPS for H.265) out of each keyframe to build the format
 description. On Windows the Microsoft decoder MFT runs synchronously with a
 Direct3D11 device bound to it, so the decode happens on the GPU through DXVA
 (NVDEC / Intel / AMD). H.264 falls back to openh264 on a GPU-less host; H.265 has
 no software decoder, so it needs the GPU path (on Windows, an HEVC decoder MFT:
-the inbox HEVC Video Extensions or a vendor one). A non-H.264/H.265 rendition
+the inbox HEVC Video Extensions or a vendor one). On Linux, NVDEC decodes H.264,
+H.265, and 8-bit 4:2:0 AV1 to CUDA NV12 frames; AV1 is decode-only and is useful
+for AV1 source to H.264/H.265 transcode rungs. A non-H.264/H.265/AV1 rendition
 yields `Error::UnsupportedCodec`.

--- a/rs/moq-video/src/decode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/decode/backend/mediafoundation.rs
@@ -94,6 +94,11 @@ impl MediaFoundation {
 		let (input_subtype, label) = match codec {
 			Codec::H264 => (MFVideoFormat_H264, "H.264"),
 			Codec::H265 => (MFVideoFormat_HEVC, "H.265"),
+			Codec::Av1 => {
+				return Err(Error::Codec(anyhow::anyhow!(
+					"Media Foundation AV1 decode is not wired"
+				)));
+			}
 		};
 		let com = ComGuard::new()?;
 		let transform = enumerate_decoder(input_subtype)?;

--- a/rs/moq-video/src/decode/backend/mod.rs
+++ b/rs/moq-video/src/decode/backend/mod.rs
@@ -1,18 +1,17 @@
-//! Pluggable H.264 / H.265 decoder backends.
+//! Pluggable video decoder backends.
 //!
 //! The mirror of [`encode::backend`](crate::encode). [`Backend`] is the seam
-//! between the access-unit prep (length-prefixed -> Annex-B conversion + keyframe
-//! gating, owned by [`Decoder`](super::Decoder)) and the codec itself. Every
-//! backend takes one **Annex-B** access unit (parameter sets inline ahead of each
-//! keyframe: SPS/PPS for H.264, VPS/SPS/PPS for H.265) and returns zero or more
-//! [`Decoded`] pictures (a raw CPU or GPU frame plus its timestamp).
+//! between the access-unit prep (keyframe gating plus any codec-specific payload
+//! conversion, owned by [`Decoder`](super::Decoder)) and the codec itself. H.264
+//! / H.265 backends take Annex-B access units with parameter sets inline ahead
+//! of each keyframe; AV1 backends take OBU temporal units directly.
 //!
 //! [`open`] picks the best backend for a [`Codec`] and [`Config`], trying
 //! hardware candidates (platform-gated: VideoToolbox on macOS, Media Foundation
 //! / DXVA on Windows, NVDEC on Linux) before the openh264 software fallback,
 //! exactly like the encode side. Only backends that support the requested codec
-//! are considered: there is no software H.265 decoder, so an H.265 track has no
-//! fallback below the hardware path.
+//! are considered: there is no software H.265 or AV1 decoder, so those tracks
+//! have no fallback below the hardware path.
 
 use bytes::Bytes;
 use moq_net::Timestamp;
@@ -38,6 +37,7 @@ mod nvdec;
 pub(crate) enum Codec {
 	H264,
 	H265,
+	Av1,
 }
 
 impl Codec {
@@ -45,6 +45,7 @@ impl Codec {
 		match self {
 			Codec::H264 => "H.264",
 			Codec::H265 => "H.265",
+			Codec::Av1 => "AV1",
 		}
 	}
 }
@@ -60,13 +61,13 @@ pub(crate) struct Decoded {
 	pub frame: Frame,
 }
 
-/// An opened decoder. Feed it Annex-B access units in decode order; get back zero
-/// or more decoded frames (zero while the decoder is still buffering, e.g. before
-/// the first keyframe's parameter sets).
+/// An opened decoder. Feed it prepared access units in decode order; get back
+/// zero or more decoded frames (zero while the decoder is still buffering, e.g.
+/// before the first keyframe's parameter sets).
 pub(crate) trait Backend: Send {
-	/// Decode one Annex-B access unit stamped with its presentation `timestamp`.
-	/// `keyframe` marks a keyframe (parameter sets are inline ahead of it). Takes an
-	/// owned [`Bytes`] so a backend can split out NAL slices without copying.
+	/// Decode one access unit stamped with its presentation `timestamp`.
+	/// `keyframe` marks a random-access frame. Takes an owned [`Bytes`] so a
+	/// backend can split codec units without copying.
 	fn decode(&mut self, access_unit: Bytes, timestamp: Timestamp, keyframe: bool) -> Result<Vec<Decoded>, Error>;
 
 	/// The decoder name in use, e.g. `"videotoolbox"` (for logging).
@@ -95,13 +96,13 @@ const HARDWARE: &[Candidate] = &[
 	#[cfg(target_os = "windows")]
 	Candidate {
 		name: mediafoundation::NAME,
-		supports: |_| true,
+		supports: |c| matches!(c, Codec::H264 | Codec::H265),
 		open: mediafoundation::MediaFoundation::open,
 	},
 	#[cfg(all(target_os = "linux", feature = "nvdec"))]
 	Candidate {
 		name: nvdec::NAME,
-		supports: |c| matches!(c, Codec::H264 | Codec::H265),
+		supports: |c| matches!(c, Codec::H264 | Codec::H265 | Codec::Av1),
 		open: nvdec::Nvdec::open,
 	},
 ];

--- a/rs/moq-video/src/decode/backend/nvdec.rs
+++ b/rs/moq-video/src/decode/backend/nvdec.rs
@@ -1,11 +1,12 @@
-//! Hardware H.264 / H.265 decode via NVIDIA NVDEC (`moq-nvenc`'s cuvid table).
+//! Hardware H.264 / H.265 / AV1 decode via NVIDIA NVDEC (`moq-nvenc`'s cuvid table).
 //!
 //! Linux only, behind the default-on `nvdec` feature. Everything is dlopen'd at
 //! runtime (cudarc loads libcuda, the cuvid table loads libnvcuvid), so the
 //! binary links on a GPU-less builder and a driverless host falls back to the
 //! next decoder (see [`backend::open`](super::open)).
 //!
-//! Decoded frames come back as NV12 in CUDA device memory ([`Frame::Cuda`]).
+//! Decoded 8-bit 4:2:0 frames come back as NV12 in CUDA device memory
+//! ([`Frame::Cuda`]).
 //! Each mapped cuvid surface is copied device-to-device into an owned buffer
 //! (surfaces come from a small fixed pool, so holding them across calls would
 //! stall the decoder), which the NVENC encode backend then registers directly:
@@ -117,6 +118,7 @@ impl Nvdec {
 		let cuda_codec = match codec {
 			Codec::H264 => cudaVideoCodec::cudaVideoCodec_H264,
 			Codec::H265 => cudaVideoCodec::cudaVideoCodec_HEVC,
+			Codec::Av1 => cudaVideoCodec::cudaVideoCodec_AV1,
 		};
 
 		// `CudaContext::new` retains the device's primary context, the same one

--- a/rs/moq-video/src/decode/backend/openh264.rs
+++ b/rs/moq-video/src/decode/backend/openh264.rs
@@ -1,8 +1,8 @@
 //! Software H.264 decode backend via Cisco's openh264 (vendored, statically linked).
 //!
-//! The portable fallback when no hardware decoder is available, and the only
-//! backend on Linux/Windows for now. Accepts Annex-B access units (SPS/PPS
-//! inline ahead of each keyframe) and returns packed I420.
+//! The portable fallback when no hardware decoder is available. Accepts Annex-B
+//! H.264 access units (SPS/PPS inline ahead of each keyframe) and returns packed
+//! I420.
 
 use bytes::Bytes;
 use moq_net::Timestamp;
@@ -21,10 +21,15 @@ pub(crate) struct Openh264 {
 }
 
 impl Openh264 {
-	/// openh264 decodes H.264 only; the backend selector never routes another
-	/// codec here, so `codec` is accepted for signature parity and ignored, as is
-	/// `config` (no hardware scaler; callers scale the CPU frames themselves).
-	pub(crate) fn open(_codec: Codec, _config: &Config) -> Result<Box<dyn Backend>, Error> {
+	/// openh264 decodes H.264 only; `config` is accepted for signature parity
+	/// (no hardware scaler; callers scale the CPU frames themselves).
+	pub(crate) fn open(codec: Codec, _config: &Config) -> Result<Box<dyn Backend>, Error> {
+		if codec != Codec::H264 {
+			return Err(Error::Codec(anyhow::anyhow!(
+				"openh264 cannot decode {}",
+				codec.label()
+			)));
+		}
 		let decoder = Decoder::with_api_config(OpenH264API::from_source(), DecoderConfig::new())
 			.map_err(|e| Error::Codec(anyhow::anyhow!("openh264 decoder init: {e}")))?;
 

--- a/rs/moq-video/src/decode/backend/videotoolbox.rs
+++ b/rs/moq-video/src/decode/backend/videotoolbox.rs
@@ -88,6 +88,9 @@ impl VideoToolbox {
 	/// `config` is accepted for signature parity; VideoToolbox decodes at the
 	/// stream's native size (callers scale the frames themselves).
 	pub(crate) fn open(codec: Codec, _config: &Config) -> Result<Box<dyn Backend>, Error> {
+		if codec == Codec::Av1 {
+			return Err(Error::Codec(anyhow::anyhow!("VideoToolbox AV1 decode is not wired")));
+		}
 		tracing::info!(decoder = NAME, codec = ?codec, "opened video decoder");
 		Ok(Box::new(Self {
 			codec,
@@ -110,6 +113,7 @@ impl VideoToolbox {
 		match self.codec {
 			Codec::H264 => Some(vec![sps, pps]),
 			Codec::H265 => Some(vec![self.vps.clone()?, sps, pps]),
+			Codec::Av1 => None,
 		}
 	}
 
@@ -315,6 +319,9 @@ fn create_format_description(codec: Codec, params: &[Bytes]) -> Result<CFRetaine
 				NonNull::new(&mut format_ptr).unwrap(),
 			)
 		},
+		Codec::Av1 => {
+			return Err(Error::Codec(anyhow::anyhow!("VideoToolbox AV1 decode is not wired")));
+		}
 	};
 	NonNull::new(format_ptr as *mut CMFormatDescription)
 		.filter(|_| status == 0)
@@ -426,5 +433,6 @@ fn nal_kind(nal: &[u8], codec: Codec) -> NalKind {
 			34 => NalKind::Pps,
 			_ => NalKind::Slice,
 		},
+		Codec::Av1 => NalKind::Slice,
 	}
 }

--- a/rs/moq-video/src/decode/consumer.rs
+++ b/rs/moq-video/src/decode/consumer.rs
@@ -1,4 +1,4 @@
-//! Subscribe to an encoded H.264 or H.265 track and emit raw I420 frames.
+//! Subscribe to an encoded H.264, H.265, or AV1 track and emit raw I420 frames.
 
 use std::collections::VecDeque;
 
@@ -8,7 +8,7 @@ use super::Frame;
 use super::decoder::{Config, Decoder};
 use crate::Error;
 
-/// Subscribe to a moq-mux H.264 or H.265 track and emit decoded I420.
+/// Subscribe to a moq-mux video track and emit decoded I420.
 ///
 /// The codec/backend are fixed at construction; [`read`](Self::read) returns
 /// plain [`Frame`]s. The direct mirror of `moq_audio::AudioConsumer`.
@@ -23,7 +23,7 @@ pub struct Consumer {
 
 impl Consumer {
 	/// Subscribe to `name` in `broadcast`, decoding it per the catalog entry.
-	/// Errors if the rendition isn't H.264 or H.265.
+	/// Errors if the rendition's codec is not supported by a native backend.
 	pub async fn new(
 		broadcast: &moq_net::broadcast::Consumer,
 		catalog: &VideoConfig,

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -1,11 +1,12 @@
-//! H.264 / H.265 decoder front end.
+//! Video decoder front end.
 //!
 //! Prepares each container frame for a [`Backend`](super::backend::Backend):
 //! converts out-of-band payloads (avc1 / hvc1: length-prefixed NALs with the
 //! parameter sets in the description) to Annex-B and injects those parameter sets
-//! ahead of keyframes, leaving in-band payloads (avc3 / hev1, already Annex-B
-//! inline) untouched. Gates output until the first keyframe so the backend never
-//! sees a delta frame it can't decode.
+//! ahead of keyframes, leaving in-band H.264 / H.265 payloads (avc3 / hev1,
+//! already Annex-B inline) and AV1 OBU temporal units untouched. Gates output
+//! until the first keyframe so the backend never sees a delta frame it can't
+//! decode.
 
 use std::time::Duration;
 
@@ -63,11 +64,11 @@ impl Config {
 	}
 }
 
-/// How to turn a container payload into an Annex-B access unit for the backend.
+/// How to turn a container payload into a backend access unit.
 enum Conversion {
-	/// avc3 / hev1: the payload is already Annex-B with parameter sets inline.
-	/// Pass through.
-	Annexb,
+	/// The payload is already in the backend's input framing: Annex-B for avc3 /
+	/// hev1, OBU temporal units for AV1.
+	Passthrough,
 	/// avc1 / hvc1: length-prefixed NALs with the parameter sets out-of-band (in
 	/// the avcC / hvcC description). Replace the length prefixes with start codes
 	/// and prepend `keyframe_prefix` (the parameter sets) ahead of every keyframe.
@@ -79,8 +80,8 @@ enum Conversion {
 /// The bring-your-own-payload layer under [`Consumer`](super::Consumer): use it
 /// when the frames don't come from a plain track subscription, e.g. a transcoder
 /// serving individually fetched groups. Feed it the payload of each container
-/// frame in decode order; it handles avc1/hvc1 -> Annex-B conversion and gates
-/// output until the first keyframe.
+/// frame in decode order; it handles avc1/hvc1 -> Annex-B conversion, passes
+/// AV1 OBU temporal units through, and gates output until the first keyframe.
 pub struct Decoder {
 	backend: Box<dyn Backend>,
 	conversion: Conversion,
@@ -89,12 +90,12 @@ pub struct Decoder {
 
 impl Decoder {
 	/// Build a decoder for the catalog's video config. Errors if the codec is
-	/// neither H.264 nor H.265 (the codecs the native backends support).
+	/// not supported by the native backends.
 	pub fn new(catalog: &VideoConfig, config: &Config) -> Result<Self, Error> {
 		let (codec, conversion) = match &catalog.codec {
 			VideoCodec::H264(h264) => {
 				let conversion = if h264.inline {
-					Conversion::Annexb
+					Conversion::Passthrough
 				} else {
 					let avcc = catalog.description.as_ref().ok_or_else(|| {
 						Error::Codec(anyhow::anyhow!("avc1 H.264 track is missing its avcC description"))
@@ -110,7 +111,7 @@ impl Decoder {
 			}
 			VideoCodec::H265(h265) => {
 				let conversion = if h265.in_band {
-					Conversion::Annexb
+					Conversion::Passthrough
 				} else {
 					let hvcc = catalog.description.as_ref().ok_or_else(|| {
 						Error::Codec(anyhow::anyhow!("hvc1 H.265 track is missing its hvcC description"))
@@ -125,6 +126,7 @@ impl Decoder {
 				};
 				(Codec::H265, conversion)
 			}
+			VideoCodec::AV1(_) => (Codec::Av1, Conversion::Passthrough),
 			other => return Err(Error::UnsupportedCodec(other.to_string())),
 		};
 
@@ -157,9 +159,9 @@ impl Decoder {
 			self.got_keyframe = true;
 		}
 
-		let annexb = match &self.conversion {
-			// Cheap refcount bump; the backend splits NAL slices off this buffer.
-			Conversion::Annexb => payload.clone(),
+		let access_unit = match &self.conversion {
+			// Cheap refcount bump; the backend splits codec units off this buffer.
+			Conversion::Passthrough => payload.clone(),
 			Conversion::LengthPrefixed {
 				length_size,
 				keyframe_prefix,
@@ -171,7 +173,7 @@ impl Decoder {
 
 		Ok(self
 			.backend
-			.decode(annexb, timestamp, keyframe)?
+			.decode(access_unit, timestamp, keyframe)?
 			.into_iter()
 			.map(|decoded| Frame {
 				timestamp: decoded.timestamp,
@@ -273,6 +275,16 @@ mod tests {
 	fn openh264_round_trip() {
 		let decoder = backend::open(Codec::H264, &decode_config(super::Kind::Software)).expect("openh264 decoder");
 		round_trip(h264_software_encoder(), decoder, "openh264");
+	}
+
+	#[test]
+	fn av1_is_supported_by_hardware_only() {
+		let catalog = hang::catalog::VideoConfig::new(hang::catalog::AV1::default());
+		let config = decode_config(super::Kind::Software);
+		let Err(err) = super::Decoder::new(&catalog, &config) else {
+			panic!("software AV1 decode unexpectedly opened");
+		};
+		assert!(matches!(err, crate::Error::NoDecoder(_)));
 	}
 
 	#[cfg(target_os = "macos")]

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -11,7 +11,7 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use hang::catalog::{VideoCodec, VideoConfig};
+use hang::catalog::{AV1, VideoCodec, VideoConfig};
 use moq_mux::codec::{annexb, h264, h265};
 use moq_net::Timestamp;
 
@@ -126,7 +126,7 @@ impl Decoder {
 				};
 				(Codec::H265, conversion)
 			}
-			VideoCodec::AV1(_) => (Codec::Av1, Conversion::Passthrough),
+			VideoCodec::AV1(av1) if is_supported_av1(av1) => (Codec::Av1, Conversion::Passthrough),
 			other => return Err(Error::UnsupportedCodec(other.to_string())),
 		};
 
@@ -183,6 +183,10 @@ impl Decoder {
 			})
 			.collect())
 	}
+}
+
+fn is_supported_av1(av1: &AV1) -> bool {
+	av1.bitdepth == 8 && !av1.mono_chrome && av1.chroma_subsampling_x && av1.chroma_subsampling_y
 }
 
 #[cfg(test)]
@@ -285,6 +289,20 @@ mod tests {
 			panic!("software AV1 decode unexpectedly opened");
 		};
 		assert!(matches!(err, crate::Error::NoDecoder(_)));
+	}
+
+	#[test]
+	fn av1_rejects_unsupported_catalog_shape() {
+		let av1 = hang::catalog::AV1 {
+			bitdepth: 10,
+			..hang::catalog::AV1::default()
+		};
+		let catalog = hang::catalog::VideoConfig::new(av1);
+		let config = decode_config(super::Kind::Auto);
+		let Err(err) = super::Decoder::new(&catalog, &config) else {
+			panic!("10-bit AV1 decode unexpectedly opened");
+		};
+		assert!(matches!(err, crate::Error::UnsupportedCodec(_)));
 	}
 
 	#[cfg(target_os = "macos")]

--- a/rs/moq-video/src/decode/mod.rs
+++ b/rs/moq-video/src/decode/mod.rs
@@ -1,14 +1,15 @@
-//! Subscribe to an H.264 or H.265 track and decode it to raw frames.
+//! Subscribe to an H.264, H.265, or AV1 track and decode it to raw frames.
 //!
 //! The decode counterpart to [`encode`](crate::encode), and the mirror of
-//! `moq-audio`'s `AudioConsumer`. [`Consumer`] subscribes to a moq-mux H.264 or
-//! H.265 track and hands back decoded [`Frame`]s; a native backend does the work
+//! `moq-audio`'s `AudioConsumer`. [`Consumer`] subscribes to a moq-mux video
+//! track and hands back decoded [`Frame`]s; a native backend does the work
 //! (VideoToolbox on macOS, Media Foundation / DXVA on Windows, NVDEC on Linux,
 //! openh264 everywhere as the software fallback for H.264).
 //!
 //! H.264 and H.265 are supported, symmetric with what [`encode`](crate::encode)
-//! produces. H.265 is hardware-only (no software fallback). Any other codec
-//! yields [`Error::UnsupportedCodec`](crate::Error).
+//! produces. AV1 is decode-only on NVDEC. H.265 and AV1 are hardware-only (no
+//! software fallback). Any other codec yields
+//! [`Error::UnsupportedCodec`](crate::Error).
 
 use bytes::Bytes;
 use moq_net::Timestamp;

--- a/rs/moq-video/src/error.rs
+++ b/rs/moq-video/src/error.rs
@@ -7,13 +7,13 @@ pub enum Error {
 	#[error("no usable video encoder found (tried: {0})")]
 	NoEncoder(String),
 
-	/// No decoder matching the requested hardware preference could be opened
-	/// (none compiled in, or none available on this machine).
-	#[error("no usable H.264 decoder found (tried: {0})")]
+	/// No decoder matching the requested codec / hardware preference could be
+	/// opened (none compiled in, or none available on this machine).
+	#[error("no usable video decoder found (tried: {0})")]
 	NoDecoder(String),
 
-	/// A track's codec is not H.264, the only codec the native decoders support.
-	#[error("unsupported codec for native decode: {0} (only H.264 is supported)")]
+	/// A track's codec is not supported by the native decoders.
+	#[error("unsupported codec for native decode: {0}")]
 	UnsupportedCodec(String),
 
 	/// The configured framerate was zero (would divide by zero / produce a

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -18,8 +18,8 @@
 //!     front, but the camera opens only while a subscriber is watching and is
 //!     released when the last one leaves.
 //!   - [`encode::Producer`] publishes packets you encoded yourself.
-//! - [`decode`] subscribes to an H.264 or H.265 track and decodes it to raw
-//!   frames with a native backend (VideoToolbox on macOS, Media Foundation /
+//! - [`decode`] subscribes to an H.264, H.265, or AV1 track and decodes it to
+//!   raw frames with a native backend (VideoToolbox on macOS, Media Foundation /
 //!   DXVA on Windows, NVDEC on Linux, openh264 software fallback for H.264).
 //!   [`decode::Consumer`] is the mirror of `moq-audio`'s `AudioConsumer`. An
 //!   NVDEC frame stays in CUDA memory and feeds [`encode::Encoder::encode`]


### PR DESCRIPTION
## Summary
- Add AV1 as a native decode source codec in `moq-video`, passing supported AV1 OBU temporal units through to hardware backends.
- Wire Linux NVDEC to request `cudaVideoCodec_AV1` for 8-bit 4:2:0 AV1 while keeping macOS, Windows, and software decode limited to the codecs currently wired there.
- Let `moq-transcode` choose supported AV1 source renditions when a native decoder is available, with README and changelog updates.

## Review Notes
- Narrowed AV1 eligibility to the catalog shapes this PR actually supports so 10-bit or non-4:2:0 AV1 sources are rejected or skipped before the backend fails during frame decode.

## Public API Changes
None. This changes native decode behavior and private backend codec routing, but does not add, remove, rename, or change signatures for public `pub` items.

## Validation
- `cargo fmt -p moq-video -p moq-transcode`
- `env CARGO_TARGET_DIR=/tmp/moq-cargo-target cargo test -p moq-video -p moq-transcode`
- `env CARGO_TARGET_DIR=/tmp/moq-cargo-target cargo clippy -p moq-video -p moq-transcode --all-targets`

Refs #2147.

(Written by GPT-5)
