### PR TITLE
refactor(moq-net)!: clamp the subscription latency budget once, in the aggregate

### DIFF
--- a/rs/moq-net/src/model/subscription.rs
+++ b/rs/moq-net/src/model/subscription.rs
@@ -23,9 +23,20 @@ pub struct Subscription {
 	/// cache. Receivers that buffer (e.g. a jitter buffer) enforce the same budget
 	/// locally, and a group is skipped once either measure exceeds it.
 	pub latency_max: Duration,
-	/// First group to deliver, or `None` to start at the latest group.
+	/// First group the publisher should deliver, or `None` to start at the latest group.
+	///
+	/// A request, aggregated across every live subscriber (the earliest explicit start
+	/// wins), so it says what the publisher sends, not what any one subscriber sees.
+	/// [`crate::track::Subscriber::start_at`] is the local read cursor; setting one does
+	/// not imply the other. See [Local cursor vs wire
+	/// preference](crate::track::Subscriber#local-cursor-vs-wire-preference).
 	pub group_start: Option<u64>,
-	/// Last group to deliver (inclusive), or `None` for no end.
+	/// Last group the publisher should deliver (inclusive), or `None` for no end.
+	///
+	/// A request, aggregated across every live subscriber (any unbounded subscriber makes
+	/// the aggregate unbounded). [`crate::track::Subscriber::end_at`] is the local read
+	/// cursor; setting one does not imply the other. See [Local cursor vs wire
+	/// preference](crate::track::Subscriber#local-cursor-vs-wire-preference).
 	pub group_end: Option<u64>,
 }
 

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -44,7 +44,7 @@ const MAX_DATAGRAM_AGE: Duration = Duration::from_millis(50);
 /// [`broadcast::Consumer::track`](broadcast::Consumer::track),
 /// which returns the publisher's [`Info`] once the subscription is accepted.
 ///
-/// Not `Copy`: it carries a handle to its parent broadcast (see [`Self::broadcast`]).
+/// Not `Copy`: it carries an internal handle to its parent broadcast.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Info {
@@ -72,12 +72,13 @@ pub struct Info {
 	/// reported in TRACK_INFO (Lite05+), and defaults to `false` (newest-first).
 	pub ordered: bool,
 
-	/// The broadcast this track belongs to, bound when the track is created under one
-	/// (`create_track` / `reserve_track` / `Request::accept`); until then it's a
-	/// standalone broadcast with an unbounded pool. Not on the wire. It's the parent
-	/// link a group walks to reach the shared cache pool
-	/// (`track.broadcast.origin.pool`); the pool itself stays crate-private.
-	pub broadcast: Arc<broadcast::Info>,
+	// The broadcast this track belongs to, bound when the track is created under one
+	// (`create_track` / `reserve_track` / `Request::accept`); until then it's a
+	// standalone broadcast with an unbounded pool. Not on the wire, and not a knob:
+	// every bind path overwrites whatever is here. It's the parent link a group walks
+	// to reach the shared cache pool (`track.broadcast.origin.pool`), which stays
+	// crate-private.
+	pub(crate) broadcast: Arc<broadcast::Info>,
 }
 
 /// The shared parent for a not-yet-bound [`Info`]: a standalone broadcast with an
@@ -129,13 +130,6 @@ impl Info {
 	pub fn with_ordered(mut self, ordered: bool) -> Self {
 		self.ordered = ordered;
 		self
-	}
-
-	/// Clamp a subscriber's latency budget to this track's [`Self::latency_max`]: a
-	/// subscriber can't wait for a late group longer than the publisher keeps it.
-	/// `Duration::ZERO` (skip immediately) is left untouched by the `min`.
-	fn clamp_latency_max(&self, latency_max: Duration) -> Duration {
-		latency_max.min(self.latency_max)
 	}
 }
 
