### PR TITLE
build(kt): make `just kt check` compile + test instead of silently skipping

### DIFF
--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -180,7 +180,7 @@ To build and run the JVM tests locally:
 just kt check
 ```
 
-This builds `moq-ffi` for the host arch, regenerates the UniFFI Kotlin bindings, drops the host cdylib into the JNA resource layout, and runs `gradle :moq:jvmTest`.
+This builds `moq-ffi` for the host arch, regenerates the UniFFI Kotlin bindings, drops the host cdylib into the JNA resource layout, and runs `gradle :moq:jvmTest`. It needs `cargo`, a JDK, and Gradle, all of which ship in the `nix develop` shell; run it from there. To only regenerate the checked-in bindings without compiling or testing (for an environment that intentionally lacks Gradle), use `just kt generate`.
 
 Android targets are opt-in via `-Pandroid.enabled=true`. Local builds without the Android SDK still produce a working JVM variant.
 

--- a/flake.nix
+++ b/flake.nix
@@ -195,6 +195,16 @@
           nixfmt
         ];
 
+        # Kotlin wrapper (kt/) toolchain so `just kt check` actually compiles
+        # the wrapper and runs :moq:jvmTest instead of silently skipping.
+        # Pinned to gradle 8.x (Kotlin 2.0.21's Gradle plugin predates Gradle
+        # 9) and JDK 17 (the wrapper's jvmTarget). Cross-platform: the kt check
+        # builds moq-ffi for the host and runs on both Linux and macOS.
+        ktDeps = with pkgs; [
+          jdk17
+          gradle_8
+        ];
+
         # Dependencies for building the OBS plugin (`just obs build`).
         # Linux-only: nixpkgs marks obs-studio broken on Darwin, so macOS
         # and Windows fetch libobs/Qt6 via the OBS buildspec instead (see
@@ -282,6 +292,7 @@
             ++ packagingDeps
             ++ lintDeps
             ++ obsDeps
+            ++ ktDeps
             ++ devTools;
 
           # jemalloc's configure uses -O0 test builds, which conflict with

--- a/kt/README.md
+++ b/kt/README.md
@@ -42,7 +42,9 @@ Cancelling the surrounding coroutine scope propagates through to the native cons
 
 ## Local development
 
-`kt/scripts/check.sh` builds `moq-ffi` for the host, regenerates the UniFFI Kotlin bindings, drops the host cdylib into the JNA-resource layout, and runs `gradle :moq:jvmTest`. Run via `just check-ffi`. Skips cleanly without a JDK or `cargo`.
+`just kt check` (`kt/scripts/check.sh`) builds `moq-ffi` for the host, regenerates the UniFFI Kotlin bindings, drops the host cdylib into the JNA-resource layout, and runs `gradle :moq:jvmTest`. It needs `cargo`, a JDK, and Gradle, all provided by the `nix develop` shell; run it from there. A missing toolchain is an error, not a skip, so Kotlin wrapper drift can't slip past a green check.
+
+`just kt generate` (`kt/scripts/generate.sh`) runs only the generation half (build `moq-ffi` + regenerate the checked-in bindings, no compile or test). Use it in environments that intentionally lack Gradle; it needs only `cargo`.
 
 The Android target is opt-in via `-Pandroid.enabled=true`. Without the flag the JVM variant builds without an Android SDK, though Gradle still resolves the AGP plugin marker against `google()` at sync time. CI sets the flag automatically when packaging.
 

--- a/kt/README.md
+++ b/kt/README.md
@@ -42,7 +42,7 @@ Cancelling the surrounding coroutine scope propagates through to the native cons
 
 ## Local development
 
-`just kt check` (`kt/scripts/check.sh`) builds `moq-ffi` for the host, regenerates the UniFFI Kotlin bindings, drops the host cdylib into the JNA-resource layout, and runs `gradle :moq:jvmTest`. It needs `cargo`, a JDK, and Gradle, all provided by the `nix develop` shell; run it from there. A missing toolchain is an error, not a skip, so Kotlin wrapper drift can't slip past a green check.
+`just kt check` (`kt/scripts/check.sh`) builds `moq-ffi` for the host, regenerates the UniFFI Kotlin bindings, drops the host cdylib into the JNA resource layout, and runs `gradle :moq:jvmTest`. It needs `cargo`, a JDK, and Gradle, all provided by the `nix develop` shell; run it from there. A missing toolchain is an error, not a skip, so Kotlin wrapper drift can't slip past a green check.
 
 `just kt generate` (`kt/scripts/generate.sh`) runs only the generation half (build `moq-ffi` + regenerate the checked-in bindings, no compile or test). Use it in environments that intentionally lack Gradle; it needs only `cargo`.
 

--- a/kt/justfile
+++ b/kt/justfile
@@ -9,11 +9,19 @@ set working-directory := '.'
 default:
     just check
 
-# Build moq-ffi for the host, regenerate uniffi bindings, run :moq:jvmTest.
+# Build moq-ffi for the host, regenerate uniffi bindings, compile the
+# wrapper, and run :moq:jvmTest. Needs cargo + a JDK + gradle (all in the
 
-# Skips cleanly if cargo, java, or gradle is missing.
+# `nix develop` shell); errors out if any is missing so drift can't slip by.
 check:
     bash scripts/check.sh
+
+# Regenerate the checked-in uniffi bindings + host native lib without
+# compiling or testing. For environments that intentionally lack gradle;
+
+# `check` runs this first. Needs cargo.
+generate:
+    bash scripts/generate.sh
 
 # Assemble the KMP module from per-target moq-ffi binaries + bindings.
 # Used by .github/workflows/release-kt.yml; see kt/README.md for the

--- a/kt/scripts/check.sh
+++ b/kt/scripts/check.sh
@@ -1,80 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Local smoke check for the Kotlin wrapper.
+# Full check for the Kotlin wrapper: regenerate the bindings + native lib
+# (scripts/generate.sh), then compile the wrapper and run `:moq:jvmTest`.
 #
-# Builds moq-ffi for the host target, drops the cdylib into the JNA-resource
-# layout of the :moq KMP module, regenerates the bindings, and runs
-# `:moq:jvmTest`. Intended for `just check-ffi`.
-#
-# Skipped cleanly on hosts without `java` or `cargo`.
+# Unlike generation, this needs a JDK and Gradle. Both ship in the `nix
+# develop` dev shell (see flake.nix ktDeps), so a missing one is an error
+# rather than a silent skip: skipping here lets Kotlin wrapper drift slip
+# past a green `just check`. Environments that intentionally lack Gradle
+# should run `just kt generate` instead.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 KT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-WORKSPACE_DIR="$(cd "$KT_DIR/.." && pwd)"
+
+bash "$SCRIPT_DIR/generate.sh"
 
 if ! command -v java >/dev/null 2>&1; then
