### PR TITLE
refactor(moq-hls)!: replace the Authorizer callback with router middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4326,6 +4326,7 @@ dependencies = [
  "reqwest",
  "thiserror 2.0.18",
  "tokio",
+ "tower",
  "tracing",
  "url",
 ]

--- a/rs/moq-hls/Cargo.toml
+++ b/rs/moq-hls/Cargo.toml
@@ -40,3 +40,4 @@ url = "2"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
+tower = { version = "0.5", features = ["util"] }

--- a/rs/moq-hls/src/lib.rs
+++ b/rs/moq-hls/src/lib.rs
@@ -9,8 +9,8 @@
 //!   broadcasts (an HTTP *server*). It subscribes only to each broadcast's
 //!   catalog and per-rendition timeline tracks; media bytes are FETCHed from
 //!   the relay one group at a time, only when a segment is actually requested.
-//!   It serves every request by default; gate access with
-//!   [`Server::with_authorizer`](server::Server::with_authorizer).
+//!   It serves every request; gate access by layering your own middleware onto
+//!   [`Server::router`](server::Server::router).
 //!
 //! All CMAF byte handling (import via [`moq_mux::container::fmp4::Import`],
 //! export via [`moq_mux::container::fmp4::Muxer`]) lives in `moq-mux`; this
@@ -25,4 +25,22 @@ pub mod server;
 
 pub use error::*;
 #[cfg(feature = "server")]
-pub use server::{Authorizer, Server};
+pub use server::Server;
+
+/// Re-export of the HTTP stack behind the export server, so consumers can name the
+/// types that surface through [`Server::router`] (and layer their own middleware on
+/// it) without adding their own axum dependency and risking a version mismatch.
+/// `axum::http` covers the `http` crate types too. A major axum bump is therefore a
+/// breaking change for this crate.
+#[cfg(feature = "server")]
+pub use axum;
+
+/// Re-export of the HTTP client used by [`import`], so consumers can name the
+/// [`reqwest::Error`] carried by [`Error::Reqwest`] without adding their own reqwest
+/// dependency. A major reqwest bump is therefore a breaking change for this crate.
+pub use reqwest;
+
+/// Re-export of the URL parser, so consumers can name the [`url::Url`] and
+/// [`url::ParseError`] carried by [`Error`] without adding their own url dependency.
+/// A major url bump is therefore a breaking change for this crate.
+pub use url;

--- a/rs/moq-hls/src/server/mod.rs
+++ b/rs/moq-hls/src/server/mod.rs
@@ -13,8 +13,12 @@
 //! name address distinct resources.
 //!
 //! Every request is served. To gate access, wrap [`Server::router`] in your own
-//! [`axum`] middleware: the broadcast path is the first segment of the request
-//! URI, and rejecting there keeps the origin untouched.
+//! [`axum`] middleware. It runs before routing, so a rejected request never reaches
+//! the origin, but it also sees the raw request URI rather than the path parameters
+//! axum decodes for the handlers. The broadcast is the first segment, still
+//! percent-encoded: `/li%76e/master.m3u8` serves the broadcast `live`. Decode a
+//! segment before matching it against a policy, or a name can be encoded past the
+//! check.
 //!
 //! ```no_run
 //! use axum::http::StatusCode;
