### PR TITLE
test: compile doc examples across the workspace

### DIFF
--- a/rs/hang/Cargo.toml
+++ b/rs/hang/Cargo.toml
@@ -12,10 +12,6 @@ rust-version.workspace = true
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
-[lib]
-doctest = false
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 bytes = "1"
 hex = "0.4"

--- a/rs/kio/Cargo.toml
+++ b/rs/kio/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 keywords = ["async", "producer", "consumer", "state", "sync"]
 categories = ["asynchronous", "concurrency"]
 
-[lib]
-doctest = false
-
 [features]
 # Opt-in `tokio::time::Sleep`, a poll-driven wall-clock wait backed by tokio. Off by
 # default so kio stays runtime-free. Enable it when driving `poll_*` functions on tokio.

--- a/rs/moq-audio/Cargo.toml
+++ b/rs/moq-audio/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 keywords = ["quic", "http3", "webtransport", "media", "audio"]
 categories = ["multimedia", "multimedia::audio", "multimedia::encoding"]
 
-[lib]
-doctest = false
-
 [features]
 # Device capture. Microphones go through cpal (pure-Rust: CoreAudio / WASAPI /
 # ALSA); macOS system audio goes through ScreenCaptureKit, which is where Apple

--- a/rs/moq-flate/Cargo.toml
+++ b/rs/moq-flate/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 keywords = ["deflate", "compression", "streaming", "live"]
 categories = ["compression"]
 
-[lib]
-doctest = false
-
 [dependencies]
 bytes = "1"
 flate2 = { workspace = true }

--- a/rs/moq-gst/Cargo.toml
+++ b/rs/moq-gst/Cargo.toml
@@ -13,7 +13,6 @@ publish = true
 [lib]
 name = "gstmoq"
 crate-type = ["cdylib", "rlib"]
-doctest = false
 
 [dependencies]
 

