### PR TITLE
feat(net)!: accept an empty PATH and default it to "" across protocols

### DIFF
--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -318,8 +318,8 @@ moq --client-connect "unix:///run/moq/internal.sock/?jwt=$TOKEN" --broadcast my-
 Stream transports are native-only: browsers can't open raw TCP or Unix sockets,
 so the JS client doesn't support them. The plain-stream path has no TLS ALPN, so
 the MoQ version is negotiated in-band via qmux and the exact version is agreed up
-front (the listener offers moq-lite-05, the only version that carries a request
-path in-band, so a JWT/path can ride the SETUP).
+front. The negotiated version carries the request path in its SETUP (moq-lite-05
+and the moq-transport drafts both do), so a JWT/path can ride it.
 
 ## Example Configurations
 

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -1128,6 +1128,7 @@ The `Message Length` describes the payload size on the wire.
 # Appendix A: Changelog
 
 ## moq-lite-06
+- Allowed an empty SETUP `Path` parameter, equivalent to omitting it; both request the server's default path. Previously an empty value was a protocol violation, which made the two ways of asking for the default disagree.
 - Corrected SUBSCRIBE_END `Group` to an exclusive bound: the first sequence that will never be delivered, with 0 meaning no groups were produced. It was previously specified as the inclusive last group, which could not distinguish an empty track from one whose only group was 0.
 - Split ANNOUNCE_BROADCAST into three typed messages: ANNOUNCE_START (0x0), ANNOUNCE_END (0x1), and ANNOUNCE_RESTART (0x2), each prefixed with a Type discriminator like the subscribe stream's responses.
 - Added implicit Announce IDs: each ANNOUNCE_START assigns the next per-stream ordinal.

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -621,15 +621,17 @@ The Path Parameter carries the request path the client wishes to reach, equivale
 A server uses it to route the session to the correct origin, relay, or virtual host before any broadcasts are exchanged; its interpretation is otherwise application-defined and opaque to moq-lite.
 Unlike the capability-style Setup Parameters, it is per-hop setup metadata that rides along in SETUP because that is the first client-to-server message of the session.
 
