### PR TITLE
fix(net): align track ordering defaults

### DIFF
--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -142,7 +142,6 @@ network.
 struct moq_track_info info = {0};
 info.priority = 3;
 info.ordered = true;
-info.ordered_valid = true;
 info.cache_ms = 1000;
 info.cache_valid = true;
 info.timescale = 1000000;
@@ -157,13 +156,12 @@ int track = moq_publish_track(
 
 `moq_consume_track` accepts optional subscriber delivery preferences.
 `moq_consume_track_update` changes them while the callback task is running.
-Fields ending in `_valid` decide whether the matching value overrides the default:
+Fields ending in `_valid` decide whether the matching optional value is present:
 
 ```c
 struct moq_subscription sub = {0};
 sub.priority = 5;
 sub.ordered = true;
-sub.ordered_valid = true;
 sub.stale_ms = 25;
 sub.group_start = 10;
 sub.group_start_valid = true;

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -134,6 +134,9 @@ codec metadata.
 ## Raw Track Options
 
 `moq_publish_track` accepts optional publisher-side track properties:
+`ordered` controls prioritization only. When true, groups are prioritized in
+sequence order. Groups may always arrive out-of-order (or not at all) over the
+network.
 
 ```c
 struct moq_track_info info = {0};

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -188,6 +188,8 @@ if info.Timescale != nil {
 track.Update(moq.Subscription{Priority: 20, Ordered: false})
 ```
 
+`Ordered` controls prioritization only. When true, groups are prioritized in sequence order. Groups may always arrive out-of-order (or not at all) over the network.
+
 ## Fetching raw groups
 
 Fetch retrieves one group by track name and group sequence without keeping a live subscription:
@@ -320,6 +322,7 @@ for request, err := range dynamic.All(ctx) {
 ```
 
 The served broadcast is not announced. It only resolves consumers that call `RequestBroadcast(path)`. Each request arrives as a `BroadcastRequest`; call `Accept(broadcast)` to serve it, or `Abort(code)` to fail the requester.
+
 ## Local development
 
 The in-tree `go/wrapper/` directory is the source skeleton; CI publishes it to the [moq-dev/moq-go](https://github.com/moq-dev/moq-go) mirror. To exercise it locally:

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -82,6 +82,8 @@ val info = track.info()
 track.update(Subscription(priority = 20u.toUByte(), ordered = false))
 ```
 
+`ordered` controls prioritization only. When true, groups are prioritized in sequence order. Groups may always arrive out-of-order (or not at all) over the network.
+
 ## Publish
 
 ```kotlin

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -127,7 +127,8 @@ async for group in track:
 ```
 
 `write_frame` on a track creates a one-frame group by default, using a microsecond raw-track timescale. Consumers receive a `Frame` from `read_frame()` or group iteration, including `payload`, `timestamp_us`, and `keyframe`. Use `append_group()` for multi-frame groups (e.g., a video GOP).
-`TrackConsumer.info()` returns the publisher's track properties (timescale, cache, priority, ordering), and `update()` changes this subscriber's delivery preferences without resubscribing.
+`TrackConsumer.info()` returns the publisher's track properties (timescale, cache, priority, ordering priority), and `update()` changes this subscriber's delivery preferences without resubscribing.
+`ordered` controls prioritization only. When true, groups are prioritized in sequence order. Groups may always arrive out-of-order (or not at all) over the network.
 
 ### Fetching raw groups
 

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -91,6 +91,8 @@ let info = try await track.info()
 track.update(subscription: Subscription(priority: 20, ordered: false))
 ```
 
+`ordered` controls prioritization only. When true, groups are prioritized in sequence order. Groups may always arrive out-of-order (or not at all) over the network.
+
 ## Publish
 
 ```swift

--- a/go/wrapper/moq/publish.go
+++ b/go/wrapper/moq/publish.go
@@ -302,7 +302,7 @@ func (t *TrackProducer) Abort(errorCode uint16) error {
 }
 
 // Consume reads directly from this producer's track. subscription tunes delivery
-// (priority, ordering, group range); pass nil for defaults.
+// (delivery priority, group ordering priority, group range); pass nil for defaults.
 func (t *TrackProducer) Consume(subscription *Subscription) (*TrackConsumer, error) {
 	inner, err := t.inner.Consume(subscription)
 	if err != nil {

--- a/go/wrapper/moq/subscribe.go
+++ b/go/wrapper/moq/subscribe.go
@@ -22,7 +22,7 @@ func (b *BroadcastConsumer) SubscribeCatalog() (*CatalogConsumer, error) {
 }
 
 // SubscribeTrack subscribes to a track, receiving arbitrary byte payloads.
-// subscription tunes delivery (priority, ordering, group range); pass nil for defaults.
+// subscription tunes delivery priority, group ordering priority, and group range; pass nil for defaults.
 func (b *BroadcastConsumer) SubscribeTrack(name string, subscription *Subscription) (*TrackConsumer, error) {
 	inner, err := b.inner.SubscribeTrack(name, subscription)
 	if err != nil {
@@ -43,7 +43,7 @@ func (b *BroadcastConsumer) FetchGroup(name string, sequence uint64, options *Fe
 
 // SubscribeMedia subscribes to a media track, decoded with the given container.
 // maxLatencyMs bounds buffering before a stalled group is skipped. subscription
-// tunes delivery (priority, ordering, group range); pass nil for defaults.
+// tunes delivery priority, group ordering priority, and group range; pass nil for defaults.
 func (b *BroadcastConsumer) SubscribeMedia(name string, container Container, maxLatencyMs uint64, subscription *Subscription) (*MediaConsumer, error) {
 	inner, err := b.inner.SubscribeMedia(name, container, maxLatencyMs, subscription)
 	if err != nil {

--- a/js/net/src/lite/track.test.ts
+++ b/js/net/src/lite/track.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import * as Path from "../path.ts";
 import { Reader, Writer } from "../stream.ts";
+import { infoDefaults } from "../track.ts";
 import { Track, TrackInfo } from "./track.ts";
 import { Version } from "./version.ts";
 
@@ -39,6 +40,13 @@ test("TrackInfo round-trips on draft-05", async () => {
 	expect(got.ordered).toBe(false);
 	expect(got.cache).toBe(2000);
 	expect(got.timescale).toBe(90000);
+});
+
+test("TrackInfo defaults match cross-language wire bytes", async () => {
+	const info = new TrackInfo(infoDefaults());
+	expect(await bytes((w) => info.encode(w, Version.DRAFT_05))).toEqual(
+		new Uint8Array([0x06, 0x00, 0x00, 0x53, 0x88, 0x43, 0xe8]),
+	);
 });
 
 test("Track request round-trips on draft-05", async () => {

--- a/js/net/src/lite/track.ts
+++ b/js/net/src/lite/track.ts
@@ -57,7 +57,12 @@ export class Track {
  * FETCH for the track.
  */
 export class TrackInfo {
+	/** The publisher's tie-break priority for this track. */
 	priority: number;
+	/**
+	 * Whether groups are prioritized in sequence order. Groups may always arrive
+	 * out-of-order (or not at all) over the network.
+	 */
 	ordered: boolean;
 	/**
 	 * Publisher Max Latency: an upper bound (milliseconds) on how long the publisher

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -54,7 +54,10 @@ export interface Info {
 	cache: number;
 	/** Tie-break priority between subscriptions of equal subscriber priority. */
 	priority: number;
-	/** Group ordering preference (newest-first when `false`). Defaults to `false`. */
+	/**
+	 * Whether groups are prioritized in sequence order. Groups may always arrive
+	 * out-of-order (or not at all) over the network. Defaults to `false` (newest-first).
+	 */
 	ordered: boolean;
 }
 

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -54,7 +54,7 @@ export interface Info {
 	cache: number;
 	/** Tie-break priority between subscriptions of equal subscriber priority. */
 	priority: number;
-	/** Group ordering preference (newest-first when `false`). */
+	/** Group ordering preference (newest-first when `false`). Defaults to `false`. */
 	ordered: boolean;
 }
 

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -151,7 +151,7 @@ client = moq.Client(
 - **`TrackConsumer`**. Async iterator of raw groups.
   - `.read_frame() -> Frame | None` returns a timestamped raw frame.
   - `await .info() → TrackInfo`
-  - `.update(subscription)`. Change priority, ordering, staleness, or group range after subscribing.
+  - `.update(subscription)`. Change delivery priority, group ordering priority, staleness, or group range after subscribing.
 - **`GroupConsumer`**. Async iterator of timestamped `Frame`s.
   - `.read_frame() -> Frame | None` returns a timestamped raw frame.
 
@@ -178,10 +178,12 @@ All consumers (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsum
 - **`Datagram`**. `.sequence: int`, `.timestamp_us: int`, `.payload: bytes`. Delivered only on datagram-capable transports and lite-05 or newer moq-lite.
 - **`Audio`**. `.codec`, `.sample_rate`, `.channel_count`, `.bitrate`, `.description`.
 - **`Video`**. `.codec`, `.coded: Dimensions`, `.display_aspect`, `.bitrate`, `.framerate`, `.description`.
-- **`Subscription`**. Subscriber delivery preferences: priority, ordering, staleness, and optional group range.
-- **`TrackInfo`**. Publisher track properties: priority, ordering, cache window, and timescale.
+- **`Subscription`**. Subscriber delivery preferences: priority, ordering priority, staleness, and optional group range.
+- **`TrackInfo`**. Publisher track properties: priority, ordering priority, cache window, and timescale.
 - **`Dimensions`**. `.width: int`, `.height: int`.
 - **`Container`**. The catalog container enum, carried on each `Video`/`Audio` record.
+
+For both `Subscription` and `TrackInfo`, `ordered` controls prioritization only. When true, groups are prioritized in sequence order. Groups may always arrive out-of-order (or not at all) over the network.
 
 ### Logging and errors
 

--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -149,7 +149,7 @@ class TrackProducer:
     def consume(self, subscription: Subscription | None = None) -> TrackConsumer:
         """Create a consumer that reads directly from this producer's track.
 
-        ``subscription`` tunes delivery (priority, ordering, group range); omit for defaults.
+        ``subscription`` tunes delivery priority, group ordering priority, and group range; omit for defaults.
         """
         from .subscribe import TrackConsumer
 
@@ -181,7 +181,7 @@ class TrackRequest:
     def accept(self, info: TrackInfo | None = None) -> TrackProducer:
         """Accept the request as a raw track.
 
-        ``info`` fixes the track's timescale, priority, ordering, and cache; omit for defaults.
+        ``info`` fixes the track's timescale, priority, ordering priority, and cache; omit for defaults.
         """
         return TrackProducer(self._inner.accept(info))
 

--- a/py/moq-rs/moq/subscribe.py
+++ b/py/moq-rs/moq/subscribe.py
@@ -282,7 +282,7 @@ class BroadcastConsumer:
     async def subscribe_track(self, name: str, subscription: Subscription | None = None) -> TrackConsumer:
         """Subscribe to a track and receive arbitrary byte payloads.
 
-        ``subscription`` tunes delivery (priority, ordering, group range); omit for defaults.
+        ``subscription`` tunes delivery priority, group ordering priority, and group range; omit for defaults.
         """
         return TrackConsumer(await self._inner.subscribe_track(name, subscription))
 
@@ -329,7 +329,7 @@ class BroadcastConsumer:
         bitstream, or a :class:`Container` directly. Pass a bare container for the
         dynamic flow, where you subscribe before the catalog exists.
         ``max_latency_ms`` bounds buffering before a stalled GoP is skipped.
-        ``subscription`` tunes delivery (priority, ordering, group range); omit for defaults.
+        ``subscription`` tunes delivery priority, group ordering priority, and group range; omit for defaults.
         """
         container = track if isinstance(track, Container) else track.container
         return MediaConsumer(await self._inner.subscribe_media(name, container, max_latency_ms, subscription))

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -127,11 +127,9 @@ pub struct moq_track_info {
 	/// Priority, used to break ties between subscriptions of equal subscriber priority.
 	pub priority: u8,
 
-	/// Whether groups are prioritized in sequence order when `ordered_valid` is true.
+	/// Whether groups are prioritized in sequence order.
 	/// Groups may always arrive out-of-order (or not at all) over the network.
 	pub ordered: bool,
-	/// Whether `ordered` should override the default unordered setting.
-	pub ordered_valid: bool,
 
 	/// How long the relay should cache past groups, in milliseconds.
 	pub cache_ms: u64,
@@ -152,10 +150,8 @@ impl TryFrom<&moq_track_info> for moq_net::track::Info {
 		// timestamp_us units. An explicit timescale below overrides it.
 		let mut out = moq_net::track::Info::default()
 			.with_timescale(moq_net::Timescale::MICRO)
-			.with_priority(info.priority);
-		if info.ordered_valid {
-			out = out.with_ordered(info.ordered);
-		}
+			.with_priority(info.priority)
+			.with_ordered(info.ordered);
 		if info.cache_valid {
 			out = out.with_cache(std::time::Duration::from_millis(info.cache_ms));
 		}
@@ -176,11 +172,9 @@ pub struct moq_subscription {
 	/// Delivery priority. Higher values preempt lower ones under contention.
 	pub priority: u8,
 
-	/// Whether groups are prioritized in sequence order when `ordered_valid` is true.
+	/// Whether groups are prioritized in sequence order.
 	/// Groups may always arrive out-of-order (or not at all) over the network.
 	pub ordered: bool,
-	/// Whether `ordered` should override the default unordered setting.
-	pub ordered_valid: bool,
 
 	/// How long to wait for an older group once a newer group has arrived, in milliseconds.
 	pub stale_ms: u64,
@@ -200,10 +194,8 @@ impl From<&moq_subscription> for moq_net::track::Subscription {
 	fn from(subscription: &moq_subscription) -> Self {
 		let mut out = moq_net::track::Subscription::default()
 			.with_priority(subscription.priority)
+			.with_ordered(subscription.ordered)
 			.with_stale(std::time::Duration::from_millis(subscription.stale_ms));
-		if subscription.ordered_valid {
-			out = out.with_ordered(subscription.ordered);
-		}
 		if subscription.group_start_valid {
 			out = out.with_group_start(subscription.group_start);
 		}

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -127,7 +127,8 @@ pub struct moq_track_info {
 	/// Priority, used to break ties between subscriptions of equal subscriber priority.
 	pub priority: u8,
 
-	/// Whether groups are delivered in sequence order when `ordered_valid` is true.
+	/// Whether groups are prioritized in sequence order when `ordered_valid` is true.
+	/// Groups may always arrive out-of-order (or not at all) over the network.
 	pub ordered: bool,
 	/// Whether `ordered` should override the default unordered setting.
 	pub ordered_valid: bool,
@@ -175,7 +176,8 @@ pub struct moq_subscription {
 	/// Delivery priority. Higher values preempt lower ones under contention.
 	pub priority: u8,
 
-	/// Whether groups are delivered in sequence order when `ordered_valid` is true.
+	/// Whether groups are prioritized in sequence order when `ordered_valid` is true.
+	/// Groups may always arrive out-of-order (or not at all) over the network.
 	pub ordered: bool,
 	/// Whether `ordered` should override the default unordered setting.
 	pub ordered_valid: bool,

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -129,7 +129,7 @@ pub struct moq_track_info {
 
 	/// Whether groups are delivered in sequence order when `ordered_valid` is true.
 	pub ordered: bool,
-	/// Whether `ordered` should override the default ordered setting.
+	/// Whether `ordered` should override the default unordered setting.
 	pub ordered_valid: bool,
 
 	/// How long the relay should cache past groups, in milliseconds.
@@ -177,7 +177,7 @@ pub struct moq_subscription {
 
 	/// Whether groups are delivered in sequence order when `ordered_valid` is true.
 	pub ordered: bool,
-	/// Whether `ordered` should override the default ordered setting.
+	/// Whether `ordered` should override the default unordered setting.
 	pub ordered_valid: bool,
 
 	/// How long to wait for an older group once a newer group has arrived, in milliseconds.

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -543,6 +543,21 @@ fn publish_track_with_info_rejects_invalid_timescale() {
 }
 
 #[test]
+fn publish_track_info_defaults_to_unordered() {
+	let info = moq_track_info {
+		priority: 0,
+		ordered: false,
+		ordered_valid: false,
+		cache_ms: 0,
+		cache_valid: false,
+		timescale: 0,
+		timescale_valid: false,
+	};
+
+	assert!(!moq_net::track::Info::try_from(&info).unwrap().ordered);
+}
+
+#[test]
 fn raw_track_publish_consume() {
 	let origin = id(moq_origin_create());
 	let broadcast = id(moq_publish_create());

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -498,7 +498,6 @@ fn publish_track_invalid_broadcast() {
 	let info = moq_track_info {
 		priority: 1,
 		ordered: true,
-		ordered_valid: true,
 		cache_ms: 0,
 		cache_valid: false,
 		timescale: 0,
@@ -514,7 +513,6 @@ fn publish_track_invalid_broadcast() {
 	let subscription = moq_subscription {
 		priority: 1,
 		ordered: true,
-		ordered_valid: true,
 		stale_ms: 0,
 		group_start: 0,
 		group_start_valid: false,
@@ -531,7 +529,6 @@ fn publish_track_with_info_rejects_invalid_timescale() {
 	let info = moq_track_info {
 		priority: 0,
 		ordered: false,
-		ordered_valid: false,
 		cache_ms: 0,
 		cache_valid: false,
 		timescale: 0,
@@ -543,11 +540,10 @@ fn publish_track_with_info_rejects_invalid_timescale() {
 }
 
 #[test]
-fn publish_track_info_defaults_to_unordered() {
-	let info = moq_track_info {
+fn raw_track_options_preserve_ordering_priority() {
+	let mut info = moq_track_info {
 		priority: 0,
 		ordered: false,
-		ordered_valid: false,
 		cache_ms: 0,
 		cache_valid: false,
 		timescale: 0,
@@ -555,6 +551,22 @@ fn publish_track_info_defaults_to_unordered() {
 	};
 
 	assert!(!moq_net::track::Info::try_from(&info).unwrap().ordered);
+	info.ordered = true;
+	assert!(moq_net::track::Info::try_from(&info).unwrap().ordered);
+
+	let mut subscription = moq_subscription {
+		priority: 0,
+		ordered: false,
+		stale_ms: 0,
+		group_start: 0,
+		group_start_valid: false,
+		group_end: 0,
+		group_end_valid: false,
+	};
+
+	assert!(!moq_net::track::Subscription::from(&subscription).ordered);
+	subscription.ordered = true;
+	assert!(moq_net::track::Subscription::from(&subscription).ordered);
 }
 
 #[test]
@@ -723,7 +735,6 @@ fn raw_track_subscription_options_and_update() {
 	let info = moq_track_info {
 		priority: 3,
 		ordered: false,
-		ordered_valid: true,
 		cache_ms: 1_000,
 		cache_valid: true,
 		timescale: 1_000_000,
@@ -748,7 +759,6 @@ fn raw_track_subscription_options_and_update() {
 	let subscription = moq_subscription {
 		priority: 5,
 		ordered: true,
-		ordered_valid: true,
 		stale_ms: 25,
 		group_start: 1,
 		group_start_valid: true,

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -32,8 +32,9 @@ pub struct MoqSubscription {
 	/// Delivery priority; higher values preempt lower ones under bandwidth contention.
 	#[uniffi(default = 0)]
 	pub priority: u8,
-	/// Deliver groups in sequence order. Defaults to `false` (a DVR-style feature);
-	/// the aggregate is ordered only when every subscriber asks for it.
+	/// Whether groups are prioritized in sequence order. Groups may always arrive
+	/// out-of-order (or not at all) over the network. Defaults to `false`; the
+	/// aggregate is ordered only when every subscriber asks for it.
 	#[uniffi(default = false)]
 	pub ordered: bool,
 	/// How long to wait for an older group once a newer one has arrived before
@@ -161,7 +162,7 @@ impl MoqBroadcastConsumer {
 	/// Subscribe to a track by name, the same pattern as moq-boy's command/status tracks.
 	///
 	/// Frames are returned as plain byte payloads with no codec or container parsing.
-	/// `subscription` tunes delivery (priority, ordering, group range); omit for defaults.
+	/// `subscription` tunes delivery priority, group ordering priority, and group range; omit for defaults.
 	pub async fn subscribe_track(
 		&self,
 		name: String,
@@ -193,7 +194,7 @@ impl MoqBroadcastConsumer {
 	///
 	/// `container` is the track container from the catalog.
 	/// `max_latency_ms` controls the maximum buffering before skipping a GoP.
-	/// `subscription` tunes delivery (priority, ordering, group range); omit for defaults.
+	/// `subscription` tunes delivery priority, group ordering priority, and group range; omit for defaults.
 	pub async fn subscribe_media(
 		&self,
 		name: String,

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -16,7 +16,8 @@ pub struct MoqTrackInfo {
 	/// Priority, used only to break ties between subscriptions of equal subscriber priority.
 	#[uniffi(default = 0)]
 	pub priority: u8,
-	/// Whether groups are delivered in sequence order. Defaults to false.
+	/// Whether groups are prioritized in sequence order. Groups may always arrive
+	/// out-of-order (or not at all) over the network. Defaults to false.
 	#[uniffi(default = false)]
 	pub ordered: bool,
 	/// How long the relay should cache past groups, in milliseconds. Null uses the default.
@@ -646,7 +647,7 @@ impl MoqTrackProducer {
 	/// Create a consumer that reads from this producer's track.
 	///
 	/// Useful for local pub/sub without going through an origin/broadcast. `subscription`
-	/// tunes delivery (priority, ordering, group range); omit for defaults.
+	/// tunes delivery priority, group ordering priority, and group range; omit for defaults.
 	pub fn consume(&self, subscription: Option<MoqSubscription>) -> Result<Arc<MoqTrackConsumer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let guard = self.inner.lock().unwrap();

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -10,14 +10,14 @@ use crate::media::MoqInit;
 /// Publisher-side track properties, mirroring [`moq_net::track::Info`].
 ///
 /// Construct with the fields you care about; the rest use raw-track defaults
-/// (priority 0, ordered, default cache, microsecond timescale).
+/// (priority 0, unordered, default cache, microsecond timescale).
 #[derive(Clone, uniffi::Record)]
 pub struct MoqTrackInfo {
 	/// Priority, used only to break ties between subscriptions of equal subscriber priority.
 	#[uniffi(default = 0)]
 	pub priority: u8,
-	/// Whether groups are delivered in sequence order.
-	#[uniffi(default = true)]
+	/// Whether groups are delivered in sequence order. Defaults to false.
+	#[uniffi(default = false)]
 	pub ordered: bool,
 	/// How long the relay should cache past groups, in milliseconds. Null uses the default.
 	#[uniffi(default = None)]

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -141,6 +141,15 @@ async fn raw_track_info_reports_publisher_properties() {
 }
 
 #[tokio::test]
+async fn raw_track_info_defaults_to_unordered() {
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let track = broadcast.publish_track("status".into(), None).unwrap();
+	let consumer = track.consume(None).unwrap();
+
+	assert!(!consumer.info().await.unwrap().ordered);
+}
+
+#[tokio::test]
 async fn raw_track_update_does_not_wait_for_pending_read() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let track = broadcast.publish_track("status".into(), None).unwrap();

--- a/rs/moq-net/src/lite/track.rs
+++ b/rs/moq-net/src/lite/track.rs
@@ -49,7 +49,8 @@ impl Message for Track<'_> {
 pub struct TrackInfo {
 	/// The publisher's tie-break priority for this track.
 	pub priority: u8,
-	/// The publisher's group ordering preference (newest-first when `false`).
+	/// Whether groups are prioritized in sequence order. Groups may always arrive
+	/// out-of-order (or not at all) over the network.
 	pub ordered: bool,
 	/// Publisher Max Latency: an upper bound on how long the publisher caches a
 	/// non-latest group past the arrival of a newer one. Encoded as milliseconds.

--- a/rs/moq-net/src/lite/track.rs
+++ b/rs/moq-net/src/lite/track.rs
@@ -128,6 +128,21 @@ mod test {
 	}
 
 	#[test]
+	fn track_info_defaults_match_cross_language_wire_bytes() {
+		let info = crate::track::Info::default();
+		let info = TrackInfo {
+			priority: info.priority,
+			ordered: info.ordered,
+			cache: info.cache,
+			timescale: info.timescale,
+		};
+		let mut buf = Vec::new();
+		info.encode(&mut buf, Version::Lite05).unwrap();
+
+		assert_eq!(buf, [0x06, 0x00, 0x00, 0x53, 0x88, 0x43, 0xe8]);
+	}
+
+	#[test]
 	fn track_info_errors_before_lite05() {
 		let mut buf = Vec::new();
 		assert!(info_sample().encode_msg(&mut buf, Version::Lite04).is_err());

--- a/rs/moq-net/src/model/subscription.rs
+++ b/rs/moq-net/src/model/subscription.rs
@@ -11,9 +11,9 @@ use std::{task::Poll, time::Duration};
 pub struct Subscription {
 	/// Delivery priority. Higher values preempt lower ones when bandwidth is constrained.
 	pub priority: u8,
-	/// Whether groups should be delivered in sequence order (a DVR-style feature).
-	/// Defaults to `false`; the aggregate is ordered only when every live
-	/// subscriber asks for it.
+	/// Whether groups are prioritized in sequence order. Groups may always arrive
+	/// out-of-order (or not at all) over the network. Defaults to `false`; the
+	/// aggregate is ordered only when every live subscriber asks for it.
 	pub ordered: bool,
 	/// How long to wait for a group before skipping it once a newer group has
 	/// arrived. `Duration::ZERO` skips immediately (e.g. group 8 arriving means
@@ -45,7 +45,8 @@ impl Subscription {
 		self
 	}
 
-	/// Set whether groups are delivered in sequence order, returning `self` for chaining.
+	/// Set whether groups are prioritized in sequence order, returning `self` for
+	/// chaining. Groups may always arrive out-of-order (or not at all) over the network.
 	pub fn with_ordered(mut self, ordered: bool) -> Self {
 		self.ordered = ordered;
 		self
@@ -79,7 +80,7 @@ impl Subscription {
 
 		let merged = Subscription {
 			priority: self.priority.max(combined.priority),
-			// Ordered delivery is only honored when every subscriber wants it.
+			// Sequence-first prioritization is enabled only when every subscriber wants it.
 			ordered: self.ordered && combined.ordered,
 			stale: self.stale.max(combined.stale),
 			group_start: min_some(self.group_start, combined.group_start),

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -64,8 +64,9 @@ pub struct Info {
 	/// The publisher's priority for this track, used only to break ties between
 	/// subscriptions of equal subscriber priority. Reported in TRACK_INFO (Lite05+).
 	pub priority: u8,
-	/// The publisher's group ordering preference (newest-first when `false`), used
-	/// only to break ties. Reported in TRACK_INFO (Lite05+). Defaults to `false`.
+	/// Whether groups are prioritized in sequence order. Groups may always arrive
+	/// out-of-order (or not at all) over the network. Used only to break ties,
+	/// reported in TRACK_INFO (Lite05+), and defaults to `false` (newest-first).
 	pub ordered: bool,
 
 	/// The broadcast this track belongs to, bound when the track is created under one
@@ -119,8 +120,9 @@ impl Info {
 		self
 	}
 
-	/// Set the publisher's group ordering preference, returning `self` for chaining.
-	/// Defaults to `false`.
+	/// Set whether groups are prioritized in sequence order, returning `self` for
+	/// chaining. Groups may always arrive out-of-order (or not at all) over the
+	/// network. Defaults to `false`.
 	pub fn with_ordered(mut self, ordered: bool) -> Self {
 		self.ordered = ordered;
 		self
@@ -1514,8 +1516,8 @@ pub struct Subscriber {
 /// A cloneable handle to a subscriber's delivery preferences.
 ///
 /// This updates the same subscription as the owning [`Subscriber`] without
-/// borrowing its read cursor, so callers can change priority, ordering, or
-/// group bounds while another task is waiting for groups.
+/// borrowing its read cursor, so callers can change delivery priority, group
+/// ordering priority, or group bounds while another task is waiting for groups.
 #[derive(Clone)]
 pub struct SubscriberControl {
 	subscription: kio::Producer<Subscription>,

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -65,7 +65,7 @@ pub struct Info {
 	/// subscriptions of equal subscriber priority. Reported in TRACK_INFO (Lite05+).
 	pub priority: u8,
 	/// The publisher's group ordering preference (newest-first when `false`), used
-	/// only to break ties. Reported in TRACK_INFO (Lite05+).
+	/// only to break ties. Reported in TRACK_INFO (Lite05+). Defaults to `false`.
 	pub ordered: bool,
 
 	/// The broadcast this track belongs to, bound when the track is created under one
@@ -91,7 +91,7 @@ impl Default for Info {
 			timescale: Timescale::default(),
 			cache: DEFAULT_CACHE,
 			priority: 0,
-			ordered: true,
+			ordered: false,
 			broadcast: default_broadcast(),
 		}
 	}
@@ -120,6 +120,7 @@ impl Info {
 	}
 
 	/// Set the publisher's group ordering preference, returning `self` for chaining.
+	/// Defaults to `false`.
 	pub fn with_ordered(mut self, ordered: bool) -> Self {
 		self.ordered = ordered;
 		self

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -333,10 +333,10 @@ impl Role {
 }
 
 /// Summed traffic counters for one `(tier, role)` slice, aggregated across
-/// every broadcast this node is currently tracking. The host-level rollup of
-/// the internal per-broadcast counters: that detail is collapsed away (it lives on the
-/// published `.stats` broadcast, not here). Every counter is cumulative, so a
-/// rate is `delta / delta_t` and a live count is `open - closed`.
+/// every broadcast this node is currently tracking. This host-level rollup
+/// collapses the internal per-broadcast detail (it lives on the published
+/// `.stats` broadcast, not here). Every counter is cumulative, so a rate is
+/// `delta / delta_t` and a live count is `open - closed`.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct CounterTotals {

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -333,10 +333,10 @@ impl Role {
 }
 
 /// Summed traffic counters for one `(tier, role)` slice, aggregated across
-/// every broadcast this node is currently tracking. This host-level rollup
-/// collapses the internal per-broadcast detail (it lives on the published
-/// `.stats` broadcast, not here). Every counter is cumulative, so a rate is
-/// `delta / delta_t` and a live count is `open - closed`.
+/// every broadcast this node is currently tracking. The host-level rollup of
+/// the internal per-broadcast counters: that detail is collapsed away (it lives on the
+/// published `.stats` broadcast, not here). Every counter is cumulative, so a
+/// rate is `delta / delta_t` and a live count is `open - closed`.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct CounterTotals {

--- a/swift/Sources/Moq/Broadcast.swift
+++ b/swift/Sources/Moq/Broadcast.swift
@@ -15,8 +15,8 @@ public final class BroadcastConsumer: Sendable {
     }
 
     /// Subscribe to a track by name, delivering raw frame payloads with no codec
-    /// or container parsing. `subscription` tunes delivery (priority, ordering,
-    /// group range); omit for defaults.
+    /// or container parsing. `subscription` tunes delivery priority, group ordering priority,
+    /// and group range; omit for defaults.
     public func subscribeTrack(name: String, subscription: Subscription? = nil) async throws -> TrackConsumer {
         TrackConsumer(try await ffi.subscribeTrack(name: name, subscription: subscription))
     }
@@ -33,7 +33,7 @@ public final class BroadcastConsumer: Sendable {
 
     /// Subscribe to a media track, delivering frames in decode order. `container`
     /// comes from the catalog; `maxLatencyMs` bounds buffering before skipping a GoP.
-    /// `subscription` tunes delivery (priority, ordering, group range); omit for defaults.
+    /// `subscription` tunes delivery priority, group ordering priority, and group range; omit for defaults.
     public func subscribeMedia(
         name: String,
         container: Container,

--- a/swift/Sources/Moq/Dynamic.swift
+++ b/swift/Sources/Moq/Dynamic.swift
@@ -16,7 +16,7 @@ public final class TrackRequest: Sendable {
     }
 
     /// Accept the request as a raw track. `info` fixes the track's timescale,
-    /// priority, ordering, and cache; omit for defaults.
+    /// priority, ordering priority, and cache; omit for defaults.
     public func accept(info: TrackInfo? = nil) throws -> TrackProducer {
         TrackProducer(try ffi.accept(info: info))
     }

--- a/swift/Sources/Moq/Track.swift
+++ b/swift/Sources/Moq/Track.swift
@@ -119,7 +119,7 @@ public final class TrackProducer: Sendable {
     }
 
     /// A read handle for this track (local pub/sub, no origin needed).
-    /// `subscription` tunes delivery (priority, ordering, group range); omit for defaults.
+    /// `subscription` tunes delivery priority, group ordering priority, and group range; omit for defaults.
     public func consume(subscription: Subscription? = nil) throws -> TrackConsumer {
         TrackConsumer(try ffi.consume(subscription: subscription))
     }


### PR DESCRIPTION
## Summary

- Default publisher track ordering to `false` across Rust, JavaScript, UniFFI, and libmoq so every language uses newest-first prioritization unless sequence order is requested.
- Clarify that `ordered` controls group prioritization only. Groups may still arrive out-of-order or not at all over the network.
- Remove the redundant `ordered_valid` fields from the libmoq publisher and subscriber C structs now that zero-initialized `ordered = false` is the canonical default.

## Root cause

JavaScript defaulted publisher track metadata to unordered while Rust, UniFFI, and libmoq inherited an ordered default. The same application therefore serialized different TRACK_INFO metadata depending on the publishing language. The C validity flags only distinguished an omitted boolean from explicit `false`, which became unnecessary once `false` was canonical.

## Public API changes

- `moq_net::track::Info::default().ordered` changes from `true` to `false`. This changes default behavior and serialized TRACK_INFO metadata, so the PR targets `dev`.
- UniFFI-generated `MoqTrackInfo.ordered` defaults to `false` in Python, Swift, Kotlin, and Go.
- Breaking C source API change: `ordered_valid` is removed from `moq_track_info` and `moq_subscription`; `ordered` now maps directly to the Rust setting.
- No public functions, types, or enum variants are added, renamed, or removed.

The language wrapper comments and documentation were updated. `cpp/obs`, `doc/bin/obs.md`, the concept docs, and the protocol draft need no changes because they do not reference these raw C fields and the TRACK_INFO wire format is unchanged.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command cargo test -p libmoq`
- Matching Rust and TypeScript assertions for the serialized default TRACK_INFO bytes
- Generated `moq.h` inspected to confirm both `ordered_valid` fields are absent
- Go generation, vet, build, and race tests
- Python and Swift binding checks
- GitHub `Check` workflow, including `just ci` (passed)
- `just test smoke-full`: all Rust, Python, JavaScript, and GStreamer combinations passed; the current `dev` baseline still fails the native-JS subscriber because `Json.Consumer` is unavailable and the macOS C subscriber because its link command lacks system framework flags

Closes #2215.

(Written by GPT-5)
