### PR TITLE
build(rust): pin the toolchain and correct the MSRV claims

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,11 +63,13 @@ resolver = "2"
 
 [workspace.package]
 # Floor for the library surface: iroh 1.0 (via moq-native) needs 1.91. This is
-# what library consumers see. moq-relay overrides it to 1.95 (sysinfo 0.39); it
-# is a binary, so that higher floor never propagates to anyone building on the
-# libraries. The nix flake / rust-toolchain.toml pin the build toolchain (1.95,
-# so the whole workspace including the relay compiles) rather than latest
-# stable, which keeps the relay's ceiling from silently creeping up unnoticed.
+# what consumers of moq-net / hang / moq-native / etc. see. moq-relay overrides
+# it to 1.95 (sysinfo 0.39). moq-relay is lib+bin, so 1.95 does apply to its
+# own library target, but that crate is an application with no external
+# consumers; the point of the override is to keep the bump off the libraries
+# others actually build on. The nix flake / rust-toolchain.toml pin the build
+# toolchain to 1.95 (so the whole workspace including the relay compiles) rather
+# than latest stable, which keeps the relay's ceiling from creeping up unnoticed.
 rust-version = "1.91"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,13 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.85"
+# Floor for the library surface: iroh 1.0 (via moq-native) needs 1.91. This is
+# what library consumers see. moq-relay overrides it to 1.95 (sysinfo 0.39); it
+# is a binary, so that higher floor never propagates to anyone building on the
+# libraries. The nix flake / rust-toolchain.toml pin the build toolchain (1.95,
+# so the whole workspace including the relay compiles) rather than latest
+# stable, which keeps the relay's ceiling from silently creeping up unnoticed.
+rust-version = "1.91"
 
 [workspace.dependencies]
 flate2 = "1.1"

--- a/deny.toml
+++ b/deny.toml
@@ -23,7 +23,7 @@ ignore = [
     "RUSTSEC-2024-0320",
 
     # gstreamer 0.23 pulls paste (proc-macro). gstreamer 0.25 drops it but
-    # requires Rust 1.92; workspace MSRV is 1.85. Build-time only.
+    # needs Rust 1.92, above the 1.91 workspace MSRV. Build-time only.
     "RUSTSEC-2024-0436",
 
 ]

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,12 @@
           overlays = [ (import rust-overlay) ];
         };
 
