### PR TITLE
refactor(moq-net)!: fix Request::accept's lying doc + panic path and Session::closed's fake Result

### DIFF
--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -322,7 +322,7 @@ impl MoqSession {
 	pub async fn closed(&self) -> Result<(), MoqError> {
 		// We have a task to run all of the closed calls juuuuust so they use the same tokio runtime.
 		self.closed
-			.run(|session| async move { session.closed().await.map_err(Into::into) })
+			.run(|session| async move { Err(session.closed().await.into()) })
 			.await
 	}
 

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -32,7 +32,7 @@ async fn run_session(origin: moq_net::origin::Producer) -> anyhow::Result<()> {
 	let cs = client.with_publisher(&origin).connect(url).await?;
 
 	// Wait until the session is closed.
-	cs.closed().await.map_err(Into::into)
+	Err(cs.closed().await.into())
 }
 
 // Produce a broadcast and publish it to the origin.

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -341,12 +341,14 @@ async fn run_session(
 	let closed = session.closed();
 	tokio::pin!(closed);
 
-	kio::wait(|waiter| {
+	let err = kio::wait(|waiter| {
 		poll_forward(&mut send, send_bw, waiter);
 		poll_forward(&mut recv, recv_bw, waiter);
 		waiter.poll_future(closed.as_mut())
 	})
-	.await
+	.await;
+
+	Err(err)
 }
 
 /// Mirror `bw`'s live estimate into `out` for as long as it changes, dropping the source handle once

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -643,8 +643,7 @@ impl Server {
 /// Complete one accepted [`Request`] and wait for the session to close.
 async fn serve_session(request: Request) -> crate::Result<()> {
 	let session = request.ok().await?;
-	session.closed().await?;
-	Ok(())
+	Err(session.closed().await.into())
 }
 
 /// The version set offered on stream (`tcp://`/`unix://`) listeners.

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1928,12 +1928,18 @@ impl Request {
 
 	/// Serve the request with the given track, resolving every waiting subscriber.
 	///
-	/// The track's name must match [`Self::name`]. Returns [`Error::NotFound`] on
-	/// mismatch, or the broadcast's abort error if it closed while pending.
+	/// The name is taken from [`Self::name`]; `info` supplies the remaining knobs
+	/// (`None` for the defaults). If the track was already aborted, the returned
+	/// [`Producer`] is inert: writes fail with the abort error, as if it had been
+	/// aborted immediately after accepting.
 	pub fn accept(self, info: impl Into<Option<Info>>) -> Producer {
 		let mut info = info.into().unwrap_or_default();
 		info.broadcast = self.broadcast.clone();
-		self.state.write().ok().unwrap().info = Some(info);
+		// A closed state means the track was aborted under us. Mirror `reject` and
+		// tolerate it: the Producer we hand back simply can't write.
+		if let Ok(mut state) = self.state.write() {
+			state.info = Some(info);
+		}
 		Producer {
 			name: self.name,
 			broadcast: self.broadcast,

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -106,10 +106,9 @@ impl Session {
 		self.shared.close(err.to_code(), err.to_string().as_ref());
 	}
 
-	/// Block until the transport session is closed.
-	pub async fn closed(&self) -> Result<(), Error> {
-		let err = self.shared.inner.closed().await;
-		Err(Error::Transport(err))
+	/// Block until the transport session is closed, returning the reason.
+	pub async fn closed(&self) -> Error {
+		Error::Transport(self.shared.inner.closed().await)
 	}
 }
 

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -879,7 +879,7 @@ impl Cluster {
 			.await
 			.context("failed to connect to cluster peer")?;
 
-		cs.closed().await.map_err(Into::into)
+		Err(cs.closed().await.into())
 	}
 }
 

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -127,12 +127,12 @@ impl Connection {
 		// connect time, so hold the session open no longer than the credential is
 		// valid. Without an expiry, just wait for the session to close.
 		let Some(expires) = token.expires else {
-			return Ok(session.closed().await?);
+			return Err(session.closed().await.into());
 		};
 
 		let remaining = expires.duration_since(std::time::SystemTime::now()).unwrap_or_default();
 		match tokio::time::timeout(remaining, session.closed()).await {
-			Ok(res) => Ok(res?),
+			Ok(err) => Err(err.into()),
 			Err(_) => {
 				tracing::info!("credential expired, closing session");
 				session.abort(moq_net::Error::Unauthorized);

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -795,13 +795,9 @@ async fn subscribe_only_public_rejects_publisher_role() {
 	// scoped subscriber, by contrast, would stay open indefinitely.
 	match tokio::time::timeout(TIMEOUT, client().with_publisher(pub_origin.consume()).connect(url)).await {
 		Ok(Ok(session)) => {
-			let closed = tokio::time::timeout(TIMEOUT, session.closed())
+			tokio::time::timeout(TIMEOUT, session.closed())
 				.await
-				.expect("publisher session should be closed by the relay, not left open");
-			assert!(
-				closed.is_err(),
-				"relay should close a publisher whose token lacks publish scope"
-			);
+				.expect("relay should close a publisher whose token lacks publish scope, not leave it open");
 		}
 		Ok(Err(_)) => {} // rejected synchronously at connect; also acceptable.
 		Err(_) => panic!("publisher connect neither resolved nor was rejected within the timeout"),
@@ -880,13 +876,9 @@ async fn publish_only_public_rejects_subscriber_role() {
 	// outright, or the session the relay hands back closes shortly after.
 	match tokio::time::timeout(TIMEOUT, client().with_subscriber(sub_origin).connect(url)).await {
 		Ok(Ok(session)) => {
-			let closed = tokio::time::timeout(TIMEOUT, session.closed())
+			tokio::time::timeout(TIMEOUT, session.closed())
 				.await
-				.expect("subscriber session should be closed by the relay, not left open");
-			assert!(
-				closed.is_err(),
-				"relay should close a subscriber whose token lacks subscribe scope"
-			);
+				.expect("relay should close a subscriber whose token lacks subscribe scope, not leave it open");
 		}
 		Ok(Err(_)) => {} // rejected synchronously at connect; also acceptable.
 		Err(_) => panic!("subscriber connect neither resolved nor was rejected within the timeout"),


### PR DESCRIPTION
First of ~4 stacked PRs for #2314 (model API cleanup before the semver bump). This one covers the **Contract lies and panic paths** section.

## Summary

- **`track::Request::accept`** (`rs/moq-net/src/model/track.rs`): the doc promised `Error::NotFound` on a track-name mismatch, which the infallible `-> Producer` signature cannot return, and which isn't representable anyway since the name is taken from `Self::name`, not from the caller. The body also wrote via `self.state.write().ok().unwrap()`. Sibling `reject` already tolerates a closed state with `if let Ok`; `accept` now mirrors it, and the doc describes the real contract.

  Worth flagging for the reviewer: the `unwrap()` is **not reachable today**. The only `close()` on a `TrackState` is `Producer::abort`, and a `Producer` can't exist before `accept` is called. So this is a latent landmine (anything that ever closes the state pre-accept turns it into a panic), not a live bug, which is why there's no regression test. The doc was the actual defect.

- **`Session::closed`** (`rs/moq-net/src/session.rs`): was `-> Result<(), Error>` but unconditionally ended in `Err`, so every call site carried a dead `Ok` arm. All six siblings (`track::Producer::closed`, `track::Consumer::closed`, `broadcast::Producer::closed`, `broadcast::Consumer::closed`, `group::Consumer::closed`) return `Error` directly. Aligned, and the unreachable arms deleted at every caller.

## Public API changes

**Breaking** (hence `dev`):
- `moq_net::Session::closed`: `async fn closed(&self) -> Result<(), Error>` -> `async fn closed(&self) -> Error`.

**Non-breaking:**
- `moq_net::track::Request::accept`: doc + closed-state handling only. Signature unchanged.

Call sites updated in `moq-native` (`server.rs`, `reconnect.rs`, `examples/chat.rs`), `moq-relay` (`connection.rs`, `cluster.rs`, `tests/smoke.rs`), and `moq-ffi` (`session.rs`). `moq_ffi::MoqSession::closed` deliberately keeps its `Result<(), MoqError>` signature and identical behavior, so **`libmoq`, the C ABI, and the py/swift/kt/go wrappers are untouched** and need no sync.

## Cross-Package Sync

- `rs/moq-net` API: no wire change, so no draft update. `js/net` has no mirrored `Session.closed()` surface (its connection model is signals-based), so nothing to mirror.
- `rs/moq-ffi`: surface unchanged, so no binding/doc sync needed.

## Test plan

- `nix develop --command just rs fix` / `just rs check`: clean.
- `cargo check --workspace --all-targets`: clean.
- `cargo test -p moq-net`: 487 passed, 0 failed.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moq-net -p moq-native -p moq-relay`: exit 0 (CI gates this and the `accept` doc edit touches an intra-doc link).
- The two `smoke.rs` assertions that checked `closed.is_err()` became vacuous once `closed()` returns `Error`; the surviving `timeout(...).expect(...)` is what actually asserted the relay closes the session, and its message now carries the full claim.

(Written by Claude Opus 4.8)