### PR TITLE
chore(deps): update qmux to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5866,9 +5866,9 @@ dependencies = [
 
 [[package]]
 name = "qmux"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502cf8592d72a612142907f4281e8f6459d6144218bf39f9f36ec5140dc93e73"
+checksum = "90e77a69a65d8d401fa8d3f008afdac42eaa1c71923bace0b6d99c27f03eadc1"
 dependencies = [
  "bytes",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ moq-rtmp = { version = "0.1.3", path = "rs/moq-rtmp" }
 moq-srt = { version = "0.1.2", path = "rs/moq-srt" }
 moq-token = { version = "0.6", path = "rs/moq-token" }
 moq-video = { version = "0.0.6", path = "rs/moq-video" }
-qmux = { version = "0.3", default-features = false }
+qmux = { version = "0.4.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 tokio = "1.48"
 web-async = { version = "0.1.5", features = ["tracing"] }


### PR DESCRIPTION
## Summary

- update the workspace qmux dependency from 0.3 to 0.4.0
- refresh the lockfile to resolve qmux 0.4.0
- keep existing high-level transport integrations unchanged because they remain API-compatible

## Public API changes

None in this repository.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `cargo tree --offline -i qmux`
- `git diff --check`

(Written by GPT-5)
