### PR TITLE
fix(moq-net): resolve reordered track aliases

### DIFF
--- a/js/net/src/ietf/adapter.ts
+++ b/js/net/src/ietf/adapter.ts
@@ -13,7 +13,7 @@ export interface Session {
 	openNativeBi?(): Promise<Stream>;
 	acceptBi(): Promise<Stream | undefined>;
 	nextRequestId(): Promise<bigint | undefined>;
-	close?(): void;
+	close(): void;
 	readonly version: IetfVersion;
 }
 
@@ -43,6 +43,11 @@ export class NativeSession implements Session {
 		const id = this.#requestId;
 		this.#requestId += 2n;
 		return id;
+	}
+
+	/** Closes the underlying WebTransport session. */
+	close() {
+		this.#quic.close();
 	}
 }
 

--- a/js/net/src/ietf/aliases.test.ts
+++ b/js/net/src/ietf/aliases.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+import { TrackAliases } from "./aliases.ts";
+
+test("waits for the control message that establishes an alias", async () => {
+	const aliases = new TrackAliases<object>();
+	const track = {};
+	const pending = aliases.get(7n);
+
+	aliases.set(7n, track);
+
+	expect(await pending).toBe(track);
+});
+
+test("rejects an alias used by two active tracks", () => {
+	const aliases = new TrackAliases<object>();
+	aliases.set(7n, {});
+
+	expect(() => aliases.set(7n, {})).toThrow("duplicate track alias");
+});
+
+test("does not let stale cleanup remove a reused alias", async () => {
+	const aliases = new TrackAliases<object>();
+	const active = {};
+	aliases.set(7n, active);
+
+	aliases.delete(7n, {});
+
+	expect(await aliases.get(7n)).toBe(active);
+});

--- a/js/net/src/ietf/aliases.test.ts
+++ b/js/net/src/ietf/aliases.test.ts
@@ -11,6 +11,16 @@ test("waits for the control message that establishes an alias", async () => {
 	expect(await pending).toBe(track);
 });
 
