### PR TITLE
fix(publish): scope broadcast subscription serving per-track

### DIFF
--- a/js/publish/src/broadcast.test.ts
+++ b/js/publish/src/broadcast.test.ts
@@ -1,9 +1,13 @@
 import { expect, test } from "bun:test";
 import * as Catalog from "@moq/hang/catalog";
 import * as Json from "@moq/json";
-import { Track } from "@moq/net";
+import { type Connection, Path, Track } from "@moq/net";
 import { Effect } from "@moq/signals";
 import { Broadcast } from "./broadcast.ts";
+
+// The broadcast only opens its network producer once it has a connection, so tests that drive the
+// request loop hand it a stub whose publish() is a no-op; the internal producer is exposed via `net`.
+const stubConnection = () => ({ publish() {} }) as unknown as Connection.Established;
 
 // Effects and signal writes coalesce onto microtasks, so a chain of registration -> config -> catalog
 // needs a few flushes to settle.
@@ -99,6 +103,47 @@ test("rendition.close() unregisters the name and drops it from the catalog", asy
 
 	// The name is free to register again.
 	expect(() => broadcast.video("video/hd")).not.toThrow();
+
+	broadcast.close();
+});
+
+test("serving a subscription sets the rendition track and clears it when the track closes", async () => {
+	const broadcast = new Broadcast({ enabled: true, connection: stubConnection(), name: Path.from("test.hang") });
+	await settle();
+
+	const net = broadcast.net.peek();
+	if (!net) throw new Error("expected a network producer once connected");
+
+	const rendition = broadcast.video("video");
+	const subscriber = net.subscribe("video");
+	await settle();
+
+	// The request loop accepted the subscription and handed the producer to the rendition.
+	const track = rendition.track.peek();
+	expect(track).toBeDefined();
+
+	// Closing the producer (encoder error / teardown) clears the signal via track.closed, without a
+	// lingering per-subscription effect watching it.
+	track?.close();
+	await settle();
+	expect(rendition.track.peek()).toBeUndefined();
+
+	subscriber.close();
+	broadcast.close();
+});
+
+test("serves the catalog through the broadcast request loop", async () => {
+	const broadcast = new Broadcast({ enabled: true, connection: stubConnection(), name: Path.from("test.hang") });
+	broadcast.video("video").config.set(videoConfig);
+	await settle();
+
+	const net = broadcast.net.peek();
+	if (!net) throw new Error("expected a network producer once connected");
+
+	// Subscribing to the catalog track drives the request loop's per-subscription serving scope.
+	const subscriber = net.subscribe(Broadcast.CATALOG_TRACK);
+	const catalog = await new Json.Snapshot.Consumer<Catalog.Root>(subscriber).next();
+	expect(catalog?.video?.renditions.video?.codec).toBe("avc1.640028");
 
 	broadcast.close();
 });

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -194,6 +194,14 @@ export class Broadcast {
 	}
 
 	async #runBroadcast(broadcast: Moq.Broadcast.Producer, effect: Effect) {
+		// Each catalog subscription serves from its own scope so serving state doesn't pile up on the
+		// long-lived #run effect as subscribers come and go. Close whatever is still open on teardown.
+		const scopes = new Set<Effect>();
+		effect.cleanup(() => {
+			for (const scope of scopes) scope.close();
+			scopes.clear();
+		});
+
 		for (;;) {
 			const request = await broadcast.requested();
 			if (!request) break;
@@ -201,10 +209,18 @@ export class Broadcast {
 			if (request.name === Broadcast.CATALOG_TRACK || request.name === Broadcast.CATALOG_TRACK_COMPRESSED) {
 				const compression = request.name === Broadcast.CATALOG_TRACK_COMPRESSED;
 				const track = request.accept();
-				effect.cleanup(() => track.close());
-				effect.run((effect) => {
-					if (effect.get(track.closedSignal)) return;
+
+				const scope = new Effect();
+				scopes.add(scope);
+				scope.run((effect) => {
+					effect.cleanup(() => track.close());
 					this.catalog.serve(track, effect, { compression });
+				});
+
+				// Release the scope when the subscriber goes away, rather than leaking it until reconnect.
+				void track.closed.then(() => {
+					scopes.delete(scope);
+					scope.close();
 				});
 				continue;
 			}
@@ -223,8 +239,7 @@ export class Broadcast {
 			signal.set(track);
 
 			// Clear the signal when this track closes on its own, unless it's already been replaced.
-			effect.run((effect) => {
-				if (!effect.get(track.closedSignal)) return;
+			void track.closed.then(() => {
 				if (signal.peek() === track) signal.set(undefined);
 			});
 		}


### PR DESCRIPTION
## What

`Broadcast.#runBroadcast` (the `requested()` serving loop) registered an `effect.run(...)` and an `effect.cleanup(() => track.close())` on the **connection-lifetime** `#run` effect for every accepted subscription. Those were only released when the whole connection tore down (reconnect), so a long-lived publisher serving many transient subscribers accumulated one inert child effect — plus a captured `track` reference — per subscription. A gradual retention leak proportional to cumulative subscription count within a single connection.

## Fix

- Each **catalog** subscription now serves from its own `Effect` scope, tracked in a `Set` and closed when that subscription's track closes (`track.closed`) or on teardown (the set is drained in the `#run` cleanup).
- The **media** path drops its per-subscription `effect.run(track.closedSignal)` watcher entirely and clears the rendition's track signal off `track.closed` instead — no accumulating effect.

Net effect: serving state no longer piles up on the long-lived connection effect.

## Root cause

The loop body used the enclosing `#run` effect as the scope for per-subscription reactivity. `effect.run(...)` child effects and `effect.cleanup(...)` disposers registered there live until the parent closes, so a loop that runs once per subscription leaks them for the connection's lifetime. The fix gives each subscription a scope whose lifetime is its track, not the connection.

## Tests

The existing `broadcast.test.ts` only drove catalog *folding* (via `broadcast.catalog.serve` directly) and never exercised the request loop. Added two tests that drive the loop through the internal `net` producer:
- a subscription sets the rendition track, and closing the producer track clears the signal;
- the catalog is served end-to-end through the loop.

These are behavior-preservation coverage for the refactor. The retention itself is inert-effect/closure retention (not a signal-subscriber-count blowup), so there's no clean automated assertion for "the leak is gone" — noted honestly rather than faked.

## Notes

- Follow-up to #2257 (noted during that review, deferred to avoid risk right before merge).
- Targets `dev` because the touched code only exists on `dev` (it landed via #2257). No public API or wire change.
- `just js check` + `just js test` pass; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)