### PR TITLE
refactor(js/net)!: split the pulled transport stats from the pushed PROBE ones

### DIFF
--- a/demo/web/src/index.ts
+++ b/demo/web/src/index.ts
@@ -536,7 +536,7 @@ viz.interval(() => {
 	fpsGraph.push(fps);
 	throughputGraph.push(throughput);
 
-	const rtt = watch.connection.stats.peek()?.rtt as unknown as number | undefined;
+	const rtt = watch.connection.probe.peek()?.rtt as unknown as number | undefined;
 	rttGraph.push(rtt && rtt > 0 ? rtt : undefined);
 
 	prev = { frames, videoBytes, audioBytes, when: now };

--- a/demo/web/src/publish.ts
+++ b/demo/web/src/publish.ts
@@ -457,18 +457,18 @@ viz.run((effect) => {
 
 let prevFrames = 0;
 let prevWhen = performance.now();
-viz.interval(() => {
+viz.interval(async () => {
 	const now = performance.now();
 	const elapsed = now - prevWhen;
 	captureGraph.push(elapsed > 0 ? ((frames - prevFrames) * 1000) / elapsed : undefined);
 	prevFrames = frames;
 	prevWhen = now;
 
-	const stats = publish.connection.stats.peek();
-	const up = stats?.estimatedSendRate;
-	uploadGraph.push(up && up > 0 ? up : undefined);
-	const rtt = stats?.rtt as unknown as number | undefined;
+	const rtt = publish.connection.probe.peek()?.rtt as unknown as number | undefined;
 	rttGraph.push(rtt && rtt > 0 ? rtt : undefined);
+
+	const up = (await publish.connection.stats())?.estimatedSendRate;
+	uploadGraph.push(up && up > 0 ? up : undefined);
 }, 250);
 
 // Vite re-evaluates this module on hot reload, dropping the references to the

--- a/js/net/src/connection/established.ts
+++ b/js/net/src/connection/established.ts
@@ -2,7 +2,7 @@ import type { Getter } from "@moq/signals";
 import type * as announce from "../announced.ts";
 import type * as broadcast from "../broadcast.ts";
 import type * as Path from "../path.ts";
-import type { Stats } from "./stats.ts";
+import type { Probe, Stats } from "./stats.ts";
 import type { Transport } from "./transport.ts";
 
 /** An established MoQ session, implemented by both the moq-lite and moq-ietf protocols. */
@@ -17,12 +17,10 @@ export interface Established {
 	readonly transport: Transport;
 
 	/**
-	 * Live transport statistics, polled from the transport and merged with the MoQ PROBE
-	 * estimates. Every field is individually optional: what a connection can measure
-	 * depends on the transport and the negotiated version, so read the field you need and
-	 * handle `undefined` rather than assuming a populated snapshot.
+	 * Estimates measured by the peer, updated as PROBE messages arrive. Stays empty on
+	 * versions without PROBE. See {@link Stats} for what the local transport counts.
 	 */
-	readonly stats: Getter<Stats>;
+	readonly probe: Getter<Probe>;
 
 	/**
 	 * Whether the relay supports broadcast discovery: announcing which broadcasts exist under a
@@ -39,6 +37,14 @@ export interface Established {
 
 	/** Consume the broadcast at the given path. */
 	consume(path: Path.Valid): broadcast.Consumer;
+
+	/**
+	 * Snapshot the transport's counters, querying it fresh on each call.
+	 *
+	 * Resolves to an empty snapshot on a transport without `getStats()`. Sample it on
+	 * whatever schedule you need rather than expecting the library to poll for you.
+	 */
+	stats(): Promise<Stats>;
 
 	/** Close the session. */
 	close(): void;

--- a/js/net/src/connection/index.ts
+++ b/js/net/src/connection/index.ts
@@ -8,5 +8,5 @@ export { isWebTransportSupported } from "./browser.ts";
 export * from "./connect.ts";
 export * from "./established.ts";
 export * from "./reload.ts";
-export type { Stats } from "./stats.ts";
+export type { Probe, Stats } from "./stats.ts";
 export type { Transport } from "./transport.ts";

--- a/js/net/src/connection/reload.ts
+++ b/js/net/src/connection/reload.ts
@@ -4,7 +4,7 @@ import type * as Path from "../path.ts";
 import { empty as emptyPath } from "../path.ts";
 import { type ConnectProps, connect, type WebSocketOptions, type WebTransportProps } from "./connect.ts";
 import type { Established } from "./established.ts";
-import type { Stats } from "./stats.ts";
+import type { Probe, Stats } from "./stats.ts";
 
 /** Exponential backoff settings for {@link Reload}'s reconnect loop. */
 export type ReloadDelay = {
@@ -55,12 +55,12 @@ export class Reload {
 	established = new Signal<Established | undefined>(undefined);
 
 	/**
-	 * Live transport statistics of the current connection, spanning reconnects.
+	 * The current connection's PROBE estimates, spanning reconnects.
 	 *
-	 * Undefined while disconnected: the counters belong to a single connection, so
-	 * they reset rather than accumulate across a reconnect. See {@link Established.stats}.
+	 * Undefined while disconnected: the estimates belong to a single connection.
+	 * See {@link Established.probe}.
 	 */
-	readonly stats: Getter<Stats | undefined>;
+	readonly probe: Getter<Probe | undefined>;
 
 	/** WebTransport options applied to each connection attempt (not reactive). */
 	webtransport?: WebTransportProps;
@@ -123,9 +123,9 @@ export class Reload {
 			});
 		}
 
-		this.stats = this.#signals.computed((effect) => {
+		this.probe = this.#signals.computed((effect) => {
 			const connection = effect.get(this.established);
-			return connection && effect.get(connection.stats);
+			return connection && effect.get(connection.probe);
 		});
 
 		this.#url = this.#signals.computed((effect) => effect.get(this.url)?.href);
@@ -288,6 +288,14 @@ export class Reload {
 		void consumer.closed.then(() => pump.close());
 
 		return consumer;
+	}
+
+	/**
+	 * Snapshot the live connection's transport counters, or undefined while disconnected.
+	 * See {@link Established.stats}.
+	 */
+	async stats(): Promise<Stats | undefined> {
+		return this.established.peek()?.stats();
 	}
 
 	/** Stop reconnecting, close the current connection, and resolve {@link Reload.closed}. */

--- a/js/net/src/connection/stats.test.ts
+++ b/js/net/src/connection/stats.test.ts
@@ -5,15 +5,10 @@ import { createMockTransportPair } from "../mock.ts";
 import * as Time from "../time.ts";
 import { accept, connect } from "./index.ts";
 import { Reload } from "./reload.ts";
-import { mergeStats, pollTransportStats, type TransportStats, transportStats } from "./stats.ts";
+import { type TransportStats, transportStats } from "./stats.ts";
 
 function fakeQuic(stats: TransportStats): WebTransport {
 	return { getStats: () => Promise.resolve(stats) } as unknown as WebTransport;
-}
-
-// The poll refreshes every 100ms, so give it room to tick.
-function settle(ms = 250): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 test("transportStats maps the W3C dictionary and normalizes a null send rate", async () => {
@@ -29,150 +24,79 @@ test("transportStats maps the W3C dictionary and normalizes a null send rate", a
 			packetsLost: 6,
 		}),
 	);
-	expect(stats?.rtt).toBe(Time.Milli(25));
-	expect(stats?.estimatedSendRate).toBeUndefined();
-	expect(stats?.bytesSent).toBe(1);
-	expect(stats?.bytesReceived).toBe(2);
-	expect(stats?.bytesLost).toBe(3);
-	expect(stats?.packetsSent).toBe(4);
-	expect(stats?.packetsReceived).toBe(5);
-	expect(stats?.packetsLost).toBe(6);
+	expect(stats.rtt).toBe(Time.Milli(25));
+	expect(stats.estimatedSendRate).toBeUndefined();
+	expect(stats.bytesSent).toBe(1);
+	expect(stats.bytesReceived).toBe(2);
+	expect(stats.bytesLost).toBe(3);
+	expect(stats.packetsSent).toBe(4);
+	expect(stats.packetsReceived).toBe(5);
+	expect(stats.packetsLost).toBe(6);
 
-	// A snapshot without an RTT (e.g. a shim) leaves the field undefined.
-	expect((await transportStats(fakeQuic({ bytesSent: 10 })))?.rtt).toBeUndefined();
+	// Browsers don't report an RTT today, so the field is usually absent.
+	expect((await transportStats(fakeQuic({ bytesSent: 10 }))).rtt).toBeUndefined();
 });
 
-test("transportStats returns undefined without getStats or when it rejects", async () => {
-	expect(await transportStats({} as WebTransport)).toBeUndefined();
+test("transportStats returns an empty snapshot without getStats or when it rejects", async () => {
+	expect(await transportStats({} as WebTransport)).toEqual({});
 
 	const rejecting = { getStats: () => Promise.reject(new Error("nope")) } as unknown as WebTransport;
-	expect(await transportStats(rejecting)).toBeUndefined();
+	expect(await transportStats(rejecting)).toEqual({});
 });
 
-test("mergeStats prefers the transport RTT and takes the receive rate from PROBE", () => {
-	const transport = { rtt: Time.Milli(20), estimatedSendRate: 1_000, bytesSent: 5 };
-	const probe = { rtt: Time.Milli(90), estimatedRecvRate: 2_000 };
-
-	expect(mergeStats(transport, probe)).toEqual({
-		rtt: Time.Milli(20),
-		estimatedSendRate: 1_000,
-		estimatedRecvRate: 2_000,
-		bytesSent: 5,
-	});
-
-	// PROBE fills the RTT only when the transport doesn't measure one.
-	expect(mergeStats({}, probe).rtt).toBe(Time.Milli(90));
-	expect(mergeStats(transport, {}).rtt).toBe(Time.Milli(20));
-	expect(mergeStats(transport, {}).estimatedRecvRate).toBeUndefined();
-});
-
-test("pollTransportStats refreshes until the connection closes", async () => {
-	const stats: TransportStats = { smoothedRtt: 30, bytesSent: 1 };
-	const closed = Promise.withResolvers<void>();
-	const polled = pollTransportStats(fakeQuic(stats), closed.promise);
-
-	await settle();
-	expect(polled.peek().bytesSent).toBe(1);
-
-	stats.bytesSent = 2;
-	await settle();
-	expect(polled.peek().bytesSent).toBe(2);
-
-	closed.resolve();
-	await settle();
-	stats.bytesSent = 3;
-	await settle();
-	expect(polled.peek().bytesSent).toBe(2);
-});
-
-test("pollTransportStats keeps one request in flight and drops a stale completion", async () => {
-	let calls = 0;
-	let release!: (stats: TransportStats) => void;
-	const quic = {
-		getStats: () => {
-			calls += 1;
-			return new Promise<TransportStats>((resolve) => {
-				release = resolve;
-			});
-		},
-	} as unknown as WebTransport;
-
-	const closed = Promise.withResolvers<void>();
-	const polled = pollTransportStats(quic, closed.promise);
-
-	// The first request never settles, so the timer must not start another.
-	await settle(350);
-	expect(calls).toBe(1);
-
-	// Close, then let the outstanding request finish: its snapshot is stale.
-	closed.resolve();
-	release({ bytesSent: 7 });
-	await settle();
-	expect(polled.peek()).toEqual({});
-	expect(calls).toBe(1);
-});
-
-test("pollTransportStats stays empty on a transport without getStats", async () => {
-	const polled = pollTransportStats({} as WebTransport, new Promise(() => {}));
-	await settle();
-	expect(polled.peek()).toEqual({});
-});
-
-test("stats reports the transport snapshot over a live connection", async () => {
+test("stats() snapshots the transport on demand", async () => {
 	const pair = createMockTransportPair(Lite.ALPN_06_WIP, {
-		stats: { smoothedRtt: 40, estimatedSendRate: 2_000_000, bytesSent: 1_234, packetsLost: 3 },
+		stats: { estimatedSendRate: 2_000_000, bytesSent: 1_234, packetsLost: 3 },
 	});
 	const url = new URL("https://example.com/");
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 	try {
-		await settle();
-		const stats = client.stats.peek();
-		expect(stats.rtt).toBe(Time.Milli(40));
-		expect(stats.estimatedSendRate).toBe(2_000_000);
-		expect(stats.bytesSent).toBe(1_234);
-		expect(stats.packetsLost).toBe(3);
-		expect(stats.bytesReceived).toBeUndefined();
+		const first = await client.stats();
+		expect(first.estimatedSendRate).toBe(2_000_000);
+		expect(first.bytesSent).toBe(1_234);
+		expect(first.packetsLost).toBe(3);
+		expect(first.bytesReceived).toBeUndefined();
+
+		// Each call queries the transport again, so a caller controls its own sampling.
+		pair.client.stats.bytesSent = 5_678;
+		expect((await client.stats()).bytesSent).toBe(5_678);
 	} finally {
 		client.close();
 		server.close();
 	}
 });
 
-test("stats stays empty on a transport without getStats", async () => {
+test("stats() is empty on a transport without getStats", async () => {
 	const pair = createMockTransportPair(Lite.ALPN_06_WIP);
 	// Shadow the mock's getStats to imitate the qmux/WebSocket fallback.
 	(pair.client as unknown as { getStats?: unknown }).getStats = undefined;
 	const url = new URL("https://example.com/");
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 	try {
-		await settle();
-		expect(client.stats.peek()).toEqual({});
+		expect(await client.stats()).toEqual({});
 	} finally {
 		client.close();
 		server.close();
 	}
 });
 
-test("stats tracks the transport as it advances", async () => {
-	const pair = createMockTransportPair(Lite.ALPN_06_WIP, { stats: { smoothedRtt: 40 } });
+test("probe starts empty and stays empty without PROBE support", async () => {
+	const pair = createMockTransportPair(Ietf.ALPN.DRAFT_18, { stats: { bytesReceived: 42 } });
 	const url = new URL("https://example.com/");
 	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
 	try {
-		await settle();
-		expect(client.stats.peek().rtt).toBe(Time.Milli(40));
-
-		pair.client.stats.smoothedRtt = 80;
-		await settle();
-		expect(client.stats.peek().rtt).toBe(Time.Milli(80));
+		// moq-transport has no PROBE, but the transport counters still work.
+		expect(client.probe.peek()).toEqual({});
+		expect((await client.stats()).bytesReceived).toBe(42);
 	} finally {
 		client.close();
 		server.close();
 	}
 });
 
-test("Reload reports stats only while connected", async () => {
+test("Reload reports stats and probe only while connected", async () => {
 	const original = globalThis.WebTransport;
-	const pair = createMockTransportPair(Lite.ALPN_06_WIP, { stats: { smoothedRtt: 10 } });
+	const pair = createMockTransportPair(Lite.ALPN_06_WIP, { stats: { bytesSent: 99 } });
 	// `new` on a function returning an object yields that object, handing connect() the mock.
 	const stub = function StubWebTransport() {
 		return pair.client;
@@ -185,39 +109,19 @@ test("Reload reports stats only while connected", async () => {
 		while (!reload.established.peek()) {
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		}
-		await settle();
-		expect(reload.stats.peek()?.rtt).toBe(Time.Milli(10));
+		expect((await reload.stats())?.bytesSent).toBe(99);
+		expect(reload.probe.peek()).toEqual({});
 
-		// Close the server side: the session dies within the initial delay, so the
-		// loop escalates through the backoff and must not report the dead session.
 		server.close();
 		while (reload.established.peek()) {
 			await new Promise((resolve) => setTimeout(resolve, 0));
 		}
 		expect(reload.status.peek()).toBe("disconnected");
-		await settle(0);
-		expect(reload.stats.peek()).toBeUndefined();
+		expect(await reload.stats()).toBeUndefined();
+		await new Promise((resolve) => setTimeout(resolve, 0));
+		expect(reload.probe.peek()).toBeUndefined();
 	} finally {
 		reload.close();
 		globalThis.WebTransport = original;
-	}
-});
-
-test("stats reports the transport snapshot on an IETF connection", async () => {
-	const pair = createMockTransportPair(Ietf.ALPN.DRAFT_18, {
-		stats: { smoothedRtt: 15, bytesReceived: 42 },
-	});
-	const url = new URL("https://example.com/");
-	const [client, server] = await Promise.all([connect(url, { transport: pair.client }), accept(pair.server, url)]);
-	try {
-		await settle();
-		const stats = client.stats.peek();
-		expect(stats.rtt).toBe(Time.Milli(15));
-		expect(stats.bytesReceived).toBe(42);
-		// moq-transport has no PROBE, so there is no receive estimate.
-		expect(stats.estimatedRecvRate).toBeUndefined();
-	} finally {
-		client.close();
-		server.close();
 	}
 });

--- a/js/net/src/connection/stats.ts
+++ b/js/net/src/connection/stats.ts
@@ -1,38 +1,38 @@
 /**
- * Connection statistics: a live view of the transport's counters.
+ * Connection statistics: what the local transport counts, and what the peer reports.
  *
  * @module
  */
-import { type Getter, Signal } from "@moq/signals";
 import * as Time from "../time.ts";
 
-/** How often the transport is polled for fresh counters. */
-const POLL_INTERVAL = 100; // ms
-
 /**
- * A point-in-time snapshot of a connection's transport statistics.
+ * A point-in-time snapshot of the transport's counters, from `WebTransport.getStats()`.
  *
- * The counters come from `WebTransport.getStats()` (W3C field semantics) and
- * the estimates from the congestion controller and MoQ PROBE, mirroring the
- * shape of Rust's `moq_net::ConnectionStats`. Every field is optional: the
- * qmux/WebSocket fallback reports only the PROBE fields.
+ * Pulled on demand rather than pushed: the transport has no event to subscribe to, and
+ * a caller computing a rate wants to choose its own sampling instants. Snapshot twice
+ * and divide by the interval you measured.
  *
- * The field names match Rust but the counters are whatever the underlying stack
- * reports, so they are not normalized across the two. Notably W3C excludes
- * retransmissions and QUIC overhead from the byte counts where quinn includes
- * them, and counts packets where quinn counts datagrams.
+ * Every field is optional. The qmux/WebSocket fallback implements no `getStats()` at
+ * all and reports nothing; see {@link Probe} for what the peer measures.
+ *
+ * The field names match Rust's `moq_net::ConnectionStats` but the counters keep each
+ * stack's own semantics rather than being normalized. Notably W3C excludes
+ * retransmissions and QUIC overhead from the byte counts where quinn includes them,
+ * and counts packets where quinn counts datagrams.
  *
  * @public
  */
 export interface Stats {
-	/** Smoothed round-trip time estimate in milliseconds. */
+	/**
+	 * Smoothed round-trip time estimate in milliseconds.
+	 *
+	 * Usually absent: browsers don't report an RTT yet even though the W3C dictionary
+	 * has the field. Use {@link Probe.rtt}, which the peer measures.
+	 */
 	rtt?: Time.Milli;
 
 	/** Estimated send bandwidth from the congestion controller, in bits per second. */
 	estimatedSendRate?: number;
-
-	/** Estimated receive bandwidth from MoQ PROBE, in bits per second (moq-lite-03+ only). */
-	estimatedRecvRate?: number;
 
 	/** Total bytes sent on streams and datagrams, excluding retransmissions and QUIC overhead. */
 	bytesSent?: number;
@@ -54,6 +54,30 @@ export interface Stats {
 }
 
 /**
+ * Estimates measured by the peer and delivered over the MoQ PROBE stream.
+ *
+ * Pushed rather than pulled: these arrive when the peer sends them, so they're read
+ * from a signal. Empty until the first PROBE message, on versions without PROBE
+ * (moq-lite-01/02, moq-transport), and again once the stream ends, so a consumer
+ * never holds a stale estimate from a dead stream.
+ *
+ * @public
+ */
+export interface Probe {
+	/**
+	 * Round-trip time in milliseconds.
+	 *
+	 * The only RTT available today, since browsers don't populate the transport's.
+	 * Measured through the peer's application layer, so it reads higher than a
+	 * transport-level RTT would.
+	 */
+	rtt?: Time.Milli;
+
+	/** The peer's estimate of the bitrate it is receiving from us, in bits per second. */
+	estimatedRecvRate?: number;
+}
+
+/**
  * The subset of the W3C `WebTransportConnectionStats` dictionary we consume.
  * `getStats()` is not in TypeScript's DOM lib yet, so it is declared here.
  *
@@ -71,15 +95,14 @@ export interface TransportStats {
 }
 
 /**
- * Snapshot `quic` via `getStats()` into a {@link Stats}, or undefined
- * when the transport doesn't implement it (the qmux/WebSocket fallback, older
- * browsers). The caller fills the PROBE fields.
+ * Snapshot `quic` via `getStats()`, or an empty snapshot when the transport doesn't
+ * implement it (the qmux/WebSocket fallback, older browsers) or the call fails.
  *
  * @internal
  */
-export async function transportStats(quic: WebTransport): Promise<Stats | undefined> {
+export async function transportStats(quic: WebTransport): Promise<Stats> {
 	const getStats = (quic as { getStats?: () => Promise<TransportStats> }).getStats;
-	if (typeof getStats !== "function") return undefined;
+	if (typeof getStats !== "function") return {};
 	try {
 		const stats = await getStats.call(quic);
 		return {
@@ -93,74 +116,6 @@ export async function transportStats(quic: WebTransport): Promise<Stats | undefi
 			packetsLost: stats.packetsLost,
 		};
 	} catch {
-		return undefined;
+		return {};
 	}
-}
-
-/**
- * What MoQ PROBE contributes to a snapshot, measured by the peer's application layer
- * rather than the transport.
- *
- * @internal
- */
-export interface ProbeStats {
-	rtt?: Time.Milli;
-	estimatedRecvRate?: number;
-}
-
-/**
- * Merge PROBE's estimates into the transport's counters.
- *
- * The transport wins on RTT, since PROBE's round trip includes the peer's application
- * layer. The receive rate comes only from PROBE: the transport has no idea how fast the
- * peer thinks it is sending.
- *
- * @internal
- */
-export function mergeStats(transport: Stats, probe: ProbeStats): Stats {
-	return {
-		...transport,
-		rtt: transport.rtt ?? probe.rtt,
-		estimatedRecvRate: probe.estimatedRecvRate,
-	};
-}
-
-/**
- * Poll the transport's counters into a signal until `closed` settles.
- *
- * The signal starts empty. A transport without `getStats()` (the qmux/WebSocket
- * fallback, older browsers) starts no timer and stays empty forever.
- *
- * @internal
- */
-export function pollTransportStats(quic: WebTransport, closed: Promise<unknown>): Getter<Stats> {
-	const stats = new Signal<Stats>({});
-	if (typeof (quic as { getStats?: unknown }).getStats !== "function") return stats;
-
-	// One request at a time: a getStats() slower than the period would otherwise pile up
-	// requests, and an out-of-order completion would overwrite a newer snapshot.
-	let pending = false;
-	let done = false;
-
-	const poll = async () => {
-		if (pending || done) return;
-		pending = true;
-		try {
-			const next = await transportStats(quic);
-			// Drop a response that arrives after the connection closed.
-			if (!done) stats.set(next ?? {});
-		} finally {
-			pending = false;
-		}
-	};
-
-	void poll();
-	const id = setInterval(poll, POLL_INTERVAL);
-	const stop = () => {
-		done = true;
-		clearInterval(id);
-	};
-	closed.then(stop, stop);
-
-	return stats;
 }

--- a/js/net/src/ietf/connection.ts
+++ b/js/net/src/ietf/connection.ts
@@ -1,8 +1,8 @@
-import type { Getter } from "@moq/signals";
+import { type Getter, Signal } from "@moq/signals";
 import type * as announce from "../announced.ts";
 import type * as broadcast from "../broadcast.ts";
 import type { Established } from "../connection/established.ts";
-import { pollTransportStats, type Stats } from "../connection/stats.ts";
+import { type Probe, type Stats, transportStats } from "../connection/stats.ts";
 import { type Transport, transportOf } from "../connection/transport.ts";
 import * as Path from "../path.ts";
 import { type Reader, Readers, type Stream } from "../stream.ts";
@@ -36,8 +36,8 @@ export class Connection implements Established {
 	/** Whether the relay supports broadcast discovery; see {@link Established.discovery}. */
 	readonly discovery: boolean;
 
-	/** Live transport statistics; see {@link Established.stats}. */
-	readonly stats: Getter<Stats>;
+	/** moq-transport has no PROBE, so this stays empty; see {@link Established.probe}. */
+	readonly probe: Getter<Probe> = new Signal<Probe>({});
 
 	// The established WebTransport session.
 	#quic: WebTransport;
@@ -88,9 +88,6 @@ export class Connection implements Established {
 		this.transport = transportOf(quic);
 		this.#quic = quic;
 
-		// moq-transport has no PROBE, so the transport counters are the whole picture.
-		this.stats = pollTransportStats(quic, this.closed);
-
 		// Two-path dispatch: v14-v16 uses adapter, v17+ uses native bidi streams
 		if (version >= Version.DRAFT_17) {
 			this.#session = new NativeSession(quic, version, client);
@@ -110,6 +107,11 @@ export class Connection implements Established {
 		this.#subscriber = new Subscriber(this.#session);
 
 		void this.#run();
+	}
+
+	/** Snapshot the transport's counters; see {@link Established.stats}. */
+	async stats(): Promise<Stats> {
+		return transportStats(this.#quic);
 	}
 
 	/**

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -1,12 +1,11 @@
-import { Effect, type Getter, Signal } from "@moq/signals";
+import { type Getter, Signal } from "@moq/signals";
 import type * as announce from "../announced.ts";
 import type * as broadcast from "../broadcast.ts";
 import type { Established } from "../connection/established.ts";
-import { mergeStats, pollTransportStats, type Stats } from "../connection/stats.ts";
+import { type Probe, type Stats, transportStats } from "../connection/stats.ts";
 import { type Transport, transportOf } from "../connection/transport.ts";
 import * as Path from "../path.ts";
 import { type Reader, Readers, Stream, Writer } from "../stream.ts";
-import type * as Time from "../time.ts";
 import { AnnounceRequest } from "./announce.ts";
 import { Fetch } from "./fetch.ts";
 import { Goaway } from "./goaway.ts";
@@ -19,7 +18,7 @@ import { DataType, StreamId } from "./stream.ts";
 import { Subscribe } from "./subscribe.ts";
 import { Subscriber } from "./subscriber.ts";
 import { Track as TrackMessage } from "./track.ts";
-import { hasDatagrams, hasSetupStream, Version, versionName } from "./version.ts";
+import { hasDatagrams, hasSetupStream, type Version, versionName } from "./version.ts";
 
 /**
  * Constructor options for {@link Connection}.
@@ -72,8 +71,8 @@ export class Connection implements Established {
 	// Module for distributing tracks.
 	#subscriber: Subscriber;
 
-	/** Live transport statistics; see {@link Established.stats}. */
-	readonly stats: Getter<Stats>;
+	/** The peer's PROBE estimates; see {@link Established.probe}. */
+	readonly probe: Getter<Probe>;
 
 	/** Random per-connection origin id. Shared by Publisher (for outbound hop
 	 * chains) and Subscriber (available for optional self-filtering on announces). */
@@ -88,14 +87,8 @@ export class Connection implements Established {
 	// direction without handing out the whole SETUP (whose probe level gates our own streams).
 	#peerRole = new Signal<Role | undefined>(undefined);
 
-	// PROBE's own estimates, merged into `stats` behind the transport's. The recv rate
-	// exists only on versions that carry PROBE at all (lite-03+).
-	#probeRtt = new Signal<Time.Milli | undefined>(undefined);
-	#probeRecvRate?: Signal<number | undefined>;
-
-	// Merges the two sources into `stats`.
-	#signals = new Effect();
-	#stats = new Signal<Stats>({});
+	// Written by the Subscriber as PROBE messages arrive.
+	#probe = new Signal<Probe>({});
 
 	/**
 	 * The {@link Role} the peer advertised in its SETUP, for a server deciding whether the
@@ -124,32 +117,11 @@ export class Connection implements Established {
 		this.transport = transportOf(quic);
 		this.discovery = discovery;
 
-		// Recv bandwidth requires PROBE support (Lite03+).
-		if (version !== Version.DRAFT_01 && version !== Version.DRAFT_02) {
-			this.#probeRecvRate = new Signal<number | undefined>(undefined);
-		}
-
-		this.stats = this.#stats;
-		const transport = pollTransportStats(quic, this.closed);
-		this.#signals.run((effect) => {
-			this.#stats.set(
-				mergeStats(effect.get(transport), {
-					rtt: effect.get(this.#probeRtt),
-					estimatedRecvRate: this.#probeRecvRate && effect.get(this.#probeRecvRate),
-				}),
-			);
-		});
+		this.probe = this.#probe;
 
 		this.origin = randomOrigin();
 		this.#publisher = new Publisher(this.#quic, this.#version, this.origin);
-		this.#subscriber = new Subscriber(
-			this.#quic,
-			this.#version,
-			this.origin,
-			this.#probeRecvRate,
-			this.#probeRtt,
-			this.#peerSetup,
-		);
+		this.#subscriber = new Subscriber(this.#quic, this.#version, this.origin, this.#probe, this.#peerSetup);
 
 		void this.#run();
 	}
@@ -158,7 +130,6 @@ export class Connection implements Established {
 	 * Closes the connection.
 	 */
 	close() {
-		this.#signals.close();
 		this.#publisher.close();
 		this.#subscriber.close();
 
@@ -177,9 +148,7 @@ export class Connection implements Established {
 			tasks.push(this.#sendSetup());
 		}
 
-		if (this.#probeRecvRate) {
-			tasks.push(this.#subscriber.runProbe());
-		}
+		tasks.push(this.#subscriber.runProbe());
 
 		// Route incoming QUIC datagrams into their subscriptions (lite-05+; runDatagrams
 		// no-ops on a transport that doesn't carry them).
@@ -314,6 +283,11 @@ export class Connection implements Established {
 		} else {
 			throw new Error(`unknown stream type: ${typ.toString()}`);
 		}
+	}
+
+	/** Snapshot the transport's counters; see {@link Established.stats}. */
+	async stats(): Promise<Stats> {
+		return transportStats(this.#quic);
 	}
 
 	get closed(): Promise<void> {

--- a/js/net/src/lite/subscriber.test.ts
+++ b/js/net/src/lite/subscriber.test.ts
@@ -1,5 +1,6 @@
 import { expect, spyOn, test } from "bun:test";
 import { Signal } from "@moq/signals";
+import type { Probe } from "../connection/stats.ts";
 import { OriginSchema } from "./origin.ts";
 import { Subscriber } from "./subscriber.ts";
 import { Version } from "./version.ts";
@@ -12,12 +13,7 @@ test("closing the subscriber suppresses probe stream warnings", async () => {
 			writable: new WritableStream<Uint8Array>(),
 		}),
 	} as unknown as WebTransport;
-	const subscriber = new Subscriber(
-		quic,
-		Version.DRAFT_03,
-		OriginSchema.parse(1n),
-		new Signal<number | undefined>(undefined),
-	);
+	const subscriber = new Subscriber(quic, Version.DRAFT_03, OriginSchema.parse(1n), new Signal<Probe>({}));
 	const warn = spyOn(console, "warn").mockImplementation(() => {});
 
 	try {

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -1,6 +1,7 @@
 import { Signal } from "@moq/signals";
 import * as announce from "../announced.ts";
 import * as broadcast from "../broadcast.ts";
+import type { Probe as ProbeStats } from "../connection/stats.ts";
 import { BroadcastCache } from "../consume.ts";
 import * as netGroup from "../group.ts";
 import * as Path from "../path.ts";
@@ -101,11 +102,8 @@ export class Subscriber {
 	// each get an independent mirror; the entry is evicted once the group closes.
 	#fetches = new Map<string, netGroup.Producer>();
 
-	// Recv bandwidth producer (Lite03+ only).
-	#recvBandwidth?: Signal<number | undefined>;
-
-	// RTT producer (Lite04+ only).
-	#rtt?: Signal<Time.Milli | undefined>;
+	// The peer's PROBE estimates, written as they arrive (Lite03+ only).
+	#probe?: Signal<ProbeStats>;
 
 	// The peer's SETUP (lite-05+), undefined until it arrives. Gates opening the PROBE
 	// stream on the peer having advertised Probe >= Report.
@@ -118,8 +116,7 @@ export class Subscriber {
 	 * @param quic - The WebTransport session to use
 	 * @param version - The protocol version
 	 * @param origin - Origin id shared with the Publisher
-	 * @param recvBandwidth - Optional bandwidth producer for PROBE
-	 * @param rtt - Optional RTT signal for PROBE
+	 * @param probe - Optional sink for the peer's PROBE estimates
 	 * @param peerSetup - Optional peer SETUP slot for capability gating (lite-05+)
 	 *
 	 * @internal
@@ -128,15 +125,13 @@ export class Subscriber {
 		quic: WebTransport,
 		version: Version,
 		origin: Origin,
-		recvBandwidth?: Signal<number | undefined>,
-		rtt?: Signal<Time.Milli | undefined>,
+		probe?: Signal<ProbeStats>,
 		peerSetup?: Signal<Setup | undefined>,
 	) {
 		this.#quic = quic;
 		this.version = version;
 		this.origin = origin;
-		this.#recvBandwidth = recvBandwidth;
-		this.#rtt = rtt;
+		this.#probe = probe;
 		this.#peerSetup = peerSetup;
 	}
 
@@ -788,7 +783,7 @@ export class Subscriber {
 	}
 
 	async runProbe(): Promise<void> {
-		if (!this.#recvBandwidth) return;
+		if (!this.#probe) return;
 		if (this.version === Version.DRAFT_01 || this.version === Version.DRAFT_02) return;
 
 		// Lite-05+ gates the PROBE stream on the peer advertising Probe >= Report in its
@@ -801,7 +796,7 @@ export class Subscriber {
 
 		// Probe is best-effort: any failure (stream reset by peer, missing peer support,
 		// transport hiccup) MUST NOT tear down the connection. On error, drop the
-		// bandwidth/RTT estimates so consumers know they're stale.
+		// estimates so consumers know they're stale.
 		try {
 			const stream = await Stream.open(this.#quic);
 			await stream.writer.u53(StreamId.Probe);
@@ -809,18 +804,20 @@ export class Subscriber {
 			for (;;) {
 				const probe = await Probe.decodeMaybe(stream.reader, this.version);
 				if (!probe) break;
-				this.#recvBandwidth.set(probe.bitrate ?? undefined);
-				if (this.#rtt && probe.rtt !== undefined) {
-					this.#rtt.set(Time.Milli(probe.rtt));
-				}
+				// A message that omits the RTT leaves the last one standing, so a
+				// bitrate-only report doesn't blank it.
+				const prev = this.#probe.peek();
+				this.#probe.set({
+					estimatedRecvRate: probe.bitrate ?? undefined,
+					rtt: probe.rtt !== undefined ? Time.Milli(probe.rtt) : prev.rtt,
+				});
 			}
 		} catch (err: unknown) {
 			if (!this.#closed.signal.aborted) {
 				console.warn("probe stream error", err);
 			}
 		} finally {
-			this.#recvBandwidth.set(undefined);
-			this.#rtt?.set(undefined);
+			this.#probe.set({});
 		}
 	}
 

--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -14,6 +14,9 @@ import * as Source from "./source";
 import * as Video from "./video";
 
 const OBSERVED = ["url", "name", "muted", "invisible", "source", "preview", "announce"] as const;
+
+/** How often the encoder's bitrate cap resamples the transport's send estimate. */
+const BANDWIDTH_POLL = 100; // ms
 type Observed = (typeof OBSERVED)[number];
 
 /** The built-in capture sources selectable via the `source` attribute. */
@@ -173,9 +176,28 @@ export default class MoqPublish extends HTMLElement {
 			this.#publishEnabled.set(enabled && announcing);
 		});
 
-		// Track the connection's send bandwidth estimate, the encoder's bitrate cap.
+		// Track the connection's send bandwidth estimate, the encoder's bitrate cap. The
+		// transport has no event for it, so sample on our own schedule and skip a tick
+		// while the previous snapshot is outstanding.
 		this.signals.run((effect) => {
-			this.#bandwidth.set(effect.get(this.connection.stats)?.estimatedSendRate);
+			const connection = effect.get(this.connection.established);
+			effect.set(this.#bandwidth, undefined);
+			if (!connection) return;
+
+			let pending = false;
+			const sample = async () => {
+				if (pending) return;
+				pending = true;
+				try {
+					const stats = await connection.stats();
+					this.#bandwidth.set(stats.estimatedSendRate);
+				} finally {
+					pending = false;
+				}
+			};
+
+			void sample();
+			effect.interval(sample, BANDWIDTH_POLL);
 		});
 
 		this.capture = new Video.Capture({ source: this.#videoSource });

--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -189,8 +189,11 @@ export default class MoqPublish extends HTMLElement {
 				if (pending) return;
 				pending = true;
 				try {
-					const stats = await connection.stats();
-					this.#bandwidth.set(stats.estimatedSendRate);
+					// A snapshot that lands after this run was torn down describes a
+					// connection we no longer have, so drop it rather than capping the
+					// encoder at a dead peer's estimate.
+					const stats = await Promise.race([effect.cancel, connection.stats()]);
+					if (stats) this.#bandwidth.set(stats.estimatedSendRate);
 				} finally {
 					pending = false;
 				}

--- a/js/watch/src/sync.ts
+++ b/js/watch/src/sync.ts
@@ -146,7 +146,7 @@ export class Sync {
 
 		// "real-time" mode: compute jitter from RTT on the established connection.
 		const conn = effect.get(this.in.connection);
-		const rtt = conn && effect.get(conn.stats).rtt;
+		const rtt = conn && effect.get(conn.probe).rtt;
 		if (rtt !== undefined) {
 			// Track minimum RTT as baseline, ignoring bufferbloat.
 			this.#minRtt = this.#minRtt !== undefined ? Math.min(this.#minRtt, rtt) : rtt;

--- a/js/watch/src/ui/stats.ts
+++ b/js/watch/src/ui/stats.ts
@@ -139,13 +139,13 @@ export function statsTab(parent: Effect, watch: MoqWatch): HTMLElement {
 
 		// Network. "Estimated max" is the congestion controller / PROBE estimate;
 		// "Actual" is the goodput we measure from the video + audio byte counters.
-		const nStats = watch.connection.stats.peek();
-		const estimate = nStats?.estimatedRecvRate;
+		const probe = watch.connection.probe.peek();
+		const estimate = probe?.estimatedRecvRate;
 		nMax.textContent = estimate ? formatBitrate(estimate) : "—";
 		const actual =
 			vBitrate !== undefined || aBitrate2 !== undefined ? (vBitrate ?? 0) + (aBitrate2 ?? 0) : undefined;
 		nActual.textContent = actual !== undefined ? formatBitrate(actual) : "—";
-		const rtt = nStats?.rtt;
+		const rtt = probe?.rtt;
 		nRttGraph.push(rtt !== undefined && rtt > 0 ? rtt : undefined);
 	}, POLL_MS);
 

--- a/js/watch/src/video/source.ts
+++ b/js/watch/src/video/source.ts
@@ -305,7 +305,7 @@ export class Source {
 		if (!target?.bitrate) {
 			const broadcast = effect.get(this.in.broadcast);
 			const connection = broadcast ? effect.get(broadcast.in.connection) : undefined;
-			const estimate = connection && effect.get(connection.stats).estimatedRecvRate;
+			const estimate = connection && effect.get(connection.probe).estimatedRecvRate;
 			if (estimate != null) {
 				// Apply a safety margin (80%) to avoid oscillation.
 				const safeBitrate = Math.round(estimate * 0.8);


### PR DESCRIPTION
Follow-up to #2441, which merged both estimate sources into one polled `stats: Getter<Stats>`. That was the wrong shape, and this reshapes it before anything ships: `@moq/net` is still `0.1.9` and versions only move in the dedicated `chore(js): bump package versions` PRs, so no consumer has seen the merged surface.

## The two sources have opposite shapes

`WebTransport.getStats()` is a request/response with no event to subscribe to. PROBE arrives when the peer sends it and there is nothing to await. Merging them forced the pull source into a push shape, which meant inventing a 100ms poll that corresponds to nothing on the wire.

```ts
interface Established {
  /** Snapshot the transport's counters. */
  stats(): Promise<Stats>;

  /** Estimates measured by the peer, updated as PROBE messages arrive. */
  readonly probe: Getter<Probe>;
}
```

Three things fall out of that:

- **Nothing polls unless a consumer asks.** Before, every connection ran a 10Hz timer whether or not anything read it: every tab, every reconnect.
- **Rate math works.** `(bytesSent₂ - bytesSent₁) / (t₂ - t₁)` needs to know when each snapshot was taken. A polled signal only tells you when you observed it, up to a period late, with no control over the interval. Now a caller samples when it wants and timestamps it itself.
- **Consumers stop waking on unrelated fields.** `effect.get(conn.stats)` subscribed to the whole object, and byte counters move constantly, so `watch`'s track selection and jitter effects reran 10x a second. Both want PROBE values, so they now wake when a PROBE actually arrives.

## The merge rule was dead code

`mergeStats`'s `transport.rtt ?? probe.rtt` never fired: no browser populates the W3C `smoothedRtt` yet, so RTT is a PROBE value in practice. Callers read `probe.rtt` and the precedence rule is gone. `Stats.rtt` still maps `smoothedRtt`, so it lights up on its own if a browser ships it, and its doc points at `probe.rtt` in the meantime.

Keeping information rather than merging it away also means a caller can tell *which* source an RTT came from, which is the thing you want to know when diagnosing one.

## Other changes

- The `Subscriber` writes one `Signal<Probe>` instead of a bandwidth signal and an RTT signal. A report that omits the RTT now leaves the last one standing instead of letting the two drift apart, and the PROBE stream ending clears both together.
- The lite `Connection` no longer needs an `Effect` at all: there is nothing to merge.
- `<moq-publish>` is the one consumer that wants a transport value reactively (it caps the encoder bitrate from `estimatedSendRate`). It samples on its own interval and skips a tick while a snapshot is outstanding. That cost is now scoped to a page that is actually publishing.
- moq-transport connections expose an always-empty `probe`, which makes explicit what was previously hidden behind an optional field that happened to stay undefined: they have no RTT source at all, so `watch`'s sync falls back to its static jitter there.

I did not add a `pollStats(conn, interval)` adapter for the pull-to-push case. One consumer needs it today and it is ~10 lines inline; worth extracting when a second appears.

## Tests

`just js check` and `just js test` clean across all packages, `demo/web` typechecks.

`stats.test.ts` covers the W3C mapping, the empty snapshot when `getStats()` is missing or throws, `stats()` re-querying the transport on each call (so a caller controls sampling), an empty `probe` on moq-transport alongside working transport counters, and `Reload` reporting both only while connected.

(written by Opus 4.8)