### PR TITLE
fix(watch): recover from a reset catalog and a same-name republish

### DIFF
--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -60,6 +60,14 @@ export class Reload {
 	/** The set of broadcast paths currently announced by the server, updated reactively. */
 	readonly announced: Getter<Set<Path.Valid>> = this.#announced;
 
+	// Per-path announce generation, bumped every time a path is (re-)announced. Lets a consumer notice
+	// that the SAME name was re-announced by a NEW publisher instance even when the unannounce+announce
+	// coalesce so the presence Set never observably flips. Monotonic per connection (reset on reconnect).
+	#announcedGen = new Signal<Map<Path.Valid, number>>(new Map());
+
+	/** Per-path announce generation; bumps on every (re-)announce. Pairs with {@link Reload.announced}. */
+	readonly announcedGenerations: Getter<ReadonlyMap<Path.Valid, number>> = this.#announcedGen;
+
 	/** WebTransport options applied to each connection attempt (not reactive). */
 	webtransport?: WebTransportProps;
 
@@ -162,11 +170,15 @@ export class Reload {
 
 	#runAnnounced(effect: Effect): void {
 		this.#announced.set(new Set());
+		this.#announcedGen.set(new Map());
 
 		const conn = effect.get(this.established);
 		if (!conn) return;
 
-		effect.cleanup(() => this.#announced.set(new Set()));
+		effect.cleanup(() => {
+			this.#announced.set(new Set());
+			this.#announcedGen.set(new Map());
+		});
 
 		// Cloudflare's relay does not yet support SUBSCRIBE_NAMESPACE, so
 		// skip announce subscriptions entirely for those hosts.
@@ -190,9 +202,20 @@ export class Reload {
 							active.delete(entry.path);
 						}
 					});
+
+					// Never delete on unannounce: resetting a path back to 1 would make a coalesced republish
+					// look unchanged (1 -> 1), leaving the watcher bound to the dead route. The map therefore
+					// grows by one entry per distinct path ever announced (an accepted tradeoff), freed only
+					// by the reconnect reset above.
+					if (entry.active) {
+						this.#announcedGen.mutate((gens) => {
+							gens.set(entry.path, (gens.get(entry.path) ?? 0) + 1);
+						});
+					}
 				}
 			} catch (err) {
 				this.#announced.set(new Set());
+				this.#announcedGen.set(new Map());
 				throw err;
 			}
 		});

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -3,7 +3,7 @@ import type * as broadcast from "../broadcast.ts";
 import type * as group from "../group.ts";
 import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
-import { error } from "../util/error.ts";
+import { error, isStreamAbort } from "../util/error.ts";
 import type { Session } from "./adapter.ts";
 import { Frame, Group as GroupMessage } from "./object.ts";
 import { PublishDone } from "./publish.ts";
