### PR TITLE
fix(signals): recognize abort-scoped effects

### DIFF
--- a/js/signals/src/index.test.ts
+++ b/js/signals/src/index.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { Computed, Effect, Signal } from "./index.ts";
+
+const NO_SUBSCRIPTION_WARNING = "Effect did not subscribe to any signals; it will never rerun.";
 
 // Flush pending microtasks. Signal notifications and effect/computed reruns are
 // coalesced onto microtasks, so a chain of A -> B -> effect needs several flushes.
@@ -125,6 +127,65 @@ describe("Effect", () => {
 		effect.close();
 
 		expect(log).toEqual(["run 0", "cleanup 0", "run 1", "cleanup 1"]);
+	});
+
+	test("event-only effects do not warn and remove listeners on close", async () => {
+		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		const target = new EventTarget();
+		let events = 0;
+		const effect = new Effect((e) => e.event(target, "ping", () => events++));
+
+		try {
+			await settle();
+			expect(warn).not.toHaveBeenCalledWith(NO_SUBSCRIPTION_WARNING, expect.anything());
+
+			target.dispatchEvent(new Event("ping"));
+			expect(events).toBe(1);
+
+			effect.close();
+			target.dispatchEvent(new Event("ping"));
+			expect(events).toBe(1);
+		} finally {
+			effect.close();
+			warn.mockRestore();
+		}
+	});
+
+	test("abort-only effects do not warn and abort scoped work on close", async () => {
+		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		const target = new EventTarget();
+		let events = 0;
+		const effect = new Effect((e) => {
+			target.addEventListener("ping", () => events++, { signal: e.abort });
+		});
+
+		try {
+			await settle();
+			expect(warn).not.toHaveBeenCalledWith(NO_SUBSCRIPTION_WARNING, expect.anything());
+
+			target.dispatchEvent(new Event("ping"));
+			expect(events).toBe(1);
+
+			effect.close();
+			target.dispatchEvent(new Event("ping"));
+			expect(events).toBe(1);
+		} finally {
+			effect.close();
+			warn.mockRestore();
+		}
+	});
+
+	test("empty effects still warn", async () => {
+		const warn = spyOn(console, "warn").mockImplementation(() => {});
+		const effect = new Effect(() => {});
+
+		try {
+			await settle();
+			expect(warn).toHaveBeenCalledWith(NO_SUBSCRIPTION_WARNING, expect.anything());
+		} finally {
+			effect.close();
+			warn.mockRestore();
+		}
 	});
 });
 

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -237,6 +237,7 @@ export class Effect {
 	#closed: PromiseWithResolvers<void>;
 
 	#abort: AbortController = new AbortController();
+	#abortUsed = false;
 
 	/** If a function is provided, it runs immediately and reruns whenever a tracked signal changes. */
 	constructor(fn?: (effect: Effect) => void) {
@@ -277,6 +278,7 @@ export class Effect {
 		this.#stopped.resolve();
 		this.#abort.abort();
 		this.#abort = new AbortController();
+		this.#abortUsed = false;
 
 		this.#stopped = Promise.withResolvers();
 
@@ -327,7 +329,8 @@ export class Effect {
 				this.#dispose !== undefined &&
 				this.#unwatch.length === 0 &&
 				this.#dispose.length === 0 &&
-				this.#async.length === 0
+				this.#async.length === 0 &&
+				!this.#abortUsed
 			) {
 				console.warn("Effect did not subscribe to any signals; it will never rerun.", this.#stack);
 			}
@@ -598,10 +601,11 @@ export class Effect {
 		}
 
 		// Merge the abort signal so the listener is auto-removed on rerun/close.
+		const effectSignal = this.abort;
 		const signal =
 			typeof options !== "boolean" && options?.signal
-				? AbortSignal.any([this.#abort.signal, options.signal])
-				: this.#abort.signal;
+				? AbortSignal.any([effectSignal, options.signal])
+				: effectSignal;
 		const merged: AddEventListenerOptions =
 			typeof options === "boolean" ? { capture: options, signal } : { ...options, signal };
 
@@ -657,6 +661,7 @@ export class Effect {
 
 	/** An AbortSignal that fires when the current run is torn down. */
 	get abort(): AbortSignal {
+		this.#abortUsed = true;
 		return this.#abort.signal;
 	}
 


### PR DESCRIPTION
## Summary

- Track whether an effect's per-run `AbortSignal` is used and treat that as scoped work in the DEV warning heuristic.
- Route `effect.event()` through the tracked abort getter so event-only effects no longer emit a false "did not subscribe" warning.
- Add regression coverage for `effect.event()`, direct `effect.abort` usage, listener cleanup, and genuinely empty effects.

The regression was introduced when #1067 moved event listener cleanup from the disposer list to `AbortController`. The warning still inspected only subscriptions, disposers, and spawned promises, so abort-scoped effects appeared empty even though their work was cleaned up correctly.

Closes #2398.

## Public API changes

None. The change only affects the internal DEV warning heuristic.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just js test`
- `nix develop --command just check`

(Written by GPT-5)
