### PR TITLE
chore: let release-plz own the moq-ffi version; drop AI marker from moq-nvenc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4265,7 +4265,7 @@ dependencies = [
 
 [[package]]
 name = "moq-ffi"
-version = "0.3.0"
+version = "0.2.30"
 dependencies = [
  "bytes",
  "hang",

--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley <kixelated@gmail.com>", "Brian Medley <bpm@bmedley.org>"
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.3.0"
+version = "0.2.30"
 edition = "2024"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]

--- a/rs/moq-nvenc/Cargo.toml
+++ b/rs/moq-nvenc/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT"
 rust-version = "1.85"
 
-description = "(AI GENERATED) NVENC hardware video encoder bindings, forked from ViliamVadocz/nvidia-video-codec-sdk with runtime dynamic loading (dlopen only)"
+description = "NVENC hardware video encoder bindings, forked from ViliamVadocz/nvidia-video-codec-sdk with runtime dynamic loading (dlopen only)"
 repository = "https://github.com/moq-dev/moq"
 readme = "README.md"
 


### PR DESCRIPTION
Two publish-surface fixes found while reviewing `dev` for the next merge to `main`. Both are inert until `dev` reaches `main`, since Release RS (release-plz) only runs on push to `main`.

## moq-ffi: drop the hand-bump

`rs/moq-ffi/Cargo.toml` was hand-bumped to `0.3.0` in #2037, but its CHANGELOG's newest released header and the published crate both sit at `0.2.30`. That asserts the version in the manifest *and* derives it from commit history: two sources that can disagree, which reds Release RS when they do. CONTRIBUTING.md:23 already forbids this.

Reverted to `0.2.30` so release-plz computes the bump. It lands on `0.3.0` regardless: four breaking commits touch `rs/moq-ffi` since the `moq-ffi-v0.2.30` tag (#2236, #2127, #2037, #1761), and a breaking bump on a 0.x crate takes `0.2.30` -> `0.3.0`. Same version the hand-bump asserted, so `py/moq-rs`'s `moq-ffi ~= 0.3.0` floor still resolves.

Audited all 27 workspace crates two ways (manifest vs newest CHANGELOG header, manifest vs crates.io). moq-ffi was the only mismatch; everything else is in sync.

## moq-nvenc: drop the AI marker

Its `description` began with `(AI GENERATED)`. The crate is a workspace member without `publish = false`, so merging to `main` publishes it to crates.io carrying that string, and published metadata can't be edited afterward.

## Notes

- `Cargo.lock` regenerated for the version change.
- No code changes; `taplo format --check` passes.
- Not addressed here: `moq-nvenc` and `moq-transcode` both first-publish at `0.0.1` on the next `dev` -> `main`, permanently claiming those crates.io names. Worth a deliberate call on whether both should be public.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)