### PR TITLE
refactor(json): configure producer track in options

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
       "version": "0.1.1",
       "dependencies": {
         "@moq/hang": "workspace:^",
+        "@moq/json": "workspace:^",
         "@moq/publish": "workspace:^",
         "@moq/watch": "workspace:^",
       },
@@ -93,7 +94,7 @@
     },
     "js/hang": {
       "name": "@moq/hang",
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dependencies": {
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
         "@libav.js/variant-opus-af": "^6.9.8",
@@ -115,7 +116,7 @@
     },
     "js/json": {
       "name": "@moq/json",
-      "version": "0.2.0",
+      "version": "0.2.2",
       "dependencies": {
         "@moq/flate": "workspace:^",
         "@moq/net": "workspace:^",
@@ -144,7 +145,7 @@
     },
     "js/moq-boy": {
       "name": "@moq/boy",
-      "version": "0.2.13",
+      "version": "0.2.14",
       "dependencies": {
         "@moq/json": "workspace:^",
         "@moq/net": "workspace:^",
@@ -196,10 +197,9 @@
     },
     "js/publish": {
       "name": "@moq/publish",
-      "version": "0.3.1",
+      "version": "0.3.3",
       "dependencies": {
         "@moq/hang": "workspace:^",
-        "@moq/json": "workspace:^",
         "@moq/net": "workspace:^",
         "@moq/signals": "workspace:^",
       },
@@ -260,10 +260,9 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@moq/hang": "workspace:^",
-        "@moq/json": "workspace:^",
         "@moq/msf": "workspace:^",
         "@moq/net": "workspace:^",
         "@moq/signals": "workspace:^",

--- a/demo/web/package.json
+++ b/demo/web/package.json
@@ -13,8 +13,9 @@
 	},
 	"dependencies": {
 		"@moq/hang": "workspace:^",
-		"@moq/watch": "workspace:^",
-		"@moq/publish": "workspace:^"
+		"@moq/json": "workspace:^",
+		"@moq/publish": "workspace:^",
+		"@moq/watch": "workspace:^"
 	},
 	"//devDependencies": "These are only needed for local development with workspace packages. They are NOT needed when using the published npm packages.",
 	"devDependencies": {

--- a/demo/web/src/index.ts
+++ b/demo/web/src/index.ts
@@ -17,9 +17,10 @@
  */
 
 import "./highlight";
+import * as Json from "@moq/json";
 import "@moq/watch/element"; // defines <moq-watch>
 import "@moq/watch/ui"; // defines <moq-watch-ui>
-import { Hang, Json, Net, Signals } from "@moq/watch";
+import { Hang, Net, Signals } from "@moq/watch";
 import type MoqWatch from "@moq/watch/element";
 import MoqWatchSupport from "@moq/watch/support/element";
 import { bufferBars, formatBitrate, formatFps, graph, renderRows } from "./viz";

--- a/demo/web/src/publish.ts
+++ b/demo/web/src/publish.ts
@@ -16,9 +16,10 @@
  */
 
 import "./highlight";
+import * as Json from "@moq/json";
 import "@moq/publish/element"; // defines <moq-publish>
 import "@moq/publish/ui"; // defines <moq-publish-ui>
-import { type Audio, Json, type Net, Signals } from "@moq/publish";
+import { type Audio, type Net, Signals } from "@moq/publish";
 import type MoqPublish from "@moq/publish/element";
 import MoqPublishSupport from "@moq/publish/support/element";
 import { formatBitrate, formatFps, graph } from "./viz";

--- a/doc/concept/layer/hang.md
+++ b/doc/concept/layer/hang.md
@@ -98,7 +98,7 @@ This keeps application-specific sections in the application layer while the base
 
 A custom catalog section can carry its payload inline (for low-rate metadata), or it can reference a separate track in the same broadcast (for a stream of data, e.g. a `meta.json` track or an SCTE-35 event track). The relay treats such a track like any other; only the publisher and consumer give it meaning.
 
-The `@moq/publish` and `@moq/watch` components publish and subscribe to these tracks generically, with no per-application support. Each exposes a low-level track hook and re-exports `@moq/json` so the application encodes the payload itself:
+The `@moq/publish` and `@moq/watch` components publish and subscribe to these tracks generically, with no per-application support. Each exposes a low-level track hook, and the application uses `@moq/json` to encode the payload itself:
 
 - **Publish**: `broadcast.publishTrack(name, serve)` runs `serve(track, effect)` per subscriber. For JSON, serve each track from a shared track-less `Json.Snapshot.Producer` (the same fan-out producer the catalog uses, seeding late joiners with the latest value). Advertise the track by writing your own catalog section with `broadcast.catalog.mutate(...)`.
 - **Watch**: `broadcast.subscribeTrack(name, priority, consume)` follows the active broadcast across reconnects. For JSON, wrap the track in a `Json.Snapshot.Consumer` inside `consume`. Read your section back from `broadcast.catalog` (unknown sections pass through the loose schema).

--- a/doc/lib/js/@moq/publish.md
+++ b/doc/lib/js/@moq/publish.md
@@ -135,8 +135,8 @@ broadcast.name.set("bob.hang");
 Beyond audio and video, you can publish arbitrary application tracks within the
 same broadcast (no separate broadcast needed). `publishTrack(name, serve)` runs
 `serve(track, effect)` for each subscriber; it rejects the built-in track names
-(catalog/audio/video). Encode the payload yourself with the re-exported
-`@moq/json`: a track-less `Json.Snapshot.Producer` is the same fan-out producer the catalog
+(catalog/audio/video). Encode the payload yourself with `@moq/json`: a track-less
+`Json.Snapshot.Producer` is the same fan-out producer the catalog
 uses, seeding late joiners with the latest value.
 
 `publishTrack` does not touch the catalog; advertise the track by writing your own
@@ -145,7 +145,7 @@ is a loose object, so any key passes through). This lets an app support somethin
 like an `scte35` section with no hang-specific support:
 
 ```typescript
-import { Json } from "@moq/publish";
+import * as Json from "@moq/json";
 
 const scte35 = new Json.Snapshot.Producer<{ splices: number[] }>({ initial: { splices: [] } });
 broadcast.publishTrack("scte35.json", (track, effect) => scte35.serve(track, effect));

--- a/doc/lib/js/@moq/watch.md
+++ b/doc/lib/js/@moq/watch.md
@@ -219,10 +219,10 @@ catalog section (the [catalog root](/concept/layer/hang#extensions) is a loose
 object, so unknown sections pass through to `broadcast.catalog`).
 `subscribeTrack(name, priority, consume)` follows the active broadcast across
 reconnects and runs `consume(track, effect)` each time it becomes active. Decode
-the payload yourself with the re-exported `@moq/json`:
+the payload yourself with `@moq/json`:
 
 ```typescript
-import { Json } from "@moq/watch";
+import * as Json from "@moq/json";
 import { Signals } from "@moq/watch";
 
 // The app's own catalog section, read back from the loose catalog.

--- a/js/json/package.json
+++ b/js/json/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/json",
 	"type": "module",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "JSON publishing over MoQ tracks: snapshot/delta (RFC 7396 merge patch) objects, or append-log NDJSON streams.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/json/src/snapshot/compression.test.ts
+++ b/js/json/src/snapshot/compression.test.ts
@@ -38,7 +38,7 @@ async function groupCount(track: Track): Promise<number> {
 
 test("compressed snapshot per group round-trips", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { deltaRatio: 0, compression: true });
+	const producer = new Producer<Value>({ track, deltaRatio: 0, compression: true });
 	producer.update({ a: 1 });
 	producer.update({ a: 2 });
 	producer.finish();
@@ -50,7 +50,7 @@ test("compressed snapshot per group round-trips", async () => {
 test("compressed live consumer sees each update in order", async () => {
 	// A live consumer reconstructs each update in order from the shared per-group stream.
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { deltaRatio: 100, compression: true });
+	const producer = new Producer<Value>({ track, deltaRatio: 100, compression: true });
 	const consumer = new Consumer<Value>(track, { compression: true });
 
 	for (let n = 1; n <= 5; n++) {
@@ -61,7 +61,7 @@ test("compressed live consumer sees each update in order", async () => {
 
 test("compressed deltas share one group and reconstruct", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { deltaRatio: 100, compression: true });
+	const producer = new Producer<Value>({ track, deltaRatio: 100, compression: true });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
 	producer.update({ a: 5, b: 2 });
@@ -72,7 +72,7 @@ test("compressed deltas share one group and reconstruct", async () => {
 
 test("compressed late joiner reconstructs from snapshot + deltas", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { deltaRatio: 100, compression: true });
+	const producer = new Producer<Value>({ track, deltaRatio: 100, compression: true });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
 	producer.update({ a: 5, b: 2 });
@@ -86,7 +86,7 @@ test("a group's snapshot decodes from a fresh decoder", async () => {
 	// Frame 0 opens a cold window, so a brand-new decoder reconstructs it, which is what lets a late
 	// joiner (or the Rust consumer) start mid-stream at any group boundary.
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { deltaRatio: 0, compression: true });
+	const producer = new Producer<Value>({ track, deltaRatio: 0, compression: true });
 	producer.update({ hello: "world" });
 	producer.finish();
 
@@ -97,7 +97,7 @@ test("a group's snapshot decodes from a fresh decoder", async () => {
 test("compressed deltas reuse the window", async () => {
 	// The shared per-group window is the point: a delta restating snapshot content shrinks sharply.
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { deltaRatio: 100, compression: true });
+	const producer = new Producer<Value>({ track, deltaRatio: 100, compression: true });
 	const phrase = "Media over QUIC delivers real-time latency at massive scale";
 	producer.update({ note: phrase });
 	producer.update({ note: phrase, echo: phrase });
@@ -117,9 +117,9 @@ test("compression shrinks a repetitive frame", async () => {
 	const value = { renditions: Array(3).fill("video".repeat(50)) };
 
 	const plain = new Track("plain");
-	new Producer<Value>(plain, { deltaRatio: 0 }).update(value);
+	new Producer<Value>({ track: plain, deltaRatio: 0 }).update(value);
 	const compressed = new Track("compressed");
-	new Producer<Value>(compressed, { deltaRatio: 0, compression: true }).update(value);
+	new Producer<Value>({ track: compressed, deltaRatio: 0, compression: true }).update(value);
 
 	const plainLen = (await firstFrame(plain)).length;
 	const compressedLen = (await firstFrame(compressed)).length;
@@ -133,7 +133,7 @@ test("compressed deltas roll on the compressed budget", async () => {
 	// compressed group boundary. Guards against the budget regressing to raw lengths. Two identical
 	// producers (deterministic output) keep the group-count and reconstruction reads independent.
 	const fill = (track: Track) => {
-		const producer = new Producer<Value>(track, { deltaRatio: 2, compression: true });
+		const producer = new Producer<Value>({ track, deltaRatio: 2, compression: true });
 		for (let n = 0; n <= 40; n++) producer.update({ n });
 		producer.finish();
 	};

--- a/js/json/src/snapshot/producer.test.ts
+++ b/js/json/src/snapshot/producer.test.ts
@@ -102,7 +102,7 @@ test("serve() can override compression per subscriber", async () => {
 });
 
 test("serve() throws on a track-bound producer", () => {
-	const producer = new Producer<Record<string, unknown>>(new Track("meta.json"));
+	const producer = new Producer<Record<string, unknown>>({ track: new Track("meta.json") });
 	const effect = new Effect();
 	expect(() => producer.serve(new Track("other"), effect)).toThrow();
 	effect.close();

--- a/js/json/src/snapshot/producer.ts
+++ b/js/json/src/snapshot/producer.ts
@@ -13,6 +13,9 @@ const MAX_DELTA_FRAMES = 256;
 const DEFAULT_DELTA_RATIO = 8;
 
 export interface Config<T> {
+	/** Track to write directly, or unset to retain values for subscribers attached with {@link Producer.serve}. */
+	track?: Moq.Track;
+
 	// Controls how aggressively the producer emits deltas (merge patches) instead of full snapshots.
 	//
 	// `0` disables deltas: every change is published as a new snapshot group.
@@ -42,24 +45,12 @@ export interface Config<T> {
 	compression?: boolean;
 }
 
-function isTrack(value: unknown): value is Moq.Track {
-	// Package graphs may contain multiple compatible @moq/net instances, so Track identity is structural.
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		"appendGroup" in value &&
-		typeof value.appendGroup === "function" &&
-		"close" in value &&
-		typeof value.close === "function"
-	);
-}
-
 /**
  * Publishes a JSON value as snapshots and deltas, chosen automatically.
  *
- * Construct it two ways:
+ * Configure it in one of two modes:
  *
- * - **With a track** (`new Producer(track, config)`): writes directly to that one track.
+ * - **With a track** (`new Producer({ track, ...config })`): writes directly to that one track.
  * - **Without a track** (`new Producer(config)`): retains the value and fans it out to any number of
  *   subscription tracks attached with {@link serve}, seeding late joiners with the current value.
  *   This backs the hang catalog and is how an application publishes its own custom tracks.
@@ -89,16 +80,11 @@ export class Producer<T> {
 	#outputs?: Set<Producer<T>>;
 	#value?: T;
 
-	/** Create a track-less, fan-out producer; attach subscribers with {@link serve}. */
-	constructor(config?: Config<T>);
-	/** Create a producer that writes directly to `track`. */
-	constructor(track: Moq.Track, config?: Config<T>);
-	constructor(trackOrConfig?: Moq.Track | Config<T>, config: Config<T> = {}) {
-		if (isTrack(trackOrConfig)) {
-			this.#track = trackOrConfig;
-			this.#config = config;
-		} else {
-			this.#config = trackOrConfig ?? {};
+	/** Create a direct producer when `config.track` is set, or a fan-out producer otherwise. */
+	constructor(config: Config<T> = {}) {
+		this.#config = config;
+		this.#track = config.track;
+		if (!this.#track) {
 			this.#outputs = new Set();
 			this.#value = this.#config.initial;
 		}
@@ -199,7 +185,7 @@ export class Producer<T> {
 
 		const config =
 			opts?.compression === undefined ? this.#config : { ...this.#config, compression: opts.compression };
-		const output = new Producer<T>(track, config);
+		const output = new Producer<T>({ ...config, track });
 		if (this.#value !== undefined) output.update(this.#value);
 
 		this.#outputs.add(output);

--- a/js/json/src/snapshot/snapshot.test.ts
+++ b/js/json/src/snapshot/snapshot.test.ts
@@ -29,7 +29,7 @@ async function structure(track: Track): Promise<number[]> {
 
 test("deltas off: a snapshot group per change", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { deltaRatio: 0 });
+	const producer = new Producer<Value>({ track, deltaRatio: 0 });
 	producer.update({ a: 1 });
 	producer.update({ a: 2 });
 	producer.finish();
@@ -40,7 +40,7 @@ test("deltas off: a snapshot group per change", async () => {
 
 test("deltaRatio 0 disables deltas, like off", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { deltaRatio: 0 });
+	const producer = new Producer<Value>({ track, deltaRatio: 0 });
 	producer.update({ a: 1 });
 	producer.update({ a: 2 });
 	producer.finish();
@@ -52,7 +52,7 @@ test("deltaRatio 0 disables deltas, like off", async () => {
 
 test("live consumer sees each update", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track);
+	const producer = new Producer<Value>({ track });
 	const consumer = new Consumer<Value>(track);
 
 	for (let n = 1; n <= 3; n++) {
@@ -63,7 +63,7 @@ test("live consumer sees each update", async () => {
 
 test("unchanged value writes nothing", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track);
+	const producer = new Producer<Value>({ track });
 	producer.update({ a: 1 });
 	producer.update({ a: 1 });
 	producer.finish();
@@ -73,7 +73,7 @@ test("unchanged value writes nothing", async () => {
 
 test("deltas share one group", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { deltaRatio: 100 });
+	const producer = new Producer<Value>({ track, deltaRatio: 100 });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
 	producer.update({ a: 1, b: 3 });
@@ -85,7 +85,7 @@ test("deltas share one group", async () => {
 
 test("deltas reconstruct to the final value", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { deltaRatio: 100 });
+	const producer = new Producer<Value>({ track, deltaRatio: 100 });
 	producer.update({ a: 1, b: 1 });
 	producer.update({ a: 1, b: 2 });
 	producer.update({ a: 5, b: 2 });
@@ -99,7 +99,7 @@ test("deltas reconstruct to the final value", async () => {
 // section) without a single owner having to rebuild the whole document.
 test("mutate composes independent owners", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { initial: {} });
+	const producer = new Producer<Value>({ track, initial: {} });
 	const consumer = new Consumer<Value>(track);
 
 	producer.mutate((v) => {
@@ -116,7 +116,7 @@ test("mutate composes independent owners", async () => {
 
 test("mutate starts from the configured initial value", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { initial: {} });
+	const producer = new Producer<Value>({ track, initial: {} });
 	const consumer = new Consumer<Value>(track);
 
 	producer.mutate((v) => {
@@ -126,7 +126,7 @@ test("mutate starts from the configured initial value", async () => {
 });
 
 test("mutate without a prior value or initial throws", () => {
-	const producer = new Producer<Value>(new Track("test"));
+	const producer = new Producer<Value>({ track: new Track("test") });
 	expect(() => producer.mutate(() => {})).toThrow();
 });
 
@@ -134,7 +134,7 @@ test("mutate without a prior value or initial throws", () => {
 // Exercised with deltas on to cover the merge-patch null-deletion path.
 test("mutate removes a section", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { deltaRatio: 100, initial: {} });
+	const producer = new Producer<Value>({ track, deltaRatio: 100, initial: {} });
 	const consumer = new Consumer<Value>(track);
 
 	producer.mutate((v) => {
@@ -154,7 +154,7 @@ test("tight ratio rolls snapshots", async () => {
 	// A ratio of 1 budgets deltas up to one snapshot (equal 7-byte frames => 7 bytes). The gate checks
 	// the deltas already written, so the delta that tips the group over budget still lands (a one-frame
 	// overshoot): group 0 takes two deltas (14 bytes) before the fourth update rolls group 1.
-	const producer = new Producer<Value>(track, { deltaRatio: 1 });
+	const producer = new Producer<Value>({ track, deltaRatio: 1 });
 	producer.update({ a: 1 }); // snapshot, group 0
 	producer.update({ a: 2 }); // delta, group 0 (deltas = 7)
 	producer.update({ a: 3 }); // delta, group 0 (deltas = 14, now over budget)
@@ -171,7 +171,7 @@ test("deltas stay within ratio times snapshot", async () => {
 	// budgets 56 bytes of deltas. The gate checks the deltas already written, so the group keeps filling
 	// until they first exceed 56 (nine deltas = 63 bytes) and the next update rolls (a one-frame
 	// overshoot past the 56-byte budget).
-	const producer = new Producer<Value>(track, { deltaRatio: 8 });
+	const producer = new Producer<Value>({ track, deltaRatio: 8 });
 	for (let n = 0; n <= 10; n++) producer.update({ n });
 	producer.finish();
 
@@ -180,7 +180,7 @@ test("deltas stay within ratio times snapshot", async () => {
 
 test("array change is a wholesale delta", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { deltaRatio: 100 });
+	const producer = new Producer<Value>({ track, deltaRatio: 100 });
 	producer.update({ list: [1, 2] });
 	producer.update({ list: [1, 2, 3] });
 	producer.finish();
@@ -191,7 +191,7 @@ test("array change is a wholesale delta", async () => {
 
 test("late joiner collapses a buffered backlog to the latest value", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { deltaRatio: 100 });
+	const producer = new Producer<Value>({ track, deltaRatio: 100 });
 	for (let n = 0; n <= 20; n++) {
 		producer.update({ n });
 	}
@@ -204,7 +204,7 @@ test("late joiner collapses a buffered backlog to the latest value", async () =>
 
 test("frame cap rolls snapshot", async () => {
 	const track = new Track("test");
-	const producer = new Producer<Value>(track, { deltaRatio: 1_000_000 });
+	const producer = new Producer<Value>({ track, deltaRatio: 1_000_000 });
 	// First update is the snapshot; deltas fill the group until the frame cap forces a roll.
 	for (let i = 0; i <= 256; i++) {
 		producer.update({ n: i });

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/boy",
 	"type": "module",
-	"version": "0.2.13",
+	"version": "0.2.14",
 	"jsr": false,
 	"description": "MoQ Boy - Crowd-controlled Game Boy streaming via MoQ",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/moq-boy/src/game.ts
+++ b/js/moq-boy/src/game.ts
@@ -280,7 +280,7 @@ export class Game {
 				if (!req) break;
 
 				if (req.track.name === "command") {
-					const producer = new Json.Snapshot.Producer<Record<string, unknown>>(req.track);
+					const producer = new Json.Snapshot.Producer<Record<string, unknown>>({ track: req.track });
 					effect.cleanup(() => producer.finish());
 					effect.run(this.#runCommandTrack.bind(this, req.track, producer));
 				}

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"jsr": false,
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
@@ -26,7 +26,6 @@
 	},
 	"dependencies": {
 		"@moq/hang": "workspace:^",
-		"@moq/json": "workspace:^",
 		"@moq/net": "workspace:^",
 		"@moq/signals": "workspace:^"
 	},

--- a/js/publish/src/index.ts
+++ b/js/publish/src/index.ts
@@ -1,6 +1,5 @@
 export * as Hang from "@moq/hang";
 export { Producer as CatalogProducer } from "@moq/hang/catalog";
-export * as Json from "@moq/json";
 export * as Net from "@moq/net";
 /** @deprecated Use `Net` instead. */
 export * as Lite from "@moq/net";

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",
@@ -26,7 +26,6 @@
 	},
 	"dependencies": {
 		"@moq/hang": "workspace:^",
-		"@moq/json": "workspace:^",
 		"@moq/net": "workspace:^",
 		"@moq/msf": "workspace:^",
 		"@moq/signals": "workspace:^"

--- a/js/watch/src/index.ts
+++ b/js/watch/src/index.ts
@@ -1,5 +1,4 @@
 export * as Hang from "@moq/hang";
-export * as Json from "@moq/json";
 export * as Net from "@moq/net";
 /** @deprecated Use `Net` instead. */
 export * as Lite from "@moq/net";


### PR DESCRIPTION
## Summary

- Replace the overloaded snapshot producer constructor with one `Config` options object.
- Select direct mode with `new Producer({ track, ...config })`; omitting `track` retains fanout mode.
- Remove runtime argument discrimination and migrate all repository call sites.
- Remove the recently introduced `Json` re-exports from Publish and Watch.
- Migrate the demo and documentation to import `@moq/json` directly.

## Public API changes

`Json.Snapshot.Producer` no longer accepts a positional track:

```ts
// Before
new Json.Snapshot.Producer(track, { compression: true });

// After
new Json.Snapshot.Producer({ track, compression: true });
```

Fanout construction remains `new Json.Snapshot.Producer(config)`.

The recently introduced `Json` namespaces are removed from `@moq/publish` and `@moq/watch`; applications import `@moq/json` directly instead.

These recent API mistakes are corrected with patch releases: `@moq/json` 0.2.2, `@moq/publish` 0.3.3, `@moq/watch` 0.3.2, and `@moq/boy` 0.2.14.

## Test plan

- `just js fix`
- `just js check`
- `just js test`
- `just js build`

(Written by GPT-5)
