### PR TITLE
feat(moq-audio): add PCM codec

### DIFF
--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -201,6 +201,19 @@ Any Uint8Array fields are hex-encoded as a string.
 
 In addition to the WebCodecs fields, each rendition MAY carry the fields common to audio and video ({{common}}).
 
+### PCM {#audio-pcm}
+
+Hang defines the `"pcm"` audio codec for uncompressed samples.
+The `sampleRate` and `numberOfChannels` fields MUST be present and greater than zero.
+The `description` field MUST NOT be present.
+If `bitrate` is present, it MUST equal `sampleRate * numberOfChannels * 32`.
+
+Each codec payload consists of interleaved IEEE 754 binary32 samples in little-endian byte order.
+Samples are ordered by sample frame, then by ascending channel index within each frame.
+The payload length MUST be a non-zero multiple of `4 * numberOfChannels`.
+The frame timestamp identifies the presentation time of its first sample.
+The frame duration in seconds is the payload length divided by `4 * numberOfChannels * sampleRate`.
+
 For example:
 
 ~~~

--- a/js/hang/src/catalog/audio.test.ts
+++ b/js/hang/src/catalog/audio.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test";
+import { AudioConfigSchema } from "./audio.ts";
+
+test("pcm codec is accepted", () => {
+	const config = AudioConfigSchema.parse({
+		codec: "pcm",
+		container: { kind: "legacy" },
+		sampleRate: 48_000,
+		numberOfChannels: 2,
+		bitrate: 3_072_000,
+	});
+
+	expect(config.codec).toBe("pcm");
+});

