### PR TITLE
chore(moq-mux): bump mp4-atom to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4407,9 +4407,9 @@ dependencies = [
 
 [[package]]
 name = "mp4-atom"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b236fe2c6bcc08233d9de2ea9b850b07c5843c2f81dd68a5945c7961e7eea9"
+checksum = "3144b10c48a9707a4e8526a0371eebf4a46e2cb703748b0d83bbdc77421bc16f"
 dependencies = [
  "bytes",
  "derive_more 2.1.1",

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -28,7 +28,7 @@ moq-json = { workspace = true }
 moq-loc = { workspace = true }
 moq-msf = { workspace = true }
 moq-net = { workspace = true, features = ["serde"] }
-mp4-atom = { version = "0.12", features = ["tokio", "bytes", "serde"] }
+mp4-atom = { version = "0.14", features = ["tokio", "bytes", "serde"] }
 mpeg2ts = "0.6.0"
 num_enum = "0.7"
 scuffle-av1 = { version = "0.1.4" }


### PR DESCRIPTION
## Summary

- Bump `mp4-atom` from 0.12.1 to 0.14.0 for `moq-mux`.
- Preserve the existing Tokio, bytes, and serde feature set.
- No source changes were required for compatibility.

## Public API changes

- `moq_mux::mp4_atom` and the `mp4_atom::Trak` types used by `container::fmp4::Wire` move from `mp4-atom` 0.12 to 0.14. Downstream callers using those types must update to the matching dependency version.

## Test plan

- `cargo test -p moq-mux` (359 passed)
- `nix develop --command just fix`
- `nix develop --command just check`
- GitHub `Check` workflow

(Written by GPT-5)
