### PR TITLE
fix(moq-mux): emit per-frame fragments without waiting for a successor frame

### DIFF
--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -3,7 +3,7 @@ use std::task::Poll;
 use std::time::Duration;
 
 use bytes::Bytes;
-use hang::catalog::{Catalog, Container, VideoConfig};
+use hang::catalog::{AudioCodec, Catalog, Container, VideoConfig};
 use mp4_atom::{DecodeMaybe, Encode};
 
 use crate::Result;
@@ -86,6 +86,9 @@ struct Fmp4Track {
 
 	/// True if this track is video. Video tracks roll fragments on keyframes.
 	is_video: bool,
+
+	/// True for Opus audio, whose packets carry their duration in the TOC byte.
+	opus: bool,
 
 	/// Fallback duration for a trailing frame that carries no per-sample duration
 	/// (Legacy / LOC sources). Derived from the catalog framerate / sample rate.
@@ -243,11 +246,28 @@ impl<S: Stream> Export<S> {
 
 		if let Some(name) = chosen {
 			let frag = self.fragment_duration;
-			let has_video_track = self.tracks.values().any(|t| t.is_video);
+			// One fragment per frame: a zero cap, or the audio-only default where
+			// no keyframe will ever roll the fragment. These never depend on the
+			// successor, so emit immediately instead of buffering the frame until
+			// the next one flushes it.
+			let has_video = self.tracks.values().any(|t| t.is_video);
+			let per_frame = frag == Some(Duration::ZERO) || (frag.is_none() && !has_video);
 			let track = self.tracks.get_mut(&name).unwrap();
 			let frame = track.pending.take().unwrap();
-			let flush_before = should_flush(track, &frame, frag, has_video_track);
-			if flush_before {
+			if per_frame {
+				// A catalog change can leave buffered frames behind. Drain them
+				// first and retry this frame on the next poll.
+				if !track.buffer.is_empty() {
+					let frames = std::mem::take(&mut track.buffer);
+					let fragment = emit_fragment(track, frames, Some(&frame))?;
+					track.pending = Some(frame);
+					return Poll::Ready(Ok(Some(fragment)));
+				}
+				track.buffer_independent = frame.keyframe;
+				let fragment = emit_fragment(track, vec![frame], None)?;
+				return Poll::Ready(Ok(Some(fragment)));
+			}
+			if should_flush(track, &frame, frag) {
 				let frames = std::mem::take(&mut track.buffer);
 				let fragment = emit_fragment(track, frames, Some(&frame))?;
 				// The flushed run is done; the incoming frame opens the next buffer.
@@ -330,6 +350,7 @@ impl<S: Stream> Export<S> {
 					buffer: Vec::new(),
 					buffer_independent: false,
 					is_video: true,
+					opus: false,
 					default_frame: Duration::from_secs_f64(1.0 / framerate),
 					finished: false,
 					track_id: next_track_id,
@@ -354,6 +375,7 @@ impl<S: Stream> Export<S> {
 					buffer: Vec::new(),
 					buffer_independent: false,
 					is_video: false,
+					opus: matches!(config.codec, AudioCodec::Opus),
 					// Fallback for a duration-less trailing sample (~1024 samples/frame).
 					default_frame: Duration::from_secs_f64(1024.0 / config.sample_rate.max(1) as f64),
 					finished: false,
@@ -514,45 +536,29 @@ pub(crate) fn extract_init(
 	Ok(())
 }
 
-/// Should we flush `track.buffer` *before* appending the incoming `frame`?
-///
-/// Triggers:
-/// - Video keyframe and buffer non-empty (one fragment per GOP)
-/// - Optional duration cap exceeded
-/// - Per-frame mode (`Some(ZERO)`)
-/// - Audio in an audio-only broadcast under default `None` mode (otherwise
-///   the buffer would never flush — no keyframe boundary and no time cap)
-fn should_flush(track: &Fmp4Track, frame: &Frame, fragment_duration: Option<Duration>, has_video_track: bool) -> bool {
+/// Should we flush `track.buffer` before appending the incoming `frame`?
+/// Triggers on a video keyframe (one fragment per GOP) or the duration cap.
+/// Per-frame modes never buffer and are handled before this check.
+fn should_flush(track: &Fmp4Track, frame: &Frame, fragment_duration: Option<Duration>) -> bool {
 	if track.buffer.is_empty() {
 		return false;
 	}
 	if track.is_video && frame.keyframe {
 		return true;
 	}
-	match fragment_duration {
-		Some(d) if d.is_zero() => true,
-		Some(d) => {
-			// Frames within a track are in *decode* order; B-frames have
-			// non-monotonic PTS, so the span of the buffer is min..max of all
-			// PTS, not just first..incoming.
-			let mut min = Duration::from(frame.timestamp);
-			let mut max = min;
-			for f in &track.buffer {
-				let pts = Duration::from(f.timestamp);
-				if pts < min {
-					min = pts;
-				}
-				if pts > max {
-					max = pts;
-				}
-			}
-			max.saturating_sub(min) >= d
-		}
-		// No video keyframe will ever arrive to roll the fragment, so for
-		// audio-only broadcasts in `None` mode we fall back to per-frame
-		// fragments (matches the pre-batching default).
-		None => !track.is_video && !has_video_track,
+	let Some(cap) = fragment_duration else {
+		return false;
+	};
+	// Frames within a track are in *decode* order; B-frames have non-monotonic
+	// PTS, so the span of the buffer is min..max of all PTS.
+	let mut min = Duration::from(frame.timestamp);
+	let mut max = min;
+	for f in &track.buffer {
+		let pts = Duration::from(f.timestamp);
+		min = min.min(pts);
+		max = max.max(pts);
 	}
+	max.saturating_sub(min) >= cap
 }
 
 /// Encode a buffered run of samples as a single CMAF moof+mdat fragment.
@@ -572,7 +578,17 @@ fn encode_fragment(track: &mut Fmp4Track, frames: Vec<Frame>) -> Result<Bytes> {
 }
 
 /// Encode a buffered run and wrap it with the metadata a segmenting consumer needs.
-fn emit_fragment(track: &mut Fmp4Track, frames: Vec<Frame>, successor: Option<&Frame>) -> Result<Fragment> {
+fn emit_fragment(track: &mut Fmp4Track, mut frames: Vec<Frame>, successor: Option<&Frame>) -> Result<Fragment> {
+	// Opus packets carry their duration in the TOC byte (at 48 kHz), so
+	// duration-less frames get their real duration instead of the fallback.
+	if track.opus {
+		for frame in &mut frames {
+			if frame.duration.is_none() {
+				frame.duration = crate::codec::opus::packet_samples(&frame.payload)
+					.and_then(|samples| Timestamp::from_scale(samples as u64, 48_000).ok());
+			}
+		}
+	}
 	// Audio has no keyframes, so every audio fragment is independent; video is
 	// independent only when its buffer opened on a keyframe (a GOP boundary).
 	let independent = !track.is_video || track.buffer_independent;

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -5,6 +5,8 @@ use std::io::Cursor;
 use bytes::BytesMut;
 use mp4_atom::{DecodeMaybe, Encode};
 
+use crate::container::test_util::{Live, PPS, SPS, raw_frame, video_frame};
+
 /// Avc3-shape source (catalog `Container::Legacy`, `H264 { inline: true }`,
 /// `description: None`) → fMP4 / CMAF export must synthesize a valid init
 /// segment from the codec config the Avc1 transform builds on the wire.
@@ -16,65 +18,12 @@ use mp4_atom::{DecodeMaybe, Encode};
 ///   entry whose avcC is built from the inline SPS+PPS.
 #[tokio::test(start_paused = true)]
 async fn avc3_source_to_cmaf_export_roundtrip() {
-	use hang::catalog::{Container, H264, VideoConfig};
-	use moq_net::Timestamp;
+	let mut live = Live::avc3();
+	live.track.write(video_frame(0, true)).unwrap();
+	live.track.finish().unwrap();
 
-	let broadcast = moq_net::broadcast::Info::new();
-	let mut producer = broadcast.produce();
-	let consumer = producer.consume();
-
-	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let track = producer
-		.create_track(producer.unique_name(".avc3"), hang::container::track_info())
-		.unwrap();
-	let mut config = VideoConfig::new(H264 {
-		profile: 0x42,
-		constraints: 0xc0,
-		level: 0x1f,
-		inline: true,
-	});
-	config.coded_width = Some(320);
-	config.coded_height = Some(240);
-	config.container = Container::Legacy;
-	catalog.lock().video.renditions.insert(track.name().to_string(), config);
-
-	const SC: &[u8] = &[0, 0, 0, 1];
-	let sps = &[0x67u8, 0x42, 0xc0, 0x1f, 0xde, 0xad, 0xbe, 0xef][..];
-	let pps = &[0x68u8, 0xce, 0x3c, 0x80][..];
-	let idr = &[0x65u8, 0x88, 0x84, 0x21, 0x00, 0x11, 0x22, 0x33][..];
-
-	let mut keyframe_payload = BytesMut::new();
-	for nal in [sps, pps, idr] {
-		keyframe_payload.extend_from_slice(SC);
-		keyframe_payload.extend_from_slice(nal);
-	}
-	let keyframe_payload = keyframe_payload.freeze();
-
-	let mut track_producer = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy);
-	track_producer
-		.write(crate::container::Frame {
-			timestamp: Timestamp::from_micros(0).unwrap(),
-			payload: keyframe_payload,
-			keyframe: true,
-			duration: None,
-		})
-		.unwrap();
-	track_producer.finish().unwrap();
-
-	let catalog_stream = crate::catalog::Consumer::<()>::new(&consumer, crate::catalog::CatalogFormat::Hang)
-		.await
-		.expect("catalog consumer");
-	let mut exporter = crate::container::fmp4::Export::new(crate::source::announced(&consumer), catalog_stream);
-
-	let init = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
-		.await
-		.expect("exporter timed out")
-		.expect("exporter result")
-		.expect("expected init bytes");
-
-	drop(track_producer);
-	drop(catalog);
-	drop(producer);
+	let mut exporter = crate::container::fmp4::Export::new(live.source(), live.catalog_stream().await);
+	let init = fragment_now(&mut exporter).await.data;
 
 	let mut cursor = Cursor::new(init.as_ref());
 	let mut saw_ftyp = false;
@@ -97,11 +46,11 @@ async fn avc3_source_to_cmaf_export_roundtrip() {
 		mp4_atom::Codec::Avc1(avc1) => avc1,
 		other => panic!("expected Avc1 sample entry, got {:?}", other),
 	};
-	assert_eq!(avc1.avcc.avc_profile_indication, sps[1]);
-	assert_eq!(avc1.avcc.avc_level_indication, sps[3]);
+	assert_eq!(avc1.avcc.avc_profile_indication, SPS[1]);
+	assert_eq!(avc1.avcc.avc_level_indication, SPS[3]);
 	assert_eq!(avc1.avcc.sequence_parameter_sets.len(), 1);
-	assert_eq!(avc1.avcc.sequence_parameter_sets[0].as_slice(), sps);
-	assert_eq!(avc1.avcc.picture_parameter_sets[0].as_slice(), pps);
+	assert_eq!(avc1.avcc.sequence_parameter_sets[0].as_slice(), SPS);
+	assert_eq!(avc1.avcc.picture_parameter_sets[0].as_slice(), PPS);
 	assert_eq!(avc1.visual.width, 320);
 	assert_eq!(avc1.visual.height, 240);
 
@@ -116,18 +65,7 @@ async fn avc3_source_to_cmaf_export_roundtrip() {
 /// carries that AudioSpecificConfig, instead of bailing with UnsupportedSynthesis.
 #[tokio::test(start_paused = true)]
 async fn legacy_aac_source_to_cmaf_export_synthesizes_esds() {
-	use bytes::Bytes;
-	use hang::catalog::{AAC, AudioConfig, Container};
-	use moq_net::Timestamp;
-
-	let broadcast = moq_net::broadcast::Info::new();
-	let mut producer = broadcast.produce();
-	let consumer = producer.consume();
-
-	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let track = producer
-		.create_track(producer.unique_name(".aac"), hang::container::track_info())
-		.unwrap();
+	use hang::catalog::{AAC, AudioConfig};
 
 	// AAC-LC (profile 2), 44100 Hz, stereo. The TS importer sets `description`
 	// via aac::Config::encode; mirror that here.
@@ -138,35 +76,14 @@ async fn legacy_aac_source_to_cmaf_export_synthesizes_esds() {
 	}
 	.encode();
 	let mut config = AudioConfig::new(AAC { profile: 2 }, 44100, 2);
-	config.description = Some(description.clone());
-	config.container = Container::Legacy;
-	catalog.lock().audio.renditions.insert(track.name().to_string(), config);
+	config.description = Some(description);
 
-	let mut track_producer = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy);
-	track_producer
-		.write(crate::container::Frame {
-			timestamp: Timestamp::from_micros(0).unwrap(),
-			duration: None,
-			payload: Bytes::from_static(&[0x01, 0x02, 0x03, 0x04]),
-			keyframe: true,
-		})
-		.unwrap();
-	track_producer.finish().unwrap();
+	let mut live = Live::audio(config);
+	live.track.write(raw_frame(0, &[0x01, 0x02, 0x03, 0x04], true)).unwrap();
+	live.track.finish().unwrap();
 
-	let catalog_stream = crate::catalog::Consumer::<()>::new(&consumer, crate::catalog::CatalogFormat::Hang)
-		.await
-		.unwrap();
-	let mut exporter = crate::container::fmp4::Export::new(crate::source::announced(&consumer), catalog_stream);
-
-	let init = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
-		.await
-		.expect("exporter timed out")
-		.expect("exporter result")
-		.expect("expected init bytes");
-
-	drop(track_producer);
-	drop(catalog);
-	drop(producer);
+	let mut exporter = crate::container::fmp4::Export::new(live.source(), live.catalog_stream().await);
+	let init = fragment_now(&mut exporter).await.data;
 
 	let mut cursor = Cursor::new(init.as_ref());
 	let mut moov: Option<mp4_atom::Moov> = None;
@@ -208,49 +125,22 @@ async fn legacy_aac_source_to_cmaf_export_synthesizes_esds() {
 /// config, so this exercises the description-less synthesis path.
 #[tokio::test(start_paused = true)]
 async fn vp8_source_to_cmaf_export_synthesizes_vp08() {
-	use bytes::Bytes;
 	use hang::catalog::{Container, VideoCodec, VideoConfig};
-	use moq_net::Timestamp;
 
-	let broadcast = moq_net::broadcast::Info::new();
-	let mut producer = broadcast.produce();
-	let consumer = producer.consume();
-
-	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let track = producer
-		.create_track(producer.unique_name(".vp8"), hang::container::track_info())
+	let mut live = Live::new(".vp8", |catalog, name| {
+		let mut config = VideoConfig::new(VideoCodec::VP8);
+		config.coded_width = Some(320);
+		config.coded_height = Some(240);
+		config.container = Container::Legacy;
+		catalog.lock().video.renditions.insert(name, config);
+	});
+	live.track
+		.write(raw_frame(0, &[0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a], true))
 		.unwrap();
-	let mut config = VideoConfig::new(VideoCodec::VP8);
-	config.coded_width = Some(320);
-	config.coded_height = Some(240);
-	config.container = Container::Legacy;
-	catalog.lock().video.renditions.insert(track.name().to_string(), config);
+	live.track.finish().unwrap();
 
-	let mut track_producer = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy);
-	track_producer
-		.write(crate::container::Frame {
-			timestamp: Timestamp::from_micros(0).unwrap(),
-			payload: Bytes::from_static(&[0x10, 0x00, 0x00, 0x9d, 0x01, 0x2a]),
-			keyframe: true,
-			duration: None,
-		})
-		.unwrap();
-	track_producer.finish().unwrap();
-
-	let catalog_stream = crate::catalog::Consumer::<()>::new(&consumer, crate::catalog::CatalogFormat::Hang)
-		.await
-		.expect("catalog consumer");
-	let mut exporter = crate::container::fmp4::Export::new(crate::source::announced(&consumer), catalog_stream);
-
-	let init = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
-		.await
-		.expect("exporter timed out")
-		.expect("exporter result")
-		.expect("expected init bytes");
-
-	drop(track_producer);
-	drop(catalog);
-	drop(producer);
+	let mut exporter = crate::container::fmp4::Export::new(live.source(), live.catalog_stream().await);
+	let init = fragment_now(&mut exporter).await.data;
 
 	let mut cursor = Cursor::new(init.as_ref());
 	let mut moov: Option<mp4_atom::Moov> = None;
@@ -283,58 +173,29 @@ async fn vp8_source_to_cmaf_export_synthesizes_vp08() {
 /// the catalog's VP9 parameters.
 #[tokio::test(start_paused = true)]
 async fn vp9_source_to_cmaf_export_synthesizes_vp09() {
-	use bytes::Bytes;
 	use hang::catalog::{Container, VP9, VideoConfig};
-	use moq_net::Timestamp;
 
-	let broadcast = moq_net::broadcast::Info::new();
-	let mut producer = broadcast.produce();
-	let consumer = producer.consume();
-
-	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let track = producer
-		.create_track(producer.unique_name(".vp9"), hang::container::track_info())
-		.unwrap();
-	let mut config = VideoConfig::new(VP9 {
-		profile: 0,
-		level: 20,
-		bit_depth: 8,
-		chroma_subsampling: 1,
-		color_primaries: 2,
-		transfer_characteristics: 2,
-		matrix_coefficients: 5,
-		full_range: false,
+	let mut live = Live::new(".vp9", |catalog, name| {
+		let mut config = VideoConfig::new(VP9 {
+			profile: 0,
+			level: 20,
+			bit_depth: 8,
+			chroma_subsampling: 1,
+			color_primaries: 2,
+			transfer_characteristics: 2,
+			matrix_coefficients: 5,
+			full_range: false,
+		});
+		config.coded_width = Some(320);
+		config.coded_height = Some(240);
+		config.container = Container::Legacy;
+		catalog.lock().video.renditions.insert(name, config);
 	});
-	config.coded_width = Some(320);
-	config.coded_height = Some(240);
-	config.container = Container::Legacy;
-	catalog.lock().video.renditions.insert(track.name().to_string(), config);
+	live.track.write(raw_frame(0, &[0x82, 0x49, 0x83, 0x42], true)).unwrap();
+	live.track.finish().unwrap();
 
-	let mut track_producer = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy);
-	track_producer
-		.write(crate::container::Frame {
-			timestamp: Timestamp::from_micros(0).unwrap(),
-			payload: Bytes::from_static(&[0x82, 0x49, 0x83, 0x42]),
-			keyframe: true,
-			duration: None,
-		})
-		.unwrap();
-	track_producer.finish().unwrap();
-
-	let catalog_stream = crate::catalog::Consumer::<()>::new(&consumer, crate::catalog::CatalogFormat::Hang)
-		.await
-		.expect("catalog consumer");
-	let mut exporter = crate::container::fmp4::Export::new(crate::source::announced(&consumer), catalog_stream);
-
-	let init = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
-		.await
-		.expect("exporter timed out")
-		.expect("exporter result")
-		.expect("expected init bytes");
-
-	drop(track_producer);
-	drop(catalog);
-	drop(producer);
+	let mut exporter = crate::container::fmp4::Export::new(live.source(), live.catalog_stream().await);
+	let init = fragment_now(&mut exporter).await.data;
 
 	let mut cursor = Cursor::new(init.as_ref());
 	let mut moov: Option<mp4_atom::Moov> = None;
@@ -370,62 +231,33 @@ async fn vp9_source_to_cmaf_export_synthesizes_vp09() {
 /// stays empty.
 #[tokio::test(start_paused = true)]
 async fn av1_source_to_cmaf_export_synthesizes_av01() {
-	use bytes::Bytes;
 	use hang::catalog::{AV1, Container, VideoConfig};
-	use moq_net::Timestamp;
 
-	let broadcast = moq_net::broadcast::Info::new();
-	let mut producer = broadcast.produce();
-	let consumer = producer.consume();
-
-	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let track = producer
-		.create_track(producer.unique_name(".av01"), hang::container::track_info())
-		.unwrap();
-	let mut config = VideoConfig::new(AV1 {
-		profile: 0,
-		level: 8,
-		tier: 'M',
-		bitdepth: 10,
-		mono_chrome: false,
-		chroma_subsampling_x: true,
-		chroma_subsampling_y: true,
-		chroma_sample_position: 2,
-		color_primaries: 9,
-		transfer_characteristics: 16,
-		matrix_coefficients: 9,
-		full_range: false,
+	let mut live = Live::new(".av01", |catalog, name| {
+		let mut config = VideoConfig::new(AV1 {
+			profile: 0,
+			level: 8,
+			tier: 'M',
+			bitdepth: 10,
+			mono_chrome: false,
+			chroma_subsampling_x: true,
+			chroma_subsampling_y: true,
+			chroma_sample_position: 2,
+			color_primaries: 9,
+			transfer_characteristics: 16,
+			matrix_coefficients: 9,
+			full_range: false,
+		});
+		config.coded_width = Some(320);
+		config.coded_height = Some(240);
+		config.container = Container::Legacy;
+		catalog.lock().video.renditions.insert(name, config);
 	});
-	config.coded_width = Some(320);
-	config.coded_height = Some(240);
-	config.container = Container::Legacy;
-	catalog.lock().video.renditions.insert(track.name().to_string(), config);
+	live.track.write(raw_frame(0, &[0x12, 0x00, 0x0a, 0x0b], true)).unwrap();
+	live.track.finish().unwrap();
 
-	let mut track_producer = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy);
-	track_producer
-		.write(crate::container::Frame {
-			timestamp: Timestamp::from_micros(0).unwrap(),
-			payload: Bytes::from_static(&[0x12, 0x00, 0x0a, 0x0b]),
-			keyframe: true,
-			duration: None,
-		})
-		.unwrap();
-	track_producer.finish().unwrap();
-
-	let catalog_stream = crate::catalog::Consumer::<()>::new(&consumer, crate::catalog::CatalogFormat::Hang)
-		.await
-		.expect("catalog consumer");
-	let mut exporter = crate::container::fmp4::Export::new(crate::source::announced(&consumer), catalog_stream);
-
-	let init = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
-		.await
-		.expect("exporter timed out")
-		.expect("exporter result")
-		.expect("expected init bytes");
-
-	drop(track_producer);
-	drop(catalog);
-	drop(producer);
+	let mut exporter = crate::container::fmp4::Export::new(live.source(), live.catalog_stream().await);
+	let init = fragment_now(&mut exporter).await.data;
 
 	let mut cursor = Cursor::new(init.as_ref());
 	let mut moov: Option<mp4_atom::Moov> = None;
@@ -595,91 +427,29 @@ async fn single_track_export_init_matches_fragment_track_id() {
 /// independent. This is the metadata an HLS/LL-HLS packager consumes.
 #[tokio::test(start_paused = true)]
 async fn next_fragment_reports_segment_metadata() {
-	use std::time::Duration;
-
-	use bytes::BytesMut;
-	use hang::catalog::{Container, H264, VideoConfig};
-	use moq_net::Timestamp;
-
-	let broadcast = moq_net::broadcast::Info::new();
-	let mut producer = broadcast.produce();
-	let consumer = producer.consume();
-
-	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let track = producer
-		.create_track(producer.unique_name(".avc3"), hang::container::track_info())
-		.unwrap();
-	let mut config = VideoConfig::new(H264 {
-		profile: 0x42,
-		constraints: 0xc0,
-		level: 0x1f,
-		inline: true,
-	});
-	config.coded_width = Some(320);
-	config.coded_height = Some(240);
-	config.framerate = Some(30.0);
-	config.container = Container::Legacy;
-	catalog.lock().video.renditions.insert(track.name().to_string(), config);
-
-	const SC: &[u8] = &[0, 0, 0, 1];
-	let sps = &[0x67u8, 0x42, 0xc0, 0x1f, 0xde, 0xad, 0xbe, 0xef][..];
-	let pps = &[0x68u8, 0xce, 0x3c, 0x80][..];
-	let idr = &[0x65u8, 0x88, 0x84, 0x21, 0x00, 0x11, 0x22, 0x33][..];
-	let slice = &[0x41u8, 0x9a, 0x00, 0x01][..];
-
-	let annexb = |nals: &[&[u8]]| {
-		let mut buf = BytesMut::new();
-		for nal in nals {
-			buf.extend_from_slice(SC);
-			buf.extend_from_slice(nal);
-		}
-		buf.freeze()
-	};
-
-	let frame = |timestamp_us: u64, payload, keyframe| crate::container::Frame {
-		timestamp: Timestamp::from_micros(timestamp_us).unwrap(),
-		payload,
-		keyframe,
-		duration: None,
-	};
-
-	let mut track_producer = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy);
+	let mut live = Live::avc3();
 	// GOP 0: keyframe@0 (SPS+PPS+IDR), delta@33ms. GOP 1: keyframe@66ms.
-	track_producer.write(frame(0, annexb(&[sps, pps, idr]), true)).unwrap();
-	track_producer.write(frame(33_000, annexb(&[slice]), false)).unwrap();
-	track_producer
-		.write(frame(66_000, annexb(&[sps, pps, idr]), true))
-		.unwrap();
-	track_producer.finish().unwrap();
+	live.track.write(video_frame(0, true)).unwrap();
+	live.track.write(video_frame(33_000, false)).unwrap();
+	live.track.write(video_frame(66_000, true)).unwrap();
+	live.track.finish().unwrap();
 
-	let catalog_stream = crate::catalog::Consumer::<()>::new(&consumer, crate::catalog::CatalogFormat::Hang)
-		.await
-		.expect("catalog consumer");
 	// Sub-GOP cap so GOP 0 splits into two parts (the trailing part non-independent).
-	let mut exporter = crate::container::fmp4::Export::new(crate::source::announced(&consumer), catalog_stream)
-		.with_fragment_duration(Duration::from_millis(20));
+	let mut exporter = crate::container::fmp4::Export::new(live.source(), live.catalog_stream().await)
+		.with_fragment_duration(std::time::Duration::from_millis(20));
 
 	// First emit is the init segment.
-	let init = tokio::time::timeout(Duration::from_secs(1), exporter.next_fragment())
-		.await
-		.expect("exporter timed out")
-		.expect("exporter result")
-		.expect("expected init fragment");
+	let init = fragment_now(&mut exporter).await;
 	assert!(init.init, "first fragment must be the init segment");
 	assert!(!init.independent);
 	assert_eq!(init.duration, 0.0);
 
-	// The track is finished, so its three media fragments are all available. Keep
-	// the broadcast/catalog producers alive (dropping them aborts the consumer);
-	// the catalog stays open, so the exporter never reaches a clean end — read the
+	// The track is finished, so its three media fragments are all available. The
+	// catalog stays open, so the exporter never reaches a clean end. Read the
 	// known fragment count rather than looping to `None`.
 	let mut independents = Vec::new();
 	for _ in 0..3 {
-		let frag = tokio::time::timeout(Duration::from_secs(1), exporter.next_fragment())
-			.await
-			.expect("exporter timed out")
-			.expect("exporter result")
-			.expect("expected a media fragment");
+		let frag = fragment_now(&mut exporter).await;
 		assert!(!frag.init);
 		assert!(frag.duration > 0.0, "media fragment duration should be positive");
 		independents.push(frag.independent);
@@ -688,10 +458,69 @@ async fn next_fragment_reports_segment_metadata() {
 	// GOP 0 leading part (independent), GOP 0 trailing part (dependent),
 	// GOP 1 leading part (independent).
 	assert_eq!(independents, vec![true, false, true]);
+}
 
-	drop(track_producer);
-	drop(catalog);
-	drop(producer);
+#[tokio::test(start_paused = true)]
+async fn zero_fragment_duration_emits_without_successor() {
+	let mut live = Live::avc3();
+	live.track.write(video_frame(0, true)).unwrap();
+
+	let mut exporter = crate::container::fmp4::Export::new(live.source(), live.catalog_stream().await)
+		.with_fragment_duration(std::time::Duration::ZERO);
+	assert!(fragment_now(&mut exporter).await.init);
+
+	let fragment = fragment_now(&mut exporter).await;
+	assert!(!fragment.init);
+	assert!(fragment.independent, "a keyframe-led fragment can start a segment");
+	assert!(fragment.duration > 0.0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn audio_only_default_mode_emits_without_successor() {
+	use hang::catalog::{AAC, AudioConfig};
+
+	let aac = crate::codec::aac::Config {
+		profile: 2,
+		sample_rate: 44100,
+		channel_count: 2,
+	};
+	let mut config = AudioConfig::new(AAC { profile: 2 }, 44100, 2);
+	config.description = Some(aac.encode());
+
+	let mut live = Live::audio(config);
+	live.track.write(raw_frame(0, &[0x01, 0x02, 0x03, 0x04], true)).unwrap();
+
+	let mut exporter = crate::container::fmp4::Export::new(live.source(), live.catalog_stream().await);
+	assert!(fragment_now(&mut exporter).await.init);
+
+	let fragment = fragment_now(&mut exporter).await;
+	assert!(!fragment.init);
+	assert!(fragment.independent, "audio fragments are always independent");
+	// An AAC frame is 1024 samples, so the catalog fallback is the real duration.
+	assert!(
+		(fragment.duration - 1024.0 / 44100.0).abs() < 1e-4,
+		"expected one AAC frame of duration, got {}",
+		fragment.duration
+	);
+}
+
+#[tokio::test(start_paused = true)]
+async fn opus_frame_duration_from_toc() {
+	use hang::catalog::{AudioCodec, AudioConfig};
+
+	let mut live = Live::audio(AudioConfig::new(AudioCodec::Opus, 48_000, 2));
+	// TOC 0x08: config 1 (SILK 20 ms), code 0 (one frame) = 960 samples at 48 kHz.
+	live.track.write(raw_frame(0, &[0x08, 0xaa, 0xbb, 0xcc], true)).unwrap();
+
+	let mut exporter = crate::container::fmp4::Export::new(live.source(), live.catalog_stream().await);
+	assert!(fragment_now(&mut exporter).await.init);
+
+	let fragment = fragment_now(&mut exporter).await;
+	assert!(
+		(fragment.duration - 0.02).abs() < 1e-4,
+		"expected the 20 ms TOC duration, got {}",
+		fragment.duration
+	);
 }
 
 /// A legacy FLAC rendition (no init segment) synthesizes a `fLaC` sample entry
@@ -735,4 +564,15 @@ fn synthesize_flac_trak() {
 		.expect("STREAMINFO block");
 	// STREAMINFO carries the real 96 kHz rate even though the 16.16 audio box can't.
 	assert_eq!(stream_info, (96_000, 1));
+}
+
+/// The next fragment, required to be ready without another frame arriving.
+async fn fragment_now(
+	exporter: &mut crate::container::fmp4::Export<crate::catalog::Consumer>,
+) -> crate::container::fmp4::Fragment {
+	tokio::time::timeout(std::time::Duration::from_millis(1), exporter.next_fragment())
+		.await
+		.expect("waited for a successor frame")
+		.expect("exporter failed")
+		.expect("expected a fragment")
 }

--- a/rs/moq-mux/src/container/mkv/export.rs
+++ b/rs/moq-mux/src/container/mkv/export.rs
@@ -461,10 +461,10 @@ impl<S: Stream> Export<S> {
 	/// *previous* cluster; the new frame becomes the first block of a new
 	/// open cluster).
 	fn feed_frame(&mut self, name: &str, frame: Frame) -> Result<Option<Bytes>> {
-		let track = self.tracks.get(name).ok_or(Error::MissingTrack)?;
+		let track = self.tracks.get_mut(name).ok_or(Error::MissingTrack)?;
 		let track_number = track.track_number;
-		let kind = track.kind;
-		let payload = &frame.payload;
+		let is_video = track.kind == TrackKind::Video;
+		let keyframe = frame.keyframe;
 
 		// MKV's wire scale is ms (TIMESTAMP_SCALE_NS = 1_000_000). Re-express the
 		// frame's timestamp directly at MILLI rather than going through micros.
@@ -474,9 +474,21 @@ impl<S: Stream> Export<S> {
 			.try_into()
 			.map_err(|_| Error::TimestampU64)?;
 
-		let is_video = kind == TrackKind::Video;
-		let keyframe = frame.keyframe;
+		// A zero cap means one cluster per frame. Emit immediately instead of
+		// holding the frame until its successor rolls the cluster.
+		if self.fragment_duration == Some(Duration::ZERO) {
+			// A reconfiguration can leave a cluster open. Roll it out first and
+			// retry this frame on the next poll.
+			if let Some(open) = self.cluster.take() {
+				track.pending = Some(frame);
+				return Ok(Some(open.finish()));
+			}
+			let mut cluster = ClusterBuilder::new(frame_ticks);
+			cluster.append(track_number, frame_ticks, keyframe, &frame.payload, is_video)?;
+			return Ok(Some(cluster.finish()));
+		}
 
+		let payload = &frame.payload;
 		let roll_over = match &self.cluster {
 			None => true,
 			Some(cluster) => {
@@ -485,12 +497,9 @@ impl<S: Stream> Export<S> {
 				// frames in it — otherwise audio that arrived before the first
 				// keyframe would split into its own (un-renderable) cluster.
 				let gop_boundary = is_video && keyframe && cluster.has_video;
-				// Optional time-based cap. Some(ZERO) means per-frame.
-				let too_long = match self.fragment_duration {
-					Some(d) if d.is_zero() => !cluster.body.is_empty(),
-					Some(d) => frame_ticks.saturating_sub(cluster.start_ticks) >= d.as_millis() as u64,
-					None => false,
-				};
+				let too_long = self
+					.fragment_duration
+					.is_some_and(|d| frame_ticks.saturating_sub(cluster.start_ticks) >= d.as_millis() as u64);
 				overflow || gop_boundary || too_long
 			}
 		};

--- a/rs/moq-mux/src/container/mkv/export_test.rs
+++ b/rs/moq-mux/src/container/mkv/export_test.rs
@@ -11,6 +11,8 @@ use hang::catalog::{AudioCodec, VideoCodec};
 use webm_iterable::WebmIterator;
 use webm_iterable::matroska_spec::{Master, MatroskaSpec, SimpleBlock};
 
+use crate::container::test_util::{IDR, Live, PPS, SPS, raw_frame, video_frame};
+
 #[tokio::test(start_paused = true)]
 async fn export_header_roundtrip_vp9_opus() {
 	// Build a tiny synthetic WebM with one VP9 video track and one Opus audio track.
@@ -383,36 +385,26 @@ async fn export_emits_blocks_for_each_frame() {
 
 #[tokio::test(start_paused = true)]
 async fn export_rejects_cmaf_track() {
-	// Manually construct a broadcast whose catalog advertises a Cmaf-container
-	// video track. The exporter should bail.
+	// A catalog advertising a Cmaf-container video track: the exporter should bail.
 	use hang::catalog::{Container, H264, VideoConfig};
 
-	let broadcast = moq_net::broadcast::Info::new();
-	let mut producer = broadcast.produce();
-	let consumer = producer.consume();
-
-	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let track = producer
-		.create_track(producer.unique_name(".avc1"), hang::container::track_info())
-		.unwrap();
-	let mut config = VideoConfig::new(H264 {
-		profile: 0x64,
-		constraints: 0,
-		level: 0x1f,
-		inline: false,
+	let live = Live::new(".avc1", |catalog, name| {
+		let mut config = VideoConfig::new(H264 {
+			profile: 0x64,
+			constraints: 0,
+			level: 0x1f,
+			inline: false,
+		});
+		config.coded_width = Some(640);
+		config.coded_height = Some(480);
+		config.description = Some(Bytes::from(vec![0u8; 8]));
+		config.container = Container::Cmaf {
+			init: Bytes::from(vec![0u8; 32]),
+		};
+		catalog.lock().video.renditions.insert(name, config);
 	});
-	config.coded_width = Some(640);
-	config.coded_height = Some(480);
-	config.description = Some(Bytes::from(vec![0u8; 8]));
-	config.container = Container::Cmaf {
-		init: Bytes::from(vec![0u8; 32]),
-	};
-	catalog.lock().video.renditions.insert(track.name().to_string(), config);
 
-	let catalog_stream = crate::catalog::Consumer::<()>::new(&consumer, crate::catalog::CatalogFormat::Hang)
-		.await
-		.expect("catalog consumer");
-	let mut exporter = crate::container::mkv::Export::new(crate::source::announced(&consumer), catalog_stream);
+	let mut exporter = crate::container::mkv::Export::new(live.source(), live.catalog_stream().await);
 	let result = tokio::time::timeout(std::time::Duration::from_secs(1), exporter.next())
 		.await
 		.expect("exporter timed out");
@@ -423,81 +415,25 @@ async fn export_rejects_cmaf_track() {
 
 #[tokio::test(start_paused = true)]
 async fn export_avc3_source_synthesizes_avcc_and_length_prefixes() {
-	// Avc3-shape source: H264 { inline: true }, description = None, frames in
-	// Annex-B with inline SPS+PPS before keyframes. The exporter must
-	// (a) defer the header until SPS+PPS arrive, (b) emit avcC in CodecPrivate,
-	// (c) length-prefix the sample bytes in each SimpleBlock.
-	use hang::catalog::{Container, H264, VideoConfig};
-	use moq_net::Timestamp;
+	// Avc3-shape source: frames in Annex-B with inline SPS+PPS before keyframes.
+	// The exporter must (a) defer the header until SPS+PPS arrive, (b) emit avcC
+	// in CodecPrivate, (c) length-prefix the sample bytes in each SimpleBlock.
 
-	let broadcast = moq_net::broadcast::Info::new();
-	let mut producer = broadcast.produce();
-	let consumer = producer.consume();
+	// P-slice (0x61) behind an Annex-B start code.
+	const PSLICE_ANNEXB: &[u8] = &[0, 0, 0, 1, 0x61, 0xe0, 0x12, 0x34];
+	let pslice = &PSLICE_ANNEXB[4..];
 
-	let mut catalog = crate::catalog::Producer::new(&mut producer).unwrap();
-	let track = producer
-		.create_track(producer.unique_name(".avc3"), hang::container::track_info())
-		.unwrap();
-	let mut config = VideoConfig::new(H264 {
-		profile: 0x42,
-		constraints: 0xc0,
-		level: 0x1f,
-		inline: true,
-	});
-	config.coded_width = Some(320);
-	config.coded_height = Some(240);
-	config.container = Container::Legacy;
-	catalog.lock().video.renditions.insert(track.name().to_string(), config);
+	let mut live = Live::avc3();
+	live.track.write(video_frame(0, true)).unwrap();
+	live.track.write(raw_frame(33_000, PSLICE_ANNEXB, false)).unwrap();
+	live.track.finish().unwrap();
+	live.catalog.finish().unwrap();
 
-	// Annex-B start code.
-	const SC: &[u8] = &[0, 0, 0, 1];
-	let sps = &[0x67u8, 0x42, 0xc0, 0x1f, 0xde, 0xad, 0xbe, 0xef][..];
-	let pps = &[0x68u8, 0xce, 0x3c, 0x80][..];
-	let idr = &[0x65u8, 0x88, 0x84, 0x21, 0x00, 0x11, 0x22, 0x33][..];
-	let pslice = &[0x61u8, 0xe0, 0x12, 0x34][..];
-
-	let mut keyframe_payload = bytes::BytesMut::new();
-	for nal in [sps, pps, idr] {
-		keyframe_payload.extend_from_slice(SC);
-		keyframe_payload.extend_from_slice(nal);
-	}
-	let keyframe_payload = keyframe_payload.freeze();
-
-	let mut pslice_payload = bytes::BytesMut::new();
-	pslice_payload.extend_from_slice(SC);
-	pslice_payload.extend_from_slice(pslice);
-	let pslice_payload = pslice_payload.freeze();
-
-	// Publish frames via the container::Producer.
-	let mut track_producer = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy);
-	track_producer
-		.write(crate::container::Frame {
-			timestamp: Timestamp::from_micros(0).unwrap(),
-			payload: keyframe_payload,
-			keyframe: true,
-			duration: None,
-		})
-		.unwrap();
-	track_producer
-		.write(crate::container::Frame {
-			timestamp: Timestamp::from_micros(33_000).unwrap(),
-			payload: pslice_payload,
-			keyframe: false,
-			duration: None,
-		})
-		.unwrap();
-	track_producer.finish().unwrap();
-	let mut catalog = catalog;
-	catalog.finish().unwrap();
-
-	let catalog_stream = crate::catalog::Consumer::<()>::new(&consumer, crate::catalog::CatalogFormat::Hang)
-		.await
-		.expect("catalog consumer");
-	let mut exporter = crate::container::mkv::Export::new(crate::source::announced(&consumer), catalog_stream)
+	let mut exporter = crate::container::mkv::Export::new(live.source(), live.catalog_stream().await)
 		.with_fragment_duration(std::time::Duration::ZERO);
 	let mut exported: Vec<u8> = Vec::new();
 
-	let mut held_producer = Some(producer);
+	let mut live = Some(live);
 	for _ in 0..32 {
 		let next = tokio::time::timeout(std::time::Duration::from_millis(100), exporter.next()).await;
 		match next {
@@ -505,13 +441,12 @@ async fn export_avc3_source_synthesizes_avcc_and_length_prefixes() {
 			Ok(Ok(None)) => break,
 			Ok(Err(e)) => panic!("exporter error: {e}"),
 			Err(_) => {
-				held_producer = None;
+				// Drop the producers to close the broadcast so the exporter can EOS.
+				live = None;
 			}
 		}
 	}
-	drop(held_producer);
-	drop(catalog);
-	drop(track_producer);
+	drop(live);
 	drop(exporter);
 
 	// Parse the exported MKV and inspect the Tracks element and SimpleBlocks.
@@ -558,19 +493,19 @@ async fn export_avc3_source_synthesizes_avcc_and_length_prefixes() {
 	// numPPS=1, PPS_len(u16), PPS.
 	let avcc = codec_private.expect("avcC in CodecPrivate");
 	assert_eq!(avcc[0], 1, "configurationVersion");
-	assert_eq!(avcc[1], sps[1], "AVCProfileIndication");
-	assert_eq!(avcc[2], sps[2], "profile_compatibility");
-	assert_eq!(avcc[3], sps[3], "AVCLevelIndication");
+	assert_eq!(avcc[1], SPS[1], "AVCProfileIndication");
+	assert_eq!(avcc[2], SPS[2], "profile_compatibility");
+	assert_eq!(avcc[3], SPS[3], "AVCLevelIndication");
 	assert_eq!(avcc[4] & 0x03, 3, "lengthSizeMinusOne");
 
 	// SPS should be embedded after the 5+1=6 byte header.
 	let sps_len = u16::from_be_bytes([avcc[6], avcc[7]]) as usize;
-	assert_eq!(sps_len, sps.len());
-	assert_eq!(&avcc[8..8 + sps_len], sps);
+	assert_eq!(sps_len, SPS.len());
+	assert_eq!(&avcc[8..8 + sps_len], SPS);
 
 	// PPS follows: 1 byte numPPS + 2 byte length + PPS bytes.
 	let pps_offset = 8 + sps_len + 3;
-	assert_eq!(&avcc[pps_offset..pps_offset + pps.len()], pps);
+	assert_eq!(&avcc[pps_offset..pps_offset + PPS.len()], PPS);
 
 	// Both frames should be length-prefixed (no Annex-B start codes).
 	assert_eq!(sample_payloads.len(), 2, "expected 2 sample blocks");
@@ -579,8 +514,8 @@ async fn export_avc3_source_synthesizes_avcc_and_length_prefixes() {
 	// IDR makes it through as length-prefixed.
 	let first = &sample_payloads[0];
 	let idr_len = u32::from_be_bytes([first[0], first[1], first[2], first[3]]) as usize;
-	assert_eq!(idr_len, idr.len(), "IDR length prefix");
-	assert_eq!(&first[4..4 + idr_len], idr, "IDR payload");
+	assert_eq!(idr_len, IDR.len(), "IDR length prefix");
+	assert_eq!(&first[4..4 + idr_len], IDR, "IDR payload");
 
 	// Second frame: P-slice, length-prefixed.
 	let second = &sample_payloads[1];
@@ -665,6 +600,61 @@ async fn export_fragment_duration_batches_blocks() {
 
 	assert_eq!(block_count, 5, "all blocks should be emitted");
 	assert_eq!(cluster_count, 1, "all blocks should batch into one cluster");
+}
+
+#[tokio::test(start_paused = true)]
+async fn zero_fragment_duration_emits_without_successor() {
+	let mut live = Live::avc3();
+	live.track.write(video_frame(0, true)).unwrap();
+
+	let mut exporter = crate::container::mkv::Export::new(live.source(), live.catalog_stream().await)
+		.with_fragment_duration(std::time::Duration::ZERO);
+	let header = chunk_now(&mut exporter).await;
+	let cluster = chunk_now(&mut exporter).await;
+	assert_eq!(count_blocks(&header, &cluster), 1, "the cluster carries the live frame");
+}
+
+#[tokio::test(start_paused = true)]
+async fn reconfigured_zero_duration_drains_open_cluster() {
+	let mut live = Live::avc3();
+	live.track.write(video_frame(0, true)).unwrap();
+	live.track.write(video_frame(33_000, false)).unwrap();
+
+	// Default per-GOP clustering: both frames land in one open cluster.
+	let mut exporter = crate::container::mkv::Export::new(live.source(), live.catalog_stream().await);
+	let header = chunk_now(&mut exporter).await;
+	tokio::time::timeout(std::time::Duration::from_millis(1), exporter.next())
+		.await
+		.expect_err("the GOP cluster must stay open while the producer is live");
+
+	let mut exporter = exporter.with_fragment_duration(std::time::Duration::ZERO);
+	live.track.write(video_frame(66_000, false)).unwrap();
+
+	let leftover = chunk_now(&mut exporter).await;
+	let per_frame = chunk_now(&mut exporter).await;
+	assert_eq!(count_blocks(&header, &leftover), 2, "the open GOP cluster rolls first");
+	assert_eq!(
+		count_blocks(&header, &per_frame),
+		1,
+		"the live frame gets its own cluster"
+	);
+}
+
+/// The next chunk, required to be ready without another frame arriving.
+async fn chunk_now(exporter: &mut crate::container::mkv::Export<crate::catalog::Consumer>) -> Bytes {
+	tokio::time::timeout(std::time::Duration::from_millis(1), exporter.next())
+		.await
+		.expect("waited for a successor frame")
+		.expect("exporter failed")
+		.expect("expected a chunk")
+}
+
+/// SimpleBlock count of one cluster, parsed behind the file header.
+fn count_blocks(header: &[u8], cluster: &[u8]) -> usize {
+	let mut cursor = Cursor::new([header, cluster].concat());
+	WebmIterator::new(&mut cursor, &[])
+		.filter(|tag| matches!(tag, Ok(MatroskaSpec::SimpleBlock(_))))
+		.count()
 }
 
 /// Build a small WebM with VP9 video + Opus audio and several frames per track.

--- a/rs/moq-mux/src/container/mod.rs
+++ b/rs/moq-mux/src/container/mod.rs
@@ -18,6 +18,8 @@ mod consumer;
 pub(crate) mod jitter;
 mod producer;
 mod source;
+#[cfg(test)]
+pub(crate) mod test_util;
 
 pub mod flv;
 pub mod fmp4;

--- a/rs/moq-mux/src/container/test_util.rs
+++ b/rs/moq-mux/src/container/test_util.rs
@@ -1,0 +1,101 @@
+//! Shared scaffolding for exporter tests.
+
+use bytes::{Bytes, BytesMut};
+use hang::catalog::{AudioConfig, Container, H264, VideoConfig};
+use moq_net::Timestamp;
+
+/// A live single-track Legacy broadcast. All producers stay open, so an
+/// exporter sees a stream that has not ended.
+pub(crate) struct Live {
+	pub(crate) track: crate::container::Producer<crate::catalog::hang::Container>,
+	pub(crate) catalog: crate::catalog::Producer,
+	consumer: moq_net::broadcast::Consumer,
+	_broadcast: moq_net::broadcast::Producer,
+}
+
+impl Live {
+	/// One track named `name`, with `insert` registering its catalog rendition.
+	pub(crate) fn new(name: &str, insert: impl FnOnce(&mut crate::catalog::Producer, String)) -> Self {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let consumer = broadcast.consume();
+		let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+		let track = broadcast
+			.create_track(broadcast.unique_name(name), hang::container::track_info())
+			.unwrap();
+		insert(&mut catalog, track.name().to_string());
+		Self {
+			track: crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy),
+			catalog,
+			consumer,
+			_broadcast: broadcast,
+		}
+	}
+
+	/// One Avc3-shape H.264 rendition (320x240 at 30 fps).
+	pub(crate) fn avc3() -> Self {
+		Self::new(".avc3", |catalog, name| {
+			let mut config = VideoConfig::new(H264 {
+				profile: 0x42,
+				constraints: 0xc0,
+				level: 0x1f,
+				inline: true,
+			});
+			config.coded_width = Some(320);
+			config.coded_height = Some(240);
+			config.framerate = Some(30.0);
+			config.container = Container::Legacy;
+			catalog.lock().video.renditions.insert(name, config);
+		})
+	}
+
+	/// One Legacy audio rendition.
+	pub(crate) fn audio(mut config: AudioConfig) -> Self {
+		config.container = Container::Legacy;
+		Self::new(".audio", |catalog, name| {
+			catalog.lock().audio.renditions.insert(name, config);
+		})
+	}
+
+	pub(crate) fn source(&self) -> crate::Source {
+		crate::source::announced(&self.consumer)
+	}
+
+	pub(crate) async fn catalog_stream(&self) -> crate::catalog::Consumer {
+		crate::catalog::Consumer::<()>::new(&self.consumer, crate::catalog::CatalogFormat::Hang)
+			.await
+			.expect("catalog consumer")
+	}
+}
+
+/// H.264 NALs used by [`video_frame`], exposed for tests that assert on them.
+pub(crate) const SPS: &[u8] = &[0x67, 0x42, 0xc0, 0x1f, 0xde, 0xad, 0xbe, 0xef];
+pub(crate) const PPS: &[u8] = &[0x68, 0xce, 0x3c, 0x80];
+pub(crate) const IDR: &[u8] = &[0x65, 0x88, 0x84, 0x21, 0x00, 0x11, 0x22, 0x33];
+const DELTA: &[u8] = &[0x41, 0x9a, 0x00, 0x01];
+
+/// One Annex-B H.264 frame with no duration: SPS + PPS + IDR for a keyframe,
+/// otherwise a single delta slice.
+pub(crate) fn video_frame(timestamp_us: u64, keyframe: bool) -> crate::container::Frame {
+	let nals: &[&[u8]] = if keyframe { &[SPS, PPS, IDR] } else { &[DELTA] };
+	let mut payload = BytesMut::new();
+	for nal in nals {
+		payload.extend_from_slice(&[0, 0, 0, 1]);
+		payload.extend_from_slice(nal);
+	}
+	crate::container::Frame {
+		timestamp: Timestamp::from_micros(timestamp_us).unwrap(),
+		payload: payload.freeze(),
+		keyframe,
+		duration: None,
+	}
+}
+
+/// One frame with a fixed payload and no duration.
+pub(crate) fn raw_frame(timestamp_us: u64, payload: &'static [u8], keyframe: bool) -> crate::container::Frame {
+	crate::container::Frame {
+		timestamp: Timestamp::from_micros(timestamp_us).unwrap(),
+		payload: Bytes::from_static(payload),
+		keyframe,
+		duration: None,
+	}
+}


### PR DESCRIPTION
While we were benchmarking moq.dev against moq-rs, we found that we were consistently one frame interval behind. Turns out that `with_fragment_duration(Duration::ZERO)` promises one fragment per frame, but the fMP4 exporter never flushes on an empty buffer until the next frame arrives. The MKV exporter and fMP4 in audio-only mode hit a similar problem.

We fixed it by never letting the successor decide in per frame mode and instead emit the frame as its own fragment or cluster on arrival. While writing tests for that, I took the liberty to create one shared live broadcasting fixture (happy to remove that).

Note that the mixed A/V broadcaster for fMP4 still has that issue, but fixing that is a larger architectural endeavor.