--- a/js/hang/src/catalog/audio.ts
+++ b/js/hang/src/catalog/audio.ts
@@ -19,7 +19,8 @@ export const AudioConfigSchema = z.object({
 	// If unset, the track lives in the same broadcast as the catalog.
 	broadcast: z.optional(RelativeBroadcastSchema),
 
-	// See: https://w3c.github.io/webcodecs/codec_registry.html
+	// Registered WebCodecs codec string, or Hang's "pcm" extension for
+	// interleaved little-endian IEEE-754 binary32 samples.
 	codec: z.string(),
 
 	// The container format, used to decode the timestamp and more.

--- a/rs/hang/src/catalog/audio/codec.rs
+++ b/rs/hang/src/catalog/audio/codec.rs
@@ -15,6 +15,10 @@ pub enum AudioCodec {
 	#[display("opus")]
 	Opus,
 
+	/// Uncompressed interleaved little-endian IEEE-754 binary32 PCM.
+	#[display("pcm")]
+	Pcm,
+
 	/// FLAC, the Free Lossless Audio Codec (RFC 9639). The decoder
 	/// initialization data (the `fLaC` stream marker plus the STREAMINFO
 	/// metadata block) travels out of band in [`AudioConfig::description`]. Both
@@ -60,10 +64,17 @@ pub enum AudioCodec {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum AudioCodecKind {
+	/// Advanced Audio Coding.
 	AAC,
+	/// Opus.
 	Opus,
+	/// Uncompressed interleaved little-endian IEEE-754 binary32 PCM.
+	Pcm,
+	/// Unknown or unsupported codec.
 	Unknown,
+	/// Free Lossless Audio Codec.
 	Flac,
+	/// MPEG-1/2 Audio Layer III.
 	Mp3,
 }
 
@@ -73,6 +84,7 @@ impl AudioCodec {
 		match self {
 			Self::AAC(_) => AudioCodecKind::AAC,
 			Self::Opus => AudioCodecKind::Opus,
+			Self::Pcm => AudioCodecKind::Pcm,
 			Self::Flac => AudioCodecKind::Flac,
 			Self::Mp3 => AudioCodecKind::Mp3,
 			// Legacy TS-bridge codecs aren't WebCodecs-decodable, so they share the
@@ -91,6 +103,8 @@ impl FromStr for AudioCodec {
 			return AAC::from_str(s).map(Into::into);
 		} else if s == "opus" {
 			return Ok(Self::Opus);
+		} else if s == "pcm" {
+			return Ok(Self::Pcm);
 		} else if s == "flac" {
 			return Ok(Self::Flac);
 		} else if s == "mp3" {
@@ -117,5 +131,13 @@ mod tests {
 		assert_eq!(codec, AudioCodec::Flac);
 		assert_eq!(codec.to_string(), "flac");
 		assert_eq!(codec.kind(), AudioCodecKind::Flac);
+	}
+
+	#[test]
+	fn pcm_roundtrip() {
+		let codec = AudioCodec::from_str("pcm").unwrap();
+		assert_eq!(codec, AudioCodec::Pcm);
+		assert_eq!(codec.to_string(), "pcm");
+		assert_eq!(codec.kind(), AudioCodecKind::Pcm);
 	}
 }

--- a/rs/moq-audio/src/decode/decoder.rs
+++ b/rs/moq-audio/src/decode/decoder.rs
@@ -1,7 +1,7 @@
-//! Opus decoder front end.
+//! Audio decoder front end.
 //!
-//! Mirror of [`encode::Encoder`](crate::encode::Encoder): wraps libopus via
-//! [`unsafe_libopus`] and produces interleaved `f32` PCM.
+//! Mirror of [`encode::Encoder`](crate::encode::Encoder): dispatches over the
+//! catalog codec and produces interleaved `f32` PCM.
 
 use std::time::Duration;
 
@@ -58,21 +58,39 @@ impl Config {
 /// The bring-your-own-payload layer under [`Consumer`](super::Consumer): use it
 /// when the packets don't come from a plain track subscription.
 pub struct Decoder {
-	inner: *mut OpusDecoder,
+	backend: Backend,
 	sample_rate: u32,
 	channel_count: u32,
+}
+
+enum Backend {
+	Opus(Opus),
+	Pcm,
+}
+
+struct Opus {
+	inner: *mut OpusDecoder,
 	max_frame_size: usize,
 }
 
 // SAFETY: see Encoder.
-unsafe impl Send for Decoder {}
+unsafe impl Send for Opus {}
 
 impl Decoder {
 	/// Build a decoder from a catalog [`AudioConfig`](hang::catalog::AudioConfig).
 	///
 	/// Parses the OpusHead `description` if present; falls back to the catalog's
-	/// declared sample rate / channel count.
+	/// declared sample rate / channel count. PCM uses those catalog fields
+	/// directly and requires an absent `description`.
 	pub fn new(catalog: &hang::catalog::AudioConfig) -> Result<Self, Error> {
+		match &catalog.codec {
+			hang::catalog::AudioCodec::Opus => Self::new_opus(catalog),
+			hang::catalog::AudioCodec::Pcm => Self::new_pcm(catalog),
+			codec => Err(Error::Unsupported(format!("unsupported audio codec: {codec}"))),
+		}
+	}
+
+	fn new_opus(catalog: &hang::catalog::AudioConfig) -> Result<Self, Error> {
 		let (sample_rate, channel_count) = if let Some(desc) = &catalog.description {
 			let mut buf = desc.as_ref();
 			match moq_mux::codec::opus::Config::parse(&mut buf) {
@@ -96,10 +114,27 @@ impl Decoder {
 		let max_frame_size = (sample_rate as usize * MAX_FRAME_MS) / 1000;
 
 		Ok(Self {
-			inner,
+			backend: Backend::Opus(Opus { inner, max_frame_size }),
 			sample_rate,
 			channel_count,
-			max_frame_size,
+		})
+	}
+
+	fn new_pcm(catalog: &hang::catalog::AudioConfig) -> Result<Self, Error> {
+		if catalog.sample_rate == 0 {
+			return Err(Error::Unsupported("pcm sample rate must be greater than zero".into()));
+		}
+		if catalog.channel_count == 0 {
+			return Err(Error::Unsupported("pcm channel count must be greater than zero".into()));
+		}
+		if catalog.description.is_some() {
+			return Err(Error::Unsupported("pcm catalog description must be absent".into()));
+		}
+
+		Ok(Self {
+			backend: Backend::Pcm,
+			sample_rate: catalog.sample_rate,
+			channel_count: catalog.channel_count,
 		})
 	}
 
@@ -115,30 +150,75 @@ impl Decoder {
 
 	/// Decode one packet into interleaved `f32` PCM.
 	pub fn decode(&mut self, packet: &[u8]) -> Result<Vec<f32>, Error> {
-		let mut out = vec![0.0f32; self.max_frame_size * self.channel_count as usize];
-		// SAFETY: `inner` owns a live OpusDecoder; packet/out slices bound
-		// by the lengths we pass.
-		let samples = unsafe {
-			opus_decode_float(
-				&mut *self.inner,
-				packet.as_ptr(),
-				packet.len() as i32,
-				out.as_mut_ptr(),
-				self.max_frame_size as i32,
-				0,
-			)
-		};
-		if samples < 0 {
-			return Err(opus::error(samples, "opus_decode_float"));
+		match &mut self.backend {
+			Backend::Opus(opus) => {
+				let mut out = vec![0.0f32; opus.max_frame_size * self.channel_count as usize];
+				// SAFETY: `inner` owns a live OpusDecoder; packet/out slices are
+				// bounded by the lengths we pass.
+				let samples = unsafe {
+					opus_decode_float(
+						&mut *opus.inner,
+						packet.as_ptr(),
+						packet.len() as i32,
+						out.as_mut_ptr(),
+						opus.max_frame_size as i32,
+						0,
+					)
+				};
+				if samples < 0 {
+					return Err(crate::opus::error(samples, "opus_decode_float"));
+				}
+				out.truncate(samples as usize * self.channel_count as usize);
+				Ok(out)
+			}
+			Backend::Pcm => {
+				let bytes_per_frame = std::mem::size_of::<f32>() * self.channel_count as usize;
+				if packet.is_empty() || !packet.len().is_multiple_of(bytes_per_frame) {
+					return Err(Error::Misaligned {
+						got: packet.len(),
+						expected: packet.len().max(1).next_multiple_of(bytes_per_frame),
+					});
+				}
+
+				Ok(packet
+					.chunks_exact(std::mem::size_of::<f32>())
+					.map(|sample| f32::from_le_bytes([sample[0], sample[1], sample[2], sample[3]]))
+					.collect())
+			}
 		}
-		out.truncate(samples as usize * self.channel_count as usize);
-		Ok(out)
 	}
 }
 
-impl Drop for Decoder {
+impl Drop for Opus {
 	fn drop(&mut self) {
 		// SAFETY: `inner` is a live OpusDecoder that nothing else aliases.
 		unsafe { opus_decoder_destroy(self.inner) };
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn pcm_rejects_incomplete_channel_frame() {
+		let catalog = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Pcm, 48_000, 2);
+		let mut decoder = Decoder::new(&catalog).unwrap();
+
+		assert!(matches!(
+			decoder.decode(&[]),
+			Err(Error::Misaligned { got: 0, expected: 8 })
+		));
+		assert!(matches!(
+			decoder.decode(&[0; 4]),
+			Err(Error::Misaligned { got: 4, expected: 8 })
+		));
+	}
+
+	#[test]
+	fn decoder_rejects_unknown_codec() {
+		let catalog = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Unknown("future".into()), 48_000, 2);
+
+		assert!(matches!(Decoder::new(&catalog), Err(Error::Unsupported(_))));
 	}
 }

--- a/rs/moq-audio/src/decode/decoder.rs
+++ b/rs/moq-audio/src/decode/decoder.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use unsafe_libopus::{OPUS_OK, OpusDecoder, opus_decode_float, opus_decoder_create, opus_decoder_destroy};
 
 use crate::opus;
+use crate::pcm;
 use crate::{Error, Format};
 
 /// Opus packets cap at 120 ms (RFC 6716 §2.1.4).
@@ -65,7 +66,7 @@ pub struct Decoder {
 
 enum Backend {
 	Opus(Opus),
-	Pcm,
+	Pcm { bytes_per_frame: usize },
 }
 
 struct Opus {
@@ -130,9 +131,16 @@ impl Decoder {
 		if catalog.description.is_some() {
 			return Err(Error::Unsupported("pcm catalog description must be absent".into()));
 		}
+		let bitrate = pcm::bitrate(catalog.sample_rate, catalog.channel_count)?;
+		if catalog.bitrate.is_some_and(|declared| declared != bitrate) {
+			return Err(Error::Unsupported(format!(
+				"pcm catalog bitrate must be {bitrate} bits per second"
+			)));
+		}
+		let bytes_per_frame = pcm::frame_bytes(1, catalog.channel_count)?;
 
 		Ok(Self {
-			backend: Backend::Pcm,
+			backend: Backend::Pcm { bytes_per_frame },
 			sample_rate: catalog.sample_rate,
 			channel_count: catalog.channel_count,
 		})
@@ -171,17 +179,16 @@ impl Decoder {
 				out.truncate(samples as usize * self.channel_count as usize);
 				Ok(out)
 			}
-			Backend::Pcm => {
-				let bytes_per_frame = std::mem::size_of::<f32>() * self.channel_count as usize;
-				if packet.is_empty() || !packet.len().is_multiple_of(bytes_per_frame) {
+			Backend::Pcm { bytes_per_frame } => {
+				if packet.is_empty() || !packet.len().is_multiple_of(*bytes_per_frame) {
 					return Err(Error::Misaligned {
 						got: packet.len(),
-						expected: packet.len().max(1).next_multiple_of(bytes_per_frame),
+						expected: packet.len().max(1).next_multiple_of(*bytes_per_frame),
 					});
 				}
 
 				Ok(packet
-					.chunks_exact(std::mem::size_of::<f32>())
+					.chunks_exact(pcm::BYTES_PER_SAMPLE)
 					.map(|sample| f32::from_le_bytes([sample[0], sample[1], sample[2], sample[3]]))
 					.collect())
 			}
@@ -218,6 +225,14 @@ mod tests {
 	#[test]
 	fn decoder_rejects_unknown_codec() {
 		let catalog = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Unknown("future".into()), 48_000, 2);
+
+		assert!(matches!(Decoder::new(&catalog), Err(Error::Unsupported(_))));
+	}
+
+	#[test]
+	fn pcm_rejects_incorrect_catalog_bitrate() {
+		let mut catalog = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Pcm, 48_000, 2);
+		catalog.bitrate = Some(1);
 
 		assert!(matches!(Decoder::new(&catalog), Err(Error::Unsupported(_))));
 	}

--- a/rs/moq-audio/src/encode/encoder.rs
+++ b/rs/moq-audio/src/encode/encoder.rs
@@ -1,10 +1,8 @@
-//! Opus encoder front end.
+//! Audio encoder front end.
 //!
-//! Single-codec implementation today: [`Encoder`] wraps libopus 1.3.1 via
-//! [`unsafe_libopus`], a pure-Rust c2rust transpilation. No CMake toolchain, no
-//! sys crate, no linker gymnastics. When AAC or other codecs land we'll factor
-//! out a backend dispatch behind [`Codec`]; introducing a trait now would be
-//! premature.
+//! [`Encoder`] dispatches over the closed [`Codec`] set. Opus wraps libopus
+//! 1.3.1 via [`unsafe_libopus`], while PCM serializes interleaved `f32` samples
+//! directly.
 
 use std::str::FromStr;
 use std::time::Duration;
@@ -26,9 +24,11 @@ const MAX_PACKET_BYTES: usize = 4_000;
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Codec {
-	/// Opus (RFC 6716). The only codec today, and the default.
+	/// Opus (RFC 6716), and the default.
 	#[default]
 	Opus,
+	/// Uncompressed interleaved little-endian IEEE-754 binary32 PCM.
+	Pcm,
 }
 
 impl Codec {
@@ -37,6 +37,7 @@ impl Codec {
 	pub fn as_str(self) -> &'static str {
 		match self {
 			Self::Opus => "opus",
+			Self::Pcm => "pcm",
 		}
 	}
 }
@@ -53,6 +54,7 @@ impl FromStr for Codec {
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		match s {
 			"opus" => Ok(Self::Opus),
+			"pcm" => Ok(Self::Pcm),
 			other => Err(Error::Unsupported(format!("unknown codec: {other}"))),
 		}
 	}
@@ -105,9 +107,11 @@ pub struct Config {
 	/// Channel count the codec runs at. `None` matches [`Input::channels`];
 	/// anything else is rejected, since remapping isn't implemented.
 	pub channels: Option<u32>,
-	/// Bitrate in bits per second. `None` lets the codec pick.
+	/// Bitrate in bits per second. `None` lets Opus pick. PCM requires `None`
+	/// because its bitrate is fixed by the sample rate and channel count.
 	pub bitrate: Option<u32>,
 	/// Encoded frame duration. Opus accepts 2.5 / 5 / 10 / 20 / 40 / 60 ms.
+	/// PCM accepts any duration containing a whole number of samples.
 	pub frame_duration: Duration,
 }
 
@@ -131,7 +135,7 @@ impl Config {
 /// and publish the resulting packets through a [`Producer`](super::Producer)
 /// built from the same [`Config`].
 pub struct Encoder {
-	inner: *mut OpusEncoder,
+	backend: Backend,
 	config: Config,
 	/// Resolved codec sample rate (from `config.sample_rate`, else the input rate
 	/// snapped up to a supported one).
@@ -139,19 +143,29 @@ pub struct Encoder {
 	/// Resolved codec channel count (currently always the input's).
 	codec_channels: u32,
 	frame_size: usize,
+}
+
+enum Backend {
+	Opus(Opus),
+	Pcm,
+}
+
+struct Opus {
+	inner: *mut OpusEncoder,
 	scratch: Vec<u8>,
 }
 
 // SAFETY: OpusEncoder is heap-allocated state owned exclusively by this
-// struct; libopus encoder methods take a single &mut, so a unique
-// owner is allowed to move it across threads.
-unsafe impl Send for Encoder {}
+// struct; libopus encoder methods take a single &mut, so a unique owner is
+// allowed to move it across threads.
+unsafe impl Send for Opus {}
 
 impl Encoder {
 	/// Open an encoder for `config`.
 	pub fn new(config: &Config) -> Result<Self, Error> {
 		match config.codec {
 			Codec::Opus => Self::new_opus(config.clone()),
+			Codec::Pcm => Self::new_pcm(config.clone()),
 		}
 	}
 
@@ -191,12 +205,51 @@ impl Encoder {
 		}
 
 		Ok(Self {
-			inner,
+			backend: Backend::Opus(Opus {
+				inner,
+				scratch: vec![0u8; MAX_PACKET_BYTES],
+			}),
 			config,
 			codec_rate,
 			codec_channels,
 			frame_size,
-			scratch: vec![0u8; MAX_PACKET_BYTES],
+		})
+	}
+
+	fn new_pcm(config: Config) -> Result<Self, Error> {
+		if config.bitrate.is_some() {
+			return Err(Error::Unsupported(
+				"pcm bitrate is fixed; leave Config::bitrate unset".into(),
+			));
+		}
+
+		let codec_rate = config.sample_rate.unwrap_or(config.input.sample_rate);
+		if codec_rate == 0 {
+			return Err(Error::Unsupported("pcm sample rate must be greater than zero".into()));
+		}
+
+		let codec_channels = config.channels.unwrap_or(config.input.channels);
+		if codec_channels == 0 {
+			return Err(Error::Unsupported("pcm channel count must be greater than zero".into()));
+		}
+		if codec_channels != config.input.channels {
+			return Err(Error::Unsupported(format!(
+				"channel remapping not implemented (input {}ch, output {codec_channels}ch)",
+				config.input.channels
+			)));
+		}
+
+		let frame_size = pcm_frame_size(codec_rate, config.frame_duration)?;
+		frame_size
+			.checked_mul(codec_channels as usize)
+			.ok_or_else(|| Error::Unsupported("pcm frame contains too many samples".into()))?;
+		pcm_bitrate(codec_rate, codec_channels)?;
+		Ok(Self {
+			backend: Backend::Pcm,
+			config,
+			codec_rate,
+			codec_channels,
+			frame_size,
 		})
 	}
 
@@ -242,48 +295,96 @@ impl Encoder {
 				expected: expected * std::mem::size_of::<f32>(),
 			});
 		}
-		// SAFETY: `inner` owns a live OpusEncoder; pcm and scratch slices
-		// are bounded by the lengths we pass.
-		let n = unsafe {
-			opus_encode_float(
-				self.inner,
-				pcm.as_ptr(),
-				self.frame_size as i32,
-				self.scratch.as_mut_ptr(),
-				self.scratch.len() as i32,
-			)
-		};
-		if n < 0 {
-			return Err(opus::error(n, "opus_encode_float"));
+		match &mut self.backend {
+			Backend::Opus(opus) => {
+				// SAFETY: `inner` owns a live OpusEncoder; pcm and scratch slices
+				// are bounded by the lengths we pass.
+				let n = unsafe {
+					opus_encode_float(
+						opus.inner,
+						pcm.as_ptr(),
+						self.frame_size as i32,
+						opus.scratch.as_mut_ptr(),
+						opus.scratch.len() as i32,
+					)
+				};
+				if n < 0 {
+					return Err(crate::opus::error(n, "opus_encode_float"));
+				}
+				Ok(Bytes::copy_from_slice(&opus.scratch[..n as usize]))
+			}
+			Backend::Pcm => {
+				let mut payload = Vec::with_capacity(std::mem::size_of_val(pcm));
+				for sample in pcm {
+					payload.extend_from_slice(&sample.to_le_bytes());
+				}
+				Ok(payload.into())
+			}
 		}
-		Ok(Bytes::copy_from_slice(&self.scratch[..n as usize]))
 	}
 
 	/// hang catalog entry describing this encoder's output stream.
 	pub fn catalog(&self) -> hang::catalog::AudioConfig {
-		// `codec_channels` is validated to mono/stereo at encoder construction, so the
-		// OpusHead (channel mapping family 0) always encodes.
-		let head = moq_mux::codec::opus::Config {
-			sample_rate: self.codec_rate,
-			channel_count: self.codec_channels,
-		}
-		.encode()
-		.expect("opus encoder channels validated to mono/stereo");
+		match self.config.codec {
+			Codec::Opus => {
+				// `codec_channels` is validated to mono/stereo at encoder construction,
+				// so the OpusHead (channel mapping family 0) always encodes.
+				let head = moq_mux::codec::opus::Config {
+					sample_rate: self.codec_rate,
+					channel_count: self.codec_channels,
+				}
+				.encode()
+				.expect("opus encoder channels validated to mono/stereo");
 
-		let mut config =
-			hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Opus, self.codec_rate, self.codec_channels);
-		config.bitrate = self.config.bitrate.map(|b| b as u64);
-		config.description = Some(head);
-		config.container = hang::catalog::Container::Legacy;
-		config
+				let mut config = hang::catalog::AudioConfig::new(
+					hang::catalog::AudioCodec::Opus,
+					self.codec_rate,
+					self.codec_channels,
+				);
+				config.bitrate = self.config.bitrate.map(|b| b as u64);
+				config.description = Some(head);
+				config.container = hang::catalog::Container::Legacy;
+				config
+			}
+			Codec::Pcm => {
+				let mut config = hang::catalog::AudioConfig::new(
+					hang::catalog::AudioCodec::Pcm,
+					self.codec_rate,
+					self.codec_channels,
+				);
+				config.bitrate = Some(
+					pcm_bitrate(self.codec_rate, self.codec_channels)
+						.expect("pcm encoder bitrate validated at construction"),
+				);
+				config.container = hang::catalog::Container::Legacy;
+				config
+			}
+		}
 	}
 }
 
-impl Drop for Encoder {
+impl Drop for Opus {
 	fn drop(&mut self) {
 		// SAFETY: `inner` is a live OpusEncoder that nothing else aliases.
 		unsafe { opus_encoder_destroy(self.inner) };
 	}
+}
+
+fn pcm_frame_size(sample_rate: u32, duration: Duration) -> Result<usize, Error> {
+	let samples = u128::from(sample_rate) * duration.as_nanos();
+	if samples == 0 || !samples.is_multiple_of(1_000_000_000) {
+		return Err(Error::Unsupported(format!(
+			"pcm frame duration must contain a whole number of samples at {sample_rate} Hz"
+		)));
+	}
+	usize::try_from(samples / 1_000_000_000).map_err(|_| Error::Unsupported("pcm frame duration is too large".into()))
+}
+
+fn pcm_bitrate(sample_rate: u32, channels: u32) -> Result<u64, Error> {
+	u64::from(sample_rate)
+		.checked_mul(u64::from(channels))
+		.and_then(|samples| samples.checked_mul(32))
+		.ok_or_else(|| Error::Unsupported("pcm bitrate exceeds the catalog range".into()))
 }
 
 #[cfg(test)]
@@ -376,6 +477,9 @@ mod tests {
 		assert_eq!(Codec::Opus.as_str(), "opus");
 		assert_eq!(Codec::Opus.to_string(), "opus");
 		assert_eq!("opus".parse::<Codec>().unwrap(), Codec::Opus);
+		assert_eq!(Codec::Pcm.as_str(), "pcm");
+		assert_eq!(Codec::Pcm.to_string(), "pcm");
+		assert_eq!("pcm".parse::<Codec>().unwrap(), Codec::Pcm);
 		assert!("aac".parse::<Codec>().is_err());
 	}
 
@@ -392,5 +496,62 @@ mod tests {
 		.unwrap();
 		assert_eq!(enc.codec_rate(), 24_000);
 		assert_eq!(enc.catalog().sample_rate, 24_000);
+	}
+
+	#[test]
+	fn pcm_roundtrip_is_lossless() {
+		let mut enc = Encoder::new(&Config {
+			codec: Codec::Pcm,
+			..Config::new(stereo_48k())
+		})
+		.unwrap();
+		let mut dec = Decoder::new(&enc.catalog()).unwrap();
+		let input = sine(440.0, enc.codec_rate(), enc.codec_channels(), enc.frame_size());
+
+		let packet = enc.encode(&input).unwrap();
+		let output = dec.decode(&packet).unwrap();
+
+		assert_eq!(output, input);
+	}
+
+	#[test]
+	fn pcm_catalog_declares_fixed_bitrate() {
+		let enc = Encoder::new(&Config {
+			codec: Codec::Pcm,
+			..Config::new(stereo_48k())
+		})
+		.unwrap();
+		let catalog = enc.catalog();
+
+		assert_eq!(catalog.codec, hang::catalog::AudioCodec::Pcm);
+		assert_eq!(catalog.bitrate, Some(48_000 * 2 * 32));
+		assert_eq!(catalog.description, None);
+	}
+
+	#[test]
+	fn pcm_rejects_fractional_sample_frame_duration() {
+		let err = Encoder::new(&Config {
+			codec: Codec::Pcm,
+			frame_duration: Duration::from_micros(2_500),
+			..Config::new(Input {
+				sample_rate: 44_100,
+				..Input::default()
+			})
+		});
+		assert!(matches!(err, Err(Error::Unsupported(_))));
+	}
+
+	#[test]
+	fn pcm_rejects_bitrate_overflow() {
+		let err = Encoder::new(&Config {
+			codec: Codec::Pcm,
+			frame_duration: Duration::from_secs(1),
+			..Config::new(Input {
+				sample_rate: u32::MAX,
+				channels: u32::MAX,
+				..Input::default()
+			})
+		});
+		assert!(matches!(err, Err(Error::Unsupported(_))));
 	}
 }

--- a/rs/moq-audio/src/encode/encoder.rs
+++ b/rs/moq-audio/src/encode/encoder.rs
@@ -14,6 +14,7 @@ use unsafe_libopus::{
 };
 
 use crate::opus;
+use crate::pcm;
 use crate::{Error, Format};
 
 /// libopus packet size ceiling per RFC 6716 §3.4.
@@ -239,11 +240,9 @@ impl Encoder {
 			)));
 		}
 
-		let frame_size = pcm_frame_size(codec_rate, config.frame_duration)?;
-		frame_size
-			.checked_mul(codec_channels as usize)
-			.ok_or_else(|| Error::Unsupported("pcm frame contains too many samples".into()))?;
-		pcm_bitrate(codec_rate, codec_channels)?;
+		let frame_size = pcm::frame_size(codec_rate, config.frame_duration)?;
+		pcm::frame_bytes(frame_size, codec_channels)?;
+		pcm::bitrate(codec_rate, codec_channels)?;
 		Ok(Self {
 			backend: Backend::Pcm,
 			config,
@@ -353,7 +352,7 @@ impl Encoder {
 					self.codec_channels,
 				);
 				config.bitrate = Some(
-					pcm_bitrate(self.codec_rate, self.codec_channels)
+					pcm::bitrate(self.codec_rate, self.codec_channels)
 						.expect("pcm encoder bitrate validated at construction"),
 				);
 				config.container = hang::catalog::Container::Legacy;
@@ -368,23 +367,6 @@ impl Drop for Opus {
 		// SAFETY: `inner` is a live OpusEncoder that nothing else aliases.
 		unsafe { opus_encoder_destroy(self.inner) };
 	}
-}
-
-fn pcm_frame_size(sample_rate: u32, duration: Duration) -> Result<usize, Error> {
-	let samples = u128::from(sample_rate) * duration.as_nanos();
-	if samples == 0 || !samples.is_multiple_of(1_000_000_000) {
-		return Err(Error::Unsupported(format!(
-			"pcm frame duration must contain a whole number of samples at {sample_rate} Hz"
-		)));
-	}
-	usize::try_from(samples / 1_000_000_000).map_err(|_| Error::Unsupported("pcm frame duration is too large".into()))
-}
-
-fn pcm_bitrate(sample_rate: u32, channels: u32) -> Result<u64, Error> {
-	u64::from(sample_rate)
-		.checked_mul(u64::from(channels))
-		.and_then(|samples| samples.checked_mul(32))
-		.ok_or_else(|| Error::Unsupported("pcm bitrate exceeds the catalog range".into()))
 }
 
 #[cfg(test)]

--- a/rs/moq-audio/src/encode/mod.rs
+++ b/rs/moq-audio/src/encode/mod.rs
@@ -1,6 +1,6 @@
 //! Encode raw PCM and publish it as a moq audio track.
 //!
-//! The output codec is selected via [`Codec`]; Opus is the only one today.
+//! The output codec is selected via [`Codec`].
 //!
 //! Entry points, high to low level:
 //! - `publish_capture` captures a microphone (or system audio) and publishes

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -35,9 +35,11 @@ pub struct Options {
 	/// Channel count the codec runs at. `None` matches the input; anything else
 	/// is rejected, since remapping isn't implemented.
 	pub channels: Option<u32>,
-	/// Bitrate in bits per second. `None` lets the codec pick.
+	/// Bitrate in bits per second. `None` lets Opus pick. PCM requires `None`
+	/// because its bitrate is fixed by the sample rate and channel count.
 	pub bitrate: Option<u32>,
 	/// Encoded frame duration. Opus accepts 2.5 / 5 / 10 / 20 / 40 / 60 ms.
+	/// PCM accepts any duration containing a whole number of samples.
 	pub frame_duration: Duration,
 }
 
@@ -217,7 +219,8 @@ impl<E: CatalogExt> Producer<E> {
 
 	fn publish(&mut self, payload: Bytes, timestamp: Timestamp) -> Result<(), Error> {
 		// Each audio packet is its own moq-lite group, matching
-		// moq_mux::codec::opus::Import. Opus PLC handles dropped groups.
+		// moq_mux::codec::opus::Import. Codecs can recover independently after
+		// a dropped group.
 		let mux_frame = MuxFrame {
 			timestamp,
 			payload,

--- a/rs/moq-audio/src/lib.rs
+++ b/rs/moq-audio/src/lib.rs
@@ -2,9 +2,8 @@
 //!
 //! Counterpart to [`moq-video`](https://crates.io/crates/moq-video) for audio
 //! tracks, and shaped the same way. Sits on top of [`moq_mux`] and [`hang`] and
-//! adds the missing piece for native callers: a Rust-native Opus implementation
-//! that turns raw PCM into the bitstreams `moq_mux::codec::opus` already knows
-//! how to ingest (and vice versa for decode).
+//! adds the missing piece for native callers: Rust-native Opus and uncompressed
+//! PCM codecs that turn raw samples into HANG audio tracks and back.
 //!
 //! - `capture` describes an audio source (`capture::Config`) and grabs buffers
 //!   per platform: a microphone via cpal (CoreAudio / WASAPI / ALSA) everywhere,

--- a/rs/moq-audio/src/lib.rs
+++ b/rs/moq-audio/src/lib.rs
@@ -31,6 +31,7 @@ mod error;
 mod format;
 mod frame;
 mod opus;
+mod pcm;
 mod resample;
 
 #[cfg(feature = "capture")]

--- a/rs/moq-audio/src/pcm.rs
+++ b/rs/moq-audio/src/pcm.rs
@@ -1,0 +1,31 @@
+//! PCM wire-format constraints shared by the encoder and decoder.
+
+use std::time::Duration;
+
+use crate::Error;
+
+pub(crate) const BYTES_PER_SAMPLE: usize = std::mem::size_of::<f32>();
+
+pub(crate) fn bitrate(sample_rate: u32, channels: u32) -> Result<u64, Error> {
+	u64::from(sample_rate)
+		.checked_mul(u64::from(channels))
+		.and_then(|samples| samples.checked_mul(32))
+		.ok_or_else(|| Error::Unsupported("pcm bitrate exceeds the catalog range".into()))
+}
+
+pub(crate) fn frame_size(sample_rate: u32, duration: Duration) -> Result<usize, Error> {
+	let samples = u128::from(sample_rate) * duration.as_nanos();
+	if samples == 0 || !samples.is_multiple_of(1_000_000_000) {
+		return Err(Error::Unsupported(format!(
+			"pcm frame duration must contain a whole number of samples at {sample_rate} Hz"
+		)));
+	}
+	usize::try_from(samples / 1_000_000_000).map_err(|_| Error::Unsupported("pcm frame duration is too large".into()))
+}
+
+pub(crate) fn frame_bytes(frame_size: usize, channels: u32) -> Result<usize, Error> {
+	frame_size
+		.checked_mul(channels as usize)
+		.and_then(|samples| samples.checked_mul(BYTES_PER_SAMPLE))
+		.ok_or_else(|| Error::Unsupported("pcm frame is too large".into()))
+}

--- a/rs/moq-audio/tests/roundtrip.rs
+++ b/rs/moq-audio/tests/roundtrip.rs
@@ -165,3 +165,49 @@ async fn opus_round_trip_44100_s16_resampled() {
 		total_bytes
 	);
 }
+
+#[tokio::test]
+async fn pcm_round_trip_is_lossless() {
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+	let mut catalog_consumer = catalog.consume().unwrap();
+	let broadcast_consumer = broadcast.consume();
+
+	let input = encode::Input {
+		format: Format::F32,
+		sample_rate: 48_000,
+		channels: 2,
+	};
+	let mut options = encode::Options::default();
+	options.track = Some("pcm".to_string());
+	options.codec = encode::Codec::Pcm;
+
+	let mut producer = encode::Producer::new(&mut broadcast, catalog.clone(), input, &options).unwrap();
+	let samples = sine_f32_interleaved(440.0, 48_000, 2, 960);
+	producer
+		.write(&Frame {
+			timestamp: Timestamp::from_micros(123_000).unwrap(),
+			data: f32_bytes(&samples),
+		})
+		.unwrap();
+
+	let snapshot = catalog_consumer.next().await.unwrap().unwrap();
+	let catalog = snapshot.audio.renditions.get("pcm").unwrap();
+	assert_eq!(catalog.codec, hang::catalog::AudioCodec::Pcm);
+	assert_eq!(catalog.bitrate, Some(3_072_000));
+
+	let mut consumer = decode::Consumer::new(&broadcast_consumer, catalog, "pcm", decode::Config::default())
+		.await
+		.unwrap();
+	producer.finish().unwrap();
+
+	let frame = consumer.read().await.unwrap().unwrap();
+	assert_eq!(frame.timestamp, Timestamp::from_micros(123_000).unwrap());
+	let decoded: Vec<f32> = frame
+		.data
+		.chunks_exact(4)
+		.map(|sample| f32::from_le_bytes([sample[0], sample[1], sample[2], sample[3]]))
+		.collect();
+	assert_eq!(decoded, samples);
+	assert!(consumer.read().await.unwrap().is_none());
+}


### PR DESCRIPTION
Part of #2481.

## Summary

- Add a closed PCM backend to `moq-audio` for lossless interleaved little-endian IEEE-754 binary32 encode/decode, with configurable whole-sample frame durations and fixed bitrate calculation.
- Add the `"pcm"` codec to the Rust HANG catalog, document it in the TypeScript catalog, and specify its payload and metadata contract in the HANG Internet-Draft.
- Reject invalid PCM catalogs, empty or channel-misaligned payloads, fractional-sample frame durations, and size/bitrate overflow.

Native publishers can now select PCM when they need to isolate compression cost and latency while keeping the existing producer, consumer, catalog, and timestamp pipeline.

## Public API changes

All changes are additive and target `main`:

- Add `moq_audio::encode::Codec::Pcm`.
- Add `hang::catalog::AudioCodec::Pcm`.
- Add `hang::catalog::AudioCodecKind::Pcm`.

The JavaScript catalog continues accepting extensible codec strings and now documents and tests the `"pcm"` value.

## Test plan

- `nix develop --command just check`
- `nix develop --command cargo clippy -p hang -p moq-audio --all-targets -- -D warnings`
- `nix develop --command cargo test -p hang -p moq-audio`
- `bun test js/hang/src && bun run --cwd js/hang check`
- `nix develop --command just drafts check`

## Cross-package sync

Updated `rs/hang`, `js/hang`, and `drafts/draft-lcurley-moq-hang.md` with the same codec contract. `moq-ffi` and language wrappers are intentionally unchanged because wrapper exposure is out of scope for #2481's current PCM slice.

(Written by GPT-5)
