### PR TITLE
fix(net)!: align js/net and the moq-lite draft on the exclusive SUBSCRIBE_END

### DIFF
--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -958,7 +958,7 @@ A value of 0 means the track ended before producing any groups.
 The subscriber MUST NOT wait for any group at or after this sequence.
 
 This field is encoded as a plain absolute sequence and is used as-is; it is **not** the `absolute + 1` form used by `Group Start`/`Group End` in SUBSCRIBE, which decode by subtracting 1.
-The two are easily confused, because a track whose last delivered group is `N` sends `N + 1` here, the same number SUBSCRIBE would carry for an inclusive bound of `N`.
+The two are easily confused, because a track whose highest delivered group is `N` sends `N + 1` here, the same number SUBSCRIBE would carry for an inclusive bound of `N`.
 They differ in why: SUBSCRIBE offsets by 1 only so that 0 can mean "absent", whereas this field has no absent case and 0 already means "no groups at all".
 
 SUBSCRIBE_END bounds the range but does not by itself end the stream: the publisher MAY still send SUBSCRIBE_DROP for groups below this sequence that it cannot deliver, and FINs the stream only once every group below this sequence has been accounted for.

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -939,7 +939,7 @@ If it is strictly greater, the groups in between are unavailable and will not be
 A subscriber that requested the latest group (`Group Start` = 0) learns the resolved sequence here.
 
 ## SUBSCRIBE_END {#subscribe-end}
