### PR TITLE
fix(js/publish): pace capture polyfill via requestVideoFrameCallback

### DIFF
--- a/js/publish/src/support/index.ts
+++ b/js/publish/src/support/index.ts
@@ -99,7 +99,8 @@ export async function isSupported(): Promise<Full> {
 				// @ts-expect-error No typescript types yet.
 				typeof MediaStreamTrackProcessor !== "undefined"
 					? "full"
-					: typeof OffscreenCanvas !== "undefined"
+					: // The fallback drives a <video> element via requestVideoFrameCallback.
+						"requestVideoFrameCallback" in HTMLVideoElement.prototype
 						? "partial"
 						: "none",
 			encoding:

--- a/js/publish/src/video/polyfill.ts
+++ b/js/publish/src/video/polyfill.ts
@@ -31,15 +31,8 @@ export function TrackProcessor(track: StreamTrack): ReadableStream<VideoFrame> {
 	// TODO Firefox supports this in a background worker.
 	console.warn("Using MediaStreamTrackProcessor polyfill; performance might suffer.");
 
-	const settings = track.getSettings();
-	if (!settings) {
-		throw new Error("track has no settings");
-	}
-
 	let video: HTMLVideoElement;
-	let last: Time.Milli;
-
-	const frameRate = settings.frameRate ?? 30;
+	let handle: number | undefined;
 
 	return new ReadableStream<VideoFrame>({
 		async start() {
@@ -51,20 +44,25 @@ export function TrackProcessor(track: StreamTrack): ReadableStream<VideoFrame> {
 					video.onloadedmetadata = r;
 				}),
 			]);
-
-			last = Time.Milli.now();
 		},
 		async pull(controller) {
-			while (true) {
-				const now = Time.Milli.now();
-				if (Time.Milli.sub(now, last) < ((1000 / frameRate) as Time.Milli)) {
-					await new Promise((r) => requestAnimationFrame(r));
-					continue;
-				}
-
-				last = now;
-				controller.enqueue(new VideoFrame(video, { timestamp: Time.Micro.fromMilli(last) }));
-			}
+			// requestVideoFrameCallback fires once per frame the camera actually delivers, so we
+			// sample its true cadence instead of racing a wall clock. The old timer settled at
+			// 20fps for a 30fps camera because Safari/Firefox clamp performance.now() to whole
+			// milliseconds, so a 33ms tick always read as "too early" for a 33.333ms period.
+			await new Promise<void>((resolve) => {
+				handle = video.requestVideoFrameCallback((now, metadata) => {
+					// captureTime is the frame's capture instant; both it and now are on the
+					// performance.now() timebase, so audio and video stay on one epoch.
+					const timestamp = (metadata.captureTime ?? now) as Time.Milli;
+					controller.enqueue(new VideoFrame(video, { timestamp: Time.Micro.fromMilli(timestamp) }));
+					resolve();
+				});
+			});
+		},
+		cancel() {
+			if (handle !== undefined) video.cancelVideoFrameCallback(handle);
+			if (video) video.srcObject = null;
 		},
 	});
 }


### PR DESCRIPTION
Fixes #2208.

## Problem

On Safari the publisher falls back to the `MediaStreamTrackProcessor` polyfill in `js/publish/src/video/polyfill.ts`, which paced frames with a `requestAnimationFrame` loop comparing elapsed `performance.now()` against the frame period. Safari and Firefox clamp `performance.now()` to 1ms resolution (Spectre mitigation), so at 60Hz a two-tick gap reads as `33` while the 30fps period is `33.333`. `33 < 33.333` is always true, so the loop declined every other tick and settled at **20fps for a 30fps camera**, dropping ~1/3 of frames. `last` was also set to the observed wake time rather than an ideal deadline, so phase error never carried over.

## Fix

Drive the stream off `HTMLVideoElement.requestVideoFrameCallback` instead. It fires once per frame the camera actually delivers, so we sample the true cadence with no wall-clock guessing, no `frameRate` assumption, and no dependence on display refresh rate. This deletes the class of bug rather than tuning the timer.

- **Timestamps** now come from the rVFC metadata: `metadata.captureTime ?? now`. `captureTime` is the frame's actual capture instant, and both it and the callback time are on the `performance.now()` timebase, so audio and video stay on one epoch (matching the native branch's rewrite). `mediaTime` is deliberately avoided since it's media-relative and would break that epoch.
- **`cancel()`** now cancels the pending frame callback and releases the `<video>` `srcObject`; the old loop leaked the element and never stopped on teardown.

## Dropped the rAF fallback

The corrected rAF path is removed rather than kept as a fallback: `requestVideoFrameCallback` shipped in **Firefox 132** (Oct 2024), and the publish encode path already requires WebCodecs, enabled on Firefox desktop in **130** (Sept 2024). So the only browsers that could reach the polyfill without rVFC are Firefox 130-131, a ~1-month window in late 2024, all long since auto-updated. Safari has had rVFC since 15.4 (2022); Chrome/Edge never hit the polyfill (native `MediaStreamTrackProcessor`).

Consequently the support scorer's `video.capture` "partial" gate moves from `OffscreenCanvas` to `requestVideoFrameCallback in HTMLVideoElement.prototype`, so a browser lacking rVFC reports `"none"` rather than reporting "partial" and then silently hanging in `pull`.

## Testing

`just js check` passes (type-check + Biome). No unit test added: the primary path's cadence now comes from the browser rather than code (nothing arithmetic left to regress), and exercising it end-to-end needs a real camera + rVFC, which the bun test env can't provide. Verified against the issue's standalone reproducer that rVFC is the right primitive.

## Follow-up

#2224 tracks routing Firefox through a Worker for native `MediaStreamTrackProcessor`, which would take it off this polyfill entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)