### PR TITLE
fix(publish): align audio inputs to codec frames

### DIFF
--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -20,6 +20,7 @@ const AAC_CODEC = "mp4a.40.2";
 
 // Compiled and inlined as a blob URL via vite-plugin-worklet.
 import CaptureWorklet from "./capture-worklet.ts?worklet";
+import { Framer } from "./framer";
 
 // Selects the audio codec and its encoder settings. Either the bare codec name (all defaults) or an
 // object with the mime plus tuning knobs.
@@ -356,75 +357,76 @@ export class Encoder {
 			// We're using an async polyfill temporarily for Safari support.
 			await Util.Libav.polyfill();
 
-			const encoder = new AudioEncoder({
-				output: (frame) => {
-					if (frame.type !== "key") {
-						throw new Error("only key frames are supported");
-					}
-
-					this.#out.stats.update((stats) => ({
-						frames: stats.frames + 1,
-						bytes: stats.bytes + frame.byteLength,
-					}));
-
-					// Each audio frame is its own group so the relay can forward it without
-					// waiting for a group boundary. Loss is handled by the codec's PLC.
-					track.writeFrame({
-						payload: Container.Legacy.encodeFrame(frame, frame.timestamp as Time.Micro),
-						timestamp: Time.Timestamp.fromMicros(frame.timestamp as Time.Micro),
-					});
-				},
-				error: (err) => {
-					console.error("encoder error", err);
-					track.close(err);
-				},
-			});
-			effect.cleanup(() => encoder.close());
-
-			let config: Catalog.AudioConfig | undefined;
 			effect.run((effect: Effect) => {
-				config = effect.get(this.out.catalog);
+				const config = effect.get(this.out.catalog);
 				if (!config) return;
 
 				const source = effect.get(this.in.source);
 				const kind: Kind = source ? normalizeSource(source).kind : "auto";
 				const encoderConfig = toEncoderConfig(config, kind, this.#opusOptions(effect));
+				const framer = createFramer(config);
+
+				const encoder = new AudioEncoder({
+					output: (frame) => {
+						if (frame.type !== "key") {
+							throw new Error("only key frames are supported");
+						}
+
+						this.#out.stats.update((stats) => ({
+							frames: stats.frames + 1,
+							bytes: stats.bytes + frame.byteLength,
+						}));
+
+						// Each audio frame is its own group so the relay can forward it without
+						// waiting for a group boundary. Loss is handled by the codec's PLC.
+						track.writeFrame({
+							payload: Container.Legacy.encodeFrame(frame, frame.timestamp as Time.Micro),
+							timestamp: Time.Timestamp.fromMicros(frame.timestamp as Time.Micro),
+						});
+					},
+					error: (err) => {
+						console.error("encoder error", err);
+						track.close(err);
+					},
+				});
+				effect.cleanup(() => encoder.close());
 
 				console.debug("encoding audio", encoderConfig);
 				encoder.configure(encoderConfig);
-			});
 
-			effect.event(worklet.port, "message", (event: Event) => {
-				const data = (event as MessageEvent<Capture.AudioFrame>).data;
-				const channelCount = data.channels.length;
-				if (!channelCount) return;
+				effect.event(worklet.port, "message", (event: Event) => {
+					const captured = (event as MessageEvent<Capture.AudioFrame>).data;
+					const channelCount = captured.channels.length;
+					if (!channelCount) return;
 
-				if (!config || channelCount !== config.numberOfChannels) {
-					this.#captured.set({ sampleRate: worklet.context.sampleRate, channelCount });
-					return;
-				}
+					if (channelCount !== config.numberOfChannels) {
+						this.#captured.set({ sampleRate: worklet.context.sampleRate, channelCount });
+						return;
+					}
 
-				const channels = data.channels;
-				const joinedLength = channels.reduce((a, b) => a + b.length, 0);
-				const joined = new Float32Array(joinedLength);
+					for (const data of framer.push(captured)) {
+						const joinedLength = data.channels.reduce((total, channel) => total + channel.length, 0);
+						const joined = new Float32Array(joinedLength);
 
-				channels.reduce((offset: number, channel: Float32Array): number => {
-					joined.set(channel, offset);
-					return offset + channel.length;
-				}, 0);
+						data.channels.reduce((offset: number, channel: Float32Array): number => {
+							joined.set(channel, offset);
+							return offset + channel.length;
+						}, 0);
 
-				const frame = new AudioData({
-					format: "f32-planar",
-					sampleRate: worklet.context.sampleRate,
-					numberOfFrames: channels[0].length,
-					numberOfChannels: channels.length,
-					timestamp: data.timestamp,
-					data: joined,
-					transfer: [joined.buffer],
+						const frame = new AudioData({
+							format: "f32-planar",
+							sampleRate: worklet.context.sampleRate,
+							numberOfFrames: data.channels[0].length,
+							numberOfChannels: data.channels.length,
+							timestamp: data.timestamp,
+							data: joined,
+							transfer: [joined.buffer],
+						});
+
+						encoder.encode(frame);
+						frame.close();
+					}
 				});
-
-				encoder.encode(frame);
-				frame.close();
 			});
 			worklet.port.start();
 		});
