### PR TITLE
Pr/moq rust caller grouping

### DIFF
--- a/rs/libmoq/Cargo.toml
+++ b/rs/libmoq/Cargo.toml
@@ -16,6 +16,15 @@ categories = ["multimedia", "network-programming", "web-programming"]
 name = "moq"
 crate-type = ["staticlib"]
 
+[features]
+# No hardware / system-dep video by default: a stock libmoq builds with no libva/CUDA.
+# Opt into native video decode (the moq_consume_video* C API) with `--features hw-video`,
+# which pulls in moq-video (NVENC/VAAPI/NVDEC); its vaapi backend links libva at build time.
+# Mirrors moq-cli's capture/transcode: hardware / system deps are opt-in, never assumed.
+# INVARIANT: libmoq MUST keep building with --no-default-features (no libva/CUDA). CI enforces this.
+default = []
+hw-video = ["dep:moq-video"]
+
 [dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
 bytes = "1"
@@ -25,8 +34,9 @@ moq-json = { workspace = true }
 moq-mux = { workspace = true }
 moq-native = { workspace = true, default-features = true }
 moq-net = { workspace = true }
-# Enable the NVENC / VAAPI / NVDEC hardware codecs (default-off at the workspace level).
-moq-video = { workspace = true, features = ["nvenc", "vaapi", "nvdec"] }
+# Optional, behind the `hw-video` feature: native video decode for the moq_consume_video* C API.
+# Keeps its default NVENC/VAAPI/NVDEC backends; the vaapi backend links libva at build time.
+moq-video = { workspace = true, optional = true }
 serde_json = "1"
 thiserror = "2"
 tokio = { workspace = true, features = ["macros"] }

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -406,6 +406,41 @@ pub extern "C" fn moq_error() -> *const c_char {
 	ffi::last_error_ptr()
 }
 
+/// Disable TLS certificate verification for all future sessions.
+///
+/// Global setting; call before [moq_session_connect]. Convenient for local development
+/// against a self-signed relay; use with caution in production.
+///
+/// Returns a zero on success.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_tls_disable_verify(disable: bool) -> i32 {
+	ffi::enter(move || {
+		State::lock().tls_disable_verify = disable;
+		Ok(())
+	})
+}
+
+/// Configure the exponential backoff used when a session reconnects.
+///
+/// Global setting; call before [moq_session_connect]. Durations are in milliseconds.
+/// `multiplier` scales the delay after each failed attempt. A `timeout_ms` of 0 retries
+/// forever; otherwise reconnection gives up (delivering a terminal negative status) once
+/// the timeout is exceeded.
+///
+/// Returns a zero on success.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_backoff_config(initial_ms: u64, multiplier: u32, max_ms: u64, timeout_ms: u64) -> i32 {
+	ffi::enter(move || {
+		let mut backoff = moq_native::Backoff::default();
+		backoff.initial = std::time::Duration::from_millis(initial_ms);
+		backoff.multiplier = multiplier;
+		backoff.max = std::time::Duration::from_millis(max_ms);
+		backoff.timeout = std::time::Duration::from_millis(timeout_ms);
+		State::lock().backoff = backoff;
+		Ok(())
+	})
+}
+
 /// Start establishing a connection to a MoQ server.
 ///
 /// Takes origin handles, which are used for publishing and consuming broadcasts respectively.
@@ -461,8 +496,12 @@ pub unsafe extern "C" fn moq_session_connect(
 			.transpose()?
 			.cloned();
 
+		let tls_disable_verify = state.tls_disable_verify;
+		let backoff = state.backoff.clone();
 		let on_status = unsafe { ffi::OnStatus::new(user_data, on_status) };
-		state.session.connect(url, publish, consume, on_status)
+		state
+			.session
+			.connect(url, publish, consume, tls_disable_verify, backoff, on_status)
 	})
 }
 

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -798,6 +798,40 @@ pub extern "C" fn moq_publish_media_finish(export: u32) -> i32 {
 	})
 }
 
