### PR TITLE
feat(mux): preserve the DVB service layer across the TS round-trip

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -371,6 +371,12 @@ cues, teletext, DVB subtitles, ...) are carried verbatim too, one MoQ track per
 PID, described in the catalog `mpegts` section, and survive `import ts` /
 `export ts` end-to-end.
 
+The DVB service layer rides the same `mpegts` section: the transport/service
+identity (transport stream ID, service number, PMT PID) plus the SDT and NIT
+tables are captured on import and re-emitted on export, so the service name,
+provider, type, and network survive the round-trip. Regenerated tables (TDT/TOT)
+and EPG (EIT) are not carried.
+
 ### FLV
 
 ```bash

--- a/rs/moq-mux/src/container/ts/catalog.rs
+++ b/rs/moq-mux/src/container/ts/catalog.rs
@@ -4,9 +4,10 @@
 //! back to MPEG-TS that doesn't belong in the codec-neutral media configs: one
 //! entry per track (its original PID and PMT descriptors), a `verbatim` carriage
 //! record for every elementary stream we don't decode (SCTE-35, teletext, DVB
-//! subtitles, private data, ...), and the program-level PMT descriptors. Demuxed
-//! media tracks keep their codec config in the base `video`/`audio` sections; only
-//! their MPEG-TS identity lands here.
+//! subtitles, private data, ...), the program-level PMT descriptors, and the DVB
+//! service layer ([`Service`]: transport/service identity plus the SDT/NIT tables).
+//! Demuxed media tracks keep their codec config in the base `video`/`audio`
+//! sections; only their MPEG-TS identity lands here.
 
 use std::collections::BTreeMap;
 
@@ -16,6 +17,15 @@ use serde_with::base64::Base64;
 use serde_with::serde_as;
 
 use crate::catalog::hang::CatalogExt;
+
+/// PID of the DVB Network Information Table (NIT).
+pub(super) const NIT_PID: u16 = 0x0010;
+/// PID of the DVB Service Description Table (SDT).
+pub(super) const SDT_PID: u16 = 0x0011;
+/// `table_id` of the NIT for the actual network (NIT Actual).
+pub(super) const NIT_ACTUAL_TABLE_ID: u8 = 0x40;
+/// `table_id` of the SDT for the actual transport stream (SDT Actual).
+pub(super) const SDT_ACTUAL_TABLE_ID: u8 = 0x42;
 
 /// The `mpegts` catalog section.
 ///
@@ -34,13 +44,57 @@ pub struct Mpegts {
 	/// re-emits these; the SCTE-35 'CUEI' registration is derived when absent.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub program_descriptors: Vec<Descriptor>,
+
+	/// The DVB service layer (transport/service identity plus the SDT/NIT tables).
+	/// Present only for a source that carries it (a TS input); omitted for media-only
+	/// broadcasts, so export then synthesizes a minimal identity.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub service: Option<Service>,
 }
 
 impl Mpegts {
 	/// True when the section carries nothing, so it's omitted from the catalog.
 	pub fn is_empty(&self) -> bool {
-		self.tracks.is_empty() && self.program_descriptors.is_empty()
+		self.tracks.is_empty() && self.program_descriptors.is_empty() && self.service.is_none()
 	}
+}
+
+/// The DVB service layer of a TS program.
+///
+/// Two kinds of data: the small structured identity export needs to rebuild a
+/// consistent PAT/PMT (the transport stream, service, and PMT PID), and the
+/// standalone SI tables ([`sdt`](Self::sdt), [`nit`](Self::nit)) carried verbatim
+/// so the service name, provider, type, original network, and network description
+/// survive the round-trip byte-for-byte. Regenerated tables (TDT/TOT) and EPG (EIT)
+/// are out of scope; they are live or dynamic, not static identity.
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct Service {
+	/// Transport stream ID from the PAT, preserved so the rebuilt PAT stays
+	/// consistent with the carried SDT/NIT.
+	pub transport_stream_id: u16,
+
+	/// Program (service) number from the PAT. Re-emitted as the PAT program number
+	/// and the PMT `program_number`.
+	pub service_id: u16,
+
+	/// Original PMT PID from the PAT, preserved so PMT cross-references survive.
+	pub pmt_pid: u16,
+
+	/// SDT Actual section (`table_id` 0x42), carried verbatim and re-emitted on
+	/// PID 0x0011. Carries the service name, provider, type, and original network ID.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	#[serde_as(as = "Option<Base64>")]
+	pub sdt: Option<Bytes>,
+
+	/// NIT Actual section (`table_id` 0x40), carried verbatim and re-emitted on
+	/// PID 0x0010. Describes the originating delivery network, so it is preserved
+	/// rather than synthesized (an operator decision).
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	#[serde_as(as = "Option<Base64>")]
+	pub nit: Option<Bytes>,
 }
 
 /// One track's MPEG-TS identity and signaling.
@@ -225,5 +279,29 @@ mod test {
 
 		let parsed: Ext = serde_json::from_str(&json).unwrap();
 		assert_eq!(parsed.mpegts, mpegts, "mpegts section round-trips");
+	}
+
+	#[test]
+	fn service_roundtrip() {
+		let mpegts = Mpegts {
+			service: Some(Service {
+				transport_stream_id: 0x1234,
+				service_id: 1,
+				pmt_pid: 0x0064,
+				sdt: Some(Bytes::from_static(b"\x42\xf0\x25")),
+				nit: None,
+				..Default::default()
+			}),
+			..Default::default()
+		};
+		assert!(!mpegts.is_empty(), "a service record is not empty");
+
+		let json = serde_json::to_string(&Ext { mpegts: mpegts.clone() }).unwrap();
+		// The SDT section is base64; the absent NIT is omitted.
+		assert!(json.contains("\"sdt\""), "sdt present: {json}");
+		assert!(!json.contains("\"nit\""), "absent nit omitted: {json}");
+
+		let parsed: Ext = serde_json::from_str(&json).unwrap();
+		assert_eq!(parsed.mpegts, mpegts, "service section round-trips");
 	}
 }

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -63,6 +63,10 @@ pub struct Export<E: catalog::Catalog = ()> {
 	counters: HashMap<u16, ContinuityCounter>,
 	/// PMT program-level descriptors captured on import, re-emitted in the PMT.
 	program_descriptors: Vec<catalog::Descriptor>,
+	/// DVB service layer captured on import: transport/service identity (rebuilds a
+	/// consistent PAT/PMT) plus the SDT/NIT sections re-emitted verbatim. `None` for
+	/// a media-only source, so a minimal identity is synthesized instead.
+	service: Option<catalog::Service>,
 
 	/// Program tables, built once the track layout is known.
 	psi: Option<Psi>,
@@ -136,6 +140,9 @@ struct Psi {
 	pat: Pat,
 	pmt: Pmt,
 	pcr_pid: u16,
+	/// PID the PMT rides on: the source's original (preserved from the service
+	/// record) or the synthesized [`PMT_PID`] for a media-only source.
+	pmt_pid: u16,
 }
 
 /// Per-frame PES descriptor (everything but the payload bytes).
@@ -192,6 +199,7 @@ impl<E: catalog::Catalog> Export<E> {
 			tracks: HashMap::new(),
 			counters: HashMap::new(),
 			program_descriptors: Vec::new(),
+			service: None,
 			psi: None,
 			last_psi: None,
 			video_start: None,
@@ -331,6 +339,7 @@ impl<E: catalog::Catalog> Export<E> {
 		// empty default: no verbatim streams, no preserved PIDs/descriptors).
 		let mpegts = catalog.mpegts_mut().cloned().unwrap_or_default();
 		self.program_descriptors = mpegts.program_descriptors.clone();
+		self.service = mpegts.service.clone();
 
 		// The desired track set: media renditions plus the verbatim streams.
 		let mut active: BTreeMap<String, ()> = BTreeMap::new();
@@ -368,7 +377,7 @@ impl<E: catalog::Catalog> Export<E> {
 		// PIDs, descriptors, and stream_ids across several catalog publishes, so this
 		// runs every snapshot until the PMT is built and the tracks below are
 		// *refreshed*, not latched from the first (partial) snapshot.
-		let mut used: Vec<u16> = vec![0x0000, PMT_PID, 0x1FFF];
+		let mut used: Vec<u16> = vec![0x0000, self.pmt_pid(), 0x1FFF];
 		let mut pids: BTreeMap<String, u16> = BTreeMap::new();
 		for name in active.keys() {
 			if let Some(pid) = mpegts.tracks.get(name).map(|t| t.pid)
@@ -510,6 +519,16 @@ impl<E: catalog::Catalog> Export<E> {
 			.min()
 	}
 
+	/// PID the PMT rides on: the source's original (preserved in the service record),
+	/// or the synthesized [`PMT_PID`] for a media-only source or an invalid (zero) value.
+	fn pmt_pid(&self) -> u16 {
+		self.service
+			.as_ref()
+			.map(|s| s.pmt_pid)
+			.filter(|&pid| pid != 0)
+			.unwrap_or(PMT_PID)
+	}
+
 	/// Build the PAT/PMT once every track's PID and codec is known.
 	fn build_psi(&mut self) -> anyhow::Result<()> {
 		// Order tracks by PID for a stable layout; first video track carries the PCR.
@@ -616,23 +635,39 @@ impl<E: catalog::Catalog> Export<E> {
 			Vec::new()
 		};
 
+		// Preserve the source's transport/service identity so the rebuilt PAT/PMT stay
+		// consistent with the carried SDT/NIT; synthesize a minimal identity otherwise.
+		let pmt_pid = self.pmt_pid();
+		let transport_stream_id = self.service.as_ref().map(|s| s.transport_stream_id).unwrap_or(1);
+		let service_id = self
+			.service
+			.as_ref()
+			.map(|s| s.service_id)
+			.filter(|&id| id != 0)
+			.unwrap_or(1);
+
 		let pat = Pat {
-			transport_stream_id: 1,
+			transport_stream_id,
 			version_number: VersionNumber::default(),
 			table: vec![ProgramAssociation {
-				program_num: 1,
-				program_map_pid: Pid::new(PMT_PID)?,
+				program_num: service_id,
+				program_map_pid: Pid::new(pmt_pid)?,
 			}],
 		};
 		let pmt = Pmt {
-			program_num: 1,
+			program_num: service_id,
 			pcr_pid: Some(Pid::new(pcr_pid)?),
 			version_number: VersionNumber::default(),
 			program_info,
 			es_info,
 		};
 
-		self.psi = Some(Psi { pat, pmt, pcr_pid });
+		self.psi = Some(Psi {
+			pat,
+			pmt,
+			pcr_pid,
+			pmt_pid,
+		});
 		Ok(())
 	}
 
@@ -705,10 +740,23 @@ impl<E: catalog::Catalog> Export<E> {
 		let psi_due = psi_due(frame.timestamp, self.last_psi);
 		if (is_video && frame.keyframe) || psi_due {
 			let psi = self.psi.as_ref().context("PSI not built")?;
+			let pmt_pid = psi.pmt_pid;
 			let pat = TsPayload::Pat(psi.pat.clone());
 			let pmt = TsPayload::Pmt(psi.pmt.clone());
 			self.write_packet(&mut out, Pid::PAT, None, pat)?;
-			self.write_packet(&mut out, PMT_PID, None, pmt)?;
+			self.write_packet(&mut out, pmt_pid, None, pmt)?;
+
+			// Re-emit the DVB service layer (SDT, NIT) verbatim alongside the PSI, so the
+			// service name/provider/network survive. Regenerated tables (TDT/TOT) and EPG
+			// (EIT) are out of scope.
+			let sdt = self.service.as_ref().and_then(|s| s.sdt.clone());
+			let nit = self.service.as_ref().and_then(|s| s.nit.clone());
+			if let Some(sdt) = sdt {
+				self.write_section(&mut out, catalog::SDT_PID, &sdt)?;
+			}
+			if let Some(nit) = nit {
+				self.write_section(&mut out, catalog::NIT_PID, &nit)?;
+			}
 			self.last_psi = Some(frame.timestamp);
 		}
 

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1286,6 +1286,40 @@ fn si_packet(pid: u16, section: &[u8]) -> Vec<u8> {
 	p
 }
 
+/// Split a complete section across several 188-byte TS packets on `pid`: a PUSI packet
+/// (pointer_field 0) carrying the head, then continuation packets (PUSI clear, continuity
+/// counter advancing) for the rest, the last padded with 0xff stuffing. Unlike `si_packet`
+/// this reaches the multi-packet reassembly path (PUSI + continuity across packets).
+fn si_packets_multi(pid: u16, section: &[u8]) -> Vec<u8> {
+	let mut out = Vec::new();
+	let mut cc = 0u8;
+	// First packet: PUSI set, pointer_field 0, then as much of the section as fits.
+	let mut first = vec![
+		0x47,
+		0x40 | ((pid >> 8) as u8 & 0x1f),
+		(pid & 0xff) as u8,
+		0x10 | cc,
+		0x00,
+	];
+	let head = section.len().min(188 - first.len());
+	first.extend_from_slice(&section[..head]);
+	first.resize(188, 0xff);
+	out.extend_from_slice(&first);
+
+	// Continuation packets: PUSI clear, continuity counter incremented per payload packet.
+	let mut pos = head;
+	while pos < section.len() {
+		cc = (cc + 1) & 0x0f;
+		let mut p = vec![0x47, (pid >> 8) as u8 & 0x1f, (pid & 0xff) as u8, 0x10 | cc];
+		let take = (section.len() - pos).min(188 - p.len());
+		p.extend_from_slice(&section[pos..pos + take]);
+		p.resize(188, 0xff);
+		out.extend_from_slice(&p);
+		pos += take;
+	}
+	out
+}
+
 /// Decode an SDT Actual section's first service: `(service_type, provider, name)` from the
 /// service_descriptor (tag 0x48). Enough to prove the service identity survived, no more.
 fn parse_sdt_service(sec: &[u8]) -> (u8, String, String) {
@@ -1395,6 +1429,35 @@ async fn service_layer_survives_roundtrip() {
 	assert_eq!(service2.pmt_pid, service.pmt_pid, "PMT PID survived");
 	assert_eq!(service2.sdt, service.sdt, "SDT survived byte-for-byte");
 	assert_eq!(service2.nit, service.nit, "NIT survived byte-for-byte");
+}
+
+/// A DVB SI section larger than one TS packet must be reassembled and captured verbatim.
+/// `si_packet` only covers a single-packet section; a real SDT with several services (or a
+/// NIT) spans packets, exercising the `SectionReassembler` PUSI + continuity path that
+/// feeds `service.sdt`. The body is arbitrary here (capture is verbatim, not parsed).
+#[test]
+fn multi_packet_si_section_is_captured() {
+	// 400-byte body forces the SDT Actual across three TS packets (183 + 184 + rest).
+	let body: Vec<u8> = (0..400u16).map(|i| i as u8).collect();
+	let sdt = make_section(0x42, &body);
+	let input = si_packets_multi(0x0011, &sdt);
+	assert!(input.len() > 188, "the SDT must span more than one TS packet");
+
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let _consumer = broadcast.consume();
+	let catalog =
+		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
+	import.decode(&BytesMut::from(&input[..])).unwrap();
+	import.finish().unwrap();
+
+	let service = catalog.snapshot().mpegts.service.clone().expect("a service record");
+	assert_eq!(
+		service.sdt.as_deref(),
+		Some(&sdt[..]),
+		"the multi-packet SDT was reassembled and captured byte-for-byte"
+	);
 }
 
 /// A raw Opus packet: a one-byte TOC (config 1 = SILK NB 20 ms, stereo, code 0) plus

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1262,6 +1262,141 @@ async fn scte35_fixtures_survive_roundtrip() {
 	}
 }
 
+/// Build a PSI section: `table_id`, the 12-bit `section_length` (covering `body` plus a
+/// 4-byte CRC), then `body` and a dummy CRC. The reassembler carries it verbatim and
+/// never validates the CRC, so the bytes only need a self-consistent length.
+fn make_section(table_id: u8, body: &[u8]) -> Vec<u8> {
+	let section_length = body.len() + 4;
+	let mut s = vec![
+		table_id,
+		0xb0 | ((section_length >> 8) as u8 & 0x0f),
+		(section_length & 0xff) as u8,
+	];
+	s.extend_from_slice(body);
+	s.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+	s
+}
+
+/// Wrap a complete section in one PUSI TS packet on `pid` (pointer_field 0), padded to 188.
+fn si_packet(pid: u16, section: &[u8]) -> Vec<u8> {
+	let mut p = vec![0x47, 0x40 | ((pid >> 8) as u8 & 0x1f), (pid & 0xff) as u8, 0x10, 0x00];
+	p.extend_from_slice(section);
+	assert!(p.len() <= 188, "section overflows one TS packet");
+	p.resize(188, 0xff);
+	p
+}
+
+/// Decode an SDT Actual section's first service: `(service_type, provider, name)` from the
+/// service_descriptor (tag 0x48). Enough to prove the service identity survived, no more.
+fn parse_sdt_service(sec: &[u8]) -> (u8, String, String) {
+	// header(8) + first service loop entry: service_id(2), flags(1), running/free + desc_len(2).
+	let desc_loop_len = (((sec[11 + 3] & 0x0f) as usize) << 8) | sec[11 + 4] as usize;
+	let mut d = 11 + 5;
+	let end = d + desc_loop_len;
+	while d < end {
+		let (tag, len) = (sec[d], sec[d + 1] as usize);
+		let body = &sec[d + 2..d + 2 + len];
+		if tag == 0x48 {
+			let service_type = body[0];
+			let prov_len = body[1] as usize;
+			let provider = String::from_utf8_lossy(&body[2..2 + prov_len]).into_owned();
+			let name_len = body[2 + prov_len] as usize;
+			let name = String::from_utf8_lossy(&body[3 + prov_len..3 + prov_len + name_len]).into_owned();
+			return (service_type, provider, name);
+		}
+		d += 2 + len;
+	}
+	panic!("SDT service_descriptor (0x48) not found");
+}
+
+/// The DVB service layer (SDT + NIT + transport/service identity) must survive
+/// TS -> MoQ -> TS. `bbb.ts` carries a real ffmpeg SDT (service "Service01" / provider
+/// "FFmpeg"); no fixture carries a NIT, so a synthetic one is injected on PID 0x0010.
+/// After the round-trip the SDT and NIT are byte-identical and the identity is preserved.
+#[tokio::test(start_paused = true)]
+async fn service_layer_survives_roundtrip() {
+	let data = include_bytes!("test_data/bbb.ts");
+	let nit = make_section(0x40, &[0x12, 0x34, 0xff, 0x01]);
+
+	// Prepend a synthetic NIT Actual packet (0x0010); prepend keeps bbb's alignment.
+	let mut input = si_packet(0x0010, &nit);
+	input.extend_from_slice(&data[..]);
+
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let catalog =
+		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
+	import.decode(&BytesMut::from(&input[..])).unwrap();
+	import.finish().unwrap();
+
+	let service = catalog.snapshot().mpegts.service.clone().expect("a service record");
+	assert_eq!(service.transport_stream_id, 1, "TSID captured from the PAT");
+	assert_eq!(service.service_id, 1, "service number captured from the PAT");
+	assert_eq!(service.pmt_pid, 0x1000, "original PMT PID captured from the PAT");
+	let sdt = service.sdt.clone().expect("the source SDT was captured");
+	assert_eq!(sdt.first(), Some(&0x42), "SDT Actual (table_id 0x42)");
+	let (service_type, provider, name) = parse_sdt_service(&sdt);
+	assert_eq!(
+		(service_type, provider.as_str(), name.as_str()),
+		(0x01, "FFmpeg", "Service01")
+	);
+	assert_eq!(
+		service.nit.as_deref(),
+		Some(&make_section(0x40, &[0x12, 0x34, 0xff, 0x01])[..])
+	);
+
+	// `import` and `catalog` stay alive: retained tracks the exporter subscribes to.
+	let ts = drain_with(
+		Export::with_ts(crate::source::announced(&consumer), crate::catalog::CatalogFormat::Hang)
+			.await
+			.unwrap(),
+	)
+	.await;
+	assert_packet_aligned(&ts);
+
+	// The rebuilt PAT preserves the transport/service identity and PMT PID.
+	let mut reader = TsPacketReader::new(Cursor::new(ts.as_ref()));
+	let mut checked_pat = false;
+	while let Some(packet) = reader.read_ts_packet().unwrap() {
+		if let Some(TsPayload::Pat(pat)) = packet.payload {
+			assert_eq!(pat.transport_stream_id, 1, "TSID preserved in the rebuilt PAT");
+			assert_eq!(pat.table.len(), 1);
+			assert_eq!(pat.table[0].program_num, 1, "service number preserved");
+			assert_eq!(pat.table[0].program_map_pid.as_u16(), 0x1000, "PMT PID preserved");
+			checked_pat = true;
+			break;
+		}
+	}
+	assert!(checked_pat, "missing PAT");
+
+	// Re-import: the SDT and NIT must come back byte-for-byte.
+	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
+	let _consumer2 = broadcast2.consume();
+	let catalog2 =
+		crate::catalog::Producer::with_catalog(&mut broadcast2, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.reserve());
+	import2.decode(&BytesMut::from(ts.as_ref())).unwrap();
+	import2.finish().unwrap();
+
+	let service2 = catalog2
+		.snapshot()
+		.mpegts
+		.service
+		.clone()
+		.expect("a service record after round-trip");
+	assert_eq!(
+		service2.transport_stream_id, service.transport_stream_id,
+		"TSID survived"
+	);
+	assert_eq!(service2.service_id, service.service_id, "service number survived");
+	assert_eq!(service2.pmt_pid, service.pmt_pid, "PMT PID survived");
+	assert_eq!(service2.sdt, service.sdt, "SDT survived byte-for-byte");
+	assert_eq!(service2.nit, service.nit, "NIT survived byte-for-byte");
+}
+
 /// A raw Opus packet: a one-byte TOC (config 1 = SILK NB 20 ms, stereo, code 0) plus
 /// `len` filler bytes, so it parses as one 20 ms frame.
 fn opus_packet(fill: u8, len: usize) -> Bytes {

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -8,7 +8,10 @@
 //! ride the normal PES reassembly, while section-framed streams (SCTE-35 and
 //! other private sections, which are not PES) are intercepted before the mpeg2ts
 //! reader and reassembled. TS adds PAT/PMT discovery, PES reassembly, the
-//! private-section path, and the 90 kHz -> microsecond PTS conversion.
+//! private-section path, and the 90 kHz -> microsecond PTS conversion. The DVB
+//! service layer (transport/service identity from the PAT, plus the SDT and NIT
+//! sections) is captured into the `mpegts` catalog [`Service`](catalog::Service)
+//! record so it survives the round-trip.
 
 use std::collections::{HashMap, HashSet};
 use std::io::Read;
@@ -97,6 +100,13 @@ pub struct Import<E: catalog::Catalog = ()> {
 	/// Whether the PMT program-level descriptors have been recorded yet (set once;
 	/// PMT `program_info` is stable for the program's life).
 	program_recorded: bool,
+	/// Reassemblers for the standalone DVB SI PIDs (SDT 0x0011, NIT 0x0010), keyed
+	/// by PID. Intercepted before the reader (like SCTE-35 sections) so the service
+	/// layer survives the round-trip. Only populated with `mpegts` catalog support.
+	service_sections: HashMap<u16, SectionReassembler>,
+	/// Whether the service identity (TSID/service_id/PMT PID) has been captured from
+	/// the PAT into the catalog service record yet (set once; the PAT is stable).
+	service_recorded: bool,
 	/// Latest video PTS: the media clock used to timestamp private sections, which
 	/// carry no PES PTS of their own. Unwrapped independently of the video stream.
 	/// SPTS scope: one clock for the whole input. Under MPTS every program's video
@@ -133,6 +143,8 @@ impl<E: catalog::Catalog> Import<E> {
 			es_descriptors: HashMap::new(),
 			recorded_media: HashSet::new(),
 			program_recorded: false,
+			service_sections: HashMap::new(),
+			service_recorded: false,
 			last_pts: None,
 			media_unwrap: PtsUnwrap::default(),
 		}
@@ -193,6 +205,13 @@ impl<E: catalog::Catalog> Import<E> {
 			let pts = self.last_pts.unwrap_or(Timestamp::ZERO);
 			if let Some(section) = self.sections.get_mut(&pid) {
 				section.packet(&pkt, pts)?;
+				continue;
+			}
+			// Intercept the standalone DVB SI PIDs (SDT, NIT) before the routing gate
+			// below drops them: they carry the service layer, not media, and are not fed
+			// to the reader (which only routes the PAT/PMT/ES PIDs it learns).
+			if self.supports_mpegts && matches!(pid, catalog::SDT_PID | catalog::NIT_PID) {
+				self.service_section(pid, &pkt);
 				continue;
 			}
 			// PIDs we don't decode and don't carry (`Stream::Ignored`: a base catalog's
@@ -281,6 +300,7 @@ impl<E: catalog::Catalog> Import<E> {
 			Some(TsPayload::Pat(pat)) => {
 				self.pmt_pids
 					.extend(pat.table.iter().map(|entry| entry.program_map_pid));
+				self.record_service_identity(&pat);
 			}
 			_ => {}
 		}
@@ -563,6 +583,60 @@ impl<E: catalog::Catalog> Import<E> {
 			entry.descriptors = descriptors;
 		}
 		self.recorded_media.insert(pid);
+	}
+
+	/// Capture the transport/service identity (TSID, service number, PMT PID) from the
+	/// PAT into the catalog service record, once. No-op without `mpegts` support.
+	fn record_service_identity(&mut self, pat: &mpeg2ts::ts::payload::Pat) {
+		if !self.supports_mpegts || self.service_recorded {
+			return;
+		}
+		// program_number 0 is the network PID association, not a service; skip it.
+		let Some(program) = pat.table.iter().find(|entry| entry.program_num != 0) else {
+			return;
+		};
+		if let Some(mpegts) = self.catalog.lock().mpegts_mut() {
+			let service = mpegts.service.get_or_insert_with(Default::default);
+			service.transport_stream_id = pat.transport_stream_id;
+			service.service_id = program.program_num;
+			service.pmt_pid = program.program_map_pid.as_u16();
+		}
+		self.service_recorded = true;
+	}
+
+	/// Feed one TS packet on a DVB SI PID (SDT or NIT) to its reassembler, recording
+	/// each completed Actual section verbatim into the catalog service record.
+	fn service_section(&mut self, pid: u16, pkt: &[u8]) {
+		let mut sections = Vec::new();
+		self.service_sections.entry(pid).or_default().push(pkt, &mut sections);
+		for section in sections {
+			self.record_service_section(pid, section);
+		}
+	}
+
+	/// Record one complete SI section verbatim: the first SDT Actual (table_id 0x42) or
+	/// NIT Actual (table_id 0x40) seen. Later sections (repeats, the `Other` variants,
+	/// BAT on the SDT PID) are ignored; a single-service SPTS needs only the first.
+	fn record_service_section(&mut self, pid: u16, section: Vec<u8>) {
+		let wanted = matches!(
+			(pid, section.first().copied()),
+			(catalog::SDT_PID, Some(catalog::SDT_ACTUAL_TABLE_ID))
+				| (catalog::NIT_PID, Some(catalog::NIT_ACTUAL_TABLE_ID))
+		);
+		if !wanted {
+			return;
+		}
+		if let Some(mpegts) = self.catalog.lock().mpegts_mut() {
+			let service = mpegts.service.get_or_insert_with(Default::default);
+			let slot = if pid == catalog::SDT_PID {
+				&mut service.sdt
+			} else {
+				&mut service.nit
+			};
+			if slot.is_none() {
+				*slot = Some(bytes::Bytes::from(section));
+			}
+		}
 	}
 
 	/// Close the current group on every track and reopen at `sequence`.

--- a/rs/moq-mux/src/container/ts/mod.rs
+++ b/rs/moq-mux/src/container/ts/mod.rs
@@ -9,6 +9,9 @@
 //! Elementary streams we don't decode (SCTE-35, teletext, DVB subtitles, private
 //! data, ...) are carried verbatim, one MoQ track per PID, described in the
 //! [`Mpegts`] catalog section. SCTE-35 is just one such stream (`stream_type` 0x86).
+//! The DVB service layer (transport/service identity plus the SDT/NIT tables) rides
+//! the same section as a [`Service`] record, so the service name, provider, and
+//! network survive the round-trip.
 
 mod adts;
 mod export;
@@ -19,7 +22,7 @@ mod import;
 // they read as `ts::Catalog`, `ts::Mpegts`, ... instead of stuttering under `catalog`.
 mod catalog;
 
-pub use catalog::{Catalog, Descriptor, Ext, Framing, Mpegts, Track, Verbatim};
+pub use catalog::{Catalog, Descriptor, Ext, Framing, Mpegts, Service, Track, Verbatim};
 pub use export::*;
 pub use import::*;
 


### PR DESCRIPTION
Closes #2433.

## Summary

- The media-aware TS demux/remux dropped the DVB service layer. The SDT (service name, provider, type, original network ID) and NIT never entered the catalog, and export synthesized a fresh PAT/PMT with a hardcoded transport stream ID (`1`), service number (`1`), and PMT PID (`0x1000`). A TS input came out the other side stripped of its service identity, with a different PMT PID.
- Import now captures the transport/service identity (TSID, service number, PMT PID) from the PAT and carries the SDT Actual (`table_id` 0x42) and NIT Actual (`table_id` 0x40) sections **verbatim** in a new `mpegts` catalog `Service` record. The SI PIDs (SDT 0x0011, NIT 0x0010) are intercepted ahead of the mpeg2ts reader, the same way SCTE-35 private sections already are.
- Export rebuilds the PAT/PMT from the preserved identity (original TSID, service number, PMT PID) and re-emits the SDT and NIT byte-for-byte. A media-only source (no service record) still synthesizes a minimal identity, so nothing regresses.
- TDT/TOT (a live wall-clock) and EIT (EPG) are intentionally out of scope: they are dynamic, not static identity, and verbatim re-emission would ship a stale clock. Noted as a follow-up.

## Public API changes

- `rs/moq-mux` `ts::Service` (new `pub` struct, `#[non_exhaustive]`): the DVB service record (`transport_stream_id`, `service_id`, `pmt_pid`, verbatim `sdt`/`nit`). Re-exported from `ts`.
- `rs/moq-mux` `ts::Mpegts` gains an optional `pub service: Option<Service>` field (additive; `#[serde(default, skip_serializing_if)]`).

