### PR TITLE
feat(net): route by cumulative cost on lite-06 announcements

### DIFF
--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -37,13 +37,13 @@ Pick the shape that matches your traffic. Linear chains are great for fanout; sm
 
 Hop counting treats every link the same, but links rarely cost the same: traffic between two relays in one datacenter is free, while a metered backbone bills per byte. On `moq-lite-06` (still work-in-progress and opt-in via `--version`), announcements carry a route cost so relays can route by price instead of distance.
 
-Price a link by adding `?link_cost=N` to the peer URL:
+Price a link by adding `?cost=N` to the peer URL:
 
 ```toml
 [cluster]
 connect = [
-  "https://sibling.same-dc.example/?link_cost=0",
-  "https://us-east.example.com/?link_cost=10",
+  "https://sibling.same-dc.example/?cost=0",
+  "https://us-east.example.com/?cost=10",
 ]
 ```
 

--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -33,6 +33,24 @@ A publisher on `eu-west` reaches a viewer on `us-west` through `us-east`. If a s
 
 Pick the shape that matches your traffic. Linear chains are great for fanout; small N-way meshes are fine when latency matters more than dedup; mixed shapes work too.
 
+## Link costs
+
+Hop counting treats every link the same, but links rarely cost the same: traffic between two relays in one datacenter is free, while a metered backbone bills per byte. On `moq-lite-06` (still work-in-progress and opt-in via `--version`), announcements carry a route cost so relays can route by price instead of distance.
+
+Price a link by adding `?link_cost=N` to the peer URL:
+
+```toml
+[cluster]
+connect = [
+  "https://sibling.same-dc.example/?link_cost=0",
+  "https://us-east.example.com/?link_cost=10",
+]
+```
+
+The dialing relay declares the price during setup and both ends charge it: every announcement crossing the link adds `N` to its cost. An unpriced link costs 1, which reproduces plain hop counting. The param is consumed locally; it is never sent as part of the URL.
+
+The cost a relay advertises is the *marginal* cost of pulling the broadcast through it. A relay actively carrying a broadcast (a subscriber is pulling it) re-announces it at cost 0: its upstream fetch is already paid for, so a sibling should pull the warm copy over a free intra-DC link instead of opening a second metered fetch. When the last subscriber leaves, the cost decays back after a short grace period. Standby publishers (e.g. a transcoder pool) can seed a large cost so they are only selected when nothing cheaper exists, and the winner's cost drops to 0 once it starts working.
+
 ## Auto-discovery
 
 Listing every peer by hand can get tedious in larger clusters. Tell the relay its own URL with `cluster.node`, then enable gossip with `cluster.mesh`; connected peers will discover and dial it back automatically:

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -294,7 +294,8 @@ A publisher SHOULD advertise only the best path it knows for each broadcast.
 If the best path changes (e.g. a relay failover or upstream restart), the publisher MAY send an ANNOUNCE_RESTART referencing the advertisement's Announce ID: the new announcement atomically replaces the prior one (equivalent to ANNOUNCE_END+ANNOUNCE_START) and the id stays live.
 The first entry of the reconstructed path identifies the original publisher (see [ANNOUNCE_START](#announce-start)); a restart that preserves it is an alternate route to the same broadcast, while one that changes it replaces the broadcast entirely (see [ANNOUNCE_RESTART](#announce-restart)).
 A publisher MUST NOT keep multiple current advertisements for the same broadcast on the same stream — each broadcast has at most one current advertisement at a time, and a second ANNOUNCE_START for an already-available path is a protocol violation (use ANNOUNCE_RESTART).
-A subscriber that sees the same broadcast advertised across multiple streams SHOULD route subscriptions to the advertisement with the shortest total path length (see [ANNOUNCE_START](#announce-start)).
+A subscriber that sees the same broadcast advertised across multiple streams SHOULD route subscriptions to the advertisement with the lowest Route Cost after adding each arriving link's cost, breaking ties by the shortest total path length (see [ANNOUNCE_START](#announce-start)).
+Advertisements from peers that predate the Route Cost carry an effective cost of 0, so a mixed mesh degrades to shortest-path routing.
 
 The subscriber MUST reset the stream if it receives an ANNOUNCE_END or ANNOUNCE_RESTART referencing an Announce ID that was never assigned or already retired, an ANNOUNCE_START for a path that is already available, or any announcement before ANNOUNCE_OK.
 When the stream is closed, the subscriber MUST assume that all broadcasts are now unavailable.
@@ -590,15 +591,17 @@ The parameter-specific value, interpreted according to Parameter ID.
 A capability is available for the session only if the relevant endpoint advertises it; an absent parameter means the sender does not support that capability.
 The following Setup Parameters are defined:
 
-|------|----------|-------------|
-|  ID  | Name     | Value       |
-|-----:|:---------|:------------|
-| 0x1  | Probe    | Level (i)   |
-|------|----------|-------------|
-| 0x2  | Path     | Path (s)    |
-|------|----------|-------------|
-| 0x3  | Role     | Role (i)    |
-|------|----------|-------------|
+|------|-----------|-------------|
+|  ID  | Name      | Value       |
+|-----:|:----------|:------------|
+| 0x1  | Probe     | Level (i)   |
+|------|-----------|-------------|
+| 0x2  | Path      | Path (s)    |
+|------|-----------|-------------|
+| 0x3  | Role      | Role (i)    |
+|------|-----------|-------------|
+| 0x4  | Link Cost | Cost (i)    |
+|------|-----------|-------------|
 
 ### Probe Parameter {#probe-parameter}
 The Probe Parameter advertises the sender's capability level when acting as a publisher on a [Probe Stream](#probe).
@@ -651,6 +654,18 @@ A receiver that does not recognize the value MUST treat it as `Both`, so a newer
 The Role Parameter is a hint that only ever narrows the session: a server MUST still enforce the client's authorization on every publish and subscribe regardless of the advertised role, and MUST NOT grant a direction the authorization does not already allow. A server MAY close a session when the advertised role requires a direction the client's authorization does not grant: `Publisher` without publish authorization, or `Subscriber` without subscribe authorization.
 
 Like the [Path Parameter](#path-parameter), the Role Parameter is meaningful only from client to server. A server MUST NOT send a Role Parameter; a client that receives one MUST close the session with a PROTOCOL_VIOLATION. A relay MUST NOT forward it; it applies only to this hop.
+
+### Link Cost Parameter {#link-cost-parameter}
+The Link Cost Parameter declares the routing cost of this connection: each endpoint adds the value to the Route Cost of every announcement it receives over the connection before forwarding or acting on it (see [ANNOUNCE_START](#announce-start)).
+
+The Parameter Value is a variable-length integer in deployment-chosen units, the same units as the Route Cost.
+An absent parameter means the default cost of 1, under which the accumulated Route Cost equals the hop count and routing degenerates to shortest-path, matching the behavior of versions that predate the parameter.
+A deployment prices links to reflect its economics: 0 for a link within a datacenter (making a warm sibling effectively free to reach), larger values for metered or long-haul links.
+A value of 0 is meaningful and distinct from omitting the parameter.
+
+Only the client sends it: the price lives in the dialing side's configuration, and the server reads it from the client's SETUP so both ends charge the same link the same amount.
+A server MUST NOT send a Link Cost Parameter.
+Like the [Path Parameter](#path-parameter), it is per-hop setup metadata: a relay MUST NOT forward it.
 
 
 ## ANNOUNCE_REQUEST {#announce-request}
@@ -718,6 +733,7 @@ ANNOUNCE_START Message {
   Broadcast Path Suffix (s),
   Hop Count (i),
   Hop ID (i) ...,
+  Route Cost (i),
 }
 ~~~
 
@@ -739,6 +755,19 @@ When forwarding an announcement received from an upstream peer, a relay MUST app
 The total path length is `Hop Count + 1` (including the implicit ANNOUNCE_OK `Hop ID`).
 The first entry of the reconstructed path (the first Hop ID, or the ANNOUNCE_OK `Hop ID` when the list is empty) identifies the original publisher of the broadcast; ANNOUNCE_RESTART uses it to distinguish a route change from a replacement (see [ANNOUNCE_RESTART](#announce-restart)).
 A Hop ID value of 0 means the hop is unknown: either it was never assigned (e.g. when bridging from an older protocol version) or a relay deliberately withholds it to obscure the underlying routing; the Hop Count still reflects the total number of entries including unknown hops.
+
+**Route Cost**:
+The marginal cost of subscribing to the broadcast via this advertisement, in units chosen by the deployment.
+The original publisher seeds the value with its production cost: 0 for content it is already producing, larger for content it would have to start producing on demand (e.g. a standby transcoder that advertises every broadcast it could serve, at a cost reflecting the work of actually serving it).
+When forwarding an announcement received from an upstream peer, a relay adds the cost of the link the announcement arrived on (see [Link Cost Parameter](#link-cost-parameter)), saturating rather than wrapping so an absurd upstream value ranks last instead of overflowing to best.
+
+A relay that is actively carrying the broadcast (a live subscription exists for at least one of its tracks) SHOULD advertise 0 instead of the accumulated value: its ingress is already paid for, so the marginal cost of one more subscriber is only the links between them, which downstream receivers add themselves.
+This is what lets a cluster deduplicate: a subscriber that sees both a warm copy at cost 0 and the original at the full path cost pulls the copy that already exists.
+When the relay stops carrying the broadcast it SHOULD restore the accumulated value via ANNOUNCE_RESTART, optionally after a grace period so brief subscriber churn does not flap routing across the mesh.
+
+Two relays that independently begin carrying the same broadcast will each see the other's zero-cost advertisement as cheaper than their own source, and switching simultaneously would leave the broadcast with no source at all.
+An actively-carrying relay SHOULD therefore apply a deterministic tie-break before re-parenting onto a strictly cheaper advertisement, such as comparing a stable hash of the broadcast path and each endpoint's Hop ID, so that exactly one side moves.
+Hop-based loop detection (dropping any advertisement whose reconstructed path contains the receiver's own Hop ID) remains the authority on loop freedom; the tie-break only prevents the transient double-switch.
 
 
 ## ANNOUNCE_END {#announce-end}
@@ -784,6 +813,7 @@ ANNOUNCE_RESTART Message {
   Announce ID (i),
   Hop Count (i),
   Hop ID (i) ...,
+  Route Cost (i),
 }
 ~~~
 
@@ -794,8 +824,9 @@ Set to 0x2 to indicate an ANNOUNCE_RESTART message.
 The ordinal implicitly assigned by a prior ANNOUNCE_START on this stream.
 Referencing an id that was never assigned, or one already retired by an ANNOUNCE_END, is a protocol violation.
 
-**Hop Count** and **Hop ID**:
+**Hop Count**, **Hop ID**, and **Route Cost**:
 As defined for [ANNOUNCE_START](#announce-start).
+A restart whose only change is the Route Cost is valid: it is how a relay advertises that it started or stopped actively carrying the broadcast.
 
 
 ## SUBSCRIBE

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -600,7 +600,7 @@ The following Setup Parameters are defined:
 |------|-----------|-------------|
 | 0x3  | Role      | Role (i)    |
 |------|-----------|-------------|
-| 0x4  | Link Cost | Cost (i)    |
+| 0x4  | Cost      | Cost (i)    |
 |------|-----------|-------------|
 
 ### Probe Parameter {#probe-parameter}
@@ -655,8 +655,8 @@ The Role Parameter is a hint that only ever narrows the session: a server MUST s
 
 Like the [Path Parameter](#path-parameter), the Role Parameter is meaningful only from client to server. A server MUST NOT send a Role Parameter; a client that receives one MUST close the session with a PROTOCOL_VIOLATION. A relay MUST NOT forward it; it applies only to this hop.
 
-### Link Cost Parameter {#link-cost-parameter}
-The Link Cost Parameter declares the routing cost of this connection: each endpoint adds the value to the Route Cost of every announcement it receives over the connection before forwarding or acting on it (see [ANNOUNCE_START](#announce-start)).
+### Cost Parameter {#cost-parameter}
+The Cost Parameter declares the routing cost of this connection: each endpoint adds the value to the Route Cost of every announcement it receives over the connection before forwarding or acting on it (see [ANNOUNCE_START](#announce-start)).
 
 The Parameter Value is a variable-length integer in deployment-chosen units, the same units as the Route Cost.
 An absent parameter means the default cost of 1, under which the accumulated Route Cost equals the hop count and routing degenerates to shortest-path, matching the behavior of versions that predate the parameter.
@@ -664,7 +664,7 @@ A deployment prices links to reflect its economics: 0 for a link within a datace
 A value of 0 is meaningful and distinct from omitting the parameter.
 
 Only the client sends it: the price lives in the dialing side's configuration, and the server reads it from the client's SETUP so both ends charge the same link the same amount.
-A server MUST NOT send a Link Cost Parameter.
+A server MUST NOT send a Cost Parameter.
 Like the [Path Parameter](#path-parameter), it is per-hop setup metadata: a relay MUST NOT forward it.
 
 
@@ -759,14 +759,15 @@ A Hop ID value of 0 means the hop is unknown: either it was never assigned (e.g.
 **Route Cost**:
 The marginal cost of subscribing to the broadcast via this advertisement, in units chosen by the deployment.
 The original publisher seeds the value with its production cost: 0 for content it is already producing, larger for content it would have to start producing on demand (e.g. a standby transcoder that advertises every broadcast it could serve, at a cost reflecting the work of actually serving it).
-When forwarding an announcement received from an upstream peer, a relay adds the cost of the link the announcement arrived on (see [Link Cost Parameter](#link-cost-parameter)), saturating rather than wrapping so an absurd upstream value ranks last instead of overflowing to best.
+When forwarding an announcement received from an upstream peer, a relay adds the cost of the link the announcement arrived on (see [Cost Parameter](#cost-parameter)), saturating rather than wrapping so an absurd upstream value ranks last instead of overflowing to best.
 
 A relay that is actively carrying the broadcast (a live subscription exists for at least one of its tracks) SHOULD advertise 0 instead of the accumulated value: its ingress is already paid for, so the marginal cost of one more subscriber is only the links between them, which downstream receivers add themselves.
 This is what lets a cluster deduplicate: a subscriber that sees both a warm copy at cost 0 and the original at the full path cost pulls the copy that already exists.
 When the relay stops carrying the broadcast it SHOULD restore the accumulated value via ANNOUNCE_RESTART, optionally after a grace period so brief subscriber churn does not flap routing across the mesh.
 
 Two relays that independently begin carrying the same broadcast will each see the other's zero-cost advertisement as cheaper than their own source, and switching simultaneously would leave the broadcast with no source at all.
-An actively-carrying relay SHOULD therefore apply a deterministic tie-break before re-parenting onto a strictly cheaper advertisement, such as comparing a stable hash of the broadcast path and each endpoint's Hop ID, so that exactly one side moves.
+An actively-carrying relay SHOULD therefore apply a deterministic tie-break before re-parenting onto a strictly cheaper advertisement from another actively-carrying relay (one that advertised a Route Cost of 0 from a path of two or more hops; a single-hop path is the original publisher, which can never adopt a route to its own broadcast), such as comparing a stable hash of the broadcast path and each endpoint's Hop ID, so that exactly one side moves.
+Cheaper advertisements from anything else, e.g. a forwarding relay or a repriced upstream, carry no such hazard and SHOULD be adopted immediately.
 Hop-based loop detection (dropping any advertisement whose reconstructed path contains the receiver's own Hop ID) remains the authority on loop freedom; the tie-break only prevents the transient double-switch.
 
 
@@ -1166,6 +1167,8 @@ The `Message Length` describes the payload size on the wire.
 - ANNOUNCE_END and ANNOUNCE_RESTART reference the Announce ID instead of repeating the broadcast path.
 - Replaced the duplicate-`active` restart idiom with ANNOUNCE_RESTART; a second ANNOUNCE_START for an already-available path is now a protocol violation.
 - Defined the first entry of the reconstructed path as the original publisher's identity: a restart that preserves it is a route change (TRACK_INFO stays valid, subscriptions may resume), one that changes it replaces the broadcast (TRACK_INFO discarded, nothing resumes).
+- Added a `Route Cost` field to ANNOUNCE_START and ANNOUNCE_RESTART: the accumulated cost of the transfers a subscription via this advertisement would newly cause. Route selection prefers the lowest cost, with path length as the tie-break.
+- Added a SETUP `Cost` parameter (0x4) declaring the price a link adds to every announcement crossing it; unpriced links default to 1, degrading to shortest-path routing.
 
 ## moq-lite-05
 - Renamed ANNOUNCE_INTEREST to ANNOUNCE_REQUEST and ANNOUNCE to ANNOUNCE_BROADCAST.

--- a/js/net/src/lite/announce.test.ts
+++ b/js/net/src/lite/announce.test.ts
@@ -43,14 +43,31 @@ test("AnnounceBroadcast round-trips on draft-05", async () => {
 
 test("AnnounceBroadcast round-trips on draft-06", async () => {
 	const hops = [OriginSchema.parse(7n)];
+	// An absent cost encodes as zero and decodes explicitly.
 	const gotActive = await roundTrip({ status: "active", suffix: Path.from("room/cam"), hops }, Version.DRAFT_06);
-	expect(gotActive).toEqual({ status: "active", suffix: Path.from("room/cam"), hops });
+	expect(gotActive).toEqual({ status: "active", suffix: Path.from("room/cam"), hops, cost: 0n });
+
+	const gotCost = await roundTrip(
+		{ status: "active", suffix: Path.from("room/cam"), hops, cost: 12n },
+		Version.DRAFT_06,
+	);
+	expect(gotCost).toEqual({ status: "active", suffix: Path.from("room/cam"), hops, cost: 12n });
 
 	const gotEnded = await roundTrip({ status: "endedId", id: 3n }, Version.DRAFT_06);
 	expect(gotEnded).toEqual({ status: "endedId", id: 3n });
 
-	const gotRestart = await roundTrip({ status: "restart", id: 3n, hops }, Version.DRAFT_06);
-	expect(gotRestart).toEqual({ status: "restart", id: 3n, hops });
+	const gotRestart = await roundTrip({ status: "restart", id: 3n, hops, cost: 12n }, Version.DRAFT_06);
+	expect(gotRestart).toEqual({ status: "restart", id: 3n, hops, cost: 12n });
+});
+
+test("AnnounceBroadcast drops the route cost before draft-06", async () => {
+	// Pre-lite-06 has no room for a cost on the wire, so one set locally is
+	// simply not sent, keeping mixed-version meshes ranking on hop count.
+	const got = await roundTrip(
+		{ status: "active", suffix: Path.from("room/cam"), hops: [], cost: 9n },
+		Version.DRAFT_05,
+	);
+	expect(got).toEqual({ status: "active", suffix: Path.from("room/cam"), hops: [] });
 });
 
 test("AnnounceBroadcast rejects cross-version forms", async () => {

--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -2,7 +2,7 @@ import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
 import * as Message from "./message.ts";
 import { type Origin, OriginSchema } from "./origin.ts";
-import { hasAnnounceId, hasAnnounceOk, Version } from "./version.ts";
+import { hasAnnounceId, hasAnnounceOk, hasRouteCost, Version } from "./version.ts";
 
 // Must match the MAX_HOPS in Rust's model/origin.rs. Broadcasts with longer
 // hop chains are rejected; this keeps loop-detection bounded and rejects
@@ -32,16 +32,17 @@ const ANNOUNCE_RESTART = 2;
  * message that retracts by path (`ended`).
  */
 export type AnnounceBroadcast =
-	/** A broadcast is now available, carrying the path suffix and the hop chain. */
-	| { status: "active"; suffix: Path.Valid; hops: Origin[] }
+	/** A broadcast is now available, carrying the path suffix, the hop chain, and
+	 * (lite-06+) the route cost. An absent cost encodes as zero. */
+	| { status: "active"; suffix: Path.Valid; hops: Origin[]; cost?: bigint }
 	/** Pre-lite-06: a broadcast is no longer available, retracted by path. */
 	| { status: "ended"; suffix: Path.Valid }
 	/** Lite06+: a broadcast is no longer available, retracted by announce id.
 	 * The id is retired; referencing it again is a protocol violation. */
 	| { status: "endedId"; id: bigint }
 	/** Lite06+: atomically replace the announcement with this id (e.g. a new hop
-	 * chain after a relay failover). The id stays live. */
-	| { status: "restart"; id: bigint; hops: Origin[] };
+	 * chain after a relay failover, or a route whose cost moved). The id stays live. */
+	| { status: "restart"; id: bigint; hops: Origin[]; cost?: bigint };
 
 function checkHops(hops: Origin[]) {
 	if (hops.length > MAX_HOPS) {
@@ -94,12 +95,25 @@ async function decodeHops(r: Reader, version: Version): Promise<Origin[]> {
 	}
 }
 
+// The route cost rides lite-06+ announcements as a single varint; older
+// versions carry nothing and decode as zero.
+async function encodeRouteCost(w: Writer, version: Version, cost: bigint | undefined) {
+	if (!hasRouteCost(version)) return;
+	await w.u62(cost ?? 0n);
+}
+
+async function decodeRouteCost(r: Reader, version: Version): Promise<bigint> {
+	if (!hasRouteCost(version)) return 0n;
+	return await r.u62();
+}
+
 // lite-06 message body (no discriminator; the type is carried outside the length prefix).
 async function encodeAnnounce06Body(w: Writer, msg: AnnounceBroadcast, version: Version) {
 	switch (msg.status) {
 		case "active":
 			await w.string(Path.encode(msg.suffix));
 			await encodeHops(w, version, msg.hops);
+			await encodeRouteCost(w, version, msg.cost);
 			break;
 		case "endedId":
 			await w.u62(msg.id);
@@ -107,6 +121,7 @@ async function encodeAnnounce06Body(w: Writer, msg: AnnounceBroadcast, version: 
 		case "restart":
 			await w.u62(msg.id);
 			await encodeHops(w, version, msg.hops);
+			await encodeRouteCost(w, version, msg.cost);
 			break;
 		case "ended":
 			// The pre-lite-06 path-form retraction has no place on lite-06.
@@ -130,12 +145,18 @@ function announce06Type(msg: AnnounceBroadcast): number {
 
 async function decodeAnnounce06Body(r: Reader, typ: number, version: Version): Promise<AnnounceBroadcast> {
 	switch (typ) {
-		case ANNOUNCE_START:
-			return { status: "active", suffix: Path.decode(await r.string()), hops: await decodeHops(r, version) };
+		case ANNOUNCE_START: {
+			const suffix = Path.decode(await r.string());
+			const hops = await decodeHops(r, version);
+			return { status: "active", suffix, hops, cost: await decodeRouteCost(r, version) };
+		}
 		case ANNOUNCE_END:
 			return { status: "endedId", id: await r.u62() };
-		case ANNOUNCE_RESTART:
-			return { status: "restart", id: await r.u62(), hops: await decodeHops(r, version) };
+		case ANNOUNCE_RESTART: {
+			const id = await r.u62();
+			const hops = await decodeHops(r, version);
+			return { status: "restart", id, hops, cost: await decodeRouteCost(r, version) };
+		}
 		default:
 			throw new Error(`unknown announce message type: ${typ}`);
 	}

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -74,6 +74,24 @@ export function hasAnnounceId(version: Version): boolean {
 	}
 }
 
+/** Whether announcements carry a route cost varint alongside the hop chain: the
+ * marginal cost of pulling the broadcast via this route, accumulated per link.
+ * Added in lite-06. Older versions carry nothing, so a received route stays at
+ * zero and routing falls back to the hop-count tie-break. */
+export function hasRouteCost(version: Version): boolean {
+	// Explicitly list older versions so future versions keep the lite-06+ behavior.
+	switch (version) {
+		case Version.DRAFT_01:
+		case Version.DRAFT_02:
+		case Version.DRAFT_03:
+		case Version.DRAFT_04:
+		case Version.DRAFT_05:
+			return false;
+		default:
+			return true;
+	}
+}
+
 /// The WebTransport subprotocol identifier for moq-lite.
 /// Version negotiation still happens via SETUP when this is used.
 export const ALPN = "moql";

--- a/rs/kio/src/producer.rs
+++ b/rs/kio/src/producer.rs
@@ -194,6 +194,14 @@ impl<T> Producer<T> {
 		Poll::Pending
 	}
 
+	/// Whether any consumer handle currently exists.
+	///
+	/// A point-in-time snapshot with no registration; use [`Self::poll_used`] /
+	/// [`Self::poll_unused`] to wait for the edge instead.
+	pub fn is_used(&self) -> bool {
+		self.counts.consumers.load(Ordering::Relaxed) > 0
+	}
+
 	/// Wait until at least one consumer exists.
 	///
 	/// Returns `Ok(())` when a consumer is created, or [`Closed`] if the channel closes first.

--- a/rs/kio/src/weak.rs
+++ b/rs/kio/src/weak.rs
@@ -121,6 +121,14 @@ impl<T> ProducerWeak<T> {
 		Poll::Pending
 	}
 
+	/// Whether any consumer handle currently exists.
+	///
+	/// A point-in-time snapshot with no registration; use [`Self::poll_used`] /
+	/// [`Self::poll_unused`] to wait for the edge instead.
+	pub fn is_used(&self) -> bool {
+		self.counts.consumers.load(Ordering::Relaxed) > 0
+	}
+
 	/// Wait until at least one consumer exists.
 	///
 	/// Returns `Ok(())` when a consumer is created, or [`Closed`] if the channel closes first.

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -254,6 +254,12 @@ impl Client {
 		self
 	}
 
+	/// Price the links this client dials; see [`moq_net::Client::with_link_cost`].
+	pub fn with_link_cost(mut self, cost: u64) -> Self {
+		self.moq = self.moq.with_link_cost(cost);
+		self
+	}
+
 	/// Start a background reconnect loop that connects to the given URL,
 	/// waits for the session to close, then reconnects with exponential backoff.
 	///

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -254,9 +254,9 @@ impl Client {
 		self
 	}
 
-	/// Price the links this client dials; see [`moq_net::Client::with_link_cost`].
-	pub fn with_link_cost(mut self, cost: u64) -> Self {
-		self.moq = self.moq.with_link_cost(cost);
+	/// Price the links this client dials; see [`moq_net::Client::with_cost`].
+	pub fn with_cost(mut self, cost: u64) -> Self {
+		self.moq = self.moq.with_cost(cost);
 		self
 	}
 

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -14,7 +14,7 @@ pub struct Client {
 	stats: stats::Handle,
 	versions: Versions,
 	setup_path: Option<String>,
-	link_cost: Option<u64>,
+	cost: Option<u64>,
 }
 
 impl Client {
@@ -89,14 +89,14 @@ impl Client {
 	/// Every announcement crossing the connection adds this to its route cost, so
 	/// routing prefers cheap paths over short ones. Use `0` for a link that should
 	/// look free (a sibling in the same datacenter), and something large for one that
-	/// should be a last resort (a metered backbone). Defaults to
-	/// [`lite::DEFAULT_LINK_COST`], which makes the cost track the hop count and so
-	/// reproduces plain shortest-path routing.
+	/// should be a last resort (a metered backbone). An unpriced link costs `1`,
+	/// which makes the cost track the hop count and so reproduces plain
+	/// shortest-path routing.
 	///
 	/// The dialing side owns the price: it is declared in our SETUP so the server
 	/// charges the same link the same amount. A server never sets one.
-	pub fn with_link_cost(mut self, cost: u64) -> Self {
-		self.link_cost = Some(cost);
+	pub fn with_cost(mut self, cost: u64) -> Self {
+		self.cost = Some(cost);
 		self
 	}
 
@@ -218,7 +218,7 @@ impl Client {
 					probe: lite::ProbeLevel::Report,
 					path: self.setup_path.clone(),
 					role: lite::Role::from_origins(self.publish.is_some(), self.subscribe.is_some()),
-					link_cost: self.link_cost,
+					cost: self.cost,
 				};
 
 				let start = lite::start(

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -14,6 +14,7 @@ pub struct Client {
 	stats: stats::Handle,
 	versions: Versions,
 	setup_path: Option<String>,
+	link_cost: Option<u64>,
 }
 
 impl Client {
@@ -80,6 +81,22 @@ impl Client {
 	/// versions with no in-band request path (lite 01-04).
 	pub fn with_path(mut self, path: impl Into<String>) -> Self {
 		self.setup_path = Some(path.into());
+		self
+	}
+
+	/// Price this link, in the units the rest of the mesh uses (moq-lite-06+).
+	///
+	/// Every announcement crossing the connection adds this to its route cost, so
+	/// routing prefers cheap paths over short ones. Use `0` for a link that should
+	/// look free (a sibling in the same datacenter), and something large for one that
+	/// should be a last resort (a metered backbone). Defaults to
+	/// [`lite::DEFAULT_LINK_COST`], which makes the cost track the hop count and so
+	/// reproduces plain shortest-path routing.
+	///
+	/// The dialing side owns the price: it is declared in our SETUP so the server
+	/// charges the same link the same amount. A server never sets one.
+	pub fn with_link_cost(mut self, cost: u64) -> Self {
+		self.link_cost = Some(cost);
 		self
 	}
 
@@ -201,6 +218,7 @@ impl Client {
 					probe: lite::ProbeLevel::Report,
 					path: self.setup_path.clone(),
 					role: lite::Role::from_origins(self.publish.is_some(), self.subscribe.is_some()),
+					link_cost: self.link_cost,
 				};
 
 				let start = lite::start(

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -37,18 +37,66 @@ pub fn restart_supported(version: Version) -> bool {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum AnnounceBroadcast<'a> {
 	/// ANNOUNCE_START (lite-06) / active (older): a broadcast is now available.
-	/// Carries the path suffix and the hop chain, and assigns the next announce id.
-	Active { suffix: Path<'a>, hops: OriginList },
+	/// Carries the path suffix, the hop chain, and (lite-06+) the route cost, and
+	/// assigns the next announce id.
+	Active {
+		suffix: Path<'a>,
+		hops: OriginList,
+		cost: RouteCost,
+	},
 	/// Pre-lite-06: a broadcast is no longer available, retracted by path.
 	Ended { suffix: Path<'a>, hops: OriginList },
 	/// ANNOUNCE_END (lite-06+): a broadcast is no longer available, retracted by
 	/// announce id. The id is retired; referencing it again is a protocol violation.
 	EndedId { id: u64 },
 	/// ANNOUNCE_RESTART (lite-06+): atomically replace the announcement with this id
-	/// (e.g. a new hop chain after a relay failover). The id stays live.
+	/// (e.g. a new hop chain after a relay failover, or a route whose cost moved).
+	/// The id stays live.
 	///
 	/// Only ever received: we advertise a replacement as an `EndedId` + `Active` pair.
-	Restart { id: u64, hops: OriginList },
+	Restart { id: u64, hops: OriginList, cost: RouteCost },
+}
+
+/// The marginal cost of pulling the broadcast via this route, carried on lite-06
+/// announcements as a single varint.
+///
+/// The original publisher seeds it with its production cost: zero for a live
+/// publish, something large for a standby that would have to start working (a
+/// cold transcoder). Each link adds its own price when the announcement crosses
+/// it, and a node actively carrying the broadcast re-announces zero instead: its
+/// ingress is already paid for, so a peer should pull the copy that exists rather
+/// than open a second one all the way back. The sum is what routing minimizes:
+/// what one more subscription would actually cost the mesh.
+///
+/// Pre-lite-06 peers don't carry it, so it stays zero and routing falls back to
+/// the hop-count tie-break.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RouteCost(pub u64);
+
+impl RouteCost {
+	/// Add a link's price, saturating so a hostile or buggy peer advertising a
+	/// huge cost sorts last instead of wrapping around to best.
+	pub fn charged(self, link_cost: u64) -> Self {
+		Self(self.0.saturating_add(link_cost))
+	}
+}
+
+impl Encode<Version> for RouteCost {
+	fn encode<W: BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		if !version.has_route_cost() {
+			return Ok(());
+		}
+		self.0.encode(w, version)
+	}
+}
+
+impl Decode<Version> for RouteCost {
+	fn decode<B: Buf>(buf: &mut B, version: Version) -> Result<Self, DecodeError> {
+		if !version.has_route_cost() {
+			return Ok(Self::default());
+		}
+		Ok(Self(u64::decode(buf, version)?))
+	}
 }
 
 impl Encode<Version> for AnnounceBroadcast<'_> {
@@ -59,18 +107,20 @@ impl Encode<Version> for AnnounceBroadcast<'_> {
 			// infrequent, so the scratch buffer is cheap.
 			let mut body = Vec::new();
 			let typ = match self {
-				Self::Active { suffix, hops } => {
+				Self::Active { suffix, hops, cost } => {
 					suffix.encode(&mut body, version)?;
 					hops.encode(&mut body, version)?;
+					cost.encode(&mut body, version)?;
 					ANNOUNCE_START
 				}
 				Self::EndedId { id } => {
 					id.encode(&mut body, version)?;
 					ANNOUNCE_END
 				}
-				Self::Restart { id, hops } => {
+				Self::Restart { id, hops, cost } => {
 					id.encode(&mut body, version)?;
 					hops.encode(&mut body, version)?;
+					cost.encode(&mut body, version)?;
 					ANNOUNCE_RESTART
 				}
 				// The pre-lite-06 path-form retraction has no place on lite-06.
@@ -86,7 +136,8 @@ impl Encode<Version> for AnnounceBroadcast<'_> {
 		// status carried inside the body.
 		let mut body = Vec::new();
 		match self {
-			Self::Active { suffix, hops } => {
+			// The cost is a lite-06 addition, so it is simply not on the wire here.
+			Self::Active { suffix, hops, .. } => {
 				AnnounceStatus::Active.encode(&mut body, version)?;
 				suffix.encode(&mut body, version)?;
 				encode_hops(&mut body, version, hops)?;
@@ -119,6 +170,7 @@ impl Decode<Version> for AnnounceBroadcast<'_> {
 				ANNOUNCE_START => Self::Active {
 					suffix: Path::decode(&mut body, version)?,
 					hops: OriginList::decode(&mut body, version)?,
+					cost: RouteCost::decode(&mut body, version)?,
 				},
 				ANNOUNCE_END => Self::EndedId {
 					id: u64::decode(&mut body, version)?,
@@ -126,6 +178,7 @@ impl Decode<Version> for AnnounceBroadcast<'_> {
 				ANNOUNCE_RESTART => Self::Restart {
 					id: u64::decode(&mut body, version)?,
 					hops: OriginList::decode(&mut body, version)?,
+					cost: RouteCost::decode(&mut body, version)?,
 				},
 				_ => return Err(DecodeError::InvalidMessage(typ)),
 			};
@@ -171,14 +224,22 @@ impl AnnounceBroadcast<'_> {
 		};
 
 		Ok(match status {
-			AnnounceStatus::Active => Self::Active { suffix, hops },
+			AnnounceStatus::Active => Self::Active {
+				suffix,
+				hops,
+				cost: RouteCost::default(),
+			},
 			AnnounceStatus::Ended => Self::Ended { suffix, hops },
 			// On lite-05 a restart travels as a duplicate ANNOUNCE (a second `Active`), so accept
 			// the draft's explicit `restart` status and treat it the same. Either way the
 			// subscriber retires an already-announced path before republishing it; for an unknown
 			// path it's a fresh announce. Older versions never defined this status, so it's an
 			// invalid value there.
-			AnnounceStatus::Restart if restart_supported(version) => Self::Active { suffix, hops },
+			AnnounceStatus::Restart if restart_supported(version) => Self::Active {
+				suffix,
+				hops,
+				cost: RouteCost::default(),
+			},
 			AnnounceStatus::Restart => return Err(DecodeError::InvalidValue),
 		})
 	}
@@ -343,6 +404,7 @@ mod tests {
 		AnnounceBroadcast::Active {
 			suffix: Path::new("foo/bar"),
 			hops: OriginList::new(),
+			cost: RouteCost::default(),
 		}
 		.encode(&mut buf, version)
 		.expect("encode");
@@ -421,16 +483,17 @@ mod tests {
 		assert!(slice.is_empty(), "trailing bytes after decode");
 		// Decode borrows from `buf`; re-own so the value can outlive this frame.
 		match got {
-			AnnounceBroadcast::Active { suffix, hops } => AnnounceBroadcast::Active {
+			AnnounceBroadcast::Active { suffix, hops, cost } => AnnounceBroadcast::Active {
 				suffix: suffix.to_owned(),
 				hops,
+				cost,
 			},
 			AnnounceBroadcast::Ended { suffix, hops } => AnnounceBroadcast::Ended {
 				suffix: suffix.to_owned(),
 				hops,
 			},
 			AnnounceBroadcast::EndedId { id } => AnnounceBroadcast::EndedId { id },
-			AnnounceBroadcast::Restart { id, hops } => AnnounceBroadcast::Restart { id, hops },
+			AnnounceBroadcast::Restart { id, hops, cost } => AnnounceBroadcast::Restart { id, hops, cost },
 		}
 	}
 
@@ -441,6 +504,7 @@ mod tests {
 		let msg = AnnounceBroadcast::Active {
 			suffix: Path::new("room/cam"),
 			hops: hops.clone(),
+			cost: RouteCost::default(),
 		};
 		assert_eq!(broadcast_round_trip(&msg, Version::Lite05), msg);
 
@@ -456,16 +520,19 @@ mod tests {
 		let mut hops = OriginList::new();
 		hops.push(Origin::new(7).unwrap()).unwrap();
 
+		let cost = RouteCost(12);
+
 		let active = AnnounceBroadcast::Active {
 			suffix: Path::new("room/cam"),
 			hops: hops.clone(),
+			cost,
 		};
 		assert_eq!(broadcast_round_trip(&active, Version::Lite06Wip), active);
 
 		let ended = AnnounceBroadcast::EndedId { id: 3 };
 		assert_eq!(broadcast_round_trip(&ended, Version::Lite06Wip), ended);
 
-		let restart = AnnounceBroadcast::Restart { id: 3, hops };
+		let restart = AnnounceBroadcast::Restart { id: 3, hops, cost };
 		assert_eq!(broadcast_round_trip(&restart, Version::Lite06Wip), restart);
 	}
 
@@ -480,7 +547,8 @@ mod tests {
 		assert!(matches!(
 			AnnounceBroadcast::Restart {
 				id: 1,
-				hops: OriginList::new()
+				hops: OriginList::new(),
+				cost: RouteCost::default()
 			}
 			.encode(&mut buf, Version::Lite05),
 			Err(EncodeError::Version)
@@ -493,6 +561,35 @@ mod tests {
 			.encode(&mut buf, Version::Lite06Wip),
 			Err(EncodeError::Version)
 		));
+	}
+
+	// Pre-lite-06 has no room for a cost on the wire, so one set locally is simply
+	// not sent and the peer decodes the default. This is what keeps a mixed-version
+	// mesh ranking those routes on hop count exactly as it did before.
+	#[test]
+	fn route_cost_is_dropped_before_lite06() {
+		let msg = AnnounceBroadcast::Active {
+			suffix: Path::new("room/cam"),
+			hops: OriginList::new(),
+			cost: RouteCost(9),
+		};
+		let got = broadcast_round_trip(&msg, Version::Lite05);
+		assert_eq!(
+			got,
+			AnnounceBroadcast::Active {
+				suffix: Path::new("room/cam"),
+				hops: OriginList::new(),
+				cost: RouteCost::default(),
+			}
+		);
+	}
+
+	// Charging a link accumulates, saturating rather than wrapping so a bogus peer
+	// sorts last, not first.
+	#[test]
+	fn route_cost_charge_saturates() {
+		assert_eq!(RouteCost(4).charged(5), RouteCost(9));
+		assert_eq!(RouteCost(u64::MAX).charged(10), RouteCost(u64::MAX));
 	}
 
 	// An ANNOUNCE_END message on lite-06 is tiny: type byte, size prefix, id varint.

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -22,8 +22,16 @@ use super::Version;
 /// `None` while the announce is filtered (reflected or excluded).
 struct WatchedRoute {
 	consumer: crate::broadcast::Consumer,
+	/// Demand edges re-price the route without a route change, so the announce
+	/// loop watches this alongside `route_changed`.
+	demand: crate::broadcast::Demand,
 	path: crate::PathOwned,
 	sent: Option<SentRoute>,
+	/// When demand drained while a zero cost was advertised. The restart that
+	/// restores the cold cost is deferred by [`COST_LINGER`] past this, so
+	/// viewer churn doesn't flap routing across the mesh; demand returning in
+	/// the window cancels the restore.
+	idle_at: Option<web_async::time::Instant>,
 }
 
 /// What the peer currently holds for a path: the forwarded hop chain plus, on
@@ -310,15 +318,18 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						Some(broadcast) => {
 							let route = broadcast.route();
 							let hops = route.hops.clone();
-							let cost = Self::outgoing_cost(version, &broadcast, &route);
+							let demand = broadcast.demand();
+							let cost = Self::outgoing_cost(version, &demand, &route);
 							// Watch even the announces we filter below: a later route update
 							// can cross the forwarding filter in either direction.
 							watched.insert(
 								suffix.clone(),
 								WatchedRoute {
 									consumer: broadcast.clone(),
+									demand,
 									path: path.clone(),
 									sent: None,
+									idle_at: None,
 								},
 							);
 							// Apply the same exclude_hop and reflected-announce skips as the live
@@ -385,39 +396,48 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		}
 
 		// One announce-loop turn: either an (un)announce from the origin, a route
-		// change on an already-announced broadcast, or the periodic cost recheck.
-		// Resolved outside the select so the handlers below can freely mutate the
-		// maps its futures borrow.
+		// change on an already-announced broadcast, or a demand edge re-pricing
+		// one. Resolved outside the select so the handlers below can freely
+		// mutate the maps its futures borrow.
 		enum Op {
 			Announce(Option<crate::announce::Update>),
 			Route(crate::PathOwned, Result<crate::broadcast::Route, Error>),
-			Recheck,
+			Idle(crate::PathOwned),
+			/// The linger sleep fired without an expired entry (it was canceled,
+			/// or a later deadline remains): restart the turn so the next
+			/// deadline arms a fresh sleep.
+			Linger,
 		}
 
-		// How often to re-evaluate the advertised cost of every watched broadcast.
-		// The cost depends on liveness (`is_active`), which is not part of the
-		// route: going active wakes this loop anyway (minting the track writes the
-		// broadcast state), but the last consumer dropping does not, so decay back
-		// to the cold cost rides this tick. The period is deliberately coarse: it
-		// doubles as hysteresis, keeping a briefly-idle broadcast advertising zero
-		// so viewer churn doesn't flap the mesh's routing.
-		const COST_RECHECK: Duration = Duration::from_secs(5);
-		let mut recheck = version
-			.has_route_cost()
-			.then(|| web_async::time::interval(COST_RECHECK));
+		// How long a drained broadcast keeps advertising zero before the restart
+		// that restores its cold cost. Pure hysteresis: demand edges arrive
+		// exactly (via `broadcast::Demand`), but re-pricing the instant the last
+		// viewer leaves would flap routing across the mesh on viewer churn.
+		const COST_LINGER: Duration = Duration::from_secs(5);
 
 		// Send updates as they arrive. Closure wins the race so a dead peer can't
 		// stall on a busy announce feed.
 		loop {
+			// The earliest deferred cost-restore, if any entry's linger is running.
+			let deadline = watched
+				.values()
+				.filter_map(|entry| entry.idle_at)
+				.min()
+				.map(|at| at + COST_LINGER);
 			let op = {
 				let mut closed = std::pin::pin!(stream.reader.closed());
-				// Pending forever when the version carries no cost on the wire.
-				let mut tick = std::pin::pin!(async {
-					match recheck.as_mut() {
-						Some(interval) => interval.tick().await,
+				// Pending forever while no linger is running. Fused via `fired`:
+				// a completed future must not be polled again, and once it fires
+				// the turn always ends in a `Ready` below.
+				let mut linger = std::pin::pin!(async move {
+					match deadline {
+						Some(at) => {
+							web_async::time::sleep(at.saturating_duration_since(web_async::time::Instant::now())).await
+						}
 						None => std::future::pending().await,
 					}
 				});
+				let mut fired: Option<web_async::time::Instant> = None;
 				kio::wait(|waiter| {
 					if let Poll::Ready(res) = waiter.poll_future(closed.as_mut()) {
 						return Poll::Ready(Err(res));
@@ -425,27 +445,53 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					if let Poll::Ready(next) = announced.poll_next(waiter) {
 						return Poll::Ready(Ok(Op::Announce(next)));
 					}
+					if fired.is_none() && waiter.poll_future(linger.as_mut()).is_ready() {
+						fired = Some(web_async::time::Instant::now());
+					}
 					// Poll every watched broadcast for a route change; each wake
 					// rescans the map, which announce-control rates make fine.
 					for (suffix, entry) in watched.iter_mut() {
 						if let Poll::Ready(res) = entry.consumer.poll_route_changed(waiter) {
 							return Poll::Ready(Ok(Op::Route(suffix.clone(), res)));
 						}
-						// The advertised cost drifts without a route change when
-						// liveness flips; reuse the route path to re-send it.
-						if version.has_route_cost()
-							&& let Some(sent) = &entry.sent
-						{
-							let route = entry.consumer.route();
-							if Self::outgoing_cost(version, &entry.consumer, &route) != sent.cost {
-								return Poll::Ready(Ok(Op::Route(suffix.clone(), Ok(route))));
+						// Demand edges re-price the route without a route change:
+						// watch the direction opposite the advertised cost. Closure
+						// is ignored here; the route watch above surfaces it.
+						if !version.has_route_cost() {
+							continue;
+						}
+						let Some(sent) = &entry.sent else { continue };
+						if sent.cost != lite::RouteCost(0) {
+							if let Poll::Ready(Ok(())) = entry.demand.poll_used(waiter) {
+								return Poll::Ready(Ok(Op::Route(suffix.clone(), Ok(entry.consumer.route()))));
 							}
+							continue;
+						}
+						match entry.idle_at {
+							// Demand coming back within the linger cancels the
+							// restore; fall through to re-arm the unused watch.
+							Some(_) if entry.demand.is_used() => entry.idle_at = None,
+							// The linger expired: re-price via the route path.
+							Some(at) if fired.is_some_and(|now| now >= at + COST_LINGER) => {
+								entry.idle_at = None;
+								return Poll::Ready(Ok(Op::Route(suffix.clone(), Ok(entry.consumer.route()))));
+							}
+							// Still lingering: the sleep owns the wakeup, and
+							// `poll_used` re-arms the cancel check above.
+							Some(_) => {
+								let _ = entry.demand.poll_used(waiter);
+								continue;
+							}
+							None => {}
+						}
+						if let Poll::Ready(Ok(())) = entry.demand.poll_unused(waiter) {
+							return Poll::Ready(Ok(Op::Idle(suffix.clone())));
 						}
 					}
-					if waiter.poll_future(tick.as_mut()).is_ready() {
-						return Poll::Ready(Ok(Op::Recheck));
+					match fired {
+						Some(_) => Poll::Ready(Ok(Op::Linger)),
+						None => Poll::Pending,
 					}
-					Poll::Pending
 				})
 				.await
 			};
@@ -469,6 +515,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					match broadcast {
 						Some(active) => {
 							let route = active.route();
+							let demand = active.demand();
 							if lite::restart_supported(version) {
 								// Watch even if filtered below: a route update can cross
 								// the forwarding filter in either direction.
@@ -476,8 +523,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 									suffix.clone(),
 									WatchedRoute {
 										consumer: active.clone(),
+										demand: demand.clone(),
 										path: path.clone(),
 										sent: None,
+										idle_at: None,
 									},
 								);
 							}
@@ -486,7 +535,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 							else {
 								continue;
 							};
-							let cost = Self::outgoing_cost(version, &active, &route);
+							let cost = Self::outgoing_cost(version, &demand, &route);
 							tracing::debug!(broadcast = %absolute, "announce");
 							let bs = stats.broadcast(&absolute);
 							// Count the broadcast name length, not the encoded message size, so
@@ -553,8 +602,11 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					let Some(entry) = watched.get_mut(&suffix) else {
 						continue;
 					};
+					// Any re-price supersedes a pending cost-restore; a stale
+					// timestamp would spin the linger sleep forever.
+					entry.idle_at = None;
 					let absolute = origin.absolute(&entry.path).to_owned();
-					let cost = Self::outgoing_cost(version, &entry.consumer, &route);
+					let cost = Self::outgoing_cost(version, &entry.demand, &route);
 					let hops = Self::prepare_active_hops(&route.hops, self_origin, exclude_hop, version, &absolute)
 						.map(|hops| SentRoute { hops, cost });
 					let sent = entry.sent.clone();
@@ -650,19 +702,26 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						(None, None) => {}
 					}
 				}
-				// The tick's only job is waking the loop: the next poll pass runs
-				// the cost drift scan and surfaces any change as `Op::Route`.
-				Op::Recheck => {}
+				// Demand drained while advertising zero: start the linger. The
+				// restore rides the deadline unless demand returns first.
+				Op::Idle(suffix) => {
+					if let Some(entry) = watched.get_mut(&suffix) {
+						entry.idle_at = Some(web_async::time::Instant::now());
+					}
+				}
+				// The linger sleep's job is done; the next turn arms the next
+				// deadline (or none).
+				Op::Linger => {}
 			}
 		}
 	}
 
 	/// The cost to advertise for a route, alongside its outgoing hop chain.
 	///
-	/// While we are actively carrying the broadcast the cost is zero: our ingress
-	/// is already paid for (or, for a local standby publisher, the work is already
-	/// running), so one more subscriber only pays the link to reach us. Otherwise
-	/// we forward the accumulated route cost unchanged, which for a standby
+	/// While the broadcast has demand the cost is zero: our ingress is already
+	/// paid for (or, for a local standby publisher, the work is already running),
+	/// so one more subscriber only pays the link to reach us. Otherwise we
+	/// forward the accumulated route cost unchanged, which for a standby
 	/// publisher is its production cost and for a pure forwarder is the price of
 	/// the fetch a subscription would trigger.
 	///
@@ -671,14 +730,14 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	/// on their wire), leaving hop count as the metric exactly as before.
 	fn outgoing_cost(
 		version: Version,
-		consumer: &crate::broadcast::Consumer,
+		demand: &crate::broadcast::Demand,
 		route: &crate::broadcast::Route,
 	) -> lite::RouteCost {
 		if !version.has_route_cost() {
 			return lite::RouteCost::default();
 		}
 
-		match consumer.is_active() {
+		match demand.is_used() {
 			true => lite::RouteCost(0),
 			false => lite::RouteCost(route.cost),
 		}

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -23,7 +23,16 @@ use super::Version;
 struct WatchedRoute {
 	consumer: crate::broadcast::Consumer,
 	path: crate::PathOwned,
-	sent: Option<OriginList>,
+	sent: Option<SentRoute>,
+}
+
+/// What the peer currently holds for a path: the forwarded hop chain plus, on
+/// lite-06+, the route cost. A fresh route that differs in either is worth a wire
+/// message; one that matches is not.
+#[derive(Clone, PartialEq, Eq)]
+struct SentRoute {
+	hops: OriginList,
+	cost: lite::RouteCost,
 }
 
 pub(super) struct PublisherConfig<S: web_transport_trait::Session> {
@@ -289,7 +298,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				// stashing suffix+hops so we can both COUNT them for AnnounceOk and re-send
 				// them afterward. The receiver stamps our origin onto each hop chain, so we
 				// forward the stored chain as-is (no self push here).
-				let mut initial: Vec<(crate::PathOwned, OriginList)> = Vec::new();
+				let mut initial: Vec<(crate::PathOwned, SentRoute)> = Vec::new();
 				while let Some(crate::announce::Update { path, broadcast }) = announced.try_next() {
 					let suffix = path
 						.strip_prefix(&prefix)
@@ -299,7 +308,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 					match broadcast {
 						Some(broadcast) => {
-							let hops = broadcast.route().hops;
+							let route = broadcast.route();
+							let hops = route.hops.clone();
+							let cost = Self::outgoing_cost(version, &broadcast, &route);
 							// Watch even the announces we filter below: a later route update
 							// can cross the forwarding filter in either direction.
 							watched.insert(
@@ -322,7 +333,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 							let guard = stats.broadcast(&absolute).publisher();
 							stats_guards.entry(absolute.clone()).or_insert(guard);
 							initial.retain(|(s, _)| s != &suffix);
-							initial.push((suffix, hops));
+							initial.push((suffix, SentRoute { hops, cost }));
 						}
 						None => {
 							// A potential race: a just-announced path already unannounced.
@@ -342,17 +353,18 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				};
 				let mut buf = bytes::BytesMut::new();
 				ok.encode(&mut buf, version)?;
-				for (suffix, hops) in &initial {
+				for (suffix, route) in &initial {
 					if version.has_announce_id() {
 						announce_ids.insert(suffix.clone(), next_announce_id);
 						next_announce_id += 1;
 					}
 					if let Some(entry) = watched.get_mut(suffix) {
-						entry.sent = Some(hops.clone());
+						entry.sent = Some(route.clone());
 					}
 					lite::AnnounceBroadcast::Active {
 						suffix: suffix.as_path(),
-						hops: hops.clone(),
+						hops: route.hops.clone(),
+						cost: route.cost,
 					}
 					.encode(&mut buf, version)?;
 				}
@@ -372,19 +384,40 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			}
 		}
 
-		// One announce-loop turn: either an (un)announce from the origin or a route
-		// change on an already-announced broadcast. Resolved outside the select so
-		// the handlers below can freely mutate the maps its futures borrow.
+		// One announce-loop turn: either an (un)announce from the origin, a route
+		// change on an already-announced broadcast, or the periodic cost recheck.
+		// Resolved outside the select so the handlers below can freely mutate the
+		// maps its futures borrow.
 		enum Op {
 			Announce(Option<crate::announce::Update>),
 			Route(crate::PathOwned, Result<crate::broadcast::Route, Error>),
+			Recheck,
 		}
+
+		// How often to re-evaluate the advertised cost of every watched broadcast.
+		// The cost depends on liveness (`is_active`), which is not part of the
+		// route: going active wakes this loop anyway (minting the track writes the
+		// broadcast state), but the last consumer dropping does not, so decay back
+		// to the cold cost rides this tick. The period is deliberately coarse: it
+		// doubles as hysteresis, keeping a briefly-idle broadcast advertising zero
+		// so viewer churn doesn't flap the mesh's routing.
+		const COST_RECHECK: Duration = Duration::from_secs(5);
+		let mut recheck = version
+			.has_route_cost()
+			.then(|| web_async::time::interval(COST_RECHECK));
 
 		// Send updates as they arrive. Closure wins the race so a dead peer can't
 		// stall on a busy announce feed.
 		loop {
 			let op = {
 				let mut closed = std::pin::pin!(stream.reader.closed());
+				// Pending forever when the version carries no cost on the wire.
+				let mut tick = std::pin::pin!(async {
+					match recheck.as_mut() {
+						Some(interval) => interval.tick().await,
+						None => std::future::pending().await,
+					}
+				});
 				kio::wait(|waiter| {
 					if let Poll::Ready(res) = waiter.poll_future(closed.as_mut()) {
 						return Poll::Ready(Err(res));
@@ -398,6 +431,19 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						if let Poll::Ready(res) = entry.consumer.poll_route_changed(waiter) {
 							return Poll::Ready(Ok(Op::Route(suffix.clone(), res)));
 						}
+						// The advertised cost drifts without a route change when
+						// liveness flips; reuse the route path to re-send it.
+						if version.has_route_cost()
+							&& let Some(sent) = &entry.sent
+						{
+							let route = entry.consumer.route();
+							if Self::outgoing_cost(version, &entry.consumer, &route) != sent.cost {
+								return Poll::Ready(Ok(Op::Route(suffix.clone(), Ok(route))));
+							}
+						}
+					}
+					if waiter.poll_future(tick.as_mut()).is_ready() {
+						return Poll::Ready(Ok(Op::Recheck));
 					}
 					Poll::Pending
 				})
@@ -440,6 +486,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 							else {
 								continue;
 							};
+							let cost = Self::outgoing_cost(version, &active, &route);
 							tracing::debug!(broadcast = %absolute, "announce");
 							let bs = stats.broadcast(&absolute);
 							// Count the broadcast name length, not the encoded message size, so
@@ -453,11 +500,14 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 								next_announce_id += 1;
 							}
 							if let Some(entry) = watched.get_mut(&suffix) {
-								entry.sent = Some(hops.clone());
+								entry.sent = Some(SentRoute {
+									hops: hops.clone(),
+									cost,
+								});
 							}
 							stream
 								.writer
-								.encode(&lite::AnnounceBroadcast::Active { suffix, hops })
+								.encode(&lite::AnnounceBroadcast::Active { suffix, hops, cost })
 								.await?;
 						}
 						None => {
@@ -504,15 +554,17 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						continue;
 					};
 					let absolute = origin.absolute(&entry.path).to_owned();
-					let hops = Self::prepare_active_hops(&route.hops, self_origin, exclude_hop, version, &absolute);
+					let cost = Self::outgoing_cost(version, &entry.consumer, &route);
+					let hops = Self::prepare_active_hops(&route.hops, self_origin, exclude_hop, version, &absolute)
+						.map(|hops| SentRoute { hops, cost });
 					let sent = entry.sent.clone();
 					match (hops, sent) {
-						// The forwarded chain is unchanged (e.g. only the cost moved,
-						// which doesn't ride the wire yet): nothing to send.
-						(Some(hops), Some(sent)) if hops == sent => {}
-						// The chain changed (an upstream failover): restart, so the
-						// peer updates its route in place instead of re-resolving.
-						(Some(hops), Some(_)) => {
+						// Neither the forwarded chain nor the cost moved: nothing to send.
+						(Some(route), Some(sent)) if route == sent => {}
+						// The chain or the cost changed (an upstream failover, a repriced
+						// link, or a broadcast going hot): restart, so the peer updates its
+						// route in place instead of re-resolving.
+						(Some(route), Some(_)) => {
 							tracing::debug!(broadcast = %absolute, "reannounce");
 							if version.has_announce_id() {
 								// The id exists for every live advertisement; a panic here would
@@ -526,25 +578,33 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 								stats
 									.broadcast(&absolute)
 									.publisher_announced_bytes(absolute.as_str().len() as u64);
-								entry.sent = Some(hops.clone());
+								entry.sent = Some(route.clone());
 								stream
 									.writer
-									.encode(&lite::AnnounceBroadcast::Restart { id, hops })
+									.encode(&lite::AnnounceBroadcast::Restart {
+										id,
+										hops: route.hops,
+										cost: route.cost,
+									})
 									.await?;
 							} else {
 								// Lite05: a duplicate ANNOUNCE for a live path is the restart.
 								stats
 									.broadcast(&absolute)
 									.publisher_announced_bytes(absolute.as_str().len() as u64);
-								entry.sent = Some(hops.clone());
+								entry.sent = Some(route.clone());
 								stream
 									.writer
-									.encode(&lite::AnnounceBroadcast::Active { suffix, hops })
+									.encode(&lite::AnnounceBroadcast::Active {
+										suffix,
+										hops: route.hops,
+										cost: route.cost,
+									})
 									.await?;
 							}
 						}
 						// Previously filtered, now forwardable: a fresh announce.
-						(Some(hops), None) => {
+						(Some(route), None) => {
 							tracing::debug!(broadcast = %absolute, "announce");
 							let bs = stats.broadcast(&absolute);
 							bs.publisher_announced_bytes(absolute.as_str().len() as u64);
@@ -553,10 +613,14 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 								announce_ids.insert(suffix.clone(), next_announce_id);
 								next_announce_id += 1;
 							}
-							entry.sent = Some(hops.clone());
+							entry.sent = Some(route.clone());
 							stream
 								.writer
-								.encode(&lite::AnnounceBroadcast::Active { suffix, hops })
+								.encode(&lite::AnnounceBroadcast::Active {
+									suffix,
+									hops: route.hops,
+									cost: route.cost,
+								})
 								.await?;
 						}
 						// The new chain must not be forwarded (it now loops through the
@@ -586,7 +650,37 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						(None, None) => {}
 					}
 				}
+				// The tick's only job is waking the loop: the next poll pass runs
+				// the cost drift scan and surfaces any change as `Op::Route`.
+				Op::Recheck => {}
 			}
+		}
+	}
+
+	/// The cost to advertise for a route, alongside its outgoing hop chain.
+	///
+	/// While we are actively carrying the broadcast the cost is zero: our ingress
+	/// is already paid for (or, for a local standby publisher, the work is already
+	/// running), so one more subscriber only pays the link to reach us. Otherwise
+	/// we forward the accumulated route cost unchanged, which for a standby
+	/// publisher is its production cost and for a pure forwarder is the price of
+	/// the fetch a subscription would trigger.
+	///
+	/// The receiving side adds its own link price on top, so we never account for
+	/// the link we are sending over. Pre-lite-06 peers get nothing (the field isn't
+	/// on their wire), leaving hop count as the metric exactly as before.
+	fn outgoing_cost(
+		version: Version,
+		consumer: &crate::broadcast::Consumer,
+		route: &crate::broadcast::Route,
+	) -> lite::RouteCost {
+		if !version.has_route_cost() {
+			return lite::RouteCost::default();
+		}
+
+		match consumer.is_active() {
+			true => lite::RouteCost(0),
+			false => lite::RouteCost(route.cost),
 		}
 	}
 

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -124,7 +124,7 @@ pub fn start<S: web_transport_trait::Session>(
 	let (tasks, task_set) = TaskSet::new();
 
 	// Read out before the setup task takes ownership below.
-	let our_link_cost = our_setup.link_cost;
+	let our_cost = our_setup.cost;
 
 	// Advertise our own capabilities on a uni Setup Stream, then FIN. Best-effort:
 	// a failure here just means the peer falls back to "no capabilities" for us.
@@ -153,7 +153,7 @@ pub fn start<S: web_transport_trait::Session>(
 		// The dialing side prices the link in its own SETUP, so that is also where the
 		// subscriber reads our price from. A server never sets one, leaving the
 		// subscriber to take the price out of the client's SETUP instead.
-		link_cost: our_link_cost,
+		cost: our_cost,
 		tasks,
 	});
 

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -123,6 +123,9 @@ pub fn start<S: web_transport_trait::Session>(
 	let peer_setup = peer_setup_slot;
 	let (tasks, task_set) = TaskSet::new();
 
+	// Read out before the setup task takes ownership below.
+	let our_link_cost = our_setup.link_cost;
+
 	// Advertise our own capabilities on a uni Setup Stream, then FIN. Best-effort:
 	// a failure here just means the peer falls back to "no capabilities" for us.
 	if version.has_setup_stream() {
@@ -147,6 +150,10 @@ pub fn start<S: web_transport_trait::Session>(
 		stats,
 		version,
 		peer_setup,
+		// The dialing side prices the link in its own SETUP, so that is also where the
+		// subscriber reads our price from. A server never sets one, leaving the
+		// subscriber to take the price out of the client's SETUP instead.
+		link_cost: our_link_cost,
 		tasks,
 	});
 

--- a/rs/moq-net/src/lite/setup.rs
+++ b/rs/moq-net/src/lite/setup.rs
@@ -12,7 +12,7 @@ const PARAM_PATH: u64 = 0x2;
 /// Setup Parameter id for the client's intended [`Role`] (client-only).
 const PARAM_ROLE: u64 = 0x3;
 /// Setup Parameter id for the link cost the dialer assigns to this connection.
-const PARAM_LINK_COST: u64 = 0x4;
+const PARAM_COST: u64 = 0x4;
 
 /// The cost of crossing a link that neither end priced.
 ///
@@ -20,7 +20,7 @@ const PARAM_LINK_COST: u64 = 0x4;
 /// hop count and ranks routes exactly as pre-lite-06 shortest-path routing did. Pricing
 /// a link at 0 makes it free (a sibling in the same datacenter); pricing it higher
 /// makes it a last resort (a metered backbone).
-pub const DEFAULT_LINK_COST: u64 = 1;
+pub const DEFAULT_COST: u64 = 1;
 
 /// The probe capability an endpoint advertises in SETUP.
 ///
@@ -148,7 +148,7 @@ pub struct Setup {
 	/// announcement forwarded over it. Sent only by the dialing side, since the link
 	/// cost lives in its connect config; the accepting side reads it here so both
 	/// ends price the same link identically. `None` means the default cost of 1.
-	pub link_cost: Option<u64>,
+	pub cost: Option<u64>,
 }
 
 impl Message for Setup {
@@ -171,13 +171,13 @@ impl Message for Setup {
 			None => None,
 		};
 		let role = params.get_varint(PARAM_ROLE)?.and_then(Role::from_code);
-		let link_cost = params.get_varint(PARAM_LINK_COST)?;
+		let cost = params.get_varint(PARAM_COST)?;
 
 		Ok(Self {
 			probe,
 			path,
 			role,
-			link_cost,
+			cost,
 		})
 	}
 
@@ -199,8 +199,8 @@ impl Message for Setup {
 		if let Some(role) = self.role {
 			params.set_varint(PARAM_ROLE, role.to_code());
 		}
-		if let Some(link_cost) = self.link_cost {
-			params.set_varint(PARAM_LINK_COST, link_cost);
+		if let Some(cost) = self.cost {
+			params.set_varint(PARAM_COST, cost);
 		}
 
 		params.encode(w, version)
@@ -228,8 +228,8 @@ impl PeerSetup {
 
 	/// Await the link cost the peer (the dialing side) declared in its SETUP.
 	/// `None` when it declared none, meaning the default cost of 1.
-	pub async fn link_cost(&self) -> Option<u64> {
-		self.wait(|setup| setup.link_cost).await
+	pub async fn cost(&self) -> Option<u64> {
+		self.wait(|setup| setup.cost).await
 	}
 
 	/// Await the peer's SETUP and read a field out of it.
@@ -283,12 +283,12 @@ mod tests {
 	}
 
 	#[test]
-	fn link_cost_round_trip() {
+	fn cost_round_trip() {
 		// Zero is a meaningful price (a free same-datacenter link), so it must survive
 		// the round trip as `Some(0)` rather than collapsing into "unpriced".
-		for link_cost in [None, Some(0), Some(1), Some(7)] {
+		for cost in [None, Some(0), Some(1), Some(7)] {
 			let msg = Setup {
-				link_cost,
+				cost,
 				..Default::default()
 			};
 			assert_eq!(round_trip(&msg), msg);
@@ -301,7 +301,7 @@ mod tests {
 			probe: ProbeLevel::Report,
 			path: Some("/room/123".to_string()),
 			role: None,
-			link_cost: None,
+			cost: None,
 		};
 		assert_eq!(round_trip(&msg), msg);
 	}

--- a/rs/moq-net/src/lite/setup.rs
+++ b/rs/moq-net/src/lite/setup.rs
@@ -11,6 +11,16 @@ const PARAM_PROBE: u64 = 0x1;
 const PARAM_PATH: u64 = 0x2;
 /// Setup Parameter id for the client's intended [`Role`] (client-only).
 const PARAM_ROLE: u64 = 0x3;
+/// Setup Parameter id for the link cost the dialer assigns to this connection.
+const PARAM_LINK_COST: u64 = 0x4;
+
+/// The cost of crossing a link that neither end priced.
+///
+/// One, so a mesh that configures no costs accumulates a route cost equal to the
+/// hop count and ranks routes exactly as pre-lite-06 shortest-path routing did. Pricing
+/// a link at 0 makes it free (a sibling in the same datacenter); pricing it higher
+/// makes it a last resort (a metered backbone).
+pub const DEFAULT_LINK_COST: u64 = 1;
 
 /// The probe capability an endpoint advertises in SETUP.
 ///
@@ -134,6 +144,11 @@ pub struct Setup {
 	/// session. `None` is sent as the absence of the parameter, which is also how a
 	/// client that predates the parameter decodes.
 	pub role: Option<Role>,
+	/// What crossing this link costs (lite-06+), added to the route cost of every
+	/// announcement forwarded over it. Sent only by the dialing side, since the link
+	/// cost lives in its connect config; the accepting side reads it here so both
+	/// ends price the same link identically. `None` means the default cost of 1.
+	pub link_cost: Option<u64>,
 }
 
 impl Message for Setup {
@@ -156,8 +171,14 @@ impl Message for Setup {
 			None => None,
 		};
 		let role = params.get_varint(PARAM_ROLE)?.and_then(Role::from_code);
+		let link_cost = params.get_varint(PARAM_LINK_COST)?;
 
-		Ok(Self { probe, path, role })
+		Ok(Self {
+			probe,
+			path,
+			role,
+			link_cost,
+		})
 	}
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
@@ -177,6 +198,9 @@ impl Message for Setup {
 		// directional role is encoded.
 		if let Some(role) = self.role {
 			params.set_varint(PARAM_ROLE, role.to_code());
+		}
+		if let Some(link_cost) = self.link_cost {
+			params.set_varint(PARAM_LINK_COST, link_cost);
 		}
 
 		params.encode(w, version)
@@ -198,11 +222,22 @@ impl PeerSetup {
 	}
 
 	/// Await the peer's advertised probe level, blocking until its SETUP arrives.
+	pub async fn probe_level(&self) -> ProbeLevel {
+		self.wait(|setup| setup.probe).await
+	}
+
+	/// Await the link cost the peer (the dialing side) declared in its SETUP.
+	/// `None` when it declared none, meaning the default cost of 1.
+	pub async fn link_cost(&self) -> Option<u64> {
+		self.wait(|setup| setup.link_cost).await
+	}
+
+	/// Await the peer's SETUP and read a field out of it.
 	///
 	/// The peer MUST send exactly one SETUP, so this resolves once that stream is read.
 	/// Waits forever if it never does; the caller is a session task, cancelled when the
 	/// driver drops.
-	pub async fn probe_level(&self) -> ProbeLevel {
+	async fn wait<T>(&self, f: impl FnOnce(&Setup) -> T) -> T {
 		let slot = self
 			.0
 			.wait(|setup| {
@@ -213,8 +248,7 @@ impl PeerSetup {
 				}
 			})
 			.await;
-		let setup = slot.as_ref().expect("waited for Some");
-		setup.probe
+		f(slot.as_ref().expect("waited for Some"))
 	}
 }
 
@@ -249,11 +283,25 @@ mod tests {
 	}
 
 	#[test]
+	fn link_cost_round_trip() {
+		// Zero is a meaningful price (a free same-datacenter link), so it must survive
+		// the round trip as `Some(0)` rather than collapsing into "unpriced".
+		for link_cost in [None, Some(0), Some(1), Some(7)] {
+			let msg = Setup {
+				link_cost,
+				..Default::default()
+			};
+			assert_eq!(round_trip(&msg), msg);
+		}
+	}
+
+	#[test]
 	fn path_round_trip() {
 		let msg = Setup {
 			probe: ProbeLevel::Report,
 			path: Some("/room/123".to_string()),
 			role: None,
+			link_cost: None,
 		};
 		assert_eq!(round_trip(&msg), msg);
 	}

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -38,7 +38,7 @@ pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 	/// What this session's link costs, when we are the side that dialed it and so
 	/// owns the price. `None` on an accepted session, which reads the dialer's
 	/// price out of its SETUP instead so both ends agree.
-	pub link_cost: Option<u64>,
+	pub cost: Option<u64>,
 	/// Driver-owned scope for broadcast and track handlers.
 	pub tasks: Tasks,
 }
@@ -72,7 +72,7 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	peer_setup: super::PeerSetup,
 	/// Our own price for this link when we dialed it; `None` when we accepted and
 	/// the dialer's SETUP carries the price instead.
-	link_cost: Option<u64>,
+	cost: Option<u64>,
 	tasks: Tasks,
 }
 
@@ -105,7 +105,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			next_id: Default::default(),
 			version: config.version,
 			peer_setup: config.peer_setup,
-			link_cost: config.link_cost,
+			cost: config.cost,
 			tasks: config.tasks,
 		}
 	}
@@ -115,18 +115,18 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	///
 	/// The dialing side owns the price (it lives in its connect config) and declares
 	/// it in SETUP, so the accepting side reads it back out and both ends charge the
-	/// same amount for the same link. Falls back to [`super::DEFAULT_LINK_COST`] when
+	/// same amount for the same link. Falls back to [`super::DEFAULT_COST`] when
 	/// nobody priced it.
-	async fn resolve_link_cost(&self) -> u64 {
+	async fn resolve_cost(&self) -> u64 {
 		// Older versions carry no cost on the wire, so nothing is charged and their
 		// routes rank on hop count alone. Returning early also avoids blocking on a
 		// SETUP that versions without a Setup Stream never send.
 		if !self.version.has_route_cost() {
 			return 0;
 		}
-		match self.link_cost {
+		match self.cost {
 			Some(cost) => cost,
-			None => self.peer_setup.link_cost().await.unwrap_or(super::DEFAULT_LINK_COST),
+			None => self.peer_setup.cost().await.unwrap_or(super::DEFAULT_COST),
 		}
 	}
 
@@ -261,7 +261,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// What we charge every announcement arriving on this stream. Resolved once:
 		// it comes from the connect config or the peer's SETUP, neither of which
 		// changes for the life of the session.
-		let link_cost = self.resolve_link_cost().await;
+		let link_cost = self.resolve_cost().await;
 
 		let mut routes = HashMap::new();
 		// Per-broadcast subscriber-side stats guards. Dropping the guard records
@@ -299,11 +299,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						.broadcast(&abs)
 						.subscriber_announced_bytes(abs.as_str().len() as u64);
 					// Lite01/02 don't carry hop information; the broadcast starts with
-					// an empty chain.
+					// an empty chain and an unpriced link.
 					if self.start_announce(
 						path.clone(),
 						crate::OriginList::new(),
 						RouteCost::default(),
+						0,
 						responder_origin,
 						&mut routes,
 					)? {
@@ -359,13 +360,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						// atomically replace the broadcast. Lite06+ restarts by announce id, and older
 						// versions never defined restarts, so both fall through to start_announce, which
 						// rejects the duplicate (Error::Duplicate).
-						if self.restart_announce(
-							path.clone(),
-							hops,
-							cost.charged(link_cost),
-							responder_origin,
-							&mut routes,
-						)? {
+						if self.restart_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)? {
 							// Continuity: keep the existing stats guard if present.
 							stats_guards
 								.entry(abs.clone())
@@ -373,13 +368,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						} else {
 							stats_guards.remove(&abs);
 						}
-					} else if self.start_announce(
-						path.clone(),
-						hops,
-						cost.charged(link_cost),
-						responder_origin,
-						&mut routes,
-					)? {
+					} else if self.start_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)? {
 						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
 					}
 					// The first `initial_count` Active messages are the initial set; once
@@ -444,13 +433,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						.broadcast(&abs)
 						.subscriber_announced_bytes(abs.as_str().len() as u64);
 					if routes.contains_key(&path) {
-						if self.restart_announce(
-							path.clone(),
-							hops,
-							cost.charged(link_cost),
-							responder_origin,
-							&mut routes,
-						)? {
+						if self.restart_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)? {
 							// Continuity: keep the existing stats guard if present.
 							stats_guards
 								.entry(abs.clone())
@@ -458,13 +441,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						} else {
 							stats_guards.remove(&abs);
 						}
-					} else if self.start_announce(
-						path.clone(),
-						hops,
-						cost.charged(link_cost),
-						responder_origin,
-						&mut routes,
-					)? {
+					} else if self.start_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)? {
 						// The original announce was dropped locally (e.g. a reflected loop);
 						// the replacement may be routable, so treat it as a fresh start.
 						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
@@ -552,9 +529,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		path: PathOwned,
 		mut hops: crate::OriginList,
-		// The route cost off the wire, plus this link's price. Zero before
+		// The route cost off the wire, i.e. as the peer advertised it. Zero before
 		// lite-06, leaving the hop chain as the only routing input as before.
 		cost: RouteCost,
+		// This link's price, added to the wire cost; the pre-charge value is kept
+		// on the route so the origin's handover gate can tell a warm peer apart.
+		link_cost: u64,
 		// Lite05+: the announce sender's origin id (from AnnounceOk). The sender no
 		// longer stamps itself onto the chain, so we append it here to reconstruct
 		// the full `[src...sender]` chain Lite04 stored. None for older versions,
@@ -617,10 +597,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// (other sessions announcing the same path) join it silently as standbys.
 		// An error means the path is outside our scope, so don't serve it.
 		// Reflections are already filtered above.
-		let route = crate::broadcast::Route::new()
+		let mut route = crate::broadcast::Route::new()
 			.with_hops(hops)
-			.with_cost(cost.0)
+			.with_cost(cost.charged(link_cost).0)
 			.with_announce(true);
+		route.advertised = cost.0;
 		let Ok(source) = self.origin.create_broadcast(&path, route) else {
 			return Ok(false);
 		};
@@ -648,8 +629,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		path: PathOwned,
 		mut hops: crate::OriginList,
-		// The route cost off the wire, plus this link's price. See `start_announce`.
+		// The route cost off the wire and this link's price. See `start_announce`.
 		cost: RouteCost,
+		link_cost: u64,
 		// Lite05+: the announce sender's origin id (from AnnounceOk), appended here to
 		// rebuild the full chain since the sender no longer stamps itself. None for older
 		// versions. See `start_announce`.
@@ -672,10 +654,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "restart");
 		let publisher = hops.iter().next().copied().unwrap_or(self.session_origin);
-		let metadata = crate::broadcast::Route::new()
+		let mut metadata = crate::broadcast::Route::new()
 			.with_hops(hops)
-			.with_cost(cost.0)
+			.with_cost(cost.charged(link_cost).0)
 			.with_announce(true);
+		metadata.advertised = cost.0;
 
 		match routes.get_mut(&path) {
 			Some(entry) if entry.publisher != publisher => {

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -17,7 +17,7 @@ use crate::{
 	track::Subscription,
 };
 
-use super::{ConnectingProducer, Version};
+use super::{ConnectingProducer, RouteCost, Version};
 
 use web_async::Lock;
 
@@ -35,6 +35,10 @@ pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 	/// Shared slot for the peer's SETUP (lite-05+). Written when the peer's Setup
 	/// stream is read; the probe stream waits on it before opening.
 	pub peer_setup: super::PeerSetup,
+	/// What this session's link costs, when we are the side that dialed it and so
+	/// owns the price. `None` on an accepted session, which reads the dialer's
+	/// price out of its SETUP instead so both ends agree.
+	pub link_cost: Option<u64>,
 	/// Driver-owned scope for broadcast and track handlers.
 	pub tasks: Tasks,
 }
@@ -66,6 +70,9 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	version: Version,
 	/// The peer's advertised SETUP (lite-05+), set when its Setup stream is read.
 	peer_setup: super::PeerSetup,
+	/// Our own price for this link when we dialed it; `None` when we accepted and
+	/// the dialer's SETUP carries the price instead.
+	link_cost: Option<u64>,
 	tasks: Tasks,
 }
 
@@ -98,7 +105,28 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			next_id: Default::default(),
 			version: config.version,
 			peer_setup: config.peer_setup,
+			link_cost: config.link_cost,
 			tasks: config.tasks,
+		}
+	}
+
+	/// What crossing this session's link costs, added to the route cost of every
+	/// announcement received over it.
+	///
+	/// The dialing side owns the price (it lives in its connect config) and declares
+	/// it in SETUP, so the accepting side reads it back out and both ends charge the
+	/// same amount for the same link. Falls back to [`super::DEFAULT_LINK_COST`] when
+	/// nobody priced it.
+	async fn resolve_link_cost(&self) -> u64 {
+		// Older versions carry no cost on the wire, so nothing is charged and their
+		// routes rank on hop count alone. Returning early also avoids blocking on a
+		// SETUP that versions without a Setup Stream never send.
+		if !self.version.has_route_cost() {
+			return 0;
+		}
+		match self.link_cost {
+			Some(cost) => cost,
+			None => self.peer_setup.link_cost().await.unwrap_or(super::DEFAULT_LINK_COST),
 		}
 	}
 
@@ -230,6 +258,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			(None, 0)
 		};
 
+		// What we charge every announcement arriving on this stream. Resolved once:
+		// it comes from the connect config or the peer's SETUP, neither of which
+		// changes for the life of the session.
+		let link_cost = self.resolve_link_cost().await;
+
 		let mut routes = HashMap::new();
 		// Per-broadcast subscriber-side stats guards. Dropping the guard records
 		// `subscriber.broadcasts_closed`. We only insert a guard when start_announce
@@ -267,7 +300,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						.subscriber_announced_bytes(abs.as_str().len() as u64);
 					// Lite01/02 don't carry hop information; the broadcast starts with
 					// an empty chain.
-					if self.start_announce(path.clone(), crate::OriginList::new(), responder_origin, &mut routes)? {
+					if self.start_announce(
+						path.clone(),
+						crate::OriginList::new(),
+						RouteCost::default(),
+						responder_origin,
+						&mut routes,
+					)? {
 						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
 					}
 				}
@@ -299,7 +338,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		while let Some(announce) = stream.reader.decode_maybe::<lite::AnnounceBroadcast>().await? {
 			match announce {
-				lite::AnnounceBroadcast::Active { suffix, hops } => {
+				lite::AnnounceBroadcast::Active { suffix, hops, cost } => {
 					let path = prefix.join(&suffix);
 					let abs = self.origin.absolute(&path).to_owned();
 					// Count the broadcast name length (not the encoded message size) for
@@ -320,7 +359,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						// atomically replace the broadcast. Lite06+ restarts by announce id, and older
 						// versions never defined restarts, so both fall through to start_announce, which
 						// rejects the duplicate (Error::Duplicate).
-						if self.restart_announce(path.clone(), hops, responder_origin, &mut routes)? {
+						if self.restart_announce(
+							path.clone(),
+							hops,
+							cost.charged(link_cost),
+							responder_origin,
+							&mut routes,
+						)? {
 							// Continuity: keep the existing stats guard if present.
 							stats_guards
 								.entry(abs.clone())
@@ -328,7 +373,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						} else {
 							stats_guards.remove(&abs);
 						}
-					} else if self.start_announce(path.clone(), hops, responder_origin, &mut routes)? {
+					} else if self.start_announce(
+						path.clone(),
+						hops,
+						cost.charged(link_cost),
+						responder_origin,
+						&mut routes,
+					)? {
 						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
 					}
 					// The first `initial_count` Active messages are the initial set; once
@@ -382,7 +433,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						stats_guards.remove(&abs);
 					}
 				}
-				lite::AnnounceBroadcast::Restart { id, hops } => {
+				lite::AnnounceBroadcast::Restart { id, hops, cost } => {
 					// Resolve the id; it stays live (the replacement reuses it). An unknown
 					// or retired id is a protocol violation.
 					let Some(path) = announced_by_id.get(&id).cloned() else {
@@ -393,7 +444,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						.broadcast(&abs)
 						.subscriber_announced_bytes(abs.as_str().len() as u64);
 					if routes.contains_key(&path) {
-						if self.restart_announce(path.clone(), hops, responder_origin, &mut routes)? {
+						if self.restart_announce(
+							path.clone(),
+							hops,
+							cost.charged(link_cost),
+							responder_origin,
+							&mut routes,
+						)? {
 							// Continuity: keep the existing stats guard if present.
 							stats_guards
 								.entry(abs.clone())
@@ -401,7 +458,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						} else {
 							stats_guards.remove(&abs);
 						}
-					} else if self.start_announce(path.clone(), hops, responder_origin, &mut routes)? {
+					} else if self.start_announce(
+						path.clone(),
+						hops,
+						cost.charged(link_cost),
+						responder_origin,
+						&mut routes,
+					)? {
 						// The original announce was dropped locally (e.g. a reflected loop);
 						// the replacement may be routable, so treat it as a fresh start.
 						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
@@ -489,6 +552,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		path: PathOwned,
 		mut hops: crate::OriginList,
+		// The route cost off the wire, plus this link's price. Zero before
+		// lite-06, leaving the hop chain as the only routing input as before.
+		cost: RouteCost,
 		// Lite05+: the announce sender's origin id (from AnnounceOk). The sender no
 		// longer stamps itself onto the chain, so we append it here to reconstruct
 		// the full `[src...sender]` chain Lite04 stored. None for older versions,
@@ -551,7 +617,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// (other sessions announcing the same path) join it silently as standbys.
 		// An error means the path is outside our scope, so don't serve it.
 		// Reflections are already filtered above.
-		let route = crate::broadcast::Route::new().with_hops(hops).with_announce(true);
+		let route = crate::broadcast::Route::new()
+			.with_hops(hops)
+			.with_cost(cost.0)
+			.with_announce(true);
 		let Ok(source) = self.origin.create_broadcast(&path, route) else {
 			return Ok(false);
 		};
@@ -579,6 +648,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		path: PathOwned,
 		mut hops: crate::OriginList,
+		// The route cost off the wire, plus this link's price. See `start_announce`.
+		cost: RouteCost,
 		// Lite05+: the announce sender's origin id (from AnnounceOk), appended here to
 		// rebuild the full chain since the sender no longer stamps itself. None for older
 		// versions. See `start_announce`.
@@ -601,7 +672,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "restart");
 		let publisher = hops.iter().next().copied().unwrap_or(self.session_origin);
-		let metadata = crate::broadcast::Route::new().with_hops(hops).with_announce(true);
+		let metadata = crate::broadcast::Route::new()
+			.with_hops(hops)
+			.with_cost(cost.0)
+			.with_announce(true);
 
 		match routes.get_mut(&path) {
 			Some(entry) if entry.publisher != publisher => {

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -13,9 +13,11 @@ pub enum Version {
 	Lite05,
 	/// Work-in-progress lite-06. Adds announce ids: each `active` ANNOUNCE_BROADCAST
 	/// implicitly assigns the next ordinal, and `ended`/`restart` reference that id
-	/// instead of repeating the path. Advertised over ALPN (`moq-lite-06`, no `-wip`
-	/// suffix on the wire) and the preferred version in the default sets. The wire
-	/// format is still WIP; finalizing is a pure rename to `Lite06` with no wire change.
+	/// instead of repeating the path. Also adds the route cost carried alongside the
+	/// hop chain, ranking above hop count in route selection. Advertised over ALPN
+	/// (`moq-lite-06`, no `-wip` suffix on the wire) and the preferred version in the
+	/// default sets. The wire format is still WIP; finalizing is a pure rename to
+	/// `Lite06` with no wire change.
 	Lite06Wip,
 }
 
@@ -75,6 +77,19 @@ impl Version {
 	/// reference that id instead of repeating the path. Added in lite-06.
 	#[allow(clippy::match_like_matches_macro)]
 	pub fn has_announce_id(self) -> bool {
+		// Match form so future versions default forward (CLAUDE.md convention).
+		match self {
+			Self::Lite01 | Self::Lite02 | Self::Lite03 | Self::Lite04 | Self::Lite05 => false,
+			_ => true,
+		}
+	}
+
+	/// Whether announcements carry the route cost: the marginal cost of pulling
+	/// the broadcast via this route, accumulated per link. Added in lite-06.
+	/// Older versions carry nothing, so a received route stays at zero and ranks
+	/// on hop count alone, exactly as before.
+	#[allow(clippy::match_like_matches_macro)]
+	pub fn has_route_cost(self) -> bool {
 		// Match form so future versions default forward (CLAUDE.md convention).
 		match self {
 			Self::Lite01 | Self::Lite02 | Self::Lite03 | Self::Lite04 | Self::Lite05 => false,

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -181,14 +181,35 @@ impl BroadcastState {
 		}
 	}
 
-	/// Live demand: a subscribed spliced track (route-fed broadcast), or a live
-	/// track producer / pending request (ordinary broadcast). See
-	/// [`Consumer::is_active`].
-	fn is_active(&self) -> bool {
+	/// Live demand: a subscribed spliced track (route-fed broadcast), or a
+	/// pending request / consumed track (ordinary broadcast). See [`Demand`].
+	fn is_used(&self) -> bool {
 		if let Some(spliced) = &self.spliced {
 			return spliced.tracks.values().any(|track| track.is_used());
 		}
-		!self.requests.is_empty() || self.tracks.has_live()
+		!self.requests.is_empty() || self.tracks.iter().any(|track| track.is_used())
+	}
+
+	/// Park `waiter` on every per-track channel feeding [`Self::is_used`]: the
+	/// consumer counts live on those channels, and their flips don't write this
+	/// state, so a watcher registered here alone would miss the edge. `want`
+	/// picks the direction; each channel only arms while its side is unmet.
+	fn register_demand(&self, waiter: &kio::Waiter, want: bool) {
+		if let Some(spliced) = &self.spliced {
+			for track in spliced.tracks.values() {
+				match want {
+					true => track.poll_used(waiter),
+					false => track.poll_unused(waiter),
+				}
+			}
+			return;
+		}
+		for track in self.tracks.iter() {
+			match want {
+				true => track.poll_used(waiter),
+				false => track.poll_unused(waiter),
+			}
+		}
 	}
 }
 
@@ -254,9 +275,12 @@ impl Producer {
 		&self.info
 	}
 
-	/// True while the broadcast has live demand. See [`Consumer::is_active`].
-	pub fn is_active(&self) -> bool {
-		self.state.read().is_active()
+	/// A watch-only handle to the broadcast's demand. See [`Demand`].
+	pub fn demand(&self) -> Demand {
+		Demand {
+			alive: self.alive.consume().weak(),
+			state: self.state.clone(),
+		}
 	}
 
 	/// Remove a track from the lookup.
@@ -731,19 +755,12 @@ impl Consumer {
 		Ok(consumer)
 	}
 
-	/// True while the broadcast has live demand: a spliced (route-fed) broadcast
-	/// with a subscribed logical track, or an ordinary broadcast with a live
-	/// track producer or pending request.
-	///
-	/// This is the cache signal routing announces: an active broadcast's ingress
-	/// (or, for a local publisher, its production) is already paid for, so it
-	/// advertises zero marginal cost and peers pull the copy that exists. An idle
-	/// one advertises what a fresh fetch would cost. The transition back to idle
-	/// doesn't wake state watchers (dropping a consumer doesn't write the
-	/// broadcast state), so poll this on a coarse tick rather than waiting on an
-	/// edge; the tick doubles as hysteresis against viewer churn.
-	pub fn is_active(&self) -> bool {
-		self.state.read().is_active()
+	/// A watch-only handle to the broadcast's demand. See [`Demand`].
+	pub(crate) fn demand(&self) -> Demand {
+		Demand {
+			alive: self.alive.weak(),
+			state: self.state.clone(),
+		}
 	}
 
 	/// Block until the broadcast is closed (every producer dropped) and return the cause.
@@ -837,6 +854,78 @@ impl super::WeakEntry for WeakConsumer {
 	}
 }
 
+/// A cloneable, watch-only handle to a broadcast's subscriber demand.
+///
+/// Obtained from [`Producer::demand`]; the broadcast-level sibling of
+/// [`track::Demand`](crate::track::Demand). Demand means live interest in the
+/// broadcast's content: a subscribed spliced track on a route-fed broadcast, or
+/// a pending track request / a consumed track on an ordinary one. A publisher
+/// uses it to run expensive work only while someone is watching, and routing
+/// uses it to advertise a warm copy at zero cost.
+///
+/// It's a weak handle: it neither keeps the broadcast alive nor counts as
+/// demand itself. Once every producer is gone, [`used`](Self::used) /
+/// [`unused`](Self::unused) return [`Error::Dropped`].
+#[derive(Clone)]
+pub struct Demand {
+	alive: kio::ConsumerWeak<()>,
+	state: kio::Shared<BroadcastState>,
+}
+
+impl Demand {
+	/// Whether the broadcast has live demand right now.
+	///
+	/// A point-in-time snapshot with no registration; use [`Self::used`] /
+	/// [`Self::unused`] (or their `poll_*` forms) to wait for the edge.
+	pub fn is_used(&self) -> bool {
+		self.state.read().is_used()
+	}
+
+	/// Block until the broadcast has demand. Resolves immediately if it already
+	/// does; returns [`Error::Dropped`] once every producer is gone.
+	pub async fn used(&self) -> Result<(), Error> {
+		kio::wait(|waiter| self.poll_used(waiter)).await
+	}
+
+	/// Block until the broadcast has no demand. Resolves immediately if it has
+	/// none; returns [`Error::Dropped`] once every producer is gone.
+	pub async fn unused(&self) -> Result<(), Error> {
+		kio::wait(|waiter| self.poll_unused(waiter)).await
+	}
+
+	/// Poll-based variant of [`Self::used`].
+	pub fn poll_used(&self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		self.poll_demand(waiter, true)
+	}
+
+	/// Poll-based variant of [`Self::unused`].
+	pub fn poll_unused(&self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		self.poll_demand(waiter, false)
+	}
+
+	fn poll_demand(&self, waiter: &kio::Waiter, want: bool) -> Poll<Result<(), Error>> {
+		// Closure is checked first, matching `track::Demand`: a dead broadcast
+		// reports Dropped rather than pretending to answer.
+		if self.alive.poll_closed(waiter).is_ready() {
+			return Poll::Ready(Err(Error::Dropped));
+		}
+		let ready = self.state.poll(waiter, |state| {
+			// The consumer counts live on the per-track channels, whose flips
+			// don't write this state: park on those channels too so the edge
+			// wakes us, then recompute here.
+			state.register_demand(waiter, want);
+			match state.is_used() == want {
+				true => Poll::Ready(()),
+				false => Poll::Pending,
+			}
+		});
+		match ready {
+			Poll::Ready(_) => Poll::Ready(Ok(())),
+			Poll::Pending => Poll::Pending,
+		}
+	}
+}
+
 #[cfg(test)]
 impl Consumer {
 	pub fn assert_not_closed(&self) {
@@ -851,6 +940,74 @@ impl Consumer {
 #[cfg(test)]
 mod test {
 	use super::*;
+
+	/// Await with a timeout so a missed demand wake fails the test instead of
+	/// hanging it (time is paused, so the timeout fires instantly when idle).
+	async fn expect<T>(fut: impl Future<Output = T>) -> T {
+		tokio::time::timeout(std::time::Duration::from_secs(1), fut)
+			.await
+			.expect("timed out waiting for a demand edge")
+	}
+
+	/// Demand on an ordinary broadcast tracks subscriber interest, not
+	/// production: a live track producer alone is unused, a consumed track is
+	/// used, and both edges wake parked waiters.
+	#[tokio::test]
+	async fn demand_ordinary() {
+		tokio::time::pause();
+
+		let mut producer = Info::new().produce();
+		let consumer = producer.consume();
+		let demand = producer.demand();
+
+		// No demand yet; `unused` resolves immediately.
+		assert!(!demand.is_used());
+		demand.unused().await.unwrap();
+
+		// Producing alone is not demand.
+		let _track = producer.create_track("a", None).unwrap();
+		assert!(!demand.is_used());
+
+		// A consumer appearing wakes a parked `used`.
+		let (used, handle) = tokio::join!(expect(demand.used()), async { consumer.track("a").unwrap() });
+		used.unwrap();
+		assert!(demand.is_used());
+
+		// The last consumer dropping wakes a parked `unused`.
+		let (unused, ()) = tokio::join!(expect(demand.unused()), async { drop(handle) });
+		unused.unwrap();
+		assert!(!demand.is_used());
+
+		// Every producer gone: both edges report the closure.
+		producer.finish();
+		assert!(matches!(demand.used().await, Err(Error::Dropped)));
+		assert!(matches!(demand.unused().await, Err(Error::Dropped)));
+	}
+
+	/// Demand on a spliced (route-fed) broadcast follows the logical tracks'
+	/// consumers, which is what flips a relay's advertised cost.
+	#[tokio::test]
+	async fn demand_spliced() {
+		tokio::time::pause();
+
+		let producer = Producer::new_spliced(Info::new());
+		let consumer = producer.consume();
+		let demand = producer.demand();
+
+		assert!(!demand.is_used());
+		let track = consumer.track("video").unwrap();
+		assert!(demand.is_used());
+
+		// Dropping the only consumer wakes a parked `unused`, even though the
+		// logical track itself stays cached in the broadcast.
+		let (unused, ()) = tokio::join!(expect(demand.unused()), async { drop(track) });
+		unused.unwrap();
+		assert!(!demand.is_used());
+
+		// A repeat consumer for the cached track counts again.
+		let _track = consumer.track("video").unwrap();
+		assert!(demand.is_used());
+	}
 
 	/// Subscribe and assert the result hasn't resolved yet (it stays pending until
 	/// a publisher accepts). Returns the pending subscription to resolve after accepting.

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -55,21 +55,27 @@ pub struct Route {
 	/// and as the selection tie-break.
 	pub hops: OriginList,
 
-	/// The marginal cost of pulling the broadcast via this route: lower wins, with
-	/// ties broken by hop length and then a deterministic hash.
+	/// The cost of pulling the broadcast via this route, accumulated per link:
+	/// lower wins, with ties broken by hop length and then a deterministic hash.
 	///
 	/// The original publisher seeds it with its production cost (zero for a live
 	/// publish, something large for a standby that would have to start working,
-	/// like a cold transcoder). Each link adds its own configured price as the
-	/// announcement crosses it, so a route over a metered backbone ranks worse
-	/// than an equal-length one within a datacenter. A node actively carrying the
-	/// broadcast re-announces zero instead of the accumulated value: its ingress
-	/// is already paid for, so peers should pull the copy that exists rather than
-	/// open a second one all the way back.
+	/// like a cold transcoder), and each link adds its own configured price as
+	/// the announcement crosses it, so a route over a metered backbone ranks
+	/// worse than an equal-length one within a datacenter. The accumulation
+	/// restarts at zero at any node actively carrying the broadcast: those
+	/// upstream legs already exist and are not re-paid by one more subscriber,
+	/// so the sum is the cost of the transfers a subscription would newly cause.
 	///
 	/// Carried on the wire from lite-06; older peers always report zero, leaving
 	/// the hop-count tie-break as the effective metric exactly as before.
 	pub cost: u64,
+
+	/// The cost as the announcing peer advertised it, before this link's charge
+	/// was added to [`Self::cost`]. Local bookkeeping, never forwarded: zero on a
+	/// chain of two or more hops means the announcing relay is actively carrying
+	/// the broadcast, which is what the origin's handover gate keys on.
+	pub(crate) advertised: u64,
 
 	/// Whether the broadcast should be announced: advertised to consumers via
 	/// [`crate::origin::Consumer::announced`] while this is the best route. A

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -55,11 +55,20 @@ pub struct Route {
 	/// and as the selection tie-break.
 	pub hops: OriginList,
 
-	/// Preference among routes serving the same broadcast: lower wins, with ties
-	/// broken by hop length and then a deterministic hash. Lets a publisher
-	/// advertise how expensive it is to serve (e.g. a standby transcoder), and
-	/// change its mind as capacity shifts. Local for now: the wire only carries
-	/// hops, so a received route always has the default cost.
+	/// The marginal cost of pulling the broadcast via this route: lower wins, with
+	/// ties broken by hop length and then a deterministic hash.
+	///
+	/// The original publisher seeds it with its production cost (zero for a live
+	/// publish, something large for a standby that would have to start working,
+	/// like a cold transcoder). Each link adds its own configured price as the
+	/// announcement crosses it, so a route over a metered backbone ranks worse
+	/// than an equal-length one within a datacenter. A node actively carrying the
+	/// broadcast re-announces zero instead of the accumulated value: its ingress
+	/// is already paid for, so peers should pull the copy that exists rather than
+	/// open a second one all the way back.
+	///
+	/// Carried on the wire from lite-06; older peers always report zero, leaving
+	/// the hop-count tie-break as the effective metric exactly as before.
 	pub cost: u64,
 
 	/// Whether the broadcast should be announced: advertised to consumers via
@@ -165,6 +174,16 @@ impl BroadcastState {
 			None => Ok(()),
 		}
 	}
+
+	/// Live demand: a subscribed spliced track (route-fed broadcast), or a live
+	/// track producer / pending request (ordinary broadcast). See
+	/// [`Consumer::is_active`].
+	fn is_active(&self) -> bool {
+		if let Some(spliced) = &self.spliced {
+			return spliced.tracks.values().any(|track| track.is_used());
+		}
+		!self.requests.is_empty() || self.tracks.has_live()
+	}
 }
 
 /// Manages tracks within a broadcast.
@@ -227,6 +246,11 @@ impl Producer {
 
 	pub fn info(&self) -> &Info {
 		&self.info
+	}
+
+	/// True while the broadcast has live demand. See [`Consumer::is_active`].
+	pub fn is_active(&self) -> bool {
+		self.state.read().is_active()
 	}
 
 	/// Remove a track from the lookup.
@@ -699,6 +723,21 @@ impl Consumer {
 		}
 
 		Ok(consumer)
+	}
+
+	/// True while the broadcast has live demand: a spliced (route-fed) broadcast
+	/// with a subscribed logical track, or an ordinary broadcast with a live
+	/// track producer or pending request.
+	///
+	/// This is the cache signal routing announces: an active broadcast's ingress
+	/// (or, for a local publisher, its production) is already paid for, so it
+	/// advertises zero marginal cost and peers pull the copy that exists. An idle
+	/// one advertises what a fresh fetch would cost. The transition back to idle
+	/// doesn't wake state watchers (dropping a consumer doesn't write the
+	/// broadcast state), so poll this on a coarse tick rather than waiting on an
+	/// edge; the tick doubles as hysteresis against viewer churn.
+	pub fn is_active(&self) -> bool {
+		self.state.read().is_active()
 	}
 
 	/// Block until the broadcast is closed (every producer dropped) and return the cause.

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -350,11 +350,22 @@ struct OriginBroadcast {
 /// build-stable. Mixing the name in spreads equal routes across different
 /// upstreams rather than funneling onto one.
 fn route_key(name: &Path, hops: &OriginList) -> (usize, u64) {
-	// FNV-1a, not the std hasher: its output is fixed across Rust versions and
-	// builds, which matters when nodes run mismatched binaries during a rolling
-	// deploy and still need to agree on the same route. SEED is a custom basis
-	// (any nonzero u64 works, the textbook one is just as arbitrary); FNV_PRIME is
-	// the standard FNV-64 prime and should stay put.
+	(hops.len(), fnv_key(name, hops.iter().copied()))
+}
+
+/// FNV-1a over the broadcast name and a sequence of origin ids.
+///
+/// FNV-1a, not the std hasher: its output is fixed across Rust versions and
+/// builds, which matters when nodes run mismatched binaries during a rolling
+/// deploy and still need to agree on the same route. SEED is a custom basis
+/// (any nonzero u64 works, the textbook one is just as arbitrary); FNV_PRIME is
+/// the standard FNV-64 prime and should stay put.
+///
+/// Two callers, two different id sequences: [`route_key`] hashes a route's hop
+/// chain to pick among *routes*, and [`FrontState::handover_allowed`] hashes a
+/// single relay's origin to pick among *relays*. Mixing the name in spreads
+/// equal candidates across different winners rather than funneling onto one.
+fn fnv_key(name: &Path, origins: impl IntoIterator<Item = Origin>) -> u64 {
 	const SEED: u64 = 0x420C0DECB00B; // 420 C0DEC B00B
 	const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
 
@@ -362,18 +373,23 @@ fn route_key(name: &Path, hops: &OriginList) -> (usize, u64) {
 	for &byte in name.as_str().as_bytes() {
 		hash = (hash ^ u64::from(byte)).wrapping_mul(FNV_PRIME);
 	}
-	for hop in hops {
-		for &byte in &hop.id().to_le_bytes() {
+	for origin in origins {
+		for &byte in &origin.id().to_le_bytes() {
 			hash = (hash ^ u64::from(byte)).wrapping_mul(FNV_PRIME);
 		}
 	}
 
-	(hops.len(), hash)
+	hash
 }
 
 /// Full ordering key for a [`broadcast::Route`]: announced routes first (an
-/// actively published source beats an offline one), then cost (the publisher's
-/// own preference), then the [`route_key`] hop ordering. Lower wins.
+/// actively published source beats an offline one), then the marginal cost of
+/// pulling via the route, then the [`route_key`] hop ordering. Lower wins.
+///
+/// Hop length stays the tie-break below cost, so peers that never carry a cost
+/// (pre-lite-06, or a plain local publish) rank exactly as they did before route
+/// cost existed, and equal-cost warm copies resolve to the closest one, which
+/// bounds same-datacenter chains to a single hop.
 fn route_order(name: &Path, route: &broadcast::Route) -> (bool, u64, usize, u64) {
 	let (len, hash) = route_key(name, &route.hops);
 	(!route.announce, route.cost, len, hash)
@@ -967,6 +983,8 @@ struct FrontRoute {
 struct FrontState {
 	/// Absolute path of the broadcast, mixed into the route tie-break hash.
 	path: PathOwned,
+	/// The local origin's identity, the other half of the handover key gate.
+	self_origin: Origin,
 	next_route: u64,
 	routes: Vec<FrontRoute>,
 	/// The source tracks are dispatched to. Backups park until promoted.
@@ -989,8 +1007,50 @@ impl FrontState {
 
 	/// Re-pick the active source after the table changed. Serve tasks watch
 	/// `active` and re-splice on their own.
-	fn reselect(&mut self) {
-		self.active = self.best_route();
+	///
+	/// `carrying` is whether the front currently has live demand (the spliced
+	/// broadcast is active). While it does, a strictly cheaper announced route may
+	/// only displace an announced incumbent when [`Self::handover_allowed`] says
+	/// so. This is the symmetry break for the simultaneous-activation race: two
+	/// nodes that each pulled the broadcast before seeing the other both advertise
+	/// zero cost, so each sees the other as cheaper than its own source. Without
+	/// the gate both re-parent at once and the broadcast is left with no upstream
+	/// at all; with it, exactly one moves (make-before-break via the usual splice)
+	/// and the other keeps its source.
+	fn reselect(&mut self, carrying: bool) {
+		let best = self.best_route();
+		if carrying
+			&& let (Some(best_id), Some(cur_id)) = (best, self.active)
+			&& best_id != cur_id
+			&& let Some(candidate) = self.routes.iter().find(|r| r.id == best_id)
+			&& let Some(incumbent) = self.routes.iter().find(|r| r.id == cur_id)
+			&& incumbent.route.announce
+			&& candidate.route.cost < incumbent.route.cost
+			&& !self.handover_allowed(&candidate.route)
+		{
+			// We lost the key comparison: stay put and let the peer come to us.
+			return;
+		}
+		self.active = best;
+	}
+
+	/// Whether re-parenting onto `route` is allowed while actively carrying: the
+	/// announcing peer (the chain's last hop) must hash strictly below our own
+	/// origin for this broadcast name.
+	///
+	/// Both sides compute the same two keys (the hash is build-stable and the
+	/// inputs are shared), so the comparison resolves the same way everywhere:
+	/// the lower-keyed node keeps its source, the higher-keyed one re-parents.
+	/// A strict total order has no cycles, so mutual pulls cannot happen. Mixing
+	/// the broadcast name in spreads ownership across a region's relays instead
+	/// of funneling every broadcast onto the lowest-keyed one. A route with no
+	/// hops is a local publish and always allowed.
+	fn handover_allowed(&self, route: &broadcast::Route) -> bool {
+		let name = self.path.as_path();
+		match route.hops.iter().last() {
+			Some(peer) => fnv_key(&name, [*peer]) < fnv_key(&name, [self.self_origin]),
+			None => true,
+		}
 	}
 
 	/// The active source's route, advertised on the front's broadcast. The caller
@@ -1040,12 +1100,13 @@ fn detach_source(
 	graceful: bool,
 ) {
 	let close = {
+		let carrying = broadcast.is_active();
 		let Ok(mut s) = state.write() else { return };
 		let Some(pos) = s.routes.iter().position(|r| r.id == id) else {
 			return;
 		};
 		s.routes.remove(pos);
-		s.reselect();
+		s.reselect(carrying);
 		if graceful && s.routes.is_empty() && !s.closed {
 			// Deliberate end: close now. The front task observes `closed` and
 			// finishes the teardown (unpublish).
@@ -1092,6 +1153,7 @@ async fn run_source(
 		match source.route_changed().await {
 			Ok(route) => {
 				{
+					let carrying = broadcast.is_active();
 					let Ok(mut s) = state.write() else { return };
 					let Some(entry) = s.routes.iter_mut().find(|r| r.id == id) else {
 						return;
@@ -1100,7 +1162,7 @@ async fn run_source(
 						continue;
 					}
 					entry.route = route;
-					s.reselect();
+					s.reselect(carrying);
 				}
 				sync_front(&state, &broadcast, &leaf);
 			}
@@ -1131,6 +1193,7 @@ fn attach_source(
 	// down, or awaiting teardown) is replaced below instead.
 	if let Some(existing) = &leaf_guard.broadcast {
 		let mut joined = None;
+		let carrying = existing.broadcast.is_active();
 		if let Ok(mut s) = existing.state.write()
 			&& !s.closed
 		{
@@ -1141,7 +1204,7 @@ fn attach_source(
 				route: route.clone(),
 				source: source.clone(),
 			});
-			s.reselect();
+			s.reselect(carrying);
 			joined = Some(id);
 		}
 		if let Some(id) = joined {
@@ -1159,6 +1222,7 @@ fn attach_source(
 	let _ = broadcast.clone().set_route(route.clone());
 	let state = kio::Producer::new(FrontState {
 		path: full.clone(),
+		self_origin: origin.id,
 		next_route: 1,
 		routes: vec![FrontRoute {
 			id: 0,
@@ -2195,6 +2259,125 @@ mod tests {
 		broadcast::Route::new().with_announce(true)
 	}
 
+	/// The first origin whose handover key for `name` sits above (`true`) or below
+	/// (`false`) the peer's, so tests exercising the carrying gate are
+	/// deterministic instead of hinging on a random id winning a hash comparison.
+	/// Starts searching above the small ids the tests use in hop chains, so the
+	/// result never collides with a hop (a looping chain trips a debug_assert).
+	fn origin_keyed(name: &str, peer: Origin, above: bool) -> Origin {
+		let name = Path::new(name);
+		let peer_key = fnv_key(&name, [peer]);
+		(100u64..)
+			.map(|id| Origin::new(id).unwrap())
+			.find(|origin| (fnv_key(&name, [*origin]) > peer_key) == above)
+			.unwrap()
+	}
+
+	/// A front table for reselect tests: routes get ids in order, the first is
+	/// the incumbent.
+	fn front_state(self_origin: Origin, routes: Vec<broadcast::Route>) -> FrontState {
+		let source = broadcast::Info::new().produce().consume();
+		FrontState {
+			path: Path::new("test").to_owned(),
+			self_origin,
+			next_route: routes.len() as u64,
+			routes: routes
+				.into_iter()
+				.enumerate()
+				.map(|(id, route)| FrontRoute {
+					id: id as u64,
+					route,
+					source: source.clone(),
+				})
+				.collect(),
+			active: Some(0),
+			closed: false,
+		}
+	}
+
+	/// A route as a warm sibling would announce it: zero cost, chain ending at
+	/// the announcing peer.
+	fn sibling_route(peer: Origin) -> broadcast::Route {
+		let hops = OriginList::try_from(vec![Origin::new(90).unwrap(), peer]).unwrap();
+		announce().with_hops(hops)
+	}
+
+	/// A route as the upstream announces it: priced, one hop.
+	fn upstream_route(cost: u64) -> broadcast::Route {
+		let hops = OriginList::try_from(vec![Origin::new(90).unwrap()]).unwrap();
+		announce().with_hops(hops).with_cost(cost)
+	}
+
+	/// While carrying, a strictly cheaper route from a peer that hashes above us
+	/// must not displace the incumbent; the same table re-parents freely once
+	/// idle, or when the peer hashes below us.
+	#[test]
+	fn test_carrying_gate_keys() {
+		let peer = Origin::new(3).unwrap();
+
+		// We lose the key comparison: stay put while carrying, migrate when idle.
+		let mut lost = front_state(
+			origin_keyed("test", peer, false),
+			vec![upstream_route(10), sibling_route(peer)],
+		);
+		lost.reselect(true);
+		assert_eq!(
+			lost.active,
+			Some(0),
+			"carrying front re-parented onto a higher-keyed peer"
+		);
+		lost.reselect(false);
+		assert_eq!(lost.active, Some(1), "idle front must take the cheaper route");
+
+		// We win the key comparison: re-parent even while carrying.
+		let mut won = front_state(
+			origin_keyed("test", peer, true),
+			vec![upstream_route(10), sibling_route(peer)],
+		);
+		won.reselect(true);
+		assert_eq!(won.active, Some(1), "carrying front must follow a lower-keyed peer");
+	}
+
+	/// The simultaneous-activation race: two relays that each pulled the same
+	/// broadcast independently see each other's zero-cost route. Exactly one of
+	/// them re-parents; the other keeps its upstream, so the broadcast is never
+	/// left without a source.
+	#[test]
+	fn test_carrying_gate_symmetric_race() {
+		let a = Origin::new(1).unwrap();
+		let b = Origin::new(2).unwrap();
+
+		let mut a_view = front_state(a, vec![upstream_route(10), sibling_route(b)]);
+		let mut b_view = front_state(b, vec![upstream_route(10), sibling_route(a)]);
+		a_view.reselect(true);
+		b_view.reselect(true);
+
+		let a_moved = a_view.active == Some(1);
+		let b_moved = b_view.active == Some(1);
+		assert!(
+			a_moved != b_moved,
+			"exactly one side must re-parent (a: {a_moved}, b: {b_moved})"
+		);
+	}
+
+	/// The gate only protects an announced incumbent: one that lost its announce
+	/// (the upstream retracted) is displaced regardless of the key comparison.
+	#[test]
+	fn test_carrying_gate_ignores_unannounced_incumbent() {
+		let peer = Origin::new(3).unwrap();
+		let unannounced = upstream_route(10).with_announce(false);
+		let mut state = front_state(
+			origin_keyed("test", peer, false),
+			vec![unannounced, sibling_route(peer)],
+		);
+		state.reselect(true);
+		assert_eq!(
+			state.active,
+			Some(1),
+			"an unannounced incumbent must always be displaced"
+		);
+	}
+
 	/// Let the spawned origin tasks (source watchers, front dispatch) run. The
 	/// tests pause tokio time, so this advances the clock without reaching the
 	/// 5-second failure linger.
@@ -2461,7 +2644,10 @@ mod tests {
 	async fn test_route_cost_update() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		// The takeover happens while a subscriber is live (carrying), so the local
+		// origin must win the handover key comparison against B's announcing hop
+		// (origin 3); a random id would flake on the hash.
+		let origin = Info::new(origin_keyed("test", Origin::new(3).unwrap(), true)).produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1006,17 +1006,22 @@ impl FrontState {
 	}
 
 	/// Re-pick the active source after the table changed. Serve tasks watch
-	/// `active` and re-splice on their own.
+	/// `active` and re-splice on their own, so a cheaper route takes over
+	/// seamlessly at a group boundary.
 	///
-	/// `carrying` is whether the front currently has live demand (the spliced
-	/// broadcast is active). While it does, a strictly cheaper announced route may
-	/// only displace an announced incumbent when [`Self::handover_allowed`] says
-	/// so. This is the symmetry break for the simultaneous-activation race: two
-	/// nodes that each pulled the broadcast before seeing the other both advertise
-	/// zero cost, so each sees the other as cheaper than its own source. Without
-	/// the gate both re-parent at once and the broadcast is left with no upstream
-	/// at all; with it, exactly one moves (make-before-break via the usual splice)
-	/// and the other keeps its source.
+	/// The one exception is the simultaneous-activation race: two nodes that
+	/// each pulled the broadcast before seeing the other both advertise zero
+	/// cost, so each sees the other as cheaper than its own source, and
+	/// re-parenting onto each other at once leaves the broadcast with no
+	/// upstream at all. That hazard only exists when both sides are actively
+	/// carrying, so the gate is scoped to exactly that: while `carrying` (the
+	/// front has live demand), a cheaper route whose announcing relay is itself
+	/// carrying (it advertised zero from a chain of two or more hops; a chain of
+	/// one is the original publisher, which can never adopt a route to its own
+	/// broadcast) displaces an announced incumbent only when
+	/// [`Self::handover_allowed`] says so. Every other cheaper route, e.g. a
+	/// forwarder path or an upstream that repriced itself down, is taken
+	/// immediately.
 	fn reselect(&mut self, carrying: bool) {
 		let best = self.best_route();
 		if carrying
@@ -1026,9 +1031,11 @@ impl FrontState {
 			&& let Some(incumbent) = self.routes.iter().find(|r| r.id == cur_id)
 			&& incumbent.route.announce
 			&& candidate.route.cost < incumbent.route.cost
+			&& candidate.route.advertised == 0
+			&& candidate.route.hops.len() >= 2
 			&& !self.handover_allowed(&candidate.route)
 		{
-			// We lost the key comparison: stay put and let the peer come to us.
+			// We won the key comparison: keep our source and let the peer come to us.
 			return;
 		}
 		self.active = best;
@@ -2357,6 +2364,37 @@ mod tests {
 		assert!(
 			a_moved != b_moved,
 			"exactly one side must re-parent (a: {a_moved}, b: {b_moved})"
+		);
+	}
+
+	/// The gate is scoped to warm siblings: a cheaper route via a relay that is
+	/// not itself carrying (advertised nonzero), or directly from the original
+	/// publisher (single-hop chain), is taken immediately even while carrying
+	/// and even when we would lose the key comparison.
+	#[test]
+	fn test_carrying_switches_to_benign_routes() {
+		let peer = Origin::new(3).unwrap();
+		let lost = origin_keyed("test", peer, false);
+
+		// A cheaper forwarder path: the relay advertised its accumulated cost.
+		let mut forwarder = sibling_route(peer).with_cost(4);
+		forwarder.advertised = 4;
+		let mut state = front_state(lost, vec![upstream_route(10), forwarder]);
+		state.reselect(true);
+		assert_eq!(
+			state.active,
+			Some(1),
+			"a cheaper forwarder path must win while carrying"
+		);
+
+		// Directly from the original publisher: single-hop chain, advertised zero.
+		let direct = announce().with_hops(OriginList::try_from(vec![peer]).unwrap());
+		let mut state = front_state(lost, vec![upstream_route(10), direct]);
+		state.reselect(true);
+		assert_eq!(
+			state.active,
+			Some(1),
+			"a direct publisher route must win while carrying"
 		);
 	}
 

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1107,7 +1107,7 @@ fn detach_source(
 	graceful: bool,
 ) {
 	let close = {
-		let carrying = broadcast.is_active();
+		let carrying = broadcast.demand().is_used();
 		let Ok(mut s) = state.write() else { return };
 		let Some(pos) = s.routes.iter().position(|r| r.id == id) else {
 			return;
@@ -1160,7 +1160,7 @@ async fn run_source(
 		match source.route_changed().await {
 			Ok(route) => {
 				{
-					let carrying = broadcast.is_active();
+					let carrying = broadcast.demand().is_used();
 					let Ok(mut s) = state.write() else { return };
 					let Some(entry) = s.routes.iter_mut().find(|r| r.id == id) else {
 						return;
@@ -1200,7 +1200,7 @@ fn attach_source(
 	// down, or awaiting teardown) is replaced below instead.
 	if let Some(existing) = &leaf_guard.broadcast {
 		let mut joined = None;
-		let carrying = existing.broadcast.is_active();
+		let carrying = existing.broadcast.demand().is_used();
 		if let Ok(mut s) = existing.state.write()
 			&& !s.closed
 		{

--- a/rs/moq-net/src/model/requests.rs
+++ b/rs/moq-net/src/model/requests.rs
@@ -107,7 +107,6 @@ impl<K: Clone + Eq + Hash, V> Requests<K, V> {
 	}
 
 	/// Returns `true` when nothing is pending, queued or handed out.
-	#[cfg(test)]
 	pub fn is_empty(&self) -> bool {
 		self.pending.is_empty()
 	}

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -253,6 +253,18 @@ impl Producer {
 	pub fn is_used(&self) -> bool {
 		self.state.is_used()
 	}
+
+	/// Park `waiter` for the next consumer appearing; a no-op once one exists.
+	/// Feeds [`crate::broadcast::Demand`], which recomputes on wake.
+	pub(crate) fn poll_used(&self, waiter: &kio::Waiter) {
+		let _ = self.state.poll_used(waiter);
+	}
+
+	/// Park `waiter` for the last consumer going away; a no-op once none remain.
+	/// Feeds [`crate::broadcast::Demand`].
+	pub(crate) fn poll_unused(&self, waiter: &kio::Waiter) {
+		let _ = self.state.poll_unused(waiter);
+	}
 }
 
 /// A cheap, cloneable read handle for a spliced logical track.

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -245,6 +245,14 @@ impl Producer {
 			state: self.state.consume(),
 		}
 	}
+
+	/// Whether any read handle for the logical track currently exists.
+	///
+	/// This is the demand signal: a spliced track with no consumers is cached
+	/// state nobody is watching.
+	pub fn is_used(&self) -> bool {
+		self.state.is_used()
+	}
 }
 
 /// A cheap, cloneable read handle for a spliced logical track.

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1242,6 +1242,24 @@ impl TrackWeak {
 	pub(crate) fn name(&self) -> &Arc<str> {
 		&self.name
 	}
+
+	/// Whether anyone is consuming the track right now. A closed track doesn't
+	/// count even if consumers linger to drain its cache: no new work is owed.
+	pub(crate) fn is_used(&self) -> bool {
+		!self.state.is_closed() && self.state.is_used()
+	}
+
+	/// Park `waiter` for the next consumer appearing; a no-op once one exists.
+	/// Feeds [`crate::broadcast::Demand`], which recomputes on wake.
+	pub(crate) fn poll_used(&self, waiter: &kio::Waiter) {
+		let _ = self.state.poll_used(waiter);
+	}
+
+	/// Park `waiter` for the last consumer (or the track) going away; a no-op
+	/// once none remain. Feeds [`crate::broadcast::Demand`].
+	pub(crate) fn poll_unused(&self, waiter: &kio::Waiter) {
+		let _ = self.state.poll_unused(waiter);
+	}
 }
 
 impl super::WeakEntry for TrackWeak {

--- a/rs/moq-net/src/model/weak_cache.rs
+++ b/rs/moq-net/src/model/weak_cache.rs
@@ -124,6 +124,15 @@ where
 		self.map.contains_key(key)
 	}
 
+	/// True if any cached handle is still live (its channel hasn't closed).
+	///
+	/// O(entries), so call it off the hot path: the relay probes it on a coarse
+	/// tick to decide whether a broadcast is still actively flowing. Closed
+	/// entries that GC hasn't reclaimed yet are correctly ignored.
+	pub fn has_live(&self) -> bool {
+		self.map.values().any(|v| !v.is_closed())
+	}
+
 	/// Probe a bounded, rotating window of the ring, reclaiming dead entries.
 	fn gc(&mut self) {
 		for _ in 0..self.ring.len().min(GC_PROBE) {

--- a/rs/moq-net/src/model/weak_cache.rs
+++ b/rs/moq-net/src/model/weak_cache.rs
@@ -124,13 +124,10 @@ where
 		self.map.contains_key(key)
 	}
 
-	/// True if any cached handle is still live (its channel hasn't closed).
-	///
-	/// O(entries), so call it off the hot path: the relay probes it on a coarse
-	/// tick to decide whether a broadcast is still actively flowing. Closed
-	/// entries that GC hasn't reclaimed yet are correctly ignored.
-	pub fn has_live(&self) -> bool {
-		self.map.values().any(|v| !v.is_closed())
+	/// Iterate the cached handles, including closed entries GC hasn't reclaimed
+	/// yet (callers filter on liveness themselves).
+	pub fn iter(&self) -> impl Iterator<Item = &V> {
+		self.map.values()
 	}
 
 	/// Probe a bounded, rotating window of the ring, reclaiming dead entries.

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -413,7 +413,7 @@ impl<S: web_transport_trait::Session> Request<S> {
 					path: None,
 					role: None,
 					// The dialing side prices the link; we charge what its SETUP declared.
-					link_cost: None,
+					cost: None,
 				};
 				let start = lite::start(
 					session.clone(),
@@ -654,7 +654,7 @@ mod tests {
 			probe: lite::ProbeLevel::None,
 			path: path.map(str::to_string),
 			role,
-			link_cost: None,
+			cost: None,
 		}
 		.encode(&mut buf, v)
 		.unwrap();

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -412,6 +412,8 @@ impl<S: web_transport_trait::Session> Request<S> {
 					probe: lite::ProbeLevel::Report,
 					path: None,
 					role: None,
+					// The dialing side prices the link; we charge what its SETUP declared.
+					link_cost: None,
 				};
 				let start = lite::start(
 					session.clone(),
@@ -652,6 +654,7 @@ mod tests {
 			probe: lite::ProbeLevel::None,
 			path: path.map(str::to_string),
 			role,
+			link_cost: None,
 		}
 		.encode(&mut buf, v)
 		.unwrap();

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -254,6 +254,13 @@ pub struct ClusterConfig {
 	/// `https://host/?jwt=TOKEN`; a bare host or `host:port` is deprecated but
 	/// still accepted (wrapped in `https://.../`). Accepts a comma-separated list
 	/// on the CLI or repeat the flag; in config files use a TOML array.
+	///
+	/// A `?link_cost=N` query param prices the link (moq-lite-06+): every
+	/// announcement crossing it adds `N` to its route cost, so routing prefers
+	/// cheap paths over short ones. Use `0` for a same-datacenter sibling and
+	/// something large for a metered backbone; an unpriced link costs 1, which
+	/// reproduces plain hop counting. The param is consumed by this relay, not
+	/// sent to the peer.
 	#[serde(alias = "connect")]
 	#[arg(
 		id = "cluster-connect",
@@ -829,6 +836,13 @@ impl Cluster {
 	#[tracing::instrument("remote", skip_all, err, fields(%remote))]
 	async fn run_remote(self, remote: &str, token: String) -> anyhow::Result<()> {
 		let mut url = peer_url(remote)?;
+		// The link's price, declared by us as the dialing side and charged to
+		// every announcement crossing the connection (see
+		// `moq_net::Client::with_link_cost`). Carried as a `?link_cost=` query
+		// param on the peer URL so static lists, gossip, and connect-api feeds can
+		// each price their links: 0 for a same-datacenter sibling, higher for a
+		// metered backbone. Stripped here; the value rides SETUP, not the URL.
+		let link_cost = take_link_cost(&mut url)?;
 		// Apply the shared cluster token unless the URL already carries its own
 		// non-empty `?jwt=` (an inline token on a static `connect` peer wins; the
 		// shared token still covers discovered peers that have none). An empty
@@ -848,7 +862,7 @@ impl Cluster {
 
 		loop {
 			let started = tokio::time::Instant::now();
-			let result = self.run_remote_once(&url).await;
+			let result = self.run_remote_once(&url, link_cost).await;
 			let elapsed = started.elapsed();
 
 			match result {
@@ -867,7 +881,7 @@ impl Cluster {
 		}
 	}
 
-	async fn run_remote_once(&self, url: &Url) -> anyhow::Result<()> {
+	async fn run_remote_once(&self, url: &Url, link_cost: Option<u64>) -> anyhow::Result<()> {
 		let mut log_url = url.clone();
 		log_url.set_query(None);
 		tracing::info!(url = %log_url, "dialing cluster peer");
@@ -879,16 +893,53 @@ impl Cluster {
 			.context("internal: cluster peer dial without an attached QUIC client")?;
 
 		// Cluster dials use their configured stats tier.
-		let cs = client
+		let mut client = client
 			.with_publisher(&self.origin)
 			.with_subscriber(self.origin.clone())
-			.with_stats(self.stats.tier(self.cluster_tier()))
+			.with_stats(self.stats.tier(self.cluster_tier()));
+		if let Some(cost) = link_cost {
+			client = client.with_link_cost(cost);
+		}
+		let cs = client
 			.connect(url.clone())
 			.await
 			.context("failed to connect to cluster peer")?;
 
 		Err(cs.closed().await.into())
 	}
+}
+
+/// Extract and remove the `link_cost` query param from a peer URL.
+///
+/// The param is dial-side configuration, not something the peer reads off the
+/// URL (it rides SETUP instead), so it is stripped before connecting. An
+/// unparseable value is an error rather than a silent default: a mispriced link
+/// skews routing for every broadcast crossing it.
+fn take_link_cost(url: &mut Url) -> anyhow::Result<Option<u64>> {
+	let Some(value) = url
+		.query_pairs()
+		.find_map(|(key, value)| (key == "link_cost").then(|| value.into_owned()))
+	else {
+		return Ok(None);
+	};
+	let cost: u64 = value
+		.parse()
+		.with_context(|| format!("invalid link_cost {value:?} on cluster peer URL"))?;
+
+	let remaining: Vec<(String, String)> = url
+		.query_pairs()
+		.filter(|(key, _)| key != "link_cost")
+		.map(|(key, value)| (key.into_owned(), value.into_owned()))
+		.collect();
+	url.set_query(None);
+	if !remaining.is_empty() {
+		let mut pairs = url.query_pairs_mut();
+		for (key, value) in &remaining {
+			pairs.append_pair(key, value);
+		}
+	}
+
+	Ok(Some(cost))
 }
 
 /// Whether a `--cluster-connect-api` source is an http(s) URL (otherwise it's
@@ -963,6 +1014,23 @@ where
 mod tests {
 	use super::*;
 	use crate::Config;
+
+	/// `?link_cost=` is read and stripped (it rides SETUP, not the URL), other
+	/// query params survive, and a garbage value is an error rather than a
+	/// silent default.
+	#[test]
+	fn link_cost_param_is_consumed() {
+		let mut url = Url::parse("https://peer.example/?jwt=abc&link_cost=0").unwrap();
+		assert_eq!(take_link_cost(&mut url).unwrap(), Some(0));
+		assert_eq!(url.as_str(), "https://peer.example/?jwt=abc");
+
+		let mut url = Url::parse("https://peer.example/").unwrap();
+		assert_eq!(take_link_cost(&mut url).unwrap(), None);
+		assert_eq!(url.as_str(), "https://peer.example/");
+
+		let mut url = Url::parse("https://peer.example/?link_cost=cheap").unwrap();
+		assert!(take_link_cost(&mut url).is_err());
+	}
 
 	#[test]
 	fn cluster_tier_defaults_to_unprefixed() {

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -255,7 +255,7 @@ pub struct ClusterConfig {
 	/// still accepted (wrapped in `https://.../`). Accepts a comma-separated list
 	/// on the CLI or repeat the flag; in config files use a TOML array.
 	///
-	/// A `?link_cost=N` query param prices the link (moq-lite-06+): every
+	/// A `?cost=N` query param prices the link (moq-lite-06+): every
 	/// announcement crossing it adds `N` to its route cost, so routing prefers
 	/// cheap paths over short ones. Use `0` for a same-datacenter sibling and
 	/// something large for a metered backbone; an unpriced link costs 1, which
@@ -838,11 +838,11 @@ impl Cluster {
 		let mut url = peer_url(remote)?;
 		// The link's price, declared by us as the dialing side and charged to
 		// every announcement crossing the connection (see
-		// `moq_net::Client::with_link_cost`). Carried as a `?link_cost=` query
+		// `moq_net::Client::with_cost`). Carried as a `?cost=` query
 		// param on the peer URL so static lists, gossip, and connect-api feeds can
 		// each price their links: 0 for a same-datacenter sibling, higher for a
 		// metered backbone. Stripped here; the value rides SETUP, not the URL.
-		let link_cost = take_link_cost(&mut url)?;
+		let cost = take_cost(&mut url)?;
 		// Apply the shared cluster token unless the URL already carries its own
 		// non-empty `?jwt=` (an inline token on a static `connect` peer wins; the
 		// shared token still covers discovered peers that have none). An empty
@@ -862,7 +862,7 @@ impl Cluster {
 
 		loop {
 			let started = tokio::time::Instant::now();
-			let result = self.run_remote_once(&url, link_cost).await;
+			let result = self.run_remote_once(&url, cost).await;
 			let elapsed = started.elapsed();
 
 			match result {
@@ -881,7 +881,7 @@ impl Cluster {
 		}
 	}
 
-	async fn run_remote_once(&self, url: &Url, link_cost: Option<u64>) -> anyhow::Result<()> {
+	async fn run_remote_once(&self, url: &Url, cost: Option<u64>) -> anyhow::Result<()> {
 		let mut log_url = url.clone();
 		log_url.set_query(None);
 		tracing::info!(url = %log_url, "dialing cluster peer");
@@ -897,8 +897,8 @@ impl Cluster {
 			.with_publisher(&self.origin)
 			.with_subscriber(self.origin.clone())
 			.with_stats(self.stats.tier(self.cluster_tier()));
-		if let Some(cost) = link_cost {
-			client = client.with_link_cost(cost);
+		if let Some(cost) = cost {
+			client = client.with_cost(cost);
 		}
 		let cs = client
 			.connect(url.clone())
@@ -909,26 +909,26 @@ impl Cluster {
 	}
 }
 
-/// Extract and remove the `link_cost` query param from a peer URL.
+/// Extract and remove the `cost` query param from a peer URL.
 ///
 /// The param is dial-side configuration, not something the peer reads off the
 /// URL (it rides SETUP instead), so it is stripped before connecting. An
 /// unparseable value is an error rather than a silent default: a mispriced link
 /// skews routing for every broadcast crossing it.
-fn take_link_cost(url: &mut Url) -> anyhow::Result<Option<u64>> {
+fn take_cost(url: &mut Url) -> anyhow::Result<Option<u64>> {
 	let Some(value) = url
 		.query_pairs()
-		.find_map(|(key, value)| (key == "link_cost").then(|| value.into_owned()))
+		.find_map(|(key, value)| (key == "cost").then(|| value.into_owned()))
 	else {
 		return Ok(None);
 	};
 	let cost: u64 = value
 		.parse()
-		.with_context(|| format!("invalid link_cost {value:?} on cluster peer URL"))?;
+		.with_context(|| format!("invalid cost {value:?} on cluster peer URL"))?;
 
 	let remaining: Vec<(String, String)> = url
 		.query_pairs()
-		.filter(|(key, _)| key != "link_cost")
+		.filter(|(key, _)| key != "cost")
 		.map(|(key, value)| (key.into_owned(), value.into_owned()))
 		.collect();
 	url.set_query(None);
@@ -1015,21 +1015,21 @@ mod tests {
 	use super::*;
 	use crate::Config;
 
-	/// `?link_cost=` is read and stripped (it rides SETUP, not the URL), other
+	/// `?cost=` is read and stripped (it rides SETUP, not the URL), other
 	/// query params survive, and a garbage value is an error rather than a
 	/// silent default.
 	#[test]
-	fn link_cost_param_is_consumed() {
-		let mut url = Url::parse("https://peer.example/?jwt=abc&link_cost=0").unwrap();
-		assert_eq!(take_link_cost(&mut url).unwrap(), Some(0));
+	fn cost_param_is_consumed() {
+		let mut url = Url::parse("https://peer.example/?jwt=abc&cost=0").unwrap();
+		assert_eq!(take_cost(&mut url).unwrap(), Some(0));
 		assert_eq!(url.as_str(), "https://peer.example/?jwt=abc");
 
 		let mut url = Url::parse("https://peer.example/").unwrap();
-		assert_eq!(take_link_cost(&mut url).unwrap(), None);
+		assert_eq!(take_cost(&mut url).unwrap(), None);
 		assert_eq!(url.as_str(), "https://peer.example/");
 
-		let mut url = Url::parse("https://peer.example/?link_cost=cheap").unwrap();
-		assert!(take_link_cost(&mut url).is_err());
+		let mut url = Url::parse("https://peer.example/?cost=cheap").unwrap();
+		assert!(take_cost(&mut url).is_err());
 	}
 
 	#[test]


### PR DESCRIPTION
Routing today ranks candidate routes by hop count, which is blind to what a link costs and to which candidate already carries the media. Two relays in one datacenter each pull the same broadcast over a metered backbone, because the via-sibling route is +1 hop and shortest-hop routing never picks it. The same blindness applies to expensive work: a transcoder pool has no way to say "one of us is already transcoding this, route to it" versus "any of us could, pick one".

## The cost model

`Route.cost` becomes the cumulative cost of the transfers (and work) a subscription via that route would newly cause, and rides lite-06 announcements as a single varint:

- The original publisher seeds its production cost: zero for a live publish, something large for a standby (a cold transcoder pool announces every broadcast it could serve at, say, 1000; the existing name+hop hash tie-break then elects the same standby on every node, spreading broadcasts across the pool).
- Each link adds its configured price as the announcement crosses it (new SETUP `Cost` parameter, id 0x4; the dialing side declares it and both ends charge the same amount; unpriced links cost 1, which reproduces hop counting exactly).
- The accumulation restarts at zero at any node **actively carrying** the broadcast: those upstream legs already exist and are not re-paid by one more subscriber. This one rule covers both relay cache dedup (a warm sibling beats a second metered fetch) and standby activation (the winning transcoder's cost drops to ~0 once it starts working and snaps back after it stops), with no application code.
- `route_order` keeps its exact prior shape (`!announce, cost, hops.len(), hash`). Pre-lite-06 peers carry no cost and rank exactly as before; equal-cost warm copies resolve by hop length, which also bounds same-datacenter chains to one hop.

"Actively carrying" is exposed as `broadcast::Demand`, the broadcast-level sibling of `track::Demand`: a watch-only weak handle from `Producer::demand()` with `is_used()` plus `used()`/`unused()` edges (and `poll_*` variants). Demand means subscriber interest: a subscribed spliced track on a relay front, or a pending request / consumed track on an ordinary broadcast (a publisher producing into the void is not a warm copy worth routing to). The consumer counts live on per-track channels whose flips never write the broadcast state, so `Demand` parks the waiter across every channel feeding the answer.

The announce loop waits on exactly the transition it cares about, watching `unused` while advertising zero and `used` while advertising cold, with no polling tick. Activation re-prices immediately; decay keeps a deliberate 5s linger (demand returning within the window cancels the restore), so viewer churn does not flap routing across the mesh.

## The simultaneous-activation race

Two relays that independently pulled the same broadcast both advertise zero, each sees the other as cheaper than its own source, and re-parenting onto each other simultaneously leaves the broadcast with no upstream at all (the reflected-announce check then breaks the cycle, both revert, and the attraction repeats: a stall/resume oscillation at announce-RTT cadence).

The fix is a deterministic tie-break scoped to exactly that hazard. While a front is carrying, a strictly cheaper route whose announcing relay is *itself carrying* (it advertised zero from a chain of two or more hops; a single-hop chain is the original publisher, which can never adopt a route to its own broadcast) only displaces an announced incumbent if the peer's build-stable FNV key for the broadcast is below ours. Both sides compute the same pair, exactly one re-parents (seamlessly, at a group boundary via the existing splice), and the loser's restarted announcement carries the winner in its chain, so the reflected-announce check removes the residual attraction. Every other cheaper route, e.g. a forwarder path or an upstream that repriced itself down, is taken immediately. The pre-charge cost needed to recognize a warm peer is kept on the route as a crate-private `advertised` field.

`OriginList` remains the authority on loop freedom; the key only prevents the transient double-switch.

## Config

Cluster peer URLs price their links with a `?cost=N` query param, composing with static lists, gossip, and `connect_api` feeds:

```toml
[cluster]
connect = [
  "https://sibling.same-dc.example/?cost=0",
  "https://us-east.example.com/?cost=10",
]
```

The param is consumed locally (the value rides SETUP, never the URL); a garbage value is a startup error rather than a silent default. `moq_net::Client::with_cost` / `moq_native::Client::with_cost` are the API surface.

## Cross-package sync

- `js/net`: mirrors the wire change (`hasRouteCost`, `cost` on ANNOUNCE_START/RESTART) with round-trip tests. The browser client does not charge links.
- `drafts/draft-lcurley-moq-lite.md`: Route Cost fields on ANNOUNCE_START/RESTART, the SETUP Cost parameter, the tie-break guidance, and changelog entries. Validated with `just drafts check`.
- `doc/bin/relay/cluster.md`: new Link costs section.
- Not run: `just test smoke-full`; the wire change is gated behind the opt-in `moq-lite-06-wip` version, which the smoke matrix does not negotiate.

## Notes for review

- Targets `dev` per the wire-change rule: the feature rides `moq-lite-06-wip` (opt-in, still WIP), extending ANNOUNCE_START/RESTART and adding a SETUP parameter. All Rust/JS API changes are additive.
- Rebased from a `main` base onto `dev`: the one conflict was `detach_source`, where dev's `graceful` teardown gate and this PR's `reselect(carrying)` touch the same lines; the resolution keeps both. Everything else applied clean and the full suite passes on the dev base.
- Supersedes #2179; the `base`+`transit` split from that prototype collapsed into the single cumulative cost above (lexicographic policy-vs-distance turned out unnecessary once the cost is denominated in real units: prices sum).
- Follow-ups worth their own issues: an e2e two-relay test of the race itself, standby announce fan-out (N transcoders x M broadcasts) if it shows up in practice, and re-running reselect when a front's demand drains (today the next route event picks it up).

(written by Fable 5)
