### PR TITLE
fix(watch): re-anchor the audio buffer on a latency-floor increase

### DIFF
--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -240,14 +240,14 @@ export class Decoder {
 			this.#prevFloor = floor;
 			return;
 		}
+		// When the timer fires, the floor read above is still current: any change would have rerun
+		// this effect (tearing down the timer), so compare it against the pre-change baseline directly.
 		const baseline = this.#prevFloor;
-		const timer = setTimeout(() => {
-			const settled = latencyBounds(this.sync.in.latency.peek()).min;
+		effect.timer(() => {
 			const toMs = (b: Bound): number => (b === "real-time" ? 0 : b);
-			if (toMs(settled) > toMs(baseline)) this.reset();
-			this.#prevFloor = settled;
+			if (toMs(floor) > toMs(baseline)) this.reset();
+			this.#prevFloor = floor;
 		}, LATENCY_REANCHOR_DEBOUNCE_MS);
-		effect.cleanup(() => clearTimeout(timer));
 	}
 
 	#runDecoder(effect: Effect): void {

--- a/js/watch/src/audio/decoder.ts
+++ b/js/watch/src/audio/decoder.ts
@@ -6,12 +6,16 @@ import { Time } from "@moq/net";
 import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Signal } from "@moq/signals";
 import { base64ToBytes } from "../base64";
 
-import type { Sync } from "../sync";
+import { type Bound, latencyBounds, type Sync } from "../sync";
 import { type AudioBuffer, createAudioBuffer } from "./buffer";
 // Compiled and inlined as a blob URL via vite-plugin-worklet.
 import RenderWorklet from "./render-worklet.ts?worklet";
 import type { Source } from "./source";
 import { unlockOnGesture } from "./unlock";
+
+// How long the latency target must hold steady before a floor increase re-anchors. Coalesces a
+// slider drag (many small steps) into a single re-anchor once the user settles on a value.
+const LATENCY_REANCHOR_DEBOUNCE_MS = 150;
 
 export type DecoderInput = {
 	// Enable to download the audio track.
@@ -93,6 +97,10 @@ export class Decoder {
 	// would make the consumer's threshold NaN and skip every group.
 	#consumerLatency = new Signal<Time.Milli>(Time.Milli.zero);
 
+	// The latency floor as of the last settled change, to detect a floor *increase* (needs a deeper
+	// cushion) versus a decrease or a real-time RTT wiggle. See #runLatencyReanchor.
+	#prevFloor?: Bound;
+
 	#signals = new Effect();
 
 	constructor(source: Source, sync: Sync, props?: Inputs<DecoderInput>) {
@@ -110,6 +118,7 @@ export class Decoder {
 		this.#signals.run(this.#runWorklet.bind(this));
 		this.#signals.run(this.#runEnabled.bind(this));
 		this.#signals.run(this.#runLatency.bind(this));
+		this.#signals.run(this.#runLatencyReanchor.bind(this));
 		this.#signals.run(this.#runDecoder.bind(this));
 	}
 
@@ -214,6 +223,31 @@ export class Decoder {
 		const latency = effect.get(this.sync.out.buffer);
 		const latencySamples = Math.ceil(ring.rate * Time.Second.fromMilli(latency));
 		ring.setLatency(latencySamples);
+	}
+
+	// Re-anchor when the latency floor *increases*. A larger floor needs a deeper cushion: video
+	// rebuilds it implicitly (its per-frame sync.wait() reads the live buffer, so it just holds
+	// longer), but the audio ring keeps draining at its old depth -- resize() (via setLatency) only
+	// re-stalls an *empty* ring, so a mid-playback ring never refills to the new floor and audio runs
+	// ahead of video (the "raise latency, only video re-buffers" desync). reset() re-stalls the ring
+	// so it refills to the new floor. Watch the latency *target* (not the derived buffer) so real-time
+	// RTT jitter never triggers this, and debounce so a slider drag coalesces into one re-anchor.
+	// Decreases are left to natural catch-up.
+	#runLatencyReanchor(effect: Effect): void {
+		const floor = latencyBounds(effect.get(this.sync.in.latency)).min;
+		if (this.#prevFloor === undefined) {
+			// Startup: the initial fill already builds the cushion; just record the baseline.
+			this.#prevFloor = floor;
+			return;
+		}
+		const baseline = this.#prevFloor;
+		const timer = setTimeout(() => {
+			const settled = latencyBounds(this.sync.in.latency.peek()).min;
+			const toMs = (b: Bound): number => (b === "real-time" ? 0 : b);
+			if (toMs(settled) > toMs(baseline)) this.reset();
+			this.#prevFloor = settled;
+		}, LATENCY_REANCHOR_DEBOUNCE_MS);
+		effect.cleanup(() => clearTimeout(timer));
 	}
 
 	#runDecoder(effect: Effect): void {

--- a/js/watch/src/audio/ring-buffer.test.ts
+++ b/js/watch/src/audio/ring-buffer.test.ts
@@ -735,5 +735,12 @@ describe("latency increase re-anchor", () => {
 		// calls reset() on a latency-floor increase (#runLatencyReanchor) to re-anchor to the cushion.
 		buffer.reset();
 		expect(buffer.stalled).toBe(true);
+
+		// ...and it refills to the *new* 200-sample floor, not the old 100: still stalled at 199,
+		// un-stalls only once the 200th sample lands. This proves resize(200) moved the target.
+		write(buffer, 0 as Time.Milli, 199, { channels: 1, value: 1.0 });
+		expect(buffer.stalled).toBe(true);
+		write(buffer, 199 as Time.Milli, 1, { channels: 1, value: 1.0 });
+		expect(buffer.stalled).toBe(false);
 	});
 });

