### PR TITLE
feat(moq-mux): add custom catalog tracks

### DIFF
--- a/rs/moq-mux/CHANGELOG.md
+++ b/rs/moq-mux/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add typed custom catalog rendition handles with automatic publishing, timeline configuration, and drop cleanup.
+
 ## [0.7.4](https://github.com/moq-dev/moq/compare/moq-mux-v0.7.3...moq-mux-v0.7.4) - 2026-07-12
 
 ### Other

--- a/rs/moq-mux/src/catalog/mod.rs
+++ b/rs/moq-mux/src/catalog/mod.rs
@@ -35,4 +35,4 @@ pub use format::*;
 pub use producer::{Guard, Producer};
 pub use select::Select;
 pub use stream::Stream;
-pub use tracks::{AudioTrack, VideoTrack};
+pub use tracks::{AudioTrack, CustomTrack, CustomTrackExt, VideoTrack};

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -142,6 +142,14 @@ impl<E: CatalogExt> Producer<E> {
 		super::AudioTrack::new(self.clone(), name)
 	}
 
+	/// A handle for publishing one custom rendition, retired on drop.
+	pub fn custom_track(&self, name: impl Into<String>) -> super::CustomTrack<E>
+	where
+		E: super::CustomTrackExt,
+	{
+		super::CustomTrack::new(self.clone(), name)
+	}
+
 	/// Build the media [`container::Producer`](crate::container::Producer) for the rendition named by
 	/// `track`, with its timeline recorder wired in.
 	///