-    echo "kt check: no JDK on PATH, skipping" >&2
-    exit 0
-fi
-if ! command -v cargo >/dev/null 2>&1; then
-    echo "kt check: no cargo on PATH, skipping" >&2
-    exit 0
-fi
-
-HOST_TARGET=$(rustc -vV | awk '/^host:/ {print $2}')
-echo "kt check: building moq-ffi for $HOST_TARGET..."
-cargo build --release --package moq-ffi \
-    --manifest-path "$WORKSPACE_DIR/Cargo.toml"
-
-TARGET_BASE=$(cargo metadata --format-version 1 --manifest-path "$WORKSPACE_DIR/Cargo.toml" --no-deps |
-    sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
-
-case "$HOST_TARGET" in
-    *-apple-*)
-        CDYLIB="$TARGET_BASE/release/libmoq_ffi.dylib"
-        OS_TAG="darwin"
-        ;;
-    *-windows-*)
-        CDYLIB="$TARGET_BASE/release/moq_ffi.dll"
-        OS_TAG="win32"
-        ;;
-    *)
-        CDYLIB="$TARGET_BASE/release/libmoq_ffi.so"
-        OS_TAG="linux"
-        ;;
-esac
-case "$HOST_TARGET" in
-    aarch64-*) ARCH_TAG="aarch64" ;;
-    x86_64-*) ARCH_TAG="x86-64" ;;
-    *)
-        echo "kt check: unsupported host arch in $HOST_TARGET" >&2
-        exit 1
-        ;;
-esac
-
-[[ -f "$CDYLIB" ]] || {
-    echo "kt check: cdylib not found at $CDYLIB" >&2
+    echo "kt check: no JDK on PATH; run 'nix develop' or use 'just kt generate' to only regenerate bindings" >&2
     exit 1
-}
-
-RES_DIR="$KT_DIR/moq/src/jvmMain/resources/${OS_TAG}-${ARCH_TAG}"
-mkdir -p "$RES_DIR"
-cp "$CDYLIB" "$RES_DIR/"
-
-BINDGEN_OUT=$(mktemp -d)
-trap 'rm -rf "$BINDGEN_OUT"' EXIT
-cargo run --release --package moq-ffi --bin uniffi-bindgen \
-    --manifest-path "$WORKSPACE_DIR/Cargo.toml" -- \
-    generate --library "$CDYLIB" --language kotlin --out-dir "$BINDGEN_OUT"
-
-mkdir -p "$KT_DIR/moq/src/jvmAndAndroidMain/kotlin/uniffi/moq"
-cp "$BINDGEN_OUT/uniffi/moq/moq.kt" "$KT_DIR/moq/src/jvmAndAndroidMain/kotlin/uniffi/moq/moq.kt"
+fi
 
 GRADLE_CMD="${GRADLE_CMD:-$(command -v gradle || true)}"
 if [[ -z "$GRADLE_CMD" ]]; then