@@ -196,7 +196,10 @@ export class Publisher {
 			stream.close();
 		} catch (err: unknown) {
 			const e = error(err);
-			console.warn(`publish error: broadcast=${name} track=${track.name} error=${e.message}`);
+			// A downstream unsubscribe/handover aborts the stream; that is expected teardown, not a fault.
+			console[isStreamAbort(e) ? "debug" : "warn"](
+				`publish error: broadcast=${name} track=${track.name} error=${e.message}`,
+			);
 			stream.abort(e);
 		} finally {
 			track.close();

--- a/js/net/src/index.ts
+++ b/js/net/src/index.ts
@@ -23,5 +23,7 @@ export * as Path from "./path.ts";
 export * as Time from "./time.ts";
 /** Track role handles. */
 export * as Track from "./track.ts";
+/** Classify an error as a routine stream teardown vs a client-actionable fault (for log-level decisions). */
+export { isStreamAbort } from "./util/error.ts";
 /** QUIC variable-length integer encoding and decoding. */
 export * as Varint from "./varint.ts";

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -6,6 +6,7 @@ import type { Established } from "../connection/established.ts";
 import * as Path from "../path.ts";
 import { type Reader, Readers, Stream, Writer } from "../stream.ts";
 import type * as Time from "../time.ts";
+import { isStreamAbort } from "../util/error.ts";
 import { AnnounceRequest } from "./announce.ts";
 import { Fetch } from "./fetch.ts";
 import { Goaway } from "./goaway.ts";
@@ -150,7 +151,9 @@ export class Connection implements Established {
 		try {
 			await Promise.all(tasks);
 		} catch (err) {
-			console.error("fatal error running connection", err);
+			// Routine teardown (unsubscribe, handover, peer close) rejects the same way a fault does;
+			// isStreamAbort tells them apart from the error content, same as every other run-loop catch.
+			console[isStreamAbort(err) ? "debug" : "error"]("connection run loop stopped", err);
 		} finally {
 			this.close();
 		}

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -5,7 +5,7 @@ import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
 import { Timescale } from "../time.ts";
 import type * as track from "../track.ts";
-import { error } from "../util/error.ts";
+import { error, isStreamAbort } from "../util/error.ts";
 import { AnnounceInit, AnnounceOk, type AnnounceRequest, encodeAnnounceBroadcast } from "./announce.ts";
 import { Datagram as DatagramMessage } from "./datagram.ts";
 import type { Fetch } from "./fetch.ts";
@@ -307,7 +307,10 @@ export class Publisher {
 			await datagrams;
 		} catch (err: unknown) {
 			const e = error(err);
-			console.warn(`publish error: broadcast=${msg.broadcast} track=${track.name} error=${e.message}`);
+			// A downstream unsubscribe/handover aborts the stream; that is expected teardown, not a fault.
+			console[isStreamAbort(e) ? "debug" : "warn"](
+				`publish error: broadcast=${msg.broadcast} track=${track.name} error=${e.message}`,
+			);
 			track.close(e);
 			stream.abort(e);
 			await datagrams;
@@ -394,7 +397,10 @@ export class Publisher {
 			stream.close();
 		} catch (err: unknown) {
 			const e = error(err);
-			console.warn(`publish error: broadcast=${broadcast} track=${track.name} error=${e.message}`);
+			// A downstream unsubscribe/handover resets the stream; that is expected teardown, not a fault.
+			console[isStreamAbort(e) ? "debug" : "warn"](
+				`publish error: broadcast=${broadcast} track=${track.name} error=${e.message}`,
+			);
 			track.close(e);
 			stream.reset(e);
 		}
@@ -603,7 +609,9 @@ export class Publisher {
 				}
 			}
 		} catch (err: unknown) {
-			console.warn("probe stream error", err);
+			// Best-effort bandwidth side channel: a reset on reconnect/teardown is routine, but a real
+			// fault (auth, protocol, unroutable) must still surface.
+			console[isStreamAbort(err) ? "debug" : "warn"]("probe stream error", err);
 			stream.close();
 		}
 	}

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -8,7 +8,7 @@ import * as Path from "../path.ts";
 import { type Reader, Stream } from "../stream.ts";
 import * as Time from "../time.ts";
 import type * as track from "../track.ts";
-import { error } from "../util/error.ts";
+import { error, isStreamAbort } from "../util/error.ts";
 import { withTimeout } from "../util/timeout.ts";
 import { AnnounceInit, AnnounceOk, AnnounceRequest, decodeAnnounceBroadcastMaybe } from "./announce.ts";
 import { Datagram as DatagramMessage } from "./datagram.ts";
