### PR TITLE
feat(stats): count datagrams in the model layer

### DIFF
--- a/demo/web/src/stats.html
+++ b/demo/web/src/stats.html
@@ -24,8 +24,9 @@
 		</div>
 	</header>
 
-	<!-- Cluster summary: six headline numbers, no prose. -->
-	<section id="overview" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
+	<!-- Cluster summary: headline numbers, no prose. Rates are per-second; the rest
+	     are live gauges, except fetches/datagrams/announce which are cumulative. -->
+	<section id="overview" class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mb-6">
 		<div class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-3">
 			<div class="text-[11px] uppercase tracking-wide text-neutral-500">Nodes</div>
 			<div id="kpi-nodes" class="text-2xl font-semibold tabular-nums mt-0.5">0</div>
@@ -39,6 +40,14 @@
 			<div id="kpi-viewers" class="text-2xl font-semibold tabular-nums mt-0.5 text-emerald-300">0</div>
 		</div>
 		<div class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-3">
+			<div class="text-[11px] uppercase tracking-wide text-neutral-500">Tracks</div>
+			<div id="kpi-tracks" class="text-2xl font-semibold tabular-nums mt-0.5 text-emerald-300">0</div>
+		</div>
+		<div class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-3">
+			<div class="text-[11px] uppercase tracking-wide text-neutral-500">Sessions</div>
+			<div id="kpi-sessions" class="text-2xl font-semibold tabular-nums mt-0.5">0</div>
+		</div>
+		<div class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-3">
 			<div class="text-[11px] uppercase tracking-wide text-neutral-500">Egress</div>
 			<div id="kpi-egress" class="text-2xl font-semibold tabular-nums mt-0.5 text-emerald-400">0</div>
 		</div>
@@ -47,8 +56,16 @@
 			<div id="kpi-ingress" class="text-2xl font-semibold tabular-nums mt-0.5 text-sky-400">0</div>
 		</div>
 		<div class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-3">
-			<div class="text-[11px] uppercase tracking-wide text-neutral-500">Sessions</div>
-			<div id="kpi-sessions" class="text-2xl font-semibold tabular-nums mt-0.5">0</div>
+			<div class="text-[11px] uppercase tracking-wide text-neutral-500" title="One-shot group fetches requested">Fetches</div>
+			<div id="kpi-fetches" class="text-2xl font-semibold tabular-nums mt-0.5">0</div>
+		</div>
+		<div class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-3">
+			<div class="text-[11px] uppercase tracking-wide text-neutral-500" title="Single-frame groups carried over unreliable QUIC datagrams">Datagrams</div>
+			<div id="kpi-datagrams" class="text-2xl font-semibold tabular-nums mt-0.5">0</div>
+		</div>
+		<div class="rounded-lg border border-neutral-800 bg-neutral-900/50 p-3">
+			<div class="text-[11px] uppercase tracking-wide text-neutral-500" title="Broadcast-name bytes charged for announces and unannounces">Announce</div>
+			<div id="kpi-announce" class="text-2xl font-semibold tabular-nums mt-0.5">0</div>
 		</div>
 	</section>
 
@@ -97,6 +114,10 @@
 			<div>
 				<h3 class="text-xs font-semibold text-emerald-300 mb-1">Viewers <span class="text-neutral-500 font-normal">· served downstream</span></h3>
 				<div id="node-subscribers" class="overflow-x-auto text-neutral-500 text-sm">no viewers</div>
+			</div>
+			<div>
+				<h3 class="text-xs font-semibold text-neutral-300 mb-1">Sessions <span class="text-neutral-500 font-normal">· by auth root</span></h3>
+				<div id="node-session-roots" class="overflow-x-auto text-neutral-500 text-sm">no sessions</div>
 			</div>
 		</div>
 	</section>