-    echo "kt check: gradle not on PATH, skipping" >&2
-    exit 0
+    echo "kt check: gradle not on PATH; run 'nix develop' or use 'just kt generate' to only regenerate bindings" >&2
+    exit 1
 fi
 
 "$GRADLE_CMD" -p "$KT_DIR" -Pmoqffi.version=0.0.0-dev :moq:jvmTest

--- a/kt/scripts/generate.sh
+++ b/kt/scripts/generate.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Generation-only step for the Kotlin wrapper: build moq-ffi for the host
-# target, drop the cdylib into the JNA-resource layout of the :moq KMP module,
+# target, drop the cdylib into the JNA resource layout of the :moq KMP module,
 # and regenerate the uniffi bindings. No Gradle, no JDK required.
 #
 # Intended for environments that intentionally lack Gradle (e.g. regenerating
@@ -15,6 +15,10 @@ WORKSPACE_DIR="$(cd "$KT_DIR/.." && pwd)"
 
 if ! command -v cargo >/dev/null 2>&1; then
     echo "kt generate: cargo not on PATH; install the Rust toolchain (or use 'nix develop')" >&2
+    exit 1
+fi
+if ! command -v rustc >/dev/null 2>&1; then
+    echo "kt generate: rustc not on PATH; install the Rust toolchain (or use 'nix develop')" >&2
     exit 1
 fi
 

