### PR TITLE
refactor(moq-net)!: remove Announced::Restart; a replacement is an unannounce/announce pair

### DIFF
--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -42,13 +42,9 @@ async fn run_session(origin: moq_net::origin::Producer) -> anyhow::Result<()> {
 // Subscribe to a broadcast and read media frames.
 async fn run_subscribe(consumer: moq_net::origin::Consumer) -> anyhow::Result<()> {
 	// Wait for a broadcast to be announced.
-	let moq_net::announce::Update {
-		path, event: broadcast, ..
-	} = consumer.announced().next().await.context("origin closed")?;
+	let moq_net::announce::Update { path, broadcast } = consumer.announced().next().await.context("origin closed")?;
 
-	let broadcast = broadcast
-		.broadcast()
-		.with_context(|| format!("broadcast unannounced: {path}"))?;
+	let broadcast = broadcast.with_context(|| format!("broadcast unannounced: {path}"))?;
 
 	tracing::info!(%path, "broadcast announced");
 

--- a/rs/libmoq/src/origin.rs
+++ b/rs/libmoq/src/origin.rs
@@ -80,7 +80,7 @@ impl Origin {
 	) -> Result<(), Error> {
 		loop {
 			// `biased` so a pending close always wins over a ready announcement.
-			let moq_net::announce::Update { path, event, .. } = tokio::select! {
+			let moq_net::announce::Update { path, broadcast } = tokio::select! {
 				biased;
 				_ = &mut close => return Ok(()),
 				next = consumer.next() => match next {
@@ -94,7 +94,7 @@ impl Origin {
 			let announced_id = State::lock()
 				.origin
 				.announced
-				.insert((path.to_string(), event.broadcast().is_some()))?;
+				.insert((path.to_string(), broadcast.is_some()))?;
 			callback.call(announced_id);
 		}
 	}

--- a/rs/libmoq/src/origin.rs
+++ b/rs/libmoq/src/origin.rs
@@ -90,7 +90,6 @@ impl Origin {
 			};
 
 			// Hold the lock only to buffer the announcement; release it before the callback.
-			// Active and Restart both carry a broadcast; Ended does not.
 			let announced_id = State::lock()
 				.origin
 				.announced

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -239,10 +239,10 @@ async fn subscribe(
 	let mut seen: HashSet<String> = HashSet::new();
 
 	while (seen.len() as u64) < want {
-		let Some(moq_net::announce::Update { path, event, .. }) = announced.next().await else {
+		let Some(moq_net::announce::Update { path, broadcast }) = announced.next().await else {
 			break;
 		};
-		let Some(broadcast) = event.broadcast() else {
+		let Some(broadcast) = broadcast else {
 			continue;
 		};
 

--- a/rs/moq-boy/src/input.rs
+++ b/rs/moq-boy/src/input.rs
@@ -65,13 +65,13 @@ pub async fn handle_viewers(
 	cmd_tx: &tokio::sync::mpsc::Sender<Command>,
 ) -> anyhow::Result<()> {
 	loop {
-		let Some(moq_net::announce::Update { path, event, .. }) = viewer_origin.next().await else {
+		let Some(moq_net::announce::Update { path, broadcast }) = viewer_origin.next().await else {
 			break;
 		};
 
 		let viewer_id = path.to_string();
 
-		if let Some(broadcast) = event.broadcast() {
+		if let Some(broadcast) = broadcast {
 			tracing::info!(%viewer_id, "viewer connected");
 			let cmd_tx = cmd_tx.clone();
 			let vid = viewer_id.clone();

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -57,7 +57,9 @@ impl Announced {
 	async fn next(&mut self) -> Result<Option<Arc<MoqAnnouncement>>, MoqError> {
 		loop {
 			match self.inner.next().await {
-				// Active and Restart both carry a broadcast; skip unannounce events.
+				// Skip unannounce events; this surface only reports availability. A
+				// replacement arrives as an unannounce/announce pair, so the caller
+				// still sees a single announcement carrying the new broadcast.
 				Some(moq_net::announce::Update { path, broadcast }) => {
 					let Some(broadcast) = broadcast else {
 						continue;
@@ -77,7 +79,7 @@ impl Announced {
 	async fn available(&mut self) -> Result<Arc<MoqBroadcastConsumer>, MoqError> {
 		loop {
 			match self.inner.next().await {
-				// Active and Restart both carry a broadcast; skip unannounce events.
+				// Skip unannounce events; we're waiting for the broadcast to become available.
 				Some(moq_net::announce::Update { broadcast, .. }) => match broadcast {
 					Some(broadcast) => return Ok(Arc::new(MoqBroadcastConsumer::new(broadcast))),
 					None => continue,

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -58,8 +58,8 @@ impl Announced {
 		loop {
 			match self.inner.next().await {
 				// Active and Restart both carry a broadcast; skip unannounce events.
-				Some(moq_net::announce::Update { path, event, .. }) => {
-					let Some(broadcast) = event.broadcast() else {
+				Some(moq_net::announce::Update { path, broadcast }) => {
+					let Some(broadcast) = broadcast else {
 						continue;
 					};
 					let hops = broadcast.info().hops.iter().map(|origin| origin.id()).collect();
@@ -78,7 +78,7 @@ impl Announced {
 		loop {
 			match self.inner.next().await {
 				// Active and Restart both carry a broadcast; skip unannounce events.
-				Some(moq_net::announce::Update { event, .. }) => match event.broadcast() {
+				Some(moq_net::announce::Update { broadcast, .. }) => match broadcast {
 					Some(broadcast) => return Ok(Arc::new(MoqBroadcastConsumer::new(broadcast))),
 					None => continue,
 				},

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -107,7 +107,7 @@ async fn main() -> anyhow::Result<()> {
 
 			loop {
 				tokio::select! {
-					Some(moq_net::announce::Update { path, event, .. }) = origin.next() => match event.broadcast() {
+					Some(moq_net::announce::Update { path, broadcast }) = origin.next() => match broadcast {
 						Some(broadcast) => {
 							tracing::info!(broadcast = %path, "broadcast is online, subscribing to track");
 							let track = broadcast

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -65,14 +65,14 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 		.expect("client connect timed out")
 		.expect("client connect failed");
 
-	let moq_native::moq_net::announce::Update { path, event: bc, .. } =
+	let moq_native::moq_net::announce::Update { path, broadcast: bc } =
 		tokio::time::timeout(TIMEOUT, announcements.next())
 			.await
 			.expect("announce timed out")
 			.expect("origin closed");
 
 	assert_eq!(path.as_str(), "test");
-	let bc = bc.broadcast().expect("expected announce, got unannounce");
+	let bc = bc.expect("expected announce, got unannounce");
 
 	let mut track_sub = bc
 		.track("video")
@@ -342,14 +342,14 @@ async fn iroh_connect() {
 		.expect("client connect timed out")
 		.expect("client connect failed");
 
-	let moq_native::moq_net::announce::Update { path, event: bc, .. } =
+	let moq_native::moq_net::announce::Update { path, broadcast: bc } =
 		tokio::time::timeout(TIMEOUT, announcements.next())
 			.await
 			.expect("announce timed out")
 			.expect("origin closed");
 
 	assert_eq!(path.as_str(), "test");
-	let bc = bc.broadcast().expect("expected announce, got unannounce");
+	let bc = bc.expect("expected announce, got unannounce");
 
 	let mut track_sub = bc
 		.track("video")

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -570,9 +570,9 @@ async fn next_announce(announcements: &mut moq_net::announce::Consumer) -> moq_n
 }
 
 /// Lite06 announce lifecycle end-to-end: initial set, live announce, unannounce,
-/// re-announce, and restart. On lite-06 every retraction/restart references the
-/// implicit announce id rather than repeating the path (the path form doesn't even
-/// encode), so this exercises the id bookkeeping on both sides of the session.
+/// re-announce, and replacement. On lite-06 every retraction references the implicit
+/// announce id rather than repeating the path (the path form doesn't even encode), so
+/// this exercises the id bookkeeping on both sides of the session.
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_moq_lite_06_announce_lifecycle() {
@@ -636,9 +636,9 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 	assert_eq!(path.as_str(), "second");
 	assert!(matches!(event, Event::Active(_)), "expected re-announce");
 
-	// Restart: publish a replacement at "first" and retire the original. Whichever
-	// of the two transitions wins the origin's route tie-break, downstream sees a
-	// single atomic restart (never an unannounce).
+	// Replace the broadcast at "first": publish a replacement, then retire the original
+	// so the origin promotes it. A replacement is an unannounce/announce pair, which on
+	// the wire retires the old id and assigns a fresh one.
 	let mut replacement_info = moq_net::broadcast::Info::new();
 	replacement_info.origin = pub_origin.info();
 	let replacement = replacement_info.produce();
@@ -648,9 +648,12 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 	drop(first);
 	let moq_net::announce::Update { path, event, .. } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "first");
-	assert!(matches!(event, Event::Restart(_)), "expected restart");
+	assert!(matches!(event, Event::Ended), "expected the replaced unannounce");
+	let moq_net::announce::Update { path, event, .. } = next_announce(&mut announcements).await;
+	assert_eq!(path.as_str(), "first");
+	assert!(matches!(event, Event::Active(_)), "expected the replacement announce");
 
-	// A sentinel proves no stray unannounce for "first" snuck in behind the restart.
+	// A sentinel proves no stray event for "first" snuck in behind the replacement.
 	let _sentinel = pub_origin.create_broadcast("sentinel").expect("create broadcast");
 	let moq_net::announce::Update { path, event, .. } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "sentinel");

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -78,14 +78,14 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 		.expect("client connect failed");
 
 	// Wait for the broadcast announcement.
-	let moq_native::moq_net::announce::Update { path, event: bc, .. } =
+	let moq_native::moq_net::announce::Update { path, broadcast: bc } =
 		tokio::time::timeout(TIMEOUT, announcements.next())
 			.await
 			.expect("announce timed out")
 			.expect("origin closed");
 
 	assert_eq!(path.as_str(), "test");
-	let bc = bc.broadcast().expect("expected announce, got unannounce");
+	let bc = bc.expect("expected announce, got unannounce");
 
 	// Subscribe to the track.
 	let mut track_sub = bc
@@ -184,13 +184,13 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 		.expect("client connect timed out")
 		.expect("client connect failed");
 
-	let moq_native::moq_net::announce::Update { path, event: bc, .. } =
+	let moq_native::moq_net::announce::Update { path, broadcast: bc } =
 		tokio::time::timeout(TIMEOUT, announcements.next())
 			.await
 			.expect("announce timed out")
 			.expect("origin closed");
 	assert_eq!(path.as_str(), "test");
-	let bc = bc.broadcast().expect("expected announce, got unannounce");
+	let bc = bc.expect("expected announce, got unannounce");
 
 	let mut track_sub = bc
 		.track("video")
@@ -299,13 +299,13 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 		.expect("client connect timed out")
 		.expect("client connect failed");
 
-	let moq_native::moq_net::announce::Update { path, event: bc, .. } =
+	let moq_native::moq_net::announce::Update { path, broadcast: bc } =
 		tokio::time::timeout(TIMEOUT, announcements.next())
 			.await
 			.expect("announce timed out")
 			.expect("origin closed");
 	assert_eq!(path.as_str(), "test");
-	let bc = bc.broadcast().expect("expected announce, got unannounce");
+	let bc = bc.expect("expected announce, got unannounce");
 
 	// Fetch group 0 directly, without subscribing. No live producer holds the group
 	// on the client, so this issues a wire FETCH upstream.
@@ -421,13 +421,13 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 		.expect("client connect timed out")
 		.expect("client connect failed");
 
-	let moq_native::moq_net::announce::Update { path, event: bc, .. } =
+	let moq_native::moq_net::announce::Update { path, broadcast: bc } =
 		tokio::time::timeout(TIMEOUT, announcements.next())
 			.await
 			.expect("announce timed out")
 			.expect("origin closed");
 	assert_eq!(path.as_str(), "test");
-	let bc = bc.broadcast().expect("expected announce, got unannounce");
+	let bc = bc.expect("expected announce, got unannounce");
 
 	// Subscribe (starts at the latest group) and read the live group, which
 	// establishes the upstream subscription and leaves it active.
@@ -526,11 +526,12 @@ async fn broadcast_moq_lite_05_default_timescale() {
 		.expect("connect timeout")
 		.expect("connect failed");
 
-	let moq_native::moq_net::announce::Update { event: bc, .. } = tokio::time::timeout(TIMEOUT, announcements.next())
-		.await
-		.expect("announce timeout")
-		.expect("origin closed");
-	let bc = bc.broadcast().expect("expected announce");
+	let moq_native::moq_net::announce::Update { broadcast: bc, .. } =
+		tokio::time::timeout(TIMEOUT, announcements.next())
+			.await
+			.expect("announce timeout")
+			.expect("origin closed");
+	let bc = bc.expect("expected announce");
 
 	let mut track_sub = bc
 		.track("video")
@@ -576,8 +577,6 @@ async fn next_announce(announcements: &mut moq_net::announce::Consumer) -> moq_n
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_moq_lite_06_announce_lifecycle() {
-	use moq_net::announce::Event;
-
 	let pub_origin = Origin::random().produce();
 
 	// Announced before the client connects, so it rides the initial set.
@@ -614,27 +613,27 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 		.expect("connect failed");
 
 	// The initial set: "first" was announced before the session existed.
-	let moq_net::announce::Update { path, event, .. } = next_announce(&mut announcements).await;
+	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "first");
-	assert!(matches!(event, Event::Active(_)), "expected initial announce");
+	assert!(broadcast.is_some(), "expected initial announce");
 
 	// A live announce after the initial set.
 	let second = pub_origin.create_broadcast("second").expect("create broadcast");
-	let moq_net::announce::Update { path, event, .. } = next_announce(&mut announcements).await;
+	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "second");
-	assert!(matches!(event, Event::Active(_)), "expected live announce");
+	assert!(broadcast.is_some(), "expected live announce");
 
 	// Unannounce: retracted by announce id on the wire.
 	drop(second);
-	let moq_net::announce::Update { path, event, .. } = next_announce(&mut announcements).await;
+	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "second");
-	assert!(matches!(event, Event::Ended), "expected unannounce");
+	assert!(broadcast.is_none(), "expected unannounce");
 
 	// Re-announce the same path: a fresh announce assigning a fresh id.
 	let _second = pub_origin.create_broadcast("second").expect("create broadcast");
-	let moq_net::announce::Update { path, event, .. } = next_announce(&mut announcements).await;
+	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "second");
-	assert!(matches!(event, Event::Active(_)), "expected re-announce");
+	assert!(broadcast.is_some(), "expected re-announce");
 
 	// Replace the broadcast at "first": publish a replacement, then retire the original
 	// so the origin promotes it. A replacement is an unannounce/announce pair, which on
@@ -646,18 +645,18 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 		.publish_broadcast("first", &replacement)
 		.expect("publish replacement");
 	drop(first);
-	let moq_net::announce::Update { path, event, .. } = next_announce(&mut announcements).await;
+	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "first");
-	assert!(matches!(event, Event::Ended), "expected the replaced unannounce");
-	let moq_net::announce::Update { path, event, .. } = next_announce(&mut announcements).await;
+	assert!(broadcast.is_none(), "expected the replaced unannounce");
+	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "first");
-	assert!(matches!(event, Event::Active(_)), "expected the replacement announce");
+	assert!(broadcast.is_some(), "expected the replacement announce");
 
 	// A sentinel proves no stray event for "first" snuck in behind the replacement.
 	let _sentinel = pub_origin.create_broadcast("sentinel").expect("create broadcast");
-	let moq_net::announce::Update { path, event, .. } = next_announce(&mut announcements).await;
+	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "sentinel");
-	assert!(matches!(event, Event::Active(_)), "expected sentinel announce");
+	assert!(broadcast.is_some(), "expected sentinel announce");
 
 	drop(session);
 	server_handle
@@ -1083,14 +1082,14 @@ async fn broadcast_websocket() {
 		.expect("client connect failed");
 
 	// Wait for the broadcast announcement.
-	let moq_native::moq_net::announce::Update { path, event: bc, .. } =
+	let moq_native::moq_net::announce::Update { path, broadcast: bc } =
 		tokio::time::timeout(TIMEOUT, announcements.next())
 			.await
 			.expect("announce timed out")
 			.expect("origin closed");
 
 	assert_eq!(path.as_str(), "test");
-	let bc = bc.broadcast().expect("expected announce, got unannounce");
+	let bc = bc.expect("expected announce, got unannounce");
 
 	// Subscribe to the track.
 	let mut track_sub = bc
@@ -1194,14 +1193,14 @@ async fn broadcast_websocket_fallback() {
 		.expect("client connect failed");
 
 	// Wait for the broadcast announcement.
-	let moq_native::moq_net::announce::Update { path, event: bc, .. } =
+	let moq_native::moq_net::announce::Update { path, broadcast: bc } =
 		tokio::time::timeout(TIMEOUT, announcements.next())
 			.await
 			.expect("announce timed out")
 			.expect("origin closed");
 
 	assert_eq!(path.as_str(), "test");
-	let bc = bc.broadcast().expect("expected announce, got unannounce");
+	let bc = bc.expect("expected announce, got unannounce");
 
 	// Subscribe to the track.
 	let mut track_sub = bc
@@ -1444,13 +1443,13 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 		.expect("connect timeout")
 		.expect("connect failed");
 
-	let moq_native::moq_net::announce::Update { path, event: bc, .. } =
+	let moq_native::moq_net::announce::Update { path, broadcast: bc } =
 		tokio::time::timeout(TIMEOUT, announcements.next())
 			.await
 			.expect("announce timeout")
 			.expect("origin closed");
 	assert_eq!(path.as_str(), "test");
-	let bc = bc.broadcast().expect("expected announce");
+	let bc = bc.expect("expected announce");
 
 	// First subscription: receive group 0.
 	let mut sub1 = bc.track("video").unwrap().subscribe(None).await.expect("subscribe1");
@@ -1646,13 +1645,13 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 		.expect("client connect failed");
 
 	// The "allowed" announce stream still delivers even though "denied" was FINed.
-	let moq_native::moq_net::announce::Update { path, event: bc, .. } =
+	let moq_native::moq_net::announce::Update { path, broadcast: bc } =
 		tokio::time::timeout(TIMEOUT, announcements.next())
 			.await
 			.expect("announce timed out")
 			.expect("origin closed");
 	assert_eq!(path.as_str(), "allowed/test");
-	assert!(bc.broadcast().is_some(), "expected announce, got unannounce");
+	assert!(bc.is_some(), "expected announce, got unannounce");
 
 	// The unauthorized "denied" interest must not have torn down the session.
 	assert!(
@@ -1699,13 +1698,13 @@ async fn publish_only_client_to_subscribe_only_server() {
 
 		// The client serves "allowed/test"; the "denied" interest is FINed but must not
 		// tear down the session.
-		let moq_native::moq_net::announce::Update { path, event: bc, .. } =
+		let moq_native::moq_net::announce::Update { path, broadcast: bc } =
 			tokio::time::timeout(TIMEOUT, announcements.next())
 				.await
 				.expect("announce timed out")
 				.expect("origin closed");
 		assert_eq!(path.as_str(), "allowed/test");
-		let bc = bc.broadcast().expect("expected announce, got unannounce");
+		let bc = bc.expect("expected announce, got unannounce");
 
 		let mut track_sub = bc
 			.track("video")

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -525,11 +525,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				announce::Event::Active(_) => {
 					self.announce_namespace(suffix, &mut namespace_streams).await?;
 				}
-				announce::Event::Restart(_) => {
-					// moq-transport has no RESTART; fall back to done + re-announce.
-					self.unannounce_namespace(&suffix, &mut namespace_streams).await;
-					self.announce_namespace(suffix, &mut namespace_streams).await?;
-				}
 				announce::Event::Ended => {
 					self.unannounce_namespace(&suffix, &mut namespace_streams).await;
 				}
@@ -690,9 +685,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			_ => {
 				let mut announced = origin.announced();
 
-				// Send initial NAMESPACE messages for currently active namespaces
 				// Send initial NAMESPACE messages for currently active namespaces.
-				// A restart is indistinguishable from an active here (the namespace is present).
 				while let Some(crate::announce::Update { path, event, .. }) = announced.try_next() {
 					if event.broadcast().is_some() {
 						let suffix = path
@@ -721,15 +714,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 						match event {
 							announce::Event::Active(_) => {
-								tracing::debug!(broadcast = %absolute, "namespace");
-								stream.writer.encode(&ietf::Namespace::ID).await?;
-								stream.writer.encode(&ietf::Namespace { suffix }).await?;
-							}
-							announce::Event::Restart(_) => {
-								// moq-transport has no RESTART; fall back to namespace_done + namespace.
-								tracing::debug!(broadcast = %absolute, "namespace_done");
-								stream.writer.encode(&ietf::NamespaceDone::ID).await?;
-								stream.writer.encode(&ietf::NamespaceDone { suffix: suffix.clone() }).await?;
 								tracing::debug!(broadcast = %absolute, "namespace");
 								stream.writer.encode(&ietf::Namespace::ID).await?;
 								stream.writer.encode(&ietf::Namespace { suffix }).await?;

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -1,4 +1,4 @@
-use crate::{announce, group, origin, track};
+use crate::{group, origin, track};
 use std::collections::HashMap;
 
 use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
@@ -515,17 +515,17 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				next = announced.next() => next,
 			};
 
-			let Some(crate::announce::Update { path, event, .. }) = next else {
+			let Some(crate::announce::Update { path, broadcast }) = next else {
 				break;
 			};
 
 			let suffix = path.to_owned();
 
-			match event {
-				announce::Event::Active(_) => {
+			match broadcast {
+				Some(_) => {
 					self.announce_namespace(suffix, &mut namespace_streams).await?;
 				}
-				announce::Event::Ended => {
+				None => {
 					self.unannounce_namespace(&suffix, &mut namespace_streams).await;
 				}
 			}
@@ -686,8 +686,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				let mut announced = origin.announced();
 
 				// Send initial NAMESPACE messages for currently active namespaces.
-				while let Some(crate::announce::Update { path, event, .. }) = announced.try_next() {
-					if event.broadcast().is_some() {
+				while let Some(crate::announce::Update { path, broadcast }) = announced.try_next() {
+					if broadcast.is_some() {
 						let suffix = path
 							.strip_prefix(&prefix)
 							.expect("origin returned invalid path")
@@ -704,7 +704,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						biased;
 						res = stream.reader.closed() => return res,
 					next = announced.next() => {
-						let Some(crate::announce::Update { path, event, .. }) = next else {
+						let Some(crate::announce::Update { path, broadcast }) = next else {
 							stream.writer.finish()?;
 							return stream.writer.closed().await;
 						};
@@ -712,13 +712,13 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						let suffix = path.strip_prefix(&prefix).expect("origin returned invalid path").to_owned();
 						let absolute = origin.absolute(&path).to_owned();
 
-						match event {
-							announce::Event::Active(_) => {
+						match broadcast {
+							Some(_) => {
 								tracing::debug!(broadcast = %absolute, "namespace");
 								stream.writer.encode(&ietf::Namespace::ID).await?;
 								stream.writer.encode(&ietf::Namespace { suffix }).await?;
 							}
-							announce::Event::Ended => {
+							None => {
 								tracing::debug!(broadcast = %absolute, "namespace_done");
 								stream.writer.encode(&ietf::NamespaceDone::ID).await?;
 								stream.writer.encode(&ietf::NamespaceDone { suffix }).await?;

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -15,8 +15,10 @@ const ANNOUNCE_RESTART: u64 = 2;
 /// Whether the negotiated version carries restart (REANNOUNCE) semantics. On lite-05 a restart
 /// travels as a duplicate ANNOUNCE (a second `active` for an already-announced path); on lite-06+
 /// it is the explicit `restart` status referencing an announce id. Older versions never defined
-/// this, so we neither send nor interpret it there; a restart is sent as an unannounce followed
-/// by a fresh announce instead.
+/// this, so a duplicate ANNOUNCE is a protocol violation there rather than a restart.
+///
+/// This is a receive-side capability: we only ever advertise a replacement as an unannounce
+/// followed by a fresh announce, but a peer may still restart.
 pub fn restart_supported(version: Version) -> bool {
 	// Explicitly list older versions so future versions default to supported.
 	!matches!(
@@ -46,6 +48,8 @@ pub enum AnnounceBroadcast<'a> {
 	EndedId { id: u64 },
 	/// ANNOUNCE_RESTART (lite-06+): atomically replace the announcement with this id
 	/// (e.g. a new hop chain after a relay failover). The id stays live.
+	///
+	/// Only ever received: we advertise a replacement as an `EndedId` + `Active` pair.
 	Restart { id: u64, hops: OriginList },
 }
 
@@ -171,11 +175,11 @@ impl AnnounceBroadcast<'_> {
 		Ok(match status {
 			AnnounceStatus::Active => Self::Active { suffix, hops },
 			AnnounceStatus::Ended => Self::Ended { suffix, hops },
-			// On lite-05 we encode a restart as a duplicate ANNOUNCE (a second `Active`), but we
-			// also accept the draft's explicit `restart` status and treat it the same. For an
-			// already-announced path the subscriber turns it into a restart; for an unknown path
-			// it's a fresh announce. Older versions never defined this status, so it's an invalid
-			// value there.
+			// On lite-05 a restart travels as a duplicate ANNOUNCE (a second `Active`), so accept
+			// the draft's explicit `restart` status and treat it the same. Either way the
+			// subscriber retires an already-announced path before republishing it; for an unknown
+			// path it's a fresh announce. Older versions never defined this status, so it's an
+			// invalid value there.
 			AnnounceStatus::Restart if restart_supported(version) => Self::Active { suffix, hops },
 			AnnounceStatus::Restart => return Err(DecodeError::InvalidValue),
 		})
@@ -229,9 +233,8 @@ impl Message for AnnounceRequest<'_> {
 enum AnnounceStatus {
 	Ended = 0,
 	Active = 1,
-	/// The explicit restart status. Encoded on lite-06+ (referencing an announce id); on lite-05
-	/// a restart goes out as a duplicate `Active` instead, but we still accept the explicit
-	/// status on decode for forward/cross-compatibility.
+	/// The explicit restart status, accepted on decode for forward/cross-compatibility. We never
+	/// encode it: a replacement goes out as an `Ended` + `Active` pair.
 	Restart = 2,
 }
 
@@ -358,7 +361,7 @@ mod tests {
 	}
 
 	// On lite-05+ the explicit `restart` status is accepted and surfaced as an `Active` (the
-	// subscriber turns it into a restart for an already-announced path).
+	// subscriber retires an already-announced path before republishing it).
 	#[test]
 	fn decodes_explicit_restart_status_as_active_on_lite05() {
 		let version = Version::Lite05;

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -212,9 +212,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			std::collections::HashMap::new();
 
 		// Lite06+: announce ids. Every `active` we send implicitly assigns the next
-		// per-stream ordinal, and `ended`/`restart` reference the id instead of
-		// repeating the path. Keyed by suffix; only announces that actually hit the
-		// wire get an id (filtered ones were never seen by the peer).
+		// per-stream ordinal, and `ended` references the id instead of repeating the
+		// path. Keyed by suffix; only announces that actually hit the wire get an id
+		// (filtered ones were never seen by the peer).
 		let mut next_announce_id: u64 = 0;
 		let mut announce_ids: std::collections::HashMap<crate::PathOwned, u64> = std::collections::HashMap::new();
 
@@ -231,8 +231,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						.to_owned();
 					let absolute = origin.absolute(&path).to_owned();
 
-					// Lite01/02 only carries the set of active paths, so a restart is
-					// indistinguishable from an active here.
 					if event.broadcast().is_some() {
 						tracing::debug!(broadcast = %absolute, "announce");
 						let guard = stats.broadcast(&absolute).publisher();
@@ -367,67 +365,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 									next_announce_id += 1;
 								}
 								stream.writer.encode(&lite::AnnounceBroadcast::Active { suffix, hops }).await?;
-							}
-							announce::Event::Restart(active) => {
-								// On lite-06+ a restart references the announce id. On lite-05 it
-								// travels as a duplicate ANNOUNCE (a second `Active` for an
-								// already-announced path). Older versions never defined either, so
-								// split it into an unannounce followed by a fresh announce.
-								let info = active.info();
-								match Self::prepare_active_hops(&info.hops, self_origin, exclude_hop, version, &absolute) {
-									Some(hops) => {
-										tracing::debug!(broadcast = %absolute, "restart");
-										let bs = stats.broadcast(&absolute);
-										// Continuity: keep the existing stats guard (no close + reopen).
-										if version.has_announce_id() {
-											// One message on the wire, one name-length count.
-											bs.publisher_announced_bytes(absolute.as_str().len() as u64);
-											if let Some(&id) = announce_ids.get(&suffix) {
-												stream.writer.encode(&lite::AnnounceBroadcast::Restart { id, hops }).await?;
-											} else {
-												// The prior announcement was filtered, so the peer never saw
-												// it: this is a fresh announce, assigning the next id.
-												stats_guards.entry(absolute.clone()).or_insert_with(|| bs.publisher());
-												announce_ids.insert(suffix.clone(), next_announce_id);
-												next_announce_id += 1;
-												stream.writer.encode(&lite::AnnounceBroadcast::Active { suffix, hops }).await?;
-											}
-										} else if lite::restart_supported(version) {
-											// One Active message on the wire, one name-length count.
-											bs.publisher_announced_bytes(absolute.as_str().len() as u64);
-											stream.writer.encode(&lite::AnnounceBroadcast::Active { suffix, hops }).await?;
-										} else {
-											// Ended + Active pair, so count the name twice.
-											bs.publisher_announced_bytes(2 * absolute.as_str().len() as u64);
-											stream
-												.writer
-												.encode(&lite::AnnounceBroadcast::Ended {
-													suffix: suffix.clone(),
-													hops: OriginList::new(),
-												})
-												.await?;
-											stream.writer.encode(&lite::AnnounceBroadcast::Active { suffix, hops }).await?;
-										}
-									}
-									None => {
-										// The replacement loops back to us; from this peer's view the broadcast is gone.
-										tracing::debug!(broadcast = %absolute, "restart replacement looped; unannouncing");
-										stats_guards.remove(&absolute);
-										if version.has_announce_id() {
-											// Retract by id; nothing to send if the prior announcement was
-											// filtered and the peer never saw it.
-											if let Some(id) = announce_ids.remove(&suffix) {
-												stats.broadcast(&absolute)
-													.publisher_announced_bytes(absolute.as_str().len() as u64);
-												stream.writer.encode(&lite::AnnounceBroadcast::EndedId { id }).await?;
-											}
-										} else {
-											stats.broadcast(&absolute)
-												.publisher_announced_bytes(absolute.as_str().len() as u64);
-											stream.writer.encode(&lite::AnnounceBroadcast::Ended { suffix, hops: OriginList::new() }).await?;
-										}
-									}
-								}
 							}
 							announce::Event::Ended => {
 								tracing::debug!(broadcast = %absolute, "unannounce");

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -224,14 +224,14 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 				// Send ANNOUNCE_INIT as the first message with all currently active paths
 				// We use `try_next()` to synchronously get the initial updates.
-				while let Some(crate::announce::Update { path, event, .. }) = announced.try_next() {
+				while let Some(crate::announce::Update { path, broadcast }) = announced.try_next() {
 					let suffix = path
 						.strip_prefix(&prefix)
 						.expect("origin returned invalid path")
 						.to_owned();
 					let absolute = origin.absolute(&path).to_owned();
 
-					if event.broadcast().is_some() {
+					if broadcast.is_some() {
 						tracing::debug!(broadcast = %absolute, "announce");
 						let guard = stats.broadcast(&absolute).publisher();
 						stats_guards.entry(absolute).or_insert(guard);
@@ -263,14 +263,14 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				// them afterward. The receiver stamps our origin onto each hop chain, so we
 				// forward the stored chain as-is (no self push here).
 				let mut initial: Vec<(crate::PathOwned, OriginList)> = Vec::new();
-				while let Some(crate::announce::Update { path, event, .. }) = announced.try_next() {
+				while let Some(crate::announce::Update { path, broadcast }) = announced.try_next() {
 					let suffix = path
 						.strip_prefix(&prefix)
 						.expect("origin returned invalid path")
 						.to_owned();
 					let absolute = origin.absolute(&path).to_owned();
 
-					match event.broadcast() {
+					match broadcast {
 						Some(broadcast) => {
 							let info = broadcast.info();
 							let hops = &info.hops;
@@ -338,7 +338,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				biased;
 				res = stream.reader.closed() => return res,
 				next = announced.next() => {
-						let Some(crate::announce::Update { path, event, .. }) = next else {
+						let Some(crate::announce::Update { path, broadcast }) = next else {
 							stream.writer.finish()?;
 							return stream.writer.closed().await;
 						};
@@ -346,8 +346,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						let suffix = path.strip_prefix(&prefix).expect("origin returned invalid path").to_owned();
 						let absolute = origin.absolute(&path).to_owned();
 
-						match event {
-							announce::Event::Active(active) => {
+						match broadcast {
+							Some(active) => {
 								let info = active.info();
 								let Some(hops) = Self::prepare_active_hops(&info.hops, self_origin, exclude_hop, version, &absolute) else {
 									continue;
@@ -366,7 +366,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 								}
 								stream.writer.encode(&lite::AnnounceBroadcast::Active { suffix, hops }).await?;
 							}
-							announce::Event::Ended => {
+							None => {
 								tracing::debug!(broadcast = %absolute, "unannounce");
 								stats_guards.remove(&absolute);
 								if version.has_announce_id() {

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -220,7 +220,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// Lite06+: announce ids. Each received `active` implicitly assigns the next
 		// per-stream ordinal; `ended`/`restart` reference it instead of repeating the
 		// path. Tracked even for announces we drop locally (reflected loops), since
-		// the sender doesn't know we dropped them.
+		// the sender doesn't know we dropped them. We never send a restart ourselves,
+		// but a peer may.
 		let mut next_announce_id: u64 = 0;
 		let mut announced_by_id: HashMap<u64, PathOwned> = HashMap::new();
 
@@ -291,23 +292,16 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						announced_by_id.insert(next_announce_id, path.clone());
 						next_announce_id += 1;
 					}
-					if lite::restart_supported(self.version)
-						&& !self.version.has_announce_id()
-						&& producers.contains_key(&path)
-					{
-						// lite-05 only: a duplicate ANNOUNCE for an already-announced path is a RESTART;
-						// atomically replace the broadcast. Lite06+ restarts by announce id, and older
-						// versions never defined restarts, so both fall through to start_announce, which
-						// rejects the duplicate (Error::Duplicate).
-						if self.restart_announce(path.clone(), hops, responder_origin, &mut producers)? {
-							// Continuity: keep the existing stats guard if present.
-							stats_guards
-								.entry(abs.clone())
-								.or_insert_with(|| self.stats.broadcast(&abs).subscriber());
-						} else {
-							stats_guards.remove(&abs);
-						}
-					} else if self.start_announce(path.clone(), hops, responder_origin, &mut producers)? {
+					if lite::restart_supported(self.version) && !self.version.has_announce_id() {
+						// lite-05 only: a duplicate ANNOUNCE for an already-announced path is a
+						// RESTART. Retire the old announcement so the replacement arrives as a
+						// fresh announce; the origin has no atomic swap. A no-op for a path we
+						// haven't announced, which is the common case. Lite06+ restarts by
+						// announce id, and older versions never defined restarts, so both fall
+						// through to start_announce, which rejects a duplicate (Error::Duplicate).
+						Self::retire_announce(&path, &abs, &mut producers, &mut stats_guards);
+					}
+					if self.start_announce(path.clone(), hops, responder_origin, &mut producers)? {
 						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
 					}
 					// The first `initial_count` Active messages are the initial set; once
@@ -328,13 +322,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						.broadcast(&abs)
 						.subscriber_announced_bytes(abs.as_str().len() as u64);
 
-					// The matching Active may have been silently dropped by
-					// start_announce as a reflected loop, in which case
-					// `producers` has no entry; that's expected, not an error.
-					// Dropping the entry drops its origin::Publish guard, which unannounces.
-					if producers.remove(&path).is_some() {
-						stats_guards.remove(&abs);
-					}
+					Self::retire_announce(&path, &abs, &mut producers, &mut stats_guards);
 				}
 				lite::AnnounceBroadcast::EndedId { id } => {
 					// Resolve and retire the id; an unknown or already-retired id is a
@@ -349,13 +337,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						.broadcast(&abs)
 						.subscriber_announced_bytes(abs.as_str().len() as u64);
 
-					// The matching Active may have been silently dropped by
-					// start_announce as a reflected loop, in which case
-					// `producers` has no entry; that's expected, not an error.
-					// Dropping the entry drops its origin::Publish guard, which unannounces.
-					if producers.remove(&path).is_some() {
-						stats_guards.remove(&abs);
-					}
+					Self::retire_announce(&path, &abs, &mut producers, &mut stats_guards);
 				}
 				lite::AnnounceBroadcast::Restart { id, hops } => {
 					// Resolve the id; it stays live (the replacement reuses it). An unknown
@@ -367,18 +349,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					self.stats
 						.broadcast(&abs)
 						.subscriber_announced_bytes(abs.as_str().len() as u64);
-					if producers.contains_key(&path) {
-						if self.restart_announce(path.clone(), hops, responder_origin, &mut producers)? {
-							// Continuity: keep the existing stats guard if present.
-							stats_guards
-								.entry(abs.clone())
-								.or_insert_with(|| self.stats.broadcast(&abs).subscriber());
-						} else {
-							stats_guards.remove(&abs);
-						}
-					} else if self.start_announce(path.clone(), hops, responder_origin, &mut producers)? {
-						// The original announce was dropped locally (e.g. a reflected loop);
-						// the replacement may be routable, so treat it as a fresh start.
+
+					// The origin has no atomic swap, so retire the old announcement and let the
+					// replacement arrive as a fresh announce. A no-op if the original was dropped
+					// locally (e.g. a reflected loop); the replacement may still be routable.
+					Self::retire_announce(&path, &abs, &mut producers, &mut stats_guards);
+					if self.start_announce(path.clone(), hops, responder_origin, &mut producers)? {
 						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
 					}
 				}
@@ -534,58 +510,20 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(true)
 	}
 
-	/// Handle a RESTART (a duplicate ANNOUNCE): atomically replace the broadcast at `path`.
+	/// Retire the announcement at `path`, unannouncing the broadcast.
 	///
-	/// Publishing the replacement before retiring the old producer lets the origin demote the old
-	/// broadcast to a backup and emit a single restart downstream, rather than an
-	/// unannounce/announce pair with a visible gap. Returns `Ok(false)` if the replacement was a
-	/// reflected loop (the broadcast is now gone), `Ok(true)` otherwise.
-	fn restart_announce(
-		&mut self,
-		path: PathOwned,
-		mut hops: crate::OriginList,
-		// Lite05+: the announce sender's origin id (from AnnounceOk), appended here to
-		// rebuild the full chain since the sender no longer stamps itself. None for older
-		// versions. See `start_announce`.
-		responder_origin: Option<crate::Origin>,
+	/// Dropping the [`origin::Publish`] guard is what unannounces. A no-op when the announce was
+	/// never accepted (`start_announce` silently drops reflected loops), which is expected rather
+	/// than an error: the peer doesn't know we dropped it, so it still retracts by path or id.
+	fn retire_announce(
+		path: &PathOwned,
+		absolute: &PathOwned,
 		producers: &mut HashMap<PathOwned, origin::Publish>,
-	) -> Result<bool, Error> {
-		// Reflected loop (or a full chain): the replacement can't be used here. Retire the broadcast.
-		let reflected = match responder_origin {
-			Some(responder) => hops.push(responder).is_err() || hops.contains(&self.self_origin),
-			None => hops.contains(&self.self_origin),
-		};
-		if reflected {
-			tracing::debug!(broadcast = %self.log_path(&path), "dropping reflected restart");
-			// Dropping the entry drops its guard, unannouncing the broadcast.
-			producers.remove(&path);
-			return Ok(false);
+		stats_guards: &mut HashMap<PathOwned, SubscriberStats>,
+	) {
+		if producers.remove(path).is_some() {
+			stats_guards.remove(absolute);
 		}
-
-		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "restart");
-
-		let broadcast = broadcast::Info {
-			hops,
-			origin: self.origin.info(),
-		}
-		.produce();
-		let dynamic = broadcast.dynamic();
-
-		// Publish the replacement first so the origin restarts atomically; the old broadcast is
-		// demoted to a backup and removed silently when we drop its guard below.
-		let Ok(publish) = self.origin.publish_broadcast(path.clone(), &broadcast) else {
-			// Origin rejected the replacement; retire the existing broadcast.
-			producers.remove(&path);
-			return Ok(false);
-		};
-
-		let old = producers.insert(path.clone(), publish);
-		web_async::spawn(self.clone().run_broadcast(path.clone(), dynamic));
-
-		// Drop the replaced broadcast's guard last, unannouncing it now that the replacement is live.
-		drop(old);
-
-		Ok(true)
 	}
 
 	async fn run_broadcast(self, path: PathOwned, mut broadcast: broadcast::Dynamic) {

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -515,6 +515,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	/// Dropping the [`origin::Publish`] guard is what unannounces. A no-op when the announce was
 	/// never accepted (`start_announce` silently drops reflected loops), which is expected rather
 	/// than an error: the peer doesn't know we dropped it, so it still retracts by path or id.
+	///
+	/// When retiring ahead of a replacement, this drops to whatever route the origin has left
+	/// before the replacement lands, so a path another session also announces briefly flaps to
+	/// that session's route. The replacement then wins the route key back. Harmless (every event
+	/// is true when emitted, and a consumer that hasn't drained coalesces the pair away) and only
+	/// reachable from a peer that restarts, since we never advertise one ourselves.
 	fn retire_announce(
 		path: &PathOwned,
 		absolute: &PathOwned,

--- a/rs/moq-net/src/model/mod.rs
+++ b/rs/moq-net/src/model/mod.rs
@@ -33,7 +33,7 @@ pub mod origin {
 /// Subscribing to broadcast (un)announcements from an origin.
 pub mod announce {
 	pub use super::origin_impl::{
-		AnnounceConsumer as Consumer, AnnounceProducer as Producer, Announced as Event, OriginAnnounce as Update,
+		AnnounceConsumer as Consumer, AnnounceProducer as Producer, OriginAnnounce as Update,
 	};
 }
 

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -367,14 +367,11 @@ fn route_key(name: &Path, info: &broadcast::Info) -> (usize, u64) {
 /// that a broadcast genuinely went away and a different one took its place (the
 /// consumer must see [`Announced::Ended`] before [`Announced::Active`]), while a
 /// stale `Announce` cancels with a subsequent `unannounce` because the consumer
-/// has not yet observed it. `Restart` is the atomic replacement: the broadcast
-/// at the path never became unavailable, so it collapses to a single
-/// [`Announced::Restart`] delivery.
+/// has not yet observed it.
 enum PendingUpdate {
 	Announce(broadcast::Consumer),
 	Unannounce,
 	UnannounceAnnounce(broadcast::Consumer),
-	Restart(broadcast::Consumer),
 }
 
 /// Pending updates keyed by path. `BTreeMap` keeps memory strictly bounded by
@@ -395,22 +392,6 @@ impl OriginConsumerState {
 			Some(PendingUpdate::Unannounce | PendingUpdate::UnannounceAnnounce(_)) => {
 				PendingUpdate::UnannounceAnnounce(broadcast)
 			}
-			// A restart the consumer hasn't drained yet; just swap in the newer broadcast.
-			Some(PendingUpdate::Restart(_)) => PendingUpdate::Restart(broadcast),
-		};
-		self.pending.insert(path, new);
-	}
-
-	fn apply_restart(&mut self, path: PathOwned, broadcast: broadcast::Consumer) {
-		let new = match self.pending.remove(&path) {
-			// Consumer has already drained the prior active; replace it atomically.
-			None => PendingUpdate::Restart(broadcast),
-			// Consumer hasn't seen the original announce yet; keep it a fresh announce.
-			Some(PendingUpdate::Announce(_)) => PendingUpdate::Announce(broadcast),
-			// Consumer saw the original active; collapse everything into one restart.
-			Some(PendingUpdate::Unannounce | PendingUpdate::UnannounceAnnounce(_) | PendingUpdate::Restart(_)) => {
-				PendingUpdate::Restart(broadcast)
-			}
 		};
 		self.pending.insert(path, new);
 	}
@@ -422,9 +403,9 @@ impl OriginConsumerState {
 			None | Some(PendingUpdate::Unannounce) => {
 				self.pending.insert(path, PendingUpdate::Unannounce);
 			}
-			// The embedded/replacement announce cancels with this unannounce; the
-			// consumer still needs the leading unannounce.
-			Some(PendingUpdate::UnannounceAnnounce(_) | PendingUpdate::Restart(_)) => {
+			// The embedded announce cancels with this unannounce; the consumer still
+			// needs the leading unannounce.
+			Some(PendingUpdate::UnannounceAnnounce(_)) => {
 				self.pending.insert(path, PendingUpdate::Unannounce);
 			}
 		}
@@ -442,7 +423,6 @@ impl OriginConsumerState {
 				self.pending.insert(path.clone(), PendingUpdate::Announce(broadcast));
 				Announced::Ended
 			}
-			PendingUpdate::Restart(broadcast) => Announced::Restart(broadcast),
 		};
 		Some(OriginAnnounce { path, event })
 	}
@@ -462,15 +442,6 @@ impl AnnounceConsumerNotify {
 			.ok()
 			.expect("consumer closed")
 			.apply_announce(path, broadcast);
-	}
-
-	fn restart(&self, path: impl AsPath, broadcast: broadcast::Consumer) {
-		let path = path.as_path().strip_prefix(&self.root).unwrap().to_owned();
-		self.state
-			.write()
-			.ok()
-			.expect("consumer closed")
-			.apply_restart(path, broadcast);
 	}
 
 	fn unannounce(&self, path: impl AsPath) {
@@ -502,16 +473,6 @@ impl NotifyNode {
 
 		if let Some(parent) = &self.parent {
 			parent.lock().announce(path, broadcast);
-		}
-	}
-
-	fn restart(&mut self, path: impl AsPath, broadcast: &broadcast::Consumer) {
-		for consumer in self.consumers.values() {
-			consumer.restart(path.as_path(), broadcast.clone());
-		}
-
-		if let Some(parent) = &self.parent {
-			parent.lock().restart(path, broadcast);
 		}
 	}
 
@@ -589,7 +550,11 @@ impl OriginNode {
 				existing.active = broadcast.clone();
 				existing.backup.push_back(old);
 
-				self.notify.lock().restart(full, broadcast);
+				// A replacement is an unannounce/announce pair: the path briefly reads as
+				// unavailable rather than swapping atomically.
+				let mut notify = self.notify.lock();
+				notify.unannounce(&full);
+				notify.announce(&full, broadcast);
 			} else {
 				// Loses the ordering (longer path, or the tie-break): keep as a backup
 				// in case the active one drops.
@@ -683,7 +648,12 @@ impl OriginNode {
 			if let Some(idx) = best {
 				let active = entry.backup.remove(idx).expect("index in range");
 				entry.active = active;
-				self.notify.lock().restart(full, &entry.active);
+
+				// Promoting a backup is an unannounce/announce pair: the path briefly reads
+				// as unavailable rather than swapping atomically.
+				let mut notify = self.notify.lock();
+				notify.unannounce(&full);
+				notify.announce(&full, &entry.active);
 			} else {
 				// No more backups, so remove the entry.
 				self.broadcast = None;
@@ -796,28 +766,15 @@ pub struct OriginAnnounce {
 pub enum Announced {
 	/// A broadcast became available.
 	Active(broadcast::Consumer),
-	/// The broadcast was replaced without an interruption in availability (e.g. a
-	/// relay failover or a shorter hop path arriving).
-	///
-	/// Carries the replacement broadcast. On the wire this is the explicit `restart`
-	/// status referencing the announce id (lite-06+), or a duplicate ANNOUNCE (an
-	/// active announcement for a path that is already announced, with no intervening
-	/// unannounce) on lite-05.
-	Restart(broadcast::Consumer),
 	/// The broadcast is no longer available.
 	Ended,
 }
 
 impl Announced {
 	/// The broadcast consumer, or `None` if the broadcast ended.
-	///
-	/// Both [`Active`](Self::Active) and [`Restart`](Self::Restart) carry a
-	/// broadcast; [`Ended`](Self::Ended) does not. This is the legacy
-	/// `Option<broadcast::Consumer>` view for callers that don't distinguish a fresh
-	/// announce from a restart.
 	pub fn broadcast(self) -> Option<broadcast::Consumer> {
 		match self {
-			Self::Active(broadcast) | Self::Restart(broadcast) => Some(broadcast),
+			Self::Active(broadcast) => Some(broadcast),
 			Self::Ended => None,
 		}
 	}
@@ -1047,9 +1004,10 @@ impl Producer {
 ///
 /// Returned by [`Producer::publish_broadcast`]. While held, the broadcast stays
 /// announced to all consumers. Dropping it (or calling [`Self::unannounce`]) removes the
-/// broadcast from the tree: the origin promotes the best remaining backup route (emitting a
-/// restart) or, if none remain, unannounces the path. The guard is independent of the
-/// broadcast's own lifetime, so it can outlive or be dropped before the broadcast itself.
+/// broadcast from the tree: the origin promotes the best remaining backup route (unannouncing
+/// the path and re-announcing it with the backup) or, if none remain, unannounces the path.
+/// The guard is independent of the broadcast's own lifetime, so it can outlive or be dropped
+/// before the broadcast itself.
 #[must_use = "the broadcast is unannounced as soon as this guard is dropped"]
 pub struct Publish {
 	node: Lock<OriginNode>,
@@ -1827,15 +1785,11 @@ impl AnnounceConsumer {
 		);
 	}
 
-	pub fn assert_next_restart(&mut self, expected: impl AsPath, broadcast: &broadcast::Consumer) {
+	/// A replacement route arrives as an unannounce/announce pair for the same path.
+	pub fn assert_next_replaced(&mut self, expected: impl AsPath, broadcast: &broadcast::Consumer) {
 		let expected = expected.as_path();
-		let OriginAnnounce { path, event, .. } = self.next().now_or_never().expect("next blocked").expect("no next");
-		assert!(matches!(event, Announced::Restart(_)), "should be a restart");
-		assert_eq!(path, expected, "wrong path");
-		assert!(
-			event.broadcast().unwrap().is_clone(broadcast),
-			"should be the same broadcast"
-		);
+		self.assert_next_none(&expected);
+		self.assert_next(&expected, broadcast);
 	}
 
 	pub fn assert_try_next(&mut self, expected: impl AsPath, broadcast: &broadcast::Consumer) {
@@ -2037,7 +1991,7 @@ mod tests {
 		assert!(consumer.get_broadcast("test").is_some());
 
 		// Identical (empty) hop chains tie on the deterministic key, so the first publish
-		// stays active and the rest queue as backups. No churn, no restart.
+		// stays active and the rest queue as backups. No churn.
 		announced.assert_next("test", &consumer1);
 		announced.assert_next_wait();
 
@@ -2050,14 +2004,14 @@ mod tests {
 		assert!(consumer.get_broadcast("test").is_some());
 		announced.assert_next_wait();
 
-		// Drop the active, we should restart with the remaining backup.
+		// Drop the active, we should promote the remaining backup.
 		drop(broadcast1);
 
 		// Wait for the async task to run.
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
 
 		assert!(consumer.get_broadcast("test").is_some());
-		announced.assert_next_restart("test", &consumer3);
+		announced.assert_next_replaced("test", &consumer3);
 
 		// Drop the final broadcast, we should unannounce.
 		drop(broadcast3);
@@ -2071,10 +2025,10 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn test_restart_after_drain() {
+	async fn test_replace_after_drain() {
 		// A strictly-better route (shorter hop chain) replacing the active broadcast
-		// after the consumer has drained the original announce is delivered as a
-		// single atomic restart.
+		// after the consumer has drained the original announce is delivered as an
+		// unannounce/announce pair.
 		let origin = Origin::random().produce();
 		// `a` carries one hop; `b` has none, so `b` wins the route and replaces it.
 		let a = broadcast::Info {
@@ -2089,14 +2043,15 @@ mod tests {
 		announced.assert_next("test", &a.consume());
 
 		origin.publish_broadcast_spawn("test", b.consume());
-		announced.assert_next_restart("test", &b.consume());
+		announced.assert_next_replaced("test", &b.consume());
 		announced.assert_next_wait();
 	}
 
 	#[tokio::test]
-	async fn test_restart_undrained_stays_active() {
+	async fn test_replace_undrained_stays_active() {
 		// If the consumer hasn't observed the original announce yet, a winning route
-		// just swaps in the newer broadcast and is still delivered as a fresh Active.
+		// just swaps in the newer broadcast: the unannounce cancels the undrained
+		// announce, so a single fresh Active is delivered with no leading Ended.
 		let origin = Origin::random().produce();
 		// `a` carries one hop; `b` has none, so `b` wins the route and replaces it.
 		let a = broadcast::Info {

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -365,9 +365,9 @@ fn route_key(name: &Path, info: &broadcast::Info) -> (usize, u64) {
 /// At most one entry exists per path, so a slow consumer's pending set is bounded
 /// by the number of distinct paths. `UnannounceAnnounce` preserves the signal
 /// that a broadcast genuinely went away and a different one took its place (the
-/// consumer must see [`Announced::Ended`] before [`Announced::Active`]), while a
-/// stale `Announce` cancels with a subsequent `unannounce` because the consumer
-/// has not yet observed it.
+/// consumer must see the `None` before the `Some`), while a stale `Announce`
+/// cancels with a subsequent `unannounce` because the consumer has not yet
+/// observed it.
 enum PendingUpdate {
 	Announce(broadcast::Consumer),
 	Unannounce,
@@ -414,17 +414,17 @@ impl OriginConsumerState {
 	/// Take one update to deliver to the consumer, if any.
 	fn take(&mut self) -> Option<OriginAnnounce> {
 		let path = self.pending.keys().next()?.clone();
-		let event = match self.pending.remove(&path).unwrap() {
-			PendingUpdate::Announce(broadcast) => Announced::Active(broadcast),
-			PendingUpdate::Unannounce => Announced::Ended,
+		let broadcast = match self.pending.remove(&path).unwrap() {
+			PendingUpdate::Announce(broadcast) => Some(broadcast),
+			PendingUpdate::Unannounce => None,
 			PendingUpdate::UnannounceAnnounce(broadcast) => {
 				// Deliver the unannounce now; leave the trailing announce pending so
 				// the next take returns it for the same path.
 				self.pending.insert(path.clone(), PendingUpdate::Announce(broadcast));
-				Announced::Ended
+				None
 			}
 		};
-		Some(OriginAnnounce { path, event })
+		Some(OriginAnnounce { path, broadcast })
 	}
 }
 
@@ -750,34 +750,16 @@ impl Default for OriginNodes {
 	}
 }
 
-/// A path and what happened to the broadcast there, delivered by [`AnnounceConsumer`].
+/// A path and the broadcast now available there, delivered by [`AnnounceConsumer`].
 #[derive(Clone)]
-#[non_exhaustive]
 pub struct OriginAnnounce {
 	/// The path of the broadcast, relative to the consuming cursor's root.
 	pub path: PathOwned,
-	/// What happened to the broadcast at that path.
-	pub event: Announced,
-}
-
-/// What happened to a broadcast at a path.
-#[derive(Clone)]
-#[non_exhaustive]
-pub enum Announced {
-	/// A broadcast became available.
-	Active(broadcast::Consumer),
-	/// The broadcast is no longer available.
-	Ended,
-}
-
-impl Announced {
-	/// The broadcast consumer, or `None` if the broadcast ended.
-	pub fn broadcast(self) -> Option<broadcast::Consumer> {
-		match self {
-			Self::Active(broadcast) => Some(broadcast),
-			Self::Ended => None,
-		}
-	}
+	/// The broadcast now available at that path, or `None` if it is no longer available.
+	///
+	/// A replacement (a relay failover, or a shorter hop path arriving) is delivered as a
+	/// `None` followed by a `Some`, never as a swap in place.
+	pub broadcast: Option<broadcast::Consumer>,
 }
 
 /// Announces broadcasts to consumers over the network.
@@ -1529,11 +1511,11 @@ impl Consumer {
 		loop {
 			let OriginAnnounce {
 				path: announced_path,
-				event,
+				broadcast,
 			} = announced.next().await?;
 			// `scope` narrows by prefix, but we only want an exact-path match.
 			if announced_path.as_path() == path {
-				if let Some(broadcast) = event.broadcast() {
+				if let Some(broadcast) = broadcast {
 					return Some(broadcast);
 				}
 			}
@@ -1776,13 +1758,10 @@ use futures::FutureExt;
 impl AnnounceConsumer {
 	pub fn assert_next(&mut self, expected: impl AsPath, broadcast: &broadcast::Consumer) {
 		let expected = expected.as_path();
-		let OriginAnnounce { path, event, .. } = self.next().now_or_never().expect("next blocked").expect("no next");
-		assert!(matches!(event, Announced::Active(_)), "should be an active announce");
-		assert_eq!(path, expected, "wrong path");
-		assert!(
-			event.broadcast().unwrap().is_clone(broadcast),
-			"should be the same broadcast"
-		);
+		let announce = self.next().now_or_never().expect("next blocked").expect("no next");
+		assert_eq!(announce.path, expected, "wrong path");
+		let announced = announce.broadcast.expect("should be an active announce");
+		assert!(announced.is_clone(broadcast), "should be the same broadcast");
 	}
 
 	/// A replacement route arrives as an unannounce/announce pair for the same path.
@@ -1794,19 +1773,17 @@ impl AnnounceConsumer {
 
 	pub fn assert_try_next(&mut self, expected: impl AsPath, broadcast: &broadcast::Consumer) {
 		let expected = expected.as_path();
-		let OriginAnnounce { path, event, .. } = self.try_next().expect("no next");
-		assert_eq!(path, expected, "wrong path");
-		assert!(
-			event.broadcast().unwrap().is_clone(broadcast),
-			"should be the same broadcast"
-		);
+		let announce = self.try_next().expect("no next");
+		assert_eq!(announce.path, expected, "wrong path");
+		let announced = announce.broadcast.expect("should be an active announce");
+		assert!(announced.is_clone(broadcast), "should be the same broadcast");
 	}
 
 	pub fn assert_next_none(&mut self, expected: impl AsPath) {
 		let expected = expected.as_path();
-		let OriginAnnounce { path, event, .. } = self.next().now_or_never().expect("next blocked").expect("no next");
-		assert_eq!(path, expected, "wrong path");
-		assert!(event.broadcast().is_none(), "should be unannounced");
+		let announce = self.next().now_or_never().expect("next blocked").expect("no next");
+		assert_eq!(announce.path, expected, "wrong path");
+		assert!(announce.broadcast.is_none(), "should be unannounced");
 	}
 
 	pub fn assert_next_wait(&mut self) {

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -1871,8 +1871,8 @@ mod tests {
 		let _t2 = bs2.publisher().track("video");
 
 		tokio::time::advance(Duration::from_millis(1)).await;
-		let crate::announce::Update { path, event, .. } = consumer.next().await.expect("expected announce");
-		assert!(event.broadcast().is_some());
+		let crate::announce::Update { path, broadcast } = consumer.next().await.expect("expected announce");
+		assert!(broadcast.is_some());
 		assert_eq!(path.as_str(), ".stats/node/sjc/1");
 	}
 
@@ -1886,8 +1886,8 @@ mod tests {
 		let _t = bs.publisher().track("video");
 
 		tokio::time::advance(Duration::from_millis(1)).await;
-		let crate::announce::Update { path, event, .. } = consumer.next().await.expect("expected announce");
-		assert!(event.broadcast().is_some());
+		let crate::announce::Update { path, broadcast } = consumer.next().await.expect("expected announce");
+		assert!(broadcast.is_some());
 		assert_eq!(path.as_str(), ".stats/node");
 	}
 
@@ -1971,8 +1971,8 @@ mod tests {
 
 		tokio::time::advance(Duration::from_millis(1100)).await;
 
-		let crate::announce::Update { event, .. } = consumer.next().await.expect("expected announce");
-		let broadcast = event.broadcast().expect("active");
+		let crate::announce::Update { broadcast, .. } = consumer.next().await.expect("expected announce");
+		let broadcast = broadcast.expect("active");
 		let track = broadcast
 			.track("publisher.json")
 			.unwrap()
@@ -2017,8 +2017,8 @@ mod tests {
 
 		tokio::time::advance(Duration::from_millis(1100)).await;
 
-		let crate::announce::Update { event, .. } = consumer.next().await.expect("announce");
-		let broadcast = event.broadcast().expect("active");
+		let crate::announce::Update { broadcast, .. } = consumer.next().await.expect("announce");
+		let broadcast = broadcast.expect("active");
 		let track = broadcast
 			.track("publisher.json")
 			.unwrap()
@@ -2042,8 +2042,8 @@ mod tests {
 
 		tokio::time::advance(Duration::from_millis(1100)).await;
 
-		let crate::announce::Update { event, .. } = consumer.next().await.expect("announce");
-		let broadcast = event.broadcast().expect("active");
+		let crate::announce::Update { broadcast, .. } = consumer.next().await.expect("announce");
+		let broadcast = broadcast.expect("active");
 		let track = broadcast
 			.track("publisher.json")
 			.unwrap()
@@ -2078,8 +2078,8 @@ mod tests {
 
 		tokio::time::advance(Duration::from_millis(1100)).await;
 
-		let crate::announce::Update { event, .. } = consumer.next().await.expect("announce");
-		let broadcast = event.broadcast().expect("active");
+		let crate::announce::Update { broadcast, .. } = consumer.next().await.expect("announce");
+		let broadcast = broadcast.expect("active");
 		let track = broadcast
 			.track("publisher.json")
 			.unwrap()
@@ -2194,8 +2194,8 @@ mod tests {
 
 		tokio::time::advance(Duration::from_millis(1100)).await;
 
-		let crate::announce::Update { event, .. } = consumer.next().await.expect("announce");
-		let broadcast = event.broadcast().expect("active");
+		let crate::announce::Update { broadcast, .. } = consumer.next().await.expect("announce");
+		let broadcast = broadcast.expect("active");
 
 		let track = broadcast
 			.track("sessions.json")
@@ -2258,8 +2258,8 @@ mod tests {
 
 		drive_ticks(2).await;
 
-		let crate::announce::Update { event, .. } = consumer.next().await.expect("announce");
-		let broadcast = event.broadcast().expect("active");
+		let crate::announce::Update { broadcast, .. } = consumer.next().await.expect("announce");
+		let broadcast = broadcast.expect("active");
 
 		// Default-tier publisher slot SHOULD include foo/bar.
 		let pub_track = broadcast

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -627,7 +627,7 @@ impl Cluster {
 		loop {
 			tokio::select! {
 				ann = announced.next() => {
-					let Some(moq_net::announce::Update { path: relative, event, .. }) = ann else { return; };
+					let Some(moq_net::announce::Update { path: relative, broadcast }) = ann else { return; };
 					let peer = relative.as_str();
 					// Skip self and any peer we lose the tiebreaker to; that side
 					// dials us instead, so each pair forms a single session.
@@ -636,7 +636,7 @@ impl Cluster {
 					}
 					let peer = peer.to_owned();
 					let key = canonicalize_peer_key(&peer);
-					match event.broadcast() {
+					match broadcast {
 						Some(_) => {
 							if dialed.contains(&key) {
 								// Already dialed (possibly via another source). Mark gossip as
@@ -1202,10 +1202,10 @@ mod tests {
 		tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
 
 		// The self-registration broadcast must be visible on the origin.
-		let moq_net::announce::Update { path, event, .. } =
+		let moq_net::announce::Update { path, broadcast } =
 			watcher.try_next().expect("self-registration must be published");
 		assert_eq!(path.as_str(), ".internal/origins/rendezvous.example.com:4443");
-		assert!(event.broadcast().is_some());
+		assert!(broadcast.is_some());
 
 		// run() must NOT have returned: dropping the broadcast (via run returning)
 		// would unannounce the registration immediately. Use a short timeout to

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -505,10 +505,11 @@ async fn serve_announced(
 	let mut broadcasts = Vec::new();
 
 	while let Some(moq_net::announce::Update {
-		path: suffix, event, ..
+		path: suffix,
+		broadcast,
 	}) = announced.try_next()
 	{
-		if event.broadcast().is_some() {
+		if broadcast.is_some() {
 			broadcasts.push(suffix);
 		}
 	}

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -175,13 +175,13 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	);
 
 	// ── data path ───────────────────────────────────────────────────
-	let moq_net::announce::Update { path, event: bc, .. } = tokio::time::timeout(TIMEOUT, announcements.next())
+	let moq_net::announce::Update { path, broadcast: bc } = tokio::time::timeout(TIMEOUT, announcements.next())
 		.await
 		.expect("announcement timeout")
 		.expect("origin closed");
 	// Auth root for `/smoke` is "smoke"; the broadcast "test" announces underneath.
 	assert_eq!(path.as_str(), "test");
-	let bc = bc.broadcast().expect("expected announce, got unannounce");
+	let bc = bc.expect("expected announce, got unannounce");
 
 	let mut track_sub = bc.track("video").unwrap().subscribe(None).await.expect("consume_track");
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
@@ -273,12 +273,12 @@ async fn relay_websocket_root_path_upgrades() {
 	// ── data path ───────────────────────────────────────────────────
 	// The root auth scope is the empty path, so the broadcast announces at its
 	// own name with no prefix.
-	let moq_net::announce::Update { path, event: bc, .. } = tokio::time::timeout(TIMEOUT, announcements.next())
+	let moq_net::announce::Update { path, broadcast: bc } = tokio::time::timeout(TIMEOUT, announcements.next())
 		.await
 		.expect("announcement timeout")
 		.expect("origin closed");
 	assert_eq!(path.as_str(), "test");
-	let bc = bc.broadcast().expect("expected announce, got unannounce");
+	let bc = bc.expect("expected announce, got unannounce");
 
 	let mut track_sub = bc.track("video").unwrap().subscribe(None).await.expect("consume_track");
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
@@ -346,11 +346,11 @@ async fn two_publish_only_clients_coexist() {
 
 	let mut seen = std::collections::HashSet::new();
 	while seen.len() < 2 {
-		let moq_net::announce::Update { path, event: bc, .. } = tokio::time::timeout(TIMEOUT, announcements.next())
+		let moq_net::announce::Update { path, broadcast: bc } = tokio::time::timeout(TIMEOUT, announcements.next())
 			.await
 			.expect("announcement timeout")
 			.expect("origin closed");
-		if bc.broadcast().is_some() {
+		if bc.is_some() {
 			seen.insert(path.as_str().to_owned());
 		}
 	}
@@ -482,12 +482,12 @@ async fn internal_tcp_round_trip() {
 	// ── data path ───────────────────────────────────────────────────
 	// The internal listener grants the empty root, so the broadcast announces
 	// at its own name with no path prefix.
-	let moq_net::announce::Update { path, event: bc, .. } = tokio::time::timeout(TIMEOUT, announcements.next())
+	let moq_net::announce::Update { path, broadcast: bc } = tokio::time::timeout(TIMEOUT, announcements.next())
 		.await
 		.expect("announcement timeout")
 		.expect("origin closed");
 	assert_eq!(path.as_str(), "test");
-	let bc = bc.broadcast().expect("expected announce, got unannounce");
+	let bc = bc.expect("expected announce, got unannounce");
 
 	let mut track_sub = bc.track("video").unwrap().subscribe(None).await.expect("consume_track");
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())
@@ -592,14 +592,13 @@ async fn internal_unix_round_trip() {
 	// ── data path ───────────────────────────────────────────────────
 	let moq_net::announce::Update {
 		path: announced_path,
-		event: bc,
-		..
+		broadcast: bc,
 	} = tokio::time::timeout(TIMEOUT, announcements.next())
 		.await
 		.expect("announcement timeout")
 		.expect("origin closed");
 	assert_eq!(announced_path.as_str(), "test");
-	let bc = bc.broadcast().expect("expected announce, got unannounce");
+	let bc = bc.expect("expected announce, got unannounce");
 
 	let mut track_sub = bc.track("video").unwrap().subscribe(None).await.expect("consume_track");
 	let mut group_sub = tokio::time::timeout(TIMEOUT, track_sub.recv_group())


### PR DESCRIPTION
## Summary

- The origin gained an atomic-replacement event so a route change (a shorter hop chain arriving, or a backup promoted after the active route drops) reached consumers as one `Announced::Restart` instead of a visible unannounce/announce gap. Removing it: a replacement is an unannounce followed by an announce.
- The coalescing queue already modeled exactly this as `UnannounceAnnounce`, so the two `OriginNode` call sites just notify both in turn and the delivery ordering falls out. `PendingUpdate::Restart`, `apply_restart`, and the parallel `restart` path down the notify tree are gone.
- Consumers now see the unannounce then the announce across a relay failover or backup promotion, and re-establish their subscriptions. That blip is the trade: it's cheaper than the complexity of avoiding it.
- The deleted publisher arms weren't carrying their weight. Both edge cases the lite publisher's ~60-line `Event::Restart` arm hand-coded now fall out of the existing arms: if the prior announcement was filtered, the unannounce has no id and sends nothing, then the announce assigns a fresh one; if the replacement loops back to us, the unannounce retracts and the announce skips it. The ietf publisher's two done+re-announce fallbacks go too (moq-transport never had RESTART).
- `restart_announce` on the lite subscriber, with its subtle publish-the-replacement-first-so-the-origin-demotes-the-old-one ordering, collapses into a four-line `retire_announce` that the `Ended`/`EndedId` arms now share.
- With `Restart` gone, `Announced` was a two-variant enum isomorphic to `Option<broadcast::Consumer>`, with `Announced::broadcast()` an identity conversion wearing an accessor's clothes. Second commit collapses it into a plain `Option` and drops `#[non_exhaustive]` from both it and `announce::Update`: the attribute only earns its keep on an enum that will realistically gain variants, and `Restart` was the only variant this one ever gained.

Net -208 lines.

## Wire

**Untouched**, so no draft update is needed. lite-06 keeps ANNOUNCE_RESTART and lite-05 keeps the duplicate-ANNOUNCE idiom, both now receive-only: a peer may still restart, and the subscriber retires the old announcement before republishing rather than rejecting it as a duplicate. lite-06's rule that a second ANNOUNCE_START for an already-available path is a protocol violation is unchanged.

## Public API changes

All breaking (hence `dev`), all in `rs/moq-net`:

- **Removed** `Announced` (re-exported as `announce::Event`) and its `Restart(broadcast::Consumer)` / `Active(broadcast::Consumer)` / `Ended` variants, along with `Announced::broadcast()`.
- **Changed** `announce::Update` (`OriginAnnounce`): the `event: Announced` field becomes `broadcast: Option<broadcast::Consumer>`. `#[non_exhaustive]` removed, so callers can destructure it without a trailing `..`.

Migration is mechanical: `Event::Active(b)` → `Some(b)`, `Event::Ended` → `None`, `update.event.broadcast()` → `update.broadcast`.

No other `pub` items added, renamed, or signature-changed. `retire_announce` and the `PendingUpdate`/notify-tree changes are private.

## Cross-package sync

Walked the `rs/moq-net` and `rs/moq-ffi` rows. Restart never crossed the FFI boundary, so the bindings needed only two stale comments removed:

- `rs/moq-ffi`: no API change. `MoqAnnounced::next` and `MoqAnnouncedBroadcast::available` skip unannounce events, so a replacement surfaced as one announcement before (a `Restart`) and still does now (the unannounce is skipped, the announce is returned). Identical observable behavior.
- `rs/libmoq`: **no ABI change** (`moq.h` untouched; `moq_announced` still `{path, path_len, active}`). Its `on_announce` callback does surface the pair, so a route change now delivers `active=false` then `active=true` where it previously delivered a second bare `active=true` with no intervening unannounce. That's strictly more consistent with the boolean's own contract, and `doc/lib/c/index.md` already documents a record per "announce / unannounce event". C callers already free every record, so the extra one needs no new handling.
- `py/`, `swift/`, `kt/`, `go/wrapper`: no change. All four are thin passthroughs over `MoqAnnounced`/`MoqAnnouncedBroadcast`, which are announce-only; none has a restart concept or an unannounce surface.
- `doc/lib/{py,swift,kt,go,c}`: no change; zero restart/re-announce references, and the C announce-callback docs stay accurate.
- `js/net`: no change. The wire is untouched, and js/net has no model-level restart to remove. Its announce consumer is already a `{path, active}` pair; it maps a received wire restart to a single `active: true`, which js/watch's `#runBroadcast` re-consumes on, as before.
- `drafts/draft-lcurley-moq-lite.md`: no change, per Wire above.

## Test plan

- `just check` (compile, clippy `-D warnings`, fmt, rustdoc `-D warnings`, shear, sort, js, remark): clean.
- `just rs test`: 39/39 test binaries green.
- `rs/moq-net` unit tests updated: `test_restart_after_drain` → `test_replace_after_drain` and `test_restart_undrained_stays_active` → `test_replace_undrained_stays_active` now assert the pair; the backup-promotion test uses a new `assert_next_replaced` helper in place of `assert_next_restart`. The undrained case still asserts a lone announce, since the unannounce cancels the announce the consumer never saw.
- `rs/moq-native` `broadcast_moq_lite_06_announce_lifecycle` end-to-end now asserts the unannounce then the announce for a replacement, i.e. the wire retires the old announce id and assigns a fresh one. Its sentinel still proves nothing stray follows.
- The `Option` collapse rippled through ~11 downstream files (relay, bench, boy, ffi, libmoq, hang/native examples and tests); all mechanical, all covered by the suite above.

## Worth flagging

- **The restart receive paths lost their e2e coverage.** That lite-06 lifecycle test was the only thing exercising ANNOUNCE_RESTART over a real session, and only because our own publisher sent it. Nothing in-tree can originate a restart now, so covering the decode paths would mean forging wire bytes. The codec round-trip unit tests still cover encode/decode; the subscriber's *handling* of a received restart is unexercised.
- **Stats now count a close/reopen per route change.** The old restart arm deliberately held the stats guard across a replacement for continuity. An unannounce/announce pair drops and re-creates it, so `broadcasts_closed` increments on each failover. That follows from the model genuinely closing the broadcast, but it will show up in relay dashboards.

(Written by Claude Opus 4.8)
