### PR TITLE
feat(publish): measure the upload bitrate from encoder Stats

### DIFF
--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -50,6 +50,15 @@ export type OpusConfig = {
 	usedtx?: boolean; // discontinuous transmission (silence suppression)
 };
 
+/** Cumulative encoder output totals, measured from the chunks the encoder produces. */
+export interface Stats {
+	/** Total frames encoded while serving. Monotonic; diff over an interval for a frame rate. */
+	frames: number;
+
+	/** Total bytes encoded while serving. Monotonic; diff over an interval for an upload bitrate. */
+	bytes: number;
+}
+
 // The initial values for our signals.
 export type EncoderProps = {
 	enabled?: boolean | Signal<boolean>;
@@ -100,6 +109,10 @@ export class Encoder {
 	readonly root: Getter<AudioNode | undefined> = this.#gain;
 
 	active = new Signal<boolean>(false);
+
+	#stats = new Signal<Stats>({ frames: 0, bytes: 0 });
+	/** Cumulative encoder output totals (frames, bytes) measured while serving. */
+	readonly stats: Getter<Stats> = this.#stats;
 
 	#signals = new Effect();
 
@@ -291,6 +304,11 @@ export class Encoder {
 					if (frame.type !== "key") {
 						throw new Error("only key frames are supported");
 					}
+
+					this.#stats.update((stats) => ({
+						frames: stats.frames + 1,
+						bytes: stats.bytes + frame.byteLength,
+					}));
 
 					// Each audio frame is its own group so the relay can forward it without
 					// waiting for a group boundary. Loss is handled by the codec's PLC.

--- a/js/publish/src/ui/components/stats-tab.ts
+++ b/js/publish/src/ui/components/stats-tab.ts
@@ -23,7 +23,7 @@ function card(kind: Kind, label: string, svg: string): { el: HTMLElement; grid: 
 }
 
 /** Show an active/idle pill: an encoder only runs (and uses bandwidth) while a viewer is subscribed. */
