### PR TITLE
feat(publish): measure the upload bitrate from the bytes we encode

### DIFF
--- a/js/publish/src/ui/components/stats-tab.ts
+++ b/js/publish/src/ui/components/stats-tab.ts
@@ -23,7 +23,7 @@ function card(kind: Kind, label: string, svg: string): { el: HTMLElement; grid: 
 }
 
 /** Show an active/idle pill: an encoder only runs (and uses bandwidth) while a viewer is subscribed. */
-function trackActive(parent: Effect, status: HTMLElement, active: Getter<boolean>) {
+function trackActive(parent: Effect, status: HTMLElement, active: Getter<boolean | undefined>) {
 	parent.run((effect) => {
 		const on = effect.get(active);
 		status.style.display = "";
@@ -56,8 +56,12 @@ export function statsTab(parent: Effect, publish: MoqPublish): HTMLElement {
 	const vFpsGraph = graph(parent, "Frame rate", { color: "#facc15", format: formatFps });
 	videoCard.el.append(vBitrateGraph.el, vFpsGraph.el);
 
-	// active = a viewer is subscribed and we're actually encoding/sending.
-	trackActive(parent, videoCard.status, publish.broadcast.video.hd.active);
+	// active = a viewer is subscribed and we're actually encoding/sending. Either rendition counts,
+	// and the bitrate graph below sums both.
+	const videoActive = parent.computed(
+		(effect) => effect.get(publish.broadcast.video.hd.active) || effect.get(publish.broadcast.video.sd.active),
+	);
+	trackActive(parent, videoCard.status, videoActive);
 
 	const audioCard = card("audio", "Audio", audioIcon);
 	const aCodec = line(audioCard.grid, "Codec");
@@ -101,25 +105,34 @@ export function statsTab(parent: Effect, publish: MoqPublish): HTMLElement {
 		nName.textContent = name?.toString() || "—";
 	});
 
-	// Live graphs: frame rate from captured frames, bitrate from the upload estimate.
+	// Live graphs: frame rate from captured frames, bitrate measured from the bytes we encoded.
+	// The congestion controller's send estimate would be simpler, but Safari's WebTransport has no
+	// getStats(), so it has no estimate at all and the graph stayed empty there.
 	let frames = 0;
 	parent.subscribe(publish.broadcast.video.frame, () => {
 		frames++;
 	});
+
+	const encoded = () =>
+		publish.broadcast.video.hd.bytesEncoded.peek() + publish.broadcast.video.sd.bytesEncoded.peek();
+
 	let prevFrames = 0;
+	let prevBytes = encoded();
 	let prevWhen = performance.now();
 
 	parent.interval(() => {
 		const now = performance.now();
 		const elapsed = now - prevWhen;
-		const delta = frames - prevFrames;
-		const fps = elapsed > 0 && delta > 0 ? delta / (elapsed / 1000) : undefined;
-		prevFrames = frames;
 		prevWhen = now;
-		vFpsGraph.push(fps);
 
-		const upload = publish.connection.established.peek()?.sendBandwidth?.peek();
-		vBitrateGraph.push(upload && upload > 0 ? upload : undefined);
+		const frameDelta = frames - prevFrames;
+		prevFrames = frames;
+		vFpsGraph.push(elapsed > 0 && frameDelta > 0 ? frameDelta / (elapsed / 1000) : undefined);
+
+		const bytes = encoded();
+		const byteDelta = bytes - prevBytes;
+		prevBytes = bytes;
+		vBitrateGraph.push(elapsed > 0 && byteDelta > 0 ? (byteDelta * 8) / (elapsed / 1000) : undefined);
 	}, POLL_MS);
 
 	return container;

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -50,6 +50,10 @@ export class Encoder {
 	#catalog = new Signal<Catalog.VideoConfig | undefined>(undefined);
 	readonly catalog: Getter<Catalog.VideoConfig | undefined> = this.#catalog;
 
+	#bytesEncoded = new Signal(0);
+	/** Total bytes encoded while serving. Monotonic; diff it over an interval for an upload bitrate. */
+	readonly bytesEncoded: Getter<number> = this.#bytesEncoded;
+
 	#signals = new Effect();
 
 	// The user provided config.
@@ -105,6 +109,8 @@ export class Encoder {
 					if (frame.type === "key") {
 						lastKeyframe = frame.timestamp as Time.Micro;
 					}
+
+					this.#bytesEncoded.update((total) => total + frame.byteLength);
 
 					producer.encode(frame, frame.timestamp as Time.Micro, frame.type === "key");
 				},


### PR DESCRIPTION
Split out of #2190, which I am closing in favour of focused PRs.

## Root cause

The stats tab graphs the connection's send-bandwidth estimate:

```ts
const upload = publish.connection.established.peek()?.sendBandwidth?.peek();
vBitrateGraph.push(upload && upload > 0 ? upload : undefined);
```

Safari has no such estimate. Its WebTransport implements no `getStats()`, so `sendBandwidth` is `undefined` and the bitrate graph stays empty for the entire session. Measured on Safari 26.5, publishing over WebTransport to the local relay:

```
transport=webtransport  sendBandwidth=UNDEFINED  measuredKbps=1394
```

## The fix

Count the bytes the encoder actually produces. That is transport agnostic, so it works on Safari and on the WebSocket fallback; it is what we really upload rather than an estimate of what we could; and it matches the graph's "Bitrate" label, which is not the same quantity as the congestion controller's capacity estimate (the demo graphs that separately, as "Upload estimate").

`Video.Encoder` gains a `bytesEncoded` getter, which is additive. `demo/web/src/publish.ts` already calls out the gap this closes:

> Live graphs (capture rate, upload-bandwidth estimate, round trip). The publish API exposes no encoded-byte counter, so these are the honestly-observable signals.

The active pill now reflects either rendition rather than just `hd`, to match the bitrate graph, which sums both.

## Public API

`@moq/publish` gains `Video.Encoder.bytesEncoded: Getter<number>`. Monotonic total; diff it over an interval for a bitrate.

## Test plan

`just js check` and `just js test` green. Verified on device, Safari 26.5, publishing the camera from `demo/web` with a subscriber attached: the estimate is `undefined` while the measured value tracks the encode at ~1394 kbps.