### PR TITLE
fix(publish): capture the full frame rate in the capture polyfill

### DIFF
--- a/js/publish/src/video/polyfill.test.ts
+++ b/js/publish/src/video/polyfill.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { Time } from "@moq/net";
+import { Pacer } from "./polyfill";
+
+// Wake once per display refresh, with the clock clamped to 1ms like Safari and Firefox.
+function capture(frameRate: number, seconds: number, displayHz = 60): number {
+	const pacer = new Pacer(frameRate, Time.Milli(0));
+
+	let frames = 0;
+	const ticks = Math.round(seconds * displayHz);
+	for (let i = 1; i <= ticks; i++) {
+		const now = Time.Milli(Math.floor((i * 1000) / displayHz));
+		if (pacer.due(now)) frames++;
+	}
+
+	return frames / seconds;
+}
+
+describe("Pacer", () => {
+	test("captures the source frame rate on a clamped clock", () => {
+		// A 60Hz display and a 30fps camera is the case from #2208: the frame period is 33.333ms, the
+		// clamped clock reports the two elapsed animation frames as 33, and comparing against the wake
+		// time then waits for a third frame, capturing every 50ms instead of every 33ms.
+		expect(capture(30, 10)).toBeCloseTo(30, 0);
+		expect(capture(24, 10)).toBeCloseTo(24, 0);
+		expect(capture(60, 10)).toBeCloseTo(60, 0);
+	});
+
+	test("never captures faster than the display", () => {
+		expect(capture(120, 10)).toBeCloseTo(60, 0);
+	});
+
+	test("resyncs after a stall instead of capturing a burst", () => {
+		const pacer = new Pacer(30, Time.Milli(0));
+		expect(pacer.due(Time.Milli(0))).toBe(true);
+
+		// The tab was hidden for a second, which suspends requestAnimationFrame entirely.
+		expect(pacer.due(Time.Milli(1000))).toBe(true);
+
+		// The next frame is one period out, not a second's worth of backlog.
+		expect(pacer.due(Time.Milli(1001))).toBe(false);
+		expect(pacer.due(Time.Milli(1034))).toBe(true);
+	});
+});

--- a/js/publish/src/video/polyfill.ts
+++ b/js/publish/src/video/polyfill.ts
@@ -1,6 +1,38 @@
 import { Time } from "@moq/net";
 import type { StreamTrack } from "./types";
 
