### PR TITLE
fix(hang,watch): deliver non-sequential group ids incrementally

### DIFF
--- a/js/hang/src/container/consumer.nonsequential.test.ts
+++ b/js/hang/src/container/consumer.nonsequential.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test";
+import { Group, Time, Track, Varint } from "@moq/net";
+import { Consumer } from "./consumer.ts";
+import { Format as LegacyFormat } from "./legacy.ts";
+
+// Standalone from consumer.test.ts so it only pulls the Legacy format, not the CMAF decoder.
+
+function encodeLegacyFrame(timestamp: Time.Micro, payload: Uint8Array): Uint8Array {
+	const tsBytes = Varint.encode(timestamp);
+	const data = new Uint8Array(tsBytes.byteLength + payload.byteLength);
+	data.set(tsBytes, 0);
+	data.set(payload, tsBytes.byteLength);
+	return data;
+}
+
+test("Consumer waits on a non-sequential hang group because it has no per-frame duration", async () => {
+	// The Legacy (hang) container encodes only a timestamp per frame, no duration, so a group's
+	// presentation end is unknown until the next group arrives. With non-sequential group ids we
+	// therefore cannot prove the timeline is unbroken across a jump: a large id gap is
+	// indistinguishable from a real missing segment that may still be in transit. So the consumer
+	// waits (and lets #checkLatency / #tryDurationSkip decide once the latency budget or duration
+	// coverage proves the gap too old) rather than eagerly skipping ahead, which would drop an
+	// in-transit group and wreck audio.
+	//
+	// A hang group can only promote early once its end is known, e.g. via an end-of-group signal such
+	// as a trailing frame carrying the group's end timestamp. Until the container carries that, expect
+	// the wait. The CMAF path (per-sample duration in the moof) is covered in consumer.test.ts.
+	const track = new Track.Producer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 5000 as Time.Milli });
+
+	// Group A at a large sequence, completed so the cursor advances past it.
+	const a = new Group.Producer(1_000_000);
+	a.writeFrame({
+		payload: encodeLegacyFrame(0 as Time.Micro, new Uint8Array([0x01])),
+		timestamp: Time.Timestamp.now(),
+	});
+	a.close();
+	track.writeGroup(a);
+
+	// Drain A: its frame, then its group-done marker.
+	const firstFrame = await consumer.next();
+	expect(firstFrame?.frame?.payload).toEqual(new Uint8Array([0x01]));
+	await consumer.next();
+
+	// Park next() before the next group's frames arrive (the live streaming case).
+	const pending = consumer.next();
+
+	// Open group B at a large jump (+90_000, NOT +1) with a frame far past A's last PTS, and leave it
+	// open. Legacy has no duration, so A's end is unknown -- B could be continuous, or group 1_000_001
+	// could still be coming. We cannot tell, so B must NOT surface yet.
+	const b = new Group.Producer(1_090_000);
+	track.writeGroup(b);
+	b.writeFrame({
+		payload: encodeLegacyFrame(1_000_000 as Time.Micro, new Uint8Array([0x02])),
+		timestamp: Time.Timestamp.now(),
+	});
+
+	// Within the latency budget (5s), the parked next() stays parked: no duration means no proof of
+	// contiguity, so the consumer waits instead of eagerly delivering across the gap.
+	const result = await Promise.race([
+		pending,
+		new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 500)),
+	]);
+
+	expect(result).toBe("timeout");
+
+	consumer.close();
+});

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -594,3 +594,134 @@ test("Consumer does not duration-skip when the gap is not covered", async () => 
 	expect(frames.map((f) => f.group)).toEqual([0, 0, 1]);
 	consumer.close();
 });
