### PR TITLE
fix(nix): keep moq-cli's cross-crate test fixture in the build source

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -55,7 +55,18 @@ let
   };
 
   moqCliArgs = crateInfo ../rs/moq-cli/Cargo.toml // {
-    src = craneLib.cleanCargoSource ../.;
+    # moq-cli's tests `include_bytes!` a fixture that lives in ANOTHER crate
+    # (rs/moq-mux/src/container/ts/test_data/bbb.ts, since #1879 moved the TS
+    # verbatim coverage there). craneLib.cleanCargoSource's default filter keeps
+    # only Cargo/Rust sources, so the fixture never reaches the sandbox and the
+    # checkPhase fails to compile the test binary. Keep the test data so the
+    # tests still run here rather than switching this package to doCheck = false.
+    src = final.lib.cleanSourceWith {
+      src = ../.;
+      name = "source";
+      filter =
+        path: type: (final.lib.hasInfix "/test_data/" path) || (craneLib.filterCargoSources path type);
+    };
     cargoExtraArgs = "-p moq-cli";
     # The crate is `moq-cli`, but its `[[bin]]` ships as `moq`.
     meta.mainProgram = "moq";


### PR DESCRIPTION
## Problem

A from-source build of `moq-cli` (`nix build .#moq-cli`, or a `nix develop` that builds it) fails in the check phase:

```
error: couldn't read `rs/moq-cli/src/../../moq-mux/src/container/ts/test_data/bbb.ts`:
       No such file or directory (os error 2)
 --> rs/moq-cli/src/publish.rs:447
error: could not compile `moq-cli` (bin "moq" test)
```

`#1879` moved moq-cli's MPEG-TS verbatim coverage so its fixture now lives in the **moq-mux** crate, but the test still `include_bytes!`s it. `craneLib.cleanCargoSource`'s filter keeps only Cargo/Rust sources, so `bbb.ts` never reaches the sandbox and the test binary won't compile.

Tagged releases hide this because they come from the Cachix cache; it only bites a from-source build of an untagged commit -- e.g. a downstream flake input pinned to `dev` (which is how I hit it).

## Fix

Extend `moqCliArgs`'s source filter to also keep `/test_data/` paths, mirroring the existing `libmoqArgs` filter that keeps `.pc.in` / `native-libs`. This keeps moq-cli's tests running in the sandbox rather than switching the package to `doCheck = false`.

Verified: `nix build .#moq-cli` completes and produces `bin/moq` (checkPhase green) on this commit; it fails without the change.

(written by Opus 4.8)