@@ -406,6 +400,12 @@ impl TrackState {
 			.flatten()
 			.find(|(group, _)| group.sequence == sequence && !group.is_aborted())
 			.map(|(group, _)| group.consume())
+	}
+
+	/// The publisher's latency window, or `None` while the info is unknown (an
+	/// unaccepted [`Request`]). Bounds the aggregate subscription; see [`clamp_combined`].
+	fn latency_bound(&self) -> Option<Duration> {
+		self.info.as_ref().map(|info| info.latency_max)
 	}
 
 	/// Resolve a one-shot fetch from the track side: the cached group, or an [`Error`]
@@ -716,8 +716,8 @@ impl Producer {
 	/// deliver them. Keep payloads well under the 1200-byte minimum path MTU. An origin
 	/// publisher uses this; a relay preserving upstream numbering uses
 	/// [`Self::write_datagram`].
-	pub fn append_datagram<B: Into<bytes::Bytes>>(&mut self, timestamp: Timestamp, payload: B) -> Result<u64> {
-		let payload = payload.into();
+	pub fn append_datagram<B: crate::IntoBytes>(&mut self, timestamp: Timestamp, payload: B) -> Result<u64> {
+		let payload = payload.into_bytes();
 		if payload.len() > super::datagram::MAX_DATAGRAM_PAYLOAD {
 			return Err(Error::FrameTooLarge);
 		}
@@ -909,10 +909,9 @@ impl Producer {
 	/// Subscribing to this in-process track, resolving synchronously.
 	///
 	/// The info is fixed at creation, so there's nothing to wait for (no
-	/// SUBSCRIBE_OK round trip). The subscriber's latency budget is clamped to the
-	/// track's cache. Pass `None` for [`Subscription::default`].
+	/// SUBSCRIBE_OK round trip). Pass `None` for [`Subscription::default`].
 	pub fn subscribe(&self, subscription: impl Into<Option<Subscription>>) -> Subscriber {
-		let mut preferences = subscription.into().unwrap_or_default();
+		let preferences = subscription.into().unwrap_or_default();
 
 		// Info is fixed at creation and survives a close/abort, so read it without
 		// requiring a live producer state. If the track already ended, the returned
@@ -925,7 +924,6 @@ impl Producer {
 			.as_ref()
 			.expect("producer always has info")
 			.clone();
-		preferences.latency_max = info.clamp_latency_max(preferences.latency_max);
 		let subscription = kio::Producer::new(preferences);
 		register_subscription(self.state.read(), &subscription);
 
@@ -954,9 +952,15 @@ impl Producer {
 	/// A non-blocking snapshot of the current aggregate subscription, or `None`
 	/// when there are no live subscribers. Unlike [`Self::subscription`], this
 	/// doesn't wait for a change or advance the change cursor.
+	///
+	/// The aggregate's [`Subscription::latency_max`] is clamped to this track's
+	/// [`Info::latency_max`]: no subscriber can wait for a late group longer than the
+	/// publisher keeps it.
 	pub fn subscription(&self) -> Option<Subscription> {
-		let subs = self.state.read().subscriptions.clone();
-		snapshot_subscription(&subs)
+		let state = self.state.read();
+		let (subs, bound) = (state.subscriptions.clone(), state.latency_bound());
+		drop(state);
+		snapshot_subscription(&subs, bound)
 	}
 
 	pub fn poll_subscription_changed(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Subscription>>> {
@@ -967,11 +971,15 @@ impl Producer {
 			return Poll::Ready(Err(abort.unwrap_or(Error::Dropped)));
 		}
 
-		let subs = self.state.read().subscriptions.clone();
+		// Read the bound before locking `subs`, so the aggregation never nests the two locks.
+		let state = self.state.read();
+		let (subs, bound) = (state.subscriptions.clone(), state.latency_bound());
+		drop(state);
+
 		let prev = &self.prev_subscription;
 		let mut combined = None;
 		let mut guard = match subs.poll(waiter, |subs| {
-			let next = combined_subscription(subs, waiter);
+			let next = combined_subscription(subs, bound, waiter);
 			if &next == prev {
 				Poll::Pending
 			} else {
@@ -1156,25 +1164,40 @@ impl Drop for Producer {
 /// Read-only: iterates the subscriptions immutably and registers `waiter` on each, so a
 /// preference update (or a subscriber dropping) wakes the caller's poll. Callers decide
 /// readiness from the returned value, then prune closed subscribers through the `Mut`.
-fn combined_subscription(subs: &Subscriptions, waiter: &kio::Waiter) -> Option<Subscription> {
+fn combined_subscription(subs: &Subscriptions, bound: Option<Duration>, waiter: &kio::Waiter) -> Option<Subscription> {
 	let mut combined = None;
 	for sub in subs.iter() {
 		if let Poll::Ready(Ok(sub)) = sub.poll(waiter, |sub| sub.poll_combined(&combined)) {
 			combined = Some(sub);
 		}
 	}
-	combined
+	clamp_combined(combined, bound)
 }
 
 /// A non-blocking aggregate of the current subscriptions, without arming any waiter.
-fn snapshot_subscription(subs: &kio::Shared<Subscriptions>) -> Option<Subscription> {
+fn snapshot_subscription(subs: &kio::Shared<Subscriptions>, bound: Option<Duration>) -> Option<Subscription> {
 	let mut combined: Option<Subscription> = None;
 	for sub in subs.read().iter() {
 		if let Poll::Ready(merged) = sub.read().poll_combined(&combined) {
 			combined = Some(merged);
 		}
 	}
-	combined
+	clamp_combined(combined, bound)
+}
+
+/// Clamp the aggregate's latency budget to the publisher's window: nobody can wait for a
+/// late group longer than the publisher keeps it around.
+///
+/// The single clamp point. Subscribers hold their preferences verbatim, so what they asked
+/// for stays readable, and clamping the aggregate is equivalent to clamping each subscriber
+/// first (`min` distributes over the `max` that combines them). `bound` is `None` on a track
+/// whose info isn't known yet (an unaccepted [`Request`]), which imposes no window.
+fn clamp_combined(combined: Option<Subscription>, bound: Option<Duration>) -> Option<Subscription> {
+	let mut combined = combined?;
+	if let Some(bound) = bound {
+		combined.latency_max = combined.latency_max.min(bound);
+	}
+	Some(combined)
 }
 
 /// Register a subscription if the track is live: clone the shared list out of the
@@ -1583,6 +1606,23 @@ impl kio::Future for Fetching {
 /// Created via [`Consumer::subscribe`](Consumer::subscribe), or
 /// directly from a [`Producer`] for an in-process track. Carries this
 /// subscriber's [`Subscription`] preferences, which feed the producer's aggregate.
+///
+/// # Local cursor vs wire preference
+///
+/// Group bounds exist at two levels, and setting one does not imply the other:
+///
+/// - [`Self::start_at`] / [`Self::end_at`] move **this subscriber's read cursor**. They
+///   filter exactly what this handle returns and are invisible to the publisher.
+/// - [`Subscription::group_start`] / [`Subscription::group_end`], set via [`Self::update`],
+///   are a **request to the publisher**. They're aggregated across every live subscriber
+///   (earliest start, widest end), so they say what the publisher should send, not what
+///   this subscriber sees.
+///
+/// They stay separate because their scopes differ: a subscriber can't filter by the
+/// aggregate, since another subscriber can widen it, and the publisher can't honor a
+/// cursor it's never told about. So setting only the cursor still transfers the skipped
+/// groups, and setting only the preference still returns groups another subscriber asked
+/// for. Set both to skip them *and* avoid the transfer.
 pub struct Subscriber {
 	name: Arc<str>,
 	info: Info,
@@ -1797,14 +1837,23 @@ impl Subscriber {
 		kio::wait(|waiter| self.poll_finished(waiter)).await
 	}
 
-	/// Start the consumer at the specified sequence.
+	/// Start this subscriber's read cursor at the given sequence.
+	///
+	/// A local filter, not a request: it doesn't tell the publisher anything, so the
+	/// skipped groups are still delivered and simply not returned. To ask the publisher
+	/// to start there instead, set [`Subscription::group_start`] via [`Self::update`].
+	/// See [Local cursor vs wire preference](Self#local-cursor-vs-wire-preference).
 	pub fn start_at(&mut self, sequence: u64) {
 		self.min_sequence = sequence;
 	}
 
-	/// Cap the consumer at the specified sequence (inclusive), or remove the cap entirely.
+	/// Cap this subscriber's read cursor at the given sequence (inclusive), or remove the
+	/// cap entirely.
 	///
 	/// Accepts a bare `u64` (cap), `Some(u64)`, or `None` (uncap).
+	///
+	/// A local filter, not a request; [`Subscription::group_end`] is the wire-level
+	/// counterpart. See [Local cursor vs wire preference](Self#local-cursor-vs-wire-preference).
 	///
 	/// Affects [`Self::next_group`] only: groups beyond the cap stay in the producer's
 	/// cache rather than being skipped past, so a later call to [`Self::end_at`] with a
@@ -1821,11 +1870,10 @@ impl Subscriber {
 
 	/// Replace this subscriber's delivery preferences.
 	///
-	/// The latency budget is clamped to the track's cache, like the initial subscribe.
-	/// Returns [`Error::Closed`] if the track already ended; the update is
-	/// meaningless at that point and can usually be ignored.
-	pub fn update(&mut self, mut subscription: Subscription) -> Result<()> {
-		subscription.latency_max = self.info.clamp_latency_max(subscription.latency_max);
+	/// Stored verbatim; the publisher's latency window is applied to the aggregate, not
+	/// here (see [`Producer::subscription`]). Returns [`Error::Closed`] if the track
+	/// already ended; the update is meaningless at that point and can usually be ignored.
+	pub fn update(&mut self, subscription: Subscription) -> Result<()> {
 		let mut state = self.subscription.write().map_err(|_| Error::Closed)?;
 		*state = subscription;
 		Ok(())
@@ -1925,8 +1973,10 @@ impl Request {
 	}
 
 	pub fn subscription(&self) -> Option<Subscription> {
-		let subs = self.state.read().subscriptions.clone();
-		snapshot_subscription(&subs)
+		let state = self.state.read();
+		let (subs, bound) = (state.subscriptions.clone(), state.latency_bound());
+		drop(state);
+		snapshot_subscription(&subs, bound)
 	}
 
 	pub async fn subscription_changed(&mut self) -> Option<Subscription> {
@@ -1934,11 +1984,14 @@ impl Request {
 	}
 
 	pub fn poll_subscription_changed(&mut self, waiter: &kio::Waiter) -> Poll<Option<Subscription>> {
-		let subs = self.state.read().subscriptions.clone();
+		let state = self.state.read();
+		let (subs, bound) = (state.subscriptions.clone(), state.latency_bound());
+		drop(state);
+
 		let prev = &self.prev_subscription;
 		let mut combined = None;
 		let mut guard = ready!(subs.poll(waiter, |subs| {
-			let next = combined_subscription(subs, waiter);
+			let next = combined_subscription(subs, bound, waiter);
 			if &next == prev {
 				Poll::Pending
 			} else {
@@ -2355,21 +2408,52 @@ mod test {
 	fn latency_max_clamped_to_cache() {
 		let producer = track_producer("test", Info::default().with_latency_max(Duration::from_secs(2)));
 
-		// A latency budget beyond the cache is capped to the cache; a group can't be
-		// waited for longer than the publisher keeps it.
+		// A latency budget beyond the cache is capped in the aggregate; a group can't be
+		// waited for longer than the publisher keeps it. The subscriber's own preference
+		// is stored verbatim, so what it asked for stays readable.
 		let mut subscriber = producer.subscribe(Subscription::default().with_latency_max(Duration::from_secs(10)));
-		assert_eq!(subscriber.subscription().latency_max, Duration::from_secs(2));
+		assert_eq!(subscriber.subscription().latency_max, Duration::from_secs(10));
+		assert_eq!(producer.subscription().unwrap().latency_max, Duration::from_secs(2));
 
 		// A budget within the cache is left alone, and ZERO (skip immediately) stays ZERO.
 		subscriber
 			.update(Subscription::default().with_latency_max(Duration::from_millis(500)))
 			.unwrap();
-		assert_eq!(subscriber.subscription().latency_max, Duration::from_millis(500));
+		assert_eq!(producer.subscription().unwrap().latency_max, Duration::from_millis(500));
 
 		subscriber
 			.update(Subscription::default().with_latency_max(Duration::ZERO))
 			.unwrap();
-		assert_eq!(subscriber.subscription().latency_max, Duration::ZERO);
+		assert_eq!(producer.subscription().unwrap().latency_max, Duration::ZERO);
+	}
+
+	#[test]
+	fn latency_max_clamped_via_every_update_path() {
+		let producer = track_producer("test", Info::default().with_latency_max(Duration::from_secs(2)));
+		let over = Subscription::default().with_latency_max(Duration::from_secs(10));
+
+		// The clamp lives in the aggregation, so it applies no matter which entry point
+		// wrote the raw preference. Previously only `Subscriber::update` clamped.
+		let mut subscriber = producer.subscribe(over.clone());
+		assert_eq!(producer.subscription().unwrap().latency_max, Duration::from_secs(2));
+
+		subscriber.control().update(over.clone()).unwrap();
+		assert_eq!(producer.subscription().unwrap().latency_max, Duration::from_secs(2));
+
+		subscriber.update(over).unwrap();
+		assert_eq!(producer.subscription().unwrap().latency_max, Duration::from_secs(2));
+	}
+
+	#[test]
+	fn latency_max_aggregate_clamps_the_max_across_subscribers() {
+		let producer = track_producer("test", Info::default().with_latency_max(Duration::from_secs(2)));
+
+		// The aggregate takes the max, then clamps once. Equivalent to clamping each
+		// subscriber first, since `min` distributes over `max`.
+		let _a = producer.subscribe(Subscription::default().with_latency_max(Duration::from_millis(500)));
+		let _b = producer.subscribe(Subscription::default().with_latency_max(Duration::from_secs(10)));
+
+		assert_eq!(producer.subscription().unwrap().latency_max, Duration::from_secs(2));
 	}
 
 	#[test]


### PR DESCRIPTION
Third of ~4 stacked PRs for #2314. Covers the **Subscription plumbing** section. Stacked on #2339; review that first (this PR's base is its branch).

## Summary

### The scattered clamp was a real bug, not just a wart

The issue flags that only one of the update entry points clamped the latency budget. That's worse than untidy: **`Producer::subscription` is what a relay forwards upstream as SUBSCRIBE_UPDATE**, so a single `SubscriberControl::update` propagated an *unclamped* `latency_max` upstream, asking a peer to hold a late group longer than the publisher keeps it around. Before this PR:

| entry point | clamped? |
|---|---|
| `Producer::subscribe` | yes |
| `Subscriber::update` | yes |
| `SubscriberControl::update` | **no** |
| `Subscribing::update` | **no** |
| `Consumer::subscribe` | **no** |

The clamp now lives in one place, `clamp_combined`, applied by both aggregation functions (`combined_subscription` and `snapshot_subscription`), so it holds regardless of which entry point wrote the preference. The two per-call clamps and `Info::clamp_latency_max` are gone.

Two properties worth checking in review:

- **Clamping the aggregate is equivalent to clamping each subscriber**, because `min` distributes over the `max` that combines them: `min(max(a,b), c) == max(min(a,c), min(b,c))`. `latency_max_aggregate_clamps_the_max_across_subscribers` pins this.
- **Subscribers keep their preference verbatim.** `Subscriber::subscription()` now reports what it *asked for* (previously it silently reported the clamped value), while `Producer::subscription()` reports what it will *get*. That's the honest split, and it's why `latency_max_clamped_to_cache` changed rather than broke.

An unaccepted `Request` has no `Info` yet, so `latency_bound()` is `None` and imposes no window — unchanged from before, where a `Request` never clamped at all.

### The rest

- **`track::Info.broadcast` -> `pub(crate)`.** A parent link a group walks to reach the cache pool, not a knob: every bind path overwrites it and there was no `with_broadcast`. No external readers exist. The struct doc's `[`Self::broadcast`]` link had to go with it, or rustdoc's `-D warnings` fails CI.
- **`Producer::append_datagram` takes the crate's `IntoBytes`**, matching `write_frame`, so `&[u8]`/`&str` work. (`write_datagram` takes a `Datagram`, so it's unaffected.)
- **`start_at`/`end_at` vs `group_start`/`group_end`: documented, not unified.** They're structurally different, and I'd argue they should stay that way: the local cursor (`min_sequence`/`end_sequence`) is per-subscriber and exact, while the wire preference is aggregated across *every* live subscriber and advisory. Neither can substitute for the other, since a subscriber can't filter by an aggregate another subscriber can widen, and the publisher can't honor a cursor it's never told about. New "Local cursor vs wire preference" section on `Subscriber`, linked from all four methods.

  Unification is possible (have `start_at` also set `group_start`; it composes correctly through the aggregate) but riskier: it would undercut `end_at`'s documented "raise the cap later to get cached groups back" behavior once a relay stops pulling upstream, and would touch four existing tests. The issue permits "unify **or** document"; happy to do the unify if preferred.

## Public API changes

**Breaking** (hence `dev`):
- `track::Info.broadcast`: `pub` -> `pub(crate)`.
- `track::Producer::append_datagram`: bound `B: Into<bytes::Bytes>` -> `B: crate::IntoBytes`. Source-breaking only for a caller relying on an `Into<Bytes>` impl that isn't `IntoBytes`; `Bytes`/`Vec<u8>`/`BytesMut`/`String` all still work, and `&[u8]`/`&str` now work too.
- `track::Subscriber::subscription()` / `SubscriberControl::subscription()`: same signature, but now report the subscriber's raw preference rather than the clamped one. Behavioral, not a signature change.

**Non-breaking:**
- `track::Info::clamp_latency_max` was private; removed.
- Doc-only on `Subscriber`, `start_at`, `end_at`, `Subscription::group_start`, `Subscription::group_end`, `Producer::subscription`, `Subscriber::update`.

## Cross-Package Sync

- `rs/moq-net` API: **no wire format change** (the clamp bounds a value already carried as `Subscriber Max Latency`; the bug was sending it unclamped). So no draft update.
- `js/net`: nothing to relocate — it has **no subscriber-side clamp at all**, using `Info.latencyMax` only for producer-side eviction. Adding one there is a separate change, filed rather than smuggled in here.
- No FFI/WASM exposure of `Info.broadcast` or `append_datagram`'s bound, so `libmoq`/py/swift/kt/go are untouched.

## Test plan

- `cargo check -p moq-net --all-targets` + `cargo check --workspace --all-targets`: clean.
- `cargo test -p moq-net`: **488 passed**, 0 failed (486 + 2 new).
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moq-net`: exit 0 (CI gates this; this PR adds intra-doc anchor links that would fail if wrong).
- `nix develop --command cargo fmt --check -p moq-net`: clean.
- New tests:
  - `latency_max_clamped_via_every_update_path` — **fails without the fix**: on the old code `SubscriberControl::update` wrote raw, so `producer.subscription()` returned the unclamped 10s. Encodes the root cause (the relay-forwarding bug), not just the symptom.
  - `latency_max_aggregate_clamps_the_max_across_subscribers` — pins the min/max distribution property the single-clamp reshape relies on.
  - `latency_max_clamped_to_cache` — updated to assert the clamp on the producer's aggregate and the verbatim preference on the subscriber.

(Written by Claude Opus 4.8)
