### PR TITLE
fix(moq-video): mark the macOS Surface Sync so moq-transcode compiles

### DIFF
--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -334,7 +334,7 @@ impl Role {
 
 /// Summed traffic counters for one `(tier, role)` slice, aggregated across
 /// every broadcast this node is currently tracking. The host-level rollup of
-/// [`Counters`]: per-broadcast detail is collapsed away (it lives on the
+/// the internal per-broadcast counters: that detail is collapsed away (it lives on the
 /// published `.stats` broadcast, not here). Every counter is cumulative, so a
 /// rate is `delta / delta_t` and a live count is `open - closed`.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -312,7 +312,7 @@ mod tests {
 		for (name, subscriber) in &mut subscribers {
 			let mut group = subscriber.next_group().await.unwrap().unwrap();
 			let payload = group.read_frame().await.unwrap().unwrap();
-			let frame = hang::container::Frame::decode(payload).unwrap();
+			let frame = hang::container::Frame::decode(payload.payload).unwrap();
 			assert!(
 				frame.payload.starts_with(&[0, 0, 0, 1]) || frame.payload.starts_with(&[0, 0, 1]),
 				"{name} output is not Annex-B"
@@ -366,7 +366,7 @@ mod tests {
 		for (name, subscriber) in &mut subscribers {
 			let mut group = subscriber.next_group().await.unwrap().unwrap();
 			let payload = group.read_frame().await.unwrap().unwrap();
-			let frame = hang::container::Frame::decode(payload).unwrap();
+			let frame = hang::container::Frame::decode(payload.payload).unwrap();
 			assert!(
 				frame.payload.starts_with(&[0, 0, 0, 1]) || frame.payload.starts_with(&[0, 0, 1]),
 				"{name} output is not Annex-B"

--- a/rs/moq-video/src/decode/mod.rs
+++ b/rs/moq-video/src/decode/mod.rs
@@ -109,12 +109,16 @@ impl Frame {
 #[cfg(test)]
 mod tests {
 	/// Callers (libmoq, moq-transcode) hold these across `.await`s in spawned
-	/// tasks, so they must stay `Send` even when a platform's frame wraps a GPU
-	/// handle. Compile-time check; fails per-platform if a variant regresses.
+	/// tasks and share frames via `Arc` (the transcode fanout), so they must
+	/// stay `Send` (and `Frame` also `Sync`) even when a platform's frame wraps
+	/// a GPU handle. Compile-time check; fails per-platform if a variant
+	/// regresses.
 	#[test]
 	fn frame_and_consumer_are_send() {
 		fn assert_send<T: Send>() {}
+		fn assert_sync<T: Sync>() {}
 		assert_send::<super::Frame>();
+		assert_sync::<super::Frame>();
 		assert_send::<super::Consumer>();
 	}
 }

--- a/rs/moq-video/src/decode/mod.rs
+++ b/rs/moq-video/src/decode/mod.rs
@@ -109,12 +109,12 @@ impl Frame {
 #[cfg(test)]
 mod tests {
 	/// Callers (libmoq, moq-transcode) hold these across `.await`s in spawned
-	/// tasks and share frames via `Arc` (the transcode fanout), so they must
-	/// stay `Send` (and `Frame` also `Sync`) even when a platform's frame wraps
+	/// tasks and share frames via `Arc` (the transcode fanout), so both must
+	/// stay `Send` and `Frame` also `Sync` even when a platform's frame wraps
 	/// a GPU handle. Compile-time check; fails per-platform if a variant
 	/// regresses.
 	#[test]
-	fn frame_and_consumer_are_send() {
+	fn frame_and_consumer_are_thread_safe() {
 		fn assert_send<T: Send>() {}
 		fn assert_sync<T: Sync>() {}
 		assert_send::<super::Frame>();

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -357,10 +357,13 @@ pub(crate) mod macos {
 
 	// SAFETY: CVPixelBuffer is a reference-counted CoreFoundation wrapper around
 	// an IOSurface. Retain/release are thread-safe and the pixel data is only
-	// touched under CVPixelBufferLockBaseAddress, so the handle can move between
-	// threads (capture delegate -> encode loop, decode task -> caller). objc2
-	// leaves CoreVideo types !Send out of conservatism.
+	// touched under CVPixelBufferLockBaseAddress (read-only here, and the lock
+	// itself is thread-safe), so the handle can move between threads and be
+	// shared by reference (capture delegate -> encode loop, decode task ->
+	// transcode fanout via Arc). objc2 leaves CoreVideo types !Send/!Sync out
+	// of conservatism.
 	unsafe impl Send for Surface {}
+	unsafe impl Sync for Surface {}
 
 	impl Surface {
 		pub(crate) fn new(buffer: CFRetained<CVPixelBuffer>, width: u32, height: u32) -> Self {

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -356,12 +356,14 @@ pub(crate) mod macos {
 	}
 
 	// SAFETY: CVPixelBuffer is a reference-counted CoreFoundation wrapper around
-	// an IOSurface. Retain/release are thread-safe and the pixel data is only
-	// touched under CVPixelBufferLockBaseAddress (read-only here, and the lock
-	// itself is thread-safe), so the handle can move between threads and be
-	// shared by reference (capture delegate -> encode loop, decode task ->
-	// transcode fanout via Arc). objc2 leaves CoreVideo types !Send/!Sync out
-	// of conservatism.
+	// an IOSurface. Retain/release are thread-safe, every &self access is a
+	// plain field read or a read-only CVPixelBufferLockBaseAddress, and no code
+	// path write-locks a shared surface, so the handle can move between threads
+	// (capture delegate -> encode loop) and be shared by reference. objc2
+	// leaves CoreVideo types !Send/!Sync out of conservatism. Sync exists for
+	// the enum-level bound: moq-transcode shares Arc<decode::Frame>, which
+	// needs every variant Sync even though macOS decoded frames are always
+	// downloaded to I420 before they reach that fanout.
 	unsafe impl Send for Surface {}
 	unsafe impl Sync for Surface {}
 


### PR DESCRIPTION
## Summary

- `moq-transcode` fails to build on macOS: its decode fanout shares `Arc<moq_video::decode::Frame>` across spawned tasks, which requires every `Frame` variant to be `Sync`, but the macOS `CVPixelBuffer` `Surface` wrapper only asserted `Send`. Add `unsafe impl Sync for Surface`: every `&self` access is a plain field read or a read-only `CVPixelBufferLockBaseAddress`, and CoreVideo retain/release/lock are thread-safe (objc2 marks CoreVideo types `!Send`/`!Sync` out of conservatism). The Windows (`windows` COM interfaces) and Linux (`cudarc`) variants are already `Sync`.
- Extend the compile-time regression test in `decode/mod.rs` (now `frame_and_consumer_are_thread_safe`) to assert `Frame: Sync` so a platform variant can't silently regress.
- Fix two `moq-transcode` test sites missed by the #2170 `read_frame` reshape: pass `frame.payload` into `hang::container::Frame::decode` instead of the whole `moq_net::frame::Frame` (the other test sites in the file already do this).
- Fix a pre-existing rustdoc failure on dev that blocked CI: `CounterTotals` (moq-net stats, from #2172) linked the `pub(crate)` `Counters` in its doc, which fails `cargo doc` under `-D warnings`.

No public API changes: `Surface` and the touched tests are `pub(crate)`/test-only, and the stats change is doc prose only. Targets `dev` because `moq-transcode`/`moq-video` live there.

## Test plan

- [x] `cargo check --workspace --all-targets` passes (previously failed with 6 Send/Sync errors in moq-transcode)
- [x] `cargo clippy --workspace --all-targets` clean
- [x] `cargo test -p moq-video -p moq-transcode`: 13 + 26 tests pass
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` clean

(Written by Claude Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)