### PR TITLE
refactor(mux): carry the TS service layer as opaque SI sections

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -371,11 +371,13 @@ cues, teletext, DVB subtitles, ...) are carried verbatim too, one MoQ track per
 PID, described in the catalog `mpegts` section, and survive `import ts` /
 `export ts` end-to-end.
 
-The DVB service layer rides the same `mpegts` section: the transport/service
-identity (transport stream ID, service number, PMT PID) plus the SDT and NIT
-tables are captured on import and re-emitted on export, so the service name,
-provider, type, and network survive the round-trip. Regenerated tables (TDT/TOT)
-and EPG (EIT) are not carried.
+The service layer rides the same `mpegts` section. The program identity
+(transport stream ID, service number, PMT PID) is captured from the PAT and used to
+rebuild a matching PAT/PMT, while the standalone SI tables (SDT, NIT) are carried as
+opaque sections and re-emitted byte-for-byte on their original PIDs, each at its own
+repetition interval. So the service name, provider, type, and network survive the
+round-trip without being parsed. Regenerated tables (TDT/TOT) and EPG (EIT) are not
+captured: they are live or bulky rather than static identity.
 
 ### FLV
 

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -371,6 +371,12 @@ cues, teletext, DVB subtitles, ...) are carried verbatim too, one MoQ track per
 PID, described in the catalog `mpegts` section, and survive `import ts` /
 `export ts` end-to-end.
 
