### PR TITLE
refactor(moq-net)!: remove Subscriber::get_group; make the sync peek a test hook

### DIFF
--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -408,28 +408,8 @@ impl TrackState {
 			.map(|(group, _)| group.consume())
 	}
 
-	fn poll_get_group(&self, sequence: u64) -> Poll<Result<Option<group::Consumer>>> {
-		if let Some(group) = self.cached_group(sequence) {
-			return Poll::Ready(Ok(Some(group)));
-		}
-
-		// Once final_sequence is set, groups at or past it can never exist.
-		if let Some(fin) = self.final_sequence
-			&& sequence >= fin
-		{
-			return Poll::Ready(Ok(None));
-		}
-
-		if let Some(err) = &self.abort {
-			return Poll::Ready(Err(err.clone()));
-		}
-
-		Poll::Pending
-	}
-
 	/// Resolve a one-shot fetch from the track side: the cached group, or an [`Error`]
-	/// once it can never be served. Unlike [`Self::poll_get_group`] there's no
-	/// `Ok(None)`, since a missing group is a failure ([`Error::NotFound`]), not an
+	/// once it can never be served. A missing group is a failure ([`Error::NotFound`]), not an
 	/// end-of-stream. The handler side (a rejection, or no [`Dynamic`] at all) lives
 	/// in [`FetchState`]; [`Fetching`] polls both.
 	fn poll_fetch_cached(&self, sequence: u64) -> Poll<Result<group::Consumer>> {
@@ -1321,10 +1301,11 @@ impl Consumer {
 		})
 	}
 
-	/// Return a cached group by sequence without blocking, or `None` if it isn't in
-	/// the cache. Use [`Self::fetch_group`] to wait for a group that a [`Dynamic`]
-	/// will serve on demand.
-	pub fn get_group(&self, sequence: u64) -> Option<group::Consumer> {
+	// Peek at a cached group by sequence without blocking, or `None` if it isn't in the
+	// cache. A test hook for asserting cache state; the library reads
+	// `TrackState::cached_group` directly, and callers want `fetch_group`.
+	#[cfg(test)]
+	pub(crate) fn peek_group(&self, sequence: u64) -> Option<group::Consumer> {
 		self.state.read().cached_group(sequence)
 	}
 
@@ -1382,6 +1363,12 @@ impl Consumer {
 		})
 	}
 
