### PR TITLE
fix(moq-hls): release source subscriptions when a Broadcaster is dropped

### DIFF
--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -12,7 +12,7 @@ mod rendition;
 pub mod store;
 
 use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
 use moq_mux::catalog::hang::Catalog;
@@ -24,6 +24,19 @@ pub use rendition::{Kind, Rendition};
 
 /// How long to wait before retrying the initial catalog subscription.
 const CATALOG_RETRY: Duration = Duration::from_millis(250);
+
+/// Aborts a spawned task when dropped, tying the task's lifetime to the value that
+/// owns this guard. Used to stop the catalog watcher + rendition pumps the moment a
+/// [`Broadcaster`] is dropped, so its source subscriptions are released instead of
+/// lingering until the broadcast itself closes (which a subscription-driven
+/// publisher would never do while we hold it open -- a self-sustaining leak).
+pub(super) struct AbortOnDrop(pub(super) tokio::task::AbortHandle);
+
+impl Drop for AbortOnDrop {
+	fn drop(&mut self) {
+		self.0.abort();
+	}
+}
 
 /// Export tuning shared across renditions.
 #[derive(Clone, Debug)]
@@ -62,6 +75,11 @@ pub struct Broadcaster {
 	/// reading; renditions discovered later inherit the current value (they
 	/// `subscribe()` to this sender).
 	paused: watch::Sender<bool>,
+	/// Aborts the [`watch_catalog`] task when this `Broadcaster` is dropped. The task
+	/// holds only a `Weak<Self>`, so dropping the last external `Arc` runs this `Drop`
+	/// (and, transitively, every rendition's [`AbortOnDrop`]), releasing the catalog
+	/// and per-track subscriptions instead of leaking them until the broadcast closes.
+	_catalog: AbortOnDrop,
 }
 
 impl Broadcaster {
@@ -69,14 +87,21 @@ impl Broadcaster {
 	pub fn new(broadcast: moq_net::BroadcastConsumer, config: Config) -> Arc<Self> {
 		let (ready, _) = watch::channel(0);
 		let (paused, _) = watch::channel(false);
-		let broadcaster = Arc::new(Self {
-			broadcast: broadcast.clone(),
-			renditions: Mutex::new(BTreeMap::new()),
-			ready,
-			paused,
-		});
-		tokio::spawn(watch_catalog(broadcast, config, broadcaster.clone()));
-		broadcaster
+		// `new_cyclic` hands the catalog watcher a `Weak<Self>` so it can't keep the
+		// `Broadcaster` alive; the `AbortOnDrop` we store then stops that (possibly
+		// parked) task the instant the last external `Arc` drops. Without both halves the
+		// task's `Arc` (old code) pinned the `Broadcaster` -- and thus every source
+		// subscription -- until the broadcast closed on its own.
+		Arc::new_cyclic(|weak: &Weak<Self>| {
+			let catalog = tokio::spawn(watch_catalog(broadcast.clone(), config, weak.clone()));
+			Self {
+				broadcast,
+				renditions: Mutex::new(BTreeMap::new()),
+				ready,
+				paused,
+				_catalog: AbortOnDrop(catalog.abort_handle()),
+			}
+		})
 	}
 
 	/// Pause or resume pulling media from the broadcast.
@@ -181,7 +206,7 @@ impl Broadcaster {
 	}
 }
 
-async fn watch_catalog(broadcast: moq_net::BroadcastConsumer, config: Config, broadcaster: Arc<Broadcaster>) {
+async fn watch_catalog(broadcast: moq_net::BroadcastConsumer, config: Config, broadcaster: Weak<Broadcaster>) {
 	let mut consumer = loop {
 		match catalog::Consumer::<()>::new(&broadcast, CatalogFormat::Hang) {
 			Ok(consumer) => break consumer,
@@ -197,12 +222,57 @@ async fn watch_catalog(broadcast: moq_net::BroadcastConsumer, config: Config, br
 
 	loop {
 		match kio::wait(|waiter| consumer.poll_next(waiter)).await {
-			Ok(Some(catalog)) => broadcaster.sync(&broadcast, &config, &catalog),
+			// Upgrade per catalog rather than holding an `Arc`: if the owner has dropped
+			// the `Broadcaster`, stop (our `AbortOnDrop` will also have aborted us, but a
+			// clean exit is fine if that race hasn't run yet).
+			Ok(Some(catalog)) => match broadcaster.upgrade() {
+				Some(broadcaster) => broadcaster.sync(&broadcast, &config, &catalog),
+				None => break,
+			},
 			Ok(None) => break,
 			Err(err) => {
 				tracing::warn!(%err, "broadcast catalog stream ended with error");
 				break;
 			}
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Dropping a `Broadcaster` must release its source subscription, not pin it until
+	/// the broadcast closes on its own. Regression for the VOD recorder leaving demo
+	/// publishers "subscribed" (and, being subscription-driven, emulating + encoding)
+	/// for hours after a recording was deleted: the catalog watcher held an
+	/// `Arc<Broadcaster>` and the rendition pumps only exited on broadcast close, so
+	/// nothing dropped when the recorder task ended.
+	#[tokio::test]
+	async fn dropping_broadcaster_releases_subscription() {
+		let mut producer = moq_net::Broadcast::new().produce();
+		let catalog = producer
+			.create_track(moq_net::Track {
+				name: "catalog.json".to_string(),
+				priority: 0,
+			})
+			.unwrap();
+
+		let broadcaster = Broadcaster::new(producer.consume(), Config::default());
+
+		// The catalog watcher subscribes to `catalog.json`; wait until it actually has.
+		tokio::time::timeout(Duration::from_secs(5), catalog.used())
+			.await
+			.expect("export should subscribe to the catalog track")
+			.unwrap();
+
+		// Dropping the export must release that subscription so the producer sees no
+		// consumers. Before the fix this timed out: the watcher's `Arc` kept the
+		// `Broadcaster` (and its subscription) alive until the broadcast closed.
+		drop(broadcaster);
+		tokio::time::timeout(Duration::from_secs(5), catalog.unused())
+			.await
+			.expect("dropping the Broadcaster must release the catalog subscription")
+			.unwrap();
 	}
 }

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -8,8 +8,8 @@ use moq_mux::container::fmp4::Export;
 use moq_mux::select;
 use tokio::sync::watch;
 
-use super::Config;
 use super::store::SegmentStore;
+use super::{AbortOnDrop, Config};
 use crate::Result;
 
 /// Fallback advertised bitrates when the catalog doesn't carry one.
@@ -42,6 +42,10 @@ pub struct Rendition {
 	pub codec: String,
 	/// The segment/part store fed by this rendition's exporter task.
 	pub store: Arc<SegmentStore>,
+	/// Aborts this rendition's exporter pump when the `Rendition` is dropped (i.e. when
+	/// the owning `Broadcaster` drops its renditions map), releasing the source track
+	/// subscription instead of leaving the pump reading a track nobody records.
+	_pump: AbortOnDrop,
 }
 
 impl Rendition {
@@ -54,7 +58,7 @@ impl Rendition {
 		paused: watch::Receiver<bool>,
 	) -> Self {
 		let store = Arc::new(SegmentStore::new(Kind::Video, cfg));
-		spawn_pump(broadcast, name.clone(), Kind::Video, store.clone(), cfg.clone(), paused);
+		let pump = spawn_pump(broadcast, name.clone(), Kind::Video, store.clone(), cfg.clone(), paused);
 		Self {
 			name,
 			kind: Kind::Video,
@@ -63,6 +67,7 @@ impl Rendition {
 			height: config.coded_height,
 			codec: config.codec.to_string(),
 			store,
+			_pump: pump,
 		}
 	}
 
@@ -75,7 +80,7 @@ impl Rendition {
 		paused: watch::Receiver<bool>,
 	) -> Self {
 		let store = Arc::new(SegmentStore::new(Kind::Audio, cfg));
-		spawn_pump(broadcast, name.clone(), Kind::Audio, store.clone(), cfg.clone(), paused);
+		let pump = spawn_pump(broadcast, name.clone(), Kind::Audio, store.clone(), cfg.clone(), paused);
 		Self {
 			name,
 			kind: Kind::Audio,
@@ -84,6 +89,7 @@ impl Rendition {
 			height: None,
 			codec: config.codec.to_string(),
 			store,
+			_pump: pump,
 		}
 	}
 }
@@ -95,14 +101,15 @@ fn spawn_pump(
 	store: Arc<SegmentStore>,
 	cfg: Config,
 	paused: watch::Receiver<bool>,
-) {
-	tokio::spawn(async move {
+) -> AbortOnDrop {
+	let handle = tokio::spawn(async move {
 		if let Err(err) = run_pump(broadcast, &name, kind, &store, &cfg, paused).await {
 			tracing::warn!(%name, ?kind, %err, "hls rendition pump ended with error");
 		}
 		// Whatever happened, mark the playlist closed so blocking readers wake.
 		store.finish();
 	});
+	AbortOnDrop(handle.abort_handle())
 }
 
 async fn run_pump(


### PR DESCRIPTION
## Problem

`export::Broadcaster::new` spawns a detached `watch_catalog` task that holds an
`Arc<Broadcaster>` self-reference, and the rendition pumps only exit when the
**source broadcast closes**. So dropping the last *external* `Arc<Broadcaster>`
(e.g. a downstream recorder task ending) does **not** stop the export: the
catalog + per-track subscriptions stay open, and the `Broadcaster` lives on
until the broadcast closes on its own.

For a **subscription-driven publisher** this is self-sustaining:

```
leaked subscription -> publisher keeps producing -> broadcast never closes
      ^                                                      |
      +--------------- watch_catalog never exits <-----------+
```

### Observed in production (moq.pro)

A VOD recording (which builds a `Broadcaster` per recorded broadcast) was
enabled against the demo's six `moq-boy` Game Boy streams, then deleted a couple
minutes later. Deleting it made the recorder's session heartbeats 404, so the
recorder tasks ended and dropped their `Arc<Broadcaster>`s. But the exports kept
their subscriptions open: 18 track subs / 6 "viewers" stayed live. `moq-boy`
only emulates while subscribed, so all six emulators ran flat-out for **~16
hours** after the recording was gone, pinning the single-vCPU demo node at ~90%
CPU. `#2021 (evict finished HLS broadcasters)` doesn't cover this: the broadcast
isn't finished, it's kept alive by the leak.

For an always-pushing encoder the same drop leaks the `watch_catalog` +
rendition pump tasks and their subscriptions on the relay (a slow accumulation),
just without the visible CPU symptom.

## Fix

Break the cycle and tie every spawned task to its owner's lifetime:

- `watch_catalog` now holds a `Weak<Broadcaster>` (upgrades per catalog, exits
  when the owner is gone), so dropping the last external `Arc` runs
  `Broadcaster`'s `Drop`.
- A small `AbortOnDrop` guard aborts the (possibly parked) `watch_catalog` task
  on drop, and each `Rendition` owns its pump's guard, so dropping the
  `Broadcaster` -> renditions map -> pumps releases every track subscription
  immediately.

No public API change (`Broadcaster::new` / `set_paused` / `rendition()`
unchanged; the added fields are private).

## Test

`export::tests::dropping_broadcaster_releases_subscription`: build a
`Broadcaster` over a producer-owned `catalog.json` track, wait for it to
subscribe, drop it, and assert the producer sees no consumers. Times out before
the fix (verified by neutralizing the abort), passes after. Full `moq-hls`
suite green (20/20).

> Branch is based on the moq.pro pin (`6b46b1f0`) for a minimal delta; happy to
> rebase onto `dev`.