### PR TITLE
fix(moq-net): stop racing priority updates against group frame writes

### DIFF
--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -617,20 +617,21 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				biased;
 				_ = stream.closed() => return Err(Error::Cancel),
 				frame = group.next_frame() => frame,
-				new_pri = priority.next() => {
-					stream.set_priority(new_pri);
-					continue;
-				}
-				Ok(()) = track_priority.changed() => {
-					priority.set_track(*track_priority.borrow_and_update());
-					continue;
-				}
 			};
 
 			let mut frame = match frame? {
 				Some(frame) => frame,
 				None => break,
 			};
+
+			// Apply priority updates only between frames. Racing them against the
+			// encode/write awaits below cancels an in-flight write, which loses or
+			// duplicates bytes after the frame length was already written and
+			// desyncs the stream for the subscriber.
+			if track_priority.has_changed().unwrap_or(false) {
+				priority.set_track(*track_priority.borrow_and_update());
+			}
+			stream.set_priority(priority.current());
 
 			if version.has_track_stream() {
 				let now = i64::try_from(crate::Time::now().as_millis()).unwrap_or(i64::MAX);
@@ -648,34 +649,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					biased;
 					_ = stream.closed() => return Err(Error::Cancel),
 					chunk = frame.read_chunk() => chunk,
-					new_pri = priority.next() => {
-						stream.set_priority(new_pri);
-						continue;
-					}
-					Ok(()) = track_priority.changed() => {
-						priority.set_track(*track_priority.borrow_and_update());
-						continue;
-					}
 				};
 
 				match chunk? {
 					Some(mut chunk) => {
 						let n = chunk.len() as u64;
-						loop {
-							tokio::select! {
-								biased;
-								result = stream.write_all(&mut chunk) => {
-									result?;
-									break;
-								}
-								new_pri = priority.next() => {
-									stream.set_priority(new_pri);
-								}
-								Ok(()) = track_priority.changed() => {
-									priority.set_track(*track_priority.borrow_and_update());
-								}
-							}
-						}
+						stream.write_all(&mut chunk).await?;
 						track_stats.bytes(n);
 					}
 					None => break,


### PR DESCRIPTION
## Summary

- `serve_group` in the lite publisher raced `priority.next()` and `track_priority.changed()` against `next_frame`/`read_chunk`/`write_all` inside `tokio::select!`. The priority queue re-sorts on every inserted group, so with typical audio (one group per 20ms frame) the priority branches fire ~50x/s and each firing drops the in-flight future.
- Root cause of the corruption: cancelling `write_all` mid-frame loses or duplicates bytes after the frame length header was already written. The subscriber's stream is then desynced: it either parses payload bytes as a varint length ("frame too large" errors) or waits forever on a length that never fills (frozen track, no error surfaced).
- Only triggers when writes actually block, i.e. under egress backpressure to a slow or congested subscriber. Fast paths never see it, which is why it hides well.
- Fix: apply priority updates between frames instead of racing them against the writes. A stream that is mid-frame keeps draining at its previous priority until the next frame boundary, a bounded lag.

## Public API changes

None. `pub(super)` internals of `rs/moq-net/src/lite/publisher.rs` only; no wire or `pub` surface change.

## Test plan

- `cargo test -p moq-net` (392 tests pass).
- Load repro against a relay built from this branch: a publisher with production-like traffic (6 Mbps video in 2s groups + one-frame-per-group 20ms audio) and a subscriber behind a congested link, performing repeated join sequences. Before: ~30/100 subscriptions died with "frame too large" (plus silent mid-group stalls); after: 0/100 in the same topology. A same-node (unbackpressured) subscriber sharing the identical publisher/relay was clean in both cases, confirming the corruption was per-viewer egress.
- No unit test included: reproducing requires a transport whose writes block mid-frame while the priority queue churns, which the current test harness cannot express. Happy to add one if there is an accepted pattern for backpressured-transport tests.

(Written by Claude Fable 5)