+	/// Resolve the track's [`Info`] without subscribing.
+	///
+	/// A [`Consumer`] is a lazy handle, so the info may not be known yet: this waits
+	/// for the producer to [`Request::accept`] the track (a wire TRACK_INFO round-trip
+	/// for a relay), and errors with the track's abort error if it closes first.
+	/// [`Subscriber::info`] is the already-resolved counterpart.
 	pub fn info(&self) -> kio::Pending<Querying> {
 		kio::Pending::new(Querying {
 			state: self.state.clone(),
@@ -1646,6 +1633,10 @@ impl SubscriberControl {
 }
 
 impl Subscriber {
+	/// The track's [`Info`], resolved when the subscription was established.
+	///
+	/// Free, unlike [`Consumer::info`]: subscribing already waited for the info
+	/// (SUBSCRIBE_OK on the wire), so a subscriber always has it.
 	pub fn info(&self) -> &Info {
 		&self.info
 	}
@@ -1783,29 +1774,6 @@ impl Subscriber {
 	/// See [`Self::poll_read_frame`] for semantics.
 	pub async fn read_frame(&mut self) -> Result<Option<frame::Frame>> {
 		kio::wait(|waiter| self.poll_read_frame(waiter)).await
-	}
-
-	/// Poll for the group with the given sequence.
-	///
-	/// This waits for live arrival, not on-demand retrieval. If the sequence is
-	/// below the final sequence but was already evicted from the cache, this parks
-	/// until the track closes. Use [`Consumer::fetch_group`] for a past group that a
-	/// [`Dynamic`] can serve on demand.
-	pub fn poll_get_group(&self, waiter: &kio::Waiter, sequence: u64) -> Poll<Result<Option<group::Consumer>>> {
-		self.poll(waiter, |state| state.poll_get_group(sequence))
-	}
-
-	/// Wait until the group with the given sequence becomes available.
-	///
-	/// Resolves to `Some(group::Consumer)` once the group is in the cache.
-	/// Resolves to `None` only when `sequence` is at or past the track's
-	/// `final_sequence` (set by `finish()` / `finish_at()`), since such a
-	/// group can never be produced. Sequences below `final_sequence` still
-	/// wait, since older groups may still arrive out of order. If the sequence
-	/// was already evicted, this waits until the track closes; use
-	/// [`Consumer::fetch_group`] for on-demand retrieval of past groups.
-	pub async fn get_group(&self, sequence: u64) -> Result<Option<group::Consumer>> {
-		kio::wait(|waiter| self.poll_get_group(waiter, sequence)).await
 	}
 
 	/// Whether `other` was cloned from this subscriber (shares the same underlying state).
@@ -3111,29 +3079,6 @@ mod test {
 		assert!(done.is_none());
 	}
 
-	#[tokio::test]
-	async fn get_group_finishes_without_waiting_for_gaps() {
-		let mut producer = track_producer("test", None);
-		producer.create_group(group::Info { sequence: 1 }).unwrap();
-		producer.finish().unwrap();
-
-		let consumer = producer.subscribe(None);
-		// get_group(0) blocks because group 0 is below final_sequence and could still arrive.
-		assert!(
-			consumer.get_group(0).now_or_never().is_none(),
-			"sequence below fin should block (group could still arrive)"
-		);
-		assert!(
-			consumer
-				.get_group(2)
-				.now_or_never()
-				.expect("sequence at-or-after fin should resolve")
-				.expect("should not error")
-				.is_none(),
-			"sequence at-or-after fin should not exist"
-		);
-	}
-
 	#[test]
 	fn append_group_returns_bounds_exceeded_on_sequence_overflow() {
 		let mut producer = track_producer("test", None);
@@ -3156,11 +3101,11 @@ mod test {
 			.unwrap();
 		group.finish().unwrap();
 
-		// A cached group resolves immediately and never queues a request. `get_group`
+		// A cached group resolves immediately and never queues a request. `peek_group`
 		// also returns it synchronously.
 		let dynamic = producer.dynamic();
 		let consumer = producer.consume();
-		assert!(consumer.get_group(0).is_some());
+		assert!(consumer.peek_group(0).is_some());
 		let mut g = consumer.fetch_group(0, None).await.unwrap();
 		assert_eq!(g.sequence, 0);
 		assert_eq!(&g.read_frame().await.unwrap().unwrap().payload[..], b"hello");
@@ -3175,10 +3120,10 @@ mod test {
 		let dynamic = producer.dynamic();
 		let consumer = producer.consume();
 
-		// A cache miss isn't in `get_group`, but a dynamic handler exists, so
+		// A cache miss isn't in `peek_group`, but a dynamic handler exists, so
 		// `fetch_group` stays pending and queues a request. `*pending` derefs the
 		// wrapper to the inner `Fetching` (a `kio::Future`).
-		assert!(consumer.get_group(5).is_none());
+		assert!(consumer.peek_group(5).is_none());
 		let pending = consumer.fetch_group(5, group::Fetch::default().with_priority(7));
 		assert!(kio::Future::poll(&*pending, &kio::Waiter::noop()).is_pending());
 
@@ -3418,9 +3363,9 @@ mod test {
 		assert!(pool.used() <= 3000, "pool should be back under budget");
 
 		let consumer = producer.consume();
-		assert!(consumer.get_group(0).is_none(), "evicted group is a cache miss");
-		assert!(consumer.get_group(1).is_some());
-		assert!(consumer.get_group(2).is_some());
+		assert!(consumer.peek_group(0).is_none(), "evicted group is a cache miss");
+		assert!(consumer.peek_group(1).is_some());
+		assert!(consumer.peek_group(2).is_some());
 
 		// A fresh subscriber skips the evicted group entirely.
 		let mut subscriber = producer.subscribe(None);
@@ -3465,12 +3410,12 @@ mod test {
 
 		let consumer = producer.consume();
 		assert!(
-			consumer.get_group(0).is_some(),
+			consumer.peek_group(0).is_some(),
 			"recently read group survives: {:?}",
 			pool.debug_entries()
 		);
 		assert!(
-			consumer.get_group(1).is_none(),
+			consumer.peek_group(1).is_none(),
 			"stale group is evicted: {:?}",
 			pool.debug_entries()
 		);
@@ -3567,7 +3512,7 @@ mod test {
 			.unwrap();
 
 		assert!(pool.used() <= 3000);
-		let mut group = consumer.get_group(1).expect("refetched latest must stay pinned");
+		let mut group = consumer.peek_group(1).expect("refetched latest must stay pinned");
 		assert_eq!(group.read_frame().await.unwrap().unwrap().payload.len(), 1000);
 	}
 
@@ -3587,7 +3532,7 @@ mod test {
 		// The evicted group is a miss, so the fetch queues for the dynamic handler
 		// (a relay would issue a wire FETCH upstream).
 		let consumer = producer.consume();
-		assert!(consumer.get_group(0).is_none());
+		assert!(consumer.peek_group(0).is_none());
 		let pending = consumer.fetch_group(0, None);
 
 		let req = dynamic

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -565,15 +565,21 @@ async fn serve_fetch(
 			.await
 			.ok_or(StatusCode::NOT_FOUND)?;
 		let group = match params.group {
-			// "latest" needs a live subscription to learn the newest sequence;
-			// fetch only retrieves a specified past group.
-			FetchGroup::Latest => match async { broadcast.track(&track)?.subscribe(None).await }.await {
-				Ok(mut sub) => match sub.latest() {
-					Some(sequence) => sub.get_group(sequence).await,
-					None => sub.recv_group().await,
-				},
-				Err(err) => Err(err),
-			},
+			// "latest" needs a live subscription to learn the newest sequence, since a
+			// fetch can only retrieve a sequence you already know. Once it's known, fetch
+			// it rather than reading it off the subscription, so an evicted latest is
+			// re-retrieved from upstream instead of waited on forever.
+			FetchGroup::Latest => {
+				async {
+					let consumer = broadcast.track(&track)?;
+					let mut sub = consumer.subscribe(None).await?;
+					match sub.latest() {
+						Some(sequence) => consumer.fetch_group(sequence, None).await.map(Some),
+						None => sub.recv_group().await,
+					}
+				}
+				.await
+			}
 			// A one-shot fetch, no subscription required.
 			FetchGroup::Num(sequence) => async { broadcast.track(&track)?.fetch_group(sequence, None).await }
 				.await


### PR DESCRIPTION
Second of ~4 stacked PRs for #2314. Covers the **Same name, different semantics** section. Stacked on #2334; review that first (this PR's base is its branch).

## Summary

### `get_group` was two unrelated operations wearing one name

- **`track::Subscriber::get_group` is removed**, not renamed. It waited for *live arrival* of a specific sequence, so an evicted-but-not-yet-final group parked until the track closed. That's the footgun: a caller who wants group N generally wants its content, and this could never deliver it.

  Three things say removal beats a rename:
  - **`js/net` never had it.** The mirror implementation has only `fetchGroup`. Rust was the outlier.
  - **Its one external caller didn't use what made it different.** `moq-relay`'s `web.rs` already collapsed `Ok(None)` and `Err(NotFound)` into the same 404, so the `Option` return bought nothing.
  - **Live arrival is already covered** by `recv_group`/`next_group`, and on-demand retrieval by `Consumer::fetch_group`. `get_group` was the confused middle.

  Renaming it to `fetch_group` (the obvious candidate) would have collided head-on with `Consumer::fetch_group`, which means the *opposite* thing (on-demand retrieval via a wire FETCH). `web.rs` calls both in the same `match`, for opposite purposes.

  `web.rs` now uses `fetch_group` for the "latest" case, which is strictly better there: an evicted latest group is re-fetched from upstream instead of waited on forever. The subscription is still needed, but only to learn the sequence.

- **`track::Consumer::get_group` -> `peek_group`, now `#[cfg(test)]`.** It had zero callers outside `moq-net` and is a one-line wrapper over `TrackState::cached_group`, which the library calls directly. `pub(crate)` would have tripped `dead_code` and failed CI's `-D warnings`, so it's marked as what it actually is: a test hook for asserting cache state.

- `Subscriber::poll_get_group` and the private `TrackState::poll_get_group` go with it (no other callers).

### `info()`: documented, not aligned

The issue asks to align `Subscriber::info() -> &Info` with `Consumer::info() -> impl Future`. **I'd argue this pair should stay as-is**, and the reviewer should push back if unconvinced:

- The asymmetry is inherent. A `Subscriber` is a post-`SUBSCRIBE_OK` handle that already resolved its info, so `&Info` is correct and free. A `Consumer` is a lazy handle that may need a wire TRACK_INFO round-trip. Making the subscriber async adds a pointless await on data already in hand; making the consumer sync is impossible.
- Unlike `get_group`, the type system already prevents the confusion. A reference and a future are not interchangeable, so a caller who reaches for the wrong one gets a compile error, not a silent hang.
- `js/net` has the same split (`Consumer.info()` resolves over the wire; a subscriber holds its info); everything there is a `Promise` only because it's JS.

The real defect was that **both methods were completely undocumented**. Each now documents its cost and points at its counterpart.

## Public API changes

**Breaking** (hence `dev`):
- `moq_net::track::Subscriber::get_group` — **removed**.
- `moq_net::track::Subscriber::poll_get_group` — **removed**.
- `moq_net::track::Consumer::get_group` — **removed from the public API** (now `#[cfg(test)] pub(crate) peek_group`).

**Non-breaking:**
- `moq_net::track::Consumer::info` / `Subscriber::info` — doc comments only; signatures unchanged.

Net -49 lines.

## Cross-Package Sync

- `rs/moq-net` API: no wire change (`get_group` was a pure cache/model read, never a wire message), so no draft update.
- `js/net`: nothing to mirror — it has no `getGroup`, and this makes Rust match it. `fetchGroup` is already the shared surface.
- No FFI/WASM exposure of `get_group`, so `libmoq`/`py`/`swift`/`kt`/`go` are untouched.
- Zero references to `get_group` remain anywhere in the repo (`rs/`, `js/`, `doc/`, `drafts/`).

## Test plan

- `nix develop --command just rs fix`: clean.
- `cargo check --workspace --all-targets`: clean.
- `cargo test -p moq-net`: 486 passed, 0 failed (487 minus the deleted `get_group_finishes_without_waiting_for_gaps`).
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moq-net -p moq-relay`: exit 0 (CI gates this and both `info` docs add intra-doc links).
- **On the deleted test:** it asserted `get_group`'s past-`final_sequence` behavior. The equivalent for the replacement path is already covered by `fetch_past_final_not_found` and `fetch_miss_no_dynamic_not_found` — the latter named for resolving "instead of blocking forever", i.e. exactly the footgun this removes. No coverage lost.

(Written by Claude Opus 4.8)
