### PR TITLE
test(smoke): exercise browser playback and audio

### DIFF
--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -11,9 +11,11 @@ regressions before anything is published. No apt/brew/npm/PyPI, and no
 distribution-mechanism matrix.
 
 It stands up a `moq-relay`, then for each publisher language publishes an H.264
-broadcast and confirms every subscriber sees data flowing (a non-empty frame
-before the timeout). We check that bytes move end-to-end across implementations,
-not that H.264 decodes.
+broadcast and confirms every subscriber sees data flowing before the timeout.
+Most subscribers check for a non-empty frame. The browser additionally verifies
+WebCodecs output painted to a canvas and drives the player's pause/resume controls.
+The browser publisher also sends fake microphone audio, which the browser
+subscriber checks end-to-end.
 
 ## Clients
 
@@ -21,7 +23,7 @@ not that H.264 decodes.
 |---|---|---|---|
 | Rust | `rs/moq-relay` + `rs/moq-cli` | `cargo build` | publish + subscribe |
 | Python | `py/moq-rs` (+ `rs/moq-ffi`, import `moq`) | `just py build` (maturin editable into `.venv`) | publish + subscribe |
-| Browser | `js/watch` + `js/publish` | `vite build` + headless Chromium (Playwright) | publish + subscribe |
+| Browser | `js/watch` + `js/publish` | `vite build` + headless Chromium (Playwright) | audio/video publish + rendered playback |
 | Native JS | `js/net` + `js/hang` + the npm `@moq/web-transport` polyfill | `node` (tsx) and `bun` | subscribe |
 | C | `rs/libmoq` | `cargo build -p libmoq` + `cc` | subscribe |
 | GStreamer | `rs/moq-gst` (`moqsrc`) | `cargo build -p moq-gst` + `gst-launch-1.0` | subscribe |

--- a/test/smoke/clients/js/driver.ts
+++ b/test/smoke/clients/js/driver.ts
@@ -64,6 +64,17 @@ type WaitForStateProps = {
 	predicate: (state: PlayerState) => boolean;
 };
 
