### PR TITLE
feat(relay): add --cache-duration ceiling on cached group age

### DIFF
--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -420,10 +420,11 @@ capacity = "8GiB"
 # `capacity` to also cap the absolute size.
 headroom = "2GiB"
 
-# Maximum age of any cached group ("30s", "500ms"). Caps each track's own
-# retention window: a publisher advertising a longer window is clamped down to
-# this, so the relay never holds a group longer than this no matter what
-# upstream asks for. Unbounded (each track keeps its own window) when unset.
+# Maximum age of a non-latest cached group ("30s", "500ms"). Caps each track's
+# own retention window: a publisher advertising a longer window is clamped down
+# to this, so the relay never holds an old group longer than this no matter what
+# upstream asks for. The latest group of every track is always retained, as it
+# is the live edge. Unbounded (each track keeps its own window) when unset.
 duration = "30s"
 ```
 

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -400,10 +400,11 @@ environment variable (`MOQ_STATS_ENABLED`, `MOQ_STATS_PREFIX`,
 ### \[cache]
 
 Memory budget for cached groups. Old (non-latest) groups stay cached until their
-track's TTL expires or the pool runs out of room, whichever comes first; under
-memory pressure the least-recently-read groups are evicted first. The latest
-group of every track is always retained. With neither knob set the cache is
-unbounded and only the per-track TTL limits memory.
+track's retention window expires, the `duration` ceiling is reached, or the pool
+runs out of room, whichever comes first; under memory pressure the
+least-recently-read groups are evicted first. The latest group of every track is
+always retained. With none of the knobs set the cache is unbounded and only each
+track's own window limits memory.
 
 ```toml
 [cache]
@@ -418,14 +419,23 @@ capacity = "8GiB"
 # the cache is effectively the lowest-priority user of RAM. Combine with
 # `capacity` to also cap the absolute size.
 headroom = "2GiB"
