### PR TITLE
feat(moq-native): expose a congestion control knob for the quinn backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4418,6 +4418,7 @@ dependencies = [
  "humantime-serde",
  "jni 0.22.4",
  "moq-net",
+ "noq-proto",
  "notify",
  "parking_lot",
  "qmux",

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -187,6 +187,39 @@ tls.disable_verify = true
 # tls.system_roots = true
 ```
 
+### \[server.quic] and \[client.quic]
+
+Per-connection QUIC transport knobs, applied to incoming connections
+(`server.quic`) and to outgoing cluster dials (`client.quic`) independently.
+
+```toml
+[server.quic]
+# Congestion control: "loss" or "delay". Omit to keep the backend's default.
+congestion_control = "delay"
+
+[client.quic]
+congestion_control = "delay"
+```
+
+`loss` is CUBIC: it grows until it drops packets, so the send rate sawtooths.
+`delay` is BBR: it tracks the measured delivery rate and RTT instead of waiting
+for loss, which keeps queues shorter and the send rate steady enough for a live
+encoder to follow. Prefer `delay` for interactive media.
+
+The knob names a family rather than an algorithm because each QUIC backend ships
+a different BBR generation:
+
+| Backend | `loss` | `delay` | Default when unset |
+| --- | --- | --- | --- |
+| quinn | CUBIC | BBRv1 | CUBIC |
+| quiche | CUBIC | BBRv2 | CUBIC |
+| noq | CUBIC | BBRv3 | BBRv3 |
+| iroh | CUBIC | BBRv3 | BBRv3 |
+
+Also available as `--server-quic-congestion-control` /
+`--client-quic-congestion-control`, or `MOQ_SERVER_QUIC_CONGESTION_CONTROL` /
+`MOQ_CLIENT_QUIC_CONGESTION_CONTROL`.
+
 ### \[stats]
 
 Per-node stats publishing. When enabled, the relay publishes stats broadcasts

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -22,7 +22,7 @@ watch = ["dep:notify"]
 # The QUIC backends pull in their crypto provider from these features (default-features
 # are off on each backend dep), so a backend without aws-lc-rs/ring has no initial cipher.
 aws-lc-rs = ["rustls/aws-lc-rs", "rcgen?/aws_lc_rs", "quinn?/rustls-aws-lc-rs", "web-transport-noq?/aws-lc-rs"]
-iroh = ["dep:web-transport-iroh", "dep:web-transport-proto"]
+iroh = ["dep:web-transport-iroh", "dep:web-transport-proto", "dep:noq-proto"]
 jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 websocket = ["dep:qmux"]
 # Plain-TCP qmux transport (`tcp://`), no TLS. Server-side and client-side.
@@ -41,6 +41,9 @@ humantime = "2.3"
 humantime-serde = "1.1"
 
 moq-net = { workspace = true }
+# iroh runs on noq but re-exports only the ControllerFactory trait, not the concrete
+# congestion configs. Version matched to the copy iroh pulls in.
+noq-proto = { version = "1", default-features = false, optional = true }
 notify = { version = "8", optional = true }
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 qmux = { workspace = true, features = ["wss", "tls", "tcp"], optional = true }

--- a/rs/moq-native/src/iroh.rs
+++ b/rs/moq-native/src/iroh.rs
@@ -4,8 +4,9 @@
 //! falling back to an iroh relay. Both WebTransport-over-H3 and raw QUIC are
 //! negotiated via ALPN.
 
-use std::{net, path::PathBuf, str::FromStr};
+use std::{net, path::PathBuf, str::FromStr, sync::Arc};
 
+use crate::quic::CongestionControl;
 use url::Url;
 use web_transport_iroh::iroh::{self, SecretKey};
 // NOTE: web-transport-iroh should re-export proto like web-transport-quinn does.
@@ -13,6 +14,17 @@ use web_transport_proto::{ConnectRequest, ConnectResponse};
 
 pub use iroh::Endpoint;
 pub use web_transport_iroh;
+
+/// The iroh controller factory for a congestion control family.
+///
+/// iroh is built on noq, so its BBR is v3. It re-exports the `ControllerFactory`
+/// trait but not the concrete configs, hence the direct `noq-proto` dependency.
+fn congestion_factory(family: CongestionControl) -> Arc<dyn iroh::endpoint::ControllerFactory + Send + Sync> {
+	match family {
+		CongestionControl::Loss => Arc::new(noq_proto::congestion::CubicConfig::default()),
+		CongestionControl::Delay => Arc::new(noq_proto::congestion::Bbr3Config::default()),
+	}
+}
 
 /// Errors specific to the iroh P2P backend.
 #[derive(Debug, thiserror::Error)]
@@ -89,12 +101,6 @@ pub enum Error {
 	/// GSO is always on for iroh, so `--quic-gso=false` cannot be honored.
 	#[error("the iroh backend cannot disable GSO; drop --quic-gso=false or use the quinn backend")]
 	GsoUnsupported,
-
-	/// iroh exposes no congestion controller knob.
-	#[error(
-		"the iroh backend cannot select a congestion controller; drop --client-quic-congestion-control or use the quinn backend"
-	)]
-	CongestionControlUnsupported,
 }
 
 type Result<T> = std::result::Result<T, Error>;
