### PR TITLE
fix(net): log a non-empty error reason on Safari WebTransport failures

### DIFF
--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -3,7 +3,7 @@ import type * as broadcast from "../broadcast.ts";
 import type * as group from "../group.ts";
 import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
-import { error } from "../util/error.ts";
+import { error, reason } from "../util/error.ts";
 import type { Session } from "./adapter.ts";
 import { Frame, Group as GroupMessage } from "./object.ts";
 import { PublishDone } from "./publish.ts";
@@ -108,7 +108,7 @@ export class Publisher {
 			}
 		} catch (err: unknown) {
 			const e = error(err);
-			console.warn(`announce failed: broadcast=${path} error=${e.message}`);
+			console.warn(`announce failed: broadcast=${path} error=${reason(e)}`);
 		} finally {
 			broadcast.close();
 			this.#broadcasts.delete(path);
@@ -196,7 +196,7 @@ export class Publisher {
 			stream.close();
 		} catch (err: unknown) {
 			const e = error(err);
-			console.warn(`publish error: broadcast=${name} track=${track.name} error=${e.message}`);
+			console.warn(`publish error: broadcast=${name} track=${track.name} error=${reason(e)}`);
 			stream.abort(e);
 		} finally {
 			track.close();
@@ -306,7 +306,7 @@ export class Publisher {
 			stream.close();
 		} catch (err: unknown) {
 			const e = error(err);
-			console.debug(`subscribe_namespace stream error: ${e.message}`);
+			console.debug(`subscribe_namespace stream error: ${reason(e)}`);
 			stream.abort(e);
 		}
 	}

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -6,7 +6,7 @@ import * as Path from "../path.ts";
 import type { Reader, Stream } from "../stream.ts";
 import { Timestamp } from "../time.ts";
 import type * as track from "../track.ts";
-import { error } from "../util/error.ts";
+import { error, reason } from "../util/error.ts";
 import { withTimeout } from "../util/timeout.ts";
 import type { Session } from "./adapter.ts";
 import { TrackAliases } from "./aliases.ts";
@@ -196,7 +196,7 @@ export class Subscriber {
 			}
 		} catch (err: unknown) {
 			const e = error(err);
-			console.warn(`subscribe_namespace error: ${e.message}`);
+			console.warn(`subscribe_namespace error: ${reason(e)}`);
 		}
 	}
 
@@ -265,7 +265,7 @@ export class Subscriber {
 			const e = error(err);
 			producer.close(e);
 			console.warn(
-				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.name} error=${e.message}`,
+				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.name} error=${reason(e)}`,
 			);
 			// If setup eventually settles after the timeout, abort the stream
 			// and drop any registration so we don't leak. Cover both branches:
