### PR TITLE
refactor(moq-native): type request transports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,7 +2253,7 @@ dependencies = [
  "fastrand",
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -2425,7 +2425,7 @@ dependencies = [
  "diatomic-waker",
  "futures-core",
  "pin-project-lite",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -3882,7 +3882,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -7598,18 +7598,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spinning_top"

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -789,7 +789,7 @@ fn spawn_tcp_loop(
 	tokio::spawn(async move {
 		loop {
 			match listener.accept().await {
-				Some(Ok(session)) => spawn_stream_request(session, "tcp", versions.clone(), tx.clone()),
+				Some(Ok(session)) => spawn_stream_request(session, Transport::Tcp, versions.clone(), tx.clone()),
 				Some(Err(err)) => tracing::warn!(%err, "tcp listener accept failed"),
 				None => break,
 			}
@@ -815,7 +815,7 @@ fn spawn_unix_loop(
 						tracing::warn!(uid = cred.uid, gid = cred.gid, pid = ?cred.pid, "unix connection rejected by allow list");
 						continue;
 					}
-					spawn_stream_request(session, "unix", versions.clone(), tx.clone());
+					spawn_stream_request(session, Transport::Unix, versions.clone(), tx.clone());
 				}
 				Some(Err(err)) => tracing::warn!(%err, "unix listener accept failed"),
 				None => break,
@@ -829,7 +829,7 @@ fn spawn_unix_loop(
 #[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
 fn spawn_stream_request(
 	session: qmux::Session,
-	transport: &'static str,
+	transport: Transport,
 	versions: moq_net::Versions,
 	tx: tokio::sync::mpsc::Sender<Request>,
 ) {
@@ -853,7 +853,7 @@ fn spawn_stream_request(
 #[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
 pub(crate) struct StreamRequest {
 	request: moq_net::Request<qmux::Session>,
-	transport: &'static str,
+	transport: Transport,
 }
 
 /// An incoming connection that can be accepted or rejected.
@@ -870,6 +870,41 @@ pub(crate) enum RequestKind {
 	WebSocket(Box<qmux::Session>),
 	#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
 	Stream(Box<StreamRequest>),
+}
+
+/// The network transport carrying an incoming MoQ session.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Transport {
+	/// QUIC, either directly or through WebTransport over HTTP/3.
+	Quic,
+	/// An Iroh QUIC connection.
+	Iroh,
+	/// A WebSocket connection using qmux framing.
+	WebSocket,
+	/// A plaintext TCP connection using qmux framing.
+	Tcp,
+	/// A Unix domain socket using qmux framing.
+	Unix,
+}
+
+impl Transport {
+	/// Returns the stable lowercase name used in logs and external metadata.
+	pub const fn as_str(self) -> &'static str {
+		match self {
+			Self::Quic => "quic",
+			Self::Iroh => "iroh",
+			Self::WebSocket => "websocket",
+			Self::Tcp => "tcp",
+			Self::Unix => "unix",
+		}
+	}
+}
+
+impl std::fmt::Display for Transport {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.write_str(self.as_str())
+	}
 }
 
 /// An incoming MoQ session that can be accepted or rejected.
@@ -1040,19 +1075,19 @@ impl Request {
 		}
 	}
 
-	/// Returns the transport type as a string (e.g. "quic", "tcp", "unix").
-	pub fn transport(&self) -> &'static str {
+	/// Returns the network transport carrying this session.
+	pub fn transport(&self) -> Transport {
 		match self.kind {
 			#[cfg(feature = "noq")]
-			RequestKind::Noq(_) => "quic",
+			RequestKind::Noq(_) => Transport::Quic,
 			#[cfg(feature = "quinn")]
-			RequestKind::Quinn(_) => "quic",
+			RequestKind::Quinn(_) => Transport::Quic,
 			#[cfg(feature = "quiche")]
-			RequestKind::Quiche(_) => "quic",
+			RequestKind::Quiche(_) => Transport::Quic,
 			#[cfg(feature = "iroh")]
-			RequestKind::Iroh(_) => "iroh",
+			RequestKind::Iroh(_) => Transport::Iroh,
 			#[cfg(feature = "websocket")]
-			RequestKind::WebSocket(_) => "websocket",
+			RequestKind::WebSocket(_) => Transport::WebSocket,
 			#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
 			RequestKind::Stream(ref stream) => stream.transport,
 		}
@@ -1170,6 +1205,15 @@ impl std::str::FromStr for ServerId {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn transport_names_are_stable() {
+		assert_eq!(Transport::Quic.as_str(), "quic");
+		assert_eq!(Transport::Iroh.as_str(), "iroh");
+		assert_eq!(Transport::WebSocket.as_str(), "websocket");
+		assert_eq!(Transport::Tcp.as_str(), "tcp");
+		assert_eq!(Transport::Unix.as_str(), "unix");
+	}
 
 	#[test]
 	fn test_tls_string_or_array() {

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -1063,7 +1063,7 @@ async fn broadcast_websocket() {
 	// ── run server and client concurrently ──────────────────────────
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		assert_eq!(request.transport(), "websocket");
+		assert_eq!(request.transport(), moq_native::Transport::WebSocket);
 		let session = request.with_publisher(&pub_origin).ok().await?;
 
 		let _broadcast = broadcast;
@@ -1174,7 +1174,7 @@ async fn broadcast_websocket_fallback() {
 	// ── run server and client concurrently ──────────────────────────
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		assert_eq!(request.transport(), "websocket");
+		assert_eq!(request.transport(), moq_native::Transport::WebSocket);
 		let session = request.with_publisher(&pub_origin).ok().await?;
 
 		let _broadcast = broadcast;
@@ -1281,7 +1281,7 @@ async fn broadcast_websocket_uses_newest_version() {
 
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
-		assert_eq!(request.transport(), "websocket");
+		assert_eq!(request.transport(), moq_native::Transport::WebSocket);
 		let session = request.with_publisher(&pub_origin).ok().await?;
 		assert_eq!(session.version(), expected_version, "server negotiated stale version");
 		let _broadcast = broadcast;
@@ -1355,7 +1355,7 @@ async fn broadcast_race_quic_wins() {
 		let request = server.accept().await.expect("no incoming connection");
 		assert_eq!(
 			request.transport(),
-			"quic",
+			moq_native::Transport::Quic,
 			"QUIC lost the race to WebSocket with both reachable",
 		);
 		let session = request.with_publisher(&pub_origin).ok().await?;

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use axum::http;
+use moq_native::Transport;
 #[cfg(test)]
 use moq_net::AsPath;
 use moq_net::{Path, PathOwned, PathPrefixes, Tier};
@@ -24,9 +25,8 @@ pub struct AuthParams {
 	/// The connection's transport, forwarded to the auth API as `transport=` so it
 	/// can bucket by connection type (e.g. bill traffic on the internal Unix-socket
 	/// listener -- the out-of-process RTMP/SRT/WebRTC gateways, `"unix"` -- into a
-	/// distinct tier). `Request::transport()` values: `"quic"`, `"websocket"`,
-	/// `"tcp"`, `"unix"`, `"iroh"`. Absent (`None`) sends no `transport` param.
-	pub transport: Option<String>,
+	/// distinct tier). Absent (`None`) sends no `transport` parameter.
+	pub transport: Option<Transport>,
 }
 
 impl AuthParams {
@@ -944,7 +944,7 @@ impl Auth {
 	/// This method applies the relay's canonical alias resolution and billing
 	/// tier decision, so embedded HTTP handlers get the same authorization scope
 	/// as the built-in relay routes.
-	pub async fn verify_mtls(&self, path: &str, transport: Option<&str>) -> Result<AuthToken, AuthError> {
+	pub async fn verify_mtls(&self, path: &str, transport: Option<Transport>) -> Result<AuthToken, AuthError> {
 		let (root, tier) = self.resolve_mtls(path, transport).await?;
 		let mut token = AuthToken::unrestricted(Path::new(&root).to_owned());
 		token.tier = tier;
@@ -965,12 +965,12 @@ impl Auth {
 	/// canonical root (e.g. `x7k2qp`), producing a zombie session: the publisher
 	/// believes it is connected and never reconnects, but nothing is ever served.
 	/// Failing closed lets the client retry and self-heal once the API recovers.
-	async fn resolve_mtls(&self, path: &str, transport: Option<&str>) -> Result<(String, Tier), AuthError> {
+	async fn resolve_mtls(&self, path: &str, transport: Option<Transport>) -> Result<(String, Tier), AuthError> {
 		let Some((base, client)) = &self.auth_api else {
 			return Ok((path.to_string(), self.mtls_tier.clone()));
 		};
 
-		let resp = Self::fetch_auth_api(client, base, path, None, true, transport).await?;
+		let resp = Self::fetch_auth_api(client, base, path, None, true, transport.map(Transport::as_str)).await?;
 		// Fall back to the configured mTLS tier when the API omits one.
 		let tier = resp.tier().unwrap_or_else(|| self.mtls_tier.clone());
 		Ok((resp.alias.unwrap_or_else(|| path.to_string()), tier))
@@ -1039,7 +1039,7 @@ impl Auth {
 			&params.path,
 			kid.as_deref(),
 			false,
-			params.transport.as_deref(),
+			params.transport.map(Transport::as_str),
 		)
 		.await?;
 		// Resolve the tier before consuming `resp`'s other fields below.
@@ -3285,7 +3285,7 @@ api = "https://api.example.com/access"
 		let auth = auth_with_api(&server).await;
 		let params = AuthParams {
 			path: "/customer/live".into(),
-			transport: Some("unix".into()),
+			transport: Some(Transport::Unix),
 			..Default::default()
 		};
 		let verified = auth.verify(&params).await?;

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -54,13 +54,13 @@ impl Connection {
 
 		match (&publish, &subscribe) {
 			(Some(publish), Some(subscribe)) => {
-				tracing::info!(transport, tier = %token.tier, root = %token.root, publish = %publish.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), subscribe = %subscribe.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "session accepted");
+				tracing::info!(%transport, tier = %token.tier, root = %token.root, publish = %publish.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), subscribe = %subscribe.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "session accepted");
 			}
 			(Some(publish), None) => {
-				tracing::info!(transport, tier = %token.tier, root = %token.root, publish = %publish.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "publisher accepted");
+				tracing::info!(%transport, tier = %token.tier, root = %token.root, publish = %publish.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "publisher accepted");
 			}
 			(None, Some(subscribe)) => {
-				tracing::info!(transport, tier = %token.tier, root = %token.root, subscribe = %subscribe.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "subscriber accepted")
+				tracing::info!(%transport, tier = %token.tier, root = %token.root, subscribe = %subscribe.allowed().map(|p| p.as_str()).collect::<Vec<_>>().join(","), "subscriber accepted")
 			}
 			_ => {
 				let _ = self.request.close(http::StatusCode::FORBIDDEN.as_u16()).await;
@@ -96,7 +96,7 @@ impl Connection {
 		}
 		let session = request.ok().await?;
 
-		tracing::info!(version = %session.version(), transport, "negotiated");
+		tracing::info!(version = %session.version(), %transport, "negotiated");
 
 		// The credential (JWT `exp` or client cert `notAfter`) is only checked at
 		// connect time, so hold the session open no longer than the credential is
@@ -155,7 +155,7 @@ impl Connection {
 			// URL-less stream transports: path + `?jwt=` ride the SETUP.
 			None => AuthParams::from_path(self.request.path().unwrap_or("")),
 		};
-		params.transport = Some(transport.to_string());
+		params.transport = Some(transport);
 
 		Ok(self.auth.verify(&params).await?)
 	}

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -493,10 +493,7 @@ async fn serve_announced(
 	};
 	let token = if mtls.is_some() {
 		// mTLS peers: the API returns the canonical root and the billing tier.
-		state
-			.auth
-			.verify_mtls(&params.path, params.transport.as_deref())
-			.await?
+		state.auth.verify_mtls(&params.path, params.transport).await?
 	} else {
 		state.auth.verify(&params).await?
 	};
@@ -542,7 +539,7 @@ async fn serve_fetch(
 	};
 	let token = if mtls.is_some() {
 		// mTLS peers: the API returns the canonical root and the billing tier.
-		state.auth.verify_mtls(&auth.path, auth.transport.as_deref()).await?
+		state.auth.verify_mtls(&auth.path, auth.transport).await?
 	} else {
 		state.auth.verify(&auth).await?
 	};

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -45,14 +45,11 @@ pub(crate) async fn serve_ws(
 	let params = AuthParams {
 		path,
 		jwt: query.jwt,
-		transport: Some("websocket".to_string()),
+		transport: Some(moq_native::Transport::WebSocket),
 	};
 	let token = if mtls.is_some() {
 		// mTLS peers: the API returns the canonical root and the billing tier.
-		state
-			.auth
-			.verify_mtls(&params.path, params.transport.as_deref())
-			.await?
+		state.auth.verify_mtls(&params.path, params.transport).await?
 	} else {
 		state.auth.verify(&params).await?
 	};


### PR DESCRIPTION
## Summary

- Replace stringly typed request transport metadata with a documented `moq_native::Transport` enum.
- Preserve stable lowercase names through `as_str()` and `Display`, converting only at logging, HTTP query, and UniFFI boundaries.
- Carry the enum through relay authentication so invalid transport labels cannot be represented in Rust.

## Public API changes

- Add the non-exhaustive `moq_native::Transport` enum.
- Change `moq_native::Request::transport()` from `&'static str` to `Transport`.
- Change `moq_relay::AuthParams::transport` from `Option<String>` to `Option<Transport>`.
- Change `moq_relay::Auth::verify_mtls` to accept `Option<Transport>`.

These signature changes are breaking, so this PR targets `dev`. The UniFFI and language-wrapper surfaces remain strings at the foreign-language boundary, so no generated binding or wrapper changes are needed.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `cargo test -p moq-native transport_names_are_stable`
- `cargo test -p moq-relay auth_api_forwards_transport_for_tiering`

(Written by GPT-5)
