### PR TITLE
feat(hang)!: mark Catalog and Container #[non_exhaustive]

### DIFF
--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -65,14 +65,13 @@ fn create_track(broadcast: &mut moq_net::broadcast::Producer) -> anyhow::Result<
 	renditions.insert(video_track.to_string(), video_config);
 
 	// Create the catalog describing our video track.
-	let catalog = hang::catalog::Catalog {
-		video: hang::catalog::Video {
-			renditions,
-			display: None,
-			rotation: None,
-			flip: None,
-		},
-		..Default::default()
+	// `Catalog` is #[non_exhaustive], so start from the default and assign the sections you need.
+	let mut catalog = hang::catalog::Catalog::default();
+	catalog.video = hang::catalog::Video {
+		renditions,
+		display: None,
+		rotation: None,
+		flip: None,
 	};
 
 	// Publish the catalog as a "catalog.json" track in the broadcast.

--- a/rs/hang/src/catalog/container.rs
+++ b/rs/hang/src/catalog/container.rs
@@ -16,10 +16,15 @@ use serde_with::{base64::Base64, serde_as};
 /// { "kind": "cmaf", "init": "<base64-encoded ftyp+moov>" }
 /// { "kind": "loc" }
 /// ```
+///
+/// Marked `#[non_exhaustive]` so new container formats can be added without bumping the major
+/// version. External `match`es need a wildcard arm; constructing the existing variants is
+/// unaffected.
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "kind")]
+#[non_exhaustive]
 pub enum Container {
 	#[serde(rename = "legacy")]
 	#[default]
@@ -30,6 +35,42 @@ pub enum Container {
 		init: Bytes,
 	},
 	Loc,
+}
+
+impl Container {
+	/// The `kind` tag this container serializes as, e.g. `"cmaf"`.
+	///
+	/// Useful in logs and errors, where the variant's payload (a whole init segment) has no place.
+	pub fn kind(&self) -> &'static str {
+		match self {
+			Self::Legacy => "legacy",
+			Self::Cmaf { .. } => "cmaf",
+			Self::Loc => "loc",
+		}
+	}
+
+	/// The out-of-band init segment (ftyp+moov) this container needs to decode its frames, if any.
+	///
+	/// `None` means frames are self-describing given the catalog's codec config, so a consumer
+	/// that needs an init segment has to synthesize one.
+	pub fn init(&self) -> Option<&Bytes> {
+		match self {
+			Self::Cmaf { init } => Some(init),
+			Self::Legacy | Self::Loc => None,
+		}
+	}
+
+	/// Whether each frame is a raw codec bitstream, modulo a small per-frame header.
+	///
+	/// True for `legacy` (VarInt timestamp prefix) and `loc` (property block). False for `cmaf`,
+	/// whose frames are complete moof+mdat fragments. Consumers that re-emit raw codec payloads
+	/// (MPEG-TS, MKV, FLV) can only accept a container where this holds.
+	pub fn is_raw(&self) -> bool {
+		match self {
+			Self::Legacy | Self::Loc => true,
+			Self::Cmaf { .. } => false,
+		}
+	}
 }
 
 #[cfg(test)]
@@ -43,5 +84,33 @@ mod tests {
 
 		let json = serde_json::to_string(&parsed).unwrap();
 		assert_eq!(json, r#"{"kind":"loc"}"#);
+	}
+
+	/// `kind()` has to keep matching the serde tag, since that's the whole point of it.
+	#[test]
+	fn kind_matches_serde_tag() {
+		for container in [
+			Container::Legacy,
+			Container::Cmaf { init: Bytes::new() },
+			Container::Loc,
+		] {
+			let json: serde_json::Value = serde_json::to_value(&container).unwrap();
+			assert_eq!(json["kind"], container.kind());
+		}
+	}
+
+	#[test]
+	fn init_only_for_cmaf() {
+		let init = Bytes::from_static(b"ftyp");
+		assert_eq!(Container::Cmaf { init: init.clone() }.init(), Some(&init));
+		assert_eq!(Container::Legacy.init(), None);
+		assert_eq!(Container::Loc.init(), None);
+	}
+
+	#[test]
+	fn raw_containers_carry_codec_bitstreams() {
+		assert!(Container::Legacy.is_raw());
+		assert!(Container::Loc.is_raw());
+		assert!(!Container::Cmaf { init: Bytes::new() }.is_raw());
 	}
 }

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -9,10 +9,15 @@ use serde::{Deserialize, Serialize};
 /// their own root sections (e.g. `scte35`) by flattening this struct into their own with
 /// `#[serde(flatten)]`. The catalog does not deny unknown fields, so a base consumer ignores the
 /// extra sections and an extended catalog stays wire-compatible. See the `extension_roundtrip` test.
