### PR TITLE
fix(publish): release per-subscription serve scopes instead of leaking them

### DIFF
--- a/js/publish/src/broadcast.test.ts
+++ b/js/publish/src/broadcast.test.ts
@@ -1,9 +1,13 @@
 import { expect, test } from "bun:test";
 import * as Catalog from "@moq/hang/catalog";
 import * as Json from "@moq/json";
-import { Track } from "@moq/net";
+import { type Connection, Path, Track } from "@moq/net";
 import { Effect } from "@moq/signals";
 import { Broadcast } from "./broadcast.ts";
+
+// The broadcast only opens its network producer once it has a connection, so tests that drive the
+// request loop hand it a stub whose publish() is a no-op; the internal producer is exposed via `net`.
+const stubConnection = () => ({ publish() {} }) as unknown as Connection.Established;
 
 // Effects and signal writes coalesce onto microtasks, so a chain of registration -> config -> catalog
 // needs a few flushes to settle.
@@ -99,6 +103,52 @@ test("rendition.close() unregisters the name and drops it from the catalog", asy
 
 	// The name is free to register again.
 	expect(() => broadcast.video("video/hd")).not.toThrow();
+
+	broadcast.close();
+});
+
+test("serving a subscription hands the producer to the rendition and clears it when the track closes", async () => {
+	const broadcast = new Broadcast({ enabled: true, connection: stubConnection(), name: Path.from("test.hang") });
+	await settle();
+
+	const net = broadcast.net.peek();
+	if (!net) throw new Error("expected a network producer once connected");
+
+	const rendition = broadcast.video("video");
+	const subscriber = net.subscribe("video");
+	await settle();
+
+	// The request loop accepted the subscription and handed the producer to the rendition.
+	const track = rendition.track.peek();
+	expect(track).toBeDefined();
+
+	// Closing the producer (encoder error / teardown) clears the signal, with no lingering per-subscription
+	// effect watching it.
+	track?.close();
+	await settle();
+	expect(rendition.track.peek()).toBeUndefined();
+
+	subscriber.close();
+	broadcast.close();
+});
+
+test("serves the catalog through the request loop and releases the scope when the subscriber leaves", async () => {
+	const broadcast = new Broadcast({ enabled: true, connection: stubConnection(), name: Path.from("test.hang") });
+	broadcast.video("video").config.set(videoConfig);
+	await settle();
+
+	const net = broadcast.net.peek();
+	if (!net) throw new Error("expected a network producer once connected");
+
+	// Subscribing to the catalog track drives the per-subscription serving scope.
+	const subscriber = net.subscribe(Broadcast.CATALOG_TRACK);
+	const catalog = await new Json.Snapshot.Consumer<Catalog.Root>(subscriber).next();
+	expect(catalog?.video?.renditions.video?.codec).toBe("avc1.640028");
+
+	// Dropping the subscriber closes the served track; the broadcast keeps running for the next viewer.
+	subscriber.close();
+	await settle();
+	expect(broadcast.net.peek()).toBe(net);
 
 	broadcast.close();
 });

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -201,11 +201,14 @@ export class Broadcast {
 			if (request.name === Broadcast.CATALOG_TRACK || request.name === Broadcast.CATALOG_TRACK_COMPRESSED) {
 				const compression = request.name === Broadcast.CATALOG_TRACK_COMPRESSED;
 				const track = request.accept();
-				effect.cleanup(() => track.close());
-				effect.run((effect) => {
-					if (effect.get(track.closedSignal)) return;
+
+				// Serve from a per-subscription child scope. Releasing it when this subscriber leaves keeps
+				// serving state from piling up on the connection-lifetime effect as viewers come and go.
+				const dispose = effect.run((effect) => {
+					effect.cleanup(() => track.close());
 					this.catalog.serve(track, effect, { compression });
 				});
+				void track.closed.then(dispose);
 				continue;
 			}
 
@@ -222,9 +225,9 @@ export class Broadcast {
 			signal.peek()?.close();
 			signal.set(track);
 
-			// Clear the signal when this track closes on its own, unless it's already been replaced.
-			effect.run((effect) => {
-				if (!effect.get(track.closedSignal)) return;
+			// Clear the signal when this track closes on its own, unless it's already been replaced. A
+			// plain promise callback (no child effect) so nothing lingers on the connection effect.
+			void track.closed.then(() => {
 				if (signal.peek() === track) signal.set(undefined);
 			});
 		}

--- a/js/signals/src/index.test.ts
+++ b/js/signals/src/index.test.ts
@@ -126,6 +126,44 @@ describe("Effect", () => {
 
 		expect(log).toEqual(["run 0", "cleanup 0", "run 1", "cleanup 1"]);
 	});
+
+	test("run() returns a disposer that closes the child and releases it from the parent", async () => {
+		const parent = new Effect();
+		const trigger = new Signal(0);
+		const runs: number[] = [];
+		const log: string[] = [];
+
+		const dispose = parent.run((e) => {
+			runs.push(e.get(trigger));
+			e.cleanup(() => log.push("cleanup"));
+		});
+		await settle();
+		expect(runs).toEqual([0]);
+
+		// Disposing runs the child's cleanup and stops it from rerunning.
+		dispose();
+		expect(log).toEqual(["cleanup"]);
+		trigger.set(1);
+		await settle();
+		expect(runs).toEqual([0]);
+
+		// Idempotent, and the child was released so closing the parent doesn't re-run its cleanup.
+		dispose();
+		parent.close();
+		expect(log).toEqual(["cleanup"]);
+	});
+
+	test("run() children left undisposed are still closed with the parent", async () => {
+		const parent = new Effect();
+		const log: string[] = [];
+
+		parent.run((e) => e.cleanup(() => log.push("a")));
+		parent.run((e) => e.cleanup(() => log.push("b")));
+		await settle();
+
+		parent.close();
+		expect(log.sort()).toEqual(["a", "b"]);
+	});
 });
 
 describe("Computed", () => {

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -578,17 +578,32 @@ export class Effect {
 		this.cleanup(() => clearInterval(interval));
 	}
 
-	/** Creates a nested effect that reruns independently and is closed with its parent. */
-	run(fn: (effect: Effect) => void) {
+	/**
+	 * Creates a nested effect that reruns independently and is closed with its parent.
+	 *
+	 * Returns a disposer that closes the child early and releases it from the parent, so a long-lived
+	 * effect spawning a child per event (e.g. one per accepted subscription) doesn't accumulate dead
+	 * scopes until it finally reruns or closes.
+	 */
+	run(fn: (effect: Effect) => void): Dispose {
 		if (this.#dispose === undefined) {
 			if (DEV) {
-				console.warn("Effect.nested called when closed, ignoring");
+				console.warn("Effect.run called when closed, ignoring");
 			}
-			return;
+			return () => {};
 		}
 
 		const effect = new Effect(fn);
-		this.#dispose.push(() => effect.close());
+		const dispose = () => effect.close();
+		this.#dispose.push(dispose);
+
+		return () => {
+			effect.close();
+			// Drop our disposer from the parent so repeated run()/dispose() cycles don't pile up.
+			const disposers = this.#dispose;
+			const index = disposers?.indexOf(dispose) ?? -1;
+			if (index !== -1) disposers?.splice(index, 1);
+		};
 	}
 
 	/** Creates a derived signal scoped to this effect, closed when the effect reruns or closes. */


### PR DESCRIPTION
## Problem

In `js/publish/src/broadcast.ts`, the connection-lifetime `#run` effect spawns `#runBroadcast`, and every accepted subscription registers `effect.run(...)` + `effect.cleanup(...)` **directly on that long-lived effect**. Those child effects/cleanups are only released when the whole connection tears down (reconnect). A long-lived publisher serving many transient subscribers therefore accumulates one inert child effect per *cumulative* subscription: a gradual memory leak proportional to subscription count within a single connection.

Noted during review of #2257 (composable Broadcast + per-rendition encoders) but deferred to avoid risk right before merge.

## Root cause

A gap in the `Effect` primitive, not just the call site: `Effect.run()` gave the caller no handle to tear down a single nested effect early. Only a parent rerun or `close()` released children, so a long-lived effect that spawns a child per event has no way to reclaim them as those events end.

## Fix

Fix the primitive, then use it:

- **`@moq/signals`**: `Effect.run()` now returns a `Dispose` (mirroring `Signal.subscribe(): Dispose` in the same file). The disposer closes the child **and** splices it out of the parent's dispose list, so repeated `run()`/dispose cycles on a long-lived effect don't pile up dead scopes. Additive and non-breaking, every existing `effect.run(...)` ignores the return.
- **`js/publish`**: key each accepted track's lifetime off `track.closed`.
  - Catalog track: serve from a per-subscription child scope (`const dispose = effect.run(...); void track.closed.then(dispose)`); still closed with the parent on teardown if the subscriber never leaves first.
  - Media track: dropped the child effect entirely, the old `effect.run` only watched `closedSignal` to clear a signal, which is now a plain `track.closed.then(...)`.

This is an alternative to #2259, which solved the same leak with an inline `Set<Effect>` of freestanding scopes. Fixing `run()` keeps the mechanism in the primitive (per CLAUDE.md's "fix the lower layer, not the caller"), reads cleaner at the call site, and fixes the leak for every future long-lived-effect-spawning-children caller.

## Tests

- `js/signals/src/index.test.ts`: the disposer closes the child, stops reruns, is idempotent, and (regression) is *released* so closing the parent doesn't re-run a disposed child's cleanup; undisposed children still close with the parent.
- `js/publish/src/broadcast.test.ts`: drive the real request loop via a stub connection, a media subscription hands the producer to the rendition and clears it on close; a catalog subscription serves and releases its scope when the subscriber leaves while the broadcast keeps running.

`just js check` and `just js test` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)