--- a/kt/scripts/generate.sh
+++ b/kt/scripts/generate.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generation-only step for the Kotlin wrapper: build moq-ffi for the host
+# target, drop the cdylib into the JNA-resource layout of the :moq KMP module,
+# and regenerate the uniffi bindings. No Gradle, no JDK required.
+#
+# Intended for environments that intentionally lack Gradle (e.g. regenerating
+# checked-in bindings after a moq-ffi change). `scripts/check.sh` calls this
+# first and then compiles + tests the result. Requires cargo.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKSPACE_DIR="$(cd "$KT_DIR/.." && pwd)"
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "kt generate: cargo not on PATH; install the Rust toolchain (or use 'nix develop')" >&2
+    exit 1
+fi
+
+HOST_TARGET=$(rustc -vV | awk '/^host:/ {print $2}')
+echo "kt generate: building moq-ffi for $HOST_TARGET..."
+cargo build --release --package moq-ffi \
+    --manifest-path "$WORKSPACE_DIR/Cargo.toml"
+
+TARGET_BASE=$(cargo metadata --format-version 1 --manifest-path "$WORKSPACE_DIR/Cargo.toml" --no-deps |
+    sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+
+case "$HOST_TARGET" in
+    *-apple-*)
+        CDYLIB="$TARGET_BASE/release/libmoq_ffi.dylib"
+        OS_TAG="darwin"
+        ;;
+    *-windows-*)
+        CDYLIB="$TARGET_BASE/release/moq_ffi.dll"
+        OS_TAG="win32"
+        ;;
+    *)
+        CDYLIB="$TARGET_BASE/release/libmoq_ffi.so"
+        OS_TAG="linux"
+        ;;
+esac
+case "$HOST_TARGET" in
+    aarch64-*) ARCH_TAG="aarch64" ;;
+    x86_64-*) ARCH_TAG="x86-64" ;;
+    *)
+        echo "kt generate: unsupported host arch in $HOST_TARGET" >&2
+        exit 1
+        ;;
+esac
+
+[[ -f "$CDYLIB" ]] || {
+    echo "kt generate: cdylib not found at $CDYLIB" >&2
+    exit 1
+}
+
+RES_DIR="$KT_DIR/moq/src/jvmMain/resources/${OS_TAG}-${ARCH_TAG}"
+mkdir -p "$RES_DIR"
+cp "$CDYLIB" "$RES_DIR/"
+
+BINDGEN_OUT=$(mktemp -d)
+trap 'rm -rf "$BINDGEN_OUT"' EXIT
+cargo run --release --package moq-ffi --bin uniffi-bindgen \
+    --manifest-path "$WORKSPACE_DIR/Cargo.toml" -- \
+    generate --library "$CDYLIB" --language kotlin --no-format --out-dir "$BINDGEN_OUT"
+
+mkdir -p "$KT_DIR/moq/src/jvmAndAndroidMain/kotlin/uniffi/moq"
+cp "$BINDGEN_OUT/uniffi/moq/moq.kt" "$KT_DIR/moq/src/jvmAndAndroidMain/kotlin/uniffi/moq/moq.kt"


### PR DESCRIPTION
Fixes #2222.

## Problem

`nix develop --command just kt check` regenerated the UniFFI Kotlin bindings and then exited `0` with `kt check: gradle not on PATH, skipping` — the Nix dev shell shipped neither a JDK nor Gradle, and the script treated their absence as a silent skip. So the *recommended* dev environment never actually compiled the Kotlin wrapper or ran `:moq:jvmTest`, and wrapper drift after a `moq-ffi` change could ride straight through a green `just check`.

## Fix

Root cause is the missing toolchain in the dev shell plus a skip-on-absence policy that hid it. Addressed on both fronts (all three directions the issue suggested):

- **`flake.nix`** — add `ktDeps` (`jdk17`, matching the wrapper's `jvmTarget`; `gradle_8`, since Kotlin 2.0.21's Gradle plugin predates Gradle 9) to the default dev shell. Verified the shell now exposes JDK 17 and Gradle 8.14 on PATH.
- **`kt/scripts/check.sh`** — a missing JDK or Gradle is now a hard error that points at `nix develop` / `just kt generate`, instead of `exit 0`. Skipping is what let drift slip by.
- **`kt/scripts/generate.sh` (new) + `just kt generate`** — a generation-only recipe (build `moq-ffi` + regenerate the checked-in bindings, no compile/test) for environments that intentionally lack Gradle. `check.sh` calls it first, so the generation half has a single source of truth. It passes `--no-format` to `uniffi-bindgen` so it no longer warns about a missing `ktlint` while prettifying the gitignored bindings.
- **`doc/lib/kt/moq.md`, `kt/README.md`** — document the toolchain requirement and the new `generate` recipe.

## Verification

`nix develop --command just kt check` now runs the real path: builds `moq-ffi`, regenerates bindings, then `> Task :moq:jvmTest` → **`BUILD SUCCESSFUL`**. Regenerating produces no binding drift, generation output is warning-free, and `shfmt`/`shellcheck`/`nixfmt`/`just --fmt` are all clean.

Targets `main` per Branch Targeting — tooling/build only, no published contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)