### PR TITLE
refactor(stats)!: collect traffic counters in the model layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4588,6 +4588,7 @@ dependencies = [
 name = "moq-stats"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "moq-json",
  "moq-net",
  "serde",

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -263,12 +263,14 @@ counterpart no traffic can flow, so the entry is dropped:
     "announced": 1, "announced_closed": 0, "announced_bytes": 8,
     "broadcasts": 1, "broadcasts_closed": 0,
     "subscriptions": 5, "subscriptions_closed": 2,
+    "fetches": 3,
     "bytes": 12345, "frames": 678, "groups": 9
   },
   "anon/foo": {
     "announced": 1, "announced_closed": 0, "announced_bytes": 8,
     "broadcasts": 1, "broadcasts_closed": 0,
     "subscriptions": 2, "subscriptions_closed": 0,
+    "fetches": 0,
     "bytes": 234, "frames": 12, "groups": 1
   }
 }
@@ -280,10 +282,12 @@ Field semantics:
   announce/unannounce event on this `(tier, role)` slot, regardless of
   whether any subscription happened. Use this for "all known broadcasts".
 - `announced_bytes`: cumulative broadcast-name length summed over each
-  announce and unannounce of this broadcast. It counts the name, not the
-  encoded message size, so a broadcast isn't charged for hop chains or
+  model-visible announce and unannounce of this broadcast. It counts the name,
+  not the encoded message size, so a broadcast isn't charged for hop chains or
   framing overhead (and the count is the same across protocol versions).
-  Separate from `bytes`, which is media payload.
+  Separate from `bytes`, which is media payload. Announce control traffic that
+  never enters the model (auth-rejected or unmatched-prefix announcements) is
+  not counted.
 - `broadcasts` / `broadcasts_closed`: per-(broadcast, session)
   subscription sentinel. The first active subscription a peer session
   opens for a broadcast bumps `broadcasts`; the last one it closes bumps
@@ -292,9 +296,18 @@ Field semantics:
   subscribed to the broadcast (i.e. viewers on the egress side), which is
   typically what billing and UI want.
 - `subscriptions` / `subscriptions_closed`: cumulative count of
-  track-level subscription guards opened and dropped.
-- `bytes` / `frames` / `groups`: cumulative payload counters from the
-  session loops (both the `moq-lite` and IETF `moq-transport` paths).
+  track-level subscriptions opened and dropped.
+- `fetches`: cumulative one-shot group fetches served to a calling session,
+  counted once per coalesced fetch (requests served, not upstream work). It is
+  separate from `subscriptions` and the viewer sentinel; the fetched payload
+  still flows into `bytes` / `frames` / `groups`.
+- `bytes` / `frames` / `groups`: cumulative payload counters, bumped as
+  groups/frames are read out of the model on the egress side and written into
+  it on the ingress side. Egress bytes are counted when read out of the model
+  (into the QUIC send path), so bytes read but lost to a mid-group stream reset
+  still count. For a fan-out egress reader (e.g. an HLS/DASH muxer) this is
+  bytes read once per segment at the broadcast origin, not per downstream HTTP
+  client.
 
 The session tracks (`sessions.json` and any `<tier>/sessions.json`) instead map
 each auth root to a `{ sessions, sessions_closed }` snapshot. `sessions`

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -236,8 +236,9 @@ impl Client {
 		self
 	}
 
