### PR TITLE
feat(publish): Safari hardware encode, worker capture, and a stable video catalog

### DIFF
--- a/doc/lib/js/env/web.md
+++ b/doc/lib/js/env/web.md
@@ -334,7 +334,9 @@ Requires modern browser features:
 **Experimental support:**
 
 - Firefox (behind flag)
-- Safari (future support planned)
+- Safari
+
+Safari always connects over the WebSocket fallback, because reading WebTransport datagrams terminates the session. It therefore has no congestion-controller bandwidth estimate, so the encoder does not adapt its bitrate downward. Set `maxBitrate` explicitly if you need a ceiling.
 
 ## Production Deployment
 

--- a/doc/lib/js/env/web.md
+++ b/doc/lib/js/env/web.md
@@ -334,7 +334,7 @@ Requires modern browser features:
 **Experimental support:**
 
 - Firefox (behind flag)
-- Safari
+- Safari 18+ (publishing: hardware H.264/HEVC encode, Worker capture; older Safari falls back to a degraded capture that pauses while the tab is hidden). Opus audio uses the native WebCodecs codec on Safari 26+ and a WebAssembly polyfill on Safari 16.4 through 18.7, which ship no WebCodecs audio API.
 
 Safari always connects over the WebSocket fallback, because reading WebTransport datagrams terminates the session. It therefore has no congestion-controller bandwidth estimate, so the encoder does not adapt its bitrate downward. Set `maxBitrate` explicitly if you need a ceiling.
 

--- a/doc/lib/js/index.md
+++ b/doc/lib/js/index.md
@@ -165,7 +165,7 @@ Requires modern browser features:
 **Experimental support:**
 
 - Firefox (behind flag)
-- Safari
+- Safari 18+ (publishing: hardware H.264/HEVC encode, Worker capture; older Safari falls back to a degraded capture that pauses while the tab is hidden). Opus audio uses the native WebCodecs codec on Safari 26+ and a WebAssembly polyfill on Safari 16.4 through 18.7, which ship no WebCodecs audio API.
 
 Safari always connects over the WebSocket fallback, because reading WebTransport datagrams terminates the session.
 

--- a/doc/lib/js/index.md
+++ b/doc/lib/js/index.md
@@ -165,7 +165,9 @@ Requires modern browser features:
 **Experimental support:**
 
 - Firefox (behind flag)
