### PR TITLE
fix(test): update js-native smoke client to the renamed frame payload field

### DIFF
--- a/test/smoke/clients/js-native/subscribe.ts
+++ b/test/smoke/clients/js-native/subscribe.ts
@@ -88,7 +88,7 @@ async function run(): Promise<void> {
 			for (;;) {
 				const frame = await group.readFrame();
 				if (!frame) break;
-				total += frame.data.byteLength;
+				total += frame.payload.byteLength;
 				if (total > 0) {
 					// The harness judges success by this marker, not the exit code: the
 					// @moq/web-transport NAPI addon can segfault during the runtime's exit


### PR DESCRIPTION
## Summary

`#2337` (refactor(js/net)!: close three js/net gaps vs rs/moq-net) renamed the consumed-frame field from `data` to `payload` across js/net and js/hang, but missed `test/smoke/clients/js-native/subscribe.ts`. It still reads `frame.data.byteLength`, which is `undefined` at runtime.

Consequence: every `js-native-node` and `js-native-bun` subscriber cell in the full smoke matrix throws `Cannot read properties of undefined (reading 'byteLength')` / `undefined is not an object (evaluating 'frame.data.byteLength')`, so **Smoke fails on every PR targeting `dev`** (e.g. #2344). The rust/python/js/c/gst cells are unaffected.

Root cause: a Cross-Package Sync miss. `#2337` updated the library and its tests but not this one out-of-tree smoke consumer. Confirmed it is the only remaining `.data` reader: `git grep '\.data\.byteLength' test/smoke/` returns just this line.

The fix matches js/net's own API: `js/net/src/group.ts:23` declares `payload: Uint8Array` and `readFrame()` (group.ts:256) returns `{ sequence, payload, timestamp }`; there is no `.data` field.

## Test plan

- One-line field rename, `frame.data` -> `frame.payload`, matching the `readFrame()?.payload.byteLength` pattern used throughout `js/net/src/group.test.ts`.
- Full verification is the Smoke workflow itself: the `* -> js-native-node` / `* -> js-native-bun` cells should go green.

(Written by Claude Opus 4.8)