### PR TITLE
fix(js/net): disable WebTransport on Safari

### DIFF
--- a/js/net/src/connection/browser.test.ts
+++ b/js/net/src/connection/browser.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+import { isWebTransportUserAgentSupported } from "./browser.ts";
+
+test.each([
+	[
+		"Safari on macOS",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15",
+	],
+	[
+		"Safari on iOS",
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 26_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Mobile/15E148 Safari/604.1",
+	],
+	["Firefox", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:151.0) Gecko/20100101 Firefox/151.0"],
+])("disables WebTransport on %s", (_browser, userAgent) => {
+	expect(isWebTransportUserAgentSupported(userAgent)).toBeFalse();
+});
+
+test.each([
+	[
+		"Chrome",
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36",
+	],
+	[
+		"Chrome on Android",
+		"Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/151.0.0.0 Mobile Safari/537.36",
+	],
+])("enables WebTransport on %s", (_browser, userAgent) => {
+	expect(isWebTransportUserAgentSupported(userAgent)).toBeTrue();
+});

--- a/js/net/src/connection/browser.ts
+++ b/js/net/src/connection/browser.ts
@@ -1,0 +1,24 @@
+/** Returns whether a browser user agent has a usable WebTransport implementation. */
+export function isWebTransportUserAgentSupported(userAgent: string): boolean {
+	const normalized = userAgent.toLowerCase();
+
+	// Firefox only allows two concurrent remote-initiated streams:
+	// https://bugzilla.mozilla.org/show_bug.cgi?id=2046262
+	if (normalized.includes("firefox")) return false;
+
+	// Safari's flow-control window never refills, which permanently stalls sessions:
+	// https://bugs.webkit.org/show_bug.cgi?id=319818
+	const isSafari =
+		normalized.includes("safari") &&
+		!normalized.includes("chrome") &&
+		!normalized.includes("chromium") &&
+		!normalized.includes("android");
+	return !isSafari;
+}
+
+/** Returns whether this runtime can connect with WebTransport. */
+export function isWebTransportSupported(): boolean {
+	if (typeof globalThis.WebTransport === "undefined") return false;
+	if (typeof navigator === "undefined") return true;
+	return isWebTransportUserAgentSupported(navigator.userAgent);
+}

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -3,6 +3,7 @@ import * as Ietf from "../ietf/index.ts";
 import * as Lite from "../lite/index.ts";
 import { Stream } from "../stream.ts";
 import * as Hex from "../util/hex.ts";
+import { isWebTransportSupported } from "./browser.ts";
 import type { Established } from "./established.ts";
 import { exchangeSetup } from "./handshake.ts";
 
@@ -88,11 +89,6 @@ function defaultDiscovery(url: URL): boolean {
 // Save if WebSocket won the last race, so we won't give QUIC a head start next time.
 const websocketWon = new Set<string>();
 
-// Firefox's WebTransport implementation drops server-initiated bidi streams,
-// breaking publish (the relay opens a subscribe bidi back to us). Force WebSocket.
-// TODO: remove once Firefox fixes incoming bidi delivery.
-const isFirefox = typeof navigator !== "undefined" && navigator.userAgent.toLowerCase().includes("firefox");
-
 /**
  * Establishes a connection to a MOQ server.
  *
@@ -109,8 +105,7 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 	// Create a cancel promise to kill whichever is still connecting.
 	const { promise: cancel, resolve: done } = Promise.withResolvers<void>();
 
-	const webtransport =
-		globalThis.WebTransport && !isFirefox ? connectWebTransport(url, cancel, props?.webtransport) : undefined;
+	const webtransport = isWebTransportSupported() ? connectWebTransport(url, cancel, props?.webtransport) : undefined;
 
 	// Give QUIC a head start to connect before trying WebSocket, unless WebSocket has won in the past.
 	// NOTE that QUIC should be faster because it involves 1/2 fewer RTTs.

--- a/js/net/src/connection/index.ts
+++ b/js/net/src/connection/index.ts
@@ -4,6 +4,7 @@
  * @module
  */
 export * from "./accept.ts";
+export { isWebTransportSupported } from "./browser.ts";
 export * from "./connect.ts";
 export * from "./established.ts";
 export * from "./reload.ts";

--- a/js/publish/src/support/index.ts
+++ b/js/publish/src/support/index.ts
@@ -5,6 +5,7 @@
  * @module
  */
 import * as Util from "@moq/hang/util";
+import { Connection } from "@moq/net";
 
 export type Level = "full" | "partial" | "none";
 
@@ -92,9 +93,8 @@ async function videoEncoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 
 export async function isSupported(): Promise<Full> {
 	return {
-		// Firefox's WebTransport drops server-initiated bidi streams, so we force the
-		// WebSocket fallback. Report "partial" to surface the degraded path in UI.
-		webtransport: typeof WebTransport !== "undefined" ? (Util.Hacks.isFirefox ? "partial" : "full") : "partial",
+		// Report "partial" when @moq/net forces the WebSocket fallback.
+		webtransport: Connection.isWebTransportSupported() ? "full" : "partial",
 		audio: {
 			capture: typeof AudioWorkletNode !== "undefined",
 			encoding: {

--- a/js/watch/src/support/index.ts
+++ b/js/watch/src/support/index.ts
@@ -3,6 +3,8 @@
  *
  * @module
  */
+import { Connection } from "@moq/net";
+
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1967793
 const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
 
@@ -84,9 +86,8 @@ async function videoDecoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 
 export async function isSupported(): Promise<Full> {
 	return {
-		// Firefox's WebTransport drops server-initiated bidi streams, so we force the
-		// WebSocket fallback. Report "partial" to surface the degraded path in UI.
-		webtransport: typeof WebTransport !== "undefined" ? (isFirefox ? "partial" : "full") : "partial",
+		// Report "partial" when @moq/net forces the WebSocket fallback.
+		webtransport: Connection.isWebTransportSupported() ? "full" : "partial",
 		audio: {
 			decoding: {
 				aac: await audioDecoderSupported("aac"),


### PR DESCRIPTION
## Summary

- Force Safari onto the WebSocket fallback because WebTransport flow-control credit never refills, permanently stalling sessions.
- Preserve the Firefox fallback for its remote-initiated stream limit.
- Centralize the browser gate and use it in the publish/watch support diagnostics.
- Add Safari, Firefox, and Chrome user-agent regression coverage.

## Public API changes

- Add the additive `Connection.isWebTransportSupported()` helper.

## Test plan

- `nix develop --command just ci`

No wire-format or Rust changes are involved, so no cross-language synchronization is needed.

(Written by GPT-5)
