### PR TITLE
fix(bindings)!: converge py/swift/kt/go on one wrapper contract

### DIFF
--- a/doc/concept/layer/hang.md
+++ b/doc/concept/layer/hang.md
@@ -100,7 +100,7 @@ The catalog is a JSON document published through the merge-patch snapshot helper
   In Rust, either flatten the catalog into your own struct with `#[serde(flatten)]` for typed access, or read sections untyped from an `Extra` catalog, which keeps unknown keys as raw JSON (`catalog.section("scte35")`). The `()` default drops sections it doesn't model.
   The FFI bindings always use the untyped form, one JSON string per section keyed by name (`catalog.sections["scte35"]` in Python, `moq_catalog_get_section()` / `moq_catalog_section_at()` in C).
 - **Writing**: the catalog producer holds one shared document.
-  Each owner edits only its own keys and publishes: `producer.mutate(c => { c.scte35 = ... })` in TypeScript; the `Deref`/`DerefMut` lock guard from `producer.lock()` for a typed Rust extension, or `producer.set_section("scte35", value)` for an untyped one; `broadcast.set_catalog_section("scte35", json)` in Python; `moq_publish_catalog_section()` in C.
+  Each owner edits only its own keys and publishes: `producer.mutate(c => { c.scte35 = ... })` in TypeScript; the `Deref`/`DerefMut` lock guard from `producer.lock()` for a typed Rust extension, or `producer.set_section("scte35", value)` for an untyped one; `broadcast.set_catalog_section("scte35", value)` in Python; `moq_publish_catalog_section()` in C.
   Every edit starts from the latest value, so the base media sections and any extension sections compose instead of clobbering one another.
   Removing a key publishes a deletion (`producer.remove_section(...)`, `broadcast.remove_catalog_section(...)` in Python, `moq_remove_catalog_section()` in C), which a consumer reads as the section being removed.
 

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -234,6 +234,26 @@ _ = producer.Finish()
 
 Call `request.Abort(code)` when the requested group cannot be produced. Fetch is currently a single-group operation and is supported by the moq-lite 05+ FETCH wire path.
 
+To serve requests in a loop, range over `dynamic.Requests(ctx)` instead, the same shape `BroadcastDynamic` and `OriginDynamic` use:
+
+```go
+for request, err := range dynamic.Requests(ctx) {
+    if err != nil {
+        if moq.IsShutdown(err) {
+            break
+        }
+        log.Fatal(err)
+    }
+
+    producer, err := request.Accept()
+    if err != nil {
+        log.Fatal(err)
+    }
+    _ = producer.WriteFrame(loadArchivedFrame(request.Sequence()), request.Sequence()*20_000)
+    _ = producer.Finish()
+}
+```
+
 ## Raw track timestamps
 
 Raw tracks carry arbitrary byte payloads. `WriteFrame` takes a caller-supplied
