### PR TITLE
refactor(moq-native)!: pre-bump polish (docs, tls handle, setters, exports)

### DIFF
--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -39,14 +39,20 @@ impl Net {
 	fn client(&self, config: moq_native::ClientConfig) -> anyhow::Result<moq_native::Client> {
 		let client = config.init()?;
 		#[cfg(feature = "iroh")]
-		let client = client.with_iroh(self.iroh.clone());
+		let client = match self.iroh.clone() {
+			Some(iroh) => client.with_iroh(iroh),
+			None => client,
+		};
 		Ok(client)
 	}
 
 	fn server(&self, config: moq_native::ServerConfig) -> anyhow::Result<moq_native::Server> {
 		let server = config.init()?;
 		#[cfg(feature = "iroh")]
-		let server = server.with_iroh(self.iroh.clone());
+		let server = match self.iroh.clone() {
+			Some(iroh) => server.with_iroh(iroh),
+			None => server,
+		};
 		Ok(server)
 	}
 }
@@ -130,11 +136,11 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 	}
 	if let Some(web_bind) = moq.server.bind.clone() {
 		let server = net.server(moq.server.clone())?;
-		let tls_info = server.tls_info();
+		let certificates = server.certificates();
 		moq::notify_ready();
 		let origin = origin.consume();
 		tasks.spawn(async move { Ok(server.serve_publish(origin).await?) });
-		tasks.spawn(async move { web::run_web(&web_bind, tls_info).await });
+		tasks.spawn(async move { web::run_web(&web_bind, certificates).await });
 	}
 
 	// Foreign side: the single source.
@@ -232,11 +238,11 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 	}
 	if let Some(web_bind) = moq.server.bind.clone() {
 		let server = net.server(moq.server.clone())?;
-		let tls_info = server.tls_info();
+		let certificates = server.certificates();
 		moq::notify_ready();
 		let origin = origin.clone();
 		tasks.spawn(async move { Ok(server.serve_consume(origin).await?) });
-		tasks.spawn(async move { web::run_web(&web_bind, tls_info).await });
+		tasks.spawn(async move { web::run_web(&web_bind, certificates).await });
 	}
 
 	// Foreign side: the single sink.

--- a/rs/moq-cli/src/web.rs
+++ b/rs/moq-cli/src/web.rs
@@ -3,7 +3,7 @@ use axum::handler::HandlerWithoutStateExt;
 use axum::http::{HeaderValue, Method, StatusCode};
 use axum::response::IntoResponse;
 use axum::{Router, routing::get};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
 
 /// Browser CORS policy for HTTP gateway listeners.
