### PR TITLE
feat(moq-net): linger a broadcast across an ungraceful source loss

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4495,6 +4495,8 @@ dependencies = [
  "futures",
  "http-body",
  "http-cache-reqwest",
+ "humantime",
+ "humantime-serde",
  "jsonwebtoken",
  "moq-native",
  "moq-net",

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -164,6 +164,13 @@ connect_api = "https://api.example.com/cluster/connect"
 # whose URL has no inline ?jwt=. Required to authenticate gossip / connect_api
 # discovered peers; for static `connect` peers, prefer an inline ?jwt=.
 token = "cluster.jwt"
+
+# Optional. How long a broadcast stays alive and announced after abruptly
+# losing its last publisher (a session dying without unannouncing). A publisher
+# reconnecting within the window resumes the same broadcast and subscribers
+# never notice. A clean unannounce always takes effect immediately. "0"
+# unannounces abrupt losses immediately too. Default: 5s.
+linger = "5s"
 ```
 
 See [Clustering](/bin/relay/cluster) for topology choices and the trade-off between hand-listed peers and gossip.

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -273,9 +273,16 @@ impl Client {
 	/// into `origin` and reconnecting with backoff until the returned handle is
 	/// dropped.
 	///
+	/// Broadcasts fed by these sessions linger across a session drop for as long
+	/// as the reconnect loop keeps retrying ([`Backoff::linger`]): a relay restart
+	/// is a bounded gap the reconnect splices over, not a teardown. When the loop
+	/// gives up, its error surfaces (via [`Reconnect::closed`]) just before the
+	/// broadcasts abort.
+	///
 	/// Returns `None` when no `--client-connect` URL was configured.
 	pub fn consume(self, origin: moq_net::origin::Producer) -> Option<Reconnect> {
 		let url = self.connect.clone()?;
+		let origin = origin.with_linger(self.backoff.linger());
 		Some(self.with_subscriber(origin).reconnect(url))
 	}
 

--- a/rs/moq-native/src/reconnect.rs
+++ b/rs/moq-native/src/reconnect.rs
@@ -65,6 +65,20 @@ impl Default for Backoff {
 	}
 }
 
+impl Backoff {
+	/// How long broadcasts fed by a reconnecting session should outlive a session
+	/// drop (see [`moq_net::origin::Info::linger`]): slightly past the give-up
+	/// [`timeout`](Self::timeout), so when the loop does give up its error surfaces
+	/// before the broadcasts tear down. A zero timeout retries forever, so the
+	/// broadcasts linger forever too.
+	pub fn linger(&self) -> Duration {
+		match self.timeout.is_zero() {
+			true => Duration::MAX,
+			false => self.timeout.saturating_add(Duration::from_secs(1)),
+		}
+	}
+}
+
 /// A connection lifecycle transition reported by [`Reconnect::status`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
@@ -403,6 +417,20 @@ mod tests {
 		assert_eq!(backoff.multiplier, 2);
 		assert_eq!(backoff.max, Duration::from_secs(30));
 		assert_eq!(backoff.timeout, Duration::from_secs(300));
+	}
+
+	/// The linger outlives the give-up timeout (so the reconnect error surfaces
+	/// first), and an unlimited-retry timeout lingers forever.
+	#[test]
+	fn test_backoff_linger() {
+		let backoff = Backoff::default();
+		assert_eq!(backoff.linger(), backoff.timeout + Duration::from_secs(1));
+
+		let unlimited = Backoff {
+			timeout: Duration::ZERO,
+			..Backoff::default()
+		};
+		assert_eq!(unlimited.linger(), Duration::MAX);
 	}
 
 	#[test]

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -170,6 +170,11 @@ struct BroadcastState {
 	// Set by an explicit `Producer::finish()` or `Producer::abort()` so `Drop` can
 	// tell a deliberate shutdown apart from a producer dropped by accident.
 	closing: bool,
+
+	// Set only by `Producer::finish()`: the broadcast ended deliberately, as
+	// opposed to aborting or losing its producer. The origin reads this to decide
+	// whether a detached source may linger for a replacement.
+	finished: bool,
 }
 
 /// The spliced (route-fed) half of a broadcast: logical tracks that outlive any
@@ -453,7 +458,11 @@ impl Producer {
 	/// declares the end, so it must not depend on the caller also surrendering the
 	/// handle.
 	pub fn finish(&mut self) {
-		self.state.lock().closing = true;
+		{
+			let mut state = self.state.lock();
+			state.closing = true;
+			state.finished = true;
+		}
 		// Ending the broadcast is what consumers wait on, so signal it here rather
 		// than leaving it to the last handle drop.
 		let _ = self.alive.close();
@@ -860,6 +869,13 @@ impl Consumer {
 	/// than a strike.
 	pub(crate) fn is_closing(&self) -> bool {
 		self.is_closed() || self.state.read().closing
+	}
+
+	/// Whether the broadcast ended via an explicit [`Producer::finish`], as opposed
+	/// to aborting or losing its producer. The origin uses this to close a front
+	/// immediately on a deliberate end instead of lingering for a replacement.
+	pub(crate) fn is_finished(&self) -> bool {
+		self.state.read().finished
 	}
 
 	/// Register a [`kio::Waiter`] that fires when the broadcast closes.

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -680,7 +680,7 @@ impl Dynamic {
 
 	/// Poll until the broadcast closes; ready with the cause: the error passed to
 	/// [`Producer::abort`], or [`Error::Dropped`] for a [`Producer::finish`] or a
-	/// dropped producer (check [`is_finished`](Self::is_finished) to tell those apart).
+	/// dropped producer (check [`Consumer::is_finished`] to tell those apart).
 	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<Error> {
 		ready!(self.alive.poll_closed(waiter));
 		Poll::Ready(self.state.read().abort.clone().unwrap_or(Error::Dropped))
@@ -870,14 +870,15 @@ impl Consumer {
 		}
 	}
 
-	/// Block until the broadcast is closed, by [`Producer::finish`] or by every producer
-	/// dropping, and return the cause.
+	/// Block until the broadcast is closed, by [`Producer::finish`],
+	/// [`Producer::abort`], or every producer dropping, and return the cause.
 	///
-	/// Always returns [`Error::Dropped`]: a broadcast is just a collection of tracks, so it
-	/// only ends when every producer is gone. There is no way to abort it with a code.
+	/// Returns the error passed to [`Producer::abort`], or [`Error::Dropped`] for a
+	/// [`Producer::finish`] or a dropped producer (check [`Self::is_finished`] to
+	/// tell those apart).
 	pub async fn closed(&self) -> Error {
 		self.alive.closed().await;
-		Error::Dropped
+		self.state.read().abort.clone().unwrap_or(Error::Dropped)
 	}
 
 	/// Returns true if every [`Producer`] has been dropped.
@@ -1183,6 +1184,33 @@ mod test {
 		// track1's producer is held outside the broadcast, so it survives.
 		assert!(!track1.is_closed());
 		track1c.assert_not_closed();
+	}
+
+	/// `closed()` reports the cause: the abort error, or `Dropped` for a finish or
+	/// a dropped producer, with `is_finished` telling the latter two apart.
+	#[tokio::test]
+	async fn closed_cause() {
+		// Abort: the error comes through, and it isn't a finish.
+		let producer = Info::new().produce();
+		let consumer = producer.consume();
+		producer.abort(Error::Timeout).unwrap();
+		assert!(matches!(consumer.closed().await, Error::Timeout));
+		assert!(!consumer.is_finished());
+
+		// Finish: a deliberate clean end.
+		let mut producer = Info::new().produce();
+		let consumer = producer.consume();
+		producer.finish();
+		assert!(matches!(consumer.closed().await, Error::Dropped));
+		assert!(consumer.is_finished());
+
+		// Plain drop: neither aborted nor finished.
+		let producer = Info::new().produce();
+		let consumer = producer.consume();
+		// Deliberate for the test: exercises the accidental-drop path (warns).
+		drop(producer);
+		assert!(matches!(consumer.closed().await, Error::Dropped));
+		assert!(!consumer.is_finished());
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -175,6 +175,10 @@ struct BroadcastState {
 	// opposed to aborting or losing its producer. The origin reads this to decide
 	// whether a detached source may linger for a replacement.
 	finished: bool,
+
+	// The error passed to `Producer::abort()`, reported by `Consumer::closed`.
+	// `None` for a finish or a dropped producer (reported as `Error::Dropped`).
+	abort: Option<Error>,
 }
 
 /// The spliced (route-fed) half of a broadcast: logical tracks that outlive any
@@ -468,12 +472,29 @@ impl Producer {
 		let _ = self.alive.close();
 	}
 
-	/// Mark the broadcast as deliberately ended so the drop path doesn't warn, without
-	/// ending it for consumers the way [`Self::finish`] does. Used by sessions tearing
-	/// down announced broadcasts when the connection dies, where the broadcast may
-	/// still linger for a reconnect.
-	pub(crate) fn abort(&self) {
-		self.state.lock().closing = true;
+	/// Abort the broadcast, ending it for consumers with `err`.
+	///
+	/// Like [`finish`](Self::finish) the end is immediate, whether or not other
+	/// producer clones are still alive, and existing tracks stay readable so
+	/// consumers can drain what they already have (an abort does not cascade into
+	/// the tracks). Unlike a finish, consumers observe `err` from
+	/// [`Consumer::closed`], and an origin treats the source as ungracefully lost,
+	/// so the path may linger for a replacement (see
+	/// [`origin::Info::linger`](crate::origin::Info::linger)).
+	///
+	/// Consumes the producer: an abort is terminal. Errors if the broadcast was
+	/// already finished or aborted.
+	pub fn abort(self, err: Error) -> Result<(), Error> {
+		{
+			let mut state = self.state.lock();
+			if state.closing {
+				return Err(Error::Closed);
+			}
+			state.closing = true;
+			state.abort = Some(err);
+		}
+		let _ = self.alive.close();
+		Ok(())
 	}
 
 	/// Return true if this is the same broadcast instance.
@@ -514,10 +535,9 @@ impl Producer {
 
 /// A session-owned handle to a source broadcast created via
 /// [`crate::origin::Producer::create_broadcast`]: [`Self::finish`] ends it
-/// deliberately, while dropping the guard marks the source aborted (keeping the
-/// dropped-without-finish warning quiet). Either way the origin unannounces once
-/// the last source detaches. Shared by the lite and IETF subscribers so the
-/// drop-vs-finish contract lives in one place.
+/// deliberately, while dropping the guard aborts it as [`Error::Dropped`] (a dead
+/// session), letting the origin linger the path for a reconnect. Shared by the
+/// lite and IETF subscribers so the drop-vs-finish contract lives in one place.
 pub(crate) struct SourceGuard {
 	// `Option` so `finish` can consume the producer while `Drop` aborts it.
 	producer: Option<Producer>,
@@ -553,8 +573,8 @@ impl SourceGuard {
 
 impl Drop for SourceGuard {
 	fn drop(&mut self) {
-		if let Some(producer) = &self.producer {
-			producer.abort();
+		if let Some(producer) = self.producer.take() {
+			let _ = producer.abort(Error::Dropped);
 		}
 	}
 }
@@ -652,16 +672,18 @@ impl Dynamic {
 		}
 	}
 
-	/// Block until the broadcast is closed, by [`Producer::finish`] or by every producer
-	/// dropping, returning the cause.
+	/// Block until the broadcast is closed, by [`Producer::finish`],
+	/// [`Producer::abort`], or every producer dropping, returning the cause.
 	pub async fn closed(&self) -> Error {
 		kio::wait(|waiter| self.poll_closed(waiter)).await
 	}
 
-	/// Poll until the broadcast closes; ready with the cause (always [`Error::Dropped`],
-	/// whether it ended via [`Producer::finish`] or by every producer dropping).
+	/// Poll until the broadcast closes; ready with the cause: the error passed to
+	/// [`Producer::abort`], or [`Error::Dropped`] for a [`Producer::finish`] or a
+	/// dropped producer (check [`is_finished`](Self::is_finished) to tell those apart).
 	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<Error> {
-		self.alive.poll_closed(waiter).map(|()| Error::Dropped)
+		ready!(self.alive.poll_closed(waiter));
+		Poll::Ready(self.state.read().abort.clone().unwrap_or(Error::Dropped))
 	}
 
 	/// Return true if this is the same broadcast instance.
@@ -871,10 +893,11 @@ impl Consumer {
 		self.is_closed() || self.state.read().closing
 	}
 
-	/// Whether the broadcast ended via an explicit [`Producer::finish`], as opposed
-	/// to aborting or losing its producer. The origin uses this to close a front
-	/// immediately on a deliberate end instead of lingering for a replacement.
-	pub(crate) fn is_finished(&self) -> bool {
+	/// Whether the broadcast ended via a deliberate [`Producer::finish`], as opposed
+	/// to aborting or losing its producer. `false` while the broadcast is still live;
+	/// an origin uses this to close a front immediately on a deliberate end instead
+	/// of lingering for a replacement.
+	pub fn is_finished(&self) -> bool {
 		self.state.read().finished
 	}
 

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -3041,8 +3041,7 @@ mod tests {
 		// is announced.
 		// abort() consumes the producer, so this both aborts and drops it.
 		producer.abort(Error::Dropped).unwrap();
-		source_a.abort();
-		drop(source_a);
+		source_a.abort(Error::Dropped).unwrap();
 		drop(dynamic_a);
 		settle().await;
 		announced.assert_next_wait();
@@ -3198,8 +3197,7 @@ mod tests {
 		sub.assert_closed();
 
 		// A detaching must not re-dispatch the finished track to B.
-		source_a.abort();
-		drop(source_a);
+		source_a.abort(Error::Dropped).unwrap();
 		drop(dynamic_a);
 		settle().await;
 		dynamic_b.assert_no_request();
@@ -3368,8 +3366,7 @@ mod tests {
 
 		// The session dies without unannouncing.
 		drop(producer);
-		source.abort();
-		drop(source);
+		source.abort(Error::Dropped).unwrap();
 		drop(dynamic);
 
 		settle().await;
@@ -3423,8 +3420,7 @@ mod tests {
 		// The session dies without unannouncing: the broadcast enters the linger
 		// window instead of closing.
 		drop(producer);
-		source.abort();
-		drop(source);
+		source.abort(Error::Dropped).unwrap();
 		drop(dynamic);
 		settle().await;
 
@@ -3485,8 +3481,7 @@ mod tests {
 		let mut sub = subscribing.await.unwrap();
 
 		drop(producer);
-		source.abort();
-		drop(source);
+		source.abort(Error::Dropped).unwrap();
 		drop(dynamic);
 		settle().await;
 		announced.assert_next_wait();
@@ -3526,8 +3521,7 @@ mod tests {
 		let broadcast = consumer.request_broadcast("test").await.unwrap();
 		announced.assert_next_some("test");
 
-		source.abort();
-		drop(source);
+		source.abort(Error::Dropped).unwrap();
 		settle().await;
 
 		// Days later the broadcast is still announced and still splices a reconnect.

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -6,6 +6,7 @@ use std::{
 	sync::Arc,
 	sync::atomic::{AtomicU64, Ordering},
 	task::{Poll, ready},
+	time::Duration,
 };
 
 use rand::RngExt;
@@ -106,6 +107,15 @@ pub struct Info {
 	/// relay sets a bounded one (via [`Self::with_pool`]) so cached groups across the
 	/// whole process share one memory budget.
 	pub pool: cache::Pool,
+
+	/// How long a broadcast under this origin outlives the *ungraceful* loss of its
+	/// last source before closing. Within the window the path stays announced and a
+	/// source re-attaching at it (a session reconnecting, a publisher re-announcing)
+	/// splices in seamlessly, so consumers never observe the gap. A source that ends
+	/// deliberately ([`broadcast::Producer::finish`], a clean unannounce from a peer)
+	/// closes the broadcast immediately regardless. Zero (the default) closes
+	/// immediately either way.
+	pub linger: Duration,
 }
 
 impl Default for Info {
@@ -115,6 +125,7 @@ impl Default for Info {
 		Self {
 			id: Origin::UNKNOWN,
 			pool: cache::Pool::default(),
+			linger: Duration::ZERO,
 		}
 	}
 }
@@ -122,15 +133,19 @@ impl Default for Info {
 impl Info {
 	/// Config for the given origin id with an unbounded cache pool.
 	pub fn new(id: Origin) -> Self {
-		Self {
-			id,
-			pool: cache::Pool::default(),
-		}
+		Self { id, ..Self::default() }
 	}
 
 	/// Set the cache pool this origin's broadcasts inherit, returning `self` for chaining.
 	pub fn with_pool(mut self, pool: cache::Pool) -> Self {
 		self.pool = pool;
+		self
+	}
+
+	/// Set how long a broadcast survives ungracefully losing its last source (see
+	/// [`Self::linger`]), returning `self` for chaining.
+	pub fn with_linger(mut self, linger: Duration) -> Self {
+		self.linger = linger;
 		self
 	}
 
@@ -769,6 +784,10 @@ pub struct Producer {
 	// mint their remote broadcasts with it). Unbounded by default.
 	pool: cache::Pool,
 
+	// How long a broadcast outlives ungracefully losing its last source (see
+	// [`Info::linger`]). Zero by default.
+	linger: Duration,
+
 	// Ingress stats context. Broadcasts created through this producer are attributed
 	// to it (writes counted on the subscriber/ingress side). Empty (no-op) unless a
 	// session tagged this handle via [`Self::with_stats`].
@@ -794,6 +813,7 @@ impl Producer {
 			root: PathOwned::default(),
 			dynamic: kio::Shared::default(),
 			pool: info.pool,
+			linger: info.linger,
 			stats: stats::Session::default(),
 		}
 	}
@@ -812,6 +832,7 @@ impl Producer {
 		Info {
 			id: self.info,
 			pool: self.pool.clone(),
+			linger: self.linger,
 		}
 	}
 
@@ -826,6 +847,7 @@ impl Producer {
 			root: PathOwned::default(),
 			dynamic: kio::Shared::default(),
 			pool: cache::Pool::default(),
+			linger: Duration::ZERO,
 			stats: stats::Session::default(),
 		}
 	}
@@ -854,9 +876,11 @@ impl Producer {
 	/// consumer finds them.
 	///
 	/// End the broadcast with [`broadcast::Producer::finish`]; dropping it
-	/// without finishing also works, but logs a warning. Either way the path
-	/// unannounces once the last source detaches, so a replacement splices in
-	/// without consumers noticing only if it attaches before that happens.
+	/// without finishing also works, but logs a warning. A finish closes and
+	/// unannounces the path immediately once it was the last source. An unfinished
+	/// drop is treated as an outage: the path survives for the origin's
+	/// [`Info::linger`] (zero by default), so a replacement source attaching within
+	/// that window splices in without consumers noticing.
 	///
 	/// Fails with [`Error::Unauthorized`] if `path` is outside the prefixes this
 	/// producer may publish under (after [`scope`](Self::scope) /
@@ -912,6 +936,7 @@ impl Producer {
 			root: self.root.clone(),
 			dynamic: self.dynamic.clone(),
 			pool: self.pool.clone(),
+			linger: self.linger,
 			stats: self.stats.clone(),
 		})
 	}
@@ -966,6 +991,7 @@ impl Producer {
 			nodes: self.nodes.root(&prefix)?,
 			dynamic: self.dynamic.clone(),
 			pool: self.pool.clone(),
+			linger: self.linger,
 			stats: self.stats.clone(),
 		})
 	}
@@ -1013,8 +1039,12 @@ struct FrontState {
 	routes: Vec<FrontRoute>,
 	/// The source tracks are dispatched to. Backups park until promoted.
 	active: Option<u64>,
+	/// How long the front outlives ungracefully losing its last source (see
+	/// [`Info::linger`]). [`run_front`] arms the countdown when the table empties.
+	linger: Duration,
 	/// Terminal: no more sources may attach and every poller stops. Set
-	/// synchronously by the detach that empties the table.
+	/// synchronously by the detach that empties the table, or by [`run_front`]
+	/// when the linger window expires without a replacement.
 	closed: bool,
 }
 
@@ -1117,10 +1147,22 @@ fn sync_front(state: &kio::Producer<FrontState>, broadcast: &broadcast::Producer
 /// Detach source `id`, promoting the next-best source; the tracks it was serving
 /// re-splice on their own. Idempotent.
 ///
-/// Detaching the last source closes the broadcast synchronously, which
-/// guarantees a following create at the path is a *new* broadcast rather than
-/// splicing new content into this one.
-fn detach_source(state: &kio::Producer<FrontState>, broadcast: &broadcast::Producer, leaf: &Lock<OriginNode>, id: u64) {
+/// `graceful` says how the source ended: a deliberate finish (a publisher done
+/// publishing, a peer's clean unannounce) or an abrupt loss (a session dying).
+/// Detaching the last source *gracefully* closes the broadcast synchronously,
+/// which guarantees a following create at the path is a *new* broadcast rather
+/// than splicing new content into this one. An abrupt last detach instead leaves
+/// the front open for the configured linger ([`Info::linger`]), so a source
+/// re-attaching within the window (a reconnect) splices in seamlessly;
+/// [`run_front`] closes it if the window expires empty. A zero linger closes
+/// abrupt detaches synchronously too.
+fn detach_source(
+	state: &kio::Producer<FrontState>,
+	broadcast: &broadcast::Producer,
+	leaf: &Lock<OriginNode>,
+	id: u64,
+	graceful: bool,
+) {
 	let close = {
 		let carrying = broadcast.demand().is_used();
 		let Ok(mut s) = state.write() else { return };
@@ -1129,7 +1171,7 @@ fn detach_source(state: &kio::Producer<FrontState>, broadcast: &broadcast::Produ
 		};
 		s.routes.remove(pos);
 		s.reselect(carrying);
-		if s.routes.is_empty() && !s.closed {
+		if s.routes.is_empty() && !s.closed && (graceful || s.linger.is_zero()) {
 			// Last one out: close now. The front task observes `closed` and
 			// finishes the teardown (unpublish).
 			s.closed = true;
@@ -1202,7 +1244,9 @@ async fn run_source(
 				sync_front(&state, &broadcast, &leaf);
 			}
 			Err(_) => {
-				detach_source(&state, &broadcast, &leaf, id);
+				// A deliberate finish closes the front immediately; an abrupt loss
+				// (dropped producer, dead session) may linger for a replacement.
+				detach_source(&state, &broadcast, &leaf, id, source.is_finished());
 				return;
 			}
 		}
@@ -1265,6 +1309,7 @@ fn attach_source(
 			source: source.clone(),
 		}],
 		active: Some(0),
+		linger: origin.linger,
 		closed: false,
 	});
 
@@ -1303,28 +1348,96 @@ async fn run_front(
 ) {
 	enum Step {
 		Serve(Arc<str>, super::resume::Producer),
+		/// The source table emptied or refilled: re-arm the linger countdown.
+		Changed,
+		/// The linger window expired: close if the table is still empty.
+		Expired,
 		Closed,
 	}
 
+	let linger = state.read().linger;
+	// Armed while the table is ungracefully empty: the instant the front gives up
+	// waiting for a replacement source. A graceful close never gets here (the
+	// detach sets `closed` synchronously), so a running countdown always means a
+	// reconnect is welcome.
+	let mut deadline: Option<web_async::time::Instant> = None;
+
 	loop {
-		let step = kio::wait(|waiter| {
-			if let Poll::Ready((name, resume)) = broadcast.poll_spliced_assigned(waiter) {
-				return Poll::Ready(Step::Serve(name, resume));
-			}
-			// `closed` is set by the detach that empties the table, so an empty
-			// table is always terminal.
-			match state.poll(waiter, |s| if s.closed { Poll::Ready(()) } else { Poll::Pending }) {
-				Poll::Ready(_) => Poll::Ready(Step::Closed),
-				Poll::Pending => Poll::Pending,
-			}
-		})
-		.await;
+		let empty = {
+			let s = state.read();
+			!s.closed && s.routes.is_empty()
+		};
+		deadline = match (empty, deadline) {
+			(true, None) => Some(web_async::time::Instant::now() + linger),
+			(true, at) => at,
+			(false, _) => None,
+		};
+
+		let step = {
+			// Pending forever while no countdown is running. Fused via `fired`: a
+			// completed future must not be polled again.
+			let mut sleep = std::pin::pin!(async {
+				match deadline {
+					Some(at) => {
+						web_async::time::sleep(at.saturating_duration_since(web_async::time::Instant::now())).await
+					}
+					None => std::future::pending().await,
+				}
+			});
+			let mut fired = false;
+			kio::wait(|waiter| {
+				if let Poll::Ready((name, resume)) = broadcast.poll_spliced_assigned(waiter) {
+					return Poll::Ready(Step::Serve(name, resume));
+				}
+				// Watch for the close, and for the table changing shape so the
+				// countdown re-arms (a detach emptying it, a reconnect refilling it).
+				match state.poll(waiter, |s| {
+					if s.closed || s.routes.is_empty() != empty {
+						Poll::Ready(())
+					} else {
+						Poll::Pending
+					}
+				}) {
+					Poll::Ready(Ok(guard)) => {
+						return Poll::Ready(if guard.closed { Step::Closed } else { Step::Changed });
+					}
+					Poll::Ready(Err(_)) => return Poll::Ready(Step::Closed),
+					Poll::Pending => {}
+				}
+				if deadline.is_some() && !fired && waiter.poll_future(sleep.as_mut()).is_ready() {
+					fired = true;
+				}
+				match fired {
+					true => Poll::Ready(Step::Expired),
+					false => Poll::Pending,
+				}
+			})
+			.await
+		};
 
 		match step {
 			Step::Serve(name, resume) => {
 				// Serve tasks self-terminate when the track completes or the
 				// front closes.
 				web_async::spawn(serve_track(state.clone(), name, resume));
+			}
+			Step::Changed => {}
+			Step::Expired => {
+				// Close only if the table is still empty: a source that re-attached
+				// as the window expired wins the write-lock race and keeps the
+				// broadcast alive.
+				let close = {
+					let Ok(mut s) = state.write() else { break };
+					if !s.closed && s.routes.is_empty() {
+						s.closed = true;
+						true
+					} else {
+						false
+					}
+				};
+				if close {
+					break;
+				}
 			}
 			Step::Closed => break,
 		}
@@ -2375,6 +2488,7 @@ mod tests {
 				})
 				.collect(),
 			active: Some(0),
+			linger: Duration::ZERO,
 			closed: false,
 		}
 	}
@@ -3211,9 +3325,10 @@ mod tests {
 		);
 	}
 
-	/// A dying source (a session drop, not a deliberate unannounce) closes the
-	/// broadcast just as promptly as a graceful one: no reconnect window, the
-	/// tracks abort, and a re-create is a fresh broadcast rather than a splice.
+	/// With the default zero linger, a dying source (a session drop, not a
+	/// deliberate unannounce) closes the broadcast just as promptly as a graceful
+	/// one: no reconnect window, the tracks abort, and a re-create is a fresh
+	/// broadcast rather than a splice.
 	#[tokio::test(start_paused = true)]
 	async fn test_route_detach_immediate() {
 		let origin = Origin::random().produce();
@@ -3255,6 +3370,161 @@ mod tests {
 		assert!(
 			!fresh.is_clone(&broadcast),
 			"re-create must not splice the old broadcast"
+		);
+	}
+
+	/// With a linger configured, an ungraceful source loss keeps the broadcast
+	/// alive and announced; a source re-attaching within the window splices in and
+	/// consumers resume at the group boundary, never observing the outage.
+	#[tokio::test(start_paused = true)]
+	async fn test_linger_reconnect_splices() {
+		let origin = Info::new(Origin::random())
+			.with_linger(Duration::from_secs(5))
+			.produce();
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+
+		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let source = origin
+			.create_broadcast("test", announce().with_hops(hops.clone()))
+			.unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+		announced.assert_next_some("test");
+
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		let mut producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+		let mut sub = subscribing.await.unwrap();
+
+		producer.append_group().unwrap();
+		producer.append_group().unwrap();
+		assert_eq!(sub.assert_group().sequence, 0);
+		assert_eq!(sub.assert_group().sequence, 1);
+
+		// The session dies without unannouncing: the broadcast enters the linger
+		// window instead of closing.
+		drop(producer);
+		source.abort();
+		drop(source);
+		drop(dynamic);
+		settle().await;
+
+		// No unannounce, no track error: the outage is invisible so far.
+		announced.assert_next_wait();
+		sub.assert_no_group();
+		sub.assert_not_closed();
+
+		// A consumer arriving mid-outage still resolves the lingering broadcast.
+		let during = consumer.request_broadcast("test").await.unwrap();
+		assert!(during.is_clone(&broadcast), "the lingering broadcast still resolves");
+
+		// The session reconnects within the window: the new source splices into
+		// the same broadcast.
+		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+		announced.assert_next_wait();
+		let again = consumer.request_broadcast("test").await.unwrap();
+		assert!(again.is_clone(&broadcast), "the reconnect must splice, not replace");
+
+		// The pending track re-splices from the new source and resumes one past
+		// the groups the old source already delivered. Demand registers as the
+		// subscriber polls.
+		let mut producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+		sub.assert_no_group();
+		assert_eq!(producer.subscription().unwrap().group_start, Some(2));
+		producer.create_group(group::Info { sequence: 2 }).unwrap();
+		assert_eq!(sub.assert_group().sequence, 2);
+		sub.assert_not_closed();
+	}
+
+	/// The linger window expiring without a replacement closes the broadcast: the
+	/// path unannounces, tracks abort, and a later re-create is a fresh broadcast.
+	#[tokio::test(start_paused = true)]
+	async fn test_linger_expiry_closes() {
+		let origin = Info::new(Origin::random())
+			.with_linger(Duration::from_secs(5))
+			.produce();
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+
+		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let source = origin
+			.create_broadcast("test", announce().with_hops(hops.clone()))
+			.unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+		announced.assert_next_some("test");
+
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		let producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+		let mut sub = subscribing.await.unwrap();
+
+		drop(producer);
+		source.abort();
+		drop(source);
+		drop(dynamic);
+		settle().await;
+		announced.assert_next_wait();
+
+		// Nobody comes back: the window expires and the broadcast closes.
+		tokio::time::sleep(std::time::Duration::from_secs(6)).await;
+		settle().await;
+		announced.assert_next_none("test");
+		sub.assert_error();
+
+		// A session reconnecting after the window gets a brand-new broadcast.
+		let _source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		settle().await;
+		settle().await;
+		let fresh = consumer.request_broadcast("test").await.unwrap();
+		announced.assert_next_some("test");
+		assert!(
+			!fresh.is_clone(&broadcast),
+			"a late re-create must not splice the expired broadcast"
+		);
+	}
+
+	/// A deliberate finish never lingers, even with a linger configured: a clean
+	/// unannounce from a peer must propagate immediately.
+	#[tokio::test(start_paused = true)]
+	async fn test_linger_skipped_on_finish() {
+		let origin = Info::new(Origin::random())
+			.with_linger(Duration::from_secs(5))
+			.produce();
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+
+		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let mut source = origin
+			.create_broadcast("test", announce().with_hops(hops.clone()))
+			.unwrap();
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+		announced.assert_next_some("test");
+
+		// A clean unannounce: the broadcast is gone as soon as the teardown task
+		// observes the close, with no reconnect window.
+		source.finish();
+		settle().await;
+		announced.assert_next_none("test");
+
+		// A re-create at the same path is a brand-new broadcast.
+		let _source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		settle().await;
+		let fresh = consumer.request_broadcast("test").await.unwrap();
+		announced.assert_next_some("test");
+		assert!(
+			!fresh.is_clone(&broadcast),
+			"a finish must not leave a lingering broadcast to splice into"
 		);
 	}
 

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -114,7 +114,8 @@ pub struct Info {
 	/// splices in seamlessly, so consumers never observe the gap. A source that ends
 	/// deliberately ([`broadcast::Producer::finish`], a clean unannounce from a peer)
 	/// closes the broadcast immediately regardless. Zero (the default) closes
-	/// immediately either way.
+	/// immediately either way; a duration too large to represent as a deadline
+	/// (e.g. [`Duration::MAX`]) lingers indefinitely.
 	pub linger: Duration,
 }
 
@@ -826,6 +827,19 @@ impl Producer {
 		self
 	}
 
+	/// Set the linger (see [`Info::linger`]) for broadcasts created through this
+	/// handle and any handle derived from it.
+	///
+	/// A broadcast adopts the window of the handle whose source *created* it (the
+	/// first source at the path), so set this before handing the producer to
+	/// whatever attaches sources through it (e.g. a session). Lets one supplier
+	/// declare its own recovery promise, like a reconnecting client lingering for
+	/// as long as its retry loop keeps trying, without reconfiguring the origin.
+	pub fn with_linger(mut self, linger: Duration) -> Self {
+		self.linger = linger;
+		self
+	}
+
 	/// This origin's [`Info`] (identity + cache pool), the parent handle a broadcast
 	/// created under this origin carries (see [`broadcast::Info::origin`]).
 	pub fn info(&self) -> Info {
@@ -1368,7 +1382,9 @@ async fn run_front(
 			!s.closed && s.routes.is_empty()
 		};
 		deadline = match (empty, deadline) {
-			(true, None) => Some(web_async::time::Instant::now() + linger),
+			// An unrepresentable deadline (e.g. `Duration::MAX`) lingers forever:
+			// no timer, only a re-attach or teardown moves the front on.
+			(true, None) => web_async::time::Instant::now().checked_add(linger),
 			(true, at) => at,
 			(false, _) => None,
 		};
@@ -3491,6 +3507,38 @@ mod tests {
 			!fresh.is_clone(&broadcast),
 			"a late re-create must not splice the expired broadcast"
 		);
+	}
+
+	/// A linger too large to represent as a deadline never expires: the broadcast
+	/// outlives an arbitrarily long outage (a reconnect loop with no give-up
+	/// timeout promises to retry forever).
+	#[tokio::test(start_paused = true)]
+	async fn test_linger_forever() {
+		let origin = Info::new(Origin::random()).with_linger(Duration::MAX).produce();
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+
+		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let source = origin
+			.create_broadcast("test", announce().with_hops(hops.clone()))
+			.unwrap();
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+		announced.assert_next_some("test");
+
+		source.abort();
+		drop(source);
+		settle().await;
+
+		// Days later the broadcast is still announced and still splices a reconnect.
+		tokio::time::sleep(std::time::Duration::from_secs(60 * 60 * 24 * 3)).await;
+		announced.assert_next_wait();
+		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		settle().await;
+		settle().await;
+		let again = consumer.request_broadcast("test").await.unwrap();
+		assert!(again.is_clone(&broadcast), "the reconnect must splice, not replace");
+		drop(source);
 	}
 
 	/// A deliberate finish never lingers, even with a linger configured: a clean

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -39,6 +39,8 @@ clap = { version = "4", features = ["derive"] }
 futures = "0.3"
 http-body = "1"
 http-cache-reqwest = { version = "1.0.0-alpha.6", features = ["manager-moka", "url-standard"], default-features = false }
+humantime = "2.3"
+humantime-serde = "1.1"
 jsonwebtoken = "10"
 moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs", "watch", "tcp"] }
 moq-net = { workspace = true }

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -21,6 +21,12 @@ const MESH_PREFIX: &str = ".internal/origins";
 /// How often the discovery loop scans for stale entries.
 const SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 
+/// Default for [`ClusterConfig::linger`]: how long a broadcast survives abruptly
+/// losing its last publisher before unannouncing. Long enough for a publisher
+/// restart or a brief network blip to resume seamlessly, short enough that a
+/// genuinely-gone broadcast unannounces promptly.
+const DEFAULT_LINGER: Duration = Duration::from_secs(5);
+
 /// How long a peer must stay unannounced before we abort the dial. Must clear the
 /// "prefer shorter hop" re-announce flap (which arrives as
 /// unannounce-then-announce within sub-milliseconds) plus reasonable churn from
@@ -327,6 +333,21 @@ pub struct ClusterConfig {
 	/// stats under. Defaults to the unprefixed tier.
 	#[arg(id = "cluster-tier", long = "cluster-tier", env = "MOQ_CLUSTER_TIER")]
 	pub tier: Option<String>,
+
+	/// How long a broadcast stays alive and announced after abruptly losing its
+	/// last publisher (a session dying without unannouncing), e.g. "5s" or "500ms".
+	/// A publisher reconnecting within the window resumes the same broadcast and
+	/// subscribers never notice; the window expiring unannounces it. A clean
+	/// unannounce always takes effect immediately. Set "0" to unannounce abrupt
+	/// losses immediately too. Defaults to 5s.
+	#[arg(
+		id = "cluster-linger",
+		long = "cluster-linger",
+		env = "MOQ_CLUSTER_LINGER",
+		value_parser = humantime::parse_duration,
+	)]
+	#[serde(default, with = "humantime_serde")]
+	pub linger: Option<Duration>,
 }
 
 /// A relay cluster built around a single [`origin::Producer`].
@@ -343,6 +364,11 @@ pub struct ClusterConfig {
 pub struct Cluster {
 	config: ClusterConfig,
 	client: Option<moq_native::Client>,
+
+	/// The origin's construction config (identity, cache pool, linger). Kept so
+	/// the `with_*` builders can rebuild the origin without losing each other's
+	/// settings.
+	info: origin::Info,
 
 	/// Client TLS config used to build the `--cluster-connect-api` HTTP client, so
 	/// peer-list fetches present the same cluster cert the QUIC dials do. `Arc` so
@@ -371,20 +397,22 @@ impl Cluster {
 	/// Errors if `config.id` is set but invalid: it must be non-zero and below
 	/// 2^62 (the wire varint limit). An unset id picks a fresh random origin.
 	pub fn new(config: ClusterConfig) -> anyhow::Result<Self> {
-		let origin = match config.id {
+		let id = match config.id {
 			Some(0) => anyhow::bail!("--cluster-id must be non-zero"),
 			Some(id) if id >= 1 << 62 => {
 				anyhow::bail!("--cluster-id must be below 2^62 (wire varint limit), got {id}")
 			}
 			Some(id) => Origin::new(id).expect("cluster id already validated"),
 			None => Origin::random(),
-		}
-		.produce();
+		};
+		let info = origin::Info::new(id).with_linger(config.linger.unwrap_or(DEFAULT_LINGER));
+		let origin = info.clone().produce();
 		tracing::info!(origin_id = %origin.id(), configured = config.id.is_some(), "cluster initialized");
 		Ok(Cluster {
 			config,
 			client: None,
 			client_tls: None,
+			info,
 			origin,
 			stats: moq_net::stats::Registry::disabled(),
 		})
@@ -398,8 +426,8 @@ impl Cluster {
 	/// Rebuilds the origin with the pool: safe because the cluster's origin is
 	/// still pristine here (no broadcasts published, no scopes derived).
 	pub fn with_cache(mut self, pool: moq_net::cache::Pool) -> Self {
-		let id = *self.origin; // origin::Producer derefs to its Origin id.
-		self.origin = moq_net::origin::Info::new(id).with_pool(pool).produce();
+		self.info = self.info.clone().with_pool(pool);
+		self.origin = self.info.clone().produce();
 		self
 	}
 

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -208,6 +208,41 @@ headroom = "10%"
 		assert_eq!(config.cache.headroom.as_deref(), Some("10%"));
 	}
 
+	/// Serializes tests that touch `MOQ_CLUSTER_LINGER`. Same rationale as
+	/// `STATS_ENV_LOCK`.
+	static LINGER_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+	/// Regression test for the clap+TOML clobber bug applied to `cluster.linger`.
+	/// The field is `Option<Duration>` so a TOML-configured window survives the
+	/// CLI re-parse when no `--cluster-linger` flag is passed.
+	#[test]
+	fn cli_does_not_clobber_toml_linger() {
+		let _guard = LINGER_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+		// SAFETY: LINGER_ENV_LOCK ensures no other test in this binary touches
+		// this env var concurrently.
+		unsafe {
+			std::env::remove_var("MOQ_CLUSTER_LINGER");
+		}
+
+		let toml = r#"
+[cluster]
+linger = "30s"
+"#;
+		let dir = std::env::temp_dir().join("moq-relay-config-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("linger-toml-wins.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
+		let config = Config::parse_and_merge(args).expect("config load");
+
+		assert_eq!(
+			config.cluster.linger,
+			Some(std::time::Duration::from_secs(30)),
+			"TOML's cluster.linger must not be clobbered by the CLI re-parse"
+		);
+	}
+
 	/// Serializes tests that touch `MOQ_SERVER_PREFERRED_V4` / `_V6`. Same
 	/// rationale as `STATS_ENV_LOCK`.
 	static PREFERRED_ENV_LOCK: Mutex<()> = Mutex::new(());


### PR DESCRIPTION
Fixes #2459 (`moq export` dies with `json: dropped` on relay restart).

## Root cause

An origin front (`FrontState`) closed synchronously the instant its last source detached, regardless of *why* it detached. A session dying therefore aborted every downstream subscription with `Error::Dropped` even though the session's reconnect loop was about to re-establish it and re-attach a source seconds later. The graceful/abrupt distinction already existed at the source layer (`SourceGuard`: `finish()` on a clean unannounce in both the lite and IETF subscribers, `abort()` on session death, whose doc already anticipated "the broadcast may still linger for a reconnect") but was discarded at detach: `run_source` dropped the close reason and `detach_source` had a single teardown path.

## Change

**Model (`moq-net`):**

- `broadcast::Producer::finish()` now sets a `finished` bit that the origin reads when the source closes, so a **deliberate end (clean unannounce) still closes and unannounces immediately: it never lingers.**
- `origin::Info` gains `linger` (+ `Info::with_linger` / `origin::Producer::with_linger`, default zero): how long a front outlives the *ungraceful* loss of its last source. Within the window the path stays announced (so the linger composes across relay hops without any wire change) and a source re-attaching at the path splices into the same broadcast; tracks resume at the group boundary via the existing route-migration machinery, so consumers never observe the gap. `run_front` arms the countdown when the table empties, cancels it on re-attach, and closes the front if the window expires empty (re-checking under the write lock so a reconnect racing the deadline wins). An unrepresentable deadline (`Duration::MAX`) lingers forever.

**Wiring (what actually fixes the issue):**

- `moq-native`: `Client::consume()` derives the linger from the reconnect loop's own promise: `Backoff::linger()` = `backoff.timeout + 1s`, or forever when the timeout is 0 (unlimited retries). Broadcasts fed by a reconnecting session therefore survive a session drop exactly as long as the loop keeps retrying, and when it gives up, the loop's real error (`reconnect timed out after ...: <cause>`) surfaces from the CLI's JoinSet *before* the broadcasts abort, replacing the misleading `json: dropped`. The +1s epsilon exists to win that race. `moq export` (and every other `consume()` caller) picks this up with no CLI changes.
- `moq-relay`: new `[cluster] linger` / `--cluster-linger` (default 5s): an abruptly-disconnected publisher stays announced for the window so its reconnect resumes the same broadcast downstream; a clean unannounce still propagates immediately. `Cluster` now keeps its `origin::Info` so `with_cache` and the linger compose instead of the rebuild clobbering whichever was set first.

Why not one fixed 5s everywhere: with default exponential backoff (1s, 3s, 7s, ...) a fixed 5s window only survives outages of about 3s, so the window has to come from whoever knows the recovery promise. The relay's 5s covers publisher churn on a healthy link; the subscriber's `backoff.timeout` covers its own reconnects.

## Tests

- `test_linger_skipped_on_finish`: clean unannounce with a linger configured tears down immediately.
- `test_linger_reconnect_splices`: ungraceful loss is invisible during the window (no unannounce, no track error, mid-outage `request_broadcast` resolves), and the reconnect resumes at `group_start = Some(2)` after groups 0-1.
- `test_linger_expiry_closes`: expiry unannounces, aborts tracks, and a late re-create is a fresh broadcast.
- `test_linger_forever`: `Duration::MAX` never expires; a reconnect days later still splices.
- `test_backoff_linger`: the derived window outlives the give-up timeout; unlimited retries linger forever.
- `cli_does_not_clobber_toml_linger`: the new relay flag survives the clap+TOML merge.
- Existing `test_route_unannounce_immediate` / `test_route_detach_immediate` pin the zero-linger defaults.

`just rs check` passes (full workspace); rustdoc with `-D warnings` clean on the touched crates.

## Cross-package sync

- No wire change, so no draft update: the linger is expressed as "the announce has not gone away yet", which is already on the wire.
- `doc/bin/relay/config.md` documents the new `[cluster] linger` knob.
- No `moq-ffi` surface change; `js/net` has its own origin model and can mirror the linger when wired up there.

## Deferred
- Server-mode consumption (moq --server-bind export, serve_consume) gets no linger: inbound sessions carry no reconnect promise and the origin default is zero, so a publisher reconnecting to a moq-cli server still tears down its broadcast.
- An end-to-end relay-restart regression (two real sessions) reusing the sink-session harness; the mechanism is covered at the model layer here.

- An announce-end *reason* on the wire (a truncated broadcast currently reads as a clean end downstream of a relay once its linger expires); additive SETUP-gated extension, separate draft+impl PR.
- Splice-with-a-restarted-publisher (group sequences resetting) relies on the existing resume machinery; the same-publisher case is what this PR tests.

(written by Fable 5)
