### PR TITLE
fix(js/net): give the ietf server odd request IDs so v14-16 subscribes don't hang

### DIFF
--- a/js/net/src/connection/accept.ts
+++ b/js/net/src/connection/accept.ts
@@ -51,6 +51,7 @@ async function acceptAlpn(transport: WebTransport, url: URL, version: Ietf.IetfV
 	const controlStream = await exchangeSetup(transport, version, "moq-lite-js");
 
 	return new Ietf.Connection({
+		client: false,
 		url,
 		quic: transport,
 		control: controlStream,
@@ -89,6 +90,7 @@ async function acceptSetup(transport: WebTransport, url: URL, version: Ietf.Ietf
 	const maxRequestId = 42069n;
 
 	return new Ietf.Connection({
+		client: false,
 		url,
 		quic: transport,
 		control: stream,
@@ -140,6 +142,7 @@ async function acceptNegotiated(transport: WebTransport, url: URL, props?: Accep
 	} else if (Object.values(Ietf.Version).includes(selectedVersion as Ietf.Version)) {
 		const maxRequestId = client.parameters.getVarint(Ietf.SetupOption.MaxRequestId) ?? 0n;
 		return new Ietf.Connection({
+			client: false,
 			url,
 			quic: transport,
 			control: stream,

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -200,6 +200,7 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	} else if (Object.values(Ietf.Version).includes(server.version as Ietf.Version)) {
 		const maxRequestId = server.parameters.getVarint(Ietf.SetupOption.MaxRequestId) ?? 0n;
 		return new Ietf.Connection({
+			client: true,
 			url,
 			quic: session,
 			control: stream,
@@ -275,6 +276,7 @@ async function connectTransport(url: URL, session: WebTransport): Promise<Establ
 	} else if (Object.values(Ietf.Version).includes(server.version as Ietf.Version)) {
 		const maxRequestId = server.parameters.getVarint(Ietf.SetupOption.MaxRequestId) ?? 0n;
 		return new Ietf.Connection({
+			client: true,
 			url,
 			quic: session,
 			control: stream,
@@ -294,6 +296,7 @@ async function handshakeAlpn(url: URL, session: WebTransport, version: Ietf.Ietf
 	const controlStream = await exchangeSetup(session, version, "moq-lite-js");
 
 	return new Ietf.Connection({
+		client: true,
 		url,
 		quic: session,
 		control: controlStream,

--- a/js/net/src/ietf/adapter.ts
+++ b/js/net/src/ietf/adapter.ts
@@ -23,12 +23,15 @@ export interface Session {
  */
 export class NativeSession implements Session {
 	#quic: WebTransport;
-	#requestId = 0n;
+	// moq-transport reserves even request IDs for the client and odd for the server,
+	// so the two peers' ID spaces never overlap.
+	#requestId: bigint;
 	readonly version: IetfVersion;
 
-	constructor(quic: WebTransport, version: IetfVersion) {
+	constructor(quic: WebTransport, version: IetfVersion, client: boolean) {
 		this.#quic = quic;
 		this.version = version;
+		this.#requestId = client ? 0n : 1n;
 	}
 
 	async openBi(): Promise<Stream> {
@@ -101,14 +104,26 @@ export class ControlStreamAdapter implements Session {
 	#incomingQueue: Stream[] = [];
 	#incomingWaiters: ((stream: Stream | undefined) => void)[] = [];
 
-	// Request ID flow control
-	#requestId = 0n;
+	// Request ID flow control. moq-transport reserves even request IDs for the
+	// client and odd for the server, so the two peers' ID spaces never overlap.
+	// This matters here because a single `#streams` map routes every request by
+	// ID: overlapping spaces would let an inbound request clobber the routing
+	// entry of an outbound one with the same number (e.g. an inbound
+	// PUBLISH_NAMESPACE stealing a pending SUBSCRIBE's slot, so SUBSCRIBE_OK is
+	// delivered to the wrong virtual stream).
+	#requestId: bigint;
 	#maxRequestId: bigint;
 	#maxRequestIdResolves: (() => void)[] = [];
 
 	#closed = false;
 
-	constructor(quic: WebTransport, controlStream: Stream, version: IetfVersion, maxRequestId: bigint) {
+	constructor(
+		quic: WebTransport,
+		controlStream: Stream,
+		version: IetfVersion,
+		maxRequestId: bigint,
+		client: boolean,
+	) {
 		this.#quic = quic;
 		this.#reader = controlStream.reader;
 		this.#reader.version = version;
@@ -116,6 +131,7 @@ export class ControlStreamAdapter implements Session {
 		this.#writer.version = version;
 		this.version = version;
 		this.#maxRequestId = maxRequestId;
+		this.#requestId = client ? 0n : 1n;
 	}
 
 	/**

--- a/js/net/src/ietf/connection.ts
+++ b/js/net/src/ietf/connection.ts
@@ -58,12 +58,16 @@ export class Connection implements Established {
 		control,
 		maxRequestId,
 		version,
+		client,
 	}: {
 		url: URL;
 		quic: WebTransport;
 		control: Stream;
 		maxRequestId: bigint;
 		version: IetfVersion;
+		// True if we initiated the session (connect), false if we accepted it. Selects
+		// the even/odd request-ID space per moq-transport.
+		client: boolean;
 	}) {
 		this.url = url;
 		this.version = versionName(version);
@@ -71,11 +75,11 @@ export class Connection implements Established {
 
 		// Two-path dispatch: v14-v16 uses adapter, v17+ uses native bidi streams
 		if (version >= Version.DRAFT_17) {
-			this.#session = new NativeSession(quic, version);
+			this.#session = new NativeSession(quic, version, client);
 			// v17+: control/setup stream only carries GoAway
 			void this.#runGoAway(control, version);
 		} else {
-			const adapter = new ControlStreamAdapter(quic, control, version, maxRequestId);
+			const adapter = new ControlStreamAdapter(quic, control, version, maxRequestId, client);
 			this.#session = adapter;
 			// Start the adapter read loop (routes control messages to virtual streams)
 			void adapter.run().catch((err: unknown) => {

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -88,6 +88,58 @@ test("integration: ietf draft-19", async () => {
 	await runPublishSubscribeFlow(Ietf.ALPN.DRAFT_19);
 });
 
+// Regression: on the multiplexed control-stream drafts (14-16) a subscribe must
+// resolve even when it races an inbound announce, without first "warming" the
+// session by reading the announce. The client and server share one virtual-stream
+// routing map keyed by request ID, so if both peers allocated from the same ID
+// space the inbound PUBLISH_NAMESPACE would clobber the pending SUBSCRIBE's slot
+// and SUBSCRIBE_OK would be delivered to the wrong stream, hanging forever.
+async function runSubscribeWithoutWarmup(version: number) {
+	const pair = createMockTransportPair("");
+
+	const [client, server] = await Promise.all([
+		connect(url, { transport: pair.client }),
+		accept(pair.server, url, { version }),
+	]);
+
+	const broadcast = new Broadcast();
+	server.publish(Path.from("test"), broadcast);
+	const serving = (async () => {
+		const req = await broadcast.requested();
+		if (req) req.track.writeString("hello");
+	})();
+
+	// Subscribe immediately, without awaiting the announce.
+	const remote = client.consume(Path.from("test"));
+	const track = remote.subscribe("video", 0);
+
+	const data = await Promise.race([
+		track.readString(),
+		new Promise<never>((_, reject) =>
+			setTimeout(() => reject(new Error("timed out waiting for SUBSCRIBE_OK")), 2000),
+		),
+	]);
+	expect(data).toBe("hello");
+
+	await serving;
+	broadcast.close();
+	remote.close();
+	client.close();
+	server.close();
+}
+
+test("integration: ietf draft-14 subscribe without announce warmup", async () => {
+	await runSubscribeWithoutWarmup(Ietf.Version.DRAFT_14);
+});
+
+test("integration: ietf draft-15 subscribe without announce warmup", async () => {
+	await runSubscribeWithoutWarmup(Ietf.Version.DRAFT_15);
+});
+
+test("integration: ietf draft-16 subscribe without announce warmup", async () => {
+	await runSubscribeWithoutWarmup(Ietf.Version.DRAFT_16);
+});
+
 test("integration: subscribe to non-existent broadcast", async () => {
 	const pair = createMockTransportPair("");
 


### PR DESCRIPTION
## Summary

A draft-14/15/16 (`@moq/net`) subscribe hangs waiting for `SUBSCRIBE_OK` when it races an inbound announce, unless the session is first "warmed" by reading an announce round-trip. Root cause: the ietf server used the wrong request-ID space.

moq-transport reserves **even** request IDs for the client and **odd** for the server, so the two peers' ID spaces never overlap. The JS ietf session allocated from `0` for both roles: both `ControlStreamAdapter` (v14-16) and `NativeSession` (v17) started `#requestId` at `0n` and incremented by 2, so a JS server also emitted even IDs. The Rust side already does this correctly (`rs/moq-net/src/ietf/control.rs`: `if client { RequestId(0) } else { RequestId(1) }`).

## Why it hangs (v14-16 only)

Drafts 14-16 multiplex every request through a single virtual-stream routing map keyed by request ID (`ControlStreamAdapter.#streams`). With overlapping ID spaces, an inbound request clobbers the routing entry of an outbound one that shares its number:

1. Client's outgoing `SUBSCRIBE` registers `#streams[0]`.
2. Server's inbound `PUBLISH_NAMESPACE` (server req `0`) overwrites `#streams[0]` via `#newRequest`.
3. Server sends `SUBSCRIBE_OK` (req `0`); the client routes it to `#streams[0]`, which now points at the **announce's** virtual stream, not the subscribe's. The subscribe's reader never completes → hang.

Reading the announce first reshuffles allocation/timing so the pending subscribe's ID no longer coincides with a live inbound request — which is why the "announce warmup" masked it. Draft-17+ uses native bidi streams with no shared routing map, so the same ID collision is benign there (and why draft-17 was unaffected).

**Scope:** only bites when a JS peer is the draft-14/15/16 **server** (`accept`) — JS↔JS (including the `createMockTransportPair` integration tests), or any client against a JS server. A JS client against the Rust relay is fine, because the Rust server correctly uses odd IDs.

## On `main` too?

Yes. `#requestId = 0n` is identical on `origin/main` and `origin/dev`, so both branches carry the bug. This targets `main` per the branch policy (a bug fix that brings the server into spec conformance, not a break of a published contract; the `client` field is added to the `@internal` `Ietf.Connection` constructor, `connect`/`accept` signatures are unchanged).

## Fix

Thread a `client` boolean into the ietf `Connection` and seed `#requestId` to `0` (client) / `1` (server) in both `ControlStreamAdapter` and `NativeSession`.

## Test plan

- [x] New regression test: subscribe **without** an announce warmup on drafts 14/15/16 (`integration.test.ts`). Fails without the fix (draft-14), passes with it.
- [x] `just js check` passes (typecheck + biome + all package tests, 93 net tests).

## Follow-up (not in this PR)

- `js/net/src/ietf/control.ts` contains a legacy `Stream` control-stream class with the same latent `#requestId = 0n` ("The client always starts at 0"). It appears unused by the active path (the adapter in `adapter.ts` is what `Connection` wires up). Worth deleting or fixing separately.
- The ietf subscriber/publisher/adapter carry committed `console.debug` tracing on the hot path (`subscribe start`, `publish ok`, `adapter: closing stream ...`) that's worth removing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)