### PR TITLE
fix(bindings)!: unify moq-ffi shapes before the bump (#2315)

### DIFF
--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -105,7 +105,7 @@ go func() {
     if err != nil {
         return
     }
-    _ = track.WriteFrame([]byte("ready"), 0)
+    _ = track.WriteFrame(moq.Frame{Payload: []byte("ready")})
 }()
 ```
 
@@ -120,7 +120,7 @@ media, err := broadcast.PublishMediaOnTrack(request, "opus", opusInit)
 if err != nil {
     log.Fatal(err)
 }
-_ = media.WriteFrame(opusFrame, 20_000)
+_ = media.WriteFrame(moq.Frame{Payload: opusFrame, TimestampUs: 20_000})
 ```
 
 Video catalog fields that are known before the first keyframe can be supplied
@@ -177,7 +177,7 @@ if err != nil {
 	log.Fatal(err)
 }
 
-info, err := track.Info(ctx)
+info, err := track.Info()
 if err != nil {
 	log.Fatal(err)
 }
@@ -228,7 +228,7 @@ producer, err := request.Accept()
 if err != nil {
     log.Fatal(err)
 }
-_ = producer.WriteFrame(loadArchivedFrame(request.Sequence()), request.Sequence()*20_000)
+_ = producer.WriteFrame(moq.Frame{Payload: loadArchivedFrame(request.Sequence()), TimestampUs: request.Sequence() * 20_000})
 _ = producer.Finish()
 ```
 
@@ -256,15 +256,15 @@ for request, err := range dynamic.Requests(ctx) {
 
 ## Raw track timestamps
 
-Raw tracks carry arbitrary byte payloads. `WriteFrame` takes a caller-supplied
-presentation timestamp in microseconds, and raw tracks default to a microsecond
-timescale. `ReadFrame` returns the timestamped raw frame:
+Raw tracks carry arbitrary byte payloads. `WriteFrame` takes a `Frame`, whose
+`TimestampUs` is a caller-supplied presentation timestamp in microseconds, and raw
+tracks default to a microsecond timescale. `ReadFrame` returns the timestamped raw frame:
 
 ```go
 track, _ := broadcast.PublishTrack("events", nil)
 consumer, _ := track.Consume(nil)
 
-_ = track.WriteFrame([]byte("ready"), 20_000)
+_ = track.WriteFrame(moq.Frame{Payload: []byte("ready"), TimestampUs: 20_000})
 
 frame, err := consumer.ReadFrame(ctx)
 if err != nil {
@@ -278,7 +278,7 @@ fmt.Println(string(frame.Payload), frame.TimestampUs)
 Raw tracks can send a single best-effort payload without opening a group stream:
 
 ```go
-sequence, err := track.AppendDatagram(42_000, []byte("meter update"))
+sequence, err := track.AppendDatagram(moq.Frame{Payload: []byte("meter update"), TimestampUs: 42_000})
 if err != nil {
     return err
 }
@@ -341,7 +341,7 @@ for request, err := range dynamic.Requests(ctx) {
 	if err := request.Accept(broadcast); err != nil {
 		log.Fatal(err)
 	}
-	if err := track.WriteFrame([]byte("ready"), 0); err != nil {
+	if err := track.WriteFrame(moq.Frame{Payload: []byte("ready")}); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -109,10 +109,10 @@ Moq.connect("https://relay.example.com").use { moq ->
     val broadcast = BroadcastProducer()
     val audio = broadcast.publishMedia(Init(format = "opus", data = opusInitBytes, video = null))
 
-    moq.announce("my-stream", broadcast)
+    val announce = moq.announce("my-stream", broadcast)
 
-    audio.writeFrame(payload, timestampUs = 0u)
-    audio.writeFrame(payload, timestampUs = 20_000u)
+    audio.writeFrame(Frame(payload = payload))
+    audio.writeFrame(Frame(payload = payload, timestampUs = 20_000u))
     audio.finish()
     broadcast.finish()
 }
@@ -127,7 +127,7 @@ import dev.moq.*
 
 Server.listen("127.0.0.1:4443", tlsGenerate = listOf("localhost")).use { server ->
     val broadcast = BroadcastProducer()
-    server.announce("live", broadcast)
+    val announce = server.announce("live", broadcast)
 
     server.serve()
 }
@@ -140,11 +140,11 @@ Server.listen("127.0.0.1:4443", tlsGenerate = listOf("localhost")).use { server 
     server.requests().collect { request ->
         val url = request.url()
         if (url != null && "/admin" in url) {
-            request.close(403u)
+            request.reject(403u)
             return@collect
         }
         launch {
-            val session = request.ok()
+            val session = request.accept()
             session.closed()
         }
     }
@@ -175,7 +175,7 @@ val dynamic = track.dynamic()
 
 dynamic.requestedGroups().collect { request ->
     val group = request.accept()
-    group.writeFrame(loadArchivedFrame(request.sequence()), timestampUs = request.sequence() * 20_000uL)
+    group.writeFrame(Frame(payload = loadArchivedFrame(request.sequence()), timestampUs = request.sequence() * 20_000uL))
     group.finish()
 }
 ```
@@ -193,12 +193,12 @@ Moq.connect("https://relay.example.com").use { moq ->
     val broadcast = BroadcastProducer()
     val dynamic = broadcast.dynamic()
 
-    moq.announce("events", broadcast)
+    val announce = moq.announce("events", broadcast)
 
     dynamic.requestedTracks().collect { request ->
         if (request.name() == "alerts") {
             val track = request.accept(null)
-            track.writeFrame(payload = "ready".encodeToByteArray(), timestampUs = 20_000u)
+            track.writeFrame(Frame(payload = "ready".encodeToByteArray(), timestampUs = 20_000u))
             track.finish()
         } else {
             request.abort(404u)
@@ -207,14 +207,14 @@ Moq.connect("https://relay.example.com").use { moq ->
 }
 ```
 
-Each requested track arrives as a `TrackRequest`; call `accept(info)` to turn it into a `TrackProducer` (pass `null` for defaults), or `abort(code)` to reject the subscriber. Use `writeFrame(payload, timestampUs)` with a presentation timestamp in microseconds. Raw tracks default to a microsecond timescale. Raw consumers receive `MoqFrame` values from `readFrame()` or the `frames()` Flow extension.
+Each requested track arrives as a `TrackRequest`; call `accept(info)` to turn it into a `TrackProducer` (pass `null` for defaults), or `abort(code)` to reject the subscriber. Use `writeFrame(Frame(payload, timestampUs))` with a presentation timestamp in microseconds. Raw tracks default to a microsecond timescale. Raw consumers receive `Frame` values (payload plus timestamp) from `readFrame()` or the `frames()` Flow extension; media subscriptions yield `MediaFrame`, which adds the codec-derived `keyframe` flag.
 
 ### Raw datagrams
 
 Raw tracks can send a single best-effort payload without opening a group stream:
 
 ```kotlin
-val sequence = track.appendDatagram(timestampUs = 42_000u, payload = "meter update".encodeToByteArray())
+val sequence = track.appendDatagram(Frame(payload = "meter update".encodeToByteArray(), timestampUs = 42_000u))
 val datagram = consumer.recvDatagram()
 
 consumer.datagrams().collect { datagram ->
@@ -239,7 +239,7 @@ dynamic.requestedBroadcasts().collect { request ->
         val broadcast = BroadcastProducer()
         val track = broadcast.publishTrack("status", null)
         request.accept(broadcast)
-        track.writeFrame("ready".encodeToByteArray(), timestampUs = 0u)
+        track.writeFrame(Frame(payload = "ready".encodeToByteArray()))
     } else {
         request.abort(404u)
     }

--- a/doc/lib/py/index.md
+++ b/doc/lib/py/index.md
@@ -73,7 +73,7 @@ async def main():
     async with moq.Client("https://relay.quic.video") as client:
         broadcast = moq.BroadcastProducer()
         audio = broadcast.publish_media("opus", opus_init_bytes)
-        client.announce("my-stream", broadcast)
+        announce = client.announce("my-stream", broadcast)
 
         audio.write_frame(payload, timestamp_us=0)
         audio.write_frame(payload, timestamp_us=20_000)

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -23,6 +23,8 @@ Requires Python 3.10+. The distribution is `moq-rs` (the `moq` name is taken on 
 
 A **broadcast** is a collection of tracks identified by a path. A **track** is a live stream of frames. Producers write broadcasts to an origin; consumers subscribe to whatever has been announced.
 
+`announce` returns an `Announce` handle that owns the announcement: the broadcast stays discoverable until you call `unannounce()` or drop the handle. Closing the broadcast does not unannounce it, so keep the handle alive for as long as the path should resolve.
+
 For unstructured byte streams (status, commands, sensor data), use `publish_track` / `subscribe_track`. For media with a known container format (audio/video), use `publish_media` / `subscribe_media` and the catalog will be populated automatically.
 
 ## API summary
@@ -55,7 +57,7 @@ except moq.Error as err:
 ```python
 broadcast = moq.BroadcastProducer()
 audio = broadcast.publish_media("opus", opus_init_bytes)
-client.announce("my-stream", broadcast)
+announce = client.announce("my-stream", broadcast)
 
 audio.write_frame(payload, timestamp_us=0)
 audio.finish()
@@ -98,7 +100,7 @@ import json
 # Publish: attach a custom section.
 broadcast = moq.BroadcastProducer()
 broadcast.set_catalog_section("transcript", {"track": "transcript.json"})
-client.announce("my-stream", broadcast)
+announce = client.announce("my-stream", broadcast)
 
 # Subscribe: read it back. Sections are unknown to the base catalog, so decode the JSON yourself.
 catalog = await announcement.broadcast.catalog()
@@ -123,14 +125,14 @@ track = await broadcast_consumer.subscribe_track(
     "events",
     subscription=moq.Subscription(priority=10),
 )
-info = await track.info()
+info = track.info()
 track.update(moq.Subscription(priority=20, ordered=False))
 async for group in track:
     async for frame in group:
         print(frame.timestamp_us, frame.payload)
 ```
 
-`write_frame` on a track creates a one-frame group by default, using a microsecond raw-track timescale. Consumers receive a `Frame` from `read_frame()` or group iteration, including `payload`, `timestamp_us`, and `keyframe`. Use `append_group()` for multi-frame groups (e.g., a video GOP).
+`write_frame` on a track creates a one-frame group by default, using a microsecond raw-track timescale. Consumers receive a `Frame` from `read_frame()` or group iteration, carrying `payload` and `timestamp_us`. (Media tracks yield a `MediaFrame`, which adds the codec-derived `keyframe` flag.) Use `append_group()` for multi-frame groups (e.g., a video GOP).
 Use `create_group(sequence)` for sparse or replayed groups. `finish_at(final_sequence)` declares the exclusive end while still permitting lower groups to arrive, and `abort(error_code)` terminates a track or group with an application error.
 `TrackConsumer.info()` returns the publisher's track properties (timescale, cache, priority, ordering priority), and `update()` changes this subscriber's delivery preferences without resubscribing.
 `ordered` controls prioritization only. When true, groups are prioritized in sequence order. Groups may always arrive out-of-order (or not at all) over the network.
@@ -167,7 +169,7 @@ Call `request.abort(code)` when the requested group cannot be produced. Fetch is
 Raw tracks can also send best-effort datagrams:
 
 ```python
-seq = track.append_datagram(timestamp_us=42_000, payload=b"meter update")
+seq = track.append_datagram(b"meter update", timestamp_us=42_000)
 datagram = await track_consumer.recv_datagram()
 ```
 
@@ -206,7 +208,7 @@ Use a dynamic broadcast when subscribers should be able to request raw tracks th
 ```python
 broadcast = moq.BroadcastProducer()
 dynamic = broadcast.dynamic()
-client.announce("events", broadcast)
+announce = client.announce("events", broadcast)
 
 async for request in dynamic:
     if request.name == "alerts":

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -87,7 +87,7 @@ Raw track subscribers can query the publisher's track properties and change thei
 let track = try await announcement.broadcast.subscribeTrack(
     name: "events",
     subscription: Subscription(priority: 10))
-let info = try await track.info()
+let info = try track.info()
 track.update(subscription: Subscription(priority: 20, ordered: false))
 ```
 
@@ -99,7 +99,7 @@ track.update(subscription: Subscription(priority: 20, ordered: false))
 let broadcast = try BroadcastProducer()
 let audio = try broadcast.publishMedia(format: "opus", initData: opusInitBytes)
 
-try session.publisher.announce(path: "my-stream", broadcast: broadcast)
+let announce = try session.publisher.announce(path: "my-stream", broadcast: broadcast)
 
 try audio.writeFrame(payload, timestampUs: 0)
 try audio.writeFrame(payload, timestampUs: 20_000)
@@ -148,7 +148,7 @@ Use a dynamic broadcast when subscribers should be able to request raw tracks th
 let broadcast = try BroadcastProducer()
 let dynamic = try broadcast.dynamic()
 
-try session.publisher.announce(path: "events", broadcast: broadcast)
+let announce = try session.publisher.announce(path: "events", broadcast: broadcast)
 
 for try await request in dynamic {
     if try request.name == "alerts" {
@@ -161,14 +161,14 @@ for try await request in dynamic {
 }
 ```
 
-Each request arrives as a `TrackRequest`; call `accept(info:)` to turn it into a `TrackProducer` (omit `info` for defaults), or `abort(errorCode:)` to reject the subscriber. Use `writeFrame(_:timestampUs:)` with a presentation timestamp in microseconds. Raw tracks default to a microsecond timescale. Raw consumers receive `Frame` values from `readFrame()` and group iteration.
+Each request arrives as a `TrackRequest`; call `accept(info:)` to turn it into a `TrackProducer` (omit `info` for defaults), or `abort(errorCode:)` to reject the subscriber. Use `writeFrame(_:timestampUs:)` with a presentation timestamp in microseconds. Raw tracks default to a microsecond timescale. Raw consumers receive `Frame` values (payload plus timestamp) from `readFrame()` and group iteration; media subscriptions yield `MediaFrame`, which adds the codec-derived `keyframe` flag.
 
 ### Raw datagrams
 
 Raw tracks can send a single best-effort payload without opening a group stream:
 
 ```swift
-let sequence = try track.appendDatagram(timestampUs: 42_000, payload: Data("meter update".utf8))
+let sequence = try track.appendDatagram(Data("meter update".utf8), timestampUs: 42_000)
 let datagram = try await consumer.recvDatagram()
 
 for try await datagram in consumer.datagrams {

--- a/go/wrapper/README.md
+++ b/go/wrapper/README.md
@@ -87,7 +87,7 @@ until the owning producer/server is closed. See the package doc for details.
 ## Raw datagrams
 
 Raw tracks support best-effort datagrams alongside groups: `TrackProducer.AppendDatagram`
-sends one payload and returns its sequence number, while `TrackConsumer.RecvDatagram`
+sends one `Frame` and returns its sequence number, while `TrackConsumer.RecvDatagram`
 and `TrackConsumer.Datagrams` receive them in arrival order. Payloads are capped at
 1200 bytes. Datagram delivery requires a datagram-capable transport and lite-05 or
 newer moq-lite; IETF moq-transport, pre-lite-05, WebSocket, and TCP paths do not

--- a/go/wrapper/moq/client.go
+++ b/go/wrapper/moq/client.go
@@ -87,16 +87,14 @@ func WithSubscribeOrigin(o *OriginProducer) ClientOption {
 }
 
 // Client is a connected MoQ client with automatic origin wiring. When no origin
-// option is given, Dial creates a shared internal origin used for both
-// publishing and consuming.
+// option is given, both sides share one origin, so a broadcast announced here is
+// also discoverable here.
 type Client struct {
-	inner         *ffi.MoqClient
-	origin        *OriginProducer
-	publishOrigin *OriginProducer
-	consumeOrigin *OriginProducer
-	consumer      *OriginConsumer
-	session       *Session
-	closeOnce     sync.Once
+	inner     *ffi.MoqClient
+	publisher *OriginProducer
+	consumer  *OriginConsumer
+	session   *Session
+	closeOnce sync.Once
 }
 
 // Dial connects to a MoQ server and returns the established client. Cancel ctx
@@ -110,15 +108,6 @@ func Dial(ctx context.Context, url string, opts ...ClientOption) (*Client, error
 	}
 
 	c := &Client{}
-	if cfg.publish == nil && cfg.subscribe == nil {
-		c.origin = NewOriginProducer()
-		c.publishOrigin = c.origin
-		c.consumeOrigin = c.origin
-	} else {
-		c.publishOrigin = cfg.publish
-		c.consumeOrigin = cfg.subscribe
-	}
-
 	inner := ffi.NewMoqClient()
 	if !cfg.tlsVerify {
 		inner.SetTlsDisableVerify(true)
@@ -144,11 +133,11 @@ func Dial(ctx context.Context, url string, opts ...ClientOption) (*Client, error
 			return nil, err
 		}
 	}
-	if c.publishOrigin != nil {
-		inner.SetPublish(&c.publishOrigin.inner)
+	if cfg.publish != nil {
+		inner.SetPublish(&cfg.publish.inner)
 	}
-	if c.consumeOrigin != nil {
-		inner.SetConsume(&c.consumeOrigin.inner)
+	if cfg.subscribe != nil {
+		inner.SetConsume(&cfg.subscribe.inner)
 	}
 	c.inner = inner
 
@@ -161,42 +150,33 @@ func Dial(ctx context.Context, url string, opts ...ClientOption) (*Client, error
 	}
 	c.session = &Session{inner: session}
 
-	// Only a configured consume origin yields a consumer. A publish-only client
-	// has none, so Announced/AnnouncedBroadcast surface ErrNoConsumeOrigin
-	// rather than silently reading from the local publish origin.
-	if c.consumeOrigin != nil {
-		c.consumer = c.consumeOrigin.Consume()
-	}
+	// The session always exposes both sides, wired from the options above or auto-created,
+	// so publishing and discovery always have somewhere to go.
+	c.publisher = c.session.Publisher()
+	c.consumer = c.session.Consumer()
 
 	return c, nil
 }
 
 // Announce advertises a broadcast under path so the remote can discover it.
-func (c *Client) Announce(path string, broadcast *BroadcastProducer) error {
-	if c.publishOrigin == nil {
-		return ErrNoPublishOrigin
-	}
-	return c.publishOrigin.Announce(path, broadcast)
+//
+// Hold the returned Announce for as long as the broadcast should stay discoverable.
+func (c *Client) Announce(path string, broadcast *BroadcastProducer) (*Announce, error) {
+	return c.publisher.Announce(path, broadcast)
 }
 
 // Deprecated: use Announce.
-func (c *Client) Publish(path string, broadcast *BroadcastProducer) error {
+func (c *Client) Publish(path string, broadcast *BroadcastProducer) (*Announce, error) {
 	return c.Announce(path, broadcast)
 }
 
 // Announced streams broadcasts announced by the remote under prefix.
 func (c *Client) Announced(prefix string) (*Announced, error) {
-	if c.consumer == nil {
-		return nil, ErrNoConsumeOrigin
-	}
 	return c.consumer.Announced(prefix)
 }
 
 // AnnouncedBroadcast resolves a single announced broadcast at path.
 func (c *Client) AnnouncedBroadcast(path string) (*AnnouncedBroadcast, error) {
-	if c.consumer == nil {
-		return nil, ErrNoConsumeOrigin
-	}
 	return c.consumer.AnnouncedBroadcast(path)
 }
 
@@ -204,9 +184,6 @@ func (c *Client) AnnouncedBroadcast(path string) (*AnnouncedBroadcast, error) {
 // announced broadcast if present, otherwise a dynamic fallback on the origin, or an
 // error. Unlike AnnouncedBroadcast, it does not wait for a future announcement.
 func (c *Client) RequestBroadcast(path string) (*BroadcastConsumer, error) {
-	if c.consumer == nil {
-		return nil, ErrNoConsumeOrigin
-	}
 	return c.consumer.RequestBroadcast(path)
 }
 

--- a/go/wrapper/moq/errors.go
+++ b/go/wrapper/moq/errors.go
@@ -15,7 +15,6 @@ type Error = ffi.MoqError
 // Configuration errors returned by the wrapper itself (not the FFI layer).
 var (
 	ErrNoPublishOrigin = errors.New("moq: no publish origin configured")
-	ErrNoConsumeOrigin = errors.New("moq: no consume origin configured")
 )
 
 // Error sentinels re-exported from the ffi layer without the MoqError prefix, so

--- a/go/wrapper/moq/example_test.go
+++ b/go/wrapper/moq/example_test.go
@@ -57,10 +57,14 @@ func ExampleClient_Publish() {
 		log.Fatal(err)
 	}
 
-	if err := client.Announce("me/mic", broadcast); err != nil {
+	announce, err := client.Announce("me/mic", broadcast)
+	if err != nil {
 		log.Fatal(err)
 	}
-	if err := media.WriteFrame([]byte("opus frame"), 0); err != nil {
+	// The broadcast stays announced until this handle goes away.
+	defer announce.Unannounce()
+
+	if err := media.WriteFrame(moq.Frame{Payload: []byte("opus frame")}); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -133,11 +137,11 @@ func ExampleServer_Requests() {
 
 		// Reject anything that didn't arrive over QUIC.
 		if req.Transport() != moq.TransportQUIC {
-			_ = req.Close(ctx, 403)
+			_ = req.Reject(ctx, 403)
 			continue
 		}
 
-		session, err := req.OK(ctx)
+		session, err := req.Accept(ctx)
 		if err != nil {
 			continue
 		}

--- a/go/wrapper/moq/json.go
+++ b/go/wrapper/moq/json.go
@@ -8,12 +8,26 @@ import (
 	ffi "github.com/moq-dev/moq-go-ffi/moq"
 )
 
+// DefaultDeltaRatio is used when [JSONSnapshotOptions.DeltaRatio] is nil. Go has no field
+// defaults, so unlike the other bindings this restates the `#[uniffi(default = 8)]` on
+// moq-ffi's MoqJsonSnapshotConfig (itself pinned to moq-json's default by a Rust test).
+const DefaultDeltaRatio uint32 = 8
+
 // JSONSnapshotOptions configures publishing a lossy latest-value JSON track.
 type JSONSnapshotOptions struct {
-	// DeltaRatio controls how aggressively deltas replace full snapshots. Zero disables deltas.
-	DeltaRatio uint32
+	// DeltaRatio controls how aggressively deltas replace full snapshots. Nil uses
+	// [DefaultDeltaRatio]; a pointer to zero disables deltas entirely.
+	DeltaRatio *uint32
 	// Compression enables group-scoped DEFLATE and must match on the consumer.
 	Compression bool
+}
+
+// deltaRatio resolves the configured ratio, falling back to the shared default.
+func (o JSONSnapshotOptions) deltaRatio() uint32 {
+	if o.DeltaRatio == nil {
+		return DefaultDeltaRatio
+	}
+	return *o.DeltaRatio
 }
 
 // JSONStreamOptions configures publishing a lossless append-log JSON track.
@@ -125,7 +139,7 @@ func (b *BroadcastProducer) PublishJSONSnapshot(
 	options JSONSnapshotOptions,
 ) (*JSONSnapshotProducer, error) {
 	inner, err := b.inner.PublishJsonSnapshot(name, ffi.MoqJsonSnapshotConfig{
-		DeltaRatio:  options.DeltaRatio,
+		DeltaRatio:  options.deltaRatio(),
 		Compression: options.Compression,
 	})
 	if err != nil {

--- a/go/wrapper/moq/moq_test.go
+++ b/go/wrapper/moq/moq_test.go
@@ -93,7 +93,7 @@ func TestDynamicBroadcastRequest(t *testing.T) {
 	defer trackConsumer.Cancel()
 
 	payload := []byte("served dynamically")
-	if err := track.WriteFrame(payload, 0); err != nil {
+	if err := track.WriteFrame(moq.Frame{Payload: payload, TimestampUs: 0}); err != nil {
 		t.Fatal(err)
 	}
 	frame, err := trackConsumer.ReadFrame(ctx)
@@ -121,7 +121,7 @@ func TestPublishMediaLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := media.WriteFrame([]byte("opus frame"), 1000); err != nil {
+	if err := media.WriteFrame(moq.Frame{Payload: []byte("opus frame"), TimestampUs: 1000}); err != nil {
 		t.Fatal(err)
 	}
 	if err := media.Finish(); err != nil {
@@ -153,7 +153,7 @@ func TestFetchGroupAndServeDynamicMiss(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := cached.WriteFrame([]byte("cached"), 0); err != nil {
+	if err := cached.WriteFrame(moq.Frame{Payload: []byte("cached"), TimestampUs: 0}); err != nil {
 		t.Fatal(err)
 	}
 	if err := cached.Finish(); err != nil {
@@ -194,7 +194,7 @@ func TestFetchGroupAndServeDynamicMiss(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := produced.WriteFrame([]byte("archive"), request.Sequence()*20_000); err != nil {
+	if err := produced.WriteFrame(moq.Frame{Payload: []byte("archive"), TimestampUs: request.Sequence()*20_000}); err != nil {
 		t.Fatal(err)
 	}
 	if err := produced.Finish(); err != nil {
@@ -234,9 +234,12 @@ func TestLocalPublishConsumeAudio(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := origin.Announce("live", broadcast); err != nil {
+	announce, err := origin.Announce("live", broadcast)
+	if err != nil {
 		t.Fatal(err)
 	}
+	// The announcement lives as long as this handle, so keep it past the reads below.
+	defer announce.Unannounce()
 
 	consumer := origin.Consume()
 	announced, err := consumer.Announced("")
@@ -283,7 +286,7 @@ func TestLocalPublishConsumeAudio(t *testing.T) {
 	defer mediaConsumer.Cancel()
 
 	payload := []byte("opus audio payload data")
-	if err := media.WriteFrame(payload, 1_000_000); err != nil {
+	if err := media.WriteFrame(moq.Frame{Payload: payload, TimestampUs: 1_000_000}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -317,7 +320,7 @@ func TestTrackPublishConsume(t *testing.T) {
 	}
 	defer consumer.Cancel()
 
-	if err := track.WriteFrame([]byte("hello"), 12_345); err != nil {
+	if err := track.WriteFrame(moq.Frame{Payload: []byte("hello"), TimestampUs: 12_345}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -341,7 +344,7 @@ func TestTrackPublishConsume(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer groupConsumer.Cancel()
-	if err := group.WriteFrame([]byte("group"), 23_456); err != nil {
+	if err := group.WriteFrame(moq.Frame{Payload: []byte("group"), TimestampUs: 23_456}); err != nil {
 		t.Fatal(err)
 	}
 	if err := group.Finish(); err != nil {
@@ -409,7 +412,7 @@ func TestJSONTracks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	snapshot, err := broadcast.PublishJSONSnapshot("status", moq.JSONSnapshotOptions{DeltaRatio: 8, Compression: true})
+	snapshot, err := broadcast.PublishJSONSnapshot("status", moq.JSONSnapshotOptions{Compression: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -509,7 +512,7 @@ func TestDynamicTrackRequest(t *testing.T) {
 		t.Fatal(err)
 	}
 	payload := []byte("hello dynamic track")
-	if err := track.WriteFrame(payload, 0); err != nil {
+	if err := track.WriteFrame(moq.Frame{Payload: payload, TimestampUs: 0}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -608,7 +611,7 @@ func TestDynamicTrackRequestCanPublishMedia(t *testing.T) {
 	defer mediaConsumer.Cancel()
 
 	payload := []byte("dynamic opus frame")
-	if err := media.WriteFrame(payload, 20_000); err != nil {
+	if err := media.WriteFrame(moq.Frame{Payload: payload, TimestampUs: 20_000}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/wrapper/moq/origin.go
+++ b/go/wrapper/moq/origin.go
@@ -36,16 +36,35 @@ func (o *OriginProducer) Dynamic() *OriginDynamic {
 }
 
 // Announce advertises a broadcast at the given path so subscribers can discover it.
-func (o *OriginProducer) Announce(path string, broadcast *BroadcastProducer) error {
+//
+// Hold the returned Announce for as long as the broadcast should stay discoverable;
+// unannouncing it removes the path. Closing the broadcast does not unannounce it.
+func (o *OriginProducer) Announce(path string, broadcast *BroadcastProducer) (*Announce, error) {
 	if broadcast == nil {
-		return errors.New("moq: nil broadcast producer")
+		return nil, errors.New("moq: nil broadcast producer")
 	}
-	return o.inner.Announce(path, broadcast.inner)
+	inner, err := o.inner.Announce(path, broadcast.inner)
+	if err != nil {
+		return nil, err
+	}
+	return &Announce{inner: inner}, nil
 }
 
 // Deprecated: use Announce.
-func (o *OriginProducer) Publish(path string, broadcast *BroadcastProducer) error {
+func (o *OriginProducer) Publish(path string, broadcast *BroadcastProducer) (*Announce, error) {
 	return o.Announce(path, broadcast)
+}
+
+// Announce is a live announcement returned by [OriginProducer.Announce]: the publish-side
+// guard keeping one broadcast announced. The subscribe-side [Announced] is the unrelated
+// stream of announcements arriving from a remote.
+type Announce struct {
+	inner *ffi.MoqAnnounce
+}
+
+// Unannounce removes the broadcast from the origin. Idempotent.
+func (a *Announce) Unannounce() {
+	a.inner.Unannounce()
 }
 
 // OriginDynamic streams broadcast requests for paths that are not announced.

--- a/go/wrapper/moq/publish.go
+++ b/go/wrapper/moq/publish.go
@@ -218,9 +218,10 @@ func (m *MediaProducer) Unused(ctx context.Context) error {
 	return runErr(ctx, nil, m.inner.Unused)
 }
 
-// WriteFrame appends a frame with a presentation timestamp in microseconds.
-func (m *MediaProducer) WriteFrame(payload []byte, timestampUs uint64) error {
-	return m.inner.WriteFrame(payload, timestampUs)
+// WriteFrame appends frame to the media track. The importer derives keyframe status from
+// the bitstream, so a Frame carries only the payload and its timestamp.
+func (m *MediaProducer) WriteFrame(frame Frame) error {
+	return m.inner.WriteFrame(frame)
 }
 
 // Finish closes the media track.
@@ -293,16 +294,15 @@ func (t *TrackProducer) CreateGroup(sequence uint64) (*GroupProducer, error) {
 	return &GroupProducer{inner: inner}, nil
 }
 
-// WriteFrame writes a single-frame group with a timestamp in microseconds.
-func (t *TrackProducer) WriteFrame(payload []byte, timestampUs uint64) error {
-	return t.inner.WriteFrame(payload, timestampUs)
+// WriteFrame writes frame as a single-frame group.
+func (t *TrackProducer) WriteFrame(frame Frame) error {
+	return t.inner.WriteFrame(frame)
 }
 
-// AppendDatagram sends a best-effort datagram and returns its sequence number.
-// timestampUs is the presentation timestamp in microseconds. Payloads are capped
-// at 1200 bytes. There is no stream fallback.
-func (t *TrackProducer) AppendDatagram(timestampUs uint64, payload []byte) (uint64, error) {
-	return t.inner.AppendDatagram(timestampUs, payload)
+// AppendDatagram sends frame as a best-effort datagram and returns the sequence number
+// assigned to it. Payloads are capped at 1200 bytes. There is no stream fallback.
+func (t *TrackProducer) AppendDatagram(frame Frame) (uint64, error) {
+	return t.inner.AppendDatagram(frame)
 }
 
 // Abort closes the track with an application error code.
@@ -350,9 +350,9 @@ func (g *GroupProducer) Consume() (*GroupConsumer, error) {
 	return &GroupConsumer{inner: inner}, nil
 }
 
-// WriteFrame appends a frame with a timestamp in microseconds.
-func (g *GroupProducer) WriteFrame(payload []byte, timestampUs uint64) error {
-	return g.inner.WriteFrame(payload, timestampUs)
+// WriteFrame appends frame to the group.
+func (g *GroupProducer) WriteFrame(frame Frame) error {
+	return g.inner.WriteFrame(frame)
 }
 
 // Finish closes the group.

--- a/go/wrapper/moq/server.go
+++ b/go/wrapper/moq/server.go
@@ -19,7 +19,7 @@ const (
 	TransportWebSocket Transport = "websocket"
 )
 
-// Request is an incoming session that can be accepted (OK) or rejected (Close).
+// Request is an incoming session that can be accepted (Accept) or rejected (Reject).
 // Dropping a Request without responding closes the connection silently.
 type Request struct {
 	inner *ffi.MoqRequest
@@ -55,24 +55,24 @@ func (r *Request) SetConsume(o *OriginProducer) {
 	r.inner.SetConsume(&o.inner)
 }
 
-// OK completes the handshake and returns the established session. Hold the
+// Accept completes the handshake and returns the established session. Hold the
 // session to keep the connection alive.
-func (r *Request) OK(ctx context.Context) (*Session, error) {
-	inner, err := runCancellable(ctx, r.inner.Cancel, r.inner.Ok)
+func (r *Request) Accept(ctx context.Context) (*Session, error) {
+	inner, err := runCancellable(ctx, r.inner.Cancel, r.inner.Accept)
 	if err != nil {
 		return nil, err
 	}
 	return &Session{inner: inner}, nil
 }
 
-// Close rejects the session with an HTTP status code (default convention: 404).
-func (r *Request) Close(ctx context.Context, code uint16) error {
+// Reject refuses the session with an HTTP status code (default convention: 404).
+func (r *Request) Reject(ctx context.Context, code uint16) error {
 	return runErr(ctx, r.inner.Cancel, func() error {
-		return r.inner.Close(code)
+		return r.inner.Reject(code)
 	})
 }
 
-// Cancel aborts an in-flight OK or Close.
+// Cancel aborts an in-flight Accept or Reject.
 func (r *Request) Cancel() {
 	r.inner.Cancel()
 }
@@ -186,15 +186,17 @@ func (s *Server) CertFingerprints() ([]string, error) {
 }
 
 // Announce advertises a broadcast under path, served to incoming sessions.
-func (s *Server) Announce(path string, broadcast *BroadcastProducer) error {
+//
+// Hold the returned Announce for as long as the broadcast should stay discoverable.
+func (s *Server) Announce(path string, broadcast *BroadcastProducer) (*Announce, error) {
 	if s.publishOrigin == nil {
-		return ErrNoPublishOrigin
+		return nil, ErrNoPublishOrigin
 	}
 	return s.publishOrigin.Announce(path, broadcast)
 }
 
 // Deprecated: use Announce.
-func (s *Server) Publish(path string, broadcast *BroadcastProducer) error {
+func (s *Server) Publish(path string, broadcast *BroadcastProducer) (*Announce, error) {
 	return s.Announce(path, broadcast)
 }
 
@@ -217,7 +219,7 @@ func (s *Server) Accept(ctx context.Context) (*Request, error) {
 }
 
 // Requests ranges over incoming requests until the server stops or the loop
-// breaks. Each request must be answered with OK or Close.
+// breaks. Each request must be answered with Accept or Reject.
 func (s *Server) Requests(ctx context.Context) iter.Seq2[*Request, error] {
 	return func(yield func(*Request, error) bool) {
 		for {
@@ -248,10 +250,10 @@ func (s *Server) Requests(ctx context.Context) iter.Seq2[*Request, error] {
 //	        return err
 //	    }
 //	    if url := req.URL(); url != nil && strings.Contains(*url, "/admin") {
-//	        _ = req.Close(ctx, 403)
+//	        _ = req.Reject(ctx, 403)
 //	        continue
 //	    }
-//	    session, err := req.OK(ctx)
+//	    session, err := req.Accept(ctx)
 //	    // hold the session to keep the connection alive
 //	}
 func (s *Server) Serve(ctx context.Context) error {
@@ -275,7 +277,7 @@ func (s *Server) Serve(ctx context.Context) error {
 		wg.Add(1)
 		go func(req *Request) {
 			defer wg.Done()
-			session, err := req.OK(ctx)
+			session, err := req.Accept(ctx)
 			if err != nil {
 				return
 			}

--- a/go/wrapper/moq/subscribe.go
+++ b/go/wrapper/moq/subscribe.go
@@ -87,12 +87,12 @@ type MediaConsumer struct {
 }
 
 // Next returns the next frame, or (nil, nil) when the track ends.
-func (m *MediaConsumer) Next(ctx context.Context) (*Frame, error) {
+func (m *MediaConsumer) Next(ctx context.Context) (*MediaFrame, error) {
 	return runCancellable(ctx, m.inner.Cancel, m.inner.Next)
 }
 
 // Frames ranges over frames until the track ends or the loop breaks.
-func (m *MediaConsumer) Frames(ctx context.Context) iter.Seq2[*Frame, error] {
+func (m *MediaConsumer) Frames(ctx context.Context) iter.Seq2[*MediaFrame, error] {
 	return streamSeq(ctx, m.Next)
 }
 
@@ -173,8 +173,8 @@ func (t *TrackConsumer) RecvDatagram(ctx context.Context) (*Datagram, error) {
 }
 
 // Info returns the publisher-side track properties learned during subscription.
-func (t *TrackConsumer) Info(ctx context.Context) (TrackInfo, error) {
-	return runCancellable(ctx, nil, t.inner.Info)
+func (t *TrackConsumer) Info() (TrackInfo, error) {
+	return t.inner.Info()
 }
 
 // Update changes this subscriber's delivery preferences.

--- a/go/wrapper/moq/types.go
+++ b/go/wrapper/moq/types.go
@@ -18,6 +18,7 @@ type (
 	Datagram           = ffi.MoqDatagram
 	Dimensions         = ffi.MoqDimensions
 	Frame              = ffi.MoqFrame
+	MediaFrame         = ffi.MoqMediaFrame
 	FetchGroupOptions  = ffi.MoqFetchGroupOptions
 	OriginOptions      = ffi.MoqOriginOptions
 	Subscription       = ffi.MoqSubscription
@@ -27,10 +28,10 @@ type (
 
 	// Container selects how subscribed media frames are demuxed. Build one with
 	// LegacyContainer, CmafContainer, or LocContainer.
-	Container       = ffi.Container
-	ContainerLegacy = ffi.ContainerLegacy
-	ContainerCmaf   = ffi.ContainerCmaf
-	ContainerLoc    = ffi.ContainerLoc
+	Container       = ffi.MoqContainer
+	ContainerLegacy = ffi.MoqContainerLegacy
+	ContainerCmaf   = ffi.MoqContainerCmaf
+	ContainerLoc    = ffi.MoqContainerLoc
 )
 
 // LegacyContainer selects the legacy hang container for a media subscription.

--- a/kt/README.md
+++ b/kt/README.md
@@ -48,7 +48,7 @@ The `dev.moq` package is intentionally thin: Kotlin has extension functions, so 
 - **Typealiases** (`Aliases.kt`): re-export the `Moq*`-prefixed FFI types under clean `dev.moq` names (`OriginProducer`, `BroadcastConsumer`, `Catalog`, `Frame`, ...), so you import `dev.moq.*` only. A couple of sealed types (`Container`, `MoqException`) are not aliased because Kotlin can't resolve their subtypes through a typealias; use `uniffi.moq.*` for those.
 - **Flow extensions** (`Flows.kt`): `updates()`, `groups()`, `frames()`, `announcements()`, `catalog()` turn the pull-based consumers into coroutine `Flow`s with cancellation wired through.
 - **`logLevel(...)`**: configures native Rust tracing without importing the raw bindings package.
-- **Raw datagrams**: `TrackProducer.appendDatagram(timestampUs, payload)` sends one best-effort payload and returns its sequence; `TrackConsumer.recvDatagram()` and `datagrams()` receive them. Payloads are capped at 1200 bytes, require a datagram-capable transport plus lite-05 or newer moq-lite, and have no stream fallback.
+- **Raw datagrams**: `TrackProducer.appendDatagram(Frame(payload, timestampUs))` sends one best-effort frame and returns its sequence; `TrackConsumer.recvDatagram()` and `datagrams()` receive them. Payloads are capped at 1200 bytes, require a datagram-capable transport plus lite-05 or newer moq-lite, and have no stream fallback.
 - **`MoqException.isShutdown`** (`Errors.kt`): true for the graceful `Cancelled`/`Closed` cases.
 
 ## Versioning

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -19,6 +19,8 @@ typealias OriginOptions = uniffi.moq.MoqOriginOptions
 typealias OriginConsumer = uniffi.moq.MoqOriginConsumer
 typealias OriginDynamic = uniffi.moq.MoqOriginDynamic
 typealias BroadcastRequest = uniffi.moq.MoqBroadcastRequest
+/** The publish-side guard keeping one broadcast announced; unannounce it to remove the path. */
+typealias Announce = uniffi.moq.MoqAnnounce
 typealias Announced = uniffi.moq.MoqAnnounced
 typealias AnnouncedBroadcast = uniffi.moq.MoqAnnouncedBroadcast
 typealias Announcement = uniffi.moq.MoqAnnouncement
@@ -56,6 +58,8 @@ typealias JsonStreamConsumer = uniffi.moq.MoqJsonStreamConsumer
 typealias Catalog = uniffi.moq.MoqCatalog
 typealias Datagram = uniffi.moq.MoqDatagram
 typealias Frame = uniffi.moq.MoqFrame
+/** A [Frame] plus the codec metadata a media track carries. */
+typealias MediaFrame = uniffi.moq.MoqMediaFrame
 typealias Video = uniffi.moq.MoqVideo
 /** Caller-provided catalog fields for a video track. */
 typealias VideoHint = uniffi.moq.MoqVideoHint
@@ -79,8 +83,8 @@ typealias JsonSnapshotConfig = uniffi.moq.MoqJsonSnapshotConfig
 /** Configures a lossless JSON stream track. */
 typealias JsonStreamConfig = uniffi.moq.MoqJsonStreamConfig
 
-// NOTE: a few types are intentionally NOT aliased. `Container` (sealed) and
-// `MoqException` (sealed) need subtype access (`Container.Loc`,
+// NOTE: a few types are intentionally NOT aliased. `MoqContainer` (sealed) and
+// `MoqException` (sealed) need subtype access (`MoqContainer.Loc`,
 // `MoqException.Closed`), which Kotlin 2.0.21 can't resolve through a typealias.
-// Reference those as `uniffi.moq.Container` / `uniffi.moq.MoqException`. Enums
+// Reference those as `uniffi.moq.MoqContainer` / `uniffi.moq.MoqException`. Enums
 // (AudioCodec/AudioFormat) are fine: entry access through the alias works.

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Flows.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Flows.kt
@@ -22,6 +22,7 @@ import uniffi.moq.MoqGroupRequest
 import uniffi.moq.MoqJsonSnapshotConsumer
 import uniffi.moq.MoqJsonStreamConsumer
 import uniffi.moq.MoqMediaConsumer
+import uniffi.moq.MoqMediaFrame
 import uniffi.moq.MoqOriginConsumer
 import uniffi.moq.MoqOriginDynamic
 import uniffi.moq.MoqTrackConsumer
@@ -59,7 +60,7 @@ suspend fun MoqBroadcastConsumer.catalog(): MoqCatalog {
 }
 
 /** Stream of decoded media frames in decode order. */
-fun MoqMediaConsumer.frames(): Flow<MoqFrame> = flow {
+fun MoqMediaConsumer.frames(): Flow<MoqMediaFrame> = flow {
     while (true) {
         currentCoroutineContext().ensureActive()
         emit(next() ?: break)

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt
@@ -26,15 +26,16 @@ class Moq internal constructor(
     val session: MoqSession,
     private val client: MoqClient,
 ) : AutoCloseable {
-    /** Announce [broadcast] under [path] so subscribers can discover it. */
-    fun announce(path: String, broadcast: BroadcastProducer) {
-        session.publisher().announce(path, broadcast)
-    }
+    /**
+     * Announce [broadcast] under [path] so subscribers can discover it.
+     *
+     * Hold the returned [Announce] for as long as the broadcast should stay discoverable;
+     * unannouncing it removes the path. Closing the broadcast does not unannounce it.
+     */
+    fun announce(path: String, broadcast: BroadcastProducer): Announce = session.publisher().announce(path, broadcast)
 
     @Deprecated("Renamed to announce()", ReplaceWith("announce(path, broadcast)"))
-    fun publish(path: String, broadcast: BroadcastProducer) {
-        announce(path, broadcast)
-    }
+    fun publish(path: String, broadcast: BroadcastProducer): Announce = announce(path, broadcast)
 
     /**
      * Discover broadcasts whose path starts with [prefix] as a [Flow]. The
@@ -81,6 +82,10 @@ class Moq internal constructor(
          * @param bind local socket address to bind, e.g. "0.0.0.0:0".
          * @param publish origin to announce broadcasts through; auto-created when null.
          * @param subscribe origin to discover broadcasts through; auto-created when null.
+         *
+         * With neither [publish] nor [subscribe] given, both sides share one origin, so a
+         * broadcast announced on this connection is discoverable via its own [announcements]
+         * (loopback). Wiring either side opts out and isolates the two directions.
          */
         suspend fun connect(
             url: String,
@@ -94,14 +99,6 @@ class Moq internal constructor(
             publish: MoqOriginProducer? = null,
             subscribe: MoqOriginProducer? = null,
         ): Moq {
-            // With neither side specified, wire ONE shared origin to both so a
-            // broadcast published on this connection is discoverable via its own
-            // announcements() (loopback). Otherwise honor what the caller passed
-            // and let the FFI auto-create any side left null.
-            val shared = if (publish == null && subscribe == null) MoqOriginProducer(MoqOriginOptions()) else null
-            val publishOrigin = publish ?: shared
-            val subscribeOrigin = subscribe ?: shared
-
             val client = MoqClient()
             try {
                 if (!tlsVerify) client.setTlsDisableVerify(true)
@@ -111,8 +108,8 @@ class Moq internal constructor(
                 if (tlsCert != null) client.setTlsCert(tlsCert)
                 if (tlsKey != null) client.setTlsKey(tlsKey)
                 if (bind != null) client.setBind(bind)
-                if (publishOrigin != null) client.setPublish(publishOrigin)
-                if (subscribeOrigin != null) client.setConsume(subscribeOrigin)
+                if (publish != null) client.setPublish(publish)
+                if (subscribe != null) client.setConsume(subscribe)
 
                 val session = client.connect(url)
                 return Moq(session, client)

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Server.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Server.kt
@@ -32,10 +32,15 @@ class Server internal constructor(
     val localAddr: String,
     private val publishOrigin: MoqOriginProducer?,
 ) : AutoCloseable {
-    /** Announce [broadcast] under [path] so incoming sessions can discover it. */
-    fun announce(path: String, broadcast: BroadcastProducer) {
+    /**
+     * Announce [broadcast] under [path] so incoming sessions can discover it.
+     *
+     * Hold the returned [Announce] for as long as the broadcast should stay discoverable;
+     * unannouncing it removes the path. Closing the broadcast does not unannounce it.
+     */
+    fun announce(path: String, broadcast: BroadcastProducer): Announce {
         val origin = publishOrigin ?: throw IllegalStateException("no publish origin configured")
-        origin.announce(path, broadcast)
+        return origin.announce(path, broadcast)
     }
 
     /**
@@ -48,7 +53,7 @@ class Server internal constructor(
 
     /**
      * Stream of incoming sessions. Each [MoqRequest] must be answered with
-     * `ok()` to complete the handshake or `close(code)` to reject it; the
+     * `accept()` to complete the handshake or `reject(code)` to reject it; the
      * returned session must be held to keep the connection alive.
      *
      * The Flow completes when the server stops accepting.
@@ -76,7 +81,7 @@ class Server internal constructor(
                 // routine. Swallow it: letting it escape would cancel the scope
                 // and let one client take the whole accept loop down.
                 try {
-                    request.ok().closed()
+                    request.accept().closed()
                 } catch (e: MoqException) {
                     // Nothing to do; this session is already gone.
                 }

--- a/kt/moq/src/jvmAndAndroidTest/kotlin/dev/moq/SmokeTest.kt
+++ b/kt/moq/src/jvmAndAndroidTest/kotlin/dev/moq/SmokeTest.kt
@@ -64,7 +64,7 @@ class SmokeTest {
         BroadcastProducer().use { broadcast ->
             val track = broadcast.publishTrack("events", null)
             val group = track.appendGroup()
-            group.writeFrame("cached".encodeToByteArray(), timestampUs = 0u)
+            group.writeFrame(Frame(payload = "cached".encodeToByteArray()))
             group.finish()
 
             val fetched = broadcast.consume().fetchGroup(
@@ -118,7 +118,8 @@ class SmokeTest {
             assertEquals(64, fingerprints[0].length)
 
             BroadcastProducer().use { broadcast ->
-                server.announce("live", broadcast)
+                val announce = server.announce("live", broadcast)
+                announce.unannounce()
             }
         }
     }

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -46,7 +46,7 @@ async def main():
 
         # Publish an Opus audio track (init bytes from your encoder)
         audio = broadcast.publish_media("opus", opus_init_bytes)
-        client.announce("my-stream", broadcast)
+        announce = client.announce("my-stream", broadcast)
 
         # Write frames
         audio.write_frame(payload, timestamp_us=0)
@@ -69,18 +69,18 @@ async def main():
     async with moq.Server("127.0.0.1:4443", tls_generate=["localhost"]) as server:
         broadcast = moq.BroadcastProducer()
         track = broadcast.publish_track("events")
-        server.announce("hello", broadcast)
+        announce = server.announce("hello", broadcast)
         print(f"listening on https://{server.local_addr}")
 
         sessions = []
         async for request in server:
             print(f"  + {request.transport} from {request.url}")
-            sessions.append(await request.ok())
+            sessions.append(await request.accept())
 
 asyncio.run(main())
 ```
 
-Reject a request instead of accepting it with `await request.close(403)`.
+Reject a request instead of accepting it with `await request.reject(403)`.
 
 ### Advanced: Manual origin wiring
 
@@ -111,13 +111,13 @@ client = moq.Client(
 - **`Server(bind="[::]:443", *, tls_cert=(), tls_key=(), tls_generate=(), publish=None, subscribe=None)`**. Async context manager + async iterator of incoming `Request`s.
   - `.local_addr`. The bound address (useful when binding to port `0`).
   - `.cert_fingerprints()`. SHA-256 fingerprints of the configured TLS certificates, for `serverCertificateHashes` browser cert pinning.
-  - `.announce(path, broadcast)`. Advertise a broadcast to be served.
+  - `.announce(path, broadcast) → Announce`. Advertise a broadcast to be served; hold the handle to keep it announced.
 - **`Request`**. An incoming session, yielded by `async for request in server`.
   - `.url`, `.transport`. Properties.
   - `.set_publish(origin)`, `.set_consume(origin)`. Per-request overrides.
-  - `await .ok() → Session`. Complete the handshake (hold the result to keep the connection alive).
-  - `await .close(code)`. Reject with an HTTP status code.
-  - `.cancel()`. Cancel an in-flight `ok()`/`close()` call.
+  - `await .accept() → Session`. Complete the handshake (hold the result to keep the connection alive).
+  - `await .reject(code)`. Reject with an HTTP status code.
+  - `.cancel()`. Cancel an in-flight `accept()`/`reject()` call.
 - **`Session`**. An established connection. Holding it keeps the connection alive; it is also an `async with` context manager that shuts down on exit.
   - `await .closed()`. Wait until the session closes.
   - `.cancel(code)`, `.shutdown()`. Close with an error code, or gracefully (code 0).
@@ -134,14 +134,14 @@ client = moq.Client(
   - `await .requested_track() → TrackRequest`. Call `.accept()` on it for a `TrackProducer`, or `.abort(code)` to reject.
   - Async iterator yielding `TrackRequest`
 - **`MediaProducer`**. Write frames to a track.
-  - `.write_frame(payload, timestamp_us)`
+  - `.write_frame(payload, timestamp_us=0)`
   - `.finish()`
 - **`TrackProducer` / `GroupProducer`**. Write raw payloads with no codec parsing.
-  - `.write_frame(payload, timestamp_us)` writes a payload with a presentation timestamp in microseconds.
+  - `.write_frame(payload, timestamp_us=0)` writes a payload with a presentation timestamp in microseconds.
   - `.create_group(sequence)` creates a sparse or replayed group at an explicit sequence.
   - `.finish_at(final_sequence)` declares the first group that will never be produced while leaving lower groups writable.
   - `.abort(error_code)` terminates the track or group with an application error.
-  - `.append_datagram(timestamp_us, payload) -> sequence` (`TrackProducer`) sends a best-effort datagram. Payloads are capped at 1200 bytes and there is no stream fallback.
+  - `.append_datagram(payload, timestamp_us=0) -> sequence` (`TrackProducer`) sends a best-effort datagram. Payloads are capped at 1200 bytes and there is no stream fallback.
 
 ### Subscribing
 
@@ -151,14 +151,14 @@ client = moq.Client(
   - `await .subscribe_media(name, track, subscription=None) → MediaConsumer`. `track` is the catalog record (e.g. `catalog.video[name]`); its container tells the decoder how to parse the bitstream.
   - `await .catalog() → Catalog` (convenience)
 - **`CatalogConsumer`**. Async iterator of `Catalog`.
-- **`MediaConsumer`**. Async iterator of `Frame`.
+- **`MediaConsumer`**. Async iterator of `MediaFrame`.
 - **`TrackConsumer`**. Async iterator of raw groups, in sequence order.
   - `await .next_group() → GroupConsumer | None`. Sequence order; what the default iteration yields.
   - `await .recv_group() → GroupConsumer | None`. Arrival order, which may be out of sequence. Prefer it when latency matters more than order.
   - `.groups_as_arrived()`. Async iterator over `recv_group()`.
   - `.read_frame() -> Frame | None` returns a timestamped raw frame.
   - `await .recv_datagram() -> Datagram | None` for best-effort raw track datagrams.
-  - `await .info() → TrackInfo`
+  - `.info() → TrackInfo`
   - `.update(subscription)`. Change delivery priority, group ordering priority, staleness, or group range after subscribing.
 - **`GroupConsumer`**. Async iterator of timestamped `Frame`s.
   - `.read_frame() -> Frame | None` returns a timestamped raw frame.
@@ -170,7 +170,7 @@ All consumers (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsum
 - **`OriginProducer(cache_capacity_bytes=None)`**. Manage broadcast announcements. Set `cache_capacity_bytes` to bound cached groups under this origin.
   - `.consume() → OriginConsumer`
   - `.dynamic() → OriginDynamic`
-  - `.announce(path, broadcast)`
+  - `.announce(path, broadcast) → Announce`
 - **`OriginDynamic`**. Async source of broadcasts requested by consumers.
   - `await .requested_broadcast() → BroadcastRequest`. Call `.accept(broadcast)` to serve it, or `.abort(code)` to fail the requester.
   - Async iterator yielding `BroadcastRequest`
@@ -182,7 +182,8 @@ All consumers (`CatalogConsumer`, `MediaConsumer`, `TrackConsumer`, `AudioConsum
 ### Types
 
 - **`Catalog`**. `.audio: dict[str, Audio]`, `.video: dict[str, Video]`, `.display`, `.rotation`, `.flip`.
-- **`Frame`**. `.payload: bytes`, `.timestamp_us: int`, `.keyframe: bool`.
+- **`Frame`**. `.payload: bytes`, `.timestamp_us: int`. The unit of every write and every raw read.
+- **`MediaFrame`**. `.payload: bytes`, `.timestamp_us: int`, `.keyframe: bool`. Returned by media subscriptions.
 - **`Datagram`**. `.sequence: int`, `.timestamp_us: int`, `.payload: bytes`. Delivered only on datagram-capable transports and lite-05 or newer moq-lite.
 - **`Audio`**. `.codec`, `.sample_rate`, `.channel_count`, `.bitrate`, `.description`.
 - **`Video`**. `.codec`, `.coded: Dimensions`, `.display_aspect`, `.bitrate`, `.framerate`, `.description`.

--- a/py/moq-rs/examples/clock.py
+++ b/py/moq-rs/examples/clock.py
@@ -20,7 +20,7 @@ async def publish(url: str, broadcast_name: str, track_name: str, tls_verify: bo
     track = broadcast.publish_track(track_name)
 
     async with moq.Client(url, tls_verify=tls_verify) as client:
-        client.announce(broadcast_name, broadcast)
+        _announce = client.announce(broadcast_name, broadcast)
         print(f"publishing {broadcast_name!r} track={track_name!r} at {url}")
 
         while True:

--- a/py/moq-rs/examples/serve_clock.py
+++ b/py/moq-rs/examples/serve_clock.py
@@ -23,7 +23,7 @@ async def run(bind: str, broadcast_name: str, track_name: str, host: str) -> Non
     track = broadcast.publish_track(track_name)
 
     async with moq.Server(bind, tls_generate=[host]) as server:
-        server.announce(broadcast_name, broadcast)
+        _announce = server.announce(broadcast_name, broadcast)
         print(f"serving {broadcast_name!r} track={track_name!r} on https://{server.local_addr}")
         for fp in server.cert_fingerprints():
             print(f"  cert fingerprint sha256: {fp}")

--- a/py/moq-rs/moq/__init__.py
+++ b/py/moq-rs/moq/__init__.py
@@ -9,6 +9,7 @@ from .client import Client, connect
 from .errors import is_auth, is_shutdown
 from .log import log_level
 from .origin import (
+    Announce,
     Announced,
     AnnouncedBroadcast,
     Announcement,
@@ -58,6 +59,7 @@ from .types import (
     Dimensions,
     FetchGroupOptions,
     Frame,
+    MediaFrame,
     Subscription,
     TrackInfo,
     Video,
@@ -65,6 +67,7 @@ from .types import (
 )
 
 __all__ = [
+    "Announce",
     "Announced",
     "AnnouncedBroadcast",
     "Announcement",
@@ -90,6 +93,7 @@ __all__ = [
     "Dimensions",
     "Error",
     "Frame",
+    "MediaFrame",
     "FetchGroupOptions",
     "GroupConsumer",
     "GroupRequest",

--- a/py/moq-rs/moq/client.py
+++ b/py/moq-rs/moq/client.py
@@ -6,7 +6,7 @@ import warnings
 
 from moq_ffi import MoqClient
 
-from .origin import Announced, AnnouncedBroadcast, OriginConsumer, OriginProducer
+from .origin import Announce, Announced, AnnouncedBroadcast, OriginConsumer, OriginProducer
 from .publish import BroadcastProducer
 from .session import Session
 from .subscribe import BroadcastConsumer
@@ -15,7 +15,8 @@ from .subscribe import BroadcastConsumer
 class Client:
     """High-level MoQ client with automatic origin wiring.
 
-    In simple mode (no origin provided), creates an internal origin automatically:
+    In simple mode (no origin provided), both sides share one origin, so a broadcast
+    announced here is also discoverable here:
 
         async with Client("https://relay.example.com") as client:
             async for ann in client.announced():
@@ -54,16 +55,12 @@ class Client:
         self._tls_key = tls_key
         self._bind = bind
 
-        # If neither origin is provided, create a shared internal one.
-        if publish is None and subscribe is None:
-            self._origin = OriginProducer()
-            self._publish_origin = self._origin
-            self._consume_origin = self._origin
-        else:
-            self._origin = None
-            self._publish_origin = publish
-            self._consume_origin = subscribe
+        # With neither side given, moq-ffi wires one shared origin to both, so a broadcast
+        # announced here is discoverable via announced() (loopback).
+        self._publish_origin = publish
+        self._consume_origin = subscribe
 
+        self._publisher: OriginProducer | None = None
         self._consumer: OriginConsumer | None = None
         self._inner: MoqClient | None = None
         self._session: Session | None = None
@@ -93,14 +90,15 @@ class Client:
 
         self._session = Session(await self._inner.connect(self._url))
 
-        # Create consumer from whichever origin handles consuming.
-        origin = self._consume_origin or self._publish_origin
-        if origin is not None:
-            self._consumer = origin.consume()
+        # The session always exposes both sides, wired from the origins above or
+        # auto-created, so publishing and discovery always have somewhere to go.
+        self._publisher = self._session.publisher()
+        self._consumer = self._session.consumer()
 
         return self
 
     async def __aexit__(self, *exc) -> None:
+        self._publisher = None
         self._consumer = None
         if self._session is not None:
             self._session.shutdown()
@@ -110,36 +108,41 @@ class Client:
             self._inner = None
         self._session = None
 
-    def announce(self, path: str, broadcast: BroadcastProducer) -> None:
-        """Advertise ``broadcast`` at ``path`` so subscribers can discover it."""
-        origin = self._publish_origin
-        if origin is None:
-            raise RuntimeError("no publish origin configured")
-        origin.announce(path, broadcast)
+    def announce(self, path: str, broadcast: BroadcastProducer) -> Announce:
+        """Advertise ``broadcast`` at ``path`` so subscribers can discover it.
 
-    def publish(self, path: str, broadcast: BroadcastProducer) -> None:
+        Hold the returned :class:`Announce` for as long as the broadcast should stay
+        discoverable; unannouncing it removes the path.
+        """
+        return self._require_publisher().announce(path, broadcast)
+
+    def publish(self, path: str, broadcast: BroadcastProducer) -> Announce:
         warnings.warn(
             "Client.publish() is deprecated; use Client.announce() instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        self.announce(path, broadcast)
+        return self.announce(path, broadcast)
 
     def announced(self, prefix: str = "") -> Announced:
-        if self._consumer is None:
-            raise RuntimeError("no consume origin configured")
-        return self._consumer.announced(prefix)
+        return self._require_consumer().announced(prefix)
 
     def announced_broadcast(self, path: str) -> AnnouncedBroadcast:
-        if self._consumer is None:
-            raise RuntimeError("no consume origin configured")
-        return self._consumer.announced_broadcast(path)
+        return self._require_consumer().announced_broadcast(path)
 
     async def request_broadcast(self, path: str) -> BroadcastConsumer:
         """Request a broadcast by path, resolving as soon as it can be served."""
+        return await self._require_consumer().request_broadcast(path)
+
+    def _require_publisher(self) -> OriginProducer:
+        if self._publisher is None:
+            raise RuntimeError("not connected; use the client as an async context manager")
+        return self._publisher
+
+    def _require_consumer(self) -> OriginConsumer:
         if self._consumer is None:
-            raise RuntimeError("no consume origin configured")
-        return await self._consumer.request_broadcast(path)
+            raise RuntimeError("not connected; use the client as an async context manager")
+        return self._consumer
 
     @property
     def session(self) -> Session | None:

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 
 from moq_ffi import (
+    MoqAnnounce,
     MoqAnnounced,
     MoqAnnouncedBroadcast,
     MoqAnnouncement,
@@ -17,6 +18,30 @@ from moq_ffi import (
 
 from .publish import BroadcastProducer
 from .subscribe import BroadcastConsumer
+
+
+class Announce:
+    """A live announcement, returned by :meth:`OriginProducer.announce`.
+
+    The broadcast stays announced until :meth:`unannounce` is called or this object is
+    collected. Closing the broadcast does not unannounce it. Usable as a context manager::
+
+        with origin.announce("live", broadcast):
+            ...
+    """
+
+    def __init__(self, inner: MoqAnnounce) -> None:
+        self._inner = inner
+
+    def unannounce(self) -> None:
+        """Unannounce the broadcast, removing it from the origin. Idempotent."""
+        self._inner.unannounce()
+
+    def __enter__(self) -> Announce:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.unannounce()
 
 
 class Announcement:
@@ -168,14 +193,18 @@ class OriginProducer:
         """Serve broadcasts that consumers request without an announcement."""
         return OriginDynamic(self._inner.dynamic())
 
-    def announce(self, path: str, broadcast: BroadcastProducer) -> None:
-        """Advertise ``broadcast`` at ``path`` so subscribers can discover it."""
-        self._inner.announce(path, broadcast._inner)
+    def announce(self, path: str, broadcast: BroadcastProducer) -> Announce:
+        """Advertise ``broadcast`` at ``path`` so subscribers can discover it.
 
-    def publish(self, path: str, broadcast: BroadcastProducer) -> None:
+        Hold the returned :class:`Announce` for as long as the broadcast should stay
+        discoverable; unannouncing it (or dropping it) removes the path.
+        """
+        return Announce(self._inner.announce(path, broadcast._inner))
+
+    def publish(self, path: str, broadcast: BroadcastProducer) -> Announce:
         warnings.warn(
             "OriginProducer.publish() is deprecated; use OriginProducer.announce() instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        self.announce(path, broadcast)
+        return self.announce(path, broadcast)

--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -23,7 +23,7 @@ from moq_ffi import (
     MoqTrackRequest,
 )
 
-from .types import AudioEncoderInput, AudioEncoderOutput, AudioFrame, Subscription, TrackInfo, VideoHint
+from .types import AudioEncoderInput, AudioEncoderOutput, AudioFrame, Frame, Subscription, TrackInfo, VideoHint
 
 if TYPE_CHECKING:
     from .subscribe import BroadcastConsumer, GroupConsumer, TrackConsumer
@@ -52,8 +52,8 @@ class MediaProducer:
         """Wait until this media track has no active subscribers."""
         await self._inner.unused()
 
-    def write_frame(self, payload: bytes, timestamp_us: int) -> None:
-        self._inner.write_frame(payload, timestamp_us)
+    def write_frame(self, payload: bytes, timestamp_us: int = 0) -> None:
+        self._inner.write_frame(Frame(payload=payload, timestamp_us=timestamp_us))
 
     def finish(self) -> None:
         self._inner.finish()
@@ -96,9 +96,9 @@ class GroupProducer:
 
         return GroupConsumer(self._inner.consume())
 
-    def write_frame(self, payload: bytes, timestamp_us: int) -> None:
+    def write_frame(self, payload: bytes, timestamp_us: int = 0) -> None:
         """Write a frame with a presentation timestamp in microseconds."""
-        self._inner.write_frame(payload, timestamp_us)
+        self._inner.write_frame(Frame(payload=payload, timestamp_us=timestamp_us))
 
     def finish(self) -> None:
         self._inner.finish()
@@ -142,17 +142,17 @@ class TrackProducer:
         """Create a group with an explicit sequence number."""
         return GroupProducer(self._inner.create_group(sequence))
 
-    def write_frame(self, payload: bytes, timestamp_us: int) -> None:
+    def write_frame(self, payload: bytes, timestamp_us: int = 0) -> None:
         """Write a single-frame group with a timestamp in microseconds."""
-        self._inner.write_frame(payload, timestamp_us)
+        self._inner.write_frame(Frame(payload=payload, timestamp_us=timestamp_us))
 
-    def append_datagram(self, timestamp_us: int, payload: bytes) -> int:
+    def append_datagram(self, payload: bytes, timestamp_us: int = 0) -> int:
         """Send a best-effort datagram and return its sequence number.
 
         Payloads are capped at 1200 bytes. Datagram delivery requires a datagram-capable
         transport and wire version; there is no stream fallback.
         """
-        return self._inner.append_datagram(timestamp_us, payload)
+        return self._inner.append_datagram(Frame(payload=payload, timestamp_us=timestamp_us))
 
     def consume(self, subscription: Subscription | None = None) -> TrackConsumer:
         """Create a consumer that reads directly from this producer's track.
@@ -391,17 +391,23 @@ class BroadcastProducer:
         return TrackProducer(self._inner.publish_track(name, info))
 
     def publish_json_snapshot(
-        self, name: str, *, delta_ratio: int = 8, compression: bool = False
+        self, name: str, *, delta_ratio: int | None = None, compression: bool = False
     ) -> JsonSnapshotProducer:
         """Publish a JSON snapshot track (lossy latest-value).
 
         Each update supersedes the last; a late joiner only sees the newest value.
         ``delta_ratio`` controls how aggressively deltas are emitted instead of full
-        snapshots (0 disables deltas). Set ``compression`` to DEFLATE-compress each group;
-        the consumer must pass the same flag. Advertise the track with
-        :meth:`set_catalog_section` if consumers should discover it.
+        snapshots (0 disables deltas); ``None`` uses the binding's default. Set
+        ``compression`` to DEFLATE-compress each group; the consumer must pass the same
+        flag. Advertise the track with :meth:`set_catalog_section` if consumers should
+        discover it.
         """
-        config = MoqJsonSnapshotConfig(delta_ratio=delta_ratio, compression=compression)
+        # Let the record supply delta_ratio's default rather than restating it here.
+        config = (
+            MoqJsonSnapshotConfig(compression=compression)
+            if delta_ratio is None
+            else MoqJsonSnapshotConfig(delta_ratio=delta_ratio, compression=compression)
+        )
         return JsonSnapshotProducer(self._inner.publish_json_snapshot(name, config))
 
     def publish_json_stream(self, name: str, *, compression: bool = False) -> JsonStreamProducer:

--- a/py/moq-rs/moq/server.py
+++ b/py/moq-rs/moq/server.py
@@ -9,7 +9,7 @@ from typing import Literal
 
 from moq_ffi import MoqRequest, MoqServer
 
-from .origin import OriginProducer
+from .origin import Announce, OriginProducer
 from .publish import BroadcastProducer
 from .session import Session
 
@@ -19,11 +19,11 @@ Transport = Literal["quic", "iroh", "websocket"]
 class Request:
     """Wraps MoqRequest, an incoming session that can be accepted or rejected.
 
-    Use `await request.ok()` to complete the handshake, or
-    `await request.close(code)` to reject with an HTTP status code.
+    Use `await request.accept()` to complete the handshake, or
+    `await request.reject(code)` to reject with an HTTP status code.
 
     Dropping a Request without responding closes the underlying connection
-    silently; call `close(code)` to send an explicit HTTP status.
+    silently; call `reject(code)` to send an explicit HTTP status.
     """
 
     def __init__(self, inner: MoqRequest) -> None:
@@ -47,25 +47,25 @@ class Request:
         server's configured consume origin if unset."""
         self._inner.set_consume(origin._inner if origin is not None else None)
 
-    async def ok(self) -> Session:
+    async def accept(self) -> Session:
         """Complete the MoQ handshake and return the established session.
 
         The caller must hold the returned session to keep the connection
         alive; dropping it closes the session. Raises `Error.AlreadyResponded`
-        if `ok()` or `close()` has already been called.
+        if `accept()` or `reject()` has already been called.
         """
-        return Session(await self._inner.ok())
+        return Session(await self._inner.accept())
 
-    async def close(self, code: int) -> None:
+    async def reject(self, code: int) -> None:
         """Reject the session with the given HTTP status code.
 
-        Raises `Error.AlreadyResponded` if `ok()` or `close()` has already
+        Raises `Error.AlreadyResponded` if `accept()` or `reject()` has already
         been called.
         """
-        await self._inner.close(code)
+        await self._inner.reject(code)
 
     def cancel(self) -> None:
-        """Cancel an in-flight `ok()` or `close()` call."""
+        """Cancel an in-flight `accept()` or `reject()` call."""
         self._inner.cancel()
 
 
@@ -75,7 +75,7 @@ class Server:
     In simple mode (no origin provided), creates an internal origin automatically:
 
         async with Server("127.0.0.1:4443", tls_generate=["localhost"]) as server:
-            server.announce("live", broadcast)
+            announce = server.announce("live", broadcast)
             await server.serve()
 
     Or hand-roll the accept loop if you need per-request control:
@@ -83,9 +83,9 @@ class Server:
         async with Server("127.0.0.1:4443", tls_generate=["localhost"]) as server:
             async for request in server:
                 if request.url and "/admin" in request.url:
-                    await request.close(403)
+                    await request.reject(403)
                     continue
-                session = await request.ok()  # hold to keep the connection alive
+                session = await request.accept()  # hold to keep the connection alive
 
     Exiting the context manager stops accepting new sessions but does not
     close in-flight sessions; those stay alive until their handles are
@@ -181,20 +181,24 @@ class Server:
             raise StopAsyncIteration
         return Request(request)
 
-    def announce(self, path: str, broadcast: BroadcastProducer) -> None:
-        """Advertise a broadcast under the given path, served to incoming sessions."""
+    def announce(self, path: str, broadcast: BroadcastProducer) -> Announce:
+        """Advertise a broadcast under the given path, served to incoming sessions.
+
+        Hold the returned :class:`Announce` for as long as the broadcast should stay
+        discoverable; unannouncing it removes the path.
+        """
         origin = self._publish_origin
         if origin is None:
             raise RuntimeError("no publish origin configured")
-        origin.announce(path, broadcast)
+        return origin.announce(path, broadcast)
 
-    def publish(self, path: str, broadcast: BroadcastProducer) -> None:
+    def publish(self, path: str, broadcast: BroadcastProducer) -> Announce:
         warnings.warn(
             "Server.publish() is deprecated; use Server.announce() instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        self.announce(path, broadcast)
+        return self.announce(path, broadcast)
 
     async def serve(self) -> None:
         """Accept every session in a loop, holding each one alive until it closes.
@@ -206,14 +210,14 @@ class Server:
 
             async for request in server:
                 if request.url and "/admin" in request.url:
-                    await request.close(403)
+                    await request.reject(403)
                     continue
-                session = await request.ok()
+                session = await request.accept()
         """
         session_tasks: set[asyncio.Task] = set()
 
         async def serve_session(request: Request) -> None:
-            session = await request.ok()
+            session = await request.accept()
             await session.closed()
 
         try:

--- a/py/moq-rs/moq/session.py
+++ b/py/moq-rs/moq/session.py
@@ -9,12 +9,12 @@ from .types import ConnectionStats
 
 
 class Session:
-    """An established MoQ connection, returned by `Client` and `Request.ok()`.
+    """An established MoQ connection, returned by `Client` and `Request.accept()`.
 
     Hold the session to keep the connection alive; dropping it closes the
     connection. As an async context manager it shuts down gracefully on exit:
 
-        session = await request.ok()
+        session = await request.accept()
         async with session:
             await session.closed()
     """

--- a/py/moq-rs/moq/subscribe.py
+++ b/py/moq-rs/moq/subscribe.py
@@ -28,6 +28,7 @@ from .types import (
     Datagram,
     FetchGroupOptions,
     Frame,
+    MediaFrame,
     Subscription,
     TrackInfo,
     Video,
@@ -35,7 +36,7 @@ from .types import (
 
 
 class MediaConsumer:
-    """Wraps MoqMediaConsumer as an async iterator of Frame."""
+    """Wraps MoqMediaConsumer as an async iterator of MediaFrame."""
 
     def __init__(self, inner: MoqMediaConsumer) -> None:
         self._inner = inner
@@ -49,7 +50,7 @@ class MediaConsumer:
     def __aiter__(self):
         return self
 
-    async def __anext__(self) -> Frame:
+    async def __anext__(self) -> MediaFrame:
         frame = await self._inner.next()
         if frame is None:
             raise StopAsyncIteration
@@ -172,9 +173,9 @@ class TrackConsumer:
         """
         return await self._inner.recv_datagram()
 
-    async def info(self) -> TrackInfo:
+    def info(self) -> TrackInfo:
         """Return the publisher-side track properties."""
-        return await self._inner.info()
+        return self._inner.info()
 
     def update(self, subscription: Subscription) -> None:
         """Change this subscriber's delivery preferences."""
@@ -307,7 +308,8 @@ class BroadcastConsumer:
 
         Yields parsed Python objects. Pass the same ``compression`` the producer used.
         """
-        config = MoqJsonSnapshotConfig(delta_ratio=0, compression=compression)
+        # delta_ratio is producer-only, so leave it at its default here.
+        config = MoqJsonSnapshotConfig(compression=compression)
         return JsonSnapshotConsumer(await self._inner.subscribe_json_snapshot(name, config))
 
     async def subscribe_json_stream(self, name: str, *, compression: bool = False) -> JsonStreamConsumer:

--- a/py/moq-rs/moq/types.py
+++ b/py/moq-rs/moq/types.py
@@ -1,9 +1,6 @@
 """Re-export moq-ffi record types without the Moq prefix."""
 
 from moq_ffi import (
-    Container as Container,
-)
-from moq_ffi import (
     MoqAudio as Audio,
 )
 from moq_ffi import (
@@ -31,6 +28,9 @@ from moq_ffi import (
     MoqConnectionStats as ConnectionStats,
 )
 from moq_ffi import (
+    MoqContainer as Container,
+)
+from moq_ffi import (
     MoqDatagram as Datagram,
 )
 from moq_ffi import (
@@ -41,6 +41,9 @@ from moq_ffi import (
 )
 from moq_ffi import (
     MoqFrame as Frame,
+)
+from moq_ffi import (
+    MoqMediaFrame as MediaFrame,
 )
 from moq_ffi import (
     MoqSubscription as Subscription,
@@ -70,6 +73,7 @@ __all__ = [
     "Dimensions",
     "Frame",
     "FetchGroupOptions",
+    "MediaFrame",
     "Subscription",
     "TrackInfo",
     "Video",

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -94,7 +94,7 @@ async def test_local_publish_consume_audio():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     media = broadcast.publish_media("opus", opus_head())
-    origin.announce("live", broadcast)
+    _announce = origin.announce("live", broadcast)
 
     consumer = origin.consume()
 
@@ -129,7 +129,7 @@ async def test_video_publish_consume():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     media = broadcast.publish_media("avc3", h264_init())
-    origin.announce("video-test", broadcast)
+    _announce = origin.announce("video-test", broadcast)
 
     consumer = origin.consume()
 
@@ -163,7 +163,7 @@ async def test_multiple_frames_ordering():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     media = broadcast.publish_media("opus", opus_head())
-    origin.announce("ordering-test", broadcast)
+    _announce = origin.announce("ordering-test", broadcast)
 
     consumer = origin.consume()
 
@@ -190,7 +190,7 @@ async def test_catalog_update_on_new_track():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     _media1 = broadcast.publish_media("opus", opus_head())
-    origin.announce("catalog-update", broadcast)
+    _announce = origin.announce("catalog-update", broadcast)
 
     consumer = origin.consume()
 
@@ -222,7 +222,7 @@ def test_finish_closes_producer():
 async def test_announced_broadcast():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
-    origin.announce("test/broadcast", broadcast)
+    _announce = origin.announce("test/broadcast", broadcast)
 
     consumer = origin.consume()
 
@@ -545,7 +545,7 @@ async def test_subscribe_media_default_latency_and_context_manager():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     media = broadcast.publish_media("opus", opus_head())
-    origin.announce("live", broadcast)
+    _announce = origin.announce("live", broadcast)
 
     consumer = origin.consume()
 
@@ -569,7 +569,7 @@ async def test_raw_publish_consume():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     raw = broadcast.publish_track("events")
-    origin.announce("robot/arm", broadcast)
+    _announce = origin.announce("robot/arm", broadcast)
 
     consumer = origin.consume()
 
@@ -594,7 +594,7 @@ async def test_raw_multiple_frames():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     raw = broadcast.publish_track("commands")
-    origin.announce("robot/io", broadcast)
+    _announce = origin.announce("robot/io", broadcast)
 
     consumer = origin.consume()
 
@@ -676,7 +676,7 @@ async def test_raw_group_sequence():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     raw = broadcast.publish_track("seq")
-    origin.announce("track/seq", broadcast)
+    _announce = origin.announce("track/seq", broadcast)
 
     consumer = origin.consume()
 
@@ -711,7 +711,7 @@ async def test_default_iteration_is_sequence_order():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     raw = broadcast.publish_track("ordering")
-    origin.announce("track/ordering", broadcast)
+    _announce = origin.announce("track/ordering", broadcast)
 
     sequenced = origin.consume()
     arrived = origin.consume()
@@ -746,7 +746,7 @@ async def test_raw_multi_frame_group():
     origin = moq.OriginProducer()
     broadcast = moq.BroadcastProducer()
     raw = broadcast.publish_track("chunks")
-    origin.announce("stream/chunks", broadcast)
+    _announce = origin.announce("stream/chunks", broadcast)
 
     consumer = origin.consume()
 
@@ -799,7 +799,6 @@ async def test_raw_read_frame_preserves_timestamp():
     assert frame is not None
     assert frame.payload == b"ready"
     assert frame.timestamp_us == 12_345
-    assert not frame.keyframe
 
     group = track.append_group()
     group_consumer = group.consume()
@@ -810,7 +809,6 @@ async def test_raw_read_frame_preserves_timestamp():
     assert frame is not None
     assert frame.payload == b"group"
     assert frame.timestamp_us == 23_456
-    assert not frame.keyframe
 
 
 async def test_read_frame_skips_remaining_frames_in_group():

--- a/py/moq-rs/tests/test_server.py
+++ b/py/moq-rs/tests/test_server.py
@@ -25,7 +25,7 @@ async def test_server_client_roundtrip():
         # Publish a broadcast on the server side.
         broadcast = moq.BroadcastProducer()
         media = broadcast.publish_media("opus", opus_head())
-        server.announce("hello", broadcast)
+        _announce = server.announce("hello", broadcast)
 
         # Auto-accept incoming sessions in the background so the handshake
         # completes from the server side. Hold references so the sessions
@@ -34,7 +34,7 @@ async def test_server_client_roundtrip():
 
         async def accept_loop() -> None:
             async for request in server:
-                sessions.append(await request.ok())
+                sessions.append(await request.accept())
 
         accept_task = asyncio.create_task(accept_loop())
 
@@ -79,7 +79,7 @@ async def test_server_request_close():
 
         async def reject_loop() -> None:
             async for request in server:
-                await request.close(403)
+                await request.reject(403)
 
         reject_task = asyncio.create_task(reject_loop())
         try:
@@ -108,20 +108,20 @@ async def test_cert_fingerprints_after_listen():
         assert all(c in "0123456789abcdef" for c in fps[0])
 
 
-async def test_request_double_ok_returns_already_responded():
-    """Calling ok() twice on the same request raises AlreadyResponded."""
+async def test_request_double_accept_returns_already_responded():
+    """Calling accept() twice on the same request raises AlreadyResponded."""
     async with moq.Server("127.0.0.1:0", tls_generate=["localhost"]) as server:
         sessions: list = []
 
         async def accept_once() -> None:
             async for request in server:
-                sessions.append(await request.ok())
-                # Second ok() must fail; MoqError is an Exception at runtime,
+                sessions.append(await request.accept())
+                # A second accept() must fail; MoqError is an Exception at runtime,
                 # UniFFI's static rebind hides that from pyright.
                 with pytest.raises(moq_ffi.MoqError):  # type: ignore[arg-type]
-                    await request.ok()
+                    await request.accept()
                 with pytest.raises(moq_ffi.MoqError):  # type: ignore[arg-type]
-                    await request.close(403)
+                    await request.reject(403)
                 break
 
         accept_task = asyncio.create_task(accept_once())
@@ -145,7 +145,7 @@ async def test_serve_helper_accepts_clients():
     """Server.serve() accepts incoming sessions and holds them automatically."""
     async with moq.Server("127.0.0.1:0", tls_generate=["localhost"]) as server:
         broadcast = moq.BroadcastProducer()
-        server.announce("via-serve", broadcast)
+        _announce = server.announce("via-serve", broadcast)
 
         serve_task = asyncio.create_task(server.serve())
         try:
@@ -170,7 +170,7 @@ async def test_announcement_hops_over_wire():
     """An announcement received over the wire exposes its relay hop chain as a list of ints."""
     async with moq.Server("127.0.0.1:0", tls_generate=["localhost"]) as server:
         broadcast = moq.BroadcastProducer()
-        server.announce("with-hops", broadcast)
+        _announce = server.announce("with-hops", broadcast)
 
         serve_task = asyncio.create_task(server.serve())
         try:

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -1050,8 +1050,8 @@ pub unsafe extern "C" fn moq_publish_track_frame(
 
 /// Send a best-effort datagram on a raw track created by [moq_publish_track].
 ///
-/// `timestamp_us` is the presentation timestamp in microseconds. The payload must be at
-/// most 1200 bytes. On success the datagram's per-track sequence number (shared with the
+/// Takes `payload` then `timestamp_us`, matching [moq_publish_track_frame]. The payload must
+/// be at most 1200 bytes. On success the datagram's per-track sequence number (shared with the
 /// group namespace) is written to `out_sequence` when it is non-NULL. Datagrams are
 /// delivered only on transports and wire versions with a datagram channel; there is no
 /// group fallback.
@@ -1064,9 +1064,9 @@ pub unsafe extern "C" fn moq_publish_track_frame(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn moq_publish_track_datagram(
 	track: u32,
-	timestamp_us: u64,
 	payload: *const u8,
 	payload_size: usize,
+	timestamp_us: u64,
 	out_sequence: *mut u64,
 ) -> i32 {
 	ffi::enter(move || {

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -697,7 +697,7 @@ fn raw_track_datagram_publish_consume() {
 	let payload = b"hello datagram";
 	let mut sequence: u64 = u64::MAX;
 	assert_eq!(
-		unsafe { moq_publish_track_datagram(track, 120_000, payload.as_ptr(), payload.len(), &mut sequence) },
+		unsafe { moq_publish_track_datagram(track, payload.as_ptr(), payload.len(), 120_000, &mut sequence) },
 		0
 	);
 

--- a/rs/moq-ffi/examples/server_smoke.py
+++ b/rs/moq-ffi/examples/server_smoke.py
@@ -36,7 +36,7 @@ async def main() -> int:
     async def accept_one() -> moq.MoqSession:
         request = await server.accept()
         assert request is not None, "server.accept() returned None"
-        return await request.ok()
+        return await request.accept()
 
     accept_task = asyncio.create_task(accept_one())
 

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -19,7 +19,6 @@ fn raw_frame(frame: moq_net::frame::Frame) -> Result<MoqFrame, MoqError> {
 	Ok(MoqFrame {
 		payload: frame.payload.to_vec(),
 		timestamp_us,
-		keyframe: false,
 	})
 }
 
@@ -125,7 +124,7 @@ struct Media {
 }
 
 impl Media {
-	async fn next(&mut self) -> Result<Option<MoqFrame>, MoqError> {
+	async fn next(&mut self) -> Result<Option<MoqMediaFrame>, MoqError> {
 		let frame = self.inner.read().await?;
 
 		let Some(frame) = frame else {
@@ -137,7 +136,7 @@ impl Media {
 		let mut buf = frame.payload;
 		let payload = buf.copy_to_bytes(buf.remaining()).to_vec();
 
-		Ok(Some(MoqFrame {
+		Ok(Some(MoqMediaFrame {
 			payload,
 			timestamp_us,
 			keyframe: frame.keyframe,
@@ -203,7 +202,7 @@ impl MoqBroadcastConsumer {
 	pub async fn subscribe_media(
 		&self,
 		name: String,
-		container: Container,
+		container: MoqContainer,
 		subscription: Option<MoqSubscription>,
 	) -> Result<Arc<MoqMediaConsumer>, MoqError> {
 		// Parse the container before subscribing so we don't leave a dangling
@@ -323,7 +322,6 @@ impl MoqTrackConsumer {
 	///
 	/// Convenience for tracks using one-frame-per-group (like moq-boy's
 	/// status/command tracks). Returns `None` when the track ends.
-	/// `keyframe` is always false for raw frames because no codec metadata is parsed.
 	pub async fn read_frame(&self) -> Result<Option<MoqFrame>, MoqError> {
 		self.task.run(|mut state| async move { state.read_frame().await }).await
 	}
@@ -339,7 +337,7 @@ impl MoqTrackConsumer {
 	}
 
 	/// Return the publisher-side track properties learned during subscription.
-	pub async fn info(&self) -> Result<MoqTrackInfo, MoqError> {
+	pub fn info(&self) -> Result<MoqTrackInfo, MoqError> {
 		MoqTrackInfo::try_from(&self.info)
 	}
 
@@ -390,8 +388,7 @@ impl MoqGroupConsumer {
 
 	/// Read the next frame in this group, including its timestamp.
 	///
-	/// Returns `None` when the group ends. `keyframe` is always false for raw frames
-	/// because no codec metadata is parsed.
+	/// Returns `None` when the group ends.
 	pub async fn read_frame(&self) -> Result<Option<MoqFrame>, MoqError> {
 		self.task.run(|mut state| async move { state.read_frame().await }).await
 	}
@@ -421,7 +418,7 @@ impl MoqCatalogConsumer {
 #[uniffi::export]
 impl MoqMediaConsumer {
 	/// Get the next frame. Returns `None` when the track ends or is closed.
-	pub async fn next(&self) -> Result<Option<MoqFrame>, MoqError> {
+	pub async fn next(&self) -> Result<Option<MoqMediaFrame>, MoqError> {
 		self.task.run(|mut state| async move { state.next().await }).await
 	}
 

--- a/rs/moq-ffi/src/json.rs
+++ b/rs/moq-ffi/src/json.rs
@@ -23,9 +23,11 @@ pub struct MoqJsonSnapshotConfig {
 	/// How aggressively the producer emits deltas instead of full snapshots. `0` disables deltas
 	/// (one snapshot per group); a positive value allows roughly that many snapshots' worth of
 	/// deltas before rolling a new group. Ignored by the consumer.
+	#[uniffi(default = 8)]
 	pub delta_ratio: u32,
 
 	/// DEFLATE-compress each group. Must match on the producer and consumer.
+	#[uniffi(default = false)]
 	pub compression: bool,
 }
 
@@ -52,6 +54,7 @@ impl From<MoqJsonSnapshotConfig> for moq_json::snapshot::ConsumerConfig {
 #[derive(Clone, uniffi::Record)]
 pub struct MoqJsonStreamConfig {
 	/// DEFLATE-compress the group. Must match on the producer and consumer.
+	#[uniffi(default = false)]
 	pub compression: bool,
 }
 
@@ -64,6 +67,23 @@ impl From<MoqJsonStreamConfig> for moq_json::stream::ProducerConfig {
 impl From<MoqJsonStreamConfig> for moq_json::stream::ConsumerConfig {
 	fn from(config: MoqJsonStreamConfig) -> Self {
 		moq_json::stream::ConsumerConfig::default().with_compression(config.compression)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	// The `#[uniffi(default = ...)]` attributes have to be literals, so they restate moq-json's
+	// own defaults. Every binding inherits those literals, so a drift here would silently give
+	// each wrapper different behavior than the Rust API.
+	#[test]
+	fn record_defaults_match_moq_json() {
+		let snapshot = moq_json::snapshot::ProducerConfig::default();
+		assert_eq!(snapshot.delta_ratio, 8, "update #[uniffi(default)] on delta_ratio");
+		assert!(!snapshot.compression, "update #[uniffi(default)] on compression");
+		assert!(
+			!moq_json::stream::ProducerConfig::default().compression,
+			"update #[uniffi(default)] on MoqJsonStreamConfig::compression"
+		);
 	}
 }
 

--- a/rs/moq-ffi/src/media.rs
+++ b/rs/moq-ffi/src/media.rs
@@ -6,14 +6,18 @@ pub struct MoqDimensions {
 	pub height: u32,
 }
 
+/// How a track's frames are packaged, as advertised in the catalog.
 #[derive(Clone, uniffi::Enum)]
-pub enum Container {
+pub enum MoqContainer {
+	/// The legacy hang container.
 	Legacy,
+	/// CMAF (fMP4), carrying the initialization segment.
 	Cmaf { init: Vec<u8> },
+	/// LOC, the low-overhead container.
 	Loc,
 }
 
-impl From<hang::catalog::Container> for Container {
+impl From<hang::catalog::Container> for MoqContainer {
 	fn from(container: hang::catalog::Container) -> Self {
 		match container {
 			hang::catalog::Container::Legacy => Self::Legacy,
@@ -23,12 +27,12 @@ impl From<hang::catalog::Container> for Container {
 	}
 }
 
-impl From<Container> for hang::catalog::Container {
-	fn from(container: Container) -> Self {
+impl From<MoqContainer> for hang::catalog::Container {
+	fn from(container: MoqContainer) -> Self {
 		match container {
-			Container::Legacy => Self::Legacy,
-			Container::Cmaf { init } => Self::Cmaf { init: init.into() },
-			Container::Loc => Self::Loc,
+			MoqContainer::Legacy => Self::Legacy,
+			MoqContainer::Cmaf { init } => Self::Cmaf { init: init.into() },
+			MoqContainer::Loc => Self::Loc,
 		}
 	}
 }
@@ -55,7 +59,7 @@ pub struct MoqVideo {
 	pub display_aspect: Option<MoqDimensions>,
 	pub bitrate: Option<u64>,
 	pub framerate: Option<f64>,
-	pub container: Container,
+	pub container: MoqContainer,
 }
 
 #[derive(Clone, uniffi::Record)]
@@ -65,18 +69,38 @@ pub struct MoqAudio {
 	pub sample_rate: u32,
 	pub channel_count: u32,
 	pub bitrate: Option<u64>,
-	pub container: Container,
+	pub container: MoqContainer,
 }
 
-/// A media frame.
-#[derive(uniffi::Record)]
+/// A payload and the time it should be presented.
+///
+/// The unit of both writing and raw reading: every producer write takes one of these, and a
+/// raw (non-media) read returns one. Media reads return a [`MoqMediaFrame`] instead, which
+/// adds the codec-derived keyframe flag.
+#[derive(Clone, uniffi::Record)]
 pub struct MoqFrame {
+	/// The frame payload.
 	pub payload: Vec<u8>,
+	/// Presentation timestamp in microseconds.
+	#[uniffi(default = 0)]
 	pub timestamp_us: u64,
+}
+
+/// A [`MoqFrame`] plus the codec metadata a media track carries.
+#[derive(Clone, uniffi::Record)]
+pub struct MoqMediaFrame {
+	/// The frame payload.
+	pub payload: Vec<u8>,
+	/// Presentation timestamp in microseconds.
+	pub timestamp_us: u64,
+	/// Whether this frame can be decoded without any earlier frame.
 	pub keyframe: bool,
 }
 
-/// A best-effort raw track datagram.
+/// A best-effort raw track datagram, as received.
+///
+/// Send one with [`append_datagram`](crate::producer::MoqTrackProducer::append_datagram), which
+/// takes a [`MoqFrame`] and assigns the sequence number for you.
 #[derive(uniffi::Record)]
 pub struct MoqDatagram {
 	/// Per-track sequence number, shared with groups.

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -131,6 +131,29 @@ impl MoqOriginConsumer {
 	}
 }
 
+/// Resolve the (publish, subscribe) origin pair backing a session.
+///
+/// With neither side wired, both sides share ONE origin, so a broadcast announced on a session
+/// is discoverable through that same session's consumer. Wiring either side opts out of the
+/// loopback and gives the other side a fresh origin, keeping the two directions isolated.
+pub(crate) fn resolve_pair(
+	publish: Option<&Arc<MoqOriginProducer>>,
+	consume: Option<&Arc<MoqOriginProducer>>,
+) -> (moq_net::origin::Producer, moq_net::origin::Producer) {
+	if publish.is_none() && consume.is_none() {
+		// Clones of a Producer share the underlying origin, so this is one origin, not two.
+		let shared = moq_net::Origin::random().produce();
+		return (shared.clone(), shared);
+	}
+
+	let resolve = |origin: Option<&Arc<MoqOriginProducer>>| {
+		origin
+			.map(|o| o.inner().clone())
+			.unwrap_or_else(|| moq_net::Origin::random().produce())
+	};
+	(resolve(publish), resolve(consume))
+}
+
 #[uniffi::export]
 impl MoqOriginProducer {
 	/// Create a new origin for publishing and/or consuming broadcasts.
@@ -161,24 +184,45 @@ impl MoqOriginProducer {
 		})
 	}
 
-	/// Announce a broadcast to this origin under the given path so
-	/// subscribers can discover it. Named `announce` (not `publish`) so
-	/// the `MoqSession::publisher().announce(...)` chain doesn't stutter
-	/// "publisher.publish".
-	pub fn announce(&self, path: String, broadcast: &MoqBroadcastProducer) -> Result<(), MoqError> {
+	/// Announce a broadcast to this origin under the given path so subscribers can discover it.
+	/// Named `announce` (not `publish`) so the `MoqSession::publisher().announce(...)` chain
+	/// doesn't stutter "publisher.publish".
+	///
+	/// The broadcast stays announced until the returned [`MoqAnnounce`] is unannounced or
+	/// dropped. Closing the broadcast alone does not unannounce it, so hold the handle for as
+	/// long as the broadcast should be discoverable.
+	pub fn announce(&self, path: String, broadcast: &MoqBroadcastProducer) -> Result<Arc<MoqAnnounce>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let consumer = broadcast.consume_inner()?;
 		// Surfaces Error::Unauthorized (out of scope) via the MoqError::Protocol conversion.
 		let publish = self.inner.publish_broadcast(path.as_str(), &consumer)?;
 
-		// Auto-unannounce when the broadcast closes (all producers dropped). The origin no longer
-		// watches closure itself, so the spawn lives here at the runtime-bound FFI boundary.
-		tokio::spawn(async move {
-			consumer.closed().await;
-			drop(publish);
-		});
+		Ok(Arc::new(MoqAnnounce {
+			inner: std::sync::Mutex::new(Some(publish)),
+		}))
+	}
+}
 
-		Ok(())
+// ---- MoqAnnounce ----
+
+/// A live announcement, returned by [`MoqOriginProducer::announce`].
+///
+/// This is the publish-side guard: it keeps one broadcast announced, and unannouncing it
+/// removes the path from the origin. (The subscribe-side [`MoqAnnounced`] is the unrelated
+/// stream of announcements arriving from a remote.)
+#[derive(uniffi::Object)]
+pub struct MoqAnnounce {
+	inner: std::sync::Mutex<Option<moq_net::origin::Publish>>,
+}
+
+#[uniffi::export]
+impl MoqAnnounce {
+	/// Unannounce the broadcast, removing it from the origin. Idempotent, and implied by
+	/// dropping this handle.
+	pub fn unannounce(&self) {
+		let _guard = crate::ffi::RUNTIME.enter();
+		// Dropping the moq-net guard is what unannounces.
+		drop(self.inner.lock().unwrap().take());
 	}
 }
 

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -5,7 +5,7 @@ use moq_mux::catalog::hang::Extra;
 use crate::consumer::{MoqBroadcastConsumer, MoqGroupConsumer, MoqSubscription, MoqTrackConsumer};
 use crate::error::MoqError;
 use crate::ffi::Task;
-use crate::media::MoqInit;
+use crate::media::{MoqFrame, MoqInit};
 
 /// Publisher-side track properties, mirroring [`moq_net::track::Info`].
 ///
@@ -683,30 +683,29 @@ impl MoqTrackProducer {
 		}))
 	}
 
-	/// Write a single-frame group with a presentation timestamp in microseconds.
+	/// Write `frame` as a single-frame group.
 	///
 	/// Raw tracks default to a microsecond timescale. Custom timescales may round
 	/// the timestamp during conversion.
-	pub fn write_frame(&self, payload: Vec<u8>, timestamp_us: u64) -> Result<(), MoqError> {
+	pub fn write_frame(&self, frame: MoqFrame) -> Result<(), MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		let timestamp = moq_net::Timestamp::from_micros(timestamp_us)?;
+		let timestamp = moq_net::Timestamp::from_micros(frame.timestamp_us)?;
 		let mut guard = self.inner.lock().unwrap();
 		let track = guard.as_mut().ok_or(MoqError::Closed)?;
-		track.write_frame(timestamp, payload)?;
+		track.write_frame(timestamp, frame.payload)?;
 		Ok(())
 	}
 
-	/// Send a best-effort datagram, returning its per-track sequence number.
+	/// Send `frame` as a best-effort datagram, returning the sequence number assigned to it.
 	///
-	/// `timestamp_us` is the presentation timestamp in microseconds. The payload
-	/// must be at most 1200 bytes. Datagrams are only delivered on transports and
+	/// The payload must be at most 1200 bytes. Datagrams are only delivered on transports and
 	/// wire versions with a datagram channel; there is no stream fallback.
-	pub fn append_datagram(&self, timestamp_us: u64, payload: Vec<u8>) -> Result<u64, MoqError> {
+	pub fn append_datagram(&self, frame: MoqFrame) -> Result<u64, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		let timestamp = moq_net::Timestamp::from_micros(timestamp_us)?;
+		let timestamp = moq_net::Timestamp::from_micros(frame.timestamp_us)?;
 		let mut guard = self.inner.lock().unwrap();
 		let track = guard.as_mut().ok_or(MoqError::Closed)?;
-		Ok(track.append_datagram(timestamp, payload)?)
+		Ok(track.append_datagram(timestamp, frame.payload)?)
 	}
 
 	/// Abort this track with an application error code.
@@ -767,16 +766,16 @@ impl MoqGroupProducer {
 		Ok(Arc::new(MoqGroupConsumer::new(group.consume())))
 	}
 
-	/// Write a frame into this group with a presentation timestamp in microseconds.
+	/// Write `frame` into this group.
 	///
 	/// Raw tracks default to a microsecond timescale. Custom timescales may round
 	/// the timestamp during conversion.
-	pub fn write_frame(&self, payload: Vec<u8>, timestamp_us: u64) -> Result<(), MoqError> {
+	pub fn write_frame(&self, frame: MoqFrame) -> Result<(), MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		let timestamp = moq_net::Timestamp::from_micros(timestamp_us)?;
+		let timestamp = moq_net::Timestamp::from_micros(frame.timestamp_us)?;
 		let mut guard = self.inner.lock().unwrap();
 		let group = guard.as_mut().ok_or_else(|| MoqError::Closed)?;
-		group.write_frame(timestamp, payload)?;
+		group.write_frame(timestamp, frame.payload)?;
 		Ok(())
 	}
 
@@ -857,18 +856,19 @@ impl MoqMediaProducer {
 		}
 	}
 
-	/// Write a frame to this media track.
+	/// Write `frame` to this media track.
 	///
-	/// `timestamp_us` is the presentation timestamp in microseconds.
-	pub fn write_frame(&self, payload: Vec<u8>, timestamp_us: u64) -> Result<(), MoqError> {
+	/// The importer derives keyframe status from the bitstream, so a [`MoqFrame`] carries only
+	/// the payload and its timestamp.
+	pub fn write_frame(&self, frame: MoqFrame) -> Result<(), MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		let mut guard = self.inner.lock().unwrap();
 		let media = guard.as_mut().ok_or_else(|| MoqError::Closed)?;
 
-		let timestamp = hang::container::Timestamp::from_micros(timestamp_us)?;
+		let timestamp = hang::container::Timestamp::from_micros(frame.timestamp_us)?;
 		media
 			.decoder
-			.decode(&payload, Some(timestamp))
+			.decode(&frame.payload, Some(timestamp))
 			.map_err(|err| MoqError::Codec(format!("decode failed: {err}")))?;
 
 		Ok(())

--- a/rs/moq-ffi/src/server.rs
+++ b/rs/moq-ffi/src/server.rs
@@ -226,23 +226,14 @@ impl MoqRequest {
 
 	/// Complete the MoQ handshake and return the established session.
 	///
-	/// Returns `AlreadyResponded` if `ok()` or `close()` has already been called.
-	pub async fn ok(&self) -> Result<Arc<MoqSession>, MoqError> {
+	/// Returns `AlreadyResponded` if `accept()` or `reject()` has already been called.
+	pub async fn accept(&self) -> Result<Arc<MoqSession>, MoqError> {
 		self.task
 			.run(|mut state| async move {
 				let request = state.request.take().ok_or(MoqError::AlreadyResponded)?;
-				// Materialize both origin sides (reusing the caller's if wired) so the
-				// session can publish/subscribe and the FFI can hand back a publisher/consumer.
-				let publish = state
-					.publish
-					.as_ref()
-					.map(|p| p.inner().clone())
-					.unwrap_or_else(|| moq_net::Origin::random().produce());
-				let subscribe = state
-					.consume
-					.as_ref()
-					.map(|p| p.inner().clone())
-					.unwrap_or_else(|| moq_net::Origin::random().produce());
+				// Materialize both origin sides so the session can publish/subscribe and the
+				// FFI can hand back a publisher/consumer.
+				let (publish, subscribe) = crate::origin::resolve_pair(state.publish.as_ref(), state.consume.as_ref());
 				let session = request
 					.with_publisher(&publish)
 					.with_subscriber(subscribe.clone())
@@ -256,8 +247,8 @@ impl MoqRequest {
 
 	/// Reject the session with the given HTTP status code.
 	///
-	/// Returns `AlreadyResponded` if `ok()` or `close()` has already been called.
-	pub async fn close(&self, code: u16) -> Result<(), MoqError> {
+	/// Returns `AlreadyResponded` if `accept()` or `reject()` has already been called.
+	pub async fn reject(&self, code: u16) -> Result<(), MoqError> {
 		self.task
 			.run(move |mut state| async move {
 				let request = state.request.take().ok_or(MoqError::AlreadyResponded)?;
@@ -270,7 +261,7 @@ impl MoqRequest {
 			.await
 	}
 
-	/// Cancel any in-flight `ok()` or `close()` call.
+	/// Cancel any in-flight `accept()` or `reject()` call.
 	pub fn cancel(&self) {
 		self.task.cancel();
 	}

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -16,19 +16,9 @@ impl Client {
 	async fn connect(&self, url: Url) -> Result<Arc<MoqSession>, MoqError> {
 		let client = self.config.clone().init().map_err(map_connect_error)?;
 
-		// Materialize both origin sides (reusing the caller's if wired, else a
-		// fresh one) so the session can publish/subscribe and the FFI can always
-		// hand back a publisher/consumer.
-		let publish = self
-			.publish
-			.as_ref()
-			.map(|p| p.inner().clone())
-			.unwrap_or_else(|| moq_net::Origin::random().produce());
-		let subscribe = self
-			.consume
-			.as_ref()
-			.map(|p| p.inner().clone())
-			.unwrap_or_else(|| moq_net::Origin::random().produce());
+		// Materialize both origin sides so the session can publish/subscribe and the FFI can
+		// always hand back a publisher/consumer.
+		let (publish, subscribe) = crate::origin::resolve_pair(self.publish.as_ref(), self.consume.as_ref());
 
 		let session = client
 			.with_publisher(&publish)
@@ -211,11 +201,12 @@ impl MoqClient {
 
 	/// Connect to a MoQ server and wait for the session to be established.
 	///
-	/// Any side not wired via [`set_publish`](Self::set_publish) /
-	/// [`set_consume`](Self::set_consume) gets a fresh origin, so the producer
-	/// and consumer sides are always accessible via [`MoqSession::publisher`]
-	/// and [`MoqSession::consumer`] without the caller constructing a
-	/// [`MoqOriginProducer`] themselves.
+	/// Both origin sides are always accessible via [`MoqSession::publisher`] and
+	/// [`MoqSession::consumer`], without the caller constructing a [`MoqOriginProducer`]
+	/// themselves. With neither [`set_publish`](Self::set_publish) nor
+	/// [`set_consume`](Self::set_consume) wired, the two sides share one origin, so a broadcast
+	/// announced on this session is also discoverable through it. Wiring either side opts out of
+	/// that and gives the other side its own fresh origin.
 	///
 	/// Can be cancelled by calling `cancel()`.
 	pub async fn connect(&self, url: String) -> Result<Arc<MoqSession>, MoqError> {

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -6,7 +6,7 @@ use crate::consumer::MoqFetchGroupOptions;
 use crate::consumer::MoqSubscription;
 use crate::error::MoqError;
 use crate::json::{MoqJsonSnapshotConfig, MoqJsonStreamConfig};
-use crate::media::MoqInit;
+use crate::media::{MoqFrame, MoqInit};
 
 use std::time::Duration;
 
@@ -68,7 +68,12 @@ fn publish_media_lifecycle() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let media = broadcast.publish_media(media_init("opus", init)).unwrap();
-	media.write_frame(b"opus frame".to_vec(), 1000).unwrap();
+	media
+		.write_frame(MoqFrame {
+			payload: b"opus frame".to_vec(),
+			timestamp_us: 1000,
+		})
+		.unwrap();
 	media.finish().unwrap();
 	broadcast.finish().unwrap();
 }
@@ -109,7 +114,12 @@ async fn raw_track_datagram_roundtrip() {
 	let consumer = track.consume(None).unwrap();
 	let payload = b"hello datagram".to_vec();
 
-	let sequence = track.append_datagram(123_456, payload.clone()).unwrap();
+	let sequence = track
+		.append_datagram(MoqFrame {
+			payload: payload.clone(),
+			timestamp_us: 123_456,
+		})
+		.unwrap();
 	let datagram = tokio::time::timeout(TIMEOUT, consumer.recv_datagram())
 		.await
 		.expect("timed out waiting for datagram")
@@ -133,7 +143,7 @@ async fn raw_track_info_reports_publisher_properties() {
 	let track = broadcast.publish_track("status".into(), Some(info)).unwrap();
 	let consumer = track.consume(None).unwrap();
 
-	let got = consumer.info().await.unwrap();
+	let got = consumer.info().unwrap();
 	assert_eq!(got.priority, 7);
 	assert!(!got.ordered);
 	assert_eq!(got.latency_max_ms, Some(2_500));
@@ -146,7 +156,7 @@ async fn raw_track_info_defaults_to_unordered() {
 	let track = broadcast.publish_track("status".into(), None).unwrap();
 	let consumer = track.consume(None).unwrap();
 
-	assert!(!consumer.info().await.unwrap().ordered);
+	assert!(!consumer.info().unwrap().ordered);
 }
 
 #[tokio::test]
@@ -169,7 +179,12 @@ async fn raw_track_update_does_not_wait_for_pending_read() {
 	});
 
 	let payload = b"updated subscription".to_vec();
-	track.write_frame(payload.clone(), 20_000).unwrap();
+	track
+		.write_frame(MoqFrame {
+			payload: payload.clone(),
+			timestamp_us: 20_000,
+		})
+		.unwrap();
 
 	let frame = tokio::time::timeout(TIMEOUT, read)
 		.await
@@ -272,7 +287,12 @@ async fn dynamic_track_request() {
 	// Accept the request as a raw track (which unblocks the subscribe), then write.
 	let track = request.accept(None).unwrap();
 	let payload = b"hello dynamic track".to_vec();
-	track.write_frame(payload.clone(), 0).unwrap();
+	track
+		.write_frame(MoqFrame {
+			payload: payload.clone(),
+			timestamp_us: 0,
+		})
+		.unwrap();
 
 	let track_consumer = tokio::time::timeout(TIMEOUT, subscribe)
 		.await
@@ -298,7 +318,12 @@ async fn raw_frame_timestamps() {
 	let consumer = track.consume(None).unwrap();
 
 	let payload = b"ready".to_vec();
-	track.write_frame(payload.clone(), 12_345).unwrap();
+	track
+		.write_frame(MoqFrame {
+			payload: payload.clone(),
+			timestamp_us: 12_345,
+		})
+		.unwrap();
 
 	let frame = tokio::time::timeout(TIMEOUT, consumer.read_frame())
 		.await
@@ -307,12 +332,16 @@ async fn raw_frame_timestamps() {
 		.expect("expected a frame");
 	assert_eq!(frame.payload, payload);
 	assert_eq!(frame.timestamp_us, 12_345);
-	assert!(!frame.keyframe);
 
 	let group = track.append_group().unwrap();
 	let group_consumer = group.consume().unwrap();
 	let payload = b"group frame".to_vec();
-	group.write_frame(payload.clone(), 23_456).unwrap();
+	group
+		.write_frame(MoqFrame {
+			payload: payload.clone(),
+			timestamp_us: 23_456,
+		})
+		.unwrap();
 	group.finish().unwrap();
 
 	let frame = tokio::time::timeout(TIMEOUT, group_consumer.read_frame())
@@ -322,7 +351,6 @@ async fn raw_frame_timestamps() {
 		.expect("expected a frame");
 	assert_eq!(frame.payload, payload);
 	assert_eq!(frame.timestamp_us, 23_456);
-	assert!(!frame.keyframe);
 
 	track.finish().unwrap();
 }
@@ -387,8 +415,18 @@ async fn fetches_cached_group_without_subscribing() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let track = broadcast.publish_track("events".into(), None).unwrap();
 	let group = track.append_group().unwrap();
-	group.write_frame(b"first".to_vec(), 0).unwrap();
-	group.write_frame(b"second".to_vec(), 20_000).unwrap();
+	group
+		.write_frame(MoqFrame {
+			payload: b"first".to_vec(),
+			timestamp_us: 0,
+		})
+		.unwrap();
+	group
+		.write_frame(MoqFrame {
+			payload: b"second".to_vec(),
+			timestamp_us: 20_000,
+		})
+		.unwrap();
 	group.finish().unwrap();
 
 	let consumer = broadcast.consume().unwrap();
@@ -428,7 +466,12 @@ async fn dynamic_track_serves_fetch_miss_and_priority() {
 	assert_eq!(request.priority(), 11);
 
 	let group = request.accept().unwrap();
-	group.write_frame(b"fetched".to_vec(), 100_000).unwrap();
+	group
+		.write_frame(MoqFrame {
+			payload: b"fetched".to_vec(),
+			timestamp_us: 100_000,
+		})
+		.unwrap();
 	group.finish().unwrap();
 
 	let fetched = tokio::time::timeout(TIMEOUT, fetch)
@@ -503,7 +546,12 @@ async fn requested_track_dynamic_survives_accept() {
 		.unwrap();
 	assert_eq!(group_request.sequence(), 9);
 	let group = group_request.accept().unwrap();
-	group.write_frame(b"archive".to_vec(), 180_000).unwrap();
+	group
+		.write_frame(MoqFrame {
+			payload: b"archive".to_vec(),
+			timestamp_us: 180_000,
+		})
+		.unwrap();
 	group.finish().unwrap();
 
 	let fetched = tokio::time::timeout(TIMEOUT, fetch)
@@ -529,7 +577,7 @@ async fn dynamic_track_request_can_publish_media() {
 		let consumer = consumer.clone();
 		tokio::spawn(async move {
 			consumer
-				.subscribe_media("requested-audio".into(), crate::media::Container::Legacy, None)
+				.subscribe_media("requested-audio".into(), crate::media::MoqContainer::Legacy, None)
 				.await
 		})
 	};
@@ -566,7 +614,12 @@ async fn dynamic_track_request_can_publish_media() {
 	assert_eq!(audio.channel_count, 2);
 
 	let payload = b"dynamic opus frame".to_vec();
-	media.write_frame(payload.clone(), 20_000).unwrap();
+	media
+		.write_frame(MoqFrame {
+			payload: payload.clone(),
+			timestamp_us: 20_000,
+		})
+		.unwrap();
 
 	let frame = tokio::time::timeout(TIMEOUT, media_consumer.next())
 		.await
@@ -650,12 +703,65 @@ fn unknown_format() {
 }
 
 #[tokio::test]
+async fn announce_handle_unannounces() {
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
+	let consumer = origin.consume();
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+
+	let announce = origin.announce("live".into(), &broadcast).unwrap();
+	tokio::time::timeout(TIMEOUT, consumer.request_broadcast("live".into()))
+		.await
+		.expect("timed out waiting for the announced broadcast")
+		.expect("an announced broadcast should resolve");
+
+	announce.unannounce();
+	let result = tokio::time::timeout(TIMEOUT, consumer.request_broadcast("live".into()))
+		.await
+		.expect("timed out waiting for the unannounced broadcast");
+	assert!(
+		result.is_err(),
+		"unannounce should remove the broadcast from the origin"
+	);
+}
+
+#[tokio::test]
+async fn closing_broadcast_leaves_it_announced() {
+	// The handle owns the announcement's lifetime: closing the broadcast is not an implicit
+	// unannounce, matching libmoq's moq_origin_unpublish contract.
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
+	let consumer = origin.consume();
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+
+	let _announce = origin.announce("live".into(), &broadcast).unwrap();
+	broadcast.finish().unwrap();
+
+	tokio::time::timeout(TIMEOUT, consumer.request_broadcast("live".into()))
+		.await
+		.expect("timed out waiting for the closed broadcast")
+		.expect("closing a broadcast must not unannounce it");
+}
+
+#[tokio::test]
+async fn dropping_announce_handle_unannounces() {
+	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
+	let consumer = origin.consume();
+	let broadcast = MoqBroadcastProducer::new().unwrap();
+
+	drop(origin.announce("live".into(), &broadcast).unwrap());
+
+	let result = tokio::time::timeout(TIMEOUT, consumer.request_broadcast("live".into()))
+		.await
+		.expect("timed out waiting for the dropped announcement");
+	assert!(result.is_err(), "dropping the handle should unannounce");
+}
+
+#[tokio::test]
 async fn local_publish_consume_audio() {
 	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let media = broadcast.publish_media(media_init("opus", init)).unwrap();
-	origin.announce("live".into(), &broadcast).unwrap();
+	let _announce = origin.announce("live".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -690,7 +796,12 @@ async fn local_publish_consume_audio() {
 		.unwrap();
 
 	let payload = b"opus audio payload data".to_vec();
-	media.write_frame(payload.clone(), 1_000_000).unwrap();
+	media
+		.write_frame(MoqFrame {
+			payload: payload.clone(),
+			timestamp_us: 1_000_000,
+		})
+		.unwrap();
 
 	let frame = tokio::time::timeout(TIMEOUT, media_consumer.next())
 		.await
@@ -708,7 +819,7 @@ async fn video_publish_consume() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = h264_init();
 	let media = broadcast.publish_media(media_init("avc3", init)).unwrap();
-	origin.announce("video-test".into(), &broadcast).unwrap();
+	let _announce = origin.announce("video-test".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -746,7 +857,12 @@ async fn video_publish_consume() {
 		.unwrap();
 
 	let keyframe = vec![0x00, 0x00, 0x00, 0x01, 0x65, 0xAA, 0xBB, 0xCC];
-	media.write_frame(keyframe, 0).unwrap();
+	media
+		.write_frame(MoqFrame {
+			payload: keyframe,
+			timestamp_us: 0,
+		})
+		.unwrap();
 
 	let frame = tokio::time::timeout(TIMEOUT, media_consumer.next())
 		.await
@@ -764,7 +880,7 @@ async fn multiple_frames_ordering() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let media = broadcast.publish_media(media_init("opus", init)).unwrap();
-	origin.announce("ordering-test".into(), &broadcast).unwrap();
+	let _announce = origin.announce("ordering-test".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -791,7 +907,12 @@ async fn multiple_frames_ordering() {
 	let timestamps: [u64; 5] = [0, 20_000, 40_000, 60_000, 80_000];
 	for (i, &ts) in timestamps.iter().enumerate() {
 		let payload = format!("frame-{i}");
-		media.write_frame(payload.into_bytes(), ts).unwrap();
+		media
+			.write_frame(MoqFrame {
+				payload: payload.into_bytes(),
+				timestamp_us: ts,
+			})
+			.unwrap();
 	}
 
 	for (i, &expected_ts) in timestamps.iter().enumerate() {
@@ -813,7 +934,7 @@ async fn catalog_update_on_new_track() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let _media1 = broadcast.publish_media(media_init("opus", init.clone())).unwrap();
-	origin.announce("catalog-update".into(), &broadcast).unwrap();
+	let _announce = origin.announce("catalog-update".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -861,7 +982,7 @@ fn finish_closes_producer() {
 async fn announced_broadcast() {
 	let origin = MoqOriginProducer::new(MoqOriginOptions::default());
 	let broadcast = MoqBroadcastProducer::new().unwrap();
-	origin.announce("test/broadcast".into(), &broadcast).unwrap();
+	let _announce = origin.announce("test/broadcast".into(), &broadcast).unwrap();
 
 	let consumer = origin.consume();
 	let announced = consumer.announced("".into()).unwrap();
@@ -906,7 +1027,12 @@ async fn dynamic_broadcast_request() {
 
 	let track_consumer = broadcast.subscribe_track("status".into(), None).await.unwrap();
 	let payload = b"served dynamically".to_vec();
-	track.write_frame(payload.clone(), 20_000).unwrap();
+	track
+		.write_frame(MoqFrame {
+			payload: payload.clone(),
+			timestamp_us: 20_000,
+		})
+		.unwrap();
 
 	let frame = tokio::time::timeout(TIMEOUT, track_consumer.read_frame())
 		.await
@@ -956,8 +1082,13 @@ fn without_runtime() {
 		let broadcast = MoqBroadcastProducer::new().unwrap();
 		let init = opus_head();
 		let media = broadcast.publish_media(media_init("opus", init)).unwrap();
-		media.write_frame(b"hello".to_vec(), 1000).unwrap();
-		origin.announce("test".into(), &broadcast).unwrap();
+		media
+			.write_frame(MoqFrame {
+				payload: b"hello".to_vec(),
+				timestamp_us: 1000,
+			})
+			.unwrap();
+		let _announce = origin.announce("test".into(), &broadcast).unwrap();
 
 		let announced = consumer.announced("".into()).unwrap();
 		let announcement = pollster::block_on(announced.next()).unwrap().unwrap();
@@ -1003,7 +1134,7 @@ async fn server_client_roundtrip() {
 			.await
 			.expect("accept errored")
 			.expect("accept returned None");
-		request.ok().await.expect("handshake failed")
+		request.accept().await.expect("handshake failed")
 	});
 
 	// Client side: connect, subscribe via a consume origin.
@@ -1026,7 +1157,7 @@ async fn server_client_roundtrip() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let media = broadcast.publish_media(media_init("opus", init)).unwrap();
-	server_origin.announce("hello".into(), &broadcast).unwrap();
+	let _announce = server_origin.announce("hello".into(), &broadcast).unwrap();
 
 	// Receive the announcement on the client side via the consume origin.
 	let consumer = client_origin.consume();
@@ -1053,7 +1184,12 @@ async fn server_client_roundtrip() {
 		.unwrap();
 
 	let payload = b"hello over the wire".to_vec();
-	media.write_frame(payload.clone(), 1_000_000).unwrap();
+	media
+		.write_frame(MoqFrame {
+			payload: payload.clone(),
+			timestamp_us: 1_000_000,
+		})
+		.unwrap();
 
 	let frame = tokio::time::timeout(TIMEOUT, media_consumer.next())
 		.await
@@ -1096,7 +1232,7 @@ async fn server_client_roundtrip_auto_origin() {
 			.await
 			.expect("accept errored")
 			.expect("accept returned None");
-		request.ok().await.expect("handshake failed")
+		request.accept().await.expect("handshake failed")
 	});
 
 	// No set_publish / set_consume, so this uses the auto-origin path.
@@ -1120,7 +1256,7 @@ async fn server_client_roundtrip_auto_origin() {
 	let broadcast = MoqBroadcastProducer::new().unwrap();
 	let init = opus_head();
 	let media = broadcast.publish_media(media_init("opus", init)).unwrap();
-	server_origin.announce("hello".into(), &broadcast).unwrap();
+	let _announce = server_origin.announce("hello".into(), &broadcast).unwrap();
 
 	let announced = consumer.announced("".into()).unwrap();
 	let announcement = tokio::time::timeout(TIMEOUT, announced.next())
@@ -1130,11 +1266,14 @@ async fn server_client_roundtrip_auto_origin() {
 		.expect("expected an announcement");
 	assert_eq!(announcement.path(), "hello");
 
-	// The auto publisher is wired too: dropping it should not break anything,
-	// and a local announce() on it should succeed (though the server
-	// isn't consuming, so we only verify the call doesn't error).
+	// With neither side wired, both share one origin, so a broadcast announced on this
+	// session's publisher is discoverable through its own consumer.
 	let local_broadcast = MoqBroadcastProducer::new().unwrap();
-	publisher.announce("local-only".into(), &local_broadcast).unwrap();
+	let _local_announce = publisher.announce("local-only".into(), &local_broadcast).unwrap();
+	tokio::time::timeout(TIMEOUT, consumer.request_broadcast("local-only".into()))
+		.await
+		.expect("timed out waiting for the loopback broadcast")
+		.expect("an auto-origin session should discover its own announcement");
 	local_broadcast.finish().unwrap();
 
 	media.finish().unwrap();
@@ -1199,13 +1338,13 @@ async fn request_double_respond_returns_already_responded() {
 			.expect("accept returned None");
 
 		// Accept once, then try a second response. It must error.
-		let session = request.ok().await.expect("first ok succeeds");
-		let second_ok = request.ok().await;
+		let session = request.accept().await.expect("first ok succeeds");
+		let second_ok = request.accept().await;
 		assert!(
 			matches!(second_ok, Err(MoqError::AlreadyResponded)),
 			"second ok() must fail"
 		);
-		let second_close = request.close(403).await;
+		let second_close = request.reject(403).await;
 		assert!(
 			matches!(second_close, Err(MoqError::AlreadyResponded)),
 			"close after ok must fail"
@@ -1252,7 +1391,7 @@ async fn request_per_session_publish_override() {
 			.expect("accept returned None");
 		// Override publish on a per-request basis.
 		request.set_publish(Some(override_for_task));
-		request.ok().await.expect("ok succeeds")
+		request.accept().await.expect("ok succeeds")
 	});
 
 	let client_origin = MoqOriginProducer::new(MoqOriginOptions::default());
@@ -1272,7 +1411,7 @@ async fn request_per_session_publish_override() {
 
 	// Publishing on the override origin must reach the client.
 	let broadcast = MoqBroadcastProducer::new().unwrap();
-	override_origin.announce("override-only".into(), &broadcast).unwrap();
+	let _announce = override_origin.announce("override-only".into(), &broadcast).unwrap();
 
 	let consumer = client_origin.consume();
 	let announced = consumer.announced("".into()).unwrap();

--- a/swift/README.md
+++ b/swift/README.md
@@ -64,7 +64,7 @@ The wrapper fully wraps every stateful handle (`Client`, `Session`, `BroadcastPr
 
 Every consumer conforms to `AsyncSequence`, so `for try await x in consumer` works directly. `TrackConsumer` iterates groups in sequence order; use its `groupsAsArrived` property for arrival order.
 
-Raw tracks also expose best-effort datagrams: `TrackProducer.appendDatagram(timestampUs:payload:)`
+Raw tracks also expose best-effort datagrams: `TrackProducer.appendDatagram(_:timestampUs:)`
 returns the assigned sequence number, `TrackConsumer.recvDatagram()` receives one datagram,
 and `TrackConsumer.datagrams` streams them in arrival order. Payloads are capped at 1200 bytes.
 Datagrams require a datagram-capable transport and lite-05 or newer moq-lite; IETF moq-transport,

--- a/swift/Sources/Moq/Aliases.swift
+++ b/swift/Sources/Moq/Aliases.swift
@@ -7,6 +7,8 @@ import MoqFFI
 // classes never appear in the public API.
 
 public typealias Frame = MoqFFI.MoqFrame
+/// A frame plus the codec metadata a media track carries.
+public typealias MediaFrame = MoqFFI.MoqMediaFrame
 public typealias Catalog = MoqFFI.MoqCatalog
 public typealias Video = MoqFFI.MoqVideo
 /// Caller-provided catalog fields for a video track.
@@ -19,7 +21,7 @@ public typealias AudioEncoderOutput = MoqFFI.MoqAudioEncoderOutput
 public typealias AudioDecoderOutput = MoqFFI.MoqAudioDecoderOutput
 public typealias AudioFormat = MoqFFI.MoqAudioFormat
 public typealias AudioCodec = MoqFFI.MoqAudioCodec
-public typealias Container = MoqFFI.Container
+public typealias Container = MoqFFI.MoqContainer
 public typealias Datagram = MoqFFI.MoqDatagram
 public typealias Subscription = MoqFFI.MoqSubscription
 /// Options for fetching one complete group by sequence.

--- a/swift/Sources/Moq/Broadcast.swift
+++ b/swift/Sources/Moq/Broadcast.swift
@@ -60,7 +60,8 @@ public final class BroadcastConsumer: Sendable {
         as _: Value.Type,
         compression: Bool = false
     ) async throws -> JsonSnapshotConsumer<Value> {
-        JsonSnapshotConsumer(try await ffi.subscribeJsonSnapshot(name: name, config: MoqJsonSnapshotConfig(deltaRatio: 0, compression: compression)))
+        // deltaRatio is producer-only, so leave it at its default here.
+        JsonSnapshotConsumer(try await ffi.subscribeJsonSnapshot(name: name, config: MoqJsonSnapshotConfig(compression: compression)))
     }
 
     /// Subscribe to a JSON stream track (lossless append-log), decoding each record as `Value`.
@@ -148,7 +149,7 @@ public final class BroadcastProducer: Sendable {
     public func publishJsonSnapshot<Value: Encodable>(
         name: String,
         of _: Value.Type,
-        deltaRatio: UInt32 = 8,
+        deltaRatio: UInt32 = MoqJsonSnapshotConfig().deltaRatio,
         compression: Bool = false
     ) throws -> JsonSnapshotProducer<Value> {
         JsonSnapshotProducer(try ffi.publishJsonSnapshot(name: name, config: MoqJsonSnapshotConfig(deltaRatio: deltaRatio, compression: compression)))

--- a/swift/Sources/Moq/Client.swift
+++ b/swift/Sources/Moq/Client.swift
@@ -61,6 +61,10 @@ public final class Client: Sendable {
     }
 
     /// Connect and wait for the session to be established. Cancellable via `cancel()`.
+    ///
+    /// With neither `setPublish` nor `setConsume` wired, both sides of the session share one
+    /// origin, so a broadcast announced via `Session.publisher` is also discoverable through
+    /// `Session.consumer`. Wiring either side opts out and isolates the two directions.
     public func connect(to url: String) async throws -> Session {
         Session(try await ffi.connect(url: url))
     }

--- a/swift/Sources/Moq/Media.swift
+++ b/swift/Sources/Moq/Media.swift
@@ -31,7 +31,7 @@ public final class CatalogConsumer: AsyncSequence, Sendable {
 
 /// Read side of a media track. Iterating yields decoded frames in decode order.
 public final class MediaConsumer: AsyncSequence, Sendable {
-    public typealias Element = Frame
+    public typealias Element = MediaFrame
 
     let ffi: MoqMediaConsumer
 
@@ -40,7 +40,7 @@ public final class MediaConsumer: AsyncSequence, Sendable {
     }
 
     /// The next frame, or `nil` once the track ends or is closed.
-    public func next() async throws -> Frame? {
+    public func next() async throws -> MediaFrame? {
         try await ffi.next()
     }
 
@@ -49,7 +49,7 @@ public final class MediaConsumer: AsyncSequence, Sendable {
         ffi.cancel()
     }
 
-    public func makeAsyncIterator() -> AsyncThrowingStream<Frame, Swift.Error>.Iterator {
+    public func makeAsyncIterator() -> AsyncThrowingStream<MediaFrame, Swift.Error>.Iterator {
         moqStream(cancel: { [ffi] in ffi.cancel() }) { [ffi] in
             try await ffi.next()
         }.makeAsyncIterator()
@@ -80,8 +80,11 @@ public final class MediaProducer: Sendable {
     }
 
     /// Write a frame with the given presentation timestamp (microseconds).
-    public func writeFrame(_ payload: Data, timestampUs: UInt64) throws {
-        try ffi.writeFrame(payload: payload, timestampUs: timestampUs)
+    ///
+    /// The importer derives keyframe status from the bitstream, so only the payload and its
+    /// timestamp cross the boundary.
+    public func writeFrame(_ payload: Data, timestampUs: UInt64 = 0) throws {
+        try ffi.writeFrame(frame: Frame(payload: payload, timestampUs: timestampUs))
     }
 
     /// Finish the track and finalize encoding.

--- a/swift/Sources/Moq/Origin.swift
+++ b/swift/Sources/Moq/Origin.swift
@@ -24,8 +24,29 @@ public final class OriginProducer: Sendable {
     }
 
     /// Announce a broadcast under the given path so subscribers can find it.
-    public func announce(path: String, broadcast: BroadcastProducer) throws {
-        try ffi.announce(path: path, broadcast: broadcast.ffi)
+    ///
+    /// Hold the returned `Announce` for as long as the broadcast should stay discoverable;
+    /// unannouncing it (or releasing it) removes the path. Closing the broadcast does not.
+    @discardableResult
+    public func announce(path: String, broadcast: BroadcastProducer) throws -> Announce {
+        Announce(try ffi.announce(path: path, broadcast: broadcast.ffi))
+    }
+}
+
+/// A live announcement, returned by `OriginProducer.announce`.
+///
+/// The publish-side guard keeping one broadcast announced. (The subscribe-side `Announced` is
+/// the unrelated stream of announcements arriving from a remote.)
+public final class Announce: Sendable {
+    let ffi: MoqAnnounce
+
+    init(_ ffi: MoqAnnounce) {
+        self.ffi = ffi
+    }
+
+    /// Unannounce the broadcast, removing it from the origin. Idempotent.
+    public func unannounce() {
+        ffi.unannounce()
     }
 }
 

--- a/swift/Sources/Moq/Server.swift
+++ b/swift/Sources/Moq/Server.swift
@@ -94,12 +94,12 @@ public final class Request: Sendable {
 
     /// Complete the handshake and return the established session.
     public func accept() async throws -> Session {
-        Session(try await ffi.ok())
+        Session(try await ffi.accept())
     }
 
     /// Reject the session with the given HTTP status code.
     public func reject(code: UInt16) async throws {
-        try await ffi.close(code: code)
+        try await ffi.reject(code: code)
     }
 
     /// Cancel any in-flight `accept()` or `reject()` call.

--- a/swift/Sources/Moq/Track.swift
+++ b/swift/Sources/Moq/Track.swift
@@ -36,8 +36,8 @@ public final class TrackConsumer: AsyncSequence, Sendable {
     }
 
     /// The publisher-side properties learned during subscription.
-    public func info() async throws -> TrackInfo {
-        try await ffi.info()
+    public func info() throws -> TrackInfo {
+        try ffi.info()
     }
 
     /// Change this subscriber's delivery preferences.
@@ -150,16 +150,16 @@ public final class TrackProducer: Sendable {
     }
 
     /// Write a single-frame group with a timestamp in microseconds.
-    public func writeFrame(_ payload: Data, timestampUs: UInt64) throws {
-        try ffi.writeFrame(payload: payload, timestampUs: timestampUs)
+    public func writeFrame(_ payload: Data, timestampUs: UInt64 = 0) throws {
+        try ffi.writeFrame(frame: Frame(payload: payload, timestampUs: timestampUs))
     }
 
     /// Send a best-effort datagram and return its sequence number.
     ///
     /// `timestampUs` is the presentation timestamp in microseconds. Payloads are
     /// capped at 1200 bytes. There is no stream fallback.
-    public func appendDatagram(timestampUs: UInt64, payload: Data) throws -> UInt64 {
-        try ffi.appendDatagram(timestampUs: timestampUs, payload: payload)
+    public func appendDatagram(_ payload: Data, timestampUs: UInt64 = 0) throws -> UInt64 {
+        try ffi.appendDatagram(frame: Frame(payload: payload, timestampUs: timestampUs))
     }
 
     /// Abort the track with an application error code, failing active consumers.
@@ -198,8 +198,8 @@ public final class GroupProducer: Sendable {
     }
 
     /// Write a frame with a timestamp in microseconds.
-    public func writeFrame(_ payload: Data, timestampUs: UInt64) throws {
-        try ffi.writeFrame(payload: payload, timestampUs: timestampUs)
+    public func writeFrame(_ payload: Data, timestampUs: UInt64 = 0) throws {
+        try ffi.writeFrame(frame: Frame(payload: payload, timestampUs: timestampUs))
     }
 
     /// Mark the group complete. No more frames can be written.

--- a/test/smoke/clients/python/smoke.py
+++ b/test/smoke/clients/python/smoke.py
@@ -24,7 +24,8 @@ async def publish(url: str, broadcast: str) -> None:
     media = producer.publish_media_stream("avc3")
 
     async with moq.Client(url, tls_verify=False) as client:
-        client.publish(broadcast, producer)
+        # Hold the announcement for the lifetime of the publish loop; dropping it unannounces.
+        _announce = client.announce(broadcast, producer)
         print(f"publishing {broadcast!r} (Annex-B H.264 from stdin) to {url}")
 
         loop = asyncio.get_running_loop()


### PR DESCRIPTION
Closes #2315.

Batch of `moq-ffi` API-shape inconsistencies, each mirrored into `libmoq` and all four wrappers (py/swift/kt/go) plus their docs. All are breaking, so they land together on `dev` and consumers migrate once instead of per-item.

## What changed (per issue item)

1. **Datagram/frame writes take a record.** `write_frame` and `append_datagram` now take `MoqFrame { payload, timestamp_us }` instead of flipped positional args (`append_datagram` was ts-then-payload, `write_frame` was payload-then-ts). One record, one order, room for future fields. `libmoq` (no records) instead unifies `moq_publish_track_datagram` to payload-then-timestamp, matching its own `moq_publish_track_frame`; `moq.h` regenerates accordingly.
   - **Deviation from the plan, please sanity-check:** the issue suggested a `MoqDatagram` write record, but `js/net` (the cited model) keeps `appendDatagram` positional precisely because `sequence` is an *output*. So I used one `MoqFrame { payload, timestamp_us }` for all writes and dropped the `keyframe` flag from it (a lie on the two write paths and the raw read path, which documented "always false"). Media reads return a new `MoqMediaFrame` that carries `keyframe`.
2. **`MoqRequest.ok()/close(code)` → `accept()/reject(code)`**, matching Swift's prior rename and the sibling `*Request` types. "close" read as benign and collided with UniFFI's `AutoCloseable.close()` in Kotlin.
3. **Error-code ints** were already `u16` on `dev`; nothing to do. `Session.cancel(u32)` (a MoQ error code) vs `Request.reject(u16)` (an HTTP status) are genuinely different and left alone.
4. **`MoqJsonSnapshotConfig` gains `#[uniffi(default = 8)]`** on `delta_ratio` + a `compression` default, so every binding inherits them instead of reinventing the default (Go's zero value silently disabled deltas). A Rust test pins the literal to `moq-json`'s own default. Go has no field defaults, so it uses a nil `*uint32` + `DefaultDeltaRatio`.
5. **`Container` → `MoqContainer`** — the last unprefixed exported type in UniFFI's flat namespace. (Note: this does *not* fix Kotlin's `uniffi.moq.*` leak — sealed types like `MoqException` can't be typealiased either — but it's still worth the flat-namespace consistency.)
6. **`announce()` returns a `MoqAnnounce` guard.** Unannouncing (or dropping) it removes the path; closing the broadcast alone no longer unannounces. Matches moq-net's `origin::Publish` and `libmoq`'s `moq_origin_unpublish`.
7. **`MoqTrackConsumer.info()` is now sync** (its body always was).
8. **The shared loopback-origin default moves into the FFI** (`origin::resolve_pair`, used by `Client::connect` / `Request.ok`), so py/kt/go stop reimplementing it and Swift gains it (announce-then-discover-locally previously yielded nothing there).

## Regression tests

- Announce-handle lifecycle: unannounce removes the path, dropping the handle unannounces, and closing the broadcast does **not** unannounce (encodes the libmoq contract).
- Loopback default: an auto-origin session discovers its own announcement.
- `MoqJsonSnapshotConfig` defaults stay in lockstep with `moq-json`.

## Cross-package sync

All wrappers, their tests, `doc/lib/{py,swift,kt,go}`, and the READMEs are updated. `libmoq`'s `moq.h` regenerates from the reordered datagram signature. No wire-format change, so no draft update.

## Verification

Green against the current `dev` tip: `cargo test -p moq-ffi -p libmoq` (47 + 35), clippy, `cargo fmt --check`, `cargo doc -D warnings`, remark; Python (`just py check` + 49 tests), Go (`just go check`: vet/build/`test -race`), Kotlin (`just kt check`: build + tests). Swift's wrapper **and** tests typecheck against freshly regenerated bindings, but were **not executed** — this machine's Xcode can't build the XCFramework (`IDESimulatorFoundation` plugin load failure), so CI is the first real Swift run.

**`just test smoke-full` (cross-language interop) has not been run** and is owed for a change of this shape.

This branch was rebased onto `dev` twice to absorb #2345 (wrapper convergence) and later Rust-side breaking changes (#2359 `tls_info→certificates`, #2366 Timestamp-as-instant, #2348 stats, #2367 `CacheFull→Lagged`); conflict resolutions kept both sides (e.g. #2345's `DeprecationWarning`s + this PR's `Announce`-returning signatures, and rebinding announce call sites that #2345 left unbound since they now leak an unannounce).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
