### PR TITLE
fix(net): force Safari onto the WebSocket transport

### DIFF
--- a/doc/lib/js/env/web.md
+++ b/doc/lib/js/env/web.md
@@ -334,7 +334,9 @@ Requires modern browser features:
 **Experimental support:**
 
 - Firefox (behind flag)
-- Safari (future support planned)
+- Safari
+
+Safari always connects over the WebSocket fallback, because reading WebTransport datagrams terminates the session. It therefore has no congestion-controller bandwidth estimate, so the encoder does not adapt its bitrate downward. Set `maxBitrate` explicitly if you need a ceiling.
 
 ## Production Deployment
 

--- a/doc/lib/js/index.md
+++ b/doc/lib/js/index.md
@@ -165,7 +165,9 @@ Requires modern browser features:
 **Experimental support:**
 
 - Firefox (behind flag)
-- Safari (future support planned)
+- Safari
+
+Safari always connects over the WebSocket fallback, because reading WebTransport datagrams terminates the session.
 
 ## Framework Integration
 

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -15,6 +15,7 @@
 	"scripts": {
 		"build": "rimraf dist && tsc -b && bun ../common/package.ts",
 		"check": "tsc --noEmit",
+		"test": "bun test --only-failures",
 		"release": "bun ../common/release.ts"
 	},
 	"dependencies": {

--- a/js/hang/src/util/hacks.test.ts
+++ b/js/hang/src/util/hacks.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { detectSafari } from "./hacks.ts";
+
+// This corpus is intentionally shared with `js/net/src/connection/transport.test.ts`, which tests the
+// twin Safari rule in `pickTransport`. Adding a case here without adding it there lets the two drift.
+const UA = {
+	chrome: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+	edge: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0",
+	firefox: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0",
+	androidChrome:
+		"Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36",
+	androidWebview:
+		"Mozilla/5.0 (Linux; Android 13; Pixel 7 wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/120.0.0.0 Mobile Safari/537.36",
+	// The legacy Android stock browser. It says "safari" and "android" but never "chrome", so it is the
+	// only case that exercises the `android` clause; every other Android agent short-circuits on "chrome".
+	androidLegacy:
+		"Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; SM-G900F Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
+	safari17:
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15",
+	safari18:
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
+	iosSafari:
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1",
+	iosChrome:
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.6099.119 Mobile/15E148 Safari/604.1",
+	iosFirefox:
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/119.0 Mobile/15E148 Safari/605.1.15",
+	epiphany: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15",
+};
+
+test("detectSafari matches real Safari and all iOS/WebKit browsers, excludes Chrome/Edge/Firefox/Android", () => {
+	expect(detectSafari(UA.safari17)).toBe(true);
+	expect(detectSafari(UA.safari18)).toBe(true);
+	expect(detectSafari(UA.iosSafari)).toBe(true);
+	expect(detectSafari(UA.iosChrome)).toBe(true); // "CriOS" is WebKit under the hood, not Chrome
+	expect(detectSafari(UA.iosFirefox)).toBe(true); // "FxiOS" likewise, and it never says "firefox"
+	expect(detectSafari(UA.epiphany)).toBe(true); // WebKitGTK
+
+	expect(detectSafari(UA.chrome)).toBe(false); // "safari" + "chrome" -> Chrome
+	expect(detectSafari(UA.edge)).toBe(false);
+	expect(detectSafari(UA.firefox)).toBe(false);
+	expect(detectSafari(UA.androidChrome)).toBe(false); // android
+	expect(detectSafari(UA.androidWebview)).toBe(false); // android + chrome
+	// Guards the `android` clause on its own: this agent passes the "safari" and !"chrome" checks.
+	expect(detectSafari(UA.androidLegacy)).toBe(false);
+});
+
+test("the user agent is matched case-insensitively", () => {
+	expect(detectSafari(UA.safari17.toUpperCase())).toBe(true);
+	expect(detectSafari(UA.chrome.toUpperCase())).toBe(false);
+	expect(detectSafari(UA.androidWebview.toUpperCase())).toBe(false);
+});

--- a/js/hang/src/util/hacks.ts
+++ b/js/hang/src/util/hacks.ts
@@ -1,5 +1,36 @@
+// `navigator` is absent in some worker/worklet scopes and SSR, so guard the read (empty string ->
+// all flags false) rather than throwing at import time. Under bun, navigator.userAgent is
+// "Bun/1.3.14", which matches no token below, so tests also see false flags.
+const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
+
+function detectChrome(ua: string): boolean {
+	return ua.toLowerCase().includes("chrome");
+}
+
+function detectFirefox(ua: string): boolean {
+	return ua.toLowerCase().includes("firefox");
+}
+
+/**
+ * True for Safari-style WebKit user agents: those that report "safari" but are not Chrome or an
+ * Android WebView (both of which also carry "safari"). This also matches every iOS browser, since
+ * Chrome, Firefox, etc. on iOS are all WebKit.
+ *
+ * This rule must agree with `pickTransport` in `@moq/net`'s `connection/transport.ts`, which decides
+ * the transport this predicate is used to report. The two cannot share code: `@moq/net` is a
+ * dependency and `pickTransport` is internal. The shared test corpus in `hacks.test.ts` and
+ * `transport.test.ts` is what catches a drift.
+ */
+export function detectSafari(ua: string): boolean {
+	const s = ua.toLowerCase();
+	return s.includes("safari") && !s.includes("android") && !detectChrome(ua);
+}
+
 /** True when running in Chrome, used to work around https://issues.chromium.org/issues/40504498. */
-export const isChrome = navigator.userAgent.toLowerCase().includes("chrome");
+export const isChrome = detectChrome(userAgent);
 
 /** True when running in Firefox, used to work around https://bugzilla.mozilla.org/show_bug.cgi?id=1967793. */
-export const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
+export const isFirefox = detectFirefox(userAgent);
+
+/** True for Safari-style WebKit user agents (see {@link detectSafari}). */
+export const isSafari = detectSafari(userAgent);

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -5,6 +5,7 @@ import { Stream } from "../stream.ts";
 import * as Hex from "../util/hex.ts";
 import type { Established } from "./established.ts";
 import { exchangeSetup } from "./handshake.ts";
+import { pickTransport } from "./transport.ts";
 
 // Default head start for WebTransport before attempting the WebSocket fallback.
 const DEFAULT_WEBSOCKET_DELAY_MS = 500;
@@ -61,11 +62,6 @@ export interface ConnectProps {
 // Save if WebSocket won the last race, so we won't give QUIC a head start next time.
 const websocketWon = new Set<string>();
 
-// Firefox's WebTransport implementation drops server-initiated bidi streams,
-// breaking publish (the relay opens a subscribe bidi back to us). Force WebSocket.
-// TODO: remove once Firefox fixes incoming bidi delivery.
-const isFirefox = typeof navigator !== "undefined" && navigator.userAgent.toLowerCase().includes("firefox");
-
 /**
  * Establishes a connection to a MOQ server.
  *
@@ -80,8 +76,12 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	// Create a cancel promise to kill whichever is still connecting.
 	const { promise: cancel, resolve: done } = Promise.withResolvers<void>();
 
+	// `navigator` is absent under SSR, some worker scopes, and bun tests.
+	const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
 	const webtransport =
-		globalThis.WebTransport && !isFirefox ? connectWebTransport(url, cancel, props?.webtransport) : undefined;
+		pickTransport(userAgent, !!globalThis.WebTransport) === "webtransport"
+			? connectWebTransport(url, cancel, props?.webtransport)
+			: undefined;
 
 	// Give QUIC a head start to connect before trying WebSocket, unless WebSocket has won in the past.
 	// NOTE that QUIC should be faster because it involves 1/2 fewer RTTs.

--- a/js/net/src/connection/transport.test.ts
+++ b/js/net/src/connection/transport.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import { pickTransport } from "./transport.ts";
+
+// Real user agents. The WebKit ones are the whole point: Safari's WebTransport session dies the
+// moment `datagrams.readable` is read, which moq-lite-05 always does.
+//
+// This corpus is intentionally shared with `js/hang/src/util/hacks.test.ts`, which tests the twin
+// Safari rule in `detectSafari`. Adding a case here without adding it there lets the two drift.
+const CHROME =
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const EDGE = `${CHROME} Edg/120.0.0.0`;
+const FIREFOX = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0";
+const SAFARI =
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15";
+const IOS_SAFARI =
+	"Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1";
+const IOS_CHROME =
+	"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/119.0.6045.109 Mobile/15E148 Safari/604.1";
+const IOS_FIREFOX =
+	"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/119.0 Mobile/15E148 Safari/605.1.15";
+const ANDROID_CHROME =
+	"Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36";
+const ANDROID_WEBVIEW =
+	"Mozilla/5.0 (Linux; Android 13; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/120.0.0.0 Mobile Safari/537.36";
+// The legacy Android stock browser. It says "safari" and "android" but never "chrome", so it is the
+// only case that exercises the `android` clause; every other Android agent short-circuits on "chrome".
+const ANDROID_LEGACY =
+	"Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; SM-G900F Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30";
+// WebKitGTK, e.g. GNOME Web. Not Safari, but the same engine and the same datagram bug.
+const EPIPHANY =
+	"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15";
+
+test("every WebKit engine gets WebSocket, even when WebTransport exists", () => {
+	// Safari 26.4+ ships WebTransport, so `hasWebTransport` is true and must be ignored.
+	expect(pickTransport(SAFARI, true)).toBe("websocket");
+	expect(pickTransport(IOS_SAFARI, true)).toBe("websocket");
+
+	// Chrome and Firefox on iOS are WebKit under the skin. They report CriOS/FxiOS, never
+	// "chrome"/"firefox", so they must fall through to the Safari branch rather than the default.
+	expect(pickTransport(IOS_CHROME, true)).toBe("websocket");
+	expect(pickTransport(IOS_FIREFOX, true)).toBe("websocket");
+
+	// Desktop WebKit that is not Safari at all.
+	expect(pickTransport(EPIPHANY, true)).toBe("websocket");
+});
+
+test("Firefox gets WebSocket", () => {
+	expect(pickTransport(FIREFOX, true)).toBe("websocket");
+});
+
+test("Chromium engines keep WebTransport", () => {
+	// These carry "Safari" in their user agent but are not WebKit.
+	expect(pickTransport(CHROME, true)).toBe("webtransport");
+	expect(pickTransport(EDGE, true)).toBe("webtransport");
+	expect(pickTransport(ANDROID_CHROME, true)).toBe("webtransport");
+	expect(pickTransport(ANDROID_WEBVIEW, true)).toBe("webtransport");
+});
+
+test("Android keeps WebTransport even when the agent says only Safari", () => {
+	// Guards the `android` clause on its own: this agent passes the "safari" and !"chrome" checks,
+	// so dropping `!ua.includes("android")` would wrongly route it to WebSocket.
+	expect(pickTransport(ANDROID_LEGACY, true)).toBe("webtransport");
+});
+
+test("no WebTransport support falls back to WebSocket", () => {
+	expect(pickTransport(CHROME, false)).toBe("websocket");
+	expect(pickTransport(SAFARI, false)).toBe("websocket");
+});
+
+test("an absent user agent falls back to WebTransport support", () => {
+	// `navigator` is undefined under SSR, some worker scopes, and bun tests.
+	expect(pickTransport("", true)).toBe("webtransport");
+	expect(pickTransport("", false)).toBe("websocket");
+});
+
+test("the user agent is matched case-insensitively", () => {
+	expect(pickTransport(SAFARI.toUpperCase(), true)).toBe("websocket");
+	expect(pickTransport(FIREFOX.toUpperCase(), true)).toBe("websocket");
+	expect(pickTransport(CHROME.toUpperCase(), true)).toBe("webtransport");
+});

--- a/js/net/src/connection/transport.ts
+++ b/js/net/src/connection/transport.ts
@@ -1,0 +1,30 @@
+/** The wire transport a session runs over. */
+export type Transport = "webtransport" | "websocket";
+
+/**
+ * Which transport {@link connect} will attempt for a user agent. Safari and Firefox always get
+ * WebSocket, whether or not they expose `WebTransport`.
+ *
+ * @internal Not re-exported from the package entrypoint.
+ */
+export function pickTransport(userAgent: string, hasWebTransport: boolean): Transport {
+	const ua = userAgent.toLowerCase();
+
+	// Firefox's WebTransport implementation drops server-initiated bidi streams,
+	// breaking publish (the relay opens a subscribe bidi back to us).
+	// TODO: remove once Firefox fixes incoming bidi delivery.
+	if (ua.includes("firefox")) return "websocket";
+
+	// Reading `WebTransport.datagrams.readable` tears down the whole session on Safari, and
+	// moq-lite-05 always reads it. There is no catchable failure, so Safari never gets WebTransport.
+	// Matches Safari-style WebKit: reports "safari" but is not Chrome or an Android WebView, which
+	// also carry it. This also catches every iOS browser, since they are all WebKit.
+	//
+	// This rule must agree with `detectSafari` in `@moq/hang`'s `util/hacks.ts`, which the support
+	// matrix uses to report the transport this function actually picks. The two cannot share code:
+	// `@moq/hang` depends on `@moq/net`, and `pickTransport` is internal. The shared test corpus in
+	// `transport.test.ts` and `hacks.test.ts` is what catches a drift.
+	if (ua.includes("safari") && !ua.includes("chrome") && !ua.includes("android")) return "websocket";
+
+	return hasWebTransport ? "webtransport" : "websocket";
+}

--- a/js/publish/src/support/element.ts
+++ b/js/publish/src/support/element.ts
@@ -1,9 +1,7 @@
+import * as Util from "@moq/hang/util";
 import { Effect, Signal } from "@moq/signals";
 import * as DOM from "@moq/signals/dom";
 import { type Codec, type Full, isSupported, type Partial } from "./";
-
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1967793
-const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
 
 const OBSERVED = ["show", "details"] as const;
 type Observed = (typeof OBSERVED)[number];
@@ -202,7 +200,11 @@ export default class MoqPublishSupport extends HTMLElement {
 
 		const binary = (value: boolean | undefined) => (value ? "🟢 Yes" : "🔴 No");
 		const hardware = (codec: Codec | undefined) =>
-			codec?.hardware ? "🟢 Hardware" : codec?.software ? `🟡 Software${isFirefox ? "*" : ""}` : "🔴 No";
+			codec?.hardware
+				? "🟢 Hardware"
+				: codec?.software
+					? `🟡 Software${Util.Hacks.isFirefox ? "*" : ""}`
+					: "🔴 No";
 		const partial = (value: Partial | undefined) =>
 			value === "full" ? "🟢 Full" : value === "partial" ? "🟡 Polyfill" : "🔴 None";
 
@@ -254,7 +256,7 @@ export default class MoqPublishSupport extends HTMLElement {
 		addRow("", "VP9", hardware(support.video.encoding?.vp9));
 		addRow("", "VP8", hardware(support.video.encoding?.vp8));
 
-		if (isFirefox) {
+		if (Util.Hacks.isFirefox) {
 			const noteDiv = DOM.create(
 				"div",
 				{

--- a/js/publish/src/support/index.ts
+++ b/js/publish/src/support/index.ts
@@ -1,5 +1,4 @@
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1967793
-const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
+import * as Util from "@moq/hang/util";
 
 export type Partial = "full" | "partial" | "none";
 
@@ -73,7 +72,7 @@ async function videoEncoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 		hardwareAcceleration: "prefer-hardware",
 	});
 
-	const unknown = isFirefox || hardware.config?.hardwareAcceleration !== "prefer-hardware";
+	const unknown = Util.Hacks.isFirefox || hardware.config?.hardwareAcceleration !== "prefer-hardware";
 
 	return {
 		hardware: unknown ? undefined : hardware.supported === true,
@@ -83,9 +82,11 @@ async function videoEncoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 
 export async function isSupported(): Promise<Full> {
 	return {
-		// Firefox's WebTransport drops server-initiated bidi streams, so we force the
-		// WebSocket fallback. Report "partial" to surface the degraded path in UI.
-		webtransport: typeof WebTransport !== "undefined" ? (isFirefox ? "partial" : "full") : "partial",
+		// Firefox drops server-initiated bidi streams, and reading datagrams kills the session on
+		// Safari, so both are forced onto the WebSocket fallback even though they define
+		// `WebTransport`. Report "partial" to surface the degraded path in UI.
+		webtransport:
+			typeof WebTransport !== "undefined" && !Util.Hacks.isFirefox && !Util.Hacks.isSafari ? "full" : "partial",
 		audio: {
 			capture: typeof AudioWorkletNode !== "undefined",
 			encoding: {

--- a/js/watch/src/support/index.ts
+++ b/js/watch/src/support/index.ts
@@ -1,5 +1,4 @@
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1967793
-const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
+import * as Util from "@moq/hang/util";
 
 export type Partial = "full" | "partial" | "none";
 
@@ -69,7 +68,7 @@ async function videoDecoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 	});
 
 	// We can't reliably detect hardware encoding on Firefox: https://github.com/w3c/webcodecs/issues/896
-	const unknown = isFirefox || hardware.config?.hardwareAcceleration !== "prefer-hardware";
+	const unknown = Util.Hacks.isFirefox || hardware.config?.hardwareAcceleration !== "prefer-hardware";
 
 	return {
 		hardware: unknown ? undefined : hardware.supported === true,
@@ -79,9 +78,11 @@ async function videoDecoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 
 export async function isSupported(): Promise<Full> {
 	return {
-		// Firefox's WebTransport drops server-initiated bidi streams, so we force the
-		// WebSocket fallback. Report "partial" to surface the degraded path in UI.
-		webtransport: typeof WebTransport !== "undefined" ? (isFirefox ? "partial" : "full") : "partial",
+		// Firefox drops server-initiated bidi streams, and reading datagrams kills the session on
+		// Safari, so both are forced onto the WebSocket fallback even though they define
+		// `WebTransport`. Report "partial" to surface the degraded path in UI.
+		webtransport:
+			typeof WebTransport !== "undefined" && !Util.Hacks.isFirefox && !Util.Hacks.isSafari ? "full" : "partial",
 		audio: {
 			decoding: {
 				aac: await audioDecoderSupported("aac"),


### PR DESCRIPTION
Split out of #2163.

**Safari cannot use WebTransport here at all.** Reading `WebTransport.datagrams.readable` tears down the whole session on Safari, and moq-lite-05 always reads it once the negotiated version carries datagrams. There is no catchable failure and no way to opt out per-session, so a Safari client that wins the WebTransport race is simply dead. Route Safari onto the qmux WebSocket fallback, exactly the way Firefox already is.

The rule lives in a pure `pickTransport(userAgent, hasWebTransport)` rather than another inline boolean in `connect.ts`, because "is this WebKit" is genuinely subtle and now has a test matrix:
- iOS Chrome (`CriOS`) and iOS Firefox (`FxiOS`) are WebKit under the hood and must be routed like Safari, even though one says "Chrome" and the other never says "Firefox".
- Desktop Chrome and Android WebViews also carry `safari` in the UA and must **not** match.
- The legacy Android stock browser says `safari` and never says `chrome`, which is the only agent that exercises the `android` clause.

`@moq/hang` needs the same predicate for its support matrix but cannot import net's internal `pickTransport` (`@moq/hang` depends on `@moq/net`), so `detectSafari` is its twin. The two share a user-agent corpus, so a drift between them fails a test in **both** packages. While doing that I noticed `js/hang` had no `test` script at all, so its suite had never run under `just js test`; it does now.

Both support matrices report `webtransport: "partial"` on Safari and Firefox to surface the degraded path. A consequence worth knowing: Safari has no `getStats()`, so there is no congestion-controller bandwidth estimate and the encoder does not adapt its bitrate downward (same as Firefox today).

**Public API changes:** `@moq/hang` gains `Util.Hacks.isSafari` and `detectSafari` (additive). `pickTransport` is internal (not re-exported). **No breaking changes.** Exposing the negotiated transport on `Established` is deliberately split into a separate PR so it can be judged on its own.

**Test plan:** `bun test js/net/src/connection/transport.test.ts js/hang/src/util/hacks.test.ts`: 9 tests over the shared UA corpus. `just js check` green. Verified on device: Safari connects and plays over the WebSocket fallback instead of dying on session setup.

