### PR TITLE
chore(js): bump package versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -93,7 +93,7 @@
     },
     "js/hang": {
       "name": "@moq/hang",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
         "@libav.js/variant-opus-af": "^6.8.8",
@@ -115,7 +115,7 @@
     },
     "js/json": {
       "name": "@moq/json",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "dependencies": {
         "@moq/flate": "workspace:^",
         "@moq/net": "workspace:^",
@@ -144,7 +144,7 @@
     },
     "js/moq-boy": {
       "name": "@moq/boy",
-      "version": "0.2.12",
+      "version": "0.2.13",
       "dependencies": {
         "@moq/json": "workspace:^",
         "@moq/net": "workspace:^",
@@ -176,7 +176,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@moq/qmux": "^0.1.3",
         "@moq/signals": "workspace:*",
@@ -196,7 +196,7 @@
     },
     "js/publish": {
       "name": "@moq/publish",
-      "version": "0.2.17",
+      "version": "0.3.0",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/json": "workspace:^",
@@ -260,7 +260,7 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.2.19",
+      "version": "0.3.0",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/json": "workspace:^",

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/json/package.json
+++ b/js/json/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/json",
 	"type": "module",
-	"version": "0.1.2",
+	"version": "0.2.0",
 	"description": "JSON publishing over MoQ tracks: snapshot/delta (RFC 7396 merge patch) objects, or append-log NDJSON streams.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/boy",
 	"type": "module",
-	"version": "0.2.12",
+	"version": "0.2.13",
 	"jsr": false,
 	"description": "MoQ Boy - Crowd-controlled Game Boy streaming via MoQ",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.1.7",
+	"version": "0.1.8",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.2.17",
+	"version": "0.3.0",
 	"jsr": false,
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.2.19",
+	"version": "0.3.0",
 	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",


### PR DESCRIPTION
## Summary

- Bump `@moq/json` to `0.2.0` because the top-level `Producer` and `Consumer` exports moved under `Json.Snapshot`, removing the old import shape.
- Bump `@moq/watch` and `@moq/publish` to `0.3.0` because they re-export `@moq/json`, so the same removal is visible through their public API.
- Bump `@moq/net`, `@moq/hang`, and `@moq/boy` by patch versions for their shipped JS changes since the previous package bump.
- Mirror the workspace versions in `bun.lock`.

## Public API changes

- `@moq/json`: removed top-level `Producer` and `Consumer` exports from the package entrypoint. Consumers should use `Json.Snapshot.Producer` and `Json.Snapshot.Consumer`.
- `@moq/watch` / `@moq/publish`: the re-exported `Json` namespace reflects the same `Producer` / `Consumer` move.
- `@moq/net`: added `Path.MAX_PARTS`, `Path.parts`, `Path.decode`, and `Path.encode`.
- `@moq/watch`: added the `SourceError` type and `Source.error` getter.

## Validation

- `env TMPDIR=/private/tmp bun install --frozen-lockfile`
- `env TMPDIR=/private/tmp bun run --filter='*' check`
- `env TMPDIR=/private/tmp bun biome check js/net/package.json js/json/package.json js/hang/package.json js/watch/package.json js/moq-boy/package.json bun.lock`
- `nix develop --command just ci`

(Written by GPT-5)