@@ -160,8 +168,9 @@ impl<E: CatalogExt> Producer<E> {
 	/// The catalog [`Timeline`](hang::catalog::Timeline) section for media rendition `name`, to
 	/// advertise on the rendition's config (creating the timeline track on first use).
 	///
-	/// [`VideoTrack::set`](super::VideoTrack::set) / [`AudioTrack::set`](super::AudioTrack::set) do
-	/// this automatically; callers that build a rendition config by hand attach it themselves.
+	/// [`VideoTrack::set`](super::VideoTrack::set), [`AudioTrack::set`](super::AudioTrack::set), and
+	/// [`CustomTrack::set`](super::CustomTrack::set) do this automatically when their config exposes
+	/// a timeline field; callers that build a rendition config by hand attach it themselves.
 	pub fn timeline_section(&self, name: &str) -> hang::catalog::Timeline {
 		self.with_timeline(name, |timeline| timeline.section())
 	}

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -1,126 +1,270 @@
-use super::Producer;
-use super::hang::CatalogExt;
+use std::collections::BTreeMap;
 
-/// A single video track's catalog rendition, retired on drop.
-///
-/// Made via [`Producer::video_track`]. An importer holds one and publishes its
-/// rendition through it ([`set`](Self::set), refined in place with
-/// [`update`](Self::update)). When the importer drops, the rendition is removed
-/// from the shared catalog, so the broadcast catalog stays out of the importer's
-/// type while still being published into.
-pub struct VideoTrack<E: CatalogExt = ()> {
+use super::Producer;
+use super::hang::{Catalog, CatalogExt};
+
+/// A catalog extension that owns one kind of custom track rendition.
+pub trait CustomTrackExt: CatalogExt {
+	/// The custom rendition config stored in the catalog.
+	type Config;
+
+	/// The rendition map owned by this extension.
+	fn renditions(&mut self) -> &mut BTreeMap<String, Self::Config>;
+
+	/// The optional timeline field to populate when publishing a config.
+	fn timeline(_config: &mut Self::Config) -> Option<&mut Option<hang::catalog::Timeline>> {
+		None
+	}
+}
+
+struct Track<E: CatalogExt, C> {
 	catalog: Producer<E>,
 	name: String,
-	/// Whether a config has been published yet, so a lazily-configured importer
-	/// (e.g. H.264 before its SPS) can hold the handle without a catalog entry, and
-	/// drop without a spurious removal.
+	renditions: fn(&mut Catalog<E>) -> &mut BTreeMap<String, C>,
+	timeline: fn(&mut C) -> Option<&mut Option<hang::catalog::Timeline>>,
+	// A lazily-configured importer can hold the handle before publishing a config.
 	present: bool,
+}
+
+impl<E: CatalogExt, C> Track<E, C> {
+	fn new(
+		catalog: Producer<E>,
+		name: impl Into<String>,
+		renditions: fn(&mut Catalog<E>) -> &mut BTreeMap<String, C>,
+		timeline: fn(&mut C) -> Option<&mut Option<hang::catalog::Timeline>>,
+	) -> Self {
+		Self {
+			catalog,
+			name: name.into(),
+			renditions,
+			timeline,
+			present: false,
+		}
+	}
+
+	fn name(&self) -> &str {
+		&self.name
+	}
+
+	fn timestamp(&self, hint: Option<crate::container::Timestamp>) -> crate::Result<crate::container::Timestamp> {
+		self.catalog.timestamp(hint)
+	}
+
+	fn set(&mut self, mut config: C) {
+		if let Some(timeline) = (self.timeline)(&mut config) {
+			*timeline = Some(self.catalog.timeline_section(&self.name));
+		}
+		(self.renditions)(&mut self.catalog.lock()).insert(self.name.clone(), config);
+		self.present = true;
+	}
+
+	fn update(&mut self, f: impl FnOnce(&mut C)) {
+		if !self.present {
+			return;
+		}
+		let mut guard = self.catalog.lock();
+		if let Some(config) = (self.renditions)(&mut guard).get_mut(&self.name) {
+			f(config);
+		}
+	}
+}
+
+impl<E: CatalogExt, C> Drop for Track<E, C> {
+	fn drop(&mut self) {
+		if self.present {
+			(self.renditions)(&mut self.catalog.lock()).remove(&self.name);
+		}
+	}
+}
+
+/// A single custom track's catalog rendition, retired on drop.
+///
+/// Made via [`Producer::custom_track`]. [`set`](Self::set) inserts or replaces
+/// the config, [`update`](Self::update) refines it in place, and dropping the
+/// handle removes it. Every mutation automatically publishes the shared catalog.
+pub struct CustomTrack<E: CustomTrackExt> {
+	inner: Track<E, E::Config>,
+}
+
+impl<E: CustomTrackExt> CustomTrack<E> {
+	pub(super) fn new(catalog: Producer<E>, name: impl Into<String>) -> Self {
+		Self {
+			inner: Track::new(catalog, name, |catalog| catalog.ext.renditions(), E::timeline),
+		}
+	}
+
+	/// The track name this rendition is keyed by.
+	pub fn name(&self) -> &str {
+		self.inner.name()
+	}
+
+	/// Resolve a timestamp on the broadcast's shared clock (see [`Producer::timestamp`]).
+	pub fn timestamp(&self, hint: Option<crate::container::Timestamp>) -> crate::Result<crate::container::Timestamp> {
+		self.inner.timestamp(hint)
+	}
+
+	/// Insert or replace the rendition, publishing the catalog.
+	pub fn set(&mut self, config: E::Config) {
+		self.inner.set(config);
+	}
+
+	/// Refine the rendition in place, publishing if present.
+	pub fn update(&mut self, f: impl FnOnce(&mut E::Config)) {
+		self.inner.update(f);
+	}
+}
+
+/// A single video track's catalog rendition, retired on drop.
+pub struct VideoTrack<E: CatalogExt = ()> {
+	inner: Track<E, hang::catalog::VideoConfig>,
 }
 
 impl<E: CatalogExt> VideoTrack<E> {
 	pub(super) fn new(catalog: Producer<E>, name: impl Into<String>) -> Self {
 		Self {
-			catalog,
-			name: name.into(),
-			present: false,
+			inner: Track::new(
+				catalog,
+				name,
+				|catalog| &mut catalog.video.renditions,
+				|config| Some(&mut config.timeline),
+			),
 		}
 	}
 
 	/// The track name this rendition is keyed by.
 	pub fn name(&self) -> &str {
-		&self.name
+		self.inner.name()
 	}
 
 	/// Resolve a timestamp on the broadcast's shared clock (see [`Producer::timestamp`]).
 	pub fn timestamp(&self, hint: Option<crate::container::Timestamp>) -> crate::Result<crate::container::Timestamp> {
-		self.catalog.timestamp(hint)
+		self.inner.timestamp(hint)
 	}
 
-	/// Insert or replace the rendition, publishing the catalog.
-	///
-	/// Advertises the rendition's timeline track in the config, so a consumer can index its
-	/// groups without downloading media (see [`Producer::timeline_section`](crate::catalog::Producer::timeline_section)).
-	pub fn set(&mut self, mut config: hang::catalog::VideoConfig) {
-		config.timeline = Some(self.catalog.timeline_section(&self.name));
-		self.catalog.lock().video.renditions.insert(self.name.clone(), config);
-		self.present = true;
+	/// Insert or replace the rendition, publishing the catalog and advertising its timeline.
+	pub fn set(&mut self, config: hang::catalog::VideoConfig) {
+		self.inner.set(config);
 	}
 
-	/// Refine the rendition in place (e.g. observed jitter), publishing if present.
+	/// Refine the rendition in place, publishing if present.
 	pub fn update(&mut self, f: impl FnOnce(&mut hang::catalog::VideoConfig)) {
-		if !self.present {
-			return;
-		}
-		let mut guard = self.catalog.lock();
-		if let Some(config) = guard.video.renditions.get_mut(&self.name) {
-			f(config);
-		}
-	}
-}
-
-impl<E: CatalogExt> Drop for VideoTrack<E> {
-	fn drop(&mut self) {
-		if self.present {
-			self.catalog.lock().video.renditions.remove(&self.name);
-		}
+		self.inner.update(f);
 	}
 }
 
 /// A single audio track's catalog rendition, retired on drop.
-///
-/// The audio counterpart of [`VideoTrack`]; made via [`Producer::audio_track`].
 pub struct AudioTrack<E: CatalogExt = ()> {
-	catalog: Producer<E>,
-	name: String,
-	present: bool,
+	inner: Track<E, hang::catalog::AudioConfig>,
 }
 
 impl<E: CatalogExt> AudioTrack<E> {
 	pub(super) fn new(catalog: Producer<E>, name: impl Into<String>) -> Self {
 		Self {
-			catalog,
-			name: name.into(),
-			present: false,
+			inner: Track::new(
+				catalog,
+				name,
+				|catalog| &mut catalog.audio.renditions,
+				|config| Some(&mut config.timeline),
+			),
 		}
 	}
 
 	/// The track name this rendition is keyed by.
 	pub fn name(&self) -> &str {
-		&self.name
+		self.inner.name()
 	}
 
 	/// Resolve a timestamp on the broadcast's shared clock (see [`Producer::timestamp`]).
 	pub fn timestamp(&self, hint: Option<crate::container::Timestamp>) -> crate::Result<crate::container::Timestamp> {
-		self.catalog.timestamp(hint)
+		self.inner.timestamp(hint)
 	}
 
-	/// Insert or replace the rendition, publishing the catalog.
-	///
-	/// Advertises the rendition's timeline track in the config, so a consumer can index its
-	/// groups without downloading media (see [`Producer::timeline_section`](crate::catalog::Producer::timeline_section)).
-	pub fn set(&mut self, mut config: hang::catalog::AudioConfig) {
-		config.timeline = Some(self.catalog.timeline_section(&self.name));
-		self.catalog.lock().audio.renditions.insert(self.name.clone(), config);
-		self.present = true;
+	/// Insert or replace the rendition, publishing the catalog and advertising its timeline.
+	pub fn set(&mut self, config: hang::catalog::AudioConfig) {
+		self.inner.set(config);
 	}
 
-	/// Refine the rendition in place (e.g. a synthesized description or jitter),
-	/// publishing if present.
+	/// Refine the rendition in place, publishing if present.
 	pub fn update(&mut self, f: impl FnOnce(&mut hang::catalog::AudioConfig)) {
-		if !self.present {
-			return;
-		}
-		let mut guard = self.catalog.lock();
-		if let Some(config) = guard.audio.renditions.get_mut(&self.name) {
-			f(config);
-		}
+		self.inner.update(f);
 	}
 }
 
-impl<E: CatalogExt> Drop for AudioTrack<E> {
-	fn drop(&mut self) {
-		if self.present {
-			self.catalog.lock().audio.renditions.remove(&self.name);
+#[cfg(test)]
+mod test {
+	use std::task::Poll;
+
+	use serde::{Deserialize, Serialize};
+
+	use super::*;
+
+	#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
+	struct TestExt {
+		data: TestSection,
+	}
+
+	impl CatalogExt for TestExt {}
+
+	impl CustomTrackExt for TestExt {
+		type Config = TestConfig;
+
+		fn renditions(&mut self) -> &mut BTreeMap<String, Self::Config> {
+			&mut self.data.renditions
 		}
+
+		fn timeline(config: &mut Self::Config) -> Option<&mut Option<hang::catalog::Timeline>> {
+			Some(&mut config.timeline)
+		}
+	}
+
+	#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
+	struct TestSection {
+		renditions: BTreeMap<String, TestConfig>,
+	}
+
+	#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
+	struct TestConfig {
+		value: u64,
+		#[serde(skip_serializing_if = "Option::is_none")]
+		timeline: Option<hang::catalog::Timeline>,
+	}
+
+	#[test]
+	fn custom_track_manages_rendition() {
+		let mut broadcast = moq_net::Broadcast::new().produce();
+		let catalog = Producer::with_catalog(&mut broadcast, Catalog::<TestExt>::default()).unwrap();
+		let mut consumer = catalog.consume().unwrap();
+		let waiter = kio::Waiter::noop();
+
+		let mut track = catalog.custom_track("data0");
+		track.update(|config| config.value = 1);
+		assert!(catalog.snapshot().data.renditions.is_empty());
+		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
+
+		track.set(TestConfig {
+			value: 2,
+			timeline: None,
+		});
+		let snapshot = match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(catalog))) => catalog,
+			other => panic!("expected custom rendition catalog, got {other:?}"),
+		};
+		let config = snapshot.data.renditions.get("data0").unwrap();
+		assert_eq!(config.value, 2);
+		assert_eq!(config.timeline.as_ref().unwrap().track, "data0.timeline.z");
+
+		track.update(|config| config.value = 3);
+		let snapshot = match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(catalog))) => catalog,
+			other => panic!("expected updated custom rendition catalog, got {other:?}"),
+		};
+		assert_eq!(snapshot.data.renditions["data0"].value, 3);
+
+		drop(track);
+		let snapshot = match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(catalog))) => catalog,
+			other => panic!("expected retired custom rendition catalog, got {other:?}"),
+		};
+		assert!(snapshot.data.renditions.is_empty());
 	}
 }

