### PR TITLE
fix(publish): stop audio capture on mute, publishing silence in its place

### DIFF
--- a/doc/lib/js/@moq/publish.md
+++ b/doc/lib/js/@moq/publish.md
@@ -67,7 +67,7 @@ a real bundler (the examples below).
 - `url` (required) - Relay server URL
 - `name` (required) - Broadcast name
 - `source` - Input to capture: `"camera"`, `"screen"`, or `"file"`
-- `muted` - Mute audio capture (boolean)
+- `muted` - Stop capturing audio and publish silence in its place (a microphone is released and the OS recording indicator turns off; screen or file audio is detached); the audio track stays in the catalog so viewers don't rebuild (boolean)
 - `invisible` - Disable video capture (boolean)
 - `simulcast` - Also publish a lower-resolution `video/sd` rendition (a fraction of the source resolution) alongside `video/hd` (boolean)
 - `preview` - What the preview renders: `"source"` (default), `"encoded"`, or `"none"` to disable it (see [Preview element](#preview-element))

--- a/doc/lib/js/env/web.md
+++ b/doc/lib/js/env/web.md
@@ -54,7 +54,7 @@ Publish camera/microphone or screen as a MoQ broadcast.
 - `url` (required) - Relay server URL
 - `name` (required) - Broadcast name
 - `source` - "camera", "screen", or "file"
-- `muted` - Disable audio capture (boolean)
+- `muted` - Stop capturing audio and publish silence in its place (a microphone is released and the OS recording indicator turns off; screen or file audio is detached); the audio track stays in the catalog so viewers don't rebuild (boolean)
 - `invisible` - Disable video capture (boolean)
 - `simulcast` - Also publish a lower-resolution `video/sd` rendition (a fraction of the source resolution) alongside `video/hd` (boolean)
 

--- a/js/publish/README.md
+++ b/js/publish/README.md
@@ -69,7 +69,7 @@ The simplest way to publish a stream:
 | `url`       | string  | required | Relay server URL                |
 | `name`      | string  | required | Broadcast name                  |
 | `source`    | string  | —        | `"camera"`, `"screen"`, `"file"` |
-| `muted`     | boolean | false    | Mute audio capture              |
+| `muted`     | boolean | false    | Stop audio capture and publish silence (a mic is released, OS indicator off); track stays in the catalog |
 | `invisible` | boolean | false    | Disable video capture           |
 | `preview`   | string  | `"source"` | What the preview renders: `"source"`, `"encoded"`, `"none"` |
 | `announce`  | string  | `"source"` | When to publish: `"always"`, `"never"`, `"source"` (once a source is selected) |

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -17,9 +17,6 @@ const AAC_FRAME_SAMPLES = 1024; // AAC-LC encodes a fixed 1024 samples per frame
 // The WebCodecs/MP4 codec string for AAC-LC. "aac" is our user-facing shorthand.
 const AAC_CODEC = "mp4a.40.2";
 
-// Compiled and inlined as a blob URL via vite-plugin-worklet.
-import CaptureWorklet from "./capture-worklet.ts?worklet";
-
 // Selects the audio codec and its encoder settings. Either the bare codec name (all defaults) or an
 // object with the mime plus tuning knobs.
 export type Codec = Opus | Aac;
@@ -70,6 +67,11 @@ export type EncoderProps = {
 // channel count (which can differ from the requested count on some platforms, e.g. Safari/macOS).
 type Captured = { sampleRate: number; channelCount: number };
 
+// The capture format derived from the live source: the AudioContext rate, the worklet channel count,
+// and the audio kind. Persisted across a mute so the pipeline (context + worklet + catalog) survives
+// the audio source being released, publishing silence instead of dropping the audio track.
+type Format = { sampleRate: number; channelCount: number; kind: Kind };
+
 export class Encoder {
 	static readonly TRACK = "audio/data";
 	static readonly PRIORITY = Catalog.PRIORITY.audio;
@@ -90,6 +92,10 @@ export class Encoder {
 	// Observed capture format. #config (and thus #catalog) is derived from this plus the codec, so the
 	// worklet handlers only ever write here, never read-modify-write #config.
 	#captured = new Signal<Captured | undefined>(undefined);
+
+	// The capture format derived from the live source, persisted so a mute (which clears `source`)
+	// leaves it intact and #runPipeline keeps the AudioContext + worklet + catalog up. See #runFormat.
+	#format = new Signal<Format | undefined>(undefined);
 
 	#config = new Signal<Catalog.AudioConfig | undefined>(undefined);
 	readonly config: Getter<Catalog.AudioConfig | undefined> = this.#config;
@@ -112,13 +118,18 @@ export class Encoder {
 		this.channelCount = Signal.from<number | undefined>(props?.channelCount);
 		this.codec = Signal.from<Codec>(props?.codec ?? "opus");
 
+		this.#signals.run(this.#runFormat.bind(this));
+		this.#signals.run(this.#runPipeline.bind(this));
 		this.#signals.run(this.#runSource.bind(this));
 		this.#signals.run(this.#runGain.bind(this));
 		this.#signals.run(this.#runConfig.bind(this));
 		this.#signals.run(this.#runCatalog.bind(this));
 	}
 
-	#runSource(effect: Effect): void {
+	// Derive the capture format from the live source and persist it. NOT effect.set: a mute clears
+	// `source`, and we deliberately keep the last format so #runPipeline holds the AudioContext,
+	// worklet, and catalog up while the audio source is detached. Only a real change rebuilds.
+	#runFormat(effect: Effect): void {
 		const values = effect.getAll([this.enabled, this.source]);
 		if (!values) return;
 		const [_, rawSource] = values;
@@ -131,49 +142,73 @@ export class Encoder {
 		// macOS misreports a mono mic as stereo: getSettings().channelCount is undefined and
 		// MediaStreamAudioSourceNode.channelCount defaults to 2, so the graph carries (and Opus
 		// encodes) duplicated mono as stereo. Prefer an explicitly requested channel count, from
-		// the prop or the track's applied getUserMedia constraint, and force the worklet to mix to it.
-		const requestedChannels = effect.get(this.channelCount) ?? requestedChannelCount(source.track);
+		// the prop or the track's applied getUserMedia constraint; fall back to the settings count,
+		// then 2 (the source-node default). The worklet is pinned to this fixed count so it stays
+		// stable when the source detaches on mute and only the mono silence source drives the graph.
+		const channelCount =
+			effect.get(this.channelCount) ?? requestedChannelCount(source.track) ?? settings.channelCount ?? 2;
+
+		// Signal.set's deep-equality dedupe drops a rebuilt-but-identical format, so codec knob
+		// tweaks that rerun this effect never tear down the AudioContext.
+		this.#format.set({ sampleRate, channelCount, kind: source.kind });
+	}
+
+	// Build and hold the capture pipeline (AudioContext -> GainNode -> capture worklet) from the
+	// persisted #format. It outlives a mute, so the catalog never flaps. A silent ConstantSourceNode
+	// keeps the 0-output worklet pulled while no mic is attached, so it keeps emitting silence frames.
+	#runPipeline(effect: Effect): void {
+		const enabled = effect.get(this.enabled);
+		const format = effect.get(this.#format);
+		if (!enabled || !format) return;
 
 		const context = new AudioContext({
 			latencyHint: "interactive",
-			sampleRate,
+			sampleRate: format.sampleRate,
 		});
 		effect.cleanup(() => context.close());
-
-		const root = new MediaStreamAudioSourceNode(context, {
-			mediaStream: new MediaStream([source.track]),
-		});
-		effect.cleanup(() => root.disconnect());
 
 		const gain = new GainNode(context, {
 			gain: this.volume.peek(),
 		});
-		root.connect(gain);
 		effect.cleanup(() => gain.disconnect());
+
+		// A muted broadcast detaches its audio source (see element.ts), so nothing else drives the graph.
+		// This always-running silent source keeps the 0-output worklet processing so it keeps emitting
+		// silence frames on the same clock; without it the worklet would stop and the catalog flap. Its
+		// mono zeros up-mix to the worklet's fixed channel count, so a muted broadcast is true silence.
+		const silence = new ConstantSourceNode(context, { offset: 0 });
+		silence.connect(gain);
+		silence.start();
+		effect.cleanup(() => {
+			silence.stop();
+			silence.disconnect();
+		});
 
 		// Async because we need to wait for the worklet to be registered.
 		effect.spawn(async () => {
-			await context.audioWorklet.addModule(CaptureWorklet);
+			// Load lazily (compiled and inlined as a blob URL via vite-plugin-worklet). A static
+			// import would pull the ?worklet module into the eager graph, which breaks non-Vite
+			// loaders like `bun test` that lack the plugin.
+			const { default: captureWorklet } = await import("./capture-worklet.ts?worklet");
+			await context.audioWorklet.addModule(captureWorklet);
 			if (context.state === "closed") return;
 
-			const channelCount = requestedChannels ?? settings.channelCount ?? root.channelCount;
 			const worklet = new AudioWorkletNode(context, "capture", {
 				numberOfInputs: 1,
 				numberOfOutputs: 0,
-				channelCount,
-				// "explicit" forces Web Audio to (down)mix the input to channelCount before the
-				// worklet sees it. The default "max" just follows the input, which is the unreliable
-				// path on macOS. Only force it when we actually have a requested count to honor.
-				channelCountMode: requestedChannels !== undefined ? "explicit" : "max",
+				channelCount: format.channelCount,
+				// "explicit" pins the count so it can't drift when the source detaches on mute and only the
+				// mono silence source drives the graph; the worklet (down)mixes every input to it.
+				channelCountMode: "explicit",
 				// Stamp audio against the same wall clock as video (see video/polyfill.ts), so both
-				// tracks share an epoch and stay in sync.
+				// tracks share an epoch. Fixed once per pipeline, so the epoch survives a mute/unmute.
 				processorOptions: { zero: performance.now() * 1000 },
 			});
 
 			effect.set(this.#worklet, worklet);
 
-			// The information about channels count can be unreliable on different platforms (Apple's Safari).
-			// Try to get the first audio frame and only then record the captured format.
+			// The channel count can be unreliable across platforms (Apple's Safari). Record the captured
+			// format from the first frame the worklet emits (silence or mic, both at the fixed count).
 			effect.event(
 				worklet.port,
 				"message",
@@ -197,6 +232,23 @@ export class Encoder {
 			// Only set the gain after the worklet is registered.
 			effect.set(this.#gain, gain);
 		});
+	}
+
+	// Attach the live source track to the pipeline gain. Keyed on `source` alone: a mute clears it and
+	// this effect tears the source node down, leaving the silent keep-alive to drive the worklet.
+	// Unmuting re-attaches the source (re-acquiring the mic when there is one) and reconnects here,
+	// all on the same AudioContext (no catalog flap).
+	#runSource(effect: Effect): void {
+		const rawSource = effect.get(this.source);
+		const gain = effect.get(this.#gain);
+		if (!rawSource || !gain) return;
+
+		const track = normalizeSource(rawSource).track;
+		const root = new MediaStreamAudioSourceNode(gain.context as AudioContext, {
+			mediaStream: new MediaStream([track]),
+		});
+		root.connect(gain);
+		effect.cleanup(() => root.disconnect());
 	}
 
 	#createConfig(captured: Captured, codec: OpusConfig | AacConfig): Catalog.AudioConfig {
@@ -304,15 +356,20 @@ export class Encoder {
 					track.close(err);
 				},
 			});
-			effect.cleanup(() => encoder.close());
+			// Guard against double-close: a fatal error auto-closes the encoder, and close() on a closed
+			// encoder throws InvalidStateError, aborting the signals dispose loop and leaking the sibling effects.
+			effect.cleanup(() => {
+				if (encoder.state !== "closed") encoder.close();
+			});
 
 			let config: Catalog.AudioConfig | undefined;
 			effect.run((effect: Effect) => {
 				config = effect.get(this.#config);
 				if (!config) return;
 
-				const source = effect.get(this.source);
-				const kind: Kind = source ? normalizeSource(source).kind : "auto";
+				// Read the persisted format's kind, not `source`: a mute clears `source` but must not
+				// reconfigure the encoder (voice -> auto would drop DTX) while it publishes silence.
+				const kind: Kind = effect.get(this.#format)?.kind ?? "auto";
 				const encoderConfig = toEncoderConfig(config, kind, this.#opusOptions(effect));
 
 				console.debug("encoding audio", encoderConfig);

--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -45,10 +45,18 @@ export default class MoqPublish extends HTMLElement {
 	audio = new Signal<Source.Microphone | Source.Screen | undefined>(undefined);
 	file = new Signal<Source.File | undefined>(undefined);
 
-	// The inverse of the `muted` and `invisible` signals.
+	// Whether the audio/video encoder pipelines run. #audioEnabled stays true across `muted`; see
+	// #micEnabled below for why (the encoder keeps publishing silence, the audio input is what's gated).
 	#videoEnabled: Signal<boolean>;
 	#audioEnabled: Signal<boolean>;
 	#eitherEnabled: Signal<boolean>;
+
+	// Whether the microphone should actually capture: audio enabled AND not muted. Muting stops audio
+	// capture without dropping the published track: a mic track is stopped (releasing the OS device and
+	// its recording indicator), while screen/file audio, whose track can't be stopped without killing
+	// the share, is detached in the source branches instead. The encoder pipeline stays up and publishes
+	// silence, so watchers keep their audio subtree instead of rebuilding it.
+	#micEnabled: Signal<boolean>;
 
 	// Set when `simulcast` is enabled and video is not `invisible`.
 	#sdEnabled: Signal<boolean>;
@@ -71,10 +79,12 @@ export default class MoqPublish extends HTMLElement {
 		});
 		this.signals.cleanup(() => this.connection.close());
 
-		// The inverse of the `muted` and `invisible` signals.
 		// TODO make this.signals.computed to simplify the code.
 		this.#videoEnabled = new Signal(false);
-		this.#audioEnabled = new Signal(false);
+		// Always on; muting gates the audio input (see #micEnabled and the screen/file source
+		// branches), not the pipeline.
+		this.#audioEnabled = new Signal(true);
+		this.#micEnabled = new Signal(false);
 		this.#eitherEnabled = new Signal(false);
 		this.#sdEnabled = new Signal(false);
 
@@ -83,7 +93,7 @@ export default class MoqPublish extends HTMLElement {
 			const invisible = effect.get(this.state.invisible);
 			const simulcast = effect.get(this.state.simulcast);
 			this.#videoEnabled.set(!invisible);
-			this.#audioEnabled.set(!muted);
+			this.#micEnabled.set(effect.get(this.#audioEnabled) && !muted);
 			this.#eitherEnabled.set(!muted || !invisible);
 			this.#sdEnabled.set(simulcast && !invisible);
 		});
@@ -108,6 +118,9 @@ export default class MoqPublish extends HTMLElement {
 
 			audio: {
 				enabled: this.#audioEnabled,
+				// Muting stops audio capture (see #micEnabled); this fades the encoder gain to zero in step,
+				// so any in-flight samples during the teardown are silenced and unmute fades back in.
+				muted: this.state.muted,
 			},
 			video: {
 				hd: {
@@ -232,16 +245,16 @@ export default class MoqPublish extends HTMLElement {
 		if (!source) return;
 
 		if (source === "camera") {
+			// These proxies are scoped to this run so they close before the capture below, which would
+			// otherwise clear its `source` signal and let a stale proxy write over the next source.
 			const video = new Source.Camera({ enabled: this.#videoEnabled });
-			this.signals.run((effect) => {
-				const source = effect.get(video.source);
-				this.broadcast.video.source.set(source);
+			effect.run((effect) => {
+				effect.set(this.broadcast.video.source, effect.get(video.source));
 			});
 
-			const audio = new Source.Microphone({ enabled: this.#audioEnabled });
-			this.signals.run((effect) => {
-				const source = effect.get(audio.source);
-				this.broadcast.audio.source.set(source);
+			const audio = new Source.Microphone({ enabled: this.#micEnabled });
+			effect.run((effect) => {
+				effect.set(this.broadcast.audio.source, effect.get(audio.source));
 			});
 
 			effect.set(this.video, video);
@@ -260,12 +273,15 @@ export default class MoqPublish extends HTMLElement {
 				enabled: this.#eitherEnabled,
 			});
 
-			this.signals.run((effect) => {
+			effect.run((effect) => {
 				const source = effect.get(screen.source);
 				if (!source) return;
 
+				// The shared screen track can't be stopped without killing video (and re-prompting), so
+				// mute detaches its audio from the encoder instead. The pipeline keeps publishing silence.
+				const muted = effect.get(this.state.muted);
 				effect.set(this.broadcast.video.source, source.video);
-				effect.set(this.broadcast.audio.source, source.audio);
+				effect.set(this.broadcast.audio.source, muted ? undefined : source.audio);
 			});
 
 			effect.set(this.video, screen);
@@ -293,10 +309,12 @@ export default class MoqPublish extends HTMLElement {
 
 			effect.set(this.file, fileSource);
 
-			this.signals.run((effect) => {
+			effect.run((effect) => {
 				const source = effect.get(fileSource.source);
-				this.broadcast.video.source.set(source.video);
-				this.broadcast.audio.source.set(source.audio);
+				// Mute detaches the file's audio from the encoder; the pipeline keeps publishing silence.
+				const muted = effect.get(this.state.muted);
+				effect.set(this.broadcast.video.source, source.video);
+				effect.set(this.broadcast.audio.source, muted ? undefined : source.audio);
 			});
 
 			effect.cleanup(() => {

--- a/js/publish/src/ui/components/audio-toggle.ts
+++ b/js/publish/src/ui/components/audio-toggle.ts
@@ -3,7 +3,7 @@ import type MoqPublish from "../../element";
 import { icon, micOff, microphone } from "../icons";
 import { controlButton } from "./button";
 
-/** Toggles whether audio is published (publish.muted). Red when muted. */
+/** Toggles publish.muted: stops audio capture and publishes silence in its place. Red when muted. */
 export function audioToggle(parent: Effect, publish: MoqPublish): HTMLElement {
 	const button = controlButton(microphone, "Mute");
 
@@ -12,7 +12,7 @@ export function audioToggle(parent: Effect, publish: MoqPublish): HTMLElement {
 		const muted = effect.get(publish.state.muted);
 		button.disabled = !hasSource;
 		button.classList.toggle("control--off", hasSource && muted);
-		button.title = muted ? "Unmute microphone" : "Mute microphone";
+		button.title = muted ? "Unmute audio" : "Mute audio";
 		button.setAttribute("aria-label", button.title);
 		button.replaceChildren(icon(muted ? micOff : microphone));
 	});


### PR DESCRIPTION
Split out of #2163.

**Muting used to tear the whole audio pipeline down.** It stopped the mic track, closed the `AudioContext`, the worklet and the `AudioEncoder`, closed the audio track producer, and cascaded the catalog to drop the audio section entirely. Two consequences: every watcher had to rebuild its audio subtree (AudioContext + worklet + ring buffer) on every mute *and* unmute, and the resulting head-of-line contention on the shared WebSocket **froze the video** for a moment. Muting your mic should not stutter your video for everyone watching.

Mute now gates the audio **input**, not the pipeline. Per source:
- A **microphone** track is stopped outright, so the OS releases the device and the recording indicator goes off. That is the entire point of a mute, and the previous soft-mute-by-gain approach (which I tried first) fails it: the mic stays live and the indicator stays lit while the UI claims you are muted.
- **Screen and file** audio is detached from the encoder instead, because stopping a share track would kill the share itself and force a re-prompt.

A silent `ConstantSourceNode` keeps the worklet pulled while no input is attached, so the encoder keeps publishing true silence on the same clock and the catalog never changes shape. Selecting a source while muted never touches the microphone at all; unmuting acquires it.

Also scopes the four source-proxy effects to the child effect rather than the root, so switching source tears its proxies down in order instead of leaking a root-scoped writer over the next source.

**Public API changes:** none. `muted` keeps its type and name; its *behavior* changes as described (documented in the README and `/doc`).

**Test plan:** `just js check` green. The behavior was proven end-to-end with an ad hoc headless-Chrome run (fake media device via CDP; not a committed test, the repo has no browser-test harness) against the fork's integrated branch, whose `js/` tree is byte-identical to these split PRs combined:
- selecting a source while muted performs **zero** `getUserMedia` calls;
- every mute **ends** the mic track (`readyState: "ended"`);
- the audio catalog stays present and shape-identical across mute cycles;
- exactly **one** AudioContext spans the whole cycle, proving the pipeline survives the mute.

