### PR TITLE
docs: document Go/Kotlin/Swift/Python APIs and wire automated API-doc hosts

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs build config for the Python `moq` (moq-rs) API reference.
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
+#
+# The wrapper is pure python and its native moq_ffi dependency is mocked in
+# py/moq-rs/docs/conf.py, so we install the wrapper with --no-deps and never
+# build the Rust crate. Hosted at https://moq-rs.readthedocs.io.
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+  jobs:
+    install:
+      - pip install -r py/moq-rs/docs/requirements.txt
+      - pip install --no-deps ./py/moq-rs
+
+sphinx:
+  configuration: py/moq-rs/docs/conf.py
+
+formats:
+  - htmlzip

--- a/doc/lib/go/index.md
+++ b/doc/lib/go/index.md
@@ -41,6 +41,7 @@ cgo picks the right `libmoq_ffi.a` automatically via build tags; no `LD_LIBRARY_
 
 ## Source and issues
 
+- API reference: [pkg.go.dev/github.com/moq-dev/moq-go](https://pkg.go.dev/github.com/moq-dev/moq-go)
 - Source: [go/](https://github.com/moq-dev/moq/tree/main/go) (in the monorepo)
 - Wrapper mirror (what `go get` resolves): [moq-dev/moq-go](https://github.com/moq-dev/moq-go)
 - Raw bindings mirror: [moq-dev/moq-go-ffi](https://github.com/moq-dev/moq-go-ffi)

--- a/doc/lib/go/moq-ffi.md
+++ b/doc/lib/go/moq-ffi.md
@@ -35,7 +35,7 @@ cargo install uniffi-bindgen-go \
 
 ## See also
 
-- API reference: [pkg.go.dev/github.com/moq-dev/moq-go-ffi](https://pkg.go.dev/github.com/moq-dev/moq-go-ffi) (the cgo build can keep pkg.go.dev from rendering it; the ergonomic [moq](/lib/go/moq) package is the documented surface)
+- API reference: pkg.go.dev can't build this cgo module, so it isn't rendered there; the ergonomic [moq](/lib/go/moq) package (also cgo, but buildable) is the documented surface at [pkg.go.dev/github.com/moq-dev/moq-go](https://pkg.go.dev/github.com/moq-dev/moq-go)
 - Source: [go/ffi](https://github.com/moq-dev/moq/tree/main/go/ffi)
 - Mirror repo: [moq-dev/moq-go-ffi](https://github.com/moq-dev/moq-go-ffi)
 - Ergonomic wrapper: [moq](/lib/go/moq)

--- a/doc/lib/go/moq-ffi.md
+++ b/doc/lib/go/moq-ffi.md
@@ -35,6 +35,7 @@ cargo install uniffi-bindgen-go \
 
 ## See also
 
+- API reference: [pkg.go.dev/github.com/moq-dev/moq-go-ffi](https://pkg.go.dev/github.com/moq-dev/moq-go-ffi) (the cgo build can keep pkg.go.dev from rendering it; the ergonomic [moq](/lib/go/moq) package is the documented surface)
 - Source: [go/ffi](https://github.com/moq-dev/moq/tree/main/go/ffi)
 - Mirror repo: [moq-dev/moq-go-ffi](https://github.com/moq-dev/moq-go-ffi)
 - Ergonomic wrapper: [moq](/lib/go/moq)

--- a/doc/lib/go/moq.md
+++ b/doc/lib/go/moq.md
@@ -9,6 +9,10 @@ The ergonomic Go module for [Media over QUIC](/). This is the package most calle
 
 It wraps the raw [moq-ffi](/lib/go/moq-ffi) bindings in idiomatic Go: `context.Context` cancellation, Go `error` returns (with an `IsShutdown` helper for graceful Cancelled/Closed), and Go 1.23 range-over-func iterators (`iter.Seq2`) for live streams. The record and enum types are re-exported without the `Moq` prefix, so most programs never import the ffi package directly.
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/moq-dev/moq-go.svg)](https://pkg.go.dev/github.com/moq-dev/moq-go)
+
+Full API reference: [pkg.go.dev/github.com/moq-dev/moq-go](https://pkg.go.dev/github.com/moq-dev/moq-go), generated automatically from the godoc.
+
 ## Install
 
 ```bash
@@ -367,6 +371,7 @@ The committed `go/wrapper/go.mod` carries a `require github.com/moq-dev/moq-go-f
 
 ## See also
 
+- API reference: [pkg.go.dev/github.com/moq-dev/moq-go](https://pkg.go.dev/github.com/moq-dev/moq-go)
 - Source: [go/wrapper](https://github.com/moq-dev/moq/tree/main/go/wrapper)
 - Mirror repo: [moq-dev/moq-go](https://github.com/moq-dev/moq-go)
 - Raw bindings it builds on: [moq-ffi](/lib/go/moq-ffi)

--- a/doc/lib/kt/index.md
+++ b/doc/lib/kt/index.md
@@ -54,6 +54,7 @@ Moq.connect("https://relay.example.com").use { moq ->
 
 ## Source and issues
 
+- API reference: [javadoc.io/doc/dev.moq/moq](https://javadoc.io/doc/dev.moq/moq)
 - Source: [kt/](https://github.com/moq-dev/moq/tree/main/kt) (in the monorepo)
 - README: [kt/README.md](https://github.com/moq-dev/moq/blob/main/kt/README.md)
 - Maven Central: [dev.moq:moq](https://central.sonatype.com/artifact/dev.moq/moq)

--- a/doc/lib/kt/moq.md
+++ b/doc/lib/kt/moq.md
@@ -7,6 +7,10 @@ description: Kotlin Multiplatform library for Media over QUIC
 
 The ergonomic Kotlin wrapper for [Media over QUIC](/), layered on the [`dev.moq:moq-ffi`](https://central.sonatype.com/artifact/dev.moq/moq-ffi) bindings. Both publish JVM and Android variants under one coordinate; Gradle metadata picks the right one for your target.
 
+[![javadoc](https://javadoc.io/badge2/dev.moq/moq/javadoc.svg)](https://javadoc.io/doc/dev.moq/moq)
+
+Full API reference: [javadoc.io/doc/dev.moq/moq](https://javadoc.io/doc/dev.moq/moq), the KDoc rendered from each release's Dokka javadoc jar.
+
 ## Install
 
 ```kotlin
@@ -302,6 +306,7 @@ Android targets are opt-in via `-Pandroid.enabled=true`. Local builds without th
 
 ## See also
 
