### PR TITLE
fix(audio): advertise the Opus output sample rate

### DIFF
--- a/js/hang/src/util/index.ts
+++ b/js/hang/src/util/index.ts
@@ -1,5 +1,5 @@
 /**
- * Miscellaneous helpers for the hang media layer: AAC config, hex encoding,
+ * Miscellaneous helpers for the hang media layer: audio codec config, hex encoding,
  * and the libav/WebCodecs polyfill.
  *
  * @module
@@ -9,3 +9,4 @@ export * as Aac from "./aac";
 export * as Hacks from "./hacks";
 export * as Hex from "./hex";
 export * as Libav from "./libav";
+export * as Opus from "./opus";

--- a/js/hang/src/util/opus.test.ts
+++ b/js/hang/src/util/opus.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeSampleRate } from "./opus";
+
+describe("normalizeSampleRate", () => {
+	it("defaults to fullband Opus", () => {
+		expect(normalizeSampleRate()).toBe(48_000);
+	});
+
+	it("preserves native Opus rates", () => {
+		for (const sampleRate of [8_000, 12_000, 16_000, 24_000, 48_000]) {
+			expect(normalizeSampleRate(sampleRate)).toBe(sampleRate);
+		}
+	});
+
+	it("rounds up to preserve the input bandwidth", () => {
+		expect(normalizeSampleRate(11_025)).toBe(12_000);
+		expect(normalizeSampleRate(22_050)).toBe(24_000);
+		expect(normalizeSampleRate(32_000)).toBe(48_000);
+		expect(normalizeSampleRate(44_100)).toBe(48_000);
+	});
+
+	it("caps rates above fullband Opus", () => {
+		expect(normalizeSampleRate(96_000)).toBe(48_000);
+	});
+
+	it("rejects invalid rates", () => {
+		expect(() => normalizeSampleRate(0)).toThrow("invalid Opus sample rate");
+		expect(() => normalizeSampleRate(Number.NaN)).toThrow("invalid Opus sample rate");
+	});
+});

--- a/js/hang/src/util/opus.ts
+++ b/js/hang/src/util/opus.ts
@@ -1,0 +1,9 @@
+const SAMPLE_RATES = [8_000, 12_000, 16_000, 24_000, 48_000] as const;
+
+/** Normalize to an Opus output rate, rounding up when possible and capping at 48 kHz. */
+export function normalizeSampleRate(sampleRate?: number): number {
+	if (sampleRate === undefined) return 48_000;
+	if (!Number.isFinite(sampleRate) || sampleRate <= 0) throw new Error("invalid Opus sample rate");
+
+	return SAMPLE_RATES.find((candidate) => candidate >= sampleRate) ?? 48_000;
+}

--- a/js/publish/src/audio/encoder.test.ts
+++ b/js/publish/src/audio/encoder.test.ts
@@ -1,5 +1,6 @@
 import { expect, mock, spyOn, test } from "bun:test";
 import { Signal } from "@moq/signals";
+import type { StreamTrack } from "./types";
 
 // The encoder pulls the capture processor in as a `?worklet` blob URL, which the bun test loader can't
 // resolve. Stub it so the module imports; the value is only ever passed to our fake addModule.
