### PR TITLE
refactor(watch)!: shorten signal input and output groups

### DIFF
--- a/demo/web/src/index.ts
+++ b/demo/web/src/index.ts
@@ -13,7 +13,7 @@
  *
  * The per-stream metadata rides on a separate `meta.json` track within the active
  * broadcast (advertised in the catalog's `metadata` list); we subscribe to it off
- * the tile's `broadcast.output.active` consumer and decode it with @moq/json.
+ * the tile's `broadcast.out.active` consumer and decode it with @moq/json.
  */
 
 import "./highlight";
@@ -145,7 +145,7 @@ function createTile(name: string): WatchTile {
 	// an audio track to play.
 	effects.run((effect) => {
 		const isActive = effect.get(active) === name;
-		const hasAudio = !!effect.get(watch.broadcast.output.catalog)?.audio;
+		const hasAudio = !!effect.get(watch.broadcast.out.catalog)?.audio;
 		audioBadge.hidden = !(isActive && hasAudio);
 	});
 
@@ -285,7 +285,7 @@ ui.run((effect) => {
 // Broadcast pill: Online when the active broadcast is live, else Loading/Offline.
 ui.run((effect) => {
 	const watch = effect.get(activeWatch);
-	const stream = watch ? effect.get(watch.broadcast.output.status) : "offline"; // offline | loading | live
+	const stream = watch ? effect.get(watch.broadcast.out.status) : "offline"; // offline | loading | live
 	if (stream === "live") setPill("bcast-status", "bcast-text", "Online", "ok");
 	else if (watch && stream === "loading") setPill("bcast-status", "bcast-text", "Loading", "wait");
 	else setPill("bcast-status", "bcast-text", "Offline", "bad");
@@ -295,7 +295,7 @@ ui.run((effect) => {
 // the video track config from the catalog plus live decode stats.
 ui.run((effect) => {
 	const watch = effect.get(activeWatch);
-	const catalog = watch ? effect.get(watch.broadcast.output.catalog) : undefined;
+	const catalog = watch ? effect.get(watch.broadcast.out.catalog) : undefined;
 	const video = catalog?.video;
 	const section = $("video-section");
 	if (!watch || !video) {
@@ -304,8 +304,8 @@ ui.run((effect) => {
 	}
 	section.hidden = false;
 
-	const stalled = effect.get(watch.backend.video.output.stalled);
-	const live = effect.get(watch.broadcast.output.status) === "live";
+	const stalled = effect.get(watch.backend.video.out.stalled);
+	const live = effect.get(watch.broadcast.out.status) === "live";
 	const r = Object.values(video.renditions)[0];
 
 	const resolution =
@@ -328,7 +328,7 @@ ui.run((effect) => {
 // Audio section: only shown when the active catalog has an audio section.
 ui.run((effect) => {
 	const watch = effect.get(activeWatch);
-	const catalog = watch ? effect.get(watch.broadcast.output.catalog) : undefined;
+	const catalog = watch ? effect.get(watch.broadcast.out.catalog) : undefined;
 	const audio = catalog?.audio;
 	const section = $("audio-section");
 	if (!watch || !audio) {
@@ -361,8 +361,8 @@ ui.run((effect) => {
 	const conn = effect.get(connection.established);
 	$("network-transport").textContent = conn ? (conn.transport === "websocket" ? "WebSocket" : "WebTransport") : "";
 
-	const video = effect.get(watch.backend.video.output.stats);
-	const audio = effect.get(watch.backend.audio.output.stats);
+	const video = effect.get(watch.backend.video.out.stats);
+	const audio = effect.get(watch.backend.audio.out.stats);
 	const bytes = (video?.bytesReceived ?? 0) + (audio?.bytesReceived ?? 0);
 	renderRows($("network-info"), [["bytes received", bytes > 0 ? formatBytes(bytes) : undefined]]);
 });
@@ -370,7 +370,7 @@ ui.run((effect) => {
 // Raw catalog (collapsible) - only rendered once the active catalog arrives.
 ui.run((effect) => {
 	const watch = effect.get(activeWatch);
-	const catalog = watch ? effect.get(watch.broadcast.output.catalog) : undefined;
+	const catalog = watch ? effect.get(watch.broadcast.out.catalog) : undefined;
 	const section = $("catalog-raw-section");
 	if (!catalog) {
 		section.hidden = true;
@@ -386,7 +386,7 @@ ui.run((effect) => {
 //
 // The publish demo serves its metadata as a separate `meta.json` track, advertised
 // in the catalog's `metadata` list. We read the active broadcast off
-// `broadcast.output.active`, subscribe to that track, and decode the JSON value,
+// `broadcast.out.active`, subscribe to that track, and decode the JSON value,
 // re-subscribing whenever the broadcast (or the advertised track) changes.
 // Memoize the advertised track name so the subscription below only re-runs when it
 // (or the active broadcast) changes, not on every catalog frame (e.g. a live
@@ -394,13 +394,13 @@ ui.run((effect) => {
 const metaTrackName = ui.computed((effect) => {
 	const watch = effect.get(activeWatch);
 	if (!watch) return undefined;
-	const catalog = effect.get(watch.broadcast.output.catalog) as { metadata?: string[] } | undefined;
+	const catalog = effect.get(watch.broadcast.out.catalog) as { metadata?: string[] } | undefined;
 	return catalog?.metadata?.[0];
 });
 
 ui.run((effect) => {
 	const watch = effect.get(activeWatch);
-	const broadcast = watch ? effect.get(watch.broadcast.output.active) : undefined;
+	const broadcast = watch ? effect.get(watch.broadcast.out.active) : undefined;
 	const trackName = effect.get(metaTrackName);
 	if (!broadcast || !trackName) {
 		metaSignal.set(undefined);
@@ -431,7 +431,7 @@ ui.run((effect) => {
 ui.run((effect) => {
 	const meta = effect.get(metaSignal);
 	const watch = effect.get(activeWatch);
-	const live = watch ? effect.get(watch.broadcast.output.status) === "live" : false;
+	const live = watch ? effect.get(watch.broadcast.out.status) === "live" : false;
 	const section = $("metadata-section");
 	const pre = $("metadata");
 	if (live && meta !== undefined) {
@@ -479,8 +479,8 @@ viz.interval(() => {
 		return;
 	}
 
-	const v = watch.backend.video.output.stats.peek();
-	const a = watch.backend.audio.output.stats.peek();
+	const v = watch.backend.video.out.stats.peek();
+	const a = watch.backend.audio.out.stats.peek();
 	const videoBytes = v?.bytesReceived ?? 0;
 	const totalBytes = videoBytes + (a?.bytesReceived ?? 0);
 	const frames = v?.frameCount ?? 0;
@@ -510,7 +510,7 @@ viz.interval(() => {
 // one element and runs its own animation loop until its child effect closes.
 ui.run((effect) => {
 	const watch = effect.get(activeWatch);
-	const live = watch ? effect.get(watch.broadcast.output.status) === "live" : false;
+	const live = watch ? effect.get(watch.broadcast.out.status) === "live" : false;
 	const section = $("buffer-section");
 	const host = $("buffer-viz");
 	host.replaceChildren();

--- a/demo/web/src/viz.ts
+++ b/demo/web/src/viz.ts
@@ -290,12 +290,12 @@ export function bufferBars(parent: Signals.Effect, watch: MoqWatch): HTMLElement
 					: 0;
 		if (delta === 0) return;
 		e.preventDefault();
-		setLatency((watch.backend.output.jitter.peek() as unknown as number) + delta);
+		setLatency((watch.backend.out.jitter.peek() as unknown as number) + delta);
 	});
 
 	// Position the target line from the live jitter (actual measured buffer in ms).
 	parent.run((effect) => {
-		const jitter = effect.get(watch.backend.output.jitter) as unknown as number;
+		const jitter = effect.get(watch.backend.out.jitter) as unknown as number;
 		const pct = Math.max(0, Math.min(1, jitter / BUFFER_MAX)) * 100;
 		target.style.left = `${pct}%`;
 		targetLabel.textContent = `${Math.round(jitter)}ms`;
@@ -305,9 +305,9 @@ export function bufferBars(parent: Signals.Effect, watch: MoqWatch): HTMLElement
 	// Repaint the bars every animation frame; cleaned up when the effect closes.
 	const draw = () => {
 		const timestamp = watch.backend.sync.now() as number | undefined;
-		const stalled = watch.backend.video.output.stalled.peek();
-		drawRanges(video.canvas, watch.backend.video.output.buffered.peek(), timestamp, stalled);
-		drawRanges(audio.canvas, watch.backend.audio.output.buffered.peek(), timestamp, false);
+		const stalled = watch.backend.video.out.stalled.peek();
+		drawRanges(video.canvas, watch.backend.video.out.buffered.peek(), timestamp, stalled);
+		drawRanges(audio.canvas, watch.backend.audio.out.buffered.peek(), timestamp, false);
 		parent.animate(draw);
 	};
 	parent.animate(draw);

--- a/js/moq-boy/src/game.ts
+++ b/js/moq-boy/src/game.ts
@@ -138,8 +138,8 @@ export class Game {
 		this.sync = new Watch.Sync({
 			latency: this.latency,
 			connection: connection.established,
-			video: this.videoSource.output.jitter,
-			audio: this.audioSource.output.jitter,
+			video: this.videoSource.out.jitter,
+			audio: this.audioSource.out.jitter,
 		});
 		this.#signals.cleanup(() => this.sync.close());
 
@@ -174,7 +174,7 @@ export class Game {
 		// Resume AudioContext on first user interaction (browser autoplay policy).
 		for (const event of ["click", "touchstart", "touchend", "mousedown", "keydown"]) {
 			this.#signals.event(document, event, () => {
-				const ctx = this.audioDecoder.output.context.peek();
+				const ctx = this.audioDecoder.out.context.peek();
 				if (ctx?.state === "suspended") ctx.resume();
 			});
 		}
@@ -204,11 +204,11 @@ export class Game {
 	/** Collect media timestamps at each pipeline stage for latency measurement. */
 	#timestamps(): { label: string; ts: number }[] {
 		const entries: { label: string; ts: number }[] = [];
-		const received = this.sync.output.timestamp.peek();
+		const received = this.sync.out.timestamp.peek();
 		if (received != null) entries.push({ label: "received", ts: received });
-		const decoded = this.videoDecoder.output.timestamp.peek();
+		const decoded = this.videoDecoder.out.timestamp.peek();
 		if (decoded != null) entries.push({ label: "decoded", ts: decoded });
-		const rendered = this.videoRenderer.output.timestamp.peek();
+		const rendered = this.videoRenderer.out.timestamp.peek();
 		if (rendered != null) entries.push({ label: "rendered", ts: rendered });
 		return entries;
 	}
@@ -235,7 +235,7 @@ export class Game {
 
 	#runVideoEnabled(videoEnabled: Moq.Signals.Signal<boolean>, effect: Moq.Signals.Effect) {
 		const exp = effect.get(this.expanded);
-		const visible = effect.get(this.videoRenderer.output.visible);
+		const visible = effect.get(this.videoRenderer.out.visible);
 		// On the grid or when expanded, but never download an off-screen tile.
 		videoEnabled.set((exp === undefined || exp === this.sessionId) && visible);
 	}
@@ -246,7 +246,7 @@ export class Game {
 	}
 
 	#runStatus(effect: Moq.Signals.Effect) {
-		const active = effect.get(this.broadcast.output.active);
+		const active = effect.get(this.broadcast.out.active);
 		if (!active) return;
 
 		const statusTrack = active.subscribe("status", { priority: 10 });

--- a/js/moq-boy/src/ui/components/StatsPanel.tsx
+++ b/js/moq-boy/src/ui/components/StatsPanel.tsx
@@ -7,7 +7,7 @@ export default function StatsPanel() {
 	const ctx = useGameUI();
 	const game = ctx.game;
 
-	const jitter = createAccessor(game.sync.output.jitter);
+	const jitter = createAccessor(game.sync.out.jitter);
 
 	const onJitterInput = (e: Event) => {
 		const el = e.currentTarget as HTMLInputElement;

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -277,7 +277,7 @@ export class Once<T> implements GetPromise<T> {
 type SetterType<S> = S extends Setter<infer T> ? T : never;
 export type GetterType<G> = G extends Getter<infer T> ? T : never;
 
-// A record of named signals, used to group a component's inputs or outputs.
+// A record of named signals, used to group a component's `in` or `out` signals.
 export type SignalMap = Record<string, Getter<unknown>>;
 
 // A read-only view over a SignalMap: every entry collapses to its Getter and the
@@ -289,10 +289,10 @@ export type Readonlys<T extends SignalMap> = {
 
 // Re-type a record of Signals as read-only Getters. This is the identity function at
 // runtime; it only narrows the static type. Keep the original (writable) reference
-// private for the component to set, and expose the result as the public output.
+// private for the component to set, and expose the result as the public `out`.
 //
-//   readonly #output = { status: new Signal("offline") };
-//   readonly output = readonlys(this.#output); // status is now a Getter to callers
+//   readonly #out = { status: new Signal("offline") };
+//   readonly out = readonlys(this.#out); // status is now a Getter to callers
 export function readonlys<T extends SignalMap>(signals: T): Readonlys<T> {
 	return signals as unknown as Readonlys<T>;
 }
@@ -302,9 +302,9 @@ export function readonlys<T extends SignalMap>(signals: T): Readonlys<T> {
 export type GetterInit<T> = T | Getter<T>;
 
 // Build a read-only Getter from a value or an existing readable. The read-only
-// counterpart to `Signal.from`: a branded Signal (including the output of `readonlys`)
-// is reused as-is, so one component's output can be wired straight into another's
-// input; any other value is wrapped in a fresh Signal. The brand check means a
+// counterpart to `Signal.from`: a branded Signal (including the result of `readonlys`)
+// is reused as-is, so one component's `out` can be wired straight into another's
+// `in`; any other value is wrapped in a fresh Signal. The brand check means a
 // hand-rolled Getter that isn't backed by a Signal would be treated as a value.
 export function getter<T>(value: GetterInit<T>): Getter<T> {
 	if (typeof value === "object" && value !== null && SIGNAL_BRAND in value) {
@@ -313,8 +313,8 @@ export function getter<T>(value: GetterInit<T>): Getter<T> {
 	return new Signal(value as T);
 }
 
-// Derive a component's constructor argument from its input map: every input becomes
-// optional and accepts a raw value, a Signal, or another component's output Getter
+// Derive a component's constructor argument from its `in` map: every entry becomes
+// optional and accepts a raw value, a Signal, or another component's `out` Getter
 // (the `getter()` contract). Removes the hand-written, drift-prone argument interface.
 export type Inputs<I extends SignalMap> = { [K in keyof I]?: GetterInit<GetterType<I[K]>> };
 

--- a/js/signals/src/io.test.ts
+++ b/js/signals/src/io.test.ts
@@ -11,7 +11,7 @@ test("getter reuses an existing Signal instead of wrapping it", () => {
 	expect(getter(s)).toBe(s);
 });
 
-test("getter reuses a readonlys() output (so outputs wire into inputs)", () => {
+test("getter reuses a readonlys() result (so out wires into in)", () => {
 	const s = new Signal("hello");
 	const view = readonlys({ value: s }).value;
 	// The read-only view is the same branded Signal, so getter() passes it through.
@@ -26,8 +26,8 @@ test("readonlys exposes live reads without a writable handle", () => {
 	expect(out.count.peek()).toBe(2);
 });
 
-test("an output Getter feeds another component's input end to end", () => {
-	// Mimic: produced.output.value -> consumed input via getter().
+test("an out Getter feeds another component's in end to end", () => {
+	// Mimic: produced.out.value -> consumed input via getter().
 	const produced = new Signal(0);
 	const output: Getter<number> = readonlys({ value: produced }).value;
 

--- a/js/watch/src/audio/backend.ts
+++ b/js/watch/src/audio/backend.ts
@@ -7,7 +7,7 @@ export interface Backend {
 	// The source of the audio.
 	source: Source;
 
-	readonly output: {
+	readonly out: {
 		// The stats of the audio.
 		readonly stats: Getter<Stats | undefined>;
 

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -48,11 +48,11 @@ export interface AudioStats {
  * The user is responsible for hooking up audio to speakers, an analyzer, etc.
  */
 export class Decoder {
-	readonly input: Readonlys<DecoderInput>;
+	readonly in: Readonlys<DecoderInput>;
 	source: Source;
 	sync: Sync;
 
-	readonly #output: DecoderOutput = {
+	readonly #out: DecoderOutput = {
 		context: new Signal<AudioContext | undefined>(undefined),
 		root: new Signal<AudioNode | undefined>(undefined),
 		sampleRate: new Signal<number | undefined>(undefined),
@@ -61,7 +61,7 @@ export class Decoder {
 		stalled: new Signal<boolean>(true),
 		buffered: new Signal<BufferedRanges>([]),
 	};
-	readonly output = readonlys(this.#output);
+	readonly out = readonlys(this.#out);
 
 	// Decode buffer: audio sent to worklet but not yet played
 	#decodeBuffered = new Signal<BufferedRanges>([]);
@@ -88,7 +88,7 @@ export class Decoder {
 	#signals = new Effect();
 
 	constructor(source: Source, sync: Sync, props?: Inputs<DecoderInput>) {
-		this.input = {
+		this.in = {
 			enabled: getter(props?.enabled ?? false),
 		};
 
@@ -96,7 +96,7 @@ export class Decoder {
 		this.sync = sync;
 
 		this.#signals.run((effect) => {
-			this.#consumerLatency.set(effect.get(this.sync.output.maxBuffer));
+			this.#consumerLatency.set(effect.get(this.sync.out.maxBuffer));
 		});
 
 		this.#signals.run(this.#runWorklet.bind(this));
@@ -112,7 +112,7 @@ export class Decoder {
 		//const enabled = effect.get(this.enabled);
 		//if (!enabled) return;
 
-		const config = effect.get(this.source.output.config);
+		const config = effect.get(this.source.out.config);
 		if (!config) return;
 
 		const sampleRate = config.sampleRate;
@@ -122,7 +122,7 @@ export class Decoder {
 			latencyHint: "interactive", // We don't use real-time because of the buffer.
 			sampleRate,
 		});
-		effect.set(this.#output.context, context);
+		effect.set(this.#out.context, context);
 
 		effect.cleanup(() => context.close());
 
@@ -144,9 +144,9 @@ export class Decoder {
 			effect.cleanup(() => worklet.disconnect());
 
 			// Initial target latency in samples.
-			const latency = this.sync.output.buffer.peek();
+			const latency = this.sync.out.buffer.peek();
 			const latencySamples = Math.ceil(sampleRate * Time.Second.fromMilli(latency));
-			const buffered = this.sync.output.buffered.peek();
+			const buffered = this.sync.out.buffered.peek();
 
 			// Let the factory pick the best transport (SharedArrayBuffer or postMessage).
 			const ring = createAudioBuffer(worklet, channelCount, sampleRate, latencySamples, buffered);
@@ -159,19 +159,19 @@ export class Decoder {
 			// Mirror ring state (timestamp/stalled) onto our public signals.
 			effect.run((inner) => {
 				const ts = Time.Milli.fromMicro(inner.get(ring.timestamp));
-				this.#output.timestamp.set(ts);
+				this.#out.timestamp.set(ts);
 				this.#trimDecodeBuffered(ts);
 			});
 			effect.run((inner) => {
-				this.#output.stalled.set(inner.get(ring.stalled));
+				this.#out.stalled.set(inner.get(ring.stalled));
 			});
 
-			effect.set(this.#output.root, worklet);
+			effect.set(this.#out.root, worklet);
 		});
 	}
 
 	#runEnabled(effect: Effect): void {
-		const values = effect.getAll([this.input.enabled, this.#output.context]);
+		const values = effect.getAll([this.in.enabled, this.#out.context]);
 		if (!values) return;
 		const [_, context] = values;
 
@@ -182,28 +182,28 @@ export class Decoder {
 
 	#runLatency(effect: Effect): void {
 		// Gate on the worklet signal so this effect re-runs once the ring is created.
-		const worklet = effect.get(this.#output.root);
+		const worklet = effect.get(this.#out.root);
 		if (!worklet) return;
 
 		const ring = this.#ring;
 		if (!ring) return;
 
-		const latency = effect.get(this.sync.output.buffer);
+		const latency = effect.get(this.sync.out.buffer);
 		const latencySamples = Math.ceil(ring.rate * Time.Second.fromMilli(latency));
 		ring.setLatency(latencySamples);
 	}
 
 	#runDecoder(effect: Effect): void {
-		const enabled = effect.get(this.input.enabled);
+		const enabled = effect.get(this.in.enabled);
 		if (!enabled) return;
 
-		const broadcast = effect.get(this.source.input.broadcast);
+		const broadcast = effect.get(this.source.in.broadcast);
 		if (!broadcast) return;
 
-		const track = effect.get(this.source.output.track);
+		const track = effect.get(this.source.out.track);
 		if (!track) return;
 
-		const config = effect.get(this.source.output.config);
+		const config = effect.get(this.source.out.config);
 		if (!config) return;
 
 		// Honor a per-rendition `broadcast` override: subscribe on the resolved source
@@ -235,7 +235,7 @@ export class Decoder {
 		effect.run((inner) => {
 			const network = inner.get(consumer.buffered);
 			const decode = inner.get(this.#decodeBuffered);
-			this.#output.buffered.update(() => Container.mergeBufferedRanges(network, decode));
+			this.#out.buffered.update(() => Container.mergeBufferedRanges(network, decode));
 		});
 
 		effect.spawn(async () => {
@@ -286,7 +286,7 @@ export class Decoder {
 				const timestamp = Time.Milli.fromMicro(frame.timestamp as Time.Micro);
 				this.sync.received(timestamp, "audio");
 
-				this.#output.stats.update((stats) => ({
+				this.#out.stats.update((stats) => ({
 					bytesReceived: (stats?.bytesReceived ?? 0) + frame.data.byteLength,
 				}));
 
@@ -329,7 +329,7 @@ export class Decoder {
 		effect.run((inner) => {
 			const network = inner.get(consumer.buffered);
 			const decode = inner.get(this.#decodeBuffered);
-			this.#output.buffered.update(() => Container.mergeBufferedRanges(network, decode));
+			this.#out.buffered.update(() => Container.mergeBufferedRanges(network, decode));
 		});
 
 		effect.spawn(async () => {
@@ -365,7 +365,7 @@ export class Decoder {
 				const timestamp = Time.Milli.fromMicro(frame.timestamp);
 				this.sync.received(timestamp, "audio");
 
-				this.#output.stats.update((stats) => ({
+				this.#out.stats.update((stats) => ({
 					bytesReceived: (stats?.bytesReceived ?? 0) + frame.data.byteLength,
 				}));
 

--- a/js/watch/src/audio/emitter.ts
+++ b/js/watch/src/audio/emitter.ts
@@ -24,12 +24,12 @@ type EmitterOutput = {
 export class Emitter {
 	source: Decoder;
 
-	readonly input: Readonlys<EmitterInput>;
+	readonly in: Readonlys<EmitterInput>;
 
-	readonly #output: EmitterOutput = {
+	readonly #out: EmitterOutput = {
 		enabled: new Signal<boolean>(false),
 	};
-	readonly output = readonlys(this.#output);
+	readonly out = readonlys(this.#out);
 
 	#signals = new Effect();
 
@@ -38,7 +38,7 @@ export class Emitter {
 
 	constructor(source: Decoder, props?: Inputs<EmitterInput>) {
 		this.source = source;
-		this.input = {
+		this.in = {
 			volume: getter(props?.volume ?? 0.5),
 			muted: getter(props?.muted ?? false),
 			paused: getter(props?.paused ?? false),
@@ -46,15 +46,15 @@ export class Emitter {
 
 		// Only download while playing audible audio. Pausing or muting stops it.
 		this.#signals.run((effect) => {
-			const enabled = !effect.get(this.input.paused) && !effect.get(this.input.muted);
-			this.#output.enabled.set(enabled);
+			const enabled = !effect.get(this.in.paused) && !effect.get(this.in.muted);
+			this.#out.enabled.set(enabled);
 		});
 
 		this.#signals.run((effect) => {
-			const root = effect.get(this.source.output.root);
+			const root = effect.get(this.source.out.root);
 			if (!root) return;
 
-			const gain = new GainNode(root.context, { gain: effect.get(this.input.volume) });
+			const gain = new GainNode(root.context, { gain: effect.get(this.in.volume) });
 			root.connect(gain);
 
 			effect.set(this.#gain, gain);
@@ -62,7 +62,7 @@ export class Emitter {
 			effect.run((inner) => {
 				// We only connect/disconnect when enabled to save power.
 				// Otherwise the worklet keeps running in the background returning 0s.
-				const enabled = inner.get(this.#output.enabled);
+				const enabled = inner.get(this.#out.enabled);
 				if (!enabled) return;
 
 				gain.connect(root.context.destination); // speakers
@@ -77,7 +77,7 @@ export class Emitter {
 			// Cancel any scheduled transitions on change.
 			effect.cleanup(() => gain.gain.cancelScheduledValues(gain.context.currentTime));
 
-			const volume = effect.get(this.input.volume);
+			const volume = effect.get(this.in.volume);
 			if (volume < MIN_GAIN) {
 				gain.gain.exponentialRampToValueAtTime(MIN_GAIN, gain.context.currentTime + FADE_TIME);
 				gain.gain.setValueAtTime(0, gain.context.currentTime + FADE_TIME + 0.01);

--- a/js/watch/src/audio/mse.ts
+++ b/js/watch/src/audio/mse.ts
@@ -27,14 +27,14 @@ export class Mse implements Backend {
 	sync: Sync;
 	source: Source;
 
-	readonly input: Readonlys<MseInput>;
+	readonly in: Readonlys<MseInput>;
 
-	readonly #output: MseOutput = {
+	readonly #out: MseOutput = {
 		stats: new Signal<Stats | undefined>(undefined),
 		buffered: new Signal<BufferedRanges>([]),
 		context: new Signal<AudioContext | undefined>(undefined),
 	};
-	readonly output = readonlys(this.#output);
+	readonly out = readonlys(this.#out);
 
 	#signals = new Effect();
 
@@ -43,7 +43,7 @@ export class Mse implements Backend {
 		this.sync = sync;
 		this.source = source;
 
-		this.input = {
+		this.in = {
 			volume: getter(props?.volume ?? 0.5),
 			muted: getter(props?.muted ?? false),
 		};
@@ -53,19 +53,19 @@ export class Mse implements Backend {
 	}
 
 	#runMedia(effect: Effect): void {
-		const element = effect.get(this.muxer.input.element);
+		const element = effect.get(this.muxer.in.element);
 		if (!element) return;
 
-		const mediaSource = effect.get(this.muxer.output.mediaSource);
+		const mediaSource = effect.get(this.muxer.out.mediaSource);
 		if (!mediaSource) return;
 
-		const broadcast = effect.get(this.source.input.broadcast);
+		const broadcast = effect.get(this.source.in.broadcast);
 		if (!broadcast) return;
 
-		const track = effect.get(this.source.output.track);
+		const track = effect.get(this.source.out.track);
 		if (!track) return;
 
-		const config = effect.get(this.source.output.config);
+		const config = effect.get(this.source.out.config);
 		if (!config) return;
 
 		// Honor a per-rendition `broadcast` override: subscribe on the resolved source
@@ -86,7 +86,7 @@ export class Mse implements Backend {
 		});
 
 		effect.event(sourceBuffer, "updateend", () => {
-			this.#output.buffered.set(timeRangesToArray(sourceBuffer.buffered));
+			this.#out.buffered.set(timeRangesToArray(sourceBuffer.buffered));
 		});
 
 		const sub = active.track(track).subscribe({ priority: Catalog.PRIORITY.audio });
@@ -163,7 +163,7 @@ export class Mse implements Backend {
 		// Create consumer that reorders groups/frames up to the provided latency.
 		const consumer = new Container.Consumer(sub, {
 			format,
-			latency: this.sync.output.buffer,
+			latency: this.sync.out.buffer,
 		});
 		effect.cleanup(() => consumer.close());
 
@@ -229,11 +229,11 @@ export class Mse implements Backend {
 	}
 
 	#runVolume(effect: Effect): void {
-		const element = effect.get(this.muxer.input.element);
+		const element = effect.get(this.muxer.in.element);
 		if (!element) return;
 
-		const volume = effect.get(this.input.volume);
-		const muted = effect.get(this.input.muted);
+		const volume = effect.get(this.in.volume);
+		const muted = effect.get(this.in.muted);
 
 		if (muted && !element.muted) {
 			element.muted = true;

--- a/js/watch/src/audio/source.ts
+++ b/js/watch/src/audio/source.ts
@@ -43,21 +43,21 @@ type SourceOutput = {
  * for audio playback. It is used by both MSE and Decoder backends.
  */
 export class Source {
-	readonly input: Readonlys<SourceInput>;
+	readonly in: Readonlys<SourceInput>;
 
-	readonly #output: SourceOutput = {
+	readonly #out: SourceOutput = {
 		catalog: new Signal<Catalog.Audio | undefined>(undefined),
 		available: new Signal<Record<string, Catalog.AudioConfig>>({}),
 		track: new Signal<string | undefined>(undefined),
 		config: new Signal<Catalog.AudioConfig | undefined>(undefined),
 		jitter: new Signal<Moq.Time.Milli | undefined>(undefined),
 	};
-	readonly output = readonlys(this.#output);
+	readonly out = readonlys(this.#out);
 
 	#signals = new Effect();
 
 	constructor(props?: Inputs<SourceInput>) {
-		this.input = {
+		this.in = {
 			broadcast: getter(props?.broadcast),
 			target: getter(props?.target),
 			supported: getter(props?.supported),
@@ -69,18 +69,18 @@ export class Source {
 	}
 
 	#runCatalog(effect: Effect): void {
-		const broadcast = effect.get(this.input.broadcast);
+		const broadcast = effect.get(this.in.broadcast);
 		if (!broadcast) return;
 
-		const catalog = effect.get(broadcast.output.catalog)?.audio;
+		const catalog = effect.get(broadcast.out.catalog)?.audio;
 		if (!catalog) return;
 
-		effect.set(this.#output.catalog, catalog);
+		effect.set(this.#out.catalog, catalog);
 	}
 
 	#runSupported(effect: Effect): void {
-		const renditions = effect.get(this.#output.catalog)?.renditions ?? {};
-		const supported = effect.get(this.input.supported);
+		const renditions = effect.get(this.#out.catalog)?.renditions ?? {};
+		const supported = effect.get(this.in.supported);
 		if (!supported) return;
 
 		effect.spawn(async () => {
@@ -95,15 +95,15 @@ export class Source {
 				console.warn("no supported audio renditions found:", renditions);
 			}
 
-			this.#output.available.set(available);
+			this.#out.available.set(available);
 		});
 	}
 
 	#runSelected(effect: Effect): void {
-		const available = effect.get(this.#output.available);
+		const available = effect.get(this.#out.available);
 		if (Object.keys(available).length === 0) return;
 
-		const target = effect.get(this.input.target);
+		const target = effect.get(this.in.target);
 
 		let selected: { track: string; config: Catalog.AudioConfig } | undefined;
 
@@ -116,15 +116,15 @@ export class Source {
 			if (!selected) return;
 		}
 
-		effect.set(this.#output.track, selected.track);
-		effect.set(this.#output.config, selected.config);
+		effect.set(this.#out.track, selected.track);
+		effect.set(this.#out.config, selected.config);
 
 		// Use catalog jitter if available, otherwise estimate from codec frame duration.
 		// Add the worklet render quantum so the ring buffer has margin between frame arrivals.
 		const codecJitter = selected.config.jitter ?? defaultAudioJitter(selected.config) ?? 0;
 		const overhead = Math.ceil((WORKLET_QUANTUM / selected.config.sampleRate) * 1000);
 		const jitter = codecJitter + overhead;
-		effect.set(this.#output.jitter, Time.Milli(jitter));
+		effect.set(this.#out.jitter, Time.Milli(jitter));
 	}
 
 	/**

--- a/js/watch/src/backend.ts
+++ b/js/watch/src/backend.ts
@@ -17,11 +17,11 @@ type VideoBackendOutput = {
 // Unifies the video outputs across the MSE and WebCodecs backends.
 class VideoBackend implements Video.Backend {
 	source: Video.Source;
-	readonly output: Readonlys<VideoBackendOutput>;
+	readonly out: Readonlys<VideoBackendOutput>;
 
 	constructor(source: Video.Source, output: VideoBackendOutput) {
 		this.source = source;
-		this.output = readonlys(output);
+		this.out = readonlys(output);
 	}
 }
 
@@ -34,11 +34,11 @@ type AudioBackendOutput = {
 // Unifies the audio outputs across the MSE and WebCodecs backends.
 class AudioBackend implements Audio.Backend {
 	source: Audio.Source;
-	readonly output: Readonlys<AudioBackendOutput>;
+	readonly out: Readonlys<AudioBackendOutput>;
 
 	constructor(source: Audio.Source, output: AudioBackendOutput) {
 		this.source = source;
-		this.output = readonlys(output);
+		this.out = readonlys(output);
 	}
 }
 
@@ -70,10 +70,10 @@ type MultiBackendInput = {
 ///
 /// This is primarily what backs the <moq-watch> web component, but it's useful as a standalone for other use cases.
 export class MultiBackend {
-	readonly input: Readonlys<MultiBackendInput>;
+	readonly in: Readonlys<MultiBackendInput>;
 
 	// Read-only signals computed by Sync: the jitter buffer (ms) and whether buffered playback is active.
-	readonly output: { readonly jitter: Getter<Moq.Time.Milli>; readonly buffered: Getter<boolean> };
+	readonly out: { readonly jitter: Getter<Moq.Time.Milli>; readonly buffered: Getter<boolean> };
 
 	#videoSource: Video.Source;
 	#audioSource: Audio.Source;
@@ -110,7 +110,7 @@ export class MultiBackend {
 	signals = new Effect();
 
 	constructor(props?: Inputs<MultiBackendInput>) {
-		this.input = {
+		this.in = {
 			element: getter(props?.element),
 			broadcast: getter(props?.broadcast),
 			connection: getter(props?.connection),
@@ -123,34 +123,34 @@ export class MultiBackend {
 		};
 
 		this.#videoSource = new Video.Source({
-			broadcast: this.input.broadcast,
-			target: this.input.target,
+			broadcast: this.in.broadcast,
+			target: this.in.target,
 			supported: this.#videoSupported,
 		});
 		this.#audioSource = new Audio.Source({
-			broadcast: this.input.broadcast,
+			broadcast: this.in.broadcast,
 			supported: this.#audioSupported,
 		});
 
 		// Sources produce the per-rendition jitter that Sync reads, so they're created
 		// before Sync to avoid a construction cycle.
 		this.sync = new Sync({
-			latency: this.input.latency,
-			connection: this.input.connection,
-			video: this.#videoSource.output.jitter,
-			audio: this.#audioSource.output.jitter,
+			latency: this.in.latency,
+			connection: this.in.connection,
+			video: this.#videoSource.out.jitter,
+			audio: this.#audioSource.out.jitter,
 		});
 
 		this.video = new VideoBackend(this.#videoSource, this.#videoOutput);
 		this.audio = new AudioBackend(this.#audioSource, this.#audioOutput);
 
-		this.output = { jitter: this.sync.output.jitter, buffered: this.sync.output.buffered };
+		this.out = { jitter: this.sync.out.jitter, buffered: this.sync.out.buffered };
 
 		this.signals.run(this.#runElement.bind(this));
 	}
 
 	#runElement(effect: Effect): void {
-		const element = effect.get(this.input.element);
+		const element = effect.get(this.in.element);
 		if (!element) return;
 
 		if (element instanceof HTMLCanvasElement) {
@@ -170,14 +170,14 @@ export class MultiBackend {
 		this.#audioDecoder = audioDecoder;
 
 		const audioEmitter = new Audio.Emitter(audioDecoder, {
-			volume: this.input.volume,
-			muted: this.input.muted,
-			paused: this.input.paused,
+			volume: this.in.volume,
+			muted: this.in.muted,
+			paused: this.in.paused,
 		});
 
 		const videoRenderer = new Video.Renderer(videoDecoder, {
 			canvas: element,
-			visible: this.input.visible,
+			visible: this.in.visible,
 		});
 
 		effect.cleanup(() => {
@@ -189,19 +189,19 @@ export class MultiBackend {
 		});
 
 		// Audio download follows the emitter's enable policy (paused/muted).
-		effect.proxy(this.#audioEnabled, audioEmitter.output.enabled);
+		effect.proxy(this.#audioEnabled, audioEmitter.out.enabled);
 
 		// Video downloads while playing and on-screen. When paused, keep downloading only
 		// until a frame is on the canvas, then stop: a cold paused start still shows a poster
 		// instead of black, without streaming while paused. Read the rendered frame only in
 		// the paused branch so playback doesn't re-run this every painted frame.
 		effect.run((inner) => {
-			const visible = inner.get(videoRenderer.output.visible);
-			if (!inner.get(this.input.paused)) {
+			const visible = inner.get(videoRenderer.out.visible);
+			if (!inner.get(this.in.paused)) {
 				this.#videoEnabled.set(visible);
 				return;
 			}
-			const frame = inner.get(videoRenderer.output.frame);
+			const frame = inner.get(videoRenderer.out.frame);
 			this.#videoEnabled.set(visible && !frame);
 		});
 		effect.cleanup(() => {
@@ -210,14 +210,14 @@ export class MultiBackend {
 		});
 
 		// Proxy the read only signals to the backend.
-		effect.proxy(this.#videoOutput.stats, videoDecoder.output.stats);
-		effect.proxy(this.#videoOutput.buffered, videoDecoder.output.buffered);
-		effect.proxy(this.#videoOutput.stalled, videoDecoder.output.stalled);
-		effect.proxy(this.#videoOutput.timestamp, videoDecoder.output.timestamp);
+		effect.proxy(this.#videoOutput.stats, videoDecoder.out.stats);
+		effect.proxy(this.#videoOutput.buffered, videoDecoder.out.buffered);
+		effect.proxy(this.#videoOutput.stalled, videoDecoder.out.stalled);
+		effect.proxy(this.#videoOutput.timestamp, videoDecoder.out.timestamp);
 
-		effect.proxy(this.#audioOutput.stats, audioDecoder.output.stats);
-		effect.proxy(this.#audioOutput.buffered, audioDecoder.output.buffered);
-		effect.proxy(this.#audioOutput.context, audioDecoder.output.context);
+		effect.proxy(this.#audioOutput.stats, audioDecoder.out.stats);
+		effect.proxy(this.#audioOutput.buffered, audioDecoder.out.buffered);
+		effect.proxy(this.#audioOutput.context, audioDecoder.out.context);
 	}
 
 	#runMse(effect: Effect, element: HTMLVideoElement): void {
@@ -226,14 +226,14 @@ export class MultiBackend {
 		effect.set(this.#audioSupported, Audio.Mse.supported, undefined);
 
 		const muxer = new Muxer(this.sync, {
-			paused: this.input.paused,
+			paused: this.in.paused,
 			element,
 		});
 
 		const video = new Video.Mse(muxer, this.sync, this.#videoSource);
 		const audio = new Audio.Mse(muxer, this.sync, this.#audioSource, {
-			volume: this.input.volume,
-			muted: this.input.muted,
+			volume: this.in.volume,
+			muted: this.in.muted,
 		});
 
 		effect.cleanup(() => {
@@ -243,14 +243,14 @@ export class MultiBackend {
 		});
 
 		// Proxy the read only signals to the backend.
-		effect.proxy(this.#videoOutput.stats, video.output.stats);
-		effect.proxy(this.#videoOutput.buffered, video.output.buffered);
-		effect.proxy(this.#videoOutput.stalled, video.output.stalled);
-		effect.proxy(this.#videoOutput.timestamp, video.output.timestamp);
+		effect.proxy(this.#videoOutput.stats, video.out.stats);
+		effect.proxy(this.#videoOutput.buffered, video.out.buffered);
+		effect.proxy(this.#videoOutput.stalled, video.out.stalled);
+		effect.proxy(this.#videoOutput.timestamp, video.out.timestamp);
 
-		effect.proxy(this.#audioOutput.stats, audio.output.stats);
-		effect.proxy(this.#audioOutput.buffered, audio.output.buffered);
-		effect.proxy(this.#audioOutput.context, audio.output.context);
+		effect.proxy(this.#audioOutput.stats, audio.out.stats);
+		effect.proxy(this.#audioOutput.buffered, audio.out.buffered);
+		effect.proxy(this.#audioOutput.context, audio.out.context);
 	}
 
 	// Re-anchor playback at an utterance boundary in buffered mode: reset the sync reference

--- a/js/watch/src/broadcast.ts
+++ b/js/watch/src/broadcast.ts
@@ -75,14 +75,14 @@ type BroadcastOutput = {
 
 // A catalog source that (optionally) reloads automatically when live/offline.
 export class Broadcast {
-	readonly input: Readonlys<BroadcastInput>;
+	readonly in: Readonlys<BroadcastInput>;
 
-	readonly #output: BroadcastOutput = {
+	readonly #out: BroadcastOutput = {
 		status: new Signal<Status>("offline"),
 		active: new Signal<Moq.Broadcast.Consumer | undefined>(undefined),
 		catalog: new Signal<Catalog.Root | undefined>(undefined),
 	};
-	readonly output = readonlys(this.#output);
+	readonly out = readonlys(this.#out);
 
 	// The set of announced paths on the connection, for cross-broadcast (`broadcast: ../`) references
 	// so `relativeBroadcast` can gate on whether a sibling is announced. `undefined` until the stream
@@ -97,7 +97,7 @@ export class Broadcast {
 	signals = new Effect();
 
 	constructor(props?: Inputs<BroadcastInput>) {
-		this.input = {
+		this.in = {
 			connection: getter(props?.connection),
 			name: getter(props?.name ?? Path.empty()),
 			enabled: getter(props?.enabled ?? false),
@@ -118,9 +118,9 @@ export class Broadcast {
 		this.#announced.set(undefined);
 
 		if (!effect.get(this.#wantAnnounced)) return;
-		if (!effect.get(this.input.reload)) return;
+		if (!effect.get(this.in.reload)) return;
 
-		const conn = effect.get(this.input.connection);
+		const conn = effect.get(this.in.connection);
 		if (!conn || skipDiscovery(conn)) return;
 
 		const announced = conn.announced(Path.empty());
@@ -144,9 +144,9 @@ export class Broadcast {
 	// true (subscribe immediately) when the gate can't apply: reload is off, or the relay doesn't
 	// support discovery. Opens the announcement stream on first use.
 	#isPathAnnounced(effect: Effect, path: Moq.Path.Valid): boolean {
-		if (!effect.get(this.input.reload)) return true;
+		if (!effect.get(this.in.reload)) return true;
 
-		const conn = effect.get(this.input.connection);
+		const conn = effect.get(this.in.connection);
 		if (conn && skipDiscovery(conn)) return true;
 
 		this.#wantAnnounced.set(true);
@@ -161,19 +161,19 @@ export class Broadcast {
 	// the dead one. Driven off the announcement stream's updates rather than a membership flag, since
 	// a coalesced republish leaves the active set unchanged yet still emits a fresh update.
 	#runBroadcast(effect: Effect): void {
-		const enabled = effect.get(this.input.enabled);
+		const enabled = effect.get(this.in.enabled);
 		if (!enabled) return;
 
-		const conn = effect.get(this.input.connection);
+		const conn = effect.get(this.in.connection);
 		if (!conn) return;
 
-		const name = effect.get(this.input.name);
+		const name = effect.get(this.in.name);
 
 		// No announcement gate: subscribe immediately (reload off, or the relay lacks discovery).
-		if (!effect.get(this.input.reload) || skipDiscovery(conn)) {
+		if (!effect.get(this.in.reload) || skipDiscovery(conn)) {
 			const broadcast = conn.consume(name);
 			effect.cleanup(() => broadcast.close());
-			effect.set(this.#output.active, broadcast, undefined);
+			effect.set(this.#out.active, broadcast, undefined);
 			return;
 		}
 
@@ -184,7 +184,7 @@ export class Broadcast {
 		effect.cleanup(() => {
 			current?.close();
 			current = undefined;
-			this.#output.active.set(undefined);
+			this.#out.active.set(undefined);
 		});
 
 		effect.spawn(async () => {
@@ -200,22 +200,22 @@ export class Broadcast {
 					if (current && !current.closedSignal.peek()) continue;
 					current?.close();
 					current = conn.consume(name);
-					this.#output.active.set(current);
+					this.#out.active.set(current);
 				} else {
 					current?.close();
 					current = undefined;
-					this.#output.active.set(undefined);
+					this.#out.active.set(undefined);
 				}
 			}
 		});
 	}
 
 	#runCatalog(effect: Effect): void {
-		const enabled = effect.get(this.input.enabled);
+		const enabled = effect.get(this.in.enabled);
 		if (!enabled) return;
 
-		const catalogFormat = effect.get(this.input.catalogFormat);
-		const name = effect.get(this.input.name);
+		const catalogFormat = effect.get(this.in.catalogFormat);
+		const name = effect.get(this.in.name);
 		// Explicit override beats name-derived auto-detection. When neither is
 		// set we fall back to the default, keeping legacy names that have no
 		// extension working.
@@ -223,16 +223,16 @@ export class Broadcast {
 
 		if (format === "manual") {
 			// Mirror the caller-supplied catalog into the effective output.
-			const catalog = effect.get(this.input.catalog);
-			effect.set(this.#output.catalog, catalog, undefined);
-			this.#output.status.set(catalog ? "live" : "loading");
+			const catalog = effect.get(this.in.catalog);
+			effect.set(this.#out.catalog, catalog, undefined);
+			this.#out.status.set(catalog ? "live" : "loading");
 			return;
 		}
 
-		const broadcast = effect.get(this.output.active);
+		const broadcast = effect.get(this.out.active);
 		if (!broadcast) return;
 
-		this.#output.status.set("loading");
+		this.#out.status.set("loading");
 
 		const trackName = format === "hang" ? Catalog.TRACK : format === "hangz" ? Catalog.TRACK_COMPRESSED : "catalog";
 		const track = broadcast.track(trackName).subscribe({ priority: Catalog.PRIORITY.catalog });
@@ -260,16 +260,16 @@ export class Broadcast {
 					const update = await Promise.race([effect.cancel, fetchNext()]);
 					if (!update) break;
 
-					console.debug("received catalog", format, this.input.name.peek(), update);
+					console.debug("received catalog", format, this.in.name.peek(), update);
 
-					this.#output.catalog.set(update);
-					this.#output.status.set("live");
+					this.#out.catalog.set(update);
+					this.#out.status.set("live");
 				}
 			} catch (err) {
-				console.warn("error fetching catalog", this.input.name.peek(), err);
+				console.warn("error fetching catalog", this.in.name.peek(), err);
 			} finally {
-				this.#output.catalog.set(undefined);
-				this.#output.status.set("offline");
+				this.#out.catalog.set(undefined);
+				this.#out.status.set("offline");
 			}
 		});
 	}
@@ -286,19 +286,19 @@ export class Broadcast {
 	 * changes exactly like the catalog broadcast.
 	 */
 	relativeBroadcast(effect: Effect, rel: string | undefined): Moq.Broadcast.Consumer | undefined {
-		if (!rel) return effect.get(this.output.active);
+		if (!rel) return effect.get(this.out.active);
 
-		const base = effect.get(this.input.name);
+		const base = effect.get(this.in.name);
 		const resolved = Path.resolve(base, rel);
 
 		// A reference that walks back to the catalog's own broadcast (or resolves to
 		// the empty root, via excess `..`) is served by the catalog broadcast itself,
 		// avoiding a duplicate subscription on the same path.
-		if (resolved === base || resolved === Path.empty()) return effect.get(this.output.active);
+		if (resolved === base || resolved === Path.empty()) return effect.get(this.out.active);
 
-		if (!effect.get(this.input.enabled)) return undefined;
+		if (!effect.get(this.in.enabled)) return undefined;
 
-		const conn = effect.get(this.input.connection);
+		const conn = effect.get(this.in.connection);
 		if (!conn) return undefined;
 
 		if (!this.#isPathAnnounced(effect, resolved)) return undefined;

--- a/js/watch/src/element.ts
+++ b/js/watch/src/element.ts
@@ -221,7 +221,7 @@ export default class MoqWatch extends HTMLElement {
 			if (min === "real-time") {
 				this.setAttribute("latency", "real-time");
 			} else {
-				const jitter = Math.floor(effect.get(this.backend.output.jitter));
+				const jitter = Math.floor(effect.get(this.backend.out.jitter));
 				this.setAttribute("latency", jitter.toString());
 			}
 		});
@@ -405,7 +405,7 @@ export default class MoqWatch extends HTMLElement {
 
 	/** The jitter buffer in milliseconds. */
 	get jitter(): Time.Milli {
-		return this.backend.output.jitter.peek();
+		return this.backend.out.jitter.peek();
 	}
 
 	/** Re-anchor playback and flush the audio buffer at an utterance boundary (buffered mode). */
@@ -426,7 +426,7 @@ export default class MoqWatch extends HTMLElement {
 	 * for `"hang"` and `"msf"` this is overwritten by the fetch loop.
 	 */
 	get catalog(): Catalog.Root | undefined {
-		return this.broadcast.output.catalog.peek();
+		return this.broadcast.out.catalog.peek();
 	}
 
 	set catalog(value: Catalog.Root | undefined) {

--- a/js/watch/src/mse.ts
+++ b/js/watch/src/mse.ts
@@ -16,18 +16,18 @@ type MuxerOutput = {
  * Uses Media Source Extensions to handle complete moof+mdat fragments.
  */
 export class Muxer {
-	readonly input: Readonlys<MuxerInput>;
+	readonly in: Readonlys<MuxerInput>;
 	sync: Sync;
 
-	readonly #output: MuxerOutput = {
+	readonly #out: MuxerOutput = {
 		mediaSource: new Signal<MediaSource | undefined>(undefined),
 	};
-	readonly output = readonlys(this.#output);
+	readonly out = readonlys(this.#out);
 
 	#signals = new Effect();
 
 	constructor(sync: Sync, props?: Inputs<MuxerInput>) {
-		this.input = {
+		this.in = {
 			element: getter(props?.element),
 			paused: getter(props?.paused ?? false),
 		};
@@ -41,7 +41,7 @@ export class Muxer {
 	}
 
 	#runMediaSource(effect: Effect): void {
-		const element = effect.get(this.input.element);
+		const element = effect.get(this.in.element);
 		if (!element) return;
 
 		const mediaSource = new MediaSource();
@@ -53,7 +53,7 @@ export class Muxer {
 			mediaSource,
 			"sourceopen",
 			() => {
-				effect.set(this.#output.mediaSource, mediaSource);
+				effect.set(this.#out.mediaSource, mediaSource);
 			},
 			{ once: true },
 		);
@@ -64,16 +64,16 @@ export class Muxer {
 	}
 
 	#runSkip(effect: Effect): void {
-		const element = effect.get(this.input.element);
+		const element = effect.get(this.in.element);
 		if (!element) return;
 
 		// Don't skip when paused, otherwise we'll keep jerking forward.
-		const paused = effect.get(this.input.paused);
+		const paused = effect.get(this.in.paused);
 		if (paused) return;
 
 		// Use the computed latency (catalog jitter + user jitter)
 		// Convert to seconds since DOM APIs use seconds
-		const latency = Time.Milli.toSecond(effect.get(this.sync.output.buffer));
+		const latency = Time.Milli.toSecond(effect.get(this.sync.out.buffer));
 
 		effect.interval(() => {
 			// Skip over gaps based on the effective latency.
@@ -93,10 +93,10 @@ export class Muxer {
 	}
 
 	#runTrim(effect: Effect): void {
-		const element = effect.get(this.input.element);
+		const element = effect.get(this.in.element);
 		if (!element) return;
 
-		const media = effect.get(this.output.mediaSource);
+		const media = effect.get(this.out.mediaSource);
 		if (!media) return;
 
 		// Periodically clean up old buffered data.
@@ -114,10 +114,10 @@ export class Muxer {
 	}
 
 	#runPaused(effect: Effect): void {
-		const element = effect.get(this.input.element);
+		const element = effect.get(this.in.element);
 		if (!element) return;
 
-		const paused = effect.get(this.input.paused);
+		const paused = effect.get(this.in.paused);
 		if (paused && !element.paused) {
 			element.pause();
 		} else if (!paused && element.paused) {
@@ -129,17 +129,17 @@ export class Muxer {
 
 	// Seek to the target position based on the reference and latency.
 	#runSync(effect: Effect): void {
-		const element = effect.get(this.input.element);
+		const element = effect.get(this.in.element);
 		if (!element) return;
 
 		// Don't seek when paused, otherwise we'll keep jerking around.
-		const paused = effect.get(this.input.paused);
+		const paused = effect.get(this.in.paused);
 		if (paused) return;
 
-		const reference = effect.get(this.sync.output.reference);
+		const reference = effect.get(this.sync.out.reference);
 		if (reference === undefined) return;
 
-		const latency = effect.get(this.sync.output.buffer);
+		const latency = effect.get(this.sync.out.buffer);
 
 		// Compute the target currentTime based on reference and latency.
 		// reference = performance.now() - frameTimestamp (in ms) when we received the earliest frame

--- a/js/watch/src/sync.test.ts
+++ b/js/watch/src/sync.test.ts
@@ -10,23 +10,23 @@ describe("latency range", () => {
 	it("is collapsed by default", async () => {
 		const sync = new Sync();
 		await flush();
-		expect(sync.output.buffered.peek()).toBe(false);
+		expect(sync.out.buffered.peek()).toBe(false);
 		sync.close();
 	});
 
 	it("stays collapsed for a scalar latency", async () => {
 		const sync = new Sync({ latency: 100 as Time.Milli });
 		await flush();
-		expect(sync.output.buffered.peek()).toBe(false);
-		expect(sync.output.maxBuffer.peek()).toBe(100 as Time.Milli);
+		expect(sync.out.buffered.peek()).toBe(false);
+		expect(sync.out.maxBuffer.peek()).toBe(100 as Time.Milli);
 		sync.close();
 	});
 
 	it("enters buffered mode when the ceiling is above the floor", async () => {
 		const sync = new Sync({ latency: { max: 30_000 as Time.Milli } });
 		await flush();
-		expect(sync.output.buffered.peek()).toBe(true);
-		expect(sync.output.maxBuffer.peek()).toBe(30_000 as Time.Milli);
+		expect(sync.out.buffered.peek()).toBe(true);
+		expect(sync.out.maxBuffer.peek()).toBe(30_000 as Time.Milli);
 		sync.close();
 	});
 
@@ -34,7 +34,7 @@ describe("latency range", () => {
 		// Fixed 200ms floor sits above the 100ms ceiling, so there's no room to buffer.
 		const sync = new Sync({ latency: { min: 200 as Time.Milli, max: 100 as Time.Milli } });
 		await flush();
-		expect(sync.output.buffered.peek()).toBe(false);
+		expect(sync.out.buffered.peek()).toBe(false);
 		sync.close();
 	});
 
@@ -42,18 +42,18 @@ describe("latency range", () => {
 		const latency = new Signal<Latency>("real-time");
 		const sync = new Sync({ latency });
 		await flush();
-		expect(sync.output.buffered.peek()).toBe(false);
+		expect(sync.out.buffered.peek()).toBe(false);
 
 		latency.set({ max: 30_000 as Time.Milli });
 		await flush();
-		expect(sync.output.buffered.peek()).toBe(true);
+		expect(sync.out.buffered.peek()).toBe(true);
 		sync.close();
 	});
 
 	it("stays collapsed for an explicit real-time ceiling", async () => {
 		const sync = new Sync({ latency: { max: "real-time" } });
 		await flush();
-		expect(sync.output.buffered.peek()).toBe(false);
+		expect(sync.out.buffered.peek()).toBe(false);
 		sync.close();
 	});
 });

--- a/js/watch/src/sync.ts
+++ b/js/watch/src/sync.ts
@@ -69,9 +69,9 @@ type SyncOutput = {
 };
 
 export class Sync {
-	readonly input: Readonlys<SyncInput>;
+	readonly in: Readonlys<SyncInput>;
 
-	readonly #output: SyncOutput = {
+	readonly #out: SyncOutput = {
 		reference: new Signal<Time.Milli | undefined>(undefined),
 		buffer: new Signal<Time.Milli>(Time.Milli.zero),
 		jitter: new Signal<Time.Milli>(FALLBACK_JITTER),
@@ -79,7 +79,7 @@ export class Sync {
 		buffered: new Signal<boolean>(false),
 		maxBuffer: new Signal<Time.Milli>(Time.Milli.zero),
 	};
-	readonly output = readonlys(this.#output);
+	readonly out = readonlys(this.#out);
 
 	// A ghetto way to learn when the reference/buffer changes.
 	// There's probably a way to use Effect, but lets keep it simple for now.
@@ -95,7 +95,7 @@ export class Sync {
 	signals = new Effect();
 
 	constructor(props?: Inputs<SyncInput>) {
-		this.input = {
+		this.in = {
 			latency: getter(props?.latency ?? ("real-time" as Latency)),
 			connection: getter(props?.connection),
 			audio: getter(props?.audio),
@@ -111,41 +111,41 @@ export class Sync {
 
 	// Derive `buffered` / `maxBuffer` from the floor (`buffer`) and the ceiling (the `max` bound).
 	#runRange(effect: Effect): void {
-		const { max } = latencyBounds(effect.get(this.input.latency));
-		const floor = effect.get(this.#output.buffer);
+		const { max } = latencyBounds(effect.get(this.in.latency));
+		const floor = effect.get(this.#out.buffer);
 
 		if (max === "real-time") {
 			// Ceiling tracks the floor: minimize latency, the live default.
-			this.#output.buffered.set(false);
-			this.#output.maxBuffer.set(floor);
+			this.#out.buffered.set(false);
+			this.#out.maxBuffer.set(floor);
 		} else {
 			// Buffered only when the ceiling is above the floor; otherwise it collapses to minimize.
-			this.#output.buffered.set(max > floor);
-			this.#output.maxBuffer.set(Time.Milli.max(max, floor));
+			this.#out.buffered.set(max > floor);
+			this.#out.maxBuffer.set(Time.Milli.max(max, floor));
 		}
 	}
 
 	// The maximum total latency (lookahead + floor) we tolerate before re-anchoring, in ms.
 	// Used by `received()` to decide when to skip ahead.
 	#latencyCap(): Time.Milli {
-		const { max } = latencyBounds(this.input.latency.peek());
-		const floor = this.#output.buffer.peek();
+		const { max } = latencyBounds(this.in.latency.peek());
+		const floor = this.#out.buffer.peek();
 		if (max === "real-time") return floor;
 		return Time.Milli.max(max, floor);
 	}
 
 	#runJitter(effect: Effect): void {
-		const { min } = latencyBounds(effect.get(this.input.latency));
+		const { min } = latencyBounds(effect.get(this.in.latency));
 
 		if (typeof min === "number") {
 			// Fixed mode: the floor value is the jitter.
 			this.#minRtt = undefined;
-			this.#output.jitter.set(min);
+			this.#out.jitter.set(min);
 			return;
 		}
 
 		// "real-time" mode: compute jitter from RTT on the established connection.
-		const conn = effect.get(this.input.connection);
+		const conn = effect.get(this.in.connection);
 		const rttSignal = conn?.rtt;
 		const rtt = rttSignal ? effect.get(rttSignal) : undefined;
 		if (rtt !== undefined) {
@@ -154,22 +154,22 @@ export class Sync {
 
 			// Buffer enough for a retransmit (1 RTT for ACK + retransmit).
 			const jitter = Time.Milli(Math.max(MIN_JITTER, this.#minRtt * 1.25));
-			this.#output.jitter.set(jitter);
+			this.#out.jitter.set(jitter);
 			return;
 		}
 
 		// No RTT available: fall back to static default.
 		this.#minRtt = undefined;
-		this.#output.jitter.set(FALLBACK_JITTER);
+		this.#out.jitter.set(FALLBACK_JITTER);
 	}
 
 	#runBuffer(effect: Effect): void {
-		const jitter = effect.get(this.#output.jitter);
-		const video = effect.get(this.input.video) ?? Time.Milli.zero;
-		const audio = effect.get(this.input.audio) ?? Time.Milli.zero;
+		const jitter = effect.get(this.#out.jitter);
+		const video = effect.get(this.in.video) ?? Time.Milli.zero;
+		const audio = effect.get(this.in.audio) ?? Time.Milli.zero;
 
 		const buffer = Time.Milli.add(Time.Milli.max(video, audio), jitter);
-		this.#output.buffer.set(buffer);
+		this.#out.buffer.set(buffer);
 
 		this.#update.resolve();
 		this.#update = Promise.withResolvers();
@@ -178,12 +178,10 @@ export class Sync {
 	// Fold a newly received frame into the reference. The reference anchors playback to the
 	// wall clock; we lower it (skip ahead) only when keeping it would push latency past the cap.
 	received(timestamp: Time.Milli, label = ""): void {
-		this.#output.timestamp.update((current) =>
-			current === undefined || timestamp > current ? timestamp : current,
-		);
+		this.#out.timestamp.update((current) => (current === undefined || timestamp > current ? timestamp : current));
 		const now = Time.Milli.now();
 		const ref = Time.Milli.sub(now, timestamp);
-		const currentRef = this.#output.reference.peek();
+		const currentRef = this.#out.reference.peek();
 
 		// First frame anchors the reference.
 		if (currentRef === undefined) {
@@ -194,7 +192,7 @@ export class Sync {
 		// Check if `wait()` would not sleep at all.
 		// NOTE: We check here instead of in `wait()` so we can identify when frames are received late.
 		// Otherwise, chained `wait()` calls would cause a false-positive during CPU starvation.
-		const floor = this.#output.buffer.peek();
+		const floor = this.#out.buffer.peek();
 		const sleep = Time.Milli.add(Time.Milli.sub(currentRef, ref), floor);
 		if (sleep < 0) {
 			const entry = this.#late.get(label);
@@ -226,7 +224,7 @@ export class Sync {
 	}
 
 	#setReference(ref: Time.Milli): void {
-		this.#output.reference.set(ref);
+		this.#out.reference.set(ref);
 		this.#update.resolve();
 		this.#update = Promise.withResolvers();
 	}
@@ -235,7 +233,7 @@ export class Sync {
 	// in buffered mode (typically alongside flushing the audio buffer) so the new content
 	// plays from its own first frame instead of inheriting the previous reference.
 	reset(): void {
-		this.#output.reference.set(undefined);
+		this.#out.reference.set(undefined);
 		this.#late.clear();
 		this.#update.resolve();
 		this.#update = Promise.withResolvers();
@@ -244,14 +242,14 @@ export class Sync {
 	// The PTS that should be rendering right now, derived from the reference + buffer.
 	// Returns undefined if no frames have been received yet.
 	now(): Time.Milli | undefined {
-		const reference = this.#output.reference.peek();
+		const reference = this.#out.reference.peek();
 		if (reference === undefined) return undefined;
-		return Time.Milli.sub(Time.Milli.sub(Time.Milli.now(), reference), this.#output.buffer.peek());
+		return Time.Milli.sub(Time.Milli.sub(Time.Milli.now(), reference), this.#out.buffer.peek());
 	}
 
 	// Sleep until it's time to render this frame.
 	async wait(timestamp: Time.Milli): Promise<void> {
-		const reference = this.#output.reference.peek();
+		const reference = this.#out.reference.peek();
 		if (reference === undefined) {
 			throw new Error("reference not set; call update() first");
 		}
@@ -262,10 +260,10 @@ export class Sync {
 			const now = Time.Milli.now();
 			const ref = Time.Milli.sub(now, timestamp);
 
-			const currentRef = this.#output.reference.peek();
+			const currentRef = this.#out.reference.peek();
 			if (currentRef === undefined) return;
 
-			const sleep = Time.Milli.add(Time.Milli.sub(currentRef, ref), this.#output.buffer.peek());
+			const sleep = Time.Milli.add(Time.Milli.sub(currentRef, ref), this.#out.buffer.peek());
 			if (sleep <= 0) return;
 
 			// Skip setTimeout for small sleeps; the timer resolution (~4ms) would overshoot.

--- a/js/watch/src/ui/components/buffer-control.ts
+++ b/js/watch/src/ui/components/buffer-control.ts
@@ -127,7 +127,7 @@ export function bufferControl(parent: Effect, watch: MoqWatch, max: Moq.Time.Mil
 	let hasInteracted = false;
 
 	parent.run((effect) => {
-		const jitter = effect.get(watch.backend.output.jitter);
+		const jitter = effect.get(watch.backend.out.jitter);
 		const pct = (jitter / max) * 100;
 		targetLine.style.left = `${pct}%`;
 		targetLabel.textContent = `${Math.round(jitter)}ms`;
@@ -179,16 +179,16 @@ export function bufferControl(parent: Effect, watch: MoqWatch, max: Moq.Time.Mil
 		}
 		e.preventDefault();
 		interact();
-		const current = watch.backend.output.jitter.peek();
+		const current = watch.backend.out.jitter.peek();
 		const value = Moq.Time.Milli(Math.max(MIN_RANGE, Math.min(max, current + delta)));
 		watch.latencyMin = value;
 	});
 
 	const draw = () => {
 		const timestamp = watch.backend.sync.now();
-		const isBuffering = watch.backend.video.output.stalled.peek();
-		drawRanges(videoCanvas, watch.backend.video.output.buffered.peek(), timestamp, max, isBuffering);
-		drawRanges(audioCanvas, watch.backend.audio.output.buffered.peek(), timestamp, max, isBuffering);
+		const isBuffering = watch.backend.video.out.stalled.peek();
+		drawRanges(videoCanvas, watch.backend.video.out.buffered.peek(), timestamp, max, isBuffering);
+		drawRanges(audioCanvas, watch.backend.audio.out.buffered.peek(), timestamp, max, isBuffering);
 		parent.animate(draw);
 	};
 	parent.animate(draw);

--- a/js/watch/src/ui/components/buffering-indicator.ts
+++ b/js/watch/src/ui/components/buffering-indicator.ts
@@ -9,9 +9,9 @@ export function bufferingIndicator(parent: Effect, watch: MoqWatch): HTMLElement
 	container.appendChild(spinner);
 
 	parent.run((effect) => {
-		const buffering = effect.get(watch.backend.video.output.stalled);
-		const offline = effect.get(watch.broadcast.output.status) === "offline";
-		const unsupported = effect.get(watch.backend.video.source.output.error) === "unsupported";
+		const buffering = effect.get(watch.backend.video.out.stalled);
+		const offline = effect.get(watch.broadcast.out.status) === "offline";
+		const unsupported = effect.get(watch.backend.video.source.out.error) === "unsupported";
 		container.style.display = buffering && !offline && !unsupported ? "" : "none";
 	});
 

--- a/js/watch/src/ui/components/center-play.ts
+++ b/js/watch/src/ui/components/center-play.ts
@@ -13,7 +13,7 @@ export function centerPlay(parent: Effect, watch: MoqWatch): HTMLElement {
 
 	parent.run((effect) => {
 		const paused = effect.get(watch.controls.paused);
-		const sourceError = effect.get(watch.backend.video.source.output.error);
+		const sourceError = effect.get(watch.backend.video.source.out.error);
 		button.style.display = paused && !sourceError ? "" : "none";
 	});
 

--- a/js/watch/src/ui/components/latency.ts
+++ b/js/watch/src/ui/components/latency.ts
@@ -55,8 +55,8 @@ export function latencyTab(parent: Effect, watch: MoqWatch): HTMLElement {
 
 	parent.run((effect) => {
 		const mode = latencyBounds(effect.get(watch.controls.latency)).min;
-		const jitter = effect.get(watch.backend.output.jitter);
-		const total = effect.get(watch.backend.sync.output.buffer);
+		const jitter = effect.get(watch.backend.out.jitter);
+		const total = effect.get(watch.backend.sync.out.buffer);
 		jitterVal.textContent = `${formatMillis(jitter)}${mode === "real-time" ? " (auto)" : ""}`;
 		bufferVal.textContent = formatMillis(total);
 	});

--- a/js/watch/src/ui/components/live-badge.ts
+++ b/js/watch/src/ui/components/live-badge.ts
@@ -41,7 +41,7 @@ export function liveBadge(parent: Effect, watch: MoqWatch, state: UiState): HTML
 	parent.run((effect) => {
 		const url = effect.get(watch.connection.url);
 		const conn = effect.get(watch.connection.status);
-		const broadcast = effect.get(watch.broadcast.output.status);
+		const broadcast = effect.get(watch.broadcast.out.status);
 		const { variant, text: label } = deriveStatus(url, conn, broadcast);
 
 		// The center overlay already shows a prominent OFFLINE notice; don't
@@ -54,7 +54,7 @@ export function liveBadge(parent: Effect, watch: MoqWatch, state: UiState): HTML
 	parent.run((effect) => {
 		// Show the total added latency (jitter buffer + codec frame overhead),
 		// which is what the viewer actually experiences.
-		const total = effect.get(watch.backend.sync.output.buffer);
+		const total = effect.get(watch.backend.sync.out.buffer);
 		latency.textContent = `+${formatMillis(total)} latency`;
 	});
 

--- a/js/watch/src/ui/components/offline-indicator.ts
+++ b/js/watch/src/ui/components/offline-indicator.ts
@@ -13,7 +13,7 @@ export function offlineIndicator(parent: Effect, watch: MoqWatch): HTMLElement {
 	container.appendChild(text);
 
 	parent.run((effect) => {
-		const offline = effect.get(watch.broadcast.output.status) === "offline";
+		const offline = effect.get(watch.broadcast.out.status) === "offline";
 		container.style.display = offline ? "" : "none";
 	});
 

--- a/js/watch/src/ui/components/quality.ts
+++ b/js/watch/src/ui/components/quality.ts
@@ -52,9 +52,9 @@ export function qualityTab(parent: Effect, watch: MoqWatch): HTMLElement {
 
 	parent.run((effect) => {
 		const source = watch.backend.video.source;
-		const catalog = effect.get(source.output.catalog);
+		const catalog = effect.get(source.out.catalog);
 		const target = effect.get(watch.controls.target);
-		const active = effect.get(source.output.track);
+		const active = effect.get(source.out.track);
 		const renditions = catalog?.renditions ?? {};
 		const entries = Object.entries(renditions);
 

--- a/js/watch/src/ui/components/unsupported-indicator.ts
+++ b/js/watch/src/ui/components/unsupported-indicator.ts
@@ -13,13 +13,13 @@ export function unsupportedIndicator(parent: Effect, watch: MoqWatch): HTMLEleme
 	container.appendChild(text);
 
 	parent.run((effect) => {
-		const unsupported = effect.get(watch.backend.video.source.output.error) === "unsupported";
-		const offline = effect.get(watch.broadcast.output.status) === "offline";
+		const unsupported = effect.get(watch.backend.video.source.out.error) === "unsupported";
+		const offline = effect.get(watch.broadcast.out.status) === "offline";
 		const show = unsupported && !offline;
 		container.style.display = show ? "" : "none";
 		if (!show) return;
 
-		const renditions = effect.get(watch.backend.video.source.output.catalog)?.renditions ?? {};
+		const renditions = effect.get(watch.backend.video.source.out.catalog)?.renditions ?? {};
 		const codecs = [...new Set(Object.values(renditions).map((rendition) => rendition.codec))].join(", ");
 		text.textContent = codecs
 			? `This video codec is not supported by your browser: ${codecs}`

--- a/js/watch/src/ui/stats.ts
+++ b/js/watch/src/ui/stats.ts
@@ -75,7 +75,7 @@ export function statsTab(parent: Effect, watch: MoqWatch): HTMLElement {
 	const vFpsGraph = graph(parent, "Frame rate", { color: "#facc15", format: formatFps });
 	videoCard.el.append(vBitrateGraph.el, vFpsGraph.el);
 	track(parent, videoCard, {
-		catalog: watch.backend.video.source.output.catalog,
+		catalog: watch.backend.video.source.out.catalog,
 		flag: watch.controls.paused,
 		label: "paused",
 	});
@@ -87,7 +87,7 @@ export function statsTab(parent: Effect, watch: MoqWatch): HTMLElement {
 	const aChannels = line(audioCard.grid, "Channels");
 	const aBitrate = line(audioCard.grid, "Bitrate");
 	track(parent, audioCard, {
-		catalog: watch.backend.audio.source.output.catalog,
+		catalog: watch.backend.audio.source.out.catalog,
 		flag: watch.controls.muted,
 		label: "muted",
 	});
@@ -108,9 +108,9 @@ export function statsTab(parent: Effect, watch: MoqWatch): HTMLElement {
 		const now = performance.now();
 
 		// Video. Resolution comes from the active rendition (catalog.display is optional).
-		const vConf = watch.backend.video.source.output.config.peek();
-		const vCat = watch.backend.video.source.output.catalog.peek();
-		const vStats = watch.backend.video.output.stats.peek();
+		const vConf = watch.backend.video.source.out.config.peek();
+		const vCat = watch.backend.video.source.out.catalog.peek();
+		const vStats = watch.backend.video.out.stats.peek();
 		const w = vConf?.codedWidth ?? vCat?.display?.width;
 		const h = vConf?.codedHeight ?? vCat?.display?.height;
 		vRes.textContent = w && h ? `${w}×${h}` : "—";
@@ -128,8 +128,8 @@ export function statsTab(parent: Effect, watch: MoqWatch): HTMLElement {
 		if (vStats) vPrev = { frames: vStats.frameCount, bytes: vStats.bytesReceived, when: now };
 
 		// Audio.
-		const aConf = watch.backend.audio.source.output.config.peek();
-		const aStats = watch.backend.audio.output.stats.peek();
+		const aConf = watch.backend.audio.source.out.config.peek();
+		const aStats = watch.backend.audio.out.stats.peek();
 		aCodec.textContent = aConf?.codec ?? "—";
 		aRate2.textContent = aConf?.sampleRate ? formatHz(aConf.sampleRate) : "—";
 		aChannels.textContent = aConf?.numberOfChannels ? `${aConf.numberOfChannels}` : "—";

--- a/js/watch/src/video/backend.ts
+++ b/js/watch/src/video/backend.ts
@@ -8,7 +8,7 @@ export interface Backend {
 	// The source of the video.
 	source: Source;
 
-	readonly output: {
+	readonly out: {
 		// The stats of the video.
 		readonly stats: Getter<Stats | undefined>;
 

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -42,11 +42,11 @@ type DecoderOutput = {
 type RequiredDecoderConfig = Omit<Catalog.VideoConfig, "codedWidth" | "codedHeight">;
 
 export class Decoder implements Backend {
-	readonly input: Readonlys<DecoderInput>;
+	readonly in: Readonlys<DecoderInput>;
 	source: Source;
 	sync: Sync;
 
-	readonly #output: DecoderOutput = {
+	readonly #out: DecoderOutput = {
 		frame: new Signal<VideoFrame | undefined>(undefined),
 		timestamp: new Signal<Time.Milli | undefined>(undefined),
 		display: new Signal<{ width: number; height: number } | undefined>(undefined),
@@ -54,7 +54,7 @@ export class Decoder implements Backend {
 		stats: new Signal<Stats | undefined>(undefined),
 		buffered: new Signal<BufferedRanges>([]),
 	};
-	readonly output = readonlys(this.#output);
+	readonly out = readonlys(this.#out);
 
 	// The current track running, held so we can cancel it when the new track is ready.
 	#active = new Signal<DecoderTrack | undefined>(undefined);
@@ -62,15 +62,15 @@ export class Decoder implements Backend {
 	#signals = new Effect();
 
 	#clearCurrentFrame(): void {
-		this.#output.frame.update((prev) => {
+		this.#out.frame.update((prev) => {
 			prev?.close();
 			return undefined;
 		});
-		this.#output.timestamp.set(undefined);
+		this.#out.timestamp.set(undefined);
 	}
 
 	constructor(source: Source, sync: Sync, props?: Inputs<DecoderInput>) {
-		this.input = {
+		this.in = {
 			enabled: getter(props?.enabled ?? false),
 		};
 
@@ -85,10 +85,10 @@ export class Decoder implements Backend {
 
 	#runPending(effect: Effect): void {
 		const values = effect.getAll([
-			this.input.enabled,
-			this.source.input.broadcast,
-			this.source.output.track,
-			this.source.output.config,
+			this.in.enabled,
+			this.source.in.broadcast,
+			this.source.out.track,
+			this.source.out.config,
 		]);
 		if (!values) {
 			// Close the active track when disabled (e.g. paused or not visible).
@@ -105,7 +105,7 @@ export class Decoder implements Backend {
 			// Going offline should clear the last rendered frame.
 			this.#active.set(undefined);
 			this.#clearCurrentFrame();
-			this.#output.buffered.set([]);
+			this.#out.buffered.set([]);
 			return;
 		}
 
@@ -115,7 +115,7 @@ export class Decoder implements Backend {
 			broadcast: active,
 			track,
 			config,
-			stats: this.#output.stats,
+			stats: this.#out.stats,
 		});
 
 		effect.cleanup(() => pending?.close());
@@ -147,7 +147,7 @@ export class Decoder implements Backend {
 		const active = effect.get(this.#active);
 		if (!active) {
 			// Clear stale data when disabled (e.g. paused or not visible).
-			this.#output.buffered.set([]);
+			this.#out.buffered.set([]);
 			return;
 		}
 
@@ -157,51 +157,51 @@ export class Decoder implements Backend {
 		// proxy() would share the same reference, allowing the source to close our frame.
 		effect.run((inner) => {
 			const frame = inner.get(active.frame);
-			this.#output.frame.update((prev) => {
+			this.#out.frame.update((prev) => {
 				prev?.close();
 				return frame?.clone();
 			});
 		});
-		effect.proxy(this.#output.timestamp, active.timestamp);
-		effect.proxy(this.#output.buffered, active.buffered);
+		effect.proxy(this.#out.timestamp, active.timestamp);
+		effect.proxy(this.#out.buffered, active.buffered);
 	}
 
 	#runDisplay(effect: Effect): void {
-		const catalog = effect.get(this.source.output.catalog);
+		const catalog = effect.get(this.source.out.catalog);
 		if (!catalog) return;
 
 		const display = catalog.display;
 		if (display) {
-			effect.set(this.#output.display, {
+			effect.set(this.#out.display, {
 				width: display.width,
 				height: display.height,
 			});
 			return;
 		}
 
-		const frame = effect.get(this.#output.frame);
+		const frame = effect.get(this.#out.frame);
 		if (!frame) return;
 
-		effect.set(this.#output.display, {
+		effect.set(this.#out.display, {
 			width: frame.displayWidth,
 			height: frame.displayHeight,
 		});
 	}
 
 	#runBuffering(effect: Effect): void {
-		const enabled = effect.get(this.input.enabled);
+		const enabled = effect.get(this.in.enabled);
 		if (!enabled) return;
 
-		const frame = effect.get(this.#output.frame);
+		const frame = effect.get(this.#out.frame);
 		if (!frame) {
-			this.#output.stalled.set(true);
+			this.#out.stalled.set(true);
 			return;
 		}
 
-		this.#output.stalled.set(false);
+		this.#out.stalled.set(false);
 
 		effect.timer(() => {
-			this.#output.stalled.set(true);
+			this.#out.stalled.set(true);
 		}, BUFFERING);
 	}
 
@@ -329,7 +329,7 @@ class DecoderTrack {
 		// Create consumer that reorders groups/frames up to the provided latency.
 		const consumer = new Container.Consumer(sub, {
 			format,
-			latency: this.sync.output.buffer,
+			latency: this.sync.out.buffer,
 		});
 		effect.cleanup(() => consumer.close());
 
@@ -412,7 +412,7 @@ class DecoderTrack {
 
 		const consumer = new Container.Consumer(sub, {
 			format: new Container.Cmaf.Format(init),
-			latency: this.sync.output.buffer,
+			latency: this.sync.out.buffer,
 		});
 		effect.cleanup(() => consumer.close());
 

--- a/js/watch/src/video/mse.ts
+++ b/js/watch/src/video/mse.ts
@@ -26,13 +26,13 @@ export class Mse implements Backend {
 	sync: Sync;
 	source: Source;
 
-	readonly #output: MseOutput = {
+	readonly #out: MseOutput = {
 		stats: new Signal<Stats | undefined>(undefined),
 		buffered: new Signal<BufferedRanges>([]),
 		stalled: new Signal<boolean>(false),
 		timestamp: new Signal<Moq.Time.Milli>(Moq.Time.Milli.zero),
 	};
-	readonly output = readonlys(this.#output);
+	readonly out = readonlys(this.#out);
 
 	signals = new Effect();
 
@@ -47,19 +47,19 @@ export class Mse implements Backend {
 	}
 
 	#runMedia(effect: Effect): void {
-		const element = effect.get(this.muxer.input.element);
+		const element = effect.get(this.muxer.in.element);
 		if (!element) return;
 
-		const mediaSource = effect.get(this.muxer.output.mediaSource);
+		const mediaSource = effect.get(this.muxer.out.mediaSource);
 		if (!mediaSource) return;
 
-		const broadcast = effect.get(this.source.input.broadcast);
+		const broadcast = effect.get(this.source.in.broadcast);
 		if (!broadcast) return;
 
-		const track = effect.get(this.source.output.track);
+		const track = effect.get(this.source.out.track);
 		if (!track) return;
 
-		const config = effect.get(this.source.output.config);
+		const config = effect.get(this.source.out.config);
 		if (!config) return;
 
 		// Honor a per-rendition `broadcast` override: subscribe on the resolved source
@@ -80,7 +80,7 @@ export class Mse implements Backend {
 		});
 
 		effect.event(sourceBuffer, "updateend", () => {
-			this.#output.buffered.set(timeRangesToArray(sourceBuffer.buffered));
+			this.#out.buffered.set(timeRangesToArray(sourceBuffer.buffered));
 		});
 
 		if (config.container.kind === "cmaf") {
@@ -167,7 +167,7 @@ export class Mse implements Backend {
 		// Create consumer that reorders groups/frames up to the provided latency.
 		const consumer = new Container.Consumer(data, {
 			format,
-			latency: this.sync.output.buffer,
+			latency: this.sync.out.buffer,
 		});
 		effect.cleanup(() => consumer.close());
 
@@ -232,11 +232,11 @@ export class Mse implements Backend {
 	}
 
 	#runStalled(effect: Effect): void {
-		const element = effect.get(this.muxer.input.element);
+		const element = effect.get(this.muxer.in.element);
 		if (!element) return;
 
 		const update = () => {
-			this.#output.stalled.set(element.readyState <= HTMLMediaElement.HAVE_CURRENT_DATA);
+			this.#out.stalled.set(element.readyState <= HTMLMediaElement.HAVE_CURRENT_DATA);
 		};
 
 		// Set initial state
@@ -249,7 +249,7 @@ export class Mse implements Backend {
 	}
 
 	#runTimestamp(effect: Effect): void {
-		const element = effect.get(this.muxer.input.element);
+		const element = effect.get(this.muxer.in.element);
 		if (!element) return;
 
 		// Use requestVideoFrameCallback if available (frame-accurate)
@@ -259,7 +259,7 @@ export class Mse implements Backend {
 			let handle: number;
 			const onFrame = () => {
 				const timestamp = Moq.Time.Milli.fromSecond(video.currentTime as Moq.Time.Second);
-				this.#output.timestamp.set(timestamp);
+				this.#out.timestamp.set(timestamp);
 				handle = video.requestVideoFrameCallback(onFrame);
 			};
 			handle = video.requestVideoFrameCallback(onFrame);
@@ -269,7 +269,7 @@ export class Mse implements Backend {
 			// Fallback to timeupdate event
 			effect.event(element, "timeupdate", () => {
 				const timestamp = Moq.Time.Milli.fromSecond(element.currentTime as Moq.Time.Second);
-				this.#output.timestamp.set(timestamp);
+				this.#out.timestamp.set(timestamp);
 			});
 		}
 	}

--- a/js/watch/src/video/renderer.ts
+++ b/js/watch/src/video/renderer.ts
@@ -40,27 +40,27 @@ type RendererOutput = {
 export class Renderer {
 	decoder: Decoder;
 
-	readonly input: Readonlys<RendererInput>;
+	readonly in: Readonlys<RendererInput>;
 
-	readonly #output: RendererOutput = {
+	readonly #out: RendererOutput = {
 		frame: new Signal<VideoFrame | undefined>(undefined),
 		timestamp: new Signal<Time.Milli | undefined>(undefined),
 		visible: new Signal(false),
 	};
-	readonly output = readonlys(this.#output);
+	readonly out = readonlys(this.#out);
 
 	#ctx = new Signal<CanvasRenderingContext2D | undefined>(undefined);
 	#signals = new Effect();
 
 	constructor(decoder: Decoder, props?: Inputs<RendererInput>) {
 		this.decoder = decoder;
-		this.input = {
+		this.in = {
 			canvas: getter(props?.canvas),
 			visible: getter(props?.visible ?? "20%"),
 		};
 
 		this.#signals.run((effect) => {
-			const canvas = effect.get(this.input.canvas);
+			const canvas = effect.get(this.in.canvas);
 			this.#ctx.set(canvas?.getContext("2d") ?? undefined);
 		});
 
@@ -70,7 +70,7 @@ export class Renderer {
 	}
 
 	#runResize(effect: Effect) {
-		const values = effect.getAll([this.input.canvas, this.decoder.output.display]);
+		const values = effect.getAll([this.in.canvas, this.decoder.out.display]);
 		if (!values) return; // Keep current canvas size until we have new dimensions
 		const [canvas, display] = values;
 
@@ -84,30 +84,30 @@ export class Renderer {
 
 	// Track whether the canvas should currently download per the configured distance and tab focus.
 	#runVisible(effect: Effect): void {
-		const visible = effect.get(this.input.visible);
+		const visible = effect.get(this.in.visible);
 
 		// "never" forces the check off; "always" forces it on regardless of viewport or tab state.
 		if (visible === "never") {
-			this.#output.visible.set(false);
+			this.#out.visible.set(false);
 			return;
 		}
 
 		if (visible === "always") {
-			this.#output.visible.set(true);
-			effect.cleanup(() => this.#output.visible.set(false));
+			this.#out.visible.set(true);
+			effect.cleanup(() => this.#out.visible.set(false));
 			return;
 		}
 
 		// A distance gates on the viewport (used as the rootMargin) and the tab being visible.
-		const canvas = effect.get(this.input.canvas);
+		const canvas = effect.get(this.in.canvas);
 		if (!canvas) {
-			this.#output.visible.set(false);
+			this.#out.visible.set(false);
 			return;
 		}
 
 		let intersecting = false;
 		const update = () => {
-			this.#output.visible.set(intersecting && !document.hidden);
+			this.#out.visible.set(intersecting && !document.hidden);
 		};
 
 		const callback = (entries: IntersectionObserverEntry[]) => {
@@ -131,14 +131,14 @@ export class Renderer {
 		effect.event(document, "visibilitychange", update);
 		observer.observe(canvas);
 		effect.cleanup(() => observer.disconnect());
-		effect.cleanup(() => this.#output.visible.set(false));
+		effect.cleanup(() => this.#out.visible.set(false));
 	}
 
 	#runRender(effect: Effect) {
 		const ctx = effect.get(this.#ctx);
 		if (!ctx) return;
 
-		const frame = effect.get(this.decoder.output.frame);
+		const frame = effect.get(this.decoder.out.frame);
 
 		// Request a callback to render the frame based on the monitor's refresh rate.
 		// Always render, even when paused (to show last frame).
@@ -146,17 +146,17 @@ export class Renderer {
 			this.#render(ctx, frame);
 
 			if (frame) {
-				this.#output.frame.update((current) => {
+				this.#out.frame.update((current) => {
 					current?.close();
 					return frame.clone();
 				});
-				this.#output.timestamp.set(Time.Milli.fromMicro(frame.timestamp as Time.Micro));
+				this.#out.timestamp.set(Time.Milli.fromMicro(frame.timestamp as Time.Micro));
 			} else {
-				this.#output.frame.update((current) => {
+				this.#out.frame.update((current) => {
 					current?.close();
 					return undefined;
 				});
-				this.#output.timestamp.set(undefined);
+				this.#out.timestamp.set(undefined);
 			}
 
 			animate = undefined;
@@ -182,7 +182,7 @@ export class Renderer {
 		ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
 
 		// Apply horizontal flip if specified in the video config
-		const flip = this.decoder.source.output.catalog.peek()?.flip;
+		const flip = this.decoder.source.out.catalog.peek()?.flip;
 		if (flip) {
 			ctx.scale(-1, 1);
 			ctx.translate(-ctx.canvas.width, 0);
@@ -194,11 +194,11 @@ export class Renderer {
 
 	// Close the track and all associated resources.
 	close() {
-		this.#output.frame.update((current) => {
+		this.#out.frame.update((current) => {
 			current?.close();
 			return undefined;
 		});
-		this.#output.timestamp.set(undefined);
+		this.#out.timestamp.set(undefined);
 		this.#signals.close();
 	}
 }

--- a/js/watch/src/video/source.test.ts
+++ b/js/watch/src/video/source.test.ts
@@ -16,10 +16,10 @@ function config(codec: string): Catalog.VideoConfig {
 
 function broadcast(renditions: Record<string, Catalog.VideoConfig>): Broadcast {
 	return {
-		input: {
+		in: {
 			connection: new Signal(undefined),
 		},
-		output: {
+		out: {
 			catalog: new Signal({ video: { renditions } }),
 		},
 	} as unknown as Broadcast;
@@ -44,8 +44,8 @@ describe("Source error signal", () => {
 			});
 
 			await settle();
-			expect(source.output.error.peek()).toBe("unsupported");
-			expect(source.output.available.peek()).toEqual({});
+			expect(source.out.error.peek()).toBe("unsupported");
+			expect(source.out.available.peek()).toEqual({});
 
 			source.close();
 		});
@@ -65,8 +65,8 @@ describe("Source error signal", () => {
 			});
 
 			await settle();
-			expect(source.output.error.peek()).toBeUndefined();
-			expect(Object.keys(source.output.available.peek())).toEqual(["good"]);
+			expect(source.out.error.peek()).toBeUndefined();
+			expect(Object.keys(source.out.available.peek())).toEqual(["good"]);
 
 			source.close();
 		});
@@ -79,8 +79,8 @@ describe("Source error signal", () => {
 		});
 
 		await settle();
-		expect(source.output.error.peek()).toBeUndefined();
-		expect(source.output.available.peek()).toEqual({});
+		expect(source.out.error.peek()).toBeUndefined();
+		expect(source.out.available.peek()).toEqual({});
 
 		source.close();
 	});

--- a/js/watch/src/video/source.ts
+++ b/js/watch/src/video/source.ts
@@ -210,9 +210,9 @@ function bestRendition(entries: [string, Catalog.VideoConfig][]): string {
  * for video playback. It is used by both MSE and Decoder backends.
  */
 export class Source {
-	readonly input: Readonlys<SourceInput>;
+	readonly in: Readonlys<SourceInput>;
 
-	readonly #output: SourceOutput = {
+	readonly #out: SourceOutput = {
 		catalog: new Signal<Catalog.Video | undefined>(undefined),
 		available: new Signal<Record<string, Catalog.VideoConfig>>({}),
 		error: new Signal<SourceError | undefined>(undefined),
@@ -220,12 +220,12 @@ export class Source {
 		config: new Signal<Catalog.VideoConfig | undefined>(undefined),
 		jitter: new Signal<Moq.Time.Milli | undefined>(undefined),
 	};
-	readonly output = readonlys(this.#output);
+	readonly out = readonlys(this.#out);
 
 	#signals = new Effect();
 
 	constructor(props?: Inputs<SourceInput>) {
-		this.input = {
+		this.in = {
 			broadcast: getter(props?.broadcast),
 			target: getter(props?.target),
 			supported: getter(props?.supported),
@@ -237,24 +237,24 @@ export class Source {
 	}
 
 	#runCatalog(effect: Effect): void {
-		const broadcast = effect.get(this.input.broadcast);
+		const broadcast = effect.get(this.in.broadcast);
 		if (!broadcast) return;
 
-		const catalog = effect.get(broadcast.output.catalog)?.video;
+		const catalog = effect.get(broadcast.out.catalog)?.video;
 		if (!catalog) return;
 
-		effect.set(this.#output.catalog, catalog);
+		effect.set(this.#out.catalog, catalog);
 	}
 
 	#runSupported(effect: Effect): void {
-		const supported = effect.get(this.input.supported);
+		const supported = effect.get(this.in.supported);
 		if (!supported) {
-			this.#output.error.set(undefined);
+			this.#out.error.set(undefined);
 			return;
 		}
 
-		const renditions = effect.get(this.#output.catalog)?.renditions ?? {};
-		this.#output.error.set(undefined);
+		const renditions = effect.get(this.#out.catalog)?.renditions ?? {};
+		this.#out.error.set(undefined);
 
 		effect.spawn(async () => {
 			const available: Record<string, Catalog.VideoConfig> = {};
@@ -278,31 +278,31 @@ export class Source {
 				console.warn("[Source] No supported video renditions found:", renditions);
 			}
 
-			this.#output.error.set(error);
-			this.#output.available.set(available);
+			this.#out.error.set(error);
+			this.#out.available.set(available);
 		});
 	}
 
 	#runSelected(effect: Effect): void {
-		const available = effect.get(this.#output.available);
+		const available = effect.get(this.#out.available);
 		if (Object.keys(available).length === 0) return;
 
-		const target = effect.get(this.input.target);
+		const target = effect.get(this.in.target);
 
 		// Manual selection by name — skip all ABR logic.
 		if (target?.name && target.name in available) {
 			const config = available[target.name];
-			effect.set(this.#output.track, target.name);
-			effect.set(this.#output.config, config);
-			effect.set(this.#output.jitter, config.jitter !== undefined ? Time.Milli(config.jitter) : undefined);
+			effect.set(this.#out.track, target.name);
+			effect.set(this.#out.config, config);
+			effect.set(this.#out.jitter, config.jitter !== undefined ? Time.Milli(config.jitter) : undefined);
 			return;
 		}
 
 		// Auto-select: use recv bandwidth if no explicit bitrate target.
 		let effectiveTarget = target;
 		if (!target?.bitrate) {
-			const broadcast = effect.get(this.input.broadcast);
-			const connection = broadcast ? effect.get(broadcast.input.connection) : undefined;
+			const broadcast = effect.get(this.in.broadcast);
+			const connection = broadcast ? effect.get(broadcast.in.connection) : undefined;
 			const recvBw = connection?.recvBandwidth;
 			if (recvBw) {
 				const estimate = effect.get(recvBw);
@@ -319,12 +319,12 @@ export class Source {
 
 		const config = available[selected];
 
-		effect.set(this.#output.track, selected);
-		effect.set(this.#output.config, config);
+		effect.set(this.#out.track, selected);
+		effect.set(this.#out.config, config);
 
 		// Use catalog jitter if available, otherwise estimate from framerate.
 		const jitter = config.jitter ?? (config.framerate ? Math.ceil(1000 / config.framerate) : undefined);
-		effect.set(this.#output.jitter, jitter !== undefined ? Time.Milli(jitter) : undefined);
+		effect.set(this.#out.jitter, jitter !== undefined ? Time.Milli(jitter) : undefined);
 	}
 
 	/**

--- a/test/smoke/clients/js-native/subscribe.ts
+++ b/test/smoke/clients/js-native/subscribe.ts
@@ -68,10 +68,10 @@ async function run(): Promise<void> {
 		const bc = connection.consume(path);
 
 		// The .hang catalog lives on the "catalog.json" track. It's a @moq/json
-		// snapshot+delta value, reconstructed by Json.Consumer. A lazy publisher may
+		// snapshot+delta value, reconstructed by Json.Snapshot.Consumer. A lazy publisher may
 		// announce video in a later update, so keep reading until one has it.
 		const track = bc.subscribe("catalog.json", { priority: Catalog.PRIORITY.catalog });
-		const catalog = new Json.Consumer<Catalog.Root>(track, { schema: Catalog.RootSchema });
+		const catalog = new Json.Snapshot.Consumer<Catalog.Root>(track, { schema: Catalog.RootSchema });
 		let videoTrack: string | undefined;
 		while (!videoTrack) {
 			const root = await catalog.next();

--- a/test/smoke/clients/js/driver.ts
+++ b/test/smoke/clients/js/driver.ts
@@ -79,7 +79,7 @@ try {
 		while (Date.now() < deadline) {
 			frames = await page.evaluate(() => {
 				const w = document.querySelector("moq-watch") as unknown as {
-					backend?: { video?: { output?: { stats?: { peek(): { frameCount?: number } | undefined } } } };
+					backend?: { video?: { out?: { stats?: { peek(): { frameCount?: number } | undefined } } } };
 				} | null;
 				return w?.backend?.video?.out?.stats?.peek()?.frameCount ?? 0;
 			});

--- a/test/smoke/clients/js/driver.ts
+++ b/test/smoke/clients/js/driver.ts
@@ -81,7 +81,7 @@ try {
 				const w = document.querySelector("moq-watch") as unknown as {
 					backend?: { video?: { output?: { stats?: { peek(): { frameCount?: number } | undefined } } } };
 				} | null;
-				return w?.backend?.video?.output?.stats?.peek()?.frameCount ?? 0;
+				return w?.backend?.video?.out?.stats?.peek()?.frameCount ?? 0;
 			});
 			if (frames > 0) break;
 			// The watch element gives up if it subscribes to the catalog before the


### PR DESCRIPTION
## Summary

- Rename classified JS signal groups from `.input` to `.in` and from `.output` to `.out`.
- Update `@moq/watch`, MoQ Boy, the web demo, signal examples, unit tests, and the JS smoke-test driver to use the shorter names.
- Update the native JS smoke subscriber for the current `Json.Snapshot.Consumer` API.
- Keep unrelated input and output terminology, such as DOM events and WebCodecs callbacks, unchanged.

## Public API changes

- Breaking: `@moq/watch` component signal accessors now use `.in` and `.out`; the former `.input` and `.output` names are removed.
- This PR targets `dev` because the rename breaks the published JavaScript API.

## Test plan

- `nix develop --command just js check`
- `nix develop --command just js test`
- `nix develop --command just test smoke --publishers rust --subscribers js-native-node,js-native-bun --timeout 30`
- `nix develop --command just ci` (project checks and builds passed; dependency audit is blocked by yanked `spin` versions already present on `dev`)
- `git diff --check`

(Written by GPT-5)
