### PR TITLE
fix(moq-net): end a finished track cleanly when its broadcast closes

### DIFF
--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -649,6 +649,98 @@ async fn server_client_roundtrip() {
 	server.cancel();
 }
 
+/// A cleanly finished broadcast ends its tracks rather than aborting them.
+///
+/// Finishing a track and then the broadcast that owns it sends those two events
+/// on separate streams, so a subscriber can see the broadcast go away before the
+/// track's FIN arrives. The subscription still ends cleanly: the publisher said
+/// "done", not "failed", and the track's data had already been delivered.
+///
+/// Regressing this is quiet and expensive. Every consumer of a well behaved
+/// publisher sees an error at the end of an ordinary session, and no amount of
+/// politeness on the publisher's side avoids it.
+#[tokio::test]
+async fn json_stream_ends_cleanly_when_broadcast_finishes() {
+	let server_origin = MoqOriginProducer::new();
+	let server = MoqServer::new();
+	server.set_bind("127.0.0.1:0".into()).unwrap();
+	server.set_tls_generate(vec!["localhost".into()]);
+	server.set_publish(Some(server_origin.clone()));
+
+	let addr = tokio::time::timeout(TIMEOUT, server.listen())
+		.await
+		.expect("listen timed out")
+		.expect("listen failed");
+	let url = format!("https://{addr}");
+
+	let accept_server = server.clone();
+	let accept = tokio::spawn(async move {
+		let request = accept_server
+			.accept()
+			.await
+			.expect("accept errored")
+			.expect("accept returned None");
+		request.ok().await.expect("handshake failed")
+	});
+
+	let client_origin = MoqOriginProducer::new();
+	let client = MoqClient::new();
+	client.set_tls_disable_verify(true);
+	client.set_bind("127.0.0.1:0".into()).unwrap();
+	client.set_consume(Some(client_origin.clone()));
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+		.await
+		.expect("connect timed out")
+		.expect("connect failed");
+	let server_session = tokio::time::timeout(TIMEOUT, accept)
+		.await
+		.expect("server accept timed out")
+		.expect("server accept task panicked");
+
+	let config = MoqJsonStreamConfig { compression: true };
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+	let producer = broadcast.publish_json_stream("events".into(), config.clone()).unwrap();
+	server_origin.publish("hello".into(), &broadcast).unwrap();
+
+	let consumer = client_origin.consume();
+	let announced = consumer.announced("".into()).unwrap();
+	let announcement = tokio::time::timeout(TIMEOUT, announced.next())
+		.await
+		.expect("timed out waiting for announcement")
+		.unwrap()
+		.expect("expected an announcement");
+	let sub = announcement
+		.broadcast()
+		.subscribe_json_stream("events".into(), config)
+		.unwrap();
+
+	// Drain a record first, so the subscription is fully established over the
+	// wire before anything is finished.
+	producer.append(r#"{"n":0}"#.into()).unwrap();
+	let first = tokio::time::timeout(TIMEOUT, sub.next())
+		.await
+		.expect("timed out waiting for the first record")
+		.expect("first record errored")
+		.expect("expected a record");
+	assert_eq!(
+		serde_json::from_str::<serde_json::Value>(&first).unwrap(),
+		serde_json::json!({ "n": 0 })
+	);
+
+	// The polite shutdown: finish the track, then the broadcast that owns it.
+	producer.finish().unwrap();
+	broadcast.finish().unwrap();
+
+	let end = tokio::time::timeout(TIMEOUT, sub.next())
+		.await
+		.expect("timed out waiting for end of stream");
+	assert!(matches!(end, Ok(None)), "expected a clean end of stream, got {end:?}");
+
+	session.shutdown();
+	server_session.cancel(0);
+	server.cancel();
+}
+
 #[tokio::test]
 async fn server_set_bind_validates() {
 	let server = MoqServer::new();

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -403,7 +403,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let msg = lite::Subscribe {
 			id,
 			broadcast: path.as_path(),
-			track: (&track.name).into(),
+			// Owned so the subscribe future below doesn't borrow the track we finish.
+			track: track.name.clone().into(),
 			priority: track.priority,
 			ordered: true,
 			max_latency: std::time::Duration::ZERO,
@@ -411,27 +412,44 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			end_group: None,
 		};
 
-		tracing::info!(id, broadcast = %self.log_path(&path), track = %track.name, "subscribe started");
+		// Owned because `run_track` holds a `&mut self` borrow below.
+		let log_path = self.log_path(&path).to_string();
 
-		tokio::select! {
-			_ = track.unused() => {
-				tracing::info!(id, broadcast = %self.log_path(&path), track = %track.name, "subscribe cancelled");
-				let _ = track.abort(Error::Cancel);
+		tracing::info!(id, broadcast = %log_path, track = %track.name, "subscribe started");
+
+		let mut run = std::pin::pin!(self.run_track(msg));
+		let mut unannounced = false;
+
+		let res = loop {
+			tokio::select! {
+				_ = track.unused() => {
+					tracing::info!(id, broadcast = %log_path, track = %track.name, "subscribe cancelled");
+					let _ = track.abort(Error::Cancel);
+					return;
+				}
+				// An unannounce doesn't decide this track's fate. It travels on the
+				// announce stream while the track's data has its own, so it can arrive
+				// before the FIN of a track the publisher already finished. Aborting
+				// here would turn that clean end into an error no publisher could
+				// avoid. The publisher ends this subscribe stream either way, so let
+				// it say what actually happened.
+				err = broadcast.closed(), if !unannounced => {
+					tracing::info!(id, broadcast = %log_path, track = %track.name, %err, "broadcast closed");
+					unannounced = true;
+				}
+				res = &mut run => break res,
 			}
-			err = broadcast.closed() => {
-				tracing::info!(id, broadcast = %self.log_path(&path), track = %track.name, "broadcast closed");
+		};
+
+		match res {
+			Ok(()) => {
+				tracing::info!(id, broadcast = %log_path, track = %track.name, "subscribe complete");
+				let _ = track.finish();
+			}
+			Err(err) => {
+				tracing::warn!(id, broadcast = %log_path, track = %track.name, %err, "subscribe error");
 				let _ = track.abort(err);
 			}
-			res = self.run_track(msg) => match res {
-				Ok(()) => {
-					tracing::info!(id, broadcast = %self.log_path(&path), track = %track.name, "subscribe complete");
-					let _ = track.finish();
-				}
-				Err(err) => {
-					tracing::warn!(id, broadcast = %self.log_path(&path), track = %track.name, %err, "subscribe error");
-					let _ = track.abort(err);
-				}
-			},
 		}
 	}
 


### PR DESCRIPTION
## Summary

- A publisher that finishes a track and then finishes the broadcast that owns it sends those two events on **separate streams**, so there is no ordering between them.
- The subscriber handled `Announce::Ended` by aborting its local broadcast with `Error::Cancel`, and `run_subscribe` aborted every in-flight track the moment `broadcast.closed()` fired. That raced the track's own FIN and usually won.
- **Root cause:** a cleanly finished track reached consumers as `cancelled` instead of end-of-stream, even though the publisher had already logged the subscription complete. The two signals travel on different QUIC streams and the unannounce lands first.
- No publisher could avoid this. `finish()` is the polite shutdown API and it produced an error at the far end on any real session (a local `moq.Server` reproduces it just as a remote relay does). Only an in-process origin, with no subscriber in the loop, ended cleanly — which is why it hid from unit tests.
- **Fix:** an unannounce no longer decides a track's fate. `run_subscribe` records that the broadcast closed and keeps waiting for the subscribe stream, which the publisher ends either way (FIN → `finish()`, reset → `abort(err)`), so the track's outcome reflects what actually happened. `track.unused()` still covers local disinterest, which is how a relay reaps subscriptions once its downstream consumers go away.

### Behavior change worth a look

A publisher that unannounces but never ends the subscribe stream now leaves the subscription waiting rather than being aborted immediately on the unannounce. For a relay this is covered by `track.unused()` firing when downstream consumers drop; the concern would be a consumer that holds the track open indefinitely against a publisher that never FINs.

## Public API changes

None. The change is entirely within `moq_net`'s private `lite::subscriber` module; no `pub` signatures change.

## Test plan

- Added `json_stream_ends_cleanly_when_broadcast_finishes` in `moq-ffi` (real loopback server + client): finish a track, then the broadcast, and assert the consumer sees a clean end of stream. **Fails without the fix** (`expected a clean end of stream, got Err(JsonTrack(Net(Cancel)))`), passes with it.
- `cargo test -p moq-net -p moq-ffi` — green (moq-net 387, moq-ffi 30).
- `cargo test --workspace` — green, 0 failures across all crates.
- `cargo clippy -p moq-net --all-targets -- -D warnings` and `cargo fmt --all --check` — clean. (Pre-existing clippy errors in `moq-native` under Rust 1.96 are unrelated and present on `main`.)

(Written by Claude Opus 4.8)