+The DVB service layer rides the same `mpegts` section: the transport/service
+identity (transport stream ID, service number, PMT PID) plus the SDT and NIT
+tables are captured on import and re-emitted on export, so the service name,
+provider, type, and network survive the round-trip. Regenerated tables (TDT/TOT)
+and EPG (EIT) are not carried.
+
 ### FLV
 
 ```bash

--- a/rs/moq-mux/src/container/ts/catalog.rs
+++ b/rs/moq-mux/src/container/ts/catalog.rs
@@ -4,9 +4,10 @@
 //! back to MPEG-TS that doesn't belong in the codec-neutral media configs: one
 //! entry per track (its original PID and PMT descriptors), a `verbatim` carriage
 //! record for every elementary stream we don't decode (SCTE-35, teletext, DVB
-//! subtitles, private data, ...), and the program-level PMT descriptors. Demuxed
-//! media tracks keep their codec config in the base `video`/`audio` sections; only
-//! their MPEG-TS identity lands here.
+//! subtitles, private data, ...), the program-level PMT descriptors, and the DVB
+//! service layer ([`Service`]: transport/service identity plus the SDT/NIT tables).
+//! Demuxed media tracks keep their codec config in the base `video`/`audio`
+//! sections; only their MPEG-TS identity lands here.
 
 use std::collections::BTreeMap;
 
@@ -16,6 +17,15 @@ use serde_with::base64::Base64;
 use serde_with::serde_as;
 
 use crate::catalog::hang::CatalogExt;
+
+/// PID of the DVB Network Information Table (NIT).
+pub(super) const NIT_PID: u16 = 0x0010;
+/// PID of the DVB Service Description Table (SDT).
+pub(super) const SDT_PID: u16 = 0x0011;
+/// `table_id` of the NIT for the actual network (NIT Actual).
+pub(super) const NIT_ACTUAL_TABLE_ID: u8 = 0x40;
+/// `table_id` of the SDT for the actual transport stream (SDT Actual).
+pub(super) const SDT_ACTUAL_TABLE_ID: u8 = 0x42;
 
 /// The `mpegts` catalog section.
 ///
@@ -34,13 +44,57 @@ pub struct Mpegts {
 	/// re-emits these; the SCTE-35 'CUEI' registration is derived when absent.
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub program_descriptors: Vec<Descriptor>,
+
+	/// The DVB service layer (transport/service identity plus the SDT/NIT tables).
+	/// Present only for a source that carries it (a TS input); omitted for media-only
+	/// broadcasts, so export then synthesizes a minimal identity.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub service: Option<Service>,
 }
 
 impl Mpegts {
 	/// True when the section carries nothing, so it's omitted from the catalog.
 	pub fn is_empty(&self) -> bool {
-		self.tracks.is_empty() && self.program_descriptors.is_empty()
+		self.tracks.is_empty() && self.program_descriptors.is_empty() && self.service.is_none()
 	}
+}
+
+/// The DVB service layer of a TS program.
+///
+/// Two kinds of data: the small structured identity export needs to rebuild a
+/// consistent PAT/PMT (the transport stream, service, and PMT PID), and the
+/// standalone SI tables ([`sdt`](Self::sdt), [`nit`](Self::nit)) carried verbatim
+/// so the service name, provider, type, original network, and network description
+/// survive the round-trip byte-for-byte. Regenerated tables (TDT/TOT) and EPG (EIT)
+/// are out of scope; they are live or dynamic, not static identity.
+#[serde_as]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct Service {
+	/// Transport stream ID from the PAT, preserved so the rebuilt PAT stays
+	/// consistent with the carried SDT/NIT.
+	pub transport_stream_id: u16,
+
+	/// Program (service) number from the PAT. Re-emitted as the PAT program number
+	/// and the PMT `program_number`.
+	pub service_id: u16,
+
+	/// Original PMT PID from the PAT, preserved so PMT cross-references survive.
+	pub pmt_pid: u16,
+
+	/// SDT Actual section (`table_id` 0x42), carried verbatim and re-emitted on
+	/// PID 0x0011. Carries the service name, provider, type, and original network ID.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	#[serde_as(as = "Option<Base64>")]
+	pub sdt: Option<Bytes>,
+
+	/// NIT Actual section (`table_id` 0x40), carried verbatim and re-emitted on
+	/// PID 0x0010. Describes the originating delivery network, so it is preserved
+	/// rather than synthesized (an operator decision).
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	#[serde_as(as = "Option<Base64>")]
+	pub nit: Option<Bytes>,
 }
 
 /// One track's MPEG-TS identity and signaling.
@@ -225,5 +279,29 @@ mod test {
 
 		let parsed: Ext = serde_json::from_str(&json).unwrap();
 		assert_eq!(parsed.mpegts, mpegts, "mpegts section round-trips");
+	}
+
+	#[test]
+	fn service_roundtrip() {
+		let mpegts = Mpegts {
+			service: Some(Service {
+				transport_stream_id: 0x1234,
+				service_id: 1,
+				pmt_pid: 0x0064,
+				sdt: Some(Bytes::from_static(b"\x42\xf0\x25")),
+				nit: None,
+				..Default::default()
+			}),
+			..Default::default()
+		};
+		assert!(!mpegts.is_empty(), "a service record is not empty");
+
+		let json = serde_json::to_string(&Ext { mpegts: mpegts.clone() }).unwrap();
+		// The SDT section is base64; the absent NIT is omitted.
+		assert!(json.contains("\"sdt\""), "sdt present: {json}");
+		assert!(!json.contains("\"nit\""), "absent nit omitted: {json}");
+
+		let parsed: Ext = serde_json::from_str(&json).unwrap();
+		assert_eq!(parsed.mpegts, mpegts, "service section round-trips");
 	}
 }

--- a/rs/moq-mux/src/container/ts/catalog.rs
+++ b/rs/moq-mux/src/container/ts/catalog.rs
@@ -4,33 +4,40 @@
 //! back to MPEG-TS that doesn't belong in the codec-neutral media configs: one
 //! entry per track (its original PID and PMT descriptors), a `verbatim` carriage
 //! record for every elementary stream we don't decode (SCTE-35, teletext, DVB
-//! subtitles, private data, ...), the program-level PMT descriptors, and the DVB
-//! service layer ([`Service`]: transport/service identity plus the SDT/NIT tables).
+//! subtitles, private data, ...), the program-level PMT descriptors, the program
+//! identity ([`Program`]), and the standalone SI tables ([`Si`]).
 //! Demuxed media tracks keep their codec config in the base `video`/`audio`
 //! sections; only their MPEG-TS identity lands here.
 
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use serde_with::base64::Base64;
-use serde_with::serde_as;
+use serde_with::{DisplayFromStr, DurationMilliSeconds, serde_as};
 
 use crate::catalog::hang::CatalogExt;
 
-/// PID of the DVB Network Information Table (NIT).
-pub(super) const NIT_PID: u16 = 0x0010;
-/// PID of the DVB Service Description Table (SDT).
-pub(super) const SDT_PID: u16 = 0x0011;
-/// `table_id` of the NIT for the actual network (NIT Actual).
-pub(super) const NIT_ACTUAL_TABLE_ID: u8 = 0x40;
-/// `table_id` of the SDT for the actual transport stream (SDT Actual).
-pub(super) const SDT_ACTUAL_TABLE_ID: u8 = 0x42;
+/// A standalone SI PID we capture, and how often export must re-emit it.
+///
+/// Intervals are the DVB maximum repetition intervals (ETSI TS 101 211); export
+/// treats them as an upper bound, not the source's observed cadence, which is a
+/// property of that multiplexer's bitrate shaping and means nothing downstream.
+/// Adding a table here is a one-line change: the sections themselves are opaque.
+pub(super) const SI_PIDS: &[(u16, Duration)] = &[
+	// NIT (network description): 10s.
+	(0x0010, Duration::from_secs(10)),
+	// SDT and BAT (service and bouquet description): 2s for SDT Actual, the tightest
+	// of the two, so one interval per PID stays conservative.
+	(0x0011, Duration::from_secs(2)),
+];
 
 /// The `mpegts` catalog section.
 ///
 /// Omitted from the catalog when empty, so a broadcast that needs none of it stays
 /// byte-identical to one without the extension.
+#[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
@@ -45,56 +52,117 @@ pub struct Mpegts {
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	pub program_descriptors: Vec<Descriptor>,
 
-	/// The DVB service layer (transport/service identity plus the SDT/NIT tables).
-	/// Present only for a source that carries it (a TS input); omitted for media-only
-	/// broadcasts, so export then synthesizes a minimal identity.
+	/// Program identity from the PAT. Present only for a source that carries one (a TS
+	/// input); omitted for media-only broadcasts, so export then synthesizes a minimal
+	/// identity.
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub service: Option<Service>,
+	pub program: Option<Program>,
+
+	/// Standalone SI tables carried verbatim, keyed by the PID they ride on (0x0011
+	/// SDT, 0x0010 NIT, ...). Export re-emits each PID's sections byte-for-byte on that
+	/// PID, so the service name, provider, and network survive without anyone parsing
+	/// them.
+	///
+	/// JSON object keys are strings, so the PID is written in decimal (`"17"`) rather
+	/// than as a number. The catalog is parsed via `serde_json::Value`, which will not
+	/// coerce a string key back to an integer on its own.
+	#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+	#[serde_as(as = "BTreeMap<DisplayFromStr, _>")]
+	pub si: BTreeMap<u16, Si>,
 }
 
 impl Mpegts {
 	/// True when the section carries nothing, so it's omitted from the catalog.
 	pub fn is_empty(&self) -> bool {
-		self.tracks.is_empty() && self.program_descriptors.is_empty() && self.service.is_none()
+		self.tracks.is_empty() && self.program_descriptors.is_empty() && self.program.is_none() && self.si.is_empty()
 	}
 }
 
-/// The DVB service layer of a TS program.
+/// Program identity, from the PAT.
 ///
-/// Two kinds of data: the small structured identity export needs to rebuild a
-/// consistent PAT/PMT (the transport stream, service, and PMT PID), and the
-/// standalone SI tables ([`sdt`](Self::sdt), [`nit`](Self::nit)) carried verbatim
-/// so the service name, provider, type, original network, and network description
-/// survive the round-trip byte-for-byte. Regenerated tables (TDT/TOT) and EPG (EIT)
-/// are out of scope; they are live or dynamic, not static identity.
+/// The only part of the service layer we parse, because export has to: these three
+/// values rebuild a PAT/PMT consistent with the SI tables carried alongside in
+/// [`Si`]. Everything else about the program (its name, provider, type, network)
+/// stays opaque bytes. Named for the MPEG concept rather than the DVB one: DVB calls
+/// a program a service, but the same PAT fields carry an ATSC or ISDB stream too.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+#[non_exhaustive]
+pub struct Program {
+	/// Transport stream ID from the PAT, preserved so the rebuilt PAT stays
+	/// consistent with the carried SI.
+	pub transport_stream_id: u16,
+
+	/// Program number from the PAT (the DVB service ID). Re-emitted as the PAT program
+	/// number and the PMT `program_number`.
+	pub program_number: u16,
+
+	/// Original PMT PID from the PAT, preserved so PMT cross-references survive.
+	pub pmt_pid: u16,
+}
+
+/// The standalone SI tables on one PID, carried verbatim.
+///
+/// Sections are opaque: nothing here parses a table, so an SDT, a NIT, a BAT, or a
+/// table we've never heard of all round-trip the same way. A PID carries a *set* of
+/// sections (a multi-service SDT is several, and the SDT PID also carries the BAT),
+/// so they are held together and replaced individually as each is re-signaled.
 #[serde_as]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
-pub struct Service {
-	/// Transport stream ID from the PAT, preserved so the rebuilt PAT stays
-	/// consistent with the carried SDT/NIT.
-	pub transport_stream_id: u16,
+pub struct Si {
+	/// The current sections, in the order they were first seen. Each is a complete
+	/// section including its header and CRC, re-emitted byte-for-byte.
+	#[serde_as(as = "Vec<Base64>")]
+	pub sections: Vec<Bytes>,
 
-	/// Program (service) number from the PAT. Re-emitted as the PAT program number
-	/// and the PMT `program_number`.
-	pub service_id: u16,
-
-	/// Original PMT PID from the PAT, preserved so PMT cross-references survive.
-	pub pmt_pid: u16,
-
-	/// SDT Actual section (`table_id` 0x42), carried verbatim and re-emitted on
-	/// PID 0x0011. Carries the service name, provider, type, and original network ID.
+	/// Re-emit at least this often. A hint: import fills in the DVB maximum for the
+	/// PIDs it knows, and export is free to clamp it. Absent for an unrecognized PID,
+	/// which export then re-emits on its own PSI cadence, so an unknown table degrades
+	/// to a safe rate rather than being dropped.
+	///
+	/// Serialized as an integer number of milliseconds (sub-ms precision is truncated).
+	#[serde_as(as = "Option<DurationMilliSeconds<u64>>")]
 	#[serde(default, skip_serializing_if = "Option::is_none")]
-	#[serde_as(as = "Option<Base64>")]
-	pub sdt: Option<Bytes>,
+	pub interval: Option<Duration>,
+}
 
-	/// NIT Actual section (`table_id` 0x40), carried verbatim and re-emitted on
-	/// PID 0x0010. Describes the originating delivery network, so it is preserved
-	/// rather than synthesized (an operator decision).
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	#[serde_as(as = "Option<Base64>")]
-	pub nit: Option<Bytes>,
+impl Si {
+	/// Add `section`, replacing an earlier one with the same identity. Returns whether
+	/// the set actually changed, so a caller can skip republishing on a repetition (SI
+	/// repeats every couple of seconds; almost every section is a repeat).
+	pub fn upsert(&mut self, section: Bytes) -> bool {
+		let key = section_key(&section);
+		match self.sections.iter_mut().find(|s| section_key(s) == key) {
+			Some(existing) if *existing == section => false,
+			Some(existing) => {
+				*existing = section;
+				true
+			}
+			None => {
+				self.sections.push(section);
+				true
+			}
+		}
+	}
+}
+
+/// Identify a section within its PID: `(table_id, table_id_extension, section_number)`.
+///
+/// Generic section syntax (ISO 13818-1 / EN 300 468), not table-specific: a long-form
+/// section (`section_syntax_indicator` set) is one part of one version of one table,
+/// while a short-form one (TDT and friends) has no extension or numbering and so is
+/// identified by its `table_id` alone. A runt is keyed by whatever it has, leaving the
+/// byte-equality check to decide.
+fn section_key(section: &[u8]) -> (u8, u16, u8) {
+	let table_id = section.first().copied().unwrap_or(0);
+	let long_form = section.get(1).is_some_and(|b| b & 0x80 != 0);
+	if !long_form || section.len() < 8 {
+		return (table_id, 0, 0);
+	}
+	let extension = ((section[3] as u16) << 8) | section[4] as u16;
+	(table_id, extension, section[6])
 }
 
 /// One track's MPEG-TS identity and signaling.
@@ -282,26 +350,79 @@ mod test {
 	}
 
 	#[test]
-	fn service_roundtrip() {
-		let mpegts = Mpegts {
-			service: Some(Service {
-				transport_stream_id: 0x1234,
-				service_id: 1,
-				pmt_pid: 0x0064,
-				sdt: Some(Bytes::from_static(b"\x42\xf0\x25")),
-				nit: None,
-				..Default::default()
-			}),
+	fn program_and_si_roundtrip() {
+		let mut si = Si {
+			interval: Some(Duration::from_secs(2)),
 			..Default::default()
 		};
-		assert!(!mpegts.is_empty(), "a service record is not empty");
+		assert!(
+			si.upsert(Bytes::from_static(b"\x42\xf0\x25")),
+			"first section is a change"
+		);
+
+		let mpegts = Mpegts {
+			program: Some(Program {
+				transport_stream_id: 0x1234,
+				program_number: 1,
+				pmt_pid: 0x0064,
+				..Default::default()
+			}),
+			si: BTreeMap::from([(0x0011, si)]),
+			..Default::default()
+		};
+		assert!(!mpegts.is_empty(), "a program record is not empty");
 
 		let json = serde_json::to_string(&Ext { mpegts: mpegts.clone() }).unwrap();
-		// The SDT section is base64; the absent NIT is omitted.
-		assert!(json.contains("\"sdt\""), "sdt present: {json}");
-		assert!(!json.contains("\"nit\""), "absent nit omitted: {json}");
+		// Sections are base64 under their PID; the PMT PID is structured, not a section.
+		assert!(json.contains("\"sections\""), "sections present: {json}");
+		assert!(json.contains("\"pmtPid\":100"), "identity stays structured: {json}");
+		// The PID key is a decimal string, since JSON object keys are strings.
+		assert!(json.contains("\"17\":"), "PID key written as a string: {json}");
+		// Lock in the interval's wire shape: a bare integer number of milliseconds.
+		// Without the `DurationMilliSeconds` adapter this regresses to serde's default
+		// `{secs, nanos}` object.
+		assert!(json.contains("\"interval\":2000"), "interval is bare millis: {json}");
 
 		let parsed: Ext = serde_json::from_str(&json).unwrap();
-		assert_eq!(parsed.mpegts, mpegts, "service section round-trips");
+		assert_eq!(parsed.mpegts, mpegts, "program and SI round-trip");
+	}
+
+	/// A repeated section must not count as a change: SI repeats every couple of
+	/// seconds, so treating a repeat as an update would republish the catalog forever.
+	/// A *revised* section (same identity, new bytes) replaces in place, and a sibling
+	/// section (same table, different `section_number`) is added alongside.
+	#[test]
+	fn si_upsert_dedupes_by_section_identity() {
+		// Long-form SDT Actual: table_id 0x42, syntax indicator set, extension 0x0001.
+		let section = |section_number: u8, fill: u8| {
+			Bytes::from(vec![
+				0x42,
+				0xf0,
+				0x0b,
+				0x00,
+				0x01,
+				0xc1,
+				section_number,
+				0x01,
+				fill,
+				fill,
+				fill,
+				fill,
+				fill,
+				fill,
+			])
+		};
+
+		let mut si = Si::default();
+		assert!(si.upsert(section(0, 0xaa)), "first section");
+		assert!(!si.upsert(section(0, 0xaa)), "a byte-identical repeat is not a change");
+		assert_eq!(si.sections.len(), 1);
+
+		assert!(si.upsert(section(0, 0xbb)), "revised section 0 is a change");
+		assert_eq!(si.sections.len(), 1, "the revision replaced in place");
+		assert_eq!(si.sections[0], section(0, 0xbb));
+
+		assert!(si.upsert(section(1, 0xcc)), "section 1 is a sibling, not a replacement");
+		assert_eq!(si.sections.len(), 2, "both sections of the table are held");
 	}
 }

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -63,10 +63,14 @@ pub struct Export<E: catalog::Catalog = ()> {
 	counters: HashMap<u16, ContinuityCounter>,
 	/// PMT program-level descriptors captured on import, re-emitted in the PMT.
 	program_descriptors: Vec<catalog::Descriptor>,
-	/// DVB service layer captured on import: transport/service identity (rebuilds a
-	/// consistent PAT/PMT) plus the SDT/NIT sections re-emitted verbatim. `None` for
-	/// a media-only source, so a minimal identity is synthesized instead.
-	service: Option<catalog::Service>,
+	/// Transport/service identity captured on import, used to rebuild a consistent
+	/// PAT/PMT. `None` for a media-only source, so a minimal identity is synthesized.
+	program: Option<catalog::Program>,
+	/// Standalone SI sections captured on import, keyed by PID and re-emitted verbatim
+	/// on their own cadence. Opaque: export never parses a table it carries.
+	si: BTreeMap<u16, catalog::Si>,
+	/// When each SI PID was last emitted, so each honors its own interval.
+	last_si: HashMap<u16, Timestamp>,
 
 	/// Program tables, built once the track layout is known.
 	psi: Option<Psi>,
@@ -199,7 +203,9 @@ impl<E: catalog::Catalog> Export<E> {
 			tracks: HashMap::new(),
 			counters: HashMap::new(),
 			program_descriptors: Vec::new(),
-			service: None,
+			program: None,
+			si: BTreeMap::new(),
+			last_si: HashMap::new(),
 			psi: None,
 			last_psi: None,
 			video_start: None,
@@ -339,7 +345,8 @@ impl<E: catalog::Catalog> Export<E> {
 		// empty default: no verbatim streams, no preserved PIDs/descriptors).
 		let mpegts = catalog.mpegts_mut().cloned().unwrap_or_default();
 		self.program_descriptors = mpegts.program_descriptors.clone();
-		self.service = mpegts.service.clone();
+		self.program = mpegts.program.clone();
+		self.si = mpegts.si.clone();
 
 		// The desired track set: media renditions plus the verbatim streams.
 		let mut active: BTreeMap<String, ()> = BTreeMap::new();
@@ -522,7 +529,7 @@ impl<E: catalog::Catalog> Export<E> {
 	/// PID the PMT rides on: the source's original (preserved in the service record),
 	/// or the synthesized [`PMT_PID`] for a media-only source or an invalid (zero) value.
 	fn pmt_pid(&self) -> u16 {
-		self.service
+		self.program
 			.as_ref()
 			.map(|s| s.pmt_pid)
 			.filter(|&pid| pid != 0)
@@ -635,14 +642,14 @@ impl<E: catalog::Catalog> Export<E> {
 			Vec::new()
 		};
 
-		// Preserve the source's transport/service identity so the rebuilt PAT/PMT stay
-		// consistent with the carried SDT/NIT; synthesize a minimal identity otherwise.
+		// Preserve the source's program identity so the rebuilt PAT/PMT stay consistent
+		// with the carried SI; synthesize a minimal identity otherwise.
 		let pmt_pid = self.pmt_pid();
-		let transport_stream_id = self.service.as_ref().map(|s| s.transport_stream_id).unwrap_or(1);
-		let service_id = self
-			.service
+		let transport_stream_id = self.program.as_ref().map(|s| s.transport_stream_id).unwrap_or(1);
+		let program_number = self
+			.program
 			.as_ref()
-			.map(|s| s.service_id)
+			.map(|s| s.program_number)
 			.filter(|&id| id != 0)
 			.unwrap_or(1);
 
@@ -650,12 +657,12 @@ impl<E: catalog::Catalog> Export<E> {
 			transport_stream_id,
 			version_number: VersionNumber::default(),
 			table: vec![ProgramAssociation {
-				program_num: service_id,
+				program_num: program_number,
 				program_map_pid: Pid::new(pmt_pid)?,
 			}],
 		};
 		let pmt = Pmt {
-			program_num: service_id,
+			program_num: program_number,
 			pcr_pid: Some(Pid::new(pcr_pid)?),
 			version_number: VersionNumber::default(),
 			program_info,
@@ -737,27 +744,35 @@ impl<E: catalog::Catalog> Export<E> {
 		let mut out = Vec::with_capacity(TsPacket::SIZE);
 
 		// Refresh PSI at keyframes or after the interval lapses.
-		let psi_due = psi_due(frame.timestamp, self.last_psi);
-		if (is_video && frame.keyframe) || psi_due {
+		if (is_video && frame.keyframe) || due(frame.timestamp, self.last_psi, PSI_INTERVAL) {
 			let psi = self.psi.as_ref().context("PSI not built")?;
 			let pmt_pid = psi.pmt_pid;
 			let pat = TsPayload::Pat(psi.pat.clone());
 			let pmt = TsPayload::Pmt(psi.pmt.clone());
 			self.write_packet(&mut out, Pid::PAT, None, pat)?;
 			self.write_packet(&mut out, pmt_pid, None, pmt)?;
-
-			// Re-emit the DVB service layer (SDT, NIT) verbatim alongside the PSI, so the
-			// service name/provider/network survive. Regenerated tables (TDT/TOT) and EPG
-			// (EIT) are out of scope.
-			let sdt = self.service.as_ref().and_then(|s| s.sdt.clone());
-			let nit = self.service.as_ref().and_then(|s| s.nit.clone());
-			if let Some(sdt) = sdt {
-				self.write_section(&mut out, catalog::SDT_PID, &sdt)?;
-			}
-			if let Some(nit) = nit {
-				self.write_section(&mut out, catalog::NIT_PID, &nit)?;
-			}
 			self.last_psi = Some(frame.timestamp);
+		}
+
+		// Re-emit each SI PID's sections verbatim on its own cadence, which is the
+		// table's own repetition requirement rather than the PSI interval: an SDT wants
+		// 2s where the PSI wants 500ms, and an EPG table would want far less again.
+		// Unknown PIDs have no declared interval and fall back to the PSI cadence.
+		// `Bytes` clones are refcount bumps, and only a due PID is collected at all.
+		let pending: Vec<(u16, Vec<Bytes>)> = self
+			.si
+			.iter()
+			.filter(|(pid, si)| {
+				let interval = si.interval.unwrap_or(PSI_INTERVAL);
+				due(frame.timestamp, self.last_si.get(*pid).copied(), interval)
+			})
+			.map(|(pid, si)| (*pid, si.sections.clone()))
+			.collect();
+		for (pid, sections) in pending {
+			for section in &sections {
+				self.write_section(&mut out, pid, section)?;
+			}
+			self.last_si.insert(pid, frame.timestamp);
 		}
 
 		match es_payload {
@@ -963,13 +978,13 @@ const PES_DTS_LEN: usize = 5;
 /// [`author_dts`] and [`Track::dts_reserve`].
 const DEFAULT_DTS_RESERVE: u64 = 16;
 
-fn psi_due(timestamp: Timestamp, last: Option<Timestamp>) -> bool {
+fn due(timestamp: Timestamp, last: Option<Timestamp>, interval: Duration) -> bool {
 	let Some(last) = last else {
 		return true;
 	};
 	Duration::from(timestamp)
 		.checked_sub(Duration::from(last))
-		.is_some_and(|elapsed| elapsed >= PSI_INTERVAL)
+		.is_some_and(|elapsed| elapsed >= interval)
 }
 
 /// External byte size of an adaptation field (manual mirror of the crate's
@@ -1166,7 +1181,9 @@ fn dts_reserve(config: &VideoConfig) -> u64 {
 
 #[cfg(test)]
 mod tests {
-	use super::{DEFAULT_DTS_RESERVE, author_dts, is_complete_section, psi_due};
+	use std::time::Duration;
+
+	use super::{DEFAULT_DTS_RESERVE, PSI_INTERVAL, author_dts, due, is_complete_section};
 	use moq_net::Timestamp;
 
 	fn ms(value: u64) -> Timestamp {
@@ -1268,11 +1285,17 @@ mod tests {
 	}
 
 	#[test]
-	fn psi_due_uses_elapsed_duration() {
-		assert!(psi_due(ms(1_000), None));
-		assert!(!psi_due(ms(1_250), Some(ms(1_000))));
-		assert!(psi_due(ms(1_500), Some(ms(1_000))));
-		assert!(!psi_due(ms(750), Some(ms(1_000))));
+	fn due_uses_elapsed_duration() {
+		assert!(due(ms(1_000), None, PSI_INTERVAL));
+		assert!(!due(ms(1_250), Some(ms(1_000)), PSI_INTERVAL));
+		assert!(due(ms(1_500), Some(ms(1_000)), PSI_INTERVAL));
+		assert!(!due(ms(750), Some(ms(1_000)), PSI_INTERVAL));
+
+		// A per-PID SI interval is honored independently of the PSI cadence: an SDT at
+		// 2s is not due when the 500ms PSI would be.
+		let sdt = Duration::from_millis(2_000);
+		assert!(!due(ms(1_500), Some(ms(1_000)), sdt));
+		assert!(due(ms(3_000), Some(ms(1_000)), sdt));
 	}
 
 	#[test]

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -63,6 +63,10 @@ pub struct Export<E: catalog::Catalog = ()> {
 	counters: HashMap<u16, ContinuityCounter>,
 	/// PMT program-level descriptors captured on import, re-emitted in the PMT.
 	program_descriptors: Vec<catalog::Descriptor>,
+	/// DVB service layer captured on import: transport/service identity (rebuilds a
+	/// consistent PAT/PMT) plus the SDT/NIT sections re-emitted verbatim. `None` for
+	/// a media-only source, so a minimal identity is synthesized instead.
+	service: Option<catalog::Service>,
 
 	/// Program tables, built once the track layout is known.
 	psi: Option<Psi>,
@@ -136,6 +140,9 @@ struct Psi {
 	pat: Pat,
 	pmt: Pmt,
 	pcr_pid: u16,
+	/// PID the PMT rides on: the source's original (preserved from the service
+	/// record) or the synthesized [`PMT_PID`] for a media-only source.
+	pmt_pid: u16,
 }
 
 /// Per-frame PES descriptor (everything but the payload bytes).
@@ -192,6 +199,7 @@ impl<E: catalog::Catalog> Export<E> {
 			tracks: HashMap::new(),
 			counters: HashMap::new(),
 			program_descriptors: Vec::new(),
+			service: None,
 			psi: None,
 			last_psi: None,
 			video_start: None,
@@ -331,6 +339,7 @@ impl<E: catalog::Catalog> Export<E> {
 		// empty default: no verbatim streams, no preserved PIDs/descriptors).
 		let mpegts = catalog.mpegts_mut().cloned().unwrap_or_default();
 		self.program_descriptors = mpegts.program_descriptors.clone();
+		self.service = mpegts.service.clone();
 
 		// The desired track set: media renditions plus the verbatim streams.
 		let mut active: BTreeMap<String, ()> = BTreeMap::new();
@@ -368,7 +377,7 @@ impl<E: catalog::Catalog> Export<E> {
 		// PIDs, descriptors, and stream_ids across several catalog publishes, so this
 		// runs every snapshot until the PMT is built and the tracks below are
 		// *refreshed*, not latched from the first (partial) snapshot.
-		let mut used: Vec<u16> = vec![0x0000, PMT_PID, 0x1FFF];
+		let mut used: Vec<u16> = vec![0x0000, self.pmt_pid(), 0x1FFF];
 		let mut pids: BTreeMap<String, u16> = BTreeMap::new();
 		for name in active.keys() {
 			if let Some(pid) = mpegts.tracks.get(name).map(|t| t.pid)
@@ -510,6 +519,16 @@ impl<E: catalog::Catalog> Export<E> {
 			.min()
 	}
 
+	/// PID the PMT rides on: the source's original (preserved in the service record),
+	/// or the synthesized [`PMT_PID`] for a media-only source or an invalid (zero) value.
+	fn pmt_pid(&self) -> u16 {
+		self.service
+			.as_ref()
+			.map(|s| s.pmt_pid)
+			.filter(|&pid| pid != 0)
+			.unwrap_or(PMT_PID)
+	}
+
 	/// Build the PAT/PMT once every track's PID and codec is known.
 	fn build_psi(&mut self) -> anyhow::Result<()> {
 		// Order tracks by PID for a stable layout; first video track carries the PCR.
@@ -616,23 +635,39 @@ impl<E: catalog::Catalog> Export<E> {
 			Vec::new()
 		};
 
+		// Preserve the source's transport/service identity so the rebuilt PAT/PMT stay
+		// consistent with the carried SDT/NIT; synthesize a minimal identity otherwise.
+		let pmt_pid = self.pmt_pid();
+		let transport_stream_id = self.service.as_ref().map(|s| s.transport_stream_id).unwrap_or(1);
+		let service_id = self
+			.service
+			.as_ref()
+			.map(|s| s.service_id)
+			.filter(|&id| id != 0)
+			.unwrap_or(1);
+
 		let pat = Pat {
-			transport_stream_id: 1,
+			transport_stream_id,
 			version_number: VersionNumber::default(),
 			table: vec![ProgramAssociation {
-				program_num: 1,
-				program_map_pid: Pid::new(PMT_PID)?,
+				program_num: service_id,
+				program_map_pid: Pid::new(pmt_pid)?,
 			}],
 		};
 		let pmt = Pmt {
-			program_num: 1,
+			program_num: service_id,
 			pcr_pid: Some(Pid::new(pcr_pid)?),
 			version_number: VersionNumber::default(),
 			program_info,
 			es_info,
 		};
 
-		self.psi = Some(Psi { pat, pmt, pcr_pid });
+		self.psi = Some(Psi {
+			pat,
+			pmt,
+			pcr_pid,
+			pmt_pid,
+		});
 		Ok(())
 	}
 
@@ -705,10 +740,23 @@ impl<E: catalog::Catalog> Export<E> {
 		let psi_due = psi_due(frame.timestamp, self.last_psi);
 		if (is_video && frame.keyframe) || psi_due {
 			let psi = self.psi.as_ref().context("PSI not built")?;
+			let pmt_pid = psi.pmt_pid;
 			let pat = TsPayload::Pat(psi.pat.clone());
 			let pmt = TsPayload::Pmt(psi.pmt.clone());
 			self.write_packet(&mut out, Pid::PAT, None, pat)?;
-			self.write_packet(&mut out, PMT_PID, None, pmt)?;
+			self.write_packet(&mut out, pmt_pid, None, pmt)?;
+
+			// Re-emit the DVB service layer (SDT, NIT) verbatim alongside the PSI, so the
+			// service name/provider/network survive. Regenerated tables (TDT/TOT) and EPG
+			// (EIT) are out of scope.
+			let sdt = self.service.as_ref().and_then(|s| s.sdt.clone());
+			let nit = self.service.as_ref().and_then(|s| s.nit.clone());
+			if let Some(sdt) = sdt {
+				self.write_section(&mut out, catalog::SDT_PID, &sdt)?;
+			}
+			if let Some(nit) = nit {
+				self.write_section(&mut out, catalog::NIT_PID, &nit)?;
+			}
 			self.last_psi = Some(frame.timestamp);
 		}
 

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1353,7 +1353,10 @@ async fn service_layer_survives_roundtrip() {
 	let nit = make_section(0x40, &[0x12, 0x34, 0xff, 0x01]);
 
 	// Prepend a synthetic NIT Actual packet (0x0010); prepend keeps bbb's alignment.
+	// Twice, because real SI repeats every few seconds: the repetition must collapse
+	// into the same single section rather than accumulating a duplicate.
 	let mut input = si_packet(0x0010, &nit);
+	input.extend_from_slice(&si_packet(0x0010, &nit));
 	input.extend_from_slice(&data[..]);
 
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
@@ -1365,20 +1368,31 @@ async fn service_layer_survives_roundtrip() {
 	import.decode(&BytesMut::from(&input[..])).unwrap();
 	import.finish().unwrap();
 
-	let service = catalog.snapshot().mpegts.service.clone().expect("a service record");
-	assert_eq!(service.transport_stream_id, 1, "TSID captured from the PAT");
-	assert_eq!(service.service_id, 1, "service number captured from the PAT");
-	assert_eq!(service.pmt_pid, 0x1000, "original PMT PID captured from the PAT");
-	let sdt = service.sdt.clone().expect("the source SDT was captured");
+	let snapshot = catalog.snapshot();
+	let program = snapshot.mpegts.program.clone().expect("a program record");
+	assert_eq!(program.transport_stream_id, 1, "TSID captured from the PAT");
+	assert_eq!(program.program_number, 1, "program number captured from the PAT");
+	assert_eq!(program.pmt_pid, 0x1000, "original PMT PID captured from the PAT");
+	let si = snapshot.mpegts.si.clone();
+	let entry = |pid: u16| si.get(&pid).expect("an SI entry for the PID");
+
+	assert_eq!(entry(0x0011).sections.len(), 1, "bbb.ts carries one SDT section");
+	let sdt = entry(0x0011).sections[0].clone();
 	assert_eq!(sdt.first(), Some(&0x42), "SDT Actual (table_id 0x42)");
+	assert_eq!(
+		entry(0x0011).interval,
+		Some(std::time::Duration::from_secs(2)),
+		"the DVB SDT interval was filled in"
+	);
 	let (service_type, provider, name) = parse_sdt_service(&sdt);
 	assert_eq!(
 		(service_type, provider.as_str(), name.as_str()),
 		(0x01, "FFmpeg", "Service01")
 	);
 	assert_eq!(
-		service.nit.as_deref(),
-		Some(&make_section(0x40, &[0x12, 0x34, 0xff, 0x01])[..])
+		entry(0x0010).sections,
+		vec![Bytes::from(make_section(0x40, &[0x12, 0x34, 0xff, 0x01]))],
+		"the repeated NIT deduped to one section"
 	);
 
 	// `import` and `catalog` stay alive: retained tracks the exporter subscribes to.
@@ -1415,20 +1429,22 @@ async fn service_layer_survives_roundtrip() {
 	import2.decode(&BytesMut::from(ts.as_ref())).unwrap();
 	import2.finish().unwrap();
 
-	let service2 = catalog2
-		.snapshot()
+	let snapshot2 = catalog2.snapshot();
+	let program2 = snapshot2
 		.mpegts
-		.service
+		.program
 		.clone()
-		.expect("a service record after round-trip");
+		.expect("a program record after round-trip");
 	assert_eq!(
-		service2.transport_stream_id, service.transport_stream_id,
+		program2.transport_stream_id, program.transport_stream_id,
 		"TSID survived"
 	);
-	assert_eq!(service2.service_id, service.service_id, "service number survived");
-	assert_eq!(service2.pmt_pid, service.pmt_pid, "PMT PID survived");
-	assert_eq!(service2.sdt, service.sdt, "SDT survived byte-for-byte");
-	assert_eq!(service2.nit, service.nit, "NIT survived byte-for-byte");
+	assert_eq!(
+		program2.program_number, program.program_number,
+		"program number survived"
+	);
+	assert_eq!(program2.pmt_pid, program.pmt_pid, "PMT PID survived");
+	assert_eq!(snapshot2.mpegts.si, si, "every SI PID survived byte-for-byte");
 }
 
 /// A DVB SI section larger than one TS packet must be reassembled and captured verbatim.
@@ -1452,10 +1468,10 @@ fn multi_packet_si_section_is_captured() {
 	import.decode(&BytesMut::from(&input[..])).unwrap();
 	import.finish().unwrap();
 
-	let service = catalog.snapshot().mpegts.service.clone().expect("a service record");
+	let si = catalog.snapshot().mpegts.si.clone();
 	assert_eq!(
-		service.sdt.as_deref(),
-		Some(&sdt[..]),
+		si.get(&0x0011).expect("an SDT entry").sections,
+		vec![Bytes::from(sdt)],
 		"the multi-packet SDT was reassembled and captured byte-for-byte"
 	);
 }

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1286,6 +1286,40 @@ fn si_packet(pid: u16, section: &[u8]) -> Vec<u8> {
 	p
 }
 
+/// Split a complete section across several 188-byte TS packets on `pid`: a PUSI packet
+/// (pointer_field 0) carrying the head, then continuation packets (PUSI clear, continuity
+/// counter advancing) for the rest, the last padded with 0xff stuffing. Unlike `si_packet`
+/// this reaches the multi-packet reassembly path (PUSI + continuity across packets).
+fn si_packets_multi(pid: u16, section: &[u8]) -> Vec<u8> {
+	let mut out = Vec::new();
+	let mut cc = 0u8;
+	// First packet: PUSI set, pointer_field 0, then as much of the section as fits.
+	let mut first = vec![
+		0x47,
+		0x40 | ((pid >> 8) as u8 & 0x1f),
+		(pid & 0xff) as u8,
+		0x10 | cc,
+		0x00,
+	];
+	let head = section.len().min(188 - first.len());
+	first.extend_from_slice(&section[..head]);
+	first.resize(188, 0xff);
+	out.extend_from_slice(&first);
+
+	// Continuation packets: PUSI clear, continuity counter incremented per payload packet.
+	let mut pos = head;
+	while pos < section.len() {
+		cc = (cc + 1) & 0x0f;
+		let mut p = vec![0x47, (pid >> 8) as u8 & 0x1f, (pid & 0xff) as u8, 0x10 | cc];
+		let take = (section.len() - pos).min(188 - p.len());
+		p.extend_from_slice(&section[pos..pos + take]);
+		p.resize(188, 0xff);
+		out.extend_from_slice(&p);
+		pos += take;
+	}
+	out
+}
+
 /// Decode an SDT Actual section's first service: `(service_type, provider, name)` from the
 /// service_descriptor (tag 0x48). Enough to prove the service identity survived, no more.
 fn parse_sdt_service(sec: &[u8]) -> (u8, String, String) {
@@ -1395,6 +1429,35 @@ async fn service_layer_survives_roundtrip() {
 	assert_eq!(service2.pmt_pid, service.pmt_pid, "PMT PID survived");
 	assert_eq!(service2.sdt, service.sdt, "SDT survived byte-for-byte");
 	assert_eq!(service2.nit, service.nit, "NIT survived byte-for-byte");
+}
+
+/// A DVB SI section larger than one TS packet must be reassembled and captured verbatim.
+/// `si_packet` only covers a single-packet section; a real SDT with several services (or a
+/// NIT) spans packets, exercising the `SectionReassembler` PUSI + continuity path that
+/// feeds `service.sdt`. The body is arbitrary here (capture is verbatim, not parsed).
+#[test]
+fn multi_packet_si_section_is_captured() {
+	// 400-byte body forces the SDT Actual across three TS packets (183 + 184 + rest).
+	let body: Vec<u8> = (0..400u16).map(|i| i as u8).collect();
+	let sdt = make_section(0x42, &body);
+	let input = si_packets_multi(0x0011, &sdt);
+	assert!(input.len() > 188, "the SDT must span more than one TS packet");
+
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let _consumer = broadcast.consume();
+	let catalog =
+		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
+	import.decode(&BytesMut::from(&input[..])).unwrap();
+	import.finish().unwrap();
+
+	let service = catalog.snapshot().mpegts.service.clone().expect("a service record");
+	assert_eq!(
+		service.sdt.as_deref(),
+		Some(&sdt[..]),
+		"the multi-packet SDT was reassembled and captured byte-for-byte"
+	);
 }
 
 /// A raw Opus packet: a one-byte TOC (config 1 = SILK NB 20 ms, stereo, code 0) plus

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -1262,6 +1262,141 @@ async fn scte35_fixtures_survive_roundtrip() {
 	}
 }
 
+/// Build a PSI section: `table_id`, the 12-bit `section_length` (covering `body` plus a
+/// 4-byte CRC), then `body` and a dummy CRC. The reassembler carries it verbatim and
+/// never validates the CRC, so the bytes only need a self-consistent length.
+fn make_section(table_id: u8, body: &[u8]) -> Vec<u8> {
+	let section_length = body.len() + 4;
+	let mut s = vec![
+		table_id,
+		0xb0 | ((section_length >> 8) as u8 & 0x0f),
+		(section_length & 0xff) as u8,
+	];
+	s.extend_from_slice(body);
+	s.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+	s
+}
+
+/// Wrap a complete section in one PUSI TS packet on `pid` (pointer_field 0), padded to 188.
+fn si_packet(pid: u16, section: &[u8]) -> Vec<u8> {
+	let mut p = vec![0x47, 0x40 | ((pid >> 8) as u8 & 0x1f), (pid & 0xff) as u8, 0x10, 0x00];
+	p.extend_from_slice(section);
+	assert!(p.len() <= 188, "section overflows one TS packet");
+	p.resize(188, 0xff);
+	p
+}
+
+/// Decode an SDT Actual section's first service: `(service_type, provider, name)` from the
+/// service_descriptor (tag 0x48). Enough to prove the service identity survived, no more.
+fn parse_sdt_service(sec: &[u8]) -> (u8, String, String) {
+	// header(8) + first service loop entry: service_id(2), flags(1), running/free + desc_len(2).
+	let desc_loop_len = (((sec[11 + 3] & 0x0f) as usize) << 8) | sec[11 + 4] as usize;
+	let mut d = 11 + 5;
+	let end = d + desc_loop_len;
+	while d < end {
+		let (tag, len) = (sec[d], sec[d + 1] as usize);
+		let body = &sec[d + 2..d + 2 + len];
+		if tag == 0x48 {
+			let service_type = body[0];
+			let prov_len = body[1] as usize;
+			let provider = String::from_utf8_lossy(&body[2..2 + prov_len]).into_owned();
+			let name_len = body[2 + prov_len] as usize;
+			let name = String::from_utf8_lossy(&body[3 + prov_len..3 + prov_len + name_len]).into_owned();
+			return (service_type, provider, name);
+		}
+		d += 2 + len;
+	}
+	panic!("SDT service_descriptor (0x48) not found");
+}
+
+/// The DVB service layer (SDT + NIT + transport/service identity) must survive
+/// TS -> MoQ -> TS. `bbb.ts` carries a real ffmpeg SDT (service "Service01" / provider
+/// "FFmpeg"); no fixture carries a NIT, so a synthetic one is injected on PID 0x0010.
+/// After the round-trip the SDT and NIT are byte-identical and the identity is preserved.
+#[tokio::test(start_paused = true)]
+async fn service_layer_survives_roundtrip() {
+	let data = include_bytes!("test_data/bbb.ts");
+	let nit = make_section(0x40, &[0x12, 0x34, 0xff, 0x01]);
+
+	// Prepend a synthetic NIT Actual packet (0x0010); prepend keeps bbb's alignment.
+	let mut input = si_packet(0x0010, &nit);
+	input.extend_from_slice(&data[..]);
+
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let catalog =
+		crate::catalog::Producer::with_catalog(&mut broadcast, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
+	import.decode(&BytesMut::from(&input[..])).unwrap();
+	import.finish().unwrap();
+
+	let service = catalog.snapshot().mpegts.service.clone().expect("a service record");
+	assert_eq!(service.transport_stream_id, 1, "TSID captured from the PAT");
+	assert_eq!(service.service_id, 1, "service number captured from the PAT");
+	assert_eq!(service.pmt_pid, 0x1000, "original PMT PID captured from the PAT");
+	let sdt = service.sdt.clone().expect("the source SDT was captured");
+	assert_eq!(sdt.first(), Some(&0x42), "SDT Actual (table_id 0x42)");
+	let (service_type, provider, name) = parse_sdt_service(&sdt);
+	assert_eq!(
+		(service_type, provider.as_str(), name.as_str()),
+		(0x01, "FFmpeg", "Service01")
+	);
+	assert_eq!(
+		service.nit.as_deref(),
+		Some(&make_section(0x40, &[0x12, 0x34, 0xff, 0x01])[..])
+	);
+
+	// `import` and `catalog` stay alive: retained tracks the exporter subscribes to.
+	let ts = drain_with(
+		Export::with_ts(crate::source::announced(&consumer), crate::catalog::CatalogFormat::Hang)
+			.await
+			.unwrap(),
+	)
+	.await;
+	assert_packet_aligned(&ts);
+
+	// The rebuilt PAT preserves the transport/service identity and PMT PID.
+	let mut reader = TsPacketReader::new(Cursor::new(ts.as_ref()));
+	let mut checked_pat = false;
+	while let Some(packet) = reader.read_ts_packet().unwrap() {
+		if let Some(TsPayload::Pat(pat)) = packet.payload {
+			assert_eq!(pat.transport_stream_id, 1, "TSID preserved in the rebuilt PAT");
+			assert_eq!(pat.table.len(), 1);
+			assert_eq!(pat.table[0].program_num, 1, "service number preserved");
+			assert_eq!(pat.table[0].program_map_pid.as_u16(), 0x1000, "PMT PID preserved");
+			checked_pat = true;
+			break;
+		}
+	}
+	assert!(checked_pat, "missing PAT");
+
+	// Re-import: the SDT and NIT must come back byte-for-byte.
+	let mut broadcast2 = moq_net::broadcast::Info::new().produce();
+	let _consumer2 = broadcast2.consume();
+	let catalog2 =
+		crate::catalog::Producer::with_catalog(&mut broadcast2, crate::catalog::hang::Catalog::<tscat::Ext>::default())
+			.unwrap();
+	let mut import2 = crate::container::ts::Import::new(broadcast2, catalog2.reserve());
+	import2.decode(&BytesMut::from(ts.as_ref())).unwrap();
+	import2.finish().unwrap();
+
+	let service2 = catalog2
+		.snapshot()
+		.mpegts
+		.service
+		.clone()
+		.expect("a service record after round-trip");
+	assert_eq!(
+		service2.transport_stream_id, service.transport_stream_id,
+		"TSID survived"
+	);
+	assert_eq!(service2.service_id, service.service_id, "service number survived");
+	assert_eq!(service2.pmt_pid, service.pmt_pid, "PMT PID survived");
+	assert_eq!(service2.sdt, service.sdt, "SDT survived byte-for-byte");
+	assert_eq!(service2.nit, service.nit, "NIT survived byte-for-byte");
+}
+
 /// A raw Opus packet: a one-byte TOC (config 1 = SILK NB 20 ms, stereo, code 0) plus
 /// `len` filler bytes, so it parses as one 20 ms frame.
 fn opus_packet(fill: u8, len: usize) -> Bytes {

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -8,12 +8,12 @@
 //! ride the normal PES reassembly, while section-framed streams (SCTE-35 and
 //! other private sections, which are not PES) are intercepted before the mpeg2ts
 //! reader and reassembled. TS adds PAT/PMT discovery, PES reassembly, the
-//! private-section path, and the 90 kHz -> microsecond PTS conversion. The DVB
-//! service layer (transport/service identity from the PAT, plus the SDT and NIT
-//! sections) is captured into the `mpegts` catalog [`Service`](catalog::Service)
-//! record so it survives the round-trip.
+//! private-section path, and the 90 kHz -> microsecond PTS conversion. The service
+//! layer is captured into the `mpegts` catalog too: the identity parsed from the PAT
+//! as a [`Program`](catalog::Program) record, and the standalone SI PIDs as opaque
+//! [`Si`](catalog::Si) sections, so both survive the round-trip.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::Read;
 use std::sync::{Arc, Mutex};
 
@@ -100,13 +100,17 @@ pub struct Import<E: catalog::Catalog = ()> {
 	/// Whether the PMT program-level descriptors have been recorded yet (set once;
 	/// PMT `program_info` is stable for the program's life).
 	program_recorded: bool,
-	/// Reassemblers for the standalone DVB SI PIDs (SDT 0x0011, NIT 0x0010), keyed
-	/// by PID. Intercepted before the reader (like SCTE-35 sections) so the service
-	/// layer survives the round-trip. Only populated with `mpegts` catalog support.
-	service_sections: HashMap<u16, SectionReassembler>,
+	/// Reassemblers for the standalone SI PIDs ([`catalog::SI_PIDS`]), keyed by PID.
+	/// Intercepted before the reader (like SCTE-35 sections) so the service layer
+	/// survives the round-trip. Only populated with `mpegts` catalog support.
+	si_sections: HashMap<u16, SectionReassembler>,
+	/// The SI sections currently published, keyed by PID. Kept alongside the catalog
+	/// so a repetition can be recognized without taking the catalog's write lock,
+	/// which would mark it modified and republish it every couple of seconds.
+	si: BTreeMap<u16, catalog::Si>,
 	/// Whether the service identity (TSID/service_id/PMT PID) has been captured from
 	/// the PAT into the catalog service record yet (set once; the PAT is stable).
-	service_recorded: bool,
+	identity_recorded: bool,
 	/// Latest video PTS: the media clock used to timestamp private sections, which
 	/// carry no PES PTS of their own. Unwrapped independently of the video stream.
 	/// SPTS scope: one clock for the whole input. Under MPTS every program's video
@@ -143,8 +147,9 @@ impl<E: catalog::Catalog> Import<E> {
 			es_descriptors: HashMap::new(),
 			recorded_media: HashSet::new(),
 			program_recorded: false,
-			service_sections: HashMap::new(),
-			service_recorded: false,
+			si_sections: HashMap::new(),
+			si: BTreeMap::new(),
+			identity_recorded: false,
 			last_pts: None,
 			media_unwrap: PtsUnwrap::default(),
 		}
@@ -207,11 +212,11 @@ impl<E: catalog::Catalog> Import<E> {
 				section.packet(&pkt, pts)?;
 				continue;
 			}
-			// Intercept the standalone DVB SI PIDs (SDT, NIT) before the routing gate
-			// below drops them: they carry the service layer, not media, and are not fed
-			// to the reader (which only routes the PAT/PMT/ES PIDs it learns).
-			if self.supports_mpegts && matches!(pid, catalog::SDT_PID | catalog::NIT_PID) {
-				self.service_section(pid, &pkt);
+			// Intercept the standalone SI PIDs before the routing gate below drops them:
+			// they carry the service layer, not media, and are not fed to the reader
+			// (which only routes the PAT/PMT/ES PIDs it learns).
+			if self.supports_mpegts && catalog::SI_PIDS.iter().any(|(p, _)| *p == pid) {
+				self.si_section(pid, &pkt);
 				continue;
 			}
 			// PIDs we don't decode and don't carry (`Stream::Ignored`: a base catalog's
@@ -300,7 +305,7 @@ impl<E: catalog::Catalog> Import<E> {
 			Some(TsPayload::Pat(pat)) => {
 				self.pmt_pids
 					.extend(pat.table.iter().map(|entry| entry.program_map_pid));
-				self.record_service_identity(&pat);
+				self.record_program_identity(&pat);
 			}
 			_ => {}
 		}
@@ -587,55 +592,59 @@ impl<E: catalog::Catalog> Import<E> {
 
 	/// Capture the transport/service identity (TSID, service number, PMT PID) from the
 	/// PAT into the catalog service record, once. No-op without `mpegts` support.
-	fn record_service_identity(&mut self, pat: &mpeg2ts::ts::payload::Pat) {
-		if !self.supports_mpegts || self.service_recorded {
+	fn record_program_identity(&mut self, pat: &mpeg2ts::ts::payload::Pat) {
+		if !self.supports_mpegts || self.identity_recorded {
 			return;
 		}
 		// program_number 0 is the network PID association, not a service; skip it.
-		let Some(program) = pat.table.iter().find(|entry| entry.program_num != 0) else {
+		let Some(entry) = pat.table.iter().find(|entry| entry.program_num != 0) else {
 			return;
 		};
 		if let Some(mpegts) = self.catalog.lock().mpegts_mut() {
-			let service = mpegts.service.get_or_insert_with(Default::default);
-			service.transport_stream_id = pat.transport_stream_id;
-			service.service_id = program.program_num;
-			service.pmt_pid = program.program_map_pid.as_u16();
+			let program = mpegts.program.get_or_insert_with(Default::default);
+			program.transport_stream_id = pat.transport_stream_id;
+			program.program_number = entry.program_num;
+			program.pmt_pid = entry.program_map_pid.as_u16();
 		}
-		self.service_recorded = true;
+		self.identity_recorded = true;
 	}
 
-	/// Feed one TS packet on a DVB SI PID (SDT or NIT) to its reassembler, recording
-	/// each completed Actual section verbatim into the catalog service record.
-	fn service_section(&mut self, pid: u16, pkt: &[u8]) {
+	/// Feed one TS packet on a standalone SI PID to its reassembler, recording each
+	/// completed section verbatim into that PID's catalog entry.
+	///
+	/// Every section is captured, whatever its `table_id`: the SDT PID also carries
+	/// the BAT, an SDT can describe several services across several sections, and a
+	/// table we don't recognize is exactly as worth preserving as one we do. The
+	/// catalog holds a *set* per PID, so these coexist instead of overwriting each
+	/// other, and a plain repetition (SI repeats every couple of seconds) leaves the
+	/// set untouched rather than republishing the catalog.
+	fn si_section(&mut self, pid: u16, pkt: &[u8]) {
 		let mut sections = Vec::new();
-		self.service_sections.entry(pid).or_default().push(pkt, &mut sections);
-		for section in sections {
-			self.record_service_section(pid, section);
-		}
-	}
-
-	/// Record one complete SI section verbatim: the first SDT Actual (table_id 0x42) or
-	/// NIT Actual (table_id 0x40) seen. Later sections (repeats, the `Other` variants,
-	/// BAT on the SDT PID) are ignored; a single-service SPTS needs only the first.
-	fn record_service_section(&mut self, pid: u16, section: Vec<u8>) {
-		let wanted = matches!(
-			(pid, section.first().copied()),
-			(catalog::SDT_PID, Some(catalog::SDT_ACTUAL_TABLE_ID))
-				| (catalog::NIT_PID, Some(catalog::NIT_ACTUAL_TABLE_ID))
-		);
-		if !wanted {
+		self.si_sections.entry(pid).or_default().push(pkt, &mut sections);
+		if sections.is_empty() {
 			return;
 		}
-		if let Some(mpegts) = self.catalog.lock().mpegts_mut() {
-			let service = mpegts.service.get_or_insert_with(Default::default);
-			let slot = if pid == catalog::SDT_PID {
-				&mut service.sdt
-			} else {
-				&mut service.nit
-			};
-			if slot.is_none() {
-				*slot = Some(bytes::Bytes::from(section));
+
+		// Apply to the local copy first and bail on a repetition. Taking the catalog's
+		// write lock marks it modified even when the value is unchanged, so doing this
+		// the other way round would republish the catalog on every SI cycle.
+		let updated = {
+			let si = self.si.entry(pid).or_insert_with(|| catalog::Si {
+				interval: catalog::SI_PIDS.iter().find(|(p, _)| *p == pid).map(|(_, i)| *i),
+				..Default::default()
+			});
+			let mut changed = false;
+			for section in sections {
+				changed |= si.upsert(bytes::Bytes::from(section));
 			}
+			changed.then(|| si.clone())
+		};
+		let Some(updated) = updated else {
+			return;
+		};
+
+		if let Some(mpegts) = self.catalog.lock().mpegts_mut() {
+			mpegts.si.insert(pid, updated);
 		}
 	}
 

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -8,7 +8,10 @@
 //! ride the normal PES reassembly, while section-framed streams (SCTE-35 and
 //! other private sections, which are not PES) are intercepted before the mpeg2ts
 //! reader and reassembled. TS adds PAT/PMT discovery, PES reassembly, the
-//! private-section path, and the 90 kHz -> microsecond PTS conversion.
+//! private-section path, and the 90 kHz -> microsecond PTS conversion. The DVB
+//! service layer (transport/service identity from the PAT, plus the SDT and NIT
+//! sections) is captured into the `mpegts` catalog [`Service`](catalog::Service)
+//! record so it survives the round-trip.
 
 use std::collections::{HashMap, HashSet};
 use std::io::Read;
@@ -97,6 +100,13 @@ pub struct Import<E: catalog::Catalog = ()> {
 	/// Whether the PMT program-level descriptors have been recorded yet (set once;
 	/// PMT `program_info` is stable for the program's life).
 	program_recorded: bool,
+	/// Reassemblers for the standalone DVB SI PIDs (SDT 0x0011, NIT 0x0010), keyed
+	/// by PID. Intercepted before the reader (like SCTE-35 sections) so the service
+	/// layer survives the round-trip. Only populated with `mpegts` catalog support.
+	service_sections: HashMap<u16, SectionReassembler>,
+	/// Whether the service identity (TSID/service_id/PMT PID) has been captured from
+	/// the PAT into the catalog service record yet (set once; the PAT is stable).
+	service_recorded: bool,
 	/// Latest video PTS: the media clock used to timestamp private sections, which
 	/// carry no PES PTS of their own. Unwrapped independently of the video stream.
 	/// SPTS scope: one clock for the whole input. Under MPTS every program's video
@@ -133,6 +143,8 @@ impl<E: catalog::Catalog> Import<E> {
 			es_descriptors: HashMap::new(),
 			recorded_media: HashSet::new(),
 			program_recorded: false,
+			service_sections: HashMap::new(),
+			service_recorded: false,
 			last_pts: None,
 			media_unwrap: PtsUnwrap::default(),
 		}
@@ -193,6 +205,13 @@ impl<E: catalog::Catalog> Import<E> {
 			let pts = self.last_pts.unwrap_or(Timestamp::ZERO);
 			if let Some(section) = self.sections.get_mut(&pid) {
 				section.packet(&pkt, pts)?;
+				continue;
+			}
+			// Intercept the standalone DVB SI PIDs (SDT, NIT) before the routing gate
+			// below drops them: they carry the service layer, not media, and are not fed
+			// to the reader (which only routes the PAT/PMT/ES PIDs it learns).
+			if self.supports_mpegts && matches!(pid, catalog::SDT_PID | catalog::NIT_PID) {
+				self.service_section(pid, &pkt);
 				continue;
 			}
 			// PIDs we don't decode and don't carry (`Stream::Ignored`: a base catalog's
@@ -281,6 +300,7 @@ impl<E: catalog::Catalog> Import<E> {
 			Some(TsPayload::Pat(pat)) => {
 				self.pmt_pids
 					.extend(pat.table.iter().map(|entry| entry.program_map_pid));
+				self.record_service_identity(&pat);
 			}
 			_ => {}
 		}
@@ -563,6 +583,60 @@ impl<E: catalog::Catalog> Import<E> {
 			entry.descriptors = descriptors;
 		}
 		self.recorded_media.insert(pid);
+	}
+
+	/// Capture the transport/service identity (TSID, service number, PMT PID) from the
+	/// PAT into the catalog service record, once. No-op without `mpegts` support.
+	fn record_service_identity(&mut self, pat: &mpeg2ts::ts::payload::Pat) {
+		if !self.supports_mpegts || self.service_recorded {
+			return;
+		}
+		// program_number 0 is the network PID association, not a service; skip it.
+		let Some(program) = pat.table.iter().find(|entry| entry.program_num != 0) else {
+			return;
+		};
+		if let Some(mpegts) = self.catalog.lock().mpegts_mut() {
+			let service = mpegts.service.get_or_insert_with(Default::default);
+			service.transport_stream_id = pat.transport_stream_id;
+			service.service_id = program.program_num;
+			service.pmt_pid = program.program_map_pid.as_u16();
+		}
+		self.service_recorded = true;
+	}
+
+	/// Feed one TS packet on a DVB SI PID (SDT or NIT) to its reassembler, recording
+	/// each completed Actual section verbatim into the catalog service record.
+	fn service_section(&mut self, pid: u16, pkt: &[u8]) {
+		let mut sections = Vec::new();
+		self.service_sections.entry(pid).or_default().push(pkt, &mut sections);
+		for section in sections {
+			self.record_service_section(pid, section);
+		}
+	}
+
+	/// Record one complete SI section verbatim: the first SDT Actual (table_id 0x42) or
+	/// NIT Actual (table_id 0x40) seen. Later sections (repeats, the `Other` variants,
+	/// BAT on the SDT PID) are ignored; a single-service SPTS needs only the first.
+	fn record_service_section(&mut self, pid: u16, section: Vec<u8>) {
+		let wanted = matches!(
+			(pid, section.first().copied()),
+			(catalog::SDT_PID, Some(catalog::SDT_ACTUAL_TABLE_ID))
+				| (catalog::NIT_PID, Some(catalog::NIT_ACTUAL_TABLE_ID))
+		);
+		if !wanted {
+			return;
+		}
+		if let Some(mpegts) = self.catalog.lock().mpegts_mut() {
+			let service = mpegts.service.get_or_insert_with(Default::default);
+			let slot = if pid == catalog::SDT_PID {
+				&mut service.sdt
+			} else {
+				&mut service.nit
+			};
+			if slot.is_none() {
+				*slot = Some(bytes::Bytes::from(section));
+			}
+		}
 	}
 
 	/// Close the current group on every track and reopen at `sequence`.

--- a/rs/moq-mux/src/container/ts/mod.rs
+++ b/rs/moq-mux/src/container/ts/mod.rs
@@ -9,9 +9,10 @@
 //! Elementary streams we don't decode (SCTE-35, teletext, DVB subtitles, private
 //! data, ...) are carried verbatim, one MoQ track per PID, described in the
 //! [`Mpegts`] catalog section. SCTE-35 is just one such stream (`stream_type` 0x86).
-//! The DVB service layer (transport/service identity plus the SDT/NIT tables) rides
-//! the same section as a [`Service`] record, so the service name, provider, and
-//! network survive the round-trip.
+//! The service layer rides the same section: the transport/service identity as a
+//! [`Program`] record, and the standalone SI tables (SDT, NIT, ...) as opaque [`Si`]
+//! sections re-emitted on their original PIDs, so the service name, provider, and
+//! network survive the round-trip without anything parsing them.
 
 mod adts;
 mod export;
@@ -22,7 +23,7 @@ mod import;
 // they read as `ts::Catalog`, `ts::Mpegts`, ... instead of stuttering under `catalog`.
 mod catalog;
 
-pub use catalog::{Catalog, Descriptor, Ext, Framing, Mpegts, Service, Track, Verbatim};
+pub use catalog::{Catalog, Descriptor, Ext, Framing, Mpegts, Program, Si, Track, Verbatim};
 pub use export::*;
 pub use import::*;
 

--- a/rs/moq-mux/src/container/ts/mod.rs
+++ b/rs/moq-mux/src/container/ts/mod.rs
@@ -9,6 +9,9 @@
 //! Elementary streams we don't decode (SCTE-35, teletext, DVB subtitles, private
 //! data, ...) are carried verbatim, one MoQ track per PID, described in the
 //! [`Mpegts`] catalog section. SCTE-35 is just one such stream (`stream_type` 0x86).
+//! The DVB service layer (transport/service identity plus the SDT/NIT tables) rides
+//! the same section as a [`Service`] record, so the service name, provider, and
+//! network survive the round-trip.
 
 mod adts;
 mod export;
@@ -19,7 +22,7 @@ mod import;
 // they read as `ts::Catalog`, `ts::Mpegts`, ... instead of stuttering under `catalog`.
 mod catalog;
 
-pub use catalog::{Catalog, Descriptor, Ext, Framing, Mpegts, Track, Verbatim};
+pub use catalog::{Catalog, Descriptor, Ext, Framing, Mpegts, Service, Track, Verbatim};
 pub use export::*;
 pub use import::*;
 


### PR DESCRIPTION
An alternative shape for #2434, opened separately so the two can be diffed. **Built directly on @t0ms's two commits** (`feat(mux): preserve the DVB service layer across the TS round-trip` and `test(mux): cover multi-packet DVB SI section reassembly`), which are unchanged here. The third commit is the only delta.

The diagnosis in #2434 is right and the end-to-end validation there (a live CNN International feed through a real publisher -> relay -> subscriber, with matching SHA-1s on the SDT and NIT) stands. This changes where the section bytes live, not whether they are preserved.

## What differs

| | #2434 | here |
|---|---|---|
| Carriage | `Service::sdt`, `Service::nit` | `si: BTreeMap<u16, Si>`, opaque sections keyed by PID |
| Cost of the next table | 2 constants + 2 branches + a field | one row in `SI_PIDS` |
| Multi-section table | not representable | `sections: Vec<Bytes>` |
| Repeats | first section wins, permanently | upsert by section identity |
| Cadence | the PSI interval (500ms) | per-PID interval (SDT 2s, NIT 10s) |

## Why

**Two named fields do not generalize.** `sdt` and `nit` each need a PID constant, a `table_id` constant, and a branch on both the import and export side. BAT, ATSC PSIP, or a private operator table would each cost another of all four. Splitting on what export actually *understands* removes that: the transport/service identity stays parsed, because rebuilding a consistent PAT/PMT requires it, and everything else is opaque bytes re-emitted on the PID it arrived on. An unrecognized table now round-trips exactly like a recognized one.

**A PID carries a set, not a single table.** PID 0x0011 carries SDT Actual *and* the BAT; a multi-service SDT spans several sections that are all simultaneously current. `Option<Bytes>` structurally cannot hold that, so a real MPTS SDT would have been truncated to its first section.

**Repetition is not mutation.** The first-wins latch meant a service rename or a `running_status` change was pinned to whatever arrived first. Sections are now deduped by `(table_id, table_id_extension, section_number)`, so a revision replaces in place and a sibling section is added alongside. The dedupe runs *before* the catalog's write lock is taken, because that lock marks the catalog modified even on an unchanged write, and SI repeats every couple of seconds.

**Repetition cadence is transport policy, not source data.** #2434 emits SDT and NIT on the PSI cadence, which is 4x more often than DVB requires for the SDT and 20x for the NIT. Harmless at ~1KB each, bad the moment a larger table joins the same path. Each PID now carries its own interval, taken from the spec maximum (ETSI TS 101 211) rather than the source's observed cadence, which is a property of that multiplexer's bitrate shaping and means nothing after a remux. It is a hint: absent for an unknown PID, which falls back to the PSI cadence rather than being dropped.

## Notes

- `si` is keyed by PID, with the key serialized as a decimal string (`"17"`) via `serde_with`'s `DisplayFromStr`. A plain integer-keyed map serializes fine and then fails to parse: the catalog deserializes via `serde_json::Value`, which does not coerce string map keys back to integers. Four existing tests caught that; `DisplayFromStr` makes the string key explicit on both sides. The map (rather than a list with a `pid` field) also makes a duplicate entry for one PID unrepresentable, and removes the chance of a key disagreeing with the field it duplicates.
- TDT/TOT and EIT stay out of scope, unchanged from #2434, but they are now a policy decision in `SI_PIDS` rather than a shape limitation.
- Retargeted to `main`. `dev` is currently 0 commits ahead of `main`, so this is purely additive `pub` API per the branch-targeting rules.

## Public API

- `ts::Service` becomes `ts::Program`, loses `sdt`/`nit`, and renames `service_id` to `program_number`. It now holds only the three PAT-parsed identity fields, which is the MPEG *program*; DVB's "service" is a synonym that does not travel to ATSC or ISDB, so the record is named for the role. `Mpegts::service` becomes `Mpegts::program`.
- `ts::Si` is new (`sections`, `interval`) with `Si::upsert`, plus `Mpegts::si`. `interval` is a `Duration` serialized as bare milliseconds via `DurationMilliSeconds`, matching the hang catalog's `jitter` field, with a test locking that wire shape (without the adapter it silently regresses to serde's `{secs, nanos}`).

Nothing in #2434 has shipped, so this is a reshape of an unreleased surface rather than a break.

## Test plan

- `cargo test -p moq-mux`: 401 tests + 2 doctests pass. `cargo clippy -p moq-mux --all-targets -- -D warnings` and `RUSTDOCFLAGS="-D warnings" cargo doc -p moq-mux` clean.
- `catalog::si_upsert_dedupes_by_section_identity` (new): a byte-identical repeat is not a change, a revision replaces in place, a sibling `section_number` is added alongside.
- `export_test::service_layer_survives_roundtrip` (adapted from #2434): now injects the synthetic NIT **twice**, so the repeat-collapses path is actually exercised. The original assertion I first wrote here was vacuous, since `bbb.ts` contains exactly one SDT packet.
- `due_uses_elapsed_duration` (extended): a 2s SI interval is not due when the 500ms PSI would be.
- `catalog::program_and_si_roundtrip` asserts the PID key lands as a string; `service_layer_survives_roundtrip` is the load-bearing check, since it drives a full import -> export -> import through the real `Value`-based catalog path.
- Not re-run: the live-feed end-to-end validation from #2434. The section bytes take the same verbatim path, but the cadence change is not covered by the unit tests.

(written by Opus 4.8)