-	/// Attach a tier-scoped [`moq_net::stats::Handle`] to all sessions opened by this client.
-	pub fn with_stats(mut self, stats: moq_net::stats::Handle) -> Self {
+	/// Attach a per-connection [`moq_net::stats::Session`] context to all sessions
+	/// opened by this client.
+	pub fn with_stats(mut self, stats: moq_net::stats::Session) -> Self {
 		self.moq = self.moq.with_stats(stats);
 		self
 	}

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -252,8 +252,9 @@ impl Server {
 		self
 	}
 
-	/// Attach a tier-scoped [`moq_net::stats::Handle`] to all sessions accepted by this server.
-	pub fn with_stats(mut self, stats: moq_net::stats::Handle) -> Self {
+	/// Attach a per-connection [`moq_net::stats::Session`] context to all sessions
+	/// accepted by this server.
+	pub fn with_stats(mut self, stats: moq_net::stats::Session) -> Self {
 		self.moq = self.moq.with_stats(stats);
 		self
 	}
@@ -932,8 +933,8 @@ impl Request {
 		}
 	}
 
-	/// Attach a tier-scoped [`moq_net::stats::Handle`] to this session.
-	pub fn with_stats(self, stats: moq_net::stats::Handle) -> Self {
+	/// Attach a per-connection [`moq_net::stats::Session`] context to this session.
+	pub fn with_stats(self, stats: moq_net::stats::Session) -> Self {
 		let Request {
 			transport,
 			url,

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -11,7 +11,7 @@ use crate::{
 pub struct Client {
 	publish: Option<origin::Consumer>,
 	subscribe: Option<origin::Producer>,
-	stats: stats::Handle,
+	stats: stats::Session,
 	versions: Versions,
 	setup_path: Option<String>,
 	cost: Option<u64>,
@@ -38,10 +38,11 @@ impl Client {
 		self
 	}
 
-	/// Attach a tier-scoped [`stats::Handle`]. Per-broadcast and per-subscription
-	/// counters will be bumped through this handle for the lifetime of the session.
-	/// Pass [`stats::Handle::default`] (a no-op handle) to opt out.
-	pub fn with_stats(mut self, stats: stats::Handle) -> Self {
+	/// Attach a per-connection [`stats::Session`] context. The session's publish
+	/// (egress) and subscribe (ingress) origin handles are tagged with it, so all
+	/// traffic counters are attributed through the model for this session's lifetime.
+	/// Pass [`stats::Session::default`] (a no-op context) to opt out.
+	pub fn with_stats(mut self, stats: stats::Session) -> Self {
 		self.stats = stats;
 		self
 	}
@@ -99,6 +100,16 @@ impl Client {
 			tracing::warn!("not publishing or consuming anything");
 		}
 
+		// Tag the origin pair with the stats context: reads through the publish
+		// (egress) consumer and writes through the subscribe (ingress) producer are
+		// then attributed by the model. One shared context, so presence and viewer
+		// counts are never double-attributed across the two halves.
+		let publish = self.publish.clone().map(|origin| origin.with_stats(self.stats.clone()));
+		let subscribe = self
+			.subscribe
+			.clone()
+			.map(|origin| origin.with_stats(self.stats.clone()));
+
 		// If ALPN was used to negotiate the version, use the appropriate encoding.
 		// Default to IETF 14 if no ALPN was used and we'll negotiate the version later.
 		let (encoding, supported) = match session.protocol() {
@@ -114,9 +125,8 @@ impl Client {
 					None,
 					None,
 					true,
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
+					publish.clone(),
+					subscribe.clone(),
 					ietf::Version::Draft19,
 					self.setup_path.clone(),
 					None,
@@ -138,9 +148,8 @@ impl Client {
 					None,
 					None,
 					true,
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
+					publish.clone(),
+					subscribe.clone(),
 					ietf::Version::Draft18,
 					self.setup_path.clone(),
 					None,
@@ -162,9 +171,8 @@ impl Client {
 					None,
 					None,
 					true,
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
+					publish.clone(),
+					subscribe.clone(),
 					ietf::Version::Draft17,
 					self.setup_path.clone(),
 					None,
@@ -215,9 +223,8 @@ impl Client {
 				let start = lite::start(
 					session.clone(),
 					None,
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
+					publish.clone(),
+					subscribe.clone(),
 					version,
 					our_setup,
 					None,
@@ -239,9 +246,8 @@ impl Client {
 				let start = lite::start(
 					session.clone(),
 					None,
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
+					publish.clone(),
+					subscribe.clone(),
 					lite::Version::Lite04,
 					lite::Setup::default(),
 					None,
@@ -267,9 +273,8 @@ impl Client {
 				let start = lite::start(
 					session.clone(),
 					None,
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
+					publish.clone(),
+					subscribe.clone(),
 					lite::Version::Lite03,
 					lite::Setup::default(),
 					None,
@@ -328,9 +333,8 @@ impl Client {
 				let start = lite::start(
 					session.clone(),
 					Some(stream),
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
+					publish.clone(),
+					subscribe.clone(),
 					v,
 					// This path only handles versions negotiated via the bidi SETUP exchange
 					// (pre-lite-05), which have no Setup Stream.
@@ -354,9 +358,8 @@ impl Client {
 					Some(stream),
 					request_id_max,
 					true,
-					self.publish.clone(),
-					self.subscribe.clone(),
-					self.stats.clone(),
+					publish.clone(),
+					subscribe.clone(),
 					v,
 					None,
 					None,

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -1,4 +1,4 @@
-use crate::{group, origin, stats, track};
+use crate::{group, origin, track};
 use std::{collections::HashMap, task::Poll};
 
 use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
@@ -17,25 +17,18 @@ use super::{Message, Version};
 #[derive(Clone)]
 pub(super) struct Publisher<S: web_transport_trait::Session> {
 	session: S,
+	// Traffic stats are attributed through this tagged origin handle.
 	origin: origin::Consumer,
 	control: Control,
-	stats: stats::Handle,
-	/// Per-session egress broadcast-subscription tracker. Each downstream
-	/// subscription holds a guard so `broadcasts - broadcasts_closed` counts
-	/// the distinct sessions (viewers) watching each broadcast.
-	broadcasts: stats::SessionBroadcasts,
 	version: Version,
 }
 
 impl<S: web_transport_trait::Session> Publisher<S> {
-	pub fn new(session: S, origin: origin::Consumer, control: Control, stats: stats::Handle, version: Version) -> Self {
-		let broadcasts = stats.publisher_broadcasts();
+	pub fn new(session: S, origin: origin::Consumer, control: Control, version: Version) -> Self {
 		Self {
 			session,
 			origin,
 			control,
-			stats,
-			broadcasts,
 			version,
 		}
 	}
@@ -133,12 +126,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		tracing::info!(id = %request_id, broadcast = %absolute, track = %track_name, "subscribe started");
 
-		// Per-track subscription guard (bumps `subscriptions`). Taken before
-		// validation so a stale/invalid SUBSCRIBE still counts as an attempt,
-		// matching the lite path. The per-(session, broadcast) `broadcasts`
-		// sentinel that counts viewers is taken only once the subscription is
-		// validated and active, below.
-		let track_stats = std::sync::Arc::new(self.stats.broadcast(&absolute).publisher_track(&track_name));
+		// Stats (subscriptions, viewer refcount, groups/frames/bytes) are counted in
+		// the model, through the tagged `origin::Consumer` the broadcast resolves from.
 
 		// We just received a subscribe for this exact namespace, so the peer must have already
 		// seen the announcement. `request_broadcast` resolves it immediately, or falls back to
@@ -166,10 +155,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			}
 		};
 
-		// Subscription is now active: count this session as a viewer of the
-		// broadcast. Dropping this guard (subscription end) releases it.
-		let _broadcast_sub = self.broadcasts.subscribe(&absolute);
-
 		// Send SubscribeOk on the stream
 		stream.writer.encode(&ietf::SubscribeOk::ID).await?;
 		stream
@@ -185,7 +170,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		// Run the track, cancelling on reader close (Unsubscribe or stream close)
 		let res = {
-			let mut serve = std::pin::pin!(self.run_track(track, request_id, track_stats));
+			let mut serve = std::pin::pin!(self.run_track(track, request_id));
 			let mut reader_closed = std::pin::pin!(stream.reader.closed());
 			let mut session_closed = std::pin::pin!(self.session.closed());
 			kio::wait(|waiter| {
@@ -272,12 +257,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	/// Serve a track using FuturesUnordered for unlimited concurrent groups.
-	async fn run_track(
-		&self,
-		mut track: track::Subscriber,
-		request_id: RequestId,
-		track_stats: std::sync::Arc<stats::PublisherTrack>,
-	) -> Result<(), Error> {
+	async fn run_track(&self, mut track: track::Subscriber, request_id: RequestId) -> Result<(), Error> {
 		let mut tasks = FuturesUnordered::new();
 
 		loop {
@@ -315,17 +295,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			};
 
 			let priority = track.subscription().priority;
-			tasks.push(
-				Self::run_group(
-					self.session.clone(),
-					msg,
-					priority,
-					group,
-					track_stats.clone(),
-					self.version,
-				)
-				.map(|_| ()),
-			);
+			tasks.push(Self::run_group(self.session.clone(), msg, priority, group, self.version).map(|_| ()));
 		}
 	}
 
@@ -334,7 +304,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		msg: ietf::GroupHeader,
 		priority: u8,
 		mut group: group::Consumer,
-		track_stats: std::sync::Arc<stats::PublisherTrack>,
 		version: Version,
 	) -> Result<(), Error> {
 		let mut stream = session.open_uni().await.map_err(Error::from_transport)?;
@@ -343,7 +312,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let mut stream = Writer::new(stream, version);
 
 		stream.encode(&msg).await?;
-		track_stats.group();
 
 		loop {
 			// Wait for the next frame, bailing if the peer closes the stream first.
@@ -376,7 +344,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 			// Write the size of the frame.
 			stream.encode(&frame.size).await?;
-			track_stats.frame();
 
 			if frame.size == 0 {
 				// Have to write the object status too.
@@ -397,9 +364,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 					match chunk? {
 						Some(chunk) => {
-							let n = chunk.len() as u64;
 							stream.write_chunk(chunk).await?;
-							track_stats.bytes(n);
 						}
 						None => break,
 					}
@@ -543,8 +508,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// Each accepted namespace holds a `publisher()` announce guard (bumps
 		// `announced` / `announced_closed`) alongside its stream, so dropping the
 		// tuple on unannounce or cleanup records the close.
-		let mut namespace_streams: HashMap<crate::PathOwned, (RequestId, Stream<S, Version>, stats::Publisher)> =
-			HashMap::new();
+		let mut namespace_streams: HashMap<crate::PathOwned, (RequestId, Stream<S, Version>)> = HashMap::new();
 		let mut announced = self.origin.announced();
 
 		loop {
@@ -592,15 +556,13 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	async fn announce_namespace(
 		&self,
 		suffix: crate::PathOwned,
-		namespace_streams: &mut HashMap<crate::PathOwned, (RequestId, Stream<S, Version>, stats::Publisher)>,
+		namespace_streams: &mut HashMap<crate::PathOwned, (RequestId, Stream<S, Version>)>,
 	) -> Result<(), Error> {
 		let absolute = self.origin.absolute(&suffix).to_owned();
 		tracing::debug!(broadcast = %absolute, "announce");
 
 		let request_id = self.control.next_request_id().await?;
 		let mut stream = Stream::open(&self.session, self.version).await?;
-
-		let bs = self.stats.broadcast(&absolute);
 
 		stream.writer.encode(&ietf::PublishNamespace::ID).await?;
 		stream
@@ -610,10 +572,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				track_namespace: suffix.as_path(),
 			})
 			.await?;
-		// Count the broadcast name length (not the encoded message size) as soon
-		// as the request is on the wire, so a rejected namespace still counts the
-		// announce we spent.
-		bs.publisher_announced_bytes(absolute.as_str().len() as u64);
 
 		let type_id: u64 = stream.reader.decode().await?;
 		let size: u16 = stream.reader.decode().await?;
@@ -623,9 +581,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			(Version::Draft14, ietf::PublishNamespaceOk::ID) => {
 				let msg = ietf::PublishNamespaceOk::decode_msg(&mut data, self.version)?;
 				tracing::debug!(message = ?msg, "publish namespace ok");
-				// Holds the announce guard (bumps `announced` / `announced_closed`)
-				// until the namespace stream is torn down.
-				namespace_streams.insert(suffix, (request_id, stream, bs.publisher()));
+				namespace_streams.insert(suffix, (request_id, stream));
 			}
 			(Version::Draft14, ietf::PublishNamespaceError::ID) => {
 				let msg = ietf::PublishNamespaceError::decode_msg(&mut data, self.version)?;
@@ -634,7 +590,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			(_, ietf::RequestOk::ID) => {
 				let msg = ietf::RequestOk::decode_msg(&mut data, self.version)?;
 				tracing::debug!(message = ?msg, "publish namespace ok");
-				namespace_streams.insert(suffix, (request_id, stream, bs.publisher()));
+				namespace_streams.insert(suffix, (request_id, stream));
 			}
 			(_, ietf::RequestError::ID) => {
 				let msg = ietf::RequestError::decode_msg(&mut data, self.version)?;
@@ -650,11 +606,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	async fn unannounce_namespace(
 		&self,
 		suffix: &crate::PathOwned,
-		namespace_streams: &mut HashMap<crate::PathOwned, (RequestId, Stream<S, Version>, stats::Publisher)>,
+		namespace_streams: &mut HashMap<crate::PathOwned, (RequestId, Stream<S, Version>)>,
 	) {
 		tracing::debug!(broadcast = %self.origin.absolute(suffix), "unannounce");
-		// Dropping `_stats` on removal records the announce close.
-		if let Some((request_id, mut stream, _stats)) = namespace_streams.remove(suffix) {
+		if let Some((request_id, mut stream)) = namespace_streams.remove(suffix) {
 			// v14-16 sends PublishNamespaceDone; v17+ just closes the stream.
 			match self.version {
 				Version::Draft14 | Version::Draft15 | Version::Draft16 => {
@@ -668,12 +623,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				}
 				_ => {}
 			}
-			// Count the unannounce name length, mirroring the announce above (we
-			// measure the name, not the on-wire framing, so this is draft-agnostic).
-			let absolute = self.origin.absolute(suffix).to_owned();
-			self.stats
-				.broadcast(&absolute)
-				.publisher_announced_bytes(absolute.as_str().len() as u64);
 			stream.writer.finish().ok();
 		}
 	}

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -17,10 +17,10 @@ pub fn start<S: web_transport_trait::Session>(
 	setup: Option<Stream<S, Version>>,
 	request_id_max: Option<RequestId>,
 	client: bool,
+	// Traffic stats are attributed through these origin handles: tag them with
+	// `origin::{Consumer, Producer}::with_stats` before calling `start`.
 	publish: Option<origin::Consumer>,
 	subscribe: Option<origin::Producer>,
-	// Tier-scoped stats handle. Pass [`crate::stats::Handle::default`] to opt out.
-	stats: crate::stats::Handle,
 	version: Version,
 	// The request path we advertise in our SETUP (draft-17+ clients on URL-less
 	// transports). A server passes `None`.
@@ -46,9 +46,9 @@ pub fn start<S: web_transport_trait::Session>(
 				let control = Control::new(request_id_max, client);
 				let adapter = ControlStreamAdapter::new(session.clone(), control.clone(), version);
 
-				let publisher = Publisher::new(adapter.clone(), publish, control.clone(), stats.clone(), version);
+				let publisher = Publisher::new(adapter.clone(), publish, control.clone(), version);
 				let (tasks, mut task_set) = TaskSet::new();
-				let subscriber = Subscriber::new(adapter.clone(), subscribe, control, stats, version, tasks);
+				let subscriber = Subscriber::new(adapter.clone(), subscribe, control, version, tasks);
 
 				let dispatch_session = adapter.clone();
 				let mut sub_ns = subscriber.clone();
@@ -119,9 +119,9 @@ pub fn start<S: web_transport_trait::Session>(
 				};
 
 				let control = Control::new(None, client);
-				let publisher = Publisher::new(session.clone(), publish, control.clone(), stats.clone(), version);
+				let publisher = Publisher::new(session.clone(), publish, control.clone(), version);
 				let (tasks, mut task_set) = TaskSet::new();
-				let subscriber = Subscriber::new(session.clone(), subscribe, control, stats, version, tasks);
+				let subscriber = Subscriber::new(session.clone(), subscribe, control, version, tasks);
 
 				let sub_ns_session = session.clone();
 				let mut sub_ns = subscriber.clone();

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1,6 +1,5 @@
 use std::{
 	collections::{HashMap, hash_map::Entry},
-	sync::Arc,
 	task::Poll,
 	time::Duration,
 };
@@ -10,7 +9,7 @@ use crate::{
 	coding::{Reader, Stream},
 	frame, group,
 	ietf::{self, Control, FilterType, GroupOrder, RequestId},
-	origin, stats, track,
+	origin, track,
 	util::{MaybeBoxedExt, MaybeSendBox, TaskSet, Tasks},
 };
 
@@ -61,9 +60,6 @@ struct State {
 struct TrackState {
 	producer: track::Producer,
 	alias: Option<u64>,
-	/// Subscriber-side track stats; counters bump as frames/bytes/groups arrive.
-	/// Dropping on subscription end records `subscriptions_closed`.
-	stats: Arc<stats::SubscriberTrack>,
 }
 
 struct BroadcastState {
@@ -74,22 +70,14 @@ struct BroadcastState {
 
 	// active number of PUBLISH or PUBLISH_NAMESPACE messages.
 	count: usize,
-
-	/// Subscriber-side announce guard (bumps `announced` / `announced_closed`),
-	/// held for as long as the broadcast is announced into our origin.
-	_stats: stats::Subscriber,
 }
 
 #[derive(Clone)]
 pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	session: S,
+	// Traffic stats are attributed through this tagged origin handle.
 	origin: origin::Producer,
 	control: Control,
-	stats: stats::Handle,
-	/// Per-session ingress broadcast-subscription tracker. Each upstream
-	/// subscription holds a guard so `broadcasts - broadcasts_closed` counts the
-	/// distinct upstream sessions feeding each broadcast.
-	broadcasts: stats::SessionBroadcasts,
 	// A random per-connection origin stamped into the hop chain of every
 	// broadcast. moq-transport never carries hop ids on the wire, so each
 	// upstream session needs a stable, unique identity in the hop list for two
@@ -120,21 +108,11 @@ async fn resolve_track_alias(aliases: kio::Consumer<HashMap<u64, RequestId>>, al
 }
 
 impl<S: web_transport_trait::Session> Subscriber<S> {
-	pub fn new(
-		session: S,
-		origin: origin::Producer,
-		control: Control,
-		stats: stats::Handle,
-		version: Version,
-		tasks: Tasks,
-	) -> Self {
-		let broadcasts = stats.subscriber_broadcasts();
+	pub fn new(session: S, origin: origin::Producer, control: Control, version: Version, tasks: Tasks) -> Self {
 		Self {
 			session,
 			origin,
 			control,
-			stats,
-			broadcasts,
 			session_origin: crate::Origin::random(),
 			state: Default::default(),
 			tasks,
@@ -356,9 +334,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			// PUBLISH is the peer feeding us a broadcast, so count this session as
 			// an active upstream feed for the lifetime of the publish. The guard
 			// drops (releasing `broadcasts_closed`) when the stream closes below.
-			let abs = self.origin.absolute(&msg.track_namespace).to_owned();
-			let _broadcast_sub = self.broadcasts.subscribe(&abs);
-
 			// Wait for PublishDone or stream close
 			let _ = stream.reader.closed().await;
 		}
@@ -533,14 +508,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	fn start_announce(&mut self, path: PathOwned) -> Result<broadcast::Producer, Error> {
-		let abs = self.origin.absolute(&path).to_owned();
-		// Count the broadcast name length per announce (not the encoded message
-		// size, so framing overhead isn't charged), keyed by path so it's
-		// independent of the lifetime guard below.
-		self.stats
-			.broadcast(&abs)
-			.subscriber_announced_bytes(abs.as_str().len() as u64);
-
+		// The ingress announce stats (announced / announced_bytes) are driven in the
+		// model by `create_broadcast`'s route transitions below.
 		let mut state = self.state.lock();
 		match state.broadcasts.entry(path.clone()) {
 			Entry::Occupied(mut entry) => {
@@ -568,7 +537,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				entry.insert(BroadcastState {
 					producer: crate::model::broadcast::SourceGuard::new(broadcast.clone()),
 					count: 1,
-					_stats: self.stats.broadcast(&abs).subscriber(),
 				});
 
 				tracing::debug!(broadcast = %self.origin.absolute(&path), "announce");
@@ -589,18 +557,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 	}
 
-	/// `count_bytes` records the unannounce name length (mirroring the announce in
-	/// [`Self::start_announce`]). Pass `true` for a real unannounce / stream-close
-	/// control event and `false` for a local rollback (e.g. a failed OK write),
-	/// which is a teardown rather than an announce the peer ended.
-	fn stop_announce(&mut self, path: PathOwned, count_bytes: bool) -> Result<(), Error> {
-		if count_bytes {
-			let abs = self.origin.absolute(&path).to_owned();
-			self.stats
-				.broadcast(&abs)
-				.subscriber_announced_bytes(abs.as_str().len() as u64);
-		}
-
+	/// `_count_bytes` is retained for call-site clarity (a real unannounce vs a local
+	/// rollback), but the ingress announce stats are now driven in the model by the
+	/// source's route transitions and last-route detach, not here.
+	fn stop_announce(&mut self, path: PathOwned, _count_bytes: bool) -> Result<(), Error> {
 		let mut state = self.state.lock();
 
 		match state.broadcasts.entry(path.clone()) {
@@ -633,16 +593,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 		};
 
-		let abs = self.origin.absolute(&msg.track_namespace).to_owned();
-		let track_stats = Arc::new(self.stats.broadcast(&abs).subscriber_track(&msg.track_name));
-
 		let mut state = self.state.lock();
 		match state.subscribes.entry(request_id) {
 			Entry::Vacant(entry) => {
 				entry.insert(TrackState {
 					producer: track.clone(),
 					alias: Some(msg.track_alias),
-					stats: track_stats,
 				});
 			}
 			Entry::Occupied(_) => {
@@ -735,9 +691,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 		};
 
-		let abs = self.origin.absolute(&broadcast_path).to_owned();
-		let track_stats = Arc::new(self.stats.broadcast(&abs).subscriber_track(track.name()));
-
 		// Register the request before writing SUBSCRIBE so SUBSCRIBE_OK can bind its alias.
 		{
 			let mut state = self.state.lock();
@@ -746,7 +699,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				TrackState {
 					producer: track.clone(),
 					alias: None,
-					stats: track_stats,
 				},
 			);
 		}
@@ -782,11 +734,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				return;
 			}
 		};
-
-		// Upstream confirmed (SubscribeOk), so this session is now actively feeding
-		// the broadcast: take the `broadcasts` sentinel for the subscription's
-		// lifetime. It drops (releasing `broadcasts_closed`) when this fn returns.
-		let _broadcast_sub = self.broadcasts.subscribe(&abs);
 
 		// One event ends the subscription: the last consumer leaving, the broadcast
 		// dying, or the subscribe stream closing.
@@ -900,22 +847,21 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			tracing::warn!(track_alias = %group.track_alias, "unknown track alias");
 		})?;
 
-		let (mut producer, track, track_stats) = {
+		let (mut producer, track) = {
 			let mut state = self.state.lock();
 			let track = state.subscribes.get_mut(&request_id).ok_or(Error::NotFound)?;
 
 			let group_info = group::Info {
 				sequence: group.group_id,
 			};
+			// Stats (groups/frames/bytes) are counted in the model as the group is
+			// written, through the tagged `track::Producer`.
 			let producer = track.producer.create_group(group_info)?;
-			(producer, track.producer.clone(), track.stats.clone())
+			(producer, track.producer.clone())
 		};
 
-		// Bump groups counter for this incoming group on the subscriber side.
-		track_stats.group();
-
 		let res = {
-			let mut serve = std::pin::pin!(self.run_group(group, stream, producer.clone(), track_stats.clone()));
+			let mut serve = std::pin::pin!(self.run_group(group, stream, producer.clone()));
 			kio::wait(|waiter| {
 				if let Poll::Ready(err) = track.poll_closed(waiter) {
 					return Poll::Ready(Err(err));
@@ -949,7 +895,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		group: ietf::GroupHeader,
 		stream: &mut Reader<S::RecvStream, Version>,
 		mut producer: group::Producer,
-		track_stats: Arc<stats::SubscriberTrack>,
 	) -> Result<(), Error> {
 		while let Some(id_delta) = stream.decode_maybe::<u64>().await? {
 			if id_delta != 0 {
@@ -973,7 +918,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				if status == 0 {
 					let timestamp = timestamp.unwrap_or_else(crate::Timestamp::now);
 					let frame = producer.create_frame(frame::Info { size: 0, timestamp })?;
-					track_stats.frame();
 					frame.finish()?;
 				} else if status == 3 && !group.flags.has_end {
 					break;
@@ -985,9 +929,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				// `size` before allocating, so no pre-check is needed.
 				let timestamp = timestamp.unwrap_or_else(crate::Timestamp::now);
 				let mut frame = producer.create_frame(frame::Info { size, timestamp })?;
-				track_stats.frame();
 
-				if let Err(err) = self.run_frame(stream, &mut frame, &track_stats).await {
+				if let Err(err) = self.run_frame(stream, &mut frame).await {
 					let _ = frame.abort(err.clone());
 					return Err(err);
 				}
@@ -1003,12 +946,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		stream: &mut Reader<S::RecvStream, Version>,
 		frame: &mut frame::Producer<'_>,
-		track_stats: &stats::SubscriberTrack,
 	) -> Result<(), Error> {
 		while frame.remaining() > 0 {
 			match stream.read_chunk(frame.remaining()).await? {
 				Some(chunk) if !chunk.is_empty() => {
-					track_stats.bytes(chunk.len() as u64);
 					frame.write(chunk)?;
 				}
 				_ => return Err(Error::WrongSize),

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1,4 +1,4 @@
-use crate::{announce, frame, group, origin, stats, track};
+use crate::{announce, frame, group, origin, track};
 use std::{sync::Arc, task::Poll, time::Duration};
 
 use bytes::Buf;
@@ -45,22 +45,15 @@ struct SentRoute {
 
 pub(super) struct PublisherConfig<S: web_transport_trait::Session> {
 	pub session: S,
-	/// The origin we read local broadcasts from.
+	/// The origin we read local broadcasts from. Traffic stats are attributed
+	/// through this handle: tag it with [`origin::Consumer::with_stats`] first.
 	pub origin: origin::Consumer,
-	/// Stats aggregator for this session's egress. Use [`stats::Handle::default`]
-	/// to opt out.
-	pub stats: stats::Handle,
 	pub version: Version,
 }
 
 pub(super) struct Publisher<S: web_transport_trait::Session> {
 	session: S,
 	origin: origin::Consumer,
-	stats: stats::Handle,
-	/// Per-session egress broadcast-subscription tracker. Each downstream
-	/// subscription holds a guard so `broadcasts - broadcasts_closed` counts
-	/// the distinct sessions (viewers) watching each broadcast.
-	broadcasts: stats::SessionBroadcasts,
 	self_origin: Origin,
 	priority: PriorityQueue,
 	version: Version,
@@ -72,12 +65,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// origin we're consuming so it matches the local relay identity
 		// across every session, required for cross-session loop detection.
 		let self_origin = *config.origin;
-		let broadcasts = config.stats.publisher_broadcasts();
 		Self {
 			session: config.session,
 			origin: config.origin,
-			stats: config.stats,
-			broadcasts,
 			self_origin,
 			priority: Default::default(),
 			version: config.version,
@@ -206,7 +196,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			&prefix,
 			self.self_origin,
 			exclude_hop,
-			self.stats.clone(),
 			self.version,
 		)
 		.await
@@ -238,16 +227,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// reflected announces (cluster loops) never hit the wire. Zero means
 		// the peer didn't set it (Lite03 or earlier), pass through.
 		exclude_hop: u64,
-		stats: stats::Handle,
 		version: Version,
 	) -> Result<(), Error> {
 		let prefix = prefix.as_path();
-
-		// Per-path stats guards: dropping the guard records `broadcasts_closed`.
-		// The origin contract guarantees announce/unannounce toggles per path, so a
-		// new active announcement must always be for a path with no live guard.
-		let mut stats_guards: std::collections::HashMap<crate::PathOwned, stats::Publisher> =
-			std::collections::HashMap::new();
 
 		// Lite06+: announce ids. Every `active` we send implicitly assigns the next
 		// per-stream ordinal, and `ended` references the id instead of repeating the
@@ -277,29 +259,18 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 					if broadcast.is_some() {
 						tracing::debug!(broadcast = %absolute, "announce");
-						let guard = stats.broadcast(&absolute).publisher();
-						stats_guards.entry(absolute).or_insert(guard);
 						if !init.contains(&suffix) {
 							init.push(suffix);
 						}
 					} else {
 						// A potential race.
 						tracing::debug!(broadcast = %absolute, "unannounce");
-						stats_guards.remove(&absolute);
 						init.retain(|p| p != &suffix);
 					}
 				}
 
 				let announce_init = lite::AnnounceInit { suffixes: init };
 				stream.writer.encode(&announce_init).await?;
-
-				// AnnounceInit batches the initial active set into one message; attribute
-				// it per broadcast by name length so Lite01/02 isn't undercounted.
-				for absolute in stats_guards.keys() {
-					stats
-						.broadcast(absolute)
-						.publisher_announced_bytes(absolute.as_str().len() as u64);
-				}
 			}
 			_ if version.has_announce_ok() => {
 				// Drain the current active set synchronously (like the Lite01/02 path),
@@ -341,15 +312,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 								continue;
 							}
 							tracing::debug!(broadcast = %absolute, "announce");
-							let guard = stats.broadcast(&absolute).publisher();
-							stats_guards.entry(absolute.clone()).or_insert(guard);
 							initial.retain(|(s, _)| s != &suffix);
 							initial.push((suffix, SentRoute { hops, cost }));
 						}
 						None => {
 							// A potential race: a just-announced path already unannounced.
 							tracing::debug!(broadcast = %absolute, "unannounce");
-							stats_guards.remove(&absolute);
 							watched.remove(&suffix);
 							initial.retain(|(s, _)| s != &suffix);
 						}
@@ -381,14 +349,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				}
 				let mut buf = buf.freeze();
 				stream.writer.write_all(&mut buf).await?;
-
-				// Count each initial announce by broadcast name length, mirroring the
-				// live loop below (the name, not the encoded message size).
-				for absolute in stats_guards.keys() {
-					stats
-						.broadcast(absolute)
-						.publisher_announced_bytes(absolute.as_str().len() as u64);
-				}
 			}
 			_ => {
 				// Lite03/Lite04: no announce init, no AnnounceOk.
@@ -537,12 +497,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 							};
 							let cost = Self::outgoing_cost(version, &demand, &route);
 							tracing::debug!(broadcast = %absolute, "announce");
-							let bs = stats.broadcast(&absolute);
-							// Count the broadcast name length, not the encoded message size, so
-							// stats don't penalize the broadcast for hop/framing overhead.
-							bs.publisher_announced_bytes(absolute.as_str().len() as u64);
-							let prev = stats_guards.insert(absolute.clone(), bs.publisher());
-							debug_assert!(prev.is_none(), "origin announced a path that was already active");
 							if version.has_announce_id() {
 								let prev = announce_ids.insert(suffix.clone(), next_announce_id);
 								debug_assert!(prev.is_none(), "announce id still assigned for a new announce");
@@ -567,20 +521,13 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 							// versions never populate `watched`, so they keep sending the
 							// Ended even for announces filtered above.
 							let retracted = watched.remove(&suffix).is_some_and(|entry| entry.sent.is_none());
-							stats_guards.remove(&absolute);
 							if version.has_announce_id() {
 								// Retract by id; nothing to send if the announce was filtered and
 								// the peer never saw it (an unknown id is a protocol violation).
 								if let Some(id) = announce_ids.remove(&suffix) {
-									stats
-										.broadcast(&absolute)
-										.publisher_announced_bytes(absolute.as_str().len() as u64);
 									stream.writer.encode(&lite::AnnounceBroadcast::EndedId { id }).await?;
 								}
 							} else if !retracted {
-								stats
-									.broadcast(&absolute)
-									.publisher_announced_bytes(absolute.as_str().len() as u64);
 								// An ended announce doesn't need hops; the receiver matches on path only.
 								stream
 									.writer
@@ -627,9 +574,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 									tracing::warn!(broadcast = %absolute, "restart without an announce id; skipping");
 									continue;
 								};
-								stats
-									.broadcast(&absolute)
-									.publisher_announced_bytes(absolute.as_str().len() as u64);
 								entry.sent = Some(route.clone());
 								stream
 									.writer
@@ -641,9 +585,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 									.await?;
 							} else {
 								// Lite05: a duplicate ANNOUNCE for a live path is the restart.
-								stats
-									.broadcast(&absolute)
-									.publisher_announced_bytes(absolute.as_str().len() as u64);
 								entry.sent = Some(route.clone());
 								stream
 									.writer
@@ -658,9 +599,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						// Previously filtered, now forwardable: a fresh announce.
 						(Some(route), None) => {
 							tracing::debug!(broadcast = %absolute, "announce");
-							let bs = stats.broadcast(&absolute);
-							bs.publisher_announced_bytes(absolute.as_str().len() as u64);
-							stats_guards.insert(absolute.clone(), bs.publisher());
 							if version.has_announce_id() {
 								announce_ids.insert(suffix.clone(), next_announce_id);
 								next_announce_id += 1;
@@ -680,10 +618,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 						(None, Some(_)) => {
 							tracing::debug!(broadcast = %absolute, "unannounce (filtered route)");
 							entry.sent = None;
-							stats_guards.remove(&absolute);
-							stats
-								.broadcast(&absolute)
-								.publisher_announced_bytes(absolute.as_str().len() as u64);
 							if version.has_announce_id() {
 								if let Some(id) = announce_ids.remove(&suffix) {
 									stream.writer.encode(&lite::AnnounceBroadcast::EndedId { id }).await?;
@@ -837,19 +771,15 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// handler (or resolves to an error when there is none).
 		let broadcast = self.origin.request_broadcast(&subscribe.broadcast);
 
-		// Per-track subscription guard (bumps `subscriptions`). The per-(session,
-		// broadcast) `broadcasts` sentinel that counts viewers is taken inside
-		// `run_subscribe`, only once the subscription is validated and active, so
-		// a stale/invalid SUBSCRIBE isn't counted as a viewer.
-		let track_stats = self.stats.broadcast(&absolute).publisher_track(&track);
-
+		// Stats (subscriptions, viewer refcount, groups/frames/bytes) are counted in
+		// the model, through the tagged `origin::Consumer` this broadcast is resolved
+		// from; the wire loop carries no counters.
 		if let Err(err) = Self::run_subscribe(
 			self.session.clone(),
 			&mut stream,
 			&subscribe,
 			broadcast,
 			self.priority.clone(),
-			(track_stats, self.broadcasts.clone(), absolute.clone()),
 			self.version,
 		)
 		.await
@@ -877,13 +807,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		subscribe: &lite::Subscribe<'_>,
 		broadcast: kio::Pending<origin::Requesting>,
 		priority: PriorityQueue,
-		// The track guard (bumps `subscriptions`), the per-session broadcast
-		// tracker, and the broadcast path. The `broadcasts` sentinel is taken
-		// below, after the subscription is validated, and held for its lifetime.
-		stats: (stats::PublisherTrack, stats::SessionBroadcasts, crate::PathOwned),
 		version: Version,
 	) -> Result<(), Error> {
-		let (track_stats, broadcasts, absolute) = stats;
 		let subscription = crate::track::Subscription {
 			priority: subscribe.priority,
 			ordered: subscribe.ordered,
@@ -911,10 +836,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			None
 		};
 
-		// Subscription is now active: count this session as a viewer of the
-		// broadcast. Dropping this guard (subscription end) releases it.
-		let _broadcast_sub = broadcasts.subscribe(&absolute);
-
 		// Lite05+ accepts implicitly: no SUBSCRIBE_OK, the immutable properties live
 		// in TRACK_INFO, and the resolved range arrives as SUBSCRIBE_START/END emitted
 		// from run_track. Older drafts still acknowledge with SUBSCRIBE_OK here.
@@ -940,7 +861,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			session,
 			id: subscribe.id,
 			track_name: Arc::from(track.name()),
-			track_stats: Arc::new(track_stats),
 			priority,
 			track_priority: track_priority_tx.consume(),
 			track_priority_seen: subscribe.priority,
@@ -987,9 +907,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// `request_broadcast` resolves it immediately, or falls back to an `origin::Dynamic`
 		// handler (as in recv_subscribe).
 		let broadcast = self.origin.request_broadcast(&fetch.broadcast);
-		let track_stats = self.stats.broadcast(&absolute).publisher_track(&track);
 
-		if let Err(err) = Self::run_fetch(&mut stream, &fetch, broadcast, track_stats, self.version).await {
+		if let Err(err) = Self::run_fetch(&mut stream, &fetch, broadcast, self.version).await {
 			match &err {
 				Error::Cancel | Error::Transport(_) => {
 					tracing::info!(broadcast = %absolute, %track, %group, "fetch cancelled")
@@ -1008,7 +927,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		stream: &mut Stream<S, Version>,
 		fetch: &lite::Fetch<'_>,
 		broadcast: kio::Pending<origin::Requesting>,
-		track_stats: stats::PublisherTrack,
 		version: Version,
 	) -> Result<(), Error> {
 		let broadcast = broadcast.await?;
@@ -1030,16 +948,12 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			None
 		};
 
-		// Lite05+ FETCH responds with bare FRAME messages; the subscriber already has
-		// the timescale from TRACK_INFO and the group sequence from its request.
-		track_stats.group();
-
 		// Stream every frame in order. The delta-timestamp baseline resets to 0, so the
 		// first served frame's delta is its absolute timestamp (the subscriber decodes
 		// against the same baseline).
 		let mut prev_ts: u64 = 0;
 		while let Some(mut frame) = group.next_frame().await? {
-			write_fetch_frame(&mut stream.writer, &mut frame, timescale, &mut prev_ts, &track_stats).await?;
+			write_fetch_frame(&mut stream.writer, &mut frame, timescale, &mut prev_ts).await?;
 		}
 
 		stream.writer.finish()?;
@@ -1164,16 +1078,12 @@ async fn write_fetch_frame<W: web_transport_trait::SendStream>(
 	frame: &mut frame::Consumer,
 	timescale: Option<crate::Timescale>,
 	prev_ts: &mut u64,
-	track_stats: &stats::PublisherTrack,
 ) -> Result<(), Error> {
 	encode_frame_timing(writer, frame, timescale, prev_ts).await?;
 
 	writer.encode(&frame.size).await?;
-	track_stats.frame();
 	while let Some(chunk) = frame.read_chunk().await? {
-		let n = chunk.len() as u64;
 		writer.write_chunk(chunk).await?;
-		track_stats.bytes(n);
 	}
 
 	Ok(())
@@ -1251,7 +1161,6 @@ struct Subscription<S: web_transport_trait::Session> {
 	session: S,
 	id: u64,
 	track_name: Arc<str>,
-	track_stats: Arc<stats::PublisherTrack>,
 	priority: PriorityQueue,
 	track_priority: kio::Consumer<u8>,
 	/// Last track priority observed by this clone, so a change only fires once.
@@ -1418,7 +1327,6 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		stream.set_priority(priority.current());
 		stream.encode(&lite::DataType::Group).await?;
 		stream.encode(&msg).await?;
-		self.track_stats.group();
 
 		// Lite05+ delta-encodes per-frame timestamps within the group. The first
 		// frame's delta is absolute (against an implicit prev value of 0), every
@@ -1465,9 +1373,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 			return;
 		}
 
-		if self.session.send_datagram(body).is_ok() {
-			self.track_stats.group();
-		}
+		let _ = self.session.send_datagram(body);
 	}
 
 	/// Send one frame: the size, then the payload streamed chunk-by-chunk so we
@@ -1482,7 +1388,6 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		encode_frame_timing(stream, &frame, self.timescale, prev_ts).await?;
 
 		stream.encode(&frame.size).await?;
-		self.track_stats.frame();
 
 		while let Some(chunk) = self.read_chunk(stream, priority, &mut frame).await? {
 			self.write_chunk(stream, priority, chunk).await?;
@@ -1589,20 +1494,17 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		self.track_priority_seen
 	}
 
-	/// Write a whole chunk, applying priority changes between partial writes,
-	/// then count the bytes sent.
+	/// Write a whole chunk, applying priority changes between partial writes.
 	async fn write_chunk(
 		&mut self,
 		stream: &mut Writer<S::SendStream, Version>,
 		priority: &mut PriorityHandle,
 		mut chunk: bytes::Bytes,
 	) -> Result<(), Error> {
-		let n = chunk.len() as u64;
 		while chunk.has_remaining() {
 			self.apply_priority(stream, priority);
 			stream.write(&mut chunk).await?;
 		}
-		self.track_stats.bytes(n);
 		Ok(())
 	}
 

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -61,9 +61,9 @@ pub fn start<S: web_transport_trait::Session>(
 	// We will publish any local broadcasts from this origin, when set.
 	publish: Option<origin::Consumer>,
 	// We will consume any remote broadcasts, inserting them into this origin, when set.
+	// Traffic stats are attributed through these origin handles: tag them with
+	// `origin::{Consumer, Producer}::with_stats` before calling `start`.
 	subscribe: Option<origin::Producer>,
-	// Tier-scoped stats handle. Pass [`crate::stats::Handle::default`] to opt out.
-	stats: crate::stats::Handle,
 	// The version of the protocol to use.
 	version: Version,
 	// The capabilities (and optional request path) we advertise in our SETUP message.
@@ -140,14 +140,12 @@ pub fn start<S: web_transport_trait::Session>(
 	let publisher = Publisher::new(PublisherConfig {
 		session: session.clone(),
 		origin: publish,
-		stats: stats.clone(),
 		version,
 	});
 	let subscriber = Subscriber::new(SubscriberConfig {
 		session: session.clone(),
 		origin: subscribe,
 		recv_bandwidth: recv_bw_for_sub,
-		stats,
 		version,
 		peer_setup,
 		// The dialing side prices the link in its own SETUP, so that is also where the

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1,4 +1,4 @@
-use crate::{frame, group, origin, stats, track};
+use crate::{frame, group, origin, track};
 use std::{
 	collections::HashMap,
 	sync::{Arc, atomic},
@@ -23,14 +23,13 @@ use web_async::Lock;
 
 pub(super) struct SubscriberConfig<S: web_transport_trait::Session> {
 	pub session: S,
-	/// The origin into which remote broadcasts are inserted.
+	/// The origin into which remote broadcasts are inserted. Traffic stats are
+	/// attributed through this handle: tag it with [`origin::Producer::with_stats`]
+	/// first.
 	pub origin: origin::Producer,
 	/// Receiver-side bandwidth producer for PROBE feedback. None disables the
 	/// feature (used by versions that don't carry probe streams).
 	pub recv_bandwidth: Option<bandwidth::Producer>,
-	/// Stats aggregator for this session's ingress. Use [`stats::Handle::default`]
-	/// to opt out.
-	pub stats: stats::Handle,
 	pub version: Version,
 	/// Shared slot for the peer's SETUP (lite-05+). Written when the peer's Setup
 	/// stream is read; the probe stream waits on it before opening.
@@ -48,11 +47,6 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 	session: S,
 
 	origin: origin::Producer,
-	stats: stats::Handle,
-	/// Per-session ingress broadcast-subscription tracker. Each upstream
-	/// subscription holds a guard so `broadcasts - broadcasts_closed` counts the
-	/// distinct upstream sessions feeding each broadcast.
-	broadcasts: stats::SessionBroadcasts,
 	recv_bandwidth: Option<bandwidth::Producer>,
 	// Session-level origin id shared with the Publisher. Used to filter out
 	// reflected announces: we ask the peer (via AnnounceInterest.exclude_hop)
@@ -79,7 +73,6 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 #[derive(Clone)]
 struct TrackEntry {
 	producer: track::Producer,
-	stats: Arc<stats::SubscriberTrack>,
 	/// Timestamp scale from this track's TRACK_INFO, known before the SUBSCRIBE is
 	/// even opened, so group streams decode frames without blocking.
 	timescale: Option<Timescale>,
@@ -92,12 +85,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// every session sharing that origin, required for cross-session
 		// loop detection.
 		let self_origin = *config.origin;
-		let broadcasts = config.stats.subscriber_broadcasts();
 		Self {
 			session: config.session,
 			origin: config.origin,
-			stats: config.stats,
-			broadcasts,
 			recv_bandwidth: config.recv_bandwidth,
 			self_origin,
 			session_origin: crate::Origin::random(),
@@ -264,11 +254,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let link_cost = self.resolve_cost().await;
 
 		let mut routes = HashMap::new();
-		// Per-broadcast subscriber-side stats guards. Dropping the guard records
-		// `subscriber.broadcasts_closed`. We only insert a guard when start_announce
-		// actually accepted the announcement (it may drop reflected loops), so the
-		// guard set tracks `routes` exactly.
-		let mut stats_guards: HashMap<PathOwned, stats::Subscriber> = HashMap::new();
 
 		// Lite06+: announce ids. Each received `active` implicitly assigns the next
 		// per-stream ordinal; `ended`/`restart` reference it instead of repeating the
@@ -277,10 +262,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// but a peer may.
 		let mut next_announce_id: u64 = 0;
 		let mut announced_by_id: HashMap<u64, PathOwned> = HashMap::new();
-
-		// Stats keys are absolute paths (matching the publisher side) so the
-		// fanned-out level keys line up with the absolute broadcast paths a
-		// dashboard sees on the origin.
 
 		// `connecting` is a local (a param), not a `self` field, so the `self.clone()` that
 		// start_announce uses for long-lived broadcast tasks doesn't carry the producer
@@ -293,23 +274,17 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				let msg: lite::AnnounceInit = stream.reader.decode().await?;
 				for suffix in msg.suffixes {
 					let path = prefix.join(&suffix);
-					let abs = self.origin.absolute(&path).to_owned();
-					// Count every received name, even ones start_announce drops as loops.
-					self.stats
-						.broadcast(&abs)
-						.subscriber_announced_bytes(abs.as_str().len() as u64);
 					// Lite01/02 don't carry hop information; the broadcast starts with
-					// an empty chain and an unpriced link.
-					if self.start_announce(
+					// an empty chain and an unpriced link. Stats are attributed in the
+					// model when this enters the origin via `create_broadcast`.
+					self.start_announce(
 						path.clone(),
 						crate::OriginList::new(),
 						RouteCost::default(),
 						0,
 						responder_origin,
 						&mut routes,
-					)? {
-						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
-					}
+					)?;
 				}
 			}
 			_ => {
@@ -341,12 +316,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			match announce {
 				lite::AnnounceBroadcast::Active { suffix, hops, cost } => {
 					let path = prefix.join(&suffix);
-					let abs = self.origin.absolute(&path).to_owned();
-					// Count the broadcast name length (not the encoded message size) for
-					// every received announce, even ones start_announce drops as loops.
-					self.stats
-						.broadcast(&abs)
-						.subscriber_announced_bytes(abs.as_str().len() as u64);
 					if self.version.has_announce_id() {
 						// Every `active` assigns the next ordinal, even ones we drop locally.
 						announced_by_id.insert(next_announce_id, path.clone());
@@ -360,16 +329,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						// atomically replace the broadcast. Lite06+ restarts by announce id, and older
 						// versions never defined restarts, so both fall through to start_announce, which
 						// rejects the duplicate (Error::Duplicate).
-						if self.restart_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)? {
-							// Continuity: keep the existing stats guard if present.
-							stats_guards
-								.entry(abs.clone())
-								.or_insert_with(|| self.stats.broadcast(&abs).subscriber());
-						} else {
-							stats_guards.remove(&abs);
-						}
-					} else if self.start_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)? {
-						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
+						self.restart_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)?;
+					} else {
+						self.start_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)?;
 					}
 					// The first `initial_count` Active messages are the initial set; once
 					// they're all in, drop our producer to mark this prefix connected.
@@ -383,11 +345,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				lite::AnnounceBroadcast::Ended { suffix, .. } => {
 					let path = prefix.join(&suffix);
 					tracing::debug!(broadcast = %self.log_path(&path), "unannounced");
-					let abs = self.origin.absolute(&path).to_owned();
-					// Count the unannounce name length whether or not a matching guard exists.
-					self.stats
-						.broadcast(&abs)
-						.subscriber_announced_bytes(abs.as_str().len() as u64);
 
 					// The matching Active may have been silently dropped by
 					// start_announce as a reflected loop, in which case
@@ -396,7 +353,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					// unannounces if this was the broadcast's last route.
 					if let Some(entry) = routes.remove(&path) {
 						entry.finish();
-						stats_guards.remove(&abs);
 					}
 				}
 				lite::AnnounceBroadcast::EndedId { id } => {
@@ -406,11 +362,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 						return Err(Error::ProtocolViolation);
 					};
 					tracing::debug!(broadcast = %self.log_path(&path), "unannounced");
-					let abs = self.origin.absolute(&path).to_owned();
-					// Count the unannounce name length whether or not a matching guard exists.
-					self.stats
-						.broadcast(&abs)
-						.subscriber_announced_bytes(abs.as_str().len() as u64);
 
 					// The matching Active may have been silently dropped by
 					// start_announce as a reflected loop, in which case
@@ -419,7 +370,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					// unannounces if this was the broadcast's last route.
 					if let Some(entry) = routes.remove(&path) {
 						entry.finish();
-						stats_guards.remove(&abs);
 					}
 				}
 				lite::AnnounceBroadcast::Restart { id, hops, cost } => {
@@ -428,23 +378,12 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					let Some(path) = announced_by_id.get(&id).cloned() else {
 						return Err(Error::ProtocolViolation);
 					};
-					let abs = self.origin.absolute(&path).to_owned();
-					self.stats
-						.broadcast(&abs)
-						.subscriber_announced_bytes(abs.as_str().len() as u64);
 					if routes.contains_key(&path) {
-						if self.restart_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)? {
-							// Continuity: keep the existing stats guard if present.
-							stats_guards
-								.entry(abs.clone())
-								.or_insert_with(|| self.stats.broadcast(&abs).subscriber());
-						} else {
-							stats_guards.remove(&abs);
-						}
-					} else if self.start_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)? {
+						self.restart_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)?;
+					} else {
 						// The original announce was dropped locally (e.g. a reflected loop);
 						// the replacement may be routable, so treat it as a fresh start.
-						stats_guards.insert(abs.clone(), self.stats.broadcast(&abs).subscriber());
+						self.start_announce(path.clone(), hops, cost, link_cost, responder_origin, &mut routes)?;
 					}
 				}
 			}
@@ -718,16 +657,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			};
 
 			let name = request.name().to_string();
-			let abs = self.origin.absolute(&path);
-			// Subscriber-side track stats; counters bump as frames/bytes/groups arrive.
-			// subscriber_track avoids double-counting broadcasts: the broadcast lifetime
-			// is tracked separately by the announce loop's `stats_guards`.
-			let track_stats = Arc::new(self.stats.broadcast(&abs).subscriber_track(&name));
 
 			let serve = TrackServe {
 				subscriber: self.clone(),
 				path: path.clone(),
-				track_stats,
 				name,
 			};
 
@@ -777,30 +710,28 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			timestamp,
 			payload: dg.payload,
 		})?;
-		entry.stats.group();
 		Ok(())
 	}
 
 	pub async fn recv_group(&mut self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {
 		let hdr: lite::Group = stream.decode().await?;
 
-		let (mut group, track, track_stats, timescale) = {
+		let (mut group, track, timescale) = {
 			let mut subs = self.subscribes.lock();
 			let entry = subs.get_mut(&hdr.subscribe).ok_or(Error::Cancel)?;
 
 			let group_info = group::Info { sequence: hdr.sequence };
+			// Stats (groups/frames/bytes) are counted in the model as the group is
+			// written, through the tagged `track::Producer`.
 			let group = entry.producer.create_group(group_info)?;
-			(group, entry.producer.clone(), entry.stats.clone(), entry.timescale)
+			(group, entry.producer.clone(), entry.timescale)
 		};
-
-		// Bump groups counter for this incoming group on the subscriber side.
-		track_stats.group();
 
 		// The timescale came from TRACK_INFO (read before this subscription was even
 		// registered), so frames decode immediately. No SUBSCRIBE_OK to wait on.
 
 		let res = {
-			let mut serve = std::pin::pin!(self.run_group(stream, group.clone(), track_stats.clone(), timescale));
+			let mut serve = std::pin::pin!(self.run_group(stream, group.clone(), timescale));
 			kio::wait(|waiter| {
 				if let Poll::Ready(err) = track.poll_closed(waiter) {
 					return Poll::Ready(Err(err));
@@ -833,7 +764,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		stream: &mut Reader<S::RecvStream, Version>,
 		mut group: group::Producer,
-		track_stats: Arc<stats::SubscriberTrack>,
 		timescale: Option<Timescale>,
 	) -> Result<(), Error> {
 		// Previous frame's raw timestamp value (in `timescale` units), for the
@@ -868,9 +798,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			// (pre-lite-05) means local receive time.
 			let timestamp = timestamp.unwrap_or_else(Timestamp::now);
 			let mut frame = group.create_frame(frame::Info { size, timestamp })?;
-			track_stats.frame();
 
-			if let Err(err) = self.run_frame(stream, &mut frame, &track_stats).await {
+			if let Err(err) = self.run_frame(stream, &mut frame).await {
 				let _ = frame.abort(err.clone());
 				return Err(err);
 			}
@@ -885,12 +814,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		&mut self,
 		stream: &mut Reader<S::RecvStream, Version>,
 		frame: &mut frame::Producer<'_>,
-		track_stats: &stats::SubscriberTrack,
 	) -> Result<(), Error> {
 		while frame.remaining() > 0 {
 			match stream.read_chunk(frame.remaining()).await? {
 				Some(chunk) if !chunk.is_empty() => {
-					track_stats.bytes(chunk.len() as u64);
 					frame.write(chunk)?;
 				}
 				_ => return Err(Error::WrongSize),
@@ -925,8 +852,6 @@ struct SubStream<S: web_transport_trait::Session> {
 	max_latency: Duration,
 	start_group: Option<u64>,
 	priority: u8,
-	/// Per-(session, broadcast) viewer sentinel, held for the subscription's life.
-	_broadcast_sub: stats::BroadcastSubscription,
 }
 
 enum Sub<S: web_transport_trait::Session> {
@@ -998,7 +923,6 @@ enum Event {
 struct TrackServe<S: web_transport_trait::Session> {
 	subscriber: Subscriber<S>,
 	path: PathOwned,
-	track_stats: Arc<stats::SubscriberTrack>,
 	name: String,
 }
 
@@ -1330,11 +1254,6 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		// Pre-lite-05 acknowledges with SUBSCRIBE_OK; it arrives on this stream and
 		// is consumed (and logged) by the serve loop's response arm.
 
-		// This session is now actively feeding the broadcast, so take the per-(session,
-		// broadcast) viewer sentinel for the subscription's life.
-		let abs = self.subscriber.origin.absolute(&self.path).to_owned();
-		let broadcast_sub = self.subscriber.broadcasts.subscribe(&abs);
-
 		// Register before the SUBSCRIBE hits the wire. `id` is live the moment the peer
 		// reads it, and a publisher may serve its first group immediately, so a late
 		// insert races the group stream: `recv_group` would find no entry and drop it,
@@ -1343,7 +1262,6 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			id,
 			TrackEntry {
 				producer: producer.clone(),
-				stats: self.track_stats.clone(),
 				timescale,
 			},
 		);
@@ -1394,7 +1312,6 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			max_latency: subscription.latency_max,
 			start_group: subscription.group_start,
 			priority: subscription.priority,
-			_broadcast_sub: broadcast_sub,
 		});
 
 		Ok(())
@@ -1421,7 +1338,6 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		let TrackServe {
 			mut subscriber,
 			path,
-			track_stats,
 			name,
 		} = self;
 		let group = request.sequence();
@@ -1470,7 +1386,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		};
 
 		let res = subscriber
-			.run_group(&mut stream.reader, producer.clone(), track_stats, timescale)
+			.run_group(&mut stream.reader, producer.clone(), timescale)
 			.await;
 		match res {
 			Ok(()) => {

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -7,7 +7,7 @@
 //!
 //! [Info] is the static metadata; [Route] is the dynamic path the broadcast takes to
 //! reach an origin, including whether it is announced to subscribers.
-use crate::track;
+use crate::{stats, track};
 use std::{
 	collections::{HashMap, VecDeque},
 	sync::Arc,
@@ -258,6 +258,11 @@ pub struct Producer {
 	// Track registry plus the dynamic request queue, mutated by producers and
 	// consumers alike under one lock.
 	state: kio::Shared<BroadcastState>,
+
+	// Ingress stats scope, set by a tagged `origin::Producer` at
+	// `create_broadcast`. Inherited by the tracks this producer creates. Empty
+	// (no-op) for an untagged broadcast.
+	stats: stats::Scope,
 }
 
 impl Producer {
@@ -267,7 +272,15 @@ impl Producer {
 			info: Arc::new(info),
 			alive: Default::default(),
 			state: Default::default(),
+			stats: stats::Scope::default(),
 		}
+	}
+
+	/// Attach an ingress stats scope, inherited by the tracks created on this
+	/// broadcast. Set by a tagged `origin::Producer` at `create_broadcast`.
+	pub(crate) fn with_stats(mut self, scope: stats::Scope) -> Self {
+		self.stats = scope;
+		self
 	}
 
 	/// Create a route-fed (spliced) broadcast: consumer track lookups mint logical
@@ -281,6 +294,9 @@ impl Producer {
 				spliced: Some(SplicedState::default()),
 				..Default::default()
 			}),
+			// The origin-owned spliced broadcast stays untagged: egress attribution is
+			// applied when a tagged `origin::Consumer` hands the consumer out.
+			stats: stats::Scope::default(),
 		}
 	}
 
@@ -313,7 +329,7 @@ impl Producer {
 		info: impl Into<Option<track::Info>>,
 	) -> Result<track::Producer, Error> {
 		let info = info.into().unwrap_or_default();
-		let track = track::Producer::new(self.info.clone(), name, info);
+		let track = track::Producer::new(self.info.clone(), name, info).with_stats(self.stats.clone());
 		self.state.lock().insert_track(track.weak())?;
 		Ok(track)
 	}
@@ -326,7 +342,7 @@ impl Producer {
 	/// inspected the media, the same shape as a consumer-driven
 	/// [`Dynamic::requested_track`].
 	pub fn reserve_track(&mut self, name: impl Into<Arc<str>>) -> Result<track::Request, Error> {
-		let request = track::Request::new(self.info.clone(), name);
+		let request = track::Request::new(self.info.clone(), name).with_stats(self.stats.clone());
 		self.state.lock().insert_track(request.weak())?;
 		Ok(request)
 	}
@@ -359,7 +375,12 @@ impl Producer {
 
 	/// Create a dynamic producer that handles on-demand track requests from consumers.
 	pub fn dynamic(&self) -> Dynamic {
-		Dynamic::new(self.info.clone(), self.alive.clone(), self.state.clone())
+		Dynamic::new(
+			self.info.clone(),
+			self.alive.clone(),
+			self.state.clone(),
+			self.stats.clone(),
+		)
 	}
 
 	/// Set the broadcast's [`Route`]: the hop chain and cost it advertises.
@@ -414,6 +435,7 @@ impl Producer {
 			alive: self.alive.consume(),
 			state: self.state.clone(),
 			route_seen: None,
+			stats: stats::Scope::default(),
 		}
 	}
 
@@ -533,6 +555,9 @@ pub struct Dynamic {
 	// Keeps the broadcast alive while a handler exists (mirrors a producer).
 	alive: kio::Producer<()>,
 	state: kio::Shared<BroadcastState>,
+	// Ingress stats scope, applied to the tracks this handler serves. Empty (no-op)
+	// for an untagged broadcast.
+	stats: stats::Scope,
 }
 
 impl Clone for Dynamic {
@@ -546,15 +571,21 @@ impl Clone for Dynamic {
 			info: self.info.clone(),
 			alive: self.alive.clone(),
 			state: self.state.clone(),
+			stats: self.stats.clone(),
 		}
 	}
 }
 
 impl Dynamic {
-	fn new(info: Arc<Info>, alive: kio::Producer<()>, state: kio::Shared<BroadcastState>) -> Self {
+	fn new(info: Arc<Info>, alive: kio::Producer<()>, state: kio::Shared<BroadcastState>, stats: stats::Scope) -> Self {
 		state.lock().requests.add_handler();
 
-		Self { info, alive, state }
+		Self {
+			info,
+			alive,
+			state,
+			stats,
+		}
 	}
 
 	/// The broadcast's static metadata, fixed when it was created.
@@ -585,7 +616,8 @@ impl Dynamic {
 		// Cache the served track so concurrent lookups coalesce onto it. If a live track already
 		// holds the name (a publish raced the request), `insert` keeps it rather than shadowing it.
 		let _ = state.tracks.insert(name, pending.weak());
-		Poll::Ready(Ok(pending))
+		// Attribute the served track to this broadcast's ingress scope (no-op untagged).
+		Poll::Ready(Ok(pending.with_stats(self.stats.clone())))
 	}
 
 	/// Block until a consumer requests a track, returning a [`track::Request`] to serve.
@@ -600,6 +632,7 @@ impl Dynamic {
 			alive: self.alive.consume(),
 			state: self.state.clone(),
 			route_seen: None,
+			stats: stats::Scope::default(),
 		}
 	}
 
@@ -663,6 +696,10 @@ pub struct Consumer {
 	// The route epoch last yielded by `route_changed`, so each consumer clone
 	// observes the current route first and every change after it exactly once.
 	route_seen: Option<u64>,
+	// Egress stats scope, set by a tagged `origin::Consumer` at the broadcast
+	// handoff. Inherited by the tracks subscribed through this handle. Empty (no-op)
+	// for an untagged broadcast.
+	stats: stats::Scope,
 }
 
 impl Clone for Consumer {
@@ -674,11 +711,19 @@ impl Clone for Consumer {
 			// Reset the cursor so the clone observes the current route first,
 			// even if the original already drained `route_changed`.
 			route_seen: None,
+			stats: self.stats.clone(),
 		}
 	}
 }
 
 impl Consumer {
+	/// Attach an egress stats scope, inherited by the tracks subscribed through this
+	/// handle. Set by a tagged `origin::Consumer` at the broadcast handoff.
+	pub(crate) fn with_stats(mut self, scope: stats::Scope) -> Self {
+		self.stats = scope;
+		self
+	}
+
 	/// The broadcast's static metadata, fixed when it was created.
 	pub fn info(&self) -> &Info {
 		&self.info
@@ -718,6 +763,12 @@ impl Consumer {
 
 	/// Get a handle to a track on this broadcast.
 	pub fn track(&self, name: &str) -> Result<track::Consumer, Error> {
+		// Tag the resolved track with this broadcast's egress scope so its
+		// subscriptions, fetches, and groups are attributed to the same broadcast.
+		self.track_inner(name).map(|track| track.with_stats(self.stats.clone()))
+	}
+
+	fn track_inner(&self, name: &str) -> Result<track::Consumer, Error> {
 		// A closed broadcast (every producer and handler gone) serves nothing.
 		if self.is_closed() {
 			return Err(Error::Dropped);
@@ -850,6 +901,7 @@ impl WeakConsumer {
 			alive: self.alive.consume(),
 			state: self.state.clone(),
 			route_seen: None,
+			stats: stats::Scope::default(),
 		}
 	}
 }

--- a/rs/moq-net/src/model/frame.rs
+++ b/rs/moq-net/src/model/frame.rs
@@ -13,7 +13,7 @@ use std::task::{Poll, ready};
 use bytes::Bytes;
 
 use crate::group::{self, GroupState};
-use crate::{Error, IntoBytes, Result, Timestamp};
+use crate::{Error, IntoBytes, Result, Timestamp, stats};
 
 /// A chunk of data with an upfront size and a presentation timestamp.
 ///
@@ -224,6 +224,9 @@ pub struct Producer<'a> {
 	info: Info,
 	// Set once the frame is committed (finished) or aborted, so Drop is a no-op.
 	done: bool,
+	// Ingress payload meter, inherited from the parent group. Counts each written
+	// chunk's bytes. Empty (no-op) for an untagged group.
+	stats: stats::Meter,
 }
 
 impl std::ops::Deref for Producer<'_> {
@@ -241,7 +244,14 @@ impl<'a> Producer<'a> {
 			buf,
 			info,
 			done: false,
+			stats: stats::Meter::default(),
 		}
+	}
+
+	/// Attach the parent group's ingress meter, so written chunks bump `bytes`.
+	pub(crate) fn with_meter(mut self, meter: stats::Meter) -> Self {
+		self.stats = meter;
+		self
 	}
 
 	/// The parent group this frame belongs to.
@@ -262,6 +272,8 @@ impl<'a> Producer<'a> {
 		if len > self.remaining() {
 			return Err(Error::WrongSize);
 		}
+		// Ingress payload: count the chunk's bytes as they're written.
+		self.stats.bytes(len as u64);
 		// Fast path: a single whole-frame write keeps the caller's allocation.
 		if len == self.buf.capacity() && self.buf.written(Ordering::Acquire) == 0 {
 			match self.buf.try_set_bytes(chunk.into_bytes()) {
@@ -339,6 +351,10 @@ pub struct Consumer {
 	source: Source,
 	// Byte offset consumed so far.
 	read_idx: usize,
+	// Egress payload meter. Set only for frames read directly from the group (not
+	// from the prefetch batch, whose bytes were already counted at fill), so chunks
+	// bump `bytes` exactly once. Empty (no-op) otherwise.
+	stats: stats::Meter,
 }
 
 impl std::ops::Deref for Consumer {
@@ -356,7 +372,15 @@ impl Consumer {
 			info,
 			source,
 			read_idx: 0,
+			stats: stats::Meter::default(),
 		}
+	}
+
+	/// Attach an egress meter so read-out chunks bump `bytes`. Used only for frames
+	/// read directly from the group (whose bytes weren't counted at a batch fill).
+	pub(crate) fn with_meter(mut self, meter: stats::Meter) -> Self {
+		self.stats = meter;
+		self
 	}
 
 	/// Poll for the next chunk of bytes since the last read.
@@ -370,6 +394,7 @@ impl Consumer {
 				}
 				let out = bytes.slice(self.read_idx..);
 				self.read_idx = bytes.len();
+				self.stats.bytes(out.len() as u64);
 				Poll::Ready(Ok(Some(out)))
 			}
 			Source::Partial(buf) => {
@@ -380,6 +405,7 @@ impl Consumer {
 					if written > self.read_idx {
 						let out = buf.slice(self.read_idx, written);
 						self.read_idx = written;
+						self.stats.bytes(out.len() as u64);
 						return Poll::Ready(Ok(Some(out)));
 					}
 					if written >= size {
@@ -415,6 +441,7 @@ impl Consumer {
 			Source::Complete(bytes) => {
 				let out = bytes.slice(self.read_idx..);
 				self.read_idx = bytes.len();
+				self.stats.bytes(out.len() as u64);
 				Poll::Ready(Ok(out))
 			}
 			Source::Partial(buf) => {
@@ -433,6 +460,7 @@ impl Consumer {
 				})?);
 				let out = buf.slice(read_idx, size);
 				self.read_idx = size;
+				self.stats.bytes(out.len() as u64);
 				Poll::Ready(Ok(out))
 			}
 		}

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -10,7 +10,7 @@
 //! The stream is closed with [Error] when all writers or readers are dropped.
 use crate::cache;
 use crate::frame::{self, Frame, FrameBuf};
-use crate::{Timescale, track};
+use crate::{Timescale, stats, track};
 use std::collections::VecDeque;
 use std::mem::MaybeUninit;
 use std::sync::Arc;
@@ -220,6 +220,10 @@ pub struct Producer {
 	// timestamp into the track scale before it enters the stream. Threaded down by
 	// value from [`track::Producer::create_group`] / `append_group`.
 	track: track::Info,
+
+	// Ingress payload meter, set by a tagged [`track::Producer`] via
+	// [`Self::with_meter`]. Empty (no-op) for an untagged group.
+	stats: stats::Meter,
 }
 
 impl std::ops::Deref for Producer {
@@ -246,7 +250,20 @@ impl Producer {
 		let weak = state.weak();
 		let charge = track.broadcast.origin.pool.register(Box::new(move || evict(&weak)));
 		state.write().ok().expect("a new group is open").charge = charge;
-		Self { info, state, track }
+		Self {
+			info,
+			state,
+			track,
+			stats: stats::Meter::default(),
+		}
+	}
+
+	/// Attach an ingress payload meter, counting this as one delivered group.
+	/// Called by a tagged [`track::Producer`] when it creates the group.
+	pub(crate) fn with_meter(mut self, meter: stats::Meter) -> Self {
+		meter.group();
+		self.stats = meter;
+		self
 	}
 
 	/// The group header.
@@ -290,6 +307,10 @@ impl Producer {
 		// lock. Reached via the parent chain; a no-op when the pool is unbounded.
 		drop(state);
 		self.track.broadcast.origin.pool.evict();
+
+		// Ingress payload: one whole frame written.
+		self.stats.frames(1);
+		self.stats.bytes(size);
 		Ok(())
 	}
 
@@ -329,11 +350,16 @@ impl Producer {
 		drop(state);
 		self.track.broadcast.origin.pool.evict();
 
+		// Ingress payload: one frame opened; its bytes are counted per chunk as the
+		// frame::Producer writes them.
+		self.stats.frames(1);
+		let meter = self.stats.clone();
+
 		let info = frame::Info {
 			size: frame.size,
 			timestamp,
 		};
-		Ok(frame::Producer::new(self, buf, info))
+		Ok(frame::Producer::new(self, buf, info).with_meter(meter))
 	}
 
 	/// Wake consumers parked on the group channel (called after a partial write).
@@ -404,6 +430,9 @@ impl Producer {
 			track: self.track.clone(),
 			index: 0,
 			prefetch: Prefetch::default(),
+			// Untagged: a tagged track attaches the egress meter via `with_meter`
+			// when it hands the consumer to a subscriber/fetch.
+			stats: stats::Meter::default(),
 		}
 	}
 
@@ -434,6 +463,7 @@ impl Clone for Producer {
 			info: self.info,
 			state: self.state.clone(),
 			track: self.track.clone(),
+			stats: self.stats.clone(),
 		}
 	}
 }
@@ -498,6 +528,17 @@ impl Prefetch {
 			self.len += 1;
 		}
 	}
+
+	/// `(frame count, total payload bytes)` of the buffered, not-yet-taken frames.
+	/// Read once per fill to bump the egress payload counters for the whole batch.
+	fn buffered(&self) -> (u64, u64) {
+		let mut bytes = 0u64;
+		for slot in &self.frames[self.pos..self.len] {
+			// SAFETY: slots in `pos..len` are initialized (written by `fill`, not yet popped).
+			bytes += unsafe { slot.assume_init_ref() }.payload.len() as u64;
+		}
+		((self.len - self.pos) as u64, bytes)
+	}
 }
 
 impl Default for Prefetch {
@@ -537,6 +578,10 @@ pub struct Consumer {
 
 	// A batch of completed frames drained ahead under one lock (whole-frame reads only).
 	prefetch: Prefetch,
+
+	// Egress payload meter, set by a tagged track via [`Self::with_meter`]. Empty
+	// (no-op) for an untagged group.
+	stats: stats::Meter,
 }
 
 impl Clone for Consumer {
@@ -549,6 +594,9 @@ impl Clone for Consumer {
 			track: self.track.clone(),
 			index: self.index,
 			prefetch: Prefetch::default(),
+			// Inherit the meter without re-counting the group: the original already
+			// counted it when the track handed it out.
+			stats: self.stats.clone(),
 		}
 	}
 }
@@ -562,6 +610,14 @@ impl std::ops::Deref for Consumer {
 }
 
 impl Consumer {
+	/// Attach an egress payload meter, counting this as one delivered group.
+	/// Called by a tagged track when it hands the consumer to a subscriber or fetch.
+	pub(crate) fn with_meter(mut self, meter: stats::Meter) -> Self {
+		meter.group();
+		self.stats = meter;
+		self
+	}
+
 	/// The parent track's timescale.
 	pub fn timescale(&self) -> Timescale {
 		self.track.timescale
@@ -589,6 +645,8 @@ impl Consumer {
 	/// Returns None if the group is finished and the index is out of range.
 	pub fn poll_next_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<frame::Consumer>>> {
 		// Hand out any frames a prior read_frame prefetched before touching the tail.
+		// Their bytes were already counted at the batch fill, so the frame::Consumer
+		// carries no meter.
 		if let Some(frame) = self.prefetch.pop() {
 			self.index += 1;
 			let info = frame::Info {
@@ -605,7 +663,12 @@ impl Consumer {
 		};
 
 		self.index += 1;
-		Poll::Ready(Ok(Some(frame::Consumer::new(self.state.clone(), info, source))))
+		// A direct read (not prefetched): count the frame here; the frame::Consumer
+		// counts its bytes per chunk as they're read out.
+		self.stats.frames(1);
+		Poll::Ready(Ok(Some(
+			frame::Consumer::new(self.state.clone(), info, source).with_meter(self.stats.clone()),
+		)))
 	}
 
 	/// Read the next frame (timestamp and payload) all at once, without blocking.
@@ -653,6 +716,12 @@ impl Consumer {
 			Ok(Err(err)) => return Poll::Ready(Err(err)),
 			Err(state) => return Poll::Ready(Err(state.abort.clone().unwrap_or(Error::Dropped))),
 		}
+
+		// A fresh batch was just filled (empty only on a clean end). Count the whole
+		// batch once here, under no lock, so the drained pops that follow stay free.
+		let (frames, bytes) = self.prefetch.buffered();
+		self.stats.frames(frames);
+		self.stats.bytes(bytes);
 
 		Poll::Ready(Ok(self.prefetch.pop().inspect(|_| {
 			self.index += 1;

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -2609,6 +2609,60 @@ mod tests {
 		assert_eq!(entry.publisher.broadcasts, 1, "fetch does not bump the viewer refcount");
 	}
 
+	/// `Subscriber::read_frame` collapses a group to its first frame. The paths it
+	/// delegates to (plain and spliced) build their own *unmetered* group consumers,
+	/// so the wrapper is the only place that can attribute the read: exactly one
+	/// group, one frame, and the payload bytes, counted once each.
+	#[tokio::test]
+	async fn test_stats_read_frame_counts_once() {
+		use crate::Timestamp;
+		use crate::stats::{Config, Registry, Tier};
+		use bytes::Bytes;
+
+		tokio::time::pause();
+
+		let registry = Registry::new(Config::new());
+		let ctx = registry.tier(Tier::default()).session("acme");
+
+		let origin = Origin::random().produce();
+		let ingress = origin.clone().with_stats(ctx.clone());
+		let egress = origin.consume().with_stats(ctx.clone());
+
+		let mut announced = egress.announced();
+		let source = ingress.create_broadcast("demo", announce()).unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+
+		let broadcast = announced.next().await.unwrap().broadcast.unwrap();
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		let mut producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+		let mut sub = subscribing.await.unwrap();
+
+		// A single-frame group, read back through the collapsing helper.
+		producer
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"hello"))
+			.unwrap();
+
+		let frame = sub.read_frame().await.unwrap().expect("frame");
+		assert_eq!(frame.payload.len(), 5);
+		settle().await;
+
+		let report = registry.report();
+		let entry = report
+			.traffic
+			.iter()
+			.find(|e| e.path.as_str() == "demo")
+			.expect("demo tracked");
+		assert_eq!(entry.publisher.groups, 1, "one group, counted once");
+		assert_eq!(entry.publisher.frames, 1, "one frame, counted once");
+		assert_eq!(
+			entry.publisher.bytes, 5,
+			"payload counted once, not zero and not doubled"
+		);
+	}
+
 	#[test]
 	fn origin_rejects_reserved_ids() {
 		assert!(Origin::new(0).is_err());

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1,4 +1,4 @@
-use crate::{broadcast, cache, track};
+use crate::{broadcast, cache, stats, track};
 use kio::Pollable;
 use std::{
 	collections::{BTreeMap, HashMap},
@@ -768,6 +768,11 @@ pub struct Producer {
 	// The cache pool inherited by broadcasts created under this origin (sessions
 	// mint their remote broadcasts with it). Unbounded by default.
 	pool: cache::Pool,
+
+	// Ingress stats context. Broadcasts created through this producer are attributed
+	// to it (writes counted on the subscriber/ingress side). Empty (no-op) unless a
+	// session tagged this handle via [`Self::with_stats`].
+	stats: stats::Session,
 }
 
 impl std::ops::Deref for Producer {
@@ -789,7 +794,16 @@ impl Producer {
 			root: PathOwned::default(),
 			dynamic: kio::Shared::default(),
 			pool: info.pool,
+			stats: stats::Session::default(),
 		}
+	}
+
+	/// Attach an ingress stats context: broadcasts created through this handle (and
+	/// any handle derived from it) are attributed to `session` on the subscriber
+	/// (ingress) side. Pass [`stats::Session::default`] to opt out.
+	pub fn with_stats(mut self, session: stats::Session) -> Self {
+		self.stats = session;
+		self
 	}
 
 	/// This origin's [`Info`] (identity + cache pool), the parent handle a broadcast
@@ -812,6 +826,7 @@ impl Producer {
 			root: PathOwned::default(),
 			dynamic: kio::Shared::default(),
 			pool: cache::Pool::default(),
+			stats: stats::Session::default(),
 		}
 	}
 
@@ -869,10 +884,17 @@ impl Producer {
 			return Err(BoundsExceeded.into());
 		}
 
-		let mut source = broadcast::Info { origin: self.info() }.produce();
+		// Resolve the ingress counters once, keyed by the absolute broadcast path.
+		// The source producer tags its tracks; run_source drives the announce guard
+		// off route transitions.
+		let ingress = self.stats.ingress(&full);
+
+		let mut source = broadcast::Info { origin: self.info() }
+			.produce()
+			.with_stats(ingress.clone());
 		source.set_route(route).expect("fresh producer");
 
-		web_async::spawn(run_source(self.info(), node, full, rest, source.consume()));
+		web_async::spawn(run_source(self.info(), node, full, rest, source.consume(), ingress));
 
 		Ok(source)
 	}
@@ -890,6 +912,7 @@ impl Producer {
 			root: self.root.clone(),
 			dynamic: self.dynamic.clone(),
 			pool: self.pool.clone(),
+			stats: self.stats.clone(),
 		})
 	}
 
@@ -910,7 +933,15 @@ impl Producer {
 	/// Use [`Consumer::announced`] to register interest and start receiving
 	/// announcement events; the consumer itself does not allocate any channels.
 	pub fn consume(&self) -> Consumer {
-		Consumer::new(self.info, self.root.clone(), self.nodes.clone(), self.dynamic.clone())
+		// Untagged: a session tags the egress consumer separately via
+		// `origin::Consumer::with_stats` (ingress and egress are distinct sides).
+		Consumer::new(
+			self.info,
+			self.root.clone(),
+			self.nodes.clone(),
+			self.dynamic.clone(),
+			stats::Session::default(),
+		)
 	}
 
 	/// Handle to the announcement stream for this producer's subtree.
@@ -935,6 +966,7 @@ impl Producer {
 			nodes: self.nodes.root(&prefix)?,
 			dynamic: self.dynamic.clone(),
 			pool: self.pool.clone(),
+			stats: self.stats.clone(),
 		})
 	}
 
@@ -1121,6 +1153,7 @@ async fn run_source(
 	full: PathOwned,
 	rest: PathOwned,
 	mut source: broadcast::Consumer,
+	ingress: stats::Scope,
 ) {
 	// The first `route_changed` yields the current route immediately; nothing is
 	// visible to consumers until this attach, giving the creator a window to set
@@ -1129,6 +1162,12 @@ async fn run_source(
 		// Closed before ever attaching; nothing became visible.
 		return;
 	};
+
+	// Ingress announce guard: held while this source's route is announced. Opening
+	// bumps `announced` + `announced_bytes`; dropping (route offline, or the source
+	// closing below) bumps `announced_closed` + `announced_bytes`. Empty scope =
+	// no-op.
+	let mut announce = route.announce.then(|| ingress.announce());
 
 	let leaf = if rest.is_empty() {
 		node.clone()
@@ -1141,6 +1180,7 @@ async fn run_source(
 	loop {
 		match source.route_changed().await {
 			Ok(route) => {
+				let announced = route.announce;
 				{
 					let carrying = broadcast.demand().is_used();
 					let Ok(mut s) = state.write() else { return };
@@ -1152,6 +1192,12 @@ async fn run_source(
 					}
 					entry.route = route;
 					s.reselect(carrying);
+				}
+				// Toggle the ingress announce guard on a live/offline transition.
+				match (announced, announce.is_some()) {
+					(true, false) => announce = Some(ingress.announce()),
+					(false, true) => announce = None,
+					_ => {}
 				}
 				sync_front(&state, &broadcast, &leaf);
 			}
@@ -1663,6 +1709,9 @@ impl Drop for Request {
 /// handler drops before serving it.
 pub struct Requesting {
 	inner: RequestState,
+	// Egress scope applied to the resolved broadcast, so its reads are attributed.
+	// Empty (no-op) for an untagged consumer.
+	stats: stats::Scope,
 }
 
 enum RequestState {
@@ -1679,32 +1728,40 @@ impl Requesting {
 	fn ready(broadcast: broadcast::Consumer) -> Self {
 		Self {
 			inner: RequestState::Ready(broadcast),
+			stats: stats::Scope::default(),
 		}
 	}
 
 	fn failed(error: Error) -> Self {
 		Self {
 			inner: RequestState::Failed(error),
+			stats: stats::Scope::default(),
 		}
 	}
 
 	fn pending(consumer: kio::Consumer<PendingBroadcast>) -> Self {
 		Self {
 			inner: RequestState::Pending(consumer),
+			stats: stats::Scope::default(),
 		}
+	}
+
+	fn with_stats(mut self, scope: stats::Scope) -> Self {
+		self.stats = scope;
+		self
 	}
 
 	/// Poll for the requested broadcast without blocking.
 	pub fn poll_ok(&self, waiter: &kio::Waiter) -> Poll<Result<broadcast::Consumer, Error>> {
 		match &self.inner {
-			RequestState::Ready(broadcast) => Poll::Ready(Ok(broadcast.clone())),
+			RequestState::Ready(broadcast) => Poll::Ready(Ok(broadcast.clone().with_stats(self.stats.clone()))),
 			RequestState::Failed(error) => Poll::Ready(Err(error.clone())),
 			RequestState::Pending(consumer) => Poll::Ready(
 				match ready!(consumer.poll(waiter, |state| match &state.resolved {
 					Some(result) => Poll::Ready(result.clone()),
 					None => Poll::Pending,
 				})) {
-					Ok(result) => result,
+					Ok(result) => result.map(|broadcast| broadcast.with_stats(self.stats.clone())),
 					// Every handler dropped without resolving: nobody could route it.
 					Err(_closed) => Err(Error::Unroutable),
 				},
@@ -1742,8 +1799,15 @@ impl<T, U: Consume<T>> Consume<T> for &U {
 impl Consume<Consumer> for Producer {
 	fn consume(&self) -> Consumer {
 		// Mirrors the inherent `Producer::consume`; inlined to avoid the
-		// inherent-vs-trait `consume` ambiguity.
-		Consumer::new(self.info, self.root.clone(), self.nodes.clone(), self.dynamic.clone())
+		// inherent-vs-trait `consume` ambiguity. Untagged: egress is tagged
+		// separately from ingress.
+		Consumer::new(
+			self.info,
+			self.root.clone(),
+			self.nodes.clone(),
+			self.dynamic.clone(),
+			stats::Session::default(),
+		)
 	}
 }
 
@@ -1795,6 +1859,11 @@ pub struct Consumer {
 	// Shared fallback request queue, fed to any `Dynamic` handler on the
 	// producer side. Used only by `request_broadcast`; announced lookups ignore it.
 	dynamic: kio::Shared<OriginDynamicState>,
+
+	// Egress stats context. Broadcasts handed out through this consumer (and any
+	// handle derived from them) are attributed to it (reads counted on the
+	// publisher/egress side). Empty (no-op) unless a session tagged this handle.
+	stats: stats::Session,
 }
 
 impl std::ops::Deref for Consumer {
@@ -1806,12 +1875,37 @@ impl std::ops::Deref for Consumer {
 }
 
 impl Consumer {
-	fn new(info: Origin, root: PathOwned, nodes: OriginNodes, dynamic: kio::Shared<OriginDynamicState>) -> Self {
+	fn new(
+		info: Origin,
+		root: PathOwned,
+		nodes: OriginNodes,
+		dynamic: kio::Shared<OriginDynamicState>,
+		stats: stats::Session,
+	) -> Self {
 		Self {
 			info,
 			nodes,
 			root,
 			dynamic,
+			stats,
+		}
+	}
+
+	/// Attach an egress stats context: broadcasts handed out through this handle (and
+	/// any handle derived from it) are attributed to `session` on the publisher
+	/// (egress) side. Pass [`stats::Session::default`] to opt out.
+	pub fn with_stats(mut self, session: stats::Session) -> Self {
+		self.stats = session;
+		self
+	}
+
+	/// A clone of this consumer with its stats context cleared, so an internal
+	/// lookup stream (e.g. [`Self::announced_broadcast`]) doesn't drive the egress
+	/// announce guards; the caller re-attributes the result itself.
+	fn untagged(&self) -> Self {
+		Self {
+			stats: stats::Session::default(),
+			..self.clone()
 		}
 	}
 
@@ -1825,6 +1919,7 @@ impl Consumer {
 			nodes: OriginNodes { nodes: Vec::new() },
 			root: self.root.clone(),
 			dynamic: self.dynamic.clone(),
+			stats: self.stats.clone(),
 		}
 	}
 
@@ -1835,7 +1930,7 @@ impl Consumer {
 	/// set as initial announcements. Drop the returned [`AnnounceConsumer`]
 	/// to unregister.
 	pub fn announced(&self) -> AnnounceConsumer {
-		AnnounceConsumer::new(self.root.clone(), self.nodes.clone())
+		AnnounceConsumer::new(self.root.clone(), self.nodes.clone(), self.stats.clone())
 	}
 
 	/// Returns a cheap duplicate of this read handle.
@@ -1880,7 +1975,11 @@ impl Consumer {
 			return None;
 		}
 
-		let mut announced = consumer.announced();
+		// Use an untagged stream: this is a lookup, not egress announce forwarding, so
+		// it must not drive the announce guards. The matched result is attributed
+		// with the egress scope instead.
+		let mut announced = consumer.untagged().announced();
+		let scope = self.stats.egress(self.root.join(&path).to_owned());
 		loop {
 			let OriginAnnounce {
 				path: announced_path,
@@ -1889,7 +1988,7 @@ impl Consumer {
 			// `scope` narrows by prefix, but we only want an exact-path match.
 			if announced_path.as_path() == path {
 				if let Some(broadcast) = broadcast {
-					return Some(broadcast);
+					return Some(broadcast.with_stats(scope));
 				}
 			}
 		}
@@ -1907,6 +2006,7 @@ impl Consumer {
 			self.root.clone(),
 			self.nodes.select(&prefixes)?,
 			self.dynamic.clone(),
+			self.stats.clone(),
 		))
 	}
 
@@ -1931,14 +2031,16 @@ impl Consumer {
 	pub fn request_broadcast(&self, path: impl AsPath) -> kio::Pending<Requesting> {
 		let path = path.as_path();
 
+		// Key requests by absolute path so a scoped/rooted consumer and the handler
+		// (which may have a different root) agree on the same entry, and so the egress
+		// counters resolve against the same broadcast the ingress side wrote.
+		let absolute = self.root.join(&path).to_owned();
+		let scope = self.stats.egress(&absolute);
+
 		// Prefer a live announcement when one is present; the dynamic queue is only a fallback.
 		if let Some(broadcast) = self.get_broadcast(&path) {
-			return kio::Pending::new(Requesting::ready(broadcast));
+			return kio::Pending::new(Requesting::ready(broadcast).with_stats(scope));
 		}
-
-		// Key requests by absolute path so a scoped/rooted consumer and the handler
-		// (which may have a different root) agree on the same entry.
-		let absolute = self.root.join(&path).to_owned();
 
 		let mut state = self.dynamic.lock();
 
@@ -1946,7 +2048,7 @@ impl Consumer {
 		// requests share one upstream subscription. A closed entry is stale; `get` drops it
 		// and returns `None`, so we fall through and re-serve below.
 		if let Some(weak) = state.served.get(&absolute) {
-			return kio::Pending::new(Requesting::ready(weak.consume()));
+			return kio::Pending::new(Requesting::ready(weak.consume()).with_stats(scope));
 		}
 
 		// Coalesce onto a pending request for the same path; otherwise register a new
@@ -1962,7 +2064,7 @@ impl Consumer {
 			consumer
 		};
 
-		kio::Pending::new(Requesting::pending(consumer))
+		kio::Pending::new(Requesting::pending(consumer).with_stats(scope))
 	}
 
 	/// Returns a new Consumer that automatically strips out the provided prefix.
@@ -1977,6 +2079,7 @@ impl Consumer {
 			self.root.join(&prefix).to_owned(),
 			self.nodes.root(&prefix)?,
 			self.dynamic.clone(),
+			self.stats.clone(),
 		))
 	}
 
@@ -2018,7 +2121,9 @@ impl AnnounceProducer {
 	/// as initial announcements. Drop the returned [`AnnounceConsumer`] to
 	/// unregister.
 	pub fn consume(&self) -> AnnounceConsumer {
-		AnnounceConsumer::new(self.root.clone(), self.nodes.clone())
+		// Untagged: `AnnounceProducer` is used for internal announce plumbing, not
+		// egress attribution (which flows through `origin::Consumer::announced`).
+		AnnounceConsumer::new(self.root.clone(), self.nodes.clone(), stats::Session::default())
 	}
 
 	/// Returns the prefix that is automatically stripped from announced paths.
@@ -2039,10 +2144,19 @@ pub struct AnnounceConsumer {
 	// Pending updates queued for this cursor. Coalesced so a slow consumer
 	// can't accumulate redundant announce/unannounce pairs.
 	state: kio::Producer<OriginConsumerState>,
+
+	// Egress stats context (empty for an untagged stream). Announce events drive the
+	// per-broadcast announce guards below and tag the broadcasts handed out.
+	stats: stats::Session,
+
+	// Live egress announce guards, keyed by absolute broadcast path. An announce
+	// opens one (bumping `announced` + `announced_bytes`); the matching unannounce
+	// drops it (bumping `announced_closed` + `announced_bytes`).
+	guards: HashMap<PathOwned, stats::Announce>,
 }
 
 impl AnnounceConsumer {
-	fn new(root: PathOwned, nodes: OriginNodes) -> Self {
+	fn new(root: PathOwned, nodes: OriginNodes, stats: stats::Session) -> Self {
 		let state = kio::Producer::<OriginConsumerState>::default();
 		let id = ConsumerId::new();
 
@@ -2054,7 +2168,38 @@ impl AnnounceConsumer {
 			node.lock().consume(id, notify);
 		}
 
-		Self { id, nodes, root, state }
+		Self {
+			id,
+			nodes,
+			root,
+			state,
+			stats,
+			guards: HashMap::new(),
+		}
+	}
+
+	/// Drive the egress announce guards and tag the broadcast for one update.
+	///
+	/// An announce opens a guard (keyed by absolute path) and tags the yielded
+	/// broadcast with the egress scope; an unannounce drops the guard. A no-op for
+	/// an untagged stream.
+	fn attribute(&mut self, update: OriginAnnounce) -> OriginAnnounce {
+		let OriginAnnounce { path, broadcast } = update;
+		let absolute = self.root.join(&path).to_owned();
+		match broadcast {
+			Some(broadcast) => {
+				let scope = self.stats.egress(&absolute);
+				self.guards.entry(absolute).or_insert_with(|| scope.announce());
+				OriginAnnounce {
+					path,
+					broadcast: Some(broadcast.with_stats(scope)),
+				}
+			}
+			None => {
+				self.guards.remove(&absolute);
+				OriginAnnounce { path, broadcast: None }
+			}
+		}
 	}
 
 	/// Returns the next (un)announced broadcast and its path relative to this
@@ -2073,18 +2218,21 @@ impl AnnounceConsumer {
 	/// cursor is closed, or `Poll::Pending` after registering `waiter` to be
 	/// notified when the next update arrives.
 	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Option<OriginAnnounce>> {
-		let mut state = match ready!(self.state.poll(waiter, |state| {
-			if state.pending.is_empty() {
-				Poll::Pending
-			} else {
-				Poll::Ready(())
-			}
-		})) {
-			Ok(state) => state,
-			// Closed: discard the Ref so its MutexGuard doesn't escape this call.
-			Err(_) => return Poll::Ready(None),
+		let update = {
+			let mut state = match ready!(self.state.poll(waiter, |state| {
+				if state.pending.is_empty() {
+					Poll::Pending
+				} else {
+					Poll::Ready(())
+				}
+			})) {
+				Ok(state) => state,
+				// Closed: discard the Ref so its MutexGuard doesn't escape this call.
+				Err(_) => return Poll::Ready(None),
+			};
+			state.take().expect("predicate guaranteed an update")
 		};
-		Poll::Ready(Some(state.take().expect("predicate guaranteed an update")))
+		Poll::Ready(Some(self.attribute(update)))
 	}
 
 	/// Returns the next (un)announced broadcast without blocking.
@@ -2092,7 +2240,8 @@ impl AnnounceConsumer {
 	/// Returns None if there is no update available; NOT because the cursor is closed.
 	/// Use [`Self::is_closed`] to check if the cursor is closed.
 	pub fn try_next(&mut self) -> Option<OriginAnnounce> {
-		self.state.write().ok()?.take()
+		let update = self.state.write().ok()?.take()?;
+		Some(self.attribute(update))
 	}
 
 	/// Returns true if the cursor is closed (no more updates will arrive).
@@ -2359,6 +2508,105 @@ mod tests {
 			.expect("source closed");
 		assert_eq!(request.name(), name, "unexpected track dispatched");
 		request.accept(None)
+	}
+
+	/// Tagging both origin handles with one context attributes the full model path:
+	/// ingress writes on the subscriber side, egress reads on the publisher side,
+	/// each counter landing exactly once (the model-layer silent-zero guard).
+	#[tokio::test]
+	async fn test_stats_tagged_end_to_end() {
+		use crate::Timestamp;
+		use crate::stats::{Config, Registry, Tier};
+		use bytes::Bytes;
+
+		tokio::time::pause();
+
+		let registry = Registry::new(Config::new());
+		let ctx = registry.tier(Tier::default()).session("acme");
+
+		let origin = Origin::random().produce();
+		let ingress = origin.clone().with_stats(ctx.clone());
+		let egress = origin.consume().with_stats(ctx.clone());
+
+		// Egress announce stream: this is the tagged stream that drives the egress
+		// announce guard.
+		let mut announced = egress.announced();
+
+		// Ingress publishes an announced broadcast.
+		let source = ingress.create_broadcast("demo", announce()).unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+
+		// Egress observes the announce and gets the tagged broadcast.
+		let update = announced.next().await.unwrap();
+		assert_eq!(update.path.as_str(), "demo");
+		let broadcast = update.broadcast.unwrap();
+
+		// Egress subscribes; the ingress side serves the track on demand.
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		let mut producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+		let mut sub = subscribing.await.unwrap();
+
+		// Ingress writes one group with two 5-byte frames.
+		let mut group = producer.append_group().unwrap();
+		group
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"hello"))
+			.unwrap();
+		group
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"world"))
+			.unwrap();
+		group.finish().unwrap();
+
+		// Egress reads the group and both frames.
+		let mut group_c = sub.recv_group().await.unwrap().unwrap();
+		let mut frames = 0;
+		while let Some(frame) = group_c.read_frame().await.unwrap() {
+			assert_eq!(frame.payload.len(), 5);
+			frames += 1;
+		}
+		assert_eq!(frames, 2);
+		settle().await;
+
+		let report = registry.report();
+		let entry = report
+			.traffic
+			.iter()
+			.find(|e| e.path.as_str() == "demo")
+			.expect("demo tracked");
+		let path_len = "demo".len() as u64;
+
+		// Egress (publisher side): reads out of the model.
+		let egress = &entry.publisher;
+		assert_eq!(egress.announced, 1, "one egress announce");
+		assert_eq!(egress.announced_bytes, path_len);
+		assert_eq!(egress.subscriptions, 1, "one egress subscription");
+		assert_eq!(egress.broadcasts, 1, "one viewer");
+		assert_eq!(egress.groups, 1);
+		assert_eq!(egress.frames, 2);
+		assert_eq!(egress.bytes, 10);
+		assert_eq!(egress.fetches, 0);
+
+		// Ingress (subscriber side): writes into the model.
+		let ingress = &entry.subscriber;
+		assert_eq!(ingress.announced, 1, "one ingress announce");
+		assert_eq!(ingress.announced_bytes, path_len);
+		assert_eq!(ingress.subscriptions, 1, "one ingress track");
+		assert_eq!(ingress.broadcasts, 0, "ingress has no viewer refcount");
+		assert_eq!(ingress.groups, 1);
+		assert_eq!(ingress.frames, 2);
+		assert_eq!(ingress.bytes, 10);
+
+		// A fetch bumps only `fetches` on the egress side, plus the delivered group.
+		let fetched = broadcast.track("video").unwrap().fetch_group(0, None).await.unwrap();
+		let _ = fetched;
+		settle().await;
+		let report = registry.report();
+		let entry = report.traffic.iter().find(|e| e.path.as_str() == "demo").unwrap();
+		assert_eq!(entry.publisher.fetches, 1, "one fetch");
+		assert_eq!(entry.publisher.subscriptions, 1, "fetch does not bump subscriptions");
+		assert_eq!(entry.publisher.broadcasts, 1, "fetch does not bump the viewer refcount");
 	}
 
 	#[test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -14,7 +14,7 @@
 //! The track is closed with [Error] when all writers or readers are dropped.
 
 use crate::{Error, Result, Timescale, Timestamp, coding};
-use crate::{broadcast, cache, frame, group};
+use crate::{broadcast, cache, frame, group, stats};
 
 use super::{Datagram, Requests};
 
@@ -609,6 +609,10 @@ pub struct Producer {
 	broadcast: Arc<broadcast::Info>,
 	state: kio::Producer<TrackState>,
 	prev_subscription: Option<Subscription>,
+	// Ingress stats scope, inherited from a tagged [`broadcast::Producer`]. Bumped as
+	// one subscription on tag and closed when the last producer clone drops. Empty
+	// (no-op) for an untagged broadcast.
+	stats: stats::Scope,
 }
 
 impl Producer {
@@ -635,7 +639,17 @@ impl Producer {
 			}),
 			broadcast,
 			prev_subscription: None,
+			stats: stats::Scope::default(),
 		}
+	}
+
+	/// Attach the parent broadcast's ingress stats scope, counting this track as one
+	/// ingress subscription (closed when the last producer clone drops). Called by a
+	/// tagged [`broadcast::Producer`] when it creates the track.
+	pub(crate) fn with_stats(mut self, scope: stats::Scope) -> Self {
+		scope.open_subscription();
+		self.stats = scope;
+		self
 	}
 
 	/// The track's name, unique within its broadcast.
@@ -668,7 +682,7 @@ impl Producer {
 				.unwrap_or(Err(Error::Duplicate));
 		}
 
-		let group = group::Producer::new(group, track);
+		let group = group::Producer::new(group, track).with_meter(self.stats.meter());
 		state.max_sequence = Some(state.max_sequence.unwrap_or(0).max(group.sequence));
 		state.groups.push_back(Some((group.clone(), now)));
 		state.pin_latest(&group);
@@ -694,7 +708,7 @@ impl Producer {
 		let track = info.clone();
 		let latency_max = info.latency_max;
 
-		let group = group::Producer::new(group::Info { sequence }, track);
+		let group = group::Producer::new(group::Info { sequence }, track).with_meter(self.stats.meter());
 
 		let now = web_async::time::Instant::now();
 		state.duplicates.insert(sequence);
@@ -940,6 +954,9 @@ impl Producer {
 				next_sequence: 0,
 				end_sequence: None,
 			}),
+			// A producer-side (in-process) subscribe is not egress: stay untagged.
+			stats: stats::Scope::default(),
+			_stats_sub: stats::Subscription::default(),
 		}
 	}
 
@@ -1149,6 +1166,8 @@ impl Drop for Producer {
 		if !self.state.is_last() {
 			return;
 		}
+		// The last ingress producer closing the track ends its subscription.
+		self.stats.close_subscription();
 		if let Ok(mut state) = self.state.write()
 			&& state.final_sequence.is_none()
 		{
@@ -1334,6 +1353,9 @@ impl Demand {
 pub struct Consumer {
 	name: Arc<str>,
 	inner: ConsumerKind,
+	// Egress stats scope, set by a tagged [`broadcast::Consumer`] via
+	// [`Self::with_stats`]. Empty (no-op) for an untagged track.
+	stats: stats::Scope,
 }
 
 #[derive(Clone)]
@@ -1347,6 +1369,7 @@ impl Consumer {
 		Self {
 			name,
 			inner: ConsumerKind::Plain(state),
+			stats: stats::Scope::default(),
 		}
 	}
 
@@ -1355,7 +1378,15 @@ impl Consumer {
 		Self {
 			name,
 			inner: ConsumerKind::Spliced(resume),
+			stats: stats::Scope::default(),
 		}
+	}
+
+	/// Attach an egress stats scope, inherited by the subscriptions, fetches, and
+	/// groups derived from this handle. Called by a tagged [`broadcast::Consumer`].
+	pub(crate) fn with_stats(mut self, scope: stats::Scope) -> Self {
+		self.stats = scope;
+		self
 	}
 
 	/// The track name this handle is bound to.
@@ -1386,6 +1417,7 @@ impl Consumer {
 			name: self.name.clone(),
 			inner,
 			subscription,
+			stats: self.stats.clone(),
 		})
 	}
 
@@ -1416,6 +1448,11 @@ impl Consumer {
 	pub fn fetch_group(&self, sequence: u64, options: impl Into<Option<group::Fetch>>) -> kio::Pending<Fetching> {
 		let options = options.into().unwrap_or_default();
 
+		// One fetch per calling context, counted here (coalesced upstream work is
+		// still one request served). Independent of `subscriptions` and the viewer
+		// refcount.
+		self.stats.fetch();
+
 		let state = match &self.inner {
 			ConsumerKind::Plain(state) => state,
 			// Spliced: routed to the newest segment's (plain) track, waiting for a
@@ -1423,6 +1460,7 @@ impl Consumer {
 			ConsumerKind::Spliced(resume) => {
 				return kio::Pending::new(Fetching {
 					inner: FetchingKind::Spliced(resume.fetch_group(sequence, options)),
+					stats: self.stats.clone(),
 				});
 			}
 		};
@@ -1467,6 +1505,7 @@ impl Consumer {
 				sequence,
 				result,
 			},
+			stats: self.stats.clone(),
 		})
 	}
 
@@ -1523,6 +1562,7 @@ pub struct Subscribing {
 	name: Arc<str>,
 	inner: SubscribingKind,
 	subscription: kio::Producer<Subscription>,
+	stats: stats::Scope,
 }
 
 enum SubscribingKind {
@@ -1552,6 +1592,8 @@ impl Subscribing {
 						next_sequence: 0,
 						end_sequence: None,
 					}),
+					stats: self.stats.clone(),
+					_stats_sub: self.stats.subscribe(),
 				}))
 			}
 			SubscribingKind::Spliced(resume) => {
@@ -1563,6 +1605,8 @@ impl Subscribing {
 					name: self.name.clone(),
 					info,
 					inner: SubscriberKind::Spliced(Box::new(resume.subscribe_shared(self.subscription.clone()))),
+					stats: self.stats.clone(),
+					_stats_sub: self.stats.subscribe(),
 				}))
 			}
 		}
@@ -1708,6 +1752,9 @@ impl Drop for GroupRequest {
 /// or produced after a wire FETCH), or [`Error::NotFound`] if it can never exist.
 pub struct Fetching {
 	inner: FetchingKind,
+	// Egress stats scope, so the resolved group carries a payload meter (and counts
+	// as one delivered group). Empty (no-op) for an untagged track.
+	stats: stats::Scope,
 }
 
 enum FetchingKind {
@@ -1733,13 +1780,18 @@ impl kio::Pollable for Fetching {
 				sequence,
 				result,
 			} => (state, fetch, *sequence, result.as_ref()),
-			FetchingKind::Spliced(spliced) => return kio::Pollable::poll(&**spliced, waiter),
+			FetchingKind::Spliced(spliced) => {
+				// A fetched group is metered here (once), at the tagged handle: the
+				// spliced source track it comes from is the origin's own, untagged.
+				return kio::Pollable::poll(&**spliced, waiter)
+					.map(|res| res.map(|group| group.with_meter(self.stats.meter())));
+			}
 		};
 
 		// Track side: the cached group, the abort error, or past-final. The outer
 		// error is the channel closing without any of those.
 		match state.poll(waiter, |state| state.poll_fetch_cached(sequence)) {
-			Poll::Ready(Ok(res)) => return Poll::Ready(res),
+			Poll::Ready(Ok(res)) => return Poll::Ready(res.map(|group| group.with_meter(self.stats.meter()))),
 			Poll::Ready(Err(closed)) => {
 				return Poll::Ready(Err(closed.abort.clone().unwrap_or(Error::Dropped)));
 			}
@@ -1798,6 +1850,12 @@ pub struct Subscriber {
 	name: Arc<str>,
 	info: Info,
 	inner: SubscriberKind,
+	// Egress stats scope, used to meter the groups this subscriber reads. Empty
+	// (no-op) for an untagged track.
+	stats: stats::Scope,
+	// The subscription guard: bumps `subscriptions` (and the egress viewer refcount)
+	// while held, closing them on drop. Empty (no-op) for an untagged track.
+	_stats_sub: stats::Subscription,
 }
 
 enum SubscriberKind {
@@ -1948,10 +2006,12 @@ impl Subscriber {
 	/// `Poll::Ready(Err(e))` when the track has been aborted, or
 	/// `Poll::Pending` when no group is available yet.
 	pub fn poll_recv_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
-		match &mut self.inner {
+		let meter = self.stats.meter();
+		let res = match &mut self.inner {
 			SubscriberKind::Plain(plain) => plain.poll_recv_group(waiter),
 			SubscriberKind::Spliced(spliced) => spliced.poll_recv_group(waiter),
-		}
+		};
+		res.map(|res| res.map(|group| group.map(|group| group.with_meter(meter))))
 	}
 
 	/// Receive the next group in arrival order.
@@ -1999,10 +2059,12 @@ impl Subscriber {
 	/// Honors the cap set by [`Self::end_at`]: groups with sequence past the cap are left
 	/// in the producer's cache and become eligible again if the cap is raised or removed.
 	pub fn poll_next_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
-		match &mut self.inner {
+		let meter = self.stats.meter();
+		let res = match &mut self.inner {
 			SubscriberKind::Plain(plain) => plain.poll_next_group(waiter),
 			SubscriberKind::Spliced(spliced) => spliced.poll_next_group(waiter),
-		}
+		};
+		res.map(|res| res.map(|group| group.map(|group| group.with_meter(meter))))
 	}
 
 	/// Return the next group with a higher sequence number than any previously returned.
@@ -2018,10 +2080,19 @@ impl Subscriber {
 	/// (timestamp and payload), skipping the rest of the group. Intended for
 	/// single-frame groups (see [`Producer::write_frame`]).
 	pub fn poll_read_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<frame::Frame>>> {
-		match &mut self.inner {
+		let meter = self.stats.meter();
+		let res = match &mut self.inner {
 			SubscriberKind::Plain(plain) => plain.poll_read_frame(waiter),
 			SubscriberKind::Spliced(spliced) => spliced.poll_read_frame(waiter),
+		};
+		// This helper collapses a group to its first frame: count the group, the one
+		// frame, and the bytes actually read.
+		if let Poll::Ready(Ok(Some(frame))) = &res {
+			meter.group();
+			meter.frames(1);
+			meter.bytes(frame.payload.len() as u64);
 		}
+		res
 	}
 
 	/// Read a single full frame (timestamp and payload) from the next group in
@@ -2147,6 +2218,10 @@ pub struct Request {
 	// racing the producer (e.g. a relay) into creating its own handler. Released
 	// when the request is accepted or dropped; by then the relay holds its own.
 	_dynamic: Dynamic,
+
+	// Ingress stats scope, threaded into the accepted [`Producer`]. Empty (no-op)
+	// unless this request was reserved on a tagged broadcast.
+	stats: stats::Scope,
 }
 
 impl Request {
@@ -2163,7 +2238,15 @@ impl Request {
 			state,
 			prev_subscription: None,
 			_dynamic: dynamic,
+			stats: stats::Scope::default(),
 		}
+	}
+
+	/// Attach an ingress stats scope, applied to the [`Producer`] on accept. Set by
+	/// a tagged [`broadcast::Producer::reserve_track`].
+	pub(crate) fn with_stats(mut self, scope: stats::Scope) -> Self {
+		self.stats = scope;
+		self
 	}
 
 	/// The requested track name.
@@ -2203,11 +2286,15 @@ impl Request {
 		if let Ok(mut state) = self.state.write() {
 			state.info = Some(info);
 		}
+		// Accepting the request creates the track producer: count it as one ingress
+		// subscription (closed on the last producer drop). No-op when untagged.
+		self.stats.open_subscription();
 		Producer {
 			name: self.name,
 			broadcast: self.broadcast,
 			state: self.state,
 			prev_subscription: None,
+			stats: self.stats,
 		}
 	}
 

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -11,7 +11,7 @@ use crate::{
 pub struct Server {
 	publish: Option<origin::Consumer>,
 	subscribe: Option<origin::Producer>,
-	stats: stats::Handle,
+	stats: stats::Session,
 	versions: Versions,
 }
 
@@ -37,10 +37,11 @@ impl Server {
 		self
 	}
 
-	/// Attach a tier-scoped [`stats::Handle`]. Per-broadcast and per-subscription
-	/// counters will be bumped through this handle for the lifetime of the session.
-	/// Pass [`stats::Handle::default`] (a no-op handle) to opt out.
-	pub fn with_stats(mut self, stats: stats::Handle) -> Self {
+	/// Attach a per-connection [`stats::Session`] context. The session's publish
+	/// (egress) and subscribe (ingress) origin handles are tagged with it, so all
+	/// traffic counters are attributed through the model for this session's lifetime.
+	/// Pass [`stats::Session::default`] (a no-op context) to opt out.
+	pub fn with_stats(mut self, stats: stats::Session) -> Self {
 		self.stats = stats;
 		self
 	}
@@ -337,8 +338,9 @@ impl<S: web_transport_trait::Session> Request<S> {
 		self
 	}
 
-	/// Set the tier-scoped stats handle. Overrides any value from the [`Server`] builder.
-	pub fn with_stats(mut self, stats: stats::Handle) -> Self {
+	/// Set the per-connection [`stats::Session`] context. Overrides any value from the
+	/// [`Server`] builder.
+	pub fn with_stats(mut self, stats: stats::Session) -> Self {
 		self.inner_mut().server.stats = stats;
 		self
 	}
@@ -351,6 +353,12 @@ impl<S: web_transport_trait::Session> Request<S> {
 	/// its protocol work.
 	pub async fn ok(mut self) -> Result<(Session, Driver), Error> {
 		let RequestInner { server, handshake } = self.inner.take().expect("request already responded");
+
+		// Tag the origin pair with the stats context so the model attributes reads
+		// (egress) and writes (ingress) for this session. One shared context across
+		// both halves keeps presence and viewer counts from double-attributing.
+		let publish = server.publish.map(|origin| origin.with_stats(server.stats.clone()));
+		let subscribe = server.subscribe.map(|origin| origin.with_stats(server.stats.clone()));
 
 		let (session, mut stream, version, request_id_max) = match handshake {
 			Handshake::IetfModern {
@@ -365,9 +373,8 @@ impl<S: web_transport_trait::Session> Request<S> {
 					None,
 					None,
 					false,
-					server.publish,
-					server.subscribe,
-					server.stats,
+					publish,
+					subscribe,
 					version,
 					None,
 					Some(peer_setup),
@@ -379,9 +386,8 @@ impl<S: web_transport_trait::Session> Request<S> {
 				let start = lite::start(
 					session.clone(),
 					None,
-					server.publish,
-					server.subscribe,
-					server.stats,
+					publish,
+					subscribe,
 					version,
 					lite::Setup::default(),
 					None,
@@ -409,9 +415,8 @@ impl<S: web_transport_trait::Session> Request<S> {
 				let start = lite::start(
 					session.clone(),
 					None,
-					server.publish,
-					server.subscribe,
-					server.stats,
+					publish,
+					subscribe,
 					version,
 					our_setup,
 					Some(client_setup),
@@ -455,9 +460,8 @@ impl<S: web_transport_trait::Session> Request<S> {
 				let start = lite::start(
 					session.clone(),
 					Some(stream),
-					server.publish,
-					server.subscribe,
-					server.stats,
+					publish,
+					subscribe,
 					v,
 					lite::Setup::default(),
 					None,
@@ -472,9 +476,8 @@ impl<S: web_transport_trait::Session> Request<S> {
 					Some(stream),
 					request_id_max,
 					false,
-					server.publish,
-					server.subscribe,
-					server.stats,
+					publish,
+					subscribe,
 					v,
 					None,
 					None,

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -13,34 +13,44 @@
 //! tracked separately per (tier, auth root), counting presence regardless of
 //! whether any data flows.
 //!
+//! # Where counting happens
+//!
+//! Counting lives in the model layer, not the wire loops. A session tags its
+//! origin pair with a [`Session`] context ([`crate::Client::with_stats`] /
+//! [`crate::Server::with_stats`], which call `origin::{Consumer, Producer}`
+//! `with_stats`); every derived handle (broadcast, announce, track, group, frame)
+//! then attributes its reads (egress = publisher) and writes (ingress =
+//! subscriber) through that context. So any protocol that drives the model gets
+//! the full counter set for free, and an untagged handle pays nothing.
+//!
 //! Per-counter semantics:
 //!
-//! * `announced` / `announced_closed`: cumulative count of broadcast
-//!   announce/unannounce events on this `(tier, role)`. Bumped on every
-//!   `publisher()` / `subscriber()` guard creation and drop.
+//! * `announced` / `announced_closed`: cumulative broadcast announce/unannounce
+//!   events on this `(tier, role)`. Driven by the tagged announce stream on the
+//!   egress side, and by `create_broadcast` route transitions on the ingress
+//!   side.
 //! * `announced_bytes`: cumulative broadcast-name length summed over each
-//!   announce and unannounce of this broadcast (the name, not the encoded
-//!   message size, so hop/framing overhead isn't charged, and the count is
-//!   the same across protocol versions). Recorded keyed by path via
-//!   [`Broadcast::publisher_announced_bytes`] /
-//!   [`Broadcast::subscriber_announced_bytes`], independent of the
-//!   announce lifetime guard, so filtered/reflected/unmatched control flows
-//!   still count. Kept separate from the `bytes` payload counter.
-//! * `broadcasts` / `broadcasts_closed`: per-(broadcast, session)
-//!   subscription sentinel. The first active subscription a peer session
-//!   opens for a broadcast bumps `broadcasts`; the last one it closes bumps
-//!   `broadcasts_closed`. Summed across sessions, `broadcasts -
-//!   broadcasts_closed` is the number of distinct sessions currently
-//!   subscribed to the broadcast (i.e. viewers on the egress side). Driven
-//!   by [`SessionBroadcasts`]; use `announced` if you want all broadcasts
-//!   ever seen.
-//! * `subscriptions` / `subscriptions_closed`: cumulative count of
-//!   track-level subscription guards opened/dropped.
-//! * `bytes` / `frames` / `groups`: cumulative payload counters bumped from
-//!   the session loops (both lite and IETF).
+//!   model-visible announce and unannounce of this broadcast (the name, not the
+//!   encoded message size, so hop/framing overhead isn't charged, and the count
+//!   is the same across protocol versions). Kept separate from the `bytes`
+//!   payload counter.
+//! * `broadcasts` / `broadcasts_closed`: per-(broadcast, context) egress
+//!   subscription sentinel. The first active subscription a context opens for a
+//!   broadcast bumps `broadcasts`; the last it closes bumps `broadcasts_closed`.
+//!   Summed across contexts, `broadcasts - broadcasts_closed` is the number of
+//!   distinct sessions currently subscribed (viewers on the egress side).
+//! * `subscriptions` / `subscriptions_closed`: cumulative track-level
+//!   subscriptions opened/dropped (egress `track::Subscriber`, ingress
+//!   `track::Producer`).
+//! * `fetches`: cumulative one-shot group fetches served to a calling
+//!   context, counted once per coalesced fetch. Separate from
+//!   `subscriptions` and the viewer refcount; fetched payload still flows
+//!   into `bytes` / `frames` / `groups`.
+//! * `bytes` / `frames` / `groups`: cumulative payload counters bumped as
+//!   groups/frames are read (egress) or written (ingress) in the model.
 //! * `sessions` / `sessions_closed` ([`Presence`]): cumulative count of
 //!   sessions connected/disconnected under an auth root on this tier.
-//!   Driven by [`Handle::session`].
+//!   Driven by [`Handle::session`] (the [`Session`] context).
 //!
 //! Counters are strictly monotonic (only `fetch_add`); a counter going
 //! backwards across reads means the underlying entry was garbage collected
@@ -104,13 +114,13 @@ use crate::{AsPath, PathOwned};
 
 /// Cumulative atomic counters for a single `(tier, role)` on a broadcast.
 ///
-/// Every field is bumped from a RAII guard: the open counters on construction
-/// and their `_closed` counterparts on drop. `broadcasts` / `broadcasts_closed`
-/// are the per-(broadcast, session) subscription sentinel driven by
-/// [`SessionBroadcasts`] (the first active subscription a session opens for the
-/// broadcast bumps `broadcasts`, the last to close bumps `broadcasts_closed`),
-/// so summed across sessions `broadcasts - broadcasts_closed` is the count of
-/// distinct sessions currently subscribed.
+/// Open counters bump when a model handle records activity; their `_closed`
+/// counterparts bump from the [`Scope`] / [`Subscription`] / [`Announce`] RAII
+/// guards on drop. `broadcasts` / `broadcasts_closed` are the per-(broadcast,
+/// context) egress subscription sentinel (the first active subscription a context
+/// opens for the broadcast bumps `broadcasts`, the last to close bumps
+/// `broadcasts_closed`), so summed across contexts `broadcasts -
+/// broadcasts_closed` is the count of distinct sessions currently subscribed.
 // Kept crate-private: the load/store orderings are load-bearing (see the
 // module-level "Snapshot atomicity" note), so external code only ever sees
 // the derived [`Traffic`] readout.
@@ -125,6 +135,10 @@ pub(crate) struct Counters {
 	announced_bytes: AtomicU64,
 	subscriptions: AtomicU64,
 	subscriptions_closed: AtomicU64,
+	// Cumulative one-shot group fetches served to a calling context. Counted once
+	// per coalesced fetch (requests served, not upstream work); does not touch
+	// `subscriptions` or the viewer refcount.
+	fetches: AtomicU64,
 	broadcasts: AtomicU64,
 	broadcasts_closed: AtomicU64,
 	bytes: AtomicU64,
@@ -147,6 +161,7 @@ impl Counters {
 		let announced = self.announced.load(Ordering::Relaxed);
 		let announced_bytes = self.announced_bytes.load(Ordering::Relaxed);
 		let subscriptions = self.subscriptions.load(Ordering::Relaxed);
+		let fetches = self.fetches.load(Ordering::Relaxed);
 		let broadcasts = self.broadcasts.load(Ordering::Relaxed);
 		let bytes = self.bytes.load(Ordering::Relaxed);
 		let frames = self.frames.load(Ordering::Relaxed);
@@ -159,6 +174,7 @@ impl Counters {
 			broadcasts_closed,
 			subscriptions,
 			subscriptions_closed,
+			fetches,
 			bytes,
 			frames,
 			groups,
@@ -217,6 +233,10 @@ pub struct Traffic {
 	pub subscriptions: u64,
 	/// Cumulative track-level subscriptions closed.
 	pub subscriptions_closed: u64,
+	/// Cumulative one-shot group fetches served. Counted once per coalesced fetch,
+	/// separate from `subscriptions` and the viewer refcount. Fetched payload still
+	/// flows into `bytes`/`frames`/`groups`.
+	pub fetches: u64,
 	/// Cumulative payload bytes.
 	pub bytes: u64,
 	/// Cumulative frames delivered.
@@ -235,6 +255,7 @@ impl Traffic {
 		self.broadcasts_closed += other.broadcasts_closed;
 		self.subscriptions += other.subscriptions;
 		self.subscriptions_closed += other.subscriptions_closed;
+		self.fetches += other.fetches;
 		self.bytes += other.bytes;
 		self.frames += other.frames;
 		self.groups += other.groups;
@@ -752,38 +773,13 @@ impl Handle {
 		&self.tier
 	}
 
-	/// Returns a per-broadcast handle scoped to this tier.
-	///
-	/// Paths under the registry's exclude prefix return an empty handle
-	/// whose bumps are no-ops. This keeps stats traffic from feeding back into
-	/// the registry.
-	pub fn broadcast(&self, path: impl AsPath) -> Broadcast {
-		Broadcast {
-			counters: self.stats.entry(path).map(|entry| entry.tier(&self.tier)),
-		}
-	}
-
-	/// Per-session egress (publisher) broadcast-subscription tracker. Construct
-	/// one per session and call [`SessionBroadcasts::subscribe`] for each
-	/// downstream subscription so `broadcasts - broadcasts_closed` counts the
-	/// distinct sessions watching each broadcast.
-	pub fn publisher_broadcasts(&self) -> SessionBroadcasts {
-		SessionBroadcasts::new(self.stats.clone(), self.tier.clone(), Side::Publisher)
-	}
-
-	/// Per-session ingress (subscriber) counterpart to
-	/// [`Self::publisher_broadcasts`].
-	pub fn subscriber_broadcasts(&self) -> SessionBroadcasts {
-		SessionBroadcasts::new(self.stats.clone(), self.tier.clone(), Side::Subscriber)
-	}
-
 	/// Record a connected session authenticated under `root` on this tier. Hold
 	/// the returned guard for the session's lifetime; dropping it bumps
 	/// `sessions_closed`. Counts presence regardless of any data flow, so a
 	/// session that merely connects is still billable. Surfaced on the session
 	/// track for this tier, keyed by `root`.
 	pub fn session(&self, root: impl AsPath) -> Session {
-		Session::new(self.stats.session_counters(&self.tier, root))
+		Session::new(self.clone(), self.stats.session_counters(&self.tier, root))
 	}
 }
 
@@ -794,100 +790,12 @@ impl Default for Handle {
 	}
 }
 
-/// A per-broadcast, tier-scoped handle. Cheap to clone.
-///
-/// Open a broadcast-lifetime guard with [`Self::publisher`] / [`Self::subscriber`],
-/// or skip straight to a track guard with [`Self::publisher_track`] /
-/// [`Self::subscriber_track`] when the broadcast's lifetime is tracked
-/// elsewhere.
-#[derive(Clone)]
-pub struct Broadcast {
-	/// Resolved counters for this `(broadcast, tier)`, or `None` when the path
-	/// was under the registry's exclude prefix or stats are disabled.
-	counters: Option<Arc<TierCounters>>,
-}
-
-impl Broadcast {
-	/// True if this handle has no underlying entry (path was under the
-	/// registry's exclude prefix, or stats are disabled). All bumps through an
-	/// empty handle are no-ops.
-	pub fn is_empty(&self) -> bool {
-		self.counters.is_none()
-	}
-
-	/// Open a broadcast-lifetime guard for the publisher (egress) role.
-	/// Bumps `announced` on construction and `announced_closed` on drop.
-	/// (The `broadcasts` sentinel is driven separately by
-	/// [`SessionBroadcasts`]; see the module docs.)
-	pub fn publisher(&self) -> Publisher {
-		if let Some(counters) = &self.counters {
-			counters.publisher.announced.fetch_add(1, Ordering::Relaxed);
-		}
-		Publisher {
-			counters: self.counters.clone(),
-		}
-	}
-
-	/// Open a broadcast-lifetime guard for the subscriber (ingress) role.
-	/// Bumps `announced` on construction and `announced_closed` on drop.
-	/// (The `broadcasts` sentinel is driven separately by
-	/// [`SessionBroadcasts`]; see the module docs.)
-	pub fn subscriber(&self) -> Subscriber {
-		if let Some(counters) = &self.counters {
-			counters.subscriber.announced.fetch_add(1, Ordering::Relaxed);
-		}
-		Subscriber {
-			counters: self.counters.clone(),
-		}
-	}
-
-	/// Open a publisher-track guard.
-	///
-	/// `_name` is unused; counters are per-broadcast only. The track name
-	/// parameter is kept for symmetry with the rest of moq-net so callers
-	/// don't have to thread an `Option<&str>` through subscribe sites.
-	pub fn publisher_track(&self, _name: &str) -> PublisherTrack {
-		if let Some(counters) = &self.counters {
-			counters.publisher.subscriptions.fetch_add(1, Ordering::Relaxed);
-		}
-		PublisherTrack {
-			counters: self.counters.clone(),
-		}
-	}
-
-	/// Record `n` announce-control bytes (the broadcast name length) for one
-	/// publisher-side announce/unannounce, independent of any lifetime guard.
-	/// Recording is keyed by broadcast path, so it still captures messages
-	/// whose matching guard was skipped, reflected, or already dropped (e.g.
-	/// an unannounce whose announce was filtered out). Bumps `announced_bytes`;
-	/// distinct from [`PublisherTrack::bytes`], which counts media payload.
-	pub fn publisher_announced_bytes(&self, n: u64) {
-		if let Some(counters) = &self.counters {
-			counters.publisher.announced_bytes.fetch_add(n, Ordering::Relaxed);
-		}
-	}
-
-	/// Subscriber-side counterpart to [`Self::publisher_announced_bytes`].
-	pub fn subscriber_announced_bytes(&self, n: u64) {
-		if let Some(counters) = &self.counters {
-			counters.subscriber.announced_bytes.fetch_add(n, Ordering::Relaxed);
-		}
-	}
-
-	/// Subscriber-side counterpart to [`Self::publisher_track`].
-	pub fn subscriber_track(&self, _name: &str) -> SubscriberTrack {
-		if let Some(counters) = &self.counters {
-			counters.subscriber.subscriptions.fetch_add(1, Ordering::Relaxed);
-		}
-		SubscriberTrack {
-			counters: self.counters.clone(),
-		}
-	}
-}
-
-/// Which side of a [`BroadcastEntry`] a [`SessionBroadcasts`] bumps.
-#[derive(Copy, Clone)]
+/// Which side of a [`TierCounters`] a bump lands on: publisher (egress) or
+/// subscriber (ingress). `Default` is `Publisher`, chosen only so an empty
+/// [`Meter`] / [`Scope`] has one; it never records because its counters are `None`.
+#[derive(Copy, Clone, Default)]
 enum Side {
+	#[default]
 	Publisher,
 	Subscriber,
 }
@@ -901,259 +809,324 @@ impl Side {
 	}
 }
 
-/// Per-session tracker that turns a peer session's per-broadcast subscription
-/// lifecycle into `broadcasts` / `broadcasts_closed` bumps.
+/// Per-connection stats context, created via [`Handle::session`].
 ///
-/// Hold one per session (and side). Call [`Self::subscribe`] for every
-/// subscription the session opens and keep the returned [`BroadcastSubscription`]
-/// alive for that subscription's lifetime. The guard refcounts subscriptions per
-/// broadcast for this session, so the session's *first* subscription to a
-/// broadcast bumps `broadcasts` and its *last* to drop bumps `broadcasts_closed`.
-/// Summed across sessions, `broadcasts - broadcasts_closed` is the number of
-/// distinct sessions currently subscribed to the broadcast (viewers on the
-/// egress side).
+/// Cheap to clone (an `Arc` inside): one context is shared by both origin handles
+/// of a session (its publish and subscribe halves) so presence and viewer counts
+/// are never double-attributed. It carries three things:
 ///
-/// Cheap to clone; clones share the same per-broadcast refcounts (so a single
-/// logical session that clones its handle still counts as one).
-#[derive(Clone)]
-pub struct SessionBroadcasts {
-	stats: Registry,
-	tier: Tier,
-	side: Side,
-	counts: Arc<Mutex<HashMap<PathOwned, u32>>>,
-}
-
-impl SessionBroadcasts {
-	fn new(stats: Registry, tier: Tier, side: Side) -> Self {
-		Self {
-			stats,
-			tier,
-			side,
-			counts: Arc::new(Mutex::new(HashMap::new())),
-		}
-	}
-
-	/// Register one active subscription to `path` for this session. Hold the
-	/// returned guard for the subscription's lifetime; dropping it releases the
-	/// subscription (bumping `broadcasts_closed` when it was the session's last
-	/// for that broadcast).
-	pub fn subscribe(&self, path: impl AsPath) -> BroadcastSubscription {
-		let path = path.as_path().to_owned();
-		let counters = self.stats.entry(&path).map(|entry| entry.tier(&self.tier));
-		let first = {
-			let mut counts = self.counts.lock().expect("stats refcount poisoned");
-			let n = counts.entry(path.clone()).or_insert(0);
-			let first = *n == 0;
-			*n += 1;
-			first
-		};
-		if first {
-			if let Some(counters) = &counters {
-				self.side.counters(counters).broadcasts.fetch_add(1, Ordering::Relaxed);
-			}
-		}
-		BroadcastSubscription {
-			counters,
-			side: self.side,
-			counts: self.counts.clone(),
-			path,
-		}
-	}
-}
-
-/// RAII guard for one of a session's per-broadcast subscriptions.
-/// See [`SessionBroadcasts::subscribe`].
-#[must_use = "drop the guard to release the subscription"]
-pub struct BroadcastSubscription {
-	counters: Option<Arc<TierCounters>>,
-	side: Side,
-	counts: Arc<Mutex<HashMap<PathOwned, u32>>>,
-	path: PathOwned,
-}
-
-impl Drop for BroadcastSubscription {
-	fn drop(&mut self) {
-		let last = {
-			let mut counts = self.counts.lock().expect("stats refcount poisoned");
-			match counts.get_mut(&self.path) {
-				Some(n) => {
-					*n -= 1;
-					if *n == 0 {
-						counts.remove(&self.path);
-						true
-					} else {
-						false
-					}
-				}
-				None => false,
-			}
-		};
-		if last {
-			if let Some(counters) = &self.counters {
-				// Release pairs with the readout's Acquire load of
-				// `broadcasts_closed`; see `Publisher::drop`.
-				self.side
-					.counters(counters)
-					.broadcasts_closed
-					.fetch_add(1, Ordering::Release);
-			}
-		}
-	}
-}
-
-/// RAII guard for a connected session, keyed by auth root and tier. Bumps
-/// `sessions` on construction and `sessions_closed` on drop. See
-/// [`Handle::session`].
-#[must_use = "drop the guard to record the session as closed"]
+/// * the tier + auth root, so any broadcast reached through a tagged origin handle
+///   resolves the right per-`(path, tier)` counters,
+/// * the presence gauge: `sessions` bumps when the context is created and
+///   `sessions_closed` when the last clone drops (a more honest close than a
+///   separately-held guard),
+/// * the egress viewer refcount map (first/last active subscription per broadcast),
+///   driving `broadcasts` / `broadcasts_closed`.
+///
+/// [`Session::default`] is the no-op context (disabled registry / untagged caller):
+/// every bump reached through it is silently dropped, so a handle can hold one
+/// unconditionally instead of threading an `Option`.
+#[derive(Clone, Default)]
 pub struct Session {
-	/// `None` for a disabled registry; bumps are then dropped.
-	counters: Option<Arc<SessionCounters>>,
+	/// `None` for the no-op context (disabled registry or a `default()` handle).
+	inner: Option<Arc<SessionInner>>,
+}
+
+/// The shared state behind a [`Session`]. Its `Drop` (on the last clone) records
+/// the session as closed.
+struct SessionInner {
+	/// Registry + tier, so derived model handles resolve `(path, tier)` counters.
+	handle: Handle,
+	/// The presence gauge for `(tier, root)`, or `None` for a disabled registry.
+	presence: Option<Arc<SessionCounters>>,
+	/// Egress viewer refcount, keyed by absolute broadcast path: the first active
+	/// subscription this context opens for a broadcast bumps `broadcasts`, the last
+	/// to close bumps `broadcasts_closed`.
+	viewers: Mutex<HashMap<PathOwned, u32>>,
 }
 
 impl Session {
-	fn new(counters: Option<Arc<SessionCounters>>) -> Self {
-		if let Some(counters) = &counters {
-			counters.sessions.fetch_add(1, Ordering::Relaxed);
+	fn new(handle: Handle, presence: Option<Arc<SessionCounters>>) -> Self {
+		if let Some(presence) = &presence {
+			presence.sessions.fetch_add(1, Ordering::Relaxed);
 		}
-		Self { counters }
+		Self {
+			inner: Some(Arc::new(SessionInner {
+				handle,
+				presence,
+				viewers: Mutex::new(HashMap::new()),
+			})),
+		}
+	}
+
+	/// Egress (publisher / reads) scope for a broadcast path. The path is the
+	/// absolute broadcast name; counters are resolved once here.
+	pub(crate) fn egress(&self, path: impl AsPath) -> Scope {
+		self.scope(path, Side::Publisher)
+	}
+
+	/// Ingress (subscriber / writes) scope for a broadcast path.
+	pub(crate) fn ingress(&self, path: impl AsPath) -> Scope {
+		self.scope(path, Side::Subscriber)
+	}
+
+	fn scope(&self, path: impl AsPath, side: Side) -> Scope {
+		let Some(inner) = &self.inner else {
+			return Scope::default();
+		};
+		let path = path.as_path().to_owned();
+		let counters = inner
+			.handle
+			.stats
+			.entry(&path)
+			.map(|entry| entry.tier(&inner.handle.tier));
+		Scope {
+			session: self.clone(),
+			counters,
+			side,
+			path,
+		}
+	}
+
+	/// Register one active egress subscription to `path`, returning `true` if it was
+	/// the first (so the caller bumps `broadcasts`).
+	fn viewer_open(&self, path: &PathOwned) -> bool {
+		let Some(inner) = &self.inner else { return false };
+		let mut viewers = inner.viewers.lock().expect("stats viewers poisoned");
+		let n = viewers.entry(path.clone()).or_insert(0);
+		let first = *n == 0;
+		*n += 1;
+		first
+	}
+
+	/// Release one active egress subscription to `path`, returning `true` if it was
+	/// the last (so the caller bumps `broadcasts_closed`).
+	fn viewer_close(&self, path: &PathOwned) -> bool {
+		let Some(inner) = &self.inner else { return false };
+		let mut viewers = inner.viewers.lock().expect("stats viewers poisoned");
+		match viewers.get_mut(path) {
+			Some(n) => {
+				*n -= 1;
+				if *n == 0 {
+					viewers.remove(path);
+					true
+				} else {
+					false
+				}
+			}
+			None => false,
+		}
 	}
 }
 
-impl Drop for Session {
+impl Drop for SessionInner {
 	fn drop(&mut self) {
-		if let Some(counters) = &self.counters {
-			// Release pairs with the readout's Acquire load of
-			// `sessions_closed`; see `Publisher::drop`.
-			counters.sessions_closed.fetch_add(1, Ordering::Release);
+		if let Some(presence) = &self.presence {
+			// Release pairs with the readout's Acquire load of `sessions_closed`
+			// (see the module-level "Snapshot atomicity" note).
+			presence.sessions_closed.fetch_add(1, Ordering::Release);
 		}
 	}
 }
 
-/// RAII broadcast guard for the publisher role. See [`Broadcast::publisher`].
-#[must_use = "drop the guard to record the broadcast as closed"]
-pub struct Publisher {
+// ---------------------------------------------------------------------------
+// Model-layer carriers
+//
+// These are what a tagged `origin::{Consumer, Producer}` threads down through the
+// derived handles (broadcast -> track -> group -> frame). A tagged origin resolves
+// the per-`(path, tier)` counters once into a [`Scope`]; child handles carry a
+// cheap [`Meter`] for the payload bumps. All of them are no-ops when empty (a
+// disabled registry, an excluded path, or an untagged caller), so an untagged
+// handle pays nothing.
+// ---------------------------------------------------------------------------
+
+/// Payload bump handle carried by the group and frame model handles. Cheap to
+/// clone (an `Option<Arc>` plus a `Side`); empty when the broadcast is untracked.
+#[derive(Clone, Default)]
+pub(crate) struct Meter {
 	counters: Option<Arc<TierCounters>>,
+	side: Side,
 }
 
-impl Publisher {
-	/// Open a track-subscription guard. Bumps `subscriptions` on construction
-	/// and `subscriptions_closed` on drop.
-	pub fn track(&self, name: &str) -> PublisherTrack {
-		Broadcast {
+impl Meter {
+	fn counters(&self) -> Option<&Counters> {
+		self.counters.as_ref().map(|c| self.side.counters(c))
+	}
+
+	/// Bump `groups` once (a group delivered/consumed on this side).
+	pub(crate) fn group(&self) {
+		if let Some(counters) = self.counters() {
+			counters.groups.fetch_add(1, Ordering::Relaxed);
+		}
+	}
+
+	/// Bump `frames` by `n`.
+	pub(crate) fn frames(&self, n: u64) {
+		if n == 0 {
+			return;
+		}
+		if let Some(counters) = self.counters() {
+			counters.frames.fetch_add(n, Ordering::Relaxed);
+		}
+	}
+
+	/// Bump `bytes` by `n`.
+	pub(crate) fn bytes(&self, n: u64) {
+		if n == 0 {
+			return;
+		}
+		if let Some(counters) = self.counters() {
+			counters.bytes.fetch_add(n, Ordering::Relaxed);
+		}
+	}
+}
+
+/// A per-`(broadcast, tier, side)` scope, carried by the broadcast and track model
+/// handles. Resolved once by a tagged origin at the broadcast handoff; hands out
+/// [`Meter`]s for the payload path and RAII guards for the subscription / announce
+/// lifecycle. Cheap to clone; empty (no-op) when the broadcast is untracked.
+#[derive(Clone, Default)]
+pub(crate) struct Scope {
+	/// The owning context, kept for the egress viewer refcount map.
+	session: Session,
+	/// Resolved counters for `(path, tier)`, or `None` when untracked.
+	counters: Option<Arc<TierCounters>>,
+	side: Side,
+	/// Absolute broadcast path, used to key the viewer refcount and as the
+	/// `announced_bytes` length.
+	path: PathOwned,
+}
+
+impl Scope {
+	fn counters(&self) -> Option<&Counters> {
+		self.counters.as_ref().map(|c| self.side.counters(c))
+	}
+
+	/// A payload [`Meter`] for a group/frame derived from this scope.
+	pub(crate) fn meter(&self) -> Meter {
+		Meter {
 			counters: self.counters.clone(),
-		}
-		.publisher_track(name)
-	}
-}
-
-impl Drop for Publisher {
-	fn drop(&mut self) {
-		if let Some(counters) = &self.counters {
-			// Release pairs with the readout's Acquire load of
-			// `announced_closed`, propagating the open-bump from this
-			// guard's construction to whichever thread observes the close.
-			counters.publisher.announced_closed.fetch_add(1, Ordering::Release);
+			side: self.side,
 		}
 	}
-}
 
-/// RAII broadcast guard for the subscriber role. See [`Broadcast::subscriber`].
-#[must_use = "drop the guard to record the broadcast as closed"]
-pub struct Subscriber {
-	counters: Option<Arc<TierCounters>>,
-}
-
-impl Subscriber {
-	/// Open a track-subscription guard. Mirrors [`Publisher::track`].
-	pub fn track(&self, name: &str) -> SubscriberTrack {
-		Broadcast {
+	/// Open a track-subscription guard: bumps `subscriptions` now and
+	/// `subscriptions_closed` on drop. On the egress (publisher) side it also drives
+	/// the context's viewer refcount (`broadcasts` / `broadcasts_closed`).
+	pub(crate) fn subscribe(&self) -> Subscription {
+		if let Some(counters) = self.counters() {
+			counters.subscriptions.fetch_add(1, Ordering::Relaxed);
+		}
+		// Viewer refcount is egress-only: `broadcasts` counts distinct sessions
+		// watching a broadcast.
+		let viewer = if matches!(self.side, Side::Publisher) && self.counters.is_some() {
+			if self.session.viewer_open(&self.path)
+				&& let Some(counters) = self.counters()
+			{
+				counters.broadcasts.fetch_add(1, Ordering::Relaxed);
+			}
+			Some((self.session.clone(), self.path.clone()))
+		} else {
+			None
+		};
+		Subscription {
 			counters: self.counters.clone(),
+			side: self.side,
+			viewer,
 		}
-		.subscriber_track(name)
+	}
+
+	/// Bump the `fetches` counter once (a coalesced group fetch served).
+	pub(crate) fn fetch(&self) {
+		if let Some(counters) = self.counters() {
+			counters.fetches.fetch_add(1, Ordering::Relaxed);
+		}
+	}
+
+	/// Bump `subscriptions` once. The ingress (producer-lifetime) counterpart to
+	/// [`Self::subscribe`], which cannot use an RAII guard because the producer is
+	/// cloneable and closes only on the last clone drop. No viewer refcount (that is
+	/// egress-only). Pair with [`Self::close_subscription`].
+	pub(crate) fn open_subscription(&self) {
+		if let Some(counters) = self.counters() {
+			counters.subscriptions.fetch_add(1, Ordering::Relaxed);
+		}
+	}
+
+	/// Bump `subscriptions_closed` once. See [`Self::open_subscription`].
+	pub(crate) fn close_subscription(&self) {
+		if let Some(counters) = self.counters() {
+			// Release pairs with the readout's Acquire load of `subscriptions_closed`.
+			counters.subscriptions_closed.fetch_add(1, Ordering::Release);
+		}
+	}
+
+	/// Open an announce guard: bumps `announced` and adds the path length to
+	/// `announced_bytes` now; on drop bumps `announced_closed` and adds the path
+	/// length again. Used for egress announce-stream events and ingress
+	/// route-transition (un)announces.
+	pub(crate) fn announce(&self) -> Announce {
+		let len = self.path.as_str().len() as u64;
+		if let Some(counters) = self.counters() {
+			counters.announced.fetch_add(1, Ordering::Relaxed);
+			counters.announced_bytes.fetch_add(len, Ordering::Relaxed);
+		}
+		Announce {
+			counters: self.counters.clone(),
+			side: self.side,
+			len,
+		}
 	}
 }
 
-impl Drop for Subscriber {
-	fn drop(&mut self) {
-		if let Some(counters) = &self.counters {
-			// See `Publisher::drop` for why this is Release.
-			counters.subscriber.announced_closed.fetch_add(1, Ordering::Release);
-		}
-	}
-}
-
-/// RAII subscription guard for the publisher role.
+/// RAII guard for a track subscription (either side). See [`Scope::subscribe`].
+/// [`Subscription::default`] is an empty no-op guard.
+#[derive(Default)]
 #[must_use = "drop the guard to record the subscription as closed"]
-pub struct PublisherTrack {
+pub(crate) struct Subscription {
 	counters: Option<Arc<TierCounters>>,
+	side: Side,
+	/// `Some((session, path))` on the egress side, to release the viewer refcount.
+	viewer: Option<(Session, PathOwned)>,
 }
 
-impl PublisherTrack {
-	/// Bumps `frames` once.
-	pub fn frame(&self) {
-		if let Some(counters) = &self.counters {
-			counters.publisher.frames.fetch_add(1, Ordering::Relaxed);
+impl Drop for Subscription {
+	fn drop(&mut self) {
+		if let Some((session, path)) = &self.viewer
+			&& session.viewer_close(path)
+			&& let Some(counters) = &self.counters
+		{
+			// Release pairs with the readout's Acquire load of `broadcasts_closed`.
+			self.side
+				.counters(counters)
+				.broadcasts_closed
+				.fetch_add(1, Ordering::Release);
 		}
-	}
-
-	/// Bumps `bytes` by `n`.
-	pub fn bytes(&self, n: u64) {
 		if let Some(counters) = &self.counters {
-			counters.publisher.bytes.fetch_add(n, Ordering::Relaxed);
-		}
-	}
-
-	/// Bumps `groups` once.
-	pub fn group(&self) {
-		if let Some(counters) = &self.counters {
-			counters.publisher.groups.fetch_add(1, Ordering::Relaxed);
+			// Release pairs with the readout's Acquire load of `subscriptions_closed`.
+			self.side
+				.counters(counters)
+				.subscriptions_closed
+				.fetch_add(1, Ordering::Release);
 		}
 	}
 }
 
-impl Drop for PublisherTrack {
+/// RAII guard for one announce lifetime. See [`Scope::announce`].
+#[must_use = "drop the guard to record the unannounce"]
+pub(crate) struct Announce {
+	counters: Option<Arc<TierCounters>>,
+	side: Side,
+	len: u64,
+}
+
+impl Drop for Announce {
 	fn drop(&mut self) {
 		if let Some(counters) = &self.counters {
-			// See `Publisher::drop` for why this is Release.
-			counters.publisher.subscriptions_closed.fetch_add(1, Ordering::Release);
-		}
-	}
-}
-
-/// RAII subscription guard for the subscriber role.
-#[must_use = "drop the guard to record the subscription as closed"]
-pub struct SubscriberTrack {
-	counters: Option<Arc<TierCounters>>,
-}
-
-impl SubscriberTrack {
-	/// Bumps `frames` once.
-	pub fn frame(&self) {
-		if let Some(counters) = &self.counters {
-			counters.subscriber.frames.fetch_add(1, Ordering::Relaxed);
-		}
-	}
-
-	/// Bumps `bytes` by `n`.
-	pub fn bytes(&self, n: u64) {
-		if let Some(counters) = &self.counters {
-			counters.subscriber.bytes.fetch_add(n, Ordering::Relaxed);
-		}
-	}
-
-	/// Bumps `groups` once.
-	pub fn group(&self) {
-		if let Some(counters) = &self.counters {
-			counters.subscriber.groups.fetch_add(1, Ordering::Relaxed);
-		}
-	}
-}
-
-impl Drop for SubscriberTrack {
-	fn drop(&mut self) {
-		if let Some(counters) = &self.counters {
-			// See `Publisher::drop` for why this is Release.
-			counters.subscriber.subscriptions_closed.fetch_add(1, Ordering::Release);
+			let counters = self.side.counters(counters);
+			counters.announced_bytes.fetch_add(self.len, Ordering::Relaxed);
+			// Release pairs with the readout's Acquire load of `announced_closed`.
+			counters.announced_closed.fetch_add(1, Ordering::Release);
 		}
 	}
 }
@@ -1198,42 +1171,13 @@ mod tests {
 	}
 
 	#[test]
-	fn per_broadcast_counters_isolated() {
-		// Bumps on one broadcast must not leak into another.
-		let stats = test_stats();
-		let bs1 = stats.tier(Tier::default()).broadcast("demo/bbb");
-		let bs2 = stats.tier(Tier::default()).broadcast("demo/ccc");
-		let g1 = bs1.publisher().track("video");
-		g1.bytes(100);
-		let g2 = bs2.publisher().track("video");
-		g2.bytes(7);
-
-		assert_eq!(
-			tier_counters(&stats, "demo/bbb", &Tier::default())
-				.publisher
-				.bytes
-				.load(Relaxed),
-			100
-		);
-		assert_eq!(
-			tier_counters(&stats, "demo/ccc", &Tier::default())
-				.publisher
-				.bytes
-				.load(Relaxed),
-			7
-		);
-	}
-
-	#[test]
 	fn default_and_named_tiers_are_independent() {
 		let stats = test_stats();
-		let default = stats.tier(Tier::default());
-		let regional = stats.tier(Tier::new("region/sjc"));
+		let default = stats.tier(Tier::default()).session("root");
+		let regional = stats.tier(Tier::new("region/sjc")).session("root");
 
-		let default_track = default.broadcast("demo/bbb").publisher().track("video");
-		default_track.bytes(100);
-		let regional_track = regional.broadcast("demo/bbb").subscriber().track("audio");
-		regional_track.bytes(7);
+		default.egress("demo/bbb").meter().bytes(100);
+		regional.ingress("demo/bbb").meter().bytes(7);
 
 		let default_counters = tier_counters(&stats, "demo/bbb", &Tier::default());
 		let regional_counters = tier_counters(&stats, "demo/bbb", &Tier::new("region/sjc"));
@@ -1249,21 +1193,21 @@ mod tests {
 		let default = stats.tier(Tier::default());
 		let regional = stats.tier(Tier::new("region/sjc"));
 
-		// Default-tier egress across two broadcasts; the snapshot sums them.
-		let pub_a = default.broadcast("demo/aaa").publisher().track("video");
-		pub_a.bytes(100);
-		pub_a.frame();
-		pub_a.group();
-		let pub_b = default.broadcast("demo/bbb").publisher().track("video");
-		pub_b.bytes(50);
-		// Regional ingress on a different tier/role stays isolated.
-		let sub_a = regional.broadcast("demo/aaa").subscriber().track("audio");
-		sub_a.bytes(7);
-
-		// Hold session guards so `sessions_closed` stays zero.
-		let _s1 = default.session("acme");
+		// Two default-tier sessions under one root, one regional; presence sums them.
+		let s1 = default.session("acme");
 		let _s2 = default.session("acme");
-		let _s3 = regional.session("peer");
+		let s3 = regional.session("peer");
+
+		// Default-tier egress across two broadcasts; the snapshot sums them.
+		{
+			let m = s1.egress("demo/aaa").meter();
+			m.bytes(100);
+			m.frames(1);
+			m.group();
+		}
+		s1.egress("demo/bbb").meter().bytes(50);
+		// Regional ingress on a different tier/role stays isolated.
+		s3.ingress("demo/aaa").meter().bytes(7);
 
 		let snap = stats.snapshot();
 
@@ -1308,9 +1252,10 @@ mod tests {
 		// after the last guard drops (returning the final values that once).
 		let stats = test_stats();
 		let key = PathOwned::from("foo/bar");
-		let bs = stats.tier(Tier::default()).broadcast("foo/bar");
-		let track = bs.publisher().track("video");
-		track.bytes(42);
+		let ctx = stats.tier(Tier::default()).session("root");
+		let scope = ctx.egress("foo/bar");
+		let sub = scope.subscribe();
+		scope.meter().bytes(42);
 
 		let report = stats.report();
 		let row = report
@@ -1320,14 +1265,14 @@ mod tests {
 			.expect("live entry present");
 		assert_eq!(row.publisher.bytes, 42);
 		assert_eq!(row.publisher.subscriptions, 1);
-		assert!(!row.publisher.is_idle(), "track guard still open");
+		assert!(!row.publisher.is_idle(), "subscription guard still open");
 		assert!(
 			stats.shared().entries.lock().contains_key(&key),
 			"live entry kept across drains"
 		);
 
-		drop(track);
-		drop(bs);
+		drop(sub);
+		drop(scope);
 
 		// The drain after the last guard drops still returns the final values,
 		// then prunes the entry.
@@ -1353,8 +1298,9 @@ mod tests {
 		// subscription could still begin at any moment.
 		let stats = test_stats();
 		let key = PathOwned::from("foo/bar");
-		let bs = stats.tier(Tier::default()).broadcast("foo/bar");
-		let guard = bs.publisher();
+		let ctx = stats.tier(Tier::default()).session("root");
+		let scope = ctx.egress("foo/bar");
+		let guard = scope.announce();
 
 		for _ in 0..3 {
 			let report = stats.report();
@@ -1365,7 +1311,7 @@ mod tests {
 		}
 
 		drop(guard);
-		drop(bs);
+		drop(scope);
 		let report = stats.report();
 		let row = report.traffic.iter().find(|row| row.path == key).expect("final report");
 		assert!(row.publisher.is_idle());
@@ -1400,36 +1346,15 @@ mod tests {
 	}
 
 	#[test]
-	fn announced_bytes_recorded_per_side() {
-		// Path-keyed announce-byte recording is isolated per side, accumulates,
-		// works without holding a lifetime guard, and doesn't touch the payload
-		// `bytes` counter.
-		let stats = test_stats();
-		let bs = stats.tier(Tier::default()).broadcast("foo/bar");
-		bs.publisher_announced_bytes(40);
-		bs.publisher_announced_bytes(2);
-		bs.subscriber_announced_bytes(7);
-
-		let counters = tier_counters(&stats, "foo/bar", &Tier::default());
-		let pub_ext = counters.publisher.snapshot();
-		let sub_ext = counters.subscriber.snapshot();
-		assert_eq!(pub_ext.announced_bytes, 42, "publisher announce bytes accumulate");
-		assert_eq!(pub_ext.bytes, 0, "announce bytes are not payload bytes");
-		assert_eq!(sub_ext.announced_bytes, 7, "subscriber side tracked independently");
-	}
-
-	#[test]
 	fn paths_under_exclude_are_no_op() {
 		// Our own stats broadcasts (and any sibling category under the same
 		// prefix) must not feed back into the registry.
 		let stats = test_stats();
-		let bs = stats.tier(Tier::default()).broadcast(".stats/node/sjc");
-		assert!(bs.is_empty());
-		let p = bs.publisher();
-		let track = p.track("video");
-		track.bytes(100);
-		drop(track);
-		drop(p);
+		let ctx = stats.tier(Tier::default()).session("root");
+		let scope = ctx.egress(".stats/node/sjc");
+		scope.meter().bytes(100);
+		let _guard = scope.announce();
+		let _sub = scope.subscribe();
 		assert!(stats.shared().entries.lock().is_empty());
 	}
 
@@ -1439,79 +1364,13 @@ mod tests {
 		// and bumps are dropped.
 		let stats = Registry::default();
 		assert!(stats.shared.is_none());
-		let bs = stats.tier(Tier::default()).broadcast("demo/bbb");
-		assert!(bs.is_empty());
-		let p = bs.publisher();
-		let track = p.track("video");
-		track.bytes(100);
-		drop(track);
-		drop(p);
+		let ctx = stats.tier(Tier::default()).session("root");
+		let scope = ctx.egress("demo/bbb");
+		scope.meter().bytes(100);
+		let _guard = scope.announce();
+		let _sub = scope.subscribe();
 		assert!(stats.report().traffic.is_empty());
 		assert!(stats.snapshot().traffic().is_empty());
-	}
-
-	#[test]
-	fn multiple_subs_count_as_one_broadcast() {
-		// Two concurrent subs from the SAME session count as one broadcast, not
-		// two: broadcasts is "distinct sessions with >=1 active sub", not
-		// "subscription count". broadcasts_closed only bumps once the session's
-		// last sub for the broadcast closes.
-		let stats = test_stats();
-		let bs = stats.tier(Tier::default()).broadcast("foo/bar");
-		let sessions = stats.tier(Tier::default()).publisher_broadcasts();
-		let pub_guard = bs.publisher();
-		let t1 = pub_guard.track("video");
-		let t2 = pub_guard.track("audio");
-		let s1 = sessions.subscribe("foo/bar");
-		let s2 = sessions.subscribe("foo/bar");
-
-		let raw = || tier_counters(&stats, "foo/bar", &Tier::default()).publisher.snapshot();
-
-		let r = raw();
-		assert_eq!(r.subscriptions, 2, "two track subs");
-		assert_eq!(r.subscriptions_closed, 0, "neither dropped yet");
-		assert_eq!(r.broadcasts, 1, "one session => one broadcast");
-		assert_eq!(r.broadcasts_closed, 0);
-
-		drop(s1);
-		assert_eq!(raw().broadcasts_closed, 0, "session still has a sub open");
-
-		drop(s2);
-		drop(t1);
-		drop(t2);
-		let r = raw();
-		assert_eq!(r.subscriptions_closed, 2, "both track subs dropped");
-		assert_eq!(r.broadcasts, 1);
-		assert_eq!(r.broadcasts_closed, 1, "last sub closed => one broadcasts_closed");
-
-		drop(pub_guard);
-		drop(bs);
-	}
-
-	#[test]
-	fn distinct_sessions_count_as_separate_broadcasts() {
-		// The viewer-count invariant: two different sessions subscribing to the
-		// same broadcast bump broadcasts to 2 (each is a distinct viewer).
-		let stats = test_stats();
-		let viewer1 = stats.tier(Tier::default()).publisher_broadcasts();
-		let viewer2 = stats.tier(Tier::default()).publisher_broadcasts();
-
-		let raw = || tier_counters(&stats, "foo/bar", &Tier::default()).publisher.snapshot();
-
-		let s1 = viewer1.subscribe("foo/bar");
-		assert_eq!(raw().broadcasts, 1, "one viewer");
-		let s2 = viewer2.subscribe("foo/bar");
-		assert_eq!(raw().broadcasts, 2, "two distinct viewers");
-		assert_eq!(raw().broadcasts_closed, 0);
-
-		drop(s1);
-		let r = raw();
-		assert_eq!(r.broadcasts, 2, "broadcasts is cumulative");
-		assert_eq!(r.broadcasts_closed, 1, "one viewer left");
-		assert_eq!(r.active_broadcasts(), 1, "one remaining viewer");
-
-		drop(s2);
-		assert_eq!(raw().broadcasts_closed, 2, "both viewers gone");
 	}
 
 	#[test]
@@ -1585,6 +1444,180 @@ mod tests {
 			bcast_closed_pos < bcast_pos,
 			"broadcasts_closed must be loaded before broadcasts",
 		);
+	}
+
+	#[test]
+	fn context_presence_closes_on_last_clone() {
+		// The reshaped Session context bumps `sessions` once at creation and
+		// `sessions_closed` only when the last clone drops.
+		let stats = test_stats();
+		let snap =
+			|root: &str| session_snapshot(&stats, &Tier::default(), root).map(|p| (p.sessions, p.sessions_closed));
+
+		let ctx = stats.tier(Tier::default()).session("acme");
+		assert_eq!(snap("acme"), Some((1, 0)));
+
+		let clone = ctx.clone();
+		// A clone shares the Arc: no extra `sessions`, and dropping one does nothing.
+		assert_eq!(snap("acme"), Some((1, 0)));
+		drop(ctx);
+		assert_eq!(snap("acme"), Some((1, 0)));
+		drop(clone);
+		assert_eq!(snap("acme"), Some((1, 1)));
+	}
+
+	#[test]
+	fn meter_bumps_the_right_side() {
+		// A payload meter records on its own side only.
+		let stats = test_stats();
+		let ctx = stats.tier(Tier::default()).session("root");
+
+		let egress = ctx.egress("demo/bbb").meter();
+		egress.group();
+		egress.frames(3);
+		egress.bytes(100);
+
+		let ingress = ctx.ingress("demo/bbb").meter();
+		ingress.group();
+		ingress.frames(1);
+		ingress.bytes(7);
+
+		let counters = tier_counters(&stats, "demo/bbb", &Tier::default());
+		let pub_ = counters.publisher.snapshot();
+		let sub = counters.subscriber.snapshot();
+		assert_eq!((pub_.groups, pub_.frames, pub_.bytes), (1, 3, 100));
+		assert_eq!((sub.groups, sub.frames, sub.bytes), (1, 1, 7));
+	}
+
+	#[test]
+	fn egress_subscribe_drives_subscriptions_and_viewers() {
+		// An egress subscription bumps `subscriptions` and, being the context's first
+		// for the broadcast, `broadcasts`. Dropping closes both.
+		let stats = test_stats();
+		let ctx = stats.tier(Tier::default()).session("root");
+		let raw = || tier_counters(&stats, "demo/bbb", &Tier::default()).publisher.snapshot();
+
+		let scope = ctx.egress("demo/bbb");
+		let s1 = scope.subscribe();
+		let s2 = scope.subscribe();
+		let r = raw();
+		assert_eq!(r.subscriptions, 2, "two track subs");
+		assert_eq!(r.broadcasts, 1, "one context => one viewer");
+		assert_eq!(r.broadcasts_closed, 0);
+
+		drop(s1);
+		assert_eq!(raw().broadcasts_closed, 0, "context still has a sub open");
+		drop(s2);
+		let r = raw();
+		assert_eq!(r.subscriptions_closed, 2);
+		assert_eq!(r.broadcasts_closed, 1, "last sub closed => one broadcasts_closed");
+	}
+
+	#[test]
+	fn distinct_contexts_are_distinct_viewers() {
+		// Two contexts (sessions) subscribing to the same broadcast are two viewers.
+		let stats = test_stats();
+		let raw = || tier_counters(&stats, "demo/bbb", &Tier::default()).publisher.snapshot();
+
+		let v1 = stats.tier(Tier::default()).session("a").egress("demo/bbb").subscribe();
+		assert_eq!(raw().broadcasts, 1);
+		let v2 = stats.tier(Tier::default()).session("b").egress("demo/bbb").subscribe();
+		assert_eq!(raw().broadcasts, 2, "two distinct contexts => two viewers");
+
+		drop(v1);
+		assert_eq!(raw().active_broadcasts(), 1);
+		drop(v2);
+		assert_eq!(raw().broadcasts_closed, 2);
+	}
+
+	#[test]
+	fn ingress_subscription_has_no_viewer() {
+		// The ingress (producer-lifetime) subscription pair bumps subscriptions but
+		// never the viewer refcount.
+		let stats = test_stats();
+		let ctx = stats.tier(Tier::default()).session("root");
+		let scope = ctx.ingress("demo/bbb");
+		scope.open_subscription();
+		let sub = tier_counters(&stats, "demo/bbb", &Tier::default())
+			.subscriber
+			.snapshot();
+		assert_eq!(sub.subscriptions, 1);
+		assert_eq!(sub.broadcasts, 0, "ingress has no viewer refcount");
+		scope.close_subscription();
+		assert_eq!(
+			tier_counters(&stats, "demo/bbb", &Tier::default())
+				.subscriber
+				.snapshot()
+				.subscriptions_closed,
+			1
+		);
+	}
+
+	#[test]
+	fn fetch_counts_separately_from_subscriptions() {
+		// A fetch bumps `fetches`, not `subscriptions` or the viewer refcount.
+		let stats = test_stats();
+		let ctx = stats.tier(Tier::default()).session("root");
+		let scope = ctx.egress("demo/bbb");
+		scope.fetch();
+		scope.fetch();
+		let r = tier_counters(&stats, "demo/bbb", &Tier::default()).publisher.snapshot();
+		assert_eq!(r.fetches, 2);
+		assert_eq!(r.subscriptions, 0);
+		assert_eq!(r.broadcasts, 0);
+	}
+
+	#[test]
+	fn announce_guard_records_bytes_on_open_and_close() {
+		// The announce guard bumps `announced` + the path length on open, and
+		// `announced_closed` + the path length again on drop.
+		let stats = test_stats();
+		let ctx = stats.tier(Tier::default()).session("root");
+		let path_len = "demo/bbb".len() as u64;
+
+		let guard = ctx.egress("demo/bbb").announce();
+		let r = tier_counters(&stats, "demo/bbb", &Tier::default()).publisher.snapshot();
+		assert_eq!(r.announced, 1);
+		assert_eq!(r.announced_closed, 0);
+		assert_eq!(r.announced_bytes, path_len);
+
+		drop(guard);
+		let r = tier_counters(&stats, "demo/bbb", &Tier::default()).publisher.snapshot();
+		assert_eq!(r.announced_closed, 1);
+		assert_eq!(
+			r.announced_bytes,
+			path_len * 2,
+			"path length recorded on open and close"
+		);
+	}
+
+	#[test]
+	fn disabled_context_is_noop() {
+		// A default (disabled) context resolves empty scopes: every bump is dropped.
+		let ctx = Session::default();
+		let scope = ctx.egress("demo/bbb");
+		scope.meter().bytes(100);
+		let _guard = scope.announce();
+		let _sub = scope.subscribe();
+		scope.fetch();
+		// No registry to inspect; the point is that none of this panics or allocates.
+		assert!(ctx.inner.is_none());
+	}
+
+	#[test]
+	fn fetches_serde_roundtrips() {
+		// The new `fetches` field is additive: an older frame omits it (defaults to
+		// zero), and it survives a roundtrip.
+		let old: Traffic = serde_json::from_str(r#"{"bytes":5}"#).expect("older shape parses");
+		assert_eq!(old.fetches, 0);
+
+		let t = Traffic {
+			fetches: 9,
+			..Default::default()
+		};
+		let json = serde_json::to_string(&t).unwrap();
+		let back: Traffic = serde_json::from_str(&json).unwrap();
+		assert_eq!(back.fetches, 9);
 	}
 
 	#[test]

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -892,11 +892,12 @@ impl Cluster {
 			.clone()
 			.context("internal: cluster peer dial without an attached QUIC client")?;
 
-		// Cluster dials use their configured stats tier.
+		// Cluster dials use their configured stats tier. Cluster peers carry no auth
+		// root, so presence is keyed under the empty root within the cluster tier.
 		let mut client = client
 			.with_publisher(&self.origin)
 			.with_subscriber(self.origin.clone())
-			.with_stats(self.stats.tier(self.cluster_tier()));
+			.with_stats(self.stats.tier(self.cluster_tier()).session(""));
 		if let Some(cost) = cost {
 			client = client.with_cost(cost);
 		}

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -85,15 +85,12 @@ impl Connection {
 			_ => unreachable!("authorized above guarantees at least one origin"),
 		}
 
-		// Record this session's stats under its billing tier. The aggregator is
-		// shared; the tier picks which counter set the bumps land in.
-		let stats = self.cluster.stats.tier(token.tier.clone());
-
-		// Count this session against its auth root for the whole connection,
-		// independent of any data flow, so presence-based billing sees a client
-		// that connects to e.g. `/acme` even while idle. Dropped when
-		// the connection closes below.
-		let _session_stats = stats.session(&token.root);
+		// Build this session's stats context under its billing tier and auth root.
+		// The context carries the presence gauge (a client that merely connects to
+		// e.g. `/acme` is counted, even idle) and drives the model-layer counters
+		// once it tags the session's origin pair below. It closes when the last
+		// clone drops (the connection ends).
+		let stats = self.cluster.stats.tier(token.tier.clone()).session(&token.root);
 
 		// Wire only the direction(s) the client will actually use. The token scope
 		// (enforced above) caps what it *may* do; the role caps what it *will* do.

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -216,27 +216,53 @@ mod tests {
 	/// The `/metrics` renderer emits well-formed Prometheus exposition: a
 	/// HELP/TYPE header per metric and a labeled line carrying the live counter
 	/// value, summed across broadcasts.
-	#[test]
-	fn metrics_render_exposition() {
+	#[tokio::test(start_paused = true)]
+	async fn metrics_render_exposition() {
 		use moq_net::stats::{Registry, Tier};
+		use moq_net::{Origin, Timestamp, broadcast};
 
 		let stats = Registry::new(Default::default());
 
-		let track = stats
-			.tier(Tier::default())
-			.broadcast("demo/x")
-			.publisher()
-			.track("video");
-		track.bytes(1234);
-		let _session = stats.tier(Tier::default()).session("acme");
+		// Default-tier egress: an untagged local publisher writes, a tagged egress
+		// consumer reads it out, so publisher `bytes` advance on the default tier.
+		let default_ctx = stats.tier(Tier::default()).session("acme");
+		let pub_origin = Origin::random().produce();
+		let egress = pub_origin.consume().with_stats(default_ctx.clone());
+		let mut announced = egress.announced();
+		let mut pub_source = pub_origin
+			.create_broadcast("demo/x", broadcast::Route::announced())
+			.unwrap();
+		let mut pub_track = pub_source.create_track("video", None).unwrap();
 
-		// A second, named tier renders its own labeled rows.
-		let regional = stats
-			.tier(Tier::new("region/sjc"))
-			.broadcast("demo/x")
-			.subscriber()
-			.track("audio");
-		regional.bytes(56);
+		// Named-tier ingress: a tagged ingress producer writes, so subscriber
+		// `bytes` advance on the regional tier.
+		let regional_ctx = stats.tier(Tier::new("region/sjc")).session("peer");
+		let sub_origin = Origin::random().produce().with_stats(regional_ctx.clone());
+		let mut sub_source = sub_origin
+			.create_broadcast("demo/x", broadcast::Route::announced())
+			.unwrap();
+		let mut sub_track = sub_source.create_track("audio", None).unwrap();
+
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+
+		// Read 1234 egress bytes out of the default-tier broadcast.
+		let bc = announced.next().await.unwrap().broadcast.unwrap();
+		let mut egress_sub = bc.track("video").unwrap().subscribe(None).await.unwrap();
+		{
+			let mut group = pub_track.append_group().unwrap();
+			group.write_frame(Timestamp::ZERO, vec![0u8; 1234]).unwrap();
+			group.finish().unwrap();
+		}
+		let mut group = egress_sub.recv_group().await.unwrap().unwrap();
+		while group.read_frame().await.unwrap().is_some() {}
+
+		// Write 56 ingress bytes into the regional-tier broadcast.
+		{
+			let mut group = sub_track.append_group().unwrap();
+			group.write_frame(Timestamp::ZERO, vec![0u8; 56]).unwrap();
+			group.finish().unwrap();
+		}
 
 		let body = render_metrics(&stats.snapshot());
 

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -12,7 +12,7 @@ use axum::{
 	response::Response,
 };
 use moq_net::origin;
-use moq_net::stats::Handle;
+use moq_net::stats::Session;
 
 use crate::{Auth, AuthParams, web::MtlsPeer, web::WebState, web::landing_response};
 
@@ -50,7 +50,7 @@ pub(crate) async fn serve_ws(
 	};
 	let publish = state.cluster.publisher(&token);
 	let subscribe = state.cluster.subscriber(&token);
-	let stats = state.cluster.stats.tier(token.tier.clone());
+	let stats = state.cluster.stats.tier(token.tier.clone()).session(&token.root);
 
 	if publish.is_none() && subscribe.is_none() {
 		// Bad token, we can't publish or subscribe.
@@ -85,7 +85,7 @@ async fn handle_socket<T>(
 	alpn: Option<String>,
 	publish: Option<origin::Producer>,
 	subscribe: Option<origin::Producer>,
-	stats: Handle,
+	stats: Session,
 ) -> anyhow::Result<()>
 where
 	T: futures::Stream<Item = Result<tungstenite::Message, tungstenite::Error>>

--- a/rs/moq-stats/Cargo.toml
+++ b/rs/moq-stats/Cargo.toml
@@ -22,4 +22,5 @@ tracing = "0.1"
 web-async = { workspace = true }
 
 [dev-dependencies]
+futures = "0.3"
 tokio = { workspace = true, features = ["macros", "rt", "test-util", "time"] }

--- a/rs/moq-stats/src/consume.rs
+++ b/rs/moq-stats/src/consume.rs
@@ -103,7 +103,7 @@ impl SessionsConsumer {
 mod tests {
 	use std::time::Duration;
 
-	use moq_net::{Consume, Origin, PathOwned, announce, origin};
+	use moq_net::{Consume, Origin, PathOwned, Timestamp, announce, broadcast, origin, track};
 
 	use crate::{Producer, ProducerConfig, Tier};
 
@@ -117,6 +117,55 @@ mod tests {
 				.with_node(PathOwned::from("sjc")),
 		);
 		(producer, origin)
+	}
+
+	/// A tagged egress feed into a producer's registry, holding the handles needed
+	/// to write more traffic incrementally. Presence is recorded under `root`.
+	struct Feed {
+		track: track::Producer,
+		sub: track::Subscriber,
+		_announced: announce::Consumer,
+		_source: broadcast::Producer,
+		_ctx: moq_net::stats::Session,
+	}
+
+	impl Feed {
+		/// Write one frame of `bytes` bytes into the broadcast and read it out on the
+		/// egress side, so the publisher `bytes`/`frames`/`groups` counters advance.
+		async fn write(&mut self, bytes: usize) {
+			let mut group = self.track.append_group().unwrap();
+			group.write_frame(Timestamp::ZERO, vec![0u8; bytes]).unwrap();
+			group.finish().unwrap();
+			let mut group = self.sub.recv_group().await.unwrap().unwrap();
+			while group.read_frame().await.unwrap().is_some() {}
+		}
+	}
+
+	async fn feed(producer: &Producer, tier: Tier, root: &str, path: &str) -> Feed {
+		let ctx = producer.registry().tier(tier).session(root);
+		let feed_origin = Origin::random().produce();
+		let egress = feed_origin.consume().with_stats(ctx.clone());
+
+		let mut announced = egress.announced();
+		let mut source = feed_origin
+			.create_broadcast(path, broadcast::Route::announced())
+			.unwrap();
+		let track = source.create_track("video", None).unwrap();
+
+		tokio::time::sleep(Duration::from_millis(1)).await;
+		tokio::time::sleep(Duration::from_millis(1)).await;
+
+		let announce::Update { broadcast, .. } = announced.next().await.expect("announce");
+		let consumer = broadcast.expect("active");
+		let sub = consumer.track("video").unwrap().subscribe(None).await.unwrap();
+
+		Feed {
+			track,
+			sub,
+			_announced: announced,
+			_source: source,
+			_ctx: ctx,
+		}
 	}
 
 	async fn announced(origin: &origin::Producer) -> moq_net::broadcast::Consumer {
@@ -140,11 +189,8 @@ mod tests {
 		// track's delta path).
 		let (producer, origin) = test_producer();
 		let tier = Tier::default();
-		let stats = producer.registry().tier(tier.clone());
-		let bs = stats.broadcast("foo/bar");
-		let track = bs.publisher().track("video");
-		track.bytes(42);
-		let _session = stats.session("acme");
+		let mut fed = feed(&producer, tier.clone(), "acme", "foo/bar").await;
+		fed.write(42).await;
 
 		drive_tick().await;
 
@@ -164,7 +210,7 @@ mod tests {
 		assert_eq!(plain_frame.get("foo/bar").expect("entry").bytes, 42);
 
 		// A later drain updates both flavors; the compressed one rides a delta.
-		track.bytes(8);
+		fed.write(8).await;
 		drive_tick().await;
 		let plain_frame = plain_traffic.next().await.expect("read").expect("frame");
 		let z_frame = z_traffic.next().await.expect("read").expect("frame");

--- a/rs/moq-stats/src/produce.rs
+++ b/rs/moq-stats/src/produce.rs
@@ -552,7 +552,8 @@ fn advertised_path(prefix: &Path, group: &Path, node: Option<&str>) -> PathOwned
 mod tests {
 	use std::collections::BTreeMap;
 
-	use moq_net::{Origin, announce, track};
+	use moq_net::stats::{Registry, Tier};
+	use moq_net::{Origin, Timestamp, announce, broadcast, track};
 
 	use super::*;
 
@@ -564,6 +565,82 @@ mod tests {
 				.with_node(node.map(|s| PathOwned::from(s.to_string()))),
 		);
 		(producer, origin)
+	}
+
+	/// Kept-alive handles from [`feed`]: dropping them closes the subscription and the
+	/// announce (bumping the `_closed` counters).
+	#[allow(dead_code)]
+	struct Feed {
+		announced: announce::Consumer,
+		source: broadcast::Producer,
+		consumer: broadcast::Consumer,
+		sub: Option<track::Subscriber>,
+	}
+
+	/// Drive a tagged egress broadcast so `registry` records publisher-side traffic on
+	/// `path` under `tier`. The local publisher (ingress) is left untagged, so only the
+	/// egress (publisher) counters move, matching how a relay bills read-out traffic.
+	///
+	/// Announces the broadcast; if `subscribe`, opens one subscription and reads a group
+	/// of `frames` frames of `frame_size` bytes each (so `bytes`/`frames`/`groups` move).
+	async fn feed(
+		registry: &Registry,
+		tier: Tier,
+		path: &str,
+		subscribe: bool,
+		frames: usize,
+		frame_size: usize,
+	) -> Feed {
+		let ctx = registry.tier(tier).session("feed");
+		let origin = Origin::random().produce();
+		// Egress (publisher side) is tagged; the local publisher stays untagged.
+		let egress = origin.consume().with_stats(ctx);
+
+		let mut announced = egress.announced();
+		let mut source = origin
+			.create_broadcast(path, broadcast::Route::announced())
+			.expect("create_broadcast");
+		let mut producer = source.create_track("video", None).expect("create_track");
+
+		// Let the origin's source watcher attach and announce (paused time advances
+		// instantly and yields to the spawned tasks).
+		tokio::time::sleep(Duration::from_millis(1)).await;
+		tokio::time::sleep(Duration::from_millis(1)).await;
+
+		let announce::Update { broadcast, .. } = announced.next().await.expect("announce");
+		let consumer = broadcast.expect("active");
+
+		let sub = if subscribe {
+			let mut sub = consumer
+				.track("video")
+				.expect("track")
+				.subscribe(None)
+				.await
+				.expect("subscribe");
+
+			if frames > 0 {
+				let mut group = producer.append_group().expect("group");
+				for _ in 0..frames {
+					group
+						.write_frame(Timestamp::ZERO, vec![0u8; frame_size])
+						.expect("write");
+				}
+				group.finish().expect("finish");
+
+				let mut group = sub.recv_group().await.expect("recv").expect("group");
+				while group.read_frame().await.expect("read").is_some() {}
+			}
+			Some(sub)
+		} else {
+			None
+		};
+
+		Feed {
+			announced,
+			source,
+			consumer,
+			sub,
+		}
 	}
 
 	/// Awaits the stats announce and returns its broadcast.
@@ -590,6 +667,19 @@ mod tests {
 		let mut track = subscribe(broadcast, name).await;
 		let frame = track.read_frame().await.expect("ok").expect("frame");
 		serde_json::from_slice(&frame.payload).expect("json parse")
+	}
+
+	/// Read the latest buffered traffic frame off a track. The producer emits an
+	/// immediate first (often empty) frame at time zero, so a test that records
+	/// traffic asynchronously reads the accumulated state rather than that stale one.
+	async fn read_last_frame(broadcast: &moq_net::broadcast::Consumer, name: &str) -> BTreeMap<String, Traffic> {
+		use futures::FutureExt;
+		let mut track = subscribe(broadcast, name).await;
+		let mut last = track.read_frame().await.expect("ok").expect("frame");
+		while let Some(Ok(Some(frame))) = track.read_frame().now_or_never() {
+			last = frame;
+		}
+		serde_json::from_slice(&last.payload).expect("json parse")
 	}
 
 	async fn read_session_frame(broadcast: &moq_net::broadcast::Consumer, name: &str) -> BTreeMap<String, Presence> {
@@ -625,10 +715,8 @@ mod tests {
 		// broadcast is announced (the per-node aggregate).
 		let (producer, origin) = test_producer(Some("sjc/1"));
 
-		let bs1 = producer.registry().tier(Tier::default()).broadcast("foo/bar");
-		let _t1 = bs1.publisher().track("video");
-		let bs2 = producer.registry().tier(Tier::default()).broadcast("baz/qux");
-		let _t2 = bs2.publisher().track("video");
+		let _f1 = feed(producer.registry(), Tier::default(), "foo/bar", true, 1, 8).await;
+		let _f2 = feed(producer.registry(), Tier::default(), "baz/qux", true, 1, 8).await;
 
 		assert_eq!(announced(&origin).await.0, ".stats/node/sjc/1");
 	}
@@ -636,28 +724,22 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn task_announces_without_node_suffix() {
 		let (producer, origin) = test_producer(None);
-		let bs = producer.registry().tier(Tier::default()).broadcast("foo/bar");
-		let _t = bs.publisher().track("video");
+		let _f = feed(producer.registry(), Tier::default(), "foo/bar", true, 1, 8).await;
 		assert_eq!(announced(&origin).await.0, ".stats/node");
 	}
 
 	#[tokio::test(start_paused = true)]
 	async fn frame_emits_expected_counters() {
 		let (producer, origin) = test_producer(Some("sjc"));
-		let stats = producer.registry().tier(Tier::default());
-		let bs = stats.broadcast("foo/bar");
-		let track = bs.publisher().track("video");
-		track.bytes(42);
-		track.frame();
-		let sessions = stats.publisher_broadcasts();
-		let _sub = sessions.subscribe("foo/bar");
+		// One announced broadcast, one subscription, one 42-byte frame read out.
+		let _f = feed(producer.registry(), Tier::default(), "foo/bar", true, 1, 42).await;
 
 		drive_tick().await;
 
 		let (_, broadcast) = announced(&origin).await;
-		let frame = read_frame(&broadcast, "publisher.json").await;
+		let frame = read_last_frame(&broadcast, "publisher.json").await;
 		let snap = frame.get("foo/bar").expect("foo/bar entry");
-		assert_eq!(snap.announced, 1, "publisher() guard bumps announced");
+		assert_eq!(snap.announced, 1, "egress announce stream bumps announced");
 		assert_eq!(snap.broadcasts, 1, "one session subscribed");
 		assert_eq!(snap.subscriptions, 1);
 		assert_eq!(snap.bytes, 42);
@@ -667,31 +749,33 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn announced_bytes_surfaces_in_frame() {
 		let (producer, origin) = test_producer(Some("sjc"));
-		let bs = producer.registry().tier(Tier::default()).broadcast("foo/bar");
-		let _guard = bs.publisher();
-		bs.publisher_announced_bytes(123);
+		// Announce only: the guard records the broadcast-name length once on open.
+		let _f = feed(producer.registry(), Tier::default(), "foo/bar", false, 0, 0).await;
 
 		drive_tick().await;
 
 		let (_, broadcast) = announced(&origin).await;
-		let frame = read_frame(&broadcast, "publisher.json").await;
+		let frame = read_last_frame(&broadcast, "publisher.json").await;
 		let snap = frame.get("foo/bar").expect("foo/bar entry");
 		assert_eq!(snap.announced, 1);
-		assert_eq!(snap.announced_bytes, 123);
+		assert_eq!(
+			snap.announced_bytes,
+			"foo/bar".len() as u64,
+			"name length recorded on announce"
+		);
 	}
 
 	#[tokio::test(start_paused = true)]
 	async fn announced_decouples_from_broadcasts() {
-		// publisher() (announce) with no subscription should bump announced but
-		// NOT broadcasts (which only counts sessions with an active sub).
+		// An announce with no subscription should bump announced but NOT broadcasts
+		// (which only counts sessions with an active sub).
 		let (producer, origin) = test_producer(Some("sjc"));
-		let bs = producer.registry().tier(Tier::default()).broadcast("foo/bar");
-		let _guard = bs.publisher();
+		let _f = feed(producer.registry(), Tier::default(), "foo/bar", false, 0, 0).await;
 
 		drive_tick().await;
 
 		let (_, broadcast) = announced(&origin).await;
-		let frame = read_frame(&broadcast, "publisher.json").await;
+		let frame = read_last_frame(&broadcast, "publisher.json").await;
 		let snap = frame.get("foo/bar").expect("foo/bar entry");
 		assert_eq!(snap.announced, 1);
 		assert_eq!(snap.broadcasts, 0, "no subscription, no broadcasts sentinel");
@@ -706,21 +790,16 @@ mod tests {
 		// change-driven inclusion surfaces the entry even though it's net-idle
 		// by drain time.
 		let (producer, origin) = test_producer(Some("sjc"));
-		let stats = producer.registry().tier(Tier::default());
-		let bs = stats.broadcast("foo/bar");
-		let sessions = stats.publisher_broadcasts();
 		{
-			let track = bs.publisher().track("video");
-			track.bytes(123);
-			track.frame();
-			let _sub = sessions.subscribe("foo/bar");
-			// track + sub dropped here, all within the first interval
+			// Subscribe, read one 123-byte frame, then drop everything within the
+			// first interval so the open and close both land before the drain.
+			let _f = feed(producer.registry(), Tier::default(), "foo/bar", true, 1, 123).await;
 		}
 
 		drive_tick().await;
 
 		let (_, broadcast) = announced(&origin).await;
-		let frame = read_frame(&broadcast, "publisher.json").await;
+		let frame = read_last_frame(&broadcast, "publisher.json").await;
 		let snap = frame.get("foo/bar").expect("foo/bar entry");
 		// One session opened then closed a subscription within the drain.
 		assert_eq!(snap.subscriptions, 1);
@@ -763,9 +842,9 @@ mod tests {
 		// surface on its sibling default-tier subscriber track, and a tier
 		// with no traffic gets no tracks at all.
 		let (producer, origin) = test_producer(Some("sjc"));
-		let bs = producer.registry().tier(Tier::default()).broadcast("foo/bar");
-		let track = bs.publisher().track("video");
-		track.frame();
+		// Only the egress (publisher) side is tagged, so `foo/bar` gets publisher
+		// traffic and no subscriber traffic.
+		let _f = feed(producer.registry(), Tier::default(), "foo/bar", true, 1, 8).await;
 
 		drive_tick().await;
 		drive_tick().await;
@@ -774,7 +853,9 @@ mod tests {
 
 		// Default-tier publisher slot SHOULD include foo/bar.
 		assert!(
-			read_frame(&broadcast, "publisher.json").await.contains_key("foo/bar"),
+			read_last_frame(&broadcast, "publisher.json")
+				.await
+				.contains_key("foo/bar"),
 			"publisher.json must include the active foo/bar entry"
 		);
 


### PR DESCRIPTION
## What

Moves the `moq_net::stats` bump sites out of the four wire loops (lite/ietf × publisher/subscriber) and into the **model layer**, attributed through tagged `origin::{Consumer, Producer}` handles. A session picks a tier at one seam and its reads (egress = publisher) and writes (ingress = subscriber) are counted as they flow through `broadcast → track → group → frame`. Any protocol that drives the model now gets the full counter set for free; an untagged handle pays nothing.

## Why

This is the **prerequisite** for consolidating the moq.pro gateways (srt/rtmp/webrtc/hls) into a single edge binary. Today each gateway is billed because its qmux session to edge crosses the wire layer. Once they run in-process on `cluster.origin`, those sessions (and the wire-layer counting that billed them) disappear, and tagged origin handles become the only place their traffic is visible. It also closes the existing gap where in-process consumers on edge (the VOD/HLS recorder reading `cluster.origin`) are invisible today.

## How it works

- **`stats::Session` reshaped** from a bare `#[must_use]` presence guard into a cheap-to-clone (`Arc` inside) per-connection **context**, created via `Registry::tier(tier).session(root)`. One context per connection, shared by both origin halves, so presence and viewer counts never double-attribute. It carries the tier + auth root, the presence gauge (`sessions` / `sessions_closed` on the last clone drop), and the egress viewer refcount map (`broadcasts` / `broadcasts_closed`).
- **Tagging**: new `origin::{Consumer, Producer}::with_stats(session)`; every derived handle inherits it. `Client/Server::with_stats` take the context and tag the session's origin pair at setup — the wire loops keep zero bump code.
- **New `Traffic::fetches` counter** (additive: `#[non_exhaustive]` + `#[serde(default)]`). `fetch_group()` bumps it once per calling context (coalesced fetches count once, requests-served not upstream-work) and no longer touches `subscriptions` or the viewer refcount.
- **Deleted** every wire-loop bump site and the now-dead pub guard API (`Broadcast`, `Publisher`/`Subscriber`, `PublisherTrack`/`SubscriberTrack`, `SessionBroadcasts`, `BroadcastSubscription`, `Handle::broadcast`/`*_broadcasts`).

Memory-ordering invariants are unchanged: open/payload bumps stay `Relaxed`, guard-drop closes stay `Release`, readout loads `_closed` with `Acquire` first (the source-pinning ordering tests still pass). The read hot path bumps **per prefetch batch fill** — one `Relaxed` add per batch — never per `pop()`; chunked reads bump per chunk.

## Deliberate semantic changes

- **Egress bytes are counted when read out of the model**, not when written to the QUIC send buffer. Bytes read but lost to a mid-group stream reset now count. (Today's counting was send-buffer-side / not-acked anyway.)
- **Announce control traffic that never enters the model** (auth-rejected, unmatched prefix, reflected cluster loops) is no longer counted. Announce spam is handled by auth/rate limits, not billing.
- **Datagrams are no longer counted** as groups — the group/frame model counters don't cover the best-effort datagram path. (Rare/tiny; flagged for follow-up if it needs its own counter.)

## Public API (all breaking → `dev`)

- Removed the `stats` guard-injection API listed above; the direct-injection path is replaced by tagging an origin handle.
- `stats::Session` is now `Clone + Default` (was a `#[must_use]` guard); still produced by `Handle::session(root)`, drop-on-last-clone preserves the presence close.
- `Client/Server/Request::with_stats(stats::Handle)` → `(stats::Session)`; mirrored in `moq-native`.
- Added `origin::{Consumer, Producer}::with_stats` and `Traffic::fetches`.
- The `Meter`/`Scope`/`Subscription`/`Announce` carriers are `pub(crate)`, not surface.

## Testing

- New stats carrier unit tests (meter side isolation, egress subscribe → subscriptions + viewer, distinct contexts = distinct viewers, ingress has no viewer, fetch vs subscriptions, announce-guard bytes on open/close, presence closes on last clone) plus the ported `Registry` snapshot/report/prune/exclude/disabled tests migrated to the tagged-origin path.
- A model-level end-to-end test (`origin::tests::test_stats_tagged_end_to_end`) tags both origin halves with one context, publishes a broadcast/track/group/frames, reads on egress, and asserts **exact** values for every counter on both roles, then a fetch — the model-layer silent-zero guard.
- `moq-stats` producer/consumer tests and the relay `/metrics` test rewritten to feed the registry through tagged origin handles (the real path).
- `just check` (incl. `cargo doc -D warnings`) is green.

## Cross-package sync

- `moq-native` `with_stats` forwarders updated to `stats::Session`.
- `moq-relay` connection/websocket/cluster build the context (`stats.tier(tier).session(root)`) instead of holding a separate presence guard; internal listener and cluster dials unchanged in behavior.
- `doc/bin/relay/config.md` documents the new `fetches` counter and the semantic notes.
- **No draft changes**: the MoQ wire protocol is untouched; the stats JSON gains one additive field. `js/net` skipped — the JS model carries no stats registry.

## Follow-ups (separate PRs, per the plan)

- **PR B (moq.pro)**: tag the in-process VOD/HLS recorder and sweep edge for other in-process origin consumers.
- **Phase C (moq.pro)**: fold the gateways into the edge binary, one tagged context per external gateway connection.
- A wire-level lite+ietf silent-zero test would need an in-memory duplex transport (none exists yet); the model end-to-end test covers the counting path today, and the interop smoke matrix covers the wire.

(Written by Opus 4.8)