### PR TITLE
fix(moq-rtc): handle IPv4-mapped peers on a dual-stack socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4290,6 +4290,7 @@ name = "moq-rtc"
 version = "0.1.4"
 dependencies = [
  "anyhow",
+ "aws-lc-rs",
  "axum",
  "bytes",
  "hang",

--- a/rs/moq-rtc/Cargo.toml
+++ b/rs/moq-rtc/Cargo.toml
@@ -34,4 +34,7 @@ url = "2"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
+# Signs the MESSAGE-INTEGRITY on a forged STUN binding request: str0m rejects a
+# request without one, and its own SHA1 provider is private.
+aws-lc-rs = "1"
 tokio = { workspace = true, features = ["test-util"] }

--- a/rs/moq-rtc/src/lib.rs
+++ b/rs/moq-rtc/src/lib.rs
@@ -42,6 +42,7 @@ pub mod codec;
 pub mod egress;
 mod error;
 pub mod ingest;
+mod net;
 pub mod sdp;
 pub mod server;
 pub mod session;

--- a/rs/moq-rtc/src/net.rs
+++ b/rs/moq-rtc/src/net.rs
@@ -1,0 +1,73 @@
+//! Address-family adaptation at the UDP socket boundary.
+//!
+//! A dual-stack listener (`[::]`, which Linux serves both families from unless
+//! `bindv6only` is set) reports an IPv4 peer as an IPv4-mapped IPv6 address
+//! (`::ffff:a.b.c.d`), and refuses a send to a real `V4` destination. Neither
+//! form should leak past this boundary:
+//!
+//! - **Inbound**: [`canonical`] unmaps, so an IPv4 peer looks like the `V4` it
+//!   is. ICE pairing keys off the address family (see
+//!   [`pick_local`](crate::session::pick_local)), so without this an IPv4 peer
+//!   on a dual-stack socket would be paired against the IPv6 host candidate.
+//! - **Outbound**: [`to_family`] re-maps, because the destination str0m hands
+//!   back is the canonical address we fed it.
+
+use std::net::{IpAddr, SocketAddr};
+
+/// Unmap an IPv4-mapped peer address to the `V4` it really is; other addresses
+/// pass through unchanged.
+pub(crate) fn canonical(addr: SocketAddr) -> SocketAddr {
+	SocketAddr::new(addr.ip().to_canonical(), addr.port())
+}
+
+/// Adapt a destination to what `socket_is_v6`'s socket will accept: an AF_INET6
+/// socket can only send to an IPv6 address, so an IPv4 destination has to go
+/// back to its mapped form.
+pub(crate) fn to_family(dst: SocketAddr, socket_is_v6: bool) -> SocketAddr {
+	match (socket_is_v6, dst.ip()) {
+		(true, IpAddr::V4(ip)) => SocketAddr::new(IpAddr::V6(ip.to_ipv6_mapped()), dst.port()),
+		_ => dst,
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn canonical_unmaps_v4_mapped_peers() {
+		// What a dual-stack socket reports for an IPv4 peer.
+		let mapped: SocketAddr = "[::ffff:1.2.3.4]:5000".parse().unwrap();
+		assert_eq!(canonical(mapped), "1.2.3.4:5000".parse().unwrap());
+	}
+
+	#[test]
+	fn canonical_passes_through_native_addresses() {
+		let v4: SocketAddr = "1.2.3.4:5000".parse().unwrap();
+		let v6: SocketAddr = "[2001:db8::1]:5000".parse().unwrap();
+		assert_eq!(canonical(v4), v4);
+		assert_eq!(canonical(v6), v6);
+	}
+
+	#[test]
+	fn to_family_remaps_v4_for_a_dual_stack_socket() {
+		let v4: SocketAddr = "1.2.3.4:5000".parse().unwrap();
+		assert_eq!(to_family(v4, true), "[::ffff:1.2.3.4]:5000".parse().unwrap());
+	}
+
+	#[test]
+	fn to_family_leaves_matching_families_alone() {
+		let v4: SocketAddr = "1.2.3.4:5000".parse().unwrap();
+		let v6: SocketAddr = "[2001:db8::1]:5000".parse().unwrap();
+		assert_eq!(to_family(v4, false), v4);
+		assert_eq!(to_family(v6, true), v6);
+	}
+
+	/// The round trip a dual-stack server does per IPv4 peer: canonicalize the
+	/// source on the way in, then re-map str0m's destination on the way out.
+	#[test]
+	fn canonical_and_to_family_round_trip() {
+		let mapped: SocketAddr = "[::ffff:1.2.3.4]:5000".parse().unwrap();
+		assert_eq!(to_family(canonical(mapped), true), mapped);
+	}
+}

--- a/rs/moq-rtc/src/server/mux.rs
+++ b/rs/moq-rtc/src/server/mux.rs
@@ -133,6 +133,9 @@ async fn demux(socket: Arc<UdpSocket>, registry: Arc<Mutex<Registry>>) {
 				continue;
 			}
 		};
+		// A dual-stack bind reports IPv4 peers as `::ffff:a.b.c.d`; unmap before
+		// this address becomes a registry key or reaches ICE (see crate::net).
+		let src = crate::net::canonical(src);
 		let data = &buf[..len];
 
 		// Fast path: a source we've already paired with a session.
@@ -183,4 +186,73 @@ fn local_ufrag(data: &[u8]) -> Option<String> {
 		return None;
 	}
 	msg.split_username().map(|(local, _remote)| local.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+	use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+	use std::time::Duration;
+
+	use str0m::ice::{StunMessage, TransId};
+
+	use super::*;
+
+	/// SHA1-HMAC for a STUN MESSAGE-INTEGRITY, matching what str0m signs with.
+	fn sha1_hmac(key: &[u8], payloads: &[&[u8]]) -> [u8; 20] {
+		use aws_lc_rs::hmac;
+
+		let key = hmac::Key::new(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, key);
+		let mut ctx = hmac::Context::with_key(&key);
+		for payload in payloads {
+			ctx.update(payload);
+		}
+		let mut out = [0u8; 20];
+		out.copy_from_slice(ctx.sign().as_ref());
+		out
+	}
+
+	/// Forge the STUN binding request a peer opens an ICE session with, addressed
+	/// to the session holding `creds`. Signed with that session's password, which
+	/// is what str0m authenticates an inbound request against.
+	fn binding_request(creds: &IceCreds) -> Vec<u8> {
+		let username = format!("{}:peer", creds.ufrag);
+		let msg = StunMessage::binding_request(&username, TransId::new(), true, 0, 0, false);
+		let mut buf = vec![0u8; 1024];
+		let len = msg
+			.to_bytes(Some(creds.pass.as_bytes()), &mut buf, sha1_hmac)
+			.expect("serialize binding request");
+		buf.truncate(len);
+		buf
+	}
+
+	/// An IPv4 peer reaching a dual-stack (`[::]`) mux must route to its session
+	/// with its source unmapped to the `V4` it really is. Without the
+	/// canonicalization the source stays `::ffff:127.0.0.1`, which pairs the peer
+	/// against the wrong-family ICE host candidate.
+	#[tokio::test]
+	async fn dual_stack_mux_routes_an_ipv4_peer_with_a_canonical_source() {
+		let bind = SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 0);
+		let advertise = [
+			SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+			SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 0),
+		];
+		let mux = Mux::bind(bind, &advertise).await.expect("dual-stack bind");
+		let port = mux.socket.local_addr().unwrap().port();
+		let (creds, mut rx, _registration) = mux.register();
+
+		// Dial the mux over IPv4, which a dual-stack socket accepts as v4-mapped.
+		let peer = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+		let peer_addr = peer.local_addr().unwrap();
+		peer.send_to(&binding_request(&creds), (Ipv4Addr::LOCALHOST, port))
+			.await
+			.expect("IPv4 peer must reach a dual-stack mux");
+
+		let (_data, src) = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+			.await
+			.expect("the demux must route the IPv4 peer's binding request")
+			.expect("session inbox stayed open");
+
+		assert_eq!(src, peer_addr, "an IPv4 peer's source must arrive unmapped");
+		assert!(src.is_ipv4());
+	}
 }

