### PR TITLE
docs: align media docs and priorities

### DIFF
--- a/doc/concept/layer/hang.md
+++ b/doc/concept/layer/hang.md
@@ -28,7 +28,7 @@ Here is Big Buck Bunny's `catalog.json` as of 2026-02-02:
         "description": "0164001fffe100196764001fac2484014016ec0440000003004000000c23c60c9201000568ee32c8b0",
         "codedWidth": 1280,
         "codedHeight": 720,
-        "container": "legacy"
+        "container": { "kind": "legacy" }
       }
     }
   },
@@ -39,7 +39,7 @@ Here is Big Buck Bunny's `catalog.json` as of 2026-02-02:
         "sampleRate": 44100,
         "numberOfChannels": 2,
         "bitrate": 283637,
-        "container": "legacy"
+        "container": { "kind": "legacy" }
       }
     }
   }

--- a/doc/concept/layer/moq-lite.md
+++ b/doc/concept/layer/moq-lite.md
@@ -110,10 +110,10 @@ Each Subscription consists of a few properties:
 
 - **Track Priority**: A value between 0 and 255. Tracks with higher priority will be delivered first.
 - **Group Order**: The order in which groups are delivered. Defaults to descending; higher IDs are delivered first.
-- **Group Timeout**: The maximum duration to keep old groups in cache/transit. Defaults to 30 seconds.
+- **Subscriber Max Latency**: The maximum age of a non-latest group before it is skipped. Defaults to zero, so stale groups are skipped immediately.
 
-The publisher also keeps old groups around for a best-effort **cache** window so relays and late subscribers can still fetch them.
-This is a local hint rather than a guarantee carried on the wire, and a subscriber's Group Timeout is bounded by it: a group can't be waited for longer than it's actually kept around.
+The publisher also keeps old groups around for a best-effort **Publisher Max Latency** cache window so relays and late subscribers can still fetch them. This defaults to 5 seconds.
+The subscriber's maximum latency is bounded by this window: a group can't be waited for longer than it's actually kept around.
 
 By utilizing these properties, you can choose how your application behaves during congestion.
 For example, consider a conference room with Alice and Bob:

--- a/doc/lib/rs/crate/hang.md
+++ b/doc/lib/rs/crate/hang.md
@@ -112,7 +112,7 @@ Groups are aligned with natural boundaries:
 - Usually 1 second of audio
 - Independent decoding
 
-See the [video example](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/video.rs) for grouping with `OrderedProducer`.
+See the [video example](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/video.rs) for grouping with `moq_mux::container::Producer`.
 
 ## Prioritization
 
@@ -126,7 +126,7 @@ This is handled automatically based on frame metadata.
 
 ## CLI Tool
 
