### PR TITLE
fix(moq-gst): reconnect the moqsink publisher instead of dying on transport death

### DIFF
--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -118,14 +118,12 @@ impl Session {
 		let status = Arc::new(Status::default());
 		let errored = Arc::new(AtomicBool::new(false));
 
-		// Hand the publish origin to a background reconnect loop: connect, wait for the session to
-		// close, then reconnect with exponential backoff. This replaces the previous one-shot connect
-		// that posted a fatal bus error on the first transport death — a relay restart or QUIC idle
-		// timeout left the publish permanently dead until the pipeline was rebuilt. `timeout = 0` means
-		// never give up, so an unattended publisher outlives arbitrary relay/transport outages; the
-		// pad threads keep writing across an outage (bounded by moq-net's per-group eviction) and the
-		// relay catches up from a group boundary on reconnect. A bounded retry policy is available via
-		// `ClientConfig::backoff` if a terminal error is preferred.
+		// Publish through a background reconnect loop (connect, wait for close, reconnect with
+		// backoff) rather than a one-shot connect that died on the first transport drop. `timeout = 0`
+		// retries transport/connection failures indefinitely so an unattended publisher outlives
+		// relay/QUIC outages; non-retryable errors (e.g. auth) stay terminal. During an outage the pad
+		// threads keep writing — bounded by moq-net's per-group eviction — and the relay catches up
+		// from a group boundary on reconnect. A bounded policy is available via `ClientConfig::backoff`.
 		let mut config = moq_native::ClientConfig::default();
 		config.tls.disable_verify = Some(settings.tls_disable_verify);
 		config.backoff.timeout = std::time::Duration::ZERO;
@@ -156,12 +154,12 @@ impl Session {
 
 /// Mirror the reconnect loop's observable state into the element's [`Status`] until the loop stops.
 ///
-/// The reconnect loop owns the session, so this task doesn't touch the transport — it forwards each
-/// [`moq_native::Snapshot`] (connected/version/send-bitrate) into the status the property getters
-/// read, and notifies `connected` on the connect/disconnect edges. With `backoff.timeout = 0` the
-/// loop never gives up, so the `Err` arm is a safety net (a bounded backoff would post the bus error
-/// there on final give-up, as the one-shot path did). [`Session::stop`] aborts this task, which drops
-/// the `Reconnect` handle and quietly tears the loop down.
+/// The reconnect loop owns the session, so this task forwards each [`moq_native::Snapshot`]
+/// (connected/version/send-bitrate) into the status the property getters read, and notifies
+/// `connected` on the connect/disconnect edges. The loop stops only on a terminal error — a
+/// non-retryable auth failure, or (with a bounded backoff) a give-up — which the `Err` arm posts as
+/// a bus error, matching the old one-shot path. [`Session::stop`] aborts this task, which drops the
+/// `Reconnect` handle and quietly tears the loop down.
 async fn forward(
 	mut reconnect: moq_native::Reconnect,
 	origin: moq_net::OriginProducer,
@@ -169,8 +167,9 @@ async fn forward(
 	errored: Arc<AtomicBool>,
 	element: glib::WeakRef<Element>,
 ) {
-	// `origin` is held for the task's lifetime so the published broadcast stays alive across every
-	// reconnect; the loop re-consumes it (a fresh publish leg) for each connection.
+	// Hold the origin producer for the task's lifetime so the published broadcast stays alive: the
+	// reconnecting client owns the consumer (taken once, via `origin.consume()` at start) and
+	// re-publishes it on each connect.
 	let _origin = origin;
 
 	let mut was_connected = false;
@@ -192,9 +191,9 @@ async fn forward(
 				}
 			}
 			Err(err) => {
-				// The reconnect loop permanently gave up (only reachable with a bounded backoff).
-				// Reset the observable surface, flag `errored` so the pad threads stop feeding a dead
-				// session, and post a fatal element error — matching the old one-shot failure path.
+				// The reconnect loop stopped on a terminal error (a non-retryable auth failure, or a
+				// bounded backoff's give-up). Reset the observable surface, flag `errored` so the pad
+				// threads stop feeding a dead session, and post a fatal element error.
 				status.reset();
 				if was_connected {
 					notify_connected(&element);

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -118,7 +118,21 @@ impl Session {
 		let status = Arc::new(Status::default());
 		let errored = Arc::new(AtomicBool::new(false));
 
-		let join = RUNTIME.spawn(run(settings, origin, status.clone(), errored.clone(), element));
+		// Hand the publish origin to a background reconnect loop: connect, wait for the session to
+		// close, then reconnect with exponential backoff. This replaces the previous one-shot connect
+		// that posted a fatal bus error on the first transport death — a relay restart or QUIC idle
+		// timeout left the publish permanently dead until the pipeline was rebuilt. `timeout = 0` means
+		// never give up, so an unattended publisher outlives arbitrary relay/transport outages; the
+		// pad threads keep writing across an outage (bounded by moq-net's per-group eviction) and the
+		// relay catches up from a group boundary on reconnect. A bounded retry policy is available via
+		// `ClientConfig::backoff` if a terminal error is preferred.
+		let mut config = moq_native::ClientConfig::default();
+		config.tls.disable_verify = Some(settings.tls_disable_verify);
+		config.backoff.timeout = std::time::Duration::ZERO;
+		let client = config.init()?.with_publish(origin.consume());
+		let reconnect = client.reconnect(settings.url.clone());
+
+		let join = RUNTIME.spawn(forward(reconnect, origin, status.clone(), errored.clone(), element));
 
 		Ok((Self { join, status, errored }, broadcast, catalog))
 	}
@@ -140,71 +154,57 @@ impl Session {
 	}
 }
 
-/// Connect, then idle on the transport until it closes or dies. A remote death is surfaced as an
-/// element error on the bus; [`Session::stop`] aborts this task instead, which is quiet.
-async fn run(
-	settings: ResolvedSettings,
+/// Mirror the reconnect loop's observable state into the element's [`Status`] until the loop stops.
+///
+/// The reconnect loop owns the session, so this task doesn't touch the transport — it forwards each
+/// [`moq_native::Snapshot`] (connected/version/send-bitrate) into the status the property getters
+/// read, and notifies `connected` on the connect/disconnect edges. With `backoff.timeout = 0` the
+/// loop never gives up, so the `Err` arm is a safety net (a bounded backoff would post the bus error
+/// there on final give-up, as the one-shot path did). [`Session::stop`] aborts this task, which drops
+/// the `Reconnect` handle and quietly tears the loop down.
+async fn forward(
+	mut reconnect: moq_native::Reconnect,
 	origin: moq_net::OriginProducer,
 	status: Arc<Status>,
 	errored: Arc<AtomicBool>,
 	element: glib::WeakRef<Element>,
 ) {
-	// `origin` is held for the task's lifetime so the published broadcast stays alive across the session.
-	let result = connect_and_run(&settings, &origin, &status, &element).await;
+	// `origin` is held for the task's lifetime so the published broadcast stays alive across every
+	// reconnect; the loop re-consumes it (a fresh publish leg) for each connection.
+	let _origin = origin;
 
-	// Reset the observable surface on exit. The Status arc is private to this session, so this never
-	// touches a newer session's status even if a new one started before this task unwound.
-	status.reset();
-	notify_connected(&element);
-
-	if let Err(err) = result {
-		errored.store(true, Ordering::Relaxed);
-		if let Some(obj) = element.upgrade() {
-			gst::element_error!(obj, gst::CoreError::Failed, ("session error"), ["{err:?}"]);
-		}
-	}
-}
-
-async fn connect_and_run(
-	settings: &ResolvedSettings,
-	origin: &moq_net::OriginProducer,
-	status: &Status,
-	element: &glib::WeakRef<Element>,
-) -> Result<()> {
-	let mut config = moq_native::ClientConfig::default();
-	config.tls.disable_verify = Some(settings.tls_disable_verify);
-	let client = config.init()?.with_publish(origin.consume());
-
-	// A stop() during connect aborts this task, cancelling the connect future cleanly.
-	let session = client.connect(settings.url.clone()).await?;
-	status.set_connected(true);
-	status.set_version(Some(session.version().to_string()));
-	notify_connected(element);
-	gst::info!(CAT, "session connected to {}", settings.url);
-
-	// Congestion-controller send estimate; None when unavailable, then this arm parks forever.
-	let mut send_bandwidth = session.send_bandwidth();
-	// Resolves to Err when the transport dies; pinned so the select polls it each iteration.
-	let closed = session.closed();
-	tokio::pin!(closed);
-
+	let mut was_connected = false;
 	loop {
-		tokio::select! {
-			// Remote death: propagate the Err so the wrapper posts an element error to the bus.
-			result = &mut closed => return Ok(result?),
-			bitrate = async {
-				match send_bandwidth.as_mut() {
-					Some(bw) => bw.changed().await,
-					None => std::future::pending::<Option<u64>>().await,
+		match reconnect.changed().await {
+			Ok(snapshot) => {
+				let connected = snapshot.status == Some(moq_native::Status::Connected);
+				status.set_connected(connected);
+				status.set_version(snapshot.version);
+				status.set_send_bitrate(snapshot.send_bitrate);
+				if connected != was_connected {
+					if connected {
+						gst::info!(CAT, "session connected");
+					} else {
+						gst::warning!(CAT, "session disconnected, reconnecting");
+					}
+					notify_connected(&element);
+					was_connected = connected;
 				}
-			} => match bitrate {
-				Some(rate) => status.set_send_bitrate(rate),
-				None => {
-					// Estimate gone: report 0 (the documented "unavailable" value) and stop polling.
-					status.set_send_bitrate(0);
-					send_bandwidth = None;
+			}
+			Err(err) => {
+				// The reconnect loop permanently gave up (only reachable with a bounded backoff).
+				// Reset the observable surface, flag `errored` so the pad threads stop feeding a dead
+				// session, and post a fatal element error — matching the old one-shot failure path.
+				status.reset();
+				if was_connected {
+					notify_connected(&element);
 				}
-			},
+				errored.store(true, Ordering::Relaxed);
+				if let Some(obj) = element.upgrade() {
+					gst::element_error!(obj, gst::CoreError::Failed, ("session error"), ["{err:?}"]);
+				}
+				return;
+			}
 		}
 	}
 }

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -44,10 +44,14 @@ fn missing_url_fails_state_change() {
 	let _ = sink.set_state(gst::State::Null);
 }
 
-// A connect that cannot succeed surfaces as an ERROR on the bus (not a silent log) and leaves the
-// element disconnected. The `.invalid` host fails fast at DNS resolution in this test environment.
+// A connect that cannot succeed does NOT post a fatal ERROR: the sink reconnects with backoff
+// (issue #2212), so an unattended publisher survives a relay that is unreachable at startup or
+// during an outage instead of tearing down the pipeline. It keeps retrying and stays disconnected.
+// (A non-retryable failure — e.g. auth rejection — is still terminal; that path needs a live relay
+// and is covered separately.) The `.invalid` host fails fast at DNS resolution, so the loop is
+// already several retries deep within the window below.
 #[test]
-fn connect_failure_posts_error_to_bus() {
+fn connect_failure_retries_without_erroring() {
 	init();
 	let pipeline = gst::Pipeline::new();
 	let sink = gst::ElementFactory::make("moqsink")
@@ -59,10 +63,16 @@ fn connect_failure_posts_error_to_bus() {
 
 	let _ = pipeline.set_state(gst::State::Playing);
 	let bus = pipeline.bus().expect("pipeline bus");
-	let msg = bus.timed_pop_filtered(gst::ClockTime::from_seconds(10), &[gst::MessageType::Error]);
+	let msg = bus.timed_pop_filtered(gst::ClockTime::from_seconds(3), &[gst::MessageType::Error]);
 	let connected = sink.property::<bool>("connected");
 	let _ = pipeline.set_state(gst::State::Null);
 
-	assert!(msg.is_some(), "a failed connect must post an ERROR to the bus");
-	assert!(!connected, "a failed connect must leave connected = false");
+	assert!(
+		msg.is_none(),
+		"a failed connect must NOT post an ERROR — the sink retries (issue #2212)"
+	);
+	assert!(
+		!connected,
+		"a failed connect must leave connected = false while retrying"
+	);
 }

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -76,7 +76,11 @@ pub enum Status {
 /// The reconnect loop owns the session, so a caller that needs the session's stats (a publisher
 /// element surfacing them as properties, say) reads them from here rather than holding the session
 /// itself. All fields reflect the *current* session and reset when it disconnects.
+///
+/// `#[non_exhaustive]`: read the fields you need; a future observable field won't be a breaking
+/// change. Construct via [`Default`] when a placeholder is needed.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Snapshot {
 	/// Current connection status, or `None` before the first connect.
 	pub status: Option<Status>,

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -71,6 +71,21 @@ pub enum Status {
 	Disconnected,
 }
 
+/// A snapshot of the live session's observable state, reported by [`Reconnect::changed`].
+///
+/// The reconnect loop owns the session, so a caller that needs the session's stats (a publisher
+/// element surfacing them as properties, say) reads them from here rather than holding the session
+/// itself. All fields reflect the *current* session and reset when it disconnects.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Snapshot {
+	/// Current connection status, or `None` before the first connect.
+	pub status: Option<Status>,
+	/// The negotiated MoQ version of the live session, or `None` when disconnected.
+	pub version: Option<String>,
+	/// The congestion controller's send estimate in bits/sec, `0` when disconnected or unavailable.
+	pub send_bitrate: u64,
+}
+
 /// Shared reconnect state, observed by consumers through a [`kio`] channel.
 ///
 /// The channel closing (all producers dropped) is the terminal signal; `error`
@@ -79,8 +94,23 @@ pub enum Status {
 struct State {
 	/// Current connection status, or `None` before the first connect.
 	status: Option<Status>,
+	/// The negotiated MoQ version of the live session, or `None` when disconnected.
+	version: Option<String>,
+	/// The live session's congestion-controller send estimate (bits/sec); `0` when disconnected
+	/// or the backend has no estimate.
+	send_bitrate: u64,
 	/// Set when the reconnect loop permanently gives up (reconnect timeout exceeded).
 	error: Option<Error>,
+}
+
+impl State {
+	fn snapshot(&self) -> Snapshot {
+		Snapshot {
+			status: self.status,
+			version: self.version.clone(),
+			send_bitrate: self.send_bitrate,
+		}
+	}
 }
 
 /// Handle to a background reconnect loop.
@@ -93,6 +123,8 @@ pub struct Reconnect {
 	state: kio::Consumer<State>,
 	/// The last status returned by [`status`](Self::status), for change detection.
 	last_reported: Option<Status>,
+	/// The last snapshot returned by [`changed`](Self::changed), for change detection.
+	last_snapshot: Option<Snapshot>,
 }
 
 impl Reconnect {
@@ -112,6 +144,7 @@ impl Reconnect {
 			abort: task.abort_handle(),
 			state,
 			last_reported: None,
+			last_snapshot: None,
 		}
 	}
 
@@ -137,12 +170,18 @@ impl Reconnect {
 					tracing::info!(%url, "connected");
 					if let Ok(mut state) = state.write() {
 						state.status = Some(Status::Connected);
+						state.version = Some(session.version().to_string());
+						state.send_bitrate = 0;
 					}
 
 					let connected = tokio::time::Instant::now();
-					let closed = session.closed().await;
+					// Wait for the session to close, forwarding its send-bandwidth estimate into the
+					// shared state meanwhile so a consumer tracks the live stats across the connection.
+					let closed = run_session(state, &session).await;
 					if let Ok(mut state) = state.write() {
 						state.status = Some(Status::Disconnected);
+						state.version = None;
+						state.send_bitrate = 0;
 					}
 
 					if connected.elapsed() >= backoff.initial {
@@ -223,6 +262,86 @@ impl Reconnect {
 	pub async fn closed(&self) -> crate::Result<()> {
 		kio::wait(|waiter| self.poll_closed(waiter)).await
 	}
+
+	/// Poll for the next change to the live session's observable [`Snapshot`] since this handle last
+	/// reported one.
+	///
+	/// `Ready(Ok(snapshot))` on any change (connect/disconnect, version, or send-bitrate),
+	/// `Ready(Err)` once the loop has stopped, `Pending` otherwise.
+	pub fn poll_changed(&mut self, waiter: &kio::Waiter) -> Poll<crate::Result<Snapshot>> {
+		let last = self.last_snapshot.clone();
+		let snapshot = match ready!(self.state.poll(waiter, |state| {
+			let snapshot = state.snapshot();
+			if Some(&snapshot) != last.as_ref() {
+				Poll::Ready(snapshot)
+			} else {
+				Poll::Pending
+			}
+		})) {
+			Ok(snapshot) => snapshot,
+			Err(state) => return Poll::Ready(Err(terminal(&state))),
+		};
+
+		self.last_snapshot = Some(snapshot.clone());
+		Poll::Ready(Ok(snapshot))
+	}
+
+	/// Wait until the live session's observable [`Snapshot`] changes from what this handle last
+	/// reported — a connect/disconnect, a version change, or a send-bitrate update — and return the
+	/// current snapshot. `Err` once the loop has stopped.
+	///
+	/// This is the stats-carrying counterpart to [`status`](Self::status): the reconnect loop owns
+	/// the session, so a caller that needs the live session's version/send-bitrate reads them here
+	/// instead of holding the session across reconnects.
+	pub async fn changed(&mut self) -> crate::Result<Snapshot> {
+		kio::wait(|waiter| self.poll_changed(waiter)).await
+	}
+
+	/// The negotiated MoQ version of the live session, or `None` when disconnected.
+	pub fn version(&self) -> Option<String> {
+		self.state.read().version.clone()
+	}
+
+	/// The live session's congestion-controller send estimate in bits/sec, `0` when disconnected or
+	/// unavailable.
+	pub fn send_bitrate(&self) -> u64 {
+		self.state.read().send_bitrate
+	}
+}
+
+/// Wait for `session` to close, forwarding its congestion-controller send estimate into `state`
+/// meanwhile so a [`Reconnect`] consumer tracks the live send-bitrate. Returns the session's close
+/// result (the reconnect loop uses it to distinguish a healthy drop from an immediate sever).
+async fn run_session(state: &kio::Producer<State>, session: &moq_net::Session) -> Result<(), moq_net::Error> {
+	// `None` when the QUIC backend has no bandwidth estimate; then that select arm parks forever.
+	let mut send_bandwidth = session.send_bandwidth();
+	let closed = session.closed();
+	tokio::pin!(closed);
+
+	loop {
+		tokio::select! {
+			result = &mut closed => return result,
+			bitrate = async {
+				match send_bandwidth.as_mut() {
+					Some(bw) => bw.changed().await,
+					None => std::future::pending::<Option<u64>>().await,
+				}
+			} => match bitrate {
+				Some(rate) => {
+					if let Ok(mut state) = state.write() {
+						state.send_bitrate = rate;
+					}
+				}
+				None => {
+					// Estimate gone: report 0 (the documented "unavailable" value) and stop polling.
+					if let Ok(mut state) = state.write() {
+						state.send_bitrate = 0;
+					}
+					send_bandwidth = None;
+				}
+			},
+		}
+	}
 }
 
 impl Drop for Reconnect {
@@ -250,5 +369,36 @@ mod tests {
 		assert_eq!(backoff.multiplier, 2);
 		assert_eq!(backoff.max, Duration::from_secs(30));
 		assert_eq!(backoff.timeout, Duration::from_secs(300));
+	}
+
+	#[test]
+	fn snapshot_reflects_state_and_detects_change() {
+		// The observable surface `changed()`/`poll_changed()` forward is `State::snapshot()`, and the
+		// change filter is snapshot inequality — so every observable field must round-trip and a
+		// send-bitrate update alone must read as a distinct snapshot.
+		let mut state = State::default();
+		assert_eq!(state.snapshot(), Snapshot::default());
+
+		state.status = Some(Status::Connected);
+		state.version = Some("moq-lite-04".to_string());
+		state.send_bitrate = 2_000_000;
+		let connected = state.snapshot();
+		assert_eq!(connected.status, Some(Status::Connected));
+		assert_eq!(connected.version.as_deref(), Some("moq-lite-04"));
+		assert_eq!(connected.send_bitrate, 2_000_000);
+
+		// A send-bitrate change alone is a new snapshot (so a live estimate update wakes poll_changed).
+		state.send_bitrate = 2_100_000;
+		assert_ne!(state.snapshot(), connected);
+
+		// Disconnect clears version + bitrate but keeps the (distinct) Disconnected status.
+		state.status = Some(Status::Disconnected);
+		state.version = None;
+		state.send_bitrate = 0;
+		let disconnected = state.snapshot();
+		assert_eq!(disconnected.status, Some(Status::Disconnected));
+		assert_eq!(disconnected.version, None);
+		assert_eq!(disconnected.send_bitrate, 0);
+		assert_ne!(disconnected, connected);
 	}
 }


### PR DESCRIPTION
Closes the moqsink half of #2212.

### Problem
`moqsink` did a one-shot `client.connect()` and, on any transport death, posted a fatal `element_error` and set an `errored` flag that stopped the pads feeding the session (`sink/session.rs`). So after **any** transport drop — relay restart, QUIC idle timeout, a transient blip — the publish was permanently dead until the whole pipeline was rebuilt. Fatal for an unattended 24/7 publisher (we hit exactly this in production: a QUIC idle timeout → "session terminated" → publish gone).

### Fix
Switch the sink to the existing `moq-native` reconnect primitive (`Client::reconnect`) with `backoff.timeout = 0` (never give up), matching #1806's flap backoff. Pads keep writing across an outage (bounded by moq-net's per-group eviction) and the relay catches up from a group boundary on reconnect.

### The one design decision — surfacing per-session stats through `Reconnect`
The wrinkle from #2212: the sink reads **per-session** state for its read-only properties — `session.version()` and the congestion-controller send estimate (`estimated-send-bitrate`) — but `Reconnect` owned the session and exposed only `Connected`/`Disconnected`. This is the "transparent reconnect" you mentioned wanting, so I surfaced that state **through** `Reconnect`:

- `reconnect.rs` gains a `Snapshot { status, version, send_bitrate }`; the loop writes `version` on connect and forwards the live `send_bandwidth` estimate into shared state (the `select` that used to live in the sink moved into the primitive).
- `changed()` / `poll_changed()` report snapshot deltas (so a live send-bitrate update wakes a consumer, not just connect edges), plus `version()` / `send_bitrate()` accessors. `status()` is unchanged.
- The sink's `forward` task mirrors each snapshot into its `Status` and notifies `connected` on the edges. `imp.rs` is untouched — its `errored` short-circuit now trips only on a *bounded* backoff's terminal give-up, never on a transient drop.

**This is a proposal, not a fixed shape** — since you want reconnect to become the default/transparent behavior, I'm happy to move the stats surface wherever fits that API (e.g. hang it off `connect()` directly, or a different observability handle). Wanted to give you a working, tested reference for the moqsink half either way.

### Validation
`cargo build` / `test` / `fmt --check` / `clippy` clean on `moq-native` + `moq-gst` (the one clippy note is pre-existing in `quinn.rs`, untouched here). Added a `reconnect.rs` unit test for the snapshot change-detection. Running it in production (patched) across our fleet; reconnect survives relay restarts + QUIC idle timeouts with the properties intact.