-The Parameter Value is a non-empty UTF-8 string that begins with `/` and uses the path syntax of a URI [RFC3986].
+The Parameter Value is a UTF-8 string using the path syntax of a URI [RFC3986]; a non-empty value begins with `/`.
+The value MAY be empty, which is equivalent to omitting the parameter: both mean the client requests the server's default path.
+A client that wants the default therefore need not special-case the parameter, and a server MUST treat the two forms identically.
 
 This parameter exists for bindings that have no request URI of their own: the native QUIC binding (binding 1 in [Transports](#transports)) and the Qmux-over-TCP/TLS binding (binding 3), both of which negotiate only an ALPN token.
 The remaining bindings convey the path in their own handshake.
 
-- A client using a binding without a request URI (binding 1 or 3) MUST send exactly one Path Parameter in its SETUP.
+- A client using a binding without a request URI (binding 1 or 3) SHOULD send one Path Parameter in its SETUP. Omitting it requests the server's default path.
 - The Path Parameter MUST NOT be sent on a binding that carries a request URI. The WebTransport (binding 2) and Qmux-over-WebSocket (binding 4) bindings convey the path in their handshake URI (the CONNECT request path and the WebSocket request URI, respectively). A server that receives a Path Parameter on either of these bindings MUST close the session with a PROTOCOL_VIOLATION.
 - A server MUST NOT send a Path Parameter. SETUP is bidirectional, but the path is meaningful only from client to server; a client that receives a Path Parameter MUST close the session with a PROTOCOL_VIOLATION.
-- A server that receives a Path that is empty or is not a valid URI path MUST close the session with a PROTOCOL_VIOLATION. A server that does not recognize or support the requested path MUST close the session.
+- A server that receives a Path that is not a valid URI path MUST close the session with a PROTOCOL_VIOLATION. A server that does not recognize or support the requested path MUST close the session.
 
 A relay MUST NOT forward the Path Parameter; like other per-hop setup metadata it applies only to this hop (see [Session](#session)).
 

--- a/js/net/src/lite/setup.test.ts
+++ b/js/net/src/lite/setup.test.ts
@@ -134,6 +134,8 @@ test("SETUP decode is rejected before draft-05", async () => {
 	await expect(Setup.decode(new Reader(undefined, framed), Version.DRAFT_04)).rejects.toThrow();
 });
 
-test("empty path is rejected on decode", async () => {
-	await expect(decodeParam(PARAM_PATH, new Uint8Array())).rejects.toThrow();
+test("empty path decodes as the root", async () => {
+	// Valid on the wire and equivalent to omitting the parameter.
+	const got = await decodeParam(PARAM_PATH, new Uint8Array());
+	expect(got.path).toBe("");
 });

--- a/js/net/src/lite/setup.ts
+++ b/js/net/src/lite/setup.ts
@@ -181,8 +181,9 @@ export class Setup {
 
 	/**
 	 * The request path, for transports that carry no request URI (native QUIC, qmux over
-	 * TCP/TLS). Sent only by the client; a server never sends one and a relay never forwards
-	 * it. `undefined` on URI-carrying bindings such as WebTransport.
+	 * TCP/TLS, unix sockets). Sent only by the client; a server never sends one and a relay
+	 * never forwards it. `undefined` on URI-carrying bindings such as WebTransport, where
+	 * sending one is a protocol violation. An empty string means the same as `undefined`.
 	 */
 	path?: string;
 
@@ -227,14 +228,10 @@ export class Setup {
 		const probeCode = params.getVarint(PARAM_PROBE);
 		const probe = probeCode === undefined ? ProbeLevel.None : probeFromCode(probeCode);
 
+		// An empty path is valid and means the same as omitting the parameter, so a
+		// client that wants the root doesn't have to special-case it.
 		const pathBytes = params.getBytes(PARAM_PATH);
-		let path: string | undefined;
-		if (pathBytes !== undefined) {
-			path = new TextDecoder().decode(pathBytes);
-			if (path.length === 0) {
-				throw new Error("empty path parameter");
-			}
-		}
+		const path = pathBytes === undefined ? undefined : new TextDecoder().decode(pathBytes);
 
 		const roleCode = params.getVarint(PARAM_ROLE);
 		const role = roleCode === undefined ? Role.Both : roleFromCode(roleCode);

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -458,20 +458,23 @@ impl Client {
 	}
 }
 
-/// The resource path to advertise in the lite-05 SETUP, derived from the dial URL.
+/// The resource path to advertise in the SETUP, derived from the dial URL.
 ///
 /// When `path_is_address` (Unix sockets, whose URL path is the socket file), the
 /// resource path rides in the `?path=` query; otherwise the URL path is it.
 #[cfg(any(feature = "tcp", feature = "uds"))]
 fn setup_path(url: &Url, path_is_address: bool) -> Option<String> {
-	if path_is_address {
+	let path = if path_is_address {
 		url.query_pairs()
 			.find(|(k, _)| k == "path")
 			.map(|(_, v)| v.into_owned())
 	} else {
-		let path = url.path();
-		(!path.is_empty()).then(|| path.to_string())
-	}
+		Some(url.path().to_string())
+	};
+
+	// An empty path means the same as omitting the parameter, so send neither. A peer
+	// on published lite-05 rejects an empty value outright, and `?path=` yields one.
+	path.filter(|path| !path.is_empty())
 }
 
 #[cfg(feature = "websocket")]
@@ -544,6 +547,26 @@ where
 mod tests {
 	use super::*;
 	use clap::Parser;
+
+	#[cfg(any(feature = "tcp", feature = "uds"))]
+	#[test]
+	fn setup_path_omits_an_empty_path() {
+		// An empty path and an absent one both mean the server's default, so we send
+		// neither. A peer on published lite-05 rejects an empty value outright.
+		let cases = [
+			("unix:///run/moq.sock?path=/room", true, Some("/room")),
+			("unix:///run/moq.sock?path=", true, None),
+			("unix:///run/moq.sock", true, None),
+			("tcp://localhost:4443/room", false, Some("/room")),
+			("tcp://localhost:4443", false, None),
+		];
+
+		for (url, path_is_address, want) in cases {
+			let url = Url::parse(url).unwrap();
+			let got = setup_path(&url, path_is_address);
+			assert_eq!(got.as_deref(), want, "{url}");
+		}
+	}
 
 	#[test]
 	fn test_toml_disable_verify_survives_update_from() {

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -996,10 +996,17 @@ impl Request {
 	///
 	/// Taken from the SETUP for the URL-less stream bindings (and moq-transport, which
 	/// carries it in-band), and from the dial [`url`](Self::url) for WebTransport/QUIC.
-	/// `None` only when neither carries one.
-	pub fn path(&self) -> Option<&str> {
+	/// Empty only when neither carries one.
+	pub fn path(&self) -> &str {
+		// An empty SETUP path means the client advertised none, so fall back to the
+		// dial URL. URI-carrying bindings are the ones that must not send a path at
+		// all, so this never discards a path the client meant us to use.
 		let setup = request_ref!(self, r => r.path());
-		setup.or(self.url.as_ref().map(Url::path))
+		if setup.is_empty() {
+			self.url.as_ref().map(Url::path).unwrap_or("")
+		} else {
+			setup
+		}
 	}
 
 	/// The single direction the client advertised in its SETUP, or `None` for a

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -69,13 +69,15 @@ impl Client {
 		self
 	}
 
-	/// Set the request path to advertise in the SETUP (moq-lite-05 and moq-transport
-	/// 14-18).
+	/// Set the request path to advertise in the SETUP (moq-lite-05 and every
+	/// moq-transport draft we speak).
 	///
-	/// Required on transports that carry no request URI (native QUIC, qmux over
-	/// TCP/TLS) so the server learns which path the client wants; omit it on bindings
-	/// that already carry a URI (WebTransport). Ignored by versions with no in-band
-	/// request path (lite 01-04).
+	/// Only for transports that carry no request URI of their own (native QUIC, qmux
+	/// over TCP/TLS, unix sockets), so the server learns which path the client wants.
+	/// Bindings that already carry a URI (WebTransport, qmux over WebSocket) convey
+	/// the path there and MUST NOT send this; a server is entitled to treat it as a
+	/// protocol violation. An empty path is equivalent to omitting it. Ignored by
+	/// versions with no in-band request path (lite 01-04).
 	pub fn with_path(mut self, path: impl Into<String>) -> Self {
 		self.setup_path = Some(path.into());
 		self

--- a/rs/moq-net/src/lite/setup.rs
+++ b/rs/moq-net/src/lite/setup.rs
@@ -125,8 +125,10 @@ pub struct Setup {
 	/// The probe capability this endpoint supports. [`ProbeLevel::None`] when absent.
 	pub probe: ProbeLevel,
 	/// The request path, for transports that carry no request URI (native QUIC,
-	/// qmux over TCP/TLS). Sent only by the client; a server never sends one and a
-	/// relay never forwards it. `None` on URI-carrying bindings.
+	/// qmux over TCP/TLS, unix sockets). Sent only by the client; a server never
+	/// sends one and a relay never forwards it. `None` on URI-carrying bindings,
+	/// where it would be a protocol violation. An empty path means the same thing
+	/// as `None`; both are on the wire so a client need not special-case the root.
 	pub path: Option<String>,
 	/// The single direction the client intends to use, or `None` for a bidirectional
 	/// session. `None` is sent as the absence of the parameter, which is also how a
@@ -146,13 +148,11 @@ impl Message for Setup {
 			.map(ProbeLevel::from_code)
 			.unwrap_or_default();
 		let path = match params.get_bytes(PARAM_PATH) {
-			Some(bytes) => {
-				let s = std::str::from_utf8(bytes).map_err(|_| DecodeError::InvalidValue)?;
-				if s.is_empty() {
-					return Err(DecodeError::InvalidValue);
-				}
-				Some(s.to_string())
-			}
+			Some(bytes) => Some(
+				std::str::from_utf8(bytes)
+					.map_err(|_| DecodeError::InvalidValue)?
+					.to_string(),
+			),
 			None => None,
 		};
 		let role = params.get_varint(PARAM_ROLE)?.and_then(Role::from_code);
@@ -254,6 +254,17 @@ mod tests {
 			probe: ProbeLevel::Report,
 			path: Some("/room/123".to_string()),
 			role: None,
+		};
+		assert_eq!(round_trip(&msg), msg);
+	}
+
+	#[test]
+	fn empty_path_round_trips() {
+		// An empty path is valid and distinct from absent only on the wire; both mean
+		// the root, so a client doesn't have to special-case it.
+		let msg = Setup {
+			path: Some(String::new()),
+			..Default::default()
 		};
 		assert_eq!(round_trip(&msg), msg);
 	}

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -84,8 +84,8 @@ impl Server {
 	/// serve, and call [`ok`](Request::ok) or [`close`](Request::close). Session start
 	/// is deferred to `ok()`, so origins set on the `Request` always take effect.
 	///
-	/// The path is surfaced for moq-lite-05 and every moq-transport draft (14-18);
-	/// it's `None` on versions with no in-band request path (e.g. lite 01-04).
+	/// The path is surfaced for moq-lite-05 and every moq-transport draft we speak;
+	/// it's empty on versions with no in-band request path (e.g. lite 01-04).
 	pub async fn accept_request<S: web_transport_trait::Session>(&self, session: S) -> Result<Request<S>, Error> {
 		// Regimes without a path to read defer to `ok()` without surfacing one, and
 		// carry no role hint, so authorization is unchanged for them.
@@ -311,12 +311,14 @@ enum Handshake<S: web_transport_trait::Session> {
 }
 
 impl<S: web_transport_trait::Session> Request<S> {
-	/// The request path the client advertised in its SETUP, if any.
+	/// The request path the client advertised in its SETUP.
 	///
-	/// Populated for moq-lite-05 and moq-transport 14-18; `None` on versions without
-	/// an in-band request path. See the note on [`Server::accept_request`].
-	pub fn path(&self) -> Option<&str> {
-		self.path.as_deref()
+	/// Empty when the client advertised none: either it sent an empty path, or the
+	/// version carries none in-band (lite 01-04). Those mean the same thing, so the
+	/// wire distinction isn't surfaced. Populated for moq-lite-05 and every
+	/// moq-transport draft we speak. See the note on [`Server::accept_request`].
+	pub fn path(&self) -> &str {
+		self.path.as_deref().unwrap_or("")
 	}
 
 	/// The single [`Role`] the client advertised in its SETUP, or `None` for a
@@ -656,6 +658,51 @@ mod tests {
 		buf
 	}
 
+	/// Encode a draft-17+ Setup Stream: the unified SETUP message, whose parameters
+	/// carry the request path the same way lite-05's does.
+	fn ietf_setup(version: ietf::Version, path: Option<&str>) -> Vec<u8> {
+		let mut params = ietf::Parameters::default();
+		if let Some(path) = path {
+			params.set_bytes(ietf::ParameterBytes::Path, path.as_bytes().to_vec());
+		}
+		let parameters = params.encode_bytes(version).unwrap();
+
+		let mut buf = Vec::new();
+		setup::Setup { parameters }
+			.encode(&mut buf, crate::Version::Ietf(version))
+			.unwrap();
+		buf
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn accept_request_reads_ietf_path() {
+		// Every draft-17+ version gates on the SETUP stream before starting, so the
+		// path is known at authorization time just like lite-05.
+		for (alpn, version) in [
+			(ALPN_17, ietf::Version::Draft17),
+			(ALPN_18, ietf::Version::Draft18),
+			(ALPN_19, ietf::Version::Draft19),
+		] {
+			let session = FakeSession::new(alpn, [ietf_setup(version, Some("/team/room"))]);
+			let request = Server::new().accept_request(session).await.unwrap();
+			assert_eq!(request.path(), "/team/room", "{alpn}");
+		}
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn accept_request_ietf_without_path_is_empty() {
+		let session = FakeSession::new(ALPN_19, [ietf_setup(ietf::Version::Draft19, None)]);
+		let request = Server::new().accept_request(session).await.unwrap();
+		assert_eq!(request.path(), "");
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn accept_request_ietf_empty_path_is_accepted() {
+		let session = FakeSession::new(ALPN_19, [ietf_setup(ietf::Version::Draft19, Some(""))]);
+		let request = Server::new().accept_request(session).await.unwrap();
+		assert_eq!(request.path(), "");
+	}
+
 	/// Encode a lite-05 GROUP uni stream header (just the `DataType::Group` tag).
 	fn lite05_group() -> Vec<u8> {
 		let mut buf = Vec::new();
@@ -667,15 +714,24 @@ mod tests {
 	async fn accept_request_reads_lite05_path() {
 		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(Some("/team/room"), None)]);
 		let request = Server::new().accept_request(session).await.unwrap();
-		assert_eq!(request.path(), Some("/team/room"));
+		assert_eq!(request.path(), "/team/room");
 		assert_eq!(request.role(), None, "a client that omits the role is bidirectional");
 	}
 
 	#[tokio::test(start_paused = true)]
-	async fn accept_request_lite05_without_path_is_none() {
+	async fn accept_request_lite05_without_path_is_empty() {
 		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(None, None)]);
 		let request = Server::new().accept_request(session).await.unwrap();
-		assert_eq!(request.path(), None);
+		assert_eq!(request.path(), "");
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn accept_request_lite05_empty_path_is_accepted() {
+		// An empty path is valid on the wire and means the same as omitting it, so a
+		// client that wants the root doesn't have to special-case the parameter.
+		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(Some(""), None)]);
+		let request = Server::new().accept_request(session).await.unwrap();
+		assert_eq!(request.path(), "");
 	}
 
 	#[tokio::test(start_paused = true)]
@@ -691,6 +747,6 @@ mod tests {
 		// keeps reading until it finds the SETUP.
 		let session = FakeSession::new(ALPN_LITE_05, [lite05_group(), lite05_setup(Some("/team/room"), None)]);
 		let request = Server::new().accept_request(session).await.unwrap();
-		assert_eq!(request.path(), Some("/team/room"));
+		assert_eq!(request.path(), "/team/room");
 	}
 }

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -178,7 +178,7 @@ impl Connection {
 				params
 			}
 			// URL-less stream transports: path + `?jwt=` ride the SETUP.
-			None => AuthParams::from_path(self.request.path().unwrap_or("")),
+			None => AuthParams::from_path(self.request.path()),
 		};
 		params.transport = Some(transport);
 


### PR DESCRIPTION
## Root cause

moq-lite and moq-transport disagreed about an empty request path. `lite::Setup::decode_msg` rejected it with `DecodeError::InvalidValue`, implementing the draft's "non-empty UTF-8 string" requirement. The IETF decoders (`ietf::accept_setup` for draft-17+, `server.rs` for the legacy bidi exchange) accepted it and returned `Some("")`. So identical bytes either tore down the session or sailed through, purely on which protocol got negotiated. Callers hid the split behind `path().unwrap_or("")`.

An empty path and an absent one mean the same thing: the server's default. That was never worth a session teardown, and it forced clients that want the root to special-case the parameter.

## Changes

**API (breaking)**
- `Request::path()` returns `&str` instead of `Option<&str>`, empty when the client advertised none. `moq_native::server::Request::path()` matches; its dial-URL fallback now keys off an empty setup path rather than `None`. Safe because a URI-carrying binding must not send a path at all, so the fallback can't discard one the client meant us to use.
- Relay drops its `unwrap_or("")`.

**Wire**
- lite's decoder accepts an empty path, matching what IETF and `js/net` effectively already did.
- `js/net`'s `Setup` decoder drops its matching `throw`.

**Draft** (`draft-lcurley-moq-lite.md`, Path Parameter)
- Value MAY be empty and is equivalent to omitting the parameter; servers MUST treat the two identically.
- Client rule relaxed from `MUST send exactly one` to `SHOULD send one`.
- "empty or" removed from the PROTOCOL_VIOLATION rule.
- Unchanged: URI-carrying bindings (WebTransport, qmux-over-WebSocket) MUST NOT send a path.

**Test coverage gap**

PATH over moq-transport was already plumbed end to end. `Client::with_path` feeds the draft-17/18/19 SETUP stream via `run_setup` and the 14-16 legacy bidi SETUP; `ietf::accept_setup` and `server.rs` read it back. But only the parameter codec was unit-tested. Nothing exercised the handshake gate that actually surfaces the path for authorization, which is the layer where a regression bites. Added `accept_request` tests across drafts 17/18/19 plus absent- and empty-path cases, and an `empty_path_round_trips` case on the lite codec.

Also corrected stale "14-18" doc comments on `Client::with_path` and `Request::path` (draft-19 forwards the path too), and documented the URI-less binding restriction on `with_path`.

## Testing

- `cargo test -p moq-net --lib` — 517 pass
- `cargo check --workspace --all-targets` — clean
- `bun test net/src/lite/setup.test.ts` — 12 pass
- `just drafts check` — clean
- `cargo fmt --all --check`, `biome check` — clean

`cargo clippy` across the workspace has **not** run: the build disk filled up mid-pass. Worth a look at CI's clippy result before merging.

## Notes

Targets `dev` for the breaking `path()` signature and the wire relaxation.

Cross-package sync: `js/net` updated alongside `rs/moq-net`, draft updated for the wire change. No `doc/concept` page documents the Path Parameter, so nothing to update there.

One thing left open: `moq-native` supports `unix://` (resource path in `?path=`), but the draft's Transports table enumerates only four bindings and UDS isn't among them, so the spec text grants PATH to bindings 1 and 3 only. Adding a UDS binding is a real spec addition rather than a wording fix, so it's not in this PR.

(written by Opus 4.8)