### PR TITLE
refactor(stats)!: remove internal tier defaults

### DIFF
--- a/demo/relay/localhost.toml
+++ b/demo/relay/localhost.toml
@@ -30,10 +30,8 @@ public = ""
 #
 #   .stats/node/local/host
 #
-# carrying four JSON tracks (publisher.json, subscriber.json,
-# internal/publisher.json, internal/subscriber.json) of {path: counters}
-# for every broadcast that has changed within the last `retention`
-# intervals. See doc/bin/relay/config.md for the field semantics.
+# carrying publisher.json, subscriber.json, and sessions.json tracks. See
+# doc/bin/relay/config.md for the field semantics.
 [stats]
 enabled = true
 

--- a/demo/web/src/stats.html
+++ b/demo/web/src/stats.html
@@ -59,7 +59,6 @@
 			<div class="flex items-center gap-4 text-xs">
 				<span class="flex items-center gap-1.5"><span class="inline-block w-2.5 h-2.5 rounded-sm bg-emerald-400"></span>egress <span id="legend-egress" class="font-mono text-neutral-400 tabular-nums">–</span></span>
 				<span class="flex items-center gap-1.5"><span class="inline-block w-2.5 h-2.5 rounded-sm bg-sky-400"></span>ingress <span id="legend-ingress" class="font-mono text-neutral-400 tabular-nums">–</span></span>
-				<span class="flex items-center gap-1.5"><span class="inline-block w-2.5 h-2.5 rounded-sm bg-violet-400"></span>cluster <span id="legend-cluster" class="font-mono text-neutral-400 tabular-nums">–</span></span>
 			</div>
 		</div>
 		<div id="chart-throughput" class="h-44"></div>
@@ -74,29 +73,19 @@
 	<section id="node-detail" hidden class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-4 mb-6">
 		<div class="flex flex-wrap items-baseline justify-between gap-2 mb-4">
 			<h2 class="text-base font-semibold">Node <span id="node-title" class="font-mono text-emerald-400"></span></h2>
-			<div class="text-xs text-neutral-400 font-mono"><span id="node-sessions"></span> · <span id="node-internal-sessions"></span></div>
+			<div id="node-sessions" class="text-xs text-neutral-400 font-mono"></div>
 		</div>
 
-		<div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+		<div class="mb-4">
 			<div>
 				<div class="flex items-center justify-between mb-1">
-					<h3 class="text-xs font-semibold text-neutral-400">External throughput</h3>
+					<h3 class="text-xs font-semibold text-neutral-400">Throughput</h3>
 					<div class="flex items-center gap-3 text-[11px]">
 						<span class="flex items-center gap-1"><span class="inline-block w-2 h-2 rounded-sm bg-emerald-400"></span>egress</span>
 						<span class="flex items-center gap-1"><span class="inline-block w-2 h-2 rounded-sm bg-sky-400"></span>ingress</span>
 					</div>
 				</div>
-				<div id="chart-node-external" class="h-32"></div>
-			</div>
-			<div>
-				<div class="flex items-center justify-between mb-1">
-					<h3 class="text-xs font-semibold text-neutral-400">Cluster throughput (mTLS peers)</h3>
-					<div class="flex items-center gap-3 text-[11px]">
-						<span class="flex items-center gap-1"><span class="inline-block w-2 h-2 rounded-sm bg-violet-400"></span>out</span>
-						<span class="flex items-center gap-1"><span class="inline-block w-2 h-2 rounded-sm bg-fuchsia-400"></span>in</span>
-					</div>
-				</div>
-				<div id="chart-node-cluster" class="h-32"></div>
+				<div id="chart-node-throughput" class="h-32"></div>
 			</div>
 		</div>
 
@@ -108,14 +97,6 @@
 			<div>
 				<h3 class="text-xs font-semibold text-emerald-300 mb-1">Viewers <span class="text-neutral-500 font-normal">· served downstream</span></h3>
 				<div id="node-subscribers" class="overflow-x-auto text-neutral-500 text-sm">no viewers</div>
-			</div>
-			<div>
-				<h3 class="text-xs font-semibold text-fuchsia-300 mb-1">Cluster ingress <span class="text-neutral-500 font-normal">· from peer relays</span></h3>
-				<div id="node-internal-publishers" class="overflow-x-auto text-neutral-500 text-sm">none</div>
-			</div>
-			<div>
-				<h3 class="text-xs font-semibold text-violet-300 mb-1">Cluster egress <span class="text-neutral-500 font-normal">· to peer relays</span></h3>
-				<div id="node-internal-subscribers" class="overflow-x-auto text-neutral-500 text-sm">none</div>
 			</div>
 		</div>
 	</section>

--- a/demo/web/src/stats.ts
+++ b/demo/web/src/stats.ts
@@ -7,20 +7,10 @@
  * works for a single relay and for a cluster alike, then aggregate each node and
  * let you drill into one.
  *
- * The relay splits its stats by billing tier, an arbitrary label chosen by
- * business logic. The default tier is unprefixed; a named tier prefixes its
- * tracks with its label. This dashboard reads the two well-known tiers: the
- * default tier (external clients: JWT/public) and `internal` (mTLS /
- * cluster-connect peers), so cluster fan-out (e.g. the hub relaying between
- * nodes) shows up only in the `internal/*` tracks, never in the default numbers.
- *
  * Per-node tracks we read:
- *   publisher.json            default-tier egress  (relay -> downstream viewers)
- *   subscriber.json           default-tier ingress (upstream publishers -> relay)
- *   sessions.json             default-tier sessions by auth root
- *   internal/publisher.json   internal egress  (relay -> downstream cluster peers)
- *   internal/subscriber.json  internal ingress (upstream cluster peers -> relay)
- *   internal/sessions.json    internal sessions by auth root
+ *   publisher.json   egress  (relay -> downstream viewers)
+ *   subscriber.json  ingress (upstream publishers -> relay)
+ *   sessions.json    sessions by auth root
  *
  * Each frame is `{ "<broadcast path>": Snapshot }`. Counters are cumulative;
  * "active" = open - closed. The relay only includes currently-live entries, so
@@ -71,16 +61,13 @@ interface NodeStats {
 	egress: BroadcastFrame; // publisher.json
 	ingress: BroadcastFrame; // subscriber.json
 	sessions: SessionFrame; // sessions.json
-	internalEgress: BroadcastFrame; // internal/publisher.json
-	internalIngress: BroadcastFrame; // internal/subscriber.json
-	internalSessions: SessionFrame; // internal/sessions.json
 }
 
 const active = (open?: number, closed?: number) => (open ?? 0) - (closed ?? 0);
 
