### PR TITLE
fix(mux,boy): tail-frame a group's end so a pause doesn't inflate recordings

### DIFF
--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -216,6 +216,25 @@ The remainder of the payload is codec specific; see the WebCodecs specification 
 
 For example, h.264 with no `description` field would be annex.b encoded, while h.264 with a `description` field would be AVCC encoded.
 
+## Tail Frame
+A frame with a timestamp but an *empty* payload is a **tail frame**.
+It carries no media; its timestamp marks the presentation *end* of the preceding frame.
+
+Legacy and LOC frames carry no per-frame duration, so a decoder normally learns where the last frame of a group ends only from the first frame of the *next* group.
+That is wrong across a discontinuity: if a publisher pauses and resumes with a later timestamp (see {{draft-lcurley-moq-timestamp}}), the gap is real elapsed time, not the duration of the last frame.
+A tail frame closes the group explicitly, so the gap between one group's tail and the next group's first frame is an unambiguous discontinuity rather than a multi-hour final frame.
+
+A tail frame MUST be the last frame of its group.
+A publisher SHOULD write a tail frame as the last frame of every video group, with a timestamp equal to the presentation end of the group's last media frame (its timestamp plus its intended duration).
+The timestamp MUST be greater than or equal to the group's last media frame's timestamp.
+A tail frame is NOT required for audio, whose frame duration is deterministic (samples / sample-rate).
+
+A decoder MUST skip tail frames: they produce no output sample.
+A decoder that computes frame durations SHOULD bound the last media frame's duration by the tail frame's timestamp, and SHOULD treat a gap between the tail and the next group's first frame as a discontinuity.
+
+Tail frames are OPTIONAL for backward compatibility: a publisher MAY omit them, and a decoder that predates this section will treat the empty payload as an empty (no-op) access unit.
+Because a coded video frame is never empty, an empty payload is an unambiguous signal.
+
 
 # Security Considerations
 TODO Security

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -433,8 +433,12 @@ fn run_emulator(
 			let rgba = Bytes::from(emu.framebuffer());
 			let ts =
 				hang::container::Timestamp::from_micros(elapsed.as_micros() as u64).context("timestamp overflow")?;
-			session.video_encoder.try_frame(rgba, ts);
-			last_video_ts = Some(ts);
+			// Only advance the group's end past frames the encoder actually accepted;
+			// a frame dropped for backpressure was never published, so cutting at its
+			// timestamp would stretch the previous frame past the real media.
+			if session.video_encoder.try_frame(rgba, ts) {
+				last_video_ts = Some(ts);
+			}
 		} else {
 			// Video went idle without the whole emulator pausing (e.g. an audio-only
 			// viewer): close its group so the last frame isn't stretched to the resume.

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -292,7 +292,7 @@ fn close_video_group(
 	if let Some(ts) = last.take() {
 		let end = hang::container::Timestamp::from_micros(ts.as_micros() as u64 + frame_duration.as_micros() as u64)
 			.unwrap_or(ts);
-		encoder.end_group(end);
+		encoder.cut(end);
 	}
 }
 

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -17,7 +17,10 @@
 //!   audio_active ─┘
 //!                    either true → resumed (condvar notified)
 //!
-//!   On resume → force video keyframe, re-anchor audio epoch
+//!   On pause  → close the video group at its last frame's end (bounds that frame
+//!               instead of stretching it across the idle gap, and arms the keyframe
+//!               the resumed group must open on)
+//!   On resume → re-anchor audio epoch
 //! ```
 //!
 //! Emulator state is preserved across pauses: a new viewer joining after a
@@ -278,6 +281,21 @@ async fn run(config: &Config) -> Result<()> {
 	}
 }
 
+/// Close the open video group (if any) at its last frame's presentation end -- one
+/// frame past the last published timestamp -- so that frame isn't stretched across an
+/// idle gap to the resumed group. Clears `last`; a no-op when no group is open.
+fn close_video_group(
+	encoder: &video::VideoEncoder,
+	last: &mut Option<hang::container::Timestamp>,
+	frame_duration: Duration,
+) {
+	if let Some(ts) = last.take() {
+		let end = hang::container::Timestamp::from_micros(ts.as_micros() as u64 + frame_duration.as_micros() as u64)
+			.unwrap_or(ts);
+		encoder.end_group(end);
+	}
+}
+
 /// The main emulator loop, running on a blocking thread.
 ///
 /// Ticks the Game Boy at ~59.73fps (the real hardware rate), captures
