### PR TITLE
fix(moq-native): silence gso_disabled dead-code in default builds

### DIFF
--- a/rs/moq-native/src/quic.rs
+++ b/rs/moq-native/src/quic.rs
@@ -270,6 +270,11 @@ impl Resolved {
 	}
 
 	/// Whether the config asks to turn GSO off, which not every backend can honor.
+	///
+	/// Only the quiche and iroh backends consult this, to reject a GSO-off request
+	/// they can't satisfy; quinn and noq toggle GSO directly. A default build
+	/// compiles neither, so the method is intentionally unused there.
+	#[cfg_attr(not(any(feature = "quiche", feature = "iroh")), allow(dead_code))]
 	pub(crate) fn gso_disabled(&self) -> bool {
 		self.gso == Some(false)
 	}


### PR DESCRIPTION
## Problem

`just rs check` fails on a `-D warnings` dead-code error for every local contributor, unrelated to any of their changes:

```
error: method `gso_disabled` is never used
  --> rs/moq-native/src/quic.rs  (impl Resolved)
  = note: `-D dead-code` implied by `-D warnings`
```

## Root cause

`Resolved::gso_disabled` (`rs/moq-native/src/quic.rs`) is only called from the `quiche` and `iroh` backends, which reject a GSO-off request they can't honor. `quinn`/`noq` toggle GSO directly via the transport config and never call it. Both `quiche` and `iroh` are **non-default** features, so under default features the method is dead in the plain lib unit. The `#[cfg(test)]` tests that call it don't rescue it, because the plain lib unit compiles without `cfg(test)`.

CI doesn't catch this because `just rs ci` runs `cargo clippy --workspace --all-targets --all-features`, where both backends are enabled and the method is live. But `just rs check` (rs/justfile line 18) runs `cargo clippy --all-targets` with **default** features, so every local dev hits it.

## Fix

Mark the method `allow(dead_code)` only when neither consuming backend is compiled:

```rust
#[cfg_attr(not(any(feature = "quiche", feature = "iroh")), allow(dead_code))]
```

Chose this over cfg-gating the method (`#[cfg(any(...))]`) so the tests need no gating and keep exercising all three cases (`None`, `Some(false)`, `Some(true)`) in every feature config. Cfg-gating would have forced dropping the `None`-case assertion, which only lives in `defaults_apply_when_unset`.

Verified it was the **only** default-feature dead-code warning in the crate.

## Testing

All pass:
- `cargo clippy -p moq-native --all-targets -- -D warnings` (default) ✅
- `cargo clippy -p moq-native --all-targets --all-features -- -D warnings` ✅
- `cargo check -p moq-native --no-default-features` ✅
- `cargo test -p moq-native` (incl. `gso_disabled_only_on_explicit_false`, now running in the default build too) ✅
- `cargo fmt --check` ✅

## Out of scope

While verifying, I found the `--no-default-features --features quiche` combo (quiche-only, no quinn/noq/websocket) has its own pre-existing dead-code warnings (`Client::tls`, `Resolved::keep_alive`, `util::pick_addr`, `util::normalize_family`, an unreachable `QuicBackend` match arm). Confirmed identical on pristine `main`, unrelated to this change, and not a combo CI gates. Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)