### PR TITLE
fix(publish): scope video config effect

### DIFF
--- a/js/publish/src/video/encoder.test.ts
+++ b/js/publish/src/video/encoder.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "bun:test";
+import type * as Moq from "@moq/net";
+import { Effect, Signal } from "@moq/signals";
+import { Encoder } from "./encoder";
+import type { Source } from "./types";
+
+test("serve tracks encoder config in its child effect", async () => {
+	const OriginalVideoEncoder = globalThis.VideoEncoder;
+	const originalWarn = console.warn;
+	const warnings: unknown[][] = [];
+
+	class FakeVideoEncoder {
+		state: CodecState = "unconfigured";
+
+		configure(): void {
+			this.state = "configured";
+		}
+
+		encode(): void {}
+
+		close(): void {
+			this.state = "closed";
+		}
+	}
+
+	globalThis.VideoEncoder = FakeVideoEncoder as unknown as typeof VideoEncoder;
+	console.warn = (...args: unknown[]) => warnings.push(args);
+
+	const frame = new Signal<VideoFrame | undefined>(undefined);
+	const source = new Signal<Source | undefined>(undefined);
+	const connection = new Signal<Moq.Connection.Established | undefined>(undefined);
+	const encoder = new Encoder(frame, source, connection, { enabled: true });
+	const effect = new Effect();
+
+	try {
+		encoder.serve({ close() {} } as never, effect);
+		for (let i = 0; i < 5; i++) await Promise.resolve();
+
+		expect(warnings.map(([message]) => message)).not.toContain(
+			"Effect did not subscribe to any signals; it will never rerun.",
+		);
+	} finally {
+		effect.close();
+		encoder.close();
+		console.warn = originalWarn;
+		globalThis.VideoEncoder = OriginalVideoEncoder;
+	}
+});

--- a/js/publish/src/video/encoder.test.ts
+++ b/js/publish/src/video/encoder.test.ts
@@ -1,30 +1,45 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import type * as Moq from "@moq/net";
 import { Effect, Signal } from "@moq/signals";
 import { Encoder } from "./encoder";
 import type { Source } from "./types";
 
-test("serve tracks encoder config in its child effect", async () => {
-	const OriginalVideoEncoder = globalThis.VideoEncoder;
-	const originalWarn = console.warn;
-	const warnings: unknown[][] = [];
+class FakeVideoEncoder {
+	state: CodecState = "unconfigured";
 
-	class FakeVideoEncoder {
-		state: CodecState = "unconfigured";
-
-		configure(): void {
-			this.state = "configured";
-		}
-
-		encode(): void {}
-
-		close(): void {
-			this.state = "closed";
-		}
+	configure(): void {
+		this.state = "configured";
 	}
 
-	globalThis.VideoEncoder = FakeVideoEncoder as unknown as typeof VideoEncoder;
-	console.warn = (...args: unknown[]) => warnings.push(args);
+	encode(): void {}
+
+	close(): void {
+		this.state = "closed";
+	}
+}
+
+function installFakeVideoEncoder() {
+	const original = Object.getOwnPropertyDescriptor(globalThis, "VideoEncoder");
+	Object.defineProperty(globalThis, "VideoEncoder", {
+		configurable: true,
+		value: FakeVideoEncoder,
+		writable: true,
+	});
+
+	return {
+		[Symbol.dispose]() {
+			if (original) {
+				Object.defineProperty(globalThis, "VideoEncoder", original);
+			} else {
+				Reflect.deleteProperty(globalThis, "VideoEncoder");
+			}
+		},
+	};
+}
+
+test("serve tracks encoder config in its child effect", async () => {
+	using _videoEncoder = installFakeVideoEncoder();
+	using warn = spyOn(console, "warn").mockImplementation(() => {});
 
 	const frame = new Signal<VideoFrame | undefined>(undefined);
 	const source = new Signal<Source | undefined>(undefined);
@@ -36,13 +51,12 @@ test("serve tracks encoder config in its child effect", async () => {
 		encoder.serve({ close() {} } as never, effect);
 		for (let i = 0; i < 5; i++) await Promise.resolve();
 
-		expect(warnings.map(([message]) => message)).not.toContain(
+		expect(warn).not.toHaveBeenCalledWith(
 			"Effect did not subscribe to any signals; it will never rerun.",
+			expect.anything(),
 		);
 	} finally {
 		effect.close();
 		encoder.close();
-		console.warn = originalWarn;
-		globalThis.VideoEncoder = OriginalVideoEncoder;
 	}
 });

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -115,8 +115,8 @@ export class Encoder {
 
 			effect.cleanup(() => encoder.close());
 
-			effect.run((effect) => {
-				const config = effect.get(this.#config);
+			effect.run((childEffect) => {
+				const config = childEffect.get(this.#config);
 				if (!config) return;
 
 				encoder.configure(config);

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -115,7 +115,7 @@ export class Encoder {
 
 			effect.cleanup(() => encoder.close());
 
-			effect.run(() => {
+			effect.run((effect) => {
 				const config = effect.get(this.#config);
 				if (!config) return;
 


### PR DESCRIPTION
## Summary

- Track the resolved video encoder config on the nested config effect created by Effect.run.
- Prevent bitrate-driven config updates from rerunning the parent track-serving effect and recreating the producer and encoder.
- Add a regression test that catches the empty child effect warning from the incorrect scope.

Closes #2206.

## Public API changes

None.

## Test plan

- nix develop --command just ci

## Cross-package sync

No paired package or documentation updates are needed because this is an internal effect-lifecycle fix with no UI, public API, or wire-format change.

(Written by GPT-5)