+
+// --- Non-sequential group ids: PTS-timeline-gated incremental delivery (regression) ---
+
+// Group numbers may be non-sequential (large, non-+1 jumps). Delivery follows the PTS *timeline*,
+// not the numbering: a next group whose first frame continues where the active group ended must
+// surface immediately, even while still open.
+test("Consumer delivers a PTS-contiguous next group whose sequence jumped (CMAF)", async () => {
+	const track = new Track.Producer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new CmafFormat(TEST_INIT), latency: 500 as Time.Milli });
+
+	// Group A (seq 1_000_000): one 3000-tick sample, so its content ends at 33_333µs (3000/90000 * 1e6).
+	const a = new Group.Producer(1_000_000);
+	a.writeFrame({
+		payload: encodeDataSegment({
+			data: new Uint8Array([0x01]),
+			timestamp: 0,
+			duration: 3000,
+			keyframe: true,
+			sequence: 0,
+		}),
+		timestamp: Time.Timestamp.now(),
+	});
+	a.close();
+	track.writeGroup(a);
+
+	const firstFrame = await consumer.next();
+	expect(firstFrame?.frame?.payload).toEqual(new Uint8Array([0x01]));
+	await consumer.next(); // group-done marker
+
+	const pending = consumer.next();
+
+	// Group B: sequence jumps +90_000, and its first PTS (3045 ticks ~= 33_833µs) sits ~500µs past
+	// A.end (33_333µs) -- the sub-millisecond skew a genuinely contiguous CMAF boundary shows because
+	// per-sample durations and base-decode-times round to µs independently. It's within the contiguity
+	// tolerance, so the timeline is unbroken and B must deliver immediately even while still open.
+	const b = new Group.Producer(1_090_000);
+	track.writeGroup(b);
+	b.writeFrame({
+		payload: encodeDataSegment({
+			data: new Uint8Array([0x02]),
+			timestamp: 3045,
+			duration: 3000,
+			keyframe: true,
+			sequence: 1,
+		}),
+		timestamp: Time.Timestamp.now(),
+	});
+
+	const result = await Promise.race([
+		pending,
+		new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 500)),
+	]);
+	expect(result).not.toBe("timeout");
+	expect((result as { frame?: Frame } | undefined)?.frame?.payload).toEqual(new Uint8Array([0x02]));
+
+	consumer.close();
+});
+
+// A real PTS gap (the active group's end does NOT reach the next buffered group's first frame) means
+// an intermediate group may still be in transit, so we must NOT skip ahead and wreck ordering.
+// Delivery resumes only once the missing, timeline-continuous group arrives.
+test("Consumer waits on a PTS gap instead of skipping to a later buffered group (CMAF)", async () => {
+	const track = new Track.Producer("test");
+	// Large latency so the gap can't be latency-skipped during the test window.
+	const consumer = new Consumer(track.subscribe(), {
+		format: new CmafFormat(TEST_INIT),
+		latency: 10_000 as Time.Milli,
+	});
+
+	// Group A (seq 1_000_000): content ends at 33_333µs.
+	const a = new Group.Producer(1_000_000);
+	a.writeFrame({
+		payload: encodeDataSegment({
+			data: new Uint8Array([0x01]),
+			timestamp: 0,
+			duration: 3000,
+			keyframe: true,
+			sequence: 0,
+		}),
+		timestamp: Time.Timestamp.now(),
+	});
+	a.close();
+	track.writeGroup(a);
+
+	const firstFrame = await consumer.next();
+	expect(firstFrame?.frame?.payload).toEqual(new Uint8Array([0x01]));
+	await consumer.next(); // group-done marker
+
+	const pending = consumer.next();
+
+	// Group C (seq 1_090_000) starts at 90_000 ticks (1_000_000µs) -- far past A.end (33_333µs), a real
+	// gap. An intermediate group may still be in transit, so C must NOT be delivered yet.
+	const c = new Group.Producer(1_090_000);
+	track.writeGroup(c);
+	c.writeFrame({
+		payload: encodeDataSegment({
+			data: new Uint8Array([0x03]),
+			timestamp: 90_000,
+			duration: 3000,
+			keyframe: true,
+			sequence: 1,
+		}),
+		timestamp: Time.Timestamp.now(),
+	});
+
+	const gap = await Promise.race([
+		pending,
+		new Promise<"timeout">((resolve) => setTimeout(() => resolve("timeout"), 300)),
+	]);
+	expect(gap).toBe("timeout"); // held: the gap is not eagerly skipped
+
+	// The missing group B arrives, contiguous with A (first PTS 3000 ticks = 33_333µs = A.end); it
+	// continues the timeline, so delivery resumes with B's frame.
+	const b = new Group.Producer(1_045_000);
+	track.writeGroup(b);
+	b.writeFrame({
+		payload: encodeDataSegment({
+			data: new Uint8Array([0x02]),
+			timestamp: 3000,
+			duration: 3000,
+			keyframe: true,
+			sequence: 2,
+		}),
+		timestamp: Time.Timestamp.now(),
+	});
+
+	const result = await pending;
+	expect((result as { frame?: Frame } | undefined)?.frame?.payload).toEqual(new Uint8Array([0x02]));
+
+	consumer.close();
+});

--- a/js/hang/src/container/consumer.test.ts
+++ b/js/hang/src/container/consumer.test.ts
@@ -25,6 +25,16 @@ function encodeLegacyFrame(timestamp: Time.Micro, payload: Uint8Array): Uint8Arr
 	return data;
 }
 
