### PR TITLE
go: pass timestamps to raw frame writes

### DIFF
--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -105,7 +105,7 @@ go func() {
     if err != nil {
         return
     }
-    _ = track.WriteFrame([]byte("ready"))
+    _ = track.WriteFrame([]byte("ready"), 0)
 }()
 ```
 

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -186,7 +186,7 @@ dynamic.requestedBroadcasts().collect { request ->
         val broadcast = BroadcastProducer()
         val track = broadcast.publishTrack("status", null)
         request.accept(broadcast)
-        track.writeFrame("ready".encodeToByteArray())
+        track.writeFrame("ready".encodeToByteArray(), timestampUs = 0u)
     } else {
         request.abort(404)
     }

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -224,7 +224,7 @@ async for request in dynamic:
         broadcast = moq.BroadcastProducer()
         track = broadcast.publish_track("status")
         request.accept(broadcast)
-        track.write_frame(b"ready")
+        track.write_frame(b"ready", 0)
 ```
 
 The served broadcast is not announced. It only resolves consumers that call `request_broadcast(path)`. Each request arrives as a `BroadcastRequest`; call `accept(broadcast)` to serve it, or `abort(code)` to fail the requester.

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -185,7 +185,7 @@ for try await request in dynamic {
         let broadcast = try BroadcastProducer()
         let track = try broadcast.publishTrack(name: "status")
         try request.accept(broadcast: broadcast)
-        try track.writeFrame(Data("ready".utf8))
+        try track.writeFrame(Data("ready".utf8), timestampUs: 0)
     } else {
         try request.abort(errorCode: 404)
     }

--- a/go/wrapper/moq/moq_test.go
+++ b/go/wrapper/moq/moq_test.go
@@ -92,15 +92,15 @@ func TestDynamicBroadcastRequest(t *testing.T) {
 	defer trackConsumer.Cancel()
 
 	payload := []byte("served dynamically")
-	if err := track.WriteFrame(payload); err != nil {
+	if err := track.WriteFrame(payload, 0); err != nil {
 		t.Fatal(err)
 	}
 	frame, err := trackConsumer.ReadFrame(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(frame) != string(payload) {
-		t.Fatalf("frame = %q, want %q", frame, payload)
+	if frame == nil || string(frame.Payload) != string(payload) || frame.TimestampUs != 0 {
+		t.Fatalf("frame = %+v, want payload=%q ts=0", frame, payload)
 	}
 
 	if err := track.Finish(); err != nil {
@@ -406,7 +406,7 @@ func TestDynamicTrackRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 	payload := []byte("hello dynamic track")
-	if err := track.WriteFrame(payload); err != nil {
+	if err := track.WriteFrame(payload, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -426,8 +426,8 @@ func TestDynamicTrackRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if string(frame) != string(payload) {
-		t.Fatalf("frame = %q, want %q", frame, payload)
+	if frame == nil || string(frame.Payload) != string(payload) || frame.TimestampUs != 0 {
+		t.Fatalf("frame = %+v, want payload=%q ts=0", frame, payload)
 	}
 	if err := track.Finish(); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

- pass explicit zero timestamps from raw Go wrapper tests
- assert the returned frame payload and timestamp
- update Go, Python, Swift, and Kotlin examples for the required timestamp argument

## Public API changes

None. This ports callers to the existing timestamp-taking API.

## Testing

- `nix develop --command just go check`
- `nix develop --command just ci origin/dev`

Closes #2221

(Written by GPT-5)