+- API reference: [javadoc.io/doc/dev.moq/moq](https://javadoc.io/doc/dev.moq/moq)
 - Source: [kt/](https://github.com/moq-dev/moq/tree/main/kt)
 - README: [kt/README.md](https://github.com/moq-dev/moq/blob/main/kt/README.md)
 - Maven Central: [dev.moq:moq](https://central.sonatype.com/artifact/dev.moq/moq)

--- a/doc/lib/py/index.md
+++ b/doc/lib/py/index.md
@@ -85,6 +85,7 @@ asyncio.run(main())
 
 ## Source and issues
 
+- API reference: [moq-rs.readthedocs.io](https://moq-rs.readthedocs.io)
 - Source: [py/moq-rs](https://github.com/moq-dev/moq/tree/main/py/moq-rs) (wrapper), [py/moq-ffi](https://github.com/moq-dev/moq/tree/main/py/moq-ffi) (raw bindings)
 - README: [py/moq-rs/README.md](https://github.com/moq-dev/moq/blob/main/py/moq-rs/README.md)
 - Example scripts: [py/moq-rs/examples](https://github.com/moq-dev/moq/tree/main/py/moq-rs/examples)

--- a/doc/lib/py/moq-rs.md
+++ b/doc/lib/py/moq-rs.md
@@ -6,8 +6,11 @@ description: Python pub/sub for Media over QUIC
 # moq-rs
 
 [![PyPI](https://img.shields.io/pypi/v/moq-rs)](https://pypi.org/project/moq-rs/)
+[![Documentation](https://readthedocs.org/projects/moq-rs/badge/?version=latest)](https://moq-rs.readthedocs.io)
 
 Async pub/sub for [Media over QUIC](/) in Python.
+
+Full API reference: [moq-rs.readthedocs.io](https://moq-rs.readthedocs.io), built automatically from the docstrings on each commit.
 
 The underlying transport is the Rust [`moq-net`](/lib/rs/crate/moq-net) crate, exposed through UniFFI (the [`moq-ffi`](https://pypi.org/project/moq-ffi/) package) and wrapped in a Pythonic API: no `Moq` prefixes on user-facing types, async iterators for streams, async context managers for sessions. `moq-rs` is versioned independently of `moq-ffi` and floats to the latest compatible patch.
 
@@ -261,6 +264,7 @@ The repo ships [example scripts](https://github.com/moq-dev/moq/tree/main/py/moq
 
 ## See also
 
+- API reference: [moq-rs.readthedocs.io](https://moq-rs.readthedocs.io)
 - Source: [py/moq-rs](https://github.com/moq-dev/moq/tree/main/py/moq-rs)
 - README: [py/moq-rs/README.md](https://github.com/moq-dev/moq/blob/main/py/moq-rs/README.md)
 - Raw bindings: [moq-ffi](https://pypi.org/project/moq-ffi/)

--- a/doc/lib/swift/index.md
+++ b/doc/lib/swift/index.md
@@ -84,6 +84,7 @@ Cancelling the surrounding Swift `Task` propagates through to the underlying `ca
 
 ## Source and issues
 
+- API reference: [Swift Package Index (DocC)](https://swiftpackageindex.com/moq-dev/moq-swift/documentation/moq)
 - Source: [swift/](https://github.com/moq-dev/moq/tree/main/swift) (in the monorepo)
 - Mirrors (what SPM resolves): [moq-dev/moq-swift](https://github.com/moq-dev/moq-swift) (wrapper), [moq-dev/moq-swift-ffi](https://github.com/moq-dev/moq-swift-ffi) (raw bindings)
 - README: [swift/README.md](https://github.com/moq-dev/moq/blob/main/swift/README.md)

--- a/doc/lib/swift/moq.md
+++ b/doc/lib/swift/moq.md
@@ -9,6 +9,8 @@ The ergonomic Swift Package Manager target for [Media over QUIC](/).
 
 A Swift-native wrapper over the UniFFI-generated bindings: de-prefixed types, `AsyncSequence` streams, throwing initializers, `Sendable` handles, and Swift-friendly errors. The raw `MoqFFI` types it wraps stay out of your way (data types like `Frame` and `Catalog` are re-exported under de-prefixed names).
 
+Full API reference: [Swift Package Index](https://swiftpackageindex.com/moq-dev/moq-swift/documentation/moq), which builds and hosts the DocC docs from the `///` comments on each tagged release.
+
 ## Install
 
 ```swift
@@ -259,6 +261,7 @@ This runs `swift/scripts/check.sh`, which builds `moq-ffi` for the host arch, re
 
 ## See also
 
+- API reference: [Swift Package Index (DocC)](https://swiftpackageindex.com/moq-dev/moq-swift/documentation/moq)
 - Source: [swift/Sources/Moq](https://github.com/moq-dev/moq/tree/main/swift/Sources/Moq)
 - Mirror repos: [moq-dev/moq-swift](https://github.com/moq-dev/moq-swift) (wrapper), [moq-dev/moq-swift-ffi](https://github.com/moq-dev/moq-swift-ffi) (raw bindings)
 - The Rust crate this wraps: [moq-net](/lib/rs/crate/moq-net)

--- a/go/wrapper/moq/errors.go
+++ b/go/wrapper/moq/errors.go
@@ -14,6 +14,7 @@ type Error = ffi.MoqError
 
 // Configuration errors returned by the wrapper itself (not the FFI layer).
 var (
+	// ErrNoPublishOrigin is returned when a publish operation is attempted but the server has no publish origin configured.
 	ErrNoPublishOrigin = errors.New("moq: no publish origin configured")
 )
 
@@ -23,26 +24,46 @@ var (
 // (Protocol, Media, ...) wrap a lower-level error whose detail survives in the
 // message.
 var (
-	ErrProtocol         = ffi.ErrMoqErrorProtocol
-	ErrMedia            = ffi.ErrMoqErrorMedia
-	ErrMux              = ffi.ErrMoqErrorMux
-	ErrAudio            = ffi.ErrMoqErrorAudio
-	ErrURL              = ffi.ErrMoqErrorUrl
-	ErrTimeOverflow     = ffi.ErrMoqErrorTimeOverflow
-	ErrLogLevel         = ffi.ErrMoqErrorLogLevel
-	ErrTask             = ffi.ErrMoqErrorTask
-	ErrCancelled        = ffi.ErrMoqErrorCancelled
-	ErrClosed           = ffi.ErrMoqErrorClosed
-	ErrConnect          = ffi.ErrMoqErrorConnect
-	ErrBind             = ffi.ErrMoqErrorBind
-	ErrReject           = ffi.ErrMoqErrorReject
+	// ErrProtocol matches a lower-level moq-net transport or protocol error; the underlying detail survives in the message.
+	ErrProtocol = ffi.ErrMoqErrorProtocol
+	// ErrMedia matches a hang media error, such as a malformed catalog or container.
+	ErrMedia = ffi.ErrMoqErrorMedia
+	// ErrMux matches a muxing or demuxing failure from moq-mux.
+	ErrMux = ffi.ErrMoqErrorMux
+	// ErrAudio matches a raw-audio encode or decode failure.
+	ErrAudio = ffi.ErrMoqErrorAudio
+	// ErrURL matches a malformed URL passed when connecting or publishing.
+	ErrURL = ffi.ErrMoqErrorUrl
+	// ErrTimeOverflow matches a timestamp that overflowed its timescale.
+	ErrTimeOverflow = ffi.ErrMoqErrorTimeOverflow
+	// ErrLogLevel matches an unparseable log level string passed to LogLevel.
+	ErrLogLevel = ffi.ErrMoqErrorLogLevel
+	// ErrTask matches a panic or cancellation in a background native task.
+	ErrTask = ffi.ErrMoqErrorTask
+	// ErrCancelled is returned when an operation is cancelled, e.g. via a cancelled context; IsShutdown treats it as a graceful stop.
+	ErrCancelled = ffi.ErrMoqErrorCancelled
+	// ErrClosed is returned when the session or stream has closed; IsShutdown treats it as a graceful stop.
+	ErrClosed = ffi.ErrMoqErrorClosed
+	// ErrConnect is returned when establishing a client session fails.
+	ErrConnect = ffi.ErrMoqErrorConnect
+	// ErrBind is returned when the server fails to bind its listening address.
+	ErrBind = ffi.ErrMoqErrorBind
+	// ErrReject is returned when a session is refused during the handshake.
+	ErrReject = ffi.ErrMoqErrorReject
+	// ErrAlreadyResponded is returned when a Request is accepted or rejected more than once.
 	ErrAlreadyResponded = ffi.ErrMoqErrorAlreadyResponded
-	ErrCodec            = ffi.ErrMoqErrorCodec
-	ErrUnauthorized     = ffi.ErrMoqErrorUnauthorized
-	ErrForbidden        = ffi.ErrMoqErrorForbidden
-	ErrNotFound         = ffi.ErrMoqErrorNotFound
-	ErrUnsupported      = ffi.ErrMoqErrorUnsupported
-	ErrLog              = ffi.ErrMoqErrorLog
+	// ErrCodec is returned when codec configuration or bitstream parsing fails.
+	ErrCodec = ffi.ErrMoqErrorCodec
+	// ErrUnauthorized is returned when the relay rejects the session with HTTP 401.
+	ErrUnauthorized = ffi.ErrMoqErrorUnauthorized
+	// ErrForbidden is returned when the relay rejects the session with HTTP 403.
+	ErrForbidden = ffi.ErrMoqErrorForbidden
+	// ErrNotFound is returned when the requested track or group is not available.
+	ErrNotFound = ffi.ErrMoqErrorNotFound
+	// ErrUnsupported is returned when the requested operation is not supported.
+	ErrUnsupported = ffi.ErrMoqErrorUnsupported
+	// ErrLog is returned when installing or configuring the native log subscriber fails.
+	ErrLog = ffi.ErrMoqErrorLog
 )
 
 // IsShutdown reports whether err is the expected result of a graceful shutdown

--- a/go/wrapper/moq/errors.go
+++ b/go/wrapper/moq/errors.go
@@ -26,7 +26,7 @@ var (
 var (
 	// ErrProtocol matches a lower-level moq-net transport or protocol error; the underlying detail survives in the message.
 	ErrProtocol = ffi.ErrMoqErrorProtocol
-	// ErrMedia matches a hang media error, such as a malformed catalog or container.
+	// ErrMedia matches a media error from the hang layer, such as a malformed catalog or container.
 	ErrMedia = ffi.ErrMoqErrorMedia
 	// ErrMux matches a muxing or demuxing failure from moq-mux.
 	ErrMux = ffi.ErrMoqErrorMux

--- a/go/wrapper/moq/server.go
+++ b/go/wrapper/moq/server.go
@@ -14,8 +14,11 @@ type Transport string
 // Known transports reported by Request.Transport. Future native versions may
 // report values not listed here, so treat Transport as an open set.
 const (
-	TransportQUIC      Transport = "quic"
-	TransportIroh      Transport = "iroh"
+	// TransportQUIC is a session that arrived over native QUIC.
+	TransportQUIC Transport = "quic"
+	// TransportIroh is a session that arrived over an Iroh peer-to-peer connection.
+	TransportIroh Transport = "iroh"
+	// TransportWebSocket is a session that arrived over the WebSocket fallback transport.
 	TransportWebSocket Transport = "websocket"
 )
 

--- a/go/wrapper/moq/types.go
+++ b/go/wrapper/moq/types.go
@@ -6,33 +6,56 @@ import ffi "github.com/moq-dev/moq-go-ffi/moq"
 // These are plain data, so type aliases are exact: a moq.AudioFrame is an
 // ffi.MoqAudioFrame, constructible and comparable across the boundary.
 type (
-	Audio              = ffi.MoqAudio
-	AudioCodec         = ffi.MoqAudioCodec
+	// Audio describes one audio rendition in a broadcast catalog: codec, sample rate, channel count, and container.
+	Audio = ffi.MoqAudio
+	// AudioCodec identifies an audio track's codec; Opus is currently the only value.
+	AudioCodec = ffi.MoqAudioCodec
+	// AudioDecoderOutput configures the PCM format, sample rate, and channels SubscribeAudio delivers.
 	AudioDecoderOutput = ffi.MoqAudioDecoderOutput
-	AudioEncoderInput  = ffi.MoqAudioEncoderInput
+	// AudioEncoderInput declares the PCM sample format, sample rate, and channel count of frames written to an audio producer.
+	AudioEncoderInput = ffi.MoqAudioEncoderInput
+	// AudioEncoderOutput configures the Opus encoder: codec, optional sample rate, channels, bitrate, and frame duration.
 	AudioEncoderOutput = ffi.MoqAudioEncoderOutput
-	AudioFormat        = ffi.MoqAudioFormat
-	AudioFrame         = ffi.MoqAudioFrame
-	Catalog            = ffi.MoqCatalog
-	ConnectionStats    = ffi.MoqConnectionStats
-	Datagram           = ffi.MoqDatagram
-	Dimensions         = ffi.MoqDimensions
-	Frame              = ffi.MoqFrame
-	MediaFrame         = ffi.MoqMediaFrame
-	FetchGroupOptions  = ffi.MoqFetchGroupOptions
-	OriginOptions      = ffi.MoqOriginOptions
-	Route              = ffi.MoqRoute
-	Subscription       = ffi.MoqSubscription
-	TrackInfo          = ffi.MoqTrackInfo
-	Video              = ffi.MoqVideo
-	VideoHint          = ffi.MoqVideoHint
+	// AudioFormat is a raw PCM sample layout, mirroring WebCodecs AudioData.format.
+	AudioFormat = ffi.MoqAudioFormat
+	// AudioFrame is one audio frame: PCM payload plus a presentation timestamp in microseconds.
+	AudioFrame = ffi.MoqAudioFrame
+	// Catalog is a broadcast's manifest: its video and audio renditions plus display metadata.
+	Catalog = ffi.MoqCatalog
+	// ConnectionStats holds transport metrics for a session (RTT, bandwidth, byte and packet counters); each field is nil when unreported.
+	ConnectionStats = ffi.MoqConnectionStats
+	// Datagram is a best-effort track datagram as received: sequence number, timestamp, and payload.
+	Datagram = ffi.MoqDatagram
+	// Dimensions is a width and height in pixels.
+	Dimensions = ffi.MoqDimensions
+	// Frame is a raw track frame: a payload and its presentation timestamp in microseconds.
+	Frame = ffi.MoqFrame
+	// MediaFrame is a Frame plus the codec-derived keyframe flag carried on a media track.
+	MediaFrame = ffi.MoqMediaFrame
+	// FetchGroupOptions configures a single FetchGroup call, currently just the delivery priority.
+	FetchGroupOptions = ffi.MoqFetchGroupOptions
+	// OriginOptions configures a new origin, such as its maximum cache size in bytes.
+	OriginOptions = ffi.MoqOriginOptions
+	// Route is the hop chain a broadcast takes to reach an origin, its cost, and whether it's announced.
+	Route = ffi.MoqRoute
+	// Subscription holds subscriber-side delivery preferences: priority, ordering, latency budget, and group range.
+	Subscription = ffi.MoqSubscription
+	// TrackInfo holds publisher-side track properties: priority, ordering, latency budget, and timescale.
+	TrackInfo = ffi.MoqTrackInfo
+	// Video describes one video rendition in a broadcast catalog: codec, dimensions, bitrate, framerate, and container.
+	Video = ffi.MoqVideo
+	// VideoHint supplies catalog fields a video stream can't reveal itself, such as bitrate, filling only the gaps.
+	VideoHint = ffi.MoqVideoHint
 
 	// Container selects how subscribed media frames are demuxed. Build one with
 	// LegacyContainer, CmafContainer, or LocContainer.
-	Container       = ffi.MoqContainer
+	Container = ffi.MoqContainer
+	// ContainerLegacy is the legacy hang container variant of Container; build one with LegacyContainer.
 	ContainerLegacy = ffi.MoqContainerLegacy
-	ContainerCmaf   = ffi.MoqContainerCmaf
-	ContainerLoc    = ffi.MoqContainerLoc
+	// ContainerCmaf is the CMAF (fMP4) container variant of Container, carrying its init segment; build one with CmafContainer.
+	ContainerCmaf = ffi.MoqContainerCmaf
+	// ContainerLoc is the low-overhead container variant of Container; build one with LocContainer.
+	ContainerLoc = ffi.MoqContainerLoc
 )
 
 // LegacyContainer selects the legacy hang container for a media subscription.
@@ -54,13 +77,21 @@ func LocContainer() Container {
 // AudioFormat values: the raw PCM sample layout fed to or returned from the
 // in-process Opus codec.
 const (
-	AudioFormatU8        = ffi.MoqAudioFormatU8
-	AudioFormatS16       = ffi.MoqAudioFormatS16
-	AudioFormatS32       = ffi.MoqAudioFormatS32
-	AudioFormatF32       = ffi.MoqAudioFormatF32
-	AudioFormatU8Planar  = ffi.MoqAudioFormatU8Planar
+	// AudioFormatU8 is unsigned 8-bit interleaved PCM.
+	AudioFormatU8 = ffi.MoqAudioFormatU8
+	// AudioFormatS16 is signed 16-bit interleaved PCM.
+	AudioFormatS16 = ffi.MoqAudioFormatS16
+	// AudioFormatS32 is signed 32-bit interleaved PCM.
+	AudioFormatS32 = ffi.MoqAudioFormatS32
+	// AudioFormatF32 is 32-bit float interleaved PCM.
+	AudioFormatF32 = ffi.MoqAudioFormatF32
+	// AudioFormatU8Planar is unsigned 8-bit planar PCM, one buffer per channel.
+	AudioFormatU8Planar = ffi.MoqAudioFormatU8Planar
+	// AudioFormatS16Planar is signed 16-bit planar PCM, one buffer per channel.
 	AudioFormatS16Planar = ffi.MoqAudioFormatS16Planar
+	// AudioFormatS32Planar is signed 32-bit planar PCM, one buffer per channel.
 	AudioFormatS32Planar = ffi.MoqAudioFormatS32Planar
+	// AudioFormatF32Planar is 32-bit float planar PCM, one buffer per channel.
 	AudioFormatF32Planar = ffi.MoqAudioFormatF32Planar
 )
 

--- a/kt/build.gradle.kts
+++ b/kt/build.gradle.kts
@@ -20,6 +20,10 @@ plugins {
     kotlin("plugin.serialization") version "2.0.21" apply false
     id("com.android.library") apply false
     id("com.vanniktech.maven.publish") version "0.30.0" apply false
+    // Generates the KDoc HTML that `:moq` ships as its Maven Central javadoc jar,
+    // which javadoc.io then hosts. Declared once here (see the header note) so the
+    // module can request it by id.
+    id("org.jetbrains.dokka") version "1.9.20" apply false
 }
 
 allprojects {

--- a/kt/moq/build.gradle.kts
+++ b/kt/moq/build.gradle.kts
@@ -22,6 +22,8 @@
 // is present (see mavenPublishing below), so keyless local and fork-PR builds work.
 
 import com.android.build.gradle.LibraryExtension
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.SonatypeHost
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -33,6 +35,8 @@ plugins {
     kotlin("plugin.serialization")
     id("com.android.library") apply false
     id("com.vanniktech.maven.publish")
+    // Builds the KDoc HTML bundled as the javadoc jar (see mavenPublishing below).
+    id("org.jetbrains.dokka")
 }
 
 version = providers.gradleProperty("moq.version").get()
@@ -133,6 +137,11 @@ if (androidEnabled) {
 }
 
 mavenPublishing {
+    // Bundle the Dokka-generated KDoc HTML as the javadoc jar. Without this the
+    // KMP default is an empty javadoc jar, so javadoc.io (which mirrors whatever
+    // Maven Central holds) would serve a docless page.
+    configure(KotlinMultiplatform(javadocJar = JavadocJar.Dokka("dokkaHtml")))
+
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
     // Only sign when a key is actually configured. signAllPublications() registers a
     // *required* sign task, so calling it unconditionally makes publishToMavenLocal

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -99,7 +99,7 @@ typealias Init = uniffi.moq.MoqInit
 typealias Audio = uniffi.moq.MoqAudio
 /** A width and height pair, in pixels. */
 typealias Dimensions = uniffi.moq.MoqDimensions
-/** The route a broadcast takes to reach this origin: relay hop ids (oldest first) plus advertised cost (lower wins). */
+/** The route a broadcast takes to reach this origin: relay hop ids (oldest first), advertised cost (lower wins), and whether it's announced. */
 typealias Route = uniffi.moq.MoqRoute
 /** Tunes how a track subscription is delivered: priority, group ordering, and range. */
 typealias Subscription = uniffi.moq.MoqSubscription

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Aliases.kt
@@ -9,41 +9,67 @@ package dev.moq
 
 // Session + connection handles. `Server` is not aliased: `dev.moq.Server` is the
 // listen facade (see Server.kt), which exposes the raw handle as `server`.
+/** A MoQ client: configure the TLS/bind knobs, then connect to a relay. */
 typealias Client = uniffi.moq.MoqClient
+/** A live pub/sub session with a relay, exposing a publisher and a consumer. */
 typealias Session = uniffi.moq.MoqSession
+/** An incoming session awaiting a decision: accept it to handshake, or reject it. */
 typealias Request = uniffi.moq.MoqRequest
 
 // Origin (broadcast discovery / announcement).
+/** The publish side of an origin: create broadcasts so subscribers can discover them. */
 typealias OriginProducer = uniffi.moq.MoqOriginProducer
+/** Options for creating an origin, such as its total cache budget. */
 typealias OriginOptions = uniffi.moq.MoqOriginOptions
+/** The subscribe side of an origin: discover and request announced broadcasts. */
 typealias OriginConsumer = uniffi.moq.MoqOriginConsumer
+/** A stream of broadcasts requested by subscribers, for serving unannounced paths on demand. */
 typealias OriginDynamic = uniffi.moq.MoqOriginDynamic
+/** A requested broadcast not yet accepted: fulfill it with a producer or abort it. */
 typealias BroadcastRequest = uniffi.moq.MoqBroadcastRequest
+/** A stream of broadcast announcements under a prefix. */
 typealias Announced = uniffi.moq.MoqAnnounced
+/** A pending wait for a specific broadcast path to be announced. */
 typealias AnnouncedBroadcast = uniffi.moq.MoqAnnouncedBroadcast
+/** A single broadcast announcement: its path plus a consumer. */
 typealias Announcement = uniffi.moq.MoqAnnouncement
 
 // Broadcast / track / group producers and consumers.
+/** The write side of a broadcast: publish tracks into it. */
 typealias BroadcastProducer = uniffi.moq.MoqBroadcastProducer
+/** The read side of a broadcast: subscribe to its catalog and tracks. */
 typealias BroadcastConsumer = uniffi.moq.MoqBroadcastConsumer
 /** Watches a broadcast's route: yields the current route first, then every change. */
 typealias RouteWatch = uniffi.moq.MoqRouteWatch
 /** Receives tracks requested from a dynamically served broadcast. */
 typealias BroadcastDynamic = uniffi.moq.MoqBroadcastDynamic
+/** The write side of a raw track: append groups of frames. */
 typealias TrackProducer = uniffi.moq.MoqTrackProducer
+/** A subscriber-requested track not yet accepted: accept it for a [TrackProducer] or abort it. */
 typealias TrackRequest = uniffi.moq.MoqTrackRequest
+/** A stream of uncached group requests for one track, for serving fetches on demand. */
 typealias TrackDynamic = uniffi.moq.MoqTrackDynamic
+/** The read side of a raw track: yields groups in sequence order, skipping ahead if it falls behind. */
 typealias TrackConsumer = uniffi.moq.MoqTrackConsumer
+/** A request to produce one uncached group for a fetch consumer. */
 typealias GroupRequest = uniffi.moq.MoqGroupRequest
+/** The write side of a single group: append frames to it. */
 typealias GroupProducer = uniffi.moq.MoqGroupProducer
+/** The read side of a single group: yields timestamped raw frames. */
 typealias GroupConsumer = uniffi.moq.MoqGroupConsumer
 
 // Media (codec-aware) producers and consumers.
+/** The write side of a media track fed pre-framed payloads. */
 typealias MediaProducer = uniffi.moq.MoqMediaProducer
+/** The write side of a media track fed a raw byte stream, with frame boundaries inferred. */
 typealias MediaStreamProducer = uniffi.moq.MoqMediaStreamProducer
+/** The read side of a media track: yields frames with codec metadata in decode order. */
 typealias MediaConsumer = uniffi.moq.MoqMediaConsumer
+/** The write side of a raw-audio track; PCM written here is encoded inside the FFI boundary. */
 typealias AudioProducer = uniffi.moq.MoqAudioProducer
+/** The read side of a raw-audio track: yields decoded PCM frames. */
 typealias AudioConsumer = uniffi.moq.MoqAudioConsumer
+/** The read side of a broadcast's catalog: yields updates as the set of tracks changes. */
 typealias CatalogConsumer = uniffi.moq.MoqCatalogConsumer
 /** Publishes lossy latest-value JSON snapshots. */
 typealias JsonSnapshotProducer = uniffi.moq.MoqJsonSnapshotProducer
@@ -55,28 +81,43 @@ typealias JsonStreamProducer = uniffi.moq.MoqJsonStreamProducer
 typealias JsonStreamConsumer = uniffi.moq.MoqJsonStreamConsumer
 
 // Data types.
+/** A broadcast's catalog: its tracks and their properties, plus any application sections. */
 typealias Catalog = uniffi.moq.MoqCatalog
+/** A datagram-delivered frame, tagged with a per-track sequence number. */
 typealias Datagram = uniffi.moq.MoqDatagram
+/** A payload plus the timestamp it should be presented at. */
 typealias Frame = uniffi.moq.MoqFrame
 /** A [Frame] plus the codec metadata a media track carries. */
 typealias MediaFrame = uniffi.moq.MoqMediaFrame
+/** The catalog description of a video track: codec, dimensions, bitrate, and container. */
 typealias Video = uniffi.moq.MoqVideo
 /** Caller-provided catalog fields for a video track. */
 typealias VideoHint = uniffi.moq.MoqVideoHint
 /** Media format, initialization bytes, and optional video hints. */
 typealias Init = uniffi.moq.MoqInit
+/** The catalog description of an audio track: codec, sample rate, channels, and container. */
 typealias Audio = uniffi.moq.MoqAudio
+/** A width and height pair, in pixels. */
 typealias Dimensions = uniffi.moq.MoqDimensions
 /** The route a broadcast takes to reach this origin: relay hop ids (oldest first) plus advertised cost (lower wins). */
 typealias Route = uniffi.moq.MoqRoute
+/** Tunes how a track subscription is delivered: priority, group ordering, and range. */
 typealias Subscription = uniffi.moq.MoqSubscription
+/** Options for fetching one past group by sequence. */
 typealias FetchGroupOptions = uniffi.moq.MoqFetchGroupOptions
+/** Delivery settings for a raw track: priority, ordering, latency budget, and timescale. */
 typealias TrackInfo = uniffi.moq.MoqTrackInfo
+/** One audio frame: PCM payload bytes plus a presentation timestamp. */
 typealias AudioFrame = uniffi.moq.MoqAudioFrame
+/** An audio codec identifier. */
 typealias AudioCodec = uniffi.moq.MoqAudioCodec
+/** A raw PCM sample format, mirroring WebCodecs `AudioData.format`. */
 typealias AudioFormat = uniffi.moq.MoqAudioFormat
+/** The PCM layout an [AudioConsumer] should decode to. */
 typealias AudioDecoderOutput = uniffi.moq.MoqAudioDecoderOutput
+/** The PCM layout the caller feeds an [AudioProducer]. */
 typealias AudioEncoderInput = uniffi.moq.MoqAudioEncoderInput
+/** The codec-side encoder configuration: codec, output rate/channels, bitrate, and frame duration. */
 typealias AudioEncoderOutput = uniffi.moq.MoqAudioEncoderOutput
 /** A snapshot of transport connection statistics. */
 typealias ConnectionStats = uniffi.moq.MoqConnectionStats

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt
@@ -61,6 +61,7 @@ class Moq internal constructor(
      */
     suspend fun requestBroadcast(path: String): MoqBroadcastConsumer = session.consumer().requestBroadcast(path)
 
+    /** Gracefully shut down the session and cancel the client, releasing the native handles. */
     override fun close() {
         session.shutdown()
         client.cancel()

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Server.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Server.kt
@@ -90,6 +90,7 @@ class Server internal constructor(
         }
     }
 
+    /** Stop accepting new sessions and release the native server handle; in-flight sessions stay alive. */
     override fun close() {
         server.cancel()
     }

--- a/py/justfile
+++ b/py/justfile
@@ -69,6 +69,17 @@ package:
     rm -rf dist
     uv build --package moq-rs --out-dir dist
 
+# Build the Sphinx API docs for the `moq` wrapper into py/dist/docs. Read the
+# Docs builds the same config (see .readthedocs.yaml) and hosts the result. The
+# native moq_ffi is mocked (autodoc_mock_imports in docs/conf.py), so this needs
+# no Rust build: install the pure-python wrapper metadata and render.
+docs:
+    uv sync --no-install-workspace
+    uv pip install --no-deps -e moq-rs
+    rm -rf dist/docs
+    uv run --no-sync --with sphinx --with myst-parser --with furo \
+        sphinx-build -b html moq-rs/docs dist/docs
+
 # Full Python CI: lint + tests + build. Takes a newline-separated list
 # of changed files; skips if FILES is non-empty and none match the
 # Python scope (which includes rs/moq-ffi because moq-ffi bundles it via
@@ -84,3 +95,4 @@ ci FILES="":
     just check
     just test
     just build
+    just docs

--- a/py/moq-rs/docs/.gitignore
+++ b/py/moq-rs/docs/.gitignore
@@ -1,0 +1,3 @@
+# Sphinx build output and autosummary-generated stubs (regenerated each build).
+_build/
+api/

--- a/py/moq-rs/docs/conf.py
+++ b/py/moq-rs/docs/conf.py
@@ -1,0 +1,55 @@
+"""Sphinx configuration for the moq (moq-rs) API reference.
+
+Read the Docs builds this (see .readthedocs.yaml) and hosts the result. The
+native moq_ffi extension is mocked, so the pure-python wrapper documents
+without a Rust build. `just py docs` renders the same config locally.
+"""
+
+from pathlib import Path
+
+import tomllib
+
+# Pull name/version straight from the wrapper's pyproject so the docs never
+# drift from the released metadata.
+_pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+_meta = tomllib.loads(_pyproject.read_text())["project"]
+
+project = "moq"
+author = "moq-dev"
+release = _meta["version"]
+version = release
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.intersphinx",
+    "myst_parser",
+]
+
+# The wrapper is pure python; its only runtime dependency is the native
+# moq_ffi extension. Mock it so autodoc can import `moq` without building the
+# Rust crate. The re-exported FFI data types are documented on the Rust side.
+autodoc_mock_imports = ["moq_ffi"]
+
+# The re-exported FFI record/enum types (Frame, Catalog, Audio, ...) resolve to
+# mocks, which autodoc flags. That is expected here, so silence just that
+# category rather than the whole build.
+suppress_warnings = ["autodoc.mocked_object"]
+
+autosummary_generate = True
+autodoc_typehints = "description"
+autodoc_member_order = "bysource"
+napoleon_google_docstring = True
+napoleon_numpy_docstring = False
+
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build"]
+
+html_theme = "furo"
+html_title = "moq"
+
+# A .md landing page next to reStructuredText API stubs.
+source_suffix = {".rst": "restructuredtext", ".md": "markdown"}

--- a/py/moq-rs/docs/index.md
+++ b/py/moq-rs/docs/index.md
@@ -1,0 +1,159 @@
+# moq
+
+Python bindings for [Media over QUIC](https://moq.dev): real-time pub/sub with
+built-in caching, fan-out, and prioritization over QUIC. This is the API
+reference for the ergonomic `moq` wrapper (installed as
+[`moq-rs`](https://pypi.org/project/moq-rs/)).
+
+```bash
+pip install moq-rs
+```
+
+```python
+import asyncio
+import moq
+
+
+async def main():
+    async with moq.Client("https://relay.quic.video") as client:
+        async for announcement in client.announced():
+            catalog = await announcement.broadcast.catalog()
+            print(catalog)
+
+
+asyncio.run(main())
+```
+
+## Connecting
+
+```{eval-rst}
+.. currentmodule:: moq
+
+.. autosummary::
+   :toctree: api
+   :nosignatures:
+
+   Client
+   connect
+   Server
+   Session
+   Request
+   Transport
+```
+
+## Publishing
+
+```{eval-rst}
+.. currentmodule:: moq
+
+.. autosummary::
+   :toctree: api
+   :nosignatures:
+
+   BroadcastProducer
+   BroadcastDynamic
+   BroadcastRequest
+   TrackProducer
+   TrackDynamic
+   TrackRequest
+   GroupProducer
+   GroupRequest
+   MediaProducer
+   MediaStreamProducer
+   AudioProducer
+   JsonSnapshotProducer
+   JsonStreamProducer
+```
+
+## Subscribing
+
+```{eval-rst}
+.. currentmodule:: moq
+
+.. autosummary::
+   :toctree: api
+   :nosignatures:
+
+   BroadcastConsumer
+   TrackConsumer
+   GroupConsumer
+   MediaConsumer
+   AudioConsumer
+   CatalogConsumer
+   JsonSnapshotConsumer
+   JsonStreamConsumer
+```
+
+## Origin and announcements
+
+```{eval-rst}
+.. currentmodule:: moq
+
+.. autosummary::
+   :toctree: api
+   :nosignatures:
+
+   OriginProducer
+   OriginConsumer
+   OriginDynamic
+   Announced
+   AnnouncedBroadcast
+   Announcement
+```
+
+## Data types
+
+These records and enums are re-exported from the native `moq_ffi` bindings; the
+wrapper surfaces them under `moq` unchanged. Their fields are defined on the
+Rust side ([`moq-ffi`](https://crates.io/crates/moq-ffi)).
+
+```{eval-rst}
+.. currentmodule:: moq
+
+.. autosummary::
+   :toctree: api
+   :nosignatures:
+
+   Catalog
+   Container
+   Frame
+   MediaFrame
+   Datagram
+   Video
+   VideoHint
+   Dimensions
+   Audio
+   AudioFrame
+   AudioCodec
+   AudioFormat
+   AudioDecoderOutput
+   AudioEncoderInput
+   AudioEncoderOutput
+   Subscription
+   TrackInfo
+   FetchGroupOptions
+   Route
+   ConnectionStats
+```
+
+## Helpers
+
+```{eval-rst}
+.. currentmodule:: moq
+
+.. autosummary::
+   :toctree: api
+   :nosignatures:
+
+   Error
+   is_auth
+   is_shutdown
+   log_level
+```
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+
+self
+```

--- a/py/moq-rs/docs/requirements.txt
+++ b/py/moq-rs/docs/requirements.txt
@@ -1,0 +1,7 @@
+# Doc-build dependencies for the moq API reference. Used by both Read the Docs
+# (.readthedocs.yaml) and `just py docs`. The wrapper itself is installed
+# separately with --no-deps so the native moq_ffi is never built (it is mocked
+# in conf.py).
+sphinx>=8.1
+myst-parser>=4.0
+furo>=2024.8.6

--- a/py/moq-rs/moq/client.py
+++ b/py/moq-rs/moq/client.py
@@ -114,9 +114,17 @@ class Client:
         return self._require_publisher().create_broadcast(path)
 
     def announced(self, prefix: str = "") -> Announced:
+        """Async-iterate broadcasts announced under ``prefix`` (empty matches all).
+
+        See :meth:`OriginConsumer.announced`.
+        """
         return self._require_consumer().announced(prefix)
 
     def announced_broadcast(self, path: str) -> AnnouncedBroadcast:
+        """Await announcement of the broadcast at exactly ``path``.
+
+        See :meth:`OriginConsumer.announced_broadcast`.
+        """
         return self._require_consumer().announced_broadcast(path)
 
     async def request_broadcast(self, path: str) -> BroadcastConsumer:

--- a/py/moq-rs/moq/origin.py
+++ b/py/moq-rs/moq/origin.py
@@ -18,7 +18,10 @@ from .subscribe import BroadcastConsumer
 
 
 class Announcement:
-    """Wraps MoqAnnouncement, a discovered broadcast."""
+    """A single broadcast discovered via :meth:`OriginConsumer.announced`.
+
+    Read its :attr:`path` and get a :attr:`broadcast` consumer to subscribe to it.
+    """
 
     def __init__(self, inner: MoqAnnouncement) -> None:
         self._inner = inner
@@ -26,6 +29,7 @@ class Announcement:
 
     @property
     def path(self) -> str:
+        """The path this broadcast is announced at."""
         return self._inner.path()
 
     @property
@@ -41,7 +45,11 @@ class Announcement:
 
 
 class Announced:
-    """Wraps MoqAnnounced as an async iterator of Announcement."""
+    """Async-iterable stream of :class:`Announcement` broadcasts as they appear.
+
+    Usable as an async context manager; iterate with ``async for`` and it keeps
+    yielding new broadcasts until cancelled.
+    """
 
     def __init__(self, inner: MoqAnnounced) -> None:
         self._inner = inner
@@ -62,11 +70,16 @@ class Announced:
         return Announcement(result)
 
     def cancel(self) -> None:
+        """Stop iterating and release the underlying announcement stream."""
         self._inner.cancel()
 
 
 class AnnouncedBroadcast:
-    """Wraps MoqAnnouncedBroadcast, awaitable for a specific broadcast."""
+    """Awaitable that resolves when the broadcast at a specific path is announced.
+
+    ``await`` it (or call :meth:`available`) to get the :class:`BroadcastConsumer`
+    once the broadcast becomes available. Usable as an async context manager.
+    """
 
     def __init__(self, inner: MoqAnnouncedBroadcast) -> None:
         self._inner = inner
@@ -78,12 +91,14 @@ class AnnouncedBroadcast:
         self.cancel()
 
     async def available(self) -> BroadcastConsumer:
+        """Await the broadcast becoming available and return its consumer."""
         return BroadcastConsumer(await self._inner.available())
 
     def __await__(self):
         return self.available().__await__()
 
     def cancel(self) -> None:
+        """Stop waiting for the broadcast and release the underlying handle."""
         self._inner.cancel()
 
 
@@ -120,22 +135,31 @@ class OriginDynamic:
         return await self.requested_broadcast()
 
     async def requested_broadcast(self) -> BroadcastRequest:
+        """Await the next broadcast a consumer requested but that isn't published yet."""
         return BroadcastRequest(await self._inner.requested_broadcast())
 
     def cancel(self) -> None:
+        """Stop serving dynamic requests and release the underlying handle."""
         self._inner.cancel()
 
 
 class OriginConsumer:
-    """Wraps MoqOriginConsumer for discovering broadcasts."""
+    """The discovery side of an origin: find and subscribe to broadcasts.
+
+    Iterate :meth:`announced` to watch broadcasts appear, await
+    :meth:`announced_broadcast` for a specific path, or :meth:`request_broadcast`
+    to resolve one as soon as it can be served.
+    """
 
     def __init__(self, inner: MoqOriginConsumer) -> None:
         self._inner = inner
 
     def announced(self, prefix: str = "") -> Announced:
+        """Async-iterate broadcasts announced under ``prefix`` (empty matches all)."""
         return Announced(self._inner.announced(prefix))
 
     def announced_broadcast(self, path: str) -> AnnouncedBroadcast:
+        """Await announcement of the broadcast at exactly ``path``."""
         return AnnouncedBroadcast(self._inner.announced_broadcast(path))
 
     async def request_broadcast(self, path: str) -> BroadcastConsumer:
@@ -150,7 +174,11 @@ class OriginConsumer:
 
 
 class OriginProducer:
-    """Wraps MoqOriginProducer for publishing broadcasts."""
+    """The publishing side of an origin: announce broadcasts for consumers to discover.
+
+    Call :meth:`create_broadcast` to publish at a path, :meth:`consume` for a
+    matching :class:`OriginConsumer`, or :meth:`dynamic` to serve on-demand requests.
+    """
 
     def __init__(self, *, cache_capacity_bytes: int | None = None) -> None:
         self._inner = MoqOriginProducer(MoqOriginOptions(cache_capacity_bytes=cache_capacity_bytes))
@@ -163,6 +191,7 @@ class OriginProducer:
         return self
 
     def consume(self) -> OriginConsumer:
+        """Create a consumer that discovers the broadcasts this origin publishes."""
         return OriginConsumer(self._inner.consume())
 
     def dynamic(self) -> OriginDynamic:

--- a/py/moq-rs/moq/publish.py
+++ b/py/moq-rs/moq/publish.py
@@ -34,7 +34,11 @@ def _media_init(format: str, init: bytes, video: VideoHint | None) -> MoqInit:
 
 
 class MediaProducer:
-    """Wraps MoqMediaProducer with a cleaner interface."""
+    """Publish encoded media frames on a single track, one payload at a time.
+
+    Built via :meth:`BroadcastProducer.publish_media`. Push each encoded frame
+    with :meth:`write_frame`, then :meth:`finish` when the stream ends.
+    """
 
     def __init__(self, inner: MoqMediaProducer) -> None:
         self._inner = inner
@@ -53,9 +57,11 @@ class MediaProducer:
         await self._inner.unused()
 
     def write_frame(self, payload: bytes, timestamp_us: int = 0) -> None:
+        """Write one encoded frame with a presentation timestamp in microseconds."""
         self._inner.write_frame(Frame(payload=payload, timestamp_us=timestamp_us))
 
     def finish(self) -> None:
+        """Finish publishing and flush a clean end to subscribers."""
         self._inner.finish()
 
 
@@ -76,6 +82,7 @@ class MediaStreamProducer:
         self._inner.write(payload)
 
     def finish(self) -> None:
+        """Finish publishing and flush a clean end to subscribers."""
         self._inner.finish()
 
 
@@ -101,6 +108,7 @@ class GroupProducer:
         self._inner.write_frame(Frame(payload=payload, timestamp_us=timestamp_us))
 
     def finish(self) -> None:
+        """Close this group cleanly, marking it complete for subscribers."""
         self._inner.finish()
 
     def abort(self, error_code: int) -> None:
@@ -168,6 +176,7 @@ class TrackProducer:
         self._inner.abort(error_code)
 
     def finish(self) -> None:
+        """Finish publishing and flush a clean end to subscribers."""
         self._inner.finish()
 
     def finish_at(self, final_sequence: int) -> None:
@@ -328,9 +337,11 @@ class BroadcastDynamic:
         return await self.requested_track()
 
     async def requested_track(self) -> TrackRequest:
+        """Await the next track a subscriber requested but that isn't published yet."""
         return TrackRequest(await self._inner.requested_track())
 
     def cancel(self) -> None:
+        """Stop accepting track requests and release the underlying handle."""
         self._inner.cancel()
 
 
@@ -475,4 +486,5 @@ class BroadcastProducer:
         return BroadcastConsumer(self._inner.consume())
 
     def finish(self) -> None:
+        """Finish the broadcast, closing its tracks and unpublishing it."""
         self._inner.finish()

--- a/py/moq-rs/moq/server.py
+++ b/py/moq-rs/moq/server.py
@@ -12,6 +12,7 @@ from .origin import OriginProducer
 from .publish import BroadcastProducer
 from .session import Session
 
+# The wire transport carrying a session: raw QUIC, iroh's peer-to-peer QUIC, or WebSocket.
 Transport = Literal["quic", "iroh", "websocket"]
 
 
@@ -30,10 +31,12 @@ class Request:
 
     @property
     def url(self) -> str | None:
+        """The URL the client connected to, or `None` if the transport carries none."""
         return self._inner.url()
 
     @property
     def transport(self) -> Transport:
+        """The wire transport carrying this session (`"quic"`, `"iroh"`, or `"websocket"`)."""
         return self._inner.transport()  # type: ignore[return-value]
 
     def set_publish(self, origin: OriginProducer | None) -> None:
@@ -71,13 +74,13 @@ class Request:
 class Server:
     """High-level MoQ server with automatic origin wiring.
 
-    In simple mode (no origin provided), creates an internal origin automatically:
+    In simple mode (no origin provided), creates an internal origin automatically::
 
         async with Server("127.0.0.1:4443", tls_generate=["localhost"]) as server:
             broadcast = server.create_broadcast("live")
             await server.serve()
 
-    Or hand-roll the accept loop if you need per-request control:
+    Or hand-roll the accept loop if you need per-request control::
 
         async with Server("127.0.0.1:4443", tls_generate=["localhost"]) as server:
             async for request in server:
@@ -90,7 +93,7 @@ class Server:
     close in-flight sessions; those stay alive until their handles are
     dropped or `Session.cancel()` is called.
 
-    In advanced mode, provide your own origins for full control:
+    In advanced mode, provide your own origins for full control::
 
         origin = OriginProducer()
         server = Server(

--- a/py/moq-rs/moq/session.py
+++ b/py/moq-rs/moq/session.py
@@ -12,7 +12,7 @@ class Session:
     """An established MoQ connection, returned by `Client` and `Request.accept()`.
 
     Hold the session to keep the connection alive; dropping it closes the
-    connection. As an async context manager it shuts down gracefully on exit:
+    connection. As an async context manager it shuts down gracefully on exit::
 
         session = await request.accept()
         async with session:

--- a/py/moq-rs/moq/subscribe.py
+++ b/py/moq-rs/moq/subscribe.py
@@ -37,7 +37,11 @@ from .types import (
 
 
 class MediaConsumer:
-    """Wraps MoqMediaConsumer as an async iterator of MediaFrame."""
+    """Async-iterable stream of decoded :class:`MediaFrame` in decode order.
+
+    Built via :meth:`BroadcastConsumer.subscribe_media`. Iterate with ``async for``;
+    usable as an async context manager that cancels on exit.
+    """
 
     def __init__(self, inner: MoqMediaConsumer) -> None:
         self._inner = inner
@@ -58,6 +62,7 @@ class MediaConsumer:
         return frame
 
     def cancel(self) -> None:
+        """Cancel the subscription and stop delivering frames."""
         self._inner.cancel()
 
 
@@ -92,6 +97,7 @@ class GroupConsumer:
         return await self._inner.read_frame()
 
     def cancel(self) -> None:
+        """Cancel reading this group and stop delivering frames."""
         self._inner.cancel()
 
 
@@ -183,6 +189,7 @@ class TrackConsumer:
         self._inner.update(subscription)
 
     def cancel(self) -> None:
+        """Cancel the subscription and stop delivering groups."""
         self._inner.cancel()
 
 
@@ -213,6 +220,7 @@ class AudioConsumer:
         return frame
 
     def cancel(self) -> None:
+        """Cancel the subscription and stop delivering audio frames."""
         self._inner.cancel()
 
 
@@ -264,7 +272,11 @@ class JsonStreamConsumer:
 
 
 class CatalogConsumer:
-    """Wraps MoqCatalogConsumer as an async iterator of Catalog."""
+    """Async-iterable stream of :class:`Catalog` snapshots as the broadcast updates.
+
+    Built via :meth:`BroadcastConsumer.subscribe_catalog`. Each item is the latest
+    catalog describing the broadcast's tracks; usable as an async context manager.
+    """
 
     def __init__(self, inner: MoqCatalogConsumer) -> None:
         self._inner = inner
@@ -285,11 +297,16 @@ class CatalogConsumer:
         return catalog
 
     def cancel(self) -> None:
+        """Cancel the catalog subscription and stop delivering updates."""
         self._inner.cancel()
 
 
 class BroadcastConsumer:
-    """Wraps MoqBroadcastConsumer with convenience methods."""
+    """The consume side of one broadcast: subscribe to its tracks, catalog, and media.
+
+    Built by resolving an announcement or request. Read its :attr:`route`, then use
+    the ``subscribe_*`` / :meth:`fetch_group` methods to pull tracks and media.
+    """
 
     def __init__(self, inner: MoqBroadcastConsumer) -> None:
         self._inner = inner
@@ -316,6 +333,7 @@ class BroadcastConsumer:
         return await self._route_watch.next()
 
     async def subscribe_catalog(self) -> CatalogConsumer:
+        """Subscribe to the broadcast's catalog, async-iterating snapshots as it changes."""
         return CatalogConsumer(await self._inner.subscribe_catalog())
 
     async def subscribe_track(self, name: str, subscription: Subscription | None = None) -> TrackConsumer:

--- a/swift/.spi.yml
+++ b/swift/.spi.yml
@@ -1,0 +1,11 @@
+# Swift Package Index config. Tells SPI to build and host DocC documentation
+# for the `Moq` target (generated from the `///` doc comments in Sources/Moq),
+# served at https://swiftpackageindex.com/moq-dev/moq-swift/documentation.
+#
+# This file is copied into the published moq-dev/moq-swift mirror by
+# swift/scripts/package.sh, since SPI reads it from the package root.
+version: 1
+builder:
+  configs:
+    - documentation_targets:
+        - Moq

--- a/swift/Sources/Moq/Aliases.swift
+++ b/swift/Sources/Moq/Aliases.swift
@@ -44,7 +44,7 @@ public typealias Container = MoqFFI.MoqContainer
 /// A best-effort raw-track datagram as received: sequence, timestamp, and payload.
 public typealias Datagram = MoqFFI.MoqDatagram
 /// The route a broadcast takes to reach this origin: relay hop ids (oldest
-/// first) plus the publisher's advertised cost (lower wins).
+/// first), the publisher's advertised cost (lower wins), and whether it's announced.
 public typealias Route = MoqFFI.MoqRoute
 /// Per-subscription delivery preferences: priority, group ordering, latency
 /// budget, and group range.

--- a/swift/Sources/Moq/Aliases.swift
+++ b/swift/Sources/Moq/Aliases.swift
@@ -6,29 +6,53 @@ import MoqFFI
 // instead (see Client.swift, Broadcast.swift, etc.), so MoqFFI's `Moq`-prefixed
 // classes never appear in the public API.
 
+/// A payload plus the presentation timestamp it should play at. The unit of
+/// every raw write and raw read.
 public typealias Frame = MoqFFI.MoqFrame
 /// A frame plus the codec metadata a media track carries.
 public typealias MediaFrame = MoqFFI.MoqMediaFrame
+/// The JSON manifest describing a broadcast's tracks: video and audio
+/// renditions, display geometry, and untyped application sections.
 public typealias Catalog = MoqFFI.MoqCatalog
+/// A video rendition in the catalog: codec, coded/display dimensions, bitrate,
+/// framerate, and container.
 public typealias Video = MoqFFI.MoqVideo
 /// Caller-provided catalog fields for a video track.
 public typealias VideoHint = MoqFFI.MoqVideoHint
+/// An audio rendition in the catalog: codec, sample rate, channel count,
+/// bitrate, and container.
 public typealias Audio = MoqFFI.MoqAudio
+/// One raw-audio frame: PCM samples in the configured layout plus a
+/// presentation timestamp.
 public typealias AudioFrame = MoqFFI.MoqAudioFrame
+/// A width and height in pixels.
 public typealias Dimensions = MoqFFI.MoqDimensions
+/// The PCM layout (format, sample rate, channels) written to an `AudioProducer`.
 public typealias AudioEncoderInput = MoqFFI.MoqAudioEncoderInput
+/// The encoder-side config for a published audio track: codec, rate, channels,
+/// bitrate, and frame duration.
 public typealias AudioEncoderOutput = MoqFFI.MoqAudioEncoderOutput
+/// The PCM layout an `AudioConsumer` decodes to, plus its latency budget.
 public typealias AudioDecoderOutput = MoqFFI.MoqAudioDecoderOutput
+/// A raw PCM sample format, mirroring WebCodecs `AudioData.format`.
 public typealias AudioFormat = MoqFFI.MoqAudioFormat
+/// An audio codec identifier (e.g. Opus).
 public typealias AudioCodec = MoqFFI.MoqAudioCodec
+/// How a track's frames are packaged (Legacy, CMAF, or LOC), as advertised in
+/// the catalog.
 public typealias Container = MoqFFI.MoqContainer
+/// A best-effort raw-track datagram as received: sequence, timestamp, and payload.
 public typealias Datagram = MoqFFI.MoqDatagram
 /// The route a broadcast takes to reach this origin: relay hop ids (oldest
 /// first) plus the publisher's advertised cost (lower wins).
 public typealias Route = MoqFFI.MoqRoute
+/// Per-subscription delivery preferences: priority, group ordering, latency
+/// budget, and group range.
 public typealias Subscription = MoqFFI.MoqSubscription
 /// Options for fetching one complete group by sequence.
 public typealias FetchGroupOptions = MoqFFI.MoqFetchGroupOptions
+/// Publisher-side track properties: priority, group ordering, latency budget,
+/// and timescale.
 public typealias TrackInfo = MoqFFI.MoqTrackInfo
 
 /// A snapshot of connection statistics (RTT, bandwidth estimates, byte/packet

--- a/swift/Sources/Moq/Audio.swift
+++ b/swift/Sources/Moq/Audio.swift
@@ -3,6 +3,7 @@ import MoqFFI
 /// Read side of a raw-audio track. Iterating yields decoded PCM frames in the
 /// layout declared by the `AudioDecoderOutput` passed at subscribe time.
 public final class AudioConsumer: AsyncSequence, Sendable {
+    /// The decoded PCM audio frame emitted by this sequence.
     public typealias Element = AudioFrame
 
     let ffi: MoqAudioConsumer
@@ -21,6 +22,7 @@ public final class AudioConsumer: AsyncSequence, Sendable {
         ffi.cancel()
     }
 
+    /// Create an iterator that cancels native reads when iteration ends.
     public func makeAsyncIterator() -> AsyncThrowingStream<AudioFrame, Swift.Error>.Iterator {
         moqStream(cancel: { [ffi] in ffi.cancel() }) { [ffi] in
             try await ffi.next()

--- a/swift/Sources/Moq/Broadcast.swift
+++ b/swift/Sources/Moq/Broadcast.swift
@@ -92,6 +92,7 @@ public final class BroadcastConsumer: Sendable {
 /// route first, then every change, ending when the broadcast does. Created by
 /// `BroadcastConsumer.routeUpdates`.
 public final class RouteWatch: AsyncSequence, Sendable {
+    /// The route emitted by this sequence.
     public typealias Element = Route
 
     let ffi: MoqRouteWatch
@@ -111,6 +112,7 @@ public final class RouteWatch: AsyncSequence, Sendable {
         ffi.cancel()
     }
 
+    /// Create an iterator that cancels native reads when iteration ends.
     public func makeAsyncIterator() -> AsyncThrowingStream<Route, Swift.Error>.Iterator {
         moqStream(cancel: { [ffi] in ffi.cancel() }) { [ffi] in
             try await ffi.next()
@@ -126,6 +128,8 @@ public final class RouteWatch: AsyncSequence, Sendable {
 public final class BroadcastProducer: Sendable {
     let ffi: MoqBroadcastProducer
 
+    /// Create a standalone broadcast for serving dynamic requests or local
+    /// pub/sub. To publish at a path, use `OriginProducer.createBroadcast(path:)`.
     public init() throws {
         ffi = try MoqBroadcastProducer()
     }

--- a/swift/Sources/Moq/Client.swift
+++ b/swift/Sources/Moq/Client.swift
@@ -4,6 +4,7 @@ import MoqFFI
 public final class Client: Sendable {
     let ffi: MoqClient
 
+    /// Create a client with default settings, ready to configure and `connect(to:)`.
     public init() {
         ffi = MoqClient()
     }

--- a/swift/Sources/Moq/Dynamic.swift
+++ b/swift/Sources/Moq/Dynamic.swift
@@ -95,6 +95,7 @@ public final class TrackDynamic: AsyncSequence, Sendable {
 /// while such requests should be served; the sequence ends (throwing `Closed`)
 /// when the broadcast closes, and cancelling the consuming task stops serving.
 public final class BroadcastDynamic: AsyncSequence, Sendable {
+    /// The track request emitted by this sequence.
     public typealias Element = TrackRequest
 
     let ffi: MoqBroadcastDynamic
@@ -113,6 +114,7 @@ public final class BroadcastDynamic: AsyncSequence, Sendable {
         ffi.cancel()
     }
 
+    /// Create an iterator that cancels native waits when iteration ends.
     public func makeAsyncIterator() -> AsyncThrowingStream<TrackRequest, Swift.Error>.Iterator {
         moqStream(cancel: { [ffi] in ffi.cancel() }) { [ffi] in
             TrackRequest(try await ffi.requestedTrack())

--- a/swift/Sources/Moq/Json.swift
+++ b/swift/Sources/Moq/Json.swift
@@ -30,6 +30,7 @@ public final class JsonSnapshotProducer<Value: Encodable>: Sendable {
 /// Read side of a JSON snapshot track (lossy latest-value). Iterating yields the latest value,
 /// collapsing the backlog for a reader that has fallen behind: `for try await value in json { ... }`.
 public final class JsonSnapshotConsumer<Value: Decodable & Sendable>: AsyncSequence, Sendable {
+    /// The decoded snapshot value emitted by this sequence.
     public typealias Element = Value
 
     let ffi: MoqJsonSnapshotConsumer
@@ -49,6 +50,7 @@ public final class JsonSnapshotConsumer<Value: Decodable & Sendable>: AsyncSeque
         ffi.cancel()
     }
 
+    /// Create an iterator that cancels native reads when iteration ends.
     public func makeAsyncIterator() -> AsyncThrowingStream<Value, Swift.Error>.Iterator {
         moqStream(cancel: { [ffi] in ffi.cancel() }) { [self] in
             try await next()
@@ -83,6 +85,7 @@ public final class JsonStreamProducer<Value: Encodable>: Sendable {
 /// Read side of a JSON stream track (lossless append-log). Iterating yields every record in
 /// order: `for try await record in json { ... }`.
 public final class JsonStreamConsumer<Value: Decodable & Sendable>: AsyncSequence, Sendable {
+    /// The decoded stream record emitted by this sequence.
     public typealias Element = Value
 
     let ffi: MoqJsonStreamConsumer
@@ -102,6 +105,7 @@ public final class JsonStreamConsumer<Value: Decodable & Sendable>: AsyncSequenc
         ffi.cancel()
     }
 
+    /// Create an iterator that cancels native reads when iteration ends.
     public func makeAsyncIterator() -> AsyncThrowingStream<Value, Swift.Error>.Iterator {
         moqStream(cancel: { [ffi] in ffi.cancel() }) { [self] in
             try await next()

--- a/swift/Sources/Moq/Media.swift
+++ b/swift/Sources/Moq/Media.swift
@@ -4,6 +4,7 @@ import MoqFFI
 /// Read side of a broadcast's catalog. Iterating yields catalog updates as the
 /// set of tracks changes.
 public final class CatalogConsumer: AsyncSequence, Sendable {
+    /// The catalog update emitted by this sequence.
     public typealias Element = Catalog
 
     let ffi: MoqCatalogConsumer
@@ -22,6 +23,7 @@ public final class CatalogConsumer: AsyncSequence, Sendable {
         ffi.cancel()
     }
 
+    /// Create an iterator that cancels native reads when iteration ends.
     public func makeAsyncIterator() -> AsyncThrowingStream<Catalog, Swift.Error>.Iterator {
         moqStream(cancel: { [ffi] in ffi.cancel() }) { [ffi] in
             try await ffi.next()
@@ -31,6 +33,7 @@ public final class CatalogConsumer: AsyncSequence, Sendable {
 
 /// Read side of a media track. Iterating yields decoded frames in decode order.
 public final class MediaConsumer: AsyncSequence, Sendable {
+    /// The decoded media frame emitted by this sequence.
     public typealias Element = MediaFrame
 
     let ffi: MoqMediaConsumer
@@ -49,6 +52,7 @@ public final class MediaConsumer: AsyncSequence, Sendable {
         ffi.cancel()
     }
 
+    /// Create an iterator that cancels native reads when iteration ends.
     public func makeAsyncIterator() -> AsyncThrowingStream<MediaFrame, Swift.Error>.Iterator {
         moqStream(cancel: { [ffi] in ffi.cancel() }) { [ffi] in
             try await ffi.next()

--- a/swift/Sources/Moq/Origin.swift
+++ b/swift/Sources/Moq/Origin.swift
@@ -5,6 +5,8 @@ import MoqFFI
 public final class OriginProducer: Sendable {
     let ffi: MoqOriginProducer
 
+    /// Create a standalone origin, optionally capping its cache at `cacheCapacityBytes`
+    /// (nil uses the default capacity).
     public init(cacheCapacityBytes: UInt64? = nil) {
         ffi = MoqOriginProducer(options: MoqOriginOptions(cacheCapacityBytes: cacheCapacityBytes))
     }
@@ -63,6 +65,7 @@ public final class BroadcastRequest: Sendable {
 /// `for try await request in dynamic { ... }`. Hold this while missing
 /// broadcasts should be served; cancelling the consuming task stops serving.
 public final class OriginDynamic: AsyncSequence, Sendable {
+    /// The broadcast request emitted by this sequence.
     public typealias Element = BroadcastRequest
 
     let ffi: MoqOriginDynamic
@@ -81,6 +84,7 @@ public final class OriginDynamic: AsyncSequence, Sendable {
         ffi.cancel()
     }
 
+    /// Create an iterator that cancels native waits when iteration ends.
     public func makeAsyncIterator() -> AsyncThrowingStream<BroadcastRequest, Swift.Error>.Iterator {
         moqStream(cancel: { [ffi] in ffi.cancel() }) { [ffi] in
             BroadcastRequest(try await ffi.requestedBroadcast())
@@ -119,6 +123,7 @@ public final class OriginConsumer: Sendable {
 /// `for try await announcement in announced { ... }`. The sequence ends when the
 /// origin closes; cancelling the consuming task cancels the subscription.
 public final class Announced: AsyncSequence, Sendable {
+    /// The broadcast announcement emitted by this sequence.
     public typealias Element = Announcement
 
     let ffi: MoqAnnounced
@@ -137,6 +142,7 @@ public final class Announced: AsyncSequence, Sendable {
         ffi.cancel()
     }
 
+    /// Create an iterator that cancels native reads when iteration ends.
     public func makeAsyncIterator() -> AsyncThrowingStream<Announcement, Swift.Error>.Iterator {
         moqStream(cancel: { [ffi] in ffi.cancel() }) { [ffi] in
             (try await ffi.next()).map(Announcement.init)

--- a/swift/Sources/Moq/Server.swift
+++ b/swift/Sources/Moq/Server.swift
@@ -4,6 +4,7 @@ import MoqFFI
 public final class Server: Sendable {
     let ffi: MoqServer
 
+    /// Create a server with default settings, ready to configure and `listen()`.
     public init() {
         ffi = MoqServer()
     }

--- a/swift/Sources/Moq/Track.swift
+++ b/swift/Sources/Moq/Track.swift
@@ -4,6 +4,7 @@ import MoqFFI
 /// Read side of a raw track. Iterating yields groups in sequence order, skipping
 /// forward if the reader falls behind: `for try await group in track { ... }`.
 public final class TrackConsumer: AsyncSequence, Sendable {
+    /// The group emitted by this sequence, in sequence order.
     public typealias Element = GroupConsumer
 
     let ffi: MoqTrackConsumer
@@ -66,6 +67,7 @@ public final class TrackConsumer: AsyncSequence, Sendable {
         }
     }
 
+    /// Create an iterator that cancels native reads when iteration ends.
     public func makeAsyncIterator() -> AsyncThrowingStream<GroupConsumer, Swift.Error>.Iterator {
         moqStream(cancel: { [ffi] in ffi.cancel() }) { [ffi] in
             (try await ffi.nextGroup()).map(GroupConsumer.init)
@@ -75,6 +77,7 @@ public final class TrackConsumer: AsyncSequence, Sendable {
 
 /// Read side of a single group. Iterating yields timestamped raw frames.
 public final class GroupConsumer: AsyncSequence, Sendable {
+    /// The timestamped frame emitted by this sequence.
     public typealias Element = Frame
 
     let ffi: MoqGroupConsumer
@@ -98,6 +101,7 @@ public final class GroupConsumer: AsyncSequence, Sendable {
         ffi.cancel()
     }
 
+    /// Create an iterator that cancels native reads when iteration ends.
     public func makeAsyncIterator() -> AsyncThrowingStream<Frame, Swift.Error>.Iterator {
         moqStream(cancel: { [ffi] in ffi.cancel() }) { [ffi] in
             try await ffi.readFrame()

--- a/swift/scripts/package.sh
+++ b/swift/scripts/package.sh
@@ -100,6 +100,10 @@ mkdir -p "$PKG_STAGE/Sources/Moq" "$PKG_STAGE/Tests/MoqTests"
 cp -R "$SWIFT_DIR/Sources/Moq/." "$PKG_STAGE/Sources/Moq/"
 cp -R "$SWIFT_DIR/Tests/MoqTests/." "$PKG_STAGE/Tests/MoqTests/"
 
+# Swift Package Index reads .spi.yml from the package root to build and host the
+# DocC docs. Ship it in the mirror so SPI documents the tagged release.
+cp "$SWIFT_DIR/.spi.yml" "$PKG_STAGE/.spi.yml"
+
 # Dual-license files lifted from the workspace root so the mirror isn't
 # licenseless. Both files are required by the MIT OR Apache-2.0 grant.
 for license in LICENSE-MIT LICENSE-APACHE; do


### PR DESCRIPTION
## What

Two things for the four FFI-wrapper languages (Go, Kotlin, Swift, Python):

1. **Complete public doc-comment coverage** so every exported symbol is documented (the CLAUDE.md rule, and the input every automated doc generator reads).
2. **Stand up an automated API-doc pipeline per language** and link it from the doc site, matching how the Rust/C pages link to docs.rs.

## Doc-comment coverage

Audited each wrapper for undocumented public symbols and filled the gaps:

| Language | Added |
|---|---|
| Go | 55 grouped `type`/`const`/`var` members (`types.go`, `errors.go`, `server.go`) |
| Kotlin | 41 `Aliases.kt` typealiases + the two `close()` overrides |
| Swift | 15 `Aliases.swift` typealiases, 4 public initializers, and the `AsyncSequence` `Element`/`makeAsyncIterator()` members on every consumer |
| Python | 28 methods/properties + 9 fleshed-out class docstrings |

Descriptions were grounded in the actual FFI type roles (`rs/moq-ffi/src/*`), not boilerplate. No em dashes.

## Automated API-doc hosts

Each `doc/lib/{go,kt,swift,py}` page now links its language's generated reference:

- **Go → [pkg.go.dev](https://pkg.go.dev/github.com/moq-dev/moq-go)** — already live and automatic; just linked (badge + See also). The cgo `-ffi` module doesn't render there (its build fails on pkg.go.dev's servers), so `moq` is the documented surface.
- **Kotlin → [javadoc.io](https://javadoc.io/doc/dev.moq/moq)** — the published javadoc jar was empty (no Dokka). Applied the Dokka plugin and configured vanniktech to bundle its HTML as the Maven Central javadoc jar, which javadoc.io mirrors. Takes effect on the next `dev.moq:moq` release.
- **Swift → [Swift Package Index (DocC)](https://swiftpackageindex.com/moq-dev/moq-swift/documentation/moq)** — added `.spi.yml` (`documentation_targets: [Moq]`), copied into the published mirror by `package.sh`, so SPI builds and hosts DocC from the `///` comments.
- **Python → [Read the Docs](https://moq-rs.readthedocs.io)** — new Sphinx config (`py/moq-rs/docs/`) + root `.readthedocs.yaml`. The `moq` wrapper is pure Python, so `autodoc_mock_imports=["moq_ffi"]` documents it with **no Rust build**. Added a `just py docs` recipe (Sphinx, furo theme) wired into `py … ci` as a regression gate.

## Verification

- **Python docs**: built locally with `just py docs` — clean, zero warnings, 57 API pages. Autosummary stubs are gitignored (regenerated each build). `ruff` passes.
- **Go**: `gofmt` clean on all edited files.
- **VitePress doc site**: `bun run build` succeeds — the 9 edited pages have no broken links.
- **Kotlin**: the Dokka javadoc jar is exercised by the existing `release-kt-lib.yml` PR dry-run (`publishToMavenLocal`), so CI validates the wiring. Not built in this sandbox (no Android SDK).
- **Swift**: `.spi.yml` is static config validated by SPI remotely (no `swift` toolchain in the sandbox).

## One-time maintainer setup (outside this repo)

The hosts that auto-build from a registered project need a one-time enable:
- **Read the Docs**: import the `moq-rs` project at readthedocs.org (points at the root `.readthedocs.yaml`).
- **Swift Package Index**: ensure `moq-dev/moq-swift` is in the SPI package list so it picks up `.spi.yml`.

Both links go live once those are done and a release runs; nothing here breaks in the meantime.

## Cross-package sync

No wire, `moq-ffi`, catalog, or public-API **signature** changes — this is additive documentation plus doc-build tooling, so no draft or paired-package updates apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0164fGBSG45XRxikxfwafKMu)_