### PR TITLE
fix(go-ffi): install cross target std before building moq-ffi

### DIFF
--- a/rs/moq-ffi/build.sh
+++ b/rs/moq-ffi/build.sh
@@ -120,6 +120,17 @@ build_target() {
         cargo ndk --target "$target" --platform 24 -- \
             build --release --package moq-ffi --manifest-path "$WORKSPACE_DIR/Cargo.toml"
     else
+        # Ensure the target's std is installed for the toolchain cargo actually
+        # resolves here. The release workflow's rust-toolchain action adds the
+        # target to `stable`, but the repo's channel-less rust-toolchain.toml
+        # makes cargo pick a different toolchain for this build, which then lacks
+        # the cross target's std -- cross builds die with E0463 "can't find crate
+        # for `std`" (e.g. building serde_core for aarch64). No-op once present,
+        # and for a host target; skipped when rustup isn't the toolchain manager.
+        if command -v rustup >/dev/null 2>&1; then
+            rustup target add "$target"
+        fi
+
         # Set up cross-compilation for Linux ARM64
         if [[ "$target" == "aarch64-unknown-linux-gnu" ]]; then
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc


### PR DESCRIPTION
## Problem

The ergonomic **`moq-go` wrapper (`v0.4.x`) has never published**. `go get github.com/moq-dev/moq-go@latest` still resolves the pre-split raw bindings at `v0.2.32`. The root cause is three levels down, in the FFI release chain:

1. **`rs/moq-ffi/build.sh` cross-builds `aarch64-unknown-linux-gnu` with the wrong toolchain's std.** `release-go-ffi.yml` uses `dtolnay/rust-toolchain@stable` with `targets: aarch64-unknown-linux-gnu`, which adds that std to the **`stable`** toolchain. But the repo's `rust-toolchain.toml` is **channel-less** (`components` only), so `build.sh`'s bare `cargo build` resolves a *different* effective toolchain — one without the cross target's std. The aarch64 leg dies with:

   ```
   error[E0463]: can't find crate for `std`
   error: could not compile `serde_core`
   ```

2. That failing leg **fails `release-go-ffi.yml`** on every FFI tag (`moq-ffi-v0.3.0` ❌, `moq-ffi-v0.3.1` ❌), so the **`moq-dev/moq-go-ffi` mirror has zero tags**.

3. **`release-go.yml` then can't publish the wrapper**: `require moq-go-ffi@v0.3.1` won't resolve, so it hits its gate — *"moq-go-ffi v0.3.1 not on the mirror yet; deferring"* — and skips. `v0.4.0` never gets minted.

## Fix

Run `rustup target add "$target"` before the cross `cargo build` in `build_target()`, so the target's std is present on the toolchain cargo actually resolves. It's a no-op once the target is installed (and for host targets), and is guarded behind `command -v rustup` so non-rustup environments (e.g. nix) are unaffected.

## Verification

- `bash -n rs/moq-ffi/build.sh` passes.
- Full validation is the CI matrix itself: once this merges, the next `moq-ffi-v*` tag should build all targets, populate the `moq-go-ffi` mirror, and let `release-go.yml` mint the ergonomic `moq-go v0.4.0`.

## Note for reviewers

This only unblocks the pipeline; it doesn't re-tag the already-failed `moq-ffi-v0.3.0`/`v0.3.1`. The next FFI release tag after merge will carry it through. If you want `v0.4.0` out immediately, re-run `release-go-ffi.yml` on the `moq-ffi-v0.3.1` tag after this lands.

(written by Opus 4.8)