@@ -179,6 +183,9 @@ mod tests {
 			.await
 			.unwrap();
 		assert_eq!(allowed.status(), StatusCode::NOT_FOUND);
+		// Pin the 404 to our handler: an unmatched route would also 404, but without
+		// the no-store that not_found() sets, so a broken URI can't fake this pass.
+		assert_eq!(allowed.headers()[header::CACHE_CONTROL], "no-store");
 	}
 
 	async fn closed_broadcaster() -> Arc<Broadcaster> {

--- a/rs/moq-hls/src/server/mod.rs
+++ b/rs/moq-hls/src/server/mod.rs
@@ -12,41 +12,40 @@
 //! `{kind}` is `video` or `audio`, so a video and an audio rendition that share a
 //! name address distinct resources.
 //!
-//! By default every request is served. Pass an [`Authorizer`] via
-//! [`Server::with_authorizer`] to gate access per request (token, cookie, or
-//! signed URL); a denied request is rejected before the origin is touched.
+//! Every request is served. To gate access, wrap [`Server::router`] in your own
+//! [`axum`] middleware: the broadcast path is the first segment of the request
+//! URI, and rejecting there keeps the origin untouched.
+//!
+//! ```no_run
+//! use axum::http::StatusCode;
+//! use axum::middleware::{self, Next};
+//! use axum::extract::Request;
+//! use axum::response::Response;
+//!
+//! async fn gate(req: Request, next: Next) -> Result<Response, StatusCode> {
+//!     match req.headers().get("authorization") {
+//!         Some(token) if token == "secret" => Ok(next.run(req).await),
+//!         _ => Err(StatusCode::UNAUTHORIZED),
+//!     }
+//! }
+//!
+//! # fn build(server: moq_hls::Server) -> axum::Router {
+//! server.router().layer(middleware::from_fn(gate))
+//! # }
+//! ```
 
 mod routes;
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use axum::Router;
-use axum::http::{HeaderMap, StatusCode};
 
 use crate::export::{Broadcaster, Config};
 
 /// How long to wait for a requested broadcast to be announced by the relay.
 const RESOLVE_TIMEOUT: Duration = Duration::from_secs(5);
-
-/// Per-request authorization for the HLS endpoints. Return `Err(status)` to deny
-/// a request; the server never touches the origin for a denied request. A closure
-/// `Fn(&str, &HeaderMap, Option<&str>) -> Result<(), StatusCode>` implements this.
-pub trait Authorizer: Send + Sync + 'static {
-	/// `broadcast` is the requested broadcast path, `headers` the request headers
-	/// (Authorization / Cookie), `query` the raw query string (token / signed-URL schemes).
-	fn authorize(&self, broadcast: &str, headers: &HeaderMap, query: Option<&str>) -> Result<(), StatusCode>;
-}
-
-impl<F> Authorizer for F
-where
-	F: Fn(&str, &HeaderMap, Option<&str>) -> Result<(), StatusCode> + Send + Sync + 'static,
-{
-	fn authorize(&self, broadcast: &str, headers: &HeaderMap, query: Option<&str>) -> Result<(), StatusCode> {
-		self(broadcast, headers, query)
-	}
-}
 
 /// HLS export HTTP server. Cheap to clone (shared inner).
 #[derive(Clone)]