-The `moq-cli` package provides a command-line tool (binary name: `moq-cli`):
+The `moq-cli` package provides a command-line tool (binary name: `moq`):
 
 ```bash
 # Install

--- a/doc/lib/rs/crate/moq-mux.md
+++ b/doc/lib/rs/crate/moq-mux.md
@@ -73,8 +73,7 @@ Full API documentation: [docs.rs/moq-mux](https://docs.rs/moq-mux)
 
 Key types:
 
-- `Fmp4` - fMP4/CMAF importer
-- `Fmp4Config` - Configuration for fMP4 import
+- `container::fmp4::Import` - fMP4/CMAF importer
 - `Decoder` - Codec-specific decoders (AAC, Opus, AVC, HEVC)
 
 ## CLI Tool

--- a/rs/hang/src/catalog/mod.rs
+++ b/rs/hang/src/catalog/mod.rs
@@ -6,12 +6,14 @@
 
 mod audio;
 mod container;
+mod priority;
 mod root;
 mod timeline;
 mod video;
 
 pub use audio::*;
 pub use container::*;
+pub use priority::*;
 pub use root::*;
 pub use timeline::*;
 pub use video::*;

--- a/rs/hang/src/catalog/priority.rs
+++ b/rs/hang/src/catalog/priority.rs
@@ -1,0 +1,32 @@
+//! Default delivery priorities for hang tracks.
+
+/// Delivery priorities for each hang track kind.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct Priorities {
+	/// Catalog track priority.
+	pub catalog: u8,
+	/// Audio track priority.
+	pub audio: u8,
+	/// Video track priority.
+	pub video: u8,
+}
+
+/// Default delivery priorities for hang tracks, with higher values sent first.
+pub const PRIORITY: Priorities = Priorities {
+	catalog: 100,
+	audio: 80,
+	video: 60,
+};
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn media_priorities_match_the_browser() {
+		assert_eq!(PRIORITY.catalog, 100);
+		assert_eq!(PRIORITY.audio, 80);
+		assert_eq!(PRIORITY.video, 60);
+	}
+}

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -1,6 +1,6 @@
 //! This module contains the structs and functions for the MoQ catalog format
 use crate::Result;
-use crate::catalog::{Audio, Video};
+use crate::catalog::{Audio, PRIORITY, Video};
 use serde::{Deserialize, Serialize};
 
 /// A catalog track, created by a broadcaster to describe the tracks available in a broadcast.
@@ -85,7 +85,7 @@ impl Catalog {
 	/// The subscription preferences used for the catalog track (high priority so
 	/// it preempts media tracks).
 	pub fn default_subscription() -> moq_net::track::Subscription {
-		moq_net::track::Subscription::default().with_priority(100)
+		moq_net::track::Subscription::default().with_priority(PRIORITY.catalog)
 	}
 }
 

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -342,7 +342,7 @@ impl Consume {
 			let res = async move {
 				let track = broadcast
 					.track(&name)?
-					.subscribe(moq_net::track::Subscription::default().with_priority(1))
+					.subscribe(moq_net::track::Subscription::default().with_priority(hang::catalog::PRIORITY.video))
 					.await?;
 				let track = moq_mux::container::Consumer::new(track, container).with_latency(latency);
 				Self::run_track(on_frame, track, channel.1).await
@@ -391,7 +391,7 @@ impl Consume {
 			let res = async move {
 				let track = broadcast
 					.track(&name)?
-					.subscribe(moq_net::track::Subscription::default().with_priority(2))
+					.subscribe(moq_net::track::Subscription::default().with_priority(hang::catalog::PRIORITY.audio))
 					.await?;
 				let track = moq_mux::container::Consumer::new(track, container).with_latency(latency);
 				Self::run_track(on_frame, track, channel.1).await

--- a/rs/moq-audio/src/consumer.rs
+++ b/rs/moq-audio/src/consumer.rs
@@ -53,7 +53,10 @@ impl AudioConsumer {
 		};
 
 		let name = name.into();
-		let track = broadcast.track(&name)?.subscribe(None).await?;
+		let track = broadcast
+			.track(&name)?
+			.subscribe(moq_net::track::Subscription::default().with_priority(hang::catalog::PRIORITY.audio))
+			.await?;
 		let mut track = moq_mux::container::Consumer::new(track, moq_mux::container::legacy::Wire);
 		if let Some(latency) = output.latency_max {
 			track = track.with_latency(latency);

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -64,7 +64,7 @@ mod test {
 	use super::*;
 
 	/// Mint a standalone track for tests via a throwaway broadcast, since tracks are
-	/// born from their broadcast (no public `TrackProducer::new`).
+	/// born from their broadcast (no public `track::Producer::new`).
 	fn track_producer(
 		name: impl Into<std::sync::Arc<str>>,
 		info: impl Into<Option<moq_net::track::Info>>,

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -653,7 +653,7 @@ mod tests {
 	use bytes::Bytes;
 
 	/// Mint a standalone track for tests via a throwaway broadcast, since tracks are
-	/// born from their broadcast (no public `TrackProducer::new`).
+	/// born from their broadcast (no public `track::Producer::new`).
 	fn track_producer(
 		name: impl Into<std::sync::Arc<str>>,
 		info: impl Into<Option<moq_net::track::Info>>,

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -264,7 +264,7 @@ mod tests {
 	use moq_net::Timestamp;
 
 	/// Mint a standalone track for tests via a throwaway broadcast, since tracks are
-	/// born from their broadcast (no public `TrackProducer::new`).
+	/// born from their broadcast (no public `track::Producer::new`).
 	fn track_producer(
 		name: impl Into<std::sync::Arc<str>>,
 		info: impl Into<Option<moq_net::track::Info>>,

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1851,6 +1851,7 @@ impl Subscriber {
 		self.control().subscription()
 	}
 
+	/// Replace this subscriber's delivery preferences.
 	///
 	/// The latency budget is clamped to the track's cache, like the initial subscribe.
 	/// Returns [`Error::Closed`] if the track already ended; the update is

--- a/rs/moq-video/src/decode/consumer.rs
+++ b/rs/moq-video/src/decode/consumer.rs
@@ -33,7 +33,10 @@ impl Consumer {
 		let decoder = Decoder::new(catalog, &config)?;
 
 		let name = name.into();
-		let track = broadcast.track(&name)?.subscribe(None).await?;
+		let track = broadcast
+			.track(&name)?
+			.subscribe(moq_net::track::Subscription::default().with_priority(hang::catalog::PRIORITY.video))
+			.await?;
 		let mut track = moq_mux::container::Consumer::new(track, moq_mux::container::legacy::Wire);
 		if let Some(latency) = config.latency_max {
 			track = track.with_latency(latency);

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -3,7 +3,7 @@
 //! Encoding is strictly on demand: the track and catalog entry are advertised
 //! immediately, but the camera stays closed (LED off, no CPU) until a subscriber
 //! appears. When the last viewer leaves, the camera is released again. This
-//! mirrors `moq-boy`, which pauses its emulator on `TrackProducer::used()` /
+//! mirrors `moq-boy`, which pauses its emulator on `track::Producer::used()` /
 //! `unused()`.
 
 use std::time::Instant;


### PR DESCRIPTION
## Summary

- fix stale media type names, catalog JSON, CLI naming, and latency defaults in documentation
- add shared Rust hang priorities matching the browser's catalog, audio, and video ordering
- use the shared priorities in libmoq and native audio and video consumers

The drift accumulated after the track API rename, tagged container schema, and latency model changed without the corresponding examples and hard-coded native priorities being updated.

Closes #2325

## Public API changes

- adds `hang::catalog::Priorities`
- adds `hang::catalog::PRIORITY` with catalog, audio, and video defaults

These additions are non-breaking. The issue only affects post-refactor `dev`, so the PR targets `dev`; the equivalent APIs do not exist on `main`.

## Test plan

- `nix develop --command env CARGO_TARGET_DIR=/private/tmp/moq-2325-156e-target just ci` passed through Kotlin; the local Swift step is blocked by a broken Xcode plug-in installation
- `cargo test -p hang` (27 passed)
- GitHub Actions supplies the clean macOS environment for the Swift gate

Cross-package sync: no wire format or catalog schema changed. Rust priority defaults now match the existing `@moq/hang` table.

(Written by GPT-5)
