### PR TITLE
fix(json): accept tracks across package instances

### DIFF
--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.2.15",
+	"version": "0.2.16",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/json/package.json
+++ b/js/json/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/json",
 	"type": "module",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "JSON publishing over MoQ tracks: snapshot/delta (RFC 7396 merge patch) objects, or append-log NDJSON streams.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/json/src/snapshot/producer.test.ts
+++ b/js/json/src/snapshot/producer.test.ts
@@ -31,6 +31,24 @@ test("a track-less producer seeds subscribers and fans out edits", async () => {
 	effect.close();
 });
 
+test("a producer serves tracks from another compatible package instance", async () => {
+	const source = new Producer<{ ready: boolean }>({ initial: { ready: true } });
+	const track = new Track("catalog.json");
+	// Separate package instances have distinct constructors but the same public track surface.
+	const foreignTrack = {
+		appendGroup: track.appendGroup.bind(track),
+		close: track.close.bind(track),
+	} as unknown as Track;
+	const effect = new Effect();
+
+	expect(foreignTrack).not.toBeInstanceOf(Track);
+	source.serve(foreignTrack, effect);
+	expect(track.state.groups.peek()).toHaveLength(1);
+	expect(await new Consumer<{ ready: boolean }>(track).next()).toEqual({ ready: true });
+
+	effect.close();
+});
+
 test("a reconnecting subscriber is seeded with the full current value", async () => {
 	const source = new Producer<Record<string, unknown>>({ initial: {} });
 	source.mutate((v) => {

--- a/js/json/src/snapshot/producer.ts
+++ b/js/json/src/snapshot/producer.ts
@@ -1,5 +1,5 @@
 import { Encoder } from "@moq/flate";
-import * as Moq from "@moq/net";
+import type * as Moq from "@moq/net";
 import type { Effect } from "@moq/signals";
 import type * as z from "zod/mini";
 
@@ -42,6 +42,18 @@ export interface Config<T> {
 	compression?: boolean;
 }
 
+function isTrack(value: unknown): value is Moq.Track {
+	// Package graphs may contain multiple compatible @moq/net instances, so Track identity is structural.
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"appendGroup" in value &&
+		typeof value.appendGroup === "function" &&
+		"close" in value &&
+		typeof value.close === "function"
+	);
+}
+
 /**
  * Publishes a JSON value as snapshots and deltas, chosen automatically.
  *
@@ -82,7 +94,7 @@ export class Producer<T> {
 	/** Create a producer that writes directly to `track`. */
 	constructor(track: Moq.Track, config?: Config<T>);
 	constructor(trackOrConfig?: Moq.Track | Config<T>, config: Config<T> = {}) {
-		if (trackOrConfig instanceof Moq.Track) {
+		if (isTrack(trackOrConfig)) {
 			this.#track = trackOrConfig;
 			this.#config = config;
 		} else {

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"jsr": false,
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",


### PR DESCRIPTION
## Summary

- Treat compatible `@moq/net` tracks structurally instead of relying on constructor identity.
- Add a regression test covering a track created by a separate package instance.
- Bump JSON, Hang, and Publish so jsDelivr selects the fixed dependency chain.

## Root cause

jsDelivr loaded `@moq/publish` and `@moq/json` with different compatible `@moq/net` versions. The snapshot producer used `track instanceof Moq.Track` to distinguish its overloaded constructor forms, so a valid track from the other package instance was mistaken for configuration. The catalog producer then entered fanout mode and wrote no frames.

## Public API changes

None. Both existing snapshot producer constructor forms remain supported.

## Test plan

- `just js check`
- `just js test`
- `just js build`

(Written by GPT-5)
