### PR TITLE
fix(net): support WebTransport datagram API variants

### DIFF
--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -227,6 +227,90 @@ test("integration: lite draft-05 datagrams not sent on a non-datagram transport"
 	server.close();
 });
 
+test("integration: lite draft-05 datagrams sent with standards-track createWritable", async () => {
+	const enc = new TextEncoder();
+	const dec = new TextDecoder();
+	const pair = createMockTransportPair(Lite.ALPN_05, { datagramWritable: "createWritable" });
+
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	const broadcast = new BroadcastProducer();
+	server.publish(Path.from("test"), broadcast);
+	const producer = broadcast.createTrack("video", { timescale: Timescale.MILLI });
+
+	const remote = client.consume(Path.from("test"));
+	const track = remote.track("video").subscribe();
+
+	const received = track.recvDatagram();
+	let stop = false;
+	const pump = (async () => {
+		for (let i = 0; !stop; i++) {
+			producer.appendDatagram(Timestamp.fromMillis(i), enc.encode("dgram"));
+			await sleep(2);
+		}
+	})();
+
+	const got = await received;
+	stop = true;
+	await pump;
+
+	expect(got).toBeDefined();
+	expect(dec.decode(got?.payload)).toBe("dgram");
+
+	broadcast.close();
+	remote.close();
+	client.close();
+	server.close();
+});
+
+test("integration: lite draft-05 missing datagram writer does not close streams", async () => {
+	const enc = new TextEncoder();
+	const pair = createMockTransportPair(Lite.ALPN_05, { datagramWritable: "none" });
+
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	const broadcast = new BroadcastProducer();
+	server.publish(Path.from("test"), broadcast);
+	const producer = broadcast.createTrack("video", { timescale: Timescale.MILLI });
+
+	const remote = client.consume(Path.from("test"));
+	const track = remote.track("video").subscribe();
+
+	producer.appendDatagram(Timestamp.fromMillis(0), enc.encode("dgram"));
+	producer.writeString("group");
+
+	expect(await track.readString()).toBe("group");
+
+	broadcast.close();
+	remote.close();
+	client.close();
+	server.close();
+});
+
+test("integration: lite draft-05 missing datagram reader does not close streams", async () => {
+	const enc = new TextEncoder();
+	const pair = createMockTransportPair(Lite.ALPN_05, { datagramReadable: false });
+
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	const broadcast = new BroadcastProducer();
+	server.publish(Path.from("test"), broadcast);
+	const producer = broadcast.createTrack("video", { timescale: Timescale.MILLI });
+
+	const remote = client.consume(Path.from("test"));
+	const track = remote.track("video").subscribe();
+
+	producer.appendDatagram(Timestamp.fromMillis(0), enc.encode("dgram"));
+	producer.writeString("group");
+
+	expect(await track.readString()).toBe("group");
+
+	broadcast.close();
+	remote.close();
+	client.close();
+	server.close();
+});
+
 test("integration: lite draft-05 fetches a cached group", async () => {
 	const enc = new TextEncoder();
 	const dec = new TextDecoder();

--- a/js/net/src/lite/datagram_stream.test.ts
+++ b/js/net/src/lite/datagram_stream.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test";
+import * as DatagramStream from "./datagram_stream.ts";
+
+test("datagram writer disables send when createWritable throws", () => {
+	const transport = {
+		datagrams: {
+			maxDatagramSize: 1200,
+			createWritable: () => {
+				throw new Error("unsupported");
+			},
+		},
+	} as unknown as WebTransport;
+
+	expect(DatagramStream.datagramWriter(transport)).toBeUndefined();
+});

--- a/js/net/src/lite/datagram_stream.ts
+++ b/js/net/src/lite/datagram_stream.ts
@@ -1,0 +1,55 @@
+/** Compatibility helpers for browser WebTransport datagram stream shape changes. */
+
+/** The current standards-track datagram send stream, plus Chrome's legacy writable property. */
+interface DatagramDuplex {
+	readonly readable?: ReadableStream<Uint8Array>;
+	readonly writable?: WritableStream<Uint8Array>;
+	readonly maxDatagramSize?: number;
+	createWritable?: () => WritableStream<Uint8Array>;
+}
+
+function datagrams(quic: WebTransport): DatagramDuplex | undefined {
+	return (quic as unknown as { datagrams?: DatagramDuplex }).datagrams;
+}
+
+/** The max outgoing datagram payload size, or 0 when this transport cannot send datagrams. */
+export function maxDatagramSize(quic: WebTransport): number {
+	const size = datagrams(quic)?.maxDatagramSize;
+	return typeof size === "number" && size > 0 ? size : 0;
+}
+
+/** Get a datagram reader, or undefined when this browser/transport does not expose one. */
+export function datagramReader(quic: WebTransport): ReadableStreamDefaultReader<Uint8Array> | undefined {
+	const readable = datagrams(quic)?.readable;
+	if (!readable) {
+		console.warn("datagram receive disabled: WebTransport datagrams.readable is unavailable");
+		return undefined;
+	}
+
+	try {
+		return readable.getReader();
+	} catch (err: unknown) {
+		console.warn("datagram receive disabled: failed to open WebTransport datagram reader", err);
+		return undefined;
+	}
+}
+
+/** Get a datagram writer, or undefined when this browser/transport does not expose one. */
+export function datagramWriter(quic: WebTransport): WritableStreamDefaultWriter<Uint8Array> | undefined {
+	const stream = datagrams(quic);
+	if (!stream || maxDatagramSize(quic) === 0) return undefined;
+
+	const writable = typeof stream.createWritable === "function" ? stream.createWritable() : stream.writable;
+
+	if (!writable) {
+		console.warn("datagram send disabled: WebTransport datagram writable stream is unavailable");
+		return undefined;
+	}
+
+	try {
+		return writable.getWriter();
+	} catch (err: unknown) {
+		console.warn("datagram send disabled: failed to open WebTransport datagram writer", err);
+		return undefined;
+	}
+}

--- a/js/net/src/lite/datagram_stream.ts
+++ b/js/net/src/lite/datagram_stream.ts
@@ -39,14 +39,13 @@ export function datagramWriter(quic: WebTransport): WritableStreamDefaultWriter<
 	const stream = datagrams(quic);
 	if (!stream || maxDatagramSize(quic) === 0) return undefined;
 
-	const writable = typeof stream.createWritable === "function" ? stream.createWritable() : stream.writable;
-
-	if (!writable) {
-		console.warn("datagram send disabled: WebTransport datagram writable stream is unavailable");
-		return undefined;
-	}
-
 	try {
+		const writable = typeof stream.createWritable === "function" ? stream.createWritable() : stream.writable;
+		if (!writable) {
+			console.warn("datagram send disabled: WebTransport datagram writable stream is unavailable");
+			return undefined;
+		}
+
 		return writable.getWriter();
 	} catch (err: unknown) {
 		console.warn("datagram send disabled: failed to open WebTransport datagram writer", err);

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -8,6 +8,7 @@ import type * as track from "../track.ts";
 import { error } from "../util/error.ts";
 import { AnnounceInit, AnnounceOk, type AnnounceRequest, encodeAnnounceBroadcast } from "./announce.ts";
 import { Datagram as DatagramMessage } from "./datagram.ts";
+import * as DatagramStream from "./datagram_stream.ts";
 import type { Fetch } from "./fetch.ts";
 import { Group as GroupMessage } from "./group.ts";
 import type { Origin } from "./origin.ts";
@@ -94,8 +95,8 @@ export class Publisher {
 
 		// Grab the datagram writer up front when the transport carries datagrams (no group
 		// fallback, so it stays undefined otherwise). One writer for all subscriptions.
-		if (hasDatagrams(version) && quic.datagrams.maxDatagramSize > 0) {
-			this.#datagramWriter = quic.datagrams.writable.getWriter();
+		if (hasDatagrams(version)) {
+			this.#datagramWriter = DatagramStream.datagramWriter(quic);
 		}
 	}
 
@@ -461,7 +462,7 @@ export class Publisher {
 	async #runDatagrams(sub: bigint, track: track.Subscriber, timescale: Timescale) {
 		const writer = this.#datagramWriter;
 		if (!writer) return; // Only reached with a writer (see the #datagramWriter gate).
-		const maxSize = this.#quic.datagrams.maxDatagramSize;
+		const maxSize = DatagramStream.maxDatagramSize(this.#quic);
 
 		try {
 			for (;;) {

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -12,6 +12,7 @@ import { error } from "../util/error.ts";
 import { withTimeout } from "../util/timeout.ts";
 import { AnnounceInit, AnnounceOk, AnnounceRequest, decodeAnnounceBroadcastMaybe } from "./announce.ts";
 import { Datagram as DatagramMessage } from "./datagram.ts";
+import * as DatagramStream from "./datagram_stream.ts";
 import { Fetch as FetchMessage } from "./fetch.ts";
 import type { Group as GroupMessage } from "./group.ts";
 import type { Origin } from "./origin.ts";
@@ -684,14 +685,16 @@ export class Subscriber {
 	 * @internal
 	 */
 	async runDatagrams(): Promise<void> {
-		if (!hasDatagrams(this.version) || this.#quic.datagrams.maxDatagramSize === 0) {
+		if (!hasDatagrams(this.version) || DatagramStream.maxDatagramSize(this.#quic) === 0) {
 			return;
 		}
 
 		// Never reject: this loop is awaited alongside the connection's other tasks, so a
 		// datagram-stream failure must not tear the whole session down (it's best-effort).
+		const reader = DatagramStream.datagramReader(this.#quic);
+		if (!reader) return;
+
 		try {
-			const reader = this.#quic.datagrams.readable.getReader();
 			try {
 				for (;;) {
 					const { value, done } = await reader.read();
@@ -708,7 +711,12 @@ export class Subscriber {
 				reader.releaseLock();
 			}
 		} catch (err: unknown) {
-			console.warn("datagram stream error", err);
+			const e = error(err);
+			if (e.message === "The session is closed.") {
+				console.debug(`datagram receive stopped: ${e.message}`);
+			} else {
+				console.warn("datagram stream error", err);
+			}
 		}
 	}
 

--- a/js/net/src/mock.ts
+++ b/js/net/src/mock.ts
@@ -45,7 +45,12 @@ class MockTransport implements WebTransport {
 	// Reference to the peer so we can enqueue streams to them
 	#peer?: MockTransport;
 
-	constructor(protocol: string, datagramsEnabled = true) {
+	constructor(
+		protocol: string,
+		datagramsEnabled = true,
+		datagramWritable: DatagramWritableApi = "writable",
+		datagramReadable = true,
+	) {
 		this.protocol = protocol;
 		this.ready = Promise.resolve(undefined);
 		this.closed = new Promise((resolve) => {
@@ -71,11 +76,13 @@ class MockTransport implements WebTransport {
 			// A real datagram duplex: writes enqueue into the peer's incoming readable,
 			// so a peer pair actually exchanges datagrams (unlike a real qmux Session,
 			// whose datagram streams are inert stubs).
-			const readable = new ReadableStream<Uint8Array>({
-				start: (controller) => {
-					this.#datagramController = controller;
-				},
-			});
+			const readable = datagramReadable
+				? new ReadableStream<Uint8Array>({
+						start: (controller) => {
+							this.#datagramController = controller;
+						},
+					})
+				: undefined;
 			const writable = new WritableStream<Uint8Array>({
 				write: (chunk) => {
 					const peer = this.#peer;
@@ -90,15 +97,29 @@ class MockTransport implements WebTransport {
 					}
 				},
 			});
-			this.datagrams = {
+			const datagrams: {
+				readable?: ReadableStream<Uint8Array>;
+				writable?: WritableStream<Uint8Array>;
+				maxDatagramSize: number;
+				incomingHighWaterMark: number;
+				outgoingHighWaterMark: number;
+				incomingMaxAge: null;
+				outgoingMaxAge: null;
+				createWritable?: () => WritableStream<Uint8Array>;
+			} = {
 				readable,
-				writable,
 				incomingHighWaterMark: 0,
 				outgoingHighWaterMark: 0,
 				incomingMaxAge: null,
 				outgoingMaxAge: null,
 				maxDatagramSize: 1200,
 			};
+			if (datagramWritable === "writable") {
+				datagrams.writable = writable;
+			} else if (datagramWritable === "createWritable") {
+				datagrams.createWritable = () => writable;
+			}
+			this.datagrams = datagrams as WebTransportDatagramDuplexStream;
 		} else {
 			// Simulate a transport that doesn't carry datagrams (maxDatagramSize 0): the
 			// wire layer must fall back to not sending, with no group fallback.
@@ -212,6 +233,8 @@ class MockTransport implements WebTransport {
 	}
 }
 
+type DatagramWritableApi = "writable" | "createWritable" | "none";
+
 /** Options for {@link createMockTransportPair}. */
 export interface MockTransportOptions {
 	/**
@@ -220,13 +243,19 @@ export interface MockTransportOptions {
 	 * session), so the wire layer must fall back to not sending datagrams.
 	 */
 	datagrams?: boolean;
+
+	/** Which outgoing datagram API shape the mock exposes. */
+	datagramWritable?: DatagramWritableApi;
+
+	/** Whether the incoming datagram readable stream is exposed. */
+	datagramReadable?: boolean;
 }
 
 /**
  * Creates a pair of connected MockTransport instances.
  *
  * @param protocol - The WebTransport protocol identifier (e.g. "moqt-17", "moql", "")
- * @param options - Optional behavior toggles (e.g. disabling datagrams)
+ * @param options - Optional behavior toggles for datagram availability
  * @returns An object containing `client` and `server` transports
  */
 export function createMockTransportPair(
@@ -234,8 +263,8 @@ export function createMockTransportPair(
 	options?: MockTransportOptions,
 ): { client: WebTransport; server: WebTransport } {
 	const datagrams = options?.datagrams ?? true;
-	const client = new MockTransport(protocol, datagrams);
-	const server = new MockTransport(protocol, datagrams);
+	const client = new MockTransport(protocol, datagrams, options?.datagramWritable, options?.datagramReadable);
+	const server = new MockTransport(protocol, datagrams, options?.datagramWritable, options?.datagramReadable);
 	client.setPeer(server);
 	server.setPeer(client);
 	return { client, server };


### PR DESCRIPTION
## Summary

Replaces and closes #2184. The previous fix forced Safari onto the WebSocket fallback, but the immediate crash is caused by using Chrome's legacy `transport.datagrams.writable` shape unconditionally.

This PR adds a small WebTransport datagram compatibility helper that:

- prefers the standards-track `transport.datagrams.createWritable()` send API
- falls back to Chrome's legacy `transport.datagrams.writable`
- disables datagram send or receive with a warning when the browser does not expose that side or fails while opening it
- keeps normal stream delivery working when datagrams are unavailable

## Root Cause

Safari exposes the newer datagram write shape, where `writable` is not present and callers create a writable stream with `createWritable()`. The publisher was doing `quic.datagrams.writable.getWriter()` during connection setup, so Safari threw before the connection could continue.

## Public API Changes

None. This is internal JS transport compatibility only.

## Test Plan

- `bun test js/net/src/lite/datagram_stream.test.ts js/net/src/integration.test.ts`
- `nix develop --command just js check`
- `nix develop --command just js ci`
- Manual Safari playback on `http://localhost:5173/watch.html`

(Written by GPT-5)