### PR TITLE
fix(moq-hls): account for audio groups in master variants

### DIFF
--- a/rs/moq-hls/src/export/master.rs
+++ b/rs/moq-hls/src/export/master.rs
@@ -3,6 +3,7 @@
 //! URIs are relative to the master playlist (`/<broadcast>/master.m3u8`), so a
 //! rendition's `<name>/media.m3u8` resolves under the broadcast directory.
 
+use std::collections::BTreeMap;
 use std::fmt::Write;
 
 const VERSION: u32 = 9;
@@ -32,41 +33,86 @@ pub struct AudioVariant {
 	pub codec: String,
 }
 
-/// Render the multivariant playlist. The first audio rendition is marked default.
+struct AudioGroup<'a> {
+	id: String,
+	bandwidth: u64,
+	codec: &'a str,
+	variants: Vec<&'a AudioVariant>,
+}
+
+fn group_audio(audio: &[AudioVariant]) -> Vec<AudioGroup<'_>> {
+	let mut codecs = BTreeMap::<&str, Vec<&AudioVariant>>::new();
+	for variant in audio {
+		codecs.entry(&variant.codec).or_default().push(variant);
+	}
+
+	let multiple = codecs.len() > 1;
+	codecs
+		.into_iter()
+		.enumerate()
+		.map(|(index, (codec, variants))| AudioGroup {
+			id: if multiple {
+				format!("{AUDIO_GROUP}-{index}")
+			} else {
+				AUDIO_GROUP.to_string()
+			},
+			bandwidth: variants
+				.iter()
+				.map(|variant| variant.bandwidth)
+				.max()
+				.unwrap_or_default(),
+			codec,
+			variants,
+		})
+		.collect()
+}
+
+fn render_video(out: &mut String, variant: &VideoVariant, audio: Option<&AudioGroup<'_>>) {
+	let bandwidth = variant
+		.bandwidth
+		.saturating_add(audio.map_or(0, |group| group.bandwidth));
+	let codecs = audio.map_or_else(
+		|| variant.codec.clone(),
+		|group| format!("{},{}", variant.codec, group.codec),
+	);
+	let mut line = format!("#EXT-X-STREAM-INF:BANDWIDTH={bandwidth}");
+	if let (Some(w), Some(h)) = (variant.width, variant.height) {
+		let _ = write!(line, ",RESOLUTION={w}x{h}");
+	}
+	let _ = write!(line, ",CODECS=\"{codecs}\"");
+	if let Some(group) = audio {
+		let _ = write!(line, ",AUDIO=\"{}\"", group.id);
+	}
+	let _ = writeln!(out, "{line}");
+	let _ = writeln!(out, "{}/media.m3u8", variant.name);
+}
+
+/// Render the multivariant playlist. The first rendition in each audio codec group is default.
 pub fn render_master(video: &[VideoVariant], audio: &[AudioVariant]) -> String {
 	let mut out = String::new();
 	let _ = writeln!(out, "#EXTM3U");
 	let _ = writeln!(out, "#EXT-X-VERSION:{VERSION}");
 
-	let has_audio = !audio.is_empty();
-	for (index, variant) in audio.iter().enumerate() {
-		let default = if index == 0 { "YES" } else { "NO" };
-		let _ = writeln!(
-			out,
-			"#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"{AUDIO_GROUP}\",NAME=\"{}\",DEFAULT={default},AUTOSELECT=YES,URI=\"{}/media.m3u8\"",
-			variant.name, variant.name
-		);
+	let audio_groups = group_audio(audio);
+	for group in &audio_groups {
+		for (index, variant) in group.variants.iter().enumerate() {
+			let default = if index == 0 { "YES" } else { "NO" };
+			let _ = writeln!(
+				out,
+				"#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"{}\",NAME=\"{}\",DEFAULT={default},AUTOSELECT=YES,URI=\"{}/media.m3u8\"",
+				group.id, variant.name, variant.name
+			);
+		}
 	}
 
-	// One audio codec is enough for the combined CODECS attribute.
-	let audio_codec = audio.first().map(|a| a.codec.as_str());
-
 	for variant in video {
-		let codecs = match audio_codec {
-			Some(audio) => format!("{},{}", variant.codec, audio),
-			None => variant.codec.clone(),
-		};
-
-		let mut line = format!("#EXT-X-STREAM-INF:BANDWIDTH={}", variant.bandwidth);
-		if let (Some(w), Some(h)) = (variant.width, variant.height) {
-			let _ = write!(line, ",RESOLUTION={w}x{h}");
+		if audio_groups.is_empty() {
+			render_video(&mut out, variant, None);
+		} else {
+			for group in &audio_groups {
+				render_video(&mut out, variant, Some(group));
+			}
 		}
-		let _ = write!(line, ",CODECS=\"{codecs}\"");
-		if has_audio {
-			let _ = write!(line, ",AUDIO=\"{AUDIO_GROUP}\"");
-		}
-		let _ = writeln!(out, "{line}");
-		let _ = writeln!(out, "{}/media.m3u8", variant.name);
 	}
 
 	// Audio-only broadcast: still expose a playable variant per audio rendition.
@@ -109,9 +155,55 @@ mod tests {
 			"#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"aud\",NAME=\"audio\",DEFAULT=YES,AUTOSELECT=YES,URI=\"audio/media.m3u8\"\n"
 		));
 		assert!(out.contains(
-			"#EXT-X-STREAM-INF:BANDWIDTH=2500000,RESOLUTION=1280x720,CODECS=\"avc1.42c01f,mp4a.40.2\",AUDIO=\"aud\"\n"
+			"#EXT-X-STREAM-INF:BANDWIDTH=2628000,RESOLUTION=1280x720,CODECS=\"avc1.42c01f,mp4a.40.2\",AUDIO=\"aud\"\n"
 		));
 		assert!(out.contains("\nvideo/media.m3u8\n"));
+	}
+
+	#[test]
+	fn separates_audio_codecs_into_accurate_variants() {
+		let video = vec![VideoVariant {
+			name: "video".into(),
+			bandwidth: 2_500_000,
+			width: Some(1280),
+			height: Some(720),
+			codec: "avc1.42c01f".into(),
+		}];
+		let audio = vec![
+			AudioVariant {
+				name: "aac-low".into(),
+				bandwidth: 96_000,
+				codec: "mp4a.40.2".into(),
+			},
+			AudioVariant {
+				name: "aac-high".into(),
+				bandwidth: 128_000,
+				codec: "mp4a.40.2".into(),
+			},
+			AudioVariant {
+				name: "opus".into(),
+				bandwidth: 160_000,
+				codec: "opus".into(),
+			},
+		];
+
+		let out = render_master(&video, &audio);
+		assert!(out.contains(
+			"#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"aud-0\",NAME=\"aac-low\",DEFAULT=YES,AUTOSELECT=YES,URI=\"aac-low/media.m3u8\"\n"
+		));
+		assert!(out.contains(
+			"#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"aud-0\",NAME=\"aac-high\",DEFAULT=NO,AUTOSELECT=YES,URI=\"aac-high/media.m3u8\"\n"
+		));
+		assert!(out.contains(
+			"#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"aud-1\",NAME=\"opus\",DEFAULT=YES,AUTOSELECT=YES,URI=\"opus/media.m3u8\"\n"
+		));
+		assert!(out.contains(
+			"#EXT-X-STREAM-INF:BANDWIDTH=2628000,RESOLUTION=1280x720,CODECS=\"avc1.42c01f,mp4a.40.2\",AUDIO=\"aud-0\"\n"
+		));
+		assert!(out.contains(
+			"#EXT-X-STREAM-INF:BANDWIDTH=2660000,RESOLUTION=1280x720,CODECS=\"avc1.42c01f,opus\",AUDIO=\"aud-1\"\n"
+		));
+		assert_eq!(out.matches("\nvideo/media.m3u8\n").count(), 2);
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

- Add the maximum selectable audio bitrate to each video variant's `BANDWIDTH`.
- Split audio renditions into homogeneous codec groups and emit one accurate video variant per group.
- Cover combined bandwidth and mixed AAC/Opus groups with regression tests.

The root cause was that master rendering treated a video rendition as the complete playable HLS variant. It therefore advertised only the video bitrate and copied the first audio codec even though the referenced audio group could select other renditions.

Closes #2250.

## Public API changes

- None. The master-playlist renderer is private to `moq-hls`.
- Cross-package synchronization is not applicable because this does not change the MoQ wire protocol, catalog format, or public API.

## Test plan

- `cargo test -p moq-hls` (24 passed)
- `cargo clippy -p moq-hls --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

(Written by GPT-5)
