### PR TITLE
fix(publish): snap the capture rate to one the codec supports

### DIFF
--- a/js/hang/src/util/aac.test.ts
+++ b/js/hang/src/util/aac.test.ts
@@ -1,5 +1,33 @@
 import { describe, expect, it } from "bun:test";
-import { audioSpecificConfig } from "./aac";
+import { audioSpecificConfig, pickRate, SAMPLE_RATES, supportsRate } from "./aac";
+
+describe("pickRate", () => {
+	// 44.1kHz is in the AAC table, unlike Opus, so it must survive untouched.
+	it("leaves the table rates alone", () => {
+		for (const rate of SAMPLE_RATES) {
+			expect(pickRate(rate)).toBe(rate);
+		}
+	});
+
+	it("snaps an off-table rate up to the next one", () => {
+		expect(pickRate(44101)).toBe(48000);
+		expect(pickRate(20000)).toBe(22050);
+	});
+
+	it("falls back to the highest rate above the table", () => {
+		expect(pickRate(192000)).toBe(96000);
+	});
+});
+
+describe("supportsRate", () => {
+	it("accepts 44.1kHz", () => {
+		expect(supportsRate(44100)).toBe(true);
+	});
+
+	it("rejects an off-table rate", () => {
+		expect(supportsRate(44101)).toBe(false);
+	});
+});
 
 describe("audioSpecificConfig", () => {
 	// Well-known AAC-LC AudioSpecificConfig values.

--- a/js/hang/src/util/aac.ts
+++ b/js/hang/src/util/aac.ts
@@ -39,7 +39,7 @@ export function supportsRate(rate: number): boolean {
  * accept the table rates, so capture at one of those instead of relying on the escape form.
  */
 export function pickRate(rate: number): number {
-	return SAMPLE_RATES.find((r) => r >= rate) ?? 96_000;
+	return SAMPLE_RATES.find((r) => r >= rate) ?? SAMPLE_RATES[SAMPLE_RATES.length - 1];
 }
 
 const AAC_LC = 2; // audioObjectType for AAC-LC

--- a/js/hang/src/util/aac.ts
+++ b/js/hang/src/util/aac.ts
@@ -15,6 +15,30 @@ const SAMPLE_RATE_INDEX: Record<number, number> = {
 	7350: 12,
 };
 
+// The table's rates, ascending. Derived from the index table above so the two can't drift.
+const SAMPLE_RATES_ASC = Object.keys(SAMPLE_RATE_INDEX)
+	.map(Number)
+	.sort((a, b) => a - b);
+
+/** The sample rates the AAC sampling frequency table lists, ascending. */
+export const SAMPLE_RATES: readonly number[] = SAMPLE_RATES_ASC;
+
+/** Whether the sample rate is one the AAC sampling frequency table lists. */
+export function supportsRate(rate: number): boolean {
+	return SAMPLE_RATE_INDEX[rate] !== undefined;
+}
+
+/**
+ * Snap an arbitrary sample rate up to the nearest rate in the AAC sampling frequency table, falling
+ * back to the highest (96 kHz) for anything above it.
+ *
+ * `audioSpecificConfig` can describe an off-table rate via its escape form, but encoders only
+ * accept the table rates, so capture at one of those instead of relying on the escape form.
+ */
+export function pickRate(rate: number): number {
+	return SAMPLE_RATES_ASC.find((r) => r >= rate) ?? 96_000;
+}
+
 const AAC_LC = 2; // audioObjectType for AAC-LC
 
 // Map a channel count to its AAC channelConfiguration (ISO 14496-3 Table 1.19). Configs 1..=6 are

--- a/js/hang/src/util/aac.ts
+++ b/js/hang/src/util/aac.ts
@@ -15,13 +15,16 @@ const SAMPLE_RATE_INDEX: Record<number, number> = {
 	7350: 12,
 };
 
-// The table's rates, ascending. Derived from the index table above so the two can't drift.
-const SAMPLE_RATES_ASC = Object.keys(SAMPLE_RATE_INDEX)
-	.map(Number)
-	.sort((a, b) => a - b);
-
-/** The sample rates the AAC sampling frequency table lists, ascending. */
-export const SAMPLE_RATES: readonly number[] = SAMPLE_RATES_ASC;
+/**
+ * The sample rates the AAC sampling frequency table lists, ascending.
+ *
+ * Derived from the index table above so the two can't drift, and frozen because `pickRate` reads it.
+ */
+export const SAMPLE_RATES: readonly number[] = Object.freeze(
+	Object.keys(SAMPLE_RATE_INDEX)
+		.map(Number)
+		.sort((a, b) => a - b),
+);
 
 /** Whether the sample rate is one the AAC sampling frequency table lists. */
 export function supportsRate(rate: number): boolean {
@@ -36,7 +39,7 @@ export function supportsRate(rate: number): boolean {
  * accept the table rates, so capture at one of those instead of relying on the escape form.
  */
 export function pickRate(rate: number): number {
-	return SAMPLE_RATES_ASC.find((r) => r >= rate) ?? 96_000;
+	return SAMPLE_RATES.find((r) => r >= rate) ?? 96_000;
 }
 
 const AAC_LC = 2; // audioObjectType for AAC-LC

--- a/js/hang/src/util/index.ts
+++ b/js/hang/src/util/index.ts
@@ -1,5 +1,5 @@
 /**
- * Miscellaneous helpers for the hang media layer: AAC config, hex encoding,
+ * Miscellaneous helpers for the hang media layer: AAC and Opus codec constraints, hex encoding,
  * latency tracking, and the libav/WebCodecs polyfill.
  *
  * @module
@@ -10,3 +10,4 @@ export * as Hacks from "./hacks";
 export * as Hex from "./hex";
 export * as Latency from "./latency";
 export * as Libav from "./libav";
+export * as Opus from "./opus";

--- a/js/hang/src/util/opus.test.ts
+++ b/js/hang/src/util/opus.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { pickRate, SAMPLE_RATES, supportsRate } from "./opus";
+
+describe("pickRate", () => {
+	// Matches the rate_picker_snaps_up test in rs/moq-audio/src/opus.rs.
+	it("snaps 44.1kHz up to 48kHz", () => {
+		expect(pickRate(44100)).toBe(48000);
+	});
+
+	it("snaps 22.05kHz up to 24kHz", () => {
+		expect(pickRate(22050)).toBe(24000);
+	});
+
+	it("leaves the native rates alone", () => {
+		for (const rate of SAMPLE_RATES) {
+			expect(pickRate(rate)).toBe(rate);
+		}
+	});
+
+	it("falls back to 48kHz above the highest rate", () => {
+		expect(pickRate(96000)).toBe(48000);
+	});
+
+	it("snaps up to the lowest rate", () => {
+		expect(pickRate(1)).toBe(8000);
+	});
+});
+
+describe("supportsRate", () => {
+	it("rejects rates Opus cannot run at", () => {
+		// The rate a Bluetooth headset on macOS reports after an A2DP flip, and the one Safari's
+		// AudioDecoder accepts via isConfigSupported and then fails on.
+		expect(supportsRate(44100)).toBe(false);
+		expect(supportsRate(22050)).toBe(false);
+	});
+
+	it("accepts the native rates", () => {
+		for (const rate of SAMPLE_RATES) {
+			expect(supportsRate(rate)).toBe(true);
+		}
+	});
+});

--- a/js/hang/src/util/opus.test.ts
+++ b/js/hang/src/util/opus.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { pickRate, SAMPLE_RATES, supportsRate } from "./opus";
 
 describe("pickRate", () => {
-	// Matches the rate_picker_snaps_up test in rs/moq-audio/src/opus.rs.
+	// Matches the pick_opus_rate tests in rs/moq-audio/src/codec.rs.
 	it("snaps 44.1kHz up to 48kHz", () => {
 		expect(pickRate(44100)).toBe(48000);
 	});

--- a/js/hang/src/util/opus.ts
+++ b/js/hang/src/util/opus.ts
@@ -1,0 +1,27 @@
+// Opus sample rate constraints, mirroring rs/moq-audio/src/opus.rs so the Rust and JS publishers
+// advertise the same rates.
+//
+// Opus runs at a fixed set of rates and nothing else. Audio captured at 44.1 kHz is resampled to
+// 48 kHz before it reaches the codec, and the bitstream carries no trace of the original rate, so
+// 44100 is never a valid decoder config. Chrome hides this by ignoring the configured rate; Safari
+// trusts it and fails every decode.
+
+// Sample rates Opus runs at, ascending.
+const RATES = [8_000, 12_000, 16_000, 24_000, 48_000];
+
+/** The sample rates Opus can encode and decode at, ascending. */
+export const SAMPLE_RATES: readonly number[] = RATES;
+
+/** Whether Opus can be configured at this sample rate. */
+export function supportsRate(rate: number): boolean {
+	return RATES.includes(rate);
+}
+
+/**
+ * Snap an arbitrary sample rate up to the nearest rate Opus supports, falling back to 48 kHz for
+ * anything above the highest. Snapping up rather than down avoids throwing away bandwidth the
+ * source actually had.
+ */
+export function pickRate(rate: number): number {
+	return RATES.find((r) => r >= rate) ?? 48_000;
+}

--- a/js/hang/src/util/opus.ts
+++ b/js/hang/src/util/opus.ts
@@ -6,12 +6,15 @@
 // 44100 is never a valid decoder config. Chrome hides this by ignoring the configured rate; Safari
 // trusts it and fails every decode.
 
+/** Full-band Opus: its highest rate, and the one to use when the source rate is unknown. */
+export const DEFAULT_SAMPLE_RATE = 48_000;
+
 /**
  * The sample rates Opus can encode and decode at, ascending.
  *
  * Frozen because `pickRate` and `supportsRate` read this same array.
  */
-export const SAMPLE_RATES: readonly number[] = Object.freeze([8_000, 12_000, 16_000, 24_000, 48_000]);
+export const SAMPLE_RATES: readonly number[] = Object.freeze([8_000, 12_000, 16_000, 24_000, DEFAULT_SAMPLE_RATE]);
 
 /** Whether Opus can be configured at this sample rate. */
 export function supportsRate(rate: number): boolean {
@@ -24,5 +27,5 @@ export function supportsRate(rate: number): boolean {
  * source actually had.
  */
 export function pickRate(rate: number): number {
-	return SAMPLE_RATES.find((r) => r >= rate) ?? 48_000;
+	return SAMPLE_RATES.find((r) => r >= rate) ?? DEFAULT_SAMPLE_RATE;
 }

--- a/js/hang/src/util/opus.ts
+++ b/js/hang/src/util/opus.ts
@@ -1,20 +1,21 @@
-// Opus sample rate constraints, mirroring rs/moq-audio/src/opus.rs so the Rust and JS publishers
-// advertise the same rates.
+// Opus sample rate constraints, mirroring `pick_opus_rate` in rs/moq-audio/src/codec.rs so the Rust
+// and JS publishers advertise the same rates.
 //
 // Opus runs at a fixed set of rates and nothing else. Audio captured at 44.1 kHz is resampled to
 // 48 kHz before it reaches the codec, and the bitstream carries no trace of the original rate, so
 // 44100 is never a valid decoder config. Chrome hides this by ignoring the configured rate; Safari
 // trusts it and fails every decode.
 
-// Sample rates Opus runs at, ascending.
-const RATES = [8_000, 12_000, 16_000, 24_000, 48_000];
-
-/** The sample rates Opus can encode and decode at, ascending. */
-export const SAMPLE_RATES: readonly number[] = RATES;
+/**
+ * The sample rates Opus can encode and decode at, ascending.
+ *
+ * Frozen because `pickRate` and `supportsRate` read this same array.
+ */
+export const SAMPLE_RATES: readonly number[] = Object.freeze([8_000, 12_000, 16_000, 24_000, 48_000]);
 
 /** Whether Opus can be configured at this sample rate. */
 export function supportsRate(rate: number): boolean {
-	return RATES.includes(rate);
+	return SAMPLE_RATES.includes(rate);
 }
 
 /**
@@ -23,5 +24,5 @@ export function supportsRate(rate: number): boolean {
  * source actually had.
  */
 export function pickRate(rate: number): number {
-	return RATES.find((r) => r >= rate) ?? 48_000;
+	return SAMPLE_RATES.find((r) => r >= rate) ?? 48_000;
 }

--- a/js/publish/src/audio/encoder.test.ts
+++ b/js/publish/src/audio/encoder.test.ts
@@ -6,6 +6,7 @@ import { Signal } from "@moq/signals";
 mock.module("./capture-worklet.ts?worklet", () => ({ default: "blob:fake-capture" }));
 
 const { Encoder } = await import("./encoder.ts");
+type Codec = import("./encoder.ts").Codec;
 
 const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
 async function settle(times = 5): Promise<void> {
@@ -151,4 +152,33 @@ test("requests full-band Opus when the source reports no rate", async () => {
 // 44100 is in the AAC sampling frequency table, so it must survive untouched.
 test("leaves an AAC-native capture rate alone", async () => {
 	expect(await requestedRate(44_100, "aac")).toBe(44_100);
+});
+
+// Regression: only the codec's mime picks the capture rate, so tweaking an encode-only knob must not
+// tear down the microphone. Subscribing #runSource to the whole codec signal rebuilt the AudioContext
+// on every change, which dropped #worklet and closed the track being published. The demo writes this
+// signal from live bitrate/complexity sliders, so it fired on every slider tick.
+test("does not rebuild the capture graph when an encode-only knob changes", async () => {
+	using webaudio = installFakeWebAudio();
+
+	const codec = new Signal<Codec>({ mime: "opus", bitrate: 32_000 });
+	const encoder = new Encoder({
+		enabled: true,
+		source: new Signal(fakeSource()) as never,
+		codec,
+	});
+	await settle();
+	expect(webaudio.requestedRates.length).toBe(1);
+
+	codec.set({ mime: "opus", bitrate: 64_000 });
+	await settle();
+	expect(webaudio.requestedRates.length).toBe(1);
+
+	// A real codec switch still has to rebuild: AAC captures at rates Opus can't.
+	codec.set({ mime: "aac" });
+	await settle();
+	expect(webaudio.requestedRates.length).toBe(2);
+
+	encoder.close();
+	await settle();
 });

--- a/js/publish/src/audio/encoder.test.ts
+++ b/js/publish/src/audio/encoder.test.ts
@@ -19,11 +19,14 @@ function installFakeWebAudio() {
 	// Never resolves during the test, so the spawned worklet load stays pending until teardown.
 	const addModule = () => new Promise<void>(() => {});
 	let audioWorkletNodes = 0;
+	const requestedRates: (number | undefined)[] = [];
 
 	class FakeAudioContext {
 		state: AudioContextState = "suspended";
 		audioWorklet = { addModule };
-		constructor(_options?: AudioContextOptions) {}
+		constructor(options?: AudioContextOptions) {
+			requestedRates.push(options?.sampleRate);
+		}
 		close(): Promise<void> {
 			// Firefox/Safari behavior: stays "suspended", never "closed".
 			return Promise.resolve();
@@ -67,6 +70,9 @@ function installFakeWebAudio() {
 		get audioWorkletNodes() {
 			return audioWorkletNodes;
 		},
+		get requestedRates() {
+			return requestedRates;
+		},
 		[Symbol.dispose]() {
 			for (const [name, original] of originals) {
 				if (original) Object.defineProperty(globalThis, name, original);
@@ -76,10 +82,10 @@ function installFakeWebAudio() {
 	};
 }
 
-function fakeSource() {
+function fakeSource(sampleRate: number | undefined = 48_000) {
 	return {
 		kind: "audio",
-		getSettings: () => ({ deviceId: "", groupId: "", sampleRate: 48_000 }),
+		getSettings: () => ({ deviceId: "", groupId: "", sampleRate }),
 		getConstraints: () => ({}),
 	} as unknown as MediaStreamTrack;
 }
@@ -106,4 +112,43 @@ test("does not construct an AudioWorkletNode when torn down mid worklet load", a
 
 	expect(webaudio.audioWorkletNodes).toBe(0);
 	expect(error).not.toHaveBeenCalled();
+});
+
+// Regression: a Bluetooth mic on macOS reports 44100 after an A2DP flip. Capturing at that rate means
+// the encoder silently resamples to 48000 while the catalog advertises 44100, which no Opus decoder can
+// honor: Safari's AudioDecoder fails every decode with InternalAudioDecoderCocoa.
+async function requestedRate(sampleRate: number | undefined, codec?: "opus" | "aac") {
+	using webaudio = installFakeWebAudio();
+
+	const encoder = new Encoder({
+		enabled: true,
+		source: new Signal(fakeSource(sampleRate)) as never,
+		...(codec ? { codec } : {}),
+	});
+	await settle();
+	encoder.close();
+	await settle();
+
+	return webaudio.requestedRates.at(-1);
+}
+
+test("snaps the capture rate to one Opus supports", async () => {
+	expect(await requestedRate(44_100)).toBe(48_000);
+	expect(await requestedRate(22_050)).toBe(24_000);
+});
+
+test("leaves an Opus-native capture rate alone", async () => {
+	expect(await requestedRate(16_000)).toBe(16_000);
+	expect(await requestedRate(48_000)).toBe(48_000);
+});
+
+// captureStream() tracks report no rate, which would otherwise let the AudioContext fall back to the
+// machine's output rate (44100 on most Macs).
+test("requests full-band Opus when the source reports no rate", async () => {
+	expect(await requestedRate(undefined)).toBe(48_000);
+});
+
+// 44100 is in the AAC sampling frequency table, so it must survive untouched.
+test("leaves an AAC-native capture rate alone", async () => {
+	expect(await requestedRate(44_100, "aac")).toBe(44_100);
 });

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -11,6 +11,7 @@ const GAIN_MIN = 0.001;
 const FADE_TIME = 0.2;
 const OPUS_BITRATE_PER_CHANNEL = 32_000;
 const OPUS_FRAME_DURATION_MS = 20;
+const OPUS_DEFAULT_SAMPLE_RATE = 48_000;
 const AAC_BITRATE_PER_CHANNEL = 64_000;
 const AAC_FRAME_SAMPLES = 1024; // AAC-LC encodes a fixed 1024 samples per frame.
 
@@ -125,7 +126,12 @@ export class Encoder {
 
 		const settings = source.track.getSettings();
 		const overrideSampleRate = effect.get(this.sampleRate);
-		const sampleRate = overrideSampleRate ?? settings.sampleRate;
+		const codec = normalizeCodec(effect.get(this.codec));
+		const sampleRate = pickSampleRate(codec, overrideSampleRate ?? settings.sampleRate);
+
+		if (overrideSampleRate !== undefined && sampleRate !== overrideSampleRate) {
+			console.warn(`${codec.mime} does not support ${overrideSampleRate}Hz, capturing at ${sampleRate}Hz`);
+		}
 
 		// macOS misreports a mono mic as stereo: getSettings().channelCount is undefined and
 		// MediaStreamAudioSourceNode.channelCount defaults to 2, so the graph carries (and Opus
@@ -384,6 +390,24 @@ function requestedChannelCount(track: MediaStreamTrack): number | undefined {
 	if (constraint === undefined) return undefined;
 	if (typeof constraint === "number") return constraint;
 	return constraint.exact ?? constraint.ideal ?? constraint.max ?? constraint.min;
+}
+
+// Pick the rate to run the capture AudioContext at, given what the source reports (or the caller
+// asked for). Codecs only encode at a discrete set of rates, so snap to one they actually support.
+//
+// This has to happen at the AudioContext rather than just in the catalog. A context running at
+// 44100 hands 44100 AudioData to an encoder that resamples to 48000 behind our back, and we then
+// advertise 44100: a rate no Opus decoder can honor, which Safari rejects outright. Snapping here
+// keeps one rate across the capture graph, the encoder config, and the catalog.
+function pickSampleRate(codec: OpusConfig | AacConfig, requested: number | undefined): number | undefined {
+	if (codec.mime === "opus") {
+		// An unknown rate (captureStream reports none) would let the AudioContext fall back to the
+		// machine's output rate, which is 44100 on most Macs. Ask for full-band Opus instead.
+		return Util.Opus.pickRate(requested ?? OPUS_DEFAULT_SAMPLE_RATE);
+	}
+
+	// The AAC table includes 44100, so an unknown rate can safely fall through to the context default.
+	return requested !== undefined ? Util.Aac.pickRate(requested) : undefined;
 }
 
 // Resolve the bare codec shorthands to their full config object so callers can read fields uniformly.

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -11,7 +11,6 @@ const GAIN_MIN = 0.001;
 const FADE_TIME = 0.2;
 const OPUS_BITRATE_PER_CHANNEL = 32_000;
 const OPUS_FRAME_DURATION_MS = 20;
-const OPUS_DEFAULT_SAMPLE_RATE = 48_000;
 const AAC_BITRATE_PER_CHANNEL = 64_000;
 const AAC_FRAME_SAMPLES = 1024; // AAC-LC encodes a fixed 1024 samples per frame.
 
@@ -427,7 +426,7 @@ function pickSampleRate(mime: CodecMime, requested: number | undefined): number 
 	if (mime === "opus") {
 		// An unknown rate (captureStream reports none) would let the AudioContext fall back to the
 		// machine's output rate, which is 44100 on most Macs. Ask for full-band Opus instead.
-		return Util.Opus.pickRate(rate ?? OPUS_DEFAULT_SAMPLE_RATE);
+		return Util.Opus.pickRate(rate ?? Util.Opus.DEFAULT_SAMPLE_RATE);
 	}
 
 	// The AAC table includes 44100, so an unknown rate can safely fall through to the context default.

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -70,6 +70,9 @@ export type EncoderProps = {
 // channel count (which can differ from the requested count on some platforms, e.g. Safari/macOS).
 type Captured = { sampleRate: number; channelCount: number };
 
+// Which codec is in use, ignoring its tuning knobs.
+type CodecMime = OpusConfig["mime"] | AacConfig["mime"];
+
 export class Encoder {
 	static readonly TRACK = "audio/data";
 	static readonly PRIORITY = Catalog.PRIORITY.audio;
@@ -91,6 +94,11 @@ export class Encoder {
 	// worklet handlers only ever write here, never read-modify-write #config.
 	#captured = new Signal<Captured | undefined>(undefined);
 
+	// Only the mime picks the capture sample rate, so the capture graph tracks this rather than the
+	// whole codec signal. Otherwise changing an encode-only knob (bitrate, complexity) would rebuild
+	// the AudioContext, drop #worklet, and close the track we're publishing.
+	#codecMime: Signal<CodecMime>;
+
 	#config = new Signal<Catalog.AudioConfig | undefined>(undefined);
 	readonly config: Getter<Catalog.AudioConfig | undefined> = this.#config;
 
@@ -111,6 +119,11 @@ export class Encoder {
 		this.sampleRate = Signal.from<number | undefined>(props?.sampleRate);
 		this.channelCount = Signal.from<number | undefined>(props?.channelCount);
 		this.codec = Signal.from<Codec>(props?.codec ?? "opus");
+		this.#codecMime = new Signal(normalizeCodec(this.codec.peek()).mime);
+
+		this.#signals.run((effect) => {
+			this.#codecMime.set(normalizeCodec(effect.get(this.codec)).mime);
+		});
 
 		this.#signals.run(this.#runSource.bind(this));
 		this.#signals.run(this.#runGain.bind(this));
@@ -126,11 +139,11 @@ export class Encoder {
 
 		const settings = source.track.getSettings();
 		const overrideSampleRate = effect.get(this.sampleRate);
-		const codec = normalizeCodec(effect.get(this.codec));
-		const sampleRate = pickSampleRate(codec, overrideSampleRate ?? settings.sampleRate);
+		const mime = effect.get(this.#codecMime);
+		const sampleRate = pickSampleRate(mime, overrideSampleRate ?? settings.sampleRate);
 
 		if (overrideSampleRate !== undefined && sampleRate !== overrideSampleRate) {
-			console.warn(`${codec.mime} does not support ${overrideSampleRate}Hz, capturing at ${sampleRate}Hz`);
+			console.warn(`${mime} does not support ${overrideSampleRate}Hz, capturing at ${sampleRate}Hz`);
 		}
 
 		// macOS misreports a mono mic as stereo: getSettings().channelCount is undefined and
@@ -212,6 +225,13 @@ export class Encoder {
 	}
 
 	#createConfig(captured: Captured, codec: OpusConfig | AacConfig): Catalog.AudioConfig {
+		// The catalog carries the rate the context actually realized, not the one we asked for. They
+		// only diverge if the browser ignored the request, which would put us right back to
+		// advertising a rate the codec can't decode, so make that visible instead of silent.
+		if (codec.mime === "opus" && !Util.Opus.supportsRate(captured.sampleRate)) {
+			console.warn(`capturing at ${captured.sampleRate}Hz, which opus cannot decode`);
+		}
+
 		const sampleRate = Catalog.u53(captured.sampleRate);
 		const numberOfChannels = Catalog.u53(captured.channelCount);
 
@@ -399,15 +419,19 @@ function requestedChannelCount(track: MediaStreamTrack): number | undefined {
 // 44100 hands 44100 AudioData to an encoder that resamples to 48000 behind our back, and we then
 // advertise 44100: a rate no Opus decoder can honor, which Safari rejects outright. Snapping here
 // keeps one rate across the capture graph, the encoder config, and the catalog.
-function pickSampleRate(codec: OpusConfig | AacConfig, requested: number | undefined): number | undefined {
-	if (codec.mime === "opus") {
+function pickSampleRate(mime: CodecMime, requested: number | undefined): number | undefined {
+	// Treat a nonsense rate as unknown. It would otherwise snap to the codec's floor (7350Hz for AAC)
+	// instead of throwing NotSupportedError at the AudioContext where it's obvious.
+	const rate = requested !== undefined && Number.isFinite(requested) && requested > 0 ? requested : undefined;
+
+	if (mime === "opus") {
 		// An unknown rate (captureStream reports none) would let the AudioContext fall back to the
 		// machine's output rate, which is 44100 on most Macs. Ask for full-band Opus instead.
-		return Util.Opus.pickRate(requested ?? OPUS_DEFAULT_SAMPLE_RATE);
+		return Util.Opus.pickRate(rate ?? OPUS_DEFAULT_SAMPLE_RATE);
 	}
 
 	// The AAC table includes 44100, so an unknown rate can safely fall through to the context default.
-	return requested !== undefined ? Util.Aac.pickRate(requested) : undefined;
+	return rate !== undefined ? Util.Aac.pickRate(rate) : undefined;
 }
 
 // Resolve the bare codec shorthands to their full config object so callers can read fields uniformly.

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -251,7 +251,7 @@ export class Decoder {
 					}
 					this.#emit(data);
 				},
-				error: (error) => console.error(error),
+				error: (error) => console.error("audio decoder error", error),
 			});
 			effect.cleanup(() => {
 				if (decoder.state !== "closed") decoder.close();
@@ -297,6 +297,9 @@ export class Decoder {
 					timestamp: frame.timestamp,
 				});
 
+				// A fatal decode error closes the decoder, so decoding again throws InvalidStateError out
+				// of this loop. Stop instead: the error callback already reported the real failure.
+				if (decoder.state === "closed") break;
 				decoder.decode(chunk);
 			}
 		});
@@ -335,7 +338,7 @@ export class Decoder {
 
 			const decoder = new AudioDecoder({
 				output: (data) => this.#emit(data),
-				error: (error) => console.error(error),
+				error: (error) => console.error("audio decoder error", error),
 			});
 			effect.cleanup(() => {
 				if (decoder.state !== "closed") decoder.close();
@@ -471,6 +474,14 @@ export class Decoder {
 }
 
 async function supported(config: Catalog.AudioConfig): Promise<boolean> {
+	// Opus only runs at its native rates, and isConfigSupported can't be trusted to say so: Safari
+	// returns supported for 44100 and then fails every decode with InternalAudioDecoderCocoa. Reject
+	// the rendition here so we fall back cleanly instead of selecting a track we can't decode.
+	if (config.codec === "opus" && !Util.Opus.supportsRate(config.sampleRate)) {
+		console.warn(`audio: opus cannot decode at ${config.sampleRate}Hz`);
+		return false;
+	}
+
 	// Opus in CMAF uses raw packets; dOps is not a valid OGG Identification Header.
 	let description: Uint8Array | undefined;
 	if (config.codec !== "opus") {

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -474,12 +474,11 @@ export class Decoder {
 }
 
 async function supported(config: Catalog.AudioConfig): Promise<boolean> {
-	// Opus only runs at its native rates, and isConfigSupported can't be trusted to say so: Safari
-	// returns supported for 44100 and then fails every decode with InternalAudioDecoderCocoa. Reject
-	// the rendition here so we fall back cleanly instead of selecting a track we can't decode.
+	// Opus only runs at its native rates, so a catalog advertising anything else is wrong and Safari
+	// refuses to decode it. Warn rather than reject: Chrome and Firefox ignore the configured rate and
+	// play these streams fine, so rejecting would silence them for a publisher they handle today.
 	if (config.codec === "opus" && !Util.Opus.supportsRate(config.sampleRate)) {
-		console.warn(`audio: opus cannot decode at ${config.sampleRate}Hz`);
-		return false;
+		console.warn(`audio: opus advertised at ${config.sampleRate}Hz, which some browsers cannot decode`);
 	}
 
 	// Opus in CMAF uses raw packets; dOps is not a valid OGG Identification Header.


### PR DESCRIPTION
## Summary

Fixes #2400: Safari watchers of a Safari publisher hard-fail with `InternalAudioDecoderCocoa decoding failed` and never recover, after a Bluetooth mute/unmute flips the mic's reported rate from 16000 to 44100.

**Root cause is the publisher, not Safari.** Opus runs at 8/12/16/24/48 kHz and nothing else, so audio captured at 44100 is resampled to 48000 before it ever reaches the codec, and the bitstream carries no trace of the original rate. Catalog `sampleRate` is handed verbatim to `AudioDecoder.configure`, making it a decoder-config field rather than provenance, so 44100 is a value it cannot legally take for Opus. We advertised it anyway. Chrome hides this by ignoring the configured rate; Safari trusts it and fails every decode.

`rs/moq-audio` already got this right (`pick_opus_rate` in `codec.rs` snaps the input rate up). The JS publisher was the only one advertising unsnapped capture rates, so this is parity rather than new codec special-casing.

- **Publisher**: `#runSource` snaps the requested rate to one the codec supports before constructing the `AudioContext`. Doing it at the context rather than only in `#createConfig` keeps one rate across the capture graph, the encoder config, and the catalog, instead of feeding 44100 `AudioData` to an encoder configured at 48000.
- **Unknown rate now means 48 kHz for Opus.** A `captureStream()` track reports no `sampleRate`, which previously let the context fall back to the machine's output rate (44100 on most Macs). That is the file-publish path from #2352, so this closes it too. AAC still falls through to the context default, since 44100 is a valid AAC rate.
- **AAC is snapped too**, though 44100 is in the AAC sampling frequency table so real captures are unaffected; only genuinely off-table rates move.
- **Watcher**: the legacy decode loop now checks `decoder.state === "closed"` before decoding, matching what the CMAF path already did. A fatal decode error closes the decoder, so the next `decode()` threw `InvalidStateError` out of the loop into `effect.spawn` — the second error line in the report. Both decoder error callbacks also log with context, and an off-rate Opus rendition logs a warning.

Deliberately **not** included:

- **Rejecting off-rate Opus renditions.** An earlier revision had `supported()` return false for them. Per the measured table in #2400, Chrome and Firefox ignore the configured rate and play these streams fine today, so rejecting would silence them for every publisher that hasn't picked up this fix yet. Warning is the non-regressive choice.
- **Snapping the rate at decoder-configure time.** It would fix Safari playback of existing publishers, but on `main` the render graph is still built from `config.sampleRate` (PR #2368's "graph follows `sample.sampleRate`" landed on `dev` only), so it would trade silence for the #2352 noise bug. Worth revisiting on `dev`.
- **Decoder recovery/retry.** With a catalog that keeps saying 44100, a retry loop would spin. Real recovery is a policy call worth deciding separately.

An explicit `sampleRate` prop the codec cannot honor is snapped with a `console.warn` rather than Rust's `validate_rate` hard error, since a throw out of an effect is awkward for callers.

## Public API changes

Additive only, no breaking changes, so this targets `main`.

- `@moq/hang/util`: new `Opus` namespace exporting `SAMPLE_RATES`, `supportsRate(rate)`, `pickRate(rate)`.
- `@moq/hang/util` `Aac`: new `SAMPLE_RATES`, `supportsRate(rate)`, `pickRate(rate)`. The rate list is derived from the existing `SAMPLE_RATE_INDEX` table so the two cannot drift. Both tables are frozen, since `pickRate` and `supportsRate` read them.

No wire format, catalog schema, or signature changes.

## Review fixes (second commit)

An independent review pass caught a regression in the first commit, plus smaller items:

- **`#runSource` subscribed to the whole `codec` signal.** `Signal` equality is deep for plain objects, so any encode-only knob change (bitrate, complexity, DTX) rebuilt the `AudioContext`, dropped `#worklet`, and cascaded into `serve()`'s cleanup closing the published track. `demo/web/src/publish.ts` drives those knobs from live sliders, so it fired on every tick. Only the mime picks the rate, so a `#codecMime` signal is tracked instead. Regression test included and verified to fail against the first commit.
- The Rust cross-reference pointed at `rs/moq-audio/src/opus.rs`, which exists on `dev` but not here; corrected to `pick_opus_rate` in `codec.rs`.
- A non-finite or zero capture rate is treated as unknown rather than snapping to the codec floor (7350 Hz for AAC).
- `#createConfig` warns if the realized context rate is one Opus cannot decode, making the one line that writes the catalog fail loudly rather than silently.

## Test plan

- `bun test js/hang/src js/publish/src js/watch/src`: 135 pass, 0 fail.
- New `js/hang/src/util/opus.test.ts` mirrors the `pick_opus_rate` cases in `rs/moq-audio/src/codec.rs`; extended `aac.test.ts` asserts 44100 survives untouched.
- `encoder.test.ts` asserts the requested `AudioContext` rate (44100 to 48000, 22050 to 24000, native rates unchanged, no reported rate to 48000, AAC 44100 unchanged) and that an encode-only knob change does not rebuild the graph while an `opus` to `aac` switch does. Both regression cases **verified to fail without their fix**.
- `just js check` passes (exit 0).
- Not runtime-verified in Safari with a Bluetooth headset. The decode-side claims come from the standalone WebCodecs matrix in #2400.

## Cross-package sync

No rows apply. `rs/moq-audio` already implements this behavior, the catalog schema is unchanged, and no `doc/` or `demo/` content references audio sample rates.

## Unrelated note

`bun test js/json` has 27 pre-existing failures from stale `js/json/dist/` artifacts, identical on a clean tree, which makes `just js test` red on `main`. Untouched here, but worth a separate look.

(Written by Opus 4.8)