### PR TITLE
feat(native): default quinn and quiche to delay-based congestion control

### DIFF
--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -194,7 +194,7 @@ Per-connection QUIC transport knobs, applied to incoming connections
 
 ```toml
 [server.quic]
-# Congestion control: "loss" or "delay". Omit to keep the backend's default.
+# Congestion control: "loss" or "delay". Defaults per backend, see below.
 congestion_control = "delay"
 
 [client.quic]
@@ -211,10 +211,14 @@ a different BBR generation:
 
 | Backend | `loss` | `delay` | Default when unset |
 | --- | --- | --- | --- |
-| quinn | CUBIC | BBRv1 | CUBIC |
-| quiche | CUBIC | BBRv2 | CUBIC |
-| noq | CUBIC | BBRv3 | BBRv3 |
-| iroh | CUBIC | BBRv3 | BBRv3 |
+| quinn | CUBIC | BBRv1 | BBRv1 |
+| quiche | CUBIC | BBRv2 | BBRv2 |
+| noq | CUBIC | BBRv3 | CUBIC |
+| iroh | CUBIC | BBRv3 | CUBIC |
+
+noq and iroh are the exception because their shared BBRv3 can panic on packet
+loss, which aborts the process. Select `delay` there only if you are testing that
+controller on purpose.
 
 Also available as `--server-quic-congestion-control` /
 `--client-quic-congestion-control`, or `MOQ_SERVER_QUIC_CONGESTION_CONTROL` /

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -194,7 +194,7 @@ Per-connection QUIC transport knobs, applied to incoming connections
 
 ```toml
 [server.quic]
-# Congestion control: "loss" or "delay". Defaults per backend, see below.
+# "loss" or "delay". Defaults per backend; don't set "delay" on noq/iroh (see below).
 congestion_control = "delay"
 
 [client.quic]
@@ -217,8 +217,8 @@ a different BBR generation:
 | iroh | CUBIC | BBRv3 | CUBIC |
 
 noq and iroh are the exception because their shared BBRv3 can panic on packet
-loss, which aborts the process. Select `delay` there only if you are testing that
-controller on purpose.
+loss, which aborts the process. Do not select `delay` on those backends unless
+you are testing that controller on purpose and can tolerate the crash.
 
 Also available as `--server-quic-congestion-control` /
 `--client-quic-congestion-control`, or `MOQ_SERVER_QUIC_CONGESTION_CONTROL` /

--- a/rs/moq-native/src/iroh.rs
+++ b/rs/moq-native/src/iroh.rs
@@ -15,6 +15,16 @@ use web_transport_proto::{ConnectRequest, ConnectResponse};
 pub use iroh::Endpoint;
 pub use web_transport_iroh;
 
+/// The congestion control family to install, defaulting to loss-based.
+///
+/// Unlike the other backends we don't default to BBR here: noq's BBRv3 subtracts
+/// without a floor when computing the inflight bytes at the loss event, so a single
+/// packet loss can underflow and panic, taking the whole process with it. Delay-based
+/// stays reachable, but only when an operator asks for it by name.
+fn congestion_control(quic: &crate::quic::Resolved) -> CongestionControl {
+	quic.congestion_control.unwrap_or(CongestionControl::Loss)
+}
+
 /// The iroh controller factory for a congestion control family.
 ///
 /// iroh is built on noq, so its BBR is v3. It re-exports the `ControllerFactory`
