### PR TITLE
fix(moq-mux): strip edit lists from the CMAF init

### DIFF
--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -493,6 +493,11 @@ fn extract_init(
 			mp4_atom::Any::Moov(moov) => {
 				for mut trak in moov.trak {
 					trak.tkhd.track_id = track_id;
+					// Drop the source edit list. CMAF carries timing via tfdt +
+					// composition offsets, so an edit list is redundant here, and a
+					// browser applying an empty-edit media_time would shift the track
+					// off the others (a black screen in Media Source Extensions).
+					trak.edts = None;
 					traks.push(trak);
 				}
 				if let Some(mvex) = moov.mvex {
@@ -736,5 +741,36 @@ mod tests {
 		assert_eq!(frames[1].duration, Some(ts(33_000)));
 		assert_eq!(frames[2].duration, Some(ts(33_000)));
 		assert_eq!(fragment_seconds(&frames, Duration::from_millis(33)), 0.099);
+	}
+
+	// A source init whose trak carries an edit list must come out of extract_init with
+	// the edit list dropped: CMAF carries timing via tfdt + composition offsets, and a
+	// browser applying an edit list shifts the track off the others (a black screen).
+	#[test]
+	fn extract_init_strips_edit_lists() {
+		use mp4_atom::Encode;
+
+		let trak = mp4_atom::Trak {
+			edts: Some(mp4_atom::Edts {
+				elst: Some(mp4_atom::Elst {
+					entries: vec![mp4_atom::ElstEntry::default()],
+				}),
+			}),
+			..Default::default()
+		};
+		let moov = mp4_atom::Moov {
+			trak: vec![trak],
+			..Default::default()
+		};
+		let mut init = Vec::new();
+		moov.encode(&mut init).unwrap();
+
+		let mut traks = Vec::new();
+		let mut trexs = Vec::new();
+		let mut ftyp = None;
+		extract_init(&Bytes::from(init), 1, &mut ftyp, &mut traks, &mut trexs).unwrap();
+
+		assert_eq!(traks.len(), 1);
+		assert!(traks[0].edts.is_none(), "CMAF init must not carry an edit list");
 	}
 }


### PR DESCRIPTION
## Problem

The fMP4 exporter copies each source track's edit list (`edts`/`elst`) straight into the merged CMAF/HLS init (`extract_init`). Edit lists are redundant in CMAF -- timing is carried by `tfdt` and per-sample composition offsets -- and browsers *apply* them, so a source's initial **empty edit** (`media_time = -1`) becomes a real presentation offset.

In practice this showed up as a **black screen** on VOD/HLS playback in the browser: the applied edit shifted the video track off the audio track's timeline (here by ~2 days, because the empty edit's `-1` was being mis-encoded to `+2^32-1` upstream), so Media Source Extensions left the video source buffer empty at the playhead while audio played fine. Even with a correctly-encoded `-1`, an edit list in a fragmented CMAF init is an interop hazard best avoided.

## Fix

Drop the edit list in `extract_init` so the CMAF/HLS init never carries one:

```rust
for mut trak in moov.trak {
    trak.tkhd.track_id = track_id;
    trak.edts = None;   // CMAF carries timing via tfdt + composition offsets
    traks.push(trak);
}
```

This is the only place a source `edts` enters the output (the synthesized-trak paths don't add one).

## Test

`extract_init_strips_edit_lists` builds a source moov whose trak carries an `edts`/`elst`, runs it through `extract_init`, and asserts the resulting trak has no `edts`. Full `moq-mux` suite green.

## Note

Blanket-stripping also drops any *non-empty* trim edit (`media_time > 0`, used to trim encoder-priming samples). For such sources the first few priming samples would play instead of being trimmed -- a minor start-of-clip artifact, never a black screen. If preserving real trims matters, this could be gated to empty edits only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)