### PR TITLE
fix(moq-native): accept SNI-less raw QUIC connections

### DIFF
--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -488,9 +488,11 @@ impl NoqRequest {
 				Ok(Self::WebTransport { request, alpns })
 			}
 			alpn if moq_net::ALPNS.contains(&alpn) => {
-				if host.is_empty() {
-					return Err(Error::MissingServerName);
-				}
+				// Raw QUIC carries no in-band request URL like WebTransport's CONNECT, so the TLS
+				// SNI is the only authority the client can offer, and it's optional. A client dialing
+				// a bare IP sends no SNI (RFC 6066 forbids IP literals), leaving `host` empty; the
+				// resulting hostless `moqt://` routes to the root path, exactly like a URL-less stream
+				// transport. `url()` returns `None` for the raw variant either way.
 				let host_str = if host.contains(':') {
 					format!("[{}]", host)
 				} else {

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -483,9 +483,11 @@ impl QuinnRequest {
 				Ok(Self::WebTransport { request, alpns })
 			}
 			alpn if moq_net::ALPNS.contains(&alpn) => {
-				if host.is_empty() {
-					return Err(Error::MissingServerName);
-				}
+				// Raw QUIC carries no in-band request URL like WebTransport's CONNECT, so the TLS
+				// SNI is the only authority the client can offer, and it's optional. A client dialing
+				// a bare IP sends no SNI (RFC 6066 forbids IP literals), leaving `host` empty; the
+				// resulting hostless `moqt://` routes to the root path, exactly like a URL-less stream
+				// transport. `url()` returns `None` for the raw variant either way.
 				let host_str = if host.contains(':') {
 					format!("[{}]", host)
 				} else {

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -11,8 +11,27 @@ const TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Publish a broadcast on the server, subscribe on the client, and verify
 /// the data arrives correctly using the specified QUIC backend and URL scheme.
+///
+/// Dials `localhost`, so the client sends an SNI. Use [`no_sni_test`] to cover
+/// the SNI-less path.
 #[cfg(any(feature = "quinn", feature = "quiche", feature = "noq"))]
 async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
+	connect_test(scheme, "[::]:0", "localhost", backend).await;
+}
+
+/// Dial a bare IP so the client sends no TLS SNI (RFC 6066 forbids IP literals
+/// in the server name). Raw QUIC has no in-band request URL, so this exercises
+/// the accept path with an empty server name, which must still establish rather
+/// than reject. Binds the loopback IP directly to avoid dual-stack flakiness.
+#[cfg(any(feature = "quinn", feature = "noq"))]
+async fn no_sni_test(scheme: &str, backend: moq_native::QuicBackend) {
+	connect_test(scheme, "127.0.0.1:0", "127.0.0.1", backend).await;
+}
+
+/// Publish a broadcast on the server bound to `bind`, subscribe on a client that
+/// dials `authority`, and verify the data arrives over the given backend + scheme.
+#[cfg(any(feature = "quinn", feature = "quiche", feature = "noq"))]
+async fn connect_test(scheme: &str, bind: &str, authority: &str, backend: moq_native::QuicBackend) {
 	// ── publisher (server) ──────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
@@ -25,7 +44,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	group.finish().expect("failed to finish group");
 
 	let mut server_config = moq_native::ServerConfig::default();
-	server_config.bind = Some("[::]:0".to_string());
+	server_config.bind = Some(bind.to_string());
 	server_config.tls.generate = vec!["localhost".into()];
 	server_config.backend = Some(backend.clone());
 
@@ -39,9 +58,12 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	let mut client_config = moq_native::ClientConfig::default();
 	client_config.tls.disable_verify = Some(true);
 	client_config.backend = Some(backend);
+	// Bind the client to the same address family as the server so an IPv4 dial
+	// doesn't try to egress from an IPv6 socket (and vice versa).
+	client_config.bind = bind.parse().expect("invalid bind address");
 
 	let client = client_config.init().expect("failed to init client");
-	let url: url::Url = format!("{scheme}://localhost:{}", addr.port()).parse().unwrap();
+	let url: url::Url = format!("{scheme}://{authority}:{}", addr.port()).parse().unwrap();
 
 	// ── run server and client concurrently ──────────────────────────
 	let server_handle = tokio::spawn(async move {
@@ -211,6 +233,13 @@ async fn quinn_raw_quic() {
 #[cfg(feature = "quinn")]
 #[tracing_test::traced_test]
 #[tokio::test]
+async fn quinn_raw_quic_no_sni() {
+	no_sni_test("moqt", moq_native::QuicBackend::Quinn).await;
+}
+
+#[cfg(feature = "quinn")]
+#[tracing_test::traced_test]
+#[tokio::test]
 async fn quinn_mtls() {
 	mtls_test("https", moq_native::QuicBackend::Quinn).await;
 }
@@ -365,6 +394,13 @@ async fn iroh_connect() {
 #[tokio::test]
 async fn noq_raw_quic() {
 	backend_test("moqt", moq_native::QuicBackend::Noq).await;
+}
+
+#[cfg(feature = "noq")]
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn noq_raw_quic_no_sni() {
+	no_sni_test("moqt", moq_native::QuicBackend::Noq).await;
 }
 
 #[cfg(feature = "noq")]

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -9,6 +9,18 @@ use std::time::Duration;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Inputs for [`connect_test`].
+#[cfg(any(feature = "quinn", feature = "quiche", feature = "noq"))]
+struct ConnectTest<'a> {
+	/// URL scheme to dial (`moqt` for raw QUIC, `https` for WebTransport).
+	scheme: &'a str,
+	/// Server bind address, e.g. `[::]:0` or `127.0.0.1:0`.
+	bind: &'a str,
+	/// Authority the client dials: a DNS name (sends SNI) or a bare IP (no SNI).
+	authority: &'a str,
+	backend: moq_native::QuicBackend,
+}
+
 /// Publish a broadcast on the server, subscribe on the client, and verify
 /// the data arrives correctly using the specified QUIC backend and URL scheme.
 ///
@@ -16,7 +28,13 @@ const TIMEOUT: Duration = Duration::from_secs(10);
 /// the SNI-less path.
 #[cfg(any(feature = "quinn", feature = "quiche", feature = "noq"))]
 async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
-	connect_test(scheme, "[::]:0", "localhost", backend).await;
+	connect_test(ConnectTest {
+		scheme,
+		bind: "[::]:0",
+		authority: "localhost",
+		backend,
+	})
+	.await;
 }
 
 /// Dial a bare IP so the client sends no TLS SNI (RFC 6066 forbids IP literals
@@ -25,13 +43,26 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 /// than reject. Binds the loopback IP directly to avoid dual-stack flakiness.
 #[cfg(any(feature = "quinn", feature = "noq"))]
 async fn no_sni_test(scheme: &str, backend: moq_native::QuicBackend) {
-	connect_test(scheme, "127.0.0.1:0", "127.0.0.1", backend).await;
+	connect_test(ConnectTest {
+		scheme,
+		bind: "127.0.0.1:0",
+		authority: "127.0.0.1",
+		backend,
+	})
+	.await;
 }
 
 /// Publish a broadcast on the server bound to `bind`, subscribe on a client that
 /// dials `authority`, and verify the data arrives over the given backend + scheme.
 #[cfg(any(feature = "quinn", feature = "quiche", feature = "noq"))]
-async fn connect_test(scheme: &str, bind: &str, authority: &str, backend: moq_native::QuicBackend) {
+async fn connect_test(config: ConnectTest<'_>) {
+	let ConnectTest {
+		scheme,
+		bind,
+		authority,
+		backend,
+	} = config;
+
 	// ── publisher (server) ──────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");


### PR DESCRIPTION
## Problem

The quinn and noq raw-QUIC accept paths reject any connection whose TLS ClientHello carries no server name:

```rust
let host = handshake.server_name.unwrap_or_default(); // "" with no SNI
...
if host.is_empty() {
    return Err(Error::MissingServerName);
}
```

A client dialing a **bare IP address** sends no SNI at all. RFC 6066 §3 forbids IP literals in the `server_name` extension, so rustls omits the extension entirely. The server then sees `handshake.server_name == None`, `host` is empty, and the session is aborted right after the handshake.

This bites anyone making a direct QUIC connection by IP (reported for a drone ↔ cloud link over a raw Tailscale IP, dropping the relay). MagicDNS "worked" only because it supplies a real DNS name that *can* be sent as SNI. The escape hatch `--client-tls-host-name` also works, but requiring either for a plain IP dial is surprising.

## Root cause

Raw QUIC (a moq ALPN with no WebTransport CONNECT) has no in-band request URL, so the TLS SNI is the only authority a client can offer, and it is **optional**. The accept path synthesizes a `moqt://{sni}` URL purely to fit the shared `Session::raw(ConnectRequest, …)` shape, but that URL is never surfaced: `NoqRequest::url()` / `QuinnRequest::url()` return `None` for the raw variant, so the relay routes such sessions to the root path exactly like a URL-less `tcp`/`unix` stream transport. The empty-SNI rejection guards a value that is immediately discarded. An empty host even parses fine (`moqt://` → host `None`), so the guard is the only thing failing the connection.

The **quiche** backend already gets this right, accepting raw QUIC with a hardcoded `moqt://` and no server-name check. This change aligns quinn and noq with it.

## Change

- Drop the `MissingServerName` rejection in `quinn.rs` and `noq.rs`. An empty SNI now yields a hostless `moqt://` request, matching quiche and the URL-less stream transports.
- The `MissingServerName` error variant is retained (unused). Removing a `pub` variant from these `#[non_exhaustive]` enums would be a breaking API change routed to `dev`; keeping it stays non-breaking so the fix can land on `main`. Flagging it here in case you'd prefer to drop it in a follow-up `dev` cleanup.
- When a client *does* present a DNS SNI, the behavior is unchanged (the synthesized URL is still discarded by `url()`, same as before).

## Tests

Added `quinn_raw_quic_no_sni` and `noq_raw_quic_no_sni` regression tests that dial a bare loopback IP (so the client sends no SNI) and assert the broadcast still flows end-to-end. Both fail without the fix (the server rejects with `MissingServerName`, so the client times out) and pass with it. Refactored `backend_test` into a shared `connect_test(scheme, bind, authority, backend)` and bound the client to the server's address family so an IPv4 dial doesn't egress from an IPv6 socket.

## Cross-package sync

No paired updates: this is native connection-acceptance behavior in `moq-native`, not a wire/API/catalog change, and no `/doc` page documents the SNI requirement. Interop matrix untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NoKJfq8ALde1MKMyvCLE5u

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoKJfq8ALde1MKMyvCLE5u)_