@@ -58,49 +57,22 @@ struct Inner {
 	origin: moq_net::origin::Consumer,
 	config: Config,
 	broadcasters: Mutex<HashMap<String, Arc<Broadcaster>>>,
-	/// Optional per-request authorizer, set at most once via [`Server::with_authorizer`];
-	/// unset allows every request. On the shared inner so a clone or an
-	/// already-handed-out router sees it too (no auth-bypass from call ordering).
-	auth: OnceLock<Arc<dyn Authorizer>>,
 }
 
 impl Server {
-	/// Build a server reading broadcasts from `origin`. Every request is allowed;
-	/// call [`with_authorizer`](Self::with_authorizer) to gate access.
+	/// Build a server reading broadcasts from `origin`. Every request is served;
+	/// gate access by layering middleware onto [`router`](Self::router).
 	pub fn new(origin: moq_net::origin::Consumer, config: Config) -> Self {
 		Self {
 			inner: Arc::new(Inner {
 				origin,
 				config,
 				broadcasters: Mutex::new(HashMap::new()),
-				auth: OnceLock::new(),
 			}),
 		}
 	}
 
-	/// Gate every request through `auth`, rejecting a denied request before the server
-	/// touches the origin. The authorizer lives on the shared inner, so every clone of
-	/// this server and its router enforces it regardless of call order. Set at most
-	/// once; a second call is ignored.
-	pub fn with_authorizer(self, auth: impl Authorizer) -> Self {
-		let _ = self.inner.auth.set(Arc::new(auth));
-		self
-	}
-
-	/// Authorize a request, allowing it when no authorizer is configured.
-	pub(crate) fn authorize(
-		&self,
-		broadcast: &str,
-		headers: &HeaderMap,
-		query: Option<&str>,
-	) -> Result<(), StatusCode> {
-		match self.inner.auth.get() {
-			Some(auth) => auth.authorize(broadcast, headers, query),
-			None => Ok(()),
-		}
-	}
-
-	/// The axum router for the HLS endpoints.
+	/// The axum router for the HLS endpoints, ready to nest or wrap in middleware.
 	pub fn router(&self) -> Router {
 		routes::router(self.clone())
 	}
@@ -163,6 +135,51 @@ async fn evict_closed(inner: Arc<Inner>, name: String, broadcaster: Arc<Broadcas
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	/// Mirrors the middleware example in this module's docs, which `doctest = false`
+	/// keeps out of the compiler's reach. Paused time skips the allowed request's
+	/// RESOLVE_TIMEOUT wait for a broadcast that never arrives.
+	#[tokio::test(start_paused = true)]
+	async fn router_middleware_gates_requests() {
+		use axum::body::Body;
+		use axum::extract::Request;
+		use axum::http::{StatusCode, header};
+		use axum::middleware::{self, Next};
+		use axum::response::Response;
+		use tower::ServiceExt;
+
+		async fn gate(req: Request, next: Next) -> Result<Response, StatusCode> {
+			match req.headers().get(header::AUTHORIZATION) {
+				Some(token) if token == "secret" => Ok(next.run(req).await),
+				_ => Err(StatusCode::UNAUTHORIZED),
+			}
+		}
+
+		// An origin with no broadcasts: a request that reaches the handlers 404s after
+		// RESOLVE_TIMEOUT, so a 401 proves the middleware rejected it first.
+		let origin = moq_net::Origin::random().produce();
+		let server = Server::new(origin.consume(), Config::default());
+		let app = server.router().layer(middleware::from_fn(gate));
+
+		let denied = app
+			.clone()
+			.oneshot(Request::builder().uri("/live/master.m3u8").body(Body::empty()).unwrap())
+			.await
+			.unwrap();
+		assert_eq!(denied.status(), StatusCode::UNAUTHORIZED);
+
+		let allowed = app
+			.oneshot(
+				Request::builder()
+					.uri("/live/master.m3u8")
+					.header(header::AUTHORIZATION, "secret")
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+		assert_eq!(allowed.status(), StatusCode::NOT_FOUND);
+	}
 
 	async fn closed_broadcaster() -> Arc<Broadcaster> {
 		let origin = moq_net::Origin::random().produce();

--- a/rs/moq-hls/src/server/routes.rs
+++ b/rs/moq-hls/src/server/routes.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::Router;
-use axum::extract::{Path, RawQuery, State};
-use axum::http::{HeaderMap, StatusCode, header};
+use axum::extract::{Path, State};
+use axum::http::{StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use bytes::Bytes;
@@ -29,10 +29,7 @@ pub fn router(server: Server) -> Router {
 		.with_state(server)
 }
 
-async fn master(State(server): State<Server>, Path(broadcast): Path<String>, headers: HeaderMap) -> Response {
-	if let Err(status) = server.authorize(&broadcast, &headers, None) {
-		return status.into_response();
-	}
+async fn master(State(server): State<Server>, Path(broadcast): Path<String>) -> Response {
 	let Some(broadcaster) = server.broadcaster(&broadcast).await else {
 		return not_found();
 	};
@@ -46,12 +43,7 @@ async fn master(State(server): State<Server>, Path(broadcast): Path<String>, hea
 async fn media(
 	State(server): State<Server>,
 	Path((broadcast, kind, rendition)): Path<(String, String, String)>,
-	RawQuery(query): RawQuery,
-	headers: HeaderMap,
 ) -> Response {
-	if let Err(status) = server.authorize(&broadcast, &headers, query.as_deref()) {
-		return status.into_response();
-	}
 	let Some(rendition) = rendition_for(&server, &broadcast, &kind, &rendition).await else {
 		return not_found();
 	};
@@ -78,12 +70,7 @@ async fn media(
 async fn init(
 	State(server): State<Server>,
 	Path((broadcast, kind, rendition)): Path<(String, String, String)>,
-	RawQuery(query): RawQuery,
-	headers: HeaderMap,
 ) -> Response {
-	if let Err(status) = server.authorize(&broadcast, &headers, query.as_deref()) {
-		return status.into_response();
-	}
 	let Some(rendition) = rendition_for(&server, &broadcast, &kind, &rendition).await else {
 		return not_found();
 	};
@@ -97,12 +84,7 @@ async fn init(
 async fn segment(
 	State(server): State<Server>,
 	Path((broadcast, kind, rendition, file)): Path<(String, String, String, String)>,
-	RawQuery(query): RawQuery,
-	headers: HeaderMap,
 ) -> Response {
-	if let Err(status) = server.authorize(&broadcast, &headers, query.as_deref()) {
-		return status.into_response();
-	}
 	let Some(sequence) = file.strip_suffix(".m4s").and_then(|s| s.parse::<u64>().ok()) else {
 		return not_found();
 	};


### PR DESCRIPTION
Closes #2322.

## Authorizer -> middleware

`moq_hls::Server::with_authorizer(impl Authorizer)` was exactly the callback-parameter shape the root `CLAUDE.md` bans: a user-supplied hook trait with `Send + Sync + 'static` bounds and a blanket `Fn(&str, &HeaderMap, Option<&str>) -> Result<(), StatusCode>` impl. It had zero in-repo consumers (`rs/moq-cli/src/hls.rs` never called it), and `Server::router()` already returns an `axum::Router`, so the caller-in-control alternative already existed: layer your own axum middleware. `moq-cli` already does this for CORS.

So `Authorizer` is deleted rather than frozen into the next semver bump. The module docs now show the middleware replacement, which is strictly more capable than the trait was: middleware sees the whole request, can run async work (a token check against a remote API, which the sync `Fn` could not), and composes with everything else in the tower ecosystem.

Dropping it also removed the `OnceLock<Arc<dyn Authorizer>>` on the shared inner, and the `HeaderMap`/`RawQuery` extractors plus the four `authorize` guards in the handlers.

### One sharp edge, documented

The trait handed the caller an already-decoded `broadcast` string. Middleware runs before routing, so it sees the **raw** URI instead. Verified with a throwaway probe:

```
MIDDLEWARE_SEES = "/li%76e/master.m3u8"
HANDLER_SEES    = "live"
STATUS          = 200 OK
```

A middleware matching the raw first segment against a policy can therefore be walked past with percent-encoding, on a request the handlers happily serve. That bug class was unrepresentable with the old trait, so the module docs now state what middleware actually sees and tell you to decode before matching a name. (Fail-closed allowlists are unaffected; a denylist or a broadcast-scoped token is where it bites.)

## Stop leaking third-party types

The crate leaked third-party types with no way to name them. `axum::Router` surfaces through `router()`, and (not mentioned in the issue, but the same rule and the same crate) `Error` carries `reqwest::Error`, `url::Url`, and `url::ParseError`. Without a re-export, an axum 0.8 -> 0.9 bump is an invisible breaking change, and matching on `Error::Reqwest` requires the consumer to guess our reqwest version.

Re-exported `axum`, `reqwest`, and `url`, each with the documented "a major bump is a breaking change for this crate" note, matching the pattern `moq-rtc` uses for `str0m`. `axum::http` is itself a re-export of `http`, so it covers the `HeaderMap`/`StatusCode` leak the issue called out without a separate `pub use http`.

## Public API changes

Breaking (hence `dev`):
- **Removed** `moq_hls::Authorizer` (and `server::Authorizer`).
- **Removed** `moq_hls::Server::with_authorizer`.

Additive:
- **Added** `moq_hls::axum` (feature `server`), `moq_hls::reqwest`, `moq_hls::url` re-exports.

No wire, catalog, or container change, so no draft update. No FFI change. `moq-hls` isn't in the Cross-Package Sync table; `doc/bin/hls.md` documents the CLI surface only and never mentioned the authorizer, so no doc row applies. Migration for any out-of-tree consumer:

```rust
// before
let server = Server::new(origin, config).with_authorizer(|broadcast, headers, query| { ... });
let app = server.router();

// after
let app = server.router().layer(axum::middleware::from_fn(gate));
```

Note this is a compile error for such a consumer, not a silent auth bypass.

## Testing

`router_middleware_gates_requests` covers the replacement end to end: a denied request gets 401, an allowed one reaches the handlers (404 against an empty origin, pinned to our handler via the `no-store` header `not_found()` sets, since an unmatched route would 404 too). The crate sets `doctest = false`, so the docs' middleware example is never compile-checked; the test mirrors it so it can't rot silently. It runs with `start_paused = true` so the allowed request skips `RESOLVE_TIMEOUT` instead of parking the suite for 5s.

`cargo check`/`clippy -D warnings`/`fmt`/`doc -D warnings`/`shear`/`sort`/`taplo` are clean, and all 35 `moq-hls` tests pass.