### PR TITLE
feat(moq-net)!: gate broadcast announcements on a liveness flag

### DIFF
--- a/doc/concept/layer/moq-lite.md
+++ b/doc/concept/layer/moq-lite.md
@@ -65,6 +65,10 @@ This asks the peer to notify us of any existing broadcasts that match the prefix
 
 This is extremely useful for conference rooms, as you can live discover when participants join and leave.
 It's also useful for individual broadcasts as you can get notifications it comes online or goes offline (no spamming F5).
+
+An announcement signals **liveness**, not merely existence.
+A publisher registers a broadcast and then marks it *live* (via `set_live` / `setLive`) when it's ready to be discovered, typically once its catalog has landed, so a subscriber that reacts to the announcement never races an empty broadcast.
+A broadcast that is registered but not live stays reachable by an exact-path fetch but is not advertised, which lets a relay keep routing to offline broadcasts without announcing them.
 The [moq-relay clustering](/bin/relay/cluster) feature actually uses this to discover other nodes in the cluster AND what broadcasts are available on each node.
 
 The peer first replies with the set of broadcasts that are currently live, then streams updates as they change.

--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -68,7 +68,11 @@ let session = client.connect(url).await?;
 
 let mut broadcast = moq_net::Broadcast::new().produce();
 // ... add catalog and tracks to the broadcast ...
