### PR TITLE
fix(libmoq): write moq.pc under a profile-scoped path so debug/release don't collide

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -108,16 +108,17 @@ let
       mkdir -p $out/lib/pkgconfig $out/include $out/lib/cmake/moq
 
       # build.rs derives its output dir from OUT_DIR, so a cross --target
-      # build puts the staticlib, header and pkgconfig (under lib/) below
-      # target/<triple>/. Keep the prefix target-aware so the native and
-      # cross outputs share one installPhase.
+      # build puts the staticlib and pkgconfig (under <profile>/lib/) below
+      # target/<triple>/, and the shared header under target/<triple>/include/.
+      # Keep the prefix target-aware so the native and cross outputs share one
+      # installPhase.
       tdir="target''${CARGO_BUILD_TARGET:+/$CARGO_BUILD_TARGET}"
       cp "$tdir/release/libmoq.a" $out/lib/
       cp "$tdir/include/moq.h" $out/include/
-      cp "$tdir/lib/pkgconfig/moq.pc" $out/lib/pkgconfig/
+      cp "$tdir/release/lib/pkgconfig/moq.pc" $out/lib/pkgconfig/
 
       # build.rs points libdir at the raw cargo target tree's profile dir
-      # (../../<profile>). The installPhase puts the staticlib in $out/lib
+      # (../.. from the .pc). The installPhase puts the staticlib in $out/lib
       # alongside pkgconfig/, so rewrite libdir one level up. Match the whole
       # line so this is independent of the profile name and the exact .pc
       # template. Stays relocatable; no build-time path leaks into the store.

--- a/rs/libmoq/README.md
+++ b/rs/libmoq/README.md
@@ -12,7 +12,7 @@ This will:
 
 - Build the static library (`libmoq.a` on Unix-like systems, `moq.lib` on Windows)
 - Generate the C header file at `target/include/moq.h`
-- Generate the pkg-config file at `target/lib/pkgconfig/moq.pc`
+- Generate the pkg-config file at `target/release/lib/pkgconfig/moq.pc`
 
 There's also a [CMakeLists.txt](CMakeLists.txt) file that can be used to import/build the library.
 

