### PR TITLE
feat(capture): macOS window/app/system-audio sources and device enumeration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4178,11 +4178,16 @@ dependencies = [
  "block2",
  "bytes",
  "cpal",
+ "dispatch2",
  "hang",
  "moq-mux",
  "moq-net",
  "objc2",
  "objc2-av-foundation",
+ "objc2-core-audio-types",
+ "objc2-core-media",
+ "objc2-foundation",
+ "objc2-screen-capture-kit",
  "rubato",
  "thiserror 2.0.18",
  "tokio",
@@ -4648,6 +4653,7 @@ dependencies = [
  "objc2",
  "objc2-av-foundation",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-core-media",
  "objc2-core-video",
  "objc2-foundation",
@@ -5348,10 +5354,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.13.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
  "objc2-io-surface",
+ "objc2-metal",
 ]
 
 [[package]]

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -127,7 +127,63 @@ moq --client-connect https://relay.example.com/anon --broadcast cam.hang import 
 moq --client-connect https://relay.example.com/anon --broadcast cam.hang import capture --codec h265
 
 # Capture a display instead of a camera:
-moq --client-connect https://relay.example.com/anon --broadcast screen.hang import capture --screen --no-audio
+moq --client-connect https://relay.example.com/anon --broadcast screen.hang import capture --display --no-audio
+```
+
+### Pick a source
+
+The video source is one of `--camera`, `--display`, `--window`, or `--app`;
+without one, `capture` opens the default camera. `--camera` and `--display` also
+take no value, meaning "the default one".
+
+`moq devices` lists every source and the id each flag expects, so you can read an
+id off it and paste it straight in. It talks only to the local hardware, so it is
+the one verb that takes no MoQ side:
+
+```bash
+moq devices
+```
+
+```
+Cameras:
+  6C707041-05AC-0010-000D-000000000001  FaceTime HD Camera
+
+Displays:
+  0  Display 1 (3456x2234)
+
+Windows:
+  39193  Safari - MoQ Demo (1200x800)
+
+Applications:
+  com.apple.Safari  Safari
+
+Microphones:
+  * MacBook Pro Microphone
+```
+
+```bash
+# A single window, followed as it moves and resizes (macOS only):
+moq --client-connect https://relay.example.com/anon --broadcast win.hang \
+    import capture --window 39193 --no-audio
+
+# Every window of an application, including ones opened later (macOS only):
+moq --client-connect https://relay.example.com/anon --broadcast app.hang \
+    import capture --app com.apple.Safari --no-audio
+
+# A specific display, without the mouse cursor:
+moq --client-connect https://relay.example.com/anon --broadcast screen.hang \
+    import capture --display 1 --no-cursor --no-audio
+```
+
+The audio source is `--microphone` or `--system-audio`, defaulting to the default
+microphone. `--system-audio` captures everything the machine is playing (minus
+this process, so playing the broadcast back doesn't feed itself), which is what
+you usually want next to a screen share:
+
+```bash
+# Share a screen with its sound (macOS only):
+moq --client-connect https://relay.example.com/anon --broadcast screen.hang \
+    import capture --display --system-audio
 ```
 
 On Linux the NVENC (NVIDIA) and VAAPI (Intel/AMD) encoders and the PipeWire
@@ -141,10 +197,16 @@ cargo build --release -p moq-cli --no-default-features \
 ```
 
 Video capture uses a native per-platform backend (AVFoundation on macOS, V4L2 on
-Linux, Media Foundation on Windows). `--screen` captures a display instead:
+Linux, Media Foundation on Windows). `--display` captures a screen instead:
 ScreenCaptureKit on macOS, DXGI Desktop Duplication on Windows, and
 xdg-desktop-portal + PipeWire on Linux (Wayland and X11), where the desktop's
-picker dialog chooses the screen. The Linux screen backend links libpipewire and
+picker dialog chooses the screen (so the display id is ignored there).
+`--window` and `--app` are macOS-only, and `--no-cursor` applies to all three.
+On macOS these capture at the logical resolution, i.e. what the screen looks like
+to its owner rather than its native pixels: a 2x retina display shares as
+1710x1106, not 3420x2214, which keeps the derived bitrate sane. Pass
+`--width`/`--height` to capture native pixels instead.
+The Linux screen backend links libpipewire and
 is behind the default-on `pipewire` feature; drop it (like the codecs above) for
 a build without the dependency. The codec is chosen with `--codec`
 (`h264` default, or `h265`). For H.264 it picks a hardware encoder
@@ -153,8 +215,10 @@ is present, falling back to the built-in software encoder (openh264); force eith
 with `--hardware` / `--software`. H.265 is hardware-only (VideoToolbox on macOS,
 Media Foundation on Windows). `--camera` takes a bare integer as a device index, otherwise a
 device path (Linux) or name (a friendly-name substring on Windows, the
-AVFoundation `uniqueID` on macOS). Audio capture uses cpal (CoreAudio / WASAPI /
-ALSA) and encodes Opus.
+AVFoundation `uniqueID` on macOS). Microphone capture uses cpal (CoreAudio /
+WASAPI / ALSA) and encodes Opus. `--system-audio` is macOS-only: there is no
+loopback input device, so it goes through ScreenCaptureKit (the same API as
+screen capture, and the same Screen Recording permission) rather than cpal.
 
 Alternatively, pipe an external FFmpeg process as MPEG-TS:
 

--- a/rs/moq-audio/Cargo.toml
+++ b/rs/moq-audio/Cargo.toml
@@ -16,12 +16,25 @@ categories = ["multimedia", "multimedia::audio", "multimedia::encoding"]
 doctest = false
 
 [features]
-# Microphone capture via cpal (pure-Rust: CoreAudio / WASAPI / ALSA). Off by
-# default so audio-only consumers (e.g. moq-ffi) don't pull cpal and, on Linux,
-# the ALSA build dependency. On macOS it also pulls AVFoundation for the TCC
-# permission pre-check (the objc deps below are target-gated, so this is a no-op
-# elsewhere).
-capture = ["dep:cpal", "dep:tokio", "dep:tracing", "dep:block2", "dep:objc2", "dep:objc2-av-foundation"]
+# Device capture. Microphones go through cpal (pure-Rust: CoreAudio / WASAPI /
+# ALSA); macOS system audio goes through ScreenCaptureKit, which is where Apple
+# puts it. Off by default so audio-only consumers (e.g. moq-ffi) don't pull cpal
+# and, on Linux, the ALSA build dependency. On macOS it also pulls AVFoundation
+# for the TCC permission pre-check (the objc deps below are target-gated, so this
+# is a no-op elsewhere).
+capture = [
+    "dep:cpal",
+    "dep:tokio",
+    "dep:tracing",
+    "dep:block2",
+    "dep:dispatch2",
+    "dep:objc2",
+    "dep:objc2-av-foundation",
+    "dep:objc2-core-audio-types",
+    "dep:objc2-core-media",
+    "dep:objc2-foundation",
+    "dep:objc2-screen-capture-kit",
+]
 
 [dependencies]
 bytes = "1"
@@ -50,13 +63,20 @@ tracing = { version = "0.1", optional = true }
 # real-time budget.
 unsafe-libopus = "0.2"
 
-# macOS-only: query/request the microphone TCC permission so a denied mic fails
-# fast with a clear error instead of feeding silence into the capture loop. Only
-# pulled in by the `capture` feature (see above); a no-op on other platforms.
+# macOS-only, and only pulled in by the `capture` feature (see above); a no-op on
+# other platforms. AVFoundation queries/requests the microphone TCC permission so
+# a denied mic fails fast instead of feeding silence into the capture loop.
+# ScreenCaptureKit (plus CoreMedia/CoreAudioTypes to read the PCM out of its
+# sample buffers) is how macOS exposes system audio.
 [target.'cfg(target_os="macos")'.dependencies]
 block2 = { version = "0.6.2", optional = true }
+dispatch2 = { version = "0.3.0", optional = true }
 objc2 = { version = "0.6.4", optional = true }
 objc2-av-foundation = { version = "0.3.2", optional = true }
