### PR TITLE
feat(moq-net): coalesce concurrent group fetches behind a shared Requests queue

### DIFF
--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -1,13 +1,12 @@
 use crate::track;
 use std::{
-	collections::{HashMap, VecDeque},
 	sync::Arc,
 	task::{Poll, ready},
 };
 
 use crate::Error;
 
-use super::{OriginList, WeakCache};
+use super::{OriginList, Requests, WeakCache};
 
 /// A collection of media tracks that can be published and subscribed to.
 ///
@@ -61,17 +60,11 @@ struct BroadcastState {
 	// broadcast churning distinct track names stays bounded by the live count.
 	tracks: WeakCache<Arc<str>, track::TrackWeak>,
 
-	// Pending requests keyed by track name, waiting for the dynamic handler to
-	// accept or deny them.
-	requests: HashMap<Arc<str>, track::Request>,
-
-	// Requested names in FIFO order for the dynamic handler to drain. A name
-	// stays in `requests` (but not here) once handed out as a `track::Request`.
-	request_order: VecDeque<Arc<str>>,
-
-	// The current number of dynamic producers.
-	// If this is 0, requests must be empty.
-	dynamic: usize,
+	// Pending requests keyed by track name, coalescing concurrent `track()` calls
+	// and waiting for a dynamic handler to accept or deny them. A request leaves
+	// here once handed out (the handler caches it in `tracks`, so lookups keep
+	// coalescing onto it there).
+	requests: Requests<Arc<str>, track::Request>,
 
 	// Set by an explicit `Producer::finish()` so `Drop` can tell a deliberate
 	// shutdown apart from a producer that was dropped by accident.
@@ -86,15 +79,6 @@ impl BroadcastState {
 			Some(_) => Err(Error::Duplicate),
 			None => Ok(()),
 		}
-	}
-
-	/// Reject any pending dynamic track requests. Called when the last dynamic handler
-	/// goes away, so consumers don't block forever on requests nobody will fulfill.
-	fn reject_requests(&mut self, err: Error) {
-		for (_, request) in self.requests.drain() {
-			request.reject(err.clone());
-		}
-		self.request_order.clear();
 	}
 }
 
