### PR TITLE
fix(signals)!: narrow Setter.set, brand Computed/Once, drop get/next aliases

### DIFF
--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -588,7 +588,7 @@ export class Subscriber {
 			const current = track.subscriptionSignal.peek()?.priority;
 			if (current === undefined || current === lastSent) {
 				// Nothing new to send; wait for a change or termination.
-				const next = await Promise.race([track.subscriptionSignal.next(), stopped]);
+				const next = await Promise.race([track.subscriptionSignal.changed(), stopped]);
 				if (next === null) return;
 				continue;
 			}
@@ -755,7 +755,7 @@ export class Subscriber {
 	async #peerProbeLevel(peerSetup: Signal<Setup | undefined>): Promise<ProbeLevel> {
 		let setup = peerSetup.peek();
 		while (setup === undefined) {
-			setup = await peerSetup.next();
+			setup = await peerSetup.changed();
 		}
 		return setup.probe;
 	}

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -65,7 +65,7 @@ test("a subscriber update is forwarded to the producer's update signal", async (
 
 	// The wire layer watches the producer's signal to emit SUBSCRIBE_UPDATE.
 	expect(producer.subscriptionSignal.peek()).toBeUndefined();
-	const next = producer.subscriptionSignal.next();
+	const next = producer.subscriptionSignal.changed();
 	track.update({ priority: 7 });
 	expect((await next)?.priority).toBe(7);
 });

--- a/js/signals/src/index.test.ts
+++ b/js/signals/src/index.test.ts
@@ -16,6 +16,19 @@ describe("Signal", () => {
 		expect(count.peek()).toBe(1); // value is synchronous; only notification is deferred
 	});
 
+	test("set stores a function as the value; update transforms", () => {
+		const fn = () => 1;
+		const held = new Signal<() => number>(fn);
+		expect(held.peek()).toBe(fn);
+
+		const other = () => 2;
+		held.set(other); // stored as-is, never invoked as a transform
+		expect(held.peek()).toBe(other);
+
+		held.update(() => fn);
+		expect(held.peek()).toBe(fn);
+	});
+
 	test("subscribers are notified asynchronously", async () => {
 		const count = new Signal(0);
 		const seen: number[] = [];

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -13,8 +13,14 @@ type Subscriber<T> = (value: T) => void;
 // @ts-ignore - Some environments don't recognize import.meta.env
 const DEV = typeof import.meta.env !== "undefined" && import.meta.env?.MODE !== "production";
 
-// Symbol to identify Signal instances across different package versions
+// Symbols to identify our instances across different package versions.
+// SIGNAL_BRAND is Signal only (it implies a write side); GETTER_BRAND is every readable we ship.
 const SIGNAL_BRAND = Symbol.for("@moq/signals");
+const GETTER_BRAND = Symbol.for("@moq/signals.getter");
+
+function branded(value: unknown, brand: symbol): boolean {
+	return typeof value === "object" && value !== null && brand in value;
+}
 
 /** Read side of a signal: peek the current value and subscribe to changes. */
 export interface Getter<T> {
@@ -32,8 +38,8 @@ export interface Getter<T> {
 
 /** Write side of a signal: replace or transform the current value. */
 export interface Setter<T> {
-	/** Replaces the value, or transforms it via a function of the previous value. */
-	set(value: T | ((prev: T) => T)): void;
+	/** Replaces the value. A function is stored as-is; use {@link update} to transform. */
+	set(value: T): void;
 	/** Transforms the value via a function of the previous value. */
 	update(fn: (prev: T) => T): void;
 }
@@ -58,8 +64,9 @@ export class Signal<T> implements Getter<T>, Setter<T> {
 	#hasCapturedOldValue = false;
 	#forceNotify = false;
 
-	// Brand to identify this as a Signal across package instances
+	// Brands to identify this as a Signal (and a readable) across package instances.
 	readonly [SIGNAL_BRAND] = true;
+	readonly [GETTER_BRAND] = true;
 
 	constructor(value: T) {
 		this.#value = value;
@@ -68,19 +75,13 @@ export class Signal<T> implements Getter<T>, Setter<T> {
 	/** Returns the value if it's already a Signal, otherwise wraps it in a new Signal. */
 	static from<T>(value: T | Signal<T>): Signal<T> {
 		// Use brand check instead of instanceof to work across package instances
-		if (typeof value === "object" && value !== null && SIGNAL_BRAND in value) {
+		if (branded(value, SIGNAL_BRAND)) {
 			return value as Signal<T>;
 		}
-		return new Signal(value);
+		return new Signal(value as T);
 	}
 
 	/** Returns the current value without subscribing. */
-	get(): T {
-		return this.#value;
-	}
-
-	/** Returns the current value without subscribing. */
-	// TODO rename to `get` once we've ported everything
 	peek(): T {
 		return this.#value;
 	}
@@ -88,6 +89,7 @@ export class Signal<T> implements Getter<T>, Setter<T> {
 	/**
 	 * Sets the current value, notifying subscribers if it changed.
 	 * Pass `notify` true to always notify or false to never notify.
+	 * A function is stored as the value; use {@link update} to transform instead.
 	 */
 	set(value: T, notify?: boolean): void {
 		// Capture old value before the first set in this microtask.
@@ -191,11 +193,6 @@ export class Signal<T> implements Getter<T>, Setter<T> {
 		});
 	}
 
-	/** Resolves with the next value, once the signal changes. */
-	next(): Promise<T> {
-		return this.changed();
-	}
-
 	/** Calls `fn` with the current value now, and again every time it changes. */
 	watch(fn: Subscriber<T>): Dispose {
 		const dispose = this.subscribe(fn);
@@ -236,6 +233,9 @@ export class Signal<T> implements Getter<T>, Setter<T> {
 export class Once<T> implements GetPromise<T> {
 	#signal = new Signal<T | undefined>(undefined);
 
+	// Brand to identify this as a readable across package instances.
+	readonly [GETTER_BRAND] = true;
+
 	/** Settle the value. Throws if it has already settled. */
 	set(value: T): void {
 		if (this.#signal.peek() !== undefined) {
@@ -275,47 +275,78 @@ export class Once<T> implements GetPromise<T> {
 }
 
 type SetterType<S> = S extends Setter<infer T> ? T : never;
+
+/** The value type a {@link Getter} yields, e.g. `number` for `Getter<number>`. */
 export type GetterType<G> = G extends Getter<infer T> ? T : never;
 
-// A record of named signals, used to group a component's `in` or `out` signals.
+/** A record of named signals, used to group a component's `in` or `out` signals. */
 export type SignalMap = Record<string, Getter<unknown>>;
 
-// A read-only view over a SignalMap: every entry collapses to its Getter and the
-// record itself is readonly. Consumers can peek/subscribe but can neither call set()
-// nor swap a signal out, so the owning component keeps sole write access.
+/**
+ * A read-only view over a {@link SignalMap}: every entry collapses to its {@link Getter} and the
+ * record itself is readonly. Consumers can peek/subscribe but can neither call `set()`
+ * nor swap a signal out, so the owning component keeps sole write access.
+ */
 export type Readonlys<T extends SignalMap> = {
 	readonly [K in keyof T]: Getter<GetterType<T[K]>>;
 };
 
-// Re-type a record of Signals as read-only Getters. This is the identity function at
-// runtime; it only narrows the static type. Keep the original (writable) reference
-// private for the component to set, and expose the result as the public `out`.
-//
-//   readonly #out = { status: new Signal("offline") };
-//   readonly out = readonlys(this.#out); // status is now a Getter to callers
+/**
+ * Re-types a record of Signals as read-only {@link Getter}s. This is the identity function at
+ * runtime; it only narrows the static type. Keep the original (writable) reference
+ * private for the component to set, and expose the result as the public `out`.
+ *
+ * ```ts
+ * readonly #out = { status: new Signal("offline") };
+ * readonly out = readonlys(this.#out); // status is now a Getter to callers
+ * ```
+ */
 export function readonlys<T extends SignalMap>(signals: T): Readonlys<T> {
 	return signals as unknown as Readonlys<T>;
 }
 
-// A value or an existing readable for it: the argument form accepted by `getter()`
-// and, per-field, by `Inputs`. Mirrors the `T | Signal<T>` shape of `Signal.from`.
+/**
+ * A value or an existing readable for it: the argument form accepted by {@link getter}
+ * and, per-field, by {@link Inputs}. Mirrors the `T | Signal<T>` shape of {@link Signal.from}.
+ */
 export type GetterInit<T> = T | Getter<T>;
 
-// Build a read-only Getter from a value or an existing readable. The read-only
-// counterpart to `Signal.from`: a branded Signal (including the result of `readonlys`)
-// is reused as-is, so one component's `out` can be wired straight into another's
-// `in`; any other value is wrapped in a fresh Signal. The brand check means a
-// hand-rolled Getter that isn't backed by a Signal would be treated as a value.
+/**
+ * Builds a read-only {@link Getter} from a value or an existing readable. The read-only
+ * counterpart to {@link Signal.from}: a `Signal`, `Computed`, or `Once` (including the result
+ * of {@link readonlys}) is reused as-is, so one component's `out` can be wired straight into
+ * another's `in`; any other value is wrapped in a fresh `Signal`.
+ *
+ * Throws on a readable this package didn't create, since wrapping it would silently
+ * freeze it into a constant.
+ */
 export function getter<T>(value: GetterInit<T>): Getter<T> {
-	if (typeof value === "object" && value !== null && SIGNAL_BRAND in value) {
+	if (branded(value, GETTER_BRAND) || branded(value, SIGNAL_BRAND)) {
 		return value as Getter<T>;
 	}
+
+	if (getterShaped(value)) {
+		throw new Error("getter() requires a Signal, Computed, or Once; a foreign readable would become a constant");
+	}
+
 	return new Signal(value as T);
 }
 
-// Derive a component's constructor argument from its `in` map: every entry becomes
-// optional and accepts a raw value, a Signal, or another component's `out` Getter
-// (the `getter()` contract). Removes the hand-written, drift-prone argument interface.
+// A readable we didn't make: it would be wrapped as a value and never update, so callers get an
+// error instead of a component that silently never sees a change.
+function getterShaped(value: unknown): boolean {
+	if (typeof value !== "object" || value === null) return false;
+	const maybe = value as Partial<Getter<unknown>>;
+	return (
+		typeof maybe.peek === "function" && typeof maybe.subscribe === "function" && typeof maybe.changed === "function"
+	);
+}
+
+/**
+ * Derives a component's constructor argument from its `in` map: every entry becomes
+ * optional and accepts a raw value, a Signal, or another component's `out` Getter
+ * (the {@link getter} contract). Removes the hand-written, drift-prone argument interface.
+ */
 export type Inputs<I extends SignalMap> = { [K in keyof I]?: GetterInit<GetterType<I[K]>> };
 
 // Excludes common falsy values from a type
@@ -800,6 +831,9 @@ export class Effect {
 export class Computed<T> implements Getter<T | undefined> {
 	#signal = new Signal<T | undefined>(undefined);
 	#effect: Effect;
+
+	// Brand to identify this as a readable across package instances.
+	readonly [GETTER_BRAND] = true;
 
 	/** Creates a computed that derives its value from `fn`, rerunning when dependencies change. */
 	constructor(fn: (effect: Effect) => T) {

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -308,6 +308,9 @@ export function readonlys<T extends SignalMap>(signals: T): Readonlys<T> {
 /**
  * A value or an existing readable for it: the argument form accepted by {@link getter}
  * and, per-field, by {@link Inputs}. Mirrors the `T | Signal<T>` shape of {@link Signal.from}.
+ *
+ * The readable must be a `Signal`, `Computed`, or `Once`; {@link getter} throws on any other
+ * implementation of {@link Getter} because it can't subscribe to one without leaking.
  */
 export type GetterInit<T> = T | Getter<T>;
 

--- a/js/signals/src/io.test.ts
+++ b/js/signals/src/io.test.ts
@@ -78,6 +78,19 @@ test("a Computed wired into an in stays live under an effect", async () => {
 	computed.close();
 });
 
+test("getter passes through a Signal from an older package version", () => {
+	// Older versions brand Signal but not the readable, so getter() must still accept the
+	// signal brand alone. Symbol.for shares the brand across copies of the package.
+	const old = {
+		[Symbol.for("@moq/signals")]: true,
+		peek: () => 3,
+		changed: (() => {}) as Getter<number>["changed"],
+		subscribe: () => () => {},
+	};
+
+	expect(getter(old as unknown as Getter<number>)).toBe(old);
+});
+
 test("getter throws on a foreign readable instead of freezing it", () => {
 	// Quacks like a Getter but carries no brand: wrapping it would silently never update.
 	const foreign: Getter<number> = {

--- a/js/signals/src/io.test.ts
+++ b/js/signals/src/io.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { type Getter, getter, readonlys, Signal } from "./index.ts";
+import { Computed, Effect, type Getter, getter, Once, readonlys, Signal } from "./index.ts";
 
 test("getter wraps a raw value in a fresh Signal", () => {
 	const g = getter(5);
@@ -24,6 +24,75 @@ test("readonlys exposes live reads without a writable handle", () => {
 	expect(out.count.peek()).toBe(1);
 	s.set(2);
 	expect(out.count.peek()).toBe(2);
+});
+
+test("getter reuses a Computed instead of wrapping it as a constant", async () => {
+	const source = new Signal(1);
+	const computed = new Computed((effect) => effect.get(source) * 2);
+
+	const input = getter(computed);
+	expect(input).toBe(computed);
+
+	await Promise.resolve();
+	expect(input.peek()).toBe(2);
+
+	source.set(5);
+	await computed.changed();
+	expect(input.peek()).toBe(10);
+
+	computed.close();
+});
+
+test("getter reuses a Once instead of wrapping it as a constant", async () => {
+	const once = new Once<string>();
+
+	const input = getter(once);
+	expect(input).toBe(once);
+	expect(input.peek()).toBeUndefined();
+
+	const settled = once.changed();
+	once.set("settled");
+
+	expect(await settled).toBe("settled");
+	expect(input.peek()).toBe("settled");
+});
+
+test("a Computed wired into an in stays live under an effect", async () => {
+	const source = new Signal(1);
+	const computed = new Computed((effect) => effect.get(source) * 2);
+	const input = getter(computed);
+
+	const seen: (number | undefined)[] = [];
+	const effect = new Effect((e) => {
+		seen.push(e.get(input));
+	});
+
+	await Promise.resolve();
+	source.set(4);
+	await computed.changed();
+	await Promise.resolve();
+
+	expect(seen).toContain(8);
+
+	effect.close();
+	computed.close();
+});
+
+test("getter throws on a foreign readable instead of freezing it", () => {
+	// Quacks like a Getter but carries no brand: wrapping it would silently never update.
+	const foreign: Getter<number> = {
+		peek: () => 1,
+		changed: (() => {}) as Getter<number>["changed"],
+		subscribe: () => () => {},
+	};
+
+	expect(() => getter(foreign)).toThrow();
+});
+
+test("getter still wraps plain objects that are not readables", () => {
+	const value = { peek: 1 };
+	const g = getter(value);
+	expect(g.peek()).toBe(value);
 });
 
 test("an out Getter feeds another component's in end to end", () => {


### PR DESCRIPTION
Fixes #2312.

## Summary

- **`Setter.set` advertised a transform it never ran.** The interface declared `set(value: T | ((prev: T) => T))` while `Signal.set(value, notify?)` never inspected the argument, so `set(prev => ...)` through any `Setter<T>` handle stored the function *as the value*. Root cause is the interface, not the implementation: `Signal<T>` can hold a function, so a functional overload is ambiguous by construction (a `Signal<() => void>` could never store its own value). Narrowed to `set(value: T)`; `update()` already covers transforms, and `signals/solid.ts` already implements Solid's functional setter contract itself.
- **The readable brand was only on `Signal`.** `getter()` decides readable-vs-raw-value on `Symbol.for("@moq/signals")`, which `Computed` and `Once` never carried, so passing either into a component `Inputs` prop type-checked and then got wrapped as a constant: the component saw the object and never updated. Added `GETTER_BRAND` (`Symbol.for("@moq/signals.getter")`) to `Signal`/`Computed`/`Once` and check it in `getter()`, leaving `SIGNAL_BRAND` to mean "has a write side" for `Signal.from`. `getter()` still accepts `SIGNAL_BRAND` alone so a `Signal` from an older package version keeps passing through.
- **Foreign readables now throw instead of freezing.** An object with `peek`/`subscribe`/`changed` that carries neither brand can't be kept live, so `getter()` throws rather than silently wrapping it as a constant.
- **Swept the smaller items:** removed `Signal.get()` (a duplicate of `peek()`, which is the `Getter` interface name, so `get` no longer means opposite things on a signal vs an effect) and `Signal.next()` (an undocumented alias of `changed()`); migrated the three call sites. Converted the `//` comments on the #2242 in/out surface (`SignalMap`, `Readonlys`, `readonlys`, `GetterInit`, `getter`, `Inputs`, `GetterType`) to `/** */` so they render on JSR.

## Public API changes

Breaking, in `@moq/signals` (hence `dev`):

- `Setter.set(value: T | ((prev: T) => T))` -> `Setter.set(value: T)`. Type-only: the functional form never worked at runtime.
- `Signal.get()` removed; use `peek()`.
- `Signal.next()` removed; use `changed()`.
- `getter()` throws on an unbranded readable that was previously wrapped (silently, and wrongly) as a constant.

Additive: `Computed` and `Once` now carry the getter brand, so `getter()` passes them through instead of wrapping them.

No `rs/` counterpart to sync: `@moq/signals` is browser-only with no crate mirror, and no Cross-Package Sync row applies. `js/net` changes here are only the `next()` -> `changed()` call-site migration.

## Test plan

- `just js check` clean across every package (this caught the three `Signal.next()` callers in `js/net`: `lite/subscriber.ts` x2 and `track.test.ts`).
- `bun test` in `js/signals`: 35 pass, 0 fail.
- New tests in `io.test.ts` cover `getter()` passthrough of `Computed`/`Once`, a `Computed` staying live through `getter()` under an `Effect`, the throw on a foreign readable, and that a plain object with a `peek` *field* is still wrapped as a value.
- New test in `index.test.ts` pins that `set` stores a function as the value while `update` transforms.
- Verified the tests encode the root cause: removing the `GETTER_BRAND` fields from `Computed`/`Once` fails 3 of the new tests, and they pass with the brand restored.

(Written by Claude Opus 4.8)