### PR TITLE
fix(net,watch): recover the viewer from a same-name republish

### DIFF
--- a/demo/web/src/index.ts
+++ b/demo/web/src/index.ts
@@ -164,17 +164,14 @@ function createTile(name: string): WatchTile {
 // Broadcast discovery
 // ---------------------------------------------------------------------------
 //
-// Subscribe to announcements under the prefix and keep a live set of active
-// broadcasts. `announced.next()` drains a queue, so we track membership
-// ourselves: active=true adds the path, active=false removes it.
+// Subscribe to announcements under the prefix and keep a live set of active broadcasts.
+// `announced.next()` drains the update stream, so we track membership ourselves: active=true adds the
+// path, active=false removes it. `Reload.announced()` spans reconnects (it retracts everything on
+// disconnect and re-announces on reconnect), so the set self-heals without any extra wiring here.
 const discovery = new Signals.Effect();
 discovery.run((effect) => {
-	const conn = effect.get(connection.established);
-	broadcasts.set([]);
-	if (!conn) return;
-
 	const prefix = prefixPath(effect.get(prefixInput));
-	const announced = conn.announced(prefix);
+	const announced = connection.announced(prefix);
 	effect.cleanup(() => announced.close());
 
 	const live = new Set<string>();

--- a/js/net/src/announced.test.ts
+++ b/js/net/src/announced.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test";
+import * as Announce from "./announced.ts";
+import * as Path from "./path.ts";
+
+const p = (s: string) => Path.from(s);
+
+test("next streams every appended event in order", async () => {
+	const producer = new Announce.Producer();
+	const consumer = producer.consume();
+
+	producer.append({ path: p("a"), active: true });
+	producer.append({ path: p("a"), active: false });
+
+	expect(await consumer.next()).toEqual({ path: p("a"), active: true });
+	expect(await consumer.next()).toEqual({ path: p("a"), active: false });
+});
+
+test("a same-name re-announce is a distinct update", async () => {
+	const producer = new Announce.Producer();
+	const consumer = producer.consume();
+
+	// A republish (a lite-06 RESTART, or an unannounce+announce that coalesces) arrives as a
+	// redundant active:true. The stream carries it as its own update, which is what lets a watcher
+	// notice the new instance even though membership never observably flipped.
+	producer.append({ path: p("a"), active: true });
+	producer.append({ path: p("a"), active: true });
+
+	expect(await consumer.next()).toEqual({ path: p("a"), active: true });
+	expect(await consumer.next()).toEqual({ path: p("a"), active: true });
+});
+
+test("closing resolves next with undefined", async () => {
+	const producer = new Announce.Producer();
+	const consumer = producer.consume();
+
+	producer.close();
+	expect(await consumer.next()).toBeUndefined();
+});
+
+test("aborting rejects next", async () => {
+	const producer = new Announce.Producer();
+	const consumer = producer.consume();
+
+	producer.close(new Error("boom"));
+	await expect(consumer.next()).rejects.toThrow("boom");
+});

--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -1,4 +1,5 @@
-import { Effect, type Getter, Signal } from "@moq/signals";
+import { Effect, Signal } from "@moq/signals";
+import * as Announce from "../announced.ts";
 import type * as Path from "../path.ts";
 import { empty as emptyPath } from "../path.ts";
 import { type ConnectProps, connect, type WebSocketOptions, type WebTransportProps } from "./connect.ts";
@@ -54,12 +55,6 @@ export class Reload {
 	/** The currently established session, or undefined while disconnected. */
 	established = new Signal<Established | undefined>(undefined);
 
-	// All actively announced broadcast paths, updated reactively.
-	#announced = new Signal<Set<Path.Valid>>(new Set());
-
-	/** The set of broadcast paths currently announced by the server, updated reactively. */
-	readonly announced: Getter<Set<Path.Valid>> = this.#announced;
-
 	/** WebTransport options applied to each connection attempt (not reactive). */
 	webtransport?: WebTransportProps;
 
@@ -113,7 +108,6 @@ export class Reload {
 
 		// Create a reactive root so cleanup is easier.
 		this.signals.run(this.#connect.bind(this));
-		this.signals.run(this.#runAnnounced.bind(this));
 	}
 
 	#connect(effect: Effect): void {
@@ -173,42 +167,65 @@ export class Reload {
 		});
 	}
 
-	#runAnnounced(effect: Effect): void {
-		this.#announced.set(new Set());
+	/**
+	 * Subscribe to broadcast announcements under an optional prefix, spanning reconnects.
+	 *
+	 * The same {@link Announce.Consumer} stream as {@link Established.announced}, but everything active
+	 * is retracted (an `active: false` update) whenever the connection drops and re-announced on
+	 * reconnect, so a consumer draining `next()` never clings to a dead route across a reconnect.
+	 */
+	announced(prefix: Path.Valid = emptyPath()): Announce.Consumer {
+		const producer = new Announce.Producer(prefix);
+		const consumer = producer.consume();
 
-		const conn = effect.get(this.established);
-		if (!conn) return;
-
-		effect.cleanup(() => this.#announced.set(new Set()));
-
-		// Cloudflare's relay does not yet support SUBSCRIBE_NAMESPACE, so
-		// skip announce subscriptions entirely for those hosts.
-		if (conn.url.hostname.endsWith("mediaoverquic.com")) {
-			return;
-		}
-
-		const announced = conn.announced(emptyPath());
-		effect.cleanup(() => announced.close());
-
-		effect.spawn(async () => {
-			try {
-				for (;;) {
-					const entry = await Promise.race([effect.cancel, announced.next()]);
-					if (!entry) break;
-
-					this.#announced.mutate((active) => {
-						if (entry.active) {
-							active.add(entry.path);
-						} else {
-							active.delete(entry.path);
-						}
-					});
-				}
-			} catch (err) {
-				this.#announced.set(new Set());
-				throw err;
-			}
+		// Closing the consumer closes the shared state, so stop appending after that.
+		let closed = false;
+		void consumer.closed.then(() => {
+			closed = true;
 		});
+
+		const pump = new Effect();
+		pump.run((effect) => {
+			const conn = effect.get(this.established);
+			if (!conn) return;
+
+			// Cloudflare's relay does not yet support SUBSCRIBE_NAMESPACE, so skip the
+			// subscription for those hosts (the consumer just stays empty).
+			if (conn.url.hostname.endsWith("mediaoverquic.com")) return;
+
+			const upstream = conn.announced(prefix);
+			effect.cleanup(() => upstream.close());
+
+			// Track what this connection announced so we can retract it if the connection drops.
+			const active = new Set<Path.Valid>();
+
+			effect.spawn(async () => {
+				try {
+					for (;;) {
+						const entry = await Promise.race([effect.cancel, upstream.next()]);
+						if (!entry) break;
+						if (entry.active) active.add(entry.path);
+						else active.delete(entry.path);
+						producer.append(entry);
+					}
+				} catch {
+					// A dropped connection resets the announce stream; the retractions below cover it.
+				} finally {
+					// Retract everything from the connection that just went away, so a per-broadcast
+					// watcher tears down instead of clinging to the dead route.
+					if (!closed) {
+						for (const path of active) {
+							producer.append({ path, active: false });
+						}
+					}
+				}
+			});
+		});
+
+		this.signals.cleanup(() => pump.close());
+		void consumer.closed.then(() => pump.close());
+
+		return consumer;
 	}
 
 	/** Stop reconnecting, close the current connection, and resolve {@link Reload.closed}. */

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -8,8 +8,20 @@ import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Si
 import { toHang } from "./msf";
 
 // Connections already warned about missing broadcast-discovery support, so the
-// per-rendition announcement check logs at most once per connection.
+// announcement check logs at most once per connection.
 const warnedNoDiscovery = new WeakSet<Moq.Connection.Established>();
+
+// Whether to skip the announcement gate for this connection. Cloudflare's relay does not yet support
+// SUBSCRIBE_NAMESPACE, so waiting on announcements there would hang forever; subscribe immediately
+// instead, warning once per connection.
+function skipDiscovery(conn: Moq.Connection.Established): boolean {
+	if (!conn.url.hostname.endsWith("mediaoverquic.com")) return false;
+	if (!warnedNoDiscovery.has(conn)) {
+		warnedNoDiscovery.add(conn);
+		console.warn("Cloudflare relay does not support broadcast discovery yet; ignoring reload signal.");
+	}
+	return true;
+}
 
 // Watch supports the on-the-wire catalog formats from @moq/hang, plus "hangz" (the
 // DEFLATE-compressed `catalog.json.z` track) and a "manual" mode where the user supplies the
@@ -72,18 +84,19 @@ export class Broadcast {
 	};
 	readonly output = readonlys(this.#output);
 
-	// All actively announced broadcast paths from the connection. If omitted, reload skips the
-	// announcement gate and subscribes immediately.
-	readonly #announced?: Getter<Set<Moq.Path.Valid>>;
+	// The set of announced paths on the connection, for cross-broadcast (`broadcast: ../`) references
+	// so `relativeBroadcast` can gate on whether a sibling is announced. `undefined` until the stream
+	// is open. Opened lazily; the main broadcast doesn't use it (`#runBroadcast` drives off its own
+	// name-scoped stream).
+	readonly #announced = new Signal<Set<Moq.Path.Valid> | undefined>(undefined);
 
-	// Whether `name` is currently in the announced set (or skipping the check).
-	// Derived in its own effect so that flaps for unrelated broadcasts don't
-	// retrigger the broadcast/catalog subscriptions.
-	readonly #announcedNow = new Signal(false);
+	// Set true the first time a relative reference needs the announcement gate, so a broadcast with
+	// no cross-broadcast renditions never opens the (broad) connection-scoped announcement stream.
+	readonly #wantAnnounced = new Signal(false);
 
 	signals = new Effect();
 
-	constructor(props?: Inputs<BroadcastInput> & { announced?: Getter<Set<Moq.Path.Valid>> }) {
+	constructor(props?: Inputs<BroadcastInput>) {
 		this.input = {
 			connection: getter(props?.connection),
 			name: getter(props?.name ?? Path.empty()),
@@ -93,60 +106,108 @@ export class Broadcast {
 			catalog: getter(props?.catalog),
 		};
 
-		this.#announced = props?.announced;
-
-		this.signals.run(this.#runAnnouncedNow.bind(this));
+		this.signals.run(this.#runAnnounced.bind(this));
 		this.signals.run(this.#runBroadcast.bind(this));
 		this.signals.run(this.#runCatalog.bind(this));
 	}
 
-	#runAnnouncedNow(effect: Effect): void {
-		const name = effect.get(this.input.name);
-		this.#announcedNow.set(this.#isPathAnnounced(effect, name));
-	}
+	// Maintain the set of announced paths used by `relativeBroadcast`, by draining a connection-scoped
+	// announcement stream. Only opened once a relative reference asks for it (see `#wantAnnounced`),
+	// and reopened per connection.
+	#runAnnounced(effect: Effect): void {
+		this.#announced.set(undefined);
 
-	// Whether `name` is currently announced on the connection (or skipping the check
-	// because reload is off, no announced set is wired in, or the relay doesn't support
-	// announcements). Used by both `#runAnnouncedNow` (for `input.name`) and
-	// `relativeBroadcast` (for cross-broadcast refs, which reruns per rendition).
-	#isPathAnnounced(effect: Effect, name: Moq.Path.Valid): boolean {
-		const reload = effect.get(this.input.reload);
-		if (!reload) return true;
+		if (!effect.get(this.#wantAnnounced)) return;
+		if (!effect.get(this.input.reload)) return;
 
-		// Without an announced set to consult, subscribe immediately.
-		if (!this.#announced) return true;
-
-		// Cloudflare's relay does not yet support announcement subscriptions,
-		// so default to subscribing immediately instead of waiting forever. This runs in a
-		// per-rendition reactive path, so warn at most once per connection instead of on
-		// every re-evaluation.
 		const conn = effect.get(this.input.connection);
-		if (conn?.url.hostname.endsWith("mediaoverquic.com")) {
-			if (!warnedNoDiscovery.has(conn)) {
-				warnedNoDiscovery.add(conn);
-				console.warn("Cloudflare relay does not support broadcast discovery yet; ignoring reload signal.");
-			}
-			return true;
-		}
+		if (!conn || skipDiscovery(conn)) return;
 
-		const announced = effect.get(this.#announced);
-		return announced.has(name);
+		const announced = conn.announced(Path.empty());
+		effect.cleanup(() => announced.close());
+		this.#announced.set(new Set());
+
+		effect.spawn(async () => {
+			for (;;) {
+				const entry = await Promise.race([effect.cancel, announced.next()]);
+				if (!entry) break;
+				this.#announced.mutate((active) => {
+					if (!active) return;
+					if (entry.active) active.add(entry.path);
+					else active.delete(entry.path);
+				});
+			}
+		});
 	}
 
+	// Whether `path` is currently announced, for `relativeBroadcast`'s cross-broadcast refs. Returns
+	// true (subscribe immediately) when the gate can't apply: reload is off, or the relay doesn't
+	// support discovery. Opens the announcement stream on first use.
+	#isPathAnnounced(effect: Effect, path: Moq.Path.Valid): boolean {
+		if (!effect.get(this.input.reload)) return true;
+
+		const conn = effect.get(this.input.connection);
+		if (conn && skipDiscovery(conn)) return true;
+
+		this.#wantAnnounced.set(true);
+
+		const active = effect.get(this.#announced);
+		if (!active) return false; // stream not open yet: wait rather than subscribe to a maybe-absent path
+		return active.has(path);
+	}
+
+	// Subscribe to the broadcast, re-consuming on every (re-)announce so a same-name republish (a new
+	// publisher, or a relay-failover RESTART) re-attaches to the new instance instead of clinging to
+	// the dead one. Driven off the announcement stream's updates rather than a membership flag, since
+	// a coalesced republish leaves the active set unchanged yet still emits a fresh update.
 	#runBroadcast(effect: Effect): void {
 		const enabled = effect.get(this.input.enabled);
 		if (!enabled) return;
-
-		if (!effect.get(this.#announcedNow)) return;
 
 		const conn = effect.get(this.input.connection);
 		if (!conn) return;
 
 		const name = effect.get(this.input.name);
-		const broadcast = conn.consume(name);
-		effect.cleanup(() => broadcast.close());
 
-		effect.set(this.#output.active, broadcast, undefined);
+		// No announcement gate: subscribe immediately (reload off, or the relay lacks discovery).
+		if (!effect.get(this.input.reload) || skipDiscovery(conn)) {
+			const broadcast = conn.consume(name);
+			effect.cleanup(() => broadcast.close());
+			effect.set(this.#output.active, broadcast, undefined);
+			return;
+		}
+
+		const announced = conn.announced(name);
+		effect.cleanup(() => announced.close());
+
+		let current: Moq.Broadcast.Consumer | undefined;
+		effect.cleanup(() => {
+			current?.close();
+			current = undefined;
+			this.#output.active.set(undefined);
+		});
+
+		effect.spawn(async () => {
+			for (;;) {
+				const event = await Promise.race([effect.cancel, announced.next()]);
+				if (!event) break;
+
+				// Scoped to `name`, so the exact broadcast arrives with an empty suffix; ignore children.
+				if (event.path !== Path.empty()) continue;
+
+				if (event.active) {
+					// A live subscription survives a redundant (re-)announce; only replace a dead one.
+					if (current && !current.closedSignal.peek()) continue;
+					current?.close();
+					current = conn.consume(name);
+					this.#output.active.set(current);
+				} else {
+					current?.close();
+					current = undefined;
+					this.#output.active.set(undefined);
+				}
+			}
+		});
 	}
 
 	#runCatalog(effect: Effect): void {

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -104,7 +104,6 @@ export default class MoqWatch extends HTMLElement {
 
 		this.broadcast = new Broadcast({
 			connection: this.connection.established,
-			announced: this.connection.announced,
 			enabled: this.#enabled,
 			name: this.#name,
 			reload: this.#reload,


### PR DESCRIPTION
An alternative to #2188's announce/republish fix.

> Scope: this is the announce/republish half only (#2188 bug #2). The orthogonal catalog-reset retry (bug #1: a slow-consumer reset stranding a tile while it's still announced) is **not** included here.

## The bug

A tile could go permanently offline while the relay was healthy: when a publisher's unannounce and a new instance's announce under the same name coalesce, the presence set never observably flips, so the watcher stays bound to the dead route until a page reload.

The root cause is gating on announcement **membership** (a `Set`) rather than the announcement **stream**. A republish arrives as a redundant `active: true` (a lite-06 `RESTART`, or an unannounce+announce), which `Set.has(name)` collapses to "no change". The stream still carries a distinct update.

## The fix

**`@moq/watch`**
- `Broadcast` drives its subscription off a **name-scoped** announcement stream and re-consumes on every (re-)announce, so a same-name republish re-attaches to the new instance. Scoping to the name also means unrelated broadcasts never retrigger it (what the old `#announcedNow` membership flag guarded against). A live subscription survives a redundant re-announce; only a dead one is replaced.
- Dropped the `announced` prop; `Broadcast` derives announcements from its connection. The connection-scoped stream for cross-broadcast (`broadcast: ../`) refs is opened lazily and drained into a local set.

**`@moq/net`**
- `Reload.announced` changes from a bare `Getter<Set>` property to an `announced(prefix?)` **method** matching `Established.announced`: the same `Announce.Consumer` stream, but everything active is retracted (an `active: false` update) on disconnect and re-announced on reconnect, so a consumer draining `next()` never clings to a dead route across a reconnect.
- `Announce.Consumer` stays a plain stream. Callers that want a set of active paths maintain their own by draining `next()` (there's no `active` accessor to hold wrong).

**demo** discovery uses `Reload.announced(prefix)` so its set self-heals on reconnect without wiring up `established` by hand.

## Public API changes (breaking → targets `dev`)

- `@moq/net`: `Reload.announced` **changed** from a `Getter<Set<Path>>` property to an `announced(prefix?): Announce.Consumer` method.
- `@moq/watch`: `Broadcast` constructor **drops** the `announced` option.

## Test plan

- [x] `bun run --filter='*' check` (all packages) + `bun biome check` green.
- [x] New `js/net/src/announced.test.ts` covers the stream carrying a re-announce as its own distinct update (the property the fix relies on).
- [x] `bun test` green (net 239, watch 78).
- [ ] Manual: kill and immediately restart a publisher under the same name; the viewer re-attaches without a reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)