-// Broadcasts whose path starts with "." are internal (e.g. the `.stats` feed
+// Broadcasts whose path starts with "." are system broadcasts (e.g. the `.stats` feed
 // this dashboard itself reads). We exclude them from the user-facing counters.
-const isInternal = (path: string) => path.startsWith(".");
+const isSystem = (path: string) => path.startsWith(".");
 
 // ---- State ----------------------------------------------------------------
 
@@ -141,9 +128,6 @@ function subscribeNode(effect: Signals.Effect, conn: Net.Connection.Established,
 			egress: {},
 			ingress: {},
 			sessions: {},
-			internalEgress: {},
-			internalIngress: {},
-			internalSessions: {},
 		};
 	});
 
@@ -168,40 +152,29 @@ function subscribeNode(effect: Signals.Effect, conn: Net.Connection.Established,
 	sub("publisher.json", "egress");
 	sub("subscriber.json", "ingress");
 	sub("sessions.json", "sessions");
-	sub("internal/publisher.json", "internalEgress");
-	sub("internal/subscriber.json", "internalIngress");
-	sub("internal/sessions.json", "internalSessions");
 }
 
 // ---- Aggregation ----------------------------------------------------------
 
-// Aggregate one ingress/egress pair (either the external or the internal tier).
-// `.`-prefixed system broadcasts (the `.stats` feed itself) are excluded either
-// way; we only count real content, including its cluster fan-out.
-function aggregatePair(ingress: BroadcastFrame, egress: BroadcastFrame) {
+// Aggregate ingress/egress while excluding `.`-prefixed system broadcasts such
+// as the `.stats` feed itself.
+function aggregate(ingress: BroadcastFrame, egress: BroadcastFrame) {
 	let broadcasters = 0; // active broadcasts being published (ingress)
 	let viewers = 0; // active downstream consumers (egress)
 	let ingressBytes = 0;
 	let egressBytes = 0;
 
 	for (const [path, s] of Object.entries(ingress)) {
-		if (isInternal(path)) continue;
+		if (isSystem(path)) continue;
 		if (active(s.announced, s.announced_closed) > 0) broadcasters++;
 		ingressBytes += s.bytes ?? 0;
 	}
 	for (const [path, s] of Object.entries(egress)) {
-		if (isInternal(path)) continue;
+		if (isSystem(path)) continue;
 		egressBytes += s.bytes ?? 0;
 		viewers += active(s.broadcasts, s.broadcasts_closed);
 	}
 	return { broadcasters, viewers, ingressBytes, egressBytes };
-}
-
-function aggregate(stats: NodeStats) {
-	return {
-		external: aggregatePair(stats.ingress, stats.egress),
-		internal: aggregatePair(stats.internalIngress, stats.internalEgress),
-	};
 }
 
 const countSessions = (f: SessionFrame) =>
@@ -214,10 +187,8 @@ const countSessions = (f: SessionFrame) =>
 // cluster-wide aggregate.
 interface Sample {
 	t: number;
-	egress: number; // cumulative external egress bytes
-	ingress: number; // cumulative external ingress bytes
-	clusterOut: number; // cumulative internal egress bytes
-	clusterIn: number; // cumulative internal ingress bytes
+	egress: number; // cumulative egress bytes
+	ingress: number; // cumulative ingress bytes
 	broadcasters: number;
 	viewers: number;
 	sessions: number;
@@ -229,15 +200,13 @@ const history = new Map<string, Sample[]>();
 const clock = new Signals.Signal(0);
 
 function sampleNode(t: number, stats: NodeStats): Sample {
-	const a = aggregate(stats);
+	const totals = aggregate(stats.ingress, stats.egress);
 	return {
 		t,
-		egress: a.external.egressBytes,
-		ingress: a.external.ingressBytes,
-		clusterOut: a.internal.egressBytes,
-		clusterIn: a.internal.ingressBytes,
-		broadcasters: a.external.broadcasters,
-		viewers: a.external.viewers,
+		egress: totals.egressBytes,
+		ingress: totals.ingressBytes,
+		broadcasters: totals.broadcasters,
+		viewers: totals.viewers,
 		sessions: countSessions(stats.sessions),
 	};
 }
@@ -274,8 +243,6 @@ sampler.run((effect) => {
 			t,
 			egress: 0,
 			ingress: 0,
-			clusterOut: 0,
-			clusterIn: 0,
 			broadcasters: 0,
 			viewers: 0,
 			sessions: 0,
@@ -285,8 +252,6 @@ sampler.run((effect) => {
 			pushSample(node, s);
 			agg.egress += s.egress;
 			agg.ingress += s.ingress;
-			agg.clusterOut += s.clusterOut;
-			agg.clusterIn += s.clusterIn;
 			agg.broadcasters += s.broadcasters;
 			agg.viewers += s.viewers;
 			agg.sessions += s.sessions;
@@ -388,16 +353,13 @@ ui.run((effect) => {
 	const cluster = history.get("") ?? [];
 	const egress = rateSeries(cluster, "egress");
 	const ingress = rateSeries(cluster, "ingress");
-	const peer = rateSeries(cluster, "clusterOut");
 
 	renderChart($("chart-throughput"), [
 		{ values: egress, color: "#34d399" }, // emerald-400
 		{ values: ingress, color: "#38bdf8" }, // sky-400
-		{ values: peer, color: "#a78bfa" }, // violet-400
 	]);
 	$("legend-egress").textContent = formatRate(egress[egress.length - 1] ?? 0);
 	$("legend-ingress").textContent = formatRate(ingress[ingress.length - 1] ?? 0);
-	$("legend-cluster").textContent = formatRate(peer[peer.length - 1] ?? 0);
 });
 
 // Node cards: one per node with a live egress sparkline. Click to drill in.
@@ -435,29 +397,25 @@ ui.run((effect) => {
 	$("node-title").textContent = node;
 
 	const samples = history.get(node) ?? [];
-	renderChart($("chart-node-external"), [
+	renderChart($("chart-node-throughput"), [
 		{ values: rateSeries(samples, "egress"), color: "#34d399" },
 		{ values: rateSeries(samples, "ingress"), color: "#38bdf8" },
 	]);
-	renderChart($("chart-node-cluster"), [
-		{ values: rateSeries(samples, "clusterOut"), color: "#a78bfa" },
-		{ values: rateSeries(samples, "clusterIn"), color: "#e879f9" }, // fuchsia-400
-	]);
 
-	// Broadcasters: what this node ingests (from upstream publishers / cluster peers).
+	// Broadcasters: what this node ingests from upstream publishers.
 	const ingressRows = (frame: BroadcastFrame) =>
 		Object.keys(frame)
-			.filter((p) => !isInternal(p))
+			.filter((p) => !isSystem(p))
 			.sort()
 			.map((path) => {
 				const i = frame[path] ?? {};
 				return { key: path, cells: [path, formatBytes(i.bytes ?? 0), String(i.frames ?? 0)] };
 			});
 
-	// Viewers: what this node serves downstream (to subscribers / cluster peers).
+	// Viewers: what this node serves to downstream subscribers.
 	const egressRows = (frame: BroadcastFrame) =>
 		Object.keys(frame)
-			.filter((p) => !isInternal(p))
+			.filter((p) => !isSystem(p))
 			.sort()
 			.map((path) => {
 				const e = frame[path] ?? {};
@@ -474,17 +432,9 @@ ui.run((effect) => {
 
 	renderTable($("node-publishers"), ["broadcast", "ingress", "frames"], ingressRows(stats.ingress));
 	renderTable($("node-subscribers"), ["broadcast", "viewers", "egress", "frames"], egressRows(stats.egress));
-	renderTable($("node-internal-publishers"), ["broadcast", "ingress", "frames"], ingressRows(stats.internalIngress));
-	renderTable(
-		$("node-internal-subscribers"),
-		["broadcast", "peers", "egress", "frames"],
-		egressRows(stats.internalEgress),
-	);
 
 	const sessions = countSessions(stats.sessions);
-	const internalSessions = countSessions(stats.internalSessions);
 	$("node-sessions").textContent = `${sessions} session${sessions === 1 ? "" : "s"}`;
-	$("node-internal-sessions").textContent = `${internalSessions} cluster`;
 });
 
 // Raw frames for everyone who wants the numbers behind the charts.

--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -161,7 +161,7 @@ Per connection the relay issues `GET <base>?root=<path>&kid=<kid>&mtls=true&tran
 - `alias` — the canonical full root to scope this connection to: the path with its first segment (a stable id, current vanity, or recently-changed vanity) resolved to the project's canonical id, the rest of the path preserved (e.g. `demo/room/cam` → `x7k2qp/room/cam`). The relay uses it verbatim, so the server owns the entire mapping. Absent → the request path is used unchanged.
 - `public` — `{ "subscribe": [...], "publish": [...] }` anonymous access prefixes (relative to the root), used when there is no JWT. Absent → no public access.
 - `key` — the verifying JWK (a JSON object, deserialized directly) for the requested `kid`. Absent → key-not-found, and the JWT is rejected.
-- `tier` — the billing tier label this connection's stats record under (an arbitrary string, e.g. `internal`, `local`, `region/sjc`). The relay forwards `mtls=true` and lets the API decide; absent defaults to `--auth-mtls-tier` (itself defaulting to `internal`) for mTLS peers and the default (unprefixed) tier for JWT/public connections. So the API can bucket a first-party token to `internal`, or a cert-verified connection back to the default tier. An empty label selects the default tier. See [Stats](/bin/relay/config#stats) for how tier labels map to track names. For backward compatibility the relay still accepts the older boolean `internal` field (`true` → the `internal` tier, `false` → the default tier) when `tier` is absent.
+- `tier`: the billing tier label this connection's stats record under (an arbitrary string, e.g. `local` or `region/sjc`). Absent or empty selects the default unprefixed tier. See [Stats](/bin/relay/config#stats) for how tier labels map to track names.
 
 This lets a project stay reachable by both its stable id and its current/old vanity path, all mapping to the same broadcast tree: with the API resolving `demo` → `x7k2qp`, both `cdn.moq.dev/demo/foo` and `cdn.moq.dev/x7k2qp/foo` scope to `/x7k2qp/foo`.
 
@@ -222,10 +222,10 @@ certificate chaining to that CA is granted **full publish and subscribe access
 within the connection URL path**. The URL path scopes the grant exactly like a
 JWT's `root` claim, so a peer dialing `/demo` can only publish and subscribe
 under `demo/`. A peer dialing `/` (as cluster nodes do) gets an empty root and
-unscoped, cluster-wide access. The session records on the `internal` billing
-tier by default, configurable via `--auth-mtls-tier` (the auth API's `tier` field
-overrides per-connection); this only selects the stats tier used for billing and
-grants no extra permissions.
+unscoped, cluster-wide access. The session records on the default unprefixed
+billing tier unless `--auth-mtls-tier` or the auth API's `tier` field selects a
+named tier; this only selects the stats tier used for billing and grants no extra
+permissions.
 
 This is primarily intended for relay-to-relay (clustering) authentication, as a
 simpler alternative to distributing long-lived JWTs.

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -228,7 +228,7 @@ a session track:
 |-----------------------------|---------------------------------------------|
 | `publisher.json`            | default-tier egress                         |
 | `subscriber.json`           | default-tier ingress                        |
-| `<tier>/publisher.json`    | named-tier egress (e.g. `internal/publisher.json`) |
+| `<tier>/publisher.json`    | named-tier egress (e.g. `region/sjc/publisher.json`) |
 | `<tier>/subscriber.json`   | named-tier ingress                          |
 | `sessions.json`             | default-tier connected sessions, keyed by root |
 | `<tier>/sessions.json`     | named-tier connected sessions, keyed by root |
@@ -243,14 +243,12 @@ as raw JSON frames; the plain `.json` tracks remain one full JSON object per
 frame.
 
 The default-tier tracks always exist (emitting `{}` while idle). A named tier's
-tracks are created the first time traffic routes to that label, so cluster
-fan-out shows up under `internal/*` (the default trusted-peer label) and never in
-the default-tier numbers.
+tracks are created the first time traffic routes to that label.
 
-Trusted (non-JWT/public) traffic defaults to the `internal` tier, configurable
-per source: `--cluster-tier` (relay-to-relay dials) and `--auth-mtls-tier`
-(mTLS peers, when the auth API doesn't return a `tier`). Set either to a
-different label, or to `""` to record on the default unprefixed tier.
+All traffic records on the default unprefixed tier unless configured otherwise.
+Use `--cluster-tier` for relay-to-relay dials, `--auth-mtls-tier` for mTLS peers
+when the auth API does not return a `tier`, or the auth API's `tier` field to
+select a named tier.
 
 Each per-broadcast frame is a JSON object mapping broadcast path to a
 cumulative counter snapshot. An entry surfaces on any tick where the

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -307,10 +307,9 @@ impl Presence {
 ///
 /// The default tier ([`Tier::default`]) is unprefixed: its published tracks are
 /// `publisher.json`, `subscriber.json`, and `sessions.json`. A named tier
-/// prefixes every track with its label, so `Tier::new("internal")` records on
-/// `internal/publisher.json`. The label is an arbitrary path, so business logic
-/// can bucket by anything (`"internal"`, `"region/sjc"`, ...); an empty label is
-/// the default tier.
+/// prefixes every track with its label, so `Tier::new("region/sjc")` records on
+/// `region/sjc/publisher.json`. The label is an arbitrary path chosen by business
+/// logic; an empty label is the default tier.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct Tier(PathOwned);
 
@@ -340,8 +339,8 @@ impl Tier {
 		}
 	}
 
-	/// The tier label as used in metrics: empty (`""`) for the default/external
-	/// (customer) tier, otherwise the label (e.g. `"internal"`). Mirrors the
+	/// The tier label as used in metrics: empty (`""`) for the default tier,
+	/// otherwise the label (e.g. `"region/sjc"`). Mirrors the
 	/// wire convention, where the default tier is unprefixed and named
 	/// tiers are `<label>/`-prefixed.
 	pub fn as_str(&self) -> &str {
@@ -350,14 +349,9 @@ impl Tier {
 }
 
 impl fmt::Display for Tier {
-	/// The label, or `external` for the default (unprefixed) tier. For logs only;
-	/// the wire uses the empty-prefix track names.
+	/// The label, empty for the default unprefixed tier.
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		if self.0.is_empty() {
-			f.write_str("external")
-		} else {
-			fmt::Display::fmt(&self.0, f)
-		}
+		fmt::Display::fmt(&self.0, f)
 	}
 }
 
@@ -1170,6 +1164,14 @@ mod tests {
 
 	use super::*;
 
+	#[test]
+	fn default_tier_has_empty_label() {
+		let tier = Tier::default();
+		assert_eq!(tier.as_str(), "");
+		assert_eq!(tier.to_string(), "");
+		assert_eq!(tier.track_name("publisher.json"), "publisher.json");
+	}
+
 	/// Counters for `(path, tier)`, creating the tier slot if absent.
 	fn tier_counters(stats: &Registry, path: &str, tier: &Tier) -> Arc<TierCounters> {
 		stats
@@ -1223,45 +1225,45 @@ mod tests {
 	}
 
 	#[test]
-	fn external_and_internal_tiers_are_independent() {
+	fn default_and_named_tiers_are_independent() {
 		let stats = test_stats();
-		let ext = stats.tier(Tier::default());
-		let int = stats.tier(Tier::new("internal"));
+		let default = stats.tier(Tier::default());
+		let regional = stats.tier(Tier::new("region/sjc"));
 
-		let ext_track = ext.broadcast("demo/bbb").publisher().track("video");
-		ext_track.bytes(100);
-		let int_track = int.broadcast("demo/bbb").subscriber().track("audio");
-		int_track.bytes(7);
+		let default_track = default.broadcast("demo/bbb").publisher().track("video");
+		default_track.bytes(100);
+		let regional_track = regional.broadcast("demo/bbb").subscriber().track("audio");
+		regional_track.bytes(7);
 
-		let ext_c = tier_counters(&stats, "demo/bbb", &Tier::default());
-		let int_c = tier_counters(&stats, "demo/bbb", &Tier::new("internal"));
-		assert_eq!(ext_c.publisher.bytes.load(Relaxed), 100);
-		assert_eq!(ext_c.subscriber.bytes.load(Relaxed), 0);
-		assert_eq!(int_c.publisher.bytes.load(Relaxed), 0);
-		assert_eq!(int_c.subscriber.bytes.load(Relaxed), 7);
+		let default_counters = tier_counters(&stats, "demo/bbb", &Tier::default());
+		let regional_counters = tier_counters(&stats, "demo/bbb", &Tier::new("region/sjc"));
+		assert_eq!(default_counters.publisher.bytes.load(Relaxed), 100);
+		assert_eq!(default_counters.subscriber.bytes.load(Relaxed), 0);
+		assert_eq!(regional_counters.publisher.bytes.load(Relaxed), 0);
+		assert_eq!(regional_counters.subscriber.bytes.load(Relaxed), 7);
 	}
 
 	#[test]
 	fn snapshot_rolls_up_by_tier_role_and_sessions() {
 		let stats = test_stats();
-		let ext = stats.tier(Tier::default());
-		let int = stats.tier(Tier::new("internal"));
+		let default = stats.tier(Tier::default());
+		let regional = stats.tier(Tier::new("region/sjc"));
 
-		// External egress across two broadcasts; the snapshot sums them.
-		let pub_a = ext.broadcast("demo/aaa").publisher().track("video");
+		// Default-tier egress across two broadcasts; the snapshot sums them.
+		let pub_a = default.broadcast("demo/aaa").publisher().track("video");
 		pub_a.bytes(100);
 		pub_a.frame();
 		pub_a.group();
-		let pub_b = ext.broadcast("demo/bbb").publisher().track("video");
+		let pub_b = default.broadcast("demo/bbb").publisher().track("video");
 		pub_b.bytes(50);
-		// Internal ingress on a different tier/role stays isolated.
-		let sub_a = int.broadcast("demo/aaa").subscriber().track("audio");
+		// Regional ingress on a different tier/role stays isolated.
+		let sub_a = regional.broadcast("demo/aaa").subscriber().track("audio");
 		sub_a.bytes(7);
 
 		// Hold session guards so `sessions_closed` stays zero.
-		let _s1 = ext.session("acme");
-		let _s2 = ext.session("acme");
-		let _s3 = int.session("peer");
+		let _s1 = default.session("acme");
+		let _s2 = default.session("acme");
+		let _s3 = regional.session("peer");
 
 		let snap = stats.snapshot();
 
@@ -1273,15 +1275,18 @@ mod tests {
 				.expect("row present")
 		};
 
-		let ext_pub = slot(Tier::default(), Role::Publisher);
-		assert_eq!(ext_pub.bytes, 150, "external egress bytes sum across broadcasts");
-		assert_eq!(ext_pub.frames, 1);
-		assert_eq!(ext_pub.groups, 1);
+		let default_publisher = slot(Tier::default(), Role::Publisher);
+		assert_eq!(
+			default_publisher.bytes, 150,
+			"default egress bytes sum across broadcasts"
+		);
+		assert_eq!(default_publisher.frames, 1);
+		assert_eq!(default_publisher.groups, 1);
 
-		let int_sub = slot(Tier::new("internal"), Role::Subscriber);
-		assert_eq!(int_sub.bytes, 7, "internal ingress isolated by tier/role");
+		let regional_subscriber = slot(Tier::new("region/sjc"), Role::Subscriber);
+		assert_eq!(regional_subscriber.bytes, 7, "regional ingress isolated by tier/role");
 		assert_eq!(slot(Tier::default(), Role::Subscriber).bytes, 0);
-		assert_eq!(slot(Tier::new("internal"), Role::Publisher).bytes, 0);
+		assert_eq!(slot(Tier::new("region/sjc"), Role::Publisher).bytes, 0);
 
 		let sessions = |tier| {
 			snap.sessions()
@@ -1290,10 +1295,10 @@ mod tests {
 				.map(|(_, s)| s)
 				.expect("tier present")
 		};
-		let ext_sessions = sessions(Tier::default());
-		assert_eq!(ext_sessions.sessions, 2, "two external sessions under one root");
-		assert_eq!(ext_sessions.sessions_closed, 0, "guards still held");
-		assert_eq!(sessions(Tier::new("internal")).sessions, 1);
+		let default_sessions = sessions(Tier::default());
+		assert_eq!(default_sessions.sessions, 2, "two default-tier sessions under one root");
+		assert_eq!(default_sessions.sessions_closed, 0, "guards still held");
+		assert_eq!(sessions(Tier::new("region/sjc")).sessions, 1);
 	}
 
 	#[test]

--- a/rs/moq-relay/src/auth.rs
+++ b/rs/moq-relay/src/auth.rs
@@ -393,14 +393,9 @@ pub struct AuthConfig {
 	///   no public access.
 	/// - `key`: the verifying JWK (a JSON object, deserialized directly) for the
 	///   requested `kid`. Absent -> key-not-found (the JWT is rejected).
-	/// - `tier`: the billing tier label (e.g. `internal`, `region/sjc`). The relay
-	///   forwards `mtls=true` and lets the API decide. Absent defaults per
-	///   connection: `internal` for mTLS peers (trusted), the default (unprefixed)
-	///   tier for JWT/public. So the API can bucket a first-party token to
-	///   `internal`, or a cert-verified connection back to the default tier. An
-	///   empty label selects the default tier. The legacy `internal: bool` field
-	///   is still accepted (`true` -> `internal`, `false` -> default tier) when
-	///   `tier` is absent.
+	/// - `tier`: the billing tier label (e.g. `region/sjc`). The relay forwards
+	///   `mtls=true` and lets the API decide. Absent or empty selects the default
+	///   unprefixed tier for every connection.
 	///
 	/// FAILS CLOSED: any network error, non-2xx status, or parse error rejects
 	/// the connection. Unlike the standalone flags, the verifying key itself
@@ -413,9 +408,8 @@ pub struct AuthConfig {
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub auth_api: Option<String>,
 
-	/// Default billing tier label for mTLS peers when the auth API doesn't
-	/// return one (or no `--auth-api` is configured). Default `internal`. An
-	/// empty value selects the default (unprefixed) tier.
+	/// Billing tier label for mTLS peers when the auth API doesn't return one
+	/// (or no `--auth-api` is configured). Defaults to the unprefixed tier.
 	#[arg(long = "auth-mtls-tier", env = "MOQ_AUTH_MTLS_TIER")]
 	#[serde(default, skip_serializing_if = "Option::is_none")]
 	pub mtls_tier: Option<String>,
@@ -557,36 +551,19 @@ struct AuthApiResponse {
 	/// moq-token's serde); absent -> not found.
 	#[serde(default)]
 	key: Option<Key>,
-	/// Billing tier label for this connection (e.g. `internal`, `region/sjc`).
+	/// Billing tier label for this connection (e.g. `region/sjc`).
 	/// The relay sends `mtls=true` when the peer presented a verified client
-	/// cert and lets the API decide. Absent defaults per path: `internal` for
-	/// mTLS peers (trusted), the default (unprefixed) tier otherwise. An empty
-	/// label is the default tier.
+	/// cert and lets the API decide. Absent or empty selects the default
+	/// unprefixed tier.
 	#[serde(default)]
 	tier: Option<String>,
-	/// Legacy boolean form of `tier`, kept for backward compatibility with auth
-	/// APIs written against the original contract. `true` maps to the `internal`
-	/// tier, `false` to the default (unprefixed) tier. Ignored when `tier` is
-	/// also present.
-	#[serde(default)]
-	internal: Option<bool>,
 }
 
 impl AuthApiResponse {
-	/// Billing tier this response selects, honoring the legacy `internal: bool`
-	/// field when the newer `tier` label is absent. `None` leaves the choice to
-	/// the relay's per-connection default.
+	/// Billing tier this response selects. `None` leaves the choice to the
+	/// relay's per-connection default.
 	fn tier(&self) -> Option<Tier> {
-		if let Some(label) = &self.tier {
-			return Some(Tier::new(label.clone()));
-		}
-		self.internal.map(|internal| {
-			if internal {
-				Tier::new("internal")
-			} else {
-				Tier::default()
-			}
-		})
+		self.tier.clone().map(Tier::new)
 	}
 }
 
@@ -648,9 +625,8 @@ pub struct AuthToken {
 	/// Paths the holder is allowed to publish to, relative to `root`.
 	pub publish: PathPrefixes,
 	/// Billing tier this session's stats record under. Chosen by business logic
-	/// (the auth API's `tier` field), defaulting to `internal` for trusted mTLS
-	/// peers and the default tier otherwise, so cluster peers can be billed
-	/// separately from end-user traffic.
+	/// through configuration or the auth API's `tier` field; defaults to the
+	/// unprefixed tier.
 	pub tier: Tier,
 	/// When the credential backing this session expires, if it has an expiry.
 	///
@@ -664,7 +640,7 @@ impl AuthToken {
 	/// Construct a token for a peer that was authenticated at the TLS layer
 	/// via mTLS. These peers are granted full publish and subscribe access
 	/// within `root`. The billing tier is left at the default; the caller (mTLS
-	/// handshake, internal listener, or cluster dial) sets it from config. The cert's trust chain
+	/// handshake or cluster dial) sets it from config. The cert's trust chain
 	/// (verified against the configured CA) is the only credential we require;
 	/// nothing else in the cert is inspected.
 	///
@@ -765,8 +741,7 @@ pub struct Auth {
 	/// key/public sources. See [`AuthConfig::auth_api`].
 	auth_api: Option<(url::Url, ClientWithMiddleware)>,
 	/// Billing tier recorded for an mTLS peer when the auth API doesn't return a
-	/// tier (or none is configured). See [`AuthConfig::mtls_tier`]; default
-	/// `internal`, set via [`Auth::with_mtls_tier`].
+	/// tier (or none is configured). See [`AuthConfig::mtls_tier`].
 	mtls_tier: Tier,
 }
 
@@ -919,16 +894,16 @@ impl Auth {
 			public,
 			domains: Arc::from(domains.into_boxed_slice()),
 			auth_api,
-			mtls_tier: crate::trusted_tier(config.mtls_tier),
+			mtls_tier: crate::configured_tier(config.mtls_tier),
 		})
 	}
 
-	/// Override the mTLS fallback billing tier (default `internal`). For the
+	/// Override the mTLS fallback billing tier. For the
 	/// mTLS-only stub built via [`Auth::default`], where there is no
 	/// [`AuthConfig`] to carry `--auth-mtls-tier`. An empty label selects the
 	/// default (unprefixed) tier.
 	pub fn with_mtls_tier(mut self, tier: Option<String>) -> Self {
-		self.mtls_tier = crate::trusted_tier(tier);
+		self.mtls_tier = crate::configured_tier(tier);
 		self
 	}
 
@@ -956,8 +931,8 @@ impl Auth {
 	/// credential), so this only fetches the alias + tier.
 	///
 	/// Fails OPEN only when there is no auth API configured: the cert is the
-	/// credential and there is nothing to resolve, so the path is used unchanged
-	/// at the internal tier. Otherwise the API is the source of truth for every
+	/// credential and there is nothing to resolve, so the path and configured
+	/// tier are used unchanged. Otherwise the API is the source of truth for every
 	/// connection, including the root (`/`), so it can alias and tier root peers
 	/// too. An API error therefore FAILS CLOSED (returns `Err`) rather than
 	/// accepting the connection with the path unresolved. Accepting it would route
@@ -1043,8 +1018,8 @@ impl Auth {
 		)
 		.await?;
 		// Resolve the tier before consuming `resp`'s other fields below.
-		// Non-mTLS connections default to the unprefixed tier; the API may bucket
-		// specific ones (e.g. a first-party dashboard token to `internal`).
+		// Connections default to the unprefixed tier; the API may bucket specific
+		// ones under a named tier.
 		let tier = resp.tier().unwrap_or_default();
 		// The API resolves the connection path's leading segment (a vanity name or
 		// pid) to the project's canonical pid. Broadcasts anchor here on the
@@ -3117,14 +3092,14 @@ api = "https://api.example.com/access"
 			.and(query_param("root", "demo"))
 			.respond_with(
 				ResponseTemplate::new(200)
-					.set_body_string(r#"{"alias":"x7k2qp","public":{"subscribe":[""]},"tier":"internal"}"#),
+					.set_body_string(r#"{"alias":"x7k2qp","public":{"subscribe":[""]},"tier":"region/sjc"}"#),
 			)
 			.mount(&server)
 			.await;
 
 		let auth = auth_with_api(&server).await;
 		let verified = auth.verify(&AuthParams::new("/demo")).await?;
-		assert_eq!(verified.tier, Tier::new("internal"));
+		assert_eq!(verified.tier, Tier::new("region/sjc"));
 		Ok(())
 	}
 
@@ -3140,7 +3115,7 @@ api = "https://api.example.com/access"
 			.and(query_param("root", "customer/live"))
 			.and(query_param("transport", "unix"))
 			.respond_with(
-				ResponseTemplate::new(200).set_body_string(r#"{"public":{"subscribe":[""]},"tier":"legacy"}"#),
+				ResponseTemplate::new(200).set_body_string(r#"{"public":{"subscribe":[""]},"tier":"gateway"}"#),
 			)
 			.mount(&server)
 			.await;
@@ -3152,41 +3127,18 @@ api = "https://api.example.com/access"
 			..Default::default()
 		};
 		let verified = auth.verify(&params).await?;
-		assert_eq!(verified.tier, Tier::new("legacy"));
-		Ok(())
-	}
-
-	#[tokio::test]
-	async fn auth_api_legacy_internal_bool_maps_to_tier() -> anyhow::Result<()> {
-		// Backward compatibility: an auth API written against the original
-		// contract returns `internal: bool`, not `tier`. `true` -> `internal`.
-		let server = MockServer::start().await;
-		Mock::given(method("GET"))
-			.and(path_matcher("/auth"))
-			.and(query_param("root", "demo"))
-			.respond_with(
-				ResponseTemplate::new(200).set_body_string(r#"{"public":{"subscribe":[""]},"internal":true}"#),
-			)
-			.mount(&server)
-			.await;
-
-		let auth = auth_with_api(&server).await;
-		let verified = auth.verify(&AuthParams::new("/demo")).await?;
-		assert_eq!(verified.tier, Tier::new("internal"));
+		assert_eq!(verified.tier, Tier::new("gateway"));
 		Ok(())
 	}
 
 	#[test]
-	fn auth_api_response_tier_precedence() {
-		// New `tier` label wins over the legacy `internal` bool when both are present.
-		let both: AuthApiResponse = serde_json::from_str(r#"{"tier":"region/sjc","internal":true}"#).unwrap();
-		assert_eq!(both.tier(), Some(Tier::new("region/sjc")));
+	fn auth_api_response_tier() {
+		let named: AuthApiResponse = serde_json::from_str(r#"{"tier":"region/sjc"}"#).unwrap();
+		assert_eq!(named.tier(), Some(Tier::new("region/sjc")));
 
-		// Legacy `internal: false` demotes to the default (unprefixed) tier.
-		let legacy_false: AuthApiResponse = serde_json::from_str(r#"{"internal":false}"#).unwrap();
-		assert_eq!(legacy_false.tier(), Some(Tier::default()));
+		let default: AuthApiResponse = serde_json::from_str(r#"{"tier":""}"#).unwrap();
+		assert_eq!(default.tier(), Some(Tier::default()));
 
-		// Neither field present: the relay applies its per-connection default.
 		let neither: AuthApiResponse = serde_json::from_str(r#"{}"#).unwrap();
 		assert_eq!(neither.tier(), None);
 	}
@@ -3260,8 +3212,8 @@ api = "https://api.example.com/access"
 
 	#[tokio::test]
 	async fn auth_api_mtls_resolves_alias_and_tier() -> anyhow::Result<()> {
-		// mTLS peers get the canonical root + tier; absent `tier` defaults to
-		// `internal` (trusted peer).
+		// mTLS peers get the canonical root + tier; absent `tier` uses the
+		// configured default.
 		let server = MockServer::start().await;
 		Mock::given(method("GET"))
 			.and(path_matcher("/auth"))
@@ -3273,27 +3225,26 @@ api = "https://api.example.com/access"
 		let auth = auth_with_api(&server).await;
 		assert_eq!(
 			auth.resolve_mtls("/demo/room", None).await?,
-			("x7k2qp/room".to_string(), Tier::new("internal"))
+			("x7k2qp/room".to_string(), Tier::default())
 		);
 		Ok(())
 	}
 
 	#[tokio::test]
 	async fn auth_api_mtls_tier_override_default() -> anyhow::Result<()> {
-		// The API can move a cert-verified connection to the default (unprefixed)
-		// tier by returning an empty label.
+		// The API can move a cert-verified connection to a named tier.
 		let server = MockServer::start().await;
 		Mock::given(method("GET"))
 			.and(path_matcher("/auth"))
 			.and(query_param("root", "demo"))
-			.respond_with(ResponseTemplate::new(200).set_body_string(r#"{"alias":"x7k2qp","tier":""}"#))
+			.respond_with(ResponseTemplate::new(200).set_body_string(r#"{"alias":"x7k2qp","tier":"region"}"#))
 			.mount(&server)
 			.await;
 
 		let auth = auth_with_api(&server).await;
 		assert_eq!(
 			auth.resolve_mtls("/demo", None).await?,
-			("x7k2qp".to_string(), Tier::default())
+			("x7k2qp".to_string(), Tier::new("region"))
 		);
 		Ok(())
 	}
@@ -3321,7 +3272,7 @@ api = "https://api.example.com/access"
 	#[tokio::test]
 	async fn auth_api_mtls_no_api_fails_open() -> anyhow::Result<()> {
 		// With no auth API configured the cert is the only credential: use the path
-		// unchanged at the internal tier. This is the sole fail-open case. (A public
+		// and configured tier unchanged. This is the sole fail-open case. (A public
 		// path just makes the config valid; mTLS resolution ignores it.)
 		let auth = Auth::new(AuthConfig {
 			public: simple_public("anon"),
@@ -3330,12 +3281,9 @@ api = "https://api.example.com/access"
 		.await?;
 		assert_eq!(
 			auth.resolve_mtls("/demo", None).await?,
-			("/demo".to_string(), Tier::new("internal"))
+			("/demo".to_string(), Tier::default())
 		);
-		assert_eq!(
-			auth.resolve_mtls("/", None).await?,
-			("/".to_string(), Tier::new("internal"))
-		);
+		assert_eq!(auth.resolve_mtls("/", None).await?, ("/".to_string(), Tier::default()));
 		Ok(())
 	}
 

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -317,8 +317,7 @@ pub struct ClusterConfig {
 	pub token: Option<PathBuf>,
 
 	/// Billing tier label that cluster-peer (relay-to-relay) traffic records
-	/// stats under. Default `internal`. An empty value selects the default
-	/// (unprefixed) tier.
+	/// stats under. Defaults to the unprefixed tier.
 	#[arg(id = "cluster-tier", long = "cluster-tier", env = "MOQ_CLUSTER_TIER")]
 	pub tier: Option<String>,
 }
@@ -349,8 +348,8 @@ pub struct Cluster {
 
 	/// Stats registry. One instance per relay; sessions pick a billing tier via
 	/// [`stats::Registry::tier`](moq_net::stats::Registry::tier) at acceptance time
-	/// (default tier for JWT/public, `internal` for mTLS / cluster peers, or any label
-	/// the auth API returns) so traffic classes land in separate counter sets. Defaults
+	/// (the default tier unless configured otherwise, or any label the auth API
+	/// returns) so traffic classes land in separate counter sets. Defaults
 	/// to a disabled (no-op) registry until [`with_stats`](Self::with_stats) is called.
 	pub stats: moq_net::stats::Registry,
 }
@@ -427,10 +426,10 @@ impl Cluster {
 		self
 	}
 
-	/// Billing tier cluster-peer traffic records under (`--cluster-tier`,
-	/// default `internal`). An empty label is the default (unprefixed) tier.
+	/// Billing tier cluster-peer traffic records under (`--cluster-tier`).
+	/// An absent or empty label selects the default unprefixed tier.
 	fn cluster_tier(&self) -> Tier {
-		crate::trusted_tier(self.config.tier.clone())
+		crate::configured_tier(self.config.tier.clone())
 	}
 
 	/// Returns an [`origin::Producer`] scoped to this session's subscribe permissions.
@@ -879,7 +878,7 @@ impl Cluster {
 			.clone()
 			.context("internal: cluster peer dial without an attached QUIC client")?;
 
-		// Cluster-to-cluster traffic is internal by definition.
+		// Cluster dials use their configured stats tier.
 		let cs = client
 			.with_publisher(&self.origin)
 			.with_subscriber(self.origin.clone())
@@ -964,6 +963,19 @@ where
 mod tests {
 	use super::*;
 	use crate::Config;
+
+	#[test]
+	fn cluster_tier_defaults_to_unprefixed() {
+		let cluster = Cluster::new(ClusterConfig::default()).expect("cluster");
+		assert_eq!(cluster.cluster_tier(), Tier::default());
+
+		let cluster = Cluster::new(ClusterConfig {
+			tier: Some("region/sjc".to_string()),
+			..Default::default()
+		})
+		.expect("cluster");
+		assert_eq!(cluster.cluster_tier(), Tier::new("region/sjc"));
+	}
 
 	/// Stand-in dial task: never makes progress, exposes an AbortHandle.
 	fn placeholder_handle() -> AbortHandle {

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -83,9 +83,8 @@ impl Connection {
 			_ => unreachable!("authorized above guarantees at least one origin"),
 		}
 
-		// Record this session's stats under its billing tier (chosen by the auth
-		// API; mTLS peers and cluster nodes default to `internal`). The aggregator
-		// is shared; the tier picks which counter set the bumps land in.
+		// Record this session's stats under its billing tier. The aggregator is
+		// shared; the tier picks which counter set the bumps land in.
 		let stats = self.cluster.stats.tier(token.tier.clone());
 
 		// Count this session against its auth root for the whole connection,
@@ -169,7 +168,7 @@ impl Connection {
 					// Scope the grant to the canonical root. An mTLS publisher dialing a
 					// vanity alias lands on the same tree a JWT would; cluster peers dial
 					// "/", which the API resolves (typically to an unscoped root). The API
-					// also returns the billing tier (defaulting to internal for trusted peers).
+					// also returns the billing tier.
 					let mut token = self.auth.verify_mtls(&params.path, Some(transport)).await?;
 					// Close the session when the client certificate expires, mirroring
 					// the JWT `exp` handling. Validated once at the TLS handshake otherwise.

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -231,12 +231,12 @@ mod tests {
 		let _session = stats.tier(Tier::default()).session("acme");
 
 		// A second, named tier renders its own labeled rows.
-		let internal = stats
-			.tier(Tier::new("internal"))
+		let regional = stats
+			.tier(Tier::new("region/sjc"))
 			.broadcast("demo/x")
 			.subscriber()
 			.track("audio");
-		internal.bytes(56);
+		regional.bytes(56);
 
 		let body = render_metrics(&stats.snapshot());
 
@@ -249,7 +249,7 @@ mod tests {
 			"default-tier egress bytes (empty tier label):\n{body}"
 		);
 		assert!(
-			body.contains("moq_relay_bytes_total{tier=\"internal\",role=\"subscriber\"} 56"),
+			body.contains("moq_relay_bytes_total{tier=\"region/sjc\",role=\"subscriber\"} 56"),
 			"named tier gets its own row:\n{body}"
 		);
 		assert!(

--- a/rs/moq-relay/src/lib.rs
+++ b/rs/moq-relay/src/lib.rs
@@ -23,15 +23,10 @@ mod websocket;
 /// to handle many concurrent subscriptions across connections.
 pub const DEFAULT_MAX_STREAMS: u64 = 10_000;
 
-/// Default billing tier for trusted (non-JWT/public) connections when no label
-/// is configured, shared by the `--cluster-tier` / `--auth-mtls-tier` defaults.
-const DEFAULT_TRUSTED_TIER: &str = "internal";
-
-/// Resolve a configured tier label to a [`moq_net::stats::Tier`], defaulting to
-/// [`DEFAULT_TRUSTED_TIER`] when unset. An empty label selects the default
-/// (unprefixed) tier.
-fn trusted_tier(label: Option<String>) -> moq_net::stats::Tier {
-	moq_net::stats::Tier::new(label.unwrap_or_else(|| DEFAULT_TRUSTED_TIER.to_string()))
+/// Resolve an optional stats tier label. An absent or empty label selects the
+/// default unprefixed tier.
+fn configured_tier(label: Option<String>) -> moq_net::stats::Tier {
+	label.map(moq_net::stats::Tier::new).unwrap_or_default()
 }
 
 pub use auth::*;

--- a/rs/moq-stats/src/lib.rs
+++ b/rs/moq-stats/src/lib.rs
@@ -210,12 +210,15 @@ mod tests {
 
 	#[test]
 	fn track_names() {
-		let ext = Tier::default();
-		let int = Tier::new("internal");
-		assert_eq!(traffic_track(&ext, Role::Publisher, false), "publisher.json");
-		assert_eq!(traffic_track(&ext, Role::Subscriber, true), "subscriber.json.z");
-		assert_eq!(traffic_track(&int, Role::Publisher, false), "internal/publisher.json");
-		assert_eq!(sessions_track(&ext, false), "sessions.json");
-		assert_eq!(sessions_track(&int, true), "internal/sessions.json.z");
+		let default = Tier::default();
+		let regional = Tier::new("region/sjc");
+		assert_eq!(traffic_track(&default, Role::Publisher, false), "publisher.json");
+		assert_eq!(traffic_track(&default, Role::Subscriber, true), "subscriber.json.z");
+		assert_eq!(
+			traffic_track(&regional, Role::Publisher, false),
+			"region/sjc/publisher.json"
+		);
+		assert_eq!(sessions_track(&default, false), "sessions.json");
+		assert_eq!(sessions_track(&regional, true), "region/sjc/sessions.json.z");
 	}
 }

--- a/rs/moq-stats/src/produce.rs
+++ b/rs/moq-stats/src/produce.rs
@@ -735,7 +735,7 @@ mod tests {
 		let (producer, origin) = test_producer(Some("sjc"));
 		let _a = producer.registry().tier(Tier::default()).session("acme");
 		let _b = producer.registry().tier(Tier::default()).session("acme");
-		let _c = producer.registry().tier(Tier::new("internal")).session("peer");
+		let _c = producer.registry().tier(Tier::new("region/sjc")).session("peer");
 
 		drive_tick().await;
 
@@ -746,13 +746,13 @@ mod tests {
 		assert_eq!(snap.sessions_closed, 0);
 		assert!(
 			!frame.contains_key("peer"),
-			"internal session must not appear on the external track"
+			"regional session must not appear on the default track"
 		);
 
-		let snap = *read_session_frame(&broadcast, "internal/sessions.json")
+		let snap = *read_session_frame(&broadcast, "region/sjc/sessions.json")
 			.await
 			.get("peer")
-			.expect("internal entry");
+			.expect("regional entry");
 		assert_eq!(snap.sessions, 1);
 	}
 
@@ -787,10 +787,10 @@ mod tests {
 			assert!(broadcast.track(name).is_ok(), "{name} must exist");
 		}
 
-		// The internal tier never saw traffic, so its tracks were never created.
+		// The regional tier never saw traffic, so its tracks were never created.
 		// The announced broadcast is an origin-owned splice, so `track()` always
 		// hands back a logical track; only the subscription reveals absence.
-		for name in ["internal/publisher.json", "internal/publisher.json.z"] {
+		for name in ["region/sjc/publisher.json", "region/sjc/publisher.json.z"] {
 			let track = broadcast.track(name).expect("logical track");
 			assert!(
 				track.subscribe(None).await.is_err(),


### PR DESCRIPTION
## Summary

- make the empty label the canonical default stats tier for cluster and mTLS traffic
- remove the legacy auth API `internal` boolean and keep explicit named tiers through `tier`
- simplify the dev stats dashboard to subscribe to and render only the unprefixed tracks
- update relay documentation and regression coverage

The dashboard hard-coded both unprefixed and `internal/*` tracks while trusted connections were silently assigned to `internal`. That split made the dashboard depend on tier-specific tracks that may not exist and preserved two ways to express the same policy. The empty tier is already the wire convention for the default unprefixed tracks, so the relay and demo now use it consistently.

Fixes #2399.

## Public API changes

- Breaking: the default `moq_net::stats::Tier` now formats as an empty string instead of `external`.
- Breaking integration change: auth API responses must use `tier`; the legacy `internal` boolean no longer affects stats policy.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just ci origin/dev`
- open `http://localhost:5173/stats.html` against the local relay and confirm the dashboard connects without `internal/` or `spawn error` console messages

(Written by GPT-5)
