### PR TITLE
fix(moq-net): exclude dropped subscribers from the aggregate (#2351)

### DIFF
--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1167,6 +1167,13 @@ impl Drop for Producer {
 fn combined_subscription(subs: &Subscriptions, bound: Option<Duration>, waiter: &kio::Waiter) -> Option<Subscription> {
 	let mut combined = None;
 	for sub in subs.iter() {
+		// A closed consumer means the subscriber dropped: it holds no live demand.
+		// `Consumer::poll` evaluates the closure before the closed flag, so it would
+		// still replay the final value into the aggregate; skip it explicitly so a
+		// departed subscriber can't keep the aggregate pinned to its last request.
+		if sub.is_closed() {
+			continue;
+		}
 		if let Poll::Ready(Ok(sub)) = sub.poll(waiter, |sub| sub.poll_combined(&combined)) {
 			combined = Some(sub);
 		}
@@ -1178,6 +1185,10 @@ fn combined_subscription(subs: &Subscriptions, bound: Option<Duration>, waiter: 
 fn snapshot_subscription(subs: &kio::Shared<Subscriptions>, bound: Option<Duration>) -> Option<Subscription> {
 	let mut combined: Option<Subscription> = None;
 	for sub in subs.read().iter() {
+		// Skip dropped subscribers, matching `combined_subscription`.
+		if sub.is_closed() {
+			continue;
+		}
 		if let Poll::Ready(merged) = sub.read().poll_combined(&combined) {
 			combined = Some(merged);
 		}
@@ -2472,6 +2483,38 @@ mod test {
 		let aggregate = producer.subscription().expect("expected an active subscription");
 		assert_eq!(aggregate.priority, 7);
 		assert!(!aggregate.ordered);
+	}
+
+	#[test]
+	fn dropped_subscriber_leaves_no_ghost_in_aggregate() {
+		// Regression (#2351): a departed subscriber must not keep contributing its
+		// last subscription to the aggregate. When it did, a relay's linger loop
+		// never observed the track going idle, and an identical viewer reconnecting
+		// within the linger window was reset when the stale timer fired.
+		let mut producer = track_producer("test", None);
+		let a = producer.subscribe(Subscription::default().with_priority(5));
+
+		// Prime the change cursor: the aggregate currently has one subscriber.
+		let waiter = kio::Waiter::noop();
+		assert!(
+			matches!(producer.poll_subscription_changed(&waiter), Poll::Ready(Ok(Some(_)))),
+			"one live subscriber should aggregate to Some",
+		);
+
+		// The only subscriber leaves.
+		drop(a);
+
+		// The aggregate must report the drop to None, not the ghost's last value.
+		assert!(
+			matches!(producer.poll_subscription_changed(&waiter), Poll::Ready(Ok(None))),
+			"a dropped subscriber must not linger in the aggregate",
+		);
+
+		// And the snapshot used by the linger loop must agree.
+		assert!(
+			producer.subscription().is_none(),
+			"snapshot must exclude a dropped subscriber",
+		);
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
Fixes #2351.

## Symptom

Reloading a watch page while the publisher keeps running left the reconnected page permanently offline. Every track of the fresh session (`catalog.json`, `meta.json`, `video`, `audio`) was reset by the relay ~5s after it subscribed, with `RESET_STREAM` code 0 (`Error::Cancel`), and the tile never recovered. Waiting >5s between close and reopen avoided it; a second concurrent watcher avoided it. Reproduces across Chrome/WebTransport, Firefox/qmux, and Safari.

## Root cause

The relay aggregates downstream demand across `Vec<kio::Consumer<Subscription>>` in `combined_subscription`/`snapshot_subscription` (`rs/moq-net/src/model/track.rs`). Each subscriber is folded in via `kio::Consumer::poll`, which evaluates its closure and returns `Ready(Ok(value))` **before** checking the `closed` flag (`rs/kio/src/consumer.rs`). So when a viewer drops, its now-closed `Consumer<Subscription>` keeps replaying its final value into the aggregate, a **ghost subscriber**.

That ghost:

1. Hid the track going idle: the aggregate never changed to `None`, so `TrackServe`'s upstream was never paused and `prev_subscription` stayed `Some(S)`.
2. Was never pruned: `guard.retain(|sub| !sub.is_closed())` only runs on the *changed* branch of `poll_subscription_changed`, which the ghost suppressed.

An identical viewer reconnecting within the 5s linger window aggregated to the same `Some(S)`, so no `Event::Subscription` fired, the linger was never disarmed, and `Event::LingerExpired` tore the live track down with `Error::Cancel`. That's the RESET_STREAM the watcher sees.

This matches the controlled experiments in the issue: waiting >5s works (linger already expired), and a second concurrent watcher works (the track never goes idle, so the ghost never matters).

The `kio` "replay the final value once after close" behavior is correct and load-bearing elsewhere (e.g. draining trailing frames after a producer finishes), so the fix belongs in moq-net's demand aggregation, not in kio.

## Fix

Skip closed subscription consumers in both aggregation helpers. A dropped subscriber holds no live demand, so it must not contribute. With this:

- the departure correctly reports `None` (pausing the upstream, arming the linger with `prev = None`), and
- the identical return reports `Some(S)` (resuming and disarming the linger).

The now-correct change events also let the existing `retain` prune the ghosts.

## Test

Adds `dropped_subscriber_leaves_no_ghost_in_aggregate`, which fails on the unpatched code (the aggregate replays the ghost's value instead of reporting `None`) and passes with the fix. Full `just rs check` is green.

## Scope

No wire, public-API, or cross-package changes: both helpers are private and the wire is untouched, so no draft or `js/net` update is needed. Targets `dev` because the linger/`TrackServe` code only exists there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)