@@ -326,7 +326,11 @@ export class Subscriber {
 			const e = error(err);
 			request.reject(e);
 			this.#subscribes.delete(id);
-			console.warn(`subscribe error: id=${id} broadcast=${broadcast} track=${request.name} error=${e.message}`);
+			// A publisher handover/unsubscribe (or session close) resets the stream during setup; that is
+			// expected teardown, not a fault. A timeout is not a stream abort, so it still logs at warn.
+			console[isStreamAbort(e) ? "debug" : "warn"](
+				`subscribe error: id=${id} broadcast=${broadcast} track=${request.name} error=${e.message}`,
+			);
 			// If the stream eventually opens after the timeout, abort it so we
 			// don't leak it. Cover both branches: setup may resolve late, or it
 			// may reject (e.g. encode/decode failure) after the stream is open.
@@ -365,7 +369,10 @@ export class Subscriber {
 		} catch (err) {
 			const e = error(err);
 			producer.close(e);
-			console.warn(`subscribe error: id=${id} broadcast=${broadcast} track=${request.name} error=${e.message}`);
+			// A publisher handover/unsubscribe resets the stream; that is expected teardown, not a fault.
+			console[isStreamAbort(e) ? "debug" : "warn"](
+				`subscribe error: id=${id} broadcast=${broadcast} track=${request.name} error=${e.message}`,
+			);
 			stream.abort(e);
 		} finally {
 			this.#subscribes.delete(id);
@@ -708,7 +715,8 @@ export class Subscriber {
 				reader.releaseLock();
 			}
 		} catch (err: unknown) {
-			console.warn("datagram stream error", err);
+			// Best-effort loop: a deliberate session close resets this stream on every teardown.
+			console[isStreamAbort(err) ? "debug" : "warn"]("datagram stream error", err);
 		}
 	}
 