-session.publisher().publish_broadcast("", broadcast.consume());
+
+// Register the broadcast, then advertise it. A broadcast starts offline: publishing only
+// registers it (so a fetch can resolve), and `set_live(true)` announces it to subscribers.
+let _publish = session.publisher().publish_broadcast("", broadcast.consume())?;
+broadcast.set_live(true);
 ```
 
 See the full [video.rs](https://github.com/moq-dev/moq/blob/main/rs/hang/examples/video.rs) example for catalog setup, track creation, and frame encoding.

--- a/go/wrapper/moq/publish.go
+++ b/go/wrapper/moq/publish.go
@@ -48,6 +48,13 @@ func NewBroadcastProducer() (*BroadcastProducer, error) {
 	return &BroadcastProducer{inner: inner}, nil
 }
 
+// SetLive sets whether the broadcast is live, i.e. whether origins advertise it. A broadcast
+// starts offline; OriginProducer.Announce marks it live. Pass false to stop advertising it while
+// keeping it fetchable, or true to advertise it again.
+func (b *BroadcastProducer) SetLive(live bool) error {
+	return b.inner.SetLive(live)
+}
+
 // Dynamic accepts requests for tracks that are not published yet.
 func (b *BroadcastProducer) Dynamic() (*BroadcastDynamic, error) {
 	inner, err := b.inner.Dynamic()

--- a/js/clock/src/main.ts
+++ b/js/clock/src/main.ts
@@ -77,6 +77,7 @@ async function publish(config: Config) {
 
 	// Create a new "broadcast", which is a collection of tracks.
 	const broadcast = new Moq.Broadcast.Producer();
+	broadcast.setLive(true);
 	connection.publish(Moq.Path.from(config.broadcast), broadcast);
 
 	console.log("✅ Published broadcast:", config.broadcast);

--- a/js/moq-boy/src/game.ts
+++ b/js/moq-boy/src/game.ts
@@ -292,6 +292,7 @@ export class Game {
 		this.viewerId.set(viewerId);
 
 		const viewerBroadcast = new Moq.Broadcast.Producer();
+		viewerBroadcast.setLive(true);
 		conn.publish(Moq.Path.from(`${this.#viewerPrefix}/${this.sessionId}/${viewerId}`), viewerBroadcast);
 		effect.cleanup(() => {
 			viewerBroadcast.close();

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -13,6 +13,9 @@ class BroadcastState {
 	requested = new Signal<track.Request[]>([]);
 	closed = new Once<Error | null>();
 	tracks = new Map<string, track.Producer>();
+	// Whether the broadcast is live, i.e. whether origins advertise it. Starts offline: publishing
+	// registers it (so a fetch resolves) without announcing it, until a producer flips this on.
+	live = new Signal<boolean>(false);
 	// Live consumer handles sharing this state (see {@link Consumer.clone}). The broadcast
 	// closes once the last one closes, so a shared consumer can be handed to several callers.
 	consumers = 0;
@@ -148,6 +151,22 @@ export class Producer implements track.Broadcast {
 		return makeConsumer(this.#state);
 	}
 
+	/**
+	 * Whether the broadcast is live, i.e. whether origins advertise it.
+	 *
+	 * Starts `false`: publishing registers the broadcast (so a fetch resolves) without announcing
+	 * it. Set it `true` to advertise it (typically once the catalog has its first group), and back
+	 * to `false` to stop advertising while keeping it fetchable. Read reactively or `.peek()` it.
+	 */
+	get live(): Signal<boolean> {
+		return this.#state.live;
+	}
+
+	/** Set whether the broadcast is live. Shorthand for `live.set(value)`. */
+	setLive(live: boolean): void {
+		this.#state.live.set(live);
+	}
+
 	/** Return the next track requested by a peer. */
 	async requested(): Promise<track.Request | undefined> {
 		for (;;) {
@@ -257,6 +276,17 @@ export class Consumer implements track.Broadcast {
 	 */
 	get closed(): GetPromise<Error | null> {
 		return this.#state.closed;
+	}
+
+	/**
+	 * Whether the broadcast is live, i.e. whether origins advertise it.
+	 *
+	 * A live broadcast is announced; an offline one still exists and can answer a fetch but is not
+	 * advertised. Read reactively or `.peek()` it. Only meaningful for a locally-produced broadcast;
+	 * a broadcast consumed over the wire is discovered via its announcement, so this stays `false`.
+	 */
+	get live(): Signal<boolean> {
+		return this.#state.live;
 	}
 
 	/**

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -53,11 +53,14 @@ export class Publisher {
 	 */
 	publish(path: Path.Valid, broadcast: broadcast.Producer) {
 		this.#broadcasts.set(path, broadcast);
-		this.#notifyConsumers(path, true);
-		void this.#runPublish(path, broadcast);
+		// Announced only while live; an offline broadcast stays registered (so a fetch resolves)
+		// but hidden. Notify the current state, then track changes.
+		if (broadcast.live.peek()) this.#notifyConsumers(path, true);
+		const disposeLive = broadcast.live.subscribe((live) => this.#notifyConsumers(path, live));
+		void this.#runPublish(path, broadcast, disposeLive);
 	}
 
-	async #runPublish(path: Path.Valid, broadcast: broadcast.Producer) {
+	async #runPublish(path: Path.Valid, broadcast: broadcast.Producer, disposeLive: () => void) {
 		try {
 			const requestId = await this.#session.nextRequestId();
 			if (requestId === undefined) return;
@@ -110,6 +113,7 @@ export class Publisher {
 			const e = error(err);
 			console.warn(`announce failed: broadcast=${path} error=${reason(e)}`);
 		} finally {
+			disposeLive();
 			broadcast.close();
 			this.#broadcasts.delete(path);
 			this.#notifyConsumers(path, false);
@@ -269,7 +273,8 @@ export class Publisher {
 			}
 
 			const announced = new announce.Producer(prefix);
-			for (const name of this.#broadcasts.keys()) {
+			for (const [name, producer] of this.#broadcasts) {
+				if (!producer.live.peek()) continue; // offline: registered but not advertised
 				const suffix = Path.stripPrefix(prefix, name);
 				if (suffix === null) continue;
 				announced.append({ path: suffix, active: true });

--- a/js/net/src/integration.test.ts
+++ b/js/net/src/integration.test.ts
@@ -21,8 +21,10 @@ async function runPublishSubscribeFlow(protocol: string, version?: number) {
 
 	// Server publishes a broadcast
 	const broadcast = new BroadcastProducer();
+	broadcast.setLive(true);
 	server.publish(Path.from("test"), broadcast);
 	const prefixedBroadcast = new BroadcastProducer();
+	prefixedBroadcast.setLive(true);
 	server.publish(Path.from("root/child"), prefixedBroadcast);
 
 	// Serve every requested "video" track. On lite-05+ a subscribe is preceded by
@@ -105,6 +107,7 @@ test("integration: lite draft-06 announce lifecycle", async () => {
 
 	// Announced before the client asks, so it can ride the initial set.
 	const first = new BroadcastProducer();
+	first.setLive(true);
 	server.publish(Path.from("first"), first);
 
 	const announced = client.announced();
@@ -115,6 +118,7 @@ test("integration: lite draft-06 announce lifecycle", async () => {
 
 	// A live announce.
 	const second = new BroadcastProducer();
+	second.setLive(true);
 	server.publish(Path.from("second"), second);
 	entry = await announced.next();
 	if (!entry) throw new Error("expected announce");
@@ -130,6 +134,7 @@ test("integration: lite draft-06 announce lifecycle", async () => {
 
 	// Re-announce the same path: a fresh announce assigning a fresh id.
 	const secondAgain = new BroadcastProducer();
+	secondAgain.setLive(true);
 	server.publish(Path.from("second"), secondAgain);
 	entry = await announced.next();
 	if (!entry) throw new Error("expected re-announce");
@@ -153,6 +158,7 @@ test("integration: lite draft-05 datagram delivery", async () => {
 
 	// A static track fans datagrams out to whoever subscribes.
 	const broadcast = new BroadcastProducer();
+	broadcast.setLive(true);
 	server.publish(Path.from("test"), broadcast);
 	const producer = broadcast.createTrack("video", { timescale: Timescale.MILLI });
 
@@ -192,6 +198,7 @@ test("integration: lite draft-05 datagrams not sent on a non-datagram transport"
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 
 	const broadcast = new BroadcastProducer();
+	broadcast.setLive(true);
 	server.publish(Path.from("test"), broadcast);
 	const producer = broadcast.createTrack("video", { timescale: Timescale.MILLI });
 
@@ -235,6 +242,7 @@ test("integration: lite draft-05 datagrams sent with standards-track createWrita
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 
 	const broadcast = new BroadcastProducer();
+	broadcast.setLive(true);
 	server.publish(Path.from("test"), broadcast);
 	const producer = broadcast.createTrack("video", { timescale: Timescale.MILLI });
 
@@ -270,6 +278,7 @@ test("integration: lite draft-05 missing datagram writer does not close streams"
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 
 	const broadcast = new BroadcastProducer();
+	broadcast.setLive(true);
 	server.publish(Path.from("test"), broadcast);
 	const producer = broadcast.createTrack("video", { timescale: Timescale.MILLI });
 
@@ -294,6 +303,7 @@ test("integration: lite draft-05 missing datagram reader does not close streams"
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 
 	const broadcast = new BroadcastProducer();
+	broadcast.setLive(true);
 	server.publish(Path.from("test"), broadcast);
 	const producer = broadcast.createTrack("video", { timescale: Timescale.MILLI });
 
@@ -319,6 +329,7 @@ test("integration: lite draft-05 fetches a cached group", async () => {
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 
 	const broadcast = new BroadcastProducer();
+	broadcast.setLive(true);
 	const producer = broadcast.createTrack("video");
 	server.publish(Path.from("test"), broadcast);
 
@@ -359,6 +370,7 @@ test("integration: lite draft-05 coalesces concurrent fetches of one group", asy
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 
 	const broadcast = new BroadcastProducer();
+	broadcast.setLive(true);
 	const producer = broadcast.createTrack("video");
 	server.publish(Path.from("test"), broadcast);
 
@@ -400,6 +412,7 @@ test("integration: lite draft-05 fetches an in-progress group", async () => {
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 
 	const broadcast = new BroadcastProducer();
+	broadcast.setLive(true);
 	const producer = broadcast.createTrack("video");
 	server.publish(Path.from("test"), broadcast);
 
@@ -527,6 +540,49 @@ test("integration: subscribe to non-existent broadcast", async () => {
 		})(),
 	).rejects.toThrow();
 
+	client.close();
+	server.close();
+});
+
+test("integration: liveness gates announcement, not existence", async () => {
+	const pair = createMockTransportPair("");
+
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+
+	// Publish OFFLINE: the broadcast is registered but not announced.
+	const broadcast = new BroadcastProducer();
+	server.publish(Path.from("test"), broadcast);
+
+	const serving = (async () => {
+		for (;;) {
+			const req = await broadcast.requested();
+			if (!req) break;
+			if (req.name === "video") req.accept().writeString("hello");
+			else req.reject(new Error(`unexpected track: ${req.name}`));
+		}
+	})();
+
+	// The announce stream does not surface an offline broadcast. Keep the same pending `next()`
+	// (racing a fresh one would leak a waiter that steals the later announce).
+	const announced = client.announced();
+	const next = announced.next();
+	const offline = await Promise.race([next, sleep(50).then(() => "timeout" as const)]);
+	expect(offline).toBe("timeout");
+
+	// It is still reachable: consuming a track resolves via the fetch/existence path.
+	const remote = client.consume(Path.from("test"));
+	const track = remote.track("video").subscribe();
+	expect(await track.readString()).toBe("hello");
+
+	// Going live announces it: the previously-pending `next()` now resolves.
+	broadcast.setLive(true);
+	const entry = await next;
+	if (!entry) throw new Error("expected entry");
+	expect(entry.path).toBe("test" as Path.Valid);
+	expect(entry.active).toBe(true);
+
+	broadcast.close();
+	await serving;
 	client.close();
 	server.close();
 });

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -110,8 +110,16 @@ export class Publisher {
 			broadcasts.set(path, broadcast);
 		});
 
+		// A broadcast is announced only while live (offline ones stay registered but hidden, so a
+		// fetch still resolves). Re-notify the announce loops when liveness flips; they recompute the
+		// active set from each broadcast's `live` flag.
+		const disposeLive = broadcast.live.subscribe(() => {
+			this.#broadcasts.set(this.#broadcasts.peek(), true);
+		});
+
 		// Remove the broadcast from the lookup when it's closed.
 		void broadcast.closed.then(() => {
+			disposeLive();
 			this.#broadcasts.mutate((broadcasts) => {
 				broadcasts?.delete(path);
 			});
@@ -134,7 +142,8 @@ export class Publisher {
 		const broadcasts = this.#broadcasts.peek();
 		if (!broadcasts) return; // closed
 
-		for (const name of broadcasts.keys()) {
+		for (const [name, producer] of broadcasts) {
+			if (!producer.live.peek()) continue; // offline: registered but not advertised
 			const suffix = Path.stripPrefix(msg.prefix, name);
 			if (suffix === null) continue;
 			console.debug(`announce: broadcast=${name} active=true`);
@@ -196,7 +205,8 @@ export class Publisher {
 			// Create a new set of active broadcasts.
 			// This is SLOW, but it's not worth optimizing because we often have just 1 broadcast anyway.
 			const newActive = new Set<Path.Valid>();
-			for (const name of broadcasts.keys()) {
+			for (const [name, producer] of broadcasts) {
+				if (!producer.live.peek()) continue; // offline: registered but not advertised
 				const suffix = Path.stripPrefix(msg.prefix, name);
 				if (suffix === null) continue; // Not our prefix.
 				newActive.add(suffix);

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -188,6 +188,8 @@ export class Broadcast {
 			if (this.net.peek() === broadcast) this.net.set(undefined);
 		});
 
+		// Advertise it (a broadcast starts offline; publishing only registers it).
+		broadcast.setLive(true);
 		connection.publish(name, broadcast);
 
 		effect.spawn(this.#runBroadcast.bind(this, broadcast, effect));

--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -340,6 +340,12 @@ class BroadcastProducer:
     def __init__(self) -> None:
         self._inner = MoqBroadcastProducer()
 
+    def set_live(self, live: bool) -> None:
+        """Set whether the broadcast is live, i.e. whether origins advertise it. A broadcast starts
+        offline; :meth:`Publisher.announce` marks it live. Pass ``False`` to stop advertising it
+        while keeping it fetchable, or ``True`` to advertise it again."""
+        self._inner.set_live(live)
+
     def dynamic(self) -> BroadcastDynamic:
         """Accept subscriptions to tracks that are not published yet."""
         return BroadcastDynamic(self._inner.dynamic())

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -85,6 +85,7 @@ async fn run_broadcast(origin: moq_net::origin::Producer) -> anyhow::Result<()> 
 
 	// NOTE: The path is empty because we're using the URL to scope the broadcast.
 	// OPTIONAL: We publish after inserting the tracks just to avoid a nearly impossible race condition.
+	broadcast.set_live(true);
 	let _publish = origin
 		.publish_broadcast("", &broadcast)
 		.context("failed to publish broadcast")?;

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -492,11 +492,12 @@ pub extern "C" fn moq_origin_create() -> i32 {
 
 /// Announce a broadcast on an origin under `path`.
 ///
-/// The broadcast becomes available to any origin consumers, such as over the network.
+/// The broadcast becomes available to any origin consumers, such as over the network. This also
+/// marks the broadcast live (see [moq_publish_set_live]) so it is advertised right away.
 ///
 /// Returns a positive announce handle on success, or a negative code on failure. The broadcast
-/// stays announced until the handle is passed to [moq_origin_unannounce]; finishing the broadcast
-/// itself does not unannounce it.
+/// stays registered until the handle is passed to [moq_origin_unannounce] or the broadcast is
+/// finished, whichever comes first.
 ///
 /// # Safety
 /// - The caller must ensure that path is a valid pointer to path_len bytes of data.
@@ -508,8 +509,25 @@ pub unsafe extern "C" fn moq_origin_announce(origin: u32, path: *const c_char, p
 		let broadcast = ffi::parse_id(broadcast)?;
 
 		let mut state = State::lock();
-		let broadcast = state.publish.get(broadcast)?.consume();
+		let producer = state.publish.get(broadcast)?;
+		// Announcing implies going live; the origin advertises it while live and removes it on close.
+		producer.set_live(true);
+		let broadcast = producer.consume();
 		state.origin.announce(origin, path, broadcast)
+	})
+}
+
+/// Set whether a broadcast is live, i.e. whether origins advertise it.
+///
+/// A broadcast starts offline: [moq_origin_announce] registers it (so a fetch resolves) and marks
+/// it live. Pass `false` to stop advertising it while keeping it fetchable, or `true` to advertise
+/// it again. Returns zero on success, or a negative code on failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_publish_set_live(broadcast: u32, live: bool) -> i32 {
+	ffi::enter(move || {
+		let broadcast = ffi::parse_id(broadcast)?;
+		State::lock().publish.get(broadcast)?.set_live(live);
+		Ok(0)
 	})
 }
 

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -93,6 +93,7 @@ pub async fn run(ctx: Connection) {
 		let path = format!("{name}/{run_id:08x}/{connection}/{index}");
 
 		let mut broadcast = broadcast::Info::new().produce();
+		broadcast.set_live(true);
 		let track = match broadcast.create_track(TRACK, None) {
 			Ok(track) => track,
 			Err(err) => {

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -210,6 +210,7 @@ async fn run(config: &Config) -> Result<()> {
 
 	// Create the broadcast producer.
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	broadcast.set_live(true);
 
 	// Publish origin: the game session broadcast.
 	let publish_origin = moq_net::Origin::random().produce();

--- a/rs/moq-cli/src/hls.rs
+++ b/rs/moq-cli/src/hls.rs
@@ -47,6 +47,9 @@ pub async fn import(origin: &moq_net::origin::Producer, name: String, playlist: 
 	// consume the catalog as soon as it observes the announcement.
 	let catalog = moq_mux::catalog::Producer::new(&mut producer)?;
 
+	// Live for the lifetime of the import.
+	producer.set_live(true);
+
 	// Hold the RAII announcement for the lifetime of the import.
 	let _announce = origin
 		.publish_broadcast(&name, producer.consume())

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -215,6 +215,8 @@ impl Publish {
 	/// Build a publisher decoding the given container format from stdin.
 	pub fn new(format: &PublishFormat) -> anyhow::Result<Self> {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		// Live for the lifetime of the publish; the catalog reservation gate covers completeness.
+		broadcast.set_live(true);
 
 		// TS carries undecoded elementary streams (SCTE-35, teletext, DVB AC-3, ...)
 		// verbatim, so it uses the `mpegts` catalog extension rather than the media-only
@@ -266,6 +268,7 @@ impl Publish {
 	#[cfg(feature = "capture")]
 	pub fn capture(args: &CaptureArgs, bandwidth: Option<moq_net::bandwidth::Consumer>) -> anyhow::Result<Self> {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		broadcast.set_live(true);
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 
 		let video = (!args.no_video).then(|| (args.video_config(), args.video_encode(bandwidth)));
@@ -481,6 +484,7 @@ mod tests {
 	/// re-exporting with the `mpegts` catalog extension.
 	async fn manufacture_input() -> Vec<u8> {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		broadcast.set_live(true);
 		let consumer = broadcast.consume();
 		// Announce the broadcast on a throwaway origin so the exporter can resolve it by path.
 		let origin = moq_net::Origin::random().produce();

--- a/rs/moq-cli/src/rtc.rs
+++ b/rs/moq-cli/src/rtc.rs
@@ -82,6 +82,7 @@ fn scope_producer(origin: &moq_net::origin::Producer, name: &str) -> anyhow::Res
 /// WHEP client: pull a remote broadcast into the Origin under `name` (import).
 pub async fn connect_import(origin: moq_net::origin::Producer, url: Url, name: String) -> anyhow::Result<()> {
 	let producer = moq_net::broadcast::Info::new().produce();
+	producer.set_live(true);
 	// Hold the RAII announcement for the lifetime of the pull.
 	let _announce = origin
 		.publish_broadcast(&name, producer.consume())

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -113,6 +113,7 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 	});
 
 	let output = moq_net::broadcast::Info::default().produce();
+	output.set_live(true);
 	let _announce = publish
 		.publish_broadcast(&output_path, &output)
 		.context("failed to publish the derivative broadcast")?;

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -171,14 +171,13 @@ impl MoqOriginProducer {
 		// Surfaces Error::Unauthorized (out of scope) via the MoqError::Protocol conversion.
 		let publish = self.inner.publish_broadcast(path.as_str(), &consumer)?;
 
-		// Auto-unannounce when the broadcast closes (all producers dropped). The origin no longer
-		// watches closure itself, so the spawn lives here at the runtime-bound FFI boundary.
-		tokio::spawn(async move {
-			consumer.closed().await;
-			drop(publish);
-		});
-
-		Ok(())
+		// Mark the broadcast live and hold the guard on the producer: the origin advertises it
+		// while live and removes it once it closes, so no close-watching task is needed here.
+		broadcast.with_state(|state| {
+			state.broadcast.set_live(true);
+			state.announces.push(publish);
+			Ok(())
+		})
 	}
 }
 

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -78,6 +78,9 @@ pub(crate) struct BroadcastProducer {
 	// Carries the untyped `Extra` extension so callers can attach application catalog
 	// sections by name (the only extension shape that crosses the FFI boundary).
 	pub(crate) catalog: moq_mux::catalog::Producer<Extra>,
+	// Announce guards from `MoqOriginProducer::announce`. Held here so the broadcast stays
+	// registered for the producer's lifetime; the origin removes it once the broadcast closes.
+	pub(crate) announces: Vec<moq_net::origin::Publish>,
 }
 
 /// A whole-frame importer: a single codec track, or a container that may publish
@@ -255,8 +258,25 @@ impl MoqBroadcastProducer {
 		let catalog =
 			moq_mux::catalog::Producer::with_catalog(&mut broadcast, moq_mux::catalog::hang::Catalog::default())?;
 		Ok(Arc::new(Self {
-			state: std::sync::Mutex::new(Some(BroadcastProducer { broadcast, catalog })),
+			state: std::sync::Mutex::new(Some(BroadcastProducer {
+				broadcast,
+				catalog,
+				announces: Vec::new(),
+			})),
 		}))
+	}
+
+	/// Set whether the broadcast is live, i.e. whether origins advertise it.
+	///
+	/// A broadcast starts offline: publishing it registers it (so a fetch resolves) without
+	/// advertising it. `announce` marks it live; call this with `false` to stop advertising it
+	/// while keeping it fetchable, or `true` to advertise it again.
+	pub fn set_live(&self, live: bool) -> Result<(), MoqError> {
+		let _guard = crate::ffi::RUNTIME.enter();
+		self.with_state(|state| {
+			state.broadcast.set_live(live);
+			Ok(())
+		})
 	}
 
 	/// Set (or replace) a top-level application catalog section by name.

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -129,6 +129,7 @@ impl Session {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let broadcast_consumer = broadcast.consume();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
+		broadcast.set_live(true);
 		let publish = origin.publish_broadcast(&settings.broadcast, broadcast_consumer)?;
 
 		let status = Arc::new(Status::default());

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -259,6 +259,7 @@ mod tests {
 	async fn serves_playlist_and_segments_from_the_timeline() {
 		let origin = moq_net::Origin::random().produce();
 		let mut broadcast = origin.create_broadcast("live").expect("publish allowed");
+		broadcast.set_live(true);
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		let reserved = catalog.reserve();
@@ -319,6 +320,7 @@ mod tests {
 	async fn reconciles_removed_and_reconfigured_renditions() {
 		let origin = moq_net::Origin::random().produce();
 		let broadcast = origin.create_broadcast("live").expect("publish allowed");
+		broadcast.set_live(true);
 		let source = moq_mux::Source::new(origin.consume(), "live");
 		let (ready, _) = watch::channel(0);
 		let broadcaster = Broadcaster {

--- a/rs/moq-hls/src/server/mod.rs
+++ b/rs/moq-hls/src/server/mod.rs
@@ -191,6 +191,7 @@ mod tests {
 	async fn closed_broadcaster() -> Arc<Broadcaster> {
 		let origin = moq_net::Origin::random().produce();
 		let producer = origin.create_broadcast("gone").expect("publish allowed");
+		producer.set_live(true);
 		let source = moq_mux::Source::new(origin.consume(), "gone");
 		let broadcaster = Broadcaster::new(source, Config::default())
 			.await
@@ -213,6 +214,7 @@ mod tests {
 			.unwrap()
 			.insert("live".to_string(), stale.clone());
 		let _producer = origin.create_broadcast("live").expect("publish allowed");
+		_producer.set_live(true);
 
 		let fresh = server.broadcaster("live").await.expect("broadcast announced");
 
@@ -226,6 +228,7 @@ mod tests {
 		let server = Server::new(origin.consume(), Config::default());
 		let old = closed_broadcaster().await;
 		let new_producer = origin.create_broadcast("live").expect("publish allowed");
+		new_producer.set_live(true);
 		let new = Broadcaster::new(moq_mux::Source::new(origin.consume(), "live"), Config::default())
 			.await
 			.expect("catalog broadcast resolves while announced");

--- a/rs/moq-native/examples/chat.rs
+++ b/rs/moq-native/examples/chat.rs
@@ -48,6 +48,7 @@ async fn run_broadcast(origin: moq_net::origin::Producer) -> anyhow::Result<()> 
 	// NOTE: The path is empty because we're using the URL to scope the broadcast.
 	// If you put "alice" here, it would be published as "anon/chat-example/alice".
 	// OPTIONAL: We publish after inserting the track just to avoid a nearly impossible race condition.
+	broadcast.set_live(true);
 	let _publish = origin
 		.publish_broadcast("", &broadcast)
 		.context("failed to publish broadcast")?;

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -69,6 +69,7 @@ async fn main() -> anyhow::Result<()> {
 			let mut broadcast = moq_net::broadcast::Info::new().produce();
 			let track = broadcast.create_track(track, None)?;
 			let clock = Publisher::new(track);
+			broadcast.set_live(true);
 
 			let _publish = origin
 				.publish_broadcast(&config.broadcast, &broadcast)

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -16,6 +16,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	// ── publisher (server) ──────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 
 	let mut group = track.append_group().expect("failed to append group");
@@ -263,6 +264,7 @@ async fn iroh_connect() {
 	// ── publisher (server) ──────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 
 	let mut group = track.append_group().expect("failed to append group");

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -25,6 +25,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	// ── publisher (server) ──────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 
 	// Write a group containing a single frame.
@@ -126,6 +127,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
+	broadcast.set_live(true);
 
 	// Track with an explicit microsecond timescale (the default is milliseconds).
 	let mut track = broadcast
@@ -243,6 +245,7 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast
 		.create_track(
 			"video",
@@ -369,6 +372,7 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast
 		.create_track(
 			"video",
@@ -487,6 +491,7 @@ async fn broadcast_moq_lite_05_default_timescale() {
 
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("create track");
 
 	let mut group = track.append_group().expect("append group");
@@ -581,6 +586,7 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 
 	// Announced before the client connects, so it rides the initial set.
 	let first = pub_origin.create_broadcast("first").expect("create broadcast");
+	first.set_live(true);
 
 	let mut server_config = moq_native::ServerConfig::default();
 	server_config.bind = Some("[::]:0".to_string());
@@ -619,6 +625,7 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 
 	// A live announce after the initial set.
 	let second = pub_origin.create_broadcast("second").expect("create broadcast");
+	second.set_live(true);
 	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "second");
 	assert!(broadcast.is_some(), "expected live announce");
@@ -631,6 +638,7 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 
 	// Re-announce the same path: a fresh announce assigning a fresh id.
 	let _second = pub_origin.create_broadcast("second").expect("create broadcast");
+	_second.set_live(true);
 	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "second");
 	assert!(broadcast.is_some(), "expected re-announce");
@@ -641,6 +649,7 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 	let mut replacement_info = moq_net::broadcast::Info::new();
 	replacement_info.origin = pub_origin.info();
 	let replacement = replacement_info.produce();
+	replacement.set_live(true);
 	let _replacement_guard = pub_origin
 		.publish_broadcast("first", &replacement)
 		.expect("publish replacement");
@@ -654,6 +663,7 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 
 	// A sentinel proves no stray event for "first" snuck in behind the replacement.
 	let _sentinel = pub_origin.create_broadcast("sentinel").expect("create broadcast");
+	_sentinel.set_live(true);
 	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "sentinel");
 	assert!(broadcast.is_some(), "expected sentinel announce");
@@ -1027,6 +1037,7 @@ async fn broadcast_websocket() {
 	// ── publisher (server) ──────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 
 	let mut group = track.append_group().expect("failed to append group");
@@ -1135,6 +1146,7 @@ async fn broadcast_websocket_fallback() {
 	// ── publisher (server) ──────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 
 	let mut group = track.append_group().expect("failed to append group");
@@ -1250,6 +1262,7 @@ const NEWEST_LITE: &str = "moq-lite-05";
 async fn broadcast_websocket_uses_newest_version() {
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 	let mut group = track.append_group().expect("failed to append group");
 	group
@@ -1318,6 +1331,7 @@ async fn broadcast_websocket_uses_newest_version() {
 async fn broadcast_race_quic_wins() {
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("failed to create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 	let mut group = track.append_group().expect("failed to append group");
 	group
@@ -1406,6 +1420,7 @@ async fn broadcast_race_quic_wins() {
 async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("create track");
 
 	let mut group0 = track.append_group().expect("append group 0");
@@ -1604,6 +1619,7 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 	let mut broadcast = pub_origin
 		.create_broadcast("allowed/test")
 		.expect("failed to create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 	let mut group = track.append_group().expect("failed to append group");
 	group
@@ -1740,6 +1756,7 @@ async fn publish_only_client_to_subscribe_only_server() {
 	let mut broadcast = pub_origin
 		.create_broadcast("allowed/test")
 		.expect("failed to create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("failed to create track");
 	let mut group = track.append_group().expect("failed to append group");
 	group

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -564,6 +564,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				}
 				.produce();
 
+				// The upstream announced this broadcast, so it is live: mark it so the origin
+				// advertises it. Retiring the announce drops the publish guard, removing it again.
+				broadcast.set_live(true);
+
 				// Create the dynamic handler BEFORE publishing so consumers see
 				// dynamic >= 1 the moment they receive the announce. Otherwise a
 				// consumer can call subscribe_track() before the driver-owned

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -499,6 +499,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 		.produce();
 
+		// The upstream announced this broadcast, so it is live: mark it so the origin advertises
+		// it. Retiring the announce later drops the publish guard, which removes it again.
+		broadcast.set_live(true);
+
 		// Create the dynamic handler BEFORE publishing, so that consumers
 		// see dynamic >= 1 immediately when they receive the announcement.
 		// Otherwise there's a race on multi-threaded runtimes where a consumer

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -112,6 +112,13 @@ pub struct Producer {
 	// producer (this handle and every `Dynamic`) ends the broadcast.
 	alive: kio::Producer<()>,
 
+	// Whether the broadcast is currently *live* (should be announced), separate from
+	// whether it exists. Starts `false`: the origin keeps an unannounced broadcast in
+	// its tree so it stays routable for a FETCH, and only advertises it once a producer
+	// flips this on with [`Self::set_live`] (typically after the catalog is populated).
+	// Shared across producer clones; closes when the last producer drops.
+	live: kio::Producer<bool>,
+
 	// Track registry plus the dynamic request queue, mutated by producers and
 	// consumers alike under one lock.
 	state: kio::Shared<BroadcastState>,
@@ -123,12 +130,31 @@ impl Producer {
 		Self {
 			info: Arc::new(info),
 			alive: Default::default(),
+			live: kio::Producer::new(false),
 			state: Default::default(),
 		}
 	}
 
 	pub fn info(&self) -> &Info {
 		&self.info
+	}
+
+	/// Set whether the broadcast is live, i.e. whether the origin advertises it.
+	///
+	/// A broadcast starts offline (`false`); publishing it registers it in the origin's
+	/// tree (so it can still answer a FETCH) but does not announce it. Flip this to `true`
+	/// once the broadcast is ready to be discovered (e.g. the catalog track has its first
+	/// group), and back to `false` to stop advertising it without tearing it down. Closing
+	/// the broadcast implicitly makes it offline.
+	pub fn set_live(&self, live: bool) {
+		if let Ok(mut current) = self.live.write() {
+			*current = live;
+		}
+	}
+
+	/// Whether the broadcast is currently live (see [`Self::set_live`]).
+	pub fn is_live(&self) -> bool {
+		*self.live.read()
 	}
 
 	/// Remove a track from the lookup.
@@ -193,7 +219,12 @@ impl Producer {
 
 	/// Create a dynamic producer that handles on-demand track requests from consumers.
 	pub fn dynamic(&self) -> Dynamic {
-		Dynamic::new(self.info.clone(), self.alive.clone(), self.state.clone())
+		Dynamic::new(
+			self.info.clone(),
+			self.alive.clone(),
+			self.live.clone(),
+			self.state.clone(),
+		)
 	}
 
 	/// Create a consumer that can subscribe to tracks in this broadcast.
@@ -201,6 +232,7 @@ impl Producer {
 		Consumer {
 			info: self.info.clone(),
 			alive: self.alive.consume(),
+			live: self.live.consume(),
 			state: self.state.clone(),
 		}
 	}
@@ -264,6 +296,9 @@ pub struct Dynamic {
 	info: Arc<Info>,
 	// Keeps the broadcast alive while a handler exists (mirrors a producer).
 	alive: kio::Producer<()>,
+	// Broadcast liveness, shared with the producer. A relay keeps a forwarded broadcast alive
+	// through its `Dynamic` (the bare producer is dropped), so the handler owns liveness too.
+	live: kio::Producer<bool>,
 	state: kio::Shared<BroadcastState>,
 }
 
@@ -277,20 +312,46 @@ impl Clone for Dynamic {
 		Self {
 			info: self.info.clone(),
 			alive: self.alive.clone(),
+			live: self.live.clone(),
 			state: self.state.clone(),
 		}
 	}
 }
 
 impl Dynamic {
-	fn new(info: Arc<Info>, alive: kio::Producer<()>, state: kio::Shared<BroadcastState>) -> Self {
+	fn new(
+		info: Arc<Info>,
+		alive: kio::Producer<()>,
+		live: kio::Producer<bool>,
+		state: kio::Shared<BroadcastState>,
+	) -> Self {
 		state.lock().requests.add_handler();
 
-		Self { info, alive, state }
+		Self {
+			info,
+			alive,
+			live,
+			state,
+		}
 	}
 
 	pub fn info(&self) -> &Info {
 		&self.info
+	}
+
+	/// Set whether the broadcast is live (see [`Producer::set_live`]).
+	///
+	/// Available here too because a relay keeps a forwarded broadcast alive through its
+	/// [`Dynamic`] handler rather than a [`Producer`].
+	pub fn set_live(&self, live: bool) {
+		if let Ok(mut current) = self.live.write() {
+			*current = live;
+		}
+	}
+
+	/// Whether the broadcast is currently live (see [`Producer::set_live`]).
+	pub fn is_live(&self) -> bool {
+		*self.live.read()
 	}
 
 	/// Poll for the next consumer-requested track, without blocking.
@@ -321,6 +382,7 @@ impl Dynamic {
 		Consumer {
 			info: self.info.clone(),
 			alive: self.alive.consume(),
+			live: self.live.consume(),
 			state: self.state.clone(),
 		}
 	}
@@ -375,6 +437,8 @@ pub struct Consumer {
 	info: Arc<Info>,
 	// Broadcast liveness (read-only): watched for close.
 	alive: kio::Consumer<()>,
+	// Whether the broadcast is currently live (read-only). Closes when the last producer drops.
+	live: kio::Consumer<bool>,
 	// Track registry plus request queue; `track()` reads the registry and enqueues requests.
 	state: kio::Shared<BroadcastState>,
 }
@@ -382,6 +446,46 @@ pub struct Consumer {
 impl Consumer {
 	pub fn info(&self) -> &Info {
 		&self.info
+	}
+
+	/// Whether the broadcast is currently live, i.e. advertised by its origin.
+	///
+	/// A live broadcast is announced; an offline one still exists and can answer a FETCH but
+	/// is not advertised. A closed broadcast (every producer gone) reads as offline.
+	pub fn is_live(&self) -> bool {
+		// A closed live channel keeps its last value; treat "every producer gone" as offline.
+		!self.live.is_closed() && *self.live.read()
+	}
+
+	/// Poll for the next change to the broadcast's liveness relative to `last`.
+	///
+	/// Returns `Poll::Ready(Some(live))` once the flag differs from `last`, `Poll::Ready(None)`
+	/// when the broadcast closes (every producer gone, so it is permanently offline and won't
+	/// change again), or arms `waiter` otherwise. Seed `last` from [`Self::is_live`] and pass back
+	/// each value you observe. Counterpart to the async [`Self::live_changed`]; drives the origin's
+	/// announce reconciler.
+	pub fn poll_live(&self, waiter: &kio::Waiter, last: bool) -> Poll<Option<bool>> {
+		match self.live.poll(waiter, |live| {
+			if **live == last {
+				Poll::Pending
+			} else {
+				Poll::Ready(**live)
+			}
+		}) {
+			Poll::Ready(Ok(live)) => Poll::Ready(Some(live)),
+			// Every producer dropped: the broadcast is closed, so liveness is done.
+			Poll::Ready(Err(_closed)) => Poll::Ready(None),
+			Poll::Pending => Poll::Pending,
+		}
+	}
+
+	/// Await the next change to the broadcast's liveness relative to `last`.
+	///
+	/// Resolves to `Some(live)` on the next change, or `None` once the broadcast closes. Seed
+	/// from [`Self::is_live`] and loop to follow liveness:
+	/// `while let Some(live) = consumer.live_changed(live).await { ... }`.
+	pub async fn live_changed(&self, last: bool) -> Option<bool> {
+		kio::wait(|waiter| self.poll_live(waiter, last)).await
 	}
 
 	/// Get a handle to a track on this broadcast.
@@ -456,6 +560,7 @@ impl Consumer {
 		WeakConsumer {
 			info: self.info.clone(),
 			alive: self.alive.weak(),
+			live: self.live.clone(),
 			state: self.state.clone(),
 		}
 	}
@@ -471,6 +576,8 @@ impl Consumer {
 pub(crate) struct WeakConsumer {
 	info: Arc<Info>,
 	alive: kio::ConsumerWeak<()>,
+	// A live-value consumer pins no producer, so a strong handle is safe to hold here.
+	live: kio::Consumer<bool>,
 	state: kio::Shared<BroadcastState>,
 }
 
@@ -480,6 +587,7 @@ impl WeakConsumer {
 		Consumer {
 			info: self.info.clone(),
 			alive: self.alive.consume(),
+			live: self.live.clone(),
 			state: self.state.clone(),
 		}
 	}
@@ -521,6 +629,27 @@ mod test {
 			);
 			pending
 		}};
+	}
+
+	#[tokio::test]
+	async fn live_changed() {
+		let producer = Info::new().produce();
+		let consumer = producer.consume();
+		assert!(!consumer.is_live(), "starts offline");
+
+		// Each toggle wakes the observer with the new value.
+		producer.set_live(true);
+		assert_eq!(consumer.live_changed(false).await, Some(true));
+		assert!(consumer.is_live());
+
+		producer.set_live(false);
+		assert_eq!(consumer.live_changed(true).await, Some(false));
+
+		// Closing the broadcast ends the liveness stream.
+		producer.set_live(true);
+		assert_eq!(consumer.live_changed(false).await, Some(true));
+		drop(producer);
+		assert_eq!(consumer.live_changed(true).await, None, "closed reads as end-of-stream");
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -328,6 +328,11 @@ struct OriginBroadcast {
 	path: PathOwned,
 	active: broadcast::Consumer,
 	backup: VecDeque<broadcast::Consumer>,
+
+	// Whether `active` is currently announced. Existence (tree membership, so a FETCH can
+	// still resolve) is independent of announcement: we advertise the active route only
+	// while it is live, and reconcile this flag as liveness or the active route changes.
+	announced: bool,
 }
 
 /// Ordering key used to pick the active route among broadcasts at the same path.
@@ -533,10 +538,24 @@ impl OriginNode {
 		if let Some((dir, relative)) = rest.next_part() {
 			// Not using entry to avoid allocating a string most of the time.
 			self.entry(dir).lock().publish(&full, broadcast, &relative);
-		} else if let Some(existing) = &mut self.broadcast {
-			// This node is a leaf with an existing broadcast. Prefer the route with the
-			// lower ordering key (shorter hop chain, deterministic hash on ties), so every
-			// node converges on the same route regardless of the order announces arrive.
+			return;
+		}
+
+		if self.broadcast.is_none() {
+			// This node is a leaf with no existing broadcast. Register it (existence) but leave
+			// it unannounced; `reconcile` advertises it if it is already live.
+			self.broadcast = Some(OriginBroadcast {
+				path: full.to_owned(),
+				active: broadcast.clone(),
+				backup: VecDeque::new(),
+				announced: false,
+			});
+		} else {
+			let existing = self.broadcast.as_mut().expect("checked above");
+
+			// Prefer the route with the lower ordering key (shorter hop chain, deterministic hash
+			// on ties), so every node converges on the same route regardless of the order announces
+			// arrive.
 			//
 			// Drop duplicates (same underlying broadcast delivered via multiple links) so the
 			// backup queue can't accumulate clones of the active entry and trigger redundant
@@ -547,27 +566,58 @@ impl OriginNode {
 
 			if route_key(&full, broadcast.info()) < route_key(&full, existing.active.info()) {
 				let old = existing.active.clone();
-				existing.active = broadcast.clone();
 				existing.backup.push_back(old);
+				existing.active = broadcast.clone();
 
-				// A replacement is an unannounce/announce pair: the path briefly reads as
-				// unavailable rather than swapping atomically.
-				let mut notify = self.notify.lock();
-				notify.unannounce(&full);
-				notify.announce(&full, broadcast);
+				// The active route changed. Drop the old announcement so `reconcile` can
+				// re-announce the new active (a replacement reads as an unannounce/announce
+				// pair rather than an atomic swap).
+				if existing.announced {
+					self.notify.lock().unannounce(&full);
+					existing.announced = false;
+				}
 			} else {
 				// Loses the ordering (longer path, or the tie-break): keep as a backup
 				// in case the active one drops.
 				existing.backup.push_back(broadcast.clone());
 			}
+		}
+
+		self.reconcile(&full);
+	}
+
+	// Traverse `relative` to the leaf node and reconcile it. Unlike `publish`/`remove` this never
+	// creates nodes: a missing node means the broadcast was already removed, so there is nothing to
+	// reconcile. Used by the liveness reconciler, which holds the subtree root, not the leaf.
+	fn reconcile_at(&mut self, full: impl AsPath, relative: impl AsPath) {
+		let full = full.as_path();
+		let relative = relative.as_path();
+
+		if let Some((dir, rest)) = relative.next_part() {
+			if let Some(node) = self.nested.get(dir) {
+				node.lock().reconcile_at(&full, &rest);
+			}
 		} else {
-			// This node is a leaf with no existing broadcast.
-			self.broadcast = Some(OriginBroadcast {
-				path: full.to_owned(),
-				active: broadcast.clone(),
-				backup: VecDeque::new(),
-			});
-			self.notify.lock().announce(full, broadcast);
+			self.reconcile(&full);
+		}
+	}
+
+	// Bring the announcement of the active broadcast in line with its liveness: announce a
+	// live active route that isn't yet advertised, and unannounce one that went offline (or
+	// closed). Idempotent, so any liveness or route change can just call it.
+	fn reconcile(&mut self, full: impl AsPath) {
+		let full = full.as_path();
+		let Some(existing) = self.broadcast.as_mut() else {
+			return;
+		};
+
+		let desired = existing.active.is_live();
+		if desired && !existing.announced {
+			self.notify.lock().announce(&full, &existing.active);
+			existing.announced = true;
+		} else if !desired && existing.announced {
+			self.notify.lock().unannounce(&full);
+			existing.announced = false;
 		}
 	}
 
@@ -578,7 +628,11 @@ impl OriginNode {
 
 	fn consume_initial(&mut self, notify: &mut AnnounceConsumerNotify) {
 		if let Some(broadcast) = &self.broadcast {
-			notify.announce(&broadcast.path, broadcast.active.clone());
+			// Replay only currently-announced (live) routes; an offline-but-existing broadcast
+			// stays discoverable by FETCH, not by the announce stream.
+			if broadcast.announced {
+				notify.announce(&broadcast.path, broadcast.active.clone());
+			}
 		}
 
 		// Recursively subscribe to all nested nodes.
@@ -606,7 +660,6 @@ impl OriginNode {
 		}
 	}
 
-	// Returns true if the broadcast should be unannounced.
 	fn remove(&mut self, full: impl AsPath, broadcast: broadcast::Consumer, relative: impl AsPath) {
 		let full = full.as_path();
 		let relative = relative.as_path();
@@ -620,7 +673,12 @@ impl OriginNode {
 				drop(locked);
 				self.nested.remove(dir);
 			}
-		} else {
+			return;
+		}
+
+		// Whether the leaf emptied out, so we can clear it after the borrow ends.
+		let mut cleared = false;
+		{
 			let entry = match &mut self.broadcast {
 				Some(existing) => existing,
 				None => return,
@@ -630,12 +688,19 @@ impl OriginNode {
 			let pos = entry.backup.iter().position(|b| b.is_clone(&broadcast));
 			if let Some(pos) = pos {
 				entry.backup.remove(pos);
-				// Nothing else to do
+				// A backup was never the active route, so there is nothing to reconcile.
 				return;
 			}
 
 			// Okay so it must be the active broadcast or else we fucked up.
 			assert!(entry.active.is_clone(&broadcast));
+
+			// The active route is going away; drop its announcement first so a promoted backup
+			// re-announces cleanly (or the path goes offline if none remain).
+			if entry.announced {
+				self.notify.lock().unannounce(&full);
+				entry.announced = false;
+			}
 
 			// Promote the backup with the lowest ordering key, the same rule used when
 			// publishing, so the route a node heals to still matches its peers.
@@ -645,20 +710,18 @@ impl OriginNode {
 				.enumerate()
 				.min_by_key(|(_, b)| route_key(&full, b.info()))
 				.map(|(i, _)| i);
-			if let Some(idx) = best {
-				let active = entry.backup.remove(idx).expect("index in range");
-				entry.active = active;
-
-				// Promoting a backup is an unannounce/announce pair: the path briefly reads
-				// as unavailable rather than swapping atomically.
-				let mut notify = self.notify.lock();
-				notify.unannounce(&full);
-				notify.announce(&full, &entry.active);
-			} else {
-				// No more backups, so remove the entry.
-				self.broadcast = None;
-				self.notify.lock().unannounce(full);
+			match best {
+				Some(idx) => entry.active = entry.backup.remove(idx).expect("index in range"),
+				None => cleared = true,
 			}
+		}
+
+		if cleared {
+			// No more backups, so remove the entry entirely.
+			self.broadcast = None;
+		} else {
+			// A backup was promoted; announce it if it is live.
+			self.reconcile(&full);
 		}
 	}
 
@@ -848,12 +911,20 @@ impl Producer {
 		Ok(Broadcast { producer, publish })
 	}
 
-	/// Publish a broadcast, announcing it to all consumers.
+	/// Publish a broadcast, registering it so consumers can reach it.
 	///
-	/// Returns an [`Publish`] guard that keeps the broadcast announced. Drop it (or call
-	/// [`Publish::unannounce`]) to remove the broadcast. The announcement is independent
-	/// of the broadcast's own lifetime, so dropping the guard unannounces even while the
-	/// [`broadcast::Producer`] keeps serving tracks.
+	/// Registering makes the broadcast *exist* in the origin: a FETCH or exact-path
+	/// [`request_broadcast`](Consumer::request_broadcast) resolves to it immediately. It is
+	/// *announced* to [`Consumer::announced`] only while it is live (see
+	/// [`broadcast::Producer::set_live`]); a broadcast starts offline, so publish it, populate
+	/// it, then flip it live. The origin tracks the broadcast's liveness and announces or
+	/// unannounces it accordingly, so an offline broadcast stays FETCH-routable without being
+	/// advertised.
+	///
+	/// Returns a [`Publish`] guard that keeps the broadcast registered. Drop it (or call
+	/// [`Publish::unannounce`]) to remove the broadcast, which also unannounces it if it was
+	/// live. Registration is independent of the broadcast's own lifetime; when the broadcast
+	/// closes on its own the origin removes it too.
 	///
 	/// Fails with [`Error::Unauthorized`] if `path` is outside the prefixes this producer may
 	/// publish under (after [`scope`](Self::scope) / [`with_root`](Self::with_root)). A full-scope
@@ -863,13 +934,13 @@ impl Producer {
 	/// routing loop); relays filter such reflections before they reach here, checked by a
 	/// `debug_assert`.
 	///
-	/// If there is already a broadcast with the same path, the new one replaces the active only
-	/// if it has a shorter hop path, or an equal-length path that wins a deterministic tie-break
-	/// (a hash of the broadcast name and hop chain); otherwise it is queued as a backup. The
-	/// tie-break is identical on every node, so a cluster converges on the same route.
-	/// When the active guard is dropped, the backup that wins the same ordering is promoted and
-	/// reannounced. Backups whose guards drop before being promoted are silently removed.
-	#[must_use = "the broadcast is unannounced as soon as the returned guard is dropped"]
+	/// If there is already a broadcast with the same path, the new one replaces the active route
+	/// only if it has a shorter hop path, or an equal-length path that wins a deterministic
+	/// tie-break (a hash of the broadcast name and hop chain); otherwise it is queued as a backup.
+	/// The tie-break is identical on every node, so a cluster converges on the same route. When the
+	/// active broadcast is removed, the backup that wins the same ordering is promoted (and
+	/// announced if it is live). Backups removed before being promoted are silently dropped.
+	#[must_use = "the broadcast is removed as soon as the returned guard is dropped"]
 	pub fn publish_broadcast(
 		&self,
 		path: impl AsPath,
@@ -895,13 +966,15 @@ impl Producer {
 			return Err(BoundsExceeded.into());
 		}
 
+		// Register existence synchronously so a concurrent FETCH sees it right away.
 		node.lock().publish(&full, &broadcast, &rest);
-		Ok(Publish {
-			node,
-			full,
-			rest,
-			broadcast: Some(broadcast),
-		})
+
+		// Drive announcements off the broadcast's liveness. The task also removes the broadcast
+		// when it closes or when the returned guard drops (closing `token`).
+		let token = kio::Producer::<()>::default();
+		web_async::spawn(reconcile_publish(node, full, rest, broadcast, token.consume()));
+
+		Ok(Publish { _token: token })
 	}
 
 	/// Returns a new Producer restricted to publishing under one of `prefixes`.
@@ -982,49 +1055,82 @@ impl Producer {
 	}
 }
 
-/// Keeps a broadcast announced in the origin tree.
+/// Keeps a broadcast registered in the origin tree.
 ///
-/// Returned by [`Producer::publish_broadcast`]. While held, the broadcast stays
-/// announced to all consumers. Dropping it (or calling [`Self::unannounce`]) removes the
-/// broadcast from the tree: the origin promotes the best remaining backup route (unannouncing
-/// the path and re-announcing it with the backup) or, if none remain, unannounces the path.
-/// The guard is independent of the broadcast's own lifetime, so it can outlive or be dropped
+/// Returned by [`Producer::publish_broadcast`]. While held, the broadcast stays registered
+/// (reachable by a FETCH) and is announced whenever it is live. Dropping it (or calling
+/// [`Self::unannounce`]) removes the broadcast from the tree: the origin promotes the best
+/// remaining backup route (announcing it if live), or removes the path entirely if none remain.
+/// Registration is independent of the broadcast's own lifetime, so it can outlive or be dropped
 /// before the broadcast itself.
-#[must_use = "the broadcast is unannounced as soon as this guard is dropped"]
+#[must_use = "the broadcast is removed as soon as this guard is dropped"]
 pub struct Publish {
-	node: Lock<OriginNode>,
-	full: PathOwned,
-	rest: PathOwned,
-	// `Option` so `Drop` can take ownership to hand the consumer to `remove`.
-	broadcast: Option<broadcast::Consumer>,
+	// Dropping closes the channel; the reconciler task observes it and removes the broadcast.
+	_token: kio::Producer<()>,
 }
 
 impl Publish {
-	/// Unannounce the broadcast. Equivalent to dropping the guard, but spells out the intent.
+	/// Remove the broadcast. Equivalent to dropping the guard, but spells out the intent.
 	pub fn unannounce(self) {}
 }
 
-impl Drop for Publish {
-	fn drop(&mut self) {
-		if let Some(broadcast) = self.broadcast.take() {
-			self.node.lock().remove(&self.full, broadcast, &self.rest);
+/// Drives a published broadcast's announcements off its liveness, and removes it on teardown.
+///
+/// Runs until the broadcast closes or the [`Publish`] guard drops (closing `token`), reconciling
+/// the announce state on every liveness change, then removes the broadcast from the tree.
+async fn reconcile_publish(
+	node: Lock<OriginNode>,
+	full: PathOwned,
+	rest: PathOwned,
+	broadcast: broadcast::Consumer,
+	token: kio::Consumer<()>,
+) {
+	enum Wake {
+		Live(bool),
+		Done,
+	}
+
+	let mut last_live = broadcast.is_live();
+	loop {
+		node.lock().reconcile_at(&full, &rest);
+
+		let wake = kio::wait(|waiter| {
+			// The guard dropped: tear down.
+			if token.poll_closed(waiter).is_ready() {
+				return Poll::Ready(Wake::Done);
+			}
+			// Otherwise wait for the next liveness change, or the broadcast closing (`None`).
+			match broadcast.poll_live(waiter, last_live) {
+				Poll::Ready(Some(live)) => Poll::Ready(Wake::Live(live)),
+				Poll::Ready(None) => Poll::Ready(Wake::Done),
+				Poll::Pending => Poll::Pending,
+			}
+		})
+		.await;
+
+		match wake {
+			Wake::Live(live) => last_live = live,
+			Wake::Done => break,
 		}
 	}
+
+	node.lock().remove(&full, broadcast, &rest);
 }
 
-/// A [`broadcast::Producer`] paired with its [`Publish`] announcement guard.
+/// A [`broadcast::Producer`] paired with its [`Publish`] registration guard.
 ///
-/// Returned by [`Producer::create_broadcast`]. Derefs to the underlying
-/// [`broadcast::Producer`] so you can add tracks directly; dropping it unannounces the broadcast.
+/// Returned by [`Producer::create_broadcast`]. Derefs to the underlying [`broadcast::Producer`]
+/// so you can add tracks directly, then flip it live with [`broadcast::Producer::set_live`];
+/// dropping it removes the broadcast.
 pub struct Broadcast {
 	producer: broadcast::Producer,
-	// Held only for its Drop, which unannounces the broadcast.
+	// Held only for its Drop, which removes the broadcast.
 	#[allow(dead_code)]
 	publish: Publish,
 }
 
 impl Broadcast {
-	/// Stop announcing the broadcast but keep producing into it, returning the bare producer.
+	/// Stop advertising the broadcast but keep producing into it, returning the bare producer.
 	pub fn unannounce(self) -> broadcast::Producer {
 		self.producer
 	}
@@ -1724,6 +1830,16 @@ impl AnnounceConsumer {
 		assert!(announced.is_clone(broadcast), "should be the same broadcast");
 	}
 
+	/// Like [`Self::assert_next`] but awaits the announcement, for when liveness is toggled
+	/// after publish (the origin's reconciler announces asynchronously).
+	pub async fn assert_next_soon(&mut self, expected: impl AsPath, broadcast: &broadcast::Consumer) {
+		let expected = expected.as_path();
+		let announce = self.next().await.expect("no next");
+		assert_eq!(announce.path, expected, "wrong path");
+		let announced = announce.broadcast.expect("should be an active announce");
+		assert!(announced.is_clone(broadcast), "should be the same broadcast");
+	}
+
 	/// A replacement route arrives as an unannounce/announce pair for the same path.
 	pub fn assert_next_replaced(&mut self, expected: impl AsPath, broadcast: &broadcast::Consumer) {
 		let expected = expected.as_path();
@@ -1764,13 +1880,15 @@ impl AnnounceConsumer {
 
 #[cfg(test)]
 impl Producer {
-	/// Test helper that reproduces the legacy fire-and-forget contract: publish, then
-	/// auto-unannounce when the broadcast closes (every producer dropped) via a spawned
-	/// watcher that drops the [`Publish`] guard. Returns whether the publish was
-	/// accepted. Exercises [`Publish`]'s `Drop` on the close path.
-	fn publish_broadcast_spawn(&self, path: impl AsPath, broadcast: broadcast::Consumer) -> bool {
-		match self.publish_broadcast(path, &broadcast) {
+	/// Test helper that reproduces the legacy fire-and-forget contract: mark the broadcast live,
+	/// publish it, then drop the [`Publish`] guard when the broadcast closes (every producer
+	/// dropped) via a spawned watcher. Returns whether the publish was accepted. Marking it live
+	/// keeps the tests asserting on the announce stream, which now tracks liveness.
+	fn publish_broadcast_spawn(&self, path: impl AsPath, broadcast: &broadcast::Producer) -> bool {
+		broadcast.set_live(true);
+		match self.publish_broadcast(path, broadcast) {
 			Ok(publish) => {
+				let broadcast = broadcast.consume();
 				web_async::spawn(async move {
 					broadcast.closed().await;
 					drop(publish);
@@ -1852,7 +1970,7 @@ mod tests {
 		consumer1.assert_next_wait();
 
 		// Publish the first broadcast.
-		origin.publish_broadcast_spawn("test1", broadcast1.consume());
+		origin.publish_broadcast_spawn("test1", &broadcast1);
 
 		consumer1.assert_next("test1", &broadcast1.consume());
 		consumer1.assert_next_wait();
@@ -1862,7 +1980,7 @@ mod tests {
 		let mut consumer2 = origin.consume().announced();
 
 		// Publish the second broadcast.
-		origin.publish_broadcast_spawn("test2", broadcast2.consume());
+		origin.publish_broadcast_spawn("test2", &broadcast2);
 
 		consumer1.assert_next("test2", &broadcast2.consume());
 		consumer1.assert_next_wait();
@@ -1916,15 +2034,14 @@ mod tests {
 		let broadcast3 = broadcast::Info::new().produce();
 
 		let consumer1 = broadcast1.consume();
-		let consumer2 = broadcast2.consume();
 		let consumer3 = broadcast3.consume();
 
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
-		origin.publish_broadcast_spawn("test", consumer1.clone());
-		origin.publish_broadcast_spawn("test", consumer2.clone());
-		origin.publish_broadcast_spawn("test", consumer3.clone());
+		origin.publish_broadcast_spawn("test", &broadcast1);
+		origin.publish_broadcast_spawn("test", &broadcast2);
+		origin.publish_broadcast_spawn("test", &broadcast3);
 		assert!(consumer.get_broadcast("test").is_some());
 
 		// Identical (empty) hop chains tie on the deterministic key, so the first publish
@@ -1961,6 +2078,44 @@ mod tests {
 		announced.assert_next_wait();
 	}
 
+	// Liveness gates announcement, not existence: an offline broadcast stays reachable by a
+	// FETCH (`get_broadcast`) but is never announced; toggling live drives announce/unannounce.
+	#[tokio::test(start_paused = true)]
+	async fn test_liveness_gates_announcement() {
+		let origin = Origin::random().produce();
+		let broadcast = broadcast::Info::new().produce();
+
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+
+		// Publish offline: registered (routable) but not announced.
+		let publish = origin.publish_broadcast("test", &broadcast).unwrap();
+		assert!(
+			consumer.get_broadcast("test").is_some(),
+			"offline broadcast is still routable"
+		);
+		announced.assert_next_wait();
+
+		// Going live announces it (the reconciler runs asynchronously).
+		broadcast.set_live(true);
+		announced.assert_next_soon("test", &broadcast.consume()).await;
+
+		// Going offline again unannounces it, but it stays routable for a FETCH.
+		broadcast.set_live(false);
+		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+		announced.assert_next_none("test");
+		assert!(
+			consumer.get_broadcast("test").is_some(),
+			"offline again but still routable"
+		);
+
+		// Dropping the guard removes it entirely.
+		drop(publish);
+		drop(broadcast);
+		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
+		assert!(consumer.get_broadcast("test").is_none(), "removed after unpublish");
+	}
+
 	#[tokio::test]
 	async fn test_replace_after_drain() {
 		// A strictly-better route (shorter hop chain) replacing the active broadcast
@@ -1976,10 +2131,10 @@ mod tests {
 		let b = broadcast::Info::new().produce();
 
 		let mut announced = origin.consume().announced();
-		origin.publish_broadcast_spawn("test", a.consume());
+		origin.publish_broadcast_spawn("test", &a);
 		announced.assert_next("test", &a.consume());
 
-		origin.publish_broadcast_spawn("test", b.consume());
+		origin.publish_broadcast_spawn("test", &b);
 		announced.assert_next_replaced("test", &b.consume());
 		announced.assert_next_wait();
 	}
@@ -1999,8 +2154,8 @@ mod tests {
 		let b = broadcast::Info::new().produce();
 
 		let mut announced = origin.consume().announced();
-		origin.publish_broadcast_spawn("test", a.consume());
-		origin.publish_broadcast_spawn("test", b.consume());
+		origin.publish_broadcast_spawn("test", &a);
+		origin.publish_broadcast_spawn("test", &b);
 
 		announced.assert_next("test", &b.consume());
 		announced.assert_next_wait();
@@ -2014,8 +2169,8 @@ mod tests {
 		let broadcast1 = broadcast::Info::new().produce();
 		let broadcast2 = broadcast::Info::new().produce();
 
-		origin.publish_broadcast_spawn("test", broadcast1.consume());
-		origin.publish_broadcast_spawn("test", broadcast2.consume());
+		origin.publish_broadcast_spawn("test", &broadcast1);
+		origin.publish_broadcast_spawn("test", &broadcast2);
 		assert!(origin.consume().get_broadcast("test").is_some());
 
 		// This is harder, dropping the new broadcast first.
@@ -2056,8 +2211,8 @@ mod tests {
 			let origin = Origin::random().produce();
 			let a = route(first);
 			let b = route(second);
-			origin.publish_broadcast_spawn("test", a.consume());
-			origin.publish_broadcast_spawn("test", b.consume());
+			origin.publish_broadcast_spawn("test", &a);
+			origin.publish_broadcast_spawn("test", &b);
 			let hops = origin.consume().get_broadcast("test").unwrap().info().hops.clone();
 			// Keep the producers alive until after we read the active route.
 			drop((a, b));
@@ -2083,8 +2238,8 @@ mod tests {
 		let broadcast = broadcast::Info::new().produce();
 
 		// Ensure it doesn't crash.
-		origin.publish_broadcast_spawn("test", broadcast.consume());
-		origin.publish_broadcast_spawn("test", broadcast.consume());
+		origin.publish_broadcast_spawn("test", &broadcast);
+		origin.publish_broadcast_spawn("test", &broadcast);
 
 		assert!(origin.consume().get_broadcast("test").is_some());
 
@@ -2105,7 +2260,7 @@ mod tests {
 
 		let mut consumer = origin.consume().announced();
 		for i in 0..256 {
-			origin.publish_broadcast_spawn(format!("test{i:03}"), broadcast.consume());
+			origin.publish_broadcast_spawn(format!("test{i:03}"), &broadcast);
 		}
 
 		for i in 0..256 {
@@ -2121,7 +2276,7 @@ mod tests {
 
 		let mut consumer = origin.consume().announced();
 		for i in 0..256 {
-			origin.publish_broadcast_spawn(format!("test{i:03}"), broadcast.consume());
+			origin.publish_broadcast_spawn(format!("test{i:03}"), &broadcast);
 		}
 
 		for i in 0..256 {
@@ -2141,7 +2296,7 @@ mod tests {
 		let mut consumer = origin.consume().announced();
 
 		// When publishing to "bar/baz", it should actually publish to "foo/bar/baz"
-		assert!(foo_producer.publish_broadcast_spawn("bar/baz", broadcast.consume()));
+		assert!(foo_producer.publish_broadcast_spawn("bar/baz", &broadcast));
 		// The original consumer should see the full path
 		consumer.assert_next("foo/bar/baz", &broadcast.consume());
 
@@ -2163,7 +2318,7 @@ mod tests {
 		let mut consumer = origin.consume().announced();
 
 		// Publishing to "baz" should actually publish to "foo/bar/baz"
-		assert!(foo_bar_producer.publish_broadcast_spawn("baz", broadcast.consume()));
+		assert!(foo_bar_producer.publish_broadcast_spawn("baz", &broadcast));
 		// The original consumer sees the full path
 		consumer.assert_next("foo/bar/baz", &broadcast.consume());
 
@@ -2183,14 +2338,14 @@ mod tests {
 			.expect("should create limited producer");
 
 		// Should be able to publish to allowed paths
-		assert!(limited_producer.publish_broadcast_spawn("allowed/path1", broadcast.consume()));
-		assert!(limited_producer.publish_broadcast_spawn("allowed/path1/nested", broadcast.consume()));
-		assert!(limited_producer.publish_broadcast_spawn("allowed/path2", broadcast.consume()));
+		assert!(limited_producer.publish_broadcast_spawn("allowed/path1", &broadcast));
+		assert!(limited_producer.publish_broadcast_spawn("allowed/path1/nested", &broadcast));
+		assert!(limited_producer.publish_broadcast_spawn("allowed/path2", &broadcast));
 
 		// Should not be able to publish to disallowed paths
-		assert!(!limited_producer.publish_broadcast_spawn("notallowed", broadcast.consume()));
-		assert!(!limited_producer.publish_broadcast_spawn("allowed", broadcast.consume())); // Parent of allowed path
-		assert!(!limited_producer.publish_broadcast_spawn("other/path", broadcast.consume()));
+		assert!(!limited_producer.publish_broadcast_spawn("notallowed", &broadcast));
+		assert!(!limited_producer.publish_broadcast_spawn("allowed", &broadcast)); // Parent of allowed path
+		assert!(!limited_producer.publish_broadcast_spawn("other/path", &broadcast));
 	}
 
 	#[tokio::test]
@@ -2202,14 +2357,14 @@ mod tests {
 			.map(|i| i.to_string())
 			.collect::<Vec<_>>()
 			.join("/");
-		assert!(origin.publish_broadcast_spawn(at_limit.as_str(), broadcast.consume()));
+		assert!(origin.publish_broadcast_spawn(at_limit.as_str(), &broadcast));
 
 		let too_deep = format!("{at_limit}/extra");
-		assert!(!origin.publish_broadcast_spawn(too_deep.as_str(), broadcast.consume()));
+		assert!(!origin.publish_broadcast_spawn(too_deep.as_str(), &broadcast));
 
 		// The root counts toward the limit; a joined path past 32 parts is rejected.
 		let rooted = origin.with_root("root").expect("wildcard allows any root");
-		assert!(!rooted.publish_broadcast_spawn(at_limit.as_str(), broadcast.consume()));
+		assert!(!rooted.publish_broadcast_spawn(at_limit.as_str(), &broadcast));
 	}
 
 	#[tokio::test]
@@ -2230,9 +2385,9 @@ mod tests {
 		let mut consumer = origin.consume().announced();
 
 		// Publish to different paths
-		origin.publish_broadcast_spawn("allowed", broadcast1.consume());
-		origin.publish_broadcast_spawn("allowed/nested", broadcast2.consume());
-		origin.publish_broadcast_spawn("notallowed", broadcast3.consume());
+		origin.publish_broadcast_spawn("allowed", &broadcast1);
+		origin.publish_broadcast_spawn("allowed/nested", &broadcast2);
+		origin.publish_broadcast_spawn("notallowed", &broadcast3);
 
 		// Create a consumer that only sees "allowed" paths
 		let mut limited_consumer = origin
@@ -2259,9 +2414,9 @@ mod tests {
 		let broadcast2 = broadcast::Info::new().produce();
 		let broadcast3 = broadcast::Info::new().produce();
 
-		origin.publish_broadcast_spawn("foo/test", broadcast1.consume());
-		origin.publish_broadcast_spawn("bar/test", broadcast2.consume());
-		origin.publish_broadcast_spawn("baz/test", broadcast3.consume());
+		origin.publish_broadcast_spawn("foo/test", &broadcast1);
+		origin.publish_broadcast_spawn("bar/test", &broadcast2);
+		origin.publish_broadcast_spawn("baz/test", &broadcast3);
 
 		// Consumer that only sees "foo" and "bar" paths
 		let mut limited_consumer = origin
@@ -2292,15 +2447,15 @@ mod tests {
 		let mut consumer = origin.consume().announced();
 
 		// Should be able to publish to foo/bar and foo/goop/pee (but user sees as bar and goop/pee)
-		assert!(limited_producer.publish_broadcast_spawn("bar", broadcast.consume()));
-		assert!(limited_producer.publish_broadcast_spawn("bar/nested", broadcast.consume()));
-		assert!(limited_producer.publish_broadcast_spawn("goop/pee", broadcast.consume()));
-		assert!(limited_producer.publish_broadcast_spawn("goop/pee/nested", broadcast.consume()));
+		assert!(limited_producer.publish_broadcast_spawn("bar", &broadcast));
+		assert!(limited_producer.publish_broadcast_spawn("bar/nested", &broadcast));
+		assert!(limited_producer.publish_broadcast_spawn("goop/pee", &broadcast));
+		assert!(limited_producer.publish_broadcast_spawn("goop/pee/nested", &broadcast));
 
 		// Should not be able to publish outside allowed paths
-		assert!(!limited_producer.publish_broadcast_spawn("baz", broadcast.consume()));
-		assert!(!limited_producer.publish_broadcast_spawn("goop", broadcast.consume())); // Parent of allowed
-		assert!(!limited_producer.publish_broadcast_spawn("goop/other", broadcast.consume()));
+		assert!(!limited_producer.publish_broadcast_spawn("baz", &broadcast));
+		assert!(!limited_producer.publish_broadcast_spawn("goop", &broadcast)); // Parent of allowed
+		assert!(!limited_producer.publish_broadcast_spawn("goop/other", &broadcast));
 
 		// Original consumer sees full paths
 		consumer.assert_next("foo/bar", &broadcast.consume());
@@ -2317,9 +2472,9 @@ mod tests {
 		let broadcast3 = broadcast::Info::new().produce();
 
 		// Publish broadcasts
-		origin.publish_broadcast_spawn("foo/bar/test", broadcast1.consume());
-		origin.publish_broadcast_spawn("foo/goop/pee/test", broadcast2.consume());
-		origin.publish_broadcast_spawn("foo/other/test", broadcast3.consume());
+		origin.publish_broadcast_spawn("foo/bar/test", &broadcast1);
+		origin.publish_broadcast_spawn("foo/goop/pee/test", &broadcast2);
+		origin.publish_broadcast_spawn("foo/other/test", &broadcast3);
 
 		// User connects to /foo root
 		let foo_producer = origin.with_root("foo").expect("should create foo root");
@@ -2365,8 +2520,8 @@ mod tests {
 		let root_producer = origin.clone();
 
 		// Should be able to publish anywhere
-		assert!(root_producer.publish_broadcast_spawn("any/path", broadcast.consume()));
-		assert!(root_producer.publish_broadcast_spawn("other/path", broadcast.consume()));
+		assert!(root_producer.publish_broadcast_spawn("any/path", &broadcast));
+		assert!(root_producer.publish_broadcast_spawn("other/path", &broadcast));
 
 		// Can create any root
 		let foo_producer = root_producer.with_root("foo").expect("should create any root");
@@ -2379,8 +2534,8 @@ mod tests {
 		let broadcast1 = broadcast::Info::new().produce();
 		let broadcast2 = broadcast::Info::new().produce();
 
-		origin.publish_broadcast_spawn("allowed/test", broadcast1.consume());
-		origin.publish_broadcast_spawn("notallowed/test", broadcast2.consume());
+		origin.publish_broadcast_spawn("allowed/test", &broadcast1);
+		origin.publish_broadcast_spawn("notallowed/test", &broadcast2);
 
 		// Create limited consumer
 		let limited_consumer = origin
@@ -2411,14 +2566,14 @@ mod tests {
 		let limited_producer = origin.scope(&["a/b/c".into()]).expect("should create limited producer");
 
 		// Should be able to publish to exact path and nested paths
-		assert!(limited_producer.publish_broadcast_spawn("a/b/c", broadcast.consume()));
-		assert!(limited_producer.publish_broadcast_spawn("a/b/c/d", broadcast.consume()));
-		assert!(limited_producer.publish_broadcast_spawn("a/b/c/d/e", broadcast.consume()));
+		assert!(limited_producer.publish_broadcast_spawn("a/b/c", &broadcast));
+		assert!(limited_producer.publish_broadcast_spawn("a/b/c/d", &broadcast));
+		assert!(limited_producer.publish_broadcast_spawn("a/b/c/d/e", &broadcast));
 
 		// Should not be able to publish to parent or sibling paths
-		assert!(!limited_producer.publish_broadcast_spawn("a", broadcast.consume()));
-		assert!(!limited_producer.publish_broadcast_spawn("a/b", broadcast.consume()));
-		assert!(!limited_producer.publish_broadcast_spawn("a/b/other", broadcast.consume()));
+		assert!(!limited_producer.publish_broadcast_spawn("a", &broadcast));
+		assert!(!limited_producer.publish_broadcast_spawn("a/b", &broadcast));
+		assert!(!limited_producer.publish_broadcast_spawn("a/b/other", &broadcast));
 	}
 
 	#[tokio::test]
@@ -2429,9 +2584,9 @@ mod tests {
 		let broadcast3 = broadcast::Info::new().produce();
 
 		// Publish to different paths
-		origin.publish_broadcast_spawn("foo/test", broadcast1.consume());
-		origin.publish_broadcast_spawn("bar/test", broadcast2.consume());
-		origin.publish_broadcast_spawn("baz/test", broadcast3.consume());
+		origin.publish_broadcast_spawn("foo/test", &broadcast1);
+		origin.publish_broadcast_spawn("bar/test", &broadcast2);
+		origin.publish_broadcast_spawn("baz/test", &broadcast3);
 
 		// Create consumers with different permissions
 		let mut foo_consumer = origin
@@ -2477,8 +2632,8 @@ mod tests {
 			.expect("should create limited producer");
 
 		// Publish some broadcasts
-		assert!(limited_producer.publish_broadcast_spawn("worm-node/test", broadcast1.consume()));
-		assert!(limited_producer.publish_broadcast_spawn("foobar/test", broadcast2.consume()));
+		assert!(limited_producer.publish_broadcast_spawn("worm-node/test", &broadcast1));
+		assert!(limited_producer.publish_broadcast_spawn("foobar/test", &broadcast2));
 
 		// scope with empty prefix should keep the exact same "worm-node" and "foobar" nodes
 		let mut consumer = limited_producer
@@ -2511,9 +2666,9 @@ mod tests {
 			.expect("should create limited producer");
 
 		// Publish broadcasts at different levels
-		assert!(limited_producer.publish_broadcast_spawn("worm-node", broadcast1.consume()));
-		assert!(limited_producer.publish_broadcast_spawn("worm-node/foo", broadcast2.consume()));
-		assert!(limited_producer.publish_broadcast_spawn("foobar/bar", broadcast3.consume()));
+		assert!(limited_producer.publish_broadcast_spawn("worm-node", &broadcast1));
+		assert!(limited_producer.publish_broadcast_spawn("worm-node/foo", &broadcast2));
+		assert!(limited_producer.publish_broadcast_spawn("foobar/bar", &broadcast3));
 
 		// Test 1: scope("worm-node") should result in a single "" node with contents of "worm-node" ONLY
 		let mut worm_consumer = limited_producer
@@ -2551,9 +2706,9 @@ mod tests {
 			.expect("should create limited producer");
 
 		// Publish to each root
-		assert!(limited_producer.publish_broadcast_spawn("app1/data", broadcast1.consume()));
-		assert!(limited_producer.publish_broadcast_spawn("app2/config", broadcast2.consume()));
-		assert!(limited_producer.publish_broadcast_spawn("shared/resource", broadcast3.consume()));
+		assert!(limited_producer.publish_broadcast_spawn("app1/data", &broadcast1));
+		assert!(limited_producer.publish_broadcast_spawn("app2/config", &broadcast2));
+		assert!(limited_producer.publish_broadcast_spawn("shared/resource", &broadcast3));
 
 		// scope with empty prefix should maintain all roots
 		let mut consumer = limited_producer
@@ -2585,10 +2740,10 @@ mod tests {
 			.expect("should create producer with empty prefix");
 
 		// Should still have the same publishing restrictions
-		assert!(same_producer.publish_broadcast_spawn("services/api", broadcast.consume()));
-		assert!(same_producer.publish_broadcast_spawn("services/web", broadcast.consume()));
-		assert!(!same_producer.publish_broadcast_spawn("services/db", broadcast.consume()));
-		assert!(!same_producer.publish_broadcast_spawn("other", broadcast.consume()));
+		assert!(same_producer.publish_broadcast_spawn("services/api", &broadcast));
+		assert!(same_producer.publish_broadcast_spawn("services/web", &broadcast));
+		assert!(!same_producer.publish_broadcast_spawn("services/db", &broadcast));
+		assert!(!same_producer.publish_broadcast_spawn("other", &broadcast));
 	}
 
 	#[tokio::test]
@@ -2602,9 +2757,9 @@ mod tests {
 		let limited_producer = origin.scope(&["org".into()]).expect("should create limited producer");
 
 		// Publish at various depths
-		assert!(limited_producer.publish_broadcast_spawn("org/team1/project1", broadcast1.consume()));
-		assert!(limited_producer.publish_broadcast_spawn("org/team1/project2", broadcast2.consume()));
-		assert!(limited_producer.publish_broadcast_spawn("org/team2/project1", broadcast3.consume()));
+		assert!(limited_producer.publish_broadcast_spawn("org/team1/project1", &broadcast1));
+		assert!(limited_producer.publish_broadcast_spawn("org/team1/project2", &broadcast2));
+		assert!(limited_producer.publish_broadcast_spawn("org/team2/project1", &broadcast3));
 
 		// Narrow down to team2 only
 		let mut team2_consumer = limited_producer
@@ -2655,7 +2810,9 @@ mod tests {
 		let mut consumer = origin.consume().with_root(prefix).unwrap().announced();
 
 		let b = origin.create_broadcast("some_prefix/test").unwrap();
-		consumer.assert_next("test", &b.consume());
+		// A created broadcast starts offline; go live so it is announced.
+		b.set_live(true);
+		consumer.assert_next_soon("test", &b.consume()).await;
 	}
 
 	// Same issue but for the producer side of with_root
@@ -2668,9 +2825,10 @@ mod tests {
 		let rooted = origin.with_root(prefix).unwrap();
 
 		let b = rooted.create_broadcast("test").unwrap();
+		b.set_live(true);
 
 		let mut consumer = rooted.consume().announced();
-		consumer.assert_next("test", &b.consume());
+		consumer.assert_next_soon("test", &b.consume()).await;
 	}
 
 	// Verify unannounce also doesn't panic with trailing slash
@@ -2684,7 +2842,8 @@ mod tests {
 		let mut consumer = origin.consume().with_root(prefix).unwrap().announced();
 
 		let b = origin.create_broadcast("some_prefix/test").unwrap();
-		consumer.assert_next("test", &b.consume());
+		b.set_live(true);
+		consumer.assert_next_soon("test", &b.consume()).await;
 
 		// Drop the broadcast producer to trigger unannounce
 		drop(b);
@@ -2707,8 +2866,8 @@ mod tests {
 			.expect("should create user producer");
 
 		// Publish some data
-		assert!(user_producer.publish_broadcast_spawn("worm-node/data", broadcast1.consume()));
-		assert!(user_producer.publish_broadcast_spawn("foobar", broadcast2.consume()));
+		assert!(user_producer.publish_broadcast_spawn("worm-node/data", &broadcast1));
+		assert!(user_producer.publish_broadcast_spawn("foobar", &broadcast2));
 
 		// Key test: scope with "" should maintain access to allowed roots
 		let mut consumer = user_producer
@@ -2747,7 +2906,7 @@ mod tests {
 			.scope(&["demo".into(), "demo".into()])
 			.expect("should create producer");
 
-		assert!(producer.publish_broadcast_spawn("demo/stream", broadcast.consume()));
+		assert!(producer.publish_broadcast_spawn("demo/stream", &broadcast));
 
 		let mut consumer = producer.consume().announced();
 		consumer.assert_next("demo/stream", &broadcast.consume());
@@ -2765,7 +2924,7 @@ mod tests {
 			.expect("should create producer");
 
 		// Can still publish under "demo/bar" since "demo" covers everything
-		assert!(producer.publish_broadcast_spawn("demo/bar/stream", broadcast.consume()));
+		assert!(producer.publish_broadcast_spawn("demo/bar/stream", &broadcast));
 
 		let mut consumer = producer.consume().announced();
 		consumer.assert_next("demo/bar/stream", &broadcast.consume());
@@ -2782,7 +2941,7 @@ mod tests {
 			.scope(&["demo".into(), "demo/foo".into()])
 			.expect("should create producer");
 
-		assert!(producer.publish_broadcast_spawn("demo/foo/stream", broadcast.consume()));
+		assert!(producer.publish_broadcast_spawn("demo/foo/stream", &broadcast));
 
 		let mut consumer = producer.consume().announced();
 		// Should only get ONE announcement (not two from overlapping nodes)
@@ -2807,7 +2966,7 @@ mod tests {
 		let origin = Origin::random().produce();
 		let broadcast = broadcast::Info::new().produce();
 
-		origin.publish_broadcast_spawn("test", broadcast.consume());
+		origin.publish_broadcast_spawn("test", &broadcast);
 
 		let consumer = origin.consume();
 		let result = consumer.announced_broadcast("test").await.expect("should find it");
@@ -2832,7 +2991,7 @@ mod tests {
 		// Give the spawned task a chance to subscribe.
 		tokio::task::yield_now().await;
 
-		origin.publish_broadcast_spawn("test", broadcast.consume());
+		origin.publish_broadcast_spawn("test", &broadcast);
 
 		let result = wait.await.unwrap().expect("should find it");
 		assert!(result.is_clone(&broadcast.consume()));
@@ -2856,11 +3015,11 @@ mod tests {
 		tokio::task::yield_now().await;
 
 		// Publish an unrelated broadcast first. announced_broadcast should skip it.
-		origin.publish_broadcast_spawn("other", other.consume());
+		origin.publish_broadcast_spawn("other", &other);
 		tokio::task::yield_now().await;
 		assert!(!wait.is_finished(), "must not resolve on unrelated path");
 
-		origin.publish_broadcast_spawn("target", target.consume());
+		origin.publish_broadcast_spawn("target", &target);
 		let result = wait.await.unwrap().expect("should find target");
 		assert!(result.is_clone(&target.consume()));
 	}
@@ -2883,11 +3042,11 @@ mod tests {
 		tokio::task::yield_now().await;
 
 		// "foo/bar" is under the prefix scope, but it's not the exact path. Skip it.
-		origin.publish_broadcast_spawn("foo/bar", nested.consume());
+		origin.publish_broadcast_spawn("foo/bar", &nested);
 		tokio::task::yield_now().await;
 		assert!(!wait.is_finished(), "must not resolve on a nested path");
 
-		origin.publish_broadcast_spawn("foo", exact.consume());
+		origin.publish_broadcast_spawn("foo", &exact);
 		let result = wait.await.unwrap().expect("should find foo exactly");
 		assert!(result.is_clone(&exact.consume()));
 	}
@@ -2934,7 +3093,7 @@ mod tests {
 		let mut announced = origin.consume().announced();
 
 		let broadcast = broadcast::Info::new().produce();
-		origin.publish_broadcast_spawn("test", broadcast.consume());
+		origin.publish_broadcast_spawn("test", &broadcast);
 		drop(broadcast);
 
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
@@ -2954,10 +3113,10 @@ mod tests {
 		let broadcast1 = broadcast::Info::new().produce();
 		let broadcast2 = broadcast::Info::new().produce();
 
-		origin.publish_broadcast_spawn("test", broadcast1.consume());
+		origin.publish_broadcast_spawn("test", &broadcast1);
 		drop(broadcast1);
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
-		origin.publish_broadcast_spawn("test", broadcast2.consume());
+		origin.publish_broadcast_spawn("test", &broadcast2);
 
 		announced.assert_next("test", &broadcast2.consume());
 		announced.assert_next_wait();
@@ -2971,7 +3130,7 @@ mod tests {
 
 		let origin = Origin::random().produce();
 		let broadcast1 = broadcast::Info::new().produce();
-		origin.publish_broadcast_spawn("test", broadcast1.consume());
+		origin.publish_broadcast_spawn("test", &broadcast1);
 
 		let mut announced = origin.consume().announced();
 		announced.assert_next("test", &broadcast1.consume());
@@ -2981,7 +3140,7 @@ mod tests {
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
 
 		let broadcast2 = broadcast::Info::new().produce();
-		origin.publish_broadcast_spawn("test", broadcast2.consume());
+		origin.publish_broadcast_spawn("test", &broadcast2);
 
 		// The cursor must see the unannounce before the new announce.
 		announced.assert_next_none("test");
@@ -2997,7 +3156,7 @@ mod tests {
 
 		let origin = Origin::random().produce();
 		let broadcast1 = broadcast::Info::new().produce();
-		origin.publish_broadcast_spawn("test", broadcast1.consume());
+		origin.publish_broadcast_spawn("test", &broadcast1);
 
 		let mut announced = origin.consume().announced();
 		announced.assert_next("test", &broadcast1.consume());
@@ -3006,7 +3165,7 @@ mod tests {
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
 
 		let broadcast2 = broadcast::Info::new().produce();
-		origin.publish_broadcast_spawn("test", broadcast2.consume());
+		origin.publish_broadcast_spawn("test", &broadcast2);
 		drop(broadcast2);
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
 
@@ -3027,7 +3186,7 @@ mod tests {
 
 		for _ in 0..1000 {
 			let broadcast = broadcast::Info::new().produce();
-			origin.publish_broadcast_spawn("test", broadcast.consume());
+			origin.publish_broadcast_spawn("test", &broadcast);
 			drop(broadcast);
 		}
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
@@ -3056,8 +3215,8 @@ mod tests {
 		let broadcast1 = broadcast::Info::new().produce();
 		let broadcast2 = broadcast::Info::new().produce();
 
-		origin.publish_broadcast_spawn("test1", broadcast1.consume());
-		origin.publish_broadcast_spawn("test2", broadcast2.consume());
+		origin.publish_broadcast_spawn("test1", &broadcast1);
+		origin.publish_broadcast_spawn("test2", &broadcast2);
 
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -1330,6 +1330,9 @@ impl GroupPublisher {
 		};
 		tracing::debug!(advertised = %advertised, "stats: publishing broadcast");
 
+		// The stats broadcast is always live once published.
+		broadcast.set_live(true);
+
 		Some(Self {
 			_publish: publish,
 			broadcast,

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -577,6 +577,9 @@ impl Cluster {
 				.origin
 				.create_broadcast(&path)
 				.expect(".internal/origins is within the relay origin's root");
+			// Peers discover this node by watching `.internal/origins/*` announcements, so it must
+			// be live, not merely registered.
+			broadcast.set_live(true);
 			tracing::info!(%node, %path, "advertising cluster node URL");
 
 			if has_outbound {

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -143,6 +143,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	// ── publisher ───────────────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("create track");
 	let mut group = track.append_group().expect("append group");
 	group
@@ -247,6 +248,7 @@ async fn relay_websocket_root_path_upgrades() {
 	// ── publisher ───────────────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("create track");
 	let mut group = track.append_group().expect("append group");
 	group
@@ -311,6 +313,7 @@ async fn two_publish_only_clients_coexist() {
 	// ── two publish-only publishers, each serving a distinct broadcast ──
 	let pub_a = Origin::random().produce();
 	let mut broadcast_a = pub_a.create_broadcast("alpha").expect("create broadcast a");
+	broadcast_a.set_live(true);
 	let mut track_a = broadcast_a.create_track("video", None).expect("create track a");
 	track_a
 		.append_group()
@@ -320,6 +323,7 @@ async fn two_publish_only_clients_coexist() {
 
 	let pub_b = Origin::random().produce();
 	let mut broadcast_b = pub_b.create_broadcast("beta").expect("create broadcast b");
+	broadcast_b.set_live(true);
 	let mut track_b = broadcast_b.create_track("video", None).expect("create track b");
 	track_b
 		.append_group()
@@ -451,6 +455,7 @@ async fn internal_tcp_round_trip() {
 	// ── publisher ───────────────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("create track");
 	let mut group = track.append_group().expect("append group");
 	group
@@ -561,6 +566,7 @@ async fn internal_unix_round_trip() {
 	// ── publisher ───────────────────────────────────────────────────
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
+	broadcast.set_live(true);
 	let mut track = broadcast.create_track("video", None).expect("create track");
 	let mut group = track.append_group().expect("append group");
 	group
@@ -646,6 +652,7 @@ fn path_versions() -> Vec<moq_net::Version> {
 async fn path_round_trip(version: moq_net::Version, pub_url: url::Url, sub_url: url::Url, broadcast: &str) -> String {
 	let pub_origin = Origin::random().produce();
 	let mut bc = pub_origin.create_broadcast(broadcast).expect("create broadcast");
+	bc.set_live(true);
 	let mut track = bc.create_track("video", None).expect("create track");
 	let mut group = track.append_group().expect("append group");
 	group

--- a/rs/moq-rtc/src/server/whip.rs
+++ b/rs/moq-rtc/src/server/whip.rs
@@ -99,6 +99,7 @@ pub async fn accept(
 	// fast subscriber doesn't see a 404 in the gap between the SDP answer
 	// and the first RTP packet.
 	let producer = moq_net::broadcast::Info::new().produce();
+	producer.set_live(true);
 	let consumer = producer.consume();
 	let publish = publisher
 		.publish_broadcast(broadcast, &consumer)

--- a/rs/moq-rtmp/src/dial.rs
+++ b/rs/moq-rtmp/src/dial.rs
@@ -449,6 +449,8 @@ impl Publisher {
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 		let mut importer = FlvImport::new(broadcast.clone(), catalog.reserve());
 
+		// Live for as long as it is published; the catalog reservation gate covers completeness.
+		broadcast.set_live(true);
 		let publish = origin
 			.publish_broadcast(path, broadcast.consume())
 			.map_err(|err| anyhow::anyhow!("broadcast '{path}' could not be published: {err}"))?;
@@ -512,6 +514,7 @@ mod tests {
 		let mut broadcast = broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 		let mut importer = FlvImport::new(broadcast.clone(), catalog.reserve());
+		broadcast.set_live(true);
 		let _publish = server_origin
 			.publish_broadcast("live/cam0", broadcast.consume())
 			.unwrap();

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -1175,6 +1175,8 @@ impl Publisher {
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 		let mut importer = FlvImport::new(broadcast.clone(), catalog.reserve());
 
+		// Live for as long as it is published; the catalog reservation gate covers completeness.
+		broadcast.set_live(true);
 		let publish = origin.publish_broadcast(path, broadcast.consume())?;
 
 		// Feed the FLV file header once up front; media tags follow per message.
@@ -1519,6 +1521,7 @@ mod tests {
 		let mut broadcast = broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 		let mut importer = FlvImport::new(broadcast.clone(), catalog.reserve());
+		broadcast.set_live(true);
 		let _publish = origin.publish_broadcast("live/cam0", broadcast.consume()).unwrap();
 		importer.decode(&flv::file_header()).unwrap();
 		importer.decode(&flv::tag(flv::TAG_VIDEO, 0, &vseq)).unwrap();
@@ -1567,6 +1570,7 @@ mod tests {
 		let mut broadcast = broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 		let mut importer = FlvImport::new(broadcast.clone(), catalog.reserve());
+		broadcast.set_live(true);
 		let _publish = origin.publish_broadcast("live/cam0", broadcast.consume()).unwrap();
 		importer.decode(&flv::file_header()).unwrap();
 
@@ -1689,6 +1693,7 @@ mod tests {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 		let mut importer = FlvImport::new(broadcast.clone(), catalog.reserve());
+		broadcast.set_live(true);
 		let _publish = origin.publish_broadcast("live/cam0", broadcast.consume()).unwrap();
 		importer.decode(&flv::file_header()).unwrap();
 		importer.decode(&flv::tag(flv::TAG_VIDEO, 0, &seq)).unwrap();

--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -37,6 +37,9 @@ impl Publisher {
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
 		let importer = ts::Import::new(broadcast.clone(), catalog.reserve());
 
+		// An ingest broadcast is live for as long as it is published (the catalog reservation
+		// gate keeps subscribers from seeing an incomplete catalog).
+		broadcast.set_live(true);
 		let publish = origin.publish_broadcast(path, broadcast.consume())?;
 		tracing::info!(%path, "publishing ingest broadcast");
 

--- a/rs/moq-transcode/examples/transcode.rs
+++ b/rs/moq-transcode/examples/transcode.rs
@@ -65,6 +65,7 @@ async fn main() -> anyhow::Result<()> {
 	config.source = Some(moq_net::PathRelativeOwned::from("..".to_string()));
 
 	let output = moq_net::broadcast::Info::default().produce();
+	output.set_live(true);
 	let _announce = publish
 		.publish_broadcast(&output_path, &output)
 		.context("failed to publish the derivative broadcast")?;

--- a/swift/Sources/Moq/Broadcast.swift
+++ b/swift/Sources/Moq/Broadcast.swift
@@ -89,6 +89,13 @@ public final class BroadcastProducer: Sendable {
         BroadcastConsumer(try ffi.consume())
     }
 
+    /// Set whether the broadcast is live, i.e. whether origins advertise it. A broadcast starts
+    /// offline; ``OriginProducer/announce(_:broadcast:)`` marks it live. Pass `false` to stop
+    /// advertising it while keeping it fetchable, or `true` to advertise it again.
+    public func setLive(_ live: Bool) throws {
+        try ffi.setLive(live: live)
+    }
+
     /// Accept subscriptions to tracks that are not published yet. Hold and iterate
     /// the returned `BroadcastDynamic` while such requests should be served.
     public func dynamic() throws -> BroadcastDynamic {


### PR DESCRIPTION
## What

Separate a broadcast's **existence** (registered in the origin tree, reachable by a FETCH) from its **liveness** (advertised to `announced()` subscribers), and drive announcement off a new per-broadcast liveness flag.

Publishing now registers a broadcast **offline**: `publish_broadcast` / `create_broadcast` make it FETCH-routable but do not announce it. A producer calls `set_live(true)` to advertise it and `set_live(false)` to stop advertising while it stays routable.

## Why

Today the only way to reach a broadcast is via an announcement, so "exists" and "advertised" are the same thing. We want to route FETCH requests to **offline** broadcasts eventually, which means announcements should signal *liveness*, not *existence*. This PR makes that split: existence lives in the origin tree (what `request_broadcast` / a FETCH resolves against), and the announce stream is gated on the liveness flag. It also removes the accidental "announce before the catalog exists" race for callers that populate then go live.

## How

- `broadcast::{Producer,Dynamic}::set_live(bool)` / `is_live()` and `Consumer::is_live()` back a liveness flag on the broadcast.
- The origin registers existence synchronously on publish, then a small per-broadcast reconciler watches the flag: it announces a live active route and unannounces one that goes offline or closes. Existence stays in the tree throughout; a promoted backup announces only if it is live.
- Route selection among broadcasts at the same path (active vs backup, hop/cost ordering) is unchanged.

## API impact

Additive everywhere; nothing renamed or removed:

| Layer | New |
|---|---|
| `rs/moq-net` | `broadcast::{Producer,Dynamic}::{set_live,is_live}`; on `broadcast::Consumer` `is_live` + the async observer `live_changed` / `poll_live` |
| `rs/moq-ffi` | `MoqBroadcastProducer::set_live` |
| `rs/libmoq` | `moq_publish_set_live` (new `moq.h` symbol) |
| py / swift / go / js | `set_live` / `setLive` / `SetLive` / `Broadcast.live` + `setLive` |

**Breaking (behavioral, not signature):** in rust and js, publishing no longer announces on its own — callers must `set_live(true)`. Hence this targets **`dev`**. The FFI-based bindings keep behavior: their `announce` verb marks the broadcast live internally, so `announce` still means "discoverable now" (additive only there).

**No wire change / no IETF draft update:** announce already *is* the wire liveness signal. `cpp/obs` unaffected (the C ABI change is a new function).

**Consumer observer:** `broadcast::Consumer` exposes an async `live_changed(last) -> Option<bool>` / `poll_live` (mirroring `closed`/`poll_closed`; `None` on close), so a rust consumer can react to a broadcast going offline — parity with the js `Consumer.live` signal. The origin's own unannounce reconciler drives off this same observer.

## Interim API note

`set_live` is a standalone flag for now. Once #2241 lands the mutable `broadcast::Route { hops, cost }`, `live` should fold in as a third field (`Route { hops, cost, live }`) reconciled through the same route observer, dropping this PR's separate liveness channel and `reconcile_publish` reconciler. `live` is a genuine third axis, not `cost = ∞`: cost orders *announced* routes, `live=false` means *don't announce but stay FETCH-routable*.

## Tests

- `moq-net`: new `test_liveness_gates_announcement` (offline = registered-but-not-announced and still FETCH-routable; toggling live drives announce/unannounce; unpublish removes it). Existing origin/announce suite updated for offline-by-default.
- Verified green: `moq-net`, `moq-native`, `moq-rtmp`, `moq-relay`, `moq-srt`, `moq-hls`, and `@moq/net` (js, incl. a wire-level regression).
- `cargo doc -D warnings` (public items, CI-equivalent) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
