### PR TITLE
fix(js/net): bump @moq/qmux to 0.3.0 to fix a post-close enqueue crash

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -80,7 +80,7 @@
     },
     "js/flate": {
       "name": "@moq/flate",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "pako": "^3.0.0",
       },
@@ -178,7 +178,7 @@
       "name": "@moq/net",
       "version": "0.1.8",
       "dependencies": {
-        "@moq/qmux": "^0.1.3",
+        "@moq/qmux": "^0.3.0",
         "@moq/signals": "workspace:*",
         "async-mutex": "^0.5.0",
       },
@@ -582,7 +582,7 @@
 
     "@moq/publish": ["@moq/publish@workspace:js/publish"],
 
-    "@moq/qmux": ["@moq/qmux@0.1.3", "", { "dependencies": { "@moq/web-socket-stream": "^0.1.0" } }, "sha512-naGmMMOxCSMeLyEATrLiY9RGyeZENC4dHFVVNWNcA17LXE9NwM3aQrQY218xXypWahYIgIkl/ZCutIP2xHibgA=="],
+    "@moq/qmux": ["@moq/qmux@0.3.0", "", { "dependencies": { "@moq/web-socket-stream": "^0.1.0" } }, "sha512-0DchimaN2XaxdRhk5e+vVyTPAYxRZObNPqPWIwhesIiXCT9xJsZ5ltpQhXD/S3OPjrFk0aEH3rRmP0THdD0Ukw=="],
 
     "@moq/signals": ["@moq/signals@workspace:js/signals"],
 

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -17,7 +17,7 @@
 		"release": "bun ../common/release.ts"
 	},
 	"dependencies": {
-		"@moq/qmux": "^0.1.3",
+		"@moq/qmux": "^0.3.0",
 		"@moq/signals": "workspace:*",
 		"async-mutex": "^0.5.0"
 	},


