### PR TITLE
docs(js/signals): note that run() defers a stale child to the next teardown

### DIFF
--- a/js/signals/src/index.test.ts
+++ b/js/signals/src/index.test.ts
@@ -315,6 +315,46 @@ describe("Effect", () => {
 		}
 	});
 
+	test("run() from a stale spawn defers its child to the next teardown", async () => {
+		// Deliberately unlike cleanup(): closing the child right away would cancel its first run
+		// before `fn` executes, so the teardown `fn` registers would never fire at all. Landing on
+		// the next teardown is late, but it still runs and still releases.
+		const tick = new Signal(0);
+		const gate = Promise.withResolvers<void>();
+		const log: string[] = [];
+		let runs = 0;
+
+		const effect = new Effect((e) => {
+			e.get(tick);
+			if (++runs > 1) return;
+
+			e.spawn(async () => {
+				await gate.promise;
+				e.run((child) => {
+					log.push("served");
+					child.cleanup(() => log.push("released"));
+				});
+			});
+		});
+
+		try {
+			await settle();
+			tick.set(1);
+			await settle();
+			expect(runs).toBe(1); // stale window
+
+			gate.resolve();
+			await settle();
+
+			// The child ran rather than being cancelled before it could serve.
+			expect(log).toEqual(["served"]);
+		} finally {
+			effect.close();
+		}
+
+		expect(log).toEqual(["served", "released"]);
+	});
+
 	test("cleanup after close fires immediately", async () => {
 		const effect = new Effect((e) => {
 			e.get(new Signal(0));

--- a/js/signals/src/index.ts
+++ b/js/signals/src/index.ts
@@ -567,7 +567,12 @@ export class Effect {
 		this.cleanup(() => timeout && clearTimeout(timeout));
 	}
 
-	/** Runs `fn` as a nested effect, then closes that effect after `ms` milliseconds. */
+	/**
+	 * Runs `fn` as a nested effect, then closes that effect after `ms` milliseconds.
+	 *
+	 * Shares {@link run}'s handling of a task that outlived its run: the child is closed at the
+	 * next teardown, not immediately.
+	 */
 	timeout(fn: (effect: Effect) => void, ms: DOMHighResTimeStamp) {
 		if (this.#dispose === undefined) {
 			if (DEV) {
@@ -630,6 +635,10 @@ export class Effect {
 	 * Returns a disposer that closes the child early and releases it from the parent, so a long-lived
 	 * effect spawning a child per event (e.g. one per accepted subscription) doesn't accumulate dead
 	 * scopes until it finally reruns or closes.
+	 *
+	 * Called from a task that outlived its run, the child is closed at the *next* teardown rather
+	 * than immediately, unlike {@link cleanup}. Closing it now would cancel its first run before
+	 * `fn` executes, so whatever teardown `fn` registers would never fire at all.
 	 */
 	run(fn: (effect: Effect) => void): Dispose {
 		if (this.#dispose === undefined) {


### PR DESCRIPTION
## Summary

Follow-up to #2446, from a sweep of every `effect.spawn` site in `js/`.

`run()` and `timeout()` push their child's disposer straight onto the dispose list instead of going through `cleanup()`:

```ts
const effect = new Effect(fn);
const dispose = () => effect.close();
this.#dispose.push(dispose);   // bypasses cleanup(), so #stale never applies
```

So unlike `cleanup()`, a child created by a task that outlived its run is closed at the **next** teardown rather than immediately. Four call sites hit this today, all `run()` after an `await` inside a spawn: `publish/audio/encoder.ts:385`, `watch/audio/decoder.ts:179`, `publish/broadcast.ts:207`, `moq-boy/game.ts:311`.

**This documents the asymmetry rather than removing it, because the consistent version is worse.** Closing the child immediately cancels its first run before `fn` executes, so any teardown `fn` registers never fires at all. `publish/broadcast.ts` closes its accepted track *inside* the child's `fn` — routing `run()` through `cleanup()` would leave that track accepted, never served, and never closed. Releasing one teardown late beats never releasing.

The alternative worth considering later is making `close()` run a never-started effect's `fn` once before tearing it down, which would make the two consistent without the leak. That's a real semantic change to every nested effect, so it belongs in its own PR rather than riding along here.

## Public API changes

None. Doc comments and a test only.

## Test plan

- New test pinning the documented behavior: a stale `run()` child still executes its `fn` (`"served"`) and releases at the parent's teardown (`"released"`), so the deferral can't be silently changed into cancel-before-run.
- `just js test` green across all packages; `just js check` clean.

### Sweep results (no other changes needed)

Already fixed by #2446, listed so the payoff is on record:

- `publish/source/screen.ts:89` — `cleanup(() => v?.stop())` after an await used to land on the next run, so a rerun didn't stop the screen-share track and the browser's sharing indicator stayed up.
- `camera.ts:90` / `microphone.ts:82` — `cleanup(this.device.capture(...))` after an await left the device marked active past teardown.
- `publish/audio/encoder.ts:267` — `effect.event(worklet.port, ...)` after an await bound to the next run's abort signal and outlived its worklet.
- ~12 `await Promise.race([effect.cancel, X])` loops — a re-read of `effect.cancel` after teardown returned the next run's promise, parking the loop instead of bailing.

Examined and dismissed: the pre-registered cleanups in camera/microphone (now unnecessary, still readable); direct `#out.x.set()` writes after awaits in `watch/video/source.ts`, `source/device.ts`, `watch/broadcast.ts` (the spawn drain blocks the next run until in-flight tasks settle, so the new run always writes last); the `addModule` race in `watch/audio/decoder.ts:143` (deliberate, documented Firefox quirk).

(written by Opus 4.8)