### PR TITLE
feat(token): scope signing keys to publish/subscribe paths

### DIFF
--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -47,6 +47,38 @@ moq-token generate --algorithm ES256 --out-dir ./private/ --public-dir ./keys/
 
 A random key ID is generated if `--id` is not specified.
 
+### Scope a Key
+
+Keys can embed immutable publish and subscribe limits. Every token signed or
+verified with a scoped key must stay within those limits. Rotate the key if its
+scope needs to change.
+
+```bash
+# This key may publish below project/live and subscribe below project/watch.
+moq-token generate \
+  --root project \
+  --publish live \
+  --subscribe watch \
+  --out private.jwk \
+  --public public.jwk
+```
+
+The scope is stored in both halves of an asymmetric JWK:
+
+```json
+{
+  "scope": {
+    "root": "project",
+    "put": ["live"],
+    "get": ["watch"]
+  }
+}
+```
+
+Existing JWKs without `scope` remain unrestricted for backwards compatibility.
+The library rejects the entire token when any requested role or path exceeds the
+key scope; it never silently intersects permissions.
+
 ### Configure the Relay
 
 Single key (simplest):
@@ -120,6 +152,8 @@ The JWT payload contains these claims:
 | `exp` | Expiration time (Unix timestamp) |
 | `iat` | Issued-at time (Unix timestamp) |
 
+`get` is named that way because `sub` is a reserved JWT claim.
+
 The `exp` claim is enforced for the whole session, not just at connect time. The relay closes the connection once `exp` passes, so a client must reconnect with a fresh token to continue. The same applies to mTLS: the connection is closed when the client certificate's `notAfter` is reached.
 
 ### Path Matching
@@ -138,9 +172,9 @@ path boundaries, so `foo` grants `foo` and `foo/bar` but never `foobar`.
 
 | root | put | get | Can publish | Can subscribe |
 |------|-----|-----|-------------|---------------|
-| `demo` | `my-stream` | `""` | `demo/my-stream` | `demo/*` |
-| `rooms/123` | `alice` | `""` | `rooms/123/alice` | `rooms/123/*` |
-| `""` | `""` | `""` | Everything | Everything |
+| `demo` | `["my-stream"]` | `[""]` | `demo/my-stream` | `demo/*` |
+| `rooms/123` | `["alice"]` | `[""]` | `rooms/123/alice` | `rooms/123/*` |
+| `""` | `[""]` | `[""]` | Everything | Everything |
 
 ### Connection Path
 
@@ -164,6 +198,8 @@ Per connection the relay issues `GET <base>?root=<path>&kid=<kid>&mtls=true&tran
 - `tier`: the billing tier label this connection's stats record under (an arbitrary string, e.g. `local` or `region/sjc`). Absent or empty selects the default unprefixed tier. See [Stats](/bin/relay/config#stats) for how tier labels map to track names.
 
 This lets a project stay reachable by both its stable id and its current/old vanity path, all mapping to the same broadcast tree: with the API resolving `demo` → `x7k2qp`, both `cdn.moq.dev/demo/foo` and `cdn.moq.dev/x7k2qp/foo` scope to `/x7k2qp/foo`.
+
+The token root is still checked against the path the client dialed, not the alias. A [scoped key](#scope-a-key) is immutable, so its scope has to be anchored at whichever name the tokens it signs are rooted at: anchor it at the stable id and its tokens work on stable-id paths, anchor it at a vanity name and they stop working once that name changes. Reconciling the two is tracked separately.
 
 ```toml
 [auth]

--- a/doc/lib/rs/crate/moq-token.md
+++ b/doc/lib/rs/crate/moq-token.md
@@ -69,7 +69,14 @@ moq-token generate --algorithm RS256 --out private.jwk --public public.jwk
 
 # Asymmetric key pair (EdDSA)
 moq-token generate --algorithm EdDSA --out private.jwk --public public.jwk
