### PR TITLE
fix(mux): emit timelines from the fMP4 CMAF passthrough importer

### DIFF
--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -72,6 +72,11 @@ struct Fmp4Track {
 	track: moq_net::track::Producer,
 	group: Option<moq_net::group::Producer>,
 
+	// Indexes this track's group opens into its `<name>.timeline.z` timeline, advertised in the
+	// rendition's config. Passthrough writes groups by hand (no `container::Producer`), so the
+	// recorder is fed directly at each keyframe rather than through `with_recorder`.
+	recorder: crate::timeline::Recorder,
+
 	// The minimum buffer required for the track.
 	jitter: Option<Timestamp>,
 
@@ -229,16 +234,22 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 				moq_net::track::Info::default().with_timescale(timescale),
 			)?;
 
+			// Each track indexes its own group opens: audio and video group boundaries differ, so a
+			// per-track timeline (the 1:1 default) is correct here, not a shared one.
+			let timeline = self.catalog.timeline(track.name());
+
 			let detect_bitrate = match kind {
 				TrackKind::Video => {
-					let config = self.init_video(trak, &moov)?;
+					let mut config = self.init_video(trak, &moov)?;
 					let detect = config.bitrate.is_none();
+					config.timeline = Some(timeline.section());
 					catalog.video.renditions.insert(track.name().to_string(), config);
 					detect
 				}
 				TrackKind::Audio => {
-					let config = self.init_audio(trak, &moov)?;
+					let mut config = self.init_audio(trak, &moov)?;
 					let detect = config.bitrate.is_none();
+					config.timeline = Some(timeline.section());
 					catalog.audio.renditions.insert(track.name().to_string(), config);
 					detect
 				}
@@ -250,6 +261,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 					kind,
 					track,
 					group: None,
+					recorder: timeline.recorder(),
 					jitter: None,
 					last_timestamp: None,
 					min_duration: None,
@@ -750,6 +762,12 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			// in the track's native timescale. The relay reads it off the wire; the
 			// consumer still drives playback from the fragment's internal timing.
 			let timestamp = min_timestamp.ok_or(Error::MissingTrun)?;
+
+			// A keyframe fragment just opened a new group; index it in the track's timeline (throttled
+			// to the recorder's granularity) so a playlist/seek/VOD reader can map time to group.
+			if contains_keyframe {
+				track.recorder.record(g.sequence(), timestamp)?;
+			}
 
 			// A keyframe fragment starts a new group: close the previous one for the bitrate
 			// detector (used only when the descriptor didn't declare a bitrate).

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -75,7 +75,9 @@ struct Fmp4Track {
 	// Indexes this track's group opens into its `<name>.timeline.z` timeline, advertised in the
 	// rendition's config. Passthrough writes groups by hand (no `container::Producer`), so the
 	// recorder is fed directly at each keyframe rather than through `with_recorder`.
-	recorder: crate::timeline::Recorder,
+	// `None` once recording has failed, matching `container::Producer`: the timeline is an
+	// optional sidecar, so losing it must not take the media down with it.
+	recorder: Option<crate::timeline::Recorder>,
 
 	// The minimum buffer required for the track.
 	jitter: Option<Timestamp>,
@@ -261,7 +263,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 					kind,
 					track,
 					group: None,
-					recorder: timeline.recorder(),
+					recorder: Some(timeline.recorder()),
 					jitter: None,
 					last_timestamp: None,
 					min_duration: None,
@@ -765,8 +767,17 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 			// A keyframe fragment just opened a new group; index it in the track's timeline (throttled
 			// to the recorder's granularity) so a playlist/seek/VOD reader can map time to group.
+			// The timeline is an optional sidecar (consumers extrapolate across gaps), so a recording
+			// failure must NOT abort the passthrough. Drop the recorder and carry on.
 			if contains_keyframe {
-				track.recorder.record(g.sequence(), timestamp)?;
+				let timeline_err = match track.recorder.as_mut() {
+					Some(recorder) => recorder.record(g.sequence, timestamp).err(),
+					None => None,
+				};
+				if let Some(err) = timeline_err {
+					tracing::warn!(?err, "timeline recording failed; dropping the timeline for this track");
+					track.recorder = None;
+				}
 			}
 
 			// A keyframe fragment starts a new group: close the previous one for the bitrate

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -328,6 +328,63 @@ async fn test_msf_catalog_roundtrip() {
 	assert!(matches!(audio.container, Container::Cmaf { .. }));
 }
 
+/// Passthrough writes groups by hand (no `container::Producer`), so the timeline recorder is fed
+/// directly. This guards that every rendition advertises a `<name>.timeline.z` section and that its
+/// group opens are actually recorded, the index the VOD/playlist export reads. Regression for the
+/// missing-timeline break that skipped VOD renditions.
+#[tokio::test]
+async fn import_populates_per_rendition_timeline() {
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.reserve());
+
+	let data = include_bytes!("test_data/bbb.mp4");
+	let buf = bytes::BytesMut::from(&data[..]);
+	// Trailing partial fragments may error; ignore.
+	let _ = fmp4.decode(&buf);
+	fmp4.finish().unwrap();
+
+	let snapshot = catalog.snapshot();
+
+	// Every rendition (one video + one audio) advertises a timeline named after its media track.
+	let mut sections = Vec::new();
+	for (name, config) in &snapshot.video.renditions {
+		let section = config
+			.timeline
+			.clone()
+			.unwrap_or_else(|| panic!("video {name} advertises no timeline"));
+		assert_eq!(section.track, format!("{name}.timeline.z"));
+		sections.push(section);
+	}
+	for (name, config) in &snapshot.audio.renditions {
+		let section = config
+			.timeline
+			.clone()
+			.unwrap_or_else(|| panic!("audio {name} advertises no timeline"));
+		assert_eq!(section.track, format!("{name}.timeline.z"));
+		sections.push(section);
+	}
+	assert_eq!(sections.len(), 2, "bbb has one video and one audio rendition");
+
+	// Subscribe while the producer is alive, then finish so each timeline group closes and the reader
+	// terminates rather than blocking; the first recorded group (sequence 0) must be present.
+	let mut timelines: Vec<crate::timeline::Consumer> = Vec::new();
+	for section in sections {
+		timelines.push(crate::timeline::Consumer::subscribe(&consumer, &section).await.unwrap());
+	}
+	catalog.finish().unwrap();
+
+	for mut timeline in timelines {
+		let first = timeline
+			.next()
+			.await
+			.unwrap()
+			.expect("a group open should be recorded in the timeline");
+		assert_eq!(first.group, 0, "the first recorded group is sequence 0");
+	}
+}
+
 // ---- Sample-duration handling in decode() ----
 
 fn scale() -> moq_net::Timescale {

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -254,6 +254,12 @@ impl Producer {
 		self.info
 	}
 
+	/// This group's sequence number, as assigned at creation (explicitly, or by
+	/// [`track::Producer::append_group`](super::track::Producer::append_group) auto-incrementing).
+	pub fn sequence(&self) -> u64 {
+		self.info.sequence
+	}
+
 	/// The parent track's timescale.
 	pub fn timescale(&self) -> Timescale {
 		self.track.timescale

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -254,12 +254,6 @@ impl Producer {
 		self.info
 	}
 
-	/// This group's sequence number, as assigned at creation (explicitly, or by
-	/// [`track::Producer::append_group`](super::track::Producer::append_group) auto-incrementing).
-	pub fn sequence(&self) -> u64 {
-		self.info.sequence
-	}
-
 	/// The parent track's timescale.
 	pub fn timescale(&self) -> Timescale {
 		self.track.timescale


### PR DESCRIPTION
## Summary

- `moq import fmp4` published renditions with no `timeline` section and no `<name>.timeline.z` track, so the fetch-on-demand VOD/HLS export skipped every rendition. This is why the VOD smoke found no renditions.
- **Root cause**: moq-mux has two publish paths. The codec importers (`codec::*::Import`, used by raw/Annex-B/TS/FLV/MKV) set `config.timeline` and build their media producer via `catalog::Producer::media_producer`, which wires a `timeline::Recorder` into `container::Producer`. The fMP4 importer is **CMAF passthrough**: it ships whole `moof`+`mdat` fragments byte-for-byte, so it deliberately avoids `container::Producer`, creating its track by hand, inserting configs straight into the catalog, and opening groups directly. The timeline recorder lives on the one type passthrough skips, so a timeline was never advertised *or* filled. Not a deliberate omission, a coupling gap.
- **Fix**: wire the recorder directly, keeping passthrough intact. `init` advertises `catalog.timeline(name).section()` on each rendition config and stores its recorder in `Fmp4Track`; `extract` records each keyframe group open. Records append immediately (not buffered until finish), so the existing catalog lifecycle is enough for a subscriber/FETCH to read them.

### Why per-track timelines, not shared

Timelines stay 1:1 with the media track, matching the codec importers. A shared timeline is only valid for an *aligned* rendition set whose group boundaries coincide (per `timeline.rs`): audio and video group durations differ, and passthrough detects keyframes per track independently, so their sequences aren't coupled. Sharing remains reserved for `moq-transcode` ladders.

### Timeline recording is non-fatal

`container::Producer::write` documents that the timeline is an optional sidecar and "a recording failure must NOT abort the media write", holding its recorder in an `Option` so it can be dropped after one failure. The passthrough path mirrors that: warn, drop the recorder, carry on. Propagating instead would abandon the just-opened group before its frame was written, drop it without `finish()`, and abort the entire import — taking every other track in the broadcast down over a sidecar write. A `.timeline.z` track is small, long-lived and usually unwatched, so an `Evicted` from the cache pool is a realistic trigger.

## Public API changes

None. `group::Producer` already derefs to `Info`, whose `sequence` field is `pub`, so `g.sequence` was reachable all along (`container::Producer` already reads it that way). An earlier revision of this PR added a redundant `sequence()` accessor to `moq-net`; it has been dropped.

`moq-mux` has no signature changes either. Behavior change only: fMP4 renditions now carry `config.timeline` and get a `<name>.timeline.z` track.

## Test plan

- New regression test `import_populates_per_rendition_timeline`: imports `bbb.mp4`, asserts both renditions advertise a `<name>.timeline.z` section and that each timeline records its first group. Fails without the fix (no `config.timeline`).
- `cargo test -p moq-mux -p moq-net --lib` — 517 passed, 0 failed.
- `cargo clippy -p moq-mux -p moq-net --all-targets` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p moq-net -p moq-mux --no-deps` — clean.
- `cargo check -p moq-cli -p moq-hls` — clean.

## Cross-Package Sync

- No wire-format change (the hang timeline record/catalog schema is unchanged; fMP4 import simply populates what the format already defines), so no `drafts/` update.
- No `js/net` row applies: with the accessor dropped, `moq-net`'s public surface is untouched.

Targets `main` per Branch Targeting: no published contract breaks.

(Written by Opus 4.8)