### PR TITLE
fix(net): support IETF PATH over native QUIC

### DIFF
--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -314,14 +314,15 @@ impl Client {
 		feature = "tcp",
 		feature = "uds"
 	))]
-	fn connect_client(&self, url: &Url) -> moq_net::Client {
+	fn connect_client(&self, url: &Url, versions: &moq_net::Versions) -> moq_net::Client {
+		let client = self.moq.clone().with_versions(versions.clone());
 		if transport_carries_path(url) {
-			return self.moq.clone();
+			return client;
 		}
 
 		match request_path(url) {
-			Some(path) => self.moq.clone().with_path(path),
-			None => self.moq.clone(),
+			Some(path) => client.with_path(path),
+			None => client,
 		}
 	}
 
@@ -335,15 +336,20 @@ impl Client {
 		feature = "uds"
 	))]
 	async fn connect_inner(&self, url: Url) -> crate::Result<moq_net::Session> {
+		let versions = scheme_versions(&self.versions, &url);
+		if versions.iter().next().is_none() {
+			return Err(moq_net::Error::Version.into());
+		}
+
 		// Advertise the request path in the moq SETUP for transports that carry no
 		// request URI of their own; WebTransport and WebSocket already convey it.
-		let moq = self.connect_client(&url);
+		let moq = self.connect_client(&url, &versions);
 
 		// Plain TCP (qmux, no TLS). Explicit opt-in scheme; never raced against
 		// QUIC, which can't speak it. Use only on a trusted network.
 		#[cfg(feature = "tcp")]
 		if url.scheme() == "tcp" {
-			let session = crate::tcp::connect(url, &self.versions.alpns()).await?;
+			let session = crate::tcp::connect(url, &versions.alpns()).await?;
 			return Ok(moq.connect(session).await?);
 		}
 
@@ -351,7 +357,7 @@ impl Client {
 		// authenticate us by uid/gid via SO_PEERCRED.
 		#[cfg(all(feature = "uds", unix))]
 		if url.scheme() == "unix" {
-			let session = crate::unix::connect(url, &self.versions.alpns()).await?;
+			let session = crate::unix::connect(url, &versions.alpns()).await?;
 			return Ok(moq.connect(session).await?);
 		}
 
@@ -367,11 +373,11 @@ impl Client {
 		if let Some(noq) = self.noq.as_ref() {
 			let tls = self.tls.clone();
 			let quic_url = url.clone();
-			let quic_handle = async { noq.connect(&tls, quic_url, &self.versions).await.map_err(Error::from) };
+			let quic_handle = async { noq.connect(&tls, quic_url, &versions).await.map_err(Error::from) };
 
 			#[cfg(feature = "websocket")]
 			{
-				return self.race_moq_connect(&moq, url, quic_handle).await;
+				return self.race_moq_connect(&moq, &versions, url, quic_handle).await;
 			}
 
 			#[cfg(not(feature = "websocket"))]
@@ -385,11 +391,11 @@ impl Client {
 		if let Some(quinn) = self.quinn.as_ref() {
 			let tls = self.tls.clone();
 			let quic_url = url.clone();
-			let quic_handle = async { quinn.connect(&tls, quic_url, &self.versions).await.map_err(Error::from) };
+			let quic_handle = async { quinn.connect(&tls, quic_url, &versions).await.map_err(Error::from) };
 
 			#[cfg(feature = "websocket")]
 			{
-				return self.race_moq_connect(&moq, url, quic_handle).await;
+				return self.race_moq_connect(&moq, &versions, url, quic_handle).await;
 			}
 
 			#[cfg(not(feature = "websocket"))]
@@ -402,11 +408,11 @@ impl Client {
 		#[cfg(feature = "quiche")]
 		if let Some(quiche) = self.quiche.as_ref() {
 			let quic_url = url.clone();
-			let quic_handle = async { quiche.connect(quic_url, &self.versions).await.map_err(Error::from) };
+			let quic_handle = async { quiche.connect(quic_url, &versions).await.map_err(Error::from) };
 
 			#[cfg(feature = "websocket")]
 			{
-				return self.race_moq_connect(&moq, url, quic_handle).await;
+				return self.race_moq_connect(&moq, &versions, url, quic_handle).await;
 			}
 
 			#[cfg(not(feature = "websocket"))]
@@ -418,7 +424,7 @@ impl Client {
 
 		#[cfg(feature = "websocket")]
 		{
-			let alpns = self.versions.alpns();
+			let alpns = versions.alpns();
 			let session = crate::websocket::connect(&self.websocket, &self.tls, url, &alpns).await?;
 			return Ok(moq.connect(session).await?);
 		}
@@ -428,12 +434,18 @@ impl Client {
 	}
 
 	#[cfg(feature = "websocket")]
-	async fn race_moq_connect<Q, S>(&self, moq: &moq_net::Client, url: Url, quic: Q) -> crate::Result<moq_net::Session>
+	async fn race_moq_connect<Q, S>(
+		&self,
+		moq: &moq_net::Client,
+		versions: &moq_net::Versions,
+		url: Url,
+		quic: Q,
+	) -> crate::Result<moq_net::Session>
 	where
 		Q: Future<Output = crate::Result<S>>,
 		S: web_transport_trait::Session,
 	{
-		let alpns = self.versions.alpns();
+		let alpns = versions.alpns();
 		let ws_config = self.websocket.clone();
 		let ws_tls = self.tls.clone();
 		let websocket = async move {
@@ -447,6 +459,25 @@ impl Client {
 			TransportRace::WebSocket(websocket) => Ok(moq.connect(websocket).await?),
 		}
 	}
+}
+
+/// Restrict raw QUIC to the protocol family named by its URL scheme.
+#[cfg(any(
+	feature = "noq",
+	feature = "quinn",
+	feature = "quiche",
+	feature = "iroh",
+	feature = "websocket",
+	feature = "tcp",
+	feature = "uds"
+))]
+fn scheme_versions(base: &moq_net::Versions, url: &Url) -> moq_net::Versions {
+	let versions = base.iter().copied().filter(|version| match url.scheme() {
+		"moqt" => version.is_ietf(),
+		"moql" => version.is_lite(),
+		_ => true,
+	});
+	moq_net::Versions::from(versions.collect::<Vec<_>>())
 }
 
 /// Whether the transport for this URL always conveys the request path itself.
@@ -485,13 +516,32 @@ fn transport_carries_path(url: &Url) -> bool {
 	feature = "uds"
 ))]
 fn request_path(url: &Url) -> Option<String> {
-	if let Some((_, path)) = url.query_pairs().find(|(key, _)| key == "path") {
-		return Some(path.into_owned());
+	let override_path = url
+		.query_pairs()
+		.find(|(key, _)| key == "path")
+		.map(|(_, path)| path.into_owned());
+
+	let mut path = match override_path {
+		Some(path) => path,
+		None if url.scheme() == "unix" => return None,
+		None => url.path().to_string(),
+	};
+
+	let query = if url.query_pairs().any(|(key, _)| key == "path") {
+		let mut query = url::form_urlencoded::Serializer::new(String::new());
+		for (key, value) in url.query_pairs().filter(|(key, _)| key != "path") {
+			query.append_pair(&key, &value);
+		}
+		query.finish()
+	} else {
+		url.query().unwrap_or_default().to_string()
+	};
+
+	if !query.is_empty() {
+		path.push('?');
+		path.push_str(&query);
 	}
-	match url.scheme() {
-		"unix" => None,
-		_ => Some(url.path().to_string()),
-	}
+	Some(path)
 }
 
 #[cfg(feature = "websocket")]
@@ -623,11 +673,37 @@ mod tests {
 		let uds = Url::parse("unix:///run/s.sock?path=/anycast").unwrap();
 		assert_eq!(uds.path(), "/run/s.sock");
 		assert_eq!(request_path(&uds).as_deref(), Some("/anycast"));
-		// ?path= overrides the URL path on any scheme.
+		// ?path= overrides the URL path on any scheme; other query parameters still
+		// ride with it because they are part of the IETF PATH option.
 		assert_eq!(
-			request_path(&Url::parse("tcp://h:1/ignored?path=/win").unwrap()).as_deref(),
-			Some("/win")
+			request_path(&Url::parse("tcp://h:1/ignored?path=/win&jwt=a%20b").unwrap()).as_deref(),
+			Some("/win?jwt=a+b")
 		);
+		assert_eq!(
+			request_path(&Url::parse("moqt://h/anon?jwt=a%20b").unwrap()).as_deref(),
+			Some("/anon?jwt=a%20b")
+		);
+	}
+
+	#[cfg(any(
+		feature = "noq",
+		feature = "quinn",
+		feature = "quiche",
+		feature = "iroh",
+		feature = "websocket",
+		feature = "tcp",
+		feature = "uds"
+	))]
+	#[test]
+	fn raw_quic_scheme_selects_protocol_family() {
+		let versions = moq_net::Versions::all();
+		let ietf = scheme_versions(&versions, &Url::parse("moqt://host/anon").unwrap());
+		assert!(ietf.iter().all(moq_net::Version::is_ietf));
+		assert!(ietf.iter().next().is_some());
+
+		let lite = scheme_versions(&versions, &Url::parse("moql://host/anon").unwrap());
+		assert!(lite.iter().all(moq_net::Version::is_lite));
+		assert!(lite.iter().next().is_some());
 	}
 
 	#[test]

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -521,9 +521,25 @@ impl Server {
 						let alpns = versions.alpns();
 						self.accept.push(async move {
 							let noq = super::noq::NoqRequest::accept(_conn, alpns).await?;
+							let url = noq.url().cloned();
+							let identity = noq.peer_identity();
+							if url.is_some() {
+								return Ok(Request {
+									server,
+									transport: "quic",
+									url,
+									identity,
+									kind: RequestKind::NoqPending(Box::new(noq)),
+								});
+							}
+							let session = noq.ok().await.map_err(crate::noq::Error::Server)?;
+							let request = server.accept_request(session).await?;
 							Ok(Request {
 								server,
-								kind: RequestKind::Noq(Box::new(noq)),
+								transport: "quic",
+								url,
+								identity,
+								kind: RequestKind::Noq(Box::new(request)),
 							})
 						}.boxed());
 					}
@@ -534,9 +550,25 @@ impl Server {
 						let alpns = versions.alpns();
 						self.accept.push(async move {
 							let quinn = super::quinn::QuinnRequest::accept(_conn, alpns).await?;
+							let url = quinn.url().cloned();
+							let identity = quinn.peer_identity();
+							if url.is_some() {
+								return Ok(Request {
+									server,
+									transport: "quic",
+									url,
+									identity,
+									kind: RequestKind::QuinnPending(Box::new(quinn)),
+								});
+							}
+							let session = quinn.ok().await.map_err(crate::quinn::Error::Server)?;
+							let request = server.accept_request(session).await?;
 							Ok(Request {
 								server,
-								kind: RequestKind::Quinn(Box::new(quinn)),
+								transport: "quic",
+								url,
+								identity,
+								kind: RequestKind::Quinn(Box::new(request)),
 							})
 						}.boxed());
 					}
@@ -547,9 +579,24 @@ impl Server {
 						let alpns = versions.alpns();
 						self.accept.push(async move {
 							let quiche = super::quiche::QuicheRequest::accept(_conn, alpns).await?;
+							let url = quiche.url().cloned();
+							if url.is_some() {
+								return Ok(Request {
+									server,
+									transport: "quic",
+									url,
+									identity: None,
+									kind: RequestKind::QuichePending(Box::new(quiche)),
+								});
+							}
+							let session = quiche.ok().await.map_err(crate::quiche::Error::Accept)?;
+							let request = server.accept_request(session).await?;
 							Ok(Request {
 								server,
-								kind: RequestKind::Quiche(Box::new(quiche)),
+								transport: "quic",
+								url,
+								identity: None,
+								kind: RequestKind::Quiche(Box::new(request)),
 							})
 						}.boxed());
 					}
@@ -558,9 +605,24 @@ impl Server {
 					#[cfg(feature = "iroh")]
 					self.accept.push(async move {
 						let iroh = super::iroh::Request::accept(_conn).await?;
+						let url = iroh.url().cloned();
+						if url.is_some() {
+							return Ok(Request {
+								server,
+								transport: "iroh",
+								url,
+								identity: None,
+								kind: RequestKind::IrohPending(Box::new(iroh)),
+							});
+						}
+						let session = iroh.ok().await.map_err(crate::iroh::Error::Server)?;
+						let request = server.accept_request(session).await?;
 						Ok(Request {
 							server,
-							kind: RequestKind::Iroh(Box::new(iroh)),
+							transport: "iroh",
+							url,
+							identity: None,
+							kind: RequestKind::Iroh(Box::new(request)),
 						})
 					}.boxed());
 				}
@@ -570,6 +632,9 @@ impl Server {
 						Ok(session) => {
 							return Some(Request {
 								server,
+								transport: "websocket",
+								url: None,
+								identity: None,
 								kind: RequestKind::WebSocket(Box::new(session)),
 							});
 						}
@@ -655,10 +720,10 @@ async fn serve_session(request: Request) -> crate::Result<()> {
 
 /// The version set offered on stream (`tcp://`/`unix://`) listeners.
 ///
-/// A URL-less transport carries the request path in the moq-lite-05 SETUP, the
-/// only version that expresses one, so it is offered on top of the configured
-/// versions even though it's work-in-progress (and thus absent from the default
-/// ALPN set). Older versions still work for clients that need no path.
+/// A URL-less transport carries the request path in SETUP. Configured IETF
+/// versions already support it; moq-lite-05 is offered on top of the configured
+/// versions even though it is work-in-progress and absent from the default ALPN
+/// set. Older lite versions still work for clients that need no path.
 #[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
 fn stream_versions(base: &moq_net::Versions) -> moq_net::Versions {
 	let mut versions: Vec<moq_net::Version> = base.iter().copied().collect();
@@ -828,7 +893,10 @@ fn spawn_stream_request(
 			Ok(request) => {
 				let request = Request {
 					server: moq_net::Server::new(),
-					kind: RequestKind::Stream(Box::new(StreamRequest { request, transport })),
+					transport,
+					url: None,
+					identity: None,
+					kind: RequestKind::Qmux(Box::new(request)),
 				};
 				let _ = tx.send(request).await;
 			}
@@ -837,278 +905,277 @@ fn spawn_stream_request(
 	});
 }
 
-/// A stream (`tcp://`/`unix://`) request: the moq SETUP has already been read so
-/// its in-band path is available for authorization before accepting.
-#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
-pub(crate) struct StreamRequest {
-	request: moq_net::Request<qmux::Session>,
-	transport: &'static str,
-}
-
 /// An incoming connection that can be accepted or rejected.
 pub(crate) enum RequestKind {
 	#[cfg(feature = "noq")]
-	Noq(Box<crate::noq::NoqRequest>),
+	Noq(Box<moq_net::Request<web_transport_noq::Session>>),
+	#[cfg(feature = "noq")]
+	NoqPending(Box<crate::noq::NoqRequest>),
 	#[cfg(feature = "quinn")]
-	Quinn(Box<crate::quinn::QuinnRequest>),
+	Quinn(Box<moq_net::Request<web_transport_quinn::Session>>),
+	#[cfg(feature = "quinn")]
+	QuinnPending(Box<crate::quinn::QuinnRequest>),
 	#[cfg(feature = "quiche")]
-	Quiche(Box<crate::quiche::QuicheRequest>),
+	Quiche(Box<moq_net::Request<web_transport_quiche::Connection>>),
+	#[cfg(feature = "quiche")]
+	QuichePending(Box<crate::quiche::QuicheRequest>),
 	#[cfg(feature = "iroh")]
-	Iroh(Box<crate::iroh::Request>),
+	Iroh(Box<moq_net::Request<web_transport_iroh::Session>>),
+	#[cfg(feature = "iroh")]
+	IrohPending(Box<crate::iroh::Request>),
 	#[cfg(feature = "websocket")]
 	WebSocket(Box<qmux::Session>),
-	#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
-	Stream(Box<StreamRequest>),
+	#[cfg(any(feature = "websocket", feature = "tcp", all(feature = "uds", unix)))]
+	Qmux(Box<moq_net::Request<qmux::Session>>),
 }
 
 /// An incoming MoQ session that can be accepted or rejected.
 ///
-/// [Self::with_publish] and [Self::with_consume] will configure what will be published and consumed from the session respectively.
-/// Otherwise, the Server's configuration is used by default.
+/// URL-less transports have already completed their transport handshake and
+/// exposed SETUP before this value is returned. URL-bearing WebTransport
+/// requests remain pending so [`Self::close`] can reject them with an HTTP status.
+/// [`Self::with_publish`] and [`Self::with_consume`] override the server defaults.
 pub struct Request {
 	server: moq_net::Server,
+	transport: &'static str,
+	url: Option<Url>,
+	identity: Option<crate::tls::PeerIdentity>,
 	kind: RequestKind,
 }
 
+macro_rules! request_ref {
+	($self:expr, $request:ident => $body:expr) => {
+		match &$self.kind {
+			#[cfg(feature = "noq")]
+			RequestKind::Noq($request) => $body,
+			#[cfg(feature = "noq")]
+			RequestKind::NoqPending(_) => None,
+			#[cfg(feature = "quinn")]
+			RequestKind::Quinn($request) => $body,
+			#[cfg(feature = "quinn")]
+			RequestKind::QuinnPending(_) => None,
+			#[cfg(feature = "quiche")]
+			RequestKind::Quiche($request) => $body,
+			#[cfg(feature = "quiche")]
+			RequestKind::QuichePending(_) => None,
+			#[cfg(feature = "iroh")]
+			RequestKind::Iroh($request) => $body,
+			#[cfg(feature = "iroh")]
+			RequestKind::IrohPending(_) => None,
+			#[cfg(feature = "websocket")]
+			RequestKind::WebSocket(_) => None,
+			#[cfg(any(feature = "websocket", feature = "tcp", all(feature = "uds", unix)))]
+			RequestKind::Qmux($request) => $body,
+		}
+	};
+}
+
+macro_rules! request_configure {
+	($server:expr, $kind:expr, $request:ident => $body:expr, $configure:ident($value:expr)) => {
+		match $kind {
+			#[cfg(feature = "noq")]
+			RequestKind::Noq($request) => ($server, RequestKind::Noq(Box::new($body))),
+			#[cfg(feature = "quinn")]
+			RequestKind::Quinn($request) => ($server, RequestKind::Quinn(Box::new($body))),
+			#[cfg(feature = "quiche")]
+			RequestKind::Quiche($request) => ($server, RequestKind::Quiche(Box::new($body))),
+			#[cfg(feature = "iroh")]
+			RequestKind::Iroh($request) => ($server, RequestKind::Iroh(Box::new($body))),
+			#[cfg(any(feature = "websocket", feature = "tcp", all(feature = "uds", unix)))]
+			RequestKind::Qmux($request) => ($server, RequestKind::Qmux(Box::new($body))),
+			kind => ($server.$configure($value), kind),
+		}
+	};
+}
+
 impl Request {
-	/// Reject the session, returning your favorite HTTP status code.
-	pub async fn close(self, _code: u16) -> crate::Result<()> {
+	/// Reject the session with an HTTP-style status code.
+	///
+	/// URL-bearing WebTransport requests are rejected before acceptance. Raw
+	/// transports have already been accepted so their SETUP path can be read; for
+	/// those, 401 and 403 map to MoQ Unauthorized and other values map to app codes.
+	pub async fn close(self, code: u16) -> crate::Result<()> {
+		let err = match code {
+			401 | 403 => moq_net::Error::Unauthorized,
+			other => moq_net::Error::App(other),
+		};
 		match self.kind {
 			#[cfg(feature = "noq")]
-			RequestKind::Noq(request) => {
+			RequestKind::Noq(request) => request.close(err),
+			#[cfg(feature = "noq")]
+			RequestKind::NoqPending(request) => {
 				let status =
-					web_transport_noq::http::StatusCode::from_u16(_code).map_err(|_| Error::InvalidStatusCode)?;
+					web_transport_noq::http::StatusCode::from_u16(code).map_err(|_| Error::InvalidStatusCode)?;
 				request.close(status).await.map_err(crate::noq::Error::Server)?;
-				Ok(())
 			}
 			#[cfg(feature = "quinn")]
-			RequestKind::Quinn(request) => {
+			RequestKind::Quinn(request) => request.close(err),
+			#[cfg(feature = "quinn")]
+			RequestKind::QuinnPending(request) => {
 				let status =
-					web_transport_quinn::http::StatusCode::from_u16(_code).map_err(|_| Error::InvalidStatusCode)?;
+					web_transport_quinn::http::StatusCode::from_u16(code).map_err(|_| Error::InvalidStatusCode)?;
 				request.close(status).await.map_err(crate::quinn::Error::Server)?;
-				Ok(())
 			}
 			#[cfg(feature = "quiche")]
-			RequestKind::Quiche(request) => {
+			RequestKind::Quiche(request) => request.close(err),
+			#[cfg(feature = "quiche")]
+			RequestKind::QuichePending(request) => {
 				let status =
-					web_transport_quiche::http::StatusCode::from_u16(_code).map_err(|_| Error::InvalidStatusCode)?;
+					web_transport_quiche::http::StatusCode::from_u16(code).map_err(|_| Error::InvalidStatusCode)?;
 				request.reject(status).await.map_err(crate::quiche::Error::Reject)?;
-				Ok(())
 			}
 			#[cfg(feature = "iroh")]
-			RequestKind::Iroh(request) => {
+			RequestKind::Iroh(request) => request.close(err),
+			#[cfg(feature = "iroh")]
+			RequestKind::IrohPending(request) => {
 				let status =
-					web_transport_iroh::http::StatusCode::from_u16(_code).map_err(|_| Error::InvalidStatusCode)?;
+					web_transport_iroh::http::StatusCode::from_u16(code).map_err(|_| Error::InvalidStatusCode)?;
 				request.close(status).await.map_err(crate::iroh::Error::Server)?;
-				Ok(())
 			}
 			#[cfg(feature = "websocket")]
-			RequestKind::WebSocket(_session) => {
-				// WebSocket doesn't support HTTP status codes; just drop to close.
-				Ok(())
-			}
-			#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
-			RequestKind::Stream(stream) => {
-				// A raw stream has no HTTP status; convey auth failures as the moq
-				// Unauthorized code, anything else as an app code.
-				let err = match _code {
-					401 | 403 => moq_net::Error::Unauthorized,
-					other => moq_net::Error::App(other),
-				};
-				stream.request.close(err);
-				Ok(())
-			}
+			RequestKind::WebSocket(_) => {}
+			#[cfg(any(feature = "websocket", feature = "tcp", all(feature = "uds", unix)))]
+			RequestKind::Qmux(request) => request.close(err),
 		}
+		Ok(())
 	}
 
 	/// Publish the given origin to the session.
 	pub fn with_publish(self, publish: impl Into<Option<moq_net::OriginConsumer>>) -> Self {
-		let Request { server, kind } = self;
-		match kind {
-			#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
-			RequestKind::Stream(stream) => {
-				let StreamRequest { request, transport } = *stream;
-				Request {
-					server,
-					kind: RequestKind::Stream(Box::new(StreamRequest {
-						request: request.with_publish(publish),
-						transport,
-					})),
-				}
-			}
-			kind => Request {
-				server: server.with_publish(publish),
-				kind,
-			},
+		let Request {
+			server,
+			transport,
+			url,
+			identity,
+			kind,
+		} = self;
+		let (server, kind) = request_configure!(
+			server,
+			kind,
+			request => request.with_publish(publish),
+			with_publish(publish)
+		);
+		Self {
+			server,
+			transport,
+			url,
+			identity,
+			kind,
 		}
 	}
 
 	/// Consume the given origin from the session.
 	pub fn with_consume(self, consume: impl Into<Option<moq_net::OriginProducer>>) -> Self {
-		let Request { server, kind } = self;
-		match kind {
-			#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
-			RequestKind::Stream(stream) => {
-				let StreamRequest { request, transport } = *stream;
-				Request {
-					server,
-					kind: RequestKind::Stream(Box::new(StreamRequest {
-						request: request.with_consume(consume),
-						transport,
-					})),
-				}
-			}
-			kind => Request {
-				server: server.with_consume(consume),
-				kind,
-			},
+		let Request {
+			server,
+			transport,
+			url,
+			identity,
+			kind,
+		} = self;
+		let (server, kind) = request_configure!(
+			server,
+			kind,
+			request => request.with_consume(consume),
+			with_consume(consume)
+		);
+		Self {
+			server,
+			transport,
+			url,
+			identity,
+			kind,
 		}
 	}
 
 	/// Attach a tier-scoped [`moq_net::StatsHandle`] to this session.
 	pub fn with_stats(self, stats: moq_net::StatsHandle) -> Self {
-		let Request { server, kind } = self;
-		match kind {
-			#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
-			RequestKind::Stream(stream) => {
-				let StreamRequest { request, transport } = *stream;
-				Request {
-					server,
-					kind: RequestKind::Stream(Box::new(StreamRequest {
-						request: request.with_stats(stats),
-						transport,
-					})),
-				}
-			}
-			kind => Request {
-				server: server.with_stats(stats),
-				kind,
-			},
+		let Request {
+			server,
+			transport,
+			url,
+			identity,
+			kind,
+		} = self;
+		let (server, kind) = request_configure!(
+			server,
+			kind,
+			request => request.with_stats(stats),
+			with_stats(stats)
+		);
+		Self {
+			server,
+			transport,
+			url,
+			identity,
+			kind,
 		}
 	}
 
-	/// Accept the session, performing rest of the MoQ handshake.
+	/// Accept the session, starting the MoQ session tasks.
 	pub async fn ok(self) -> crate::Result<Session> {
 		match self.kind {
 			#[cfg(feature = "noq")]
-			RequestKind::Noq(request) => Ok(self
+			RequestKind::Noq(request) => Ok(request.ok().await?),
+			#[cfg(feature = "noq")]
+			RequestKind::NoqPending(request) => Ok(self
 				.server
 				.accept(request.ok().await.map_err(crate::noq::Error::Server)?)
 				.await?),
 			#[cfg(feature = "quinn")]
-			RequestKind::Quinn(request) => Ok(self
+			RequestKind::Quinn(request) => Ok(request.ok().await?),
+			#[cfg(feature = "quinn")]
+			RequestKind::QuinnPending(request) => Ok(self
 				.server
 				.accept(request.ok().await.map_err(crate::quinn::Error::Server)?)
 				.await?),
 			#[cfg(feature = "quiche")]
-			RequestKind::Quiche(request) => {
-				let conn = request.ok().await.map_err(crate::quiche::Error::Accept)?;
-				Ok(self.server.accept(conn).await?)
+			RequestKind::Quiche(request) => Ok(request.ok().await?),
+			#[cfg(feature = "quiche")]
+			RequestKind::QuichePending(request) => {
+				let session = request.ok().await.map_err(crate::quiche::Error::Accept)?;
+				Ok(self.server.accept(session).await?)
 			}
 			#[cfg(feature = "iroh")]
-			RequestKind::Iroh(request) => Ok(self
+			RequestKind::Iroh(request) => Ok(request.ok().await?),
+			#[cfg(feature = "iroh")]
+			RequestKind::IrohPending(request) => Ok(self
 				.server
 				.accept(request.ok().await.map_err(crate::iroh::Error::Server)?)
 				.await?),
 			#[cfg(feature = "websocket")]
 			RequestKind::WebSocket(session) => Ok(self.server.accept(*session).await?),
-			#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
-			RequestKind::Stream(stream) => Ok(stream.request.ok().await?),
+			#[cfg(any(feature = "websocket", feature = "tcp", all(feature = "uds", unix)))]
+			RequestKind::Qmux(request) => Ok(request.ok().await?),
 		}
 	}
 
 	/// Returns the transport type as a string (e.g. "quic", "tcp", "unix").
 	pub fn transport(&self) -> &'static str {
-		match self.kind {
-			#[cfg(feature = "noq")]
-			RequestKind::Noq(_) => "quic",
-			#[cfg(feature = "quinn")]
-			RequestKind::Quinn(_) => "quic",
-			#[cfg(feature = "quiche")]
-			RequestKind::Quiche(_) => "quic",
-			#[cfg(feature = "iroh")]
-			RequestKind::Iroh(_) => "iroh",
-			#[cfg(feature = "websocket")]
-			RequestKind::WebSocket(_) => "websocket",
-			#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
-			RequestKind::Stream(ref stream) => stream.transport,
-		}
+		self.transport
 	}
 
 	/// Returns the URL provided by the client, for transports that carry one.
 	///
-	/// Stream transports (`tcp`/`unix`) are URL-less; use [`Self::path`] for their
-	/// in-band request path.
+	/// Raw QUIC, WebSocket, TCP, and Unix requests expose no URL here; use
+	/// [`Self::path`] for an in-band request path when the protocol provides one.
 	pub fn url(&self) -> Option<&Url> {
-		#[cfg(not(any(
-			feature = "noq",
-			feature = "quinn",
-			feature = "quiche",
-			feature = "iroh",
-			feature = "tcp",
-			all(feature = "uds", unix)
-		)))]
-		unreachable!("no transport compiled; enable a QUIC backend, tcp, or uds feature");
-
-		#[allow(unreachable_code)]
-		match self.kind {
-			#[cfg(feature = "noq")]
-			RequestKind::Noq(ref request) => request.url(),
-			#[cfg(feature = "quinn")]
-			RequestKind::Quinn(ref request) => request.url(),
-			#[cfg(feature = "quiche")]
-			RequestKind::Quiche(ref request) => request.url(),
-			#[cfg(feature = "iroh")]
-			RequestKind::Iroh(ref request) => request.url(),
-			#[cfg(feature = "websocket")]
-			RequestKind::WebSocket(_) => None,
-			#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
-			RequestKind::Stream(_) => None,
-		}
+		self.url.as_ref()
 	}
 
-	/// The in-band request path for stream transports (the moq-lite-05 SETUP
-	/// path), or `None` for URL-bearing transports (use [`Self::url`] there).
+	/// Returns the request path from SETUP, falling back to a transport URL path.
 	pub fn path(&self) -> Option<&str> {
-		match self.kind {
-			#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
-			RequestKind::Stream(ref stream) => stream.request.path(),
-			#[allow(unreachable_patterns)]
-			_ => None,
-		}
+		request_ref!(self, request => request.path()).or(self.url.as_ref().map(Url::path))
 	}
 
 	/// The client certificate chain the peer presented, if any, validated
 	/// against a configured [`crate::tls::Server::root`] during the handshake.
 	///
-	/// Only the Quinn and noq backends support mTLS; other backends always
-	/// return `None`. Use it to grant elevated access or to close the session
-	/// once the certificate expires (see [`crate::tls::PeerIdentity::expiry`]).
+	/// Only the Quinn and noq backends support mTLS; other backends return `None`.
+	/// Use it to grant elevated access or to close the session once the certificate
+	/// expires (see [`crate::tls::PeerIdentity::expiry`]).
 	pub fn peer_identity(&self) -> Option<crate::tls::PeerIdentity> {
-		match self.kind {
-			#[cfg(feature = "quinn")]
-			RequestKind::Quinn(ref request) => request.peer_identity(),
-			#[cfg(feature = "noq")]
-			RequestKind::Noq(ref request) => request.peer_identity(),
-			#[cfg(feature = "quiche")]
-			RequestKind::Quiche(_) => None,
-			#[cfg(feature = "iroh")]
-			RequestKind::Iroh(_) => None,
-			#[cfg(feature = "websocket")]
-			RequestKind::WebSocket(_) => None,
-			#[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
-			RequestKind::Stream(_) => None,
-			#[cfg(not(any(
-				feature = "noq",
-				feature = "quinn",
-				feature = "quiche",
-				feature = "iroh",
-				feature = "websocket",
-				feature = "tcp",
-				all(feature = "uds", unix)
-			)))]
-			_ => None,
-		}
+		self.identity.clone()
 	}
 
 	/// Whether the peer presented a valid client certificate during the handshake.

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -658,6 +658,7 @@ fn server_config(config: &Server, alpn: Vec<Vec<u8>>) -> Result<Arc<rustls::Serv
 /// certificate that chained to a configured [`Server::root`]. Owns the chain
 /// (leaf first) so callers can inspect it, e.g. [`expiry`](Self::expiry),
 /// without re-parsing the type-erased QUIC identity.
+#[derive(Clone)]
 pub struct PeerIdentity {
 	chain: Vec<CertificateDer<'static>>,
 }

--- a/rs/moq-native/tests/alpn.rs
+++ b/rs/moq-native/tests/alpn.rs
@@ -9,7 +9,7 @@
 //! request instead of TLS ALPN, but serves the same purpose.
 
 /// Spin up a server and client both restricted to the given version,
-/// and verify the handshake completes over raw QUIC (moqt:// URL).
+/// and verify the handshake completes over the matching raw QUIC scheme.
 async fn connect_with_version(version: &str) {
 	let version: moq_native::moq_net::Version = version.parse().expect("invalid version");
 
@@ -33,8 +33,9 @@ async fn connect_with_version(version: &str) {
 
 	let client = client_config.init().expect("failed to init client");
 
-	// Use raw QUIC URL so ALPN negotiation is direct (no WebTransport framing).
-	let url: url::Url = format!("moqt://localhost:{}", addr.port()).parse().unwrap();
+	// Use raw QUIC so ALPN negotiation is direct (no WebTransport framing).
+	let scheme = if version.is_lite() { "moql" } else { "moqt" };
+	let url: url::Url = format!("{scheme}://localhost:{}", addr.port()).parse().unwrap();
 
 	// Run server accept and client connect concurrently.
 	let server_handle = tokio::spawn(async move {

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -147,6 +147,56 @@ async fn connect_test(config: ConnectTest<'_>) {
 		.expect("server task failed");
 }
 
+/// Verify a raw QUIC client's IETF PATH option is available before the server
+/// accepts or rejects the paused MoQ request.
+#[cfg(any(feature = "quinn", feature = "noq"))]
+async fn ietf_path_test(backend: moq_native::QuicBackend) {
+	let version: moq_native::moq_net::Version = "moq-transport-19".parse().unwrap();
+
+	let mut server_config = moq_native::ServerConfig::default();
+	server_config.bind = Some("127.0.0.1:0".to_string());
+	server_config.tls.generate = vec!["localhost".into()];
+	server_config.backend = Some(backend.clone());
+	server_config.version = vec![version];
+	let mut server = server_config.init().expect("failed to init server");
+	let addr = server.local_addr().expect("failed to get local addr");
+
+	let mut client_config = moq_native::ClientConfig::default();
+	client_config.tls.disable_verify = Some(true);
+	client_config.backend = Some(backend);
+	client_config.bind = "127.0.0.1:0".parse().unwrap();
+	client_config.version = vec![version];
+	let client = client_config.init().expect("failed to init client");
+	let url = format!("moqt://localhost:{}/anon?jwt=test-token", addr.port())
+		.parse()
+		.unwrap();
+
+	let server_handle = tokio::spawn(async move {
+		let request = server.accept().await.expect("no incoming connection");
+		assert_eq!(request.url(), None, "raw QUIC must not synthesize a request URL");
+		assert_eq!(request.path(), Some("/anon?jwt=test-token"));
+		request.close(403).await.unwrap();
+	});
+
+	let _session = tokio::time::timeout(TIMEOUT, client.connect(url))
+		.await
+		.expect("client connect timed out")
+		.expect("client connect failed");
+	server_handle.await.expect("server task panicked");
+}
+
+#[cfg(feature = "quinn")]
+#[tokio::test]
+async fn quinn_raw_quic_ietf_path() {
+	ietf_path_test(moq_native::QuicBackend::Quinn).await;
+}
+
+#[cfg(feature = "noq")]
+#[tokio::test]
+async fn noq_raw_quic_ietf_path() {
+	ietf_path_test(moq_native::QuicBackend::Noq).await;
+}
+
 /// Generate a CA, a server cert + key, and a client cert + key (all PEM, the
 /// leaf certs signed by the CA) written to a tempdir. Returns the dir plus the
 /// five paths so the caller can wire them into the TLS configs.

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -5,7 +5,8 @@
 //! The client connects, receives the announcement, subscribes to the track,
 //! and verifies it receives the correct payload.
 //!
-//! This covers raw QUIC (moqt://) and WebTransport (https://) transports,
+//! This covers raw QUIC (`moqt://` for IETF, `moql://` for lite) and
+//! WebTransport (`https://`) transports,
 //! exercising every protocol version the library supports.
 
 use moq_native::moq_net::{self, Origin, Track};
@@ -115,24 +116,24 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 		.expect("server task failed");
 }
 
-// ── Raw QUIC (moqt://) – same version on both sides ─────────────────
+// ── Raw QUIC, same version on both sides ────────────────────────────
 
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_moq_lite_01() {
-	broadcast_test("moqt", Some("moq-lite-01"), Some("moq-lite-01")).await;
+	broadcast_test("moql", Some("moq-lite-01"), Some("moq-lite-01")).await;
 }
 
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_moq_lite_02() {
-	broadcast_test("moqt", Some("moq-lite-02"), Some("moq-lite-02")).await;
+	broadcast_test("moql", Some("moq-lite-02"), Some("moq-lite-02")).await;
 }
 
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_moq_lite_03() {
-	broadcast_test("moqt", Some("moq-lite-03"), Some("moq-lite-03")).await;
+	broadcast_test("moql", Some("moq-lite-03"), Some("moq-lite-03")).await;
 }
 
 #[tracing_test::traced_test]
@@ -176,19 +177,19 @@ async fn broadcast_moq_transport_19() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_negotiate_server_all_client_lite_01() {
-	broadcast_test("moqt", Some("moq-lite-01"), None).await;
+	broadcast_test("moql", Some("moq-lite-01"), None).await;
 }
 
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_negotiate_server_all_client_lite_02() {
-	broadcast_test("moqt", Some("moq-lite-02"), None).await;
+	broadcast_test("moql", Some("moq-lite-02"), None).await;
 }
 
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_negotiate_server_all_client_lite_03() {
-	broadcast_test("moqt", Some("moq-lite-03"), None).await;
+	broadcast_test("moql", Some("moq-lite-03"), None).await;
 }
 
 #[tracing_test::traced_test]
@@ -232,19 +233,19 @@ async fn broadcast_negotiate_server_all_client_transport_19() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_negotiate_client_all_server_lite_01() {
-	broadcast_test("moqt", None, Some("moq-lite-01")).await;
+	broadcast_test("moql", None, Some("moq-lite-01")).await;
 }
 
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_negotiate_client_all_server_lite_02() {
-	broadcast_test("moqt", None, Some("moq-lite-02")).await;
+	broadcast_test("moql", None, Some("moq-lite-02")).await;
 }
 
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_negotiate_client_all_server_lite_03() {
-	broadcast_test("moqt", None, Some("moq-lite-03")).await;
+	broadcast_test("moql", None, Some("moq-lite-03")).await;
 }
 
 #[tracing_test::traced_test]

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -51,13 +51,13 @@ impl Client {
 		self
 	}
 
-	/// Set the request path to advertise in the SETUP (moq-lite-05).
+	/// Set the request path to advertise in the SETUP.
 	///
 	/// Required on transports that carry no request URI (native QUIC, qmux over
 	/// TCP/TLS/UDS) so the server learns which path the client wants. Omit it on
-	/// bindings that already carry a URI (WebTransport). Ignored by versions with no
-	/// Setup stream (moq-lite-01 through 04). The value is normalized to an absolute
-	/// path (empty becomes `/`, a leading `/` is prepended).
+	/// bindings that already carry a URI (WebTransport). Supported by IETF
+	/// moq-transport and moq-lite-05; ignored by moq-lite-01 through 04. The value is
+	/// normalized to an absolute path (empty becomes `/`, a leading `/` is prepended).
 	pub fn with_path(mut self, path: impl Into<String>) -> Self {
 		let path = path.into();
 		self.path = Some(if path.is_empty() {
@@ -90,7 +90,9 @@ impl Client {
 					session.clone(),
 					None,
 					None,
+					None,
 					true,
+					self.path.clone(),
 					self.publish.clone(),
 					self.consume.clone(),
 					self.stats.clone(),
@@ -111,7 +113,9 @@ impl Client {
 					session.clone(),
 					None,
 					None,
+					None,
 					true,
+					self.path.clone(),
 					self.publish.clone(),
 					self.consume.clone(),
 					self.stats.clone(),
@@ -132,7 +136,9 @@ impl Client {
 					session.clone(),
 					None,
 					None,
+					None,
 					true,
+					self.path.clone(),
 					self.publish.clone(),
 					self.consume.clone(),
 					self.stats.clone(),
@@ -231,6 +237,9 @@ impl Client {
 		let ietf_encoding = ietf::Version::try_from(encoding).map_err(|_| Error::Version)?;
 
 		let mut parameters = ietf::Parameters::default();
+		if let Some(path) = &self.path {
+			parameters.set_bytes(ietf::ParameterBytes::Path, path.as_bytes().to_vec());
+		}
 		parameters.set_varint(ietf::ParameterVarInt::MaxRequestId, u32::MAX as u64);
 		parameters.set_bytes(ietf::ParameterBytes::Implementation, b"moq-lite-rs".to_vec());
 		let parameters = parameters.encode_bytes(ietf_encoding)?;
@@ -275,8 +284,10 @@ impl Client {
 				ietf::start(
 					session.clone(),
 					Some(stream),
+					None,
 					request_id_max,
 					true,
+					None,
 					self.publish.clone(),
 					self.consume.clone(),
 					self.stats.clone(),
@@ -523,5 +534,36 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn no_alpn_falls_back_to_draft14_and_switches_version_post_setup() {
 		run_alpn_lite_fallback_case(None).await;
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn legacy_ietf_setup_includes_path() {
+		for ietf_version in [ietf::Version::Draft14, ietf::Version::Draft15, ietf::Version::Draft16] {
+			let version = Version::Ietf(ietf_version);
+			let mut response = Vec::new();
+			setup::Server {
+				version: version.into(),
+				parameters: ietf::Parameters::default().encode_bytes(ietf_version).unwrap(),
+			}
+			.encode(&mut response, version)
+			.unwrap();
+
+			let fake = FakeSession::new(Some(version.alpn()), response);
+			Client::new()
+				.with_versions(version.into())
+				.with_path("/anon?jwt=token")
+				.connect(fake.clone())
+				.await
+				.unwrap();
+
+			let mut bytes = Bytes::from(fake.control_writes());
+			let mut setup = setup::Client::decode(&mut bytes, version).unwrap();
+			let parameters = ietf::Parameters::decode(&mut setup.parameters, ietf_version).unwrap();
+			assert_eq!(
+				parameters.get_bytes(ietf::ParameterBytes::Path),
+				Some(b"/anon?jwt=token".as_ref()),
+				"{ietf_version}"
+			);
+		}
 	}
 }

--- a/rs/moq-net/src/ietf/parameters.rs
+++ b/rs/moq-net/src/ietf/parameters.rs
@@ -211,8 +211,7 @@ impl Parameters {
 		self.vars.insert(kind, value);
 	}
 
-	#[cfg(test)]
-	pub fn get_bytes(&self, kind: ParameterBytes) -> Option<&[u8]> {
+	pub(crate) fn get_bytes(&self, kind: ParameterBytes) -> Option<&[u8]> {
 		self.bytes.get(&kind).map(|v| v.as_slice())
 	}
 

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -1,6 +1,6 @@
 use crate::{
 	Error, OriginConsumer, OriginProducer, StatsHandle,
-	coding::{Encode, Reader, Stream, Writer},
+	coding::{Decode, Encode, Reader, Stream, Writer},
 	ietf::{self, FetchHeader, RequestId},
 	setup,
 };
@@ -13,8 +13,10 @@ use super::{Control, Message, Publisher, Subscriber, Version, adapter::ControlSt
 pub fn start<S: web_transport_trait::Session>(
 	session: S,
 	setup: Option<Stream<S, Version>>,
+	peer_setup: Option<Reader<S::RecvStream, crate::Version>>,
 	request_id_max: Option<RequestId>,
 	client: bool,
+	path: Option<String>,
 	publish: Option<OriginConsumer>,
 	subscribe: Option<OriginProducer>,
 	// Tier-scoped stats handle. Pass [`StatsHandle::default`] to opt out.
@@ -40,7 +42,7 @@ pub fn start<S: web_transport_trait::Session>(
 
 				tokio::select! {
 					Err(err) = adapter.run(setup.reader, setup.writer, rx) => Err::<(), Error>(err),
-					Err(err) = run_unis(adapter.clone(), subscriber.clone(), version) => Err(err),
+					Err(err) = run_unis(adapter.clone(), subscriber.clone(), version, None) => Err(err),
 					Err(err) = run_dispatch(dispatch_session, publisher.clone(), subscriber.clone(), version) => Err(err),
 					Err(err) = publisher.run() => Err(err),
 					Err(err) = async {
@@ -69,7 +71,7 @@ pub fn start<S: web_transport_trait::Session>(
 				web_async::spawn({
 					let session = session.clone();
 					async move {
-						if let Err(err) = run_setup(session, version).await {
+						if let Err(err) = run_setup(session, version, path).await {
 							tracing::warn!(%err, "setup send error");
 						}
 					}
@@ -83,7 +85,7 @@ pub fn start<S: web_transport_trait::Session>(
 				let mut sub_ns = subscriber.clone();
 
 				tokio::select! {
-					Err(err) = run_unis(session.clone(), subscriber.clone(), version) => Err(err),
+					Err(err) = run_unis(session.clone(), subscriber.clone(), version, peer_setup) => Err(err),
 					Err(err) = run_dispatch(session.clone(), publisher.clone(), subscriber.clone(), version) => Err(err),
 					Err(err) = publisher.run() => Err(err),
 					Err(err) = async {
@@ -120,13 +122,20 @@ pub fn start<S: web_transport_trait::Session>(
 }
 
 /// Send our SETUP on a uni stream and keep it alive for potential GOAWAY.
-async fn run_setup<S: web_transport_trait::Session>(session: S, version: Version) -> Result<(), Error> {
+async fn run_setup<S: web_transport_trait::Session>(
+	session: S,
+	version: Version,
+	path: Option<String>,
+) -> Result<(), Error> {
 	let outer_version = crate::Version::Ietf(version);
 
 	let send = session.open_uni().await.map_err(Error::from_transport)?;
 	let mut writer: Writer<S::SendStream, crate::Version> = Writer::new(send, outer_version);
 
 	let mut parameters = ietf::Parameters::default();
+	if let Some(path) = path {
+		parameters.set_bytes(ietf::ParameterBytes::Path, path.into_bytes());
+	}
 	parameters.set_bytes(ietf::ParameterBytes::Implementation, b"moq-lite-rs".to_vec());
 	let parameters = parameters.encode_bytes(version)?;
 
@@ -139,6 +148,33 @@ async fn run_setup<S: web_transport_trait::Session>(session: S, version: Version
 	Ok(())
 }
 
+/// Read the peer's draft-17+ SETUP before the session starts.
+///
+/// The returned reader remains positioned after SETUP so the session can continue
+/// monitoring the same control stream for GOAWAY.
+pub(crate) async fn accept_setup<S: web_transport_trait::Session>(
+	session: &S,
+	version: Version,
+) -> Result<(ietf::Parameters, Reader<S::RecvStream, crate::Version>), Error> {
+	let outer_version = crate::Version::Ietf(version);
+
+	loop {
+		let recv = session.accept_uni().await.map_err(Error::from_transport)?;
+		let mut reader = Reader::new(recv, outer_version);
+		let kind: u64 = reader.decode_peek().await?;
+
+		if kind != setup::SETUP_V17 {
+			// Nothing may be served before the request path has been authorized.
+			reader.abort(&Error::Cancel);
+			continue;
+		}
+
+		let mut setup = reader.decode::<setup::Setup>().await?;
+		let parameters = ietf::Parameters::decode(&mut setup.parameters, version)?;
+		return Ok((parameters, reader));
+	}
+}
+
 /// Accept incoming uni streams and dispatch each to a handler.
 ///
 /// For v17, this also handles the SETUP stream (0x2F00) and GOAWAY.
@@ -147,8 +183,17 @@ async fn run_unis<S: web_transport_trait::Session>(
 	session: S,
 	subscriber: Subscriber<S>,
 	version: Version,
+	peer_setup: Option<Reader<S::RecvStream, crate::Version>>,
 ) -> Result<(), Error> {
 	let outer_version = crate::Version::Ietf(version);
+
+	if let Some(reader) = peer_setup {
+		web_async::spawn(async move {
+			if let Err(err) = run_goaway(reader.with_version(version), version).await {
+				tracing::warn!(%err, "goaway error");
+			}
+		});
+	}
 
 	loop {
 		let recv = session.accept_uni().await.map_err(Error::from_transport)?;

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -67,13 +67,13 @@ impl Server {
 	/// serve, and call [`ok`](Request::ok) or [`close`](Request::close). Starting the
 	/// session is deferred to `ok()`, so origins set on the `Request` take effect.
 	///
-	/// The path is surfaced for moq-lite-05; it is `None` on versions with no in-band
-	/// request path (lite 01-04, and the IETF drafts in this build).
+	/// The path is surfaced for IETF moq-transport and moq-lite-05; it is `None` on
+	/// moq-lite-01 through 04.
 	pub async fn accept_request<S: web_transport_trait::Session>(&self, session: S) -> Result<Request<S>, Error> {
 		// Regimes without an in-band path defer to `ok()` without surfacing one.
-		let deferred = |handshake| Request {
+		let deferred = |path, handshake| Request {
 			server: self.clone(),
-			path: None,
+			path,
 			handshake,
 		};
 
@@ -82,28 +82,43 @@ impl Server {
 				self.versions
 					.select(Version::Ietf(ietf::Version::Draft19))
 					.ok_or(Error::Version)?;
-				return Ok(deferred(Handshake::IetfModern {
-					session,
-					version: ietf::Version::Draft19,
-				}));
+				let (parameters, setup) = ietf::accept_setup(&session, ietf::Version::Draft19).await?;
+				return Ok(deferred(
+					ietf_path(&parameters)?,
+					Handshake::IetfModern {
+						session,
+						version: ietf::Version::Draft19,
+						setup,
+					},
+				));
 			}
 			Some(ALPN_18) => {
 				self.versions
 					.select(Version::Ietf(ietf::Version::Draft18))
 					.ok_or(Error::Version)?;
-				return Ok(deferred(Handshake::IetfModern {
-					session,
-					version: ietf::Version::Draft18,
-				}));
+				let (parameters, setup) = ietf::accept_setup(&session, ietf::Version::Draft18).await?;
+				return Ok(deferred(
+					ietf_path(&parameters)?,
+					Handshake::IetfModern {
+						session,
+						version: ietf::Version::Draft18,
+						setup,
+					},
+				));
 			}
 			Some(ALPN_17) => {
 				self.versions
 					.select(Version::Ietf(ietf::Version::Draft17))
 					.ok_or(Error::Version)?;
-				return Ok(deferred(Handshake::IetfModern {
-					session,
-					version: ietf::Version::Draft17,
-				}));
+				let (parameters, setup) = ietf::accept_setup(&session, ietf::Version::Draft17).await?;
+				return Ok(deferred(
+					ietf_path(&parameters)?,
+					Handshake::IetfModern {
+						session,
+						version: ietf::Version::Draft17,
+						setup,
+					},
+				));
 			}
 			Some(ALPN_16) => {
 				let v = self
@@ -144,19 +159,25 @@ impl Server {
 				self.versions
 					.select(Version::Lite(lite::Version::Lite04))
 					.ok_or(Error::Version)?;
-				return Ok(deferred(Handshake::LiteBare {
-					session,
-					version: lite::Version::Lite04,
-				}));
+				return Ok(deferred(
+					None,
+					Handshake::LiteBare {
+						session,
+						version: lite::Version::Lite04,
+					},
+				));
 			}
 			Some(ALPN_LITE_03) => {
 				self.versions
 					.select(Version::Lite(lite::Version::Lite03))
 					.ok_or(Error::Version)?;
-				return Ok(deferred(Handshake::LiteBare {
-					session,
-					version: lite::Version::Lite03,
-				}));
+				return Ok(deferred(
+					None,
+					Handshake::LiteBare {
+						session,
+						version: lite::Version::Lite03,
+					},
+				));
 			}
 			Some(ALPN_LITE) | None => {
 				let supported = self.versions.filter(&NEGOTIATED.into()).ok_or(Error::Version)?;
@@ -179,23 +200,42 @@ impl Server {
 
 		// Pull the max request ID out now (IETF only) so `ok()` doesn't re-decode the
 		// consumed parameters.
-		let request_id_max = match version {
+		let (request_id_max, path) = match version {
 			Version::Ietf(v) => {
 				let params = ietf::Parameters::decode(&mut client.parameters, v)?;
-				params
-					.get_varint(ietf::ParameterVarInt::MaxRequestId)
-					.map(ietf::RequestId)
+				(
+					params
+						.get_varint(ietf::ParameterVarInt::MaxRequestId)
+						.map(ietf::RequestId),
+					ietf_path(&params)?,
+				)
 			}
-			Version::Lite(_) => None,
+			Version::Lite(_) => (None, None),
 		};
 
-		Ok(deferred(Handshake::Legacy {
-			session,
-			stream,
-			version,
-			request_id_max,
-		}))
+		Ok(deferred(
+			path,
+			Handshake::Legacy {
+				session,
+				stream,
+				version,
+				request_id_max,
+			},
+		))
 	}
+}
+
+fn ietf_path(parameters: &ietf::Parameters) -> Result<Option<String>, Error> {
+	let Some(path) = parameters.get_bytes(ietf::ParameterBytes::Path) else {
+		return Ok(None);
+	};
+
+	let path = std::str::from_utf8(path).map_err(|_| Error::ProtocolViolation)?;
+	if !path.is_empty() && !path.starts_with('/') && !path.starts_with('?') {
+		return Err(Error::ProtocolViolation);
+	}
+
+	Ok(Some(path.to_string()))
 }
 
 /// A paused server-side handshake.
@@ -213,8 +253,12 @@ pub struct Request<S: web_transport_trait::Session> {
 /// The handshake state captured at the pause point. Every variant defers its session
 /// start to [`Request::ok`] so origins set on the `Request` still apply.
 enum Handshake<S: web_transport_trait::Session> {
-	/// Modern IETF (17/18): SETUP is exchanged in the background by the session.
-	IetfModern { session: S, version: ietf::Version },
+	/// Modern IETF (17+): the client's SETUP has already been read.
+	IetfModern {
+		session: S,
+		version: ietf::Version,
+		setup: crate::coding::Reader<S::RecvStream, Version>,
+	},
 	/// moq-lite 03/04: no Setup stream.
 	LiteBare { session: S, version: lite::Version },
 	/// moq-lite 05+: the client's Setup stream has already been read.
@@ -232,7 +276,8 @@ enum Handshake<S: web_transport_trait::Session> {
 impl<S: web_transport_trait::Session> Request<S> {
 	/// The request path the client advertised in its SETUP, if any.
 	///
-	/// Populated for moq-lite-05; `None` on versions without an in-band request path.
+	/// Populated for IETF moq-transport and moq-lite-05; `None` on versions without
+	/// an in-band request path.
 	/// See the note on [`Server::accept_request`].
 	pub fn path(&self) -> Option<&str> {
 		self.path.as_deref()
@@ -268,12 +313,18 @@ impl<S: web_transport_trait::Session> Request<S> {
 		}
 
 		let (session, mut stream, version, request_id_max) = match self.handshake {
-			Handshake::IetfModern { session, version } => {
+			Handshake::IetfModern {
+				session,
+				version,
+				setup,
+			} => {
 				ietf::start(
 					session.clone(),
 					None,
+					Some(setup),
 					None,
 					false,
+					None,
 					server.publish,
 					server.consume,
 					server.stats,
@@ -351,8 +402,10 @@ impl<S: web_transport_trait::Session> Request<S> {
 				ietf::start(
 					session.clone(),
 					Some(stream),
+					None,
 					request_id_max,
 					false,
+					None,
 					server.publish,
 					server.consume,
 					server.stats,
@@ -518,6 +571,21 @@ mod tests {
 		buf
 	}
 
+	fn ietf_setup(version: ietf::Version, path: Option<&str>) -> Vec<u8> {
+		let mut parameters = ietf::Parameters::default();
+		if let Some(path) = path {
+			parameters.set_bytes(ietf::ParameterBytes::Path, path.as_bytes().to_vec());
+		}
+
+		let mut buf = Vec::new();
+		setup::Setup {
+			parameters: parameters.encode_bytes(version).unwrap(),
+		}
+		.encode(&mut buf, Version::Ietf(version))
+		.unwrap();
+		buf
+	}
+
 	#[tokio::test(start_paused = true)]
 	async fn accept_request_reads_lite05_path() {
 		let session = FakeSession::new(ALPN_LITE_05_WIP, [lite05_setup(Some("/team/room"))]);
@@ -551,5 +619,21 @@ mod tests {
 			.await
 			.unwrap();
 		assert_eq!(request.path(), Some("/team/room"));
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn accept_request_reads_modern_ietf_path() {
+		for version in [ietf::Version::Draft17, ietf::Version::Draft18, ietf::Version::Draft19] {
+			let session = FakeSession::new(
+				Version::Ietf(version).alpn(),
+				[ietf_setup(version, Some("/anon?jwt=token"))],
+			);
+			let request = Server::new()
+				.with_versions(Version::Ietf(version).into())
+				.accept_request(session)
+				.await
+				.unwrap();
+			assert_eq!(request.path(), Some("/anon?jwt=token"), "{version}");
+		}
 	}
 }

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -122,13 +122,13 @@ impl Connection {
 	///
 	/// Every transport goes through the same authenticator; only the source of
 	/// the path + JWT differs:
-	/// - URL-bearing transports (QUIC, WebSocket) take it from the request URL,
-	///   and a valid mTLS client certificate (QUIC only) stands in for a JWT,
+	/// - URL-bearing WebTransport requests take it from the request URL, and a
+	///   valid mTLS client certificate stands in for a JWT,
 	///   granting full access within the URL path's root.
-	/// - Stream transports (`tcp`/`unix`) take the path + `?jwt=` from the
-	///   moq-lite-05 SETUP. A no-JWT connection resolves anonymous/public access
-	///   for its path exactly like a tokenless QUIC client (`--auth-public`).
-	///   Unix peer-credential gating happens earlier, in the listener.
+	/// - URL-less transports (raw QUIC, `tcp`, and `unix`) take the path + `?jwt=`
+	///   from SETUP. A no-JWT connection resolves anonymous/public access for its
+	///   path exactly like a tokenless WebTransport client (`--auth-public`). Unix
+	///   peer-credential gating happens earlier, in the listener.
 	async fn authenticate(&self) -> Result<AuthToken, StatusError> {
 		let params = match self.request.url() {
 			// URL-bearing transports: mTLS (QUIC only) can stand in for a JWT.
@@ -148,7 +148,7 @@ impl Connection {
 				}
 				params
 			}
-			// URL-less stream transports: path + `?jwt=` ride the SETUP.
+			// URL-less transports: path + `?jwt=` ride the SETUP.
 			None => AuthParams::from_path(self.request.path().unwrap_or("")),
 		};
 

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -407,6 +407,74 @@ async fn spawn_stream_relay(config: moq_native::ServerConfig) -> tokio::task::Jo
 	})
 }
 
+/// Stand up a raw-QUIC relay that grants anonymous access only below `/anon`.
+async fn spawn_ietf_quic_relay() -> (u16, tokio::task::JoinHandle<()>) {
+	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+	let mut server_config = moq_native::ServerConfig::default();
+	server_config.bind = Some("127.0.0.1:0".to_string());
+	server_config.tls.generate = vec!["localhost".into()];
+	let mut server = server_config.init().expect("server init");
+	let port = server.local_addr().expect("local addr").port();
+
+	#[allow(deprecated)]
+	let public = PublicConfig::Simple(vec!["anon".to_string()]);
+	let mut auth_config = AuthConfig::default();
+	auth_config.public = Some(public);
+	let auth = auth_config
+		.init(&moq_native::tls::Client::default())
+		.await
+		.expect("auth init");
+	let cluster = Cluster::new(ClusterConfig::default()).expect("cluster init");
+
+	let handle = tokio::spawn(async move {
+		let mut id = 0;
+		while let Some(request) = server.accept().await {
+			let connection = Connection {
+				id,
+				request,
+				cluster: cluster.clone(),
+				auth: auth.clone(),
+			};
+			id += 1;
+			tokio::spawn(async move {
+				let _ = connection.run().await;
+			});
+		}
+	});
+
+	(port, handle)
+}
+
+/// A raw-QUIC IETF client must stay connected when `/anon` is granted publicly.
+/// This fails if relay authorization runs before the server reads PATH from SETUP.
+#[tokio::test]
+async fn ietf_raw_quic_uses_path_for_anonymous_auth() {
+	let (port, relay) = spawn_ietf_quic_relay().await;
+
+	let mut config = moq_native::ClientConfig::default();
+	config.tls.disable_verify = Some(true);
+	config.bind = "127.0.0.1:0".parse().unwrap();
+	let origin = Origin::random().produce();
+	let session = config
+		.init()
+		.expect("client init")
+		.with_consume(origin)
+		.connect(format!("moqt://localhost:{port}/anon").parse().unwrap())
+		.await
+		.expect("client connect");
+
+	assert!(
+		tokio::time::timeout(Duration::from_millis(500), session.closed())
+			.await
+			.is_err(),
+		"relay rejected the anonymous IETF session"
+	);
+
+	drop(session);
+	relay.abort();
+}
+
 /// Stand up the relay listening only on a plain-TCP qmux `--server-bind` on a
 /// free loopback port, with fully public auth (no-JWT => whole root). Returns
 /// the port and an abort handle.


### PR DESCRIPTION
## Summary

- Send the IETF PATH setup parameter for drafts 14 through 19 and expose it before server authorization.
- Accept URL-less native QUIC far enough to read SETUP while leaving URL-bearing WebTransport pending so HTTP rejection semantics stay intact.
- Restrict `moqt://` and `moql://` to their documented protocol families and preserve URL query parameters such as `?jwt=` in PATH.

## Root cause

Native raw QUIC has no request URL, but `moq_native::Server` returned its request before `moq_net` read SETUP. Relay authentication therefore received an empty path and rejected connections such as `/anon`. The default `moqt://` version offer could also negotiate a lite version without an in-band PATH.

## Public API changes

- No new or breaking public API.
- `moq_net::Client::with_path` and `moq_native::Request::path` now cover IETF native QUIC as documented behavior.

## Test plan

- `just check`
- `cargo test -p moq-net --all-features`
- `cargo test -p moq-native --all-features --test alpn`
- `cargo test -p moq-native --all-features --test broadcast`
- `cargo test -p moq-native --all-features --test backend raw_quic_ietf_path`
- `cargo test -p moq-relay --test smoke ietf_raw_quic_uses_path_for_anonymous_auth`

No JS or draft update is needed. WebTransport must continue carrying its path in the transport request, and this implements the existing IETF PATH wire definition rather than changing it.

(Written by GPT-5)
