### PR TITLE
fix(moq-token): default missing key_ops to sign and verify

### DIFF
--- a/js/token/src/key.test.ts
+++ b/js/token/src/key.test.ts
@@ -110,13 +110,34 @@ test("load - missing required fields", () => {
 	const invalidKey = {
 		alg: "HS256",
 		kty: "oct",
-		// missing key_ops and k
+		// missing k
 	};
 	const jwk = encodeJwk(invalidKey);
 
 	expect(() => {
 		load(jwk);
 	}).toThrow();
+});
+
+test("load - missing key_ops defaults to sign and verify", async () => {
+	const { key_ops: _ignored, ...keyWithoutOps } = testKey;
+	const key = load(encodeJwk(keyWithoutOps));
+
+	expect(key.key_ops).toEqual(["sign", "verify"]);
+
+	const token = await sign(key, testClaims);
+	const claims = await verify(key, token);
+	expect(claims.root).toBe(testClaims.root);
+});
+
+test("toPublicKey - defaulted key_ops yields exactly verify", async () => {
+	const { privateKey } = await generateKeyPair("EdDSA", { extractable: true });
+	const jwk = await exportJWK(privateKey);
+	const key = load(encodeJwk({ ...jwk, alg: "EdDSA", kid: "defaulted" }));
+	expect(key.key_ops).toEqual(["sign", "verify"]);
+
+	const publicKey = toPublicKey(key);
+	expect(publicKey.key_ops).toEqual(["verify"]);
 });
 
 test("load - legacy oct key without kty", () => {

--- a/js/token/src/key.ts
+++ b/js/token/src/key.ts
@@ -37,7 +37,8 @@ const Base64FieldSchema = z.string().check(
 
 const BaseKeySchema = z.object({
 	alg: AlgorithmSchema,
-	key_ops: z.array(OperationSchema).check(z.minLength(1)),
+	// RFC 7517 leaves omitted key_ops unrestricted. Default to the operations this library supports.
+	key_ops: z._default(z.array(OperationSchema).check(z.minLength(1)), ["sign", "verify"]),
 	kid: z.optional(KeyIdSchema),
 	scope: z.optional(ScopeSchema),
 });

--- a/js/token/src/set.test.ts
+++ b/js/token/src/set.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { decodeProtectedHeader } from "jose";
 import { generate } from "./generate.ts";
 import { sign } from "./key.ts";
 import { findKey, type KeySet, loadSet, signWith, toPublicSet, verifyWith } from "./set.ts";
@@ -57,6 +58,19 @@ test("signWith - fails when no key can sign", async () => {
 	set.keys[0].key_ops = ["verify"];
 
 	await expect(signWith(set, CLAIMS)).rejects.toThrow(/Cannot find signing key/);
+});
+
+test("signWith - skips a public-only key that claims sign", async () => {
+	const privateKey = await generate("ES256", "active");
+
+	const publicOnly = await generate("ES256", "old");
+	if (publicOnly.kty !== "EC") throw new Error("expected an EC key");
+	delete publicOnly.d;
+	publicOnly.key_ops = ["sign", "verify"];
+
+	const set: KeySet = { keys: [publicOnly, privateKey] };
+	const token = await signWith(set, CLAIMS);
+	expect(decodeProtectedHeader(token).kid).toBe("active");
 });
 
 test("toPublicSet - strips private material", async () => {

--- a/js/token/src/set.ts
+++ b/js/token/src/set.ts
@@ -57,9 +57,9 @@ export function findKey(set: KeySet, kid: string): Key | undefined {
 	return set.keys.find((key) => key.kid === kid);
 }
 
-/** Sign the claims with the first key in the set that supports signing. */
+/** Sign the claims with the first key that permits signing and contains signing material. */
 export async function signWith(set: KeySet, claims: Claims): Promise<string> {
-	const key = set.keys.find((key) => key.key_ops.includes("sign"));
+	const key = set.keys.find((key) => key.key_ops.includes("sign") && (key.kty === "oct" || key.d !== undefined));
 	if (!key) throw new Error("Cannot find signing key");
 	return await sign(key, claims);
 }

--- a/rs/moq-token/src/error.rs
+++ b/rs/moq-token/src/error.rs
@@ -17,6 +17,9 @@ pub enum KeyError {
 	#[error("missing private key")]
 	MissingPrivateKey,
 
+	#[error("oct key secret must be at least {0} bytes")]
+	SecretTooShort(usize),
+
 	#[error("OCT key cannot be converted to public key")]
 	NoPublicKey,
 

--- a/rs/moq-token/src/key.rs
+++ b/rs/moq-token/src/key.rs
@@ -54,10 +54,9 @@ pub enum KeyMaterial {
 	/// <https://datatracker.ietf.org/doc/html/rfc7518#section-6.4>
 	#[serde(rename = "oct")]
 	OCT {
-		/// The secret key as base64url (unpadded).
+		/// The secret key as base64url (unpadded). Must be at least 32 bytes once decoded.
 		#[serde(
 			rename = "k",
-			default,
 			serialize_with = "serialize_base64url",
 			deserialize_with = "deserialize_base64url"
 		)]
@@ -154,8 +153,9 @@ pub struct Jwk {
 	#[serde(rename = "alg")]
 	pub algorithm: Algorithm,
 
-	/// The operations that the key can perform.
-	#[serde(rename = "key_ops")]
+	/// The permitted operations, defaulting to sign and verify when `key_ops` is absent
+	/// (optional per RFC 7517 section 4.3).
+	#[serde(rename = "key_ops", default = "sign_verify")]
 	pub operations: HashSet<KeyOperation>,
 
 	/// The key material. Defaults to [`KeyMaterial::OCT`] when `kty` is absent.
@@ -171,6 +171,13 @@ pub struct Jwk {
 	pub scope: Option<crate::Scope>,
 }
 
+fn sign_verify() -> HashSet<KeyOperation> {
+	[KeyOperation::Sign, KeyOperation::Verify].into()
+}
+
+/// Matches the minimum `js/token` enforces, so a key that loads in one loads in the other.
+const MIN_OCT_SECRET_BYTES: usize = 32;
+
 impl Jwk {
 	/// A key that can both sign and verify, with no key ID or scope.
 	///
@@ -179,7 +186,7 @@ impl Jwk {
 	pub fn new(algorithm: Algorithm, material: KeyMaterial) -> Self {
 		Self {
 			algorithm,
-			operations: [KeyOperation::Sign, KeyOperation::Verify].into(),
+			operations: sign_verify(),
 			material,
 			kid: None,
 			scope: None,
@@ -194,6 +201,12 @@ impl Jwk {
 	pub fn import(self) -> crate::Result<Key> {
 		if let Some(scope) = &self.scope {
 			scope.validate()?;
+		}
+
+		if let KeyMaterial::OCT { secret } = &self.material
+			&& secret.len() < MIN_OCT_SECRET_BYTES
+		{
+			return Err(KeyError::SecretTooShort(MIN_OCT_SECRET_BYTES).into());
 		}
 
 		Ok(Key {
@@ -398,6 +411,18 @@ impl Key {
 			decode: Default::default(),
 			encode: Default::default(),
 		})
+	}
+
+	/// Whether the key carries the private material signing actually needs.
+	///
+	/// `key_ops` says what a key is *permitted* to do, which a public JWK can still advertise.
+	pub(crate) fn has_signing_material(&self) -> bool {
+		match &self.material {
+			KeyMaterial::OCT { .. } => true,
+			KeyMaterial::EC { d, .. } => d.is_some(),
+			KeyMaterial::OKP { d, .. } => d.is_some(),
+			KeyMaterial::RSA { private, .. } => private.is_some(),
+		}
 	}
 
 	fn to_decoding_key(&self) -> crate::Result<&DecodingKey> {
@@ -738,6 +763,67 @@ mod tests {
 		assert!(loaded.operations.contains(&KeyOperation::Sign));
 		assert!(loaded.operations.contains(&KeyOperation::Verify));
 		assert!(matches!(loaded.material, KeyMaterial::OCT { .. }));
+	}
+
+	#[test]
+	fn test_key_without_key_ops_defaults_sign_verify() {
+		let json = r#"{"kty":"oct","alg":"HS256","k":"Fp8kipWUJeUFqeSqWym_tRC_tyI8z-QpqopIGrbrD68","kid":"no-ops"}"#;
+		let key = Key::from_str(json).unwrap();
+
+		assert_eq!(key.operations, sign_verify());
+
+		let claims = create_test_claims();
+		let token = key.sign(&claims).unwrap();
+		let verified = key.verify(&token).unwrap();
+		assert_eq!(verified.root, claims.root);
+	}
+
+	#[test]
+	fn test_key_without_key_ops_round_trip() {
+		let json = r#"{"kty":"oct","alg":"HS256","k":"Fp8kipWUJeUFqeSqWym_tRC_tyI8z-QpqopIGrbrD68"}"#;
+		let key = Key::from_str(json).unwrap();
+
+		let serialized = serde_json::to_string(&key).unwrap();
+		let parsed: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+		let ops = parsed["key_ops"].as_array().unwrap();
+		assert_eq!(ops.len(), 2);
+
+		let reloaded = Key::from_str(&serialized).unwrap();
+		assert_eq!(reloaded.operations, sign_verify());
+		assert_eq!(reloaded.algorithm, key.algorithm);
+	}
+
+	// Defaulting key_ops must not let a weak or truncated file parse into a working key.
+	#[test]
+	fn test_key_oct_secret_required_and_min_length() {
+		// Missing k entirely, the truncated-file case.
+		assert!(Key::from_str(r#"{"kty":"oct","alg":"HS256"}"#).is_err());
+		assert!(Key::from_str(r#"{"kty":"oct","alg":"HS256","k":""}"#).is_err());
+
+		// 16-byte secret, below the 32-byte minimum.
+		assert!(Key::from_str(r#"{"kty":"oct","alg":"HS256","k":"AAAAAAAAAAAAAAAAAAAAAA"}"#).is_err());
+
+		// A short secret is rejected however the Jwk was built, not just when deserialized.
+		let short = Jwk::new(Algorithm::HS256, KeyMaterial::OCT { secret: vec![0; 16] });
+		assert!(short.import().is_err());
+
+		// Exactly 32 bytes.
+		let key =
+			Key::from_str(r#"{"kty":"oct","alg":"HS256","k":"Fp8kipWUJeUFqeSqWym_tRC_tyI8z-QpqopIGrbrD68"}"#).unwrap();
+		let KeyMaterial::OCT { ref secret } = key.material else {
+			panic!("Expected OCT key");
+		};
+		assert_eq!(secret.len(), 32);
+	}
+
+	#[test]
+	fn test_key_without_key_ops_to_public() {
+		let json = r#"{"kty":"OKP","alg":"EdDSA","crv":"Ed25519","x":"UiU9fT_SdBBpkFtJPRCY0gX1jK_Dr9syYLFuEz4QUM4","d":"lm-L_PV3ksuQ-KrFBgFMDJqAZC3_Z6Z5UC4ZQY5OoDQ","kid":"defaulted"}"#;
+		let key = Key::from_str(json).unwrap();
+		assert_eq!(key.operations, sign_verify());
+
+		let public = key.to_public().unwrap();
+		assert_eq!(public.operations, [KeyOperation::Verify].into());
 	}
 
 	#[test]

--- a/rs/moq-token/src/set.rs
+++ b/rs/moq-token/src/set.rs
@@ -85,9 +85,14 @@ impl KeySet {
 			.cloned()
 	}
 
-	/// Find the first key that supports the given operation.
+	/// Find the first key that permits the operation and carries any key material it needs.
 	pub fn find_supported_key(&self, operation: &KeyOperation) -> Option<Arc<Key>> {
-		self.keys.iter().find(|key| key.operations.contains(operation)).cloned()
+		self.keys
+			.iter()
+			.find(|key| {
+				key.operations.contains(operation) && (*operation != KeyOperation::Sign || key.has_signing_material())
+			})
+			.cloned()
 	}
 
 	/// Sign the claims with the first key in the set that supports signing.
@@ -266,6 +271,23 @@ mod tests {
 		let found_verify = set.find_supported_key(&KeyOperation::Verify);
 		assert!(found_verify.is_some());
 		assert_eq!(found_verify.unwrap().kid.as_ref().map(|k| k.encode()), Some("verify"));
+	}
+
+	#[test]
+	fn test_sign_skips_public_only_key() {
+		let private = create_test_key(Some("active"));
+		let public = create_test_key(Some("old"))
+			.to_public()
+			.unwrap()
+			.with_operations([KeyOperation::Sign, KeyOperation::Verify]);
+
+		let set = KeySet {
+			keys: vec![Arc::new(public), Arc::new(private)],
+		};
+
+		let token = set.sign(&create_test_claims()).unwrap();
+		let header = jsonwebtoken::decode_header(&token).unwrap();
+		assert_eq!(header.kid.as_deref(), Some("active"));
 	}
 
 	#[test]


### PR DESCRIPTION
In our initial prototype we generated our JWKs with standard tooling and none of it wrote key_ops, so we had to patch every key with jq. I believe RFC 7517 makes it optional, where absence means unrestricted.

While testing that, two things fell out. Key sets could now pick a public-only key for signing and fail, so signing selection requires actual private material. And the oct k field had a lenient empty default that the key_ops default suddenly made reachable, letting a bare {"kty":"oct","alg":"HS256"} parse into a working key with an empty secret. k is now required with the same 32-byte minimum js/token already enforces.

(Second paragraph written by Claude Fable 5)