### PR TITLE
refactor(moq-net)!: model Timestamp as an instant; drop panicking arithmetic operators

### DIFF
--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -89,7 +89,7 @@ Negotiation: `version::NEGOTIATED` lists SETUP-negotiated versions in preference
 ## Invariants and footguns
 
 - **No cascading abort**: Broadcast/Track/Group/Frame closes stay independent so handles can be shared. Closing or aborting one layer must not tear down its parent or siblings.
-- **`moq_net::Timestamp` scales**: the inherent `max`/`checked_add`/`checked_sub` panic or error on mismatched scales (`Ord::cmp` is safe), and `ZERO` is second-scale. Don't seed a `.max()` accumulator with `ZERO`; use an `Option` instead. A panic in a spawned task can hang a `finished().await` forever, so this once cost a 60-minute CI hang.
+- **`moq_net::Timestamp` scales**: it's an instant, not a scalar, so it has no `+`/`-` operators. `checked_add`/`checked_sub` require matching scales and return `Err` (never panic) otherwise; `.convert()` to align scales first. `Ord::cmp` is scale-aware and safe, but `Eq`/`Hash` are structural (`from_secs(1) != from_millis(1000)`). `ZERO` is second-scale, so don't seed a `.max()` accumulator with it (a finer-scale value loses the tie-break); use an `Option` instead.
 
 ## Rust conventions
 

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -775,7 +775,9 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			}
 
 			if let (Some(min), Some(max), Some(min_duration)) = (min_timestamp, max_timestamp, track.min_duration) {
-				let jitter = max - min + min_duration;
+				// All three share the track timescale (min/max are this fragment's frame
+				// timestamps, min_duration is derived from them).
+				let jitter = max.checked_sub(min)?.checked_add(min_duration)?;
 
 				if track.jitter.is_none_or(|j| jitter < j) {
 					track.jitter = Some(jitter);

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -1164,7 +1164,7 @@ impl<E: CatalogExt> AacStream<E> {
 					let advance = Timestamp::from_scale(index * 1024, header.sample_rate as u64)?;
 					// `base` is a 90 kHz PTS; rescale the sample-rate advance to match
 					// before adding (the scale-aware Timestamp rejects mixed scales).
-					Some(base + advance.convert(base.scale())?)
+					Some(base.checked_add(advance.convert(base.scale())?)?)
 				}
 				other => other,
 			};
@@ -1266,7 +1266,7 @@ impl<E: CatalogExt> OpusStream<E> {
 					let advance = Timestamp::from_scale(elapsed, 48_000)?;
 					// `base` is a 90 kHz PTS; rescale the sample advance to match before
 					// adding (the scale-aware Timestamp rejects mixed scales).
-					Some(base + advance.convert(base.scale())?)
+					Some(base.checked_add(advance.convert(base.scale())?)?)
 				}
 				other => other,
 			};
@@ -1445,7 +1445,7 @@ impl<E: CatalogExt> LegacyStream<E> {
 				// before adding (the scale-aware Timestamp rejects mixed scales).
 				Some(pts) => {
 					let advance = Timestamp::from_scale(header.samples, header.sample_rate as u64)?;
-					Some(pts + advance.convert(pts.scale())?)
+					Some(pts.checked_add(advance.convert(pts.scale())?)?)
 				}
 				None => None,
 			};

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -41,7 +41,7 @@ use moq_net::{Timescale, Timestamp};
 
 /// The default [`granularity`](Producer::with_granularity): at most one record per second of
 /// media time.
-pub const DEFAULT_GRANULARITY: Timestamp = Timestamp::from_secs_unchecked(1);
+pub const DEFAULT_GRANULARITY: Timestamp = Timestamp::new_const(1, Timescale::SECOND);
 
 /// Owns one media track's timeline: its catalog [`section`](Self::section) and wall anchor, and the
 /// `Recorder` its group opens are recorded through.