@@ -291,7 +311,7 @@ origin := moq.NewOriginProducerWithOptions(moq.OriginOptions{
 dynamic := origin.Dynamic()
 defer dynamic.Cancel()
 
-for request, err := range dynamic.All(ctx) {
+for request, err := range dynamic.Requests(ctx) {
 	if err != nil {
 		if moq.IsShutdown(err) {
 			break

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -48,6 +48,16 @@ Moq.connect(
 
 Advanced callers can pass their own `publish` / `subscribe` origins, or skip the facade entirely and drive `uniffi.moq.MoqClient` directly.
 
+To resolve a single broadcast rather than iterate announcements:
+
+```kotlin
+// Waits for the announcement, however long that takes.
+val broadcast = moq.announcedBroadcast("demos/clock").available()
+
+// Resolves as soon as it can be served (announced or dynamic), else throws.
+val broadcast = moq.requestBroadcast("demos/clock")
+```
+
 A server can reject the connection on auth grounds: `MoqException.Unauthorized` (HTTP 401) or `MoqException.Forbidden` (HTTP 403). These are terminal: retrying without new credentials won't help, so handle them separately from a transient transport failure. Use the `isAuth` helper to catch both:
 
 ```kotlin
@@ -107,6 +117,41 @@ Moq.connect("https://relay.example.com").use { moq ->
     broadcast.finish()
 }
 ```
+
+## Serve
+
+`Server.listen(bind)` binds a listener, wires an internal origin for both directions, and returns an `AutoCloseable` `Server`. `serve()` accepts every session and holds it alive until it closes:
+
+```kotlin
+import dev.moq.*
+
+Server.listen("127.0.0.1:4443", tlsGenerate = listOf("localhost")).use { server ->
+    val broadcast = BroadcastProducer()
+    server.announce("live", broadcast)
+
+    server.serve()
+}
+```
+
+Collect `requests()` instead when you need to inspect or reject a session before accepting it. Each `Request` must be answered with `ok()` or `close(code)`, and the returned session held to keep the connection alive:
+
+```kotlin
+Server.listen("127.0.0.1:4443", tlsGenerate = listOf("localhost")).use { server ->
+    server.requests().collect { request ->
+        val url = request.url()
+        if (url != null && "/admin" in url) {
+            request.close(403u)
+            return@collect
+        }
+        launch {
+            val session = request.ok()
+            session.closed()
+        }
+    }
+}
+```
+
+`server.certFingerprints()` returns the hex SHA-256 fingerprints of the configured certificates, for pinning a generated self-signed certificate in a browser via `serverCertificateHashes`. Advanced callers can pass their own `publish` / `subscribe` origins to `listen`, or drive `uniffi.moq.MoqServer` directly.
 
 ### Fetching raw groups
 
@@ -205,27 +250,31 @@ The served broadcast is not announced. It only resolves consumers that call `req
 
 ### JSON tracks
 
-For JSON payloads, publish and subscribe with the framing handled for you, in one of two modes. Snapshot (lossy) carries one value updated over time; a subscriber only sees the latest. Stream (lossless) is an ordered append-log where every record is preserved. Values cross as JSON strings; serialize with your JSON library of choice.
+For JSON payloads, publish and subscribe with the framing handled for you, in one of two modes. Snapshot (lossy) carries one value updated over time; a subscriber only sees the latest. Stream (lossless) is an ordered append-log where every record is preserved.
+
+Pass a `@Serializable` type and the wrapper encodes and decodes it with `kotlinx.serialization`:
 
 ```kotlin
 import dev.moq.*
-import uniffi.moq.MoqBroadcastProducer
-import uniffi.moq.MoqJsonSnapshotConfig
-import uniffi.moq.MoqJsonStreamConfig
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Status(val state: String)
 
 // Snapshot: each update supersedes the last.
-val config = MoqJsonSnapshotConfig(deltaRatio = 8u, compression = true)
+val config = JsonSnapshotConfig(deltaRatio = 8u, compression = true)
 val status = broadcast.publishJsonSnapshot("status", config)
-status.update("""{"state":"live"}""")
+status.update(Status(state = "live"))
 
-val broadcastConsumer = broadcast.consume()
-val consumer = broadcastConsumer.subscribeJsonSnapshot("status", config)
-consumer.values().collect { value -> println(value) }
+val consumer = broadcast.consume().subscribeJsonSnapshot("status", config)
+consumer.valuesAs<Status>().collect { value -> println(value.state) }
 
 // Stream: every record is delivered in order.
-val events = broadcast.publishJsonStream("events", MoqJsonStreamConfig(compression = false))
-events.append("""{"event":"started"}""")
+val events = broadcast.publishJsonStream("events", JsonStreamConfig(compression = false))
+events.append(Status(state = "started"))
 ```
+
+The raw string form stays available for other JSON libraries: `update("""{"state":"live"}""")` passes the payload straight through, and `values()` yields the undecoded strings. The same split applies to `setCatalogSection(name, value)`, which encodes a `@Serializable` value, or forwards a `String` unchanged.
 
 `compression` must match on the producer and subscriber. In snapshot mode, `deltaRatio` of `0` disables merge-patch deltas (every change is a fresh snapshot).
 

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -36,15 +36,19 @@ async with moq.Client("https://relay.example.com") as client:
 
 `Client(url, *, tls_verify=True, tls_roots=None, tls_system_roots=None, tls_fingerprints=None, tls_cert=None, tls_key=None, bind=None, publish=None, subscribe=None)`. Use `tls_cert` and `tls_key` for mutual TLS. Without `publish` / `subscribe` an internal origin is created automatically. Pass an `OriginProducer` to share state across multiple clients.
 
-A server can reject the connection on auth grounds: `moq.Error.Unauthorized` (HTTP 401) or `moq.Error.Forbidden` (HTTP 403). These are terminal, so handle them separately from a transient transport failure rather than reconnecting:
+A server can reject the connection on auth grounds: `moq.Error.Unauthorized` (HTTP 401) or `moq.Error.Forbidden` (HTTP 403). These are terminal, so handle them separately from a transient transport failure rather than reconnecting. `moq.is_auth(err)` catches both:
 
 ```python
 try:
     async with moq.Client("https://relay.example.com") as client:
         ...
-except (moq.Error.Unauthorized, moq.Error.Forbidden):
-    ...  # Prompt for credentials; don't reconnect.
+except moq.Error as err:
+    if moq.is_auth(err):
+        ...  # Prompt for credentials; don't reconnect.
+    raise
 ```
+
+`moq.is_shutdown(err)` is the companion: true for `Cancelled` and `Closed`, which arise from graceful shutdown rather than an actual failure. Use it to break out of an `async for` without treating the expected end-of-stream error as a problem.
 
 ### Publishing media
 
@@ -86,14 +90,14 @@ async for announcement in client.announced("prefix/"):
 
 ### Catalog extensions
 
-Advertise application-specific metadata (for example a side-channel transcript track) as an untyped catalog section. The value is any JSON string; it rides alongside `video`/`audio` and reaches subscribers as `Catalog.sections`.
+Advertise application-specific metadata (for example a side-channel transcript track) as an untyped catalog section. The value is any JSON-serializable object; it rides alongside `video`/`audio` and reaches subscribers as `Catalog.sections`.
 
 ```python
 import json
 
 # Publish: attach a custom section.
 broadcast = moq.BroadcastProducer()
-broadcast.set_catalog_section("transcript", json.dumps({"track": "transcript.json"}))
+broadcast.set_catalog_section("transcript", {"track": "transcript.json"})
 client.announce("my-stream", broadcast)
 
 # Subscribe: read it back. Sections are unknown to the base catalog, so decode the JSON yourself.

--- a/go/wrapper/moq/client.go
+++ b/go/wrapper/moq/client.go
@@ -11,7 +11,7 @@ import (
 type ClientOption func(*clientConfig)
 
 type clientConfig struct {
-	tlsDisableVerify   bool
+	tlsVerify          bool
 	tlsRoots           []string
 	tlsRootsSet        bool
 	tlsSystemRoots     bool
@@ -25,9 +25,11 @@ type clientConfig struct {
 	subscribe          *OriginProducer
 }
 
-// WithTLSDisableVerify disables TLS certificate verification (development only).
-func WithTLSDisableVerify() ClientOption {
-	return func(c *clientConfig) { c.tlsDisableVerify = true }
+// WithTLSVerify toggles TLS certificate verification. Verification is on by
+// default; pass false only against a relay with a self-signed certificate
+// during development.
+func WithTLSVerify(verify bool) ClientOption {
+	return func(c *clientConfig) { c.tlsVerify = verify }
 }
 
 // WithTLSRoots trusts PEM root certificate files instead of the system roots.
@@ -100,7 +102,9 @@ type Client struct {
 // Dial connects to a MoQ server and returns the established client. Cancel ctx
 // to abort an in-flight connect.
 func Dial(ctx context.Context, url string, opts ...ClientOption) (*Client, error) {
-	var cfg clientConfig
+	// Verification is on unless WithTLSVerify(false) says otherwise; the zero
+	// value would mean the opposite.
+	cfg := clientConfig{tlsVerify: true}
 	for _, opt := range opts {
 		opt(&cfg)
 	}
@@ -116,7 +120,7 @@ func Dial(ctx context.Context, url string, opts ...ClientOption) (*Client, error
 	}
 
 	inner := ffi.NewMoqClient()
-	if cfg.tlsDisableVerify {
+	if !cfg.tlsVerify {
 		inner.SetTlsDisableVerify(true)
 	}
 	if cfg.tlsRootsSet {

--- a/go/wrapper/moq/example_test.go
+++ b/go/wrapper/moq/example_test.go
@@ -108,11 +108,40 @@ func ExampleListen() {
 	}
 	defer server.Close()
 
-	err = server.Serve(ctx, func(req *moq.Request) (bool, error) {
-		// Reject anything that didn't arrive over QUIC.
-		return req.Transport() == moq.TransportQUIC, nil
-	})
-	if err != nil && !moq.IsShutdown(err) {
+	if err := server.Serve(ctx); err != nil && !moq.IsShutdown(err) {
 		log.Fatal(err)
+	}
+}
+
+// Drive the accept loop directly to decide which sessions to admit.
+func ExampleServer_Requests() {
+	ctx := context.Background()
+
+	server, err := moq.Listen(ctx, "127.0.0.1:4443", moq.WithTLSGenerate("localhost"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer server.Close()
+
+	for req, err := range server.Requests(ctx) {
+		if err != nil {
+			if moq.IsShutdown(err) {
+				break
+			}
+			log.Fatal(err)
+		}
+
+		// Reject anything that didn't arrive over QUIC.
+		if req.Transport() != moq.TransportQUIC {
+			_ = req.Close(ctx, 403)
+			continue
+		}
+
+		session, err := req.OK(ctx)
+		if err != nil {
+			continue
+		}
+		// Hold the session to keep the connection alive.
+		go func() { _ = session.Closed(ctx) }()
 	}
 }

--- a/go/wrapper/moq/origin.go
+++ b/go/wrapper/moq/origin.go
@@ -62,8 +62,9 @@ func (d *OriginDynamic) RequestedBroadcast(ctx context.Context) (*BroadcastReque
 	return &BroadcastRequest{inner: inner}, nil
 }
 
-// All ranges over requested broadcasts until the stream errors or the loop breaks.
-func (d *OriginDynamic) All(ctx context.Context) iter.Seq2[*BroadcastRequest, error] {
+// Requests ranges over requested broadcasts until the stream errors or the loop
+// breaks.
+func (d *OriginDynamic) Requests(ctx context.Context) iter.Seq2[*BroadcastRequest, error] {
 	return streamSeq(ctx, d.RequestedBroadcast)
 }
 

--- a/go/wrapper/moq/publish.go
+++ b/go/wrapper/moq/publish.go
@@ -379,6 +379,11 @@ func (d *TrackDynamic) RequestedGroup(ctx context.Context) (*GroupRequest, error
 	return &GroupRequest{inner: inner}, nil
 }
 
+// Requests ranges over uncached group requests until the dynamic source ends.
+func (d *TrackDynamic) Requests(ctx context.Context) iter.Seq2[*GroupRequest, error] {
+	return streamSeq(ctx, d.RequestedGroup)
+}
+
 // Cancel stops current and future requested-group waits.
 func (d *TrackDynamic) Cancel() {
 	d.inner.Cancel()

--- a/go/wrapper/moq/server.go
+++ b/go/wrapper/moq/server.go
@@ -236,14 +236,25 @@ func (s *Server) Requests(ctx context.Context) iter.Seq2[*Request, error] {
 	}
 }
 
-// Serve accepts sessions in a loop, holding each one alive in its own goroutine
-// until it closes, so memory does not grow with past connections. It returns
-// when Accept stops (nil) or fails, after the in-flight sessions wind down.
+// Serve accepts every session in a loop, holding each one alive in its own
+// goroutine until it closes, so memory does not grow with past connections. It
+// returns when Accept stops (nil) or fails, after the in-flight sessions wind
+// down.
 //
-// Pass onRequest to inspect a Request before accepting: return false to reject
-// with HTTP 403, or an error to reject with 500 and stop serving. Pass nil to
-// accept every request. For richer routing, drive Requests/Accept directly.
-func (s *Server) Serve(ctx context.Context, onRequest func(*Request) (bool, error)) error {
+// To inspect or reject requests, range over Requests instead:
+//
+//	for req, err := range server.Requests(ctx) {
+//	    if err != nil {
+//	        return err
+//	    }
+//	    if url := req.URL(); url != nil && strings.Contains(*url, "/admin") {
+//	        _ = req.Close(ctx, 403)
+//	        continue
+//	    }
+//	    session, err := req.OK(ctx)
+//	    // hold the session to keep the connection alive
+//	}
+func (s *Server) Serve(ctx context.Context) error {
 	var wg sync.WaitGroup
 	defer wg.Wait()
 
@@ -259,18 +270,6 @@ func (s *Server) Serve(ctx context.Context, onRequest func(*Request) (bool, erro
 		}
 		if req == nil {
 			return nil
-		}
-
-		if onRequest != nil {
-			ok, err := onRequest(req)
-			if err != nil {
-				_ = req.Close(ctx, 500)
-				return err
-			}
-			if !ok {
-				_ = req.Close(ctx, 403)
-				continue
-			}
 		}
 
 		wg.Add(1)

--- a/kt/build.gradle.kts
+++ b/kt/build.gradle.kts
@@ -1,6 +1,18 @@
-// Root build script. Each module declares its own plugins and version
-// (`:moq-ffi` from `moqffi.version`, `:moq` from `moq.version`); root just
-// pins the shared group.
+// Root build script. Each module sets its own version (`:moq-ffi` from
+// `moqffi.version`, `:moq` from `moq.version`); root pins the shared group and
+// the plugin versions.
+//
+// The plugin versions live here rather than in each module because Gradle
+// refuses to load the Kotlin plugin twice across subprojects that each declare
+// their own version. Declaring them once at the root with `apply false` puts
+// them on one shared classpath; the modules then request them by id alone and
+// choose whether to apply.
+
+plugins {
+    kotlin("multiplatform") version "2.0.21" apply false
+    kotlin("plugin.serialization") version "2.0.21" apply false
+    id("com.vanniktech.maven.publish") version "0.30.0" apply false
+}
 
 allprojects {
     group = "dev.moq"

--- a/kt/build.gradle.kts
+++ b/kt/build.gradle.kts
@@ -7,10 +7,18 @@
 // their own version. Declaring them once at the root with `apply false` puts
 // them on one shared classpath; the modules then request them by id alone and
 // choose whether to apply.
+//
+// The Android plugin has to be declared here too, even though its version is
+// pinned in settings.gradle.kts. Once Kotlin resolves from the root classloader,
+// AGP declared only in a module lands on a child one that Kotlin can't see, and
+// applying it fails with "Can't infer current AndroidGradlePluginVersion". Only
+// the Android-enabled build hits that, so it fails in CI but not a default local
+// `just kt check`.
 
 plugins {
     kotlin("multiplatform") version "2.0.21" apply false
     kotlin("plugin.serialization") version "2.0.21" apply false
+    id("com.android.library") apply false
     id("com.vanniktech.maven.publish") version "0.30.0" apply false
 }
 

--- a/kt/moq-ffi/build.gradle.kts
+++ b/kt/moq-ffi/build.gradle.kts
@@ -35,11 +35,12 @@ import com.android.build.gradle.LibraryExtension
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
+// Plugin versions are pinned in the root build.gradle.kts (Kotlin, publish) and
+// settings.gradle.kts (Android); request them by id alone here.
 plugins {
-    kotlin("multiplatform") version "2.0.21"
-    // Version pinned in settings.gradle.kts.
+    kotlin("multiplatform")
     id("com.android.library") apply false
-    id("com.vanniktech.maven.publish") version "0.30.0"
+    id("com.vanniktech.maven.publish")
 }
 
 version = providers.gradleProperty("moqffi.version").get()

--- a/kt/moq/build.gradle.kts
+++ b/kt/moq/build.gradle.kts
@@ -25,11 +25,14 @@ import com.android.build.gradle.LibraryExtension
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
+// Plugin versions are pinned in the root build.gradle.kts (Kotlin, publish) and
+// settings.gradle.kts (Android); request them by id alone here.
 plugins {
-    kotlin("multiplatform") version "2.0.21"
-    // Version pinned in settings.gradle.kts.
+    kotlin("multiplatform")
+    // Powers the typed JSON track helpers in Json.kt.
+    kotlin("plugin.serialization")
     id("com.android.library") apply false
-    id("com.vanniktech.maven.publish") version "0.30.0"
+    id("com.vanniktech.maven.publish")
 }
 
 version = providers.gradleProperty("moq.version").get()
@@ -66,6 +69,9 @@ kotlin {
         val commonMain by getting {
             dependencies {
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")
+                // api: the typed JSON helpers are inline+reified, so they
+                // resolve serializers at the consumer's call site.
+                api("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
             }
         }
         val commonTest by getting {

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -7,10 +7,10 @@ package dev.moq
 // are the exact same objects, so every FFI method and the extensions in
 // Flows.kt / Errors.kt apply unchanged.
 
-// Session + connection handles.
+// Session + connection handles. `Server` is not aliased: `dev.moq.Server` is the
+// listen facade (see Server.kt), which exposes the raw handle as `server`.
 typealias Client = uniffi.moq.MoqClient
 typealias Session = uniffi.moq.MoqSession
-typealias Server = uniffi.moq.MoqServer
 typealias Request = uniffi.moq.MoqRequest
 
 // Origin (broadcast discovery / announcement).

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Json.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Json.kt
@@ -1,0 +1,65 @@
+package dev.moq
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
+import uniffi.moq.MoqBroadcastProducer
+import uniffi.moq.MoqJsonSnapshotConsumer
+import uniffi.moq.MoqJsonSnapshotProducer
+import uniffi.moq.MoqJsonStreamConsumer
+import uniffi.moq.MoqJsonStreamProducer
+
+/**
+ * The [Json] format used by the typed helpers below.
+ *
+ * Lenient about unknown keys so a producer adding a field does not break older
+ * subscribers, matching how the catalog treats untyped sections.
+ */
+val MoqJson: Json = Json { ignoreUnknownKeys = true }
+
+/**
+ * Publish [value] as a JSON snapshot, superseding the last. A no-op when unchanged.
+ *
+ * The `@Serializable` type is encoded with [MoqJson]. Pass an already-encoded
+ * `String` to serialize with another library: the member overload takes it
+ * unchanged.
+ */
+inline fun <reified T> MoqJsonSnapshotProducer.update(value: T) {
+    update(MoqJson.encodeToString(serializer<T>(), value))
+}
+
+/** Append [value] to a JSON stream track as one record, encoded with [MoqJson]. */
+inline fun <reified T> MoqJsonStreamProducer.append(value: T) {
+    append(MoqJson.encodeToString(serializer<T>(), value))
+}
+
+/**
+ * Stream of decoded snapshot values, yielding the latest reconstructed value.
+ *
+ * A consumer that has fallen behind collapses the backlog to the latest. Use
+ * [MoqJsonSnapshotConsumer.values] for the undecoded JSON strings.
+ */
+inline fun <reified T> MoqJsonSnapshotConsumer.valuesAs(): Flow<T> =
+    values().map { MoqJson.decodeFromString(serializer<T>(), it) }
+
+/**
+ * Stream of decoded stream records, in order.
+ *
+ * Use [MoqJsonStreamConsumer.values] for the undecoded JSON strings.
+ */
+inline fun <reified T> MoqJsonStreamConsumer.valuesAs(): Flow<T> =
+    values().map { MoqJson.decodeFromString(serializer<T>(), it) }
+
+/**
+ * Set or replace an untyped application section in the catalog.
+ *
+ * [value] is encoded with [MoqJson] and lands as a top-level catalog key
+ * alongside `video`/`audio`, reaching subscribers via `Catalog.sections`. [name]
+ * must not be a reserved media section ("video"/"audio"). The catalog is
+ * republished automatically. Pass an already-encoded `String` to serialize with
+ * another library.
+ */
+inline fun <reified T> MoqBroadcastProducer.setCatalogSection(name: String, value: T) {
+    setCatalogSection(name, MoqJson.encodeToString(serializer<T>(), value))
+}

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt
@@ -2,7 +2,9 @@ package dev.moq
 
 import kotlinx.coroutines.flow.Flow
 import uniffi.moq.MoqAnnounced
+import uniffi.moq.MoqAnnouncedBroadcast
 import uniffi.moq.MoqAnnouncement
+import uniffi.moq.MoqBroadcastConsumer
 import uniffi.moq.MoqClient
 import uniffi.moq.MoqOriginOptions
 import uniffi.moq.MoqOriginProducer
@@ -43,6 +45,23 @@ class Moq internal constructor(
 
     /** Raw announcement handle under [prefix]. */
     fun announced(prefix: String = ""): MoqAnnounced = session.consumer().announced(prefix)
+
+    /**
+     * Await the broadcast announced at exactly [path].
+     *
+     * Unlike [requestBroadcast] this waits indefinitely for a future
+     * announcement. Cancel the returned handle to stop waiting.
+     */
+    fun announcedBroadcast(path: String): MoqAnnouncedBroadcast = session.consumer().announcedBroadcast(path)
+
+    /**
+     * Resolve the broadcast at [path] as soon as it can be served: the announced
+     * broadcast if present, otherwise a dynamic fallback on the origin.
+     *
+     * Unlike [announcedBroadcast] this does not wait for a future announcement;
+     * it throws when neither can serve the path.
+     */
+    suspend fun requestBroadcast(path: String): MoqBroadcastConsumer = session.consumer().requestBroadcast(path)
 
     override fun close() {
         session.shutdown()

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Server.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Server.kt
@@ -1,0 +1,135 @@
+package dev.moq
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.launch
+import uniffi.moq.MoqException
+import uniffi.moq.MoqOriginOptions
+import uniffi.moq.MoqOriginProducer
+import uniffi.moq.MoqRequest
+import uniffi.moq.MoqServer
+
+/**
+ * A listening MoQ server with publish/subscribe conveniences.
+ *
+ * Build one with [Server.listen]. Broadcasts announced via [announce] are served
+ * to incoming sessions, and [requests] streams each incoming [MoqRequest] for
+ * the caller to accept or reject.
+ *
+ * [Server] is [AutoCloseable]; `use { ... }` (or [close]) stops accepting new
+ * sessions. In-flight sessions stay alive until their handles are dropped or
+ * cancelled.
+ */
+class Server internal constructor(
+    /** The underlying server handle. */
+    val server: MoqServer,
+    /** The bound local address, e.g. `127.0.0.1:4443`. Resolved by [listen]. */
+    val localAddr: String,
+    private val publishOrigin: MoqOriginProducer?,
+) : AutoCloseable {
+    /** Announce [broadcast] under [path] so incoming sessions can discover it. */
+    fun announce(path: String, broadcast: BroadcastProducer) {
+        val origin = publishOrigin ?: throw IllegalStateException("no publish origin configured")
+        origin.announce(path, broadcast)
+    }
+
+    /**
+     * SHA-256 fingerprints of the configured TLS certificates, hex-encoded.
+     *
+     * Useful for pinning a generated self-signed certificate in a browser via
+     * WebTransport's `serverCertificateHashes`.
+     */
+    fun certFingerprints(): List<String> = server.certFingerprints()
+
+    /**
+     * Stream of incoming sessions. Each [MoqRequest] must be answered with
+     * `ok()` to complete the handshake or `close(code)` to reject it; the
+     * returned session must be held to keep the connection alive.
+     *
+     * The Flow completes when the server stops accepting.
+     */
+    fun requests(): Flow<MoqRequest> = flow {
+        while (true) {
+            currentCoroutineContext().ensureActive()
+            emit(server.accept() ?: break)
+        }
+    }.onCompletion { cause ->
+        if (cause is CancellationException) server.cancel()
+    }
+
+    /**
+     * Accept every session in a loop, holding each one alive in its own
+     * coroutine until it closes, so memory does not grow with past connections.
+     *
+     * Returns when the server stops accepting. To inspect or reject requests,
+     * collect [requests] instead.
+     */
+    suspend fun serve(): Unit = coroutineScope {
+        requests().collect { request ->
+            launch {
+                // A session failing its handshake, or dying mid-stream, is
+                // routine. Swallow it: letting it escape would cancel the scope
+                // and let one client take the whole accept loop down.
+                try {
+                    request.ok().closed()
+                } catch (e: MoqException) {
+                    // Nothing to do; this session is already gone.
+                }
+            }
+        }
+    }
+
+    override fun close() {
+        server.cancel()
+    }
+
+    companion object {
+        /**
+         * Bind a server at [bind] and start accepting.
+         *
+         * @param bind local socket address to listen on, e.g. "127.0.0.1:4443" or "[::]:443".
+         * @param tlsCert PEM certificate chain paths to serve.
+         * @param tlsKey PEM private key paths to serve.
+         * @param tlsGenerate hostnames to generate a self-signed certificate for.
+         * @param publish origin whose broadcasts are served to incoming sessions; auto-created when null.
+         * @param subscribe origin that receives broadcasts published by incoming sessions; auto-created when null.
+         */
+        suspend fun listen(
+            bind: String = "[::]:443",
+            tlsCert: List<String>? = null,
+            tlsKey: List<String>? = null,
+            tlsGenerate: List<String>? = null,
+            publish: MoqOriginProducer? = null,
+            subscribe: MoqOriginProducer? = null,
+        ): Server {
+            // With neither side specified, wire ONE shared origin to both so a
+            // broadcast announced on this server is also visible to sessions
+            // publishing into it. Mirrors Moq.connect.
+            val shared = if (publish == null && subscribe == null) MoqOriginProducer(MoqOriginOptions()) else null
+            val publishOrigin = publish ?: shared
+            val subscribeOrigin = subscribe ?: shared
+
+            val server = MoqServer()
+            try {
+                server.setBind(bind)
+                if (tlsCert != null) server.setTlsCert(tlsCert)
+                if (tlsKey != null) server.setTlsKey(tlsKey)
+                if (tlsGenerate != null) server.setTlsGenerate(tlsGenerate)
+                if (publishOrigin != null) server.setPublish(publishOrigin)
+                if (subscribeOrigin != null) server.setConsume(subscribeOrigin)
+
+                val localAddr = server.listen()
+                return Server(server, localAddr, publishOrigin)
+            } catch (e: Throwable) {
+                // listen() failed: don't leak the server handle.
+                server.cancel()
+                throw e
+            }
+        }
+    }
+}

--- a/kt/moq/src/jvmAndAndroidTest/kotlin/dev/moq/SmokeTest.kt
+++ b/kt/moq/src/jvmAndAndroidTest/kotlin/dev/moq/SmokeTest.kt
@@ -1,12 +1,17 @@
 package dev.moq
 
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
 import uniffi.moq.MoqException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
+
+@Serializable
+private data class Status(val state: String)
 
 class SmokeTest {
     /**
@@ -70,6 +75,51 @@ class SmokeTest {
             assertEquals(0uL, fetched.sequence())
             assertEquals("cached", fetched.readFrame()?.payload?.decodeToString())
             assertNull(fetched.readFrame())
+        }
+    }
+
+    /** The typed JSON helpers round-trip a `@Serializable` value. */
+    @Test
+    fun `typed json snapshot round-trips a serializable value`() = runTest {
+        BroadcastProducer().use { broadcast ->
+            val config = JsonSnapshotConfig(deltaRatio = 0u, compression = false)
+            val producer = broadcast.publishJsonSnapshot("status", config)
+            producer.update(Status(state = "live"))
+
+            val consumer = broadcast.consume().subscribeJsonSnapshot("status", config)
+            assertEquals(Status(state = "live"), consumer.valuesAs<Status>().first())
+        }
+    }
+
+    /**
+     * A pre-encoded `String` must reach the wire untouched: the member overload
+     * wins over the reified extension, which would otherwise double-encode it
+     * into a JSON string literal.
+     */
+    @Test
+    fun `raw json string passes through unencoded`() = runTest {
+        BroadcastProducer().use { broadcast ->
+            val config = JsonSnapshotConfig(deltaRatio = 0u, compression = false)
+            val producer = broadcast.publishJsonSnapshot("status", config)
+            producer.update("""{"state":"raw"}""")
+
+            val consumer = broadcast.consume().subscribeJsonSnapshot("status", config)
+            assertEquals(Status(state = "raw"), consumer.valuesAs<Status>().first())
+        }
+    }
+
+    @Test
+    fun `server listens, announces, and streams requests`() = runTest {
+        Server.listen("127.0.0.1:0", tlsGenerate = listOf("localhost")).use { server ->
+            assertTrue(server.localAddr.startsWith("127.0.0.1:"), "bound: ${server.localAddr}")
+
+            val fingerprints = server.certFingerprints()
+            assertEquals(1, fingerprints.size)
+            assertEquals(64, fingerprints[0].length)
+
+            BroadcastProducer().use { broadcast ->
+                server.announce("live", broadcast)
+            }
         }
     }
 

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -152,9 +152,12 @@ client = moq.Client(
   - `await .catalog() → Catalog` (convenience)
 - **`CatalogConsumer`**. Async iterator of `Catalog`.
 - **`MediaConsumer`**. Async iterator of `Frame`.
-- **`TrackConsumer`**. Async iterator of groups, plus `.recv_datagram() -> Datagram | None` for best-effort raw track datagrams.
-- **`TrackConsumer`**. Async iterator of raw groups.
+- **`TrackConsumer`**. Async iterator of raw groups, in sequence order.
+  - `await .next_group() → GroupConsumer | None`. Sequence order; what the default iteration yields.
+  - `await .recv_group() → GroupConsumer | None`. Arrival order, which may be out of sequence. Prefer it when latency matters more than order.
+  - `.groups_as_arrived()`. Async iterator over `recv_group()`.
   - `.read_frame() -> Frame | None` returns a timestamped raw frame.
+  - `await .recv_datagram() -> Datagram | None` for best-effort raw track datagrams.
   - `await .info() → TrackInfo`
   - `.update(subscription)`. Change delivery priority, group ordering priority, staleness, or group range after subscribing.
 - **`GroupConsumer`**. Async iterator of timestamped `Frame`s.
@@ -194,6 +197,8 @@ For both `Subscription` and `TrackInfo`, `ordered` controls prioritization only.
 
 - **`log_level(level="info")`**. Initialize logging for the underlying Rust layer (`"error"`, `"warn"`, `"info"`, `"debug"`, `"trace"`). Call once per process.
 - **`Error`**. The exception raised by all operations. Catch a specific case via its variants, e.g. `except moq.Error.AlreadyResponded:` or `except moq.Error.Cancelled:`.
+- **`is_shutdown(err)`**. True for `Cancelled` and `Closed`, which arise from graceful shutdown rather than an actual failure. Use it to break out of an `async for` without treating the expected end-of-stream error as a problem.
+- **`is_auth(err)`**. True for `Unauthorized` (HTTP 401) and `Forbidden` (HTTP 403). Retrying without new credentials won't help, so surface these rather than reconnect.
 
 ## See Also
 

--- a/py/moq-rs/moq/__init__.py
+++ b/py/moq-rs/moq/__init__.py
@@ -6,6 +6,7 @@ Real-time pub/sub with built-in caching, fan-out, and prioritization.
 from moq_ffi import MoqError as Error
 
 from .client import Client, connect
+from .errors import is_auth, is_shutdown
 from .log import log_level
 from .origin import (
     Announced,
@@ -116,5 +117,7 @@ __all__ = [
     "Video",
     "VideoHint",
     "connect",
+    "is_auth",
+    "is_shutdown",
     "log_level",
 ]

--- a/py/moq-rs/moq/client.py
+++ b/py/moq-rs/moq/client.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 from moq_ffi import MoqClient
 
 from .origin import Announced, AnnouncedBroadcast, OriginConsumer, OriginProducer
@@ -116,7 +118,11 @@ class Client:
         origin.announce(path, broadcast)
 
     def publish(self, path: str, broadcast: BroadcastProducer) -> None:
-        # Deprecated alias for announce(); kept for back-compat.
+        warnings.warn(
+            "Client.publish() is deprecated; use Client.announce() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.announce(path, broadcast)
 
     def announced(self, prefix: str = "") -> Announced:

--- a/py/moq-rs/moq/errors.py
+++ b/py/moq-rs/moq/errors.py
@@ -1,0 +1,26 @@
+"""Classification helpers for the errors raised across the FFI boundary."""
+
+from __future__ import annotations
+
+from moq_ffi import MoqError
+
+
+def is_shutdown(err: BaseException) -> bool:
+    """True for `Cancelled` and `Closed`, which arise from graceful shutdown
+    rather than actual failures.
+
+    Useful for breaking out of an `async for` without treating the expected
+    end-of-stream error as a problem.
+    """
+    return isinstance(err, (MoqError.Cancelled, MoqError.Closed))
+
+
+def is_auth(err: BaseException) -> bool:
+    """True for `Unauthorized` (HTTP 401) and `Forbidden` (HTTP 403), which the
+    server returns to reject a connection on authentication or authorization
+    grounds.
+
+    Unlike a transport failure, retrying without new credentials won't help, so
+    callers should surface these rather than reconnect.
+    """
+    return isinstance(err, (MoqError.Unauthorized, MoqError.Forbidden))

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 from moq_ffi import (
     MoqAnnounced,
     MoqAnnouncedBroadcast,
@@ -171,5 +173,9 @@ class OriginProducer:
         self._inner.announce(path, broadcast._inner)
 
     def publish(self, path: str, broadcast: BroadcastProducer) -> None:
-        # Deprecated alias for announce(); kept for back-compat.
+        warnings.warn(
+            "OriginProducer.publish() is deprecated; use OriginProducer.announce() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.announce(path, broadcast)

--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -413,16 +413,16 @@ class BroadcastProducer:
         config = MoqJsonStreamConfig(compression=compression)
         return JsonStreamProducer(self._inner.publish_json_stream(name, config))
 
-    def set_catalog_section(self, name: str, value: str) -> None:
+    def set_catalog_section(self, name: str, value: Any) -> None:
         """Set or replace an untyped application section in the catalog.
 
-        `value` is a JSON string that lands as a top-level catalog key alongside
-        `video`/`audio` and reaches subscribers via `Catalog.sections`. `name` must not
-        be a reserved media section ("video"/"audio"). The catalog is republished
-        automatically. Use this to advertise a side-channel track (e.g. a transcript
-        or captions track) that the catalog doesn't model natively.
+        `value` is any JSON-serializable Python object; it lands as a top-level catalog
+        key alongside `video`/`audio` and reaches subscribers via `Catalog.sections`.
+        `name` must not be a reserved media section ("video"/"audio"). The catalog is
+        republished automatically. Use this to advertise a side-channel track (e.g. a
+        transcript or captions track) that the catalog doesn't model natively.
         """
-        self._inner.set_catalog_section(name, value)
+        self._inner.set_catalog_section(name, json.dumps(value))
 
     def remove_catalog_section(self, name: str) -> None:
         """Remove an untyped application section from the catalog by name.

--- a/py/moq-rs/moq/server.py
+++ b/py/moq-rs/moq/server.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable, Sequence
+import warnings
+from collections.abc import Sequence
 from typing import Literal
 
 from moq_ffi import MoqRequest, MoqServer
@@ -55,7 +56,7 @@ class Request:
         """
         return Session(await self._inner.ok())
 
-    async def close(self, code: int = 404) -> None:
+    async def close(self, code: int) -> None:
         """Reject the session with the given HTTP status code.
 
         Raises `Error.AlreadyResponded` if `ok()` or `close()` has already
@@ -188,22 +189,26 @@ class Server:
         origin.announce(path, broadcast)
 
     def publish(self, path: str, broadcast: BroadcastProducer) -> None:
-        # Deprecated alias for announce(); kept for back-compat.
+        warnings.warn(
+            "Server.publish() is deprecated; use Server.announce() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.announce(path, broadcast)
 
-    async def serve(
-        self,
-        on_request: Callable[[Request], Awaitable[bool | None]] | None = None,
-    ) -> None:
-        """Accept sessions in a loop, holding each one alive until it closes.
+    async def serve(self) -> None:
+        """Accept every session in a loop, holding each one alive until it closes.
 
         Each session is handled by its own task that awaits `session.closed()`,
         so memory does not grow with the number of past connections.
 
-        Pass `on_request` to inspect a `Request` before accepting it; return
-        `False` (or raise) to reject the request with HTTP 403, `True` (or
-        `None`) to accept. For richer routing, hand-roll the accept loop
-        instead.
+        To inspect or reject requests, iterate the server directly instead:
+
+            async for request in server:
+                if request.url and "/admin" in request.url:
+                    await request.close(403)
+                    continue
+                session = await request.ok()
         """
         session_tasks: set[asyncio.Task] = set()
 
@@ -213,15 +218,6 @@ class Server:
 
         try:
             async for request in self:
-                if on_request is not None:
-                    try:
-                        decision = await on_request(request)
-                    except Exception:
-                        await request.close(500)
-                        raise
-                    if decision is False:
-                        await request.close(403)
-                        continue
                 task = asyncio.create_task(serve_session(request))
                 session_tasks.add(task)
                 task.add_done_callback(session_tasks.discard)

--- a/py/moq-rs/moq/subscribe.py
+++ b/py/moq-rs/moq/subscribe.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncIterator
 from typing import Any
 
 from moq_ffi import (
@@ -93,7 +94,10 @@ class GroupConsumer:
 
 
 class TrackConsumer:
-    """Async iterator of groups from a track.
+    """Async iterator of groups from a track, in sequence order.
+
+    Iterating yields groups via :meth:`next_group`. Use :meth:`recv_group` (or
+    :meth:`groups_as_arrived`) for arrival order instead.
 
     Each group is itself an async iterator of timestamped frames. Same pattern as
     moq-boy's status/command tracks (one frame per group), but multi-frame
@@ -113,10 +117,22 @@ class TrackConsumer:
         return self
 
     async def __anext__(self) -> GroupConsumer:
-        group = await self.recv_group()
+        group = await self.next_group()
         if group is None:
             raise StopAsyncIteration
         return group
+
+    async def groups_as_arrived(self) -> AsyncIterator[GroupConsumer]:
+        """Iterate groups in arrival order, including out-of-sequence deliveries.
+
+        The default iteration uses sequence order instead. Use this for live
+        consumption where latency matters more than order.
+        """
+        while True:
+            group = await self.recv_group()
+            if group is None:
+                return
+            yield group
 
     async def recv_group(self) -> GroupConsumer | None:
         """Return the next group in arrival order. Returns `None` when the track ends.
@@ -132,8 +148,8 @@ class TrackConsumer:
     async def next_group(self) -> GroupConsumer | None:
         """Return the next group in sequence order, skipping forward if behind.
 
-        Returns `None` when the track ends. Use this when order matters more than
-        latency; `recv_group` is preferred for live consumption.
+        Returns `None` when the track ends. This is what the default iteration
+        yields; use `recv_group` when latency matters more than order.
         """
         group = await self._inner.next_group()
         if group is None:

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -94,7 +94,7 @@ async def test_local_publish_consume_audio():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     media = broadcast.publish_media("opus", opus_head())
-    origin.publish("live", broadcast)
+    origin.announce("live", broadcast)
 
     consumer = origin.consume()
 
@@ -129,7 +129,7 @@ async def test_video_publish_consume():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     media = broadcast.publish_media("avc3", h264_init())
-    origin.publish("video-test", broadcast)
+    origin.announce("video-test", broadcast)
 
     consumer = origin.consume()
 
@@ -163,7 +163,7 @@ async def test_multiple_frames_ordering():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     media = broadcast.publish_media("opus", opus_head())
-    origin.publish("ordering-test", broadcast)
+    origin.announce("ordering-test", broadcast)
 
     consumer = origin.consume()
 
@@ -190,7 +190,7 @@ async def test_catalog_update_on_new_track():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     _media1 = broadcast.publish_media("opus", opus_head())
-    origin.publish("catalog-update", broadcast)
+    origin.announce("catalog-update", broadcast)
 
     consumer = origin.consume()
 
@@ -222,7 +222,7 @@ def test_finish_closes_producer():
 async def test_announced_broadcast():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
-    origin.publish("test/broadcast", broadcast)
+    origin.announce("test/broadcast", broadcast)
 
     consumer = origin.consume()
 
@@ -545,7 +545,7 @@ async def test_subscribe_media_default_latency_and_context_manager():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     media = broadcast.publish_media("opus", opus_head())
-    origin.publish("live", broadcast)
+    origin.announce("live", broadcast)
 
     consumer = origin.consume()
 
@@ -569,7 +569,7 @@ async def test_raw_publish_consume():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     raw = broadcast.publish_track("events")
-    origin.publish("robot/arm", broadcast)
+    origin.announce("robot/arm", broadcast)
 
     consumer = origin.consume()
 
@@ -594,7 +594,7 @@ async def test_raw_multiple_frames():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     raw = broadcast.publish_track("commands")
-    origin.publish("robot/io", broadcast)
+    origin.announce("robot/io", broadcast)
 
     consumer = origin.consume()
 
@@ -676,7 +676,7 @@ async def test_raw_group_sequence():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     raw = broadcast.publish_track("seq")
-    origin.publish("track/seq", broadcast)
+    origin.announce("track/seq", broadcast)
 
     consumer = origin.consume()
 
@@ -702,12 +702,51 @@ async def test_raw_group_sequence():
         break
 
 
+async def test_default_iteration_is_sequence_order():
+    """Iterating a track yields sequence order; groups_as_arrived yields arrival order.
+
+    Group 5 is produced before group 3, so the two orderings genuinely diverge and
+    this fails if the default iteration ever reverts to recv_group.
+    """
+    origin = moq.OriginProducer()
+    broadcast = moq.BroadcastProducer()
+    raw = broadcast.publish_track("ordering")
+    origin.announce("track/ordering", broadcast)
+
+    sequenced = origin.consume()
+    arrived = origin.consume()
+
+    seq_consumer = await (await anext(sequenced.announced())).broadcast.subscribe_track("ordering")
+    arr_consumer = await (await anext(arrived.announced())).broadcast.subscribe_track("ordering")
+
+    for sequence in (5, 3):
+        group = raw.create_group(sequence)
+        group.write_frame(f"group-{sequence}".encode(), 0)
+        group.finish()
+
+    # Arrival order sees them as produced, newest sequence first.
+    assert [g.sequence async for g in _take(arr_consumer.groups_as_arrived(), 2)] == [5, 3]
+
+    # The default iteration sorts them back into ascending sequence order.
+    assert [g.sequence async for g in _take(seq_consumer, 2)] == [3, 5]
+
+
+async def _take(iterator, count: int):
+    """Yield the first `count` items of an async iterator."""
+    taken = 0
+    async for item in iterator:
+        yield item
+        taken += 1
+        if taken == count:
+            return
+
+
 async def test_raw_multi_frame_group():
     """A single group can carry multiple frames, not just one per group."""
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     raw = broadcast.publish_track("chunks")
-    origin.publish("stream/chunks", broadcast)
+    origin.announce("stream/chunks", broadcast)
 
     consumer = origin.consume()
 

--- a/py/moq-rs/tests/test_server.py
+++ b/py/moq-rs/tests/test_server.py
@@ -25,7 +25,7 @@ async def test_server_client_roundtrip():
         # Publish a broadcast on the server side.
         broadcast = moq.BroadcastProducer()
         media = broadcast.publish_media("opus", opus_head())
-        server.publish("hello", broadcast)
+        server.announce("hello", broadcast)
 
         # Auto-accept incoming sessions in the background so the handshake
         # completes from the server side. Hold references so the sessions
@@ -145,7 +145,7 @@ async def test_serve_helper_accepts_clients():
     """Server.serve() accepts incoming sessions and holds them automatically."""
     async with moq.Server("127.0.0.1:0", tls_generate=["localhost"]) as server:
         broadcast = moq.BroadcastProducer()
-        server.publish("via-serve", broadcast)
+        server.announce("via-serve", broadcast)
 
         serve_task = asyncio.create_task(server.serve())
         try:
@@ -170,7 +170,7 @@ async def test_announcement_hops_over_wire():
     """An announcement received over the wire exposes its relay hop chain as a list of ints."""
     async with moq.Server("127.0.0.1:0", tls_generate=["localhost"]) as server:
         broadcast = moq.BroadcastProducer()
-        server.publish("with-hops", broadcast)
+        server.announce("with-hops", broadcast)
 
         serve_task = asyncio.create_task(server.serve())
         try:
@@ -196,24 +196,16 @@ async def test_announcement_hops_over_wire():
             broadcast.finish()
 
 
-async def test_serve_helper_with_on_request_rejection():
-    """on_request returning False causes Server.serve() to reject the request."""
+async def test_deprecated_publish_alias_warns():
+    """The publish() aliases forward to announce() but warn on use."""
     async with moq.Server("127.0.0.1:0", tls_generate=["localhost"]) as server:
-
-        async def reject_all(_request: moq.Request) -> bool:
-            return False
-
-        serve_task = asyncio.create_task(server.serve(on_request=reject_all))
+        broadcast = moq.BroadcastProducer()
         try:
-            client = moq_ffi.MoqClient()
-            client.set_tls_disable_verify(True)
-            client.set_bind("127.0.0.1:0")
-            session = await asyncio.wait_for(client.connect(f"https://{server.local_addr}"), timeout=5.0)
-            with pytest.raises(moq_ffi.MoqError):  # type: ignore[arg-type]
-                await asyncio.wait_for(session.closed(), timeout=5.0)
+            with pytest.warns(DeprecationWarning, match="Server.publish"):
+                server.publish("deprecated", broadcast)
+
+            origin = moq.OriginProducer()
+            with pytest.warns(DeprecationWarning, match="OriginProducer.publish"):
+                origin.publish("deprecated", broadcast)
         finally:
-            serve_task.cancel()
-            try:
-                await serve_task
-            except asyncio.CancelledError:
-                pass
+            broadcast.finish()


### PR DESCRIPTION
Closes #2316.

Places where the same code translated across py/swift/kt/go behaved differently or could not be written the same way. Each item picks the majority shape rather than inventing a new one.

## Summary

| Drift | Resolution |
|---|---|
| Default track iteration order | py used arrival order (`recv_group`); swift/kt/go used sequence order. **py now matches** (3-of-4 majority). |
| py error classification | Added `moq.is_shutdown(err)` / `moq.is_auth(err)`, mirroring swift `isShutdown`/`isAuth` and go `IsShutdown`/`IsAuthError`. |
| TLS knob polarity | go's inverted `WithTLSDisableVerify()` → `WithTLSVerify(bool)`, matching py/kt `tls_verify` and swift `setTlsVerify`. |
| go dynamic iterators | Added the missing `TrackDynamic.Requests`; renamed `OriginDynamic.All` → `Requests`. All three dynamics now agree. |
| Serve-loop callbacks | Dropped from py and go (see below). |
| py invented defaults | `Request.close(code=404)` → `code` required. |
| py JSON in/out asymmetry | `set_catalog_section` now takes any JSON-serializable value, like the JSON producers. |
| py silent deprecations | `Client/Server/OriginProducer.publish` now emit `DeprecationWarning`. |
| kt wrapper depth | Gaps closed (see below). |

Two items from the issue were already resolved and needed no change: `subscribe_media(max_latency_ms=10000)` is gone (it takes a `Subscription` now), and swift/kt/go already iterated in sequence order.

## Decisions worth reviewing

**Iteration order.** py's `__anext__` now calls `next_group()`. `groups_as_arrived()` is the named arrival stream, mirroring `groupsAsArrived` in swift/kt/go. The regression test produces group 5 before group 3 so the two orderings genuinely diverge: arrival yields `[5, 3]`, sequence yields `[3, 5]`. It fails if the default ever reverts.

**Serve-loop sugar dropped rather than standardized.** py mapped `False`/`None`/raise to 403/accept/500; go used `(bool, error)`. Rather than pick one, both lose the callback: the caller-driven accept loop already exists in both (`async for request in server` / `Requests`) and is what swift/kt do, so removing it makes all four agree and deletes the implicit status mapping instead of blessing it. `serve()`/`Serve(ctx)` now mean "accept everything". go's `ExampleListen` kept its non-QUIC filter, moved to a new `ExampleServer_Requests`.

**`Announced.All` kept.** The three *dynamics* now agree on `Requests`, which is the drift the issue names. `Announced` has one natural iteration, where `All` is the Go-stdlib convention and `Announcements()` would stutter.

**go TLS default.** `clientConfig{tlsVerify: true}` is set explicitly before applying options: the zero value would silently disable verification.

## kt: closing the gaps

Chosen over documenting the thin level in `parity.md`.

- `Moq.announcedBroadcast` / `requestBroadcast`, which py/go/swift had.
- **`dev.moq.Server`**: a listen facade with origin wiring, a `requests()` Flow, and `serve()`, mirroring `Moq.connect`. This replaces `typealias Server = uniffi.moq.MoqServer`; the raw handle is still reachable as `.server`. `serve()` swallows per-session failures rather than letting them escape `launch` and cancel the scope, since one bad handshake would otherwise take the whole accept loop down (go and py both isolate this).
- **Typed JSON** over kotlinx.serialization (`update(value)`, `valuesAs<T>()`, `setCatalogSection(name, value)`). Added as an `api` dependency because the helpers are `inline`+`reified` and resolve serializers at the consumer's call site. The raw `String` overloads stay, so consumers on Moshi/Gson are not forced onto it; a test pins that a pre-encoded string reaches the wire unencoded (Kotlin resolves it to the member overload, not the extension, so it is not double-encoded).

Kotlin plugin versions moved to the root build script. A second Kotlin plugin carrying its own version in a subproject makes Gradle load the Kotlin plugin twice across `:moq-ffi` and `:moq`, which it rejects outright. The Android plugin had to move to the root too: once Kotlin resolves from the root classloader, AGP declared only in a module lands on a child one Kotlin can't see, and applying it fails with "Can't infer current AndroidGradlePluginVersion". Only the Android-enabled build reaches that path, so it passed a default local `just kt check` (Android is opt-in) and failed CI's publish dry-run; it is fixed and verified locally with the workflow's own `gradle -p kt -Pandroid.enabled=true :moq:publishToMavenLocal`.

## Branch targeting

`dev`: this breaks published wrapper APIs (go's TLS option and `Serve` signature, py's `close`, kt's `Server` typealias). No version bumped; kt's `moq.version` and `py/moq-rs`'s are hand-bumped at release time.

## Testing

- `just py test`: 49 passed, including the new sequence-order and deprecation-warning tests.
- `just kt check`: 8 passed, including the typed-JSON round-trip, raw-string passthrough, and server tests.
- `just go check`: vet + build + `go test -race` passed.
- `bun remark`: clean.
- Android-enabled `:moq:publishToMavenLocal` and `:moq-ffi:assemble`: pass (the path CI's publish dry-run exercises).

Cross-Package Sync: `doc/lib/{py,kt,go}`, `doc/concept/layer/hang.md`, and `py/moq-rs/README.md` updated. No `rs/moq-ffi` change, so the other rows and the wire drafts do not apply. swift needed no code change (already on the majority shape for every item).

One caveat on local verification: `just py check`'s pyright and a late `just go check` fail against `MoqRequest has no method Ok` / `MoqMediaFrame`, but neither symbol matches this checkout (`rs/moq-ffi/src/server.rs` has `pub async fn ok`). Concurrent builds from another branch overwrote the shared Cargo target that binding generation reads. Stashing this diff reproduces the identical 14 pyright errors on a clean tree, and go passed before that build landed, so it is environmental rather than from this change. CI builds from a clean target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