-        rust-toolchain = pkgs.rust-bin.stable.latest.default.override {
+        # Pinned build toolchain (not latest stable) so `nix develop` and CI
+        # compile against a fixed rustc and the relay's MSRV can't creep up
+        # unnoticed. Set to moq-relay's 1.95 (the highest crate MSRV in the
+        # workspace) so the whole workspace, including the relay, builds; the
+        # library crates declare a lower 1.91 floor (Cargo.toml rust-version).
+        rust-toolchain = pkgs.rust-bin.stable."1.95.0".default.override {
           extensions = [
             "rust-src"
             "rust-analyzer"

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -2,16 +2,17 @@
 { crane }:
 final: prev:
 let
-  # Pin crane to rust-overlay's latest stable so `nix build` uses the same
-  # toolchain as `nix develop`. Without this, crane falls back to
-  # `final.rustc`/`final.cargo`, which nixpkgs resolves to its default Rust
-  # (currently 1.94) while the devShell pulls 1.95 from rust-overlay.
+  # Pin crane to the workspace MSRV (Cargo.toml rust-version /
+  # rust-toolchain.toml) so `nix build` uses the same toolchain as
+  # `nix develop` and release artifacts build with the version CI verifies.
+  # Without an explicit toolchain, crane falls back to `final.rustc`/
+  # `final.cargo`, which nixpkgs resolves to its own default Rust.
   #
   # Add both Apple targets so an aarch64-darwin host can cross-compile the
   # x86_64-darwin release artifacts (Apple's clang is multi-arch, so no
   # emulated x86_64 toolchain is needed). The default profile only ships
   # std for the host triple, which is why the target list is explicit.
-  rustToolchain = final.rust-bin.stable.latest.default.override {
+  rustToolchain = final.rust-bin.stable."1.95.0".default.override {
     targets = final.lib.optionals final.stdenv.isDarwin [
       "x86_64-apple-darwin"
       "aarch64-apple-darwin"

--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Reference for the `/rs` Cargo workspace. Universal rules (writing style, no em dashes, Root Cause First, Cross-Package Sync, Public API Scrutiny, Refactor As You Go) live in the root `/CLAUDE.md`; PR/commit/release mechanics live in `/CONTRIBUTING.md`. Neither is repeated here.
 
-Workspace members live in the root `Cargo.toml` (`[workspace]`). `rust-version = "1.85"`, edition 2024. Shared versions/paths are pinned under `[workspace.dependencies]`; new crates should add their dep there and reference it via `{ workspace = true }`.
+Workspace members live in the root `Cargo.toml` (`[workspace]`). `rust-version = "1.91"` (the library floor; `moq-relay` overrides to 1.95 for `sysinfo`), edition 2024. Shared versions/paths are pinned under `[workspace.dependencies]`; new crates should add their dep there and reference it via `{ workspace = true }`.
 
 ## Crate Map
 

--- a/rs/moq-audio/src/capture/screencapture.rs
+++ b/rs/moq-audio/src/capture/screencapture.rs
@@ -302,11 +302,11 @@ define_class!(
 			if kind.0 != SCStreamOutputType::Audio.0 {
 				return;
 			}
-			if let Some(buffer) = samples(sample_buffer) {
-				if let Some(tx) = self.ivars().tx.lock().unwrap().as_ref() {
-					// Send errors mean the reader is gone, i.e. capture is shutting down.
-					let _ = tx.send(buffer);
-				}
+			if let Some(buffer) = samples(sample_buffer)
+				&& let Some(tx) = self.ivars().tx.lock().unwrap().as_ref()
+			{
+				// Send errors mean the reader is gone, i.e. capture is shutting down.
+				let _ = tx.send(buffer);
 			}
 		}
 	}

--- a/rs/moq-audio/src/format.rs
+++ b/rs/moq-audio/src/format.rs
@@ -69,7 +69,7 @@ impl Format {
 		}
 
 		let bps = self.bytes_per_sample();
-		if data.len() % (bps * channels) != 0 {
+		if !data.len().is_multiple_of(bps * channels) {
 			return Err(Error::Misaligned {
 				got: data.len(),
 				expected: data.len().next_multiple_of(bps * channels),
@@ -162,7 +162,7 @@ impl Format {
 		if channels == 0 {
 			return Err(Error::Unsupported("channel count must be > 0".into()));
 		}
-		if samples.len() % channels != 0 {
+		if !samples.len().is_multiple_of(channels) {
 			return Err(Error::Misaligned {
 				got: samples.len(),
 				expected: samples.len().next_multiple_of(channels),

--- a/rs/moq-audio/src/resample.rs
+++ b/rs/moq-audio/src/resample.rs
@@ -70,7 +70,7 @@ impl Resampler {
 	/// Returns whatever the resampler can produce given the input and
 	/// the chunk size; remaining samples are buffered for the next call.
 	pub fn process(&mut self, samples: &[f32]) -> Result<Vec<f32>, Error> {
-		if samples.len() % self.channels != 0 {
+		if !samples.len().is_multiple_of(self.channels) {
 			return Err(Error::Misaligned {
 				got: samples.len(),
 				expected: samples.len().next_multiple_of(self.channels),

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -288,16 +288,17 @@ async fn drain(broadcast: broadcast::Consumer, stats: &Stats) -> anyhow::Result<
 		while let Some(frame) = group.read_frame().await? {
 			// The first frame of every group is the JSON keyframe. Parse it once to
 			// learn the publisher's shape (we may be watching a peer, not ourselves).
-			if first && !learned_shape {
-				if let Ok(header) = serde_json::from_slice::<RecvHeader>(&frame.payload) {
-					tracing::debug!(
-						fps = header.fps,
-						frame_size = header.frame_size,
-						group_size = header.group_size,
-						"subscribed broadcast shape"
-					);
-					learned_shape = true;
-				}
+			if first
+				&& !learned_shape
+				&& let Ok(header) = serde_json::from_slice::<RecvHeader>(&frame.payload)
+			{
+				tracing::debug!(
+					fps = header.fps,
+					frame_size = header.frame_size,
+					group_size = header.group_size,
+					"subscribed broadcast shape"
+				);
+				learned_shape = true;
 			}
 			first = false;
 			stats.frame_recv(frame.payload.len());

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -433,10 +433,10 @@ fn run_emulator(
 				audio_encoder.reset_epoch();
 			}
 			let samples = emu.audio_samples();
-			if !samples.is_empty() {
-				if let Err(e) = audio_encoder.push_samples(&samples, elapsed) {
-					tracing::warn!(error = %e, "audio encode error");
-				}
+			if !samples.is_empty()
+				&& let Err(e) = audio_encoder.push_samples(&samples, elapsed)
+			{
+				tracing::warn!(error = %e, "audio encode error");
 			}
 		} else {
 			// Drain audio buffer even when not encoding to prevent buildup.

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -104,10 +104,10 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 	// platform capture stream is not Send, so its future cannot be spawned.
 	let mut local: Option<Publish> = None;
 
-	if let ImportSource::Rtc(rtc) = &import.source {
-		if rtc.connect.is_some() {
-			reject_listener_cors(&rtc.cors, "import rtc")?;
-		}
+	if let ImportSource::Rtc(rtc) = &import.source
+		&& rtc.connect.is_some()
+	{
+		reject_listener_cors(&rtc.cors, "import rtc")?;
 	}
 
 	// The uplink's bandwidth estimate, for sources that can encode to fit it. Only
@@ -119,18 +119,18 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 	let mut send_bandwidth = None;
 
 	// MoQ side: publish the Origin outward.
-	if moq.client.connect.is_some() {
-		if let Some(reconnect) = net.client(moq.client.clone())?.publish(origin.consume()) {
-			moq::notify_ready();
-			// Read before the handle moves into the task. This consumer is
-			// persistent: it survives reconnects, reading `None` while down, so it
-			// can be wired up before anything connects.
-			#[cfg(feature = "capture")]
-			{
-				send_bandwidth = Some(reconnect.send_bandwidth());
-			}
-			tasks.spawn(async move { Ok(reconnect.closed().await?) });
+	if moq.client.connect.is_some()
+		&& let Some(reconnect) = net.client(moq.client.clone())?.publish(origin.consume())
+	{
+		moq::notify_ready();
+		// Read before the handle moves into the task. This consumer is
+		// persistent: it survives reconnects, reading `None` while down, so it
+		// can be wired up before anything connects.
+		#[cfg(feature = "capture")]
+		{
+			send_bandwidth = Some(reconnect.send_bandwidth());
 		}
+		tasks.spawn(async move { Ok(reconnect.closed().await?) });
 	}
 	if let Some(web_bind) = moq.server.bind.clone() {
 		let server = net.server(moq.server.clone())?;
@@ -215,18 +215,18 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 	let name = moq.broadcast.clone().unwrap_or_default();
 	let mut tasks: JoinSet<anyhow::Result<()>> = JoinSet::new();
 
-	if let ExportSink::Rtc(rtc) = &export.sink {
-		if rtc.connect.is_some() {
-			reject_listener_cors(&rtc.cors, "export rtc")?;
-		}
+	if let ExportSink::Rtc(rtc) = &export.sink
+		&& rtc.connect.is_some()
+	{
+		reject_listener_cors(&rtc.cors, "export rtc")?;
 	}
 
 	// MoQ side: fill the Origin.
-	if moq.client.connect.is_some() {
-		if let Some(reconnect) = net.client(moq.client.clone())?.consume(origin.clone()) {
-			moq::notify_ready();
-			tasks.spawn(async move { Ok(reconnect.closed().await?) });
-		}
+	if moq.client.connect.is_some()
+		&& let Some(reconnect) = net.client(moq.client.clone())?.consume(origin.clone())
+	{
+		moq::notify_ready();
+		tasks.spawn(async move { Ok(reconnect.closed().await?) });
 	}
 	if let Some(web_bind) = moq.server.bind.clone() {
 		let server = net.server(moq.server.clone())?;

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -91,10 +91,10 @@ impl SessionController {
 	fn start(settings: ResolvedSettings, element: glib::WeakRef<super::MoqSrc>) -> Self {
 		let (shutdown_tx, mut shutdown_rx) = watch::channel(false);
 		let join = RUNTIME.spawn(async move {
-			if let Err(err) = run_session(settings, element.clone(), &mut shutdown_rx).await {
-				if let Some(obj) = element.upgrade() {
-					gst::element_error!(obj, gst::CoreError::Failed, ("session error"), ["{err:?}"]);
-				}
+			if let Err(err) = run_session(settings, element.clone(), &mut shutdown_rx).await
+				&& let Some(obj) = element.upgrade()
+			{
+				gst::element_error!(obj, gst::CoreError::Failed, ("session error"), ["{err:?}"]);
 			}
 		});
 

--- a/rs/moq-json/benches/codec.rs
+++ b/rs/moq-json/benches/codec.rs
@@ -57,7 +57,7 @@ fn telemetry(tick: u64) -> Value {
 			"temp_c": ((4.0 + (t * 0.05).sin() * 1.5) * 100.0).round() / 100.0,
 			"humidity": 60 + (tick % 10),
 			"shock_g": (((t * 0.3).sin().abs()) * 100.0).round() / 100.0,
-			"door_open": tick % 30 == 0,
+			"door_open": tick.is_multiple_of(30),
 		},
 		"power": {
 			"battery_pct": 100 - (tick / 6) % 100,

--- a/rs/moq-json/examples/telemetry.rs
+++ b/rs/moq-json/examples/telemetry.rs
@@ -51,7 +51,7 @@ fn telemetry(tick: u64) -> Value {
 			"temp_c": (4.0 + (t * 0.05).sin() * 1.5 * 100.0).round() / 100.0,
 			"humidity": 60 + (tick % 10),
 			"shock_g": (((t * 0.3).sin().abs()) * 100.0).round() / 100.0,
-			"door_open": tick % 30 == 0,
+			"door_open": tick.is_multiple_of(30),
 		},
 		"power": {
 			"battery_pct": 100 - (tick / 6) % 100,

--- a/rs/moq-mux/src/codec/h264/mod.rs
+++ b/rs/moq-mux/src/codec/h264/mod.rs
@@ -400,10 +400,10 @@ impl Avc1 {
 			}
 		}
 
-		if let Some(nal) = nal_iter.flush()? {
-			if process_nal(&nal, &mut out, &mut frame_sps, &mut frame_pps)? {
-				emitted_any_slice = true;
-			}
+		if let Some(nal) = nal_iter.flush()?
+			&& process_nal(&nal, &mut out, &mut frame_sps, &mut frame_pps)?
+		{
+			emitted_any_slice = true;
 		}
 
 		// A frame that carries parameter sets (a keyframe) redefines the active

--- a/rs/moq-mux/src/codec/h265/mod.rs
+++ b/rs/moq-mux/src/codec/h265/mod.rs
@@ -282,10 +282,10 @@ impl Hvc1 {
 			}
 		}
 
-		if let Some(nal) = nal_iter.flush()? {
-			if process_nal(&nal, &mut out, &mut frame_vps, &mut frame_sps, &mut frame_pps)? {
-				emitted_any_slice = true;
-			}
+		if let Some(nal) = nal_iter.flush()?
+			&& process_nal(&nal, &mut out, &mut frame_vps, &mut frame_sps, &mut frame_pps)?
+		{
+			emitted_any_slice = true;
 		}
 
 		// A frame that carries parameter sets (a keyframe) redefines the active

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -227,10 +227,10 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 	fn handle_tracks(&mut self, entries: Vec<MatroskaSpec>) -> Result<()> {
 		for entry in entries {
-			if let MatroskaSpec::TrackEntry(Master::Full(children)) = entry {
-				if let Err(e) = self.add_track(children) {
-					tracing::warn!(error = ?e, "skipping MKV track");
-				}
+			if let MatroskaSpec::TrackEntry(Master::Full(children)) = entry
+				&& let Err(e) = self.add_track(children)
+			{
+				tracing::warn!(error = ?e, "skipping MKV track");
 			}
 		}
 		Ok(())
@@ -375,10 +375,8 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		// Manage groups: new group on video keyframe; audio always finishes its group immediately.
 		match track.kind {
 			TrackKind::Video => {
-				if keyframe {
-					if let Some(mut prev) = track.group.take() {
-						prev.finish()?;
-					}
+				if keyframe && let Some(mut prev) = track.group.take() {
+					prev.finish()?;
 				}
 				track.track.write(frame)?;
 			}

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -504,14 +504,12 @@ async fn export_bframe_video_authors_dts() {
 	let mut effective = Vec::new();
 	while let Some(packet) = reader.read_ts_packet().unwrap() {
 		match packet.payload {
-			Some(TsPayload::Pmt(pmt)) => {
-				if video_pid.is_none() {
-					video_pid = pmt
-						.es_info
-						.iter()
-						.find(|e| e.stream_type == StreamType::H264)
-						.map(|e| e.elementary_pid);
-				}
+			Some(TsPayload::Pmt(pmt)) if video_pid.is_none() => {
+				video_pid = pmt
+					.es_info
+					.iter()
+					.find(|e| e.stream_type == StreamType::H264)
+					.map(|e| e.elementary_pid);
 			}
 			Some(TsPayload::PesStart(pes)) if Some(packet.header.pid) == video_pid => {
 				let p = pes.header.pts.expect("video PES carried no PTS").as_u64();

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -584,10 +584,10 @@ async fn serve_session(request: Request) -> crate::Result<()> {
 #[cfg(any(feature = "tcp", all(feature = "uds", unix)))]
 fn stream_versions(base: &moq_net::Versions) -> moq_net::Versions {
 	let mut versions: Vec<moq_net::Version> = base.iter().copied().collect();
-	if let Ok(lite05) = "moq-lite-05".parse::<moq_net::Version>() {
-		if !versions.contains(&lite05) {
-			versions.push(lite05);
-		}
+	if let Ok(lite05) = "moq-lite-05".parse::<moq_net::Version>()
+		&& !versions.contains(&lite05)
+	{
+		versions.push(lite05);
 	}
 	moq_net::Versions::from(versions)
 }

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1181,20 +1181,20 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 				// Last subscriber left: pause the upstream (cap at the latest cached
 				// group, priority 0) but keep the stream open in case one returns.
 				if supports_update {
-					if let Sub::Active(active) = sub {
-						if !active.paused {
-							active.paused = true;
-							active.start_group = None;
-							let cap = producer.latest().unwrap_or(0);
-							let update = lite::SubscribeUpdate {
-								priority: 0,
-								ordered: active.ordered,
-								max_latency: active.max_latency,
-								start_group: active.start_group,
-								end_group: Some(cap),
-							};
-							active.stream.writer.encode(&update).await?;
-						}
+					if let Sub::Active(active) = sub
+						&& !active.paused
+					{
+						active.paused = true;
+						active.start_group = None;
+						let cap = producer.latest().unwrap_or(0);
+						let update = lite::SubscribeUpdate {
+							priority: 0,
+							ordered: active.ordered,
+							max_latency: active.max_latency,
+							start_group: active.start_group,
+							end_group: Some(cap),
+						};
+						active.stream.writer.encode(&update).await?;
 					}
 				} else if let Sub::Active(active) = sub {
 					// No SUBSCRIBE_UPDATE to pause with (Lite01/02): cancel the

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1986,10 +1986,10 @@ impl Consumer {
 				broadcast,
 			} = announced.next().await?;
 			// `scope` narrows by prefix, but we only want an exact-path match.
-			if announced_path.as_path() == path {
-				if let Some(broadcast) = broadcast {
-					return Some(broadcast.with_stats(scope));
-				}
+			if announced_path.as_path() == path
+				&& let Some(broadcast) = broadcast
+			{
+				return Some(broadcast.with_stats(scope));
 			}
 		}
 	}

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -659,13 +659,13 @@ impl Subscriber {
 		let mut all_done = true;
 		for seg in &mut self.segments {
 			// Re-offer a group parked at the cap once the cap rises.
-			if let Some(group) = seg.parked.take_if(|group| !beyond_cap(group.sequence)) {
-				if group.sequence >= self.min_sequence {
-					self.next_sequence = self.next_sequence.max(group.sequence.saturating_add(1));
-					return Poll::Ready(Ok(Some(group)));
-				}
-				// A `start_at` overtook the parked group; drop it and read on.
+			if let Some(group) = seg.parked.take_if(|group| !beyond_cap(group.sequence))
+				&& group.sequence >= self.min_sequence
+			{
+				self.next_sequence = self.next_sequence.max(group.sequence.saturating_add(1));
+				return Poll::Ready(Ok(Some(group)));
 			}
+			// A `start_at` overtook the parked group; drop it and read on.
 			if seg.parked.is_some() {
 				// Still capped: the segment isn't done, it's parked.
 				all_done = false;

--- a/rs/moq-nvenc/Cargo.toml
+++ b/rs/moq-nvenc/Cargo.toml
@@ -3,7 +3,7 @@ name = "moq-nvenc"
 version = "0.0.1"
 edition = "2021"
 license = "MIT"
-rust-version = "1.85"
+rust-version.workspace = true
 
 description = "NVENC hardware video encoder bindings, forked from ViliamVadocz/nvidia-video-codec-sdk with runtime dynamic loading (dlopen only)"
 repository = "https://github.com/moq-dev/moq"

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -8,8 +8,10 @@ license = "MIT OR Apache-2.0"
 version = "0.14.0"
 edition = "2024"
 # sysinfo 0.39 (cache governor cgroup limits) needs 1.95, above the 1.91
-# workspace floor. moq-relay is a binary, so this doesn't reach library
-# consumers; keep it a per-crate override rather than raising the workspace.
+# workspace floor. moq-relay is lib+bin, so this applies to its library target
+# too, but the crate is an application with no external consumers; keeping the
+# bump per-crate holds it off the libraries others build on rather than raising
+# the whole workspace.
 rust-version = "1.95"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -7,7 +7,10 @@ license = "MIT OR Apache-2.0"
 
 version = "0.14.0"
 edition = "2024"
-rust-version.workspace = true
+# sysinfo 0.39 (cache governor cgroup limits) needs 1.95, above the 1.91
+# workspace floor. moq-relay is a binary, so this doesn't reach library
+# consumers; keep it a per-crate override rather than raising the workspace.
+rust-version = "1.95"
 
 keywords = ["quic", "http3", "webtransport", "media", "live"]
 categories = ["multimedia", "network-programming", "web-programming"]

--- a/rs/moq-video/src/capture/pipewire.rs
+++ b/rs/moq-video/src/capture/pipewire.rs
@@ -568,8 +568,8 @@ mod tests {
 			}
 		};
 
-		assert!(stream.width() >= 2 && stream.width() % 2 == 0, "bad width");
-		assert!(stream.height() >= 2 && stream.height() % 2 == 0, "bad height");
+		assert!(stream.width() >= 2 && stream.width().is_multiple_of(2), "bad width");
+		assert!(stream.height() >= 2 && stream.height().is_multiple_of(2), "bad height");
 
 		for i in 0..5 {
 			let frame = stream.read().await.unwrap_or_else(|| panic!("no frame {i}"));

--- a/rs/moq-video/src/capture/v4l2.rs
+++ b/rs/moq-video/src/capture/v4l2.rs
@@ -104,7 +104,7 @@ impl Camera {
 
 		let (width, height, stride) = (format.width, format.height, format.stride);
 		// I420 chroma is 2x2 subsampled, so the encoder needs even dimensions.
-		if width % 2 != 0 || height % 2 != 0 {
+		if !width.is_multiple_of(2) || !height.is_multiple_of(2) {
 			return Err(Error::Codec(anyhow::anyhow!(
 				"camera resolution {width}x{height} must be even for H.264 encoding"
 			)));

--- a/rs/moq-video/src/decode/backend/nvdec.rs
+++ b/rs/moq-video/src/decode/backend/nvdec.rs
@@ -271,13 +271,12 @@ impl State {
 		// keyframe) keeps the existing decoder. The display crop matters even at
 		// the same coded and target sizes: it selects the source rect the scaler
 		// reads from.
-		if let Some(decoder) = &self.decoder {
-			if decoder.coded == coded
-				&& decoder.display_area == display_area
-				&& (decoder.width, decoder.height) == (width, height)
-			{
-				return Ok(surfaces);
-			}
+		if let Some(decoder) = &self.decoder
+			&& decoder.coded == coded
+			&& decoder.display_area == display_area
+			&& (decoder.width, decoder.height) == (width, height)
+		{
+			return Ok(surfaces);
 		}
 		self.decoder = None;
 

--- a/rs/moq-video/src/encode/backend/openh264.rs
+++ b/rs/moq-video/src/encode/backend/openh264.rs
@@ -101,10 +101,10 @@ impl Backend for Openh264 {
 		// A rate deferred from before the encoder existed lands here, ahead of the
 		// frame rather than after it, so a rejected rate can't cost us a frame's
 		// packets on the way out.
-		if self.started {
-			if let Some(bitrate) = self.pending.take() {
-				self.apply_bitrate(bitrate)?;
-			}
+		if self.started
+			&& let Some(bitrate) = self.pending.take()
+		{
+			self.apply_bitrate(bitrate)?;
 		}
 
 		if keyframe {

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -518,7 +518,7 @@ pub(crate) mod cuda {
 		/// Allocate an NV12 buffer for `width` x `height` (both even) at row
 		/// pitch `pitch`. Uninitialized: the caller copies the full extent in.
 		pub(crate) fn alloc(ctx: &Arc<CudaContext>, width: u32, height: u32, pitch: u32) -> Result<Self, Error> {
-			debug_assert!(pitch >= width && width % 2 == 0 && height % 2 == 0);
+			debug_assert!(pitch >= width && width.is_multiple_of(2) && height.is_multiple_of(2));
 			let len = pitch as usize * height as usize * 3 / 2;
 			ctx.bind_to_thread()
 				.map_err(|e| Error::Codec(anyhow::anyhow!("CUDA bind: {e:?}")))?;

--- a/rs/moq-video/src/size.rs
+++ b/rs/moq-video/src/size.rs
@@ -35,7 +35,7 @@ impl Size {
 				"{what} {self}: dimensions must be non-zero"
 			)));
 		}
-		if self.width % 2 != 0 || self.height % 2 != 0 {
+		if !self.width.is_multiple_of(2) || !self.height.is_multiple_of(2) {
 			return Err(Error::Codec(anyhow::anyhow!("{what} {self}: dimensions must be even")));
 		}
 		Ok(())

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,6 @@
 [toolchain]
-# Pinned to the workspace MSRV (see Cargo.toml rust-version). Keep in sync with
-# the version pinned in flake.nix / nix/overlay.nix.
+# Pinned to the build toolchain: moq-relay's 1.95 (the highest crate MSRV), so
+# the whole workspace compiles. NOT the 1.91 workspace library floor in
+# Cargo.toml. Keep in sync with flake.nix / nix/overlay.nix.
 channel = "1.95.0"
 components = ["rustfmt", "clippy"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,5 @@
 [toolchain]
+# Pinned to the workspace MSRV (see Cargo.toml rust-version). Keep in sync with
+# the version pinned in flake.nix / nix/overlay.nix.
+channel = "1.95.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Problem

Closes #2460. The workspace claimed `rust-version = "1.85"`, but that was never accurate or verified. The flake used `rust-bin.stable.latest.default`, so CI always compiled with the newest stable (currently 1.96) and never tested the claimed floor. The real requirements from the dependency graph are higher:

| Dep | Declares | Pulled in by |
|---|---|---|
| `sysinfo 0.39` | **1.95** | `moq-relay` (cache governor reads cgroup memory limits) |
| `iroh 1.0` | **1.91** | `moq-native` -> `web-transport-iroh` |

(The 1.95 from `sysinfo` is exactly the "moq-relay builder had to bump to 1.95" the issue reporter hit; the ChatGPT analysis in the issue stopped at iroh and missed it.)

## Approach: two-tier MSRV

Rather than tax the whole workspace with the relay's requirement, the MSRV is split so library consumers keep the lowest honest floor:

- **Workspace floor stays at 1.91** (iroh) — what consumers of `moq-net` / `hang` / `moq-native` / `moq-token` / etc. see. Verified: the whole workspace **minus `moq-relay`** compiles on a real 1.91 toolchain.
- **`moq-relay` overrides to 1.95** via a per-crate `rust-version`. It's a binary, so the higher floor never propagates to anyone building on the libraries.

`sysinfo 0.39` is kept (not downgraded to 0.38, which would drop the relay to 1.91) because 0.39.0 adds *"Linux: take into account parent cgroup memory limits"* — directly relevant to the relay's cache governor sizing the LRU pool inside nested-cgroup containers (k8s), where getting the limit wrong risks OOM.

## Toolchain pin

The nix build toolchain (`flake.nix`, `nix/overlay.nix`, `rust-toolchain.toml`) is pinned to **1.95** instead of latest stable. It has to be 1.95 to compile the relay, and **pinning the build compiler does not raise anyone's declared MSRV** — consumers read the per-crate `rust-version`, not whatever we build with. This keeps the relay's ceiling from silently creeping to 1.96+ unnoticed, the exact drift that hid the stale 1.85 claim.

## Also

- `moq-nvenc` now inherits the workspace `rust-version` (was a stale standalone `1.85`).
- `deny.toml`: the gstreamer-0.25 RUSTSEC ignore note is accurate again (0.25 needs 1.92, above the 1.91 floor).
- `rs/CLAUDE.md` documents the two-tier floor.

## Verification

- Full workspace compiles on **1.95** ✓
- Workspace minus `moq-relay` compiles on a real **1.91** toolchain ✓
- `taplo` / `nixfmt` / `cargo sort` clean ✓

## Known gap

The 1.95 pin protects the *ceiling* (relay can't silently need 1.96), but nothing in CI continuously re-checks the **1.91 library floor** — it's verified once here by hand. A future 1.92–1.94 feature slipping into a library crate would pass CI (on 1.95) and quietly falsify the 1.91 claim. Closing that is a cheap follow-up: a `just rs msrv` recipe + CI step running `cargo check --workspace --exclude moq-relay` under a pinned 1.91 toolchain. Left out here to keep the change focused; happy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Opus 4.8)