### PR TITLE
refactor(net): make connections caller-driven

### DIFF
--- a/doc/lib/rs/env/wasm.md
+++ b/doc/lib/rs/env/wasm.md
@@ -74,10 +74,16 @@ let transport = web_transport::ClientBuilder::new()
 // Hand the transport to moq-net and run the MoQ handshake.
 let origin = moq_net::Origin::new().produce();
 let mut consumer = origin.consume();
-let session = moq_net::Client::new()
+let connection = moq_net::Client::new()
     .with_subscriber(origin)
     .connect(transport)
     .await?;
+let session = connection.session().clone();
+
+// The connection is the protocol driver and must be polled for its lifetime.
+wasm_bindgen_futures::spawn_local(async move {
+    let _ = connection.await;
+});
 
 // Read announcements off `consumer` exactly as on native...
 ```

--- a/doc/lib/rs/env/wasm.md
+++ b/doc/lib/rs/env/wasm.md
@@ -78,11 +78,13 @@ let connection = moq_net::Client::new()
     .with_subscriber(origin)
     .connect(transport)
     .await?;
-let session = connection.session().clone();
 
-// The connection is the protocol driver and must be polled for its lifetime.
+// Nothing drives the protocol but this driver, so it has to be polled for as long
+// as you hold the session. Split it off first: a whole `Connection` holds a session
+// handle, so spawning one would stop `session` from ever closing the transport.
+let (session, driver) = connection.split();
 wasm_bindgen_futures::spawn_local(async move {
-    let _ = connection.await;
+    let _ = driver.await;
 });
 
 // Read announcements off `consumer` exactly as on native...

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -308,9 +308,9 @@ impl Client {
 		feature = "uds"
 	))]
 	pub async fn connect(&self, url: Url) -> crate::Result<moq_net::Session> {
-		let session = self.connect_inner(url).await?;
-		tracing::info!(version = %session.version(), "connected");
-		Ok(session)
+		let connection = self.connect_inner(url).await?;
+		tracing::info!(version = %connection.session().version(), "connected");
+		Ok(crate::spawn_connection(connection))
 	}
 
 	/// The moq client builder, with `path` advertised in the SETUP if present.
@@ -331,7 +331,7 @@ impl Client {
 		feature = "tcp",
 		feature = "uds"
 	))]
-	async fn connect_inner(&self, url: Url) -> crate::Result<moq_net::Session> {
+	async fn connect_inner(&self, url: Url) -> crate::Result<moq_net::Connection> {
 		// Plain TCP (qmux, no TLS). Explicit opt-in scheme; never raced against
 		// QUIC, which can't speak it. Use only on a trusted network.
 		//
@@ -429,7 +429,7 @@ impl Client {
 	}
 
 	#[cfg(feature = "websocket")]
-	async fn race_moq_connect<Q, S>(&self, url: Url, quic: Q) -> crate::Result<moq_net::Session>
+	async fn race_moq_connect<Q, S>(&self, url: Url, quic: Q) -> crate::Result<moq_net::Connection>
 	where
 		Q: Future<Output = crate::Result<S>>,
 		S: web_transport_trait::Session,

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -43,6 +43,14 @@ pub use log::*;
 pub use reconnect::*;
 pub use server::*;
 
+pub(crate) fn spawn_connection(connection: moq_net::Connection) -> moq_net::Session {
+	let session = connection.session().clone();
+	tokio::spawn(async move {
+		let _ = connection.await;
+	});
+	session
+}
+
 // Re-export these crates.
 pub use moq_net;
 pub use rustls;

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -43,11 +43,15 @@ pub use log::*;
 pub use reconnect::*;
 pub use server::*;
 
+/// Run the connection's protocol driver on the current tokio runtime, handing back
+/// the session it drives.
+///
+/// Splitting first keeps the driver task out of the session's handle count, so the
+/// session still closes when the caller drops the returned [`moq_net::Session`],
+/// which in turn lets the driver task finish.
 pub(crate) fn spawn_connection(connection: moq_net::Connection) -> moq_net::Session {
-	let session = connection.session().clone();
-	tokio::spawn(async move {
-		let _ = connection.await;
-	});
+	let (session, driver) = connection.split();
+	tokio::spawn(driver);
 	session
 }
 

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -1052,7 +1052,8 @@ impl Request {
 
 	/// Accept the session, starting the MoQ session loops.
 	pub async fn ok(self) -> crate::Result<Session> {
-		Ok(request_into!(self.kind, request => request.ok().await?))
+		let connection = request_into!(self.kind, request => request.ok().await?);
+		Ok(crate::spawn_connection(connection))
 	}
 
 	/// Returns the network transport carrying this session.

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -214,7 +214,7 @@ impl Client {
 				// via AnnounceOk + N), so a `request_broadcast()` for a live path resolves
 				// immediately instead of racing announcement gossip.
 				let mut connection = Connection::new(session, version.into(), start.recv_bandwidth, start.driver);
-				connection.wait_ready(start.connecting.ready()).await?;
+				connection.wait_ready(start.connecting.ready()).await;
 
 				return Ok(connection);
 			}
@@ -241,7 +241,7 @@ impl Client {
 					start.recv_bandwidth,
 					start.driver,
 				);
-				connection.wait_ready(start.connecting.ready()).await?;
+				connection.wait_ready(start.connecting.ready()).await;
 
 				return Ok(connection);
 			}
@@ -269,7 +269,7 @@ impl Client {
 					start.recv_bandwidth,
 					start.driver,
 				);
-				connection.wait_ready(start.connecting.ready()).await?;
+				connection.wait_ready(start.connecting.ready()).await;
 
 				return Ok(connection);
 			}
@@ -356,7 +356,7 @@ impl Client {
 		if let Some(connecting) = connecting {
 			// Block until the initial announce set has landed (for versions that
 			// report one); resolves immediately otherwise.
-			connection.wait_ready(connecting.ready()).await?;
+			connection.wait_ready(connecting.ready()).await;
 		}
 
 		Ok(connection)
@@ -602,18 +602,43 @@ mod tests {
 		run_alpn_lite_fallback_case(None).await;
 	}
 
+	// This fake reports no send-rate estimate, so it never reaches the tokio timer in
+	// the bandwidth loop. A connection is NOT runtime-free in general; see the Async
+	// docs in lib.rs.
 	#[test]
-	fn driven_connection_can_be_polled_without_a_tokio_runtime() {
+	fn connection_is_caller_polled_and_closes_on_drop() {
 		let fake = FakeSession::new(Some(ALPN_LITE_04), Vec::new());
 		let client = Client::new().with_versions(Version::Lite(lite::Version::Lite04).into());
 
 		let mut connection = futures::executor::block_on(client.connect(fake.clone())).unwrap();
 		assert_eq!(connection.session().version(), Version::Lite(lite::Version::Lite04));
 
+		// An arbitrary waker drives it: nothing was spawned onto a runtime.
 		let mut context = std::task::Context::from_waker(std::task::Waker::noop());
 		assert!(std::future::Future::poll(std::pin::Pin::new(&mut connection), &mut context).is_pending());
 
 		drop(connection);
+		assert_eq!(fake.state.close_events.lock().unwrap()[0].0, Error::Cancel.to_code());
+	}
+
+	// A split driver must hold no Session clone, or the close-on-last-drop contract
+	// silently stops firing for every caller that runs the driver detached
+	// (moq-native's spawn_connection, moq-wasm's handshake).
+	#[test]
+	fn split_driver_does_not_keep_the_session_alive() {
+		let fake = FakeSession::new(Some(ALPN_LITE_04), Vec::new());
+		let client = Client::new().with_versions(Version::Lite(lite::Version::Lite04).into());
+
+		let connection = futures::executor::block_on(client.connect(fake.clone())).unwrap();
+		let (session, driver) = connection.split();
+
+		// Stand in for spawning: the driver outlives the caller's handle.
+		let mut driver = Box::pin(driver);
+		let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+		assert!(driver.as_mut().poll(&mut context).is_pending());
+
+		// The caller drops their only handle, so the transport closes.
+		drop(session);
 		assert_eq!(fake.state.close_events.lock().unwrap()[0].0, Error::Cancel.to_code());
 	}
 }

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -1,7 +1,7 @@
 use crate::origin;
 use crate::{
 	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05,
-	ALPN_LITE_06_WIP, Consume, Error, NEGOTIATED, Session, StatsHandle, Version, Versions,
+	ALPN_LITE_06_WIP, Connection, Consume, Error, NEGOTIATED, StatsHandle, Version, Versions,
 	coding::{self, Decode, Encode, Stream},
 	ietf, lite, setup,
 };
@@ -81,8 +81,8 @@ impl Client {
 		self
 	}
 
-	/// Perform the MoQ handshake as a client negotiating the version.
-	pub async fn connect<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
+	/// Perform the MoQ handshake and return its caller-driven connection.
+	pub async fn connect<S: web_transport_trait::Session>(&self, session: S) -> Result<Connection, Error> {
 		if self.publish.is_none() && self.subscribe.is_none() {
 			tracing::warn!("not publishing or consuming anything");
 		}
@@ -96,8 +96,8 @@ impl Client {
 					.select(Version::Ietf(ietf::Version::Draft19))
 					.ok_or(Error::Version)?;
 
-				// Draft-17+: SETUP is exchanged in the background by the session.
-				ietf::start(
+				// Draft-17+: SETUP is exchanged by the connection driver.
+				let driver = ietf::start(
 					session.clone(),
 					None,
 					None,
@@ -111,7 +111,7 @@ impl Client {
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
-				return Ok(Session::new(session, v, None));
+				return Ok(Connection::new(session, v, None, driver));
 			}
 			Some(ALPN_18) => {
 				let v = self
@@ -119,9 +119,9 @@ impl Client {
 					.select(Version::Ietf(ietf::Version::Draft18))
 					.ok_or(Error::Version)?;
 
-				// Draft-17+: SETUP is exchanged in the background by the session.
+				// Draft-17+: SETUP is exchanged by the connection driver.
 				// We advertise the request path in our SETUP for URL-less transports.
-				ietf::start(
+				let driver = ietf::start(
 					session.clone(),
 					None,
 					None,
@@ -135,7 +135,7 @@ impl Client {
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
-				return Ok(Session::new(session, v, None));
+				return Ok(Connection::new(session, v, None, driver));
 			}
 			Some(ALPN_17) => {
 				let v = self
@@ -143,9 +143,9 @@ impl Client {
 					.select(Version::Ietf(ietf::Version::Draft17))
 					.ok_or(Error::Version)?;
 
-				// Draft-17+: SETUP is exchanged in the background by the session.
+				// Draft-17+: SETUP is exchanged by the connection driver.
 				// We advertise the request path in our SETUP for URL-less transports.
-				ietf::start(
+				let driver = ietf::start(
 					session.clone(),
 					None,
 					None,
@@ -159,7 +159,7 @@ impl Client {
 				)?;
 
 				tracing::debug!(version = ?v, "connected");
-				return Ok(Session::new(session, v, None));
+				return Ok(Connection::new(session, v, None, driver));
 			}
 			Some(ALPN_16) => {
 				let v = self
@@ -199,7 +199,7 @@ impl Client {
 					role: lite::Role::from_origins(self.publish.is_some(), self.subscribe.is_some()),
 				};
 
-				let (recv_bw, connecting) = lite::start(
+				let start = lite::start(
 					session.clone(),
 					None,
 					self.publish.clone(),
@@ -213,16 +213,17 @@ impl Client {
 				// Block until the initial announce set has landed (Lite05+ reports it
 				// via AnnounceOk + N), so a `request_broadcast()` for a live path resolves
 				// immediately instead of racing announcement gossip.
-				connecting.ready().await;
+				let mut connection = Connection::new(session, version.into(), start.recv_bandwidth, start.driver);
+				connection.wait_ready(start.connecting.ready()).await?;
 
-				return Ok(Session::new(session, version.into(), recv_bw));
+				return Ok(connection);
 			}
 			Some(ALPN_LITE_04) => {
 				self.versions
 					.select(Version::Lite(lite::Version::Lite04))
 					.ok_or(Error::Version)?;
 
-				let (recv_bw, connecting) = lite::start(
+				let start = lite::start(
 					session.clone(),
 					None,
 					self.publish.clone(),
@@ -234,9 +235,15 @@ impl Client {
 				)?;
 
 				// Lite04 has no initial-set boundary, so this resolves immediately.
-				connecting.ready().await;
+				let mut connection = Connection::new(
+					session,
+					lite::Version::Lite04.into(),
+					start.recv_bandwidth,
+					start.driver,
+				);
+				connection.wait_ready(start.connecting.ready()).await?;
 
-				return Ok(Session::new(session, lite::Version::Lite04.into(), recv_bw));
+				return Ok(connection);
 			}
 			Some(ALPN_LITE_03) => {
 				self.versions
@@ -244,7 +251,7 @@ impl Client {
 					.ok_or(Error::Version)?;
 
 				// Starting with draft-03, there's no more SETUP control stream.
-				let (recv_bw, connecting) = lite::start(
+				let start = lite::start(
 					session.clone(),
 					None,
 					self.publish.clone(),
@@ -256,9 +263,15 @@ impl Client {
 				)?;
 
 				// Lite03 has no initial-set boundary, so this resolves immediately.
-				connecting.ready().await;
+				let mut connection = Connection::new(
+					session,
+					lite::Version::Lite03.into(),
+					start.recv_bandwidth,
+					start.driver,
+				);
+				connection.wait_ready(start.connecting.ready()).await?;
 
-				return Ok(Session::new(session, lite::Version::Lite03.into(), recv_bw));
+				return Ok(connection);
 			}
 			Some(ALPN_LITE) | None => {
 				let supported = self.versions.filter(&NEGOTIATED.into()).ok_or(Error::Version)?;
@@ -296,10 +309,10 @@ impl Client {
 			.copied()
 			.ok_or(Error::Version)?;
 
-		let recv_bw = match version {
+		let (recv_bw, driver, connecting) = match version {
 			Version::Lite(v) => {
 				let stream = stream.with_version(v);
-				let (recv_bw, connecting) = lite::start(
+				let start = lite::start(
 					session.clone(),
 					Some(stream),
 					self.publish.clone(),
@@ -312,11 +325,7 @@ impl Client {
 					None,
 				)?;
 
-				// Block until the initial announce set has landed (for versions that
-				// report one); resolves immediately otherwise.
-				connecting.ready().await;
-
-				recv_bw
+				(start.recv_bandwidth, start.driver, Some(start.connecting))
 			}
 			Version::Ietf(v) => {
 				// Decode the parameters to get the initial request ID.
@@ -327,7 +336,7 @@ impl Client {
 
 				let stream = stream.with_version(v);
 				// Draft 14-16: the path rode in the bidi SETUP above, not the uni one.
-				ietf::start(
+				let driver = ietf::start(
 					session.clone(),
 					Some(stream),
 					request_id_max,
@@ -339,11 +348,18 @@ impl Client {
 					None,
 					None,
 				)?;
-				None
+				(None, driver, None)
 			}
 		};
 
-		Ok(Session::new(session, version, recv_bw))
+		let mut connection = Connection::new(session, version, recv_bw, driver);
+		if let Some(connecting) = connecting {
+			// Block until the initial announce set has landed (for versions that
+			// report one); resolves immediately otherwise.
+			connection.wait_ready(connecting.ready()).await?;
+		}
+
+		Ok(connection)
 	}
 }
 
@@ -551,7 +567,7 @@ mod tests {
 			.into(),
 		);
 
-		let _session = client.connect(fake.clone()).await.unwrap();
+		let _connection = client.connect(fake.clone()).await.unwrap();
 
 		// Verify the client setup was encoded using Draft14 framing (ALPN_LITE fallback path).
 		let mut setup_bytes = Bytes::from(fake.control_writes());
@@ -566,7 +582,7 @@ mod tests {
 			]
 		);
 
-		// The first close comes from the background lite session task.
+		// The first close comes from the lite connection driver.
 		// Any non-Version error here means SessionInfo decoded successfully
 		// after set_version(). This test cares about the SETUP framing
 		// fallback, not the specific close code. Cancel is what we'd see
@@ -584,5 +600,20 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn no_alpn_falls_back_to_draft14_and_switches_version_post_setup() {
 		run_alpn_lite_fallback_case(None).await;
+	}
+
+	#[test]
+	fn driven_connection_can_be_polled_without_a_tokio_runtime() {
+		let fake = FakeSession::new(Some(ALPN_LITE_04), Vec::new());
+		let client = Client::new().with_versions(Version::Lite(lite::Version::Lite04).into());
+
+		let mut connection = futures::executor::block_on(client.connect(fake.clone())).unwrap();
+		assert_eq!(connection.session().version(), Version::Lite(lite::Version::Lite04));
+
+		let mut context = std::task::Context::from_waker(std::task::Waker::noop());
+		assert!(std::future::Future::poll(std::pin::Pin::new(&mut connection), &mut context).is_pending());
+
+		drop(connection);
+		assert_eq!(fake.state.close_events.lock().unwrap()[0].0, Error::Cancel.to_code());
 	}
 }

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -10,6 +10,7 @@ use crate::{
 	coding::{Stream, Writer},
 	ietf::{self, Control, FetchHeader, FetchType, FilterType, GroupOrder, Location, RequestId},
 	track::Subscription,
+	util::{MaybeBoxedExt, MaybeSendBox},
 };
 
 use super::{Message, Version};
@@ -45,20 +46,26 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	/// Handle an incoming bidi stream dispatched by the session.
-	pub fn handle_stream(&self, id: u64, mut data: bytes::Bytes, stream: Stream<S, Version>) -> Result<(), Error> {
+	pub fn handle_stream(
+		&self,
+		id: u64,
+		mut data: bytes::Bytes,
+		stream: Stream<S, Version>,
+	) -> Result<MaybeSendBox<'static, ()>, Error> {
 		let this = self.clone();
-		match id {
+		let task = match id {
 			ietf::Subscribe::ID => {
 				let msg = ietf::Subscribe::decode_msg(&mut data, this.version)?;
 				if !data.is_empty() {
 					return Err(Error::WrongSize);
 				}
 				tracing::debug!(message = ?msg, "received subscribe");
-				web_async::spawn(async move {
+				async move {
 					if let Err(err) = this.run_subscribe_stream(stream, msg).await {
 						tracing::debug!(%err, "subscribe stream error");
 					}
-				});
+				}
+				.maybe_boxed()
 			}
 			ietf::Fetch::ID => {
 				let msg = ietf::Fetch::decode_msg(&mut data, this.version)?;
@@ -66,11 +73,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					return Err(Error::WrongSize);
 				}
 				tracing::debug!(message = ?msg, "received fetch");
-				web_async::spawn(async move {
+				async move {
 					if let Err(err) = this.run_fetch_stream(stream, msg).await {
 						tracing::debug!(%err, "fetch stream error");
 					}
-				});
+				}
+				.maybe_boxed()
 			}
 			// Draft-18 SUBSCRIBE_NAMESPACE (0x50) and the legacy 0x11 message decode
 			// to the same request_id + namespace; the legacy Subscribe Options field
@@ -89,21 +97,23 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					return Err(Error::WrongSize);
 				}
 				tracing::debug!(message = ?msg, "received subscribe_namespace");
-				web_async::spawn(async move {
+				async move {
 					if let Err(err) = this.run_subscribe_namespace_stream(stream, msg).await {
 						tracing::debug!(%err, "subscribe_namespace stream error");
 					}
-				});
+				}
+				.maybe_boxed()
 			}
 			ietf::TrackStatus::ID => {
 				tracing::warn!("TrackStatus not supported");
+				async {}.maybe_boxed()
 			}
 			_ => {
 				tracing::warn!(id, "unexpected bidi stream type for publisher");
 				return Err(Error::UnexpectedStream);
 			}
-		}
-		Ok(())
+		};
+		Ok(task)
 	}
 
 	/// Handle a SUBSCRIBE on its bidi stream.

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -7,8 +7,6 @@ use crate::{
 	util::{MaybeBoxedExt, MaybeSendBox, TaskSet},
 };
 
-use futures::{StreamExt, stream::FuturesUnordered};
-
 use super::{Control, Message, Publisher, Subscriber, Version, adapter::ControlStreamAdapter};
 
 // Handshake dispatcher: each argument is an independent session parameter, so
@@ -230,51 +228,42 @@ async fn run_unis<S: web_transport_trait::Session>(
 	version: Version,
 ) -> Result<(), Error> {
 	let outer_version = crate::Version::Ietf(version);
-	let mut tasks = FuturesUnordered::new();
+	let mut tasks = TaskSet::owned();
 
 	loop {
-		let recv = tokio::select! {
-			recv = session.accept_uni() => recv.map_err(Error::from_transport)?,
-			Some(()) = tasks.next(), if !tasks.is_empty() => continue,
-		};
+		let recv = tasks.drive(session.accept_uni()).await.map_err(Error::from_transport)?;
 		let mut reader: Reader<S::RecvStream, crate::Version> = Reader::new(recv, outer_version);
-		let kind: u64 = reader.decode_peek().await?;
+		let kind: u64 = tasks.drive(reader.decode_peek()).await?;
 
 		// v17+: SETUP arrives on a uni stream, then becomes the GOAWAY channel.
 		// We accept it in the background without blocking, since there are no
 		// extensions that require waiting on the SETUP before proceeding.
 		if kind == setup::SETUP_V17 {
-			tasks.push(
-				async move {
-					// Decode and discard the unified SETUP message.
-					if let Err(err) = reader.decode::<setup::Setup>().await {
-						tracing::warn!(%err, "setup decode error");
-						return;
-					}
-
-					// Monitor for GOAWAY after setup completes.
-					if let Err(err) = run_goaway(reader.with_version(version), version).await {
-						tracing::warn!(%err, "goaway error");
-					}
+			tasks.push(async move {
+				// Decode and discard the unified SETUP message.
+				if let Err(err) = reader.decode::<setup::Setup>().await {
+					tracing::warn!(%err, "setup decode error");
+					return;
 				}
-				.maybe_boxed(),
-			);
+
+				// Monitor for GOAWAY after setup completes.
+				if let Err(err) = run_goaway(reader.with_version(version), version).await {
+					tracing::warn!(%err, "goaway error");
+				}
+			});
 
 			continue;
 		}
 
 		// Poll one child handler for each group stream.
 		let mut sub = subscriber.clone();
-		tasks.push(
-			async move {
-				let mut reader = reader.with_version(version);
-				if let Err(err) = run_uni_group(&mut sub, &mut reader).await {
-					tracing::debug!(%err, "uni stream error");
-					reader.abort(&err);
-				}
+		tasks.push(async move {
+			let mut reader = reader.with_version(version);
+			if let Err(err) = run_uni_group(&mut sub, &mut reader).await {
+				tracing::debug!(%err, "uni stream error");
+				reader.abort(&err);
 			}
-			.maybe_boxed(),
-		);
+		});
 	}
 }
 
@@ -306,16 +295,19 @@ async fn run_dispatch<S: web_transport_trait::Session>(
 	mut subscriber: Subscriber<S>,
 	version: Version,
 ) -> Result<(), Error> {
-	let mut tasks = FuturesUnordered::new();
+	let mut tasks = TaskSet::owned();
 	loop {
-		let mut stream = tokio::select! {
-			stream = Stream::accept(&session, version) => stream?,
-			Some(()) = tasks.next(), if !tasks.is_empty() => continue,
-		};
+		let mut stream = tasks.drive(Stream::accept(&session, version)).await?;
 
-		let id: u64 = stream.reader.decode().await?;
-		let size: u16 = stream.reader.decode().await?;
-		let data = stream.reader.read_exact(size as usize).await?;
+		let header = tasks
+			.drive(async {
+				let id: u64 = stream.reader.decode().await?;
+				let size: u16 = stream.reader.decode().await?;
+				let data = stream.reader.read_exact(size as usize).await?;
+				Ok::<_, Error>((id, data))
+			})
+			.await;
+		let (id, data) = header?;
 
 		match id {
 			// Publisher handles: Subscribe, Fetch, SubscribeNamespace (0x50 modern /

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -4,7 +4,10 @@ use crate::{
 	coding::{Decode, Encode, Reader, Stream, Writer},
 	ietf::{self, FetchHeader, RequestId},
 	setup,
+	util::{MaybeBoxedExt, MaybeSendBox, TaskSet},
 };
+
+use futures::{StreamExt, stream::FuturesUnordered};
 
 use super::{Control, Message, Publisher, Subscriber, Version, adapter::ControlStreamAdapter};
 
@@ -28,8 +31,8 @@ pub fn start<S: web_transport_trait::Session>(
 	// server that gated on the client's path via [`accept_setup`]). It becomes the
 	// GOAWAY channel; `None` lets the uni loop read the SETUP itself.
 	peer_setup: Option<Reader<S::RecvStream, crate::Version>>,
-) -> Result<(), Error> {
-	web_async::spawn(async move {
+) -> Result<MaybeSendBox<'static, Result<(), Error>>, Error> {
+	let driver = async move {
 		// moq-transport threads concrete origins through the publisher/subscriber.
 		// An unset half gets an empty origin: an empty publish origin announces
 		// nothing, and an empty subscribe origin issues no SUBSCRIBE_NAMESPACE.
@@ -38,56 +41,62 @@ pub fn start<S: web_transport_trait::Session>(
 		let res = match version {
 			Version::Draft14 | Version::Draft15 | Version::Draft16 => {
 				let Some(setup) = setup else {
-					return session.close(Error::ProtocolViolation.to_code(), "setup stream required");
+					let err = Error::ProtocolViolation;
+					session.close(err.to_code(), "setup stream required");
+					return Err(err);
 				};
 				let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
 				let control = Control::new(request_id_max, client);
 				let adapter = ControlStreamAdapter::new(session.clone(), tx, control.clone(), version);
 
 				let publisher = Publisher::new(adapter.clone(), publish, control.clone(), stats.clone(), version);
-				let subscriber = Subscriber::new(adapter.clone(), subscribe, control, stats, version);
+				let (tasks, task_set) = TaskSet::new();
+				let subscriber = Subscriber::new(adapter.clone(), subscribe, control, stats, version, tasks);
 
 				let dispatch_session = adapter.clone();
 				let mut sub_ns = subscriber.clone();
 				let sub_ns_adapter = adapter.clone();
 
 				tokio::select! {
-									Err(err) = adapter.run(setup.reader, setup.writer, rx) => Err::<(), Error>(err),
-									Err(err) = run_unis(adapter.clone(), subscriber.clone(), version) => Err(err),
-									Err(err) = run_dispatch(dispatch_session, publisher.clone(), subscriber.clone(), version) => Err(err),
-									Err(err) = publisher.run() => Err(err),
-									Err(err) = async {
-				let stream = match version {
-											Version::Draft16 => {
-												let (send, recv) = sub_ns_adapter.open_native_bi().await?;
-												Stream {
-													writer: crate::coding::Writer::new(send, version),
-													reader: crate::coding::Reader::new(recv, version),
-												}
-											}
-											_ => Stream::open(&sub_ns_adapter, version).await?,
-										};
-										if let Err(err) = sub_ns.run_subscribe_namespace(stream).await {
-										tracing::warn!(%err, "subscribe_namespace failed, continuing without");
-									}
-									Ok(())
-									} => Err(err),
+					Err(err) = adapter.run(setup.reader, setup.writer, rx) => Err::<(), Error>(err),
+					Err(err) = run_unis(adapter.clone(), subscriber.clone(), version) => Err(err),
+					Err(err) = run_dispatch(dispatch_session, publisher.clone(), subscriber.clone(), version) => Err(err),
+					Err(err) = publisher.run() => Err(err),
+					_ = task_set.run() => Ok(()),
+					Err(err) = async {
+						let stream = match version {
+							Version::Draft16 => {
+								let (send, recv) = sub_ns_adapter.open_native_bi().await?;
+								Stream {
+									writer: crate::coding::Writer::new(send, version),
+									reader: crate::coding::Reader::new(recv, version),
 								}
+							}
+							_ => Stream::open(&sub_ns_adapter, version).await?,
+						};
+						if let Err(err) = sub_ns.run_subscribe_namespace(stream).await {
+							tracing::warn!(%err, "subscribe_namespace failed, continuing without");
+						}
+						Ok(())
+					} => Err(err),
+				}
 			}
 			_ => {
-				// Spawn SETUP sender (keeps stream alive for GOAWAY).
-				web_async::spawn({
+				// Send SETUP and keep the stream alive for GOAWAY.
+				let setup = {
 					let session = session.clone();
 					async move {
 						if let Err(err) = run_setup(session, version, path).await {
 							tracing::warn!(%err, "setup send error");
 						}
+						std::future::pending::<()>().await;
 					}
-				});
+				};
 
 				let control = Control::new(None, client);
 				let publisher = Publisher::new(session.clone(), publish, control.clone(), stats.clone(), version);
-				let subscriber = Subscriber::new(session.clone(), subscribe, control, stats, version);
+				let (tasks, task_set) = TaskSet::new();
+				let subscriber = Subscriber::new(session.clone(), subscribe, control, stats, version, tasks);
 
 				let sub_ns_session = session.clone();
 				let mut sub_ns = subscriber.clone();
@@ -103,22 +112,24 @@ pub fn start<S: web_transport_trait::Session>(
 				};
 
 				tokio::select! {
-									Err(err) = run_unis(session.clone(), subscriber.clone(), version) => Err(err),
-									Err(err) = run_dispatch(session.clone(), publisher.clone(), subscriber.clone(), version) => Err(err),
-									Err(err) = publisher.run() => Err(err),
-									Err(err) = goaway => Err(err),
-									Err(err) = async {
-				let stream = Stream::open(&sub_ns_session, version).await?;
-										if let Err(err) = sub_ns.run_subscribe_namespace(stream).await {
-											tracing::warn!(%err, "subscribe_namespace failed, continuing without");
-										}
-										Ok(())
-									} => Err(err),
-								}
+					Err(err) = run_unis(session.clone(), subscriber.clone(), version) => Err(err),
+					Err(err) = run_dispatch(session.clone(), publisher.clone(), subscriber.clone(), version) => Err(err),
+					Err(err) = publisher.run() => Err(err),
+					Err(err) = goaway => Err(err),
+					_ = setup => Ok(()),
+					_ = task_set.run() => Ok(()),
+					Err(err) = async {
+						let stream = Stream::open(&sub_ns_session, version).await?;
+						if let Err(err) = sub_ns.run_subscribe_namespace(stream).await {
+							tracing::warn!(%err, "subscribe_namespace failed, continuing without");
+						}
+						Ok(())
+					} => Err(err),
+				}
 			}
 		};
 
-		match res {
+		match &res {
 			Err(Error::Transport(_)) => {
 				tracing::info!("session terminated");
 				session.close(1, "");
@@ -132,9 +143,12 @@ pub fn start<S: web_transport_trait::Session>(
 				session.close(0, "");
 			}
 		}
-	});
 
-	Ok(())
+		res
+	}
+	.maybe_boxed();
+
+	Ok(driver)
 }
 
 /// Server (draft-17+): read the peer's SETUP off its uni stream before starting the
@@ -216,9 +230,13 @@ async fn run_unis<S: web_transport_trait::Session>(
 	version: Version,
 ) -> Result<(), Error> {
 	let outer_version = crate::Version::Ietf(version);
+	let mut tasks = FuturesUnordered::new();
 
 	loop {
-		let recv = session.accept_uni().await.map_err(Error::from_transport)?;
+		let recv = tokio::select! {
+			recv = session.accept_uni() => recv.map_err(Error::from_transport)?,
+			Some(()) = tasks.next(), if !tasks.is_empty() => continue,
+		};
 		let mut reader: Reader<S::RecvStream, crate::Version> = Reader::new(recv, outer_version);
 		let kind: u64 = reader.decode_peek().await?;
 
@@ -226,31 +244,37 @@ async fn run_unis<S: web_transport_trait::Session>(
 		// We accept it in the background without blocking, since there are no
 		// extensions that require waiting on the SETUP before proceeding.
 		if kind == setup::SETUP_V17 {
-			web_async::spawn(async move {
-				// Decode and discard the unified SETUP message.
-				if let Err(err) = reader.decode::<setup::Setup>().await {
-					tracing::warn!(%err, "setup decode error");
-					return;
-				}
+			tasks.push(
+				async move {
+					// Decode and discard the unified SETUP message.
+					if let Err(err) = reader.decode::<setup::Setup>().await {
+						tracing::warn!(%err, "setup decode error");
+						return;
+					}
 
-				// Monitor for GOAWAY after setup completes.
-				if let Err(err) = run_goaway(reader.with_version(version), version).await {
-					tracing::warn!(%err, "goaway error");
+					// Monitor for GOAWAY after setup completes.
+					if let Err(err) = run_goaway(reader.with_version(version), version).await {
+						tracing::warn!(%err, "goaway error");
+					}
 				}
-			});
+				.maybe_boxed(),
+			);
 
 			continue;
 		}
 
-		// Group data — spawn a handler for each stream.
+		// Poll one child handler for each group stream.
 		let mut sub = subscriber.clone();
-		web_async::spawn(async move {
-			let mut reader = reader.with_version(version);
-			if let Err(err) = run_uni_group(&mut sub, &mut reader).await {
-				tracing::debug!(%err, "uni stream error");
-				reader.abort(&err);
+		tasks.push(
+			async move {
+				let mut reader = reader.with_version(version);
+				if let Err(err) = run_uni_group(&mut sub, &mut reader).await {
+					tracing::debug!(%err, "uni stream error");
+					reader.abort(&err);
+				}
 			}
-		});
+			.maybe_boxed(),
+		);
 	}
 }
 
@@ -282,8 +306,12 @@ async fn run_dispatch<S: web_transport_trait::Session>(
 	mut subscriber: Subscriber<S>,
 	version: Version,
 ) -> Result<(), Error> {
+	let mut tasks = FuturesUnordered::new();
 	loop {
-		let mut stream = Stream::accept(&session, version).await?;
+		let mut stream = tokio::select! {
+			stream = Stream::accept(&session, version) => stream?,
+			Some(()) = tasks.next(), if !tasks.is_empty() => continue,
+		};
 
 		let id: u64 = stream.reader.decode().await?;
 		let size: u16 = stream.reader.decode().await?;
@@ -297,11 +325,11 @@ async fn run_dispatch<S: web_transport_trait::Session>(
 			| ietf::SubscribeNamespace::ID
 			| ietf::SubscribeNamespaceLegacy::ID
 			| ietf::TrackStatus::ID => {
-				publisher.handle_stream(id, data, stream)?;
+				tasks.push(publisher.handle_stream(id, data, stream)?);
 			}
 			// Subscriber handles: Publish, PublishNamespace
 			ietf::Publish::ID | ietf::PublishNamespace::ID => {
-				subscriber.handle_stream(id, data, stream)?;
+				tasks.push(subscriber.handle_stream(id, data, stream)?);
 			}
 			_ => {
 				tracing::warn!(id, "unexpected bidi stream type");

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -5,15 +5,13 @@ use std::{
 	time::Duration,
 };
 
-use futures::StreamExt;
-
 use crate::{
 	Error, Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, broadcast,
 	coding::{Reader, Stream},
 	frame, group,
 	ietf::{self, Control, FilterType, GroupOrder, RequestId},
 	origin, track,
-	util::{MaybeBoxedExt, MaybeSendBox, Tasks},
+	util::{MaybeBoxedExt, MaybeSendBox, TaskSet, Tasks},
 };
 
 use super::{Message, Version};
@@ -675,30 +673,34 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	async fn run_broadcast(&self, path: Path<'_>, mut broadcast: broadcast::Dynamic) -> Result<(), Error> {
-		let mut subscribes = futures::stream::FuturesUnordered::new();
+		let mut subscribes = TaskSet::owned();
 		loop {
-			let request = tokio::select! {
-				request = broadcast.requested_track() => match request {
-					Ok(request) => request,
-					Err(err) => {
-						tracing::debug!(%err, "broadcast closed");
-						break;
+			let next = subscribes
+				.drive(async {
+					tokio::select! {
+						request = broadcast.requested_track() => Some(request),
+						_ = self.session.closed() => None,
 					}
-				},
-				_ = self.session.closed() => break,
-				Some(()) = subscribes.next(), if !subscribes.is_empty() => continue,
+				})
+				.await;
+
+			let request = match next {
+				Some(Ok(request)) => request,
+				Some(Err(err)) => {
+					tracing::debug!(%err, "broadcast closed");
+					break;
+				}
+				// Session gone.
+				None => break,
 			};
 
 			let mut this = self.clone();
 
 			let path = path.to_owned();
 			let broadcast = broadcast.clone();
-			subscribes.push(
-				async move {
-					this.run_subscribe(path, broadcast, request).await;
-				}
-				.maybe_boxed(),
-			);
+			subscribes.push(async move {
+				this.run_subscribe(path, broadcast, request).await;
+			});
 		}
 
 		Ok(())

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -5,12 +5,15 @@ use std::{
 	time::Duration,
 };
 
+use futures::StreamExt;
+
 use crate::{
 	Error, Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, broadcast,
 	coding::{Reader, Stream},
 	frame, group,
 	ietf::{self, Control, FilterType, GroupOrder, RequestId},
 	origin, track,
+	util::{MaybeBoxedExt, MaybeSendBox, Tasks},
 };
 
 use super::{Message, Version};
@@ -98,6 +101,7 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	// of colliding on an empty chain.
 	session_origin: crate::Origin,
 	state: Lock<State>,
+	tasks: Tasks,
 	version: Version,
 }
 
@@ -122,7 +126,14 @@ async fn resolve_track_alias(aliases: kio::Consumer<HashMap<u64, RequestId>>, al
 }
 
 impl<S: web_transport_trait::Session> Subscriber<S> {
-	pub fn new(session: S, origin: origin::Producer, control: Control, stats: StatsHandle, version: Version) -> Self {
+	pub fn new(
+		session: S,
+		origin: origin::Producer,
+		control: Control,
+		stats: StatsHandle,
+		version: Version,
+		tasks: Tasks,
+	) -> Self {
 		let broadcasts = stats.subscriber_broadcasts();
 		Self {
 			session,
@@ -132,6 +143,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			broadcasts,
 			session_origin: crate::Origin::random(),
 			state: Default::default(),
+			tasks,
 			version,
 		}
 	}
@@ -250,20 +262,26 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	/// Handle an incoming bidi stream dispatched by the session.
-	pub fn handle_stream(&mut self, id: u64, mut data: bytes::Bytes, stream: Stream<S, Version>) -> Result<(), Error> {
+	pub fn handle_stream(
+		&mut self,
+		id: u64,
+		mut data: bytes::Bytes,
+		stream: Stream<S, Version>,
+	) -> Result<MaybeSendBox<'static, ()>, Error> {
 		let mut this = self.clone();
-		match id {
+		let task = match id {
 			ietf::Publish::ID => {
 				let msg = ietf::Publish::decode_msg(&mut data, this.version)?;
 				if !data.is_empty() {
 					return Err(Error::WrongSize);
 				}
 				tracing::debug!(message = ?msg, "received publish");
-				web_async::spawn(async move {
+				async move {
 					if let Err(err) = this.run_publish_stream(stream, msg).await {
 						tracing::debug!(%err, "publish stream error");
 					}
-				});
+				}
+				.maybe_boxed()
 			}
 			ietf::PublishNamespace::ID => {
 				let msg = ietf::PublishNamespace::decode_msg(&mut data, this.version)?;
@@ -271,18 +289,19 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					return Err(Error::WrongSize);
 				}
 				tracing::debug!(message = ?msg, "received publish_namespace");
-				web_async::spawn(async move {
+				async move {
 					if let Err(err) = this.run_publish_namespace_stream(stream, msg).await {
 						tracing::debug!(%err, "publish_namespace stream error");
 					}
-				});
+				}
+				.maybe_boxed()
 			}
 			_ => {
 				tracing::warn!(id, "unexpected bidi stream type for subscriber");
 				return Err(Error::UnexpectedStream);
 			}
-		}
-		Ok(())
+		};
+		Ok(task)
 	}
 
 	/// Handle an incoming PUBLISH_NAMESPACE on its bidi stream.
@@ -549,7 +568,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 				// Create the dynamic handler BEFORE publishing so consumers see
 				// dynamic >= 1 the moment they receive the announce. Otherwise a
-				// consumer can call subscribe_track() before the spawned
+				// consumer can call subscribe_track() before the driver-owned
 				// run_broadcast bumps the counter and get NotFound (mirrors the
 				// note in lite::Subscriber).
 				let dynamic = broadcast.dynamic();
@@ -566,7 +585,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				tracing::debug!(broadcast = %self.origin.absolute(&path), "announce");
 
 				let this = self.clone();
-				web_async::spawn(async move {
+				self.tasks.push(async move {
 					// stop_announce is the authoritative remover: it drops the entry (and
 					// its producer) once the announce refcount hits zero, which is what
 					// makes run_broadcast exit. Removing here too would let a stale task
@@ -656,6 +675,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	async fn run_broadcast(&self, path: Path<'_>, mut broadcast: broadcast::Dynamic) -> Result<(), Error> {
+		let mut subscribes = futures::stream::FuturesUnordered::new();
 		loop {
 			let request = tokio::select! {
 				request = broadcast.requested_track() => match request {
@@ -666,15 +686,19 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					}
 				},
 				_ = self.session.closed() => break,
+				Some(()) = subscribes.next(), if !subscribes.is_empty() => continue,
 			};
 
 			let mut this = self.clone();
 
 			let path = path.to_owned();
 			let broadcast = broadcast.clone();
-			web_async::spawn(async move {
-				this.run_subscribe(path, broadcast, request).await;
-			});
+			subscribes.push(
+				async move {
+					this.run_subscribe(path, broadcast, request).await;
+				}
+				.maybe_boxed(),
+			);
 		}
 
 		Ok(())

--- a/rs/moq-net/src/lib.rs
+++ b/rs/moq-net/src/lib.rs
@@ -43,12 +43,19 @@
 //!
 //! ## Async
 //! This library is async-first. [`Client::connect`] and [`Server::accept`] return a
-//! [`Connection`] future whose protocol work is
-//! polled by the caller, so task coordination does not require a Tokio runtime.
+//! [`Connection`] future that owns all of the session's protocol work, so the caller
+//! decides where it runs and dropping it cancels the session. Nothing is spawned
+//! behind your back.
 //!
-//! More methods are gaining `poll_xxx` counterparts built on [`kio`], so you can
-//! drive them from custom executors or synchronously. [`kio`] is built on the
-//! standard [`std::task::Waker`] API, and any [`std::task::Waker`] is a valid driver.
+//! You still need a tokio runtime (with its time driver) to poll a [`Connection`]:
+//! bandwidth sampling, the control stream timeout, and subscription linger all use
+//! tokio timers, which panic outside a runtime. Awaiting any other plain `async`
+//! method has the same requirement.
+//!
+//! That requirement is being phased out as more methods grow `poll_xxx` counterparts
+//! built on [`kio`], so you can drive them from custom executors without a tokio
+//! runtime. You can also call them synchronously, since [`kio`] is built on the
+//! standard [`std::task::Waker`] API and any [`std::task::Waker`] is a valid driver.
 
 mod client;
 mod coding;

--- a/rs/moq-net/src/lib.rs
+++ b/rs/moq-net/src/lib.rs
@@ -42,14 +42,13 @@
 //! last producer signals consumers that no more updates are coming.
 //!
 //! ## Async
-//! This library is async-first, using [tokio] for async I/O and task management.
-//! Any plain `async` method should be awaited from inside an active tokio runtime.
-//! Otherwise you risk a panic.
+//! This library is async-first. [`Client::connect`] and [`Server::accept`] return a
+//! [`Connection`] future whose protocol work is
+//! polled by the caller, so task coordination does not require a Tokio runtime.
 //!
-//! This requirement is being phased out as more methods grow `poll_xxx` counterparts
-//! built on [`kio`], so you can drive them from custom executors without a tokio
-//! runtime. You can also call them synchronously, since [`kio`] is built on the
-//! standard [`std::task::Waker`] API and any [`std::task::Waker`] is a valid driver.
+//! More methods are gaining `poll_xxx` counterparts built on [`kio`], so you can
+//! drive them from custom executors or synchronously. [`kio`] is built on the
+//! standard [`std::task::Waker`] API, and any [`std::task::Waker`] is a valid driver.
 
 mod client;
 mod coding;

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -12,7 +12,7 @@ use crate::{
 		self,
 		priority::{Priority, PriorityHandle, PriorityQueue},
 	},
-	util::{MaybeBoxedExt, MaybeSendBox},
+	util::{MaybeBoxedExt, MaybeSendBox, TaskSet},
 };
 
 use super::Version;
@@ -62,23 +62,17 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// `origin::Consumer` and friends are cheap to clone (shared handles), so each control
 		// stream gets its own child future and they all make progress independently.
 		let this = Arc::new(self);
-		let mut tasks = FuturesUnordered::new();
+		let mut tasks = TaskSet::owned();
 
 		loop {
-			let stream = tokio::select! {
-				stream = Stream::accept(&this.session, this.version) => stream?,
-				Some(()) = tasks.next(), if !tasks.is_empty() => continue,
-			};
+			let stream = tasks.drive(Stream::accept(&this.session, this.version)).await?;
 
 			let this = this.clone();
-			tasks.push(
-				async move {
-					if let Err(err) = this.handle(stream).await {
-						tracing::warn!(%err, "control stream error");
-					}
+			tasks.push(async move {
+				if let Err(err) = this.handle(stream).await {
+					tracing::warn!(%err, "control stream error");
 				}
-				.maybe_boxed(),
-			);
+			});
 		}
 	}
 

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -60,18 +60,25 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 	pub async fn run(self) -> Result<(), Error> {
 		// `origin::Consumer` and friends are cheap to clone (shared handles), so each control
-		// stream gets its own task and they all make progress independently.
+		// stream gets its own child future and they all make progress independently.
 		let this = Arc::new(self);
+		let mut tasks = FuturesUnordered::new();
 
 		loop {
-			let stream = Stream::accept(&this.session, this.version).await?;
+			let stream = tokio::select! {
+				stream = Stream::accept(&this.session, this.version) => stream?,
+				Some(()) = tasks.next(), if !tasks.is_empty() => continue,
+			};
 
 			let this = this.clone();
-			web_async::spawn(async move {
-				if let Err(err) = this.handle(stream).await {
-					tracing::warn!(%err, "control stream error");
+			tasks.push(
+				async move {
+					if let Err(err) = this.handle(stream).await {
+						tracing::warn!(%err, "control stream error");
+					}
 				}
-			});
+				.maybe_boxed(),
+			);
 		}
 	}
 
@@ -944,7 +951,7 @@ async fn recv_next(track: &mut track::Subscriber, datagrams: bool, emit_boundary
 }
 
 /// Shared per-subscription state for the publisher side. Cloned cheaply. Every
-/// field is either small or already Arc-backed) for each spawned serve_group task
+/// field is either small or already Arc-backed for each in-flight serve_group task
 /// so each in-flight group reads the latest SUBSCRIBE_UPDATE priority via its own
 /// watch::Receiver.
 #[derive(Clone)]
@@ -1014,7 +1021,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 									.encode(&lite::SubscribeResponse::Start(lite::SubscribeStart { group: group.sequence }))
 									.await?;
 							}
-							self.spawn_serve(group, &mut tasks);
+							self.queue_serve(group, &mut tasks);
 						}
 						Recv::Datagram(datagram) => self.serve_datagram(datagram),
 						Recv::Boundary(group) => {
@@ -1066,7 +1073,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		}
 	}
 
-	fn spawn_serve(&mut self, group: group::Consumer, tasks: &mut FuturesUnordered<MaybeSendBox<'static, ()>>) {
+	fn queue_serve(&mut self, group: group::Consumer, tasks: &mut FuturesUnordered<MaybeSendBox<'static, ()>>) {
 		let sequence = group.sequence;
 		tracing::debug!(subscribe = self.id, track = %self.track_name, sequence, "serving group");
 

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -3,11 +3,18 @@ use crate::{
 	Error, Origin, StatsHandle, bandwidth,
 	coding::{Reader, Stream, Writer},
 	lite::SessionInfo,
+	util::{MaybeBoxedExt, MaybeSendBox, TaskSet},
 };
 
 use super::{
 	Connecting, DataType, PeerSetup, Publisher, PublisherConfig, Setup, Subscriber, SubscriberConfig, Version,
 };
+
+pub(crate) struct SessionStart {
+	pub recv_bandwidth: Option<bandwidth::Consumer>,
+	pub connecting: Connecting,
+	pub driver: MaybeSendBox<'static, Result<(), Error>>,
+}
 
 /// Server: read the peer's single SETUP message off its Setup Stream before starting
 /// the session, so the caller can inspect the advertised path (and gate on it) before
@@ -64,7 +71,7 @@ pub fn start<S: web_transport_trait::Session>(
 	// gated on the client's path via [`accept_setup`]). Seeds the peer-setup slot so
 	// the Setup Stream isn't expected again. `None` reads it from the wire as usual.
 	peer_setup: Option<Setup>,
-) -> Result<(Option<bandwidth::Consumer>, Connecting), Error> {
+) -> Result<SessionStart, Error> {
 	let recv_bw = bandwidth::Producer::new();
 
 	let recv_bw_consumer = match version {
@@ -112,12 +119,13 @@ pub fn start<S: web_transport_trait::Session>(
 		peer_setup_slot.set(setup);
 	}
 	let peer_setup = peer_setup_slot;
+	let (tasks, task_set) = TaskSet::new();
 
 	// Advertise our own capabilities on a uni Setup Stream, then FIN. Best-effort:
 	// a failure here just means the peer falls back to "no capabilities" for us.
 	if version.has_setup_stream() {
 		let session = session.clone();
-		web_async::spawn(async move {
+		tasks.push(async move {
 			if let Err(err) = send_setup(&session, our_setup, version).await {
 				tracing::debug!(%err, "failed to send setup");
 			}
@@ -137,16 +145,17 @@ pub fn start<S: web_transport_trait::Session>(
 		stats,
 		version,
 		peer_setup,
+		tasks,
 	});
 
-	web_async::spawn(async move {
+	let driver = async move {
 		let res = tokio::select! {
 			Err(res) = run_session(setup_stream) => Err(res),
 			res = publisher.run() => res,
-			res = subscriber.run(sub_connecting) => res,
+			res = subscriber.run(sub_connecting, task_set) => res,
 		};
 
-		match res {
+		match &res {
 			Err(Error::Transport(_)) => {
 				tracing::info!("session terminated");
 				session.close(1, "");
@@ -160,9 +169,16 @@ pub fn start<S: web_transport_trait::Session>(
 				session.close(0, "");
 			}
 		}
-	});
 
-	Ok((recv_bw_consumer, connecting))
+		res
+	}
+	.maybe_boxed();
+
+	Ok(SessionStart {
+		recv_bandwidth: recv_bw_consumer,
+		connecting,
+		driver,
+	})
 }
 
 /// Open a unidirectional Setup Stream, send our single SETUP message, and FIN.

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -9,7 +9,7 @@ use std::{
 
 use futures::{StreamExt, stream::FuturesUnordered};
 
-use crate::util::{MaybeBoxedExt, MaybeSendBox};
+use crate::util::{MaybeBoxedExt, MaybeSendBox, TaskSet, Tasks};
 
 use crate::{
 	AsPath, Error, Path, PathOwned, StatsHandle, SubscriberStats, SubscriberTrack, Timescale, Timestamp, bandwidth,
@@ -42,6 +42,8 @@ pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 	/// Shared slot for the peer's SETUP (lite-05+). Written when the peer's Setup
 	/// stream is read; the probe stream waits on it before opening.
 	pub peer_setup: super::PeerSetup,
+	/// Driver-owned scope for broadcast and track handlers.
+	pub tasks: Tasks,
 }
 
 #[derive(Clone)]
@@ -71,6 +73,7 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	version: Version,
 	/// The peer's advertised SETUP (lite-05+), set when its Setup stream is read.
 	peer_setup: super::PeerSetup,
+	tasks: Tasks,
 }
 
 #[derive(Clone)]
@@ -102,6 +105,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			next_id: Default::default(),
 			version: config.version,
 			peer_setup: config.peer_setup,
+			tasks: config.tasks,
 		}
 	}
 
@@ -110,7 +114,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// rather than stored on `Subscriber`: the struct is cloned for several long-lived
 	/// tasks (`bw`, `run_uni`), and any clone retaining a producer would keep the channel
 	/// open and hang `connect()`.
-	pub async fn run(self, connecting: Option<ConnectingProducer>) -> Result<(), Error> {
+	pub async fn run(self, connecting: Option<ConnectingProducer>, tasks: TaskSet) -> Result<(), Error> {
 		let bw = self.clone();
 		let dg = self.clone();
 		tokio::select! {
@@ -118,21 +122,29 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			res = self.run_uni() => res,
 			Err(err) = bw.run_recv_bandwidth() => Err(err),
 			Err(err) = dg.run_datagrams() => Err(err),
+			_ = tasks.run() => Ok(()),
 		}
 	}
 
 	async fn run_uni(self) -> Result<(), Error> {
+		let mut tasks = FuturesUnordered::new();
 		loop {
-			let stream = self.session.accept_uni().await.map_err(Error::from_transport)?;
+			let stream = tokio::select! {
+				stream = self.session.accept_uni() => stream.map_err(Error::from_transport)?,
+				Some(()) = tasks.next(), if !tasks.is_empty() => continue,
+			};
 
 			let stream = Reader::new(stream, self.version);
 			let this = self.clone();
 
-			web_async::spawn(async move {
-				if let Err(err) = this.run_uni_stream(stream).await {
-					tracing::debug!(%err, "error running uni stream");
+			tasks.push(
+				async move {
+					if let Err(err) = this.run_uni_stream(stream).await {
+						tracing::debug!(%err, "error running uni stream");
+					}
 				}
-			});
+				.maybe_boxed(),
+			);
 		}
 	}
 
@@ -229,7 +241,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// dashboard sees on the origin.
 
 		// `connecting` is a local (a param), not a `self` field, so the `self.clone()` that
-		// start_announce uses to spawn long-lived broadcast tasks doesn't carry the producer
+		// start_announce uses for long-lived broadcast tasks doesn't carry the producer
 		// (which would keep the channel open for the broadcast's lifetime). Dropping it marks
 		// this prefix connected; on an early error it drops via scope exit, so a failed prefix
 		// can't hang connect().
@@ -521,15 +533,15 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let dynamic = broadcast.dynamic();
 
 		// Publish into the origin. An error means the path is outside our scope, so don't announce
-		// or spawn a server for it. Reflections are already filtered above.
+		// or start a server for it. Reflections are already filtered above.
 		let Ok(publish) = self.origin.publish_broadcast(path.clone(), &broadcast) else {
 			return Ok(false);
 		};
 
 		producers.insert(path.clone(), publish);
 
-		// Run the broadcast in the background until all consumers are dropped.
-		web_async::spawn(self.clone().run_broadcast(path, dynamic));
+		// Run the broadcast under the connection driver until all consumers are dropped.
+		self.tasks.push(self.clone().run_broadcast(path, dynamic));
 
 		Ok(true)
 	}
@@ -580,7 +592,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		};
 
 		let old = producers.insert(path.clone(), publish);
-		web_async::spawn(self.clone().run_broadcast(path.clone(), dynamic));
+		self.tasks.push(self.clone().run_broadcast(path.clone(), dynamic));
 
 		// Drop the replaced broadcast's guard last, unannouncing it now that the replacement is live.
 		drop(old);
@@ -590,6 +602,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 	async fn run_broadcast(self, path: PathOwned, mut broadcast: broadcast::Dynamic) {
 		// Serve track requests until every consumer of the broadcast is gone.
+		let mut tracks = FuturesUnordered::new();
 		loop {
 			let request = tokio::select! {
 				request = broadcast.requested_track() => match request {
@@ -600,6 +613,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					}
 				},
 				_ = self.session.closed() => break,
+				Some(()) = tracks.next(), if !tracks.is_empty() => continue,
 			};
 
 			let name = request.name().to_string();
@@ -619,7 +633,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 			// One task per track serves its lone subscription and any number of
 			// fetches concurrently, then lingers before tearing the upstream down.
-			web_async::spawn(serve.run(request));
+			tracks.push(serve.run(request).maybe_boxed());
 		}
 	}
 

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1189,11 +1189,19 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		Ok(())
 	}
 
+	/// Open the SUBSCRIBE control stream and send the request.
+	async fn open_subscribe(&self, msg: &lite::Subscribe<'_>) -> Result<Stream<S, Version>, Error> {
+		let mut stream = Stream::open(&self.subscriber.session, self.subscriber.version).await?;
+		stream.writer.encode(&lite::ControlType::Subscribe).await?;
+		stream.writer.encode(msg).await?;
+		Ok(stream)
+	}
+
 	/// Open the upstream SUBSCRIBE and start routing groups into the producer.
 	///
 	/// On Lite05+ the producer already exists (accepted from TRACK_INFO) and the
-	/// subscription is accepted implicitly. On older drafts this waits for the first
-	/// SUBSCRIBE_OK and promotes the pending request to a producer.
+	/// subscription is accepted implicitly. On older drafts this promotes the pending
+	/// request to a producer, then confirms with the first SUBSCRIBE_OK.
 	async fn establish(
 		&self,
 		track: &mut Option<Track>,
@@ -1216,10 +1224,6 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 
 		tracing::info!(id, broadcast = %self.subscriber.log_path(&self.path), track = %self.name, "subscribe started");
 
-		let mut stream = Stream::open(&self.subscriber.session, self.subscriber.version).await?;
-		stream.writer.encode(&lite::ControlType::Subscribe).await?;
-		stream.writer.encode(&msg).await?;
-
 		let producer = if self.subscriber.version.has_track_stream() {
 			// Lite05+: implicit acceptance, no SUBSCRIBE_OK. The producer already exists.
 			let Some(Track::Active(producer)) = track.as_ref() else {
@@ -1227,25 +1231,16 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			};
 			producer.clone()
 		} else {
-			// Older drafts: the first SUBSCRIBE_OK promotes the pending request. Bail if
-			// the broadcast dies meanwhile.
-			let resp = tokio::select! {
-				err = self.broadcast.closed() => return Err(err),
-				resp = stream.reader.decode::<lite::SubscribeResponse>() => resp?,
-			};
-			if !matches!(resp, lite::SubscribeResponse::Ok(_)) {
-				return Err(Error::ProtocolViolation);
-			}
-
-			// Accept with defaults: pre-lite-05 carries no timescale, and the cache
-			// window falls back to the model default.
+			// Older drafts promote the pending request themselves. Accept with defaults
+			// (pre-lite-05 carries no timescale, and the cache window falls back to the
+			// model default), which needs nothing from SUBSCRIBE_OK.
 			let Some(Track::Pending(request)) = track.take() else {
 				unreachable!("establish called without a pending track");
 			};
 			let mut producer = request.accept(track::Info::default());
 			// The accepted producer starts with a fresh subscription cursor, so its first
-			// poll would re-report the subscription we just sent as a "change". Prime it
-			// now (the params are already on the wire) so only genuine later changes fire.
+			// poll would re-report the subscription we're about to send as a "change".
+			// Prime it now so only genuine later changes fire.
 			let _ = producer.poll_subscription_changed(&kio::Waiter::noop());
 			*track = Some(Track::Active(producer.clone()));
 			producer
@@ -1256,6 +1251,10 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		let abs = self.subscriber.origin.absolute(&self.path).to_owned();
 		let broadcast_sub = self.subscriber.broadcasts.subscribe(&abs);
 
+		// Register before the SUBSCRIBE hits the wire. `id` is live the moment the peer
+		// reads it, and a publisher may serve its first group immediately, so a late
+		// insert races the group stream: `recv_group` would find no entry and drop it,
+		// stalling the track forever.
 		self.subscriber.subscribes.lock().insert(
 			id,
 			TrackEntry {
@@ -1264,6 +1263,36 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 				timescale,
 			},
 		);
+
+		let mut stream = match self.open_subscribe(&msg).await {
+			Ok(stream) => stream,
+			Err(err) => {
+				self.subscriber.subscribes.lock().remove(&id);
+				return Err(err);
+			}
+		};
+
+		if !self.subscriber.version.has_track_stream() {
+			// Older drafts: the first SUBSCRIBE_OK confirms it. Bail if the broadcast
+			// dies meanwhile.
+			let resp = tokio::select! {
+				err = self.broadcast.closed() => Err(err),
+				resp = stream.reader.decode::<lite::SubscribeResponse>() => resp,
+			};
+
+			let ok = match resp {
+				Ok(resp) => matches!(resp, lite::SubscribeResponse::Ok(_)),
+				Err(err) => {
+					self.subscriber.subscribes.lock().remove(&id);
+					return Err(err);
+				}
+			};
+
+			if !ok {
+				self.subscriber.subscribes.lock().remove(&id);
+				return Err(Error::ProtocolViolation);
+			}
+		}
 
 		*sub = Sub::Active(SubStream {
 			stream,

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -127,24 +127,21 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	async fn run_uni(self) -> Result<(), Error> {
-		let mut tasks = FuturesUnordered::new();
+		let mut tasks = TaskSet::owned();
 		loop {
-			let stream = tokio::select! {
-				stream = self.session.accept_uni() => stream.map_err(Error::from_transport)?,
-				Some(()) = tasks.next(), if !tasks.is_empty() => continue,
-			};
+			let stream = tasks
+				.drive(self.session.accept_uni())
+				.await
+				.map_err(Error::from_transport)?;
 
 			let stream = Reader::new(stream, self.version);
 			let this = self.clone();
 
-			tasks.push(
-				async move {
-					if let Err(err) = this.run_uni_stream(stream).await {
-						tracing::debug!(%err, "error running uni stream");
-					}
+			tasks.push(async move {
+				if let Err(err) = this.run_uni_stream(stream).await {
+					tracing::debug!(%err, "error running uni stream");
 				}
-				.maybe_boxed(),
-			);
+			});
 		}
 	}
 
@@ -602,18 +599,25 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 	async fn run_broadcast(self, path: PathOwned, mut broadcast: broadcast::Dynamic) {
 		// Serve track requests until every consumer of the broadcast is gone.
-		let mut tracks = FuturesUnordered::new();
+		let mut tracks = TaskSet::owned();
 		loop {
-			let request = tokio::select! {
-				request = broadcast.requested_track() => match request {
-					Ok(request) => request,
-					Err(err) => {
-						tracing::debug!(%err, "broadcast closed");
-						break;
+			let next = tracks
+				.drive(async {
+					tokio::select! {
+						request = broadcast.requested_track() => Some(request),
+						_ = self.session.closed() => None,
 					}
-				},
-				_ = self.session.closed() => break,
-				Some(()) = tracks.next(), if !tracks.is_empty() => continue,
+				})
+				.await;
+
+			let request = match next {
+				Some(Ok(request)) => request,
+				Some(Err(err)) => {
+					tracing::debug!(%err, "broadcast closed");
+					break;
+				}
+				// Session gone.
+				None => break,
 			};
 
 			let name = request.name().to_string();
@@ -633,7 +637,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 			// One task per track serves its lone subscription and any number of
 			// fetches concurrently, then lingers before tearing the upstream down.
-			tracks.push(serve.run(request).maybe_boxed());
+			tracks.push(serve.run(request));
 		}
 	}
 

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1,7 +1,7 @@
 use crate::origin;
 use crate::{
 	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05,
-	ALPN_LITE_06_WIP, Consume, Error, NEGOTIATED, Role, Session, StatsHandle, Version, Versions,
+	ALPN_LITE_06_WIP, Connection, Consume, Error, NEGOTIATED, Role, StatsHandle, Version, Versions,
 	coding::{Decode, Encode, Reader, Stream},
 	ietf, lite, setup,
 };
@@ -66,12 +66,12 @@ impl Server {
 		self
 	}
 
-	/// Perform the MoQ handshake as a server, returning the established [`Session`].
+	/// Perform the MoQ handshake as a server, returning the caller-driven [`Connection`].
 	///
 	/// Convenience wrapper over [`accept_request`](Self::accept_request) that
 	/// completes the handshake immediately. Use `accept_request` when you need to
 	/// inspect the client's advertised path before deciding what to serve.
-	pub async fn accept<S: web_transport_trait::Session>(&self, session: S) -> Result<Session, Error> {
+	pub async fn accept<S: web_transport_trait::Session>(&self, session: S) -> Result<Connection, Error> {
 		self.accept_request(session).await?.ok().await
 	}
 
@@ -349,8 +349,8 @@ impl<S: web_transport_trait::Session> Request<S> {
 		self.inner.as_mut().expect("request already responded")
 	}
 
-	/// Accept the session, completing the handshake.
-	pub async fn ok(mut self) -> Result<Session, Error> {
+	/// Accept the session, returning its caller-driven connection.
+	pub async fn ok(mut self) -> Result<Connection, Error> {
 		let RequestInner { server, handshake } = self.inner.take().expect("request already responded");
 
 		let (session, mut stream, version, request_id_max) = match handshake {
@@ -361,7 +361,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 			} => {
 				// The client's SETUP was read in `accept_request`; hand the stream back
 				// for GOAWAY. A server never advertises a path, hence `None`.
-				ietf::start(
+				let driver = ietf::start(
 					session.clone(),
 					None,
 					None,
@@ -374,10 +374,10 @@ impl<S: web_transport_trait::Session> Request<S> {
 					Some(peer_setup),
 				)?;
 				tracing::debug!(?version, "connected");
-				return Ok(Session::new(session, version.into(), None));
+				return Ok(Connection::new(session, version.into(), None, driver));
 			}
 			Handshake::LiteBare { session, version } => {
-				let (recv_bw, _connecting) = lite::start(
+				let start = lite::start(
 					session.clone(),
 					None,
 					server.publish,
@@ -387,7 +387,12 @@ impl<S: web_transport_trait::Session> Request<S> {
 					lite::Setup::default(),
 					None,
 				)?;
-				return Ok(Session::new(session, version.into(), recv_bw));
+				return Ok(Connection::new(
+					session,
+					version.into(),
+					start.recv_bandwidth,
+					start.driver,
+				));
 			}
 			Handshake::LiteSetup {
 				session,
@@ -400,7 +405,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					path: None,
 					role: lite::Role::Both,
 				};
-				let (recv_bw, _connecting) = lite::start(
+				let start = lite::start(
 					session.clone(),
 					None,
 					server.publish,
@@ -410,7 +415,12 @@ impl<S: web_transport_trait::Session> Request<S> {
 					our_setup,
 					Some(client_setup),
 				)?;
-				return Ok(Session::new(session, version.into(), recv_bw));
+				return Ok(Connection::new(
+					session,
+					version.into(),
+					start.recv_bandwidth,
+					start.driver,
+				));
 			}
 			Handshake::Legacy {
 				session,
@@ -437,11 +447,11 @@ impl<S: web_transport_trait::Session> Request<S> {
 		};
 		stream.writer.encode(&server_setup).await?;
 
-		let recv_bw = match version {
+		let (recv_bw, driver) = match version {
 			Version::Lite(v) => {
 				let stream = stream.with_version(v);
 				// Pre-lite-05: no Setup Stream, so nothing to advertise or seed.
-				let (recv_bw, _connecting) = lite::start(
+				let start = lite::start(
 					session.clone(),
 					Some(stream),
 					server.publish,
@@ -451,12 +461,12 @@ impl<S: web_transport_trait::Session> Request<S> {
 					lite::Setup::default(),
 					None,
 				)?;
-				recv_bw
+				(start.recv_bandwidth, start.driver)
 			}
 			Version::Ietf(v) => {
 				let stream = stream.with_version(v);
 				// Draft 14-16: path came in the bidi SETUP, no uni SETUP to hand back.
-				ietf::start(
+				let driver = ietf::start(
 					session.clone(),
 					Some(stream),
 					request_id_max,
@@ -468,11 +478,11 @@ impl<S: web_transport_trait::Session> Request<S> {
 					None,
 					None,
 				)?;
-				None
+				(None, driver)
 			}
 		};
 
-		Ok(Session::new(session, version, recv_bw))
+		Ok(Connection::new(session, version, recv_bw, driver))
 	}
 
 	/// Reject the session, closing the transport with `err`'s wire code.

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -64,14 +64,25 @@ pub struct Session {
 	recv_bandwidth: Option<bandwidth::Consumer>,
 }
 
-/// A connected session and the future that drives its protocol state.
+/// A connected session bundled with the future that drives its protocol state.
 ///
-/// Poll this future for the lifetime of the session. Dropping it cancels protocol
-/// work and closes the session.
+/// Poll this future for the lifetime of every [`Session`] clone taken from it:
+/// nothing else drives the protocol, so a session whose connection isn't polled
+/// makes no progress. Dropping it cancels protocol work and closes the session.
+/// It resolves when the session ends, and keeps returning that same result if
+/// polled again.
+///
+/// To run the driver elsewhere (an executor task) while handing the session to a
+/// caller, use [`split`](Self::split) rather than moving the whole connection: a
+/// [`Connection`] holds a [`Session`] clone, so a detached one would keep the
+/// session's close-on-last-drop from ever firing.
+///
+/// Polling requires a tokio runtime with a time driver; see the crate-level Async
+/// docs.
 pub struct Connection {
-	session: Session,
-	inner: MaybeSendBox<'static, Result<(), Error>>,
-	result: Option<Result<(), Error>>,
+	// Both are `Some` until `split` takes them, which also suppresses `Drop`.
+	session: Option<Session>,
+	driver: Option<Driver>,
 }
 
 impl Connection {
@@ -86,41 +97,86 @@ impl Connection {
 			let mut protocol = protocol;
 			tokio::select! {
 				result = &mut protocol => result,
+				// Bandwidth sampling stops at close; the protocol still owns the teardown.
 				_ = maintenance => protocol.await,
 			}
 		}
 		.maybe_boxed();
 
 		Self {
-			session,
-			inner,
-			result: None,
+			session: Some(session),
+			driver: Some(Driver { inner, result: None }),
 		}
 	}
 
 	/// Borrow the connected session handle.
 	pub fn session(&self) -> &Session {
-		&self.session
+		self.session.as_ref().expect("connection split")
 	}
 
-	pub(super) async fn wait_ready(&mut self, ready: impl Future<Output = ()>) -> Result<(), Error> {
+	/// Split into the session handle and the future driving it.
+	///
+	/// The [`Driver`] holds no [`Session`] clone, so the session still closes once
+	/// the caller drops its last handle, and the driver then finishes on its own.
+	/// That makes this the right way to hand the driver to an executor.
+	pub fn split(mut self) -> (Session, Driver) {
+		let session = self.session.take().expect("connection split");
+		let driver = self.driver.take().expect("connection split");
+		(session, driver)
+	}
+
+	fn driver_mut(&mut self) -> &mut Driver {
+		self.driver.as_mut().expect("connection split")
+	}
+
+	/// Drive the connection until `ready` resolves, so `connect` can block on the
+	/// initial announce set.
+	///
+	/// A session that dies first still resolves `ready`: the connecting producers
+	/// live inside the driver, so its completion drops them and releases the barrier.
+	/// The error isn't lost, it's cached for whoever polls the connection next.
+	pub(super) async fn wait_ready(&mut self, ready: impl Future<Output = ()>) {
 		tokio::pin!(ready);
 		tokio::select! {
 			biased;
-			_ = &mut ready => Ok(()),
-			result = &mut *self => {
-				// Connecting producers live inside the driver. Its completion drops
-				// them and releases the barrier on an early session error. The cached
-				// result remains available when the caller polls the connection.
-				let _ = result;
-				ready.await;
-				Ok(())
-			}
+			_ = &mut ready => {},
+			_ = self.driver_mut() => ready.await,
 		}
 	}
 }
 
 impl Future for Connection {
+	type Output = Result<(), Error>;
+
+	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+		Pin::new(self.driver_mut()).poll(cx)
+	}
+}
+
+impl Drop for Connection {
+	fn drop(&mut self) {
+		// `split` handed the session off, so there's nothing to cancel.
+		if let Some(session) = &self.session {
+			session.close(Error::Cancel);
+		}
+	}
+}
+
+/// The future driving a [`Session`]'s protocol state, split off from its
+/// [`Connection`].
+///
+/// Poll it for the lifetime of the session. Unlike a [`Connection`], dropping it
+/// cancels protocol work without closing the session, since it holds no session
+/// handle of its own. It resolves when the session ends, and keeps returning that
+/// same result if polled again.
+pub struct Driver {
+	inner: MaybeSendBox<'static, Result<(), Error>>,
+	// Cached so a poll after `wait_ready` consumed the result doesn't re-poll a
+	// completed future.
+	result: Option<Result<(), Error>>,
+}
+
+impl Future for Driver {
 	type Output = Result<(), Error>;
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -131,12 +187,6 @@ impl Future for Connection {
 		let result = std::task::ready!(self.inner.as_mut().poll(cx));
 		self.result = Some(result.clone());
 		Poll::Ready(result)
-	}
-}
-
-impl Drop for Connection {
-	fn drop(&mut self) {
-		self.session.close(Error::Cancel);
 	}
 }
 
@@ -168,7 +218,7 @@ impl Session {
 		recv_bandwidth: Option<bandwidth::Consumer>,
 	) -> (Self, MaybeSendBox<'static, ()>) {
 		// Send bandwidth is version-agnostic: it depends on QUIC backend support.
-		let send_bandwidth = if session.stats().estimated_send_rate().is_some() {
+		let (send_bandwidth, maintenance) = if session.stats().estimated_send_rate().is_some() {
 			let producer = bandwidth::Producer::new();
 			let consumer = producer.consume();
 
@@ -182,7 +232,6 @@ impl Session {
 		} else {
 			(None, std::future::pending().maybe_boxed())
 		};
-		let (send_bandwidth, maintenance) = send_bandwidth;
 
 		let session = Self {
 			session: Arc::new(SessionShared {

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -1,8 +1,17 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+	future::Future,
+	pin::Pin,
+	sync::Arc,
+	task::{Context, Poll},
+	time::Duration,
+};
 
 use web_transport_trait::Stats;
 
-use crate::{Error, Version, bandwidth, util::MaybeSendBox};
+use crate::{
+	Error, Version, bandwidth,
+	util::{MaybeBoxedExt, MaybeSendBox},
+};
 
 /// A snapshot of connection statistics for a [`Session`].
 ///
@@ -45,15 +54,90 @@ pub struct ConnectionStats {
 
 /// A MoQ transport session, wrapping a WebTransport connection.
 ///
-/// Created via:
-/// - [`crate::Client::connect`] for clients.
-/// - [`crate::Server::accept`] for servers.
+/// Borrowed or cloned from the [`Connection`] returned by [`crate::Client::connect`]
+/// or [`crate::Server::accept`].
 #[derive(Clone)]
 pub struct Session {
 	session: Arc<SessionShared>,
 	version: Version,
 	send_bandwidth: Option<bandwidth::Consumer>,
 	recv_bandwidth: Option<bandwidth::Consumer>,
+}
+
+/// A connected session and the future that drives its protocol state.
+///
+/// Poll this future for the lifetime of the session. Dropping it cancels protocol
+/// work and closes the session.
+pub struct Connection {
+	session: Session,
+	inner: MaybeSendBox<'static, Result<(), Error>>,
+	result: Option<Result<(), Error>>,
+}
+
+impl Connection {
+	pub(super) fn new<S: web_transport_trait::Session>(
+		transport: S,
+		version: Version,
+		recv_bandwidth: Option<bandwidth::Consumer>,
+		protocol: MaybeSendBox<'static, Result<(), Error>>,
+	) -> Self {
+		let (session, maintenance) = Session::new(transport, version, recv_bandwidth);
+		let inner = async move {
+			let mut protocol = protocol;
+			tokio::select! {
+				result = &mut protocol => result,
+				_ = maintenance => protocol.await,
+			}
+		}
+		.maybe_boxed();
+
+		Self {
+			session,
+			inner,
+			result: None,
+		}
+	}
+
+	/// Borrow the connected session handle.
+	pub fn session(&self) -> &Session {
+		&self.session
+	}
+
+	pub(super) async fn wait_ready(&mut self, ready: impl Future<Output = ()>) -> Result<(), Error> {
+		tokio::pin!(ready);
+		tokio::select! {
+			biased;
+			_ = &mut ready => Ok(()),
+			result = &mut *self => {
+				// Connecting producers live inside the driver. Its completion drops
+				// them and releases the barrier on an early session error. The cached
+				// result remains available when the caller polls the connection.
+				let _ = result;
+				ready.await;
+				Ok(())
+			}
+		}
+	}
+}
+
+impl Future for Connection {
+	type Output = Result<(), Error>;
+
+	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+		if let Some(result) = &self.result {
+			return Poll::Ready(result.clone());
+		}
+
+		let result = std::task::ready!(self.inner.as_mut().poll(cx));
+		self.result = Some(result.clone());
+		Poll::Ready(result)
+	}
+}
+
+impl Drop for Connection {
+	fn drop(&mut self) {
+		self.session.close(Error::Cancel);
+	}
 }
 
 // Close-once state shared by every clone: the transport closes when [`Session::close`]
@@ -78,27 +162,29 @@ impl Drop for SessionShared {
 }
 
 impl Session {
-	pub(super) fn new<S: web_transport_trait::Session>(
+	fn new<S: web_transport_trait::Session>(
 		session: S,
 		version: Version,
 		recv_bandwidth: Option<bandwidth::Consumer>,
-	) -> Self {
+	) -> (Self, MaybeSendBox<'static, ()>) {
 		// Send bandwidth is version-agnostic: it depends on QUIC backend support.
 		let send_bandwidth = if session.stats().estimated_send_rate().is_some() {
 			let producer = bandwidth::Producer::new();
 			let consumer = producer.consume();
 
 			let session = session.clone();
-			web_async::spawn(async move {
+			let maintenance = async move {
 				run_send_bandwidth(&session, producer).await;
-			});
+			}
+			.maybe_boxed();
 
-			Some(consumer)
+			(Some(consumer), maintenance)
 		} else {
-			None
+			(None, std::future::pending().maybe_boxed())
 		};
+		let (send_bandwidth, maintenance) = send_bandwidth;
 
-		Self {
+		let session = Self {
 			session: Arc::new(SessionShared {
 				inner: Box::new(session),
 				closed: std::sync::atomic::AtomicBool::new(false),
@@ -106,7 +192,9 @@ impl Session {
 			version,
 			send_bandwidth,
 			recv_bandwidth,
-		}
+		};
+
+		(session, maintenance)
 	}
 
 	/// Returns the negotiated protocol version.

--- a/rs/moq-net/src/util.rs
+++ b/rs/moq-net/src/util.rs
@@ -7,7 +7,7 @@
 
 use std::future::Future;
 
-use futures::FutureExt;
+use futures::{FutureExt, StreamExt, channel::mpsc, stream::FuturesUnordered};
 
 #[cfg(not(target_family = "wasm"))]
 pub(crate) type MaybeSendBox<'a, T> = futures::future::BoxFuture<'a, T>;
@@ -31,3 +31,83 @@ pub(crate) trait MaybeBoxedExt<'a>: Future + Sized + 'a {
 }
 #[cfg(target_family = "wasm")]
 impl<'a, F: Future + 'a> MaybeBoxedExt<'a> for F {}
+
+/// Cloneable handle for submitting futures to a driver-owned [`TaskSet`].
+#[derive(Clone)]
+pub(crate) struct Tasks {
+	tx: mpsc::UnboundedSender<MaybeSendBox<'static, ()>>,
+}
+
+impl Tasks {
+	/// Queue a future for polling by the associated [`TaskSet`].
+	pub fn push(&self, task: impl MaybeBoxedExt<'static, Output = ()>) {
+		self.tx.unbounded_send(task.maybe_boxed()).expect("task driver dropped");
+	}
+}
+
+/// A dynamic set of child futures polled by its parent driver.
+///
+/// Unlike an executor spawn, dropping this value cancels every queued and active
+/// child. [`Tasks`] handles may be cloned into those children so nested protocol
+/// state can submit more work without choosing an async runtime.
+pub(crate) struct TaskSet {
+	rx: mpsc::UnboundedReceiver<MaybeSendBox<'static, ()>>,
+	active: FuturesUnordered<MaybeSendBox<'static, ()>>,
+}
+
+impl TaskSet {
+	/// Create a task submission handle and its driver-owned receiver.
+	pub fn new() -> (Tasks, Self) {
+		let (tx, rx) = mpsc::unbounded();
+		(
+			Tasks { tx },
+			Self {
+				rx,
+				active: FuturesUnordered::new(),
+			},
+		)
+	}
+
+	/// Drive submitted children until every submission handle is dropped and all
+	/// active children finish.
+	pub async fn run(mut self) {
+		loop {
+			tokio::select! {
+				Some(task) = self.rx.next() => self.active.push(task),
+				Some(()) = self.active.next(), if !self.active.is_empty() => {},
+				else => return,
+			}
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::sync::{
+		Arc,
+		atomic::{AtomicUsize, Ordering},
+	};
+
+	use super::*;
+
+	#[test]
+	fn task_set_runs_nested_work_without_a_runtime() {
+		let (tasks, task_set) = TaskSet::new();
+		let completed = Arc::new(AtomicUsize::new(0));
+
+		let nested_tasks = tasks.clone();
+		let outer_completed = completed.clone();
+		tasks.push(async move {
+			outer_completed.fetch_add(1, Ordering::SeqCst);
+
+			let inner_completed = outer_completed.clone();
+			nested_tasks.push(async move {
+				inner_completed.fetch_add(1, Ordering::SeqCst);
+			});
+		});
+		drop(tasks);
+
+		futures::executor::block_on(task_set.run());
+		assert_eq!(completed.load(Ordering::SeqCst), 2);
+	}
+}

--- a/rs/moq-net/src/util.rs
+++ b/rs/moq-net/src/util.rs
@@ -40,8 +40,11 @@ pub(crate) struct Tasks {
 
 impl Tasks {
 	/// Queue a future for polling by the associated [`TaskSet`].
+	///
+	/// A task submitted after the set is gone is dropped: the driver has torn down,
+	/// so the task would have been cancelled anyway.
 	pub fn push(&self, task: impl MaybeBoxedExt<'static, Output = ()>) {
-		self.tx.unbounded_send(task.maybe_boxed()).expect("task driver dropped");
+		let _ = self.tx.unbounded_send(task.maybe_boxed());
 	}
 }
 
@@ -66,6 +69,35 @@ impl TaskSet {
 				active: FuturesUnordered::new(),
 			},
 		)
+	}
+
+	/// Create a set that only its owner can push to, for a loop that accepts streams
+	/// and serves each one as a child.
+	pub fn owned() -> Self {
+		let (_, set) = Self::new();
+		set
+	}
+
+	/// Queue a future for polling by this set.
+	pub fn push(&mut self, task: impl MaybeBoxedExt<'static, Output = ()>) {
+		self.active.push(task.maybe_boxed());
+	}
+
+	/// Poll every child while awaiting `future`, returning its output.
+	///
+	/// `future` is polled in place rather than cancelled and rebuilt each time a
+	/// child finishes, so an accept loop can serve its children without assuming the
+	/// transport's `accept_*` is cancel-safe (`web_transport_trait` promises nothing).
+	pub async fn drive<F: Future>(&mut self, future: F) -> F::Output {
+		tokio::pin!(future);
+
+		loop {
+			tokio::select! {
+				output = &mut future => return output,
+				Some(task) = self.rx.next() => self.active.push(task),
+				Some(()) = self.active.next(), if !self.active.is_empty() => {},
+			}
+		}
 	}
 
 	/// Drive submitted children until every submission handle is dropped and all

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -118,8 +118,8 @@ where
 	if let Some(publish) = publish {
 		server = server.with_subscriber(publish);
 	}
-	let session = server.accept(ws).await?;
-	session.closed().await.map_err(Into::into)
+	let connection = server.accept(ws).await?;
+	connection.await.map_err(Into::into)
 }
 
 /// QMux wire-format versions that can ride under a `{prefix}.{alpn}` pair.

--- a/rs/moq-wasm/src/lib.rs
+++ b/rs/moq-wasm/src/lib.rs
@@ -71,7 +71,11 @@ impl Session {
 		let origin = moq_net::Origin::random().produce();
 		let consumer = origin.consume();
 		let client = moq_net::Client::new().with_subscriber(origin);
-		let inner = client.connect(transport).await.map_err(js_err)?;
+		let connection = client.connect(transport).await.map_err(js_err)?;
+		let inner = connection.session().clone();
+		web_async::spawn(async move {
+			let _ = connection.await;
+		});
 		Ok(Session { inner, consumer })
 	}
 

--- a/rs/moq-wasm/src/lib.rs
+++ b/rs/moq-wasm/src/lib.rs
@@ -72,9 +72,11 @@ impl Session {
 		let consumer = origin.consume();
 		let client = moq_net::Client::new().with_subscriber(origin);
 		let connection = client.connect(transport).await.map_err(js_err)?;
-		let inner = connection.session().clone();
+		// Split so the spawned driver holds no session handle: dropping this `Session`
+		// then still closes the transport, which ends the driver.
+		let (inner, driver) = connection.split();
 		web_async::spawn(async move {
-			let _ = connection.await;
+			let _ = driver.await;
 		});
 		Ok(Session { inner, consumer })
 	}


### PR DESCRIPTION
## Summary

Make each MoQ connection a caller-polled future that owns the protocol driver, bandwidth maintenance, and dynamic publisher/subscriber work. No hidden executor spawns remain in the moq-net connection, publisher, or subscriber paths: runtime choices move out to the adapters, where moq-native spawns on Tokio, moq-wasm spawns on the web executor, and the relay's WebSocket path polls the connection directly.

## Public API changes

- **Breaking:** `Client::connect`, `Server::accept`, and `Request::ok` return `Connection` instead of `Session`.
- Add `Connection`, its `session()` accessor, and `split()` -> `(Session, Driver)`. The connection must be polled for the lifetime of any session handle taken from it.
- Targets `dev` because it changes existing moq-net return types.

## What changed since the first draft

The original draft was written by GPT-5, and review turned up two problems worth calling out, both proven with a failing test before being fixed.

**A `Connection` that gets detached breaks the session close contract.** `Connection` holds a `Session` clone, and `SessionShared` only closes the transport when the *last* clone drops. Any caller that ran the driver detached, which is exactly what moq-native's `spawn_connection` and moq-wasm's `handshake` did, parked that clone in a task forever, so dropping the returned `Session` closed nothing and every moq-native consumer leaked its session until the peer timed it out. `just check` passed the whole time, since nothing covered the contract.

`Connection::split()` is the fix: the `Driver` it returns holds no session handle, so the caller's last drop still closes the transport, which in turn ends the driver. moq-native, moq-wasm, and the wasm doc now use it, and `split_driver_does_not_keep_the_session_alive` is the regression test (it fails against the previous shape). The relay keeps awaiting the whole `Connection`, which is the usage `split` exists to avoid needing.

**The runtime-free claim was false.** Polling a connection still requires a tokio runtime: bandwidth sampling (`session.rs`), the control-stream timeout (`ietf/control.rs`), and subscription linger (`lite/subscriber.rs`) all use tokio timers, which panic outside one. A fake transport reporting a send-rate estimate, like Quinn does, panics with "there is no reactor running" on the first poll. The draft's test only passed because its fake reports no estimate, so it never reaches a timer.

The crate docs now state what actually changed, that nothing is spawned behind the caller's back, and keep the existing note that the runtime requirement is being phased out as `poll_*` coverage grows. The test is renamed off "without a tokio runtime" to what it really pins down.

**Cleanup.** The five hand-rolled accept-and-serve loops each open-coded the same `select!` over a `FuturesUnordered` with a `continue` arm, and each rebuilt its `accept_*` future every time a child finished, assuming a cancel-safety `web_transport_trait` never promises. They now share `TaskSet`, which grew `owned()` and `drive()`; `drive()` polls the accept future in place. `Tasks::push` drops its task instead of panicking when the driver is gone, since that's a teardown race rather than a bug.

**A group could arrive before its subscription was registered.** `establish` sent SUBSCRIBE, awaited SUBSCRIBE_OK, and only then inserted the id into `subscribes`. But the id is live the moment the peer reads it, and a publisher serves its first group immediately, so a group landing in that window found an empty map: `recv_group` dropped it as `Error::Cancel` and the track stalled until the consumer gave up. The fix accepts the producer and registers the id *before* sending, which costs nothing because the pre-lite-05 accept path never used SUBSCRIBE_OK's contents (it accepts with `track::Info::default()` regardless).

The race predates this branch. `web_async::spawn` put the uni handler on its own task, which ordered the insert ahead of the group in practice; a caller-polled connection drives both from one task, so select order alone decides and the drop became reachable. That made it this PR's problem to fix, and the fix belongs at the registration rather than in the poll plumbing, since nothing about the group path was wrong.

This was failing ~40% of runs on `lite-01` through `lite-04` (`broadcast_moq_lite_02` plus the lite-02/lite-03 negotiate cases). Bisect: `dev` passes, and the branch's first commit (`c17e54e18`) fails identically, so CI never saw this branch green. Now 20/20 on the isolated test and 12/12 on the full broadcast suite, against 6/10 before.

## Test plan

- `just fix` and `just check` pass.
- `cargo test -p moq-net` (475 tests), plus the moq-native broadcast suite run 12x for the race above.
- `cargo clippy -p moq-net --all-targets -- -D warnings`.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p moq-net -p moq-native --no-deps`.

Gaps worth knowing: the session-leak fix is covered by a unit test against a fake transport rather than real traffic. The subscription-ordering fix has no deterministic regression test - it's verified by the e2e suite going from ~40% failure to 0/32 runs, which catches it probabilistically rather than pinning the invariant.

## Cross-package sync

Updated the Rust native, relay, and WebAssembly adapters plus the WebAssembly docs. No wire format changed, so js/net and the IETF drafts need no update.
