### PR TITLE
moq-hls: rewrite export::Broadcaster as an owned poll-driven state machine

### DIFF
--- a/rs/moq-cli/src/hls.rs
+++ b/rs/moq-cli/src/hls.rs
@@ -50,12 +50,17 @@ pub struct ExportArgs {
 /// Pull a remote HLS/LL-HLS playlist (URL or file path) into the Origin under `name`.
 pub async fn import(origin: &moq_net::OriginProducer, name: String, playlist: String) -> anyhow::Result<()> {
 	let mut producer = moq_net::Broadcast::new().produce();
+
+	// Create the catalog tracks BEFORE announcing the broadcast: a subscriber that
+	// sees the announce must be able to subscribe `catalog.json` immediately. Announcing
+	// first left a window where a consumer got `NotFound` (the export side used to paper
+	// over it with a retry loop).
+	let catalog = moq_mux::catalog::Producer::new(&mut producer)?;
 	anyhow::ensure!(
 		origin.publish_broadcast(&name, producer.consume()),
 		"failed to publish broadcast"
 	);
 
-	let catalog = moq_mux::catalog::Producer::new(&mut producer)?;
 	let mut importer = moq_hls::import::Import::new(producer, catalog, moq_hls::import::Config::new(playlist))?;
 
 	tracing::info!(%name, "importing HLS");

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -77,19 +77,28 @@ struct Shared {
 }
 
 /// A driver-private per-rendition unit: the shared metadata/store plus the exporter
-/// that fills it, and whether that exporter has finished.
+/// that fills it. `export` is `None` once the rendition has finished -- dropping it
+/// then RELEASES the source subscription immediately, instead of holding a live (but
+/// no-longer-polled) track open until the whole `Broadcaster` drops. That matters on
+/// the error path: moq-mux's exporter returns an error *before* it would internally
+/// drop the track, so a rendition that errors while its publisher is still live would
+/// otherwise pin that subscription for the rest of the recording (a scoped #2255).
 struct Driver {
 	info: Arc<Rendition>,
-	export: RenditionExport,
-	done: bool,
+	export: Option<RenditionExport>,
 }
 
 impl Driver {
-	/// Finalize the store (waking blocked readers with an ENDLIST) and mark done.
+	/// True once this rendition's exporter has finished (its subscription released).
+	fn done(&self) -> bool {
+		self.export.is_none()
+	}
+
+	/// Finalize the store (waking blocked readers with an ENDLIST) and drop the
+	/// exporter, releasing its source track subscription.
 	fn finish(&mut self) {
-		if !self.done {
+		if self.export.take().is_some() {
 			self.info.store.finish();
-			self.done = true;
 		}
 	}
 }
@@ -220,11 +229,16 @@ impl Broadcaster {
 			}
 
 			for driver in self.renditions.values_mut() {
-				if driver.done {
+				// A finished rendition (`export` is `None`) is skipped; while draining, the
+				// exporter stays `Some` until an arm below finishes it and breaks.
+				if driver.export.is_none() {
 					continue;
 				}
 				loop {
-					match driver.export.poll_next_fragment(waiter) {
+					// Poll into an owned outcome so the `driver.export` borrow is released
+					// before the arms touch `driver` (e.g. `finish`, which drops the exporter).
+					let outcome = driver.export.as_mut().unwrap().poll_next_fragment(waiter);
+					match outcome {
 						Poll::Ready(Ok(Some(fragment))) => driver.info.store.push(fragment),
 						Poll::Ready(Ok(None)) => {
 							driver.finish();
@@ -242,7 +256,7 @@ impl Broadcaster {
 		}
 
 		// Done once the catalog has ended and every rendition has finished.
-		if self.catalog_done && self.renditions.values().all(|d| d.done) {
+		if self.catalog_done && self.renditions.values().all(Driver::done) {
 			return Poll::Ready(());
 		}
 
@@ -304,8 +318,7 @@ impl Broadcaster {
 			name.clone(),
 			Driver {
 				info: info.clone(),
-				export,
-				done: false,
+				export: Some(export),
 			},
 		);
 		self.shared.renditions.write().unwrap().insert(name, info);

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -2,9 +2,18 @@
 //!
 //! A [`Broadcaster`] watches one broadcast's catalog and, per rendition, runs a
 //! [`moq_mux::container::fmp4::Export`] narrowed to that single track (via
-//! [`moq_mux::catalog::Select`]) feeding a [`store::SegmentStore`]. The HTTP
-//! [`server`](crate::server) reads the stores to answer playlist and segment
-//! requests.
+//! [`moq_mux::catalog::Select`]) feeding a [`store::SegmentStore`].
+//!
+//! It is a plain owned value the caller drives by polling: [`poll`](Broadcaster::poll)
+//! (or the [`run`](Broadcaster::run) convenience) advances the catalog and every
+//! rendition's exporter in one pass, with **no** background tasks. Dropping the
+//! `Broadcaster` drops its catalog consumer and every exporter, which releases the
+//! source subscriptions immediately -- so an owner that stops recording a still-live
+//! broadcast tears its subscriptions down instead of leaking them (moq#2255).
+//!
+//! Readers (the HTTP [`server`](crate::server), the VOD uploader) hold a cheap
+//! [`Handle`] instead: the shared rendition set + stores, with no control over the
+//! subscriptions and no ability to keep them alive past the driver.
 
 mod master;
 mod playlist;
@@ -12,31 +21,24 @@ mod rendition;
 pub mod store;
 
 use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, RwLock};
+use std::task::Poll;
 use std::time::Duration;
 
 use moq_mux::catalog::hang::Catalog;
-use moq_mux::catalog::{self, CatalogFormat, Stream};
+use moq_mux::catalog::{CatalogFormat, Consumer, Select, Stream};
+use moq_mux::container::fmp4::Export;
+use moq_mux::select;
 use tokio::sync::watch;
 
 pub use playlist::render_media;
 pub use rendition::{Kind, Rendition};
 
-/// How long to wait before retrying the initial catalog subscription.
-const CATALOG_RETRY: Duration = Duration::from_millis(250);
+use crate::Result;
 
-/// Aborts a spawned task when dropped, tying the task's lifetime to the value that
-/// owns this guard. Used to stop the catalog watcher + rendition pumps the moment a
-/// [`Broadcaster`] is dropped, so its source subscriptions are released instead of
-/// lingering until the broadcast itself closes (which a subscription-driven
-/// publisher would never do while we hold it open -- a self-sustaining leak).
-pub(super) struct AbortOnDrop(pub(super) tokio::task::AbortHandle);
-
-impl Drop for AbortOnDrop {
-	fn drop(&mut self) {
-		self.0.abort();
-	}
-}
+/// The per-rendition exporter: a catalog consumer narrowed (via [`Select`]) to one
+/// track, wrapped in the fMP4 [`Export`] that emits CMAF fragments.
+type RenditionExport = Export<Select<Consumer<()>>>;
 
 /// Export tuning shared across renditions.
 #[derive(Clone, Debug)]
@@ -64,81 +66,297 @@ impl Default for Config {
 	}
 }
 
-/// All renditions of one broadcast, kept in sync with its catalog.
+/// Shared read side, handed out via [`Handle`]. Written only by the driver's
+/// [`sync`](Broadcaster::sync); read by playlist renderers and segment handlers.
+struct Shared {
+	/// name -> rendition metadata + store. Grows as the catalog advertises tracks.
+	renditions: RwLock<BTreeMap<String, Arc<Rendition>>>,
+	/// Rendition count, bumped on every catalog sync so a handler can wait for the
+	/// catalog to populate before rendering a playlist.
+	ready: watch::Sender<usize>,
+}
+
+/// A driver-private per-rendition unit: the shared metadata/store plus the exporter
+/// that fills it, and whether that exporter has finished.
+struct Driver {
+	info: Arc<Rendition>,
+	export: RenditionExport,
+	done: bool,
+}
+
+impl Driver {
+	/// Finalize the store (waking blocked readers with an ENDLIST) and mark done.
+	fn finish(&mut self) {
+		if !self.done {
+			self.info.store.finish();
+			self.done = true;
+		}
+	}
+}
+
+/// All renditions of one broadcast, kept in sync with its catalog and driven by
+/// polling. Owns every source subscription; drop it to release them.
 pub struct Broadcaster {
 	broadcast: moq_net::BroadcastConsumer,
-	renditions: Mutex<BTreeMap<String, Arc<Rendition>>>,
-	/// Current rendition count, bumped on every catalog sync so handlers can wait
-	/// for the catalog to populate before rendering a playlist.
-	ready: watch::Sender<usize>,
-	/// Pause flag shared with every rendition pump. While true the pumps stop
-	/// reading; renditions discovered later inherit the current value (they
-	/// `subscribe()` to this sender).
-	paused: watch::Sender<bool>,
-	/// Aborts the [`watch_catalog`] task when this `Broadcaster` is dropped. The task
-	/// holds only a `Weak<Self>`, so dropping the last external `Arc` runs this `Drop`
-	/// (and, transitively, every rendition's [`AbortOnDrop`]), releasing the catalog
-	/// and per-track subscriptions instead of leaking them until the broadcast closes.
-	_catalog: AbortOnDrop,
+	config: Config,
+	/// Catalog consumer used to DISCOVER renditions (each exporter runs its own,
+	/// narrowed, catalog consumer for track (un)subscription -- all deduped by
+	/// moq-net to one wire subscription).
+	catalog: Consumer<()>,
+	/// The discovery catalog has ended (broadcast closed) or errored.
+	catalog_done: bool,
+	renditions: BTreeMap<String, Driver>,
+	shared: Arc<Shared>,
+	/// While true, the exporters aren't polled: nothing is read, so the relay stops
+	/// sending and the media produced during the pause is dropped from the recording.
+	paused: bool,
+	/// Set once a poll actually skips media because we're paused, so the next
+	/// unpaused poll tags a `#EXT-X-DISCONTINUITY` at the seam. A pause toggled on
+	/// and back off between polls (no media skipped) leaves this false -> no seam.
+	paused_observed: bool,
 }
 
 impl Broadcaster {
-	/// Subscribe to `broadcast` and start tracking its renditions.
-	pub fn new(broadcast: moq_net::BroadcastConsumer, config: Config) -> Arc<Self> {
+	/// Subscribe to `broadcast`'s catalog and start tracking its renditions.
+	///
+	/// Fails loud if the catalog can't be subscribed: a broadcast must publish its
+	/// catalog before it is announced (the relay guarantees this; a local publisher
+	/// must create the catalog before `publish_broadcast`). There is no retry -- a
+	/// failure here is a real publish-ordering bug, not a transient.
+	pub fn new(broadcast: moq_net::BroadcastConsumer, config: Config) -> Result<Self> {
+		let catalog = Consumer::<()>::new(&broadcast, CatalogFormat::Hang)?;
 		let (ready, _) = watch::channel(0);
-		let (paused, _) = watch::channel(false);
-		// `new_cyclic` hands the catalog watcher a `Weak<Self>` so it can't keep the
-		// `Broadcaster` alive; the `AbortOnDrop` we store then stops that (possibly
-		// parked) task the instant the last external `Arc` drops. Without both halves the
-		// task's `Arc` (old code) pinned the `Broadcaster` -- and thus every source
-		// subscription -- until the broadcast closed on its own.
-		Arc::new_cyclic(|weak: &Weak<Self>| {
-			let catalog = tokio::spawn(watch_catalog(broadcast.clone(), config, weak.clone()));
-			Self {
-				broadcast,
-				renditions: Mutex::new(BTreeMap::new()),
+		Ok(Self {
+			broadcast,
+			config,
+			catalog,
+			catalog_done: false,
+			renditions: BTreeMap::new(),
+			shared: Arc::new(Shared {
+				renditions: RwLock::new(BTreeMap::new()),
 				ready,
-				paused,
-				_catalog: AbortOnDrop(catalog.abort_handle()),
-			}
+			}),
+			paused: false,
+			paused_observed: false,
 		})
+	}
+
+	/// A cheap read handle: the shared rendition set + stores. Cloneable; holds no
+	/// subscription and can't keep the export alive past this `Broadcaster`.
+	pub fn handle(&self) -> Handle {
+		Handle {
+			shared: self.shared.clone(),
+		}
 	}
 
 	/// Pause or resume pulling media from the broadcast.
 	///
-	/// While paused, every rendition's pump stops reading its track, so the relay
-	/// stops sending and the live media produced during the pause is dropped from the
-	/// recording (not buffered, and the publisher isn't kept ingesting). Resuming
-	/// continues the SAME playlists from the next group still in the relay cache (the
-	/// evicted span is skipped, then it reads forward -- it does NOT jump to live),
-	/// marking the first post-resume segment `#EXT-X-DISCONTINUITY`. CMAF sequence
-	/// numbers and the init segment persist, so it's one continuous recording with a
-	/// gap, not a restart. Idempotent.
-	pub fn set_paused(&self, paused: bool) {
-		let _ = self.paused.send(paused);
+	/// While paused the exporters aren't polled, so the relay stops sending and the
+	/// live media produced during the pause is dropped from the recording (not
+	/// buffered, and the publisher isn't kept ingesting). Resuming continues the SAME
+	/// playlists from the next group still in the relay cache (the evicted span is
+	/// skipped, then it reads forward -- it does NOT jump to live), marking the first
+	/// post-resume segment `#EXT-X-DISCONTINUITY`. CMAF sequence numbers and the init
+	/// segment persist, so it's one continuous recording with a gap, not a restart.
+	///
+	/// Takes `&mut self`: the owner applies pause between polls (e.g. in a
+	/// `select!` alongside [`poll`](Self::poll)), so there's no shared pause flag and
+	/// no separate forwarding task. Idempotent.
+	pub fn set_paused(&mut self, paused: bool) {
+		self.paused = paused;
 	}
 
 	/// Whether the export is currently paused.
 	pub fn is_paused(&self) -> bool {
-		*self.paused.borrow()
+		self.paused
 	}
 
-	pub(crate) fn is_closed(&self) -> bool {
-		self.broadcast.is_closed()
+	/// Advance the catalog and every rendition's exporter one pass.
+	///
+	/// - Drains catalog snapshots (even while paused, so the rendition set / a
+	///   reader's `wait_ready` still resolve), adding newly advertised renditions.
+	/// - Unless paused, drains each exporter into its store.
+	/// - Returns `Ready(())` once the catalog has ended and every rendition has
+	///   finished; `Pending` otherwise.
+	///
+	/// A source ending -- whether cleanly (`finish()`) or abruptly (the publisher
+	/// disconnecting, the common live case) -- finishes that rendition's store and
+	/// completes it; an abrupt end is logged, not propagated, since for a live
+	/// broadcast it is the normal termination, not a fault.
+	///
+	/// Cancel-safe: every underlying poll is cancel-safe and all cursor state lives on
+	/// `self`, so dropping the future mid-poll and re-entering resumes cleanly.
+	pub fn poll(&mut self, waiter: &kio::Waiter) -> Poll<()> {
+		// 1. Discover renditions from the catalog. Runs regardless of pause.
+		while !self.catalog_done {
+			match self.catalog.poll_next(waiter) {
+				Poll::Ready(Ok(Some(catalog))) => self.sync(&catalog),
+				Poll::Ready(Ok(None)) => self.catalog_done = true,
+				Poll::Ready(Err(err)) => {
+					// The catalog track ended abruptly (publisher gone): stop discovering
+					// and let the media tracks drain to completion on their own.
+					tracing::warn!(%err, "broadcast catalog stream ended");
+					self.catalog_done = true;
+				}
+				Poll::Pending => break,
+			}
+		}
+
+		if self.paused {
+			// Not reading media, so nothing wakes us from the exporters. We must still
+			// notice the broadcast closing, or a paused recording would hang forever.
+			self.paused_observed = true;
+			if self.broadcast.poll_closed(waiter).is_ready() {
+				self.finish_all();
+			}
+		} else {
+			// First unpaused poll after actually skipping media: the dropped span is a
+			// real gap, so tag the seam on every rendition.
+			if self.paused_observed {
+				for driver in self.renditions.values() {
+					driver.info.store.mark_discontinuity();
+				}
+				self.paused_observed = false;
+			}
+
+			for driver in self.renditions.values_mut() {
+				if driver.done {
+					continue;
+				}
+				loop {
+					match driver.export.poll_next_fragment(waiter) {
+						Poll::Ready(Ok(Some(fragment))) => driver.info.store.push(fragment),
+						Poll::Ready(Ok(None)) => {
+							driver.finish();
+							break;
+						}
+						Poll::Ready(Err(err)) => {
+							tracing::warn!(name = %driver.info.name, ?driver.info.kind, %err, "hls rendition exporter ended");
+							driver.finish();
+							break;
+						}
+						Poll::Pending => break,
+					}
+				}
+			}
+		}
+
+		// Done once the catalog has ended and every rendition has finished.
+		if self.catalog_done && self.renditions.values().all(|d| d.done) {
+			return Poll::Ready(());
+		}
+
+		Poll::Pending
 	}
 
-	pub(crate) async fn closed(&self) {
-		self.broadcast.closed().await;
+	/// Drive the broadcaster to completion. Convenience for owners with no pause
+	/// signal (the HTTP server); a pausing owner writes its own `select!` over
+	/// [`poll`](Self::poll) instead.
+	pub async fn run(&mut self) {
+		kio::wait(|waiter| self.poll(waiter)).await
 	}
 
+	/// Finish every rendition's store (used when the broadcast closes while paused,
+	/// so a paused recording terminates instead of hanging).
+	fn finish_all(&mut self) {
+		self.catalog_done = true;
+		for driver in self.renditions.values_mut() {
+			driver.finish();
+		}
+	}
+
+	/// Add renditions newly present in `catalog`. Renditions are add-only: one that
+	/// disappears from the catalog keeps its store (rare for a live broadcast, and
+	/// dropping it would break a player mid-stream). Removal-on-drop is now possible
+	/// (drop the `Driver` = release its subscription) but left as a follow-up.
+	fn sync(&mut self, catalog: &Catalog) {
+		for (name, video) in &catalog.video.renditions {
+			if self.renditions.contains_key(name) {
+				continue;
+			}
+			let info = Arc::new(Rendition::video(name.clone(), video, &self.config));
+			self.insert_rendition(name.clone(), info, Kind::Video);
+		}
+		for (name, audio) in &catalog.audio.renditions {
+			if self.renditions.contains_key(name) {
+				continue;
+			}
+			let info = Arc::new(Rendition::audio(name.clone(), audio, &self.config));
+			self.insert_rendition(name.clone(), info, Kind::Audio);
+		}
+		let _ = self.shared.ready.send(self.renditions.len());
+	}
+
+	/// Register a discovered rendition: build its exporter, add it to the driver map,
+	/// and publish its metadata/store to the shared read side.
+	fn insert_rendition(&mut self, name: String, info: Arc<Rendition>, kind: Kind) {
+		let export = match build_export(&self.broadcast, &name, kind, &self.config) {
+			Ok(export) => export,
+			Err(err) => {
+				// The catalog we're mid-read on lists this track, so subscribing its
+				// catalog again can't legitimately fail; if it somehow does, skip the
+				// rendition (it just won't be served) rather than abort discovery.
+				tracing::warn!(%name, ?kind, %err, "failed to build rendition exporter; skipping");
+				return;
+			}
+		};
+		self.renditions.insert(
+			name.clone(),
+			Driver {
+				info: info.clone(),
+				export,
+				done: false,
+			},
+		);
+		self.shared.renditions.write().unwrap().insert(name, info);
+	}
+}
+
+/// Build a per-track exporter: subscribe the catalog, narrow it to `name` on the
+/// `kind` axis so the exporter sees exactly one track, and cap fragment duration +
+/// latency from the config.
+fn build_export(
+	broadcast: &moq_net::BroadcastConsumer,
+	name: &str,
+	kind: Kind,
+	cfg: &Config,
+) -> Result<RenditionExport> {
+	let consumer = Consumer::<()>::new(broadcast, CatalogFormat::Hang)?;
+	let selection = match kind {
+		Kind::Video => select::Broadcast::default().video(select::Video::default().name(name)),
+		Kind::Audio => select::Broadcast::default().audio(select::Audio::default().name(name)),
+	};
+	let filtered = consumer.select(selection);
+	Ok(Export::new(broadcast.clone(), filtered)
+		.with_fragment_duration(cfg.part_target)
+		.with_latency(cfg.latency))
+}
+
+/// A cheap, cloneable read handle to a [`Broadcaster`]'s renditions.
+///
+/// Holds only the shared rendition set + stores, so it can't keep the export alive:
+/// when the owning `Broadcaster` (and its driver) is dropped, the stores finish and
+/// this handle's reads see the final state.
+#[derive(Clone)]
+pub struct Handle {
+	shared: Arc<Shared>,
+}
+
+impl Handle {
 	/// Look up a rendition by name.
 	pub fn rendition(&self, name: &str) -> Option<Arc<Rendition>> {
-		self.renditions.lock().unwrap().get(name).cloned()
+		self.shared.renditions.read().unwrap().get(name).cloned()
+	}
+
+	/// Every discovered rendition, in name order. Lets a caller enumerate the
+	/// rendition set directly instead of re-parsing the master playlist.
+	pub fn renditions(&self) -> Vec<Arc<Rendition>> {
+		self.shared.renditions.read().unwrap().values().cloned().collect()
 	}
 
 	/// Wait until at least one rendition has been discovered, or `timeout` elapses.
 	pub async fn wait_ready(&self, timeout: Duration) {
-		let mut rx = self.ready.subscribe();
+		let mut rx = self.shared.ready.subscribe();
 		if *rx.borrow() > 0 {
 			return;
 		}
@@ -154,7 +372,7 @@ impl Broadcaster {
 
 	/// Render the multivariant (master) playlist from the current renditions.
 	pub fn master_playlist(&self) -> String {
-		let renditions = self.renditions.lock().unwrap();
+		let renditions = self.shared.renditions.read().unwrap();
 		let mut video = Vec::new();
 		let mut audio = Vec::new();
 		for rendition in renditions.values() {
@@ -175,67 +393,6 @@ impl Broadcaster {
 		}
 		master::render_master(&video, &audio)
 	}
-
-	/// Add renditions newly present in `catalog`. Renditions are not removed when
-	/// they disappear; their stores simply go stale (rare for a live broadcast).
-	fn sync(&self, broadcast: &moq_net::BroadcastConsumer, config: &Config, catalog: &Catalog) {
-		let mut renditions = self.renditions.lock().unwrap();
-		for (name, video) in &catalog.video.renditions {
-			renditions.entry(name.clone()).or_insert_with(|| {
-				Arc::new(Rendition::video(
-					name.clone(),
-					video,
-					broadcast.clone(),
-					config,
-					self.paused.subscribe(),
-				))
-			});
-		}
-		for (name, audio) in &catalog.audio.renditions {
-			renditions.entry(name.clone()).or_insert_with(|| {
-				Arc::new(Rendition::audio(
-					name.clone(),
-					audio,
-					broadcast.clone(),
-					config,
-					self.paused.subscribe(),
-				))
-			});
-		}
-		let _ = self.ready.send(renditions.len());
-	}
-}
-
-async fn watch_catalog(broadcast: moq_net::BroadcastConsumer, config: Config, broadcaster: Weak<Broadcaster>) {
-	let mut consumer = loop {
-		match catalog::Consumer::<()>::new(&broadcast, CatalogFormat::Hang) {
-			Ok(consumer) => break consumer,
-			Err(err) => {
-				tracing::warn!(%err, "failed to subscribe to broadcast catalog, retrying");
-				tokio::select! {
-					_ = tokio::time::sleep(CATALOG_RETRY) => {}
-					_ = kio::wait(|waiter| broadcast.poll_closed(waiter)) => return,
-				}
-			}
-		}
-	};
-
-	loop {
-		match kio::wait(|waiter| consumer.poll_next(waiter)).await {
-			// Upgrade per catalog rather than holding an `Arc`: if the owner has dropped
-			// the `Broadcaster`, stop (our `AbortOnDrop` will also have aborted us, but a
-			// clean exit is fine if that race hasn't run yet).
-			Ok(Some(catalog)) => match broadcaster.upgrade() {
-				Some(broadcaster) => broadcaster.sync(&broadcast, &config, &catalog),
-				None => break,
-			},
-			Ok(None) => break,
-			Err(err) => {
-				tracing::warn!(%err, "broadcast catalog stream ended with error");
-				break;
-			}
-		}
-	}
 }
 
 #[cfg(test)]
@@ -245,9 +402,8 @@ mod tests {
 	/// Dropping a `Broadcaster` must release its source subscription, not pin it until
 	/// the broadcast closes on its own. Regression for the VOD recorder leaving demo
 	/// publishers "subscribed" (and, being subscription-driven, emulating + encoding)
-	/// for hours after a recording was deleted: the catalog watcher held an
-	/// `Arc<Broadcaster>` and the rendition pumps only exited on broadcast close, so
-	/// nothing dropped when the recorder task ended.
+	/// for hours after a recording was deleted (moq#2255): with the poll model, drop
+	/// tears down the catalog consumer + exporters structurally, no guards needed.
 	#[tokio::test]
 	async fn dropping_broadcaster_releases_subscription() {
 		let mut producer = moq_net::Broadcast::new().produce();
@@ -258,21 +414,84 @@ mod tests {
 			})
 			.unwrap();
 
-		let broadcaster = Broadcaster::new(producer.consume(), Config::default());
+		let mut broadcaster = Broadcaster::new(producer.consume(), Config::default()).unwrap();
 
-		// The catalog watcher subscribes to `catalog.json`; wait until it actually has.
+		// Drive the broadcaster so it actually subscribes to the catalog track, then
+		// wait until the producer sees that consumer.
+		let driver = tokio::spawn(async move { broadcaster.run().await });
 		tokio::time::timeout(Duration::from_secs(5), catalog.used())
 			.await
 			.expect("export should subscribe to the catalog track")
 			.unwrap();
 
-		// Dropping the export must release that subscription so the producer sees no
-		// consumers. Before the fix this timed out: the watcher's `Arc` kept the
-		// `Broadcaster` (and its subscription) alive until the broadcast closed.
-		drop(broadcaster);
+		// Dropping the driver (which owns the Broadcaster) must release that
+		// subscription so the producer sees no consumers.
+		driver.abort();
 		tokio::time::timeout(Duration::from_secs(5), catalog.unused())
 			.await
 			.expect("dropping the Broadcaster must release the catalog subscription")
 			.unwrap();
+	}
+
+	/// The real #2255 scenario: a rendition's MEDIA subscription (not just the
+	/// catalog) must be released when the driver is dropped. A live media track held
+	/// open is what kept the demo's subscription-driven publishers emulating.
+	#[tokio::test]
+	async fn dropping_broadcaster_releases_media_subscription() {
+		use moq_mux::catalog::Producer as CatalogProducer;
+
+		let mut producer = moq_net::Broadcast::new().produce();
+		let mut catalog = CatalogProducer::new(&mut producer).unwrap();
+		let video = producer.create_track(moq_net::Track::new("video")).unwrap();
+		// List the "video" rendition so the exporter subscribes to that media track.
+		catalog.lock().video.renditions.insert(
+			"video".to_string(),
+			hang::catalog::VideoConfig::new(hang::catalog::H264 {
+				profile: 0x42,
+				constraints: 0xc0,
+				level: 0x1f,
+				inline: true,
+			}),
+		);
+
+		let mut broadcaster = Broadcaster::new(producer.consume(), Config::default()).unwrap();
+		let driver = tokio::spawn(async move { broadcaster.run().await });
+
+		// The exporter subscribes to the (still-live) "video" track once it sees the
+		// catalog; the track is never finished, so the subscription stays open.
+		tokio::time::timeout(Duration::from_secs(5), video.used())
+			.await
+			.expect("exporter should subscribe to the video track")
+			.unwrap();
+
+		// Dropping the driver (owning the Broadcaster -> renditions -> exporters) must
+		// release that media subscription, not leave the publisher "subscribed".
+		driver.abort();
+		tokio::time::timeout(Duration::from_secs(5), video.unused())
+			.await
+			.expect("dropping the Broadcaster must release the media subscription")
+			.unwrap();
+	}
+
+	/// A broadcast that goes away drives the broadcaster to completion instead of
+	/// hanging: the catalog stream ends and, with no renditions, `run()` returns.
+	#[tokio::test]
+	async fn broadcast_gone_completes() {
+		let mut producer = moq_net::Broadcast::new().produce();
+		let catalog = producer
+			.create_track(moq_net::Track {
+				name: "catalog.json".to_string(),
+				priority: 0,
+			})
+			.unwrap();
+		let mut broadcaster = Broadcaster::new(producer.consume(), Config::default()).unwrap();
+
+		// No renditions ever appear; dropping the catalog track + producer ends the
+		// discovery catalog stream, so the broadcaster completes.
+		drop(catalog);
+		drop(producer);
+		tokio::time::timeout(Duration::from_secs(5), broadcaster.run())
+			.await
+			.expect("broadcaster should complete when the broadcast goes away");
 	}
 }

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -1,16 +1,17 @@
-//! One rendition: a per-track exporter pumping CMAF fragments into a store.
+//! One rendition's read-side metadata plus the store its media lands in.
+//!
+//! A `Rendition` carries only what a playlist renderer / HTTP handler needs: the
+//! master-playlist attributes and the [`SegmentStore`] fed by the owning
+//! [`Broadcaster`](super::Broadcaster)'s poll loop. The per-track
+//! [`Export`](moq_mux::container::fmp4::Export) that fills the store lives on the
+//! driver side (see `mod.rs`), so nothing here spawns or owns a subscription.
 
 use std::sync::Arc;
 
 use hang::catalog::{AudioConfig, VideoConfig};
-use moq_mux::catalog::{self, CatalogFormat, Stream};
-use moq_mux::container::fmp4::Export;
-use moq_mux::select;
-use tokio::sync::watch;
 
+use super::Config;
 use super::store::SegmentStore;
-use super::{AbortOnDrop, Config};
-use crate::Result;
 
 /// Fallback advertised bitrates when the catalog doesn't carry one.
 const DEFAULT_VIDEO_BITRATE: u64 = 2_000_000;
@@ -26,7 +27,8 @@ pub enum Kind {
 }
 
 /// A single HLS rendition: its display metadata for the master playlist plus the
-/// segment/part store fed by a background exporter task.
+/// segment/part store the driver fills. Cheap to hold behind an `Arc`; the driver
+/// and every reader (HTTP handlers, the VOD uploader) share the same store.
 pub struct Rendition {
 	/// Rendition name (the catalog track name; also its URL path component).
 	pub name: String,
@@ -40,25 +42,14 @@ pub struct Rendition {
 	pub height: Option<u32>,
 	/// RFC 6381 codec string for the master playlist `CODECS` attribute.
 	pub codec: String,
-	/// The segment/part store fed by this rendition's exporter task.
+	/// The segment/part store the driver's exporter fills.
 	pub store: Arc<SegmentStore>,
-	/// Aborts this rendition's exporter pump when the `Rendition` is dropped (i.e. when
-	/// the owning `Broadcaster` drops its renditions map), releasing the source track
-	/// subscription instead of leaving the pump reading a track nobody records.
-	_pump: AbortOnDrop,
 }
 
 impl Rendition {
-	/// Build a video rendition and spawn its exporter pump.
-	pub fn video(
-		name: String,
-		config: &VideoConfig,
-		broadcast: moq_net::BroadcastConsumer,
-		cfg: &Config,
-		paused: watch::Receiver<bool>,
-	) -> Self {
-		let store = Arc::new(SegmentStore::new(Kind::Video, cfg));
-		let pump = spawn_pump(broadcast, name.clone(), Kind::Video, store.clone(), cfg.clone(), paused);
+	/// Build a video rendition (metadata + an empty store). The driver pairs this
+	/// with an exporter that fills the store.
+	pub(super) fn video(name: String, config: &VideoConfig, cfg: &Config) -> Self {
 		Self {
 			name,
 			kind: Kind::Video,
@@ -66,21 +57,12 @@ impl Rendition {
 			width: config.coded_width,
 			height: config.coded_height,
 			codec: config.codec.to_string(),
-			store,
-			_pump: pump,
+			store: Arc::new(SegmentStore::new(Kind::Video, cfg)),
 		}
 	}
 
-	/// Build an audio rendition and spawn its exporter pump.
-	pub fn audio(
-		name: String,
-		config: &AudioConfig,
-		broadcast: moq_net::BroadcastConsumer,
-		cfg: &Config,
-		paused: watch::Receiver<bool>,
-	) -> Self {
-		let store = Arc::new(SegmentStore::new(Kind::Audio, cfg));
-		let pump = spawn_pump(broadcast, name.clone(), Kind::Audio, store.clone(), cfg.clone(), paused);
+	/// Build an audio rendition (metadata + an empty store).
+	pub(super) fn audio(name: String, config: &AudioConfig, cfg: &Config) -> Self {
 		Self {
 			name,
 			kind: Kind::Audio,
@@ -88,96 +70,7 @@ impl Rendition {
 			width: None,
 			height: None,
 			codec: config.codec.to_string(),
-			store,
-			_pump: pump,
+			store: Arc::new(SegmentStore::new(Kind::Audio, cfg)),
 		}
 	}
-}
-
-fn spawn_pump(
-	broadcast: moq_net::BroadcastConsumer,
-	name: String,
-	kind: Kind,
-	store: Arc<SegmentStore>,
-	cfg: Config,
-	paused: watch::Receiver<bool>,
-) -> AbortOnDrop {
-	let handle = tokio::spawn(async move {
-		if let Err(err) = run_pump(broadcast, &name, kind, &store, &cfg, paused).await {
-			tracing::warn!(%name, ?kind, %err, "hls rendition pump ended with error");
-		}
-		// Whatever happened, mark the playlist closed so blocking readers wake.
-		store.finish();
-	});
-	AbortOnDrop(handle.abort_handle())
-}
-
-async fn run_pump(
-	broadcast: moq_net::BroadcastConsumer,
-	name: &str,
-	kind: Kind,
-	store: &SegmentStore,
-	cfg: &Config,
-	mut paused: watch::Receiver<bool>,
-) -> Result<()> {
-	let consumer = catalog::Consumer::<()>::new(&broadcast, CatalogFormat::Hang)?;
-
-	// Select this rendition's name on its own axis so the exporter sees exactly one track.
-	let selection = match kind {
-		Kind::Video => select::Broadcast::default().video(select::Video::default().name(name)),
-		Kind::Audio => select::Broadcast::default().audio(select::Audio::default().name(name)),
-	};
-	let filtered = consumer.select(selection);
-
-	// A handle for noticing the broadcast close even while paused; the `Export`
-	// below takes its own clone for pulling fragments.
-	let closed = broadcast.clone();
-
-	let mut export = Export::new(broadcast, filtered)
-		.with_fragment_duration(cfg.part_target)
-		.with_latency(cfg.latency);
-
-	// Whether we just resumed, so the first post-resume fragment opens a new
-	// continuity region (`#EXT-X-DISCONTINUITY`).
-	let mut resumed = false;
-
-	loop {
-		// While paused, stop reading the track entirely: the relay stops sending, so
-		// nothing is buffered here and the publisher isn't kept ingesting for a
-		// receiver that isn't recording.
-		while *paused.borrow_and_update() {
-			resumed = true;
-			tokio::select! {
-				// Resume request, or the Broadcaster (and its sender) being dropped.
-				res = paused.changed() => {
-					if res.is_err() {
-						return Ok(()); // Broadcaster gone: stop pumping.
-					}
-				}
-				// The broadcast ending while paused still finalizes the track.
-				_ = kio::wait(|w| closed.poll_closed(w)) => return Ok(()),
-			}
-		}
-
-		if resumed {
-			// The media dropped while paused is a real gap, so tag the seam. The export
-			// recovers on its own: the group it was mid-read on aged out of the relay
-			// cache while we weren't reading, and reading an evicted (or now-missing)
-			// group errors instead of blocking (moq-net aborts it with `Error::Old`), so
-			// the consumer skips the evicted span and resumes from the NEXT group still in
-			// the cache (`recv_group`), reading forward -- not jumping to live.
-			store.mark_discontinuity();
-			resumed = false;
-		}
-
-		// Pull one fragment uninterrupted (next_fragment isn't cancel-safe), then
-		// re-check the pause flag at the top of the loop -- so entering a pause costs at
-		// most one extra fragment (~part_target), recording right up to the pause point.
-		match export.next_fragment().await? {
-			Some(fragment) => store.push(fragment),
-			None => break,
-		}
-	}
-
-	Ok(())
 }

--- a/rs/moq-hls/src/server/mod.rs
+++ b/rs/moq-hls/src/server/mod.rs
@@ -13,15 +13,37 @@
 mod routes;
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use axum::Router;
 
-use crate::export::{Broadcaster, Config};
+use crate::export::{Broadcaster, Config, Handle};
 
 /// How long to wait for a requested broadcast to be announced by the relay.
 const RESOLVE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Aborts the driver task when its cache entry is dropped, tearing the whole
+/// export (catalog consumer + every exporter) down and releasing its source
+/// subscriptions -- so evicting/replacing an entry stops recording immediately.
+struct AbortOnDrop(tokio::task::AbortHandle);
+
+impl Drop for AbortOnDrop {
+	fn drop(&mut self) {
+		self.0.abort();
+	}
+}
+
+/// One cached broadcast: the read handle served to HTTP requests, plus the driver
+/// task that owns the `Broadcaster` (aborted when this entry is dropped). The `id`
+/// distinguishes generations so a finishing driver only evicts its OWN entry, not a
+/// replacement.
+struct Entry {
+	id: u64,
+	handle: Handle,
+	_driver: AbortOnDrop,
+}
 
 /// HLS export HTTP server. Cheap to clone (shared inner).
 #[derive(Clone)]
@@ -32,7 +54,8 @@ pub struct Server {
 struct Inner {
 	origin: moq_net::OriginConsumer,
 	config: Config,
-	broadcasters: Mutex<HashMap<String, Arc<Broadcaster>>>,
+	broadcasters: Mutex<HashMap<String, Entry>>,
+	next_id: AtomicU64,
 }
 
 impl Server {
@@ -43,6 +66,7 @@ impl Server {
 				origin,
 				config,
 				broadcasters: Mutex::new(HashMap::new()),
+				next_id: AtomicU64::new(0),
 			}),
 		}
 	}
@@ -52,18 +76,13 @@ impl Server {
 		routes::router(self.clone())
 	}
 
-	/// Get or create the [`Broadcaster`] for `name`, resolving the broadcast from
-	/// the relay (waiting briefly for its announcement). Returns `None` if the
-	/// broadcast never shows up.
-	pub(crate) async fn broadcaster(&self, name: &str) -> Option<Arc<Broadcaster>> {
-		{
-			let mut broadcasters = self.inner.broadcasters.lock().unwrap();
-			if let Some(existing) = broadcasters.get(name) {
-				if !existing.is_closed() {
-					return Some(existing.clone());
-				}
-				broadcasters.remove(name);
-			}
+	/// Get or create the read [`Handle`] for `name`, resolving the broadcast from the
+	/// relay (waiting briefly for its announcement) and spawning a driver to fill it.
+	/// Returns `None` if the broadcast never shows up (or its catalog can't be
+	/// subscribed).
+	pub(crate) async fn handle(&self, name: &str) -> Option<Handle> {
+		if let Some(handle) = self.cached(name) {
+			return Some(handle);
 		}
 
 		let broadcast = tokio::time::timeout(RESOLVE_TIMEOUT, self.inner.origin.announced_broadcast(name))
@@ -72,30 +91,55 @@ impl Server {
 			.flatten()?;
 
 		let mut broadcasters = self.inner.broadcasters.lock().unwrap();
-		if let Some(existing) = broadcasters.get(name) {
-			if !existing.is_closed() {
-				return Some(existing.clone());
-			}
-			broadcasters.remove(name);
+		// Someone may have resolved the same broadcast while we awaited.
+		if let Some(entry) = broadcasters.get(name) {
+			return Some(entry.handle.clone());
 		}
 
+		let mut broadcaster = match Broadcaster::new(broadcast, self.inner.config.clone()) {
+			Ok(broadcaster) => broadcaster,
+			Err(err) => {
+				tracing::warn!(%name, %err, "failed to start HLS export");
+				return None;
+			}
+		};
+		let handle = broadcaster.handle();
+		let id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
+		let inner = self.inner.clone();
 		let name = name.to_string();
-		let broadcaster = Broadcaster::new(broadcast, self.inner.config.clone());
-		broadcasters.insert(name.clone(), broadcaster.clone());
-		tokio::spawn(evict_closed(self.inner.clone(), name, broadcaster.clone()));
-		Some(broadcaster)
+		let driver = tokio::spawn({
+			let name = name.clone();
+			async move {
+				broadcaster.run().await;
+				// Self-evict once the broadcast has finished, unless this entry has
+				// already been replaced by a newer generation.
+				evict(&inner, &name, id);
+			}
+		});
+		broadcasters.insert(
+			name,
+			Entry {
+				id,
+				handle: handle.clone(),
+				_driver: AbortOnDrop(driver.abort_handle()),
+			},
+		);
+		Some(handle)
+	}
+
+	/// Return the cached handle for `name`, if one is live.
+	fn cached(&self, name: &str) -> Option<Handle> {
+		let broadcasters = self.inner.broadcasters.lock().unwrap();
+		broadcasters.get(name).map(|entry| entry.handle.clone())
 	}
 }
 
-async fn evict_closed(inner: Arc<Inner>, name: String, broadcaster: Arc<Broadcaster>) {
-	broadcaster.closed().await;
-
+/// Remove `name`'s cache entry iff it is still generation `id` (a driver that just
+/// finished doesn't evict a replacement that took its place).
+fn evict(inner: &Inner, name: &str, id: u64) {
 	let mut broadcasters = inner.broadcasters.lock().unwrap();
-	if broadcasters
-		.get(&name)
-		.is_some_and(|current| Arc::ptr_eq(current, &broadcaster))
-	{
-		broadcasters.remove(&name);
+	if broadcasters.get(name).is_some_and(|entry| entry.id == id) {
+		broadcasters.remove(name);
 	}
 }
 
@@ -103,52 +147,77 @@ async fn evict_closed(inner: Arc<Inner>, name: String, broadcaster: Arc<Broadcas
 mod tests {
 	use super::*;
 
-	fn closed_broadcaster() -> Arc<Broadcaster> {
-		let producer = moq_net::Broadcast::new().produce();
-		let broadcaster = Broadcaster::new(producer.consume(), Config::default());
-		drop(producer);
-		broadcaster
+	/// A broadcast producer carrying a `catalog.json` track, so a `Broadcaster` can
+	/// subscribe its catalog (fail-loud `new` rejects a broadcast without one). The
+	/// producer + track are returned so the caller keeps the broadcast alive.
+	fn live_broadcast() -> (moq_net::BroadcastProducer, moq_net::TrackProducer) {
+		let mut producer = moq_net::Broadcast::new().produce();
+		let catalog = producer
+			.create_track(moq_net::Track {
+				name: "catalog.json".to_string(),
+				priority: 0,
+			})
+			.unwrap();
+		(producer, catalog)
+	}
+
+	/// Seed an entry of generation `id` over a live broadcast; returns the guards that
+	/// keep it alive (producer + catalog track).
+	fn seed_entry(server: &Server, id: u64) -> (moq_net::BroadcastProducer, moq_net::TrackProducer) {
+		let (producer, catalog) = live_broadcast();
+		let mut broadcaster = Broadcaster::new(producer.consume(), Config::default()).unwrap();
+		let handle = broadcaster.handle();
+		let driver = tokio::spawn(async move { broadcaster.run().await });
+		server.inner.broadcasters.lock().unwrap().insert(
+			"live".to_string(),
+			Entry {
+				id,
+				handle,
+				_driver: AbortOnDrop(driver.abort_handle()),
+			},
+		);
+		(producer, catalog)
 	}
 
 	#[tokio::test]
-	async fn broadcaster_replaces_finished_cached_instance() {
+	async fn resolves_and_caches_handle() {
 		let origin = moq_net::Origin::random().produce();
 		let server = Server::new(origin.consume(), Config::default());
-		let stale = closed_broadcaster();
+		let mut producer = origin.create_broadcast("live").expect("publish allowed");
+		let _catalog = producer
+			.create_track(moq_net::Track {
+				name: "catalog.json".to_string(),
+				priority: 0,
+			})
+			.unwrap();
 
-		server
-			.inner
-			.broadcasters
-			.lock()
-			.unwrap()
-			.insert("live".to_string(), stale.clone());
-		let _producer = origin.create_broadcast("live").expect("publish allowed");
-
-		let fresh = server.broadcaster("live").await.expect("broadcast announced");
-
-		assert!(!Arc::ptr_eq(&stale, &fresh));
+		let first = server.handle("live").await.expect("broadcast announced");
+		// A second request reuses the same cached entry rather than spawning a new driver.
 		assert!(server.inner.broadcasters.lock().unwrap().contains_key("live"));
+		let _second = server.handle("live").await.expect("cached");
+		assert_eq!(server.inner.broadcasters.lock().unwrap().len(), 1);
+		drop(first);
 	}
 
 	#[tokio::test]
-	async fn eviction_keeps_newer_cached_instance() {
+	async fn finished_driver_evicts_its_own_entry() {
 		let origin = moq_net::Origin::random().produce();
 		let server = Server::new(origin.consume(), Config::default());
-		let old = closed_broadcaster();
-		let new_producer = moq_net::Broadcast::new().produce();
-		let new = Broadcaster::new(new_producer.consume(), Config::default());
+		let _guards = seed_entry(&server, 7);
 
-		server
-			.inner
-			.broadcasters
-			.lock()
-			.unwrap()
-			.insert("live".to_string(), new.clone());
+		evict(&server.inner, "live", 7);
+		assert!(!server.inner.broadcasters.lock().unwrap().contains_key("live"));
+	}
 
-		evict_closed(server.inner.clone(), "live".to_string(), old).await;
+	#[tokio::test]
+	async fn stale_eviction_keeps_newer_entry() {
+		let origin = moq_net::Origin::random().produce();
+		let server = Server::new(origin.consume(), Config::default());
+		// The current entry is generation 9.
+		let _guards = seed_entry(&server, 9);
 
-		let cached = server.inner.broadcasters.lock().unwrap().get("live").cloned();
-		assert!(cached.is_some_and(|cached| Arc::ptr_eq(&cached, &new)));
-		drop(new_producer);
+		// An older generation (id 8) finishing must NOT evict the newer entry.
+		evict(&server.inner, "live", 8);
+		assert!(server.inner.broadcasters.lock().unwrap().contains_key("live"));
 	}
 }

--- a/rs/moq-hls/src/server/routes.rs
+++ b/rs/moq-hls/src/server/routes.rs
@@ -31,11 +31,16 @@ pub fn router(server: Server) -> Router {
 }
 
 async fn master(State(server): State<Server>, Path(broadcast): Path<String>) -> Response {
-	let Some(broadcaster) = server.broadcaster(&broadcast).await else {
+	let Some(handle) = server.handle(&broadcast).await else {
 		return not_found();
 	};
-	broadcaster.wait_ready(READY_TIMEOUT).await;
-	m3u8(broadcaster.master_playlist())
+	handle.wait_ready(READY_TIMEOUT).await;
+	// Don't serve an empty master (a 200 with no variants): if no rendition showed up
+	// within the timeout, the broadcast isn't playable yet, so 404.
+	if handle.renditions().is_empty() {
+		return not_found();
+	}
+	m3u8(handle.master_playlist())
 }
 
 async fn media(
@@ -122,9 +127,9 @@ async fn part(
 
 /// Resolve a rendition's store, waiting for the catalog to populate.
 async fn store(server: &Server, broadcast: &str, rendition: &str) -> Option<std::sync::Arc<SegmentStore>> {
-	let broadcaster = server.broadcaster(broadcast).await?;
-	broadcaster.wait_ready(READY_TIMEOUT).await;
-	broadcaster.rendition(rendition).map(|r| r.store.clone())
+	let handle = server.handle(broadcast).await?;
+	handle.wait_ready(READY_TIMEOUT).await;
+	handle.rendition(rendition).map(|r| r.store.clone())
 }
 
 /// Block until the store holds `(msn, part)`, the window passed it, or the track


### PR DESCRIPTION
## Why

`export::Broadcaster` spawned a detached `watch_catalog` task (holding an `Arc<Broadcaster>` self-reference) plus one detached pump per rendition, and tore down only when the **source broadcast** closed. Dropping the owner's handle did nothing, so a VOD recorder that stopped recording a still-live broadcast leaked its catalog + per-track subscriptions -- keeping subscription-driven publishers (moq-boy) emulating at ~90% CPU for hours after a recording was deleted (#2255).

#2254 patched this with a `Weak` + abort-on-drop guards. This replaces that machinery with a design that **can't leak by construction**, and cleans up the surrounding task/ownership layer that motivated the leak.

## What

`Broadcaster` is now a plain owned value the caller drives by polling, mirroring `fmp4::Export` one layer down:

- **`poll(&mut self, waiter) -> Poll<()>`** advances the discovery catalog and every rendition's `fmp4::Export` in one **cancel-safe** pass, with **no** background tasks. Dropping the `Broadcaster` drops its catalog consumer + every `Export`, releasing all source subscriptions immediately -- the leak is unrepresentable, and the #2254 `Weak`/`AbortOnDrop` machinery is gone.
- **`Handle`** (cheap, cloneable) carries the read side (rendition set + stores + `wait_ready` + `master_playlist`) to HTTP handlers and downstream consumers, and adds **`renditions()`** so callers enumerate the set directly instead of re-parsing the master playlist. It holds no subscription and can't keep the export alive past the driver.
- **`set_paused(&mut self)`** is a plain setter applied between polls (each owner writes its own `select!` over `poll` + its pause signals); **`run()`** is a no-pause convenience for the HTTP server.

### Delete the catalog retry loop (fix the real bug)

`CATALOG_RETRY` papered over a publish-order race, not a transient. `catalog::Consumer::new` returns `NotFound` only when `catalog.json` is absent **and** the broadcast has no dynamic producer. Relayed broadcasts can't hit it (the relay's subscriber creates the dynamic handler *before* `publish_broadcast`); only the local `moq-cli hls import` could, because it announced the broadcast *before* creating the catalog. Fixed the ordering there (create the catalog before `publish_broadcast`) and made `Broadcaster::new` **fail loud** instead of retrying.

### Server

The driver task owns the `Broadcaster` and holds it via an abort-on-drop guard behind a per-generation id, so evicting/replacing a cache entry tears the export down; a finished driver self-evicts only its own generation. `master.m3u8` now returns 404 instead of serving an empty 200 when no rendition appears within the timeout.

### Source-end handling

A source ending abruptly (publisher disconnect -- the common live case, which surfaces as an `Err` rather than a clean `None`) finishes the rendition and is **logged, not propagated**: for a live broadcast it's the normal termination, not a fault, so propagating it would false-flag nearly every recording as truncated.

## Tests

- `dropping_broadcaster_releases_subscription` -- dropping the driver releases the **catalog** subscription.
- `dropping_broadcaster_releases_media_subscription` -- and the **live media** subscription (the actual #2255 scenario: a live track held open is what kept the demo publishers emulating).
- `broadcast_gone_completes` -- the broadcast going away drives `run()` to completion instead of hanging.
- Server cache/eviction generation tests.

Full `moq-hls` suite green (23/23). `cargo fmt` + `clippy` clean on `moq-hls`.

> Based on `main` (the #2254 merge), which this supersedes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)