@@ -778,7 +786,9 @@ export class Subscriber {
 				}
 			}
 		} catch (err: unknown) {
-			console.warn("probe stream error", err);
+			// Best-effort bandwidth/RTT side channel: a reset on reconnect/teardown just means no estimate
+			// right now, but a real fault (auth, protocol, unroutable) must still surface.
+			console[isStreamAbort(err) ? "debug" : "warn"]("probe stream error", err);
 		} finally {
 			this.#recvBandwidth.set(undefined);
 			this.#rtt?.set(undefined);

--- a/js/net/src/util/error.test.ts
+++ b/js/net/src/util/error.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test";
+import { isStreamAbort } from "./error.ts";
+
+// A stand-in for WebTransportError, which the test runner does not define. isStreamAbort keys on
+// `err.name` + duck-typed `source`/`streamErrorCode`, so this reproduces what the browser passes.
+function wtError(source: string, streamErrorCode?: number | null): Error {
+	const err = new Error("The stream was aborted by the remote server.");
+	err.name = "WebTransportError";
+	return Object.assign(err, { source, streamErrorCode });
+}
+
+// A stand-in for the DOMException Safari throws when a stream is used after it ended.
+function invalidState(message: string): Error {
+	const err = new Error(message);
+	err.name = "InvalidStateError";
+	return err;
+}
+
+test("routine stream resets (Cancel/Dropped/Closed/no-code) are teardown", () => {
+	// Native WebTransport (streamErrorCode carries the relay's rs/moq-net error.rs code).
+	expect(isStreamAbort(wtError("stream", 0))).toBe(true); // Cancel: normal unsubscribe
+	expect(isStreamAbort(wtError("stream", 24))).toBe(true); // Dropped
+	expect(isStreamAbort(wtError("stream", 25))).toBe(true); // Closed
+	expect(isStreamAbort(wtError("stream", null))).toBe(true); // reset with no app code -> routine
+	// WebSocket/qmux fallback ("RESET_STREAM: <code>" / "STOP_SENDING: <code>").
+	expect(isStreamAbort(new Error("RESET_STREAM: 0"))).toBe(true);
+	expect(isStreamAbort(new Error("STOP_SENDING: 0"))).toBe(true);
+});
+
+test("client-actionable fault codes surface (warn), not teardown", () => {
+	expect(isStreamAbort(wtError("stream", 6))).toBe(false); // Unauthorized
+	expect(isStreamAbort(wtError("stream", 13))).toBe(false); // NotFound (wrong path)
+	expect(isStreamAbort(wtError("stream", 15))).toBe(false); // ProtocolViolation
+	expect(isStreamAbort(wtError("stream", 30))).toBe(false); // Unroutable
+	expect(isStreamAbort(new Error("RESET_STREAM: 13"))).toBe(false); // NotFound over qmux
+	expect(isStreamAbort(new Error("STOP_SENDING: 6"))).toBe(false); // Unauthorized over qmux
+});
+
+test("write-after-close over the WebSocket/qmux fallback is teardown", () => {
+	// Generic Streams-API errors from writing after the stream ended (a peer reset racing an in-flight
+	// write). Chromium/Firefox and Safari word it differently; both are routine teardown, not faults.
+	expect(isStreamAbort(new Error("The stream is closed or closing"))).toBe(true);
+	expect(isStreamAbort(invalidState("The object is in an invalid state."))).toBe(true);
+});
+
+test("a session close is teardown, unless the peer signalled a fault", () => {
+	// The exact strings qmux constructs when the session ends (see @moq/qmux session.js).
+	expect(isStreamAbort(new Error("Connection closed"))).toBe(true); // local close()
+	expect(isStreamAbort(new Error("Connection closed: 0: "))).toBe(true); // peer CONNECTION_CLOSE, no error
+	expect(isStreamAbort(new Error("Connection closed: 1006 "))).toBe(true); // abnormal WebSocket closure
+
+	// A client-actionable code on the CONNECTION_CLOSE frame still surfaces.
+	expect(isStreamAbort(new Error("Connection closed: 6: unauthorized"))).toBe(false); // Unauthorized
+	expect(isStreamAbort(new Error("Connection closed: 15: bad frame"))).toBe(false); // ProtocolViolation
+});
+
+test("a coded fault wins over the teardown message heuristics", () => {
+	// A fault code must not be reclassified as teardown just because the browser's prose happens to
+	// mention a closing stream.
+	const err = wtError("stream", 6); // Unauthorized
+	err.message = "The stream is closed or closing";
+	expect(isStreamAbort(err)).toBe(false);
+});
+
+test("an unrelated error mentioning an invalid state still surfaces", () => {
+	// Keyed on `name`, so one of our own ordering bugs is not silently downgraded to debug.
+	expect(isStreamAbort(new Error("decoder is in an invalid state"))).toBe(false);
+});
+
+test("non-WebTransport errors are surfaced", () => {
+	expect(isStreamAbort(new Error("first subscribe response must be SUBSCRIBE_OK"))).toBe(false);
+	expect(isStreamAbort("not an error")).toBe(false);
+	expect(isStreamAbort(undefined)).toBe(false);
+});
+
+test("WebTransport errors are classified by code regardless of source", () => {
+	// Chrome surfaces a write-side abort (a downstream unsubscribe seen by the publisher) as a
+	// WebTransportError with source "session" and the relay's Cancel(0) code: routine, must not warn.
+	expect(isStreamAbort(wtError("session", 0))).toBe(true);
+	expect(isStreamAbort(wtError("session", null))).toBe(true);
+	// A genuine session-level fault code still surfaces.
+	expect(isStreamAbort(wtError("session", 6))).toBe(false); // Unauthorized
+});

--- a/js/net/src/util/error.ts
+++ b/js/net/src/util/error.ts
@@ -3,6 +3,69 @@ export function error(err: unknown): Error {
 	return err instanceof Error ? err : new Error(String(err));
 }
 
+// Stream-reset application codes that indicate a client-actionable FAULT (bad auth, wrong path, protocol
+// violation, unroutable, ...) rather than a routine teardown. Mirrors rs/moq-net/src/error.rs
+// `Error::to_code()`. Kept as a DENYLIST: any code NOT listed (Cancel=0, Timeout=3, Transport=4,
+// Dropped=24, Closed=25, ...) is treated as an expected teardown, so a normal unsubscribe/handover reset
+// stays quiet whatever code it carries, while a genuine failure surfaces.
+const STREAM_FAULT_CODES = new Set<number>([
+	6, // Unauthorized
+	9, // Version
+	11, // BoundsExceeded
+	12, // Duplicate
+	13, // NotFound
+	14, // WrongSize
+	15, // ProtocolViolation
+	16, // UnexpectedMessage
+	17, // Unsupported
+	27, // FrameTooLarge
+	30, // Unroutable
+]);
+
+/**
+ * True when `err` is a stream-lifecycle event a caller can log at debug rather than warn: false for a
+ * client-actionable fault (see STREAM_FAULT_CODES) or a non-stream error.
+ *
+ * Reads the application code the relay encodes (rs/moq-net `error.rs`): `WebTransportError.streamErrorCode`
+ * on native transports, or the trailing number in qmux's "RESET_STREAM: <code>" / "STOP_SENDING: <code>"
+ * message on the WebSocket fallback. Keyed on `err.name` rather than `instanceof WebTransportError` so it
+ * is safe where that global is undefined (e.g. the test runner).
+ */
+export function isStreamAbort(err: unknown): boolean {
+	if (!(err instanceof Error)) return false;
+
+	// Coded stream resets decide first: a client-actionable fault code always wins over the message
+	// heuristics below.
+	if (err.name === "WebTransportError") {
+		// Trust the relay's numeric app code regardless of `source`: Chrome reports a WRITE-side abort
+		// (a downstream unsubscribe seen by the publisher) as source "session", not "stream", so gating on
+		// source would leave that routine teardown warning on every closed viewer.
+		const c = (err as { streamErrorCode?: number | null }).streamErrorCode;
+		const code = typeof c === "number" ? c : undefined;
+		return code === undefined || !STREAM_FAULT_CODES.has(code);
+	}
+
+	const match = /^(?:RESET_STREAM|STOP_SENDING): (\d+)/.exec(err.message);
+	if (match) return !STREAM_FAULT_CODES.has(Number(match[1]));
+
+	// The session itself ended, which fails every stream still open on it. qmux words this
+	// "Connection closed", optionally carrying the peer's CONNECTION_CLOSE code. (Native WebTransport
+	// reports the equivalent as a WebTransportError with no `streamErrorCode`, handled above.)
+	const closed = /^Connection closed(?::\s*(\d+))?/.exec(err.message);
+	if (closed) {
+		const code = closed[1] === undefined ? undefined : Number(closed[1]);
+		return code === undefined || !STREAM_FAULT_CODES.has(code);
+	}
+
+	// A write/close after the stream already ended (a peer reset racing an in-flight write) surfaces as a
+	// generic Streams-API error rather than a coded RESET_STREAM/STOP_SENDING, common over the WebSocket/qmux
+	// fallback. Engines word it differently: Chromium/Firefox say the stream is "closed or closing"; Safari
+	// throws InvalidStateError. Key Safari on `name` rather than the prose, so an unrelated error that merely
+	// mentions an invalid state still surfaces.
+	if (err.name === "InvalidStateError") return true;
+	return /closed or closing/i.test(err.message);
+}
+
 export function unreachable(value: never): never {
 	throw new Error(`unreachable: ${value}`);
 }

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -2,7 +2,7 @@ import * as Catalog from "@moq/hang/catalog";
 import * as Json from "@moq/json";
 import * as Msf from "@moq/msf";
 import type * as Moq from "@moq/net";
-import { Path } from "@moq/net";
+import { isStreamAbort, Path } from "@moq/net";
 import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Signal } from "@moq/signals";
 
 import { toHang } from "./msf";
