### PR TITLE
fix(watch): render audio at the decoder's real sample rate

### DIFF
--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -70,6 +70,12 @@ export class Decoder {
 	// Audio ring bridging main thread and worklet (shared memory or postMessage transport).
 	#ring: AudioBuffer | undefined;
 
+	// The rate the decoder actually outputs, learned from the first decoded frame. This is the source
+	// of truth for the graph: a decoder can output a different rate than it was configured with (e.g.
+	// Opus decodes to 48kHz on Chrome/Firefox but to the configured rate on Safari). Until a frame
+	// arrives we pre-build the graph from the catalog rate; if the real rate differs we rebuild it.
+	#decodedSampleRate = new Signal<number | undefined>(undefined);
+
 	// The last discontinuity count seen from the container consumer. A change means the
 	// publisher rewound the timeline (e.g. a voice agent interrupted) and we must flush.
 	#discontinuity = 0;
@@ -116,8 +122,14 @@ export class Decoder {
 		const config = effect.get(this.source.out.config);
 		if (!config) return;
 
-		const sampleRate = config.sampleRate;
+		// Pre-build the graph at the catalog rate so warm-up starts before the first frame arrives. The
+		// decoder's actual output rate is the source of truth (see #emit); if it differs, #emit sets
+		// #decodedSampleRate, which re-runs this effect and rebuilds the graph at the real rate.
+		const sampleRate = effect.get(this.#decodedSampleRate) ?? config.sampleRate;
 		const channelCount = config.numberOfChannels;
+
+		// Expose the rate the graph actually runs at.
+		effect.set(this.#out.sampleRate, sampleRate);
 
 		const context = new AudioContext({
 			latencyHint: "interactive", // We don't use real-time because of the buffer.
@@ -393,6 +405,16 @@ export class Decoder {
 		const ring = this.#ring;
 		if (!ring) {
 			// We're probably in the process of closing.
+			sample.close();
+			return;
+		}
+
+		// sample.sampleRate is the source of truth, and it can differ from the rate we pre-built the
+		// graph against (Opus decodes to 48kHz on Chrome/Firefox but to the configured rate on Safari).
+		// If they disagree, rebuild the graph at the real rate and drop this frame; the ring being torn
+		// down can't accept it, and the next frame lands in the correctly-rated ring.
+		if (sample.sampleRate !== ring.rate) {
+			this.#decodedSampleRate.set(sample.sampleRate);
 			sample.close();
 			return;
 		}

--- a/js/watch/src/audio/ring-buffer.test.ts
+++ b/js/watch/src/audio/ring-buffer.test.ts
@@ -634,6 +634,33 @@ describe("resize", () => {
 	});
 });
 
+describe("decoded rate must match the ring (#2352)", () => {
+	// The ring maps a frame's timestamp to a sample index using its own rate, so the ring must run at
+	// the rate the decoder actually output. A 20ms Opus frame decodes to 960 samples (48kHz); if the
+	// ring runs at that rate they land contiguously, but if it runs at a mismatched rate (e.g. 44100,
+	// the machine default a file publish leaked into the catalog) each frame overruns its slot and
+	// every frame after the first is misplaced, which is the noise reported in #2352.
+	function writeOpusFrames(rate: number): AudioRingBuffer {
+		// 1s floor so nothing overflows while we fill 10 frames.
+		const buffer = new AudioRingBuffer({ rate, channels: 1, latency: 1000 as Time.Milli });
+		for (let i = 0; i < 10; i++) {
+			write(buffer, (i * 20) as Time.Milli, 960, { channels: 1, value: (i + 1) / 10 });
+		}
+		return buffer;
+	}
+
+	it("places 20ms/960-sample frames contiguously at 48kHz", () => {
+		// 20ms at 48kHz is exactly 960 samples, so 10 frames pack into 9600 with no gaps or overlap.
+		expect(writeOpusFrames(48000).length).toBe(9600);
+	});
+
+	it("misplaces the frames when the ring rate disagrees", () => {
+		// 20ms at 44100 is 882 samples, so each 960-sample frame overlaps the next and the buffer never
+		// reaches the contiguous 9600 it would at the matching rate.
+		expect(writeOpusFrames(44100).length).toBeLessThan(9600);
+	});
+});
+
 describe("buffered mode", () => {
 	function createBuffered(latency: number) {
 		return new AudioRingBuffer({ rate: 1000, channels: 1, latency: latency as Time.Milli, buffered: true });


### PR DESCRIPTION
Fixes #2352.

## Root cause

The WebCodecs `AudioDecoder` does not necessarily output audio at the rate it was configured with. **Opus** in particular decodes to 48kHz on Chrome and Firefox regardless of the configured rate (Opus is a 48kHz codec), while **Safari** honors the configured rate. The watcher, though, built its entire audio graph, AudioContext, ring buffer, and worklet, from the sample rate the **catalog advertised**. When the decoder's actual output rate disagreed, each decoded frame was placed on a mismatched grid (a 48kHz/960-sample frame on a 44100 grid is 882 samples per 20ms), so every frame after the first landed in the wrong position and the audio played back as noise.

This hit file publishing by default: a `captureStream()` audio track reports no `sampleRate`, so the publisher's AudioContext fell back to the machine's default output rate (often 44100 on a Mac) and advertised that in the catalog. On Chrome the stream then decoded to 48kHz while the graph ran at 44100 → noise. The demo's 24000/16000 sample-rate options broke the same way. Only 48000 worked.

## Fix

Use the decoded `AudioData.sampleRate` as the **source of truth** for the render graph, instead of trusting the catalog. The worklet/AudioContext are still pre-built from the catalog rate so warm-up starts before the first frame arrives, but when a frame comes in at a different rate the graph is rebuilt at the real one (via a `#decodedSampleRate` signal that the worklet effect reads). The decoder itself is still configured with the catalog rate, which Safari needs in order to decode.

No codec-specific defaulting: it works for Opus (Chrome/FF → 48kHz, Safari → configured) and any other codec, because the graph simply follows whatever the decoder produces. Publisher and catalog are untouched.

## Tests

`js/watch/src/audio/ring-buffer.test.ts` documents the mechanism the fix depends on: a 20ms/960-sample (48kHz) Opus frame packs contiguously when the ring runs at 48kHz but overruns its slot at 44100, which is the misplacement that produced the noise.

`@moq/watch` typechecks clean and all tests pass.

Not runtime-verified in a browser (audio-is-noise vs. correct can't be asserted programmatically). Note the mispredict path (e.g. Safari, where the decoder's rate differs from the catalog rate we pre-built against) rebuilds the graph on first playback, dropping the frames decoded during the (~1s) worklet reload before it settles at the correct rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)