### PR TITLE
feat(watch): surface unsupported codec errors

### DIFF
--- a/doc/lib/js/@moq/watch.md
+++ b/doc/lib/js/@moq/watch.md
@@ -246,7 +246,7 @@ The component exposes everything via its `broadcast` property
 
 ## UI Overlay
 
-Import `@moq/watch/ui` for a Web Component overlay with buffering indicator, stats panel, and playback controls:
+Import `@moq/watch/ui` for a Web Component overlay with buffering indicator, unsupported-codec indicator, stats panel, and playback controls:
 
 ```html
 <script type="module">

--- a/js/watch/README.md
+++ b/js/watch/README.md
@@ -109,7 +109,7 @@ watch.video.media.subscribe((stream) => {
 
 ## UI Web Component
 
-`@moq/watch` includes a Web Component UI overlay (`<moq-watch-ui>`) with playback controls, volume, buffering indicator, quality selector, and stats panel. It is built on top of `@moq/signals` with no framework dependency.
+`@moq/watch` includes a Web Component UI overlay (`<moq-watch-ui>`) with playback controls, volume, buffering indicator, unsupported-codec indicator, quality selector, and stats panel. It is built on top of `@moq/signals` with no framework dependency.
 
 ```html
 <script type="module">

--- a/js/watch/src/ui/components/buffering-indicator.ts
+++ b/js/watch/src/ui/components/buffering-indicator.ts
@@ -11,7 +11,8 @@ export function bufferingIndicator(parent: Effect, watch: MoqWatch): HTMLElement
 	parent.run((effect) => {
 		const buffering = effect.get(watch.backend.video.stalled);
 		const offline = effect.get(watch.broadcast.status) === "offline";
-		container.style.display = buffering && !offline ? "" : "none";
+		const unsupported = effect.get(watch.backend.video.source.error) === "unsupported";
+		container.style.display = buffering && !offline && !unsupported ? "" : "none";
 	});
 
 	return container;

