### PR TITLE
fix(net): bump @moq/qmux to 0.3.1 for the WebSocket fallback crash

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -179,7 +179,7 @@
       "name": "@moq/net",
       "version": "0.1.9",
       "dependencies": {
-        "@moq/qmux": "^0.3.0",
+        "@moq/qmux": "^0.3.1",
         "@moq/signals": "workspace:*",
         "async-mutex": "^0.5.0",
       },
@@ -581,7 +581,7 @@
 
     "@moq/publish": ["@moq/publish@workspace:js/publish"],
 
-    "@moq/qmux": ["@moq/qmux@0.3.0", "", { "dependencies": { "@moq/web-socket-stream": "^0.1.0" } }, "sha512-0DchimaN2XaxdRhk5e+vVyTPAYxRZObNPqPWIwhesIiXCT9xJsZ5ltpQhXD/S3OPjrFk0aEH3rRmP0THdD0Ukw=="],
+    "@moq/qmux": ["@moq/qmux@0.3.1", "", { "dependencies": { "@moq/web-socket-stream": "^0.1.1" } }, "sha512-0bSa8S8Mpr6J/kM94MgPRCPefmLhFwMzkFpNsu873SuS5Jne4oYzXoud/5tyDDoS5JAXb1/KBOBrim55qSrViA=="],
 
     "@moq/signals": ["@moq/signals@workspace:js/signals"],
 
@@ -595,7 +595,7 @@
 
     "@moq/watch": ["@moq/watch@workspace:js/watch"],
 
-    "@moq/web-socket-stream": ["@moq/web-socket-stream@0.1.0", "", {}, "sha512-VxPaJZvZ8qgFmTjG9XhTH0bQoQE9pExvlS/R0fH1aNcpqCnZdbYS2kvB2ypO5SyFTf6oH+4eWvgElDzW6yiqFQ=="],
+    "@moq/web-socket-stream": ["@moq/web-socket-stream@0.1.1", "", {}, "sha512-VKi/GE/CLqmbEZlgNbBLbAFk2pQTxT+KUD2DjCSoxqZxbS3KBe5BBZ0m3fila4fEGyll2JT5MmgEyVr4zkZEVA=="],
 
     "@moq/web-transport": ["@moq/web-transport@0.1.3", "", { "optionalDependencies": { "@moq/web-transport-darwin-arm64": "0.1.3", "@moq/web-transport-darwin-x64": "0.1.3", "@moq/web-transport-linux-arm64-gnu": "0.1.3", "@moq/web-transport-linux-x64-gnu": "0.1.3", "@moq/web-transport-win32-x64-msvc": "0.1.3" } }, "sha512-hg3mKWUJaEwtJDGf8Ck62XP8ya+7wyMV/9ycV1A+M3iVly3xBOTPHpT8BrpOLomsBIB9iXQY6Z85MjknhUJW8w=="],
 
@@ -1643,7 +1643,7 @@
 
     "tabbable": ["tabbable@6.5.0", "", {}, "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA=="],
 
-    "tailwindcss": ["tailwindcss@4.3.1", "", {}, "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q=="],
+    "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
@@ -1813,8 +1813,6 @@
 
     "@rollup/pluginutils/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
-    "@tailwindcss/node/tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
-
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
@@ -1826,8 +1824,6 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "@tailwindcss/vite/tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
     "@types/concat-stream/@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -17,7 +17,7 @@
 		"release": "bun ../common/release.ts"
 	},
 	"dependencies": {
-		"@moq/qmux": "^0.3.0",
+		"@moq/qmux": "^0.3.1",
 		"@moq/signals": "workspace:*",
 		"async-mutex": "^0.5.0"
 	},


### PR DESCRIPTION
## Summary

- Browser clients using the `@moq/qmux` WebSocket fallback crashed immediately against a relay, in **Chromium only**. The page reported "connected" but discovered nothing, and the relay logged `moq_relay::websocket: error=transport: connection closed` per attempt.
- **Root cause:** Chromium's native `WebSocketStream` enqueues `ArrayBuffer` chunks, not `Uint8Array` (verified: `chunk.constructor.name === "ArrayBuffer"`, `.buffer === undefined`). qmux 0.3.0 passed those straight to `Frame.decodeRecord`, whose `VarInt.decode` does `new DataView(buffer.buffer, buffer.byteOffset)`. With `.buffer` undefined it threw `TypeError: First argument to DataView constructor must be an ArrayBuffer` on the *first* record decoded, the peer's `QX_TRANSPORT_PARAMETERS`, before any application data flowed.
- Firefox and Safari were unaffected: they have no native `WebSocketStream`, so they take the `@moq/web-socket-stream` ponyfill path, which already normalized to `Uint8Array`. Chrome reaches the WS fallback at all because WebTransport loses to a self-signed localhost cert.
- Fixed upstream at both layers in moq-dev/web-transport (`2909f30`, with regression tests) and released as `@moq/qmux` 0.3.1 + `@moq/web-socket-stream` 0.1.1. This PR is only the dependency bump.

Worth knowing: `@moq/web-socket-stream` 0.1.1 is what actually repairs *this* path, since `js/net` connects through `openWebSocketStream`. The qmux read-loop normalization covers the separate case of a transport handed to the constructor or `accept()` directly. Pinning qmux to 0.3.0 alone does not reproduce the bug.

## Public API changes

None. Dependency version bump only.

## Test plan

Built `moq-relay`, ran it on `demo/relay/localhost.toml`, served `demo/web`, and drove Chromium against it. The WS fallback was forced deterministically using the real `stats.html` verbatim with one injected line (`delete globalThis.WebTransport`); the page confirms the path with `connected via WebSocket`.

- **Negative control** (`@moq/qmux@0.3.0` + `@moq/web-socket-stream@0.1.0`, pinned via a bun override, vite restarted with `--force` so the dep pre-bundle cache did not mask the swap): reproduced the failure exactly. Page showed "connected", 0 nodes, "searching for nodes…"; console threw the `TypeError` at `VarInt.decode` -> `decodeQMuxOne` -> `decodeRecord` -> `#onData` -> `#readLoop`; relay logged `transport: connection closed` per attempt.
- **With 0.3.1 / 0.1.1**: node discovered, stats flowing, no console error.
- `js/net`: `bun run check` clean, `bun test` 288/288 pass, `biome check` clean.

No regression test is added here: the fix lives in the dependency, and upstream carries the tests (`session.test.ts`, "native WebSocketStream ArrayBuffer records are normalized before QMux decoding" and "ArrayBuffer chunks decode on a transport we were handed directly"). There is no seam in `js/net` to assert against.

## Cross-Package Sync

No rows apply. No wire format, `moq-ffi`, catalog, or CLI surface is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Opus 4.8)