-- Safari (future support planned)
+- Safari
+
+Safari always connects over the WebSocket fallback, because reading WebTransport datagrams terminates the session.
 
 ## Framework Integration
 

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -15,6 +15,7 @@
 	"scripts": {
 		"build": "rimraf dist && tsc -b && bun ../common/package.ts",
 		"check": "tsc --noEmit",
+		"test": "bun test --only-failures",
 		"release": "bun ../common/release.ts"
 	},
 	"dependencies": {

--- a/js/hang/src/util/hacks.test.ts
+++ b/js/hang/src/util/hacks.test.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "bun:test";
+import { detectSafari } from "./hacks.ts";
+
+// This corpus is intentionally shared with `js/net/src/connection/transport.test.ts`, which tests the
+// twin Safari rule in `pickTransport`. Adding a case here without adding it there lets the two drift.
+const UA = {
+	chrome: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+	edge: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0",
+	firefox: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0",
+	androidChrome:
+		"Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36",
+	androidWebview:
+		"Mozilla/5.0 (Linux; Android 13; Pixel 7 wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/120.0.0.0 Mobile Safari/537.36",
+	// The legacy Android stock browser. It says "safari" and "android" but never "chrome", so it is the
+	// only case that exercises the `android` clause; every other Android agent short-circuits on "chrome".
+	androidLegacy:
+		"Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; SM-G900F Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30",
+	safari17:
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15",
+	safari18:
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
+	iosSafari:
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1",
+	iosChrome:
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.6099.119 Mobile/15E148 Safari/604.1",
+	iosFirefox:
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/119.0 Mobile/15E148 Safari/605.1.15",
+	epiphany: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15",
+};
+
+test("detectSafari matches real Safari and all iOS/WebKit browsers, excludes Chrome/Edge/Firefox/Android", () => {
+	expect(detectSafari(UA.safari17)).toBe(true);
+	expect(detectSafari(UA.safari18)).toBe(true);
+	expect(detectSafari(UA.iosSafari)).toBe(true);
+	expect(detectSafari(UA.iosChrome)).toBe(true); // "CriOS" is WebKit under the hood, not Chrome
+	expect(detectSafari(UA.iosFirefox)).toBe(true); // "FxiOS" likewise, and it never says "firefox"
+	expect(detectSafari(UA.epiphany)).toBe(true); // WebKitGTK
+
+	expect(detectSafari(UA.chrome)).toBe(false); // "safari" + "chrome" -> Chrome
+	expect(detectSafari(UA.edge)).toBe(false);
+	expect(detectSafari(UA.firefox)).toBe(false);
+	expect(detectSafari(UA.androidChrome)).toBe(false); // android
+	expect(detectSafari(UA.androidWebview)).toBe(false); // android + chrome
+	// Guards the `android` clause on its own: this agent passes the "safari" and !"chrome" checks.
+	expect(detectSafari(UA.androidLegacy)).toBe(false);
+});
+
+test("the user agent is matched case-insensitively", () => {
+	expect(detectSafari(UA.safari17.toUpperCase())).toBe(true);
+	expect(detectSafari(UA.chrome.toUpperCase())).toBe(false);
+	expect(detectSafari(UA.androidWebview.toUpperCase())).toBe(false);
+});

--- a/js/hang/src/util/hacks.test.ts
+++ b/js/hang/src/util/hacks.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { detectSafari } from "./hacks.ts";
+import { detectSafari, detectSafariVersion, detectSafariWorkerCapture } from "./hacks.ts";
 
 // This corpus is intentionally shared with `js/net/src/connection/transport.test.ts`, which tests the
 // twin Safari rule in `pickTransport`. Adding a case here without adding it there lets the two drift.
@@ -21,10 +21,16 @@ const UA = {
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15",
 	iosSafari:
 		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Mobile/15E148 Safari/604.1",
+	iosSafari18:
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1",
 	iosChrome:
 		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.6099.119 Mobile/15E148 Safari/604.1",
 	iosFirefox:
 		"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/119.0 Mobile/15E148 Safari/605.1.15",
+	iosChrome18:
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/130.0.0.0 Mobile/15E148 Safari/604.1",
+	ipadChrome18:
+		"Mozilla/5.0 (iPad; CPU OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/130.0.0.0 Mobile/15E148 Safari/604.1",
 	epiphany: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15",
 };
 
@@ -49,4 +55,36 @@ test("the user agent is matched case-insensitively", () => {
 	expect(detectSafari(UA.safari17.toUpperCase())).toBe(true);
 	expect(detectSafari(UA.chrome.toUpperCase())).toBe(false);
 	expect(detectSafari(UA.androidWebview.toUpperCase())).toBe(false);
+});
+
+test("detectSafariVersion parses the major Version token, else undefined", () => {
+	expect(detectSafariVersion(UA.safari17)).toBe(17);
+	expect(detectSafariVersion(UA.safari18)).toBe(18);
+	expect(detectSafariVersion(UA.iosSafari)).toBe(17);
+	expect(detectSafariVersion(UA.epiphany)).toBe(15);
+	// No "Version/" token -> undefined (real Safari always has one; iOS Chrome does not).
+	expect(detectSafariVersion(UA.chrome)).toBeUndefined();
+	expect(detectSafariVersion(UA.iosChrome)).toBeUndefined();
+	// A word ending in "version" before the real token must not steal the match (word boundary).
+	expect(detectSafariVersion("Foo/1.0 SomeVersion/9 Version/17.0 Safari/605.1.15")).toBe(17);
+});
+
+test("detectSafariWorkerCapture: WebKit >= 18 via the Version/ token or the iOS OS token", () => {
+	// macOS/iOS Safari: driven by the Version/ token.
+	expect(detectSafariWorkerCapture(UA.safari18)).toBe(true);
+	expect(detectSafariWorkerCapture(UA.safari17)).toBe(false);
+	expect(detectSafariWorkerCapture(UA.iosSafari18)).toBe(true);
+	expect(detectSafariWorkerCapture(UA.iosSafari)).toBe(false); // iOS 17
+
+	// The point: iOS Chrome/Firefox omit Version/ but carry the OS token, and iOS major tracks the
+	// WebKit major, so an iOS 18 iOS-Chrome is worker-capable exactly like Safari 18.
+	expect(detectSafariWorkerCapture(UA.iosChrome18)).toBe(true);
+	expect(detectSafariWorkerCapture(UA.ipadChrome18)).toBe(true); // iPad form: "CPU OS 18_0"
+	expect(detectSafariWorkerCapture(UA.iosChrome)).toBe(false); // iOS 17
+
+	// Non-WebKit, or WebKit with no >= 18 signal, never qualifies.
+	expect(detectSafariWorkerCapture(UA.chrome)).toBe(false);
+	expect(detectSafariWorkerCapture(UA.firefox)).toBe(false);
+	expect(detectSafariWorkerCapture(UA.androidWebview)).toBe(false); // has Version/4.0 but Android -> not Safari
+	expect(detectSafariWorkerCapture(UA.epiphany)).toBe(false); // WebKitGTK 15, no iOS token
 });

--- a/js/hang/src/util/hacks.ts
+++ b/js/hang/src/util/hacks.ts
@@ -26,6 +26,37 @@ export function detectSafari(ua: string): boolean {
 	return s.includes("safari") && !s.includes("android") && !detectChrome(ua);
 }
 
+/**
+ * Major Safari version from the user agent's `Version/NN` token, or undefined when absent (some
+ * WebKit builds, and iOS browsers like Chrome/CriOS, omit it). Only the major number is returned.
+ */
+export function detectSafariVersion(ua: string): number | undefined {
+	// \b so a token ending in "version" (some in-app-browser UAs) can't steal the match.
+	const match = ua.toLowerCase().match(/\bversion\/(\d+)/);
+	return match ? Number(match[1]) : undefined;
+}
+
+// Major iOS/iPadOS version from the `CPU iPhone OS NN` / `CPU OS NN` token. Every iOS WebKit browser
+// carries it, including Chrome (CriOS) and Firefox (FxiOS) and in-app WebViews, which omit the Safari
+// `Version/` token. undefined off iOS. Private: only the worker-capture gate needs it.
+function detectIosVersion(ua: string): number | undefined {
+	const match = ua.toLowerCase().match(/\bcpu (?:iphone )?os (\d+)/);
+	return match ? Number(match[1]) : undefined;
+}
+
+/**
+ * True when the WebKit behind this UA is new enough to capture video in a Worker: Safari 18 added
+ * worker-scope MediaStreamTrackProcessor and transferable MediaStreamTrack. The version comes from
+ * the Safari `Version/NN` token, or, for iOS WebKit browsers that omit it (Chrome/Firefox and in-app
+ * WebViews on iOS are all WebKit), from the iOS OS version, which tracks the Safari WebKit major. So
+ * an iOS 18 Chrome qualifies exactly like Safari 18. A UA with neither version signal does not.
+ */
+export function detectSafariWorkerCapture(ua: string): boolean {
+	if (!detectSafari(ua)) return false;
+	const version = detectSafariVersion(ua) ?? detectIosVersion(ua);
+	return version !== undefined && version >= 18;
+}
+
 /** True when running in Chrome, used to work around https://issues.chromium.org/issues/40504498. */
 export const isChrome = detectChrome(userAgent);
 
@@ -34,3 +65,10 @@ export const isFirefox = detectFirefox(userAgent);
 
 /** True for Safari-style WebKit user agents (see {@link detectSafari}). */
 export const isSafari = detectSafari(userAgent);
+
+/**
+ * True when this WebKit browser can capture video in a Worker (see {@link detectSafariWorkerCapture}).
+ * Covers macOS/iOS Safari 18+ and iOS Chrome/Firefox/WebViews on iOS 18+ (all WebKit). Everything
+ * else, including a WebKit UA too old or with no detectable version, uses the rAF capture path.
+ */
+export const safariWorkerCapture = detectSafariWorkerCapture(userAgent);

--- a/js/hang/src/util/hacks.ts
+++ b/js/hang/src/util/hacks.ts
@@ -1,5 +1,36 @@
+// `navigator` is absent in some worker/worklet scopes and SSR, so guard the read (empty string ->
+// all flags false) rather than throwing at import time. Under bun, navigator.userAgent is
+// "Bun/1.3.14", which matches no token below, so tests also see false flags.
+const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
+
+function detectChrome(ua: string): boolean {
+	return ua.toLowerCase().includes("chrome");
+}
+
+function detectFirefox(ua: string): boolean {
+	return ua.toLowerCase().includes("firefox");
+}
+
+/**
+ * True for Safari-style WebKit user agents: those that report "safari" but are not Chrome or an
+ * Android WebView (both of which also carry "safari"). This also matches every iOS browser, since
+ * Chrome, Firefox, etc. on iOS are all WebKit.
+ *
+ * This rule must agree with `pickTransport` in `@moq/net`'s `connection/transport.ts`, which decides
+ * the transport this predicate is used to report. The two cannot share code: `@moq/net` is a
+ * dependency and `pickTransport` is internal. The shared test corpus in `hacks.test.ts` and
+ * `transport.test.ts` is what catches a drift.
+ */
+export function detectSafari(ua: string): boolean {
+	const s = ua.toLowerCase();
+	return s.includes("safari") && !s.includes("android") && !detectChrome(ua);
+}
+
 /** True when running in Chrome, used to work around https://issues.chromium.org/issues/40504498. */
-export const isChrome = navigator.userAgent.toLowerCase().includes("chrome");
+export const isChrome = detectChrome(userAgent);
 
 /** True when running in Firefox, used to work around https://bugzilla.mozilla.org/show_bug.cgi?id=1967793. */
-export const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
+export const isFirefox = detectFirefox(userAgent);
+
+/** True for Safari-style WebKit user agents (see {@link detectSafari}). */
+export const isSafari = detectSafari(userAgent);

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -5,6 +5,7 @@ import { Stream } from "../stream.ts";
 import * as Hex from "../util/hex.ts";
 import type { Established } from "./established.ts";
 import { exchangeSetup } from "./handshake.ts";
+import { pickTransport } from "./transport.ts";
 
 // Default head start for WebTransport before attempting the WebSocket fallback.
 const DEFAULT_WEBSOCKET_DELAY_MS = 500;
@@ -61,11 +62,6 @@ export interface ConnectProps {
 // Save if WebSocket won the last race, so we won't give QUIC a head start next time.
 const websocketWon = new Set<string>();
 
-// Firefox's WebTransport implementation drops server-initiated bidi streams,
-// breaking publish (the relay opens a subscribe bidi back to us). Force WebSocket.
-// TODO: remove once Firefox fixes incoming bidi delivery.
-const isFirefox = typeof navigator !== "undefined" && navigator.userAgent.toLowerCase().includes("firefox");
-
 /**
  * Establishes a connection to a MOQ server.
  *
@@ -80,8 +76,12 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	// Create a cancel promise to kill whichever is still connecting.
 	const { promise: cancel, resolve: done } = Promise.withResolvers<void>();
 
+	// `navigator` is absent under SSR, some worker scopes, and bun tests.
+	const userAgent = typeof navigator !== "undefined" ? navigator.userAgent : "";
 	const webtransport =
-		globalThis.WebTransport && !isFirefox ? connectWebTransport(url, cancel, props?.webtransport) : undefined;
+		pickTransport(userAgent, !!globalThis.WebTransport) === "webtransport"
+			? connectWebTransport(url, cancel, props?.webtransport)
+			: undefined;
 
 	// Give QUIC a head start to connect before trying WebSocket, unless WebSocket has won in the past.
 	// NOTE that QUIC should be faster because it involves 1/2 fewer RTTs.

--- a/js/net/src/connection/transport.test.ts
+++ b/js/net/src/connection/transport.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import { pickTransport } from "./transport.ts";
+
+// Real user agents. The WebKit ones are the whole point: Safari's WebTransport session dies the
+// moment `datagrams.readable` is read, which moq-lite-05 always does.
+//
+// This corpus is intentionally shared with `js/hang/src/util/hacks.test.ts`, which tests the twin
+// Safari rule in `detectSafari`. Adding a case here without adding it there lets the two drift.
+const CHROME =
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+const EDGE = `${CHROME} Edg/120.0.0.0`;
+const FIREFOX = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:121.0) Gecko/20100101 Firefox/121.0";
+const SAFARI =
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15";
+const IOS_SAFARI =
+	"Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1";
+const IOS_CHROME =
+	"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/119.0.6045.109 Mobile/15E148 Safari/604.1";
+const IOS_FIREFOX =
+	"Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/119.0 Mobile/15E148 Safari/605.1.15";
+const ANDROID_CHROME =
+	"Mozilla/5.0 (Linux; Android 13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36";
+const ANDROID_WEBVIEW =
+	"Mozilla/5.0 (Linux; Android 13; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/120.0.0.0 Mobile Safari/537.36";
+// The legacy Android stock browser. It says "safari" and "android" but never "chrome", so it is the
+// only case that exercises the `android` clause; every other Android agent short-circuits on "chrome".
+const ANDROID_LEGACY =
+	"Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; SM-G900F Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30";
+// WebKitGTK, e.g. GNOME Web. Not Safari, but the same engine and the same datagram bug.
+const EPIPHANY =
+	"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15";
+
+test("every WebKit engine gets WebSocket, even when WebTransport exists", () => {
+	// Safari 26.4+ ships WebTransport, so `hasWebTransport` is true and must be ignored.
+	expect(pickTransport(SAFARI, true)).toBe("websocket");
+	expect(pickTransport(IOS_SAFARI, true)).toBe("websocket");
+
+	// Chrome and Firefox on iOS are WebKit under the skin. They report CriOS/FxiOS, never
+	// "chrome"/"firefox", so they must fall through to the Safari branch rather than the default.
+	expect(pickTransport(IOS_CHROME, true)).toBe("websocket");
+	expect(pickTransport(IOS_FIREFOX, true)).toBe("websocket");
+
+	// Desktop WebKit that is not Safari at all.
+	expect(pickTransport(EPIPHANY, true)).toBe("websocket");
+});
+
+test("Firefox gets WebSocket", () => {
+	expect(pickTransport(FIREFOX, true)).toBe("websocket");
+});
+
+test("Chromium engines keep WebTransport", () => {
+	// These carry "Safari" in their user agent but are not WebKit.
+	expect(pickTransport(CHROME, true)).toBe("webtransport");
+	expect(pickTransport(EDGE, true)).toBe("webtransport");
+	expect(pickTransport(ANDROID_CHROME, true)).toBe("webtransport");
+	expect(pickTransport(ANDROID_WEBVIEW, true)).toBe("webtransport");
+});
+
+test("Android keeps WebTransport even when the agent says only Safari", () => {
+	// Guards the `android` clause on its own: this agent passes the "safari" and !"chrome" checks,
+	// so dropping `!ua.includes("android")` would wrongly route it to WebSocket.
+	expect(pickTransport(ANDROID_LEGACY, true)).toBe("webtransport");
+});
+
+test("no WebTransport support falls back to WebSocket", () => {
+	expect(pickTransport(CHROME, false)).toBe("websocket");
+	expect(pickTransport(SAFARI, false)).toBe("websocket");
+});
+
+test("an absent user agent falls back to WebTransport support", () => {
+	// `navigator` is undefined under SSR, some worker scopes, and bun tests.
+	expect(pickTransport("", true)).toBe("webtransport");
+	expect(pickTransport("", false)).toBe("websocket");
+});
+
+test("the user agent is matched case-insensitively", () => {
+	expect(pickTransport(SAFARI.toUpperCase(), true)).toBe("websocket");
+	expect(pickTransport(FIREFOX.toUpperCase(), true)).toBe("websocket");
+	expect(pickTransport(CHROME.toUpperCase(), true)).toBe("webtransport");
+});

--- a/js/net/src/connection/transport.ts
+++ b/js/net/src/connection/transport.ts
@@ -1,0 +1,30 @@
+/** The wire transport a session runs over. */
+export type Transport = "webtransport" | "websocket";
+
+/**
+ * Which transport {@link connect} will attempt for a user agent. Safari and Firefox always get
+ * WebSocket, whether or not they expose `WebTransport`.
+ *
+ * @internal Not re-exported from the package entrypoint.
+ */
+export function pickTransport(userAgent: string, hasWebTransport: boolean): Transport {
+	const ua = userAgent.toLowerCase();
+
+	// Firefox's WebTransport implementation drops server-initiated bidi streams,
+	// breaking publish (the relay opens a subscribe bidi back to us).
+	// TODO: remove once Firefox fixes incoming bidi delivery.
+	if (ua.includes("firefox")) return "websocket";
+
+	// Reading `WebTransport.datagrams.readable` tears down the whole session on Safari, and
+	// moq-lite-05 always reads it. There is no catchable failure, so Safari never gets WebTransport.
+	// Matches Safari-style WebKit: reports "safari" but is not Chrome or an Android WebView, which
+	// also carry it. This also catches every iOS browser, since they are all WebKit.
+	//
+	// This rule must agree with `detectSafari` in `@moq/hang`'s `util/hacks.ts`, which the support
+	// matrix uses to report the transport this function actually picks. The two cannot share code:
+	// `@moq/hang` depends on `@moq/net`, and `pickTransport` is internal. The shared test corpus in
+	// `transport.test.ts` and `hacks.test.ts` is what catches a drift.
+	if (ua.includes("safari") && !ua.includes("chrome") && !ua.includes("android")) return "websocket";
+
+	return hasWebTransport ? "webtransport" : "websocket";
+}

--- a/js/publish/src/preview.ts
+++ b/js/publish/src/preview.ts
@@ -153,7 +153,13 @@ export class Transcode {
 		});
 
 		const encoder = new VideoEncoder({
-			output: (chunk: EncodedVideoChunk) => {
+			output: (chunk: EncodedVideoChunk, metadata?: EncodedVideoChunkMetadata) => {
+				// Configure the decoder from the init the encoder actually produced, not the requested
+				// codec: hvc1/av1 carry parameter sets (hvcC/av1C) in decoderConfig.description that a bare
+				// { codec } omits, so HEVC/AV1 preview would never decode. Mirrors video/encoder.ts.
+				if (decoder.state === "unconfigured" && metadata?.decoderConfig) {
+					decoder.configure({ ...metadata.decoderConfig, optimizeForLatency: true });
+				}
 				if (decoder.state === "configured") decoder.decode(chunk);
 			},
 			error: (err: Error) => {
@@ -166,9 +172,6 @@ export class Transcode {
 		});
 
 		encoder.configure(config);
-
-		// The encoder emits Annex B (inline SPS/PPS on keyframes), so the decoder needs no description.
-		decoder.configure({ codec: config.codec, optimizeForLatency: true });
 
 		// Re-key on the same cadence as the real encoder so the decoder can start and recover.
 		let lastKeyframe: Time.Micro | undefined;

--- a/js/publish/src/source/camera.ts
+++ b/js/publish/src/source/camera.ts
@@ -1,3 +1,4 @@
+import * as Util from "@moq/hang/util";
 import { Effect, Signal } from "@moq/signals";
 import type * as Video from "../video";
 import { Device, type DeviceProps } from "./device";
@@ -22,6 +23,11 @@ export class Camera {
 	constraints: Signal<Video.Constraints | undefined>;
 
 	source = new Signal<Video.Source | undefined>(undefined);
+
+	// Bumped when the captured track ends underneath us (e.g. the webcam is unplugged),
+	// so #run re-acquires instead of leaving a frozen source forever.
+	#retry = new Signal(0);
+
 	signals = new Effect();
 
 	constructor(props?: CameraProps) {
@@ -36,6 +42,7 @@ export class Camera {
 		const enabled = effect.get(this.enabled);
 		if (!enabled) return;
 
+		effect.get(this.#retry);
 		const device = effect.get(this.device.requested);
 		const constraints = effect.get(this.constraints) ?? {};
 
@@ -47,7 +54,12 @@ export class Camera {
 		};
 
 		effect.spawn(async () => {
-			const media = navigator.mediaDevices.getUserMedia({ video: finalConstraints }).catch(() => undefined);
+			// A denied/cancelled permission prompt must not take down the effect, but stay visible:
+			// the broadcast still announces, so watchers would otherwise buffer forever with no clue why.
+			const media = navigator.mediaDevices.getUserMedia({ video: finalConstraints }).catch((err) => {
+				console.warn("camera capture failed:", err);
+				return undefined;
+			});
 
 			// If the effect is cancelled for any reason (ex. cancel), stop any media that we got.
 			effect.cleanup(() =>
@@ -67,6 +79,30 @@ export class Camera {
 			if (!source) return;
 
 			const settings = source.getSettings();
+
+			// The track can end underneath us (device unplugged, OS revoked). Re-acquire so
+			// capture moves to whatever device is now available.
+			effect.event(source, "ended", () => {
+				console.warn("camera track ended; re-acquiring");
+				this.#retry.update((n) => n + 1);
+			});
+
+			// Safari mutes (does not end) the track when the tab is backgrounded and doesn't reliably
+			// unmute it on return, leaving a frozen source. On return to the foreground, give Safari a
+			// moment to auto-unmute; if the track is still muted, re-acquire. Safari-only: desktop
+			// Chrome/Firefox don't mute on background, and mobile Chrome/Firefox auto-unmute reliably, so
+			// re-acquiring there would only glitch a stream that was about to recover on its own.
+			if (Util.Hacks.isSafari) {
+				effect.event(document, "visibilitychange", () => {
+					if (document.hidden || !source.muted) return;
+					effect.timer(() => {
+						if (!document.hidden && source.muted) {
+							console.warn("camera track stuck muted after returning to foreground; re-acquiring");
+							this.#retry.update((n) => n + 1);
+						}
+					}, 500);
+				});
+			}
 
 			effect.set(this.device.active, settings.deviceId);
 			effect.set(this.source, source);

--- a/js/publish/src/source/microphone.ts
+++ b/js/publish/src/source/microphone.ts
@@ -17,6 +17,10 @@ export class Microphone {
 
 	source = new Signal<Audio.Source | undefined>(undefined);
 
+	// Bumped when the captured track ends underneath us (e.g. a Bluetooth headset disconnects),
+	// so #run re-acquires instead of encoding silence off a dead track forever.
+	#retry = new Signal(0);
+
 	signals = new Effect();
 
 	constructor(props?: MicrophoneProps) {
@@ -32,6 +36,7 @@ export class Microphone {
 		const enabled = effect.get(this.enabled);
 		if (!enabled) return;
 
+		effect.get(this.#retry);
 		const device = effect.get(this.device.requested);
 
 		const constraints = effect.get(this.constraints) ?? {};
@@ -41,7 +46,12 @@ export class Microphone {
 		};
 
 		effect.spawn(async () => {
-			const media = navigator.mediaDevices.getUserMedia({ audio: finalConstraints }).catch(() => undefined);
+			// A denied/cancelled permission prompt must not take down the effect, but stay visible:
+			// the broadcast still announces, so watchers would otherwise buffer forever with no clue why.
+			const media = navigator.mediaDevices.getUserMedia({ audio: finalConstraints }).catch((err) => {
+				console.warn("microphone capture failed:", err);
+				return undefined;
+			});
 
 			// If the effect is cancelled for any reason (ex. cancel), stop any media that we got.
 			effect.cleanup(() =>
@@ -67,6 +77,13 @@ export class Microphone {
 				// Save the device that the user selected during the dialog prompt.
 				this.device.preferred.set(settings.deviceId);
 			}
+
+			// The track can end underneath us (device unplugged, Bluetooth dropped, OS revoked).
+			// Re-acquire so capture moves to whatever device is now available.
+			effect.event(track, "ended", () => {
+				console.warn("microphone track ended; re-acquiring");
+				this.#retry.update((n) => n + 1);
+			});
 
 			effect.set(this.device.active, settings.deviceId);
 			effect.set(this.source, { track, kind: "voice" });

--- a/js/publish/src/support/element.ts
+++ b/js/publish/src/support/element.ts
@@ -1,9 +1,7 @@
+import * as Util from "@moq/hang/util";
 import { Effect, Signal } from "@moq/signals";
 import * as DOM from "@moq/signals/dom";
 import { type Codec, type Full, isSupported, type Partial } from "./";
-
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1967793
-const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
 
 const OBSERVED = ["show", "details"] as const;
 type Observed = (typeof OBSERVED)[number];
@@ -202,7 +200,11 @@ export default class MoqPublishSupport extends HTMLElement {
 
 		const binary = (value: boolean | undefined) => (value ? "🟢 Yes" : "🔴 No");
 		const hardware = (codec: Codec | undefined) =>
-			codec?.hardware ? "🟢 Hardware" : codec?.software ? `🟡 Software${isFirefox ? "*" : ""}` : "🔴 No";
+			codec?.hardware
+				? "🟢 Hardware"
+				: codec?.software
+					? `🟡 Software${Util.Hacks.isFirefox ? "*" : ""}`
+					: "🔴 No";
 		const partial = (value: Partial | undefined) =>
 			value === "full" ? "🟢 Full" : value === "partial" ? "🟡 Polyfill" : "🔴 None";
 
@@ -254,7 +256,7 @@ export default class MoqPublishSupport extends HTMLElement {
 		addRow("", "VP9", hardware(support.video.encoding?.vp9));
 		addRow("", "VP8", hardware(support.video.encoding?.vp8));
 
-		if (isFirefox) {
+		if (Util.Hacks.isFirefox) {
 			const noteDiv = DOM.create(
 				"div",
 				{

--- a/js/publish/src/support/index.ts
+++ b/js/publish/src/support/index.ts
@@ -1,5 +1,4 @@
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1967793
-const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
+import * as Util from "@moq/hang/util";
 
 export type Partial = "full" | "partial" | "none";
 
@@ -73,7 +72,7 @@ async function videoEncoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 		hardwareAcceleration: "prefer-hardware",
 	});
 
-	const unknown = isFirefox || hardware.config?.hardwareAcceleration !== "prefer-hardware";
+	const unknown = Util.Hacks.isFirefox || hardware.config?.hardwareAcceleration !== "prefer-hardware";
 
 	return {
 		hardware: unknown ? undefined : hardware.supported === true,
@@ -83,9 +82,11 @@ async function videoEncoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 
 export async function isSupported(): Promise<Full> {
 	return {
-		// Firefox's WebTransport drops server-initiated bidi streams, so we force the
-		// WebSocket fallback. Report "partial" to surface the degraded path in UI.
-		webtransport: typeof WebTransport !== "undefined" ? (isFirefox ? "partial" : "full") : "partial",
+		// Firefox drops server-initiated bidi streams, and reading datagrams kills the session on
+		// Safari, so both are forced onto the WebSocket fallback even though they define
+		// `WebTransport`. Report "partial" to surface the degraded path in UI.
+		webtransport:
+			typeof WebTransport !== "undefined" && !Util.Hacks.isFirefox && !Util.Hacks.isSafari ? "full" : "partial",
 		audio: {
 			capture: typeof AudioWorkletNode !== "undefined",
 			encoding: {

--- a/js/publish/src/support/index.ts
+++ b/js/publish/src/support/index.ts
@@ -57,20 +57,27 @@ async function audioEncoderSupported(codec: keyof typeof CODECS): Promise<boolea
 }
 
 async function videoEncoderSupported(codec: keyof typeof CODECS): Promise<Codec> {
-	const software = await VideoEncoder.isConfigSupported({
-		codec: CODECS[codec],
-		width: 1280,
-		height: 720,
-		hardwareAcceleration: "prefer-software",
-	});
+	const base = { codec: CODECS[codec], width: 1280, height: 720 };
+
+	const software = await VideoEncoder.isConfigSupported({ ...base, hardwareAcceleration: "prefer-software" });
+
+	// On Apple Silicon Safari, VideoToolbox hardware-encodes only H.264 and HEVC; Safari reports the
+	// others as prefer-hardware supported even though they run on software libvpx, so key off the
+	// codec rather than the echoed (and unreliable) hint, and skip the probe it would ignore. The
+	// same H.264/HEVC-only set drives hardwareCodecOrder in ../video/codecs.ts.
+	if (Util.Hacks.isSafari) {
+		const hardwareCapable = codec === "h264" || codec === "h265";
+		const hardware = hardwareCapable
+			? await VideoEncoder.isConfigSupported({ ...base, hardwareAcceleration: "prefer-hardware" })
+			: undefined;
+		return {
+			hardware: hardware?.supported === true,
+			software: software.supported === true,
+		};
+	}
 
 	// We can't reliably detect hardware encoding on Firefox: https://github.com/w3c/webcodecs/issues/896
-	const hardware = await VideoEncoder.isConfigSupported({
-		codec: CODECS[codec],
-		width: 1280,
-		height: 720,
-		hardwareAcceleration: "prefer-hardware",
-	});
+	const hardware = await VideoEncoder.isConfigSupported({ ...base, hardwareAcceleration: "prefer-hardware" });
 
 	const unknown = Util.Hacks.isFirefox || hardware.config?.hardwareAcceleration !== "prefer-hardware";
 
@@ -81,6 +88,10 @@ async function videoEncoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 }
 
 export async function isSupported(): Promise<Full> {
+	// @ts-expect-error MediaStreamTrackProcessor has no TypeScript types yet. Keep the suppression on
+	// this line only so it doesn't mask type errors in the capture expression below.
+	const mainThreadCapture = typeof MediaStreamTrackProcessor !== "undefined";
+
 	return {
 		// Firefox drops server-initiated bidi streams, and reading datagrams kills the session on
 		// Safari, so both are forced onto the WebSocket fallback even though they define
@@ -95,12 +106,13 @@ export async function isSupported(): Promise<Full> {
 			},
 		},
 		video: {
+			// Chrome exposes MediaStreamTrackProcessor on the main thread; WebKit 18+ (incl. iOS
+			// Chrome/Firefox) uses it in a Worker (see video/polyfill.ts). Older/undetectable WebKit falls
+			// back to the rAF polyfill, so it's only "partial".
 			capture:
-				// We have a fallback for MediaStreamTrackProcessor, but it's pretty gross so no full points.
-				// @ts-expect-error No typescript types yet.
-				typeof MediaStreamTrackProcessor !== "undefined"
+				mainThreadCapture || Util.Hacks.safariWorkerCapture
 					? "full"
-					: typeof OffscreenCanvas !== "undefined"
+					: Util.Hacks.isSafari || typeof OffscreenCanvas !== "undefined"
 						? "partial"
 						: "none",
 			encoding:

--- a/js/publish/src/ui/components/stats-tab.ts
+++ b/js/publish/src/ui/components/stats-tab.ts
@@ -23,7 +23,7 @@ function card(kind: Kind, label: string, svg: string): { el: HTMLElement; grid: 
 }
 
 /** Show an active/idle pill: an encoder only runs (and uses bandwidth) while a viewer is subscribed. */
-function trackActive(parent: Effect, status: HTMLElement, active: Getter<boolean>) {
+function trackActive(parent: Effect, status: HTMLElement, active: Getter<boolean | undefined>) {
 	parent.run((effect) => {
 		const on = effect.get(active);
 		status.style.display = "";
@@ -56,8 +56,11 @@ export function statsTab(parent: Effect, publish: MoqPublish): HTMLElement {
 	const vFpsGraph = graph(parent, "Frame rate", { color: "#facc15", format: formatFps });
 	videoCard.el.append(vBitrateGraph.el, vFpsGraph.el);
 
-	// active = a viewer is subscribed and we're actually encoding/sending.
-	trackActive(parent, videoCard.status, publish.broadcast.video.hd.active);
+	// active = a viewer is subscribed and we're actually encoding/sending (either HD or SD rendition).
+	const videoActive = parent.computed(
+		(e) => e.get(publish.broadcast.video.hd.active) || e.get(publish.broadcast.video.sd.active),
+	);
+	trackActive(parent, videoCard.status, videoActive);
 
 	const audioCard = card("audio", "Audio", audioIcon);
 	const aCodec = line(audioCard.grid, "Codec");
@@ -101,25 +104,34 @@ export function statsTab(parent: Effect, publish: MoqPublish): HTMLElement {
 		nName.textContent = name?.toString() || "—";
 	});
 
-	// Live graphs: frame rate from captured frames, bitrate from the upload estimate.
+	// Live graphs: frame rate from captured frames; bitrate MEASURED from encoded bytes (transport-
+	// agnostic, so it works on Safari and the WebSocket fallback where WebTransport getStats is absent).
 	let frames = 0;
 	parent.subscribe(publish.broadcast.video.frame, () => {
 		frames++;
 	});
+	const encodedBytes = () =>
+		publish.broadcast.video.hd.bytesEncoded.peek() + publish.broadcast.video.sd.bytesEncoded.peek();
 	let prevFrames = 0;
+	let prevBytes = encodedBytes();
 	let prevWhen = performance.now();
 
 	parent.interval(() => {
 		const now = performance.now();
 		const elapsed = now - prevWhen;
-		const delta = frames - prevFrames;
-		const fps = elapsed > 0 && delta > 0 ? delta / (elapsed / 1000) : undefined;
+
+		const frameDelta = frames - prevFrames;
+		const fps = elapsed > 0 && frameDelta > 0 ? frameDelta / (elapsed / 1000) : undefined;
 		prevFrames = frames;
+
+		const bytes = encodedBytes();
+		const byteDelta = bytes - prevBytes;
+		const bitrate = elapsed > 0 && byteDelta > 0 ? (byteDelta * 8) / (elapsed / 1000) : undefined;
+		prevBytes = bytes;
+
 		prevWhen = now;
 		vFpsGraph.push(fps);
-
-		const upload = publish.connection.established.peek()?.sendBandwidth?.peek();
-		vBitrateGraph.push(upload && upload > 0 ? upload : undefined);
+		vBitrateGraph.push(bitrate);
 	}, POLL_MS);
 
 	return container;

--- a/js/publish/src/video/capture-worker.ts
+++ b/js/publish/src/video/capture-worker.ts
@@ -1,0 +1,49 @@
+// Runs as a module Web Worker (started from ./polyfill.ts). Compiled and inlined as a blob URL by
+// vite-plugin-worklet via the ?worklet suffix.
+//
+// Safari only exposes MediaStreamTrackProcessor inside a Worker. Capturing here rather than on the
+// main thread also keeps frames flowing while the publish window is occluded, where the browser
+// throttles the main-thread requestAnimationFrame loop to a freeze.
+
+/** Messages the capture worker posts back to the host (./polyfill.ts). */
+export type CaptureToHost =
+	| { type: "frame"; frame: VideoFrame }
+	| { type: "done" }
+	| { type: "error"; message: string };
+
+// `self` is the worker global scope. The project's DOM lib doesn't ship the worker-scope types, so
+// declare just the slice we use instead of pulling in the conflicting webworker lib.
+const scope = self as unknown as {
+	onmessage: ((event: MessageEvent<{ track: MediaStreamTrack }>) => void) | null;
+	postMessage(message: CaptureToHost, transfer?: Transferable[]): void;
+};
+
+scope.onmessage = async (event: MessageEvent<{ track: MediaStreamTrack }>) => {
+	const { track } = event.data;
+
+	try {
+		// The host only starts this worker on a known Safari 18+, where the global exists. If it were
+		// somehow missing, `new MediaStreamTrackProcessor` throws ReferenceError, which the catch below
+		// reports to the host as an error rather than hanging with no frames.
+		// @ts-expect-error MediaStreamTrackProcessor has no TypeScript types yet.
+		const processor = new MediaStreamTrackProcessor({ track });
+		const reader: ReadableStreamDefaultReader<VideoFrame> = processor.readable.getReader();
+
+		for (;;) {
+			const { value: frame, done } = await reader.read();
+			if (done || !frame) break;
+
+			// Transfer ownership to the host, which rewrites the timestamp and closes the frame.
+			scope.postMessage({ type: "frame", frame }, [frame]);
+		}
+
+		scope.postMessage({ type: "done" });
+	} catch (err) {
+		scope.postMessage({ type: "error", message: String(err) });
+	} finally {
+		// Release the transferred camera clone. The host terminates this worker on any terminal
+		// message; we deliberately do not self-close, so a terminal message can never race a
+		// self.close() that might drop it before it reaches the host.
+		track.stop();
+	}
+};

--- a/js/publish/src/video/catalog.test.ts
+++ b/js/publish/src/video/catalog.test.ts
@@ -1,0 +1,84 @@
+import { expect, test } from "bun:test";
+import { videoCatalog } from "./catalog.ts";
+
+const base: VideoEncoderConfig = {
+	codec: "hev1.1.6.L93.B0",
+	width: 1920,
+	height: 1080,
+	framerate: 30,
+	bitrate: 2_000_000,
+};
+
+test("uses the encoder's authoritative codec + hex description when codec+dimensions match", () => {
+	// Safari can emit hvc1 for a hev1 request; the catalog must advertise what was produced plus the hvcC
+	// (as hex) the watcher's decoder needs to init HEVC.
+	const catalog = videoCatalog(base, {
+		reqCodec: "hev1.1.6.L93.B0",
+		width: 1920,
+		height: 1080,
+		codec: "hvc1.1.6.L93.B0",
+		description: "deadbeef",
+	});
+
+	expect(catalog.codec).toBe("hvc1.1.6.L93.B0");
+	expect(catalog.description).toBe("deadbeef");
+});
+
+test("matches by value, not identity, so bitrate churn (a rebuilt config object) keeps the description", () => {
+	// Bandwidth adaptation rebuilds the VideoEncoderConfig ~10x/s as a NEW object with the same codec +
+	// dimensions; a value match keeps the HEVC description stable (an identity check would flap it off and
+	// make watchers yank HD down to SD).
+	const churned: VideoEncoderConfig = { ...base, bitrate: 3_500_000 };
+	const catalog = videoCatalog(churned, {
+		reqCodec: "hev1.1.6.L93.B0",
+		width: 1920,
+		height: 1080,
+		codec: "hvc1.1.6.L93.B0",
+		description: "deadbeef",
+	});
+
+	expect(catalog.codec).toBe("hvc1.1.6.L93.B0");
+	expect(catalog.description).toBe("deadbeef");
+});
+
+test("falls back to the requested codec with no description before the first keyframe", () => {
+	const catalog = videoCatalog(base, undefined);
+
+	expect(catalog.codec).toBe("hev1.1.6.L93.B0");
+	expect(catalog.description).toBeUndefined();
+});
+
+test("keeps the requested codec when the produced config carries no description (VP9/H.264)", () => {
+	// A description-less encoder may report a more-qualified codec (e.g. VP9). Keeping the requested string
+	// leaves the catalog byte-identical so no watcher rebuilds its decoder over a cosmetic change.
+	const cfg: VideoEncoderConfig = { ...base, codec: "vp09.00.10.08" };
+	const catalog = videoCatalog(cfg, {
+		reqCodec: "vp09.00.10.08",
+		width: 1920,
+		height: 1080,
+		codec: "vp09.00.10.08.01.01.01.01.00",
+	});
+
+	expect(catalog.codec).toBe("vp09.00.10.08");
+	expect(catalog.description).toBeUndefined();
+});
+
+test("ignores a capture whose requested codec no longer matches (real codec change)", () => {
+	const catalog = videoCatalog(
+		{ ...base, codec: "vp09.00.10.08" },
+		{ reqCodec: "hev1.1.6.L93.B0", width: 1920, height: 1080, codec: "hvc1.1.6.L93.B0", description: "deadbeef" },
+	);
+
+	expect(catalog.codec).toBe("vp09.00.10.08");
+	expect(catalog.description).toBeUndefined();
+});
+
+test("ignores a capture whose dimensions no longer match (real resolution change)", () => {
+	const catalog = videoCatalog(
+		{ ...base, width: 1280, height: 720 },
+		{ reqCodec: "hev1.1.6.L93.B0", width: 1920, height: 1080, codec: "hvc1.1.6.L93.B0", description: "deadbeef" },
+	);
+
+	expect(catalog.codec).toBe("hev1.1.6.L93.B0");
+	expect(catalog.description).toBeUndefined();
+});

--- a/js/publish/src/video/catalog.ts
+++ b/js/publish/src/video/catalog.ts
@@ -1,0 +1,43 @@
+import * as Catalog from "@moq/hang/catalog";
+
+/**
+ * Build the catalog video config from the requested encoder config plus, when present, the decoder
+ * config the encoder actually produced. Carries the out-of-band `description` (hvcC/av1C) some codecs
+ * need, and only then adopts the encoder's codec string (a hev1 request can come back as hvc1, whose
+ * length-prefixed bitstream the codec string must match). For in-band formats (H.264/HEVC annexb, VP8,
+ * VP9, or before the first keyframe) it keeps the REQUESTED codec, so the catalog stays byte-identical
+ * to what was requested and a watcher never rebuilds its decoder over a cosmetic codec-string change.
+ * The captured value is applied only while its requested codec + dimensions still match the current
+ * config. That is stable across the send-bandwidth-driven bitrate changes that rebuild the config object
+ * ~10x/s (so a plain re-encode never flaps the description off), yet a real codec/resolution change
+ * invalidates it until the next keyframe recaptures.
+ *
+ * Intentionally not re-exported from ./index (video/index.ts), so it stays an internal detail that
+ * unit tests can pin without widening the package's public API (same as ./codecs).
+ */
+export function videoCatalog(
+	config: VideoEncoderConfig,
+	decoderConfig?: { reqCodec: string; width: number; height: number; codec: string; description?: string },
+): Catalog.VideoConfig {
+	const dc =
+		decoderConfig &&
+		decoderConfig.reqCodec === config.codec &&
+		decoderConfig.width === config.width &&
+		decoderConfig.height === config.height
+			? decoderConfig
+			: undefined;
+	return {
+		// Only the description-bearing case (hvc1/av1C) needs the encoder's codec; otherwise the requested
+		// codec is authoritative enough and avoids a mid-stream codec change on the common path.
+		codec: dc?.description ? dc.codec : config.codec,
+		description: dc?.description,
+		bitrate: config.bitrate ? Catalog.u53(config.bitrate) : undefined,
+		framerate: config.framerate,
+		codedWidth: Catalog.u53(config.width),
+		codedHeight: Catalog.u53(config.height),
+		optimizeForLatency: true,
+		container: { kind: "legacy" } as const,
+		// Each frame is flushed immediately, so the jitter is one frame duration.
+		jitter: config.framerate ? Catalog.u53(Math.ceil(1000 / config.framerate)) : undefined,
+	};
+}

--- a/js/publish/src/video/codecs.test.ts
+++ b/js/publish/src/video/codecs.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { hardwareCodecOrder, softwareCodecOrder } from "./codecs.ts";
+
+test("Safari hardware order offers only the codecs it actually hardware-encodes", () => {
+	const order = hardwareCodecOrder(true);
+
+	// H.264 first (the requested default), HEVC after; both are VideoToolbox hardware.
+	expect(order[0]).toBe("avc1.640028");
+	expect(order).toContain("hev1.1.6.L93.B0");
+	// avc1 must beat hev1: H.264 has universal decode support (Firefox can't decode HEVC).
+	expect(order.indexOf("avc1.640028")).toBeLessThan(order.indexOf("hev1.1.6.L93.B0"));
+
+	// Safari has no hardware VP9/VP8/AV1 encoder, so they must not appear in the hardware pass
+	// (that is the bug: Safari reports software VP9 as hardware-supported).
+	expect(order.some((c) => c.startsWith("vp09"))).toBe(false);
+	expect(order.some((c) => c.startsWith("vp8"))).toBe(false);
+	expect(order.some((c) => c.startsWith("av01"))).toBe(false);
+});
+
+test("non-Safari hardware order keeps the decode-friendly VP9-first preference", () => {
+	const order = hardwareCodecOrder(false);
+
+	expect(order[0]).toBe("vp09.00.10.08");
+	// VP9 stays ahead of H.264 in the generic (non-Safari) order used by Chrome et al.
+	expect(order.indexOf("vp09.00.10.08")).toBeLessThan(order.indexOf("avc1.640028"));
+	// The full generic set is still offered.
+	for (const family of ["vp09", "avc1", "av01", "hev1", "vp8"]) {
+		expect(order.some((c) => c.startsWith(family))).toBe(true);
+	}
+});
+
+test("software order prefers cheap-to-encode H.264 first and AV1 last", () => {
+	const order = softwareCodecOrder();
+
+	expect(order[0]).toBe("avc1.640028");
+	expect(order[order.length - 1]).toBe("av01");
+	// VP9 sits behind H.264 (more expensive to encode in software).
+	expect(order.indexOf("vp09.00.10.08")).toBeGreaterThan(order.indexOf("avc1.640028"));
+});

--- a/js/publish/src/video/codecs.ts
+++ b/js/publish/src/video/codecs.ts
@@ -1,0 +1,36 @@
+// Video encode codec preference lists for Encoder.#bestCodec.
+//
+// Intentionally not re-exported from ./index (video/index.ts), so the ordering stays an internal
+// detail that unit tests can pin without widening the package's public API.
+
+// Codec families, most-preferred profile first within each. The bare-family entries ("avc1",
+// "hev1", "vp09", "av01") let the browser pick a profile/level when a specific one isn't required.
+const H264 = ["avc1.640028", "avc1.4D401F", "avc1.42E01E", "avc1"]; // Almost always hardware.
+const HEVC = ["hev1.1.6.L93.B0", "hev1"]; // Often hardware, but licensing limits support (no Firefox decode).
+const VP9 = ["vp09.00.10.08", "vp09"]; // Broadly hardware-*decodable*; hardware *encode* is rare.
+const AV1 = ["av01.0.08M.08", "av01"]; // Great compression, but hardware encode is rare and CPU encode is costly.
+const VP8 = ["vp8"]; // A terrible codec, but easy and widely supported.
+
+/**
+ * Ordered codec preference for the hardware-accelerated encode pass.
+ *
+ * #bestCodec returns the first codec the browser reports as supported under `prefer-hardware`, so
+ * this order picks the default. The generic order front-loads VP9 because it is the most widely
+ * hardware-decodable, which suits the watcher side on most engines.
+ *
+ * Safari is the exception: it reports VP9 as supported under `prefer-hardware` even though it only
+ * has a software (libvpx) VP9 encoder, so the generic order makes Safari burn CPU on software VP9
+ * while its hardware H.264/HEVC (VideoToolbox) sits idle. On Safari we therefore offer only the
+ * codecs it actually hardware-encodes; anything else is reached, if ever needed, via the software
+ * pass. `hardwareAcceleration` is a hint the browser may ignore, so we cannot detect this from the
+ * probe (see https://github.com/w3c/webcodecs/issues/896) and must key off the engine.
+ */
+export function hardwareCodecOrder(safari: boolean): string[] {
+	if (safari) return [...H264, ...HEVC];
+	return [...VP9, ...H264, ...AV1, ...HEVC, ...VP8];
+}
+
+/** Ordered codec preference for the software encode pass, cheapest-to-encode first. */
+export function softwareCodecOrder(): string[] {
+	return [...H264, ...VP8, ...VP9, ...HEVC, ...AV1];
+}

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -1,9 +1,11 @@
-import * as Catalog from "@moq/hang/catalog";
+import type * as Catalog from "@moq/hang/catalog";
 import * as Container from "@moq/hang/container";
 import * as Util from "@moq/hang/util";
 import type * as Moq from "@moq/net";
 import { Time } from "@moq/net";
 import { Effect, type Getter, Signal } from "@moq/signals";
+import { videoCatalog } from "./catalog";
+import { hardwareCodecOrder, softwareCodecOrder } from "./codecs";
 import type { Source } from "./types";
 
 export interface EncoderProps {
@@ -49,6 +51,18 @@ export class Encoder {
 
 	#catalog = new Signal<Catalog.VideoConfig | undefined>(undefined);
 	readonly catalog: Getter<Catalog.VideoConfig | undefined> = this.#catalog;
+
+	// The decoder init the encoder actually produced (authoritative codec + hvcC/av1C description),
+	// captured from keyframe metadata in serve(), tagged with the requested codec + dimensions it was
+	// measured against. See videoCatalog's doc comment for why it survives bitrate churn but not a real
+	// codec/resolution change.
+	#decoderConfig = new Signal<
+		{ reqCodec: string; width: number; height: number; codec: string; description?: string } | undefined
+	>(undefined);
+
+	#bytesEncoded = new Signal(0);
+	/** Cumulative bytes encoded while serving a subscriber; monotonic, diff per tick for an upload bitrate. */
+	readonly bytesEncoded: Getter<number> = this.#bytesEncoded;
 
 	#signals = new Effect();
 
@@ -101,9 +115,36 @@ export class Encoder {
 
 		effect.spawn(async () => {
 			const encoder = new VideoEncoder({
-				output: (frame: EncodedVideoChunk) => {
+				output: (frame: EncodedVideoChunk, metadata?: EncodedVideoChunkMetadata) => {
 					if (frame.type === "key") {
 						lastKeyframe = frame.timestamp as Time.Micro;
+					}
+
+					this.#bytesEncoded.update((n) => n + frame.byteLength);
+
+					// Capture the decoder init the encoder actually produced (present on keyframes), tagged
+					// with the config it was measured against. For hvc1/av1 this carries the out-of-band
+					// parameter sets (hvcC/av1C) the watcher's decoder needs; without it Chrome can't init HEVC.
+					// Mirrors the AAC path in audio/encoder.ts. Stored as hex so an identical value each
+					// keyframe compares equal and doesn't re-publish the catalog.
+					const decoderConfig = metadata?.decoderConfig;
+					const config = this.#config.peek();
+					if (decoderConfig && config) {
+						const desc = decoderConfig.description;
+						const description = desc
+							? Util.Hex.fromBytes(
+									ArrayBuffer.isView(desc)
+										? new Uint8Array(desc.buffer, desc.byteOffset, desc.byteLength)
+										: new Uint8Array(desc),
+								)
+							: undefined;
+						this.#decoderConfig.set({
+							reqCodec: config.codec,
+							width: config.width,
+							height: config.height,
+							codec: decoderConfig.codec,
+							description,
+						});
 					}
 
 					producer.encode(frame, frame.timestamp as Time.Micro, frame.type === "key");
@@ -113,10 +154,18 @@ export class Encoder {
 				},
 			});
 
-			effect.cleanup(() => encoder.close());
+			// Guard against double-close: a fatal encoder error auto-transitions the encoder to "closed", and
+			// close() on a closed encoder throws InvalidStateError, which would abort the signals dispose loop
+			// and leak the sibling effects. Matches the guarded close in preview.ts and the decoders.
+			effect.cleanup(() => {
+				if (encoder.state !== "closed") encoder.close();
+			});
 
-			effect.run(() => {
-				const config = effect.get(this.#config);
+			// Reconfigure on the INNER effect. Subscribing via the outer `effect` would attach the #config
+			// dependency to serve()'s effect and tear down + rebuild the whole encoder + producer on every
+			// bitrate change, instead of reconfiguring the live encoder in place (the audio encoder does this).
+			effect.run((inner) => {
+				const config = inner.get(this.#config);
 				if (!config) return;
 
 				encoder.configure(config);
@@ -160,19 +209,9 @@ export class Encoder {
 		if (!values) return;
 		const [_, config] = values;
 
-		const catalog: Catalog.VideoConfig = {
-			codec: config.codec,
-			bitrate: config.bitrate ? Catalog.u53(config.bitrate) : undefined,
-			framerate: config.framerate,
-			codedWidth: Catalog.u53(config.width),
-			codedHeight: Catalog.u53(config.height),
-			optimizeForLatency: true,
-			container: { kind: "legacy" } as const,
-			// Each frame is flushed immediately, so the jitter is one frame duration.
-			jitter: config.framerate ? Catalog.u53(Math.ceil(1000 / config.framerate)) : undefined,
-		};
-
-		effect.set(this.#catalog, catalog);
+		// Fold in the decoder config the encoder actually produced (authoritative codec + hvcC/av1C
+		// description), available after the first keyframe. See videoCatalog.
+		effect.set(this.#catalog, videoCatalog(config, effect.get(this.#decoderConfig)));
 	}
 
 	#runConfig(effect: Effect): void {
@@ -235,7 +274,9 @@ export class Encoder {
 				// Worse than H.264 but it's a backup plan.
 				bitrate *= 1.1;
 			} else {
-				throw new Error(`unknown codec: ${codec}`);
+				// Unknown codec (e.g. a caller-forced string outside our efficiency table): don't throw out
+				// of the config effect; skip the efficiency scaling (1.0) so the encoder still configures.
+				console.warn(`unknown codec for bitrate scaling: ${codec} (using 1.0)`);
 			}
 
 			bitrate = Math.round(Math.min(bitrate, user.maxBitrate || bitrate));
@@ -312,72 +353,23 @@ export class Encoder {
 		const dimensions = effect.get(this.#dimensions);
 		if (!dimensions) return;
 
-		// A list of codecs to try, in order of preference.
-		const HARDWARE_CODECS = [
-			// VP9
-			// More likely to have hardware decoding, but hardware encoding is less likely.
-			"vp09.00.10.08",
-			"vp09", // Browser's choice
+		// Codec preference lists, including why Safari needs its own hardware order, live in ./codecs.
+		const HARDWARE_CODECS = hardwareCodecOrder(Util.Hacks.isSafari);
+		const SOFTWARE_CODECS = softwareCodecOrder();
 
-			// H.264
-			// Almost always has hardware encoding and decoding.
-			"avc1.640028",
-			"avc1.4D401F",
-			"avc1.42E01E",
-			"avc1",
+		// Candidates for a preference order: entries matching the requested prefix, or the requested string
+		// itself when the caller forced an exact codec our lists don't enumerate (e.g. "av01.0.04M.08"). An
+		// empty `required` (auto) prefix-matches everything, so this returns the whole ordered list.
+		const candidates = (order: readonly string[]): string[] => {
+			const matched = order.filter((codec) => codec.startsWith(required));
+			return matched.length > 0 ? matched : [required];
+		};
 
-			// AV1
-			// One day will get moved higher up the list, but hardware decoding is rare.
-			"av01.0.08M.08",
-			"av01",
-
-			// HEVC (aka h.265)
-			// More likely to have hardware encoding, but less likely to be supported (licensing issues).
-			// Unfortunately, Firefox doesn't support decoding so it's down here at the bottom.
-			"hev1.1.6.L93.B0",
-			"hev1", // Browser's choice
-
-			// VP8
-			// A terrible codec but it's easy.
-			"vp8",
-		];
-
-		const SOFTWARE_CODECS = [
-			// Now try software encoding for simple enough codecs.
-			// H.264
-			"avc1.640028", // High
-			"avc1.4D401F", // Main
-			"avc1.42E01E", // Baseline
-			"avc1",
-
-			// VP8
-			"vp8",
-
-			// VP9
-			// It's a bit more expensive to encode so we shy away from it.
-			"vp09.00.10.08",
-			"vp09",
-
-			// HEVC (aka h.265)
-			// This likely won't work because of licensing issues.
-			"hev1.1.6.L93.B0",
-			"hev1", // Browser's choice
-
-			// AV1
-			// Super expensive to encode so it's our last choice.
-			"av01.0.08M.08",
-			"av01",
-		];
-
-		// Try hardware encoding first.
-		// We can't reliably detect hardware encoding on Firefox: https://github.com/w3c/webcodecs/issues/896
-		if (!Util.Hacks.isFirefox) {
-			for (const codec of HARDWARE_CODECS) {
-				if (!codec.startsWith(required)) continue;
-
-				const hardwareAcceleration: HardwareAcceleration = "prefer-hardware";
-
-				const hardware: VideoEncoderConfig = {
+		// Probe one codec. isConfigSupported rejects (TypeError) on some malformed/unknown codec strings
+		// instead of resolving { supported: false }, so treat a throw as "not supported, try the next".
+		const probe = async (codec: string, hardwareAcceleration: HardwareAcceleration): Promise<boolean> => {
+			try {
+				const { supported } = await VideoEncoder.isConfigSupported({
 					codec,
 					width: dimensions.width,
 					height: dimensions.height,
@@ -386,35 +378,32 @@ export class Encoder {
 					avc: codec.startsWith("avc1") ? { format: "annexb" } : undefined,
 					// @ts-expect-error Typescript needs to be updated.
 					hevc: codec.startsWith("hev1") ? { format: "annexb" } : undefined,
-				};
+				});
+				return supported === true;
+			} catch {
+				return false;
+			}
+		};
 
-				const { supported } = await VideoEncoder.isConfigSupported(hardware);
-				if (supported) return { codec, hardwareAcceleration };
+		// Try hardware encoding first.
+		// We can't reliably detect hardware encoding on Firefox: https://github.com/w3c/webcodecs/issues/896
+		if (!Util.Hacks.isFirefox) {
+			for (const codec of candidates(HARDWARE_CODECS)) {
+				if (await probe(codec, "prefer-hardware")) return { codec, hardwareAcceleration: "prefer-hardware" };
 			}
 		}
 
-		// Try software encoding.
-		for (const codec of SOFTWARE_CODECS) {
-			if (!codec.startsWith(required)) continue;
-
-			const hardwareAcceleration: HardwareAcceleration = "prefer-software";
-
-			const software: VideoEncoderConfig = {
-				codec,
-				width: dimensions.width,
-				height: dimensions.height,
-				latencyMode: "realtime",
-				hardwareAcceleration,
-				avc: codec.startsWith("avc1") ? { format: "annexb" } : undefined,
-				// @ts-expect-error Typescript needs to be updated.
-				hevc: codec.startsWith("hev1") ? { format: "annexb" } : undefined,
-			};
-
-			const { supported } = await VideoEncoder.isConfigSupported(software);
-			if (supported) return { codec, hardwareAcceleration };
+		// Then software encoding.
+		for (const codec of candidates(SOFTWARE_CODECS)) {
+			if (await probe(codec, "prefer-software")) return { codec, hardwareAcceleration: "prefer-software" };
 		}
 
-		throw new Error("no supported codec");
+		// Nothing encoded: skip this rendition instead of throwing out of the config effect (the caller
+		// early-returns on undefined), so a forced-but-unsupported codec just drops the rendition.
+		console.warn(
+			`no supported video encoder: codec=${required || "auto"} ${dimensions.width}x${dimensions.height}`,
+		);
+		return undefined;
 	}
 
 	close() {

--- a/js/publish/src/video/index.ts
+++ b/js/publish/src/video/index.ts
@@ -63,19 +63,33 @@ export class Root {
 		// NOTE: We modify the stock MediaStreamTrackProcessor so timestamps use our wall clock time.
 		// This is so even when the source is changed or encoder reloaded, the timestamps will be consistent.
 		const reader = TrackProcessor(source).getReader();
-		effect.cleanup(() => reader.cancel());
+		// cancel() rejects when the stream already errored (e.g. the worker crashed); swallow it so
+		// teardown doesn't emit an unhandled rejection.
+		effect.cleanup(() => reader.cancel().catch(() => {}));
 
 		effect.spawn(async () => {
-			for (;;) {
-				const next = await Promise.race([reader.read(), effect.cancel]);
-				if (!next?.value) break;
+			try {
+				for (;;) {
+					const next = await Promise.race([reader.read(), effect.cancel]);
+					if (!next?.value) break;
 
+					this.frame.update((prev) => {
+						prev?.close();
+						return next.value;
+					});
+
+					this.display.set({ width: next.value.codedWidth, height: next.value.codedHeight });
+				}
+			} catch (err) {
+				// The capture stream errored (e.g. the Safari worker crashed). effect.spawn swallows the
+				// rejection and the effect won't rerun on its own, so clear the last frame rather than
+				// leave a stale image looking live.
+				console.warn("video capture stopped:", err);
 				this.frame.update((prev) => {
 					prev?.close();
-					return next.value;
+					return undefined;
 				});
-
-				this.display.set({ width: next.value.codedWidth, height: next.value.codedHeight });
+				this.display.set(undefined);
 			}
 		});
 

--- a/js/publish/src/video/polyfill.ts
+++ b/js/publish/src/video/polyfill.ts
@@ -1,33 +1,171 @@
+import * as Util from "@moq/hang/util";
 import { Time } from "@moq/net";
+import type { CaptureToHost } from "./capture-worker";
 import type { StreamTrack } from "./types";
 
+/**
+ * A ReadableStream of camera VideoFrames, with timestamps rewritten onto our wall clock.
+ *
+ * Prefers MediaStreamTrackProcessor: on the main thread in Chrome, and in a Worker on known Safari
+ * 18+ (which only exposes it there). The Worker path keeps capturing while the publish window is
+ * occluded. Every other engine (Firefox, older or version-less WebKit) falls back to a
+ * requestAnimationFrame loop, which freezes when the page is hidden because the browser suspends rAF.
+ */
+export function TrackProcessor(track: StreamTrack): ReadableStream<VideoFrame> {
+	// Chrome exposes MediaStreamTrackProcessor on the main thread.
+	// @ts-expect-error MediaStreamTrackProcessor has no TypeScript types yet.
+	if (self.MediaStreamTrackProcessor) {
+		// @ts-expect-error MediaStreamTrackProcessor has no TypeScript types yet.
+		const input: ReadableStream<VideoFrame> = new self.MediaStreamTrackProcessor({ track }).readable;
+		return input.pipeThrough(rewriteTimestamps());
+	}
+
+	// Safari only exposes MediaStreamTrackProcessor inside a Worker, whose capture loop is not gated on
+	// the main-thread render loop, so it survives window occlusion (unlike the rAF fallback below). Take
+	// this path on WebKit 18+ (safariWorkerCapture), which has both worker-scope MediaStreamTrackProcessor
+	// and transferable MediaStreamTrack. That includes iOS Chrome/Firefox on iOS 18+ (all WebKit, detected
+	// via the iOS OS version). Anything we can't confirm is 18+ uses rAF rather than risk a doomed worker.
+	if (Util.Hacks.safariWorkerCapture) {
+		return workerTrackProcessor(track).pipeThrough(rewriteTimestamps());
+	}
+
+	return rafTrackProcessor(track);
+}
+
+/** Rewrite frame timestamps onto our wall clock so audio and video share one epoch. */
+function rewriteTimestamps(): TransformStream<VideoFrame, VideoFrame> {
+	let base: number | undefined;
+	let zero = 0;
+
+	return new TransformStream<VideoFrame, VideoFrame>({
+		transform(frame, controller) {
+			if (base === undefined) {
+				base = frame.timestamp;
+				zero = performance.now() * 1000;
+			}
+			const rewritten = new VideoFrame(frame, { timestamp: frame.timestamp - base + zero });
+			frame.close();
+			controller.enqueue(rewritten);
+		},
+	});
+}
+
+/**
+ * Capture VideoFrames via MediaStreamTrackProcessor running in a Worker. Only reached on known Safari
+ * 18+ (see {@link TrackProcessor}); the worker keeps producing frames while the publish window is
+ * occluded, which the main-thread rAF path cannot.
+ */
+function workerTrackProcessor(track: StreamTrack): ReadableStream<VideoFrame> {
+	let worker: Worker | undefined;
+	// settled: the stream has closed, errored, or been cancelled, so no further chunks may be enqueued
+	// and the worker should be gone.
+	let settled = false;
+
+	const teardown = () => {
+		worker?.terminate();
+		worker = undefined;
+	};
+
+	return new ReadableStream<VideoFrame>({
+		async start(controller) {
+			// Load the worker lazily. A static import would pull the ?worklet module into the eager
+			// capture graph, which breaks non-Vite loaders like `bun test` that lack the plugin.
+			const { default: workerUrl } = await import("./capture-worker.ts?worklet");
+
+			// cancel() can run while the import above is still pending (the Streams spec does not gate
+			// cancel on start settling); it sets `settled`. No worker exists yet, so bail before spawning
+			// one nothing would stop. There is no further await below, so this is the only window cancel
+			// can sneak through.
+			if (settled) return;
+
+			worker = new Worker(workerUrl, { type: "module" });
+
+			worker.onmessage = (event: MessageEvent<CaptureToHost>) => {
+				const message = event.data;
+
+				if (settled) {
+					// A frame already in flight when we closed/errored: close it so it doesn't leak.
+					if (message.type === "frame") message.frame.close();
+					return;
+				}
+
+				switch (message.type) {
+					case "frame":
+						// The worker captures an independent clone, so mirror the caller's track state here;
+						// the Chrome main-thread path reads the original track and gets this for free. A
+						// stopped source ends the stream (matching Chrome). A muted one (enabled === false)
+						// drops frames: this diverges from Chrome, which delivers black frames for a disabled
+						// track, so remote watchers see the last frame freeze rather than go black. Privacy
+						// holds either way; we drop rather than synthesize a black frame to stay simple.
+						if (track.readyState === "ended") {
+							message.frame.close();
+							settled = true;
+							controller.close();
+							teardown();
+							return;
+						}
+						// Drop rather than buffer when muted or when the consumer is behind. This only bounds
+						// frames the host has already received: the worker reads at full rate with no
+						// backpressure, so a stalled main thread can still queue transferred frames in the
+						// message channel ahead of this check.
+						if (!track.enabled || (controller.desiredSize ?? 1) <= 0) {
+							message.frame.close();
+							return;
+						}
+						controller.enqueue(message.frame);
+						break;
+					case "done":
+						settled = true;
+						controller.close();
+						teardown();
+						break;
+					case "error":
+						settled = true;
+						controller.error(new Error(`capture worker: ${message.message}`));
+						teardown();
+						break;
+				}
+			};
+			worker.onerror = (event) => {
+				if (settled) return;
+				settled = true;
+				// ErrorEvent.message is "" (not null) for opaque/load failures, so use || not ??.
+				controller.error(new Error(`capture worker crashed: ${event.message || "unknown"}`));
+				teardown();
+			};
+
+			// Clone so transferring into the Worker never neuters the caller's track; the clone shares the
+			// same camera source, so there is no second capture. On teardown the host terminates the
+			// worker, and the browser ends the transferred clone when the worker global is destroyed (so
+			// the camera indicator turns off).
+			const clone = track.clone();
+			try {
+				worker.postMessage({ track: clone }, [clone as unknown as Transferable]);
+			} catch (err) {
+				// Transferable MediaStreamTrack ships in every Safari that reaches this path, so a throw
+				// here is unexpected. Stop the un-moved clone and surface the failure.
+				clone.stop();
+				settled = true;
+				controller.error(err instanceof Error ? err : new Error(String(err)));
+				teardown();
+			}
+		},
+		cancel() {
+			settled = true;
+			teardown();
+		},
+	});
+}
+
+/**
+ * Last-resort capture for engines with no usable MediaStreamTrackProcessor: an HTMLVideoElement paced
+ * by requestAnimationFrame. The browser suspends rAF when the page is hidden or occluded, so this
+ * freezes in the background; prefer the Worker path above wherever possible.
+ */
 // Firefox doesn't support MediaStreamTrackProcessor so we need to use a polyfill.
 // Based on: https://jan-ivar.github.io/polyfills/mediastreamtrackprocessor.js
 // Thanks Jan-Ivar
-export function TrackProcessor(track: StreamTrack): ReadableStream<VideoFrame> {
-	// @ts-expect-error No typescript types yet.
-	if (self.MediaStreamTrackProcessor) {
-		// Rewrite timestamps onto our wall clock so audio and video share one epoch.
-		let base: number | undefined;
-		let zero = 0;
-
-		const rewrite = new TransformStream<VideoFrame>({
-			transform(frame, controller) {
-				if (base === undefined) {
-					base = frame.timestamp;
-					zero = performance.now() * 1000;
-				}
-				const rewrite = new VideoFrame(frame, { timestamp: frame.timestamp - base + zero });
-				frame.close();
-				controller.enqueue(rewrite);
-			},
-		});
-
-		// @ts-expect-error No typescript types yet.
-		const input: ReadableStream<VideoFrame> = new self.MediaStreamTrackProcessor({ track }).readable;
-		return input.pipeThrough(rewrite);
-	}
-
+function rafTrackProcessor(track: StreamTrack): ReadableStream<VideoFrame> {
 	// TODO Firefox supports this in a background worker.
 	console.warn("Using MediaStreamTrackProcessor polyfill; performance might suffer.");
 
@@ -36,35 +174,72 @@ export function TrackProcessor(track: StreamTrack): ReadableStream<VideoFrame> {
 		throw new Error("track has no settings");
 	}
 
-	let video: HTMLVideoElement;
+	let video: HTMLVideoElement | undefined;
 	let last: Time.Milli;
+	let cancelled = false;
 
 	const frameRate = settings.frameRate ?? 30;
 
+	// Stop the pull loop and release the hidden <video> so it stops decoding the camera. Idempotent,
+	// and called from cancel() and every error path: a ReadableStream does NOT invoke cancel() when
+	// start()/pull() reject, so without this the element would keep decoding until GC.
+	const release = () => {
+		cancelled = true;
+		if (video) {
+			video.pause();
+			video.srcObject = null;
+			video = undefined;
+		}
+	};
+
 	return new ReadableStream<VideoFrame>({
 		async start() {
-			video = document.createElement("video") as HTMLVideoElement;
-			video.srcObject = new MediaStream([track]);
-			await Promise.all([
-				video.play(),
-				new Promise((r) => {
-					video.onloadedmetadata = r;
-				}),
-			]);
+			const el = document.createElement("video") as HTMLVideoElement;
+			video = el;
+			el.srcObject = new MediaStream([track]);
+			try {
+				await Promise.all([
+					el.play(),
+					new Promise((r) => {
+						el.onloadedmetadata = r;
+					}),
+				]);
+			} catch (err) {
+				release();
+				throw err;
+			}
 
 			last = Time.Milli.now();
 		},
 		async pull(controller) {
-			while (true) {
-				const now = Time.Milli.now();
-				if (Time.Milli.sub(now, last) < Time.Milli(1000 / frameRate)) {
-					await new Promise((r) => requestAnimationFrame(r));
-					continue;
-				}
+			try {
+				while (!cancelled) {
+					// The source track can end underneath us (camera stopped/unplugged). The hidden <video>
+					// would otherwise keep handing back its last frame forever, so close the stream cleanly.
+					if (!video || track.readyState === "ended") {
+						controller.close();
+						release();
+						return;
+					}
 
-				last = now;
-				controller.enqueue(new VideoFrame(video, { timestamp: Time.Micro.fromMilli(last) }));
+					const now = Time.Milli.now();
+					if (Time.Milli.sub(now, last) < Time.Milli(1000 / frameRate)) {
+						await new Promise((r) => requestAnimationFrame(r));
+						continue;
+					}
+
+					last = now;
+					controller.enqueue(new VideoFrame(video, { timestamp: Time.Micro.fromMilli(last) }));
+				}
+			} catch (err) {
+				// new VideoFrame() throws once the <video> loses its current frame (e.g. the track ended
+				// mid-pull). Release and surface the error instead of leaking the element.
+				release();
+				throw err;
 			}
+		},
+		cancel() {
+			release();
 		},
 	});
 }

--- a/js/watch/src/support/index.ts
+++ b/js/watch/src/support/index.ts
@@ -1,5 +1,4 @@
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1967793
-const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
+import * as Util from "@moq/hang/util";
 
 export type Partial = "full" | "partial" | "none";
 
@@ -69,7 +68,7 @@ async function videoDecoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 	});
 
 	// We can't reliably detect hardware encoding on Firefox: https://github.com/w3c/webcodecs/issues/896
-	const unknown = isFirefox || hardware.config?.hardwareAcceleration !== "prefer-hardware";
+	const unknown = Util.Hacks.isFirefox || hardware.config?.hardwareAcceleration !== "prefer-hardware";
 
 	return {
 		hardware: unknown ? undefined : hardware.supported === true,
@@ -79,9 +78,11 @@ async function videoDecoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 
 export async function isSupported(): Promise<Full> {
 	return {
-		// Firefox's WebTransport drops server-initiated bidi streams, so we force the
-		// WebSocket fallback. Report "partial" to surface the degraded path in UI.
-		webtransport: typeof WebTransport !== "undefined" ? (isFirefox ? "partial" : "full") : "partial",
+		// Firefox drops server-initiated bidi streams, and reading datagrams kills the session on
+		// Safari, so both are forced onto the WebSocket fallback even though they define
+		// `WebTransport`. Report "partial" to surface the degraded path in UI.
+		webtransport:
+			typeof WebTransport !== "undefined" && !Util.Hacks.isFirefox && !Util.Hacks.isSafari ? "full" : "partial",
 		audio: {
 			decoding: {
 				aac: await audioDecoderSupported("aac"),


### PR DESCRIPTION
Split out of #2163.

> **Stacked on #2184** (it consumes `Util.Hacks.isSafari` / `safariWorkerCapture`). The first commit belongs to that PR; **review the second commit only**. The diff collapses once #2184 merges and I rebase.

Publishing on Safari was software-only, and the capture path stalled whenever the tab was hidden.

- **Hardware encode.** On Apple Silicon, VideoToolbox only hardware-encodes H.264 and HEVC. Safari nonetheless reports the *others* as `prefer-hardware` supported, so the support matrix was keying off an echoed hint that lies (they actually run on software libvpx). Key off the codec instead, and prefer the codecs that genuinely have a hardware path.
- **Worker capture.** WebKit 18+ exposes `MediaStreamTrackProcessor` in a worker (plus transferable `MediaStreamTrack`), so capture runs there instead of the `requestAnimationFrame` fallback, which pauses whenever the tab is hidden. The gate reads the iOS OS version when the Safari `Version/` token is absent, because iOS Chrome and Firefox are WebKit too and omit it, and the iOS major tracks the WebKit major. Anything older or undetectable keeps the rAF path.
- **Camera and microphone re-acquire when their track ends** (all browsers), and a backgrounded Safari tab no longer comes back with the camera stuck muted.
- **The video catalog no longer flaps.** It folds in the encoder-produced codec string and the hvcC/av1C description after the first keyframe, tagged against the requested codec and dimensions, so bandwidth-driven bitrate churn (which fires ~10x a second) can never rewrite the description underneath watchers.
- **The stats tab graphs a measured upload bitrate** from encoded bytes rather than a transport estimate, which Safari does not have at all (no `getStats()`).

**Public API changes:** `@moq/publish` gains `Video.Encoder.bytesEncoded`; `@moq/hang` gains `Util.Hacks.safariWorkerCapture` (both additive).

**Test plan:** `bun test js/publish/src/video js/hang/src/util`: 22 tests (codec ordering, catalog description folding against bitrate churn, worker-capture UA gate). `just js check` green. Verified on device: Safari publishes with hardware H.264 and keeps capturing in a background tab.

