### PR TITLE
fix(moq-gst): reconnect the moqsink publisher instead of dying on transport death

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2105,7 +2105,7 @@ dependencies = [
  "fastrand",
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -2277,7 +2277,7 @@ dependencies = [
  "diatomic-waker",
  "futures-core",
  "pin-project-lite",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -3725,7 +3725,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -7130,18 +7130,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spinning_top"

--- a/doc/bin/gstreamer.md
+++ b/doc/bin/gstreamer.md
@@ -30,13 +30,20 @@ Both elements support the following properties:
 For `http://` URLs, `moq-native` automatically fetches the server's certificate fingerprint from `/certificate.sha256` and verifies TLS against it. You don't need `tls-disable-verify` for local development.
 :::
 
-`moqsink` additionally exposes these read-only properties for monitoring:
+`moqsink` additionally exposes these read-only properties for monitoring. Each emits a `notify`
+signal when it changes, so you can poll it via `g_object_get` or connect to `notify::<property>`:
 
 | Property                 | Type   | Description                                                  |
 | ------------------------ | ------ | ----------------------------------------------------------- |
-| `connected`              | bool   | Whether the publish session is currently connected          |
+| `status`                 | enum   | Publish connection lifecycle: `disconnected` (retrying), `connected`, or `failed` (gave up) |
+| `connected`              | bool   | Whether the publish session is currently connected (`status == connected`) |
 | `moq-version`            | string | The negotiated MoQ protocol version; null when disconnected |
-| `estimated-send-bitrate` | uint64 | Estimated send bitrate in bits per second; 0 when unavailable |
+| `estimated-send-bitrate` | uint64 | Estimated send bitrate in bits per second (congestion controller); 0 when unavailable |
+| `estimated-recv-bitrate` | uint64 | Estimated receive bitrate in bits per second; 0 when unavailable |
+
+`status` distinguishes a transient drop (`disconnected`, the reconnect loop is still retrying) from a
+permanent give-up (`failed`, a non-retryable error such as an auth rejection), which a bare
+`connected` bool cannot.
 
 ## Prerequisites
 

--- a/rs/kio/src/tokio.rs
+++ b/rs/kio/src/tokio.rs
@@ -3,9 +3,8 @@
 //! Behind the `tokio` feature. Wraps a [`tokio::time::Sleep`] so a `poll_*` function can
 //! drive it against a [`Waiter`], keeping the rest of kio runtime-free.
 
-use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::Poll;
 
 use crate::Waiter;
 
@@ -26,8 +25,7 @@ impl Sleep {
 
 	/// Poll the sleep, registering `waiter` so the poll re-fires once it elapses.
 	pub fn poll(&mut self, waiter: &Waiter) -> Poll<()> {
-		let mut cx = Context::from_waker(waiter.waker());
-		self.inner.as_mut().poll(&mut cx)
+		waiter.poll_future(self.inner.as_mut())
 	}
 
 	/// Wait until the sleep elapses.

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -55,7 +55,7 @@ impl Waiter {
 	/// The bridge for the occasional non-kio source (a transport close, a timer) inside a poll
 	/// function otherwise driven by kio channels, so the whole thing stays a single `poll_*`. Pin the
 	/// future once, then poll it each step.
-	pub fn poll_future<F: Future>(&self, future: Pin<&mut F>) -> Poll<F::Output> {
+	pub fn poll_future<F: Future + ?Sized>(&self, future: Pin<&mut F>) -> Poll<F::Output> {
 		future.poll(&mut Context::from_waker(self.waker()))
 	}
 }
@@ -188,5 +188,9 @@ mod tests {
 		// A never-ready future stays pending.
 		let fut = std::pin::pin!(std::future::pending::<u8>());
 		assert_eq!(waiter.poll_future(fut), Poll::Pending);
+
+		// A type-erased future works too (the `?Sized` bound).
+		let mut boxed: Pin<Box<dyn Future<Output = u8>>> = Box::pin(std::future::ready(9u8));
+		assert_eq!(waiter.poll_future(boxed.as_mut()), Poll::Ready(9));
 	}
 }

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -43,12 +43,20 @@ impl Waiter {
 		list.register(self);
 	}
 
-	/// The underlying task [`Waker`], for driving a foreign future inside a `poll_*`
-	/// function. Build a [`Context`] from it and poll the future so that future
-	/// re-wakes this poll when it's ready, without kio itself taking a runtime
-	/// dependency.
+	/// The underlying task [`Waker`], for hand-rolling foreign-future integration. Prefer
+	/// [`poll_future`](Self::poll_future), which wraps the usual [`Context`] dance.
 	pub fn waker(&self) -> &Waker {
 		&self.waker
+	}
+
+	/// Poll a foreign [`std::future::Future`] against this waiter, so it re-wakes the enclosing
+	/// `poll_*` step when it's ready.
+	///
+	/// The bridge for the occasional non-kio source (a transport close, a timer) inside a poll
+	/// function otherwise driven by kio channels, so the whole thing stays a single `poll_*`. Pin the
+	/// future once, then poll it each step.
+	pub fn poll_future<F: Future>(&self, future: Pin<&mut F>) -> Poll<F::Output> {
+		future.poll(&mut Context::from_waker(self.waker()))
 	}
 }
 
@@ -162,5 +170,23 @@ where
 		// list so the inner poll function's register call can recycle it.
 		this.waiter = Some(Waiter::new(cx.waker().clone()));
 		(this.poll)(this.waiter.as_ref().unwrap())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn poll_future_bridges_a_std_future() {
+		let waiter = Waiter::noop();
+
+		// A ready future resolves through the waiter.
+		let fut = std::pin::pin!(std::future::ready(7u8));
+		assert_eq!(waiter.poll_future(fut), Poll::Ready(7));
+
+		// A never-ready future stays pending.
+		let fut = std::pin::pin!(std::future::pending::<u8>());
+		assert_eq!(waiter.poll_future(fut), Poll::Pending);
 	}
 }

--- a/rs/moq-gst/src/lib.rs
+++ b/rs/moq-gst/src/lib.rs
@@ -3,6 +3,9 @@ use gst::glib;
 mod sink;
 mod source;
 
+/// The `moqsink` publish connection lifecycle, exposed as its read-only `status` property.
+pub use sink::ConnectionStatus;
+
 use tracing::level_filters::LevelFilter;
 use tracing_subscriber::EnvFilter;
 

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -164,11 +164,11 @@ impl ObjectImpl for MoqSink {
 		match pspec.name() {
 			"connected" | "moq-version" | "estimated-send-bitrate" => {
 				let state = self.state.lock().unwrap();
-				let status = state.as_ref().map(|s| s.session.status());
+				let session = state.as_ref().map(|s| &s.session);
 				match pspec.name() {
-					"connected" => status.is_some_and(|s| s.connected()).to_value(),
-					"moq-version" => status.and_then(|s| s.version()).to_value(),
-					"estimated-send-bitrate" => status.map(|s| s.send_bitrate()).unwrap_or(0).to_value(),
+					"connected" => session.is_some_and(|s| s.status().connected()).to_value(),
+					"moq-version" => session.and_then(|s| s.status().version()).to_value(),
+					"estimated-send-bitrate" => session.map(|s| s.send_bitrate()).unwrap_or(0).to_value(),
 					_ => unreachable!(),
 				}
 			}

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -17,7 +17,7 @@ use gst::subclass::prelude::*;
 use hang::moq_net;
 
 use super::pad::{Pad, caps_supported};
-use super::session::{CAT, RUNTIME, ResolvedSettings, Session};
+use super::session::{CAT, ConnectionStatus, RUNTIME, ResolvedSettings, Session};
 
 #[derive(Debug, Clone, Default)]
 struct Settings {
@@ -129,10 +129,15 @@ impl ObjectImpl for MoqSink {
 					.blurb("Disable TLS verification")
 					.default_value(false)
 					.build(),
-				// Read-only, served from the live session's status.
+				// Read-only, served from the live session's status. Each notifies on change.
+				glib::ParamSpecEnum::builder::<ConnectionStatus>("status")
+					.nick("Connection status")
+					.blurb("Publish connection lifecycle: disconnected (retrying), connected, or failed (gave up)")
+					.read_only()
+					.build(),
 				glib::ParamSpecBoolean::builder("connected")
 					.nick("Connected")
-					.blurb("Whether the session is currently connected")
+					.blurb("Whether the session is currently connected (status == connected)")
 					.read_only()
 					.build(),
 				glib::ParamSpecString::builder("moq-version")
@@ -143,6 +148,11 @@ impl ObjectImpl for MoqSink {
 				glib::ParamSpecUInt64::builder("estimated-send-bitrate")
 					.nick("Estimated send bitrate")
 					.blurb("Estimated send bitrate in bits per second (congestion controller), 0 when unavailable")
+					.read_only()
+					.build(),
+				glib::ParamSpecUInt64::builder("estimated-recv-bitrate")
+					.nick("Estimated receive bitrate")
+					.blurb("Estimated receive bitrate in bits per second, 0 when unavailable")
 					.read_only()
 					.build(),
 			]
@@ -162,13 +172,15 @@ impl ObjectImpl for MoqSink {
 
 	fn property(&self, _id: usize, pspec: &glib::ParamSpec) -> glib::Value {
 		match pspec.name() {
-			"connected" | "moq-version" | "estimated-send-bitrate" => {
+			"status" | "connected" | "moq-version" | "estimated-send-bitrate" | "estimated-recv-bitrate" => {
 				let state = self.state.lock().unwrap();
 				let session = state.as_ref().map(|s| &s.session);
 				match pspec.name() {
+					"status" => session.map(|s| s.status().status()).unwrap_or_default().to_value(),
 					"connected" => session.is_some_and(|s| s.status().connected()).to_value(),
 					"moq-version" => session.and_then(|s| s.status().version()).to_value(),
 					"estimated-send-bitrate" => session.map(|s| s.send_bitrate()).unwrap_or(0).to_value(),
+					"estimated-recv-bitrate" => session.map(|s| s.recv_bitrate()).unwrap_or(0).to_value(),
 					_ => unreachable!(),
 				}
 			}

--- a/rs/moq-gst/src/sink/mod.rs
+++ b/rs/moq-gst/src/sink/mod.rs
@@ -6,6 +6,7 @@ mod pad;
 mod session;
 mod timeline;
 
+/// The `moqsink` publish connection lifecycle, exposed as its read-only `status` property.
 pub use session::ConnectionStatus;
 
 glib::wrapper! {

--- a/rs/moq-gst/src/sink/mod.rs
+++ b/rs/moq-gst/src/sink/mod.rs
@@ -6,6 +6,8 @@ mod pad;
 mod session;
 mod timeline;
 
+pub use session::ConnectionStatus;
+
 glib::wrapper! {
 	/// The `moqsink` element: publishes its `sink_%u` pads as a single MoQ broadcast, writing each pad's
 	/// frames directly into the moq producers from its streaming thread (no intermediate queue).

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -26,14 +26,35 @@ pub(crate) static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| 
 pub(crate) static CAT: LazyLock<gst::DebugCategory> =
 	LazyLock::new(|| gst::DebugCategory::new("moq-sink", gst::DebugColorFlags::empty(), Some("MoQ Sink Element")));
 
-/// The connect/version surface behind the `connected` and `moq-version` properties. One per session:
-/// the element swaps in a fresh `Arc` on every start, so a previous session's task (which may still be
-/// unwinding) writes only its own detached copy and can never clobber the live status. No generation
-/// bookkeeping needed. The send-bitrate property reads a [`moq_net::BandwidthConsumer`] directly, so it
-/// isn't mirrored here.
+/// The publish connection's lifecycle, surfaced as the `status` property.
+///
+/// Bundles what a bare `connected` bool can't: `Failed` (a terminal give-up) is distinct from
+/// `Disconnected` (a transient drop the reconnect loop is still retrying), so a consumer watching
+/// `notify::status` learns when a connection is newly established or permanently rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, glib::Enum)]
+#[enum_type(name = "GstMoqSinkConnectionStatus")]
+pub enum ConnectionStatus {
+	/// No live session: either the first connect is still pending or an established one dropped and a
+	/// reconnect is in flight.
+	#[default]
+	#[enum_value(name = "Disconnected: no live session, (re)connecting", nick = "disconnected")]
+	Disconnected,
+	/// A session is connected and publishing.
+	#[enum_value(name = "Connected: session established", nick = "connected")]
+	Connected,
+	/// The reconnect loop gave up permanently (a non-retryable error, e.g. auth rejection). Terminal.
+	#[enum_value(name = "Failed: connection rejected, gave up", nick = "failed")]
+	Failed,
+}
+
+/// The connect/version surface behind the `status`, `connected`, and `moq-version` properties. One per
+/// session: the element swaps in a fresh `Arc` on every start, so a previous session's task (which may
+/// still be unwinding) writes only its own detached copy and can never clobber the live status. No
+/// generation bookkeeping needed. The bitrate properties read a [`moq_net::BandwidthConsumer`] directly,
+/// so they aren't mirrored here.
 #[derive(Default)]
 struct StatusInner {
-	connected: bool,
+	status: ConnectionStatus,
 	version: Option<String>,
 }
 
@@ -44,24 +65,25 @@ pub struct Status {
 }
 
 impl Status {
-	fn set_connected(&self, value: bool) {
-		self.inner.lock().unwrap().connected = value;
+	/// Set the connection status and negotiated version together, so a `notify::status` handler that
+	/// re-reads `moq-version` sees the two consistent.
+	fn set(&self, status: ConnectionStatus, version: Option<String>) {
+		let mut inner = self.inner.lock().unwrap();
+		inner.status = status;
+		inner.version = version;
 	}
 
-	fn set_version(&self, value: Option<String>) {
-		self.inner.lock().unwrap().version = value;
+	/// The current connection lifecycle status.
+	pub fn status(&self) -> ConnectionStatus {
+		self.inner.lock().unwrap().status
 	}
 
-	fn reset(&self) {
-		*self.inner.lock().unwrap() = StatusInner::default();
-	}
-
-	/// Whether the session is currently connected.
+	/// Whether a session is currently connected.
 	pub fn connected(&self) -> bool {
-		self.inner.lock().unwrap().connected
+		self.inner.lock().unwrap().status == ConnectionStatus::Connected
 	}
 
-	/// The negotiated MoQ version, or None when disconnected.
+	/// The negotiated MoQ version, or None when not connected.
 	pub fn version(&self) -> Option<String> {
 		self.inner.lock().unwrap().version.clone()
 	}
@@ -78,14 +100,17 @@ pub struct ResolvedSettings {
 	pub tls_disable_verify: bool,
 }
 
-/// A running session: the connect/lifecycle task plus the state the property getters read. Dropping
-/// the producers (held by the element) and calling [`Session::stop`] tears it down.
+/// A running session: the connect/lifecycle task plus the state the property getters read. Dropping the
+/// `Session` (or the producers held by the element) tears it down.
 pub(crate) struct Session {
 	join: tokio::task::JoinHandle<()>,
 	status: Arc<Status>,
 	/// The live send-bitrate estimate, tracked across reconnects by the reconnect loop. Read directly
 	/// by the `estimated-send-bitrate` getter.
 	send_bandwidth: moq_net::BandwidthConsumer,
+	/// The live recv-bitrate estimate, tracked across reconnects by the reconnect loop. Read directly
+	/// by the `estimated-recv-bitrate` getter.
+	recv_bandwidth: moq_net::BandwidthConsumer,
 	/// Set by the task on a fatal transport error so the pad streaming threads stop feeding a dead session.
 	errored: Arc<AtomicBool>,
 }
@@ -124,8 +149,9 @@ impl Session {
 		config.backoff.timeout = std::time::Duration::ZERO;
 		let client = config.init()?.with_publish(origin.consume());
 		let reconnect = client.reconnect(settings.url.clone());
-		// A persistent handle that survives reconnects; the getter reads it without touching the loop.
+		// Persistent handles that survive reconnects; the getters read them without touching the loop.
 		let send_bandwidth = reconnect.send_bandwidth();
+		let recv_bandwidth = reconnect.recv_bandwidth();
 
 		let join = RUNTIME.spawn(forward(reconnect, origin, status.clone(), errored.clone(), element));
 
@@ -134,6 +160,7 @@ impl Session {
 				join,
 				status,
 				send_bandwidth,
+				recv_bandwidth,
 				errored,
 			},
 			broadcast,
@@ -151,27 +178,40 @@ impl Session {
 		self.send_bandwidth.peek().unwrap_or(0)
 	}
 
+	/// The estimated receive bitrate in bits per second, 0 when disconnected or unavailable.
+	pub fn recv_bitrate(&self) -> u64 {
+		self.recv_bandwidth.peek().unwrap_or(0)
+	}
+
 	/// Whether the transport has hit a fatal error (the pad streaming threads stop feeding it on this).
 	pub fn errored(&self) -> bool {
 		self.errored.load(Ordering::Relaxed)
 	}
 
-	/// Abort the task: a clean local close, never an error. The in-flight connect or idle loop is
-	/// cancelled at its next await point and the connection drops.
-	pub fn stop(self) {
+	/// Stop the session: a clean local close, never an error. [`Drop`] aborts the task, cancelling the
+	/// in-flight connect or reconnect loop at its next await point and dropping the connection.
+	pub fn stop(self) {}
+}
+
+impl Drop for Session {
+	fn drop(&mut self) {
+		// Abort on any teardown path (explicit `stop`, or the element dropped early) so the reconnect
+		// loop can't outlive the element.
 		self.join.abort();
 	}
 }
 
-/// Track the reconnect loop's connection status into the element's [`Status`] until the loop stops.
+/// Track the reconnect loop's observable state into the element's [`Status`] and fire GObject
+/// notifications until the loop stops.
 ///
-/// The reconnect loop owns the session; this task follows [`moq_native::Reconnect::status`] to mirror
-/// connected/version into the `Status` the `connected`/`moq-version` getters read, and to notify
-/// `connected` on each connect/disconnect edge. The send-bitrate property reads the loop's persistent
-/// [`moq_native::BandwidthConsumer`] directly, so it isn't handled here. The loop stops only on a
-/// terminal error (a non-retryable auth failure, or a bounded backoff's give-up), which the `Err`
-/// arm posts as a bus error, matching the old one-shot path. [`Session::stop`] aborts this task,
-/// which drops the `Reconnect` handle and quietly tears the loop down.
+/// The reconnect loop owns the session; this task follows [`moq_native::Reconnect`] to mirror
+/// status/version into the `Status` the getters read, and watches the persistent bandwidth consumers
+/// only to `notify` the bitrate properties (the getters read the estimates directly). Each source is
+/// notified on its own change: a status edge notifies `status`/`connected`/`moq-version` together, a
+/// bitrate change notifies just that bitrate. The loop stops only on a terminal error (a non-retryable
+/// auth failure, or a bounded backoff's give-up), which the `Err` arm posts as a bus error, matching
+/// the old one-shot path. [`Session`]'s `Drop` aborts this task, which drops the `Reconnect` handle and
+/// quietly tears the loop down.
 async fn forward(
 	mut reconnect: moq_native::Reconnect,
 	origin: moq_net::OriginProducer,
@@ -184,39 +224,55 @@ async fn forward(
 	// re-publishes it on each connect.
 	let _origin = origin;
 
+	// Persistent across reconnects; watched only to fire property notifications.
+	let mut send_bandwidth = reconnect.send_bandwidth();
+	let mut recv_bandwidth = reconnect.recv_bandwidth();
+
 	loop {
-		// `status()` resolves only on a change, so every `Ok` is a connect/disconnect edge.
-		match reconnect.status().await {
-			Ok(state) => {
-				let connected = state == moq_native::Status::Connected;
-				status.set_connected(connected);
-				status.set_version(reconnect.version().map(|v| v.to_string()));
-				if connected {
-					gst::info!(CAT, "session connected");
-				} else {
-					gst::warning!(CAT, "session disconnected, reconnecting");
+		tokio::select! {
+			// Poll status first: on a terminal error it is ready immediately, so we exit rather than
+			// spinning on the bandwidth channels the loop closes as it stops.
+			biased;
+
+			result = reconnect.status() => match result {
+				Ok(state) => {
+					let connection = match state {
+						moq_native::Status::Connected => ConnectionStatus::Connected,
+						moq_native::Status::Disconnected => ConnectionStatus::Disconnected,
+					};
+					status.set(connection, reconnect.version().map(|v| v.to_string()));
+					match state {
+						moq_native::Status::Connected => gst::info!(CAT, "session connected"),
+						moq_native::Status::Disconnected => gst::warning!(CAT, "session disconnected, reconnecting"),
+					}
+					notify(&element, &["status", "connected", "moq-version"]);
 				}
-				notify_connected(&element);
-			}
-			Err(err) => {
-				// The reconnect loop stopped on a terminal error (a non-retryable auth failure, or a
-				// bounded backoff's give-up). Reset the observable surface, flag `errored` so the pad
-				// threads stop feeding a dead session, and post a fatal element error.
-				status.reset();
-				notify_connected(&element);
-				errored.store(true, Ordering::Relaxed);
-				if let Some(obj) = element.upgrade() {
-					gst::element_error!(obj, gst::CoreError::Failed, ("session error"), ["{err:?}"]);
+				Err(err) => {
+					// The reconnect loop stopped on a terminal error (a non-retryable auth failure, or a
+					// bounded backoff's give-up). Flag `errored` so the pad threads stop feeding a dead
+					// session, and post a fatal element error.
+					status.set(ConnectionStatus::Failed, None);
+					notify(&element, &["status", "connected", "moq-version"]);
+					errored.store(true, Ordering::Relaxed);
+					if let Some(obj) = element.upgrade() {
+						gst::element_error!(obj, gst::CoreError::Failed, ("session error"), ["{err:?}"]);
+					}
+					return;
 				}
-				return;
-			}
+			},
+
+			_ = send_bandwidth.changed() => notify(&element, &["estimated-send-bitrate"]),
+			_ = recv_bandwidth.changed() => notify(&element, &["estimated-recv-bitrate"]),
 		}
 	}
 }
 
-/// Notify the `connected` property on the connect/disconnect edges, never per sample.
-fn notify_connected(element: &glib::WeakRef<Element>) {
+/// Emit a GObject `notify` for each named property, on the connect/disconnect/bitrate edges, never per
+/// sample.
+fn notify(element: &glib::WeakRef<Element>, props: &[&str]) {
 	if let Some(obj) = element.upgrade() {
-		obj.notify("connected");
+		for prop in props {
+			obj.notify(prop);
+		}
 	}
 }

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -26,14 +26,15 @@ pub(crate) static RUNTIME: LazyLock<tokio::runtime::Runtime> = LazyLock::new(|| 
 pub(crate) static CAT: LazyLock<gst::DebugCategory> =
 	LazyLock::new(|| gst::DebugCategory::new("moq-sink", gst::DebugColorFlags::empty(), Some("MoQ Sink Element")));
 
-/// The observable surface behind the read-only properties. One per session: the element swaps in a
-/// fresh `Arc` on every start, so a previous session's task (which may still be unwinding) writes only
-/// its own detached copy and can never clobber the live status. No generation bookkeeping needed.
+/// The connect/version surface behind the `connected` and `moq-version` properties. One per session:
+/// the element swaps in a fresh `Arc` on every start, so a previous session's task (which may still be
+/// unwinding) writes only its own detached copy and can never clobber the live status. No generation
+/// bookkeeping needed. The send-bitrate property reads a [`moq_net::BandwidthConsumer`] directly, so it
+/// isn't mirrored here.
 #[derive(Default)]
 struct StatusInner {
 	connected: bool,
 	version: Option<String>,
-	send_bitrate: u64,
 }
 
 /// Shared session status, read by the element's property getters and written by the session task.
@@ -51,10 +52,6 @@ impl Status {
 		self.inner.lock().unwrap().version = value;
 	}
 
-	fn set_send_bitrate(&self, bits_per_sec: u64) {
-		self.inner.lock().unwrap().send_bitrate = bits_per_sec;
-	}
-
 	fn reset(&self) {
 		*self.inner.lock().unwrap() = StatusInner::default();
 	}
@@ -67,11 +64,6 @@ impl Status {
 	/// The negotiated MoQ version, or None when disconnected.
 	pub fn version(&self) -> Option<String> {
 		self.inner.lock().unwrap().version.clone()
-	}
-
-	/// The congestion controller's send estimate in bits per second, 0 when unavailable.
-	pub fn send_bitrate(&self) -> u64 {
-		self.inner.lock().unwrap().send_bitrate
 	}
 }
 
@@ -86,11 +78,14 @@ pub struct ResolvedSettings {
 	pub tls_disable_verify: bool,
 }
 
-/// A running session: the connect/lifecycle task plus the status it writes. Dropping the producers
-/// (held by the element) and calling [`Session::stop`] tears it down.
+/// A running session: the connect/lifecycle task plus the state the property getters read. Dropping
+/// the producers (held by the element) and calling [`Session::stop`] tears it down.
 pub(crate) struct Session {
 	join: tokio::task::JoinHandle<()>,
 	status: Arc<Status>,
+	/// The live send-bitrate estimate, tracked across reconnects by the reconnect loop. Read directly
+	/// by the `estimated-send-bitrate` getter.
+	send_bandwidth: moq_net::BandwidthConsumer,
 	/// Set by the task on a fatal transport error so the pad streaming threads stop feeding a dead session.
 	errored: Arc<AtomicBool>,
 }
@@ -122,22 +117,38 @@ impl Session {
 		// backoff) rather than a one-shot connect that died on the first transport drop. `timeout = 0`
 		// retries transport/connection failures indefinitely so an unattended publisher outlives
 		// relay/QUIC outages; non-retryable errors (e.g. auth) stay terminal. During an outage the pad
-		// threads keep writing — bounded by moq-net's per-group eviction — and the relay catches up
+		// threads keep writing (bounded by moq-net's per-group eviction) and the relay catches up
 		// from a group boundary on reconnect. A bounded policy is available via `ClientConfig::backoff`.
 		let mut config = moq_native::ClientConfig::default();
 		config.tls.disable_verify = Some(settings.tls_disable_verify);
 		config.backoff.timeout = std::time::Duration::ZERO;
 		let client = config.init()?.with_publish(origin.consume());
 		let reconnect = client.reconnect(settings.url.clone());
+		// A persistent handle that survives reconnects; the getter reads it without touching the loop.
+		let send_bandwidth = reconnect.send_bandwidth();
 
 		let join = RUNTIME.spawn(forward(reconnect, origin, status.clone(), errored.clone(), element));
 
-		Ok((Self { join, status, errored }, broadcast, catalog))
+		Ok((
+			Self {
+				join,
+				status,
+				send_bandwidth,
+				errored,
+			},
+			broadcast,
+			catalog,
+		))
 	}
 
 	/// The live status, read by the element's property getters.
 	pub fn status(&self) -> &Arc<Status> {
 		&self.status
+	}
+
+	/// The congestion controller's send estimate in bits per second, 0 when disconnected or unavailable.
+	pub fn send_bitrate(&self) -> u64 {
+		self.send_bandwidth.peek().unwrap_or(0)
 	}
 
 	/// Whether the transport has hit a fatal error (the pad streaming threads stop feeding it on this).
@@ -152,14 +163,15 @@ impl Session {
 	}
 }
 
-/// Mirror the reconnect loop's observable state into the element's [`Status`] until the loop stops.
+/// Track the reconnect loop's connection status into the element's [`Status`] until the loop stops.
 ///
-/// The reconnect loop owns the session, so this task forwards each [`moq_native::Snapshot`]
-/// (connected/version/send-bitrate) into the status the property getters read, and notifies
-/// `connected` on the connect/disconnect edges. The loop stops only on a terminal error — a
-/// non-retryable auth failure, or (with a bounded backoff) a give-up — which the `Err` arm posts as
-/// a bus error, matching the old one-shot path. [`Session::stop`] aborts this task, which drops the
-/// `Reconnect` handle and quietly tears the loop down.
+/// The reconnect loop owns the session; this task follows [`moq_native::Reconnect::status`] to mirror
+/// connected/version into the `Status` the `connected`/`moq-version` getters read, and to notify
+/// `connected` on each connect/disconnect edge. The send-bitrate property reads the loop's persistent
+/// [`moq_native::BandwidthConsumer`] directly, so it isn't handled here. The loop stops only on a
+/// terminal error (a non-retryable auth failure, or a bounded backoff's give-up), which the `Err`
+/// arm posts as a bus error, matching the old one-shot path. [`Session::stop`] aborts this task,
+/// which drops the `Reconnect` handle and quietly tears the loop down.
 async fn forward(
 	mut reconnect: moq_native::Reconnect,
 	origin: moq_net::OriginProducer,
@@ -172,32 +184,26 @@ async fn forward(
 	// re-publishes it on each connect.
 	let _origin = origin;
 
-	let mut was_connected = false;
 	loop {
-		match reconnect.changed().await {
-			Ok(snapshot) => {
-				let connected = snapshot.status == Some(moq_native::Status::Connected);
+		// `status()` resolves only on a change, so every `Ok` is a connect/disconnect edge.
+		match reconnect.status().await {
+			Ok(state) => {
+				let connected = state == moq_native::Status::Connected;
 				status.set_connected(connected);
-				status.set_version(snapshot.version);
-				status.set_send_bitrate(snapshot.send_bitrate);
-				if connected != was_connected {
-					if connected {
-						gst::info!(CAT, "session connected");
-					} else {
-						gst::warning!(CAT, "session disconnected, reconnecting");
-					}
-					notify_connected(&element);
-					was_connected = connected;
+				status.set_version(reconnect.version().map(|v| v.to_string()));
+				if connected {
+					gst::info!(CAT, "session connected");
+				} else {
+					gst::warning!(CAT, "session disconnected, reconnecting");
 				}
+				notify_connected(&element);
 			}
 			Err(err) => {
 				// The reconnect loop stopped on a terminal error (a non-retryable auth failure, or a
 				// bounded backoff's give-up). Reset the observable surface, flag `errored` so the pad
 				// threads stop feeding a dead session, and post a fatal element error.
 				status.reset();
-				if was_connected {
-					notify_connected(&element);
-				}
+				notify_connected(&element);
 				errored.store(true, Ordering::Relaxed);
 				if let Some(obj) = element.upgrade() {
 					gst::element_error!(obj, gst::CoreError::Failed, ("session error"), ["{err:?}"]);

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -138,11 +138,10 @@ impl Session {
 		let status = Arc::new(Status::default());
 		let errored = Arc::new(AtomicBool::new(false));
 
-		// Publish through a background reconnect loop (connect, wait for close, reconnect with
-		// backoff) rather than a one-shot connect that died on the first transport drop. `timeout = 0`
-		// retries transport/connection failures indefinitely so an unattended publisher outlives
-		// relay/QUIC outages; non-retryable errors (e.g. auth) stay terminal. During an outage the pad
-		// threads keep writing (bounded by moq-net's per-group eviction) and the relay catches up
+		// Publish through a background reconnect loop: connect, wait for close, reconnect with backoff.
+		// `timeout = 0` retries transport/connection failures indefinitely so an unattended publisher
+		// outlives relay/QUIC outages; non-retryable errors (e.g. auth) stay terminal. During an outage
+		// the pad threads keep writing (bounded by moq-net's per-group eviction) and the relay catches up
 		// from a group boundary on reconnect. A bounded policy is available via `ClientConfig::backoff`.
 		let mut config = moq_native::ClientConfig::default();
 		config.tls.disable_verify = Some(settings.tls_disable_verify);
@@ -209,9 +208,9 @@ impl Drop for Session {
 /// only to `notify` the bitrate properties (the getters read the estimates directly). Each source is
 /// notified on its own change: a status edge notifies `status`/`connected`/`moq-version` together, a
 /// bitrate change notifies just that bitrate. The loop stops only on a terminal error (a non-retryable
-/// auth failure, or a bounded backoff's give-up), which the `Err` arm posts as a bus error, matching
-/// the old one-shot path. [`Session`]'s `Drop` aborts this task, which drops the `Reconnect` handle and
-/// quietly tears the loop down.
+/// auth failure, or a bounded backoff's give-up), which the `Err` arm posts as a bus error.
+/// [`Session`]'s `Drop` aborts this task, which drops the `Reconnect` handle and quietly tears the loop
+/// down.
 async fn forward(
 	mut reconnect: moq_native::Reconnect,
 	origin: moq_net::OriginProducer,

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -118,14 +118,12 @@ impl Session {
 		let status = Arc::new(Status::default());
 		let errored = Arc::new(AtomicBool::new(false));
 
-		// Hand the publish origin to a background reconnect loop: connect, wait for the session to
-		// close, then reconnect with exponential backoff. This replaces the previous one-shot connect
-		// that posted a fatal bus error on the first transport death — a relay restart or QUIC idle
-		// timeout left the publish permanently dead until the pipeline was rebuilt. `timeout = 0` means
-		// never give up, so an unattended publisher outlives arbitrary relay/transport outages; the
-		// pad threads keep writing across an outage (bounded by moq-net's per-group eviction) and the
-		// relay catches up from a group boundary on reconnect. A bounded retry policy is available via
-		// `ClientConfig::backoff` if a terminal error is preferred.
+		// Publish through a background reconnect loop (connect, wait for close, reconnect with
+		// backoff) rather than a one-shot connect that died on the first transport drop. `timeout = 0`
+		// retries transport/connection failures indefinitely so an unattended publisher outlives
+		// relay/QUIC outages; non-retryable errors (e.g. auth) stay terminal. During an outage the pad
+		// threads keep writing — bounded by moq-net's per-group eviction — and the relay catches up
+		// from a group boundary on reconnect. A bounded policy is available via `ClientConfig::backoff`.
 		let mut config = moq_native::ClientConfig::default();
 		config.tls.disable_verify = Some(settings.tls_disable_verify);
 		config.backoff.timeout = std::time::Duration::ZERO;
@@ -156,12 +154,12 @@ impl Session {
 
 /// Mirror the reconnect loop's observable state into the element's [`Status`] until the loop stops.
 ///
-/// The reconnect loop owns the session, so this task doesn't touch the transport — it forwards each
-/// [`moq_native::Snapshot`] (connected/version/send-bitrate) into the status the property getters
-/// read, and notifies `connected` on the connect/disconnect edges. With `backoff.timeout = 0` the
-/// loop never gives up, so the `Err` arm is a safety net (a bounded backoff would post the bus error
-/// there on final give-up, as the one-shot path did). [`Session::stop`] aborts this task, which drops
-/// the `Reconnect` handle and quietly tears the loop down.
+/// The reconnect loop owns the session, so this task forwards each [`moq_native::Snapshot`]
+/// (connected/version/send-bitrate) into the status the property getters read, and notifies
+/// `connected` on the connect/disconnect edges. The loop stops only on a terminal error — a
+/// non-retryable auth failure, or (with a bounded backoff) a give-up — which the `Err` arm posts as
+/// a bus error, matching the old one-shot path. [`Session::stop`] aborts this task, which drops the
+/// `Reconnect` handle and quietly tears the loop down.
 async fn forward(
 	mut reconnect: moq_native::Reconnect,
 	origin: moq_net::OriginProducer,
@@ -169,8 +167,9 @@ async fn forward(
 	errored: Arc<AtomicBool>,
 	element: glib::WeakRef<Element>,
 ) {
-	// `origin` is held for the task's lifetime so the published broadcast stays alive across every
-	// reconnect; the loop re-consumes it (a fresh publish leg) for each connection.
+	// Hold the origin producer for the task's lifetime so the published broadcast stays alive: the
+	// reconnecting client owns the consumer (taken once, via `origin.consume()` at start) and
+	// re-publishes it on each connect.
 	let _origin = origin;
 
 	let mut was_connected = false;
@@ -192,9 +191,9 @@ async fn forward(
 				}
 			}
 			Err(err) => {
-				// The reconnect loop permanently gave up (only reachable with a bounded backoff).
-				// Reset the observable surface, flag `errored` so the pad threads stop feeding a dead
-				// session, and post a fatal element error — matching the old one-shot failure path.
+				// The reconnect loop stopped on a terminal error (a non-retryable auth failure, or a
+				// bounded backoff's give-up). Reset the observable surface, flag `errored` so the pad
+				// threads stop feeding a dead session, and post a fatal element error.
 				status.reset();
 				if was_connected {
 					notify_connected(&element);

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -118,7 +118,21 @@ impl Session {
 		let status = Arc::new(Status::default());
 		let errored = Arc::new(AtomicBool::new(false));
 
-		let join = RUNTIME.spawn(run(settings, origin, status.clone(), errored.clone(), element));
+		// Hand the publish origin to a background reconnect loop: connect, wait for the session to
+		// close, then reconnect with exponential backoff. This replaces the previous one-shot connect
+		// that posted a fatal bus error on the first transport death — a relay restart or QUIC idle
+		// timeout left the publish permanently dead until the pipeline was rebuilt. `timeout = 0` means
+		// never give up, so an unattended publisher outlives arbitrary relay/transport outages; the
+		// pad threads keep writing across an outage (bounded by moq-net's per-group eviction) and the
+		// relay catches up from a group boundary on reconnect. A bounded retry policy is available via
+		// `ClientConfig::backoff` if a terminal error is preferred.
+		let mut config = moq_native::ClientConfig::default();
+		config.tls.disable_verify = Some(settings.tls_disable_verify);
+		config.backoff.timeout = std::time::Duration::ZERO;
+		let client = config.init()?.with_publish(origin.consume());
+		let reconnect = client.reconnect(settings.url.clone());
+
+		let join = RUNTIME.spawn(forward(reconnect, origin, status.clone(), errored.clone(), element));
 
 		Ok((Self { join, status, errored }, broadcast, catalog))
 	}
@@ -140,71 +154,57 @@ impl Session {
 	}
 }
 
-/// Connect, then idle on the transport until it closes or dies. A remote death is surfaced as an
-/// element error on the bus; [`Session::stop`] aborts this task instead, which is quiet.
-async fn run(
-	settings: ResolvedSettings,
+/// Mirror the reconnect loop's observable state into the element's [`Status`] until the loop stops.
+///
+/// The reconnect loop owns the session, so this task doesn't touch the transport — it forwards each
+/// [`moq_native::Snapshot`] (connected/version/send-bitrate) into the status the property getters
+/// read, and notifies `connected` on the connect/disconnect edges. With `backoff.timeout = 0` the
+/// loop never gives up, so the `Err` arm is a safety net (a bounded backoff would post the bus error
+/// there on final give-up, as the one-shot path did). [`Session::stop`] aborts this task, which drops
+/// the `Reconnect` handle and quietly tears the loop down.
+async fn forward(
+	mut reconnect: moq_native::Reconnect,
 	origin: moq_net::OriginProducer,
 	status: Arc<Status>,
 	errored: Arc<AtomicBool>,
 	element: glib::WeakRef<Element>,
 ) {
-	// `origin` is held for the task's lifetime so the published broadcast stays alive across the session.
-	let result = connect_and_run(&settings, &origin, &status, &element).await;
+	// `origin` is held for the task's lifetime so the published broadcast stays alive across every
+	// reconnect; the loop re-consumes it (a fresh publish leg) for each connection.
+	let _origin = origin;
 
-	// Reset the observable surface on exit. The Status arc is private to this session, so this never
-	// touches a newer session's status even if a new one started before this task unwound.
-	status.reset();
-	notify_connected(&element);
-
-	if let Err(err) = result {
-		errored.store(true, Ordering::Relaxed);
-		if let Some(obj) = element.upgrade() {
-			gst::element_error!(obj, gst::CoreError::Failed, ("session error"), ["{err:?}"]);
-		}
-	}
-}
-
-async fn connect_and_run(
-	settings: &ResolvedSettings,
-	origin: &moq_net::OriginProducer,
-	status: &Status,
-	element: &glib::WeakRef<Element>,
-) -> Result<()> {
-	let mut config = moq_native::ClientConfig::default();
-	config.tls.disable_verify = Some(settings.tls_disable_verify);
-	let client = config.init()?.with_publish(origin.consume());
-
-	// A stop() during connect aborts this task, cancelling the connect future cleanly.
-	let session = client.connect(settings.url.clone()).await?;
-	status.set_connected(true);
-	status.set_version(Some(session.version().to_string()));
-	notify_connected(element);
-	gst::info!(CAT, "session connected to {}", settings.url);
-
-	// Congestion-controller send estimate; None when unavailable, then this arm parks forever.
-	let mut send_bandwidth = session.send_bandwidth();
-	// Resolves to Err when the transport dies; pinned so the select polls it each iteration.
-	let closed = session.closed();
-	tokio::pin!(closed);
-
+	let mut was_connected = false;
 	loop {
-		tokio::select! {
-			// Remote death: propagate the Err so the wrapper posts an element error to the bus.
-			result = &mut closed => return Ok(result?),
-			bitrate = async {
-				match send_bandwidth.as_mut() {
-					Some(bw) => bw.changed().await,
-					None => std::future::pending::<Option<u64>>().await,
+		match reconnect.changed().await {
+			Ok(snapshot) => {
+				let connected = snapshot.status == Some(moq_native::Status::Connected);
+				status.set_connected(connected);
+				status.set_version(snapshot.version);
+				status.set_send_bitrate(snapshot.send_bitrate);
+				if connected != was_connected {
+					if connected {
+						gst::info!(CAT, "session connected");
+					} else {
+						gst::warning!(CAT, "session disconnected, reconnecting");
+					}
+					notify_connected(&element);
+					was_connected = connected;
 				}
-			} => match bitrate {
-				Some(rate) => status.set_send_bitrate(rate),
-				None => {
-					// Estimate gone: report 0 (the documented "unavailable" value) and stop polling.
-					status.set_send_bitrate(0);
-					send_bandwidth = None;
+			}
+			Err(err) => {
+				// The reconnect loop permanently gave up (only reachable with a bounded backoff).
+				// Reset the observable surface, flag `errored` so the pad threads stop feeding a dead
+				// session, and post a fatal element error — matching the old one-shot failure path.
+				status.reset();
+				if was_connected {
+					notify_connected(&element);
 				}
-			},
+				errored.store(true, Ordering::Relaxed);
+				if let Some(obj) = element.upgrade() {
+					gst::element_error!(obj, gst::CoreError::Failed, ("session error"), ["{err:?}"]);
+				}
+				return;
+			}
 		}
 	}
 }

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -44,10 +44,14 @@ fn missing_url_fails_state_change() {
 	let _ = sink.set_state(gst::State::Null);
 }
 
-// A connect that cannot succeed surfaces as an ERROR on the bus (not a silent log) and leaves the
-// element disconnected. The `.invalid` host fails fast at DNS resolution in this test environment.
+// A connect that cannot succeed does NOT post a fatal ERROR: the sink reconnects with backoff
+// (issue #2212), so an unattended publisher survives a relay that is unreachable at startup or
+// during an outage instead of tearing down the pipeline. It keeps retrying and stays disconnected.
+// (A non-retryable failure — e.g. auth rejection — is still terminal; that path needs a live relay
+// and is covered separately.) The `.invalid` host fails fast at DNS resolution, so the loop is
+// already several retries deep within the window below.
 #[test]
-fn connect_failure_posts_error_to_bus() {
+fn connect_failure_retries_without_erroring() {
 	init();
 	let pipeline = gst::Pipeline::new();
 	let sink = gst::ElementFactory::make("moqsink")
@@ -59,10 +63,16 @@ fn connect_failure_posts_error_to_bus() {
 
 	let _ = pipeline.set_state(gst::State::Playing);
 	let bus = pipeline.bus().expect("pipeline bus");
-	let msg = bus.timed_pop_filtered(gst::ClockTime::from_seconds(10), &[gst::MessageType::Error]);
+	let msg = bus.timed_pop_filtered(gst::ClockTime::from_seconds(3), &[gst::MessageType::Error]);
 	let connected = sink.property::<bool>("connected");
 	let _ = pipeline.set_state(gst::State::Null);
 
-	assert!(msg.is_some(), "a failed connect must post an ERROR to the bus");
-	assert!(!connected, "a failed connect must leave connected = false");
+	assert!(
+		msg.is_none(),
+		"a failed connect must NOT post an ERROR — the sink retries (issue #2212)"
+	);
+	assert!(
+		!connected,
+		"a failed connect must leave connected = false while retrying"
+	);
 }

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -61,7 +61,10 @@ fn connect_failure_retries_without_erroring() {
 		.expect("create moqsink");
 	pipeline.add(&sink).expect("add sink to pipeline");
 
-	let _ = pipeline.set_state(gst::State::Playing);
+	assert!(
+		pipeline.set_state(gst::State::Playing).is_ok(),
+		"a valid url + broadcast must let the Ready->Playing change start (connect runs in the background)"
+	);
 	let bus = pipeline.bus().expect("pipeline bus");
 	let msg = bus.timed_pop_filtered(gst::ClockTime::from_seconds(3), &[gst::MessageType::Error]);
 	let connected = sink.property::<bool>("connected");

--- a/rs/moq-gst/tests/element.rs
+++ b/rs/moq-gst/tests/element.rs
@@ -47,7 +47,7 @@ fn missing_url_fails_state_change() {
 // A connect that cannot succeed does NOT post a fatal ERROR: the sink reconnects with backoff
 // (issue #2212), so an unattended publisher survives a relay that is unreachable at startup or
 // during an outage instead of tearing down the pipeline. It keeps retrying and stays disconnected.
-// (A non-retryable failure — e.g. auth rejection — is still terminal; that path needs a live relay
+// (A non-retryable failure, e.g. auth rejection, is still terminal; that path needs a live relay
 // and is covered separately.) The `.invalid` host fails fast at DNS resolution, so the loop is
 // already several retries deep within the window below.
 #[test]
@@ -65,14 +65,22 @@ fn connect_failure_retries_without_erroring() {
 	let bus = pipeline.bus().expect("pipeline bus");
 	let msg = bus.timed_pop_filtered(gst::ClockTime::from_seconds(3), &[gst::MessageType::Error]);
 	let connected = sink.property::<bool>("connected");
+	let status = sink.property::<gstmoq::ConnectionStatus>("status");
+	let send_bitrate = sink.property::<u64>("estimated-send-bitrate");
+	let recv_bitrate = sink.property::<u64>("estimated-recv-bitrate");
 	let _ = pipeline.set_state(gst::State::Null);
 
 	assert!(
 		msg.is_none(),
-		"a failed connect must NOT post an ERROR — the sink retries (issue #2212)"
+		"a failed connect must NOT post an ERROR: the sink retries (issue #2212)"
 	);
 	assert!(
 		!connected,
 		"a failed connect must leave connected = false while retrying"
 	);
+	// While retrying, status stays Disconnected (a transient retry, not the terminal Failed) and the
+	// bitrate estimates read 0.
+	assert_eq!(status, gstmoq::ConnectionStatus::Disconnected);
+	assert_eq!(send_bitrate, 0);
+	assert_eq!(recv_bitrate, 0);
 }

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -2,6 +2,7 @@ use std::task::{Poll, ready};
 use std::time::Duration;
 
 use moq_net::kio;
+use moq_net::{BandwidthConsumer, BandwidthProducer, Version};
 use url::Url;
 
 use crate::{Client, Error};
@@ -71,25 +72,6 @@ pub enum Status {
 	Disconnected,
 }
 
-/// A snapshot of the live session's observable state, reported by [`Reconnect::changed`].
-///
-/// The reconnect loop owns the session, so a caller that needs the session's stats (a publisher
-/// element surfacing them as properties, say) reads them from here rather than holding the session
-/// itself. All fields reflect the *current* session and reset when it disconnects.
-///
-/// `#[non_exhaustive]`: read the fields you need; a future observable field won't be a breaking
-/// change. Construct via [`Default`] when a placeholder is needed.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct Snapshot {
-	/// Current connection status, or `None` before the first connect.
-	pub status: Option<Status>,
-	/// The negotiated MoQ version of the live session, or `None` when disconnected.
-	pub version: Option<String>,
-	/// The congestion controller's send estimate in bits/sec, `0` when disconnected or unavailable.
-	pub send_bitrate: u64,
-}
-
 /// Shared reconnect state, observed by consumers through a [`kio`] channel.
 ///
 /// The channel closing (all producers dropped) is the terminal signal; `error`
@@ -99,60 +81,69 @@ struct State {
 	/// Current connection status, or `None` before the first connect.
 	status: Option<Status>,
 	/// The negotiated MoQ version of the live session, or `None` when disconnected.
-	version: Option<String>,
-	/// The live session's congestion-controller send estimate (bits/sec); `0` when disconnected
-	/// or the backend has no estimate.
-	send_bitrate: u64,
+	version: Option<Version>,
 	/// Set when the reconnect loop permanently gives up (reconnect timeout exceeded).
 	error: Option<Error>,
-}
-
-impl State {
-	fn snapshot(&self) -> Snapshot {
-		Snapshot {
-			status: self.status,
-			version: self.version.clone(),
-			send_bitrate: self.send_bitrate,
-		}
-	}
 }
 
 /// Handle to a background reconnect loop.
 ///
 /// Spawns a tokio task that connects, waits for session close, then reconnects with exponential
-/// backoff. [`status`](Self::status) reports connection changes; [`closed`](Self::closed) waits for
-/// the loop to stop. Dropping the handle aborts the background task.
+/// backoff. The read surface mirrors [`moq_net::Session`] so a caller can treat it like a session
+/// that transparently reconnects: [`version`](Self::version), [`send_bandwidth`](Self::send_bandwidth),
+/// and [`recv_bandwidth`](Self::recv_bandwidth) track the live session and reset while disconnected.
+/// The extra toggle a plain session doesn't have is the connection lifecycle: [`connected`](Self::connected)
+/// reads it synchronously and [`status`](Self::status) waits for the next change. [`closed`](Self::closed)
+/// waits for the loop to stop. Dropping the handle aborts the background task.
 pub struct Reconnect {
 	abort: tokio::task::AbortHandle,
 	state: kio::Consumer<State>,
+	/// Persistent send-bitrate estimate, fed by the loop from each live session.
+	send_bandwidth: BandwidthConsumer,
+	/// Persistent recv-bitrate estimate, fed by the loop from each live session.
+	recv_bandwidth: BandwidthConsumer,
 	/// The last status returned by [`status`](Self::status), for change detection.
 	last_reported: Option<Status>,
-	/// The last snapshot returned by [`changed`](Self::changed), for change detection.
-	last_snapshot: Option<Snapshot>,
 }
 
 impl Reconnect {
 	pub(crate) fn new(client: Client, url: Url, backoff: Backoff) -> Self {
 		let producer = kio::Producer::<State>::default();
 		let state = producer.consume();
+
+		// The loop feeds these across every reconnect, so a consumer's handle survives session churn
+		// (unlike a session's own bandwidth consumer, which dies with the session).
+		let send_bw = BandwidthProducer::new();
+		let recv_bw = BandwidthProducer::new();
+		let send_bandwidth = send_bw.consume();
+		let recv_bandwidth = recv_bw.consume();
+
 		let task = tokio::spawn(async move {
-			if let Err(err) = Self::run(&producer, client, url, backoff).await {
+			if let Err(err) = Self::run(&producer, &send_bw, &recv_bw, client, url, backoff).await {
 				tracing::error!(%err, "reconnect loop exited");
 				if let Ok(mut state) = producer.write() {
 					state.error = Some(err);
 				}
 			}
-			// Dropping the producer here closes the channel, signaling consumers.
+			// Dropping the producers here closes the channels, signaling consumers.
 		});
 		Self {
 			abort: task.abort_handle(),
 			state,
+			send_bandwidth,
+			recv_bandwidth,
 			last_reported: None,
-			last_snapshot: None,
 		}
 	}
 
-	async fn run(state: &kio::Producer<State>, client: Client, url: Url, backoff: Backoff) -> crate::Result<()> {
+	async fn run(
+		state: &kio::Producer<State>,
+		send_bw: &BandwidthProducer,
+		recv_bw: &BandwidthProducer,
+		client: Client,
+		url: Url,
+		backoff: Backoff,
+	) -> crate::Result<()> {
 		let mut delay = backoff.initial;
 		let mut retry_start = tokio::time::Instant::now();
 		let mut last_error: Option<Error> = None;
@@ -174,19 +165,20 @@ impl Reconnect {
 					tracing::info!(%url, "connected");
 					if let Ok(mut state) = state.write() {
 						state.status = Some(Status::Connected);
-						state.version = Some(session.version().to_string());
-						state.send_bitrate = 0;
+						state.version = Some(session.version());
 					}
 
 					let connected = tokio::time::Instant::now();
-					// Wait for the session to close, forwarding its send-bandwidth estimate into the
-					// shared state meanwhile so a consumer tracks the live stats across the connection.
-					let closed = run_session(state, &session).await;
+					// Wait for the session to close, forwarding its bandwidth estimates into the
+					// persistent producers meanwhile so consumers track the live stats across the connection.
+					let closed = run_session(send_bw, recv_bw, &session).await;
 					if let Ok(mut state) = state.write() {
 						state.status = Some(Status::Disconnected);
 						state.version = None;
-						state.send_bitrate = 0;
 					}
+					// The estimates belonged to the now-closed session; reset until the next connect.
+					let _ = send_bw.set(None);
+					let _ = recv_bw.set(None);
 
 					if connected.elapsed() >= backoff.initial {
 						// Stayed up past the initial backoff: a healthy session. Reset the backoff
@@ -250,6 +242,39 @@ impl Reconnect {
 		kio::wait(|waiter| self.poll_status(waiter)).await
 	}
 
+	/// Whether a session is currently connected.
+	///
+	/// The synchronous read behind [`status`](Self::status), for callers that just want the current
+	/// state rather than the next change.
+	pub fn connected(&self) -> bool {
+		self.state.read().status == Some(Status::Connected)
+	}
+
+	/// The negotiated MoQ version of the live session, or `None` while disconnected.
+	///
+	/// The [`moq_net::Session::version`] counterpart; `Option` because a reconnecting handle can be
+	/// between sessions.
+	pub fn version(&self) -> Option<Version> {
+		self.state.read().version
+	}
+
+	/// A consumer for the live session's estimated send bitrate, mirroring
+	/// [`moq_net::Session::send_bandwidth`].
+	///
+	/// Unlike the session's, this handle is persistent: the reconnect loop forwards each session's
+	/// estimate into it, so it survives reconnects. Its value is `None` while disconnected or when the
+	/// backend has no estimate.
+	pub fn send_bandwidth(&self) -> BandwidthConsumer {
+		self.send_bandwidth.clone()
+	}
+
+	/// A consumer for the live session's estimated receive bitrate, mirroring
+	/// [`moq_net::Session::recv_bandwidth`]. Persistent across reconnects like
+	/// [`send_bandwidth`](Self::send_bandwidth); `None` while disconnected or unavailable.
+	pub fn recv_bandwidth(&self) -> BandwidthConsumer {
+		self.recv_bandwidth.clone()
+	}
+
 	/// Poll whether the reconnect loop has stopped.
 	///
 	/// `Ready(Err)` if it permanently gave up (reconnect timeout exceeded), `Ready(Ok(()))` if
@@ -266,84 +291,54 @@ impl Reconnect {
 	pub async fn closed(&self) -> crate::Result<()> {
 		kio::wait(|waiter| self.poll_closed(waiter)).await
 	}
-
-	/// Poll for the next change to the live session's observable [`Snapshot`] since this handle last
-	/// reported one.
-	///
-	/// `Ready(Ok(snapshot))` on any change (connect/disconnect, version, or send-bitrate),
-	/// `Ready(Err)` once the loop has stopped, `Pending` otherwise.
-	pub fn poll_changed(&mut self, waiter: &kio::Waiter) -> Poll<crate::Result<Snapshot>> {
-		let last = self.last_snapshot.clone();
-		let snapshot = match ready!(self.state.poll(waiter, |state| {
-			let snapshot = state.snapshot();
-			if Some(&snapshot) != last.as_ref() {
-				Poll::Ready(snapshot)
-			} else {
-				Poll::Pending
-			}
-		})) {
-			Ok(snapshot) => snapshot,
-			Err(state) => return Poll::Ready(Err(terminal(&state))),
-		};
-
-		self.last_snapshot = Some(snapshot.clone());
-		Poll::Ready(Ok(snapshot))
-	}
-
-	/// Wait until the live session's observable [`Snapshot`] changes from what this handle last
-	/// reported — a connect/disconnect, a version change, or a send-bitrate update — and return the
-	/// current snapshot. `Err` once the loop has stopped.
-	///
-	/// This is the stats-carrying counterpart to [`status`](Self::status): the reconnect loop owns
-	/// the session, so a caller that needs the live session's version/send-bitrate reads them here
-	/// instead of holding the session across reconnects.
-	pub async fn changed(&mut self) -> crate::Result<Snapshot> {
-		kio::wait(|waiter| self.poll_changed(waiter)).await
-	}
-
-	/// The negotiated MoQ version of the live session, or `None` when disconnected.
-	pub fn version(&self) -> Option<String> {
-		self.state.read().version.clone()
-	}
-
-	/// The live session's congestion-controller send estimate in bits/sec, `0` when disconnected or
-	/// unavailable.
-	pub fn send_bitrate(&self) -> u64 {
-		self.state.read().send_bitrate
-	}
 }
 
-/// Wait for `session` to close, forwarding its congestion-controller send estimate into `state`
-/// meanwhile so a [`Reconnect`] consumer tracks the live send-bitrate. Returns the session's close
-/// result (the reconnect loop uses it to distinguish a healthy drop from an immediate sever).
-async fn run_session(state: &kio::Producer<State>, session: &moq_net::Session) -> Result<(), moq_net::Error> {
-	// `None` when the QUIC backend has no bandwidth estimate; then that select arm parks forever.
-	let mut send_bandwidth = session.send_bandwidth();
+/// Wait for `session` to close, forwarding its send/recv bandwidth estimates into the persistent
+/// producers meanwhile so [`Reconnect`] consumers track the live estimates across the connection.
+/// Returns the session's close result (the loop uses it to distinguish a healthy drop from an
+/// immediate sever).
+async fn run_session(
+	send_bw: &BandwidthProducer,
+	recv_bw: &BandwidthProducer,
+	session: &moq_net::Session,
+) -> Result<(), moq_net::Error> {
+	// `None` when the backend/version has no estimate; then that select arm parks forever.
+	let mut send = session.send_bandwidth();
+	let mut recv = session.recv_bandwidth();
+
+	// Seed the current estimates so a consumer reads them without waiting for the first change.
+	let _ = send_bw.set(send.as_ref().and_then(|bw| bw.peek()));
+	let _ = recv_bw.set(recv.as_ref().and_then(|bw| bw.peek()));
+
 	let closed = session.closed();
 	tokio::pin!(closed);
 
 	loop {
 		tokio::select! {
 			result = &mut closed => return result,
-			bitrate = async {
-				match send_bandwidth.as_mut() {
+			rate = async {
+				match send.as_mut() {
 					Some(bw) => bw.changed().await,
 					None => std::future::pending::<Option<u64>>().await,
 				}
-			} => match bitrate {
-				Some(rate) => {
-					if let Ok(mut state) = state.write() {
-						state.send_bitrate = rate;
-					}
+			} => {
+				let _ = send_bw.set(rate);
+				// Estimate gone (or the session's producer dropped): stop polling this arm.
+				if rate.is_none() {
+					send = None;
 				}
-				None => {
-					// Estimate gone: report 0 (the documented "unavailable" value) and stop polling.
-					if let Ok(mut state) = state.write() {
-						state.send_bitrate = 0;
-					}
-					send_bandwidth = None;
+			}
+			rate = async {
+				match recv.as_mut() {
+					Some(bw) => bw.changed().await,
+					None => std::future::pending::<Option<u64>>().await,
 				}
-			},
+			} => {
+				let _ = recv_bw.set(rate);
+				if rate.is_none() {
+					recv = None;
+				}
+			}
 		}
 	}
 }
@@ -373,36 +368,5 @@ mod tests {
 		assert_eq!(backoff.multiplier, 2);
 		assert_eq!(backoff.max, Duration::from_secs(30));
 		assert_eq!(backoff.timeout, Duration::from_secs(300));
-	}
-
-	#[test]
-	fn snapshot_reflects_state_and_detects_change() {
-		// The observable surface `changed()`/`poll_changed()` forward is `State::snapshot()`, and the
-		// change filter is snapshot inequality — so every observable field must round-trip and a
-		// send-bitrate update alone must read as a distinct snapshot.
-		let mut state = State::default();
-		assert_eq!(state.snapshot(), Snapshot::default());
-
-		state.status = Some(Status::Connected);
-		state.version = Some("moq-lite-04".to_string());
-		state.send_bitrate = 2_000_000;
-		let connected = state.snapshot();
-		assert_eq!(connected.status, Some(Status::Connected));
-		assert_eq!(connected.version.as_deref(), Some("moq-lite-04"));
-		assert_eq!(connected.send_bitrate, 2_000_000);
-
-		// A send-bitrate change alone is a new snapshot (so a live estimate update wakes poll_changed).
-		state.send_bitrate = 2_100_000;
-		assert_ne!(state.snapshot(), connected);
-
-		// Disconnect clears version + bitrate but keeps the (distinct) Disconnected status.
-		state.status = Some(Status::Disconnected);
-		state.version = None;
-		state.send_bitrate = 0;
-		let disconnected = state.snapshot();
-		assert_eq!(disconnected.status, Some(Status::Disconnected));
-		assert_eq!(disconnected.version, None);
-		assert_eq!(disconnected.send_bitrate, 0);
-		assert_ne!(disconnected, connected);
 	}
 }

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -76,7 +76,11 @@ pub enum Status {
 /// The reconnect loop owns the session, so a caller that needs the session's stats (a publisher
 /// element surfacing them as properties, say) reads them from here rather than holding the session
 /// itself. All fields reflect the *current* session and reset when it disconnects.
+///
+/// `#[non_exhaustive]`: read the fields you need; a future observable field won't be a breaking
+/// change. Construct via [`Default`] when a placeholder is needed.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Snapshot {
 	/// Current connection status, or `None` before the first connect.
 	pub status: Option<Status>,

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -1,5 +1,4 @@
-use std::future::Future;
-use std::task::{Context, Poll, ready};
+use std::task::{Poll, ready};
 use std::time::Duration;
 
 use moq_net::kio;
@@ -314,7 +313,7 @@ async fn run_session(
 	kio::wait(|waiter| {
 		poll_forward(&mut send, send_bw, waiter);
 		poll_forward(&mut recv, recv_bw, waiter);
-		closed.as_mut().poll(&mut Context::from_waker(waiter.waker()))
+		waiter.poll_future(closed.as_mut())
 	})
 	.await
 }

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -71,6 +71,21 @@ pub enum Status {
 	Disconnected,
 }
 
+/// A snapshot of the live session's observable state, reported by [`Reconnect::changed`].
+///
+/// The reconnect loop owns the session, so a caller that needs the session's stats (a publisher
+/// element surfacing them as properties, say) reads them from here rather than holding the session
+/// itself. All fields reflect the *current* session and reset when it disconnects.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Snapshot {
+	/// Current connection status, or `None` before the first connect.
+	pub status: Option<Status>,
+	/// The negotiated MoQ version of the live session, or `None` when disconnected.
+	pub version: Option<String>,
+	/// The congestion controller's send estimate in bits/sec, `0` when disconnected or unavailable.
+	pub send_bitrate: u64,
+}
+
 /// Shared reconnect state, observed by consumers through a [`kio`] channel.
 ///
 /// The channel closing (all producers dropped) is the terminal signal; `error`
@@ -79,8 +94,23 @@ pub enum Status {
 struct State {
 	/// Current connection status, or `None` before the first connect.
 	status: Option<Status>,
+	/// The negotiated MoQ version of the live session, or `None` when disconnected.
+	version: Option<String>,
+	/// The live session's congestion-controller send estimate (bits/sec); `0` when disconnected
+	/// or the backend has no estimate.
+	send_bitrate: u64,
 	/// Set when the reconnect loop permanently gives up (reconnect timeout exceeded).
 	error: Option<Error>,
+}
+
+impl State {
+	fn snapshot(&self) -> Snapshot {
+		Snapshot {
+			status: self.status,
+			version: self.version.clone(),
+			send_bitrate: self.send_bitrate,
+		}
+	}
 }
 
 /// Handle to a background reconnect loop.
@@ -93,6 +123,8 @@ pub struct Reconnect {
 	state: kio::Consumer<State>,
 	/// The last status returned by [`status`](Self::status), for change detection.
 	last_reported: Option<Status>,
+	/// The last snapshot returned by [`changed`](Self::changed), for change detection.
+	last_snapshot: Option<Snapshot>,
 }
 
 impl Reconnect {
@@ -112,6 +144,7 @@ impl Reconnect {
 			abort: task.abort_handle(),
 			state,
 			last_reported: None,
+			last_snapshot: None,
 		}
 	}
 
@@ -137,12 +170,18 @@ impl Reconnect {
 					tracing::info!(%url, "connected");
 					if let Ok(mut state) = state.write() {
 						state.status = Some(Status::Connected);
+						state.version = Some(session.version().to_string());
+						state.send_bitrate = 0;
 					}
 
 					let connected = tokio::time::Instant::now();
-					let closed = session.closed().await;
+					// Wait for the session to close, forwarding its send-bandwidth estimate into the
+					// shared state meanwhile so a consumer tracks the live stats across the connection.
+					let closed = run_session(state, &session).await;
 					if let Ok(mut state) = state.write() {
 						state.status = Some(Status::Disconnected);
+						state.version = None;
+						state.send_bitrate = 0;
 					}
 
 					if connected.elapsed() >= backoff.initial {
@@ -223,6 +262,86 @@ impl Reconnect {
 	pub async fn closed(&self) -> crate::Result<()> {
 		kio::wait(|waiter| self.poll_closed(waiter)).await
 	}
+
+	/// Poll for the next change to the live session's observable [`Snapshot`] since this handle last
+	/// reported one.
+	///
+	/// `Ready(Ok(snapshot))` on any change (connect/disconnect, version, or send-bitrate),
+	/// `Ready(Err)` once the loop has stopped, `Pending` otherwise.
+	pub fn poll_changed(&mut self, waiter: &kio::Waiter) -> Poll<crate::Result<Snapshot>> {
+		let last = self.last_snapshot.clone();
+		let snapshot = match ready!(self.state.poll(waiter, |state| {
+			let snapshot = state.snapshot();
+			if Some(&snapshot) != last.as_ref() {
+				Poll::Ready(snapshot)
+			} else {
+				Poll::Pending
+			}
+		})) {
+			Ok(snapshot) => snapshot,
+			Err(state) => return Poll::Ready(Err(terminal(&state))),
+		};
+
+		self.last_snapshot = Some(snapshot.clone());
+		Poll::Ready(Ok(snapshot))
+	}
+
+	/// Wait until the live session's observable [`Snapshot`] changes from what this handle last
+	/// reported — a connect/disconnect, a version change, or a send-bitrate update — and return the
+	/// current snapshot. `Err` once the loop has stopped.
+	///
+	/// This is the stats-carrying counterpart to [`status`](Self::status): the reconnect loop owns
+	/// the session, so a caller that needs the live session's version/send-bitrate reads them here
+	/// instead of holding the session across reconnects.
+	pub async fn changed(&mut self) -> crate::Result<Snapshot> {
+		kio::wait(|waiter| self.poll_changed(waiter)).await
+	}
+
+	/// The negotiated MoQ version of the live session, or `None` when disconnected.
+	pub fn version(&self) -> Option<String> {
+		self.state.read().version.clone()
+	}
+
+	/// The live session's congestion-controller send estimate in bits/sec, `0` when disconnected or
+	/// unavailable.
+	pub fn send_bitrate(&self) -> u64 {
+		self.state.read().send_bitrate
+	}
+}
+
+/// Wait for `session` to close, forwarding its congestion-controller send estimate into `state`
+/// meanwhile so a [`Reconnect`] consumer tracks the live send-bitrate. Returns the session's close
+/// result (the reconnect loop uses it to distinguish a healthy drop from an immediate sever).
+async fn run_session(state: &kio::Producer<State>, session: &moq_net::Session) -> Result<(), moq_net::Error> {
+	// `None` when the QUIC backend has no bandwidth estimate; then that select arm parks forever.
+	let mut send_bandwidth = session.send_bandwidth();
+	let closed = session.closed();
+	tokio::pin!(closed);
+
+	loop {
+		tokio::select! {
+			result = &mut closed => return result,
+			bitrate = async {
+				match send_bandwidth.as_mut() {
+					Some(bw) => bw.changed().await,
+					None => std::future::pending::<Option<u64>>().await,
+				}
+			} => match bitrate {
+				Some(rate) => {
+					if let Ok(mut state) = state.write() {
+						state.send_bitrate = rate;
+					}
+				}
+				None => {
+					// Estimate gone: report 0 (the documented "unavailable" value) and stop polling.
+					if let Ok(mut state) = state.write() {
+						state.send_bitrate = 0;
+					}
+					send_bandwidth = None;
+				}
+			},
+		}
+	}
 }
 
 impl Drop for Reconnect {
@@ -250,5 +369,36 @@ mod tests {
 		assert_eq!(backoff.multiplier, 2);
 		assert_eq!(backoff.max, Duration::from_secs(30));
 		assert_eq!(backoff.timeout, Duration::from_secs(300));
+	}
+
+	#[test]
+	fn snapshot_reflects_state_and_detects_change() {
+		// The observable surface `changed()`/`poll_changed()` forward is `State::snapshot()`, and the
+		// change filter is snapshot inequality — so every observable field must round-trip and a
+		// send-bitrate update alone must read as a distinct snapshot.
+		let mut state = State::default();
+		assert_eq!(state.snapshot(), Snapshot::default());
+
+		state.status = Some(Status::Connected);
+		state.version = Some("moq-lite-04".to_string());
+		state.send_bitrate = 2_000_000;
+		let connected = state.snapshot();
+		assert_eq!(connected.status, Some(Status::Connected));
+		assert_eq!(connected.version.as_deref(), Some("moq-lite-04"));
+		assert_eq!(connected.send_bitrate, 2_000_000);
+
+		// A send-bitrate change alone is a new snapshot (so a live estimate update wakes poll_changed).
+		state.send_bitrate = 2_100_000;
+		assert_ne!(state.snapshot(), connected);
+
+		// Disconnect clears version + bitrate but keeps the (distinct) Disconnected status.
+		state.status = Some(Status::Disconnected);
+		state.version = None;
+		state.send_bitrate = 0;
+		let disconnected = state.snapshot();
+		assert_eq!(disconnected.status, Some(Status::Disconnected));
+		assert_eq!(disconnected.version, None);
+		assert_eq!(disconnected.send_bitrate, 0);
+		assert_ne!(disconnected, connected);
 	}
 }

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -1,4 +1,5 @@
-use std::task::{Poll, ready};
+use std::future::Future;
+use std::task::{Context, Poll, ready};
 use std::time::Duration;
 
 use moq_net::kio;
@@ -297,48 +298,41 @@ impl Reconnect {
 /// producers meanwhile so [`Reconnect`] consumers track the live estimates across the connection.
 /// Returns the session's close result (the loop uses it to distinguish a healthy drop from an
 /// immediate sever).
+///
+/// One `poll_*` step drives it all: [`poll_forward`] mirrors each kio bandwidth estimate, and the
+/// transport's close future (the one non-kio source) is polled through the waiter's own waker.
 async fn run_session(
 	send_bw: &BandwidthProducer,
 	recv_bw: &BandwidthProducer,
 	session: &moq_net::Session,
 ) -> Result<(), moq_net::Error> {
-	// `None` when the backend/version has no estimate; then that select arm parks forever.
 	let mut send = session.send_bandwidth();
 	let mut recv = session.recv_bandwidth();
-
-	// Seed the current estimates so a consumer reads them without waiting for the first change.
-	let _ = send_bw.set(send.as_ref().and_then(|bw| bw.peek()));
-	let _ = recv_bw.set(recv.as_ref().and_then(|bw| bw.peek()));
-
 	let closed = session.closed();
 	tokio::pin!(closed);
 
+	kio::wait(|waiter| {
+		poll_forward(&mut send, send_bw, waiter);
+		poll_forward(&mut recv, recv_bw, waiter);
+		closed.as_mut().poll(&mut Context::from_waker(waiter.waker()))
+	})
+	.await
+}
+
+/// Mirror `bw`'s live estimate into `out` for as long as it changes, dropping the source handle once
+/// the backend stops reporting (`None`) so we don't keep polling a dead arm. A `poll_*` step: on
+/// return, `waiter` is registered for the next change (unless the source is gone). Seeding is implicit
+/// (the first call forwards the current value if there is one).
+fn poll_forward(bw: &mut Option<BandwidthConsumer>, out: &BandwidthProducer, waiter: &kio::Waiter) {
 	loop {
-		tokio::select! {
-			result = &mut closed => return result,
-			rate = async {
-				match send.as_mut() {
-					Some(bw) => bw.changed().await,
-					None => std::future::pending::<Option<u64>>().await,
-				}
-			} => {
-				let _ = send_bw.set(rate);
-				// Estimate gone (or the session's producer dropped): stop polling this arm.
-				if rate.is_none() {
-					send = None;
-				}
-			}
-			rate = async {
-				match recv.as_mut() {
-					Some(bw) => bw.changed().await,
-					None => std::future::pending::<Option<u64>>().await,
-				}
-			} => {
-				let _ = recv_bw.set(rate);
-				if rate.is_none() {
-					recv = None;
-				}
-			}
+		let Some(consumer) = bw.as_mut() else { return };
+		let Poll::Ready(rate) = consumer.poll_changed(waiter) else {
+			return;
+		};
+		let _ = out.set(rate);
+		if rate.is_none() {
+			*bw = None;
+			return;
 		}
 	}
 }
@@ -368,5 +362,35 @@ mod tests {
 		assert_eq!(backoff.multiplier, 2);
 		assert_eq!(backoff.max, Duration::from_secs(30));
 		assert_eq!(backoff.timeout, Duration::from_secs(300));
+	}
+
+	#[test]
+	fn poll_forward_mirrors_then_drops_on_none() {
+		let src = BandwidthProducer::new();
+		let out = BandwidthProducer::new();
+		let out_rx = out.consume();
+		let waiter = kio::Waiter::noop();
+
+		// No estimate yet: nothing forwarded, source retained.
+		let mut bw = Some(src.consume());
+		poll_forward(&mut bw, &out, &waiter);
+		assert_eq!(out_rx.peek(), None);
+		assert!(bw.is_some());
+
+		// A value is mirrored through.
+		src.set(Some(3_000)).unwrap();
+		poll_forward(&mut bw, &out, &waiter);
+		assert_eq!(out_rx.peek(), Some(3_000));
+
+		// Going None mirrors the None and drops the source, so we stop polling a dead arm.
+		src.set(None).unwrap();
+		poll_forward(&mut bw, &out, &waiter);
+		assert_eq!(out_rx.peek(), None);
+		assert!(bw.is_none());
+
+		// Source gone: a later value on the (now-defunct) session's producer is ignored.
+		src.set(Some(9_000)).unwrap();
+		poll_forward(&mut bw, &out, &waiter);
+		assert_eq!(out_rx.peek(), None);
 	}
 }


### PR DESCRIPTION
Closes the moqsink half of #2212. Supersedes #2223 (built on @bgreenway's reconnect commits, authorship preserved) and the closed #2237.

### Problem
`moqsink` did a one-shot `client.connect()` and posted a fatal `element_error` on any transport death (relay restart, QUIC idle timeout, a transient blip), permanently killing the publish until the whole pipeline was rebuilt. Fatal for an unattended 24/7 publisher.

### Fix
Switch the sink to the `moq-native` reconnect primitive (`Client::reconnect`) with `backoff.timeout = 0`: retryable transport failures reconnect forever, while a non-retryable error (auth rejection) stays terminal and still posts the fatal element error. Pads keep writing across an outage (bounded by moq-net's per-group eviction) and the relay catches up from a group boundary on reconnect.

### `Reconnect` mirrors `Session`
moqsink's read-only properties need the live session's state, which the reconnect loop now owns. Rather than a bespoke value-copy, `Reconnect`'s read surface **mirrors `moq_net::Session`** so a caller can treat it like a session that transparently reconnects:

- `version() -> Option<Version>` (Session's type; `Option` because a reconnecting handle can be between sessions).
- `send_bandwidth()` / `recv_bandwidth() -> BandwidthConsumer`, mirroring `Session::{send,recv}_bandwidth`. Unlike the session's, these are **persistent**: the loop forwards each session's estimate into them, so a consumer's handle survives reconnects. `None` while disconnected or when the backend has no estimate.
- `connected() -> bool`, the `&self` read behind `status()`.

### moqsink observability: bundled status + notify + recv bitrate
Reworked so a monitor can **watch, not just poll**, and can tell a transient drop from a permanent give-up (per @bgreenway: their fleet polls these off moqsink for trailer telemetry):

- New **`status`** enum property (`disconnected` / `connected` / `failed`). `failed` = terminal give-up (non-retryable, e.g. auth); `disconnected` = transient drop still being retried. A bare `connected` bool can't express that. `connected` + `moq-version` are kept (fleet reads them) and update in lockstep with `status`.
- New **`estimated-recv-bitrate`** alongside `estimated-send-bitrate`, read straight off the persistent recv `BandwidthConsumer`.
- **All read-only properties now `notify` on change** — a status edge notifies `status`/`connected`/`moq-version` together; a bitrate change notifies just that bitrate. So a consumer can `g_signal_connect(..., "notify::status", ...)` instead of polling.
- `Session` aborts its task on `Drop`, so the reconnect loop can't outlive the element on early teardown.

Kept the `estimated-send-bitrate` name (not `-send-rate`) so the fleet's `g_object_get` telemetry keeps working; `estimated-recv-bitrate` matches it. Easy to rename both if you'd prefer `-rate`.

### Cross-package sync
`doc/bin/gstreamer.md` monitoring table updated with `status` + `estimated-recv-bitrate` and the notify behavior.

### Validation
`clippy --all-features`, `fmt --check`, `cargo doc -D warnings`, and tests all clean on `moq-native` (63+19+8) + `moq-gst` (34 lib + 3 element, incl. `connect_failure_retries_without_erroring` now asserting `status == disconnected` and both bitrates 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)