+objc2-core-audio-types = { version = "0.3.2", optional = true }
+objc2-core-media = { version = "0.3.2", optional = true, features = ["CMSampleBuffer", "CMBlockBuffer", "CMSync", "objc2-core-audio-types"] }
+objc2-foundation = { version = "0.3.2", optional = true }
+objc2-screen-capture-kit = { version = "0.3.2", optional = true, features = ["SCStream", "SCShareableContent"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt", "test-util"] }

--- a/rs/moq-audio/src/capture.rs
+++ b/rs/moq-audio/src/capture.rs
@@ -1,11 +1,11 @@
-//! Microphone capture via [`cpal`] (pure-Rust: CoreAudio / WASAPI / ALSA).
+//! Audio capture: a microphone via [`cpal`] (pure-Rust: CoreAudio / WASAPI /
+//! ALSA), or macOS system audio via ScreenCaptureKit.
 //!
-//! [`Microphone`] opens an input device and yields interleaved-`f32` PCM
-//! [`Frame`]s, ready to feed an [`AudioProducer`] with
-//! an [`EncoderInput`] of `format = AudioFormat::F32`.
+//! [`Source`] picks between them and [`publish_capture`] is the turnkey entry
+//! point: it yields interleaved-`f32` PCM and publishes it as an Opus track.
 //! Encoding stays on `unsafe-libopus`, so audio never touches ffmpeg.
 //!
-//! The cpal callback (a realtime thread) forwards buffers through an async
+//! Both backends deliver buffers from a realtime callback through an async
 //! channel that the on-demand capture loop awaits, so dropping the publish
 //! future (e.g. on Ctrl+C) cancels the read and releases the device.
 
@@ -18,35 +18,112 @@ use crate::{AudioError, AudioFormat, AudioProducer, EncoderInput, EncoderOutput,
 
 mod permission;
 
+#[cfg(target_os = "macos")]
+mod screencapture;
+
+/// Where the audio comes from.
+///
+/// The identifiers come from [`devices`]; each listed device's `source()` builds
+/// the matching variant.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Source {
+	/// An audio input device, by the name [`devices`] reports. `None` opens the
+	/// system default input.
+	Microphone(Option<String>),
+
+	/// System (desktop) audio: everything the machine is playing, minus this
+	/// process. macOS only, and it needs the Screen Recording permission, since
+	/// that's the API Apple exposes it through.
+	System,
+}
+
+/// The default microphone, matching the historical `Config::default()`.
+impl Default for Source {
+	fn default() -> Self {
+		Self::Microphone(None)
+	}
+}
+
 /// How long `open` waits for the first buffer before assuming the mic never
 /// started (e.g. permission denied), mirroring the camera path's first-frame
 /// timeout. Without this the capture loop hangs silently forever when macOS TCC
 /// denies microphone access.
 const FIRST_BUFFER_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Microphone capture configuration. All fields are hints; the backend picks
-/// the closest supported mode and the [`AudioProducer`]
-/// resamples to the codec rate anyway.
+/// Audio capture configuration. All fields are hints; the backend picks the
+/// closest supported mode and the [`AudioProducer`] resamples to the codec rate
+/// anyway.
+///
+/// `#[non_exhaustive]`: construct via [`Config::default`] and set fields, so
+/// new options can be added without breaking callers.
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]
 pub struct Config {
-	/// Input device name. `None` opens the system default input.
-	pub device: Option<String>,
+	/// What to capture.
+	pub source: Source,
 	pub sample_rate: Option<u32>,
 	pub channels: Option<u32>,
 }
 
-/// An open microphone, read frame-by-frame via [`read`](Self::read).
+/// An open capture source, read buffer-by-buffer via [`read`](Self::read).
+///
+/// Private: [`publish_capture`] is the entry point, so the per-source backends
+/// stay an implementation detail.
+enum Input {
+	Microphone(Microphone),
+	#[cfg(target_os = "macos")]
+	System(screencapture::SystemAudio),
+}
+
+impl Input {
+	/// The format `config` will capture at, without opening the device, so the
+	/// catalog can be populated before anything turns on.
+	fn format(config: &Config) -> Result<(u32, u32), AudioError> {
+		match &config.source {
+			Source::Microphone(device) => Microphone::format(device.as_deref(), config),
+			#[cfg(target_os = "macos")]
+			Source::System => Ok(screencapture::SystemAudio::format(config.sample_rate, config.channels)),
+			#[cfg(not(target_os = "macos"))]
+			Source::System => Err(AudioError::Unsupported(
+				"system audio capture is only supported on macOS".into(),
+			)),
+		}
+	}
+
+	async fn open(config: &Config) -> Result<Self, AudioError> {
+		match &config.source {
+			Source::Microphone(device) => Ok(Self::Microphone(Microphone::open(device.as_deref(), config).await?)),
+			#[cfg(target_os = "macos")]
+			Source::System => Ok(Self::System(
+				screencapture::SystemAudio::open(config.sample_rate, config.channels).await?,
+			)),
+			#[cfg(not(target_os = "macos"))]
+			Source::System => Err(AudioError::Unsupported(
+				"system audio capture is only supported on macOS".into(),
+			)),
+		}
+	}
+
+	/// Await the next buffer of interleaved `f32` PCM, or `None` once the source
+	/// stops. Cancel-safe: drop the future to release the device.
+	async fn read(&mut self) -> Option<Vec<f32>> {
+		match self {
+			Self::Microphone(mic) => mic.read().await,
+			#[cfg(target_os = "macos")]
+			Self::System(system) => system.read().await,
+		}
+	}
+}
+
+/// An open microphone.
 ///
 /// Holds the live `cpal` stream, which is `!Send`, so build and use it on a
 /// single task. Buffers arrive from the realtime callback over an async channel.
-pub struct Microphone {
+struct Microphone {
 	// Kept alive to keep capturing; dropping it stops the stream.
 	_stream: cpal::Stream,
 	rx: mpsc::UnboundedReceiver<Vec<f32>>,
-	sample_rate: u32,
-	channels: u32,
-	frames_read: u64,
 	/// The first buffer, captured during `open` to surface a permission failure
 	/// as an error rather than a silent hang.
 	pending: Option<Vec<f32>>,
@@ -55,18 +132,18 @@ pub struct Microphone {
 impl Microphone {
 	/// The device's negotiated format `(sample_rate, channels)` without opening
 	/// a stream, so the catalog can be populated before the mic is turned on.
-	pub fn format(config: &Config) -> Result<(u32, u32), AudioError> {
-		let (_, _, stream_config) = resolve(config)?;
+	fn format(device: Option<&str>, config: &Config) -> Result<(u32, u32), AudioError> {
+		let (_, _, stream_config) = resolve(device, config)?;
 		Ok((stream_config.sample_rate, stream_config.channels as u32))
 	}
 
-	/// Open (and start) the microphone described by `config`.
-	pub async fn open(config: &Config) -> Result<Self, AudioError> {
+	/// Open (and start) the requested microphone.
+	async fn open(selector: Option<&str>, config: &Config) -> Result<Self, AudioError> {
 		// Fail fast on a denied/restricted mic (macOS TCC) instead of opening a
 		// stream that silently delivers nothing. A no-op on other platforms.
 		permission::ensure_microphone_access().await?;
 
-		let (device, sample_format, stream_config) = resolve(config)?;
+		let (device, sample_format, stream_config) = resolve(selector, config)?;
 		let sample_rate = stream_config.sample_rate;
 		let channels = stream_config.channels as u32;
 
@@ -124,55 +201,25 @@ impl Microphone {
 		Ok(Self {
 			_stream: stream,
 			rx,
-			sample_rate,
-			channels,
-			frames_read: 0,
 			pending: Some(pending),
 		})
 	}
 
-	pub fn sample_rate(&self) -> u32 {
-		self.sample_rate
-	}
-
-	pub fn channels(&self) -> u32 {
-		self.channels
-	}
-
-	/// Await the next buffer of PCM, or `None` once the stream stops. The
-	/// returned [`Frame`] holds interleaved little-endian `f32` samples (i.e.
-	/// `AudioFormat::F32`). Cancel-safe: drop the future to stop reading.
-	pub async fn read(&mut self) -> Option<Frame> {
-		let samples = match self.pending.take() {
-			Some(samples) => samples,
-			None => self.rx.recv().await?, // stream dropped / device gone
-		};
-		Some(self.frame_from(samples))
-	}
-
-	/// Build a timestamped [`Frame`] from a buffer of interleaved `f32` samples,
-	/// advancing the read cursor so consecutive frames carry monotonic PTS.
-	fn frame_from(&mut self, samples: Vec<f32>) -> Frame {
-		let timestamp_us = self.frames_read * 1_000_000 / self.sample_rate as u64;
-		self.frames_read += (samples.len() / self.channels.max(1) as usize) as u64;
-
-		let mut bytes = Vec::with_capacity(samples.len() * 4);
-		for sample in &samples {
-			bytes.extend_from_slice(&sample.to_le_bytes());
-		}
-
-		Frame {
-			timestamp_us,
-			data: bytes.into(),
+	/// Await the next buffer of interleaved `f32` PCM, or `None` once the stream
+	/// stops. Cancel-safe: drop the future to stop reading.
+	async fn read(&mut self) -> Option<Vec<f32>> {
+		match self.pending.take() {
+			Some(samples) => Some(samples),
+			None => self.rx.recv().await, // stream dropped / device gone
 		}
 	}
 }
 
-/// Capture the microphone on demand and publish it as an Opus moq track named
+/// Capture audio on demand and publish it as an Opus moq track named
 /// `track_name`.
 ///
-/// The catalog rendition is registered up front from the device's reported
-/// format (no capture needed), but the mic only opens while a subscriber is
+/// The catalog rendition is registered up front from the source's reported
+/// format (no capture needed), but the device only opens while a subscriber is
 /// listening and is released when the last one leaves. On resume the timeline
 /// re-anchors (via [`AudioProducer::reset_epoch`]) so the idle gap lands in the
 /// PTS, keeping audio aligned with a wall-clock video track.
@@ -180,7 +227,7 @@ impl Microphone {
 /// The capture-side settings come from [`Config`]; the encode-side settings
 /// (codec, bitrate, frame duration) from [`EncoderOutput`]. Returns when the
 /// broadcast is dropped or the capture loop fails.
-pub async fn publish_microphone(
+pub async fn publish_capture(
 	mut broadcast: moq_net::broadcast::Producer,
 	catalog: moq_mux::catalog::Producer,
 	config: Config,
@@ -188,7 +235,7 @@ pub async fn publish_microphone(
 	output: EncoderOutput,
 	clock: moq_mux::Clock,
 ) -> Result<(), AudioError> {
-	let (sample_rate, channels) = Microphone::format(&config)?;
+	let (sample_rate, channels) = Input::format(&config)?;
 	let input = EncoderInput {
 		format: AudioFormat::F32,
 		sample_rate,
@@ -209,13 +256,13 @@ pub async fn publish_microphone(
 	result
 }
 
-/// Async capture/encode loop: open the mic while a listener is subscribed,
+/// Async capture/encode loop: open the source while a listener is subscribed,
 /// release it when the last one leaves, and re-anchor the timeline on resume so
 /// the idle gap lands in the PTS.
 ///
 /// Cancel safety: every wait is a real `.await` (a buffer read or a demand
-/// transition), so dropping this future (e.g. on Ctrl+C) drops the [`Microphone`]
-/// and stops the cpal stream. No blocking thread is left behind.
+/// transition), so dropping this future (e.g. on Ctrl+C) drops the [`Input`] and
+/// stops the underlying stream. No blocking thread is left behind.
 async fn capture_loop(
 	producer: &mut AudioProducer,
 	track: &moq_net::track::Producer,
@@ -229,36 +276,35 @@ async fn capture_loop(
 			return Ok(());
 		}
 
-		let mut mic = Microphone::open(config).await?;
+		let mut input = Input::open(config).await?;
 
 		loop {
 			// Race the next buffer against the last listener leaving so we release
-			// the mic promptly. `biased` checks demand first so an unwatched track
+			// the device promptly. `biased` checks demand first so an unwatched track
 			// stops before reading another buffer.
-			let frame = tokio::select! {
+			let samples = tokio::select! {
 				biased;
 				res = track.unused() => {
 					if let Err(err) = res {
 						log_track_ended(err);
 						return Ok(());
 					}
-					break; // no listeners: release the mic, then wait for one
+					break; // no listeners: release the device, then wait for one
 				}
-				frame = mic.read() => frame,
+				samples = input.read() => samples,
 			};
 
-			let Some(mut frame) = frame else { break }; // device stopped producing samples
+			let Some(samples) = samples else { break }; // device stopped producing samples
 
 			// Stamp from the shared clock (including any idle gap) so the producer's
 			// epoch re-anchors and audio stays aligned with the video track.
-			frame.timestamp_us = clock.micros();
-			producer.write(&frame)?;
+			producer.write(&frame(samples, clock.micros()))?;
 		}
 
-		// Release the mic and re-anchor so the next frame after resume reflects the gap.
-		drop(mic);
+		// Release the device and re-anchor so the next frame after resume reflects the gap.
+		drop(input);
 		producer.reset_epoch();
-		tracing::info!("no listeners: released microphone");
+		tracing::info!("no listeners: released audio capture");
 	}
 }
 
@@ -279,14 +325,51 @@ fn forward(tx: &mpsc::UnboundedSender<Vec<f32>>, samples: Vec<f32>) {
 	let _ = tx.send(samples);
 }
 
-/// Resolve the input device and its negotiated stream config from `config`.
-fn resolve(config: &Config) -> Result<(cpal::Device, cpal::SampleFormat, cpal::StreamConfig), AudioError> {
+/// An audio input reported by [`devices`].
+#[derive(Clone, Debug)]
+pub struct Device {
+	/// The device name, which is also its identifier: pass it to
+	/// [`Source::Microphone`].
+	pub name: String,
+	/// Whether this is the system default input.
+	pub default: bool,
+}
+
+impl Device {
+	/// The [`Source`] that captures this device.
+	pub fn source(&self) -> Source {
+		Source::Microphone(Some(self.name.clone()))
+	}
+}
+
+/// List the audio inputs.
+pub fn devices() -> Result<Vec<Device>, AudioError> {
 	let host = cpal::default_host();
-	let device = match &config.device {
+	let default = host.default_input_device().map(|d| d.to_string());
+	Ok(host
+		.input_devices()
+		.map_err(cpal_err)?
+		.map(|device| {
+			let name = device.to_string();
+			Device {
+				default: Some(&name) == default.as_ref(),
+				name,
+			}
+		})
+		.collect())
+}
+
+/// Resolve the input device and its negotiated stream config from `config`.
+fn resolve(
+	selector: Option<&str>,
+	config: &Config,
+) -> Result<(cpal::Device, cpal::SampleFormat, cpal::StreamConfig), AudioError> {
+	let host = cpal::default_host();
+	let device = match selector {
 		Some(name) => host
 			.input_devices()
 			.map_err(cpal_err)?
-			.find(|d| d.to_string() == *name)
+			.find(|d| d.to_string() == name)
 			.ok_or_else(|| AudioError::Unsupported(format!("input device {name:?} not found")))?,
 		None => host
 			.default_input_device()
@@ -303,6 +386,19 @@ fn resolve(config: &Config) -> Result<(cpal::Device, cpal::SampleFormat, cpal::S
 		stream_config.channels = channels as u16;
 	}
 	Ok((device, sample_format, stream_config))
+}
+
+/// Pack interleaved `f32` samples into a timestamped [`Frame`] of
+/// little-endian bytes (i.e. `AudioFormat::F32`).
+fn frame(samples: Vec<f32>, timestamp_us: u64) -> Frame {
+	let mut bytes = Vec::with_capacity(samples.len() * size_of::<f32>());
+	for sample in &samples {
+		bytes.extend_from_slice(&sample.to_le_bytes());
+	}
+	Frame {
+		timestamp_us,
+		data: bytes.into(),
+	}
 }
 
 fn stream_err(err: cpal::Error) {

--- a/rs/moq-audio/src/capture/screencapture.rs
+++ b/rs/moq-audio/src/capture/screencapture.rs
@@ -1,0 +1,383 @@
+//! System (desktop) audio capture via ScreenCaptureKit (macOS).
+//!
+//! macOS has no "loopback" input device, so everything the machine is playing is
+//! captured through ScreenCaptureKit: the same API as screen capture, configured
+//! with `capturesAudio` and an audio-only output. The video side of the stream is
+//! still started (SCK has no audio-only mode), so it's pinned to a tiny frame at
+//! a low rate and its samples are dropped.
+//!
+//! Like the mic path, buffers arrive on a dispatch queue and are forwarded to an
+//! async channel, so dropping the capture future releases the stream.
+//!
+//! Not covered by tests: this needs the Screen Recording TCC grant and a real
+//! display, so it can't run headless.
+
+use std::time::Duration;
+
+use block2::RcBlock;
+use dispatch2::{DispatchQueue, DispatchRetained};
+use objc2::rc::Retained;
+use objc2::runtime::ProtocolObject;
+use objc2::{AnyThread, DefinedClass, define_class, msg_send};
+use objc2_core_audio_types::{AudioBuffer, AudioBufferList};
+use objc2_core_media::{CMSampleBuffer, CMTime};
+use objc2_foundation::{NSArray, NSError, NSObject, NSObjectProtocol};
+use objc2_screen_capture_kit::{
+	SCContentFilter, SCShareableContent, SCStream, SCStreamConfiguration, SCStreamDelegate, SCStreamOutput,
+	SCStreamOutputType, SCWindow,
+};
+use tokio::sync::mpsc;
+
+use crate::AudioError;
+
+/// SCK's audio defaults, used when the caller doesn't pin a format.
+const DEFAULT_SAMPLE_RATE: u32 = 48_000;
+const DEFAULT_CHANNELS: u32 = 2;
+
+/// The stream still captures video, so ask for the smallest, slowest frame we
+/// can and never read it.
+const IDLE_VIDEO_SIZE: usize = 2;
+const IDLE_VIDEO_FPS: i32 = 1;
+
+const FIRST_BUFFER_TIMEOUT: Duration = Duration::from_secs(5);
+const ASYNC_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// One delivered buffer: interleaved `f32` PCM plus the channel count SCK
+/// actually used, which `open` checks against the one we asked for.
+struct Buffer {
+	samples: Vec<f32>,
+	channels: u32,
+}
+
+/// An open system-audio capture, read buffer-by-buffer via [`read`](Self::read).
+pub(super) struct SystemAudio {
+	rx: mpsc::UnboundedReceiver<Buffer>,
+	/// The first buffer, captured during [`open`](Self::open) so a missing screen
+	/// recording grant is an error rather than a silent hang.
+	pending: Option<Vec<f32>>,
+	_guard: StreamGuard,
+}
+
+impl SystemAudio {
+	/// The format system audio will be captured at. SCK resamples to whatever we
+	/// ask for, so this is exactly what `config` requested (or the defaults), and
+	/// needs no open.
+	pub(super) fn format(sample_rate: Option<u32>, channels: Option<u32>) -> (u32, u32) {
+		(
+			sample_rate.unwrap_or(DEFAULT_SAMPLE_RATE),
+			channels.unwrap_or(DEFAULT_CHANNELS),
+		)
+	}
+
+	/// Open (and start) system audio capture.
+	pub(super) async fn open(sample_rate: Option<u32>, channels: Option<u32>) -> Result<Self, AudioError> {
+		let (sample_rate, channels) = Self::format(sample_rate, channels);
+
+		// The filter picks which audio is captured; a display filter means
+		// "everything playing on that screen", i.e. the whole system.
+		let content = shareable_content().await?;
+		let displays = unsafe { content.displays() };
+		if displays.count() == 0 {
+			return Err(AudioError::Unsupported(
+				"no display to capture system audio from".into(),
+			));
+		}
+		let display = displays.objectAtIndex(0);
+		let excluded = NSArray::<SCWindow>::new();
+		let filter =
+			unsafe { SCContentFilter::initWithDisplay_excludingWindows(SCContentFilter::alloc(), &display, &excluded) };
+
+		let configuration = unsafe { SCStreamConfiguration::new() };
+		unsafe {
+			configuration.setCapturesAudio(true);
+			configuration.setSampleRate(sample_rate as isize);
+			configuration.setChannelCount(channels as isize);
+			// Otherwise anything we play back ourselves would feed straight back in.
+			configuration.setExcludesCurrentProcessAudio(true);
+			configuration.setWidth(IDLE_VIDEO_SIZE);
+			configuration.setHeight(IDLE_VIDEO_SIZE);
+			configuration.setMinimumFrameInterval(CMTime::new(1, IDLE_VIDEO_FPS));
+		}
+
+		let (tx, mut rx) = mpsc::unbounded_channel::<Buffer>();
+		let delegate = Delegate::new(tx);
+		let dispatch = DispatchQueue::new("dev.moq.audio.system", None);
+
+		let stream = unsafe {
+			SCStream::initWithFilter_configuration_delegate(SCStream::alloc(), &filter, &configuration, None)
+		};
+		unsafe {
+			let proto = ProtocolObject::from_ref(&*delegate);
+			stream
+				.addStreamOutput_type_sampleHandlerQueue_error(proto, SCStreamOutputType::Audio, Some(&dispatch))
+				.map_err(|e| AudioError::Unsupported(format!("add audio output: {e:?}")))?;
+		}
+
+		start_capture(&stream).await?;
+
+		let guard = StreamGuard {
+			stream,
+			_delegate: delegate,
+			_dispatch: dispatch,
+		};
+
+		let pending = match tokio::time::timeout(FIRST_BUFFER_TIMEOUT, rx.recv()).await {
+			Ok(Some(buffer)) => buffer,
+			Ok(None) => {
+				return Err(AudioError::Unsupported(
+					"system audio stopped before any samples".into(),
+				));
+			}
+			Err(_) => {
+				return Err(AudioError::Unsupported(format!(
+					"no system audio within {FIRST_BUFFER_TIMEOUT:?} (screen recording permission?)"
+				)));
+			}
+		};
+
+		// The catalog is built from the requested format before this opens, so a
+		// backend that quietly picked a different layout would hand the encoder
+		// wrong-shaped frames. Fail loudly instead.
+		if pending.channels != channels {
+			return Err(AudioError::Unsupported(format!(
+				"system audio delivered {} channels, not the {channels} requested",
+				pending.channels
+			)));
+		}
+
+		tracing::info!(sample_rate, channels, "opened system audio (ScreenCaptureKit)");
+
+		Ok(Self {
+			rx,
+			pending: Some(pending.samples),
+			_guard: guard,
+		})
+	}
+
+	/// Await the next buffer of interleaved `f32` PCM, or `None` once the stream
+	/// stops. Cancel-safe: drop the future to stop reading.
+	pub(super) async fn read(&mut self) -> Option<Vec<f32>> {
+		match self.pending.take() {
+			Some(samples) => Some(samples),
+			None => Some(self.rx.recv().await?.samples),
+		}
+	}
+}
+
+/// Stops the stream on drop, which also ends the delegate callbacks and so
+/// closes the channel.
+struct StreamGuard {
+	stream: Retained<SCStream>,
+	_delegate: Retained<Delegate>,
+	_dispatch: DispatchRetained<DispatchQueue>,
+}
+
+impl Drop for StreamGuard {
+	fn drop(&mut self) {
+		unsafe { self.stream.stopCaptureWithCompletionHandler(None) };
+	}
+}
+
+/// Pull the PCM out of an audio `CMSampleBuffer` as interleaved `f32`, plus the
+/// channel count it actually carried.
+///
+/// SCK hands back non-interleaved (planar) float samples: one buffer per
+/// channel. Opus wants them interleaved, so weave them here. Returns `None` if
+/// the buffer isn't the float layout we asked for.
+fn samples(sample_buffer: &CMSampleBuffer) -> Option<Buffer> {
+	// An AudioBufferList is variable-length (a flexible array of AudioBuffer), so
+	// ask how big it needs to be, then hand back a buffer of exactly that size.
+	let mut needed = 0usize;
+	let status = unsafe {
+		sample_buffer.audio_buffer_list_with_retained_block_buffer(
+			&mut needed,
+			std::ptr::null_mut(),
+			0,
+			None,
+			None,
+			0,
+			std::ptr::null_mut(),
+		)
+	};
+	if status != 0 || needed == 0 {
+		return None;
+	}
+
+	// Backed by u64, not u8: an AudioBufferList holds a pointer and so needs
+	// 8-byte alignment, which a Vec<u8> only guarantees by accident of the
+	// allocator.
+	let mut storage = vec![0u64; needed.div_ceil(size_of::<u64>())];
+	let list = storage.as_mut_ptr().cast::<AudioBufferList>();
+	// The block buffer owns the sample data, so it has to outlive the reads below.
+	let mut block = std::ptr::null_mut();
+	let status = unsafe {
+		sample_buffer.audio_buffer_list_with_retained_block_buffer(
+			std::ptr::null_mut(),
+			list,
+			needed,
+			None,
+			None,
+			0,
+			&mut block,
+		)
+	};
+	if status != 0 {
+		return None;
+	}
+	// Retained by the call above; take ownership so it's released on return.
+	let _block = unsafe { Retained::from_raw(block) };
+
+	let count = unsafe { (*list).mNumberBuffers } as usize;
+	if count == 0 {
+		return None;
+	}
+	// `mBuffers` is declared as a 1-element array standing in for a C flexible
+	// array member, so walk it as a slice of the real length.
+	let buffers =
+		unsafe { std::slice::from_raw_parts(std::ptr::addr_of!((*list).mBuffers).cast::<AudioBuffer>(), count) };
+
+	let planes: Vec<&[f32]> = buffers
+		.iter()
+		.map(|buffer| {
+			if buffer.mData.is_null() {
+				&[][..]
+			} else {
+				unsafe {
+					std::slice::from_raw_parts(
+						buffer.mData.cast::<f32>(),
+						buffer.mDataByteSize as usize / size_of::<f32>(),
+					)
+				}
+			}
+		})
+		.collect();
+
+	// One buffer means it's already interleaved, and that buffer's own
+	// mNumberChannels says how many are woven in; otherwise it's one plane per
+	// channel and we weave them.
+	if let [only] = buffers {
+		return Some(Buffer {
+			samples: planes[0].to_vec(),
+			channels: only.mNumberChannels,
+		});
+	}
+
+	let frames = planes.iter().map(|plane| plane.len()).min().unwrap_or(0);
+	let mut out = Vec::with_capacity(frames * planes.len());
+	for frame in 0..frames {
+		for plane in &planes {
+			out.push(plane[frame]);
+		}
+	}
+	Some(Buffer {
+		samples: out,
+		channels: planes.len() as u32,
+	})
+}
+
+struct DelegateIvars {
+	/// Dropped when the stream stops, which closes the channel and lets a parked
+	/// `read` return `None` instead of hanging. Behind a lock because the stop and
+	/// the sample callbacks arrive on different queues.
+	tx: std::sync::Mutex<Option<mpsc::UnboundedSender<Buffer>>>,
+}
+
+define_class!(
+	#[unsafe(super(NSObject))]
+	#[name = "MoqAudioSystemDelegate"]
+	#[ivars = DelegateIvars]
+	struct Delegate;
+
+	unsafe impl NSObjectProtocol for Delegate {}
+
+	unsafe impl SCStreamDelegate for Delegate {
+		#[unsafe(method(stream:didStopWithError:))]
+		unsafe fn did_stop(&self, _stream: &SCStream, error: &NSError) {
+			tracing::warn!(error = %error.localizedDescription(), "system audio capture stopped");
+			// Dropping the sender closes the channel, so a parked read returns.
+			self.ivars().tx.lock().unwrap().take();
+		}
+	}
+
+	unsafe impl SCStreamOutput for Delegate {
+		#[unsafe(method(stream:didOutputSampleBuffer:ofType:))]
+		unsafe fn did_output(&self, _stream: &SCStream, sample_buffer: &CMSampleBuffer, kind: SCStreamOutputType) {
+			// The stream also delivers the (unwanted) video frames; ignore them.
+			if kind.0 != SCStreamOutputType::Audio.0 {
+				return;
+			}
+			if let Some(buffer) = samples(sample_buffer) {
+				if let Some(tx) = self.ivars().tx.lock().unwrap().as_ref() {
+					// Send errors mean the reader is gone, i.e. capture is shutting down.
+					let _ = tx.send(buffer);
+				}
+			}
+		}
+	}
+);
+
+impl Delegate {
+	fn new(tx: mpsc::UnboundedSender<Buffer>) -> Retained<Self> {
+		let this = Self::alloc().set_ivars(DelegateIvars {
+			tx: std::sync::Mutex::new(Some(tx)),
+		});
+		unsafe { msg_send![super(this), init] }
+	}
+}
+
+/// Await the async `getShareableContent` to find a display to attach to.
+async fn shareable_content() -> Result<Retained<SCShareableContent>, AudioError> {
+	let (tx, rx) = tokio::sync::oneshot::channel::<Result<SendObj<SCShareableContent>, String>>();
+	let tx = std::sync::Mutex::new(Some(tx));
+	let handler = RcBlock::new(move |content: *mut SCShareableContent, error: *mut NSError| {
+		let result = match unsafe { Retained::retain(content) } {
+			Some(content) => Ok(SendObj(content)),
+			None => Err(error_message(error)),
+		};
+		if let Some(tx) = tx.lock().unwrap().take() {
+			let _ = tx.send(result);
+		}
+	});
+	unsafe { SCShareableContent::getShareableContentWithCompletionHandler(&handler) };
+
+	match tokio::time::timeout(ASYNC_TIMEOUT, rx).await {
+		Ok(Ok(Ok(content))) => Ok(content.0),
+		Ok(Ok(Err(msg))) => Err(AudioError::Unsupported(format!("shareable content: {msg}"))),
+		Ok(Err(_)) => Err(AudioError::Unsupported("shareable content handler dropped".into())),
+		Err(_) => Err(AudioError::Unsupported(
+			"timed out listing shareable content (screen recording permission?)".into(),
+		)),
+	}
+}
+
+/// Await the async `startCapture`, surfacing any error.
+async fn start_capture(stream: &SCStream) -> Result<(), AudioError> {
+	let (tx, rx) = tokio::sync::oneshot::channel::<Option<String>>();
+	let tx = std::sync::Mutex::new(Some(tx));
+	let handler = RcBlock::new(move |error: *mut NSError| {
+		let result = (!error.is_null()).then(|| error_message(error));
+		if let Some(tx) = tx.lock().unwrap().take() {
+			let _ = tx.send(result);
+		}
+	});
+	unsafe { stream.startCaptureWithCompletionHandler(Some(&handler)) };
+
+	match tokio::time::timeout(ASYNC_TIMEOUT, rx).await {
+		Ok(Ok(None)) => Ok(()),
+		Ok(Ok(Some(msg))) => Err(AudioError::Unsupported(format!("start system audio: {msg}"))),
+		Ok(Err(_)) => Err(AudioError::Unsupported("start-capture handler dropped".into())),
+		Err(_) => Err(AudioError::Unsupported("timed out starting system audio".into())),
+	}
+}
+
+fn error_message(error: *mut NSError) -> String {
+	match unsafe { error.as_ref() } {
+		Some(error) => error.localizedDescription().to_string(),
+		None => "unknown error".to_string(),
+	}
+}
+
+/// Carries a `Retained` from the completion handler's queue to the awaiting
+/// task. The objc object is reference-counted and safe to move between threads.
+struct SendObj<T>(Retained<T>);
+unsafe impl<T> Send for SendObj<T> {}

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -42,7 +42,7 @@ transcode = ["dep:moq-transcode", "dep:moq-video"]
 nvenc = ["moq-video?/nvenc", "moq-transcode?/nvenc"]
 vaapi = ["moq-video?/vaapi", "moq-transcode?/vaapi"]
 nvdec = ["moq-video?/nvdec", "moq-transcode?/nvdec"]
-# Screen capture for `capture --screen` on Linux (xdg-desktop-portal + PipeWire),
+# Screen capture for `capture --display` on Linux (xdg-desktop-portal + PipeWire),
 # on by default like the hardware codecs above and trimmable the same way. Only
 # bites when `capture` pulls in moq-video; links libpipewire-0.3 at build time.
 pipewire = ["moq-video?/pipewire"]

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -8,6 +8,9 @@
 //! - `import` routes media INTO MoQ from one source; `export` routes it OUT to
 //!   one sink. The verb fixes the data direction (and thus, for the
 //!   bidirectional gateways, whether `--connect`/`--listen` push or pull).
+//! - `devices` touches no network at all, so it's the one verb that takes no MoQ
+//!   side. That's why the requirement is enforced per-verb ([`MoqSide::validate`])
+//!   rather than by clap: an `ArgGroup` can't be conditional on the subcommand.
 //! - The endpoint is one subcommand: a container format (`ts`, `fmp4`, ... read
 //!   from stdin on import, written to stdout on export) or a gateway (`hls`,
 //!   `rtmp`, `srt`, `rtc`). Exactly one per invocation, so "which endpoint" is
@@ -32,15 +35,18 @@ pub struct Cli {
 	#[command(flatten)]
 	pub moq: MoqSide,
 
-	/// The routing direction and endpoint.
+	/// The verb and endpoint.
 	#[command(subcommand)]
-	pub direction: Direction,
+	pub command: Command,
 }
 
 /// The MoQ attachment. At least one of `--client-connect` / `--server-bind`;
 /// both may be given at once.
+///
+/// The group is not `required`, because `devices` runs without a MoQ side. Every
+/// verb that does need one calls [`validate`](Self::validate).
 #[derive(Args, Clone)]
-#[command(group = ArgGroup::new("moq").required(true).multiple(true).args(["client-connect", "server-bind"]))]
+#[command(group = ArgGroup::new("moq").multiple(true).args(["client-connect", "server-bind"]))]
 pub struct MoqSide {
 	/// The broadcast name. Optional for the point endpoints (stdin/stdout, HLS
 	/// import, and the `--connect` dials), which default to the root broadcast at
@@ -63,9 +69,34 @@ pub struct MoqSide {
 	pub iroh: moq_native::iroh::EndpointConfig,
 }
 
-/// The data direction: the pivot between the MoQ side and the endpoint.
+impl MoqSide {
+	/// Reject a verb that needs the MoQ network but was given no way to reach it.
+	/// Stands in for the clap `required` the `moq` group can't carry, since
+	/// `devices` is exempt.
+	pub fn validate(&self) -> anyhow::Result<()> {
+		anyhow::ensure!(
+			self.client.connect.is_some() || self.server.bind.is_some(),
+			"a MoQ side is required: pass --client-connect <url> to dial a relay, or --server-bind <addr> to self-host"
+		);
+		Ok(())
+	}
+
+	/// Reject the MoQ flags on a verb that never touches the network, rather than
+	/// silently ignoring them. Only `devices` qualifies, hence the gate.
+	#[cfg(feature = "capture")]
+	pub fn reject(&self, command: &str) -> anyhow::Result<()> {
+		anyhow::ensure!(
+			self.client.connect.is_none() && self.server.bind.is_none(),
+			"`{command}` runs locally and takes no MoQ side; drop --client-connect / --server-bind"
+		);
+		Ok(())
+	}
+}
+
+/// The verb: for `import`/`export` it is also the data direction, the pivot
+/// between the MoQ side and the endpoint.
 #[derive(Subcommand, Clone)]
-pub enum Direction {
+pub enum Command {
 	/// Route media INTO MoQ from one source.
 	#[command(alias = "publish")]
 	Import(Import),
@@ -76,6 +107,9 @@ pub enum Direction {
 	/// only encoded while watched (just-in-time).
 	#[cfg(feature = "transcode")]
 	Transcode(crate::transcode::Args),
+	/// List the capture devices `import capture` can name.
+	#[cfg(feature = "capture")]
+	Devices,
 }
 
 // ------------------------------------------------------------------ import
@@ -108,7 +142,8 @@ pub enum ImportSource {
 	Srt(crate::srt::Args),
 	/// WebRTC: WHEP client pulling a remote (`--connect`) or WHIP server accepting publishes (`--listen`).
 	Rtc(crate::rtc::Args),
-	/// Capture the camera/microphone (or screen) and encode natively.
+	/// Capture a local source (camera, display, window, app, microphone) and
+	/// encode natively. Run `moq devices` to list them.
 	#[cfg(feature = "capture")]
 	Capture(crate::publish::CaptureArgs),
 }

--- a/rs/moq-cli/src/devices.rs
+++ b/rs/moq-cli/src/devices.rs
@@ -1,0 +1,108 @@
+//! `moq devices`: list what the capture flags can name.
+//!
+//! Each section prints the identifier `moq import capture` expects in the first
+//! column, so the output can be read and pasted straight into `--camera`,
+//! `--display`, `--window`, `--app`, or `--microphone`.
+
+use std::fmt::Write;
+
+/// Print every capture source this platform can enumerate.
+///
+/// A source that this platform doesn't implement is reported inline rather than
+/// failing the whole listing: a Linux box with no window enumeration should
+/// still get its cameras.
+pub async fn run() -> anyhow::Result<()> {
+	let mut out = String::new();
+
+	section(
+		&mut out,
+		"Cameras",
+		moq_video::capture::cameras().await,
+		|out, cameras| {
+			for camera in cameras {
+				writeln!(out, "  {}  {}", camera.id, camera.name).unwrap();
+			}
+		},
+	);
+
+	section(
+		&mut out,
+		"Displays",
+		moq_video::capture::displays().await,
+		|out, displays| {
+			for display in displays {
+				writeln!(
+					out,
+					"  {}  {} ({}x{})",
+					display.id, display.name, display.width, display.height
+				)
+				.unwrap();
+			}
+		},
+	);
+
+	section(
+		&mut out,
+		"Windows",
+		moq_video::capture::windows().await,
+		|out, windows| {
+			for window in windows {
+				let title = if window.title.is_empty() {
+					"(untitled)"
+				} else {
+					&window.title
+				};
+				writeln!(
+					out,
+					"  {}  {} - {} ({}x{})",
+					window.id, window.app, title, window.width, window.height
+				)
+				.unwrap();
+			}
+		},
+	);
+
+	section(
+		&mut out,
+		"Applications",
+		moq_video::capture::apps().await,
+		|out, apps| {
+			for app in apps {
+				writeln!(out, "  {}  {}", app.id, app.name).unwrap();
+			}
+		},
+	);
+
+	section(
+		&mut out,
+		"Microphones",
+		moq_audio::capture::devices(),
+		|out, devices| {
+			for device in devices {
+				// The default is what `--microphone` picks when omitted, so mark it.
+				let marker = if device.default { "*" } else { " " };
+				writeln!(out, "  {marker} {}", device.name).unwrap();
+			}
+		},
+	);
+
+	print!("{out}");
+	Ok(())
+}
+
+/// Render one section: its items, the reason it's empty, or why this platform
+/// can't list it.
+fn section<T, E: std::fmt::Display>(
+	out: &mut String,
+	title: &str,
+	result: Result<Vec<T>, E>,
+	render: impl FnOnce(&mut String, &[T]),
+) {
+	writeln!(out, "{title}:").unwrap();
+	match result {
+		Ok(items) if items.is_empty() => writeln!(out, "  (none)").unwrap(),
+		Ok(items) => render(out, &items),
+		Err(err) => writeln!(out, "  ({err})").unwrap(),
+	}
+	writeln!(out).unwrap();
+}

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -5,6 +5,8 @@
 //! selected endpoint.
 
 mod args;
+#[cfg(feature = "capture")]
+mod devices;
 mod hls;
 mod moq;
 mod publish;
@@ -16,7 +18,7 @@ mod subscribe;
 mod transcode;
 mod web;
 
-use args::{Cli, Direction, Export, ExportSink, Import, ImportSource, MoqSide};
+use args::{Cli, Command, Export, ExportSink, Import, ImportSource, MoqSide};
 use hang::moq_net;
 use publish::Publish;
 use subscribe::{Subscribe, SubscribeArgs};
@@ -60,16 +62,28 @@ async fn main() -> anyhow::Result<()> {
 	let cli = Cli::parse();
 	cli.log.init()?;
 
+	// `devices` only talks to the local hardware, so answer it before binding any
+	// transport.
+	#[cfg(feature = "capture")]
+	if matches!(cli.command, Command::Devices) {
+		cli.moq.reject("devices")?;
+		return devices::run().await;
+	}
+
+	cli.moq.validate()?;
+
 	let net = Net {
 		#[cfg(feature = "iroh")]
 		iroh: cli.moq.iroh.clone().bind(&cli.moq.client.quic).await?,
 	};
 
-	match cli.direction {
-		Direction::Import(import) => run_import(cli.moq, import, net).await,
-		Direction::Export(export) => run_export(cli.moq, export, net).await,
+	match cli.command {
+		Command::Import(import) => run_import(cli.moq, import, net).await,
+		Command::Export(export) => run_export(cli.moq, export, net).await,
 		#[cfg(feature = "transcode")]
-		Direction::Transcode(args) => transcode::run(cli.moq, args, net).await,
+		Command::Transcode(args) => transcode::run(cli.moq, args, net).await,
+		#[cfg(feature = "capture")]
+		Command::Devices => unreachable!("handled above, before the transport is bound"),
 	}
 }
 

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -35,24 +35,45 @@ impl From<VideoCodec> for moq_video::encode::Codec {
 	}
 }
 
-/// Device capture options. Video (camera -> H.264/H.265) maps to `moq-video`;
-/// audio (microphone -> Opus) to `moq-audio`. Both are captured by default; use
-/// `--no-video` / `--no-audio` to publish only one.
+/// Device capture options. Video (camera/screen -> H.264/H.265) maps to
+/// `moq-video`; audio (microphone/system -> Opus) to `moq-audio`. Both are
+/// captured by default; use `--no-video` / `--no-audio` to publish only one.
+///
+/// The video source is one of `--camera` / `--display` / `--window` / `--app`,
+/// and the audio source one of `--microphone` / `--system-audio`, defaulting to
+/// the default camera and microphone. Run `moq devices` to list the ids each one
+/// takes.
 #[cfg(feature = "capture")]
 #[derive(clap::Args, Clone)]
+#[command(group = clap::ArgGroup::new("video-source").multiple(false))]
+#[command(group = clap::ArgGroup::new("audio-source").multiple(false))]
 pub struct CaptureArgs {
-	/// Camera device. Platform-specific: an AVFoundation `uniqueID` on macOS, or
-	/// a camera index / `/dev/videoN` path on Linux. Omit to use the default
-	/// camera. Ignored with `--screen`.
-	#[arg(long, conflicts_with = "screen")]
-	pub camera: Option<String>,
+	/// Capture a camera, by the id `moq devices` reports (an AVFoundation
+	/// `uniqueID` on macOS, a camera index / `/dev/videoN` path elsewhere).
+	/// Bare `--camera`, or no source flag at all, opens the default camera.
+	#[arg(long, num_args = 0..=1, group = "video-source")]
+	pub camera: Option<Option<String>>,
 
-	/// Capture a display (whole screen) instead of a camera. On Linux the
-	/// desktop portal opens a picker dialog to choose the screen.
+	/// Capture a whole display, by the index `moq devices` reports. Bare
+	/// `--display` captures the main display. On Linux the desktop portal opens a
+	/// picker dialog and the index is ignored.
+	#[arg(long, num_args = 0..=1, group = "video-source", alias = "screen")]
+	pub display: Option<Option<String>>,
+
+	/// Capture a single window, by the id `moq devices` reports. macOS only.
+	#[arg(long, group = "video-source")]
+	pub window: Option<String>,
+
+	/// Capture every window of an application, by the bundle id `moq devices`
+	/// reports. Windows opened later are included. macOS only.
+	#[arg(long, group = "video-source")]
+	pub app: Option<String>,
+
+	/// Hide the mouse cursor. Display/window/app capture only.
 	#[arg(long)]
-	pub screen: bool,
+	pub no_cursor: bool,
 
-	/// Requested capture width. The camera snaps to its nearest supported mode.
+	/// Requested capture width. The source snaps to its nearest supported mode.
 	#[arg(long)]
 	pub width: Option<u32>,
 
@@ -60,7 +81,7 @@ pub struct CaptureArgs {
 	#[arg(long)]
 	pub height: Option<u32>,
 
-	/// Capture/encode framerate. Omit to use the camera's reported rate.
+	/// Capture/encode framerate. Omit to use the source's reported rate.
 	#[arg(long)]
 	pub fps: Option<u32>,
 
@@ -80,20 +101,27 @@ pub struct CaptureArgs {
 	#[arg(long)]
 	pub software: bool,
 
-	/// Microphone device name. Omit to use the default input.
-	#[arg(long)]
-	pub microphone: Option<String>,
+	/// Capture a microphone, by the name `moq devices` reports. Bare
+	/// `--microphone`, or no audio source flag, opens the default input.
+	#[arg(long, num_args = 0..=1, group = "audio-source")]
+	pub microphone: Option<Option<String>>,
+
+	/// Capture the system (desktop) audio instead of a microphone: everything the
+	/// machine is playing, minus this process. macOS only, and it needs the Screen
+	/// Recording permission.
+	#[arg(long, group = "audio-source")]
+	pub system_audio: bool,
 
 	/// Target audio bitrate in bits per second (Opus). Omit for the codec default.
 	#[arg(long)]
 	pub audio_bitrate: Option<u32>,
 
 	/// Capture audio only (no camera).
-	#[arg(long, conflicts_with = "no_audio")]
+	#[arg(long, conflicts_with = "no_audio", conflicts_with = "video-source")]
 	pub no_video: bool,
 
 	/// Capture video only (no microphone).
-	#[arg(long)]
+	#[arg(long, conflicts_with = "audio-source")]
 	pub no_audio: bool,
 }
 
@@ -304,11 +332,11 @@ impl Publish {
 					let broadcast = self.broadcast.clone();
 					async move {
 						match audio {
-							Some((config, output)) => moq_audio::capture::publish_microphone(
-								broadcast, catalog, config, "audio", output, clock,
-							)
-							.await
-							.map_err(anyhow::Error::from),
+							Some((config, output)) => {
+								moq_audio::capture::publish_capture(broadcast, catalog, config, "audio", output, clock)
+									.await
+									.map_err(anyhow::Error::from)
+							}
 							None => Ok(()),
 						}
 					}
@@ -323,16 +351,30 @@ impl Publish {
 
 #[cfg(feature = "capture")]
 impl CaptureArgs {
+	/// The video source named by the flags, defaulting to the default camera.
+	/// The `video-source` arg group makes these mutually exclusive, so the order
+	/// here only decides the default.
+	fn video_source(&self) -> moq_video::capture::Source {
+		use moq_video::capture::Source;
+
+		if let Some(id) = &self.window {
+			Source::Window(id.clone())
+		} else if let Some(id) = &self.app {
+			Source::App(id.clone())
+		} else if let Some(index) = &self.display {
+			Source::Display(index.clone())
+		} else {
+			Source::Camera(self.camera.clone().flatten())
+		}
+	}
+
 	fn video_config(&self) -> moq_video::capture::Config {
 		let mut config = moq_video::capture::Config::default();
-		if self.screen {
-			config.source = moq_video::capture::Source::Display;
-		} else {
-			config.device = self.camera.clone();
-		}
+		config.source = self.video_source();
 		config.width = self.width;
 		config.height = self.height;
 		config.framerate = self.fps;
+		config.cursor = !self.no_cursor;
 		config
 	}
 
@@ -350,9 +392,21 @@ impl CaptureArgs {
 		options
 	}
 
+	/// The audio source named by the flags, defaulting to the default
+	/// microphone. The `audio-source` arg group makes these mutually exclusive.
+	fn audio_source(&self) -> moq_audio::capture::Source {
+		use moq_audio::capture::Source;
+
+		if self.system_audio {
+			Source::System
+		} else {
+			Source::Microphone(self.microphone.clone().flatten())
+		}
+	}
+
 	fn audio_config(&self) -> moq_audio::capture::Config {
 		let mut config = moq_audio::capture::Config::default();
-		config.device = self.microphone.clone();
+		config.source = self.audio_source();
 		config
 	}
 

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -104,6 +104,7 @@ dispatch2 = "0.3.1"
 objc2 = "0.6.4"
 objc2-av-foundation = "0.3.2"
 objc2-core-foundation = "0.3.2"
+objc2-core-graphics = { version = "0.3.2", features = ["CGDirectDisplay"] }
 objc2-core-media = "0.3.2"
 objc2-core-video = "0.3.2"
 objc2-foundation = "0.3.2"

--- a/rs/moq-video/src/capture/avfoundation.rs
+++ b/rs/moq-video/src/capture/avfoundation.rs
@@ -22,7 +22,7 @@ use objc2_core_media::CMSampleBuffer;
 use objc2_foundation::{NSObject, NSObjectProtocol, NSString};
 
 use super::surface::surface_frame;
-use super::{Config, FrameChannel, FrameStream};
+use super::{Camera, Config, FrameChannel, FrameStream};
 use crate::Error;
 
 /// How long `open` waits for the first frame before assuming the camera never
@@ -33,8 +33,28 @@ const FIRST_FRAME_TIMEOUT: Duration = Duration::from_secs(5);
 /// first time capture runs.
 const ACCESS_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Open the default (or configured) camera and stream its frames.
-pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
+/// List the cameras. Unlike capture, enumeration needs no TCC grant: an
+/// unauthorized process still sees the devices, just not their frames.
+pub(super) fn cameras() -> Result<Vec<Camera>, Error> {
+	let media = unsafe { AVMediaTypeVideo }.ok_or_else(|| Error::Codec(anyhow::anyhow!("AVMediaTypeVideo")))?;
+	// The suggested replacement, AVCaptureDeviceDiscoverySession, has to be handed
+	// an explicit list of device types, and the constants for external and
+	// Continuity cameras are macOS 14+. Naming them would drop those cameras on
+	// older systems (or miss a symbol); this returns every video device on every
+	// version, which is exactly what listing wants.
+	#[allow(deprecated)]
+	let devices = unsafe { AVCaptureDevice::devicesWithMediaType(media) };
+	Ok((0..devices.count())
+		.map(|index| devices.objectAtIndex(index))
+		.map(|device| Camera {
+			id: unsafe { device.uniqueID() }.to_string(),
+			name: unsafe { device.localizedName() }.to_string(),
+		})
+		.collect())
+}
+
+/// Open the default (or requested) camera and stream its frames.
+pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameStream, Error> {
 	let media = unsafe { AVMediaTypeVideo }.ok_or_else(|| Error::Codec(anyhow::anyhow!("AVMediaTypeVideo")))?;
 
 	// Gate on camera authorization before opening the device, so an unauthorized
@@ -42,7 +62,7 @@ pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
 	// first-frame timeout.
 	ensure_camera_access(media).await?;
 
-	let device = match &config.device {
+	let device = match device {
 		Some(id) => {
 			let id = NSString::from_str(id);
 			unsafe { AVCaptureDevice::deviceWithUniqueID(&id) }
@@ -51,6 +71,13 @@ pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
 		None => unsafe { AVCaptureDevice::defaultDeviceWithMediaType(media) }
 			.ok_or_else(|| Error::Codec(anyhow::anyhow!("no default camera")))?,
 	};
+
+	// Honoring these means picking an `activeFormat` and locking a frame
+	// duration, which this backend doesn't do yet. Say so rather than letting the
+	// camera quietly come up at its default mode.
+	if config.width.is_some() || config.height.is_some() || config.framerate.is_some() {
+		tracing::warn!("width/height/framerate are ignored for camera capture on macOS; using the device default");
+	}
 	let device_id = unsafe { device.uniqueID() }.to_string();
 
 	let input = unsafe { AVCaptureDeviceInput::deviceInputWithDevice_error(&device) }

--- a/rs/moq-video/src/capture/desktopduplication.rs
+++ b/rs/moq-video/src/capture/desktopduplication.rs
@@ -38,13 +38,15 @@ fn err(ctx: &str, e: windows::core::Error) -> Error {
 }
 
 /// Open a display capture and stream its frames over a pump thread.
-pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
+pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameStream, Error> {
 	let config = config.clone();
+	// The device opens on the pump thread, so the selector has to be owned.
+	let device = device.map(str::to_string);
 	let chan = FrameChannel::new();
 	let (geo, guard) = pump::spawn(
 		chan.clone(),
 		move || {
-			let cap = Duplicator::open(&config)?;
+			let cap = Duplicator::open(&config, device.as_deref())?;
 			let geometry = Geometry {
 				width: cap.width,
 				height: cap.height,
@@ -91,7 +93,7 @@ struct Duplicator {
 }
 
 impl Duplicator {
-	fn open(config: &Config) -> Result<Self, Error> {
+	fn open(config: &Config, selector: Option<&str>) -> Result<Self, Error> {
 		let device = d3d11::create_device()?;
 		let context = unsafe {
 			device
@@ -99,7 +101,7 @@ impl Duplicator {
 				.map_err(|e| err("GetImmediateContext", e))?
 		};
 
-		let index = select_output(config)?;
+		let index = select_output(selector)?;
 		let output = enumerate_output(&device, index)?;
 		let device_name = format!("display:{index}");
 		let dupl = duplicate(&output, &device)?;
@@ -280,8 +282,8 @@ impl Drop for UnmapGuard<'_> {
 
 /// Which monitor to capture: a bare index or the `display:{index}` form that
 /// [`FrameStream::device`](super::FrameStream) reports; `None` is the first one.
-fn select_output(config: &Config) -> Result<u32, Error> {
-	match config.device.as_deref() {
+fn select_output(selector: Option<&str>) -> Result<u32, Error> {
+	match selector {
 		None => Ok(0),
 		Some(spec) => spec
 			.strip_prefix("display:")
@@ -324,7 +326,7 @@ mod tests {
 	#[test]
 	#[ignore]
 	fn duplicates_primary_display() {
-		let mut cap = match Duplicator::open(&Config::default()) {
+		let mut cap = match Duplicator::open(&Config::default(), None) {
 			Ok(cap) => cap,
 			Err(e) => {
 				eprintln!("skipping: no Desktop Duplication available: {e}");

--- a/rs/moq-video/src/capture/mediafoundation.rs
+++ b/rs/moq-video/src/capture/mediafoundation.rs
@@ -33,13 +33,15 @@ use crate::frame::d3d11::Texture;
 use crate::frame::{Frame, I420};
 
 /// Open a Media Foundation camera and stream its frames over a pump thread.
-pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
+pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameStream, Error> {
 	let config = config.clone();
+	// The device opens on the pump thread, so the selector has to be owned.
+	let device = device.map(str::to_string);
 	let chan = FrameChannel::new();
 	let (geo, guard) = pump::spawn(
 		chan.clone(),
 		move || {
-			let camera = Camera::open(&config)?;
+			let camera = Camera::open(&config, device.as_deref())?;
 			let geometry = Geometry {
 				width: camera.width,
 				height: camera.height,
@@ -83,9 +85,9 @@ struct Camera {
 }
 
 impl Camera {
-	fn open(config: &Config) -> Result<Self, Error> {
+	fn open(config: &Config, selector: Option<&str>) -> Result<Self, Error> {
 		let com = ComGuard::new()?;
-		let (source, device_name) = open_source(config)?;
+		let (source, device_name) = open_source(selector)?;
 
 		// Try for a GPU device; fall back to the CPU video processor if it (or any
 		// of its setup) fails, e.g. on a headless VM with no D3D11 hardware.
@@ -323,11 +325,11 @@ enum Selector {
 	Name(String),
 }
 
-/// Enumerate video capture devices and activate the one matching `config.device`
+/// Enumerate video capture devices and activate the one matching `selector`
 /// (a bare integer selects by index, anything else is a friendly-name substring;
 /// `None` opens index 0).
-fn open_source(config: &Config) -> Result<(IMFMediaSource, String), Error> {
-	let selector = match config.device.as_deref() {
+fn open_source(selector: Option<&str>) -> Result<(IMFMediaSource, String), Error> {
+	let selector = match selector {
 		None => Selector::Index(0),
 		Some(spec) => match spec.parse::<usize>() {
 			Ok(i) => Selector::Index(i),

--- a/rs/moq-video/src/capture/mod.rs
+++ b/rs/moq-video/src/capture/mod.rs
@@ -56,16 +56,137 @@ mod desktopduplication;
 #[cfg(any(target_os = "linux", target_os = "windows"))]
 mod pump;
 
-/// What to capture.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// What to capture. Each variant carries the identifier that selects it, so a
+/// window can't be captured without saying which one, and a camera id can't
+/// reach the display backend.
+///
+/// The identifiers come from [`cameras`], [`displays`], [`windows`], and
+/// [`apps`]; each listed item's `source()` builds the matching variant.
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Source {
-	/// A camera / webcam.
-	#[default]
-	Camera,
-	/// A display (whole-screen capture). macOS, Windows, and Linux (behind the
-	/// `pipewire` feature; the xdg-desktop-portal picker chooses the screen).
-	Display,
+	/// A camera / webcam. `None` opens the default camera.
+	///
+	/// macOS takes an AVFoundation `uniqueID`; other platforms take a bare
+	/// integer (`"0"`) as an index, else a device path/name.
+	Camera(Option<String>),
+
+	/// A whole display. `None` opens the main display.
+	///
+	/// The id is a bare display index. macOS and Windows honor it; on Linux the
+	/// xdg-desktop-portal picker owns selection and the id is ignored.
+	Display(Option<String>),
+
+	/// A single window, by the id [`windows`] reports. macOS only.
+	Window(String),
+
+	/// Every window belonging to one application, by the id [`apps`] reports
+	/// (a bundle identifier). Windows that open later are included. macOS only.
+	App(String),
+}
+
+/// The default camera, matching the historical `Config::default()`.
+impl Default for Source {
+	fn default() -> Self {
+		Self::Camera(None)
+	}
+}
+
+impl Source {
+	/// A short human-readable name for the source, used in logs and as the
+	/// captured device label.
+	///
+	/// macOS-only: one ScreenCaptureKit backend serves display, window, and app,
+	/// so it names the source from the config. The other backends label a stream
+	/// with the device they resolved (`/dev/video0`, a Media Foundation friendly
+	/// name), which the config doesn't know.
+	#[cfg(target_os = "macos")]
+	pub(crate) fn label(&self) -> String {
+		match self {
+			Self::Camera(None) => "camera".to_string(),
+			Self::Camera(Some(id)) => format!("camera:{id}"),
+			Self::Display(None) => "display".to_string(),
+			Self::Display(Some(id)) => format!("display:{id}"),
+			Self::Window(id) => format!("window:{id}"),
+			Self::App(id) => format!("app:{id}"),
+		}
+	}
+}
+
+/// A camera reported by [`cameras`].
+#[derive(Clone, Debug)]
+pub struct Camera {
+	/// Opaque identifier: pass to [`Source::Camera`].
+	pub id: String,
+	/// Human-readable name, e.g. "FaceTime HD Camera".
+	pub name: String,
+}
+
+impl Camera {
+	/// The [`Source`] that captures this camera.
+	pub fn source(&self) -> Source {
+		Source::Camera(Some(self.id.clone()))
+	}
+}
+
+/// A display reported by [`displays`].
+#[derive(Clone, Debug)]
+pub struct Display {
+	/// Opaque identifier: pass to [`Source::Display`].
+	pub id: String,
+	/// Human-readable name, e.g. "Display 1".
+	pub name: String,
+	/// Width in points, i.e. the logical size, which is what capture defaults to.
+	/// A 2x retina display reports half its native pixel width.
+	pub width: u32,
+	/// Height in points. See [`width`](Self::width).
+	pub height: u32,
+}
+
+impl Display {
+	/// The [`Source`] that captures this display.
+	pub fn source(&self) -> Source {
+		Source::Display(Some(self.id.clone()))
+	}
+}
+
+/// A window reported by [`windows`].
+#[derive(Clone, Debug)]
+pub struct Window {
+	/// Opaque identifier: pass to [`Source::Window`].
+	pub id: String,
+	/// The window title, empty if it has none.
+	pub title: String,
+	/// The name of the application owning the window.
+	pub app: String,
+	/// Width in points, i.e. the logical size, which is what capture defaults to.
+	/// A window on a 2x retina display reports half its native pixel width.
+	pub width: u32,
+	/// Height in points. See [`width`](Self::width).
+	pub height: u32,
+}
+
+impl Window {
+	/// The [`Source`] that captures this window.
+	pub fn source(&self) -> Source {
+		Source::Window(self.id.clone())
+	}
+}
+
+/// An application reported by [`apps`].
+#[derive(Clone, Debug)]
+pub struct App {
+	/// Bundle identifier: pass to [`Source::App`].
+	pub id: String,
+	/// Human-readable name, e.g. "Safari".
+	pub name: String,
+}
+
+impl App {
+	/// The [`Source`] that captures every window of this application.
+	pub fn source(&self) -> Source {
+		Source::App(self.id.clone())
+	}
 }
 
 /// Capture configuration. All fields are hints; the backend picks the closest
@@ -73,20 +194,29 @@ pub enum Source {
 ///
 /// `#[non_exhaustive]`: construct via [`Config::default`] and set fields, so
 /// new options can be added without breaking callers.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Config {
-	/// What to capture (camera vs display).
+	/// What to capture.
 	pub source: Source,
-	/// Source identifier. `None` opens the default device/display.
-	///
-	/// For a camera, macOS uses the AVFoundation `uniqueID`; other platforms
-	/// take a bare integer (`"0"`) as an index, else a device path/name. For a
-	/// display, a bare integer selects by index (default: the main display).
-	pub device: Option<String>,
 	pub width: Option<u32>,
 	pub height: Option<u32>,
 	pub framerate: Option<u32>,
+	/// Draw the mouse cursor into captured frames. Screen/window/app sources
+	/// only; ignored by cameras. Defaults to `true`.
+	pub cursor: bool,
+}
+
+impl Default for Config {
+	fn default() -> Self {
+		Self {
+			source: Source::default(),
+			width: None,
+			height: None,
+			framerate: None,
+			cursor: true,
+		}
+	}
 }
 
 /// A live, async frame source opened via [`open`].
@@ -162,52 +292,121 @@ impl FrameStream {
 
 /// Open the capture source described by `config`.
 pub(crate) async fn open(config: &Config) -> Result<FrameStream, Error> {
-	match config.source {
-		Source::Camera => {
+	match &config.source {
+		Source::Camera(device) => {
+			let _ = device;
 			#[cfg(target_os = "macos")]
 			{
-				avfoundation::open(config).await
+				avfoundation::open(config, device.as_deref()).await
 			}
 			#[cfg(target_os = "linux")]
 			{
-				v4l2::open(config).await
+				v4l2::open(config, device.as_deref()).await
 			}
 			#[cfg(target_os = "windows")]
 			{
-				mediafoundation::open(config).await
+				mediafoundation::open(config, device.as_deref()).await
 			}
 			#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 			{
-				Err(Error::Codec(anyhow::anyhow!(
-					"camera capture is not supported on this platform"
-				)))
+				Err(Error::Unsupported("camera capture".to_string()))
 			}
 		}
-		Source::Display => {
+		Source::Display(device) => {
+			let _ = device;
 			#[cfg(target_os = "macos")]
 			{
-				screencapture::open(config).await
+				screencapture::open_display(config, device.as_deref()).await
 			}
 			#[cfg(target_os = "windows")]
 			{
-				desktopduplication::open(config).await
+				desktopduplication::open(config, device.as_deref()).await
 			}
 			#[cfg(all(target_os = "linux", feature = "pipewire"))]
 			{
-				pipewire::open(config).await
+				pipewire::open(config, device.as_deref()).await
 			}
 			#[cfg(all(target_os = "linux", not(feature = "pipewire")))]
 			{
-				Err(Error::Codec(anyhow::anyhow!(
-					"screen capture requires the `pipewire` feature on Linux"
-				)))
+				Err(Error::Unsupported(
+					"screen capture on Linux without the `pipewire` feature".to_string(),
+				))
 			}
 			#[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
 			{
-				Err(Error::Codec(anyhow::anyhow!(
-					"screen capture is not supported on this platform"
-				)))
+				Err(Error::Unsupported("screen capture".to_string()))
 			}
 		}
+		Source::Window(id) => {
+			let _ = id;
+			#[cfg(target_os = "macos")]
+			{
+				screencapture::open_window(config, id).await
+			}
+			#[cfg(not(target_os = "macos"))]
+			{
+				Err(Error::Unsupported("window capture".to_string()))
+			}
+		}
+		Source::App(id) => {
+			let _ = id;
+			#[cfg(target_os = "macos")]
+			{
+				screencapture::open_app(config, id).await
+			}
+			#[cfg(not(target_os = "macos"))]
+			{
+				Err(Error::Unsupported("application capture".to_string()))
+			}
+		}
+	}
+}
+
+/// List the available cameras. macOS only for now.
+pub async fn cameras() -> Result<Vec<Camera>, Error> {
+	#[cfg(target_os = "macos")]
+	{
+		avfoundation::cameras()
+	}
+	#[cfg(not(target_os = "macos"))]
+	{
+		Err(Error::Unsupported("listing cameras".to_string()))
+	}
+}
+
+/// List the available displays. macOS only for now: on Linux the
+/// xdg-desktop-portal picker owns display selection.
+pub async fn displays() -> Result<Vec<Display>, Error> {
+	#[cfg(target_os = "macos")]
+	{
+		screencapture::displays().await
+	}
+	#[cfg(not(target_os = "macos"))]
+	{
+		Err(Error::Unsupported("listing displays".to_string()))
+	}
+}
+
+/// List the on-screen windows. macOS only.
+pub async fn windows() -> Result<Vec<Window>, Error> {
+	#[cfg(target_os = "macos")]
+	{
+		screencapture::windows().await
+	}
+	#[cfg(not(target_os = "macos"))]
+	{
+		Err(Error::Unsupported("listing windows".to_string()))
+	}
+}
+
+/// List the applications with at least one on-screen window. macOS only.
+pub async fn apps() -> Result<Vec<App>, Error> {
+	#[cfg(target_os = "macos")]
+	{
+		screencapture::apps().await
+	}
+	#[cfg(not(target_os = "macos"))]
+	{
+		Err(Error::Unsupported("listing applications".to_string()))
 	}
 }

--- a/rs/moq-video/src/capture/pipewire.rs
+++ b/rs/moq-video/src/capture/pipewire.rs
@@ -57,12 +57,12 @@ fn err(ctx: &str, e: impl std::fmt::Display) -> Error {
 }
 
 /// Open a portal screen capture and stream its frames from a PipeWire loop thread.
-pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
-	if let Some(device) = &config.device {
+pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameStream, Error> {
+	if let Some(device) = device {
 		tracing::debug!(%device, "portal screen capture ignores the device selector; the picker owns selection");
 	}
 
-	let (node_id, fd, session) = portal_negotiate().await?;
+	let (node_id, fd, session) = portal_negotiate(config.cursor).await?;
 
 	let chan = FrameChannel::new();
 	let framerate = config.framerate.unwrap_or(DEFAULT_FRAMERATE).max(1);
@@ -146,7 +146,7 @@ pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
 /// Ask the ScreenCast portal for a monitor: create a session, (re)select the
 /// source, and start it, returning the PipeWire node to stream, the fd of the
 /// portal's PipeWire remote, and a guard that closes the session on drop.
-async fn portal_negotiate() -> Result<(u32, OwnedFd, SessionGuard), Error> {
+async fn portal_negotiate(cursor: bool) -> Result<(u32, OwnedFd, SessionGuard), Error> {
 	let proxy = Screencast::new().await.map_err(|e| err("screencast portal", e))?;
 	let session = proxy
 		.create_session(Default::default())
@@ -158,7 +158,11 @@ async fn portal_negotiate() -> Result<(u32, OwnedFd, SessionGuard), Error> {
 		.select_sources(
 			&session,
 			SelectSourcesOptions::default()
-				.set_cursor_mode(CursorMode::Embedded)
+				.set_cursor_mode(if cursor {
+					CursorMode::Embedded
+				} else {
+					CursorMode::Hidden
+				})
 				.set_sources(ashpd::enumflags2::BitFlags::from(SourceType::Monitor))
 				.set_multiple(false)
 				.set_persist_mode(PersistMode::Application)
@@ -556,7 +560,7 @@ mod tests {
 	#[tokio::test]
 	#[ignore]
 	async fn portal_captures_frames() {
-		let mut stream = match open(&Config::default()).await {
+		let mut stream = match open(&Config::default(), None).await {
 			Ok(stream) => stream,
 			Err(e) => {
 				eprintln!("skipping: no portal screen capture available: {e}");

--- a/rs/moq-video/src/capture/screencapture.rs
+++ b/rs/moq-video/src/capture/screencapture.rs
@@ -1,13 +1,17 @@
-//! Screen capture via ScreenCaptureKit (macOS), the zero-copy path.
+//! Screen, window, and application capture via ScreenCaptureKit (macOS), the
+//! zero-copy path.
 //!
 //! `SCStream` delivers IOSurface-backed `CVPixelBuffer`s to an `SCStreamOutput`
 //! delegate, the same surface VideoToolbox encodes directly. Content enumeration
 //! and capture start are async (completion handlers) and bridged to `await`;
 //! per-frame delivery flows through the shared [`FrameChannel`].
 //!
-//! Compile-verified only: screen capture needs the Screen Recording TCC grant
-//! and a display, so it can't run in a headless test. ScreenCaptureKit may also
-//! expect a run loop for its completion handlers; validate in a real app.
+//! The three sources differ only in the `SCContentFilter` they build; everything
+//! downstream (configuration, delegate, stream, guard) is shared by [`open`].
+//!
+//! Not covered by tests: capture needs the Screen Recording TCC grant and a real
+//! display, so it can't run headless. Exercise it with `moq devices` plus
+//! `moq import capture --display/--window/--app`.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -21,57 +25,126 @@ use objc2_core_media::{CMSampleBuffer, CMTime};
 use objc2_core_video::kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange;
 use objc2_foundation::{NSArray, NSError, NSObject, NSObjectProtocol};
 use objc2_screen_capture_kit::{
-	SCContentFilter, SCShareableContent, SCStream, SCStreamConfiguration, SCStreamOutput, SCStreamOutputType, SCWindow,
+	SCContentFilter, SCDisplay, SCRunningApplication, SCShareableContent, SCStream, SCStreamConfiguration,
+	SCStreamDelegate, SCStreamOutput, SCStreamOutputType, SCWindow,
 };
 
 use super::surface::surface_frame;
-use super::{Config, FrameChannel, FrameStream};
+use super::{App, Config, Display, FrameChannel, FrameStream, Window};
 use crate::Error;
 
 const DEFAULT_FRAMERATE: i32 = 30;
 const FIRST_FRAME_TIMEOUT: Duration = Duration::from_secs(5);
 const ASYNC_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Open a display capture and stream its frames.
-pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
+/// Only capture normal application windows. Layer 0 is the standard window
+/// level; the dock, menu bar, and other chrome live on higher layers and would
+/// otherwise flood the list with things nobody means by "a window".
+const NORMAL_WINDOW_LAYER: isize = 0;
+
+/// Open a whole-display capture. `device` is a display index (`None` = main).
+pub(super) async fn open_display(config: &Config, device: Option<&str>) -> Result<FrameStream, Error> {
+	init_core_graphics();
 	let content = shareable_content().await?;
-	let displays = unsafe { content.displays() };
-	// Accept a bare index or the `display:{index}` form that `device()` reports,
-	// and reject anything else rather than silently using display 0.
-	let index = match config.device.as_deref() {
-		None => 0,
-		Some(spec) => spec
-			.strip_prefix("display:")
-			.unwrap_or(spec)
-			.parse::<usize>()
-			.map_err(|_| Error::Codec(anyhow::anyhow!("invalid display selector {spec:?}")))?,
-	};
-	if index >= displays.count() {
-		return Err(Error::Codec(anyhow::anyhow!("no display at index {index}")));
-	}
-	let display = displays.objectAtIndex(index);
-	let display_id = unsafe { display.displayID() };
+	let display = find_display(&content, device)?;
 
-	let windows = NSArray::<SCWindow>::new();
+	// An empty exclusion list captures the display as-is, including the desktop
+	// background and dock.
+	let excluded = NSArray::<SCWindow>::new();
 	let filter =
-		unsafe { SCContentFilter::initWithDisplay_excludingWindows(SCContentFilter::alloc(), &display, &windows) };
+		unsafe { SCContentFilter::initWithDisplay_excludingWindows(SCContentFilter::alloc(), &display, &excluded) };
 
+	let (width, height) = display_size(&display);
+	let size = capture_size(width, height);
+	open(config, &filter, size).await
+}
+
+/// Open a single-window capture. Follows the window as it moves and resizes.
+pub(super) async fn open_window(config: &Config, id: &str) -> Result<FrameStream, Error> {
+	init_core_graphics();
+	let content = shareable_content().await?;
+	let window = find_window(&content, id)?;
+
+	let filter = unsafe { SCContentFilter::initWithDesktopIndependentWindow(SCContentFilter::alloc(), &window) };
+
+	let frame = unsafe { window.frame() };
+	let size = capture_size(frame.size.width, frame.size.height);
+	open(config, &filter, size).await
+}
+
+/// Open an application capture: every window owned by `id` (a bundle
+/// identifier), including ones opened later.
+pub(super) async fn open_app(config: &Config, id: &str) -> Result<FrameStream, Error> {
+	init_core_graphics();
+	let content = shareable_content().await?;
+	let app = find_app(&content, id)?;
+
+	// An application's windows can span displays, but a filter is display-scoped,
+	// so the app is captured as it appears on the main display.
+	let display = find_display(&content, None)?;
+	let apps = NSArray::from_retained_slice(&[app]);
+	let excepting = NSArray::<SCWindow>::new();
+	let filter = unsafe {
+		SCContentFilter::initWithDisplay_includingApplications_exceptingWindows(
+			SCContentFilter::alloc(),
+			&display,
+			&apps,
+			&excepting,
+		)
+	};
+
+	let (width, height) = display_size(&display);
+	let size = capture_size(width, height);
+	open(config, &filter, size).await
+}
+
+/// A display's size in points.
+fn display_size(display: &SCDisplay) -> (f64, f64) {
+	(unsafe { display.width() } as f64, unsafe { display.height() } as f64)
+}
+
+/// Connect the process to the window server.
+///
+/// `SCContentFilter::initWithDesktopIndependentWindow` asserts on an
+/// uninitialized CoreGraphics (`CGS_REQUIRE_INIT`), which aborts the process
+/// rather than returning an error. A plain CLI never establishes that
+/// connection, and unlike an app there's no AppKit to do it for us; any public
+/// CG call does, so make one first. `initWithDisplay:` happens not to need it,
+/// which is why display capture survived without this.
+fn init_core_graphics() {
+	static ONCE: std::sync::Once = std::sync::Once::new();
+	ONCE.call_once(|| {
+		objc2_core_graphics::CGMainDisplayID();
+	});
+}
+
+/// Start a stream for `filter`. `size` is the source's native pixel size, used
+/// unless the caller overrode width/height.
+async fn open(config: &Config, filter: &SCContentFilter, size: (u32, u32)) -> Result<FrameStream, Error> {
 	let fps = config.framerate.map(|f| f as i32).unwrap_or(DEFAULT_FRAMERATE).max(1);
 	let configuration = unsafe { SCStreamConfiguration::new() };
+	// `size` is already even; an override might not be.
+	let width = config.width.map(|w| even(w as f64)).unwrap_or(size.0);
+	let height = config.height.map(|h| even(h as f64)).unwrap_or(size.1);
 	unsafe {
-		configuration.setWidth(config.width.map(|w| w as usize).unwrap_or(display.width() as usize));
-		configuration.setHeight(config.height.map(|h| h as usize).unwrap_or(display.height() as usize));
+		configuration.setWidth(width as usize);
+		configuration.setHeight(height as usize);
 		configuration.setPixelFormat(kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange);
 		configuration.setMinimumFrameInterval(CMTime::new(1, fps));
-		configuration.setShowsCursor(true);
+		configuration.setShowsCursor(config.cursor);
 	}
 
 	let chan = FrameChannel::new();
 	let delegate = Delegate::new(chan.clone());
 	let dispatch = DispatchQueue::new("dev.moq.video.screen", None);
 
-	let stream =
-		unsafe { SCStream::initWithFilter_configuration_delegate(SCStream::alloc(), &filter, &configuration, None) };
+	// Register as the stream delegate too, so a stream that dies on its own (the
+	// user hit "Stop Sharing", the grant was revoked, the display went away) closes
+	// the channel instead of leaving the encode loop parked on a read forever.
+	let stream = unsafe {
+		let proto = ProtocolObject::from_ref(&*delegate);
+		SCStream::initWithFilter_configuration_delegate(SCStream::alloc(), filter, &configuration, Some(proto))
+	};
 	unsafe {
 		let proto = ProtocolObject::from_ref(&*delegate);
 		stream
@@ -90,32 +163,157 @@ pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
 		_dispatch: dispatch,
 	};
 
+	let label = config.source.label();
 	let first = match tokio::time::timeout(FIRST_FRAME_TIMEOUT, chan.recv()).await {
 		Ok(Some(frame)) => frame,
 		Ok(None) | Err(_) => {
 			return Err(Error::Codec(anyhow::anyhow!(
-				"no frames from display within {FIRST_FRAME_TIMEOUT:?} (screen recording permission?)"
+				"no frames from {label} within {FIRST_FRAME_TIMEOUT:?} (screen recording permission?)"
 			)));
 		}
 	};
 	let (width, height) = (first.width(), first.height());
 
-	tracing::info!(
-		display = display_id,
-		width,
-		height,
-		"opened screen capture (ScreenCaptureKit)"
-	);
+	tracing::info!(source = %label, width, height, "opened screen capture (ScreenCaptureKit)");
 
 	Ok(FrameStream::new(
 		chan,
 		width,
 		height,
 		None,
-		format!("display:{index}"),
+		label,
 		Some(first),
 		Box::new(guard),
 	))
+}
+
+/// List the displays.
+pub(super) async fn displays() -> Result<Vec<Display>, Error> {
+	let content = shareable_content().await?;
+	let displays = unsafe { content.displays() };
+	Ok((0..displays.count())
+		.map(|index| {
+			let display = displays.objectAtIndex(index);
+			Display {
+				id: index.to_string(),
+				name: format!("Display {}", unsafe { display.displayID() }),
+				width: unsafe { display.width() } as u32,
+				height: unsafe { display.height() } as u32,
+			}
+		})
+		.collect())
+}
+
+/// List the on-screen application windows.
+pub(super) async fn windows() -> Result<Vec<Window>, Error> {
+	let content = shareable_content().await?;
+	let windows = unsafe { content.windows() };
+	Ok((0..windows.count())
+		.map(|index| windows.objectAtIndex(index))
+		.filter(|window| unsafe { window.isOnScreen() } && unsafe { window.windowLayer() } == NORMAL_WINDOW_LAYER)
+		.map(|window| {
+			let frame = unsafe { window.frame() };
+			Window {
+				id: unsafe { window.windowID() }.to_string(),
+				title: unsafe { window.title() }.map(|t| t.to_string()).unwrap_or_default(),
+				app: unsafe { window.owningApplication() }
+					.map(|app| unsafe { app.applicationName() }.to_string())
+					.unwrap_or_default(),
+				width: frame.size.width as u32,
+				height: frame.size.height as u32,
+			}
+		})
+		.collect())
+}
+
+/// List the applications owning at least one on-screen window.
+///
+/// Derived from the window list rather than `content.applications()`, which also
+/// reports background processes that have nothing to capture.
+pub(super) async fn apps() -> Result<Vec<App>, Error> {
+	let content = shareable_content().await?;
+	let windows = unsafe { content.windows() };
+
+	let mut apps = Vec::new();
+	let mut seen = std::collections::HashSet::new();
+	for index in 0..windows.count() {
+		let window = windows.objectAtIndex(index);
+		if !unsafe { window.isOnScreen() } || unsafe { window.windowLayer() } != NORMAL_WINDOW_LAYER {
+			continue;
+		}
+		let Some(app) = (unsafe { window.owningApplication() }) else {
+			continue;
+		};
+		let id = unsafe { app.bundleIdentifier() }.to_string();
+		if seen.insert(id.clone()) {
+			apps.push(App {
+				id,
+				name: unsafe { app.applicationName() }.to_string(),
+			});
+		}
+	}
+	Ok(apps)
+}
+
+/// Resolve a display index (`None` = the main display, which ScreenCaptureKit
+/// reports first).
+fn find_display(content: &SCShareableContent, device: Option<&str>) -> Result<Retained<SCDisplay>, Error> {
+	let displays = unsafe { content.displays() };
+	// Accept a bare index or the `display:{index}` form a label reports, and
+	// reject anything else rather than silently using display 0.
+	let index = match device {
+		None => 0,
+		Some(spec) => spec
+			.strip_prefix("display:")
+			.unwrap_or(spec)
+			.parse::<usize>()
+			.map_err(|_| Error::Codec(anyhow::anyhow!("invalid display selector {spec:?}")))?,
+	};
+	if index >= displays.count() {
+		return Err(Error::Codec(anyhow::anyhow!("no display at index {index}")));
+	}
+	Ok(displays.objectAtIndex(index))
+}
+
+/// Resolve a window by the id [`windows`] reports.
+fn find_window(content: &SCShareableContent, id: &str) -> Result<Retained<SCWindow>, Error> {
+	let wanted: u32 = id
+		.parse()
+		.map_err(|_| Error::Codec(anyhow::anyhow!("invalid window id {id:?}")))?;
+
+	let windows = unsafe { content.windows() };
+	(0..windows.count())
+		.map(|index| windows.objectAtIndex(index))
+		.find(|window| unsafe { window.windowID() } == wanted)
+		.ok_or_else(|| Error::Codec(anyhow::anyhow!("no window with id {id} (did it close?)")))
+}
+
+/// Resolve an application by bundle identifier.
+fn find_app(content: &SCShareableContent, id: &str) -> Result<Retained<SCRunningApplication>, Error> {
+	let apps = unsafe { content.applications() };
+	(0..apps.count())
+		.map(|index| apps.objectAtIndex(index))
+		.find(|app| unsafe { app.bundleIdentifier() }.to_string() == id)
+		.ok_or_else(|| Error::Codec(anyhow::anyhow!("no running application with bundle id {id:?}")))
+}
+
+/// Capture size for a source measured in points.
+///
+/// ScreenCaptureKit reports geometry in points, so this captures a retina
+/// display at its logical resolution rather than its native pixels: a 2x Mac
+/// gives 1710x1106, not 3420x2214. That's what the screen looks like to its
+/// owner, and it keeps the derived bitrate sane (the default is a flat
+/// bits-per-pixel, so native would quadruple it). Pass `--width`/`--height` for
+/// native pixels.
+///
+/// Rounded down to even: the encoders reject odd dimensions (4:2:0 subsampling
+/// halves each axis), and a display can well be an odd number of points tall.
+fn capture_size(width: f64, height: f64) -> (u32, u32) {
+	(even(width), even(height))
+}
+/// Round down to a non-zero even number of pixels.
+fn even(value: f64) -> u32 {
+	((value as u32) & !1).max(2)
 }
 
 /// Keeps the capture stream alive; stops it on drop and closes the channel so a
@@ -155,7 +353,7 @@ async fn shareable_content() -> Result<Retained<SCShareableContent>, Error> {
 		Ok(Ok(Err(msg))) => Err(Error::Codec(anyhow::anyhow!("shareable content: {msg}"))),
 		Ok(Err(_)) => Err(Error::Codec(anyhow::anyhow!("shareable content handler dropped"))),
 		Err(_) => Err(Error::Codec(anyhow::anyhow!(
-			"timed out listing displays (screen recording permission?)"
+			"timed out listing shareable content (screen recording permission?)"
 		))),
 	}
 }
@@ -204,10 +402,22 @@ define_class!(
 
 	unsafe impl NSObjectProtocol for Delegate {}
 
+	unsafe impl SCStreamDelegate for Delegate {
+		#[unsafe(method(stream:didStopWithError:))]
+		unsafe fn did_stop(&self, _stream: &SCStream, error: &NSError) {
+			tracing::warn!(error = %error.localizedDescription(), "screen capture stopped");
+			// Unblocks a parked read; the encode loop then reopens on demand.
+			self.ivars().chan.close();
+		}
+	}
+
 	unsafe impl SCStreamOutput for Delegate {
 		#[unsafe(method(stream:didOutputSampleBuffer:ofType:))]
 		unsafe fn did_output(&self, _stream: &SCStream, sample_buffer: &CMSampleBuffer, kind: SCStreamOutputType) {
 			if kind.0 == SCStreamOutputType::Screen.0 {
+				// ScreenCaptureKit calls this at the configured rate even when nothing
+				// changed, handing back an image-less buffer; there's no new content to
+				// encode, so drop it.
 				if let Some(frame) = surface_frame(sample_buffer) {
 					self.ivars().chan.push(frame);
 				}

--- a/rs/moq-video/src/capture/v4l2.rs
+++ b/rs/moq-video/src/capture/v4l2.rs
@@ -21,13 +21,15 @@ use crate::Error;
 use crate::frame::{Frame, I420};
 
 /// Open a V4L2 camera and stream its frames over a pump thread.
-pub(super) async fn open(config: &Config) -> Result<FrameStream, Error> {
+pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameStream, Error> {
 	let config = config.clone();
+	// The camera opens on the pump thread, so the selector has to be owned.
+	let device = device.map(str::to_string);
 	let chan = FrameChannel::new();
 	let (geo, guard) = pump::spawn(
 		chan.clone(),
 		move || {
-			let camera = Camera::open(&config)?;
+			let camera = Camera::open(&config, device.as_deref())?;
 			let geometry = Geometry {
 				width: camera.width,
 				height: camera.height,
@@ -83,8 +85,8 @@ pub(crate) struct Camera {
 }
 
 impl Camera {
-	fn open(config: &Config) -> Result<Self, Error> {
-		let (device, name) = open_device(config)?;
+	fn open(config: &Config, selector: Option<&str>) -> Result<Self, Error> {
+		let (device, name) = open_device(selector)?;
 		let width = config.width.unwrap_or(DEFAULT_WIDTH);
 		let height = config.height.unwrap_or(DEFAULT_HEIGHT);
 
@@ -160,10 +162,10 @@ impl Camera {
 	}
 }
 
-/// Open `config.device`: a bare integer selects `/dev/videoN` by index, anything
+/// Open `device`: a bare integer selects `/dev/videoN` by index, anything
 /// else is a device path. `None` opens index 0.
-fn open_device(config: &Config) -> Result<(Device, String), Error> {
-	match config.device.as_deref() {
+fn open_device(device: Option<&str>) -> Result<(Device, String), Error> {
+	match device {
 		None => {
 			let device = Device::new(0).map_err(|e| Error::Codec(anyhow::anyhow!("open /dev/video0: {e}")))?;
 			Ok((device, "/dev/video0".to_string()))

--- a/rs/moq-video/src/error.rs
+++ b/rs/moq-video/src/error.rs
@@ -16,6 +16,11 @@ pub enum Error {
 	#[error("unsupported codec for native decode: {0}")]
 	UnsupportedCodec(String),
 
+	/// The requested capture source or enumeration has no implementation on this
+	/// platform (the message names what is missing).
+	#[error("not supported on this platform: {0}")]
+	Unsupported(String),
+
 	/// The configured framerate was zero (would divide by zero / produce a
 	/// degenerate codec time base).
 	#[error("invalid framerate: {0} (must be non-zero)")]

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -7,7 +7,10 @@
 //! - [`capture`] describes a frame source ([`capture::Config`]) and grabs
 //!   frames per platform: AVFoundation/ScreenCaptureKit on macOS, native V4L2
 //!   on Linux, native Media Foundation (camera) and DXGI Desktop Duplication
-//!   (screen) on Windows. Today that's a webcam or the screen.
+//!   (screen) on Windows. [`capture::Source`] picks a camera, a display, or
+//!   (macOS only) a single window or every window of an application;
+//!   [`capture::cameras`], [`capture::displays`], [`capture::windows`], and
+//!   [`capture::apps`] list what's available and hand back the ids it takes.
 //! - [`encode`] encodes frames with a native backend and publishes them through
 //!   the matching `moq_mux::codec` importer, which handles catalog registration
 //!   and framing. The codec is chosen via [`encode::Codec`]: H.264 (openh264 /


### PR DESCRIPTION
Lets you name what to capture (camera, display, window, app) and what to listen to (microphone, system audio), and lists the ids each one takes. Part of #2272; macOS only for the new sources.

```bash
moq devices                                  # list sources + their ids
moq ... import capture --window 39193        # one window, followed as it moves
moq ... import capture --app com.apple.Safari
moq ... import capture --display 1 --no-cursor
moq ... import capture --display --system-audio   # screen share with sound
```

## Summary

- **`capture::Source` carries its own identifier**, so a window can't be captured without saying which one, and a camera id can't reach the display backend. Retires `capture::Config::device`.
- **Window and app capture** (macOS): `initWithDesktopIndependentWindow` / `initWithDisplay:includingApplications:`.
- **Enumeration**: `moq devices` lists cameras, displays, windows, apps, and microphones with the id each flag wants. The backends already built these lists internally and threw them away. It touches no network, so it's the one verb with no MoQ side (hence `MoqSide::validate`, since a clap `ArgGroup` can't be conditional on the subcommand).
- **Display selection reaches the CLI.** The macOS/Windows backends already supported display-by-index, but `video_config` only set `device` in the camera branch, so `--screen` always got the main display. `--screen` stays as a hidden alias for `--display`.
- **`--no-cursor`**; cursor was hardcoded on (macOS) / on (Linux) / absent (Windows, still).
- **System audio** (macOS): there is no loopback input device, so it goes through ScreenCaptureKit. It lives in `moq-audio` to keep the layering (audio in `moq-audio`), which costs a second `SCStream` alongside the video one; they coexist fine. `excludesCurrentProcessAudio` keeps playback from feeding itself.
- **A dying stream now surfaces.** Both backends register as `SCStreamDelegate`, so `didStopWithError` (the user hit Stop Sharing, the grant was revoked, the display went away) closes the channel instead of leaving the encode loop parked on a read forever.
- **System audio validates the format it actually got** rather than the one it asked for: the catalog is built from the request before the stream opens, so a mismatch now errors instead of feeding Opus wrong-shaped frames.
- **Capture stays at the logical resolution**, not native pixels: the default bitrate is a flat bits-per-pixel, so a 2x display would quadruple it (~16 Mbps vs ~4 Mbps). `--width`/`--height` still reach native.

### Root causes (two bugs, both found by running it)

- **Window capture aborted the process.** `SCContentFilter::initWithDesktopIndependentWindow` asserts `CGS_REQUIRE_INIT` on an uninitialized CoreGraphics, which is an `abort()`, not an error. A CLI never connects to the window server and has no AppKit to do it for it; any public CG call does, so make one first. `initWithDisplay:` happens not to need it, which is why display capture never hit this.
- **Display capture could not encode at all.** ScreenCaptureKit reports geometry in points, and this display is an odd number of points tall (1710x**1107**), which the encoders reject (4:2:0 halves each axis): `encoder dimensions must be even (got 1710x1107)`. Rounded down to even. This is why `--screen` was unusable regardless of the resolution question.

## Public API changes

**`moq-video`** (breaking, hence `dev`):
- `capture::Source`: was `Camera | Display`, now `Camera(Option<String>) | Display(Option<String>) | Window(String) | App(String)`.
- `capture::Config::device`: **removed** (folded into `Source`); `Config::cursor` added.
- Added: `capture::{cameras, displays, windows, apps}`, `capture::{Camera, Display, Window, App}` (each with `.source()`), `Error::Unsupported`.

**`moq-audio`** (breaking, hence `dev`):
- Added `capture::Source` (`Microphone(Option<String>) | System`); `Config::device` **removed** in favour of `Config::source`.
- `publish_microphone` **renamed** to `publish_capture` (it no longer names its only implementation).
- `capture::Microphone` is now **private**: `publish_capture` is the entry point and the per-source backends are an implementation detail, mirroring `moq-video`. Only `moq-cli` used it.
- Added: `capture::devices()`, `capture::Device`.

`#[non_exhaustive]` is on the two `Source` enums only (enums that will realistically gain variants, e.g. region capture); the enumeration result structs don't get it, per the `rs/CLAUDE.md` rule.

## Test plan

Ran on a real Mac (M-series, 2x display); capture can't be exercised headless, so this is manual.

- `moq devices` lists real cameras / displays / windows / apps / microphones.
- Each source published to a self-hosted server and exported, verified with ffprobe/ffmpeg:
  - `--window` → 1200x800 H.264, valid stream.
  - `--app` → 1710x1106.
  - `--display` → 1710x1106 (was a hard error before).
  - `--display --system-audio` → H.264 + Opus 48k stereo in one broadcast, audio at **max_volume -10.4 dB** (silence reads -91 dB), so the planar→interleaved conversion off `CMSampleBuffer` is right.
  - `--no-video --system-audio` → 787 Opus packets, -10.4 dB.
  - `--microphone` still opens and publishes.
- `--width 3420 --height 2214` reaches native; odd `1001x707` rounds to `1000x706` instead of erroring.
- Bad window id → clean error, not an abort. `--camera` + `--display`, and `--microphone` + `--system-audio`, are rejected by clap.
- `just rs check`, `cargo clippy --features capture` (CI never builds this feature), `cargo test`, and `RUSTDOCFLAGS=-D warnings cargo doc` all pass.
- Linux verified in a Fedora container (`cargo fmt --check` + `cargo check --all-targets` for `moq-video --features pipewire` and `moq-audio --features capture`), since macOS silently skips `cfg(target_os = "linux")` modules and CI never compiles the `pipewire`/`capture` features at all.
- Re-verified on hardware after the review fixes: system audio 681 packets at **-10.5 dB**, `--display` 1710x1106, `--window` 1488x820, `--app`, and combined display + system audio (H.264 + Opus, -10.5 dB). The new channel check passes rather than false-rejecting (2 observed = 2 requested).

### Review

Reviewed via `/review` (no prior coverage: Sourcery skipped on its weekly rate limit). Five findings, all fixed: two wrong/stale doc claims on the new public fields (`width`/`height` are **points**, not pixels; `Display.name` example didn't match the code), an alignment bug (`AudioBufferList` was backed by a `Vec<u8>` but holds a pointer, so it needs 8-byte alignment; it worked only by allocator accident), plus the delegate and format-validation items above.

Deliberately **not** done: de-duplicating the ~55 lines of objc bridging (`shareable_content`, `start_capture`, `error_message`, `SendObj`) now near-identical across the two crates. They're siblings, so sharing would mean a new published crate (plus release-plz wiring and a versioning contract) to hold four small stable functions. Revisit if a third caller appears.

**Not verified**: Windows and Linux, beyond compiling. The backend signature changes there are mechanical (the selector moves from `Config::device` to a parameter), and enumeration/window/app return `Error::Unsupported` off macOS.

## Known gaps (not fixed here)

- **A static screen produces almost no video on macOS.** ScreenCaptureKit calls the delegate at the configured rate but hands back an image-less buffer when nothing changed: measured **7 frames with an image vs 171 without** over ~10s on an idle screen. We drop the idle ones, so the stream stalls until something moves, and a late subscriber waits for the first change.

  Worth calling out that **macOS is the odd one out here**: PipeWire and Desktop Duplication both already re-emit the last frame while the screen is static ("so a still desktop still produces a steady stream"), each by holding the last `I420`. So this is a parity bug, not a design choice, and the fix has precedent: hold the last `CVPixelBuffer` in the delegate and re-push it on an idle callback. Left to its own PR because it's a behavior change with a cadence policy worth reviewing on its own, not because it's hard.
- **`--width/--height/--fps` are ignored for macOS cameras** (AVFoundation only ever read `config.device`). It now warns instead of silently coming up at the default; the real fix is `activeFormat` selection.
- **`export fmp4` drops the audio track when a broadcast has both video and audio** (mkv from the same broadcast is fine; audio-only fmp4 is fine; `--microphone` reproduces it identically). Pre-existing in `moq-mux`, unrelated to this PR.
- macOS now defaults to logical pixels while Windows/DXGI still captures its physical framebuffer, so "share my screen" differs per platform. Capping the default long edge everywhere would subsume both.

## Cross-package sync

`doc/bin/cli.md` updated (sources, `moq devices`, `--system-audio`, the resolution note). No other row applies: no wire, catalog, ffi, or JS surface changes.

(Written by Claude Opus 4.8)
