### PR TITLE
feat(native): expose a qlog feature on moq-relay and moq-cli

### DIFF
--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -23,6 +23,10 @@ iroh = ["moq-native/iroh"]
 noq = ["moq-native/noq"]
 quinn = ["moq-native/quinn"]
 quiche = ["moq-native/quiche"]
+# qlog trace capture (`--client-quic-qlog <DIR>`). Off by default: it compiles the
+# qlog machinery into the enabled backends and is only wanted for debugging or
+# congestion-control testing.
+qlog = ["moq-native/qlog"]
 websocket = ["moq-native/websocket"]
 # Device capture (camera + microphone) + encode/publish. Off by default because
 # it pulls in moq-video + moq-audio capture, which add system build deps on Linux

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -29,6 +29,10 @@ jemalloc = ["moq-native/jemalloc"]
 noq = ["moq-native/noq"]
 quinn = ["moq-native/quinn"]
 quiche = ["moq-native/quiche"]
+# qlog trace capture (`--server-quic-qlog <DIR>`). Off by default: it compiles the
+# qlog machinery into the enabled backends and is only wanted for debugging or
+# congestion-control testing.
+qlog = ["moq-native/qlog"]
 websocket = ["moq-native/websocket", "dep:qmux", "axum/ws"]
 # Unix-domain-socket stream listener (`--server-unix-bind`), unix-only. In the
 # default set; drop via --no-default-features on platforms without Unix sockets.


### PR DESCRIPTION
Forward `moq-native/qlog` through a new `qlog` feature on both `moq-relay` and `moq-cli`.

Without it the `--{server,client}-quic-qlog <DIR>` flags exist but the trace machinery is never compiled into the binaries, so **qlog cannot be captured from the shipped binaries at all**. qlog is the only source of per-connection RTT, congestion window, and loss; the traffic counters in `moq-stats` and the relay `/metrics` endpoint don't expose those. This makes qlog reachable for debugging and congestion-control work.

- Additive and off by default, matching the existing `noq`/`quiche` feature forwards.
- Resolves cleanly: `moq-relay/qlog → moq-native/qlog → qlog` crate.
- Targets `main`: no wire or public API change.

Scoped down from an earlier version that also added a local test harness under `demo/cc`; that was dropped to keep this to the reusable feature change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Opus 4.8)