### PR TITLE
feat(moq-net): let finish_at declare a future exclusive end group (#2219)

### DIFF
--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -71,9 +71,9 @@ impl Publish {
 	/// see a normal end rather than [`moq_net::Error::Dropped`].
 	pub fn close(&mut self, broadcast: Id) -> Result<(), Error> {
 		let (broadcast, mut catalog) = self.broadcasts.remove(broadcast).ok_or(Error::BroadcastNotFound)?;
-		// Close the broadcast first so the clean end reaches subscribers even if
+		// Finish the broadcast first so the clean end reaches subscribers even if
 		// finalizing the catalog fails.
-		broadcast.close();
+		broadcast.finish();
 		catalog.finish()?;
 		Ok(())
 	}

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -291,7 +291,7 @@ async fn run(config: &Config) -> Result<()> {
 
 	// Cleanly close the broadcast so subscribers see a normal end rather than
 	// Error::Dropped.
-	broadcast.close();
+	broadcast.finish();
 	result
 }
 

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -420,9 +420,9 @@ impl MoqBroadcastProducer {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let mut guard = self.state.lock().unwrap();
 		let mut state = guard.take().ok_or(MoqError::Closed)?;
-		// Close the broadcast first so the clean end reaches subscribers even if
+		// Finish the broadcast first so the clean end reaches subscribers even if
 		// finalizing the catalog fails.
-		state.broadcast.close();
+		state.broadcast.finish();
 		state.catalog.finish()?;
 		Ok(())
 	}

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -482,7 +482,8 @@ impl<F: Container> Consumer<F> {
 
 	/// Wait until the track is closed.
 	pub async fn closed(&self) -> Result<(), F::Error> {
-		Ok(self.track.closed().await?)
+		self.track.closed().await?;
+		Ok(())
 	}
 }
 

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -479,12 +479,6 @@ impl<F: Container> Consumer<F> {
 	pub fn set_latency(&mut self, latency: std::time::Duration) {
 		self.latency = latency;
 	}
-
-	/// Wait until the track is closed.
-	pub async fn closed(&self) -> Result<(), F::Error> {
-		self.track.closed().await?;
-		Ok(())
-	}
 }
 
 /// Internal reader for a group of frames.
@@ -1246,31 +1240,6 @@ mod tests {
 		.await;
 
 		assert!(result.is_ok(), "Consumer should not hang after track error");
-	}
-
-	#[tokio::test]
-	async fn closed_resolves_when_track_ends() {
-		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
-		let consumer_track = track.subscribe(None);
-		let consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
-
-		assert!(
-			tokio::time::timeout(Duration::from_millis(50), consumer.closed())
-				.await
-				.is_err()
-		);
-
-		track.finish().unwrap();
-		drop(track);
-
-		tokio::time::timeout(Duration::from_millis(200), consumer.closed())
-			.await
-			.expect("timeout expired waiting for closed()")
-			.expect("consumer.closed() returned an error");
 	}
 
 	// ---- Gap Recovery ----

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -77,7 +77,7 @@ async fn run_broadcast(origin: moq_net::origin::Producer) -> anyhow::Result<()> 
 	// Cleanly close the broadcast so subscribers see a normal end. Dropping the
 	// producer works too, but closing is explicit (and dropping it by accident
 	// while still publishing is a common bug this makes obvious).
-	broadcast.close();
+	broadcast.finish();
 
 	Ok(())
 }

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -85,7 +85,7 @@ async fn main() -> anyhow::Result<()> {
 
 			// Cleanly close the broadcast on exit so subscribers see a normal end
 			// rather than Error::Dropped.
-			broadcast.close();
+			broadcast.finish();
 			result
 		}
 		Command::Subscribe => {

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -777,14 +777,49 @@ mod test {
 			.unwrap();
 		producer.finish().unwrap();
 
-		match recv_next(&mut subscriber, true).await.unwrap() {
+		match recv_next(&mut subscriber, true, false).await.unwrap() {
 			Recv::Datagram(datagram) => assert_eq!(&datagram.payload[..], b"last"),
 			_ => panic!("expected datagram before finished"),
 		}
 
-		match recv_next(&mut subscriber, true).await.unwrap() {
+		match recv_next(&mut subscriber, true, false).await.unwrap() {
 			Recv::Finished => {}
 			_ => panic!("expected finished after datagram"),
+		}
+	}
+
+	#[tokio::test]
+	async fn recv_next_reports_future_boundary_before_finished() {
+		let mut producer = track_producer("test");
+		let mut subscriber = producer.subscribe(None);
+
+		// The last group is 6 (exclusive 7), but only group 5 has been produced so far.
+		producer.create_group(group::Info { sequence: 5 }).unwrap();
+		producer.finish_at(7).unwrap();
+
+		// Group 5 is delivered first.
+		match recv_next(&mut subscriber, false, true).await.unwrap() {
+			Recv::Group(group) => assert_eq!(group.sequence, 5),
+			_ => panic!("expected group 5"),
+		}
+
+		// With no more groups ready yet, the declared boundary surfaces even though the
+		// track isn't finished (group 6 is still outstanding).
+		match recv_next(&mut subscriber, false, true).await.unwrap() {
+			Recv::Boundary(group) => assert_eq!(group, 7),
+			_ => panic!("expected the future boundary"),
+		}
+
+		// The caller stops requesting the boundary once sent. The trailing group arrives,
+		// then the track finishes.
+		producer.create_group(group::Info { sequence: 6 }).unwrap();
+		match recv_next(&mut subscriber, false, false).await.unwrap() {
+			Recv::Group(group) => assert_eq!(group.sequence, 6),
+			_ => panic!("expected group 6"),
+		}
+		match recv_next(&mut subscriber, false, false).await.unwrap() {
+			Recv::Finished => {}
+			_ => panic!("expected finished once the boundary is reached"),
 		}
 	}
 }
@@ -856,7 +891,8 @@ async fn write_fetch_frame<W: web_transport_trait::SendStream>(
 }
 
 /// What [`recv_next`] pulled from the one subscriber: the next group to serve, the next
-/// best-effort datagram to forward, or the track finishing.
+/// best-effort datagram to forward, the track declaring its exclusive final sequence, or
+/// the track finishing (the live edge having reached that boundary).
 // A `group::Consumer` carries an inline frame prefetch, so the `Group` variant dwarfs the
 // others. This is a transient, one-at-a-time return value, so the padding is never held in
 // bulk; boxing would only add a per-group allocation.
@@ -864,13 +900,19 @@ async fn write_fetch_frame<W: web_transport_trait::SendStream>(
 enum Recv {
 	Group(group::Consumer),
 	Datagram(crate::Datagram),
+	Boundary(u64),
 	Finished,
 }
 
 /// Poll a single [`track::Subscriber`] for the next group (cap-aware) or datagram from one `&mut`
 /// borrow, so groups and datagrams share the same subscription. Groups are polled first so a
 /// datagram burst can't starve them; datagrams are polled only when the transport carries them.
-async fn recv_next(track: &mut track::Subscriber, datagrams: bool) -> Result<Recv, Error> {
+///
+/// When `emit_boundary` is set, a declared-but-not-yet-reached final sequence surfaces as
+/// [`Recv::Boundary`] in an idle moment (after groups and datagrams), so the caller can send
+/// SUBSCRIBE_END as soon as the ending is known rather than waiting for the live edge to reach
+/// it. The caller clears `emit_boundary` after the first boundary so it fires once.
+async fn recv_next(track: &mut track::Subscriber, datagrams: bool, emit_boundary: bool) -> Result<Recv, Error> {
 	kio::wait(|waiter| {
 		let mut groups_finished = false;
 		match track.poll_next_group(waiter) {
@@ -887,6 +929,11 @@ async fn recv_next(track: &mut track::Subscriber, datagrams: bool) -> Result<Rec
 				Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
 				Poll::Pending => {}
 			}
+		}
+		// No live data ready: report the boundary (if declared) before signalling Finished, so a
+		// future boundary reaches the subscriber while the trailing groups are still in flight.
+		if emit_boundary && let Poll::Ready(res) = track.poll_finished(waiter) {
+			return Poll::Ready(res.map(Recv::Boundary));
 		}
 		if groups_finished {
 			return Poll::Ready(Ok(Recv::Finished));
@@ -936,9 +983,11 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		track.end_at(initial_end_group);
 
 		// Lite05+ resolves the range on the Subscribe Stream itself: SUBSCRIBE_START
-		// once the first group is known, SUBSCRIBE_END when the track finishes.
+		// once the first group is known, SUBSCRIBE_END as soon as the track declares its
+		// exclusive final sequence (which may be ahead of the live edge).
 		let emit_range = self.version.has_track_stream();
 		let mut start_sent = false;
+		let mut end_sent = false;
 
 		// Serve datagrams off this same subscriber, but only on lite-05 over a datagram-capable
 		// transport (qmux/WebSocket/TCP/UDS report size 0). No group fallback: otherwise off.
@@ -956,7 +1005,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 				// when enabled, the next best-effort datagram. Groups are polled first so a
 				// datagram burst can't starve them; datagrams flow whenever no group is ready
 				// (including while groups are paused above the cap).
-				res = recv_next(&mut track, datagrams) => {
+				res = recv_next(&mut track, datagrams, emit_range && !end_sent) => {
 					match res? {
 						Recv::Group(group) => {
 							if emit_range && !start_sent {
@@ -968,19 +1017,19 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 							self.spawn_serve(group, &mut tasks);
 						}
 						Recv::Datagram(datagram) => self.serve_datagram(datagram),
+						Recv::Boundary(group) => {
+							// The track declared its exclusive final sequence. Forward it now,
+							// even if trailing groups (below `group`) are still in flight, then
+							// keep serving them until the live edge reaches the boundary.
+							end_sent = true;
+							writer
+								.encode(&lite::SubscribeResponse::End(lite::SubscribeEnd { group }))
+								.await?;
+						}
 						Recv::Finished => {
-							// Track finished cleanly. Tell the subscriber no group will
-							// follow, then drain in-flight tasks and exit.
-							if emit_range {
-								let group = track
-									.latest()
-									.map(|group| group.checked_add(1).ok_or(crate::coding::BoundsExceeded))
-									.transpose()?
-									.unwrap_or(0);
-								writer
-									.encode(&lite::SubscribeResponse::End(lite::SubscribeEnd { group }))
-									.await?;
-							}
+							// The live edge reached the boundary; SUBSCRIBE_END was already sent
+							// (or the version predates the track stream). Drain in-flight group
+							// tasks and FIN by returning.
 							while tasks.next().await.is_some() {}
 							return Ok(());
 						}

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -866,6 +866,8 @@ enum Event {
 	Idle,
 	/// An in-flight fetch finished.
 	FetchDone,
+	/// The upstream subscribe stream carried a START/END/DROP response.
+	SubResponse(lite::SubscribeResponse),
 	/// The upstream subscribe stream closed: `Ok` is a clean FIN, `Err` a transport error.
 	SubClosed(Result<(), Error>),
 	/// The whole broadcast went away.
@@ -971,12 +973,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 						Sub::None => std::future::pending().await,
 					}
 				}, if sub.is_active() => match res {
-					// START/END/DROP resolve the range; we don't drive delivery off them
-					// (the producer already orders groups), so log and keep reading.
-					Ok(Some(msg)) => {
-						tracing::debug!(track = %self.name, ?msg, "subscribe response");
-						continue;
-					}
+					Ok(Some(msg)) => Event::SubResponse(msg),
 					Ok(None) => Event::SubClosed(Ok(())),
 					Err(err) => Event::SubClosed(Err(err)),
 				},
@@ -1022,6 +1019,20 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 					}
 				}
 				Event::FetchDone => {}
+				Event::SubResponse(msg) => {
+					// SUBSCRIBE_END declares the track's exclusive final sequence, which may
+					// arrive while trailing groups are still in flight. Record it on the
+					// producer so consumers learn the boundary early; the later stream FIN
+					// then finds the track already finished. START/DROP just resolve the range
+					// (the producer already orders groups), so log and keep reading.
+					if let lite::SubscribeResponse::End(end) = &msg
+						&& let Some(Track::Active(producer)) = track.as_mut()
+					{
+						let _ = producer.finish_at(end.group);
+					} else {
+						tracing::debug!(track = %self.name, ?msg, "subscribe response");
+					}
+				}
 				Event::SubClosed(Ok(())) => {
 					tracing::info!(broadcast = %self.subscriber.log_path(&self.path), track = %self.name, "subscribe complete");
 					// Upstream FIN'd the live subscription. Finish the producer (no more

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -47,7 +47,7 @@ impl Info {
 	/// (including the hop chain).
 	///
 	/// Keep the returned [`Producer`] alive for as long as the broadcast should stay
-	/// available, and end it with [`Producer::close`]. See the note on [`Producer`].
+	/// available, and end it with [`Producer::finish`]. See the note on [`Producer`].
 	pub fn produce(self) -> Producer {
 		Producer::new(self)
 	}
@@ -73,7 +73,7 @@ struct BroadcastState {
 	// If this is 0, requests must be empty.
 	dynamic: usize,
 
-	// Set by an explicit `Producer::close()` so `Drop` can tell a deliberate
+	// Set by an explicit `Producer::finish()` so `Drop` can tell a deliberate
 	// shutdown apart from a producer that was dropped by accident.
 	closed: bool,
 }
@@ -117,11 +117,11 @@ impl BroadcastState {
 /// nothing for the broadcast's lifetime). When the last producer goes away every
 /// consumer observes [`Error::Dropped`].
 ///
-/// End the broadcast with [`Self::close`] rather than dropping it. Dropping is an
+/// End the broadcast with [`Self::finish`] rather than dropping it. Dropping is an
 /// easy footgun in garbage-collected bindings (Go, Python, ...), where the handle
 /// can be collected the moment it falls out of scope even while you are still
 /// publishing, tearing the stream down mid-broadcast. Dropping the last producer
-/// without [`Self::close`] logs a warning.
+/// without [`Self::finish`] logs a warning.
 #[derive(Clone)]
 pub struct Producer {
 	// Held behind an Arc so each track born from this broadcast can inherit a shared
@@ -221,16 +221,16 @@ impl Producer {
 		}
 	}
 
-	/// Cleanly close the broadcast once you are done publishing.
+	/// Cleanly finish the broadcast once you are done publishing.
 	///
 	/// Marks the broadcast as deliberately finished so consumers observe a normal
 	/// end. Prefer this over dropping the producer: an accidental drop (see the note
-	/// on [`Producer`]) logs a warning, whereas a `close()` is silent.
+	/// on [`Producer`]) logs a warning, whereas `finish()` is silent.
 	///
 	/// Only marks intent; the broadcast actually ends once every producer clone is
 	/// gone, so a clone that outlives this call keeps it alive until it too is
-	/// dropped or closed.
-	pub fn close(self) {
+	/// dropped or finished.
+	pub fn finish(self) {
 		if let Ok(mut state) = self.state.write() {
 			state.closed = true;
 		}
@@ -245,7 +245,7 @@ impl Producer {
 impl Drop for Producer {
 	fn drop(&mut self) {
 		// Only the last producer ending the broadcast matters; a clone dropping
-		// leaves it live. Warn if that last exit wasn't an explicit close(), since
+		// leaves it live. Warn if that last exit wasn't an explicit finish(), since
 		// consumers will then see Error::Dropped (classically a GC-collected handle
 		// in a language binding that tears the stream down mid-publish).
 		if !self.state.is_last() {
@@ -255,7 +255,7 @@ impl Drop for Producer {
 			&& !state.closed
 		{
 			tracing::warn!(
-				"broadcast::Producer dropped without close(). Keep the producer alive while publishing, then call close()."
+				"broadcast::Producer dropped without finish(). Keep the producer alive while publishing, then call finish()."
 			);
 		}
 	}

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -583,7 +583,7 @@ mod test {
 
 		// Create a new track and insert it into the broadcast (resolves immediately).
 		let track1 = producer.assert_create_track("track1", None);
-		let track1c = consumer.track("track1").unwrap().subscribe(None).await.unwrap();
+		let mut track1c = consumer.track("track1").unwrap().subscribe(None).await.unwrap();
 
 		// A track nobody publishes stays pending until accepted.
 		let track2_fut = subscribe_pending!(consumer, "track2");
@@ -648,7 +648,7 @@ mod test {
 		// Subscribe to a track and serve it.
 		let track1_fut = subscribe_pending!(consumer, "track1");
 		let mut producer1 = broadcast.assert_request().accept(None);
-		let track1 = track1_fut.await.unwrap();
+		let mut track1 = track1_fut.await.unwrap();
 
 		// Close the producer (simulating publisher disconnect).
 		producer1.append_group().unwrap();

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -222,7 +222,7 @@ impl TrackState {
 		}
 
 		// TODO once we have drop notifications, check if index == final_sequence.
-		if self.final_sequence.is_some() {
+		if self.is_complete() {
 			Poll::Ready(Ok(None))
 		} else if let Some(err) = &self.abort {
 			Poll::Ready(Err(err.clone()))
@@ -243,7 +243,7 @@ impl TrackState {
 		}
 
 		// Nothing buffered at the cursor: the track ending terminates the datagram stream too.
-		if self.final_sequence.is_some() {
+		if self.is_complete() {
 			Poll::Ready(Ok(None))
 		} else if let Some(err) = &self.abort {
 			Poll::Ready(Err(err.clone()))
@@ -302,7 +302,7 @@ impl TrackState {
 		// blocks new groups at/above final_sequence, not frames on existing groups.
 		if pending_seen {
 			Poll::Pending
-		} else if self.final_sequence.is_some() {
+		} else if self.is_complete() {
 			Poll::Ready(Ok(None))
 		} else if let Some(err) = &self.abort {
 			Poll::Ready(Err(err.clone()))
@@ -436,7 +436,9 @@ impl TrackState {
 	}
 
 	fn poll_closed(&self) -> Poll<Result<()>> {
-		if self.final_sequence.is_some() {
+		// A future boundary isn't "closed" until the trailing groups arrive, so gate on
+		// the live edge reaching it. Use `poll_finished` to observe the boundary early.
+		if self.is_complete() {
 			Poll::Ready(Ok(()))
 		} else if let Some(err) = &self.abort {
 			Poll::Ready(Err(err.clone()))
@@ -505,6 +507,30 @@ impl TrackState {
 			entry.set_pinned(true);
 			self.latest_entry = Some(entry);
 		}
+	}
+
+	/// Record the exclusive final sequence, rejecting a re-finish or a boundary that
+	/// would orphan already-produced groups.
+	fn set_final(&mut self, final_sequence: u64) -> Result<()> {
+		if self.final_sequence.is_some() {
+			return Err(Error::Closed);
+		}
+		if let Some(max) = self.max_sequence
+			&& final_sequence <= max
+		{
+			return Err(Error::ProtocolViolation);
+		}
+		self.final_sequence = Some(final_sequence);
+		Ok(())
+	}
+
+	/// Whether the track has reached its end: the final boundary is set and the live
+	/// edge has caught up to it, so no further group can arrive. A future boundary
+	/// (declared via [`Producer::finish_at`] ahead of the live edge) stays incomplete
+	/// until the remaining groups are produced.
+	fn is_complete(&self) -> bool {
+		self.final_sequence
+			.is_some_and(|fin| self.max_sequence.map_or(0, |max| max.saturating_add(1)) >= fin)
 	}
 
 	fn poll_finished(&self) -> Poll<Result<u64>> {
@@ -795,30 +821,27 @@ impl Producer {
 	/// NOTE: Old groups with lower sequence numbers can still arrive.
 	pub fn finish(&mut self) -> Result<()> {
 		let mut state = self.modify()?;
-		if state.final_sequence.is_some() {
-			return Err(Error::Closed);
-		}
-		state.final_sequence = Some(match state.max_sequence {
+		let final_sequence = match state.max_sequence {
 			Some(max) => max.checked_add(1).ok_or(coding::BoundsExceeded)?,
 			None => 0,
-		});
-		Ok(())
+		};
+		state.set_final(final_sequence)
 	}
 
-	/// Mark the track as finished at an exact final sequence.
+	/// Declare the track's exclusive final sequence, possibly ahead of the live edge.
 	///
-	/// The caller must pass the current max_sequence exactly.
-	/// Freezes the final boundary at one past the current max_sequence.
-	/// No new groups at or above that sequence can be created.
-	/// NOTE: Old groups with lower sequence numbers can still arrive.
-	pub fn finish_at(&mut self, sequence: u64) -> Result<()> {
-		let mut state = self.modify()?;
-		let max = state.max_sequence.ok_or(Error::Closed)?;
-		if state.final_sequence.is_some() || sequence != max {
-			return Err(Error::Closed);
-		}
-		state.final_sequence = Some(max.checked_add(1).ok_or(coding::BoundsExceeded)?);
-		Ok(())
+	/// `final_sequence` is the first sequence that will never be produced, so a track
+	/// whose last group is 89 finishes at `90`. Passing a boundary beyond the current
+	/// max_sequence records a known ending before the remaining groups arrive (e.g.
+	/// learning a track ends at group 89 while only 87 has been received). The boundary
+	/// must be strictly greater than the highest produced group, otherwise it would
+	/// orphan groups that already exist ([`Error::ProtocolViolation`]).
+	///
+	/// Groups below `final_sequence` may still be created afterwards; groups at or above
+	/// it are rejected. Consumers only see end-of-stream once the live edge reaches the
+	/// boundary. Use [`Self::finish`] to finish exactly at the live edge.
+	pub fn finish_at(&mut self, final_sequence: u64) -> Result<()> {
+		self.modify()?.set_final(final_sequence)
 	}
 
 	/// Abort the track with the given error.
@@ -1716,7 +1739,10 @@ impl Subscriber {
 
 	/// Block until the track is closed.
 	///
-	/// Returns Ok() is the track was cleanly finished.
+	/// Returns Ok() if the track was cleanly finished. Resolves once the live edge
+	/// reaches the final sequence, so a track finished ahead of its live edge (via
+	/// [`Producer::finish_at`]) stays open until the trailing groups arrive. Use
+	/// [`Self::finished`] to observe the declared boundary earlier.
 	pub async fn closed(&self) -> Result<()> {
 		kio::wait(|waiter| self.poll_closed(waiter)).await
 	}
@@ -1726,12 +1752,17 @@ impl Subscriber {
 		self.state.same_channel(&other.state)
 	}
 
-	/// Poll for the total number of groups in the track.
+	/// Poll for the track's declared final sequence, without blocking.
 	pub fn poll_finished(&mut self, waiter: &kio::Waiter) -> Poll<Result<u64>> {
 		self.poll(waiter, |state| state.poll_finished())
 	}
 
-	/// Block until the track is finished, returning the total number of groups.
+	/// Block until the track declares its end, returning the exclusive final sequence
+	/// (also the total group count).
+	///
+	/// Resolves as soon as the boundary is known, which may be ahead of the live edge
+	/// when the producer finished via [`Producer::finish_at`]. Use [`Self::closed`] to
+	/// wait until every group up to the boundary has actually arrived.
 	pub async fn finished(&mut self) -> Result<u64> {
 		kio::wait(|waiter| self.poll_finished(waiter)).await
 	}
@@ -2492,29 +2523,67 @@ mod test {
 	}
 
 	#[test]
-	fn insert_finish_validates_sequence_and_freezes_to_max() {
+	fn finish_at_rejects_a_boundary_at_or_below_the_live_edge() {
 		let mut producer = track_producer("test", None);
 		producer.create_group(group::Info { sequence: 5 }).unwrap();
 
+		// The boundary is exclusive, so it must be strictly above the highest produced
+		// group. 5 or below would orphan groups that already exist.
 		assert!(producer.finish_at(4).is_err());
-		assert!(producer.finish_at(10).is_err());
-		assert!(producer.finish_at(5).is_ok());
+		assert!(producer.finish_at(5).is_err());
+		assert!(producer.finish_at(6).is_ok());
 
 		{
 			let state = producer.state.read();
 			assert_eq!(state.final_sequence, Some(6));
 		}
 
-		assert!(producer.finish_at(5).is_err());
+		// Re-finishing is rejected, and no group at or above the boundary can be created.
+		assert!(producer.finish_at(6).is_err());
 		assert!(producer.create_group(group::Info { sequence: 4 }).is_ok());
-		assert!(producer.create_group(group::Info { sequence: 5 }).is_err());
+		assert!(producer.create_group(group::Info { sequence: 6 }).is_err());
+	}
+
+	#[tokio::test]
+	async fn finish_at_declares_a_future_boundary() {
+		let mut producer = track_producer("test", None);
+		producer.create_group(group::Info { sequence: 5 }).unwrap();
+
+		// Learn the track ends at group 6 (exclusive 7) while the live edge is still 5.
+		producer.finish_at(7).unwrap();
+
+		let mut consumer = producer.subscribe(None);
+		assert_eq!(consumer.assert_group().sequence, 5);
+
+		// The boundary is known immediately, but the track isn't done: group 6 is still
+		// outstanding, so the consumer parks rather than seeing end-of-stream.
+		let boundary = consumer
+			.finished()
+			.now_or_never()
+			.expect("boundary is known immediately")
+			.expect("would have errored");
+		assert_eq!(boundary, 7);
+		assert!(
+			consumer.recv_group().now_or_never().is_none(),
+			"should wait for the outstanding group"
+		);
+
+		// The trailing group arrives (below the boundary), then the track completes.
+		producer.create_group(group::Info { sequence: 6 }).unwrap();
+		assert_eq!(consumer.assert_group().sequence, 6);
+		let done = consumer
+			.recv_group()
+			.now_or_never()
+			.expect("should not block")
+			.expect("would have errored");
+		assert!(done.is_none(), "track completes once the boundary is reached");
 	}
 
 	#[tokio::test]
 	async fn recv_group_finishes_without_waiting_for_gaps() {
 		let mut producer = track_producer("test", None);
 		producer.create_group(group::Info { sequence: 1 }).unwrap();
-		producer.finish_at(1).unwrap();
+		producer.finish().unwrap();
 
 		let mut consumer = producer.subscribe(None);
 		assert_eq!(consumer.assert_group().sequence, 1);
@@ -2957,7 +3026,7 @@ mod test {
 	async fn get_group_finishes_without_waiting_for_gaps() {
 		let mut producer = track_producer("test", None);
 		producer.create_group(group::Info { sequence: 1 }).unwrap();
-		producer.finish_at(1).unwrap();
+		producer.finish().unwrap();
 
 		let consumer = producer.subscribe(None);
 		// get_group(0) blocks because group 0 is below final_sequence and could still arrive.

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -435,11 +435,11 @@ impl TrackState {
 		Poll::Pending
 	}
 
-	fn poll_closed(&self) -> Poll<Result<()>> {
+	fn poll_closed(&self) -> Poll<Result<u64>> {
 		// A future boundary isn't "closed" until the trailing groups arrive, so gate on
 		// the live edge reaching it. Use `poll_finished` to observe the boundary early.
-		if self.is_complete() {
-			Poll::Ready(Ok(()))
+		if let Some(fin) = self.completed() {
+			Poll::Ready(Ok(fin))
 		} else if let Some(err) = &self.abort {
 			Poll::Ready(Err(err.clone()))
 		} else {
@@ -524,13 +524,18 @@ impl TrackState {
 		Ok(())
 	}
 
-	/// Whether the track has reached its end: the final boundary is set and the live
-	/// edge has caught up to it, so no further group can arrive. A future boundary
-	/// (declared via [`Producer::finish_at`] ahead of the live edge) stays incomplete
-	/// until the remaining groups are produced.
-	fn is_complete(&self) -> bool {
+	/// The exclusive final sequence once the track has reached its end: the boundary is
+	/// set and the live edge has caught up to it, so no further group can arrive. A
+	/// future boundary (declared via [`Producer::finish_at`] ahead of the live edge)
+	/// stays `None` until the remaining groups are produced.
+	fn completed(&self) -> Option<u64> {
 		self.final_sequence
-			.is_some_and(|fin| self.max_sequence.map_or(0, |max| max.saturating_add(1)) >= fin)
+			.filter(|&fin| self.max_sequence.map_or(0, |max| max.saturating_add(1)) >= fin)
+	}
+
+	/// Whether [`Self::completed`] has a value.
+	fn is_complete(&self) -> bool {
+		self.completed().is_some()
 	}
 
 	fn poll_finished(&self) -> Poll<Result<u64>> {
@@ -1733,17 +1738,17 @@ impl Subscriber {
 	}
 
 	/// Poll for track closure, without blocking.
-	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<Result<()>> {
+	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<Result<u64>> {
 		self.poll(waiter, |state| state.poll_closed())
 	}
 
-	/// Block until the track is closed.
+	/// Block until the track is closed, returning the exclusive final sequence (also the
+	/// total group count) on a clean finish, or the cause on an abort.
 	///
-	/// Returns Ok() if the track was cleanly finished. Resolves once the live edge
-	/// reaches the final sequence, so a track finished ahead of its live edge (via
-	/// [`Producer::finish_at`]) stays open until the trailing groups arrive. Use
-	/// [`Self::finished`] to observe the declared boundary earlier.
-	pub async fn closed(&self) -> Result<()> {
+	/// Resolves once the live edge reaches the final sequence, so a track finished ahead
+	/// of its live edge (via [`Producer::finish_at`]) stays open until the trailing
+	/// groups arrive. Use [`Self::finished`] to observe the declared boundary earlier.
+	pub async fn closed(&self) -> Result<u64> {
 		kio::wait(|waiter| self.poll_closed(waiter)).await
 	}
 

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -435,18 +435,6 @@ impl TrackState {
 		Poll::Pending
 	}
 
-	fn poll_closed(&self) -> Poll<Result<u64>> {
-		// A future boundary isn't "closed" until the trailing groups arrive, so gate on
-		// the live edge reaching it. Use `poll_finished` to observe the boundary early.
-		if let Some(fin) = self.completed() {
-			Poll::Ready(Ok(fin))
-		} else if let Some(err) = &self.abort {
-			Poll::Ready(Err(err.clone()))
-		} else {
-			Poll::Pending
-		}
-	}
-
 	/// Evict groups older than `max_age`, never evicting the max_sequence group.
 	///
 	/// Groups are in arrival order, so we can stop early when we hit a non-expired,
@@ -524,18 +512,14 @@ impl TrackState {
 		Ok(())
 	}
 
-	/// The exclusive final sequence once the track has reached its end: the boundary is
-	/// set and the live edge has caught up to it, so no further group can arrive. A
-	/// future boundary (declared via [`Producer::finish_at`] ahead of the live edge)
-	/// stays `None` until the remaining groups are produced.
-	fn completed(&self) -> Option<u64> {
-		self.final_sequence
-			.filter(|&fin| self.max_sequence.map_or(0, |max| max.saturating_add(1)) >= fin)
-	}
-
-	/// Whether [`Self::completed`] has a value.
+	/// Whether the track has reached its end: the final boundary is set and the live
+	/// edge has caught up to it, so no further group can arrive. A future boundary
+	/// (declared via [`Producer::finish_at`] ahead of the live edge) stays incomplete
+	/// until the remaining groups are produced. Drives the end-of-stream signal from
+	/// the read methods (`recv_group` / `next_group` / `read_frame` return `None`).
 	fn is_complete(&self) -> bool {
-		self.completed().is_some()
+		self.final_sequence
+			.is_some_and(|fin| self.max_sequence.map_or(0, |max| max.saturating_add(1)) >= fin)
 	}
 
 	fn poll_finished(&self) -> Poll<Result<u64>> {
@@ -1737,21 +1721,6 @@ impl Subscriber {
 		kio::wait(|waiter| self.poll_get_group(waiter, sequence)).await
 	}
 
-	/// Poll for track closure, without blocking.
-	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<Result<u64>> {
-		self.poll(waiter, |state| state.poll_closed())
-	}
-
-	/// Block until the track is closed, returning the exclusive final sequence (also the
-	/// total group count) on a clean finish, or the cause on an abort.
-	///
-	/// Resolves once the live edge reaches the final sequence, so a track finished ahead
-	/// of its live edge (via [`Producer::finish_at`]) stays open until the trailing
-	/// groups arrive. Use [`Self::finished`] to observe the declared boundary earlier.
-	pub async fn closed(&self) -> Result<u64> {
-		kio::wait(|waiter| self.poll_closed(waiter)).await
-	}
-
 	/// Whether `other` was cloned from this subscriber (shares the same underlying state).
 	pub fn is_clone(&self, other: &Self) -> bool {
 		self.state.same_channel(&other.state)
@@ -1763,11 +1732,12 @@ impl Subscriber {
 	}
 
 	/// Block until the track declares its end, returning the exclusive final sequence
-	/// (also the total group count).
+	/// (also the total group count), or the cause on an abort.
 	///
 	/// Resolves as soon as the boundary is known, which may be ahead of the live edge
-	/// when the producer finished via [`Producer::finish_at`]. Use [`Self::closed`] to
-	/// wait until every group up to the boundary has actually arrived.
+	/// when the producer finished via [`Producer::finish_at`]. This reports the declared
+	/// end, not that every group has arrived: drive [`Self::recv_group`] /
+	/// [`Self::next_group`] until they yield `None` to observe the track fully drained.
 	pub async fn finished(&mut self) -> Result<u64> {
 		kio::wait(|waiter| self.poll_finished(waiter)).await
 	}
@@ -1958,18 +1928,18 @@ impl Subscriber {
 		);
 	}
 
-	pub fn assert_not_closed(&self) {
-		assert!(self.closed().now_or_never().is_none(), "should not be closed");
+	pub fn assert_not_closed(&mut self) {
+		assert!(self.finished().now_or_never().is_none(), "should not be closed");
 	}
 
-	pub fn assert_closed(&self) {
-		assert!(self.closed().now_or_never().is_some(), "should be closed");
+	pub fn assert_closed(&mut self) {
+		assert!(self.finished().now_or_never().is_some(), "should be closed");
 	}
 
 	// TODO assert specific errors after implementing PartialEq
-	pub fn assert_error(&self) {
+	pub fn assert_error(&mut self) {
 		assert!(
-			self.closed().now_or_never().expect("should not block").is_err(),
+			self.finished().now_or_never().expect("should not block").is_err(),
 			"should be error"
 		);
 	}

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -145,7 +145,7 @@ pub async fn run(
 	tasks.shutdown().await;
 
 	derived.finish()?;
-	output.close();
+	output.finish();
 	Ok(())
 }
 


### PR DESCRIPTION
Closes #2219.

## Problem

`track::Producer::finish_at(sequence)` only succeeded when `sequence` equalled the current max produced group, then recorded the same exclusive final sequence `finish()` already computes. The name promised callers could pick an exact final sequence, but the argument was really the last produced group, so it added a confusing public method with no extra capability.

## What this does

Redesigns `finish_at` to actually declare a **future** exclusive end group, then wires the boundary through the lite protocol so subscribers and relays learn it early (the intent behind the method: learning a track ends at group 89 while only 87 has been received over the network).

**Model (`model/track.rs`)**
- `finish_at(final_sequence)` now takes the exclusive boundary directly (last group 89 → `finish_at(90)`), which may be ahead of the live edge. Groups below it may still be produced; groups at or above it are rejected. The boundary must be strictly above the highest produced group, else `Error::ProtocolViolation` (it would orphan existing groups). `finish()` delegates via a shared `set_final`.
- New `TrackState::is_complete()` = the boundary is set **and** the live edge has reached it. The arrival-ordered terminal checks (`poll_recv_group` / `poll_recv_datagram` / `poll_read_frame`) gate on it instead of `final_sequence.is_some()`, so a future boundary parks consumers until the trailing groups arrive rather than reporting end-of-stream early.
- `finished() -> Result<u64>` resolves as soon as the boundary is **declared** (the point of early notification), returning the exclusive final sequence / total group count (or the abort cause). This is the reader's single terminal signal, matching `group::Consumer::finished()`. A consumer observes the track **fully drained** by driving `recv_group` / `next_group` / `read_frame` until they yield `None`.

**Terminal-state naming cleanup** (folded in per review)
- Removed the short-lived `Subscriber::closed()` / `poll_closed()`. The reader now has exactly one terminal method (`finished()`); "drained" is observed via the read methods returning `None`, so a second method was redundant.
- `closed()` therefore means exactly one thing across the model: **producer/handle teardown** (`-> Error`) on `Producer` / `Demand` / `broadcast::Consumer` (fires on abort or all handles dropping, not on `finish()`). It no longer collides with a reader terminal.
- Dropped `moq-mux`'s `Consumer::closed` wrapper (only self-tested; no production caller).
- Renamed `broadcast::Producer::close(self)` → `finish(self)` so the producer's clean-end verb matches `track`/`group`/`frame` (`finish()` + `abort()`). Pure rename; updated the internal callers (`moq-ffi`, `libmoq`, `moq-transcode`, `moq-boy`, native examples). The FFI producer method was already `finish()`; libmoq's C-facing `Publish::close` is unchanged.

**Publisher (`lite/publisher.rs`)**
- `recv_next` gained an `emit_boundary` flag and a `Recv::Boundary` result. SUBSCRIBE_END is now sent as soon as the track declares its final sequence (rather than recomputing `latest+1` at end-of-track), and the stream FINs only once every group is accounted for. END is guaranteed to precede `Recv::Finished`.

**Subscriber (`lite/subscriber.rs`)**
- On an incoming `SUBSCRIBE_END{group}` the subscriber records the boundary via `finish_at`, so downstream consumers and relays learn it before the trailing groups arrive (previously the value was discarded and completion came only from the stream FIN).

## Notes on scope

- **Wire/draft:** no format change. `SUBSCRIBE_END` already carries an exclusive `group`, and `draft-lcurley-moq-lite` already specs "no group after a given sequence" + "FINs only once every group up to this sequence has been accounted for". This brings the implementation into fuller conformance; no draft or `/doc` change needed.
- **js/net:** no change required. It has no `finish_at` producer API, and its subscriber drains `SUBSCRIBE_END` but drives completion off the stream FIN (which still comes after all groups), so an early END can't truncate it. Early boundary *consumption* in js is a possible follow-up.
- **IETF path:** `PublishDone` carries no group number; `run_track` uses `recv_group`, so the `is_complete` fix alone makes it wait correctly for a future boundary's trailing groups.
- **Edge case:** if a trailing group's stream is reset before its header arrives, a subscriber could wait on the declared boundary; on a healthy QUIC connection the publisher delivers-then-FINs so this isn't hit in practice.

## Test plan

- [x] `just rs check` (compile, clippy `-D warnings`, fmt, rustdoc, shear, sort)
- [x] `cargo nextest run -p moq-net -p moq-mux` — 844 passed
- [x] New model test `finish_at_declares_a_future_boundary` (consumer parks past the live edge, then completes) + rewritten `finish_at_rejects_a_boundary_at_or_below_the_live_edge`
- [x] New publisher test `recv_next_reports_future_boundary_before_finished`

(Written by Claude Opus 4.8)