--- a/js/watch/src/ui/components/center-play.ts
+++ b/js/watch/src/ui/components/center-play.ts
@@ -13,7 +13,8 @@ export function centerPlay(parent: Effect, watch: MoqWatch): HTMLElement {
 
 	parent.run((effect) => {
 		const paused = effect.get(watch.backend.paused);
-		button.style.display = paused ? "" : "none";
+		const sourceError = effect.get(watch.backend.video.source.error);
+		button.style.display = paused && !sourceError ? "" : "none";
 	});
 
 	parent.event(button, "click", () => {

--- a/js/watch/src/ui/components/unsupported-indicator.ts
+++ b/js/watch/src/ui/components/unsupported-indicator.ts
@@ -1,0 +1,30 @@
+import type { Effect } from "@moq/signals";
+import type MoqWatch from "../../element";
+
+/** Shows why video cannot start when every catalog rendition is unsupported. */
+export function unsupportedIndicator(parent: Effect, watch: MoqWatch): HTMLElement {
+	const container = document.createElement("div");
+	container.className = "watch-ui__unsupported-indicator";
+	container.setAttribute("role", "status");
+	container.setAttribute("aria-live", "polite");
+
+	const text = document.createElement("span");
+	text.className = "watch-ui__unsupported-text";
+	container.appendChild(text);
+
+	parent.run((effect) => {
+		const unsupported = effect.get(watch.backend.video.source.error) === "unsupported";
+		const offline = effect.get(watch.broadcast.status) === "offline";
+		const show = unsupported && !offline;
+		container.style.display = show ? "" : "none";
+		if (!show) return;
+
+		const renditions = effect.get(watch.backend.video.source.catalog)?.renditions ?? {};
+		const codecs = [...new Set(Object.values(renditions).map((rendition) => rendition.codec))].join(", ");
+		text.textContent = codecs
+			? `This video codec is not supported by your browser: ${codecs}`
+			: "This video codec is not supported by your browser";
+	});
+
+	return container;
+}

--- a/js/watch/src/ui/element.ts
+++ b/js/watch/src/ui/element.ts
@@ -6,6 +6,7 @@ import { centerPlay } from "./components/center-play";
 import { controlBar } from "./components/control-bar";
 import { offlineIndicator } from "./components/offline-indicator";
 import { settingsPanel } from "./components/settings-panel";
+import { unsupportedIndicator } from "./components/unsupported-indicator";
 import type { Tab, UiState } from "./state";
 import styles from "./styles/index.css?inline";
 
@@ -64,9 +65,14 @@ export default class MoqWatchUi extends HTMLElement {
 		// The slotted <moq-watch> (canvas/video) sits at the base of the stack.
 		player.appendChild(DOM.create("slot"));
 
-		// Center affordances: play prompt + buffering spinner + offline notice.
+		// Center affordances: play prompt + buffering spinner + offline / unsupported-codec notice.
 		const center = DOM.create("div", { className: "center" });
-		center.append(centerPlay(effect, watch), bufferingIndicator(effect, watch), offlineIndicator(effect, watch));
+		center.append(
+			centerPlay(effect, watch),
+			bufferingIndicator(effect, watch),
+			offlineIndicator(effect, watch),
+			unsupportedIndicator(effect, watch),
+		);
 
 		// Top scrim keeps the bottom bar legible and hosts ambient gradient.
 		const scrimTop = DOM.create("div", { className: "scrim scrim--top" });

--- a/js/watch/src/ui/styles/index.css
+++ b/js/watch/src/ui/styles/index.css
@@ -5,3 +5,4 @@
 @import "./buffer-control.css";
 @import "./buffering-indicator.css";
 @import "./offline-indicator.css";
+@import "./unsupported-indicator.css";

--- a/js/watch/src/ui/styles/unsupported-indicator.css
+++ b/js/watch/src/ui/styles/unsupported-indicator.css
@@ -1,0 +1,34 @@
+.watch-ui__unsupported-indicator {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	max-width: min(80%, 32rem);
+	padding: 0.75rem 1.25rem;
+	transform: translate(-50%, -50%);
+	text-align: center;
+	background-color: var(--color-black-alpha-85);
+	border-radius: 0.25rem;
+	z-index: 4;
+	pointer-events: auto;
+}
+
+.watch-ui__unsupported-text {
+	font-size: 0.875rem;
+	font-weight: 600;
+	line-height: 1.4;
+	color: var(--color-white);
+}
+
+@media (max-width: 480px) {
+	.watch-ui__unsupported-indicator {
+		max-width: 90%;
+		padding: 0.625rem 0.875rem;
+	}
+
+	.watch-ui__unsupported-text {
+		font-size: 0.75rem;
+	}
+}

--- a/js/watch/src/video/source.test.ts
+++ b/js/watch/src/video/source.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+import type * as Catalog from "@moq/hang/catalog";
+import { Signal } from "@moq/signals";
+import type { Broadcast } from "../broadcast";
+import { Sync } from "../sync";
+import { Source } from "./source";
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+async function settle(): Promise<void> {
+	for (let i = 0; i < 5; i++) await flush();
+}
+
+function config(codec: string): Catalog.VideoConfig {
+	return { codec, container: { kind: "legacy" } };
+}
+
+function broadcast(renditions: Record<string, Catalog.VideoConfig>): Broadcast {
+	return {
+		connection: new Signal(undefined),
+		catalog: new Signal({ video: { renditions } }),
+	} as unknown as Broadcast;
+}
+
+async function withoutWarnings(fn: () => Promise<void>): Promise<void> {
+	const warn = console.warn;
+	console.warn = () => {};
+	try {
+		await fn();
+	} finally {
+		console.warn = warn;
+	}
+}
+
+describe("Source error signal", () => {
+	it("is unsupported when the catalog has video renditions but none are supported", async () => {
+		await withoutWarnings(async () => {
+			const sync = new Sync();
+			const source = new Source(sync, {
+				broadcast: broadcast({ hd: config("hev1.1.6.L120.90") }),
+				supported: async () => false,
+			});
+
+			await settle();
+			expect(source.error.peek()).toBe("unsupported");
+			expect(source.available.peek()).toEqual({});
+
+			source.close();
+			sync.close();
+		});
+	});
+
+	it("treats a support probe throw as unsupported without aborting the remaining renditions", async () => {
+		await withoutWarnings(async () => {
+			const sync = new Sync();
+			const source = new Source(sync, {
+				broadcast: broadcast({
+					bad: config("not-a-codec"),
+					good: config("avc1.640028"),
+				}),
+				supported: async (rendition) => {
+					if (rendition.codec === "not-a-codec") throw new Error("probe failed");
+					return true;
+				},
+			});
+
+			await settle();
+			expect(source.error.peek()).toBeUndefined();
+			expect(Object.keys(source.available.peek())).toEqual(["good"]);
+
+			source.close();
+			sync.close();
+		});
+	});
+
+	it("is undefined when the catalog has no video renditions", async () => {
+		const sync = new Sync();
+		const source = new Source(sync, {
+			broadcast: broadcast({}),
+			supported: async () => false,
+		});
+
+		await settle();
+		expect(source.error.peek()).toBeUndefined();
+		expect(source.available.peek()).toEqual({});
+
+		source.close();
+		sync.close();
+	});
+});

--- a/js/watch/src/video/source.ts
+++ b/js/watch/src/video/source.ts
@@ -9,6 +9,9 @@ import type { Sync } from "../sync";
  */
 export type Supported = (config: Catalog.VideoConfig) => Promise<boolean>;
 
+/** A video source error that prevents choosing a usable rendition. */
+export type SourceError = "unsupported";
+
 export type SourceProps = {
 	broadcast?: Broadcast | Signal<Broadcast | undefined>;
 	target?: Target | Signal<Target | undefined>;
@@ -197,6 +200,10 @@ export class Source {
 	#available = new Signal<Record<string, Catalog.VideoConfig>>({});
 	readonly available: Getter<Record<string, Catalog.VideoConfig>> = this.#available;
 
+	#error = new Signal<SourceError | undefined>(undefined);
+	/** The current source error, or undefined while healthy or still probing. */
+	readonly error: Getter<SourceError | undefined> = this.#error;
+
 	// The name of the active rendition.
 	#track = new Signal<string | undefined>(undefined);
 	readonly track: Getter<string | undefined> = this.#track;
@@ -227,22 +234,37 @@ export class Source {
 
 	#runSupported(effect: Effect): void {
 		const supported = effect.get(this.supported);
-		if (!supported) return;
+		if (!supported) {
+			this.#error.set(undefined);
+			return;
+		}
 
 		const renditions = effect.get(this.catalog)?.renditions ?? {};
+		this.#error.set(undefined);
 
 		effect.spawn(async () => {
 			const available: Record<string, Catalog.VideoConfig> = {};
 
 			for (const [name, config] of Object.entries(renditions)) {
-				const isSupported = await supported(config);
+				let isSupported = false;
+				try {
+					isSupported = await supported(config);
+				} catch (err) {
+					console.warn(
+						`[Source] video rendition ${name} (${config.codec}) support probe failed; treating as unsupported`,
+						err,
+					);
+				}
 				if (isSupported) available[name] = config;
 			}
 
-			if (Object.keys(available).length === 0 && Object.keys(renditions).length > 0) {
+			const error =
+				Object.keys(available).length === 0 && Object.keys(renditions).length > 0 ? "unsupported" : undefined;
+			if (error === "unsupported") {
 				console.warn("[Source] No supported video renditions found:", renditions);
 			}
 
+			this.#error.set(error);
 			this.#available.set(available);
 		});
 	}


### PR DESCRIPTION
Split from #2187 so the unsupported-codec UI can land independently from decoder recovery work.

Summary:
- Add `Video.Source.error` with `SourceError = "unsupported"` when the catalog has video renditions but none pass the backend support probe.
- Show an unsupported-codec notice in `<moq-watch-ui>` and suppress the buffering spinner for that state.
- Hide the center play prompt while a source error is visible so the notice does not overlap it.
- Treat support-probe exceptions as unsupported for that rendition so one malformed codec string does not abort the scan.

Public API changes:
- `@moq/watch` adds `Video.SourceError`.
- `Video.Source` adds `error: Getter<SourceError | undefined>`.
- No breaking changes. This targets `main`.

Test plan:
- `bun biome check js/watch/src/video/source.ts js/watch/src/video/source.test.ts js/watch/src/ui/components/buffering-indicator.ts js/watch/src/ui/components/center-play.ts js/watch/src/ui/components/unsupported-indicator.ts js/watch/src/ui/element.ts js/watch/src/ui/styles/index.css js/watch/src/ui/styles/unsupported-indicator.css`
- `bun test js/watch/src`
- `bun run --filter="@moq/watch" check`
- `bun run --filter="@moq/watch" build`

Credit:
- Authored as @fperex from #2187.

(Written by GPT-5)