### PR TITLE
feat(bindings): expose shared video properties

### DIFF
--- a/.github/workflows/release-swift-lib.yml
+++ b/.github/workflows/release-swift-lib.yml
@@ -55,6 +55,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
       ffi_version: ${{ steps.version.outputs.ffi_version }}
+      ffi_changed: ${{ steps.ffi-diff.outputs.changed }}
       # On PRs we only build (dry-run). On main/dev we publish when the version
       # isn't already tagged on the mirror.
       publish: ${{ github.event_name == 'push' && steps.gate.outputs.exists == 'false' }}
@@ -62,6 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Read versions
@@ -72,6 +74,18 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "ffi_version=$FFI_VERSION" >> "$GITHUB_OUTPUT"
           echo "wrapper $VERSION, moq-ffi pin $FFI_VERSION"
+
+      - name: Check for unreleased FFI changes
+        id: ffi-diff
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if git diff --quiet "$BASE_SHA"...HEAD -- rs/moq-ffi; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       # The release gate: skip publishing a version already tagged on the mirror.
       # Runs on PRs too, as an informational dry-run.
@@ -109,6 +123,7 @@ jobs:
 
       - name: Check FFI mirror tag
         id: ffi
+        if: needs.build.outputs.publish == 'true' || (github.event_name == 'pull_request' && needs.build.outputs.ffi_changed != 'true')
         env:
           FFI_VERSION: ${{ needs.build.outputs.ffi_version }}
         # Treat a missing mirror repo / unreachable remote as "not published"
@@ -131,7 +146,11 @@ jobs:
         run: ./swift/scripts/verify.sh --tarball "artifacts/moq-${BUILD_VERSION}-swift.tar.gz"
 
       - name: Skip notice
-        if: steps.ffi.outputs.exists != 'true'
+        if: needs.build.outputs.ffi_changed == 'true'
+        run: echo "::notice::moq-ffi changed in this PR; the local Swift check validates the wrapper against freshly generated bindings."
+
+      - name: Unpublished FFI notice
+        if: (needs.build.outputs.publish == 'true' || github.event_name == 'pull_request') && needs.build.outputs.ffi_changed != 'true' && steps.ffi.outputs.exists != 'true'
         env:
           FFI_VERSION: ${{ needs.build.outputs.ffi_version }}
         run: echo "::notice::moq-swift-ffi ${FFI_VERSION} not published yet; skipping cross-package resolve."

--- a/.github/workflows/release-swift-lib.yml
+++ b/.github/workflows/release-swift-lib.yml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Skip notice
         if: needs.build.outputs.ffi_changed == 'true'
-        run: echo "::notice::moq-ffi changed in this PR; the local Swift check validates the wrapper against freshly generated bindings."
+        run: echo "::notice::moq-ffi changed in this PR; skipping the published-package cross-resolve. The required Swift workflow validates the wrapper against freshly generated bindings."
 
       - name: Unpublished FFI notice
         if: (needs.build.outputs.publish == 'true' || github.event_name == 'pull_request') && needs.build.outputs.ffi_changed != 'true' && steps.ffi.outputs.exists != 'true'

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -120,6 +120,26 @@ A server can reject the connection on auth grounds: unauthorized (HTTP 401) or f
 
 Failed calls are reported only through the return code and `moq_error()`, not logged. To surface libmoq's internal logs (moq-net / QUIC activity), call `moq_log_level("debug")` (or `"trace"`, `"info"`, etc.) to install a tracing subscriber.
 
+## Shared video properties
+
+`moq_publish_video_properties` replaces the catalog properties shared by every video rendition in one update. A false `has_*` flag clears that property, and rotation is normalized to the nearest clockwise quarter turn. Read the same snapshot with `moq_consume_video_properties`:
+
+```c
+moq_video_properties properties = {
+    .display_width = 1080,
+    .display_height = 1920,
+    .has_display = true,
+    .rotation = 90.0,
+    .has_rotation = true,
+    .flip = false,
+    .has_flip = true,
+};
+
+if (moq_publish_video_properties(broadcast, &properties) < 0) {
+    fprintf(stderr, "video properties failed: %s\n", moq_error());
+}
+```
+
 ## Raw Tracks
 
 Raw tracks carry arbitrary byte payloads without catalog or codec parsing. Use

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -138,6 +138,11 @@ moq_video_properties properties = {
 if (moq_publish_video_properties(broadcast, &properties) < 0) {
     fprintf(stderr, "video properties failed: %s\n", moq_error());
 }
+
+moq_video_properties snapshot = {0};
+if (moq_consume_video_properties(catalog, &snapshot) < 0) {
+    fprintf(stderr, "video properties failed: %s\n", moq_error());
+}
 ```
 
 ## Raw Tracks

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -136,6 +136,18 @@ media, err := broadcast.PublishMedia("avc3", nil, moq.WithVideoHint(moq.VideoHin
 }))
 ```
 
+Properties that apply to every video rendition are updated together. Nil fields clear the corresponding catalog property, and rotation is normalized to the nearest clockwise quarter turn:
+
+```go
+rotation := 90.0
+flip := false
+err := broadcast.SetVideoProperties(moq.VideoProperties{
+    Display:  &moq.Dimensions{Width: 1080, Height: 1920},
+    Rotation: &rotation,
+    Flip:     &flip,
+})
+```
+
 ## Error handling
 
 A server can reject the connection on auth grounds: `ErrMoqErrorUnauthorized` (HTTP 401) or `ErrMoqErrorForbidden` (HTTP 403). These are terminal: retrying without new credentials won't help, so handle them separately from a transient transport failure. The `moq.IsAuthError` helper catches both:

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -120,6 +120,18 @@ Moq.connect("https://relay.example.com").use { moq ->
 }
 ```
 
+Properties that apply to every video rendition are updated together. `null` fields clear the corresponding catalog property, and rotation is normalized to the nearest clockwise quarter turn:
+
+```kotlin
+broadcast.setVideoProperties(
+    VideoProperties(
+        display = Dimensions(width = 1080u, height = 1920u),
+        rotation = 90.0,
+        flip = false,
+    )
+)
+```
+
 ## Serve
 
 `Server.listen(bind)` binds a listener, wires an internal origin for both directions, and returns an `AutoCloseable` `Server`. `serve()` accepts every session and holds it alive until it closes:

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -80,6 +80,18 @@ video = broadcast.publish_media(
 
 A value the stream later detects fills only a gap the hint left, so a detected value always wins. Audio formats resolve entirely from their init bytes, so they take no hint.
 
+Properties that apply to every video rendition are updated together. Omitted fields clear the corresponding catalog property, and rotation is normalized to the nearest clockwise quarter turn:
+
+```python
+broadcast.set_video_properties(
+    moq.VideoProperties(
+        display=moq.Dimensions(width=1080, height=1920),
+        rotation=90.0,
+        flip=False,
+    )
+)
+```
+
 ### Subscribing to media
 
 ```python

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -109,6 +109,18 @@ try broadcast.finish()
 
 Video publishers can pass `video: VideoHint(...)` to seed catalog fields before the stream reveals them. Use `publishMedia(on:format:initData:video:)` to accept a media track obtained from `BroadcastDynamic`.
 
+Properties that apply to every video rendition are updated together. `nil` fields clear the corresponding catalog property, and rotation is normalized to the nearest clockwise quarter turn:
+
+```swift
+try broadcast.setVideoProperties(
+    VideoProperties(
+        display: Dimensions(width: 1080, height: 1920),
+        rotation: 90,
+        flip: false
+    )
+)
+```
+
 For sparse or replayed raw tracks, use `track.createGroup(sequence:)`. `track.finish(at:)` declares the exclusive end while still permitting lower groups, and `group.abort(errorCode:)` terminates a group with an application error.
 
 ### Fetching raw groups

--- a/go/wrapper/moq/moq_test.go
+++ b/go/wrapper/moq/moq_test.go
@@ -132,6 +132,20 @@ func TestPublishMediaLifecycle(t *testing.T) {
 	}
 }
 