+
+# Scoped key: may only ever sign tokens that publish below project/live
+# and subscribe below project/watch
+moq-token generate --root project --publish live --subscribe watch --out scoped.jwk
 ```
+
+A key's scope is fixed at generation and enforced when signing and when verifying,
+so widening it means generating a new key. A key without a scope is unrestricted.
 
 ### Sign a Token
 

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -149,6 +149,9 @@ cargo install moq-token-cli
 # Generate a key
 moq-token generate --out root.jwk
 
+# Generate a key that can only ever grant publish below rooms/123
+moq-token generate --root "rooms/123" --publish "" --out scoped.jwk
+
 # Sign a token
 moq-token sign --key root.jwk \
   --root "rooms/123" \

--- a/js/token/src/claims.ts
+++ b/js/token/src/claims.ts
@@ -14,6 +14,29 @@ function list(claim: string | string[] | undefined): string[] {
 }
 
 /**
+ * The immutable ceiling on what a key may grant, embedded in its JWK.
+ *
+ * `root` is optional on the wire to match the Rust `moq-token` crate, which omits it
+ * when the scope sits at the top level.
+ */
+export const ScopeSchema = z
+	.object({
+		/** The root that `put` and `get` are relative to. Defaults to the empty string. */
+		root: z._default(z.string(), ""),
+		/** Prefixes this key may grant to publishers, relative to `root`. */
+		put: z.optional(z.array(z.string())),
+		/** Prefixes this key may grant to subscribers, relative to `root`. */
+		get: z.optional(z.array(z.string())),
+	})
+	.check(
+		z.refine((data) => (data.put?.length ?? 0) > 0 || (data.get?.length ?? 0) > 0, {
+			message: "Either put or get must contain at least one prefix",
+		}),
+	);
+
+export type Scope = z.infer<typeof ScopeSchema>;
+
+/**
  * The JWT claims structure for moq-token.
  *
  * `root` is optional on the wire: a token scoped to the top-level path omits it, so
@@ -125,4 +148,39 @@ export function authorize(claims: Claims, path: string): Permissions {
 	}
 
 	return permissions;
+}
+
+/**
+ * Whether every path `claims` grants is covered by `scope`, per role.
+ *
+ * Both sides are resolved against their own root before comparing, so the same
+ * grant expressed as `root: "demo"` + `put: ["room"]` or as `put: ["demo/room"]` is
+ * treated identically. Matching is segment-aware, so a scope of `live` does not
+ * cover `lively`, and the roles are checked independently: a publish-only scope
+ * never authorizes a subscribe grant.
+ *
+ * Must stay in lockstep with `Scope::allows` in the Rust `moq-token` crate, which
+ * checks the same keys.
+ */
+export function scopeAllows(scope: Scope, claims: Claims): boolean {
+	return (
+		covers(scope.root, scope.put ?? [], claims.root, list(claims.put)) &&
+		covers(scope.root, scope.get ?? [], claims.root, list(claims.get))
+	);
+}
+
+/**
+ * Whether every `requested` path (relative to `claimsRoot`) sits beneath some
+ * `granted` prefix (relative to `scopeRoot`).
+ *
+ * An empty `granted` denies everything, which is what makes a publish-only scope
+ * reject subscribe grants rather than ignoring them.
+ */
+function covers(scopeRoot: string, granted: string[], claimsRoot: string, requested: string[]): boolean {
+	const absolute = (root: string, relative: string) => Path.join(Path.normalize(root), Path.normalize(relative));
+
+	return requested.every((request) => {
+		const path = absolute(claimsRoot, request);
+		return granted.some((grant) => Path.hasPrefix(path, absolute(scopeRoot, grant)));
+	});
 }

--- a/js/token/src/cli.ts
+++ b/js/token/src/cli.ts
@@ -4,7 +4,7 @@ import { readFileSync, writeFileSync } from "node:fs";
 import * as base64 from "@hexagon/base64";
 import { Command, Option } from "commander";
 import type { Algorithm } from "./algorithm.ts";
-import { authorize, type Claims } from "./claims.ts";
+import { authorize, type Claims, type Scope, ScopeSchema } from "./claims.ts";
 import { generate } from "./generate.ts";
 import type { Key, PublicKey } from "./key.ts";
 import { load, loadPublic, sign, toPublicKey, verify } from "./key.ts";
@@ -21,10 +21,23 @@ program
 	.option("--id <id>", "Key ID (randomly generated if not provided)")
 	.option("--public <path>", "Path to save the public key (for asymmetric algorithms)")
 	.option("--base64", "Output as base64url instead of JSON", false)
+	.option("--root <root>", "Root path for the optional key scope", "")
+	.option("--publish <path...>", "Publish prefixes the key may grant")
+	.option("--subscribe <path...>", "Subscribe prefixes the key may grant")
 	.action(async (options) => {
 		try {
 			const algorithm = options.algorithm as Algorithm;
-			const key = await generate(algorithm, options.id);
+			let key = await generate(algorithm, options.id);
+			if (options.publish || options.subscribe) {
+				// Parse rather than cast, so a useless scope fails here like it does
+				// in the Rust CLI instead of writing an unusable key to disk.
+				const scope: Scope = ScopeSchema.parse({
+					root: options.root,
+					...(options.publish && { put: options.publish }),
+					...(options.subscribe && { get: options.subscribe }),
+				});
+				key = { ...key, scope };
+			}
 
 			const encodeKey = (k: object): string => {
 				const json = JSON.stringify(k, null, 2);

--- a/js/token/src/interop.test.ts
+++ b/js/token/src/interop.test.ts
@@ -112,6 +112,47 @@ describe("Rust-generated fixtures", () => {
 		expect(claims.put).toEqual(["stream1", "stream2"]);
 		expect(claims.get).toEqual(["feed1"]);
 	});
+
+	// cargo run --bin moq-token -- generate --root project --publish live --subscribe watch --out /tmp/scoped.jwk
+	const RUST_SCOPED_KEY = JSON.stringify({
+		alg: "HS256",
+		key_ops: ["verify", "sign"],
+		kty: "oct",
+		k: "pLDMYsYrp6vZLQbefVzHXN6P4wc1ADTLn4L7xzi1Qm4",
+		kid: "e396f70014db9fe9",
+		scope: { root: "project", put: ["live"], get: ["watch"] },
+	});
+
+	// cargo run --bin moq-token -- sign --key /tmp/scoped.jwk --root project --publish live/room --subscribe watch
+	const RUST_SCOPED_TOKEN =
+		"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6ImUzOTZmNzAwMTRkYjlmZTkifQ.eyJyb290IjoicHJvamVjdCIsInB1dCI6WyJsaXZlL3Jvb20iXSwiZ2V0IjpbIndhdGNoIl19.24Mxox6iQeFniEppRb1gWOO7iOTIsYlQRAjnOq6A2vk";
+
+	test("load a Rust key's scope", () => {
+		const key = load(RUST_SCOPED_KEY);
+		expect(key.scope).toEqual({ root: "project", put: ["live"], get: ["watch"] });
+	});
+
+	test("verify a Rust token signed within its key scope", async () => {
+		const key = load(RUST_SCOPED_KEY);
+		const claims = await verify(key, RUST_SCOPED_TOKEN);
+		expect(claims.put).toEqual(["live/room"]);
+		expect(claims.get).toEqual(["watch"]);
+	});
+
+	test("JS enforces the same scope Rust does", async () => {
+		const key = load(RUST_SCOPED_KEY);
+
+		// Rust rejects this exact pair with "token capabilities exceed the key scope":
+		// cargo run --bin moq-token -- sign --key /tmp/scoped.jwk --root project --publish other
+		await expect(sign(key, { root: "project", put: ["other"] })).rejects.toThrow("exceed the key scope");
+
+		// ...and accepts the grants Rust signed into RUST_SCOPED_TOKEN. The encoding
+		// is not compared: JS orders the header differently and stamps `iat`.
+		const token = await sign(key, { root: "project", put: ["live/room"], get: ["watch"] });
+		const claims = await verify(key, token);
+		expect(claims.put).toEqual(["live/room"]);
+		expect(claims.get).toEqual(["watch"]);
+	});
 });
 
 describe("Rust-generated JWK Set", () => {

--- a/js/token/src/key.test.ts
+++ b/js/token/src/key.test.ts
@@ -650,3 +650,34 @@ test("verify - claims validation during verification", async () => {
 	const verifiedClaims = await verify(key, token);
 	expect(verifiedClaims.root).toBe("test-path");
 });
+
+test("key scope is enforced when signing and verifying", async () => {
+	const unrestricted = load(encodeJwk(testKey));
+	const scoped: Key = {
+		...unrestricted,
+		scope: { root: "project", put: ["live"] },
+	};
+	const allowed: Claims = { root: "project", put: ["live/room"] };
+	const denied: Claims = { root: "project", put: ["other"] };
+
+	await expect(sign(scoped, allowed)).resolves.toBeString();
+	await expect(sign(scoped, denied)).rejects.toThrow("exceed the key scope");
+
+	// A token signed by an unscoped copy of the key must still be rejected on the
+	// way in, so a scope can't be stripped by re-signing elsewhere.
+	const forged = await sign(unrestricted, denied);
+	await expect(verify(scoped, forged)).rejects.toThrow("exceed the key scope");
+});
+
+test("key scope treats absolute and rooted grants alike", async () => {
+	const scoped: Key = { ...load(encodeJwk(testKey)), scope: { root: "project", put: ["live"] } };
+
+	await expect(sign(scoped, { root: "", put: ["project/live/room"] })).resolves.toBeString();
+	await expect(sign(scoped, { root: "/project/live/", put: ["/room"] })).resolves.toBeString();
+	// Segment-aware: "live" must not cover "lively".
+	await expect(sign(scoped, { root: "project", put: ["lively"] })).rejects.toThrow("exceed the key scope");
+	// A root above the scope does not widen it.
+	await expect(sign(scoped, { root: "", put: [""] })).rejects.toThrow("exceed the key scope");
+	// Roles are independent: a publish-only scope grants no subscribe.
+	await expect(sign(scoped, { root: "project", get: ["live"] })).rejects.toThrow("exceed the key scope");
+});

--- a/js/token/src/key.ts
+++ b/js/token/src/key.ts
@@ -2,7 +2,7 @@ import * as base64 from "@hexagon/base64";
 import * as jose from "jose";
 import * as z from "zod/mini";
 import { type Algorithm, AlgorithmSchema } from "./algorithm.ts";
-import { type Claims, ClaimsSchema } from "./claims.ts";
+import { type Claims, ClaimsSchema, ScopeSchema, scopeAllows } from "./claims.ts";
 
 /**
  * A validated key identifier (kid). Only alphanumeric, hyphens, and underscores.
@@ -39,6 +39,7 @@ const BaseKeySchema = z.object({
 	alg: AlgorithmSchema,
 	key_ops: z.array(OperationSchema).check(z.minLength(1)),
 	kid: z.optional(KeyIdSchema),
+	scope: z.optional(ScopeSchema),
 });
 
 const OctKeySchema = z.extend(BaseKeySchema, {
@@ -204,6 +205,7 @@ export async function sign(key: Key, claims: Claims): Promise<string> {
 	} catch (error) {
 		throw new Error(`Invalid claims: ${error instanceof Error ? error.message : "unknown error"}`);
 	}
+	ensureClaimsWithinScope(key, claims);
 
 	const joseKey = await importJoseKey(key);
 	const jwt = await new jose.SignJWT(claims)
@@ -230,10 +232,22 @@ export async function verify(key: PublicKey | SymmetricKey, token: string): Prom
 		algorithms: [key.alg],
 	});
 
+	let claims: Claims;
 	try {
-		return ClaimsSchema.parse(payload);
+		claims = ClaimsSchema.parse(payload);
 	} catch (error) {
 		throw new Error(`Failed to parse token claims: ${error instanceof Error ? error.message : "unknown error"}`);
+	}
+
+	// Re-check on the way in, so a scope cannot be stripped by re-signing elsewhere.
+	ensureClaimsWithinScope(key, claims);
+
+	return claims;
+}
+
+function ensureClaimsWithinScope(key: PublicKey | SymmetricKey | Key, claims: Claims): void {
+	if (key.scope && !scopeAllows(key.scope, claims)) {
+		throw new Error("Token capabilities exceed the key scope");
 	}
 }
 

--- a/rs/moq-token-cli/src/main.rs
+++ b/rs/moq-token-cli/src/main.rs
@@ -43,6 +43,18 @@ enum Commands {
 		/// Write the public key to a directory as {kid}.jwk (asymmetric algorithms only).
 		#[arg(long, conflicts_with = "public")]
 		public_dir: Option<PathBuf>,
+
+		/// Root path for the optional key scope.
+		#[arg(long, default_value = "")]
+		root: String,
+
+		/// Publish prefixes the key may grant (repeatable).
+		#[arg(long)]
+		publish: Vec<String>,
+
+		/// Subscribe prefixes the key may grant (repeatable).
+		#[arg(long)]
+		subscribe: Vec<String>,
 	},
 
 	/// Sign a token, writing it to stdout.
@@ -127,13 +139,23 @@ fn main() -> anyhow::Result<()> {
 			out_dir,
 			public,
 			public_dir,
+			root,
+			publish,
+			subscribe,
 		} => {
 			let id = match id {
 				Some(id) => moq_token::KeyId::decode(&id)?,
 				None => moq_token::KeyId::random(),
 			};
 
-			let key = moq_token::Key::generate(algorithm, Some(id.clone()))?;
+			let mut key = moq_token::Key::generate(algorithm, Some(id.clone()))?;
+			if !publish.is_empty() || !subscribe.is_empty() {
+				key = key.with_scope(moq_token::Scope {
+					root,
+					publish,
+					subscribe,
+				})?;
+			}
 
 			let public_to_stdout = public.as_deref().is_some_and(is_dash);
 			let private_to_stdout = out_dir.is_none() && out.as_deref().is_none_or(is_dash);

--- a/rs/moq-token/src/claims.rs
+++ b/rs/moq-token/src/claims.rs
@@ -2,6 +2,73 @@ use crate::path;
 use serde::{Deserialize, Serialize};
 use serde_with::{OneOrMany, TimestampSeconds, formats::PreferMany, serde_as};
 
+/// The immutable ceiling on what a key may grant, embedded in its JWK.
+///
+/// Paths in `publish` and `subscribe` are relative to `root`, matching token claim
+/// semantics. A key signs a token only when every path the token grants sits at or
+/// beneath one the scope allows, in the same role; see [`allows`](Self::allows).
+///
+/// The scope is fixed at key generation. Widening it means minting a new key, which
+/// is the point: a leaked scoped key can never be talked into signing more than it
+/// already could. A key with no scope at all is unrestricted, so keys minted before
+/// scopes existed keep working.
+#[derive(Debug, Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
+pub struct Scope {
+	/// The root for the publish/subscribe prefixes below.
+	#[serde(default, skip_serializing_if = "String::is_empty")]
+	pub root: String,
+
+	/// Prefixes this key may grant to publishers.
+	#[serde(default, rename = "put", skip_serializing_if = "Vec::is_empty")]
+	pub publish: Vec<String>,
+
+	/// Prefixes this key may grant to subscribers.
+	#[serde(default, rename = "get", skip_serializing_if = "Vec::is_empty")]
+	pub subscribe: Vec<String>,
+}
+
+impl Scope {
+	/// Returns an error when the scope permits nothing, making the key unusable.
+	pub fn validate(&self) -> crate::Result<()> {
+		if self.publish.is_empty() && self.subscribe.is_empty() {
+			return Err(crate::Error::UselessScope);
+		}
+
+		Ok(())
+	}
+
+	/// Whether every path `claims` grants is covered by this scope, per role.
+	///
+	/// Both sides are resolved against their own root before comparing, so the same
+	/// grant expressed as `root: "demo"` + `put: ["room"]` or as `put: ["demo/room"]`
+	/// is treated identically. Matching is segment-aware, so a scope of `live` does
+	/// not cover `lively`, and the roles are checked independently: a publish-only
+	/// scope never authorizes a subscribe grant.
+	///
+	/// An empty prefix covers everything beneath the scope root, so a scope of
+	/// `root: "demo"` + `put: [""]` grants publish anywhere under `demo`.
+	pub fn allows(&self, claims: &Claims) -> bool {
+		covers(&self.root, &self.publish, &claims.root, &claims.publish)
+			&& covers(&self.root, &self.subscribe, &claims.root, &claims.subscribe)
+	}
+}
+
+/// Whether every `requested` path (relative to `claims_root`) sits beneath some
+/// `granted` prefix (relative to `scope_root`).
+///
+/// An empty `granted` denies everything, which is what makes a publish-only scope
+/// reject subscribe grants rather than ignoring them.
+fn covers(scope_root: &str, granted: &[String], claims_root: &str, requested: &[String]) -> bool {
+	let absolute = |root: &str, relative: &str| path::join(&path::normalize(root), &path::normalize(relative));
+
+	requested.iter().all(|request| {
+		let request = absolute(claims_root, request);
+		granted
+			.iter()
+			.any(|grant| path::has_prefix(&request, &absolute(scope_root, grant)))
+	})
+}
+
 /// The access a [`Claims`] grants at a specific path, with every prefix rebased so
 /// it is relative to that path.
 ///
@@ -187,6 +254,127 @@ mod tests {
 			expires: Some(SystemTime::now() + Duration::from_secs(3600)),
 			issued: Some(SystemTime::now()),
 		}
+	}
+
+	#[test]
+	fn scope_allows_contained_claims() {
+		let scope = Scope {
+			root: "project".into(),
+			publish: vec!["live".into()],
+			subscribe: vec!["watch".into()],
+		};
+		let claims = Claims {
+			root: "project/live/room".into(),
+			publish: vec!["".into()],
+			subscribe: vec![],
+			..Default::default()
+		};
+		assert!(scope.allows(&claims));
+	}
+
+	#[test]
+	fn scope_rejects_sibling_and_role_escalation() {
+		let scope = Scope {
+			root: "project".into(),
+			publish: vec!["live".into()],
+			subscribe: vec![],
+		};
+		let sibling = Claims {
+			root: "project/lively".into(),
+			publish: vec!["".into()],
+			..Default::default()
+		};
+		let role = Claims {
+			root: "project/live".into(),
+			subscribe: vec!["".into()],
+			..Default::default()
+		};
+		assert!(!scope.allows(&sibling));
+		assert!(!scope.allows(&role));
+	}
+
+	#[test]
+	fn scope_ignores_how_the_root_is_split() {
+		// The same grant, expressed three ways, must compare identically.
+		let scope = Scope {
+			root: "project".into(),
+			publish: vec!["live".into()],
+			subscribe: vec![],
+		};
+
+		for claims in [
+			Claims {
+				root: "project".into(),
+				publish: vec!["live/room".into()],
+				..Default::default()
+			},
+			Claims {
+				root: String::new(),
+				publish: vec!["project/live/room".into()],
+				..Default::default()
+			},
+			Claims {
+				root: "/project/live/".into(),
+				publish: vec!["/room".into()],
+				..Default::default()
+			},
+		] {
+			assert!(scope.allows(&claims), "{claims:?}");
+		}
+	}
+
+	#[test]
+	fn scope_rejects_escaping_above_its_root() {
+		let scope = Scope {
+			root: "project".into(),
+			publish: vec!["live".into()],
+			subscribe: vec![],
+		};
+
+		// A root above the scope's does not widen it, even though the empty prefix
+		// would grant everything within the scope.
+		let claims = Claims {
+			root: String::new(),
+			publish: vec!["".into()],
+			..Default::default()
+		};
+		assert!(!scope.allows(&claims));
+	}
+
+	#[test]
+	fn scope_empty_prefix_grants_everything_beneath_it() {
+		let scope = Scope {
+			root: "project".into(),
+			publish: vec![String::new()],
+			subscribe: vec![],
+		};
+		let claims = Claims {
+			root: "project/anything/deep".into(),
+			publish: vec!["".into()],
+			..Default::default()
+		};
+		assert!(scope.allows(&claims));
+	}
+
+	#[test]
+	fn scope_requires_every_requested_path() {
+		// One allowed path does not carry an unallowed sibling along with it.
+		let scope = Scope {
+			root: "project".into(),
+			publish: vec!["live".into()],
+			subscribe: vec![],
+		};
+		let claims = Claims {
+			root: "project".into(),
+			publish: vec!["live/room".into(), "other".into()],
+			..Default::default()
+		};
+		assert!(!scope.allows(&claims));
+	}
+
+	#[test]
+	fn scope_without_grants_is_useless() {
+		assert!(matches!(Scope::default().validate(), Err(crate::Error::UselessScope)));
 	}
 
 	#[test]

--- a/rs/moq-token/src/error.rs
+++ b/rs/moq-token/src/error.rs
@@ -56,6 +56,12 @@ pub enum Error {
 	#[error("token grants no access to path `{0}`")]
 	NoAccess(String),
 
+	#[error("no publish or subscribe allowed; key scope is useless")]
+	UselessScope,
+
+	#[error("token capabilities exceed the key scope")]
+	ScopeExceeded,
+
 	#[error("invalid algorithm: {0}")]
 	InvalidAlgorithm(String),
 

--- a/rs/moq-token/src/generate.rs
+++ b/rs/moq-token/src/generate.rs
@@ -26,6 +26,7 @@ pub fn generate(algorithm: Algorithm, id: Option<crate::KeyId>) -> crate::Result
 		operations: [KeyOperation::Sign, KeyOperation::Verify].into(),
 		algorithm,
 		key: key?,
+		scope: None,
 		decode: Default::default(),
 		encode: Default::default(),
 	})

--- a/rs/moq-token/src/key.rs
+++ b/rs/moq-token/src/key.rs
@@ -160,6 +160,10 @@ pub struct Key {
 	#[serde(skip_serializing_if = "Option::is_none")]
 	pub kid: Option<crate::KeyId>,
 
+	/// Optional immutable authorization limits for tokens signed by this key.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub scope: Option<crate::Scope>,
+
 	// Cached for performance reasons, unfortunately.
 	#[serde(skip)]
 	pub(crate) decode: OnceLock<DecodingKey>,
@@ -203,6 +207,7 @@ impl fmt::Debug for Key {
 			.field("algorithm", &self.algorithm)
 			.field("operations", &self.operations)
 			.field("kid", &self.kid)
+			.field("scope", &self.scope)
 			.finish()
 	}
 }
@@ -281,6 +286,7 @@ impl Key {
 			operations: [KeyOperation::Verify].into(),
 			key,
 			kid: self.kid.clone(),
+			scope: self.scope.clone(),
 			decode: Default::default(),
 			encode: Default::default(),
 		})
@@ -438,6 +444,7 @@ impl Key {
 		}
 
 		token.claims.validate()?;
+		self.validate_scope(&token.claims)?;
 
 		Ok(token.claims)
 	}
@@ -449,6 +456,7 @@ impl Key {
 		}
 
 		payload.validate()?;
+		self.validate_scope(payload)?;
 
 		let encode = self.to_encoding_key()?;
 
@@ -473,6 +481,23 @@ impl Key {
 	/// Generate a key pair for the given algorithm, returning the private and public keys.
 	pub fn generate(algorithm: Algorithm, id: Option<crate::KeyId>) -> crate::Result<Self> {
 		generate(algorithm, id)
+	}
+
+	/// Attach an immutable authorization scope to this key.
+	pub fn with_scope(mut self, scope: crate::Scope) -> crate::Result<Self> {
+		scope.validate()?;
+		self.scope = Some(scope);
+		Ok(self)
+	}
+
+	fn validate_scope(&self, claims: &Claims) -> crate::Result<()> {
+		if let Some(scope) = &self.scope {
+			scope.validate()?;
+			if !scope.allows(claims) {
+				return Err(crate::Error::ScopeExceeded);
+			}
+		}
+		Ok(())
 	}
 }
 
@@ -542,6 +567,7 @@ mod tests {
 				secret: b"test-secret-that-is-long-enough-for-hmac-sha256".to_vec(),
 			},
 			kid: Some(crate::KeyId::decode("test-key-1").unwrap()),
+			scope: None,
 			decode: Default::default(),
 			encode: Default::default(),
 		}
@@ -630,6 +656,35 @@ mod tests {
 
 		assert!(!token.is_empty());
 		assert_eq!(token.matches('.').count(), 2); // JWT format: header.payload.signature
+	}
+
+	#[test]
+	fn test_key_scope_enforced_when_signing_and_verifying() {
+		let unrestricted = create_test_key();
+		let scoped = unrestricted
+			.clone()
+			.with_scope(crate::Scope {
+				root: "test-path".into(),
+				publish: vec!["allowed".into()],
+				subscribe: vec![],
+			})
+			.unwrap();
+		let allowed = Claims {
+			root: "test-path".into(),
+			publish: vec!["allowed/room".into()],
+			..Default::default()
+		};
+		let denied = Claims {
+			root: "test-path".into(),
+			publish: vec!["other".into()],
+			..Default::default()
+		};
+
+		assert!(scoped.sign(&allowed).is_ok());
+		assert!(matches!(scoped.sign(&denied), Err(crate::Error::ScopeExceeded)));
+
+		let forged = unrestricted.sign(&denied).unwrap();
+		assert!(matches!(scoped.verify(&forged), Err(crate::Error::ScopeExceeded)));
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

A JWK can now carry an immutable `scope`, capping what tokens it may sign. A key generated for `project` + `put: ["live"]` can only ever mint tokens publishing at or beneath `project/live`, so a leaked key cannot be talked into signing more than it already could. Widening means minting a new key.

- `Scope { root, put, get }` embedded in the JWK, mirroring claim semantics. Enforced in **both** `sign` and `verify`, so a scope cannot be stripped by re-signing elsewhere and the relay re-checks on the way in.
- A key with no `scope` is unrestricted, so existing keys keep working.
- `moq-token generate --root/--publish/--subscribe` writes the scope into both halves of an asymmetric pair.
- `to_public()` preserves the scope, so a verify-only public key enforces it too.

Containment resolves both sides against their own root before comparing, so `root: "demo"` + `put: ["room"]` and `put: ["demo/room"]` are treated identically. Matching is segment-aware (`live` does not cover `lively`) and roles are independent (a publish-only scope never authorizes a subscribe grant).

## Scope of this PR

Purely additive to `moq-token` and `@moq/token`. **No relay changes.**

An earlier revision also reworked `moq-relay`'s root check so a pid-rooted token would authorize a connection dialed through a vanity name. That was dropped: it reintroduced the first-segment splicing removed in https://github.com/moq-dev/moq/pull/1581#discussion_r3336909958, and it baked in the assumption that an alias may differ from the dialed path only in its leading segment, which is exactly the flexibility that comment was preserving.

The consequence is a real limitation, documented in `doc/bin/relay/auth.md`: because the token root is checked against the dialed path, a scope must be anchored at whichever name its tokens are rooted at. Anchor at the stable id and the tokens work on stable-id paths; anchor at a vanity name and they break when that name changes. Reconciling that belongs in its own change.

## Public API changes

Additive only, hence `main`:

- **New** `moq_token::Scope`, `Key::with_scope`, `Key::scope`, `Error::UselessScope`, `Error::ScopeExceeded`.
- **New** `@moq/token`: `ScopeSchema`, `Scope`, `scopeAllows`, optional `scope` on `KeySchema`.
- **New** `moq-token generate --root/--publish/--subscribe`.
- No renamed, removed, or signature-changed items.

## Test plan

- `cargo test -p moq-token` — 119 pass. Covers cross-form equivalence, segment boundaries, role independence, escaping above the scope root, per-path requirement, and sign/verify symmetry.
- `bun test js/token/src` — 88 pass, including interop fixtures generated by the real `moq-token` CLI: a scoped JWK, an in-scope token Rust signed, and the exact grant pair Rust rejects.
- `just check` clean; `RUSTDOCFLAGS=-D warnings cargo doc` clean.

Not exercised against a live relay. The moq.pro dashboard side (surfacing scopes in the key UI, respecting them in token forms) is a follow-up that needs this published first.

(written by Opus 4.8)