--- a/rs/moq-hls/Cargo.toml
+++ b/rs/moq-hls/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 keywords = ["hls", "ll-hls", "moq", "media", "cmaf"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
-[lib]
-doctest = false
-
 [features]
 default = ["server"]
 server = ["dep:axum"]

--- a/rs/moq-json/Cargo.toml
+++ b/rs/moq-json/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 keywords = ["quic", "http3", "webtransport", "json", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
-[lib]
-doctest = false
-
 [dependencies]
 bytes = "1"
 json-patch = "4"

--- a/rs/moq-loc/Cargo.toml
+++ b/rs/moq-loc/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
-[lib]
-doctest = false
-
 [dependencies]
 bytes = "1"
 moq-net = { workspace = true }

--- a/rs/moq-msf/Cargo.toml
+++ b/rs/moq-msf/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
-[lib]
-doctest = false
-
 [dependencies]
 serde = { workspace = true }
 serde_json = "1"

--- a/rs/moq-mux/Cargo.toml
+++ b/rs/moq-mux/Cargo.toml
@@ -12,10 +12,6 @@ rust-version.workspace = true
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
-[lib]
-doctest = false
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 anyhow = "1"
 base64 = "0.22"

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
-[lib]
-doctest = false
-
 [features]
 default = ["quinn", "aws-lc-rs", "websocket", "tcp", "uds"]
 quinn = ["dep:quinn", "dep:web-transport-quinn", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch"]

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
-[lib]
-doctest = false
-
 [[bin]]
 name = "moq-relay"
 path = "src/main.rs"

--- a/rs/moq-rtc/Cargo.toml
+++ b/rs/moq-rtc/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 keywords = ["webrtc", "whip", "whep", "moq", "media"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
-[lib]
-doctest = false
-
 # Pure library: the WHIP/WHEP <-> MoQ gateway (axum routers + WHEP/WHIP client).
 # The CLI lives in `moq-cli` (the `rtc` subcommand); embedders mount the routers
 # / dial with `Client` against their own origin.

--- a/rs/moq-rtmp/Cargo.toml
+++ b/rs/moq-rtmp/Cargo.toml
@@ -15,9 +15,6 @@ rust-version.workspace = true
 keywords = ["rtmp", "moq", "media", "live", "flv"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
-[lib]
-doctest = false
-
 [features]
 default = ["tls"]
 # RTMPS (RTMP over TLS): the `Conn::Tls` variant, `Server::with_tls`,

--- a/rs/moq-rtmp/src/rml/chunk_io/deserializer.rs
+++ b/rs/moq-rtmp/src/rml/chunk_io/deserializer.rs
@@ -93,7 +93,7 @@ impl ChunkDeserializer {
 	///
 	/// ## Examples
 	///
-	/// ```
+	/// ```ignore
 	/// # extern crate bytes;
 	/// # extern crate rml_rtmp;
 	/// # use bytes::Bytes;

--- a/rs/moq-rtmp/src/rml/chunk_io/mod.rs
+++ b/rs/moq-rtmp/src/rml/chunk_io/mod.rs
@@ -25,7 +25,7 @@ provide input and output buffers with minimal allocations.
 
 ## Examples
 
-```
+```ignore
 # extern crate bytes;
 # extern crate rml_rtmp;
 # use bytes::Bytes;

--- a/rs/moq-rtmp/src/rml/handshake/mod.rs
+++ b/rs/moq-rtmp/src/rml/handshake/mod.rs
@@ -105,7 +105,7 @@ enum Stage {
 ///
 /// ## Examples
 ///
-/// ```
+/// ```ignore
 /// use rml_rtmp::handshake::{Handshake, PeerType, HandshakeProcessResult};
 ///
 /// let mut client = Handshake::new(PeerType::Client);

--- a/rs/moq-rtmp/src/rml/time.rs
+++ b/rs/moq-rtmp/src/rml/time.rs
@@ -13,7 +13,7 @@
 //!
 //! Basic arithmetic and comparison support:
 //!
-//! ```
+//! ```ignore
 //! use rml_rtmp::time::RtmpTimestamp;
 //!
 //! let time1 = RtmpTimestamp::new(10);
@@ -31,7 +31,7 @@
 //!
 //! Value Wrapping support:
 //!
-//! ```
+//! ```ignore
 //! use rml_rtmp::time::RtmpTimestamp;
 //!
 //! let time1 = RtmpTimestamp::new(10000);
@@ -44,7 +44,7 @@
 //!
 //! For ease of use, a `RtmpTimestamp` can be directly compared to u32s:
 //!
-//! ```
+//! ```ignore
 //! use rml_rtmp::time::RtmpTimestamp;
 //!
 //! let time = RtmpTimestamp::new(50);

--- a/rs/moq-srt/Cargo.toml
+++ b/rs/moq-srt/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 keywords = ["srt", "moq", "media", "live", "mpeg-ts"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
-[lib]
-doctest = false
-
 # Pure library: the SRT <-> MoQ gateway. The CLI lives in `moq-cli` (the `srt`
 # subcommand); a relay can also embed `moq_srt::run` / `Server` against its own
 # origin.

--- a/rs/moq-stats/Cargo.toml
+++ b/rs/moq-stats/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 keywords = ["quic", "http3", "webtransport", "stats", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]
 
-[lib]
-doctest = false
-
 [dependencies]
 moq-json = { workspace = true }
 moq-net = { workspace = true }

--- a/rs/moq-token/Cargo.toml
+++ b/rs/moq-token/Cargo.toml
@@ -9,9 +9,6 @@ version = "0.6.3"
 edition = "2024"
 rust-version.workspace = true
 
-[lib]
-doctest = false
-
 [features]
 jwks-loader = ["reqwest"]
 tokio = ["dep:tokio"]

--- a/rs/moq-transcode/Cargo.toml
+++ b/rs/moq-transcode/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 keywords = ["quic", "http3", "webtransport", "media", "video"]
 categories = ["multimedia", "multimedia::video", "multimedia::encoding"]
 
-[lib]
-doctest = false
-
 [features]
 # Hardware codecs on by default, mirroring moq-video: NVDEC -> NVENC is the whole
 # point of a GPU transcode fleet. Disable for a slimmer self-compiled Linux build.

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -12,9 +12,6 @@ rust-version.workspace = true
 keywords = ["quic", "http3", "webtransport", "media", "video"]
 categories = ["multimedia", "multimedia::video", "multimedia::encoding"]
 
-[lib]
-doctest = false
-
 [features]
 # Hardware codecs are enabled by default. Disable them (e.g. `--no-default-features`)
 # for a slimmer self-compiled Linux build that drops the CUDA / libva deps: openh264


### PR DESCRIPTION
## What

Every library crate under `rs/` carried `doctest = false` in its `[lib]` section, so `cargo test --doc` never compiled a single doc example. That made rot invisible: an example could reference a renamed or removed API and nothing would catch it. This removes the flag from all 19 crates that set it.

## The moq-rtmp exception

The vendored `rml` module in `moq-rtmp` is the one place where the examples genuinely can't compile in this workspace. They `use rml_rtmp::...`, but that crate is vendored as a private `mod rml` and is unreachable from a doctest (which compiles as an external crate). Making them compile would mean either churning the upstream fork or making the module public.

Instead, the six affected blocks are tagged ` ```ignore `. That matches the module's existing stance: its header already opts the whole vendor out of the workspace's `-D warnings` clippy/rustdoc gate to stay close to upstream. Prose still renders; the examples just aren't compiled.

## Result

`cargo test --workspace --doc` now compiles and passes: **24 examples pass, 9 ignored, 0 fail**. `just check` passes; `moq-rtmp`'s 193 unit tests are unaffected.

## Scope / caveat

This is deliberately just the config + doc-fence change. It is **not** wired into automated CI: `just rs ci` uses `cargo nextest run` and `just rs test` uses `--all-targets`, neither of which builds doctests. So the practical effect today is that the local `cargo test --workspace --doc` run is correct and the examples stay honest for anyone who runs it. Adding a `--doc` step to `just rs ci` (~40-60s marginal, measured) is a separate follow-up.

Targets `main`: no wire change and no `pub` API change, purely a build/test/docs refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Opus 4.8)