@@ -202,10 +212,7 @@ impl EndpointConfig {
 		if !quic.mtu_discovery {
 			transport = transport.mtu_discovery_config(None);
 		}
-		// iroh runs on noq, so match the noq backend's BBR default rather than noq's own CUBIC.
-		transport = transport.congestion_controller_factory(congestion_factory(
-			quic.congestion_control.unwrap_or(CongestionControl::Delay),
-		));
+		transport = transport.congestion_controller_factory(congestion_factory(congestion_control(&quic)));
 
 		let mut builder = if self.disable_relay.unwrap_or(false) {
 			Endpoint::builder(iroh::endpoint::presets::N0DisableRelay)
@@ -349,5 +356,17 @@ mod tests {
 
 		let delay = congestion_factory(CongestionControl::Delay).build(now, mtu);
 		assert!(delay.into_any().downcast::<noq_proto::congestion::Bbr3>().is_ok());
+	}
+
+	/// noq's BBRv3 panics on loss, so an unset knob must land on CUBIC here even
+	/// though every other backend defaults to BBR.
+	#[test]
+	fn congestion_control_defaults_to_loss() {
+		let mut quic = crate::quic::Client::default();
+		assert_eq!(congestion_control(&quic.resolve()), CongestionControl::Loss);
+
+		// An explicit request still gets through.
+		quic.congestion_control = Some(CongestionControl::Delay);
+		assert_eq!(congestion_control(&quic.resolve()), CongestionControl::Delay);
 	}
 }

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -56,10 +56,17 @@ fn apply_transport(transport: &mut noq::TransportConfig, quic: &Resolved) {
 		transport.enable_segmentation_offload(gso);
 	}
 
-	// Unlike quinn, this backend defaults to BBR rather than noq's own CUBIC.
-	transport.congestion_controller_factory(congestion_factory(
-		quic.congestion_control.unwrap_or(CongestionControl::Delay),
-	));
+	transport.congestion_controller_factory(congestion_factory(congestion_control(quic)));
+}
+
+/// The congestion control family to install, defaulting to loss-based.
+///
+/// Unlike the other backends we don't default to BBR here: noq's BBRv3 subtracts
+/// without a floor when computing the inflight bytes at the loss event, so a single
+/// packet loss can underflow and panic, taking the whole process with it. Delay-based
+/// stays reachable, but only when an operator asks for it by name.
+fn congestion_control(quic: &Resolved) -> CongestionControl {
+	quic.congestion_control.unwrap_or(CongestionControl::Loss)
 }
 
 /// The noq controller factory for a congestion control family. noq's BBR is v3.
@@ -645,5 +652,17 @@ mod tests {
 
 		let delay = congestion_factory(CongestionControl::Delay).build(now, mtu);
 		assert!(delay.into_any().downcast::<noq::congestion::Bbr3>().is_ok());
+	}
+
+	/// noq's BBRv3 panics on loss, so an unset knob must land on CUBIC here even
+	/// though every other backend defaults to BBR.
+	#[test]
+	fn congestion_control_defaults_to_loss() {
+		let mut quic = crate::quic::Client::default();
+		assert_eq!(congestion_control(&quic.resolve()), CongestionControl::Loss);
+
+		// An explicit request still gets through.
+		quic.congestion_control = Some(CongestionControl::Delay);
+		assert_eq!(congestion_control(&quic.resolve()), CongestionControl::Delay);
 	}
 }

--- a/rs/moq-native/src/quic.rs
+++ b/rs/moq-native/src/quic.rs
@@ -136,8 +136,8 @@ pub struct Client {
 	)]
 	pub mtu_discovery: Option<bool>,
 
-	/// Congestion control family. Unset keeps the backend's own default: CUBIC on
-	/// quinn and quiche, BBRv3 on noq and iroh.
+	/// Congestion control family. Defaults to `delay` on quinn and quiche, and to
+	/// `loss` on noq and iroh, whose BBRv3 is not yet fit to run by default.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(
 		id = "client-quic-congestion-control",
@@ -251,8 +251,8 @@ pub struct Server {
 	)]
 	pub mtu_discovery: Option<bool>,
 
-	/// Congestion control family. Unset keeps the backend's own default: CUBIC on
-	/// quinn and quiche, BBRv3 on noq.
+	/// Congestion control family. Defaults to `delay` on quinn and quiche, and to
+	/// `loss` on noq, whose BBRv3 is not yet fit to run by default.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(
 		id = "server-quic-congestion-control",
@@ -352,7 +352,8 @@ pub(crate) struct Resolved {
 	pub keep_alive: Option<Duration>,
 	/// Whether to run path MTU discovery.
 	pub mtu_discovery: bool,
-	/// Congestion control override, or `None` to leave the backend's own default.
+	/// Congestion control override, or `None` for the backend's own default. Each
+	/// backend picks that default itself, since they don't all agree.
 	pub congestion_control: Option<CongestionControl>,
 	/// Directory to write qlog traces into, or `None` to not capture them.
 	pub qlog: Option<PathBuf>,
@@ -551,7 +552,7 @@ mod tests {
 		assert_eq!(both.client.congestion_control, Some(CongestionControl::Delay));
 		assert_eq!(both.server.congestion_control, Some(CongestionControl::Loss));
 
-		// Unset stays None, which leaves each backend's own default.
+		// Unset stays None; each backend then picks its own default.
 		assert_eq!(Client::default().resolve().congestion_control, None);
 	}
 }