+
+# Maximum age of any cached group ("30s", "500ms"). Caps each track's own
+# retention window: a publisher advertising a longer window is clamped down to
+# this, so the relay never holds a group longer than this no matter what
+# upstream asks for. Unbounded (each track keeps its own window) when unset.
+duration = "30s"
 ```
 
 The `capacity` budget counts group payload bytes, not process RSS, so leave
 slack below physical memory (or just use `headroom`, which measures actual
-available memory).
+available memory). `duration` is the age counterpart: it bounds how far back the
+cache reaches, which is what keeps a long-running relay from holding groups from
+hours ago when the byte budget alone leaves room for them.
 
-Both flags also accept CLI arguments (`--cache-capacity`, `--cache-headroom`)
-and environment variables (`MOQ_CACHE_CAPACITY`, `MOQ_CACHE_HEADROOM`).
+All three flags also accept CLI arguments (`--cache-capacity`,
+`--cache-headroom`, `--cache-duration`) and environment variables
+(`MOQ_CACHE_CAPACITY`, `MOQ_CACHE_HEADROOM`, `MOQ_CACHE_DURATION`).
 
 ### \[iroh]
 

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -422,17 +422,24 @@ headroom = "2GiB"
 
 # Maximum age of a non-latest cached group ("30s", "500ms"). Caps each track's
 # own retention window: a publisher advertising a longer window is clamped down
-# to this, so the relay never holds an old group longer than this no matter what
-# upstream asks for. The latest group of every track is always retained, as it
-# is the live edge. Unbounded (each track keeps its own window) when unset.
+# to this, bounding how much history a track accumulates no matter what upstream
+# asks for. The latest group of every track is always retained, as it is the
+# live edge. Unbounded (each track keeps its own window) when unset.
 duration = "30s"
 ```
 
 The `capacity` budget counts group payload bytes, not process RSS, so leave
 slack below physical memory (or just use `headroom`, which measures actual
-available memory). `duration` is the age counterpart: it bounds how far back the
-cache reaches, which is what keeps a long-running relay from holding groups from
-hours ago when the byte budget alone leaves room for them.
+available memory). `duration` is the age counterpart: it stops a long-running
+relay from accumulating hours of history per track when the byte budget alone
+leaves room for it.
+
+A track's expiry is evaluated as it writes its next group, so `duration` caps
+how much history an *active* publisher builds up rather than acting as a
+background reaper. A publisher that stops writing but stays connected keeps what
+it had cached until it resumes or the broadcast closes, and a publisher that
+disconnects has its groups released once the broadcast closes (see
+`cluster.linger`). Set `capacity` or `headroom` alongside it to bound those.
 
 All three flags also accept CLI arguments (`--cache-capacity`,
 `--cache-headroom`, `--cache-duration`) and environment variables

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -108,6 +108,14 @@ pub struct Info {
 	/// whole process share one memory budget.
 	pub pool: cache::Pool,
 
+	/// Ceiling on how long any non-latest group under this origin is retained. Each
+	/// track's own [`latency_max`](track::Info::latency_max) window is clamped down to
+	/// this when the track binds, so a group is never held longer than this regardless
+	/// of what a publisher advertises. The age budget alongside [`Self::pool`]'s byte
+	/// budget: a relay bounds memory by both. [`Duration::MAX`] (the default) imposes no
+	/// ceiling, leaving each track's own window in force.
+	pub cache_duration: Duration,
+
 	/// How long a broadcast under this origin outlives the *ungraceful* loss of its
 	/// last source before closing. Within the window the path stays announced and a
 	/// source re-attaching at it (a session reconnecting, a publisher re-announcing)
@@ -126,6 +134,7 @@ impl Default for Info {
 		Self {
 			id: Origin::UNKNOWN,
 			pool: cache::Pool::default(),
+			cache_duration: Duration::MAX,
 			linger: Duration::ZERO,
 		}
 	}
@@ -140,6 +149,13 @@ impl Info {
 	/// Set the cache pool this origin's broadcasts inherit, returning `self` for chaining.
 	pub fn with_pool(mut self, pool: cache::Pool) -> Self {
 		self.pool = pool;
+		self
+	}
+
+	/// Set the retention ceiling (see [`Self::cache_duration`]) applied to every track
+	/// under this origin, returning `self` for chaining.
+	pub fn with_cache_duration(mut self, cache_duration: Duration) -> Self {
+		self.cache_duration = cache_duration;
 		self
 	}
 
@@ -785,6 +801,10 @@ pub struct Producer {
 	// mint their remote broadcasts with it). Unbounded by default.
 	pool: cache::Pool,
 
+	// Retention ceiling inherited by broadcasts created under this origin (see
+	// [`Info::cache_duration`]). `Duration::MAX` (no ceiling) by default.
+	cache_duration: Duration,
+
 	// How long a broadcast outlives ungracefully losing its last source (see
 	// [`Info::linger`]). Zero by default.
 	linger: Duration,
@@ -814,6 +834,7 @@ impl Producer {
 			root: PathOwned::default(),
 			dynamic: kio::Shared::default(),
 			pool: info.pool,
+			cache_duration: info.cache_duration,
 			linger: info.linger,
 			stats: stats::Session::default(),
 		}
@@ -846,6 +867,7 @@ impl Producer {
 		Info {
 			id: self.info,
 			pool: self.pool.clone(),
+			cache_duration: self.cache_duration,
 			linger: self.linger,
 		}
 	}
@@ -861,6 +883,7 @@ impl Producer {
 			root: PathOwned::default(),
 			dynamic: kio::Shared::default(),
 			pool: cache::Pool::default(),
+			cache_duration: Duration::MAX,
 			linger: Duration::ZERO,
 			stats: stats::Session::default(),
 		}
@@ -950,6 +973,7 @@ impl Producer {
 			root: self.root.clone(),
 			dynamic: self.dynamic.clone(),
 			pool: self.pool.clone(),
+			cache_duration: self.cache_duration,
 			linger: self.linger,
 			stats: self.stats.clone(),
 		})
@@ -1005,6 +1029,7 @@ impl Producer {
 			nodes: self.nodes.root(&prefix)?,
 			dynamic: self.dynamic.clone(),
 			pool: self.pool.clone(),
+			cache_duration: self.cache_duration,
 			linger: self.linger,
 			stats: self.stats.clone(),
 		})

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -131,6 +131,17 @@ impl Info {
 		self.ordered = ordered;
 		self
 	}
+
+	/// Bind this track to its parent `broadcast`, the moment groups gain a shared
+	/// cache pool to register with. Also clamps [`Self::latency_max`] down to the
+	/// origin's [`cache_duration`](crate::origin::Info::cache_duration) ceiling, so a
+	/// group is never retained longer than the origin allows regardless of the window
+	/// the publisher advertised. Every bind path funnels through here, so the clamp
+	/// covers local publishers and relayed (lite / IETF) tracks alike.
+	pub(crate) fn bind(&mut self, broadcast: Arc<broadcast::Info>) {
+		self.latency_max = self.latency_max.min(broadcast.origin.cache_duration);
+		self.broadcast = broadcast;
+	}
 }
 
 #[derive(Default)]
