### PR TITLE
fix(moq-hls): honor byte ranges and map changes

### DIFF
--- a/rs/moq-hls/src/error.rs
+++ b/rs/moq-hls/src/error.rs
@@ -24,8 +24,8 @@ pub enum Error {
 	#[error("invalid file URL")]
 	InvalidFileUrl,
 
-	/// The fetched media playlist could not be parsed.
-	#[error("failed to parse media playlist: {0}")]
+	/// The fetched HLS playlist could not be parsed.
+	#[error("failed to parse HLS playlist: {0}")]
 	ParsePlaylist(String),
 
 	/// The master playlist contained no variant this gateway can import.
@@ -58,9 +58,9 @@ pub enum Error {
 		length: u64,
 	},
 
-	/// A ranged resource response did not contain the complete requested range.
+	/// A ranged resource response had a different length than requested.
 	#[error("byte range for {url} returned {actual} bytes, expected {expected}")]
-	ShortByteRange {
+	ByteRangeLengthMismatch {
 		/// The ranged resource.
 		url: url::Url,
 		/// The requested byte count.

--- a/rs/moq-hls/src/error.rs
+++ b/rs/moq-hls/src/error.rs
@@ -69,6 +69,17 @@ pub enum Error {
 		actual: usize,
 	},
 
+	/// A partial HTTP response identified a different byte range than requested.
+	#[error("byte range for {url} returned a mismatched Content-Range, expected bytes {start}-{end}")]
+	ByteRangeResponseMismatch {
+		/// The ranged resource.
+		url: url::Url,
+		/// The first requested byte.
+		start: u64,
+		/// The last requested byte, inclusive.
+		end: u64,
+	},
+
 	/// An HLS media or discontinuity sequence was too large to pack into a MoQ group sequence.
 	#[error("HLS {kind} sequence {value} is too large to encode")]
 	SequenceOverflow {

--- a/rs/moq-hls/src/error.rs
+++ b/rs/moq-hls/src/error.rs
@@ -40,6 +40,35 @@ pub enum Error {
 	#[error("encountered segment with empty URI")]
 	EmptySegmentUri,
 
+	/// An implicit HLS byte range had no preceding range for the same resource.
+	#[error("implicit byte range for {url} has no preceding range for the same resource")]
+	MissingByteRangeOffset {
+		/// The resource whose range omitted an offset.
+		url: url::Url,
+	},
+
+	/// An HLS byte range was empty or overflowed its integer representation.
+	#[error("invalid byte range {start}+{length} for {url}")]
+	InvalidByteRange {
+		/// The ranged resource.
+		url: url::Url,
+		/// The first requested byte.
+		start: u64,
+		/// The requested byte count.
+		length: u64,
+	},
+
+	/// A ranged resource response did not contain the complete requested range.
+	#[error("byte range for {url} returned {actual} bytes, expected {expected}")]
+	ShortByteRange {
+		/// The ranged resource.
+		url: url::Url,
+		/// The requested byte count.
+		expected: u64,
+		/// The returned byte count.
+		actual: usize,
+	},
+
 	/// An HLS media or discontinuity sequence was too large to pack into a MoQ group sequence.
 	#[error("HLS {kind} sequence {value} is too large to encode")]
 	SequenceOverflow {

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -115,7 +115,6 @@ struct TrackState {
 	next_sequence: Option<u64>,
 	next_discontinuity: Option<u64>,
 	map: Option<MapState>,
-	map_range: RangeCursor,
 	media_range: RangeCursor,
 }
 
@@ -151,10 +150,14 @@ impl TrackState {
 			next_sequence: None,
 			next_discontinuity: None,
 			map: None,
-			map_range: RangeCursor::default(),
 			media_range: RangeCursor::default(),
 		}
 	}
+}
+
+fn resolve_map(url: Url, range: Option<&ByteRange>) -> Result<Resource> {
+	// EXT-X-MAP ranges require explicit offsets; they do not chain like media ranges.
+	RangeCursor::default().resolve(url, range)
 }
 
 impl RangeCursor {
@@ -392,13 +395,8 @@ impl Import {
 		}
 
 		let body = self.fetch_bytes(self.base_url.clone()).await?;
-		if let Ok((_, master)) = m3u8_rs::parse_master_playlist(&body) {
-			// The permissive master parser also accepts media playlists as an empty
-			// master. Only take this branch when it actually contains variants.
-			if master.variants.is_empty() {
-				self.video.push(TrackState::new(self.base_url.clone(), select_muxed()));
-				return Ok(());
-			}
+		if m3u8_rs::is_master_playlist(&body) {
+			let master = m3u8_rs::parse_master_playlist_res(&body).map_err(|e| Error::ParsePlaylist(e.to_string()))?;
 			let variants = select_variants(&master);
 			if variants.is_empty() {
 				return Err(Error::NoVariants);
@@ -552,15 +550,13 @@ impl Import {
 		}
 
 		let url = resolve_uri(&track.playlist, &map.uri)?;
-		let mut range = track.map_range.clone();
-		let resource = range.resolve(url, map.byte_range.as_ref())?;
+		let resource = resolve_map(url, map.byte_range.as_ref())?;
 		if track.map.as_ref().is_some_and(|current| current.resource == resource) {
 			track.map = Some(MapState {
 				sequence,
 				tag: map.clone(),
 				resource,
 			});
-			track.map_range = range;
 			return Ok(());
 		}
 
@@ -580,7 +576,6 @@ impl Import {
 			tag: map.clone(),
 			resource,
 		});
-		track.map_range = range;
 		track.next_discontinuity = None;
 		info!(?kind, "loaded HLS init segment generation");
 		Ok(())
@@ -675,7 +670,7 @@ impl Import {
 			.and_then(|(start, end)| bytes.get(start..end).map(|_| (start, end)))
 		{
 			Some((start, end)) => Ok(bytes.slice(start..end)),
-			None => Err(Error::ShortByteRange {
+			None => Err(Error::ByteRangeLengthMismatch {
 				url: resource.url.clone(),
 				expected: range.length,
 				actual: bytes.len().saturating_sub(start.unwrap_or(bytes.len())),
@@ -688,7 +683,7 @@ impl Import {
 			return Ok(bytes);
 		};
 		if u64::try_from(bytes.len()).ok() != Some(range.length) {
-			return Err(Error::ShortByteRange {
+			return Err(Error::ByteRangeLengthMismatch {
 				url: resource.url.clone(),
 				expected: range.length,
 				actual: bytes.len(),
@@ -984,6 +979,24 @@ mod tests {
 		hls
 	}
 
+	#[tokio::test]
+	async fn variantless_master_is_not_treated_as_media() {
+		let dir = temp_dir();
+		let path = dir.join("master.m3u8");
+		std::fs::write(
+			&path,
+			"#EXTM3U\n#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"aud\",NAME=\"en\",URI=\"audio.m3u8\"\n",
+		)
+		.unwrap();
+
+		let mut broadcast = moq_net::Broadcast::new().produce();
+		let catalog = CatalogProducer::new(&mut broadcast).unwrap();
+		let cfg = Config::new(path.to_string_lossy().into_owned());
+		let mut import = Import::new(broadcast, catalog, cfg).unwrap();
+
+		assert!(matches!(import.ensure_tracks().await, Err(Error::NoVariants)));
+	}
+
 	#[test]
 	fn byte_ranges_advance_implicit_offsets_for_the_same_resource() {
 		let url = Url::parse("https://example.com/media.mp4").unwrap();
@@ -1032,6 +1045,20 @@ mod tests {
 				}),
 			)
 			.unwrap_err();
+
+		assert!(matches!(err, Error::MissingByteRangeOffset { .. }));
+	}
+
+	#[test]
+	fn map_byte_range_requires_an_explicit_offset() {
+		let err = resolve_map(
+			Url::parse("https://example.com/init.mp4").unwrap(),
+			Some(&ByteRange {
+				length: 20,
+				offset: None,
+			}),
+		)
+		.unwrap_err();
 
 		assert!(matches!(err, Error::MissingByteRangeOffset { .. }));
 	}

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -7,6 +7,7 @@
 
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
+use std::io::SeekFrom;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -19,6 +20,7 @@ use moq_mux::catalog::Producer as CatalogProducer;
 use moq_mux::container::fmp4::Import as Fmp4;
 use moq_mux::select;
 use reqwest::Client;
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tracing::{debug, info, warn};
 use url::Url;
 
@@ -632,12 +634,25 @@ impl Import {
 		let url = &resource.url;
 		if url.scheme() == "file" {
 			let path = url.to_file_path().map_err(|_| Error::InvalidFileUrl)?;
-			let bytes = tokio::fs::read(&path).await.map_err(Error::from)?;
-			self.slice_full_response(resource, Bytes::from(bytes))
+			let Some(range) = resource.range else {
+				return tokio::fs::read(&path).await.map(Bytes::from).map_err(Error::from);
+			};
+
+			let mut file = tokio::fs::File::open(&path).await.map_err(Error::from)?;
+			file.seek(SeekFrom::Start(range.start)).await.map_err(Error::from)?;
+			let mut bytes = Vec::new();
+			file.take(range.length)
+				.read_to_end(&mut bytes)
+				.await
+				.map_err(Error::from)?;
+			self.validate_range_length(resource, Bytes::from(bytes))
 		} else {
 			let response = self.request(resource).send().await.map_err(Error::from)?;
 			let response = response.error_for_status().map_err(Error::from)?;
 			let partial = response.status() == reqwest::StatusCode::PARTIAL_CONTENT;
+			if partial {
+				self.validate_content_range(resource, response.headers())?;
+			}
 			let bytes = response.bytes().await.map_err(Error::from)?;
 			if resource.range.is_some() && !partial {
 				self.slice_full_response(resource, bytes)
@@ -690,6 +705,31 @@ impl Import {
 			});
 		}
 		Ok(bytes)
+	}
+
+	fn validate_content_range(&self, resource: &Resource, headers: &reqwest::header::HeaderMap) -> Result<()> {
+		let Some(range) = resource.range else {
+			return Ok(());
+		};
+		let end = range.start + range.length - 1;
+		let actual = headers
+			.get(reqwest::header::CONTENT_RANGE)
+			.and_then(|value| value.to_str().ok())
+			.unwrap_or("<missing>");
+		let bounds = actual
+			.split_once(' ')
+			.filter(|(unit, _)| unit.eq_ignore_ascii_case("bytes"))
+			.and_then(|(_, value)| value.split_once('/'))
+			.and_then(|(bounds, _)| bounds.split_once('-'))
+			.and_then(|(start, end)| Some((start.parse().ok()?, end.parse().ok()?)));
+		if bounds != Some((range.start, end)) {
+			return Err(Error::ByteRangeResponseMismatch {
+				url: resource.url.clone(),
+				start: range.start,
+				end,
+			});
+		}
+		Ok(())
 	}
 
 	fn new_importer(&self, select: &select::Broadcast) -> Fmp4 {
@@ -889,6 +929,8 @@ mod tests {
 	use super::*;
 	use std::path::Path;
 	use std::sync::atomic::{AtomicUsize, Ordering};
+	use tokio::io::AsyncWriteExt as _;
+	use tokio::net::TcpListener;
 
 	static COUNTER: AtomicUsize = AtomicUsize::new(0);
 
@@ -934,6 +976,57 @@ mod tests {
 			.map(|window| data[window[0]..window[1]].to_vec())
 			.collect();
 		(init, fragments)
+	}
+
+	async fn serve_response(
+		status: &str,
+		headers: &[(&str, &str)],
+		body: &[u8],
+	) -> (Url, tokio::task::JoinHandle<Vec<u8>>) {
+		let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+		let address = listener.local_addr().unwrap();
+		let mut response = format!(
+			"HTTP/1.1 {status}\r\nContent-Length: {}\r\nConnection: close\r\n",
+			body.len()
+		);
+		for (name, value) in headers {
+			response.push_str(&format!("{name}: {value}\r\n"));
+		}
+		response.push_str("\r\n");
+		let mut response = response.into_bytes();
+		response.extend_from_slice(body);
+
+		let server = tokio::spawn(async move {
+			let (mut stream, _) = listener.accept().await.unwrap();
+			let mut request = Vec::new();
+			loop {
+				let mut chunk = [0; 1024];
+				let read = stream.read(&mut chunk).await.unwrap();
+				if read == 0 {
+					break;
+				}
+				request.extend_from_slice(&chunk[..read]);
+				if request.windows(4).any(|window| window == b"\r\n\r\n") {
+					break;
+				}
+			}
+			stream.write_all(&response).await.unwrap();
+			request
+		});
+		(Url::parse(&format!("http://{address}/media.mp4")).unwrap(), server)
+	}
+
+	fn http_import(url: &Url) -> Import {
+		let mut broadcast = moq_net::Broadcast::new().produce();
+		let catalog = CatalogProducer::new(&mut broadcast).unwrap();
+		Import::new(broadcast, catalog, Config::new(url.to_string())).unwrap()
+	}
+
+	fn ranged_resource(url: Url) -> Resource {
+		Resource {
+			url,
+			range: Some(ResolvedRange { start: 2, length: 3 }),
+		}
 	}
 
 	#[test]
@@ -1078,6 +1171,62 @@ mod tests {
 			.unwrap();
 
 		assert_eq!(request.headers()[reqwest::header::RANGE], "bytes=2-4");
+	}
+
+	#[tokio::test]
+	async fn ranged_http_resource_accepts_matching_partial_response() {
+		let (url, server) = serve_response("206 Partial Content", &[("Content-Range", "bytes 2-4/6")], b"cde").await;
+		let import = http_import(&url);
+
+		let bytes = import.fetch_resource(&ranged_resource(url)).await.unwrap();
+		let request = String::from_utf8(server.await.unwrap()).unwrap();
+
+		assert_eq!(bytes, b"cde".as_slice());
+		assert!(
+			request
+				.lines()
+				.any(|line| line.eq_ignore_ascii_case("range: bytes=2-4"))
+		);
+	}
+
+	#[tokio::test]
+	async fn ranged_http_resource_slices_full_response() {
+		let (url, server) = serve_response("200 OK", &[], b"abcdef").await;
+		let import = http_import(&url);
+
+		let bytes = import.fetch_resource(&ranged_resource(url)).await.unwrap();
+		server.await.unwrap();
+
+		assert_eq!(bytes, b"cde".as_slice());
+	}
+
+	#[tokio::test]
+	async fn ranged_http_resource_rejects_wrong_response_length() {
+		let (url, server) = serve_response("206 Partial Content", &[("Content-Range", "bytes 2-4/6")], b"cd").await;
+		let import = http_import(&url);
+
+		let err = import.fetch_resource(&ranged_resource(url)).await.unwrap_err();
+		server.await.unwrap();
+
+		assert!(matches!(
+			err,
+			Error::ByteRangeLengthMismatch {
+				expected: 3,
+				actual: 2,
+				..
+			}
+		));
+	}
+
+	#[tokio::test]
+	async fn ranged_http_resource_rejects_mismatched_content_range() {
+		let (url, server) = serve_response("206 Partial Content", &[("Content-Range", "bytes 3-5/6")], b"def").await;
+		let import = http_import(&url);
+
+		let err = import.fetch_resource(&ranged_resource(url)).await.unwrap_err();
+		server.await.unwrap();
+
+		assert!(matches!(err, Error::ByteRangeResponseMismatch { start: 2, end: 4, .. }));
 	}
 
 	#[tokio::test]

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -12,7 +12,8 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use m3u8_rs::{
-	AlternativeMedia, AlternativeMediaType, Map, MasterPlaylist, MediaPlaylist, MediaSegment, Resolution, VariantStream,
+	AlternativeMedia, AlternativeMediaType, ByteRange, Map, MasterPlaylist, MediaPlaylist, MediaSegment, Resolution,
+	VariantStream,
 };
 use moq_mux::catalog::Producer as CatalogProducer;
 use moq_mux::container::fmp4::Import as Fmp4;
@@ -113,7 +114,33 @@ struct TrackState {
 	select: select::Broadcast,
 	next_sequence: Option<u64>,
 	next_discontinuity: Option<u64>,
-	init_ready: bool,
+	map: Option<MapState>,
+	map_range: RangeCursor,
+	media_range: RangeCursor,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Resource {
+	url: Url,
+	range: Option<ResolvedRange>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct ResolvedRange {
+	start: u64,
+	length: u64,
+}
+
+#[derive(Clone, Debug, Default)]
+struct RangeCursor {
+	previous: Option<(Url, u64)>,
+}
+
+#[derive(Clone, Debug)]
+struct MapState {
+	sequence: u64,
+	tag: Map,
+	resource: Resource,
 }
 
 impl TrackState {
@@ -123,8 +150,46 @@ impl TrackState {
 			select,
 			next_sequence: None,
 			next_discontinuity: None,
-			init_ready: false,
+			map: None,
+			map_range: RangeCursor::default(),
+			media_range: RangeCursor::default(),
 		}
+	}
+}
+
+impl RangeCursor {
+	fn resolve(&mut self, url: Url, range: Option<&ByteRange>) -> Result<Resource> {
+		let Some(range) = range else {
+			self.previous = None;
+			return Ok(Resource { url, range: None });
+		};
+
+		let start = match range.offset {
+			Some(offset) => offset,
+			None => self
+				.previous
+				.as_ref()
+				.filter(|(previous_url, _)| previous_url == &url)
+				.map(|(_, end)| *end)
+				.ok_or_else(|| Error::MissingByteRangeOffset { url: url.clone() })?,
+		};
+		let end = start
+			.checked_add(range.length)
+			.filter(|_| range.length > 0)
+			.ok_or_else(|| Error::InvalidByteRange {
+				url: url.clone(),
+				start,
+				length: range.length,
+			})?;
+
+		self.previous = Some((url.clone(), end));
+		Ok(Resource {
+			url,
+			range: Some(ResolvedRange {
+				start,
+				length: range.length,
+			}),
+		})
 	}
 }
 
@@ -328,6 +393,12 @@ impl Import {
 
 		let body = self.fetch_bytes(self.base_url.clone()).await?;
 		if let Ok((_, master)) = m3u8_rs::parse_master_playlist(&body) {
+			// The permissive master parser also accepts media playlists as an empty
+			// master. Only take this branch when it actually contains variants.
+			if master.variants.is_empty() {
+				self.video.push(TrackState::new(self.base_url.clone(), select_muxed()));
+				return Ok(());
+			}
 			let variants = select_variants(&master);
 			if variants.is_empty() {
 				return Err(Error::NoVariants);
@@ -382,8 +453,6 @@ impl Import {
 		playlist: &MediaPlaylist,
 		limit: Option<usize>,
 	) -> Result<usize> {
-		self.ensure_init_segment(kind, track, playlist).await?;
-
 		let next_seq = track.next_sequence.unwrap_or(0);
 		let playlist_seq = playlist.media_sequence;
 		let total_segments = playlist.segments.len();
@@ -403,6 +472,7 @@ impl Import {
 				);
 			}
 			track.next_sequence = None;
+			track.media_range = RangeCursor::default();
 			0
 		} else if next_seq < playlist_seq {
 			if track.next_sequence.is_some() {
@@ -414,6 +484,7 @@ impl Import {
 				);
 			}
 			track.next_sequence = None;
+			track.media_range = RangeCursor::default();
 			0
 		} else {
 			(next_seq - playlist_seq) as usize
@@ -450,10 +521,17 @@ impl Import {
 			}
 
 			for (i, segment) in playlist.segments[skip..skip + to_process].iter().enumerate() {
+				let sequence = base_seq + i as u64;
 				if segment.discontinuity {
 					discontinuity_seq = bump_discontinuity(discontinuity_seq)?;
 				}
-				self.push_segment(kind, track, segment, base_seq + i as u64, discontinuity_seq)
+				if let Some(map) = &segment.map {
+					self.ensure_map(kind, track, map, sequence).await?;
+				}
+				if track.map.is_none() {
+					return Err(Error::MissingMap);
+				}
+				self.push_segment(kind, track, segment, sequence, discontinuity_seq)
 					.await?;
 			}
 			info!(?kind, consumed = to_process, "consumed HLS segments");
@@ -464,32 +542,47 @@ impl Import {
 		Ok(to_process)
 	}
 
-	async fn ensure_init_segment(
-		&mut self,
-		kind: TrackKind,
-		track: &mut TrackState,
-		playlist: &MediaPlaylist,
-	) -> Result<()> {
-		if track.init_ready {
+	async fn ensure_map(&mut self, kind: TrackKind, track: &mut TrackState, map: &Map, sequence: u64) -> Result<()> {
+		if track
+			.map
+			.as_ref()
+			.is_some_and(|current| current.sequence == sequence && current.tag == *map)
+		{
 			return Ok(());
 		}
 
-		let map = self.find_map(playlist).ok_or(Error::MissingMap)?;
-
 		let url = resolve_uri(&track.playlist, &map.uri)?;
-		let bytes = self.fetch_bytes(url).await?;
-		let importer = match kind {
-			TrackKind::Video(index) => self.ensure_video_importer_for(index, &track.select),
-			TrackKind::Audio => self.ensure_audio_importer(&track.select),
-		};
+		let mut range = track.map_range.clone();
+		let resource = range.resolve(url, map.byte_range.as_ref())?;
+		if track.map.as_ref().is_some_and(|current| current.resource == resource) {
+			track.map = Some(MapState {
+				sequence,
+				tag: map.clone(),
+				resource,
+			});
+			track.map_range = range;
+			return Ok(());
+		}
+
+		let bytes = self.fetch_resource(&resource).await?;
+		let mut importer = self.new_importer(&track.select);
 
 		// The importer buffers internally, so a fully-parsed init segment leaves it
 		// initialized; any trailing partial atom just waits for the next segment. A
 		// segment that never yields a moov surfaces later as a decode error.
 		importer.decode(&bytes)?;
 
-		track.init_ready = true;
-		info!(?kind, "loaded HLS init segment");
+		// A changed map starts a new track generation. The new importer publishes its
+		// configuration first, then dropping the old importer retires its catalog entries.
+		self.replace_importer(kind, importer);
+		track.map = Some(MapState {
+			sequence,
+			tag: map.clone(),
+			resource,
+		});
+		track.map_range = range;
+		track.next_discontinuity = None;
+		info!(?kind, "loaded HLS init segment generation");
 		Ok(())
 	}
 
@@ -506,10 +599,12 @@ impl Import {
 		}
 
 		let url = resolve_uri(&track.playlist, &segment.uri)?;
-		let bytes = self.fetch_bytes(url).await?;
+		let mut range = track.media_range.clone();
+		let resource = range.resolve(url, segment.byte_range.as_ref())?;
+		let bytes = self.fetch_resource(&resource).await?;
 
-		// `consume_segments` always runs `ensure_init_segment` before reaching here, so
-		// the importer is already initialized.
+		// `consume_segments` always resolves the effective map before reaching here, so
+		// the importer is already initialized for this segment generation.
 		let importer = match kind {
 			TrackKind::Video(index) => self.ensure_video_importer_for(index, &track.select),
 			TrackKind::Audio => self.ensure_audio_importer(&track.select),
@@ -527,26 +622,95 @@ impl Import {
 		}
 
 		importer.decode(&bytes)?;
+		track.media_range = range;
 		track.next_sequence = Some(sequence + 1);
 		track.next_discontinuity = Some(discontinuity_sequence);
 
 		Ok(())
 	}
 
-	fn find_map<'a>(&self, playlist: &'a MediaPlaylist) -> Option<&'a Map> {
-		playlist.segments.iter().find_map(|segment| segment.map.as_ref())
+	async fn fetch_bytes(&self, url: Url) -> Result<Bytes> {
+		self.fetch_resource(&Resource { url, range: None }).await
 	}
 
-	async fn fetch_bytes(&self, url: Url) -> Result<Bytes> {
+	async fn fetch_resource(&self, resource: &Resource) -> Result<Bytes> {
+		let url = &resource.url;
 		if url.scheme() == "file" {
 			let path = url.to_file_path().map_err(|_| Error::InvalidFileUrl)?;
 			let bytes = tokio::fs::read(&path).await.map_err(Error::from)?;
-			Ok(Bytes::from(bytes))
+			self.slice_full_response(resource, Bytes::from(bytes))
 		} else {
-			let response = self.client.get(url).send().await.map_err(Error::from)?;
+			let response = self.request(resource).send().await.map_err(Error::from)?;
 			let response = response.error_for_status().map_err(Error::from)?;
+			let partial = response.status() == reqwest::StatusCode::PARTIAL_CONTENT;
 			let bytes = response.bytes().await.map_err(Error::from)?;
-			Ok(bytes)
+			if resource.range.is_some() && !partial {
+				self.slice_full_response(resource, bytes)
+			} else {
+				self.validate_range_length(resource, bytes)
+			}
+		}
+	}
+
+	fn request(&self, resource: &Resource) -> reqwest::RequestBuilder {
+		let mut request = self.client.get(resource.url.clone());
+		if let Some(range) = resource.range {
+			let end = range.start + range.length - 1;
+			request = request.header(reqwest::header::RANGE, format!("bytes={}-{}", range.start, end));
+		}
+		request
+	}
+
+	fn slice_full_response(&self, resource: &Resource, bytes: Bytes) -> Result<Bytes> {
+		let Some(range) = resource.range else {
+			return Ok(bytes);
+		};
+		let start = usize::try_from(range.start).ok();
+		let end = range
+			.start
+			.checked_add(range.length)
+			.and_then(|end| usize::try_from(end).ok());
+		match start
+			.zip(end)
+			.and_then(|(start, end)| bytes.get(start..end).map(|_| (start, end)))
+		{
+			Some((start, end)) => Ok(bytes.slice(start..end)),
+			None => Err(Error::ShortByteRange {
+				url: resource.url.clone(),
+				expected: range.length,
+				actual: bytes.len().saturating_sub(start.unwrap_or(bytes.len())),
+			}),
+		}
+	}
+
+	fn validate_range_length(&self, resource: &Resource, bytes: Bytes) -> Result<Bytes> {
+		let Some(range) = resource.range else {
+			return Ok(bytes);
+		};
+		if u64::try_from(bytes.len()).ok() != Some(range.length) {
+			return Err(Error::ShortByteRange {
+				url: resource.url.clone(),
+				expected: range.length,
+				actual: bytes.len(),
+			});
+		}
+		Ok(bytes)
+	}
+
+	fn new_importer(&self, select: &select::Broadcast) -> Fmp4 {
+		Fmp4::new(self.broadcast.clone(), self.catalog.clone()).with_select(select.clone())
+	}
+
+	fn replace_importer(&mut self, kind: TrackKind, importer: Fmp4) {
+		match kind {
+			TrackKind::Video(index) => {
+				while self.video_importers.len() <= index {
+					self.video_importers
+						.push(self.new_importer(&select::Broadcast::default()));
+				}
+				self.video_importers[index] = importer;
+			}
+			TrackKind::Audio => self.audio_importer = Some(importer),
 		}
 	}
 
@@ -556,7 +720,7 @@ impl Import {
 	/// independent while still contributing to the same shared catalog.
 	fn ensure_video_importer_for(&mut self, index: usize, select: &select::Broadcast) -> &mut Fmp4 {
 		while self.video_importers.len() <= index {
-			let importer = Fmp4::new(self.broadcast.clone(), self.catalog.clone()).with_select(select.clone());
+			let importer = self.new_importer(select);
 			self.video_importers.push(importer);
 		}
 
@@ -728,6 +892,54 @@ fn moq_sequence(discontinuity_sequence: u64, media_sequence: u64) -> Result<u64>
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use std::path::Path;
+	use std::sync::atomic::{AtomicUsize, Ordering};
+
+	static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+	fn temp_dir() -> PathBuf {
+		let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+		let dir = std::env::temp_dir().join(format!("moq-hls-test-{}-{n}", std::process::id()));
+		std::fs::create_dir_all(&dir).unwrap();
+		dir
+	}
+
+	fn write_import(dir: &Path, resource: &[u8], playlist: &str) -> (Import, CatalogProducer) {
+		std::fs::write(dir.join("media.mp4"), resource).unwrap();
+		let playlist_path = dir.join("media.m3u8");
+		std::fs::write(&playlist_path, playlist).unwrap();
+
+		let mut broadcast = moq_net::Broadcast::new().produce();
+		let catalog = CatalogProducer::new(&mut broadcast).unwrap();
+		let cfg = Config::new(playlist_path.to_string_lossy().into_owned());
+		let import = Import::new(broadcast, catalog.clone(), cfg).unwrap();
+		(import, catalog)
+	}
+
+	fn fmp4_parts() -> (Vec<u8>, Vec<Vec<u8>>) {
+		let data = include_bytes!("../../moq-mux/src/container/fmp4/test_data/bbb.mp4");
+		let mut moofs = Vec::new();
+		let mut position = 0usize;
+		while position + 8 <= data.len() {
+			let size = u32::from_be_bytes(data[position..position + 4].try_into().unwrap()) as usize;
+			if size < 8 || position + size > data.len() {
+				break;
+			}
+			if &data[position + 4..position + 8] == b"moof" {
+				moofs.push(position);
+			}
+			position += size;
+		}
+		assert!(moofs.len() >= 3);
+
+		let init = data[..moofs[0]].to_vec();
+		let fragments = moofs
+			.windows(2)
+			.take(2)
+			.map(|window| data[window[0]..window[1]].to_vec())
+			.collect();
+		(init, fragments)
+	}
 
 	#[test]
 	fn hls_config_new_sets_fields() {
@@ -759,12 +971,7 @@ mod tests {
 
 	/// Resolve `ensure_tracks` against a master playlist written to a temp file.
 	async fn discover(master_body: &str) -> Import {
-		use std::sync::atomic::{AtomicUsize, Ordering};
-		static COUNTER: AtomicUsize = AtomicUsize::new(0);
-
-		let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-		let dir = std::env::temp_dir().join(format!("moq-hls-test-{}-{n}", std::process::id()));
-		std::fs::create_dir_all(&dir).unwrap();
+		let dir = temp_dir();
 		let path = dir.join("master.m3u8");
 		std::fs::write(&path, master_body).unwrap();
 
@@ -775,6 +982,130 @@ mod tests {
 		let mut hls = Import::new(broadcast, catalog, cfg).unwrap();
 		hls.ensure_tracks().await.unwrap();
 		hls
+	}
+
+	#[test]
+	fn byte_ranges_advance_implicit_offsets_for_the_same_resource() {
+		let url = Url::parse("https://example.com/media.mp4").unwrap();
+		let mut cursor = RangeCursor::default();
+		let first = cursor
+			.resolve(
+				url.clone(),
+				Some(&ByteRange {
+					length: 20,
+					offset: Some(10),
+				}),
+			)
+			.unwrap();
+		let second = cursor
+			.resolve(
+				url,
+				Some(&ByteRange {
+					length: 5,
+					offset: None,
+				}),
+			)
+			.unwrap();
+
+		assert_eq!(first.range.unwrap().start, 10);
+		assert_eq!(second.range.unwrap().start, 30);
+	}
+
+	#[test]
+	fn implicit_byte_range_rejects_a_different_resource() {
+		let mut cursor = RangeCursor::default();
+		cursor
+			.resolve(
+				Url::parse("https://example.com/a.mp4").unwrap(),
+				Some(&ByteRange {
+					length: 20,
+					offset: Some(10),
+				}),
+			)
+			.unwrap();
+		let err = cursor
+			.resolve(
+				Url::parse("https://example.com/b.mp4").unwrap(),
+				Some(&ByteRange {
+					length: 5,
+					offset: None,
+				}),
+			)
+			.unwrap_err();
+
+		assert!(matches!(err, Error::MissingByteRangeOffset { .. }));
+	}
+
+	#[test]
+	fn ranged_resource_builds_http_range_request() {
+		let mut broadcast = moq_net::Broadcast::new().produce();
+		let catalog = CatalogProducer::new(&mut broadcast).unwrap();
+		let url = Url::parse("https://example.com/media.mp4").unwrap();
+		let import = Import::new(broadcast, catalog, Config::new(url.to_string())).unwrap();
+		let request = import
+			.request(&Resource {
+				url,
+				range: Some(ResolvedRange { start: 2, length: 3 }),
+			})
+			.build()
+			.unwrap();
+
+		assert_eq!(request.headers()[reqwest::header::RANGE], "bytes=2-4");
+	}
+
+	#[tokio::test]
+	async fn imports_single_file_with_implicit_segment_ranges() {
+		let (init, fragments) = fmp4_parts();
+		let mut resource = init.clone();
+		resource.extend_from_slice(&fragments[0]);
+		resource.extend_from_slice(&fragments[1]);
+		let playlist = format!(
+			"#EXTM3U\n#EXT-X-VERSION:7\n#EXT-X-TARGETDURATION:2\n#EXT-X-MAP:URI=\"media.mp4\",BYTERANGE=\"{}@0\"\n#EXTINF:1,\n#EXT-X-BYTERANGE:{}@{}\nmedia.mp4\n#EXTINF:1,\n#EXT-X-BYTERANGE:{}\nmedia.mp4\n",
+			init.len(),
+			fragments[0].len(),
+			init.len(),
+			fragments[1].len()
+		);
+		let (mut import, catalog) = write_import(&temp_dir(), &resource, &playlist);
+
+		import.init().await.unwrap();
+
+		let snapshot = catalog.snapshot();
+		assert_eq!(snapshot.video.renditions.len(), 1);
+		assert_eq!(snapshot.audio.renditions.len(), 1);
+		assert_eq!(import.video[0].next_sequence, Some(2));
+	}
+
+	#[tokio::test]
+	async fn map_change_replaces_importer_and_catalog_generation() {
+		let (init, fragments) = fmp4_parts();
+		let second_init = init.len() + fragments[0].len();
+		let second_fragment = second_init + init.len();
+		let mut resource = init.clone();
+		resource.extend_from_slice(&fragments[0]);
+		resource.extend_from_slice(&init);
+		resource.extend_from_slice(&fragments[1]);
+		let playlist = format!(
+			"#EXTM3U\n#EXT-X-VERSION:7\n#EXT-X-TARGETDURATION:2\n#EXT-X-MAP:URI=\"media.mp4\",BYTERANGE=\"{}@0\"\n#EXTINF:1,\n#EXT-X-BYTERANGE:{}@{}\nmedia.mp4\n#EXT-X-DISCONTINUITY\n#EXT-X-MAP:URI=\"media.mp4\",BYTERANGE=\"{}@{}\"\n#EXTINF:1,\n#EXT-X-BYTERANGE:{}@{}\nmedia.mp4\n",
+			init.len(),
+			fragments[0].len(),
+			init.len(),
+			init.len(),
+			second_init,
+			fragments[1].len(),
+			second_fragment
+		);
+		let (mut import, catalog) = write_import(&temp_dir(), &resource, &playlist);
+
+		import.init().await.unwrap();
+
+		let snapshot = catalog.snapshot();
+		assert_eq!(snapshot.video.renditions.len(), 1);
+		assert_eq!(snapshot.audio.renditions.len(), 1);
+		assert_eq!(
+			import.video[0].map.as_ref().unwrap().resource.range.unwrap().start,
+			second_init as u64
+		);
 	}
 
 	/// A master with a separate audio rendition: variants publish video only, the

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -75,6 +75,25 @@ fn test_bbb_catalog() {
 }
 
 #[test]
+fn dropping_import_retires_catalog_renditions() {
+	let data = include_bytes!("test_data/bbb.mp4");
+	let mut broadcast = moq_net::Broadcast::new().produce();
+	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+
+	{
+		let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.clone());
+		let _ = fmp4.decode(data);
+		let snapshot = catalog.snapshot();
+		assert_eq!(snapshot.video.renditions.len(), 1);
+		assert_eq!(snapshot.audio.renditions.len(), 1);
+	}
+
+	let snapshot = catalog.snapshot();
+	assert!(snapshot.video.renditions.is_empty());
+	assert!(snapshot.audio.renditions.is_empty());
+}
+
+#[test]
 fn select_video_only() {
 	use crate::select::{Broadcast, Video};
 

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -82,7 +82,10 @@ fn dropping_import_retires_catalog_renditions() {
 
 	{
 		let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.clone());
-		let _ = fmp4.decode(data);
+		let mut cursor = std::io::Cursor::new(data);
+		mp4_atom::Ftyp::decode(&mut cursor).unwrap();
+		mp4_atom::Moov::decode(&mut cursor).unwrap();
+		fmp4.decode(&data[..cursor.position() as usize]).unwrap();
 		let snapshot = catalog.snapshot();
 		assert_eq!(snapshot.video.renditions.len(), 1);
 		assert_eq!(snapshot.audio.renditions.len(), 1);


### PR DESCRIPTION
## Summary

- honor `EXT-X-MAP` and media byte ranges for HTTP and local resources, including implicit offsets
- track the effective map per rendition and start a fresh fMP4 track generation when it changes
- distinguish master and direct media playlists with the parser's explicit type detector
- require explicit offsets for `EXT-X-MAP` ranges while retaining implicit chaining for media segments
- seek directly to local byte ranges and validate both the length and `Content-Range` of partial HTTP responses
- add single-file, map-switch, HTTP response, and catalog-retirement regressions

## Root cause

The HLS importer discarded the parsed byte-range metadata and always fetched the full resolved URI. It also represented initialization as a permanent boolean, so later `EXT-X-MAP` tags could not replace the active fMP4 configuration. In addition, `m3u8-rs` attaches a map only to the segment following its tag, which requires the importer to retain the effective map across later segments. Ranged HTTP fetches also need to reject a partial response for different bounds, even when its byte count happens to match.

## Public API changes

- adds the non-breaking `moq_hls::Error::MissingByteRangeOffset`, `InvalidByteRange`, `ByteRangeLengthMismatch`, and `ByteRangeResponseMismatch` variants

No cross-package sync row applies. The `moq-mux` change is regression coverage for its existing catalog-retirement behavior.

## Test plan

- `cargo test -p moq-hls` (35 passed)
- `cargo clippy -p moq-hls --all-targets -- -D warnings`
- `cargo test -p moq-mux dropping_import_retires_catalog_renditions`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #2252

(Written by GPT-5)
