### PR TITLE
feat(capture): enumerate Linux and Windows sources

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -136,9 +136,9 @@ The video source is one of `--camera`, `--display`, `--window`, or `--app`;
 without one, `capture` opens the default camera. `--camera` and `--display` also
 take no value, meaning "the default one".
 
-`moq devices` lists every source and the id each flag expects, so you can read an
-id off it and paste it straight in. It talks only to the local hardware, so it is
-the one verb that takes no MoQ side:
+`moq devices` lists every source the current platform can enumerate and the id
+each flag expects, so you can read an id off it and paste it straight in. It
+talks only to the local hardware, so it is the one verb that takes no MoQ side:
 
 ```bash
 moq devices

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -49,14 +49,14 @@ impl From<VideoCodec> for moq_video::encode::Codec {
 #[command(group = clap::ArgGroup::new("audio-source").multiple(false))]
 pub struct CaptureArgs {
 	/// Capture a camera, by the id `moq devices` reports (an AVFoundation
-	/// `uniqueID` on macOS, a camera index / `/dev/videoN` path elsewhere).
+	/// `uniqueID`, `/dev/videoN` path, or Media Foundation symbolic link).
 	/// Bare `--camera`, or no source flag at all, opens the default camera.
 	#[arg(long, num_args = 0..=1, group = "video-source")]
 	pub camera: Option<Option<String>>,
 
-	/// Capture a whole display, by the index `moq devices` reports. Bare
+	/// Capture a whole display, by the id `moq devices` reports. Bare
 	/// `--display` captures the main display. On Linux the desktop portal opens a
-	/// picker dialog and the index is ignored.
+	/// picker dialog and the id is ignored.
 	#[arg(long, num_args = 0..=1, group = "video-source", alias = "screen")]
 	pub display: Option<Option<String>>,
 

--- a/rs/moq-video/CHANGELOG.md
+++ b/rs/moq-video/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- List V4L2 and Media Foundation cameras on Linux and Windows, and list DXGI
+  displays on Windows, using identifiers accepted by `capture::Source`.
+
 ## [0.0.8](https://github.com/moq-dev/moq/compare/moq-video-v0.0.7...moq-video-v0.0.8) - 2026-07-23
 
 ### Other

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -129,6 +129,7 @@ windows = { version = "0.62", features = [
     "Win32_Graphics_Direct3D11",
     "Win32_Graphics_Dxgi",
     "Win32_Graphics_Dxgi_Common",
+    "Win32_Graphics_Gdi",
     "Win32_System_Ole",
     "Win32_System_Variant",
 ] }

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -25,6 +25,11 @@ Per-platform, picked at compile time:
   Desktop Duplication (display; BGRA -> CPU I420). Display capture is
   whole-monitor; select one with a bare index or `display:{index}`.
 
+`capture::cameras()` lists AVFoundation, V4L2, or Media Foundation cameras with
+identifiers accepted by `capture::Source::Camera`. `capture::displays()` does
+the same for macOS and Windows displays. Linux display selection stays in the
+desktop portal picker, which does not expose a stable display identifier.
+
 ## Encode
 
 The codec is chosen via `encode::Codec`. Backends are tried in order (hardware

--- a/rs/moq-video/src/capture/desktopduplication.rs
+++ b/rs/moq-video/src/capture/desktopduplication.rs
@@ -20,8 +20,8 @@ use windows::Win32::Graphics::Direct3D11::{
 	ID3D11Device, ID3D11DeviceContext, ID3D11Texture2D,
 };
 use windows::Win32::Graphics::Dxgi::{
-	DXGI_ERROR_ACCESS_LOST, DXGI_ERROR_WAIT_TIMEOUT, DXGI_OUTDUPL_FRAME_INFO, IDXGIAdapter, IDXGIDevice, IDXGIOutput1,
-	IDXGIOutputDuplication, IDXGIResource,
+	DXGI_ERROR_ACCESS_LOST, DXGI_ERROR_NOT_FOUND, DXGI_ERROR_WAIT_TIMEOUT, DXGI_OUTDUPL_FRAME_INFO, IDXGIAdapter,
+	IDXGIDevice, IDXGIOutput1, IDXGIOutputDuplication, IDXGIResource,
 };
 use windows::core::Interface;
 
@@ -35,6 +35,42 @@ const DEFAULT_FRAMERATE: u32 = 30;
 
 fn err(ctx: &str, e: windows::core::Error) -> Error {
 	Error::Codec(anyhow::anyhow!("{ctx}: {e}"))
+}
+
+/// List the outputs on the same adapter [`open`] can capture.
+pub(super) fn displays() -> Result<Vec<super::Display>, Error> {
+	let device = d3d11::create_device()?;
+	let adapter = adapter(&device)?;
+	let mut displays = Vec::new();
+
+	for index in 0.. {
+		let output = match unsafe { adapter.EnumOutputs(index) } {
+			Ok(output) => output,
+			Err(error) if error.code() == DXGI_ERROR_NOT_FOUND => break,
+			Err(error) => return Err(err("EnumOutputs", error)),
+		};
+		let desc = unsafe { output.GetDesc().map_err(|error| err("GetDesc", error))? };
+		if !desc.AttachedToDesktop.as_bool() {
+			continue;
+		}
+
+		let name_end = desc
+			.DeviceName
+			.iter()
+			.position(|character| *character == 0)
+			.unwrap_or(desc.DeviceName.len());
+		let name = String::from_utf16_lossy(&desc.DeviceName[..name_end]);
+		let width = (desc.DesktopCoordinates.right - desc.DesktopCoordinates.left).unsigned_abs();
+		let height = (desc.DesktopCoordinates.bottom - desc.DesktopCoordinates.top).unsigned_abs();
+		displays.push(super::Display {
+			id: format!("display:{index}"),
+			name,
+			width,
+			height,
+		});
+	}
+
+	Ok(displays)
 }
 
 /// Open a display capture and stream its frames over a pump thread.
@@ -295,10 +331,7 @@ fn select_output(selector: Option<&str>) -> Result<u32, Error> {
 
 /// Get the `index`th output (monitor) attached to the device's adapter.
 fn enumerate_output(device: &ID3D11Device, index: u32) -> Result<IDXGIOutput1, Error> {
-	let dxgi = device
-		.cast::<IDXGIDevice>()
-		.map_err(|e| err("device is not a DXGI device", e))?;
-	let adapter: IDXGIAdapter = unsafe { dxgi.GetAdapter().map_err(|e| err("GetAdapter", e))? };
+	let adapter = adapter(device)?;
 	let output = unsafe {
 		adapter
 			.EnumOutputs(index)
@@ -307,6 +340,14 @@ fn enumerate_output(device: &ID3D11Device, index: u32) -> Result<IDXGIOutput1, E
 	output
 		.cast::<IDXGIOutput1>()
 		.map_err(|e| err("output is not IDXGIOutput1", e))
+}
+
+/// The DXGI adapter backing a Direct3D device.
+fn adapter(device: &ID3D11Device) -> Result<IDXGIAdapter, Error> {
+	let dxgi = device
+		.cast::<IDXGIDevice>()
+		.map_err(|e| err("device is not a DXGI device", e))?;
+	unsafe { dxgi.GetAdapter().map_err(|e| err("GetAdapter", e)) }
 }
 
 /// Start duplicating `output` on `device`.

--- a/rs/moq-video/src/capture/mediafoundation.rs
+++ b/rs/moq-video/src/capture/mediafoundation.rs
@@ -16,14 +16,14 @@ use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11Texture2D};
 use windows::Win32::Media::MediaFoundation::{
 	IMF2DBuffer, IMFActivate, IMFAttributes, IMFDXGIBuffer, IMFDXGIDeviceManager, IMFMediaSource, IMFSample,
 	IMFSourceReader, MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME, MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE,
-	MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_GUID, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE, MF_MT_MAJOR_TYPE,
-	MF_MT_SUBTYPE, MF_SOURCE_READER_D3D_MANAGER, MF_SOURCE_READER_ENABLE_ADVANCED_VIDEO_PROCESSING,
-	MF_SOURCE_READER_ENABLE_VIDEO_PROCESSING, MF_SOURCE_READER_FIRST_VIDEO_STREAM, MF_SOURCE_READERF_ENDOFSTREAM,
-	MFCreateAttributes, MFCreateMediaType, MFCreateSourceReaderFromMediaSource, MFEnumDeviceSources, MFMediaType_Video,
-	MFVideoFormat_NV12,
+	MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_GUID, MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK,
+	MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE, MF_MT_MAJOR_TYPE, MF_MT_SUBTYPE, MF_SOURCE_READER_D3D_MANAGER,
+	MF_SOURCE_READER_ENABLE_ADVANCED_VIDEO_PROCESSING, MF_SOURCE_READER_ENABLE_VIDEO_PROCESSING,
+	MF_SOURCE_READER_FIRST_VIDEO_STREAM, MF_SOURCE_READERF_ENDOFSTREAM, MFCreateAttributes, MFCreateMediaType,
+	MFCreateSourceReaderFromMediaSource, MFEnumDeviceSources, MFMediaType_Video, MFVideoFormat_NV12,
 };
 use windows::Win32::System::Com::CoTaskMemFree;
-use windows::core::{Interface, PWSTR};
+use windows::core::{GUID, Interface, PWSTR};
 
 use super::channel::FrameChannel;
 use super::pump::{self, Geometry};
@@ -31,6 +31,18 @@ use super::{Config, FrameStream};
 use crate::Error;
 use crate::frame::d3d11::Texture;
 use crate::frame::{Frame, I420};
+
+/// List Media Foundation capture devices by their stable symbolic links.
+pub(super) fn cameras() -> Result<Vec<super::Camera>, Error> {
+	let _com = ComGuard::new()?;
+	Ok(enumerate_sources()?
+		.into_iter()
+		.map(|source| super::Camera {
+			id: source.id,
+			name: source.name,
+		})
+		.collect())
+}
 
 /// Open a Media Foundation camera and stream its frames over a pump thread.
 pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameStream, Error> {
@@ -322,21 +334,57 @@ fn create_attributes(capacity: u32) -> Result<IMFAttributes, Error> {
 /// Which device to open.
 enum Selector {
 	Index(usize),
-	Name(String),
+	IdOrName(String),
 }
 
 /// Enumerate video capture devices and activate the one matching `selector`
-/// (a bare integer selects by index, anything else is a friendly-name substring;
-/// `None` opens index 0).
+/// (a bare integer selects by index, anything else is an exact symbolic link or
+/// a friendly-name substring; `None` opens index 0).
 fn open_source(selector: Option<&str>) -> Result<(IMFMediaSource, String), Error> {
 	let selector = match selector {
 		None => Selector::Index(0),
 		Some(spec) => match spec.parse::<usize>() {
 			Ok(i) => Selector::Index(i),
-			Err(_) => Selector::Name(spec.to_string()),
+			Err(_) => Selector::IdOrName(spec.to_string()),
 		},
 	};
 
+	let sources = enumerate_sources()?;
+	let count = sources.len();
+	let chosen = sources
+		.into_iter()
+		.enumerate()
+		.find(|(index, source)| match &selector {
+			Selector::Index(want) => *index == *want,
+			Selector::IdOrName(want) => {
+				source.id.eq_ignore_ascii_case(want) || source.name.to_lowercase().contains(&want.to_lowercase())
+			}
+		})
+		.map(|(_, source)| source);
+
+	let source = chosen.ok_or_else(|| match &selector {
+		Selector::Index(i) => Error::Codec(anyhow::anyhow!("camera index {i} out of range ({count} found)")),
+		Selector::IdOrName(value) => Error::Codec(anyhow::anyhow!("no camera matching {value:?} ({count} found)")),
+	})?;
+
+	let media: IMFMediaSource = unsafe {
+		source
+			.activate
+			.ActivateObject()
+			.map_err(|e| mf_err("activate device", e))?
+	};
+	Ok((media, source.name))
+}
+
+/// One Media Foundation capture source and the metadata exposed publicly.
+struct SourceInfo {
+	activate: IMFActivate,
+	id: String,
+	name: String,
+}
+
+/// Enumerate every Media Foundation video-capture source on the current thread.
+fn enumerate_sources() -> Result<Vec<SourceInfo>, Error> {
 	let attrs = create_attributes(1)?;
 	unsafe {
 		attrs
@@ -353,47 +401,35 @@ fn open_source(selector: Option<&str>) -> Result<(IMFMediaSource, String), Error
 		MFEnumDeviceSources(&attrs, &mut activates, &mut count).map_err(|e| mf_err("enumerate devices", e))?;
 	}
 	if count == 0 {
-		return Err(Error::Codec(anyhow::anyhow!("no video capture devices found")));
+		return Ok(Vec::new());
 	}
 
 	// `MFEnumDeviceSources` hands back a CoTaskMemAlloc'd array, each entry holding
-	// one ref we own. `take()` each into an owned handle so the unmatched ones drop
-	// (release) here; the chosen one stays alive. Then free the array itself.
+	// one ref we own. `take()` each into an owned handle, then free the array.
 	let entries = unsafe { slice::from_raw_parts_mut(activates, count as usize) };
-	let mut chosen: Option<(IMFActivate, String)> = None;
+	let mut sources = Vec::with_capacity(count as usize);
 	for (i, slot) in entries.iter_mut().enumerate() {
 		let Some(activate) = slot.take() else { continue };
-		let name = unsafe { friendly_name(&activate) }.unwrap_or_else(|_| format!("camera {i}"));
-		let matched = match &selector {
-			Selector::Index(idx) => i == *idx,
-			Selector::Name(want) => name.to_lowercase().contains(&want.to_lowercase()),
-		};
-		if matched && chosen.is_none() {
-			chosen = Some((activate, name));
-		}
+		let name = unsafe { allocated_string(&activate, &MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME) }
+			.unwrap_or_else(|_| format!("camera {i}"));
+		let id = unsafe { allocated_string(&activate, &MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK) }
+			.unwrap_or_else(|_| i.to_string());
+		sources.push(SourceInfo { activate, id, name });
 	}
 	unsafe {
 		CoTaskMemFree(Some(activates as *const c_void));
 	}
-
-	let (activate, name) = chosen.ok_or_else(|| match &selector {
-		Selector::Index(i) => Error::Codec(anyhow::anyhow!("camera index {i} out of range ({count} found)")),
-		Selector::Name(n) => Error::Codec(anyhow::anyhow!("no camera matching {n:?} ({count} found)")),
-	})?;
-
-	let source: IMFMediaSource = unsafe { activate.ActivateObject().map_err(|e| mf_err("activate device", e))? };
-	Ok((source, name))
+	Ok(sources)
 }
 
-/// Read a device's `MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME`, freeing the
-/// COM-allocated string afterward.
-unsafe fn friendly_name(activate: &IMFActivate) -> Result<String, Error> {
+/// Read an allocated string attribute, freeing the COM allocation afterward.
+unsafe fn allocated_string(activate: &IMFActivate, key: &GUID) -> Result<String, Error> {
 	let mut value = PWSTR::null();
 	let mut len: u32 = 0;
 	unsafe {
 		activate
-			.GetAllocatedString(&MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME, &mut value, &mut len)
-			.map_err(|e| mf_err("friendly name", e))?;
+			.GetAllocatedString(key, &mut value, &mut len)
+			.map_err(|e| mf_err("capture source attribute", e))?;
 	}
 	let name = unsafe { value.to_string() }.unwrap_or_default();
 	unsafe {

--- a/rs/moq-video/src/capture/mod.rs
+++ b/rs/moq-video/src/capture/mod.rs
@@ -67,8 +67,9 @@ mod pump;
 pub enum Source {
 	/// A camera / webcam. `None` opens the default camera.
 	///
-	/// macOS takes an AVFoundation `uniqueID`; other platforms take a bare
-	/// integer (`"0"`) as an index, else a device path/name.
+	/// The identifiers from [`cameras`] are an AVFoundation `uniqueID` on macOS,
+	/// a `/dev/videoN` path on Linux, and a Media Foundation symbolic link on
+	/// Windows. Bare numeric indices remain accepted on every platform.
 	Camera(Option<String>),
 
 	/// A whole display. `None` opens the main display.
@@ -136,10 +137,10 @@ pub struct Display {
 	pub id: String,
 	/// Human-readable name, e.g. "Display 1".
 	pub name: String,
-	/// Width in points, i.e. the logical size, which is what capture defaults to.
-	/// A 2x retina display reports half its native pixel width.
+	/// Width in the platform's desktop coordinate space. This is points on
+	/// macOS and desktop pixels on Windows.
 	pub width: u32,
-	/// Height in points. See [`width`](Self::width).
+	/// Height in the platform's desktop coordinate space.
 	pub height: u32,
 }
 
@@ -362,26 +363,40 @@ pub(crate) async fn open(config: &Config) -> Result<FrameStream, Error> {
 	}
 }
 
-/// List the available cameras. macOS only for now.
+/// List the available cameras and the identifiers [`Source::Camera`] accepts.
 pub async fn cameras() -> Result<Vec<Camera>, Error> {
 	#[cfg(target_os = "macos")]
 	{
 		avfoundation::cameras()
 	}
-	#[cfg(not(target_os = "macos"))]
+	#[cfg(target_os = "linux")]
+	{
+		blocking(v4l2::cameras).await
+	}
+	#[cfg(target_os = "windows")]
+	{
+		blocking(mediafoundation::cameras).await
+	}
+	#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
 	{
 		Err(Error::Unsupported("listing cameras".to_string()))
 	}
 }
 
-/// List the available displays. macOS only for now: on Linux the
-/// xdg-desktop-portal picker owns display selection.
+/// List the available displays and the identifiers [`Source::Display`] accepts.
+///
+/// On Linux the xdg-desktop-portal picker owns display selection, so there is no
+/// list or stable identifier to expose.
 pub async fn displays() -> Result<Vec<Display>, Error> {
 	#[cfg(target_os = "macos")]
 	{
 		screencapture::displays().await
 	}
-	#[cfg(not(target_os = "macos"))]
+	#[cfg(target_os = "windows")]
+	{
+		blocking(desktopduplication::displays).await
+	}
+	#[cfg(not(any(target_os = "macos", target_os = "windows")))]
 	{
 		Err(Error::Unsupported("listing displays".to_string()))
 	}
@@ -409,4 +424,16 @@ pub async fn apps() -> Result<Vec<App>, Error> {
 	{
 		Err(Error::Unsupported("listing applications".to_string()))
 	}
+}
+
+/// Run synchronous platform enumeration off the async runtime's worker threads.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+async fn blocking<T, F>(f: F) -> Result<T, Error>
+where
+	F: FnOnce() -> Result<T, Error> + Send + 'static,
+	T: Send + 'static,
+{
+	tokio::task::spawn_blocking(f)
+		.await
+		.map_err(|err| Error::Codec(anyhow::anyhow!("capture enumeration thread failed: {err}")))?
 }

--- a/rs/moq-video/src/capture/mod.rs
+++ b/rs/moq-video/src/capture/mod.rs
@@ -69,7 +69,7 @@ pub enum Source {
 	///
 	/// The identifiers from [`cameras`] are an AVFoundation `uniqueID` on macOS,
 	/// a `/dev/videoN` path on Linux, and a Media Foundation symbolic link on
-	/// Windows. Bare numeric indices remain accepted on every platform.
+	/// Windows. Bare numeric indices remain accepted on Linux and Windows.
 	Camera(Option<String>),
 
 	/// A whole display. `None` opens the main display.

--- a/rs/moq-video/src/capture/v4l2.rs
+++ b/rs/moq-video/src/capture/v4l2.rs
@@ -7,6 +7,7 @@
 //! NVENC / VAAPI / openh264; there's no GPU surface here.
 
 use v4l::buffer::Type as BufType;
+use v4l::capability::Flags;
 use v4l::io::mmap::Stream as MmapStream;
 use v4l::io::traits::CaptureStream;
 use v4l::video::Capture;
@@ -19,6 +20,42 @@ use super::pump::{self, Geometry};
 use super::{Config, FrameStream};
 use crate::Error;
 use crate::frame::{Frame, I420};
+
+/// List V4L2 capture nodes using paths that [`open_device`] accepts.
+pub(super) fn cameras() -> Result<Vec<super::Camera>, Error> {
+	let mut nodes = v4l::context::enum_devices();
+	nodes.sort_by_key(v4l::context::Node::index);
+
+	let cameras = nodes
+		.into_iter()
+		.filter_map(|node| {
+			let path = node.path().to_string_lossy().into_owned();
+			let device = match Device::with_path(node.path()) {
+				Ok(device) => device,
+				Err(err) => {
+					tracing::debug!(device = %path, error = %err, "could not inspect V4L2 node");
+					return None;
+				}
+			};
+			let capabilities = match device.query_caps() {
+				Ok(capabilities) => capabilities,
+				Err(err) => {
+					tracing::debug!(device = %path, error = %err, "could not query V4L2 node");
+					return None;
+				}
+			};
+			if !capabilities.capabilities.contains(Flags::VIDEO_CAPTURE)
+				|| !capabilities.capabilities.contains(Flags::STREAMING)
+			{
+				return None;
+			}
+
+			let name = node.name().filter(|name| !name.is_empty()).unwrap_or(capabilities.card);
+			Some(super::Camera { id: path, name })
+		})
+		.collect();
+	Ok(cameras)
+}
 
 /// Open a V4L2 camera and stream its frames over a pump thread.
 pub(super) async fn open(config: &Config, device: Option<&str>) -> Result<FrameStream, Error> {


### PR DESCRIPTION
## Summary

- enumerate Linux V4L2 cameras, filtering for streaming capture nodes and returning `/dev/videoN` identifiers accepted by `capture::Source::Camera`
- enumerate Windows Media Foundation cameras with stable symbolic-link identifiers while preserving index and friendly-name selection
- enumerate Windows DXGI displays with selector-compatible IDs, names, and dimensions
- keep synchronous platform enumeration off async runtime worker threads and update the CLI and crate documentation

Closes #2321.

## Public API changes

- `moq_video::capture::cameras()` now works on Linux and Windows instead of returning `Error::Unsupported`
- `moq_video::capture::displays()` now works on Windows instead of returning `Error::Unsupported`
- no symbols or signatures changed; these are additive platform implementations targeting `main`

Cross-package sync: no table row applies to these additive `moq-video` capture implementations. The consuming `moq-cli` help and user documentation are updated in this PR.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command cargo test -p moq-video` (48 unit tests and doctests passed)
- Windows cross-target `cargo check` passed after selecting dynamic OpenH264 solely to avoid requiring the MSVC C++ toolchain for the check
- Linux cross-target checking was attempted, but this macOS environment lacks `x86_64-linux-gnu-g++` and `linux/videodev2.h`; native Linux CI remains the platform verification

(Written by GPT-5)
