### PR TITLE
feat(moq-video): PipeWire screen capture on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "annotate-snippets"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+dependencies = [
+ "anstyle",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +217,21 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "ashpd"
+version = "0.13.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "281e6645758940dee594495e28807a7672ce40f11ebf4df6c22c4fcd59e2689f"
+dependencies = [
+ "enumflags2",
+ "futures-util",
+ "getrandom 0.4.3",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "zbus",
+]
 
 [[package]]
 name = "askama"
@@ -300,6 +325,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +357,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -614,6 +662,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
+ "annotate-snippets",
  "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
@@ -1203,6 +1252,12 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
 
 [[package]]
 name = "cordyceps"
@@ -2006,6 +2061,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum-assoc"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2023,6 +2084,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa18ce2bc66555b3218614519ac839ddb759a7d6720732f979ef8d13be147ecd"
 dependencies = [
  "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -3863,6 +3945,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "libspa"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2909f3be29d674e7f10604aff18d1bbe1bb03c4cd61c8a8ba19c0b1d162f7d4e"
+dependencies = [
+ "bitflags 2.13.0",
+ "cc",
+ "cookie-factory",
+ "libc",
+ "libspa-sys",
+ "nom 8.0.0",
+ "rustix 1.1.4",
+ "system-deps",
+]
+
+[[package]]
+name = "libspa-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ad52764fca54818486f3cf75afec844d1f1a1568c24dcee25d41b1ab007dda"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "system-deps",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4524,6 +4633,7 @@ name = "moq-video"
 version = "0.0.6"
 dependencies = [
  "anyhow",
+ "ashpd",
  "block2",
  "bytes",
  "cudarc",
@@ -4544,6 +4654,7 @@ dependencies = [
  "objc2-screen-capture-kit",
  "objc2-video-toolbox",
  "openh264",
+ "pipewire",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5610,6 +5721,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5796,6 +5917,31 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pipewire"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8585aba8a52ad74ccc633b8e293c1dc4277976bd5d510b925533f34fd6685f38"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+ "libspa",
+ "libspa-sys",
+ "pipewire-sys",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "pipewire-sys"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2089f245b548723e60325773c27f586b7a2372c79ea941b246cd0d654706adc"
+dependencies = [
+ "bindgen 0.72.1",
+ "libspa-sys",
+ "system-deps",
+]
 
 [[package]]
 name = "pkcs1"
@@ -7072,6 +7218,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7956,6 +8113,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2 0.6.4",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -8465,6 +8623,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8481,6 +8650,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -8687,6 +8862,7 @@ checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -9743,6 +9919,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b97f866896a4be7aefd2b5a8e01bb6773d19a775d54ab28b4d094b9a4480e"
+dependencies = [
+ "async-broadcast",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e05ad887425eecf5e8384dc2406a4a9313eb73468712fc1cdea362eb4fe0469"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039ca249fee9559680f3a9f05b55e0761fee51af4f6c1e7d8c1f31e549721d2"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9883,4 +10115,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf057bb00bf5c9ad77abb6147b0ca4818236a1858416e9d988e40d6322fefa7"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8118ca6bda77bfc0ab51d660db0c955f2505eef854c9a449435bccb616933b31"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.118",
+ "winnow 1.0.3",
 ]

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -125,12 +125,15 @@ moq --client-connect https://relay.example.com/anon --broadcast cam.hang import 
 
 # Pick a codec (default h264). h265 is hardware-only:
 moq --client-connect https://relay.example.com/anon --broadcast cam.hang import capture --codec h265
+
+# Capture a display instead of a camera:
+moq --client-connect https://relay.example.com/anon --broadcast screen.hang import capture --screen --no-audio
 ```
 
-On Linux the NVENC (NVIDIA) and VAAPI (Intel/AMD) encoders are compiled in by
-default and link the CUDA / libva system libraries. To build `capture` without
-them (software openh264 + V4L2 capture only, no CUDA/libva dependency), drop the
-default features:
+On Linux the NVENC (NVIDIA) and VAAPI (Intel/AMD) encoders and the PipeWire
+screen capture are compiled in by default and link the CUDA / libva / libpipewire
+system libraries. To build `capture` without them (software openh264 + V4L2
+camera capture only, no system library dependency), drop the default features:
 
 ```bash
 cargo build --release -p moq-cli --no-default-features \
@@ -138,7 +141,12 @@ cargo build --release -p moq-cli --no-default-features \
 ```
 
 Video capture uses a native per-platform backend (AVFoundation on macOS, V4L2 on
-Linux, Media Foundation on Windows). The codec is chosen with `--codec`
+Linux, Media Foundation on Windows). `--screen` captures a display instead:
+ScreenCaptureKit on macOS, DXGI Desktop Duplication on Windows, and
+xdg-desktop-portal + PipeWire on Linux (Wayland and X11), where the desktop's
+picker dialog chooses the screen. The Linux screen backend links libpipewire and
+is behind the default-on `pipewire` feature; drop it (like the codecs above) for
+a build without the dependency. The codec is chosen with `--codec`
 (`h264` default, or `h265`). For H.264 it picks a hardware encoder
 (VideoToolbox on macOS, NVENC on Linux NVIDIA, VAAPI on Linux Intel/AMD) when one
 is present, falling back to the built-in software encoder (openh264); force either

--- a/flake.nix
+++ b/flake.nix
@@ -124,6 +124,11 @@
             # #1837: if moq-vaapi switches to dlopen'ing libva, this stays needed
             # only to run it, and a libva-less build/host would fall back cleanly.)
             pkgs.libva
+            # moq-video's `pipewire` screen-capture feature: the pipewire crate
+            # links libpipewire-0.3 via pkg-config and generates bindings at build
+            # time (bindgenHook above provides libclang). Linux-only; macOS uses
+            # ScreenCaptureKit.
+            pkgs.pipewire
           ];
 
         # JavaScript dependencies

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -18,7 +18,7 @@ name = "moq"
 path = "src/main.rs"
 
 [features]
-default = ["iroh", "noq", "websocket", "nvenc", "vaapi", "nvdec"]
+default = ["iroh", "noq", "websocket", "nvenc", "vaapi", "nvdec", "pipewire"]
 iroh = ["moq-native/iroh"]
 noq = ["moq-native/noq"]
 quinn = ["moq-native/quinn"]
@@ -42,6 +42,10 @@ transcode = ["dep:moq-transcode", "dep:moq-video"]
 nvenc = ["moq-video?/nvenc", "moq-transcode?/nvenc"]
 vaapi = ["moq-video?/vaapi", "moq-transcode?/vaapi"]
 nvdec = ["moq-video?/nvdec", "moq-transcode?/nvdec"]
+# Screen capture for `capture --screen` on Linux (xdg-desktop-portal + PipeWire),
+# on by default like the hardware codecs above and trimmable the same way. Only
+# bites when `capture` pulls in moq-video; links libpipewire-0.3 at build time.
+pipewire = ["moq-video?/pipewire"]
 
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -47,7 +47,8 @@ pub struct CaptureArgs {
 	#[arg(long, conflicts_with = "screen")]
 	pub camera: Option<String>,
 
-	/// Capture a display (whole screen) instead of a camera. macOS and Windows.
+	/// Capture a display (whole screen) instead of a camera. On Linux the
+	/// desktop portal opens a picker dialog to choose the screen.
 	#[arg(long)]
 	pub screen: bool,
 

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -35,6 +35,11 @@ nvdec = ["dep:cudarc", "dep:moq-nvenc", "dep:libloading"]
 # binary carries NEEDED libva.so.2 / libva-drm.so.2), so disable this feature for a
 # build with no libva dependency. See #1837.
 vaapi = ["dep:moq-vaapi"]
+# Screen capture on Linux via xdg-desktop-portal + PipeWire (Wayland and X11).
+# Off by default because the `pipewire` crate links libpipewire-0.3 via pkg-config
+# at build time (and its bindgen needs libclang), so it only belongs in builds
+# that actually capture displays. Camera capture (V4L2) needs nothing extra.
+pipewire = ["dep:pipewire", "dep:ashpd"]
 
 [dependencies]
 anyhow = "1"
@@ -58,6 +63,10 @@ tracing = "0.1"
 yuv = "0.8.14"
 
 [target.'cfg(target_os="linux")'.dependencies]
+# xdg-desktop-portal ScreenCast negotiation for the `pipewire` feature (pure Rust,
+# zbus over DBus). The portal owns source selection: the user picks a monitor in a
+# compositor dialog, and we get back a PipeWire fd + node id to stream from.
+ashpd = { version = "0.13", optional = true, default-features = false, features = ["tokio", "screencast"] }
 # NVENC hardware encoder, behind the default-on `nvenc` feature. Everything is
 # dlopen'd at runtime: cudarc loads CUDA, and moq-nvenc (an in-tree fork of
 # nvidia-video-codec-sdk, see rs/moq-nvenc) loads libnvidia-encode. So the binary
@@ -81,6 +90,9 @@ moq-nvenc = { workspace = true, optional = true }
 # switch moq-vaapi to dlopen libva (one portable binary that falls back like the
 # NVENC backend); the latter is tracked in #1837.
 moq-vaapi = { workspace = true, optional = true }
+# PipeWire video stream for the portal's node, behind the `pipewire` feature.
+# Links libpipewire-0.3 via pkg-config at build time; bindgen needs libclang.
+pipewire = { version = "0.10", optional = true }
 # Native V4L2 webcam capture (replaces nokhwa). `v4l` streams MMAP buffers;
 # MJPEG cameras are decoded with the pure-Rust `zune-jpeg` (no libjpeg/IJG).
 v4l = "0.14"

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -16,7 +16,11 @@ Per-platform, picked at compile time:
 
 - **macOS**: AVFoundation (camera) and ScreenCaptureKit (display), yielding
   zero-copy `CVPixelBuffer` surfaces straight to VideoToolbox.
-- **Linux**: native V4L2 (camera; YUYV resampled, MJPEG via `zune-jpeg`).
+- **Linux**: native V4L2 (camera; YUYV resampled, MJPEG via `zune-jpeg`) and
+  xdg-desktop-portal + PipeWire (display; RGB -> CPU I420, behind the `pipewire`
+  feature since it links libpipewire). Works on Wayland and X11; the desktop's
+  picker dialog chooses the screen, and the portal's restore token is reused so
+  demand-driven reopens don't re-prompt.
 - **Windows**: native Media Foundation (camera; `IMFSourceReader`) and DXGI
   Desktop Duplication (display; BGRA -> CPU I420). Display capture is
   whole-monitor; select one with a bare index or `display:{index}`.

--- a/rs/moq-video/src/capture/mod.rs
+++ b/rs/moq-video/src/capture/mod.rs
@@ -2,7 +2,8 @@
 //! per-source:
 //! - macOS camera -> AVFoundation, screen -> ScreenCaptureKit, both yielding
 //!   zero-copy `CVPixelBuffer` surfaces straight to VideoToolbox.
-//! - Linux camera -> native V4L2 (YUYV / MJPEG -> CPU I420).
+//! - Linux camera -> native V4L2 (YUYV / MJPEG -> CPU I420), screen ->
+//!   xdg-desktop-portal + PipeWire (RGB -> CPU I420, `pipewire` feature).
 //! - Windows camera -> native Media Foundation (`IMFSourceReader`), screen ->
 //!   DXGI Desktop Duplication (BGRA -> CPU I420).
 //!
@@ -39,6 +40,10 @@ mod surface;
 #[cfg(target_os = "linux")]
 mod v4l2;
 
+// Portal + PipeWire screen capture on Linux.
+#[cfg(all(target_os = "linux", feature = "pipewire"))]
+mod pipewire;
+
 // Native Media Foundation camera capture on Windows.
 #[cfg(target_os = "windows")]
 mod mediafoundation;
@@ -58,7 +63,8 @@ pub enum Source {
 	/// A camera / webcam.
 	#[default]
 	Camera,
-	/// A display (whole-screen capture). macOS and Windows.
+	/// A display (whole-screen capture). macOS, Windows, and Linux (behind the
+	/// `pipewire` feature; the xdg-desktop-portal picker chooses the screen).
 	Display,
 }
 
@@ -186,7 +192,17 @@ pub(crate) async fn open(config: &Config) -> Result<FrameStream, Error> {
 			{
 				desktopduplication::open(config).await
 			}
-			#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+			#[cfg(all(target_os = "linux", feature = "pipewire"))]
+			{
+				pipewire::open(config).await
+			}
+			#[cfg(all(target_os = "linux", not(feature = "pipewire")))]
+			{
+				Err(Error::Codec(anyhow::anyhow!(
+					"screen capture requires the `pipewire` feature on Linux"
+				)))
+			}
+			#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 			{
 				Err(Error::Codec(anyhow::anyhow!(
 					"screen capture is not supported on this platform"

--- a/rs/moq-video/src/capture/pipewire.rs
+++ b/rs/moq-video/src/capture/pipewire.rs
@@ -11,7 +11,9 @@
 //!   demand. A fresh portal session would re-prompt the picker every time, so the
 //!   portal's restore token is kept in a process-wide slot and replayed on the
 //!   next [`open`], which restores the same grant without a dialog (on
-//!   compositors that support persistence).
+//!   compositors that support persistence). The token is forgotten when the
+//!   compositor ends the stream (the user hit "stop sharing"), so a revoked
+//!   grant is asked for again rather than silently resumed.
 //! - Compositors only deliver frames on damage, so a static screen would starve
 //!   the encoder. A loop timer re-emits the last frame whenever a frame interval
 //!   passes without a fresh one, mirroring the Windows Desktop Duplication pacing.
@@ -39,6 +41,11 @@ const DEFAULT_FRAMERATE: u32 = 30;
 /// The compositor sends the negotiated format right after the stream connects;
 /// if nothing arrives the session is broken (or the grant was revoked mid-setup).
 const FORMAT_TIMEOUT: Duration = Duration::from_secs(10);
+/// ScreenCast compositors deliver the current content as a first frame right
+/// after negotiation; none arriving means the session is broken, so fail `open`
+/// rather than hand the encoder a stream that will never produce (same
+/// first-frame wait as the macOS ScreenCaptureKit backend).
+const FIRST_FRAME_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// The portal restore token from the last grant, replayed on the next [`open`]
 /// so a demand-driven reopen skips the picker dialog. Process-wide because the
@@ -55,7 +62,7 @@ pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
 		tracing::debug!(%device, "portal screen capture ignores the device selector; the picker owns selection");
 	}
 
-	let (node_id, fd) = portal_negotiate().await?;
+	let (node_id, fd, session) = portal_negotiate().await?;
 
 	let chan = FrameChannel::new();
 	let framerate = config.framerate.unwrap_or(DEFAULT_FRAMERATE).max(1);
@@ -86,9 +93,13 @@ pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
 
 	// Own the thread from here on, so cancelling this `await` still stops and
 	// joins it instead of detaching a loop that holds the portal session open.
+	// `Drop` quits and joins the loop first, then its `session` field closes the
+	// portal session, so the compositor's sharing indicator turns off and the
+	// token-clearing `Unconnected` path can't fire on our own teardown.
 	let guard = LoopGuard {
 		quit: quit_tx,
 		handle: Some(handle),
+		_session: session,
 	};
 
 	let geo = match tokio::time::timeout(FORMAT_TIMEOUT, geo_rx).await {
@@ -101,6 +112,15 @@ pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
 		Err(_) => {
 			return Err(Error::Codec(anyhow::anyhow!(
 				"no video format from the compositor within {FORMAT_TIMEOUT:?}"
+			)));
+		}
+	};
+
+	let first = match tokio::time::timeout(FIRST_FRAME_TIMEOUT, chan.recv()).await {
+		Ok(Some(frame)) => frame,
+		Ok(None) | Err(_) => {
+			return Err(Error::Codec(anyhow::anyhow!(
+				"no frames from the compositor within {FIRST_FRAME_TIMEOUT:?}"
 			)));
 		}
 	};
@@ -118,15 +138,15 @@ pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
 		geo.height,
 		geo.framerate,
 		geo.device,
-		None,
+		Some(first),
 		Box::new(guard),
 	))
 }
 
 /// Ask the ScreenCast portal for a monitor: create a session, (re)select the
-/// source, and start it, returning the PipeWire node to stream plus the fd of
-/// the portal's PipeWire remote.
-async fn portal_negotiate() -> Result<(u32, OwnedFd), Error> {
+/// source, and start it, returning the PipeWire node to stream, the fd of the
+/// portal's PipeWire remote, and a guard that closes the session on drop.
+async fn portal_negotiate() -> Result<(u32, OwnedFd, SessionGuard), Error> {
 	let proxy = Screencast::new().await.map_err(|e| err("screencast portal", e))?;
 	let session = proxy
 		.create_session(Default::default())
@@ -167,14 +187,40 @@ async fn portal_negotiate() -> Result<(u32, OwnedFd), Error> {
 		.open_pipe_wire_remote(&session, Default::default())
 		.await
 		.map_err(|e| err("portal pipewire remote", e))?;
-	Ok((node_id, fd))
+	Ok((node_id, fd, SessionGuard::new(session)))
 }
 
-/// Stops the PipeWire loop and joins its thread on drop, ending the portal
-/// session and closing the frame channel.
+/// Closes the portal session when dropped, so the compositor's "screen is being
+/// shared" indicator turns off and sessions don't pile up across demand-driven
+/// reopens. The close call is async and `Drop` is not, so a task spawned here
+/// waits for the guard to drop. Closing does not invalidate the restore token.
+struct SessionGuard {
+	_close: tokio::sync::oneshot::Sender<()>,
+}
+
+impl SessionGuard {
+	fn new(session: ashpd::desktop::Session<Screencast>) -> Self {
+		let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+		tokio::spawn(async move {
+			// Resolves with `Err` once the guard (the sender) drops.
+			let _ = rx.await;
+			if let Err(e) = session.close().await {
+				tracing::debug!(error = %e, "failed to close portal session");
+			}
+		});
+		Self { _close: tx }
+	}
+}
+
+/// Stops the PipeWire loop and joins its thread on drop, then (via the
+/// `session` field, which drops after `drop` runs) closes the portal session
+/// and thereby the frame channel's upstream.
 struct LoopGuard {
 	quit: pw::channel::Sender<()>,
 	handle: Option<JoinHandle<()>>,
+	/// Held so the portal session outlives the loop; dropping it closes the
+	/// session only after the loop thread has been joined above.
+	_session: SessionGuard,
 }
 
 impl Drop for LoopGuard {
@@ -240,6 +286,13 @@ fn run_loop(
 					pw::stream::StreamState::Error(_) | pw::stream::StreamState::Unconnected
 				);
 				if done {
+					// The compositor ended the stream while our loop was live (the
+					// user hit "stop sharing", or the output went away). Forget the
+					// restore token so the demand-driven reopen asks again instead
+					// of silently resuming a grant the user just revoked. Our own
+					// teardown quits the loop before anything disconnects, so it
+					// never reaches this path.
+					*RESTORE_TOKEN.lock().unwrap() = None;
 					tracing::debug!(state = ?new, "screen capture stream ended");
 					if let Some(mainloop) = mainloop.upgrade() {
 						mainloop.quit();
@@ -318,6 +371,11 @@ fn run_loop(
 				let offset = data.chunk().offset() as usize;
 				let size = data.chunk().size() as usize;
 				let stride = data.chunk().stride();
+				// Compositors mark skipped frames as empty or corrupted; drop those
+				// rather than treating them as a fatal conversion failure below.
+				if size == 0 || data.chunk().flags().contains(spa::buffer::ChunkFlags::CORRUPTED) {
+					return;
+				}
 				// Without dmabuf modifiers in our format offer the compositor uses
 				// shared memory, which MAP_BUFFERS mmaps for us; `None` here means
 				// it forced something we can't read, so give up cleanly.
@@ -331,7 +389,13 @@ fn run_loop(
 				let Some(bytes) = bytes.get(offset..offset + size) else {
 					return;
 				};
-				let stride = if stride > 0 { stride as u32 } else { width * 4 };
+				// Fall back to the unclamped source width: for an odd-width source
+				// the real row is one pixel wider than the clamped `width`.
+				let stride = if stride > 0 {
+					stride as u32
+				} else {
+					state.format.size().width * 4
+				};
 
 				match convert(state.format.format(), bytes, stride, width, height) {
 					Ok(i420) => {

--- a/rs/moq-video/src/capture/pipewire.rs
+++ b/rs/moq-video/src/capture/pipewire.rs
@@ -1,0 +1,513 @@
+//! Screen capture via xdg-desktop-portal + PipeWire (Linux, Wayland and X11).
+//!
+//! The ScreenCast portal owns source selection: [`open`] pops the compositor's
+//! picker dialog, the user chooses a monitor, and the portal hands us a PipeWire
+//! fd + node id. A dedicated thread then runs the PipeWire main loop, converting
+//! each RGB frame to CPU [`I420`] and pushing it into the shared [`FrameChannel`]
+//! (callback-driven like the macOS delegate, not a pull-style pump).
+//!
+//! Two quirks worth knowing:
+//! - `publish_capture` releases the capture while unwatched and reopens it on
+//!   demand. A fresh portal session would re-prompt the picker every time, so the
+//!   portal's restore token is kept in a process-wide slot and replayed on the
+//!   next [`open`], which restores the same grant without a dialog (on
+//!   compositors that support persistence).
+//! - Compositors only deliver frames on damage, so a static screen would starve
+//!   the encoder. A loop timer re-emits the last frame whenever a frame interval
+//!   passes without a fresh one, mirroring the Windows Desktop Duplication pacing.
+
+use std::cell::RefCell;
+use std::os::fd::OwnedFd;
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use ashpd::desktop::PersistMode;
+use ashpd::desktop::screencast::{CursorMode, Screencast, SelectSourcesOptions, SourceType};
+use pipewire as pw;
+use pw::spa;
+use spa::param::video::{VideoFormat, VideoInfoRaw};
+
+use super::channel::FrameChannel;
+use super::pump::Geometry;
+use super::{Config, FrameStream};
+use crate::Error;
+use crate::frame::{Frame, I420};
+
+const DEFAULT_FRAMERATE: u32 = 30;
+/// The compositor sends the negotiated format right after the stream connects;
+/// if nothing arrives the session is broken (or the grant was revoked mid-setup).
+const FORMAT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// The portal restore token from the last grant, replayed on the next [`open`]
+/// so a demand-driven reopen skips the picker dialog. Process-wide because the
+/// capture session (and its `FrameStream`) is torn down between opens.
+static RESTORE_TOKEN: Mutex<Option<String>> = Mutex::new(None);
+
+fn err(ctx: &str, e: impl std::fmt::Display) -> Error {
+	Error::Codec(anyhow::anyhow!("{ctx}: {e}"))
+}
+
+/// Open a portal screen capture and stream its frames from a PipeWire loop thread.
+pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
+	if let Some(device) = &config.device {
+		tracing::debug!(%device, "portal screen capture ignores the device selector; the picker owns selection");
+	}
+
+	let (node_id, fd) = portal_negotiate().await?;
+
+	let chan = FrameChannel::new();
+	let framerate = config.framerate.unwrap_or(DEFAULT_FRAMERATE).max(1);
+	let (geo_tx, geo_rx) = tokio::sync::oneshot::channel();
+	let (quit_tx, quit_rx) = pw::channel::channel::<()>();
+
+	let handle = std::thread::spawn({
+		let chan = chan.clone();
+		move || {
+			let state = Rc::new(RefCell::new(State {
+				format: VideoInfoRaw::default(),
+				geometry: None,
+				geo_tx: Some(geo_tx),
+				last: None,
+				fresh: false,
+			}));
+			if let Err(e) = run_loop(fd, node_id, framerate, chan.clone(), state.clone(), quit_rx) {
+				// Surface a setup failure through the awaiting `open`; a mid-stream
+				// failure just ends the stream (the encode loop reopens on demand).
+				match state.borrow_mut().geo_tx.take() {
+					Some(tx) => drop(tx.send(Err(e))),
+					None => tracing::warn!(error = %e, "screen capture stream failed"),
+				}
+			}
+			chan.close();
+		}
+	});
+
+	// Own the thread from here on, so cancelling this `await` still stops and
+	// joins it instead of detaching a loop that holds the portal session open.
+	let guard = LoopGuard {
+		quit: quit_tx,
+		handle: Some(handle),
+	};
+
+	let geo = match tokio::time::timeout(FORMAT_TIMEOUT, geo_rx).await {
+		Ok(Ok(result)) => result?,
+		Ok(Err(_)) => {
+			return Err(Error::Codec(anyhow::anyhow!(
+				"screen capture thread exited before negotiating a format"
+			)));
+		}
+		Err(_) => {
+			return Err(Error::Codec(anyhow::anyhow!(
+				"no video format from the compositor within {FORMAT_TIMEOUT:?}"
+			)));
+		}
+	};
+
+	tracing::info!(
+		node = node_id,
+		width = geo.width,
+		height = geo.height,
+		"opened screen capture (PipeWire)"
+	);
+
+	Ok(FrameStream::new(
+		chan,
+		geo.width,
+		geo.height,
+		geo.framerate,
+		geo.device,
+		None,
+		Box::new(guard),
+	))
+}
+
+/// Ask the ScreenCast portal for a monitor: create a session, (re)select the
+/// source, and start it, returning the PipeWire node to stream plus the fd of
+/// the portal's PipeWire remote.
+async fn portal_negotiate() -> Result<(u32, OwnedFd), Error> {
+	let proxy = Screencast::new().await.map_err(|e| err("screencast portal", e))?;
+	let session = proxy
+		.create_session(Default::default())
+		.await
+		.map_err(|e| err("portal session", e))?;
+
+	let restore = RESTORE_TOKEN.lock().unwrap().clone();
+	proxy
+		.select_sources(
+			&session,
+			SelectSourcesOptions::default()
+				.set_cursor_mode(CursorMode::Embedded)
+				.set_sources(ashpd::enumflags2::BitFlags::from(SourceType::Monitor))
+				.set_multiple(false)
+				.set_persist_mode(PersistMode::Application)
+				.set_restore_token(restore.as_deref()),
+		)
+		.await
+		.map_err(|e| err("portal select sources", e))?;
+
+	// This is where the compositor's picker dialog appears (unless the restore
+	// token silently re-grants), so it blocks on the user.
+	let response = proxy
+		.start(&session, None, Default::default())
+		.await
+		.map_err(|e| err("portal start", e))?
+		.response()
+		.map_err(|e| err("screen capture request denied", e))?;
+	*RESTORE_TOKEN.lock().unwrap() = response.restore_token().map(str::to_string);
+
+	let stream = response
+		.streams()
+		.first()
+		.ok_or_else(|| Error::Codec(anyhow::anyhow!("portal granted no streams")))?;
+	let node_id = stream.pipe_wire_node_id();
+
+	let fd = proxy
+		.open_pipe_wire_remote(&session, Default::default())
+		.await
+		.map_err(|e| err("portal pipewire remote", e))?;
+	Ok((node_id, fd))
+}
+
+/// Stops the PipeWire loop and joins its thread on drop, ending the portal
+/// session and closing the frame channel.
+struct LoopGuard {
+	quit: pw::channel::Sender<()>,
+	handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for LoopGuard {
+	fn drop(&mut self) {
+		let _ = self.quit.send(());
+		if let Some(handle) = self.handle.take() {
+			let _ = handle.join();
+		}
+	}
+}
+
+/// Shared by the stream callbacks and the pacing timer, all on the loop thread.
+struct State {
+	format: VideoInfoRaw,
+	/// The even-clamped size sent to `open`; a later renegotiation to a different
+	/// size quits the loop so the encode loop reopens at the new geometry.
+	geometry: Option<(u32, u32)>,
+	geo_tx: Option<tokio::sync::oneshot::Sender<Result<Geometry, Error>>>,
+	/// Most recent converted frame, re-emitted while the screen is static.
+	last: Option<I420>,
+	/// Whether a fresh frame arrived since the last pacing tick.
+	fresh: bool,
+}
+
+/// Connect to the portal's PipeWire node and run the main loop until the stream
+/// ends, `quit_rx` fires (the `FrameStream` dropped), or the format changes.
+fn run_loop(
+	fd: OwnedFd,
+	node_id: u32,
+	framerate: u32,
+	chan: Arc<FrameChannel>,
+	state: Rc<RefCell<State>>,
+	quit_rx: pw::channel::Receiver<()>,
+) -> Result<(), Error> {
+	pw::init();
+
+	let mainloop = pw::main_loop::MainLoopRc::new(None).map_err(|e| err("pipewire main loop", e))?;
+	let context = pw::context::ContextRc::new(&mainloop, None).map_err(|e| err("pipewire context", e))?;
+	let core = context
+		.connect_fd_rc(fd, None)
+		.map_err(|e| err("pipewire connect", e))?;
+
+	let stream = pw::stream::StreamRc::new(
+		core,
+		"moq-screen",
+		pw::properties::properties! {
+			*pw::keys::MEDIA_TYPE => "Video",
+			*pw::keys::MEDIA_CATEGORY => "Capture",
+			*pw::keys::MEDIA_ROLE => "Screen",
+		},
+	)
+	.map_err(|e| err("pipewire stream", e))?;
+
+	let _listener = stream
+		.add_local_listener::<()>()
+		.state_changed({
+			let mainloop = mainloop.downgrade();
+			move |_, _, _, new| {
+				// Error is fatal; Unconnected after setup means the user stopped
+				// sharing from the compositor. Either way the stream is over.
+				let done = matches!(
+					new,
+					pw::stream::StreamState::Error(_) | pw::stream::StreamState::Unconnected
+				);
+				if done {
+					tracing::debug!(state = ?new, "screen capture stream ended");
+					if let Some(mainloop) = mainloop.upgrade() {
+						mainloop.quit();
+					}
+				}
+			}
+		})
+		.param_changed({
+			let state = state.clone();
+			let mainloop = mainloop.downgrade();
+			move |_, _, id, param| {
+				let Some(param) = param else { return };
+				if id != spa::param::ParamType::Format.as_raw() {
+					return;
+				}
+				let Ok((media_type, media_subtype)) = spa::param::format_utils::parse_format(param) else {
+					return;
+				};
+				if media_type != spa::param::format::MediaType::Video
+					|| media_subtype != spa::param::format::MediaSubtype::Raw
+				{
+					return;
+				}
+
+				let mut state = state.borrow_mut();
+				if let Err(e) = state.format.parse(param) {
+					tracing::warn!(error = %e, "failed to parse pipewire video format");
+					return;
+				}
+
+				let size = state.format.size();
+				// I420 chroma is 2x2 subsampled; clamp down (drop the last odd
+				// row/column, the stride still covers the full source row).
+				let (width, height) = (size.width & !1, size.height & !1);
+				if width == 0 || height == 0 {
+					tracing::warn!(width = size.width, height = size.height, "unusable capture size");
+					return;
+				}
+
+				if let Some(tx) = state.geo_tx.take() {
+					state.geometry = Some((width, height));
+					// The compositor reports 0/1 for a variable rate; only a real
+					// rate is worth forwarding to the encoder.
+					let fr = state.format.framerate();
+					let framerate = (fr.num > 0 && fr.denom > 0).then(|| (fr.num / fr.denom).max(1));
+					let _ = tx.send(Ok(Geometry {
+						width,
+						height,
+						framerate,
+						device: format!("pipewire:{node_id}"),
+					}));
+				} else if state.geometry != Some((width, height)) {
+					// Renegotiated to a new size (e.g. the monitor changed mode).
+					// End the stream; the encode loop reopens at the new geometry
+					// and the restore token skips the picker.
+					tracing::info!(width, height, "capture size changed; restarting the stream");
+					if let Some(mainloop) = mainloop.upgrade() {
+						mainloop.quit();
+					}
+				}
+			}
+		})
+		.process({
+			let state = state.clone();
+			let chan = chan.clone();
+			let mainloop = mainloop.downgrade();
+			move |stream, _| {
+				let mut state = state.borrow_mut();
+				let Some((width, height)) = state.geometry else { return };
+				let Some(mut buffer) = stream.dequeue_buffer() else {
+					return;
+				};
+				let datas = buffer.datas_mut();
+				let Some(data) = datas.first_mut() else { return };
+
+				let offset = data.chunk().offset() as usize;
+				let size = data.chunk().size() as usize;
+				let stride = data.chunk().stride();
+				// Without dmabuf modifiers in our format offer the compositor uses
+				// shared memory, which MAP_BUFFERS mmaps for us; `None` here means
+				// it forced something we can't read, so give up cleanly.
+				let Some(bytes) = data.data() else {
+					tracing::warn!("pipewire buffer is not CPU-mapped; stopping capture");
+					if let Some(mainloop) = mainloop.upgrade() {
+						mainloop.quit();
+					}
+					return;
+				};
+				let Some(bytes) = bytes.get(offset..offset + size) else {
+					return;
+				};
+				let stride = if stride > 0 { stride as u32 } else { width * 4 };
+
+				match convert(state.format.format(), bytes, stride, width, height) {
+					Ok(i420) => {
+						chan.push(Frame::I420(i420.clone()));
+						state.last = Some(i420);
+						state.fresh = true;
+					}
+					Err(e) => {
+						// Persistent (bad format), not per-frame; stop rather than spam.
+						tracing::warn!(error = %e, "screen frame conversion failed; stopping capture");
+						if let Some(mainloop) = mainloop.upgrade() {
+							mainloop.quit();
+						}
+					}
+				}
+			}
+		})
+		.register()
+		.map_err(|e| err("pipewire listener", e))?;
+
+	// Offer the CPU-convertible RGB layouts; the compositor picks one and
+	// replies through `param_changed`. No dmabuf modifiers, so buffers stay in
+	// shared memory (the CPU path, like the other non-macOS backends).
+	let pod = format_offer(framerate);
+	let mut params = [spa::pod::Pod::from_bytes(&pod)
+		.ok_or_else(|| Error::Codec(anyhow::anyhow!("failed to build pipewire format offer")))?];
+	stream
+		.connect(
+			spa::utils::Direction::Input,
+			Some(node_id),
+			pw::stream::StreamFlags::AUTOCONNECT | pw::stream::StreamFlags::MAP_BUFFERS,
+			&mut params,
+		)
+		.map_err(|e| err("pipewire stream connect", e))?;
+
+	// Re-emit the last frame when an interval passes without a fresh one, so a
+	// static screen still produces a steady stream for the encoder.
+	let timer = mainloop.loop_().add_timer({
+		let state = state.clone();
+		let chan = chan.clone();
+		move |_| {
+			let mut state = state.borrow_mut();
+			if std::mem::take(&mut state.fresh) {
+				return;
+			}
+			if let Some(last) = &state.last {
+				chan.push(Frame::I420(last.clone()));
+			}
+		}
+	});
+	let interval = Duration::from_micros(1_000_000 / framerate as u64);
+	timer
+		.update_timer(Some(interval), Some(interval))
+		.into_result()
+		.map_err(|e| err("pipewire timer", e))?;
+
+	// Quit when the FrameStream drops.
+	let _quit = quit_rx.attach(mainloop.loop_(), {
+		let mainloop = mainloop.downgrade();
+		move |_| {
+			if let Some(mainloop) = mainloop.upgrade() {
+				mainloop.quit();
+			}
+		}
+	});
+
+	mainloop.run();
+	Ok(())
+}
+
+/// Convert one strided RGB screen frame to tightly-packed I420.
+fn convert(format: VideoFormat, bytes: &[u8], stride: u32, width: u32, height: u32) -> Result<I420, Error> {
+	match format {
+		VideoFormat::BGRx | VideoFormat::BGRA => I420::from_bgra(bytes, stride, width, height),
+		VideoFormat::RGBx | VideoFormat::RGBA => I420::from_rgba(bytes, stride, width, height),
+		other => Err(Error::Codec(anyhow::anyhow!(
+			"pipewire negotiated an unsupported video format {other:?}"
+		))),
+	}
+}
+
+/// Serialize the `EnumFormat` pod offering the RGB layouts we can convert,
+/// any size, and a framerate range preferring `framerate`.
+fn format_offer(framerate: u32) -> Vec<u8> {
+	let obj = spa::pod::object!(
+		spa::utils::SpaTypes::ObjectParamFormat,
+		spa::param::ParamType::EnumFormat,
+		spa::pod::property!(
+			spa::param::format::FormatProperties::MediaType,
+			Id,
+			spa::param::format::MediaType::Video
+		),
+		spa::pod::property!(
+			spa::param::format::FormatProperties::MediaSubtype,
+			Id,
+			spa::param::format::MediaSubtype::Raw
+		),
+		spa::pod::property!(
+			spa::param::format::FormatProperties::VideoFormat,
+			Choice,
+			Enum,
+			Id,
+			VideoFormat::BGRx,
+			VideoFormat::BGRx,
+			VideoFormat::BGRA,
+			VideoFormat::RGBx,
+			VideoFormat::RGBA,
+		),
+		spa::pod::property!(
+			spa::param::format::FormatProperties::VideoSize,
+			Choice,
+			Range,
+			Rectangle,
+			spa::utils::Rectangle {
+				width: 1920,
+				height: 1080
+			},
+			spa::utils::Rectangle { width: 1, height: 1 },
+			spa::utils::Rectangle {
+				width: 8192,
+				height: 8192
+			}
+		),
+		spa::pod::property!(
+			spa::param::format::FormatProperties::VideoFramerate,
+			Choice,
+			Range,
+			Fraction,
+			spa::utils::Fraction {
+				num: framerate,
+				denom: 1
+			},
+			spa::utils::Fraction { num: 0, denom: 1 },
+			spa::utils::Fraction { num: 1000, denom: 1 }
+		),
+	);
+	spa::pod::serialize::PodSerializer::serialize(std::io::Cursor::new(Vec::new()), &spa::pod::Value::Object(obj))
+		.expect("serializing a static format pod cannot fail")
+		.0
+		.into_inner()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::capture::Config;
+
+	/// The serialized format offer must parse back as a valid pod.
+	#[test]
+	fn format_offer_is_valid_pod() {
+		let bytes = format_offer(30);
+		assert!(spa::pod::Pod::from_bytes(&bytes).is_some(), "offer did not round-trip");
+	}
+
+	/// Open the portal, grab a few frames, and check geometry. Ignored because it
+	/// needs a desktop session, PipeWire, and a human clicking the picker dialog:
+	/// `cargo test -p moq-video --features pipewire portal_capture -- --ignored`.
+	#[tokio::test]
+	#[ignore]
+	async fn portal_captures_frames() {
+		let mut stream = match open(&Config::default()).await {
+			Ok(stream) => stream,
+			Err(e) => {
+				eprintln!("skipping: no portal screen capture available: {e}");
+				return;
+			}
+		};
+
+		assert!(stream.width() >= 2 && stream.width() % 2 == 0, "bad width");
+		assert!(stream.height() >= 2 && stream.height() % 2 == 0, "bad height");
+
+		for i in 0..5 {
+			let frame = stream.read().await.unwrap_or_else(|| panic!("no frame {i}"));
+			assert_eq!(frame.width(), stream.width());
+			assert_eq!(frame.height(), stream.height());
+		}
+		eprintln!("captured 5 frames at {}x{}", stream.width(), stream.height());
+	}
+}

--- a/rs/moq-video/src/decode/backend/nvdec.rs
+++ b/rs/moq-video/src/decode/backend/nvdec.rs
@@ -545,7 +545,7 @@ mod tests {
 		.unwrap();
 		let decoder = Nvdec::open(Codec::H264, &decode_config(None)).expect("NVDEC H.264 decoder");
 
-		let expected = I420::from_rgba(&gradient_rgba(w, h), w, h).unwrap();
+		let expected = I420::from_rgba(&gradient_rgba(w, h), w * 4, w, h).unwrap();
 		let decoded = round_trip(encoder, decoder, w, h);
 
 		for (i, (timestamp, i420)) in decoded.iter().enumerate() {
@@ -575,7 +575,7 @@ mod tests {
 		let decoder = Nvdec::open(Codec::H264, &decode_config(Some((160, 120)))).expect("NVDEC H.264 decoder");
 
 		// Nearest-neighbor reference downscale of the expected picture.
-		let full = I420::from_rgba(&gradient_rgba(w, h), w, h).unwrap();
+		let full = I420::from_rgba(&gradient_rgba(w, h), w * 4, w, h).unwrap();
 		let sample = |plane: &[u8], pw: usize, x: usize, y: usize| plane[y * 2 * pw + x * 2];
 		let mut expected_y = vec![0u8; 160 * 120];
 		for y in 0..120 {
@@ -609,7 +609,7 @@ mod tests {
 		};
 		let decoder = Nvdec::open(Codec::H265, &decode_config(None)).expect("NVDEC H.265 decoder");
 
-		let expected = I420::from_rgba(&gradient_rgba(w, h), w, h).unwrap();
+		let expected = I420::from_rgba(&gradient_rgba(w, h), w * 4, w, h).unwrap();
 		let decoded = round_trip(encoder, decoder, w, h);
 		for (_, i420) in &decoded {
 			assert_eq!((i420.width, i420.height), (w, h));
@@ -673,7 +673,7 @@ mod tests {
 
 		// Decode the re-encoded stream in software and compare to the source.
 		let expected = {
-			let full = I420::from_rgba(&gradient_rgba(w, h), w, h).unwrap();
+			let full = I420::from_rgba(&gradient_rgba(w, h), w * 4, w, h).unwrap();
 			let mut y = vec![0u8; 160 * 120];
 			for row in 0..120 {
 				for col in 0..160 {

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -504,7 +504,7 @@ mod tests {
 		};
 
 		let rgba = gradient_rgba(w, h);
-		let expected = crate::frame::I420::from_rgba(&rgba, w, h).unwrap();
+		let expected = crate::frame::I420::from_rgba(&rgba, w * 4, w, h).unwrap();
 
 		let decode_config = crate::decode::Config {
 			kind: crate::decode::Kind::Software,

--- a/rs/moq-video/src/encode/encoder.rs
+++ b/rs/moq-video/src/encode/encoder.rs
@@ -174,7 +174,7 @@ impl Encoder {
 			)));
 		}
 
-		let frame = Frame::I420(I420::from_rgba(rgba, width, height)?);
+		let frame = Frame::I420(I420::from_rgba(rgba, width * 4, width, height)?);
 		self.encode_raw(&frame, keyframe)
 	}
 

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -91,15 +91,16 @@ impl I420 {
 		luma + luma / 2
 	}
 
-	/// Convert tightly-packed RGBA (`width * height * 4` bytes) to I420, BT.601
+	/// Convert RGBA (`stride` bytes per row, >= `width * 4`) to I420, BT.601
 	/// limited range (studio swing, what H.264 decoders expect by default). Used
-	/// by [`Encoder::encode_rgba`](crate::encode::Encoder) and the Windows capture.
-	pub(crate) fn from_rgba(rgba: &[u8], width: u32, height: u32) -> Result<Self, Error> {
+	/// by [`Encoder::encode_rgba`](crate::encode::Encoder) (tightly packed) and
+	/// the screen-capture paths, whose surfaces carry a driver-chosen row pitch.
+	pub(crate) fn from_rgba(rgba: &[u8], stride: u32, width: u32, height: u32) -> Result<Self, Error> {
 		let mut planar = YuvPlanarImageMut::alloc(width, height, YuvChromaSubsampling::Yuv420);
 		rgba_to_yuv420(
 			&mut planar,
 			rgba,
-			width * 4,
+			stride,
 			YuvRange::Limited,
 			YuvStandardMatrix::Bt601,
 			YuvConversionMode::Balanced,
@@ -110,9 +111,9 @@ impl I420 {
 
 	/// Convert BGRA to I420, BT.601 limited range. `stride` is the source row
 	/// pitch in bytes (>= `width * 4`), so a padded surface maps directly. Used by
-	/// the Windows Desktop Duplication screen-capture path, whose staging texture
-	/// is BGRA with a driver-chosen row pitch.
-	#[cfg(target_os = "windows")]
+	/// the screen-capture paths: Windows Desktop Duplication (BGRA staging
+	/// texture) and Linux PipeWire (BGRx/BGRA shared-memory buffers).
+	#[cfg(any(target_os = "windows", all(target_os = "linux", feature = "pipewire")))]
 	pub(crate) fn from_bgra(bgra: &[u8], stride: u32, width: u32, height: u32) -> Result<Self, Error> {
 		use yuv::bgra_to_yuv420;
 


### PR DESCRIPTION
## Summary

Fills the last gap in the display-capture matrix: `capture --screen` now works on Linux (Wayland and X11) via **xdg-desktop-portal + PipeWire**.

- New `rs/moq-video/src/capture/pipewire.rs` backend: [ashpd](https://crates.io/crates/ashpd) negotiates a monitor through the ScreenCast portal (the compositor's picker dialog chooses the source), then a dedicated thread runs the PipeWire main loop on the granted node, converting BGRx/BGRA/RGBx/RGBA shared-memory buffers to CPU I420 for the encoder. Callback-driven like the macOS delegate backends, not a pull-style pump.
- **Restore token reuse**: `publish_capture` releases the capture while unwatched and reopens on demand; the portal restore token is kept process-wide (`PersistMode::Application`) so reopens restore the grant without re-prompting the picker. The token is forgotten when the compositor ends the stream, so a grant revoked via the system "stop sharing" control is asked for again rather than silently resumed.
- **Session lifecycle**: the portal session is closed on teardown (async close via a reaper task), so the compositor's sharing indicator turns off when capture stops and sessions don't accumulate across reopens.
- **Static-screen pacing**: compositors only deliver frames on damage, so a loop timer re-emits the last frame each interval without a fresh one, mirroring the Windows Desktop Duplication behavior. `open` waits for the first frame (like the ScreenCaptureKit backend) so a broken session fails loudly instead of starving the encoder.
- **Robustness**: empty/`CORRUPTED` chunks are skipped (not fatal); mid-stream renegotiation (monitor mode change) ends the stream cleanly and the encode loop reopens at the new geometry, dialog-free thanks to the restore token.

## Feature gating

The `pipewire` crate hard-links libpipewire-0.3 via pkg-config and generates bindings at build time (libclang), so it follows the VAAPI pattern:

- `moq-video/pipewire`: off by default in the library.
- `moq-cli/pipewire`: default-on passthrough (`moq-video?/pipewire`) like `nvenc`/`vaapi`/`nvdec`, so `--features capture` gets screen capture while `--no-default-features` slim builds (e.g. a headless camera publisher) stay libpipewire-free.
- devShell gains `pkgs.pipewire` (Linux only); the nix release packages build without capture, so no overlay change.

## Public API changes

No breaking changes; everything is additive:

- `capture::Source::Display` now works on Linux (doc updated); previously it returned an error there. No signature changes.
- New cargo features: `moq-video/pipewire`, `moq-cli/pipewire` (default).
- Internal only: `I420::from_rgba` (pub(crate)) gained a stride parameter; `from_bgra` widened from Windows-only to Windows + Linux.

Targets `dev` (not `main`) because the capture subsystem this builds on has not merged to `main` yet, not because anything here is breaking.

## Review

CodeRabbit/Sourcery were rate-limited, so an adversarial local review ran instead (second commit addresses its findings): portal session leak + sharing indicator stuck on, restore token overriding a user's "stop sharing", corrupted/empty chunks killing the stream, a wrong zero-stride fallback for odd widths, and missing first-frame wait. It also verified the pipewire channel quit race is safe (pipe-based, level-triggered), RefCell use is single-threaded by construction, and every `from_rgba` caller passes a correct stride.

## Cross-package sync

- `doc/bin/cli.md`: `--screen` platform matrix, slim-build note, screen example.
- `rs/moq-video/README.md`: capture matrix.
- `js/*`, wire specs, ffi: untouched (native capture only, no wire or ffi surface change).

## Test plan

- [x] `rs just check` passes (clippy all-features -D warnings, docs, nextest, no-default-features check).
- [x] `cargo check -p moq-cli --no-default-features --features "iroh noq websocket capture"` (slim build without pipewire).
- [x] `cargo clippy -p moq-video --no-default-features --features pipewire` (pipewire without the codec features).
- [x] End-to-end on KDE Wayland (Fedora 44): `portal_captures_frames -- --ignored` popped the KDE picker and captured live 2560x1440 frames from the compositor, before and after the review fixes.
- [x] New unit test validates the serialized SPA format offer round-trips as a pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Fable 5)