### PR TITLE
refactor(mux)!: unseal catalog renditions and make timelines explicit/shareable

### DIFF
--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -133,7 +133,7 @@ impl<E: CatalogExt> Producer<E> {
 
 		let mut catalog_mut = catalog.clone();
 		let mut config = encoder.catalog();
-		config.timeline = Some(catalog.timeline_section(&name));
+		config.timeline = Some(catalog.timeline(&name).section());
 		catalog_mut.lock().audio.insert(&name, config)?;
 
 		Ok(Self {

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -233,6 +233,7 @@ mod tests {
 		let mut registration = reserved.video("video0");
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		config.framerate = Some(30.0);
+		config.timeline = Some(catalog.timeline("video0").section());
 		registration.set(config);
 		drop(reserved);
 
@@ -301,6 +302,7 @@ mod tests {
 		let mut registration = reserved.video("video0");
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		config.framerate = Some(30.0);
+		config.timeline = Some(catalog.timeline("video0").section());
 		registration.set(config);
 		drop(reserved);
 
@@ -393,6 +395,7 @@ mod tests {
 		let mut registration = reserved.video("video0");
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		config.framerate = Some(30.0);
+		config.timeline = Some(catalog.timeline("video0").section());
 		registration.set(config);
 		drop(reserved);
 
@@ -449,6 +452,7 @@ mod tests {
 		let mut registration = reserved.video("video0");
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		config.framerate = Some(30.0);
+		config.timeline = Some(catalog.timeline("video0").section());
 		registration.set(config);
 		drop(reserved);
 

--- a/rs/moq-mux/src/catalog/mod.rs
+++ b/rs/moq-mux/src/catalog/mod.rs
@@ -35,4 +35,4 @@ pub use format::*;
 pub use producer::{Guard, Producer};
 pub use select::Select;
 pub use stream::Stream;
-pub use tracks::{Audio, AudioTrack, Kind, Rendition, Reserved, Video, VideoHint, VideoTrack};
+pub use tracks::{AudioTrack, Estimate, Rendition, RenditionConfig, Reserved, VideoHint, VideoTrack};

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -199,46 +199,38 @@ impl<E: CatalogExt> Producer<E> {
 		emit(&mut self.hang, &mut self.hangz, &mut self.msf_track, &catalog);
 	}
 
-	/// Build the media [`container::Producer`](crate::container::Producer) for the rendition named by
-	/// `track`, with its timeline recorder wired in.
+	/// Build the media [`container::Producer`](crate::container::Producer) for `track`, recording its
+	/// group opens into the `<name>.timeline.z` timeline named after it.
 	///
-	/// The timeline is bound to this exact track, so a rendition records only into its own
-	/// `<name>.timeline.z` track (timelines are 1:1 with media tracks and can't be shared). This is
-	/// how a media track gets a timeline: build it here rather than attaching one by hand.
+	/// This is the 1:1 default. To share a timeline across aligned renditions, build the producer
+	/// yourself and wire the shared timeline's recorder:
+	/// `container::Producer::new(track, container).with_recorder(catalog.timeline(shared).recorder())`,
+	/// and advertise `catalog.timeline(shared).section()` on each of their configs.
 	pub fn media_producer<C: crate::container::Container>(
 		&self,
 		track: moq_net::track::Producer,
 		container: C,
 	) -> crate::container::Producer<C> {
-		let recorder = self.timeline_recorder(track.name());
+		let recorder = self.timeline(track.name()).recorder();
 		crate::container::Producer::new(track, container).with_recorder(recorder)
 	}
 
-	/// The catalog [`Timeline`](hang::catalog::Timeline) section for media rendition `name`, to
-	/// advertise on the rendition's config (creating the timeline track on first use).
+	/// The [`timeline::Producer`](crate::timeline::Producer) named `name`, creating its
+	/// `<name>.timeline.z` track on first use and returning the same shared handle thereafter.
 	///
-	/// [`VideoTrack::set`](super::VideoTrack::set) / [`AudioTrack::set`](super::AudioTrack::set) do
-	/// this automatically; callers that build a rendition config by hand attach it themselves.
-	pub fn timeline_section(&self, name: &str) -> hang::catalog::Timeline {
-		self.with_timeline(name, |timeline| timeline.section())
-	}
-
-	/// Mint the media track's timeline [`Recorder`](crate::timeline::Recorder) for rendition `name`,
-	/// creating its track on first use. Used by [`media_producer`](Self::media_producer) to wire one
-	/// recorder per media track.
-	pub(crate) fn timeline_recorder(&self, name: &str) -> crate::timeline::Recorder {
-		self.with_timeline(name, |timeline| timeline.recorder())
-	}
-
-	/// Run `f` against the timeline producer for rendition `name`, memoized by name (creating its
-	/// track on first use). Panics only if the broadcast can't mint the track (a duplicate name),
-	/// which the `<name>.timeline.z` convention avoids.
-	fn with_timeline<R>(&self, name: &str, f: impl FnOnce(&mut crate::timeline::Producer) -> R) -> R {
+	/// Advertise it on a rendition by setting `config.timeline = Some(timeline.section())`, and
+	/// record group opens through its [`recorder`](crate::timeline::Producer::recorder). Two
+	/// renditions naming the same timeline share it: an aligned transcode ladder records the source
+	/// and has the rungs only advertise the same section.
+	pub fn timeline(&self, name: &str) -> crate::timeline::Producer {
 		let mut timelines = self.timelines.lock().unwrap();
-		let timeline = timelines.entry(name.to_string()).or_insert_with(|| {
-			crate::timeline::Producer::new(&mut self.broadcast.clone(), name).expect("failed to create timeline track")
-		});
-		f(timeline)
+		timelines
+			.entry(name.to_string())
+			.or_insert_with(|| {
+				crate::timeline::Producer::new(&mut self.broadcast.clone(), name)
+					.expect("failed to create timeline track")
+			})
+			.clone()
 	}
 
 	/// Create a consumer for this catalog, receiving updates as they're published.

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -37,10 +37,10 @@ impl Estimate {
 /// A catalog config that can be published as a named rendition.
 ///
 /// Implement it on your own config type to get the full [`Rendition`] lifecycle for a custom
-/// track: reservation gating, timeline advertising, removal on drop, and optional jitter/bitrate
-/// detection. [`VideoConfig`](hang::catalog::VideoConfig) and
-/// [`AudioConfig`](hang::catalog::AudioConfig) implement it for every extension; a custom config
-/// implements it for the one [`CatalogExt`] that holds it:
+/// track: reservation gating, removal on drop, and optional jitter/bitrate detection.
+/// [`VideoConfig`](hang::catalog::VideoConfig) and [`AudioConfig`](hang::catalog::AudioConfig)
+/// implement it for every extension; a custom config implements it for the one [`CatalogExt`] that
+/// holds it:
 ///
 /// ```
 /// # use moq_mux::catalog::{Estimate, RenditionConfig};
@@ -83,6 +83,10 @@ impl Estimate {
 /// Note that `insert` takes the whole [`Catalog`], not just the extension, so the built-in media
 /// configs use the same trait. Writing to `catalog.video` / `catalog.audio` from a custom config
 /// fights the media pipeline for those sections; stay in your own.
+///
+/// To advertise a timeline for a custom track, set your config's timeline field from
+/// [`catalog::Producer::timeline`](crate::catalog::Producer::timeline) before [`set`](Rendition::set)
+/// (the same way an importer does), and record group opens through its recorder.
 pub trait RenditionConfig<E: CatalogExt>: Sized + 'static {
 	/// Insert or replace this config under `name`.
 	fn insert(self, catalog: &mut Catalog<E>, name: &str);
@@ -92,10 +96,6 @@ pub trait RenditionConfig<E: CatalogExt>: Sized + 'static {
 
 	/// Remove the config stored under `name`.
 	fn remove(catalog: &mut Catalog<E>, name: &str);
-
-	/// Advertise the rendition's timeline track, so a consumer can index its groups without
-	/// downloading media. Defaults to not advertising one.
-	fn set_timeline(&mut self, _timeline: hang::catalog::Timeline) {}
 
 	/// The config's current [`Estimate`] fields. Defaults to none, disabling detection.
 	fn estimate(&self) -> Estimate {
@@ -188,10 +188,6 @@ impl<E: CatalogExt> RenditionConfig<E> for hang::catalog::VideoConfig {
 		catalog.video.renditions.remove(name);
 	}
 
-	fn set_timeline(&mut self, timeline: hang::catalog::Timeline) {
-		self.timeline = Some(timeline);
-	}
-
 	fn estimate(&self) -> Estimate {
 		Estimate::default().with_jitter(self.jitter).with_bitrate(self.bitrate)
 	}
@@ -210,10 +206,6 @@ impl<E: CatalogExt> RenditionConfig<E> for hang::catalog::AudioConfig {
 	}
 	fn remove(catalog: &mut Catalog<E>, name: &str) {
 		catalog.audio.renditions.remove(name);
-	}
-
-	fn set_timeline(&mut self, timeline: hang::catalog::Timeline) {
-		self.timeline = Some(timeline);
 	}
 
 	fn estimate(&self) -> Estimate {
@@ -350,13 +342,9 @@ impl<E: CatalogExt, C: RenditionConfig<E>> Rendition<E, C> {
 	/// dirty start or a B-frame reorder) and kept current as frames arrive. A caller who wants to
 	/// pre-empt detection sets the field on the config, or (for a config an importer builds out of
 	/// the bitstream) hands the importer a hint like [`VideoHint`].
-	///
-	/// Also advertises the rendition's timeline track in the config, so a consumer can index its groups
-	/// without downloading media (see [`Producer::timeline_section`](crate::catalog::Producer::timeline_section)).
 	pub fn set(&mut self, mut config: C) {
 		self.supplied = config.estimate();
 		config.set_estimate(self.resolved());
-		config.set_timeline(self.catalog.timeline_section(&self.name));
 
 		// Write the config first (still withheld, since we're holding our reservation), then release
 		// the reservation. If this was the last one, the release flushes a complete snapshot.
@@ -537,6 +525,49 @@ mod tests {
 		assert_eq!(config.bitrate, Some(789), "the re-set bitrate is now authoritative");
 	}
 
+	/// Two renditions can advertise one shared timeline: the same handle yields the same section, so
+	/// an aligned ladder (source + rung) indexes off a single `.timeline.z` track.
+	#[test]
+	fn renditions_share_a_timeline() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = super::super::Producer::new(&mut broadcast).unwrap();
+		let reserved = catalog.reserve();
+
+		let shared = catalog.timeline("video");
+		let mut source = reserved.video("video0");
+		let mut rung = reserved.video("video1");
+		drop(reserved);
+
+		for rendition in [&mut source, &mut rung] {
+			let mut config = config(None, None);
+			config.timeline = Some(shared.section());
+			rendition.set(config);
+		}
+
+		let snapshot = catalog.snapshot();
+		let source_tl = snapshot
+			.video
+			.renditions
+			.get("video0")
+			.unwrap()
+			.timeline
+			.as_ref()
+			.unwrap();
+		let rung_tl = snapshot
+			.video
+			.renditions
+			.get("video1")
+			.unwrap()
+			.timeline
+			.as_ref()
+			.unwrap();
+		assert_eq!(source_tl.track, "video.timeline.z");
+		assert_eq!(
+			rung_tl.track, source_tl.track,
+			"both renditions index off one shared timeline track"
+		);
+	}
+
 	mod custom {
 		use std::collections::BTreeMap;
 
@@ -572,10 +603,6 @@ mod tests {
 				catalog.telemetry.remove(name);
 			}
 
-			fn set_timeline(&mut self, timeline: hang::catalog::Timeline) {
-				self.timeline = Some(timeline);
-			}
-
 			// Opts into bitrate detection only; jitter is left undetected.
 			fn estimate(&self) -> Estimate {
 				Estimate::default().with_bitrate(self.bitrate)
@@ -599,7 +626,8 @@ mod tests {
 			(broadcast, catalog)
 		}
 
-		/// A custom kind gets the same detection, timeline wiring, and drop-removal as video/audio.
+		/// A custom kind gets the same detection and drop-removal as video/audio, and advertises a
+		/// timeline the same explicit way an importer does.
 		#[test]
 		fn detects_and_advertises() {
 			let (_broadcast, catalog) = produce();
@@ -607,13 +635,20 @@ mod tests {
 			let mut rendition = reserved.init::<Telemetry>("gps");
 			drop(reserved);
 
-			rendition.set(telemetry(None));
+			// The caller advertises the timeline explicitly, exactly as an importer does for video/audio.
+			let mut config = telemetry(None);
+			config.timeline = Some(catalog.timeline("gps").section());
+			rendition.set(config);
 			feed(&mut rendition);
 
 			let snapshot = catalog.snapshot();
 			let config = snapshot.telemetry.get("gps").unwrap();
 			assert!(config.bitrate.is_some(), "absent bitrate should be auto-detected");
-			assert!(config.timeline.is_some(), "the timeline track should be advertised");
+			assert_eq!(
+				config.timeline.as_ref().map(|t| t.track.as_str()),
+				Some("gps.timeline.z"),
+				"the advertised timeline names the companion track"
+			);
 
 			drop(rendition);
 			assert!(

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -7,52 +7,104 @@ use super::Producer;
 use super::hang::{Catalog, CatalogExt};
 use crate::container::jitter::Metrics;
 
-mod sealed {
-	pub trait Sealed {}
-}
-
-/// The media kind of a reserved rendition, selecting its config type and catalog slot.
+/// The catalog fields a [`Rendition`] can measure from the frames fed to it.
 ///
-/// Implemented only by [`Video`] and [`Audio`]; used as the `K` in
-/// [`Rendition`] and [`Reserved::init`].
-pub trait Kind: sealed::Sealed + 'static {
-	/// The catalog config type carried by this kind ([`VideoConfig`](hang::catalog::VideoConfig)
-	/// or [`AudioConfig`](hang::catalog::AudioConfig)).
-	type Config;
-	/// The caller-provided overlay for this kind: [`VideoHint`] for video, `()` for audio (which takes
-	/// a complete [`AudioConfig`](hang::catalog::AudioConfig) instead).
-	type Hint: Clone + Default;
-
-	#[doc(hidden)]
-	fn insert<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str, config: Self::Config);
-	#[doc(hidden)]
-	fn with_mut<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str, f: impl FnOnce(&mut Self::Config));
-	#[doc(hidden)]
-	fn remove<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str);
-
-	/// The config's detected-jitter field, so [`Rendition`] can update it generically.
-	#[doc(hidden)]
-	fn jitter_mut(config: &mut Self::Config) -> &mut Option<Duration>;
-	/// The config's bitrate field, so [`Rendition`] can update it generically.
-	#[doc(hidden)]
-	fn bitrate_mut(config: &mut Self::Config) -> &mut Option<u64>;
-
-	/// The config's timeline field, so [`Rendition`] can advertise the timeline track generically.
-	#[doc(hidden)]
-	fn timeline_mut(config: &mut Self::Config) -> &mut Option<hang::catalog::Timeline>;
-
-	/// Fill a detected config's absent optional fields from a caller-provided hint.
-	#[doc(hidden)]
-	fn apply_hint(config: &mut Self::Config, hint: &Self::Hint);
+/// An absent field is one to measure: whatever the config already carries when it reaches
+/// [`Rendition::set`] is authoritative and left alone, and the rest is detected and kept current.
+#[derive(Clone, Default, Debug, PartialEq)]
+#[non_exhaustive]
+pub struct Estimate {
+	/// The maximum jitter before the next frame is emitted.
+	pub jitter: Option<Duration>,
+	/// The maximum bitrate in bits per second.
+	pub bitrate: Option<u64>,
 }
 
-/// Video rendition marker for [`Rendition`] / [`Reserved::init`].
-pub enum Video {}
-/// Audio rendition marker for [`Rendition`] / [`Reserved::init`].
-pub enum Audio {}
+impl Estimate {
+	/// Set the jitter (or clear it with `None`).
+	pub fn with_jitter(mut self, jitter: impl Into<Option<Duration>>) -> Self {
+		self.jitter = jitter.into();
+		self
+	}
 
-impl sealed::Sealed for Video {}
-impl sealed::Sealed for Audio {}
+	/// Set the bitrate in bits per second (or clear it with `None`).
+	pub fn with_bitrate(mut self, bitrate: impl Into<Option<u64>>) -> Self {
+		self.bitrate = bitrate.into();
+		self
+	}
+}
+
+/// A catalog config that can be published as a named rendition.
+///
+/// Implement it on your own config type to get the full [`Rendition`] lifecycle for a custom
+/// track: reservation gating, timeline advertising, removal on drop, and optional jitter/bitrate
+/// detection. [`VideoConfig`](hang::catalog::VideoConfig) and
+/// [`AudioConfig`](hang::catalog::AudioConfig) implement it for every extension; a custom config
+/// implements it for the one [`CatalogExt`] that holds it:
+///
+/// ```
+/// # use moq_mux::catalog::{Estimate, RenditionConfig};
+/// # use moq_mux::catalog::hang::{Catalog, CatalogExt};
+/// # use serde::{Deserialize, Serialize};
+/// # use std::collections::BTreeMap;
+/// #[derive(Serialize, Deserialize, Clone, Default)]
+/// struct MyExt {
+///     telemetry: BTreeMap<String, Telemetry>,
+/// }
+/// impl CatalogExt for MyExt {}
+///
+/// #[derive(Serialize, Deserialize, Clone, Default)]
+/// struct Telemetry {
+///     schema: String,
+///     bitrate: Option<u64>,
+/// }
+///
+/// impl RenditionConfig<MyExt> for Telemetry {
+///     fn insert(self, catalog: &mut Catalog<MyExt>, name: &str) {
+///         catalog.telemetry.insert(name.to_string(), self);
+///     }
+///     fn get_mut<'a>(catalog: &'a mut Catalog<MyExt>, name: &str) -> Option<&'a mut Self> {
+///         catalog.telemetry.get_mut(name)
+///     }
+///     fn remove(catalog: &mut Catalog<MyExt>, name: &str) {
+///         catalog.telemetry.remove(name);
+///     }
+///
+///     // Opt into bitrate detection; jitter is left undetected.
+///     fn estimate(&self) -> Estimate {
+///         Estimate::default().with_bitrate(self.bitrate)
+///     }
+///     fn set_estimate(&mut self, estimate: Estimate) {
+///         self.bitrate = estimate.bitrate;
+///     }
+/// }
+/// ```
+///
+/// Note that `insert` takes the whole [`Catalog`], not just the extension, so the built-in media
+/// configs use the same trait. Writing to `catalog.video` / `catalog.audio` from a custom config
+/// fights the media pipeline for those sections; stay in your own.
+pub trait RenditionConfig<E: CatalogExt>: Sized + 'static {
+	/// Insert or replace this config under `name`.
+	fn insert(self, catalog: &mut Catalog<E>, name: &str);
+
+	/// Borrow the config stored under `name`, if it's present.
+	fn get_mut<'a>(catalog: &'a mut Catalog<E>, name: &str) -> Option<&'a mut Self>;
+
+	/// Remove the config stored under `name`.
+	fn remove(catalog: &mut Catalog<E>, name: &str);
+
+	/// Advertise the rendition's timeline track, so a consumer can index its groups without
+	/// downloading media. Defaults to not advertising one.
+	fn set_timeline(&mut self, _timeline: hang::catalog::Timeline) {}
+
+	/// The config's current [`Estimate`] fields. Defaults to none, disabling detection.
+	fn estimate(&self) -> Estimate {
+		Estimate::default()
+	}
+
+	/// Replace the config's [`Estimate`] fields. Defaults to discarding them.
+	fn set_estimate(&mut self, _estimate: Estimate) {}
+}
 
 /// Caller-provided catalog fields for a video track: a starting point for what the importer detects.
 ///
@@ -62,8 +114,9 @@ impl sealed::Sealed for Audio {}
 /// decoder config then arrives in band). Use it for fields the stream can't reveal (bitrate) or to
 /// skip that wait.
 ///
-/// Audio has no equivalent: an audio importer can't resolve its config from frames, so it takes a
-/// complete [`AudioConfig`](hang::catalog::AudioConfig) up front instead of a hint.
+/// Video importers take one because they build the [`VideoConfig`](hang::catalog::VideoConfig)
+/// themselves, out of the bitstream, so the caller never holds the config to set these on. An audio
+/// importer publishes a complete config from its init bytes, so audio has no equivalent.
 #[derive(Clone, Default, Debug, PartialEq)]
 #[non_exhaustive]
 pub struct VideoHint {
@@ -99,7 +152,9 @@ impl VideoHint {
 	/// Fill a detected video config's absent optional fields from these hints.
 	///
 	/// Only the gaps: a value the stream detects (e.g. the dimensions from an SPS) is left untouched,
-	/// so a resolution change updates the catalog instead of conflicting with the hint.
+	/// so a resolution change updates the catalog instead of conflicting with the hint. An importer
+	/// calls this on every config it publishes, before handing it to [`Rendition::set`], so a hinted
+	/// field counts as supplied and is never overwritten by detection.
 	pub fn apply(&self, config: &mut hang::catalog::VideoConfig) {
 		fill(&mut config.coded_width, self.coded_width);
 		fill(&mut config.coded_height, self.coded_height);
@@ -122,66 +177,52 @@ impl VideoHint {
 	}
 }
 
-impl Kind for Video {
-	type Config = hang::catalog::VideoConfig;
-	type Hint = VideoHint;
-
-	fn insert<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str, config: Self::Config) {
-		catalog.video.renditions.insert(name.to_string(), config);
+impl<E: CatalogExt> RenditionConfig<E> for hang::catalog::VideoConfig {
+	fn insert(self, catalog: &mut Catalog<E>, name: &str) {
+		catalog.video.renditions.insert(name.to_string(), self);
 	}
-	fn with_mut<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str, f: impl FnOnce(&mut Self::Config)) {
-		if let Some(config) = catalog.video.renditions.get_mut(name) {
-			f(config);
-		}
+	fn get_mut<'a>(catalog: &'a mut Catalog<E>, name: &str) -> Option<&'a mut Self> {
+		catalog.video.renditions.get_mut(name)
 	}
-	fn remove<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str) {
+	fn remove(catalog: &mut Catalog<E>, name: &str) {
 		catalog.video.renditions.remove(name);
 	}
 
-	fn jitter_mut(config: &mut Self::Config) -> &mut Option<Duration> {
-		&mut config.jitter
-	}
-	fn bitrate_mut(config: &mut Self::Config) -> &mut Option<u64> {
-		&mut config.bitrate
-	}
-	fn timeline_mut(config: &mut Self::Config) -> &mut Option<hang::catalog::Timeline> {
-		&mut config.timeline
+	fn set_timeline(&mut self, timeline: hang::catalog::Timeline) {
+		self.timeline = Some(timeline);
 	}
 
-	fn apply_hint(config: &mut Self::Config, hint: &Self::Hint) {
-		hint.apply(config);
+	fn estimate(&self) -> Estimate {
+		Estimate::default().with_jitter(self.jitter).with_bitrate(self.bitrate)
+	}
+	fn set_estimate(&mut self, estimate: Estimate) {
+		self.jitter = estimate.jitter;
+		self.bitrate = estimate.bitrate;
 	}
 }
 
-impl Kind for Audio {
-	type Config = hang::catalog::AudioConfig;
-	// Audio has no hint: importers publish a complete `AudioConfig` (see the crate docs on why audio
-	// is eager while video is lazy), so there's nothing to overlay.
-	type Hint = ();
-
-	fn insert<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str, config: Self::Config) {
-		catalog.audio.renditions.insert(name.to_string(), config);
+impl<E: CatalogExt> RenditionConfig<E> for hang::catalog::AudioConfig {
+	fn insert(self, catalog: &mut Catalog<E>, name: &str) {
+		catalog.audio.renditions.insert(name.to_string(), self);
 	}
-	fn with_mut<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str, f: impl FnOnce(&mut Self::Config)) {
-		if let Some(config) = catalog.audio.renditions.get_mut(name) {
-			f(config);
-		}
+	fn get_mut<'a>(catalog: &'a mut Catalog<E>, name: &str) -> Option<&'a mut Self> {
+		catalog.audio.renditions.get_mut(name)
 	}
-	fn remove<E: CatalogExt>(catalog: &mut Catalog<E>, name: &str) {
+	fn remove(catalog: &mut Catalog<E>, name: &str) {
 		catalog.audio.renditions.remove(name);
 	}
 
-	fn jitter_mut(config: &mut Self::Config) -> &mut Option<Duration> {
-		&mut config.jitter
-	}
-	fn bitrate_mut(config: &mut Self::Config) -> &mut Option<u64> {
-		&mut config.bitrate
-	}
-	fn timeline_mut(config: &mut Self::Config) -> &mut Option<hang::catalog::Timeline> {
-		&mut config.timeline
+	fn set_timeline(&mut self, timeline: hang::catalog::Timeline) {
+		self.timeline = Some(timeline);
 	}
 
-	fn apply_hint(_config: &mut Self::Config, _hint: &Self::Hint) {}
+	fn estimate(&self) -> Estimate {
+		Estimate::default().with_jitter(self.jitter).with_bitrate(self.bitrate)
+	}
+	fn set_estimate(&mut self, estimate: Estimate) {
+		self.jitter = estimate.jitter;
+		self.bitrate = estimate.bitrate;
+	}
 }
 
 /// A clonable reservation context handed to importers so they declare their tracks up front.
@@ -202,31 +243,23 @@ impl<E: CatalogExt> Reserved<E> {
 		Self { catalog }
 	}
 
-	/// Reserve a rendition of kind `K` under `name`, returning a guard to fill it in.
+	/// Reserve a rendition of config type `C` under `name`, returning a guard to fill it in.
 	///
 	/// The guard holds its own `Reserved` clone, so the catalog stays withheld until the returned
 	/// [`Rendition`] is [`set`](Rendition::set) (or dropped). Prefer [`video`](Self::video) /
-	/// [`audio`](Self::audio) at call sites.
-	pub fn init<K: Kind>(&self, name: impl Into<String>) -> Rendition<E, K> {
-		Rendition::new(self.clone(), name, K::Hint::default())
+	/// [`audio`](Self::audio) for the built-in media configs.
+	pub fn init<C: RenditionConfig<E>>(&self, name: impl Into<String>) -> Rendition<E, C> {
+		Rendition::new(self.clone(), name)
 	}
 
-	/// Reserve a video rendition seeded with caller-provided catalog fields.
-	///
-	/// The `hint` is carried on the returned [`Rendition`]: every [`set`](Rendition::set) fills the
-	/// gaps it declares (a detected value wins). See [`VideoHint`].
-	pub fn video_with_hint(&self, name: impl Into<String>, hint: VideoHint) -> Rendition<E, Video> {
-		Rendition::new(self.clone(), name, hint)
+	/// Reserve a video rendition; shorthand for [`init`](Self::init).
+	pub fn video(&self, name: impl Into<String>) -> VideoTrack<E> {
+		self.init(name)
 	}
 
-	/// Reserve a video rendition; shorthand for [`init::<Video>`](Self::init).
-	pub fn video(&self, name: impl Into<String>) -> Rendition<E, Video> {
-		self.init::<Video>(name)
-	}
-
-	/// Reserve an audio rendition; shorthand for [`init::<Audio>`](Self::init).
-	pub fn audio(&self, name: impl Into<String>) -> Rendition<E, Audio> {
-		self.init::<Audio>(name)
+	/// Reserve an audio rendition; shorthand for [`init`](Self::init).
+	pub fn audio(&self, name: impl Into<String>) -> AudioTrack<E> {
+		self.init(name)
 	}
 
 	/// Resolve a timestamp on the broadcast's shared clock (see [`Producer::timestamp`]).
@@ -259,13 +292,13 @@ impl<E: CatalogExt> Drop for Reserved<E> {
 	}
 }
 
-/// A reserved rendition of kind `K`, retired from the catalog on drop.
+/// A reserved rendition of config type `C`, retired from the catalog on drop.
 ///
 /// Made via [`Reserved::init`] (or [`video`](Reserved::video) / [`audio`](Reserved::audio)). Fill
 /// it in with [`set`](Self::set) and refine it in place with [`update`](Self::update). Until it's
 /// set (or dropped) it holds a [`Reserved`] clone, so an unresolved rendition keeps the initial
 /// catalog publish gated. On drop the rendition is removed from the shared catalog.
-pub struct Rendition<E: CatalogExt, K: Kind> {
+pub struct Rendition<E: CatalogExt, C: RenditionConfig<E>> {
 	catalog: Producer<E>,
 	name: String,
 	/// The reservation this rendition holds until its config is set (or it's dropped unfulfilled).
@@ -276,32 +309,27 @@ pub struct Rendition<E: CatalogExt, K: Kind> {
 	present: bool,
 	/// Detects jitter and bitrate from the frames fed in, keeping the config's fields current.
 	metrics: Metrics,
-	/// Auto-fill `jitter` from the detector only while the config hasn't provided it.
-	detect_jitter: bool,
-	/// Auto-fill `bitrate` from the detector only while the config hasn't provided it.
-	detect_bitrate: bool,
-	/// Caller-provided fields, validated against and overlaid onto every [`set`](Self::set).
-	hint: K::Hint,
-	_kind: PhantomData<fn() -> K>,
+	/// The fields the config carried at [`set`](Self::set): authoritative, never overwritten by
+	/// detection. Whatever is absent here is what the detector fills.
+	supplied: Estimate,
+	_config: PhantomData<fn() -> C>,
 }
 
 /// A single video track's catalog rendition. See [`Rendition`].
-pub type VideoTrack<E = ()> = Rendition<E, Video>;
+pub type VideoTrack<E = ()> = Rendition<E, hang::catalog::VideoConfig>;
 /// A single audio track's catalog rendition. See [`Rendition`].
-pub type AudioTrack<E = ()> = Rendition<E, Audio>;
+pub type AudioTrack<E = ()> = Rendition<E, hang::catalog::AudioConfig>;
 
-impl<E: CatalogExt, K: Kind> Rendition<E, K> {
-	fn new(reserved: Reserved<E>, name: impl Into<String>, hint: K::Hint) -> Self {
+impl<E: CatalogExt, C: RenditionConfig<E>> Rendition<E, C> {
+	fn new(reserved: Reserved<E>, name: impl Into<String>) -> Self {
 		Self {
 			catalog: reserved.catalog.clone(),
 			gate: Some(reserved),
 			name: name.into(),
 			present: false,
 			metrics: Metrics::new(),
-			detect_jitter: true,
-			detect_bitrate: true,
-			hint,
-			_kind: PhantomData,
+			supplied: Estimate::default(),
+			_config: PhantomData,
 		}
 	}
 
@@ -317,97 +345,90 @@ impl<E: CatalogExt, K: Kind> Rendition<E, K> {
 
 	/// Insert or replace the rendition, fulfilling the reservation and publishing the catalog.
 	///
-	/// The rendition's hint (a [`VideoHint`] from [`Reserved::video_with_hint`], or nothing for audio)
-	/// fills any gap `config` leaves first, so a value the stream detected wins over the hint. A field
-	/// then present (`jitter` or `bitrate`,
-	/// whether from the caller or the hint) is authoritative and left alone; only an absent field is
-	/// auto-detected. Any metrics accumulated before the rendition existed (a dirty start or a B-frame
-	/// reorder) are seeded into the fields being detected.
+	/// Whatever [`Estimate`] fields `config` already carries are authoritative and left alone; the
+	/// rest are auto-detected, seeded with any metrics accumulated before the rendition existed (a
+	/// dirty start or a B-frame reorder) and kept current as frames arrive. A caller who wants to
+	/// pre-empt detection sets the field on the config, or (for a config an importer builds out of
+	/// the bitstream) hands the importer a hint like [`VideoHint`].
 	///
 	/// Also advertises the rendition's timeline track in the config, so a consumer can index its groups
 	/// without downloading media (see [`Producer::timeline_section`](crate::catalog::Producer::timeline_section)).
-	pub fn set(&mut self, mut config: K::Config) {
-		K::apply_hint(&mut config, &self.hint);
-		self.detect_jitter = K::jitter_mut(&mut config).is_none();
-		self.detect_bitrate = K::bitrate_mut(&mut config).is_none();
-
-		if self.detect_jitter
-			&& let Some(jitter) = self.metrics.jitter()
-		{
-			*K::jitter_mut(&mut config) = Some(jitter);
-		}
-		if self.detect_bitrate
-			&& let Some(bitrate) = self.metrics.bitrate()
-		{
-			*K::bitrate_mut(&mut config) = Some(bitrate);
-		}
-
-		*K::timeline_mut(&mut config) = Some(self.catalog.timeline_section(&self.name));
+	pub fn set(&mut self, mut config: C) {
+		self.supplied = config.estimate();
+		config.set_estimate(self.resolved());
+		config.set_timeline(self.catalog.timeline_section(&self.name));
 
 		// Write the config first (still withheld, since we're holding our reservation), then release
 		// the reservation. If this was the last one, the release flushes a complete snapshot.
 		{
 			let mut guard = self.catalog.lock();
-			K::insert(&mut guard, &self.name, config);
+			config.insert(&mut guard, &self.name);
 		}
 		self.present = true;
 		self.gate = None;
 	}
 
+	/// The supplied fields, with anything absent filled from the detector.
+	fn resolved(&self) -> Estimate {
+		let mut estimate = self.supplied.clone();
+		if estimate.jitter.is_none() {
+			estimate.jitter = self.metrics.jitter();
+		}
+		if estimate.bitrate.is_none() {
+			estimate.bitrate = self.metrics.bitrate();
+		}
+		estimate
+	}
+
+	/// Republish the estimate after the detector moved a field nothing supplied.
+	fn refresh(&mut self) {
+		let estimate = self.resolved();
+		self.update(|config| config.set_estimate(estimate));
+	}
+
 	/// Refine the rendition in place (e.g. a synthesized description), publishing if present.
-	pub fn update(&mut self, f: impl FnOnce(&mut K::Config)) {
+	pub fn update(&mut self, f: impl FnOnce(&mut C)) {
 		if !self.present {
 			return;
 		}
 		let mut guard = self.catalog.lock();
-		K::with_mut(&mut guard, &self.name, f);
+		if let Some(config) = C::get_mut(&mut guard, &self.name) {
+			f(config);
+		}
 	}
 
 	/// Record one frame (presentation timestamp + encoded size), auto-filling the jitter if the
 	/// config didn't provide it and the detected value changed.
 	pub fn record_frame(&mut self, ts: Timestamp, bytes: usize) {
-		if let Some(jitter) = self.metrics.record_frame(ts, bytes)
-			&& self.detect_jitter
-		{
-			self.update(|config| *K::jitter_mut(config) = Some(jitter));
+		if self.metrics.record_frame(ts, bytes).is_some() && self.supplied.jitter.is_none() {
+			self.refresh();
 		}
 	}
 
 	/// Record a frame's reorder delay (`PTS - DTS`), auto-filling the jitter as for
 	/// [`record_frame`](Self::record_frame).
 	pub fn record_reorder(&mut self, reorder: Timestamp) {
-		if let Some(jitter) = self.metrics.record_reorder(reorder)
-			&& self.detect_jitter
-		{
-			self.update(|config| *K::jitter_mut(config) = Some(jitter));
+		if self.metrics.record_reorder(reorder).is_some() && self.supplied.jitter.is_none() {
+			self.refresh();
 		}
 	}
 
 	/// Close the current group (`next` is its end timestamp when known), auto-filling the bitrate
 	/// if the config didn't provide it and the detected maximum rose.
 	pub fn record_group_end(&mut self, next: Option<Timestamp>) {
-		if let Some(bitrate) = self.metrics.finish_group(next)
-			&& self.detect_bitrate
-		{
-			self.update(|config| raise_bitrate(K::bitrate_mut(config), bitrate));
+		if self.metrics.finish_group(next).is_some() && self.supplied.bitrate.is_none() {
+			self.refresh();
 		}
 	}
 }
 
-/// Raise a catalog `bitrate` field, never lowering a previously detected value.
-fn raise_bitrate(field: &mut Option<u64>, bitrate: u64) {
-	if field.is_none_or(|current| bitrate > current) {
-		*field = Some(bitrate);
-	}
-}
-
-impl<E: CatalogExt, K: Kind> Drop for Rendition<E, K> {
+impl<E: CatalogExt, C: RenditionConfig<E>> Drop for Rendition<E, C> {
 	fn drop(&mut self) {
 		if self.present {
 			// Removing mutates the catalog, so the guard publishes it (immediately if live, else it
 			// accumulates until the gate opens).
 			let mut guard = self.catalog.lock();
-			K::remove(&mut guard, &self.name);
+			C::remove(&mut guard, &self.name);
 		}
 		// Our reservation (`gate`) drops here. If still held (never set), its release flushes any
 		// staged change; if already released by `set`, this is a no-op.
@@ -418,11 +439,7 @@ impl<E: CatalogExt, K: Kind> Drop for Rendition<E, K> {
 mod tests {
 	use super::*;
 
-	fn video_track() -> (
-		moq_net::broadcast::Producer,
-		super::super::Producer,
-		Rendition<(), Video>,
-	) {
+	fn video_track() -> (moq_net::broadcast::Producer, super::super::Producer, VideoTrack) {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = super::super::Producer::new(&mut broadcast).unwrap();
 		let reserved = catalog.reserve();
@@ -445,7 +462,7 @@ mod tests {
 	}
 
 	/// Feed ~40ms 100 kB frames (one per group) over more than the bitrate window.
-	fn feed(rendition: &mut Rendition<(), Video>) {
+	fn feed<E: CatalogExt, C: RenditionConfig<E>>(rendition: &mut Rendition<E, C>) {
 		for i in 0..60u64 {
 			let t = ts(i * 40_000);
 			rendition.record_group_end(Some(t));
@@ -480,5 +497,173 @@ mod tests {
 			Some(Duration::from_millis(50)),
 			"a provided jitter must not be overwritten"
 		);
+	}
+
+	/// A hint is applied by the importer before `set`, so a hinted field is indistinguishable from
+	/// one the stream revealed: supplied, and never overwritten by detection.
+	#[test]
+	fn hinted_fields_count_as_supplied() {
+		let (_broadcast, catalog, mut rendition) = video_track();
+
+		let hint = VideoHint {
+			bitrate: Some(456),
+			..Default::default()
+		};
+		let mut config = config(None, None);
+		hint.apply(&mut config);
+
+		rendition.set(config);
+		feed(&mut rendition);
+
+		let snapshot = catalog.snapshot();
+		let config = snapshot.video.renditions.get("v").unwrap();
+		assert_eq!(config.bitrate, Some(456), "a hinted bitrate must not be overwritten");
+		assert!(config.jitter.is_some(), "the unhinted jitter should still be detected");
+	}
+
+	/// A detected value the stream later reveals wins: `set` recaptures what the new config carries.
+	#[test]
+	fn resetting_recaptures_supplied() {
+		let (_broadcast, catalog, mut rendition) = video_track();
+		rendition.set(config(None, None));
+		feed(&mut rendition);
+		assert!(catalog.snapshot().video.renditions.get("v").unwrap().bitrate.is_some());
+
+		rendition.set(config(Some(789), None));
+		feed(&mut rendition);
+
+		let snapshot = catalog.snapshot();
+		let config = snapshot.video.renditions.get("v").unwrap();
+		assert_eq!(config.bitrate, Some(789), "the re-set bitrate is now authoritative");
+	}
+
+	mod custom {
+		use std::collections::BTreeMap;
+
+		use serde::{Deserialize, Serialize};
+
+		use super::*;
+
+		#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
+		struct TelemetryExt {
+			#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+			telemetry: BTreeMap<String, Telemetry>,
+		}
+
+		impl CatalogExt for TelemetryExt {}
+
+		#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
+		struct Telemetry {
+			schema: String,
+			#[serde(default, skip_serializing_if = "Option::is_none")]
+			bitrate: Option<u64>,
+			#[serde(default, skip_serializing_if = "Option::is_none")]
+			timeline: Option<hang::catalog::Timeline>,
+		}
+
+		impl RenditionConfig<TelemetryExt> for Telemetry {
+			fn insert(self, catalog: &mut Catalog<TelemetryExt>, name: &str) {
+				catalog.telemetry.insert(name.to_string(), self);
+			}
+			fn get_mut<'a>(catalog: &'a mut Catalog<TelemetryExt>, name: &str) -> Option<&'a mut Self> {
+				catalog.telemetry.get_mut(name)
+			}
+			fn remove(catalog: &mut Catalog<TelemetryExt>, name: &str) {
+				catalog.telemetry.remove(name);
+			}
+
+			fn set_timeline(&mut self, timeline: hang::catalog::Timeline) {
+				self.timeline = Some(timeline);
+			}
+
+			// Opts into bitrate detection only; jitter is left undetected.
+			fn estimate(&self) -> Estimate {
+				Estimate::default().with_bitrate(self.bitrate)
+			}
+			fn set_estimate(&mut self, estimate: Estimate) {
+				self.bitrate = estimate.bitrate;
+			}
+		}
+
+		fn telemetry(bitrate: Option<u64>) -> Telemetry {
+			Telemetry {
+				schema: "gps/v1".to_string(),
+				bitrate,
+				timeline: None,
+			}
+		}
+
+		fn produce() -> (moq_net::broadcast::Producer, crate::catalog::Producer<TelemetryExt>) {
+			let mut broadcast = moq_net::broadcast::Info::new().produce();
+			let catalog = crate::catalog::Producer::with_catalog(&mut broadcast, Catalog::default()).unwrap();
+			(broadcast, catalog)
+		}
+
+		/// A custom kind gets the same detection, timeline wiring, and drop-removal as video/audio.
+		#[test]
+		fn detects_and_advertises() {
+			let (_broadcast, catalog) = produce();
+			let reserved = catalog.reserve();
+			let mut rendition = reserved.init::<Telemetry>("gps");
+			drop(reserved);
+
+			rendition.set(telemetry(None));
+			feed(&mut rendition);
+
+			let snapshot = catalog.snapshot();
+			let config = snapshot.telemetry.get("gps").unwrap();
+			assert!(config.bitrate.is_some(), "absent bitrate should be auto-detected");
+			assert!(config.timeline.is_some(), "the timeline track should be advertised");
+
+			drop(rendition);
+			assert!(
+				!catalog.snapshot().telemetry.contains_key("gps"),
+				"the rendition should be removed on drop"
+			);
+		}
+
+		/// A field the config supplies is authoritative even though the kind opts into detection.
+		#[test]
+		fn keeps_supplied_bitrate() {
+			let (_broadcast, catalog) = produce();
+			let reserved = catalog.reserve();
+			let mut rendition = reserved.init::<Telemetry>("gps");
+			drop(reserved);
+
+			rendition.set(telemetry(Some(4_200)));
+			feed(&mut rendition);
+
+			let snapshot = catalog.snapshot();
+			assert_eq!(snapshot.telemetry.get("gps").unwrap().bitrate, Some(4_200));
+		}
+
+		/// Custom and media renditions share one reservation gate, so the first snapshot carries both.
+		#[test]
+		fn gates_with_media_tracks() {
+			let (_broadcast, catalog) = produce();
+			let mut consumer = catalog.consume().unwrap();
+
+			let reserved = catalog.reserve();
+			let mut video = reserved.video("v");
+			let mut gps = reserved.init::<Telemetry>("gps");
+			drop(reserved);
+
+			let waiter = kio::Waiter::noop();
+			video.set(config(None, None));
+			assert!(
+				matches!(consumer.poll_next(&waiter), std::task::Poll::Pending),
+				"the catalog stays withheld while the telemetry rendition is unresolved"
+			);
+
+			gps.set(telemetry(None));
+
+			let mut latest = None;
+			while let std::task::Poll::Ready(Ok(Some(catalog))) = consumer.poll_next(&waiter) {
+				latest = Some(catalog);
+			}
+			let published = latest.expect("catalog published");
+			assert!(published.video.renditions.contains_key("v"));
+			assert!(published.telemetry.contains_key("gps"));
+		}
 	}
 }

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -22,9 +22,11 @@ impl<E: CatalogExt> Import<E> {
 	pub fn new(
 		track: moq_net::track::Producer,
 		reserved: crate::catalog::Reserved<E>,
-		config: hang::catalog::AudioConfig,
+		mut config: hang::catalog::AudioConfig,
 	) -> Self {
 		tracing::debug!(name = ?track.name(), ?config, "starting track");
+		// Advertise this rendition's timeline before publishing (the generic set() no longer does).
+		config.timeline = Some(reserved.producer().timeline(track.name()).section());
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Self {

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -33,6 +33,9 @@ pub struct Import<E: CatalogExt = ()> {
 	/// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
 	/// overwritten by the rendition's detector.
 	hint: crate::catalog::VideoHint,
+	/// This rendition's timeline section, advertised on every config we publish (the generic
+	/// set() no longer does). Snapshotted at construction; the timeline track is 1:1 by name.
+	timeline: hang::catalog::Timeline,
 	last_seq: Option<Bytes>,
 }
 
@@ -48,6 +51,7 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> Self {
 		let rendition = reserved.video(track.name());
+		let timeline = reserved.producer().timeline(track.name()).section();
 		let mut import = Self {
 			track: reserved
 				.producer()
@@ -55,6 +59,7 @@ impl<E: CatalogExt> Import<E> {
 			rendition,
 			config: None,
 			hint,
+			timeline,
 			last_seq: None,
 		};
 		if let Some(config) = import.hint.to_config() {
@@ -177,6 +182,7 @@ impl<E: CatalogExt> Import<E> {
 	/// to reject a reconfiguration.
 	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
 		self.hint.apply(&mut config);
+		config.timeline = Some(self.timeline.clone());
 		if self.config.as_ref() == Some(&config) {
 			return;
 		}

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -30,6 +30,9 @@ pub struct Import<E: CatalogExt = ()> {
 	track: crate::container::Producer<crate::catalog::hang::Container>,
 	rendition: crate::catalog::VideoTrack<E>,
 	config: Option<hang::catalog::VideoConfig>,
+	/// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
+	/// overwritten by the rendition's detector.
+	hint: crate::catalog::VideoHint,
 	last_seq: Option<Bytes>,
 }
 
@@ -44,18 +47,18 @@ impl<E: CatalogExt> Import<E> {
 		reserved: crate::catalog::Reserved<E>,
 		hint: crate::catalog::VideoHint,
 	) -> Self {
-		let rendition = reserved.video_with_hint(track.name(), hint.clone());
+		let rendition = reserved.video(track.name());
 		let mut import = Self {
 			track: reserved
 				.producer()
 				.media_producer(track, crate::catalog::hang::Container::Legacy),
 			rendition,
 			config: None,
+			hint,
 			last_seq: None,
 		};
-		if let Some(config) = hint.to_config() {
-			import.rendition.set(config.clone());
-			import.config = Some(config);
+		if let Some(config) = import.hint.to_config() {
+			import.apply_config(config);
 		}
 		import
 	}
@@ -172,7 +175,8 @@ impl<E: CatalogExt> Import<E> {
 	///
 	/// A changed config just re-mirrors the rendition; there are no fixed tracks
 	/// to reject a reconfiguration.
-	fn apply_config(&mut self, config: hang::catalog::VideoConfig) {
+	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
+		self.hint.apply(&mut config);
 		if self.config.as_ref() == Some(&config) {
 			return;
 		}

--- a/rs/moq-mux/src/codec/flac/import.rs
+++ b/rs/moq-mux/src/codec/flac/import.rs
@@ -25,9 +25,11 @@ impl<E: CatalogExt> Import<E> {
 	pub fn new(
 		track: moq_net::track::Producer,
 		reserved: crate::catalog::Reserved<E>,
-		config: hang::catalog::AudioConfig,
+		mut config: hang::catalog::AudioConfig,
 	) -> Self {
 		tracing::debug!(name = ?track.name(), ?config, "starting track");
+		// Advertise this rendition's timeline before publishing (the generic set() no longer does).
+		config.timeline = Some(reserved.producer().timeline(track.name()).section());
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Self {

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -36,6 +36,9 @@ pub struct Import<E: CatalogExt = ()> {
 	/// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
 	/// overwritten by the rendition's detector.
 	hint: crate::catalog::VideoHint,
+	/// This rendition's timeline section, advertised on every config we publish (the generic
+	/// set() no longer does). Snapshotted at construction; the timeline track is 1:1 by name.
+	timeline: hang::catalog::Timeline,
 	last_sps: Option<Bytes>,
 }
 
@@ -51,6 +54,7 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> Self {
 		let rendition = reserved.video(track.name());
+		let timeline = reserved.producer().timeline(track.name()).section();
 		let mut import = Self {
 			avc1: false,
 			track: reserved
@@ -59,6 +63,7 @@ impl<E: CatalogExt> Import<E> {
 			rendition,
 			config: None,
 			hint,
+			timeline,
 			last_sps: None,
 		};
 		if let Some(config) = import.hint.to_config() {
@@ -199,6 +204,7 @@ impl<E: CatalogExt> Import<E> {
 	/// rendition; there are no fixed tracks to reject a reconfiguration.
 	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
 		self.hint.apply(&mut config);
+		config.timeline = Some(self.timeline.clone());
 		if self.config.as_ref() == Some(&config) {
 			return;
 		}

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -33,6 +33,9 @@ pub struct Import<E: CatalogExt = ()> {
 	track: crate::container::Producer<crate::catalog::hang::Container>,
 	rendition: crate::catalog::VideoTrack<E>,
 	config: Option<hang::catalog::VideoConfig>,
+	/// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
+	/// overwritten by the rendition's detector.
+	hint: crate::catalog::VideoHint,
 	last_sps: Option<Bytes>,
 }
 
@@ -47,7 +50,7 @@ impl<E: CatalogExt> Import<E> {
 		reserved: crate::catalog::Reserved<E>,
 		hint: crate::catalog::VideoHint,
 	) -> Self {
-		let rendition = reserved.video_with_hint(track.name(), hint.clone());
+		let rendition = reserved.video(track.name());
 		let mut import = Self {
 			avc1: false,
 			track: reserved
@@ -55,11 +58,11 @@ impl<E: CatalogExt> Import<E> {
 				.media_producer(track, crate::catalog::hang::Container::Legacy),
 			rendition,
 			config: None,
+			hint,
 			last_sps: None,
 		};
-		if let Some(config) = hint.to_config() {
-			import.rendition.set(config.clone());
-			import.config = Some(config);
+		if let Some(config) = import.hint.to_config() {
+			import.apply_config(config);
 		}
 		import
 	}
@@ -194,7 +197,8 @@ impl<E: CatalogExt> Import<E> {
 	///
 	/// A changed config (new avcC, or a new inline SPS) just re-mirrors the
 	/// rendition; there are no fixed tracks to reject a reconfiguration.
-	fn apply_config(&mut self, config: hang::catalog::VideoConfig) {
+	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
+		self.hint.apply(&mut config);
 		if self.config.as_ref() == Some(&config) {
 			return;
 		}

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -32,6 +32,9 @@ pub struct Import<E: CatalogExt = ()> {
 	track: crate::container::Producer<crate::catalog::hang::Container>,
 	rendition: crate::catalog::VideoTrack<E>,
 	config: Option<hang::catalog::VideoConfig>,
+	/// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
+	/// overwritten by the rendition's detector.
+	hint: crate::catalog::VideoHint,
 	last_sps: Option<Bytes>,
 }
 
@@ -46,18 +49,18 @@ impl<E: CatalogExt> Import<E> {
 		reserved: crate::catalog::Reserved<E>,
 		hint: crate::catalog::VideoHint,
 	) -> Self {
-		let rendition = reserved.video_with_hint(track.name(), hint.clone());
+		let rendition = reserved.video(track.name());
 		let mut import = Self {
 			track: reserved
 				.producer()
 				.media_producer(track, crate::catalog::hang::Container::Legacy),
 			rendition,
 			config: None,
+			hint,
 			last_sps: None,
 		};
-		if let Some(config) = hint.to_config() {
-			import.rendition.set(config.clone());
-			import.config = Some(config);
+		if let Some(config) = import.hint.to_config() {
+			import.apply_config(config);
 		}
 		import
 	}
@@ -156,17 +159,22 @@ impl<E: CatalogExt> Import<E> {
 		config.container = hang::catalog::Container::Legacy;
 
 		self.last_sps = Some(sps_nal.clone());
+		self.apply_config(config);
+		Ok(())
+	}
 
-		// A changed SPS just re-mirrors the rendition in place; there are no fixed
-		// tracks to reject a reconfiguration.
+	/// Apply a resolved config, updating the catalog rendition in place.
+	///
+	/// A changed config just re-mirrors the rendition; there are no fixed tracks to reject a
+	/// reconfiguration.
+	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
+		self.hint.apply(&mut config);
 		if self.config.as_ref() == Some(&config) {
-			return Ok(());
+			return;
 		}
-
 		tracing::debug!(name = ?self.track.name(), ?config, "starting track");
 		self.rendition.set(config.clone());
 		self.config = Some(config);
-		Ok(())
 	}
 
 	/// Write split frames to the track, resolving the config from the first

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -35,6 +35,9 @@ pub struct Import<E: CatalogExt = ()> {
 	/// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
 	/// overwritten by the rendition's detector.
 	hint: crate::catalog::VideoHint,
+	/// This rendition's timeline section, advertised on every config we publish (the generic
+	/// set() no longer does). Snapshotted at construction; the timeline track is 1:1 by name.
+	timeline: hang::catalog::Timeline,
 	last_sps: Option<Bytes>,
 }
 
@@ -50,6 +53,7 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> Self {
 		let rendition = reserved.video(track.name());
+		let timeline = reserved.producer().timeline(track.name()).section();
 		let mut import = Self {
 			track: reserved
 				.producer()
@@ -57,6 +61,7 @@ impl<E: CatalogExt> Import<E> {
 			rendition,
 			config: None,
 			hint,
+			timeline,
 			last_sps: None,
 		};
 		if let Some(config) = import.hint.to_config() {
@@ -169,6 +174,7 @@ impl<E: CatalogExt> Import<E> {
 	/// reconfiguration.
 	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
 		self.hint.apply(&mut config);
+		config.timeline = Some(self.timeline.clone());
 		if self.config.as_ref() == Some(&config) {
 			return;
 		}

--- a/rs/moq-mux/src/codec/legacy.rs
+++ b/rs/moq-mux/src/codec/legacy.rs
@@ -137,6 +137,8 @@ impl<E: CatalogExt> Import<E> {
 
 		tracing::debug!(name = ?track.name(), config = ?audio_config, "starting track");
 
+		// Advertise this rendition's timeline before publishing (the generic set() no longer does).
+		audio_config.timeline = Some(reserved.producer().timeline(track.name()).section());
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(audio_config);
 

--- a/rs/moq-mux/src/codec/mp3.rs
+++ b/rs/moq-mux/src/codec/mp3.rs
@@ -113,9 +113,11 @@ impl<E: CatalogExt> Import<E> {
 	pub fn new(
 		track: moq_net::track::Producer,
 		reserved: crate::catalog::Reserved<E>,
-		config: hang::catalog::AudioConfig,
+		mut config: hang::catalog::AudioConfig,
 	) -> Self {
 		tracing::debug!(name = ?track.name(), ?config, "starting track");
+		// Advertise this rendition's timeline before publishing (the generic set() no longer does).
+		config.timeline = Some(reserved.producer().timeline(track.name()).section());
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Self {

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -25,9 +25,11 @@ impl<E: CatalogExt> Import<E> {
 	pub fn new(
 		track: moq_net::track::Producer,
 		reserved: crate::catalog::Reserved<E>,
-		config: hang::catalog::AudioConfig,
+		mut config: hang::catalog::AudioConfig,
 	) -> Self {
 		tracing::debug!(name = ?track.name(), ?config, "starting track");
+		// Advertise this rendition's timeline before publishing (the generic set() no longer does).
+		config.timeline = Some(reserved.producer().timeline(track.name()).section());
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Self {

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -23,6 +23,9 @@ pub struct Import<E: CatalogExt = ()> {
 	// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
 	// overwritten by the rendition's detector.
 	hint: crate::catalog::VideoHint,
+	/// This rendition's timeline section, advertised on every config we publish (the generic
+	/// set() no longer does). Snapshotted at construction; the timeline track is 1:1 by name.
+	timeline: hang::catalog::Timeline,
 }
 
 impl<E: CatalogExt> Import<E> {
@@ -37,6 +40,7 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> Self {
 		let rendition = reserved.video(track.name());
+		let timeline = reserved.producer().timeline(track.name()).section();
 		let mut import = Self {
 			track: reserved
 				.producer()
@@ -44,6 +48,7 @@ impl<E: CatalogExt> Import<E> {
 			rendition,
 			config: None,
 			hint,
+			timeline,
 		};
 		if let Some(config) = import.hint.to_config() {
 			import.apply_config(config);
@@ -80,6 +85,7 @@ impl<E: CatalogExt> Import<E> {
 	/// reconfiguration.
 	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
 		self.hint.apply(&mut config);
+		config.timeline = Some(self.timeline.clone());
 		if self.config.as_ref() == Some(&config) {
 			return;
 		}

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -19,6 +19,10 @@ pub struct Import<E: CatalogExt = ()> {
 
 	// The resolved config, used to detect resolution changes.
 	config: Option<hang::catalog::VideoConfig>,
+
+	// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
+	// overwritten by the rendition's detector.
+	hint: crate::catalog::VideoHint,
 }
 
 impl<E: CatalogExt> Import<E> {
@@ -32,17 +36,17 @@ impl<E: CatalogExt> Import<E> {
 		reserved: crate::catalog::Reserved<E>,
 		hint: crate::catalog::VideoHint,
 	) -> Self {
-		let rendition = reserved.video_with_hint(track.name(), hint.clone());
+		let rendition = reserved.video(track.name());
 		let mut import = Self {
 			track: reserved
 				.producer()
 				.media_producer(track, crate::catalog::hang::Container::Legacy),
 			rendition,
 			config: None,
+			hint,
 		};
-		if let Some(config) = hint.to_config() {
-			import.rendition.set(config.clone());
-			import.config = Some(config);
+		if let Some(config) = import.hint.to_config() {
+			import.apply_config(config);
 		}
 		import
 	}
@@ -66,15 +70,22 @@ impl<E: CatalogExt> Import<E> {
 		config.coded_height = Some(height as u32);
 		config.container = hang::catalog::Container::Legacy;
 
-		if self.config.as_ref() == Some(&config) {
-			return Ok(());
-		}
+		self.apply_config(config);
+		Ok(())
+	}
 
+	/// Apply a resolved config, updating the catalog rendition in place.
+	///
+	/// A changed config just re-mirrors the rendition; there are no fixed tracks to reject a
+	/// reconfiguration.
+	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
+		self.hint.apply(&mut config);
+		if self.config.as_ref() == Some(&config) {
+			return;
+		}
 		tracing::debug!(name = ?self.track.name(), ?config, "starting track");
 		self.rendition.set(config.clone());
 		self.config = Some(config);
-
-		Ok(())
 	}
 
 	/// Decode a single VP8 frame.

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -19,6 +19,10 @@ pub struct Import<E: CatalogExt = ()> {
 
 	// The resolved config, used to detect resolution / format changes.
 	config: Option<hang::catalog::VideoConfig>,
+
+	// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
+	// overwritten by the rendition's detector.
+	hint: crate::catalog::VideoHint,
 }
 
 impl<E: CatalogExt> Import<E> {
@@ -32,17 +36,17 @@ impl<E: CatalogExt> Import<E> {
 		reserved: crate::catalog::Reserved<E>,
 		hint: crate::catalog::VideoHint,
 	) -> Self {
-		let rendition = reserved.video_with_hint(track.name(), hint.clone());
+		let rendition = reserved.video(track.name());
 		let mut import = Self {
 			track: reserved
 				.producer()
 				.media_producer(track, crate::catalog::hang::Container::Legacy),
 			rendition,
 			config: None,
+			hint,
 		};
-		if let Some(config) = hint.to_config() {
-			import.rendition.set(config.clone());
-			import.config = Some(config);
+		if let Some(config) = import.hint.to_config() {
+			import.apply_config(config);
 		}
 		import
 	}
@@ -66,15 +70,22 @@ impl<E: CatalogExt> Import<E> {
 		config.coded_height = Some(height as u32);
 		config.container = hang::catalog::Container::Legacy;
 
-		if self.config.as_ref() == Some(&config) {
-			return Ok(());
-		}
+		self.apply_config(config);
+		Ok(())
+	}
 
+	/// Apply a resolved config, updating the catalog rendition in place.
+	///
+	/// A changed config just re-mirrors the rendition; there are no fixed tracks to reject a
+	/// reconfiguration.
+	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
+		self.hint.apply(&mut config);
+		if self.config.as_ref() == Some(&config) {
+			return;
+		}
 		tracing::debug!(name = ?self.track.name(), ?config, "starting track");
 		self.rendition.set(config.clone());
 		self.config = Some(config);
-
-		Ok(())
 	}
 
 	/// Decode a single VP9 frame (or superframe).

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -23,6 +23,9 @@ pub struct Import<E: CatalogExt = ()> {
 	// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
 	// overwritten by the rendition's detector.
 	hint: crate::catalog::VideoHint,
+	/// This rendition's timeline section, advertised on every config we publish (the generic
+	/// set() no longer does). Snapshotted at construction; the timeline track is 1:1 by name.
+	timeline: hang::catalog::Timeline,
 }
 
 impl<E: CatalogExt> Import<E> {
@@ -37,6 +40,7 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> Self {
 		let rendition = reserved.video(track.name());
+		let timeline = reserved.producer().timeline(track.name()).section();
 		let mut import = Self {
 			track: reserved
 				.producer()
@@ -44,6 +48,7 @@ impl<E: CatalogExt> Import<E> {
 			rendition,
 			config: None,
 			hint,
+			timeline,
 		};
 		if let Some(config) = import.hint.to_config() {
 			import.apply_config(config);
@@ -80,6 +85,7 @@ impl<E: CatalogExt> Import<E> {
 	/// reconfiguration.
 	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
 		self.hint.apply(&mut config);
+		config.timeline = Some(self.timeline.clone());
 		if self.config.as_ref() == Some(&config) {
 			return;
 		}

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -74,11 +74,12 @@ impl<C: Container> Producer<C> {
 	/// Record each group open (sequence + keyframe timestamp) through `recorder`, so consumers can
 	/// index the media without downloading it.
 	///
-	/// Not public: a timeline is 1:1 with its media track (the record carries no track id), and the
-	/// [`Recorder`](crate::timeline::Recorder) is move-only, so it's bound to this exact track and
-	/// can't be shared. The catalog owns that binding, via
-	/// [`catalog::Producer::media_producer`](crate::catalog::Producer::media_producer).
-	pub(crate) fn with_recorder(mut self, recorder: crate::timeline::Recorder) -> Self {
+	/// Mint the recorder from a [`timeline::Producer`](crate::timeline::Producer) (see
+	/// [`catalog::Producer::timeline`](crate::catalog::Producer::timeline)). The record carries no
+	/// track id, so wire one recorder per timeline; a set of aligned renditions shares a timeline by
+	/// recording only the source and advertising the same section on the rest.
+	/// [`media_producer`](crate::catalog::Producer::media_producer) wires the 1:1 default for you.
+	pub fn with_recorder(mut self, recorder: crate::timeline::Recorder) -> Self {
 		self.recorder = Some(recorder);
 		self
 	}

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -6,17 +6,20 @@
 //! from a few bytes per group without subscribing to media, the primitive a playlist server
 //! (HLS/DASH), a seek bar, or a recorder index needs.
 //!
-//! One timeline track per media track (audio and video groups have different durations, so a
-//! single broadcast-wide timeline can't describe both). The write side splits by role:
+//! A timeline can be shared: audio and video groups have different durations so they need separate
+//! timelines, but an aligned set of renditions (a transcode ladder whose rungs mirror the source's
+//! group boundaries) can point at one. The write side splits by role:
 //!
 //! - [`Producer`] owns the track and its catalog metadata: the [`section`](Producer::section)
-//!   advertised in the rendition's config and the [`set_wall`](Producer::set_wall) anchor. The
-//!   [`catalog::Producer`](crate::catalog::Producer) creates and owns one per rendition; it is not
-//!   `Clone`, so a timeline is bound to its one media track.
-//! - `Recorder` is the move-only handle the media track records group opens through, minted 1:1
-//!   by the catalog into the rendition's [`container::Producer`](crate::container::Producer) (see
-//!   [`catalog::Producer::media_producer`](crate::catalog::Producer::media_producer)). Being
-//!   move-only, it can't be shared with a second track, and it owns its throttle cursor outright.
+//!   advertised in a rendition's config and the [`set_wall`](Producer::set_wall) anchor. Get one
+//!   from [`catalog::Producer::timeline`](crate::catalog::Producer::timeline); it is `Clone`, and
+//!   every clone shares the one track, so N renditions advertising the same timeline share it.
+//! - [`Recorder`] is the move-only handle a media track records group opens through, wired into a
+//!   rendition's [`container::Producer`](crate::container::Producer) via
+//!   [`with_recorder`](crate::container::Producer::with_recorder) (or, for the 1:1 default,
+//!   [`catalog::Producer::media_producer`](crate::catalog::Producer::media_producer)). Recording is
+//!   what fills a shared timeline, so wire exactly one recorder into it (the source), and let the
+//!   other renditions only advertise.
 //!
 //! On the read side, [`Consumer::subscribe`] reads a timeline straight from its
 //! [`hang::catalog::Timeline`] section (so the track name and timescale come from the catalog and
@@ -31,6 +34,7 @@
 //! are thinned out. A consumer that lands between two records extrapolates the group number
 //! (sequences are contiguous) or fetches to fill the gap.
 
+use std::sync::{Arc, Mutex};
 use std::task::Poll;
 use std::time::SystemTime;
 
@@ -43,18 +47,22 @@ use moq_net::{Timescale, Timestamp};
 /// media time.
 pub const DEFAULT_GRANULARITY: Timestamp = Timestamp::new_const(1, Timescale::SECOND);
 
-/// Owns one media track's timeline: its catalog [`section`](Self::section) and wall anchor, and the
-/// `Recorder` its group opens are recorded through.
+/// A media timeline: its catalog [`section`](Self::section) and wall anchor, and the [`Recorder`]
+/// its group opens are recorded through.
 ///
-/// Generic over the record extension `E` (defaulting to `()`; see [`RecordExt`]). Owned 1:1 by the
-/// catalog and deliberately not `Clone`, so a timeline is bound to its one media track.
+/// Generic over the record extension `E` (defaulting to `()`; see [`RecordExt`]). `Clone`, and every
+/// clone shares the one track and its wall anchor, so a set of aligned renditions can advertise one
+/// timeline. Get one from [`catalog::Producer::timeline`](crate::catalog::Producer::timeline), which
+/// keeps ownership and closes the track when the catalog finishes.
+#[derive(Clone)]
 pub struct Producer<E: RecordExt = ()> {
 	inner: moq_json::stream::Producer<Record<E>>,
 	track: String,
 	timescale: Timescale,
 	granularity: Timestamp,
 	// The wall-clock time of pts 0, in timescale units since the moq epoch, advertised in section().
-	wall: Option<u64>,
+	// Shared across clones so a set_wall on one is seen by every rendition advertising this timeline.
+	wall: Arc<Mutex<Option<u64>>>,
 }
 
 impl<E: RecordExt> Producer<E> {
@@ -73,7 +81,7 @@ impl<E: RecordExt> Producer<E> {
 			track,
 			timescale: Timescale::new(Timeline::default_timescale() as u64).expect("default timescale is nonzero"),
 			granularity: DEFAULT_GRANULARITY,
-			wall: None,
+			wall: Arc::new(Mutex::new(None)),
 		})
 	}
 
@@ -88,7 +96,7 @@ impl<E: RecordExt> Producer<E> {
 	pub fn section(&self) -> Timeline {
 		let mut section = Timeline::new(&self.track);
 		section.timescale = self.timescale.as_u64() as u32;
-		section.wall = self.wall;
+		section.wall = *self.wall.lock().unwrap();
 		section
 	}
 
@@ -109,14 +117,15 @@ impl<E: RecordExt> Producer<E> {
 		let pts_units = pts.as_scale(self.timescale);
 		let moq_millis = unix_millis.saturating_sub(hang::catalog::MOQ_EPOCH_UNIX_MILLIS as u128);
 		let moq_units = moq_millis * scale / 1000;
-		self.wall = Some(moq_units.saturating_sub(pts_units) as u64);
+		*self.wall.lock().unwrap() = Some(moq_units.saturating_sub(pts_units) as u64);
 	}
 
-	/// Mint the [`Recorder`] the media track records its group opens through.
+	/// Mint a [`Recorder`] to record group opens into this timeline.
 	///
-	/// Internal: the catalog wires exactly one into the rendition's container producer, which is how
-	/// a timeline stays 1:1 with its media track.
-	pub(crate) fn recorder(&self) -> Recorder<E> {
+	/// Wire it into a media track's [`container::Producer`](crate::container::Producer) with
+	/// [`with_recorder`](crate::container::Producer::with_recorder). A recorder owns its own throttle
+	/// cursor, so wire exactly one per timeline (a shared timeline is filled by its source alone).
+	pub fn recorder(&self) -> Recorder<E> {
 		Recorder {
 			inner: self.inner.clone(),
 			timescale: self.timescale,
@@ -137,11 +146,10 @@ impl<E: RecordExt> Producer<E> {
 
 /// Records a media track's group opens into its timeline, throttled to a granularity.
 ///
-/// Move-only (not `Clone`): exactly one recorder exists per media track, so it owns its throttle
-/// cursor outright (no shared state to diverge) and can't be handed to a second track. Minted by
-/// [`Producer::recorder`] and held by the rendition's
+/// Move-only (not `Clone`): it owns its throttle cursor, so wire exactly one per timeline. Minted by
+/// [`Producer::recorder`] and held by a rendition's
 /// [`container::Producer`](crate::container::Producer).
-pub(crate) struct Recorder<E: RecordExt = ()> {
+pub struct Recorder<E: RecordExt = ()> {
 	inner: moq_json::stream::Producer<Record<E>>,
 	timescale: Timescale,
 	granularity: Timestamp,

--- a/rs/moq-rtc/src/codec/vp8.rs
+++ b/rs/moq-rtc/src/codec/vp8.rs
@@ -32,7 +32,7 @@ impl Bridge {
 		let name = self.track.track().name().to_string();
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		config.container = hang::catalog::Container::Legacy;
-		config.timeline = Some(self.catalog.timeline_section(&name));
+		config.timeline = Some(self.catalog.timeline(&name).section());
 		self.catalog.lock().video.renditions.insert(name, config);
 		self.announced = true;
 	}

--- a/rs/moq-rtc/src/codec/vp9.rs
+++ b/rs/moq-rtc/src/codec/vp9.rs
@@ -31,7 +31,7 @@ impl Bridge {
 		let name = self.track.track().name().to_string();
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VP9::default());
 		config.container = hang::catalog::Container::Legacy;
-		config.timeline = Some(self.catalog.timeline_section(&name));
+		config.timeline = Some(self.catalog.timeline(&name).section());
 		self.catalog.lock().video.renditions.insert(name, config);
 		self.announced = true;
 	}


### PR DESCRIPTION
Two related breaking changes to `moq-mux`'s catalog layer, both landing here because they reshape the same surface. Requested by a user who wanted a `CustomTrack<Ext>` sibling to `VideoTrack`/`AudioTrack`.

## 1. Unseal `Kind` into a `RenditionConfig` trait

`catalog::Kind` was sealed, so `Video` and `Audio` were the only renditions the catalog could hold. An application publishing a non-media track (telemetry, captions) had to re-derive the whole `Rendition` lifecycle by hand: the gate-until-`set` handshake, removal on drop, and the jitter/bitrate detector.

- The trait now lives on the **config type** (`RenditionConfig<E>`), so `impl RenditionConfig<MyExt> for Telemetry` works and multiple custom kinds coexist in one extension. The `Video`/`Audio` marker enums collapse: they existed only to carry `type Config`. `VideoConfig`/`AudioConfig` implement it for every `E`, so the built-in media configs stop being a privileged path.
- `insert`/`get_mut`/`remove` take `&mut Catalog<E>`, not `&mut E`. That's what lets `VideoConfig` use the same trait. A custom impl *could* therefore touch `catalog.video`, but this grants no access it didn't already have (`Reserved::producer().lock()` is public and openly mutable) and you only reach it by deliberately constructing a `VideoConfig`. Documented as guidance, not a hazard.
- The three-way precedence (stream > caller > detector) collapses into one rule in `set()`: whatever the config carries when it reaches `set()` is authoritative; only what's absent gets measured. Hints move to the importers (the importer builds the config, so it owns what goes in it). `raise_bitrate` is deleted — the detector already ratchets.

## 2. Make timelines explicit and shareable; drop `set_timeline`

`set()` advertised the timeline via a `set_timeline` hook — the one trait method unrelated to storage or the estimate. It forced every custom config to carry a `hang::catalog::Timeline` field, and it minted the `.timeline.z` track unconditionally even when the config discarded the section (a phantom track for timeline-less kinds). More fundamentally, advertising by rendition name baked in a **1:1 timeline that can't be shared** — an aligned transcode ladder wants its rungs to index off one timeline track.

- Advertising moves to the caller, the same way hints did. `timeline::Producer` becomes a cheap shareable `Clone` handle, handed out by the new `catalog::Producer::timeline(name)`; the catalog keeps ownership and closes the track on `finish`.
- Advertise with `config.timeline = Some(tl.section())`; record group opens by wiring `tl.recorder()` (now public, as is `container::Producer::with_recorder`). **Two renditions naming one timeline share it:** record the source, advertise the same section on the rest.
- `media_producer` keeps its signature (18 callers across moq-audio/moq-rtc/moq-hls untouched) as the 1:1 convenience, reimplemented on top of the handle.

## Public API changes (all `moq-mux`, breaking → `dev`)

**Removed:** `Kind`, `Video`, `Audio`, `Reserved::video_with_hint`, `RenditionConfig::set_timeline`, `Producer::timeline_section`, `Producer::timeline_recorder`.

**Added:** `RenditionConfig<E>` (3 required + 3 defaulted methods), `Estimate` (+ `with_jitter`/`with_bitrate`), `Reserved::init::<C>`, `Producer::timeline(name) -> timeline::Producer`. `timeline::Producer` is now `Clone`; `timeline::Producer::recorder`, `timeline::Recorder`, and `container::Producer::with_recorder` are now public.

**Signature-changed:** `Rendition<E, K: Kind>` → `Rendition<E, C: RenditionConfig<E>>` (and `set`/`update`). `VideoTrack`/`AudioTrack` aliases, `Reserved::video`/`audio`, `VideoHint`, and `media_producer` are unchanged.

`Estimate` is `#[non_exhaustive]` (a third detectable field is then additive), which bans `..Default::default()` cross-crate — hence the `with_*` chainers, so the documented construction path is lint-clean in a consumer's crate.

## Cross-Package Sync

No wire change: `Estimate` isn't serialized and no catalog field changed shape, so no draft or `js/hang` update. Callers in other `rs/` crates were updated in-tree: moq-audio and moq-rtc (`timeline_section` → `timeline().section()`); moq-hls only uses the read-side `timeline::Consumer`, untouched. `moq-ffi` is untouched.

## Test plan

- `just check` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc` on moq-mux + moq-audio/moq-rtc/moq-hls — clean (deleted `set_timeline`/`timeline_section` were doc-linked; this was the real risk)
- `cargo test -p moq-mux` — 391 passed, incl. new tests
- `just test smoke` — passes (exercises every codec import path; the timeline group-recording and TS reorder-jitter tests still validate end-to-end)
- All re-run after rebasing onto current `origin/dev`

New tests: `hinted_fields_count_as_supplied` / `resetting_recaptures_supplied` pin the precedence rule; `renditions_share_a_timeline` covers the new sharing capability; a `custom` module implements a `Telemetry` kind over its own `CatalogExt` (detection, explicit timeline advertising, drop-removal, supplied-beats-detected, shared reservation gate).

## Notes for the reviewer

- `select::Broadcast::retain` only touches `catalog.video`/`catalog.audio`, so custom `ext` renditions pass through selection untouched (always kept). Out of scope; worth deciding whether that becomes a documented guarantee.
- **Behavior change for direct-API publishers:** removing `set()`'s auto-advertise means a rendition published straight through the catalog API (`reserved.video(...).set(config)`) no longer carries a timeline unless the caller adds one (`config.timeline = Some(catalog.timeline(name).section())`). Codec importers do this automatically, but HLS export skips a timeline-less rendition — the 4 moq-hls export tests were updated to advertise explicitly (they used the direct API). Real importer-based flows are unaffected.
- `moq-mux` sets `doctest = false`, so the `RenditionConfig` example isn't compile-checked. Verified by temporarily flipping the flag (passes); a separate task tracks enabling it.

(Written by Opus 4.8)