--- a/rs/moq-native/src/quic.rs
+++ b/rs/moq-native/src/quic.rs
@@ -137,7 +137,8 @@ pub struct Client {
 	pub mtu_discovery: Option<bool>,
 
 	/// Congestion control family. Defaults to `delay` on quinn and quiche, and to
-	/// `loss` on noq and iroh, whose BBRv3 is not yet fit to run by default.
+	/// `loss` on noq and iroh, whose shared BBRv3 can panic on packet loss and take
+	/// the process with it. Selecting `delay` there is for deliberate testing only.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(
 		id = "client-quic-congestion-control",
@@ -252,7 +253,8 @@ pub struct Server {
 	pub mtu_discovery: Option<bool>,
 
 	/// Congestion control family. Defaults to `delay` on quinn and quiche, and to
-	/// `loss` on noq, whose BBRv3 is not yet fit to run by default.
+	/// `loss` on noq, whose BBRv3 can panic on packet loss and take the process with
+	/// it. Selecting `delay` there is for deliberate testing only.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(
 		id = "server-quic-congestion-control",

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -150,10 +150,10 @@ fn apply_settings(settings: &mut web_transport_quiche::Settings, quic: &Resolved
 	settings.max_idle_timeout = Some(quic.idle_timeout);
 	settings.discover_path_mtu = quic.mtu_discovery;
 
-	// quiche defaults to CUBIC, so an unset knob leaves cc_algorithm alone.
-	if let Some(family) = quic.congestion_control {
-		settings.cc_algorithm = cc_algorithm(family).to_owned();
-	}
+	// Live media wants a steady send rate an encoder can track, not CUBIC's sawtooth,
+	// so default to BBR rather than quiche's own CUBIC.
+	let family = quic.congestion_control.unwrap_or(CongestionControl::Delay);
+	settings.cc_algorithm = cc_algorithm(family).to_owned();
 
 	// quiche writes one file per connection itself, named after the connection ID.
 	if let Some(dir) = quic.qlog_dir() {
@@ -585,19 +585,18 @@ mod tests {
 		assert_eq!(cc_algorithm(CongestionControl::Delay), "bbr2_gcongestion");
 	}
 
-	/// A selected family must reach the settings quiche is built from, and an
-	/// unset one must leave quiche's own default in place.
+	/// A selected family must reach the settings quiche is built from, and an unset
+	/// one must land on BBR rather than quiche's own CUBIC default.
 	#[test]
 	fn apply_settings_writes_cc_algorithm() {
 		let mut quic = crate::quic::Client::default();
 		let mut settings = web_transport_quiche::Settings::default();
-		let default = settings.cc_algorithm.clone();
 
-		apply_settings(&mut settings, &quic.resolve()).unwrap();
-		assert_eq!(settings.cc_algorithm, default);
-
-		quic.congestion_control = Some(CongestionControl::Delay);
 		apply_settings(&mut settings, &quic.resolve()).unwrap();
 		assert_eq!(settings.cc_algorithm, "bbr2_gcongestion");
+
+		quic.congestion_control = Some(CongestionControl::Loss);
+		apply_settings(&mut settings, &quic.resolve()).unwrap();
+		assert_eq!(settings.cc_algorithm, "cubic");
 	}
 }

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -67,11 +67,15 @@ fn apply_transport(transport: &mut quinn::TransportConfig, quic: &Resolved) {
 		transport.enable_segmentation_offload(gso);
 	}
 
-	// Live media wants a steady send rate an encoder can track, not CUBIC's sawtooth,
-	// so default to BBR rather than quinn's own CUBIC.
-	transport.congestion_controller_factory(congestion_factory(
-		quic.congestion_control.unwrap_or(CongestionControl::Delay),
-	));
+	transport.congestion_controller_factory(congestion_factory(congestion_control(quic)));
+}
+
+/// The congestion control family to install, defaulting to delay-based.
+///
+/// Live media wants a steady send rate an encoder can track, not CUBIC's sawtooth,
+/// so override quinn's own CUBIC default.
+fn congestion_control(quic: &Resolved) -> CongestionControl {
+	quic.congestion_control.unwrap_or(CongestionControl::Delay)
 }
 
 /// The quinn controller factory for a congestion control family. quinn's BBR is v1.
@@ -660,6 +664,17 @@ mod tests {
 
 		let delay = congestion_factory(CongestionControl::Delay).build(now, mtu);
 		assert!(delay.into_any().downcast::<quinn::congestion::Bbr>().is_ok());
+	}
+
+	/// An unset knob must land on BBR rather than quinn's own CUBIC default.
+	#[test]
+	fn congestion_control_defaults_to_delay() {
+		let mut quic = crate::quic::Client::default();
+		assert_eq!(congestion_control(&quic.resolve()), CongestionControl::Delay);
+
+		// An explicit request still gets through.
+		quic.congestion_control = Some(CongestionControl::Loss);
+		assert_eq!(congestion_control(&quic.resolve()), CongestionControl::Loss);
 	}
 
 	/// Loopback regression test: a config selecting BBR must produce live

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -67,10 +67,11 @@ fn apply_transport(transport: &mut quinn::TransportConfig, quic: &Resolved) {
 		transport.enable_segmentation_offload(gso);
 	}
 
-	// quinn defaults to CUBIC, so an unset knob leaves the factory alone.
-	if let Some(family) = quic.congestion_control {
-		transport.congestion_controller_factory(congestion_factory(family));
-	}
+	// Live media wants a steady send rate an encoder can track, not CUBIC's sawtooth,
+	// so default to BBR rather than quinn's own CUBIC.
+	transport.congestion_controller_factory(congestion_factory(
+		quic.congestion_control.unwrap_or(CongestionControl::Delay),
+	));
 }
 
 /// The quinn controller factory for a congestion control family. quinn's BBR is v1.


### PR DESCRIPTION
## Summary

- Flip the default congestion control family so an unset `--{client,server}-quic-congestion-control` lands on BBR for quinn (BBRv1) and quiche (BBRv2 gcongestion) instead of each backend's own CUBIC. Live media wants a send rate an encoder can track, not CUBIC's sawtooth.
- Move noq and iroh the *other* way, BBRv3 -> CUBIC. Their shared BBRv3 is the [subtract-overflow panic](https://github.com/n0-computer/noq/issues/768): `inflight_at_loss` computes `(inflight_prev_threshold.round() as u64) - lost_prev` with a plain `-` while every neighboring term uses `saturating_sub`, so once `lost_prev` exceeds `LOSS_THRESH * inflight_prev` it underflows and panics, aborting the process. Since #2432 that has been the *default* on those backends. A panic is not an acceptable default path, so they sit on CUBIC until the fix lands upstream. `delay` is still selectable there by name.
- Each backend now resolves its own default locally, since they no longer agree. `quic::Resolved::congestion_control` stays `Option<CongestionControl>` so "unset" remains distinguishable from an explicit request.

| Backend | Default before | Default now |
| --- | --- | --- |
| quinn | CUBIC | BBRv1 |
| quiche | CUBIC | BBRv2 gcongestion |
| noq | BBRv3 | CUBIC |
| iroh | BBRv3 | CUBIC |

## Public API changes

None. `Resolved` is `pub(crate)`; the `pub` `quic::Client`/`quic::Server` `congestion_control` fields keep their `Option<CongestionControl>` type and only their doc comments changed. This is a default-behavior change, not a contract break, hence `main` rather than `dev`.

## Cross-package sync

`doc/bin/relay/config.md` updated: the per-backend table's "Default when unset" column now matches, plus a note on why noq/iroh are the exception. No other row in the table applies (no wire, catalog, FFI, or CLI-surface change; the flag names and values are untouched).

## Test plan

- `cargo test -p moq-native --all-features` — 79/19/11/75 pass, including two new tests, `noq::tests::congestion_control_defaults_to_loss` and `iroh::tests::congestion_control_defaults_to_loss`, which pin the CUBIC default so a later edit can't quietly put the panicking controller back on the default path. `quiche::tests::apply_settings_writes_cc_algorithm` now asserts the unset case reaches `bbr2_gcongestion` and that an explicit `loss` still reaches `cubic`.
- `cargo clippy -p moq-native --all-features --all-targets -- -D warnings`, `cargo fmt --all --check`, `RUSTDOCFLAGS=-D warnings cargo doc -p moq-native --all-features`.
- Not run: `bun remark` (no `node_modules` in this worktree) and the smoke matrix.

## Reviewer note

quinn's BBRv1 and quiche's BBRv2 now ship on by default without the soak time CUBIC has here. The measurements behind this are quinn-only (CUBIC p50 RTT ~558ms vs BBRv1 ~90ms at equal goodput under bufferbloat, via `just demo cc compare bloat`); quiche's BBRv2 default is going out without a comparable local measurement.

(Written by Opus 4.8)