### PR TITLE
chore: refresh cargo-deny advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,7 +2253,7 @@ dependencies = [
  "fastrand",
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -2425,7 +2425,7 @@ dependencies = [
  "diatomic-waker",
  "futures-core",
  "pin-project-lite",
- "spin 0.10.0",
+ "spin 0.10.1",
 ]
 
 [[package]]
@@ -3882,7 +3882,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -7598,18 +7598,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
 
 [[package]]
 name = "spin"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spinning_top"

--- a/deny.toml
+++ b/deny.toml
@@ -26,18 +26,6 @@ ignore = [
     # requires Rust 1.92; workspace MSRV is 1.85. Build-time only.
     "RUSTSEC-2024-0436",
 
-    # proc-macro-error2 unmaintained. Pulled in transitively as a build-time
-    # proc-macro via local-ip-address -> neli -> getset; no runtime exposure.
-    # Drop the ignore when getset migrates off proc-macro-error2.
-    "RUSTSEC-2026-0173",
-
-    # quick-xml 0.39 DoS on untrusted XML (quadratic attribute check, unbounded
-    # namespace allocation). Fixed in 0.41, but the only consumer is
-    # plist -> netdev -> netwatch -> iroh, and even the latest plist pins
-    # quick-xml 0.39. netdev only parses local macOS system configuration, not
-    # attacker-controlled XML. Drop both when plist moves to quick-xml >= 0.41.
-    "RUSTSEC-2026-0194",
-    "RUSTSEC-2026-0195",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

- Update yanked `spin` 0.9.8 and 0.10.0 lockfile entries to compatible 0.9.9 and 0.10.1 releases.
- Remove advisory ignores that no longer match the `dev` dependency graph.
- Restore a clean cargo-deny advisory result after registry yanks and dependency updates changed external advisory state.

## Public API changes

None.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just ci origin/dev`
- `nix develop --command cargo deny check advisories --show-stats` (0 errors, 0 warnings)

No cross-package sync updates are needed because this changes only dependency lockfile versions and cargo-deny configuration.

(Written by GPT-5)