@@ -60,7 +60,7 @@ pub async fn serve(
 
 /// Serve the `/certificate.sha256` self-signed fingerprint over HTTP, so an
 /// `http://` client can pin a `--server-bind` server's generated cert.
-pub async fn run_web(bind: &str, tls_info: Arc<RwLock<moq_native::tls::Info>>) -> anyhow::Result<()> {
+pub async fn run_web(bind: &str, certificates: moq_native::tls::Certificates) -> anyhow::Result<()> {
 	let listen = tokio::net::lookup_host(bind)
 		.await
 		.context("invalid listen address")?
@@ -74,13 +74,11 @@ pub async fn run_web(bind: &str, tls_info: Arc<RwLock<moq_native::tls::Info>>) -
 	let fingerprint_handler = move || async move {
 		// Get the first certificate's fingerprint.
 		// TODO serve all of them so we can support multiple signature algorithms.
-		tls_info
-			.read()
-			.expect("tls_info read lock poisoned")
-			.fingerprints
-			.first()
-			.expect("missing certificate")
-			.clone()
+		match certificates.fingerprints().into_iter().next() {
+			Some(fingerprint) => fingerprint.into_response(),
+			// A stream-only server has no certificate to pin.
+			None => (StatusCode::NOT_FOUND, "no certificate\n").into_response(),
+		}
 	};
 
 	let app = Router::new()

--- a/rs/moq-ffi/src/server.rs
+++ b/rs/moq-ffi/src/server.rs
@@ -153,11 +153,7 @@ impl MoqServer {
 			.server
 			.as_ref()
 			.ok_or_else(|| MoqError::Bind("not listening; call listen() first".into()))?;
-		let info_handle = server.tls_info();
-		let info = info_handle
-			.read()
-			.map_err(|err| MoqError::Bind(format!("tls info lock poisoned: {err}")))?;
-		Ok(info.fingerprints.clone())
+		Ok(server.certificates().fingerprints())
 	}
 
 	/// Cancel any in-flight `listen()` or `accept()` call.

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -50,14 +50,18 @@ pub struct ClientConfig {
 	#[arg(id = "client-version", long = "client-version", env = "MOQ_CLIENT_VERSION")]
 	pub version: Vec<moq_net::Version>,
 
+	/// TLS trust and client-certificate settings (`--client-tls-*`).
 	#[command(flatten)]
 	#[serde(default)]
 	pub tls: crate::tls::Client,
 
+	/// Retry pacing for [`Client::reconnect`] (`--client-backoff-*`).
 	#[command(flatten)]
 	#[serde(default)]
 	pub backoff: Backoff,
 
+	/// WebSocket fallback settings (`--client-websocket-*`), used when QUIC is
+	/// blocked.
 	#[cfg(feature = "websocket")]
 	#[command(flatten)]
 	#[serde(default)]
@@ -65,6 +69,7 @@ pub struct ClientConfig {
 }
 
 impl ClientConfig {
+	/// Build the [`Client`] this config describes.
 	pub fn init(self) -> crate::Result<Client> {
 		Client::new(self)
 	}
@@ -119,12 +124,15 @@ pub struct Client {
 	#[cfg(feature = "quiche")]
 	quiche: Option<crate::quiche::QuicheClient>,
 	#[cfg(feature = "iroh")]
-	iroh: Option<web_transport_iroh::iroh::Endpoint>,
+	iroh: Option<crate::iroh::Endpoint>,
 	#[cfg(feature = "iroh")]
 	iroh_addrs: Vec<std::net::SocketAddr>,
 }
 
 impl Client {
+	/// Build a client from its config.
+	///
+	/// Errors if no transport feature is compiled in.
 	#[cfg(not(any(
 		feature = "noq",
 		feature = "quinn",
@@ -139,7 +147,7 @@ impl Client {
 		))
 	}
 
-	/// Create a new client
+	/// Build a client from its config, binding the QUIC socket up front.
 	#[cfg(any(
 		feature = "noq",
 		feature = "quinn",
@@ -196,9 +204,13 @@ impl Client {
 		})
 	}
 
+	/// Dial `iroh://` URLs through the given Iroh endpoint.
+	///
+	/// Required before [`connect`](Self::connect) can serve an `iroh://` URL;
+	/// without it those dials fail with [`crate::Error::IrohDisabled`].
 	#[cfg(feature = "iroh")]
-	pub fn with_iroh(mut self, iroh: Option<web_transport_iroh::iroh::Endpoint>) -> Self {
-		self.iroh = iroh;
+	pub fn with_iroh(mut self, iroh: crate::iroh::Endpoint) -> Self {
+		self.iroh = Some(iroh);
 		self
 	}
 
@@ -212,11 +224,13 @@ impl Client {
 		self
 	}
 
+	/// Publish the given origin to every session this client opens.
 	pub fn with_publisher(mut self, publish: impl moq_net::Consume<moq_net::origin::Consumer>) -> Self {
 		self.moq = self.moq.with_publisher(publish);
 		self
 	}
 
+	/// Subscribe to the peer's broadcasts, ingesting them into the given origin.
 	pub fn with_subscriber(mut self, subscribe: moq_net::origin::Producer) -> Self {
 		self.moq = self.moq.with_subscriber(subscribe);
 		self
@@ -268,6 +282,9 @@ impl Client {
 		Some(self.with_subscriber(origin).reconnect(url))
 	}
 
+	/// Dial the given URL and complete the MoQ handshake.
+	///
+	/// Errors if no transport feature is compiled in.
 	#[cfg(not(any(
 		feature = "noq",
 		feature = "quinn",
@@ -283,6 +300,12 @@ impl Client {
 		))
 	}
 
+	/// Dial the given URL and complete the MoQ handshake.
+	///
+	/// The scheme picks the transport, and `https://` races QUIC against the
+	/// WebSocket fallback so a blocked UDP path still connects. The session's
+	/// protocol driver is spawned on the current tokio runtime; the session
+	/// closes once the last returned handle drops.
 	#[cfg(any(
 		feature = "noq",
 		feature = "quinn",

--- a/rs/moq-native/src/connect.rs
+++ b/rs/moq-native/src/connect.rs
@@ -2,9 +2,13 @@
 #[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
 #[non_exhaustive]
 pub enum ConnectError {
+	/// The server rejected the credentials (HTTP 401). Retrying with the same
+	/// token will fail again.
 	#[error("unauthorized")]
 	Unauthorized,
 
+	/// The credentials were understood but don't grant access to this path
+	/// (HTTP 403).
 	#[error("forbidden")]
 	Forbidden,
 }
@@ -18,6 +22,8 @@ impl ConnectError {
 		}
 	}
 
+	/// Whether this is an authentication failure, meaning a retry is pointless
+	/// until the credentials change.
 	pub fn is_auth(&self) -> bool {
 		matches!(self, Self::Unauthorized | Self::Forbidden)
 	}

--- a/rs/moq-native/src/error.rs
+++ b/rs/moq-native/src/error.rs
@@ -8,80 +8,107 @@ use std::sync::Arc;
 #[derive(Debug, Clone, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
+	/// Reading or writing a socket, certificate, or key file failed.
 	#[error(transparent)]
 	Io(Arc<std::io::Error>),
 
+	/// The MoQ session itself failed, after the transport was established.
 	#[error(transparent)]
 	MoqNet(#[from] moq_net::Error),
 
+	/// The log filter string (ex. `RUST_LOG`) isn't a valid tracing directive.
 	#[error("invalid log directive")]
 	Directive(#[source] Arc<tracing_subscriber::filter::ParseError>),
 
+	/// Logging was initialized twice, or something else already claimed the global subscriber.
 	#[error("failed to set global tracing subscriber")]
 	SetSubscriber(#[source] Arc<tracing_subscriber::util::TryInitError>),
 
+	/// Logging couldn't attach to Android's logcat.
 	#[error("failed to initialize Android logcat layer")]
 	Logcat(#[source] Arc<std::io::Error>),
 
+	/// No backend feature is compiled in that can serve this URL. The string names the features to enable.
 	#[error("{0}")]
 	NoBackend(&'static str),
 
+	/// Every backend we tried gave up without reporting why.
 	#[error("failed to connect to server")]
 	ConnectFailed,
 
+	/// The server rejected the connection with an auth status. See [`crate::ConnectError`].
 	#[error(transparent)]
 	Connect(#[from] crate::ConnectError),
 
+	/// Both halves of the QUIC/WebSocket race failed, so neither error alone tells the story.
 	#[cfg(feature = "websocket")]
 	#[error("failed to connect to server: QUIC failed: {quic}; WebSocket failed: {websocket}")]
-	TransportRace { quic: Arc<Error>, websocket: Arc<Error> },
+	TransportRace {
+		/// Why the QUIC attempt failed.
+		quic: Arc<Error>,
+		/// Why the WebSocket attempt failed.
+		websocket: Arc<Error>,
+	},
 
+	/// An `iroh://` URL was dialed but the client was built without an Iroh endpoint.
 	#[cfg(feature = "iroh")]
 	#[error("Iroh support is not enabled")]
 	IrohDisabled,
 
+	/// A client certificate was configured, but this QUIC backend can't do mTLS.
 	#[error("tls.root (mTLS) is not supported by the selected QUIC backend")]
 	MtlsUnsupported,
 
+	/// The server's WebTransport response carried a status outside the valid HTTP range.
 	#[error("invalid status code")]
 	InvalidStatusCode,
 
+	/// Reconnecting gave up, usually after the backoff timeout expired. The string has the details.
 	#[error("{0}")]
 	Reconnect(String),
 
+	/// Loading certificates or building the TLS config failed.
 	#[error(transparent)]
 	Tls(Arc<crate::tls::Error>),
 
+	/// The Quinn backend failed.
 	#[cfg(feature = "quinn")]
 	#[error(transparent)]
 	Quinn(Arc<crate::quinn::Error>),
 
+	/// The noq backend failed.
 	#[cfg(feature = "noq")]
 	#[error(transparent)]
 	Noq(Arc<crate::noq::Error>),
 
+	/// The quiche backend failed.
 	#[cfg(feature = "quiche")]
 	#[error(transparent)]
 	Quiche(Arc<crate::quiche::Error>),
 
+	/// The Iroh backend failed.
 	#[cfg(feature = "iroh")]
 	#[error(transparent)]
 	Iroh(Arc<crate::iroh::Error>),
 
+	/// The WebSocket fallback transport failed.
 	#[cfg(feature = "websocket")]
 	#[error(transparent)]
 	WebSocket(Arc<crate::websocket::Error>),
 
+	/// The TCP (qmux) transport failed.
 	#[cfg(feature = "tcp")]
 	#[error(transparent)]
 	Tcp(Arc<crate::tcp::Error>),
 
+	/// The Unix socket transport failed.
 	#[cfg(all(feature = "uds", unix))]
 	#[error(transparent)]
 	Unix(Arc<crate::unix::Error>),
 }
 
 impl Error {
+	/// The auth rejection behind this error, digging through backend and race variants.
 	pub fn connect_error(&self) -> Option<crate::ConnectError> {
 		match self {
 			Self::Connect(err) => Some(*err),
@@ -100,6 +127,7 @@ impl Error {
 		}
 	}
 
+	/// True if the server rejected us for auth reasons, so retrying won't help without new credentials.
 	pub fn is_auth(&self) -> bool {
 		self.connect_error().is_some_and(|err| err.is_auth())
 	}

--- a/rs/moq-native/src/iroh.rs
+++ b/rs/moq-native/src/iroh.rs
@@ -1,3 +1,9 @@
+//! Iroh P2P transport, dialed by endpoint id instead of a hostname.
+//!
+//! A single [`Endpoint`] serves both roles, hole-punching directly to peers and
+//! falling back to an iroh relay. Both WebTransport-over-H3 and raw QUIC are
+//! negotiated via ALPN.
+
 use std::{net, path::PathBuf, str::FromStr};
 
 use url::Url;
@@ -12,63 +18,82 @@ pub use web_transport_iroh;
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
+	/// Reading or writing the secret key file failed.
 	#[error(transparent)]
 	Io(#[from] std::io::Error),
 
+	/// The configured secret was neither a valid hex key nor a readable key file.
 	#[error("invalid iroh secret key")]
 	Secret(#[source] iroh::KeyParsingError),
 
+	/// The endpoint could not bind its UDP socket.
 	#[error(transparent)]
 	Bind(#[from] iroh::endpoint::BindError),
 
+	/// A configured bind address was rejected by iroh.
 	#[error(transparent)]
 	BindAddr(#[from] iroh::endpoint::InvalidSocketAddr),
 
+	/// Dialing the peer failed before a connection was started.
 	#[error(transparent)]
 	Connect(#[from] iroh::endpoint::ConnectWithOptsError),
 
+	/// The QUIC handshake failed while connecting.
 	#[error(transparent)]
 	Connecting(#[from] iroh::endpoint::ConnectingError),
 
+	/// The peer never settled on an ALPN.
 	#[error(transparent)]
 	Alpn(#[from] iroh::endpoint::AlpnError),
 
+	/// An established connection was lost or closed.
 	#[error(transparent)]
 	Connection(#[from] iroh::endpoint::ConnectionError),
 
+	/// The client side of the WebTransport handshake failed.
 	#[error(transparent)]
 	Client(#[from] web_transport_iroh::ClientError),
 
+	/// The server side of the WebTransport handshake failed.
 	#[error(transparent)]
 	Server(#[from] web_transport_iroh::ServerError),
 
+	/// The negotiated ALPN was not valid UTF-8.
 	#[error("failed to decode ALPN")]
 	DecodeAlpn(#[from] std::string::FromUtf8Error),
 
+	/// The peer negotiated an ALPN this build does not speak.
 	#[error("unsupported ALPN: {0}")]
 	UnsupportedAlpn(String),
 
+	/// The URL had no host, so there is no endpoint id to dial.
 	#[error("Invalid URL: missing host")]
 	MissingHost,
 
+	/// The URL host was not an iroh endpoint id. Unlike QUIC, iroh dials a public key, not a hostname.
 	#[error("Invalid URL: host is not an iroh endpoint id")]
 	InvalidEndpointId(#[source] iroh::KeyParsingError),
 
+	/// The URL could not be rewritten to the `https` scheme for the H3 request.
 	#[error("invalid URL")]
 	InvalidUrl,
 
+	/// The rewritten URL failed to parse.
 	#[error(transparent)]
 	Url(#[from] url::ParseError),
 
+	/// The client connected but never sent a valid WebTransport CONNECT request.
 	#[error("failed to receive WebTransport request")]
 	RecvRequest(#[source] web_transport_iroh::ServerError),
 
+	/// GSO is always on for iroh, so `--quic-gso=false` cannot be honored.
 	#[error("the iroh backend cannot disable GSO; drop --quic-gso=false or use the quinn backend")]
 	GsoUnsupported,
 }
 
 type Result<T> = std::result::Result<T, Error>;
 
+/// Settings for the shared iroh endpoint, used by both the client and server.
 #[derive(clap::Args, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 #[serde(deny_unknown_fields, default)]
 #[non_exhaustive]

--- a/rs/moq-native/src/jemalloc.rs
+++ b/rs/moq-native/src/jemalloc.rs
@@ -1,3 +1,7 @@
+//! On-demand jemalloc heap profiling, for chasing leaks in a running process.
+//!
+//! Spawn [`run`] to dump a profile whenever the process gets SIGUSR1.
+
 use tikv_jemalloc_ctl::raw;
 
 pub use tikv_jemallocator;

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -10,6 +10,8 @@
 //!
 //! See [`Client`] for connecting to relays and [`Server`] for accepting connections.
 
+#![warn(missing_docs)]
+
 pub mod bind;
 mod client;
 mod connect;
@@ -36,12 +38,14 @@ pub mod watch;
 #[cfg(feature = "websocket")]
 pub mod websocket;
 
-pub use client::*;
+// Enumerated rather than globbed, so the root surface is a deliberate list and a
+// new `pub` item in these modules doesn't silently join it.
+pub use client::{Client, ClientConfig};
 pub use connect::ConnectError;
 pub use error::{Error, Result};
-pub use log::*;
-pub use reconnect::*;
-pub use server::*;
+pub use log::Log;
+pub use reconnect::{Backoff, ConnectionStatsReader, Reconnect, Status};
+pub use server::{Request, Server, ServerConfig, Transport};
 
 /// Spawn the session's protocol driver on the current tokio runtime, handing back
 /// the session it drives.

--- a/rs/moq-native/src/log.rs
+++ b/rs/moq-native/src/log.rs
@@ -26,14 +26,21 @@ impl Default for Log {
 }
 
 impl Log {
+	/// Log at the given level and below.
 	pub fn new(level: Level) -> Self {
 		Self { level }
 	}
 
+	/// The configured level as a filter.
 	pub fn level(&self) -> LevelFilter {
 		LevelFilter::from_level(self.level)
 	}
 
+	/// Install this as the process-wide tracing subscriber.
+	///
+	/// `RUST_LOG` overrides the configured level. Logs go to stderr, or to
+	/// logcat on Android. Errors if a subscriber is already installed, so call
+	/// it once at startup.
 	pub fn init(&self) -> crate::Result<()> {
 		let filter = EnvFilter::builder()
 			.with_default_directive(self.level().into()) // Default to our -q/-v args

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -1,9 +1,12 @@
+//! The noq QUIC backend, used for both WebTransport (`https://`) and raw QUIC (`moqt://`, `moql://`).
+
 use crate::client::ClientConfig;
 use crate::quic::Resolved;
-use crate::server::{ServerConfig, ServerId};
+use crate::quic::ServerId;
+use crate::server::ServerConfig;
 use crate::tls::{FingerprintVerifier, ServeCerts};
 use std::net;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
 
@@ -34,99 +37,131 @@ fn apply_transport(transport: &mut noq::TransportConfig, quic: Resolved) {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
+	/// The UDP socket failed to bind, usually because the address is in use.
 	#[error("failed to bind UDP socket")]
 	BindSocket(#[source] std::io::Error),
 
+	/// The QUIC endpoint could not be created around the bound socket.
 	#[error("failed to create QUIC endpoint")]
 	CreateEndpoint(#[source] std::io::Error),
 
+	/// No async runtime was found. Construct the client or server from within a tokio runtime.
 	#[error("no async runtime")]
 	NoRuntime,
 
+	/// The endpoint's local address could not be read from the socket.
 	#[error("failed to get local address")]
 	LocalAddr(#[source] std::io::Error),
 
+	/// The configured bind address could not be resolved.
 	#[error("failed to resolve bind address")]
 	ResolveBind(#[source] std::io::Error),
 
+	/// The URL has no host to connect to.
 	#[error("invalid DNS name")]
 	InvalidDnsName,
 
+	/// The URL host could not be resolved.
 	#[error("failed DNS lookup")]
 	DnsLookup(#[source] std::io::Error),
 
+	/// DNS resolved, but no address matched the local socket's family.
 	#[error("no DNS entries")]
 	NoDnsEntries,
 
+	/// The insecure `http://` fingerprint fetch failed to reach the server.
 	#[error("failed to fetch fingerprint")]
 	FetchFingerprint(#[source] reqwest::Error),
 
+	/// The server returned a non-success status for the fingerprint request.
 	#[error("fingerprint request failed")]
 	FingerprintStatus(#[source] reqwest::Error),
 
+	/// The fingerprint response body could not be read.
 	#[error("failed to read fingerprint")]
 	ReadFingerprint(#[source] reqwest::Error),
 
+	/// The fetched fingerprint was not valid hex.
 	#[error("invalid fingerprint")]
 	InvalidFingerprint(#[from] hex::FromHexError),
 
+	/// The URL scheme is not one this backend can dial.
 	#[error("url scheme must be 'https', 'moqt', or 'moql'")]
 	InvalidScheme,
 
+	/// The URL scheme survived ALPN selection but has no session type.
 	#[error("unsupported URL scheme: {0}")]
 	UnsupportedScheme(String),
 
+	/// The connection came up without TLS handshake data, so the ALPN is unknown.
 	#[error("missing handshake data")]
 	MissingHandshake,
 
+	/// The peer negotiated no ALPN, so there's no protocol to speak.
 	#[error("missing ALPN")]
 	MissingAlpn,
 
+	/// The negotiated ALPN was not valid UTF-8.
 	#[error("failed to decode ALPN")]
 	DecodeAlpn(#[from] std::string::FromUtf8Error),
 
+	/// The peer negotiated an ALPN this endpoint doesn't serve.
 	#[error("unsupported ALPN: {0}")]
 	UnsupportedAlpn(String),
 
+	/// A raw QUIC client connected without SNI, so there's no host to build a URL from.
 	#[error("missing server name for raw QUIC connection")]
 	MissingServerName,
 
+	/// The client's SNI host could not be parsed as a URL.
 	#[error("failed to construct URL from server name")]
 	BuildUrl(#[source] url::ParseError),
 
+	/// The configured QUIC-LB nonce is too short to be unique.
 	#[error("quic_lb_nonce must be at least 4")]
 	QuicLbNonceTooSmall,
 
+	/// The server ID plus nonce don't fit in a QUIC connection ID. Shorten either.
 	#[error("connection ID length ({0}) exceeds maximum of 20")]
 	QuicLbCidTooLong(usize),
 
+	/// The mTLS client verifier could not be built from the configured roots.
 	#[error("failed to build client certificate verifier")]
 	ClientVerifier(#[source] rustls::server::VerifierBuilderError),
 
+	/// The TLS config lacks a cipher suite QUIC can use for initial packets.
 	#[error(transparent)]
 	NoInitialCipherSuite(#[from] noq::crypto::rustls::NoInitialCipherSuite),
 
+	/// The connection could not be started, usually a bad config or address.
 	#[error(transparent)]
 	Connect(#[from] noq::ConnectError),
 
+	/// The QUIC connection failed or was closed.
 	#[error(transparent)]
 	Connection(#[from] noq::ConnectionError),
 
+	/// The WebTransport CONNECT request failed.
 	#[error(transparent)]
 	Client(#[from] web_transport_noq::ClientError),
 
+	/// The server rejected the connection with a status we understand (auth, not found, etc).
 	#[error(transparent)]
 	ConnectRejected(#[from] crate::ConnectError),
 
+	/// The WebTransport server failed to respond to a request.
 	#[error(transparent)]
 	Server(#[from] web_transport_noq::ServerError),
 
+	/// The QUIC handshake never completed for an incoming connection.
 	#[error("failed to establish QUIC connection")]
 	Establish(#[source] noq::ConnectionError),
 
+	/// The client connected but never sent a valid WebTransport CONNECT request.
 	#[error("failed to receive WebTransport request")]
 	RecvRequest(#[source] web_transport_noq::ServerError),
 
+	/// The certificates or roots could not be loaded.
 	#[error(transparent)]
 	Tls(#[from] crate::tls::Error),
 }
@@ -425,8 +460,8 @@ impl NoqServer {
 		self.quic.accept()
 	}
 
-	pub fn tls_info(&self) -> Arc<RwLock<crate::tls::Info>> {
-		self.certs.info.clone()
+	pub fn certificates(&self) -> crate::tls::Certificates {
+		crate::tls::Certificates::new(self.certs.info.clone())
 	}
 
 	pub fn local_addr(&self) -> Result<net::SocketAddr> {

--- a/rs/moq-native/src/quic.rs
+++ b/rs/moq-native/src/quic.rs
@@ -12,7 +12,34 @@
 use std::net;
 use std::time::Duration;
 
-use crate::ServerId;
+/// The routable server ID a QUIC-LB load balancer encodes into connection IDs.
+///
+/// Parsed from, and serialized as, a hex string. Its length must match the load
+/// balancer's configured server-ID length.
+#[serde_with::serde_as]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct ServerId(#[serde_as(as = "serde_with::hex::Hex")] pub(crate) Vec<u8>);
+
+impl ServerId {
+	#[allow(dead_code)]
+	pub(crate) fn len(&self) -> usize {
+		self.0.len()
+	}
+}
+
+impl std::fmt::Debug for ServerId {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_tuple("ServerId").field(&hex::encode(&self.0)).finish()
+	}
+}
+
+impl std::str::FromStr for ServerId {
+	type Err = hex::FromHexError;
+
+	fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+		hex::decode(s).map(Self)
+	}
+}
 
 /// Default maximum number of concurrent QUIC streams (bidi and uni) per connection.
 pub(crate) const DEFAULT_MAX_STREAMS: u64 = 1024;

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -1,3 +1,6 @@
+//! QUIC backend built on [`web_transport_quiche`], speaking WebTransport over HTTP/3
+//! (`https://`) or raw QUIC (`moqt://` / `moql://`).
+
 use crate::client::ClientConfig;
 use crate::crypto;
 use crate::quic::Resolved;
@@ -10,96 +13,126 @@ use std::sync::{Arc, RwLock};
 use url::Url;
 use web_transport_quiche::proto::ConnectRequest;
 
+/// Re-exported because this module's public API exposes its types. A major
+/// `web-transport-quiche` bump is therefore a breaking change for this crate.
 pub use web_transport_quiche;
 
 /// Errors specific to the quiche QUIC backend.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
+	/// The UDP socket failed to bind, or another I/O operation failed.
 	#[error(transparent)]
 	Io(#[from] std::io::Error),
 
+	/// The URL had no host to dial and use as the TLS SNI.
 	#[error("invalid DNS name")]
 	InvalidDnsName,
 
-	/// No longer returned: the `http://` scheme now fetches and pins the
-	/// certificate fingerprint instead of failing.
+	#[doc(hidden)]
 	#[deprecated(note = "fingerprint verification over http:// is now supported; this is never returned")]
 	#[error("fingerprint verification (http:// scheme) is not supported with the quiche backend")]
 	FingerprintUnsupported,
 
+	/// The `http://` fingerprint bootstrap could not reach the relay.
 	#[error("failed to fetch certificate fingerprint")]
 	FetchFingerprint(#[source] reqwest::Error),
 
+	/// The relay answered the fingerprint bootstrap with a non-success status.
 	#[error("certificate fingerprint request failed")]
 	FingerprintStatus(#[source] reqwest::Error),
 
+	/// The fingerprint response body could not be read.
 	#[error("failed to read certificate fingerprint")]
 	ReadFingerprint(#[source] reqwest::Error),
 
+	/// The fetched fingerprint was not valid hex.
 	#[error("invalid certificate fingerprint")]
 	InvalidFingerprint(#[source] hex::FromHexError),
 
+	/// The fetched fingerprint decoded to the wrong length, so it isn't a SHA-256.
 	#[error("certificate fingerprint must be 32 bytes (SHA-256), got {0}")]
 	FingerprintLength(usize),
 
+	/// The URL scheme is one this backend cannot dial.
 	#[error("url scheme must be 'https', 'moqt', or 'moql'")]
 	InvalidScheme,
 
+	/// quiche resolves the dial target and the TLS SNI from the same host, so the
+	/// two cannot be decoupled. Drop the override or use the quinn backend.
 	#[error("client tls host_name override is not supported with the quiche backend")]
 	HostNameUnsupported,
 
+	/// quiche probes GSO from the socket and offers no knob to force it off.
 	#[error("the quiche backend cannot disable GSO; drop --*-quic-gso=false or use the quinn backend")]
 	GsoUnsupported,
 
+	/// The handshake completed without negotiating an ALPN, so there is no protocol to speak.
 	#[error("missing ALPN")]
 	MissingAlpn,
 
+	/// The negotiated ALPN was not valid UTF-8.
 	#[error("failed to decode ALPN")]
 	DecodeAlpn(#[from] std::str::Utf8Error),
 
+	/// The peer negotiated an ALPN this server does not serve.
 	#[error("unsupported ALPN: {0}")]
 	UnsupportedAlpn(String),
 
+	/// The server's configured bind address could not be resolved.
 	#[error("failed to resolve bind address")]
 	ResolveBind(#[source] std::io::Error),
 
+	/// The server is not bound to any address, so there is no local address to report.
 	#[error("failed to get local address")]
 	NoLocalAddr,
 
+	/// The server was given neither a certificate pair nor hostnames to generate one from.
 	#[error("--tls-cert and --tls-key are required with the quiche backend")]
 	CertRequired,
 
+	/// The server was given a different number of certificates than keys.
 	#[error("must provide matching --tls-cert and --tls-key pairs")]
 	CertPairMismatch,
 
+	/// The QUIC connection could not be started, usually a bad address or an unusable socket.
 	#[error("failed to connect to quiche server")]
 	Connect(#[source] std::io::Error),
 
+	/// An established connection failed, including when accepting an incoming one.
 	#[error(transparent)]
 	Connection(#[from] web_transport_quiche::ez::ConnectionError),
 
+	/// The QUIC handshake failed, most often TLS verification or a timeout.
 	#[error("failed to establish quiche connection")]
 	Establish(#[source] web_transport_quiche::ez::ConnectionError),
 
+	/// The WebTransport CONNECT failed over an otherwise healthy QUIC connection.
 	#[error("failed to connect to quiche server")]
 	ClientConnect(#[from] web_transport_quiche::ClientError),
 
+	/// The server refused the WebTransport CONNECT with a recognized status, such as
+	/// an auth failure. See [`crate::ConnectError`].
 	#[error(transparent)]
 	ConnectRejected(#[from] crate::ConnectError),
 
+	/// The server could not bind its socket or load the supplied certificate.
 	#[error("failed to create quiche server")]
 	ServerBuild(#[source] std::io::Error),
 
+	/// The client never sent a usable WebTransport CONNECT request.
 	#[error("failed to accept WebTransport request")]
 	AcceptRequest(#[source] web_transport_quiche::ServerError),
 
+	/// The `200 OK` response to a WebTransport CONNECT could not be sent.
 	#[error("failed to accept quiche WebTransport")]
 	Accept(#[source] web_transport_quiche::ServerError),
 
+	/// The rejection response to a WebTransport CONNECT could not be sent.
 	#[error("failed to close quiche WebTransport request")]
 	Reject(#[source] web_transport_quiche::ServerError),
 
+	/// The TLS configuration was invalid. See [`crate::tls::Error`].
 	#[error(transparent)]
 	Tls(#[from] crate::tls::Error),
 }
@@ -334,7 +367,7 @@ fn classify_proto_error(err: &web_transport_quiche::proto::ConnectError) -> Opti
 
 pub(crate) struct QuicheServer {
 	pub server: web_transport_quiche::ez::Server,
-	pub fingerprints: Arc<RwLock<crate::tls::Info>>,
+	pub certs: crate::tls::Certificates,
 }
 
 impl QuicheServer {
@@ -373,11 +406,11 @@ impl QuicheServer {
 			.map(|cert| hex::encode(crypto::sha256(&provider, cert.as_ref())))
 			.collect();
 
-		let info = Arc::new(RwLock::new(crate::tls::Info {
+		let certs = crate::tls::Certificates::new(Arc::new(RwLock::new(crate::tls::Info {
 			#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 			certs: Vec::new(),
 			fingerprints,
-		}));
+		})));
 
 		// H3 is last because it requires WebTransport framing which not all H3 endpoints support.
 		let mut alpns: Vec<Vec<u8>> = config
@@ -398,18 +431,15 @@ impl QuicheServer {
 			.with_single_cert(chain, key)
 			.map_err(Error::ServerBuild)?;
 
-		Ok(Self {
-			server,
-			fingerprints: info,
-		})
+		Ok(Self { server, certs })
 	}
 
 	pub fn accept(&mut self) -> impl std::future::Future<Output = Option<web_transport_quiche::ez::Incoming>> + '_ {
 		self.server.accept()
 	}
 
-	pub fn tls_info(&self) -> Arc<RwLock<crate::tls::Info>> {
-		self.fingerprints.clone()
+	pub fn certificates(&self) -> crate::tls::Certificates {
+		self.certs.clone()
 	}
 
 	pub fn local_addr(&self) -> Result<net::SocketAddr> {

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -1,9 +1,12 @@
+//! The quinn QUIC backend, used for both WebTransport (`https://`) and raw QUIC (`moqt://`, `moql://`).
+
 use crate::client::ClientConfig;
 use crate::quic::Resolved;
-use crate::server::{ServerConfig, ServerId};
+use crate::quic::ServerId;
+use crate::server::ServerConfig;
 use crate::tls::{FingerprintVerifier, ServeCerts};
 use std::net;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
 
@@ -33,99 +36,131 @@ fn apply_transport(transport: &mut quinn::TransportConfig, quic: Resolved) {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
+	/// The UDP socket couldn't be bound, usually because the address is already in use.
 	#[error("failed to bind UDP socket")]
 	BindSocket(#[source] std::io::Error),
 
+	/// The bound socket couldn't be turned into a QUIC endpoint.
 	#[error("failed to create QUIC endpoint")]
 	CreateEndpoint(#[source] std::io::Error),
 
+	/// Quinn found no async runtime. Construct the client or server from within a tokio context.
 	#[error("no async runtime")]
 	NoRuntime,
 
+	/// The endpoint's local address couldn't be read back from the OS.
 	#[error("failed to get local address")]
 	LocalAddr(#[source] std::io::Error),
 
+	/// The server's configured bind address couldn't be resolved.
 	#[error("failed to resolve bind address")]
 	ResolveBind(#[source] std::io::Error),
 
+	/// The URL has no host to connect to.
 	#[error("invalid DNS name")]
 	InvalidDnsName,
 
+	/// Resolving the URL's host failed.
 	#[error("failed DNS lookup")]
 	DnsLookup(#[source] std::io::Error),
 
+	/// DNS returned no address usable from the local socket, usually an address family mismatch.
 	#[error("no DNS entries")]
 	NoDnsEntries,
 
+	/// The insecure `http://` bootstrap couldn't fetch `/certificate.sha256`.
 	#[error("failed to fetch fingerprint")]
 	FetchFingerprint(#[source] reqwest::Error),
 
+	/// The `/certificate.sha256` fetch returned a non-success status.
 	#[error("fingerprint request failed")]
 	FingerprintStatus(#[source] reqwest::Error),
 
+	/// The fingerprint response body couldn't be read.
 	#[error("failed to read fingerprint")]
 	ReadFingerprint(#[source] reqwest::Error),
 
+	/// The fetched fingerprint wasn't valid hex.
 	#[error("invalid fingerprint")]
 	InvalidFingerprint(#[from] hex::FromHexError),
 
+	/// The URL scheme isn't one this backend can dial.
 	#[error("url scheme must be 'https', 'moqt', or 'moql'")]
 	InvalidScheme,
 
+	/// The URL scheme passed the initial check but has no session type, which means it slipped through a scheme list.
 	#[error("unsupported URL scheme: {0}")]
 	UnsupportedScheme(String),
 
+	/// The connection came up without TLS handshake data, so the negotiated ALPN can't be read.
 	#[error("missing handshake data")]
 	MissingHandshake,
 
+	/// TLS negotiated no ALPN, so there's no protocol to speak.
 	#[error("missing ALPN")]
 	MissingAlpn,
 
+	/// The negotiated ALPN wasn't valid UTF-8.
 	#[error("failed to decode ALPN")]
 	DecodeAlpn(#[from] std::string::FromUtf8Error),
 
+	/// The peer negotiated an ALPN this endpoint doesn't handle.
 	#[error("unsupported ALPN: {0}")]
 	UnsupportedAlpn(String),
 
+	/// A raw QUIC client connected without SNI, so the server can't tell which host it wanted.
 	#[error("missing server name for raw QUIC connection")]
 	MissingServerName,
 
+	/// The client's SNI hostname didn't form a valid URL.
 	#[error("failed to construct URL from server name")]
 	BuildUrl(#[source] url::ParseError),
 
+	/// The configured QUIC-LB nonce is too short to be unguessable.
 	#[error("quic_lb_nonce must be at least 4")]
 	QuicLbNonceTooSmall,
 
+	/// The QUIC-LB server ID plus nonce doesn't fit in a connection ID. Shorten one of them.
 	#[error("connection ID length ({0}) exceeds maximum of 20")]
 	QuicLbCidTooLong(usize),
 
+	/// The mTLS client verifier couldn't be built from the configured roots.
 	#[error("failed to build client certificate verifier")]
 	ClientVerifier(#[source] rustls::server::VerifierBuilderError),
 
+	/// The rustls crypto provider offers no cipher suite usable for QUIC initial packets.
 	#[error(transparent)]
 	NoInitialCipherSuite(#[from] quinn::crypto::rustls::NoInitialCipherSuite),
 
+	/// Quinn refused to start the connection, before any packet was sent.
 	#[error(transparent)]
 	Connect(#[from] quinn::ConnectError),
 
+	/// The QUIC connection failed or was closed by the peer.
 	#[error(transparent)]
 	Connection(#[from] quinn::ConnectionError),
 
+	/// The WebTransport client handshake failed.
 	#[error(transparent)]
 	Client(#[from] web_transport_quinn::ClientError),
 
+	/// The server answered the WebTransport CONNECT with a rejection status.
 	#[error(transparent)]
 	ConnectRejected(#[from] crate::ConnectError),
 
+	/// The WebTransport server handshake failed while responding.
 	#[error(transparent)]
 	Server(#[from] web_transport_quinn::ServerError),
 
+	/// The QUIC handshake didn't complete for an incoming connection.
 	#[error("failed to establish QUIC connection")]
 	Establish(#[source] quinn::ConnectionError),
 
+	/// The client never sent a usable WebTransport CONNECT request.
 	#[error("failed to receive WebTransport request")]
 	RecvRequest(#[source] web_transport_quinn::ServerError),
 
+	/// The TLS configuration or certificates couldn't be loaded.
 	#[error(transparent)]
 	Tls(#[from] crate::tls::Error),
 }
@@ -423,8 +458,8 @@ impl QuinnServer {
 		self.quic.accept()
 	}
 
-	pub fn tls_info(&self) -> Arc<RwLock<crate::tls::Info>> {
-		self.certs.info.clone()
+	pub fn certificates(&self) -> crate::tls::Certificates {
+		crate::tls::Certificates::new(self.certs.info.clone())
 	}
 
 	pub fn local_addr(&self) -> Result<net::SocketAddr> {

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -2,12 +2,11 @@ use std::net;
 #[cfg(any(test, all(feature = "uds", unix)))]
 use std::path::PathBuf;
 
+#[cfg(feature = "iroh")]
+use crate::iroh;
 use crate::{Error, QuicBackend};
 use moq_net::Session;
-use std::sync::{Arc, RwLock};
 use url::Url;
-#[cfg(feature = "iroh")]
-use web_transport_iroh::iroh;
 
 use futures::FutureExt;
 use futures::future::BoxFuture;
@@ -35,14 +34,14 @@ pub struct ServerConfig {
 	#[cfg(feature = "tcp")]
 	#[command(flatten)]
 	#[serde(default)]
-	pub tcp: TcpConfig,
+	pub tcp: crate::tcp::Config,
 
 	/// Plaintext qmux Unix-socket listener (`--server-unix-bind`) with an optional
 	/// peer-credential allowlist. Requires the `uds` feature; unix-only.
 	#[cfg(all(feature = "uds", unix))]
 	#[command(flatten)]
 	#[serde(default)]
-	pub unix: UnixConfig,
+	pub unix: crate::unix::Config,
 
 	/// The QUIC backend to use.
 	/// Auto-detected from compiled features if not specified.
@@ -66,104 +65,15 @@ pub struct ServerConfig {
 	#[arg(id = "server-version", long = "server-version", env = "MOQ_SERVER_VERSION")]
 	pub version: Vec<moq_net::Version>,
 
+	/// The certificates to serve and the roots that authenticate mTLS clients
+	/// (`--server-tls-*`).
 	#[command(flatten)]
 	#[serde(default)]
 	pub tls: crate::tls::Server,
 }
 
-/// Plaintext-TCP qmux listener settings (no TLS, no UDP).
-///
-/// TCP carries no peer identity, so it must only be reachable from trusted
-/// clients. Bind it to loopback or a private interface; a non-loopback bind
-/// logs a warning but is allowed.
-#[cfg(feature = "tcp")]
-#[derive(clap::Args, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields, default)]
-#[non_exhaustive]
-pub struct TcpConfig {
-	/// Bind a plaintext qmux TCP listener on this address.
-	#[arg(long = "server-tcp-bind", id = "server-tcp-bind", env = "MOQ_SERVER_TCP_BIND")]
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub bind: Option<net::SocketAddr>,
-}
-
-/// Plaintext Unix-socket qmux listener settings, with an optional
-/// peer-credential allowlist.
-#[cfg(all(feature = "uds", unix))]
-#[derive(clap::Args, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields, default)]
-#[non_exhaustive]
-pub struct UnixConfig {
-	/// Bind a plaintext qmux Unix-socket listener at this path.
-	#[arg(long = "server-unix-bind", id = "server-unix-bind", env = "MOQ_SERVER_UNIX_BIND")]
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub bind: Option<PathBuf>,
-
-	/// Peer-credential allowlist. `None` (the default) enforces nothing, so the
-	/// socket's filesystem permissions are the only gate.
-	#[command(flatten)]
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub allow: Option<UnixAllow>,
-}
-
-/// Peer-credential allowlist for a `unix://` listener.
-///
-/// The kernel reports the connecting process's credentials. Each populated list
-/// constrains the corresponding credential (AND across the three, OR within
-/// each); all empty means no check.
-#[cfg(all(feature = "uds", unix))]
-#[derive(clap::Args, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
-#[serde(deny_unknown_fields, default)]
-#[non_exhaustive]
-pub struct UnixAllow {
-	/// Allowed peer user IDs. Empty means any uid.
-	#[arg(
-		long = "server-unix-allow-uid",
-		env = "MOQ_SERVER_UNIX_ALLOW_UID",
-		value_delimiter = ','
-	)]
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	pub uid: Vec<u32>,
-
-	/// Allowed peer group IDs. Empty means any gid.
-	#[arg(
-		long = "server-unix-allow-gid",
-		env = "MOQ_SERVER_UNIX_ALLOW_GID",
-		value_delimiter = ','
-	)]
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	pub gid: Vec<u32>,
-
-	/// Allowed peer PIDs. Empty means any pid; a populated list rejects peers
-	/// whose PID the platform doesn't report.
-	#[arg(
-		long = "server-unix-allow-pid",
-		env = "MOQ_SERVER_UNIX_ALLOW_PID",
-		value_delimiter = ','
-	)]
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	pub pid: Vec<i32>,
-}
-
-#[cfg(all(feature = "uds", unix))]
-impl UnixAllow {
-	/// Whether any field is populated (i.e. the allowlist enforces something).
-	fn is_empty(&self) -> bool {
-		self.uid.is_empty() && self.gid.is_empty() && self.pid.is_empty()
-	}
-
-	/// Whether `cred` satisfies every populated field (AND across fields, OR
-	/// within a field). A required pid is unsatisfiable when the platform
-	/// reports none.
-	fn permits(&self, cred: &crate::unix::PeerCred) -> bool {
-		let uid_ok = self.uid.is_empty() || self.uid.contains(&cred.uid);
-		let gid_ok = self.gid.is_empty() || self.gid.contains(&cred.gid);
-		let pid_ok = self.pid.is_empty() || cred.pid.is_some_and(|pid| self.pid.contains(&pid));
-		uid_ok && gid_ok && pid_ok
-	}
-}
-
 impl ServerConfig {
+	/// Build the [`Server`] this config describes, binding its listeners.
 	pub fn init(self) -> crate::Result<Server> {
 		Server::new(self)
 	}
@@ -223,6 +133,10 @@ pub struct Server {
 }
 
 impl Server {
+	/// Build a server from its config, binding the QUIC socket up front.
+	///
+	/// The stream (`tcp`/`unix`) listeners bind lazily on the first
+	/// [`accept`](Self::accept), since they need a runtime.
 	pub fn new(config: ServerConfig) -> crate::Result<Self> {
 		let backend = config.backend.clone().unwrap_or_else(crate::default_quic_backend);
 
@@ -314,22 +228,25 @@ impl Server {
 	/// For applications that need WebSocket on the same HTTP port (e.g. moq-relay),
 	/// use `qmux::Session::accept()` with your own HTTP framework instead.
 	#[cfg(feature = "websocket")]
-	pub fn with_websocket(mut self, websocket: Option<crate::websocket::Listener>) -> Self {
-		self.websocket = websocket;
+	pub fn with_websocket(mut self, websocket: crate::websocket::Listener) -> Self {
+		self.websocket = Some(websocket);
 		self
 	}
 
+	/// Also accept sessions over the given Iroh endpoint.
 	#[cfg(feature = "iroh")]
-	pub fn with_iroh(mut self, iroh: Option<iroh::Endpoint>) -> Self {
-		self.iroh = iroh;
+	pub fn with_iroh(mut self, iroh: iroh::Endpoint) -> Self {
+		self.iroh = Some(iroh);
 		self
 	}
 
+	/// Publish the given origin to every session this server accepts.
 	pub fn with_publisher(mut self, publish: impl moq_net::Consume<moq_net::origin::Consumer>) -> Self {
 		self.moq = self.moq.with_publisher(publish);
 		self
 	}
 
+	/// Subscribe to every session's broadcasts, ingesting them into the given origin.
 	pub fn with_subscriber(mut self, subscribe: moq_net::origin::Producer) -> Self {
 		self.moq = self.moq.with_subscriber(subscribe);
 		self
@@ -386,22 +303,29 @@ impl Server {
 		Ok(())
 	}
 
-	// Return the SHA256 fingerprints of all our certificates.
-	pub fn tls_info(&self) -> Arc<RwLock<crate::tls::Info>> {
+	/// A live handle to the certificates this server is serving.
+	///
+	/// Use it to publish the SHA-256 fingerprints of a generated certificate at
+	/// `/certificate.sha256`, which an `http://` client pins to reach a
+	/// self-signed server. The handle tracks cert hot reloads, so hold it rather
+	/// than the values it returns.
+	///
+	/// Empty when no TLS-bearing backend is configured (e.g. a stream-only server).
+	pub fn certificates(&self) -> crate::tls::Certificates {
 		#[cfg(feature = "noq")]
 		if let Some(noq) = self.noq.as_ref() {
-			return noq.tls_info();
+			return noq.certificates();
 		}
 		#[cfg(feature = "quinn")]
 		if let Some(quinn) = self.quinn.as_ref() {
-			return quinn.tls_info();
+			return quinn.certificates();
 		}
 		#[cfg(feature = "quiche")]
 		if let Some(quiche) = self.quiche.as_ref() {
-			return quiche.tls_info();
+			return quiche.certificates();
 		}
 		// No QUIC backend (e.g. a stream-only `--server-bind`): no certificates.
-		Arc::new(RwLock::new(crate::tls::Info::empty()))
+		crate::tls::Certificates::empty()
 	}
 
 	#[cfg(not(any(
@@ -412,6 +336,9 @@ impl Server {
 		feature = "tcp",
 		all(feature = "uds", unix)
 	)))]
+	/// Returns the next partially established session.
+	///
+	/// Panics: no transport feature is compiled in, so nothing can be accepted.
 	pub async fn accept(&mut self) -> Option<Request> {
 		unreachable!("no transport compiled; enable a QUIC backend, tcp, or uds feature");
 	}
@@ -584,11 +511,17 @@ impl Server {
 		}
 	}
 
+	/// The Iroh endpoint from [`with_iroh`](Self::with_iroh), if one was set.
 	#[cfg(feature = "iroh")]
 	pub fn iroh_endpoint(&self) -> Option<&iroh::Endpoint> {
 		self.iroh.as_ref()
 	}
 
+	/// The address the QUIC listener bound to, useful when the config asked for
+	/// port 0.
+	///
+	/// Errors with [`Error::NoBackend`] on a stream-only server, which has no
+	/// QUIC listener.
 	pub fn local_addr(&self) -> crate::Result<net::SocketAddr> {
 		#[cfg(feature = "noq")]
 		if let Some(noq) = self.noq.as_ref() {
@@ -606,11 +539,17 @@ impl Server {
 		Err(Error::NoBackend("no QUIC listener configured"))
 	}
 
+	/// The address the WebSocket listener from
+	/// [`with_websocket`](Self::with_websocket) bound to, if one was set.
 	#[cfg(feature = "websocket")]
 	pub fn websocket_local_addr(&self) -> Option<net::SocketAddr> {
 		self.websocket.as_ref().and_then(|ws| ws.local_addr().ok())
 	}
 
+	/// Close every listener, giving in-flight connections a moment to see the
+	/// shutdown.
+	///
+	/// [`accept`](Self::accept) calls this for you on Ctrl-C.
 	pub async fn close(&mut self) {
 		#[cfg(feature = "noq")]
 		if let Some(noq) = self.noq.as_mut() {
@@ -683,7 +622,7 @@ struct StreamListeners {
 	binds: Vec<StreamBind>,
 	versions: moq_net::Versions,
 	#[cfg(all(feature = "uds", unix))]
-	unix_allow: Option<UnixAllow>,
+	unix_allow: Option<crate::unix::Allow>,
 	rx: Option<tokio::sync::mpsc::Receiver<Request>>,
 	tasks: Vec<tokio::task::JoinHandle<()>>,
 }
@@ -693,7 +632,7 @@ impl StreamListeners {
 	fn new(
 		binds: Vec<StreamBind>,
 		versions: moq_net::Versions,
-		#[cfg(all(feature = "uds", unix))] unix_allow: Option<UnixAllow>,
+		#[cfg(all(feature = "uds", unix))] unix_allow: Option<crate::unix::Allow>,
 	) -> Self {
 		Self {
 			binds,
@@ -783,7 +722,7 @@ fn spawn_tcp_loop(
 fn spawn_unix_loop(
 	listener: crate::unix::Listener,
 	versions: moq_net::Versions,
-	allow: Option<UnixAllow>,
+	allow: Option<crate::unix::Allow>,
 	tx: tokio::sync::mpsc::Sender<Request>,
 ) -> tokio::task::JoinHandle<()> {
 	tokio::spawn(async move {
@@ -1082,36 +1021,10 @@ impl Request {
 		self.identity.clone()
 	}
 
-	/// Whether the peer presented a valid client certificate during the handshake.
+	#[doc(hidden)]
 	#[deprecated(note = "use `peer_identity` instead")]
 	pub fn has_peer_certificate(&self) -> bool {
 		self.peer_identity().is_some()
-	}
-}
-
-/// Server ID for QUIC-LB support.
-#[serde_with::serde_as]
-#[derive(Clone, serde::Serialize, serde::Deserialize)]
-pub struct ServerId(#[serde_as(as = "serde_with::hex::Hex")] pub(crate) Vec<u8>);
-
-impl ServerId {
-	#[allow(dead_code)]
-	pub(crate) fn len(&self) -> usize {
-		self.0.len()
-	}
-}
-
-impl std::fmt::Debug for ServerId {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		f.debug_tuple("QuicLbServerId").field(&hex::encode(&self.0)).finish()
-	}
-}
-
-impl std::str::FromStr for ServerId {
-	type Err = hex::FromHexError;
-
-	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		hex::decode(s).map(Self)
 	}
 }
 
@@ -1126,6 +1039,37 @@ mod tests {
 		assert_eq!(Transport::WebSocket.as_str(), "websocket");
 		assert_eq!(Transport::Tcp.as_str(), "tcp");
 		assert_eq!(Transport::Unix.as_str(), "unix");
+	}
+
+	/// Building the endpoint needs a runtime, and `certificates()` must stay
+	/// readable without one (no guard escapes to the caller).
+	#[cfg(feature = "quinn")]
+	#[tokio::test]
+	async fn certificates_expose_generated_fingerprints() {
+		let mut config = ServerConfig {
+			bind: Some("[::]:0".to_string()),
+			..Default::default()
+		};
+		config.tls.generate = vec!["localhost".into()];
+
+		let certs = config.init().expect("server init").certificates();
+		let fingerprints = certs.fingerprints();
+		assert_eq!(fingerprints.len(), 1, "one generated certificate");
+		// Hex-encoded SHA-256.
+		assert_eq!(fingerprints[0].len(), 64);
+		assert!(fingerprints[0].chars().all(|c| c.is_ascii_hexdigit()));
+	}
+
+	/// A stream-only server has no TLS backend, so there's nothing to pin. This
+	/// must report empty rather than panic.
+	#[cfg(all(feature = "uds", unix))]
+	#[tokio::test]
+	async fn certificates_are_empty_without_a_tls_backend() {
+		let mut config = ServerConfig::default();
+		config.unix.bind = Some(PathBuf::from("/tmp/moq-native-certificates-test.sock"));
+
+		let server = config.init().expect("server init");
+		assert!(server.certificates().fingerprints().is_empty());
 	}
 
 	#[test]

--- a/rs/moq-native/src/tcp.rs
+++ b/rs/moq-native/src/tcp.rs
@@ -15,6 +15,24 @@ use url::Url;
 /// negotiated) since there's no TLS ALPN to carry it.
 const WIRE_VERSION: qmux::Version = qmux::Version::QMux01;
 
+/// Plaintext-TCP qmux listener settings (no TLS, no UDP).
+///
+/// Flattened onto [`crate::ServerConfig::tcp`]. TCP carries no peer identity, so
+/// the listener must only be reachable from trusted clients. Bind it to loopback
+/// or a private interface; a non-loopback bind logs a warning but is allowed.
+// The derived arg group is named after the struct, so it needs an explicit id to
+// stay unique across the flattened sections.
+#[derive(clap::Args, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[group(id = "server-tcp")]
+#[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
+pub struct Config {
+	/// Bind a plaintext qmux TCP listener on this address.
+	#[arg(long = "server-tcp-bind", id = "server-tcp-bind", env = "MOQ_SERVER_TCP_BIND")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub bind: Option<net::SocketAddr>,
+}
+
 /// Errors specific to the plain-TCP qmux transport.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -1,3 +1,13 @@
+//! TLS trust, certificates, and keys, split by role.
+//!
+//! [`Client`] (`--client-tls-*`) picks who to trust: system roots, custom roots,
+//! a pinned SHA-256 fingerprint, or nothing at all. [`Server`] (`--server-tls-*`)
+//! supplies the certificate chain to serve, loaded from disk or self-signed on
+//! startup, and optionally the roots that authenticate mTLS clients.
+//!
+//! Certificates loaded from disk are watched and hot reloaded, so rotating them
+//! needs no restart. [`Certificates`] reads the current set back out.
+
 use crate::crypto;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
@@ -20,78 +30,103 @@ use std::sync::RwLock;
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
+	/// A certificate file couldn't be opened, usually a bad path or permissions.
 	#[error("failed to open certificate file")]
 	Open(#[source] std::io::Error),
 
+	/// A certificate or key file was opened but couldn't be read to the end.
 	#[error("failed to read file")]
 	ReadFile(#[source] std::io::Error),
 
+	/// A file's contents aren't valid PEM certificates.
 	#[error("failed to read certificates")]
 	Read(#[source] rustls::pki_types::pem::Error),
 
+	/// A file's contents aren't a valid PEM private key.
 	#[error("failed to parse private key")]
 	Key(#[source] rustls::pki_types::pem::Error),
 
+	/// A PEM file parsed cleanly but held no certificates.
 	#[error("no certificates found")]
 	Empty,
 
+	/// A root PEM file parsed cleanly but held no certificates, so it would trust nothing.
 	#[error("no roots found in {}", .0.display())]
 	EmptyRoots(PathBuf),
 
+	/// Nothing is configured that could ever verify a server certificate.
 	#[error(
 		"no trusted roots: provide --client-tls-root, enable --client-tls-system-roots, or use --client-tls-fingerprint / --client-tls-disable-verify"
 	)]
 	NoRoots,
 
+	/// A configured fingerprint isn't valid hex.
 	#[error("invalid TLS fingerprint (expected hex-encoded SHA-256)")]
 	Fingerprint(#[source] hex::FromHexError),
 
+	/// A configured fingerprint is valid hex but the wrong size for a SHA-256 digest.
 	#[error("invalid TLS fingerprint length: expected 32 bytes (SHA-256), got {0}")]
 	FingerprintLength(usize),
 
+	/// Fingerprint pinning was combined with CA roots. Pinning bypasses the chain, so one of
+	/// the two would be silently ignored.
 	#[error(
 		"--client-tls-fingerprint cannot be combined with --client-tls-root or --client-tls-system-roots: fingerprint pinning bypasses CA verification"
 	)]
 	FingerprintWithRoots,
 
+	/// A root certificate parsed as PEM but rustls rejected it as a trust anchor.
 	#[error("failed to add root certificate")]
 	AddRoot(#[source] rustls::Error),
 
+	/// The JNI call in [`init_android`] failed, so the platform verifier is unavailable.
 	#[cfg(target_os = "android")]
 	#[error("failed to initialize the Android platform verifier")]
 	AndroidInit(#[source] jni::errors::Error),
 
+	/// rustls rejected the mTLS client certificate and key, e.g. they don't match.
 	#[error("failed to configure client certificate")]
 	ClientAuth(#[source] rustls::Error),
 
+	/// Only one half of the mTLS client identity was given; it needs both a cert and a key.
 	#[error("both --client-tls-cert and --client-tls-key must be provided")]
 	IncompleteClientAuth,
 
+	/// The server was given a different number of certificates than keys. They pair by index.
 	#[error("must provide both cert and key")]
 	CertKeyCountMismatch,
 
+	/// The server has no certificate to serve: no cert/key pair and no hostnames to generate one for.
 	#[error("must provide at least one cert/key pair or generate entry")]
 	NoCertSource,
 
+	/// A server cert/key pair was paired up by index but the key isn't the certificate's.
 	#[error("private key {} doesn't match certificate {}", key.display(), cert.display())]
 	KeyMismatch {
+		/// Path of the private key file.
 		key: PathBuf,
+		/// Path of the certificate file it was paired with.
 		cert: PathBuf,
+		/// Why rustls says the two don't match.
 		#[source]
 		source: rustls::Error,
 	},
 
+	/// A rustls error with no more specific context, e.g. building a config.
 	#[error(transparent)]
 	Rustls(#[from] rustls::Error),
 
+	/// The mTLS client-certificate verifier couldn't be built from the configured roots.
 	#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
 	#[error("failed to build client certificate verifier")]
 	ClientVerifier(#[source] rustls::server::VerifierBuilderError),
 
+	/// Generating a self-signed certificate failed.
 	#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
 	#[error(transparent)]
 	Rcgen(#[from] rcgen::Error),
 
+	/// The crate was built without a crypto provider, so no TLS is possible.
 	#[error("no crypto provider available; enable aws-lc-rs or ring feature")]
 	NoCryptoProvider,
 }
@@ -694,22 +729,54 @@ impl PeerIdentity {
 	}
 }
 
-/// TLS certificate information including fingerprints.
-#[derive(Debug)]
-pub struct Info {
+/// The certificates a server is currently serving.
+#[derive(Debug, Default)]
+pub(crate) struct Info {
 	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 	pub(crate) certs: Vec<Arc<rustls::sign::CertifiedKey>>,
-	pub fingerprints: Vec<String>,
+	pub(crate) fingerprints: Vec<String>,
 }
 
-impl Info {
-	/// An empty certificate set, used when no TLS-bearing backend is configured.
+/// A live handle to the certificates a [`crate::Server`] is serving.
+///
+/// Cheap to clone, and every read reflects the latest hot reload of the files on
+/// disk, so a caller can build one at startup and hold it for the process
+/// lifetime. Obtained from [`crate::Server::certificates`].
+#[derive(Clone, Debug)]
+pub struct Certificates {
+	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
+	info: Arc<RwLock<Info>>,
+}
+
+impl Certificates {
+	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
+	pub(crate) fn new(info: Arc<RwLock<Info>>) -> Self {
+		Self { info }
+	}
+
+	/// An empty set, used when no TLS-bearing backend is configured.
 	pub(crate) fn empty() -> Self {
 		Self {
 			#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
-			certs: Vec::new(),
-			fingerprints: Vec::new(),
+			info: Arc::new(RwLock::new(Info::default())),
 		}
+	}
+
+	/// The SHA-256 fingerprints of the certificates being served right now, hex
+	/// encoded, one per certificate and in configuration order.
+	///
+	/// Empty when the server has no TLS-bearing backend. Re-read this per use
+	/// rather than caching it: a cert rotation on disk changes the values.
+	pub fn fingerprints(&self) -> Vec<String> {
+		#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
+		{
+			// A panicking writer can't leave the cert list half-updated (it is
+			// replaced wholesale), so a poisoned lock is still safe to read.
+			let info = self.info.read().unwrap_or_else(std::sync::PoisonError::into_inner);
+			info.fingerprints.clone()
+		}
+		#[cfg(not(any(feature = "noq", feature = "quinn", feature = "quiche")))]
+		Vec::new()
 	}
 }
 
@@ -1014,10 +1081,7 @@ pub(crate) struct ServeCerts {
 impl ServeCerts {
 	pub fn new(provider: crypto::Provider) -> Self {
 		Self {
-			info: Arc::new(RwLock::new(Info {
-				certs: Vec::new(),
-				fingerprints: Vec::new(),
-			})),
+			info: Arc::new(RwLock::new(Info::default())),
 			provider,
 		}
 	}

--- a/rs/moq-native/src/unix.rs
+++ b/rs/moq-native/src/unix.rs
@@ -15,6 +15,85 @@ use url::Url;
 /// raw stream has no TLS ALPN to carry it.
 const WIRE_VERSION: qmux::Version = qmux::Version::QMux01;
 
+/// Plaintext Unix-socket qmux listener settings, with an optional
+/// peer-credential allowlist.
+///
+/// Flattened onto [`crate::ServerConfig::unix`].
+// The derived arg group is named after the struct, so it needs an explicit id to
+// stay unique across the flattened sections.
+#[derive(clap::Args, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[group(id = "server-unix")]
+#[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
+pub struct Config {
+	/// Bind a plaintext qmux Unix-socket listener at this path.
+	#[arg(long = "server-unix-bind", id = "server-unix-bind", env = "MOQ_SERVER_UNIX_BIND")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub bind: Option<PathBuf>,
+
+	/// Peer-credential allowlist. `None` (the default) enforces nothing, so the
+	/// socket's filesystem permissions are the only gate.
+	#[command(flatten)]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub allow: Option<Allow>,
+}
+
+/// Peer-credential allowlist for a `unix://` listener.
+///
+/// The kernel reports the connecting process's credentials. Each populated list
+/// constrains the corresponding credential (AND across the three, OR within
+/// each); all empty means no check.
+#[derive(clap::Args, Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[group(id = "server-unix-allow")]
+#[serde(deny_unknown_fields, default)]
+#[non_exhaustive]
+pub struct Allow {
+	/// Allowed peer user IDs. Empty means any uid.
+	#[arg(
+		long = "server-unix-allow-uid",
+		env = "MOQ_SERVER_UNIX_ALLOW_UID",
+		value_delimiter = ','
+	)]
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub uid: Vec<u32>,
+
+	/// Allowed peer group IDs. Empty means any gid.
+	#[arg(
+		long = "server-unix-allow-gid",
+		env = "MOQ_SERVER_UNIX_ALLOW_GID",
+		value_delimiter = ','
+	)]
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub gid: Vec<u32>,
+
+	/// Allowed peer PIDs. Empty means any pid; a populated list rejects peers
+	/// whose PID the platform doesn't report.
+	#[arg(
+		long = "server-unix-allow-pid",
+		env = "MOQ_SERVER_UNIX_ALLOW_PID",
+		value_delimiter = ','
+	)]
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub pid: Vec<i32>,
+}
+
+impl Allow {
+	/// Whether any field is populated (i.e. the allowlist enforces something).
+	pub(crate) fn is_empty(&self) -> bool {
+		self.uid.is_empty() && self.gid.is_empty() && self.pid.is_empty()
+	}
+
+	/// Whether `cred` satisfies every populated field (AND across fields, OR
+	/// within a field). A required pid is unsatisfiable when the platform
+	/// reports none.
+	pub(crate) fn permits(&self, cred: &PeerCred) -> bool {
+		let uid_ok = self.uid.is_empty() || self.uid.contains(&cred.uid);
+		let gid_ok = self.gid.is_empty() || self.gid.contains(&cred.gid);
+		let pid_ok = self.pid.is_empty() || cred.pid.is_some_and(|pid| self.pid.contains(&pid));
+		uid_ok && gid_ok && pid_ok
+	}
+}
+
 /// Errors specific to the Unix-domain-socket qmux transport.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -1,3 +1,10 @@
+//! WebSocket fallback transport, running the QMux wire format over `ws://` or `wss://`.
+//!
+//! Used when QUIC is unreachable: UDP blocked by a firewall, a proxy in the way, a
+//! network that only passes TCP/443. The client races this against QUIC and gives QUIC
+//! a small head start ([`Client::delay`]), so WebSocket only wins when QUIC can't get
+//! through. Servers accept it on a separate TCP port via [`Listener`].
+
 use qmux::tokio_tungstenite;
 use qmux::tokio_tungstenite::tungstenite::{self, http};
 use std::collections::HashSet;
@@ -9,33 +16,44 @@ use url::Url;
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
+	/// The TCP socket failed to bind, accept, or connect.
 	#[error(transparent)]
 	Io(#[from] std::io::Error),
 
+	/// WebSocket fallback was turned off via [`Client::enabled`].
 	#[error("WebSocket support is disabled")]
 	Disabled,
 
+	/// The URL had no host to dial.
 	#[error("missing hostname")]
 	MissingHostname,
 
+	/// The URL scheme can't carry WebSocket. Only `http`, `https`, `ws`, and `wss` work.
 	#[error("unsupported URL scheme for WebSocket: {0}")]
 	UnsupportedScheme(String),
 
+	/// The qmux handshake failed while dialing, including a non-101 upgrade response
+	/// from the server.
 	#[error("failed to connect WebSocket")]
 	Connect(#[source] qmux::Error),
 
+	/// The URL couldn't be turned into a valid WebSocket handshake request.
 	#[error("failed to build WebSocket request")]
 	BuildRequest(#[source] tungstenite::Error),
 
+	/// An ALPN contained bytes that aren't legal in the `Sec-WebSocket-Protocol` header.
 	#[error("failed to build WebSocket protocols header")]
 	ProtocolHeader(#[source] http::header::InvalidHeaderValue),
 
+	/// The TCP/TLS connection or the WebSocket upgrade itself failed.
 	#[error("failed to connect WebSocket")]
 	WebSocketConnect(#[source] tungstenite::Error),
 
+	/// The server refused the connection outright, so retrying won't help.
 	#[error(transparent)]
 	ConnectRejected(#[from] crate::ConnectError),
 
+	/// The qmux handshake failed while accepting an incoming connection.
 	#[error("WebSocket accept failed")]
 	Accept(#[source] qmux::Error),
 }
@@ -217,10 +235,12 @@ pub struct Listener {
 }
 
 impl Listener {
+	/// Bind a listener to the given address, accepting every moq ALPN we know about.
 	pub async fn bind(addr: net::SocketAddr) -> Result<Self> {
 		Self::bind_with_alpns(addr, moq_net::ALPNS).await
 	}
 
+	/// Bind a listener that only accepts the given moq ALPNs, in preference order.
 	pub async fn bind_with_alpns(addr: net::SocketAddr, alpns: &[&str]) -> Result<Self> {
 		let listener = tokio::net::TcpListener::bind(addr).await?;
 		// `qmux_versions_for` returns `&[]` (every QMux draft) for ALPNs the spec
@@ -230,10 +250,15 @@ impl Listener {
 		Ok(Self { listener, server })
 	}
 
+	/// The local address the listener is bound to.
 	pub fn local_addr(&self) -> Result<net::SocketAddr> {
 		Ok(self.listener.local_addr()?)
 	}
 
+	/// Accept the next connection, performing the WebSocket upgrade and qmux handshake.
+	///
+	/// Returns `None` only if the listener itself is gone; a per-connection failure is
+	/// yielded as `Some(Err(..))` so the accept loop keeps running.
 	pub async fn accept(&self) -> Option<Result<qmux::Session>> {
 		match self.listener.accept().await {
 			Ok((stream, addr)) => {

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -294,7 +294,7 @@ async fn iroh_connect() {
 	let mut server = server_config
 		.init()
 		.expect("failed to init server")
-		.with_iroh(Some(server_endpoint));
+		.with_iroh(server_endpoint);
 
 	// ── subscriber (client) ─────────────────────────────────────────
 	let sub_origin = Origin::random().produce();
@@ -315,7 +315,7 @@ async fn iroh_connect() {
 	let client = client_config
 		.init()
 		.expect("failed to init client")
-		.with_iroh(Some(client_endpoint))
+		.with_iroh(client_endpoint)
 		.with_iroh_addrs(server_addrs);
 
 	let url: url::Url = format!("iroh://{server_endpoint_id}").parse().unwrap();

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -1048,7 +1048,7 @@ async fn broadcast_websocket() {
 	let mut server = server_config
 		.init()
 		.expect("failed to init server")
-		.with_websocket(Some(ws_listener));
+		.with_websocket(ws_listener);
 
 	// ── subscriber (client) ─────────────────────────────────────────
 	let sub_origin = Origin::random().produce();
@@ -1156,7 +1156,7 @@ async fn broadcast_websocket_fallback() {
 	let mut server = server_config
 		.init()
 		.expect("failed to init server")
-		.with_websocket(Some(ws_listener));
+		.with_websocket(ws_listener);
 
 	// ── subscriber (client) ─────────────────────────────────────────
 	let sub_origin = Origin::random().produce();
@@ -1269,7 +1269,7 @@ async fn broadcast_websocket_uses_newest_version() {
 	let mut server = server_config
 		.init()
 		.expect("failed to init server")
-		.with_websocket(Some(ws_listener));
+		.with_websocket(ws_listener);
 
 	let sub_origin = Origin::random().produce();
 	let mut client_config = moq_native::ClientConfig::default();
@@ -1340,7 +1340,7 @@ async fn broadcast_race_quic_wins() {
 	let mut server = server_config
 		.init()
 		.expect("failed to init server")
-		.with_websocket(Some(ws_listener));
+		.with_websocket(ws_listener);
 
 	let sub_origin = Origin::random().produce();
 	let mut client_config = moq_native::ClientConfig::default();

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -33,9 +33,9 @@ async fn main() -> anyhow::Result<()> {
 	};
 
 	#[cfg(feature = "iroh")]
-	let (server, client) = {
-		let iroh = config.iroh.bind(&config.client.quic).await?;
-		(server.with_iroh(iroh.clone()), client.with_iroh(iroh))
+	let (server, client) = match config.iroh.bind(&config.client.quic).await? {
+		Some(iroh) => (server.with_iroh(iroh.clone()), client.with_iroh(iroh)),
+		None => (server, client),
 	};
 
 	// Reject configs where neither JWT nor mTLS can authenticate anyone.
@@ -69,7 +69,7 @@ async fn main() -> anyhow::Result<()> {
 	let internal = Internal::new(config.internal, cluster.stats.clone());
 
 	// Create a web server too. mTLS for HTTPS is opt-in via `--web-https-root`.
-	let web = Web::new(auth.clone(), cluster.clone(), server.tls_info(), config.web);
+	let web = Web::new(auth.clone(), cluster.clone(), server.certificates(), config.web);
 
 	match addr {
 		Some(addr) => tracing::info!(%addr, "listening"),

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -126,7 +126,7 @@ pub(crate) struct WebState {
 	/// The cluster state for resolving origins.
 	pub(crate) cluster: Cluster,
 	/// TLS certificate information served at `/certificate.sha256`.
-	pub(crate) tls_info: Arc<std::sync::RwLock<moq_native::tls::Info>>,
+	pub(crate) certificates: moq_native::tls::Certificates,
 	/// Monotonically increasing connection counter for WebSocket sessions.
 	#[cfg_attr(not(feature = "websocket"), allow(dead_code))]
 	pub(crate) conn_id: AtomicU64,
@@ -139,19 +139,14 @@ pub struct Web {
 }
 
 impl Web {
-	/// Build a web server from its parts. `tls_info` is the relay's TLS
-	/// certificate info (e.g. `server.tls_info()`), served at
-	/// `/certificate.sha256`.
-	pub fn new(
-		auth: Auth,
-		cluster: Cluster,
-		tls_info: Arc<std::sync::RwLock<moq_native::tls::Info>>,
-		config: WebConfig,
-	) -> Self {
+	/// Build a web server from its parts. `certificates` is the relay's TLS
+	/// certificate handle (e.g. `server.certificates()`), whose fingerprints are
+	/// served at `/certificate.sha256`.
+	pub fn new(auth: Auth, cluster: Cluster, certificates: moq_native::tls::Certificates, config: WebConfig) -> Self {
 		let state = Arc::new(WebState {
 			auth,
 			cluster,
-			tls_info,
+			certificates,
 			conn_id: AtomicU64::new(0),
 		});
 		Self { state, config }
@@ -424,17 +419,14 @@ async fn serve_health() -> Response {
 	(StatusCode::OK, "ok\n").into_response()
 }
 
-async fn serve_fingerprint(State(state): State<Arc<WebState>>) -> String {
+async fn serve_fingerprint(State(state): State<Arc<WebState>>) -> Response {
 	// Get the first certificate's fingerprint.
 	// TODO serve all of them so we can support multiple signature algorithms.
-	state
-		.tls_info
-		.read()
-		.expect("tls_info lock poisoned")
-		.fingerprints
-		.first()
-		.expect("missing certificate")
-		.clone()
+	match state.certificates.fingerprints().into_iter().next() {
+		Some(fingerprint) => fingerprint.into_response(),
+		// A stream-only relay has no certificate to pin.
+		None => (StatusCode::NOT_FOUND, "no certificate\n").into_response(),
+	}
 }
 
 #[derive(Debug, serde::Deserialize)]

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -48,7 +48,7 @@ async fn build_web(port: u16, ws: bool) -> Web {
 
 	let cluster = Cluster::new(ClusterConfig::default()).expect("cluster init");
 
-	// moq_native::Server is needed for `tls_info`, even though we never
+	// moq_native::Server is needed for `certificates`, even though we never
 	// expose HTTPS or QUIC in this test. Binding QUIC to `[::]:0` picks an
 	// unused UDP port that we ignore.
 	let mut server_config = moq_native::ServerConfig::default();
@@ -60,7 +60,7 @@ async fn build_web(port: u16, ws: bool) -> Web {
 	web_config.ws = ws;
 	web_config.http.listen = Some(format!("127.0.0.1:{port}").parse().expect("parse listen"));
 
-	Web::new(auth, cluster, server.tls_info(), web_config)
+	Web::new(auth, cluster, server.certificates(), web_config)
 }
 
 fn free_tcp_port() -> u16 {


### PR DESCRIPTION
Polishes `moq-native`'s public surface ahead of a version bump. It ships the roughest finish in the workspace and is the first crate every native consumer touches. Closes #2323.

Targets `dev`: renamed/removed/signature-changed `pub` items in a core library.

## Changes

- **Missing docs → 0.** Documented the whole public surface and added `#![warn(missing_docs)]`, so the crate's `-D warnings` lint keeps it documented rather than letting it rot back. This closes 197 sites: 116 on default features (the count in the issue), plus the feature-gated `noq`/`quiche`/`iroh`/`websocket` backends that only show up under `--all-features` (what CI lints with).

- **`tls_info()` lock leak.** `Server::tls_info() -> Arc<RwLock<tls::Info>>` handed callers a shared std lock: `.read().unwrap()` poison panics, guards held across awaits, and the concrete `Arc<RwLock<_>>` frozen into the API. Replaced with `Server::certificates() -> tls::Certificates`, a cheap-to-clone live read handle whose only method is `fingerprints() -> Vec<String>`. `tls::Info` is now private; the handle reflects cert hot reloads, so callers hold the handle, not the values. Reads tolerate a poisoned lock (the cert list is replaced wholesale, never left half-updated).

- **`Option`-taking setters.** `Server::with_websocket`, `Server::with_iroh`, and `Client::with_iroh` now take the value; omission means absent, instead of `with_x(None)` reading like "unset". Both sides spell the endpoint `crate::iroh::Endpoint` (the client previously used `web_transport_iroh::iroh::Endpoint`, the same type under a confusing path).

- **Deprecation mechanics.** `Request::has_peer_certificate` was `#[deprecated]` without `#[doc(hidden)]`, violating the repo's own rule (its neighbors do it right). Hid it. Found `quiche::Error::FingerprintUnsupported` doing the same thing *and* carrying a "No longer returned: ..." doc that breaks the no-history-in-comments rule; hid it too.

- **Enumerated root re-exports.** Replaced the `pub use client::*; server::*; log::*; reconnect::*` globs with explicit lists, so the root surface is deliberate and a new `pub` item doesn't silently join it. The accidental riders the issue names move to their role modules: `ServerId` → `quic::ServerId` (it's QUIC-LB config), `TcpConfig` → `tcp::Config`, `UnixConfig`/`UnixAllow` → `unix::Config`/`unix::Allow`.

## Root cause worth flagging

Renaming to short module-scoped `Config` names made two of clap's derived `ArgGroup`s collide (`'Config' is already in use`) — the derive names the group after the struct ident. This panics at **runtime**, is invisible to the compiler, and was only caught by `moq-relay`'s config tests. Fixed with explicit `#[group(id = ...)]` ids. Verified `moq-relay --help` is byte-identical to `dev`, so no CLI docs change.

## Consumers updated

`moq-relay` (`Web::new`, `serve_fingerprint`), `moq-cli` (`run_web`, iroh setup), and `moq-ffi` (`cert_fingerprints`) all move to `certificates()` / the value-taking setters. The fingerprint HTTP handlers now return 404 on a stream-only server (no cert to pin) instead of panicking on `.expect("missing certificate")`.

## Testing

- Two new regression tests: `certificates()` exposes a generated cert's fingerprint, and reports empty (no panic) on a stream-only server with no TLS backend.
- `moq-native` lib + integration, `moq-relay`, all pass. Clippy `--all-features` clean across native/relay/cli/ffi. `cargo doc -D warnings`, `fmt`, `sort`, and `--no-default-features` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)