+// Keep the UI contract in one place so player markup changes fail clearly.
+const SELECTORS = {
+	watch: "moq-watch",
+	ui: "moq-watch-ui",
+	control: "button.control[aria-label]",
+	pauseControl: 'button.control[aria-label="Pause"]',
+	centerPlay: "button.center-play",
+} as const;
+const POLL_INTERVAL_MS = 100;
+const PAUSE_STABILITY_MS = 750;
+
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function throwPageErrors(errors: BrowserErrors): void {
@@ -75,7 +86,7 @@ function throwPageErrors(errors: BrowserErrors): void {
 }
 
 async function readPlayerState(page: Page): Promise<PlayerState> {
-	return page.evaluate(() => {
+	return page.evaluate((selectors) => {
 		type Signal<T> = { peek(): T };
 		type Watch = HTMLElement & {
 			backend: {
@@ -92,7 +103,7 @@ async function readPlayerState(page: Page): Promise<PlayerState> {
 			broadcast: { catalog: Signal<{ audio?: unknown } | undefined> };
 		};
 
-		const watch = document.querySelector("moq-watch") as Watch | null;
+		const watch = document.querySelector(selectors.watch) as Watch | null;
 		const canvas = watch?.querySelector("canvas");
 		let painted = false;
 		if (canvas && canvas.width > 0 && canvas.height > 0) {
@@ -110,9 +121,9 @@ async function readPlayerState(page: Page): Promise<PlayerState> {
 			}
 		}
 
-		const ui = document.querySelector("moq-watch-ui");
-		const control = ui?.shadowRoot?.querySelector<HTMLButtonElement>("button.control[aria-label]");
-		const centerPlay = ui?.shadowRoot?.querySelector<HTMLButtonElement>("button.center-play");
+		const ui = document.querySelector(selectors.ui);
+		const control = ui?.shadowRoot?.querySelector<HTMLButtonElement>(selectors.control);
+		const centerPlay = ui?.shadowRoot?.querySelector<HTMLButtonElement>(selectors.centerPlay);
 
 		return {
 			videoFrames: watch?.backend.video.stats.peek()?.frameCount ?? 0,
@@ -126,7 +137,7 @@ async function readPlayerState(page: Page): Promise<PlayerState> {
 			controlLabel: control?.getAttribute("aria-label") ?? undefined,
 			centerPlayVisible: centerPlay ? getComputedStyle(centerPlay).display !== "none" : false,
 		};
-	});
+	}, SELECTORS);
 }
 
 async function waitForState(page: Page, errors: BrowserErrors, props: WaitForStateProps): Promise<PlayerState> {
@@ -134,7 +145,7 @@ async function waitForState(page: Page, errors: BrowserErrors, props: WaitForSta
 	while (Date.now() < props.deadline) {
 		throwPageErrors(errors);
 		if (props.predicate(last)) return last;
-		await sleep(100);
+		await sleep(POLL_INTERVAL_MS);
 		last = await readPlayerState(page);
 	}
 	throwPageErrors(errors);
@@ -146,14 +157,14 @@ async function waitForStablePause(page: Page, errors: BrowserErrors, deadline: n
 	let stableSince = Date.now();
 	while (Date.now() < deadline) {
 		throwPageErrors(errors);
-		await sleep(100);
+		await sleep(POLL_INTERVAL_MS);
 		const current = await readPlayerState(page);
 		const stable =
 			current.videoFrames === previous.videoFrames &&
 			current.videoTimestamp === previous.videoTimestamp &&
 			(!expectAudio || current.audioBytes === previous.audioBytes);
 		if (!stable) stableSince = Date.now();
-		if (stable && Date.now() - stableSince >= 750) return current;
+		if (stable && Date.now() - stableSince >= PAUSE_STABILITY_MS) return current;
 		previous = current;
 	}
 	throwPageErrors(errors);
@@ -220,7 +231,7 @@ try {
 				reloaded = true;
 				await page.reload({ waitUntil: "load" });
 			}
-			await sleep(100);
+			await sleep(POLL_INTERVAL_MS);
 		}
 		if (!playing) {
 			const state = await readPlayerState(page);
@@ -237,8 +248,8 @@ try {
 
 		// The chrome auto-hides while playing. Pointer activity reveals the real
 		// control, then the click must flow through the public player API.
-		await page.dispatchEvent("moq-watch-ui", "pointermove");
-		await page.locator("moq-watch-ui").locator('button.control[aria-label="Pause"]').click();
+		await page.dispatchEvent(SELECTORS.ui, "pointermove");
+		await page.locator(SELECTORS.ui).locator(SELECTORS.pauseControl).click();
 		await waitForState(page, errors, {
 			deadline,
 			description: "paused player UI",
@@ -248,7 +259,7 @@ try {
 		const paused = await waitForStablePause(page, errors, deadline);
 		if (!paused.painted) throw new Error(`pause cleared the preview frame: ${JSON.stringify(paused)}`);
 
-		await page.locator("moq-watch-ui").locator("button.center-play").click();
+		await page.locator(SELECTORS.ui).locator(SELECTORS.centerPlay).click();
 		const resumed = await waitForState(page, errors, {
 			deadline,
 			description: "resumed playback",

--- a/test/smoke/clients/js/driver.ts
+++ b/test/smoke/clients/js/driver.ts
@@ -1,16 +1,17 @@
 /**
  * Drives a headless Chromium (channel "chromium" for WebTransport + WebCodecs)
- * against the vite-built page (dist/). publish streams a fake camera until
- * killed; subscribe exits 0 once the watch element decodes a frame.
+ * against the vite-built page (dist/). publish streams fake camera/microphone
+ * input until killed; subscribe verifies rendered playback, pause/resume, and
+ * optionally browser-to-browser audio.
  *
  *     bun driver.ts publish   --url http://127.0.0.1:4443 --broadcast b.hang
- *     bun driver.ts subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20
+ *     bun driver.ts subscribe --url http://127.0.0.1:4443 --broadcast b.hang --timeout 20 [--expect-audio]
  *
  * @module
  */
 import { join } from "node:path";
 import { parseArgs } from "node:util";
-import { chromium } from "playwright";
+import { chromium, type Page } from "playwright";
 
 const { positionals, values } = parseArgs({
 	allowPositionals: true,
@@ -18,6 +19,7 @@ const { positionals, values } = parseArgs({
 		url: { type: "string" },
 		broadcast: { type: "string" },
 		timeout: { type: "string", default: "20" },
+		"expect-audio": { type: "boolean", default: false },
 	},
 });
 
@@ -25,15 +27,137 @@ const role = positionals[0];
 const url = values.url;
 const broadcast = values.broadcast;
 const timeoutMs = Number.parseFloat(values.timeout ?? "20") * 1000;
+const expectAudio = values["expect-audio"] ?? false;
 if (
 	(role !== "publish" && role !== "subscribe") ||
 	!url ||
 	!broadcast ||
 	!Number.isFinite(timeoutMs) ||
-	timeoutMs <= 0
+	timeoutMs <= 0 ||
+	(expectAudio && role !== "subscribe")
 ) {
-	console.error("usage: driver.ts publish|subscribe --url U --broadcast B [--timeout S>0]");
+	console.error("usage: driver.ts publish|subscribe --url U --broadcast B [--timeout S>0] [--expect-audio]");
 	process.exit(2);
+}
+
+type PlayerState = {
+	videoFrames: number;
+	videoTimestamp?: number;
+	painted: boolean;
+	audioBytes: number;
+	audioContext?: string;
+	hasAudio: boolean;
+	paused: boolean;
+	pausedAttribute: boolean;
+	controlLabel?: string;
+	centerPlayVisible: boolean;
+};
+
+type BrowserErrors = {
+	page: string[];
+	console: string[];
+};
+
+type WaitForStateProps = {
+	deadline: number;
+	description: string;
+	predicate: (state: PlayerState) => boolean;
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function throwPageErrors(errors: BrowserErrors): void {
+	const messages = [
+		...errors.page.map((error) => `page: ${error}`),
+		...errors.console.map((error) => `console: ${error}`),
+	];
+	if (messages.length > 0) throw new Error(messages.join("\n"));
+}
+
+async function readPlayerState(page: Page): Promise<PlayerState> {
+	return page.evaluate(() => {
+		type Signal<T> = { peek(): T };
+		type Watch = HTMLElement & {
+			backend: {
+				paused: Signal<boolean>;
+				video: {
+					stats: Signal<{ frameCount?: number } | undefined>;
+					timestamp: Signal<number | undefined>;
+				};
+				audio: {
+					stats: Signal<{ bytesReceived?: number } | undefined>;
+					context: Signal<AudioContext | undefined>;
+				};
+			};
+			broadcast: { catalog: Signal<{ audio?: unknown } | undefined> };
+		};
+
+		const watch = document.querySelector("moq-watch") as Watch | null;
+		const canvas = watch?.querySelector("canvas");
+		let painted = false;
+		if (canvas && canvas.width > 0 && canvas.height > 0) {
+			const pixels = canvas.getContext("2d")?.getImageData(0, 0, canvas.width, canvas.height).data;
+			if (pixels) {
+				// The smoke sources are test patterns. Sample at most about 1,000
+				// pixels and require actual color rather than the renderer's black fill.
+				const stride = Math.max(4, Math.floor(pixels.length / 4000) * 4);
+				for (let i = 0; i < pixels.length; i += stride) {
+					if (pixels[i] + pixels[i + 1] + pixels[i + 2] > 12) {
+						painted = true;
+						break;
+					}
+				}
+			}
+		}
+
+		const ui = document.querySelector("moq-watch-ui");
+		const control = ui?.shadowRoot?.querySelector<HTMLButtonElement>("button.control[aria-label]");
+		const centerPlay = ui?.shadowRoot?.querySelector<HTMLButtonElement>("button.center-play");
+
+		return {
+			videoFrames: watch?.backend.video.stats.peek()?.frameCount ?? 0,
+			videoTimestamp: watch?.backend.video.timestamp.peek(),
+			painted,
+			audioBytes: watch?.backend.audio.stats.peek()?.bytesReceived ?? 0,
+			audioContext: watch?.backend.audio.context.peek()?.state,
+			hasAudio: watch?.broadcast.catalog.peek()?.audio !== undefined,
+			paused: watch?.backend.paused.peek() ?? false,
+			pausedAttribute: watch?.hasAttribute("paused") ?? false,
+			controlLabel: control?.getAttribute("aria-label") ?? undefined,
+			centerPlayVisible: centerPlay ? getComputedStyle(centerPlay).display !== "none" : false,
+		};
+	});
+}
+
+async function waitForState(page: Page, errors: BrowserErrors, props: WaitForStateProps): Promise<PlayerState> {
+	let last = await readPlayerState(page);
+	while (Date.now() < props.deadline) {
+		throwPageErrors(errors);
+		if (props.predicate(last)) return last;
+		await sleep(100);
+		last = await readPlayerState(page);
+	}
+	throwPageErrors(errors);
+	throw new Error(`timed out waiting for ${props.description}: ${JSON.stringify(last)}`);
+}
+
+async function waitForStablePause(page: Page, errors: BrowserErrors, deadline: number): Promise<PlayerState> {
+	let previous = await readPlayerState(page);
+	let stableSince = Date.now();
+	while (Date.now() < deadline) {
+		throwPageErrors(errors);
+		await sleep(100);
+		const current = await readPlayerState(page);
+		const stable =
+			current.videoFrames === previous.videoFrames &&
+			current.videoTimestamp === previous.videoTimestamp &&
+			(!expectAudio || current.audioBytes === previous.audioBytes);
+		if (!stable) stableSince = Date.now();
+		if (stable && Date.now() - stableSince >= 750) return current;
+		previous = current;
+	}
+	throwPageErrors(errors);
+	throw new Error(`playback did not stop after pause: ${JSON.stringify(previous)}`);
 }
 
 // Serve the prebuilt page on localhost (a secure context, so WebTransport /
@@ -64,37 +188,87 @@ const browser = await chromium.launch({
 let code = 1;
 try {
 	const page = await browser.newPage();
-	page.on("console", (m) => console.error(`[page] ${m.text()}`));
-	page.on("pageerror", (e) => console.error(`[page error] ${e.message}`));
+	const errors: BrowserErrors = { page: [], console: [] };
+	page.on("console", (message) => {
+		console.error(`[page] ${message.text()}`);
+		if (message.type() === "error") errors.console.push(message.text());
+	});
+	page.on("pageerror", (error) => {
+		console.error(`[page error] ${error.message}`);
+		errors.page.push(error.message);
+	});
 	await page.goto(pageUrl, { waitUntil: "load" });
 
 	if (role === "publish") {
-		console.error(`publishing ${broadcast} (fake camera) to ${url}`);
+		console.error(`publishing ${broadcast} (fake camera + microphone) to ${url}`);
 		await new Promise(() => {}); // stream until the orchestrator kills us
 	} else {
 		const start = Date.now();
 		const deadline = start + timeoutMs;
-		let frames = 0;
 		let reloaded = false;
+		let playing: PlayerState | undefined;
 		while (Date.now() < deadline) {
-			frames = await page.evaluate(() => {
-				const w = document.querySelector("moq-watch") as unknown as {
-					backend?: { video?: { stats?: { peek(): { frameCount?: number } | undefined } } };
-				} | null;
-				return w?.backend?.video?.stats?.peek()?.frameCount ?? 0;
-			});
-			if (frames > 0) break;
-			// The watch element gives up if it subscribes to the catalog before the
-			// publisher has announced it (RESET_STREAM). If nothing has decoded by the
-			// halfway mark, reload once to re-subscribe now that the publisher is up.
+			throwPageErrors(errors);
+			const state = await readPlayerState(page);
+			if (state.videoTimestamp !== undefined && state.painted && state.controlLabel === "Pause") {
+				playing = state;
+				break;
+			}
+			// Retry once after the publisher has had time to announce. This preserves
+			// the existing startup tolerance while the interaction checks below stay strict.
 			if (!reloaded && Date.now() - start > timeoutMs / 2) {
 				reloaded = true;
-				await page.reload({ waitUntil: "load" }).catch(() => {});
+				await page.reload({ waitUntil: "load" });
 			}
-			await new Promise((r) => setTimeout(r, 250));
+			await sleep(100);
 		}
-		console.error(`decoded ${frames} frames from ${broadcast}`);
-		code = frames > 0 ? 0 : 1;
+		if (!playing) {
+			const state = await readPlayerState(page);
+			throw new Error(`timed out waiting for rendered video: ${JSON.stringify(state)}`);
+		}
+
+		if (expectAudio) {
+			playing = await waitForState(page, errors, {
+				deadline,
+				description: "browser audio",
+				predicate: (state) => state.hasAudio && state.audioBytes > 0 && state.audioContext === "running",
+			});
+		}
+
+		// The chrome auto-hides while playing. Pointer activity reveals the real
+		// control, then the click must flow through the public player API.
+		await page.dispatchEvent("moq-watch-ui", "pointermove");
+		await page.locator("moq-watch-ui").locator('button.control[aria-label="Pause"]').click();
+		await waitForState(page, errors, {
+			deadline,
+			description: "paused player UI",
+			predicate: (state) =>
+				state.paused && state.pausedAttribute && state.controlLabel === "Play" && state.centerPlayVisible,
+		});
+		const paused = await waitForStablePause(page, errors, deadline);
+		if (!paused.painted) throw new Error(`pause cleared the preview frame: ${JSON.stringify(paused)}`);
+
+		await page.locator("moq-watch-ui").locator("button.center-play").click();
+		const resumed = await waitForState(page, errors, {
+			deadline,
+			description: "resumed playback",
+			predicate: (state) =>
+				!state.paused &&
+				!state.pausedAttribute &&
+				state.controlLabel === "Pause" &&
+				!state.centerPlayVisible &&
+				state.videoFrames > paused.videoFrames &&
+				state.videoTimestamp !== undefined &&
+				state.videoTimestamp > (paused.videoTimestamp ?? -1) &&
+				(!expectAudio || state.audioBytes > paused.audioBytes),
+		});
+
+		throwPageErrors(errors);
+		console.error(
+			`rendered, paused, and resumed ${broadcast}: video=${resumed.videoFrames} frames` +
+				(expectAudio ? ` audio=${resumed.audioBytes} bytes` : ""),
+		);
+		code = 0;
 	}
 } finally {
 	await browser.close().catch(() => {});

--- a/test/smoke/clients/js/driver.ts
+++ b/test/smoke/clients/js/driver.ts
@@ -215,10 +215,10 @@ try {
 		await new Promise(() => {}); // stream until the orchestrator kills us
 	} else {
 		const start = Date.now();
-		const deadline = start + timeoutMs;
+		const startupDeadline = start + timeoutMs;
 		let reloaded = false;
 		let playing: PlayerState | undefined;
-		while (Date.now() < deadline) {
+		while (Date.now() < startupDeadline) {
 			throwPageErrors(errors);
 			const state = await readPlayerState(page);
 			if (state.videoTimestamp !== undefined && state.painted && state.controlLabel === "Pause") {
@@ -238,9 +238,10 @@ try {
 			throw new Error(`timed out waiting for rendered video: ${JSON.stringify(state)}`);
 		}
 
+		const interactionDeadline = Date.now() + timeoutMs;
 		if (expectAudio) {
 			playing = await waitForState(page, errors, {
-				deadline,
+				deadline: interactionDeadline,
 				description: "browser audio",
 				predicate: (state) => state.hasAudio && state.audioBytes > 0 && state.audioContext === "running",
 			});
@@ -251,17 +252,17 @@ try {
 		await page.dispatchEvent(SELECTORS.ui, "pointermove");
 		await page.locator(SELECTORS.ui).locator(SELECTORS.pauseControl).click();
 		await waitForState(page, errors, {
-			deadline,
+			deadline: interactionDeadline,
 			description: "paused player UI",
 			predicate: (state) =>
 				state.paused && state.pausedAttribute && state.controlLabel === "Play" && state.centerPlayVisible,
 		});
-		const paused = await waitForStablePause(page, errors, deadline);
+		const paused = await waitForStablePause(page, errors, interactionDeadline);
 		if (!paused.painted) throw new Error(`pause cleared the preview frame: ${JSON.stringify(paused)}`);
 
 		await page.locator(SELECTORS.ui).locator(SELECTORS.centerPlay).click();
 		const resumed = await waitForState(page, errors, {
-			deadline,
+			deadline: interactionDeadline,
 			description: "resumed playback",
 			predicate: (state) =>
 				!state.paused &&

--- a/test/smoke/clients/js/package.json
+++ b/test/smoke/clients/js/package.json
@@ -2,6 +2,9 @@
 	"name": "@moq/smoke-browser",
 	"private": true,
 	"type": "module",
+	"scripts": {
+		"check": "tsc --noEmit"
+	},
 	"dependencies": {
 		"@moq/publish": "workspace:*",
 		"@moq/watch": "workspace:*"

--- a/test/smoke/clients/js/src/main.ts
+++ b/test/smoke/clients/js/src/main.ts
@@ -6,4 +6,5 @@
  */
 import "@moq/publish/element";
 import "@moq/watch/element";
+import "@moq/watch/ui";
 import "./setup.ts";

--- a/test/smoke/clients/js/src/setup.ts
+++ b/test/smoke/clients/js/src/setup.ts
@@ -1,6 +1,6 @@
 // Role logic for the browser client: read ?role= and wire up a <moq-publish> or
-// <moq-watch> element. The Playwright driver (driver.ts) polls the watch
-// element's decoded-frame stats to decide pass/fail.
+// the real <moq-watch-ui> player. The Playwright driver (driver.ts) checks
+// rendered playback and drives the player's controls.
 const params = new URLSearchParams(location.search);
 const role = params.get("role");
 const url = params.get("url") ?? "";
@@ -10,8 +10,8 @@ if (role === "publish") {
 	const el = document.createElement("moq-publish");
 	el.setAttribute("url", url);
 	el.setAttribute("name", broadcast);
-	el.setAttribute("muted", ""); // video only; keep the audio encoder out of it
-	// Chromium's --use-fake-device-for-media-stream feeds getUserMedia a pattern.
+	// Chromium's --use-fake-device-for-media-stream feeds getUserMedia fake
+	// camera and microphone input. Audio is encoded lazily when a player asks.
 	el.setAttribute("source", "camera");
 	document.body.appendChild(el);
 } else if (role === "subscribe") {
@@ -22,7 +22,10 @@ if (role === "publish") {
 	// the video track. @moq/publish only encodes on subscriber demand, so without
 	// this the publisher never produces frames.
 	el.appendChild(document.createElement("canvas"));
-	document.body.appendChild(el);
+
+	const player = document.createElement("moq-watch-ui");
+	player.appendChild(el);
+	document.body.appendChild(player);
 } else {
 	throw new Error("missing ?role=publish|subscribe");
 }

--- a/test/smoke/clients/js/tsconfig.json
+++ b/test/smoke/clients/js/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../../../js/tsconfig.json",
+	"compilerOptions": {
+		"types": ["bun", "vite/client"]
+	},
+	"include": ["driver.ts", "src", "vite.config.ts", "../../../../js/common/worklet.d.ts"]
+}

--- a/test/smoke/smoke.sh
+++ b/test/smoke/smoke.sh
@@ -9,9 +9,9 @@
 # other. There's no apt/brew/npm/PyPI here, just cargo/bun/uv/cc.
 #
 # It stands up a moq-relay, then for each publisher language publishes an H.264
-# broadcast and confirms every subscriber sees data flowing (a non-empty frame
-# before the timeout). We check that bytes move end-to-end across
-# implementations, not that H.264 decodes.
+# broadcast and confirms every subscriber sees data flowing before the timeout.
+# The browser also verifies rendered WebCodecs output, player pause/resume, and
+# audio when paired with the browser publisher.
 set -euo pipefail
 
 SMOKE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -218,6 +218,9 @@ prepare_js() {
         if [[ -z "${PLAYWRIGHT_BROWSERS_PATH:-}" ]] && ! (cd "$CLIENTS/js" && bunx playwright install chromium) >"$TMP/js-chromium.log" 2>&1; then
             mark_broken js "playwright chromium install failed"
             sed 's/^/        /' "$TMP/js-chromium.log" >&2 || true
+        elif ! (cd "$CLIENTS/js" && bun run check) >"$TMP/js-check.log" 2>&1; then
+            mark_broken js "type check failed"
+            sed 's/^/        /' "$TMP/js-check.log" >&2 || true
         elif ! (cd "$CLIENTS/js" && bunx vite build) >"$TMP/js-vite.log" 2>&1; then
             mark_broken js "vite build failed"
             sed 's/^/        /' "$TMP/js-vite.log" >&2 || true
@@ -383,7 +386,7 @@ run_native() {
 }
 
 run_subscriber() {
-    local lang="$1" broadcast="$2"
+    local lang="$1" broadcast="$2" publisher="${3:-}"
     case "$lang" in
         rust)
             # moq-cli only handles SIGINT, so -k forces SIGKILL if it ignores the
@@ -417,9 +420,16 @@ run_subscriber() {
             [[ "${n:-0}" -ge 1 ]]
             ;;
         js)
-            # Headless Chromium decodes via WebCodecs; exits 0 once a frame lands.
-            (cd "$CLIENTS/js" && bun driver.ts subscribe \
-                --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT")
+            # Headless Chromium decodes and renders via WebCodecs, then drives
+            # the real player's pause/resume controls. Browser publishers also
+            # provide fake microphone input, so validate audio in that cell.
+            if [[ "$publisher" == "js" ]]; then
+                (cd "$CLIENTS/js" && bun driver.ts subscribe \
+                    --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT" --expect-audio)
+            else
+                (cd "$CLIENTS/js" && bun driver.ts subscribe \
+                    --url "$URL" --broadcast "$broadcast" --timeout "$TIMEOUT")
+            fi
             ;;
         js-native-bun)
             # Native @moq/net via moq's WebTransport polyfill, under bun.
@@ -450,7 +460,7 @@ run_round() {
             overall=1
             continue
         fi
-        (run_subscriber "$sub" "$broadcast") >"$TMP/$pub-$sub.log" 2>&1 &
+        (run_subscriber "$sub" "$broadcast" "$pub") >"$TMP/$pub-$sub.log" 2>&1 &
         pids+=("$!")
         names+=("$sub")
     done


### PR DESCRIPTION
## Summary

- Verify that the browser subscriber decodes video and paints non-empty canvas output instead of relying only on received frame counts.
- Exercise the real watch UI pause and play controls, including stable paused media state and resumed progress.
- Cover browser-published audio by checking catalog discovery, received bytes, a running AudioContext, and pause/resume behavior.
- Fail browser smoke tests on uncaught page errors or console errors, and type-check the smoke client before building it.

The previous browser smoke assertion observed input frame counts, which increment before VideoDecoder output. It could therefore pass when decoding, rendering, player controls, or audio playback were broken.

## Public API changes

None. These changes only affect the smoke-test harness and its test page.

## Test plan

- `nix develop --command just js check`
- `nix develop --command just test smoke --publishers rust --subscribers js --timeout 30`
- `nix develop --command just test smoke --publishers js --subscribers js --timeout 30`
- `nix develop --command just test smoke --negative --subscribers js --timeout 5`
- Isolated cold build and JS-to-JS smoke run with `CARGO_TARGET_DIR=/private/tmp/moq-smoke-final`
- Biome, TypeScript, Vite build, ShellCheck, shfmt, and `git diff --check`

No cross-package synchronization row applies because production APIs and wire formats are unchanged.

(Written by GPT-5)