@@ -442,6 +444,26 @@ function requestedChannelCount(track: MediaStreamTrack): number | undefined {
 	if (constraint === undefined) return undefined;
 	if (typeof constraint === "number") return constraint;
 	return constraint.exact ?? constraint.ideal ?? constraint.max ?? constraint.min;
+}
+
+function createFramer(config: Catalog.AudioConfig): Framer {
+	// WebCodecs copies input AudioData timestamps to encoded chunks. Align those inputs to codec frames
+	// because the worklet's 128-sample quanta usually do not align with Opus frame boundaries.
+	if (config.codec.startsWith("mp4a")) {
+		return new Framer({
+			sampleRate: config.sampleRate,
+			channels: config.numberOfChannels,
+			size: { samples: AAC_FRAME_SAMPLES },
+		});
+	}
+
+	if (config.codec !== "opus") throw new Error(`unsupported audio codec: ${config.codec}`);
+	const duration = Time.Micro.fromMilli(Time.Milli(config.jitter ?? OPUS_FRAME_DURATION));
+	return new Framer({
+		sampleRate: config.sampleRate,
+		channels: config.numberOfChannels,
+		size: { duration },
+	});
 }
 
 // Resolve the bare codec shorthands to their full config object so callers can read fields uniformly.

--- a/js/publish/src/audio/framer.test.ts
+++ b/js/publish/src/audio/framer.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { Time } from "@moq/net";
+import type { AudioFrame } from "./capture";
+import { Framer } from "./framer";
+
+function quantum(sampleRate: number, index: number, origin = 0 as Time.Micro): AudioFrame {
+	const timestamp = (origin + Time.Micro.fromSecond(((index * 128) / sampleRate) as Time.Second)) as Time.Micro;
+	return {
+		timestamp,
+		channels: [Float32Array.from({ length: 128 }, (_, offset) => index * 128 + offset)],
+	};
+}
+
+function opus(sampleRate: number, duration = 20_000 as Time.Micro): Framer {
+	return new Framer({ sampleRate, channels: 1, size: { duration } });
+}
+
+describe("Opus frame alignment (#2387)", () => {
+	test("collects 16kHz capture quanta into contiguous 20ms frames", () => {
+		const framer = opus(16_000);
+		const frames = Array.from({ length: 5 }, (_, index) => framer.push(quantum(16_000, index))).flat();
+
+		expect(frames.map((frame) => frame.timestamp)).toEqual([Time.Micro(0), Time.Micro(20_000)]);
+		expect(frames.map((frame) => frame.channels[0].length)).toEqual([320, 320]);
+		expect(Array.from(frames[0].channels[0])).toEqual(Array.from({ length: 320 }, (_, index) => index));
+		expect(Array.from(frames[1].channels[0])).toEqual(Array.from({ length: 320 }, (_, index) => index + 320));
+	});
+
+	test("collects 48kHz capture quanta into contiguous 20ms frames", () => {
+		const origin = 123_456 as Time.Micro;
+		const framer = opus(48_000);
+		const frames = Array.from({ length: 15 }, (_, index) => framer.push(quantum(48_000, index, origin))).flat();
+
+		expect(frames.map((frame) => frame.timestamp)).toEqual([origin, Time.Micro(origin + 20_000)]);
+		expect(frames.map((frame) => frame.channels[0].length)).toEqual([960, 960]);
+	});
+
+	test("can emit frames shorter than a capture quantum", () => {
+		const framer = opus(48_000, 2_500 as Time.Micro);
+		const frames = [framer.push(quantum(48_000, 0)), framer.push(quantum(48_000, 1))].flat();
+
+		expect(frames.map((frame) => frame.timestamp)).toEqual([Time.Micro(0), Time.Micro(2_500)]);
+		expect(frames.map((frame) => frame.channels[0].length)).toEqual([120, 120]);
+	});
+
+	test("rounds cumulative boundaries without drifting at fractional sample counts", () => {
+		const framer = opus(44_100, 5_000 as Time.Micro);
+		const frames = Array.from({ length: 4 }, (_, index) => framer.push(quantum(44_100, index))).flat();
+
+		expect(frames.map((frame) => frame.timestamp)).toEqual([Time.Micro(0), Time.Micro(5_000)]);
+		expect(frames.map((frame) => frame.channels[0].length)).toEqual([221, 220]);
+	});
+});
+
+test("collects fixed-size AAC frames", () => {
+	const framer = new Framer({ sampleRate: 48_000, channels: 1, size: { samples: 1024 } });
+	const frames = Array.from({ length: 8 }, (_, index) => framer.push(quantum(48_000, index))).flat();
+
+	expect(frames).toHaveLength(1);
+	expect(frames[0].timestamp).toBe(Time.Micro(0));
+	expect(frames[0].channels[0]).toHaveLength(1024);
+});