-A SUBSCRIBE_END message is sent by the publisher to signal that no group after a given sequence will be produced.
+A SUBSCRIBE_END message is sent by the publisher to signal that no group at or after a given sequence will be produced.
 
 ~~~
 SUBSCRIBE_END Message {
@@ -953,10 +953,15 @@ SUBSCRIBE_END Message {
 Set to 0x1 to indicate a SUBSCRIBE_END message.
 
 **Group**:
-The absolute sequence number of the last group that may be delivered (inclusive).
-This is a plain absolute sequence, **not** the `absolute + 1` form used by `Group Start`/`Group End` in SUBSCRIBE.
-The subscriber MUST NOT wait for any group after this sequence.
-SUBSCRIBE_END bounds the range but does not by itself end the stream: the publisher MAY still send SUBSCRIBE_DROP for groups at or below this sequence that it cannot deliver, and FINs the stream only once every group up to this sequence has been accounted for.
+The exclusive end of the range: the absolute sequence number of the first group that will never be delivered.
+A value of 0 means the track ended before producing any groups.
+The subscriber MUST NOT wait for any group at or after this sequence.
+
+This field is encoded as a plain absolute sequence and is used as-is; it is **not** the `absolute + 1` form used by `Group Start`/`Group End` in SUBSCRIBE, which decode by subtracting 1.
+The two are easily confused, because a track whose last delivered group is `N` sends `N + 1` here, the same number SUBSCRIBE would carry for an inclusive bound of `N`.
+They differ in why: SUBSCRIBE offsets by 1 only so that 0 can mean "absent", whereas this field has no absent case and 0 already means "no groups at all".
+
+SUBSCRIBE_END bounds the range but does not by itself end the stream: the publisher MAY still send SUBSCRIBE_DROP for groups below this sequence that it cannot deliver, and FINs the stream only once every group below this sequence has been accounted for.
 
 ## SUBSCRIBE_DROP
 A SUBSCRIBE_DROP message is sent by the publisher on the Subscribe Stream when groups cannot be served.
@@ -1107,6 +1112,7 @@ The `Message Length` describes the payload size on the wire.
 # Appendix A: Changelog
 
 ## moq-lite-06
+- Corrected SUBSCRIBE_END `Group` to an exclusive bound: the first sequence that will never be delivered, with 0 meaning no groups were produced. It was previously specified as the inclusive last group, which could not distinguish an empty track from one whose only group was 0.
 - Split ANNOUNCE_BROADCAST into three typed messages: ANNOUNCE_START (0x0), ANNOUNCE_END (0x1), and ANNOUNCE_RESTART (0x2), each prefixed with a Type discriminator like the subscribe stream's responses.
 - Added implicit Announce IDs: each ANNOUNCE_START assigns the next per-stream ordinal.
 - ANNOUNCE_END and ANNOUNCE_RESTART reference the Announce ID instead of repeating the broadcast path.

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+import { Producer as BroadcastProducer } from "../broadcast.ts";
+import { createMockTransportPair } from "../mock.ts";
+import * as Path from "../path.ts";
+import { Stream } from "../stream.ts";
+import { randomOrigin } from "./origin.ts";
+import { Publisher } from "./publisher.ts";
+import { decodeSubscribeResponse, Subscribe } from "./subscribe.ts";
+import { ALPN_05, Version } from "./version.ts";
+
+// Serves a track of `groups` single-frame groups (sequences 0..groups-1), then finishes
+// it and returns the SUBSCRIBE_END boundary the publisher put on the wire.
+async function subscribeEnd(groups: number): Promise<number> {
+	const pair = createMockTransportPair(ALPN_05);
+	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomOrigin());
+
+	const broadcast = new BroadcastProducer();
+	const track = broadcast.createTrack("video");
+	publisher.publish(Path.from("test"), broadcast);
+
+	const client = await Stream.open(pair.client);
+	const server = await Stream.accept(pair.server);
+	if (!server) throw new Error("publisher never accepted the subscribe stream");
+
+	const msg = new Subscribe({ id: 0n, broadcast: Path.from("test"), track: "video", priority: 0 });
+	void publisher.runSubscribe(msg, server);
+
+	// Finish the track only once it's being served, so the publisher observes a live
+	// track ending rather than resolving a subscribe against an already-closed one.
+	for (let i = 0; i < groups; i++) {
+		track.writeString("hello");
+	}
+	track.close();
+
+	try {
+		for (;;) {
+			const resp = await decodeSubscribeResponse(client.reader, Version.DRAFT_05);
+			if ("end" in resp) return resp.end.group;
+		}
+	} finally {
+		broadcast.close();
+		client.close();
+	}
+}
+
+// A Rust subscriber feeds this value straight into `track::Producer::finish_at`, which is
+// exclusive, so an inclusive bound here silently truncates the final group across languages.
+test("lite draft-05: subscribe end is the exclusive boundary", async () => {
+	expect(await subscribeEnd(3)).toBe(3);
+});
+
+// 0 is the only encoding for "no groups at all"; an inclusive bound cannot express it
+// without colliding with a track whose sole group was sequence 0.
+test("lite draft-05: subscribe end is 0 when no groups were produced", async () => {
+	expect(await subscribeEnd(0)).toBe(0);
+});

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { Producer as BroadcastProducer } from "../broadcast.ts";
+import { Producer as GroupProducer } from "../group.ts";
 import { createMockTransportPair } from "../mock.ts";
 import * as Path from "../path.ts";
 import { Stream } from "../stream.ts";
@@ -8,9 +9,9 @@ import { Publisher } from "./publisher.ts";
 import { decodeSubscribeResponse, Subscribe } from "./subscribe.ts";
 import { ALPN_05, Version } from "./version.ts";
 
-// Serves a track of `groups` single-frame groups (sequences 0..groups-1), then finishes
-// it and returns the SUBSCRIBE_END boundary the publisher put on the wire.
-async function subscribeEnd(groups: number): Promise<number> {
+// Delivers `sequences` in the given order, finishes the track, and returns the
+// SUBSCRIBE_END boundary the publisher put on the wire.
+async function subscribeEnd(sequences: number[]): Promise<number> {
 	const pair = createMockTransportPair(ALPN_05);
 	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomOrigin());
 
@@ -27,8 +28,15 @@ async function subscribeEnd(groups: number): Promise<number> {
 
 	// Finish the track only once it's being served, so the publisher observes a live
 	// track ending rather than resolving a subscribe against an already-closed one.
-	for (let i = 0; i < groups; i++) {
-		track.writeString("hello");
+	for (const sequence of sequences) {
+		const group = new GroupProducer(sequence);
+		group.writeString("hello");
+		group.close();
+		track.writeGroup(group);
+
+		// Let the publisher drain this group before the next, so arrival order is the
+		// order given rather than whatever the cache hands over in one batch.
+		await new Promise((resolve) => setTimeout(resolve, 5));
 	}
 	track.close();
 
@@ -46,11 +54,17 @@ async function subscribeEnd(groups: number): Promise<number> {
 // A Rust subscriber feeds this value straight into `track::Producer::finish_at`, which is
 // exclusive, so an inclusive bound here silently truncates the final group across languages.
 test("lite draft-05: subscribe end is the exclusive boundary", async () => {
-	expect(await subscribeEnd(3)).toBe(3);
+	expect(await subscribeEnd([0, 1, 2])).toBe(3);
+});
+
+// recvGroup is arrival-ordered, so the boundary has to clear the max sequence delivered,
+// not the last one seen. Otherwise the boundary lands on a group already on the wire.
+test("lite draft-05: subscribe end clears the max sequence when groups arrive out of order", async () => {
+	expect(await subscribeEnd([0, 2, 1])).toBe(3);
 });
 
 // 0 is the only encoding for "no groups at all"; an inclusive bound cannot express it
 // without colliding with a track whose sole group was sequence 0.
 test("lite draft-05: subscribe end is 0 when no groups were produced", async () => {
-	expect(await subscribeEnd(0)).toBe(0);
+	expect(await subscribeEnd([])).toBe(0);
 });

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -366,7 +366,11 @@ export class Publisher {
 		// first group is known, SUBSCRIBE_END when the track finishes.
 		const emitRange = supportsTrackStream(this.version);
 		let startSent = false;
-		let lastSequence: number | undefined;
+
+		// The exclusive end of the delivered range. recvGroup is arrival-ordered rather than
+		// sequence-ordered, so this tracks the max and not the last group seen. 0 is already
+		// the encoding for a track that produced no groups.
+		let end = 0;
 
 		try {
 			for (;;) {
@@ -381,14 +385,12 @@ export class Publisher {
 					startSent = true;
 					await encodeSubscribeResponse(stream, { start: new SubscribeStart(group.sequence) }, this.version);
 				}
-				lastSequence = group.sequence;
+				end = Math.max(end, group.sequence + 1);
 
 				void this.#runGroup(sub, group, timescale);
 			}
 
 			if (emitRange) {
-				// The boundary is exclusive, so a track that produced no groups sends 0.
-				const end = lastSequence === undefined ? 0 : lastSequence + 1;
 				await encodeSubscribeResponse(stream, { end: new SubscribeEnd(end) }, this.version);
 			}
 

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -366,7 +366,7 @@ export class Publisher {
 		// first group is known, SUBSCRIBE_END when the track finishes.
 		const emitRange = supportsTrackStream(this.version);
 		let startSent = false;
-		let lastSequence = 0;
+		let lastSequence: number | undefined;
 
 		try {
 			for (;;) {
@@ -387,7 +387,9 @@ export class Publisher {
 			}
 
 			if (emitRange) {
-				await encodeSubscribeResponse(stream, { end: new SubscribeEnd(lastSequence) }, this.version);
+				// The boundary is exclusive, so a track that produced no groups sends 0.
+				const end = lastSequence === undefined ? 0 : lastSequence + 1;
+				await encodeSubscribeResponse(stream, { end: new SubscribeEnd(end) }, this.version);
 			}
 
 			console.debug(`publish close: broadcast=${broadcast} track=${track.name}`);

--- a/js/net/src/lite/subscribe.ts
+++ b/js/net/src/lite/subscribe.ts
@@ -281,10 +281,11 @@ export class SubscribeStart {
 }
 
 /**
- * Signals that no group after `group` (inclusive upper bound) will be produced on
- * a Draft-05+ subscription.
+ * Signals that no group at or after `group` (exclusive upper bound) will be produced
+ * on a Draft-05+ subscription. `0` means the track ended before producing any groups.
  */
 export class SubscribeEnd {
+	/** The exclusive final group sequence: the first sequence that will never be produced. */
 	group: number;
 
 	constructor(group: number) {

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -970,7 +970,14 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 					if let lite::SubscribeResponse::End(end) = &msg
 						&& let Some(Track::Active(producer)) = track.as_mut()
 					{
-						let _ = producer.finish_at(end.group);
+						// finish_at rejects a boundary at or below the live edge, which is what a
+						// peer sending an inclusive bound looks like once the final group has
+						// already arrived. Don't abort: the stream FIN still finishes the track,
+						// so this only costs the early boundary. Warn anyway, since it's our only
+						// signal that a peer disagrees about the encoding.
+						if let Err(err) = producer.finish_at(end.group) {
+							tracing::warn!(track = %self.name, group = end.group, %err, "invalid subscribe end");
+						}
 					} else {
 						tracing::debug!(track = %self.name, ?msg, "subscribe response");
 					}


### PR DESCRIPTION
Fixes #2309.

## Summary

- #2219 made the track end boundary exclusive in Rust, but js/net and the draft were not updated, so the three disagreed on the wire. This aligns js/net and `draft-lcurley-moq-lite` on the exclusive encoding.
- **Root cause**: the js publisher sent the last delivered sequence (inclusive), while a Rust subscriber feeds the received value straight into `track::Producer::finish_at`, which is exclusive. The failure is racy, which is why it stayed hidden:
  - Final group **not yet arrived**: `finish_at(N)` is accepted, group `N` then arrives and `create_group` rejects it as at/above the boundary. The final group is silently lost.
  - Final group **already arrived**: `finish_at(N)` returns `ProtocolViolation` because the bound is at/below the live edge, and the subscriber swallowed the error with `let _ =`. Benign (the stream FIN still finishes the track) but it hid the bug.
- **Why exclusive rather than reverting Rust to inclusive**:
  - It is the only encoding that distinguishes an empty track from one whose sole group was sequence 0. js/net's old `lastSequence = 0` initializer hit exactly this ambiguity.
  - It matches `final_sequence` and Rust range idiom.
  - It is close to risk-free: Rust<->Rust is already exclusive, and JS<->JS is unaffected because the js subscriber discards SUBSCRIBE_END entirely (`#drainResponses`). Only the already-broken cross-language pair changes behavior. There is no working interop being broken here, and the finalized `moq-lite-05` ALPN exists only on `dev` (`main` still has `moq-lite-05-wip`).

Reviewing the first commit surfaced a **second truncation bug in the same code path**, fixed in the follow-up commit. `recvGroup` is arrival-ordered rather than sequence-ordered (and `writeGroup` takes an arbitrary sequence), so the boundary was computed from the *last arrived* group instead of the *highest*. Groups arriving `0, 2, 1` produced a boundary of 2, landing on a group already delivered. The publisher now tracks the exclusive boundary as a running max seeded at 0, which also removes the `undefined` sentinel since 0 is already the "no groups" encoding. Rust never had this bug because its publisher takes the boundary from the model's declared `final_sequence` rather than inferring it from delivery.

The Rust subscriber no longer swallows the `finish_at` error, but still does not abort on it: when that error fires, every group up to the boundary has already been received, and the FIN path finishes the track correctly. Aborting would discard valid data and turn a complete track into a failed one, so it warns instead.

Note the remaining asymmetry, left alone deliberately: the silent-truncation case (bound accepted, group later rejected with `NotFound`) only reaches `tracing::debug!` in `run_uni_stream`. Raising that would mean distinguishing an above-boundary rejection from the other legitimate `NotFound` causes inside the model layer, which is out of scope for a wire fix.

## Public API changes

None. `SubscribeEnd.group` keeps its type and wire shape; only its meaning and docs change. The rs change is a log line.

## Test plan

- New `js/net/src/lite/publisher.test.ts` drives one subscribe stream against a `Publisher` over the mock transport and asserts the SUBSCRIBE_END on the wire. Two of the three cases **fail against `dev`**: the off-by-one (expected 3, received 2) and out-of-order arrival (expected 3, received 2). The empty-track case passes either way and is kept only as a cheap invariant guard on the `0` encoding.
- `bun test js/net/src`: 254 pass.
- `cargo test -p moq-net`: 482 pass. clippy + fmt clean.
- `just drafts check`: exit 0.

## Cross-Package Sync

`rs/moq-net` wire -> `js/net` and `drafts/draft-lcurley-moq-lite.md` both updated (changelog bullet under `moq-lite-06`, since the source is `-latest` and 05 is already submitted). `doc/concept` has no SUBSCRIBE_END references. The ietf path does not use `finish_at`; `moq-ffi`/`libmoq` expose it producer-side and are already exclusive.

Not done: the cross-language smoke case from the issue. The current smoke matrix only asserts data flows on a continuous broadcast, so catching this needs a finite-track case plumbed through `smoke.sh` and every client. Both ends of the contract are now pinned by fast tests, so I would rather that be its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