--- a/js/watch/src/audio/ring-buffer.test.ts
+++ b/js/watch/src/audio/ring-buffer.test.ts
@@ -715,3 +715,25 @@ describe("buffered mode", () => {
 		expect(read(buffer, 100, 1)[0][0]).toBeCloseTo(0.2, 5);
 	});
 });
+
+describe("latency increase re-anchor", () => {
+	it("resize() does not re-stall a mid-playback ring, but reset() does", () => {
+		const buffer = new AudioRingBuffer({ rate: 1000, channels: 1, latency: 100 as Time.Milli });
+
+		// Fill to the floor so playback starts (un-stalls), then play some samples.
+		write(buffer, 0 as Time.Milli, 100, { channels: 1, value: 1.0 });
+		expect(buffer.stalled).toBe(false);
+		read(buffer, 50, 1);
+
+		// Raising the latency floor grows the target but must NOT re-stall a ring mid-playback:
+		// resize() only re-stalls an empty ring, so it keeps draining at the old depth. This is
+		// exactly why setLatency() alone doesn't re-buffer -- the desync the Decoder re-anchor fixes.
+		buffer.resize(200 as Time.Milli);
+		expect(buffer.stalled).toBe(false);
+
+		// reset() re-stalls, so the ring refills to the (new) floor before playing again. The Decoder
+		// calls reset() on a latency-floor increase (#runLatencyReanchor) to re-anchor to the cushion.
+		buffer.reset();
+		expect(buffer.stalled).toBe(true);
+	});
+});


### PR DESCRIPTION
Raising the latency floor grew the buffer target (setLatency -> ring.resize), but a mid-playback audio ring keeps draining at its old depth: resize() only re-stalls an empty ring, so it never refills to the new floor. Only video rebuilt its cushion (its per-frame sync.wait() reads the live buffer and just holds longer), so audio ran ahead of video; at the default real-time (0ms) floor this surfaced as frequent audio glitches under network jitter.

Watch the latency target (debounced, so a slider drag coalesces) and reset() the audio ring on an increase, so it re-stalls and refills to the new floor. The target -- not the derived buffer -- is watched so real-time RTT jitter never triggers it; decreases are left to natural catch-up.

Adds a ring-buffer regression test: resize() does not re-stall a mid-playback ring, but reset() does.