-function trackActive(parent: Effect, status: HTMLElement, active: Getter<boolean>) {
+function trackActive(parent: Effect, status: HTMLElement, active: Getter<boolean | undefined>) {
 	parent.run((effect) => {
 		const on = effect.get(active);
 		status.style.display = "";
@@ -56,8 +56,12 @@ export function statsTab(parent: Effect, publish: MoqPublish): HTMLElement {
 	const vFpsGraph = graph(parent, "Frame rate", { color: "#facc15", format: formatFps });
 	videoCard.el.append(vBitrateGraph.el, vFpsGraph.el);
 
-	// active = a viewer is subscribed and we're actually encoding/sending.
-	trackActive(parent, videoCard.status, publish.broadcast.video.hd.active);
+	// active = a viewer is subscribed and we're actually encoding/sending. Either rendition counts,
+	// and the bitrate graph below sums both.
+	const videoActive = parent.computed(
+		(effect) => effect.get(publish.broadcast.video.hd.active) || effect.get(publish.broadcast.video.sd.active),
+	);
+	trackActive(parent, videoCard.status, videoActive);
 
 	const audioCard = card("audio", "Audio", audioIcon);
 	const aCodec = line(audioCard.grid, "Codec");
@@ -101,25 +105,34 @@ export function statsTab(parent: Effect, publish: MoqPublish): HTMLElement {
 		nName.textContent = name?.toString() || "—";
 	});
 
-	// Live graphs: frame rate from captured frames, bitrate from the upload estimate.
+	// Live graphs: frame rate from captured frames, bitrate measured from the bytes we encoded.
+	// The congestion controller's send estimate would be simpler, but Safari's WebTransport has no
+	// getStats(), so it has no estimate at all and the graph stayed empty there.
 	let frames = 0;
 	parent.subscribe(publish.broadcast.video.frame, () => {
 		frames++;
 	});
+
+	const encoded = () =>
+		publish.broadcast.video.hd.bytesEncoded.peek() + publish.broadcast.video.sd.bytesEncoded.peek();
+
 	let prevFrames = 0;
+	let prevBytes = encoded();
 	let prevWhen = performance.now();
 
 	parent.interval(() => {
 		const now = performance.now();
 		const elapsed = now - prevWhen;
-		const delta = frames - prevFrames;
-		const fps = elapsed > 0 && delta > 0 ? delta / (elapsed / 1000) : undefined;
-		prevFrames = frames;
 		prevWhen = now;
-		vFpsGraph.push(fps);
 
-		const upload = publish.connection.established.peek()?.sendBandwidth?.peek();
-		vBitrateGraph.push(upload && upload > 0 ? upload : undefined);
+		const frameDelta = frames - prevFrames;
+		prevFrames = frames;
+		vFpsGraph.push(elapsed > 0 && frameDelta > 0 ? frameDelta / (elapsed / 1000) : undefined);
+
+		const bytes = encoded();
+		const byteDelta = bytes - prevBytes;
+		prevBytes = bytes;
+		vBitrateGraph.push(elapsed > 0 && byteDelta > 0 ? (byteDelta * 8) / (elapsed / 1000) : undefined);
 	}, POLL_MS);
 
 	return container;

--- a/js/publish/src/ui/components/stats-tab.ts
+++ b/js/publish/src/ui/components/stats-tab.ts
@@ -113,8 +113,7 @@ export function statsTab(parent: Effect, publish: MoqPublish): HTMLElement {
 		frames++;
 	});
 
-	const encoded = () =>
-		publish.broadcast.video.hd.bytesEncoded.peek() + publish.broadcast.video.sd.bytesEncoded.peek();
+	const encoded = () => publish.broadcast.video.stats.peek().bytes;
 
 	let prevFrames = 0;
 	let prevBytes = encoded();

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -50,6 +50,10 @@ export class Encoder {
 	#catalog = new Signal<Catalog.VideoConfig | undefined>(undefined);
 	readonly catalog: Getter<Catalog.VideoConfig | undefined> = this.#catalog;
 
+	#bytesEncoded = new Signal(0);
+	/** Total bytes encoded while serving. Monotonic; diff it over an interval for an upload bitrate. */
+	readonly bytesEncoded: Getter<number> = this.#bytesEncoded;
+
 	#signals = new Effect();
 
 	// The user provided config.
@@ -105,6 +109,8 @@ export class Encoder {
 					if (frame.type === "key") {
 						lastKeyframe = frame.timestamp as Time.Micro;
 					}
+
+					this.#bytesEncoded.update((total) => total + frame.byteLength);
 
 					producer.encode(frame, frame.timestamp as Time.Micro, frame.type === "key");
 				},

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -12,6 +12,18 @@ export interface EncoderProps {
 	container?: Catalog.Container;
 }
 
+/** Cumulative encoder output totals, measured from the chunks the encoder produces. */
+export interface Stats {
+	/** Total frames encoded while serving. Monotonic; diff over an interval for a frame rate. */
+	frames: number;
+
+	/** Total bytes encoded while serving. Monotonic; diff over an interval for an upload bitrate. */
+	bytes: number;
+
+	/** Total keyframes encoded while serving. Divide frames by this for the average GOP length. */
+	keyframes: number;
+}
+
 // TODO support signals?
 export interface EncoderConfig {
 	// If not provided, the encoder will select the best codec.
@@ -50,9 +62,9 @@ export class Encoder {
 	#catalog = new Signal<Catalog.VideoConfig | undefined>(undefined);
 	readonly catalog: Getter<Catalog.VideoConfig | undefined> = this.#catalog;
 
-	#bytesEncoded = new Signal(0);
-	/** Total bytes encoded while serving. Monotonic; diff it over an interval for an upload bitrate. */
-	readonly bytesEncoded: Getter<number> = this.#bytesEncoded;
+	#stats = new Signal<Stats>({ frames: 0, bytes: 0, keyframes: 0 });
+	/** Cumulative encoder output totals (frames, bytes, keyframes) measured while serving. */
+	readonly stats: Getter<Stats> = this.#stats;
 
 	#signals = new Effect();
 
@@ -106,13 +118,18 @@ export class Encoder {
 		effect.spawn(async () => {
 			const encoder = new VideoEncoder({
 				output: (frame: EncodedVideoChunk) => {
-					if (frame.type === "key") {
+					const key = frame.type === "key";
+					if (key) {
 						lastKeyframe = frame.timestamp as Time.Micro;
 					}
 
-					this.#bytesEncoded.update((total) => total + frame.byteLength);
+					this.#stats.update((stats) => ({
+						frames: stats.frames + 1,
+						bytes: stats.bytes + frame.byteLength,
+						keyframes: key ? stats.keyframes + 1 : stats.keyframes,
+					}));
 
-					producer.encode(frame, frame.timestamp as Time.Micro, frame.type === "key");
+					producer.encode(frame, frame.timestamp as Time.Micro, key);
 				},
 				error: (err: Error) => {
 					producer.close(err);

--- a/js/publish/src/video/index.ts
+++ b/js/publish/src/video/index.ts
@@ -1,7 +1,7 @@
 import * as Catalog from "@moq/hang/catalog";
 import type * as Moq from "@moq/net";
 import { Effect, type Getter, Signal } from "@moq/signals";
-import { Encoder, type EncoderConfig, type EncoderProps } from "./encoder";
+import { Encoder, type EncoderConfig, type EncoderProps, type Stats } from "./encoder";
 import { TrackProcessor } from "./polyfill";
 import type { Source } from "./types";
 
@@ -32,6 +32,12 @@ export class Root {
 	hd: Encoder;
 	sd: Encoder;
 
+	#stats = new Signal<Stats & { hd?: Stats; sd?: Stats }>(aggregate([]));
+	// Combined encoder stats, since simulcast splits video across two encoders (hd + sd). The top-level
+	// totals sum every enabled rendition; hd/sd break them out. A rendition is present only while it's
+	// enabled, so a consumer reads one getter (and its totals) instead of knowing about the split.
+	readonly stats: Getter<Stats & { hd?: Stats; sd?: Stats }> = this.#stats;
+
 	frame = new Signal<VideoFrame | undefined>(undefined);
 
 	catalog = new Signal<Catalog.Video | undefined>(undefined);
@@ -54,6 +60,14 @@ export class Root {
 
 		this.signals.run(this.#runCatalog.bind(this));
 		this.signals.run(this.#runFrame.bind(this));
+		this.signals.run(this.#runStats.bind(this));
+	}
+
+	#runStats(effect: Effect) {
+		const hd = effect.get(this.hd.enabled) ? effect.get(this.hd.stats) : undefined;
+		const sd = effect.get(this.sd.enabled) ? effect.get(this.sd.stats) : undefined;
+		const total = aggregate([hd, sd].filter((s): s is Stats => s !== undefined));
+		this.#stats.set({ ...total, hd, sd });
 	}
 
 	#runFrame(effect: Effect) {
@@ -124,4 +138,15 @@ export class Root {
 			return undefined;
 		});
 	}
+}
+
+// Sum per-encoder Stats into a combined total (across simulcast renditions).
+function aggregate(stats: Iterable<Stats>): Stats {
+	const total: Stats = { frames: 0, bytes: 0, keyframes: 0 };
+	for (const s of stats) {
+		total.frames += s.frames;
+		total.bytes += s.bytes;
+		total.keyframes += s.keyframes;
+	}
+	return total;
 }


### PR DESCRIPTION
Takes over #2213 (from @fperex), addressing the review feedback there. The first commit is fperex's original work, preserved; the second reshapes the public API per review.

## Root cause

The stats tab graphs the connection's send-bandwidth estimate:

```ts
const upload = publish.connection.established.peek()?.sendBandwidth?.peek();
vBitrateGraph.push(upload && upload > 0 ? upload : undefined);
```

Safari has no such estimate. Its WebTransport implements no `getStats()`, so `sendBandwidth` is `undefined` and the bitrate graph stays empty for the whole session. Counting the bytes the encoder actually produces is transport agnostic (works on Safari and the WebSocket fallback), is what we really upload rather than an estimate of what we could, and matches the graph's "Bitrate" label.

## Review feedback

> just call it `bytes`. Or better yet, make a Stats object so we report frames/bytes/etc.

Instead of a lone `bytesEncoded` getter, each encoder exposes a measured-output `Stats` object. The boundary is deliberate: `stats` is what the encoder *measured*, `resolved`/`catalog` is what it was *configured* to do, so configured values aren't duplicated in.

`Video.Encoder`:

```ts
export interface Stats {
	frames: number;    // cumulative encoded frames
	bytes: number;     // cumulative encoded bytes
	keyframes: number; // cumulative keyframes; frames / keyframes = average GOP length
}

readonly stats: Getter<Stats>;
```

`Audio.Encoder` gets the same `stats: Getter<Stats>` with `{ frames, bytes }`. Audio has no keyframe concept (every frame is a key frame), so it omits that field.

All counters are monotonic, measured from the chunks the encoder produces; diff two samples over an interval for a rate. The fields are additive, so future counters slot in without a breaking change. The stats tab reads `stats.bytes` (summed across the hd + sd renditions) for the upload bitrate; the "Frame rate" graph stays on the shared capture signal, since summing per-rendition encoded frames would double-count the same source frames.

## Public API

Additive:
- `@moq/publish` `Video.Encoder.stats: Getter<Stats>` + `Video.Stats { frames, bytes, keyframes }`
- `@moq/publish` `Audio.Encoder.stats: Getter<Stats>` + `Audio.Stats { frames, bytes }`

## Test plan

`just js check` and `just js test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)