### PR TITLE
fix(moq-native): default QUIC backend to quinn

### DIFF
--- a/doc/lib/rs/crate/moq-native.md
+++ b/doc/lib/rs/crate/moq-native.md
@@ -15,7 +15,7 @@ QUIC and WebTransport connection helpers for native Rust applications. Provides 
 `moq-native` bridges the gap between the transport-agnostic `moq-net` crate and actual QUIC/WebTransport networking. It handles:
 
 - TLS certificate loading and configuration
-- QUIC connection setup via a pluggable backend, defaulting to [noq](https://crates.io/crates/noq) (enable the `quinn` feature for [quinn](https://crates.io/crates/quinn) instead)
+- QUIC connection setup via a pluggable backend, defaulting to [quinn](https://crates.io/crates/quinn) (the `noq` feature provides [noq](https://crates.io/crates/noq) as an alternative)
 - WebTransport session management
 - Development certificate generation for local testing
 

--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -12,7 +12,7 @@ This guide covers connecting to a relay, discovering broadcasts, subscribing to 
 
 The key crates:
 
-- [moq-native](https://crates.io/crates/moq-native) — Configures QUIC (via [noq](https://crates.io/crates/noq) by default, or [quinn](https://crates.io/crates/quinn) with the `quinn` feature) and TLS (via [rustls](https://crates.io/crates/rustls)) for you.
+- [moq-native](https://crates.io/crates/moq-native): Configures QUIC (via [quinn](https://crates.io/crates/quinn) by default, with [noq](https://crates.io/crates/noq) available through the `noq` feature) and TLS (via [rustls](https://crates.io/crates/rustls)) for you.
 - [moq-net](https://crates.io/crates/moq-net) — The core networking layer. Can be used directly with any `web_transport_trait::Session` implementation if you need full control over the QUIC endpoint.
 - [hang](https://crates.io/crates/hang) — Media-specific catalog and container format on top of `moq-net`.
 

--- a/rs/moq-bench/Cargo.toml
+++ b/rs/moq-bench/Cargo.toml
@@ -20,7 +20,7 @@ path = "src/main.rs"
 doc = false
 
 [features]
-default = ["noq", "websocket"]
+default = ["quinn", "websocket"]
 iroh = ["moq-native/iroh"]
 noq = ["moq-native/noq"]
 quinn = ["moq-native/quinn"]

--- a/rs/moq-boy/Cargo.toml
+++ b/rs/moq-boy/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2024"
 rust-version.workspace = true
 
 [features]
-default = ["noq", "websocket"]
+default = ["quinn", "websocket"]
 jemalloc = ["moq-native/jemalloc"]
 noq = ["moq-native/noq"]
 quinn = ["moq-native/quinn"]

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -18,7 +18,7 @@ name = "moq"
 path = "src/main.rs"
 
 [features]
-default = ["iroh", "noq", "websocket", "nvenc", "vaapi", "nvdec", "pipewire"]
+default = ["iroh", "quinn", "websocket", "nvenc", "vaapi", "nvdec", "pipewire"]
 iroh = ["moq-native/iroh"]
 noq = ["moq-native/noq"]
 quinn = ["moq-native/quinn"]
@@ -38,7 +38,7 @@ transcode = ["dep:moq-transcode", "dep:moq-video"]
 # NVENC / VAAPI / NVDEC hardware codecs for `capture` (Linux), on by default. Each
 # just turns on the matching moq-video feature, and only bites when `capture` pulls
 # in moq-video. For a `capture` build with no CUDA / libva system deps, drop them, e.g.
-#   cargo build -p moq-cli --no-default-features --features "iroh noq websocket capture"
+#   cargo build -p moq-cli --no-default-features --features "iroh quinn websocket capture"
 nvenc = ["moq-video?/nvenc", "moq-transcode?/nvenc"]
 vaapi = ["moq-video?/vaapi", "moq-transcode?/vaapi"]
 nvdec = ["moq-video?/nvdec", "moq-transcode?/nvdec"]

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["multimedia", "network-programming", "web-programming"]
 doctest = false
 
 [features]
-default = ["noq", "aws-lc-rs", "websocket", "tcp", "uds"]
+default = ["quinn", "aws-lc-rs", "websocket", "tcp", "uds"]
 quinn = ["dep:quinn", "dep:web-transport-quinn", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch"]
 noq = ["dep:web-transport-noq", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch"]
 quiche = ["dep:web-transport-quiche", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "dep:rustls-native-certs"]

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -150,22 +150,7 @@ impl Client {
 	))]
 	pub fn new(config: ClientConfig) -> crate::Result<Self> {
 		#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
-		let backend = config.backend.clone().unwrap_or({
-			#[cfg(feature = "noq")]
-			{
-				QuicBackend::Noq
-			}
-			#[cfg(all(feature = "quinn", not(feature = "noq")))]
-			{
-				QuicBackend::Quinn
-			}
-			#[cfg(all(feature = "quiche", not(feature = "noq"), not(feature = "quinn")))]
-			{
-				QuicBackend::Quiche
-			}
-			#[cfg(all(not(feature = "quiche"), not(feature = "noq"), not(feature = "quinn")))]
-			panic!("no QUIC backend compiled; enable noq, quinn, or quiche feature");
-		});
+		let backend = config.backend.clone().unwrap_or_else(crate::default_quic_backend);
 
 		let tls = config.tls.build()?;
 

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -80,3 +80,29 @@ pub enum QuicBackend {
 	#[cfg(feature = "noq")]
 	Noq,
 }
+
+fn default_quic_backend() -> QuicBackend {
+	#[cfg(feature = "quinn")]
+	{
+		QuicBackend::Quinn
+	}
+	#[cfg(all(feature = "noq", not(feature = "quinn")))]
+	{
+		QuicBackend::Noq
+	}
+	#[cfg(all(feature = "quiche", not(feature = "quinn"), not(feature = "noq")))]
+	{
+		QuicBackend::Quiche
+	}
+	#[cfg(all(not(feature = "quiche"), not(feature = "quinn"), not(feature = "noq")))]
+	panic!("no QUIC backend compiled; enable noq, quinn, or quiche feature");
+}
+
+#[cfg(test)]
+mod tests {
+	#[cfg(feature = "quinn")]
+	#[test]
+	fn quinn_is_the_default_backend() {
+		assert!(matches!(super::default_quic_backend(), super::QuicBackend::Quinn));
+	}
+}

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -224,22 +224,7 @@ pub struct Server {
 
 impl Server {
 	pub fn new(config: ServerConfig) -> crate::Result<Self> {
-		let backend = config.backend.clone().unwrap_or({
-			#[cfg(feature = "noq")]
-			{
-				QuicBackend::Noq
-			}
-			#[cfg(all(feature = "quinn", not(feature = "noq")))]
-			{
-				QuicBackend::Quinn
-			}
-			#[cfg(all(feature = "quiche", not(feature = "noq"), not(feature = "quinn")))]
-			{
-				QuicBackend::Quiche
-			}
-			#[cfg(all(not(feature = "quiche"), not(feature = "noq"), not(feature = "quinn")))]
-			panic!("no QUIC backend compiled; enable noq, quinn, or quiche feature");
-		});
+		let backend = config.backend.clone().unwrap_or_else(crate::default_quic_backend);
 
 		let versions = config.versions();
 

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 doc = false
 
 [features]
-default = ["iroh", "noq", "websocket", "uds"]
+default = ["iroh", "quinn", "websocket", "uds"]
 iroh = ["moq-native/iroh"]
 jemalloc = ["moq-native/jemalloc"]
 noq = ["moq-native/noq"]


### PR DESCRIPTION
## Summary

- Restore Quinn as the default QUIC backend for moq-native and the native binaries.
- Prefer Quinn when multiple QUIC backend features are compiled.
- Keep Noq available as an explicit feature and document the default accurately.

## Public API changes

- None. This changes the default backend selection behavior.

## Test plan

- `just fix`
- `cargo test -p moq-native --lib --features noq` (64 passed with Quinn and Noq compiled together)
- `bun test` in `js/flate` (9 passed after a contention-related timeout during the full local CI run)
- GitHub Actions

(Written by GPT-5)