### PR TITLE
fix(watch): avoid redundant URL reconnects

### DIFF
--- a/js/net/src/connection/reload.test.ts
+++ b/js/net/src/connection/reload.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "bun:test";
+import { Reload } from "./reload.ts";
+
+async function settle() {
+	await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+test("equivalent URL instances do not restart a pending connection", async () => {
+	const original = globalThis.WebTransport;
+	let connects = 0;
+
+	class PendingWebTransport {
+		ready = new Promise<void>(() => {});
+		closed = new Promise<void>(() => {});
+
+		constructor() {
+			connects++;
+		}
+
+		close() {}
+	}
+
+	globalThis.WebTransport = PendingWebTransport as unknown as typeof WebTransport;
+	const reload = new Reload({
+		enabled: true,
+		url: new URL("https://example.com/broadcast"),
+		websocket: { enabled: false },
+	});
+
+	try {
+		await settle();
+		expect(connects).toBe(1);
+
+		reload.url.set(new URL("https://example.com/broadcast"));
+		await settle();
+		expect(connects).toBe(1);
+
+		reload.url.set(new URL("https://example.com/other"));
+		await settle();
+		expect(connects).toBe(2);
+	} finally {
+		reload.close();
+		globalThis.WebTransport = original;
+	}
+});

--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -85,6 +85,10 @@ export class Reload {
 	// Increased by 1 each time to trigger a reload.
 	#tick = new Signal(0);
 
+	// Use the serialized URL as the reactive connection key. URL objects use identity
+	// equality, but replacing one with an equivalent instance should not reconnect.
+	#url: Getter<string | undefined>;
+
 	constructor(props?: ReloadProps) {
 		this.url = Signal.from(props?.url);
 		this.enabled = Signal.from(props?.enabled ?? false);
@@ -99,6 +103,8 @@ export class Reload {
 			this.#closedReject = reject;
 		});
 
+		this.#url = this.signals.computed((effect) => effect.get(this.url)?.href);
+
 		// Create a reactive root so cleanup is easier.
 		this.signals.run(this.#connect.bind(this));
 		this.signals.run(this.#runAnnounced.bind(this));
@@ -111,8 +117,9 @@ export class Reload {
 		const enabled = effect.get(this.enabled);
 		if (!enabled) return;
 
-		const url = effect.get(this.url);
-		if (!url) return;
+		const href = effect.get(this.#url);
+		if (!href) return;
+		const url = new URL(href);
 
 		effect.set(this.status, "connecting", "disconnected");
 

--- a/js/net/src/lite/subscriber.test.ts
+++ b/js/net/src/lite/subscriber.test.ts
@@ -1,0 +1,31 @@
+import { expect, spyOn, test } from "bun:test";
+import { createBandwidth } from "../bandwidth.ts";
+import { OriginSchema } from "./origin.ts";
+import { Subscriber } from "./subscriber.ts";
+import { Version } from "./version.ts";
+
+test("closing the subscriber suppresses probe stream warnings", async () => {
+	let readable!: ReadableStreamDefaultController<Uint8Array>;
+	const quic = {
+		createBidirectionalStream: async () => ({
+			readable: new ReadableStream<Uint8Array>({ start: (controller) => (readable = controller) }),
+			writable: new WritableStream<Uint8Array>(),
+		}),
+	} as unknown as WebTransport;
+	const subscriber = new Subscriber(quic, Version.DRAFT_03, OriginSchema.parse(1n), createBandwidth());
+	const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+	try {
+		const probe = subscriber.runProbe();
+
+		await Promise.resolve();
+		await Promise.resolve();
+		subscriber.close();
+		readable.error(new Error("session closed"));
+		await probe;
+
+		expect(warn).not.toHaveBeenCalled();
+	} finally {
+		warn.mockRestore();
+	}
+});

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -55,6 +55,9 @@ export class Subscriber {
 	// RTT producer (Lite04+ only).
 	#rtt?: Signal<Time.Milli | undefined>;
 
+	// Distinguishes failures from streams torn down by Subscriber.close().
+	#closed = new AbortController();
+
 	/**
 	 * Creates a new Subscriber instance.
 	 * @param quic - The WebTransport session to use
@@ -361,7 +364,9 @@ export class Subscriber {
 				}
 			}
 		} catch (err: unknown) {
-			console.warn("probe stream error", err);
+			if (!this.#closed.signal.aborted) {
+				console.warn("probe stream error", err);
+			}
 		} finally {
 			this.#recvBandwidth.set(undefined);
 			this.#rtt?.set(undefined);
@@ -369,6 +374,8 @@ export class Subscriber {
 	}
 
 	close() {
+		this.#closed.abort();
+
 		for (const track of this.#subscribes.values()) {
 			track.close();
 		}


### PR DESCRIPTION
## Summary

- key reload connections by serialized URL so attribute reflection cannot reconnect an equivalent URL instance
- suppress probe warnings when the subscriber intentionally closes its own transport
- add regression coverage for equivalent URL updates, real URL changes, and intentional probe teardown

The root cause was identity-based signal equality for `URL` instances. The watch element mirrored its URL through an attribute, reparsed the same href into a new object, and made the reload effect tear down the connection it had just established. That teardown then surfaced as a misleading probe warning.

Closes #2207.

## Public API changes

None.

## Test plan

- `nix develop --command just ci`

(Written by GPT-5)
