### PR TITLE
fix(opus): propagate pre-skip and encoder controls

### DIFF
--- a/js/hang/src/container/cmaf/encode.ts
+++ b/js/hang/src/container/cmaf/encode.ts
@@ -55,6 +55,7 @@ import {
 import type * as Catalog from "../../catalog";
 import * as Aac from "../../util/aac";
 import * as Hex from "../../util/hex";
+import * as Opus from "../../util/opus";
 
 // Identity matrix for tkhd/mvhd (stored as 16.16 fixed point)
 const IDENTITY_MATRIX = [0x00010000, 0, 0, 0, 0x00010000, 0, 0, 0, 0x40000000];
@@ -839,10 +840,9 @@ function createEsdsBox(sampleRate: number, channelCount: number, description?: s
  * See https://opus-codec.org/docs/opus_in_isobmff.html
  */
 function createDOpsBox(channelCount: number, sampleRate: number, description?: string): Uint8Array {
-	// If description is provided, it's the OpusHead without the magic signature
 	if (description) {
-		const opusHead = Hex.toBytes(description);
-		const dOpsSize = 8 + opusHead.length;
+		const payload = Opus.toDOps(Hex.toBytes(description));
+		const dOpsSize = 8 + payload.length;
 		const dOps = new Uint8Array(dOpsSize);
 		const view = new DataView(dOps.buffer);
 
@@ -851,7 +851,7 @@ function createDOpsBox(channelCount: number, sampleRate: number, description?: s
 		dOps[5] = 0x4f; // 'O'
 		dOps[6] = 0x70; // 'p'
 		dOps[7] = 0x73; // 's'
-		dOps.set(opusHead, 8);
+		dOps.set(payload, 8);
 
 		return dOps;
 	}

--- a/js/hang/src/util/opus.test.ts
+++ b/js/hang/src/util/opus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { pickRate, SAMPLE_RATES, supportsRate } from "./opus";
+import { pickRate, SAMPLE_RATES, supportsRate, toDOps } from "./opus";
 
 describe("pickRate", () => {
 	// Matches the pick_opus_rate tests in rs/moq-audio/src/codec.rs.
@@ -38,5 +38,32 @@ describe("supportsRate", () => {
 		for (const rate of SAMPLE_RATES) {
 			expect(supportsRate(rate)).toBe(true);
 		}
+	});
+});
+
+describe("toDOps", () => {
+	it("converts OpusHead fields and byte order", () => {
+		const head = new Uint8Array(19);
+		head.set(new TextEncoder().encode("OpusHead"));
+		head[8] = 1;
+		head[9] = 2;
+		const view = new DataView(head.buffer);
+		view.setUint16(10, 312, true);
+		view.setUint32(12, 48_000, true);
+		view.setInt16(16, -2, true);
+
+		const dops = toDOps(head);
+		const dopsView = new DataView(dops.buffer);
+		expect(dops[0]).toBe(0);
+		expect(dops[1]).toBe(2);
+		expect(dopsView.getUint16(2, false)).toBe(312);
+		expect(dopsView.getUint32(4, false)).toBe(48_000);
+		expect(dopsView.getInt16(8, false)).toBe(-2);
+		expect(dops[10]).toBe(0);
+	});
+
+	it("passes an existing dOps payload through", () => {
+		const dops = Uint8Array.from([0, 2, 1, 56, 0, 0, 187, 128, 0, 0, 0]);
+		expect(toDOps(dops)).toEqual(dops);
 	});
 });

--- a/js/hang/src/util/opus.ts
+++ b/js/hang/src/util/opus.ts
@@ -29,3 +29,45 @@ export function supportsRate(rate: number): boolean {
 export function pickRate(rate: number): number {
 	return SAMPLE_RATES.find((r) => r >= rate) ?? DEFAULT_SAMPLE_RATE;
 }
+
+const OPUS_HEAD = new TextEncoder().encode("OpusHead");
+
+/**
+ * Convert an OpusHead decoder description into an ISO BMFF dOps payload.
+ *
+ * Existing dOps payloads pass through unchanged so CMAF descriptions can be
+ * remuxed without another format conversion.
+ */
+export function toDOps(description: Uint8Array): Uint8Array {
+	let offset = 0;
+	let littleEndian = false;
+
+	if (description.length >= OPUS_HEAD.length && OPUS_HEAD.every((byte, index) => description[index] === byte)) {
+		offset = OPUS_HEAD.length;
+		littleEndian = true;
+	} else if (description[0] === 1) {
+		// Some callers already strip the OpusHead signature.
+		littleEndian = true;
+	} else if (description[0] !== 0) {
+		throw new Error("invalid Opus decoder description");
+	}
+
+	if (description.length - offset < 11) {
+		throw new Error("Opus decoder description must contain at least 11 bytes");
+	}
+
+	if (!littleEndian) {
+		return description.slice(offset);
+	}
+
+	const input = new DataView(description.buffer, description.byteOffset + offset, 11);
+	const output = description.slice(offset);
+	const view = new DataView(output.buffer);
+	output[0] = 0; // dOps version
+	output[1] = input.getUint8(1);
+	view.setUint16(2, input.getUint16(2, true), false);
+	view.setUint32(4, input.getUint32(4, true), false);
+	view.setInt16(8, input.getInt16(8, true), false);
+	output[10] = input.getUint8(10);
+	return output;
+}

--- a/rs/moq-audio/src/decode/consumer.rs
+++ b/rs/moq-audio/src/decode/consumer.rs
@@ -3,7 +3,7 @@
 use bytes::Bytes;
 
 use super::decoder::{Config, Decoder};
-use crate::resample::Resampler;
+use crate::resample::{Resampler, remix};
 use crate::{Error, Frame};
 
 /// Subscribe to a moq-mux audio track and emit decoded PCM in the layout
@@ -33,13 +33,7 @@ impl Consumer {
 		let decoder = Decoder::new(catalog)?;
 		let sample_rate = config.sample_rate.unwrap_or_else(|| decoder.sample_rate());
 		let channels = config.channels.unwrap_or_else(|| decoder.channel_count());
-
-		if channels != decoder.channel_count() {
-			return Err(Error::Unsupported(format!(
-				"channel remapping not implemented (decoder {}ch, requested {channels}ch)",
-				decoder.channel_count()
-			)));
-		}
+		crate::opus::validate_channels(channels)?;
 
 		let resampler = if sample_rate == decoder.sample_rate() {
 			None
@@ -101,11 +95,73 @@ impl Consumer {
 			Some(r) => r.process(&decoded)?,
 			None => decoded,
 		};
+		let pcm = if self.decoder.channel_count() == self.resolved_channels {
+			pcm
+		} else {
+			remix(&pcm, self.decoder.channel_count(), self.resolved_channels)?
+		};
 
 		let bytes = self.config.format.from_interleaved_f32(&pcm, self.resolved_channels)?;
 		Ok(Some(Frame {
 			timestamp: mux_frame.timestamp,
 			data: Bytes::from(bytes),
 		}))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use moq_net::Timestamp;
+
+	use super::*;
+	use crate::Format;
+	use crate::encode::{Encoder, Input, Options, Producer};
+
+	#[tokio::test]
+	async fn remixes_mono_stream_to_stereo_output() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let subscriber = broadcast.consume();
+		let input = Input {
+			format: Format::F32,
+			sample_rate: 48_000,
+			channels: 1,
+		};
+		let options = Options {
+			track: Some("audio".to_string()),
+			..Options::default()
+		};
+		let mut producer = Producer::new(&mut broadcast, catalog, input.clone(), &options).unwrap();
+		let catalog = Encoder::new(&crate::encode::Config::new(input)).unwrap().catalog();
+		let mut consumer = Consumer::new(
+			&subscriber,
+			&catalog,
+			"audio",
+			Config {
+				channels: Some(2),
+				..Config::new()
+			},
+		)
+		.await
+		.unwrap();
+
+		let samples = vec![0.1f32; 960];
+		let mut data = Vec::with_capacity(samples.len() * size_of::<f32>());
+		for sample in samples {
+			data.extend_from_slice(&sample.to_le_bytes());
+		}
+		producer
+			.write(&Frame {
+				timestamp: Timestamp::ZERO,
+				data: data.into(),
+			})
+			.unwrap();
+
+		let frame = consumer.read().await.unwrap().expect("decoded frame");
+		let samples = Format::F32.as_interleaved_f32(&frame.data, 2).unwrap();
+		assert_eq!(samples.len(), (960 - 312) * 2);
+		for pair in samples.chunks_exact(2) {
+			assert_eq!(pair[0], pair[1]);
+		}
 	}
 }

--- a/rs/moq-audio/src/decode/decoder.rs
+++ b/rs/moq-audio/src/decode/decoder.rs
@@ -30,7 +30,7 @@ pub struct Config {
 	/// catalog; anything else resamples.
 	pub sample_rate: Option<u32>,
 	/// Channel count to emit. `None` uses the codec's native count; anything
-	/// else is rejected, since remapping isn't implemented.
+	/// else remixes mono and stereo at the decode boundary.
 	pub channels: Option<u32>,
 	/// Upper bound on buffering before skipping a stalled group.
 	///
@@ -61,6 +61,7 @@ pub struct Decoder {
 	inner: *mut OpusDecoder,
 	sample_rate: u32,
 	channel_count: u32,
+	pre_skip_remaining: usize,
 	max_frame_size: usize,
 }
 
@@ -73,14 +74,14 @@ impl Decoder {
 	/// Parses the OpusHead `description` if present; falls back to the catalog's
 	/// declared sample rate / channel count.
 	pub fn new(catalog: &hang::catalog::AudioConfig) -> Result<Self, Error> {
-		let (sample_rate, channel_count) = if let Some(desc) = &catalog.description {
+		let (sample_rate, channel_count, pre_skip) = if let Some(desc) = &catalog.description {
 			let mut buf = desc.as_ref();
 			match moq_mux::codec::opus::Config::parse(&mut buf) {
-				Ok(head) => (head.sample_rate, head.channel_count),
-				Err(_) => (catalog.sample_rate, catalog.channel_count),
+				Ok(head) => (head.sample_rate, head.channel_count, head.pre_skip),
+				Err(_) => (catalog.sample_rate, catalog.channel_count, 0),
 			}
 		} else {
-			(catalog.sample_rate, catalog.channel_count)
+			(catalog.sample_rate, catalog.channel_count, 0)
 		};
 
 		opus::validate_rate(sample_rate)?;
@@ -94,11 +95,13 @@ impl Decoder {
 		}
 
 		let max_frame_size = (sample_rate as usize * MAX_FRAME_MS) / 1000;
+		let pre_skip_remaining = (pre_skip as usize * sample_rate as usize) / 48_000;
 
 		Ok(Self {
 			inner,
 			sample_rate,
 			channel_count,
+			pre_skip_remaining,
 			max_frame_size,
 		})
 	}
@@ -132,6 +135,13 @@ impl Decoder {
 			return Err(opus::error(samples, "opus_decode_float"));
 		}
 		out.truncate(samples as usize * self.channel_count as usize);
+		let trim_frames = self.pre_skip_remaining.min(samples as usize);
+		if trim_frames > 0 {
+			let trim_samples = trim_frames * self.channel_count as usize;
+			out.copy_within(trim_samples.., 0);
+			out.truncate(out.len() - trim_samples);
+			self.pre_skip_remaining -= trim_frames;
+		}
 		Ok(out)
 	}
 }

--- a/rs/moq-audio/src/decode/mod.rs
+++ b/rs/moq-audio/src/decode/mod.rs
@@ -7,8 +7,9 @@
 //! - [`Consumer`] subscribes to a track and hands back decoded [`Frame`](crate::Frame)s.
 //! - [`Decoder`] decodes packets you supply (bring your own payloads).
 //!
-//! [`Config`] configures both: it declares the PCM layout to emit, since the
-//! codec's own shape comes from the catalog.
+//! [`Config`] configures [`Consumer`]'s PCM output layout. The lower-level
+//! [`Decoder`] emits the codec-native sample rate and channel count from the
+//! catalog.
 
 mod consumer;
 mod decoder;

--- a/rs/moq-audio/src/encode/encoder.rs
+++ b/rs/moq-audio/src/encode/encoder.rs
@@ -11,7 +11,8 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use unsafe_libopus::{
-	OPUS_APPLICATION_AUDIO, OPUS_OK, OPUS_SET_BITRATE_REQUEST, OpusEncoder, opus_encode_float, opus_encoder_create,
+	OPUS_APPLICATION_AUDIO, OPUS_GET_BITRATE_REQUEST, OPUS_GET_LOOKAHEAD_REQUEST, OPUS_OK, OPUS_SET_BITRATE_REQUEST,
+	OPUS_SET_DTX_REQUEST, OPUS_SET_INBAND_FEC_REQUEST, OpusEncoder, opus_encode_float, opus_encoder_create,
 	opus_encoder_ctl_impl, opus_encoder_destroy, varargs,
 };
 
@@ -107,6 +108,10 @@ pub struct Config {
 	pub channels: Option<u32>,
 	/// Bitrate in bits per second. `None` lets the codec pick.
 	pub bitrate: Option<u32>,
+	/// Enable Opus in-band forward error correction.
+	pub fec: bool,
+	/// Enable Opus discontinuous transmission during silence.
+	pub dtx: bool,
 	/// Encoded frame duration. Opus accepts 2.5 / 5 / 10 / 20 / 40 / 60 ms.
 	pub frame_duration: Duration,
 }
@@ -120,6 +125,8 @@ impl Config {
 			sample_rate: None,
 			channels: None,
 			bitrate: None,
+			fec: false,
+			dtx: false,
 			frame_duration: Duration::from_millis(20),
 		}
 	}
@@ -138,6 +145,10 @@ pub struct Encoder {
 	codec_rate: u32,
 	/// Resolved codec channel count (currently always the input's).
 	codec_channels: u32,
+	/// Current libopus target bitrate.
+	bitrate: u64,
+	/// Encoder lookahead expressed in the OpusHead 48 kHz timebase.
+	pre_skip: u16,
 	frame_size: usize,
 	scratch: Vec<u8>,
 }
@@ -179,28 +190,88 @@ impl Encoder {
 			return Err(opus::error(err, "opus_encoder_create"));
 		}
 
-		if let Some(b) = config.bitrate {
-			// SAFETY: `inner` is a freshly-created encoder; varargs! produces
-			// the single i32 the SET_BITRATE request expects.
-			let rc = unsafe { opus_encoder_ctl_impl(inner, OPUS_SET_BITRATE_REQUEST, varargs![b as i32]) };
-			if rc != OPUS_OK {
+		let configured = Self::configure_opus(inner, &config, codec_rate, codec_channels);
+		let (bitrate, pre_skip) = match configured {
+			Ok(configured) => configured,
+			Err(err) => {
 				// SAFETY: `inner` was created above and not yet handed out.
 				unsafe { opus_encoder_destroy(inner) };
-				return Err(opus::error(rc, "OPUS_SET_BITRATE"));
+				return Err(err);
 			}
-		}
+		};
 
 		Ok(Self {
 			inner,
 			config,
 			codec_rate,
 			codec_channels,
+			bitrate,
+			pre_skip,
 			frame_size,
 			scratch: vec![0u8; MAX_PACKET_BYTES],
 		})
 	}
 
-	/// The config this encoder opened with.
+	fn configure_opus(
+		inner: *mut OpusEncoder,
+		config: &Config,
+		codec_rate: u32,
+		codec_channels: u32,
+	) -> Result<(u64, u16), Error> {
+		if let Some(bitrate) = config.bitrate {
+			Self::set_opus_bitrate(inner, codec_channels, bitrate as u64)?;
+		}
+		Self::set_opus_ctl(
+			inner,
+			OPUS_SET_INBAND_FEC_REQUEST,
+			i32::from(config.fec),
+			"OPUS_SET_INBAND_FEC",
+		)?;
+		Self::set_opus_ctl(inner, OPUS_SET_DTX_REQUEST, i32::from(config.dtx), "OPUS_SET_DTX")?;
+
+		let bitrate = Self::get_opus_ctl(inner, OPUS_GET_BITRATE_REQUEST, "OPUS_GET_BITRATE")?;
+		let bitrate = u64::try_from(bitrate)
+			.map_err(|_| Error::Unsupported(format!("Opus reported negative bitrate {bitrate}")))?;
+		let lookahead = Self::get_opus_ctl(inner, OPUS_GET_LOOKAHEAD_REQUEST, "OPUS_GET_LOOKAHEAD")?;
+		let lookahead = u64::try_from(lookahead)
+			.map_err(|_| Error::Unsupported(format!("Opus reported negative lookahead {lookahead}")))?;
+		let pre_skip = u16::try_from((lookahead * 48_000) / codec_rate as u64)
+			.map_err(|_| Error::Unsupported(format!("Opus lookahead {lookahead} does not fit in OpusHead")))?;
+
+		Ok((bitrate, pre_skip))
+	}
+
+	fn set_opus_bitrate(inner: *mut OpusEncoder, channels: u32, bitrate: u64) -> Result<(), Error> {
+		let max = 300_000 * channels as u64;
+		if !(500..=max).contains(&bitrate) {
+			return Err(Error::Unsupported(format!(
+				"Opus bitrate must be between 500 and {max} bits per second for {channels} channel(s), got {bitrate}"
+			)));
+		}
+		Self::set_opus_ctl(inner, OPUS_SET_BITRATE_REQUEST, bitrate as i32, "OPUS_SET_BITRATE")
+	}
+
+	fn set_opus_ctl(inner: *mut OpusEncoder, request: i32, value: i32, name: &'static str) -> Result<(), Error> {
+		// SAFETY: `inner` owns a live encoder and each request here expects one i32.
+		let rc = unsafe { opus_encoder_ctl_impl(inner, request, varargs![value]) };
+		if rc != OPUS_OK {
+			return Err(opus::error(rc, name));
+		}
+		Ok(())
+	}
+
+	fn get_opus_ctl(inner: *mut OpusEncoder, request: i32, name: &'static str) -> Result<i32, Error> {
+		let mut value = 0;
+		// SAFETY: `inner` owns a live encoder and each request here expects one
+		// valid mutable i32 output.
+		let rc = unsafe { opus_encoder_ctl_impl(inner, request, varargs![&mut value]) };
+		if rc != OPUS_OK {
+			return Err(opus::error(rc, name));
+		}
+		Ok(value)
+	}
+
+	/// The encoder config, including the latest accepted runtime bitrate.
 	pub fn config(&self) -> &Config {
 		&self.config
 	}
@@ -227,6 +298,22 @@ impl Encoder {
 	/// [`encode`](Self::encode).
 	pub fn frame_size(&self) -> usize {
 		self.frame_size
+	}
+
+	/// Current target bitrate in bits per second.
+	pub fn bitrate(&self) -> u64 {
+		self.bitrate
+	}
+
+	/// Retune the live Opus encoder to `bitrate` bits per second.
+	pub fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
+		if bitrate == self.bitrate {
+			return Ok(());
+		}
+		Self::set_opus_bitrate(self.inner, self.codec_channels, bitrate)?;
+		self.bitrate = bitrate;
+		self.config.bitrate = Some(bitrate as u32);
+		Ok(())
 	}
 
 	/// Encode one frame of interleaved `f32` PCM at [`codec_rate`](Self::codec_rate).
@@ -263,16 +350,14 @@ impl Encoder {
 	pub fn catalog(&self) -> hang::catalog::AudioConfig {
 		// `codec_channels` is validated to mono/stereo at encoder construction, so the
 		// OpusHead (channel mapping family 0) always encodes.
-		let head = moq_mux::codec::opus::Config {
-			sample_rate: self.codec_rate,
-			channel_count: self.codec_channels,
-		}
-		.encode()
-		.expect("opus encoder channels validated to mono/stereo");
+		let head = moq_mux::codec::opus::Config::new(self.codec_rate, self.codec_channels)
+			.with_pre_skip(self.pre_skip)
+			.encode()
+			.expect("opus encoder channels validated to mono/stereo");
 
 		let mut config =
 			hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Opus, self.codec_rate, self.codec_channels);
-		config.bitrate = self.config.bitrate.map(|b| b as u64);
+		config.bitrate = self.config.bitrate.map(u64::from);
 		config.description = Some(head);
 		config.container = hang::catalog::Container::Legacy;
 		config
@@ -369,6 +454,75 @@ mod tests {
 		assert_eq!(cfg.bitrate, Some(64_000));
 		let desc = cfg.description.expect("OpusHead should be present");
 		assert_eq!(desc.len(), 19);
+		let head = moq_mux::codec::opus::Config::parse(&mut desc.as_ref()).unwrap();
+		assert_eq!(head.pre_skip, enc.pre_skip);
+		assert_eq!(head.pre_skip, 312);
+	}
+
+	#[test]
+	fn opus_decoder_trims_encoder_lookahead_once() {
+		let mut enc = Encoder::new(&Config::new(stereo_48k())).unwrap();
+		let mut dec = Decoder::new(&enc.catalog()).unwrap();
+		let frame = vec![0.0; enc.frame_size() * enc.codec_channels() as usize];
+
+		let first = dec.decode(&enc.encode(&frame).unwrap()).unwrap();
+		assert_eq!(
+			first.len(),
+			(enc.frame_size() - enc.pre_skip as usize) * enc.codec_channels() as usize
+		);
+
+		let second = dec.decode(&enc.encode(&frame).unwrap()).unwrap();
+		assert_eq!(second.len(), frame.len());
+	}
+
+	#[test]
+	fn opus_runtime_bitrate_updates_encoder_state() {
+		let mut enc = Encoder::new(&Config {
+			bitrate: Some(64_000),
+			..Config::new(stereo_48k())
+		})
+		.unwrap();
+
+		enc.set_bitrate(32_000).unwrap();
+		assert_eq!(enc.bitrate(), 32_000);
+		assert_eq!(enc.config().bitrate, Some(32_000));
+		assert_eq!(
+			Encoder::get_opus_ctl(enc.inner, unsafe_libopus::OPUS_GET_BITRATE_REQUEST, "OPUS_GET_BITRATE").unwrap(),
+			32_000
+		);
+	}
+
+	#[test]
+	fn opus_runtime_bitrate_rejects_values_libopus_would_clamp() {
+		let mut enc = Encoder::new(&Config::new(stereo_48k())).unwrap();
+		let original = enc.bitrate();
+		assert!(enc.set_bitrate(1).is_err());
+		assert!(enc.set_bitrate(600_001).is_err());
+		assert_eq!(enc.bitrate(), original);
+	}
+
+	#[test]
+	fn opus_applies_fec_and_dtx_controls() {
+		let enc = Encoder::new(&Config {
+			fec: true,
+			dtx: true,
+			..Config::new(stereo_48k())
+		})
+		.unwrap();
+
+		assert_eq!(
+			Encoder::get_opus_ctl(
+				enc.inner,
+				unsafe_libopus::OPUS_GET_INBAND_FEC_REQUEST,
+				"OPUS_GET_INBAND_FEC"
+			)
+			.unwrap(),
+			1
+		);
+		assert_eq!(
+			Encoder::get_opus_ctl(enc.inner, unsafe_libopus::OPUS_GET_DTX_REQUEST, "OPUS_GET_DTX").unwrap(),
+			1
+		);
 	}
 
 	#[test]
@@ -392,5 +546,6 @@ mod tests {
 		.unwrap();
 		assert_eq!(enc.codec_rate(), 24_000);
 		assert_eq!(enc.catalog().sample_rate, 24_000);
+		assert_eq!(enc.pre_skip, 312);
 	}
 }

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -37,6 +37,10 @@ pub struct Options {
 	pub channels: Option<u32>,
 	/// Bitrate in bits per second. `None` lets the codec pick.
 	pub bitrate: Option<u32>,
+	/// Enable Opus in-band forward error correction.
+	pub fec: bool,
+	/// Enable Opus discontinuous transmission during silence.
+	pub dtx: bool,
 	/// Encoded frame duration. Opus accepts 2.5 / 5 / 10 / 20 / 40 / 60 ms.
 	pub frame_duration: Duration,
 }
@@ -49,6 +53,8 @@ impl Default for Options {
 			sample_rate: None,
 			channels: None,
 			bitrate: None,
+			fec: false,
+			dtx: false,
 			frame_duration: Duration::from_millis(20),
 		}
 	}
@@ -63,6 +69,8 @@ impl Options {
 			sample_rate: self.sample_rate,
 			channels: self.channels,
 			bitrate: self.bitrate,
+			fec: self.fec,
+			dtx: self.dtx,
 			frame_duration: self.frame_duration,
 		}
 	}
@@ -156,6 +164,16 @@ impl<E: CatalogExt> Producer<E> {
 	/// [`used`](moq_net::track::Producer::used) / [`unused`](moq_net::track::Producer::unused).
 	pub fn track(&self) -> &moq_net::track::Producer {
 		self.track.track()
+	}
+
+	/// Current encoder target bitrate in bits per second.
+	pub fn bitrate(&self) -> u64 {
+		self.encoder.bitrate()
+	}
+
+	/// Retune the live encoder to `bitrate` bits per second.
+	pub fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
+		self.encoder.set_bitrate(bitrate)
 	}
 
 	/// Re-anchor the timeline to the next frame's timestamp, dropping any

--- a/rs/moq-audio/src/resample.rs
+++ b/rs/moq-audio/src/resample.rs
@@ -2,7 +2,8 @@
 //!
 //! Wraps [`rubato`] with a small interleaved-`f32` interface so the
 //! producer/consumer doesn't have to convert to planar on every call.
-//! Currently sample-rate only; channel up/downmix is rejected upstream.
+//! The resampler keeps the channel layout unchanged; [`remix`] converts mono
+//! and stereo after sample-rate conversion.
 
 use rubato::audioadapter_buffers::direct::SequentialSliceOfVecs;
 use rubato::{
@@ -110,6 +111,24 @@ impl Resampler {
 	}
 }
 
+/// Remix interleaved mono/stereo PCM into the requested channel count.
+pub(crate) fn remix(samples: &[f32], input_channels: u32, output_channels: u32) -> Result<Vec<f32>, Error> {
+	match (input_channels, output_channels) {
+		(1, 1) | (2, 2) => Ok(samples.to_vec()),
+		(1, 2) => {
+			let mut output = Vec::with_capacity(samples.len() * 2);
+			for &sample in samples {
+				output.extend_from_slice(&[sample, sample]);
+			}
+			Ok(output)
+		}
+		(2, 1) => Ok(samples.chunks_exact(2).map(|pair| (pair[0] + pair[1]) * 0.5).collect()),
+		_ => Err(Error::Unsupported(format!(
+			"channel remix only supports mono and stereo (got {input_channels} to {output_channels})"
+		))),
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -133,5 +152,15 @@ mod tests {
 			"expected ~48k samples, got {}",
 			out.len()
 		);
+	}
+
+	#[test]
+	fn remix_mono_to_stereo_duplicates_samples() {
+		assert_eq!(remix(&[1.0, 2.0], 1, 2).unwrap(), [1.0, 1.0, 2.0, 2.0]);
+	}
+
+	#[test]
+	fn remix_stereo_to_mono_averages_channels() {
+		assert_eq!(remix(&[1.0, 3.0, 2.0, 4.0], 2, 1).unwrap(), [2.0, 3.0]);
 	}
 }

--- a/rs/moq-gst/src/sink/pad.rs
+++ b/rs/moq-gst/src/sink/pad.rs
@@ -140,10 +140,7 @@ impl Pad {
 					"multichannel Opus is not supported yet (channels={channels})"
 				);
 				ensure!(rate > 0, "Opus caps has non-positive sample rate {rate}");
-				let config = moq_mux::codec::opus::Config {
-					sample_rate: rate as u32,
-					channel_count: channels as u32,
-				};
+				let config = moq_mux::codec::opus::Config::new(rate as u32, channels as u32);
 				// Opus builds its config from caps (not an OpusHead init buffer), so it constructs the codec
 				// importer directly and lifts it into a `Track` via `.into()`.
 				let name = broadcast.unique_name(".opus");

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -117,6 +117,7 @@ impl From<Config> for hang::catalog::AudioConfig {
 			config.sample_rate,
 			config.channel_count,
 		);
+		audio.description = config.encode().ok();
 		audio.container = hang::catalog::Container::Legacy;
 		audio
 	}

--- a/rs/moq-mux/src/codec/opus/mod.rs
+++ b/rs/moq-mux/src/codec/opus/mod.rs
@@ -32,17 +32,37 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Typed Opus configuration mirroring the parsed fields of an OpusHead packet.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Config {
+	/// Original input sample rate in Hz.
 	pub sample_rate: u32,
+	/// Number of encoded channels.
 	pub channel_count: u32,
+	/// Number of decoded 48 kHz samples to discard at stream start.
+	pub pre_skip: u16,
 }
 
 impl Config {
+	/// Build a mono/stereo Opus config with no pre-skip.
+	pub fn new(sample_rate: u32, channel_count: u32) -> Self {
+		Self {
+			sample_rate,
+			channel_count,
+			pre_skip: 0,
+		}
+	}
+
+	/// Set the number of decoded 48 kHz samples to discard at stream start.
+	pub fn with_pre_skip(mut self, pre_skip: u16) -> Self {
+		self.pre_skip = pre_skip;
+		self
+	}
+
 	/// Parse an OpusHead buffer (RFC 7845 §5.1).
 	///
-	/// Verifies the magic signature; reads channel count and sample rate;
-	/// ignores pre-skip, gain, and channel mapping. Any trailing bytes are
-	/// consumed.
+	/// Verifies the magic signature; reads channel count, pre-skip, and sample
+	/// rate; ignores gain and channel mapping. Any trailing bytes are consumed.
 	pub fn parse<T: Buf>(buf: &mut T) -> Result<Self> {
 		if buf.remaining() < 19 {
 			return Err(Error::HeadTooShort);
@@ -54,7 +74,7 @@ impl Config {
 
 		buf.advance(1); // Skip version
 		let channel_count = buf.get_u8() as u32;
-		buf.advance(2); // Skip pre-skip
+		let pre_skip = buf.get_u16_le();
 		let sample_rate = buf.get_u32_le();
 
 		// Skip gain, channel mapping until if/when we support them.
@@ -65,11 +85,12 @@ impl Config {
 		Ok(Self {
 			sample_rate,
 			channel_count,
+			pre_skip,
 		})
 	}
 
 	/// Encode the minimal OpusHead packet (19 bytes; channel mapping family
-	/// 0, zero pre-skip and gain).
+	/// 0 and zero gain).
 	///
 	/// Errors with [`Error::UnsupportedChannelCount`] unless `channel_count` is 1
 	/// or 2, since mapping family 0 is only defined for mono/stereo per RFC 7845 §5.1.
@@ -83,7 +104,7 @@ impl Config {
 		head.extend_from_slice(b"OpusHead");
 		head.push(1); // version
 		head.push(self.channel_count as u8);
-		head.extend_from_slice(&0u16.to_le_bytes()); // pre-skip
+		head.extend_from_slice(&self.pre_skip.to_le_bytes());
 		head.extend_from_slice(&self.sample_rate.to_le_bytes());
 		head.extend_from_slice(&0i16.to_le_bytes()); // output gain
 		head.push(0); // channel mapping family (0 = mono/stereo)
@@ -147,38 +168,26 @@ mod tests {
 
 	#[test]
 	fn parses_valid_opus_head() {
-		let cfg = Config {
-			sample_rate: 48000,
-			channel_count: 2,
-		};
+		let cfg = Config::new(48_000, 2).with_pre_skip(312);
 		let encoded = cfg.encode().unwrap();
 		assert_eq!(encoded.len(), 19);
 		let parsed = Config::parse(&mut encoded.as_ref()).unwrap();
-		assert_eq!(parsed.sample_rate, 48000);
+		assert_eq!(parsed.sample_rate, 48_000);
 		assert_eq!(parsed.channel_count, 2);
+		assert_eq!(parsed.pre_skip, 312);
+		assert_eq!(parsed, cfg);
 	}
 
 	#[test]
 	fn parse_rejects_invalid_signature() {
-		let mut bytes = Config {
-			sample_rate: 48000,
-			channel_count: 1,
-		}
-		.encode()
-		.unwrap()
-		.to_vec();
+		let mut bytes = Config::new(48_000, 1).encode().unwrap().to_vec();
 		bytes[0] = b'X';
 		assert!(Config::parse(&mut bytes.as_slice()).is_err());
 	}
 
 	#[test]
 	fn encode_rejects_multichannel() {
-		let err = Config {
-			sample_rate: 48000,
-			channel_count: 6,
-		}
-		.encode()
-		.unwrap_err();
+		let err = Config::new(48_000, 6).encode().unwrap_err();
 		assert!(matches!(err, Error::UnsupportedChannelCount(6)));
 	}
 }

--- a/rs/moq-mux/src/container/flv/export_test.rs
+++ b/rs/moq-mux/src/container/flv/export_test.rs
@@ -204,12 +204,7 @@ const VP9_KEYFRAME: &[u8] = &[0x82, 0x49, 0x83, 0x42, 0x20, 0x13, 0xf0, 0x0e, 0x
 
 /// Build an enhanced-RTMP FLV: VP9 video + Opus audio via the FourCC payloads.
 fn synth_enhanced_flv() -> Vec<u8> {
-	let head = crate::codec::opus::Config {
-		sample_rate: 48000,
-		channel_count: 2,
-	}
-	.encode()
-	.unwrap();
+	let head = crate::codec::opus::Config::new(48_000, 2).encode().unwrap();
 
 	let mut out = Vec::new();
 	out.extend_from_slice(b"FLV");

--- a/rs/moq-mux/src/container/flv/import_test.rs
+++ b/rs/moq-mux/src/container/flv/import_test.rs
@@ -193,12 +193,7 @@ async fn import_enhanced_vp9() {
 /// header and carries the frames through.
 #[tokio::test(start_paused = true)]
 async fn import_enhanced_opus() {
-	let head = crate::codec::opus::Config {
-		sample_rate: 48000,
-		channel_count: 2,
-	}
-	.encode()
-	.unwrap();
+	let head = crate::codec::opus::Config::new(48_000, 2).encode().unwrap();
 
 	let mut out = Vec::new();
 	out.extend_from_slice(b"FLV");

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -523,6 +523,25 @@ async fn opus_frame_duration_from_toc() {
 	);
 }
 
+#[test]
+fn synthesize_opus_trak_preserves_pre_skip() {
+	use hang::catalog::{AudioCodec, AudioConfig};
+
+	let head = crate::codec::opus::Config::new(48_000, 2)
+		.with_pre_skip(312)
+		.encode()
+		.unwrap();
+	let mut config = AudioConfig::new(AudioCodec::Opus, 48_000, 2);
+	config.description = Some(head);
+
+	let trak = super::synthesize_audio_trak(1, 48_000, &config).expect("synthesize Opus trak");
+	let opus = match &trak.mdia.minf.stbl.stsd.codecs[0] {
+		mp4_atom::Codec::Opus(opus) => opus,
+		other => panic!("expected Opus sample entry, got {other:?}"),
+	};
+	assert_eq!(opus.dops.pre_skip, 312);
+}
+
 /// A legacy FLAC rendition (no init segment) synthesizes a `fLaC` sample entry
 /// whose `dfLa` STREAMINFO is rebuilt from the catalog description.
 #[test]

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -41,6 +41,9 @@ pub enum Error {
 	#[error("flac: {0}")]
 	Flac(#[from] crate::codec::flac::Error),
 
+	#[error("opus: {0}")]
+	Opus(#[from] crate::codec::opus::Error),
+
 	#[error("missing keyframe: a group must open on a keyframe")]
 	MissingKeyframe(#[from] crate::container::MissingKeyframe),
 
@@ -496,16 +499,25 @@ pub(crate) fn synthesize_audio_trak(track_id: u32, timescale: u64, config: &Audi
 	};
 
 	let sample_entry = match &config.codec {
-		AudioCodec::Opus => mp4_atom::Codec::from(mp4_atom::Opus {
-			audio,
-			dops: mp4_atom::Dops {
-				output_channel_count: config.channel_count as u8,
-				pre_skip: 0,
-				input_sample_rate: config.sample_rate,
-				output_gain: 0,
-			},
-			btrt: None,
-		}),
+		AudioCodec::Opus => {
+			let pre_skip = match &config.description {
+				Some(description) => {
+					let mut description = description.as_ref();
+					crate::codec::opus::Config::parse(&mut description)?.pre_skip
+				}
+				None => 0,
+			};
+			mp4_atom::Codec::from(mp4_atom::Opus {
+				audio,
+				dops: mp4_atom::Dops {
+					output_channel_count: config.channel_count as u8,
+					pre_skip,
+					input_sample_rate: config.sample_rate,
+					output_gain: 0,
+				},
+				btrt: None,
+			})
+		}
 		AudioCodec::AAC(_) => {
 			// The catalog `description` is the AudioSpecificConfig (set by the TS
 			// importer via aac::Config::encode, or carried over from a CMAF source).

--- a/rs/moq-mux/src/container/mkv/export.rs
+++ b/rs/moq-mux/src/container/mkv/export.rs
@@ -587,14 +587,12 @@ pub(super) fn build_audio_track_entry(track_number: u64, config: &AudioConfig) -
 	let (codec_id, codec_private) = match &config.codec {
 		AudioCodec::Opus => (
 			"A_OPUS",
-			Some(
-				crate::codec::opus::Config {
-					sample_rate: config.sample_rate,
-					channel_count: config.channel_count,
-				}
-				.encode()?
-				.to_vec(),
-			),
+			Some(match &config.description {
+				Some(description) => description.to_vec(),
+				None => crate::codec::opus::Config::new(config.sample_rate, config.channel_count)
+					.encode()?
+					.to_vec(),
+			}),
 		),
 		AudioCodec::AAC(_) => (
 			"A_AAC",

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -539,6 +539,7 @@ fn build_audio_config(
 				if cfg_rate > 0 { cfg_rate } else { sample_rate },
 				if cfg_channels > 0 { cfg_channels } else { channels },
 			);
+			config.description = codec_private.cloned();
 			config.container = Container::Legacy;
 			Ok(config)
 		}

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -369,10 +369,7 @@ impl<E: catalog::Catalog> Import<E> {
 			StreamType::Mpeg2PacketizedData if registration_format(descriptors) == Some(*b"Opus") => {
 				let channel_count = opus_channel_count(descriptors).unwrap_or(2);
 				let track = crate::import::unique_track(&mut self.broadcast, ".opus")?;
-				let config = opus::Config {
-					sample_rate: 48_000,
-					channel_count,
-				};
+				let config = opus::Config::new(48_000, channel_count);
 				Stream::Opus(Box::new(OpusStream {
 					import: opus::Import::new(track, self.catalog.reserve(), config.into())?,
 					unwrap: PtsUnwrap::default(),

--- a/rs/moq-mux/src/import/track.rs
+++ b/rs/moq-mux/src/import/track.rs
@@ -746,10 +746,7 @@ mod tests {
 		let track = broadcast.create_track("audio", hang::container::track_info()).unwrap();
 		let subscriber = track.subscribe(None);
 
-		let config = crate::codec::opus::Config {
-			sample_rate: 48_000,
-			channel_count: 2,
-		};
+		let config = crate::codec::opus::Config::new(48_000, 2);
 		let mut import = crate::codec::opus::Import::new(track, catalog.reserve(), config.into()).unwrap();
 		assert!(catalog.snapshot().audio.renditions.contains_key("audio"));
 

--- a/rs/moq-rtc/src/codec/opus.rs
+++ b/rs/moq-rtc/src/codec/opus.rs
@@ -16,10 +16,7 @@ impl Bridge {
 		sample_rate: u32,
 		channel_count: u32,
 	) -> Result<Self> {
-		let config = moq_mux::codec::opus::Config {
-			sample_rate,
-			channel_count,
-		};
+		let config = moq_mux::codec::opus::Config::new(sample_rate, channel_count);
 		let track = moq_mux::import::unique_track(&mut broadcast, ".opus")?;
 		let import = moq_mux::codec::opus::Import::new(track, catalog.reserve(), config.into())?;
 		Ok(Self { import })


### PR DESCRIPTION
## Summary

- Query the actual libopus lookahead, carry it through OpusHead, Matroska, and CMAF descriptions, and trim the corresponding priming samples in the native decoder.
- Add runtime audio bitrate control plus opt-in FEC and DTX settings, with validation so libopus cannot silently clamp an unsupported target.
- Remix mono and stereo at the native decode boundary, and convert browser OpusHead descriptions into correctly byte-ordered `dOps` payloads.

The root cause of the timing bug was that `moq-mux` discarded pre-skip while parsing OpusHead and always serialized zero, while `moq-audio` never queried `OPUS_GET_LOOKAHEAD` or trimmed decoder priming output.

## Public API changes

- `moq_mux::codec::opus::Config` gains `pre_skip`, `new`, and `with_pre_skip`.
- `moq_audio::encode::{Config, Options}` gain `fec` and `dtx` knobs.
- `moq_audio::encode::{Encoder, Producer}` gain live `bitrate` and `set_bitrate` methods.
- `moq_audio::decode::Config::channels` now supports mono/stereo remixing.
- `@moq/hang` exports `Opus.toDOps` for OpusHead and CMAF description conversion.

## Test plan

- `nix develop --command just check`
- `cargo test -p moq-audio --lib`
- `cargo test -p moq-mux --lib`
- `bun test js/hang/src/util/opus.test.ts`

Closes #2480.

(Written by GPT-5)
