### PR TITLE
feat(moq-mux): expose finish_group() through the import chain

### DIFF
--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -67,9 +67,8 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
-	/// Close the current group cleanly WITHOUT finishing the track, so the track
-	/// stays open and the next keyframe opens a fresh group. Delegates to the
-	/// container producer's `finish_group`.
+	/// Close the current group without finishing the track; publishing resumes on
+	/// the next keyframe. See `import::Track::finish_group` for the full contract.
 	pub fn finish_group(&mut self) -> crate::Result<()> {
 		self.track.finish_group()?;
 		Ok(())

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -67,6 +67,14 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Close the current group cleanly WITHOUT finishing the track, so the track
+	/// stays open and the next keyframe opens a fresh group. Delegates to the
+	/// container producer's `finish_group`.
+	pub fn finish_group(&mut self) -> crate::Result<()> {
+		self.track.finish_group()?;
+		Ok(())
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -205,9 +205,8 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
-	/// Close the current group cleanly WITHOUT finishing the track, so the track
-	/// stays open and the next keyframe opens a fresh group. Delegates to the
-	/// container producer's `finish_group`.
+	/// Close the current group without finishing the track; publishing resumes on
+	/// the next keyframe. See `import::Track::finish_group` for the full contract.
 	pub fn finish_group(&mut self) -> Result<()> {
 		self.track.finish_group()?;
 		Ok(())

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -205,6 +205,14 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Close the current group cleanly WITHOUT finishing the track, so the track
+	/// stays open and the next keyframe opens a fresh group. Delegates to the
+	/// container producer's `finish_group`.
+	pub fn finish_group(&mut self) -> Result<()> {
+		self.track.finish_group()?;
+		Ok(())
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/flac/import.rs
+++ b/rs/moq-mux/src/codec/flac/import.rs
@@ -55,6 +55,14 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Close the current group cleanly WITHOUT finishing the track, so the track
+	/// stays open and the next keyframe opens a fresh group. Delegates to the
+	/// container producer's `finish_group`.
+	pub fn finish_group(&mut self) -> crate::Result<()> {
+		self.track.finish_group()?;
+		Ok(())
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/flac/import.rs
+++ b/rs/moq-mux/src/codec/flac/import.rs
@@ -55,9 +55,8 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
-	/// Close the current group cleanly WITHOUT finishing the track, so the track
-	/// stays open and the next keyframe opens a fresh group. Delegates to the
-	/// container producer's `finish_group`.
+	/// Close the current group without finishing the track; publishing resumes on
+	/// the next keyframe. See `import::Track::finish_group` for the full contract.
 	pub fn finish_group(&mut self) -> crate::Result<()> {
 		self.track.finish_group()?;
 		Ok(())

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -126,9 +126,8 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
-	/// Close the current group cleanly WITHOUT finishing the track, so the track
-	/// stays open and the next keyframe opens a fresh group. Delegates to the
-	/// container producer's `finish_group`.
+	/// Close the current group without finishing the track; publishing resumes on
+	/// the next keyframe. See `import::Track::finish_group` for the full contract.
 	pub fn finish_group(&mut self) -> Result<()> {
 		self.track.finish_group()?;
 		Ok(())

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -126,6 +126,14 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Close the current group cleanly WITHOUT finishing the track, so the track
+	/// stays open and the next keyframe opens a fresh group. Delegates to the
+	/// container producer's `finish_group`.
+	pub fn finish_group(&mut self) -> Result<()> {
+		self.track.finish_group()?;
+		Ok(())
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -88,9 +88,8 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
-	/// Close the current group cleanly WITHOUT finishing the track, so the track
-	/// stays open and the next keyframe opens a fresh group. Delegates to the
-	/// container producer's `finish_group`.
+	/// Close the current group without finishing the track; publishing resumes on
+	/// the next keyframe. See `import::Track::finish_group` for the full contract.
 	pub fn finish_group(&mut self) -> Result<()> {
 		self.track.finish_group()?;
 		Ok(())

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -88,6 +88,14 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Close the current group cleanly WITHOUT finishing the track, so the track
+	/// stays open and the next keyframe opens a fresh group. Delegates to the
+	/// container producer's `finish_group`.
+	pub fn finish_group(&mut self) -> Result<()> {
+		self.track.finish_group()?;
+		Ok(())
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/legacy.rs
+++ b/rs/moq-mux/src/codec/legacy.rs
@@ -156,6 +156,17 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Close the current group cleanly WITHOUT finishing the track, so the track
+	/// stays open and the next keyframe opens a fresh group. Delegates to the
+	/// container producer's `finish_group`.
+	/// `allow(dead_code)`: the legacy importer isn't boxed into the `Importer`/`FrameSink`
+	/// dispatch set, so nothing calls this today — kept for parity with the other codecs.
+	#[allow(dead_code)]
+	pub fn finish_group(&mut self) -> crate::Result<()> {
+		self.track.finish_group()?;
+		Ok(())
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/legacy.rs
+++ b/rs/moq-mux/src/codec/legacy.rs
@@ -156,11 +156,10 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
-	/// Close the current group cleanly WITHOUT finishing the track, so the track
-	/// stays open and the next keyframe opens a fresh group. Delegates to the
-	/// container producer's `finish_group`.
-	/// `allow(dead_code)`: the legacy importer isn't boxed into the `Importer`/`FrameSink`
-	/// dispatch set, so nothing calls this today — kept for parity with the other codecs.
+	/// Close the current group without finishing the track; publishing resumes on
+	/// the next keyframe. See `import::Track::finish_group` for the full contract.
+	// Kept for codec-`Import` surface parity; the legacy importer isn't in the
+	// object-safe dispatch set, so it isn't wired in.
 	#[allow(dead_code)]
 	pub fn finish_group(&mut self) -> crate::Result<()> {
 		self.track.finish_group()?;

--- a/rs/moq-mux/src/codec/mp3.rs
+++ b/rs/moq-mux/src/codec/mp3.rs
@@ -137,9 +137,8 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
-	/// Close the current group cleanly WITHOUT finishing the track, so the track
-	/// stays open and the next keyframe opens a fresh group. Delegates to the
-	/// container producer's `finish_group`.
+	/// Close the current group without finishing the track; publishing resumes on
+	/// the next keyframe. See `import::Track::finish_group` for the full contract.
 	pub fn finish_group(&mut self) -> crate::Result<()> {
 		self.track.finish_group()?;
 		Ok(())

--- a/rs/moq-mux/src/codec/mp3.rs
+++ b/rs/moq-mux/src/codec/mp3.rs
@@ -137,6 +137,14 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Close the current group cleanly WITHOUT finishing the track, so the track
+	/// stays open and the next keyframe opens a fresh group. Delegates to the
+	/// container producer's `finish_group`.
+	pub fn finish_group(&mut self) -> crate::Result<()> {
+		self.track.finish_group()?;
+		Ok(())
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -57,9 +57,8 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
-	/// Close the current group cleanly WITHOUT finishing the track, so the track
-	/// stays open and the next keyframe opens a fresh group. Delegates to the
-	/// container producer's `finish_group`.
+	/// Close the current group without finishing the track; publishing resumes on
+	/// the next keyframe. See `import::Track::finish_group` for the full contract.
 	pub fn finish_group(&mut self) -> crate::Result<()> {
 		self.track.finish_group()?;
 		Ok(())

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -57,6 +57,14 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Close the current group cleanly WITHOUT finishing the track, so the track
+	/// stays open and the next keyframe opens a fresh group. Delegates to the
+	/// container producer's `finish_group`.
+	pub fn finish_group(&mut self) -> crate::Result<()> {
+		self.track.finish_group()?;
+		Ok(())
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -108,9 +108,8 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
-	/// Close the current group cleanly WITHOUT finishing the track, so the track
-	/// stays open and the next keyframe opens a fresh group. Delegates to the
-	/// container producer's `finish_group`.
+	/// Close the current group without finishing the track; publishing resumes on
+	/// the next keyframe. See `import::Track::finish_group` for the full contract.
 	pub fn finish_group(&mut self) -> crate::Result<()> {
 		self.track.finish_group()?;
 		Ok(())

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -108,6 +108,14 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Close the current group cleanly WITHOUT finishing the track, so the track
+	/// stays open and the next keyframe opens a fresh group. Delegates to the
+	/// container producer's `finish_group`.
+	pub fn finish_group(&mut self) -> crate::Result<()> {
+		self.track.finish_group()?;
+		Ok(())
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -108,9 +108,8 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
-	/// Close the current group cleanly WITHOUT finishing the track, so the track
-	/// stays open and the next keyframe opens a fresh group. Delegates to the
-	/// container producer's `finish_group`.
+	/// Close the current group without finishing the track; publishing resumes on
+	/// the next keyframe. See `import::Track::finish_group` for the full contract.
 	pub fn finish_group(&mut self) -> crate::Result<()> {
 		self.track.finish_group()?;
 		Ok(())

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -108,6 +108,14 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Close the current group cleanly WITHOUT finishing the track, so the track
+	/// stays open and the next keyframe opens a fresh group. Delegates to the
+	/// container producer's `finish_group`.
+	pub fn finish_group(&mut self) -> crate::Result<()> {
+		self.track.finish_group()?;
+		Ok(())
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.track.seek(sequence)?;

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -16,6 +16,9 @@ use crate::container::{Frame, Timestamp};
 trait Importer: Send {
 	fn decode(&mut self, frame: &[u8], pts: Option<Timestamp>) -> Result<()>;
 	fn finish(&mut self) -> Result<()>;
+	/// Close the current group without finishing the track
+	/// (see codec `Import::finish_group`).
+	fn finish_group(&mut self) -> Result<()>;
 	fn seek(&mut self, sequence: u64) -> Result<()>;
 	fn demand(&self) -> moq_net::TrackDemand;
 }
@@ -25,6 +28,9 @@ trait StreamImporter: Send {
 	fn initialize(&mut self, data: &[u8]) -> Result<()>;
 	fn decode(&mut self, data: &[u8]) -> Result<()>;
 	fn finish(&mut self) -> Result<()>;
+	/// Close the current group without finishing the track
+	/// (see codec `Import::finish_group`).
+	fn finish_group(&mut self) -> Result<()>;
 	fn seek(&mut self, sequence: u64) -> Result<()>;
 	fn demand(&self) -> moq_net::TrackDemand;
 }
@@ -41,6 +47,9 @@ trait FrameSink: Send {
 	fn initialize(&mut self, init: &[u8]) -> Result<()>;
 	fn decode(&mut self, frames: Vec<Frame>) -> Result<()>;
 	fn finish(&mut self) -> Result<()>;
+	/// Close the current group without finishing the track
+	/// (see codec `Import::finish_group`).
+	fn finish_group(&mut self) -> Result<()>;
 	fn seek(&mut self, sequence: u64) -> Result<()>;
 	fn demand(&self) -> moq_net::TrackDemand;
 }
@@ -76,6 +85,9 @@ macro_rules! impl_frame_sink {
 			fn finish(&mut self) -> Result<()> {
 				<$ty>::finish(self)
 			}
+			fn finish_group(&mut self) -> Result<()> {
+				<$ty>::finish_group(self)
+			}
 			fn seek(&mut self, sequence: u64) -> Result<()> {
 				<$ty>::seek(self, sequence)
 			}
@@ -104,6 +116,9 @@ impl<S: Splitter, I: FrameSink> Importer for SplitWhole<S, I> {
 	}
 	fn finish(&mut self) -> Result<()> {
 		self.import.finish()
+	}
+	fn finish_group(&mut self) -> Result<()> {
+		self.import.finish_group()
 	}
 	fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.split.reset();
@@ -143,6 +158,9 @@ impl<S: Splitter, I: FrameSink> StreamImporter for SplitStream<S, I> {
 		self.import.decode(tail)?;
 		self.import.finish()
 	}
+	fn finish_group(&mut self) -> Result<()> {
+		self.import.finish_group()
+	}
 	fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.split.reset();
 		self.import.seek(sequence)
@@ -168,6 +186,9 @@ impl<E: CatalogExt> Importer for Avc1<E> {
 	fn finish(&mut self) -> Result<()> {
 		self.import.finish()
 	}
+	fn finish_group(&mut self) -> Result<()> {
+		self.import.finish_group()
+	}
 	fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.import.seek(sequence)
 	}
@@ -186,6 +207,9 @@ macro_rules! impl_importer_direct {
 			}
 			fn finish(&mut self) -> Result<()> {
 				<$ty>::finish(self)
+			}
+			fn finish_group(&mut self) -> Result<()> {
+				<$ty>::finish_group(self)
 			}
 			fn seek(&mut self, sequence: u64) -> Result<()> {
 				<$ty>::seek(self, sequence)
@@ -361,6 +385,15 @@ impl<E: CatalogExt> Track<E> {
 		self.inner.finish()
 	}
 
+	/// Close the current group cleanly and leave the track (and its catalog
+	/// rendition) OPEN, so publishing resumes into a fresh group on the next
+	/// keyframe. Unlike [`finish`](Self::finish), the track is not ended — useful
+	/// to pause a track (e.g. when it loses its last subscriber) while leaving a
+	/// COMPLETE final group rather than a truncated one.
+	pub fn finish_group(&mut self) -> Result<()> {
+		self.inner.finish_group()
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.inner.seek(sequence)
@@ -468,6 +501,12 @@ impl<E: CatalogExt> TrackStream<E> {
 	/// Finish the importer, flushing any buffered data.
 	pub fn finish(&mut self) -> Result<()> {
 		self.inner.finish()
+	}
+
+	/// Close the current group cleanly without finishing the track
+	/// (see [`Track::finish_group`]).
+	pub fn finish_group(&mut self) -> Result<()> {
+		self.inner.finish_group()
 	}
 
 	/// Close the current group and open the next one at `sequence`.
@@ -630,6 +669,37 @@ mod tests {
 		assert_eq!(video.coded_width, Some(1280));
 		assert_eq!(video.coded_height, Some(720));
 		assert!(!snapshot.video.renditions.contains_key("0.avc3"));
+	}
+
+	/// `Track::finish_group` closes the current group cleanly and leaves the track OPEN — the next
+	/// decoded frame opens a fresh group and `finish` still works. Uses opus (every audio frame is a
+	/// keyframe, so each `decode` after a close opens a group).
+	#[tokio::test(start_paused = true)]
+	async fn finish_group_closes_group_and_keeps_track_open() {
+		let (mut broadcast, catalog) = new_broadcast();
+		let request = broadcast.create_track(moq_net::Track::new("audio")).unwrap();
+		let consumer = request.consume();
+		let mut import = Track::new(request, catalog, "opus", &opus_head()).unwrap();
+
+		// Group 1: one frame, then close the group early (the pause edge).
+		import
+			.decode(b"frame-one", Some(Timestamp::from_micros(1_000).unwrap()))
+			.unwrap();
+		import.finish_group().unwrap();
+
+		// Track is still open: a later frame opens a fresh group 2 (resume after pause).
+		import
+			.decode(b"frame-two", Some(Timestamp::from_micros(2_000).unwrap()))
+			.unwrap();
+		import.finish().unwrap();
+
+		// Two complete groups reached the consumer — no truncated/never-finished group.
+		let mut groups = 0usize;
+		let mut consumer = consumer;
+		while let Some(_group) = consumer.recv_group().await.unwrap() {
+			groups += 1;
+		}
+		assert_eq!(groups, 2, "finish_group closed group 1; the next frame opened group 2");
 	}
 
 	/// A changed key frame just updates the rendition in place; there are no fixed

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -17,7 +17,7 @@ trait Importer: Send {
 	fn decode(&mut self, frame: &[u8], pts: Option<Timestamp>) -> Result<()>;
 	fn finish(&mut self) -> Result<()>;
 	/// Close the current group without finishing the track
-	/// (see codec `Import::finish_group`).
+	/// (see `Track::finish_group`).
 	fn finish_group(&mut self) -> Result<()>;
 	fn seek(&mut self, sequence: u64) -> Result<()>;
 	fn demand(&self) -> moq_net::TrackDemand;
@@ -29,7 +29,7 @@ trait StreamImporter: Send {
 	fn decode(&mut self, data: &[u8]) -> Result<()>;
 	fn finish(&mut self) -> Result<()>;
 	/// Close the current group without finishing the track
-	/// (see codec `Import::finish_group`).
+	/// (see `Track::finish_group`).
 	fn finish_group(&mut self) -> Result<()>;
 	fn seek(&mut self, sequence: u64) -> Result<()>;
 	fn demand(&self) -> moq_net::TrackDemand;
@@ -48,7 +48,7 @@ trait FrameSink: Send {
 	fn decode(&mut self, frames: Vec<Frame>) -> Result<()>;
 	fn finish(&mut self) -> Result<()>;
 	/// Close the current group without finishing the track
-	/// (see codec `Import::finish_group`).
+	/// (see `Track::finish_group`).
 	fn finish_group(&mut self) -> Result<()>;
 	fn seek(&mut self, sequence: u64) -> Result<()>;
 	fn demand(&self) -> moq_net::TrackDemand;
@@ -386,10 +386,17 @@ impl<E: CatalogExt> Track<E> {
 	}
 
 	/// Close the current group cleanly and leave the track (and its catalog
-	/// rendition) OPEN, so publishing resumes into a fresh group on the next
-	/// keyframe. Unlike [`finish`](Self::finish), the track is not ended — useful
-	/// to pause a track (e.g. when it loses its last subscriber) while leaving a
-	/// COMPLETE final group rather than a truncated one.
+	/// rendition) OPEN — unlike [`finish`](Self::finish), which ends the track.
+	/// Publishing resumes into a fresh group on the next keyframe.
+	///
+	/// Typical use: pause a track that has lost its last subscriber while leaving
+	/// a COMPLETE final group rather than a truncated one.
+	///
+	/// Invariants: call it while a group is open; the next group then begins on
+	/// the following keyframe (mirroring the container producer's `finish_group`,
+	/// whose next write must be a keyframe). Composes with [`finish`](Self::finish)
+	/// and [`seek`](Self::seek). This is the canonical description — the codec
+	/// `Import`s and `TrackStream` reference it.
 	pub fn finish_group(&mut self) -> Result<()> {
 		self.inner.finish_group()
 	}


### PR DESCRIPTION
`container::Producer` already has `finish_group()` — *"close the current group early; the next write must be a keyframe"* — but it isn't reachable above the container layer. This plumbs a `finish_group()` passthrough up through:

- every codec `Import` (h264/h265/av1/vp8/vp9/aac/opus/flac/mp3/legacy),
- the `Importer` / `FrameSink` / `StreamImporter` object-safe traits and their macro/struct impls,
- the public `import::Track` / `import::TrackStream`.

### Why

It lets a caller close a track's current group cleanly **without finishing the track**: the track (and its catalog rendition) stays open and publishing resumes into a fresh group on the next keyframe. The motivating use is pausing a track that has lost its last subscriber while leaving a **complete** final group rather than a truncated one — but the primitive is generally useful for any group-boundary control above the container layer.

### Notes

- Purely additive — no behavior change to existing paths.
- Adds a test (`import::track::tests::finish_group_closes_group_and_keeps_track_open`, opus) alongside the existing `container::producer` coverage.
- `cargo test -p moq-mux` green; `cargo fmt -p moq-mux --check` + `cargo clippy -p moq-mux` clean.

Happy to gate/adjust naming or split further if you'd prefer.