@@ -150,9 +156,8 @@ impl EndpointConfig {
 	/// iroh is a single P2P endpoint shared by both roles, so it takes the client
 	/// section (the per-connection knobs are symmetric). It only honors the knobs
 	/// its transport-config builder exposes (stream limits, idle timeout, MTU
-	/// discovery); it has no keep-alive knob, cannot disable GSO (`gso = false`
-	/// fails with [`Error::GsoUnsupported`]), and cannot select a congestion
-	/// controller (`congestion_control` fails with [`Error::CongestionControlUnsupported`]).
+	/// discovery, congestion control); it has no keep-alive knob and cannot disable
+	/// GSO, so `gso = false` fails with [`Error::GsoUnsupported`].
 	pub async fn bind(self, quic: &crate::quic::Client) -> Result<Option<Endpoint>> {
 		if !self.enabled.unwrap_or(false) {
 			return Ok(None);
@@ -161,10 +166,6 @@ impl EndpointConfig {
 		let quic = quic.resolve();
 		if quic.gso_disabled() {
 			return Err(Error::GsoUnsupported);
-		}
-
-		if quic.congestion_control.is_some() {
-			return Err(Error::CongestionControlUnsupported);
 		}
 
 		// If the secret matches the expected format (hex encoded), use it directly.
@@ -201,6 +202,10 @@ impl EndpointConfig {
 		if !quic.mtu_discovery {
 			transport = transport.mtu_discovery_config(None);
 		}
+		// iroh runs on noq, so match the noq backend's BBR default rather than noq's own CUBIC.
+		transport = transport.congestion_controller_factory(congestion_factory(
+			quic.congestion_control.unwrap_or(CongestionControl::Delay),
+		));
 
 		let mut builder = if self.disable_relay.unwrap_or(false) {
 			Endpoint::builder(iroh::endpoint::presets::N0DisableRelay)
@@ -331,21 +336,18 @@ fn url_set_scheme(url: Url, scheme: &str) -> Result<Url> {
 mod tests {
 	use super::*;
 
-	/// iroh has no congestion controller knob, so a selection must fail at
-	/// bind rather than being silently ignored.
-	#[tokio::test]
-	async fn congestion_control_selection_is_rejected() {
-		let config = EndpointConfig {
-			enabled: Some(true),
-			..Default::default()
-		};
-		let quic = crate::quic::Client {
-			congestion_control: Some(crate::quic::CongestionControl::Bbr),
-			..Default::default()
-		};
-		assert!(matches!(
-			config.bind(&quic).await,
-			Err(Error::CongestionControlUnsupported)
-		));
+	/// Build a controller from each family's factory and downcast it to the
+	/// concrete implementation it must map to. iroh runs on noq, so this is the
+	/// same pairing as the noq backend.
+	#[test]
+	fn congestion_factory_maps_each_family() {
+		let now = std::time::Instant::now();
+		let mtu = 1200;
+
+		let loss = congestion_factory(CongestionControl::Loss).build(now, mtu);
+		assert!(loss.into_any().downcast::<noq_proto::congestion::Cubic>().is_ok());
+
+		let delay = congestion_factory(CongestionControl::Delay).build(now, mtu);
+		assert!(delay.into_any().downcast::<noq_proto::congestion::Bbr3>().is_ok());
 	}
 }

--- a/rs/moq-native/src/iroh.rs
+++ b/rs/moq-native/src/iroh.rs
@@ -89,6 +89,12 @@ pub enum Error {
 	/// GSO is always on for iroh, so `--quic-gso=false` cannot be honored.
 	#[error("the iroh backend cannot disable GSO; drop --quic-gso=false or use the quinn backend")]
 	GsoUnsupported,
+
+	/// iroh exposes no congestion controller knob.
+	#[error(
+		"the iroh backend cannot select a congestion controller; drop --client-quic-congestion-control or use the quinn backend"
+	)]
+	CongestionControlUnsupported,
 }
 
 type Result<T> = std::result::Result<T, Error>;
@@ -144,8 +150,9 @@ impl EndpointConfig {
 	/// iroh is a single P2P endpoint shared by both roles, so it takes the client
 	/// section (the per-connection knobs are symmetric). It only honors the knobs
 	/// its transport-config builder exposes (stream limits, idle timeout, MTU
-	/// discovery); it has no keep-alive knob and cannot disable GSO, so `gso = false`
-	/// fails with [`Error::GsoUnsupported`].
+	/// discovery); it has no keep-alive knob, cannot disable GSO (`gso = false`
+	/// fails with [`Error::GsoUnsupported`]), and cannot select a congestion
+	/// controller (`congestion_control` fails with [`Error::CongestionControlUnsupported`]).
 	pub async fn bind(self, quic: &crate::quic::Client) -> Result<Option<Endpoint>> {
 		if !self.enabled.unwrap_or(false) {
 			return Ok(None);
@@ -154,6 +161,10 @@ impl EndpointConfig {
 		let quic = quic.resolve();
 		if quic.gso_disabled() {
 			return Err(Error::GsoUnsupported);
+		}
+
+		if quic.congestion_control.is_some() {
+			return Err(Error::CongestionControlUnsupported);
 		}
 
 		// If the secret matches the expected format (hex encoded), use it directly.
@@ -314,4 +325,27 @@ fn url_set_scheme(url: Url, scheme: &str) -> Result<Url> {
 	)
 	.parse()?;
 	Ok(url)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// iroh has no congestion controller knob, so a selection must fail at
+	/// bind rather than being silently ignored.
+	#[tokio::test]
+	async fn congestion_control_selection_is_rejected() {
+		let config = EndpointConfig {
+			enabled: Some(true),
+			..Default::default()
+		};
+		let quic = crate::quic::Client {
+			congestion_control: Some(crate::quic::CongestionControl::Bbr),
+			..Default::default()
+		};
+		assert!(matches!(
+			config.bind(&quic).await,
+			Err(Error::CongestionControlUnsupported)
+		));
+	}
 }

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -57,6 +57,10 @@ pub enum Error {
 	#[error("failed to resolve bind address")]
 	ResolveBind(#[source] std::io::Error),
 
+	/// noq ships BBRv3 only, so a congestion control selection cannot be honored.
+	#[error("the noq backend always uses BBRv3; drop --*-quic-congestion-control or use the quinn backend")]
+	CongestionControlUnsupported,
+
 	/// The URL has no host to connect to.
 	#[error("invalid DNS name")]
 	InvalidDnsName,
@@ -182,11 +186,17 @@ pub(crate) struct NoqClient {
 
 impl NoqClient {
 	pub fn new(config: &ClientConfig) -> Result<Self> {
+		let quic = config.quic.resolve();
+		// noq ships BBRv3 only; fail fast instead of silently running a different controller.
+		if quic.congestion_control.is_some() {
+			return Err(Error::CongestionControlUnsupported);
+		}
+
 		let socket = crate::bind::udp(config.bind).map_err(Error::BindSocket)?;
 
 		let mut transport = noq::TransportConfig::default();
 		transport.congestion_controller_factory(Arc::new(noq::congestion::Bbr3Config::default()));
-		apply_transport(&mut transport, config.quic.resolve());
+		apply_transport(&mut transport, quic);
 		let transport = Arc::new(transport);
 
 		// There's a bit more boilerplate to make a generic endpoint.
@@ -362,9 +372,15 @@ pub(crate) struct NoqServer {
 
 impl NoqServer {
 	pub fn new(config: ServerConfig) -> Result<Self> {
+		let quic = config.quic.resolve();
+		// noq ships BBRv3 only; fail fast instead of silently running a different controller.
+		if quic.congestion_control.is_some() {
+			return Err(Error::CongestionControlUnsupported);
+		}
+
 		let mut transport = noq::TransportConfig::default();
 		transport.congestion_controller_factory(Arc::new(noq::congestion::Bbr3Config::default()));
-		apply_transport(&mut transport, config.quic.resolve());
+		apply_transport(&mut transport, quic);
 		let transport = Arc::new(transport);
 
 		let provider = crate::crypto::provider();
@@ -587,5 +603,39 @@ impl noq::ConnectionIdGenerator for ServerIdGenerator {
 
 	fn cid_lifetime(&self) -> Option<Duration> {
 		None
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// noq always runs BBRv3, so a congestion control selection must fail at
+	/// init rather than silently running a different controller.
+	#[tokio::test]
+	async fn congestion_control_selection_is_rejected() {
+		let client_config = ClientConfig {
+			quic: crate::quic::Client {
+				congestion_control: Some(crate::quic::CongestionControl::Cubic),
+				..Default::default()
+			},
+			..Default::default()
+		};
+		assert!(matches!(
+			NoqClient::new(&client_config),
+			Err(Error::CongestionControlUnsupported)
+		));
+
+		let server_config = ServerConfig {
+			quic: crate::quic::Server {
+				congestion_control: Some(crate::quic::CongestionControl::Bbr),
+				..Default::default()
+			},
+			..Default::default()
+		};
+		assert!(matches!(
+			NoqServer::new(server_config),
+			Err(Error::CongestionControlUnsupported)
+		));
 	}
 }

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -1,6 +1,7 @@
 //! The noq QUIC backend, used for both WebTransport (`https://`) and raw QUIC (`moqt://`, `moql://`).
 
 use crate::client::ClientConfig;
+use crate::quic::CongestionControl;
 use crate::quic::Resolved;
 use crate::quic::ServerId;
 use crate::server::ServerConfig;
@@ -31,6 +32,19 @@ fn apply_transport(transport: &mut noq::TransportConfig, quic: Resolved) {
 	if let Some(gso) = quic.gso {
 		transport.enable_segmentation_offload(gso);
 	}
+
+	// Unlike quinn, this backend defaults to BBR rather than noq's own CUBIC.
+	transport.congestion_controller_factory(congestion_factory(
+		quic.congestion_control.unwrap_or(CongestionControl::Delay),
+	));
+}
+
+/// The noq controller factory for a congestion control family. noq's BBR is v3.
+fn congestion_factory(family: CongestionControl) -> Arc<dyn noq::congestion::ControllerFactory + Send + Sync> {
+	match family {
+		CongestionControl::Loss => Arc::new(noq::congestion::CubicConfig::default()),
+		CongestionControl::Delay => Arc::new(noq::congestion::Bbr3Config::default()),
+	}
 }
 
 /// Errors specific to the noq QUIC backend.
@@ -56,10 +70,6 @@ pub enum Error {
 	/// The configured bind address could not be resolved.
 	#[error("failed to resolve bind address")]
 	ResolveBind(#[source] std::io::Error),
-
-	/// noq ships BBRv3 only, so a congestion control selection cannot be honored.
-	#[error("the noq backend always uses BBRv3; drop --*-quic-congestion-control or use the quinn backend")]
-	CongestionControlUnsupported,
 
 	/// The URL has no host to connect to.
 	#[error("invalid DNS name")]
@@ -186,17 +196,10 @@ pub(crate) struct NoqClient {
 
 impl NoqClient {
 	pub fn new(config: &ClientConfig) -> Result<Self> {
-		let quic = config.quic.resolve();
-		// noq ships BBRv3 only; fail fast instead of silently running a different controller.
-		if quic.congestion_control.is_some() {
-			return Err(Error::CongestionControlUnsupported);
-		}
-
 		let socket = crate::bind::udp(config.bind).map_err(Error::BindSocket)?;
 
 		let mut transport = noq::TransportConfig::default();
-		transport.congestion_controller_factory(Arc::new(noq::congestion::Bbr3Config::default()));
-		apply_transport(&mut transport, quic);
+		apply_transport(&mut transport, config.quic.resolve());
 		let transport = Arc::new(transport);
 
 		// There's a bit more boilerplate to make a generic endpoint.
@@ -372,15 +375,8 @@ pub(crate) struct NoqServer {
 
 impl NoqServer {
 	pub fn new(config: ServerConfig) -> Result<Self> {
-		let quic = config.quic.resolve();
-		// noq ships BBRv3 only; fail fast instead of silently running a different controller.
-		if quic.congestion_control.is_some() {
-			return Err(Error::CongestionControlUnsupported);
-		}
-
 		let mut transport = noq::TransportConfig::default();
-		transport.congestion_controller_factory(Arc::new(noq::congestion::Bbr3Config::default()));
-		apply_transport(&mut transport, quic);
+		apply_transport(&mut transport, config.quic.resolve());
 		let transport = Arc::new(transport);
 
 		let provider = crate::crypto::provider();
@@ -610,32 +606,17 @@ impl noq::ConnectionIdGenerator for ServerIdGenerator {
 mod tests {
 	use super::*;
 
-	/// noq always runs BBRv3, so a congestion control selection must fail at
-	/// init rather than silently running a different controller.
-	#[tokio::test]
-	async fn congestion_control_selection_is_rejected() {
-		let client_config = ClientConfig {
-			quic: crate::quic::Client {
-				congestion_control: Some(crate::quic::CongestionControl::Cubic),
-				..Default::default()
-			},
-			..Default::default()
-		};
-		assert!(matches!(
-			NoqClient::new(&client_config),
-			Err(Error::CongestionControlUnsupported)
-		));
+	/// Build a controller from each family's factory and downcast it to the
+	/// concrete noq implementation it must map to.
+	#[test]
+	fn congestion_factory_maps_each_family() {
+		let now = std::time::Instant::now();
+		let mtu = 1200;
 
-		let server_config = ServerConfig {
-			quic: crate::quic::Server {
-				congestion_control: Some(crate::quic::CongestionControl::Bbr),
-				..Default::default()
-			},
-			..Default::default()
-		};
-		assert!(matches!(
-			NoqServer::new(server_config),
-			Err(Error::CongestionControlUnsupported)
-		));
+		let loss = congestion_factory(CongestionControl::Loss).build(now, mtu);
+		assert!(loss.into_any().downcast::<noq::congestion::Cubic>().is_ok());
+
+		let delay = congestion_factory(CongestionControl::Delay).build(now, mtu);
+		assert!(delay.into_any().downcast::<noq::congestion::Bbr3>().is_ok());
 	}
 }

--- a/rs/moq-native/src/quic.rs
+++ b/rs/moq-native/src/quic.rs
@@ -41,20 +41,22 @@ impl std::str::FromStr for ServerId {
 	}
 }
 
-/// The congestion control algorithm for a QUIC connection.
+/// The congestion control family for a QUIC connection.
 ///
-/// Honored by the quinn backend only; noq, quiche, and iroh reject a
-/// selection at init (noq always uses BBRv3).
+/// This selects a family rather than a named algorithm because each backend ships a
+/// different generation: BBRv1 on quinn, BBRv2 on quiche, BBRv3 on noq and iroh. A
+/// `Bbr` variant would promise more than any one backend delivers.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[non_exhaustive]
 pub enum CongestionControl {
-	/// CUBIC (RFC 8312), quinn's default: loss-based, throughput-oriented.
-	Cubic,
-	/// BBR: tracks delivery rate instead of reacting to loss, better suited to interactive media.
-	Bbr,
-	/// NewReno (RFC 6582): the classic conservative loss-based controller.
-	NewReno,
+	/// Loss-based (CUBIC): grows until it drops packets, so the send rate sawtooths.
+	/// Throughput-oriented, and the default on most stacks.
+	Loss,
+	/// Delay-based (BBR): tracks the measured delivery rate and RTT instead of waiting
+	/// for loss, which keeps queues short and the send rate steady enough for an encoder
+	/// to track.
+	Delay,
 }
 
 /// Default maximum number of concurrent QUIC streams (bidi and uni) per connection.
@@ -133,9 +135,8 @@ pub struct Client {
 	)]
 	pub mtu_discovery: Option<bool>,
 
-	/// Congestion control algorithm. Unset means the backend's default (CUBIC on quinn).
-	/// Only the quinn backend can select one; setting it fails at init on noq, quiche, and iroh
-	/// (noq always uses BBRv3).
+	/// Congestion control family. Unset keeps the backend's own default: CUBIC on
+	/// quinn and quiche, BBRv3 on noq and iroh.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(
 		id = "client-quic-congestion-control",
@@ -226,9 +227,8 @@ pub struct Server {
 	)]
 	pub mtu_discovery: Option<bool>,
 
-	/// Congestion control algorithm. Unset means the backend's default (CUBIC on quinn).
-	/// Only the quinn backend can select one; setting it fails at init on noq and quiche
-	/// (noq always uses BBRv3).
+	/// Congestion control family. Unset keeps the backend's own default: CUBIC on
+	/// quinn and quiche, BBRv3 on noq.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(
 		id = "server-quic-congestion-control",
@@ -311,8 +311,7 @@ pub(crate) struct Resolved {
 	pub keep_alive: Option<Duration>,
 	/// Whether to run path MTU discovery.
 	pub mtu_discovery: bool,
-	/// Congestion control override, or `None` to leave the backend default (CUBIC on quinn).
-	/// Only quinn honors a selection; the other backends reject `Some` at init.
+	/// Congestion control override, or `None` to leave the backend's own default.
 	pub congestion_control: Option<CongestionControl>,
 }
 
@@ -444,27 +443,27 @@ mod tests {
 			max_streams = 7000
 			gso = false
 			preferred_v4 = "192.0.2.1:443"
-			congestion_control = "new-reno"
+			congestion_control = "delay"
 		"#;
 		let quic: Server = toml::from_str(toml).unwrap();
 		assert_eq!(quic.max_streams, Some(7000));
 		assert_eq!(quic.gso, Some(false));
 		assert_eq!(quic.preferred_v4, Some("192.0.2.1:443".parse().unwrap()));
-		assert_eq!(quic.congestion_control, Some(CongestionControl::NewReno));
+		assert_eq!(quic.congestion_control, Some(CongestionControl::Delay));
 	}
 
 	#[test]
 	fn congestion_control_flags_parse() {
 		let both = parse(&[
 			"--client-quic-congestion-control",
-			"bbr",
+			"delay",
 			"--server-quic-congestion-control",
-			"new-reno",
+			"loss",
 		]);
-		assert_eq!(both.client.congestion_control, Some(CongestionControl::Bbr));
-		assert_eq!(both.server.congestion_control, Some(CongestionControl::NewReno));
+		assert_eq!(both.client.congestion_control, Some(CongestionControl::Delay));
+		assert_eq!(both.server.congestion_control, Some(CongestionControl::Loss));
 
-		// Unset stays None, which leaves the backend's own default (CUBIC on quinn).
+		// Unset stays None, which leaves each backend's own default.
 		assert_eq!(Client::default().resolve().congestion_control, None);
 	}
 }

--- a/rs/moq-native/src/quic.rs
+++ b/rs/moq-native/src/quic.rs
@@ -41,6 +41,22 @@ impl std::str::FromStr for ServerId {
 	}
 }
 
+/// The congestion control algorithm for a QUIC connection.
+///
+/// Honored by the quinn backend only; noq, quiche, and iroh reject a
+/// selection at init (noq always uses BBRv3).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum CongestionControl {
+	/// CUBIC (RFC 8312), quinn's default: loss-based, throughput-oriented.
+	Cubic,
+	/// BBR: tracks delivery rate instead of reacting to loss, better suited to interactive media.
+	Bbr,
+	/// NewReno (RFC 6582): the classic conservative loss-based controller.
+	NewReno,
+}
+
 /// Default maximum number of concurrent QUIC streams (bidi and uni) per connection.
 pub(crate) const DEFAULT_MAX_STREAMS: u64 = 1024;
 
@@ -116,6 +132,18 @@ pub struct Client {
 		value_parser = clap::value_parser!(bool),
 	)]
 	pub mtu_discovery: Option<bool>,
+
+	/// Congestion control algorithm. Unset means the backend's default (CUBIC on quinn).
+	/// Only the quinn backend can select one; setting it fails at init on noq, quiche, and iroh
+	/// (noq always uses BBRv3).
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[arg(
+		id = "client-quic-congestion-control",
+		long = "client-quic-congestion-control",
+		env = "MOQ_CLIENT_QUIC_CONGESTION_CONTROL",
+		value_enum
+	)]
+	pub congestion_control: Option<CongestionControl>,
 }
 
 impl Client {
@@ -127,6 +155,7 @@ impl Client {
 			self.idle_timeout,
 			self.keep_alive,
 			self.mtu_discovery,
+			self.congestion_control,
 		)
 	}
 }
@@ -197,6 +226,18 @@ pub struct Server {
 	)]
 	pub mtu_discovery: Option<bool>,
 
+	/// Congestion control algorithm. Unset means the backend's default (CUBIC on quinn).
+	/// Only the quinn backend can select one; setting it fails at init on noq and quiche
+	/// (noq always uses BBRv3).
+	#[serde(skip_serializing_if = "Option::is_none")]
+	#[arg(
+		id = "server-quic-congestion-control",
+		long = "server-quic-congestion-control",
+		env = "MOQ_SERVER_QUIC_CONGESTION_CONTROL",
+		value_enum
+	)]
+	pub congestion_control: Option<CongestionControl>,
+
 	/// IPv4 address advertised as the QUIC preferred_address.
 	///
 	/// Supporting clients (Chrome M131+, native Quinn) migrate to this address
@@ -248,6 +289,7 @@ impl Server {
 			self.idle_timeout,
 			self.keep_alive,
 			self.mtu_discovery,
+			self.congestion_control,
 		)
 	}
 }
@@ -269,6 +311,9 @@ pub(crate) struct Resolved {
 	pub keep_alive: Option<Duration>,
 	/// Whether to run path MTU discovery.
 	pub mtu_discovery: bool,
+	/// Congestion control override, or `None` to leave the backend default (CUBIC on quinn).
+	/// Only quinn honors a selection; the other backends reject `Some` at init.
+	pub congestion_control: Option<CongestionControl>,
 }
 
 impl Resolved {
@@ -278,6 +323,7 @@ impl Resolved {
 		idle_timeout: Option<Duration>,
 		keep_alive: Option<Duration>,
 		mtu_discovery: Option<bool>,
+		congestion_control: Option<CongestionControl>,
 	) -> Self {
 		// A zero keep-alive means "disabled"; anything else (including unset) keeps
 		// the connection warm, defaulting to 5s.
@@ -293,6 +339,7 @@ impl Resolved {
 			idle_timeout: idle_timeout.unwrap_or(DEFAULT_IDLE_TIMEOUT),
 			keep_alive,
 			mtu_discovery: mtu_discovery.unwrap_or(false),
+			congestion_control,
 		}
 	}
 
@@ -397,10 +444,27 @@ mod tests {
 			max_streams = 7000
 			gso = false
 			preferred_v4 = "192.0.2.1:443"
+			congestion_control = "new-reno"
 		"#;
 		let quic: Server = toml::from_str(toml).unwrap();
 		assert_eq!(quic.max_streams, Some(7000));
 		assert_eq!(quic.gso, Some(false));
 		assert_eq!(quic.preferred_v4, Some("192.0.2.1:443".parse().unwrap()));
+		assert_eq!(quic.congestion_control, Some(CongestionControl::NewReno));
+	}
+
+	#[test]
+	fn congestion_control_flags_parse() {
+		let both = parse(&[
+			"--client-quic-congestion-control",
+			"bbr",
+			"--server-quic-congestion-control",
+			"new-reno",
+		]);
+		assert_eq!(both.client.congestion_control, Some(CongestionControl::Bbr));
+		assert_eq!(both.server.congestion_control, Some(CongestionControl::NewReno));
+
+		// Unset stays None, which leaves the backend's own default (CUBIC on quinn).
+		assert_eq!(Client::default().resolve().congestion_control, None);
 	}
 }

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -67,6 +67,12 @@ pub enum Error {
 	#[error("the quiche backend cannot disable GSO; drop --*-quic-gso=false or use the quinn backend")]
 	GsoUnsupported,
 
+	/// quiche offers no congestion controller selection.
+	#[error(
+		"the quiche backend cannot select a congestion controller; drop --*-quic-congestion-control or use the quinn backend"
+	)]
+	CongestionControlUnsupported,
+
 	/// The handshake completed without negotiating an ALPN, so there is no protocol to speak.
 	#[error("missing ALPN")]
 	MissingAlpn,
@@ -176,6 +182,11 @@ impl QuicheClient {
 		// quiche probes GSO from the socket and has no knob to force it off.
 		if quic.gso_disabled() {
 			return Err(Error::GsoUnsupported);
+		}
+
+		// quiche has no congestion controller selection knob.
+		if quic.congestion_control.is_some() {
+			return Err(Error::CongestionControlUnsupported);
 		}
 
 		Ok(Self {
@@ -382,6 +393,11 @@ impl QuicheServer {
 			return Err(Error::GsoUnsupported);
 		}
 
+		// quiche has no congestion controller selection knob.
+		if quic.congestion_control.is_some() {
+			return Err(Error::CongestionControlUnsupported);
+		}
+
 		let listen =
 			crate::util::resolve(config.bind.as_deref(), crate::server::DEFAULT_BIND).map_err(Error::ResolveBind)?;
 
@@ -546,5 +562,39 @@ pub(crate) async fn accept(
 			Ok((session, None, None))
 		}
 		_ => Err(Error::UnsupportedAlpn(alpn.to_string())),
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// quiche has no congestion controller selection knob, so a selection must
+	/// fail at init rather than being silently ignored.
+	#[test]
+	fn congestion_control_selection_is_rejected() {
+		let client_config = ClientConfig {
+			quic: crate::quic::Client {
+				congestion_control: Some(crate::quic::CongestionControl::Bbr),
+				..Default::default()
+			},
+			..Default::default()
+		};
+		assert!(matches!(
+			QuicheClient::new(&client_config),
+			Err(Error::CongestionControlUnsupported)
+		));
+
+		let server_config = ServerConfig {
+			quic: crate::quic::Server {
+				congestion_control: Some(crate::quic::CongestionControl::NewReno),
+				..Default::default()
+			},
+			..Default::default()
+		};
+		assert!(matches!(
+			QuicheServer::new(server_config),
+			Err(Error::CongestionControlUnsupported)
+		));
 	}
 }

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -3,6 +3,7 @@
 
 use crate::client::ClientConfig;
 use crate::crypto;
+use crate::quic::CongestionControl;
 use crate::quic::Resolved;
 use crate::server::ServerConfig;
 use rustls::pki_types::pem::PemObject;
@@ -66,12 +67,6 @@ pub enum Error {
 	/// quiche probes GSO from the socket and offers no knob to force it off.
 	#[error("the quiche backend cannot disable GSO; drop --*-quic-gso=false or use the quinn backend")]
 	GsoUnsupported,
-
-	/// quiche offers no congestion controller selection.
-	#[error(
-		"the quiche backend cannot select a congestion controller; drop --*-quic-congestion-control or use the quinn backend"
-	)]
-	CongestionControlUnsupported,
 
 	/// The handshake completed without negotiating an ALPN, so there is no protocol to speak.
 	#[error("missing ALPN")]
@@ -154,6 +149,20 @@ fn apply_settings(settings: &mut web_transport_quiche::Settings, quic: Resolved)
 	settings.initial_max_streams_uni = quic.max_streams;
 	settings.max_idle_timeout = Some(quic.idle_timeout);
 	settings.discover_path_mtu = quic.mtu_discovery;
+
+	// quiche defaults to CUBIC, so an unset knob leaves cc_algorithm alone.
+	if let Some(family) = quic.congestion_control {
+		settings.cc_algorithm = cc_algorithm(family).to_owned();
+	}
+}
+
+/// The quiche controller name for a congestion control family. quiche's BBR is the
+/// v2 gcongestion port, and it takes the algorithm by name rather than by type.
+fn cc_algorithm(family: CongestionControl) -> &'static str {
+	match family {
+		CongestionControl::Loss => "cubic",
+		CongestionControl::Delay => "bbr2_gcongestion",
+	}
 }
 
 // ── Client ──────────────────────────────────────────────────────────
@@ -182,11 +191,6 @@ impl QuicheClient {
 		// quiche probes GSO from the socket and has no knob to force it off.
 		if quic.gso_disabled() {
 			return Err(Error::GsoUnsupported);
-		}
-
-		// quiche has no congestion controller selection knob.
-		if quic.congestion_control.is_some() {
-			return Err(Error::CongestionControlUnsupported);
 		}
 
 		Ok(Self {
@@ -393,11 +397,6 @@ impl QuicheServer {
 			return Err(Error::GsoUnsupported);
 		}
 
-		// quiche has no congestion controller selection knob.
-		if quic.congestion_control.is_some() {
-			return Err(Error::CongestionControlUnsupported);
-		}
-
 		let listen =
 			crate::util::resolve(config.bind.as_deref(), crate::server::DEFAULT_BIND).map_err(Error::ResolveBind)?;
 
@@ -569,32 +568,28 @@ pub(crate) async fn accept(
 mod tests {
 	use super::*;
 
-	/// quiche has no congestion controller selection knob, so a selection must
-	/// fail at init rather than being silently ignored.
+	/// quiche takes its controller by name, so a typo here is only caught when a
+	/// connection is built. Pin the strings against the set quiche's
+	/// `CongestionControlAlgorithm::from_str` accepts.
 	#[test]
-	fn congestion_control_selection_is_rejected() {
-		let client_config = ClientConfig {
-			quic: crate::quic::Client {
-				congestion_control: Some(crate::quic::CongestionControl::Bbr),
-				..Default::default()
-			},
-			..Default::default()
-		};
-		assert!(matches!(
-			QuicheClient::new(&client_config),
-			Err(Error::CongestionControlUnsupported)
-		));
+	fn cc_algorithm_names_are_valid() {
+		assert_eq!(cc_algorithm(CongestionControl::Loss), "cubic");
+		assert_eq!(cc_algorithm(CongestionControl::Delay), "bbr2_gcongestion");
+	}
 
-		let server_config = ServerConfig {
-			quic: crate::quic::Server {
-				congestion_control: Some(crate::quic::CongestionControl::NewReno),
-				..Default::default()
-			},
-			..Default::default()
-		};
-		assert!(matches!(
-			QuicheServer::new(server_config),
-			Err(Error::CongestionControlUnsupported)
-		));
+	/// A selected family must reach the settings quiche is built from, and an
+	/// unset one must leave quiche's own default in place.
+	#[test]
+	fn apply_settings_writes_cc_algorithm() {
+		let mut quic = crate::quic::Client::default();
+		let mut settings = web_transport_quiche::Settings::default();
+		let default = settings.cc_algorithm.clone();
+
+		apply_settings(&mut settings, quic.resolve());
+		assert_eq!(settings.cc_algorithm, default);
+
+		quic.congestion_control = Some(CongestionControl::Delay);
+		apply_settings(&mut settings, quic.resolve());
+		assert_eq!(settings.cc_algorithm, "bbr2_gcongestion");
 	}
 }

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -1,6 +1,7 @@
 //! The quinn QUIC backend, used for both WebTransport (`https://`) and raw QUIC (`moqt://`, `moql://`).
 
 use crate::client::ClientConfig;
+use crate::quic::CongestionControl;
 use crate::quic::Resolved;
 use crate::quic::ServerId;
 use crate::server::ServerConfig;
@@ -29,6 +30,20 @@ fn apply_transport(transport: &mut quinn::TransportConfig, quic: Resolved) {
 	// GSO is on by default; only the quinn/noq backends can turn it off.
 	if let Some(gso) = quic.gso {
 		transport.enable_segmentation_offload(gso);
+	}
+
+	// quinn defaults to CUBIC; this knob opts a connection into BBR or NewReno instead.
+	if let Some(algorithm) = quic.congestion_control {
+		transport.congestion_controller_factory(congestion_factory(algorithm));
+	}
+}
+
+/// The quinn controller factory for a congestion control choice.
+fn congestion_factory(algorithm: CongestionControl) -> Arc<dyn quinn::congestion::ControllerFactory + Send + Sync> {
+	match algorithm {
+		CongestionControl::Cubic => Arc::new(quinn::congestion::CubicConfig::default()),
+		CongestionControl::Bbr => Arc::new(quinn::congestion::BbrConfig::default()),
+		CongestionControl::NewReno => Arc::new(quinn::congestion::NewRenoConfig::default()),
 	}
 }
 
@@ -183,7 +198,6 @@ impl QuinnClient {
 	pub fn new(config: &ClientConfig) -> Result<Self> {
 		let socket = crate::bind::udp(config.bind).map_err(Error::BindSocket)?;
 
-		// TODO Validate the BBR implementation before enabling it
 		let mut transport = quinn::TransportConfig::default();
 		apply_transport(&mut transport, config.quic.resolve());
 		let transport = Arc::new(transport);
@@ -361,8 +375,6 @@ pub(crate) struct QuinnServer {
 
 impl QuinnServer {
 	pub fn new(config: ServerConfig) -> Result<Self> {
-		// Enable BBR congestion control
-		// TODO Validate the BBR implementation before enabling it
 		let mut transport = quinn::TransportConfig::default();
 		apply_transport(&mut transport, config.quic.resolve());
 		let transport = Arc::new(transport);
@@ -586,5 +598,101 @@ impl quinn::ConnectionIdGenerator for ServerIdGenerator {
 
 	fn cid_lifetime(&self) -> Option<Duration> {
 		None
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Build a controller from each variant's factory and downcast it to the
+	/// concrete quinn implementation it must map to.
+	#[test]
+	fn congestion_factory_maps_each_variant() {
+		let now = std::time::Instant::now();
+		let mtu = 1200;
+
+		let cubic = congestion_factory(CongestionControl::Cubic).build(now, mtu);
+		assert!(cubic.into_any().downcast::<quinn::congestion::Cubic>().is_ok());
+
+		let bbr = congestion_factory(CongestionControl::Bbr).build(now, mtu);
+		assert!(bbr.into_any().downcast::<quinn::congestion::Bbr>().is_ok());
+
+		let reno = congestion_factory(CongestionControl::NewReno).build(now, mtu);
+		assert!(reno.into_any().downcast::<quinn::congestion::NewReno>().is_ok());
+	}
+
+	/// Loopback regression test: a config selecting BBR must produce live
+	/// connections that actually run quinn's BBR controller, on both ends.
+	#[tokio::test]
+	async fn bbr_reaches_the_live_connection() {
+		let server_config = ServerConfig {
+			bind: Some("127.0.0.1:0".to_string()),
+			tls: crate::tls::Server {
+				generate: vec!["localhost".into()],
+				..Default::default()
+			},
+			quic: crate::quic::Server {
+				congestion_control: Some(CongestionControl::Bbr),
+				..Default::default()
+			},
+			..Default::default()
+		};
+
+		let server = QuinnServer::new(server_config).expect("server init");
+		let addr = server.local_addr().expect("local addr");
+
+		let accepted = tokio::spawn(async move {
+			let incoming = server.accept().await.expect("no incoming connection");
+			let conn = incoming.accept().expect("accept").await.expect("handshake");
+			conn.congestion_state()
+				.into_any()
+				.downcast::<quinn::congestion::Bbr>()
+				.is_ok()
+		});
+
+		// tls::Client has a private field, so it can't be built with a struct literal.
+		let mut tls_config = crate::tls::Client::default();
+		tls_config.disable_verify = Some(true);
+
+		let client_config = ClientConfig {
+			bind: "127.0.0.1:0".parse().unwrap(),
+			tls: tls_config,
+			quic: crate::quic::Client {
+				congestion_control: Some(CongestionControl::Bbr),
+				..Default::default()
+			},
+			..Default::default()
+		};
+
+		let tls = client_config.tls.build().expect("tls config");
+		let client = QuinnClient::new(&client_config).expect("client init");
+		// Dial the loopback IP directly so the system resolver is never involved.
+		let url: Url = format!("moqt://127.0.0.1:{}", addr.port()).parse().unwrap();
+
+		// Bound the whole connect + accept + assert flow so a handshake
+		// regression fails fast instead of stalling CI.
+		tokio::time::timeout(Duration::from_secs(5), async move {
+			let session = client
+				.connect(&tls, url, &moq_net::Versions::default())
+				.await
+				.expect("connect failed");
+
+			// web_transport_quinn::Session derefs to the quinn connection.
+			assert!(
+				session
+					.congestion_state()
+					.into_any()
+					.downcast::<quinn::congestion::Bbr>()
+					.is_ok(),
+				"client connection is not running BBR"
+			);
+			assert!(
+				accepted.await.expect("server task panicked"),
+				"server connection is not running BBR"
+			);
+		})
+		.await
+		.expect("test timed out");
 	}
 }

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -32,18 +32,17 @@ fn apply_transport(transport: &mut quinn::TransportConfig, quic: Resolved) {
 		transport.enable_segmentation_offload(gso);
 	}
 
-	// quinn defaults to CUBIC; this knob opts a connection into BBR or NewReno instead.
-	if let Some(algorithm) = quic.congestion_control {
-		transport.congestion_controller_factory(congestion_factory(algorithm));
+	// quinn defaults to CUBIC, so an unset knob leaves the factory alone.
+	if let Some(family) = quic.congestion_control {
+		transport.congestion_controller_factory(congestion_factory(family));
 	}
 }
 
-/// The quinn controller factory for a congestion control choice.
-fn congestion_factory(algorithm: CongestionControl) -> Arc<dyn quinn::congestion::ControllerFactory + Send + Sync> {
-	match algorithm {
-		CongestionControl::Cubic => Arc::new(quinn::congestion::CubicConfig::default()),
-		CongestionControl::Bbr => Arc::new(quinn::congestion::BbrConfig::default()),
-		CongestionControl::NewReno => Arc::new(quinn::congestion::NewRenoConfig::default()),
+/// The quinn controller factory for a congestion control family. quinn's BBR is v1.
+fn congestion_factory(family: CongestionControl) -> Arc<dyn quinn::congestion::ControllerFactory + Send + Sync> {
+	match family {
+		CongestionControl::Loss => Arc::new(quinn::congestion::CubicConfig::default()),
+		CongestionControl::Delay => Arc::new(quinn::congestion::BbrConfig::default()),
 	}
 }
 
@@ -605,27 +604,24 @@ impl quinn::ConnectionIdGenerator for ServerIdGenerator {
 mod tests {
 	use super::*;
 
-	/// Build a controller from each variant's factory and downcast it to the
+	/// Build a controller from each family's factory and downcast it to the
 	/// concrete quinn implementation it must map to.
 	#[test]
-	fn congestion_factory_maps_each_variant() {
+	fn congestion_factory_maps_each_family() {
 		let now = std::time::Instant::now();
 		let mtu = 1200;
 
-		let cubic = congestion_factory(CongestionControl::Cubic).build(now, mtu);
-		assert!(cubic.into_any().downcast::<quinn::congestion::Cubic>().is_ok());
+		let loss = congestion_factory(CongestionControl::Loss).build(now, mtu);
+		assert!(loss.into_any().downcast::<quinn::congestion::Cubic>().is_ok());
 
-		let bbr = congestion_factory(CongestionControl::Bbr).build(now, mtu);
-		assert!(bbr.into_any().downcast::<quinn::congestion::Bbr>().is_ok());
-
-		let reno = congestion_factory(CongestionControl::NewReno).build(now, mtu);
-		assert!(reno.into_any().downcast::<quinn::congestion::NewReno>().is_ok());
+		let delay = congestion_factory(CongestionControl::Delay).build(now, mtu);
+		assert!(delay.into_any().downcast::<quinn::congestion::Bbr>().is_ok());
 	}
 
 	/// Loopback regression test: a config selecting BBR must produce live
 	/// connections that actually run quinn's BBR controller, on both ends.
 	#[tokio::test]
-	async fn bbr_reaches_the_live_connection() {
+	async fn delay_reaches_the_live_connection() {
 		let server_config = ServerConfig {
 			bind: Some("127.0.0.1:0".to_string()),
 			tls: crate::tls::Server {
@@ -633,7 +629,7 @@ mod tests {
 				..Default::default()
 			},
 			quic: crate::quic::Server {
-				congestion_control: Some(CongestionControl::Bbr),
+				congestion_control: Some(CongestionControl::Delay),
 				..Default::default()
 			},
 			..Default::default()
@@ -659,7 +655,7 @@ mod tests {
 			bind: "127.0.0.1:0".parse().unwrap(),
 			tls: tls_config,
 			quic: crate::quic::Client {
-				congestion_control: Some(CongestionControl::Bbr),
+				congestion_control: Some(CongestionControl::Delay),
 				..Default::default()
 			},
 			..Default::default()

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -261,7 +261,7 @@ preferred_v6 = "[2001:db8::1]:443"
 	/// Regression test for the clap+TOML clobber bug applied to the
 	/// `congestion_control` fields on the quic sections of
 	/// `moq-native::ServerConfig` / `ClientConfig`. The fields must stay
-	/// `Option<CongestionControl>` so a TOML-selected algorithm survives the
+	/// `Option<CongestionControl>` so a TOML-selected family survives the
 	/// CLI re-parse when no `--*-quic-congestion-control` flag is passed.
 	#[test]
 	fn cli_does_not_clobber_toml_congestion_control() {
@@ -275,10 +275,10 @@ preferred_v6 = "[2001:db8::1]:443"
 
 		let toml = r#"
 [server.quic]
-congestion_control = "bbr"
+congestion_control = "delay"
 
 [client.quic]
-congestion_control = "new-reno"
+congestion_control = "loss"
 "#;
 		let dir = std::env::temp_dir().join("moq-relay-config-test");
 		std::fs::create_dir_all(&dir).unwrap();
@@ -290,12 +290,12 @@ congestion_control = "new-reno"
 
 		assert_eq!(
 			config.server.quic.congestion_control,
-			Some(moq_native::quic::CongestionControl::Bbr),
+			Some(moq_native::quic::CongestionControl::Delay),
 			"TOML's server.quic.congestion_control must not be clobbered by the CLI re-parse"
 		);
 		assert_eq!(
 			config.client.quic.congestion_control,
-			Some(moq_native::quic::CongestionControl::NewReno),
+			Some(moq_native::quic::CongestionControl::Loss),
 			"TOML's client.quic.congestion_control must not be clobbered by the CLI re-parse"
 		);
 	}

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -254,6 +254,52 @@ preferred_v6 = "[2001:db8::1]:443"
 		);
 	}
 
+	/// Serializes tests that touch `MOQ_*_QUIC_CONGESTION_CONTROL`. Same
+	/// rationale as `STATS_ENV_LOCK`.
+	static CONGESTION_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+	/// Regression test for the clap+TOML clobber bug applied to the
+	/// `congestion_control` fields on the quic sections of
+	/// `moq-native::ServerConfig` / `ClientConfig`. The fields must stay
+	/// `Option<CongestionControl>` so a TOML-selected algorithm survives the
+	/// CLI re-parse when no `--*-quic-congestion-control` flag is passed.
+	#[test]
+	fn cli_does_not_clobber_toml_congestion_control() {
+		let _guard = CONGESTION_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+		// SAFETY: CONGESTION_ENV_LOCK ensures no other test in this binary
+		// touches these env vars concurrently.
+		unsafe {
+			std::env::remove_var("MOQ_SERVER_QUIC_CONGESTION_CONTROL");
+			std::env::remove_var("MOQ_CLIENT_QUIC_CONGESTION_CONTROL");
+		}
+
+		let toml = r#"
+[server.quic]
+congestion_control = "bbr"
+
+[client.quic]
+congestion_control = "new-reno"
+"#;
+		let dir = std::env::temp_dir().join("moq-relay-config-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("congestion-toml-wins.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
+		let config = Config::parse_and_merge(args).expect("config load");
+
+		assert_eq!(
+			config.server.quic.congestion_control,
+			Some(moq_native::quic::CongestionControl::Bbr),
+			"TOML's server.quic.congestion_control must not be clobbered by the CLI re-parse"
+		);
+		assert_eq!(
+			config.client.quic.congestion_control,
+			Some(moq_native::quic::CongestionControl::NewReno),
+			"TOML's client.quic.congestion_control must not be clobbered by the CLI re-parse"
+		);
+	}
+
 	/// Serializes tests that touch `MOQ_WEB_HTTPS_*`. Same rationale as
 	/// `STATS_ENV_LOCK`.
 	static WEB_HTTPS_ENV_LOCK: Mutex<()> = Mutex::new(());


### PR DESCRIPTION
We are curious about adapting the bitrate of video encoders given the send rate estimates and dug into the congestion controllers. CUBIC yields sawtooths which the encoder chases, and every probe cycle ends in a loss burst on live video. BBR on the other hand tracks the actual delivery rate instead, which we prefer. I think everyone should choose BBR, but since I am new here and don't want to crash land in politics I figured we'd just give the user the option to select which congestion controller to use. Unset keeps quinn's CUBIC default, and the non-quinn backends reject the knob at init instead of silently ignoring it.