--- a/rs/moq-mux/src/container/ts/catalog.rs
+++ b/rs/moq-mux/src/container/ts/catalog.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::base64::Base64;
 use serde_with::serde_as;
 
+use crate::catalog::CustomTrackExt;
 use crate::catalog::hang::CatalogExt;
 
 /// The `mpegts` catalog section.
@@ -143,6 +144,14 @@ pub struct Ext {
 }
 
 impl CatalogExt for Ext {}
+
+impl CustomTrackExt for Ext {
+	type Config = Track;
+
+	fn renditions(&mut self) -> &mut BTreeMap<String, Self::Config> {
+		&mut self.mpegts.tracks
+	}
+}
 
 /// Typed `&mut` access to the `mpegts` section of a catalog whose extension is
 /// [`Ext`], or `None` for any other extension.


### PR DESCRIPTION
## Summary

- add a callback-free `CustomTrack<Ext>` sibling to the existing audio and video catalog handles
- let catalog extensions declare their rendition config, storage, and optional timeline field once through `CustomTrackExt`
- share set, update, automatic publication, timeline configuration, and drop cleanup across custom, video, and audio tracks
- implement the extension for MPEG-TS catalog tracks and cover the full custom rendition lifecycle

## Public API changes

- add `catalog::CustomTrack<Ext>`
- add `catalog::CustomTrackExt` with the associated `Config` type and rendition/timeline accessors
- add `catalog::Producer::custom_track(name)`
- preserve the existing nominal `VideoTrack` and `AudioTrack` types and method signatures

All changes are additive and target `main`.

## Test plan

- `nix develop --command cargo test -p moq-mux --no-fail-fast` (359 passed)
- `nix develop --command just check`
- `git diff --check`

No cross-package sync row applies because this only adds a moq-mux catalog API and does not change the wire format.

(Written by GPT-5)
