### PR TITLE
fix(net): lower WebTransport log level

### DIFF
--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -144,7 +144,7 @@ export async function connect(url: URL, props?: ConnectProps): Promise<Establish
 		console.warn(url.toString(), "connected via WebSocket");
 		websocketWon.add(url.toString());
 	} else {
-		console.log(url.toString(), "connected via WebTransport");
+		console.debug(url.toString(), "connected via WebTransport");
 	}
 
 	// Get the negotiated protocol. qmux Session exposes it directly;


### PR DESCRIPTION
## Summary

- move successful WebTransport connection messages from `console.log` to `console.debug`
- keep WebSocket fallback messages at `console.warn`

The root cause was that routine WebTransport success used `console.log` while adjacent ALPN and SETUP diagnostics already used `console.debug`. WebSocket fallback remains a warning because it signals that the preferred transport was unavailable or lost the connection race.

Fixes #2405.

## Public API changes

None. Cross-package synchronization is not applicable because the wire protocol and public API are unchanged.

## Test plan

- `bun biome check js/net/src/connection/connect.ts`
- `bun run --cwd js/net check`
- `bun test js/net/src --only-failures`

(Written by GPT-5)
