### PR TITLE
fix(audio): cancel pending worklet loads

### DIFF
--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -152,7 +152,7 @@ export class Encoder {
 
 		// Async because we need to wait for the worklet to be registered.
 		effect.spawn(async () => {
-			await context.audioWorklet.addModule(CaptureWorklet);
+			await Promise.race([context.audioWorklet.addModule(CaptureWorklet), effect.cancel]);
 			if (context.state === "closed") return;
 
 			const channelCount = requestedChannels ?? settings.channelCount ?? root.channelCount;

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -122,7 +122,7 @@ export class Decoder {
 
 		effect.spawn(async () => {
 			// Register the AudioWorklet processor
-			await context.audioWorklet.addModule(RenderWorklet);
+			await Promise.race([context.audioWorklet.addModule(RenderWorklet), effect.cancel]);
 
 			// Ensure the context is running before creating the worklet
 			if (context.state === "closed") return;


### PR DESCRIPTION
## Summary

- race audio worklet module registration against effect cancellation in publish and watch
- exit through the existing closed-context guard when teardown wins
- prevent expected mid-load `AbortError` rejections from reaching `Effect.spawn`

## Root cause

Closing an `AudioContext` while `audioWorklet.addModule()` is pending rejects the load. Both audio effects awaited that promise directly, so teardown could surface a harmless rejection as a spawn error.

## Validation

- `nix develop --command just js check`

Closes #2202.

(Written by GPT-5)