--- a/rs/moq-rtc/src/session.rs
+++ b/rs/moq-rtc/src/session.rs
@@ -167,6 +167,9 @@ impl Session {
 	pub async fn run(mut self) -> Result<()> {
 		let started = Instant::now();
 		let mut connected = false;
+		// str0m hands back the canonical destination we fed it, so a dual-stack
+		// socket needs IPv4 re-mapped before each send (see crate::net).
+		let socket_v6 = self.socket.local_addr().map_err(Error::Io)?.is_ipv6();
 		loop {
 			// A dead Rtc (DTLS/SDP failure, explicit disconnect) makes poll_output
 			// return a never-firing timeout instead of erroring, which would hang
@@ -185,8 +188,9 @@ impl Session {
 			let timeout = match self.rtc.poll_output().map_err(Error::Rtc)? {
 				Output::Timeout(t) => t,
 				Output::Transmit(t) => {
-					if let Err(err) = self.socket.send_to(&t.contents, t.destination).await {
-						tracing::warn!(%err, dst = %t.destination, "send failed");
+					let dst = crate::net::to_family(t.destination, socket_v6);
+					if let Err(err) = self.socket.send_to(&t.contents, dst).await {
+						tracing::warn!(%err, %dst, "send failed");
 					}
 					continue;
 				}
@@ -615,6 +619,7 @@ pub fn spawn_socket_reader(socket: Arc<UdpSocket>) -> mpsc::Receiver<Packet> {
 				// Bounded like a socket buffer: drop on full, stop once the
 				// session's receiver is gone.
 				Ok((len, src)) => {
+					let src = crate::net::canonical(src);
 					if let Err(mpsc::error::TrySendError::Closed(_)) = tx.try_send((buf[..len].to_vec(), src)) {
 						break;
 					}


### PR DESCRIPTION
## Summary

- A `[::]` (dual-stack) UDP bind reports an IPv4 peer as an IPv4-mapped IPv6 address (`::ffff:a.b.c.d`), and refuses a send to a real `V4` destination. Neither form should cross the socket boundary, so a new private `net` module canonicalizes inbound and re-maps outbound in one place.
- **Root cause** (for the dual-stack bind this unblocks): `pick_local` pairs an inbound packet with a host candidate by address family (`is_ipv4()`). On a `[::]` socket an IPv4 peer arrives as `SocketAddr::V6`, so it would be tagged with the IPv6 host candidate and str0m's ICE pairing would go inconsistent. The registry's `by_addr` keys would likewise be in mapped form. So simply binding `[::]` today would regress IPv4 WHIP/WHEP, which works fine.
- Applied at all three socket boundaries: the server mux demux, the session send path, and the client's 1:1 reader (a no-op on the client's `0.0.0.0` socket).

Downstream context: moq.pro's GeoDNS publishes an A **and** an AAAA per relay, but its gateways bind IPv4-only, so an IPv6 encoder hard-times-out against a record that never drains (moq-dev/moq.pro#709). Binding those gateways dual-stack needs this fix first.

## Public API changes

None. `net` is a private module; `Session::ingest`/`egress`/`run` signatures are unchanged. Adds one dev-dependency (`aws-lc-rs`, already in the tree via str0m) to sign a test STUN MESSAGE-INTEGRITY.

## Test plan

- `cargo test -p moq-rtc` — 35 pass, `cargo clippy -p moq-rtc --all-targets` clean.
- New `server::mux::tests::dual_stack_mux_routes_an_ipv4_peer_with_a_canonical_source` binds `[::]:0` and drives a real IPv4 STUN peer through the demux. **Verified it fails without the fix**: `left: [::ffff:127.0.0.1]:52888, right: 127.0.0.1:52888`.
- 5 unit tests in `net.rs` covering unmap, pass-through, re-map, and the round trip.

(Written by Claude Opus 4.8)