### PR TITLE
refactor(net): remove implicit frame timestamp helpers

### DIFF
--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -78,7 +78,7 @@ fn create_track(broadcast: &mut moq_net::broadcast::Producer) -> anyhow::Result<
 	// Publish the catalog as a "catalog.json" track in the broadcast.
 	let mut catalog_track = broadcast.create_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info())?;
 	let mut group = catalog_track.append_group()?;
-	group.write_frame_now(catalog.to_string()?)?;
+	group.write_frame(moq_net::Timestamp::now(), catalog.to_string()?)?;
 	group.finish()?;
 
 	// Actually create the media track now.

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -211,13 +211,13 @@ async fn produce(
 				.as_millis(),
 		};
 		let header = Bytes::from(serde_json::to_vec(&header)?);
-		group.write_frame_now(header.clone())?;
+		group.write_frame(moq_net::Timestamp::now(), header.clone())?;
 		stats.frame_sent(header.len());
 
 		// The remaining frames in the group are zeroed payload.
 		for _ in 0..rolled.group_size {
 			ticker.tick().await;
-			group.write_frame_now(zeros.clone())?;
+			group.write_frame(moq_net::Timestamp::now(), zeros.clone())?;
 			stats.frame_sent(zeros.len());
 		}
 

--- a/rs/moq-json/src/snapshot.rs
+++ b/rs/moq-json/src/snapshot.rs
@@ -255,7 +255,7 @@ impl Inner {
 		self.group
 			.as_mut()
 			.expect("delta_allowed guarantees an open group")
-			.write_frame_now(slice)?;
+			.write_frame(moq_net::Timestamp::now(), slice)?;
 		self.delta_bytes += len;
 		self.group_frames += 1;
 
@@ -302,7 +302,7 @@ impl Inner {
 			(Bytes::from(snapshot), None)
 		};
 		self.snapshot_len = slice.len() as u64;
-		group.write_frame_now(slice)?;
+		group.write_frame(moq_net::Timestamp::now(), slice)?;
 		self.delta_bytes = 0;
 		self.group_frames = 1;
 		self.encoder = encoder;
@@ -749,7 +749,10 @@ mod test {
 		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
 
 		group
-			.write_frame_now(Bytes::from(serde_json::to_vec(&json!({ "a": 1 })).unwrap()))
+			.write_frame(
+				moq_net::Timestamp::ZERO,
+				Bytes::from(serde_json::to_vec(&json!({ "a": 1 })).unwrap()),
+			)
 			.unwrap();
 		group.finish().unwrap();
 

--- a/rs/moq-json/src/stream.rs
+++ b/rs/moq-json/src/stream.rs
@@ -141,7 +141,10 @@ impl Inner {
 			Some(encoder) => encoder.frame(&payload),
 			None => payload,
 		};
-		self.group.as_mut().expect("a group is open").write_frame_now(slice)?;
+		self.group
+			.as_mut()
+			.expect("a group is open")
+			.write_frame(moq_net::Timestamp::now(), slice)?;
 		Ok(())
 	}
 

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -103,7 +103,9 @@ mod test {
 		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
 
 		let (catalog, payload) = catalog_payload("pending");
-		group.write_frame_now(payload).expect("catalog frame should write");
+		group
+			.write_frame(moq_net::Timestamp::ZERO, payload)
+			.expect("catalog frame should write");
 		group.finish().expect("catalog group should finish");
 
 		assert_eq!(expect_catalog(consumer.poll_next(&waiter)), catalog);
@@ -121,7 +123,9 @@ mod test {
 		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
 
 		let (catalog, payload) = catalog_payload("finished");
-		group.write_frame_now(payload).expect("catalog frame should write");
+		group
+			.write_frame(moq_net::Timestamp::ZERO, payload)
+			.expect("catalog frame should write");
 		group.finish().expect("catalog group should finish");
 
 		assert_eq!(expect_catalog(consumer.poll_next(&waiter)), catalog);
@@ -138,13 +142,13 @@ mod test {
 
 		let mut old_group = track.append_group().expect("old catalog group should append");
 		old_group
-			.write_frame_now(old_payload)
+			.write_frame(moq_net::Timestamp::ZERO, old_payload)
 			.expect("old catalog frame should write");
 		old_group.finish().expect("old catalog group should finish");
 
 		let mut latest_group = track.append_group().expect("latest catalog group should append");
 		latest_group
-			.write_frame_now(latest_payload)
+			.write_frame(moq_net::Timestamp::ZERO, latest_payload)
 			.expect("latest catalog frame should write");
 		latest_group.finish().expect("latest catalog group should finish");
 		track.finish().expect("catalog track should finish");
@@ -164,7 +168,7 @@ mod test {
 
 		let mut old_group = track.append_group().expect("old catalog group should append");
 		old_group
-			.write_frame_now(old_payload)
+			.write_frame(moq_net::Timestamp::ZERO, old_payload)
 			.expect("old catalog frame should write");
 		old_group.finish().expect("old catalog group should finish");
 
@@ -173,7 +177,7 @@ mod test {
 		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
 
 		latest_group
-			.write_frame_now(latest_payload)
+			.write_frame(moq_net::Timestamp::ZERO, latest_payload)
 			.expect("latest catalog frame should write");
 		latest_group.finish().expect("latest catalog group should finish");
 
@@ -195,7 +199,7 @@ mod test {
 
 		let mut latest_group = track.append_group().expect("latest catalog group should append");
 		latest_group
-			.write_frame_now(latest_payload)
+			.write_frame(moq_net::Timestamp::ZERO, latest_payload)
 			.expect("latest catalog frame should write");
 		latest_group.finish().expect("latest catalog group should finish");
 		track.finish().expect("catalog track should finish");
@@ -203,7 +207,7 @@ mod test {
 		assert_eq!(expect_catalog(consumer.poll_next(&waiter)), latest);
 
 		old_group
-			.write_frame_now(old_payload)
+			.write_frame(moq_net::Timestamp::ZERO, old_payload)
 			.expect("old catalog frame should write");
 		old_group.finish().expect("old catalog group should finish");
 

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -346,7 +346,7 @@ fn emit<E: CatalogExt>(
 
 	let msf = to_msf(&catalog.media());
 	if let Ok(mut group) = msf_track.append_group() {
-		let _ = group.write_frame_now(msf.to_string().expect("invalid MSF catalog"));
+		let _ = group.write_frame(moq_net::Timestamp::now(), msf.to_string().expect("invalid MSF catalog"));
 		let _ = group.finish();
 	}
 }

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -1406,7 +1406,7 @@ mod tests {
 
 		fn write(&self, group: &mut moq_net::group::Producer, frames: &[Frame]) -> Result<(), Self::Error> {
 			for frame in frames {
-				group.write_frame_now(frame.payload.clone())?;
+				group.write_frame(moq_net::Timestamp::ZERO, frame.payload.clone())?;
 			}
 			Ok(())
 		}
@@ -1445,8 +1445,12 @@ mod tests {
 
 		// A decodable frame first (so startup selects the group), then a malformed one.
 		let mut group = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
-		group.write_frame_now(Bytes::from(0u64.to_le_bytes().to_vec())).unwrap();
-		group.write_frame_now(Bytes::from_static(b"FAIL")).unwrap();
+		group
+			.write_frame(moq_net::Timestamp::ZERO, Bytes::from(0u64.to_le_bytes().to_vec()))
+			.unwrap();
+		group
+			.write_frame(moq_net::Timestamp::ZERO, Bytes::from_static(b"FAIL"))
+			.unwrap();
 		group.finish().unwrap();
 		track.finish().unwrap();
 

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -58,8 +58,14 @@ async fn run_broadcast(origin: moq_net::origin::Producer) -> anyhow::Result<()> 
 
 	// Write frames to the group.
 	// Each frame is dependent on the previous frame, so older frames are prioritized.
-	group.write_frame_now(bytes::Bytes::from_static(b"Hello"))?;
-	group.write_frame_now(bytes::Bytes::from_static(b"World"))?;
+	group.write_frame(
+		moq_native::moq_net::Timestamp::now(),
+		bytes::Bytes::from_static(b"Hello"),
+	)?;
+	group.write_frame(
+		moq_native::moq_net::Timestamp::now(),
+		bytes::Bytes::from_static(b"World"),
+	)?;
 	group.finish()?;
 
 	tracing::info!("wrote hello + world");
@@ -68,7 +74,10 @@ async fn run_broadcast(origin: moq_net::origin::Producer) -> anyhow::Result<()> 
 	tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
 
 	// There's also a helper method to create a group with a single frame.
-	track.write_frame_now(bytes::Bytes::from_static(b"foobarbaz"))?;
+	track.write_frame(
+		moq_native::moq_net::Timestamp::now(),
+		bytes::Bytes::from_static(b"foobarbaz"),
+	)?;
 	tracing::info!("wrote foobarbaz");
 
 	// Sleep before exiting and closing the broadcast.

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -168,11 +168,11 @@ impl Publisher {
 		// Everything but the second.
 		let base = now.format("%Y-%m-%d %H:%M:").to_string();
 
-		segment.write_frame_now(base.clone())?;
+		segment.write_frame(moq_native::moq_net::Timestamp::now(), base.clone())?;
 
 		loop {
 			let delta = now.format("%S").to_string();
-			segment.write_frame_now(delta.clone())?;
+			segment.write_frame(moq_native::moq_net::Timestamp::now(), delta.clone())?;
 
 			let next = now + chrono::Duration::try_seconds(1).unwrap();
 			let next = next.with_nanosecond(0).unwrap();

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -19,7 +19,9 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
+	group
+		.write_frame(moq_native::moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	let mut server_config = moq_native::ServerConfig::default();
@@ -260,7 +262,9 @@ async fn iroh_connect() {
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
+	group
+		.write_frame(moq_native::moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	// Create server iroh endpoint

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -29,7 +29,9 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 
 	// Write a group containing a single frame.
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
+	group
+		.write_frame(moq_native::moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	let mut server_config = moq_native::ServerConfig::default();
@@ -488,7 +490,9 @@ async fn broadcast_moq_lite_05_default_timescale() {
 	let mut track = broadcast.create_track("video", None).expect("create track");
 
 	let mut group = track.append_group().expect("append group");
-	group.write_frame_now(b"hello".as_ref()).expect("write frame");
+	group
+		.write_frame(moq_native::moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("write frame");
 	group.finish().expect("finish group");
 
 	let mut server_config = moq_native::ServerConfig::default();
@@ -1024,7 +1028,9 @@ async fn broadcast_websocket() {
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
+	group
+		.write_frame(moq_native::moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	// Server with both QUIC (required) and WebSocket listeners.
@@ -1130,7 +1136,9 @@ async fn broadcast_websocket_fallback() {
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
+	group
+		.write_frame(moq_native::moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	// QUIC binds on its own port; WebSocket on a different port.
@@ -1242,7 +1250,9 @@ async fn broadcast_websocket_uses_newest_version() {
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
+	group
+		.write_frame(moq_native::moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	let mut server_config = moq_native::ServerConfig::default();
@@ -1308,7 +1318,9 @@ async fn broadcast_race_quic_wins() {
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
+	group
+		.write_frame(moq_native::moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	// Bind WebSocket TCP first to pick a random port, then bind QUIC UDP to
@@ -1395,7 +1407,9 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 	let mut track = broadcast.create_track("video", None).expect("create track");
 
 	let mut group0 = track.append_group().expect("append group 0");
-	group0.write_frame_now(b"a".as_ref()).expect("write frame 0");
+	group0
+		.write_frame(moq_native::moq_net::Timestamp::ZERO, b"a".as_ref())
+		.expect("write frame 0");
 	group0.finish().expect("finish group 0");
 
 	let mut server_config = moq_native::ServerConfig::default();
@@ -1465,7 +1479,9 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 	// A new group published after the resubscribe must reach the consumer
 	// regardless of which linger branch fired.
 	let mut group1 = track.append_group().expect("append group 1");
-	group1.write_frame_now(b"b".as_ref()).expect("write frame 1");
+	group1
+		.write_frame(moq_native::moq_net::Timestamp::ZERO, b"b".as_ref())
+		.expect("write frame 1");
 	group1.finish().expect("finish group 1");
 
 	let mut saw_group1 = false;
@@ -1588,7 +1604,9 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 		.expect("failed to create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
+	group
+		.write_frame(moq_native::moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	let publish = pub_origin
@@ -1722,7 +1740,9 @@ async fn publish_only_client_to_subscribe_only_server() {
 		.expect("failed to create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 	let mut group = track.append_group().expect("failed to append group");
-	group.write_frame_now(b"hello".as_ref()).expect("failed to write frame");
+	group
+		.write_frame(moq_native::moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("failed to write frame");
 	group.finish().expect("failed to finish group");
 
 	let publish = pub_origin

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -846,7 +846,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 
 			// Per-object extension headers may carry the frame's presentation timestamp
-			// (Timestamp/Timescale Object Properties). Absent it, we wall-clock-stamp.
+			// (Timestamp/Timescale Object Properties). Absent it, stamp the local receive time.
 			let timestamp = if group.flags.has_extensions {
 				let size: usize = stream.decode().await?;
 				let mut ext = stream.read_exact(size).await?;
@@ -859,10 +859,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			if size == 0 {
 				let status: u64 = stream.decode().await?;
 				if status == 0 {
-					let frame = match timestamp {
-						Some(ts) => producer.create_frame(frame::Info { size: 0, timestamp: ts })?,
-						None => producer.create_frame_now(0)?,
-					};
+					let timestamp = timestamp.unwrap_or_else(crate::Timestamp::now);
+					let frame = producer.create_frame(frame::Info { size: 0, timestamp })?;
 					track_stats.frame();
 					frame.finish()?;
 				} else if status == 3 && !group.flags.has_end {
@@ -871,12 +869,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					return Err(Error::Unsupported);
 				}
 			} else {
-				// `create_frame*` is the allocation chokepoint and rejects an oversized
+				// `create_frame` is the allocation chokepoint and rejects an oversized
 				// `size` before allocating, so no pre-check is needed.
-				let mut frame = match timestamp {
-					Some(ts) => producer.create_frame(frame::Info { size, timestamp: ts })?,
-					None => producer.create_frame_now(size)?,
-				};
+				let timestamp = timestamp.unwrap_or_else(crate::Timestamp::now);
+				let mut frame = producer.create_frame(frame::Info { size, timestamp })?;
 				track_stats.frame();
 
 				if let Err(err) = self.run_frame(stream, &mut frame, &track_stats).await {

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -743,11 +743,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 			// `create_frame` is the allocation chokepoint and rejects an oversized
 			// `size` before allocating, so no pre-check is needed. No wire timestamp
-			// (pre-lite-05) means wall-clock at receive.
-			let mut frame = match timestamp {
-				Some(ts) => group.create_frame(frame::Info { size, timestamp: ts })?,
-				None => group.create_frame_now(size)?,
-			};
+			// (pre-lite-05) means local receive time.
+			let timestamp = timestamp.unwrap_or_else(Timestamp::now);
+			let mut frame = group.create_frame(frame::Info { size, timestamp })?;
 			track_stats.frame();
 
 			if let Err(err) = self.run_frame(stream, &mut frame, &track_stats).await {
@@ -908,7 +906,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			match self.track_info().await {
 				Ok(info) => {
 					// Lite05 carries per-frame timestamps on the wire at this scale; `Some`
-					// tells `run_group` to decode them (vs. wall-clock-stamping locally).
+					// tells `run_group` to decode them instead of stamping local receive time.
 					let timescale = Some(info.timescale);
 					(Some(Track::Active(request.accept(info))), timescale)
 				}

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -27,9 +27,7 @@ pub struct Info {
 	///
 	/// [`group::Producer::create_frame`] converts it into the parent track's
 	/// timescale, so the scale you build it with doesn't have to match the track.
-	/// Use [`group::Producer::create_frame_now`] /
-	/// [`group::Producer::write_frame_now`] to stamp wall-clock time instead of
-	/// supplying one explicitly.
+	/// For data without a presentation time, pass [`Timestamp::now`] explicitly.
 	pub timestamp: Timestamp,
 }
 

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -262,8 +262,8 @@ impl Producer {
 	/// If you want to write multiple chunks, use [Self::create_frame] to get a frame producer.
 	/// But an upfront size is required.
 	///
-	/// `timestamp` is converted into the parent track's timescale. Use
-	/// [Self::write_frame_now] to stamp wall-clock time instead of supplying one.
+	/// `timestamp` is converted into the parent track's timescale. For data without
+	/// a presentation time, pass [`Timestamp::now`] explicitly.
 	pub fn write_frame<B: IntoBytes>(&mut self, timestamp: Timestamp, data: B) -> Result<()> {
 		let timestamp = timestamp
 			.convert(self.track.timescale)
@@ -289,13 +289,6 @@ impl Producer {
 		drop(state);
 		self.track.broadcast.origin.pool.evict();
 		Ok(())
-	}
-
-	/// Like [Self::write_frame] but stamps the frame with wall-clock now
-	/// ([`Timestamp::now`]). For data with no real presentation time of its own
-	/// (catalogs, JSON state) or sources whose protocol can't carry one.
-	pub fn write_frame_now<B: IntoBytes>(&mut self, data: B) -> Result<()> {
-		self.write_frame(Timestamp::now(), data)
 	}
 
 	/// Create a frame with an upfront size and presentation timestamp, streamed in
@@ -339,15 +332,6 @@ impl Producer {
 			timestamp,
 		};
 		Ok(frame::Producer::new(self, buf, info))
-	}
-
-	/// Like [Self::create_frame] but stamps the frame with wall-clock now
-	/// ([`Timestamp::now`]).
-	pub fn create_frame_now(&mut self, size: u64) -> Result<frame::Producer<'_>> {
-		self.create_frame(frame::Info {
-			size,
-			timestamp: Timestamp::now(),
-		})
 	}
 
 	/// Wake consumers parked on the group channel (called after a partial write).
@@ -713,8 +697,12 @@ mod test {
 	#[test]
 	fn basic_frame_reading() {
 		let mut producer = Info { sequence: 0 }.produce();
-		producer.write_frame_now(Bytes::from_static(b"frame0")).unwrap();
-		producer.write_frame_now(Bytes::from_static(b"frame1")).unwrap();
+		producer
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"frame0"))
+			.unwrap();
+		producer
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"frame1"))
+			.unwrap();
 		producer.finish().unwrap();
 
 		let mut consumer = producer.consume();
@@ -729,7 +717,9 @@ mod test {
 	#[test]
 	fn read_frame_all_at_once() {
 		let mut producer = Info { sequence: 0 }.produce();
-		producer.write_frame_now(Bytes::from_static(b"hello")).unwrap();
+		producer
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"hello"))
+			.unwrap();
 		producer.finish().unwrap();
 
 		let mut consumer = producer.consume();
@@ -754,7 +744,12 @@ mod test {
 	fn chunked_frame_reads_whole() {
 		let mut producer = Info { sequence: 0 }.produce();
 		{
-			let mut frame = producer.create_frame_now(10).unwrap();
+			let mut frame = producer
+				.create_frame(frame::Info {
+					size: 10,
+					timestamp: Timestamp::ZERO,
+				})
+				.unwrap();
 			frame.write(Bytes::from_static(b"hello")).unwrap();
 			frame.write(Bytes::from_static(b"world")).unwrap();
 			frame.finish().unwrap();
@@ -773,7 +768,12 @@ mod test {
 		let mut producer = Info { sequence: 0 }.produce();
 		let mut consumer = producer.consume();
 
-		let mut frame = producer.create_frame_now(6).unwrap();
+		let mut frame = producer
+			.create_frame(frame::Info {
+				size: 6,
+				timestamp: Timestamp::ZERO,
+			})
+			.unwrap();
 		frame.write(Bytes::from_static(b"foo")).unwrap();
 
 		// A consumer can stream the in-flight tail before it's finished.
@@ -814,7 +814,9 @@ mod test {
 	#[test]
 	fn abort_clears_cached_frames() {
 		let mut producer = Info { sequence: 0 }.produce();
-		producer.write_frame_now(Bytes::from_static(b"data")).unwrap();
+		producer
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"data"))
+			.unwrap();
 
 		// A stale consumer that never reads must not pin the cached frames.
 		let _consumer = producer.consume();
@@ -831,7 +833,9 @@ mod test {
 	fn drop_unfinished_clears_cached_frames() {
 		let producer = Info { sequence: 0 }.produce();
 		let mut writer = producer.clone();
-		writer.write_frame_now(Bytes::from_static(b"data")).unwrap();
+		writer
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"data"))
+			.unwrap();
 
 		// A stale consumer keeps the channel (and thus the cache) alive.
 		let mut consumer = producer.consume();
@@ -848,7 +852,9 @@ mod test {
 	#[test]
 	fn drop_finished_keeps_cached_frames() {
 		let mut producer = Info { sequence: 0 }.produce();
-		producer.write_frame_now(Bytes::from_static(b"data")).unwrap();
+		producer
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"data"))
+			.unwrap();
 		producer.finish().unwrap();
 
 		let mut consumer = producer.consume();
@@ -867,7 +873,9 @@ mod test {
 		// Consumer blocks because no frames yet.
 		assert!(consumer.next_frame().now_or_never().is_none());
 
-		producer.write_frame_now(Bytes::from_static(b"data")).unwrap();
+		producer
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"data"))
+			.unwrap();
 		producer.finish().unwrap();
 
 		let frame = consumer.next_frame().now_or_never().unwrap().unwrap().unwrap();
@@ -880,8 +888,8 @@ mod test {
 
 		// Write frames that total more than MAX_GROUP_CACHE.
 		let big = Bytes::from(vec![0u8; MAX_GROUP_CACHE as usize]);
-		producer.write_frame_now(big.clone()).unwrap();
-		producer.write_frame_now(big).unwrap();
+		producer.write_frame(Timestamp::ZERO, big.clone()).unwrap();
+		producer.write_frame(Timestamp::ZERO, big).unwrap();
 
 		// The first frame should have been evicted (tombstoned via offset).
 		let state = producer.state.read();
@@ -895,8 +903,8 @@ mod test {
 		let mut producer = Info { sequence: 0 }.produce();
 
 		let big = Bytes::from(vec![0u8; MAX_GROUP_CACHE as usize]);
-		producer.write_frame_now(big.clone()).unwrap();
-		producer.write_frame_now(big).unwrap();
+		producer.write_frame(Timestamp::ZERO, big.clone()).unwrap();
+		producer.write_frame(Timestamp::ZERO, big).unwrap();
 
 		let mut consumer = producer.consume();
 		// First frame was evicted, next_frame should return CacheFull.
@@ -909,7 +917,7 @@ mod test {
 		let mut producer = Info { sequence: 0 }.produce();
 		// Many small frames stay cached: there is no frame-count cap, only a byte budget.
 		for _ in 0..100_000 {
-			producer.write_frame_now(Bytes::from_static(b"x")).unwrap();
+			producer.write_frame(Timestamp::ZERO, Bytes::from_static(b"x")).unwrap();
 		}
 		producer.finish().unwrap();
 
@@ -921,7 +929,7 @@ mod test {
 	#[test]
 	fn clone_consumer_independent() {
 		let mut producer = Info { sequence: 0 }.produce();
-		producer.write_frame_now(Bytes::from_static(b"a")).unwrap();
+		producer.write_frame(Timestamp::ZERO, Bytes::from_static(b"a")).unwrap();
 
 		let mut c1 = producer.consume();
 		// Read one frame from c1
@@ -930,7 +938,7 @@ mod test {
 		// Clone c1, inheriting its index (past first frame).
 		let mut c2 = c1.clone();
 
-		producer.write_frame_now(Bytes::from_static(b"b")).unwrap();
+		producer.write_frame(Timestamp::ZERO, Bytes::from_static(b"b")).unwrap();
 		producer.finish().unwrap();
 
 		// c2 should get the second frame (inherited index)
@@ -948,7 +956,9 @@ mod test {
 		let n = Prefetch::CAP * 3 + 5;
 		let mut producer = Info { sequence: 0 }.produce();
 		for i in 0..n {
-			producer.write_frame_now(Bytes::from(vec![i as u8; 4])).unwrap();
+			producer
+				.write_frame(Timestamp::ZERO, Bytes::from(vec![i as u8; 4]))
+				.unwrap();
 		}
 		producer.finish().unwrap();
 
@@ -965,7 +975,7 @@ mod test {
 	fn interleave_read_and_next_frame() {
 		let mut producer = Info { sequence: 0 }.produce();
 		for i in 0..5u8 {
-			producer.write_frame_now(Bytes::from(vec![i; 1])).unwrap();
+			producer.write_frame(Timestamp::ZERO, Bytes::from(vec![i; 1])).unwrap();
 		}
 		producer.finish().unwrap();
 
@@ -988,8 +998,8 @@ mod test {
 	#[test]
 	fn read_frame_past_cleared_frames_does_not_panic() {
 		let mut producer = Info { sequence: 0 }.produce();
-		producer.write_frame_now(Bytes::from_static(b"a")).unwrap();
-		producer.write_frame_now(Bytes::from_static(b"b")).unwrap();
+		producer.write_frame(Timestamp::ZERO, Bytes::from_static(b"a")).unwrap();
+		producer.write_frame(Timestamp::ZERO, Bytes::from_static(b"b")).unwrap();
 
 		let mut consumer = producer.consume();
 		consumer.read_frame().now_or_never().unwrap().unwrap().unwrap();
@@ -1009,7 +1019,7 @@ mod test {
 	fn drop_with_partial_batch() {
 		let mut producer = Info { sequence: 0 }.produce();
 		for _ in 0..Prefetch::CAP {
-			producer.write_frame_now(Bytes::from_static(b"x")).unwrap();
+			producer.write_frame(Timestamp::ZERO, Bytes::from_static(b"x")).unwrap();
 		}
 		producer.finish().unwrap();
 
@@ -1038,25 +1048,33 @@ mod test {
 		assert_eq!(writer.timestamp.value(), 1000);
 	}
 
-	/// `create_frame_now` stamps wall-clock now, at the group's scale.
+	/// An explicit current timestamp is converted to the group's scale.
 	#[tokio::test]
-	async fn create_frame_now_stamps_wall_clock() {
+	async fn create_frame_converts_current_timestamp() {
 		use crate::Timescale;
 
 		let mut producer = Producer::new(
 			Info { sequence: 0 },
 			track::Info::default().with_timescale(Timescale::MICRO),
 		);
-		let writer = producer.create_frame_now(3).unwrap();
+		let writer = producer
+			.create_frame(frame::Info {
+				size: 3,
+				timestamp: Timestamp::now(),
+			})
+			.unwrap();
 		assert_eq!(writer.timestamp.scale(), Timescale::MICRO);
-		assert!(!writer.timestamp.is_zero(), "wall clock should be non-zero");
+		assert!(!writer.timestamp.is_zero(), "local clock should be non-zero");
 	}
 
 	/// The per-frame size cap (the group byte budget) is enforced before allocating.
 	#[test]
 	fn create_frame_rejects_oversized() {
 		let mut producer = Info { sequence: 0 }.produce();
-		let result = producer.create_frame_now(MAX_GROUP_CACHE + 1);
+		let result = producer.create_frame(frame::Info {
+			size: MAX_GROUP_CACHE + 1,
+			timestamp: Timestamp::ZERO,
+		});
 		assert!(matches!(result, Err(Error::FrameTooLarge)));
 	}
 }

--- a/rs/moq-net/src/model/time.rs
+++ b/rs/moq-net/src/model/time.rs
@@ -283,7 +283,8 @@ impl Timestamp {
 		}
 	}
 
-	/// Current time, expressed in the default timescale ([`Timescale::MILLI`]).
+	/// Current point on the local monotonic clock, expressed in the default timescale
+	/// ([`Timescale::MILLI`]).
 	///
 	/// This is the one-way bridge from a local clock to a track timestamp: there is
 	/// deliberately no inverse (a [`Timestamp`] is relative and jittered, never a clock).

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -53,7 +53,7 @@ pub struct Info {
 	/// Every track is timed; this defaults to [`Timescale::MILLI`]. On Lite05+ it is
 	/// reported in TRACK_INFO and the publisher zigzag-delta encodes per-frame
 	/// timestamps at this scale on the wire. Protocols whose wire can't carry it
-	/// (pre-Lite05 moq-lite, IETF moq-transport) fall back to wall-clock milliseconds.
+	/// (pre-Lite05 moq-lite, IETF moq-transport) fall back to local monotonic milliseconds.
 	pub timescale: Timescale,
 	/// How long the publisher keeps old groups available before evicting them
 	/// (the newest group is always retained). A subscriber's
@@ -770,20 +770,11 @@ impl Producer {
 
 	/// Create a group with a single frame, at the given presentation timestamp.
 	///
-	/// The timestamp is converted into the track's timescale. Use
-	/// [`Self::write_frame_now`] to stamp wall-clock time instead.
+	/// The timestamp is converted into the track's timescale. For data without
+	/// a presentation time, pass [`Timestamp::now`] explicitly.
 	pub fn write_frame<B: crate::IntoBytes>(&mut self, timestamp: Timestamp, frame: B) -> Result<()> {
 		let mut group = self.append_group()?;
 		group.write_frame(timestamp, frame)?;
-		group.finish()?;
-		Ok(())
-	}
-
-	/// Like [`Self::write_frame`] but stamps the frame with wall-clock now
-	/// ([`Timestamp::now`]).
-	pub fn write_frame_now<B: crate::IntoBytes>(&mut self, frame: B) -> Result<()> {
-		let mut group = self.append_group()?;
-		group.write_frame_now(frame)?;
 		group.finish()?;
 		Ok(())
 	}
@@ -2783,8 +2774,8 @@ mod test {
 		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
-		producer.write_frame_now(b"hello".as_slice()).unwrap();
-		producer.write_frame_now(b"world".as_slice()).unwrap();
+		producer.write_frame(Timestamp::ZERO, b"hello".as_slice()).unwrap();
+		producer.write_frame(Timestamp::ZERO, b"world".as_slice()).unwrap();
 
 		let frame = consumer
 			.read_frame()
@@ -2831,7 +2822,8 @@ mod test {
 		let _stalled = producer.create_group(group::Info { sequence: 3 }).unwrap();
 		// Seq 5: fully-written group with a frame.
 		let mut g5 = producer.create_group(group::Info { sequence: 5 }).unwrap();
-		g5.write_frame_now(bytes::Bytes::from_static(b"later")).unwrap();
+		g5.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"later"))
+			.unwrap();
 		g5.finish().unwrap();
 
 		// read_frame should not block on the stalled seq 3. It returns seq 5's frame.
@@ -2851,12 +2843,14 @@ mod test {
 
 		// Group 0 has two frames; only the first is returned.
 		let mut g0 = producer.create_group(group::Info { sequence: 0 }).unwrap();
-		g0.write_frame_now(bytes::Bytes::from_static(b"one")).unwrap();
-		g0.write_frame_now(bytes::Bytes::from_static(b"two")).unwrap();
+		g0.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"one"))
+			.unwrap();
+		g0.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"two"))
+			.unwrap();
 		g0.finish().unwrap();
 
 		// Group 1 is a normal single-frame group.
-		producer.write_frame_now(b"next".as_slice()).unwrap();
+		producer.write_frame(Timestamp::ZERO, b"next".as_slice()).unwrap();
 
 		let frame = consumer
 			.read_frame()
@@ -2893,7 +2887,8 @@ mod test {
 		);
 
 		// A late frame on the pending group is still delivered.
-		g0.write_frame_now(bytes::Bytes::from_static(b"late")).unwrap();
+		g0.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"late"))
+			.unwrap();
 		let frame = consumer
 			.read_frame()
 			.now_or_never()
@@ -2913,11 +2908,13 @@ mod test {
 
 		// Seq 3 has a frame but is below min_sequence, so it must be skipped.
 		let mut g3 = producer.create_group(group::Info { sequence: 3 }).unwrap();
-		g3.write_frame_now(bytes::Bytes::from_static(b"skip-me")).unwrap();
+		g3.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"skip-me"))
+			.unwrap();
 		g3.finish().unwrap();
 
 		let mut g5 = producer.create_group(group::Info { sequence: 5 }).unwrap();
-		g5.write_frame_now(bytes::Bytes::from_static(b"keep")).unwrap();
+		g5.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"keep"))
+			.unwrap();
 		g5.finish().unwrap();
 
 		let frame = consumer
@@ -2934,7 +2931,7 @@ mod test {
 		let mut producer = track_producer("test", None);
 		let mut consumer = producer.subscribe(None);
 
-		producer.write_frame_now(b"only".as_slice()).unwrap();
+		producer.write_frame(Timestamp::ZERO, b"only".as_slice()).unwrap();
 		producer.finish().unwrap();
 
 		let frame = consumer
@@ -2993,7 +2990,9 @@ mod test {
 
 		// Produce a cached group.
 		let mut group = producer.append_group().unwrap(); // seq 0
-		group.write_frame_now(bytes::Bytes::from_static(b"hello")).unwrap();
+		group
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"hello"))
+			.unwrap();
 		group.finish().unwrap();
 
 		// A cached group resolves immediately and never queues a request. `get_group`
@@ -3032,7 +3031,9 @@ mod test {
 
 		// Serve it by accepting the request; the fetch then resolves.
 		let mut group = req.accept(None).unwrap();
-		group.write_frame_now(bytes::Bytes::from_static(b"hi")).unwrap();
+		group
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"hi"))
+			.unwrap();
 		group.finish().unwrap();
 
 		let mut g = pending.await.unwrap();
@@ -3097,7 +3098,9 @@ mod test {
 			.expect("should not block")
 			.unwrap();
 		let mut group = req.accept(None).unwrap();
-		group.write_frame_now(bytes::Bytes::from_static(b"retry")).unwrap();
+		group
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"retry"))
+			.unwrap();
 		group.finish().unwrap();
 
 		let mut group = retry.await.unwrap();
@@ -3143,7 +3146,9 @@ mod test {
 
 	fn finished_group(producer: &mut Producer, size: usize) -> u64 {
 		let mut group = producer.append_group().unwrap();
-		group.write_frame_now(bytes::Bytes::from(vec![0u8; size])).unwrap();
+		group
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; size]))
+			.unwrap();
 		group.finish().unwrap();
 		group.sequence
 	}
@@ -3265,7 +3270,9 @@ mod test {
 
 		// A late frame on the old group still counts against the budget, and can
 		// evict that very group once it blows past capacity.
-		group0.write_frame_now(bytes::Bytes::from(vec![0u8; 4000])).unwrap();
+		group0
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 4000]))
+			.unwrap();
 		assert!(pool.used() <= 3000, "growth on an old group triggers eviction");
 		assert!(matches!(group0.abort(Error::Cancel), Err(Error::Evicted)));
 	}
@@ -3279,7 +3286,9 @@ mod test {
 
 		// Seq 0 stays open: the straggler used to apply memory pressure later.
 		let mut straggler = producer.append_group().unwrap();
-		straggler.write_frame_now(bytes::Bytes::from(vec![0u8; 1000])).unwrap();
+		straggler
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 1000]))
+			.unwrap();
 		tokio::time::advance(Duration::from_millis(10)).await;
 
 		// The publisher aborts its own latest group; the slot stays at max_sequence.
@@ -3297,14 +3306,18 @@ mod test {
 			.expect("should not block")
 			.unwrap();
 		let mut group = req.accept(None).unwrap();
-		group.write_frame_now(bytes::Bytes::from(vec![0u8; 1000])).unwrap();
+		group
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 1000]))
+			.unwrap();
 		group.finish().unwrap();
 		pending.await.unwrap();
 		tokio::time::advance(Duration::from_millis(10)).await;
 
 		// Blow the budget with the straggler; the refetched latest is pinned, so
 		// the straggler itself is the only eligible victim.
-		straggler.write_frame_now(bytes::Bytes::from(vec![0u8; 4000])).unwrap();
+		straggler
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 4000]))
+			.unwrap();
 
 		assert!(pool.used() <= 3000);
 		let mut group = consumer.get_group(1).expect("refetched latest must stay pinned");
@@ -3339,7 +3352,9 @@ mod test {
 
 		// Accept replaces the evicted slot in place (not Error::Duplicate).
 		let mut group = req.accept(None).unwrap();
-		group.write_frame_now(bytes::Bytes::from_static(b"refetched")).unwrap();
+		group
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"refetched"))
+			.unwrap();
 		group.finish().unwrap();
 
 		let mut group = pending.await.unwrap();

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -1258,7 +1258,7 @@ fn flush_track<T: Serialize>(track: &mut track::Producer, frame: &T, last: &mut 
 	if &json == last {
 		return;
 	}
-	if let Err(err) = track.write_frame_now(json.clone()) {
+	if let Err(err) = track.write_frame(crate::Timestamp::now(), json.clone()) {
 		tracing::debug!(?err, name, "stats: failed to write frame");
 		return;
 	}

--- a/rs/moq-net/tests/wasm.rs
+++ b/rs/moq-net/tests/wasm.rs
@@ -21,24 +21,18 @@
 #![cfg(target_arch = "wasm32")]
 
 use bytes::Bytes;
-use moq_net::{Broadcast, Time, Track};
+use moq_net::{Broadcast, Timestamp, Track};
 use wasm_bindgen_test::*;
 
-/// The producer timestamp clock works on wasm: `Time::now()` (which flows through
-/// the web_async clock) returns a sane, non-decreasing wall-clock time.
+/// The producer timestamp clock works on wasm: `Timestamp::now()` (which flows
+/// through the web_async clock) returns a non-decreasing local time.
 /// On the old code this panicked (`std::time` has no clock on wasm32).
 #[wasm_bindgen_test]
 fn timescale_now_is_sane_and_monotonic() {
-	let a = Time::now();
-	let b = Time::now();
+	let a = Timestamp::now();
+	let b = Timestamp::now();
 
-	// A real post-2020 wall-clock time in ms (2020-01-01 = 1_577_836_800_000).
-	// Proves the web_async wall clock actually resolved.
-	assert!(
-		a.as_millis() > 1_577_836_800_000,
-		"timestamp before 2020. wall clock not working: {}",
-		a.as_millis()
-	);
+	assert!(!a.is_zero(), "timestamp clock did not advance from its local anchor");
 	// Monotonic non-decreasing.
 	assert!(b >= a, "time went backwards: {} < {}", b.as_millis(), a.as_millis());
 }
@@ -54,9 +48,15 @@ async fn produce_consume_frame_roundtrip() {
 	let mut sub = consumer.subscribe_track(&Track::new("stream")).unwrap();
 
 	// Producer side: write a frame (creates a group, timestamped via the wasm clock).
-	track.write_frame(Bytes::from_static(b"hello-wasm")).unwrap();
+	track
+		.write_frame(Timestamp::now(), Bytes::from_static(b"hello-wasm"))
+		.unwrap();
 
 	// Consumer side: read it back.
 	let frame = sub.read_frame().await.unwrap();
-	assert_eq!(frame.as_deref(), Some(&b"hello-wasm"[..]), "frame did not round-trip");
+	assert_eq!(
+		frame.as_ref().map(|frame| frame.payload.as_ref()),
+		Some(&b"hello-wasm"[..]),
+		"frame did not round-trip"
+	);
 }

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -145,7 +145,9 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("create track");
 	let mut group = track.append_group().expect("append group");
-	group.write_frame_now(b"hello".as_ref()).expect("write frame");
+	group
+		.write_frame(moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("write frame");
 	group.finish().expect("finish group");
 
 	let pub_session = tokio::time::timeout(TIMEOUT, client().with_publisher(&pub_origin).connect(url.clone()))
@@ -247,7 +249,9 @@ async fn relay_websocket_root_path_upgrades() {
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("create track");
 	let mut group = track.append_group().expect("append group");
-	group.write_frame_now(b"hello".as_ref()).expect("write frame");
+	group
+		.write_frame(moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("write frame");
 	group.finish().expect("finish group");
 
 	let pub_session = tokio::time::timeout(
@@ -311,7 +315,7 @@ async fn two_publish_only_clients_coexist() {
 	track_a
 		.append_group()
 		.expect("append group a")
-		.write_frame_now(b"a".as_ref())
+		.write_frame(moq_net::Timestamp::ZERO, b"a".as_ref())
 		.expect("write frame a");
 
 	let pub_b = Origin::random().produce();
@@ -320,7 +324,7 @@ async fn two_publish_only_clients_coexist() {
 	track_b
 		.append_group()
 		.expect("append group b")
-		.write_frame_now(b"b".as_ref())
+		.write_frame(moq_net::Timestamp::ZERO, b"b".as_ref())
 		.expect("write frame b");
 
 	let sess_a = tokio::time::timeout(TIMEOUT, client().with_publisher(pub_a.consume()).connect(url.clone()))
@@ -447,7 +451,9 @@ async fn internal_tcp_round_trip() {
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("create track");
 	let mut group = track.append_group().expect("append group");
-	group.write_frame_now(b"hello".as_ref()).expect("write frame");
+	group
+		.write_frame(moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("write frame");
 	group.finish().expect("finish group");
 
 	let pub_session = tokio::time::timeout(
@@ -548,7 +554,9 @@ async fn internal_unix_round_trip() {
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
 	let mut track = broadcast.create_track("video", None).expect("create track");
 	let mut group = track.append_group().expect("append group");
-	group.write_frame_now(b"hello".as_ref()).expect("write frame");
+	group
+		.write_frame(moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("write frame");
 	group.finish().expect("finish group");
 
 	let pub_session = tokio::time::timeout(
@@ -632,7 +640,9 @@ async fn path_round_trip(version: moq_net::Version, pub_url: url::Url, sub_url: 
 	let mut bc = pub_origin.create_broadcast(broadcast).expect("create broadcast");
 	let mut track = bc.create_track("video", None).expect("create track");
 	let mut group = track.append_group().expect("append group");
-	group.write_frame_now(b"hello".as_ref()).expect("write frame");
+	group
+		.write_frame(moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("write frame");
 	group.finish().expect("finish group");
 
 	let pub_client = client_version(Some(version)).with_publisher(pub_origin.consume());


### PR DESCRIPTION
## Summary

- remove `group::Producer::write_frame_now`, `group::Producer::create_frame_now`, and `track::Producer::write_frame_now`
- require callers to choose `Timestamp::now()` or an explicit presentation timestamp at each generic frame write
- normalize missing legacy wire timestamps at the subscriber boundary
- use deterministic `Timestamp::ZERO` values in tests and update the stale wasm test API usage
- describe `Timestamp::now()` as a local monotonic timestamp instead of wall-clock time

## Why

Frame timestamps are mandatory, but the `_now` helpers made timing implicit and encouraged receive-time stamping in generic forwarding and archival paths. Explicit timestamps keep the model honest, align the Rust API with `js/net`, and make accidental timestamp replacement visible at the call site.

## Public API changes

This is a breaking `moq-net` API cleanup and therefore targets `dev`.

Removed:

- `group::Producer::write_frame_now`
- `group::Producer::create_frame_now`
- `track::Producer::write_frame_now`

No public items were added, renamed, or signature-changed. `pub(crate)` and private surfaces are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p moq-net -p moq-json` (462 moq-net tests, 56 moq-json tests, and moq-net doctests)
- `cargo check -p hang -p moq-bench -p moq-mux -p moq-native -p moq-relay --all-targets`
- `cargo clippy -p moq-net --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p moq-net --no-deps`

The wasm-target check remains blocked by the existing cache-layer `Send + Sync` incompatibility on wasm. The stale wasm test source was still updated to the current API.

(Written by GPT-5)
