### PR TITLE
refactor(hang)!: non_exhaustive catalog sections, shared container::track_info, hang draft catch-up

### DIFF
--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -123,7 +123,6 @@ A video track contains the necessary information to decode a video stream.
 ~~~
 type VideoSchema = {
 	"renditions": Map<TrackName, VideoDecoderConfig>,
-	"priority": u8,
 	"display": {
 		"width": number,
 		"height": number,
@@ -137,6 +136,22 @@ The `renditions` field contains a map of track names to video decoder configurat
 See the [WebCodecs specification](https://www.w3.org/TR/webcodecs/#video-decoder-config) for specifics and registered codecs.
 Any Uint8Array fields are hex-encoded as a string.
 
+The `display` field is the size to render the video at, in pixels.
+It is separate from a rendition's `displayAspectWidth`/`displayAspectHeight` because changing it does not require reinitializing the decoder.
+
+In addition to the WebCodecs fields, each rendition MAY carry the fields common to audio and video ({{common}}) plus:
+
+~~~
+type VideoDecoderConfigExtensions = {
+	"displayAspectWidth": number | undefined,
+	"displayAspectHeight": number | undefined,
+}
+~~~
+
+`displayAspectWidth` and `displayAspectHeight` give the display aspect ratio of the media, stretching or shrinking the coded pixels.
+A consumer that understands neither field MUST assume square pixels, a 1:1 ratio.
+Both MUST be present together; a consumer that sees only one MUST ignore it.
+
 For example:
 
 ~~~
@@ -144,20 +159,23 @@ For example:
 	"renditions": {
 		"720p": {
 			"codec": "avc1.64001f",
+			"container": { "kind": "legacy" },
 			"codedWidth": 1280,
 			"codedHeight": 720,
 			"bitrate": 6000000,
-			"framerate": 30.0
+			"framerate": 30.0,
+			"jitter": 33
 		},
 		"480p": {
 			"codec": "avc1.64001e",
+			"container": { "kind": "legacy" },
 			"codedWidth": 848,
 			"codedHeight": 480,
 			"bitrate": 2000000,
-			"framerate": 30.0
+			"framerate": 30.0,
+			"jitter": 33
 		}
 	},
-	"priority": 2,
 	"display": {
 		"width": 1280,
 		"height": 720
@@ -174,13 +192,14 @@ An audio track contains the necessary information to decode an audio stream.
 ~~~
 type AudioSchema = {
 	"renditions": Map<TrackName, AudioDecoderConfig>,
-	"priority": u8,
 }
 ~~~
 
 The `renditions` field contains a map of track names to audio decoder configurations.
 See the [WebCodecs specification](https://www.w3.org/TR/webcodecs/#audio-decoder-config) for specifics and registered codecs.
 Any Uint8Array fields are hex-encoded as a string.
+
+In addition to the WebCodecs fields, each rendition MAY carry the fields common to audio and video ({{common}}).
 
 For example:
 
@@ -189,32 +208,100 @@ For example:
 	"renditions": {
 		"stereo": {
 			"codec": "opus",
+			"container": { "kind": "legacy" },
 			"sampleRate": 48000,
 			"numberOfChannels": 2,
-			"bitrate": 128000
+			"bitrate": 128000,
+			"jitter": 20
 		},
 		"mono": {
 			"codec": "opus",
+			"container": { "kind": "legacy" },
 			"sampleRate": 48000,
 			"numberOfChannels": 1,
-			"bitrate": 64000
+			"bitrate": 64000,
+			"jitter": 20
 		}
 	},
-	"priority": 1,
 }
 ~~~
 
-# Container
-Audio and video tracks use a lightweight container to encapsulate the media payload.
+## Common Rendition Fields {#common}
+Audio and video renditions share the following fields, extending the WebCodecs decoder config:
+
+~~~
+type CommonExtensions = {
+	"broadcast": string | undefined,
+	"container": Container,
+	"jitter": number | undefined,
+}
+~~~
+
+### broadcast {#field-broadcast}
+By default a rendition's track lives in the same broadcast that served the catalog.
+The `broadcast` field overrides that, naming a different broadcast that publishes the track.
+
+The value is a relative path, resolved against the path of the broadcast that served the catalog.
+It uses the `.` and `..` semantics of a relative URL reference ({{!RFC3986, Section 5.2.4}}), for example `../source`.
+A publisher MUST NOT use an absolute path, and a consumer MUST ignore a rendition whose `broadcast` escapes above the root.
+
+This lets a publisher author a catalog that points at tracks it does not republish.
+For example, a transcoder produces a catalog listing its own downstream renditions alongside the untouched source rendition, referencing the latter in the source broadcast rather than copying the bytes through.
+
+A consumer subscribes to such a rendition in the referenced broadcast, using the rendition's track name unchanged.
+
+### container {#field-container}
+The container used to frame this rendition's media, as described in {{container}}.
+If absent, it defaults to `{ "kind": "legacy" }`.
+
+### jitter {#field-jitter}
+The maximum delay, in milliseconds, between a frame being ready and the publisher flushing it.
+A consumer's jitter buffer SHOULD be at least this large to avoid stalling.
+If absent, a consumer SHOULD assume each frame is flushed immediately.
+
+For example:
+
+- If each frame is flushed immediately, a video track's `jitter` is `1000/framerate`.
+- If up to 3 B-frames may be emitted in a row, it is `3 * 1000/framerate`.
+- If frames are buffered into 2 second segments, it is `2000`.
+
+An audio frame's duration is codec dependent.
+AAC often uses 1024 samples per frame, so at 44100Hz an immediately-flushed track's `jitter` is 23.
+
+# Container {#container}
+Audio and video tracks use a container to encapsulate the media payload.
+A rendition declares its container via the `container` field of its catalog entry ({{common}}):
+
+~~~
+type Container =
+	{ "kind": "legacy" } |
+	{ "kind": "cmaf", "init": string } |
+	{ "kind": "loc" }
+~~~
+
+The `kind` field selects the framing; a consumer MUST ignore a rendition whose `kind` it does not recognize.
+Every container shares the same group rules:
 
 Each moq-lite group MUST start with a keyframe.
 If codec does not support delta frames (ex. audio), then a group MAY consist of multiple keyframes.
 Otherwise, a group MUST consist of a single keyframe followed by zero or more delta frames.
 
+## legacy
+The default, used when the `container` field is absent.
+
 Each frame starts with a timestamp, a QUIC variable-length integer (62-bit max) encoded in microseconds.
 The remainder of the payload is codec specific; see the WebCodecs specification for specifics.
 
 For example, h.264 with no `description` field would be annex.b encoded, while h.264 with a `description` field would be AVCC encoded.
+
+## cmaf
+Each frame is a complete fragmented MP4 fragment (`moof`+`mdat`), carrying its own timestamps.
+
+The `init` field is the initialization segment (`ftyp`+`moov`) for the track, base64-encoded ({{!RFC4648, Section 4}}).
+A consumer MUST feed `init` to the decoder before the first frame.
+
+## loc
+Each frame is a Low Overhead Container frame {{!I-D.ietf-moq-loc}}: a property block, carrying the timestamp among other properties, followed by the codec payload.
 
 
 # Security Considerations

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -59,30 +59,20 @@ fn create_track(broadcast: &mut moq_net::broadcast::Producer) -> anyhow::Result<
 	video_config.framerate = Some(30.0);
 	video_config.container = hang::catalog::Container::Legacy;
 
-	// Create a map of video renditions
-	// Multiple renditions allow the viewer to choose based on their capabilities
-	let mut renditions = std::collections::BTreeMap::new();
-	renditions.insert(video_track.to_string(), video_config);
-
 	// Create the catalog describing our video track.
-	let catalog = hang::catalog::Catalog {
-		video: hang::catalog::Video {
-			renditions,
-			display: None,
-			rotation: None,
-			flip: None,
-		},
-		..Default::default()
-	};
+	// Multiple renditions allow the viewer to choose based on their capabilities.
+	let mut catalog = hang::catalog::Catalog::default();
+	catalog.video.insert(video_track, video_config)?;
 
 	// Publish the catalog as a "catalog.json" track in the broadcast.
 	let mut catalog_track = broadcast.create_track(hang::Catalog::DEFAULT_NAME, hang::Catalog::default_track_info())?;
 	let mut group = catalog_track.append_group()?;
-	group.write_frame(moq_net::Timestamp::now(), catalog.to_string()?)?;
+	group.write_frame(moq_net::Timestamp::now(), catalog.to_json()?)?;
 	group.finish()?;
 
 	// Actually create the media track now.
-	let track = broadcast.create_track(video_track, None)?;
+	// track_info() pins the microsecond timescale that the legacy container encodes with.
+	let track = broadcast.create_track(video_track, hang::container::track_info())?;
 
 	Ok(track)
 }

--- a/rs/hang/src/catalog/audio/mod.rs
+++ b/rs/hang/src/catalog/audio/mod.rs
@@ -16,10 +16,16 @@ use crate::catalog::Container;
 /// Information about an audio track in the catalog.
 ///
 /// This struct contains a map of renditions (different quality/codec options)
+///
+/// Marked `#[non_exhaustive]` so additional optional fields can be added without
+/// bumping the major version. External callers start from [`Audio::default`] and
+/// fill in what they need ([`insert`](Self::insert) for renditions); struct-literal
+/// construction (with or without `..base`) is not available outside this crate.
 #[serde_with::serde_as]
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct Audio {
 	/// A map of track name to rendition configuration.
 	/// This is not an array so it will work with JSON Merge Patch.

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -9,10 +9,16 @@ use serde::{Deserialize, Serialize};
 /// their own root sections (e.g. `scte35`) by flattening this struct into their own with
 /// `#[serde(flatten)]`. The catalog does not deny unknown fields, so a base consumer ignores the
 /// extra sections and an extended catalog stays wire-compatible. See the `extension_roundtrip` test.
+///
+/// Marked `#[non_exhaustive]` so a future base section can be added without bumping the major
+/// version. External callers start from [`Catalog::default`] and fill in the sections they
+/// publish; struct-literal construction (with or without `..base`) is not available outside
+/// this crate.
 #[serde_with::serde_as]
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(default, rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct Catalog {
 	/// Video track information with multiple renditions.
 	///
@@ -55,13 +61,13 @@ impl Catalog {
 		Ok(serde_json::from_reader(reader)?)
 	}
 
-	/// Serialize the catalog to a string.
-	pub fn to_string(&self) -> Result<String> {
+	/// Serialize the catalog to a JSON string.
+	pub fn to_json(&self) -> Result<String> {
 		Ok(serde_json::to_string(self)?)
 	}
 
-	/// Serialize the catalog to a pretty string.
-	pub fn to_string_pretty(&self) -> Result<String> {
+	/// Serialize the catalog to a pretty-printed JSON string.
+	pub fn to_json_pretty(&self) -> Result<String> {
 		Ok(serde_json::to_string_pretty(self)?)
 	}
 
@@ -150,22 +156,14 @@ mod test {
 		let mut audio_renditions = BTreeMap::new();
 		audio_renditions.insert("audio".to_string(), audio_config);
 
-		let decoded = Catalog {
-			video: Video {
-				renditions: video_renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			audio: Audio {
-				renditions: audio_renditions,
-			},
-		};
+		let mut decoded = Catalog::default();
+		decoded.video.renditions = video_renditions;
+		decoded.audio.renditions = audio_renditions;
 
 		let output = Catalog::from_str(&encoded).expect("failed to decode");
 		assert_eq!(decoded, output, "wrong decoded output");
 
-		let output = decoded.to_string().expect("failed to encode");
+		let output = decoded.to_json().expect("failed to encode");
 		assert_eq!(encoded, output, "wrong encoded output");
 	}
 
@@ -241,22 +239,14 @@ mod test {
 			},
 		);
 
-		let catalog = Catalog {
-			video: Video {
-				renditions: video_renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			audio: Audio {
-				renditions: audio_renditions,
-			},
-		};
+		let mut catalog = Catalog::default();
+		catalog.video.renditions = video_renditions;
+		catalog.audio.renditions = audio_renditions;
 
 		let decoded = Catalog::from_str(&encoded).expect("failed to decode");
 		assert_eq!(catalog, decoded, "decode mismatch");
 
-		let output = catalog.to_string().expect("failed to encode");
+		let output = catalog.to_json().expect("failed to encode");
 		assert_eq!(encoded, output, "encode mismatch");
 	}
 
@@ -288,7 +278,7 @@ mod test {
 
 		// Full encode -> decode -> equality, so the test catches any encoder regression
 		// (e.g. wrong key, double-emission, or `null` instead of skip).
-		let output = parsed.to_string().expect("failed to encode");
+		let output = parsed.to_json().expect("failed to encode");
 		let reparsed = Catalog::from_str(&output).expect("failed to re-decode");
 		assert_eq!(parsed, reparsed, "re-encoded catalog did not round-trip");
 	}
@@ -316,7 +306,7 @@ mod test {
 			..Default::default()
 		};
 
-		let output = catalog.to_string().expect("failed to encode");
+		let output = catalog.to_json().expect("failed to encode");
 		assert!(
 			!output.contains("broadcast"),
 			"broadcast field leaked into JSON when None: {output}"

--- a/rs/hang/src/catalog/video/mod.rs
+++ b/rs/hang/src/catalog/video/mod.rs
@@ -22,10 +22,16 @@ use crate::catalog::Container;
 ///
 /// This struct contains a map of renditions (different quality/codec options)
 /// and optional metadata like detection, display settings, rotation, and flip.
+///
+/// Marked `#[non_exhaustive]` so additional optional fields can be added without
+/// bumping the major version. External callers start from [`Video::default`] and
+/// fill in what they need ([`insert`](Self::insert) for renditions); struct-literal
+/// construction (with or without `..base`) is not available outside this crate.
 #[serde_with::serde_as]
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct Video {
 	/// A map of track name to rendition configuration.
 	/// This is not an array in order for it to work with JSON Merge Patch.

--- a/rs/hang/src/container/frame.rs
+++ b/rs/hang/src/container/frame.rs
@@ -53,8 +53,8 @@ impl Frame {
 	/// different source scale (e.g. nanoseconds from MKV) can decode without knowing
 	/// the producer's internal scale. Inverse of [`Self::decode`].
 	pub fn encode(&self, buf: &mut impl BufMut) -> Result<(), Error> {
-		buf.put(self.header()?);
-		buf.put(self.payload.clone());
+		self.encode_header(buf)?;
+		buf.put_slice(&self.payload);
 		Ok(())
 	}
 
@@ -77,7 +77,10 @@ impl Frame {
 	/// the moq-net frame timestamp so moq-lite-05 and later can delta-encode it on the wire
 	/// independently of the container-level prefix.
 	pub fn write_to(&self, group: &mut moq_net::group::Producer) -> Result<(), Error> {
-		let header = self.header()?;
+		let mut header = BytesMut::new();
+		self.encode_header(&mut header)?;
+		let header = header.freeze();
+
 		let size = (header.len() + self.payload.len()) as u64;
 
 		// `create_frame` converts the timestamp into the track's timescale; older drafts
@@ -94,15 +97,13 @@ impl Frame {
 		Ok(())
 	}
 
-	/// The VarInt timestamp prefix, normalized to [`TIMESCALE`].
-	fn header(&self) -> Result<Bytes, Error> {
+	/// Write the VarInt timestamp prefix, normalized to [`TIMESCALE`].
+	fn encode_header(&self, buf: &mut impl BufMut) -> Result<(), Error> {
 		let timestamp = self.timestamp.convert(TIMESCALE)?;
 		let value = VarInt::try_from(timestamp.value()).map_err(moq_net::Error::from)?;
+		value.encode_quic(buf).map_err(moq_net::Error::from)?;
 
-		let mut header = BytesMut::new();
-		value.encode_quic(&mut header).map_err(moq_net::Error::from)?;
-
-		Ok(header.freeze())
+		Ok(())
 	}
 }
 

--- a/rs/hang/src/container/frame.rs
+++ b/rs/hang/src/container/frame.rs
@@ -1,4 +1,4 @@
-use bytes::{Buf, Bytes, BytesMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use derive_more::Debug;
 use moq_net::VarInt;
 
@@ -11,6 +11,18 @@ pub use moq_net::{Timescale, Timestamp};
 /// The legacy container's on-wire timestamp is a single VarInt with no scale tag,
 /// so encoders normalize to this scale and decoders attach it.
 pub const TIMESCALE: Timescale = Timescale::MICRO;
+
+/// Track properties for creating a track that carries [`Frame`]s, via
+/// [`create_track`](moq_net::broadcast::Producer::create_track) or
+/// [`accept`](moq_net::track::Request::accept).
+///
+/// This pins the track's timescale to [`TIMESCALE`]. `moq_net::track::Info::default()`
+/// is milliseconds, which would quantize the net-level frame timestamps that
+/// moq-lite-05 and later delta-encode on the wire, even though the container prefix
+/// stays at microseconds.
+pub fn track_info() -> moq_net::track::Info {
+	moq_net::track::Info::default().with_timescale(TIMESCALE)
+}
 
 /// A media frame with a timestamp and codec-specific payload.
 ///
@@ -35,45 +47,101 @@ pub struct Frame {
 }
 
 impl Frame {
-	/// Encode the frame to the given group as a single moq-lite frame:
-	/// VarInt timestamp prefix followed by the raw codec payload.
+	/// Encode the frame: VarInt timestamp prefix followed by the raw codec payload.
 	///
-	/// The timestamp is normalized to [`TIMESCALE`] (microseconds) on the wire so
-	/// peers using a different source scale (e.g. nanoseconds from MKV) can decode
-	/// without knowing the producer's internal scale.
-	pub fn encode(&self, group: &mut moq_net::group::Producer) -> Result<(), Error> {
-		let timestamp = self.timestamp.convert(TIMESCALE)?;
-		let value = VarInt::try_from(timestamp.value()).map_err(moq_net::Error::from)?;
-
-		let mut header = BytesMut::new();
-		value.encode_quic(&mut header).map_err(moq_net::Error::from)?;
-
-		let size = (header.len() + self.payload.len()) as u64;
-
-		// Stamp the moq-net frame timestamp too so Lite05+ can delta-encode it on the
-		// wire independently of the container-level prefix. `create_frame` converts it
-		// into the track's timescale; older drafts simply don't put it on the wire.
-		let net_frame = moq_net::frame::Info {
-			size,
-			timestamp: self.timestamp,
-		};
-		let mut chunked = group.create_frame(net_frame)?;
-		chunked.write(header.freeze())?;
-		chunked.write(self.payload.clone())?;
-		chunked.finish()?;
-
+	/// The timestamp is normalized to [`TIMESCALE`] (microseconds) so peers using a
+	/// different source scale (e.g. nanoseconds from MKV) can decode without knowing
+	/// the producer's internal scale. Inverse of [`Self::decode`].
+	pub fn encode(&self, buf: &mut impl BufMut) -> Result<(), Error> {
+		buf.put(self.header()?);
+		buf.put(self.payload.clone());
 		Ok(())
 	}
 
 	/// Decode a frame from raw bytes (VarInt timestamp prefix + payload).
 	///
 	/// Attaches [`TIMESCALE`] (microseconds) to the decoded timestamp, matching what
-	/// [`Self::encode`] writes.
+	/// [`Self::encode`] writes. Inverse of [`Self::encode`].
 	pub fn decode(mut buf: impl Buf) -> Result<Self, Error> {
 		let value: u64 = VarInt::decode_quic(&mut buf).map_err(moq_net::Error::from)?.into();
 		let timestamp = Timestamp::new(value, TIMESCALE)?;
 		let payload = buf.copy_to_bytes(buf.remaining());
 
 		Ok(Self { timestamp, payload })
+	}
+
+	/// Write the frame to `group` as a single moq-lite frame, in the [`Self::encode`] format.
+	///
+	/// Prefer this over [`Self::encode`] when writing to a group: it streams the header and
+	/// payload as separate chunks rather than copying the payload into one buffer, and stamps
+	/// the moq-net frame timestamp so moq-lite-05 and later can delta-encode it on the wire
+	/// independently of the container-level prefix.
+	pub fn write_to(&self, group: &mut moq_net::group::Producer) -> Result<(), Error> {
+		let header = self.header()?;
+		let size = (header.len() + self.payload.len()) as u64;
+
+		// `create_frame` converts the timestamp into the track's timescale; older drafts
+		// simply don't put it on the wire.
+		let info = moq_net::frame::Info {
+			size,
+			timestamp: self.timestamp,
+		};
+		let mut chunked = group.create_frame(info)?;
+		chunked.write(header)?;
+		chunked.write(self.payload.clone())?;
+		chunked.finish()?;
+
+		Ok(())
+	}
+
+	/// The VarInt timestamp prefix, normalized to [`TIMESCALE`].
+	fn header(&self) -> Result<Bytes, Error> {
+		let timestamp = self.timestamp.convert(TIMESCALE)?;
+		let value = VarInt::try_from(timestamp.value()).map_err(moq_net::Error::from)?;
+
+		let mut header = BytesMut::new();
+		value.encode_quic(&mut header).map_err(moq_net::Error::from)?;
+
+		Ok(header.freeze())
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn encode_decode_roundtrip() {
+		let frame = Frame {
+			timestamp: Timestamp::from_micros(1_234_567).expect("timestamp"),
+			payload: Bytes::from_static(b"hello"),
+		};
+
+		let mut buf = BytesMut::new();
+		frame.encode(&mut buf).expect("encode");
+
+		let decoded = Frame::decode(buf.freeze()).expect("decode");
+		assert_eq!(decoded.timestamp, frame.timestamp);
+		assert_eq!(decoded.payload, frame.payload);
+	}
+
+	#[test]
+	fn encode_normalizes_timescale() {
+		// A nanosecond-scale source (e.g. MKV) still lands on the wire as microseconds.
+		let frame = Frame {
+			timestamp: Timestamp::new(1_234_567_000, Timescale::NANO).expect("timestamp"),
+			payload: Bytes::from_static(b"hello"),
+		};
+
+		let mut buf = BytesMut::new();
+		frame.encode(&mut buf).expect("encode");
+
+		let decoded = Frame::decode(buf.freeze()).expect("decode");
+		assert_eq!(decoded.timestamp, Timestamp::from_micros(1_234_567).expect("timestamp"));
+	}
+
+	#[test]
+	fn track_info_uses_container_timescale() {
+		assert_eq!(track_info().timescale, TIMESCALE);
 	}
 }

--- a/rs/hang/src/error.rs
+++ b/rs/hang/src/error.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 #[non_exhaustive]
 pub enum Error {
 	/// An error from the underlying MoQ transport layer.
-	#[error("moq lite error: {0}")]
+	#[error("moq error: {0}")]
 	Moq(#[from] moq_net::Error),
 
 	/// JSON serialization/deserialization error.

--- a/rs/moq-audio/src/producer.rs
+++ b/rs/moq-audio/src/producer.rs
@@ -67,10 +67,7 @@ impl<E: CatalogExt> AudioProducer<E> {
 		// Audio hang frames carry microsecond timestamps; advertise that on the
 		// track so Lite05 subscribers know what scale to expect and the model
 		// layer accepts Frame::timestamp on append.
-		let track = broadcast.create_track(
-			name.clone(),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)?;
+		let track = broadcast.create_track(name.clone(), hang::container::track_info())?;
 		let track = catalog.media_producer(track, moq_mux::container::legacy::Wire);
 
 		let mut catalog_mut = catalog.clone();

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -488,10 +488,7 @@ mod tests {
 
 		// Section-framed verbatim stream (SCTE-35, stream_type 0x86).
 		let section = broadcast
-			.unique_track(
-				".scte35",
-				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-			)
+			.unique_track(".scte35", hang::container::track_info())
 			.unwrap();
 		let mut section_track = tscat::Track::new(SECTION_PID);
 		section_track.verbatim = Some(tscat::Verbatim::new(0x86, tscat::Framing::Section));
@@ -517,12 +514,7 @@ mod tests {
 
 		// PES-framed verbatim stream (undecoded private data, stream_type 0x06), with
 		// an explicit PES stream_id to round-trip.
-		let pes = broadcast
-			.unique_track(
-				".data",
-				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-			)
-			.unwrap();
+		let pes = broadcast.unique_track(".data", hang::container::track_info()).unwrap();
 		let mut verbatim = tscat::Verbatim::new(0x06, tscat::Framing::Pes);
 		verbatim.stream_id = Some(VERBATIM_PES_STREAM_ID);
 		let mut pes_track = tscat::Track::new(VERBATIM_PES_PID);

--- a/rs/moq-gst/src/sink/pad.rs
+++ b/rs/moq-gst/src/sink/pad.rs
@@ -117,8 +117,7 @@ impl Pad {
 				// directly and lifts it into a `Track` via `.into()`.
 				let name = broadcast.unique_name(".mp3");
 				let request = broadcast.reserve_track(name)?;
-				let producer =
-					request.accept(moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE));
+				let producer = request.accept(hang::container::track_info());
 				moq_mux::codec::mp3::Import::new(producer, catalog.reserve(), config.into()).into()
 			}
 			"audio/mpeg" => {
@@ -149,8 +148,7 @@ impl Pad {
 				// importer directly and lifts it into a `Track` via `.into()`.
 				let name = broadcast.unique_name(".opus");
 				let request = broadcast.reserve_track(name)?;
-				let producer =
-					request.accept(moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE));
+				let producer = request.accept(hang::container::track_info());
 				moq_mux::codec::opus::Import::new(producer, catalog.reserve(), config.into()).into()
 			}
 			other => anyhow::bail!("unsupported caps: {other}"),

--- a/rs/moq-mux/src/catalog/hang/ext.rs
+++ b/rs/moq-mux/src/catalog/hang/ext.rs
@@ -108,10 +108,10 @@ pub struct Catalog<E: CatalogExt = ()> {
 impl<E: CatalogExt> Catalog<E> {
 	/// The base catalog carrying just the media sections, used to derive the MSF track.
 	pub(crate) fn media(&self) -> hang::Catalog {
-		hang::Catalog {
-			video: self.video.clone(),
-			audio: self.audio.clone(),
-		}
+		let mut catalog = hang::Catalog::default();
+		catalog.video = self.video.clone();
+		catalog.audio = self.audio.clone();
+		catalog
 	}
 }
 

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -449,7 +449,7 @@ mod test {
 	use std::task::Poll;
 
 	use bytes::Bytes;
-	use hang::catalog::{Audio, AudioCodec, AudioConfig, Container, H264, Video, VideoConfig};
+	use hang::catalog::{AudioCodec, AudioConfig, Container, H264, VideoConfig};
 
 	use super::*;
 
@@ -624,17 +624,9 @@ mod test {
 		let mut audio_renditions = BTreeMap::new();
 		audio_renditions.insert("audio0".to_string(), audio_config);
 
-		let catalog = hang::Catalog {
-			video: Video {
-				renditions: video_renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			audio: Audio {
-				renditions: audio_renditions,
-			},
-		};
+		let mut catalog = hang::Catalog::default();
+		catalog.video.renditions = video_renditions;
+		catalog.audio.renditions = audio_renditions;
 
 		let msf = to_msf(&catalog);
 
@@ -684,15 +676,8 @@ mod test {
 		let mut video_renditions = BTreeMap::new();
 		video_renditions.insert("video0.m4s".to_string(), video_config);
 
-		let catalog = hang::Catalog {
-			video: Video {
-				renditions: video_renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			..Default::default()
-		};
+		let mut catalog = hang::Catalog::default();
+		catalog.video.renditions = video_renditions;
 
 		let msf = to_msf(&catalog);
 		let video = &msf.tracks[0];
@@ -726,15 +711,8 @@ mod test {
 		let mut video_renditions = BTreeMap::new();
 		video_renditions.insert("video0.m4s".to_string(), video_config);
 
-		let catalog = hang::Catalog {
-			video: Video {
-				renditions: video_renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			..Default::default()
-		};
+		let mut catalog = hang::Catalog::default();
+		catalog.video.renditions = video_renditions;
 
 		let msf = to_msf(&catalog);
 		let video = &msf.tracks[0];
@@ -766,17 +744,9 @@ mod test {
 		let mut audio_renditions = BTreeMap::new();
 		audio_renditions.insert("audio0".to_string(), audio_config);
 
-		let catalog = hang::Catalog {
-			video: Video {
-				renditions: video_renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			audio: Audio {
-				renditions: audio_renditions,
-			},
-		};
+		let mut catalog = hang::Catalog::default();
+		catalog.video.renditions = video_renditions;
+		catalog.audio.renditions = audio_renditions;
 
 		let msf = to_msf(&catalog);
 
@@ -815,15 +785,8 @@ mod test {
 		let mut video_renditions = BTreeMap::new();
 		video_renditions.insert("video0".to_string(), video_config);
 
-		let catalog = hang::Catalog {
-			video: Video {
-				renditions: video_renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			..Default::default()
-		};
+		let mut catalog = hang::Catalog::default();
+		catalog.video.renditions = video_renditions;
 
 		let msf = to_msf(&catalog);
 		let video = &msf.tracks[0];
@@ -844,15 +807,8 @@ mod test {
 		let mut video_renditions = BTreeMap::new();
 		video_renditions.insert("video0".to_string(), video_config);
 
-		let catalog = hang::Catalog {
-			video: Video {
-				renditions: video_renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			..Default::default()
-		};
+		let mut catalog = hang::Catalog::default();
+		catalog.video.renditions = video_renditions;
 
 		let msf = to_msf(&catalog);
 		let video = &msf.tracks[0];

--- a/rs/moq-mux/src/codec/h264/export.rs
+++ b/rs/moq-mux/src/codec/h264/export.rs
@@ -183,11 +183,10 @@ impl<S: Stream> Export<S> {
 
 #[cfg(test)]
 mod tests {
-	use std::collections::BTreeMap;
 	use std::task::Poll;
 
 	use bytes::Bytes;
-	use hang::catalog::{H264, Video, VideoConfig};
+	use hang::catalog::{H264, VideoConfig};
 
 	use super::*;
 	use crate::catalog::Stream;
@@ -217,18 +216,9 @@ mod tests {
 		config.description = Some(avcc);
 		config.container = hang::catalog::Container::Legacy;
 
-		let mut renditions = BTreeMap::new();
-		renditions.insert(name.to_string(), config);
-
-		Catalog {
-			video: Video {
-				renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			..Default::default()
-		}
+		let mut catalog = Catalog::default();
+		catalog.video.insert(name, config).expect("duplicate rendition");
+		catalog
 	}
 
 	/// Build a minimal avcC carrying one SPS + one PPS.
@@ -277,10 +267,7 @@ mod tests {
 		// Producer side: publish the broadcast with one length-prefixed video track.
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut track = broadcast
-			.create_track(
-				"video.m4s",
-				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-			)
+			.create_track("video.m4s", hang::container::track_info())
 			.unwrap();
 
 		// Group 0 (keyframe-starting group): one IDR frame.

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -281,12 +281,7 @@ mod tests {
 	fn setup(name: &str) -> (moq_net::track::Producer, crate::catalog::Producer) {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-		let track = broadcast
-			.create_track(
-				name,
-				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-			)
-			.unwrap();
+		let track = broadcast.create_track(name, hang::container::track_info()).unwrap();
 		(track, catalog)
 	}
 

--- a/rs/moq-mux/src/codec/h265/export.rs
+++ b/rs/moq-mux/src/codec/h265/export.rs
@@ -176,11 +176,10 @@ impl<S: Stream> Export<S> {
 
 #[cfg(test)]
 mod tests {
-	use std::collections::BTreeMap;
 	use std::task::Poll;
 
 	use bytes::{Bytes, BytesMut};
-	use hang::catalog::{H265, Video, VideoConfig};
+	use hang::catalog::{H265, VideoConfig};
 
 	use super::*;
 	use crate::catalog::Stream;
@@ -211,18 +210,9 @@ mod tests {
 		config.description = Some(hvcc);
 		config.container = hang::catalog::Container::Legacy;
 
-		let mut renditions = BTreeMap::new();
-		renditions.insert(name.to_string(), config);
-
-		Catalog {
-			video: Video {
-				renditions,
-				display: None,
-				rotation: None,
-				flip: None,
-			},
-			..Default::default()
-		}
+		let mut catalog = Catalog::default();
+		catalog.video.insert(name, config).expect("duplicate rendition");
+		catalog
 	}
 
 	fn hvcc(vps: &[u8], sps: &[u8], pps: &[u8]) -> Bytes {
@@ -268,10 +258,7 @@ mod tests {
 		let catalog = hvc1_catalog("video.hvc1", hvcc(vps, sps, pps));
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut track = broadcast
-			.create_track(
-				"video.hvc1",
-				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-			)
+			.create_track("video.hvc1", hang::container::track_info())
 			.unwrap();
 
 		let mut g0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();

--- a/rs/moq-mux/src/codec/legacy.rs
+++ b/rs/moq-mux/src/codec/legacy.rs
@@ -120,8 +120,8 @@ pub(crate) struct Import<E: CatalogExt = ()> {
 
 impl<E: CatalogExt> Import<E> {
 	/// Publish on an existing track, reserving the rendition from `reserved`. Mint the
-	/// track at the descriptor's suffix and the microsecond
-	/// [`hang::container::TIMESCALE`] (e.g. via [`crate::import::unique_track`]).
+	/// track at the descriptor's suffix with [`hang::container::track_info`] (e.g. via
+	/// [`crate::import::unique_track`]).
 	pub fn new(
 		descriptor: &'static Descriptor,
 		track: moq_net::track::Producer,

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -148,12 +148,7 @@ mod tests {
 	fn setup() -> (moq_net::track::Producer, crate::catalog::Producer) {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-		let track = broadcast
-			.create_track(
-				"0.vp8",
-				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-			)
-			.unwrap();
+		let track = broadcast.create_track("0.vp8", hang::container::track_info()).unwrap();
 		(track, catalog)
 	}
 

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -151,12 +151,7 @@ mod tests {
 	fn setup() -> (moq_net::track::Producer, crate::catalog::Producer) {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
-		let track = broadcast
-			.create_track(
-				"0.vp9",
-				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-			)
-			.unwrap();
+		let track = broadcast.create_track("0.vp9", hang::container::track_info()).unwrap();
 		(track, catalog)
 	}
 

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -761,10 +761,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn read_single_group() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -782,10 +779,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn read_multiple_frames_single_group() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -803,10 +797,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn read_multiple_groups_within_latency() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -825,10 +816,7 @@ mod tests {
 	#[tokio::test]
 	async fn latency_skip_delivers_recent_groups() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
@@ -870,10 +858,7 @@ mod tests {
 	#[tokio::test]
 	async fn zero_latency_skips_aggressively() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::ZERO);
 
@@ -912,10 +897,7 @@ mod tests {
 	#[tokio::test]
 	async fn latency_skip_correctness() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
@@ -984,10 +966,7 @@ mod tests {
 	#[tokio::test]
 	async fn reset_keeps_out_of_order_new_group() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
 
@@ -1026,10 +1005,7 @@ mod tests {
 	#[tokio::test]
 	async fn reset_detected_behind_forward_newest_group() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
 
@@ -1064,10 +1040,7 @@ mod tests {
 	#[tokio::test]
 	async fn backwards_timestamp_resets_buffer() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		// Large latency so the slow-group skip never fires; isolate the rewind path.
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
@@ -1093,10 +1066,7 @@ mod tests {
 	/// configuration. Here group 2 rewinds the timeline and bumps the discontinuity counter.
 	#[tokio::test]
 	async fn backwards_timestamp_always_resets() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
 
@@ -1131,10 +1101,7 @@ mod tests {
 	/// last (a group's end) -- and a publisher emitting them must not break us.
 	#[tokio::test]
 	async fn empty_payload_is_skipped() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -1163,10 +1130,7 @@ mod tests {
 	/// read, so a stall or an infinite loop fails this rather than hanging forever.
 	#[tokio::test]
 	async fn consecutive_markers_do_not_stall() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -1199,10 +1163,7 @@ mod tests {
 	#[tokio::test]
 	async fn groups_delivered_in_sequence_order() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -1238,10 +1199,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn adjacent_group_flushed_immediately() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -1259,10 +1217,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn bframes_within_group() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -1281,10 +1236,7 @@ mod tests {
 	#[tokio::test]
 	async fn empty_track_returns_none() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -1302,10 +1254,7 @@ mod tests {
 	#[tokio::test]
 	async fn track_closed_with_error() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -1328,10 +1277,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn gap_in_group_sequence_recovery() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
@@ -1349,10 +1295,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn gap_at_start_of_sequence() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(80));
 
@@ -1375,10 +1318,7 @@ mod tests {
 	/// group + the sequences after it evict, then it resumes).
 	#[tokio::test]
 	async fn evicted_group_with_gap_skips_to_live() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
@@ -1421,10 +1361,7 @@ mod tests {
 	/// higher group is buffered, and the track never finishes.
 	#[tokio::test]
 	async fn missing_sequence_skips_on_live_track() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
@@ -1523,10 +1460,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn frame_timestamp_and_index_decoding() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -1546,10 +1480,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn frame_payload_preserved() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -1587,10 +1518,7 @@ mod tests {
 	#[tokio::test]
 	async fn no_infinite_loop_with_buffered_frames() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
 
@@ -1636,10 +1564,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn large_timestamps() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(3700));
 
@@ -1655,10 +1580,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn set_latency_changes_behavior() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_secs(10));
 
@@ -1676,10 +1598,7 @@ mod tests {
 	#[tokio::test]
 	async fn max_timestamp_tracks_through_bframes() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		// latency must exceed (group1_max - group0_min) = 100ms - 0ms = 100ms
 		// to avoid the latency skip and test B-frame timestamp tracking.
@@ -1731,10 +1650,7 @@ mod tests {
 	#[tokio::test]
 	async fn startup_selects_earliest_group() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
@@ -1787,10 +1703,7 @@ mod tests {
 	#[tokio::test]
 	async fn startup_skips_groups_without_data() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -1813,10 +1726,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn startup_single_group_mid_stream() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -1830,10 +1740,7 @@ mod tests {
 	#[tokio::test]
 	async fn multiple_sequential_latency_skips() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(50));
 
@@ -1869,10 +1776,7 @@ mod tests {
 	#[tokio::test]
 	async fn latency_skip_boundary_exact() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
@@ -1910,10 +1814,7 @@ mod tests {
 	#[tokio::test]
 	async fn single_newer_group_triggers_skip() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
@@ -1951,10 +1852,7 @@ mod tests {
 	#[tokio::test]
 	async fn single_missing_sequence_near_eof_skips() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
@@ -1970,10 +1868,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn group_error_skips_to_next() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -1990,10 +1885,7 @@ mod tests {
 	#[tokio::test]
 	async fn track_finishes_while_reading() {
 		tokio::time::pause();
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -2022,10 +1914,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn empty_group_advances() {
-		let mut track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("test", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 
@@ -2045,10 +1934,7 @@ mod tests {
 	async fn video_container_legacy() {
 		tokio::time::pause();
 
-		let mut track = track_producer(
-			"video",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let mut track = track_producer("video", hang::container::track_info());
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
 

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -541,10 +541,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			old.track.finish()?;
 			self.catalog.lock().video.renditions.remove(old.track.name());
 		}
-		Ok(self.broadcast.unique_track(
-			".flv-v",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)?)
+		Ok(self.broadcast.unique_track(".flv-v", hang::container::track_info())?)
 	}
 
 	/// Drop any existing audio track `track_id` (finishing it and clearing its
@@ -554,10 +551,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			old.track.finish()?;
 			self.catalog.lock().audio.renditions.remove(old.track.name());
 		}
-		Ok(self.broadcast.unique_track(
-			".flv-a",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)?)
+		Ok(self.broadcast.unique_track(".flv-a", hang::container::track_info())?)
 	}
 
 	/// Close the current group on every track and reopen at `sequence`.

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -25,10 +25,7 @@ async fn avc3_source_to_cmaf_export_roundtrip() {
 
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let track = producer
-		.create_track(
-			producer.unique_name(".avc3"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(producer.unique_name(".avc3"), hang::container::track_info())
 		.unwrap();
 	let mut config = VideoConfig::new(H264 {
 		profile: 0x42,
@@ -129,10 +126,7 @@ async fn legacy_aac_source_to_cmaf_export_synthesizes_esds() {
 
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let track = producer
-		.create_track(
-			producer.unique_name(".aac"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(producer.unique_name(".aac"), hang::container::track_info())
 		.unwrap();
 
 	// AAC-LC (profile 2), 44100 Hz, stereo. The TS importer sets `description`
@@ -224,10 +218,7 @@ async fn vp8_source_to_cmaf_export_synthesizes_vp08() {
 
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let track = producer
-		.create_track(
-			producer.unique_name(".vp8"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(producer.unique_name(".vp8"), hang::container::track_info())
 		.unwrap();
 	let mut config = VideoConfig::new(VideoCodec::VP8);
 	config.coded_width = Some(320);
@@ -302,10 +293,7 @@ async fn vp9_source_to_cmaf_export_synthesizes_vp09() {
 
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let track = producer
-		.create_track(
-			producer.unique_name(".vp9"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(producer.unique_name(".vp9"), hang::container::track_info())
 		.unwrap();
 	let mut config = VideoConfig::new(VP9 {
 		profile: 0,
@@ -392,10 +380,7 @@ async fn av1_source_to_cmaf_export_synthesizes_av01() {
 
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let track = producer
-		.create_track(
-			producer.unique_name(".av01"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(producer.unique_name(".av01"), hang::container::track_info())
 		.unwrap();
 	let mut config = VideoConfig::new(AV1 {
 		profile: 0,
@@ -622,10 +607,7 @@ async fn next_fragment_reports_segment_metadata() {
 
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let track = producer
-		.create_track(
-			producer.unique_name(".avc3"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(producer.unique_name(".avc3"), hang::container::track_info())
 		.unwrap();
 	let mut config = VideoConfig::new(H264 {
 		profile: 0x42,

--- a/rs/moq-mux/src/container/legacy/mod.rs
+++ b/rs/moq-mux/src/container/legacy/mod.rs
@@ -23,7 +23,7 @@ impl Container for Wire {
 				timestamp: frame.timestamp,
 				payload: frame.payload.clone(),
 			};
-			hang_frame.encode(group)?;
+			hang_frame.write_to(group)?;
 		}
 		Ok(())
 	}

--- a/rs/moq-mux/src/container/mkv/export_test.rs
+++ b/rs/moq-mux/src/container/mkv/export_test.rs
@@ -393,10 +393,7 @@ async fn export_rejects_cmaf_track() {
 
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let track = producer
-		.create_track(
-			producer.unique_name(".avc1"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(producer.unique_name(".avc1"), hang::container::track_info())
 		.unwrap();
 	let mut config = VideoConfig::new(H264 {
 		profile: 0x64,
@@ -439,10 +436,7 @@ async fn export_avc3_source_synthesizes_avcc_and_length_prefixes() {
 
 	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
 	let track = producer
-		.create_track(
-			producer.unique_name(".avc3"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(producer.unique_name(".avc3"), hang::container::track_info())
 		.unwrap();
 	let mut config = VideoConfig::new(H264 {
 		profile: 0x42,

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -270,10 +270,9 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			}
 		};
 
-		let track = self.broadcast.create_track(
-			self.broadcast.unique_name(suffix),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)?;
+		let track = self
+			.broadcast
+			.create_track(self.broadcast.unique_name(suffix), hang::container::track_info())?;
 		let mut catalog = self.catalog.clone();
 		let mut catalog = catalog.lock();
 

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -300,10 +300,7 @@ mod tests {
 	/// Explicit keyframe closes the current group and starts a new one.
 	#[tokio::test]
 	async fn keyframe_closes_group_immediately() {
-		let track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let track = track_producer("test", hang::container::track_info());
 		let consumer = track.subscribe(None);
 		let mut producer = Producer::new(track, Container::Legacy);
 
@@ -319,10 +316,7 @@ mod tests {
 	/// `cut()` flushes the current group immediately; the next write must be a keyframe.
 	#[tokio::test]
 	async fn cut_closes_immediately() {
-		let track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let track = track_producer("test", hang::container::track_info());
 		let consumer = track.subscribe(None);
 		let mut producer = Producer::new(track, Container::Legacy);
 
@@ -340,10 +334,7 @@ mod tests {
 	#[tokio::test]
 	#[allow(deprecated)]
 	async fn deprecated_finish_group_still_closes() {
-		let track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let track = track_producer("test", hang::container::track_info());
 		let consumer = track.subscribe(None);
 		let mut producer = Producer::new(track, Container::Legacy);
 
@@ -359,10 +350,7 @@ mod tests {
 	/// Writing a non-keyframe with no open group returns MissingKeyframe.
 	#[test]
 	fn first_frame_must_be_keyframe() {
-		let track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let track = track_producer("test", hang::container::track_info());
 		let mut producer = Producer::new(track, Container::Legacy);
 
 		let err = producer.write(frame(0, false)).unwrap_err();
@@ -381,10 +369,7 @@ mod tests {
 	/// `seek(n)` opens the next group at sequence `n`.
 	#[tokio::test]
 	async fn seek_uses_explicit_sequence() {
-		let track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let track = track_producer("test", hang::container::track_info());
 		let consumer = track.subscribe(None);
 		let mut producer = Producer::new(track, Container::Legacy);
 
@@ -399,10 +384,7 @@ mod tests {
 	/// `seek` is consumed on the next group creation; subsequent groups auto-increment from there.
 	#[tokio::test]
 	async fn seek_clears_pending_after_use() {
-		let track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let track = track_producer("test", hang::container::track_info());
 		let consumer = track.subscribe(None);
 		let mut producer = Producer::new(track, Container::Legacy);
 
@@ -440,10 +422,7 @@ mod tests {
 	/// group's last frame, without buffering an extra frame.
 	#[tokio::test]
 	async fn keyframe_backfills_batched_durations() {
-		let track = track_producer(
-			"test",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		);
+		let track = track_producer("test", hang::container::track_info());
 		let recording = Recording::default();
 		let mut producer = Producer::new(track, recording.clone()).with_latency(std::time::Duration::from_secs(10));
 

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -92,10 +92,7 @@ async fn export_aac_roundtrip() {
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
-		.create_track(
-			broadcast.unique_name(".aac"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(broadcast.unique_name(".aac"), hang::container::track_info())
 		.unwrap();
 	let name = track.name().to_string();
 	{
@@ -208,10 +205,7 @@ async fn export_lead_audio() -> BytesMut {
 
 	// In-band avc3 video (SPS/PPS inline on keyframes; no out-of-band description).
 	let vtrack = broadcast
-		.create_track(
-			broadcast.unique_name(".avc3"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(broadcast.unique_name(".avc3"), hang::container::track_info())
 		.unwrap();
 	{
 		let mut cfg = VideoConfig::new(H264 {
@@ -226,10 +220,7 @@ async fn export_lead_audio() -> BytesMut {
 	let mut video = Producer::new(vtrack, HangContainer::Legacy);
 
 	let atrack = broadcast
-		.create_track(
-			broadcast.unique_name(".aac"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(broadcast.unique_name(".aac"), hang::container::track_info())
 		.unwrap();
 	{
 		let mut cfg = AudioConfig::new(AAC { profile: 2 }, 48_000, 2);
@@ -347,10 +338,7 @@ async fn export_avc3_in_band_reassembles() {
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
-		.create_track(
-			broadcast.unique_name(".avc3"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(broadcast.unique_name(".avc3"), hang::container::track_info())
 		.unwrap();
 	let name = track.name().to_string();
 	{
@@ -398,10 +386,7 @@ async fn export_avc3_preserves_multiple_pps() {
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
-		.create_track(
-			broadcast.unique_name(".avc3"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(broadcast.unique_name(".avc3"), hang::container::track_info())
 		.unwrap();
 	let name = track.name().to_string();
 	{
@@ -451,10 +436,7 @@ async fn export_avc1_out_of_band_reassembles() {
 	let avcc = crate::codec::h264::build_avcc(&[Bytes::from_static(SPS)], &[Bytes::from_static(PPS)]).unwrap();
 
 	let track = broadcast
-		.create_track(
-			broadcast.unique_name(".avc1"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(broadcast.unique_name(".avc1"), hang::container::track_info())
 		.unwrap();
 	let name = track.name().to_string();
 	{
@@ -580,10 +562,7 @@ async fn export_scte35_roundtrip() {
 	// `Import` (which consumes it); the producer stays alive so the exporter can
 	// subscribe to the retained track.
 	let scte = broadcast
-		.unique_track(
-			".scte35",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.unique_track(".scte35", hang::container::track_info())
 		.unwrap();
 	let scte_name = scte.name().to_string();
 	{
@@ -695,12 +674,7 @@ async fn export_pes_verbatim_roundtrip() {
 
 	// Build the verbatim PES track BEFORE moving `broadcast` into `Import`; the
 	// producer stays alive so the exporter can subscribe to the retained track.
-	let data_track = broadcast
-		.unique_track(
-			".data",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
-		.unwrap();
+	let data_track = broadcast.unique_track(".data", hang::container::track_info()).unwrap();
 	let data_name = data_track.name().to_string();
 	{
 		let mut verbatim = tscat::Verbatim::new(0x06, tscat::Framing::Pes);
@@ -786,10 +760,7 @@ async fn scte35_without_video_export_is_rejected() {
 
 	// A SCTE-35 cue track and nothing else.
 	let scte = broadcast
-		.unique_track(
-			".scte35",
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.unique_track(".scte35", hang::container::track_info())
 		.unwrap();
 	let scte_name = scte.name().to_string();
 	{
@@ -1333,10 +1304,7 @@ async fn export_opus_roundtrip() {
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
-		.create_track(
-			broadcast.unique_name(".opus"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(broadcast.unique_name(".opus"), hang::container::track_info())
 		.unwrap();
 	let name = track.name().to_string();
 	{
@@ -1413,10 +1381,7 @@ async fn opus_export_import_roundtrip() {
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
 	let track = broadcast
-		.create_track(
-			broadcast.unique_name(".opus"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)
+		.create_track(broadcast.unique_name(".opus"), hang::container::track_info())
 		.unwrap();
 	let name = track.name().to_string();
 	{

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -642,10 +642,7 @@ fn register_verbatim<E: catalog::Catalog>(
 	// Verbatim payloads ride the legacy container, which normalizes the per-frame
 	// timestamp to microseconds on the wire (see `hang::container::Frame::encode`),
 	// so the track declares that timescale to match.
-	let track = broadcast.unique_track(
-		".ts",
-		moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-	)?;
+	let track = broadcast.unique_track(".ts", hang::container::track_info())?;
 
 	let mut guard = catalog.lock();
 	let Some(mpegts) = guard.mpegts_mut() else {

--- a/rs/moq-mux/src/import/mod.rs
+++ b/rs/moq-mux/src/import/mod.rs
@@ -27,14 +27,12 @@ pub use track::*;
 
 /// Mint a fresh unique track for a legacy single-codec importer.
 ///
-/// Picks a unique name from `suffix` and sets the microsecond
-/// [`hang::container::TIMESCALE`] that the legacy importers stamp their frames
-/// with, so the relay gets timing without parsing the payload. Hand the result to
-/// the importer's `new`.
+/// Picks a unique name from `suffix` and applies [`hang::container::track_info`], so the
+/// relay gets timing without parsing the payload. Hand the result to the importer's `new`.
 pub fn unique_track(
 	broadcast: &mut moq_net::broadcast::Producer,
 	suffix: &str,
 ) -> crate::Result<moq_net::track::Producer> {
-	let info = moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE);
+	let info = hang::container::track_info();
 	Ok(broadcast.unique_track(suffix, info)?)
 }

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -145,7 +145,7 @@ impl<E: CatalogExt> Track<E> {
 		// Accept at the legacy microsecond timescale, matching the frame timestamps
 		// the container stamps. A codec-specific timescale (e.g. the opus sample
 		// rate) would be chosen here instead.
-		let track = request.accept(moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE));
+		let track = request.accept(hang::container::track_info());
 		let data = init.data.as_ref();
 		let kind = match init.format.as_str() {
 			"avc1" | "avcc" => {
@@ -417,7 +417,7 @@ impl<E: CatalogExt> TrackStream<E> {
 	/// timescale would be chosen). A [`VideoHint`] carrying a codec publishes the catalog before the
 	/// first frame; any [`Init::data`] seeds the stream (as a call to [`initialize`](Self::initialize)).
 	pub fn new(request: moq_net::track::Request, reserved: crate::catalog::Reserved<E>, init: Init) -> Result<Self> {
-		let track = request.accept(moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE));
+		let track = request.accept(hang::container::track_info());
 		let hint = video_hint(&init, None);
 		// Only the self-delimiting codecs can be recovered from a raw byte stream.
 		let kind = match init.format.as_str() {
@@ -704,12 +704,7 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn opus_import_delivers_frames() {
 		let (mut broadcast, catalog) = new_broadcast();
-		let track = broadcast
-			.create_track(
-				"audio",
-				moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-			)
-			.unwrap();
+		let track = broadcast.create_track("audio", hang::container::track_info()).unwrap();
 		let subscriber = track.subscribe(None);
 
 		let config = crate::codec::opus::Config {

--- a/rs/moq-rtc/src/codec/vp8.rs
+++ b/rs/moq-rtc/src/codec/vp8.rs
@@ -16,10 +16,7 @@ pub struct Bridge {
 impl Bridge {
 	/// Publish a `.vp8` track on `broadcast`; the catalog rendition is added on the first frame.
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = broadcast.create_track(
-			broadcast.unique_name(".vp8"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)?;
+		let track = broadcast.create_track(broadcast.unique_name(".vp8"), hang::container::track_info())?;
 		let producer = catalog.media_producer(track, moq_mux::catalog::hang::Container::Legacy);
 		Ok(Self {
 			catalog,

--- a/rs/moq-rtc/src/codec/vp9.rs
+++ b/rs/moq-rtc/src/codec/vp9.rs
@@ -15,10 +15,7 @@ pub struct Bridge {
 impl Bridge {
 	/// Publish a `.vp9` track on `broadcast`; the catalog rendition is added on the first frame.
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
-		let track = broadcast.create_track(
-			broadcast.unique_name(".vp9"),
-			moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE),
-		)?;
+		let track = broadcast.create_track(broadcast.unique_name(".vp9"), hang::container::track_info())?;
 		let producer = catalog.media_producer(track, moq_mux::catalog::hang::Container::Legacy);
 		Ok(Self {
 			catalog,

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -179,7 +179,7 @@ mod tests {
 		video.framerate = Some(30.0);
 		catalog.lock().video.insert("video", video).unwrap();
 
-		let info = moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE);
+		let info = hang::container::track_info();
 		let mut track = broadcast.create_track("video", info).unwrap();
 
 		let mut encoder = moq_video::encode::Encoder::new(&{
@@ -199,7 +199,7 @@ mod tests {
 						timestamp: moq_net::Timestamp::from_micros(timestamp).unwrap(),
 						payload,
 					};
-					frame.encode(&mut group).unwrap();
+					frame.write_to(&mut group).unwrap();
 				}
 			}
 			group.finish().unwrap();
@@ -232,7 +232,7 @@ mod tests {
 		video.framerate = Some(30.0);
 		catalog.lock().video.insert("video", video).unwrap();
 
-		let info = moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE);
+		let info = hang::container::track_info();
 		let mut track = broadcast.create_track("video", info).unwrap();
 
 		let source = Source {
@@ -264,7 +264,7 @@ mod tests {
 							timestamp: moq_net::Timestamp::from_micros(timestamp).unwrap(),
 							payload,
 						};
-						frame.encode(&mut group).unwrap();
+						frame.write_to(&mut group).unwrap();
 					}
 				}
 				group.finish().unwrap();

--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -76,7 +76,7 @@ pub(crate) async fn serve(rung: Rung, request: moq_net::track::Request) -> Resul
 	// Grab the group-request handle before accepting: a Request is dynamic from
 	// birth, so a fetch racing the acceptance queues instead of failing.
 	let dynamic = request.dynamic();
-	let info = moq_net::track::Info::default().with_timescale(hang::container::TIMESCALE);
+	let info = hang::container::track_info();
 	let mut producer = request.accept(info);
 
 	let result = tokio::select! {
@@ -351,7 +351,7 @@ async fn transcode_group_inner(
 fn write(output: &mut moq_net::group::Producer, packets: Vec<(moq_net::Timestamp, Bytes)>) -> Result<(), Error> {
 	for (timestamp, payload) in packets {
 		let frame = hang::container::Frame { timestamp, payload };
-		frame.encode(output)?;
+		frame.write_to(output)?;
 	}
 	Ok(())
 }


### PR DESCRIPTION
Closes #2319. Targets `dev`: breaks published `pub` API in `hang`.

## Summary

- **`container::track_info()`.** The container normalizes wire timestamps to `hang::container::TIMESCALE` (micros) but `moq_net::track::Info` defaults to millis, so every hang publisher had to remember `Info::default().with_timescale(hang::container::TIMESCALE)`. That incantation was duplicated at ~97 sites across 24 files. Replaced with one helper. This turned up a live instance of the bug in hang's own `examples/video.rs`, which created its legacy-container media track with `None` info and so silently got the millisecond default.
- **`#[non_exhaustive]` on `Catalog`, `Video`, `Audio`.** Each has `Default` plus `insert()`, so callers build via `default()` + field set. `VideoConfig`/`AudioConfig` already landed this on dev, so that part of the issue was stale.
- **`Catalog::to_string` -> `to_json`** (and `to_string_pretty` -> `to_json_pretty`), unshadowing the std `ToString` method name that had fallible semantics.
- **`container::Frame`** now has a pure `encode(&mut impl BufMut)`/`decode(impl Buf)` pair that round-trips at one layer, plus `write_to(group)` for the group write. `write_to` keeps the zero-copy chunked write (header and payload as separate chunks) and the moq-net frame timestamp stamp; it does not go through `encode`.
- **`hang::Error::Moq`** displayed "moq lite error: {0}" though the wrapped crate is `moq_net` and may be an IETF session.
- **Hang draft** now documents `broadcast`, `displayAspectWidth`/`displayAspectHeight`, `jitter`, and `container` in a new "Common Rendition Fields" section.

## Judgment calls worth a look

- **`Display` did not get `#[non_exhaustive]`,** though the issue asked. `{width, height}` are both required, it has no `Default`, and a new field there would change behavior rather than default to a no-op. That is rs/CLAUDE.md's explicit "skip it everywhere else" case, so the attribute would be waving through an addition that should be a deliberate break.
- **`Catalog` got it, though the issue did not ask.** Same argument as `Video` (grows with additive defaultable sections); leaving it out while doing `Video` would be arbitrary.
- **Draft: removed `priority`.** The draft specified `"priority": u8` on both `VideoSchema` and `AudioSchema`. That field exists in neither rs/hang nor js/hang. Drafts are normative, so advertising a field nobody implements is worse than omitting it.
- **Draft: `timeline` deliberately left out.** Specifying it properly means specifying the timeline track's record format, which is a `moq-json` *stream*, and moq-json has no draft to reference normatively. That is its own chunk of spec work, not a field description. Follow-up.

## Public API changes

All in `hang`, all breaking:

| Item | Change |
|---|---|
| `hang::container::track_info()` | **new** |
| `hang::Catalog` | now `#[non_exhaustive]` |
| `hang::catalog::Video` / `Audio` | now `#[non_exhaustive]` |
| `Catalog::to_string` / `to_string_pretty` | **renamed** to `to_json` / `to_json_pretty` |
| `container::Frame::encode` | **signature changed**: `(&group::Producer)` -> `(&mut impl BufMut)` |
| `container::Frame::write_to` | **new** (the old `encode` behavior) |

`hang::Error::Moq`'s display string changed, but the variant is unchanged.

## Cross-Package Sync

- `rs/hang` catalog/container -> `drafts/draft-lcurley-moq-hang.md`: done (this PR).
- `rs/hang` -> `js/hang`: **no change needed.** This PR changes no wire format. `broadcast`, `displayAspect*`, and `jitter` already ship in js/hang; the draft was the only thing lagging. The Rust-side renames have no JS counterpart (`js/hang`'s catalog is zod schemas, not methods).
- `doc/concept`: no change needed; it does not document these symbols.

## Test plan

- `just fix` clean, `just check` clean (exit 0).
- `RUSTDOCFLAGS=-D warnings cargo doc -p hang -p moq-mux -p moq-transcode` clean, so the new intra-doc links resolve (CI runs this; `just check` does not).
- `cargo test -p hang -p moq-mux -p moq-transcode`: 426 passing.
- New tests in `container/frame.rs`: `encode_decode_roundtrip`, `encode_normalizes_timescale` (a nanosecond source still lands on the wire as micros), `track_info_uses_container_timescale`.
- `just drafts check` passes and `just drafts build draft-lcurley-moq-hang` renders; cross-references and TOC verified. Caught a duplicate `container` anchor this way.

Not run: `just test smoke-full`. No wire or FFI change here.

(Written by Claude Opus 4.8)