### PR TITLE
refactor(js/net)!: close three js/net gaps vs rs/moq-net (frame payload naming, SETUP role, dead export)

### DIFF
--- a/js/clock/src/main.ts
+++ b/js/clock/src/main.ts
@@ -162,7 +162,7 @@ async function subscribe(config: Config) {
 			continue;
 		}
 
-		const base = new TextDecoder().decode(baseFrame.data);
+		const base = new TextDecoder().decode(baseFrame.payload);
 
 		// Read individual second frames
 		for (;;) {

--- a/js/hang/src/container/cmaf/format.ts
+++ b/js/hang/src/container/cmaf/format.ts
@@ -15,7 +15,7 @@ export class Format implements ContainerFormat {
 	/** Decode one CMAF fragment into its media frames. */
 	decode(frame: Uint8Array): Frame[] {
 		return decodeDataSegment(frame, this.#init).map((s) => ({
-			data: s.data,
+			payload: s.data,
 			timestamp: s.timestamp as Time.Micro,
 			keyframe: s.keyframe,
 			duration: s.duration as Time.Micro,

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -37,7 +37,7 @@ test("LegacyFormat decodes a valid frame", () => {
 
 	expect(result).toHaveLength(1);
 	expect(result[0].timestamp).toBe(timestamp);
-	expect(result[0].data).toEqual(payload);
+	expect(result[0].payload).toEqual(payload);
 	expect(result[0].keyframe).toBe(false);
 });
 
@@ -92,7 +92,7 @@ test("CmafFormat decodes a valid keyframe segment", () => {
 	const result = format.decode(segment);
 
 	expect(result).toHaveLength(1);
-	expect(result[0].data).toEqual(new Uint8Array([0xca, 0xfe]));
+	expect(result[0].payload).toEqual(new Uint8Array([0xca, 0xfe]));
 	expect(result[0].timestamp).toBe(0 as Time.Micro);
 	expect(result[0].keyframe).toBe(true);
 });
@@ -147,7 +147,7 @@ function encodeLegacy(timestamp: Time.Micro): Uint8Array {
 function writeGroupWithLegacyFrames(track: Track.Producer, sequence: number, timestamps: Time.Micro[]) {
 	const group = new Group.Producer(sequence);
 	for (const ts of timestamps) {
-		group.writeFrame({ data: encodeLegacy(ts), timestamp: Time.Timestamp.now() });
+		group.writeFrame({ payload: encodeLegacy(ts), timestamp: Time.Timestamp.now() });
 	}
 	group.close();
 	track.writeGroup(group);
@@ -203,9 +203,9 @@ test("Consumer index spans MoQ frames for keyframe detection", async () => {
 	const multiFormat: ContainerFormat = {
 		decode(_frame: Uint8Array): Frame[] {
 			return [
-				{ data: new Uint8Array([1]), timestamp: 0 as Time.Micro, keyframe: false },
-				{ data: new Uint8Array([2]), timestamp: 33_000 as Time.Micro, keyframe: false },
-				{ data: new Uint8Array([3]), timestamp: 66_000 as Time.Micro, keyframe: false },
+				{ payload: new Uint8Array([1]), timestamp: 0 as Time.Micro, keyframe: false },
+				{ payload: new Uint8Array([2]), timestamp: 33_000 as Time.Micro, keyframe: false },
+				{ payload: new Uint8Array([3]), timestamp: 66_000 as Time.Micro, keyframe: false },
 			];
 		},
 	};
@@ -214,8 +214,8 @@ test("Consumer index spans MoQ frames for keyframe detection", async () => {
 	const consumer = new Consumer(track.subscribe(), { format: multiFormat, latency: 500 as Time.Milli });
 
 	const group = new Group.Producer(0);
-	group.writeFrame({ data: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() }); // first MoQ frame → 3 samples
-	group.writeFrame({ data: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() }); // second MoQ frame → 3 samples
+	group.writeFrame({ payload: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() }); // first MoQ frame → 3 samples
+	group.writeFrame({ payload: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() }); // second MoQ frame → 3 samples
 	group.close();
 	track.writeGroup(group);
 	track.close();
@@ -234,7 +234,7 @@ test("Consumer keeps frames decoded before an error (truncated GoP)", async () =
 	const truncatingFormat: ContainerFormat = {
 		decode(frame: Uint8Array): Frame[] {
 			if (frame[0] === 0xff) throw new Error("truncated");
-			return [{ data: frame, timestamp: frame[0] as Time.Micro, keyframe: false }];
+			return [{ payload: frame, timestamp: frame[0] as Time.Micro, keyframe: false }];
 		},
 	};
 
@@ -243,15 +243,15 @@ test("Consumer keeps frames decoded before an error (truncated GoP)", async () =
 
 	// Group.Producer 0: 2 valid frames then a tail-truncating error.
 	const g0 = new Group.Producer(0);
-	g0.writeFrame({ data: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() });
-	g0.writeFrame({ data: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() });
-	g0.writeFrame({ data: new Uint8Array([0xff]), timestamp: Time.Timestamp.now() });
+	g0.writeFrame({ payload: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() });
+	g0.writeFrame({ payload: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() });
+	g0.writeFrame({ payload: new Uint8Array([0xff]), timestamp: Time.Timestamp.now() });
 	g0.close();
 	track.writeGroup(g0);
 
 	// Group.Producer 1 decodes cleanly.
 	const g1 = new Group.Producer(1);
-	g1.writeFrame({ data: new Uint8Array([0x04]), timestamp: Time.Timestamp.now() });
+	g1.writeFrame({ payload: new Uint8Array([0x04]), timestamp: Time.Timestamp.now() });
 	g1.close();
 	track.writeGroup(g1);
 
@@ -431,7 +431,7 @@ test("Consumer handles empty decode result without deadlock", async () => {
 		decode(_frame: Uint8Array): Frame[] {
 			callCount++;
 			if (callCount === 1) return []; // empty result
-			return [{ data: new Uint8Array([1]), timestamp: 33_000 as Time.Micro, keyframe: false }];
+			return [{ payload: new Uint8Array([1]), timestamp: 33_000 as Time.Micro, keyframe: false }];
 		},
 	};
 
@@ -439,8 +439,8 @@ test("Consumer handles empty decode result without deadlock", async () => {
 	const consumer = new Consumer(track.subscribe(), { format: emptyThenValid, latency: 500 as Time.Milli });
 
 	const group = new Group.Producer(0);
-	group.writeFrame({ data: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() }); // empty decode
-	group.writeFrame({ data: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() }); // valid decode
+	group.writeFrame({ payload: new Uint8Array([0x01]), timestamp: Time.Timestamp.now() }); // empty decode
+	group.writeFrame({ payload: new Uint8Array([0x02]), timestamp: Time.Timestamp.now() }); // valid decode
 	group.close();
 	track.writeGroup(group);
 	track.close();
@@ -466,7 +466,7 @@ test("Consumer with CmafFormat delivers correct timestamps", async () => {
 
 	const group = new Group.Producer(0);
 	group.writeFrame({
-		data: encodeDataSegment({
+		payload: encodeDataSegment({
 			data: new Uint8Array([0xca, 0xfe]),
 			timestamp: 0,
 			duration: 3000,
@@ -476,7 +476,7 @@ test("Consumer with CmafFormat delivers correct timestamps", async () => {
 		timestamp: Time.Timestamp.now(),
 	});
 	group.writeFrame({
-		data: encodeDataSegment({
+		payload: encodeDataSegment({
 			data: new Uint8Array([0xbe, 0xef]),
 			timestamp: 3000,
 			duration: 3000,
@@ -520,7 +520,7 @@ const durationFormat: ContainerFormat = {
 	decode(frame: Uint8Array): Frame[] {
 		return [
 			{
-				data: frame,
+				payload: frame,
 				timestamp: (frame[0] * 1000) as Time.Micro,
 				duration: 33_000 as Time.Micro,
 				keyframe: false,
@@ -536,11 +536,11 @@ test("Consumer duration-skips a stalled group once it is covered", async () => {
 
 	// Group.Producer 0: one frame at ts=0 lasting 33ms, never closed (stalled).
 	const g0 = new Group.Producer(0);
-	g0.writeFrame({ data: new Uint8Array([0]), timestamp: Time.Timestamp.now() });
+	g0.writeFrame({ payload: new Uint8Array([0]), timestamp: Time.Timestamp.now() });
 
 	// Group.Producer 1: closed, starts exactly where group 0's frame ends.
 	const g1 = new Group.Producer(1);
-	g1.writeFrame({ data: new Uint8Array([33]), timestamp: Time.Timestamp.now() });
+	g1.writeFrame({ payload: new Uint8Array([33]), timestamp: Time.Timestamp.now() });
 	g1.close();
 
 	track.writeGroup(g0);
@@ -559,7 +559,7 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 		decode(frame: Uint8Array): Frame[] {
 			return [
 				{
-					data: frame,
+					payload: frame,
 					timestamp: (frame[0] * 1000) as Time.Micro,
 					duration: 10_000 as Time.Micro,
 					keyframe: false,
@@ -574,10 +574,10 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 	// Group.Producer 0 stays open and later receives a second frame; nothing covers the gap,
 	// so that late frame must survive rather than being skipped.
 	const g0 = new Group.Producer(0);
-	g0.writeFrame({ data: new Uint8Array([0]), timestamp: Time.Timestamp.now() });
+	g0.writeFrame({ payload: new Uint8Array([0]), timestamp: Time.Timestamp.now() });
 
 	const g1 = new Group.Producer(1);
-	g1.writeFrame({ data: new Uint8Array([33]), timestamp: Time.Timestamp.now() });
+	g1.writeFrame({ payload: new Uint8Array([33]), timestamp: Time.Timestamp.now() });
 	g1.close();
 
 	track.writeGroup(g0);
@@ -585,7 +585,7 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 
 	// Let the consumer settle on group 0, then extend it before closing.
 	await new Promise((resolve) => setTimeout(resolve, 20));
-	g0.writeFrame({ data: new Uint8Array([20]), timestamp: Time.Timestamp.now() });
+	g0.writeFrame({ payload: new Uint8Array([20]), timestamp: Time.Timestamp.now() });
 	g0.close();
 	track.close();
 

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -162,11 +162,11 @@ export class Consumer {
 				const next = await group.consumer.readFrame();
 				if (!next) break;
 
-				const decoded = this.#format.decode(next.data);
+				const decoded = this.#format.decode(next.payload);
 
 				for (const sample of decoded) {
 					const frame: Frame = {
-						data: sample.data,
+						payload: sample.payload,
 						timestamp: sample.timestamp,
 						// Protocol invariant: groups always start at a keyframe.
 						// For index 0, we enforce this regardless of what the format reports.

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -18,7 +18,7 @@ export class Format implements ContainerFormat {
 		// empty chunk to a decoder -- a publisher emitting these must not break us.
 		if (data.byteLength === 0) return [];
 
-		return [{ data, timestamp: timestamp as Time.Micro, keyframe: false }];
+		return [{ payload: data, timestamp: timestamp as Time.Micro, keyframe: false }];
 	}
 }
 
@@ -78,7 +78,7 @@ export class Producer {
 		}
 
 		this.#group?.writeFrame({
-			data: encodeFrame(data, timestamp),
+			payload: encodeFrame(data, timestamp),
 			timestamp: Time.Timestamp.fromMicros(timestamp),
 		});
 	}

--- a/js/hang/src/container/types.ts
+++ b/js/hang/src/container/types.ts
@@ -3,7 +3,7 @@ import { Time } from "@moq/net";
 /** A decoded media frame: codec payload plus its presentation timestamp and keyframe flag. */
 export interface Frame {
 	/** The codec bitstream payload. */
-	data: Uint8Array;
+	payload: Uint8Array;
 	/** Presentation timestamp in microseconds. */
 	timestamp: Time.Micro;
 	/** Whether this frame is a keyframe (can be decoded standalone). */

--- a/js/json/src/snapshot/compression.test.ts
+++ b/js/json/src/snapshot/compression.test.ts
@@ -22,7 +22,7 @@ async function firstFrame(track: Track.Subscriber): Promise<Uint8Array> {
 	if (!group) throw new Error("expected a group");
 	const frame = await group.readFrame();
 	if (!frame) throw new Error("expected a frame");
-	return frame.data;
+	return frame.payload;
 }
 
 // Count the groups a (finished) track published, draining each so the reads terminate.
@@ -110,7 +110,7 @@ test("compressed deltas reuse the window", async () => {
 	if (!delta) throw new Error("expected a delta");
 
 	const rawDelta = enc.encode(JSON.stringify({ echo: phrase }));
-	expect(delta.data.length).toBeLessThan(rawDelta.length / 2);
+	expect(delta.payload.length).toBeLessThan(rawDelta.length / 2);
 });
 
 test("compression shrinks a repetitive frame", async () => {

--- a/js/json/src/snapshot/consumer.ts
+++ b/js/json/src/snapshot/consumer.ts
@@ -55,7 +55,7 @@ export class Consumer<T> {
 			let value: T | undefined;
 			let advanced = false;
 			for (let frame = this.#group.tryReadFrame(); frame !== undefined; frame = this.#group.tryReadFrame()) {
-				value = this.#apply(frame.data);
+				value = this.#apply(frame.payload);
 				advanced = true;
 			}
 			if (advanced) return value;
@@ -78,7 +78,7 @@ export class Consumer<T> {
 				continue;
 			}
 
-			return this.#apply(frame.data);
+			return this.#apply(frame.payload);
 		}
 	}
 

--- a/js/json/src/snapshot/producer.ts
+++ b/js/json/src/snapshot/producer.ts
@@ -180,7 +180,7 @@ export class Producer<T> {
 			this.#encoder = new Encoder();
 			data = this.#encoder.frame(frame);
 		}
-		group.writeFrame({ data, timestamp: Time.Timestamp.now() });
+		group.writeFrame({ payload: data, timestamp: Time.Timestamp.now() });
 		return data.length;
 	}
 
@@ -192,7 +192,7 @@ export class Producer<T> {
 			if (!this.#encoder) throw new Error("compressed delta requires an open group");
 			data = this.#encoder.frame(frame);
 		}
-		group.writeFrame({ data, timestamp: Time.Timestamp.now() });
+		group.writeFrame({ payload: data, timestamp: Time.Timestamp.now() });
 		return data.length;
 	}
 }

--- a/js/json/src/stream.ts
+++ b/js/json/src/stream.ts
@@ -61,7 +61,7 @@ export class Producer<T> {
 		}
 
 		const data = this.#encoder ? this.#encoder.frame(payload) : payload;
-		this.#group.writeFrame({ data, timestamp: Time.Timestamp.now() });
+		this.#group.writeFrame({ payload: data, timestamp: Time.Timestamp.now() });
 	}
 
 	/** Finish the track, closing the group. */
@@ -107,7 +107,7 @@ export class Consumer<T> {
 				continue;
 			}
 
-			const plain = this.#decoder ? this.#decoder.frame(frame.data) : frame.data;
+			const plain = this.#decoder ? this.#decoder.frame(frame.payload) : frame.payload;
 			return JSON.parse(new TextDecoder().decode(plain));
 		}
 	}

--- a/js/loc/src/index.test.ts
+++ b/js/loc/src/index.test.ts
@@ -34,7 +34,7 @@ test("Format decodes timestamp at default microseconds timescale", () => {
 	const [decoded] = fmt.decode(frame);
 
 	expect(decoded.timestamp).toBe(12_345 as Time.Micro);
-	expect(decoded.data).toEqual(payload);
+	expect(decoded.payload).toEqual(payload);
 	expect(decoded.keyframe).toBe(false);
 });
 
@@ -70,7 +70,7 @@ test("Format skips unknown odd-typed properties", () => {
 	const [decoded] = fmt.decode(frame);
 
 	expect(decoded.timestamp).toBe(10 as Time.Micro);
-	expect(decoded.data).toEqual(payload);
+	expect(decoded.payload).toEqual(payload);
 });
 
 test("Format throws when the timestamp property is missing", () => {

--- a/js/loc/src/index.ts
+++ b/js/loc/src/index.ts
@@ -11,7 +11,7 @@ import { Time } from "@moq/net";
 /** A decoded LOC frame: the codec bitstream plus its timing metadata. */
 export interface Frame {
 	/** The codec bitstream payload, with the LOC property block stripped. */
-	data: Uint8Array;
+	payload: Uint8Array;
 	/** Presentation timestamp in microseconds. */
 	timestamp: Time.Micro;
 	/** True if this frame can be decoded without any preceding frames. */
@@ -81,7 +81,7 @@ export class Format {
 		const activeTimescale = timescale ?? DEFAULT_TIMESCALE;
 		const micros = Math.round((timestamp * DEFAULT_TIMESCALE) / activeTimescale) as Time.Micro;
 
-		return [{ data: payload, timestamp: micros, keyframe: false }];
+		return [{ payload, timestamp: micros, keyframe: false }];
 	}
 }
 
@@ -118,7 +118,7 @@ export class Producer {
 		}
 
 		this.#group?.writeFrame({
-			data: this.#encode(data, timestamp),
+			payload: this.#encode(data, timestamp),
 			timestamp: Time.Timestamp.fromMicros(timestamp),
 		});
 	}

--- a/js/msf/src/catalog.ts
+++ b/js/msf/src/catalog.ts
@@ -150,5 +150,5 @@ export function decode(raw: Uint8Array): Catalog {
 export async function fetch(track: Moq.Track.Subscriber): Promise<Catalog | undefined> {
 	const frame = await track.readFrame();
 	if (!frame) return undefined;
-	return decode(frame.data);
+	return decode(frame.payload);
 }

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -164,12 +164,12 @@ test("a read throws CacheFull on a gap, then resyncs to the next group", async (
 	// Group 0 overflows its frame cap without being read, evicting the front: a gap.
 	const g0 = producer.appendGroup();
 	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++)
-		g0.writeFrame({ data: new Uint8Array([i & 0xff]), timestamp: Timestamp.now() });
+		g0.writeFrame({ payload: new Uint8Array([i & 0xff]), timestamp: Timestamp.now() });
 	g0.close();
 
 	// Group 1 is clean.
 	const g1 = producer.appendGroup();
-	g1.writeFrame({ data: new TextEncoder().encode("ok"), timestamp: Timestamp.now() });
+	g1.writeFrame({ payload: new TextEncoder().encode("ok"), timestamp: Timestamp.now() });
 	g1.close();
 
 	// The reader hits the gap in group 0 (error, not a silent skip), then the next

--- a/js/net/src/group.test.ts
+++ b/js/net/src/group.test.ts
@@ -14,17 +14,17 @@ test("a group caps its frame count, dropping from the front", () => {
 
 	const extra = 100;
 	for (let i = 0; i < MAX_GROUP_FRAMES + extra; i++) {
-		producer.writeFrame({ data: new Uint8Array([i & 0xff]), timestamp: Timestamp.now() });
+		producer.writeFrame({ payload: new Uint8Array([i & 0xff]), timestamp: Timestamp.now() });
 	}
 
 	// Drain the buffered frames: exactly MAX_GROUP_FRAMES remain after eviction.
-	const frames: { sequence: number; data: Uint8Array }[] = [];
+	const frames: { sequence: number; payload: Uint8Array }[] = [];
 	for (let f = consumer.tryReadFrameSequence(); f; f = consumer.tryReadFrameSequence()) frames.push(f);
 	expect(frames.length).toBe(MAX_GROUP_FRAMES);
 	// Sequence numbers count every frame ever written (evicted included), so the first surviving
 	// frame is index `extra`, not 0: indices stay consistent across eviction.
 	expect(frames[0].sequence).toBe(extra);
-	expect(frames[0].data[0]).toBe(extra & 0xff);
+	expect(frames[0].payload[0]).toBe(extra & 0xff);
 });
 
 test("a group caps its byte size, dropping from the front", () => {
@@ -33,12 +33,12 @@ test("a group caps its byte size, dropping from the front", () => {
 	// 40 x 1 MiB = 40 MiB, over the 32 MiB cap.
 	const oneMiB = 1024 * 1024;
 	for (let i = 0; i < 40; i++) {
-		producer.writeFrame({ data: new Uint8Array(oneMiB), timestamp: Timestamp.now() });
+		producer.writeFrame({ payload: new Uint8Array(oneMiB), timestamp: Timestamp.now() });
 	}
 
 	// Drain the buffered frames and sum their bytes: the cache stayed under the byte cap.
 	const frames: Uint8Array[] = [];
-	for (let f = consumer.tryReadFrame(); f; f = consumer.tryReadFrame()) frames.push(f.data);
+	for (let f = consumer.tryReadFrame(); f; f = consumer.tryReadFrame()) frames.push(f.payload);
 	const bytes = frames.reduce((sum, f) => sum + f.byteLength, 0);
 	expect(bytes).toBeLessThanOrEqual(MAX_GROUP_CACHE_BYTES);
 	expect(frames.length).toBe(MAX_GROUP_CACHE_BYTES / oneMiB);
@@ -50,8 +50,8 @@ test("a caught-up reader does not trip the byte cache cap", async () => {
 	const oneMiB = 1024 * 1024;
 	const frames = MAX_GROUP_CACHE_BYTES / oneMiB + 8;
 	for (let i = 0; i < frames; i++) {
-		producer.writeFrame({ data: new Uint8Array(oneMiB), timestamp: Timestamp.now() });
-		expect((await consumer.readFrame())?.data.byteLength).toBe(oneMiB);
+		producer.writeFrame({ payload: new Uint8Array(oneMiB), timestamp: Timestamp.now() });
+		expect((await consumer.readFrame())?.payload.byteLength).toBe(oneMiB);
 	}
 });
 
@@ -60,7 +60,7 @@ test("reading a group whose frames were evicted throws CacheFull", async () => {
 
 	// Overflow the frame cap without reading, so the front frames are evicted.
 	for (let i = 0; i < MAX_GROUP_FRAMES + 10; i++) {
-		producer.writeFrame({ data: new Uint8Array([i & 0xff]), timestamp: Timestamp.now() });
+		producer.writeFrame({ payload: new Uint8Array([i & 0xff]), timestamp: Timestamp.now() });
 	}
 
 	// The reader fell behind the eviction window: it must error, not skip the gap.
@@ -69,12 +69,12 @@ test("reading a group whose frames were evicted throws CacheFull", async () => {
 
 test("a group with no eviction reads every frame without error", async () => {
 	const { producer, consumer } = pair(0);
-	producer.writeFrame({ data: new Uint8Array([1]), timestamp: Timestamp.now() });
-	producer.writeFrame({ data: new Uint8Array([2]), timestamp: Timestamp.now() });
+	producer.writeFrame({ payload: new Uint8Array([1]), timestamp: Timestamp.now() });
+	producer.writeFrame({ payload: new Uint8Array([2]), timestamp: Timestamp.now() });
 	producer.close();
 
-	expect((await consumer.readFrame())?.data[0]).toBe(1);
-	expect((await consumer.readFrame())?.data[0]).toBe(2);
+	expect((await consumer.readFrame())?.payload[0]).toBe(1);
+	expect((await consumer.readFrame())?.payload[0]).toBe(2);
 	expect(await consumer.readFrame()).toBeUndefined();
 });
 
@@ -83,8 +83,8 @@ test("tryReadFrame drains buffered frames then returns undefined", () => {
 	producer.writeString("a");
 	producer.writeString("b");
 
-	expect(dec.decode(consumer.tryReadFrame()?.data)).toBe("a");
-	expect(dec.decode(consumer.tryReadFrame()?.data)).toBe("b");
+	expect(dec.decode(consumer.tryReadFrame()?.payload)).toBe("a");
+	expect(dec.decode(consumer.tryReadFrame()?.payload)).toBe("b");
 	// Nothing buffered: undefined, and the group is not closed so this is not end-of-group.
 	expect(consumer.tryReadFrame()).toBeUndefined();
 });
@@ -94,8 +94,8 @@ test("tryReadFrameSequence reports per-frame sequence numbers", () => {
 	producer.writeString("a");
 	producer.writeString("b");
 
-	expect(consumer.tryReadFrameSequence()).toMatchObject({ sequence: 0, data: new TextEncoder().encode("a") });
-	expect(consumer.tryReadFrameSequence()).toMatchObject({ sequence: 1, data: new TextEncoder().encode("b") });
+	expect(consumer.tryReadFrameSequence()).toMatchObject({ sequence: 0, payload: new TextEncoder().encode("a") });
+	expect(consumer.tryReadFrameSequence()).toMatchObject({ sequence: 1, payload: new TextEncoder().encode("b") });
 	expect(consumer.tryReadFrameSequence()).toBeUndefined();
 });
 
@@ -104,8 +104,8 @@ test("readFrameSequence reports per-frame sequence numbers", async () => {
 	producer.writeString("a");
 	producer.writeString("b");
 
-	expect(await consumer.readFrameSequence()).toMatchObject({ sequence: 0, data: new TextEncoder().encode("a") });
-	expect(await consumer.readFrameSequence()).toMatchObject({ sequence: 1, data: new TextEncoder().encode("b") });
+	expect(await consumer.readFrameSequence()).toMatchObject({ sequence: 0, payload: new TextEncoder().encode("a") });
+	expect(await consumer.readFrameSequence()).toMatchObject({ sequence: 1, payload: new TextEncoder().encode("b") });
 });
 
 test("done distinguishes a finished group from one that is merely empty", () => {
@@ -139,7 +139,7 @@ test("readable resolves once a frame is buffered", async () => {
 	// Writing makes it resolve.
 	producer.writeString("hi");
 	await readable; // must not hang
-	expect(dec.decode(consumer.tryReadFrame()?.data)).toBe("hi");
+	expect(dec.decode(consumer.tryReadFrame()?.payload)).toBe("hi");
 });
 
 test("readable resolves once the group closes, even with nothing buffered", async () => {

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -20,9 +20,9 @@ export const MAX_GROUP_FRAMES = 1024;
  */
 export interface Frame {
 	/** The frame payload. */
-	data: Uint8Array;
+	payload: Uint8Array;
 	/**
-	 * Presentation timestamp. Required: for data with no presentation time of its own
+	 * Presentation timestamp. Required: for a payload with no presentation time of its own
 	 * (a JSON catalog, control state) pass {@link Timestamp.now} explicitly.
 	 */
 	timestamp: Timestamp;
@@ -65,14 +65,14 @@ class GroupState {
 function appendFrame(state: GroupState, frame: Frame) {
 	if (state.closed.peek()) throw new Error("group is closed");
 
-	state.cacheBytes += frame.data.byteLength;
+	state.cacheBytes += frame.payload.byteLength;
 	state.frames.mutate((frames) => {
 		frames.push(frame);
 
 		while (frames.length > MAX_GROUP_FRAMES || state.cacheBytes > MAX_GROUP_CACHE_BYTES) {
 			const evicted = frames.shift();
 			if (!evicted) break;
-			state.cacheBytes -= evicted.data.byteLength;
+			state.cacheBytes -= evicted.payload.byteLength;
 			state.offset++;
 		}
 	});
@@ -146,7 +146,7 @@ export class Producer {
 
 	/** Write a string as a single UTF-8 encoded frame, stamped with {@link Timestamp.now}. */
 	writeString(str: string) {
-		this.writeFrame({ data: new TextEncoder().encode(str), timestamp: Timestamp.now() });
+		this.writeFrame({ payload: new TextEncoder().encode(str), timestamp: Timestamp.now() });
 	}
 
 	/** Write a value as a single JSON-encoded frame, stamped with {@link Timestamp.now}. */
@@ -156,7 +156,7 @@ export class Producer {
 
 	/** Write a boolean as a single one-byte frame, stamped with {@link Timestamp.now}. */
 	writeBool(bool: boolean) {
-		this.writeFrame({ data: new Uint8Array([bool ? 1 : 0]), timestamp: Timestamp.now() });
+		this.writeFrame({ payload: new Uint8Array([bool ? 1 : 0]), timestamp: Timestamp.now() });
 	}
 
 	/** True once the group has been closed. */
@@ -216,7 +216,7 @@ export class Consumer {
 		const frame = frames.shift();
 		if (!frame) return undefined;
 
-		this.#state.cacheBytes -= frame.data.byteLength;
+		this.#state.cacheBytes -= frame.payload.byteLength;
 		return { sequence: this.#state.total.peek() - frames.length - 1, frame };
 	}
 
@@ -251,7 +251,7 @@ export class Consumer {
 	tryReadFrameSequence(): ({ sequence: number } & Frame) | undefined {
 		const read = this.#readBufferedFrame();
 		if (!read) return undefined;
-		return { sequence: read.sequence, data: read.frame.data, timestamp: read.frame.timestamp };
+		return { sequence: read.sequence, payload: read.frame.payload, timestamp: read.frame.timestamp };
 	}
 
 	/** Resolves once {@link readFrame} would not block. */
@@ -291,7 +291,7 @@ export class Consumer {
 			if (this.#state.offset > 0) throw new CacheFull();
 
 			const read = this.#readBufferedFrame();
-			if (read) return { sequence: read.sequence, data: read.frame.data, timestamp: read.frame.timestamp };
+			if (read) return { sequence: read.sequence, payload: read.frame.payload, timestamp: read.frame.timestamp };
 
 			const closed = this.#state.closed.peek();
 			if (closed instanceof Error) throw closed;
@@ -304,7 +304,7 @@ export class Consumer {
 	/** Reads the next frame and decodes its payload as a UTF-8 string. */
 	async readString(): Promise<string | undefined> {
 		const frame = await this.readFrame();
-		return frame ? new TextDecoder().decode(frame.data) : undefined;
+		return frame ? new TextDecoder().decode(frame.payload) : undefined;
 	}
 
 	/** Reads the next frame and parses its payload as JSON. */
@@ -316,7 +316,7 @@ export class Consumer {
 	/** Reads the next frame and decodes its payload as a one-byte boolean. */
 	async readBool(): Promise<boolean | undefined> {
 		const frame = await this.readFrame();
-		return frame ? frame.data[0] === 1 : undefined;
+		return frame ? frame.payload[0] === 1 : undefined;
 	}
 
 	/** Closes the group, optionally with an error to abort readers. Idempotent. */

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -231,7 +231,7 @@ export class Publisher {
 					const frame = await Promise.race([group.readFrame(), stream.closed]);
 					if (!frame) break;
 
-					const obj = new Frame({ payload: frame.data, timestamp: frame.timestamp });
+					const obj = new Frame({ payload: frame.payload, timestamp: frame.timestamp });
 					await obj.encode(stream, header.flags, this.#session.version);
 				}
 

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -496,7 +496,7 @@ export class Subscriber {
 				const frame = await Frame.decode(stream, group.flags, this.#session.version);
 				if (frame.payload === undefined) break;
 
-				producer.writeFrame({ data: frame.payload, timestamp: frame.timestamp ?? Timestamp.now() });
+				producer.writeFrame({ payload: frame.payload, timestamp: frame.timestamp ?? Timestamp.now() });
 			}
 
 			producer.close();

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -323,12 +323,12 @@ test("integration: lite draft-05 fetches a cached group", async () => {
 	server.publish(Path.from("test"), broadcast);
 
 	const group0 = producer.appendGroup();
-	group0.writeFrame({ data: enc.encode("alpha"), timestamp: Timestamp.fromMillis(10) });
-	group0.writeFrame({ data: enc.encode("beta"), timestamp: Timestamp.fromMillis(15) });
+	group0.writeFrame({ payload: enc.encode("alpha"), timestamp: Timestamp.fromMillis(10) });
+	group0.writeFrame({ payload: enc.encode("beta"), timestamp: Timestamp.fromMillis(15) });
 	group0.close();
 
 	const group1 = producer.appendGroup();
-	group1.writeFrame({ data: enc.encode("newer"), timestamp: Timestamp.fromMillis(20) });
+	group1.writeFrame({ payload: enc.encode("newer"), timestamp: Timestamp.fromMillis(20) });
 	group1.close();
 
 	// Fetch group 0 without holding a live subscription; the timestamps round-trip.
@@ -336,11 +336,11 @@ test("integration: lite draft-05 fetches a cached group", async () => {
 	const fetched = await remote.track("video").fetchGroup(0);
 
 	const first = await fetched.readFrame();
-	expect(dec.decode(first?.data)).toBe("alpha");
+	expect(dec.decode(first?.payload)).toBe("alpha");
 	expect(first?.timestamp.asMillis()).toBe(10);
 
 	const second = await fetched.readFrame();
-	expect(dec.decode(second?.data)).toBe("beta");
+	expect(dec.decode(second?.payload)).toBe("beta");
 	expect(second?.timestamp.asMillis()).toBe(15);
 
 	expect(await fetched.readFrame()).toBeUndefined();
@@ -363,8 +363,8 @@ test("integration: lite draft-05 coalesces concurrent fetches of one group", asy
 	server.publish(Path.from("test"), broadcast);
 
 	const group0 = producer.appendGroup();
-	group0.writeFrame({ data: enc.encode("alpha"), timestamp: Timestamp.fromMillis(10) });
-	group0.writeFrame({ data: enc.encode("beta"), timestamp: Timestamp.fromMillis(15) });
+	group0.writeFrame({ payload: enc.encode("alpha"), timestamp: Timestamp.fromMillis(10) });
+	group0.writeFrame({ payload: enc.encode("beta"), timestamp: Timestamp.fromMillis(15) });
 	group0.close();
 
 	const remote = client.consume(Path.from("test"));
@@ -375,15 +375,15 @@ test("integration: lite draft-05 coalesces concurrent fetches of one group", asy
 	const [a, b] = await Promise.all([trackConsumer.fetchGroup(0), trackConsumer.fetchGroup(0)]);
 
 	for (const fetched of [a, b]) {
-		expect(dec.decode((await fetched.readFrame())?.data)).toBe("alpha");
-		expect(dec.decode((await fetched.readFrame())?.data)).toBe("beta");
+		expect(dec.decode((await fetched.readFrame())?.payload)).toBe("alpha");
+		expect(dec.decode((await fetched.readFrame())?.payload)).toBe("beta");
 		expect(await fetched.readFrame()).toBeUndefined();
 	}
 
 	// After the coalesced fetch completes and its cache entry evicts, the same group re-fetches.
 	const again = await trackConsumer.fetchGroup(0);
-	expect(dec.decode((await again.readFrame())?.data)).toBe("alpha");
-	expect(dec.decode((await again.readFrame())?.data)).toBe("beta");
+	expect(dec.decode((await again.readFrame())?.payload)).toBe("alpha");
+	expect(dec.decode((await again.readFrame())?.payload)).toBe("beta");
 	expect(await again.readFrame()).toBeUndefined();
 
 	broadcast.close();
@@ -405,18 +405,18 @@ test("integration: lite draft-05 fetches an in-progress group", async () => {
 
 	// Open the group and write one frame, but leave it open (in-progress).
 	const group0 = producer.appendGroup();
-	group0.writeFrame({ data: enc.encode("alpha"), timestamp: Timestamp.fromMillis(10) });
+	group0.writeFrame({ payload: enc.encode("alpha"), timestamp: Timestamp.fromMillis(10) });
 
 	const remote = client.consume(Path.from("test"));
 	const fetched = await remote.track("video").fetchGroup(0);
 
 	const first = await fetched.readFrame();
-	expect(dec.decode(first?.data)).toBe("alpha");
+	expect(dec.decode(first?.payload)).toBe("alpha");
 
 	// Frames appended after the fetch started must still stream through, not be truncated.
-	group0.writeFrame({ data: enc.encode("beta"), timestamp: Timestamp.fromMillis(15) });
+	group0.writeFrame({ payload: enc.encode("beta"), timestamp: Timestamp.fromMillis(15) });
 	const second = await fetched.readFrame();
-	expect(dec.decode(second?.data)).toBe("beta");
+	expect(dec.decode(second?.payload)).toBe("beta");
 	expect(second?.timestamp.asMillis()).toBe(15);
 
 	group0.close();

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -1,4 +1,4 @@
-import { Signal } from "@moq/signals";
+import { type Getter, Signal } from "@moq/signals";
 import type * as announce from "../announced.ts";
 import { type Bandwidth, createBandwidth } from "../bandwidth.ts";
 import type * as broadcast from "../broadcast.ts";
@@ -14,7 +14,7 @@ import { Group } from "./group.ts";
 import { type Origin, randomOrigin } from "./origin.ts";
 import { Publisher } from "./publisher.ts";
 import { SessionInfo } from "./session.ts";
-import { ProbeLevel, Setup } from "./setup.ts";
+import { ProbeLevel, type Role, Setup } from "./setup.ts";
 import { DataType, StreamId } from "./stream.ts";
 import { Subscribe } from "./subscribe.ts";
 import { Subscriber } from "./subscriber.ts";
@@ -70,6 +70,23 @@ export class Connection implements Established {
 	// encoding depends on a negotiated capability (e.g. PROBE) wait on this. undefined
 	// until the peer's SETUP arrives; stays undefined forever on older drafts.
 	#peerSetup = new Signal<Setup | undefined>(undefined);
+
+	// Mirrors the role out of #peerSetup, so the public surface exposes the peer's declared
+	// direction without handing out the whole SETUP (whose probe level gates our own streams).
+	#peerRole = new Signal<Role | undefined>(undefined);
+
+	/**
+	 * The {@link Role} the peer advertised in its SETUP, for a server deciding whether the
+	 * peer's authorization grants the direction it intends to use.
+	 *
+	 * `undefined` until the peer's SETUP arrives, and forever on pre-lite-05 versions, which
+	 * carry no in-band role. A peer that omits the parameter, or sends a value we don't
+	 * recognize, reports {@link Role.Both}. Only a client sends a role, so this stays
+	 * `undefined` on a connection we opened.
+	 */
+	get peerRole(): Getter<Role | undefined> {
+		return this.#peerRole;
+	}
 
 	/**
 	 * Creates a new Connection instance.
@@ -192,11 +209,13 @@ export class Connection implements Established {
 	// The browser uses WebTransport, which carries the request URI, so we advertise no
 	// path and leave routing to the URL. We advertise probe = Report (we measure and
 	// report bitrate over the PROBE stream, but don't actively pad the connection).
+	// Role stays Both: publish/consume are called after this point, so there is nothing
+	// to narrow yet.
 	async #sendSetup(): Promise<void> {
 		const writer = await Writer.open(this.#quic);
 		try {
 			await writer.u53(DataType.Setup);
-			await new Setup(ProbeLevel.Report).encode(writer, this.#version);
+			await new Setup({ probe: ProbeLevel.Report }).encode(writer, this.#version);
 			writer.close();
 		} catch (err: unknown) {
 			writer.reset(err);
@@ -273,6 +292,7 @@ export class Connection implements Established {
 			// streams (e.g. PROBE) can react, then drain to the FIN.
 			const setup = await Setup.decode(stream, this.#version);
 			this.#peerSetup.set(setup);
+			this.#peerRole.set(setup.role);
 		} else {
 			throw new Error(`unknown stream type: ${typ.toString()}`);
 		}

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -80,9 +80,9 @@ export class Connection implements Established {
 	 * peer's authorization grants the direction it intends to use.
 	 *
 	 * `undefined` until the peer's SETUP arrives, and forever on pre-lite-05 versions, which
-	 * carry no in-band role. A peer that omits the parameter, or sends a value we don't
-	 * recognize, reports {@link Role.Both}. Only a client sends a role, so this stays
-	 * `undefined` on a connection we opened.
+	 * carry no in-band role. {@link Role.Both} is the absence of the parameter, so it is what
+	 * a peer reports when it declines to declare a direction, sends a value we don't
+	 * recognize, or is a server (which never sends one).
 	 */
 	get peerRole(): Getter<Role | undefined> {
 		return this.#peerRole;

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -511,8 +511,8 @@ export class Publisher {
 			await stream.u62(zigzag(ts - prevTs));
 			prevTs = ts;
 
-			await stream.u53(frame.data.byteLength);
-			await stream.write(frame.data);
+			await stream.u53(frame.payload.byteLength);
+			await stream.write(frame.payload);
 		}
 	}
 
@@ -540,8 +540,8 @@ export class Publisher {
 						prevTs = ts;
 					}
 
-					await stream.u53(frame.data.byteLength);
-					await stream.write(frame.data);
+					await stream.u53(frame.payload.byteLength);
+					await stream.write(frame.payload);
 				}
 
 				stream.close();

--- a/js/net/src/lite/setup.test.ts
+++ b/js/net/src/lite/setup.test.ts
@@ -93,11 +93,19 @@ test("SETUP carries role alongside probe and path", async () => {
 });
 
 test("Both is the wire default, so it is omitted rather than encoded", async () => {
-	// Both must be the absence of the parameter: an old server that never learned the
-	// parameter has to decode a Both client back to Both.
-	const body = await bytes((w) => new Setup({ role: Role.Both }).encode(w, Version.DRAFT_05));
-	const empty = await bytes((w) => new Setup().encode(w, Version.DRAFT_05));
-	expect(body).toEqual(empty);
+	// Both must be the absence of the parameter, so a server that predates it decodes a
+	// Both client back to Both. Assert the empty bag directly: comparing against another
+	// default-constructed Setup would agree with itself even if we encoded Both.
+	const both = await bytes((w) => new Setup({ role: Role.Both }).encode(w, Version.DRAFT_05));
+	const emptyBag = await bytes(async (w) => {
+		await w.u53(1); // Message size prefix: one byte of body follows
+		await w.u53(0); // parameter count
+	});
+	expect(both).toEqual(emptyBag);
+
+	// A directional role is still encoded, so the check above can actually fail.
+	const publisher = await bytes((w) => new Setup({ role: Role.Publisher }).encode(w, Version.DRAFT_05));
+	expect(publisher.byteLength).toBeGreaterThan(both.byteLength);
 });
 
 test("unknown role falls back to Both", async () => {

--- a/js/net/src/lite/setup.test.ts
+++ b/js/net/src/lite/setup.test.ts
@@ -1,8 +1,14 @@
 import { expect, test } from "bun:test";
 import { Reader, Writer } from "../stream.ts";
 import * as Varint from "../varint.ts";
-import { ProbeLevel, Setup } from "./setup.ts";
+import { ProbeLevel, Role, Setup } from "./setup.ts";
 import { Version } from "./version.ts";
+
+// Parameter ids, duplicated from setup.ts so a typo there fails a test rather than
+// silently agreeing with itself.
+const PARAM_PROBE = 0x1n;
+const PARAM_PATH = 0x2n;
+const PARAM_ROLE = 0x3n;
 
 function concat(chunks: Uint8Array[]): Uint8Array {
 	const total = chunks.reduce((sum, c) => sum + c.byteLength, 0);
@@ -33,35 +39,14 @@ async function roundTrip(msg: Setup): Promise<Setup> {
 	return got;
 }
 
-test("empty SETUP round-trips on draft-05", async () => {
-	const got = await roundTrip(new Setup());
-	expect(got.probe).toBe(ProbeLevel.None);
-	expect(got.path).toBeUndefined();
-});
-
-test("each probe level round-trips on draft-05", async () => {
-	for (const probe of [ProbeLevel.None, ProbeLevel.Report, ProbeLevel.Increase]) {
-		const got = await roundTrip(new Setup(probe));
-		expect(got.probe).toBe(probe);
-		expect(got.path).toBeUndefined();
-	}
-});
-
-test("SETUP with path round-trips on draft-05", async () => {
-	const got = await roundTrip(new Setup(ProbeLevel.Report, "/room/123"));
-	expect(got.probe).toBe(ProbeLevel.Report);
-	expect(got.path).toBe("/room/123");
-});
-
-test("unknown probe level saturates to Increase", async () => {
-	// Hand-frame a SETUP body carrying an unknown probe level (99): a 1-parameter bag
-	// (PROBE id 0x1) whose value is the varint 99, prefixed with the Message size.
-	const value = Varint.encode(99);
+// Hand-frame a SETUP carrying a single raw parameter, so we can feed the decoder values
+// our own encoder would never produce (unknown levels, empty paths).
+async function decodeParam(id: bigint, value: Uint8Array): Promise<Setup> {
 	const body = await bytes(async (w) => {
 		await w.u53(1); // parameter count
-		await w.u62(0x1n); // PARAM_PROBE
+		await w.u62(id);
 		await w.u53(value.byteLength);
-		await w.write(value);
+		if (value.byteLength > 0) await w.write(value);
 	});
 
 	const framed = await bytes(async (w) => {
@@ -69,7 +54,66 @@ test("unknown probe level saturates to Increase", async () => {
 		await w.write(body);
 	});
 
-	const got = await Setup.decode(new Reader(undefined, framed), Version.DRAFT_05);
+	return await Setup.decode(new Reader(undefined, framed), Version.DRAFT_05);
+}
+
+test("empty SETUP round-trips on draft-05", async () => {
+	const got = await roundTrip(new Setup());
+	expect(got.probe).toBe(ProbeLevel.None);
+	expect(got.path).toBeUndefined();
+	expect(got.role).toBe(Role.Both);
+});
+
+test("each probe level round-trips on draft-05", async () => {
+	for (const probe of [ProbeLevel.None, ProbeLevel.Report, ProbeLevel.Increase]) {
+		const got = await roundTrip(new Setup({ probe }));
+		expect(got.probe).toBe(probe);
+		expect(got.path).toBeUndefined();
+	}
+});
+
+test("SETUP with path round-trips on draft-05", async () => {
+	const got = await roundTrip(new Setup({ probe: ProbeLevel.Report, path: "/room/123" }));
+	expect(got.probe).toBe(ProbeLevel.Report);
+	expect(got.path).toBe("/room/123");
+});
+
+test("each role round-trips on draft-05", async () => {
+	for (const role of [Role.Both, Role.Publisher, Role.Subscriber]) {
+		const got = await roundTrip(new Setup({ role }));
+		expect(got.role).toBe(role);
+	}
+});
+
+test("SETUP carries role alongside probe and path", async () => {
+	const got = await roundTrip(new Setup({ probe: ProbeLevel.Increase, path: "/room/123", role: Role.Publisher }));
+	expect(got.probe).toBe(ProbeLevel.Increase);
+	expect(got.path).toBe("/room/123");
+	expect(got.role).toBe(Role.Publisher);
+});
+
+test("Both is the wire default, so it is omitted rather than encoded", async () => {
+	// Both must be the absence of the parameter: an old server that never learned the
+	// parameter has to decode a Both client back to Both.
+	const body = await bytes((w) => new Setup({ role: Role.Both }).encode(w, Version.DRAFT_05));
+	const empty = await bytes((w) => new Setup().encode(w, Version.DRAFT_05));
+	expect(body).toEqual(empty);
+});
+
+test("unknown role falls back to Both", async () => {
+	// Hand-frame a SETUP carrying an unrecognized role (99). The draft requires a receiver
+	// that doesn't know the value to treat it as Both, so a newer client can't break us.
+	const got = await decodeParam(PARAM_ROLE, Varint.encode(99));
+	expect(got.role).toBe(Role.Both);
+});
+
+test("role 0 decodes as Both", async () => {
+	const got = await decodeParam(PARAM_ROLE, Varint.encode(0));
+	expect(got.role).toBe(Role.Both);
+});
+
+test("unknown probe level saturates to Increase", async () => {
+	const got = await decodeParam(PARAM_PROBE, Varint.encode(99));
 	expect(got.probe).toBe(ProbeLevel.Increase);
 });
 
@@ -83,15 +127,5 @@ test("SETUP decode is rejected before draft-05", async () => {
 });
 
 test("empty path is rejected on decode", async () => {
-	// Hand-frame a SETUP with a zero-length PATH parameter.
-	const body = await bytes(async (w) => {
-		await w.u53(1); // parameter count
-		await w.u62(0x2n); // PARAM_PATH
-		await w.u53(0); // zero-length value
-	});
-	const framed = await bytes(async (w) => {
-		await w.u53(body.byteLength);
-		await w.write(body);
-	});
-	await expect(Setup.decode(new Reader(undefined, framed), Version.DRAFT_05)).rejects.toThrow();
+	await expect(decodeParam(PARAM_PATH, new Uint8Array())).rejects.toThrow();
 });

--- a/js/net/src/lite/setup.ts
+++ b/js/net/src/lite/setup.ts
@@ -14,6 +14,8 @@ import { hasSetupStream, type Version } from "./version.ts";
 const PARAM_PROBE = 0x1n;
 /** Setup Parameter id for the request Path (client-only, URI-less transports). */
 const PARAM_PATH = 0x2n;
+/** Setup Parameter id for the client's intended {@link Role} (client-only). */
+const PARAM_ROLE = 0x3n;
 
 /** Cap on the number of parameters in a bag, matching the Rust decoder. */
 const MAX_PARAMS = 64;
@@ -46,6 +48,45 @@ function probeFromCode(code: bigint): ProbeLevel {
 			return ProbeLevel.Report;
 		default:
 			return ProbeLevel.Increase;
+	}
+}
+
+/**
+ * The direction a client intends to use the session for.
+ *
+ * A client advertises this in its SETUP so the server can reject a token that lacks the
+ * matching scope during the handshake, instead of accepting a session that then silently
+ * carries no media (a subscribe-only token used to publish, or vice versa). It only ever
+ * narrows what the server grants, so it is not a security boundary: the server still
+ * enforces the token's scope regardless.
+ */
+export const Role = {
+	/** The client may do either, or declined to say. Equivalent to omitting the parameter. */
+	Both: 0,
+	/** The client will publish tracks (ingest); the server must consume. */
+	Publisher: 1,
+	/** The client will subscribe to tracks (egress); the server must publish. */
+	Subscriber: 2,
+} as const;
+
+/** A session role. See {@link Role}. */
+export type Role = (typeof Role)[keyof typeof Role];
+
+/**
+ * Map a wire value to a role, falling back to {@link Role.Both}.
+ *
+ * The draft requires a receiver that does not recognize the value to treat it as `Both`,
+ * so a newer client can't break an older server: it just loses the early reject and defers
+ * to the token's scope.
+ */
+function roleFromCode(code: bigint): Role {
+	switch (code) {
+		case 1n:
+			return Role.Publisher;
+		case 2n:
+			return Role.Subscriber;
+		default:
+			return Role.Both;
 	}
 }
 
@@ -117,6 +158,16 @@ class Parameters {
 	}
 }
 
+/** The capabilities a {@link Setup} advertises. Each defaults to the wire default, which is the absence of the parameter. */
+export interface SetupProps {
+	/** See {@link Setup.probe}. Defaults to {@link ProbeLevel.None}. */
+	probe?: ProbeLevel;
+	/** See {@link Setup.path}. Omitted by default. */
+	path?: string;
+	/** See {@link Setup.role}. Defaults to {@link Role.Both}. */
+	role?: Role;
+}
+
 /**
  * The SETUP message, sent once per endpoint on the unidirectional Setup Stream.
  *
@@ -135,9 +186,17 @@ export class Setup {
 	 */
 	path?: string;
 
-	constructor(probe: ProbeLevel = ProbeLevel.None, path?: string) {
-		this.probe = probe;
+	/**
+	 * The client's intended {@link Role}. `Both` is sent as the absence of the parameter, so
+	 * a client that never sets it decodes back to `Both`. Sent only by the client; a server
+	 * never sends one and a relay never forwards it.
+	 */
+	role: Role;
+
+	constructor({ probe, path, role }: SetupProps = {}) {
+		this.probe = probe ?? ProbeLevel.None;
 		this.path = path;
+		this.role = role ?? Role.Both;
 	}
 
 	static #guard(version: Version) {
@@ -154,6 +213,10 @@ export class Setup {
 		}
 		if (this.path !== undefined) {
 			params.setBytes(PARAM_PATH, new TextEncoder().encode(this.path));
+		}
+		// Both is the wire default, sent as the absence of the parameter.
+		if (this.role !== Role.Both) {
+			params.setVarint(PARAM_ROLE, this.role);
 		}
 		await params.encode(w);
 	}
@@ -173,7 +236,10 @@ export class Setup {
 			}
 		}
 
-		return new Setup(probe, path);
+		const roleCode = params.getVarint(PARAM_ROLE);
+		const role = roleCode === undefined ? Role.Both : roleFromCode(roleCode);
+
+		return new Setup({ probe, path, role });
 	}
 
 	/** Encode the SETUP message with its size prefix. Throws on pre-lite-05 versions. */

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -536,7 +536,7 @@ export class Subscriber {
 				const size = await stream.reader.u53();
 				const payload = await stream.reader.read(size);
 				if (!payload) break;
-				group.writeFrame({ data: payload, timestamp });
+				group.writeFrame({ payload, timestamp });
 			}
 
 			group.close();
@@ -665,7 +665,7 @@ export class Subscriber {
 				const payload = await stream.read(size);
 				if (!payload) break;
 
-				producer.writeFrame({ data: payload, timestamp });
+				producer.writeFrame({ payload, timestamp });
 			}
 
 			producer.close();

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -125,16 +125,6 @@ export interface FetchGroupOptions {
 }
 
 /**
- * Subscriber-side preferences for a subscription.
- *
- * @public
- */
-export interface SubscribeOptions {
-	/** Delivery priority for this subscription. Higher values are served first when constrained. Defaults to `0`. */
-	priority?: number;
-}
-
-/**
  * The per-track operations a lazy {@link Consumer} delegates to the broadcast it came from.
  *
  * Implemented by `broadcast.Producer` / `broadcast.Consumer` (and the wire-layer subclasses
@@ -645,7 +635,7 @@ export class Subscriber {
 	 */
 	async readFrame(): Promise<Frame | undefined> {
 		const next = await this.readFrameSequence();
-		return next ? { data: next.data, timestamp: next.timestamp } : undefined;
+		return next ? { payload: next.payload, timestamp: next.timestamp } : undefined;
 	}
 
 	/**
@@ -669,7 +659,7 @@ export class Subscriber {
 					return {
 						group: groups[0].sequence,
 						frame: next.sequence,
-						data: next.data,
+						payload: next.payload,
 						timestamp: next.timestamp,
 					};
 				}
@@ -693,7 +683,12 @@ export class Subscriber {
 			}
 			const next = group.tryReadFrameSequence();
 			if (next)
-				return { group: group.sequence, frame: next.sequence, data: next.data, timestamp: next.timestamp };
+				return {
+					group: group.sequence,
+					frame: next.sequence,
+					payload: next.payload,
+					timestamp: next.timestamp,
+				};
 
 			const closed = this.#state.closed.peek();
 			if (closed instanceof Error) throw closed;
@@ -717,7 +712,7 @@ export class Subscriber {
 	async readString(): Promise<string | undefined> {
 		const next = await this.readFrame();
 		if (!next) return undefined;
-		return new TextDecoder().decode(next.data);
+		return new TextDecoder().decode(next.payload);
 	}
 
 	/** Reads the next frame and parses it as JSON. */
@@ -731,9 +726,9 @@ export class Subscriber {
 	async readBool(): Promise<boolean | undefined> {
 		const next = await this.readFrame();
 		if (!next) return undefined;
-		const data = next.data;
-		if (data.byteLength !== 1 || !(data[0] === 0 || data[0] === 1)) throw new Error("invalid bool frame");
-		return data[0] === 1;
+		const payload = next.payload;
+		if (payload.byteLength !== 1 || !(payload[0] === 0 || payload[0] === 1)) throw new Error("invalid bool frame");
+		return payload[0] === 1;
 	}
 
 	/**

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -336,7 +336,7 @@ export class Encoder {
 					// Each audio frame is its own group so the relay can forward it without
 					// waiting for a group boundary. Loss is handled by the codec's PLC.
 					track.writeFrame({
-						data: Container.Legacy.encodeFrame(frame, frame.timestamp as Time.Micro),
+						payload: Container.Legacy.encodeFrame(frame, frame.timestamp as Time.Micro),
 						timestamp: Time.Timestamp.fromMicros(frame.timestamp as Time.Micro),
 					});
 				},

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -288,7 +288,7 @@ export class Decoder {
 				this.sync.received(timestamp, "audio");
 
 				this.#out.stats.update((stats) => ({
-					bytesReceived: (stats?.bytesReceived ?? 0) + frame.data.byteLength,
+					bytesReceived: (stats?.bytesReceived ?? 0) + frame.payload.byteLength,
 				}));
 
 				// Backpressure: in buffered mode this holds the encoded frame until the playhead nears
@@ -297,7 +297,7 @@ export class Decoder {
 
 				const chunk = new EncodedAudioChunk({
 					type: frame.keyframe ? "key" : "delta",
-					data: frame.data,
+					data: frame.payload,
 					timestamp: frame.timestamp,
 				});
 
@@ -367,7 +367,7 @@ export class Decoder {
 				this.sync.received(timestamp, "audio");
 
 				this.#out.stats.update((stats) => ({
-					bytesReceived: (stats?.bytesReceived ?? 0) + frame.data.byteLength,
+					bytesReceived: (stats?.bytesReceived ?? 0) + frame.payload.byteLength,
 				}));
 
 				// Backpressure: in buffered mode this holds the encoded frame until the playhead nears
@@ -378,7 +378,7 @@ export class Decoder {
 				decoder.decode(
 					new EncodedAudioChunk({
 						type: frame.keyframe ? "key" : "delta",
-						data: frame.data,
+						data: frame.payload,
 						timestamp: frame.timestamp,
 					}),
 				);

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -383,14 +383,14 @@ class DecoderTrack {
 
 				const chunk = new EncodedVideoChunk({
 					type: frame.keyframe ? "key" : "delta",
-					data: frame.data,
+					data: frame.payload,
 					timestamp: frame.timestamp,
 				});
 
 				// Track both frame count and bytes received for stats in the UI
 				this.stats.update((current) => ({
 					frameCount: (current?.frameCount ?? 0) + 1,
-					bytesReceived: (current?.bytesReceived ?? 0) + frame.data.byteLength,
+					bytesReceived: (current?.bytesReceived ?? 0) + frame.payload.byteLength,
 				}));
 
 				// Track decode buffer: frames sent to decoder but not yet rendered
@@ -467,7 +467,7 @@ class DecoderTrack {
 				// Track stats
 				this.stats.update((current) => ({
 					frameCount: (current?.frameCount ?? 0) + 1,
-					bytesReceived: (current?.bytesReceived ?? 0) + frame.data.byteLength,
+					bytesReceived: (current?.bytesReceived ?? 0) + frame.payload.byteLength,
 				}));
 
 				// Track decode buffer
@@ -488,7 +488,7 @@ class DecoderTrack {
 				decoder.decode(
 					new EncodedVideoChunk({
 						type: frame.keyframe ? "key" : "delta",
-						data: frame.data,
+						data: frame.payload,
 						timestamp: frame.timestamp,
 					}),
 				);


### PR DESCRIPTION
Three of the six items from #2318, picked because they are unblocked: the frame field naming, the SETUP role parameter, and the dead `SubscribeOptions` export. Track end semantics and range controls are left to #2309/#2333 and #2155 as the issue directs.

## Summary

- **Frame payload naming.** `@moq/net`'s `Datagram` and the IETF wire `Frame` already called their bytes `payload`, matching Rust's `moq_net::Frame` and `hang::container::Frame`. Only the group `Frame` used `data`, and `@moq/hang`'s container `Frame` and `@moq/loc`'s `Frame` copied it, so one concept had two names depending on which handle you held. All three now use `payload`. Two nearby `data` fields are deliberately untouched: `cmaf.DataSegmentOptions.data` is a distinct CMAF encode input, and the WebCodecs `EncodedVideoChunk`/`EncodedAudioChunk` init bags keep their own `data` key.
- **SETUP role.** `rs/moq-net` encodes SETUP parameter `0x3` and the draft specifies it, but `js/net` only implemented probe (`0x1`) and path (`0x2`). Adds the `Role` type with the same wire codes as Rust (Publisher `1`, Subscriber `2`, Both = absence of the parameter), decodes it, and records it on `Lite.Connection.peerRole`. This is **internal groundwork, not new public surface**: see below.
- **Dead export.** Deletes `track.SubscribeOptions`, added by #2167 and superseded by `Subscription` in #2170. It was field-for-field identical and referenced nowhere.

### The role is not derived from publish/consume

The issue proposed deriving the advertised role from `Established.publish/consume` usage, mirroring Rust's `Role::from_origins`. That is not implementable as written. Rust derives it from origins wired onto the `Client` builder *before* connecting (`client.rs`), so the value exists when SETUP is written. In JS, `publish`/`consume` are methods on the already-established session and `Lite.Connection` sends SETUP from its constructor, so there is nothing to narrow at handshake time. Deferring SETUP until first use would break PROBE gating (which waits on the peer's SETUP) and would never fire for an announce-only session.

So the JS client still advertises `Both` and **the bytes on the wire are unchanged**. Declaring a role up front needs an explicit `ConnectProps` knob; left to a follow-up.

### The role work adds no reachable API

`@moq/net` publishes two entrypoints (`.` and `./zod`), and `src/index.ts` does not export the `lite` namespace. Everything under `src/lite/` is therefore package-internal, and the role additions below are not reachable by consumers. Concretely, this PR does **not** yet close the issue's "a JS server cannot read a peer's role" gap: `accept()` returns `Established`, which has no `peerRole`, and a consumer cannot name `Lite.Connection` to narrow to it.

That is deliberate. The client half is deferred anyway (see above), so the feature is better landed as a whole once it is reachable, rather than exporting the entire `lite` wire layer or widening the protocol-agnostic `Established` interface with a lite-only concept now. The wire type, decode, and tests are the groundwork.

## Public API changes

Breaking, and reachable by consumers (hence `dev`):

- `@moq/net` `Group.Frame.data` -> `.payload`, affecting `writeFrame` callers and `readFrame` readers.
- `@moq/net` `Track.Subscriber.readFrame` / `readFrameSequence` return shapes: `.data` -> `.payload`.
- `@moq/net` removes `Track.SubscribeOptions`.
- `@moq/hang/container` `Frame.data` -> `.payload` (also reachable as `Hang.Container.Frame`).
- `@moq/loc` `Frame.data` -> `.payload` (also re-exported as `Hang.Container.Loc`). Its `Format` structurally implements hang's container `Format`, so it could not stay behind.

Every one of these is a compile error at the call site, not a silent `undefined`.

Internal only, not exported from any entrypoint:

- `Lite.Role`, `Lite.SetupProps`, `Lite.Setup.role`, `Lite.Connection.peerRole`.
- `Lite.Setup`'s constructor takes a `SetupProps` bag instead of `(probe, path)`. SETUP parameters are explicitly extensible, so a third positional would break the signature again on the next one.

## Cross-package sync

- No wire change, so no draft update is owed. The draft already documents the Role parameter, including that `0` and unrecognized values mean `Both`; the JS decoder follows it.
- No docs updated: no page under `/doc` references the JS frame field or `SubscribeOptions`. The `writeFrame` hits in `doc/lib/{swift,kt}` are FFI bindings that already say `payload`.
- `demo/web` needed no changes and type-checks against the renamed API.

## Test plan

- `just js check` and `just js test` clean: 8 packages, 0 failures.
- Added role coverage in `js/net/src/lite/setup.test.ts`: each role round-trips, role alongside probe/path, `Both` omits the parameter, and both `0` and an unrecognized value decode as `Both`.
- Verified the "Both is omitted" assertion actually fails by temporarily encoding `Both`, then confirmed green again. Its first version compared two Setups that both defaulted to `Both`, so it agreed with itself; it now asserts the encoded bytes against a hand-framed empty bag.
- Refactored the two existing hand-framing tests onto a shared `decodeParam` helper.
- The role decode is covered by unit tests hand-checked against Rust's codes, not by a live Rust<->JS handshake; `just test smoke-full` was not run, since the wire bytes are unchanged.
- Not exercised in a browser: no runtime behavior changes here.

Refs #2318

(Written by Claude Opus 4.8)