### PR TITLE
feat(js/net): expose connection transport stats

### DIFF
--- a/js/net/src/connection/established.ts
+++ b/js/net/src/connection/established.ts
@@ -4,6 +4,7 @@ import type { Bandwidth } from "../bandwidth.ts";
 import type * as broadcast from "../broadcast.ts";
 import type * as Path from "../path.ts";
 import type * as Time from "../time.ts";
+import type { ConnectionStats } from "./stats.ts";
 import type { Transport } from "./transport.ts";
 
 /** An established MoQ session, implemented by both the moq-lite and moq-ietf protocols. */
@@ -23,7 +24,7 @@ export interface Established {
 	/** Estimated receive bitrate from PROBE (moq-lite-03+ only). */
 	readonly recvBandwidth?: Bandwidth;
 
-	/** RTT in milliseconds from PROBE (moq-lite-04+ only). */
+	/** Smoothed RTT in milliseconds, from the transport when it measures one, otherwise from PROBE (moq-lite-04+ only). */
 	readonly rtt?: Signal<Time.Milli | undefined>;
 
 	/**
@@ -41,6 +42,13 @@ export interface Established {
 
 	/** Consume the broadcast at the given path. */
 	consume(path: Path.Valid): broadcast.Consumer;
+
+	/**
+	 * Snapshot the connection's transport statistics, a cheap read of the counters
+	 * in {@link ConnectionStats}. Optional so existing implementations of this
+	 * interface stay source-compatible. Both built-in connections provide it.
+	 */
+	stats?(): Promise<ConnectionStats>;
 
 	/** Close the session. */
 	close(): void;

--- a/js/net/src/connection/index.ts
+++ b/js/net/src/connection/index.ts
@@ -8,4 +8,5 @@ export { isWebTransportSupported } from "./browser.ts";
 export * from "./connect.ts";
 export * from "./established.ts";
 export * from "./reload.ts";
+export type { ConnectionStats } from "./stats.ts";
 export type { Transport } from "./transport.ts";

--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -4,6 +4,7 @@ import type * as Path from "../path.ts";
 import { empty as emptyPath } from "../path.ts";
 import { type ConnectProps, connect, type WebSocketOptions, type WebTransportProps } from "./connect.ts";
 import type { Established } from "./established.ts";
+import type { ConnectionStats } from "./stats.ts";
 
 /** Exponential backoff settings for {@link Reload}'s reconnect loop. */
 export type ReloadDelay = {
@@ -156,9 +157,24 @@ export class Reload {
 				this.#delay = this.delay.initial;
 				this.#retryStart = undefined;
 
-				await Promise.race([effect.cancel, connection.closed]);
+				const connected = performance.now();
+				const closed = await Promise.race([effect.cancel, connection.closed.then(() => true)]);
+				if (!closed) return;
+
+				// The peer closed the session: tear down and reconnect. A session that
+				// died within the initial delay escalates through the backoff instead.
+				console.warn("connection closed, reconnecting");
+				if (performance.now() - connected < this.delay.initial) {
+					throw new Error("connection closed immediately");
+				}
+				this.#tick.update((prev) => prev + 1);
 			} catch (err) {
 				console.warn("connection error:", err);
+
+				// Any session is dead now: report disconnected during the backoff
+				// rather than when the retry reruns the effect.
+				this.established.set(undefined);
+				this.status.set("disconnected");
 
 				// Track retry start for timeout.
 				this.#retryStart ??= performance.now();
@@ -242,6 +258,11 @@ export class Reload {
 		void consumer.closed.then(() => pump.close());
 
 		return consumer;
+	}
+
+	/** Snapshot the live connection's transport statistics, or undefined while disconnected. */
+	async stats(): Promise<ConnectionStats | undefined> {
+		return this.established.peek()?.stats?.();
 	}
 
 	/** Stop reconnecting, close the current connection, and resolve {@link Reload.closed}. */

--- a/js/net/src/connection/stats.test.ts
+++ b/js/net/src/connection/stats.test.ts
@@ -1,0 +1,152 @@
+import { expect, test } from "bun:test";
+import * as Ietf from "../ietf/index.ts";
+import * as Lite from "../lite/index.ts";
+import { createMockTransportPair } from "../mock.ts";
+import * as Time from "../time.ts";
+import type { Established } from "./established.ts";
+import { accept, connect } from "./index.ts";
+import { Reload } from "./reload.ts";
+import { type ConnectionStats, type TransportStats, transportStats } from "./stats.ts";
+
+// Both built-in connections implement the optional stats().
+async function snapshot(connection: Established): Promise<ConnectionStats> {
+	if (!connection.stats) throw new Error("stats not implemented");
+	return connection.stats();
+}
+
+function fakeQuic(stats: TransportStats): WebTransport {
+	return { getStats: () => Promise.resolve(stats) } as unknown as WebTransport;
+}
+
+test("transportStats maps the W3C dictionary and normalizes a null send rate", async () => {
+	const stats = await transportStats(
+		fakeQuic({
+			smoothedRtt: 25,
+			estimatedSendRate: null,
+			bytesSent: 1,
+			bytesReceived: 2,
+			bytesLost: 3,
+			packetsSent: 4,
+			packetsReceived: 5,
+			packetsLost: 6,
+		}),
+	);
+	expect(stats?.rtt).toBe(Time.Milli(25));
+	expect(stats?.estimatedSendRate).toBeUndefined();
+	expect(stats?.bytesSent).toBe(1);
+	expect(stats?.bytesReceived).toBe(2);
+	expect(stats?.bytesLost).toBe(3);
+	expect(stats?.packetsSent).toBe(4);
+	expect(stats?.packetsReceived).toBe(5);
+	expect(stats?.packetsLost).toBe(6);
+
+	// A snapshot without an RTT (e.g. a shim) leaves the field undefined.
+	expect((await transportStats(fakeQuic({ bytesSent: 10 })))?.rtt).toBeUndefined();
+});
+
+test("transportStats returns undefined without getStats or when it rejects", async () => {
+	expect(await transportStats({} as WebTransport)).toBeUndefined();
+
+	const rejecting = { getStats: () => Promise.reject(new Error("nope")) } as unknown as WebTransport;
+	expect(await transportStats(rejecting)).toBeUndefined();
+});
+
+test("stats reports the transport snapshot over a live connection", async () => {
+	const pair = createMockTransportPair(Lite.ALPN_06_WIP, {
+		stats: { smoothedRtt: 40, estimatedSendRate: 2_000_000, bytesSent: 1_234, packetsLost: 3 },
+	});
+	const url = new URL("https://example.com/");
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+	try {
+		const stats = await snapshot(client);
+		expect(stats.rtt).toBe(Time.Milli(40));
+		expect(stats.estimatedSendRate).toBe(2_000_000);
+		expect(stats.bytesSent).toBe(1_234);
+		expect(stats.packetsLost).toBe(3);
+		expect(stats.bytesReceived).toBeUndefined();
+	} finally {
+		client.close();
+		server.close();
+	}
+});
+
+test("stats falls back to the PROBE fields on a transport without getStats", async () => {
+	const pair = createMockTransportPair(Lite.ALPN_06_WIP);
+	// Shadow the mock's getStats to imitate the qmux/WebSocket fallback.
+	(pair.client as unknown as { getStats?: unknown }).getStats = undefined;
+	const url = new URL("https://example.com/");
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+	try {
+		client.rtt?.set(Time.Milli(70));
+		const stats = await snapshot(client);
+		expect(stats.rtt).toBe(Time.Milli(70));
+		expect(stats.bytesSent).toBeUndefined();
+		expect(stats.estimatedSendRate).toBeUndefined();
+	} finally {
+		client.close();
+		server.close();
+	}
+});
+
+test("the stats poll feeds the rtt signal from the transport", async () => {
+	const pair = createMockTransportPair(Lite.ALPN_06_WIP, { stats: { smoothedRtt: 40 } });
+	const url = new URL("https://example.com/");
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+	try {
+		// The poll runs every 100 ms; give it two ticks.
+		await new Promise((resolve) => setTimeout(resolve, 250));
+		expect(client.rtt?.peek()).toBe(Time.Milli(40));
+	} finally {
+		client.close();
+		server.close();
+	}
+});
+
+test("a session that dies during reconnect backoff reports disconnected", async () => {
+	const original = globalThis.WebTransport;
+	const pair = createMockTransportPair(Lite.ALPN_06_WIP, { stats: { smoothedRtt: 10 } });
+	// `new` on a function returning an object yields that object, handing connect() the mock.
+	const stub = function StubWebTransport() {
+		return pair.client;
+	};
+	globalThis.WebTransport = stub as unknown as typeof WebTransport;
+	const url = new URL("https://example.com/");
+	const reload = new Reload({ enabled: true, url, websocket: { enabled: false } });
+	try {
+		const server = await accept(pair.server, url);
+		while (!reload.established.peek()) {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		}
+		expect(await reload.stats()).toBeDefined();
+
+		// Close the server side: the session dies within the initial delay, so the
+		// loop escalates through the backoff and must not report the dead session.
+		server.close();
+		while (reload.established.peek()) {
+			await new Promise((resolve) => setTimeout(resolve, 0));
+		}
+		expect(reload.status.peek()).toBe("disconnected");
+		expect(await reload.stats()).toBeUndefined();
+	} finally {
+		reload.close();
+		globalThis.WebTransport = original;
+	}
+});
+
+test("stats reports the transport snapshot on an IETF connection", async () => {
+	const pair = createMockTransportPair(Ietf.ALPN.DRAFT_18, {
+		stats: { smoothedRtt: 15, bytesReceived: 42 },
+	});
+	const url = new URL("https://example.com/");
+	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
+	try {
+		const stats = await snapshot(client);
+		expect(stats.rtt).toBe(Time.Milli(15));
+		expect(stats.bytesReceived).toBe(42);
+		// moq-transport has no PROBE, so there is no receive estimate.
+		expect(stats.estimatedRecvRate).toBeUndefined();
+	} finally {
+		client.close();
+		server.close();
+	}
+});

--- a/js/net/src/connection/stats.ts
+++ b/js/net/src/connection/stats.ts
@@ -1,0 +1,89 @@
+/**
+ * Connection statistics: a point-in-time snapshot of the transport's counters.
+ *
+ * @module
+ */
+import * as Time from "../time.ts";
+
+/**
+ * A point-in-time snapshot of a connection's transport statistics.
+ *
+ * The counters come from `WebTransport.getStats()` (W3C field semantics) and
+ * the estimates from the congestion controller and MoQ PROBE, mirroring the
+ * shape of Rust's `moq_net::ConnectionStats`. Every field is optional: the
+ * qmux/WebSocket fallback reports only the PROBE fields.
+ *
+ * @public
+ */
+export interface ConnectionStats {
+	/** Smoothed round-trip time estimate in milliseconds. */
+	rtt?: Time.Milli;
+
+	/** Estimated send bandwidth from the congestion controller, in bits per second. */
+	estimatedSendRate?: number;
+
+	/** Estimated receive bandwidth from MoQ PROBE, in bits per second (moq-lite-03+ only). */
+	estimatedRecvRate?: number;
+
+	/** Total bytes sent on streams and datagrams, excluding retransmissions and QUIC overhead. */
+	bytesSent?: number;
+
+	/** Total bytes received on streams and datagrams, including duplicates, excluding QUIC overhead. */
+	bytesReceived?: number;
+
+	/** Bytes currently declared lost. The estimate can decrease when a loss proves spurious. */
+	bytesLost?: number;
+
+	/** Total packets sent, including retransmissions. */
+	packetsSent?: number;
+
+	/** Total packets received, including duplicates. */
+	packetsReceived?: number;
+
+	/** Packets currently declared lost. The estimate can decrease when a loss proves spurious. */
+	packetsLost?: number;
+}
+
+/**
+ * The subset of the W3C `WebTransportConnectionStats` dictionary we consume.
+ * `getStats()` is not in TypeScript's DOM lib yet, so it is declared here.
+ *
+ * @internal
+ */
+export interface TransportStats {
+	smoothedRtt?: number;
+	estimatedSendRate?: number | null;
+	bytesSent?: number;
+	bytesReceived?: number;
+	bytesLost?: number;
+	packetsSent?: number;
+	packetsReceived?: number;
+	packetsLost?: number;
+}
+
+/**
+ * Snapshot `quic` via `getStats()` into a {@link ConnectionStats}, or undefined
+ * when the transport doesn't implement it (the qmux/WebSocket fallback, older
+ * browsers). The caller fills the PROBE fields.
+ *
+ * @internal
+ */
+export async function transportStats(quic: WebTransport): Promise<ConnectionStats | undefined> {
+	const getStats = (quic as { getStats?: () => Promise<TransportStats> }).getStats;
+	if (typeof getStats !== "function") return undefined;
+	try {
+		const stats = await getStats.call(quic);
+		return {
+			rtt: stats.smoothedRtt !== undefined ? Time.Milli(stats.smoothedRtt) : undefined,
+			estimatedSendRate: stats.estimatedSendRate ?? undefined,
+			bytesSent: stats.bytesSent,
+			bytesReceived: stats.bytesReceived,
+			bytesLost: stats.bytesLost,
+			packetsSent: stats.packetsSent,
+			packetsReceived: stats.packetsReceived,
+			packetsLost: stats.packetsLost,
+		};
+	} catch {
+		return undefined;
+	}
+}

--- a/js/net/src/ietf/connection.ts
+++ b/js/net/src/ietf/connection.ts
@@ -1,6 +1,7 @@
 import type * as announce from "../announced.ts";
 import type * as broadcast from "../broadcast.ts";
 import type { Established } from "../connection/established.ts";
+import { type ConnectionStats, transportStats } from "../connection/stats.ts";
 import { type Transport, transportOf } from "../connection/transport.ts";
 import * as Path from "../path.ts";
 import { type Reader, Readers, type Stream } from "../stream.ts";
@@ -102,6 +103,14 @@ export class Connection implements Established {
 		this.#subscriber = new Subscriber(this.#session);
 
 		void this.#run();
+	}
+
+	/**
+	 * Snapshot the connection's transport statistics. See {@link Established.stats}.
+	 * moq-transport has no PROBE, so only the transport fields are filled.
+	 */
+	async stats(): Promise<ConnectionStats> {
+		return { ...(await transportStats(this.#quic)) };
 	}
 
 	/**

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -3,6 +3,7 @@ import type * as announce from "../announced.ts";
 import { type Bandwidth, createBandwidth } from "../bandwidth.ts";
 import type * as broadcast from "../broadcast.ts";
 import type { Established } from "../connection/established.ts";
+import { type ConnectionStats, transportStats } from "../connection/stats.ts";
 import { type Transport, transportOf } from "../connection/transport.ts";
 import * as Path from "../path.ts";
 import { type Reader, Readers, Stream, Writer } from "../stream.ts";
@@ -21,7 +22,7 @@ import { Subscriber } from "./subscriber.ts";
 import { Track as TrackMessage } from "./track.ts";
 import { hasDatagrams, hasSetupStream, Version, versionName } from "./version.ts";
 
-const SEND_BW_POLL_INTERVAL = 100; // ms
+const STATS_POLL_INTERVAL = 100; // ms
 
 /**
  * Constructor options for {@link Connection}.
@@ -80,7 +81,7 @@ export class Connection implements Established {
 	/** Estimated receive bitrate from PROBE (moq-lite-03+ only). */
 	readonly recvBandwidth?: Bandwidth;
 
-	/** RTT in milliseconds from PROBE (moq-lite-04+ only). */
+	/** Smoothed RTT in milliseconds, from the transport when it measures one, otherwise from PROBE (moq-lite-04+ only). */
 	readonly rtt?: Signal<Time.Milli | undefined>;
 
 	/** Random per-connection origin id. Shared by Publisher (for outbound hop
@@ -95,6 +96,10 @@ export class Connection implements Established {
 	// Mirrors the role out of #peerSetup, so the public surface exposes the peer's declared
 	// direction without handing out the whole SETUP (whose probe level gates our own streams).
 	#peerRole = new Signal<Role | undefined>(undefined);
+
+	// PROBE's RTT estimate, kept separate from `rtt` so the stats poll can merge
+	// the two sources with the transport winning. Aliases `rtt` without getStats.
+	#probeRtt: Signal<Time.Milli | undefined>;
 
 	/**
 	 * The {@link Role} the peer advertised in its SETUP, for a server deciding whether the
@@ -134,9 +139,10 @@ export class Connection implements Established {
 			this.recvBandwidth = createBandwidth();
 		}
 
-		// RTT can be populated by PROBE (Lite04+) or getStats() (when supported).
-		// TODO prefer getStats() when both are available.
+		// Fed by the stats poll, which merges the transport RTT (getStats) with
+		// PROBE (Lite04+). The transport wins whenever it measures one.
 		this.rtt = new Signal<Time.Milli | undefined>(undefined);
+		this.#probeRtt = hasGetStats ? new Signal<Time.Milli | undefined>(undefined) : this.rtt;
 
 		this.origin = randomOrigin();
 		this.#publisher = new Publisher(this.#quic, this.#version, this.origin);
@@ -145,7 +151,7 @@ export class Connection implements Established {
 			this.#version,
 			this.origin,
 			this.recvBandwidth,
-			this.rtt,
+			this.#probeRtt,
 			this.#peerSetup,
 		);
 
@@ -175,7 +181,7 @@ export class Connection implements Established {
 		}
 
 		if (this.sendBandwidth) {
-			tasks.push(this.#runSendBandwidth(this.sendBandwidth));
+			tasks.push(this.#runTransportStats(this.sendBandwidth));
 		}
 
 		if (this.recvBandwidth) {
@@ -317,27 +323,30 @@ export class Connection implements Established {
 		}
 	}
 
-	async #runSendBandwidth(bandwidth: Bandwidth): Promise<void> {
-		const quic = this.#quic as unknown as {
-			getStats: () => Promise<{ estimatedSendRate: number | null }>;
-		};
-
+	// Poll getStats() to feed the send bandwidth and RTT signals.
+	async #runTransportStats(bandwidth: Bandwidth): Promise<void> {
 		return new Promise<void>((resolve) => {
 			const id = setInterval(async () => {
-				try {
-					const stats = await quic.getStats();
-					bandwidth.set(stats.estimatedSendRate ?? undefined);
-				} catch {
-					clearInterval(id);
-					resolve();
-				}
-			}, SEND_BW_POLL_INTERVAL);
+				const stats = await transportStats(this.#quic);
+				bandwidth.set(stats?.estimatedSendRate);
+				this.rtt?.set(stats?.rtt ?? this.#probeRtt.peek());
+			}, STATS_POLL_INTERVAL);
 
 			void this.closed.then(() => {
 				clearInterval(id);
 				resolve();
 			});
 		});
+	}
+
+	/** Snapshot the connection's transport statistics. See {@link Established.stats}. */
+	async stats(): Promise<ConnectionStats> {
+		const transport = await transportStats(this.#quic);
+		return {
+			...transport,
+			rtt: transport?.rtt ?? this.#probeRtt.peek(),
+			estimatedRecvRate: this.recvBandwidth?.peek(),
+		};
 	}
 
 	get closed(): Promise<void> {

--- a/js/net/src/mock.ts
+++ b/js/net/src/mock.ts
@@ -4,6 +4,8 @@
  * Creates paired client/server transports connected via TransformStreams.
  */
 
+import type { TransportStats } from "./connection/stats.ts";
+
 // High watermark to prevent writes from blocking on backpressure.
 // Real WebTransport has kernel buffers; we simulate this with a large queue.
 const WRITABLE_STRATEGY: QueuingStrategy<Uint8Array> = { highWaterMark: 256 };
@@ -227,9 +229,11 @@ class MockTransport implements WebTransport {
 		}
 	}
 
-	// biome-ignore lint/suspicious/noExplicitAny: WebTransportStats type not available in all TS libs
-	async getStats(): Promise<any> {
-		return {};
+	/** The snapshot {@link getStats} resolves with (default empty). */
+	stats: TransportStats = {};
+
+	async getStats(): Promise<TransportStats> {
+		return this.stats;
 	}
 }
 
@@ -249,6 +253,9 @@ export interface MockTransportOptions {
 
 	/** Whether the incoming datagram readable stream is exposed. */
 	datagramReadable?: boolean;
+
+	/** The snapshot `getStats()` resolves with on both transports (default empty). */
+	stats?: TransportStats;
 }
 
 /**
@@ -265,6 +272,10 @@ export function createMockTransportPair(
 	const datagrams = options?.datagrams ?? true;
 	const client = new MockTransport(protocol, datagrams, options?.datagramWritable, options?.datagramReadable);
 	const server = new MockTransport(protocol, datagrams, options?.datagramWritable, options?.datagramReadable);
+	if (options?.stats) {
+		client.stats = options.stats;
+		server.stats = options.stats;
+	}
 	client.setPeer(server);
 	server.setPeer(client);
 	return { client, server };


### PR DESCRIPTION
We are still new to this library, but I found myself wanting to have the browser drive its own rate control. However @moq/net only exposes a send bandwidth estimate and the PROBE RTT. The Rust side just grew a full ConnectionStats snapshot, while js was lagging behind.

This adds an optional stats() in a similar shape to Rust. While at it I resolved the TODO to prefer the transport RTT over PROBE, and it turned out that Reload also kept a gracefully closed connection in established forever, so status (and now stats) would report a dead session. Hence a settled closed now tears down and reconnects, matching what the Rust reconnect loop already does.