--- a/demo/web/src/stats.ts
+++ b/demo/web/src/stats.ts
@@ -449,7 +449,9 @@ ui.run((effect) => {
 			.filter((p) => !isSystem(p))
 			.sort();
 
-	// Broadcasters: what this node ingests from upstream publishers.
+	// Broadcasters: what this node ingests from upstream publishers. No `fetches`
+	// column: only a consumer can fetch, so the counter is egress-only. The KPI
+	// total still sums both sides in case that ever changes.
 	const ingressRows = (frame: BroadcastFrame) =>
 		paths(frame).map((path) => {
 			const i = frame[path] ?? {};

--- a/demo/web/src/stats.ts
+++ b/demo/web/src/stats.ts
@@ -41,13 +41,20 @@ const $ = <T extends HTMLElement>(id: string): T => {
 interface Snapshot {
 	announced?: number;
 	announced_closed?: number;
+	// Broadcast-name bytes charged for each announce/unannounce, separate from payload `bytes`.
+	announced_bytes?: number;
 	broadcasts?: number;
 	broadcasts_closed?: number;
 	subscriptions?: number;
 	subscriptions_closed?: number;
+	// One-shot group fetches requested (counted at request time, not on resolution).
+	fetches?: number;
 	bytes?: number;
 	frames?: number;
 	groups?: number;
+	// Single-frame groups carried over unreliable QUIC datagrams: a subset of `groups`,
+	// with their payload already in `frames` / `bytes`.
+	datagrams?: number;
 }
 type BroadcastFrame = Record<string, Snapshot>;
 
@@ -161,20 +168,33 @@ function subscribeNode(effect: Signals.Effect, conn: Net.Connection.Established,
 function aggregate(ingress: BroadcastFrame, egress: BroadcastFrame) {
 	let broadcasters = 0; // active broadcasts being published (ingress)
 	let viewers = 0; // active downstream consumers (egress)
+	let tracks = 0; // active egress track subscriptions
 	let ingressBytes = 0;
 	let egressBytes = 0;
+	// Cumulative, so the sampler can turn them into rates. Announce overhead is
+	// counted on both sides; the payload counters are per-direction.
+	let announceBytes = 0;
+	let fetches = 0;
+	let datagrams = 0;
 
 	for (const [path, s] of Object.entries(ingress)) {
 		if (isSystem(path)) continue;
 		if (active(s.announced, s.announced_closed) > 0) broadcasters++;
 		ingressBytes += s.bytes ?? 0;
+		announceBytes += s.announced_bytes ?? 0;
+		fetches += s.fetches ?? 0;
+		datagrams += s.datagrams ?? 0;
 	}
 	for (const [path, s] of Object.entries(egress)) {
 		if (isSystem(path)) continue;
 		egressBytes += s.bytes ?? 0;
 		viewers += active(s.broadcasts, s.broadcasts_closed);
+		tracks += active(s.subscriptions, s.subscriptions_closed);
+		announceBytes += s.announced_bytes ?? 0;
+		fetches += s.fetches ?? 0;
+		datagrams += s.datagrams ?? 0;
 	}
-	return { broadcasters, viewers, ingressBytes, egressBytes };
+	return { broadcasters, viewers, tracks, ingressBytes, egressBytes, announceBytes, fetches, datagrams };
 }
 
 const countSessions = (f: SessionFrame) =>
@@ -189,8 +209,12 @@ interface Sample {
 	t: number;
 	egress: number; // cumulative egress bytes
 	ingress: number; // cumulative ingress bytes
+	announce: number; // cumulative announce-control bytes (both directions)
+	fetches: number; // cumulative group fetches requested
+	datagrams: number; // cumulative single-frame groups sent as QUIC datagrams
 	broadcasters: number;
 	viewers: number;
+	tracks: number;
 	sessions: number;
 }
 
@@ -205,8 +229,12 @@ function sampleNode(t: number, stats: NodeStats): Sample {
 		t,
 		egress: totals.egressBytes,
 		ingress: totals.ingressBytes,
+		announce: totals.announceBytes,
+		fetches: totals.fetches,
+		datagrams: totals.datagrams,
 		broadcasters: totals.broadcasters,
 		viewers: totals.viewers,
+		tracks: totals.tracks,
 		sessions: countSessions(stats.sessions),
 	};
 }
@@ -243,8 +271,12 @@ sampler.run((effect) => {
 			t,
 			egress: 0,
 			ingress: 0,
+			announce: 0,
+			fetches: 0,
+			datagrams: 0,
 			broadcasters: 0,
 			viewers: 0,
+			tracks: 0,
 			sessions: 0,
 		};
 		for (const node of nodes) {
@@ -252,8 +284,12 @@ sampler.run((effect) => {
 			pushSample(node, s);
 			agg.egress += s.egress;
 			agg.ingress += s.ingress;
+			agg.announce += s.announce;
+			agg.fetches += s.fetches;
+			agg.datagrams += s.datagrams;
 			agg.broadcasters += s.broadcasters;
 			agg.viewers += s.viewers;
+			agg.tracks += s.tracks;
 			agg.sessions += s.sessions;
 		}
 		// A changed node set makes this aggregate's baseline incompatible with the
@@ -342,9 +378,15 @@ ui.run((effect) => {
 	$("kpi-nodes").textContent = String(nodes.length);
 	$("kpi-broadcasters").textContent = String(latest?.broadcasters ?? 0);
 	$("kpi-viewers").textContent = String(latest?.viewers ?? 0);
+	$("kpi-tracks").textContent = String(latest?.tracks ?? 0);
 	$("kpi-sessions").textContent = String(latest?.sessions ?? 0);
 	$("kpi-egress").textContent = formatRate(lastRate(cluster, "egress"));
 	$("kpi-ingress").textContent = formatRate(lastRate(cluster, "ingress"));
+	// Cumulative totals rather than rates: both are rare enough that a per-second
+	// number spends most of its life at zero.
+	$("kpi-fetches").textContent = String(latest?.fetches ?? 0);
+	$("kpi-datagrams").textContent = String(latest?.datagrams ?? 0);
+	$("kpi-announce").textContent = formatBytes(latest?.announce ?? 0);
 });
 
 // Cluster throughput chart.
@@ -402,36 +444,72 @@ ui.run((effect) => {
 		{ values: rateSeries(samples, "ingress"), color: "#38bdf8" },
 	]);
 
-	// Broadcasters: what this node ingests from upstream publishers.
-	const ingressRows = (frame: BroadcastFrame) =>
+	const paths = (frame: BroadcastFrame) =>
 		Object.keys(frame)
 			.filter((p) => !isSystem(p))
-			.sort()
-			.map((path) => {
-				const i = frame[path] ?? {};
-				return { key: path, cells: [path, formatBytes(i.bytes ?? 0), String(i.frames ?? 0)] };
-			});
+			.sort();
+
+	// Broadcasters: what this node ingests from upstream publishers.
+	const ingressRows = (frame: BroadcastFrame) =>
+		paths(frame).map((path) => {
+			const i = frame[path] ?? {};
+			return {
+				key: path,
+				cells: [
+					path,
+					active(i.announced, i.announced_closed) > 0 ? "yes" : "no",
+					String(active(i.subscriptions, i.subscriptions_closed)), // live tracks
+					formatBytes(i.bytes ?? 0),
+					String(i.frames ?? 0),
+					String(i.groups ?? 0),
+					String(i.datagrams ?? 0),
+					formatBytes(i.announced_bytes ?? 0),
+				],
+			};
+		});
 
 	// Viewers: what this node serves to downstream subscribers.
 	const egressRows = (frame: BroadcastFrame) =>
-		Object.keys(frame)
-			.filter((p) => !isSystem(p))
-			.sort()
-			.map((path) => {
-				const e = frame[path] ?? {};
-				return {
-					key: path,
-					cells: [
-						path,
-						String(active(e.broadcasts, e.broadcasts_closed)), // viewers / peers
-						formatBytes(e.bytes ?? 0), // egress
-						String(e.frames ?? 0),
-					],
-				};
-			});
+		paths(frame).map((path) => {
+			const e = frame[path] ?? {};
+			return {
+				key: path,
+				cells: [
+					path,
+					String(active(e.broadcasts, e.broadcasts_closed)), // viewers / peers
+					String(active(e.subscriptions, e.subscriptions_closed)), // live tracks
+					formatBytes(e.bytes ?? 0), // egress
+					String(e.frames ?? 0),
+					String(e.groups ?? 0),
+					String(e.datagrams ?? 0),
+					String(e.fetches ?? 0),
+					formatBytes(e.announced_bytes ?? 0),
+				],
+			};
+		});
 
-	renderTable($("node-publishers"), ["broadcast", "ingress", "frames"], ingressRows(stats.ingress));
-	renderTable($("node-subscribers"), ["broadcast", "viewers", "egress", "frames"], egressRows(stats.egress));
+	// Sessions connected under each auth root, counted regardless of data flow.
+	const sessionRows = Object.keys(stats.sessions)
+		.sort()
+		.map((root) => {
+			const s = stats.sessions[root] ?? {};
+			return {
+				key: root,
+				cells: [root || "(none)", String(active(s.sessions, s.sessions_closed)), String(s.sessions ?? 0)],
+			};
+		});
+
+	renderTable(
+		$("node-publishers"),
+		["broadcast", "announced", "tracks", "ingress", "frames", "groups", "datagrams", "announce"],
+		ingressRows(stats.ingress),
+	);
+	renderTable(
+		$("node-subscribers"),
+		["broadcast", "viewers", "tracks", "egress", "frames", "groups", "datagrams", "fetches", "announce"],
+		egressRows(stats.egress),
+	);
+	renderTable($("node-session-roots"), ["auth root", "connected", "total"], sessionRows);
 
 	const sessions = countSessions(stats.sessions);
 	$("node-sessions").textContent = `${sessions} session${sessions === 1 ? "" : "s"}`;

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -264,14 +264,14 @@ counterpart no traffic can flow, so the entry is dropped:
     "broadcasts": 1, "broadcasts_closed": 0,
     "subscriptions": 5, "subscriptions_closed": 2,
     "fetches": 3,
-    "bytes": 12345, "frames": 678, "groups": 9
+    "bytes": 12345, "frames": 678, "groups": 9, "datagrams": 2
   },
   "anon/foo": {
     "announced": 1, "announced_closed": 0, "announced_bytes": 8,
     "broadcasts": 1, "broadcasts_closed": 0,
     "subscriptions": 2, "subscriptions_closed": 0,
     "fetches": 0,
-    "bytes": 234, "frames": 12, "groups": 1
+    "bytes": 234, "frames": 12, "groups": 1, "datagrams": 0
   }
 }
 ```
@@ -297,10 +297,11 @@ Field semantics:
   typically what billing and UI want.
 - `subscriptions` / `subscriptions_closed`: cumulative count of
   track-level subscriptions opened and dropped.
-- `fetches`: cumulative one-shot group fetches served to a calling session,
-  counted once per coalesced fetch (requests served, not upstream work). It is
-  separate from `subscriptions` and the viewer sentinel; the fetched payload
-  still flows into `bytes` / `frames` / `groups`.
+- `fetches`: cumulative one-shot group fetches requested by a calling session,
+  counted once per coalesced fetch when the request is issued, so a fetch that
+  resolves to "not found" still counts. It is separate from `subscriptions` and
+  the viewer sentinel; the fetched payload still flows into `bytes` / `frames` /
+  `groups`.
 - `bytes` / `frames` / `groups`: cumulative payload counters, bumped as
   groups/frames are read out of the model on the egress side and written into
   it on the ingress side. Egress bytes are counted when read out of the model
@@ -308,6 +309,11 @@ Field semantics:
   still count. For a fan-out egress reader (e.g. an HLS/DASH muxer) this is
   bytes read once per segment at the broadcast origin, not per downstream HTTP
   client.
+- `datagrams`: cumulative single-frame groups delivered over an unreliable QUIC
+  datagram (moq-lite-05+ on a datagram-capable transport). A subset of `groups`:
+  each datagram also counts there, and its payload in `frames` / `bytes`. Counted
+  when the datagram enters or leaves the model, so an egress datagram dropped by
+  congestion or an oversized body still counts.
 
 The session tracks (`sessions.json` and any `<tier>/sessions.json`) instead map
 each auth root to a `{ sessions, sessions_closed }` snapshot. `sessions`

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -2663,6 +2663,55 @@ mod tests {
 		);
 	}
 
+	/// Datagrams bypass the group/frame handles entirely, so they're metered at the
+	/// producer (ingress write) and the subscriber (egress read). Each one counts as
+	/// the single-frame group it stands in for, plus the `datagrams` breakout.
+	#[tokio::test]
+	async fn test_stats_datagrams_counted_both_sides() {
+		use crate::Timestamp;
+		use crate::stats::{Config, Registry, Tier};
+
+		tokio::time::pause();
+
+		let registry = Registry::new(Config::new());
+		let ctx = registry.tier(Tier::default()).session("acme");
+
+		let origin = Origin::random().produce();
+		let ingress = origin.clone().with_stats(ctx.clone());
+		let egress = origin.consume().with_stats(ctx.clone());
+
+		let mut announced = egress.announced();
+		let source = ingress.create_broadcast("demo", announce()).unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+
+		let broadcast = announced.next().await.unwrap().broadcast.unwrap();
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		let mut producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+		let mut sub = subscribing.await.unwrap();
+
+		producer.append_datagram(Timestamp::ZERO, &b"hello"[..]).unwrap();
+		let datagram = sub.recv_datagram().await.unwrap().expect("datagram");
+		assert_eq!(&datagram.payload[..], b"hello");
+		settle().await;
+
+		let report = registry.report();
+		let entry = report
+			.traffic
+			.iter()
+			.find(|e| e.path.as_str() == "demo")
+			.expect("demo tracked");
+
+		for (side, traffic) in [("egress", &entry.publisher), ("ingress", &entry.subscriber)] {
+			assert_eq!(traffic.datagrams, 1, "{side}: one datagram");
+			assert_eq!(traffic.groups, 1, "{side}: counted as its single-frame group");
+			assert_eq!(traffic.frames, 1, "{side}: one frame");
+			assert_eq!(traffic.bytes, 5, "{side}: payload counted once");
+		}
+	}
+
 	#[test]
 	fn origin_rejects_reserved_ids() {
 		assert!(Origin::new(0).is_err());

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -2607,6 +2607,10 @@ mod tests {
 		assert_eq!(entry.publisher.fetches, 1, "one fetch");
 		assert_eq!(entry.publisher.subscriptions, 1, "fetch does not bump subscriptions");
 		assert_eq!(entry.publisher.broadcasts, 1, "fetch does not bump the viewer refcount");
+		// `fetches` is egress-only for the same structural reason as `broadcasts`:
+		// only a `track::Consumer` can fetch, and the ingress scope never reaches one
+		// (`broadcast::Producer::consume` hands out an untagged consumer).
+		assert_eq!(entry.subscriber.fetches, 0, "ingress cannot fetch");
 	}
 
 	/// `Subscriber::read_frame` collapses a group to its first frame. The paths it

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -736,6 +736,8 @@ impl Producer {
 		if payload.len() > super::datagram::MAX_DATAGRAM_PAYLOAD {
 			return Err(Error::FrameTooLarge);
 		}
+		// Resolved before the state guard borrows `self`.
+		let meter = self.stats.meter();
 		let mut state = self.modify()?;
 		// Normalize into the track's timescale, like frames (see `group::Producer::create_frame`).
 		let timescale = state.info.as_ref().unwrap().timescale;
@@ -750,6 +752,7 @@ impl Producer {
 			return Err(Error::Closed);
 		}
 		state.max_sequence = Some(sequence);
+		meter.datagram(payload.len() as u64);
 		state.push_datagram(Datagram {
 			sequence,
 			timestamp,
@@ -767,6 +770,8 @@ impl Producer {
 		if datagram.payload.len() > super::datagram::MAX_DATAGRAM_PAYLOAD {
 			return Err(Error::FrameTooLarge);
 		}
+		// Resolved before the state guard borrows `self`.
+		let meter = self.stats.meter();
 		let mut state = self.modify()?;
 		// Normalize into the track's timescale, like frames (see `group::Producer::create_frame`).
 		let timescale = state.info.as_ref().unwrap().timescale;
@@ -780,6 +785,7 @@ impl Producer {
 			return Err(Error::Closed);
 		}
 		state.max_sequence = Some(state.max_sequence.unwrap_or(0).max(datagram.sequence));
+		meter.datagram(datagram.payload.len() as u64);
 		state.push_datagram(datagram);
 		Ok(())
 	}
@@ -2034,10 +2040,17 @@ impl Subscriber {
 	/// `Poll::Ready(Ok(None))` when the track is finished, `Poll::Ready(Err(e))` when the track
 	/// is aborted, or `Poll::Pending` when none is buffered yet.
 	pub fn poll_recv_datagram(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Datagram>>> {
-		match &mut self.inner {
+		let meter = self.stats.meter();
+		let res = match &mut self.inner {
 			SubscriberKind::Plain(plain) => plain.poll_recv_datagram(waiter),
 			SubscriberKind::Spliced(spliced) => spliced.poll_recv_datagram(waiter),
+		};
+		// Unlike a group (metered lazily as its frames are read), a datagram is
+		// delivered whole here, so count it as the single-frame group it stands in for.
+		if let Poll::Ready(Ok(Some(datagram))) = &res {
+			meter.datagram(datagram.payload.len() as u64);
 		}
+		res
 	}
 
 	/// Receive the next datagram in arrival order.

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -42,12 +42,17 @@
 //! * `subscriptions` / `subscriptions_closed`: cumulative track-level
 //!   subscriptions opened/dropped (egress `track::Subscriber`, ingress
 //!   `track::Producer`).
-//! * `fetches`: cumulative one-shot group fetches served to a calling
-//!   context, counted once per coalesced fetch. Separate from
-//!   `subscriptions` and the viewer refcount; fetched payload still flows
-//!   into `bytes` / `frames` / `groups`.
+//! * `fetches`: cumulative one-shot group fetches *requested* by a calling
+//!   context, counted once per coalesced fetch at request time. A fetch that
+//!   resolves to `NotFound` still counts. Separate from `subscriptions` and the
+//!   viewer refcount; fetched payload still flows into `bytes` / `frames` /
+//!   `groups`.
 //! * `bytes` / `frames` / `groups`: cumulative payload counters bumped as
 //!   groups/frames are read (egress) or written (ingress) in the model.
+//! * `datagrams`: cumulative single-frame groups carried over unreliable QUIC
+//!   datagrams. A datagram is metered as the group it stands in for, so it also
+//!   bumps `groups`, `frames`, and `bytes`; this counter breaks out how many of
+//!   those took the datagram path.
 //! * `sessions` / `sessions_closed` ([`Presence`]): cumulative count of
 //!   sessions connected/disconnected under an auth root on this tier.
 //!   Driven by [`Handle::session`] (the [`Session`] context).
@@ -135,15 +140,17 @@ pub(crate) struct Counters {
 	announced_bytes: AtomicU64,
 	subscriptions: AtomicU64,
 	subscriptions_closed: AtomicU64,
-	// Cumulative one-shot group fetches served to a calling context. Counted once
-	// per coalesced fetch (requests served, not upstream work); does not touch
-	// `subscriptions` or the viewer refcount.
+	// Cumulative one-shot group fetches requested by a calling context. Counted
+	// once per coalesced fetch, at request time rather than on resolution; does
+	// not touch `subscriptions` or the viewer refcount.
 	fetches: AtomicU64,
 	broadcasts: AtomicU64,
 	broadcasts_closed: AtomicU64,
 	bytes: AtomicU64,
 	frames: AtomicU64,
 	groups: AtomicU64,
+	// Subset of `groups` carried over an unreliable QUIC datagram.
+	datagrams: AtomicU64,
 }
 
 impl Counters {
@@ -166,6 +173,7 @@ impl Counters {
 		let bytes = self.bytes.load(Ordering::Relaxed);
 		let frames = self.frames.load(Ordering::Relaxed);
 		let groups = self.groups.load(Ordering::Relaxed);
+		let datagrams = self.datagrams.load(Ordering::Relaxed);
 		Traffic {
 			announced,
 			announced_closed,
@@ -178,6 +186,7 @@ impl Counters {
 			bytes,
 			frames,
 			groups,
+			datagrams,
 		}
 	}
 }
@@ -233,8 +242,9 @@ pub struct Traffic {
 	pub subscriptions: u64,
 	/// Cumulative track-level subscriptions closed.
 	pub subscriptions_closed: u64,
-	/// Cumulative one-shot group fetches served. Counted once per coalesced fetch,
-	/// separate from `subscriptions` and the viewer refcount. Fetched payload still
+	/// Cumulative one-shot group fetches requested. Counted once per coalesced fetch
+	/// when the fetch is issued, so one that resolves to `NotFound` still counts.
+	/// Separate from `subscriptions` and the viewer refcount. Fetched payload still
 	/// flows into `bytes`/`frames`/`groups`.
 	pub fetches: u64,
 	/// Cumulative payload bytes.
@@ -243,6 +253,10 @@ pub struct Traffic {
 	pub frames: u64,
 	/// Cumulative groups delivered.
 	pub groups: u64,
+	/// Cumulative single-frame groups delivered over an unreliable QUIC datagram.
+	/// A subset of `groups`: each one also counts there and its payload in
+	/// `frames` / `bytes`.
+	pub datagrams: u64,
 }
 
 impl Traffic {
@@ -259,6 +273,7 @@ impl Traffic {
 		self.bytes += other.bytes;
 		self.frames += other.frames;
 		self.groups += other.groups;
+		self.datagrams += other.datagrams;
 	}
 
 	/// True while the broadcast is announced (an announce guard is open).
@@ -967,6 +982,18 @@ impl Meter {
 		}
 		if let Some(counters) = self.counters() {
 			counters.frames.fetch_add(n, Ordering::Relaxed);
+		}
+	}
+
+	/// Record one datagram of `n` payload bytes. A datagram stands in for the
+	/// single-frame group it replaces, so this bumps `groups`, `frames`, and
+	/// `bytes` alongside `datagrams`.
+	pub(crate) fn datagram(&self, n: u64) {
+		if let Some(counters) = self.counters() {
+			counters.datagrams.fetch_add(1, Ordering::Relaxed);
+			counters.groups.fetch_add(1, Ordering::Relaxed);
+			counters.frames.fetch_add(1, Ordering::Relaxed);
+			counters.bytes.fetch_add(n, Ordering::Relaxed);
 		}
 	}
 

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -158,6 +158,18 @@ fn render_metrics(snap: &moq_net::stats::Snapshot) -> String {
 	});
 	counter(
 		&mut out,
+		"moq_relay_datagrams_total",
+		"Single-frame groups carried over unreliable QUIC datagrams; a subset of groups.",
+		|c| c.datagrams,
+	);
+	counter(
+		&mut out,
+		"moq_relay_fetches_total",
+		"One-shot group fetches requested.",
+		|c| c.fetches,
+	);
+	counter(
+		&mut out,
 		"moq_relay_subscriptions_opened_total",
 		"Track subscriptions opened.",
 		|c| c.subscriptions,


### PR DESCRIPTION
Follow-up to #2427.

## Summary

- **Datagrams were uncounted.** #2427 moved traffic counting into the model layer, but the datagram path had no model-layer equivalent: the old wire loop bumped `groups` on a successful `send_datagram` and nothing replaced it. Datagram payload never reached `bytes`/`frames` on either side, before or after that PR.
- Metered where the model sees them: `track::Producer::{append,write}_datagram` (ingress writes) and `track::Subscriber::poll_recv_datagram` (egress reads). A datagram is metered as the single-frame group it stands in for, so it bumps `groups`/`frames`/`bytes` **plus** the new `datagrams` counter. That preserves the pre-#2427 egress `groups` behavior and fixes the missing bytes/frames, with `datagrams` as the breakout.
- Counted on model read/write rather than on a successful `send_datagram`, so an egress datagram later dropped for congestion or an oversized body still counts. Same convention as groups, which are metered as they are read into the send path. Documented on the field and in `config.md`.
- `fetches` doc wording: the counter bumps at request time in `fetch_group`, so a fetch resolving to `NotFound` still counts. Docs said "served"; now they say "requested" and state the `NotFound` case.
- `/metrics` was missing `fetches` (added by #2427) as well as the new `datagrams`, leaving counters that existed on the published stats tracks but not on the scrape surface. Both added.
- Demo stats dashboard predates several counters. It now covers everything the relay publishes.

## Deliberate semantic changes carried over from #2427

Noting these for the record; they landed there, not here.

- **Egress `announced` now includes filtered announces.** `AnnounceConsumer::attribute` opens the guard before the wire loop drops reflected loops and `exclude_hop` matches, so it counts model-visible announces rather than only forwarded ones.
- **Cluster dials now record presence.** `.session("")` under the configured `--cluster-tier`, so cluster peers show up as rows in that tier's `sessions.json` where they previously had no presence guard. The empty string is the auth root (cluster peers carry none), not the tier.
- **Prefetch batch fill can overcount up to a few frames** if a consumer drops mid-batch, since bytes are counted at fill rather than pop. Negligible, and the right perf tradeoff.

## Public API changes

`rs/moq-net` (all additive, `main`-targetable):

- **Added** `stats::Traffic::datagrams: u64`. `Traffic` is `#[non_exhaustive]` with `#[serde(default)]`, so this is additive on both the Rust and wire surfaces: an older publisher's frame omits it and parses as zero.
- `stats::Traffic::add` folds the new field.
- Internal only: `stats::Meter::datagram(n)` is `pub(crate)`.

No changes to `js/*`.

## Cross-package sync

- `rs/moq-stats` wire (frame shapes) -> `doc/bin/relay/config.md`: done (sample frames + field semantics for `datagrams`, reworded `fetches`).
- `js/net` has no mirrored stats types; the only JS consumer of the stats frames is `demo/web`, updated here.
- No wire-format change, so no draft update under `drafts/`. The datagram body itself is untouched; this only adds a local counter.

## Demo dashboard

- KPI row: added Tracks (active subscriptions), Fetches, Datagrams, Announce bytes.
- Broadcasters table: broadcast, announced, tracks, ingress, frames, groups, datagrams, announce.
- Viewers table: broadcast, viewers, tracks, egress, frames, groups, datagrams, fetches, announce.
- New "Sessions by auth root" table (root, connected, total).

## Test plan

- `test_stats_tagged_end_to_end` now also asserts `subscriber.fetches == 0`, pinning `fetches` as egress-only (see the review note below).
- New `model::origin_impl::tests::test_stats_datagrams_counted_both_sides`: one datagram through a tagged origin pair asserts `datagrams`/`groups`/`frames`/`bytes` on both the publisher and subscriber sides.
- `just check` passes (exit 0), including the existing moq-net / moq-relay / moq-stats suites.
- `RUSTDOCFLAGS="-D warnings" cargo doc` clean for the touched crates.
- `tsc --noEmit` clean for `demo/web`; `bun biome check` clean.
- Rendered `stats.html` against a live local relay and confirmed the new KPI layout. **The tables were not exercised with live data**: the browser used fell back to WebSocket/qmux, where `@moq/qmux` 0.3.0 throws `TypeError: First argument to DataView constructor must be an ArrayBuffer` decoding the first record, so no nodes are discovered. That is a pre-existing transport bug unrelated to this change (it fires before any stats data flows, and nothing here touches wire code), tracked separately.

## Review notes

CodeRabbit flagged the demo's ingress table for omitting a `fetches` column, reading `fetches` as a generic per-role counter. Not applied: it is structurally egress-only. Only a `track::Consumer` can fetch, and the ingress scope never reaches one, because `broadcast::Producer::consume` deliberately hands out an untagged consumer (egress attribution is applied when a tagged `origin::Consumer` hands the consumer out). Same structural reason `broadcasts` is always zero on ingress. Adding the column would render a permanently-zero column; the invariant is now asserted in `test_stats_tagged_end_to_end` instead.

(written by Opus 4.8)