--- a/js/publish/src/audio/framer.ts
+++ b/js/publish/src/audio/framer.ts
@@ -1,0 +1,93 @@
+import { Time } from "@moq/net";
+import type { AudioFrame } from "./capture";
+
+type FrameSize = { samples: number } | { duration: Time.Micro };
+
+/** Collects capture quanta into codec-aligned audio frames. */
+export class Framer {
+	readonly #sampleRate: number;
+	readonly #channels: number;
+	readonly #size: FrameSize;
+
+	#origin: Time.Micro | undefined;
+	#frameIndex = 0;
+	#sampleIndex = 0;
+	#buffer: Float32Array[] = [];
+	#written = 0;
+
+	/** Create a framer for either a fixed sample count or a fixed presentation duration. */
+	constructor(props: { sampleRate: number; channels: number; size: FrameSize }) {
+		if (props.sampleRate <= 0) throw new Error("invalid sample rate");
+		if (props.channels <= 0) throw new Error("invalid channel count");
+		if ("samples" in props.size && props.size.samples <= 0) throw new Error("invalid frame samples");
+		if ("duration" in props.size && props.size.duration <= 0) throw new Error("invalid frame duration");
+
+		this.#sampleRate = props.sampleRate;
+		this.#channels = props.channels;
+		this.#size = props.size;
+	}
+
+	/** Append captured samples and return every complete codec frame they form. */
+	push(input: AudioFrame): AudioFrame[] {
+		if (input.channels.length !== this.#channels) throw new Error("wrong number of channels");
+
+		const samples = input.channels[0]?.length ?? 0;
+		for (const channel of input.channels) {
+			if (channel.length !== samples) throw new Error("mismatching number of samples");
+		}
+		if (samples === 0) return [];
+
+		this.#origin ??= input.timestamp;
+
+		const output: AudioFrame[] = [];
+		let offset = 0;
+		while (offset < samples) {
+			if (this.#buffer.length === 0) this.#buffer = this.#createBuffer();
+
+			const remaining = this.#buffer[0].length - this.#written;
+			const copied = Math.min(remaining, samples - offset);
+			for (let channel = 0; channel < this.#channels; channel++) {
+				this.#buffer[channel].set(input.channels[channel].subarray(offset, offset + copied), this.#written);
+			}
+
+			offset += copied;
+			this.#written += copied;
+			if (this.#written !== this.#buffer[0].length) continue;
+
+			output.push({
+				timestamp: this.#timestamp(),
+				channels: this.#buffer,
+			});
+			this.#sampleIndex += this.#buffer[0].length;
+			this.#frameIndex++;
+			this.#buffer = [];
+			this.#written = 0;
+		}
+
+		return output;
+	}
+
+	#createBuffer(): Float32Array[] {
+		const samples = this.#frameSamples();
+		return Array.from({ length: this.#channels }, () => new Float32Array(samples));
+	}
+
+	#frameSamples(): number {
+		if ("samples" in this.#size) return this.#size.samples;
+
+		// Round cumulative boundaries instead of each frame independently. This alternates neighboring
+		// integer sizes when a duration is a fractional number of source samples without accumulating drift.
+		const end = Math.round(((this.#frameIndex + 1) * this.#size.duration * this.#sampleRate) / 1_000_000);
+		return end - this.#sampleIndex;
+	}
+
+	#timestamp(): Time.Micro {
+		if (this.#origin === undefined) throw new Error("missing timestamp origin");
+
+		const offset =
+			"duration" in this.#size
+				? this.#frameIndex * this.#size.duration
+				: Time.Micro.fromSecond((this.#sampleIndex / this.#sampleRate) as Time.Second);
+		return (this.#origin + offset) as Time.Micro;
+	}
+}


### PR DESCRIPTION
Fixes #2387.

## Summary

- Collect the AudioWorklet's 128-sample capture quanta into codec-aligned frames before passing them to WebCodecs.
- Timestamp Opus inputs on the configured frame-duration grid and AAC inputs from their fixed 1024-sample boundaries.
- Recreate the encoder and framer together when the active audio configuration changes.

## Root cause

WebCodecs copies the timestamp of the associated input `AudioData` to each encoded chunk. The publisher previously fed it one 128-sample render quantum at a time, but the default 20 ms Opus frame is 320 samples at 16 kHz and 960 samples at 48 kHz. Those are both half-quantum boundaries, so encoded timestamps alternated around the real 20 ms cadence. Safari preserves those timestamps through decode, and the timestamp-indexed playback ring rendered the error as alternating gaps and overlaps.

Frame-aligning the encoder inputs makes the published timestamps sample-exact without teaching the watcher to hide legitimate packet loss or discontinuities.

## Public API changes

None. The framer is an internal `@moq/publish` implementation detail and is not exported by the package.

No paired package, documentation, draft, or demo update is needed because this changes timestamp values produced by the existing publisher without changing the public API or wire format.

## Test plan

- `nix develop --command just js fix`
- `nix develop --command just js check`
- `nix develop --command just js test`
- `nix develop --command just js build`
- Safari generated-tone WebCodecs smoke test at 16 kHz: encoded and decoded timestamps remained on a contiguous 20 ms grid, with 320 decoded frames per chunk.

(Written by GPT-5)