+func TestVideoPropertiesUseDefaultedFields(t *testing.T) {
+	broadcast, err := moq.NewBroadcastProducer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rotation := 315.0
+	if err := broadcast.SetVideoProperties(moq.VideoProperties{Rotation: &rotation}); err != nil {
+		t.Fatal(err)
+	}
+	if err := broadcast.Finish(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestFetchGroupAndServeDynamicMiss(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
 	defer cancel()

--- a/go/wrapper/moq/publish.go
+++ b/go/wrapper/moq/publish.go
@@ -76,6 +76,11 @@ func (b *BroadcastProducer) SetAnnounce(live bool) error {
 	return b.inner.SetAnnounce(live)
 }
 
+// SetVideoPresentation replaces the video presentation metadata in the catalog.
+func (b *BroadcastProducer) SetVideoPresentation(presentation VideoPresentation) error {
+	return b.inner.SetVideoPresentation(presentation)
+}
+
 // PublishMedia publishes a media track from an init segment, fed frame by
 // frame with explicit timestamps.
 func (b *BroadcastProducer) PublishMedia(format string, init []byte, opts ...MediaOption) (*MediaProducer, error) {

--- a/go/wrapper/moq/publish.go
+++ b/go/wrapper/moq/publish.go
@@ -76,9 +76,9 @@ func (b *BroadcastProducer) SetAnnounce(live bool) error {
 	return b.inner.SetAnnounce(live)
 }
 
-// SetVideoPresentation replaces the video presentation metadata in the catalog.
-func (b *BroadcastProducer) SetVideoPresentation(presentation VideoPresentation) error {
-	return b.inner.SetVideoPresentation(presentation)
+// SetVideoProperties replaces the catalog properties shared by every video rendition.
+func (b *BroadcastProducer) SetVideoProperties(properties VideoProperties) error {
+	return b.inner.SetVideoProperties(properties)
 }
 
 // PublishMedia publishes a media track from an init segment, fed frame by

--- a/go/wrapper/moq/types.go
+++ b/go/wrapper/moq/types.go
@@ -26,6 +26,7 @@ type (
 	TrackInfo          = ffi.MoqTrackInfo
 	Video              = ffi.MoqVideo
 	VideoHint          = ffi.MoqVideoHint
+	VideoPresentation  = ffi.MoqVideoPresentation
 
 	// Container selects how subscribed media frames are demuxed. Build one with
 	// LegacyContainer, CmafContainer, or LocContainer.

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -63,6 +63,8 @@ typealias MediaFrame = uniffi.moq.MoqMediaFrame
 typealias Video = uniffi.moq.MoqVideo
 /** Caller-provided catalog fields for a video track. */
 typealias VideoHint = uniffi.moq.MoqVideoHint
+/** Video presentation metadata applied to all video renditions in the catalog. */
+typealias VideoPresentation = uniffi.moq.MoqVideoPresentation
 /** Media format, initialization bytes, and optional video hints. */
 typealias Init = uniffi.moq.MoqInit
 typealias Audio = uniffi.moq.MoqAudio

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -93,8 +93,8 @@ typealias MediaFrame = uniffi.moq.MoqMediaFrame
 typealias Video = uniffi.moq.MoqVideo
 /** Caller-provided catalog fields for a video track. */
 typealias VideoHint = uniffi.moq.MoqVideoHint
-/** Video presentation metadata applied to all video renditions in the catalog. */
-typealias VideoPresentation = uniffi.moq.MoqVideoPresentation
+/** Catalog properties shared by every video rendition; absent fields clear those properties. */
+typealias VideoProperties = uniffi.moq.MoqVideoProperties
 /** Media format, initialization bytes, and optional video hints. */
 typealias Init = uniffi.moq.MoqInit
 /** The catalog description of an audio track: codec, sample rate, channels, and container. */

--- a/kt/moq/src/jvmAndAndroidTest/kotlin/dev/moq/SmokeTest.kt
+++ b/kt/moq/src/jvmAndAndroidTest/kotlin/dev/moq/SmokeTest.kt
@@ -54,9 +54,19 @@ class SmokeTest {
         )
         val snapshot: JsonSnapshotConfig = JsonSnapshotConfig(deltaRatio = 8u, compression = false)
         val stream: JsonStreamConfig = JsonStreamConfig(compression = false)
+        val properties: VideoProperties = VideoProperties(rotation = 315.0)
         assertEquals(4_000_000uL, hint.bitrate)
         assertEquals(8u, snapshot.deltaRatio)
         assertEquals(false, stream.compression)
+        assertNull(properties.display)
+        assertNull(properties.flip)
+    }
+
+    @Test
+    fun `broadcast updates shared video properties`() {
+        BroadcastProducer().use { broadcast ->
+            broadcast.setVideoProperties(VideoProperties(rotation = 315.0))
+        }
     }
 
     @Test

--- a/py/moq-rs/docs/index.md
+++ b/py/moq-rs/docs/index.md
@@ -121,6 +121,7 @@ Rust side ([`moq-ffi`](https://crates.io/crates/moq-ffi)).
    Datagram
    Video
    VideoHint
+   VideoProperties
    Dimensions
    Audio
    AudioFrame

--- a/py/moq-rs/moq/__init__.py
+++ b/py/moq-rs/moq/__init__.py
@@ -64,6 +64,7 @@ from .types import (
     TrackInfo,
     Video,
     VideoHint,
+    VideoPresentation,
 )
 
 __all__ = [
@@ -120,6 +121,7 @@ __all__ = [
     "Transport",
     "Video",
     "VideoHint",
+    "VideoPresentation",
     "connect",
     "is_auth",
     "is_shutdown",

--- a/py/moq-rs/moq/__init__.py
+++ b/py/moq-rs/moq/__init__.py
@@ -64,7 +64,7 @@ from .types import (
     TrackInfo,
     Video,
     VideoHint,
-    VideoPresentation,
+    VideoProperties,
 )
 
 __all__ = [
@@ -121,7 +121,7 @@ __all__ = [
     "Transport",
     "Video",
     "VideoHint",
-    "VideoPresentation",
+    "VideoProperties",
     "connect",
     "is_auth",
     "is_shutdown",

--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -23,7 +23,17 @@ from moq_ffi import (
     MoqTrackRequest,
 )
 
-from .types import AudioEncoderInput, AudioEncoderOutput, AudioFrame, Frame, Route, Subscription, TrackInfo, VideoHint
+from .types import (
+    AudioEncoderInput,
+    AudioEncoderOutput,
+    AudioFrame,
+    Frame,
+    Route,
+    Subscription,
+    TrackInfo,
+    VideoHint,
+    VideoPresentation,
+)
 
 if TYPE_CHECKING:
     from .subscribe import BroadcastConsumer, GroupConsumer, TrackConsumer
@@ -373,6 +383,10 @@ class BroadcastProducer:
         how a publisher goes on and off the air without tearing down the broadcast.
         """
         self._inner.set_announce(announce)
+
+    def set_video_presentation(self, presentation: VideoPresentation) -> None:
+        """Replace the video presentation metadata in the catalog."""
+        self._inner.set_video_presentation(presentation)
 
     def publish_media(
         self,

--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -32,7 +32,7 @@ from .types import (
     Subscription,
     TrackInfo,
     VideoHint,
-    VideoPresentation,
+    VideoProperties,
 )
 
 if TYPE_CHECKING:
@@ -395,9 +395,9 @@ class BroadcastProducer:
         """
         self._inner.set_announce(announce)
 
-    def set_video_presentation(self, presentation: VideoPresentation) -> None:
-        """Replace the video presentation metadata in the catalog."""
-        self._inner.set_video_presentation(presentation)
+    def set_video_properties(self, properties: VideoProperties) -> None:
+        """Replace the catalog properties shared by every video rendition."""
+        self._inner.set_video_properties(properties)
 
     def publish_media(
         self,

--- a/py/moq-rs/moq/types.py
+++ b/py/moq-rs/moq/types.py
@@ -60,6 +60,9 @@ from moq_ffi import (
 from moq_ffi import (
     MoqVideoHint as VideoHint,
 )
+from moq_ffi import (
+    MoqVideoPresentation as VideoPresentation,
+)
 
 __all__ = [
     "Audio",
@@ -82,4 +85,5 @@ __all__ = [
     "TrackInfo",
     "Video",
     "VideoHint",
+    "VideoPresentation",
 ]

--- a/py/moq-rs/moq/types.py
+++ b/py/moq-rs/moq/types.py
@@ -61,8 +61,11 @@ from moq_ffi import (
     MoqVideoHint as VideoHint,
 )
 from moq_ffi import (
-    MoqVideoPresentation as VideoPresentation,
+    MoqVideoProperties,
 )
+
+VideoProperties = MoqVideoProperties
+"""Video catalog properties shared by every rendition; ``None`` fields clear them."""
 
 __all__ = [
     "Audio",
@@ -85,5 +88,5 @@ __all__ = [
     "TrackInfo",
     "Video",
     "VideoHint",
-    "VideoPresentation",
+    "VideoProperties",
 ]

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -84,6 +84,15 @@ def test_publish_media_lifecycle():
     broadcast.finish()
 
 
+def test_video_properties_use_defaulted_fields():
+    broadcast = moq.BroadcastProducer()
+    properties = moq.VideoProperties(rotation=315.0)
+    assert properties.display is None
+    assert properties.flip is None
+    broadcast.set_video_properties(properties)
+    broadcast.finish()
+
+
 def test_unknown_format():
     broadcast = moq.BroadcastProducer()
     with pytest.raises(Exception):

--- a/rs/hang/src/catalog/video/mod.rs
+++ b/rs/hang/src/catalog/video/mod.rs
@@ -43,7 +43,7 @@ pub struct Video {
 	#[serde(default)]
 	pub display: Option<Display>,
 
-	/// The rotation of the video in degrees.
+	/// The clockwise rotation of the video in degrees, normalized to the nearest multiple of 90 degrees.
 	/// Default: 0
 	#[serde(default)]
 	pub rotation: Option<f64>,
@@ -52,6 +52,36 @@ pub struct Video {
 	/// Default: false
 	#[serde(default)]
 	pub flip: Option<bool>,
+}
+
+/// Video presentation metadata applied to all video renditions in the catalog.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[non_exhaustive]
+pub struct VideoPresentation {
+	/// Render the video at this final size after rotation, or clear the explicit size when absent.
+	pub display: Option<Display>,
+
+	/// Apply this clockwise rotation before rendering, or clear it when absent.
+	pub rotation: Option<f64>,
+
+	/// Flip horizontally after rotation, or clear the explicit value when absent.
+	pub flip: Option<bool>,
+}
+
+impl VideoPresentation {
+	fn normalized(mut self) -> crate::Result<Self> {
+		self.rotation = self.rotation.map(normalize_video_rotation).transpose()?;
+		Ok(self)
+	}
+}
+
+fn normalize_video_rotation(rotation: f64) -> crate::Result<f64> {
+	if !rotation.is_finite() {
+		return Err(crate::Error::InvalidVideoRotation);
+	}
+
+	let normalized = rotation.rem_euclid(360.0);
+	Ok(((normalized / 90.0).round() as u16 % 4) as f64 * 90.0)
 }
 
 impl Video {
@@ -67,6 +97,15 @@ impl Video {
 	/// Remove the track from the catalog and return the configuration if found.
 	pub fn remove(&mut self, name: &str) -> Option<VideoConfig> {
 		self.renditions.remove(name)
+	}
+
+	/// Normalize and replace the video presentation metadata as one catalog update.
+	pub fn set_presentation(&mut self, presentation: VideoPresentation) -> crate::Result<()> {
+		let presentation = presentation.normalized()?;
+		self.display = presentation.display;
+		self.rotation = presentation.rotation;
+		self.flip = presentation.flip;
+		Ok(())
 	}
 }
 

--- a/rs/hang/src/catalog/video/mod.rs
+++ b/rs/hang/src/catalog/video/mod.rs
@@ -43,7 +43,7 @@ pub struct Video {
 	#[serde(default)]
 	pub display: Option<Display>,
 
-	/// The clockwise rotation of the video in degrees, normalized to the nearest multiple of 90 degrees.
+	/// The clockwise rotation of the video in degrees.
 	/// Default: 0
 	#[serde(default)]
 	pub rotation: Option<f64>,
@@ -54,34 +54,39 @@ pub struct Video {
 	pub flip: Option<bool>,
 }
 
-/// Video presentation metadata applied to all video renditions in the catalog.
+/// Catalog properties shared by every video rendition.
 #[derive(Debug, Clone, PartialEq, Default)]
 #[non_exhaustive]
-pub struct VideoPresentation {
+pub struct VideoProperties {
 	/// Render the video at this final size after rotation, or clear the explicit size when absent.
 	pub display: Option<Display>,
 
-	/// Apply this clockwise rotation before rendering, or clear it when absent.
+	/// Apply this clockwise rotation before rendering, or clear it when absent. Values are normalized to the nearest quarter turn.
 	pub rotation: Option<f64>,
 
 	/// Flip horizontally after rotation, or clear the explicit value when absent.
 	pub flip: Option<bool>,
 }
 
-impl VideoPresentation {
+impl VideoProperties {
 	fn normalized(mut self) -> crate::Result<Self> {
 		self.rotation = self.rotation.map(normalize_video_rotation).transpose()?;
 		Ok(self)
 	}
 }
 
+const FULL_TURN_DEGREES: f64 = 360.0;
+const QUARTER_TURN_DEGREES: f64 = 90.0;
+const QUARTER_TURNS_PER_FULL_TURN: u16 = 4;
+
 fn normalize_video_rotation(rotation: f64) -> crate::Result<f64> {
 	if !rotation.is_finite() {
 		return Err(crate::Error::InvalidVideoRotation);
 	}
 
-	let normalized = rotation.rem_euclid(360.0);
-	Ok(((normalized / 90.0).round() as u16 % 4) as f64 * 90.0)
+	let normalized = rotation.rem_euclid(FULL_TURN_DEGREES);
+	let quarter_turns = (normalized / QUARTER_TURN_DEGREES).round() as u16 % QUARTER_TURNS_PER_FULL_TURN;
+	Ok(quarter_turns as f64 * QUARTER_TURN_DEGREES)
 }
 
 impl Video {
@@ -99,12 +104,12 @@ impl Video {
 		self.renditions.remove(name)
 	}
 
-	/// Normalize and replace the video presentation metadata as one catalog update.
-	pub fn set_presentation(&mut self, presentation: VideoPresentation) -> crate::Result<()> {
-		let presentation = presentation.normalized()?;
-		self.display = presentation.display;
-		self.rotation = presentation.rotation;
-		self.flip = presentation.flip;
+	/// Normalize and replace the properties shared by every video rendition.
+	pub fn set_properties(&mut self, properties: VideoProperties) -> crate::Result<()> {
+		let properties = properties.normalized()?;
+		self.display = properties.display;
+		self.rotation = properties.rotation;
+		self.flip = properties.flip;
 		Ok(())
 	}
 }
@@ -279,5 +284,77 @@ mod test {
 		let config: VideoConfig = serde_json::from_value(json).expect("failed to decode legacy keys");
 		assert_eq!(config.display_aspect_width, Some(16));
 		assert_eq!(config.display_aspect_height, Some(9));
+	}
+
+	#[test]
+	fn normalizes_video_rotation_to_quarter_turns() {
+		for (rotation, expected) in [
+			(0.0, 0.0),
+			(44.9, 0.0),
+			(45.0, 90.0),
+			(134.9, 90.0),
+			(135.0, 180.0),
+			(225.0, 270.0),
+			(315.0, 0.0),
+			(360.0, 0.0),
+			(-45.0, 0.0),
+		] {
+			assert_eq!(normalize_video_rotation(rotation).unwrap(), expected);
+		}
+	}
+
+	#[test]
+	fn rejects_non_finite_video_rotation() {
+		for rotation in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+			assert!(matches!(
+				normalize_video_rotation(rotation),
+				Err(crate::Error::InvalidVideoRotation)
+			));
+		}
+	}
+
+	#[test]
+	fn video_properties_replace_shared_fields_without_touching_renditions() {
+		let mut video = Video::default();
+		video
+			.insert(
+				"video",
+				VideoConfig::new(H264 {
+					profile: 0x64,
+					constraints: 0,
+					level: 0x1f,
+					inline: false,
+				}),
+			)
+			.unwrap();
+		video.display = Some(Display {
+			width: 640,
+			height: 480,
+		});
+		video.rotation = Some(90.0);
+		video.flip = Some(true);
+		let renditions = video.renditions.clone();
+
+		video
+			.set_properties(VideoProperties {
+				display: Some(Display {
+					width: 1920,
+					height: 1080,
+				}),
+				rotation: Some(315.0),
+				flip: None,
+			})
+			.unwrap();
+
+		assert_eq!(video.renditions, renditions);
+		assert_eq!(
+			video.display,
+			Some(Display {
+				width: 1920,
+				height: 1080
+			})
+		);
+		assert_eq!(video.rotation, Some(0.0));
+		assert_eq!(video.flip, None);
 	}
 }

--- a/rs/hang/src/catalog/video/mod.rs
+++ b/rs/hang/src/catalog/video/mod.rs
@@ -314,6 +314,30 @@ mod test {
 	}
 
 	#[test]
+	fn invalid_rotation_does_not_replace_video_properties() {
+		let mut video = Video {
+			display: Some(Display {
+				width: 640,
+				height: 480,
+			}),
+			rotation: Some(90.0),
+			flip: Some(true),
+			..Default::default()
+		};
+		let expected = video.clone();
+
+		assert!(matches!(
+			video.set_properties(VideoProperties {
+				display: None,
+				rotation: Some(f64::NAN),
+				flip: None,
+			}),
+			Err(crate::Error::InvalidVideoRotation)
+		));
+		assert_eq!(video, expected);
+	}
+
+	#[test]
 	fn video_properties_replace_shared_fields_without_touching_renditions() {
 		let mut video = Video::default();
 		video

--- a/rs/hang/src/error.rs
+++ b/rs/hang/src/error.rs
@@ -54,6 +54,10 @@ pub enum Error {
 	/// A track with this name already exists in the catalog.
 	#[error("duplicate track: {0}")]
 	Duplicate(String),
+
+	/// The video presentation rotation is not a finite number.
+	#[error("video rotation must be finite")]
+	InvalidVideoRotation,
 }
 
 /// A Result type alias for hang operations.

--- a/rs/hang/src/error.rs
+++ b/rs/hang/src/error.rs
@@ -55,7 +55,7 @@ pub enum Error {
 	#[error("duplicate track: {0}")]
 	Duplicate(String),
 
-	/// The video presentation rotation is not a finite number.
+	/// The shared video rotation is not a finite number.
 	#[error("video rotation must be finite")]
 	InvalidVideoRotation,
 }

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -30,6 +30,35 @@ pub struct moq_video_config {
 	pub coded_height: *const u32,
 }
 
+/// Video presentation metadata applied to all video renditions in the catalog.
+///
+/// A false `has_*` flag clears that field from the next catalog rather than preserving its previous value.
+#[repr(C)]
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, Default)]
+pub struct moq_video_presentation {
+	/// Final rendered width in pixels when `has_display` is true.
+	pub display_width: u32,
+
+	/// Final rendered height in pixels when `has_display` is true.
+	pub display_height: u32,
+
+	/// Whether `display_width` and `display_height` are present.
+	pub has_display: bool,
+
+	/// Clockwise rotation in degrees when `has_rotation` is true.
+	pub rotation: f64,
+
+	/// Whether `rotation` is present.
+	pub has_rotation: bool,
+
+	/// Whether to flip horizontally after rotation when `has_flip` is true.
+	pub flip: bool,
+
+	/// Whether `flip` is present.
+	pub has_flip: bool,
+}
+
 /// Information about an audio rendition in the catalog.
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -793,6 +822,35 @@ pub unsafe extern "C" fn moq_publish_media_frame(
 	})
 }
 
+/// Replace the video presentation metadata in the catalog.
+///
+/// Rotation is clockwise and normalized to the nearest quarter turn. A field whose matching `has_*` flag is false is removed from the next catalog update.
+///
+/// Returns zero on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that `presentation` points to a valid [moq_video_presentation].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_publish_video_presentation(
+	broadcast: u32,
+	presentation: *const moq_video_presentation,
+) -> i32 {
+	ffi::enter(move || {
+		let broadcast = ffi::parse_id(broadcast)?;
+		let presentation = unsafe { presentation.as_ref() }.ok_or(Error::InvalidPointer)?;
+
+		let mut value = hang::catalog::VideoPresentation::default();
+		value.display = presentation.has_display.then_some(hang::catalog::Display {
+			width: presentation.display_width,
+			height: presentation.display_height,
+		});
+		value.rotation = presentation.has_rotation.then_some(presentation.rotation);
+		value.flip = presentation.has_flip.then_some(presentation.flip);
+
+		State::lock().publish.video_presentation(broadcast, value)
+	})
+}
+
 /// Add or replace a video rendition in a broadcast's catalog.
 ///
 /// This is the producer counterpart to [moq_consume_video_config]: instead of
@@ -1329,6 +1387,24 @@ pub unsafe extern "C" fn moq_consume_video_config(catalog: u32, index: u32, dst:
 		let index = index as usize;
 		let dst = unsafe { dst.as_mut() }.ok_or(Error::InvalidPointer)?;
 		State::lock().consume.video_config(catalog, index, dst)
+	})
+}
+
+/// Query the video presentation metadata in the catalog.
+///
+/// The destination is filled by value and remains valid after the catalog snapshot is freed.
+/// Inspect each `has_*` flag before reading its value.
+///
+/// Returns zero on success, or a negative code on failure.
+///
+/// # Safety
+/// - The caller must ensure that `dst` points to a valid [moq_video_presentation].
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_consume_video_presentation(catalog: u32, dst: *mut moq_video_presentation) -> i32 {
+	ffi::enter(move || {
+		let catalog = ffi::parse_id(catalog)?;
+		let dst = unsafe { dst.as_mut() }.ok_or(Error::InvalidPointer)?;
+		State::lock().consume.video_presentation(catalog, dst)
 	})
 }
 

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -30,13 +30,13 @@ pub struct moq_video_config {
 	pub coded_height: *const u32,
 }
 
-/// Video presentation metadata applied to all video renditions in the catalog.
+/// Catalog properties shared by every video rendition.
 ///
 /// A false `has_*` flag clears that field from the next catalog rather than preserving its previous value.
 #[repr(C)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, Default)]
-pub struct moq_video_presentation {
+pub struct moq_video_properties {
 	/// Final rendered width in pixels when `has_display` is true.
 	pub display_width: u32,
 
@@ -822,32 +822,29 @@ pub unsafe extern "C" fn moq_publish_media_frame(
 	})
 }
 
-/// Replace the video presentation metadata in the catalog.
+/// Replace the catalog properties shared by every video rendition.
 ///
 /// Rotation is clockwise and normalized to the nearest quarter turn. A field whose matching `has_*` flag is false is removed from the next catalog update.
 ///
 /// Returns zero on success, or a negative code on failure.
 ///
 /// # Safety
-/// - The caller must ensure that `presentation` points to a valid [moq_video_presentation].
+/// - The caller must ensure that `properties` points to a valid [moq_video_properties].
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn moq_publish_video_presentation(
-	broadcast: u32,
-	presentation: *const moq_video_presentation,
-) -> i32 {
+pub unsafe extern "C" fn moq_publish_video_properties(broadcast: u32, properties: *const moq_video_properties) -> i32 {
 	ffi::enter(move || {
 		let broadcast = ffi::parse_id(broadcast)?;
-		let presentation = unsafe { presentation.as_ref() }.ok_or(Error::InvalidPointer)?;
+		let properties = unsafe { properties.as_ref() }.ok_or(Error::InvalidPointer)?;
 
-		let mut value = hang::catalog::VideoPresentation::default();
-		value.display = presentation.has_display.then_some(hang::catalog::Display {
-			width: presentation.display_width,
-			height: presentation.display_height,
+		let mut value = hang::catalog::VideoProperties::default();
+		value.display = properties.has_display.then_some(hang::catalog::Display {
+			width: properties.display_width,
+			height: properties.display_height,
 		});
-		value.rotation = presentation.has_rotation.then_some(presentation.rotation);
-		value.flip = presentation.has_flip.then_some(presentation.flip);
+		value.rotation = properties.has_rotation.then_some(properties.rotation);
+		value.flip = properties.has_flip.then_some(properties.flip);
 
-		State::lock().publish.video_presentation(broadcast, value)
+		State::lock().publish.video_properties(broadcast, value)
 	})
 }
 
@@ -1390,7 +1387,7 @@ pub unsafe extern "C" fn moq_consume_video_config(catalog: u32, index: u32, dst:
 	})
 }
 
-/// Query the video presentation metadata in the catalog.
+/// Query the catalog properties shared by every video rendition.
 ///
 /// The destination is filled by value and remains valid after the catalog snapshot is freed.
 /// Inspect each `has_*` flag before reading its value.
@@ -1398,13 +1395,13 @@ pub unsafe extern "C" fn moq_consume_video_config(catalog: u32, index: u32, dst:
 /// Returns zero on success, or a negative code on failure.
 ///
 /// # Safety
-/// - The caller must ensure that `dst` points to a valid [moq_video_presentation].
+/// - The caller must ensure that `dst` points to a valid [moq_video_properties].
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn moq_consume_video_presentation(catalog: u32, dst: *mut moq_video_presentation) -> i32 {
+pub unsafe extern "C" fn moq_consume_video_properties(catalog: u32, dst: *mut moq_video_properties) -> i32 {
 	ffi::enter(move || {
 		let catalog = ffi::parse_id(catalog)?;
 		let dst = unsafe { dst.as_mut() }.ok_or(Error::InvalidPointer)?;
-		State::lock().consume.video_presentation(catalog, dst)
+		State::lock().consume.video_properties(catalog, dst)
 	})
 }
 

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -4,7 +4,7 @@ use tokio::sync::{mpsc, oneshot};
 use crate::ffi::OnStatus;
 use crate::{
 	Error, Id, NonZeroSlab, State, moq_audio_config, moq_datagram, moq_frame, moq_json_value, moq_section, moq_string,
-	moq_video_config,
+	moq_video_config, moq_video_presentation,
 };
 
 struct ConsumeCatalog {
@@ -213,6 +213,24 @@ impl Consume {
 				.as_ref()
 				.map(|height| height as *const u32)
 				.unwrap_or(std::ptr::null()),
+		};
+
+		Ok(())
+	}
+
+	/// Fill `dst` with the video presentation metadata from the catalog.
+	pub fn video_presentation(&self, catalog: Id, dst: &mut moq_video_presentation) -> Result<(), Error> {
+		let consume = self.catalog.get(catalog).ok_or(Error::CatalogNotFound)?;
+		let display = consume.catalog.video.display.as_ref();
+
+		*dst = moq_video_presentation {
+			display_width: display.map_or(0, |display| display.width),
+			display_height: display.map_or(0, |display| display.height),
+			has_display: display.is_some(),
+			rotation: consume.catalog.video.rotation.unwrap_or_default(),
+			has_rotation: consume.catalog.video.rotation.is_some(),
+			flip: consume.catalog.video.flip.unwrap_or_default(),
+			has_flip: consume.catalog.video.flip.is_some(),
 		};
 
 		Ok(())

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -4,7 +4,7 @@ use tokio::sync::{mpsc, oneshot};
 use crate::ffi::OnStatus;
 use crate::{
 	Error, Id, NonZeroSlab, State, moq_audio_config, moq_datagram, moq_frame, moq_json_value, moq_section, moq_string,
-	moq_video_config, moq_video_presentation,
+	moq_video_config, moq_video_properties,
 };
 
 struct ConsumeCatalog {
@@ -218,12 +218,12 @@ impl Consume {
 		Ok(())
 	}
 
-	/// Fill `dst` with the video presentation metadata from the catalog.
-	pub fn video_presentation(&self, catalog: Id, dst: &mut moq_video_presentation) -> Result<(), Error> {
+	/// Fill `dst` with the properties shared by every video rendition.
+	pub fn video_properties(&self, catalog: Id, dst: &mut moq_video_properties) -> Result<(), Error> {
 		let consume = self.catalog.get(catalog).ok_or(Error::CatalogNotFound)?;
 		let display = consume.catalog.video.display.as_ref();
 
-		*dst = moq_video_presentation {
+		*dst = moq_video_properties {
 			display_width: display.map_or(0, |display| display.width),
 			display_height: display.map_or(0, |display| display.height),
 			has_display: display.is_some(),

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -162,6 +162,19 @@ impl Publish {
 		Ok(())
 	}
 
+	/// Replace the video presentation metadata as one catalog update.
+	pub fn video_presentation(
+		&mut self,
+		broadcast: Id,
+		presentation: hang::catalog::VideoPresentation,
+	) -> Result<(), Error> {
+		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
+		let mut catalog = catalog.lock();
+		catalog.video.set_presentation(presentation)?;
+		catalog.commit()?;
+		Ok(())
+	}
+
 	/// Insert or replace a top-level application catalog section by name.
 	///
 	/// `value` is any JSON document. Errors if `name` is reserved (`video`/`audio`).

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -162,15 +162,11 @@ impl Publish {
 		Ok(())
 	}
 
-	/// Replace the video presentation metadata as one catalog update.
-	pub fn video_presentation(
-		&mut self,
-		broadcast: Id,
-		presentation: hang::catalog::VideoPresentation,
-	) -> Result<(), Error> {
+	/// Replace the properties shared by every video rendition as one catalog update.
+	pub fn video_properties(&mut self, broadcast: Id, properties: hang::catalog::VideoProperties) -> Result<(), Error> {
 		let (_, catalog) = self.broadcasts.get_mut(broadcast).ok_or(Error::BroadcastNotFound)?;
 		let mut catalog = catalog.lock();
-		catalog.video.set_presentation(presentation)?;
+		catalog.video.set_properties(properties)?;
 		catalog.commit()?;
 		Ok(())
 	}

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -217,6 +217,7 @@ fn publish_catalog_config_invalid_broadcast() {
 		coded_height: std::ptr::null(),
 	};
 	assert!(unsafe { moq_publish_video_config(0, &video) } < 0);
+	assert!(unsafe { moq_publish_video_properties(0, &moq_video_properties::default()) } < 0);
 
 	let audio_codec = "opus";
 	let audio = moq_audio_config {
@@ -243,6 +244,11 @@ fn publish_catalog_config_null_pointer() {
 		unsafe { moq_publish_video_config(broadcast, std::ptr::null()) },
 		-6,
 		"null config should return InvalidPointer (-6)"
+	);
+	assert_eq!(
+		unsafe { moq_publish_video_properties(broadcast, std::ptr::null()) },
+		-6,
+		"null properties should return InvalidPointer (-6)"
 	);
 	assert_eq!(
 		unsafe { moq_publish_audio_config(broadcast, std::ptr::null()) },
@@ -275,6 +281,16 @@ fn publish_catalog_roundtrip() {
 		coded_height: &height,
 	};
 	assert_eq!(unsafe { moq_publish_video_config(broadcast, &video) }, 0);
+	let properties = moq_video_properties {
+		display_width: 1080,
+		display_height: 1920,
+		has_display: true,
+		rotation: 315.0,
+		has_rotation: true,
+		flip: true,
+		has_flip: true,
+	};
+	assert_eq!(unsafe { moq_publish_video_properties(broadcast, &properties) }, 0);
 
 	let audio_name = "audio";
 	let audio_codec = "opus";
@@ -318,6 +334,16 @@ fn publish_catalog_roundtrip() {
 	assert_eq!(codec, "vp8");
 	assert_eq!(unsafe { *video_cfg.coded_width }, 1920);
 	assert_eq!(unsafe { *video_cfg.coded_height }, 1080);
+
+	let mut properties = moq_video_properties::default();
+	assert_eq!(unsafe { moq_consume_video_properties(catalog_id, &mut properties) }, 0);
+	assert!(properties.has_display);
+	assert_eq!(properties.display_width, 1080);
+	assert_eq!(properties.display_height, 1920);
+	assert!(properties.has_rotation);
+	assert_eq!(properties.rotation, 0.0);
+	assert!(properties.has_flip);
+	assert!(properties.flip);
 
 	// And so does the audio rendition.
 	let mut audio_cfg = moq_audio_config {

--- a/rs/moq-ffi/src/media.rs
+++ b/rs/moq-ffi/src/media.rs
@@ -6,6 +6,22 @@ pub struct MoqDimensions {
 	pub height: u32,
 }
 
+/// Video presentation metadata applied to all video renditions in the catalog.
+///
+/// Every generated-language constructor requires all three fields.
+/// Passing an absent field clears it from the next catalog snapshot rather than preserving the previous value.
+#[derive(Clone, Default, uniffi::Record)]
+pub struct MoqVideoPresentation {
+	/// Final rendered size after rotation, or absent to clear the explicit display size.
+	pub display: Option<MoqDimensions>,
+
+	/// Clockwise rotation in degrees, or absent to clear the explicit rotation.
+	pub rotation: Option<f64>,
+
+	/// Whether to flip horizontally after rotation, or absent to clear the explicit value.
+	pub flip: Option<bool>,
+}
+
 /// How a track's frames are packaged, as advertised in the catalog.
 #[derive(Clone, uniffi::Enum)]
 pub enum MoqContainer {

--- a/rs/moq-ffi/src/media.rs
+++ b/rs/moq-ffi/src/media.rs
@@ -6,19 +6,21 @@ pub struct MoqDimensions {
 	pub height: u32,
 }
 
-/// Video presentation metadata applied to all video renditions in the catalog.
+/// Catalog properties shared by every video rendition.
 ///
-/// Every generated-language constructor requires all three fields.
 /// Passing an absent field clears it from the next catalog snapshot rather than preserving the previous value.
 #[derive(Clone, Default, uniffi::Record)]
-pub struct MoqVideoPresentation {
+pub struct MoqVideoProperties {
 	/// Final rendered size after rotation, or absent to clear the explicit display size.
+	#[uniffi(default = None)]
 	pub display: Option<MoqDimensions>,
 
 	/// Clockwise rotation in degrees, or absent to clear the explicit rotation.
+	#[uniffi(default = None)]
 	pub rotation: Option<f64>,
 
 	/// Whether to flip horizontally after rotation, or absent to clear the explicit value.
+	#[uniffi(default = None)]
 	pub flip: Option<bool>,
 }
 

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -5,7 +5,7 @@ use moq_mux::catalog::hang::Extra;
 use crate::consumer::{MoqBroadcastConsumer, MoqGroupConsumer, MoqSubscription, MoqTrackConsumer};
 use crate::error::MoqError;
 use crate::ffi::Task;
-use crate::media::{MoqFrame, MoqInit};
+use crate::media::{MoqFrame, MoqInit, MoqVideoPresentation};
 use crate::origin::MoqRoute;
 
 /// Publisher-side track properties, mirroring [`moq_net::track::Info`].
@@ -288,6 +288,27 @@ impl MoqBroadcastProducer {
 		self.with_state(|state| {
 			let route = state.broadcast.consume().route();
 			Ok(state.broadcast.set_route(route.with_announce(announce))?)
+		})
+	}
+
+	/// Replace the video presentation metadata in the catalog.
+	///
+	/// Rotation is clockwise and normalized to the nearest quarter turn. An absent field is removed from the next catalog update.
+	pub fn set_video_presentation(&self, presentation: MoqVideoPresentation) -> Result<(), MoqError> {
+		let _guard = crate::ffi::RUNTIME.enter();
+		let mut value = hang::catalog::VideoPresentation::default();
+		value.display = presentation.display.map(|display| hang::catalog::Display {
+			width: display.width,
+			height: display.height,
+		});
+		value.rotation = presentation.rotation;
+		value.flip = presentation.flip;
+
+		self.with_state(|state| {
+			let mut catalog = state.catalog.lock();
+			catalog.video.set_presentation(value)?;
+			catalog.commit()?;
+			Ok(())
 		})
 	}
 

--- a/rs/moq-ffi/src/producer.rs
+++ b/rs/moq-ffi/src/producer.rs
@@ -5,7 +5,7 @@ use moq_mux::catalog::hang::Extra;
 use crate::consumer::{MoqBroadcastConsumer, MoqGroupConsumer, MoqSubscription, MoqTrackConsumer};
 use crate::error::MoqError;
 use crate::ffi::Task;
-use crate::media::{MoqFrame, MoqInit, MoqVideoPresentation};
+use crate::media::{MoqFrame, MoqInit, MoqVideoProperties};
 use crate::origin::MoqRoute;
 
 /// Publisher-side track properties, mirroring [`moq_net::track::Info`].
@@ -291,22 +291,22 @@ impl MoqBroadcastProducer {
 		})
 	}
 
-	/// Replace the video presentation metadata in the catalog.
+	/// Replace the catalog properties shared by every video rendition.
 	///
 	/// Rotation is clockwise and normalized to the nearest quarter turn. An absent field is removed from the next catalog update.
-	pub fn set_video_presentation(&self, presentation: MoqVideoPresentation) -> Result<(), MoqError> {
+	pub fn set_video_properties(&self, properties: MoqVideoProperties) -> Result<(), MoqError> {
 		let _guard = crate::ffi::RUNTIME.enter();
-		let mut value = hang::catalog::VideoPresentation::default();
-		value.display = presentation.display.map(|display| hang::catalog::Display {
+		let mut value = hang::catalog::VideoProperties::default();
+		value.display = properties.display.map(|display| hang::catalog::Display {
 			width: display.width,
 			height: display.height,
 		});
-		value.rotation = presentation.rotation;
-		value.flip = presentation.flip;
+		value.rotation = properties.rotation;
+		value.flip = properties.flip;
 
 		self.with_state(|state| {
 			let mut catalog = state.catalog.lock();
-			catalog.video.set_presentation(value)?;
+			catalog.video.set_properties(value)?;
 			catalog.commit()?;
 			Ok(())
 		})

--- a/swift/Sources/Moq/Aliases.swift
+++ b/swift/Sources/Moq/Aliases.swift
@@ -13,6 +13,8 @@ public typealias Catalog = MoqFFI.MoqCatalog
 public typealias Video = MoqFFI.MoqVideo
 /// Caller-provided catalog fields for a video track.
 public typealias VideoHint = MoqFFI.MoqVideoHint
+/// Video presentation metadata applied to all video renditions in the catalog.
+public typealias VideoPresentation = MoqFFI.MoqVideoPresentation
 public typealias Audio = MoqFFI.MoqAudio
 public typealias AudioFrame = MoqFFI.MoqAudioFrame
 public typealias Dimensions = MoqFFI.MoqDimensions

--- a/swift/Sources/Moq/Broadcast.swift
+++ b/swift/Sources/Moq/Broadcast.swift
@@ -162,6 +162,11 @@ public final class BroadcastProducer: Sendable {
         try ffi.setAnnounce(announce: announce)
     }
 
+    /// Replace the video presentation metadata in the catalog.
+    public func setVideoPresentation(_ presentation: VideoPresentation) throws {
+        try ffi.setVideoPresentation(presentation: presentation)
+    }
+
     /// Open a media track. `format` controls how `initData` and frame payloads
     /// are interpreted (e.g. `"opus"`, `"avc3"`). `video` seeds catalog fields
     /// that the stream cannot reveal before its first keyframe.

--- a/swift/Sources/Moq/Broadcast.swift
+++ b/swift/Sources/Moq/Broadcast.swift
@@ -166,9 +166,9 @@ public final class BroadcastProducer: Sendable {
         try ffi.setAnnounce(announce: announce)
     }
 
-    /// Replace the video presentation metadata in the catalog.
-    public func setVideoPresentation(_ presentation: VideoPresentation) throws {
-        try ffi.setVideoPresentation(presentation: presentation)
+    /// Replace the catalog properties shared by every video rendition.
+    public func setVideoProperties(_ properties: VideoProperties) throws {
+        try ffi.setVideoProperties(properties: properties)
     }
 
     /// Open a media track. `format` controls how `initData` and frame payloads

--- a/swift/Tests/MoqTests/SmokeTests.swift
+++ b/swift/Tests/MoqTests/SmokeTests.swift
@@ -59,6 +59,12 @@ final class SmokeTests: XCTestCase {
         try broadcast.finish()
     }
 
+    func testVideoPropertiesUseDefaultedFields() throws {
+        let broadcast = try BroadcastProducer()
+        try broadcast.setVideoProperties(VideoProperties(rotation: 315))
+        try broadcast.finish()
+    }
+
     func testBroadcastConsumerFetchesCachedGroup() async throws {
         let broadcast = try BroadcastProducer()
         let track = try broadcast.publishTrack(name: "events")


### PR DESCRIPTION
## Summary

- Add `VideoProperties` to update the Hang catalog fields shared by every video rendition: `display`, `rotation`, and `flip`.
- Normalize finite rotation values to the nearest clockwise quarter turn while preserving rendition codec and track configuration.
- Expose matching publish APIs through Rust, C, Python, Swift, Kotlin, and Go, plus a C read API.
- Keep the existing catalog wire format unchanged.
- Fix the Swift wrapper workflow for pull requests that also change `moq-ffi`. The staged wrapper previously resolved the last published FFI package, which cannot contain symbols introduced by the same pull request. These pull requests now rely on the local Swift check against freshly generated bindings, while wrapper-only changes and releases still verify the published package.

## Public API changes

All changes are additive and target `main`.

- Rust: add `hang::catalog::VideoProperties`, `Video::set_properties`, and `Error::InvalidVideoRotation`.
- UniFFI: add `MoqVideoProperties` and `MoqBroadcastProducer::set_video_properties`.
- C: add `moq_video_properties`, `moq_publish_video_properties`, and `moq_consume_video_properties`.
- Python, Swift, Kotlin, and Go: add the corresponding `VideoProperties` types and broadcast setter methods.

`VideoPresentation` only existed in earlier revisions of this unmerged pull request, so no published API is renamed or removed.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just ci origin/main`
  - 2,311 Rust tests
  - 50 Python tests and API documentation
  - Kotlin and Swift generated-binding tests
  - Go race-enabled tests
  - Nix evaluation and GitHub Actions linting

(Written by GPT-5)