+/// Force a synchronized group boundary across all tracks of a media importer, opening the next
+/// group at `sequence`.
+///
+/// Lets a caller drive aligned, explicitly-numbered groups (e.g. two encoders publishing the same
+/// content align their groups per GOP for dual-pipeline redundancy). Without it, group boundaries
+/// follow video keyframes.
+///
+/// Returns a zero on success, or a negative code on failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_publish_media_group(media: u32, sequence: u64) -> i32 {
+	ffi::enter(move || {
+		let media = ffi::parse_id(media)?;
+		State::lock().publish.media_seek(media, sequence)
+	})
+}
+
+/// Enable caller-driven (manual) audio grouping for a media importer.
+///
+/// Default `false`: each audio frame is its own group (one QUIC stream per packet), forwarded
+/// without waiting. Pass `true` when the caller drives its own boundaries via
+/// [moq_publish_media_group]: audio frames then accumulate into the current group until the next
+/// boundary, so the origin can align audio groups to a segment cadence. For the fMP4 container
+/// passthrough, audio fragments likewise accumulate into the caller's group instead of one per
+/// fragment. No effect on video, which groups by its own keyframes.
+///
+/// Returns a zero on success, or a negative code on failure.
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_publish_media_manual_grouping(media: u32, enabled: bool) -> i32 {
+	ffi::enter(move || {
+		let media = ffi::parse_id(media)?;
+		State::lock().publish.media_manual_grouping(media, enabled)
+	})
+}
+
 /// Write data to a track.
 ///
 /// The encoding of `data` depends on the track `format`.

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -778,6 +778,7 @@ impl Consume {
 	/// Look up a video rendition by catalog index, returning the
 	/// (broadcast, config, name) tuple needed to subscribe, mirroring
 	/// the index-based selection in `video`.
+	#[cfg(feature = "hw-video")]
 	pub fn video_rendition(
 		&self,
 		catalog: Id,

--- a/rs/libmoq/src/error.rs
+++ b/rs/libmoq/src/error.rs
@@ -143,9 +143,16 @@ pub enum Error {
 	#[error("audio error: {0}")]
 	Audio(Arc<moq_audio::Error>),
 
-	/// Error from the moq-video codec layer.
+	/// Error from the moq-video codec layer (only present with the `hw-video` feature).
+	#[cfg(feature = "hw-video")]
 	#[error("video error: {0}")]
 	Video(Arc<moq_video::Error>),
+
+	/// A capability compiled out of this build, e.g. hardware video decode without the
+	/// `hw-video` feature. The matching C entry point returns this rather than linking a
+	/// backend that isn't present.
+	#[error("unsupported: feature not enabled in this build")]
+	Unsupported,
 
 	/// Invalid JSON passed for a catalog section.
 	#[error("json error: {0}")]
@@ -177,6 +184,7 @@ impl From<moq_audio::Error> for Error {
 	}
 }
 
+#[cfg(feature = "hw-video")]
 impl From<moq_video::Error> for Error {
 	fn from(err: moq_video::Error) -> Self {
 		Error::Video(Arc::new(err))
@@ -228,7 +236,9 @@ impl ffi::ReturnCode for Error {
 			Error::Native(_) => -33,
 			Error::Unauthorized => -34,
 			Error::Forbidden => -35,
+			#[cfg(feature = "hw-video")]
 			Error::Video(_) => -36,
+			Error::Unsupported => -39,
 			Error::Json(_) => -37,
 			Error::JsonTrack(_) => -38,
 		}

--- a/rs/libmoq/src/publish.rs
+++ b/rs/libmoq/src/publish.rs
@@ -126,6 +126,38 @@ impl Publish {
 		Ok(())
 	}
 
+	/// Close the current group on every track of this media importer and open the next one at
+	/// `sequence`.
+	///
+	/// Forces a synchronized group boundary. This is how a caller drives aligned,
+	/// explicitly-numbered groups when the encoder produces deterministic group IDs (e.g. two
+	/// encoders publishing the same content align per GOP for dual-pipeline redundancy). Without
+	/// it, boundaries follow video keyframes.
+	pub fn media_seek(&mut self, media: Id, sequence: u64) -> Result<(), Error> {
+		let media = self.media.get_mut(media).ok_or(Error::MediaNotFound)?;
+		match media {
+			Media::Track(track) => track.seek(sequence)?,
+			Media::Container(container) => container.seek(sequence)?,
+		}
+		Ok(())
+	}
+
+	/// Control whether a keyframe starts a new group for this media importer.
+	///
+	/// Default `true` (video GOP semantics; audio codecs where every frame is a keyframe otherwise
+	/// open a group per packet). Pass `false` when the caller drives its own boundaries via
+	/// [`media_seek`](Self::media_seek), so audio frames accumulate into the current group instead
+	/// of one group (one QUIC stream) per packet. No-op for the container passthrough path, which
+	/// already groups by track kind.
+	pub fn media_manual_grouping(&mut self, media: Id, enabled: bool) -> Result<(), Error> {
+		let media = self.media.get_mut(media).ok_or(Error::MediaNotFound)?;
+		match media {
+			Media::Track(track) => track.set_manual_grouping(enabled),
+			Media::Container(container) => container.set_manual_grouping(enabled),
+		}
+		Ok(())
+	}
+
 	/// Insert or replace a video rendition in the broadcast's catalog.
 	///
 	/// The catalog is republished automatically.

--- a/rs/libmoq/src/session.rs
+++ b/rs/libmoq/src/session.rs
@@ -30,9 +30,14 @@ impl Session {
 		url: Url,
 		publish: Option<moq_net::origin::Producer>,
 		consume: Option<moq_net::origin::Producer>,
+		tls_disable_verify: bool,
+		backoff: moq_native::Backoff,
 		callback: ffi::OnStatus,
 	) -> Result<Id, Error> {
-		let mut client = moq_native::ClientConfig::default().init()?;
+		let mut config = moq_native::ClientConfig::default();
+		config.tls.disable_verify = Some(tls_disable_verify);
+		config.backoff = backoff;
+		let mut client = config.init()?;
 		if let Some(publish) = &publish {
 			client = client.with_publisher(publish);
 		}

--- a/rs/libmoq/src/state.rs
+++ b/rs/libmoq/src/state.rs
@@ -8,6 +8,10 @@ pub struct State {
 	pub publish: Publish,
 	pub consume: Consume,
 	pub audio: Audio,
+	/// Disable TLS cert verification for future sessions (set via moq_tls_disable_verify).
+	pub tls_disable_verify: bool,
+	/// Exponential backoff applied to session reconnects (set via moq_backoff_config).
+	pub backoff: moq_native::Backoff,
 	#[cfg_attr(not(feature = "hw-video"), allow(dead_code))]
 	pub video: Video,
 }
@@ -20,6 +24,8 @@ impl State {
 			publish: Publish::default(),
 			consume: Consume::default(),
 			audio: Audio::default(),
+			tls_disable_verify: false,
+			backoff: moq_native::Backoff::default(),
 			video: Video::default(),
 		}
 	}

--- a/rs/libmoq/src/state.rs
+++ b/rs/libmoq/src/state.rs
@@ -8,6 +8,7 @@ pub struct State {
 	pub publish: Publish,
 	pub consume: Consume,
 	pub audio: Audio,
+	#[cfg_attr(not(feature = "hw-video"), allow(dead_code))]
 	pub video: Video,
 }
 

--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -1518,6 +1518,7 @@ fn video_publish_consume() {
 
 /// End-to-end native decode: publish real H.264 (encoded by moq-video) and
 /// consume it through `moq_consume_video_raw`, asserting decoded I420 frames.
+#[cfg(feature = "hw-video")]
 #[test]
 fn video_raw_decode() {
 	// Encode a few gray frames to Annex-B (avc3, SPS/PPS inline on the keyframe).

--- a/rs/libmoq/src/video.rs
+++ b/rs/libmoq/src/video.rs
@@ -10,12 +10,17 @@
 //! terminal error on the callback.
 
 use std::ffi::c_void;
+#[cfg(feature = "hw-video")]
 use std::time::Duration;
 
+#[cfg(feature = "hw-video")]
 use tokio::sync::oneshot;
 
+#[cfg(feature = "hw-video")]
 use crate::ffi::OnStatus;
-use crate::{Error, Id, NonZeroSlab, State, ffi};
+use crate::{Error, ffi};
+#[cfg(feature = "hw-video")]
+use crate::{Id, NonZeroSlab, State};
 
 // ---- C-visible types ----
 
@@ -24,6 +29,7 @@ use crate::{Error, Id, NonZeroSlab, State, ffi};
 /// Output is always tightly-packed I420 (see [`moq_video_frame`]); there is no
 /// format/resolution knob yet. The struct exists so future options (a pixel
 /// format, a target size) stay additive.
+#[cfg_attr(not(feature = "hw-video"), allow(dead_code))]
 #[repr(C)]
 #[allow(non_camel_case_types)]
 pub struct moq_video_decoder_output {
@@ -41,6 +47,7 @@ pub struct moq_video_decoder_output {
 /// limited range. `width` and `height` are even. `data` is owned by the consume
 /// slab and stays valid until the same id is released with
 /// [`moq_consume_video_raw_frame_free`].
+#[cfg_attr(not(feature = "hw-video"), allow(dead_code))]
 #[repr(C)]
 #[allow(non_camel_case_types)]
 pub struct moq_video_frame {
@@ -54,6 +61,7 @@ pub struct moq_video_frame {
 // ---- State extension (used internally by lib.rs) ----
 
 /// Raw-video consume state: decoder tasks plus their buffered decoded frames.
+#[cfg(feature = "hw-video")]
 #[derive(Default)]
 pub struct Video {
 	consumer_tasks: NonZeroSlab<Option<VideoTaskEntry>>,
@@ -63,6 +71,7 @@ pub struct Video {
 /// A delivered frame, flattened to CPU I420 at delivery time: the C ABI hands
 /// out a stable byte pointer, so a GPU-decoded frame (e.g. NVDEC) is downloaded
 /// exactly once here.
+#[cfg(feature = "hw-video")]
 struct VideoFrame {
 	timestamp_us: u64,
 	width: u32,
@@ -76,11 +85,13 @@ struct VideoFrame {
 /// terminal callback and then removes itself, so `user_data` stays valid until
 /// that callback fires. `close` is an `Option` so `consume_close` can drop just
 /// the sender without removing the entry.
+#[cfg(feature = "hw-video")]
 struct VideoTaskEntry {
 	close: Option<oneshot::Sender<()>>,
 	callback: OnStatus,
 }
 
+#[cfg(feature = "hw-video")]
 impl Video {
 	pub fn consume(
 		&mut self,
@@ -202,6 +213,7 @@ impl Video {
 /// # Safety
 /// - `output` must point to a valid [`moq_video_decoder_output`].
 /// - `user_data` must stay valid until the terminal (`<= 0`) `on_frame` callback.
+#[cfg(feature = "hw-video")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn moq_consume_video_raw(
 	catalog: u32,
@@ -237,6 +249,7 @@ pub unsafe extern "C" fn moq_consume_video_raw(
 /// terminal `0` (or a negative error), which is where `user_data` should be
 /// released. Frame ids already delivered are likewise not freed; release each
 /// with [`moq_consume_video_raw_frame_free`].
+#[cfg(feature = "hw-video")]
 #[unsafe(no_mangle)]
 pub extern "C" fn moq_consume_video_raw_close(consumer: u32) -> i32 {
 	ffi::enter(move || {
@@ -252,6 +265,7 @@ pub extern "C" fn moq_consume_video_raw_close(consumer: u32) -> i32 {
 ///
 /// # Safety
 /// - `dst` must point to a writable [`moq_video_frame`].
+#[cfg(feature = "hw-video")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn moq_consume_video_raw_frame(id: u32, dst: *mut moq_video_frame) -> i32 {
 	ffi::enter(move || {
@@ -263,10 +277,62 @@ pub unsafe extern "C" fn moq_consume_video_raw_frame(id: u32, dst: *mut moq_vide
 
 /// Free a frame previously delivered through the consume callback. Required for
 /// every delivered frame id; closing the parent consumer is not enough.
+#[cfg(feature = "hw-video")]
 #[unsafe(no_mangle)]
 pub extern "C" fn moq_consume_video_raw_frame_free(id: u32) -> i32 {
 	ffi::enter(move || {
 		let id = ffi::parse_id(id)?;
 		State::lock().video.frame_free(id)
 	})
+}
+
+// ---- Stubs when `hw-video` is disabled ----
+//
+// The C ABI stays identical (same symbols, same moq.h) so a header consumer links either
+// build; without `hw-video` these entry points report the missing capability at runtime
+// instead of pulling in moq-video (and its libva/CUDA link).
+
+#[cfg(not(feature = "hw-video"))]
+#[derive(Default)]
+pub struct Video {}
+
+/// Video decode is unavailable in this build (compiled without the `hw-video` feature);
+/// returns [`Error::Unsupported`]. The `hw-video` build carries the real implementation.
+///
+/// # Safety
+/// - `_output` must point to a valid [`moq_video_decoder_output`] (unused; not dereferenced here).
+/// - `_user_data` is never touched.
+#[cfg(not(feature = "hw-video"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_consume_video_raw(
+	_catalog: u32,
+	_index: u32,
+	_output: *const moq_video_decoder_output,
+	_on_frame: Option<extern "C" fn(user_data: *mut c_void, frame: i32)>,
+	_user_data: *mut c_void,
+) -> i32 {
+	ffi::enter(|| Result::<(), Error>::Err(Error::Unsupported))
+}
+
+#[cfg(not(feature = "hw-video"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_consume_video_raw_close(_consumer: u32) -> i32 {
+	ffi::enter(|| Result::<(), Error>::Err(Error::Unsupported))
+}
+
+/// Video decode is unavailable in this build (compiled without the `hw-video` feature);
+/// returns [`Error::Unsupported`].
+///
+/// # Safety
+/// - `_dst` must point to a writable [`moq_video_frame`] (unused; not written here).
+#[cfg(not(feature = "hw-video"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn moq_consume_video_raw_frame(_id: u32, _dst: *mut moq_video_frame) -> i32 {
+	ffi::enter(|| Result::<(), Error>::Err(Error::Unsupported))
+}
+
+#[cfg(not(feature = "hw-video"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn moq_consume_video_raw_frame_free(_id: u32) -> i32 {
+	ffi::enter(|| Result::<(), Error>::Err(Error::Unsupported))
 }

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -58,6 +58,10 @@ pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
 	// Bytes carried across calls: a partial atom at the tail of one `decode` waits
 	// here for the rest to arrive on the next call.
 	buffer: BytesMut,
+
+	// When set, audio fragments accumulate into the caller's current group instead of opening a
+	// group per fragment; the caller bounds groups via seek. Video still groups on its keyframes.
+	manual_grouping: bool,
 }
 
 #[derive(PartialEq, Debug)]
@@ -118,7 +122,15 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			moof_size: 0,
 			broadcast,
 			buffer: BytesMut::new(),
+			manual_grouping: false,
 		}
+	}
+
+	/// Enable caller-driven grouping: audio fragments accumulate into the current group instead of
+	/// opening one per fragment (the caller bounds groups via [`seek`](Self::seek)). Video is
+	/// unaffected (it groups on its own keyframes). Default false (one group per fragment).
+	pub fn set_manual_grouping(&mut self, enabled: bool) {
+		self.manual_grouping = enabled;
 	}
 
 	/// Restrict which track roles are published.
@@ -530,6 +542,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	fn extract(&mut self, mdat: Mdat, mdat_raw: &[u8]) -> Result<()> {
 		let moov = self.moov.as_ref().ok_or(Error::NoMoov)?;
 		let moof = self.moof.take().ok_or(Error::NoMoof)?;
+		let manual_grouping = self.manual_grouping;
 		let moof_size = self.moof_size;
 		let header_size = mdat_raw.len() - mdat.data.len();
 
@@ -752,7 +765,20 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			let fragment_bytes = Bytes::from(moof_buf);
 
 			// Write the per-track fragment as a single MoQ frame (passthrough).
-			let mut g = if contains_keyframe {
+			//
+			// Default: a keyframe fragment opens a new group. With manual grouping the group opens only
+			// at an explicit caller boundary (`pending_sequence` from a seek), a video keyframe, or when
+			// none is open yet. Audio samples are all flagged keyframes (for the consumer's
+			// independent-decode path), so that must NOT open a group per audio fragment: audio frames
+			// belong to the segment's group, which the caller opens at its own cadence.
+			let start_group = if manual_grouping {
+				track.pending_sequence.is_some()
+					|| track.group.is_none()
+					|| (contains_keyframe && matches!(track.kind, TrackKind::Video))
+			} else {
+				contains_keyframe
+			};
+			let mut g = if start_group {
 				if let Some(mut prev) = track.group.take() {
 					prev.finish()?;
 				}

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -501,3 +501,71 @@ fn test_flac_catalog() {
 	let desc = a.description.as_ref().expect("flac description");
 	assert_eq!(&desc[..4], b"fLaC");
 }
+
+/// Feed every fragment of bbb.mp4 through the importer with no explicit seek and return how many
+/// groups the audio track produced. Grouping is then driven purely by policy: one group per
+/// fragment (default) versus accumulate (manual).
+#[cfg(test)]
+async fn fmp4_audio_group_count(manual_grouping: bool) -> usize {
+	use mp4_atom::{Any, DecodeMaybe};
+
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let broadcast_consumer = broadcast.consume();
+	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.reserve());
+	fmp4.set_manual_grouping(manual_grouping);
+
+	let data = include_bytes!("test_data/bbb.mp4");
+	let mut init_buf = bytes::BytesMut::new();
+	let mut frag_buf = bytes::BytesMut::new();
+	let mut cursor = std::io::Cursor::new(&data[..]);
+	let mut position = 0;
+	while let Some(atom) = mp4_atom::Any::decode_maybe(&mut cursor).unwrap_or(None) {
+		let end = cursor.position() as usize;
+		let bytes = &data[position..end];
+		match atom {
+			Any::Ftyp(_) | Any::Styp(_) | Any::Moov(_) => init_buf.extend_from_slice(bytes),
+			_ => frag_buf.extend_from_slice(bytes),
+		}
+		position = end;
+	}
+
+	fmp4.decode(&init_buf).unwrap();
+
+	let snap = catalog.snapshot();
+	let audio_name = snap.audio.renditions.keys().next().expect("audio track").clone();
+	let mut audio_track = broadcast_consumer
+		.track(&audio_name)
+		.unwrap()
+		.subscribe(None)
+		.await
+		.expect("audio track should exist");
+
+	// Trailing partial fragments may error; ignore.
+	let _ = fmp4.decode(&frag_buf);
+	fmp4.finish().unwrap();
+
+	drain_group_sequences(&mut audio_track).len()
+}
+
+/// Default: the CMAF passthrough opens a MoQ group per audio fragment (audio samples are all
+/// flagged keyframes), so many fragments yield many groups.
+#[tokio::test]
+async fn fmp4_audio_groups_per_fragment_by_default() {
+	let count = fmp4_audio_group_count(false).await;
+	assert!(
+		count > 1,
+		"default should open a group per audio fragment (got {count})"
+	);
+}
+
+/// With manual grouping and no explicit seek, audio fragments accumulate into a single group
+/// instead of one per fragment. This is what lets an origin align audio to a segment cadence.
+#[tokio::test]
+async fn fmp4_manual_grouping_accumulates_audio() {
+	let count = fmp4_audio_group_count(true).await;
+	assert_eq!(
+		count, 1,
+		"manual grouping should accumulate audio fragments into one group (got {count})"
+	);
+}

--- a/rs/moq-mux/src/import/container.rs
+++ b/rs/moq-mux/src/import/container.rs
@@ -70,6 +70,12 @@ impl<E: crate::container::ts::Catalog> ContainerImpl<E> {
 			ContainerImpl::Flv(decoder) => decoder.seek(sequence),
 		}
 	}
+
+	fn set_manual_grouping(&mut self, enabled: bool) {
+		if let ContainerImpl::Fmp4(decoder) = self {
+			decoder.set_manual_grouping(enabled);
+		}
+	}
 }
 
 /// A container importer for whole chunks.
@@ -118,6 +124,13 @@ impl<E: crate::container::ts::Catalog> Container<E> {
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.inner.seek(sequence)
+	}
+
+	/// Enable caller-driven grouping (fMP4): audio fragments accumulate into the current group
+	/// instead of opening one per fragment; the caller bounds groups via [`seek`](Self::seek).
+	/// No-op for other container formats.
+	pub fn set_manual_grouping(&mut self, enabled: bool) {
+		self.inner.set_manual_grouping(enabled)
 	}
 }
 
@@ -169,5 +182,12 @@ impl<E: crate::container::ts::Catalog> ContainerStream<E> {
 	/// Close the current group and open the next one at `sequence`.
 	pub fn seek(&mut self, sequence: u64) -> Result<()> {
 		self.inner.seek(sequence)
+	}
+
+	/// Enable caller-driven grouping (fMP4): audio fragments accumulate into the current group
+	/// instead of opening one per fragment; the caller bounds groups via [`seek`](Self::seek).
+	/// No-op for other container formats.
+	pub fn set_manual_grouping(&mut self, enabled: bool) {
+		self.inner.set_manual_grouping(enabled)
 	}
 }

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -157,6 +157,10 @@ enum TrackKind<E: CatalogExt = ()> {
 /// `seek` rather than going through this facade.
 pub struct Track<E: CatalogExt = ()> {
 	kind: TrackKind<E>,
+	/// When set, decode() stops cutting a group after each audio frame, so frames accumulate into
+	/// the current group and the caller bounds groups via cut()/seek(). Lets an origin drive its own
+	/// audio grouping through this facade. Default false (one group per audio frame).
+	manual_grouping: bool,
 }
 
 impl<E: CatalogExt> Track<E> {
@@ -229,11 +233,15 @@ impl<E: CatalogExt> Track<E> {
 			_ => return Err(crate::Error::UnknownFormat(init.format)),
 		};
 
-		Ok(Self { kind })
+		Ok(Self {
+			kind,
+			manual_grouping: false,
+		})
 	}
 
 	/// Decode one whole frame.
 	pub fn decode<B: moq_net::IntoBytes>(&mut self, frame: B, pts: Option<moq_net::Timestamp>) -> Result<()> {
+		let manual_grouping = self.manual_grouping;
 		match self.kind {
 			TrackKind::Avc3 {
 				ref mut split,
@@ -283,19 +291,27 @@ impl<E: CatalogExt> Track<E> {
 			// waiting. A caller wanting multi-frame audio groups drives a codec importer directly.
 			TrackKind::Aac(ref mut import) => {
 				import.decode(frame, pts)?;
-				import.cut(None)?;
+				if !manual_grouping {
+					import.cut(None)?;
+				}
 			}
 			TrackKind::Opus(ref mut import) => {
 				import.decode(frame, pts)?;
-				import.cut(None)?;
+				if !manual_grouping {
+					import.cut(None)?;
+				}
 			}
 			TrackKind::Mp3(ref mut import) => {
 				import.decode(frame, pts)?;
-				import.cut(None)?;
+				if !manual_grouping {
+					import.cut(None)?;
+				}
 			}
 			TrackKind::Flac(ref mut import) => {
 				import.decode(frame, pts)?;
-				import.cut(None)?;
+				if !manual_grouping {
+					import.cut(None)?;
+				}
 			}
 		}
 
@@ -335,6 +351,14 @@ impl<E: CatalogExt> Track<E> {
 			TrackKind::Mp3(import) => import.abort(err),
 			TrackKind::Flac(import) => import.abort(err),
 		}
+	}
+
+	/// Opt out of the per-frame audio grouping this facade does by default. When enabled, decode()
+	/// stops cutting a group after each audio frame; frames accumulate into the current group and the
+	/// caller bounds groups explicitly via [`cut`](Self::cut) / [`seek`](Self::seek) (a segment
+	/// cadence). No effect on video, which groups by its own keyframes. Default false.
+	pub fn set_manual_grouping(&mut self, enabled: bool) {
+		self.manual_grouping = enabled;
 	}
 
 	/// Cut the current group at `end` without finishing the track.
@@ -419,6 +443,7 @@ impl<E: CatalogExt> From<crate::codec::opus::Import<E>> for Track<E> {
 	fn from(opus: crate::codec::opus::Import<E>) -> Self {
 		Self {
 			kind: TrackKind::Opus(opus),
+			manual_grouping: false,
 		}
 	}
 }
@@ -427,6 +452,7 @@ impl<E: CatalogExt> From<crate::codec::aac::Import<E>> for Track<E> {
 	fn from(aac: crate::codec::aac::Import<E>) -> Self {
 		Self {
 			kind: TrackKind::Aac(aac),
+			manual_grouping: false,
 		}
 	}
 }
@@ -438,6 +464,7 @@ impl<E: CatalogExt> From<crate::codec::mp3::Import<E>> for Track<E> {
 	fn from(mp3: crate::codec::mp3::Import<E>) -> Self {
 		Self {
 			kind: TrackKind::Mp3(mp3),
+			manual_grouping: false,
 		}
 	}
 }
@@ -830,6 +857,28 @@ mod tests {
 		import.finish().unwrap();
 
 		assert_eq!(collect_groups(subscriber).await, vec![1, 1, 1]);
+	}
+
+	/// With manual grouping the facade stops cutting per frame, so audio accumulates into a single
+	/// group until the caller cuts or seeks. This is how an origin drives aligned audio groups
+	/// (a segment cadence) through the facade instead of one group per packet.
+	#[tokio::test(start_paused = true)]
+	async fn manual_grouping_accumulates_audio() {
+		let (mut broadcast, catalog) = new_broadcast();
+		let (import, subscriber) = opus_import(&mut broadcast, &catalog);
+		let mut import: Track = import.into();
+		import.set_manual_grouping(true);
+
+		import.decode(b"a", Some(Timestamp::from_micros(0).unwrap())).unwrap();
+		import
+			.decode(b"b", Some(Timestamp::from_micros(10_000).unwrap()))
+			.unwrap();
+		import
+			.decode(b"c", Some(Timestamp::from_micros(20_000).unwrap()))
+			.unwrap();
+		import.finish().unwrap();
+
+		assert_eq!(collect_groups(subscriber).await, vec![3]);
 	}
 
 	/// Driven directly (not through the facade), the codec importer accumulates audio frames into the


### PR DESCRIPTION
Caller-driven group boundaries for audio + libmoq opt-in knobs

Lets a native publisher drive explicit, synchronized MoQ group boundaries instead of opening a new group (and QUIC stream) per audio frame — AAC flags every frame a keyframe, which was storming streams and desyncing co-multiplexed video. The spec only requires a group to start with a keyframe, not a new group at every one.

Features

moq-mux — caller-driven audio grouping. container::Producer gains keyframe_starts_group (default true, unchanged) + with_/set_keyframe_grouping; when off, keyframes accumulate and the caller bounds groups via seek/cut. AAC importer opts in; fmp4 import starts a group only at an explicit boundary, a video keyframe, or when none is open (audio rides the segment cadence, not one group per fragment).

libmoq — group-boundary C-ABI. moq_publish_media_group (forces a synchronized, explicitly-numbered boundary across a media importer's tracks) and moq_publish_media_keyframe_grouping (opt a track into caller-driven audio grouping).

libmoq — hardware video is now opt-in. moq-video moves behind a default-off hw-video feature, so a stock build needs no libva/CUDA; moq_consume_video_raw* stay in the ABI and return Unsupported without it.

libmoq — connection knobs. moq_tls_disable_verify (dev / self-signed relays) and moq_backoff_config (reconnect backoff)