### PR TITLE
feat(moq-ffi): expose client mTLS certificate configuration

### DIFF
--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -69,6 +69,31 @@ mod tests {
 		let state = client.task.lock().expect("client state should be available");
 		assert_eq!(state.config.tls.system_roots, Some(false));
 	}
+
+	#[test]
+	fn sets_tls_client_cert_and_key() {
+		let client = MoqClient::new();
+
+		client.set_tls_cert(Some("client.pem".into()));
+		client.set_tls_key(Some("client.key".into()));
+		{
+			let state = client.task.lock().expect("client state should be available");
+			assert_eq!(
+				state.config.tls.cert.as_deref(),
+				Some(std::path::Path::new("client.pem"))
+			);
+			assert_eq!(
+				state.config.tls.key.as_deref(),
+				Some(std::path::Path::new("client.key"))
+			);
+		}
+
+		client.set_tls_cert(None);
+		client.set_tls_key(None);
+		let state = client.task.lock().expect("client state should be available");
+		assert_eq!(state.config.tls.cert, None);
+		assert_eq!(state.config.tls.key, None);
+	}
 }
 
 #[derive(uniffi::Object)]
@@ -128,6 +153,27 @@ impl MoqClient {
 	pub fn set_tls_fingerprints(&self, fingerprints: Vec<String>) {
 		if let Some(mut state) = self.task.lock() {
 			state.config.tls.fingerprint = fingerprints;
+		}
+	}
+
+	/// Present this client certificate when the server requests one (mTLS).
+	///
+	/// Pass the path to a PEM file containing the certificate chain; only certificates
+	/// are extracted. Must be paired with `set_tls_key`: connecting with only one of the
+	/// pair configured fails. `None` clears it, connecting without a client certificate.
+	pub fn set_tls_cert(&self, path: Option<String>) {
+		if let Some(mut state) = self.task.lock() {
+			state.config.tls.cert = path.map(Into::into);
+		}
+	}
+
+	/// Use the private key at this path for mTLS.
+	///
+	/// Pass the path to a PEM file containing the private key; only the key is
+	/// extracted. Must be paired with `set_tls_cert`. `None` clears it.
+	pub fn set_tls_key(&self, path: Option<String>) {
+		if let Some(mut state) = self.task.lock() {
+			state.config.tls.key = path.map(Into::into);
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add `set_tls_cert` / `set_tls_key` to `MoqClient` so FFI consumers (Python, Swift, Kotlin, Go) can present a client certificate when the relay requires mTLS.
- `moq-native` already supports client certificates via `--client-tls-cert` / `--client-tls-key` (#1308), but the UniFFI client surface had no way to reach the `tls.cert` / `tls.key` config fields, so embedders could not authenticate against an mTLS relay without shelling out to the CLI.
- Pairing is validated by `moq-native` at init time (`Error::IncompleteClientAuth` when only one of the pair is set), matching the CLI behavior. Passing `None` clears a previously set path.

## Public API changes

- `moq-ffi`: new exported methods `MoqClient::set_tls_cert(path: Option<String>)` and `MoqClient::set_tls_key(path: Option<String>)`. Additive only; no existing signatures changed.

Cross-package sync rows skipped:
- `rs/libmoq`: it has no client TLS configuration surface today (its connect path builds `ClientConfig::default()`), so there is no parallel setter to mirror; exposing client TLS over the C ABI is a separate design.
- `py/swift/kt/go`: bindings are generated from `moq-ffi` by UniFFI. The ergonomic `py/moq-rs` `Client` constructor does not yet wrap `set_tls_system_roots` either, so I left kwargs plumbing for a follow-up to keep this PR shaped like #1978. Happy to add `tls_cert=` / `tls_key=` kwargs here if preferred.
- `doc/lib`: the doc pages do not enumerate individual `MoqClient` setters, so there is no page to update.

## Test plan

- `cargo test -p moq-ffi`: 26 passed, including the new `sets_tls_client_cert_and_key` unit test (set, read back, clear).
- `cargo fmt -p moq-ffi --check` and `cargo clippy -p moq-ffi`: clean (the pre-existing `gso_disabled` dead-code warning in `moq-native` is untouched).
- `RUSTDOCFLAGS="-D warnings" cargo doc -p moq-ffi --no-deps`: clean.

(Written by Claude Fable 5)