+/** A one-byte CMAF sample at `timestamp` ticks, lasting one 3000-tick (33_333µs) frame. */
+function encodeCmafFrame(data: number, timestamp: number, sequence: number): Uint8Array {
+	return encodeDataSegment({ data: new Uint8Array([data]), timestamp, duration: 3000, keyframe: true, sequence });
+}
+
+/** Yield long enough for the consumer's spawned group readers to drain what's been written. */
+function settle(ms = 20): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // --- LegacyFormat ---
 
 test("LegacyFormat decodes a valid frame", () => {
@@ -722,6 +732,154 @@ test("Consumer waits on a PTS gap instead of skipping to a later buffered group 
 
 	const result = await pending;
 	expect((result as { frame?: Frame } | undefined)?.frame?.payload).toEqual(new Uint8Array([0x02]));
+
+	consumer.close();
+});
+
+// A group can finish before it becomes the active one (it arrived and completed while an earlier
+// group was still open). The cursor then moves past it in next() rather than in #runGroup, so that
+// is where its presentation end has to be recorded. Miss it and the stale end from the group before
+// blocks every later contiguous group.
+test("Consumer delivers a contiguous group after one that completed out of order (CMAF)", async () => {
+	const track = new Track.Producer("test");
+	const consumer = new Consumer(track.subscribe(), {
+		format: new CmafFormat(TEST_INIT),
+		latency: 10_000 as Time.Milli,
+	});
+
+	// A (seq 1_000_000) stays open so it remains the active group.
+	const a = new Group.Producer(1_000_000);
+	track.writeGroup(a);
+	a.writeFrame({ payload: encodeCmafFrame(0x01, 0, 0), timestamp: Time.Timestamp.now() });
+
+	expect((await consumer.next())?.frame?.payload).toEqual(new Uint8Array([0x01]));
+
+	// A's second frame stays buffered so A can't be duration-skipped. A ends at 6000 ticks (66_666µs).
+	a.writeFrame({ payload: encodeCmafFrame(0x02, 3000, 1), timestamp: Time.Timestamp.now() });
+	await settle();
+
+	// B (seq 1_045_000) starts at A's end and is CLOSED while A is still active, so B's own finally
+	// block sees sequence !== #active and never records anything. B ends at 9000 ticks (100_000µs).
+	const b = new Group.Producer(1_045_000);
+	track.writeGroup(b);
+	b.writeFrame({ payload: encodeCmafFrame(0x03, 6000, 2), timestamp: Time.Timestamp.now() });
+	b.close();
+	await settle();
+
+	a.close();
+	expect((await consumer.next())?.frame?.payload).toEqual(new Uint8Array([0x02]));
+	expect((await consumer.next())?.frame).toBeUndefined(); // A group-done
+	expect((await consumer.next())?.frame?.payload).toEqual(new Uint8Array([0x03]));
+	expect((await consumer.next())?.frame).toBeUndefined(); // B group-done
+
+	// C (seq 1_090_000) starts at B's end, so it continues the timeline and must deliver.
+	const pending = consumer.next();
+	const c = new Group.Producer(1_090_000);
+	track.writeGroup(c);
+	c.writeFrame({ payload: encodeCmafFrame(0x04, 9000, 3), timestamp: Time.Timestamp.now() });
+
+	const result = await Promise.race([pending, settle(300).then(() => "timeout" as const)]);
+	expect(result).not.toBe("timeout");
+	expect((result as { frame?: Frame } | undefined)?.frame?.payload).toEqual(new Uint8Array([0x04]));
+
+	consumer.close();
+});
+
+// While the cursor sits below every buffered group (a real PTS gap it is waiting out), the delivery
+// head still has to run the latency check on each frame. If only the head is receiving frames,
+// that check is the only thing left that can break the stall.
+test("Consumer latency-skips a waited-out gap when only the head receives frames (CMAF)", async () => {
+	const track = new Track.Producer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new CmafFormat(TEST_INIT), latency: 100 as Time.Milli });
+
+	// A (seq 1000): one frame, ends at 3000 ticks (33_333µs).
+	const a = new Group.Producer(1000);
+	track.writeGroup(a);
+	a.writeFrame({ payload: encodeCmafFrame(0x01, 0, 0), timestamp: Time.Timestamp.now() });
+	expect((await consumer.next())?.frame?.payload).toEqual(new Uint8Array([0x01]));
+	a.close();
+	expect((await consumer.next())?.frame).toBeUndefined(); // #active falls back to the 1001 phantom
+
+	// B (seq 2000) starts at 90_000 ticks (1_000_000µs), far past A's end: a real gap, so the cursor
+	// stays on the phantom and B is never promoted.
+	const b = new Group.Producer(2000);
+	track.writeGroup(b);
+	b.writeFrame({ payload: encodeCmafFrame(0x02, 90_000, 1), timestamp: Time.Timestamp.now() });
+	await settle();
+
+	// C (seq 3000) lands just behind B, inside the 100ms budget, then goes silent for the rest of
+	// the test. So C's frames can't be what re-runs the latency check.
+	const c = new Group.Producer(3000);
+	track.writeGroup(c);
+	c.writeFrame({ payload: encodeCmafFrame(0x03, 93_000, 2), timestamp: Time.Timestamp.now() });
+	await settle();
+
+	const pending = consumer.next();
+
+	// B alone grows past the budget (90_000 -> 108_000 ticks, a 200ms span).
+	for (let i = 1; i <= 6; i++) {
+		b.writeFrame({ payload: encodeCmafFrame(0x02, 90_000 + i * 3000, 3 + i), timestamp: Time.Timestamp.now() });
+		await settle(10);
+	}
+
+	// The latency check drops B as the oldest and delivery resumes at C.
+	const result = await Promise.race([pending, settle(300).then(() => "timeout" as const)]);
+	expect(result).not.toBe("timeout");
+	const delivered = result as { frame?: Frame; continuous?: boolean } | undefined;
+	expect(delivered?.frame?.payload).toEqual(new Uint8Array([0x03]));
+	// B's content was thrown away, so downstream must not treat the span as delivered.
+	expect(delivered?.continuous).toBe(false);
+
+	consumer.close();
+});
+
+// --- Continuity reporting ---
+
+// `continuous` is what downstream buffer accounting keys on, so it must be false exactly when the
+// consumer dropped something. Group numbers can't answer that: they aren't required to be
+// sequential, and adjacency doesn't rule out a group the latency check dropped on the way past.
+test("Consumer reports continuity while nothing is dropped", async () => {
+	const track = new Track.Producer("test");
+	const consumer = new Consumer(track.subscribe(), { format: new LegacyFormat(), latency: 100 as Time.Milli });
+
+	writeGroupWithLegacyFrames(track, 0, [0 as Time.Micro, 33_000 as Time.Micro]);
+	await settle();
+
+	expect((await consumer.next())?.continuous).toBe(false); // nothing precedes the first frame
+	expect((await consumer.next())?.continuous).toBe(true); // same group: consecutive by protocol
+	expect((await consumer.next())?.frame).toBeUndefined(); // group 0 done
+
+	writeGroupWithLegacyFrames(track, 1, [66_000 as Time.Micro]);
+	await settle();
+	expect((await consumer.next())?.continuous).toBe(true); // group 1 continues group 0
+
+	consumer.close();
+});
+
+// The case the group-number heuristic got backwards: ids jump, but the PTS timeline is unbroken.
+test("Consumer reports continuity across a PTS-contiguous group id jump (CMAF)", async () => {
+	const track = new Track.Producer("test");
+	const consumer = new Consumer(track.subscribe(), {
+		format: new CmafFormat(TEST_INIT),
+		latency: 10_000 as Time.Milli,
+	});
+
+	const a = new Group.Producer(1_000_000);
+	track.writeGroup(a);
+	a.writeFrame({ payload: encodeCmafFrame(0x01, 0, 0), timestamp: Time.Timestamp.now() });
+	a.close();
+
+	expect((await consumer.next())?.frame?.payload).toEqual(new Uint8Array([0x01]));
+	expect((await consumer.next())?.frame).toBeUndefined(); // group-done
+
+	// Sequence jumps +90_000 but the first PTS meets A's end, so nothing is missing.
+	const b = new Group.Producer(1_090_000);
+	track.writeGroup(b);
+	b.writeFrame({ payload: encodeCmafFrame(0x02, 3000, 1), timestamp: Time.Timestamp.now() });
+
+	const result = await consumer.next();
+	expect(result?.frame?.payload).toEqual(new Uint8Array([0x02]));
+	expect(result?.continuous).toBe(true);
 
 	consumer.close();
 });

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -74,6 +74,30 @@ class Rewind {
 	discontinuity = 0;
 }
 
