### PR TITLE
fix(watch): resume the AudioContext from a real user gesture (#2357)

### DIFF
--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -11,6 +11,7 @@ import { type AudioBuffer, createAudioBuffer } from "./buffer";
 // Compiled and inlined as a blob URL via vite-plugin-worklet.
 import RenderWorklet from "./render-worklet.ts?worklet";
 import type { Source } from "./source";
+import { unlockOnGesture } from "./unlock";
 
 export type DecoderInput = {
 	// Enable to download the audio track.
@@ -172,11 +173,15 @@ export class Decoder {
 	}
 
 	#runEnabled(effect: Effect): void {
-		const values = effect.getAll([this.in.enabled, this.#out.context]);
-		if (!values) return;
-		const [_, context] = values;
+		const enabled = effect.get(this.in.enabled);
+		if (!enabled) return;
 
-		context.resume();
+		const context = effect.get(this.#out.context);
+		if (!context) return;
+
+		// The context is built at page load (see #runWorklet), before any user gesture, so it
+		// must be started from a real interaction. See unlockOnGesture.
+		unlockOnGesture(effect, context);
 
 		// NOTE: You should disconnect/reconnect the worklet to save power when disabled.
 	}

--- a/js/watch/src/audio/unlock.test.ts
+++ b/js/watch/src/audio/unlock.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { Effect } from "@moq/signals";
+import { unlockOnGesture } from "./unlock";
+
+// Minimal AudioContext stand-in: an EventTarget with a mutable `state` and a counting
+// `resume()`. `transition` mirrors a real context firing `statechange` when its state moves.
+class MockContext extends EventTarget {
+	state = "suspended";
+	resumeCalls = 0;
+
+	resume(): Promise<void> {
+		this.resumeCalls++;
+		return Promise.resolve();
+	}
+
+	transition(state: string): void {
+		this.state = state;
+		this.dispatchEvent(new Event("statechange"));
+	}
+}
+
+// Drain microtasks so scheduled effect (re)runs settle.
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+let originalDocument: typeof globalThis.document;
+
+beforeEach(() => {
+	originalDocument = globalThis.document;
+	globalThis.document = new EventTarget() as unknown as Document;
+});
+
+afterEach(() => {
+	globalThis.document = originalDocument;
+});
+
+const asContext = (ctx: MockContext) => ctx as unknown as AudioContext;
+
+test("retries resume() on a user gesture until the context is running", async () => {
+	const ctx = new MockContext();
+	const effect = new Effect();
+	unlockOnGesture(effect, asContext(ctx));
+	await flush();
+
+	// The at-load attempt fires once. Browsers requiring a gesture reject it, but we still
+	// try in case autoplay is already permitted.
+	expect(ctx.resumeCalls).toBe(1);
+
+	// The regression: a real gesture must produce a fresh resume(). Before the fix the effect
+	// was edge-triggered on inputs that never changed, so no gesture ever reached resume().
+	document.dispatchEvent(new Event("pointerdown"));
+	expect(ctx.resumeCalls).toBe(2);
+
+	document.dispatchEvent(new Event("keydown"));
+	expect(ctx.resumeCalls).toBe(3);
+
+	// Once the context is actually running, stop retrying: further gestures are no-ops.
+	ctx.transition("running");
+	await flush();
+	document.dispatchEvent(new Event("pointerdown"));
+	expect(ctx.resumeCalls).toBe(3);
+
+	effect.close();
+});
+
+test("re-arms when Safari drops the context to interrupted", async () => {
+	const ctx = new MockContext();
+	const effect = new Effect();
+	unlockOnGesture(effect, asContext(ctx));
+	await flush();
+
+	ctx.transition("running");
+	await flush();
+	expect(ctx.resumeCalls).toBe(1); // only the at-load attempt so far
+
+	// Safari can suspend a running context to its WebKit-only "interrupted" state. We must
+	// re-attempt on the next gesture rather than staying silent.
+	ctx.transition("interrupted");
+	await flush();
+	expect(ctx.resumeCalls).toBe(2); // immediate retry once no longer running
+
+	document.dispatchEvent(new Event("pointerdown"));
+	expect(ctx.resumeCalls).toBe(3);
+
+	effect.close();
+});
+
+test("stops resuming after the effect closes", async () => {
+	const ctx = new MockContext();
+	const effect = new Effect();
+	unlockOnGesture(effect, asContext(ctx));
+	await flush();
+
+	effect.close();
+	document.dispatchEvent(new Event("pointerdown"));
+	expect(ctx.resumeCalls).toBe(1); // only the at-load attempt, no post-close listener
+});

--- a/js/watch/src/audio/unlock.ts
+++ b/js/watch/src/audio/unlock.ts
@@ -1,0 +1,35 @@
+import { type Effect, Signal } from "@moq/signals";
+
+/**
+ * Resume a suspended {@link AudioContext} from a real user gesture.
+ *
+ * The context is built at page load, before any user activation can exist, so browsers that
+ * gate audio on a gesture reject a `resume()` made then. A single unconditional attempt would
+ * fire once, be rejected, and never retry, leaving audio silent. This instead attempts
+ * `resume()` immediately (for autoplay-permissive browsers like Chrome with prior engagement),
+ * then retries on every `pointerdown`/`keydown` until the context is actually running, dropping
+ * the gesture listeners once it is. `pointerdown` and `keydown` cover mouse, touch, pen, and
+ * keyboard, and each carries a user activation.
+ *
+ * Safari also reports an "interrupted" state (a WebKit-only value outside the
+ * suspended/running/closed set) and can leave it on its own; mirroring `statechange` into a
+ * signal picks that up so the listeners are re-armed or dropped as the state moves.
+ *
+ * Scoped to `effect`: the listeners are removed when the effect reruns or closes.
+ */
+export function unlockOnGesture(effect: Effect, context: AudioContext): void {
+	const running = new Signal(context.state === "running");
+	effect.event(context, "statechange", () => running.set(context.state === "running"));
+
+	effect.run((inner) => {
+		if (inner.get(running)) return;
+
+		const resume = () => {
+			context.resume().catch(() => {});
+		};
+
+		resume();
+		inner.event(document, "pointerdown", resume);
+		inner.event(document, "keydown", resume);
+	});
+}


### PR DESCRIPTION
Closes #2357.

## Root cause

The audio `AudioContext` is built at page load by `Decoder#runWorklet` (deliberately early, so mute/unmute is instant). `Decoder#runEnabled` was the only `resume()` site in `js/watch`, and it is an `Effect` keyed on `in.enabled` + `#out.context`. Both go truthy ~150ms into the page's life, so `resume()` fired exactly once, with no user activation present. Browsers that gate audio on a gesture reject that attempt, and because the effect is edge-triggered on inputs that never change again, `resume()` is never retried. Clicking the tile does nothing; only a mute→unmute cycle flips `enabled` false→true and re-runs the effect, which is why toggling mute was the sole way to start audio.

This matches the reported Safari/Firefox symptom: the tile plays video but audio stays silent until mute is toggled off and on. Full diagnosis (including the instrumented `userActivation` trace) is in #2357.

## Fix

Retry `resume()` from a real user gesture until the context is actually running, extracted into `unlockOnGesture` ([js/watch/src/audio/unlock.ts](../blob/claude/github-issue-2357-99632c/js/watch/src/audio/unlock.ts)):

- Attempts `resume()` immediately (for autoplay-permissive browsers like Chrome with prior engagement), then on every `pointerdown`/`keydown` until the context runs. Those two events cover mouse, touch, pen, and keyboard, and each carries a user activation.
- Mirrors the context's `statechange` into a signal, so it re-arms if Safari drops a running context to its WebKit-only `interrupted` state, and drops the gesture listeners once the context is running.
- Scoped to the `Effect`, so listeners are removed automatically when audio is disabled or the decoder closes (no leaked document listeners).

`#runEnabled` now just gates on `enabled`/`context` and delegates.

## Test

`unlock.test.ts` drives a mock context and `document` through the exact failure: a gesture must produce a fresh `resume()` (the bug: none ever did), retries stop once the context is running, it re-arms on `interrupted`, and it stops after close. Verified the test **fails** against the old one-shot behavior and passes with the fix.

## Scope

- No API or wire change; behavior only. No Cross-Package Sync rows apply (`AudioContext` autoplay unlocking is a browser-only concern with no `rs/` mirror; `demo/web` consumes no changed API).
- `just js check` passes across all packages.
- **Not runtime-verified in a real browser.** Audio autoplay unlocking only truly surfaces against real Safari/Firefox with a real gesture (which also can't be heard from CI). The logic is unit-covered and matches the measured browser behavior in the issue, but a `just dev` pass in Safari before merge would be worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)