### PR TITLE
fix(net): tear down a shared upstream once its last subscriber leaves

### DIFF
--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -34,10 +34,12 @@ function closeState(state: BroadcastState, abort?: Error) {
 }
 
 // `register` is set on the subscribing (consumer) side: the fresh producer is cached in
-// `state.tracks` so repeat subscriptions to the same track fan out from one upstream
-// subscription instead of opening a new one, mirroring the Rust `broadcast::Consumer::track`
-// weak-dedup. The publishing side leaves it false: `state.tracks` there holds only the tracks
-// the app inserted, and a dynamic serve stays one request per peer subscription.
+// `state.tracks` so repeat subscriptions to the same track fan out from one upstream subscription
+// instead of opening a new one, mirroring the Rust `broadcast::Consumer::track` weak-dedup. The
+// consumer wire watches the producer's demand ({@link track.Producer.used}) and tears the upstream
+// down once its last subscriber leaves, closing the producer, which evicts the cache entry below.
+// The publishing side leaves `register` false: `state.tracks` there holds only the tracks the app
+// inserted, and a dynamic serve stays one request per peer subscription.
 function subscribe(
 	state: BroadcastState,
 	name: string,
@@ -59,7 +61,8 @@ function subscribe(
 
 	if (register) {
 		state.tracks.set(name, producer);
-		// Drop the cache entry once the subscription closes, so a later subscribe re-opens it.
+		// Drop the cache entry once the upstream closes (the wire tears it down when its last
+		// subscriber leaves), so a later subscribe re-opens it.
 		void producer.closed.then(() => {
 			if (state.tracks.get(name) === producer) state.tracks.delete(name);
 		});

--- a/js/net/src/group.test.ts
+++ b/js/net/src/group.test.ts
@@ -4,6 +4,27 @@ import { Timestamp } from "./time.ts";
 
 const dec = new TextDecoder();
 
+test("used reflects mirror demand and unused resolves when the last reader leaves", async () => {
+	const producer = new Producer(0);
+
+	// No mirror readers: no demand.
+	expect(producer.used.peek()).toBe(false);
+
+	const a = producer.mirror();
+	const b = producer.mirror();
+	expect(producer.used.peek()).toBe(true);
+
+	// Closing one of two keeps demand, so unused() stays pending.
+	a.close();
+	expect(producer.used.peek()).toBe(true);
+
+	// Closing the last reader drops demand; unused() resolves. Fetch coalescing awaits this to
+	// cancel a download that everyone has abandoned (a group may never end on its own).
+	b.close();
+	await producer.unused();
+	expect(producer.used.peek()).toBe(false);
+});
+
 function pair(sequence: number) {
 	const producer = new Producer(sequence);
 	return { producer, consumer: producer.consume() };

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -3,7 +3,7 @@
  *
  * @module
  */
-import { type GetPromise, Once, Signal } from "@moq/signals";
+import { type GetPromise, type Getter, Once, Signal } from "@moq/signals";
 import { Timestamp } from "./time.ts";
 
 /** Maximum bytes of frames cached in a group before old frames are evicted from the front. */
@@ -92,6 +92,11 @@ export class Producer {
 	#state: GroupState;
 	#mirrors?: Set<GroupState>;
 
+	// Whether any mirror reader is attached (see {@link used}). Fetch coalescing watches it to
+	// cancel an abandoned download; a group can stay open indefinitely (a catalog or JSON stream),
+	// so this is what stops a reader-less fetch instead of the stream ending on its own.
+	#used = new Signal<boolean>(false);
+
 	constructor(sequence: number) {
 		this.#state = new GroupState(sequence);
 		this.sequence = sequence;
@@ -131,7 +136,42 @@ export class Producer {
 
 		this.#mirrors ??= new Set();
 		this.#mirrors.add(dst);
+		this.#used.set(true);
+
+		// Track this mirror's close eagerly (not just lazily on the next write) so demand drops the
+		// moment the last reader leaves, letting an abandoned fetch cancel even with no more frames.
+		const dispose = dst.closed.subscribe((c) => {
+			if (c === undefined) return;
+			this.#mirrors?.delete(dst);
+			this.#used.set((this.#mirrors?.size ?? 0) > 0);
+			dispose();
+		});
+
 		return makeConsumer(dst);
+	}
+
+	/**
+	 * Whether any mirror reader is currently attached.
+	 *
+	 * Pairs with {@link unused}. Fetch coalescing watches it to cancel a download once every reader
+	 * has gone: a group can stay open indefinitely (a catalog track, a JSON stream), so it can't
+	 * rely on the stream ending on its own.
+	 *
+	 * @internal Track fan-out and fetch coalescing only.
+	 */
+	get used(): Getter<boolean> {
+		return this.#used;
+	}
+
+	/**
+	 * Resolves once no mirror reader remains (or the group closes).
+	 *
+	 * @internal Track fan-out and fetch coalescing only.
+	 */
+	async unused(): Promise<void> {
+		while (this.#used.peek() && this.#state.closed.peek() === undefined) {
+			await Signal.race(this.#used, this.#state.closed);
+		}
 	}
 
 	/** Writes a frame to the group. */

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -280,8 +280,19 @@ export class Subscriber {
 		}
 
 		try {
-			// Wait for stream close (= PublishDone) or track close (= local unsubscribe)
-			await Promise.race([stream.reader.closed, producer.closed]);
+			// Terminal conditions settle at most once (stream close = PublishDone, track close =
+			// local unsubscribe); race them once so the demand loop doesn't re-subscribe each pass.
+			const done = Promise.race([stream.reader.closed, producer.closed]);
+
+			// Serve until a terminal condition fires or the last local subscriber leaves. The unused
+			// wake is level-triggered: re-check demand so a subscriber that returns before we tear
+			// down resumes on the same stream.
+			const idle = Symbol("idle");
+			for (;;) {
+				const reason = await Promise.race([done, producer.unused().then(() => idle)]);
+				if (reason === idle && producer.closed.peek() === undefined && producer.used.peek()) continue;
+				break;
+			}
 
 			// For v14-v16: send Unsubscribe before closing (removed in v17+)
 			if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -6,6 +6,7 @@ import * as Lite from "./lite/index.ts";
 import { createMockTransportPair } from "./mock.ts";
 import * as Path from "./path.ts";
 import { Timescale, Timestamp } from "./time.ts";
+import type { Producer as TrackProducer } from "./track.ts";
 
 const url = new URL("https://localhost:4443/test");
 
@@ -548,6 +549,50 @@ test("integration: ietf subscriber teardown on last unsubscribe", async () => {
 	await runSubscriberTeardown(Ietf.ALPN.DRAFT_17);
 });
 
+// Draft-14 sends an explicit Unsubscribe after the demand loop breaks; exercise that path too.
+// Uses a dynamic serve (draft-14 doesn't complete SUBSCRIBE_OK for a statically inserted track).
+test("integration: ietf draft-14 subscriber teardown on last unsubscribe", async () => {
+	const pair = createMockTransportPair("");
+	const [client, server] = await Promise.all([
+		connect(url, { transport: pair.client }),
+		accept(pair.server, url, { version: Ietf.Version.DRAFT_14 }),
+	]);
+
+	const broadcast = new BroadcastProducer();
+	server.publish(Path.from("test"), broadcast);
+
+	// Serve dynamically, keeping the served producer so we can watch its demand.
+	let served: TrackProducer | undefined;
+	const serving = (async () => {
+		for (;;) {
+			const req = await broadcast.requested();
+			if (!req) break;
+			served = req.accept();
+			served.writeString("hello");
+		}
+	})();
+
+	// Draft-14 only completes SUBSCRIBE_OK once the session is warmed by an announce round-trip.
+	const announced = client.announced();
+	await announced.next();
+
+	const remote = client.consume(Path.from("test"));
+	const sub = remote.track("video").subscribe();
+	expect(await sub.readString()).toBe("hello");
+	await waitUntil(() => served?.used.peek() === true);
+
+	// Closing the subscriber sends Unsubscribe and tears the subscription down, so demand drops.
+	sub.close();
+	await waitUntil(() => served?.used.peek() === false);
+
+	broadcast.close();
+	await serving;
+	announced.close();
+	remote.close();
+	client.close();
+	server.close();
+});
+
 // A fetched group can stay open indefinitely (a catalog track, a JSON stream), so abandoning the
 // fetch must cancel the FETCH stream rather than wait for a stream end that never comes.
 test("integration: lite fetch teardown when the reader abandons an open group", async () => {
@@ -573,6 +618,138 @@ test("integration: lite fetch teardown when the reader abandons an open group", 
 	await waitUntil(() => !group.used.peek());
 
 	group.close();
+	broadcast.close();
+	remote.close();
+	client.close();
+	server.close();
+});
+
+// Older drafts have no TRACK stream or SUBSCRIBE_UPDATE, so the demand loop must still tear the
+// subscription down through the plain stream-close path.
+test("integration: lite draft-01 subscriber teardown on last unsubscribe", async () => {
+	await runSubscriberTeardown("", Lite.Version.DRAFT_01);
+});
+
+// Two subscribers to one track dedupe onto a single wire subscription: closing one keeps it alive
+// for the other, and only the last close tears it down.
+test("integration: lite fan-out keeps the upstream until the last subscriber leaves", async () => {
+	const pair = createMockTransportPair(Lite.ALPN_06_WIP);
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	const broadcast = new BroadcastProducer();
+	server.publish(Path.from("test"), broadcast);
+	const video = broadcast.createTrack("video");
+	video.writeString("hello");
+
+	const remote = client.consume(Path.from("test"));
+	const a = remote.track("video").subscribe();
+	const b = remote.track("video").subscribe();
+	expect(await a.readString()).toBe("hello");
+	expect(await b.readString()).toBe("hello");
+	await waitUntil(() => video.used.peek());
+
+	// Closing one leaves the shared upstream serving the other.
+	a.close();
+	video.writeString("more");
+	expect(await b.readString()).toBe("more");
+	expect(video.used.peek()).toBe(true);
+
+	// The last close tears it down.
+	b.close();
+	await waitUntil(() => !video.used.peek());
+
+	broadcast.close();
+	remote.close();
+	client.close();
+	server.close();
+});
+
+// Repeated subscribe/unsubscribe cycles must each tear down and re-open cleanly (the 40-toggle
+// scenario in the issue), never wedging the shared cache or leaking a subscription.
+test("integration: lite re-subscribe re-opens the upstream after each teardown", async () => {
+	const pair = createMockTransportPair(Lite.ALPN_06_WIP);
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	const broadcast = new BroadcastProducer();
+	server.publish(Path.from("test"), broadcast);
+	const video = broadcast.createTrack("video");
+
+	const remote = client.consume(Path.from("test"));
+
+	for (let i = 0; i < 8; i++) {
+		video.writeString(`hello-${i}`);
+		const sub = remote.track("video").subscribe();
+		expect(await sub.readString()).toBe(`hello-${i}`);
+		await waitUntil(() => video.used.peek());
+
+		sub.close();
+		await waitUntil(() => !video.used.peek());
+	}
+
+	broadcast.close();
+	remote.close();
+	client.close();
+	server.close();
+});
+
+// Coalesced fetches of one open group share a single FETCH stream: closing one keeps it flowing
+// for the other, and only the last abandon cancels it.
+test("integration: lite coalesced fetch stays until every reader abandons the open group", async () => {
+	const pair = createMockTransportPair(Lite.ALPN_06_WIP);
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	const broadcast = new BroadcastProducer();
+	server.publish(Path.from("test"), broadcast);
+	const video = broadcast.createTrack("video");
+	const group = video.appendGroup(); // open
+	group.writeString("hello");
+
+	const remote = client.consume(Path.from("test"));
+	const f1 = await remote.track("video").fetchGroup(group.sequence);
+	const f2 = await remote.track("video").fetchGroup(group.sequence);
+	expect(await f1.readString()).toBe("hello");
+	expect(await f2.readString()).toBe("hello");
+	await waitUntil(() => group.used.peek());
+
+	// Closing one coalesced reader keeps the shared FETCH flowing for the other.
+	f1.close();
+	group.writeString("more");
+	expect(await f2.readString()).toBe("more");
+	expect(group.used.peek()).toBe(true);
+
+	// The last abandon cancels the FETCH.
+	f2.close();
+	await waitUntil(() => !group.used.peek());
+
+	group.close();
+	broadcast.close();
+	remote.close();
+	client.close();
+	server.close();
+});
+
+// A finite group must still deliver every frame and end cleanly (the demand watch must not disturb
+// normal completion), exercising the per-frame loop many times.
+test("integration: lite fetch delivers every frame of a finite multi-frame group", async () => {
+	const pair = createMockTransportPair(Lite.ALPN_06_WIP);
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	const broadcast = new BroadcastProducer();
+	server.publish(Path.from("test"), broadcast);
+	const video = broadcast.createTrack("video");
+	const group = video.appendGroup();
+	const count = 50;
+	for (let i = 0; i < count; i++) group.writeString(`f${i}`);
+	group.close(); // finite
+
+	const remote = client.consume(Path.from("test"));
+	const fetched = await remote.track("video").fetchGroup(group.sequence);
+	for (let i = 0; i < count; i++) {
+		expect(await fetched.readString()).toBe(`f${i}`);
+	}
+	// Every frame read, then a clean end.
+	expect(await fetched.readString()).toBeUndefined();
+
 	broadcast.close();
 	remote.close();
 	client.close();

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -548,6 +548,37 @@ test("integration: ietf subscriber teardown on last unsubscribe", async () => {
 	await runSubscriberTeardown(Ietf.ALPN.DRAFT_17);
 });
 
+// A fetched group can stay open indefinitely (a catalog track, a JSON stream), so abandoning the
+// fetch must cancel the FETCH stream rather than wait for a stream end that never comes.
+test("integration: lite fetch teardown when the reader abandons an open group", async () => {
+	const pair = createMockTransportPair(Lite.ALPN_06_WIP);
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	const broadcast = new BroadcastProducer();
+	server.publish(Path.from("test"), broadcast);
+	const video = broadcast.createTrack("video");
+	const group = video.appendGroup(); // deliberately left open: an indefinite group.
+	group.writeString("hello");
+
+	const remote = client.consume(Path.from("test"));
+	const fetched = await remote.track("video").fetchGroup(group.sequence);
+	expect(await fetched.readString()).toBe("hello");
+
+	// The publisher is now serving the still-open group.
+	await waitUntil(() => group.used.peek());
+
+	// Abandoning the fetch cancels the FETCH stream, so the publisher stops serving instead of
+	// pumping an open group to a reader that left.
+	fetched.close();
+	await waitUntil(() => !group.used.peek());
+
+	group.close();
+	broadcast.close();
+	remote.close();
+	client.close();
+	server.close();
+});
+
 test("integration: lite consume dedup", async () => {
 	await runConsumeDedup(Lite.ALPN_05);
 });

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -500,6 +500,54 @@ async function runConsumeDedup(protocol: string, version?: number) {
 	server.close();
 }
 
+async function waitUntil(predicate: () => boolean): Promise<void> {
+	for (let i = 0; i < 200; i++) {
+		if (predicate()) return;
+		await sleep(5);
+	}
+	throw new Error("condition not met within timeout");
+}
+
+// Closing the last subscriber to a track tears the wire subscription down, so the publisher stops
+// serving it (the muted-watch-tile case in #2355) instead of sending groups to a reader that left.
+async function runSubscriberTeardown(protocol: string, version?: number) {
+	const pair = createMockTransportPair(protocol);
+	const [client, server] = await Promise.all([
+		connect(url, { transport: pair.client }),
+		accept(pair.server, url, version !== undefined ? { version } : undefined),
+	]);
+
+	const broadcast = new BroadcastProducer();
+	server.publish(Path.from("test"), broadcast);
+	const video = broadcast.createTrack("video");
+	video.writeString("hello");
+
+	const remote = client.consume(Path.from("test"));
+	const sub = remote.track("video").subscribe();
+	expect(await sub.readString()).toBe("hello");
+
+	// The publisher now has a live downstream reader for the track.
+	await waitUntil(() => video.used.peek());
+
+	// Closing the only subscriber must tear the wire subscription down, so demand drops on the
+	// publisher rather than the relay serving groups to nobody.
+	sub.close();
+	await waitUntil(() => !video.used.peek());
+
+	broadcast.close();
+	remote.close();
+	client.close();
+	server.close();
+}
+
+test("integration: lite subscriber teardown on last unsubscribe", async () => {
+	await runSubscriberTeardown(Lite.ALPN_06_WIP);
+});
+
+test("integration: ietf subscriber teardown on last unsubscribe", async () => {
+	await runSubscriberTeardown(Ietf.ALPN.DRAFT_17);
+});
+
 test("integration: lite consume dedup", async () => {
 	await runConsumeDedup(Lite.ALPN_05);
 });

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -351,17 +351,26 @@ export class Subscriber {
 			// drain them (we don't drive delivery off the resolved range) so the FIN is
 			// observed. Older drafts just wait for the stream to close.
 			const closed = supportsTrackStream(this.version) ? this.#drainResponses(stream) : stream.reader.closed;
-			const waits: PromiseLike<unknown>[] = [closed, producer.closed];
-			switch (this.version) {
-				case Version.DRAFT_01:
-				case Version.DRAFT_02:
-					break;
-				default:
-					waits.push(this.#runPriorityUpdates(id, broadcast, producer, msg, stream));
-					break;
-			}
+			const priorityUpdates =
+				this.version === Version.DRAFT_01 || this.version === Version.DRAFT_02
+					? undefined
+					: this.#runPriorityUpdates(id, broadcast, producer, msg, stream);
 
-			await Promise.race(waits);
+			// Terminal conditions (stream end, track close, a failed priority update) settle at most
+			// once; race them into one stable promise so the demand loop doesn't re-subscribe each pass.
+			const terminal: PromiseLike<unknown>[] = [closed, producer.closed];
+			if (priorityUpdates !== undefined) terminal.push(priorityUpdates);
+			const done = Promise.race(terminal);
+
+			// Serve until a terminal condition fires or the last local subscriber leaves. The unused
+			// wake is level-triggered: re-check demand so a subscriber that returns before we tear
+			// down (e.g. a quickly unmuted tile) resumes on the same subscription.
+			const idle = Symbol("idle");
+			for (;;) {
+				const reason = await Promise.race([done, producer.unused().then(() => idle)]);
+				if (reason === idle && producer.closed.peek() === undefined && producer.used.peek()) continue;
+				break;
+			}
 
 			producer.close();
 			stream.close();

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -542,13 +542,14 @@ export class Subscriber {
 
 			// Serve until the stream FINs, the group closes, or every reader leaves. A group can
 			// stay open indefinitely (a catalog or JSON stream), so an abandoned fetch is stopped by
-			// demand, not by the stream ending. `unused` is a one-shot watched across frames (so it
-			// isn't re-subscribed per frame); the check is level-triggered, so a coalesced fetch that
-			// arrives before we cancel re-arms it and resumes on the same stream.
+			// demand, not by the stream ending. `closed` and `unused` are watched across frames as
+			// stable promises (not re-subscribed to the signals each frame); the unused check is
+			// level-triggered, so a coalesced fetch that arrives before we cancel re-arms and resumes.
 			const idle = Symbol("idle");
+			const closed = Promise.resolve<Error | null>(group.closed);
 			let unused = group.unused().then(() => idle);
 			for (;;) {
-				const done = await Promise.race([stream.reader.done(), group.closed, unused]);
+				const done = await Promise.race([stream.reader.done(), closed, unused]);
 				if (done === idle) {
 					if (!group.isClosed && group.used.peek()) {
 						unused = group.unused().then(() => idle);

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -523,8 +523,11 @@ export class Subscriber {
 				throw err;
 			}
 
+			// Mint this caller's reader before starting the pump, so the group has demand when the
+			// pump begins watching it (an abandoned fetch cancels once every reader has left).
+			const consumer = group.mirror();
 			void this.#runFetchResponse(stream, group, Time.Timescale(info.timescale));
-			return group.mirror();
+			return consumer;
 		} catch (err: unknown) {
 			group.close(error(err));
 			throw err;
@@ -537,8 +540,22 @@ export class Subscriber {
 		try {
 			let prevTs = 0n;
 
+			// Serve until the stream FINs, the group closes, or every reader leaves. A group can
+			// stay open indefinitely (a catalog or JSON stream), so an abandoned fetch is stopped by
+			// demand, not by the stream ending. `unused` is a one-shot watched across frames (so it
+			// isn't re-subscribed per frame); the check is level-triggered, so a coalesced fetch that
+			// arrives before we cancel re-arms it and resumes on the same stream.
+			const idle = Symbol("idle");
+			let unused = group.unused().then(() => idle);
 			for (;;) {
-				const done = await Promise.race([stream.reader.done(), group.closed]);
+				const done = await Promise.race([stream.reader.done(), group.closed, unused]);
+				if (done === idle) {
+					if (!group.isClosed && group.used.peek()) {
+						unused = group.unused().then(() => idle);
+						continue;
+					}
+					break;
+				}
 				if (done !== false) break;
 
 				prevTs += unzigzag(await stream.reader.u62());

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -6,6 +6,27 @@ import { Producer as TrackProducer } from "./track.ts";
 const enc = new TextEncoder();
 const dec = new TextDecoder();
 
+test("used reflects subscriber demand and unused resolves when the last one leaves", async () => {
+	const producer = new TrackProducer("test");
+
+	// No subscribers: no demand.
+	expect(producer.used.peek()).toBe(false);
+
+	const a = producer.subscribe();
+	const b = producer.subscribe();
+	expect(producer.used.peek()).toBe(true);
+
+	// Closing one of two keeps demand, so unused() stays pending.
+	a.close();
+	expect(producer.used.peek()).toBe(true);
+
+	// Closing the last subscriber drops demand; unused() resolves. The consumer wire awaits this
+	// to tear an idle upstream down.
+	b.close();
+	await producer.unused();
+	expect(producer.used.peek()).toBe(false);
+});
+
 test("appendDatagram shares the group sequence counter", () => {
 	const producer = new TrackProducer("test");
 	const ts = Timestamp.fromMillis(10);

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -27,6 +27,48 @@ test("used reflects subscriber demand and unused resolves when the last one leav
 	expect(producer.used.peek()).toBe(false);
 });
 
+test("a producer never self-closes on zero demand: a publisher keeps serving new subscribers", async () => {
+	const producer = new TrackProducer("video");
+
+	// Demand comes and goes...
+	const a = producer.subscribe();
+	a.close();
+	await producer.unused();
+
+	// ...but the producer stays open (only the wire acts on `unused`, not the producer itself),
+	// so a publisher writing to a track nobody is watching is unaffected.
+	expect(producer.closed.peek()).toBeUndefined();
+
+	// A later subscriber still works and replays the cache.
+	producer.writeString("still here");
+	const b = producer.subscribe();
+	expect(await b.readString()).toBe("still here");
+	expect(producer.used.peek()).toBe(true);
+});
+
+test("unused() resolves immediately when there was never any demand", async () => {
+	const producer = new TrackProducer("video");
+	// No subscriber was ever attached; unused() must not hang.
+	await producer.unused();
+	expect(producer.used.peek()).toBe(false);
+});
+
+test("used stays true across churn while at least one subscriber remains", async () => {
+	const producer = new TrackProducer("video");
+
+	const a = producer.subscribe();
+	// Rapidly add and drop extra subscribers; `a` keeps demand asserted throughout.
+	for (let i = 0; i < 20; i++) {
+		const t = producer.subscribe();
+		t.close();
+		expect(producer.used.peek()).toBe(true);
+	}
+
+	a.close();
+	await producer.unused();
+	expect(producer.used.peek()).toBe(false);
+});
+
 test("appendDatagram shares the group sequence counter", () => {
 	const producer = new TrackProducer("test");
 	const ts = Timestamp.fromMillis(10);

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -250,6 +250,10 @@ export class Producer {
 	// One independent downstream state per live subscriber.
 	#sinks = new Set<TrackState>();
 
+	// Whether any subscriber is currently attached. Exposed as {@link used}; the consumer wire
+	// watches it to tear down an idle upstream, and a publisher can watch it for on-demand capture.
+	#used = new Signal<boolean>(false);
+
 	constructor(name: string) {
 		this.name = name;
 	}
@@ -294,6 +298,24 @@ export class Producer {
 		return makeSubscriber(this.name, sink);
 	}
 
+	/**
+	 * Whether the track currently has any subscribers.
+	 *
+	 * Watch it (`effect.get` / `.peek()`) to drive on-demand work: a publisher can start and stop
+	 * capture with demand, and the consumer wire watches it to tear an idle upstream subscription
+	 * down instead of downloading to nobody. Pairs with {@link unused}. Mirrors the Rust `Demand`.
+	 */
+	get used(): Getter<boolean> {
+		return this.#used;
+	}
+
+	/** Resolves once the track has no subscribers (or has closed). Await it to react to demand ending. */
+	async unused(): Promise<void> {
+		while (this.#used.peek() && this.#state.closed.peek() === undefined) {
+			await Signal.race(this.#used, this.#state.closed);
+		}
+	}
+
 	// Register a downstream sink: seed its info, replay the retained window, and (while
 	// the track is open) mirror future groups into it. A late subscriber to a closed
 	// track still drains the buffered groups before seeing the end.
@@ -304,6 +326,7 @@ export class Producer {
 		const closed = this.#state.closed.peek();
 		if (closed === undefined) {
 			this.#sinks.add(sink);
+			this.#used.set(true);
 
 			// Forward subscription updates from the sink's Subscriber to the producer's own
 			// state, which the wire layer (or the serving application) watches.
@@ -329,6 +352,10 @@ export class Producer {
 				}
 				for (const group of sink.groups.peek()) group.close(abort);
 				dispose();
+
+				// Update demand: once the last subscriber leaves, the consumer wire (watching
+				// {@link unused}) tears the upstream down instead of downloading to nobody.
+				this.#used.set(this.#sinks.size > 0);
 			});
 		}
 


### PR DESCRIPTION
## Problem

Muting a watched broadcast's audio through `<moq-watch>` stops local playback but never closes the wire subscription for that track, so the relay keeps serving audio groups to a client that has gone away, contradicting the documented `Emitter` contract that muting "stops the download" ([#2355](https://github.com/moq-dev/moq/issues/2355)).

This is a `dev`-only regression. On `main`, `Broadcast.subscribe` returns a fresh `Track` per call, so closing it is 1:1 with tearing the subscription down and the bug can't occur.

## Root cause

The module-split refactor added the consumer-side fan-out dedup cache (`state.tracks`) that mirrors the Rust `broadcast::Consumer::track` weak-dedup: repeat subscriptions to a track share one upstream. But nothing ever ended that upstream when its subscribers dropped to zero. `Decoder`'s cleanup (`sub.close()` on mute) closed only its local fan-out sink; the shared producer stayed cached, the wire subscriber kept writing every group into it, and the relay's serve loop never saw a teardown.

## Fix — commit 1 (track subscriptions)

Mirror the Rust design, where the consumer wire (`TrackServe`) watches track demand (`poll_unused`) and ends the upstream once no consumer remains — rather than the producer self-closing.

- **`track.Producer` exposes demand**: `used` (a reactive `Getter<boolean>` over its subscriber set) and `unused()` (resolves once the last subscriber leaves). No second counter. A publisher can watch `used` for on-demand capture too. Mirrors the Rust `Demand`.
- **Both wire subscribers** (`lite`, `ietf`) race `producer.unused()` alongside the existing stream/track-close conditions. Last subscriber out → wire closes the producer + SUBSCRIBE stream → cache entry evicts.
- **Level-triggered**: on the unused wake the loop re-checks `used`, so a subscriber that returns before teardown (a quickly unmuted tile) resumes on the same subscription.

The producer never self-closes on zero subscribers, so the **publisher path is untouched**: an app-owned track stays open with no readers, buffering into its cache.

## Fix — commit 2 (fetch of an open group)

The same gap existed one level down. `fetchGroup` coalesces callers onto a shared `group.Producer` fed by `#runFetchResponse`, which only stopped on stream FIN or explicit close — closing the returned consumer never propagated back. Bounded for a finite group, but **not all groups are finite**: a catalog track or a `@moq/json` stream is a single group that stays open indefinitely, so an abandoned fetch downloaded forever to nobody.

- **`group.Producer` gets the same demand surface** (`used`/`unused()`), tracking mirror closes eagerly.
- **`#runFetchResponse` races `group.unused()`** and cancels the FETCH stream once the last reader leaves (level-triggered for coalesced re-fetches). The reader is minted before the pump starts so demand exists from the outset. IETF fetch is unsupported, so this is lite-only.

## Surveyed, no change needed

Broadcast consume (`BroadcastCache`) is already refcounted via `Consumer.clone()`; `announced()` is 1:1 per caller and tears down on close; group delivery inside a live subscription already races `track.closed`, so commit 1 cascades to in-flight group reads.

## Not ported

Rust's relay-side **linger** (pause/resume across brief subscriber churn) is a separate optimization; prompt teardown is what the issue asks for.

## Testing

- **Model unit tests**: `track.test.ts` (`used`/`unused()` over subscribers), `group.test.ts` (`used`/`unused()` over mirrors).
- **End-to-end wire tests** (`integration.test.ts`): subscriber teardown on last unsubscribe (lite + ietf), and fetch teardown when the reader abandons an open group (lite) — each asserts the publisher's demand actually drops.
- `just js check` — all packages typecheck + lint clean.
- `bun test js/net/` — 270 pass.

## Cross-package

No wire-format change, so no `drafts/` update. This brings `js/net` to parity with existing `rs/moq-net` behavior rather than changing a contract.

Closes #2355

🤖 Generated with [Claude Code](https://claude.com/claude-code)