All additive; no existing `pub` item renamed, removed, or signature-changed. Based on the `dev` batch, but the change itself is semver-additive.

## Cross-Package Sync

The `mpegts` catalog extension is internal to `rs/moq-mux`; it is not mirrored in `js/hang` (which parses the base hang catalog, not this TS-specific section) and is not an IETF-draft wire format, so no `js/` or `drafts/` rows apply. `doc/bin/cli.md` (the `import ts` / `export ts` reference) is updated in this PR.

## Test plan

- New unit test `catalog::service_roundtrip`: the `Service` record serializes/round-trips, base64 SDT present, absent NIT omitted.
- New integration test `export_test::service_layer_survives_roundtrip`: injects a synthetic NIT into `bbb.ts`, imports (asserting captured TSID/service/PMT PID + parsed SDT name/provider), exports, re-imports, and asserts SDT + NIT come back byte-for-byte and the identity survives.
- `cargo test -p moq-mux`: 393 tests + 2 doctests pass; `cargo fmt --check` and `cargo clippy -p moq-mux -- -D warnings` clean.
- **Real end-to-end** local `moq` publisher -> `moq-relay` -> `moq` subscriber over WebTransport, using a real broadcast TS feed (CNN International EMEA HD). Source vs exported `out.ts`:
  - PMT PID `0x0064`, TSID `0x0000`, ONID `0x0000`, service number `1`: preserved (not the `0x1000`/`1` defaults).
  - SDT ("CNNI EMEA HD" / "Warner Bros. Discovery" / type 0x19) and NIT: byte-for-byte identical (matching SHA-1).
  - Full PMT (AVC + MPEG-1 audio + AC-3 + teletext + 3x SCTE-35, original PIDs/descriptors): preserved.
  - TDT/TOT: not carried (out of scope, as above).

(Written by Claude Opus 4.8)

Made with [Cursor](https://cursor.com)