### PR TITLE
refactor(moq-net)!: rename Error::CacheFull to Lagged; document the App/Remote asymmetry

### DIFF
--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -1,6 +1,6 @@
 import { expect, setSystemTime, test } from "bun:test";
 import { Consumer as BroadcastConsumer, Producer as BroadcastProducer } from "./broadcast.ts";
-import { CacheFull, MAX_GROUP_FRAMES } from "./group.ts";
+import { Lagged, MAX_GROUP_FRAMES } from "./group.ts";
 import { Timestamp } from "./time.ts";
 import type { Request as TrackRequest } from "./track.ts";
 import { Producer as TrackProducer } from "./track.ts";
@@ -156,7 +156,7 @@ test("a late subscriber replays the cached window", async () => {
 	expect(await late.readString()).toBe("later");
 });
 
-test("a read throws CacheFull on a gap, then resyncs to the next group", async () => {
+test("a read throws Lagged on a gap, then resyncs to the next group", async () => {
 	const broadcast = new BroadcastProducer();
 	const producer = broadcast.createTrack("video");
 	const sub = broadcast.track("video").subscribe();
@@ -174,7 +174,7 @@ test("a read throws CacheFull on a gap, then resyncs to the next group", async (
 
 	// The reader hits the gap in group 0 (error, not a silent skip), then the next
 	// read resyncs from group 1.
-	expect(sub.readFrame()).rejects.toBeInstanceOf(CacheFull);
+	expect(sub.readFrame()).rejects.toBeInstanceOf(Lagged);
 	expect(await sub.readString()).toBe("ok");
 });
 

--- a/js/net/src/group.test.ts
+++ b/js/net/src/group.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { CacheFull, MAX_GROUP_CACHE_BYTES, MAX_GROUP_FRAMES, Producer } from "./group.ts";
+import { Lagged, MAX_GROUP_CACHE_BYTES, MAX_GROUP_FRAMES, Producer } from "./group.ts";
 import { Timestamp } from "./time.ts";
 
 const dec = new TextDecoder();
@@ -55,7 +55,7 @@ test("a caught-up reader does not trip the byte cache cap", async () => {
 	}
 });
 
-test("reading a group whose frames were evicted throws CacheFull", async () => {
+test("reading a group whose frames were evicted throws Lagged", async () => {
 	const { producer, consumer } = pair(0);
 
 	// Overflow the frame cap without reading, so the front frames are evicted.
@@ -64,7 +64,7 @@ test("reading a group whose frames were evicted throws CacheFull", async () => {
 	}
 
 	// The reader fell behind the eviction window: it must error, not skip the gap.
-	expect(consumer.readFrame()).rejects.toBeInstanceOf(CacheFull);
+	expect(consumer.readFrame()).rejects.toBeInstanceOf(Lagged);
 });
 
 test("a group with no eviction reads every frame without error", async () => {

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -38,10 +38,10 @@ export interface Info {
  * Thrown by a frame read when the reader fell behind the group's eviction window: frames
  * it had not yet read were dropped to stay under the cache cap, so the stream has a gap.
  */
-export class CacheFull extends Error {
+export class Lagged extends Error {
 	constructor() {
-		super("group cache full: frames were evicted before being read");
-		this.name = "CacheFull";
+		super("lagged: frames were evicted before being read");
+		this.name = "Lagged";
 	}
 }
 
@@ -53,7 +53,7 @@ class GroupState {
 	total = new Signal<number>(0); // The total number of frames in the group thus far
 
 	// Frames evicted from the front by the cache cap. A reader that had not consumed
-	// them has a gap, so its next read throws CacheFull rather than skipping silently.
+	// them has a gap, so its next read throws Lagged rather than skipping silently.
 	offset = 0;
 	cacheBytes = 0;
 
@@ -271,7 +271,7 @@ export class Consumer {
 	 */
 	async readFrame(): Promise<Frame | undefined> {
 		for (;;) {
-			if (this.#state.offset > 0) throw new CacheFull();
+			if (this.#state.offset > 0) throw new Lagged();
 
 			const read = this.#readBufferedFrame();
 			if (read) return read.frame;
@@ -290,7 +290,7 @@ export class Consumer {
 	 */
 	async readFrameSequence(): Promise<({ sequence: number } & Frame) | undefined> {
 		for (;;) {
-			if (this.#state.offset > 0) throw new CacheFull();
+			if (this.#state.offset > 0) throw new Lagged();
 
 			const read = this.#readBufferedFrame();
 			if (read) return { sequence: read.sequence, payload: read.frame.payload, timestamp: read.frame.timestamp };

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -5,7 +5,7 @@
  */
 import { type GetPromise, type Getter, Once, Signal } from "@moq/signals";
 import type { Datagram } from "./datagram.ts";
-import { CacheFull, type Frame, type Consumer as GroupConsumer, Producer as GroupProducer } from "./group.ts";
+import { type Frame, type Consumer as GroupConsumer, Producer as GroupProducer, Lagged } from "./group.ts";
 import { hooks } from "./internal.ts";
 import { Timescale, type Timestamp } from "./time.ts";
 
@@ -647,7 +647,7 @@ export class Subscriber {
 					// The reader fell behind this group's eviction window. Drop it and
 					// signal the gap; the next read resyncs from the following group.
 					groups.shift()?.close();
-					throw new CacheFull();
+					throw new Lagged();
 				}
 				const next = groups[0].tryReadFrameSequence();
 				if (next) {
@@ -674,7 +674,7 @@ export class Subscriber {
 				// Fell behind this group's eviction window. Drop it and signal the gap;
 				// the next read resyncs from the following group.
 				groups.shift()?.close();
-				throw new CacheFull();
+				throw new Lagged();
 			}
 			const next = group.tryReadFrameSequence();
 			if (next)

--- a/rs/moq-net/src/error.rs
+++ b/rs/moq-net/src/error.rs
@@ -10,7 +10,10 @@ pub enum Error {
 	#[error(transparent)]
 	Decode(#[from] coding::DecodeError),
 
-	// TODO move to a ConnectError
+	/// Version negotiation failed, or the negotiated version lacks a requested feature
+	/// (e.g. a FETCH against a version without fetch support). Mostly a connect-time
+	/// error, but the feature-gap case can surface mid-session, so it can't simply move
+	/// to a connect-only error type.
 	#[error("unsupported versions")]
 	Version,
 
@@ -42,7 +45,13 @@ pub enum Error {
 	#[error("old")]
 	Old,
 
-	// The application closes the stream with a code.
+	/// An application-chosen close code. Bounded to `u16` and offset past the library's
+	/// reserved range (`+ 64`) on the wire by [`Self::to_code`], so app codes never
+	/// collide with protocol ones.
+	///
+	/// The width asymmetry with [`Self::Remote`] is deliberate: `App` is a code *this*
+	/// side chooses to send, while `Remote` carries a raw code *received* off the wire
+	/// that didn't map to a known variant, which can be any `u32`.
 	#[error("app code={0}")]
 	App(u16),
 
@@ -78,6 +87,8 @@ pub enum Error {
 	#[error("invalid role")]
 	InvalidRole,
 
+	/// The peer offered an ALPN this endpoint doesn't recognize, so no version could be
+	/// negotiated. A connect-time error.
 	#[error("unknown ALPN: {0}")]
 	UnknownAlpn(String),
 
@@ -87,9 +98,12 @@ pub enum Error {
 	#[error("closed")]
 	Closed,
 
-	/// The cached frame has been evicted due to the group size limit.
-	#[error("cache full")]
-	CacheFull,
+	/// The reader fell behind the group's byte budget: the frame it wanted was dropped
+	/// to keep the group under its size limit. Named from the consumer's side (nothing is
+	/// "full"); distinct from [`Self::Evicted`], which drops a whole group under the
+	/// pool's memory pressure.
+	#[error("lagged")]
+	Lagged,
 
 	/// A frame declared a payload size larger than the receiver accepts.
 	#[error("frame too large")]
@@ -138,7 +152,7 @@ impl Error {
 			Self::UnknownAlpn(_) => 21,
 			Self::Dropped => 24,
 			Self::Closed => 25,
-			Self::CacheFull => 26,
+			Self::Lagged => 26,
 			Self::FrameTooLarge => 27,
 			// 28 is reserved (was per-frame decompression, removed in draft-05).
 			Self::TimestampMismatch => 29,
@@ -166,3 +180,23 @@ impl web_transport_trait::Error for Error {
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	// The wire codes are a stable contract with every other implementation, so a variant
+	// rename (e.g. CacheFull -> Lagged) must not shift them. Pin the load-bearing ones.
+	#[test]
+	fn to_code_is_stable() {
+		assert_eq!(Error::Cancel.to_code(), 0);
+		assert_eq!(Error::Version.to_code(), 9);
+		assert_eq!(Error::UnknownAlpn(String::new()).to_code(), 21);
+		assert_eq!(Error::Lagged.to_code(), 26);
+		assert_eq!(Error::Evicted.to_code(), 31);
+		// App codes sit past the reserved library range; Remote is the raw received code.
+		assert_eq!(Error::App(0).to_code(), 64);
+		assert_eq!(Error::App(404).to_code(), 468);
+		assert_eq!(Error::Remote(468).to_code(), 468);
+	}
+}

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -117,7 +117,7 @@ impl GroupState {
 	/// in-flight tail (streamed). Used by [`Consumer::poll_next_frame`].
 	fn poll_frame_source(&self, index: usize) -> Poll<Result<Option<(frame::Info, frame::Source)>>> {
 		if index < self.offset {
-			return Poll::Ready(Err(Error::CacheFull));
+			return Poll::Ready(Err(Error::Lagged));
 		}
 		let local = index - self.offset;
 		if let Some(f) = self.frames.get(local) {
@@ -616,7 +616,7 @@ impl Consumer {
 		let prefetch = &mut self.prefetch;
 		let res = self.state.poll(waiter, |state| {
 			if index < state.offset {
-				return Poll::Ready(Err(Error::CacheFull));
+				return Poll::Ready(Err(Error::Lagged));
 			}
 			// `local` can run past the buffered count when frames were cleared or evicted out
 			// from under us (abort, unfinished drop, an eviction gap); clamp so `range` never
@@ -909,9 +909,9 @@ mod test {
 		producer.write_frame(Timestamp::ZERO, big).unwrap();
 
 		let mut consumer = producer.consume();
-		// First frame was evicted, next_frame should return CacheFull.
+		// First frame was evicted, next_frame should return Lagged.
 		let result = consumer.next_frame().now_or_never().unwrap();
-		assert!(matches!(result, Err(crate::Error::CacheFull)));
+		assert!(matches!(result, Err(crate::Error::Lagged)));
 	}
 
 	#[test]


### PR DESCRIPTION
Part of the #2314 **Error enum** section. Independent of the other stacks, so it targets `dev` directly.

## Summary

- **`Error::CacheFull` → `Error::Lagged`.** It's what a *reader* gets when it fell behind a group's byte budget and the frame it wanted was already dropped. Nothing is "full" from the consumer's side, and renaming a variant after the semver bump is breaking, so do it now. Distinct from `Evicted` (drops a whole group under pool memory pressure). Wire code **26 unchanged**.
- **New `to_code_is_stable` regression test** pins the load-bearing wire codes, so a future variant rename can't silently shift them (they're a contract with every other implementation).
- **Documented the `App(u16)`/`Remote(u32)` asymmetry** as intentional: `App` is a code *this* side chooses to send (bounded, offset past the reserved library range by `+64` on the wire so it never collides with protocol codes), while `Remote` carries a raw code *received* off the wire that didn't map to a known variant, which can be any `u32`. The widths differ on purpose.

## What I deferred, and why

The issue also asks to **split connect-time errors (`Version`, `UnknownAlpn`) into a `ConnectError`**. I investigated and it isn't the clean move it looks like:

- `Error::Version` is **not connect-only**: `lite/subscriber.rs` uses it mid-session to reject a FETCH when the negotiated version lacks fetch support. So `Version` can't simply leave `Error` — a mid-session `reject(Error)` needs it.
- A real type split changes `Client::connect` / `Server::accept` from `Result<_, Error>` to a new error type, rippling through `moq-native`, `moq-relay`, and the FFI (which matches `Error::Version`).

That's a structural change deserving its own design + PR, not a rushed inclusion here. I replaced the in-source `// TODO move to a ConnectError` with a doc noting the dual-use, and documented `UnknownAlpn` as connect-time. Filed as a follow-up.

The `App(u16)` vs `Remote(u32)` **width** change is likewise deliberately *not* made: widening `App` to `u32` breaks the `+64` wire encoding (`to_code`), so the asymmetry is documented rather than "fixed".

## Public API changes

**Breaking** (hence `dev`):
- `moq_net::Error::CacheFull` renamed to `moq_net::Error::Lagged`.
- `@moq/net` `CacheFull` error class renamed to `Lagged`.

**Non-breaking:** doc-only on `Error::App`, `Error::Version`, `Error::UnknownAlpn`.

## Cross-Package Sync

- `rs/moq-net` API → **`js/net` mirrored** (`CacheFull` → `Lagged` class + throw sites + tests), keeping the two implementations' error names aligned (the theme of #2314).
- **No wire change** (code 26 preserved), so no draft update.
- No FFI exposure of this variant name beyond the `App`/`Remote`/`Version` matches, which are untouched, so `libmoq`/py/swift/kt/go need no change.

## Test plan

- `cargo test -p moq-net`: **489 passed** (incl. new `to_code_is_stable`); `cargo check --workspace` clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p moq-net`: exit 0 (new intra-doc links).
- `bun test js/net/...`: 37 passed; `bun biome check js/net/src`: clean.
- `cargo fmt` clean.

(Written by Claude Opus 4.8)