### PR TITLE
fix(moq-hls): release retired renditions instead of force-closing them

### DIFF
--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -291,14 +291,12 @@ mod tests {
 		registration.set(config);
 		drop(reserved);
 
-		// Two closed GOPs, then finish cleanly so the timeline ends and group 1 becomes the
-		// final segment.
+		// Two GOPs: group 0 is complete, while group 1 stays at the live edge until the
+		// publisher finishes.
 		let track = broadcast.create_track("video0", None).unwrap();
 		let mut media = catalog.media_producer(track, moq_mux::catalog::hang::Container::Legacy);
 		media.write(frame(0, true)).unwrap();
 		media.write(frame(2_000_000, true)).unwrap();
-		media.finish().unwrap();
-		catalog.finish().unwrap();
 
 		let source = moq_mux::Source::new(origin.consume(), "live");
 		let broadcaster = Broadcaster::new(source, Config::default()).await.unwrap();
@@ -310,6 +308,11 @@ mod tests {
 
 		// The recorder drops the broadcaster before finalizing its uploads.
 		drop(broadcaster);
+
+		// Finish the source after teardown, forcing the broadcaster's drop to land before the
+		// rendition watcher's clean-end path.
+		media.finish().unwrap();
+		catalog.finish().unwrap();
 
 		let mut groups = Vec::new();
 		while let Some(segment) = tokio::time::timeout(Duration::from_secs(5), segments.next())

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -155,7 +155,7 @@ impl Drop for Broadcaster {
 		// The rendition map lives in shared state, so unlike an owned map it does NOT free its
 		// renditions when this handle goes away: a surviving `renditions::Consumer` would pin
 		// every `Rendition`, and with it the timeline watcher and source subscription it holds.
-		// Drop them here so teardown can't leak a standing subscription.
+		// Release them here so teardown can't leak a standing subscription.
 		self.renditions.clear();
 	}
 }
@@ -273,6 +273,60 @@ mod tests {
 		drop((media, registration, broadcast));
 	}
 
+	// Dropping the broadcaster must not truncate a recording in progress. A cursor holds its
+	// rendition alive, so the rendition's own watcher still ends the timeline with `end()` --
+	// which is what promotes the live-edge record into the final segment. Force-closing the
+	// rendition here instead would race that (`end()` no-ops on a closed channel) and silently
+	// drop the last segment of every recording.
+	#[tokio::test]
+	async fn dropping_the_broadcaster_keeps_a_cursor_drainable() {
+		let origin = moq_net::Origin::random().produce();
+		let mut broadcast = origin.create_broadcast("live").expect("publish allowed");
+		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+
+		let reserved = catalog.reserve();
+		let mut registration = reserved.video("video0");
+		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		config.framerate = Some(30.0);
+		registration.set(config);
+		drop(reserved);
+
+		// Two closed GOPs, then finish cleanly so the timeline ends and group 1 becomes the
+		// final segment.
+		let track = broadcast.create_track("video0", None).unwrap();
+		let mut media = catalog.media_producer(track, moq_mux::catalog::hang::Container::Legacy);
+		media.write(frame(0, true)).unwrap();
+		media.write(frame(2_000_000, true)).unwrap();
+		media.finish().unwrap();
+		catalog.finish().unwrap();
+
+		let source = moq_mux::Source::new(origin.consume(), "live");
+		let broadcaster = Broadcaster::new(source, Config::default()).await.unwrap();
+		let _ = tokio::time::timeout(Duration::from_secs(5), broadcaster.ready()).await;
+		let rendition = broadcaster
+			.rendition(Kind::Video, "video0")
+			.expect("rendition discovered");
+		let mut segments = rendition.segments();
+
+		// The recorder drops the broadcaster before finalizing its uploads.
+		drop(broadcaster);
+
+		let mut groups = Vec::new();
+		while let Some(segment) = tokio::time::timeout(Duration::from_secs(5), segments.next())
+			.await
+			.expect("the cursor drains without parking")
+			.unwrap()
+		{
+			groups.push(segment.group);
+		}
+		assert!(
+			groups.contains(&1),
+			"the final segment survives dropping the broadcaster, got {groups:?}"
+		);
+
+		drop((catalog, media, registration, broadcast, rendition));
+	}
+
 	// A rendition the catalog drops must end its segment cursors. The cursor holds an
 	// `Arc<Rendition>`, so without an explicit close the rendition (and its timeline
 	// subscription) would stay alive and the cursor would park at the live edge forever.
@@ -347,6 +401,13 @@ mod tests {
 			matches!(next, Some(renditions::Event::Removed { .. })),
 			"dropping the broadcaster releases its renditions to a live cursor"
 		);
+
+		// ...and the cursor then reaches a terminal state rather than parking. Releasing the
+		// renditions is only safe if consumers actually finish.
+		let ended = tokio::time::timeout(Duration::from_secs(5), renditions.next())
+			.await
+			.expect("the cursor terminates after the broadcaster drops");
+		assert!(ended.is_none(), "the cursor ends once the broadcaster is gone");
 
 		drop((catalog, media, registration, broadcast));
 	}

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -177,10 +177,9 @@ impl Rendition {
 	/// drains what's left and then ends, and stop the timeline watcher (releasing its standing
 	/// source subscription).
 	///
-	/// Called when the catalog drops or replaces the rendition, and when the owning
-	/// `Broadcaster` goes away. Dropping alone isn't enough: a cursor holds an `Arc<Self>`, so
-	/// it would keep this rendition -- and its subscription -- alive while parking forever on a
-	/// timeline that never ends.
+	/// Called when the catalog drops or replaces the rendition. The media track may continue
+	/// through a replacement, so the old watcher has no clean end to await; a cursor's
+	/// `Arc<Self>` would otherwise keep it subscribed and parked forever.
 	pub(crate) fn close(&self) {
 		self.live.close();
 		self.watcher.abort();

--- a/rs/moq-hls/src/export/renditions.rs
+++ b/rs/moq-hls/src/export/renditions.rs
@@ -70,23 +70,33 @@ impl Producer {
 		self.state.read().is_empty()
 	}
 
-	/// Retire every rendition, ending their segment cursors and releasing the source
-	/// subscriptions their timeline watchers hold.
+	/// Release every rendition the map is holding.
 	///
-	/// The map lives in shared state, so a surviving [`Consumer`] (or the `Arc<Rendition>`s it
-	/// was handed) would otherwise keep every rendition -- and its standing timeline
-	/// subscription -- alive after the owning `Broadcaster` is gone. `Broadcaster::drop` calls
-	/// this so teardown doesn't depend on consumers dropping first.
+	/// The map lives in shared state, so a surviving [`Consumer`] would otherwise keep every
+	/// rendition -- and the standing timeline subscription each watcher holds -- alive after the
+	/// owning `Broadcaster` is gone. `Broadcaster::drop` calls this so teardown doesn't depend on
+	/// consumers dropping first: a rendition nobody else holds drops here, and its `Drop` aborts
+	/// its watcher.
+	///
+	/// Deliberately drops rather than [`Rendition::close`]s. A rendition a cursor still holds is
+	/// left to finish on its own, because its watcher ends a cleanly-finished timeline with
+	/// `end()` *then* `close()`, and `end()` is what promotes the live-edge record into the final
+	/// segment. Force-closing here would race that: `end()` is a no-op on an already-closed
+	/// channel, so the last segment of a recording would be silently dropped.
 	pub fn clear(&self) {
 		if let Ok(mut current) = self.state.write() {
-			for rendition in current.values() {
-				rendition.close();
-			}
 			current.clear();
 		}
 	}
 
 	/// Close the channel, signalling consumers that no more renditions will appear.
+	///
+	/// Deliberately does NOT cascade into the renditions' own segment channels, for two reasons.
+	/// On a clean end it's unnecessary and harmful: each rendition's watcher already ends its
+	/// timeline with `end()` then `close()`, and cascading a bare `close()` here would race that
+	/// and lose the final segment (see [`Self::clear`]). On a catalog-stream *error* the media
+	/// tracks are usually still fine, so cutting every in-flight segment cursor would truncate a
+	/// recording over a transient fault.
 	pub fn close(&self) {
 		let _ = self.state.close();
 	}

--- a/rs/moq-hls/src/export/segments.rs
+++ b/rs/moq-hls/src/export/segments.rs
@@ -509,6 +509,37 @@ mod tests {
 		assert_eq!(live.segment_groups(2), None, "the skipped record is not a boundary");
 	}
 
+	// `end()` is what promotes the live-edge record into the final segment, and it is a no-op
+	// once the channel is closed. So anything retiring a rendition must NOT force-close a
+	// timeline that is about to end on its own, or that last segment is silently lost -- which
+	// is why `renditions::Producer::clear` drops its renditions rather than closing them.
+	#[test]
+	fn closing_before_end_loses_the_final_segment() {
+		let window = Duration::from_secs(30);
+
+		// The watcher's own order: end() then close() -- the live edge finalizes.
+		let clean = Producer::new();
+		clean.push(entry(0, 0), window);
+		clean.push(entry(1, 2_000), window);
+		clean.end();
+		clean.close();
+		assert!(
+			matches!(clean.state.read().next_after(Some(0)), Next::Ready { .. }),
+			"end() before close() finalizes the live edge"
+		);
+
+		// Reversed: a close() that races ahead of end() strands it forever.
+		let raced = Producer::new();
+		raced.push(entry(0, 0), window);
+		raced.push(entry(1, 2_000), window);
+		raced.close();
+		raced.end();
+		assert!(
+			matches!(raced.state.read().next_after(Some(0)), Next::Pending),
+			"end() is a no-op after close(), so the final segment never finalizes"
+		);
+	}
+
 	// The cursor and the serve path must time the final (open-ended) segment identically:
 	// estimated from the observed cadence, not a flat DEFAULT_SEGMENT.
 	#[test]


### PR DESCRIPTION
## Summary

- Release broadcaster-owned rendition references without force-closing their segment timelines. A forced close can win the race with the rendition watcher's clean `end()`, leaving the live edge unfinalized and silently dropping the recording's last segment.
- Keep force-close behavior for renditions removed or replaced by the catalog, where the old live edge is incomplete and its cursor must terminate.
- Make the broadcaster-drop regression deterministic by dropping the broadcaster before finishing the publisher, then assert the retained cursor drains the final segment.
- Update `Rendition::close` documentation to describe its catalog-removal lifecycle.

## Public API changes

None. The changed producer lifecycle is crate-private, and the existing recording API is unchanged.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just ci`
- Confirmed the reordered regression test fails with the old force-close behavior and passes with this fix.

No cross-package synchronization is required because this only changes internal `moq-hls` teardown behavior.

(Written by Opus 4.8 and GPT-5)
