### PR TITLE
ci: use client-id instead of the deprecated app-id

### DIFF
--- a/.github/workflows/release-brew.yml
+++ b/.github/workflows/release-brew.yml
@@ -9,7 +9,7 @@ name: release-brew
 # the GitHub Release assets are guaranteed to exist by the time we
 # download them.
 #
-# Authenticates as the moq-bot GitHub App. The APP_ID and APP_PRIVATE_KEY
+# Authenticates as the moq-bot GitHub App. The APP_CLIENT_ID and APP_PRIVATE_KEY
 # repo secrets are already wired (see release-swift-lib.yml). The minted
 # installation token is scoped to moq-dev/homebrew-tap and expires in 1
 # hour.
@@ -113,7 +113,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: moq-dev
           repositories: homebrew-tap

--- a/.github/workflows/release-go-ffi.yml
+++ b/.github/workflows/release-go-ffi.yml
@@ -236,7 +236,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: moq-dev
           repositories: moq-go-ffi

--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -116,7 +116,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: moq-dev
           repositories: moq-go

--- a/.github/workflows/release-rs.yml
+++ b/.github/workflows/release-rs.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: generate-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/release-swift-ffi.yml
+++ b/.github/workflows/release-swift-ffi.yml
@@ -238,7 +238,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: moq-dev
           repositories: moq-swift-ffi

--- a/.github/workflows/release-swift-lib.yml
+++ b/.github/workflows/release-swift-lib.yml
@@ -151,7 +151,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         id: token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: moq-dev
           repositories: moq-swift


### PR DESCRIPTION
## What

Swaps the deprecated `app-id` input on `actions/create-github-app-token` for `client-id` across all six workflows that mint a moq-bot token: `release-rs`, `release-brew`, `release-go`, `release-go-ffi`, `release-swift-ffi`, `release-swift-lib`. Mechanical one-line change each, plus a stale comment in `release-brew.yml`.

## Why

The action declares `app-id` with a `deprecationMessage`, so every run that mints a token is annotated:

```
! Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

## ⚠️ Do not merge until the secret exists

This needs a new **`APP_CLIENT_ID`** org secret holding moq-bot's client id, `Iv23lijGeXMMj2WE2mMK` (verified against `/orgs/moq-dev/installations`, where `app_slug: moq-bot` maps to `app_id: 1039466` / that client id):

```
gh secret set APP_CLIENT_ID --org moq-dev --body Iv23lijGeXMMj2WE2mMK --visibility all
```

If this lands first, `client-id` resolves empty and the token step fails. The blast radius is worth noting: it would break the release-brew / release-go / release-swift publish steps, which push to other repos. Reverting restores the working state, but setting the secret first avoids it entirely.

## Notes

- This repo also has repo-scoped `APP_ID` / `APP_PRIVATE_KEY` secrets that shadow the org-level ones. `APP_PRIVATE_KEY` keeps working unchanged; `APP_ID` becomes unused after this lands and can be deleted. An org-level `APP_CLIENT_ID` is picked up here since there is no repo-scoped one to shadow it.
- The client id is a public identifier, not a credential — only the private key is secret. It is stored as a secret purely to match how the App is referenced elsewhere.
- Companion PR: moq-dev/web-transport#340, same change for that repo's `release-rs`. Independent of this one.
- Workflow config only; no Rust, JS, or build changes.

(written by Opus 4.8)