### PR TITLE
fix(net): reconnect when the session closes, not just when it errors

### DIFF
--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -1,6 +1,7 @@
 import { Effect, type Getter, Signal } from "@moq/signals";
 import type * as Path from "../path.ts";
 import { empty as emptyPath } from "../path.ts";
+import { error } from "../util/error.ts";
 import { type ConnectProps, connect, type WebSocketOptions, type WebTransportProps } from "./connect.ts";
 import type { Established } from "./established.ts";
 
@@ -39,6 +40,15 @@ export type ReloadProps = ConnectProps & {
 
 /** Current state of a {@link Reload} connection. */
 export type ReloadStatus = "connecting" | "connected" | "disconnected";
+
+// Tells "the effect was torn down" apart from "the session ended" when racing the two: both promises
+// resolve to undefined, and only the latter should reconnect.
+const CANCELLED = Symbol("cancelled");
+
+// How long a session must survive before we count it as a healthy connection and reset the backoff.
+// A server that accepts us and drops us straight away (bad auth, shedding load, a redirect it cannot
+// serve) would otherwise reset the ladder on every attempt and get hammered once a second forever.
+const STABLE_CONNECTION_MS = 10_000;
 
 /** Maintains a MoQ connection, reconnecting with exponential backoff when it drops. */
 export class Reload {
@@ -117,11 +127,16 @@ export class Reload {
 		effect.set(this.status, "connecting", "disconnected");
 
 		effect.spawn(async () => {
+			// Pin this run's teardown handles: both getters are swapped for fresh ones the moment a
+			// rerun begins, and a rerun begins before it awaits this spawn.
+			const cancelled: Promise<typeof CANCELLED> = effect.cancel.then(() => CANCELLED);
+			const abort = effect.abort;
+
 			try {
 				const pending = connect(url, { websocket: this.websocket, webtransport: this.webtransport });
 
-				const connection = await Promise.race([effect.cancel, pending]);
-				if (!connection) {
+				const connection = await Promise.race([cancelled, pending]);
+				if (connection === CANCELLED) {
 					pending.then((conn) => conn.close()).catch(() => {});
 					return;
 				}
@@ -131,33 +146,56 @@ export class Reload {
 
 				effect.set(this.status, "connected", "disconnected");
 
-				// Reset the exponential backoff and timeout on success.
-				this.#delay = this.delay.initial;
-				this.#retryStart = undefined;
+				const connectedAt = performance.now();
 
-				await Promise.race([effect.cancel, connection.closed]);
-			} catch (err) {
-				console.warn("connection error:", err);
+				// `closed` RESOLVES on every session end, so a dropped session arrives here rather than in
+				// the catch below. qmux never rejects it, and WebTransport rejects only on an abnormal
+				// close, so without an explicit retry a viewer whose session drops keeps a dead
+				// `established` and a status that still reads "connected", forever. Safari and Firefox are
+				// always on the qmux WebSocket, so this is their only path to drop recovery.
+				if ((await Promise.race([cancelled, connection.closed])) === CANCELLED) return;
+				if (abort.aborted) return;
 
-				// Track retry start for timeout.
-				this.#retryStart ??= performance.now();
+				this.established.set(undefined);
+				this.status.set("disconnected");
 
-				const timeout = this.delay.timeout ?? 300000;
-				if (timeout > 0) {
-					const elapsed = performance.now() - this.#retryStart;
-					if (elapsed >= timeout) {
-						console.warn("reconnect timed out");
-						this.#closedReject(err instanceof Error ? err : new Error(String(err)));
-						return;
-					}
+				// Only a session that stayed up counts as success. See STABLE_CONNECTION_MS.
+				if (performance.now() - connectedAt >= STABLE_CONNECTION_MS) {
+					this.#delay = this.delay.initial;
+					this.#retryStart = undefined;
 				}
 
-				const tick = this.#tick.peek() + 1;
-				effect.timer(() => this.#tick.update((prev) => Math.max(prev, tick)), this.#delay);
+				this.#retry(effect);
+			} catch (err) {
+				if (abort.aborted) return;
 
-				this.#delay = Math.min(this.#delay * this.delay.multiplier, this.delay.max);
+				console.warn("connection error:", err);
+				this.#retry(effect, err);
 			}
 		});
+	}
+
+	// Schedule the next connect attempt, growing the exponential backoff. Gives up (rejecting
+	// {@link Reload.closed}) once the retry budget since the last stable connection is spent. `err` is
+	// what the attempt failed with, absent when the session simply closed.
+	#retry(effect: Effect, err?: unknown): void {
+		// Track retry start for timeout.
+		this.#retryStart ??= performance.now();
+
+		const timeout = this.delay.timeout ?? 300000;
+		if (timeout > 0) {
+			const elapsed = performance.now() - this.#retryStart;
+			if (elapsed >= timeout) {
+				console.warn("reconnect timed out");
+				this.#closedReject(err === undefined ? new Error("reconnect timed out") : error(err));
+				return;
+			}
+		}
+
+		const tick = this.#tick.peek() + 1;
+		effect.timer(() => this.#tick.update((prev) => Math.max(prev, tick)), this.#delay);
+
+		this.#delay = Math.min(this.#delay * this.delay.multiplier, this.delay.max);
 	}
 
 	#runAnnounced(effect: Effect): void {

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -119,7 +119,8 @@ export class Connection implements Established {
 		this.#subscriber.close();
 
 		try {
-			// TODO: For whatever reason, this try/catch doesn't seem to work..?
+			// A failed close rejects `closed` rather than throwing; this only guards
+			// closing an already-closed transport (a teardown race).
 			this.#quic.close();
 		} catch {
 			// ignore
@@ -289,10 +290,14 @@ export class Connection implements Established {
 				}
 			}, SEND_BW_POLL_INTERVAL);
 
-			void this.closed.then(() => {
-				clearInterval(id);
-				resolve();
-			});
+			// `closed` rejects on abnormal termination (that rejection is what drives Reload's reconnect);
+			// here we only need it as a stop signal, so swallow the rejection to avoid an unhandled rejection.
+			void this.closed
+				.catch(() => {})
+				.then(() => {
+					clearInterval(id);
+					resolve();
+				});
 		});
 	}
 


### PR DESCRIPTION
Split out of #2163.

**A dropped session never reconnected.** `Established.closed` *resolves* on every session end: qmux never rejects it, and native WebTransport rejects only on an abnormal close. But `Reload` only retried from its `catch` block, so a session that simply closed fell through without scheduling a retry, leaving a dead `established`, a status still reading `"connected"`, throughput at zero, and no reconnect attempt ever. A page reload was the only way back.

This disproportionately hit Safari and Firefox, which ride the qmux WebSocket (where `closed` *always* resolves), so for them it was the only path to drop recovery.

The fix treats a resolved `closed` as a disconnect: clear `established`, report `"disconnected"`, and retry on the existing backoff ladder.

Two subtleties, both deliberate:
- The effect teardown and the session close both resolve to `undefined`, so racing them is ambiguous. A `CANCELLED` sentinel tells "the effect was torn down" apart from "the session ended", and only the latter reconnects.
- The backoff ladder only resets once a session has survived `STABLE_CONNECTION_MS`. A relay that accepts us and immediately drops us (bad auth, shedding load, a redirect it cannot serve) would otherwise reset the ladder on every attempt and get hammered once a second forever.

Also pins the per-run `cancel`/`abort` handles, since a rerun swaps both before awaiting the spawn, and swallows the `closed` rejection in the bandwidth poll, which only uses it as a stop signal (that rejection is what drives the reconnect and must not surface as an unhandled rejection).

**Public API changes:** none.

**Test plan:** `just js check` green. Verified in the demo by bouncing the relay: the viewer reconnects on the backoff ladder instead of sitting on a permanently "connected" dead session.