@@ -578,7 +589,7 @@ impl TrackState {
 			.info
 			.get_or_insert_with(|| {
 				let mut info = info.unwrap_or_default();
-				info.broadcast = broadcast;
+				info.bind(broadcast);
 				info
 			})
 			.clone();
@@ -629,7 +640,7 @@ impl Producer {
 		info: impl Into<Option<Info>>,
 	) -> Self {
 		let mut info = info.into().unwrap_or_default();
-		info.broadcast = broadcast.clone();
+		info.bind(broadcast.clone());
 		Self {
 			name: name.into(),
 			state: kio::Producer::new(TrackState {
@@ -2296,7 +2307,7 @@ impl Request {
 	/// aborted immediately after accepting.
 	pub fn accept(self, info: impl Into<Option<Info>>) -> Producer {
 		let mut info = info.into().unwrap_or_default();
-		info.broadcast = self.broadcast.clone();
+		info.bind(self.broadcast.clone());
 		// A closed state means the track was aborted under us. Mirror `reject` and
 		// tolerate it: the Producer we hand back simply can't write.
 		if let Ok(mut state) = self.state.write() {
@@ -2780,6 +2791,54 @@ mod test {
 			.update(Subscription::default().with_latency_max(Duration::ZERO))
 			.unwrap();
 		assert_eq!(producer.subscription().unwrap().latency_max, Duration::ZERO);
+	}
+
+	/// Mint a track under an origin whose retention ceiling is `cap`, so the
+	/// track's own window is clamped down to it on bind.
+	fn track_producer_capped(name: impl Into<Arc<str>>, info: Info, cap: Duration) -> Producer {
+		let origin = crate::origin::Info::default().with_cache_duration(cap);
+		Producer::new(Arc::new(broadcast::Info { origin }), name, info)
+	}
+
+	#[test]
+	fn origin_cache_duration_clamps_latency_max() {
+		// A publisher asking to keep groups for a minute is capped to the origin's 1s
+		// ceiling; a publisher already below the ceiling is left alone (it's a min).
+		let capped = track_producer_capped(
+			"test",
+			Info::default().with_latency_max(Duration::from_secs(60)),
+			Duration::from_secs(1),
+		);
+		assert_eq!(capped.state.read().latency_bound(), Some(Duration::from_secs(1)));
+
+		let under = track_producer_capped(
+			"test",
+			Info::default().with_latency_max(Duration::from_millis(500)),
+			Duration::from_secs(1),
+		);
+		assert_eq!(under.state.read().latency_bound(), Some(Duration::from_millis(500)));
+	}
+
+	#[tokio::test]
+	async fn origin_cache_duration_caps_eviction() {
+		tokio::time::pause();
+
+		// The publisher wants a 60s window, but the origin caps retention at 1s.
+		let mut producer = track_producer_capped(
+			"test",
+			Info::default().with_latency_max(Duration::from_secs(60)),
+			Duration::from_secs(1),
+		);
+		producer.append_group().unwrap(); // seq 0
+
+		// Past the origin ceiling but far within the publisher's own 60s window.
+		tokio::time::advance(Duration::from_secs(2)).await;
+		producer.append_group().unwrap(); // seq 1
+
+		// Seq 0 is evicted anyway: the origin ceiling wins over the larger publisher window.
+		let state = producer.state.read();
+		assert_eq!(live_groups(&state), 1);
+		assert_eq!(first_live_sequence(&state), 1);
 	}
 
 	#[test]

--- a/rs/moq-relay/src/cache.rs
+++ b/rs/moq-relay/src/cache.rs
@@ -15,10 +15,11 @@ const GOVERNOR_INTERVAL: Duration = Duration::from_secs(5);
 
 /// Configuration for the relay's group cache.
 ///
-/// Non-latest groups stay cached until their track's TTL expires or the pool
-/// runs out of room, whichever comes first (the latest group of every track is
-/// always retained). With neither knob set the pool is unbounded and only the
-/// per-track TTL bounds memory.
+/// Non-latest groups stay cached until their track's retention window expires,
+/// the `duration` ceiling is reached, or the pool runs out of room, whichever
+/// comes first (the latest group of every track is always retained). With none
+/// of the knobs set the pool is unbounded and only each track's own window
+/// bounds memory.
 #[derive(Args, Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]
 #[non_exhaustive]
@@ -41,12 +42,34 @@ pub struct CacheConfig {
 	/// absolute size.
 	#[arg(long = "cache-headroom", env = "MOQ_CACHE_HEADROOM")]
 	pub headroom: Option<String>,
+
+	/// Maximum age of any cached group, e.g. "30s" or "500ms".
+	///
+	/// Caps each track's own retention window: a publisher advertising a longer
+	/// window is clamped down to this, so the relay never holds a group longer
+	/// than this regardless of what upstream asks for. This bounds memory by age
+	/// where `capacity` bounds it by bytes. Unbounded (each track keeps its own
+	/// window) when unset.
+	#[arg(long = "cache-duration", env = "MOQ_CACHE_DURATION", value_parser = humantime::parse_duration)]
+	#[serde(default, with = "humantime_serde")]
+	pub duration: Option<Duration>,
+}
+
+/// The relay's resolved cache settings: the shared byte-budget pool plus the
+/// age ceiling applied to every track.
+pub struct Cache {
+	/// The shared byte-budget pool every session's groups register with.
+	pub pool: cache::Pool,
+
+	/// Ceiling on how long any cached group is retained. [`Duration::MAX`] imposes
+	/// no ceiling, leaving each track's own window in force.
+	pub duration: Duration,
 }
 
 impl CacheConfig {
-	/// Build the shared [`cache::Pool`], spawning the headroom governor when
-	/// configured. Requires a tokio runtime.
-	pub fn init(&self) -> anyhow::Result<cache::Pool> {
+	/// Resolve the size knobs into a shared [`cache::Pool`] and age ceiling,
+	/// spawning the headroom governor when configured. Requires a tokio runtime.
+	pub fn init(&self) -> anyhow::Result<Cache> {
 		let capacity = self.capacity.as_deref().map(parse_limit).transpose()?;
 		let pool = match capacity {
 			Some(bytes) => cache::Pool::new(bytes),
@@ -62,7 +85,14 @@ impl CacheConfig {
 			tracing::info!(capacity, "cache capacity set");
 		}
 
-		Ok(pool)
+		if let Some(duration) = self.duration {
+			tracing::info!(?duration, "cache duration ceiling set");
+		}
+
+		Ok(Cache {
+			pool,
+			duration: self.duration.unwrap_or(Duration::MAX),
+		})
 	}
 }
 

--- a/rs/moq-relay/src/cache.rs
+++ b/rs/moq-relay/src/cache.rs
@@ -43,13 +43,14 @@ pub struct CacheConfig {
 	#[arg(long = "cache-headroom", env = "MOQ_CACHE_HEADROOM")]
 	pub headroom: Option<String>,
 
-	/// Maximum age of any cached group, e.g. "30s" or "500ms".
+	/// Maximum age of a non-latest cached group, e.g. "30s" or "500ms".
 	///
 	/// Caps each track's own retention window: a publisher advertising a longer
-	/// window is clamped down to this, so the relay never holds a group longer
-	/// than this regardless of what upstream asks for. This bounds memory by age
-	/// where `capacity` bounds it by bytes. Unbounded (each track keeps its own
-	/// window) when unset.
+	/// window is clamped down to this, so the relay never holds an old group
+	/// longer than this regardless of what upstream asks for. The latest group of
+	/// every track is always retained, as it is the live edge. This bounds memory
+	/// by age where `capacity` bounds it by bytes. Unbounded (each track keeps its
+	/// own window) when unset.
 	#[arg(long = "cache-duration", env = "MOQ_CACHE_DURATION", value_parser = humantime::parse_duration)]
 	#[serde(default, with = "humantime_serde")]
 	pub duration: Option<Duration>,
@@ -61,8 +62,9 @@ pub struct Cache {
 	/// The shared byte-budget pool every session's groups register with.
 	pub pool: cache::Pool,
 
-	/// Ceiling on how long any cached group is retained. [`Duration::MAX`] imposes
-	/// no ceiling, leaving each track's own window in force.
+	/// Ceiling on how long a non-latest group is retained (the latest group of every
+	/// track is always kept). [`Duration::MAX`] imposes no ceiling, leaving each
+	/// track's own window in force.
 	pub duration: Duration,
 }
 

--- a/rs/moq-relay/src/cache.rs
+++ b/rs/moq-relay/src/cache.rs
@@ -46,11 +46,16 @@ pub struct CacheConfig {
 	/// Maximum age of a non-latest cached group, e.g. "30s" or "500ms".
 	///
 	/// Caps each track's own retention window: a publisher advertising a longer
-	/// window is clamped down to this, so the relay never holds an old group
-	/// longer than this regardless of what upstream asks for. The latest group of
-	/// every track is always retained, as it is the live edge. This bounds memory
-	/// by age where `capacity` bounds it by bytes. Unbounded (each track keeps its
-	/// own window) when unset.
+	/// window is clamped down to this, bounding how much history a track can
+	/// accumulate no matter what upstream asks for. This bounds memory by age
+	/// where `capacity` bounds it by bytes. Unbounded (each track keeps its own
+	/// window) when unset.
+	///
+	/// Two caveats on the ceiling. The latest group of every track is always
+	/// retained, since it is the live edge. And expiry is evaluated when a track
+	/// writes its next group, so a publisher that stops writing without
+	/// disconnecting keeps whatever it had cached until it resumes or the
+	/// broadcast closes; the `capacity` budget is what reclaims those.
 	#[arg(long = "cache-duration", env = "MOQ_CACHE_DURATION", value_parser = humantime::parse_duration)]
 	#[serde(default, with = "humantime_serde")]
 	pub duration: Option<Duration>,

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -418,15 +418,19 @@ impl Cluster {
 		})
 	}
 
-	/// Attach the shared group [`cache::Pool`](moq_net::cache::Pool) so every
-	/// session's broadcasts cache into one memory budget. Call before deriving
-	/// any origin handles (e.g. [`with_stats`](Self::with_stats)) so they inherit
-	/// the pool.
+	/// Attach the resolved [`Cache`](crate::Cache) (the shared group pool and the
+	/// per-track retention ceiling) so every session's broadcasts cache into one
+	/// memory budget bounded by both bytes and age. Call before deriving any origin
+	/// handles (e.g. [`with_stats`](Self::with_stats)) so they inherit the settings.
 	///
-	/// Rebuilds the origin with the pool: safe because the cluster's origin is
+	/// Rebuilds the origin with the cache: safe because the cluster's origin is
 	/// still pristine here (no broadcasts published, no scopes derived).
-	pub fn with_cache(mut self, pool: moq_net::cache::Pool) -> Self {
-		self.info = self.info.clone().with_pool(pool);
+	pub fn with_cache(mut self, cache: crate::Cache) -> Self {
+		self.info = self
+			.info
+			.clone()
+			.with_pool(cache.pool)
+			.with_cache_duration(cache.duration);
 		self.origin = self.info.clone().produce();
 		self
 	}

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -215,6 +215,24 @@ duration = "30s"
 		);
 	}
 
+	/// `cache.duration` is an `Option<Duration>` behind plain `humantime_serde`
+	/// (not `humantime_serde::option`), so pin both directions including the
+	/// `None` serialize path, which the merge test above never exercises.
+	#[test]
+	fn cache_duration_serde_round_trip() {
+		let set: CacheConfig = toml::from_str(r#"duration = "30s""#).expect("deserialize Some");
+		assert_eq!(set.duration, Some(std::time::Duration::from_secs(30)));
+
+		let unset: CacheConfig = toml::from_str("").expect("deserialize absent");
+		assert_eq!(unset.duration, None);
+
+		let encoded = toml::to_string(&set).expect("serialize Some");
+		let decoded: CacheConfig = toml::from_str(&encoded).expect("re-deserialize");
+		assert_eq!(decoded.duration, set.duration, "round trip must preserve the duration");
+
+		toml::to_string(&unset).expect("serialize None");
+	}
+
 	/// Serializes tests that touch `MOQ_CLUSTER_LINGER`. Same rationale as
 	/// `STATS_ENV_LOCK`.
 	static LINGER_ENV_LOCK: Mutex<()> = Mutex::new(());

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -185,12 +185,14 @@ depth = 2
 		unsafe {
 			std::env::remove_var("MOQ_CACHE_CAPACITY");
 			std::env::remove_var("MOQ_CACHE_HEADROOM");
+			std::env::remove_var("MOQ_CACHE_DURATION");
 		}
 
 		let toml = r#"
 [cache]
 capacity = "8GiB"
 headroom = "10%"
+duration = "30s"
 "#;
 		let dir = std::env::temp_dir().join("moq-relay-config-test");
 		std::fs::create_dir_all(&dir).unwrap();
@@ -206,6 +208,11 @@ headroom = "10%"
 			"TOML's cache.capacity must not be clobbered by the CLI re-parse"
 		);
 		assert_eq!(config.cache.headroom.as_deref(), Some("10%"));
+		assert_eq!(
+			config.cache.duration,
+			Some(std::time::Duration::from_secs(30)),
+			"TOML's cache.duration must not be clobbered by the CLI re-parse"
+		);
 	}
 
 	/// Serializes tests that touch `MOQ_CLUSTER_LINGER`. Same rationale as


### PR DESCRIPTION
## Summary

- Adds `--cache-duration` to bound relay cache memory by **age** as well as bytes. Today a publisher advertising a long `latency_max` can pin non-latest groups for far longer than an operator wants, and the byte-budget pool won't reclaim them while it still has room.
- The ceiling lives on `origin::Info` beside the existing `pool` and `linger`, and is enforced by clamping `track::Info::latency_max` when a track binds to its parent broadcast.
- All three bind sites now funnel through a new `pub(crate) Info::bind`, so a single choke point covers local publishers plus lite- and IETF-relayed tracks.
- Clamping at bind rather than on the wire means the relay re-advertises the capped window downstream for free. **No wire-format change**, so no `drafts/` update is required.
- Defaults to `Duration::MAX` (no ceiling), so behavior is unchanged unless configured.

Two limits on the ceiling, both documented on the flag and in the config page:

- The latest group of every track is always retained, since it is the live edge.
- Expiry is evaluated when a track writes its next group, so the knob caps how much history an *active* publisher accumulates rather than acting as a background reaper. A publisher that stops writing without disconnecting keeps what it had cached until it resumes or the broadcast closes; `capacity`/`headroom` are what reclaim those.

It clamps down only, never up: `--cache-duration 30s` leaves a track that asked for 5s at 5s. That matches "maximum", and avoids *increasing* memory for low-latency tracks that deliberately asked for less.

```bash
moq-relay --cache-capacity 8GiB --cache-duration 30s
```

Also settable via `MOQ_CACHE_DURATION` or `[cache] duration = "30s"`, humantime-parsed like the existing `--cluster-linger`.

## Public API changes

`rs/moq-net` (all additive, targets `main`):
- **Added** `pub origin::Info::cache_duration: Duration`. Additive: `origin::Info` is `#[non_exhaustive]`.
- **Added** `pub fn origin::Info::with_cache_duration(self, Duration) -> Self`.
- `track::Info::bind` is `pub(crate)`, not public surface.

`rs/moq-relay`:
- **Added** `pub struct Cache { pub pool, pub duration }` and `pub CacheConfig::duration`.
- **Signature changed**: `CacheConfig::init` now returns `Cache` instead of `cache::Pool`, and `Cluster::with_cache` takes `Cache` instead of `cache::Pool`. Breaking for library consumers of `moq-relay`, which is not one of the crates [Branch Targeting](CONTRIBUTING.md#branch-targeting) reserves for `dev`, so this targets `main`. Bundling both settings into one value kept `with_cache` a single call instead of growing a parallel setter.

No `version =` bumps; release-plz owns those.

## Test plan

- `origin_cache_duration_clamps_latency_max`: the clamp is a `min` (a 60s publisher window caps to 1s; a 500ms one is left alone).
- `origin_cache_duration_caps_eviction`: a group is actually evicted at the origin ceiling despite a 60s publisher window, so the clamp reaches `evict_expired` rather than just the stored field.
- `cache_duration_serde_round_trip`: pins the `Option<Duration>` behavior under plain `humantime_serde`, covering the `None` serialize path the config-merge test never exercises.
- Extended `cli_does_not_clobber_toml_cache` for the clap+TOML clobber footgun.
- `just check` exits 0; full `cargo test --workspace` passes.

## Cross-package sync

`rs/moq-relay` config → `doc/bin/relay/config.md` `[cache]` section updated. No other rows apply: no wire, catalog, or FFI surface is touched.

Follow-up, not in scope here: `rs/hang` never sets `latency_max`, so catalog and media tracks both inherit the 5s default. Catalog tracks are latest-value only and want `0`; media tracks want a larger window now that the relay can cap it. That spans `rs/hang`, `rs/moq-mux`, and `js/hang`, so it gets its own PR.

(Written by Opus 5)