+/**
+ * Paces the capture loop below against a frame deadline.
+ *
+ * Exported for the unit test; not part of the package's public API.
+ */
+export class Pacer {
+	// Safari and Firefox clamp performance.now() to 1ms, so a 33.333ms period never looks elapsed while
+	// the clock still reports 33. Allow the clock's own resolution as slack, otherwise we wait for one
+	// more animation frame and capture 20fps out of a 30fps camera.
+	static readonly SLACK = Time.Milli(1);
+
+	readonly #period: Time.Milli;
+	#next: Time.Milli;
+
+	constructor(frameRate: number, now: Time.Milli = Time.Milli.now()) {
+		this.#period = Time.Milli(1000 / frameRate);
+		this.#next = now;
+	}
+
+	/** True when the next frame is due, advancing the deadline past it. */
+	due(now: Time.Milli): boolean {
+		if (Time.Milli.sub(this.#next, now) > Pacer.SLACK) return false;
+
+		// Advance by exactly one period so the rounding error can't accumulate. Resync rather than build
+		// up a backlog when we've been stalled, since a hidden tab suspends requestAnimationFrame.
+		this.#next = Time.Milli.add(this.#next, this.#period);
+		if (this.#next < now) this.#next = Time.Milli.add(now, this.#period);
+
+		return true;
+	}
+}
+
 // Firefox doesn't support MediaStreamTrackProcessor so we need to use a polyfill.
 // Based on: https://jan-ivar.github.io/polyfills/mediastreamtrackprocessor.js
 // Thanks Jan-Ivar
@@ -36,35 +68,51 @@ export function TrackProcessor(track: StreamTrack): ReadableStream<VideoFrame> {
 		throw new Error("track has no settings");
 	}
 
-	let video: HTMLVideoElement;
-	let last: Time.Milli;
+	let video: HTMLVideoElement | undefined;
+	const pacer = new Pacer(settings.frameRate ?? 30);
 
-	const frameRate = settings.frameRate ?? 30;
+	const release = () => {
+		if (!video) return;
+		video.pause();
+		video.srcObject = null;
+		video = undefined;
+	};
 
 	return new ReadableStream<VideoFrame>({
 		async start() {
-			video = document.createElement("video") as HTMLVideoElement;
-			video.srcObject = new MediaStream([track]);
+			const el = document.createElement("video") as HTMLVideoElement;
+			video = el;
+
+			el.srcObject = new MediaStream([track]);
 			await Promise.all([
-				video.play(),
+				el.play(),
 				new Promise((r) => {
-					video.onloadedmetadata = r;
+					el.onloadedmetadata = r;
 				}),
 			]);
-
-			last = Time.Milli.now();
 		},
 		async pull(controller) {
-			while (true) {
+			for (;;) {
+				// The track can end underneath us (ex. the camera is unplugged), and the <video> would
+				// otherwise keep handing back its final frame forever.
+				if (!video || track.readyState === "ended") {
+					controller.close();
+					release();
+					return;
+				}
+
 				const now = Time.Milli.now();
-				if (Time.Milli.sub(now, last) < Time.Milli(1000 / frameRate)) {
+				if (!pacer.due(now)) {
 					await new Promise((r) => requestAnimationFrame(r));
 					continue;
 				}
 
-				last = now;
-				controller.enqueue(new VideoFrame(video, { timestamp: Time.Micro.fromMilli(last) }));
+				controller.enqueue(new VideoFrame(video, { timestamp: Time.Micro.fromMilli(now) }));
+				return;
 			}
+		},
+		cancel() {
+			release();
 		},
 	});
 }


### PR DESCRIPTION
Fixes #2208. Split out of #2190, which I am closing in favour of focused PRs.

## Root cause

The `MediaStreamTrackProcessor` polyfill in `js/publish/src/video/polyfill.ts` paces frames by comparing `performance.now()` against the time it last woke:

```ts
if (Time.Milli.sub(now, last) < Time.Milli(1000 / frameRate)) {
    await new Promise((r) => requestAnimationFrame(r));
    continue;
}
last = now;
```

Safari and Firefox both clamp `performance.now()` to 1ms (the Spectre timer mitigation). On a 60Hz display two animation frames are 33.33ms, the clamped clock reports that elapsed as **33**, and `33 < 1000/30` is true, so the loop declines to emit and waits for a third frame. Three frames is 50ms, which passes. Steady state is one captured frame per three animation frames: **20fps out of a 30fps camera**, and a third of the camera's frames are never captured or encoded.

`last` is assigned the observed wake time rather than the deadline, so the phase error never carries over and the loop cannot self-correct.

Chrome is unaffected: it has a native main-thread `MediaStreamTrackProcessor` and never reaches this code.

## The fix

Pace against a deadline rather than the wake time:

- Advance the deadline by exactly one period, so the rounding error cannot accumulate.
- Allow the clock's own 1ms resolution as slack, so a frame that lands 0.33ms early is not deferred by a whole animation frame.
- Resync instead of releasing a backlog after a stall, since a hidden tab suspends `requestAnimationFrame` entirely.

This is arithmetic inside the existing loop. It is not gated on an engine, adds no API, and does not change the approach: `requestAnimationFrame` still drives the loop, exactly as before. Firefox has the identical clock clamp and is fixed by the same change, with its code path otherwise untouched.

The pacing is extracted into a small `Pacer` so the clock behavior has a unit test. It is not re-exported from `./index`, so the package's public API is unchanged.

## Teardown

The issue also noted that `pull()` looped forever with no `cancel()`, so an ended track left the `<video>` element and its `MediaStream` decoding until GC. The stream now closes when the track ends and releases the element on cancel. The polyfill this is based on ([Jan-Ivar's](https://jan-ivar.github.io/polyfills/mediastreamtrackprocessor.js)) already did the former; our copy had dropped it.

## Test plan

`bun test js/publish/src/video/polyfill.test.ts`: 3 tests driving the pacer with a simulated 1ms-clamped clock on a 60Hz display. Under that clock the previous logic yields 20.0 / 20.0 / 40.0 fps for a requested 30 / 24 / 60, so the tests fail without this change. `just js check` and `just js test` are green.

Verified on device, Safari 26.5 (`AppleWebKit/605.1.15 Version/26.5`), macOS, 60Hz display, FaceTime camera reporting 30fps, using the `demo/web` publish page and its capture-rate graph:

| | capture rate |
|---|---|
| before | **21.9 fps** |
| after | **29.9 fps** |

The standalone harness from #2208, run in the same Safari:

```
performance.now() min delta: 1 ms
display refresh: 60.1 Hz

before:  requested 30 fps -> 20.5 fps   (gaps ms: 50, 49, 34, 34, 50, 50, 50, 49, 34, 50)
         requested 60 fps -> 40.0 fps   (gaps ms: 17, 33, 17, 33, 17, 33, 17, 33, 17, 33)

after:   requested 30 fps -> 30.0 fps   (gaps ms: 33, 34, 33, 33, 34, 33, 33, 33, 51, 16)
         requested 60 fps -> 59.8 fps   (gaps ms: 16, 17, 17, 16, 17, 17, 17, 16, 17, 16)
```