### PR TITLE
feat(net): unannounce as soon as the last route detaches

### DIFF
--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -145,7 +145,7 @@ if moq.IsAuthError(err) {
 
 ## Publishing lifetime
 
-A broadcast stays live only while you hold its `BroadcastProducer`. Once the producer is garbage-collected the broadcast is treated as a failure: the path lingers briefly for a replacement publisher, then subscribers get a reset mid-stream. This bites when the producer goes out of scope while a background goroutine is still writing to its tracks.
+A broadcast stays live only while you hold its `BroadcastProducer`. Once the producer is garbage-collected the path unannounces and subscribers get a reset mid-stream. This bites when the producer goes out of scope while a background goroutine is still writing to its tracks.
 
 Keep a reference for as long as you are publishing, then close it explicitly when done:
 

--- a/rs/moq-gst/src/sink/imp.rs
+++ b/rs/moq-gst/src/sink/imp.rs
@@ -349,9 +349,8 @@ impl MoqSink {
 		if let Err(err) = state.finalize_all() {
 			gst::warning!(CAT, "finalize on stop: {err:?}");
 		}
-		// Finish the broadcast (a deliberate end, so the origin unannounces it
-		// immediately instead of lingering for a reconnect) before reaping the
-		// session task.
+		// Finish the broadcast (a deliberate end, so no dropped-without-finish
+		// warning) before reaping the session task.
 		state.broadcast.finish();
 		state.session.stop();
 	}

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -68,8 +68,8 @@ struct TrackState {
 
 struct BroadcastState {
 	// The source feeding this broadcast into our origin: finish() on a
-	// deliberate unannounce detaches immediately, dropping (a dying session)
-	// aborts it so the origin lingers for a reconnect.
+	// deliberate unannounce, dropping (a dying session) aborts it. Either way
+	// the origin unannounces once the last source detaches.
 	producer: crate::model::broadcast::SourceGuard,
 
 	// active number of PUBLISH or PUBLISH_NAMESPACE messages.
@@ -608,8 +608,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				entry.get_mut().count -= 1;
 				if entry.get().count == 0 {
 					tracing::debug!(broadcast = %self.origin.absolute(&path), "unannounced");
-					// A deliberate unannounce: finish the source so the origin
-					// detaches it immediately instead of lingering.
+					// A deliberate unannounce, so finish() rather than drop.
 					entry.remove().producer.finish();
 				}
 			}

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -352,8 +352,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					// The matching Active may have been silently dropped by
 					// start_announce as a reflected loop, in which case
 					// `routes` has no entry; that's expected, not an error.
-					// A deliberate unannounce detaches gracefully: if this was the
-					// broadcast's last route it closes now, without the reconnect linger.
+					// A deliberate unannounce, so finish() rather than drop; the origin
+					// unannounces if this was the broadcast's last route.
 					if let Some(entry) = routes.remove(&path) {
 						entry.finish();
 						stats_guards.remove(&abs);
@@ -375,8 +375,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					// The matching Active may have been silently dropped by
 					// start_announce as a reflected loop, in which case
 					// `routes` has no entry; that's expected, not an error.
-					// A deliberate unannounce detaches gracefully: if this was the
-					// broadcast's last route it closes now, without the reconnect linger.
+					// A deliberate unannounce, so finish() rather than drop; the origin
+					// unannounces if this was the broadcast's last route.
 					if let Some(entry) = routes.remove(&path) {
 						entry.finish();
 						stats_guards.remove(&abs);

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -129,19 +129,8 @@ struct BroadcastState {
 	route_epoch: u64,
 
 	// Set by an explicit `Producer::finish()` or `Producer::abort()` so `Drop` can
-	// tell a deliberate shutdown apart from a producer dropped by accident, and so
-	// the origin can tell a graceful end (unpublish immediately) from a failure
-	// (linger for a reconnect).
-	close: Option<Close>,
-}
-
-/// How a broadcast was deliberately ended.
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum Close {
-	/// A clean end: the content is over.
-	Finish,
-	/// An abnormal end: the producer is going away (e.g. its session died).
-	Abort,
+	// tell a deliberate shutdown apart from a producer dropped by accident.
+	closing: bool,
 }
 
 /// The spliced (route-fed) half of a broadcast: logical tracks that outlive any
@@ -359,16 +348,14 @@ impl Producer {
 	/// gone, so a clone that outlives this call keeps it alive until it too is
 	/// dropped or finished.
 	pub fn finish(self) {
-		self.state.lock().close.get_or_insert(Close::Finish);
+		self.state.lock().closing = true;
 	}
 
 	/// Mark the broadcast as deliberately ending abnormally, without the
-	/// dropped-without-finish warning. Unlike [`Self::finish`], an origin treats the
-	/// closure as a failure: the published path lingers briefly so a reconnecting
-	/// session can replace this broadcast without consumers noticing. Used by
-	/// sessions tearing down announced broadcasts when the connection dies.
+	/// dropped-without-finish warning. Used by sessions tearing down announced
+	/// broadcasts when the connection dies.
 	pub(crate) fn abort(&self) {
-		self.state.lock().close.get_or_insert(Close::Abort);
+		self.state.lock().closing = true;
 	}
 
 	/// Return true if this is the same broadcast instance.
@@ -387,7 +374,7 @@ impl Drop for Producer {
 		if !self.alive.is_last() {
 			return;
 		}
-		if self.state.read().close.is_none() {
+		if !self.state.read().closing {
 			tracing::warn!(
 				"broadcast::Producer dropped without finish(). Keep the producer alive while publishing, then call finish()."
 			);
@@ -408,10 +395,10 @@ impl Producer {
 
 /// A session-owned handle to a source broadcast created via
 /// [`crate::origin::Producer::create_broadcast`]: [`Self::finish`] ends it
-/// deliberately (the origin unannounces immediately), while dropping the guard
-/// marks the source aborted (the origin lingers for a reconnect, and the
-/// dropped-without-finish warning stays quiet). Shared by the lite and IETF
-/// subscribers so the drop-vs-finish contract lives in one place.
+/// deliberately, while dropping the guard marks the source aborted (keeping the
+/// dropped-without-finish warning quiet). Either way the origin unannounces once
+/// the last source detaches. Shared by the lite and IETF subscribers so the
+/// drop-vs-finish contract lives in one place.
 pub(crate) struct SourceGuard {
 	// `Option` so `finish` can consume the producer while `Drop` aborts it.
 	producer: Option<Producer>,
@@ -500,14 +487,14 @@ impl Dynamic {
 	/// release its handle.
 	pub fn poll_requested_track(&mut self, waiter: &kio::Waiter) -> Poll<Result<track::Request, Error>> {
 		let mut state = ready!(self.state.poll(waiter, |state| {
-			if state.requests.has_queued() || state.close.is_some() {
+			if state.requests.has_queued() || state.closing {
 				Poll::Ready(())
 			} else {
 				Poll::Pending
 			}
 		}));
 
-		if state.close.is_some() && !state.requests.has_queued() {
+		if state.closing && !state.requests.has_queued() {
 			return Poll::Ready(Err(Error::Closed));
 		}
 
@@ -681,7 +668,7 @@ impl Consumer {
 
 		// A deliberately-ended broadcast serves nothing new; existing tracks above
 		// stay readable so consumers can drain the cache.
-		if state.close.is_some() {
+		if state.closing {
 			return Err(Error::NotFound);
 		}
 
@@ -715,19 +702,12 @@ impl Consumer {
 		self.alive.is_closed()
 	}
 
-	/// Whether the broadcast was ended deliberately with [`Producer::finish`], as
-	/// opposed to aborted or dropped. The origin uses this to unpublish a closed
-	/// broadcast immediately instead of lingering for a reconnect.
-	pub(crate) fn is_finished(&self) -> bool {
-		self.state.read().close == Some(Close::Finish)
-	}
-
 	/// Whether the broadcast is on its way out: deliberately ended (finish/abort
 	/// marked, even while handles remain) or already fully closed. The origin's
 	/// dispatcher treats a rejection from such a source as imminent detach rather
 	/// than a strike.
 	pub(crate) fn is_closing(&self) -> bool {
-		self.is_closed() || self.state.read().close.is_some()
+		self.is_closed() || self.state.read().closing
 	}
 
 	/// Register a [`kio::Waiter`] that fires when the broadcast closes.

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -351,9 +351,10 @@ impl Producer {
 		self.state.lock().closing = true;
 	}
 
-	/// Mark the broadcast as deliberately ending abnormally, without the
-	/// dropped-without-finish warning. Used by sessions tearing down announced
-	/// broadcasts when the connection dies.
+	/// Mark the broadcast as deliberately ended, without the
+	/// dropped-without-finish warning. Same effect as [`Self::finish`], but takes
+	/// `&self` for callers that can't consume the producer. Used by sessions
+	/// tearing down announced broadcasts when the connection dies.
 	pub(crate) fn abort(&self) {
 		self.state.lock().closing = true;
 	}

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -822,10 +822,10 @@ impl Producer {
 	/// [`broadcast::Producer::dynamic`] handler before awaiting, so the first
 	/// consumer finds them.
 	///
-	/// End the broadcast with [`broadcast::Producer::finish`]. Either way, a
-	/// source detaching unannounces the path if it was the last one: a
-	/// replacement splices in without consumers noticing only if it attaches
-	/// before the last source detaches.
+	/// End the broadcast with [`broadcast::Producer::finish`]; dropping it
+	/// without finishing also works, but logs a warning. Either way the path
+	/// unannounces once the last source detaches, so a replacement splices in
+	/// without consumers noticing only if it attaches before that happens.
 	///
 	/// Fails with [`Error::Unauthorized`] if `path` is outside the prefixes this
 	/// producer may publish under (after [`scope`](Self::scope) /

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -6,7 +6,6 @@ use std::{
 	sync::Arc,
 	sync::atomic::{AtomicU64, Ordering},
 	task::{Poll, ready},
-	time::Duration,
 };
 
 use rand::RngExt;
@@ -823,11 +822,10 @@ impl Producer {
 	/// [`broadcast::Producer::dynamic`] handler before awaiting, so the first
 	/// consumer finds them.
 	///
-	/// End the broadcast with [`broadcast::Producer::finish`]: a finished source
-	/// detaches immediately, unannouncing the path if it was the last. A source
-	/// that is dropped without finishing is treated as a failure: the path
-	/// lingers briefly so a replacement source (e.g. a reconnecting session) can
-	/// splice in without consumers noticing.
+	/// End the broadcast with [`broadcast::Producer::finish`]. Either way, a
+	/// source detaching unannounces the path if it was the last one: a
+	/// replacement splices in without consumers noticing only if it attaches
+	/// before the last source detaches.
 	///
 	/// Fails with [`Error::Unauthorized`] if `path` is outside the prefixes this
 	/// producer may publish under (after [`scope`](Self::scope) /
@@ -941,12 +939,6 @@ impl Producer {
 	}
 }
 
-/// How long a broadcast outlives its last source, so a reconnecting session can
-/// re-attach and resume without consumers ever noticing. Consumers stall (serving
-/// from cache) during the window; once it expires the broadcast is unpublished and
-/// its unfinished tracks abort.
-const ROUTE_LINGER: Duration = Duration::from_secs(5);
-
 /// How many times serving a single track may fail before it is spliced in (the
 /// source rejected it, or its info never resolved) before the track is aborted
 /// instead of retried. Bounds the retry loop against a source that keeps
@@ -971,9 +963,8 @@ struct FrontState {
 	routes: Vec<FrontRoute>,
 	/// The source tracks are dispatched to. Backups park until promoted.
 	active: Option<u64>,
-	/// Terminal: no more sources may attach and every poller stops. Set by the
-	/// front task when the linger window expires, or synchronously by a graceful
-	/// detach (a finished source) that empties the table.
+	/// Terminal: no more sources may attach and every poller stops. Set
+	/// synchronously by the detach that empties the table.
 	closed: bool,
 }
 
@@ -1007,9 +998,9 @@ impl FrontState {
 ///
 /// Re-reads the table at apply time (rather than applying a value computed under
 /// an earlier lock) so concurrent attach/detach/update calls converge on the
-/// latest winner regardless of the order their applies land in. While no source
-/// is attached (the linger window) the previous advert and announce state are
-/// kept, so a reconnect resumes invisibly; the front task unannounces on close.
+/// latest winner regardless of the order their applies land in. An empty table
+/// leaves the advert and announce state alone; the front task is closing and
+/// unannounces on its way out.
 fn sync_front(state: &kio::Producer<FrontState>, broadcast: &broadcast::Producer, leaf: &Lock<OriginNode>) {
 	// Snapshot and apply under the leaf lock: two concurrent syncs would
 	// otherwise race their applies, letting a stale snapshot land last and
@@ -1027,18 +1018,10 @@ fn sync_front(state: &kio::Producer<FrontState>, broadcast: &broadcast::Producer
 /// Detach source `id`, promoting the next-best source; the tracks it was serving
 /// re-splice on their own. Idempotent.
 ///
-/// `graceful` marks a deliberate end (the source finished) rather than a dying
-/// session: if it empties the table, the broadcast closes synchronously instead
-/// of lingering for a reconnect. The synchronous close also guarantees a
-/// following create at the path is a *new* broadcast rather than splicing new
-/// content into this one.
-fn detach_source(
-	state: &kio::Producer<FrontState>,
-	broadcast: &broadcast::Producer,
-	leaf: &Lock<OriginNode>,
-	id: u64,
-	graceful: bool,
-) {
+/// Detaching the last source closes the broadcast synchronously, which
+/// guarantees a following create at the path is a *new* broadcast rather than
+/// splicing new content into this one.
+fn detach_source(state: &kio::Producer<FrontState>, broadcast: &broadcast::Producer, leaf: &Lock<OriginNode>, id: u64) {
 	let close = {
 		let Ok(mut s) = state.write() else { return };
 		let Some(pos) = s.routes.iter().position(|r| r.id == id) else {
@@ -1046,8 +1029,8 @@ fn detach_source(
 		};
 		s.routes.remove(pos);
 		s.reselect();
-		if graceful && s.routes.is_empty() && !s.closed {
-			// Deliberate end: close now. The front task observes `closed` and
+		if s.routes.is_empty() && !s.closed {
+			// Last one out: close now. The front task observes `closed` and
 			// finishes the teardown (unpublish).
 			s.closed = true;
 			true
@@ -1063,8 +1046,7 @@ fn detach_source(
 
 /// Owns one source's lifecycle: attaches it to the front at its path on the first
 /// route observation, forwards route updates, and detaches it when the source
-/// closes ([`broadcast::Producer::finish`] detaching gracefully, a plain drop
-/// detaching as a failure). Spawned by [`Producer::create_broadcast`].
+/// closes. Spawned by [`Producer::create_broadcast`].
 async fn run_source(
 	origin: Info,
 	node: Lock<OriginNode>,
@@ -1105,7 +1087,7 @@ async fn run_source(
 				sync_front(&state, &broadcast, &leaf);
 			}
 			Err(_) => {
-				detach_source(&state, &broadcast, &leaf, id, source.is_finished());
+				detach_source(&state, &broadcast, &leaf, id);
 				return;
 			}
 		}
@@ -1194,9 +1176,8 @@ fn attach_source(
 	(state, broadcast, 0)
 }
 
-/// Owns a front's lifecycle: dispatches each requested track to a serve task,
-/// waits out source gaps (lingering so a reconnecting session can resume
-/// transparently), and finally unpublishes the broadcast.
+/// Owns a front's lifecycle: dispatches each requested track to a serve task
+/// until the last source detaches, then unpublishes the broadcast.
 async fn run_front(
 	state: kio::Producer<FrontState>,
 	broadcast: broadcast::Producer,
@@ -1205,7 +1186,6 @@ async fn run_front(
 ) {
 	enum Step {
 		Serve(Arc<str>, super::resume::Producer),
-		Empty,
 		Closed,
 	}
 
@@ -1214,15 +1194,10 @@ async fn run_front(
 			if let Poll::Ready((name, resume)) = broadcast.poll_spliced_assigned(waiter) {
 				return Poll::Ready(Step::Serve(name, resume));
 			}
-			match state.poll(waiter, |s| {
-				if s.closed || s.routes.is_empty() {
-					Poll::Ready(())
-				} else {
-					Poll::Pending
-				}
-			}) {
-				Poll::Ready(Ok(guard)) => Poll::Ready(if guard.closed { Step::Closed } else { Step::Empty }),
-				Poll::Ready(Err(_)) => Poll::Ready(Step::Closed),
+			// `closed` is set by the detach that empties the table, so an empty
+			// table is always terminal.
+			match state.poll(waiter, |s| if s.closed { Poll::Ready(()) } else { Poll::Pending }) {
+				Poll::Ready(_) => Poll::Ready(Step::Closed),
 				Poll::Pending => Poll::Pending,
 			}
 		})
@@ -1233,60 +1208,12 @@ async fn run_front(
 				// Serve tasks self-terminate when the track completes or the
 				// front closes.
 				web_async::spawn(serve_track(state.clone(), name, resume));
-				continue;
 			}
 			Step::Closed => break,
-			Step::Empty => {}
-		}
-
-		// No sources: linger so a reconnecting session can re-attach and resume,
-		// with consumers serving from cache in the meantime.
-		let reattached = {
-			let mut linger = std::pin::pin!(web_async::time::sleep(ROUTE_LINGER));
-			kio::wait(|waiter| {
-				match state.poll(waiter, |s| {
-					if s.routes.is_empty() && !s.closed {
-						Poll::Pending
-					} else {
-						Poll::Ready(())
-					}
-				}) {
-					Poll::Ready(res) => return Poll::Ready(res.is_ok()),
-					Poll::Pending => {}
-				}
-				if waiter.poll_future(linger.as_mut()).is_ready() {
-					return Poll::Ready(false);
-				}
-				Poll::Pending
-			})
-			.await
-		};
-		if reattached {
-			// Either a source re-attached or a graceful close landed; loop back
-			// to tell the two apart.
-			continue;
-		}
-
-		// Commit the close under the write lock, re-checking for a source that
-		// re-attached since we last looked; the `closed` flag is what stops
-		// further attaches.
-		match state.write() {
-			Ok(mut s) => {
-				if s.closed {
-					break;
-				}
-				if !s.routes.is_empty() {
-					continue;
-				}
-				s.closed = true;
-				break;
-			}
-			Err(_) => break,
 		}
 	}
 
-	// Close: no source came back. Abort the logical tracks (releasing their
-	// subscribers) and unpublish.
+	// Abort the logical tracks (releasing their subscribers) and unpublish.
 	broadcast.abort_spliced(Error::Dropped);
 
 	// Deliberate end; suppresses the dropped-without-finish warning.
@@ -2196,8 +2123,7 @@ mod tests {
 	}
 
 	/// Let the spawned origin tasks (source watchers, front dispatch) run. The
-	/// tests pause tokio time, so this advances the clock without reaching the
-	/// 5-second failure linger.
+	/// tests pause tokio time, so this advances the clock instantly.
 	async fn settle() {
 		tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
 	}
@@ -2611,61 +2537,6 @@ mod tests {
 		sub.assert_not_closed();
 	}
 
-	/// After the last source detaches the broadcast lingers: consumers stall (no
-	/// error), and a source re-attaching within the window resumes transparently.
-	#[tokio::test(start_paused = true)]
-	async fn test_route_linger_reattach() {
-		let origin = Origin::random().produce();
-		let consumer = origin.consume();
-		let mut announced = consumer.announced();
-
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let source_a = origin
-			.create_broadcast("test", announce().with_hops(hops.clone()))
-			.unwrap();
-		let mut dynamic_a = source_a.dynamic();
-		settle().await;
-		settle().await;
-		let broadcast = consumer.request_broadcast("test").await.unwrap();
-		announced.assert_next_some("test");
-
-		let subscribing = broadcast.track("video").unwrap().subscribe(None);
-		let mut producer = accept_track(&mut dynamic_a, "video").await;
-		settle().await;
-		let mut sub = subscribing.await.unwrap();
-		producer.append_group().unwrap();
-		assert_eq!(sub.assert_group().sequence, 0);
-
-		// The only source dies. The broadcast stays announced (linger) and the
-		// subscriber stalls rather than erroring.
-		producer.abort(Error::Dropped).unwrap();
-		drop(producer);
-		source_a.abort();
-		drop(source_a);
-		drop(dynamic_a);
-		tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-		announced.assert_next_wait();
-		sub.assert_no_group();
-		sub.assert_not_closed();
-
-		// A reconnecting session re-attaches within the window and resumes.
-		let source_b = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
-		let mut dynamic_b = source_b.dynamic();
-		settle().await;
-		settle().await;
-		let mut producer = accept_track(&mut dynamic_b, "video").await;
-		settle().await;
-		sub.assert_no_group();
-		assert_eq!(producer.subscription().unwrap().group_start, Some(1));
-		producer.create_group(group::Info { sequence: 1 }).unwrap();
-		assert_eq!(sub.assert_group().sequence, 1);
-
-		// Well past the linger window: the re-attached source keeps it alive.
-		tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-		announced.assert_next_wait();
-		sub.assert_not_closed();
-	}
-
 	/// A better source attaching mid-subscription takes the track over at an
 	/// explicit group boundary: the old copy's demand is capped, the new copy
 	/// starts at the boundary, and the subscriber reads a seamless sequence.
@@ -2760,16 +2631,19 @@ mod tests {
 		);
 	}
 
-	/// When no source returns within the linger window, the broadcast unannounces
-	/// and its unfinished tracks abort.
+	/// A dying source (a session drop, not a deliberate unannounce) closes the
+	/// broadcast just as promptly as a graceful one: no reconnect window, the
+	/// tracks abort, and a re-create is a fresh broadcast rather than a splice.
 	#[tokio::test(start_paused = true)]
-	async fn test_route_linger_expiry() {
+	async fn test_route_detach_immediate() {
 		let origin = Origin::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
 		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		let source = origin
+			.create_broadcast("test", announce().with_hops(hops.clone()))
+			.unwrap();
 		let mut dynamic = source.dynamic();
 		settle().await;
 		settle().await;
@@ -2781,15 +2655,27 @@ mod tests {
 		settle().await;
 		let mut sub = subscribing.await.unwrap();
 
+		// The session dies without unannouncing.
 		drop(producer);
 		source.abort();
 		drop(source);
 		drop(dynamic);
 
-		// The linger window expires with no source: unannounce, and the track aborts.
-		tokio::time::sleep(ROUTE_LINGER + std::time::Duration::from_secs(1)).await;
+		settle().await;
 		announced.assert_next_none("test");
 		sub.assert_error();
+
+		// A reconnecting session gets a brand-new broadcast, not a splice into
+		// the old one.
+		let _source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		settle().await;
+		settle().await;
+		let fresh = consumer.request_broadcast("test").await.unwrap();
+		announced.assert_next_some("test");
+		assert!(
+			!fresh.is_clone(&broadcast),
+			"re-create must not splice the old broadcast"
+		);
 	}
 
 	/// A non-live broadcast is reachable by exact path but never announced;
@@ -2965,8 +2851,10 @@ mod tests {
 		let origin = Origin::random().produce();
 
 		let mut consumer = origin.consume().announced();
+		// Held for the duration: a dropped source unannounces immediately.
+		let mut broadcasts = Vec::new();
 		for i in 0..256 {
-			let _broadcast = origin.create_broadcast(format!("test{i:03}"), announce()).unwrap();
+			broadcasts.push(origin.create_broadcast(format!("test{i:03}"), announce()).unwrap());
 			settle().await;
 		}
 
@@ -2981,8 +2869,10 @@ mod tests {
 		let origin = Origin::random().produce();
 
 		let mut consumer = origin.consume().announced();
+		// Held for the duration: a dropped source unannounces immediately.
+		let mut broadcasts = Vec::new();
 		for i in 0..256 {
-			let _broadcast = origin.create_broadcast(format!("test{i:03}"), announce()).unwrap();
+			broadcasts.push(origin.create_broadcast(format!("test{i:03}"), announce()).unwrap());
 			settle().await;
 		}
 

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -603,8 +603,8 @@ impl Cluster {
 
 		while tasks.join_next().await.is_some() {}
 
-		// Deliberate shutdown: finish the registration so it unannounces
-		// immediately instead of lingering for a reconnect.
+		// Deliberate shutdown: finish the registration rather than dropping it, so
+		// there is no dropped-without-finish warning.
 		if let Some(registration) = self_registration {
 			registration.finish();
 		}

--- a/rs/moq-rtmp/src/dial.rs
+++ b/rs/moq-rtmp/src/dial.rs
@@ -436,8 +436,8 @@ async fn client_handshake<S: Stream>(stream: &mut S) -> anyhow::Result<Vec<u8>> 
 }
 
 /// An active pull: the moq-mux FLV importer publishing into the origin. Mirrors the
-/// server's publisher; a deliberate [`Self::finish`] unannounces immediately,
-/// while dropping it lets the origin linger briefly for a reconnect.
+/// server's publisher; either [`Self::finish`] or dropping it unannounces the
+/// path, the former without the dropped-without-finish warning.
 struct Publisher {
 	importer: FlvImport,
 	// A clone of the importer's producer, so a deliberate end can finish() the

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -1160,9 +1160,8 @@ async fn run_handshake<S: Stream>(stream: &mut S, peer: SocketAddr) -> anyhow::R
 
 /// An active publish: the moq-mux FLV importer, which owns the origin-created
 /// [`BroadcastProducer`](moq_net::broadcast::Producer) it publishes into.
-/// Dropping it closes the broadcast; the origin lingers briefly before
-/// unannouncing so a reconnecting encoder can resume, while [`Self::finish`]
-/// unannounces immediately.
+/// Either [`Self::finish`] or dropping it closes the broadcast and unannounces
+/// the path, the former without the dropped-without-finish warning.
 struct Publisher {
 	importer: FlvImport,
 	// A clone of the importer's producer, so a deliberate end can finish() the

--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -20,9 +20,8 @@ use crate::Result;
 /// Each chunk is handed straight to the TS importer, which consumes whole
 /// transport packets and retains any partial trailing packet internally for the
 /// next call (the same pattern `moq-cli import ... stdin ts` uses against stdin).
-/// A deliberate [`Self::finish`] ends the broadcast and unannounces the path
-/// immediately; dropping the publisher instead lets the origin linger briefly
-/// so a reconnecting sender can resume.
+/// Either [`Self::finish`] or dropping the publisher ends the broadcast and
+/// unannounces the path, the former without the dropped-without-finish warning.
 pub struct Publisher {
 	importer: ts::Import,
 	// A clone of the importer's producer, so a deliberate end can finish() the

--- a/rs/moq-stats/src/produce.rs
+++ b/rs/moq-stats/src/produce.rs
@@ -309,8 +309,8 @@ impl Task {
 				});
 			}
 
-			// Deliberate unpublish: finish evicted broadcasts so the origin
-			// drops them immediately instead of lingering for a reconnect.
+			// Deliberate unpublish: finish evicted broadcasts rather than dropping
+			// them, so there is no dropped-without-finish warning.
 			let evicted: Vec<PathOwned> = groups
 				.keys()
 				.filter(|group| !active.contains(*group))


### PR DESCRIPTION
Closes the relay half of #2401.

## Summary

- A broadcast whose last source detached lingered for 5s (`ROUTE_LINGER`), staying announced and serving from cache so a reconnecting session could splice in unnoticed. Only a graceful detach (a finished source) closed synchronously.
- Now any detach that empties the route table closes the front, so the path unannounces immediately whether the source finished or its session died. A replacement still splices in transparently, but only if it attaches before the last route goes away.
- Multi-route redundancy is unaffected: a path served by two upstreams has two routes, and losing one just promotes the other. Only the single-route gap loses its grace window, which is the point.
- Per #2401 the linger was the dominant cost in the reported publisher-reload stall: a real re-publish (camera re-acquire + encoder warmup + keyframe) routinely exceeds 5s, so the window expired anyway and the watcher paid a full teardown/rebuild *after* having already stalled for 5s. Removing it means the watcher starts rebuilding at t+0 instead of t+5s.

Since `detach_source` is the only place routes shrink, an empty table is now always terminal, so `run_front` just watches `closed`: the `Empty` step, the linger sleep, and the re-check-under-write-lock close commit all collapse away.

Follow-on cleanups now that graceful and non-graceful detaches behave identically:

- the `graceful` parameter on `detach_source` is gone;
- `broadcast::Consumer::is_finished()` lost its only caller and is removed;
- that left `Close::Finish` / `Close::Abort` write-only and indistinguishable, so the enum collapses to a `closing: bool`. `finish()`, `abort()`, and a plain drop now differ only in whether the dropped-without-finish warning fires.

## Public API changes

None. `is_finished` and `abort` are `pub(crate)`; `Close` is private. No wire change, so no `drafts/` update. `js/net` has no origin/route-splicing layer to mirror.

## Not in scope

The other half of #2401 is client-side: `js/net/src/lite/publisher.ts` `Publisher.close()` never writes the `ended`/`endedId` retraction its incremental diff path already knows how to send, and `js/net/src/ietf/publisher.ts` has no `close()` at all. That mattered much more when it forced every disconnect down the linger path; with the linger gone the relay unannounces on transport close either way, so it's now a promptness gap rather than a 5s stall. Left for a separate PR.

## Test plan

- `just check` and `just fix` clean.
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --all-features` clean (the two `output filename collision` warnings are pre-existing).
- `cargo test -p moq-net`: 517 pass.
- Replaced `test_route_linger_expiry` with `test_route_detach_immediate`: a dying source (not a deliberate unannounce) unannounces promptly, its tracks abort, and a re-create at the same path is a fresh broadcast rather than a splice into the old one.
- Deleted `test_route_linger_reattach`; its premise is gone, and overlapping-route handover is still covered by `test_route_handover`.
- `test_many_announces{,_try}` were silently depending on the linger: each producer was bound to `let _broadcast` inside the loop and dropped immediately, staying announced only because of the 5s window. They now hold the producers, which is what they meant.

(Written by Opus 4.8)