+// Two adjacent groups are treated as timeline-contiguous when the next group's first PTS is within
+// this slack of the current group's end. Per-sample durations and base-decode-times are each rounded
+// to microseconds independently, so a genuinely contiguous boundary can be off by ~1µs (seen on 48kHz
+// audio). A real missing group spans ~one group duration (orders of magnitude larger), so 1ms cleanly
+// separates rounding noise from an actual gap.
+const CONTIGUITY_TOLERANCE_US = 1000;
+
+/**
+ * True when `nextStart` continues the timeline that ends at `end`: it lands at or before `end`,
+ * within CONTIGUITY_TOLERANCE_US to absorb the µs rounding of independently-rounded per-sample
+ * durations and base-decode-times. Undefined on either side means continuity can't be proven.
+ *
+ * The bound is one-sided (upper only) by design: a next start at or before `end` continues the
+ * timeline, a start past `end` beyond the tolerance is a gap. A start well before `end` (a backward
+ * jump) is a rewind, handled by Rewind / #checkReset, not here.
+ */
+function ptsContiguous(end: Time.Micro | undefined, nextStart: Time.Micro | undefined): boolean {
+	return (
+		end !== undefined &&
+		nextStart !== undefined &&
+		(nextStart as number) <= (end as number) + CONTIGUITY_TOLERANCE_US
+	);
+}
+
 /** Reads frames from a MoQ track in order, buffering groups and skipping slow ones to meet the latency target. */
 export class Consumer {
 	#track: Moq.Track.Subscriber;
@@ -81,6 +105,9 @@ export class Consumer {
 	#latency: Getter<Time.Milli>;
 	#groups: Group[] = [];
 	#active?: number; // the active group sequence number
+	// Presentation end (max PTS + duration) of the group we most recently advanced past, so next()'s
+	// promotion guard can tell a timeline-continuous next group from one sitting after a gap.
+	#presentedEnd?: Time.Micro;
 	#rewind = new Rewind(); // live edge + active boundary + discontinuity count
 
 	// Wake up the consumer when a new frame is available.
@@ -172,6 +199,11 @@ export class Consumer {
 						// For index 0, we enforce this regardless of what the format reports.
 						// For index > 0, we trust the format's keyframe detection.
 						keyframe: index === 0 ? true : sample.keyframe,
+						// Carry the container's per-sample duration through so group.end is the real
+						// presentation end (ts + duration), not just the last frame's ts. This is what
+						// makes the PTS-contiguity check (next.firstPTS <= group.end) work; without it a
+						// contiguous next group looks one frame past the end. Undefined for Legacy (no duration).
+						duration: sample.duration,
 					};
 
 					index++;
@@ -189,12 +221,20 @@ export class Consumer {
 
 					this.#updateBuffered();
 
-					if (group.consumer.sequence === this.#active) {
+					// Wake next() for the current delivery head so its frames surface as they
+					// arrive. Gating only on `=== #active` assumed +1 group numbering: with
+					// non-sequential group ids (large jumps between groups) #active lags one group
+					// behind as a stale `+1` phantom, so the real head never matched and its whole
+					// group was held until completion, then flushed in a burst. The earliest
+					// buffered group is the delivery head regardless of id scheme; next()'s
+					// promotion guard advances #active to it. Works for sequential and
+					// non-sequential ids alike.
+					if (group.consumer.sequence === this.#active || group === this.#groups[0]) {
 						this.#notify?.();
 						this.#notify = undefined;
 					} else {
-						// Newer group: resolve it against an active reset (dropping a reneged
-						// straggler), else detect a new rewind, then check latency.
+						// A newer, non-head group: resolve it against an active reset (dropping a
+						// reneged straggler), else detect a new rewind, then check latency.
 						if (this.#classifyStale(group)) return;
 						this.#checkReset(group);
 						this.#checkLatency();
@@ -216,8 +256,28 @@ export class Consumer {
 			group.done = true;
 
 			if (group.consumer.sequence === this.#active) {
-				// Advance to the next group.
-				this.#active += 1;
+				// Advance to the next group's actual sequence. Some encoders number
+				// groups non-sequentially with large gaps (not +1), so `+= 1` would point #active at a
+				// nonexistent sequence and stall next() until #checkLatency skipped it -- every
+				// group through the skip path, i.e. constant stutter. Fall back to +1 only when
+				// no later group is buffered yet (a promotion guard in next() fixes it up when
+				// the real next group arrives).
+				// Record where this group's content ends for the promotion guard's contiguity check.
+				this.#presentedEnd = group.end;
+
+				// Advance to the next buffered group ONLY if it continues this group's timeline: the very
+				// next sequence, or PTS-contiguous (this group's end meets the next group's first frame).
+				// Non-contiguous group numbers are fine when the PTS timeline is unbroken; a real PTS gap
+				// means an intermediate group may still be in transit, so fall back to +1 (the promotion
+				// guard fixes it up once a continuous next group arrives) and let #checkLatency /
+				// #tryDurationSkip skip the gap only when latency or duration coverage proves it too old.
+				const idx = this.#groups.indexOf(group);
+				const next = this.#groups[idx + 1];
+				const contiguous =
+					next !== undefined &&
+					(next.consumer.sequence === group.consumer.sequence + 1 ||
+						ptsContiguous(group.end, next.frames.at(0)?.timestamp));
+				this.#active = contiguous && next !== undefined ? next.consumer.sequence : group.consumer.sequence + 1;
 			}
 
 			// Recompute buffered ranges now that this group is done,
@@ -352,6 +412,12 @@ export class Consumer {
 		// Resume from the earliest survivor; if none, from the rewound group. Anchor the live
 		// edge at the rewind point (delivered), not group.latest (buffered ahead of playback).
 		this.#active = this.#groups[0]?.consumer.sequence ?? reset.group;
+		// Clear the presented-timeline end. After a rewind the old value is a stale, higher timeline
+		// end; since the promotion guard's contiguity check is upper-bound only (see ptsContiguous), a
+		// new higher-sequence group with a low post-rewind PTS would otherwise look contiguous and be
+		// promoted across the discontinuity. Undefined means "unknown", so the guard waits until the
+		// resumed group's end is recomputed as it delivers.
+		this.#presentedEnd = undefined;
 		this.#rewind.liveEdge = { group: reset.group, timestamp: start };
 		this.#updateBuffered();
 
@@ -402,6 +468,24 @@ export class Consumer {
 			// A group may have buffered a rewind while the live edge was still behind it; catch it
 			// now that delivery has advanced the edge.
 			this.#checkBufferedReset();
+
+			// If #active points below all buffered groups -- e.g. the finally block's `+ 1`
+			// fallback fired because no later group was buffered yet, and the real (large-gap,
+			// non-sequential) next group has since arrived -- promote #active to the first real
+			// group so delivery resumes instead of stalling on a nonexistent sequence.
+			// Promote #active up to the first buffered group ONLY when it continues the timeline we left
+			// off at (PTS-contiguous with #presentedEnd). Otherwise a real gap sits before it and an
+			// in-transit group may still arrive, so wait -- #checkLatency skips the gap once the buffered
+			// span exceeds the latency budget, and #tryDurationSkip once the duration covers it.
+			if (this.#active !== undefined && this.#groups.length > 0) {
+				const head = this.#groups[0];
+				if (
+					head.consumer.sequence > this.#active &&
+					ptsContiguous(this.#presentedEnd, head.frames.at(0)?.timestamp)
+				) {
+					this.#active = head.consumer.sequence;
+				}
+			}
 
 			if (
 				this.#groups.length > 0 &&

--- a/js/hang/src/container/consumer.ts
+++ b/js/hang/src/container/consumer.ts
@@ -79,11 +79,11 @@ class Rewind {
 // to microseconds independently, so a genuinely contiguous boundary can be off by ~1µs (seen on 48kHz
 // audio). A real missing group spans ~one group duration (orders of magnitude larger), so 1ms cleanly
 // separates rounding noise from an actual gap.
-const CONTIGUITY_TOLERANCE_US = 1000;
+const CONTIGUITY_TOLERANCE = Moq.Time.Micro.fromMilli(1 as Time.Milli);
 
 /**
  * True when `nextStart` continues the timeline that ends at `end`: it lands at or before `end`,
- * within CONTIGUITY_TOLERANCE_US to absorb the µs rounding of independently-rounded per-sample
+ * within CONTIGUITY_TOLERANCE to absorb the µs rounding of independently-rounded per-sample
  * durations and base-decode-times. Undefined on either side means continuity can't be proven.
  *
  * The bound is one-sided (upper only) by design: a next start at or before `end` continues the
@@ -91,10 +91,19 @@ const CONTIGUITY_TOLERANCE_US = 1000;
  * jump) is a rewind, handled by Rewind / #checkReset, not here.
  */
 function ptsContiguous(end: Time.Micro | undefined, nextStart: Time.Micro | undefined): boolean {
+	return end !== undefined && nextStart !== undefined && nextStart <= Moq.Time.Micro.add(end, CONTIGUITY_TOLERANCE);
+}
+
+/**
+ * True when `next` continues `prev`'s presentation timeline, i.e. nothing is missing between them.
+ * Either its sequence is the very next one, which is the only proof available for containers that
+ * carry no per-frame duration (Legacy), or the PTS timeline is unbroken across the boundary, which
+ * is what non-sequential group numbering (e.g. DTS-derived ids) needs.
+ */
+function continues(prev: Group, next: Group | undefined): next is Group {
+	if (next === undefined) return false;
 	return (
-		end !== undefined &&
-		nextStart !== undefined &&
-		(nextStart as number) <= (end as number) + CONTIGUITY_TOLERANCE_US
+		next.consumer.sequence === prev.consumer.sequence + 1 || ptsContiguous(prev.end, next.frames.at(0)?.timestamp)
 	);
 }
 
@@ -107,7 +116,17 @@ export class Consumer {
 	#active?: number; // the active group sequence number
 	// Presentation end (max PTS + duration) of the group we most recently advanced past, so next()'s
 	// promotion guard can tell a timeline-continuous next group from one sitting after a gap.
+	// Maintained only via #recordPresented; see its comment for the invariant.
 	#presentedEnd?: Time.Micro;
+	// Group of the last frame next() returned, so it can report whether the following result
+	// continues that frame's timeline. Undefined until the first delivery and after a rewind.
+	#deliveredGroup?: number;
+	// Set whenever the consumer throws content away: a slow group skipped to meet the latency
+	// target, a group truncated by a decode error, a reneged straggler, a rewind. Reported (and
+	// cleared) on the first frame delivered from the next group, which is where the missing span
+	// sits. Only the consumer can know this, which is why next() reports it instead of leaving
+	// callers to guess from group numbers.
+	#gap = false;
 	#rewind = new Rewind(); // live edge + active boundary + discontinuity count
 
 	// Wake up the consumer when a new frame is available.
@@ -221,6 +240,22 @@ export class Consumer {
 
 					this.#updateBuffered();
 
+					let skipped = false;
+					if (group.consumer.sequence !== this.#active) {
+						// A non-active group: resolve it against an active reset (dropping a
+						// reneged straggler), else detect a new rewind, then check latency. This
+						// runs even when the group is the delivery head, because that is exactly
+						// the stalled case (#active sits below every buffered group) where the
+						// latency budget is what eventually breaks the stall.
+						if (this.#classifyStale(group)) return;
+						this.#checkReset(group);
+						this.#checkLatency();
+
+						// A newer group reaching back to where the stalled active group has
+						// already presented means we can advance now instead of waiting.
+						skipped = this.#tryDurationSkip();
+					}
+
 					// Wake next() for the current delivery head so its frames surface as they
 					// arrive. Gating only on `=== #active` assumed +1 group numbering: with
 					// non-sequential group ids (large jumps between groups) #active lags one group
@@ -229,22 +264,9 @@ export class Consumer {
 					// buffered group is the delivery head regardless of id scheme; next()'s
 					// promotion guard advances #active to it. Works for sequential and
 					// non-sequential ids alike.
-					if (group.consumer.sequence === this.#active || group === this.#groups[0]) {
+					if (skipped || group.consumer.sequence === this.#active || group === this.#groups[0]) {
 						this.#notify?.();
 						this.#notify = undefined;
-					} else {
-						// A newer, non-head group: resolve it against an active reset (dropping a
-						// reneged straggler), else detect a new rewind, then check latency.
-						if (this.#classifyStale(group)) return;
-						this.#checkReset(group);
-						this.#checkLatency();
-
-						// A newer group reaching back to where the stalled active group has
-						// already presented means we can advance now instead of waiting.
-						if (this.#tryDurationSkip()) {
-							this.#notify?.();
-							this.#notify = undefined;
-						}
 					}
 				}
 			}
@@ -252,32 +274,24 @@ export class Consumer {
 			// Stop reading the group but keep already-decoded frames.
 			// A decode error or stream RESET truncates the tail of the GoP;
 			// frames decoded before the error are still valid and playable.
+			// The tail is gone though, so the next group does not continue this one.
+			this.#gap = true;
 		} finally {
 			group.done = true;
 
 			if (group.consumer.sequence === this.#active) {
-				// Advance to the next group's actual sequence. Some encoders number
-				// groups non-sequentially with large gaps (not +1), so `+= 1` would point #active at a
-				// nonexistent sequence and stall next() until #checkLatency skipped it -- every
-				// group through the skip path, i.e. constant stutter. Fall back to +1 only when
-				// no later group is buffered yet (a promotion guard in next() fixes it up when
-				// the real next group arrives).
-				// Record where this group's content ends for the promotion guard's contiguity check.
-				this.#presentedEnd = group.end;
+				this.#recordPresented(group);
 
-				// Advance to the next buffered group ONLY if it continues this group's timeline: the very
-				// next sequence, or PTS-contiguous (this group's end meets the next group's first frame).
-				// Non-contiguous group numbers are fine when the PTS timeline is unbroken; a real PTS gap
-				// means an intermediate group may still be in transit, so fall back to +1 (the promotion
-				// guard fixes it up once a continuous next group arrives) and let #checkLatency /
-				// #tryDurationSkip skip the gap only when latency or duration coverage proves it too old.
-				const idx = this.#groups.indexOf(group);
-				const next = this.#groups[idx + 1];
-				const contiguous =
-					next !== undefined &&
-					(next.consumer.sequence === group.consumer.sequence + 1 ||
-						ptsContiguous(group.end, next.frames.at(0)?.timestamp));
-				this.#active = contiguous && next !== undefined ? next.consumer.sequence : group.consumer.sequence + 1;
+				// Advance to the next buffered group's actual sequence, but ONLY if it continues this
+				// group's timeline. Some encoders number groups non-sequentially with large gaps (not
+				// +1), so a bare `+= 1` would point #active at a nonexistent sequence and stall next()
+				// until #checkLatency skipped it -- every group through the skip path, i.e. constant
+				// stutter. A real PTS gap is different: an intermediate group may still be in transit,
+				// so fall back to +1 there (next()'s promotion guard fixes it up once a continuous
+				// group arrives) and let #checkLatency / #tryDurationSkip skip the gap only once
+				// latency or duration coverage proves it too old.
+				const next = this.#groups[this.#groups.indexOf(group) + 1];
+				this.#active = continues(group, next) ? next.consumer.sequence : group.consumer.sequence + 1;
 			}
 
 			// Recompute buffered ranges now that this group is done,
@@ -291,6 +305,26 @@ export class Consumer {
 
 			group.consumer.close();
 		}
+	}
+
+	// Record where a group's content ends as the cursor advances past it. next()'s promotion guard
+	// compares the following group's first PTS against this to tell an unbroken timeline from a real
+	// gap, so EVERY site that moves #active past a group must call this; a site that forgets leaves a
+	// stale end behind and silently blocks the next contiguous group forever. A group with no frames
+	// (empty, or errored before the first one) says nothing about the timeline, so it leaves the last
+	// known end in place rather than wiping it.
+	#recordPresented(group: Group): void {
+		if (group.end !== undefined) this.#presentedEnd = group.end;
+	}
+
+	// Whether delivering from group `sequence` continues the timeline of the last frame returned.
+	// Frames within a group are consecutive by protocol, so only a group boundary can break it, and
+	// there it comes down to whether anything was dropped in between. Deliberately not derived from
+	// group numbers: they need not be sequential, so adjacency neither proves continuity nor catches
+	// a group the latency check truncated on the way past.
+	#continuesDelivery(sequence: number): boolean {
+		if (this.#deliveredGroup === undefined) return false;
+		return sequence === this.#deliveredGroup || !this.#gap;
 	}
 
 	#checkLatency() {
@@ -331,6 +365,7 @@ export class Consumer {
 			first.consumer.close();
 			first.frames.length = 0;
 			skipped = true;
+			this.#gap = true;
 		}
 
 		if (skipped) {
@@ -359,6 +394,7 @@ export class Consumer {
 
 		this.#groups.shift();
 		console.warn(`skipping covered group: ${active.consumer.sequence} -> ${next.consumer.sequence}`);
+		this.#recordPresented(active);
 		this.#active = next.consumer.sequence;
 
 		active.consumer.close();
@@ -392,6 +428,7 @@ export class Consumer {
 		const reset = new Reset(live.group, group.consumer.sequence, start);
 		this.#rewind.boundary = reset;
 		this.#rewind.discontinuity++;
+		this.#gap = true;
 
 		// Drop buffered groups the boundary can already prove stale; keep ambiguous ones.
 		this.#groups = this.#groups.filter((g) => {
@@ -418,6 +455,8 @@ export class Consumer {
 		// promoted across the discontinuity. Undefined means "unknown", so the guard waits until the
 		// resumed group's end is recomputed as it delivers.
 		this.#presentedEnd = undefined;
+		// Nothing on the new timeline has been delivered yet, so the next frame continues nothing.
+		this.#deliveredGroup = undefined;
 		this.#rewind.liveEdge = { group: reset.group, timestamp: start };
 		this.#updateBuffered();
 
@@ -439,6 +478,7 @@ export class Consumer {
 		this.#groups = this.#groups.filter((g) => g !== group);
 		group.consumer.close();
 		group.frames.length = 0;
+		this.#gap = true;
 		this.#updateBuffered();
 		return true;
 	}
@@ -462,8 +502,21 @@ export class Consumer {
 	 * end of that group; the overall result is undefined once closed. When `discontinuity`
 	 * jumps relative to the previous call, the publisher rewound the timeline: flush any
 	 * downstream decoder or render buffers before playing this frame.
+	 *
+	 * `continuous` is true when this result picks up exactly where the previous frame left off, so
+	 * the span between them can be treated as delivered. It is false on the first frame, after a
+	 * rewind, and whenever the consumer threw content away to keep up: a slow group skipped for the
+	 * latency target, a group truncated by a decode error, a reneged straggler. Use it rather than
+	 * comparing group numbers, which are not required to be sequential: adjacency neither proves
+	 * the timeline is unbroken nor catches a group dropped on the way past.
+	 *
+	 * It reports what this consumer dropped, not holes the publisher left. A publisher that jumps
+	 * its timeline between two groups still reads as continuous, because nothing on the wire says
+	 * the missing span will never arrive.
 	 */
-	async next(): Promise<{ frame: Frame | undefined; group: number; discontinuity: number } | undefined> {
+	async next(): Promise<
+		{ frame: Frame | undefined; group: number; discontinuity: number; continuous: boolean } | undefined
+	> {
 		for (;;) {
 			// A group may have buffered a rewind while the live edge was still behind it; catch it
 			// now that delivery has advanced the edge.
@@ -495,6 +548,10 @@ export class Consumer {
 				const frame = this.#groups[0].frames.shift();
 				if (frame) {
 					const seq = this.#groups[0].consumer.sequence;
+					const continuous = this.#continuesDelivery(seq);
+					if (seq !== this.#deliveredGroup) this.#gap = false;
+					this.#deliveredGroup = seq;
+
 					// Track the live edge (max timestamp + its group) so a later backwards jump
 					// is detectable and the old epoch's tail is anchored.
 					const live = this.#rewind.liveEdge;
@@ -502,7 +559,7 @@ export class Consumer {
 						this.#rewind.liveEdge = { group: seq, timestamp: frame.timestamp };
 					}
 					this.#updateBuffered();
-					return { frame, group: seq, discontinuity: this.#rewind.discontinuity };
+					return { frame, group: seq, discontinuity: this.#rewind.discontinuity, continuous };
 				}
 
 				// Check if the group is done and then remove it.
@@ -512,16 +569,25 @@ export class Consumer {
 				// #active reached this group (e.g. after a latency skip).
 				if (this.#active > this.#groups[0].consumer.sequence || this.#groups[0].done) {
 					if (this.#groups[0].consumer.sequence === this.#active) {
+						// The cursor moves past this group here rather than in #runGroup's finally
+						// block whenever the group finished before it became active, so this is the
+						// site that has to record its presentation end. Advance by +1 and let the
+						// promotion guard above resolve the real successor on the next iteration.
+						this.#recordPresented(this.#groups[0]);
 						this.#active += 1;
 					}
 
 					const group = this.#groups.shift();
 					if (group) {
+						const seq = group.consumer.sequence;
 						this.#updateBuffered();
 						return {
 							frame: undefined,
-							group: group.consumer.sequence,
+							group: seq,
 							discontinuity: this.#rewind.discontinuity,
+							// A marker carries no content of its own, so this just reports whether
+							// the group it closes was itself reached without a gap.
+							continuous: this.#continuesDelivery(seq),
 						};
 					}
 				}

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -393,9 +393,12 @@ class DecoderTrack {
 					bytesReceived: (current?.bytesReceived ?? 0) + frame.payload.byteLength,
 				}));
 
-				// Track decode buffer: frames sent to decoder but not yet rendered
+				// Track decode buffer: frames sent to decoder but not yet rendered.
+				// A finished prior group followed by frames from a later group is contiguous in
+				// playback even when group sequence numbers are not +1-adjacent (some encoders
+				// number groups non-sequentially with large gaps), so bridge on `prior.final`, not `+1`.
 				const prior = previous;
-				if (prior && (prior.group === group || (prior.final && prior.group + 1 === group))) {
+				if (prior && (prior.group === group || (prior.final && group > prior.group))) {
 					const start = Time.Milli.fromMicro(prior.timestamp);
 					const end = Time.Milli.fromMicro(frame.timestamp);
 					this.#addBuffered(start, end);
@@ -471,9 +474,9 @@ class DecoderTrack {
 					bytesReceived: (current?.bytesReceived ?? 0) + frame.payload.byteLength,
 				}));
 
-				// Track decode buffer
+				// Track decode buffer (see #runLegacy: bridge on prior.final, not +1, for non-sequential group ids)
 				const prior = previous;
-				if (prior && (prior.group === group || (prior.final && prior.group + 1 === group))) {
+				if (prior && (prior.group === group || (prior.final && group > prior.group))) {
 					const start = Time.Milli.fromMicro(prior.timestamp);
 					const end = Time.Milli.fromMicro(frame.timestamp);
 					this.#addBuffered(start, end);

--- a/js/watch/src/video/decoder.ts
+++ b/js/watch/src/video/decoder.ts
@@ -357,7 +357,7 @@ class DecoderTrack {
 			flip: false,
 		});
 
-		let previous: { timestamp: Time.Micro; group: number; final: boolean } | undefined;
+		let previous: Time.Micro | undefined;
 
 		effect.spawn(async () => {
 			for (;;) {
@@ -367,15 +367,8 @@ class DecoderTrack {
 				// Publisher rewound: flush queued/in-flight video and re-anchor before decoding.
 				if (this.#onDiscontinuity(next.discontinuity)) previous = undefined;
 
-				const { frame, group } = next;
-
-				if (!frame) {
-					if (previous) {
-						previous.final = true;
-					}
-					// The group is done
-					continue;
-				}
+				const { frame } = next;
+				if (!frame) continue; // The group is done
 
 				// Mark that we received this frame right now.
 				const timestamp = Time.Milli.fromMicro(frame.timestamp as Time.Micro);
@@ -393,22 +386,16 @@ class DecoderTrack {
 					bytesReceived: (current?.bytesReceived ?? 0) + frame.payload.byteLength,
 				}));
 
-				// Track decode buffer: frames sent to decoder but not yet rendered.
-				// A finished prior group followed by frames from a later group is contiguous in
-				// playback even when group sequence numbers are not +1-adjacent (some encoders
-				// number groups non-sequentially with large gaps), so bridge on `prior.final`, not `+1`.
-				const prior = previous;
-				if (prior && (prior.group === group || (prior.final && group > prior.group))) {
-					const start = Time.Milli.fromMicro(prior.timestamp);
-					const end = Time.Milli.fromMicro(frame.timestamp);
-					this.#addBuffered(start, end);
+				// Track decode buffer: frames sent to decoder but not yet rendered. Only bridge from
+				// the previous frame when the consumer says nothing is missing in between. Group ids
+				// can't answer that: they aren't required to be sequential (some encoders derive them
+				// from DTS), so adjacency neither proves continuity nor rules out a gap the consumer
+				// skipped, and reporting a skipped span as decoded overstates the buffer.
+				if (previous !== undefined && next.continuous) {
+					this.#addBuffered(Time.Milli.fromMicro(previous), Time.Milli.fromMicro(frame.timestamp));
 				}
 
-				previous = {
-					timestamp: frame.timestamp,
-					group,
-					final: false,
-				};
+				previous = frame.timestamp;
 
 				decoder.decode(chunk);
 			}
@@ -445,7 +432,7 @@ class DecoderTrack {
 			flip: false,
 		});
 
-		let previous: { timestamp: Time.Micro; group: number; final: boolean } | undefined;
+		let previous: Time.Micro | undefined;
 
 		effect.spawn(async () => {
 			for (;;) {
@@ -455,14 +442,8 @@ class DecoderTrack {
 				// Publisher rewound: flush queued/in-flight video and re-anchor before decoding.
 				if (this.#onDiscontinuity(next.discontinuity)) previous = undefined;
 
-				const { frame, group } = next;
-
-				if (!frame) {
-					if (previous) {
-						previous.final = true;
-					}
-					continue;
-				}
+				const { frame } = next;
+				if (!frame) continue;
 
 				// Mark that we received this frame right now.
 				const timestamp = Time.Milli.fromMicro(frame.timestamp);
@@ -474,19 +455,13 @@ class DecoderTrack {
 					bytesReceived: (current?.bytesReceived ?? 0) + frame.payload.byteLength,
 				}));
 
-				// Track decode buffer (see #runLegacy: bridge on prior.final, not +1, for non-sequential group ids)
-				const prior = previous;
-				if (prior && (prior.group === group || (prior.final && group > prior.group))) {
-					const start = Time.Milli.fromMicro(prior.timestamp);
-					const end = Time.Milli.fromMicro(frame.timestamp);
-					this.#addBuffered(start, end);
+				// Track decode buffer (see #runLegacy: bridge on the consumer's continuity signal,
+				// never on group adjacency, which proves nothing about the timeline).
+				if (previous !== undefined && next.continuous) {
+					this.#addBuffered(Time.Milli.fromMicro(previous), Time.Milli.fromMicro(frame.timestamp));
 				}
 
-				previous = {
-					timestamp: frame.timestamp,
-					group,
-					final: false,
-				};
+				previous = frame.timestamp;
 
 				if (decoder.state === "closed") break;
 				decoder.decode(


### PR DESCRIPTION
Tracks numbered by DTS (e.g. CMSF) use large, non-+1 group-id gaps. The consumer assumed +1 numbering: it stalled delivery (constant stutter) and held whole groups until completion, then flushed them in a 1 Hz burst.

- consumer: advance #active to the next buffered group's actual sequence (not +1), add a next() promotion guard, and wake next() for the delivery head (#groups[0]) regardless of id scheme.
- decoder: bridge the decode buffer across non-adjacent group boundaries (group > prior.group) in both the legacy and CMAF paths.
- tests: non-sequential-gap incremental-delivery coverage.