+///
+/// Marked `#[non_exhaustive]` so additional sections can be added without bumping the major
+/// version. External callers start from [`Catalog::default`] and assign the sections they need;
+/// struct-literal construction (with or without `..base`) is not available outside this crate.
 #[serde_with::serde_as]
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct Catalog {
 	/// Video track information with multiple renditions.
 	///

--- a/rs/moq-ffi/src/audio.rs
+++ b/rs/moq-ffi/src/audio.rs
@@ -246,7 +246,7 @@ impl MoqBroadcastConsumer {
 		);
 		cfg.bitrate = catalog_audio.bitrate;
 		cfg.description = catalog_audio.description.map(Into::into);
-		cfg.container = catalog_audio.container.into();
+		cfg.container = catalog_audio.container.try_into()?;
 
 		let consumer = moq_audio::AudioConsumer::new(
 			self.inner(),

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -204,7 +204,7 @@ impl MoqBroadcastConsumer {
 	) -> Result<Arc<MoqMediaConsumer>, MoqError> {
 		// Parse the container before subscribing so we don't leave a dangling
 		// subscription if init parsing fails.
-		let container: hang::catalog::Container = container.into();
+		let container: hang::catalog::Container = container.try_into()?;
 		let media: moq_mux::catalog::hang::Container = (&container)
 			.try_into()
 			.map_err(|e| MoqError::Codec(format!("invalid container: {e}")))?;

--- a/rs/moq-ffi/src/media.rs
+++ b/rs/moq-ffi/src/media.rs
@@ -9,8 +9,13 @@ pub struct MoqDimensions {
 #[derive(Clone, uniffi::Enum)]
 pub enum Container {
 	Legacy,
-	Cmaf { init: Vec<u8> },
+	Cmaf {
+		init: Vec<u8>,
+	},
 	Loc,
+	/// A container this build has no binding for, reported so the rest of the catalog still
+	/// converts. Subscribing to a track that uses it fails.
+	Unknown,
 }
 
 impl From<hang::catalog::Container> for Container {
@@ -19,17 +24,25 @@ impl From<hang::catalog::Container> for Container {
 			hang::catalog::Container::Legacy => Self::Legacy,
 			hang::catalog::Container::Cmaf { init, .. } => Self::Cmaf { init: init.to_vec() },
 			hang::catalog::Container::Loc => Self::Loc,
+			// `hang::catalog::Container` is #[non_exhaustive], so it can gain a variant with no
+			// binding here yet. Report it rather than guessing, and keep the catalog convertible.
+			_ => Self::Unknown,
 		}
 	}
 }
 
-impl From<Container> for hang::catalog::Container {
-	fn from(container: Container) -> Self {
-		match container {
+impl TryFrom<Container> for hang::catalog::Container {
+	type Error = crate::error::MoqError;
+
+	fn try_from(container: Container) -> Result<Self, Self::Error> {
+		Ok(match container {
 			Container::Legacy => Self::Legacy,
 			Container::Cmaf { init } => Self::Cmaf { init: init.into() },
 			Container::Loc => Self::Loc,
-		}
+			Container::Unknown => {
+				return Err(crate::error::MoqError::Codec("unsupported container".into()));
+			}
+		})
 	}
 }
 

--- a/rs/moq-mux/src/catalog/hang/container.rs
+++ b/rs/moq-mux/src/catalog/hang/container.rs
@@ -27,6 +27,9 @@ impl TryFrom<&hang::catalog::Container> for Container {
 			hang::catalog::Container::Legacy => Ok(Self::Legacy),
 			hang::catalog::Container::Cmaf { init, .. } => Ok(Self::Cmaf(fmp4::Wire::from_init(init)?)),
 			hang::catalog::Container::Loc => Ok(Self::Loc),
+			// `hang::catalog::Container` is #[non_exhaustive], so hang can add a container without
+			// breaking this build. Reject it until there's a wire format here to match.
+			_ => Err(crate::Error::UnsupportedContainer),
 		}
 	}
 }

--- a/rs/moq-mux/src/catalog/hang/ext.rs
+++ b/rs/moq-mux/src/catalog/hang/ext.rs
@@ -108,10 +108,10 @@ pub struct Catalog<E: CatalogExt = ()> {
 impl<E: CatalogExt> Catalog<E> {
 	/// The base catalog carrying just the media sections, used to derive the MSF track.
 	pub(crate) fn media(&self) -> hang::Catalog {
-		hang::Catalog {
-			video: self.video.clone(),
-			audio: self.audio.clone(),
-		}
+		let mut catalog = hang::Catalog::default();
+		catalog.video = self.video.clone();
+		catalog.audio = self.audio.clone();
+		catalog
 	}
 }
 

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -624,16 +624,15 @@ mod test {
 		let mut audio_renditions = BTreeMap::new();
 		audio_renditions.insert("audio0".to_string(), audio_config);
 
-		let catalog = hang::Catalog {
-			video: Video {
-				renditions: video_renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			audio: Audio {
-				renditions: audio_renditions,
-			},
+		let mut catalog = hang::Catalog::default();
+		catalog.video = Video {
+			renditions: video_renditions,
+			display: None,
+			rotation: None,
+			flip: None,
+		};
+		catalog.audio = Audio {
+			renditions: audio_renditions,
 		};
 
 		let msf = to_msf(&catalog);
@@ -684,14 +683,12 @@ mod test {
 		let mut video_renditions = BTreeMap::new();
 		video_renditions.insert("video0.m4s".to_string(), video_config);
 
-		let catalog = hang::Catalog {
-			video: Video {
-				renditions: video_renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			..Default::default()
+		let mut catalog = hang::Catalog::default();
+		catalog.video = Video {
+			renditions: video_renditions,
+			display: None,
+			rotation: None,
+			flip: None,
 		};
 
 		let msf = to_msf(&catalog);
@@ -726,14 +723,12 @@ mod test {
 		let mut video_renditions = BTreeMap::new();
 		video_renditions.insert("video0.m4s".to_string(), video_config);
 
-		let catalog = hang::Catalog {
-			video: Video {
-				renditions: video_renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			..Default::default()
+		let mut catalog = hang::Catalog::default();
+		catalog.video = Video {
+			renditions: video_renditions,
+			display: None,
+			rotation: None,
+			flip: None,
 		};
 
 		let msf = to_msf(&catalog);
@@ -766,16 +761,15 @@ mod test {
 		let mut audio_renditions = BTreeMap::new();
 		audio_renditions.insert("audio0".to_string(), audio_config);
 
-		let catalog = hang::Catalog {
-			video: Video {
-				renditions: video_renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			audio: Audio {
-				renditions: audio_renditions,
-			},
+		let mut catalog = hang::Catalog::default();
+		catalog.video = Video {
+			renditions: video_renditions,
+			display: None,
+			rotation: None,
+			flip: None,
+		};
+		catalog.audio = Audio {
+			renditions: audio_renditions,
 		};
 
 		let msf = to_msf(&catalog);
@@ -815,14 +809,12 @@ mod test {
 		let mut video_renditions = BTreeMap::new();
 		video_renditions.insert("video0".to_string(), video_config);
 
-		let catalog = hang::Catalog {
-			video: Video {
-				renditions: video_renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			..Default::default()
+		let mut catalog = hang::Catalog::default();
+		catalog.video = Video {
+			renditions: video_renditions,
+			display: None,
+			rotation: None,
+			flip: None,
 		};
 
 		let msf = to_msf(&catalog);
@@ -844,14 +836,12 @@ mod test {
 		let mut video_renditions = BTreeMap::new();
 		video_renditions.insert("video0".to_string(), video_config);
 
-		let catalog = hang::Catalog {
-			video: Video {
-				renditions: video_renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			..Default::default()
+		let mut catalog = hang::Catalog::default();
+		catalog.video = Video {
+			renditions: video_renditions,
+			display: None,
+			rotation: None,
+			flip: None,
 		};
 
 		let msf = to_msf(&catalog);

--- a/rs/moq-mux/src/container/flv/export.rs
+++ b/rs/moq-mux/src/container/flv/export.rs
@@ -342,7 +342,7 @@ impl Export {
 				continue;
 			}
 			let flavor = video_flavor(config)?;
-			ensure_legacy(&config.container, "video", name)?;
+			ensure_raw(&config.container, "video", name)?;
 			// AV1's av1C is optional in the catalog; synthesize one from the codec
 			// struct so the enhanced SequenceStart tag always has a config record.
 			let fallback_description = match (&config.codec, config.description.as_ref()) {
@@ -376,7 +376,7 @@ impl Export {
 				continue;
 			}
 			let flavor = audio_flavor(config)?;
-			ensure_legacy(&config.container, "audio", name)?;
+			ensure_raw(&config.container, "audio", name)?;
 			let source = ExportSource::for_audio(&self.source, name, config, self.latency)?;
 			let track_id = u8::try_from(self.audio.len()).context("too many FLV audio tracks")?;
 			self.audio.push(FlvTrack {
@@ -639,7 +639,7 @@ fn write_tag(out: &mut BytesMut, tag_type: u8, timestamp_ms: u32, body: &[u8]) -
 	Ok(())
 }
 
-fn ensure_legacy(container: &Container, kind: &str, name: &str) -> anyhow::Result<()> {
+fn ensure_raw(container: &Container, kind: &str, name: &str) -> anyhow::Result<()> {
 	// FLV carries raw codec payloads, so the frames have to be raw codec bitstreams.
 	if !container.is_raw() {
 		anyhow::bail!(

--- a/rs/moq-mux/src/container/flv/export.rs
+++ b/rs/moq-mux/src/container/flv/export.rs
@@ -640,10 +640,15 @@ fn write_tag(out: &mut BytesMut, tag_type: u8, timestamp_ms: u32, body: &[u8]) -
 }
 
 fn ensure_legacy(container: &Container, kind: &str, name: &str) -> anyhow::Result<()> {
-	match container {
-		Container::Legacy | Container::Loc => Ok(()),
-		Container::Cmaf { .. } => anyhow::bail!("FLV export does not support CMAF {kind} track '{name}'"),
+	// FLV carries raw codec payloads, so the frames have to be raw codec bitstreams.
+	if !container.is_raw() {
+		anyhow::bail!(
+			"FLV export requires a raw-codec container: {kind} track '{name}' uses {}",
+			container.kind()
+		);
 	}
+
+	Ok(())
 }
 
 fn is_video_flavor(flavor: Flavor) -> bool {

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -3,7 +3,7 @@ use std::task::Poll;
 use std::time::Duration;
 
 use bytes::Bytes;
-use hang::catalog::{Catalog, Container, VideoConfig};
+use hang::catalog::{Catalog, VideoConfig};
 use mp4_atom::{DecodeMaybe, Encode};
 
 use crate::Result;
@@ -393,11 +393,11 @@ impl<S: Stream> Export<S> {
 				.tracks
 				.get(name)
 				.ok_or_else(|| Error::MissingVideoTrack(name.clone()))?;
-			match &config.container {
-				Container::Cmaf { init, .. } => {
+			match config.container.init() {
+				Some(init) => {
 					extract_init(init, track.track_id, &mut ftyp_data, &mut traks, &mut trexs)?;
 				}
-				Container::Legacy | Container::Loc => {
+				None => {
 					// H.264/H.265 need a synthesized config record here; VP8 has none.
 					let description = track.source.description();
 					let trak = crate::container::fmp4::synthesize_video_trak(
@@ -421,11 +421,11 @@ impl<S: Stream> Export<S> {
 				.tracks
 				.get(name)
 				.ok_or_else(|| Error::MissingAudioTrack(name.clone()))?;
-			match &config.container {
-				Container::Cmaf { init, .. } => {
+			match config.container.init() {
+				Some(init) => {
 					extract_init(init, track.track_id, &mut ftyp_data, &mut traks, &mut trexs)?;
 				}
-				Container::Legacy | Container::Loc => {
+				None => {
 					let trak = crate::container::fmp4::synthesize_audio_trak(track.track_id, track.timescale, config)?;
 					trexs.push(mp4_atom::Trex {
 						track_id: trak.tkhd.track_id,
@@ -659,18 +659,18 @@ fn next_timestamp(frames: &[Frame], successor: Option<&Frame>, index: usize) -> 
 }
 
 pub(crate) fn catalog_timescale_video(config: &VideoConfig) -> u64 {
-	match &config.container {
-		Container::Cmaf { init, .. } => {
+	match config.container.init() {
+		Some(init) => {
 			parse_timescale_from_init(init).unwrap_or_else(|_| crate::container::fmp4::default_video_timescale(config))
 		}
-		Container::Loc | Container::Legacy => crate::container::fmp4::default_video_timescale(config),
+		None => crate::container::fmp4::default_video_timescale(config),
 	}
 }
 
 pub(crate) fn catalog_timescale_audio(config: &hang::catalog::AudioConfig) -> u64 {
-	match &config.container {
-		Container::Cmaf { init, .. } => parse_timescale_from_init(init).unwrap_or(config.sample_rate as u64),
-		Container::Loc | Container::Legacy => config.sample_rate as u64,
+	match config.container.init() {
+		Some(init) => parse_timescale_from_init(init).unwrap_or(config.sample_rate as u64),
+		None => config.sample_rate as u64,
 	}
 }
 

--- a/rs/moq-mux/src/container/fmp4/muxer.rs
+++ b/rs/moq-mux/src/container/fmp4/muxer.rs
@@ -3,7 +3,7 @@
 use std::time::Duration;
 
 use bytes::Bytes;
-use hang::catalog::{AudioConfig, Container as CatalogContainer, VideoConfig};
+use hang::catalog::{AudioConfig, VideoConfig};
 use mp4_atom::Encode;
 
 use crate::catalog::hang::Container as HangContainer;
@@ -144,11 +144,11 @@ impl Muxer {
 			Kind::Audio(config) => &config.container,
 		};
 
-		match container {
-			CatalogContainer::Cmaf { init, .. } => {
+		match container.init() {
+			Some(init) => {
 				extract_init(init, TRACK_ID, &mut ftyp, &mut traks, &mut trexs)?;
 			}
-			CatalogContainer::Legacy | CatalogContainer::Loc => {
+			None => {
 				let trak = match &self.kind {
 					Kind::Video(config) => {
 						synthesize_video_trak(TRACK_ID, self.timescale, config, self.description.as_deref())?

--- a/rs/moq-mux/src/container/mkv/export.rs
+++ b/rs/moq-mux/src/container/mkv/export.rs
@@ -328,7 +328,7 @@ impl<S: Stream> Export<S> {
 			if self.tracks.contains_key(name) {
 				continue;
 			}
-			ensure_legacy(&config.container, "video", name)?;
+			ensure_raw(&config.container, "video", name)?;
 			let source = ExportSource::for_video(&self.source, name, config, self.latency)?;
 			self.tracks.insert(
 				name.clone(),
@@ -347,7 +347,7 @@ impl<S: Stream> Export<S> {
 			if self.tracks.contains_key(name) {
 				continue;
 			}
-			ensure_legacy(&config.container, "audio", name)?;
+			ensure_raw(&config.container, "audio", name)?;
 			let source = ExportSource::for_audio(&self.source, name, config, self.latency)?;
 			self.tracks.insert(
 				name.clone(),
@@ -512,7 +512,7 @@ impl<S: Stream> Export<S> {
 	}
 }
 
-fn ensure_legacy(container: &Container, kind: &str, name: &str) -> Result<()> {
+fn ensure_raw(container: &Container, kind: &str, name: &str) -> Result<()> {
 	// MKV emits raw codec payloads, so it only accepts a container whose frames are raw
 	// codec bitstreams (Legacy varint, LOC properties).
 	if container.is_raw() {

--- a/rs/moq-mux/src/container/mkv/export.rs
+++ b/rs/moq-mux/src/container/mkv/export.rs
@@ -513,16 +513,18 @@ impl<S: Stream> Export<S> {
 }
 
 fn ensure_legacy(container: &Container, kind: &str, name: &str) -> Result<()> {
-	match container {
-		// MKV emits raw codec payloads, so it accepts both wire formats whose
-		// frames are raw codec bitstreams (Legacy varint, LOC properties).
-		Container::Legacy | Container::Loc => Ok(()),
-		Container::Cmaf { .. } => Err(Error::UnsupportedCmafTrack {
-			kind: kind.to_string(),
-			name: name.to_string(),
-		}
-		.into()),
+	// MKV emits raw codec payloads, so it only accepts a container whose frames are raw
+	// codec bitstreams (Legacy varint, LOC properties).
+	if container.is_raw() {
+		return Ok(());
 	}
+
+	Err(Error::UnsupportedContainerTrack {
+		kind: kind.to_string(),
+		name: name.to_string(),
+		container: container.kind().to_string(),
+	}
+	.into())
 }
 
 fn build_video_track_entry(

--- a/rs/moq-mux/src/container/mkv/export_test.rs
+++ b/rs/moq-mux/src/container/mkv/export_test.rs
@@ -421,7 +421,13 @@ async fn export_rejects_cmaf_track() {
 		.expect("exporter timed out");
 
 	let err = result.expect_err("expected an error");
-	assert!(err.to_string().contains("CMAF"), "expected CMAF rejection, got: {err}");
+	assert!(
+		matches!(
+			err,
+			crate::Error::Mkv(crate::container::mkv::Error::UnsupportedContainerTrack { .. })
+		),
+		"expected a non-raw container rejection, got: {err}"
+	);
 }
 
 #[tokio::test(start_paused = true)]

--- a/rs/moq-mux/src/container/mkv/mod.rs
+++ b/rs/moq-mux/src/container/mkv/mod.rs
@@ -70,8 +70,12 @@ pub enum Error {
 	#[error("MKV track layout changed after header was emitted: track '{0}' removed")]
 	HeaderRemovedTrack(String),
 
-	#[error("MKV export does not support CMAF {kind} track '{name}'")]
-	UnsupportedCmafTrack { kind: String, name: String },
+	#[error("MKV export requires a raw-codec container: {kind} track '{name}' uses {container}")]
+	UnsupportedContainerTrack {
+		kind: String,
+		name: String,
+		container: String,
+	},
 
 	#[error("MKV export does not support video codec {0}")]
 	UnsupportedVideoExport(String),

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -1069,11 +1069,15 @@ fn is_complete_section(section: &[u8]) -> bool {
 }
 
 fn ensure_raw(container: &Container, kind: &str, name: &str) -> anyhow::Result<()> {
-	match container {
-		// TS carries raw codec payloads, like the Legacy varint and LOC formats.
-		Container::Legacy | Container::Loc => Ok(()),
-		Container::Cmaf { .. } => anyhow::bail!("TS export does not support CMAF {kind} track '{name}'"),
+	// TS carries raw codec payloads, like the Legacy varint and LOC formats.
+	if !container.is_raw() {
+		anyhow::bail!(
+			"TS export requires a raw-codec container: {kind} track '{name}' uses {}",
+			container.kind()
+		);
 	}
+
+	Ok(())
 }
 
 /// Author a monotonic decode timestamp (DTS) for a reordered (B-frame) video frame.

--- a/rs/moq-mux/src/error.rs
+++ b/rs/moq-mux/src/error.rs
@@ -122,6 +122,11 @@ pub enum Error {
 	/// reserved media section (`video`/`audio`).
 	#[error("reserved catalog section: {0}")]
 	ReservedSection(String),
+
+	/// The catalog's container has no wire format here. [`hang::catalog::Container`] is
+	/// `#[non_exhaustive]`, so it can gain a variant that this crate doesn't handle yet.
+	#[error("unsupported container")]
+	UnsupportedContainer,
 }
 
 impl From<anyhow::Error> for Error {


### PR DESCRIPTION
## Summary

- Mark `hang::catalog::Catalog` and `hang::catalog::Container` `#[non_exhaustive]`. Their siblings (`VideoConfig`, `AudioConfig`, `Timeline`) already are, and both of these are types we know are about to grow: `Catalog` gains root sections for captions (#2280) and ad cues (#2279), `Container` gains a variant for encrypted payloads (#2277). Both fit the documented cases in `rs/CLAUDE.md` (an enum that will realistically gain variants; a struct that will grow with additive defaultable fields, paired with `Default`).
- Rather than sprinkle wildcard arms across `moq-mux`, the nine `Container` matches collapse onto three helpers on hang's side, where the match stays exhaustive and a new variant is a compile error instead of a silent fallthrough. This also de-duplicates the three near-identical `ensure_legacy`/`ensure_raw` guards in the FLV/MKV/TS exporters.

### Caveat worth knowing

`#[non_exhaustive]` buys **source** compatibility when *we* add a variant. It does **not** make the deserializer forward-compatible: `#[serde(tag = "kind")]` still rejects an unknown kind. Verified:

```
serde_json::from_str::<Container>(r#"{"kind":"future"}"#)
  => Err("unknown variant `future`, expected one of `legacy`, `cmaf`, `loc`")
```

So a catalog naming a future container fails to parse rather than arriving as an unknown variant. Making the *wire* forward-compatible is a separate question (and would want a `#[serde(other)]`-shaped escape hatch, which tagged enums with data don't support). Unknown *root sections* already pass through fine, since `Catalog` doesn't deny unknown fields.

## Public API changes

**Breaking (why this targets `dev`):**
- `hang::catalog::Catalog` is now `#[non_exhaustive]`: external struct-literal construction (including `..Default::default()`) no longer compiles. Build via `Catalog::default()` + field assignment.
- `hang::catalog::Container` is now `#[non_exhaustive]`: external `match`es need a wildcard arm. Constructing existing variants is unaffected.
- `moq_mux::container::mkv::Error::UnsupportedCmafTrack { kind, name }` renamed to `UnsupportedContainerTrack { kind, name, container }`. The old name was a latent lie once the guard rejects any non-raw container, and the old message pasted the entire init segment into the error via `{:?}`.
- `impl From<moq_ffi::media::Container> for hang::catalog::Container` is now `TryFrom` (an FFI `Container::Unknown` has no hang equivalent).

**Additive:**
- `hang::catalog::Container::kind() -> &'static str` (the serde `kind` tag; for logs/errors, where the variant payload has no place)
- `hang::catalog::Container::init() -> Option<&Bytes>` (the CMAF init segment, if any)
- `hang::catalog::Container::is_raw() -> bool` (whether frames are raw codec bitstreams)
- `moq_mux::Error::UnsupportedContainer` (enum is already `#[non_exhaustive]`)
- `moq_ffi::media::Container::Unknown` — reported when hang has a variant this build has no binding for, so the rest of the catalog still converts instead of failing wholesale. `MoqError` is `#[uniffi(flat_error)]`, so this needed no new error variant.

Internal only: `moq_mux::catalog::hang::Container::try_from` gains an `UnsupportedContainer` arm; `libmoq` already routed through that fallible path, so it picks the error up for free.

## Cross-package sync

- `js/hang`: **no change needed.** `#[non_exhaustive]` is a Rust compile-time attribute with no TS equivalent, and the JSON format is byte-identical.
- `drafts/draft-lcurley-moq-hang.md`, `doc/concept`: **no change needed.** No wire/format change.
- `rs/libmoq`, `{py,swift,kt,go}/`, `doc/lib/*`: **no change needed** for `Container::Unknown`. The C ABI doesn't expose a container enum (libmoq derives it from the catalog internally), the uniffi bindings regenerate, and no hand-written wrapper matches on `Container` exhaustively (checked py/swift/kt/go; `kt/.../Aliases.kt` only notes it must be referenced as `uniffi.moq.Container`). Swift/Kotlin *consumer* code with an exhaustive switch will need a new arm, which is the intended breaking part.

## Test plan

- `nix develop --command just rs fix` and `just rs check` — clean (exit 0).
- `cargo test --workspace` — clean. `cargo clippy --workspace --all-targets` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean (per the CI-only rustdoc gate).
- New tests in `rs/hang/src/catalog/container.rs`: `kind_matches_serde_tag` (asserts `kind()` tracks the serde tag, which is the whole point of it), `init_only_for_cmaf`, `raw_containers_carry_codec_bitstreams`.
- `export_rejects_cmaf_track` now asserts the error *variant* rather than substring-matching `"CMAF"`, which is what broke under the rename.

Not run: the cross-language interop matrix (`just test smoke-full`). No wire or gateway change, and the FFI delta is one unreachable-today enum variant.

(Written by Claude Opus 4.8)