@@ -24,6 +24,15 @@ export function parseCatalogFormat(value: string | null): CatalogFormat | undefi
 }
 
 type Status = "offline" | "loading" | "live";
+
+// Backoff for reopening a catalog subscription whose stream ended unexpectedly: a slow-consumer reset, a
+// relay bounce, or a publisher that dropped without unannouncing. Nothing else re-runs the catalog effect
+// in that case, so without this the viewer would sit offline forever on a connection that is still up.
+// Bounded, so a broadcast that never comes back settles into "offline" instead of retrying forever.
+const CATALOG_RETRY_INITIAL_MS = 500;
+const CATALOG_RETRY_MULTIPLIER = 2;
+const CATALOG_RETRY_MAX_MS = 5000;
+const CATALOG_RETRY_ATTEMPTS = 6;
 
 // Signals the component reads. Whoever owns the backing Signal (the caller, or
 // another component whose output is wired in) does the writing.
@@ -76,14 +85,34 @@ export class Broadcast {
 	// announcement gate and subscribes immediately.
 	readonly #announced?: Getter<Set<Moq.Path.Valid>>;
 
-	// Whether `name` is currently in the announced set (or skipping the check).
-	// Derived in its own effect so that flaps for unrelated broadcasts don't
-	// retrigger the broadcast/catalog subscriptions.
-	readonly #announcedNow = new Signal(false);
+	// Per-path announce generation from the connection (optional; see the constructor props).
+	readonly #announcedGenerations?: Getter<ReadonlyMap<Moq.Path.Valid, number>>;
+
+	// The announce generation of `name`: 0 when not announced, else the connection's generation for it (or
+	// 1 when generations aren't provided). A NUMBER rather than a boolean so a same-name republish by a new
+	// publisher (generation bump) re-runs #runBroadcast and re-consumes against the new instance. Derived
+	// in its own effect so flaps for unrelated broadcasts don't retrigger the broadcast/catalog subs.
+	readonly #announcedNow = new Signal(0);
+
+	// Bumped by the retry timer to re-run #runCatalog. A reset catalog stream changes none of the signals
+	// that effect otherwise reads, so this is the only thing that can reopen the subscription.
+	readonly #catalogRetry = new Signal(0);
+
+	// Backoff state for #catalogRetry, reset on every catalog update and whenever we start reading a
+	// different broadcast (a reconnect, or a same-name republish), so each of those starts with a full budget.
+	#catalogDelay = CATALOG_RETRY_INITIAL_MS;
+	#catalogAttempts = 0;
+	#catalogSource?: Moq.Broadcast.Consumer;
 
 	signals = new Effect();
 
-	constructor(props?: Inputs<BroadcastInput> & { announced?: Getter<Set<Moq.Path.Valid>> }) {
+	constructor(
+		props?: Inputs<BroadcastInput> & {
+			announced?: Getter<Set<Moq.Path.Valid>>;
+			/** Per-path announce generations from the connection; a bump re-runs the broadcast so a same-name republish is re-consumed. Pairs with `announced`. */
+			announcedGenerations?: Getter<ReadonlyMap<Moq.Path.Valid, number>>;
+		},
+	) {
 		this.input = {
 			connection: getter(props?.connection),
 			name: getter(props?.name ?? Path.empty()),
@@ -94,6 +123,7 @@ export class Broadcast {
 		};
 
 		this.#announced = props?.announced;
+		this.#announcedGenerations = props?.announcedGenerations;
 
 		this.signals.run(this.#runAnnouncedNow.bind(this));
 		this.signals.run(this.#runBroadcast.bind(this));
@@ -102,19 +132,21 @@ export class Broadcast {
 
 	#runAnnouncedNow(effect: Effect): void {
 		const name = effect.get(this.input.name);
-		this.#announcedNow.set(this.#isPathAnnounced(effect, name));
+		this.#announcedNow.set(this.#announcedGeneration(effect, name));
 	}
 
-	// Whether `name` is currently announced on the connection (or skipping the check
-	// because reload is off, no announced set is wired in, or the relay doesn't support
-	// announcements). Used by both `#runAnnouncedNow` (for `input.name`) and
+	// The announce generation for `name`: 0 when it is not announced, otherwise a counter that bumps
+	// on every re-announce. The bump is what makes a same-name republish (a new publisher instance)
+	// re-consume, even when the unannounce+announce coalesce so the presence Set never observably
+	// flips. Returns 1 when the check is skipped (reload is off, no announced set is wired in, or the
+	// relay doesn't support announcements). Used by both `#runAnnouncedNow` (for `input.name`) and
 	// `relativeBroadcast` (for cross-broadcast refs, which reruns per rendition).
-	#isPathAnnounced(effect: Effect, name: Moq.Path.Valid): boolean {
+	#announcedGeneration(effect: Effect, name: Moq.Path.Valid): number {
 		const reload = effect.get(this.input.reload);
-		if (!reload) return true;
+		if (!reload) return 1;
 
 		// Without an announced set to consult, subscribe immediately.
-		if (!this.#announced) return true;
+		if (!this.#announced) return 1;
 
 		// Cloudflare's relay does not yet support announcement subscriptions,
 		// so default to subscribing immediately instead of waiting forever. This runs in a
@@ -126,11 +158,14 @@ export class Broadcast {
 				warnedNoDiscovery.add(conn);
 				console.warn("Cloudflare relay does not support broadcast discovery yet; ignoring reload signal.");
 			}
-			return true;
+			return 1;
 		}
 
 		const announced = effect.get(this.#announced);
-		return announced.has(name);
+		if (!announced.has(name)) return 0;
+
+		const gen = this.#announcedGenerations ? effect.get(this.#announcedGenerations).get(name) : undefined;
+		return gen ?? 1;
 	}
 
 	#runBroadcast(effect: Effect): void {
@@ -150,8 +185,16 @@ export class Broadcast {
 	}
 
 	#runCatalog(effect: Effect): void {
+		// The retry timer bumps this to reopen a subscription that ended; see the tail of the spawn below.
+		effect.get(this.#catalogRetry);
+
+		// Every bail-out below reports offline. A retry leaves the status at "loading" while it waits, so a
+		// rerun that finds nothing left to subscribe to has to settle it, or the tile spins forever.
 		const enabled = effect.get(this.input.enabled);
-		if (!enabled) return;
+		if (!enabled) {
+			this.#output.status.set("offline");
+			return;
+		}
 
 		const catalogFormat = effect.get(this.input.catalogFormat);
 		const name = effect.get(this.input.name);
@@ -169,7 +212,24 @@ export class Broadcast {
 		}
 
 		const broadcast = effect.get(this.output.active);
-		if (!broadcast) return;
+		if (!broadcast) {
+			this.#output.status.set("offline");
+			return;
+		}
+
+		// A retry can land after the broadcast itself closed (the session dropped, or the publisher went
+		// away). Subscribing to a closed broadcast throws, and #runBroadcast will replace `output.active`
+		// once it observes the same thing, so stop here.
+		if (broadcast.closedSignal.peek()) {
+			this.#output.status.set("offline");
+			return;
+		}
+
+		// Reading a different broadcast is a fresh start, not a continuation of the previous failures.
+		if (this.#catalogSource !== broadcast) {
+			this.#catalogSource = broadcast;
+			this.#resetCatalogBackoff();
+		}
 
 		this.#output.status.set("loading");
 
@@ -194,6 +254,11 @@ export class Broadcast {
 		}
 
 		effect.spawn(async () => {
+			// Pin this run's signal: the getter is swapped for a fresh one the moment a rerun starts, and
+			// a rerun starts before it awaits this spawn.
+			const abort = effect.abort;
+
+			let failure: unknown;
 			try {
 				for (;;) {
 					const update = await Promise.race([effect.cancel, fetchNext()]);
@@ -201,16 +266,50 @@ export class Broadcast {
 
 					console.debug("received catalog", format, this.input.name.peek(), update);
 
+					this.#resetCatalogBackoff();
 					this.#output.catalog.set(update);
 					this.#output.status.set("live");
 				}
 			} catch (err) {
-				console.warn("error fetching catalog", this.input.name.peek(), err);
-			} finally {
-				this.#output.catalog.set(undefined);
-				this.#output.status.set("offline");
+				failure = err;
+				// A routine transport reset during a publisher handover is expected; a real fetch/parse
+				// failure (auth, not-found, protocol, or schema validation) still warns.
+				console[isStreamAbort(err) ? "debug" : "warn"]("error fetching catalog", this.input.name.peek(), err);
 			}
+
+			this.#output.catalog.set(undefined);
+
+			// Torn down (disabled, renamed, reconnected, or closed). Whatever replaces this run owns the
+			// status from here, and arming a timer now would leak it into that run.
+			if (abort.aborted) {
+				this.#output.status.set("offline");
+				return;
+			}
+
+			// Only a stream reset is worth retrying: the subscription was killed under us (a slow-consumer
+			// drop, a relay bounce, a publisher handover) while the broadcast is still announced on a live
+			// connection, and nothing else would ever reopen it. A clean end means the publisher stopped,
+			// and a coded fault (auth, not-found, protocol, unroutable) fails identically every time, so
+			// both report offline straight away rather than stalling the badge behind a retry ladder.
+			const reset = failure !== undefined && isStreamAbort(failure);
+			if (!reset || this.#catalogAttempts >= CATALOG_RETRY_ATTEMPTS) {
+				this.#output.status.set("offline");
+				return;
+			}
+
+			// The timer is registered on the effect, so a rerun (handover, reconnect, close) cancels it
+			// instead of racing a second subscription against it.
+			this.#catalogAttempts += 1;
+			this.#output.status.set("loading");
+
+			effect.timer(() => this.#catalogRetry.update((n) => n + 1), this.#catalogDelay);
+			this.#catalogDelay = Math.min(this.#catalogDelay * CATALOG_RETRY_MULTIPLIER, CATALOG_RETRY_MAX_MS);
 		});
+	}
+
+	#resetCatalogBackoff(): void {
+		this.#catalogDelay = CATALOG_RETRY_INITIAL_MS;
+		this.#catalogAttempts = 0;
 	}
 
 	/**
@@ -240,7 +339,7 @@ export class Broadcast {
 		const conn = effect.get(this.input.connection);
 		if (!conn) return undefined;
 
-		if (!this.#isPathAnnounced(effect, resolved)) return undefined;
+		if (!this.#announcedGeneration(effect, resolved)) return undefined;
 
 		const broadcast = conn.consume(resolved);
 		effect.cleanup(() => broadcast.close());

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -105,6 +105,7 @@ export default class MoqWatch extends HTMLElement {
 		this.broadcast = new Broadcast({
 			connection: this.connection.established,
 			announced: this.connection.announced,
+			announcedGenerations: this.connection.announcedGenerations,
 			enabled: this.#enabled,
 			name: this.#name,
 			reload: this.#reload,


### PR DESCRIPTION
Split out of #2163.

> **Stacked on #2182** (it uses `isStreamAbort` to tell a stream reset apart from a real fault). The first commit belongs to that PR; **review the second commit only**. The diff collapses once #2182 merges and I rebase.

Two ways a tile could go permanently offline while the relay was perfectly healthy:

**1. A catalog subscription that ended was terminal.** `#runCatalog` subscribed once and wrote `status = "offline"` whenever its fetch loop ended. But the effect's tracked signals (`enabled`, `name`, `catalogFormat`, `active`) do not change when only the *catalog stream* resets, so the effect never re-ran and nothing ever resubscribed. Any transient reset (a slow-consumer drop, a relay bounce, a publisher handover) stranded the tile offline until a page reload.

It now reopens on a bounded backoff, but **only** when the loop ended in a stream reset. A clean end (the publisher genuinely stopped) or a coded fault still reports offline immediately, which is why this depends on the `isStreamAbort` classification rather than retrying on any error.

**2. A republish under the same name was invisible.** The announce `Set` only tracks presence, so when a publisher's unannounce and the new instance's announce coalesce, the set never observably flips and the watcher stays bound to the dead route. `Reload` now tracks a per-path announce **generation** that bumps on every (re-)announce, so a same-name republish is a real change the watcher re-consumes.

The generation map deliberately never deletes on unannounce: resetting a path to 1 would make a coalesced republish look unchanged (1 -> 1) and reintroduce the bug. It is reset on reconnect, so it grows by one entry per distinct path ever announced, which is an accepted tradeoff.

**Public API changes:** `@moq/net` gains `Reload.announcedGenerations`; `@moq/watch` gains an optional `announcedGenerations` in the `Broadcast` options bag (both additive).

**Test plan:** `just js check` green. Verified in the demo: killing and immediately restarting a publisher under the same name re-attaches the viewer, and bouncing the relay no longer strands a tile offline.