@@ -15,38 +16,71 @@ async function settle(times = 5): Promise<void> {
 // Models the WebAudio surface `#runSource` touches. The key detail is `AudioContext.close()`: on
 // Firefox and Safari it does NOT synchronously flip `.state` to "closed" (it stays "suspended"), which
 // is exactly the browser behavior the old `context.state === "closed"` guard failed to account for.
-function installFakeWebAudio() {
-	// Never resolves during the test, so the spawned worklet load stays pending until teardown.
-	const addModule = () => new Promise<void>(() => {});
+function installFakeWebAudio(props: { loaded?: boolean } = {}) {
+	const addModule = props.loaded ? () => Promise.resolve() : () => new Promise<void>(() => {});
 	let audioWorkletNodes = 0;
+	const sampleRates: Array<number | undefined> = [];
 
 	class FakeAudioContext {
 		state: AudioContextState = "suspended";
 		audioWorklet = { addModule };
-		constructor(_options?: AudioContextOptions) {}
+		sampleRate: number;
+		currentTime = 0;
+		constructor(options?: AudioContextOptions) {
+			sampleRates.push(options?.sampleRate);
+			this.sampleRate = options?.sampleRate ?? 44_100;
+		}
 		close(): Promise<void> {
 			// Firefox/Safari behavior: stays "suspended", never "closed".
 			return Promise.resolve();
 		}
 	}
 
-	class FakeMediaStream {
-		constructor(_tracks?: unknown) {}
-	}
+	class FakeMediaStream {}
 
 	class FakeGraphNode {
 		channelCount = 2;
-		constructor(_context?: unknown, _options?: unknown) {}
+		context: FakeAudioContext;
+		gain = {
+			cancelScheduledValues: () => {},
+			exponentialRampToValueAtTime: () => {},
+			setValueAtTime: () => {},
+		};
+		constructor(context: FakeAudioContext) {
+			this.context = context;
+		}
 		connect(): void {}
 		disconnect(): void {}
 	}
 
+	class FakePort extends EventTarget {
+		#started = false;
+
+		start(): void {
+			if (this.#started) return;
+			this.#started = true;
+			queueMicrotask(() => {
+				this.dispatchEvent(
+					new MessageEvent("message", {
+						data: { timestamp: 0, channels: [new Float32Array(128)] },
+					}),
+				);
+			});
+		}
+	}
+
 	class FakeAudioWorkletNode {
-		constructor(_context: unknown, _name: string) {
+		context: FakeAudioContext;
+		port = new FakePort();
+		constructor(context: FakeAudioContext, _name: string) {
 			audioWorkletNodes++;
+			this.context = context;
+			if (props.loaded) return;
 			// The real constructor throws when the module registration was abandoned mid-load.
 			throw new DOMException("Unknown AudioWorklet name 'capture'", "InvalidStateError");
 		}
+		connect(): void {}
+		disconnect(): void {}
 	}
 
 	const globals: Record<string, unknown> = {
@@ -67,6 +101,9 @@ function installFakeWebAudio() {
 		get audioWorkletNodes() {
 			return audioWorkletNodes;
 		},
+		get sampleRates() {
+			return sampleRates;
+		},
 		[Symbol.dispose]() {
 			for (const [name, original] of originals) {
 				if (original) Object.defineProperty(globalThis, name, original);
@@ -76,13 +113,74 @@ function installFakeWebAudio() {
 	};
 }
 
-function fakeSource() {
+function fakeSource(sampleRate: number | undefined = 48_000): StreamTrack {
 	return {
 		kind: "audio",
-		getSettings: () => ({ deviceId: "", groupId: "", sampleRate: 48_000 }),
+		getSettings: () => ({ deviceId: "", groupId: "", sampleRate }),
 		getConstraints: () => ({}),
-	} as unknown as MediaStreamTrack;
+	} as unknown as StreamTrack;
 }
+
+test("normalizes a 44.1kHz Opus source to 48kHz before capture", async () => {
+	using webaudio = installFakeWebAudio({ loaded: true });
+	const encoder = new Encoder("audio", {
+		enabled: true,
+		source: fakeSource(44_100),
+		codec: "opus",
+	});
+
+	await settle();
+	expect(webaudio.sampleRates).toEqual([48_000]);
+	expect(Number(encoder.out.catalog.peek()?.sampleRate)).toBe(48_000);
+
+	encoder.close();
+	await settle();
+});
+
+test("preserves native Opus capture rates", async () => {
+	using webaudio = installFakeWebAudio();
+	const encoder = new Encoder("audio", {
+		enabled: true,
+		source: fakeSource(16_000),
+		codec: "opus",
+	});
+
+	await settle();
+	expect(webaudio.sampleRates).toEqual([16_000]);
+
+	encoder.close();
+	await settle();
+});
+
+test("defaults Opus capture to 48kHz when the source has no rate", async () => {
+	using webaudio = installFakeWebAudio();
+	const encoder = new Encoder("audio", {
+		enabled: true,
+		source: fakeSource(undefined),
+		codec: "opus",
+	});
+
+	await settle();
+	expect(webaudio.sampleRates).toEqual([48_000]);
+
+	encoder.close();
+	await settle();
+});
+
+test("does not normalize AAC capture rates", async () => {
+	using webaudio = installFakeWebAudio();
+	const encoder = new Encoder("audio", {
+		enabled: true,
+		source: fakeSource(44_100),
+		codec: "aac",
+	});
+
+	await settle();
+	expect(webaudio.sampleRates).toEqual([44_100]);
+
+	encoder.close();
+	await settle();
+});
 
 // Regression: when the current run of #runSource is torn down while `audioWorklet.addModule` is still
 // pending, no AudioWorkletNode may be constructed for that abandoned run. The old guard keyed off

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -118,7 +118,7 @@ export class Encoder {
 	muted: Signal<boolean>;
 	/** Linear gain applied before encoding, where 1 is unity. */
 	volume: Signal<number>;
-	/** Override the capture sample rate in Hz. Defaults to the track's own rate. */
+	/** Override the capture sample rate in Hz. Opus normalizes this to a supported output rate. */
 	sampleRate: Signal<number | undefined>;
 	/** Override the captured channel count. Defaults to the track's requested count. */
 	channelCount: Signal<number | undefined>;
@@ -195,7 +195,10 @@ export class Encoder {
 
 		const settings = source.track.getSettings();
 		const overrideSampleRate = effect.get(this.sampleRate);
-		const sampleRate = overrideSampleRate ?? settings.sampleRate;
+		const requestedSampleRate = overrideSampleRate ?? settings.sampleRate;
+		const codec = normalizeCodec(effect.get(this.codec));
+		const sampleRate =
+			codec.mime === "opus" ? Util.Opus.normalizeSampleRate(requestedSampleRate) : requestedSampleRate;
 
 		// macOS misreports a mono mic as stereo: getSettings().channelCount is undefined and
 		// MediaStreamAudioSourceNode.channelCount defaults to 2, so the graph carries (and Opus
@@ -365,11 +368,23 @@ export class Encoder {
 				const kind: Kind = source ? normalizeSource(source).kind : "auto";
 				const encoderConfig = toEncoderConfig(config, kind, this.#opusOptions(effect));
 				const framer = createFramer(config);
+				let failed = false;
 
 				const encoder = new AudioEncoder({
-					output: (frame) => {
+					output: (frame, metadata) => {
 						if (frame.type !== "key") {
 							throw new Error("only key frames are supported");
+						}
+
+						const outputSampleRate = metadata?.decoderConfig?.sampleRate;
+						if (outputSampleRate !== undefined && outputSampleRate !== config.sampleRate) {
+							failed = true;
+							const error = new Error(
+								`audio encoder output rate ${outputSampleRate} does not match catalog rate ${config.sampleRate}`,
+							);
+							console.error("encoder error", error);
+							track.close(error);
+							return;
 						}
 
 						this.#out.stats.update((stats) => ({
@@ -395,6 +410,8 @@ export class Encoder {
 				encoder.configure(encoderConfig);
 
 				effect.event(worklet.port, "message", (event: Event) => {
+					if (failed) return;
+
 					const captured = (event as MessageEvent<Capture.AudioFrame>).data;
 					const channelCount = captured.channels.length;
 					if (!channelCount) return;

--- a/js/watch/src/audio/config.test.ts
+++ b/js/watch/src/audio/config.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "bun:test";
+import * as Catalog from "@moq/hang/catalog";
+import { audioDecoderConfig, audioDecoderSampleRate } from "./config";
+
+function config(codec: string, sampleRate: number): Catalog.AudioConfig {
+	return {
+		codec,
+		sampleRate: Catalog.u53(sampleRate),
+		numberOfChannels: Catalog.u53(2),
+		container: { kind: "legacy" },
+	};
+}
+
+describe("audioDecoderSampleRate", () => {
+	it("normalizes a legacy 44.1kHz Opus catalog to fullband output", () => {
+		expect(audioDecoderSampleRate(config("opus", 44_100))).toBe(48_000);
+	});
+
+	it("preserves native Opus output rates", () => {
+		expect(audioDecoderSampleRate(config("opus", 16_000))).toBe(16_000);
+	});
+
+	it("does not normalize other codecs", () => {
+		expect(audioDecoderSampleRate(config("mp4a.40.2", 44_100))).toBe(44_100);
+	});
+});
+
+it("builds the decoder config with the normalized output rate", () => {
+	const description = new Uint8Array([1, 2, 3]);
+	expect(audioDecoderConfig(config("opus", 44_100), description)).toEqual({
+		codec: "opus",
+		sampleRate: 48_000,
+		numberOfChannels: 2,
+		description,
+	});
+});

--- a/js/watch/src/audio/config.ts
+++ b/js/watch/src/audio/config.ts
@@ -1,0 +1,17 @@
+import type * as Catalog from "@moq/hang/catalog";
+import * as Util from "@moq/hang/util";
+
+/** Return the decoder output rate for a catalog config, normalizing non-native Opus rates. */
+export function audioDecoderSampleRate(config: Catalog.AudioConfig): number {
+	return config.codec === "opus" ? Util.Opus.normalizeSampleRate(config.sampleRate) : config.sampleRate;
+}
+
+/** Build the exact WebCodecs audio decoder config used for support probes and playback. */
+export function audioDecoderConfig(config: Catalog.AudioConfig, description?: Uint8Array): AudioDecoderConfig {
+	return {
+		codec: config.codec,
+		sampleRate: audioDecoderSampleRate(config),
+		numberOfChannels: config.numberOfChannels,
+		description,
+	};
+}

--- a/js/watch/src/audio/decode.test.ts
+++ b/js/watch/src/audio/decode.test.ts
@@ -1,0 +1,20 @@
+import { expect, mock, test } from "bun:test";
+import { decodeAudioChunk } from "./decode";
+
+test("does not decode another chunk after a fatal decoder error", () => {
+	const decode = mock(() => {});
+	const decoder = { state: "closed", decode } as unknown as AudioDecoder;
+	const chunk = {} as EncodedAudioChunk;
+
+	expect(decodeAudioChunk(decoder, chunk)).toBeFalse();
+	expect(decode).not.toHaveBeenCalled();
+});
+
+test("decodes a chunk while the decoder is configured", () => {
+	const decode = mock(() => {});
+	const decoder = { state: "configured", decode } as unknown as AudioDecoder;
+	const chunk = {} as EncodedAudioChunk;
+
+	expect(decodeAudioChunk(decoder, chunk)).toBeTrue();
+	expect(decode).toHaveBeenCalledWith(chunk);
+});

--- a/js/watch/src/audio/decode.ts
+++ b/js/watch/src/audio/decode.ts
@@ -1,0 +1,6 @@
+/** Decode a chunk unless a fatal decoder error has already closed the WebCodecs decoder. */
+export function decodeAudioChunk(decoder: AudioDecoder, chunk: EncodedAudioChunk): boolean {
+	if (decoder.state === "closed") return false;
+	decoder.decode(chunk);
+	return true;
+}

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -8,6 +8,8 @@ import { base64ToBytes } from "../base64";
 
 import type { Sync } from "../sync";
 import { type AudioBuffer, createAudioBuffer } from "./buffer";
+import { audioDecoderConfig, audioDecoderSampleRate } from "./config";
+import { decodeAudioChunk } from "./decode";
 // Compiled and inlined as a blob URL via vite-plugin-worklet.
 import RenderWorklet from "./render-worklet.ts?worklet";
 import type { Source } from "./source";
@@ -123,10 +125,10 @@ export class Decoder {
 		const config = effect.get(this.source.out.config);
 		if (!config) return;
 
-		// Pre-build the graph at the catalog rate so warm-up starts before the first frame arrives. The
-		// decoder's actual output rate is the source of truth (see #emit); if it differs, #emit sets
+		// Pre-build the graph at the effective decoder rate so warm-up starts before the first frame arrives.
+		// The decoder's actual output rate is the source of truth (see #emit); if it differs, #emit sets
 		// #decodedSampleRate, which re-runs this effect and rebuilds the graph at the real rate.
-		const sampleRate = effect.get(this.#decodedSampleRate) ?? config.sampleRate;
+		const sampleRate = effect.get(this.#decodedSampleRate) ?? audioDecoderSampleRate(config);
 		const channelCount = config.numberOfChannels;
 
 		// Expose the rate the graph actually runs at.
@@ -277,7 +279,10 @@ export class Decoder {
 					}
 					this.#emit(data);
 				},
-				error: (error) => console.error(error),
+				error: (error) => {
+					console.error(error);
+					consumer.close();
+				},
 			});
 			effect.cleanup(() => {
 				if (decoder.state !== "closed") decoder.close();
@@ -290,10 +295,7 @@ export class Decoder {
 					: config.description
 						? Util.Hex.toBytes(config.description)
 						: undefined;
-			decoder.configure({
-				...config,
-				description,
-			});
+			decoder.configure(audioDecoderConfig(config, description));
 
 			for (;;) {
 				const next = await consumer.next();
@@ -323,7 +325,7 @@ export class Decoder {
 					timestamp: frame.timestamp,
 				});
 
-				decoder.decode(chunk);
+				if (!decodeAudioChunk(decoder, chunk)) break;
 			}
 		});
 	}
@@ -361,19 +363,17 @@ export class Decoder {
 
 			const decoder = new AudioDecoder({
 				output: (data) => this.#emit(data),
-				error: (error) => console.error(error),
+				error: (error) => {
+					console.error(error);
+					consumer.close();
+				},
 			});
 			effect.cleanup(() => {
 				if (decoder.state !== "closed") decoder.close();
 			});
 
 			// Configure decoder with description from catalog
-			decoder.configure({
-				codec: config.codec,
-				sampleRate: config.sampleRate,
-				numberOfChannels: config.numberOfChannels,
-				description,
-			});
+			decoder.configure(audioDecoderConfig(config, description));
 
 			for (;;) {
 				const next = await consumer.next();
@@ -396,14 +396,12 @@ export class Decoder {
 				// it, keeping the lookahead above the floor as Opus instead of decoded PCM. No-op live.
 				await this.#ring?.wait(frame.timestamp);
 
-				if (decoder.state === "closed") break;
-				decoder.decode(
-					new EncodedAudioChunk({
-						type: frame.keyframe ? "key" : "delta",
-						data: frame.payload,
-						timestamp: frame.timestamp,
-					}),
-				);
+				const chunk = new EncodedAudioChunk({
+					type: frame.keyframe ? "key" : "delta",
+					data: frame.payload,
+					timestamp: frame.timestamp,
+				});
+				if (!decodeAudioChunk(decoder, chunk)) break;
 			}
 		});
 	}
@@ -528,9 +526,6 @@ async function supported(config: Catalog.AudioConfig): Promise<boolean> {
 			}
 		}
 	}
-	const res = await AudioDecoder.isConfigSupported({
-		...config,
-		description,
-	});
+	const res = await AudioDecoder.isConfigSupported(audioDecoderConfig(config, description));
 	return res.supported ?? false;
 }


### PR DESCRIPTION
Fixes #2400.

## Summary

- Normalize capture to a supported Opus output rate before constructing the AudioContext, keeping capture, framing, AudioEncoder configuration, and the advertised catalog rate identical.
- Validate AudioEncoder output metadata against the catalog before publishing chunks.
- Normalize legacy non-native Opus catalogs in watchers and stop decode loops after a fatal decoder error.

The root cause was that the publisher advertised the original capture graph rate as an AudioDecoderConfig. Safari can realize 44100 Hz after a Bluetooth mute/unmute cycle, while its Opus decoder requires one of the native Opus output rates. The watcher support probe accepted 44100 but decoding closed the decoder, and the legacy loop continued calling decode on the closed instance.

## Public API changes

- Adds `Util.Opus.normalizeSampleRate(sampleRate?)`, an additive helper that selects 8, 12, 16, 24, or 48 kHz.
- No breaking API, catalog schema, container, or wire-format changes.
- No Rust or documentation sync is needed because this is browser WebCodecs rate selection and compatibility handling.

## Test plan

- `nix develop --command just js fix`
- `nix develop --command just js ci`
- `nix develop --command just js test`
- Regression tests cover 44100 to 48000 normalization, catalog advertisement, native Opus rates, AAC preservation, legacy catalog compatibility, and closed-decoder handling.
- Safari Bluetooth mute/unmute hardware verification remains pending.

(Written by GPT-5)