@@ -302,7 +302,7 @@ export class Subscriber {
 			producer.close(e);
 			stream.abort(e);
 			console.warn(
-				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.name} error=${e.message}`,
+				`subscribe error: id=${requestId} broadcast=${broadcast} track=${request.name} error=${reason(e)}`,
 			);
 		} finally {
 			this.#aliases.delete(trackAlias, producer);

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -5,7 +5,7 @@ import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
 import { Timescale } from "../time.ts";
 import type * as track from "../track.ts";
-import { error } from "../util/error.ts";
+import { error, reason } from "../util/error.ts";
 import { AnnounceInit, AnnounceOk, type AnnounceRequest, encodeAnnounceBroadcast } from "./announce.ts";
 import { Datagram as DatagramMessage } from "./datagram.ts";
 import * as DatagramStream from "./datagram_stream.ts";
@@ -308,7 +308,7 @@ export class Publisher {
 			await datagrams;
 		} catch (err: unknown) {
 			const e = error(err);
-			console.warn(`publish error: broadcast=${msg.broadcast} track=${track.name} error=${e.message}`);
+			console.warn(`publish error: broadcast=${msg.broadcast} track=${track.name} error=${reason(e)}`);
 			track.close(e);
 			stream.abort(e);
 			await datagrams;
@@ -345,7 +345,7 @@ export class Publisher {
 		} catch (err: unknown) {
 			const e = error(err);
 			console.warn(
-				`fetch error: broadcast=${msg.broadcast} track=${msg.track} group=${msg.group} error=${e.message}`,
+				`fetch error: broadcast=${msg.broadcast} track=${msg.track} group=${msg.group} error=${reason(e)}`,
 			);
 			group?.close(e);
 			stream.abort(e);
@@ -399,7 +399,7 @@ export class Publisher {
 			stream.close();
 		} catch (err: unknown) {
 			const e = error(err);
-			console.warn(`publish error: broadcast=${broadcast} track=${track.name} error=${e.message}`);
+			console.warn(`publish error: broadcast=${broadcast} track=${track.name} error=${reason(e)}`);
 			track.close(e);
 			stream.reset(e);
 		}
@@ -488,7 +488,7 @@ export class Publisher {
 			}
 		} catch (err: unknown) {
 			// Best-effort: a datagram send failure stops sending but never fails the subscription.
-			console.debug(`datagram send stopped: sub=${sub} error=${error(err).message}`);
+			console.debug(`datagram send stopped: sub=${sub} error=${reason(err)}`);
 		}
 	}
 

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -8,7 +8,7 @@ import * as Path from "../path.ts";
 import { type Reader, Stream } from "../stream.ts";
 import * as Time from "../time.ts";
 import type * as track from "../track.ts";
-import { error } from "../util/error.ts";
+import { error, reason } from "../util/error.ts";
 import { withTimeout } from "../util/timeout.ts";
 import { AnnounceInit, AnnounceOk, AnnounceRequest, decodeAnnounceBroadcastMaybe } from "./announce.ts";
 import { Datagram as DatagramMessage } from "./datagram.ts";
@@ -330,7 +330,7 @@ export class Subscriber {
 			const e = error(err);
 			request.reject(e);
 			this.#subscribes.delete(id);
-			console.warn(`subscribe error: id=${id} broadcast=${broadcast} track=${request.name} error=${e.message}`);
+			console.warn(`subscribe error: id=${id} broadcast=${broadcast} track=${request.name} error=${reason(e)}`);
 			// If the stream eventually opens after the timeout, abort it so we
 			// don't leak it. Cover both branches: setup may resolve late, or it
 			// may reject (e.g. encode/decode failure) after the stream is open.
@@ -369,7 +369,7 @@ export class Subscriber {
 		} catch (err) {
 			const e = error(err);
 			producer.close(e);
-			console.warn(`subscribe error: id=${id} broadcast=${broadcast} track=${request.name} error=${e.message}`);
+			console.warn(`subscribe error: id=${id} broadcast=${broadcast} track=${request.name} error=${reason(e)}`);
 			stream.abort(e);
 		} finally {
 			this.#subscribes.delete(id);
@@ -707,7 +707,7 @@ export class Subscriber {
 					try {
 						await this.#routeDatagram(value);
 					} catch (err: unknown) {
-						console.debug(`dropping datagram: ${error(err).message}`);
+						console.debug(`dropping datagram: ${reason(err)}`);
 					}
 				}
 			} finally {

--- a/js/net/src/util/error.test.ts
+++ b/js/net/src/util/error.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { reason } from "./error.ts";
+
+test("reason: plain Error keeps its message", () => {
+	expect(reason(new Error("boom"))).toBe("boom");
+});
+
+test("reason: non-Error value is stringified", () => {
+	expect(reason("nope")).toBe("nope");
+});
+
+test("reason: empty message falls back to the type name", () => {
+	// Safari's WebTransportError.message is always blank; the reason must never be empty.
+	expect(reason(new Error(""))).toBe("Error");
+});
+
+// Minimal stand-in for the DOM WebTransportError, which the test runtime may not define.
+class FakeWebTransportError extends Error {
+	readonly source: string;
+	readonly streamErrorCode: number | null;
+
+	constructor(source: string, streamErrorCode: number | null, message = "") {
+		super(message);
+		this.name = "WebTransportError";
+		this.source = source;
+		this.streamErrorCode = streamErrorCode;
+	}
+}
+
+const globals = globalThis as { WebTransportError?: unknown };
+let originalWebTransportError: unknown;
+
+beforeEach(() => {
+	// Force `instanceof WebTransportError` in reason() to match our stand-in.
+	originalWebTransportError = globals.WebTransportError;
+	globals.WebTransportError = FakeWebTransportError;
+});
+
+afterEach(() => {
+	globals.WebTransportError = originalWebTransportError;
+});
+
+test("reason: WebTransportError with a blank message surfaces source and code", () => {
+	// The Safari case from the bug report: a RESET_STREAM with no message.
+	expect(reason(new FakeWebTransportError("stream", 0))).toBe("WebTransportError: source=stream code=0");
+});
+
+test("reason: WebTransportError omits a null stream error code", () => {
+	expect(reason(new FakeWebTransportError("session", null))).toBe("WebTransportError: source=session");
+});
+
+test("reason: WebTransportError keeps a populated message and appends details", () => {
+	expect(reason(new FakeWebTransportError("stream", 42, "Received RESET_STREAM."))).toBe(
+		"Received RESET_STREAM. (source=stream code=42)",
+	);
+});

--- a/js/net/src/util/error.ts
+++ b/js/net/src/util/error.ts
@@ -3,6 +3,29 @@ export function error(err: unknown): Error {
 	return err instanceof Error ? err : new Error(String(err));
 }
 
+/**
+ * Format an error into a non-empty, human-readable string for logging.
+ *
+ * Safari always leaves `WebTransportError.message` blank, so a bare `err.message`
+ * degrades to an empty string and the reason is lost. This falls back to the error
+ * type name and appends the WebTransport `source` and application `streamErrorCode`
+ * (the code that identifies a RESET_STREAM), so the log line always says something.
+ */
+export function reason(err: unknown): string {
+	const e = error(err);
+
+	// WebTransportError carries the failure origin and the peer's application error code,
+	// often the only identifying detail since WebKit leaves `message` empty.
+	if (typeof WebTransportError !== "undefined" && e instanceof WebTransportError) {
+		const parts = [`source=${e.source}`];
+		if (e.streamErrorCode !== null) parts.push(`code=${e.streamErrorCode}`);
+		const detail = parts.join(" ");
+		return e.message ? `${e.message} (${detail})` : `WebTransportError: ${detail}`;
+	}
+
+	return e.message || e.name || "unknown error";
+}
+
 export function unreachable(value: never): never {
 	throw new Error(`unreachable: ${value}`);
 }


### PR DESCRIPTION
Fixes #2358.

## Root cause

Safari's `WebTransportError.message` is always an empty string (WebKit never populates it). Every error-logging site in `@moq/net` interpolated only `e.message`, so a subscribe/publish failure on Safari degraded to `error=` with nothing after it. The identical event on Chrome (`Received RESET_STREAM.`) and Firefox (`RESET_STREAM: 0`) printed a usable reason. The identifying detail on Safari lives in the `source` and `streamErrorCode` fields (the application error code), which were never logged.

## Fix

Rather than patch only the two sites named in the issue, fix the shared cause once and apply it everywhere the same bug lurks:

- **`js/net/src/util/error.ts`** — new `reason(err)` helper. Falls back to the error's type name when `message` is blank, and for a `WebTransportError` appends `source=…` and (when present) `code=…`, so the line is never empty. Safari's RESET_STREAM now logs `error=WebTransportError: source=stream code=0`.
- Replaced `error=${e.message}` with `error=${reason(e)}` at all 13 logging sites across `lite/subscriber.ts`, `lite/publisher.ts`, `ietf/subscriber.ts`, and `ietf/publisher.ts` (subscribe, publish, fetch, announce, datagram, subscribe_namespace).
- **`js/net/src/util/error.test.ts`** — regression test covering the blank-message Safari case, a null error code, and a populated message.

`reason` is internal to the net util (not a public export), and this is a Safari-specific logging quirk with no wire or Rust counterpart, so no Cross-Package Sync rows apply.

## Verification

- `just js check` — clean typecheck + Biome across the workspace.
- `bun test js/net/src` — 265 pass (6 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)