### PR TITLE
refactor(mux): extract shared video-import catalog helper

### DIFF
--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -29,13 +29,7 @@ use crate::container::Frame;
 pub struct Import<E: CatalogExt = ()> {
 	track: crate::container::Producer<crate::catalog::hang::Container>,
 	rendition: crate::catalog::VideoTrack<E>,
-	config: Option<hang::catalog::VideoConfig>,
-	/// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
-	/// overwritten by the rendition's detector.
-	hint: crate::catalog::VideoHint,
-	/// This rendition's timeline section, advertised on every config we publish (the generic
-	/// set() no longer does). Snapshotted at construction; the timeline track is 1:1 by name.
-	timeline: hang::catalog::Timeline,
+	catalog: crate::codec::video::Catalog,
 	last_seq: Option<Bytes>,
 }
 
@@ -51,18 +45,16 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> Self {
 		let rendition = reserved.video(track.name());
-		let timeline = reserved.producer().timeline(track.name()).section();
+		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint);
 		let mut import = Self {
 			track: reserved
 				.producer()
 				.media_producer(track, crate::catalog::hang::Container::Legacy),
 			rendition,
-			config: None,
-			hint,
-			timeline,
+			catalog,
 			last_seq: None,
 		};
-		if let Some(config) = import.hint.to_config() {
+		if let Some(config) = import.catalog.initial_config() {
 			import.apply_config(config);
 		}
 		import
@@ -180,15 +172,8 @@ impl<E: CatalogExt> Import<E> {
 	///
 	/// A changed config just re-mirrors the rendition; there are no fixed tracks
 	/// to reject a reconfiguration.
-	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
-		self.hint.apply(&mut config);
-		config.timeline = Some(self.timeline.clone());
-		if self.config.as_ref() == Some(&config) {
-			return;
-		}
-		tracing::debug!(name = ?self.track.name(), ?config, "starting track");
-		self.rendition.set(config.clone());
-		self.config = Some(config);
+	fn apply_config(&mut self, config: hang::catalog::VideoConfig) {
+		self.catalog.publish(&mut self.rendition, config);
 	}
 
 	/// Resolve the config from a sequence-header OBU, falling back to a minimal
@@ -205,7 +190,7 @@ impl<E: CatalogExt> Import<E> {
 
 		match SequenceHeaderObu::parse(header, &mut &seq_obu[payload_offset..]) {
 			Ok(seq_header) => self.init(&seq_header),
-			Err(_) if self.config.is_none() => {
+			Err(_) if !self.catalog.configured() => {
 				tracing::debug!("sequence header parse failed, using minimal config");
 				self.init_minimal();
 			}
@@ -257,7 +242,7 @@ impl<E: CatalogExt> Import<E> {
 			}
 
 			// A keyframe we couldn't configure (no sequence header) is undecodable.
-			if frame.keyframe && self.config.is_none() {
+			if frame.keyframe && !self.catalog.configured() {
 				return Err(Error::MissingSequenceHeader.into());
 			}
 

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -32,13 +32,7 @@ pub struct Import<E: CatalogExt = ()> {
 	avc1: bool,
 	track: crate::container::Producer<crate::catalog::hang::Container>,
 	rendition: crate::catalog::VideoTrack<E>,
-	config: Option<hang::catalog::VideoConfig>,
-	/// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
-	/// overwritten by the rendition's detector.
-	hint: crate::catalog::VideoHint,
-	/// This rendition's timeline section, advertised on every config we publish (the generic
-	/// set() no longer does). Snapshotted at construction; the timeline track is 1:1 by name.
-	timeline: hang::catalog::Timeline,
+	catalog: crate::codec::video::Catalog,
 	last_sps: Option<Bytes>,
 }
 
@@ -54,19 +48,17 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> Self {
 		let rendition = reserved.video(track.name());
-		let timeline = reserved.producer().timeline(track.name()).section();
+		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint);
 		let mut import = Self {
 			avc1: false,
 			track: reserved
 				.producer()
 				.media_producer(track, crate::catalog::hang::Container::Legacy),
 			rendition,
-			config: None,
-			hint,
-			timeline,
+			catalog,
 			last_sps: None,
 		};
-		if let Some(config) = import.hint.to_config() {
+		if let Some(config) = import.catalog.initial_config() {
 			import.apply_config(config);
 		}
 		import
@@ -202,15 +194,8 @@ impl<E: CatalogExt> Import<E> {
 	///
 	/// A changed config (new avcC, or a new inline SPS) just re-mirrors the
 	/// rendition; there are no fixed tracks to reject a reconfiguration.
-	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
-		self.hint.apply(&mut config);
-		config.timeline = Some(self.timeline.clone());
-		if self.config.as_ref() == Some(&config) {
-			return;
-		}
-		tracing::debug!(?config, "starting H.264 track");
-		self.rendition.set(config.clone());
-		self.config = Some(config);
+	fn apply_config(&mut self, config: hang::catalog::VideoConfig) {
+		self.catalog.publish(&mut self.rendition, config);
 	}
 
 	/// Write split frames to the track, resolving the avc3 config from the first
@@ -226,7 +211,7 @@ impl<E: CatalogExt> Import<E> {
 				self.configure_from_sps(&sps)?;
 			}
 
-			if self.config.is_none() {
+			if !self.catalog.configured() {
 				// A keyframe we still can't configure is undecodable, so bail
 				// loudly. A non-keyframe before config is a mid-stream-join
 				// leftover: write it through, and the producer reports

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -31,13 +31,7 @@ use crate::container::Frame;
 pub struct Import<E: CatalogExt = ()> {
 	track: crate::container::Producer<crate::catalog::hang::Container>,
 	rendition: crate::catalog::VideoTrack<E>,
-	config: Option<hang::catalog::VideoConfig>,
-	/// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
-	/// overwritten by the rendition's detector.
-	hint: crate::catalog::VideoHint,
-	/// This rendition's timeline section, advertised on every config we publish (the generic
-	/// set() no longer does). Snapshotted at construction; the timeline track is 1:1 by name.
-	timeline: hang::catalog::Timeline,
+	catalog: crate::codec::video::Catalog,
 	last_sps: Option<Bytes>,
 }
 
@@ -53,18 +47,16 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> Self {
 		let rendition = reserved.video(track.name());
-		let timeline = reserved.producer().timeline(track.name()).section();
+		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint);
 		let mut import = Self {
 			track: reserved
 				.producer()
 				.media_producer(track, crate::catalog::hang::Container::Legacy),
 			rendition,
-			config: None,
-			hint,
-			timeline,
+			catalog,
 			last_sps: None,
 		};
-		if let Some(config) = import.hint.to_config() {
+		if let Some(config) = import.catalog.initial_config() {
 			import.apply_config(config);
 		}
 		import
@@ -172,15 +164,8 @@ impl<E: CatalogExt> Import<E> {
 	///
 	/// A changed config just re-mirrors the rendition; there are no fixed tracks to reject a
 	/// reconfiguration.
-	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
-		self.hint.apply(&mut config);
-		config.timeline = Some(self.timeline.clone());
-		if self.config.as_ref() == Some(&config) {
-			return;
-		}
-		tracing::debug!(name = ?self.track.name(), ?config, "starting track");
-		self.rendition.set(config.clone());
-		self.config = Some(config);
+	fn apply_config(&mut self, config: hang::catalog::VideoConfig) {
+		self.catalog.publish(&mut self.rendition, config);
 	}
 
 	/// Write split frames to the track, resolving the config from the first
@@ -194,7 +179,7 @@ impl<E: CatalogExt> Import<E> {
 			}
 
 			// A keyframe we still can't configure (no SPS) is undecodable.
-			if frame.keyframe && self.config.is_none() {
+			if frame.keyframe && !self.catalog.configured() {
 				return Err(Error::MissingSps.into());
 			}
 

--- a/rs/moq-mux/src/codec/mod.rs
+++ b/rs/moq-mux/src/codec/mod.rs
@@ -18,5 +18,6 @@ pub(crate) mod legacy;
 pub(crate) mod mp2;
 pub mod mp3;
 pub mod opus;
+pub(crate) mod video;
 pub mod vp8;
 pub mod vp9;

--- a/rs/moq-mux/src/codec/video.rs
+++ b/rs/moq-mux/src/codec/video.rs
@@ -26,7 +26,7 @@ pub(crate) struct Catalog {
 
 impl Catalog {
 	/// Snapshot the timeline for the rendition named `name`, and hold `hint` for every publish.
-	pub(crate) fn new<E: CatalogExt>(reserved: &Reserved<E>, name: &str, hint: VideoHint) -> Self {
+	pub(crate) fn new(reserved: &Reserved<impl CatalogExt>, name: &str, hint: VideoHint) -> Self {
 		Self {
 			timeline: reserved.producer().timeline(name).section(),
 			hint,
@@ -49,9 +49,9 @@ impl Catalog {
 	/// Overlay the hint and timeline onto `config` and publish it to `rendition`, unless it matches
 	/// the last publish. A changed config just re-mirrors the rendition; there are no fixed tracks to
 	/// reject a reconfiguration.
-	pub(crate) fn publish<E: CatalogExt>(
+	pub(crate) fn publish(
 		&mut self,
-		rendition: &mut VideoTrack<E>,
+		rendition: &mut VideoTrack<impl CatalogExt>,
 		mut config: hang::catalog::VideoConfig,
 	) {
 		self.hint.apply(&mut config);

--- a/rs/moq-mux/src/codec/video.rs
+++ b/rs/moq-mux/src/codec/video.rs
@@ -1,0 +1,66 @@
+//! Shared catalog-publishing logic for the video codec importers.
+//!
+//! Every video importer resolves its [`VideoConfig`](hang::catalog::VideoConfig) lazily from the
+//! bitstream and re-publishes it whenever the stream reveals a change. [`Catalog`] owns the part of
+//! that which is identical across codecs: overlay the caller's [`VideoHint`], advertise the
+//! rendition's timeline, and skip a publish that matches the last one. The rendition itself stays a
+//! separate field on the importer, since each drives its frame recording (`record_*`) directly.
+
+use crate::catalog::hang::CatalogExt;
+use crate::catalog::{Reserved, VideoHint, VideoTrack};
+
+/// The catalog-publishing state a video importer overlays onto every config it resolves.
+///
+/// Holds the caller's hint, the rendition's advertised timeline section, and the last config
+/// published (to dedupe re-publishes). Not generic over the extension: none of these depend on it.
+pub(crate) struct Catalog {
+	/// Overlaid onto every config, so a hinted field counts as supplied and is never overwritten by
+	/// the rendition's detector.
+	hint: VideoHint,
+	/// The rendition's timeline section, advertised on every config (the generic `set()` no longer
+	/// does). Snapshotted at construction; the timeline track is 1:1 by name.
+	timeline: hang::catalog::Timeline,
+	/// The last config published, so an unchanged re-resolve doesn't re-mirror the rendition.
+	last: Option<hang::catalog::VideoConfig>,
+}
+
+impl Catalog {
+	/// Snapshot the timeline for the rendition named `name`, and hold `hint` for every publish.
+	pub(crate) fn new<E: CatalogExt>(reserved: &Reserved<E>, name: &str, hint: VideoHint) -> Self {
+		Self {
+			timeline: reserved.producer().timeline(name).section(),
+			hint,
+			last: None,
+		}
+	}
+
+	/// The config the hint alone resolves to, for importers that publish the catalog before parsing
+	/// the stream (a hint carrying a codec). `None` if the hint lacks a codec. See [`VideoHint::to_config`].
+	pub(crate) fn initial_config(&self) -> Option<hang::catalog::VideoConfig> {
+		self.hint.to_config()
+	}
+
+	/// Whether a config has been published yet, so an importer can tell a still-unconfigured stream
+	/// (an undecodable keyframe, a mid-join leftover) from a resolved one.
+	pub(crate) fn configured(&self) -> bool {
+		self.last.is_some()
+	}
+
+	/// Overlay the hint and timeline onto `config` and publish it to `rendition`, unless it matches
+	/// the last publish. A changed config just re-mirrors the rendition; there are no fixed tracks to
+	/// reject a reconfiguration.
+	pub(crate) fn publish<E: CatalogExt>(
+		&mut self,
+		rendition: &mut VideoTrack<E>,
+		mut config: hang::catalog::VideoConfig,
+	) {
+		self.hint.apply(&mut config);
+		config.timeline = Some(self.timeline.clone());
+		if self.last.as_ref() == Some(&config) {
+			return;
+		}
+		tracing::debug!(name = ?rendition.name(), ?config, "starting track");
+		rendition.set(config.clone());
+		self.last = Some(config);
+	}
+}

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -17,15 +17,7 @@ pub struct Import<E: CatalogExt = ()> {
 	// This importer's catalog rendition, published on the first key frame.
 	rendition: crate::catalog::VideoTrack<E>,
 
-	// The resolved config, used to detect resolution changes.
-	config: Option<hang::catalog::VideoConfig>,
-
-	// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
-	// overwritten by the rendition's detector.
-	hint: crate::catalog::VideoHint,
-	/// This rendition's timeline section, advertised on every config we publish (the generic
-	/// set() no longer does). Snapshotted at construction; the timeline track is 1:1 by name.
-	timeline: hang::catalog::Timeline,
+	catalog: crate::codec::video::Catalog,
 }
 
 impl<E: CatalogExt> Import<E> {
@@ -40,17 +32,15 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> Self {
 		let rendition = reserved.video(track.name());
-		let timeline = reserved.producer().timeline(track.name()).section();
+		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint);
 		let mut import = Self {
 			track: reserved
 				.producer()
 				.media_producer(track, crate::catalog::hang::Container::Legacy),
 			rendition,
-			config: None,
-			hint,
-			timeline,
+			catalog,
 		};
-		if let Some(config) = import.hint.to_config() {
+		if let Some(config) = import.catalog.initial_config() {
 			import.apply_config(config);
 		}
 		import
@@ -83,15 +73,8 @@ impl<E: CatalogExt> Import<E> {
 	///
 	/// A changed config just re-mirrors the rendition; there are no fixed tracks to reject a
 	/// reconfiguration.
-	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
-		self.hint.apply(&mut config);
-		config.timeline = Some(self.timeline.clone());
-		if self.config.as_ref() == Some(&config) {
-			return;
-		}
-		tracing::debug!(name = ?self.track.name(), ?config, "starting track");
-		self.rendition.set(config.clone());
-		self.config = Some(config);
+	fn apply_config(&mut self, config: hang::catalog::VideoConfig) {
+		self.catalog.publish(&mut self.rendition, config);
 	}
 
 	/// Decode a single VP8 frame.

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -17,15 +17,7 @@ pub struct Import<E: CatalogExt = ()> {
 	// This importer's catalog rendition, published on the first key frame.
 	rendition: crate::catalog::VideoTrack<E>,
 
-	// The resolved config, used to detect resolution / format changes.
-	config: Option<hang::catalog::VideoConfig>,
-
-	// Overlaid onto every config we publish, so a hinted field counts as supplied and is never
-	// overwritten by the rendition's detector.
-	hint: crate::catalog::VideoHint,
-	/// This rendition's timeline section, advertised on every config we publish (the generic
-	/// set() no longer does). Snapshotted at construction; the timeline track is 1:1 by name.
-	timeline: hang::catalog::Timeline,
+	catalog: crate::codec::video::Catalog,
 }
 
 impl<E: CatalogExt> Import<E> {
@@ -40,17 +32,15 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> Self {
 		let rendition = reserved.video(track.name());
-		let timeline = reserved.producer().timeline(track.name()).section();
+		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint);
 		let mut import = Self {
 			track: reserved
 				.producer()
 				.media_producer(track, crate::catalog::hang::Container::Legacy),
 			rendition,
-			config: None,
-			hint,
-			timeline,
+			catalog,
 		};
-		if let Some(config) = import.hint.to_config() {
+		if let Some(config) = import.catalog.initial_config() {
 			import.apply_config(config);
 		}
 		import
@@ -83,15 +73,8 @@ impl<E: CatalogExt> Import<E> {
 	///
 	/// A changed config just re-mirrors the rendition; there are no fixed tracks to reject a
 	/// reconfiguration.
-	fn apply_config(&mut self, mut config: hang::catalog::VideoConfig) {
-		self.hint.apply(&mut config);
-		config.timeline = Some(self.timeline.clone());
-		if self.config.as_ref() == Some(&config) {
-			return;
-		}
-		tracing::debug!(name = ?self.track.name(), ?config, "starting track");
-		self.rendition.set(config.clone());
-		self.config = Some(config);
+	fn apply_config(&mut self, config: hang::catalog::VideoConfig) {
+		self.catalog.publish(&mut self.rendition, config);
 	}
 
 	/// Decode a single VP9 frame (or superframe).


### PR DESCRIPTION
## Summary

Follow-up to #2420 (Sourcery flagged the duplication there; deferred as a focused change).

The five video codec importers (h264, h265, av1, vp8, vp9) each duplicated the same catalog-publishing logic — overlay the caller's `VideoHint`, advertise the timeline section, skip a re-publish matching the last one, remember it — plus the two-line construction (reserve the rendition, snapshot its timeline). Five copies that could drift.

Factored into `codec::video::Catalog`, holding the hint, the timeline section, and the last-published config:

- `publish(&mut rendition, config)` is the single definition of the overlay → dedupe → publish pattern.
- `configured()` exposes the "resolved yet?" state the decode paths query (was `self.config.is_none()`).
- The rendition stays a **separate field** on each importer, so the hot-path frame recording (`record_*`, ~13 call sites) is untouched — the helper takes `&mut rendition` rather than owning it.

Each importer's catalog state goes from three fields (`hint`, `timeline`, `config`) to one, and `apply_config` becomes a one-line delegate.

## Public API

None. `codec::video` is `pub(crate)`; no exported signature changes.

## Behavior

No change, with one trivial exception: the per-codec debug line (`"starting H.264 track"`, etc.) is unified to `"starting track"`. The codec is still in the logged `?config`.

## Test plan

- `cargo test -p moq-mux` — 391 passed
- `cargo clippy -p moq-mux --all-targets` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p moq-mux` — clean
- Rebased onto `main` (post-#2420 merge) and re-verified.

Net −78 lines across the importers for a ~65-line helper.

(Written by Opus 4.8)