+test("resolves every subgroup waiting for the same alias", async () => {
+	const aliases = new TrackAliases<object>();
+	const track = {};
+	const pending = [aliases.get(7n), aliases.get(7n)];
+
+	aliases.set(7n, track);
+
+	expect(await Promise.all(pending)).toEqual([track, track]);
+});
+
 test("rejects an alias used by two active tracks", () => {
 	const aliases = new TrackAliases<object>();
 	aliases.set(7n, {});

--- a/js/net/src/ietf/aliases.ts
+++ b/js/net/src/ietf/aliases.ts
@@ -1,24 +1,23 @@
 const TRACK_ALIAS_TIMEOUT_MS = 1000;
 
-interface Pending<T> extends PromiseWithResolvers<T> {
-	waiters: number;
-}
+type Resolver<T> = PromiseWithResolvers<T>["resolve"];
 
 /** Resolves publisher-chosen track aliases after control/data stream reordering. @internal */
 export class TrackAliases<T> {
 	#active = new Map<bigint, T>();
-	#pending = new Map<bigint, Pending<T>>();
+	#pending = new Map<bigint, Set<Resolver<T>>>();
 
 	/** Waits briefly for an alias to be established by SUBSCRIBE_OK or PUBLISH. */
 	async get(alias: bigint): Promise<T> {
 		if (this.#active.has(alias)) return this.#active.get(alias) as T;
 
-		let pending = this.#pending.get(alias);
-		if (!pending) {
-			pending = { ...Promise.withResolvers<T>(), waiters: 0 };
-			this.#pending.set(alias, pending);
+		const { promise, resolve } = Promise.withResolvers<T>();
+		let resolvers = this.#pending.get(alias);
+		if (!resolvers) {
+			resolvers = new Set();
+			this.#pending.set(alias, resolvers);
 		}
-		pending.waiters += 1;
+		resolvers.add(resolve);
 
 		let timer: ReturnType<typeof setTimeout> | undefined;
 		const timeout = new Promise<never>((_, reject) => {
@@ -26,11 +25,11 @@ export class TrackAliases<T> {
 		});
 
 		try {
-			return await Promise.race([pending.promise, timeout]);
+			return await Promise.race([promise, timeout]);
 		} finally {
 			clearTimeout(timer);
-			pending.waiters -= 1;
-			if (this.#pending.get(alias) === pending && pending.waiters === 0) this.#pending.delete(alias);
+			resolvers.delete(resolve);
+			if (this.#pending.get(alias) === resolvers && resolvers.size === 0) this.#pending.delete(alias);
 		}
 	}
 
@@ -43,9 +42,9 @@ export class TrackAliases<T> {
 		}
 
 		this.#active.set(alias, value);
-		const pending = this.#pending.get(alias);
+		const resolvers = this.#pending.get(alias);
 		this.#pending.delete(alias);
-		pending?.resolve(value);
+		for (const resolve of resolvers ?? []) resolve(value);
 	}
 
 	/** Removes an alias only if it still belongs to the supplied value. */

--- a/js/net/src/ietf/aliases.ts
+++ b/js/net/src/ietf/aliases.ts
@@ -1,0 +1,55 @@
+const TRACK_ALIAS_TIMEOUT_MS = 1000;
+
+interface Pending<T> extends PromiseWithResolvers<T> {
+	waiters: number;
+}
+
+/** Resolves publisher-chosen track aliases after control/data stream reordering. @internal */
+export class TrackAliases<T> {
+	#active = new Map<bigint, T>();
+	#pending = new Map<bigint, Pending<T>>();
+
+	/** Waits briefly for an alias to be established by SUBSCRIBE_OK or PUBLISH. */
+	async get(alias: bigint): Promise<T> {
+		if (this.#active.has(alias)) return this.#active.get(alias) as T;
+
+		let pending = this.#pending.get(alias);
+		if (!pending) {
+			pending = { ...Promise.withResolvers<T>(), waiters: 0 };
+			this.#pending.set(alias, pending);
+		}
+		pending.waiters += 1;
+
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const timeout = new Promise<never>((_, reject) => {
+			timer = setTimeout(() => reject(new Error(`unknown track alias: ${alias}`)), TRACK_ALIAS_TIMEOUT_MS);
+		});
+
+		try {
+			return await Promise.race([pending.promise, timeout]);
+		} finally {
+			clearTimeout(timer);
+			pending.waiters -= 1;
+			if (this.#pending.get(alias) === pending && pending.waiters === 0) this.#pending.delete(alias);
+		}
+	}
+
+	/** Establishes an alias and releases any data streams waiting for it. */
+	set(alias: bigint, value: T) {
+		const active = this.#active.get(alias);
+		if (this.#active.has(alias)) {
+			if (active !== value) throw new Error(`duplicate track alias: ${alias}`);
+			return;
+		}
+
+		this.#active.set(alias, value);
+		const pending = this.#pending.get(alias);
+		this.#pending.delete(alias);
+		pending?.resolve(value);
+	}
+
+	/** Removes an alias only if it still belongs to the supplied value. */
+	delete(alias: bigint, value: T) {
+		if (this.#active.get(alias) === value) this.#active.delete(alias);
+	}
+}

--- a/js/net/src/ietf/connection.ts
+++ b/js/net/src/ietf/connection.ts
@@ -98,7 +98,7 @@ export class Connection implements Established {
 
 		this.#closed = true;
 
-		this.#session.close?.();
+		this.#session.close();
 
 		try {
 			this.#quic.close();

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -6,6 +6,7 @@ import type { Reader, Stream } from "../stream.ts";
 import type { Track } from "../track.ts";
 import { error } from "../util/error.ts";
 import type { Session } from "./adapter.ts";
+import { TrackAliases } from "./aliases.ts";
 import { Frame, type Group as GroupMessage } from "./object.ts";
 import { type Publish, PublishError } from "./publish.ts";
 import { type PublishNamespace, PublishNamespaceError, PublishNamespaceOk } from "./publish_namespace.ts";
@@ -31,8 +32,8 @@ import { Version } from "./version.ts";
 export class Subscriber {
 	#session: Session;
 
-	// Our subscribed tracks — keyed by trackAlias for group routing
-	#subscribes = new Map<bigint, Track>();
+	// Publisher-chosen aliases used by incoming group streams.
+	#aliases = new TrackAliases<Track>();
 
 	// Any currently active announcements.
 	#announced = new Set<Path.Valid>();
@@ -219,20 +220,19 @@ export class Subscriber {
 				await msg.encode(stream.writer, version);
 				console.debug(`subscribe written: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
 
-				// Pre-register with requestId so early group uni streams aren't dropped.
-				// The publisher typically uses requestId as the trackAlias.
-				this.#subscribes.set(requestId, request.track);
-
 				// Read response (SubscribeOk or error)
 				const respTypeId = await stream.reader.u53();
 				if (respTypeId === SubscribeOk.id) {
 					const ok = await SubscribeOk.decode(stream.reader, version);
-					// Update registration to use the actual trackAlias from SubscribeOk
-					if (ok.trackAlias !== requestId) {
-						this.#subscribes.delete(requestId);
-						this.#subscribes.set(ok.trackAlias, request.track);
+					try {
+						this.#aliases.set(ok.trackAlias, request.track);
+					} catch (err) {
+						this.#session.close();
+						throw err;
 					}
-					console.debug(`subscribe ok: id=${requestId} broadcast=${broadcast} track=${request.track.name}`);
+					console.debug(
+						`subscribe ok: id=${requestId} broadcast=${broadcast} track=${request.track.name} alias=${ok.trackAlias}`,
+					);
 
 					try {
 						// Wait for stream close (= PublishDone) or track close (= local unsubscribe)
@@ -259,12 +259,9 @@ export class Subscriber {
 							`subscribe close: id=${requestId} broadcast=${broadcast} track=${request.track.name}`,
 						);
 					} finally {
-						this.#subscribes.delete(ok.trackAlias);
+						this.#aliases.delete(ok.trackAlias, request.track);
 					}
 				} else {
-					// Clean up pre-registered entry on error
-					this.#subscribes.delete(requestId);
-
 					// Error response
 					let reasonPhrase = "unknown error";
 					try {
@@ -282,7 +279,6 @@ export class Subscriber {
 					throw new Error(`SUBSCRIBE error: ${reasonPhrase}`);
 				}
 			} catch (err) {
-				this.#subscribes.delete(requestId);
 				stream.abort(error(err));
 				throw err;
 			}
@@ -417,12 +413,8 @@ export class Subscriber {
 		}
 
 		try {
-			// Look up by trackAlias directly
-			const track = this.#subscribes.get(group.trackAlias);
-			if (!track) {
-				// Fallback: try treating trackAlias as requestId (for compat)
-				throw new Error(`unknown track: trackAlias=${group.trackAlias}`);
-			}
+			// The control message establishing this alias can arrive after the data stream.
+			const track = await this.#aliases.get(group.trackAlias);
 
 			track.writeGroup(producer);
 

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1,6 +1,9 @@
-use std::collections::{HashMap, hash_map::Entry};
-
-use std::sync::Arc;
+use std::{
+	collections::{HashMap, hash_map::Entry},
+	sync::Arc,
+	task::Poll,
+	time::Duration,
+};
 
 use crate::{
 	Broadcast, BroadcastDynamic, Error, Frame, FrameProducer, Group, GroupProducer, MAX_FRAME_SIZE, OriginProducer,
@@ -14,13 +17,49 @@ use super::{Message, Version};
 
 use web_async::Lock;
 
+const TRACK_ALIAS_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[derive(Default)]
+struct TrackAliases {
+	active: HashMap<u64, RequestId>,
+	waiters: kio::WaiterList,
+}
+
+impl TrackAliases {
+	fn poll_get(&mut self, alias: u64, waiter: &kio::Waiter) -> Poll<RequestId> {
+		if let Some(request_id) = self.active.get(&alias) {
+			return Poll::Ready(*request_id);
+		}
+
+		waiter.register(&mut self.waiters);
+		Poll::Pending
+	}
+
+	fn insert(&mut self, alias: u64, request_id: RequestId) -> Result<kio::WaiterList, Error> {
+		match self.active.entry(alias) {
+			Entry::Occupied(entry) if *entry.get() == request_id => Ok(kio::WaiterList::new()),
+			Entry::Occupied(_) => Err(Error::Duplicate),
+			Entry::Vacant(entry) => {
+				entry.insert(request_id);
+				Ok(self.waiters.take())
+			}
+		}
+	}
+
+	fn remove(&mut self, alias: u64, request_id: RequestId) {
+		if self.active.get(&alias) == Some(&request_id) {
+			self.active.remove(&alias);
+		}
+	}
+}
+
 #[derive(Default)]
 struct State {
 	// Each active subscription
 	subscribes: HashMap<RequestId, TrackState>,
 
-	// A map of track aliases to request IDs.
-	aliases: HashMap<u64, RequestId>,
+	// Track aliases chosen by the remote publisher.
+	aliases: TrackAliases,
 
 	// Each broadcast created by either a PUBLISH or PUBLISH_NAMESPACE message.
 	broadcasts: HashMap<PathOwned, BroadcastState>,
@@ -68,6 +107,19 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	version: Version,
 }
 
+async fn resolve_track_alias(state: &Lock<State>, alias: u64) -> Result<RequestId, Error> {
+	let resolved = kio::wait(|waiter| state.lock().aliases.poll_get(alias, waiter));
+	let timeout = web_async::time::sleep(TRACK_ALIAS_TIMEOUT);
+
+	tokio::pin!(resolved);
+	tokio::pin!(timeout);
+
+	tokio::select! {
+		request_id = &mut resolved => Ok(request_id),
+		_ = &mut timeout => Err(Error::NotFound),
+	}
+}
+
 impl<S: web_transport_trait::Session> Subscriber<S> {
 	pub fn new(
 		session: S,
@@ -91,6 +143,31 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 	pub fn has_origin(&self) -> bool {
 		self.origin.is_some()
+	}
+
+	fn register_alias(&self, request_id: RequestId, alias: u64) -> Result<(), Error> {
+		let mut waiters = {
+			let mut state = self.state.lock();
+			if !state.subscribes.contains_key(&request_id) {
+				return Err(Error::NotFound);
+			}
+
+			let waiters = state.aliases.insert(alias, request_id)?;
+			state.subscribes.get_mut(&request_id).unwrap().alias = Some(alias);
+			waiters
+		};
+
+		waiters.wake();
+		Ok(())
+	}
+
+	fn remove_subscribe(&self, request_id: RequestId) -> Option<TrackState> {
+		let mut state = self.state.lock();
+		let track = state.subscribes.remove(&request_id)?;
+		if let Some(alias) = track.alias {
+			state.aliases.remove(alias, request_id);
+		}
+		Some(track)
 	}
 
 	/// Send SUBSCRIBE_NAMESPACE on a bidi stream.
@@ -265,6 +342,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let request_id = msg.request_id;
 
 		if let Err(err) = self.start_publish(&msg) {
+			if matches!(err, Error::Duplicate) {
+				self.session.close(err.to_code(), err.to_string().as_ref());
+				return Err(err);
+			}
 			self.write_publish_error(&mut stream, request_id, 400, &err.to_string())
 				.await?;
 			return Ok(());
@@ -291,7 +372,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		if let Some(mut track) = state.subscribes.remove(&request_id) {
 			let _ = track.producer.finish();
 			if let Some(alias) = track.alias {
-				state.aliases.remove(&alias);
+				state.aliases.remove(alias, request_id);
 			}
 		}
 		if let Some(path) = state.publishes.remove(&request_id) {
@@ -574,17 +655,16 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			Entry::Occupied(_) => return Err(Error::Duplicate),
 		};
 
-		match state.aliases.entry(msg.track_alias) {
-			Entry::Vacant(entry) => {
-				entry.insert(request_id);
-			}
-			Entry::Occupied(_) => {
+		let mut waiters = match state.aliases.insert(msg.track_alias, request_id) {
+			Ok(waiters) => waiters,
+			Err(err) => {
 				state.subscribes.remove(&request_id);
-				return Err(Error::Duplicate);
+				return Err(err);
 			}
-		}
+		};
 		state.publishes.insert(request_id, msg.track_namespace.to_owned());
 		drop(state);
+		waiters.wake();
 
 		let mut broadcast = self.start_announce(msg.track_namespace.to_owned())?;
 		broadcast.insert_track(track.consume())?;
@@ -643,9 +723,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			.to_owned();
 		let track_stats = Arc::new(self.stats.broadcast(&abs).subscriber_track(&track.name));
 
-		// Pre-register the track so group data arriving before SubscribeOk can be routed.
-		// The publisher uses request_id.0 as track_alias, and recv_group falls back to
-		// RequestId(track_alias) when no alias mapping exists, so this works.
+		// Register the request before writing SUBSCRIBE so SUBSCRIBE_OK can bind its alias.
 		{
 			let mut state = self.state.lock();
 			state.subscribes.insert(
@@ -664,7 +742,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			.await
 		{
 			tracing::debug!(%err, "failed to write subscribe");
-			self.state.lock().subscribes.remove(&request_id);
+			self.remove_subscribe(request_id);
 			let _ = track.abort(err);
 			return;
 		}
@@ -672,20 +750,19 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		tracing::info!(broadcast = %self.origin.as_ref().expect("origin set by start_announce").absolute(&broadcast_path), track = %track.name, "subscribe started");
 
 		// Read the response and register the alias mapping
-		let track_alias = match self.read_subscribe_response(&mut stream).await {
-			Ok(alias) => {
-				if let Some(alias) = alias {
-					let mut state = self.state.lock();
-					state.aliases.insert(alias, request_id);
-					if let Some(track_state) = state.subscribes.get_mut(&request_id) {
-						track_state.alias = Some(alias);
-					}
+		match self.read_subscribe_response(&mut stream).await {
+			Ok(Some(alias)) => {
+				if let Err(err) = self.register_alias(request_id, alias) {
+					self.session.close(err.to_code(), err.to_string().as_ref());
+					self.remove_subscribe(request_id);
+					let _ = track.abort(err);
+					return;
 				}
-				alias
 			}
+			Ok(None) => {}
 			Err(err) => {
 				tracing::debug!(%err, "subscribe response error");
-				self.state.lock().subscribes.remove(&request_id);
+				self.remove_subscribe(request_id);
 				let _ = track.abort(err);
 				return;
 			}
@@ -720,10 +797,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 
 		// Clean up
-		self.state.lock().subscribes.remove(&request_id);
-		if let Some(alias) = track_alias {
-			self.state.lock().aliases.remove(&alias);
-		}
+		self.remove_subscribe(request_id);
 
 		stream.writer.finish().ok();
 	}
@@ -784,15 +858,16 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			return Err(Error::Unsupported);
 		}
 
+		// SUBSCRIBE_OK or PUBLISH can be reordered behind this stream. Hold only the
+		// subgroup header while waiting so the data stream cannot consume flow control.
+		let request_id = resolve_track_alias(&self.state, group.track_alias)
+			.await
+			.inspect_err(|_| {
+				tracing::warn!(track_alias = %group.track_alias, "unknown track alias");
+			})?;
+
 		let (mut producer, track, track_stats) = {
 			let mut state = self.state.lock();
-			let request_id = match state.aliases.get(&group.track_alias) {
-				Some(request_id) => *request_id,
-				None => {
-					tracing::warn!(track_alias = %group.track_alias, "unknown track alias, using request ID");
-					RequestId(group.track_alias)
-				}
-			};
 			let track = state.subscribes.get_mut(&request_id).ok_or(Error::NotFound)?;
 
 			let group_info = Group {
@@ -893,5 +968,41 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 		}
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use futures::poll;
+
+	use super::*;
+
+	#[tokio::test(start_paused = true)]
+	async fn track_alias_waits_for_control_message() {
+		let state = Lock::new(State::default());
+		let pending = resolve_track_alias(&state, 7);
+		tokio::pin!(pending);
+
+		assert!(poll!(&mut pending).is_pending());
+
+		let mut waiters = state.lock().aliases.insert(7, RequestId(11)).unwrap();
+		waiters.wake();
+
+		assert_eq!(pending.await.unwrap(), RequestId(11));
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn unknown_track_alias_times_out() {
+		let state = Lock::new(State::default());
+		assert!(matches!(resolve_track_alias(&state, 7).await, Err(Error::NotFound)));
+	}
+
+	#[test]
+	fn removing_old_track_does_not_remove_reused_alias() {
+		let mut aliases = TrackAliases::default();
+		aliases.insert(7, RequestId(11)).unwrap();
+		aliases.remove(7, RequestId(13));
+
+		assert_eq!(aliases.active.get(&7), Some(&RequestId(11)));
 	}
 }

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -19,37 +19,26 @@ use web_async::Lock;
 
 const TRACK_ALIAS_TIMEOUT: Duration = Duration::from_secs(1);
 
-#[derive(Default)]
-struct TrackAliases {
-	active: HashMap<u64, RequestId>,
-	waiters: kio::WaiterList,
+type TrackAliases = kio::Producer<HashMap<u64, RequestId>>;
+
+fn insert_track_alias(aliases: &TrackAliases, alias: u64, request_id: RequestId) -> Result<(), Error> {
+	let mut aliases = aliases.write().map_err(|_| Error::Dropped)?;
+	match aliases.entry(alias) {
+		Entry::Occupied(entry) if *entry.get() == request_id => Ok(()),
+		Entry::Occupied(_) => Err(Error::Duplicate),
+		Entry::Vacant(entry) => {
+			entry.insert(request_id);
+			Ok(())
+		}
+	}
 }
 
-impl TrackAliases {
-	fn poll_get(&mut self, alias: u64, waiter: &kio::Waiter) -> Poll<RequestId> {
-		if let Some(request_id) = self.active.get(&alias) {
-			return Poll::Ready(*request_id);
-		}
-
-		waiter.register(&mut self.waiters);
-		Poll::Pending
-	}
-
-	fn insert(&mut self, alias: u64, request_id: RequestId) -> Result<kio::WaiterList, Error> {
-		match self.active.entry(alias) {
-			Entry::Occupied(entry) if *entry.get() == request_id => Ok(kio::WaiterList::new()),
-			Entry::Occupied(_) => Err(Error::Duplicate),
-			Entry::Vacant(entry) => {
-				entry.insert(request_id);
-				Ok(self.waiters.take())
-			}
-		}
-	}
-
-	fn remove(&mut self, alias: u64, request_id: RequestId) {
-		if self.active.get(&alias) == Some(&request_id) {
-			self.active.remove(&alias);
-		}
+fn remove_track_alias(aliases: &TrackAliases, alias: u64, request_id: RequestId) {
+	let Ok(mut aliases) = aliases.write() else {
+		return;
+	};
+	if aliases.get(&alias) == Some(&request_id) {
+		aliases.remove(&alias);
 	}
 }
 
@@ -107,15 +96,22 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	version: Version,
 }
 
-async fn resolve_track_alias(state: &Lock<State>, alias: u64) -> Result<RequestId, Error> {
-	let resolved = kio::wait(|waiter| state.lock().aliases.poll_get(alias, waiter));
+async fn resolve_track_alias(aliases: kio::Consumer<HashMap<u64, RequestId>>, alias: u64) -> Result<RequestId, Error> {
+	let resolved = kio::wait(move |waiter| {
+		aliases
+			.poll(waiter, |aliases| match aliases.get(&alias) {
+				Some(request_id) => Poll::Ready(*request_id),
+				None => Poll::Pending,
+			})
+			.map(|result| result.map_err(|_| Error::Dropped))
+	});
 	let timeout = web_async::time::sleep(TRACK_ALIAS_TIMEOUT);
 
 	tokio::pin!(resolved);
 	tokio::pin!(timeout);
 
 	tokio::select! {
-		request_id = &mut resolved => Ok(request_id),
+		request_id = &mut resolved => request_id,
 		_ = &mut timeout => Err(Error::NotFound),
 	}
 }
@@ -146,18 +142,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	fn register_alias(&self, request_id: RequestId, alias: u64) -> Result<(), Error> {
-		let mut waiters = {
-			let mut state = self.state.lock();
-			if !state.subscribes.contains_key(&request_id) {
-				return Err(Error::NotFound);
-			}
+		let mut state = self.state.lock();
+		if !state.subscribes.contains_key(&request_id) {
+			return Err(Error::NotFound);
+		}
 
-			let waiters = state.aliases.insert(alias, request_id)?;
-			state.subscribes.get_mut(&request_id).unwrap().alias = Some(alias);
-			waiters
-		};
-
-		waiters.wake();
+		insert_track_alias(&state.aliases, alias, request_id)?;
+		state.subscribes.get_mut(&request_id).unwrap().alias = Some(alias);
 		Ok(())
 	}
 
@@ -165,7 +156,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let mut state = self.state.lock();
 		let track = state.subscribes.remove(&request_id)?;
 		if let Some(alias) = track.alias {
-			state.aliases.remove(alias, request_id);
+			remove_track_alias(&state.aliases, alias, request_id);
 		}
 		Some(track)
 	}
@@ -372,7 +363,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		if let Some(mut track) = state.subscribes.remove(&request_id) {
 			let _ = track.producer.finish();
 			if let Some(alias) = track.alias {
-				state.aliases.remove(alias, request_id);
+				remove_track_alias(&state.aliases, alias, request_id);
 			}
 		}
 		if let Some(path) = state.publishes.remove(&request_id) {
@@ -655,16 +646,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			Entry::Occupied(_) => return Err(Error::Duplicate),
 		};
 
-		let mut waiters = match state.aliases.insert(msg.track_alias, request_id) {
-			Ok(waiters) => waiters,
-			Err(err) => {
-				state.subscribes.remove(&request_id);
-				return Err(err);
-			}
-		};
+		if let Err(err) = insert_track_alias(&state.aliases, msg.track_alias, request_id) {
+			state.subscribes.remove(&request_id);
+			return Err(err);
+		}
 		state.publishes.insert(request_id, msg.track_namespace.to_owned());
 		drop(state);
-		waiters.wake();
 
 		let mut broadcast = self.start_announce(msg.track_namespace.to_owned())?;
 		broadcast.insert_track(track.consume())?;
@@ -860,11 +847,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		// SUBSCRIBE_OK or PUBLISH can be reordered behind this stream. Hold only the
 		// subgroup header while waiting so the data stream cannot consume flow control.
-		let request_id = resolve_track_alias(&self.state, group.track_alias)
-			.await
-			.inspect_err(|_| {
-				tracing::warn!(track_alias = %group.track_alias, "unknown track alias");
-			})?;
+		let aliases = self.state.lock().aliases.consume();
+		let request_id = resolve_track_alias(aliases, group.track_alias).await.inspect_err(|_| {
+			tracing::warn!(track_alias = %group.track_alias, "unknown track alias");
+		})?;
 
 		let (mut producer, track, track_stats) = {
 			let mut state = self.state.lock();
@@ -979,30 +965,32 @@ mod tests {
 
 	#[tokio::test(start_paused = true)]
 	async fn track_alias_waits_for_control_message() {
-		let state = Lock::new(State::default());
-		let pending = resolve_track_alias(&state, 7);
+		let aliases = TrackAliases::default();
+		let pending = resolve_track_alias(aliases.consume(), 7);
 		tokio::pin!(pending);
 
 		assert!(poll!(&mut pending).is_pending());
 
-		let mut waiters = state.lock().aliases.insert(7, RequestId(11)).unwrap();
-		waiters.wake();
+		insert_track_alias(&aliases, 7, RequestId(11)).unwrap();
 
 		assert_eq!(pending.await.unwrap(), RequestId(11));
 	}
 
 	#[tokio::test(start_paused = true)]
 	async fn unknown_track_alias_times_out() {
-		let state = Lock::new(State::default());
-		assert!(matches!(resolve_track_alias(&state, 7).await, Err(Error::NotFound)));
+		let aliases = TrackAliases::default();
+		assert!(matches!(
+			resolve_track_alias(aliases.consume(), 7).await,
+			Err(Error::NotFound)
+		));
 	}
 
 	#[test]
 	fn removing_old_track_does_not_remove_reused_alias() {
-		let mut aliases = TrackAliases::default();
-		aliases.insert(7, RequestId(11)).unwrap();
-		aliases.remove(7, RequestId(13));
+		let aliases = TrackAliases::default();
+		insert_track_alias(&aliases, 7, RequestId(11)).unwrap();
+		remove_track_alias(&aliases, 7, RequestId(13));
 
-		assert_eq!(aliases.active.get(&7), Some(&RequestId(11)));
+		assert_eq!(aliases.read().get(&7), Some(&RequestId(11)));
 	}
 }


### PR DESCRIPTION
## Summary

- resolve publisher-chosen track aliases in both Rust `moq-net` and TypeScript `@moq/net`
- briefly hold subgroup headers while `SUBSCRIBE_OK` or `PUBLISH` catches up across independently ordered QUIC streams
- reject duplicate active aliases, make cleanup ownership-aware, and add regression coverage for resolution, timeout, and stale cleanup

## Root cause

Subgroup streams and the control message establishing their Track Alias travel on independent QUIC streams, so the subgroup can arrive first. The receive paths assumed publishers would normally reuse the request ID as the alias and immediately routed or rejected data using that guess. A distinct publisher-chosen alias therefore lost the race with `SUBSCRIBE_OK` or `PUBLISH` and the subgroup was dropped.

## Public API changes

None. The alias registries and session adapter changes are internal to the IETF transport implementations.

## Cross-package sync

Updated both `rs/moq-net` and `js/net`. No wire format, concept documentation, or draft changes are needed because this fixes receive-side handling of the existing moq-transport Track Alias field.

## Test plan

- `cargo test -p moq-net` (387 passed, plus doctests)
- `cargo clippy -p moq-net --all-targets -- -D warnings`
- `bun test js/net/src` (168 passed)
- `just js check`
- `just fix`
- `just ci` reaches an unrelated existing failure in `js/publish/src/video/encoder.test.ts`: `TypeError: Object not disposable`; the complete `@moq/net` test phase passes

(Written by GPT-5)