@@ -285,11 +269,10 @@ pub struct Dynamic {
 
 impl Clone for Dynamic {
 	fn clone(&self) -> Self {
-		// Mirror `new`: bump `state.dynamic` so each live handle is counted.
-		// Without this, deriving Clone would let `Drop` decrement past `new`'s
-		// single increment and prematurely flip `dynamic` to zero, causing
-		// future `track` calls to return `NotFound`.
-		self.state.lock().dynamic += 1;
+		// Mirror `new`: count each live handle. Without this, deriving Clone would
+		// let `Drop` decrement past `new`'s single increment and prematurely flip
+		// the handler count to zero, causing future `track` calls to return `NotFound`.
+		self.state.lock().requests.add_handler();
 
 		Self {
 			info: self.info.clone(),
@@ -301,7 +284,7 @@ impl Clone for Dynamic {
 
 impl Dynamic {
 	fn new(info: Arc<Info>, alive: kio::Producer<()>, state: kio::Shared<BroadcastState>) -> Self {
-		state.lock().dynamic += 1;
+		state.lock().requests.add_handler();
 
 		Self { info, alive, state }
 	}
@@ -313,15 +296,15 @@ impl Dynamic {
 	/// Poll for the next consumer-requested track, without blocking.
 	pub fn poll_requested_track(&mut self, waiter: &kio::Waiter) -> Poll<Result<track::Request, Error>> {
 		let mut state = ready!(self.state.poll(waiter, |state| {
-			if state.request_order.is_empty() {
-				Poll::Pending
-			} else {
+			if state.requests.has_queued() {
 				Poll::Ready(())
+			} else {
+				Poll::Pending
 			}
 		}));
 
-		let name = state.request_order.pop_front().expect("predicate guaranteed a request");
-		let pending = state.requests.remove(&name).expect("request_order out of sync");
+		let name = state.requests.pop().expect("predicate guaranteed a request");
+		let pending = state.requests.remove(&name).expect("popped key must be pending");
 		// Cache the served track so concurrent lookups coalesce onto it. If a live track already
 		// holds the name (a publish raced the request), `insert` keeps it rather than shadowing it.
 		let _ = state.tracks.insert(name, pending.weak());
@@ -356,16 +339,16 @@ impl Dynamic {
 
 impl Drop for Dynamic {
 	fn drop(&mut self) {
-		// Decrement and reject under one lock, so a `track` call that saw
-		// `dynamic > 0` through the same lock can't slip a request past the rejection.
+		// Decrement and reject under one lock, so a `track` call that saw a live
+		// handler through the same lock can't slip a request past the rejection.
 		let mut state = self.state.lock();
-		state.dynamic -= 1;
-		if state.dynamic != 0 {
-			return;
+		if state.requests.remove_handler() {
+			// No handlers left to fulfill pending requests; reject them so consumers
+			// don't block forever on tracks nobody will serve.
+			for request in state.requests.drain_queued() {
+				request.reject(Error::Dropped);
+			}
 		}
-
-		// No dynamic handlers left to fulfill pending requests; reject them.
-		state.reject_requests(Error::Dropped);
 	}
 }
 
@@ -416,13 +399,9 @@ impl Consumer {
 			return Ok(weak.consume());
 		}
 
-		if let Some(pending) = state.requests.get_mut(name) {
-			// Coalesce onto an in-flight request for the same name.
+		if let Some(pending) = state.requests.join(name) {
+			// Coalesce onto a queued request for the same name.
 			return Ok(pending.consume());
-		}
-
-		if state.dynamic == 0 {
-			return Err(Error::NotFound);
 		}
 
 		// Allocate the name once and share the same Arc across the request, the
@@ -432,8 +411,11 @@ impl Consumer {
 		let request = track::Request::new(self.info.clone(), name.clone());
 		let consumer = request.consume();
 
-		state.requests.insert(name.clone(), request);
-		state.request_order.push_back(name);
+		// With no handler alive to serve it, the request is dropped: `NotFound` beats
+		// handing back a consumer that would only resolve `Dropped`.
+		if state.requests.insert(name, request).is_err() {
+			return Err(Error::NotFound);
+		}
 
 		Ok(consumer)
 	}
@@ -717,8 +699,8 @@ mod test {
 		);
 	}
 
-	// Cloning a `Dynamic` and dropping the clone must not flip
-	// `state.dynamic` to zero. The relay's lite subscriber clones the
+	// Cloning a `Dynamic` and dropping the clone must not flip the handler
+	// count to zero. The relay's lite subscriber clones the
 	// dynamic per spawned subscribe; if Clone skipped the increment, the
 	// first finished subscribe would tear down the broadcast and any
 	// follow-up `track` would return `NotFound`.

--- a/rs/moq-net/src/model/mod.rs
+++ b/rs/moq-net/src/model/mod.rs
@@ -13,10 +13,12 @@ mod origin_impl;
 
 mod bytes;
 mod datagram;
+mod requests;
 mod subscription;
 mod time;
 mod weak_cache;
 
+pub(crate) use requests::Requests;
 pub(crate) use weak_cache::{WeakCache, WeakEntry};
 
 pub use bytes::*;

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -9,7 +9,7 @@ use std::{
 use rand::RngExt;
 use web_async::Lock;
 
-use super::WeakCache;
+use super::{Requests, WeakCache};
 use crate::{
 	AsPath, Error, Path, PathOwned, PathPrefixes,
 	coding::{BoundsExceeded, Decode, DecodeError, Encode, EncodeError},
@@ -1048,18 +1048,12 @@ impl std::ops::DerefMut for Broadcast {
 ///
 /// Lives off to the side of the announce tree because dynamically served broadcasts
 /// are never announced. Carried in a [`kio::Shared`], so consumers enqueue and handlers
-/// drain under one lock. Mirrors the `dynamic`/`requests`/`request_order` fields of the
-/// broadcast and track models.
+/// drain under one lock. Mirrors the fetch state of the track model.
 #[derive(Default)]
 struct OriginDynamicState {
-	// Result channels for queued requests, keyed by absolute path. Concurrent
-	// `request_broadcast` calls for the same path coalesce onto the same channel while
-	// it is queued. The producer is moved out (and the entry removed) when the handler
-	// picks the request up via [`Dynamic::requested_broadcast`].
-	requests: HashMap<PathOwned, kio::Producer<PendingBroadcast>>,
-
-	// Requesting paths in FIFO order for the handler to drain.
-	request_order: VecDeque<PathOwned>,
+	// Result channels for pending requests, keyed by absolute path so concurrent
+	// `request_broadcast` calls for the same path coalesce onto one channel.
+	requests: Requests<PathOwned, kio::Producer<PendingBroadcast>>,
 
 	// Broadcasts a handler has already served, kept weakly so a repeat request for the
 	// same path resolves to a shared clone instead of re-invoking the handler (which would
@@ -1067,19 +1061,6 @@ struct OriginDynamicState {
 	// its real consumers drop. The cache reclaims closed entries incrementally on insert, so a
 	// long-lived origin serving many distinct one-shot paths stays bounded by the live count.
 	served: WeakCache<PathOwned, broadcast::WeakConsumer>,
-
-	// The number of live `Dynamic` handlers. While zero, `request_broadcast`
-	// fails fast with `Unroutable` rather than queueing a request nobody will serve.
-	dynamic: usize,
-}
-
-impl OriginDynamicState {
-	/// Drop every queued request, closing its result channel so awaiting requesters
-	/// resolve to an error. Called when the last handler goes away.
-	fn reject_requests(&mut self) {
-		self.requests.clear();
-		self.request_order.clear();
-	}
 }
 
 /// One-shot result of a dynamic broadcast request.
@@ -1111,10 +1092,10 @@ pub struct Dynamic {
 
 impl Clone for Dynamic {
 	fn clone(&self) -> Self {
-		// Mirror `new`: bump `dynamic` so each live handle is counted. Without this,
-		// dropping a clone would decrement past `new`'s increment and prematurely flip
-		// `dynamic` to zero, making future `request_broadcast` calls return `Unroutable`.
-		self.state.lock().dynamic += 1;
+		// Mirror `new`: count each live handle. Without this, dropping a clone would
+		// decrement past `new`'s increment and prematurely flip the handler count to
+		// zero, making future `request_broadcast` calls return `Unroutable`.
+		self.state.lock().requests.add_handler();
 
 		Self {
 			info: self.info,
@@ -1126,7 +1107,7 @@ impl Clone for Dynamic {
 
 impl Dynamic {
 	fn new(info: Origin, root: PathOwned, state: kio::Shared<OriginDynamicState>) -> Self {
-		state.lock().dynamic += 1;
+		state.lock().requests.add_handler();
 
 		Self { info, root, state }
 	}
@@ -1139,20 +1120,20 @@ impl Dynamic {
 	/// Poll for the next requested broadcast, without blocking.
 	pub fn poll_requested_broadcast(&mut self, waiter: &kio::Waiter) -> Poll<Result<Request, Error>> {
 		let mut state = ready!(self.state.poll(waiter, |state| {
-			if state.request_order.is_empty() {
-				Poll::Pending
-			} else {
+			if state.requests.has_queued() {
 				Poll::Ready(())
+			} else {
+				Poll::Pending
 			}
 		}));
 
-		let path = state.request_order.pop_front().expect("predicate guaranteed a request");
-		// Leave the request in `requests` (only drain it from `request_order`) so a repeat
-		// request in the window between hand-off and accept coalesces onto it instead of
-		// re-invoking the handler. The producer is a shared clone; `Request::{accept, reject,
-		// drop}` removes the entry. This mirrors how `poll_requested_track` keeps a served
-		// track discoverable via the weak cache across the same window.
-		let producer = state.requests.get(&path).expect("request_order out of sync").clone();
+		let path = state.requests.pop().expect("predicate guaranteed a request");
+		// The popped request stays pending, so a repeat request in the window between
+		// hand-off and accept coalesces onto it instead of re-invoking the handler. The
+		// producer is a shared clone; `Request::{accept, reject, drop}` removes the
+		// entry. This mirrors how `poll_requested_track` keeps a served track
+		// discoverable via the weak cache across the same window.
+		let producer = state.requests.get(&path).expect("popped key must be pending").clone();
 		Poll::Ready(Ok(Request {
 			path,
 			producer,
@@ -1174,13 +1155,14 @@ impl Dynamic {
 
 impl Drop for Dynamic {
 	fn drop(&mut self) {
-		// Decrement and reject under one lock, so a `request_broadcast` that saw
-		// `dynamic > 0` through the same lock can't slip a request past the rejection.
+		// Decrement and reject under one lock, so a `request_broadcast` that saw a
+		// live handler through the same lock can't slip a request past the rejection.
 		let mut state = self.state.lock();
-		state.dynamic -= 1;
-		if state.dynamic == 0 {
-			// No handlers left to fulfill queued requests; close them.
-			state.reject_requests();
+		if state.requests.remove_handler() {
+			// No handlers left to pop queued requests; drop them, closing their result
+			// channels so awaiting requesters resolve to `Unroutable`. A request already
+			// handed to a handler stays, resolved by its `Request` instead.
+			state.requests.drain_queued();
 		}
 	}
 }
@@ -1225,7 +1207,9 @@ impl Request {
 		let resolved = {
 			let mut state = self.state.lock();
 			let existing = state.served.insert(self.path.clone(), broadcast.weak());
-			state.requests.remove(&self.path);
+			state
+				.requests
+				.remove_if(&self.path, |producer| producer.same_channel(&self.producer));
 			existing.map(|weak| weak.consume()).unwrap_or(broadcast)
 		};
 
@@ -1237,7 +1221,10 @@ impl Request {
 
 	/// Reject the request, resolving every awaiting requester with `err`.
 	pub fn reject(self, err: Error) {
-		self.state.lock().requests.remove(&self.path);
+		self.state
+			.lock()
+			.requests
+			.remove_if(&self.path, |producer| producer.same_channel(&self.producer));
 		if let Ok(mut state) = self.producer.write() {
 			state.resolved = Some(Err(err));
 		}
@@ -1246,22 +1233,17 @@ impl Request {
 
 impl Drop for Request {
 	fn drop(&mut self) {
-		// Handed off but neither accepted nor rejected: drop the still-queued entry so its
+		// Handed off but neither accepted nor rejected: drop the still-pending entry so its
 		// producer clone (plus this one) closes the channel, resolving coalesced requesters to
 		// `Unroutable` rather than hanging.
 		//
-		// Guard on channel identity: `accept`/`reject` already removed our entry and released the
-		// lock before we run, so a concurrent request for the same path may have registered a
-		// *new* one here. Removing unconditionally would clobber it (stranding its requesters and
-		// desyncing `request_order` from `requests`), so only remove while it's still ours.
-		let mut state = self.state.lock();
-		if state
+		// The identity guard matters: `accept`/`reject` already removed our entry and released
+		// the lock before we run, so a concurrent request for the same path may have registered
+		// a *new* one here. Removing unconditionally would clobber it, stranding its requesters.
+		self.state
+			.lock()
 			.requests
-			.get(&self.path)
-			.is_some_and(|producer| producer.same_channel(&self.producer))
-		{
-			state.requests.remove(&self.path);
-		}
+			.remove_if(&self.path, |producer| producer.same_channel(&self.producer));
 	}
 }
 
@@ -1559,18 +1541,16 @@ impl Consumer {
 			return kio::Pending::new(Requesting::ready(weak.consume()));
 		}
 
-		// Coalesce onto a queued request for the same path; otherwise register a new one.
-		let consumer = if let Some(producer) = state.requests.get(&absolute) {
+		// Coalesce onto a pending request for the same path; otherwise register a new
+		// one, unless there is no handler alive to serve it.
+		let consumer = if let Some(producer) = state.requests.join(&absolute) {
 			producer.consume()
 		} else {
-			if state.dynamic == 0 {
-				return kio::Pending::new(Requesting::failed(Error::Unroutable));
-			}
-
 			let producer = kio::Producer::<PendingBroadcast>::default();
 			let consumer = producer.consume();
-			state.requests.insert(absolute.clone(), producer);
-			state.request_order.push_back(absolute);
+			if state.requests.insert(absolute, producer).is_err() {
+				return kio::Pending::new(Requesting::failed(Error::Unroutable));
+			}
 			consumer
 		};
 
@@ -3324,7 +3304,7 @@ mod tests {
 	}
 
 	// After a rejected hand-off, a fresh request for the same path reaches the handler again:
-	// the rejected `Request`'s removal + `Drop` leave `requests` and `request_order` consistent
+	// the rejected `Request`'s removal + `Drop` leave the request queue consistent
 	// (a stale/clobbered entry would strand this request or panic the handler).
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_rerequest_after_reject() {

--- a/rs/moq-net/src/model/requests.rs
+++ b/rs/moq-net/src/model/requests.rs
@@ -1,0 +1,201 @@
+//! A coalescing request queue drained by dynamic handlers.
+use std::{
+	borrow::Borrow,
+	collections::{HashMap, VecDeque},
+	hash::Hash,
+};
+
+/// Requests keyed by `K`, drained in FIFO order by a pool of handlers.
+///
+/// This is the state shared between requesters and the `Dynamic` handlers that
+/// serve them (origin broadcasts, broadcast tracks, track fetches), typically
+/// inside a [`kio::Shared`] so both sides work under one lock. It encodes two
+/// invariants in one place:
+///
+/// - A request is only queued while a handler is alive to drain it
+///   ([`Self::insert`] fails otherwise), so nothing waits on an empty pool.
+/// - A repeat request joins the pending entry ([`Self::join`]) instead of
+///   queueing a duplicate, so N requesters cost one handler round-trip.
+///
+/// [`Self::pop`] hands out only the key: the entry stays pending (still
+/// joinable) until the caller explicitly removes it, on resolution or via
+/// [`Self::drain_queued`] when the last handler leaves.
+pub(crate) struct Requests<K, V> {
+	// Every pending request: queued or already handed to a handler.
+	pending: HashMap<K, V>,
+	// The queued (not yet popped) subset, FIFO. Every key here is in `pending`.
+	order: VecDeque<K>,
+	// Live handler count; gates `insert`.
+	handlers: usize,
+}
+
+impl<K, V> Default for Requests<K, V> {
+	fn default() -> Self {
+		Self {
+			pending: HashMap::new(),
+			order: VecDeque::new(),
+			handlers: 0,
+		}
+	}
+}
+
+impl<K: Clone + Eq + Hash, V> Requests<K, V> {
+	/// Join the pending request for `key`, queued or already handed out.
+	pub fn join<Q>(&mut self, key: &Q) -> Option<&mut V>
+	where
+		K: Borrow<Q>,
+		Q: Eq + Hash + ?Sized,
+	{
+		self.pending.get_mut(key)
+	}
+
+	/// Queue a new request, handing `value` back when no handler is alive to
+	/// drain it.
+	///
+	/// The caller should [`Self::join`] first; inserting over an existing entry
+	/// would orphan it.
+	pub fn insert(&mut self, key: K, value: V) -> Result<(), V> {
+		if self.handlers == 0 {
+			return Err(value);
+		}
+		let prev = self.pending.insert(key.clone(), value);
+		debug_assert!(prev.is_none(), "insert over a pending request; join it instead");
+		self.order.push_back(key);
+		Ok(())
+	}
+
+	/// Pop the next queued key for a handler to serve. The entry stays pending
+	/// (joinable) until removed.
+	pub fn pop(&mut self) -> Option<K> {
+		self.order.pop_front()
+	}
+
+	/// The pending request for `key`, if any.
+	pub fn get<Q>(&self, key: &Q) -> Option<&V>
+	where
+		K: Borrow<Q>,
+		Q: Eq + Hash + ?Sized,
+	{
+		self.pending.get(key)
+	}
+
+	/// Remove and return the pending request for `key`, if any.
+	pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
+	where
+		K: Borrow<Q>,
+		Q: Eq + Hash + ?Sized,
+	{
+		self.pending.remove(key)
+	}
+
+	/// Remove the pending request for `key` if `f` says it's the caller's own,
+	/// leaving a newer entry that replaced it alone.
+	pub fn remove_if<Q>(&mut self, key: &Q, f: impl FnOnce(&V) -> bool) -> Option<V>
+	where
+		K: Borrow<Q>,
+		Q: Eq + Hash + ?Sized,
+	{
+		if !self.pending.get(key).is_some_and(f) {
+			return None;
+		}
+		self.pending.remove(key)
+	}
+
+	/// Returns `true` if a queued (not yet popped) request exists.
+	pub fn has_queued(&self) -> bool {
+		!self.order.is_empty()
+	}
+
+	/// Returns `true` when nothing is pending, queued or handed out.
+	#[cfg(test)]
+	pub fn is_empty(&self) -> bool {
+		self.pending.is_empty()
+	}
+
+	/// Count a new live handler.
+	pub fn add_handler(&mut self) {
+		self.handlers += 1;
+	}
+
+	/// Count a handler out, returning `true` if it was the last one.
+	pub fn remove_handler(&mut self) -> bool {
+		self.handlers -= 1;
+		self.handlers == 0
+	}
+
+	/// Returns `true` while at least one handler is alive.
+	pub fn has_handlers(&self) -> bool {
+		self.handlers > 0
+	}
+
+	/// Remove and return every queued (never popped) request, so the caller can
+	/// reject them when the last handler leaves. Popped entries stay pending,
+	/// owned by whichever handler took them.
+	pub fn drain_queued(&mut self) -> Vec<V> {
+		self.order
+			.drain(..)
+			.filter_map(|key| self.pending.remove(&key))
+			.collect()
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn insert_gated_on_handlers() {
+		let mut requests = Requests::<u64, &str>::default();
+		assert_eq!(requests.insert(1, "a"), Err("a"));
+
+		requests.add_handler();
+		assert!(requests.insert(1, "a").is_ok());
+		assert_eq!(requests.pop(), Some(1));
+		assert_eq!(requests.pop(), None);
+
+		assert!(requests.remove_handler());
+		assert_eq!(requests.insert(2, "b"), Err("b"));
+	}
+
+	#[test]
+	fn popped_stays_joinable_until_removed() {
+		let mut requests = Requests::<u64, &str>::default();
+		requests.add_handler();
+		assert!(requests.insert(1, "a").is_ok());
+
+		assert_eq!(requests.pop(), Some(1));
+		assert_eq!(requests.join(&1), Some(&mut "a"));
+		assert!(!requests.has_queued());
+
+		assert_eq!(requests.remove(&1), Some("a"));
+		assert!(requests.is_empty());
+	}
+
+	#[test]
+	fn remove_if_guards_identity() {
+		let mut requests = Requests::<u64, &str>::default();
+		requests.add_handler();
+		assert!(requests.insert(1, "old").is_ok());
+
+		// A stale owner (matching "old") must not clobber the newer entry.
+		*requests.join(&1).unwrap() = "new";
+		assert_eq!(requests.remove_if(&1, |v| *v == "old"), None);
+		assert_eq!(requests.remove_if(&1, |v| *v == "new"), Some("new"));
+	}
+
+	#[test]
+	fn drain_queued_spares_popped() {
+		let mut requests = Requests::<u64, &str>::default();
+		requests.add_handler();
+		assert!(requests.insert(1, "handed out").is_ok());
+		assert!(requests.insert(2, "queued").is_ok());
+		assert_eq!(requests.pop(), Some(1));
+
+		assert!(requests.remove_handler());
+		assert_eq!(requests.drain_queued(), vec!["queued"]);
+
+		// The handed-out request is still pending, owned by its handler.
+		assert_eq!(requests.get(&1), Some(&"handed out"));
+		assert!(!requests.has_queued());
+	}
+}

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -16,12 +16,12 @@
 use crate::{Error, Result, Timescale, Timestamp, coding};
 use crate::{broadcast, cache, frame, group};
 
-use super::Datagram;
+use super::{Datagram, Requests};
 
 pub use super::subscription::Subscription;
 
 use std::{
-	collections::{HashMap, HashSet, VecDeque},
+	collections::{HashSet, VecDeque},
 	sync::Arc,
 	task::{Poll, ready},
 	time::Duration,
@@ -195,43 +195,28 @@ struct TrackState {
 type Subscriptions = Vec<kio::Consumer<Subscription>>;
 
 /// Reverse state for [`Consumer::fetch_group`], beside the track state in its own
-/// [`kio::Shared`]: consumers enqueue and [`Dynamic`] handlers drain under one lock,
-/// without write access to the track itself.
-#[derive(Default)]
-struct FetchState {
-	// Specific groups requested via `fetch` that aren't cached yet, FIFO for a
-	// `Dynamic` to serve (see `Dynamic::requested_group`).
-	queue: VecDeque<GroupRequested>,
+/// [`kio::Shared`]: consumers enqueue (coalescing per sequence, so a relay opens one
+/// upstream FETCH per group) and [`Dynamic`] handlers drain under one lock, without
+/// write access to the track itself.
+type FetchState = Requests<u64, PendingFetch>;
 
-	// Monotonic IDs for fetches that reached a dynamic handler.
-	next: u64,
+/// One fetch attempt for a sequence, shared by every [`Fetching`] that joined it.
+struct PendingFetch {
+	// The most demanding delivery priority across the joined fetches.
+	priority: u8,
 
-	// Per-request failures for popped fetches. Keyed by request ID so rejecting one
-	// transient attempt doesn't poison future retries for the same sequence.
-	rejections: HashMap<u64, Error>,
-
-	// Number of live `Dynamic` handles. While zero, the track serves no
-	// uncached groups, so a cache-miss `fetch` on an accepted track fails fast
-	// instead of blocking forever (mirrors `BroadcastState::dynamic`).
-	dynamic: usize,
+	// Result channel back to the joined fetches. Written only on rejection; a
+	// successful accept resolves them through the track cache instead. Dropping
+	// every producer without writing (a vanished handler) closes the channel,
+	// which a [`Fetching`] reads as [`Error::NotFound`].
+	result: kio::Producer<FetchOutcome>,
 }
 
-impl FetchState {
-	fn reject(&mut self, id: u64, err: Error) {
-		self.rejections.entry(id).or_insert(err);
-	}
-
-	/// Ready once the fetch can never be served from here: a handler rejected this
-	/// request, or no handler exists at all. The caller reads the rejection (if any)
-	/// through the returned guard.
-	fn poll_unservable(&self, request_id: Option<u64>) -> Poll<()> {
-		let rejected = request_id.is_some_and(|id| self.rejections.contains_key(&id));
-		if rejected || self.dynamic == 0 {
-			Poll::Ready(())
-		} else {
-			Poll::Pending
-		}
-	}
+/// The result of a fetch attempt. Stays empty on success (the group lands in the
+/// track cache); a handler writes `rejected` to fail every joined fetch.
+#[derive(Default)]
+struct FetchOutcome {
+	rejected: Option<Error>,
 }
 
 impl TrackState {
@@ -1048,20 +1033,26 @@ fn poll_requested_group(
 ) -> Poll<Result<GroupRequest>> {
 	// Prefer serving a queued fetch, even if the track has since aborted.
 	if let Poll::Ready(mut guard) = fetch.poll(waiter, |fetch| {
-		if fetch.queue.is_empty() {
-			Poll::Pending
-		} else {
+		if fetch.has_queued() {
 			Poll::Ready(())
+		} else {
+			Poll::Pending
 		}
 	}) {
-		let req = guard.queue.pop_front().expect("predicate guaranteed a request");
+		let sequence = guard.pop().expect("predicate guaranteed a request");
+		// The popped attempt stays pending, so a fetch in the window between hand-off
+		// and accept joins it instead of queueing a duplicate.
+		// `GroupRequest::{accept, reject, drop}` removes the entry.
+		let pending = guard.get(&sequence).expect("popped key must be pending");
+		let priority = pending.priority;
+		let result = pending.result.clone();
 		drop(guard);
 		return Poll::Ready(Ok(GroupRequest {
 			state: state.clone(),
 			fetch: fetch.clone(),
-			id: req.id,
-			sequence: req.sequence,
-			priority: req.priority,
+			sequence,
+			priority,
+			result,
 			done: false,
 		}));
 	}
@@ -1097,7 +1088,7 @@ pub struct Dynamic {
 impl Dynamic {
 	fn new(name: Arc<str>, state: kio::Producer<TrackState>) -> Self {
 		let fetch = state.read().fetch.clone();
-		fetch.lock().dynamic += 1;
+		fetch.lock().add_handler();
 		Self { name, state, fetch }
 	}
 
@@ -1126,8 +1117,8 @@ impl Dynamic {
 
 impl Clone for Dynamic {
 	fn clone(&self) -> Self {
-		// Bump `dynamic` so each live handle is counted (mirrors `broadcast::Dynamic`).
-		self.fetch.lock().dynamic += 1;
+		// Count each live handle (mirrors `broadcast::Dynamic`).
+		self.fetch.lock().add_handler();
 		Self {
 			name: self.name.clone(),
 			state: self.state.clone(),
@@ -1139,10 +1130,14 @@ impl Clone for Dynamic {
 impl Drop for Dynamic {
 	fn drop(&mut self) {
 		// Unlike `broadcast::Dynamic`, dropping the last handle doesn't abort the track:
-		// a live `Producer` may still be serving the subscription. It just stops
-		// fetch serving, after which an accepted track's cache miss fails fast (the
-		// decrement wakes every parked `Fetching`, which observes `dynamic == 0`).
-		self.fetch.lock().dynamic -= 1;
+		// a live `Producer` may still be serving the subscription. It just stops fetch
+		// serving. Queued attempts no handler will ever pop are dropped, closing their
+		// result channels so every joined `Fetching` resolves NotFound; an attempt
+		// already handed to a handler stays, resolved by its `GroupRequest` instead.
+		let mut fetch = self.fetch.lock();
+		if fetch.remove_handler() {
+			fetch.drain_queued();
+		}
 	}
 }
 
@@ -1339,10 +1334,11 @@ impl Consumer {
 	///
 	/// The returned future resolves to [`Error::NotFound`] when the group can never be served
 	/// (past the final sequence, or no [`Dynamic`] on the track), or the track's abort error
-	/// if it's already closed.
+	/// if it's already closed. Concurrent fetches for the same sequence coalesce onto one
+	/// handler request.
 	pub fn fetch_group(&self, sequence: u64, options: impl Into<Option<group::Fetch>>) -> kio::Pending<Fetching> {
 		let options = options.into().unwrap_or_default();
-		let mut request_id = None;
+		let mut result = None;
 
 		// Queue a request only when the group isn't already resolvable from the track
 		// (cached, aborted, or past-final all resolve through `Fetching::poll` without
@@ -1353,19 +1349,25 @@ impl Consumer {
 		};
 
 		if unresolved {
-			// Gate on a live handler, checked and pushed under the fetch lock so the
-			// check is atomic with a handler dropping (no fetch stranded on a queue
-			// nobody drains). With no handler, `Fetching::poll` fails fast instead.
 			let mut fetch = fetch.lock();
-			if fetch.dynamic > 0 {
-				let id = fetch.next;
-				fetch.next = fetch.next.wrapping_add(1);
-				fetch.queue.push_back(GroupRequested {
-					id,
-					sequence,
+			if let Some(pending) = fetch.join(&sequence) {
+				// Join the in-flight attempt for this sequence (queued or already being
+				// served): share its result channel, raising its priority if ours is higher.
+				pending.priority = pending.priority.max(options.priority);
+				result = Some(pending.result.consume());
+			} else {
+				// Queue a new attempt. The handler gate is atomic with a handler
+				// dropping (no fetch stranded on a queue nobody drains); with no
+				// handler, `Fetching::poll` fails fast instead.
+				let producer = kio::Producer::<FetchOutcome>::default();
+				let consumer = producer.consume();
+				let attempt = PendingFetch {
 					priority: options.priority,
-				});
-				request_id = Some(id);
+					result: producer,
+				};
+				if fetch.insert(sequence, attempt).is_ok() {
+					result = Some(consumer);
+				}
 			}
 		}
 
@@ -1373,7 +1375,7 @@ impl Consumer {
 			state: self.state.clone(),
 			fetch,
 			sequence,
-			request_id,
+			result,
 		})
 	}
 
@@ -1453,33 +1455,22 @@ impl kio::Future for Querying {
 	}
 }
 
-/// A specific group requested via [`Consumer::fetch_group`], queued on the
-/// track for a [`Dynamic`] to serve.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-struct GroupRequested {
-	/// The request ID matching the waiting [`Fetching`].
-	id: u64,
-	/// The group sequence the consumer wants.
-	sequence: u64,
-	/// The requested delivery priority.
-	priority: u8,
-}
-
 /// A consumer's request for a single past group, handed to a handler via
 /// [`Dynamic::requested_group`].
 ///
 /// The handler fulfills it by calling [`Self::accept`], which inserts the group
-/// into the track cache (resolving the matching [`Consumer::fetch_group`]) and
-/// returns a [`group::Producer`] to fill. A relay typically opens a wire FETCH, reads
-/// FETCH_OK, then accepts. The request carries its own producer handle, so it works
-/// the same whether or not the track has been accepted yet.
+/// into the track cache (resolving every [`Consumer::fetch_group`] that joined the
+/// attempt) and returns a [`group::Producer`] to fill. A relay typically opens a wire
+/// FETCH, reads FETCH_OK, then accepts. The request carries its own producer handle,
+/// so it works the same whether or not the track has been accepted yet.
 pub struct GroupRequest {
 	state: kio::Producer<TrackState>,
-	// Rejections route back to the waiting `Fetching` through the fetch state.
+	// To remove this attempt from the fetch state once it resolves.
 	fetch: kio::Shared<FetchState>,
-	id: u64,
 	sequence: u64,
 	priority: u8,
+	// Rejections route back to every joined `Fetching`.
+	result: kio::Producer<FetchOutcome>,
 	done: bool,
 }
 
@@ -1503,13 +1494,32 @@ impl GroupRequest {
 	/// already present, or the track's abort error if it closed while pending.
 	pub fn accept(mut self, info: impl Into<Option<Info>>) -> Result<group::Producer> {
 		self.done = true;
-		TrackState::modify(&self.state)?.insert_group_request(self.sequence, info.into())
+		// Cache the group before removing the attempt: the joined fetches resolve
+		// through the cache, and removal closes their result channel (which alone
+		// would read as NotFound).
+		let res = TrackState::modify(&self.state)
+			.and_then(|mut state| state.insert_group_request(self.sequence, info.into()));
+		self.remove();
+		res
 	}
 
-	/// Reject the fetch, resolving the waiting [`Consumer::fetch_group`] with `err`.
+	/// Reject the fetch, resolving every joined [`Consumer::fetch_group`] with `err`.
 	pub fn reject(mut self, err: Error) {
 		self.done = true;
-		self.fetch.lock().reject(self.id, err);
+		// Remove before writing, so a fetch arriving now starts a fresh attempt
+		// instead of joining a rejected one.
+		self.remove();
+		if let Ok(mut outcome) = self.result.write() {
+			outcome.rejected = Some(err);
+		}
+	}
+
+	/// Remove this attempt from the fetch state, unless a newer attempt for the same
+	/// sequence has already replaced it.
+	fn remove(&self) {
+		self.fetch
+			.lock()
+			.remove_if(&self.sequence, |pending| pending.result.same_channel(&self.result));
 	}
 }
 
@@ -1518,7 +1528,10 @@ impl Drop for GroupRequest {
 		if self.done {
 			return;
 		}
-		self.fetch.lock().reject(self.id, Error::Dropped);
+		self.remove();
+		if let Ok(mut outcome) = self.result.write() {
+			outcome.rejected = Some(Error::Dropped);
+		}
 	}
 }
 
@@ -1531,7 +1544,8 @@ pub struct Fetching {
 	state: kio::Consumer<TrackState>,
 	fetch: kio::Shared<FetchState>,
 	sequence: u64,
-	request_id: Option<u64>,
+	// The joined attempt's result channel; `None` when no handler existed to queue on.
+	result: Option<kio::Consumer<FetchOutcome>>,
 }
 
 impl kio::Future for Fetching {
@@ -1541,26 +1555,36 @@ impl kio::Future for Fetching {
 		// Track side: the cached group, the abort error, or past-final. The outer
 		// error is the channel closing without any of those.
 		match self.state.poll(waiter, |state| state.poll_fetch_cached(self.sequence)) {
-			Poll::Ready(Ok(res)) => {
-				// Resolved through the track: drop any stale rejection for this request.
-				if let Some(id) = self.request_id {
-					self.fetch.lock().rejections.remove(&id);
-				}
-				return Poll::Ready(res);
-			}
+			Poll::Ready(Ok(res)) => return Poll::Ready(res),
 			Poll::Ready(Err(closed)) => {
 				return Poll::Ready(Err(closed.abort.clone().unwrap_or(Error::Dropped)));
 			}
 			Poll::Pending => {}
 		}
 
-		// Handler side: a rejection for this request, or no handler to serve it at all.
-		let mut fetch = ready!(self.fetch.poll(waiter, |fetch| fetch.poll_unservable(self.request_id)));
-		let err = self
-			.request_id
-			.and_then(|id| fetch.rejections.remove(&id))
-			.unwrap_or(Error::NotFound);
-		Poll::Ready(Err(err))
+		// Handler side.
+		let Some(result) = &self.result else {
+			// Never queued: no handler existed when the fetch was made. Fail fast while
+			// that's still true; a handler that appeared since may yet fill the cache.
+			return match self.fetch.poll(waiter, |fetch| match fetch.has_handlers() {
+				false => Poll::Ready(()),
+				true => Poll::Pending,
+			}) {
+				Poll::Ready(_guard) => Poll::Ready(Err(Error::NotFound)),
+				Poll::Pending => Poll::Pending,
+			};
+		};
+
+		// A written rejection fails every joined fetch. The channel closing without
+		// one means the attempt was dropped unserved (its handlers went away).
+		match result.poll(waiter, |outcome| match &outcome.rejected {
+			Some(err) => Poll::Ready(err.clone()),
+			None => Poll::Pending,
+		}) {
+			Poll::Ready(Ok(err)) => Poll::Ready(Err(err)),
+			Poll::Ready(Err(_closed)) => Poll::Ready(Err(Error::NotFound)),
+			Poll::Pending => Poll::Pending,
+		}
 	}
 }
 
@@ -3184,7 +3208,7 @@ mod test {
 		req.reject(Error::Cancel);
 		assert!(matches!(pending.await, Err(Error::Cancel)));
 		let fetch = producer.state.read().fetch.clone();
-		assert!(fetch.read().rejections.is_empty());
+		assert!(fetch.read().is_empty());
 	}
 
 	#[tokio::test]
@@ -3233,6 +3257,91 @@ mod test {
 
 		let mut group = retry.await.unwrap();
 		assert_eq!(&group.read_frame().await.unwrap().unwrap().payload[..], b"retry");
+	}
+
+	#[tokio::test]
+	async fn fetch_coalesces_concurrent() {
+		let producer = track_producer("test", None);
+		let dynamic = producer.dynamic();
+		let consumer = producer.consume();
+
+		// Two fetches for the same uncached group produce ONE handler request,
+		// carrying the higher of the two priorities.
+		let first = consumer.fetch_group(5, group::Fetch::default().with_priority(1));
+		let second = consumer.fetch_group(5, group::Fetch::default().with_priority(7));
+		assert!(kio::Future::poll(&*first, &kio::Waiter::noop()).is_pending());
+
+		let req = dynamic
+			.requested_group()
+			.now_or_never()
+			.expect("should not block")
+			.unwrap();
+		assert_eq!(req.sequence(), 5);
+		assert_eq!(req.priority(), 7);
+		assert!(
+			dynamic.poll_requested_group(&kio::Waiter::noop()).is_pending(),
+			"the second fetch queued a duplicate request"
+		);
+
+		// A fetch arriving while the request is already in flight joins it too.
+		let third = consumer.fetch_group(5, None);
+
+		// One accept resolves all of them.
+		let mut group = req.accept(None).unwrap();
+		group
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"hi"))
+			.unwrap();
+		group.finish().unwrap();
+
+		assert_eq!(first.await.unwrap().sequence, 5);
+		assert_eq!(second.await.unwrap().sequence, 5);
+		assert_eq!(third.await.unwrap().sequence, 5);
+	}
+
+	#[tokio::test]
+	async fn fetch_coalesced_reject_fails_all() {
+		let producer = track_producer("test", None);
+		let dynamic = producer.dynamic();
+		let consumer = producer.consume();
+
+		let first = consumer.fetch_group(5, None);
+		let second = consumer.fetch_group(5, None);
+		let req = dynamic
+			.requested_group()
+			.now_or_never()
+			.expect("should not block")
+			.unwrap();
+		req.reject(Error::Cancel);
+
+		assert!(matches!(first.await, Err(Error::Cancel)));
+		assert!(matches!(second.await, Err(Error::Cancel)));
+
+		// The rejected attempt is gone: a retry starts a fresh one.
+		let retry = consumer.fetch_group(5, None);
+		assert!(kio::Future::poll(&*retry, &kio::Waiter::noop()).is_pending());
+		let req = dynamic
+			.requested_group()
+			.now_or_never()
+			.expect("should not block")
+			.unwrap();
+		assert_eq!(req.sequence(), 5);
+	}
+
+	#[tokio::test]
+	async fn fetch_queued_fails_when_handlers_leave() {
+		let producer = track_producer("test", None);
+		let dynamic = producer.dynamic();
+		let consumer = producer.consume();
+
+		// Queued but never popped: the last handler leaving fails it fast.
+		let pending = consumer.fetch_group(5, None);
+		assert!(kio::Future::poll(&*pending, &kio::Waiter::noop()).is_pending());
+		drop(dynamic);
+		assert!(matches!(pending.await, Err(Error::NotFound)));
+
+		// And the attempt didn't leak.
+		let fetch = producer.state.read().fetch.clone();
+		assert!(fetch.read().is_empty());
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
Follow-up to #2074, which noted that `fetch_group` was the one reverse queue without coalescing: every subscriber fetching the same uncached group queued its own handler request, so a relay opened N duplicate upstream FETCHes for one group.

## Fetch coalescing

`FetchState` is reshaped from an id-keyed queue + rejections map into attempts keyed by sequence:

- A `fetch_group` for a sequence with an in-flight attempt (queued or already handed to a handler) joins it: it shares the attempt's result channel and raises its priority to the max of the joined fetches. One `GroupRequest` reaches the handler, one upstream FETCH happens, and the accept resolves every joined fetch through the track cache.
- The per-request id and the `rejections` map are gone. Rejection now flows through a one-shot `kio::Producer<FetchOutcome>` carried by the attempt, mirroring how `origin::Request` already resolves coalesced `request_broadcast` calls. A rejection fails every joined fetch; a handler that vanishes without answering closes the channel, which reads as `NotFound`.
- Ordering invariants (encoded in comments and tests): `accept` caches the group before removing the attempt, so a close-wake can't race a joined fetch into `NotFound`; `reject` removes the attempt before writing the error, so a retry starts fresh instead of joining a rejected attempt; entry removal is identity-guarded (`same_channel`) so a stale handler can't clobber a newer attempt.
- When the last `Dynamic` drops, queued attempts are drained (their channels close, resolving joined fetches to `NotFound`); an attempt already handed to a handler stays, resolved by its `GroupRequest`.

## `Requests<K, V>`

With that change the three reverse queues (origin `request_broadcast`, broadcast track requests, track fetches) became structurally identical: a keyed coalescing map, a FIFO drain order, and a live-handler count gating inserts. They now share one private type, `model/requests.rs`:

- `join` / `insert` (fails with no live handler) / `pop` (entry stays joinable) / `remove_if` (identity-guarded) / `add_handler` / `remove_handler` / `drain_queued`.
- track: `FetchState` is now just `type FetchState = Requests<u64, PendingFetch>`.
- origin: `OriginDynamicState` keeps only the `served` weak-cache beside a `Requests<PathOwned, kio::Producer<PendingBroadcast>>`.
- broadcast: `BroadcastState` embeds `Requests<Arc<str>, track::Request>`; `reject_requests` and the hand-rolled `dynamic` counters are gone.

One deliberate behavior alignment: when the last origin `Dynamic` drops, only *queued* requests are drained now. A request already handed to a handler stays joinable and is resolved by its `Request` (previously it was severed from the map immediately, so late requesters could miss a fetch that still succeeded). Broadcast keeps its existing semantics (pending requests are explicitly rejected with `Dropped`).

`pending_subs` is untouched: it has no handler gate or coalescing, so it stays a plain `Shared<Vec<...>>`.

## Testing

- New: `fetch_coalesces_concurrent` (two fetches + one mid-flight join resolve off a single `GroupRequest`, max priority wins, no duplicate queued), `fetch_coalesced_reject_fails_all` (+ fresh retry afterwards), `fetch_queued_fails_when_handlers_leave` (fail-fast + no leak), and 4 unit tests on `Requests` (gate, join-after-pop, identity-guarded removal, drain spares handed-out entries).
- All existing moq-net tests pass unchanged (480 total); workspace check/clippy/rustdoc/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
