### PR TITLE
build(moq-video): bump moq-vaapi to 0.0.3 (dlopen libva)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4645,15 +4645,15 @@ dependencies = [
 
 [[package]]
 name = "moq-vaapi"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32870bce5b00614c94229081d57f0bc93877321ec1868ad21fcb547c54e2a59"
+checksum = "e4209e5f9401f2ed76eb5a82c807966be235c483a6932777623cec30950ba7d4"
 dependencies = [
  "anyhow",
  "bindgen 0.70.1",
  "bitflags 2.13.1",
+ "libloading 0.8.9",
  "log",
- "pkg-config",
  "regex",
  "thiserror 1.0.69",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,8 @@ moq-token = { version = "0.7", path = "rs/moq-token" }
 # still default them on when depended on directly.
 moq-transcode = { version = "0.0.1", path = "rs/moq-transcode", default-features = false }
 # Standalone crate (moq-dev/vaapi); vendored from cros-libva + cros-codecs.
-moq-vaapi = "0.0.2"
+# dlopen's libva at runtime (no libva-dev at build, no NEEDED libva in the binary).
+moq-vaapi = "0.0.3"
 moq-video = { version = "0.0.7", path = "rs/moq-video", default-features = false }
 qmux = { version = "0.4.0", default-features = false }
 serde = { version = "1", features = ["derive"] }

--- a/flake.nix
+++ b/flake.nix
@@ -122,12 +122,10 @@
             # cpal's `alsa-sys` (moq-audio `capture` feature) links libasound on
             # Linux via pkg-config; macOS uses CoreAudio, so no dep there.
             pkgs.alsa-lib
-            # moq-video's VAAPI backend (always-on for Linux): moq-vaapi links
-            # libva via pkg-config at build time and the resulting binary carries
-            # NEEDED libva.so.2 / libva-drm.so.2, so libva must be present both to
-            # build and to run vaapi in the devShell. macOS has no VAAPI. (See
-            # #1837: if moq-vaapi switches to dlopen'ing libva, this stays needed
-            # only to run it, and a libva-less build/host would fall back cleanly.)
+            # moq-video's VAAPI backend (always-on for Linux): moq-vaapi dlopen's
+            # libva at runtime, so it isn't needed to build. This is here only to
+            # actually run vaapi in the devShell; a libva-less host loads and falls
+            # back cleanly. macOS has no VAAPI.
             pkgs.libva
             # moq-video's `pipewire` screen-capture feature: the pipewire crate
             # links libpipewire-0.3 via pkg-config and generates bindings at build

--- a/rs/moq-transcode/Cargo.toml
+++ b/rs/moq-transcode/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["multimedia", "multimedia::video", "multimedia::encoding"]
 default = ["nvenc", "vaapi", "nvdec"]
 # NVIDIA NVENC hardware encoder (Linux, dlopen'd at runtime; a no-op elsewhere).
 nvenc = ["moq-video/nvenc"]
-# Intel/AMD VAAPI hardware encoder (Linux; links libva at build time).
+# Intel/AMD VAAPI hardware encoder (Linux; libva dlopen'd at runtime; a no-op elsewhere).
 vaapi = ["moq-video/vaapi"]
 # NVIDIA NVDEC hardware decoder (Linux, dlopen'd at runtime; a no-op elsewhere).
 # With `nvenc` this is the zero-copy GPU pipeline: NVDEC decodes and scales in

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -28,9 +28,9 @@ nvenc = ["dep:cudarc", "dep:moq-nvenc", "dep:libloading"]
 # links GPU-less and starts driverless, falling back to the next decoder. Decoded
 # frames stay in CUDA memory and feed NVENC zero-copy (the transcode path).
 nvdec = ["dep:cudarc", "dep:moq-nvenc", "dep:libloading"]
-# Intel/AMD VAAPI hardware encoder (Linux). moq-vaapi 0.0.2 hard-links libva (the
-# binary carries NEEDED libva.so.2 / libva-drm.so.2), so disable this feature for a
-# build with no libva dependency. See #1837.
+# Intel/AMD VAAPI hardware encoder (Linux). moq-vaapi dlopen's libva at runtime, so
+# an enabled-vaapi build needs no libva at build time and still starts on a
+# libva-less host, falling back to the next encoder like the NVENC backend.
 vaapi = ["dep:moq-vaapi"]
 # Screen capture on Linux via xdg-desktop-portal + PipeWire (Wayland and X11).
 # Off by default because the `pipewire` crate links libpipewire-0.3 via pkg-config
@@ -86,12 +86,9 @@ cudarc = { version = "0.19", optional = true, default-features = false, features
 libloading = { version = "0.8", optional = true }
 moq-nvenc = { workspace = true, optional = true }
 # Intel/AMD VAAPI hardware encoder, behind the default-on `vaapi` feature. As of
-# moq-vaapi 0.0.2 libva is dynamically linked via pkg-config (the binary carries
-# NEEDED libva.so.2 / libva-drm.so.2), so an enabled-vaapi Linux build needs libva
-# at build time and the binary needs it at runtime: a libva-less host fails to load
-# rather than falling back. Disable the `vaapi` feature for a libva-free build, or
-# switch moq-vaapi to dlopen libva (one portable binary that falls back like the
-# NVENC backend); the latter is tracked in #1837.
+# moq-vaapi 0.0.3 libva is dlopen'd at runtime, so the binary carries no NEEDED
+# libva: the build needs no libva-dev, and a libva-less host loads and falls back
+# to the next encoder instead of failing at load, matching the NVENC backend.
 moq-vaapi = { workspace = true, optional = true }
 # PipeWire video stream for the portal's node, behind the `pipewire` feature.
 # Links libpipewire-0.3 via pkg-config at build time; bindgen needs libclang.

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -30,7 +30,8 @@ nvenc = ["dep:cudarc", "dep:moq-nvenc", "dep:libloading"]
 nvdec = ["dep:cudarc", "dep:moq-nvenc", "dep:libloading"]
 # Intel/AMD VAAPI hardware encoder (Linux). moq-vaapi dlopen's libva at runtime, so
 # an enabled-vaapi build needs no libva at build time and still starts on a
-# libva-less host, falling back to the next encoder like the NVENC backend.
+# libva-less host; automatic backend selection then falls back to the next encoder,
+# like the NVENC backend.
 vaapi = ["dep:moq-vaapi"]
 # Screen capture on Linux via xdg-desktop-portal + PipeWire (Wayland and X11).
 # Off by default because the `pipewire` crate links libpipewire-0.3 via pkg-config
@@ -87,8 +88,9 @@ libloading = { version = "0.8", optional = true }
 moq-nvenc = { workspace = true, optional = true }
 # Intel/AMD VAAPI hardware encoder, behind the default-on `vaapi` feature. As of
 # moq-vaapi 0.0.3 libva is dlopen'd at runtime, so the binary carries no NEEDED
-# libva: the build needs no libva-dev, and a libva-less host loads and falls back
-# to the next encoder instead of failing at load, matching the NVENC backend.
+# libva: the build needs no libva-dev, and a libva-less host still loads. Automatic
+# backend selection then falls back to the next encoder instead of failing at load,
+# matching the NVENC backend.
 moq-vaapi = { workspace = true, optional = true }
 # PipeWire video stream for the portal's node, behind the `pipewire` feature.
 # Links libpipewire-0.3 via pkg-config at build time; bindgen needs libclang.

--- a/rs/moq-video/src/encode/backend/vaapi.rs
+++ b/rs/moq-video/src/encode/backend/vaapi.rs
@@ -4,14 +4,11 @@
 //! cros-libva + discord/cros-codecs. It takes tightly-packed NV12 and emits an
 //! Annex-B elementary stream with in-band SPS/PPS, matching avc3 mode.
 //!
-//! As of moq-vaapi 0.0.2 libva is dynamically *linked* (the binary carries
-//! `NEEDED libva.so.2` / `libva-drm.so.2`), so a VAAPI-enabled Linux build needs
-//! libva present at runtime: a libva-less host fails to load the binary, before
-//! [`backend::open`](super::open) can fall back. A present-but-unusable VA stack
-//! (no render node, no usable driver) *does* fall back: `Encoder::new` returns an
-//! error and `backend::open` moves on to openh264. Making moq-vaapi `dlopen` libva
-//! (one portable binary that loads and falls back on a libva-less box, like the
-//! NVENC backend) is tracked in #1837.
+//! As of moq-vaapi 0.0.3 libva is `dlopen`'d at runtime, so a VAAPI-enabled build
+//! needs no libva at build time and the binary carries no `NEEDED libva`. A
+//! libva-less host, or a present-but-unusable VA stack (no render node, no usable
+//! driver), makes `Encoder::new` return an error; under automatic selection
+//! [`backend::open`](super::open) then moves on to openh264, like the NVENC backend.
 //!
 //! Our captures hand us CPU I420 (webcams deliver YUYV/MJPEG, decoded to I420),
 //! so each frame is interleaved to NV12 before encoding.
@@ -80,7 +77,7 @@ impl Backend for Vaapi {
 	fn set_bitrate(&mut self, _bitrate: u64) -> Result<(), Error> {
 		// moq-vaapi rebuilds its rate control parameter from `Config::bitrate` on
 		// every frame, so this needs nothing more than a setter on that config to
-		// work. It doesn't have one as of 0.0.2 and the field is private, so the
+		// work. It doesn't have one as of 0.0.3 and the field is private, so the
 		// rate is fixed at open until moq-vaapi exposes one. Rebuilding the
 		// session per estimate isn't worth it: that forces an IDR on a link that
 		// just told us it's congested.


### PR DESCRIPTION
## What

Bump `moq-vaapi` from `0.0.2` to `0.0.3` and correct the moq-video feature comments that still described the old hard-link behavior.

## Why

`moq-vaapi 0.0.3` ([moq-dev/vaapi#1](https://github.com/moq-dev/vaapi/pull/1)) switches from linking libva at build time to `dlopen`ing it at runtime (bindgen `--dynamic-loading`). The practical effects for this repo:

- An enabled-`vaapi` build no longer needs `libva-dev` / pkg-config at build time.
- The binary carries no `NEEDED libva.so.2` — a libva-less host now loads and falls back to the next encoder (openh264) instead of failing at process load, exactly like the NVENC backend.
- This is the fix for #1837, and it unbreaks the `moq-video` docs.rs build (docs.rs builds on Linux with no `libva-dev`, which is why the `vaapi` default feature failed there).

`0.0.x` version requirements are exact, so the bump is required to pick up `0.0.3`.

## Testing

- `moq-vaapi 0.0.3` (identical code) was verified on an aarch64 Linux host with no libva: builds with rust + clang only, the binary has no `NEEDED libva`, and it falls back gracefully whether libva is absent or present-without-a-driver.
- `cargo update -p moq-vaapi --precise 0.0.3` resolves from crates.io; `cargo check -p moq-video` and `taplo format --check` pass locally.
- A real VAAPI hardware encode is still unverified (needs an x86 box with a working driver).

## Note

This does not by itself refresh the live docs.rs page for the already-published `moq-video 0.0.7` — docs.rs reads dependency metadata from the published crate, so the `vaapi` docs go green only when a new `moq-video` version ships carrying this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Opus 4.8)