--- a/rs/moq-net/src/model/time.rs
+++ b/rs/moq-net/src/model/time.rs
@@ -124,6 +124,28 @@ impl std::fmt::Display for Timescale {
 /// The scale is a [`Timescale`] (always non-zero), so unit conversions (`as_secs`, `as_millis`,
 /// etc.) are infallible. Use [`Option<Timestamp>`] at call sites that need a "missing" sentinel
 /// instead of relying on a magic value.
+///
+/// # An instant, not a number
+///
+/// A `Timestamp` is a point in time (like [`std::time::Instant`]), not a scalar, so it has no
+/// arithmetic operators: adding two instants is meaningless, and a scale mismatch can't be a
+/// silent panic. Use [`Self::checked_add`] / [`Self::checked_sub`], which **require both
+/// operands to share a scale** and return [`TimeOverflow`] otherwise. To combine timestamps
+/// from different scales, [`Self::convert`] one to the other's scale first.
+///
+/// # Equality vs ordering
+///
+/// These two intentionally disagree, so pick the one you mean:
+///
+/// - [`Eq`] / [`Hash`] are **structural** (field-wise): `from_secs(1) != from_millis(1000)`,
+///   because they encode as different `(value, scale)` pairs on the wire. Two timestamps are
+///   equal only when both their value and scale match.
+/// - [`Ord`] is **temporal**: it cross-multiplies scales, so `from_millis(1000)` orders after
+///   `from_millis(999)` and `from_secs(1)` slots in between. When a cross-scale comparison is
+///   otherwise a tie, it breaks by `(scale, value)` to stay consistent with `Eq`.
+///
+/// So `from_secs(1).cmp(&from_millis(1000))` is *not* `Equal`, and neither is `==` true. If you
+/// want "same instant regardless of encoding", compare after a [`Self::convert`] to a common scale.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Timestamp {
 	value: VarInt,
@@ -131,8 +153,14 @@ pub struct Timestamp {
 }
 
 impl Timestamp {
-	/// The zero timestamp (0 at [`Timescale::SECOND`]); compares equal to zero at any scale.
-	pub const ZERO: Self = Self::from_secs_unchecked(0);
+	/// The zero timestamp: value `0` at [`Timescale::SECOND`].
+	///
+	/// The scale is not incidental. Equality and ordering are scale-aware (see the type
+	/// docs), so this is *not* interchangeable with `0` at another scale; use
+	/// [`Self::is_zero`] to test a zero value regardless of scale. In particular, don't
+	/// seed a `.max()` accumulator with this: a later value at a finer scale would lose
+	/// the tie-break. Reach for `Option<Timestamp>` instead.
+	pub const ZERO: Self = Self::new_const(0, Timescale::SECOND);
 
 	/// Construct a timestamp directly from a raw value at the given scale.
 	/// Returns [`TimeOverflow`] if `value` exceeds `2^62 - 1`.
@@ -140,6 +168,19 @@ impl Timestamp {
 		match VarInt::from_u64(value) {
 			Some(value) => Ok(Self { value, scale }),
 			None => Err(TimeOverflow),
+		}
+	}
+
+	/// Const-context twin of [`Self::new`] that panics on overflow.
+	///
+	/// For building `const` timestamps where `?`/`unwrap` on the [`Result`] isn't
+	/// available. The panic fires only on a compile-time-known out-of-range literal, so
+	/// it's a build-time assertion, not a runtime failure path. Use [`Self::new`]
+	/// everywhere else.
+	pub const fn new_const(value: u64, scale: Timescale) -> Self {
+		match Self::new(value, scale) {
+			Ok(time) => time,
+			Err(_) => panic!("timestamp value exceeds 2^62 - 1"),
 		}
 	}
 
@@ -154,25 +195,9 @@ impl Timestamp {
 		Self::new(seconds, Timescale::SECOND)
 	}
 
-	/// Like [`Self::from_secs`] but panics on overflow.
-	pub const fn from_secs_unchecked(seconds: u64) -> Self {
-		match Self::from_secs(seconds) {
-			Ok(time) => time,
-			Err(_) => panic!("time overflow"),
-		}
-	}
-
 	/// Convert a number of milliseconds to a timestamp at [`Timescale::MILLI`].
 	pub const fn from_millis(millis: u64) -> Result<Self, TimeOverflow> {
 		Self::new(millis, Timescale::MILLI)
-	}
-
-	/// Like [`Self::from_millis`] but panics on overflow.
-	pub const fn from_millis_unchecked(millis: u64) -> Self {
-		match Self::from_millis(millis) {
-			Ok(time) => time,
-			Err(_) => panic!("time overflow"),
-		}
 	}
 
 	/// Convert a number of microseconds to a timestamp at [`Timescale::MICRO`].
@@ -180,25 +205,9 @@ impl Timestamp {
 		Self::new(micros, Timescale::MICRO)
 	}
 
-	/// Like [`Self::from_micros`] but panics on overflow.
-	pub const fn from_micros_unchecked(micros: u64) -> Self {
-		match Self::from_micros(micros) {
-			Ok(time) => time,
-			Err(_) => panic!("time overflow"),
-		}
-	}
-
 	/// Convert a number of nanoseconds to a timestamp at [`Timescale::NANO`].
 	pub const fn from_nanos(nanos: u64) -> Result<Self, TimeOverflow> {
 		Self::new(nanos, Timescale::NANO)
-	}
-
-	/// Like [`Self::from_nanos`] but panics on overflow.
-	pub const fn from_nanos_unchecked(nanos: u64) -> Self {
-		match Self::from_nanos(nanos) {
-			Ok(time) => time,
-			Err(_) => panic!("time overflow"),
-		}
 	}
 
 	/// The raw value in the timestamp's own scale.
@@ -343,14 +352,13 @@ impl PartialOrd for Timestamp {
 }
 
 impl Ord for Timestamp {
-	/// Compare two timestamps, normalizing across scales when they differ.
+	/// Temporal comparison, normalizing across scales (see the type-level docs for how
+	/// this relates to structural `Eq`).
 	///
-	/// - If both scales are equal, compares raw values directly.
+	/// - Equal scales compare raw values directly.
 	/// - Otherwise cross-multiplies in 128-bit so e.g. `1s > 2ms` orders correctly.
-	///
-	/// When the cross-scale comparison would otherwise be `Equal` (e.g. `from_secs(1)`
-	/// vs `from_millis(1000)`), breaks ties by `(scale, value)` so the result agrees
-	/// with derived `PartialEq`/`Eq`/`Hash` (which are field-wise).
+	/// - A would-be cross-scale tie (e.g. `from_secs(1)` vs `from_millis(1000)`) breaks by
+	///   `(scale, value)`, keeping `Ord` consistent with the field-wise `Eq`/`Hash`.
 	fn cmp(&self, other: &Self) -> std::cmp::Ordering {
 		if self.scale.0.get() == other.scale.0.get() {
 			return self.value.cmp(&other.value);
@@ -360,34 +368,6 @@ impl Ord for Timestamp {
 		lhs.cmp(&rhs)
 			.then_with(|| self.scale.0.get().cmp(&other.scale.0.get()))
 			.then_with(|| self.value.cmp(&other.value))
-	}
-}
-
-impl std::ops::Add for Timestamp {
-	type Output = Self;
-
-	fn add(self, rhs: Self) -> Self {
-		self.checked_add(rhs).expect("time overflow or scale mismatch")
-	}
-}
-
-impl std::ops::AddAssign for Timestamp {
-	fn add_assign(&mut self, rhs: Self) {
-		*self = *self + rhs;
-	}
-}
-
-impl std::ops::Sub for Timestamp {
-	type Output = Self;
-
-	fn sub(self, rhs: Self) -> Self {
-		self.checked_sub(rhs).expect("time overflow or scale mismatch")
-	}
-}
-
-impl std::ops::SubAssign for Timestamp {
-	fn sub_assign(&mut self, rhs: Self) {
-		*self = *self - rhs;
 	}
 }
 
@@ -587,6 +567,23 @@ mod tests {
 		let a = Timestamp::from_millis(1000).unwrap();
 		let b = Timestamp::from_micros(1000).unwrap();
 		assert!(a.checked_add(b).is_err());
+	}
+
+	#[test]
+	fn test_new_const_matches_fallible() {
+		const C: Timestamp = Timestamp::new_const(42, Timescale::MICRO);
+		assert_eq!(C, Timestamp::new(42, Timescale::MICRO).unwrap());
+	}
+
+	#[test]
+	fn test_zero_is_scale_aware() {
+		// ZERO is second-scale. is_zero() sees the value regardless of scale, but
+		// equality is structural, so it's not interchangeable with 0 at another scale.
+		assert!(Timestamp::ZERO.is_zero());
+		let zero_ms = Timestamp::from_millis(0).unwrap();
+		assert!(zero_ms.is_zero());
+		assert_ne!(Timestamp::ZERO, zero_ms);
+		assert_ne!(Timestamp::ZERO.cmp(&zero_ms), std::cmp::Ordering::Equal);
 	}
 
 	#[test]

--- a/rs/moq-srt/src/server.rs
+++ b/rs/moq-srt/src/server.rs
@@ -410,8 +410,13 @@ fn pace(anchor: Instant, base: moq_net::Timestamp, ts: moq_net::Timestamp, now: 
 	let send_at = match ts.checked_sub(base) {
 		Ok(offset) => anchor + Duration::from(offset),
 		// A reordered B-frame can carry a PTS before the anchor: pace it at that earlier
-		// instant instead of collapsing it onto the anchor.
-		Err(_) => anchor.checked_sub(Duration::from(base - ts)).unwrap_or(anchor),
+		// instant instead of collapsing it onto the anchor. `ts.checked_sub(base)` failed,
+		// so `base >= ts` (same scale); fall back to the anchor if it can't be expressed.
+		Err(_) => base
+			.checked_sub(ts)
+			.ok()
+			.and_then(|behind| anchor.checked_sub(Duration::from(behind)))
+			.unwrap_or(anchor),
 	};
 	if send_at > now {
 		// Media outran wall-clock: re-anchor so this newest frame is the live edge.


### PR DESCRIPTION
Fourth in the #2314 stack: the **Timestamp** section. Independent of the earlier three (all merged), so this targets `dev` directly.

## Summary

A `Timestamp` is a point in time carrying a scale, like `std::time::Instant` — not a scalar. Its `Add`/`Sub`/`AddAssign`/`SubAssign` operators panicked on a scale mismatch (and on overflow), the footgun `rs/CLAUDE.md` already flagged as having cost a 60-minute CI hang. This models it as an instant instead.

- **Drop the four operator impls.** Arithmetic goes through `checked_add`/`checked_sub`, which **require both operands to share a scale** and return `Err` (never panic) otherwise; callers `convert()` to align scales first. `ts + ts` no longer compiles, which is correct — summing two absolute instants is meaningless.
- **Collapse `from_*_unchecked` → one `new_const(value, scale)`.** The `_unchecked` suffix implied UB (Rust convention: `get_unchecked`); these are const-context builders that panic only on a compile-time-known bad literal. Only `from_secs_unchecked` had any caller, so the four unit variants collapse into one honest `new_const`.
- **Document the `Eq`-vs-`Ord` split on the type**, not just on `cmp`: `Eq`/`Hash` are structural (`from_secs(1) != from_millis(1000)`, since they encode as different `(value, scale)` pairs on the wire), `Ord` is temporal.

## Why not the `Duration` model

The earlier design discussion weighed a scale-free `std::time::Duration` delta (`ts - ts -> Duration`, `ts + Duration -> ts`). We landed on the simpler shape — checked methods that *enforce* a matching scale rather than erase it — because it keeps same-scale arithmetic tick-exact (media timescales like 90 kHz round through nanos), makes cross-scale mixing an explicit `.convert()`, and adds no new type. A scale-carrying `Delta` type buys nothing (same mismatch problem); a const-generic `Timestamp<SCALE>` can't work because the scale is runtime data off the wire and moq-net is deliberately media-agnostic.

## The operator removal caught real bugs-in-waiting

My pre-change grep estimated *zero* production callers; the compiler found **five**, all relying on the panic path after a `.convert()`:
- `moq-mux` `fmp4/import.rs` (jitter calc), `ts/import.rs` (×3, PTS advance) — now `checked_add`/`checked_sub` with `?`.
- `moq-srt` `server.rs` (B-frame pacing) — now graceful checked arithmetic that also covers a scale mismatch, preserving the existing `unwrap_or(anchor)` fallback.

Each was a latent panic; they're now explicit fallible arithmetic.

## Public API changes

**Breaking** (hence `dev`):
- Removed `impl Add/Sub/AddAssign/SubAssign for Timestamp`.
- Removed `Timestamp::from_secs_unchecked` / `from_millis_unchecked` / `from_micros_unchecked` / `from_nanos_unchecked`.
- Added `Timestamp::new_const(value, scale)`.

**Non-breaking:** doc-only on the `Timestamp` type, `cmp`, `ZERO`; `rs/CLAUDE.md` footgun note updated.

## Cross-Package Sync

- No wire change (model-layer arithmetic/construction only), so no draft update.
- `js/net` has no equivalent operator surface (its `Timestamp` is a branded number); nothing to mirror.
- No FFI/WASM exposure of these operators/constructors, so `libmoq`/py/swift/kt/go are untouched.

## Test plan

- `cargo check --workspace --all-targets`: clean.
- `cargo test -p moq-net`: **490 passed** (488 + 2 new: `new_const` round-trip, `ZERO` scale-awareness). `moq-mux`/`moq-srt` green.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moq-net`: exit 0 (new intra-doc links validated).
- `nix develop --command just rs fix`: clean.
- The `Eq`/`Ord` contract and scale-mismatch→`Err` are pinned by existing `test_ordering_across_known_scales` and `test_add_mismatched_scale`.

(Written by Claude Opus 4.8)