### PR TITLE
fix(watch): survive a video decoder error instead of going dark

### DIFF
--- a/doc/lib/js/@moq/watch.md
+++ b/doc/lib/js/@moq/watch.md
@@ -246,7 +246,7 @@ The component exposes everything via its `broadcast` property
 
 ## UI Overlay
 
-Import `@moq/watch/ui` for a Web Component overlay with buffering indicator, stats panel, and playback controls:
+Import `@moq/watch/ui` for a Web Component overlay with buffering indicator, an unsupported-codec indicator, stats panel, and playback controls:
 
 ```html
 <script type="module">

--- a/js/watch/README.md
+++ b/js/watch/README.md
@@ -109,7 +109,7 @@ watch.video.media.subscribe((stream) => {
 
 ## UI Web Component
 
-`@moq/watch` includes a Web Component UI overlay (`<moq-watch-ui>`) with playback controls, volume, buffering indicator, quality selector, and stats panel. It is built on top of `@moq/signals` with no framework dependency.
+`@moq/watch` includes a Web Component UI overlay (`<moq-watch-ui>`) with playback controls, volume, buffering indicator, an unsupported-codec indicator, quality selector, and stats panel. It is built on top of `@moq/signals` with no framework dependency.
 
 ```html
 <script type="module">

--- a/js/watch/src/sync.ts
+++ b/js/watch/src/sync.ts
@@ -253,7 +253,10 @@ export class Sync {
 	async wait(timestamp: Time.Milli): Promise<void> {
 		const reference = this.#output.reference.peek();
 		if (reference === undefined) {
-			throw new Error("reference not set; call update() first");
+			// No reference yet (bootstrap, or a frame slipped in during a reset -> re-anchor window):
+			// render immediately instead of throwing an uncaught rejection into a decode output callback.
+			// received() re-anchors from this frame. Matches the in-loop currentRef-undefined path below.
+			return;
 		}
 
 		for (;;) {

--- a/js/watch/src/ui/components/buffering-indicator.ts
+++ b/js/watch/src/ui/components/buffering-indicator.ts
@@ -11,7 +11,9 @@ export function bufferingIndicator(parent: Effect, watch: MoqWatch): HTMLElement
 	parent.run((effect) => {
 		const buffering = effect.get(watch.backend.video.output.stalled);
 		const offline = effect.get(watch.broadcast.output.status) === "offline";
-		container.style.display = buffering && !offline ? "" : "none";
+		// Don't spin when no rendition is decodable: the unsupported-codec notice shows instead.
+		const unsupported = effect.get(watch.backend.video.source.output.unsupported);
+		container.style.display = buffering && !offline && !unsupported ? "" : "none";
 	});
 
 	return container;

--- a/js/watch/src/ui/components/unsupported-indicator.ts
+++ b/js/watch/src/ui/components/unsupported-indicator.ts
@@ -1,0 +1,36 @@
+import type { Effect } from "@moq/signals";
+import type MoqWatch from "../../element";
+
+/**
+ * Shows a notice when the catalog has video renditions but this browser/hardware can decode none of
+ * them, so the viewer sees the cause instead of an indefinite buffering spinner. Codec support is
+ * hardware-dependent, so this can appear on one machine and not another for the same broadcast.
+ */
+export function unsupportedIndicator(parent: Effect, watch: MoqWatch): HTMLElement {
+	const container = document.createElement("div");
+	container.className = "watch-ui__unsupported-indicator";
+	container.setAttribute("role", "status");
+	container.setAttribute("aria-live", "polite");
+
+	const text = document.createElement("span");
+	text.className = "watch-ui__unsupported-text";
+	container.appendChild(text);
+
+	parent.run((effect) => {
+		const unsupported = effect.get(watch.backend.video.source.output.unsupported);
+		const offline = effect.get(watch.broadcast.output.status) === "offline";
+		const show = unsupported && !offline;
+		container.style.display = show ? "" : "none";
+		if (!show) return;
+
+		// Name the codec(s) so the cause is obvious (e.g. an HEVC-only publisher seen from a browser
+		// without HEVC decode).
+		const renditions = effect.get(watch.backend.video.source.output.catalog)?.renditions ?? {};
+		const codecs = [...new Set(Object.values(renditions).map((r) => r.codec))].join(", ");
+		text.textContent = codecs
+			? `This video codec isn't supported by your browser: ${codecs}`
+			: "This video codec isn't supported by your browser";
+	});
+
+	return container;
+}

--- a/js/watch/src/ui/element.ts
+++ b/js/watch/src/ui/element.ts
@@ -6,6 +6,7 @@ import { centerPlay } from "./components/center-play";
 import { controlBar } from "./components/control-bar";
 import { offlineIndicator } from "./components/offline-indicator";
 import { settingsPanel } from "./components/settings-panel";
+import { unsupportedIndicator } from "./components/unsupported-indicator";
 import type { Tab, UiState } from "./state";
 import styles from "./styles/index.css?inline";
 
@@ -64,9 +65,14 @@ export default class MoqWatchUi extends HTMLElement {
 		// The slotted <moq-watch> (canvas/video) sits at the base of the stack.
 		player.appendChild(DOM.create("slot"));
 
-		// Center affordances: play prompt + buffering spinner + offline notice.
+		// Center affordances: play prompt + buffering spinner + offline / unsupported-codec notice.
 		const center = DOM.create("div", { className: "center" });
-		center.append(centerPlay(effect, watch), bufferingIndicator(effect, watch), offlineIndicator(effect, watch));
+		center.append(
+			centerPlay(effect, watch),
+			bufferingIndicator(effect, watch),
+			offlineIndicator(effect, watch),
+			unsupportedIndicator(effect, watch),
+		);
 
 		// Top scrim keeps the bottom bar legible and hosts ambient gradient.
 		const scrimTop = DOM.create("div", { className: "scrim scrim--top" });

--- a/js/watch/src/ui/styles/index.css
+++ b/js/watch/src/ui/styles/index.css
@@ -5,3 +5,4 @@
 @import "./buffer-control.css";
 @import "./buffering-indicator.css";
 @import "./offline-indicator.css";
+@import "./unsupported-indicator.css";

--- a/js/watch/src/ui/styles/unsupported-indicator.css
+++ b/js/watch/src/ui/styles/unsupported-indicator.css
@@ -1,0 +1,29 @@
+.watch-ui__unsupported-indicator {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	max-width: 80%;
+	padding: 0.75rem 1.25rem;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	text-align: center;
+	background-color: rgba(0, 0, 0, 0.8);
+	z-index: 4;
+	pointer-events: auto;
+	border-radius: 0.25rem;
+}
+
+.watch-ui__unsupported-text {
+	font-size: 0.875rem;
+	font-weight: 600;
+	color: #ffffff;
+	line-height: 1.4;
+}
+
+@media (max-width: 480px) {
+	.watch-ui__unsupported-text {
+		font-size: 0.75rem;
+	}
+}

--- a/js/watch/src/video/decoder.test.ts
+++ b/js/watch/src/video/decoder.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { configSuperseded } from "./decoder";
+
+const base = { codec: "avc1.640028", container: { kind: "legacy" as const }, description: undefined };
+
+describe("configSuperseded", () => {
+	it("is false for the same config", () => {
+		expect(configSuperseded(base, base)).toBe(false);
+	});
+
+	it("is false for a deep-equal but different object (the Signal.set identity trap)", () => {
+		expect(configSuperseded({ ...base, container: { kind: "legacy" } }, base)).toBe(false);
+	});
+
+	it("is true on a codec change", () => {
+		expect(configSuperseded({ ...base, codec: "vp8" }, base)).toBe(true);
+	});
+
+	it("is true on a container-kind change", () => {
+		expect(configSuperseded({ ...base, container: { kind: "loc" } }, base)).toBe(true);
+	});
+
+	it("is true on a description change", () => {
+		expect(configSuperseded({ ...base, description: "0164" }, base)).toBe(true);
+	});
+
+	it("is false when there is no current config (nothing to supersede yet)", () => {
+		expect(configSuperseded(undefined, base)).toBe(false);
+	});
+});

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -115,6 +115,8 @@ export class Decoder implements Backend {
 			broadcast: active,
 			track,
 			config,
+			sourceTrack: this.source.output.track,
+			sourceConfig: this.source.output.config,
 			stats: this.#output.stats,
 		});
 
@@ -220,8 +222,51 @@ interface DecoderTrackProps {
 	broadcast: Moq.Broadcast.Consumer;
 	track: string;
 	config: Catalog.VideoConfig;
+	// Live source track/config so a running track can detect when the catalog has moved past its frozen
+	// config (a codec switch) and stop restarting against wrong-codec bytes.
+	sourceTrack: Getter<string | undefined>;
+	sourceConfig: Getter<Catalog.VideoConfig | undefined>;
 
 	stats: Signal<Stats | undefined>;
+}
+
+// Max in-place decoder rebuilds (see the DecoderTrack error callback) before giving up, so a config that
+// configures cleanly but always fails to decode can't restart-loop forever. Reset on a successful decode.
+const MAX_DECODER_RESTARTS = 5;
+
+// When a restart errors again within RESTART_RAPID_MS, the fresh subscription immediately hit the same
+// wrong-codec bytes (a codec switch whose catalog update still lags the media track). Back off ~one group
+// before the next retry so the budget spans the lag window instead of burning out in a sub-second storm.
+const RESTART_RAPID_MS = 300;
+const RESTART_BACKOFF_MS = 500;
+
+// Cap the encoded frames queued in the hardware decoder. Steady-state live playback keeps the queue near
+// zero (frames arrive network-paced); only a subscribe/restart catch-up burst (up to a full GoP, ~120
+// frames at 1080p60) exceeds this, and an unbounded burst can overwhelm hardware decoders at high
+// resolutions. Backpressure, not dropping: frame order and count are untouched, only the catch-up is paced.
+const MAX_DECODE_QUEUE = 32;
+
+// Wait until the decoder's queue drops back to the cap (or the effect tears down). Resolves promptly on
+// each `dequeue`; the timer is a fallback for a browser that doesn't fire it (it is spec'd and shipped
+// everywhere, but don't hang the decode loop on that). Each wait fully unregisters its own listeners and
+// timer so a sustained-overload stream (e.g. 4K the decoder can't keep up with) doesn't accumulate them.
+async function drainDecodeQueue(decoder: VideoDecoder, effect: Effect): Promise<void> {
+	const signal = effect.abort; // pin the run's signal; the getter is replaced on every re-run
+	while (decoder.state === "configured" && decoder.decodeQueueSize > MAX_DECODE_QUEUE) {
+		if (signal.aborted) return; // torn down
+		await new Promise<void>((resolve) => {
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const done = () => {
+				if (timer !== undefined) clearTimeout(timer);
+				decoder.removeEventListener("dequeue", done);
+				signal.removeEventListener("abort", done);
+				resolve();
+			};
+			decoder.addEventListener("dequeue", done, { once: true });
+			signal.addEventListener("abort", done, { once: true });
+			timer = setTimeout(done, 50);
+		});
+	}
 }
 
 class DecoderTrack {
@@ -232,6 +277,9 @@ class DecoderTrack {
 	stats: Signal<Stats | undefined>;
 
 	timestamp = new Signal<Time.Milli | undefined>(undefined);
+	// The last decoded frame, held ACROSS #restart re-runs: a restart rebuilds the subscription + decoder
+	// but must NOT clear this, or the renderer paints black between restarts. Only a real track promotion
+	// or close (DecoderTrack.close) clears it.
 	frame = new Signal<VideoFrame | undefined>(undefined);
 
 	// Network jitter + decode buffer.
@@ -244,6 +292,19 @@ class DecoderTrack {
 	// so in-flight decodes from before a rewind can be dropped on output.
 	#discontinuity = 0;
 
+	// Live source track/config, so #superseded can tell when the catalog has moved past this track's
+	// frozen config (a codec switch) and a replacement DecoderTrack is already on the way.
+	#sourceTrack: Getter<string | undefined>;
+	#sourceConfig: Getter<Catalog.VideoConfig | undefined>;
+
+	// Bumped by the decoder's error callback to rebuild the decoder in place (re-run #run) instead of
+	// permanently closing the track. Capped by #restartCount (reset on a successful decode) so a config
+	// that configures cleanly but always fails to decode can't loop forever.
+	#restart = new Signal(0);
+	#restartCount = 0;
+	// performance.now() of the last restart, to detect rapid repeats (a config mismatch, not a transient).
+	#lastRestart = 0;
+
 	signals = new Effect();
 
 	constructor(props: DecoderTrackProps) {
@@ -254,12 +315,22 @@ class DecoderTrack {
 		this.broadcast = props.broadcast;
 		this.track = props.track;
 		this.config = requiredConfig;
+		this.#sourceTrack = props.sourceTrack;
+		this.#sourceConfig = props.sourceConfig;
 		this.stats = props.stats;
 
 		this.signals.run(this.#run.bind(this));
 	}
 
 	#run(effect: Effect): void {
+		// Re-run (rebuild subscription + decoder) when the error callback bumps #restart.
+		const restarted = effect.get(this.#restart) > 0;
+
+		// A restart re-run whose config the catalog has already moved past would only re-decode wrong-codec
+		// bytes until the replacement DecoderTrack promotes. Idle instead, holding the last frame. Never on
+		// the first run (restarted === false), which must always proceed.
+		if (restarted && this.#superseded()) return;
+
 		const sub = this.broadcast.track(this.track).subscribe({ priority: Catalog.PRIORITY.video });
 		effect.cleanup(() => sub.close());
 
@@ -294,6 +365,9 @@ class DecoderTrack {
 
 					this.timestamp.set(timestamp);
 
+					// A frame rendered, so the decoder is healthy: reset the restart budget.
+					this.#restartCount = 0;
+
 					// Trim the decode buffer as frames are rendered
 					this.#trimBuffered(timestamp);
 
@@ -307,8 +381,43 @@ class DecoderTrack {
 			},
 			// TODO bubble up error
 			error: (error) => {
-				console.error(error);
-				effect.close();
+				// Rebuild the decoder in place rather than permanently closing the track. WebCodecs has
+				// already closed the decoder here, so recovery needs a fresh one via a #run re-run.
+
+				// If the catalog has moved past this config (a codec switch whose media bytes arrived before
+				// the catalog update), a replacement DecoderTrack is already coming. Stop restarting instead
+				// of storming resubscribes against stale wrong-codec bytes, and don't burn the budget on them.
+				if (this.#superseded()) {
+					console.debug("video decoder error; config superseded, awaiting replacement", error);
+					return;
+				}
+
+				if (this.#restartCount >= MAX_DECODER_RESTARTS) {
+					console.error("video decoder error; restart budget exhausted", error);
+					effect.close();
+					return;
+				}
+
+				// Rapid repeat = the fresh subscription hit the same wrong-codec bytes (catalog lag after a
+				// codec switch). Back off ~one group so the budget spans the lag window instead of a
+				// sub-second storm; an isolated (transient) error still restarts immediately. "rapid" is
+				// measured against when the restart is DISPATCHED (stamped in `restart` below), not the error
+				// time, so a backed-off restart doesn't reset the interval and oscillate immediate/backoff.
+				const rapid = performance.now() - this.#lastRestart < RESTART_RAPID_MS;
+
+				this.#restartCount++;
+				// First restart warns; subsequent ones are debug so a routine codec switch doesn't spam.
+				if (this.#restartCount === 1) console.warn("video decoder error; restarting", error);
+				else console.debug("video decoder error; restarting", error);
+
+				const restart = () => {
+					// Re-check after the backoff timer: the catalog may have landed during the wait.
+					if (this.#superseded()) return;
+					this.#lastRestart = performance.now();
+					this.#restart.update((n) => n + 1);
+				};
+				if (rapid) effect.timer(restart, RESTART_BACKOFF_MS);
+				else restart();
 			},
 		});
 		effect.cleanup(() => {
@@ -317,13 +426,22 @@ class DecoderTrack {
 
 		// Input processing - depends on container type
 		if (this.config.container.kind === "cmaf") {
-			this.#runCmaf(effect, sub, decoder);
+			this.#runCmaf(effect, sub, decoder, restarted);
 		} else {
-			this.#runLegacy(effect, sub, decoder);
+			this.#runLegacy(effect, sub, decoder, restarted);
 		}
 	}
 
-	#runLegacy(effect: Effect, sub: Moq.Track.Subscriber, decoder: VideoDecoder): void {
+	// True when the catalog has moved past this track's frozen config: the Source is already building a
+	// replacement DecoderTrack, so restarting this one would only re-decode wrong-codec bytes until the
+	// replacement promotes. Compares by track name and config fields, never object identity (Signal.set
+	// stores a deep-equal object without notifying, so peek() can return a new-but-equal object).
+	#superseded(): boolean {
+		if (this.#sourceTrack.peek() !== this.track) return true;
+		return configSuperseded(this.#sourceConfig.peek(), this.config);
+	}
+
+	#runLegacy(effect: Effect, sub: Moq.Track.Subscriber, decoder: VideoDecoder, restarted: boolean): void {
 		const format =
 			this.config.container.kind === "loc" ? new Container.Loc.Format() : new Container.Legacy.Format();
 		// Create consumer that reorders groups/frames up to the provided latency.
@@ -349,6 +467,10 @@ class DecoderTrack {
 		});
 
 		let previous: { timestamp: Time.Micro; group: number; final: boolean } | undefined;
+		// A restarted run must not feed deltas before its first keyframe. Normally a no-op: a fresh
+		// subscribe delivers the live group from frame 0 (forced keyframe), so this clears immediately;
+		// it only bites the group-head-eviction / mid-group-start edge.
+		let resyncing = restarted;
 
 		effect.spawn(async () => {
 			for (;;) {
@@ -356,7 +478,10 @@ class DecoderTrack {
 				if (!next) break;
 
 				// Publisher rewound: flush queued/in-flight video and re-anchor before decoding.
-				if (this.#onDiscontinuity(next.discontinuity)) previous = undefined;
+				if (this.#onDiscontinuity(next.discontinuity)) {
+					previous = undefined;
+					resyncing = false;
+				}
 
 				const { frame, group } = next;
 
@@ -366,6 +491,13 @@ class DecoderTrack {
 					}
 					// The group is done
 					continue;
+				}
+
+				// While resyncing after a decode error, wait for the next keyframe (group start) before
+				// decoding again; group index 0 is always a keyframe, so this resyncs within one group.
+				if (resyncing) {
+					if (!frame.keyframe) continue;
+					resyncing = false;
 				}
 
 				// Mark that we received this frame right now.
@@ -398,12 +530,28 @@ class DecoderTrack {
 					final: false,
 				};
 
-				decoder.decode(chunk);
+				if (decoder.decodeQueueSize > MAX_DECODE_QUEUE) await drainDecodeQueue(decoder, effect);
+				if (decoder.state === "closed") break;
+				try {
+					decoder.decode(chunk);
+				} catch (err) {
+					// Wrong-codec bytes (e.g. a mid-stream codec switch landing on the tail of the old
+					// codec's group) make decode() throw DataError synchronously. Skip to the next keyframe
+					// group and resync there instead of letting this spawn die and freezing until the next
+					// catalog round-trip. Any other error (closed/invalid state) stops the loop.
+					if (err instanceof DOMException && err.name === "DataError") {
+						console.debug("video decode error; resyncing at next keyframe", err);
+						resyncing = true;
+						previous = undefined;
+					} else {
+						break;
+					}
+				}
 			}
 		});
 	}
 
-	#runCmaf(effect: Effect, sub: Moq.Track.Subscriber, decoder: VideoDecoder): void {
+	#runCmaf(effect: Effect, sub: Moq.Track.Subscriber, decoder: VideoDecoder, restarted: boolean): void {
 		if (this.config.container.kind !== "cmaf") return;
 
 		const initSegment = base64ToBytes(this.config.container.init);
@@ -433,6 +581,10 @@ class DecoderTrack {
 		});
 
 		let previous: { timestamp: Time.Micro; group: number; final: boolean } | undefined;
+		// A restarted run must not feed deltas before its first keyframe. Normally a no-op: a fresh
+		// subscribe delivers the live group from frame 0 (forced keyframe), so this clears immediately;
+		// it only bites the group-head-eviction / mid-group-start edge.
+		let resyncing = restarted;
 
 		effect.spawn(async () => {
 			for (;;) {
@@ -440,7 +592,10 @@ class DecoderTrack {
 				if (!next) break;
 
 				// Publisher rewound: flush queued/in-flight video and re-anchor before decoding.
-				if (this.#onDiscontinuity(next.discontinuity)) previous = undefined;
+				if (this.#onDiscontinuity(next.discontinuity)) {
+					previous = undefined;
+					resyncing = false;
+				}
 
 				const { frame, group } = next;
 
@@ -449,6 +604,13 @@ class DecoderTrack {
 						previous.final = true;
 					}
 					continue;
+				}
+
+				// While resyncing after a decode error, wait for the next keyframe (group start) before
+				// decoding again; group index 0 is always a keyframe, so this resyncs within one group.
+				if (resyncing) {
+					if (!frame.keyframe) continue;
+					resyncing = false;
 				}
 
 				// Mark that we received this frame right now.
@@ -475,14 +637,26 @@ class DecoderTrack {
 					final: false,
 				};
 
+				if (decoder.decodeQueueSize > MAX_DECODE_QUEUE) await drainDecodeQueue(decoder, effect);
 				if (decoder.state === "closed") break;
-				decoder.decode(
-					new EncodedVideoChunk({
-						type: frame.keyframe ? "key" : "delta",
-						data: frame.data,
-						timestamp: frame.timestamp,
-					}),
-				);
+				try {
+					decoder.decode(
+						new EncodedVideoChunk({
+							type: frame.keyframe ? "key" : "delta",
+							data: frame.data,
+							timestamp: frame.timestamp,
+						}),
+					);
+				} catch (err) {
+					// See #runLegacy: skip to the next keyframe on a wrong-codec DataError instead of dying.
+					if (err instanceof DOMException && err.name === "DataError") {
+						console.debug("video decode error; resyncing at next keyframe", err);
+						resyncing = true;
+						previous = undefined;
+					} else {
+						break;
+					}
+				}
 			}
 		});
 	}
@@ -543,6 +717,23 @@ class DecoderTrack {
 			return undefined;
 		});
 	}
+}
+
+/**
+ * Whether a live catalog config has diverged from the one a decoder was frozen with, in a way that needs
+ * a new decoder (codec, container kind, or codec description). Compared by value, never object identity,
+ * because Signal.set stores a deep-equal object without notifying. Exported for unit tests.
+ */
+export function configSuperseded(
+	current: Pick<Catalog.VideoConfig, "codec" | "container" | "description"> | undefined,
+	frozen: Pick<Catalog.VideoConfig, "codec" | "container" | "description">,
+): boolean {
+	if (!current) return false;
+	return (
+		current.codec !== frozen.codec ||
+		current.container.kind !== frozen.container.kind ||
+		current.description !== frozen.description
+	);
 }
 
 async function supported(config: Catalog.VideoConfig): Promise<boolean> {

--- a/js/watch/src/video/index.ts
+++ b/js/watch/src/video/index.ts
@@ -1,5 +1,5 @@
 export type * from "./backend";
-export * from "./decoder";
+export { Decoder } from "./decoder";
 export * from "./mse";
 export * from "./renderer";
 export * from "./source";

--- a/js/watch/src/video/source.ts
+++ b/js/watch/src/video/source.ts
@@ -39,6 +39,12 @@ type SourceOutput = {
 	catalog: Signal<Catalog.Video | undefined>;
 	available: Signal<Record<string, Catalog.VideoConfig>>;
 
+	// True once we've probed the catalog's renditions and this browser/hardware can decode none of
+	// them. Distinct from "still probing" (both leave `available` empty), so the UI can show an
+	// "unsupported codec" notice instead of an indefinite spinner. Expected on some hardware, since
+	// codec support varies, so it is not necessarily a bug.
+	unsupported: Signal<boolean>;
+
 	// The name of the active rendition.
 	track: Signal<string | undefined>;
 	config: Signal<Catalog.VideoConfig | undefined>;
@@ -209,6 +215,7 @@ export class Source {
 	readonly #output: SourceOutput = {
 		catalog: new Signal<Catalog.Video | undefined>(undefined),
 		available: new Signal<Record<string, Catalog.VideoConfig>>({}),
+		unsupported: new Signal<boolean>(false),
 		track: new Signal<string | undefined>(undefined),
 		config: new Signal<Catalog.VideoConfig | undefined>(undefined),
 		jitter: new Signal<Moq.Time.Milli | undefined>(undefined),
@@ -245,18 +252,46 @@ export class Source {
 
 		const renditions = effect.get(this.#output.catalog)?.renditions ?? {};
 
+		// Drop renditions whose codec/container no longer match BEFORE the async probe: #config only
+		// updates after `supported()` resolves, so a publisher codec switch in that window would decode
+		// the new stream under the old config. A description-only change is NOT pruned: description is a
+		// decoder-reload field handled by the normal reconfigure, and pruning would yank HD down to SD on
+		// a benign description republish. Still-matching renditions keep their identical value (a no-op set).
+		const stillValid: Record<string, Catalog.VideoConfig> = {};
+		for (const [name, cfg] of Object.entries(this.#output.available.peek())) {
+			const next = renditions[name];
+			if (next && next.codec === cfg.codec && next.container?.kind === cfg.container?.kind) {
+				stillValid[name] = cfg;
+			}
+		}
+		this.#output.available.set(stillValid);
+
 		effect.spawn(async () => {
 			const available: Record<string, Catalog.VideoConfig> = {};
 
 			for (const [name, config] of Object.entries(renditions)) {
-				const isSupported = await supported(config);
+				// supported() can THROW (malformed description hex, or a codec string that makes
+				// isConfigSupported reject). A throw must not abort the loop: that would drop every rendition
+				// (including decodable ones) and leave #unsupported/#available unset, so the unsupported
+				// indicator never shows and the viewer spins forever. Treat a throw as unsupported.
+				let isSupported = false;
+				try {
+					isSupported = await supported(config);
+				} catch (err) {
+					console.warn(
+						`[Source] video rendition ${name} (${config.codec}) probe threw; treating as unsupported`,
+						err,
+					);
+				}
 				if (isSupported) available[name] = config;
 			}
 
-			if (Object.keys(available).length === 0 && Object.keys(renditions).length > 0) {
+			const unsupported = Object.keys(available).length === 0 && Object.keys(renditions).length > 0;
+			if (unsupported) {
 				console.warn("[Source] No supported video renditions found:", renditions);
 			}
 
+			this.#output.unsupported.set(unsupported);
 			this.#output.available.set(available);
 		});
 	}


### PR DESCRIPTION
Split out of #2163.

**A video decoder error was fatal.** The track stayed subscribed but nothing decoded again, so the canvas simply froze until the viewer reloaded the page. Restart the decoder in place on a budget instead, and once that budget is spent report offline rather than pretending to play a frozen frame.

Three details that make the restart actually work:
- **Keyframe resync on `DataError`.** The usual cause is a group that begins mid-GOP after a reset, so replaying it into a fresh decoder just errors again. Wait for the next keyframe.
- **Config supersession.** A restart racing a codec/rendition switch would otherwise resurrect the *old* config and decode the new stream with it. The restart checks it is still the current config before applying.
- **A decode-queue cap.** A decoder that falls behind (a tab throttled in the background, a slow software path) otherwise accumulates an unbounded queue of frames it can never catch up on, and surfaces minutes late.

Also adds an **unsupported-codec indicator**: when the catalog advertises renditions but none of them decode in this browser, the player previously looked identical to "buffering forever", which is a miserable thing to debug.

**Public API changes:** `@moq/watch` gains `Video.Source.output.unsupported` (additive).

**Test plan:** `bun test js/watch/src/video/decoder.test.ts`: 6 tests pinning the config-supersession check. The restart budget and keyframe resync have no committed tests (bun ships no WebCodecs `VideoDecoder`, so they need a real browser); they were exercised manually. `just js check` green. Verified in the demo by forcing a decoder error mid-playback: the canvas recovers instead of freezing.

