### PR TITLE
fix(publish,demo): align media constraints

### DIFF
--- a/demo/web/console-overlay.ts
+++ b/demo/web/console-overlay.ts
@@ -47,10 +47,21 @@ const BUFFER_MAX = 1000;
 const buffer = [];
 const sinks = new Set();
 
+// Safari and Firefox build Error.stack as a bare frame list, with no leading "Name: message" line.
+// Printing the stack alone therefore drops the only part that identifies the error (e.g. the code in
+// "RESET_STREAM: 24"). Key on whether the stack already carries the message so V8, which does include
+// the header, is not printed twice.
+function formatError(err) {
+	const head = err.message ? err.name + ": " + err.message : err.name;
+	if (!err.stack) return head;
+	if (!err.message || err.stack.includes(err.message)) return err.stack;
+	return head + "\\n" + err.stack;
+}
+
 function format(args) {
 	return args
 		.map((a) => {
-			if (a instanceof Error) return a.stack || a.message;
+			if (a instanceof Error) return formatError(a);
 			if (typeof a === "string") return a;
 			if (a === undefined) return "undefined";
 			try {

--- a/demo/web/src/index.ts
+++ b/demo/web/src/index.ts
@@ -132,14 +132,19 @@ function createTile(name: string): WatchTile {
 	});
 
 	// Active state: only toggle audio + the active styling, so switching tiles
-	// keeps the video playing.
+	// keeps the video playing. This depends on `active` alone: reading the catalog here
+	// would re-assert `muted` on every catalog frame and clobber the player's mute button.
 	effects.run((effect) => {
 		const isActive = effect.get(active) === name;
 		el.classList.toggle("border-emerald-500", isActive);
 		el.classList.toggle("border-neutral-800", !isActive);
 		watch.muted = !isActive;
-		// Show the speaker badge on the active tile, but only when it actually has
-		// an audio track to play.
+	});
+
+	// Show the speaker badge on the active tile, but only when it actually has
+	// an audio track to play.
+	effects.run((effect) => {
+		const isActive = effect.get(active) === name;
 		const hasAudio = !!effect.get(watch.broadcast.output.catalog)?.audio;
 		audioBadge.hidden = !(isActive && hasAudio);
 	});

--- a/demo/web/src/publish.html
+++ b/demo/web/src/publish.html
@@ -148,6 +148,42 @@
 						<span id="channels-actual" class="shrink-0 w-24 text-right font-mono text-xs text-emerald-400"></span>
 					</div>
 				</label>
+				<details class="text-xs text-neutral-400">
+					<summary class="cursor-pointer text-neutral-300">Mic processing</summary>
+					<div class="mt-2 space-y-2">
+						<p class="text-[11px] text-neutral-500">
+							Auto keeps the browser default. On macOS the defaults engage voice processing:
+							auto gain can slowly pull the level down and other system audio gets ducked.
+						</p>
+						<label class="block">
+							Echo cancellation
+							<select id="echo-cancellation"
+								class="mt-1 w-full bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-white text-sm">
+								<option value="" selected>Auto</option>
+								<option value="on">On</option>
+								<option value="off">Off</option>
+							</select>
+						</label>
+						<label class="block">
+							Auto gain control
+							<select id="auto-gain-control"
+								class="mt-1 w-full bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-white text-sm">
+								<option value="" selected>Auto</option>
+								<option value="on">On</option>
+								<option value="off">Off</option>
+							</select>
+						</label>
+						<label class="block">
+							Noise suppression
+							<select id="noise-suppression"
+								class="mt-1 w-full bg-neutral-800 border border-neutral-700 rounded px-2 py-1 text-white text-sm">
+								<option value="" selected>Auto</option>
+								<option value="on">On</option>
+								<option value="off">Off</option>
+							</select>
+						</label>
+					</div>
+				</details>
 				<details id="opus-advanced" class="text-xs text-neutral-400">
 					<summary class="cursor-pointer text-neutral-300">Opus options</summary>
 					<div class="mt-2 space-y-2">

--- a/demo/web/src/publish.ts
+++ b/demo/web/src/publish.ts
@@ -113,7 +113,7 @@ type VideoTarget = {
 	frameRate?: number;
 };
 
-const videoTarget = ui.computed((effect): VideoTarget => {
+function readVideoTarget(effect: Signals.Effect): VideoTarget {
 	const res = effect.get(resolution);
 	const [rawWidth, rawHeight] = res ? res.split("x").map(Number) : [undefined, undefined];
 	return {
@@ -121,7 +121,7 @@ const videoTarget = ui.computed((effect): VideoTarget => {
 		height: rawHeight && Number.isFinite(rawHeight) ? rawHeight : undefined,
 		frameRate: effect.get(framerate),
 	};
-});
+}
 
 function cameraConstraints(target: VideoTarget): Video.Constraints | undefined {
 	const constraints: Video.Constraints = {};
@@ -147,10 +147,7 @@ function encoderConfig(effect: Signals.Effect, target: VideoTarget): Video.Encod
 // Compose the WebCodecs/MoQ video encoder config and push it onto the HD
 // rendition. Undefined fields are omitted, so the encoder auto-sizes them.
 ui.run((effect) => {
-	const target = effect.get(videoTarget);
-	if (!target) return;
-
-	publish.broadcast.video.hd.config.set(encoderConfig(effect, target));
+	publish.broadcast.video.hd.config.set(encoderConfig(effect, readVideoTarget(effect)));
 });
 
 // Request the selected resolution from the camera itself, not just cap the encoder. publish.video
@@ -161,10 +158,7 @@ ui.run((effect) => {
 	const source = effect.get(publish.video);
 	if (!(source instanceof Source.Camera)) return;
 
-	const target = effect.get(videoTarget);
-	if (!target) return;
-
-	effect.set(source.constraints, cameraConstraints(target));
+	effect.set(source.constraints, cameraConstraints(readVideoTarget(effect)));
 });
 
 // Audio general settings (volume gain, output sample rate, channel mix).

--- a/demo/web/src/publish.ts
+++ b/demo/web/src/publish.ts
@@ -91,6 +91,12 @@ const volume = new Signals.Signal(1);
 const sampleRate = new Signals.Signal<number | undefined>(undefined);
 const channelCount = new Signals.Signal<number | undefined>(undefined);
 
+// Mic processing constraints; undefined means "browser default". macOS defaults these on, which
+// engages voice processing: auto gain can slowly pull the level down and other audio gets ducked.
+const echoCancellation = new Signals.Signal<boolean | undefined>(undefined);
+const autoGainControl = new Signals.Signal<boolean | undefined>(undefined);
+const noiseSuppression = new Signals.Signal<boolean | undefined>(undefined);
+
 // Opus-specific knobs (the "Opus options" panel), mapping 1:1 onto OpusConfig.
 const opusBitrateKbps = new Signals.Signal<number | undefined>(undefined);
 const opusFrameDuration = new Signals.Signal<number | undefined>(undefined); // ms (2.5 to 60)
@@ -117,11 +123,39 @@ ui.run((effect) => {
 	});
 });
 
+// Request the selected resolution from the camera itself, not just cap the encoder. publish.video
+// holds the active Camera source (undefined for screen/file); its constraints re-acquire the track
+// on change. getUserMedia uses `ideal`, so a camera that can't reach the target falls back to its
+// best (the green "actual" readout shows what it gave).
+ui.run((effect) => {
+	const source = effect.get(publish.video);
+	if (!source || !("constraints" in source)) return;
+
+	const res = effect.get(resolution);
+	const [w, h] = res ? res.split("x").map(Number) : [undefined, undefined];
+	source.constraints.set(w && h ? { width: { ideal: w }, height: { ideal: h } } : undefined);
+});
+
 // Audio general settings (volume gain, output sample rate, channel mix).
 ui.run((effect) => {
 	publish.broadcast.audio.volume.set(effect.get(volume));
 	publish.broadcast.audio.sampleRate.set(effect.get(sampleRate));
 	publish.broadcast.audio.channelCount.set(effect.get(channelCount));
+});
+
+// Mic processing constraints go to the capture itself (getUserMedia re-acquires the track on
+// change). publish.audio holds the active Microphone source (undefined for screen/file).
+ui.run((effect) => {
+	const source = effect.get(publish.audio);
+	if (!source || !("constraints" in source)) return;
+
+	const constraints = {
+		echoCancellation: effect.get(echoCancellation),
+		autoGainControl: effect.get(autoGainControl),
+		noiseSuppression: effect.get(noiseSuppression),
+	};
+	const any = Object.values(constraints).some((v) => v !== undefined);
+	source.constraints.set(any ? constraints : undefined);
 });
 
 // Compose the structured audio codec config; today only Opus. Undefined knobs
@@ -180,6 +214,14 @@ const bindOptionalSelect = (id: string, signal: Signals.Signal<number | undefine
 	el.addEventListener("change", sync);
 };
 
+// An optional on/off select where the empty value ("Auto") means undefined (browser default).
+const bindOptionalBoolean = (id: string, signal: Signals.Signal<boolean | undefined>) => {
+	const el = $<HTMLSelectElement>(id);
+	const sync = () => signal.set(el.value === "" ? undefined : el.value === "on");
+	sync();
+	el.addEventListener("change", sync);
+};
+
 const bindCheckbox = (id: string, signal: Signals.Signal<boolean>) => {
 	const el = $<HTMLInputElement>(id);
 	signal.set(el.checked);
@@ -196,6 +238,9 @@ bindOptionalNumber("keyframe", keyframeMs);
 bindNumber("volume", volume);
 bindOptionalSelect("samplerate", sampleRate);
 bindOptionalSelect("channels", channelCount);
+bindOptionalBoolean("echo-cancellation", echoCancellation);
+bindOptionalBoolean("auto-gain-control", autoGainControl);
+bindOptionalBoolean("noise-suppression", noiseSuppression);
 bindOptionalNumber("opus-bitrate", opusBitrateKbps);
 bindOptionalSelect("opus-frame-duration", opusFrameDuration);
 bindOptionalNumber("opus-complexity", opusComplexity);

--- a/demo/web/src/publish.ts
+++ b/demo/web/src/publish.ts
@@ -18,7 +18,7 @@
 import "./highlight";
 import "@moq/publish/element"; // defines <moq-publish>
 import "@moq/publish/ui"; // defines <moq-publish-ui>
-import { type Audio, Json, Net, Signals } from "@moq/publish";
+import { type Audio, Json, Net, Signals, Source, type Video } from "@moq/publish";
 import type MoqPublish from "@moq/publish/element";
 import MoqPublishSupport from "@moq/publish/support/element";
 import { formatBitrate, formatFps, graph } from "./viz";
@@ -107,20 +107,50 @@ const opusDtx = new Signals.Signal(false); // discontinuous transmission (silenc
 
 const ui = new Signals.Effect();
 
+type VideoTarget = {
+	width?: number;
+	height?: number;
+	frameRate?: number;
+};
+
+const videoTarget = ui.computed((effect): VideoTarget => {
+	const res = effect.get(resolution);
+	const [rawWidth, rawHeight] = res ? res.split("x").map(Number) : [undefined, undefined];
+	return {
+		width: rawWidth && Number.isFinite(rawWidth) ? rawWidth : undefined,
+		height: rawHeight && Number.isFinite(rawHeight) ? rawHeight : undefined,
+		frameRate: effect.get(framerate),
+	};
+});
+
+function cameraConstraints(target: VideoTarget): Video.Constraints | undefined {
+	const constraints: Video.Constraints = {};
+	if (target.width !== undefined) constraints.width = { ideal: target.width, max: target.width };
+	if (target.height !== undefined) constraints.height = { ideal: target.height, max: target.height };
+	if (target.frameRate !== undefined) constraints.frameRate = { ideal: target.frameRate, max: target.frameRate };
+
+	return Object.keys(constraints).length ? constraints : undefined;
+}
+
+function encoderConfig(effect: Signals.Effect, target: VideoTarget): Video.EncoderConfig {
+	const br = effect.get(bitrateKbps);
+	const kf = effect.get(keyframeMs);
+	return {
+		codec: effect.get(codec),
+		maxPixels: target.width && target.height ? target.width * target.height : undefined,
+		maxBitrate: br != null ? br * 1000 : undefined,
+		keyframeInterval: kf != null ? Net.Time.Milli(kf) : undefined,
+		frameRate: target.frameRate,
+	};
+}
+
 // Compose the WebCodecs/MoQ video encoder config and push it onto the HD
 // rendition. Undefined fields are omitted, so the encoder auto-sizes them.
 ui.run((effect) => {
-	const res = effect.get(resolution);
-	const [w, h] = res ? res.split("x").map(Number) : [undefined, undefined];
-	const br = effect.get(bitrateKbps);
-	const kf = effect.get(keyframeMs);
-	publish.broadcast.video.hd.config.set({
-		codec: effect.get(codec),
-		maxPixels: w && h ? w * h : undefined,
-		maxBitrate: br != null ? br * 1000 : undefined,
-		keyframeInterval: kf != null ? (kf as Net.Time.Milli) : undefined,
-		frameRate: effect.get(framerate),
-	});
+	const target = effect.get(videoTarget);
+	if (!target) return;
+
+	publish.broadcast.video.hd.config.set(encoderConfig(effect, target));
 });
 
 // Request the selected resolution from the camera itself, not just cap the encoder. publish.video
@@ -129,11 +159,12 @@ ui.run((effect) => {
 // best (the green "actual" readout shows what it gave).
 ui.run((effect) => {
 	const source = effect.get(publish.video);
-	if (!source || !("constraints" in source)) return;
+	if (!(source instanceof Source.Camera)) return;
 
-	const res = effect.get(resolution);
-	const [w, h] = res ? res.split("x").map(Number) : [undefined, undefined];
-	source.constraints.set(w && h ? { width: { ideal: w }, height: { ideal: h } } : undefined);
+	const target = effect.get(videoTarget);
+	if (!target) return;
+
+	effect.set(source.constraints, cameraConstraints(target));
 });
 
 // Audio general settings (volume gain, output sample rate, channel mix).

--- a/demo/web/src/viz.ts
+++ b/demo/web/src/viz.ts
@@ -224,7 +224,7 @@ export function bufferBars(parent: Signals.Effect, watch: MoqWatch): HTMLElement
 		label.className = "w-10 shrink-0 text-[10px] text-neutral-500";
 		label.textContent = name;
 		const canvas = document.createElement("canvas");
-		canvas.style.cssText = "display: block; flex: 1; height: 20px;";
+		canvas.style.cssText = "display: block; flex: 1; min-width: 0; height: 20px;";
 		row.append(label, canvas);
 		return { row, canvas };
 	};

--- a/doc/lib/js/env/web.md
+++ b/doc/lib/js/env/web.md
@@ -336,6 +336,8 @@ Requires modern browser features:
 - Firefox (behind flag)
 - Safari (future support planned)
 
+On macOS the browser's default microphone constraints engage the system voice processor: auto gain control can slowly pull the capture level down, and other system audio is ducked while the mic is live. Pass `{ echoCancellation: false, autoGainControl: false, noiseSuppression: false }` via the microphone source's `constraints` to capture the raw signal instead (expect echo without headphones).
+
 ## Production Deployment
 
 For production, you'll want to:

--- a/doc/lib/js/env/web.md
+++ b/doc/lib/js/env/web.md
@@ -336,8 +336,6 @@ Requires modern browser features:
 - Firefox (behind flag)
 - Safari (future support planned)
 
-On macOS the browser's default microphone constraints engage the system voice processor: auto gain control can slowly pull the capture level down, and other system audio is ducked while the mic is live. Pass `{ echoCancellation: false, autoGainControl: false, noiseSuppression: false }` via the microphone source's `constraints` to capture the raw signal instead (expect echo without headphones).
-
 ## Production Deployment
 
 For production, you'll want to:

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -17,8 +17,8 @@ export interface EncoderConfig {
 	// If not provided, the encoder will select the best codec.
 	codec?: string;
 
-	// Constrain the encoded width/height in pixels.
-	// TODO figure out how this interacts with the width/height props.
+	// Constrain the encoded width/height in pixels. If unset, source width.max and height.max
+	// constraints provide the cap when both are present.
 	maxPixels?: number;
 
 	// Cap the encoded resolution to this fraction of the source pixel count.
@@ -272,15 +272,16 @@ export class Encoder {
 	}
 
 	#runDimensions(effect: Effect): void {
-		const user = effect.get(this.config);
+		const values = effect.getAll([this.frame, this.source]);
+		if (!values) return;
+		const [frame, source] = values;
 
-		const frame = effect.get(this.frame);
-		if (!frame) return;
+		const user = effect.get(this.config);
 
 		const sourcePixels = frame.codedWidth * frame.codedHeight;
 
 		// maxPixels caps absolutely; maxScale caps relative to the source. The smaller cap wins.
-		let maxPixels = user?.maxPixels ?? sourcePixels;
+		let maxPixels = user?.maxPixels ?? sourceConstraintPixels(source) ?? sourcePixels;
 		if (user?.maxScale !== undefined) {
 			if (!Number.isFinite(user.maxScale) || user.maxScale <= 0) {
 				throw new Error(`maxScale must be a finite number greater than 0: ${user.maxScale}`);
@@ -420,4 +421,19 @@ export class Encoder {
 	close() {
 		this.#signals.close();
 	}
+}
+
+function sourceConstraintPixels(source: Source): number | undefined {
+	const constraints = source.getConstraints();
+	const width = constraintMax(constraints.width);
+	const height = constraintMax(constraints.height);
+
+	return width !== undefined && height !== undefined ? width * height : undefined;
+}
+
+function constraintMax(value: MediaTrackConstraints["width"]): number | undefined {
+	if (typeof value !== "object" || value === null) return undefined;
+
+	const max = value.max;
+	return typeof max === "number" && Number.isFinite(max) && max > 0 ? max : undefined;
 }


### PR DESCRIPTION
Split out of #2163.

Summary:

- Add demo mic processing controls for `echoCancellation`, `autoGainControl`, and `noiseSuppression` while keeping Auto as the browser default.
- Request the selected camera resolution and frame rate on the source, and keep the demo encoder cap aligned with that selected target.
- Let the video encoder use source `width.max * height.max` as the `maxPixels` fallback when both constraints are present and `config.maxPixels` is unset.
- Fix Safari/Firefox console-overlay error formatting, the speaker-mute reset on catalog updates, and buffer-bar shrinking in narrow layouts.

Public API changes:

- No new, renamed, removed, or signature-changed exports.
- Non-breaking behavior/doc change: `EncoderConfig.maxPixels` now documents and uses source `width.max` and `height.max` as a fallback cap when both are present.

Branch targeting:

- These changes are non-breaking and would normally target `main`. The branch is based on `dev`; retargeting to `main` would include unrelated `dev` changes, so this PR remains on `dev`.

Test plan:

- `nix develop --command env CARGO_TARGET_DIR=/Users/kixelated/.codex/worktrees/078c/moq/target just check`
- `nix develop --command just js check`
- Remote `Check` is green.

(Written by GPT-5)