### PR DESCRIPTION
Bumps `@moq/qmux` in `js/net/package.json` from `^0.1.3` to `^0.3.0` (plus the matching lockfile update). This picks up the upstream fix for a race in the qmux WebSocket polyfill that surfaced as unhandled `ReadableStreamDefaultController.enqueue` TypeErrors in Firefox during teardown storms. The caret on `^0.1.3` can never resolve to 0.3.0, so a manifest change is required. Note that `main` currently sits on the still affected `^0.2.0` (bumped by dependabot in #2292), while `dev` had `^0.1.3`; this PR targets `dev` per maintainer preference.

## Motivation

While testing the web demo in Firefox 152 (which the gate in `js/net/src/connection/connect.ts` forces onto the WebSocket/qmux transport), restarting the publisher produced a RESET_STREAM burst followed by two unhandled promise rejections:

```
TypeError: ReadableStreamDefaultController.enqueue: Cannot enqueue into a stream that has already closed.
  #handleStreamFrame <- #recvFrame <- #onData <- #readLoop   (two distinct call sites)
```

Mechanism, confirmed in the published `@moq/qmux` sources: in 0.1.x through 0.2.0, the private method `#handleStreamFrame` in `session.js` was `async` and dispatched fire-and-forget from the synchronous `#recvFrame`. It contained two unguarded `enqueue()` calls on the session level incoming stream controllers (`#incomingBidirectionalStreams` and `#incomingUnidirectionalStreams`, matching the two stacks). When the session close path ran first (a CONNECTION_CLOSE earlier in the same WebSocket record, a socket drop, or an idle timeout) and a still buffered frame opening a new stream arrived afterward, `enqueue()` threw into a promise nothing awaited, so the TypeError escaped as an unhandled rejection.

Fixed upstream in moq-dev/web-transport#285: `#handleStreamFrame` became synchronous with an `if (this.#closed) return` entry guard, plus regression tests. A later change (moq-dev/web-transport#307) hardened it further by bounding and guarding incoming stream acceptance. The fix shipped in npm `@moq/qmux` 0.3.0. Affected published versions are 0.1.x through 0.2.0; 0.3.0 is the first fixed release (verified in the published artifacts: 0.2.0 still has the async unguarded handler, 0.3.0 has the synchronous guarded one).

## Change

- `js/net/package.json`: `"@moq/qmux": "^0.1.3"` to `"^0.3.0"`.
- `bun.lock`: the matching resolution update. The lockfile hunk also carries a `js/flate` workspace version line (`0.1.0` to `0.1.1`); that is pre-existing drift (the committed `js/flate/package.json` already says 0.1.1) which any `bun install` reconciles.

`js/net` is the only workspace package that depends on `@moq/qmux`.

## Verification

All verification ran on this branch (current `dev` plus this bump), macOS ARM. The live scenarios were additionally run in full on the previous `dev` head with the same results.

Static:

- `bun install` from the repo root is a no-op; installed `node_modules/@moq/qmux` is 0.3.0, and its `session.js` `#handleStreamFrame` is not `async` and begins with the `if (this.#closed)` guard (zero `async #handleStreamFrame` occurrences).
- `js/net`: `bun run check` clean, `bun run test` 259 pass / 0 fail.
- Workspace wide: `just js check` (typecheck + biome across all packages, including `@moq/hang`, `@moq/watch`, `@moq/publish`, and the demo) and `just js test` (all package suites) both pass with the new resolution.

Targeted 0.1.3 to 0.3.0 regression risks, each probed specifically:

1. `Session.closed` now rejects on abnormal termination (moq-dev/web-transport#290 / #291). Audited every consumer: `Reload.#connect` in `js/net/src/connection/reload.ts` awaits `connection.closed` inside try/catch and drives the reconnect backoff; the `closed` getters in `js/net/src/lite/connection.ts` and `js/net/src/ietf/connection.ts` only propagate to that catch; qmux itself pre-attaches a rejection handler to its own `closed` in the `Session` constructor, so the base promise cannot leak. The one voided chain (`#runSendBandwidth` in `lite/connection.ts`) is unreachable on qmux because `Session` 0.3.0 exposes no `getStats`, so `sendBandwidth` never activates on this transport (on native WebTransport that path predates this change). Confirmed live: killing the relay under a playing watcher rejected `closed`, which surfaced as a classified `connection error: WebTransportError: Connection closed: 1006` warn followed by exponential backoff (1s/2s/4s...) and a successful reconnect. No unhandled rejection.
2. Richer blocked-claim errors (`Connection closed: <code> <reason>`). Grepped `js/net/src` for error message matching: the only match is `Subscriber.runDatagrams` in `js/net/src/lite/subscriber.ts` comparing against Chrome's native "The session is closed." string, which only selects a log level (debug vs warn) for datagram reader shutdown; cosmetic at worst. Nothing keys off a bare `Error("closed")`. The new error format was observed live and classified correctly (`probe stream error Error: Connection closed: 1006`).
3. Protocol negotiation (qmux-02 in moq-dev/web-transport#284, APPLICATION_CLOSE/CONNECTION_CLOSE split in #292). Against the local Rust relay, every session negotiated `moq-lite-05` (browser `session.protocol` debug logs and the relay's negotiated version logs agree), on both the WebSocket and QUIC paths. Abnormal closes are classified as abnormal in both directions (relay kill rejects the JS `closed`; a page reload shows up relay side as a connection drop).
4. Record limits (#317) and stream offset encoding (#316). A/B tested: ran the identical connect/subscribe sequence against the same relay build with `@moq/qmux` pinned back to 0.1.3 and then 0.3.0. The relay debug/warn lines at session setup (`failed to send setup err=transport: connection closed`, `error running uni stream err=short buffer`, `control stream error err=short buffer`) are byte identical in both versions, so they are pre-existing relay side logging, not a 0.3.0 protocol regression. No new protocol violation logs appeared with 0.3.0.
5. Bounded unaccepted incoming stream queue (#307). The busy bbb broadcast (video + audio + catalog, continuous group churn) played for the whole session across all teardown rounds with no stall and no stream acceptance errors.

Live reproduction of the original failure scenario (Firefox 152, watcher on the WebSocket/qmux transport, confirmed via `connected via WebSocket` and the negotiated ALPN log; served bundle verified to contain the guarded synchronous `#handleStreamFrame` after clearing the Vite dep cache):

- Publisher restart (the original trigger), 4 rounds total across both bases. The overlap case reproduces the original RESET burst exactly, through the same qmux call sites (`#handleResetStream <- #recvFrame <- #onData <- #readLoop`): a burst of `RESET_STREAM: 4` subscribe errors, all surfaced as handled warn/error logs. Zero unhandled rejections, zero enqueue TypeErrors.
- Watcher page reload (the trigger from #2351, which is a separate, already filed relay bug and is only used here as a teardown generator), 4 rounds. The dying page's session aborts with the new `Connection closed: 1006` rejection, handled; the new page reconnects and resubscribes in under a second.
- Relay kill under a live watcher (socket drop, the new abnormal `closed` rejection path), 4 rounds. Classified error, backoff, reconnect, playback resumes when the relay returns.

Total across every round and both package bases: 0 unhandled rejections, 0 `ReadableStreamDefaultController.enqueue` TypeErrors in the captured console (all console output, including unhandled rejections, was mirrored verbatim to a local log sink for the whole session).

One observation from the storms that is not a qmux issue: after a publisher restart where the new announce overlaps the old session's timeout, the reset subscriptions are not retried while the announce stays active; that is #2354 (a reset subscription is terminal), pre-existing js/net behavior and unchanged by this bump.

Attempted repro of the original bug on 0.1.3 for contrast (3 relay kills + 3 reloads with the buggy version served): the race did not fire locally, as it needs a stream opening frame buffered behind the close in the same record, which localhost latency rarely produces. The fix verification therefore rests on the published source diff and the upstream regression tests in moq-dev/web-transport#285.

Not tested:

- Safari on qmux: Safari here negotiates native WebTransport (it has WebTransport support), so it never exercises the qmux path in this demo. A Safari WebTransport smoke run did pass (connect, subscribe, stable playback).
- A relay initiated graceful APPLICATION_CLOSE surfacing as a graceful close in JS: the demo relay has no graceful session shutdown to trigger (a kill is a socket drop), so only the abnormal direction was exercised end to end.
- Root `just check` (Rust side): not run due to a local ffmpeg-sys build issue on this machine; the Rust workspace is untouched by this change. `just js check` and `just js test` were run instead.