@@ -311,18 +329,25 @@ fn run_emulator(
 	let mut viewer_latency: HashMap<String, Vec<status::LatencyEntry>> = HashMap::new();
 	let mut game_stats = stats::Stats::new();
 	let mut was_audio_active = false;
+	// Timestamp of the last published video frame, i.e. the open video group's end so
+	// far. `Some` means a group is open; taken when we close it.
+	let mut last_video_ts = Some(ts);
 
 	loop {
 		// Block when no viewers are watching. See state diagram in module docs.
 		if session.paused.load(Ordering::Acquire) {
+			// Close the video group before idling so its last frame is bounded at its
+			// own end, not stretched across the pause to the resumed group. This also
+			// arms the resume keyframe (a closed group must reopen on one), which is
+			// why there's no separate force-keyframe-on-resume anymore.
+			close_video_group(&session.video_encoder, &mut last_video_ts, frame_duration);
+
 			session.wait_for_resume();
 
 			// Don't try to catch up after a pause.
 			next_frame = Instant::now();
 			// Reset tick timer so pause duration isn't counted.
 			game_stats.reset_tick();
-			// Force a keyframe so new viewers can start decoding.
-			session.video_encoder.force_keyframe();
 			// Re-anchor audio timestamps so the pause gap appears in PTS.
 			audio_encoder.reset_epoch();
 		}
@@ -409,6 +434,11 @@ fn run_emulator(
 			let ts =
 				hang::container::Timestamp::from_micros(elapsed.as_micros() as u64).context("timestamp overflow")?;
 			session.video_encoder.try_frame(rgba, ts);
+			last_video_ts = Some(ts);
+		} else {
+			// Video went idle without the whole emulator pausing (e.g. an audio-only
+			// viewer): close its group so the last frame isn't stretched to the resume.
+			close_video_group(&session.video_encoder, &mut last_video_ts, frame_duration);
 		}
 
 		// Encode and publish audio.

--- a/rs/moq-boy/src/video.rs
+++ b/rs/moq-boy/src/video.rs
@@ -78,13 +78,13 @@ impl VideoEncoder {
 	/// group, and the resumed group still opens on a decodable keyframe. This replaces
 	/// a separate force-keyframe-on-resume: closing a group already requires the next
 	/// frame to be a keyframe, so the two are one operation.
-	pub fn end_group(&self, end: hang::container::Timestamp) {
+	pub fn cut(&self, end: hang::container::Timestamp) {
 		// Arm the keyframe before the close so the resumed group opens on an IDR.
 		self.force_keyframe.store(true, Ordering::Release);
 		// Blocking, not try_send: end-of-group is rare and must not be dropped, or the
 		// last pre-pause frame would stretch across the gap -- the bug this prevents.
 		if self.tx.blocking_send(EncoderMsg::EndGroup { end }).is_err() {
-			tracing::warn!("video end_group dropped: encoder gone");
+			tracing::warn!("video cut dropped: encoder gone");
 		}
 	}
 
@@ -108,8 +108,8 @@ fn encoder_thread(
 			EncoderMsg::EndGroup { end } => {
 				// Close the current group at the pre-pause end so the last frame isn't
 				// stretched across the idle gap. No encoder work: it's just a boundary.
-				if let Err(e) = producer.end_group(end) {
-					tracing::error!(error = %e, "video end_group failed; stopping encoder");
+				if let Err(e) = producer.cut(end) {
+					tracing::error!(error = %e, "video cut failed; stopping encoder");
 					return;
 				}
 				continue;

--- a/rs/moq-boy/src/video.rs
+++ b/rs/moq-boy/src/video.rs
@@ -27,9 +27,15 @@ pub struct VideoEncoder {
 	_thread: std::thread::JoinHandle<()>,
 }
 
-struct EncoderMsg {
-	rgba: Bytes,
-	ts: hang::container::Timestamp,
+enum EncoderMsg {
+	/// Encode and publish one RGBA framebuffer at `ts`.
+	Frame {
+		rgba: Bytes,
+		ts: hang::container::Timestamp,
+	},
+	/// Close the current group, marking its content as ending at `end` (the video
+	/// track went idle). Ordered after the last `Frame` so the group closes cleanly.
+	EndGroup { end: hang::container::Timestamp },
 }
 
 impl VideoEncoder {
@@ -59,15 +65,27 @@ impl VideoEncoder {
 	/// Send a frame to the encoder. Non-blocking: drops the frame if the
 	/// channel is full (capacity=4) to keep latency low.
 	pub fn try_frame(&self, rgba: Bytes, ts: hang::container::Timestamp) {
-		if self.tx.try_send(EncoderMsg { rgba, ts }).is_err() {
+		if self.tx.try_send(EncoderMsg::Frame { rgba, ts }).is_err() {
 			tracing::warn!("video frame dropped: encoder backpressure");
 		}
 	}
 
-	/// Force the next encoded frame to be a keyframe (I-frame).
-	/// Used on resume after pause so new viewers can start decoding.
-	pub fn force_keyframe(&self) {
+	/// Close the current video group, marking its content as ending at `end`, and
+	/// force the next frame to be a keyframe.
+	///
+	/// Call when the video track goes idle (pause). A consumer then bounds the last
+	/// frame at `end` instead of stretching it across the idle gap to the resumed
+	/// group, and the resumed group still opens on a decodable keyframe. This replaces
+	/// a separate force-keyframe-on-resume: closing a group already requires the next
+	/// frame to be a keyframe, so the two are one operation.
+	pub fn end_group(&self, end: hang::container::Timestamp) {
+		// Arm the keyframe before the close so the resumed group opens on an IDR.
 		self.force_keyframe.store(true, Ordering::Release);
+		// Blocking, not try_send: end-of-group is rare and must not be dropped, or the
+		// last pre-pause frame would stretch across the gap -- the bug this prevents.
+		if self.tx.blocking_send(EncoderMsg::EndGroup { end }).is_err() {
+			tracing::warn!("video end_group dropped: encoder gone");
+		}
 	}
 
 	/// Latest per-frame encode duration.
@@ -85,6 +103,19 @@ fn encoder_thread(
 	let mut encoder: Option<moq_video::encode::Encoder> = None;
 
 	while let Some(msg) = rx.blocking_recv() {
+		let (rgba, ts) = match msg {
+			EncoderMsg::Frame { rgba, ts } => (rgba, ts),
+			EncoderMsg::EndGroup { end } => {
+				// Close the current group at the pre-pause end so the last frame isn't
+				// stretched across the idle gap. No encoder work: it's just a boundary.
+				if let Err(e) = producer.end_group(end) {
+					tracing::error!(error = %e, "video end_group failed; stopping encoder");
+					return;
+				}
+				continue;
+			}
+		};
+
 		let enc = match encoder.as_mut() {
 			Some(enc) => enc,
 			None => {
@@ -104,9 +135,9 @@ fn encoder_thread(
 
 		let keyframe = force_keyframe.swap(false, Ordering::AcqRel);
 		let start = Instant::now();
-		match enc.encode_rgba(&msg.rgba, WIDTH, HEIGHT, keyframe) {
+		match enc.encode_rgba(&rgba, WIDTH, HEIGHT, keyframe) {
 			Ok(packets) => {
-				if let Err(e) = producer.publish(packets, msg.ts) {
+				if let Err(e) = producer.publish(packets, ts) {
 					// Publish only fails once the track/broadcast is gone, which
 					// is terminal -- stop rather than flooding logs every frame.
 					tracing::error!(error = %e, "video publish failed; stopping encoder");

--- a/rs/moq-boy/src/video.rs
+++ b/rs/moq-boy/src/video.rs
@@ -62,12 +62,15 @@ impl VideoEncoder {
 		}
 	}
 
-	/// Send a frame to the encoder. Non-blocking: drops the frame if the
-	/// channel is full (capacity=4) to keep latency low.
-	pub fn try_frame(&self, rgba: Bytes, ts: hang::container::Timestamp) {
+	/// Send a frame to the encoder. Non-blocking: drops the frame if the channel is
+	/// full (capacity=4) to keep latency low. Returns whether the frame was accepted,
+	/// so the caller only advances the group's end past frames actually published.
+	pub fn try_frame(&self, rgba: Bytes, ts: hang::container::Timestamp) -> bool {
 		if self.tx.try_send(EncoderMsg::Frame { rgba, ts }).is_err() {
 			tracing::warn!("video frame dropped: encoder backpressure");
+			return false;
 		}
+		true
 	}
 
 	/// Close the current video group, marking its content as ending at `end`, and

--- a/rs/moq-hls/src/export/store.rs
+++ b/rs/moq-hls/src/export/store.rs
@@ -160,8 +160,10 @@ impl SegmentStore {
 
 			// A pending discontinuity forces a fresh segment so the resumed media never
 			// shares a segment with pre-pause media (matters for audio, which otherwise
-			// rolls on duration, not keyframes).
-			let discontinuity = inner.discontinuity_pending;
+			// rolls on duration, not keyframes). Either the store was told out of band
+			// (a recording pause/resume), or the exporter flagged a forward gap in the
+			// media timeline itself (a publisher idle, surfaced by a group's tail).
+			let discontinuity = inner.discontinuity_pending || fragment.discontinuity;
 			let need_new = discontinuity
 				|| match inner.segments.back() {
 					None => true,
@@ -387,6 +389,16 @@ mod tests {
 			init: false,
 			independent: true,
 			duration,
+			discontinuity: false,
+		}
+	}
+
+	/// Like [`fragment`], but flags a timeline discontinuity (the exporter saw a
+	/// forward gap), as opposed to `store.mark_discontinuity()` (told out of band).
+	fn fragment_discontinuous(duration: f64) -> Fragment {
+		Fragment {
+			discontinuity: true,
+			..fragment(duration)
 		}
 	}
 
@@ -431,5 +443,22 @@ mod tests {
 		let snapshot = store.snapshot();
 		assert_eq!(snapshot.media_sequence, 2);
 		assert_eq!(snapshot.target_duration, 6);
+	}
+
+	/// A fragment flagged discontinuous (the exporter saw a forward timeline gap)
+	/// opens a fresh segment tagged for `#EXT-X-DISCONTINUITY`, just like an
+	/// out-of-band `mark_discontinuity()`.
+	#[test]
+	fn discontinuous_fragment_tags_next_segment() {
+		let cfg = config(Duration::from_secs(10));
+		let store = SegmentStore::new(Kind::Video, &cfg);
+
+		store.push(fragment(1.0)); // segment 0: pre-gap
+		store.push(fragment_discontinuous(1.0)); // forward gap: new, tagged segment 1
+
+		let snapshot = store.snapshot();
+		assert_eq!(snapshot.segments.len(), 2);
+		assert!(!snapshot.segments[0].discontinuity);
+		assert!(snapshot.segments[1].discontinuity, "the post-gap segment is tagged");
 	}
 }

--- a/rs/moq-hls/src/export/store.rs
+++ b/rs/moq-hls/src/export/store.rs
@@ -461,4 +461,25 @@ mod tests {
 		assert!(!snapshot.segments[0].discontinuity);
 		assert!(snapshot.segments[1].discontinuity, "the post-gap segment is tagged");
 	}
+
+	/// The discontinuity flag must force a new segment even when the roll policy
+	/// otherwise wouldn't: a non-independent (mid-GOP) video fragment normally
+	/// appends to the current segment, but a discontinuous one still opens its own.
+	/// Guards the `||` in `push` against regressing to `&&`.
+	#[test]
+	fn discontinuous_fragment_forces_segment_even_mid_gop() {
+		let cfg = config(Duration::from_secs(10));
+		let store = SegmentStore::new(Kind::Video, &cfg);
+
+		store.push(fragment(1.0)); // segment 0 (independent)
+		let mid_gop = Fragment {
+			independent: false,
+			..fragment_discontinuous(1.0)
+		};
+		store.push(mid_gop); // not a GOP boundary, but the discontinuity forces a new segment
+
+		let snapshot = store.snapshot();
+		assert_eq!(snapshot.segments.len(), 2, "discontinuity opens a segment even mid-GOP");
+		assert!(snapshot.segments[1].discontinuity);
+	}
 }

--- a/rs/moq-mux/src/catalog/hang/container.rs
+++ b/rs/moq-mux/src/catalog/hang/container.rs
@@ -49,4 +49,11 @@ impl ContainerTrait for Container {
 			Self::Loc => loc::Wire.poll_read(group, waiter),
 		}
 	}
+
+	fn carries_duration(&self) -> bool {
+		match self {
+			Self::Legacy | Self::Loc => false,
+			Self::Cmaf(cmaf) => cmaf.carries_duration(),
+		}
+	}
 }

--- a/rs/moq-mux/src/catalog/hang/container.rs
+++ b/rs/moq-mux/src/catalog/hang/container.rs
@@ -50,10 +50,10 @@ impl ContainerTrait for Container {
 		}
 	}
 
-	fn carries_duration(&self) -> bool {
+	fn has_duration(&self) -> bool {
 		match self {
 			Self::Legacy | Self::Loc => false,
-			Self::Cmaf(cmaf) => cmaf.carries_duration(),
+			Self::Cmaf(cmaf) => cmaf.has_duration(),
 		}
 	}
 }

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -136,9 +136,9 @@ impl<E: CatalogExt> Import<E> {
 	///
 	/// Use before a gap (a publisher pausing) so a consumer bounds the last frame at
 	/// `end` instead of stretching it to the next group. The next published frame must
-	/// be a keyframe. See [`Producer::end_group`](crate::container::Producer::end_group).
-	pub fn end_group(&mut self, end: crate::container::Timestamp) -> Result<()> {
-		self.track.end_group(end)?;
+	/// be a keyframe. See [`Producer::cut`](crate::container::Producer::cut).
+	pub fn cut(&mut self, end: crate::container::Timestamp) -> Result<()> {
+		self.track.cut(end)?;
 		Ok(())
 	}
 

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -132,6 +132,16 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Close the current group, marking its content as ending at `end`.
+	///
+	/// Use before a gap (a publisher pausing) so a consumer bounds the last frame at
+	/// `end` instead of stretching it to the next group. The next published frame must
+	/// be a keyframe. See [`Producer::end_group`](crate::container::Producer::end_group).
+	pub fn end_group(&mut self, end: crate::container::Timestamp) -> Result<()> {
+		self.track.end_group(end)?;
+		Ok(())
+	}
+
 	/// Record a frame's reorder delay (`PTS - DTS`) so the catalog `jitter` reflects the
 	/// B-frame reorder depth (the decode buffer a transmuxer/player must hold). The
 	/// container supplies this since the elementary stream alone carries no decode time.

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -44,7 +44,7 @@ pub struct Consumer<F: Container> {
 	current: u64,
 
 	// Groups that we are monitoring, sorted by sequence ascending.
-	pending: VecDeque<GroupBuffer>,
+	pending: VecDeque<GroupBuffer<F>>,
 
 	// When true, we haven't returned a frame yet and need to select the first group.
 	// We wait until we have at least one frame before finalizing `current`
@@ -479,7 +479,7 @@ impl<F: Container> Consumer<F> {
 ///
 /// Handles two-phase frame reading (get FrameConsumer, then read all data),
 /// timestamp parsing, and min/max timestamp tracking for latency decisions.
-struct GroupBuffer {
+struct GroupBuffer<F: Container> {
 	group: moq_net::GroupConsumer,
 
 	// The current frame index within the group.
@@ -498,9 +498,23 @@ struct GroupBuffer {
 	// Equals the max timestamp when the container carries no per-frame duration.
 	// Stored as a wall-clock duration so cross-scale comparisons are cheap.
 	max_end: Option<std::time::Duration>,
+
+	// The group's tail: the timestamp of a trailing empty-payload frame that marks
+	// the presentation end of the last media frame (see the hang draft's Container
+	// section). `None` until a tail is read, or for publishers that omit it.
+	tail: Option<Timestamp>,
+
+	// Set once the group's stream has ended (Read::Done), so poll_read can report
+	// the group finished without re-polling a spent stream.
+	finished: bool,
+
+	// An error hit while reading ahead (to bound a trailing frame), deferred until
+	// the frames already buffered before it have been emitted. Keeps a decode error
+	// from jumping ahead of the valid frames that preceded it on the wire.
+	pending_error: Option<F::Error>,
 }
 
-impl GroupBuffer {
+impl<F: Container> GroupBuffer<F> {
 	fn new(group: moq_net::GroupConsumer) -> Self {
 		Self {
 			group,
@@ -509,25 +523,67 @@ impl GroupBuffer {
 			max_timestamp: None,
 			min_timestamp: None,
 			max_end: None,
+			tail: None,
+			finished: false,
+			pending_error: None,
 		}
 	}
 
 	/// Poll for the next frame from this group.
-	fn poll_read<F: Container>(&mut self, waiter: &kio::Waiter, format: &F) -> Poll<Result<Option<Frame>, F::Error>> {
-		if let Some(frame) = self.buffered.pop_front() {
-			return Poll::Ready(Ok(Some(frame)));
+	fn poll_read(&mut self, waiter: &kio::Waiter, format: &F) -> Poll<Result<Option<Frame>, F::Error>> {
+		// Opportunistically read ahead so a trailing frame can be bounded by the
+		// group's tail before we emit it. This is non-blocking: if the successor
+		// (another frame, the tail, or the end) isn't buffered yet, we stop and
+		// emit what we have rather than stall the live edge waiting for it.
+		while self.buffered.len() < 2 && self.tail.is_none() && !self.finished && self.pending_error.is_none() {
+			match self.buffer_once(waiter, format) {
+				Poll::Ready(Ok(true)) => continue,
+				Poll::Ready(Ok(false)) => self.finished = true,
+				// Defer a read-ahead error behind the frames already buffered before
+				// it: emit those first, then surface the error once the buffer drains.
+				// With nothing buffered there's nothing to protect, so propagate now.
+				Poll::Ready(Err(e)) => {
+					if self.buffered.is_empty() {
+						return Poll::Ready(Err(e));
+					}
+					self.pending_error = Some(e);
+				}
+				Poll::Pending => break,
+			}
 		}
 
-		match ready!(self.buffer_one(waiter, format)?) {
-			true => Poll::Ready(Ok(Some(self.buffered.pop_front().unwrap()))),
-			false => Poll::Ready(Ok(None)),
+		let Some(mut frame) = self.buffered.pop_front() else {
+			// Nothing buffered. A deferred read-ahead error surfaces now; else report
+			// the group finished only once we've seen its end (a tail or Read::Done);
+			// otherwise a buffer_once above returned Pending and registered the waker.
+			if let Some(e) = self.pending_error.take() {
+				return Poll::Ready(Err(e));
+			}
+			if self.finished || self.tail.is_some() {
+				return Poll::Ready(Ok(None));
+			}
+			return Poll::Pending;
+		};
+
+		// The last media frame of the group ends at the tail. Legacy/LOC carry no
+		// per-frame duration, so without a tail we leave it None and a downstream
+		// muxer infers it from the next group -- which is wrong across a pause/resume
+		// gap, the very ambiguity the tail removes.
+		if frame.duration.is_none()
+			&& self.buffered.is_empty()
+			&& let Some(tail) = self.tail
+			&& let Ok(duration) = tail.checked_sub(frame.timestamp)
+		{
+			frame.duration = Some(duration);
 		}
+
+		Poll::Ready(Ok(Some(frame)))
 	}
 
 	// Add one (or one fragment's worth) more frames to the buffer if possible.
 	//
 	// Returns false if the group is finished.
-	fn buffer_once<F: Container>(&mut self, waiter: &kio::Waiter, format: &F) -> Poll<Result<bool, F::Error>> {
+	fn buffer_once(&mut self, waiter: &kio::Waiter, format: &F) -> Poll<Result<bool, F::Error>> {
 		match ready!(format.poll_read(&mut self.group, waiter)?) {
 			Read::Done => return Poll::Ready(Ok(false)),
 			Read::Frame(frame) => self.ingest(frame),
@@ -535,6 +591,14 @@ impl GroupBuffer {
 				for frame in frames {
 					self.ingest(frame);
 				}
+			}
+			// A tail carries no media; record its timestamp as the group's
+			// presentation end so the trailing frame's duration and the group's
+			// max_end reflect where content actually stops.
+			Read::Tail(timestamp) => {
+				self.tail = Some(self.tail.map_or(timestamp, |existing| existing.max(timestamp)));
+				let end = std::time::Duration::from(timestamp);
+				self.max_end = Some(self.max_end.map_or(end, |existing| existing.max(end)));
 			}
 		}
 
@@ -571,7 +635,7 @@ impl GroupBuffer {
 		self.buffered.push_back(frame);
 	}
 
-	fn buffer_one<F: Container>(&mut self, waiter: &kio::Waiter, format: &F) -> Poll<Result<bool, F::Error>> {
+	fn buffer_one(&mut self, waiter: &kio::Waiter, format: &F) -> Poll<Result<bool, F::Error>> {
 		loop {
 			if !self.buffered.is_empty() {
 				return Poll::Ready(Ok(true));
@@ -583,17 +647,13 @@ impl GroupBuffer {
 		}
 	}
 
-	fn buffer_all<F: Container>(&mut self, waiter: &kio::Waiter, format: &F) -> Poll<Result<(), F::Error>> {
+	fn buffer_all(&mut self, waiter: &kio::Waiter, format: &F) -> Poll<Result<(), F::Error>> {
 		while ready!(self.buffer_once(waiter, format)?) {}
 		Poll::Ready(Ok(()))
 	}
 
 	/// Poll for the maximum timestamp in this group.
-	fn poll_max_timestamp<F: Container>(
-		&mut self,
-		waiter: &kio::Waiter,
-		format: &F,
-	) -> Poll<Result<Timestamp, F::Error>> {
+	fn poll_max_timestamp(&mut self, waiter: &kio::Waiter, format: &F) -> Poll<Result<Timestamp, F::Error>> {
 		// Keep reading more frames just to advance the max timestamp.
 		let _ = self.buffer_all(waiter, format)?;
 
@@ -608,11 +668,7 @@ impl GroupBuffer {
 		Poll::Pending
 	}
 
-	fn poll_min_timestamp<F: Container>(
-		&mut self,
-		waiter: &kio::Waiter,
-		format: &F,
-	) -> Poll<Result<Timestamp, F::Error>> {
+	fn poll_min_timestamp(&mut self, waiter: &kio::Waiter, format: &F) -> Poll<Result<Timestamp, F::Error>> {
 		let _ = self.buffer_one(waiter, format)?;
 
 		if let Some(min) = self.min_timestamp {
@@ -636,7 +692,7 @@ impl GroupBuffer {
 	}
 }
 
-impl std::ops::Deref for GroupBuffer {
+impl<F: Container> std::ops::Deref for GroupBuffer<F> {
 	type Target = moq_net::GroupConsumer;
 
 	fn deref(&self) -> &Self::Target {
@@ -1078,6 +1134,79 @@ mod tests {
 			consumer.rewind.discontinuity, 1,
 			"the backwards group triggered a reset"
 		);
+	}
+
+	// ---- Tail frames ----
+
+	/// Write a group of media frames, then a tail frame (empty payload) at `tail`
+	/// marking the group's presentation end, then finish the group.
+	fn write_group_with_tail(
+		track: &mut moq_net::TrackProducer,
+		sequence: u64,
+		timestamps: &[Timestamp],
+		tail: Timestamp,
+	) {
+		let mut group = track.create_group(moq_net::Group { sequence }).unwrap();
+		for &timestamp in timestamps {
+			let frame = Frame {
+				timestamp,
+				payload: Bytes::from_static(&[0xDE, 0xAD]),
+				keyframe: false,
+				duration: None,
+			};
+			Container::Legacy.write(&mut group, &[frame]).unwrap();
+		}
+		let tail_frame = Frame {
+			timestamp: tail,
+			payload: Bytes::new(),
+			keyframe: false,
+			duration: None,
+		};
+		Container::Legacy.write(&mut group, &[tail_frame]).unwrap();
+		group.finish().unwrap();
+	}
+
+	/// A tail frame carries no media (it is not emitted) but bounds the trailing
+	/// media frame's duration to the tail timestamp. Interior frames are untouched.
+	#[tokio::test]
+	async fn tail_bounds_trailing_frame_and_is_not_emitted() {
+		let mut track = track_producer("test");
+		let consumer_track = track.consume();
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+
+		write_group_with_tail(&mut track, 0, &[ts(0), ts(33_000)], ts(50_000));
+		track.finish().unwrap();
+
+		let frames = read_all(&mut consumer).await.unwrap();
+		assert_eq!(frames.len(), 2, "the tail is not emitted as a media frame");
+		assert_eq!(frames[0].timestamp, ts(0));
+		assert_eq!(frames[1].timestamp, ts(33_000));
+		// Trailing frame ends at the tail (50ms - 33ms); interior frame is untouched.
+		assert_eq!(frames[1].duration, Some(ts(17_000)));
+		assert_eq!(frames[0].duration, None);
+	}
+
+	/// The point of the tail: it gives the last frame of a group an explicit end,
+	/// so a downstream muxer never infers its duration from the *next* group. Here
+	/// group 0 ends at its tail (16ms) and group 1 resumes ~2h later (a paused
+	/// publisher whose wall clock kept advancing). Without the tail, group 0's frame
+	/// would have no duration and a muxer would stretch it across the 2h gap.
+	#[tokio::test]
+	async fn tail_bounds_trailing_frame_across_a_resume_gap() {
+		let mut track = track_producer("test");
+		let consumer_track = track.consume();
+		// Latency above the gap so the slow-group skip never fires; isolate the tail.
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10_800));
+
+		write_group_with_tail(&mut track, 0, &[ts(0)], ts(16_000));
+		write_group(&mut track, 1, &[ts(7_200_000_000)]); // resume ~2h later
+		track.finish().unwrap();
+
+		let frames = read_all(&mut consumer).await.unwrap();
+		assert_eq!(frames[0].timestamp, ts(0));
+		// Bounded by the tail (16ms), NOT the 2h jump to group 1.
+		assert_eq!(frames[0].duration, Some(ts(16_000)));
+		assert_eq!(frames[1].timestamp, ts(7_200_000_000));
 	}
 
 	// ---- Group Ordering ----

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -67,6 +67,12 @@ pub struct Fragment {
 
 	/// Presentation duration of the fragment in seconds (0 for the init segment).
 	pub duration: f64,
+
+	/// This fragment opens a new continuity region: the media timeline jumped
+	/// forward before it (a publisher pause/idle, surfaced by the previous group's
+	/// tail bounding its last frame). A segmenting consumer emits an
+	/// `#EXT-X-DISCONTINUITY` before it. Always false for the init segment.
+	pub discontinuity: bool,
 }
 
 struct Fmp4Track {
@@ -92,6 +98,10 @@ struct Fmp4Track {
 
 	/// Whether the source has signalled end-of-track.
 	finished: bool,
+
+	/// Set when the fragment just emitted ended before its successor (a forward gap):
+	/// the *next* fragment opens a new continuity region. Consumed by that fragment.
+	pending_discontinuity: bool,
 
 	track_id: u32,
 	timescale: u64,
@@ -220,6 +230,7 @@ impl<S: Stream> Export<S> {
 					init: true,
 					independent: false,
 					duration: 0.0,
+					discontinuity: false,
 				})));
 			}
 			// Still waiting for codec configs. If every track is finished and
@@ -331,6 +342,7 @@ impl<S: Stream> Export<S> {
 					is_video: true,
 					default_frame: Duration::from_secs_f64(1.0 / framerate),
 					finished: false,
+					pending_discontinuity: false,
 					track_id: next_track_id,
 					timescale,
 					sequence_number: 1,
@@ -356,6 +368,7 @@ impl<S: Stream> Export<S> {
 					// Fallback for a duration-less trailing sample (~1024 samples/frame).
 					default_frame: Duration::from_secs_f64(1024.0 / config.sample_rate.max(1) as f64),
 					finished: false,
+					pending_discontinuity: false,
 					track_id: next_track_id,
 					timescale,
 					sequence_number: 1,
@@ -564,19 +577,49 @@ fn encode_fragment(track: &mut Fmp4Track, frames: Vec<Frame>) -> Result<Bytes> {
 	)?)
 }
 
+/// A forward jump larger than this between one fragment's end and the next fragment's
+/// start is treated as a real discontinuity (a publisher pause/idle) rather than
+/// ordinary spacing. Comfortably above any frame interval, so a dropped frame or a
+/// low framerate never trips it; a pause is seconds to hours.
+const DISCONTINUITY_GAP: Duration = Duration::from_secs(1);
+
+/// The furthest presentation point in a run of frames, i.e. max(timestamp + duration).
+fn fragment_end(frames: &[Frame]) -> Option<Duration> {
+	frames
+		.iter()
+		.map(|f| Duration::from(f.timestamp) + f.duration.map(Duration::from).unwrap_or_default())
+		.max()
+}
+
 /// Encode a buffered run and wrap it with the metadata a segmenting consumer needs.
 fn emit_fragment(track: &mut Fmp4Track, frames: Vec<Frame>, successor: Option<&Frame>) -> Result<Fragment> {
 	// Audio has no keyframes, so every audio fragment is independent; video is
 	// independent only when its buffer opened on a keyframe (a GOP boundary).
 	let independent = !track.is_video || track.buffer_independent;
+	// A gap detected when the previous fragment was emitted lands on this one: it
+	// opens the new continuity region after the jump.
+	let discontinuity = std::mem::take(&mut track.pending_discontinuity);
 	let frames = infer_missing_durations(frames, successor, track.default_frame);
 	let duration = fragment_seconds(&frames, track.default_frame);
+
+	// If this fragment ends (durations now known -- the tail bounds the trailing frame)
+	// before its successor begins, the timeline jumped forward: flag the *next*
+	// fragment as discontinuous. Without a tail the trailing duration is inferred up to
+	// the successor, leaving no gap, so this only fires on an explicit end_group.
+	if let Some(successor) = successor
+		&& let Some(end) = fragment_end(&frames)
+		&& Duration::from(successor.timestamp).saturating_sub(end) > DISCONTINUITY_GAP
+	{
+		track.pending_discontinuity = true;
+	}
+
 	let data = encode_fragment(track, frames)?;
 	Ok(Fragment {
 		data,
 		init: false,
 		independent,
 		duration,
+		discontinuity,
 	})
 }
 

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -605,7 +605,7 @@ fn emit_fragment(track: &mut Fmp4Track, frames: Vec<Frame>, successor: Option<&F
 	// If this fragment ends (durations now known -- the tail bounds the trailing frame)
 	// before its successor begins, the timeline jumped forward: flag the *next*
 	// fragment as discontinuous. Without a tail the trailing duration is inferred up to
-	// the successor, leaving no gap, so this only fires on an explicit end_group.
+	// the successor, leaving no gap, so this only fires on an explicit cut.
 	if let Some(successor) = successor
 		&& let Some(end) = fragment_end(&frames)
 		&& Duration::from(successor.timestamp).saturating_sub(end) > DISCONTINUITY_GAP

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -307,7 +307,7 @@ async fn forward_gap_yields_short_fragment_then_discontinuity() {
 
 	let mut track_producer = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy);
 	track_producer.write(keyframe(0)).unwrap(); // group 0
-	track_producer.end_group(Timestamp::from_micros(16_000).unwrap()).unwrap(); // tail at 16ms
+	track_producer.cut(Timestamp::from_micros(16_000).unwrap()).unwrap(); // tail at 16ms
 	track_producer.write(keyframe(7_200_000_000)).unwrap(); // group 1, resumes ~2h later
 	track_producer.finish().unwrap();
 

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -274,6 +274,71 @@ async fn vp8_source_to_cmaf_export_synthesizes_vp08() {
 	moov.encode(&mut buf).expect("encode synthesized moov");
 }
 
+/// A source that closes a group with an explicit end (a tail) then resumes ~2h later
+/// must export a *short* pre-gap fragment (bounded by the tail, not stretched to 2h)
+/// followed by a fragment flagged `discontinuity` -- the seam an HLS packager turns
+/// into `#EXT-X-DISCONTINUITY`. Guards the whole moq-boy-pause chain end to end.
+#[tokio::test(start_paused = true)]
+async fn forward_gap_yields_short_fragment_then_discontinuity() {
+	use crate::container::Timestamp;
+	use bytes::Bytes;
+	use hang::catalog::{Container, VideoCodec, VideoConfig};
+
+	let broadcast = moq_net::Broadcast::new();
+	let mut producer = broadcast.produce();
+	let consumer = producer.consume();
+
+	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
+	let track = producer
+		.create_track(moq_net::Track::new(producer.unique_name(".vp8")))
+		.unwrap();
+	let mut config = VideoConfig::new(VideoCodec::VP8);
+	config.coded_width = Some(320);
+	config.coded_height = Some(240);
+	config.container = Container::Legacy;
+	catalog.lock().video.renditions.insert(track.name().to_string(), config);
+
+	let keyframe = |us: u64| crate::container::Frame {
+		timestamp: Timestamp::from_micros(us).unwrap(),
+		payload: Bytes::from_static(&[0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a]),
+		keyframe: true,
+		duration: None,
+	};
+
+	let mut track_producer = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy);
+	track_producer.write(keyframe(0)).unwrap(); // group 0
+	track_producer.end_group(Timestamp::from_micros(16_000).unwrap()).unwrap(); // tail at 16ms
+	track_producer.write(keyframe(7_200_000_000)).unwrap(); // group 1, resumes ~2h later
+	track_producer.finish().unwrap();
+
+	let catalog_stream =
+		crate::catalog::Consumer::<()>::new(&consumer, crate::catalog::CatalogFormat::Hang).expect("catalog consumer");
+	let mut exporter = crate::container::fmp4::Export::new(consumer, catalog_stream);
+
+	// Collect the two media fragments (skip the init). The producers stay alive: the
+	// vp8 track is finished, so group 1 flushes at drain, but the catalog stays open
+	// so the exporter never returns None -- take exactly what we need and stop.
+	let mut media = Vec::new();
+	while media.len() < 2 {
+		let fragment = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next_fragment())
+			.await
+			.expect("exporter timed out")
+			.expect("exporter error");
+		match fragment {
+			Some(fragment) if !fragment.init => media.push(fragment),
+			Some(_) => {}
+			None => break,
+		}
+	}
+
+	assert_eq!(media.len(), 2, "one media fragment per group");
+	// Group 0 is bounded by its tail (~16ms), NOT stretched across the 2h gap.
+	assert!(media[0].duration < 1.0, "pre-gap fragment is short, got {}s", media[0].duration);
+	assert!(!media[0].discontinuity, "pre-gap fragment is continuous");
+	// Group 1 opens a new continuity region after the forward jump.
+	assert!(media[1].discontinuity, "post-gap fragment is flagged discontinuous");
+}
+
 /// VP9 source (catalog `Container::Legacy`, codec `vp09`, no `description`) →
 /// fMP4 export must synthesize a `vp09` sample entry whose `vpcC` round-trips
 /// the catalog's VP9 parameters.

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -333,7 +333,11 @@ async fn forward_gap_yields_short_fragment_then_discontinuity() {
 
 	assert_eq!(media.len(), 2, "one media fragment per group");
 	// Group 0 is bounded by its tail (~16ms), NOT stretched across the 2h gap.
-	assert!(media[0].duration < 1.0, "pre-gap fragment is short, got {}s", media[0].duration);
+	assert!(
+		media[0].duration < 1.0,
+		"pre-gap fragment is short, got {}s",
+		media[0].duration
+	);
 	assert!(!media[0].discontinuity, "pre-gap fragment is continuous");
 	// Group 1 opens a new continuity region after the forward jump.
 	assert!(media[1].discontinuity, "post-gap fragment is flagged discontinuous");

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -191,6 +191,12 @@ impl Container for Wire {
 		encode(group, frames, timescale, track_id)
 	}
 
+	// CMAF carries a per-sample duration in the trun, so a group's end is expressed
+	// as the last sample's duration -- no tail frame needed.
+	fn carries_duration(&self) -> bool {
+		true
+	}
+
 	fn poll_read(
 		&self,
 		group: &mut moq_net::GroupConsumer,

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -193,7 +193,7 @@ impl Container for Wire {
 
 	// CMAF carries a per-sample duration in the trun, so a group's end is expressed
 	// as the last sample's duration -- no tail frame needed.
-	fn carries_duration(&self) -> bool {
+	fn has_duration(&self) -> bool {
 		true
 	}
 

--- a/rs/moq-mux/src/container/legacy/mod.rs
+++ b/rs/moq-mux/src/container/legacy/mod.rs
@@ -38,6 +38,12 @@ impl Container for Wire {
 		let mut hang_frame = hang::container::Frame::decode(data)?;
 		let payload = hang_frame.payload.copy_to_bytes(hang_frame.payload.remaining());
 
+		// An empty payload is a tail frame: a timestamp marking the end of the
+		// preceding frame, carrying no media. See the hang draft's Container section.
+		if payload.is_empty() {
+			return Poll::Ready(Ok(Read::Tail(hang_frame.timestamp)));
+		}
+
 		Poll::Ready(Ok(Read::Frame(Frame {
 			timestamp: hang_frame.timestamp,
 			payload,

--- a/rs/moq-mux/src/container/legacy/mod.rs
+++ b/rs/moq-mux/src/container/legacy/mod.rs
@@ -36,14 +36,14 @@ impl Container for Wire {
 		};
 
 		let mut hang_frame = hang::container::Frame::decode(data)?;
-		let payload = hang_frame.payload.copy_to_bytes(hang_frame.payload.remaining());
 
 		// An empty payload is a tail frame: a timestamp marking the end of the
 		// preceding frame, carrying no media. See the hang draft's Container section.
-		if payload.is_empty() {
+		if !hang_frame.payload.has_remaining() {
 			return Poll::Ready(Ok(Read::Tail(hang_frame.timestamp)));
 		}
 
+		let payload = hang_frame.payload.copy_to_bytes(hang_frame.payload.remaining());
 		Poll::Ready(Ok(Read::Frame(Frame {
 			timestamp: hang_frame.timestamp,
 			payload,

--- a/rs/moq-mux/src/container/loc/mod.rs
+++ b/rs/moq-mux/src/container/loc/mod.rs
@@ -53,6 +53,12 @@ impl Container for Wire {
 		let scale = loc.timescale.unwrap_or(DEFAULT_TIMESCALE);
 		let timestamp = Timestamp::from_scale(loc.timestamp, scale).map_err(hang::Error::from)?;
 
+		// An empty payload is a tail frame: a timestamp marking the end of the
+		// preceding frame, carrying no media. See the hang draft's Container section.
+		if loc.payload.is_empty() {
+			return Poll::Ready(Ok(Read::Tail(timestamp)));
+		}
+
 		Poll::Ready(Ok(Read::Frame(Frame {
 			timestamp,
 			payload: loc.payload,

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -110,6 +110,16 @@ pub trait Container {
 	{
 		async { kio::wait(|waiter| self.poll_read(group, waiter)).await }
 	}
+
+	/// Whether this container carries a per-frame duration on the wire.
+	///
+	/// When false (Legacy, LOC), a group's last frame has no intrinsic end, so
+	/// [`Producer::end_group`] writes a zero-length tail frame to mark it. When true
+	/// (CMAF), the boundary is backfilled onto the last sample instead, and no tail
+	/// is written. Defaults to false; the duration-carrying containers override it.
+	fn carries_duration(&self) -> bool {
+		false
+	}
 }
 
 /// The outcome of one [`Container::poll_read`].

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -117,7 +117,7 @@ pub trait Container {
 	/// [`Producer::end_group`] writes a zero-length tail frame to mark it. When true
 	/// (CMAF), the boundary is backfilled onto the last sample instead, and no tail
 	/// is written. Defaults to false; the duration-carrying containers override it.
-	fn carries_duration(&self) -> bool {
+	fn has_duration(&self) -> bool {
 		false
 	}
 }

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -114,7 +114,7 @@ pub trait Container {
 	/// Whether this container carries a per-frame duration on the wire.
 	///
 	/// When false (Legacy, LOC), a group's last frame has no intrinsic end, so
-	/// [`Producer::end_group`] writes a zero-length tail frame to mark it. When true
+	/// [`Producer::cut`] writes a zero-length tail frame to mark it. When true
 	/// (CMAF), the boundary is backfilled onto the last sample instead, and no tail
 	/// is written. Defaults to false; the duration-carrying containers override it.
 	fn has_duration(&self) -> bool {

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -127,15 +127,21 @@ pub enum Read {
 	/// One moq frame decoded into several media frames, e.g. every sample in a
 	/// CMAF moof+mdat fragment.
 	Fragment(Vec<Frame>),
+	/// A tail frame: a timestamp with an empty payload, marking the presentation
+	/// end of the preceding frame (see the hang draft's Container section). It
+	/// carries no media, so it is excluded from [`frames`](Read::frames); the
+	/// [`Consumer`] uses its timestamp to bound the trailing frame's duration and
+	/// to detect a forward gap to the next group as a discontinuity.
+	Tail(Timestamp),
 }
 
 impl Read {
 	/// The decoded frames as a slice, so callers can iterate without matching the
-	/// variant: empty for [`Done`](Read::Done), one element for [`Frame`](Read::Frame),
-	/// or the whole batch for [`Fragment`](Read::Fragment).
+	/// variant: empty for [`Done`](Read::Done) and [`Tail`](Read::Tail), one element
+	/// for [`Frame`](Read::Frame), or the whole batch for [`Fragment`](Read::Fragment).
 	pub fn frames(&self) -> &[Frame] {
 		match self {
-			Read::Done => &[],
+			Read::Done | Read::Tail(_) => &[],
 			Read::Frame(frame) => std::slice::from_ref(frame),
 			Read::Fragment(frames) => frames,
 		}

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -167,11 +167,13 @@ impl<C: Container> Producer<C> {
 	/// presentation end at `end` so a consumer bounds it there instead of stretching
 	/// it across the gap to the next group's first frame.
 	///
-	/// How `end` reaches the wire depends on the container: CMAF backfills it as the
-	/// last sample's duration, while Legacy/LOC (which carry no per-frame duration)
-	/// get a zero-length "tail" frame at `end`. That encoding stays inside this crate;
-	/// callers only ever express the end timestamp. The next [`write`](Self::write)
-	/// must be a keyframe.
+	/// How `end` is recorded depends on the container. Legacy/LOC carry no per-frame
+	/// duration, so `cut` writes a zero-length "tail" frame at `end`. Duration-carrying
+	/// containers (CMAF) instead bound every sample by its own per-sample duration, so
+	/// each frame is self-terminating and `cut` just flushes and closes -- `end` only
+	/// backfills a still-buffered trailing sample that arrived without a duration. The
+	/// empty-frame encoding stays inside this crate; callers only ever express the end
+	/// timestamp. The next [`write`](Self::write) must be a keyframe.
 	pub fn cut(&mut self, end: Timestamp) -> Result<(), C::Error> {
 		self.flush(Some(end))?;
 
@@ -471,5 +473,58 @@ mod tests {
 		// Bounded by cut's tail (16ms), NOT the 2h jump to the next group.
 		assert_eq!(frames[0].duration, Some(Timestamp::from_micros(16_000).unwrap()));
 		assert_eq!(frames[1].timestamp, Timestamp::from_micros(7_200_000_000).unwrap());
+	}
+
+	/// Write-recording container that reports per-frame durations, like CMAF.
+	#[derive(Clone, Default)]
+	struct DurationRecording(std::rc::Rc<std::cell::RefCell<Vec<Vec<Frame>>>>);
+
+	impl super::Container for DurationRecording {
+		type Error = crate::Error;
+
+		fn has_duration(&self) -> bool {
+			true
+		}
+
+		fn write(&self, _group: &mut moq_net::GroupProducer, frames: &[Frame]) -> Result<(), Self::Error> {
+			self.0.borrow_mut().push(frames.to_vec());
+			Ok(())
+		}
+
+		fn poll_read(
+			&self,
+			_group: &mut moq_net::GroupConsumer,
+			_waiter: &kio::Waiter,
+		) -> std::task::Poll<Result<crate::container::Read, Self::Error>> {
+			unreachable!("DurationRecording is write-only")
+		}
+	}
+
+	/// For a duration-carrying container, `cut` backfills the trailing sample's
+	/// duration from `end` and writes NO tail frame (the per-sample duration already
+	/// terminates each sample). The `has_duration()` gate keeps an empty tail out of a
+	/// CMAF fragment.
+	#[tokio::test]
+	async fn cut_backfills_duration_and_writes_no_tail_for_cmaf() {
+		let track = track_producer("test");
+		let recording = DurationRecording::default();
+		let mut producer = Producer::new(track, recording.clone()).with_latency(std::time::Duration::from_secs(10));
+
+		producer.write(frame(0, true)).unwrap(); // buffered (latency)
+		producer.write(frame(33_000, false)).unwrap(); // buffered
+		producer.cut(Timestamp::from_micros(50_000).unwrap()).unwrap(); // flush with end = 50ms
+		producer.finish().unwrap();
+
+		let writes = recording.0.borrow();
+		let samples: Vec<&Frame> = writes.iter().flatten().collect();
+		assert!(
+			samples.iter().all(|f| !f.payload.is_empty()),
+			"a duration-carrying container gets no tail frame"
+		);
+		// The trailing sample's duration is backfilled from `end`: 50ms - 33ms.
+		assert_eq!(
+			samples.last().unwrap().duration,
+			Some(Timestamp::from_micros(17_000).unwrap())
+		);
 	}
 }

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -172,7 +172,7 @@ impl<C: Container> Producer<C> {
 	/// get a zero-length "tail" frame at `end`. That encoding stays inside this crate;
 	/// callers only ever express the end timestamp. The next [`write`](Self::write)
 	/// must be a keyframe.
-	pub fn end_group(&mut self, end: Timestamp) -> Result<(), C::Error> {
+	pub fn cut(&mut self, end: Timestamp) -> Result<(), C::Error> {
 		self.flush(Some(end))?;
 
 		// Legacy/LOC can't express the end as a duration, so mark it with a tail frame
@@ -442,11 +442,11 @@ mod tests {
 		assert_eq!(group0[1].duration, Some(Timestamp::from_micros(33_000).unwrap()));
 	}
 
-	/// `end_group(end)` on a duration-less container (Legacy) marks the group end with
+	/// `cut(end)` on a duration-less container (Legacy) marks the group end with
 	/// a tail frame, so a Consumer bounds the last frame at `end` instead of stretching
 	/// it across a gap to the next group ~2h later. The tail is never surfaced as media.
 	#[tokio::test]
-	async fn end_group_bounds_last_frame_across_gap() {
+	async fn cut_bounds_last_frame_across_gap() {
 		use crate::container::Consumer;
 
 		let track = track_producer("test");
@@ -454,7 +454,7 @@ mod tests {
 		let mut producer = Producer::new(track, Container::Legacy);
 
 		producer.write(frame(0, true)).unwrap();
-		producer.end_group(Timestamp::from_micros(16_000).unwrap()).unwrap();
+		producer.cut(Timestamp::from_micros(16_000).unwrap()).unwrap();
 		producer.write(frame(7_200_000_000, true)).unwrap(); // resume ~2h later
 		producer.finish().unwrap();
 
@@ -468,7 +468,7 @@ mod tests {
 
 		assert_eq!(frames.len(), 2, "the tail is not surfaced as a media frame");
 		assert_eq!(frames[0].timestamp, Timestamp::from_micros(0).unwrap());
-		// Bounded by end_group's tail (16ms), NOT the 2h jump to the next group.
+		// Bounded by cut's tail (16ms), NOT the 2h jump to the next group.
 		assert_eq!(frames[0].duration, Some(Timestamp::from_micros(16_000).unwrap()));
 		assert_eq!(frames[1].timestamp, Timestamp::from_micros(7_200_000_000).unwrap());
 	}

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -160,6 +160,42 @@ impl<C: Container> Producer<C> {
 		self.finish_group_at(None)
 	}
 
+	/// Close the current group, recording that its content ends at `end`.
+	///
+	/// Use this instead of [`finish_group`](Self::finish_group) when a gap may follow
+	/// (a publisher pausing, or any timeline discontinuity): it pins the last frame's
+	/// presentation end at `end` so a consumer bounds it there instead of stretching
+	/// it across the gap to the next group's first frame.
+	///
+	/// How `end` reaches the wire depends on the container: CMAF backfills it as the
+	/// last sample's duration, while Legacy/LOC (which carry no per-frame duration)
+	/// get a zero-length "tail" frame at `end`. That encoding stays inside this crate;
+	/// callers only ever express the end timestamp. The next [`write`](Self::write)
+	/// must be a keyframe.
+	pub fn end_group(&mut self, end: Timestamp) -> Result<(), C::Error> {
+		self.flush(Some(end))?;
+
+		// Legacy/LOC can't express the end as a duration, so mark it with a tail frame
+		// (empty payload) as the group's last frame. CMAF already got `end` backfilled
+		// onto its last sample by the flush above.
+		if !self.container.carries_duration()
+			&& let Some(group) = self.group.as_mut()
+		{
+			let tail = Frame {
+				timestamp: end,
+				payload: bytes::Bytes::new(),
+				keyframe: false,
+				duration: None,
+			};
+			self.container.write(group, &[tail])?;
+		}
+
+		if let Some(mut group) = self.group.take() {
+			group.finish()?;
+		}
+		Ok(())
+	}
+
 	/// Like [`finish_group`](Self::finish_group), but uses `next` (the timestamp of the
 	/// keyframe that rolled the group over) as the duration boundary for the group's
 	/// last frame. See [`flush`](Self::flush).
@@ -404,5 +440,36 @@ mod tests {
 		assert_eq!(group0[0].duration, Some(Timestamp::from_micros(33_000).unwrap()));
 		// The last sample's duration is backfilled from the next keyframe: 66ms - 33ms.
 		assert_eq!(group0[1].duration, Some(Timestamp::from_micros(33_000).unwrap()));
+	}
+
+	/// `end_group(end)` on a duration-less container (Legacy) marks the group end with
+	/// a tail frame, so a Consumer bounds the last frame at `end` instead of stretching
+	/// it across a gap to the next group ~2h later. The tail is never surfaced as media.
+	#[tokio::test]
+	async fn end_group_bounds_last_frame_across_gap() {
+		use crate::container::Consumer;
+
+		let track = track_producer("test");
+		let consumer_track = track.consume();
+		let mut producer = Producer::new(track, Container::Legacy);
+
+		producer.write(frame(0, true)).unwrap();
+		producer.end_group(Timestamp::from_micros(16_000).unwrap()).unwrap();
+		producer.write(frame(7_200_000_000, true)).unwrap(); // resume ~2h later
+		producer.finish().unwrap();
+
+		// Latency above the gap so the slow-group skip never fires; isolate the tail.
+		let mut consumer =
+			Consumer::new(consumer_track, Container::Legacy).with_latency(std::time::Duration::from_secs(10_800));
+		let mut frames = Vec::new();
+		while let Ok(Some(f)) = consumer.read().await {
+			frames.push(f);
+		}
+
+		assert_eq!(frames.len(), 2, "the tail is not surfaced as a media frame");
+		assert_eq!(frames[0].timestamp, Timestamp::from_micros(0).unwrap());
+		// Bounded by end_group's tail (16ms), NOT the 2h jump to the next group.
+		assert_eq!(frames[0].duration, Some(Timestamp::from_micros(16_000).unwrap()));
+		assert_eq!(frames[1].timestamp, Timestamp::from_micros(7_200_000_000).unwrap());
 	}
 }

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -178,7 +178,7 @@ impl<C: Container> Producer<C> {
 		// Legacy/LOC can't express the end as a duration, so mark it with a tail frame
 		// (empty payload) as the group's last frame. CMAF already got `end` backfilled
 		// onto its last sample by the flush above.
-		if !self.container.carries_duration()
+		if !self.container.has_duration()
 			&& let Some(group) = self.group.as_mut()
 		{
 			let tail = Frame {

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -60,6 +60,17 @@ impl Producer {
 		self.import.finish()?;
 		Ok(())
 	}
+
+	/// Close the current group, marking its content as ending at `end`.
+	///
+	/// Call before a gap (e.g. pausing capture) so a consumer bounds the last frame
+	/// at `end` rather than stretching it across the gap to the next group. The next
+	/// [`publish`](Self::publish) must carry a keyframe -- the caller is responsible
+	/// for forcing the encoder to emit one.
+	pub fn end_group(&mut self, end: Timestamp) -> Result<(), Error> {
+		self.import.end_group(end)?;
+		Ok(())
+	}
 }
 
 /// Source-agnostic encode knobs for [`publish_capture`], where the geometry

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -67,8 +67,8 @@ impl Producer {
 	/// at `end` rather than stretching it across the gap to the next group. The next
 	/// [`publish`](Self::publish) must carry a keyframe -- the caller is responsible
 	/// for forcing the encoder to emit one.
-	pub fn end_group(&mut self, end: Timestamp) -> Result<(), Error> {
-		self.import.end_group(end)?;
+	pub fn cut(&mut self, end: Timestamp) -> Result<(), Error> {
+		self.import.cut(end)?;
 		Ok(())
 	}
 }


### PR DESCRIPTION
## Summary

**Root cause.** Legacy/LOC hang groups carry no per-frame duration, so a muxer learns where a group's last frame *ends* only from the next group's first frame. When a publisher pauses and resumes at a later timestamp — `moq-boy` idling with no viewers while its wall clock keeps advancing — the muxer stretched the last pre-pause frame across the whole gap. A VOD of a mostly-idle stream reported a single ~2h segment and buffered forever on playback.

- **Tail frame** (spec'd in `drafts/draft-lcurley-moq-hang.md`): a frame with a timestamp but an empty payload, written as a group's last frame to mark its presentation end. The `Consumer` reads ahead (without blocking the live edge) to bound the trailing frame's duration by the tail, and never surfaces it as media. Optional for back-compat — a decoder that predates it treats the empty payload as a no-op access unit.
- **`Producer::cut(end)`** closes a group recording that its content ends at `end`. The empty-frame encoding stays inside moq-mux (gated by `Container::has_duration()`; CMAF backfills the last sample instead, no tail). Threaded through the h264 `Import` and moq-video's encode `Producer`. `moq-boy` calls it when the video track goes idle, which subsumes force-keyframe-on-resume — closing a group already requires the next frame to be a keyframe, so it arms the encoder IDR too.
- **Discontinuity.** With the trailing duration now correct, the fmp4 `Export` distinguishes a real forward jump (a pause) from ordinary spacing and sets `Fragment.discontinuity`; moq-hls's `SegmentStore` opens a fresh `#EXT-X-DISCONTINUITY` segment for the resumed media. Without a tail the trailing duration is inferred right up to the successor, so this never fires on continuous media.

## Test plan

- `cargo test -p moq-mux -p moq-hls -p moq-video` — 357 / 20 / 6 green. New coverage: the consumer bounds a frame across a 2h gap; `end_group` round-trips producer → consumer; the export emits a short pre-gap fragment plus a discontinuous one across a 2h jump; the store tags the post-gap segment.
- `cargo build -p moq-boy`.

## Cross-package sync

The wire now permits an empty-payload frame. The JS `@moq/hang` decoder and the Go/Swift/Kotlin/Python bindings should skip it — **deferred as follow-ups**, since back-compat means an old decoder treats the empty payload as a no-op access unit rather than a hard break. VOD playback is unaffected (hls.js on the recorded fMP4, not raw hang frames).

(Written by Claude Opus 4.8)
