### PR TITLE
fix: unannounce offline broadcasts

### DIFF
--- a/demo/web/src/publish.html
+++ b/demo/web/src/publish.html
@@ -20,8 +20,8 @@
 		<!-- Left: preview + player chrome. -->
 		<section>
 			<!--
-				announce="source": only advertise the broadcast once a source is picked,
-				so the watch inspector shows no phantom tile while idle.
+				announce="catalog": only advertise the broadcast while its catalog has
+				media or application metadata, so the watch inspector has no offline tile.
 
 				The preview renders into the <canvas>. With "Encoded preview" off it shows
 				the raw capture (preview="source"); on, it decodes a copy of the *encoded*
@@ -29,7 +29,7 @@
 				cost of an extra encode + decode.
 			-->
 			<moq-publish-ui>
-				<moq-publish id="publish" name="me.hang" announce="source">
+				<moq-publish id="publish" name="me.hang" announce="catalog">
 					<canvas style="width: 100%; height: auto; border-radius: 4px;"></canvas>
 				</moq-publish>
 			</moq-publish-ui>

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -145,7 +145,7 @@ if moq.IsAuthError(err) {
 
 ## Publishing lifetime
 
-A broadcast stays live only while you hold its `BroadcastProducer`. Once the producer is garbage-collected the broadcast is treated as a failure: the path lingers briefly for a replacement publisher, then subscribers get a reset mid-stream. This bites when the producer goes out of scope while a background goroutine is still writing to its tracks.
+A broadcast stays live only while you hold its `BroadcastProducer`. Once the producer is garbage-collected the path is unannounced immediately and subscribers get a reset mid-stream. This bites when the producer goes out of scope while a background goroutine is still writing to its tracks.
 
 Keep a reference for as long as you are publishing, then close it explicitly when done:
 

--- a/doc/lib/js/@moq/publish.md
+++ b/doc/lib/js/@moq/publish.md
@@ -71,7 +71,7 @@ a real bundler (the examples below).
 - `invisible` - Disable video capture (boolean)
 - `simulcast` - Also publish a lower-resolution `video/sd` rendition (a fraction of the source resolution) alongside `video/hd` (boolean)
 - `preview` - What the preview renders: `"source"` (default), `"encoded"`, or `"none"` to disable it (see [Preview element](#preview-element))
-- `announce` - When to publish the broadcast: `"source"` (default, hold off until a `source` is selected), `"always"` (announce as soon as the element connects), or `"never"`. The JS property takes the same string values (`el.announce = "always"`)
+- `announce` - Whether to publish the broadcast: `"catalog"` (default, announce while the catalog contains media or application metadata) or `"never"`. The JS property takes the same string values (`el.announce = "never"`)
 
 ## Preview element
 

--- a/go/wrapper/moq/origin.go
+++ b/go/wrapper/moq/origin.go
@@ -40,9 +40,8 @@ func (o *OriginProducer) Dynamic() *OriginDynamic {
 //
 // The broadcast starts live: the origin announces the path so subscribers can
 // discover it, becoming visible shortly after this returns. Toggle
-// discoverability with [BroadcastProducer.SetAnnounce]; Finish unpublishes
-// immediately, while dropping the producer without finishing lingers briefly so
-// a replacement publisher can take over.
+// discoverability with [BroadcastProducer.SetAnnounce]. Finishing or dropping
+// the producer unpublishes immediately.
 func (o *OriginProducer) CreateBroadcast(path string) (*BroadcastProducer, error) {
 	inner, err := o.inner.CreateBroadcast(path)
 	if err != nil {

--- a/js/publish/README.md
+++ b/js/publish/README.md
@@ -72,7 +72,7 @@ The simplest way to publish a stream:
 | `muted`     | boolean | false    | Mute audio capture              |
 | `invisible` | boolean | false    | Disable video capture           |
 | `preview`   | string  | `"source"` | What the preview renders: `"source"`, `"encoded"`, `"none"` |
-| `announce`  | string  | `"source"` | When to publish: `"always"`, `"never"`, `"source"` (once a source is selected) |
+| `announce`  | string  | `"catalog"` | When to publish: `"catalog"` (once the catalog is ready) or `"never"` |
 
 ## JavaScript API
 

--- a/js/publish/src/broadcast.test.ts
+++ b/js/publish/src/broadcast.test.ts
@@ -109,12 +109,13 @@ test("rendition.close() unregisters the name and drops it from the catalog", asy
 
 test("serving a subscription hands the producer to the rendition and clears it when the track closes", async () => {
 	const broadcast = new Broadcast({ enabled: true, connection: stubConnection(), name: Path.from("test.hang") });
+	const rendition = broadcast.video("video");
+	rendition.config.set(videoConfig);
 	await settle();
 
 	const net = broadcast.net.peek();
 	if (!net) throw new Error("expected a network producer once connected");
 
-	const rendition = broadcast.video("video");
 	const subscriber = net.subscribe("video");
 	await settle();
 
@@ -129,6 +130,25 @@ test("serving a subscription hands the producer to the rendition and clears it w
 	expect(rendition.track.peek()).toBeUndefined();
 
 	subscriber.close();
+	broadcast.close();
+});
+
+test("publishes only while the catalog is ready", async () => {
+	const broadcast = new Broadcast({ enabled: true, connection: stubConnection(), name: Path.from("test.hang") });
+	const rendition = broadcast.video("video");
+	await settle();
+	expect(broadcast.net.peek()).toBeUndefined();
+
+	rendition.config.set(videoConfig);
+	await settle();
+	const live = broadcast.net.peek();
+	expect(live).toBeDefined();
+
+	rendition.config.set(undefined);
+	await settle();
+	expect(broadcast.net.peek()).toBeUndefined();
+	expect(live?.closed.peek()).toBe(null);
+
 	broadcast.close();
 });
 

--- a/js/publish/src/broadcast.ts
+++ b/js/publish/src/broadcast.ts
@@ -9,7 +9,7 @@ import { type Kind, Rendition } from "./rendition";
 export type BroadcastInput = {
 	connection: Getter<Moq.Connection.Established | undefined>;
 
-	// Whether to publish the broadcast. Defaults to false so nothing is announced until ready.
+	// Whether publishing is enabled. The broadcast is announced only while the catalog is ready.
 	enabled: Getter<boolean>;
 
 	// The broadcast name.
@@ -117,14 +117,13 @@ export class Broadcast {
 	// Keep the base catalog sections in sync with the registered renditions, leaving extension sections
 	// alone. A section with zero defined configs is deleted.
 	#runCatalog(effect: Effect) {
-		const enabled = effect.get(this.in.enabled);
 		const renditions = effect.get(this.#renditions);
 
 		const video: Record<string, Catalog.VideoConfig> = {};
 		const audio: Record<string, Catalog.AudioConfig> = {};
 
 		for (const rendition of Object.values(renditions)) {
-			const config = enabled ? effect.get(rendition.config) : undefined;
+			const config = effect.get(rendition.config);
 			if (config === undefined) continue;
 
 			if (rendition.kind === "video") {
@@ -159,9 +158,11 @@ export class Broadcast {
 	}
 
 	#run(effect: Effect) {
-		const values = effect.getAll([this.in.enabled, this.in.connection]);
-		if (!values) return;
-		const [_enabled, connection] = values;
+		if (!effect.get(this.in.enabled)) return;
+		if (!effect.get(this.catalog.ready)) return;
+
+		const connection = effect.get(this.in.connection);
+		if (!connection) return;
 
 		const name = effect.get(this.in.name);
 		if (Catalog.detectFormat(name) === undefined) {

--- a/js/publish/src/catalog.test.ts
+++ b/js/publish/src/catalog.test.ts
@@ -5,6 +5,21 @@ import { Track } from "@moq/net";
 import { Effect } from "@moq/signals";
 import { CatalogProducer } from "./catalog.ts";
 
+test("catalog readiness follows whether any section is published", () => {
+	const catalog = new CatalogProducer();
+	expect(catalog.ready.peek()).toBe(false);
+
+	catalog.mutate((c) => {
+		c.video = { renditions: {} };
+	});
+	expect(catalog.ready.peek()).toBe(true);
+
+	catalog.mutate((c) => {
+		delete c.video;
+	});
+	expect(catalog.ready.peek()).toBe(false);
+});
+
 test("catalog producer seeds subscribers and fans out edits", async () => {
 	const catalog = new CatalogProducer();
 

--- a/js/publish/src/catalog.ts
+++ b/js/publish/src/catalog.ts
@@ -1,7 +1,7 @@
 import type * as Catalog from "@moq/hang/catalog";
 import * as Json from "@moq/json";
 import type * as Moq from "@moq/net";
-import type { Effect } from "@moq/signals";
+import { type Effect, type Getter, Signal } from "@moq/signals";
 
 /**
  * A stable catalog producer that fans out to on-demand subscription tracks.
@@ -15,12 +15,17 @@ import type { Effect } from "@moq/signals";
 export class CatalogProducer {
 	#value: Catalog.Root = {};
 	#outputs = new Set<Json.Snapshot.Producer<Catalog.Root>>();
+	#ready = new Signal(false);
+
+	/** Whether the catalog contains at least one section and the broadcast can be announced. */
+	readonly ready: Getter<boolean> = this.#ready;
 
 	/** Edit the catalog in place; the result is published to all current subscribers. */
 	mutate(fn: (catalog: Catalog.Root) => void): void {
 		const value = structuredClone(this.#value);
 		fn(value);
 		this.#value = value;
+		this.#ready.set(Object.keys(value).length > 0);
 		for (const output of this.#outputs) output.update(value);
 	}
 

--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -22,11 +22,10 @@ export type SourceType = "camera" | "screen" | "file";
 /**
  * When to announce the broadcast.
  *
- * `always` announces immediately, `never` never announces, and `source` waits until media is
- * actually being captured (a live audio/video track, i.e. permission granted). Defaults to
- * `source` so we don't announce an empty broadcast with no audio/video.
+ * `catalog` announces while the catalog contains media or application metadata, and `never`
+ * disables publishing. Defaults to `catalog` so offline broadcasts are not advertised.
  */
-export type AnnounceMode = "always" | "source" | "never";
+export type AnnounceMode = "catalog" | "never";
 
 /**
  * Parse a boolean attribute: absent uses `defaultValue`, bare presence is true, and an explicit
@@ -49,10 +48,10 @@ function parseSource(value: string | null): SourceType | undefined {
 }
 
 function parseAnnounce(value: string | null): AnnounceMode {
-	if (value === null) return "source";
-	if (value === "source" || value === "always" || value === "never") return value;
-	console.warn(`moq-publish: invalid announce="${value}", expected "source", "always", or "never"`);
-	return "source";
+	if (value === null) return "catalog";
+	if (value === "catalog" || value === "never") return value;
+	console.warn(`moq-publish: invalid announce="${value}", expected "catalog" or "never"`);
+	return "catalog";
 }
 
 function parsePreview(value: string | null): Preview.Mode {
@@ -79,8 +78,8 @@ export default class MoqPublish extends HTMLElement {
 		invisible: new Signal(false),
 		// What a <canvas> preview renders: the raw capture, or a decoded copy of the encoded video.
 		preview: new Signal<Preview.Mode>("source"),
-		// When to announce/publish the broadcast: always, never, or only once a source is selected.
-		announce: new Signal<AnnounceMode>("source"),
+		// Whether to announce once the catalog is ready, or never publish.
+		announce: new Signal<AnnounceMode>("catalog"),
 	};
 
 	connection: Moq.Connection.Reload;
@@ -126,7 +125,7 @@ export default class MoqPublish extends HTMLElement {
 	// Set when the element is connected to the DOM.
 	#enabled = new Signal(false);
 
-	// Whether to actually publish the broadcast: connected to the DOM and allowed by the `announce` mode.
+	// Whether publishing is enabled: connected to the DOM and allowed by the `announce` mode.
 	#publishEnabled = new Signal(false);
 
 	/**
@@ -164,13 +163,7 @@ export default class MoqPublish extends HTMLElement {
 		this.signals.run((effect) => {
 			const enabled = effect.get(this.#enabled);
 			const announce = effect.get(this.controls.announce);
-			// "source" waits until media is actually being captured -- a live audio or
-			// video track exists -- not merely a source *type* selected. Otherwise we'd
-			// announce an empty broadcast while the getUserMedia/getDisplayMedia
-			// permission prompt is still pending (or after the user denies it).
-			const hasMedia = effect.get(this.#videoSource) !== undefined || effect.get(this.#audioSource) !== undefined;
-			const announcing = announce === "always" || (announce === "source" && hasMedia);
-			this.#publishEnabled.set(enabled && announcing);
+			this.#publishEnabled.set(enabled && announce === "catalog");
 		});
 
 		// Track the connection's send bandwidth estimate, the encoder's bitrate cap.

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -174,8 +174,7 @@ class OriginProducer:
 
         The broadcast starts live: the origin announces the path so subscribers can
         discover it, becoming visible shortly after this returns. Toggle
-        discoverability with :meth:`BroadcastProducer.set_announce`; ``finish()``
-        unpublishes immediately, while dropping the producer without finishing
-        lingers briefly so a replacement publisher can take over.
+        discoverability with :meth:`BroadcastProducer.set_announce`. Finishing or
+        dropping the producer unpublishes immediately.
         """
         return BroadcastProducer._from_inner(self._inner.create_broadcast(path))

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -234,9 +234,7 @@ impl MoqOriginProducer {
 	/// [`MoqBroadcastProducer::set_announce`]; an unannounced broadcast stays reachable by exact
 	/// path for subscribes and fetches without being announced.
 	///
-	/// [`MoqBroadcastProducer::finish`] unpublishes immediately. Dropping the producer
-	/// without finishing is treated as a failure: the path lingers briefly so a
-	/// replacement publisher can take over without subscribers noticing.
+	/// Finishing or dropping the producer unpublishes the path immediately.
 	pub fn create_broadcast(&self, path: String) -> Result<Arc<MoqBroadcastProducer>, MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
 		// Surfaces Error::Unauthorized (out of scope) via the MoqError::Protocol conversion.

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -1031,7 +1031,7 @@ async fn announced_broadcast() {
 	assert_eq!(announcement.path(), "test/broadcast");
 	let _catalog = announcement.broadcast().subscribe_catalog().await.unwrap();
 	// Finish so the origin tears the broadcast down immediately (the canonical
-	// end for a publisher; dropping without finish is the failure-linger path).
+	// end for a publisher; dropping without finish also unannounces immediately).
 	_broadcast.finish().unwrap();
 }
 

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -637,8 +637,7 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 	assert_eq!(path.as_str(), "second");
 	assert!(broadcast.is_some(), "expected live announce");
 
-	// Unannounce: retracted by announce id on the wire. A deliberate finish
-	// unannounces immediately (a bare drop would linger for a reconnect).
+	// Unannounce: retracted by announce id on the wire immediately after finish.
 	second.finish();
 	let moq_net::announce::Update { path, broadcast } = next_announce(&mut announcements).await;
 	assert_eq!(path.as_str(), "second");

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -67,9 +67,8 @@ struct TrackState {
 }
 
 struct BroadcastState {
-	// The source feeding this broadcast into our origin: finish() on a
-	// deliberate unannounce detaches immediately, dropping (a dying session)
-	// aborts it so the origin lingers for a reconnect.
+	// The source feeding this broadcast into our origin. A deliberate unannounce
+	// or a dying session detaches and unannounces it immediately.
 	producer: crate::model::broadcast::SourceGuard,
 
 	// active number of PUBLISH or PUBLISH_NAMESPACE messages.

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -353,7 +353,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					// start_announce as a reflected loop, in which case
 					// `routes` has no entry; that's expected, not an error.
 					// A deliberate unannounce detaches gracefully: if this was the
-					// broadcast's last route it closes now, without the reconnect linger.
+					// broadcast's last route it closes immediately.
 					if let Some(entry) = routes.remove(&path) {
 						entry.finish();
 						stats_guards.remove(&abs);
@@ -376,7 +376,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					// start_announce as a reflected loop, in which case
 					// `routes` has no entry; that's expected, not an error.
 					// A deliberate unannounce detaches gracefully: if this was the
-					// broadcast's last route it closes now, without the reconnect linger.
+					// broadcast's last route it closes immediately.
 					if let Some(entry) = routes.remove(&path) {
 						entry.finish();
 						stats_guards.remove(&abs);

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -128,20 +128,9 @@ struct BroadcastState {
 	route: Route,
 	route_epoch: u64,
 
-	// Set by an explicit `Producer::finish()` or `Producer::abort()` so `Drop` can
-	// tell a deliberate shutdown apart from a producer dropped by accident, and so
-	// the origin can tell a graceful end (unpublish immediately) from a failure
-	// (linger for a reconnect).
-	close: Option<Close>,
-}
-
-/// How a broadcast was deliberately ended.
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum Close {
-	/// A clean end: the content is over.
-	Finish,
-	/// An abnormal end: the producer is going away (e.g. its session died).
-	Abort,
+	// Set by an explicit `Producer::finish()` so `Drop` can tell a deliberate
+	// shutdown from a producer dropped by accident.
+	finished: bool,
 }
 
 /// The spliced (route-fed) half of a broadcast: logical tracks that outlive any
@@ -359,16 +348,7 @@ impl Producer {
 	/// gone, so a clone that outlives this call keeps it alive until it too is
 	/// dropped or finished.
 	pub fn finish(self) {
-		self.state.lock().close.get_or_insert(Close::Finish);
-	}
-
-	/// Mark the broadcast as deliberately ending abnormally, without the
-	/// dropped-without-finish warning. Unlike [`Self::finish`], an origin treats the
-	/// closure as a failure: the published path lingers briefly so a reconnecting
-	/// session can replace this broadcast without consumers noticing. Used by
-	/// sessions tearing down announced broadcasts when the connection dies.
-	pub(crate) fn abort(&self) {
-		self.state.lock().close.get_or_insert(Close::Abort);
+		self.state.lock().finished = true;
 	}
 
 	/// Return true if this is the same broadcast instance.
@@ -387,7 +367,7 @@ impl Drop for Producer {
 		if !self.alive.is_last() {
 			return;
 		}
-		if self.state.read().close.is_none() {
+		if !self.state.read().finished {
 			tracing::warn!(
 				"broadcast::Producer dropped without finish(). Keep the producer alive while publishing, then call finish()."
 			);
@@ -408,12 +388,11 @@ impl Producer {
 
 /// A session-owned handle to a source broadcast created via
 /// [`crate::origin::Producer::create_broadcast`]: [`Self::finish`] ends it
-/// deliberately (the origin unannounces immediately), while dropping the guard
-/// marks the source aborted (the origin lingers for a reconnect, and the
-/// dropped-without-finish warning stays quiet). Shared by the lite and IETF
-/// subscribers so the drop-vs-finish contract lives in one place.
+/// deliberately. Dropping the guard finishes it too, so a session disappearing
+/// unannounces immediately without triggering the dropped-without-finish warning.
+/// Shared by the lite and IETF subscribers so this contract lives in one place.
 pub(crate) struct SourceGuard {
-	// `Option` so `finish` can consume the producer while `Drop` aborts it.
+	// `Option` so `finish` or `Drop` can consume the producer exactly once.
 	producer: Option<Producer>,
 }
 
@@ -447,8 +426,8 @@ impl SourceGuard {
 
 impl Drop for SourceGuard {
 	fn drop(&mut self) {
-		if let Some(producer) = &self.producer {
-			producer.abort();
+		if let Some(producer) = self.producer.take() {
+			producer.finish();
 		}
 	}
 }
@@ -500,14 +479,14 @@ impl Dynamic {
 	/// release its handle.
 	pub fn poll_requested_track(&mut self, waiter: &kio::Waiter) -> Poll<Result<track::Request, Error>> {
 		let mut state = ready!(self.state.poll(waiter, |state| {
-			if state.requests.has_queued() || state.close.is_some() {
+			if state.requests.has_queued() || state.finished {
 				Poll::Ready(())
 			} else {
 				Poll::Pending
 			}
 		}));
 
-		if state.close.is_some() && !state.requests.has_queued() {
+		if state.finished && !state.requests.has_queued() {
 			return Poll::Ready(Err(Error::Closed));
 		}
 
@@ -681,7 +660,7 @@ impl Consumer {
 
 		// A deliberately-ended broadcast serves nothing new; existing tracks above
 		// stay readable so consumers can drain the cache.
-		if state.close.is_some() {
+		if state.finished {
 			return Err(Error::NotFound);
 		}
 
@@ -715,19 +694,12 @@ impl Consumer {
 		self.alive.is_closed()
 	}
 
-	/// Whether the broadcast was ended deliberately with [`Producer::finish`], as
-	/// opposed to aborted or dropped. The origin uses this to unpublish a closed
-	/// broadcast immediately instead of lingering for a reconnect.
-	pub(crate) fn is_finished(&self) -> bool {
-		self.state.read().close == Some(Close::Finish)
-	}
-
-	/// Whether the broadcast is on its way out: deliberately ended (finish/abort
-	/// marked, even while handles remain) or already fully closed. The origin's
+	/// Whether the broadcast is on its way out: deliberately finished (even while
+	/// handles remain) or already fully closed. The origin's
 	/// dispatcher treats a rejection from such a source as imminent detach rather
 	/// than a strike.
 	pub(crate) fn is_closing(&self) -> bool {
-		self.is_closed() || self.state.read().close.is_some()
+		self.is_closed() || self.state.read().finished
 	}
 
 	/// Register a [`kio::Waiter`] that fires when the broadcast closes.

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -6,7 +6,6 @@ use std::{
 	sync::Arc,
 	sync::atomic::{AtomicU64, Ordering},
 	task::{Poll, ready},
-	time::Duration,
 };
 
 use rand::RngExt;
@@ -823,11 +822,9 @@ impl Producer {
 	/// [`broadcast::Producer::dynamic`] handler before awaiting, so the first
 	/// consumer finds them.
 	///
-	/// End the broadcast with [`broadcast::Producer::finish`]: a finished source
-	/// detaches immediately, unannouncing the path if it was the last. A source
-	/// that is dropped without finishing is treated as a failure: the path
-	/// lingers briefly so a replacement source (e.g. a reconnecting session) can
-	/// splice in without consumers noticing.
+	/// End the broadcast with [`broadcast::Producer::finish`]. When the last source
+	/// ends, the path is unannounced immediately and a later source creates a new
+	/// broadcast.
 	///
 	/// Fails with [`Error::Unauthorized`] if `path` is outside the prefixes this
 	/// producer may publish under (after [`scope`](Self::scope) /
@@ -941,12 +938,6 @@ impl Producer {
 	}
 }
 
-/// How long a broadcast outlives its last source, so a reconnecting session can
-/// re-attach and resume without consumers ever noticing. Consumers stall (serving
-/// from cache) during the window; once it expires the broadcast is unpublished and
-/// its unfinished tracks abort.
-const ROUTE_LINGER: Duration = Duration::from_secs(5);
-
 /// How many times serving a single track may fail before it is spliced in (the
 /// source rejected it, or its info never resolved) before the track is aborted
 /// instead of retried. Bounds the retry loop against a source that keeps
@@ -971,9 +962,8 @@ struct FrontState {
 	routes: Vec<FrontRoute>,
 	/// The source tracks are dispatched to. Backups park until promoted.
 	active: Option<u64>,
-	/// Terminal: no more sources may attach and every poller stops. Set by the
-	/// front task when the linger window expires, or synchronously by a graceful
-	/// detach (a finished source) that empties the table.
+	/// Terminal: no more sources may attach and every poller stops. Set when the
+	/// last source detaches.
 	closed: bool,
 }
 
@@ -1007,9 +997,8 @@ impl FrontState {
 ///
 /// Re-reads the table at apply time (rather than applying a value computed under
 /// an earlier lock) so concurrent attach/detach/update calls converge on the
-/// latest winner regardless of the order their applies land in. While no source
-/// is attached (the linger window) the previous advert and announce state are
-/// kept, so a reconnect resumes invisibly; the front task unannounces on close.
+/// latest winner regardless of the order their applies land in. No active source
+/// means the broadcast is offline, so it is unannounced immediately.
 fn sync_front(state: &kio::Producer<FrontState>, broadcast: &broadcast::Producer, leaf: &Lock<OriginNode>) {
 	// Snapshot and apply under the leaf lock: two concurrent syncs would
 	// otherwise race their applies, letting a stale snapshot land last and
@@ -1021,24 +1010,15 @@ fn sync_front(state: &kio::Producer<FrontState>, broadcast: &broadcast::Producer
 		let announce = advert.announce;
 		let _ = broadcast.clone().set_route(advert);
 		leaf_guard.set_announced(state, announce);
+	} else {
+		leaf_guard.set_announced(state, false);
 	}
 }
 
 /// Detach source `id`, promoting the next-best source; the tracks it was serving
-/// re-splice on their own. Idempotent.
-///
-/// `graceful` marks a deliberate end (the source finished) rather than a dying
-/// session: if it empties the table, the broadcast closes synchronously instead
-/// of lingering for a reconnect. The synchronous close also guarantees a
-/// following create at the path is a *new* broadcast rather than splicing new
-/// content into this one.
-fn detach_source(
-	state: &kio::Producer<FrontState>,
-	broadcast: &broadcast::Producer,
-	leaf: &Lock<OriginNode>,
-	id: u64,
-	graceful: bool,
-) {
+/// re-splice on their own. The last source closes and unannounces the broadcast
+/// immediately. Idempotent.
+fn detach_source(state: &kio::Producer<FrontState>, broadcast: &broadcast::Producer, leaf: &Lock<OriginNode>, id: u64) {
 	let close = {
 		let Ok(mut s) = state.write() else { return };
 		let Some(pos) = s.routes.iter().position(|r| r.id == id) else {
@@ -1046,9 +1026,7 @@ fn detach_source(
 		};
 		s.routes.remove(pos);
 		s.reselect();
-		if graceful && s.routes.is_empty() && !s.closed {
-			// Deliberate end: close now. The front task observes `closed` and
-			// finishes the teardown (unpublish).
+		if s.routes.is_empty() && !s.closed {
 			s.closed = true;
 			true
 		} else {
@@ -1063,8 +1041,7 @@ fn detach_source(
 
 /// Owns one source's lifecycle: attaches it to the front at its path on the first
 /// route observation, forwards route updates, and detaches it when the source
-/// closes ([`broadcast::Producer::finish`] detaching gracefully, a plain drop
-/// detaching as a failure). Spawned by [`Producer::create_broadcast`].
+/// closes. Spawned by [`Producer::create_broadcast`].
 async fn run_source(
 	origin: Info,
 	node: Lock<OriginNode>,
@@ -1105,7 +1082,7 @@ async fn run_source(
 				sync_front(&state, &broadcast, &leaf);
 			}
 			Err(_) => {
-				detach_source(&state, &broadcast, &leaf, id, source.is_finished());
+				detach_source(&state, &broadcast, &leaf, id);
 				return;
 			}
 		}
@@ -1194,9 +1171,8 @@ fn attach_source(
 	(state, broadcast, 0)
 }
 
-/// Owns a front's lifecycle: dispatches each requested track to a serve task,
-/// waits out source gaps (lingering so a reconnecting session can resume
-/// transparently), and finally unpublishes the broadcast.
+/// Owns a front's lifecycle: dispatches each requested track to a serve task and
+/// unpublishes the broadcast when its last source detaches.
 async fn run_front(
 	state: kio::Producer<FrontState>,
 	broadcast: broadcast::Producer,
@@ -1205,7 +1181,6 @@ async fn run_front(
 ) {
 	enum Step {
 		Serve(Arc<str>, super::resume::Producer),
-		Empty,
 		Closed,
 	}
 
@@ -1214,14 +1189,8 @@ async fn run_front(
 			if let Poll::Ready((name, resume)) = broadcast.poll_spliced_assigned(waiter) {
 				return Poll::Ready(Step::Serve(name, resume));
 			}
-			match state.poll(waiter, |s| {
-				if s.closed || s.routes.is_empty() {
-					Poll::Ready(())
-				} else {
-					Poll::Pending
-				}
-			}) {
-				Poll::Ready(Ok(guard)) => Poll::Ready(if guard.closed { Step::Closed } else { Step::Empty }),
+			match state.poll(waiter, |s| if s.closed { Poll::Ready(()) } else { Poll::Pending }) {
+				Poll::Ready(Ok(_)) => Poll::Ready(Step::Closed),
 				Poll::Ready(Err(_)) => Poll::Ready(Step::Closed),
 				Poll::Pending => Poll::Pending,
 			}
@@ -1236,57 +1205,10 @@ async fn run_front(
 				continue;
 			}
 			Step::Closed => break,
-			Step::Empty => {}
-		}
-
-		// No sources: linger so a reconnecting session can re-attach and resume,
-		// with consumers serving from cache in the meantime.
-		let reattached = {
-			let mut linger = std::pin::pin!(web_async::time::sleep(ROUTE_LINGER));
-			kio::wait(|waiter| {
-				match state.poll(waiter, |s| {
-					if s.routes.is_empty() && !s.closed {
-						Poll::Pending
-					} else {
-						Poll::Ready(())
-					}
-				}) {
-					Poll::Ready(res) => return Poll::Ready(res.is_ok()),
-					Poll::Pending => {}
-				}
-				if waiter.poll_future(linger.as_mut()).is_ready() {
-					return Poll::Ready(false);
-				}
-				Poll::Pending
-			})
-			.await
-		};
-		if reattached {
-			// Either a source re-attached or a graceful close landed; loop back
-			// to tell the two apart.
-			continue;
-		}
-
-		// Commit the close under the write lock, re-checking for a source that
-		// re-attached since we last looked; the `closed` flag is what stops
-		// further attaches.
-		match state.write() {
-			Ok(mut s) => {
-				if s.closed {
-					break;
-				}
-				if !s.routes.is_empty() {
-					continue;
-				}
-				s.closed = true;
-				break;
-			}
-			Err(_) => break,
 		}
 	}
 
-	// Close: no source came back. Abort the logical tracks (releasing their
-	// subscribers) and unpublish.
+	// Abort the logical tracks (releasing their subscribers) and unpublish.
 	broadcast.abort_spliced(Error::Dropped);
 
 	// Deliberate end; suppresses the dropped-without-finish warning.
@@ -2195,9 +2117,7 @@ mod tests {
 		broadcast::Route::new().with_announce(true)
 	}
 
-	/// Let the spawned origin tasks (source watchers, front dispatch) run. The
-	/// tests pause tokio time, so this advances the clock without reaching the
-	/// 5-second failure linger.
+	/// Let the spawned origin tasks (source watchers and front dispatch) run.
 	async fn settle() {
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
 	}
@@ -2408,8 +2328,7 @@ mod tests {
 		// is announced.
 		producer.abort(Error::Dropped).unwrap();
 		drop(producer);
-		source_a.abort();
-		drop(source_a);
+		source_a.finish();
 		drop(dynamic_a);
 		settle().await;
 		announced.assert_next_wait();
@@ -2562,8 +2481,7 @@ mod tests {
 		sub.assert_closed();
 
 		// A detaching must not re-dispatch the finished track to B.
-		source_a.abort();
-		drop(source_a);
+		source_a.finish();
 		drop(dynamic_a);
 		settle().await;
 		dynamic_b.assert_no_request();
@@ -2608,61 +2526,6 @@ mod tests {
 		let _producer = accept_track(&mut dynamic, "video").await;
 		settle().await;
 		let mut sub = subscribing.await.unwrap();
-		sub.assert_not_closed();
-	}
-
-	/// After the last source detaches the broadcast lingers: consumers stall (no
-	/// error), and a source re-attaching within the window resumes transparently.
-	#[tokio::test(start_paused = true)]
-	async fn test_route_linger_reattach() {
-		let origin = Origin::random().produce();
-		let consumer = origin.consume();
-		let mut announced = consumer.announced();
-
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let source_a = origin
-			.create_broadcast("test", announce().with_hops(hops.clone()))
-			.unwrap();
-		let mut dynamic_a = source_a.dynamic();
-		settle().await;
-		settle().await;
-		let broadcast = consumer.request_broadcast("test").await.unwrap();
-		announced.assert_next_some("test");
-
-		let subscribing = broadcast.track("video").unwrap().subscribe(None);
-		let mut producer = accept_track(&mut dynamic_a, "video").await;
-		settle().await;
-		let mut sub = subscribing.await.unwrap();
-		producer.append_group().unwrap();
-		assert_eq!(sub.assert_group().sequence, 0);
-
-		// The only source dies. The broadcast stays announced (linger) and the
-		// subscriber stalls rather than erroring.
-		producer.abort(Error::Dropped).unwrap();
-		drop(producer);
-		source_a.abort();
-		drop(source_a);
-		drop(dynamic_a);
-		tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-		announced.assert_next_wait();
-		sub.assert_no_group();
-		sub.assert_not_closed();
-
-		// A reconnecting session re-attaches within the window and resumes.
-		let source_b = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
-		let mut dynamic_b = source_b.dynamic();
-		settle().await;
-		settle().await;
-		let mut producer = accept_track(&mut dynamic_b, "video").await;
-		settle().await;
-		sub.assert_no_group();
-		assert_eq!(producer.subscription().unwrap().group_start, Some(1));
-		producer.create_group(group::Info { sequence: 1 }).unwrap();
-		assert_eq!(sub.assert_group().sequence, 1);
-
-		// Well past the linger window: the re-attached source keeps it alive.
-		tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-		announced.assert_next_wait();
 		sub.assert_not_closed();
 	}
 
@@ -2727,8 +2590,7 @@ mod tests {
 		sub.assert_not_closed();
 	}
 
-	/// A graceful detach (deliberate unannounce) closes immediately: no linger, so
-	/// the unannounce propagates promptly and a re-create is a fresh broadcast.
+	/// A deliberate finish unannounces immediately, so a re-create is fresh.
 	#[tokio::test(start_paused = true)]
 	async fn test_route_unannounce_immediate() {
 		let origin = Origin::random().produce();
@@ -2743,8 +2605,8 @@ mod tests {
 		let broadcast = consumer.request_broadcast("test").await.unwrap();
 		announced.assert_next_some("test");
 
-		// The peer deliberately unannounced: no reconnect window, the broadcast is
-		// gone as soon as the teardown task observes the close.
+		// The peer deliberately unannounced: the broadcast is gone as soon as the
+		// teardown task observes the close.
 		source.finish();
 		settle().await;
 		announced.assert_next_none("test");
@@ -2760,17 +2622,17 @@ mod tests {
 		);
 	}
 
-	/// When no source returns within the linger window, the broadcast unannounces
-	/// and its unfinished tracks abort.
-	#[tokio::test(start_paused = true)]
-	async fn test_route_linger_expiry() {
+	/// Dropping a session source unannounces immediately and aborts unfinished tracks.
+	#[tokio::test]
+	async fn test_source_drop_unannounce_immediate() {
 		let origin = Origin::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
 		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
 		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
-		let mut dynamic = source.dynamic();
+		let guard = broadcast::SourceGuard::new(source);
+		let mut dynamic = guard.producer().dynamic();
 		settle().await;
 		settle().await;
 		let broadcast = consumer.request_broadcast("test").await.unwrap();
@@ -2782,12 +2644,11 @@ mod tests {
 		let mut sub = subscribing.await.unwrap();
 
 		drop(producer);
-		source.abort();
-		drop(source);
+		drop(guard);
 		drop(dynamic);
+		settle().await;
 
-		// The linger window expires with no source: unannounce, and the track aborts.
-		tokio::time::sleep(ROUTE_LINGER + std::time::Duration::from_secs(1)).await;
+		// No source remains: unannounce and abort without advancing time.
 		announced.assert_next_none("test");
 		sub.assert_error();
 	}
@@ -2965,8 +2826,9 @@ mod tests {
 		let origin = Origin::random().produce();
 
 		let mut consumer = origin.consume().announced();
+		let mut broadcasts = Vec::new();
 		for i in 0..256 {
-			let _broadcast = origin.create_broadcast(format!("test{i:03}"), announce()).unwrap();
+			broadcasts.push(origin.create_broadcast(format!("test{i:03}"), announce()).unwrap());
 			settle().await;
 		}
 
@@ -2974,6 +2836,9 @@ mod tests {
 			consumer.assert_next_some(format!("test{i:03}"));
 		}
 		consumer.assert_next_wait();
+		for broadcast in broadcasts {
+			broadcast.finish();
+		}
 	}
 
 	#[tokio::test]
@@ -2981,13 +2846,17 @@ mod tests {
 		let origin = Origin::random().produce();
 
 		let mut consumer = origin.consume().announced();
+		let mut broadcasts = Vec::new();
 		for i in 0..256 {
-			let _broadcast = origin.create_broadcast(format!("test{i:03}"), announce()).unwrap();
+			broadcasts.push(origin.create_broadcast(format!("test{i:03}"), announce()).unwrap());
 			settle().await;
 		}
 
 		for i in 0..256 {
 			consumer.assert_try_next_some(format!("test{i:03}"));
+		}
+		for broadcast in broadcasts {
+			broadcast.finish();
 		}
 	}
 

--- a/rs/moq-rtmp/src/dial.rs
+++ b/rs/moq-rtmp/src/dial.rs
@@ -436,12 +436,11 @@ async fn client_handshake<S: Stream>(stream: &mut S) -> anyhow::Result<Vec<u8>> 
 }
 
 /// An active pull: the moq-mux FLV importer publishing into the origin. Mirrors the
-/// server's publisher; a deliberate [`Self::finish`] unannounces immediately,
-/// while dropping it lets the origin linger briefly for a reconnect.
+/// server's publisher; finishing or dropping it unannounces immediately.
 struct Publisher {
 	importer: FlvImport,
 	// A clone of the importer's producer, so a deliberate end can finish() the
-	// broadcast (prompt unannounce) even though the importer owns it.
+	// broadcast even though the importer owns it.
 	broadcast: moq_net::broadcast::Producer,
 }
 

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -1160,13 +1160,11 @@ async fn run_handshake<S: Stream>(stream: &mut S, peer: SocketAddr) -> anyhow::R
 
 /// An active publish: the moq-mux FLV importer, which owns the origin-created
 /// [`BroadcastProducer`](moq_net::broadcast::Producer) it publishes into.
-/// Dropping it closes the broadcast; the origin lingers briefly before
-/// unannouncing so a reconnecting encoder can resume, while [`Self::finish`]
-/// unannounces immediately.
+/// Dropping it closes and unannounces the broadcast immediately.
 struct Publisher {
 	importer: FlvImport,
 	// A clone of the importer's producer, so a deliberate end can finish() the
-	// broadcast (prompt unannounce) even though the importer owns it.
+	// broadcast even though the importer owns it.
 	broadcast: moq_net::broadcast::Producer,
 }
 

--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -20,13 +20,12 @@ use crate::Result;
 /// Each chunk is handed straight to the TS importer, which consumes whole
 /// transport packets and retains any partial trailing packet internally for the
 /// next call (the same pattern `moq-cli import ... stdin ts` uses against stdin).
-/// A deliberate [`Self::finish`] ends the broadcast and unannounces the path
-/// immediately; dropping the publisher instead lets the origin linger briefly
-/// so a reconnecting sender can resume.
+/// Finishing or dropping the publisher ends the broadcast and unannounces the
+/// path immediately.
 pub struct Publisher {
 	importer: ts::Import,
 	// A clone of the importer's producer, so a deliberate end can finish() the
-	// broadcast (prompt unannounce) even though the importer owns it.
+	// broadcast even though the importer owns it.
 	broadcast: moq_net::broadcast::Producer,
 }
 

--- a/swift/Sources/Moq/Origin.swift
+++ b/swift/Sources/Moq/Origin.swift
@@ -27,9 +27,8 @@ public final class OriginProducer: Sendable {
     ///
     /// The broadcast starts live: the origin announces the path so subscribers can
     /// discover it, becoming visible shortly after this returns. Toggle
-    /// discoverability with `BroadcastProducer.setAnnounce(_:)`; `finish()` unpublishes
-    /// immediately, while releasing the producer without finishing lingers briefly
-    /// so a replacement publisher can take over.
+    /// discoverability with `BroadcastProducer.setAnnounce(_:)`. Finishing or
+    /// releasing the producer unpublishes immediately.
     public func createBroadcast(path: String) throws -> BroadcastProducer {
         BroadcastProducer(try ffi.createBroadcast(path: path))
     }


### PR DESCRIPTION
## Summary

- Remove the five-second origin route linger so the last source immediately unannounces the broadcast and aborts unfinished tracks.
- Gate `@moq/publish` network publication on a non-empty catalog, so a broadcast becomes live when its catalog is ready and goes offline when the catalog becomes empty.
- Update the browser demo, public docs, language-wrapper guidance, and regression coverage for the new lifetime contract.

The root cause was two independent lifetime rules that kept offline broadcasts discoverable. The origin deliberately retained its front for five seconds after the last source detached, while the browser publisher keyed publication to raw capture presence instead of the catalog it actually served.

Fixes #2401.

## Public API changes

- **Breaking:** `AnnounceMode` now accepts `"catalog" | "never"`; the `"always"` and `"source"` modes are removed, and `"catalog"` is the default.
- **Additive:** `CatalogProducer.ready` exposes whether the catalog contains at least one top-level section.
- No wire format changed, so the protocol drafts and `js/net` do not require updates. The `moq-ffi` API shape is unchanged; synchronized wrapper and generated-facing documentation now describes immediate unannounce behavior.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just js test`
- `nix develop --command cargo test -p moq-net`
- `nix develop --command cargo test -p moq-native --test broadcast`

(Written by GPT-5)
