### PR TITLE
chore: bump non-Rust package versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -93,7 +93,7 @@
     },
     "js/hang": {
       "name": "@moq/hang",
-      "version": "0.2.14",
+      "version": "0.2.15",
       "dependencies": {
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
         "@libav.js/variant-opus-af": "^6.8.8",
@@ -176,7 +176,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@moq/qmux": "^0.1.3",
         "@moq/signals": "workspace:*",
@@ -196,7 +196,7 @@
     },
     "js/publish": {
       "name": "@moq/publish",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/json": "workspace:^",
@@ -260,7 +260,7 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/json": "workspace:^",

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.2.14",
+	"version": "0.2.15",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"jsr": false,
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/publish/src/video/encoder.test.ts
+++ b/js/publish/src/video/encoder.test.ts
@@ -39,7 +39,7 @@ function installFakeVideoEncoder() {
 
 test("serve tracks encoder config in its child effect", async () => {
 	using _videoEncoder = installFakeVideoEncoder();
-	using warn = spyOn(console, "warn").mockImplementation(() => {});
+	const warn = spyOn(console, "warn").mockImplementation(() => {});
 
 	const frame = new Signal<VideoFrame | undefined>(undefined);
 	const source = new Signal<Source | undefined>(undefined);
@@ -58,5 +58,6 @@ test("serve tracks encoder config in its child effect", async () => {
 	} finally {
 		effect.close();
 		encoder.close();
+		warn.mockRestore();
 	}
 });

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/py/moq-rs/pyproject.toml
+++ b/py/moq-rs/pyproject.toml
@@ -14,7 +14,7 @@ name = "moq-rs"
 # isn't already there (no tag needed; the registry is the gate).
 # Starts at 0.3.0 to open a new line above the old lockstep 0.2.x releases that
 # bundled the bindings.
-version = "0.3.2"
+version = "0.3.3"
 description = "Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization, with a Pythonic API. Import as `moq`."
 readme = "README.md"
 license = "MIT OR Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -103,7 +103,7 @@ source = { editable = "py/moq-ffi" }
 
 [[package]]
 name = "moq-rs"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "py/moq-rs" }
 dependencies = [
     { name = "moq-ffi" },


### PR DESCRIPTION
## Summary

- Bump the affected JavaScript packages with backward-compatible fixes.
- Bump moq-rs for the additive mTLS client options.
- Restore the publish test spy explicitly so Bun 1.2 can run the release checks.

## Public API changes

None in this PR. The version bumps release public API and behavior changes already merged to main.

## Test plan

- `bun install --frozen-lockfile`
- `uv lock --check`
- `bun test js/publish/src/video/encoder.test.ts`
- `just ci` passed JavaScript checks, tests, builds, publint, Biome, and Python Ruff checks. The local native Python build was blocked by the host Xcode license, so GitHub CI is the native-build gate.

(Written by GPT-5)