### PR TITLE
fix(js/net): reconnect correctly after a peer closes the session

### DIFF
--- a/js/net/src/connection/reload.test.ts
+++ b/js/net/src/connection/reload.test.ts
@@ -1,4 +1,7 @@
 import { expect, test } from "bun:test";
+import * as Lite from "../lite/index.ts";
+import { createMockTransportPair } from "../mock.ts";
+import { accept } from "./index.ts";
 import { Reload } from "./reload.ts";
 
 async function settle() {
@@ -38,6 +41,34 @@ test("equivalent URL instances do not restart a pending connection", async () =>
 		reload.url.set(new URL("https://example.com/other"));
 		await settle();
 		expect(connects).toBe(2);
+	} finally {
+		reload.close();
+		globalThis.WebTransport = original;
+	}
+});
+
+test("a peer that severs immediately keeps escalating the backoff", async () => {
+	const original = globalThis.WebTransport;
+	const url = new URL("https://example.com/");
+	const stub = function StubWebTransport() {
+		const pair = createMockTransportPair(Lite.ALPN_06_WIP);
+		// Sever the session as soon as the server side finishes the handshake.
+		void accept(pair.server, url).then((server) => server.close());
+		return pair.client;
+	};
+	globalThis.WebTransport = stub as unknown as typeof WebTransport;
+
+	// Every session dies well within `initial`, so the backoff has to keep escalating
+	// and the retry window has to expire. Resetting either on each successful connect
+	// reconnects forever at the initial delay and never gives up.
+	const reload = new Reload({
+		enabled: true,
+		url,
+		websocket: { enabled: false },
+		delay: { initial: 200, multiplier: 2, max: 1000, timeout: 250 },
+	});
+	try {
+		await expect(reload.closed).rejects.toThrow();
 	} finally {
 		reload.close();
 		globalThis.WebTransport = original;

--- a/js/net/src/connection/reload.test.ts
+++ b/js/net/src/connection/reload.test.ts
@@ -61,11 +61,14 @@ test("a peer that severs immediately keeps escalating the backoff", async () => 
 	// Every session dies well within `initial`, so the backoff has to keep escalating
 	// and the retry window has to expire. Resetting either on each successful connect
 	// reconnects forever at the initial delay and never gives up.
+	//
+	// `initial` sits far above the in-process handshake so a loaded runner can't make a
+	// session look healthy, and the tiny timeout gives up after one backoff.
 	const reload = new Reload({
 		enabled: true,
 		url,
 		websocket: { enabled: false },
-		delay: { initial: 200, multiplier: 2, max: 1000, timeout: 250 },
+		delay: { initial: 1000, multiplier: 2, max: 1000, timeout: 1 },
 	});
 	try {
 		await expect(reload.closed).rejects.toThrow();

--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -156,9 +156,24 @@ export class Reload {
 				this.#delay = this.delay.initial;
 				this.#retryStart = undefined;
 
-				await Promise.race([effect.cancel, connection.closed]);
+				const connected = performance.now();
+				const closed = await Promise.race([effect.cancel, connection.closed.then(() => true)]);
+				if (!closed) return;
+
+				// The peer closed the session: tear down and reconnect. A session that
+				// died within the initial delay escalates through the backoff instead.
+				console.warn("connection closed, reconnecting");
+				if (performance.now() - connected < this.delay.initial) {
+					throw new Error("connection closed immediately");
+				}
+				this.#tick.update((prev) => prev + 1);
 			} catch (err) {
 				console.warn("connection error:", err);
+
+				// Any session is dead now: report disconnected during the backoff
+				// rather than when the retry reruns the effect.
+				this.established.set(undefined);
+				this.status.set("disconnected");
 
 				// Track retry start for timeout.
 				this.#retryStart ??= performance.now();

--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -134,6 +134,10 @@ export class Reload {
 		effect.set(this.status, "connecting", "disconnected");
 
 		effect.spawn(async () => {
+			// Set once the session is live, so #retry can tell a healthy session that
+			// later dropped from a connect failure or a peer that flaps immediately.
+			let connected: DOMHighResTimeStamp | undefined;
+
 			try {
 				const pending = connect(url, {
 					websocket: this.websocket,
@@ -152,48 +156,61 @@ export class Reload {
 
 				effect.set(this.status, "connected", "disconnected");
 
-				// Reset the exponential backoff and timeout on success.
-				this.#delay = this.delay.initial;
-				this.#retryStart = undefined;
+				connected = performance.now();
 
-				const connected = performance.now();
+				// A cancelled effect resolves undefined, so the sentinel tells the session
+				// closing apart from this run being torn down.
 				const closed = await Promise.race([effect.cancel, connection.closed.then(() => true)]);
 				if (!closed) return;
 
-				// The peer closed the session: tear down and reconnect. A session that
-				// died within the initial delay escalates through the backoff instead.
 				console.warn("connection closed, reconnecting");
-				if (performance.now() - connected < this.delay.initial) {
-					throw new Error("connection closed immediately");
-				}
-				this.#tick.update((prev) => prev + 1);
+				this.#retry(effect, connected);
 			} catch (err) {
 				console.warn("connection error:", err);
-
-				// Any session is dead now: report disconnected during the backoff
-				// rather than when the retry reruns the effect.
-				this.established.set(undefined);
-				this.status.set("disconnected");
-
-				// Track retry start for timeout.
-				this.#retryStart ??= performance.now();
-
-				const timeout = this.delay.timeout ?? 300000;
-				if (timeout > 0) {
-					const elapsed = performance.now() - this.#retryStart;
-					if (elapsed >= timeout) {
-						console.warn("reconnect timed out");
-						this.#closedReject(err instanceof Error ? err : new Error(String(err)));
-						return;
-					}
-				}
-
-				const tick = this.#tick.peek() + 1;
-				effect.timer(() => this.#tick.update((prev) => Math.max(prev, tick)), this.#delay);
-
-				this.#delay = Math.min(this.#delay * this.delay.multiplier, this.delay.max);
+				this.#retry(effect, connected, err);
 			}
 		});
+	}
+
+	/**
+	 * Schedule the next connect attempt after the current backoff, or give up when the
+	 * retry window has expired. `connected` is when the dead session was established, if
+	 * it ever was, and `cause` the error that killed it, if it died with one.
+	 */
+	#retry(effect: Effect, connected: DOMHighResTimeStamp | undefined, cause?: unknown): void {
+		// Any session is dead now: report disconnected during the backoff rather than
+		// when the retry reruns the effect.
+		this.established.set(undefined);
+		this.status.set("disconnected");
+
+		// A session that outlived the initial delay was healthy, so clear the backoff and
+		// start a fresh retry window: a one-off drop should reconnect promptly. Anything
+		// shorter is a peer that accepts and immediately severs, which has to keep
+		// escalating or we hammer it forever at the initial delay.
+		if (connected !== undefined && performance.now() - connected >= this.delay.initial) {
+			this.#delay = this.delay.initial;
+			this.#retryStart = undefined;
+		}
+
+		// Track retry start for timeout.
+		this.#retryStart ??= performance.now();
+
+		const timeout = this.delay.timeout ?? 300000;
+		if (timeout > 0) {
+			const elapsed = performance.now() - this.#retryStart;
+			if (elapsed >= timeout) {
+				console.warn("reconnect timed out");
+				// A graceful close has no error, so report the timeout itself.
+				if (cause === undefined) this.#closedReject(new Error("reconnect timed out"));
+				else this.#closedReject(cause instanceof Error ? cause : new Error(String(cause)));
+				return;
+			}
+		}
+
+		const tick = this.#tick.peek() + 1;
+		effect.timer(() => this.#tick.update((prev) => Math.max(prev, tick)), this.#delay);
+
+		this.#delay = Math.min(this.#delay * this.delay.multiplier, this.delay.max);
 	}
 
 	/**


### PR DESCRIPTION
Split out of #2431 by @wrangelvid (their commit is preserved here), so the reconnect fix can land on its own rather than riding along with an API reshape. #2441 stacks the stats work on top.

## The dead end

`Reload` never reconnected after a graceful close. `WebTransport.closed` rejects on an abnormal termination, which landed in the retry path, but *resolves* on a clean one, which fell out of the try block without bumping the tick. The effect never reran, so its cleanup never ran either: `established` kept pointing at a dead connection with `status` still `"connected"`, permanently.

The blind spot was exactly the case where the relay says goodbye politely, which is the common one: draining, rebalancing, idle timeout. A network failure reconnected fine.

## The backoff bug it exposed

Once closed sessions re-enter the loop, a second bug becomes reachable. `#delay` and `#retryStart` were reset the moment `connect()` resolved, before knowing whether the session was healthy. So against a peer that accepts and immediately severs:

1. session dies within `initial` → catch → `#retryStart = now` → sleep `initial` → `#delay *= 2`
2. next connect succeeds → **both reset**
3. repeat forever

The delay never escalates past `initial` and the 5-minute give-up never fires, so a flapping relay is hammered at one attempt per second indefinitely. `moq_native::Reconnect` guards this by resetting only when `connected.elapsed() >= backoff.initial`, which is what this adopts.

Both the closed and the failed paths now share one `#retry`:

- The backoff and retry window reset only for a session that outlived `delay.initial`.
- Every path waits out the backoff before reconnecting. The closed path previously bumped the tick immediately, where the Rust loop sleeps unconditionally, so a relay draining sessions on a schedule got an instant reconnect from every open tab.
- Passing the connect timestamp into `#retry` also fixes a healthy session that dies *with* an error: it took the catch path, which never reset the backoff, so it reconnected on whatever stale delay an earlier failure streak had left behind.
- `established` and `status` are cleared when the session dies rather than when the retry reruns the effect, so nothing observes a dead connection during the backoff.

The synthetic `Error("connection closed immediately")` is gone. It existed only to reach the backoff path, and it replaced the real close reason in the error reported when the retry window expires.

## Tests

New regression test in `reload.test.ts`: a stub transport that severs each session right after the handshake must reach the retry timeout. Against the pre-fix loop it reconnects forever, verified by killing it at 60s.

`just js check` and `just js test` are clean across all packages.

(written by Opus 4.8)