### PR TITLE
fix(publish): advertise 48 kHz Opus and resample a non-canonical capture rate

### DIFF
--- a/doc/lib/js/@moq/publish.md
+++ b/doc/lib/js/@moq/publish.md
@@ -67,7 +67,7 @@ a real bundler (the examples below).
 - `url` (required) - Relay server URL
 - `name` (required) - Broadcast name
 - `source` - Input to capture: `"camera"`, `"screen"`, or `"file"`
-- `muted` - Mute audio capture (boolean)
+- `muted` - Stop capturing audio and publish silence in its place (a microphone is released and the OS recording indicator turns off; screen or file audio is detached); the audio track stays in the catalog so viewers don't rebuild (boolean)
 - `invisible` - Disable video capture (boolean)
 - `simulcast` - Also publish a lower-resolution `video/sd` rendition (a fraction of the source resolution) alongside `video/hd` (boolean)
 - `preview` - What the preview renders: `"source"` (default), `"encoded"`, or `"none"` to disable it (see [Preview element](#preview-element))

--- a/doc/lib/js/env/web.md
+++ b/doc/lib/js/env/web.md
@@ -54,7 +54,7 @@ Publish camera/microphone or screen as a MoQ broadcast.
 - `url` (required) - Relay server URL
 - `name` (required) - Broadcast name
 - `source` - "camera", "screen", or "file"
-- `muted` - Disable audio capture (boolean)
+- `muted` - Stop capturing audio and publish silence in its place (a microphone is released and the OS recording indicator turns off; screen or file audio is detached); the audio track stays in the catalog so viewers don't rebuild (boolean)
 - `invisible` - Disable video capture (boolean)
 - `simulcast` - Also publish a lower-resolution `video/sd` rendition (a fraction of the source resolution) alongside `video/hd` (boolean)
 

--- a/js/publish/README.md
+++ b/js/publish/README.md
@@ -69,7 +69,7 @@ The simplest way to publish a stream:
 | `url`       | string  | required | Relay server URL                |
 | `name`      | string  | required | Broadcast name                  |
 | `source`    | string  | —        | `"camera"`, `"screen"`, `"file"` |
-| `muted`     | boolean | false    | Mute audio capture              |
+| `muted`     | boolean | false    | Stop audio capture and publish silence (a mic is released, OS indicator off); track stays in the catalog |
 | `invisible` | boolean | false    | Disable video capture           |
 | `preview`   | string  | `"source"` | What the preview renders: `"source"`, `"encoded"`, `"none"` |
 | `announce`  | string  | `"source"` | When to publish: `"always"`, `"never"`, `"source"` (once a source is selected) |

--- a/js/publish/src/audio/cadence.test.ts
+++ b/js/publish/src/audio/cadence.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { snapCadence } from "./cadence";
+
+// Nominal 20 ms Opus frame.
+const NOMINAL = 20000;
+
+// Run a sequence of encoder-reported timestamps through the cadence snap, returning the emitted
+// container timestamps (what goes on the wire). The window defaults to half a frame, matching the
+// encoder's `max(nominal/2, quantum)` when the quantum is small (48 kHz / 20 ms).
+function run(actuals: number[], nominal = NOMINAL, window = nominal / 2): number[] {
+	let cadence: number | undefined;
+	return actuals.map((actual) => {
+		const { ts, next } = snapCadence(cadence, actual, nominal, window);
+		cadence = next;
+		return ts;
+	});
+}
+
+function deltas(ts: number[]): number[] {
+	return ts.slice(1).map((t, i) => t - ts[i]);
+}
+
+describe("snapCadence", () => {
+	it("flattens Safari's 18667/21333 quantized cadence to a constant 20000", () => {
+		// The exact alternation from the QA logs: frame starts land on the 128-sample capture grid.
+		const actuals = [0];
+		for (let i = 1; i < 40; i++) actuals.push(actuals[i - 1] + (i % 2 === 1 ? 18667 : 21333));
+		const out = run(actuals);
+		expect(out[0]).toBe(0);
+		expect(deltas(out).every((d) => d === NOMINAL)).toBe(true);
+	});
+
+	it("is an identity on an already-exact cadence (Chrome/Firefox)", () => {
+		const actuals = Array.from({ length: 20 }, (_, i) => i * NOMINAL);
+		expect(run(actuals)).toEqual(actuals);
+	});
+
+	it("re-anchors on a real gap larger than the window (mute / silence)", () => {
+		const out = run([0, 18667, 40000, 440000, 458667, 480000]);
+		expect(out).toEqual([0, 20000, 40000, 440000, 460000, 480000]);
+		expect(deltas(out)).toEqual([20000, 20000, 400000, 20000, 20000]);
+	});
+
+	it("keeps a fractional-nominal cadence contiguous at the ring index", () => {
+		// AAC: 1024 samples at 48 kHz = 21333.333.. us per frame; container timestamps must still land on
+		// exact 1024-sample boundaries once indexed by the watcher ring.
+		const nominal = (1024 / 48000) * 1_000_000;
+		const actuals = Array.from({ length: 30 }, (_, i) => Math.round(i * nominal));
+		const out = run(actuals, nominal);
+		const idx = out.map((t) => Math.round((t / 1_000_000) * 48000));
+		expect(
+			idx
+				.slice(1)
+				.map((v, i) => v - idx[i])
+				.every((d) => d === 1024),
+		).toBe(true);
+	});
+
+	it("widens the window to a full quantum at a low sample rate (8 kHz override)", () => {
+		// 8 kHz capture, 48 kHz encode: input chunks are 768 samples = 16000 us, so frame starts quantize
+		// to 16000 us and the encoder sets window = max(nominal/2, 16000) = 16000. Feed the actual
+		// floor(960N/768)*16000 stamping and assert it flattens to a constant 20000 (nominal/2 = 10000
+		// would NOT, since the max deviation is 12000 us).
+		const window = Math.max(NOMINAL / 2, 16000);
+		expect(window).toBe(16000);
+		const actuals = Array.from({ length: 40 }, (_, N) => Math.floor((960 * N) / 768) * 16000);
+		const out = run(actuals, NOMINAL, window);
+		expect(out[0]).toBe(0);
+		expect(deltas(out).every((d) => d === NOMINAL)).toBe(true);
+	});
+});

--- a/js/publish/src/audio/cadence.ts
+++ b/js/publish/src/audio/cadence.ts
@@ -1,0 +1,35 @@
+/**
+ * Frame-cadence timestamp snapping for the audio encoder. Kept in its own module (free of WebCodecs) so
+ * it can be unit tested directly.
+ *
+ * @module
+ */
+
+/**
+ * Snap an encoded frame's timestamp onto a running nominal cadence.
+ *
+ * When `actual` is within half a frame of the `expected` next slot it is pinned to that slot (returned
+ * rounded to whole microseconds for the container) and the cadence advances by `nominal`; a larger jump (a
+ * real gap: mute, DTX silence, suspend) re-anchors to `actual`. This removes the per-frame timestamp jitter
+ * Safari's AudioEncoder introduces by stamping each output frame with the timestamp of the input AudioData
+ * chunk that held its start, quantizing to the 128-sample capture-quantum grid (a 20 ms Opus frame
+ * alternates 18667/21333 us). It is an identity rewrite on an already-exact cadence (Chrome/Firefox).
+ *
+ * @param expected - the cadence clock's next expected timestamp (us), or undefined to anchor here
+ * @param actual - the encoder's reported timestamp (us) for this frame
+ * @param nominal - the nominal frame duration (us), how far the cadence advances per frame
+ * @param window - the snap tolerance (us): pin to `expected` within it, re-anchor beyond it. The caller
+ *   sizes this to absorb one capture quantum of jitter while staying under one frame (a real gap)
+ * @returns the container timestamp to emit and the next cadence value to carry forward
+ */
+export function snapCadence(
+	expected: number | undefined,
+	actual: number,
+	nominal: number,
+	window: number,
+): { ts: number; next: number } {
+	if (expected !== undefined && Math.abs(actual - expected) < window) {
+		return { ts: Math.round(expected), next: expected + nominal };
+	}
+	return { ts: actual, next: actual + nominal };
+}

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -17,9 +17,6 @@ const AAC_FRAME_SAMPLES = 1024; // AAC-LC encodes a fixed 1024 samples per frame
 // The WebCodecs/MP4 codec string for AAC-LC. "aac" is our user-facing shorthand.
 const AAC_CODEC = "mp4a.40.2";
 
-// Compiled and inlined as a blob URL via vite-plugin-worklet.
-import CaptureWorklet from "./capture-worklet.ts?worklet";
-
 // Selects the audio codec and its encoder settings. Either the bare codec name (all defaults) or an
 // object with the mime plus tuning knobs.
 export type Codec = Opus | Aac;
@@ -70,6 +67,11 @@ export type EncoderProps = {
 // channel count (which can differ from the requested count on some platforms, e.g. Safari/macOS).
 type Captured = { sampleRate: number; channelCount: number };
 
+// The capture format derived from the live source: the AudioContext rate, the worklet channel count,
+// and the audio kind. Persisted across a mute so the pipeline (context + worklet + catalog) survives
+// the audio source being released, publishing silence instead of dropping the audio track.
+type Format = { sampleRate: number; channelCount: number; kind: Kind };
+
 export class Encoder {
 	static readonly TRACK = "audio/data";
 	static readonly PRIORITY = Catalog.PRIORITY.audio;
@@ -90,6 +92,10 @@ export class Encoder {
 	// Observed capture format. #config (and thus #catalog) is derived from this plus the codec, so the
 	// worklet handlers only ever write here, never read-modify-write #config.
 	#captured = new Signal<Captured | undefined>(undefined);
+
+	// The capture format derived from the live source, persisted so a mute (which clears `source`)
+	// leaves it intact and #runPipeline keeps the AudioContext + worklet + catalog up. See #runFormat.
+	#format = new Signal<Format | undefined>(undefined);
 
 	#config = new Signal<Catalog.AudioConfig | undefined>(undefined);
 	readonly config: Getter<Catalog.AudioConfig | undefined> = this.#config;
@@ -112,13 +118,18 @@ export class Encoder {
 		this.channelCount = Signal.from<number | undefined>(props?.channelCount);
 		this.codec = Signal.from<Codec>(props?.codec ?? "opus");
 
+		this.#signals.run(this.#runFormat.bind(this));
+		this.#signals.run(this.#runPipeline.bind(this));
 		this.#signals.run(this.#runSource.bind(this));
 		this.#signals.run(this.#runGain.bind(this));
 		this.#signals.run(this.#runConfig.bind(this));
 		this.#signals.run(this.#runCatalog.bind(this));
 	}
 
-	#runSource(effect: Effect): void {
+	// Derive the capture format from the live source and persist it. NOT effect.set: a mute clears
+	// `source`, and we deliberately keep the last format so #runPipeline holds the AudioContext,
+	// worklet, and catalog up while the audio source is detached. Only a real change rebuilds.
+	#runFormat(effect: Effect): void {
 		const values = effect.getAll([this.enabled, this.source]);
 		if (!values) return;
 		const [_, rawSource] = values;
@@ -131,49 +142,73 @@ export class Encoder {
 		// macOS misreports a mono mic as stereo: getSettings().channelCount is undefined and
 		// MediaStreamAudioSourceNode.channelCount defaults to 2, so the graph carries (and Opus
 		// encodes) duplicated mono as stereo. Prefer an explicitly requested channel count, from
-		// the prop or the track's applied getUserMedia constraint, and force the worklet to mix to it.
-		const requestedChannels = effect.get(this.channelCount) ?? requestedChannelCount(source.track);
+		// the prop or the track's applied getUserMedia constraint; fall back to the settings count,
+		// then 2 (the source-node default). The worklet is pinned to this fixed count so it stays
+		// stable when the source detaches on mute and only the mono silence source drives the graph.
+		const channelCount =
+			effect.get(this.channelCount) ?? requestedChannelCount(source.track) ?? settings.channelCount ?? 2;
+
+		// Signal.set's deep-equality dedupe drops a rebuilt-but-identical format, so codec knob
+		// tweaks that rerun this effect never tear down the AudioContext.
+		this.#format.set({ sampleRate, channelCount, kind: source.kind });
+	}
+
+	// Build and hold the capture pipeline (AudioContext -> GainNode -> capture worklet) from the
+	// persisted #format. It outlives a mute, so the catalog never flaps. A silent ConstantSourceNode
+	// keeps the 0-output worklet pulled while no mic is attached, so it keeps emitting silence frames.
+	#runPipeline(effect: Effect): void {
+		const enabled = effect.get(this.enabled);
+		const format = effect.get(this.#format);
+		if (!enabled || !format) return;
 
 		const context = new AudioContext({
 			latencyHint: "interactive",
-			sampleRate,
+			sampleRate: format.sampleRate,
 		});
 		effect.cleanup(() => context.close());
-
-		const root = new MediaStreamAudioSourceNode(context, {
-			mediaStream: new MediaStream([source.track]),
-		});
-		effect.cleanup(() => root.disconnect());
 
 		const gain = new GainNode(context, {
 			gain: this.volume.peek(),
 		});
-		root.connect(gain);
 		effect.cleanup(() => gain.disconnect());
+
+		// A muted broadcast detaches its audio source (see element.ts), so nothing else drives the graph.
+		// This always-running silent source keeps the 0-output worklet processing so it keeps emitting
+		// silence frames on the same clock; without it the worklet would stop and the catalog flap. Its
+		// mono zeros up-mix to the worklet's fixed channel count, so a muted broadcast is true silence.
+		const silence = new ConstantSourceNode(context, { offset: 0 });
+		silence.connect(gain);
+		silence.start();
+		effect.cleanup(() => {
+			silence.stop();
+			silence.disconnect();
+		});
 
 		// Async because we need to wait for the worklet to be registered.
 		effect.spawn(async () => {
-			await context.audioWorklet.addModule(CaptureWorklet);
+			// Load lazily (compiled and inlined as a blob URL via vite-plugin-worklet). A static
+			// import would pull the ?worklet module into the eager graph, which breaks non-Vite
+			// loaders like `bun test` that lack the plugin.
+			const { default: captureWorklet } = await import("./capture-worklet.ts?worklet");
+			await context.audioWorklet.addModule(captureWorklet);
 			if (context.state === "closed") return;
 
-			const channelCount = requestedChannels ?? settings.channelCount ?? root.channelCount;
 			const worklet = new AudioWorkletNode(context, "capture", {
 				numberOfInputs: 1,
 				numberOfOutputs: 0,
-				channelCount,
-				// "explicit" forces Web Audio to (down)mix the input to channelCount before the
-				// worklet sees it. The default "max" just follows the input, which is the unreliable
-				// path on macOS. Only force it when we actually have a requested count to honor.
-				channelCountMode: requestedChannels !== undefined ? "explicit" : "max",
+				channelCount: format.channelCount,
+				// "explicit" pins the count so it can't drift when the source detaches on mute and only the
+				// mono silence source drives the graph; the worklet (down)mixes every input to it.
+				channelCountMode: "explicit",
 				// Stamp audio against the same wall clock as video (see video/polyfill.ts), so both
-				// tracks share an epoch and stay in sync.
+				// tracks share an epoch. Fixed once per pipeline, so the epoch survives a mute/unmute.
 				processorOptions: { zero: performance.now() * 1000 },
 			});
 
 			effect.set(this.#worklet, worklet);
 
-			// The information about channels count can be unreliable on different platforms (Apple's Safari).
-			// Try to get the first audio frame and only then record the captured format.
+			// The channel count can be unreliable across platforms (Apple's Safari). Record the captured
+			// format from the first frame the worklet emits (silence or mic, both at the fixed count).
 			effect.event(
 				worklet.port,
 				"message",
@@ -197,6 +232,23 @@ export class Encoder {
 			// Only set the gain after the worklet is registered.
 			effect.set(this.#gain, gain);
 		});
+	}
+
+	// Attach the live source track to the pipeline gain. Keyed on `source` alone: a mute clears it and
+	// this effect tears the source node down, leaving the silent keep-alive to drive the worklet.
+	// Unmuting re-attaches the source (re-acquiring the mic when there is one) and reconnects here,
+	// all on the same AudioContext (no catalog flap).
+	#runSource(effect: Effect): void {
+		const rawSource = effect.get(this.source);
+		const gain = effect.get(this.#gain);
+		if (!rawSource || !gain) return;
+
+		const track = normalizeSource(rawSource).track;
+		const root = new MediaStreamAudioSourceNode(gain.context as AudioContext, {
+			mediaStream: new MediaStream([track]),
+		});
+		root.connect(gain);
+		effect.cleanup(() => root.disconnect());
 	}
 
 	#createConfig(captured: Captured, codec: OpusConfig | AacConfig): Catalog.AudioConfig {
@@ -304,15 +356,20 @@ export class Encoder {
 					track.close(err);
 				},
 			});
-			effect.cleanup(() => encoder.close());
+			// Guard against double-close: a fatal error auto-closes the encoder, and close() on a closed
+			// encoder throws InvalidStateError, aborting the signals dispose loop and leaking the sibling effects.
+			effect.cleanup(() => {
+				if (encoder.state !== "closed") encoder.close();
+			});
 
 			let config: Catalog.AudioConfig | undefined;
 			effect.run((effect: Effect) => {
 				config = effect.get(this.#config);
 				if (!config) return;
 
-				const source = effect.get(this.source);
-				const kind: Kind = source ? normalizeSource(source).kind : "auto";
+				// Read the persisted format's kind, not `source`: a mute clears `source` but must not
+				// reconfigure the encoder (voice -> auto would drop DTX) while it publishes silence.
+				const kind: Kind = effect.get(this.#format)?.kind ?? "auto";
 				const encoderConfig = toEncoderConfig(config, kind, this.#opusOptions(effect));
 
 				console.debug("encoding audio", encoderConfig);

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -4,13 +4,24 @@ import * as Util from "@moq/hang/util";
 import type * as Moq from "@moq/net";
 import { Time } from "@moq/net";
 import { Effect, type Getter, Signal } from "@moq/signals";
+import { snapCadence } from "./cadence";
 import type * as Capture from "./capture";
+import { StreamResampler } from "./resampler";
 import { type Kind, normalizeSource, type Source } from "./types";
 
 const GAIN_MIN = 0.001;
 const FADE_TIME = 0.2;
 const OPUS_BITRATE_PER_CHANNEL = 32_000;
 const OPUS_FRAME_DURATION = Time.Milli(20);
+// Opus decoders always emit 48 kHz PCM (RFC 6716) regardless of the encoder's input rate, so the
+// catalog must advertise 48000 for watchers to build their pipeline at. The capture rate (which can
+// be e.g. 16 kHz on Safari's voice-processed mic) stays private to the encoder.
+const OPUS_OUTPUT_RATE = 48000;
+// When resampling capture PCM to the encoder rate (Safari's non-canonical hardware rate -> 48 kHz), the
+// output-clock timestamp is synthesized from a running sample counter. If the capture clock ever drifts
+// more than one frame from that synthesized clock (e.g. a dropped capture chunk or a clock jump),
+// re-anchor to the live capture timestamp so audio never lags real time (and video) forever.
+const RESAMPLE_REANCHOR_US = 20000;
 const AAC_BITRATE_PER_CHANNEL = 64_000;
 const AAC_FRAME_SAMPLES = 1024; // AAC-LC encodes a fixed 1024 samples per frame.
 
@@ -137,7 +148,13 @@ export class Encoder {
 
 		const settings = source.track.getSettings();
 		const overrideSampleRate = effect.get(this.sampleRate);
-		const sampleRate = overrideSampleRate ?? settings.sampleRate;
+		// For Opus, default the capture context to 48 kHz instead of the device rate: Web Audio
+		// resamples the source transparently, low-rate devices (Bluetooth telephony at 8/16 kHz)
+		// lose their quirks, and device rates libopus rejects (44.1 kHz) never reach a native
+		// encoder's configure(). An explicit sampleRate override still wins.
+		const codecDefaultRate =
+			normalizeCodec(effect.get(this.codec)).mime === "opus" ? OPUS_OUTPUT_RATE : settings.sampleRate;
+		const sampleRate = overrideSampleRate ?? codecDefaultRate;
 
 		// macOS misreports a mono mic as stereo: getSettings().channelCount is undefined and
 		// MediaStreamAudioSourceNode.channelCount defaults to 2, so the graph carries (and Opus
@@ -273,7 +290,10 @@ export class Encoder {
 
 		return {
 			codec: "opus",
-			sampleRate,
+			// The catalog carries what DECODERS output, and Opus decoders always emit 48 kHz whatever
+			// rate we capture/encode at. Advertising the capture rate here garbles playback: the watcher
+			// builds its ring at the catalog rate, then receives 48 kHz-dense samples.
+			sampleRate: Catalog.u53(OPUS_OUTPUT_RATE),
 			numberOfChannels,
 			bitrate: Catalog.u53(codec.bitrate ?? captured.channelCount * OPUS_BITRATE_PER_CHANNEL),
 			container: { kind: "legacy" } as const,
@@ -338,17 +358,49 @@ export class Encoder {
 			// We're using an async polyfill temporarily for Safari support.
 			await Util.Libav.polyfill();
 
+			let cadence: number | undefined; // nominal frame-cadence clock for the timestamp snap below
 			const encoder = new AudioEncoder({
 				output: (frame) => {
 					if (frame.type !== "key") {
 						throw new Error("only key frames are supported");
 					}
 
+					// Snap the container timestamp onto the nominal frame cadence. Safari's AudioEncoder
+					// stamps each output frame with the timestamp of the INPUT AudioData chunk holding its
+					// start, quantizing to the 128-sample capture-quantum grid (a 20 ms Opus frame alternates
+					// 18667/21333 us). That per-frame jitter makes the watcher's timestamp-indexed ring
+					// zero-fill or overwrite a sample every frame and crackle. Chrome/Firefox already emit an
+					// exact cadence, so this is an identity rewrite; a gap over the window (mute, DTX silence,
+					// suspend) re-anchors to the real timestamp. Device- and option-independent: capture
+					// timestamps are sample-counted (capture-worklet.ts), the rate is whatever the context
+					// actually runs at, and `nominal` tracks the encoder's frameDuration.
+					let ts = frame.timestamp as number;
+					if (config) {
+						const nominal =
+							config.codec === "opus"
+								? (config.jitter ?? OPUS_FRAME_DURATION) * 1000
+								: (AAC_FRAME_SAMPLES / worklet.context.sampleRate) * 1_000_000;
+						// One capture quantum in stream time. Rate-conversion-invariant: the resampler emits
+						// exactly one output chunk per 128-sample capture chunk, so the encoder's input-chunk
+						// duration (the stamping granularity) is 128/captureRate whatever the encode rate.
+						const quantum = (128 / worklet.context.sampleRate) * 1_000_000;
+						if (quantum < nominal) {
+							// Absorb up to one quantum of jitter, never a real frame gap.
+							const snapped = snapCadence(cadence, ts, nominal, Math.max(nominal / 2, quantum));
+							ts = snapped.ts;
+							cadence = snapped.next;
+						} else {
+							// Frame no larger than one quantum: jitter is indistinguishable from a real
+							// one-frame gap, so pass the raw timestamp through.
+							cadence = undefined;
+						}
+					}
+
 					// Each audio frame is its own group so the relay can forward it without
 					// waiting for a group boundary. Loss is handled by the codec's PLC.
 					track.writeFrame({
-						data: Container.Legacy.encodeFrame(frame, frame.timestamp as Time.Micro),
-						timestamp: Time.Timestamp.fromMicros(frame.timestamp as Time.Micro),
+						data: Container.Legacy.encodeFrame(frame, ts as Time.Micro),
+						timestamp: Time.Timestamp.fromMicros(ts as Time.Micro),
 					});
 				},
 				error: (err) => {
@@ -370,12 +422,22 @@ export class Encoder {
 				// Read the persisted format's kind, not `source`: a mute clears `source` but must not
 				// reconfigure the encoder (voice -> auto would drop DTX) while it publishes silence.
 				const kind: Kind = effect.get(this.#format)?.kind ?? "auto";
-				const encoderConfig = toEncoderConfig(config, kind, this.#opusOptions(effect));
+				const encoderConfig = toEncoderConfig(
+					config,
+					// Opus is configured at the canonical 48 kHz to match the resampled AudioData (see the
+					// port "message" handler); other codecs use the actual capture rate.
+					config.codec === "opus" ? OPUS_OUTPUT_RATE : worklet.context.sampleRate,
+					kind,
+					this.#opusOptions(effect),
+				);
 
 				console.debug("encoding audio", encoderConfig);
+				cadence = undefined; // re-anchor the cadence snap on (re)configure
 				encoder.configure(encoderConfig);
 			});
 
+			let resampler: StreamResampler | undefined;
+			let anchor = 0; // capture-clock time (us) of the resampler's first output sample
 			effect.event(worklet.port, "message", (event: Event) => {
 				const data = (event as MessageEvent<Capture.AudioFrame>).data;
 				const channelCount = data.channels.length;
@@ -386,7 +448,42 @@ export class Encoder {
 					return;
 				}
 
-				const channels = data.channels;
+				const captureRate = worklet.context.sampleRate;
+				// Opus must be fed a canonical rate (48 kHz). Chrome/Firefox honor the 48 kHz context
+				// request so captureRate is already 48000 and this is a bypass; Safari ignores it and
+				// captures at the hardware rate (~44.1 kHz, which native Opus misencodes into scratchy
+				// audio), so resample to 48 kHz before encoding. Mirror of the watch-side resampler.
+				const encodeRate = config.codec === "opus" ? OPUS_OUTPUT_RATE : captureRate;
+
+				let channels = data.channels;
+				let timestamp = data.timestamp;
+				if (captureRate !== encodeRate) {
+					if (!resampler) {
+						resampler = new StreamResampler(captureRate, encodeRate);
+						anchor = data.timestamp;
+						console.debug(
+							`audio: capture at ${captureRate} Hz, resampling to ${encodeRate} Hz for the encoder`,
+						);
+					} else {
+						// Defensive re-anchor: if the capture clock ever runs far past our synthesized output
+						// clock (e.g. a dropped capture chunk or a clock jump), snap to it instead of letting
+						// the synthesized timestamps keep counting from a stale anchor and lag real time forever.
+						const expected = anchor + (resampler.emitted / encodeRate) * 1e6;
+						if (Math.abs(data.timestamp - expected) > RESAMPLE_REANCHOR_US) {
+							resampler = new StreamResampler(captureRate, encodeRate);
+							anchor = data.timestamp;
+						}
+					}
+					channels = resampler.resample(channels);
+					if (channels[0].length === 0) return; // no output for this chunk yet
+					// Stamp on the encoder's 48 kHz clock: the first sample of this chunk sits at
+					// anchor + (emitted so far - this chunk's samples) / encodeRate. Derived from the absolute
+					// counter (not an incremented running total) so rounding never accumulates.
+					timestamp = Math.round(
+						anchor + ((resampler.emitted - channels[0].length) / encodeRate) * 1e6,
+					) as Time.Micro;
+				}
+
 				const joinedLength = channels.reduce((a, b) => a + b.length, 0);
 				const joined = new Float32Array(joinedLength);
 
@@ -397,10 +494,10 @@ export class Encoder {
 
 				const frame = new AudioData({
 					format: "f32-planar",
-					sampleRate: worklet.context.sampleRate,
+					sampleRate: encodeRate,
 					numberOfFrames: channels[0].length,
 					numberOfChannels: channels.length,
-					timestamp: data.timestamp,
+					timestamp,
 					data: joined,
 					transfer: [joined.buffer],
 				});
@@ -472,15 +569,22 @@ function opusKindDefaults(kind: Kind): OpusEncoderConfigExt {
 
 // Build the WebCodecs encoder config from the catalog (decoder) config, a Kind hint, and any
 // Opus-only knobs. Those knobs are kept out of the catalog since they only affect encoding. AAC has
-// no such knobs, so it just uses the shared base fields (codec/sampleRate/channels/bitrate).
+// no such knobs, so it just uses the shared base fields (codec/channels/bitrate).
+//
+// encodeRate is the sample rate of the AudioData fed to the encoder: the capture context's rate,
+// or 48 kHz once the Opus path has resampled it (see the port "message" handler above). The
+// encoder MUST be configured at that rate (native encoders reject mismatched input), while the
+// catalog can advertise a different decode rate (48 kHz for Opus).
+
 function toEncoderConfig(
 	config: Catalog.AudioConfig,
+	encodeRate: number,
 	kind: Kind,
 	opusOptions: OpusEncoderConfigExt,
 ): AudioEncoderConfig {
 	const encoderConfig: AudioEncoderConfig = {
 		codec: config.codec,
-		sampleRate: config.sampleRate,
+		sampleRate: encodeRate,
 		numberOfChannels: config.numberOfChannels,
 		bitrate: config.bitrate,
 	};

--- a/js/publish/src/audio/resampler.test.ts
+++ b/js/publish/src/audio/resampler.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import { StreamResampler } from "./resampler";
+
+// Safari captures Opus at the hardware rate (~44.1 kHz) and we resample to the canonical 48 kHz before
+// encoding. These pin the sample bookkeeping the encoder relies on to synthesize contiguous timestamps.
+const CAPTURE_RATE = 44100;
+const ENCODE_RATE = 48000;
+const QUANTUM = 128; // one AudioWorklet render quantum
+
+// Mirror the encoder's timestamp synthesis: anchor + (output samples emitted before this chunk) / rate.
+function synthTimestamp(anchor: number, emittedBefore: number): number {
+	return Math.round(anchor + (emittedBefore / ENCODE_RATE) * 1e6);
+}
+
+// Mirror the watcher ring's index: round(timestamp_seconds * rate).
+function ringIndex(timestampMicro: number): number {
+	return Math.round((timestampMicro / 1e6) * ENCODE_RATE);
+}
+
+describe("StreamResampler", () => {
+	it("tracks a running output-sample count", () => {
+		const r = new StreamResampler(CAPTURE_RATE, ENCODE_RATE);
+		let total = 0;
+		for (let i = 0; i < 200; i++) {
+			const out = r.resample([new Float32Array(QUANTUM)]);
+			total += out[0].length;
+			expect(r.emitted).toBe(total);
+			// 128 input samples at 44.1 kHz become ~139.3 at 48 kHz, so 139 or 140 per chunk.
+			expect(out[0].length === 139 || out[0].length === 140).toBe(true);
+		}
+		// Over many quanta the running count tracks the rate ratio to within a sample.
+		const expected = Math.round((200 * QUANTUM * ENCODE_RATE) / CAPTURE_RATE);
+		expect(Math.abs(total - expected)).toBeLessThanOrEqual(1);
+	});
+
+	it("synthesized timestamps index the ring back-to-back (no gap, no overlap)", () => {
+		const r = new StreamResampler(CAPTURE_RATE, ENCODE_RATE);
+		const anchor = 123_456; // arbitrary capture-clock epoch (us)
+		let prevStart: number | undefined;
+		let prevLen = 0;
+		for (let i = 0; i < 500; i++) {
+			const emittedBefore = r.emitted;
+			const len = r.resample([new Float32Array(QUANTUM)])[0].length;
+			if (len === 0) continue;
+			const start = ringIndex(synthTimestamp(anchor, emittedBefore));
+			if (prevStart !== undefined) {
+				// The whole point: each chunk starts exactly where the previous one ended.
+				expect(start).toBe(prevStart + prevLen);
+			}
+			prevStart = start;
+			prevLen = len;
+		}
+	});
+
+	it("raw capture-clock timestamps would NOT be contiguous (why the encoder synthesizes timestamps)", () => {
+		// Stamp each chunk with the capture-clock time of its first input sample and index the ring with
+		// it: consecutive chunks land off-by-a-sample, forcing zero-fill/overwrite. That is why the
+		// encoder instead synthesizes timestamps from the sample counter (see the previous test).
+		const r = new StreamResampler(CAPTURE_RATE, ENCODE_RATE);
+		let captureSamples = 0;
+		let prevStart: number | undefined;
+		let prevLen = 0;
+		let discontinuities = 0;
+		for (let i = 0; i < 500; i++) {
+			const captureTs = Math.round((captureSamples / CAPTURE_RATE) * 1e6);
+			const len = r.resample([new Float32Array(QUANTUM)])[0].length;
+			captureSamples += QUANTUM;
+			if (len === 0) continue;
+			const start = ringIndex(captureTs);
+			if (prevStart !== undefined && start !== prevStart + prevLen) discontinuities++;
+			prevStart = start;
+			prevLen = len;
+		}
+		expect(discontinuities).toBeGreaterThan(0);
+	});
+});

--- a/js/publish/src/audio/resampler.ts
+++ b/js/publish/src/audio/resampler.ts
@@ -1,0 +1,69 @@
+/**
+ * Continuous linear resampler for a stream of PCM chunks, used to feed Opus a canonical 48 kHz stream
+ * when the capture context runs at a non-canonical hardware rate (Safari pins ~44.1 kHz and ignores
+ * `AudioContext({ sampleRate: 48000 })`).
+ *
+ * @module
+ */
+
+/**
+ * Continuous linear resampler for a stream of PCM chunks (one rate -> another). Carries the sub-sample
+ * phase and the previous chunk's last sample across chunks, so there is NO per-chunk discontinuity. A
+ * per-chunk-independent resample would inject a slope kink every ~3 ms that the Opus encoder then bakes
+ * in as an audible buzz.
+ */
+export class StreamResampler {
+	readonly #ratio: number; // input samples advanced per output sample
+	#pos = 0; // source position (input-sample units, relative to the current chunk start) of the next output
+	#prev: number[] | undefined; // last input sample per channel from the previous chunk
+	#emitted = 0; // total output samples emitted across all chunks (drives the output-clock timestamp)
+
+	/** Build a resampler from `inputRate` Hz to `outputRate` Hz. */
+	constructor(inputRate: number, outputRate: number) {
+		this.#ratio = inputRate / outputRate;
+	}
+
+	/**
+	 * Total output samples produced so far. The caller stamps each resampled AudioData with a timestamp
+	 * derived from this counter (anchor + emitted / outputRate) so timestamps advance on the SAME clock as
+	 * the sample counts. Stamping with the raw capture-clock timestamp instead makes consecutive Opus
+	 * frames land a fraction of a sample off in the watcher's timestamp-indexed ring buffer, which
+	 * zero-fills or overwrites a sample every frame and crackles.
+	 */
+	get emitted(): number {
+		return this.#emitted;
+	}
+
+	/** Resample one chunk of planar PCM; returns the output chunk (possibly empty if nothing is ready yet). */
+	resample(channels: Float32Array[]): Float32Array[] {
+		const n = channels[0]?.length ?? 0;
+		if (n === 0) return channels.map(() => new Float32Array(0));
+
+		const ratio = this.#ratio;
+		const numCh = channels.length;
+
+		// How many output samples fall within reach this chunk (their bracketing input samples exist).
+		let count = 0;
+		for (let p = this.#pos; p <= n - 1; p += ratio) count++;
+
+		const out = channels.map(() => new Float32Array(count));
+		let p = this.#pos;
+		for (let j = 0; j < count; j++, p += ratio) {
+			const i0 = Math.floor(p);
+			const frac = p - i0;
+			for (let c = 0; c < numCh; c++) {
+				const ch = channels[c];
+				// i0 is >= -1 (the carried phase never falls further back than the previous chunk's tail).
+				const s0 = i0 < 0 ? (this.#prev?.[c] ?? ch[0]) : ch[i0];
+				const s1 = ch[Math.min(i0 + 1, n - 1)];
+				out[c][j] = s0 * (1 - frac) + s1 * frac;
+			}
+		}
+
+		// Shift the next output position into the next chunk's coordinate; remember the boundary sample.
+		this.#pos = p - n;
+		this.#prev = channels.map((ch) => ch[n - 1]);
+		this.#emitted += count;
+		return out;
+	}
+}

--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -45,10 +45,18 @@ export default class MoqPublish extends HTMLElement {
 	audio = new Signal<Source.Microphone | Source.Screen | undefined>(undefined);
 	file = new Signal<Source.File | undefined>(undefined);
 
-	// The inverse of the `muted` and `invisible` signals.
+	// Whether the audio/video encoder pipelines run. #audioEnabled stays true across `muted`; see
+	// #micEnabled below for why (the encoder keeps publishing silence, the audio input is what's gated).
 	#videoEnabled: Signal<boolean>;
 	#audioEnabled: Signal<boolean>;
 	#eitherEnabled: Signal<boolean>;
+
+	// Whether the microphone should actually capture: audio enabled AND not muted. Muting stops audio
+	// capture without dropping the published track: a mic track is stopped (releasing the OS device and
+	// its recording indicator), while screen/file audio, whose track can't be stopped without killing
+	// the share, is detached in the source branches instead. The encoder pipeline stays up and publishes
+	// silence, so watchers keep their audio subtree instead of rebuilding it.
+	#micEnabled: Signal<boolean>;
 
 	// Set when `simulcast` is enabled and video is not `invisible`.
 	#sdEnabled: Signal<boolean>;
@@ -71,10 +79,12 @@ export default class MoqPublish extends HTMLElement {
 		});
 		this.signals.cleanup(() => this.connection.close());
 
-		// The inverse of the `muted` and `invisible` signals.
 		// TODO make this.signals.computed to simplify the code.
 		this.#videoEnabled = new Signal(false);
-		this.#audioEnabled = new Signal(false);
+		// Always on; muting gates the audio input (see #micEnabled and the screen/file source
+		// branches), not the pipeline.
+		this.#audioEnabled = new Signal(true);
+		this.#micEnabled = new Signal(false);
 		this.#eitherEnabled = new Signal(false);
 		this.#sdEnabled = new Signal(false);
 
@@ -83,7 +93,7 @@ export default class MoqPublish extends HTMLElement {
 			const invisible = effect.get(this.state.invisible);
 			const simulcast = effect.get(this.state.simulcast);
 			this.#videoEnabled.set(!invisible);
-			this.#audioEnabled.set(!muted);
+			this.#micEnabled.set(effect.get(this.#audioEnabled) && !muted);
 			this.#eitherEnabled.set(!muted || !invisible);
 			this.#sdEnabled.set(simulcast && !invisible);
 		});
@@ -108,6 +118,9 @@ export default class MoqPublish extends HTMLElement {
 
 			audio: {
 				enabled: this.#audioEnabled,
+				// Muting stops audio capture (see #micEnabled); this fades the encoder gain to zero in step,
+				// so any in-flight samples during the teardown are silenced and unmute fades back in.
+				muted: this.state.muted,
 			},
 			video: {
 				hd: {
@@ -232,16 +245,16 @@ export default class MoqPublish extends HTMLElement {
 		if (!source) return;
 
 		if (source === "camera") {
+			// These proxies are scoped to this run so they close before the capture below, which would
+			// otherwise clear its `source` signal and let a stale proxy write over the next source.
 			const video = new Source.Camera({ enabled: this.#videoEnabled });
-			this.signals.run((effect) => {
-				const source = effect.get(video.source);
-				this.broadcast.video.source.set(source);
+			effect.run((effect) => {
+				effect.set(this.broadcast.video.source, effect.get(video.source));
 			});
 
-			const audio = new Source.Microphone({ enabled: this.#audioEnabled });
-			this.signals.run((effect) => {
-				const source = effect.get(audio.source);
-				this.broadcast.audio.source.set(source);
+			const audio = new Source.Microphone({ enabled: this.#micEnabled });
+			effect.run((effect) => {
+				effect.set(this.broadcast.audio.source, effect.get(audio.source));
 			});
 
 			effect.set(this.video, video);
@@ -260,12 +273,15 @@ export default class MoqPublish extends HTMLElement {
 				enabled: this.#eitherEnabled,
 			});
 
-			this.signals.run((effect) => {
+			effect.run((effect) => {
 				const source = effect.get(screen.source);
 				if (!source) return;
 
+				// The shared screen track can't be stopped without killing video (and re-prompting), so
+				// mute detaches its audio from the encoder instead. The pipeline keeps publishing silence.
+				const muted = effect.get(this.state.muted);
 				effect.set(this.broadcast.video.source, source.video);
-				effect.set(this.broadcast.audio.source, source.audio);
+				effect.set(this.broadcast.audio.source, muted ? undefined : source.audio);
 			});
 
 			effect.set(this.video, screen);
@@ -293,10 +309,12 @@ export default class MoqPublish extends HTMLElement {
 
 			effect.set(this.file, fileSource);
 
-			this.signals.run((effect) => {
+			effect.run((effect) => {
 				const source = effect.get(fileSource.source);
-				this.broadcast.video.source.set(source.video);
-				this.broadcast.audio.source.set(source.audio);
+				// Mute detaches the file's audio from the encoder; the pipeline keeps publishing silence.
+				const muted = effect.get(this.state.muted);
+				effect.set(this.broadcast.video.source, source.video);
+				effect.set(this.broadcast.audio.source, muted ? undefined : source.audio);
 			});
 
 			effect.cleanup(() => {

--- a/js/publish/src/ui/components/audio-toggle.ts
+++ b/js/publish/src/ui/components/audio-toggle.ts
@@ -3,7 +3,7 @@ import type MoqPublish from "../../element";
 import { icon, micOff, microphone } from "../icons";
 import { controlButton } from "./button";
 
-/** Toggles whether audio is published (publish.muted). Red when muted. */
+/** Toggles publish.muted: stops audio capture and publishes silence in its place. Red when muted. */
 export function audioToggle(parent: Effect, publish: MoqPublish): HTMLElement {
 	const button = controlButton(microphone, "Mute");
 
@@ -12,7 +12,7 @@ export function audioToggle(parent: Effect, publish: MoqPublish): HTMLElement {
 		const muted = effect.get(publish.state.muted);
 		button.disabled = !hasSource;
 		button.classList.toggle("control--off", hasSource && muted);
-		button.title = muted ? "Unmute microphone" : "Mute microphone";
+		button.title = muted ? "Unmute audio" : "Mute audio";
 		button.setAttribute("aria-label", button.title);
 		button.replaceChildren(icon(muted ? micOff : microphone));
 	});


### PR DESCRIPTION
Split out of #2163.

> **Stacked on #2186** (the resampling lives inside the encoder pipeline that PR creates). The first commit belongs to that PR; **review the second commit only**. The diff collapses once #2186 merges and I rebase.

**The Opus catalog advertised the wrong sample rate.** Opus decoders always emit 48 kHz PCM (RFC 6716) whatever rate the encoder was fed, but we advertised the *capture* rate. A watcher then built its ring buffer at, say, 44.1 kHz and received 48 kHz-dense samples, which garbles playback. The catalog now always advertises 48000 (what decoders actually output) and the capture rate stays private to the encoder.

That exposed the other half of the problem: **Safari ignores the `AudioContext` sample-rate request** and captures at the hardware rate anyway, so the encoder was handed 44.1 kHz audio that native Opus misencodes into scratchy noise. Capture PCM is now resampled to 48 kHz before encoding when the rates differ. This is a no-op on Chrome and Firefox, which honor the request. Timestamps on the output clock are derived from an absolute sample counter (not an incremented running total) so rounding can never accumulate, and re-anchor to the live capture clock if it ever drifts more than a frame, so audio cannot silently lag real time forever.

Also **snaps the container timestamp onto the nominal frame cadence.** Safari stamps each output frame with the timestamp of the *input* chunk holding its start, quantized to the 128-sample capture grid, so a 20 ms Opus frame alternates 18667/21333 µs. That jitter makes the watcher's timestamp-indexed ring zero-fill or overwrite a sample every frame and crackle. Chrome and Firefox already emit an exact cadence, so there it is an identity rewrite, and a real gap (mute, DTX silence, suspend) re-anchors rather than being smeared over.

**Public API changes:** none.

**Test plan:** `bun test js/publish/src/audio`: 8 tests over the cadence-snapping and resampler math (~900 assertions, including that the snap is an identity on an exact cadence and re-anchors across a real gap). `just js check` green. Verified on device: Safari audio is clean instead of scratchy.

