### PR TITLE
feat(moq-hls): expose the export observers a recorder needs

### DIFF
--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -80,11 +80,13 @@ impl Broadcaster {
 		Ok(broadcaster)
 	}
 
-	pub(crate) fn is_closed(&self) -> bool {
+	/// Whether the source broadcast has closed (ended or dropped).
+	pub fn is_closed(&self) -> bool {
 		self.broadcast.is_closed()
 	}
 
-	pub(crate) async fn closed(&self) {
+	/// Resolve once the source broadcast closes. A recorder awaits this to finalize.
+	pub async fn closed(&self) {
 		self.broadcast.closed().await;
 	}
 
@@ -92,6 +94,22 @@ impl Broadcaster {
 	/// video and an audio rendition may share a name without colliding.
 	pub fn rendition(&self, kind: Kind, name: &str) -> Option<Arc<Rendition>> {
 		self.renditions.lock().unwrap().get(&(kind, name.to_string())).cloned()
+	}
+
+	/// Snapshot the current renditions. Unlike [`Self::rendition`] (serve one on
+	/// request), this is for consumers that mirror or RECORD every rendition; pair it
+	/// with [`Self::updated`] to re-enumerate whenever the catalog changes.
+	pub fn renditions(&self) -> Vec<Arc<Rendition>> {
+		self.renditions.lock().unwrap().values().cloned().collect()
+	}
+
+	/// Subscribe to catalog reconciliations. The value is the current rendition count
+	/// and fires on every sync (a rendition added, removed, or reconfigured), so a
+	/// recorder can re-read [`Self::renditions`] and pick up the new set. This is the
+	/// broadcast-level analogue of [`Rendition::updated`] (per-rendition timeline
+	/// changes).
+	pub fn updated(&self) -> watch::Receiver<usize> {
+		self.ready.subscribe()
 	}
 
 	/// Wait until at least one rendition has been discovered, or `timeout` elapses.

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -166,8 +166,11 @@ impl Rendition {
 		})
 	}
 
-	/// Subscribe to timeline-window changes, for waiting until a playlist is renderable.
-	pub(crate) fn updated(&self) -> tokio::sync::watch::Receiver<u64> {
+	/// Subscribe to timeline-window changes: the value bumps whenever this rendition's
+	/// timeline advances (a new segment closes) or the source ends. A recorder awaits
+	/// this, then reads [`Self::playlist`] to fetch and persist the newly-closed
+	/// segments via [`Self::segment`] before the window evicts them.
+	pub fn updated(&self) -> tokio::sync::watch::Receiver<u64> {
 		self.live.subscribe()
 	}
 
@@ -206,7 +209,7 @@ impl Rendition {
 
 	/// Whether the playlist has anything to serve yet (at least one complete segment, or the
 	/// broadcast already ended).
-	pub(crate) fn playable(&self) -> bool {
+	pub fn playable(&self) -> bool {
 		let window = self.live.window();
 		window.ended || !window.segments.is_empty()
 	}


### PR DESCRIPTION
## What

The `export::Broadcaster` is built to *serve* HLS on demand: it exposes `rendition()` (look up one) and `master_playlist()`, but keeps rendition enumeration and the change signals internal. A consumer that *records* a broadcast (mirrors every rendition to durable storage) needs to observe the same state the server does, so this exposes it read-only:

- `Broadcaster::renditions() -> Vec<Arc<Rendition>>` — snapshot every current rendition, not just serve one by name.
- `Broadcaster::updated() -> watch::Receiver<usize>` — catalog-sync signal (fires on add/remove/reconfigure), so a recorder re-enumerates on catalog changes. The broadcast-level analogue of `Rendition::updated`.
- `Broadcaster::is_closed()` / `closed()` — were `pub(crate)`; a recorder awaits `closed()` to finalize.
- `Rendition::updated()` — was `pub(crate)`; the per-rendition timeline signal a recorder awaits before fetching newly-closed segments via `segment()`.
- `Rendition::playable()` — was `pub(crate)`; lets a recorder gate on real content.

## Why

All read-only accessors over existing state; **no behavior change to the serve path**. This unblocks moq.pro's VOD recorder, which archives a broadcast by driving the export as a fetch-on-demand mirror (enumerate renditions, await `updated()`, fetch each completed `segment()`/`init()`, persist to object storage).

## Risk

Purely additive visibility + two new accessor methods; nothing on the existing HTTP serve path changes.