### PR TITLE
feat(obs): allow b-frames

### DIFF
--- a/cpp/obs/src/moq-dock.cpp
+++ b/cpp/obs/src/moq-dock.cpp
@@ -217,10 +217,8 @@ bool MoQDock::CreateConfiguredEncoders()
 	if (audioBitrate <= 0)
 		audioBitrate = 160;
 
-	// MoQ publishes inline headers (avc3/hev1), so force repeat_headers and no
-	// B-frames, mirroring MoQService::ApplyEncoderSettings.
+	// MoQ publishes inline headers (avc3/hev1), so force repeat_headers
 	obs_data_set_bool(videoSettings, "repeat_headers", true);
-	obs_data_set_int(videoSettings, "bf", 0);
 	obs_data_set_int(audioSettings, "bitrate", audioBitrate);
 
 	videoEncoder =

--- a/cpp/obs/src/moq-service.cpp
+++ b/cpp/obs/src/moq-service.cpp
@@ -28,7 +28,7 @@ obs_properties_t *MoQService::Properties()
 	return ppts;
 }
 
-void MoQService::ApplyEncoderSettings(obs_data_t *video_settings, obs_data_t *audio_settings)
+void MoQService::ApplyEncoderSettings(obs_data_t *video_settings, obs_data_t *)
 {
 	/*
      This function is called to apply custom encoder settings specific to this service.
@@ -39,12 +39,7 @@ void MoQService::ApplyEncoderSettings(obs_data_t *video_settings, obs_data_t *au
 
 	// Example:
 	if (video_settings) {
-		obs_data_set_int(video_settings, "bf", 0);
 		obs_data_set_bool(video_settings, "repeat_headers", true);
-	}
-
-	if (audio_settings) {
-		obs_data_set_int(audio_settings, "bf", 0);
 	}
 }
 


### PR DESCRIPTION
Removes the b-frame limitation. These were force-disabled before.
Tested in firefox, chromium and edge with h264 and av1.