--- a/rs/libmoq/build.rs
+++ b/rs/libmoq/build.rs
@@ -7,9 +7,11 @@ const LIB_NAME: &str = "moq";
 fn main() {
 	let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 	let version = env::var("CARGO_PKG_VERSION").unwrap();
-	let target_dir = target_dir();
+	let profile_dir = profile_dir();
+	let target_dir = profile_dir.parent().expect("profile dir has no parent");
 
-	// Generate C header into target/include/
+	// Generate C header into target/include/. The header is profile-independent,
+	// so a debug and release build in the same target tree can share it.
 	let include_dir = target_dir.join("include");
 	fs::create_dir_all(&include_dir).expect("Failed to create include directory");
 	let header = include_dir.join(format!("{}.h", LIB_NAME));
@@ -20,15 +22,17 @@ fn main() {
 		.expect("Unable to generate bindings")
 		.write_to_file(&header);
 
-	// Generate pkg-config file into target/lib/pkgconfig/ so the raw cargo
-	// target tree matches the conventional lib/ layout consumers expect.
+	// Generate the pkg-config file next to the staticlib under the profile dir
+	// (target/<profile>/lib/pkgconfig/). Scoping it per profile, rather than a
+	// shared target/lib/pkgconfig/, keeps a debug and release build from
+	// clobbering each other's moq.pc, and lets libdir resolve to the sibling
+	// staticlib without a profile placeholder.
 	let pc_in = PathBuf::from(&crate_dir).join(format!("{}.pc.in", LIB_NAME));
-	let pkgconfig_dir = target_dir.join("lib").join("pkgconfig");
+	let pkgconfig_dir = profile_dir.join("lib").join("pkgconfig");
 	fs::create_dir_all(&pkgconfig_dir).expect("Failed to create pkgconfig directory");
 	let pc_out = pkgconfig_dir.join(format!("{}.pc", LIB_NAME));
 	if let Ok(template) = fs::read_to_string(&pc_in) {
 		let target = env::var("TARGET").unwrap();
-		let profile = env::var("PROFILE").unwrap();
 		let libs_private = if target.contains("apple") {
 			"-framework CoreFoundation -framework Security -framework CoreServices"
 		} else if target.contains("windows") {
@@ -39,22 +43,23 @@ fn main() {
 
 		let content = template
 			.replace("@VERSION@", &version)
-			.replace("@LIBS_PRIVATE@", libs_private)
-			.replace("@PROFILE@", &profile);
+			.replace("@LIBS_PRIVATE@", libs_private);
 		fs::write(&pc_out, content).expect("Failed to write pkg-config file");
 	}
 }
 
-fn target_dir() -> PathBuf {
+fn profile_dir() -> PathBuf {
 	// OUT_DIR is set by Cargo based on whether --target is used:
 	// - With --target: target/{target}/{profile}/build/{crate}-{hash}/out
 	// - Without --target: target/{profile}/build/{crate}-{hash}/out
-	// Go up 4 levels to get to target/ or target/{target}/
+	// Go up 3 levels to the profile dir (where the staticlib is written); its
+	// parent is target/ or target/{target}/. Deriving from OUT_DIR (rather than
+	// the PROFILE env var) stays correct for custom profiles, whose output dir
+	// name is the profile name even though PROFILE reports "debug"/"release".
 	PathBuf::from(env::var("OUT_DIR").unwrap())
 		.parent() // build/{crate}-{hash}
 		.and_then(|p| p.parent()) // build/
-		.and_then(|p| p.parent()) // {profile}/ or {target}/{profile}/
-		.and_then(|p| p.parent()) // target/ or target/{target}/
-		.expect("Failed to get target directory from OUT_DIR")
+		.and_then(|p| p.parent()) // {profile}/
+		.expect("Failed to get profile directory from OUT_DIR")
 		.to_path_buf()
 }

--- a/rs/libmoq/moq.pc.in
+++ b/rs/libmoq/moq.pc.in
@@ -1,10 +1,11 @@
 # Paths are relative to this .pc file so the raw `cargo build` target tree is
-# usable directly (e.g. PKG_CONFIG_PATH=target/lib/pkgconfig). The staticlib
-# lives in the profile dir (target/<profile>/), the header in target/include/.
+# usable directly (e.g. PKG_CONFIG_PATH=target/<profile>/lib/pkgconfig). The
+# staticlib sits in the profile root two dirs up (target/<profile>/); the header
+# is shared across profiles in target/include/.
 # Packagers that relocate into a conventional lib/+include/ layout rewrite
 # libdir; see nix/overlay.nix.
-libdir=${pcfiledir}/../../@PROFILE@
-includedir=${pcfiledir}/../../include
+libdir=${pcfiledir}/../..
+includedir=${pcfiledir}/../../../include
 
 Name: moq
 Description: Media over QUIC C Interface


### PR DESCRIPTION
## Problem

`rs/libmoq/build.rs` writes the generated pkg-config file to a fixed, profile-independent path (`$TARGET_BASE/lib/pkgconfig/moq.pc`, where `$TARGET_BASE` is `target/` or `target/{triple}/`), but substitutes `@PROFILE@` into its **body**:

```
libdir=${pcfiledir}/../../@PROFILE@
```

So a debug build and a release build in the same target tree overwrite the *same* `moq.pc` with *different* content (last-writer-wins). Whichever built last leaves a `moq.pc` whose `libdir` points at the other profile's staticlib. The generated `moq.h` is genuinely profile-independent, so it's fine at its shared path; `moq.pc` is not.

## Fix

Write `moq.pc` next to the staticlib under the profile dir: `$TARGET_BASE/{profile}/lib/pkgconfig/moq.pc`.

With the profile now encoded in the *path*, `libdir` resolves relatively (`${pcfiledir}/../..`) and the `@PROFILE@` placeholder drops out entirely. The file's content becomes profile-independent, and debug/release land at distinct, non-colliding paths — each `moq.pc` pointing at its own sibling staticlib.

Also switched from `env::var("PROFILE")` to deriving the profile dir from `OUT_DIR` (3 parents up). For custom cargo profiles, `PROFILE` reports `"debug"`/`"release"` while the output dir is named after the profile, so `OUT_DIR` is the correct source of the actual output location. The header stays at `target/include/moq.h` (profile-independent, shared).

### New layout

| artifact | before | after |
|---|---|---|
| header | `target/include/moq.h` | `target/include/moq.h` (unchanged) |
| pkg-config | `target/lib/pkgconfig/moq.pc` | `target/{profile}/lib/pkgconfig/moq.pc` |

## Consumers reconciled

- **`nix/overlay.nix`** — copies from `$tdir/release/lib/pkgconfig/moq.pc` now (the nix build is release; path is cross-`--target` aware). The `libdir` rewrite already replaces the whole line, so it's unaffected. Comments updated.
- **`rs/libmoq/README.md`** — documents `target/release/lib/pkgconfig/moq.pc`.
- **`test/smoke/smoke.sh`** — no change: it never reads `moq.pc`; it compiles the C client with `-I$TARGET_BASE/include -L$TARGET_BASE/$PROFILE`, both unchanged.
- **cmake (`rs/libmoq/CMakeLists.txt`, `cpp/obs`)** — no change: obs uses `add_subdirectory` and references target paths directly; it never consumes `moq.pc`.

## Verification

Built `libmoq` (debug), then confirmed `pkg-config --libs --cflags moq` (with `PKG_CONFIG_PATH=target/debug/lib/pkgconfig`) resolves `libdir` → `target/debug/libmoq.a` and `includedir` → `target/include/moq.h`, both existing at the computed relative paths. Only one `moq.pc` exists, at the profile-scoped path. `cargo fmt` clean via the Nix dev shell.

Targets `main` per Branch Targeting: additive/bugfix, no published-contract break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 4.8)