### PR TITLE
fix(libmoq)!: align the C ABI naming on announce/_finish and drop _ordered

### DIFF
--- a/cpp/obs/src/moq-output.cpp
+++ b/cpp/obs/src/moq-output.cpp
@@ -23,7 +23,7 @@ MoQOutput::MoQOutput(obs_data_t *, obs_output_t *output)
 
 MoQOutput::~MoQOutput()
 {
-	moq_publish_close(broadcast);
+	moq_publish_finish(broadcast);
 	moq_origin_close(origin);
 
 	Stop();
@@ -130,9 +130,10 @@ bool MoQOutput::Start()
 
 	LOG_INFO("Publishing broadcast: %s", path.c_str());
 
-	// Publish the broadcast to the origin we created.
-	// TODO: There is currently no unpublish function.
-	auto result = moq_origin_publish(origin, path.data(), path.size(), broadcast);
+	// Announce the broadcast on the origin we created. The announce handle is dropped:
+	// the announcement lives until the destructor closes the origin, which is the whole
+	// lifetime of the output anyway.
+	auto result = moq_origin_announce(origin, path.data(), path.size(), broadcast);
 	if (result < 0) {
 		LOG_ERROR("Failed to publish broadcast to session: %d", result);
 		// The session connected above; close it so a retry on this same output
@@ -157,13 +158,13 @@ void MoQOutput::Stop(bool signal)
 
 	for (auto &[encoder, handle] : video_tracks) {
 		if (handle > 0)
-			moq_publish_media_close(handle);
+			moq_publish_media_finish(handle);
 	}
 	video_tracks.clear();
 
 	for (auto &[encoder, handle] : audio_tracks) {
 		if (handle > 0)
-			moq_publish_media_close(handle);
+			moq_publish_media_finish(handle);
 	}
 	audio_tracks.clear();
 
@@ -297,7 +298,7 @@ void MoQOutput::VideoInit(obs_encoder_t *encoder)
 	}
 
 	// Intialize the media import module with the codec and initialization data.
-	int handle = moq_publish_media_ordered(broadcast, moq_codec, strlen(moq_codec), extra_data, extra_size);
+	int handle = moq_publish_media(broadcast, moq_codec, strlen(moq_codec), extra_data, extra_size);
 	video_tracks[encoder] = handle;
 	if (handle < 0) {
 		LOG_ERROR("Failed to initialize video track: %d", handle);
@@ -336,7 +337,7 @@ void MoQOutput::AudioInit(obs_encoder_t *encoder)
 
 	const char *codec = obs_encoder_get_codec(encoder);
 
-	int handle = moq_publish_media_ordered(broadcast, codec, strlen(codec), extra_data, extra_size);
+	int handle = moq_publish_media(broadcast, codec, strlen(codec), extra_data, extra_size);
 	audio_tracks[encoder] = handle;
 	if (handle < 0) {
 		LOG_ERROR("Failed to initialize audio track: %d", handle);

--- a/cpp/obs/src/moq-source.cpp
+++ b/cpp/obs/src/moq-source.cpp
@@ -471,7 +471,7 @@ static void on_catalog(void *user_data, int32_t catalog)
 	// Subscribe to the video track (index 0). This takes the catalog snapshot,
 	// not the consume handle, and does not retain it - so free the snapshot
 	// immediately after.
-	int32_t track = moq_consume_video_ordered(catalog, 0, 0, on_video_frame, ctx);
+	int32_t track = moq_consume_video(catalog, 0, 0, on_video_frame, ctx);
 	moq_consume_catalog_free(catalog);
 	if (track < 0) {
 		LOG_ERROR("Failed to subscribe to video track: %d", track);

--- a/doc/concept/layer/hang.md
+++ b/doc/concept/layer/hang.md
@@ -102,7 +102,7 @@ The catalog is a JSON document published through the merge-patch snapshot helper
 - **Writing**: the catalog producer holds one shared document.
   Each owner edits only its own keys and publishes: `producer.mutate(c => { c.scte35 = ... })` in TypeScript; the `Deref`/`DerefMut` lock guard from `producer.lock()` for a typed Rust extension, or `producer.set_section("scte35", value)` for an untyped one; `broadcast.set_catalog_section("scte35", value)` in Python; `moq_publish_catalog_section()` in C.
   Every edit starts from the latest value, so the base media sections and any extension sections compose instead of clobbering one another.
-  Removing a key publishes a deletion (`producer.remove_section(...)`, `broadcast.remove_catalog_section(...)` in Python, `moq_remove_catalog_section()` in C), which a consumer reads as the section being removed.
+  Removing a key publishes a deletion (`producer.remove_section(...)`, `broadcast.remove_catalog_section(...)` in Python, `moq_publish_catalog_section_remove()` in C), which a consumer reads as the section being removed.
 
 This keeps application-specific sections in the application layer while the base catalog stays generic.
 

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -89,7 +89,7 @@ generated header at `../../target/release/moq.h`.
 
 ## Callback lifetime
 
-Any function that registers a callback (`moq_session_connect`, `moq_origin_announced`, `moq_origin_consume_announced`, `moq_origin_request`, `moq_consume_catalog`, `moq_consume_video_ordered`, `moq_consume_audio_ordered`, `moq_consume_track`, `moq_consume_datagrams`, `moq_consume_video_raw`, `moq_consume_audio_raw`, `moq_consume_json_snapshot`, `moq_consume_json_stream`) takes a `void *user_data` pointer that libmoq passes back to every callback invocation. The status code carries the lifecycle:
+Any function that registers a callback (`moq_session_connect`, `moq_origin_announced`, `moq_origin_consume_announced`, `moq_origin_request`, `moq_consume_catalog`, `moq_consume_video`, `moq_consume_audio`, `moq_consume_track`, `moq_consume_datagrams`, `moq_consume_video_raw`, `moq_consume_audio_raw`, `moq_consume_json_snapshot`, `moq_consume_json_stream`) takes a `void *user_data` pointer that libmoq passes back to every callback invocation. The status code carries the lifecycle:
 
 - **`> 0`**: a live result you can use: a frame, catalog, or announce ID (or `1` to mean "session connected"). May fire any number of times.
 - **`0`**: closed cleanly. **Terminal.**
@@ -133,7 +133,7 @@ Use `moq_publish_track_group_at` to create sparse or replayed groups at an
 explicit sequence. `moq_publish_track_finish_at` declares the exclusive end
 while still permitting lower groups. `moq_publish_track_abort` and
 `moq_publish_group_abort` terminate a producer with an application error. Call
-`moq_publish_track_close` after filling the groups below a declared end.
+`moq_publish_track_finish` after filling the groups below a declared end.
 
 Subscribers receive raw frame handles from `moq_consume_track`; read each one
 with `moq_consume_track_frame`. The returned `moq_frame.timestamp_us` carries

--- a/rs/libmoq/CHANGELOG.md
+++ b/rs/libmoq/CHANGELOG.md
@@ -12,9 +12,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Linking `libmoq.a` on macOS no longer fails on undefined Apple framework
   symbols, and the CMake package config carries the same libraries the
   pkg-config file does.
+- `moq_track_info.timescale_valid` documented that it overrides a default
+  millisecond timescale. The default is and was microseconds, matching the
+  `timestamp_us` units used everywhere else in the ABI. Only the doc was wrong.
 
 ### Changed
 
+- Producer teardown is now spelled `_finish`, not `_close`, so the name states
+  the end-of-stream semantics and no longer reads as a synonym for the `_abort`
+  that sits next to it: `moq_publish_close` -> `moq_publish_finish`, and the
+  same for `moq_publish_media_close`, `moq_publish_track_close`,
+  `moq_publish_group_close`, `moq_publish_json_snapshot_close`,
+  `moq_publish_json_stream_close`, and `moq_publish_audio_raw_close`.
+  `moq_publish_track_finish` now also pairs with `moq_publish_track_finish_at`.
+  `_close` keeps its other two meanings (stop a listener, close a connection),
+  so `moq_consume_*_close`, `moq_origin_*_close`, and `moq_session_close` are
+  unchanged.
+- `moq_origin_publish` / `moq_origin_unpublish` -> `moq_origin_announce` /
+  `moq_origin_unannounce`, so the C ABI uses the same announce verb as every
+  other layer. The `origin_publish` / `origin_consume` parameters of
+  `moq_session_connect` keep their names: they name a direction, not this
+  operation.
+- `moq_remove_catalog_section` -> `moq_publish_catalog_section_remove`, putting
+  it under the `moq_publish_catalog_section` sibling it belongs to instead of
+  breaking the verb-prefix scheme.
+- Dropped the `_ordered` suffix, which leaked a long-gone internal type:
+  `moq_publish_media_ordered` -> `moq_publish_media`,
+  `moq_consume_video_ordered` -> `moq_consume_video`, and
+  `moq_consume_audio_ordered` -> `moq_consume_audio`. These now match the
+  `publish_media` / `subscribe_media` names moq-ffi already uses.
 - The native libraries an external linker needs alongside `libmoq.a` now come
   from `rs/libmoq/native-libs/`, so the pkg-config file and the CMake package
   config can no longer drift apart. This adds the Apple media frameworks, the
@@ -23,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON snapshot C ABI renamed for symmetry with the stream mode, so the caller
   opts explicitly into one of the two modes: `moq_json_config` ->
   `moq_json_snapshot_config`, `moq_publish_json` -> `moq_publish_json_snapshot`
-  (and `_update` / `_close`), and `moq_consume_json` ->
+  (and `_update` / `_finish`), and `moq_consume_json` ->
   `moq_consume_json_snapshot`. The shared `moq_json_value`,
   `moq_consume_json_value{,_close}`, and `moq_consume_json_close` are unchanged.
 

--- a/rs/libmoq/README.md
+++ b/rs/libmoq/README.md
@@ -31,7 +31,8 @@ int32_t moq_session_close(uint32_t session);
 // Origin
 int32_t moq_origin_create(void);
 int32_t moq_origin_close(uint32_t origin);
-int32_t moq_origin_publish(uint32_t origin, const char *path, uintptr_t path_len, uint32_t broadcast);
+int32_t moq_origin_announce(uint32_t origin, const char *path, uintptr_t path_len, uint32_t broadcast);
+int32_t moq_origin_unannounce(uint32_t announce);
 int32_t moq_origin_request(uint32_t origin, const char *path, uintptr_t path_len, void (*on_broadcast)(void *user_data, int32_t broadcast), void *user_data);
 int32_t moq_origin_request_close(uint32_t task);
 int32_t moq_origin_consume_announced(uint32_t origin, const char *path, uintptr_t path_len, void (*on_broadcast)(void *user_data, int32_t broadcast), void *user_data);
@@ -43,16 +44,16 @@ int32_t moq_origin_announced_close(uint32_t announced);
 
 // Publishing
 int32_t moq_publish_create(void);
-int32_t moq_publish_close(uint32_t broadcast);
-int32_t moq_publish_media_ordered(uint32_t broadcast, const char *format, uintptr_t format_len, const uint8_t *init, uintptr_t init_size);
-int32_t moq_publish_media_close(uint32_t media);
+int32_t moq_publish_finish(uint32_t broadcast);
+int32_t moq_publish_media(uint32_t broadcast, const char *format, uintptr_t format_len, const uint8_t *init, uintptr_t init_size);
+int32_t moq_publish_media_finish(uint32_t media);
 int32_t moq_publish_media_frame(uint32_t media, const uint8_t *payload, uintptr_t payload_size, uint64_t timestamp_us);
 int32_t moq_publish_track(uint32_t broadcast, const char *name, uintptr_t name_len);
 int32_t moq_publish_track_group(uint32_t track);
 int32_t moq_publish_track_frame(uint32_t track, const uint8_t *payload, uintptr_t payload_size, uint64_t timestamp_us);
 int32_t moq_publish_group_frame(uint32_t group, const uint8_t *payload, uintptr_t payload_size, uint64_t timestamp_us);
-int32_t moq_publish_group_close(uint32_t group);
-int32_t moq_publish_track_close(uint32_t track);
+int32_t moq_publish_group_finish(uint32_t group);
+int32_t moq_publish_track_finish(uint32_t track);
 
 // Consuming
 int32_t moq_consume_close(uint32_t consume);
@@ -65,11 +66,11 @@ int32_t moq_consume_video_config(uint32_t catalog, uint32_t index, moq_video_con
 int32_t moq_consume_audio_config(uint32_t catalog, uint32_t index, moq_audio_config *dst);
 
 // Consuming: Video
-int32_t moq_consume_video_ordered(uint32_t catalog, uint32_t index, uint64_t max_latency_ms, void (*on_frame)(void *user_data, int32_t frame), void *user_data);
+int32_t moq_consume_video(uint32_t catalog, uint32_t index, uint64_t max_latency_ms, void (*on_frame)(void *user_data, int32_t frame), void *user_data);
 int32_t moq_consume_video_close(uint32_t track);
 
 // Consuming: Audio
-int32_t moq_consume_audio_ordered(uint32_t catalog, uint32_t index, uint64_t max_latency_ms, void (*on_frame)(void *user_data, int32_t frame), void *user_data);
+int32_t moq_consume_audio(uint32_t catalog, uint32_t index, uint64_t max_latency_ms, void (*on_frame)(void *user_data, int32_t frame), void *user_data);
 int32_t moq_consume_audio_close(uint32_t track);
 
 // Consuming: Frames

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -139,7 +139,8 @@ pub struct moq_track_info {
 
 	/// Per-frame timescale in ticks per second.
 	pub timescale: u64,
-	/// Whether `timescale` should override the default millisecond timescale.
+	/// Whether `timescale` should override the default microsecond timescale,
+	/// which matches the `timestamp_us` units used everywhere else in this ABI.
 	pub timescale_valid: bool,
 }
 
@@ -489,18 +490,18 @@ pub extern "C" fn moq_origin_create() -> i32 {
 	ffi::enter(move || State::lock().origin.create())
 }
 
-/// Publish a broadcast to an origin.
+/// Announce a broadcast on an origin under `path`.
 ///
-/// The broadcast will be announced to any origin consumers, such as over the network.
+/// The broadcast becomes available to any origin consumers, such as over the network.
 ///
-/// Returns a positive publish handle on success, or a negative code on failure. The broadcast
-/// stays announced until the handle is passed to [moq_origin_unpublish]; closing the broadcast
+/// Returns a positive announce handle on success, or a negative code on failure. The broadcast
+/// stays announced until the handle is passed to [moq_origin_unannounce]; finishing the broadcast
 /// itself does not unannounce it.
 ///
 /// # Safety
 /// - The caller must ensure that path is a valid pointer to path_len bytes of data.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn moq_origin_publish(origin: u32, path: *const c_char, path_len: usize, broadcast: u32) -> i32 {
+pub unsafe extern "C" fn moq_origin_announce(origin: u32, path: *const c_char, path_len: usize, broadcast: u32) -> i32 {
 	ffi::enter(move || {
 		let origin = ffi::parse_id(origin)?;
 		let path = unsafe { ffi::parse_str(path, path_len)? };
@@ -508,19 +509,19 @@ pub unsafe extern "C" fn moq_origin_publish(origin: u32, path: *const c_char, pa
 
 		let mut state = State::lock();
 		let broadcast = state.publish.get(broadcast)?.consume();
-		state.origin.publish(origin, path, broadcast)
+		state.origin.announce(origin, path, broadcast)
 	})
 }
 
-/// Unannounce a broadcast previously published with [moq_origin_publish].
+/// Unannounce a broadcast previously announced with [moq_origin_announce].
 ///
-/// Takes the publish handle returned by [moq_origin_publish]. Returns zero on success, or a
+/// Takes the announce handle returned by [moq_origin_announce]. Returns zero on success, or a
 /// negative code on failure.
 #[unsafe(no_mangle)]
-pub extern "C" fn moq_origin_unpublish(publish: u32) -> i32 {
+pub extern "C" fn moq_origin_unannounce(announce: u32) -> i32 {
 	ffi::enter(move || {
-		let publish = ffi::parse_id(publish)?;
-		State::lock().origin.unpublish(publish)
+		let announce = ffi::parse_id(announce)?;
+		State::lock().origin.unannounce(announce)
 	})
 }
 
@@ -721,14 +722,17 @@ pub extern "C" fn moq_publish_create() -> i32 {
 	ffi::enter(move || State::lock().publish.create())
 }
 
-/// Close a broadcast and clean up its resources.
+/// Finish a broadcast and release it, ending its catalog cleanly.
+///
+/// Subscribers see a normal end of stream rather than an error. An announcement made with
+/// [moq_origin_announce] outlives this; drop it with [moq_origin_unannounce].
 ///
 /// Returns a zero on success, or a negative code on failure.
 #[unsafe(no_mangle)]
-pub extern "C" fn moq_publish_close(broadcast: u32) -> i32 {
+pub extern "C" fn moq_publish_finish(broadcast: u32) -> i32 {
 	ffi::enter(move || {
 		let broadcast = ffi::parse_id(broadcast)?;
-		State::lock().publish.close(broadcast)
+		State::lock().publish.finish(broadcast)
 	})
 }
 
@@ -743,7 +747,7 @@ pub extern "C" fn moq_publish_close(broadcast: u32) -> i32 {
 /// - The caller must ensure that format is a valid pointer to format_len bytes of data.
 /// - The caller must ensure that init is a valid pointer to init_size bytes of data.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn moq_publish_media_ordered(
+pub unsafe extern "C" fn moq_publish_media(
 	broadcast: u32,
 	format: *const c_char,
 	format_len: usize,
@@ -755,18 +759,18 @@ pub unsafe extern "C" fn moq_publish_media_ordered(
 		let format = unsafe { ffi::parse_str(format, format_len)? };
 		let init = unsafe { ffi::parse_slice(init, init_size)? };
 
-		State::lock().publish.media_ordered(broadcast, format, init)
+		State::lock().publish.media(broadcast, format, init)
 	})
 }
 
-/// Remove a track from a broadcast.
+/// Finish a media track, flushing any buffered frames. No more frames can be written.
 ///
 /// Returns a zero on success, or a negative code on failure.
 #[unsafe(no_mangle)]
-pub extern "C" fn moq_publish_media_close(export: u32) -> i32 {
+pub extern "C" fn moq_publish_media_finish(export: u32) -> i32 {
 	ffi::enter(move || {
 		let export = ffi::parse_id(export)?;
-		State::lock().publish.media_close(export)
+		State::lock().publish.media_finish(export)
 	})
 }
 
@@ -949,7 +953,11 @@ pub unsafe extern "C" fn moq_publish_catalog_section(
 /// # Safety
 /// - The caller must ensure that name is a valid pointer to name_len bytes of data.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn moq_remove_catalog_section(broadcast: u32, name: *const c_char, name_len: usize) -> i32 {
+pub unsafe extern "C" fn moq_publish_catalog_section_remove(
+	broadcast: u32,
+	name: *const c_char,
+	name_len: usize,
+) -> i32 {
 	ffi::enter(move || {
 		let broadcast = ffi::parse_id(broadcast)?;
 		let name = unsafe { ffi::parse_str(name, name_len)? };
@@ -959,7 +967,7 @@ pub unsafe extern "C" fn moq_remove_catalog_section(broadcast: u32, name: *const
 
 /// Create a raw track on a broadcast for arbitrary byte payloads.
 ///
-/// Unlike [moq_publish_media_ordered], this is the bare moq-net primitive: no
+/// Unlike [moq_publish_media], this is the bare moq-net primitive: no
 /// codec, container, or catalog framing. Frames written to it are delivered
 /// as-is to subscribers using [moq_consume_track]. Use it for non-media tracks
 /// (control channels, JSON metadata, etc.), or pair it with
@@ -1076,7 +1084,7 @@ pub unsafe extern "C" fn moq_publish_track_datagram(
 ///
 /// Returns a zero on success, or a negative code on failure.
 #[unsafe(no_mangle)]
-pub extern "C" fn moq_publish_track_close(track: u32) -> i32 {
+pub extern "C" fn moq_publish_track_finish(track: u32) -> i32 {
 	ffi::enter(move || {
 		let track = ffi::parse_id(track)?;
 		State::lock().publish.track_finish(track)
@@ -1087,7 +1095,7 @@ pub extern "C" fn moq_publish_track_close(track: u32) -> i32 {
 ///
 /// Groups below `final_sequence` may still be created. Groups at or above it
 /// are rejected. The track remains open for groups below the boundary. Call
-/// [moq_publish_track_close] after producing the remaining groups.
+/// [moq_publish_track_finish] after producing the remaining groups.
 #[unsafe(no_mangle)]
 pub extern "C" fn moq_publish_track_finish_at(track: u32, final_sequence: u64) -> i32 {
 	ffi::enter(move || {
@@ -1132,7 +1140,7 @@ pub unsafe extern "C" fn moq_publish_group_frame(
 ///
 /// Returns a zero on success, or a negative code on failure.
 #[unsafe(no_mangle)]
-pub extern "C" fn moq_publish_group_close(group: u32) -> i32 {
+pub extern "C" fn moq_publish_group_finish(group: u32) -> i32 {
 	ffi::enter(move || {
 		let group = ffi::parse_id(group)?;
 		State::lock().publish.group_finish(group)
@@ -1197,10 +1205,10 @@ pub unsafe extern "C" fn moq_publish_json_snapshot_update(json: u32, value: *con
 ///
 /// Returns a zero on success, or a negative code on failure.
 #[unsafe(no_mangle)]
-pub extern "C" fn moq_publish_json_snapshot_close(json: u32) -> i32 {
+pub extern "C" fn moq_publish_json_snapshot_finish(json: u32) -> i32 {
 	ffi::enter(move || {
 		let json = ffi::parse_id(json)?;
-		State::lock().publish.json_snapshot_close(json)
+		State::lock().publish.json_snapshot_finish(json)
 	})
 }
 
@@ -1248,10 +1256,10 @@ pub unsafe extern "C" fn moq_publish_json_stream_append(stream: u32, value: *con
 ///
 /// Returns a zero on success, or a negative code on failure.
 #[unsafe(no_mangle)]
-pub extern "C" fn moq_publish_json_stream_close(stream: u32) -> i32 {
+pub extern "C" fn moq_publish_json_stream_finish(stream: u32) -> i32 {
 	ffi::enter(move || {
 		let stream = ffi::parse_id(stream)?;
-		State::lock().publish.json_stream_close(stream)
+		State::lock().publish.json_stream_finish(stream)
 	})
 }
 
@@ -1427,7 +1435,7 @@ pub unsafe extern "C" fn moq_catalog_get_section(
 /// # Safety
 /// - The caller must keep `user_data` valid until the terminal (`<= 0`) `on_frame` callback.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn moq_consume_video_ordered(
+pub unsafe extern "C" fn moq_consume_video(
 	catalog: u32,
 	index: u32,
 	max_latency_ms: u64,
@@ -1439,16 +1447,14 @@ pub unsafe extern "C" fn moq_consume_video_ordered(
 		let index = index as usize;
 		let max_latency = std::time::Duration::from_millis(max_latency_ms);
 		let on_frame = unsafe { ffi::OnStatus::new(user_data, on_frame) };
-		State::lock()
-			.consume
-			.video_ordered(catalog, index, max_latency, on_frame)
+		State::lock().consume.video(catalog, index, max_latency, on_frame)
 	})
 }
 
 /// Stop a video track consumer's background task.
 ///
 /// Returns immediately: zero on success, or a negative code if already closed.
-/// Does NOT free `user_data`; the [moq_consume_video_ordered] `on_frame` callback
+/// Does NOT free `user_data`; the [moq_consume_video] `on_frame` callback
 /// still fires once more with a terminal `0` (or a negative error), which is
 /// where `user_data` should be released.
 #[unsafe(no_mangle)]
@@ -1473,7 +1479,7 @@ pub extern "C" fn moq_consume_video_close(track: u32) -> i32 {
 /// # Safety
 /// - The caller must keep `user_data` valid until the terminal (`<= 0`) `on_frame` callback.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn moq_consume_audio_ordered(
+pub unsafe extern "C" fn moq_consume_audio(
 	catalog: u32,
 	index: u32,
 	max_latency_ms: u64,
@@ -1485,16 +1491,14 @@ pub unsafe extern "C" fn moq_consume_audio_ordered(
 		let index = index as usize;
 		let max_latency = std::time::Duration::from_millis(max_latency_ms);
 		let on_frame = unsafe { ffi::OnStatus::new(user_data, on_frame) };
-		State::lock()
-			.consume
-			.audio_ordered(catalog, index, max_latency, on_frame)
+		State::lock().consume.audio(catalog, index, max_latency, on_frame)
 	})
 }
 
 /// Stop an audio track consumer's background task.
 ///
 /// Returns immediately: zero on success, or a negative code if already closed.
-/// Does NOT free `user_data`; the [moq_consume_audio_ordered] `on_frame` callback
+/// Does NOT free `user_data`; the [moq_consume_audio] `on_frame` callback
 /// still fires once more with a terminal `0` (or a negative error), which is
 /// where `user_data` should be released.
 #[unsafe(no_mangle)]

--- a/rs/libmoq/src/audio.rs
+++ b/rs/libmoq/src/audio.rs
@@ -1,6 +1,6 @@
 //! Raw-audio import/export via [`moq_audio`].
 //!
-//! Sibling to `moq_publish_media_*` / `moq_consume_audio_ordered`
+//! Sibling to `moq_publish_media_*` / `moq_consume_audio`
 //! (those handle already-encoded frames). These functions accept and
 //! return raw PCM, with Opus encode/decode happening inside the FFI
 //! boundary.
@@ -101,7 +101,7 @@ pub struct moq_audio_decoder_output {
 	pub channels: u32,
 	/// Upper bound on buffering before skipping a stalled group, in
 	/// milliseconds. Same congestion-control knob as
-	/// `moq_consume_audio_ordered`'s `max_latency_ms`. 0 = skip
+	/// `moq_consume_audio`'s `max_latency_ms`. 0 = skip
 	/// aggressively (the moq-mux default); set to your playout
 	/// buffer (tens to a few hundred ms) for a softer skip. Named
 	/// `_max` to leave room for a future `latency_min_ms`
@@ -159,7 +159,7 @@ impl Audio {
 		Ok(())
 	}
 
-	pub fn publish_close(&mut self, id: Id) -> Result<(), Error> {
+	pub fn publish_finish(&mut self, id: Id) -> Result<(), Error> {
 		let producer = self.producers.remove(id).ok_or(Error::MediaNotFound)?;
 		producer.finish()?;
 		Ok(())
@@ -346,17 +346,17 @@ pub unsafe extern "C" fn moq_publish_audio_raw_frame(producer: u32, frame: *cons
 
 /// Flush any pending samples and finalize an audio producer.
 #[unsafe(no_mangle)]
-pub extern "C" fn moq_publish_audio_raw_close(producer: u32) -> i32 {
+pub extern "C" fn moq_publish_audio_raw_finish(producer: u32) -> i32 {
 	ffi::enter(move || {
 		let producer = ffi::parse_id(producer)?;
-		State::lock().audio.publish_close(producer)
+		State::lock().audio.publish_finish(producer)
 	})
 }
 
 /// Subscribe to an audio track and decode it into PCM.
 ///
 /// The catalog `index` identifies which audio rendition to subscribe
-/// to, matching the existing `moq_consume_audio_ordered` selection
+/// to, matching the existing `moq_consume_audio` selection
 /// model. TODO: a future API will pick the right rendition
 /// automatically (ABR).
 ///

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -308,7 +308,7 @@ impl Consume {
 		Ok(())
 	}
 
-	pub fn video_ordered(
+	pub fn video(
 		&mut self,
 		catalog: Id,
 		index: usize,
@@ -360,7 +360,7 @@ impl Consume {
 		Ok(id)
 	}
 
-	pub fn audio_ordered(
+	pub fn audio(
 		&mut self,
 		catalog: Id,
 		index: usize,
@@ -759,7 +759,7 @@ impl Consume {
 
 	/// Look up a video rendition by catalog index, returning the
 	/// (broadcast, config, name) tuple needed to subscribe, mirroring
-	/// the index-based selection in `video_ordered`.
+	/// the index-based selection in `video`.
 	pub fn video_rendition(
 		&self,
 		catalog: Id,
@@ -935,7 +935,7 @@ impl Consume {
 	}
 	/// Look up an audio rendition by catalog index, returning the
 	/// (broadcast, config, name) tuple needed to subscribe, mirroring
-	/// the index-based selection in `audio_ordered`.
+	/// the index-based selection in `audio`.
 	pub fn audio_rendition(
 		&self,
 		catalog: Id,

--- a/rs/libmoq/src/origin.rs
+++ b/rs/libmoq/src/origin.rs
@@ -25,9 +25,9 @@ pub struct Origin {
 	/// Active origin producers for publishing and consuming broadcasts.
 	active: NonZeroSlab<moq_net::origin::Producer>,
 
-	/// Announcement guards from `publish`. Removing an entry (via `unpublish`) drops the
+	/// Announcement guards from `announce`. Removing an entry (via `unannounce`) drops the
 	/// guard, which unannounces the broadcast.
-	published: NonZeroSlab<moq_net::origin::Publish>,
+	announces: NonZeroSlab<moq_net::origin::Publish>,
 
 	/// Broadcast announcement information (path, active status).
 	announced: NonZeroSlab<(String, bool)>,
@@ -248,25 +248,25 @@ impl Origin {
 		Ok(())
 	}
 
-	/// Announce `broadcast` under `path`, returning a publish handle. The announcement stays
-	/// live until [`Self::unpublish`] is called with that handle (independent of the broadcast's
+	/// Announce `broadcast` under `path`, returning an announce handle. The announcement stays
+	/// live until [`Self::unannounce`] is called with that handle (independent of the broadcast's
 	/// own lifetime). Errors with [`Error::Moq`] if the path is outside the origin's scope.
-	pub fn publish<P: moq_net::AsPath>(
+	pub fn announce<P: moq_net::AsPath>(
 		&mut self,
 		origin: Id,
 		path: P,
 		broadcast: moq_net::broadcast::Consumer,
 	) -> Result<Id, Error> {
 		let origin = self.active.get(origin).ok_or(Error::OriginNotFound)?;
-		let publish = origin.publish_broadcast(path, &broadcast)?;
-		self.published.insert(publish)
+		let announce = origin.publish_broadcast(path, &broadcast)?;
+		self.announces.insert(announce)
 	}
 
-	/// Drop a publish handle from [`Self::publish`], unannouncing the broadcast.
-	pub fn unpublish(&mut self, publish: Id) -> Result<(), Error> {
+	/// Drop an announce handle from [`Self::announce`], unannouncing the broadcast.
+	pub fn unannounce(&mut self, announce: Id) -> Result<(), Error> {
 		// Dropping the removed guard is what unannounces the broadcast.
-		let publish = self.published.remove(publish).ok_or(Error::BroadcastNotFound)?;
-		drop(publish);
+		let announce = self.announces.remove(announce).ok_or(Error::BroadcastNotFound)?;
+		drop(announce);
 		Ok(())
 	}
 

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -67,9 +67,9 @@ impl Publish {
 		Ok((broadcast, catalog))
 	}
 
-	/// Cleanly close the broadcast and finalize the catalog stream, so subscribers
+	/// Cleanly finish the broadcast and finalize the catalog stream, so subscribers
 	/// see a normal end rather than [`moq_net::Error::Dropped`].
-	pub fn close(&mut self, broadcast: Id) -> Result<(), Error> {
+	pub fn finish(&mut self, broadcast: Id) -> Result<(), Error> {
 		let (broadcast, mut catalog) = self.broadcasts.remove(broadcast).ok_or(Error::BroadcastNotFound)?;
 		// Finish the broadcast first so the clean end reaches subscribers even if
 		// finalizing the catalog fails.
@@ -78,7 +78,7 @@ impl Publish {
 		Ok(())
 	}
 
-	pub fn media_ordered(&mut self, broadcast: Id, format: &str, init: &[u8]) -> Result<Id, Error> {
+	pub fn media(&mut self, broadcast: Id, format: &str, init: &[u8]) -> Result<Id, Error> {
 		let (broadcast, catalog) = self.broadcasts.get(broadcast).ok_or(Error::BroadcastNotFound)?;
 
 		// A container may publish several tracks; a single codec fills one reserved
@@ -114,7 +114,7 @@ impl Publish {
 		Ok(())
 	}
 
-	pub fn media_close(&mut self, media: Id) -> Result<(), Error> {
+	pub fn media_finish(&mut self, media: Id) -> Result<(), Error> {
 		let mut media = self.media.remove(media).ok_or(Error::MediaNotFound)?;
 		match &mut media {
 			Media::Track(track) => track.finish()?,
@@ -251,7 +251,7 @@ impl Publish {
 	///
 	/// Values published via [`Self::json_snapshot_update`] reach subscribers as a single latest
 	/// state; a late joiner only sees the newest value. Advertise the track in the catalog with
-	/// [`Self::catalog_section`] if consumers should discover it.
+	/// [`Self::catalog_section_set`] if consumers should discover it.
 	pub fn json_snapshot(
 		&mut self,
 		broadcast: Id,
@@ -272,7 +272,7 @@ impl Publish {
 	}
 
 	/// Finish a JSON snapshot track. No more values can be published.
-	pub fn json_snapshot_close(&mut self, json: Id) -> Result<(), Error> {
+	pub fn json_snapshot_finish(&mut self, json: Id) -> Result<(), Error> {
 		let mut producer = self.json_snapshot.remove(json).ok_or(Error::TrackNotFound)?;
 		producer.finish()?;
 		Ok(())
@@ -301,7 +301,7 @@ impl Publish {
 	}
 
 	/// Finish a JSON stream track. No more records can be appended.
-	pub fn json_stream_close(&mut self, stream: Id) -> Result<(), Error> {
+	pub fn json_stream_finish(&mut self, stream: Id) -> Result<(), Error> {
 		let mut producer = self.json_stream.remove(stream).ok_or(Error::TrackNotFound)?;
 		producer.finish()?;
 		Ok(())

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -162,13 +162,13 @@ fn last_error_set_before_callback() {
 fn publish_media_lifecycle() {
 	let broadcast = id(moq_publish_create());
 	let _guard = Guard(Some(|| {
-		moq_publish_close(broadcast);
+		moq_publish_finish(broadcast);
 	}));
 
 	let init = opus_head();
 	let format = b"opus";
 	let media = id(unsafe {
-		moq_publish_media_ordered(
+		moq_publish_media(
 			broadcast,
 			format.as_ptr() as *const c_char,
 			format.len(),
@@ -181,8 +181,8 @@ fn publish_media_lifecycle() {
 	let ret = unsafe { moq_publish_media_frame(media, payload.as_ptr(), payload.len(), 1000) };
 	assert_eq!(ret, 0, "moq_publish_media_frame should succeed");
 
-	assert_eq!(moq_publish_media_close(media), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_media_finish(media), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 }
 
 #[test]
@@ -231,7 +231,7 @@ fn publish_catalog_config_null_pointer() {
 		-6,
 		"null config should return InvalidPointer (-6)"
 	);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 }
 
 #[test]
@@ -239,7 +239,7 @@ fn publish_catalog_roundtrip() {
 	let origin = id(moq_origin_create());
 	let broadcast = id(moq_publish_create());
 
-	// Author the catalog directly instead of via moq_publish_media_ordered.
+	// Author the catalog directly instead of via moq_publish_media.
 	let video_name = "video";
 	let video_codec = "vp8";
 	let width: u32 = 1920;
@@ -273,7 +273,7 @@ fn publish_catalog_roundtrip() {
 
 	// Publish and consume the broadcast to verify the catalog round-trips.
 	let path = b"catalog-producer";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -335,7 +335,7 @@ fn publish_catalog_roundtrip() {
 	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
 	assert_eq!(catalog_cb.recv_terminal(), 0, "catalog close delivers terminal 0");
 	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -409,7 +409,7 @@ fn catalog_section_roundtrip() {
 
 	// Publish and consume to verify the sections survive the wire.
 	let path = b"catalog-sections";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -468,7 +468,7 @@ fn catalog_section_roundtrip() {
 
 	// Removing a section republishes the catalog without it.
 	assert_eq!(
-		unsafe { moq_remove_catalog_section(broadcast, name_a.as_ptr() as *const c_char, name_a.len()) },
+		unsafe { moq_publish_catalog_section_remove(broadcast, name_a.as_ptr() as *const c_char, name_a.len()) },
 		0
 	);
 	let catalog_id2 = id(catalog_cb.recv());
@@ -487,7 +487,7 @@ fn catalog_section_roundtrip() {
 	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
 	assert_eq!(catalog_cb.recv_terminal(), 0, "catalog close delivers terminal 0");
 	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -507,8 +507,8 @@ fn publish_track_invalid_broadcast() {
 	assert!(moq_publish_track_group(9999) < 0);
 	assert!(unsafe { moq_publish_track_frame(9999, name.as_ptr(), name.len(), 0) } < 0);
 	assert!(unsafe { moq_publish_group_frame(9999, name.as_ptr(), name.len(), 0) } < 0);
-	assert!(moq_publish_track_close(9999) < 0);
-	assert!(moq_publish_group_close(9999) < 0);
+	assert!(moq_publish_track_finish(9999) < 0);
+	assert!(moq_publish_group_finish(9999) < 0);
 
 	let subscription = moq_subscription {
 		priority: 1,
@@ -536,7 +536,7 @@ fn publish_track_with_info_rejects_invalid_timescale() {
 	};
 
 	assert!(unsafe { moq_publish_track(broadcast, name.as_ptr() as *const c_char, name.len(), &info) } < 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 }
 
 #[test]
@@ -586,7 +586,7 @@ fn raw_track_publish_consume() {
 	});
 
 	let path = b"raw-track";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = request_broadcast(origin, path);
 
@@ -633,7 +633,7 @@ fn raw_track_publish_consume() {
 			0
 		);
 	}
-	assert_eq!(moq_publish_group_close(group), 0);
+	assert_eq!(moq_publish_group_finish(group), 0);
 
 	for (expected, timestamp_us) in parts {
 		let frame_id = id(frame_cb.recv());
@@ -655,10 +655,10 @@ fn raw_track_publish_consume() {
 	// before the Callback (user_data) drops.
 	assert_eq!(frame_cb.recv_terminal(), 0, "clean close delivers terminal 0");
 	assert!(moq_consume_track_close(consumer) < 0, "double-close should fail");
-	assert_eq!(moq_publish_track_close(track), 0);
-	assert!(moq_publish_track_close(track) < 0, "double-close should fail");
+	assert_eq!(moq_publish_track_finish(track), 0);
+	assert!(moq_publish_track_finish(track) < 0, "double-close should fail");
 	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -678,7 +678,7 @@ fn raw_track_datagram_publish_consume() {
 	});
 
 	let path = b"raw-datagram";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = request_broadcast(origin, path);
 
@@ -720,9 +720,9 @@ fn raw_track_datagram_publish_consume() {
 	// before the Callback (user_data) drops.
 	assert_eq!(dg_cb.recv_terminal(), 0, "clean close delivers terminal 0");
 	assert!(moq_consume_datagrams_close(consumer) < 0, "double-close should fail");
-	assert_eq!(moq_publish_track_close(track), 0);
+	assert_eq!(moq_publish_track_finish(track), 0);
 	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -734,13 +734,13 @@ fn raw_track_sparse_groups_and_known_end() {
 		id(unsafe { moq_publish_track(broadcast, name.as_ptr() as *const c_char, name.len(), std::ptr::null()) });
 
 	let group = id(moq_publish_track_group_at(track, 2));
-	assert_eq!(moq_publish_group_close(group), 0);
+	assert_eq!(moq_publish_group_finish(group), 0);
 	assert_eq!(moq_publish_track_finish_at(track, 5), 0);
 	let group = id(moq_publish_track_group_at(track, 4));
-	assert_eq!(moq_publish_group_close(group), 0);
+	assert_eq!(moq_publish_group_finish(group), 0);
 	assert!(moq_publish_track_group_at(track, 5) < 0);
-	assert_eq!(moq_publish_track_close(track), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_track_finish(track), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 }
 
 #[test]
@@ -751,10 +751,10 @@ fn raw_track_and_group_abort_consume_their_handles() {
 		id(unsafe { moq_publish_track(broadcast, name.as_ptr() as *const c_char, name.len(), std::ptr::null()) });
 	let group = id(moq_publish_track_group(track));
 	assert_eq!(moq_publish_group_abort(group, 409), 0);
-	assert!(moq_publish_group_close(group) < 0);
+	assert!(moq_publish_group_finish(group) < 0);
 	assert_eq!(moq_publish_track_abort(track, 410), 0);
-	assert!(moq_publish_track_close(track) < 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert!(moq_publish_track_finish(track) < 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 }
 
 #[test]
@@ -783,7 +783,7 @@ fn raw_track_subscription_options_and_update() {
 	}
 
 	let path = b"raw-track-options";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 	let consume = request_broadcast(origin, path);
 
 	let frame_cb = Callback::new();
@@ -841,9 +841,9 @@ fn raw_track_subscription_options_and_update() {
 
 	assert_eq!(moq_consume_track_close(consumer), 0);
 	assert_eq!(frame_cb.recv_terminal(), 0);
-	assert_eq!(moq_publish_track_close(track), 0);
+	assert_eq!(moq_publish_track_finish(track), 0);
 	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -867,7 +867,7 @@ fn json_snapshot_publish_consume() {
 	});
 
 	let path = b"json-snapshot";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 	let consume = request_broadcast(origin, path);
 
 	let value_cb = Callback::new();
@@ -904,13 +904,13 @@ fn json_snapshot_publish_consume() {
 	assert_eq!(moq_consume_json_close(consumer), 0);
 	assert_eq!(value_cb.recv_terminal(), 0, "clean close delivers terminal 0");
 	assert!(moq_consume_json_close(consumer) < 0, "double-close should fail");
-	assert_eq!(moq_publish_json_snapshot_close(producer), 0);
+	assert_eq!(moq_publish_json_snapshot_finish(producer), 0);
 	assert!(
-		moq_publish_json_snapshot_close(producer) < 0,
+		moq_publish_json_snapshot_finish(producer) < 0,
 		"double-close should fail"
 	);
 	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -931,7 +931,7 @@ fn json_stream_publish_consume() {
 	});
 
 	let path = b"json-stream";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 	let consume = request_broadcast(origin, path);
 
 	let value_cb = Callback::new();
@@ -968,10 +968,10 @@ fn json_stream_publish_consume() {
 	assert_eq!(moq_consume_json_close(consumer), 0);
 	assert_eq!(value_cb.recv_terminal(), 0, "clean close delivers terminal 0");
 	assert!(moq_consume_json_close(consumer) < 0, "double-close should fail");
-	assert_eq!(moq_publish_json_stream_close(producer), 0);
-	assert!(moq_publish_json_stream_close(producer) < 0, "double-close should fail");
+	assert_eq!(moq_publish_json_stream_finish(producer), 0);
+	assert!(moq_publish_json_stream_finish(producer) < 0, "double-close should fail");
 	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -979,13 +979,13 @@ fn json_stream_publish_consume() {
 fn close_invalid_or_zero_ids() {
 	assert!(moq_origin_close(9999) < 0);
 	assert!(moq_session_close(9999) < 0);
-	assert!(moq_publish_close(9999) < 0);
+	assert!(moq_publish_finish(9999) < 0);
 	assert!(moq_consume_close(9999) < 0);
 	assert!(moq_consume_frame_close(9999) < 0);
 
 	assert!(moq_origin_close(0) < 0);
 	assert!(moq_session_close(0) < 0);
-	assert!(moq_publish_close(0) < 0);
+	assert!(moq_publish_finish(0) < 0);
 }
 
 #[test]
@@ -995,7 +995,7 @@ fn announced_free_lifecycle() {
 
 	// Publish a broadcast so the announce listener has something to deliver.
 	let path = b"announced-free";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let ann_cb = Callback::new();
 	let ann_task = id(unsafe { moq_origin_announced(origin, Some(channel_callback), ann_cb.ptr) });
@@ -1027,7 +1027,7 @@ fn announced_free_lifecycle() {
 	ann_cb.recv_terminal();
 
 	assert_eq!(moq_origin_close(origin), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 }
 
 #[test]
@@ -1040,7 +1040,7 @@ fn double_close_all_resource_types() {
 	let init = opus_head();
 	let format = b"opus";
 	let media = id(unsafe {
-		moq_publish_media_ordered(
+		moq_publish_media(
 			broadcast,
 			format.as_ptr() as *const c_char,
 			format.len(),
@@ -1049,15 +1049,15 @@ fn double_close_all_resource_types() {
 		)
 	});
 
-	assert_eq!(moq_publish_media_close(media), 0);
-	assert!(moq_publish_media_close(media) < 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_media_finish(media), 0);
+	assert!(moq_publish_media_finish(media) < 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 
 	let origin = id(moq_origin_create());
 	let broadcast = id(moq_publish_create());
 	let init = opus_head();
 	let media = id(unsafe {
-		moq_publish_media_ordered(
+		moq_publish_media(
 			broadcast,
 			format.as_ptr() as *const c_char,
 			format.len(),
@@ -1066,7 +1066,7 @@ fn double_close_all_resource_types() {
 		)
 	});
 	let path = b"double-close-test";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -1075,7 +1075,7 @@ fn double_close_all_resource_types() {
 	let catalog_id = id(catalog_cb.recv());
 
 	let frame_cb = Callback::new();
-	let track = id(unsafe { moq_consume_audio_ordered(catalog_id, 0, 10_000, Some(channel_callback), frame_cb.ptr) });
+	let track = id(unsafe { moq_consume_audio(catalog_id, 0, 10_000, Some(channel_callback), frame_cb.ptr) });
 
 	let payload = b"test";
 	assert_eq!(
@@ -1099,8 +1099,8 @@ fn double_close_all_resource_types() {
 	assert!(moq_consume_catalog_close(catalog_task) < 0);
 
 	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_media_close(media), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_media_finish(media), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -1108,12 +1108,12 @@ fn double_close_all_resource_types() {
 fn unknown_format() {
 	let broadcast = id(moq_publish_create());
 	let _guard = Guard(Some(|| {
-		moq_publish_close(broadcast);
+		moq_publish_finish(broadcast);
 	}));
 
 	let format = b"nope";
 	let ret = unsafe {
-		moq_publish_media_ordered(
+		moq_publish_media(
 			broadcast,
 			format.as_ptr() as *const c_char,
 			format.len(),
@@ -1133,7 +1133,7 @@ fn local_announce() {
 
 	let broadcast = id(moq_publish_create());
 	let path = b"test/broadcast";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let announced_id = id(cb.recv());
 
@@ -1151,7 +1151,7 @@ fn local_announce() {
 
 	assert_eq!(moq_origin_announced_close(announced_task), 0);
 	assert_eq!(cb.recv_terminal(), 0, "announced close delivers terminal 0");
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -1163,7 +1163,7 @@ fn announced_deactivation() {
 
 	let broadcast = id(moq_publish_create());
 	let path = b"deactivate/test";
-	let publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let publish = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let announced_id = id(cb.recv());
 	let mut info = moq_announced {
@@ -1176,15 +1176,15 @@ fn announced_deactivation() {
 
 	// Dropping the publish guard is what unannounces the broadcast; closing the
 	// broadcast producer itself no longer deactivates the announcement.
-	assert_eq!(moq_origin_unpublish(publish), 0);
+	assert_eq!(moq_origin_unannounce(publish), 0);
 
 	let deactivated_id = id(cb.recv());
 	assert_eq!(unsafe { moq_origin_announced_info(deactivated_id, &mut info) }, 0);
-	assert!(!info.active, "broadcast should be inactive after unpublish");
+	assert!(!info.active, "broadcast should be inactive after unannounce");
 
 	assert_eq!(moq_origin_announced_close(announced_task), 0);
 	assert_eq!(cb.recv_terminal(), 0, "announced close delivers terminal 0");
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -1196,7 +1196,7 @@ fn local_publish_consume() {
 	let init = opus_head();
 	let format = b"opus";
 	let media = id(unsafe {
-		moq_publish_media_ordered(
+		moq_publish_media(
 			broadcast,
 			format.as_ptr() as *const c_char,
 			format.len(),
@@ -1206,7 +1206,7 @@ fn local_publish_consume() {
 	});
 
 	let path = b"live";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -1253,7 +1253,7 @@ fn local_publish_consume() {
 	);
 
 	let frame_cb = Callback::new();
-	let track = id(unsafe { moq_consume_audio_ordered(catalog_id, 0, 10_000, Some(channel_callback), frame_cb.ptr) });
+	let track = id(unsafe { moq_consume_audio(catalog_id, 0, 10_000, Some(channel_callback), frame_cb.ptr) });
 
 	let payload = b"opus audio payload data";
 	let timestamp_us: u64 = 1_000_000;
@@ -1284,8 +1284,8 @@ fn local_publish_consume() {
 	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
 	assert_eq!(catalog_cb.recv_terminal(), 0, "catalog close delivers terminal 0");
 	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_media_close(media), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_media_finish(media), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -1310,7 +1310,7 @@ fn consume_announced_local() {
 	let init = opus_head();
 	let format = b"opus";
 	let media = id(unsafe {
-		moq_publish_media_ordered(
+		moq_publish_media(
 			broadcast,
 			format.as_ptr() as *const c_char,
 			format.len(),
@@ -1318,7 +1318,7 @@ fn consume_announced_local() {
 			init.len(),
 		)
 	});
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	// First the broadcast handle, then a terminal 0 once the wait finishes.
 	let consume = id(cb.recv());
@@ -1347,8 +1347,8 @@ fn consume_announced_local() {
 	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
 	assert_eq!(catalog_cb.recv_terminal(), 0, "catalog close delivers terminal 0");
 	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_media_close(media), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_media_finish(media), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -1384,7 +1384,7 @@ fn video_publish_consume() {
 	let init = h264_init();
 	let format = b"avc3";
 	let media = id(unsafe {
-		moq_publish_media_ordered(
+		moq_publish_media(
 			broadcast,
 			format.as_ptr() as *const c_char,
 			format.len(),
@@ -1394,7 +1394,7 @@ fn video_publish_consume() {
 	});
 
 	let path = b"video-test";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -1453,7 +1453,7 @@ fn video_publish_consume() {
 	);
 
 	let frame_cb = Callback::new();
-	let track = id(unsafe { moq_consume_video_ordered(catalog_id, 0, 10_000, Some(channel_callback), frame_cb.ptr) });
+	let track = id(unsafe { moq_consume_video(catalog_id, 0, 10_000, Some(channel_callback), frame_cb.ptr) });
 
 	let keyframe = [0x00, 0x00, 0x00, 0x01, 0x65, 0xAA, 0xBB, 0xCC];
 	assert_eq!(
@@ -1479,8 +1479,8 @@ fn video_publish_consume() {
 	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
 	assert_eq!(catalog_cb.recv_terminal(), 0, "catalog close delivers terminal 0");
 	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_media_close(media), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_media_finish(media), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -1512,7 +1512,7 @@ fn video_raw_decode() {
 	let init = h264_init();
 	let format = b"avc3";
 	let media = id(unsafe {
-		moq_publish_media_ordered(
+		moq_publish_media(
 			broadcast,
 			format.as_ptr() as *const c_char,
 			format.len(),
@@ -1522,7 +1522,7 @@ fn video_raw_decode() {
 	});
 
 	let path = b"video-raw-test";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -1583,8 +1583,8 @@ fn video_raw_decode() {
 		}
 	}
 	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_media_close(media), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_media_finish(media), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -1596,7 +1596,7 @@ fn multiple_frames_ordering() {
 	let init = opus_head();
 	let format = b"opus";
 	let media = id(unsafe {
-		moq_publish_media_ordered(
+		moq_publish_media(
 			broadcast,
 			format.as_ptr() as *const c_char,
 			format.len(),
@@ -1606,7 +1606,7 @@ fn multiple_frames_ordering() {
 	});
 
 	let path = b"ordering-test";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -1614,7 +1614,7 @@ fn multiple_frames_ordering() {
 	let catalog_id = id(catalog_cb.recv());
 
 	let frame_cb = Callback::new();
-	let track = id(unsafe { moq_consume_audio_ordered(catalog_id, 0, 10_000, Some(channel_callback), frame_cb.ptr) });
+	let track = id(unsafe { moq_consume_audio(catalog_id, 0, 10_000, Some(channel_callback), frame_cb.ptr) });
 
 	let timestamps: [u64; 5] = [0, 20_000, 40_000, 60_000, 80_000];
 	for (i, &ts) in timestamps.iter().enumerate() {
@@ -1653,8 +1653,8 @@ fn multiple_frames_ordering() {
 		"catalog close delivers terminal 0"
 	);
 	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_media_close(media), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_media_finish(media), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 
@@ -1666,7 +1666,7 @@ fn catalog_update_on_new_track() {
 	let init = opus_head();
 	let format = b"opus";
 	let media1 = id(unsafe {
-		moq_publish_media_ordered(
+		moq_publish_media(
 			broadcast,
 			format.as_ptr() as *const c_char,
 			format.len(),
@@ -1676,7 +1676,7 @@ fn catalog_update_on_new_track() {
 	});
 
 	let path = b"catalog-update";
-	let _publish = id(unsafe { moq_origin_publish(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
+	let _announce = id(unsafe { moq_origin_announce(origin, path.as_ptr() as *const c_char, path.len(), broadcast) });
 
 	let consume = request_broadcast(origin, path);
 	let catalog_cb = Callback::new();
@@ -1697,7 +1697,7 @@ fn catalog_update_on_new_track() {
 	assert!(unsafe { moq_consume_audio_config(catalog_id1, 1, &mut audio_cfg) } < 0);
 
 	let media2 = id(unsafe {
-		moq_publish_media_ordered(
+		moq_publish_media(
 			broadcast,
 			format.as_ptr() as *const c_char,
 			format.len(),
@@ -1716,9 +1716,9 @@ fn catalog_update_on_new_track() {
 	assert_eq!(moq_consume_catalog_close(catalog_task), 0);
 	assert_eq!(catalog_cb.recv_terminal(), 0, "catalog close delivers terminal 0");
 	assert_eq!(moq_consume_close(consume), 0);
-	assert_eq!(moq_publish_media_close(media1), 0);
-	assert_eq!(moq_publish_media_close(media2), 0);
-	assert_eq!(moq_publish_close(broadcast), 0);
+	assert_eq!(moq_publish_media_finish(media1), 0);
+	assert_eq!(moq_publish_media_finish(media2), 0);
+	assert_eq!(moq_publish_finish(broadcast), 0);
 	assert_eq!(moq_origin_close(origin), 0);
 }
 

--- a/rs/libmoq/src/video.rs
+++ b/rs/libmoq/src/video.rs
@@ -3,7 +3,7 @@
 //! The video counterpart to [`audio`](crate::audio)'s decoder: subscribe to an
 //! H.264 track and hand back decoded raw frames, with the decode happening
 //! inside the FFI boundary (VideoToolbox on macOS, openh264 elsewhere; no
-//! ffmpeg). Sibling to `moq_consume_video_ordered`, which delivers the
+//! ffmpeg). Sibling to `moq_consume_video`, which delivers the
 //! still-encoded frames for a caller that brings its own decoder.
 //!
 //! Only H.264 is supported. A non-H.264 rendition fails the subscribe with a
@@ -29,7 +29,7 @@ use crate::{Error, Id, NonZeroSlab, State, ffi};
 pub struct moq_video_decoder_output {
 	/// Upper bound on buffering before skipping a stalled group, in
 	/// milliseconds. Same congestion-control knob as
-	/// `moq_consume_video_ordered`'s `max_latency_ms`. 0 = skip aggressively
+	/// `moq_consume_video`'s `max_latency_ms`. 0 = skip aggressively
 	/// (the moq-mux default); set to your playout buffer for a softer skip.
 	pub latency_max_ms: u64,
 }
@@ -187,7 +187,7 @@ impl Video {
 /// Subscribe to a video track and decode it into raw I420 frames.
 ///
 /// The catalog `index` selects which video rendition to subscribe to, matching
-/// the existing `moq_consume_video_ordered` selection model. Only H.264 is
+/// the existing `moq_consume_video` selection model. Only H.264 is
 /// supported; a non-H.264 rendition fails on the terminal callback.
 ///
 /// Returns a non-zero handle on success or a negative error code.

--- a/test/smoke/clients/c/subscribe.c
+++ b/test/smoke/clients/c/subscribe.c
@@ -75,7 +75,7 @@ static void on_catalog(void *ud, int32_t catalog) {
         moq_video_config vcfg;
         memset(&vcfg, 0, sizeof(vcfg));
         if (moq_consume_video_config((uint32_t)catalog, 0, &vcfg) == 0) {
-            int32_t track = moq_consume_video_ordered((uint32_t)catalog, 0, 1000, on_frame, ud);
+            int32_t track = moq_consume_video((uint32_t)catalog, 0, 1000, on_frame, ud);
             if (track > 0) {
                 pthread_mutex_lock(&c->mu);
                 c->video_started = 1;


### PR DESCRIPTION
Closes #2317.

## Summary

Five naming cleanups to the C ABI, while it is still young enough to rename without a migration. Targets `dev`: this breaks a published contract.

- **`moq_origin_publish` / `moq_origin_unpublish` -> `moq_origin_announce` / `moq_origin_unannounce`.** The publish verb was libmoq-only; #2037 moved every other layer to announce (moq-ffi already calls it `origin.announce()`, and moq-net's guard is `.unannounce()`).
- **`moq_remove_catalog_section` -> `moq_publish_catalog_section_remove`**, under its `moq_publish_catalog_section` sibling instead of breaking the verb-prefix scheme.
- **Producer teardown is `_finish`, not `_close`.** `_close` meant three things (finish a producer, stop a listener, close a connection) while `_abort` sat right next to it, so a C caller had to read the doc to learn `_close` was not `_abort`. `moq_publish_track_finish` now also pairs with the pre-existing `moq_publish_track_finish_at`.
- **Dropped the `_ordered` suffix**, which leaked a long-gone internal type: `moq_publish_media`, `moq_consume_video`, `moq_consume_audio`. These match the `publish_media` / `subscribe_media` names moq-ffi already uses.
- **Doc fix:** `moq_track_info.timescale_valid` claimed it overrides a default *millisecond* timescale. The default is and was `Timescale::MICRO`, matching `timestamp_us` everywhere else. Only the doc was wrong; `doc/lib/c/index.md` already said microseconds.

### Judgment calls worth reviewing

- **No compat aliases.** The issue left this open ("hidden compat aliases if needed"). They aren't needed: libmoq is `crate-type = ["staticlib"]` only, so every consumer recompiles against the regenerated `moq.h`; there is no prebuilt-binary path an unexported alias could serve. The CHANGELOG already sets precedent for clean breaking renames this same unreleased cycle (`moq_publish_json` -> `moq_publish_json_snapshot`).
- **All 7 producer `_close` ops renamed, not just the 2 the issue named.** It named `moq_publish_track_close`/`_group_close` as examples but stated the rule as "on producers"; renaming only those leaves `_close` still meaning three things. The internals already said `finish` (`track_finish`, `group_finish`, and `close` -> `broadcast.finish()`), so the C ABI was the sole outlier.
- **`moq_session_connect`'s `origin_publish` parameter kept.** It pairs with `origin_consume` and names a direction, not this operation.

## Public API changes

All breaking, all `libmoq` C ABI:

| Before | After |
|---|---|
| `moq_origin_publish` | `moq_origin_announce` |
| `moq_origin_unpublish` | `moq_origin_unannounce` |
| `moq_remove_catalog_section` | `moq_publish_catalog_section_remove` |
| `moq_publish_close` | `moq_publish_finish` |
| `moq_publish_media_close` | `moq_publish_media_finish` |
| `moq_publish_track_close` | `moq_publish_track_finish` |
| `moq_publish_group_close` | `moq_publish_group_finish` |
| `moq_publish_json_snapshot_close` | `moq_publish_json_snapshot_finish` |
| `moq_publish_json_stream_close` | `moq_publish_json_stream_finish` |
| `moq_publish_audio_raw_close` | `moq_publish_audio_raw_finish` |
| `moq_publish_media_ordered` | `moq_publish_media` |
| `moq_consume_video_ordered` | `moq_consume_video` |
| `moq_consume_audio_ordered` | `moq_consume_audio` |

Unchanged: `moq_consume_*_close`, `moq_origin_*_close`, `moq_session_close` (`_close` keeps its stop-a-listener and close-a-connection meanings). The rest of the diff is private (`libmoq::{origin,publish,consume,audio}` internals renamed to match).

## Cross-Package Sync

- `cpp/obs/src` - updated (`moq_origin_announce`, `moq_publish_media`, `moq_publish_finish`, `moq_consume_video`).
- `doc/lib/c`, `doc/concept/layer/hang.md`, `rs/libmoq/README.md`, `rs/libmoq/CHANGELOG.md` - updated.
- `doc/bin/obs.md` - **skipped**: contains no `moq_` symbols.
- `rs/moq-ffi` + `py`/`swift`/`kt`/`go` - **skipped**: they wrap `moq-ffi`, not `libmoq`, and moq-ffi already uses the names renamed *toward*, which is what made them the right targets.

## Test plan

- `cargo test -p libmoq` - 35/35 pass.
- `cargo clippy -p libmoq --all-targets` - clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p libmoq` - passes. This PR renames documented items carrying `[moq_...]` intra-doc links, which is exactly the class that passes `just check` but fails CI.
- Generated `moq.h` - every new name present, zero old names remaining.
- `test/smoke/clients/c/subscribe.c` compiles against the regenerated header with `-Werror=implicit-function-declaration`.
- Every `moq_*` symbol `cpp/obs` calls resolves in the regenerated header (except one pre-existing break, below).
- `just fix` - no changes.

Full `just check` could not be run to green locally: it failed in `moq-mux`, `moq-native`, and `moq-relay`, none of which this branch touches, with errors that contradict the current source (e.g. `no method named sign found for moq_token::Key`, on a HEAD whose own commit is #2329 which added it). That is stale shared-target artifacts from concurrent worktrees, so the targeted per-crate runs above stand in. CI on a clean runner is the real gate.

## Pre-existing bug found, not fixed here

`cpp/obs/src/moq-source.cpp:654` calls `moq_origin_consume(origin, path, len)`, which libmoq removed in #1772; the OBS plugin cannot compile against current libmoq. Identical on pristine `dev`, so it predates this PR. The replacements (`moq_origin_request` / `moq_origin_consume_announced`) are 5-arg and callback-based with different semantics, so it needs a restructure and a behavior decision rather than a rename. Left alone to keep this PR mechanical; tracked separately.

(Written by Claude Opus 4.8)