### PR TITLE
test(moq-native): ignore flaky quiche_webtransport (SIGSEGV on CI)

### DIFF
--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -295,6 +295,9 @@ async fn quiche_raw_quic() {
 #[cfg(feature = "quiche")]
 #[tracing_test::traced_test]
 #[tokio::test]
+#[ignore = "intermittently aborts with SIGSEGV in the boring/quiche C stack on CI (seen on aarch64 \
+            runners). The crash is inside web-transport-quiche / tokio-quiche / BoringSSL, not our \
+            code. Re-enable once the underlying quiche backend teardown bug is fixed."]
 async fn quiche_webtransport() {
 	backend_test("https", moq_native::QuicBackend::Quiche).await;
 }


### PR DESCRIPTION
## Summary

- `#[ignore]` the `quiche_webtransport` integration test in `rs/moq-native/tests/backend.rs`.

## Why

The test intermittently **aborts with SIGSEGV** inside the native quiche/boring C stack (`web-transport-quiche` → `tokio-quiche` → BoringSSL), which fails the entire `just rs ci` run for whatever PR happens to be running at the time. It is not related to the code under test in those PRs.

Observed signature (identical across unrelated branches):

```
SIGSEGV [ 0.202s] ( 768/1701) moq-native::backend quiche_webtransport
(test aborted with signal 11: SIGSEGV)
```

Seen on `ubuntu-24.04-arm` (aarch64) runners; not reproducible on x86_64 (260 local runs clean), consistent with a rare race / arch-specific bug in the C stack rather than our code.

Context:
- Its sibling `quiche_raw_quic` is already `#[ignore]`'d for a related quiche backend bug.
- `dev` already ignores this test too; this brings `main` in line until the underlying quiche teardown crash is fixed.

## Test plan

- `cargo test -p moq-native --features quiche --test backend quiche_webtransport` → now reports `ignored`.
- `cargo fmt -p moq-native --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)