### PR TITLE
feat(moq-mux,moq-boy): mark discontinuities, and never time a sample across one

### DIFF
--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -231,6 +231,18 @@ impl<E: CatalogExt> Producer<E> {
 		Ok(())
 	}
 
+	/// Mark a break in the published timeline: whatever is published next does not continue
+	/// what came before.
+	///
+	/// Call this when capture stops rather than merely gapping between packets -- going idle,
+	/// switching source, anything that resumes on a re-anchored epoch (see
+	/// [`reset_epoch`](Self::reset_epoch)). See
+	/// [`Producer::discontinuity`](moq_mux::container::Producer::discontinuity).
+	pub fn discontinuity(&mut self) -> Result<(), Error> {
+		self.track.discontinuity()?;
+		Ok(())
+	}
+
 	/// Flush any pending samples (zero-padded to a full frame) and finalize the
 	/// track.
 	pub fn finish(mut self) -> Result<(), Error> {

--- a/rs/moq-boy/src/audio.rs
+++ b/rs/moq-boy/src/audio.rs
@@ -48,6 +48,14 @@ impl AudioEncoder {
 		self.producer.reset_epoch();
 	}
 
+	/// Publish an empty group marking the pause, so the gap the re-anchored epoch is about
+	/// to open reads as a break rather than one very long packet.
+	pub fn discontinuity(&mut self) {
+		if let Err(e) = self.producer.discontinuity() {
+			tracing::warn!(error = %e, "failed to mark the audio discontinuity");
+		}
+	}
+
 	/// Push interleaved signed-16-bit stereo PCM captured at `elapsed` (since
 	/// the emulator started, shared with the video clock).
 	pub fn push_samples(&mut self, samples: &[i16], elapsed: Duration) -> Result<()> {

--- a/rs/moq-boy/src/audio.rs
+++ b/rs/moq-boy/src/audio.rs
@@ -50,10 +50,9 @@ impl AudioEncoder {
 
 	/// Publish an empty group marking the pause, so the gap the re-anchored epoch is about
 	/// to open reads as a break rather than one very long packet.
-	pub fn discontinuity(&mut self) {
-		if let Err(e) = self.producer.discontinuity() {
-			tracing::warn!(error = %e, "failed to mark the audio discontinuity");
-		}
+	pub fn discontinuity(&mut self) -> Result<()> {
+		self.producer.discontinuity()?;
+		Ok(())
 	}
 
 	/// Push interleaved signed-16-bit stereo PCM captured at `elapsed` (since

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -330,6 +330,16 @@ fn run_emulator(
 	loop {
 		// Block when no viewers are watching. See state diagram in module docs.
 		if session.paused.load(Ordering::Acquire) {
+			// Mark the break BEFORE parking, not after resuming. Our PTS is the emulator
+			// clock, which keeps running while we sleep, so the next frame lands however
+			// long the pause was into the future. Published as an empty group that gap
+			// reads as a discontinuity rather than one enormous frame duration, and the
+			// marker becomes the live edge -- so a viewer arriving mid-pause waits for real
+			// media instead of being served the pre-pause group as if it were live
+			// (moq-dev/moq.pro#814).
+			session.video_encoder.discontinuity();
+			audio_encoder.discontinuity();
+
 			session.wait_for_resume();
 
 			// Don't try to catch up after a pause.

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -338,7 +338,7 @@ fn run_emulator(
 			// media instead of being served the pre-pause group as if it were live
 			// (moq-dev/moq.pro#814).
 			session.video_encoder.discontinuity();
-			audio_encoder.discontinuity();
+			audio_encoder.discontinuity()?;
 
 			session.wait_for_resume();
 

--- a/rs/moq-boy/src/video.rs
+++ b/rs/moq-boy/src/video.rs
@@ -27,9 +27,14 @@ pub struct VideoEncoder {
 	_thread: std::thread::JoinHandle<()>,
 }
 
-struct EncoderMsg {
-	rgba: Bytes,
-	ts: hang::container::Timestamp,
+enum EncoderMsg {
+	Frame {
+		rgba: Bytes,
+		ts: hang::container::Timestamp,
+	},
+	/// Publish the pause marker. Goes down the same channel as the frames so it lands
+	/// after the last one encoded, not racing ahead of it.
+	Discontinuity,
 }
 
 impl VideoEncoder {
@@ -60,8 +65,20 @@ impl VideoEncoder {
 	/// Send a frame to the encoder. Non-blocking: drops the frame if the
 	/// channel is full (capacity=4) to keep latency low.
 	pub fn try_frame(&self, rgba: Bytes, ts: hang::container::Timestamp) {
-		if self.tx.try_send(EncoderMsg { rgba, ts }).is_err() {
+		if self.tx.try_send(EncoderMsg::Frame { rgba, ts }).is_err() {
 			tracing::warn!("video frame dropped: encoder backpressure");
+		}
+	}
+
+	/// Publish an empty group marking a pause, so the PTS jump on resume reads as a break
+	/// rather than one very long frame, and a viewer arriving mid-pause isn't served the
+	/// pre-pause group as if it were live.
+	///
+	/// Blocks rather than dropping on a full channel: a dropped frame costs one frame, a
+	/// dropped marker silently reinstates the bug it exists to prevent.
+	pub fn discontinuity(&self) {
+		if self.tx.blocking_send(EncoderMsg::Discontinuity).is_err() {
+			tracing::warn!("video discontinuity dropped: encoder gone");
 		}
 	}
 
@@ -86,6 +103,16 @@ fn encoder_thread(
 	let mut encoder: Option<moq_video::encode::Encoder> = None;
 
 	while let Some(msg) = rx.blocking_recv() {
+		let msg = match msg {
+			EncoderMsg::Frame { rgba, ts } => (rgba, ts),
+			EncoderMsg::Discontinuity => {
+				if let Err(e) = producer.discontinuity() {
+					tracing::warn!(error = %e, "failed to mark the video discontinuity");
+				}
+				continue;
+			}
+		};
+		let (rgba, ts) = msg;
 		let enc = match encoder.as_mut() {
 			Some(enc) => enc,
 			None => {
@@ -105,9 +132,9 @@ fn encoder_thread(
 
 		let keyframe = force_keyframe.swap(false, Ordering::AcqRel);
 		let start = Instant::now();
-		match enc.encode_rgba(&msg.rgba, moq_video::Size::new(WIDTH, HEIGHT), keyframe) {
+		match enc.encode_rgba(&rgba, moq_video::Size::new(WIDTH, HEIGHT), keyframe) {
 			Ok(packets) => {
-				if let Err(e) = producer.publish(packets, msg.ts) {
+				if let Err(e) = producer.publish(packets, ts) {
 					// Publish only fails once the track/broadcast is gone, which
 					// is terminal -- stop rather than flooding logs every frame.
 					tracing::error!(error = %e, "video publish failed; stopping encoder");

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -387,7 +387,10 @@ impl<E: CatalogExt, C: RenditionConfig<E>> Rendition<E, C> {
 
 	/// Record one frame (presentation timestamp + encoded size), auto-filling the jitter if the
 	/// config didn't provide it and the detected value changed.
-	pub fn record_frame(&mut self, ts: Timestamp, bytes: usize) {
+	///
+	/// Crate-internal: the codec importers feed the catalog's bitrate/jitter estimator as they
+	/// publish. Not a knob for external callers.
+	pub(crate) fn record_frame(&mut self, ts: Timestamp, bytes: usize) {
 		if self.metrics.record_frame(ts, bytes).is_some() && self.supplied.jitter.is_none() {
 			self.refresh();
 		}
@@ -395,7 +398,7 @@ impl<E: CatalogExt, C: RenditionConfig<E>> Rendition<E, C> {
 
 	/// Record a frame's reorder delay (`PTS - DTS`), auto-filling the jitter as for
 	/// [`record_frame`](Self::record_frame).
-	pub fn record_reorder(&mut self, reorder: Timestamp) {
+	pub(crate) fn record_reorder(&mut self, reorder: Timestamp) {
 		if self.metrics.record_reorder(reorder).is_some() && self.supplied.jitter.is_none() {
 			self.refresh();
 		}
@@ -403,7 +406,7 @@ impl<E: CatalogExt, C: RenditionConfig<E>> Rendition<E, C> {
 
 	/// Close the current group (`next` is its end timestamp when known), auto-filling the bitrate
 	/// if the config didn't provide it and the detected maximum rose.
-	pub fn record_group_end(&mut self, next: Option<Timestamp>) {
+	pub(crate) fn record_group_end(&mut self, next: Option<Timestamp>) {
 		if self.metrics.finish_group(next).is_some() && self.supplied.bitrate.is_none() {
 			self.refresh();
 		}

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -152,6 +152,15 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Mark a break in the timeline by publishing an empty group. To bound the closing
+	/// group's final frame first, [`cut(end)`](Self::cut) before this. See
+	/// [`Producer::discontinuity`](crate::container::Producer::discontinuity).
+	pub fn discontinuity(&mut self) -> Result<()> {
+		self.rendition.record_group_end(None);
+		self.track.discontinuity()?;
+		Ok(())
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.rendition.record_group_end(None);

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -144,6 +144,15 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Mark a break in the timeline by publishing an empty group. To bound the closing
+	/// group's final frame first, [`cut(end)`](Self::cut) before this. See
+	/// [`Producer::discontinuity`](crate::container::Producer::discontinuity).
+	pub fn discontinuity(&mut self) -> Result<()> {
+		self.rendition.record_group_end(None);
+		self.track.discontinuity()?;
+		Ok(())
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.rendition.record_group_end(None);

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -70,6 +70,15 @@ impl<E: CatalogExt> Import<E> {
 		Ok(())
 	}
 
+	/// Mark a break in the timeline by publishing an empty group. To bound the closing
+	/// group's final frame first, [`cut(end)`](Self::cut) before this. See
+	/// [`Producer::discontinuity`](crate::container::Producer::discontinuity).
+	pub fn discontinuity(&mut self) -> crate::Result<()> {
+		self.rendition.record_group_end(None);
+		self.track.discontinuity()?;
+		Ok(())
+	}
+
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> crate::Result<()> {
 		self.rendition.record_group_end(None);

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -593,16 +593,7 @@ fn encode_fragment(track: &mut Fmp4Track, frames: Vec<Frame>) -> Result<Bytes> {
 
 /// Encode a buffered run and wrap it with the metadata a segmenting consumer needs.
 fn emit_fragment(track: &mut Fmp4Track, mut frames: Vec<Frame>, successor: Option<&Frame>) -> Result<Fragment> {
-	// Opus packets carry their duration in the TOC byte (at 48 kHz), so
-	// duration-less frames get their real duration instead of the fallback.
-	if track.opus {
-		for frame in &mut frames {
-			if frame.duration.is_none() {
-				frame.duration = crate::codec::opus::packet_samples(&frame.payload)
-					.and_then(|samples| Timestamp::from_scale(samples as u64, 48_000).ok());
-			}
-		}
-	}
+	apply_codec_durations(&mut frames, track.opus);
 	// Audio has no keyframes, so every audio fragment is independent; video is
 	// independent only when its buffer opened on a keyframe (a GOP boundary).
 	let independent = !track.is_video || track.buffer_independent;
@@ -647,6 +638,46 @@ fn fragment_seconds(frames: &[Frame], default_frame: Duration) -> f64 {
 	((max - min) + default_frame).as_secs_f64()
 }
 
+/// Fill in the durations the codec states outright, before anything has to be inferred
+/// from a neighbouring frame.
+///
+/// Opus packets carry their duration in the TOC byte (at 48 kHz), so an Opus track never
+/// has to look at its neighbours at all -- which matters most at a group boundary, where
+/// the neighbour is off limits (see [`infer_missing_durations`]) and the fallback would
+/// otherwise mis-time every packet of a one-packet-per-group audio track.
+pub(crate) fn apply_codec_durations(frames: &mut [Frame], opus: bool) {
+	if !opus {
+		return;
+	}
+	for frame in frames {
+		if frame.duration.is_none() {
+			frame.duration = crate::codec::opus::packet_samples(&frame.payload)
+				.and_then(|samples| Timestamp::from_scale(samples as u64, 48_000).ok());
+		}
+	}
+}
+
+/// Fill in the duration of every remaining frame from the timestamp of the frame that
+/// follows it, as long as that frame is in the same group.
+///
+/// The gap between two frames is only a duration while they sit on one continuous
+/// timeline, and a group boundary is where that stops holding. Groups are independently
+/// decodable, so a publisher may pause and resume across one (moq-boy keeps its PTS on a
+/// clock that runs through the pause), a subscriber may join mid-stream or skip to a
+/// newer group, and a fetch may span a hole. Consecutive sequence numbers do not rule any
+/// of that out, so the gap across a boundary is treated as a discontinuity, never a
+/// duration. Reading it as one makes a single sample last as long as the gap: a recording
+/// that woke a paused publisher got a 2405 second video sample, whose `EXTINF` put the HLS
+/// video timeline 9620 seconds ahead of audio and stalled the player outright
+/// (moq-dev/moq.pro#814).
+///
+/// The last frame before a boundary falls back to `default_frame` (the catalog framerate /
+/// sample rate), which is what the gap works out to anyway on a continuous constant-rate
+/// source -- the two answers only diverge when there IS a gap.
+///
+/// The publisher is the one that actually knows where its group's content ends, and
+/// [`Producer::cut`](crate::container::Producer::cut) is how it says so: the durations it
+/// writes arrive already set and are left alone here.
 pub(crate) fn infer_missing_durations(
 	mut frames: Vec<Frame>,
 	successor: Option<&Frame>,
@@ -667,9 +698,9 @@ pub(crate) fn infer_missing_durations(
 		}
 
 		frames[i].duration = infer_from_pts
-			.then(|| next_timestamp(&frames, successor, i))
+			.then(|| duration_bound(&frames, successor, i))
 			.flatten()
-			.and_then(|timestamp| timestamp.checked_sub(frames[i].timestamp).ok())
+			.and_then(|next| next.timestamp.checked_sub(frames[i].timestamp).ok())
 			.filter(|duration| !duration.is_zero())
 			.or(fallback);
 	}
@@ -679,18 +710,25 @@ pub(crate) fn infer_missing_durations(
 
 fn pts_monotonic(frames: &[Frame], successor: Option<&Frame>) -> bool {
 	let frames_monotonic = frames.windows(2).all(|pair| pair[1].timestamp >= pair[0].timestamp);
-	let successor_monotonic = match (frames.last(), successor) {
+	// Only a successor we'd actually read from gets a say: one in the next group bounds
+	// nothing here, so a rewind across that boundary must not veto inference either.
+	let successor_monotonic = match (frames.last(), successor.filter(|next| !next.keyframe)) {
 		(Some(last), Some(successor)) => successor.timestamp >= last.timestamp,
 		_ => true,
 	};
 	frames_monotonic && successor_monotonic
 }
 
-fn next_timestamp(frames: &[Frame], successor: Option<&Frame>, index: usize) -> Option<Timestamp> {
-	frames
-		.get(index + 1)
-		.map(|next| next.timestamp)
-		.or_else(|| successor.map(|next| next.timestamp))
+/// The frame that bounds `frames[index]`'s duration, or `None` when the only candidate is
+/// in the next group.
+///
+/// Every group starts with a keyframe -- the wire may carry the flag, and
+/// [`Consumer`](crate::container::Consumer) asserts it on each group's first frame
+/// regardless -- so a keyframe is where a group boundary can be. Video only ever meets one
+/// as the successor (a keyframe flushes the fragment before it can be appended), but audio
+/// has no keyframe roll, so a boundary can also fall interior to `frames`; both land here.
+fn duration_bound<'a>(frames: &'a [Frame], successor: Option<&'a Frame>, index: usize) -> Option<&'a Frame> {
+	frames.get(index + 1).or(successor).filter(|next| !next.keyframe)
 }
 
 pub(crate) fn catalog_timescale_video(config: &VideoConfig) -> Result<u64> {
@@ -741,6 +779,15 @@ mod tests {
 		}
 	}
 
+	/// A frame that opens a group. Every group starts with a keyframe, so this is what
+	/// the far side of a group boundary looks like to `infer_missing_durations`.
+	fn group_start(timestamp_us: u64) -> Frame {
+		Frame {
+			keyframe: true,
+			..frame(timestamp_us, None)
+		}
+	}
+
 	#[test]
 	fn infer_missing_durations_uses_default_for_trailing_sample() {
 		let frames = infer_missing_durations(
@@ -770,6 +817,91 @@ mod tests {
 
 		assert_eq!(frames[0].duration, Some(ts(41_667)));
 		assert_eq!(fragment_seconds(&frames, Duration::from_millis(33)), 0.041667);
+	}
+
+	/// The regression for moq-dev/moq.pro#814: a subscriber that got a stale cached group
+	/// and then jumped to live sees a huge gap across the boundary. That gap is a
+	/// discontinuity, not a duration, so the frame before it must NOT swallow it -- it
+	/// takes `default_frame` and the fragment stays one frame long.
+	#[test]
+	fn infer_stops_at_a_group_boundary() {
+		let next_group = group_start(2_405_070_000);
+		let frames = infer_missing_durations(vec![frame(63_244, None)], Some(&next_group), Duration::from_millis(33));
+
+		assert_eq!(frames[0].duration, Some(ts(33_000)));
+		assert_eq!(fragment_seconds(&frames, Duration::from_millis(33)), 0.033);
+	}
+
+	/// Audio never rolls a fragment on a keyframe, so its buffer can span whole groups.
+	/// The boundary is then interior to `frames`, and bounds the frame before it just
+	/// the same.
+	#[test]
+	fn infer_stops_at_an_interior_group_boundary() {
+		let frames = infer_missing_durations(
+			vec![frame(0, None), frame(21_333, None), group_start(600_000_000)],
+			None,
+			Duration::from_millis(21),
+		);
+
+		assert_eq!(frames[0].duration, Some(ts(21_333)), "same group, real delta");
+		assert_eq!(frames[1].duration, Some(ts(21_000)), "bounded by the next group");
+		assert_eq!(frames[2].duration, Some(ts(21_000)), "nothing after it at all");
+	}
+
+	/// The duration cap splits a GOP across fragments, so the successor is a delta frame
+	/// in the SAME group. That one is a real bound and is still used.
+	#[test]
+	fn infer_crosses_a_mid_group_fragment_boundary() {
+		let successor = frame(83_334, None);
+		let frames = infer_missing_durations(vec![frame(41_667, None)], Some(&successor), Duration::from_millis(33));
+
+		assert_eq!(frames[0].duration, Some(ts(41_667)));
+	}
+
+	/// The HLS fetch origin concatenates a segment's groups, and for audio those are often
+	/// one packet each -- so EVERY packet sits at a boundary and none of them may be timed
+	/// by the next. Opus states its own duration, which is what keeps that exact instead of
+	/// dropping each packet onto the ~21.3 ms `1024/sample_rate` fallback.
+	#[test]
+	fn codec_durations_keep_one_packet_groups_exact() {
+		// 20 ms of 48 kHz stereo Opus: TOC config 15 (SILK/WB 20 ms), one frame.
+		let packet = Bytes::from_static(&[0x78, 0x00, 0x00, 0x00]);
+		let mut frames: Vec<Frame> = (0..3)
+			.map(|i| Frame {
+				payload: packet.clone(),
+				..group_start(i * 20_000)
+			})
+			.collect();
+
+		apply_codec_durations(&mut frames, true);
+		let frames = infer_missing_durations(frames, None, Duration::from_micros(21_333));
+
+		for f in &frames {
+			assert_eq!(
+				f.duration.unwrap().as_micros(),
+				20_000,
+				"TOC duration, not the fallback"
+			);
+		}
+	}
+
+	/// A rewind across a group boundary bounds nothing here, so it must not veto
+	/// inference for the frames that do have an in-group successor.
+	#[test]
+	fn infer_ignores_a_rewound_group_boundary() {
+		let next_group = group_start(0);
+		let frames = infer_missing_durations(
+			vec![frame(1_000_000, None), frame(1_033_000, None)],
+			Some(&next_group),
+			Duration::from_millis(50),
+		);
+
+		assert_eq!(
+			frames[0].duration,
+			Some(ts(33_000)),
+			"in-group delta survives the rewind"
+		);
+		assert_eq!(frames[1].duration, Some(ts(50_000)), "last in group falls back");
 	}
 
 	#[test]

--- a/rs/moq-mux/src/container/fmp4/muxer.rs
+++ b/rs/moq-mux/src/container/fmp4/muxer.rs
@@ -10,7 +10,9 @@ use crate::catalog::hang::Container as HangContainer;
 use crate::container::Frame;
 use crate::container::source::{VideoTransform, build_video_transform};
 
-use super::export::{catalog_timescale_audio, catalog_timescale_video, extract_init, infer_missing_durations};
+use super::export::{
+	apply_codec_durations, catalog_timescale_audio, catalog_timescale_video, extract_init, infer_missing_durations,
+};
 use super::{Error, synthesize_audio_trak, synthesize_video_trak};
 
 /// The single track id used by a muxer's init segment and fragments.
@@ -52,6 +54,8 @@ pub struct Muxer {
 	/// Fallback duration for frames that carry none (Legacy / LOC sources), derived from the
 	/// catalog framerate / sample rate.
 	default_frame: Duration,
+	/// True for Opus audio, whose packets state their own duration in the TOC byte.
+	opus: bool,
 }
 
 impl Muxer {
@@ -68,6 +72,7 @@ impl Muxer {
 			description: config.description.as_ref().filter(|b| !b.is_empty()).cloned(),
 			timescale: catalog_timescale_video(config)?,
 			default_frame: Duration::from_secs_f64(1.0 / framerate),
+			opus: false,
 			kind: Kind::Video(config.clone()),
 		})
 	}
@@ -82,6 +87,7 @@ impl Muxer {
 			timescale: catalog_timescale_audio(config)?,
 			// Fallback for a duration-less trailing sample (~1024 samples per frame).
 			default_frame: Duration::from_secs_f64(1024.0 / config.sample_rate.max(1) as f64),
+			opus: matches!(config.codec, hang::catalog::AudioCodec::Opus),
 			kind: Kind::Audio(config.clone()),
 		})
 	}
@@ -202,8 +208,14 @@ impl Muxer {
 	/// it came from. Frames without a duration get one inferred from the following frame's
 	/// timestamp (falling back to the catalog frame rate / sample rate), so multi-sample
 	/// fragments stay decodable. `sequence` is the moof sequence number, informative only.
+	///
+	/// `frames` may span several groups, and a sample is never timed by one in the next group
+	/// even so: consecutive sequence numbers say nothing about whether the publisher paused
+	/// across the boundary. See [`infer_missing_durations`].
 	pub fn fragment(&self, sequence: u32, frames: &[Frame]) -> crate::Result<Bytes> {
-		let frames = infer_missing_durations(frames.to_vec(), None, self.default_frame);
+		let mut frames = frames.to_vec();
+		apply_codec_durations(&mut frames, self.opus);
+		let frames = infer_missing_durations(frames, None, self.default_frame);
 		let timescale = moq_net::Timescale::new(self.timescale).map_err(Error::from)?;
 		Ok(super::encode_fragment(TRACK_ID, timescale, sequence, &frames)?)
 	}
@@ -265,34 +277,65 @@ mod tests {
 	}
 
 	// The HLS origin accumulates every group of a (multi-group) audio segment into ONE fragment,
-	// so per-sample durations are inferred from each frame's real successor. Only the final sample
-	// falls back to the codec frame duration. This is what keeps audio contiguous across the groups
-	// an audio timeline skips.
+	// and for audio those groups are often one packet each -- so every sample sits at a group
+	// boundary and none of them may borrow the next packet's timestamp (consecutive sequence
+	// numbers don't rule out a publisher pausing across the boundary). Opus stating its own
+	// duration is what keeps the whole run exact anyway, rather than dropping every packet onto
+	// the ~21.3 ms 1024/sample_rate fallback.
 	#[tokio::test]
-	async fn audio_fragment_infers_durations_from_successors() {
+	async fn audio_fragment_takes_durations_from_the_codec() {
 		use hang::catalog::AudioCodec;
 
-		// Opus at 48 kHz: default (fallback) frame duration is 1024/48000 = 21_333 us.
 		let config = AudioConfig::new(AudioCodec::Opus, 48_000, 2);
 		let muxer = Muxer::audio(&config).unwrap();
 
-		// Frames 20 ms apart, none carrying a duration (the Legacy audio wire), as if fetched from
-		// several one-packet groups and concatenated.
-		let frames: Vec<Frame> = (0..4).map(|i| frame(i * 20_000, true)).collect();
+		// 20 ms of 48 kHz Opus: TOC config 15 (SILK wideband, 20 ms), one frame per packet.
+		let packet = Bytes::from_static(&[0x78, 0x00, 0x00, 0x00]);
+		let frames: Vec<Frame> = (0..4)
+			.map(|i| Frame {
+				payload: packet.clone(),
+				..frame(i * 20_000, true)
+			})
+			.collect();
 		let fragment = muxer.fragment(0, &frames).unwrap();
 
 		let timescale = moq_net::Timescale::new(48_000).unwrap();
 		let decoded = super::super::decode(fragment, timescale).unwrap();
 		assert_eq!(decoded.len(), 4);
-		// Interior samples take the real 20 ms gap to their successor, not the codec fallback.
-		for f in &decoded[..3] {
-			assert_eq!(f.duration.unwrap().as_micros(), 20_000, "successor-derived duration");
+		for f in &decoded {
+			assert_eq!(
+				f.duration.unwrap().as_micros(),
+				20_000,
+				"TOC duration, not the fallback"
+			);
 		}
-		// Only the last sample (no successor) falls back to the ~21.3 ms Opus frame duration.
-		let last = decoded[3].duration.unwrap().as_micros();
-		assert!(
-			(21_000..21_400).contains(&last),
-			"last sample uses the codec fallback, got {last}"
-		);
+	}
+
+	// A group boundary is never a duration, even when the groups arrived consecutively: the
+	// publisher may have paused across it (moq-boy runs its PTS on a clock that keeps going
+	// while the encoder is off), which is what produced a 2405 second sample in
+	// moq-dev/moq.pro#814.
+	#[tokio::test]
+	async fn audio_fragment_does_not_absorb_a_pause() {
+		use hang::catalog::AudioCodec;
+
+		let config = AudioConfig::new(AudioCodec::Opus, 48_000, 2);
+		let muxer = Muxer::audio(&config).unwrap();
+
+		// Two one-packet groups either side of a 40 minute pause, fetched back to back.
+		let packet = Bytes::from_static(&[0x78, 0x00, 0x00, 0x00]);
+		let frames: Vec<Frame> = [63_244, 2_405_070_000]
+			.into_iter()
+			.map(|micros| Frame {
+				payload: packet.clone(),
+				..frame(micros, true)
+			})
+			.collect();
+		let fragment = muxer.fragment(0, &frames).unwrap();
+
+		let timescale = moq_net::Timescale::new(48_000).unwrap();
+		let decoded = super::super::decode(fragment, timescale).unwrap();
+		let first = decoded[0].duration.unwrap().as_micros();
+		assert_eq!(first, 20_000, "the pause is a discontinuity, not a 2405 second sample");
 	}
 }

--- a/rs/moq-mux/src/container/fmp4/muxer.rs
+++ b/rs/moq-mux/src/container/fmp4/muxer.rs
@@ -211,7 +211,7 @@ impl Muxer {
 	///
 	/// `frames` may span several groups, and a sample is never timed by one in the next group
 	/// even so: consecutive sequence numbers say nothing about whether the publisher paused
-	/// across the boundary. See [`infer_missing_durations`].
+	/// across the boundary.
 	pub fn fragment(&self, sequence: u32, frames: &[Frame]) -> crate::Result<Bytes> {
 		let mut frames = frames.to_vec();
 		apply_codec_durations(&mut frames, self.opus);

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -12,10 +12,12 @@ use super::{Container, Frame};
 /// closes the previous group (if any) and starts a new one. Writing a non-keyframe
 /// frame when no group is open is a protocol violation.
 ///
-/// [`cut`](Self::cut) closes the current group early; the next write
-/// must be a keyframe. This is useful for streams without inherent keyframes
-/// (e.g. audio) that mark every Nth frame as a keyframe but want to flush the
-/// current group immediately rather than waiting for the next keyframe to arrive.
+/// [`cut`](Self::cut) closes the current group early, ideally saying where its content
+/// ends; the next write must be a keyframe. Reach for it when the following keyframe won't
+/// supply that boundary in time, or for a stream without inherent keyframes (e.g. audio)
+/// that marks every Nth frame as one but wants to close the current group now.
+/// [`discontinuity`](Self::discontinuity) goes further and publishes an empty group, for
+/// when the timeline is about to jump rather than merely continue.
 ///
 /// ## Latency Buffering
 ///
@@ -175,10 +177,43 @@ impl<C: Container> Producer<C> {
 	/// Close the current group (if any) and open the next group at the given sequence.
 	///
 	/// The next [`write`](Self::write) must be a keyframe and will land in a group with
-	/// `sequence`. Useful for joining mid-stream or signalling a discontinuity.
+	/// `sequence`. Useful for joining mid-stream.
 	pub fn seek(&mut self, sequence: u64) -> Result<(), C::Error> {
 		self.cut(None)?;
 		self.pending_sequence = Some(sequence);
+		Ok(())
+	}
+
+	/// Publish an EMPTY group standing for a break in the timeline: content stopped, and
+	/// whatever comes next does not continue it.
+	///
+	/// Call this whenever the timeline is about to jump -- pausing an encoder, switching
+	/// source, resuming on a re-anchored clock. Without it a break is invisible: the next
+	/// group looks exactly like the one that would have followed, and a consumer bounding a
+	/// sample by the next group's first frame hands it the entire gap as its duration. That
+	/// produced a 2405 second video sample out of a publisher that had been paused 40 minutes
+	/// (moq-dev/moq.pro#814). Consecutive sequence numbers can't rule a pause out, so this
+	/// marker is the only thing that can say one happened.
+	///
+	/// It also fixes what a subscriber joining mid-break sees. A subscription starts at the
+	/// track's latest group, and creating this one advances that -- so a late joiner lands on
+	/// the marker and waits for real media, instead of being served the group from *before*
+	/// the break as though it were live.
+	///
+	/// Carries no timestamp on purpose: a break is a gap between two groups, so any single
+	/// timestamp is ambiguous about which side it belongs to. To bound the closing group's
+	/// final frame, [`cut(end)`](Self::cut) before calling this; the open group is closed
+	/// either way (an unbounded [`cut`](Self::cut) here is a no-op after yours).
+	///
+	/// The marker group carries no frames at all. Ending the closing group with an empty
+	/// frame at `end` is the eventual shape, once decoders are known to skip one.
+	pub fn discontinuity(&mut self) -> Result<(), C::Error> {
+		self.cut(None)?;
+		let mut group = match self.pending_sequence.take() {
+			Some(sequence) => self.inner.create_group(moq_net::group::Info { sequence })?,
+			None => self.inner.append_group()?,
+		};
+		group.finish()?;
 		Ok(())
 	}
 
@@ -296,6 +331,43 @@ mod tests {
 			groups.push(count);
 		}
 		groups
+	}
+
+	/// A discontinuity lands as its own empty group between the content either side, so a
+	/// consumer can see the break instead of inferring continuity from adjacent sequences.
+	#[tokio::test]
+	async fn discontinuity_publishes_an_empty_group() {
+		let track = track_producer("test", hang::container::track_info());
+		let consumer = track.subscribe(None);
+		let mut producer = Producer::new(track, Container::Legacy);
+
+		producer.write(frame(0, true)).unwrap();
+		producer.write(frame(10_000, false)).unwrap();
+		producer.discontinuity().unwrap();
+		// Resumed on a re-anchored clock, 40 minutes later.
+		producer.write(frame(2_405_070_000, true)).unwrap();
+		producer.finish().unwrap();
+
+		assert_eq!(collect_groups(consumer).await, vec![2, 0, 1]);
+	}
+
+	/// A subscription starts at the track's LATEST group, and the marker advances it even
+	/// though it carries nothing. So a subscriber arriving mid-break waits for real media
+	/// rather than being handed the pre-break group as if it were live -- which is how a
+	/// 40-minute-stale frame reached a VOD recording in moq-dev/moq.pro#814.
+	#[tokio::test]
+	async fn discontinuity_moves_the_live_edge_off_stale_content() {
+		let track = track_producer("test", hang::container::track_info());
+		let mut producer = Producer::new(track, Container::Legacy);
+
+		producer.write(frame(0, true)).unwrap();
+		let stale = producer.track().latest();
+
+		producer.discontinuity().unwrap();
+		let edge = producer.track().latest();
+
+		assert_ne!(edge, stale, "the empty group is the live edge now");
+		assert_eq!(edge, stale.map(|s| s + 1));
 	}
 
 	/// Explicit keyframe closes the current group and starts a new one.

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -103,6 +103,21 @@ impl Producer {
 		Ok(())
 	}
 
+	/// Mark a break in the published timeline: whatever is published next does not continue
+	/// what came before.
+	///
+	/// Call this when the encoder stops rather than merely pausing between frames -- a
+	/// capture that goes idle, a source switch, anything that will resume on a re-anchored
+	/// clock. See [`Producer::discontinuity`](moq_mux::container::Producer::discontinuity)
+	/// for what the marker buys a consumer.
+	pub fn discontinuity(&mut self) -> Result<(), Error> {
+		match &mut self.codecs {
+			Codecs::H264 { import, .. } => import.discontinuity()?,
+			Codecs::H265 { import, .. } => import.discontinuity()?,
+		}
+		Ok(())
+	}
+
 	/// Finalize the track.
 	///
 	/// Consumes the producer: nothing can be published after the track ends, so


### PR DESCRIPTION
## Summary

- A duration-less frame took its duration from the timestamp of whatever frame came next, **including one in a different group**. Groups are independently decodable, so the gap across a boundary is a discontinuity, not a duration; reading it as one makes a single sample last as long as the gap.
- Root cause of the report: `moq-boy` parks the emulator when nobody is watching, but its PTS is `start.elapsed()`, a clock that keeps running through the pause (the code says so: *"Re-anchor audio timestamps so the pause gap appears in PTS"*). It also ticks once at startup so the catalog gets codec config. A VOD recording that woke a box idle for 40 minutes therefore saw a warm-up frame at 63ms followed by the post-resume keyframe at 2405s, and emitted a video sample lasting **2405.05s**. Its `EXTINF` put the HLS video timeline 9620s ahead of audio, so hls.js picked a video position past the end of the audio playlist and stalled there forever, never buffering a byte. (moq-dev/moq.pro#814)
- The last frame before a boundary now falls back to `default_frame` from the catalog framerate / sample rate. On a continuous constant-rate source that is what the gap works out to anyway — the two answers only diverge when there *is* a gap. `base_dts` re-anchors on the real PTS every fragment, so a fallback that misses on a variable-rate source stays a local one-frame error rather than accumulating.
- This applies to the HLS fetch origin too, even though it walks a segment's groups in sequence and abandons the segment on the first missing one. **Consecutive sequence numbers say nothing about whether the publisher paused across the boundary**, so that path could reproduce the same sample. What it actually relied on was timing each one-packet audio group by the next packet; the Opus TOC fill-in that `emit_fragment` already did is now a shared `apply_codec_durations` step both callers run first, so those packets carry their real duration and never need a neighbour (otherwise every packet would drop onto the ~21.3ms `1024/sample_rate` fallback against real 20ms packets).
- `Producer::discontinuity()` makes a break visible: it publishes an **empty** group. A consumer can then see the break instead of inferring continuity from adjacent sequences, and — because a subscription starts at the latest group (`start_group.or_else(|| track.latest())`, and `max_sequence` advances on group *creation* regardless of frames) — a subscriber arriving mid-break lands on the marker and waits, instead of being served the pre-break group as though it were live. That is how the 40-minute-stale frame reached the recording in the first place.
- `discontinuity` takes no timestamp on purpose: a break is a gap between two groups, so any single timestamp is ambiguous about which side it belongs to. A caller that wants to bound the closing group's final frame calls `cut(end)` first. `moq-boy` marks the break **before parking**, not after resuming, so the marker is the live edge for the whole pause.

The marker carries no frames at all. Writing an empty frame to carry the group's end timestamp (the boundary `cut(end)` wants) is the eventual shape, once decoders are known to skip one; an empty *group* needs no such guarantee, since a consumer that ignores it just sees a group with nothing in it.

Publishers that know where a group's content ends should still say so with `Producer::cut(end)`; those durations arrive already set and are untouched.

## Public API changes

All additive, no renames/removals/signature changes to existing items:

- `moq_mux::container::Producer::discontinuity()`
- `moq_mux::codec::{h264,h265,opus}::Import::discontinuity()`
- `moq_video::encode::Producer::discontinuity()`
- `moq_audio::encode::Producer::discontinuity()`

Internal only (`pub(crate)`): `apply_codec_durations` added; `infer_missing_durations` / `pts_monotonic` behavior changed (signatures unchanged); `next_timestamp` renamed to `duration_bound`.

Removed from the public surface: `moq_mux::catalog::Rendition::{record_frame, record_reorder, record_group_end}` are now `pub(crate)`. They were `pub` but every caller is a codec importer inside the crate; no external consumer could meaningfully drive the catalog's private bitrate/jitter estimator, so this only sheds accidental surface.

Behavior change for existing callers: `Muxer::fragment` no longer times a sample by the next group's first frame. Its previous behavior is preserved for Opus via `apply_codec_durations`; other codecs get `default_frame` at a boundary instead of the cross-group delta.

## Test plan

- `cargo test -p moq-mux -p moq-hls -p moq-video -p moq-audio` — 427 / 49 / 48 / 18 pass.
- `cargo clippy` clean on those crates plus `moq-boy`, `--all-targets`.
- `cargo check --workspace --all-targets` clean.
- New tests, verified to fail without the fix — three of them reproduce the exact `Some(2405006756µs)` sample read out of the real recording's `trun`:
  - `infer_stops_at_a_group_boundary`, `infer_stops_at_an_interior_group_boundary` (audio buffers span groups; it has no keyframe roll), `infer_ignores_a_rewound_group_boundary`
  - `infer_crosses_a_mid_group_fragment_boundary` guards against over-applying it: a cap-flush successor in the same group is still used
  - `codec_durations_keep_one_packet_groups_exact`, `audio_fragment_takes_durations_from_the_codec`, `audio_fragment_does_not_absorb_a_pause`
  - `discontinuity_publishes_an_empty_group`, `discontinuity_moves_the_live_edge_off_stale_content`
- **Not run for real:** the `moq-boy` pause/resume path is compile- and unit-tested only; I have not driven an actual pause cycle to watch the empty group land on the wire.

(written by Opus 4.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
