### PR TITLE
feat(moq-video)!: carry timestamps through encode

### DIFF
--- a/rs/libmoq/src/test.rs
+++ b/rs/libmoq/src/test.rs
@@ -1501,13 +1501,16 @@ fn video_raw_decode() {
 	let gray = vec![0x80u8; 320 * 240 * 4];
 	let mut frames: Vec<bytes::Bytes> = Vec::new();
 	for i in 0..5 {
+		let timestamp = moq_net::Timestamp::from_micros(i * 33_333).unwrap();
 		frames.extend(
 			encoder
-				.encode_rgba(&gray, moq_video::Size::new(320, 240), i == 0)
-				.unwrap(),
+				.encode_rgba(&gray, moq_video::Size::new(320, 240), timestamp, i == 0)
+				.unwrap()
+				.into_iter()
+				.map(|packet| packet.payload),
 		);
 	}
-	frames.extend(encoder.finish().unwrap());
+	frames.extend(encoder.finish().unwrap().into_iter().map(|packet| packet.payload));
 	assert!(!frames.is_empty(), "encoder produced no frames");
 
 	let origin = id(moq_origin_create());

--- a/rs/moq-boy/src/video.rs
+++ b/rs/moq-boy/src/video.rs
@@ -105,9 +105,9 @@ fn encoder_thread(
 
 		let keyframe = force_keyframe.swap(false, Ordering::AcqRel);
 		let start = Instant::now();
-		match enc.encode_rgba(&msg.rgba, moq_video::Size::new(WIDTH, HEIGHT), keyframe) {
+		match enc.encode_rgba(&msg.rgba, moq_video::Size::new(WIDTH, HEIGHT), msg.ts, keyframe) {
 			Ok(packets) => {
-				if let Err(e) = producer.publish(packets, msg.ts) {
+				if let Err(e) = producer.publish(packets) {
 					// Publish only fails once the track/broadcast is gone, which
 					// is terminal -- stop rather than flooding logs every frame.
 					tracing::error!(error = %e, "video publish failed; stopping encoder");

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -193,14 +193,14 @@ mod tests {
 		for sequence in 0..groups {
 			let mut group = track.create_group(sequence.into()).unwrap();
 			for index in 0..frames {
-				let timestamp = (sequence * frames + index) * 33_333;
-				for payload in encoder
-					.encode_rgba(&gray, moq_video::Size::new(320, 240), index == 0)
+				let timestamp = moq_net::Timestamp::from_micros((sequence * frames + index) * 33_333).unwrap();
+				for packet in encoder
+					.encode_rgba(&gray, moq_video::Size::new(320, 240), timestamp, index == 0)
 					.unwrap()
 				{
 					let frame = hang::container::Frame {
-						timestamp: moq_net::Timestamp::from_micros(timestamp).unwrap(),
-						payload,
+						timestamp: packet.timestamp,
+						payload: packet.payload,
 					};
 					frame.write_to(&mut group).unwrap();
 				}
@@ -261,14 +261,14 @@ mod tests {
 				tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 				let mut group = track.create_group(sequence.into()).unwrap();
 				for index in 0..frames {
-					let timestamp = (sequence * frames + index) * 33_333;
-					for payload in encoder
-						.encode_rgba(&gray, moq_video::Size::new(320, 240), index == 0)
+					let timestamp = moq_net::Timestamp::from_micros((sequence * frames + index) * 33_333).unwrap();
+					for packet in encoder
+						.encode_rgba(&gray, moq_video::Size::new(320, 240), timestamp, index == 0)
 						.unwrap()
 					{
 						let frame = hang::container::Frame {
-							timestamp: moq_net::Timestamp::from_micros(timestamp).unwrap(),
-							payload,
+							timestamp: packet.timestamp,
+							payload: packet.payload,
 						};
 						frame.write_to(&mut group).unwrap();
 					}

--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -175,8 +175,7 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 						let scaled = frame.resize(rung.info.size)?;
 						encoder.encode(&scaled, keyframe)?
 					};
-					let timestamp = frame.timestamp;
-					write(output, encoded.into_iter().map(|packet| (timestamp, packet)).collect())?;
+					write(output, encoded)?;
 				}
 				Some(Item::End) => {
 					if let Some(mut output) = current.take() {
@@ -314,17 +313,12 @@ async fn transcode_group_inner(
 	output: &mut moq_net::group::Producer,
 ) -> Result<(), Error> {
 	let mut first = true;
-	// The latest presentation time seen, tracked so a one-shot group can stamp any
-	// packets the encoder still holds at the end. `None` until the first frame:
-	// `Timestamp` compares by raw value at a fixed scale, so there's no scale-neutral
-	// zero to seed it with (the source's scale isn't known until a frame arrives).
-	let mut last_timestamp: Option<moq_net::Timestamp> = None;
+	let mut saw_frame = false;
 
 	while let Some(frames) = container.read(source).await? {
 		for frame in frames {
 			let timestamp = frame.timestamp;
-			// All source frames share one scale, so this `max` never crosses scales.
-			last_timestamp = Some(last_timestamp.map_or(timestamp, |last| last.max(timestamp)));
+			saw_frame = true;
 
 			// A group opens on a keyframe by construction, so the first frame is
 			// an IDR. The low-level `Container::read` the transcoder uses does not
@@ -340,17 +334,17 @@ async fn transcode_group_inner(
 		}
 	}
 
-	if let Some(last_timestamp) = last_timestamp {
-		// One-shot group: drain whatever the encoder still buffers, stamping it with
-		// the last presentation time we saw. No frames read means nothing to drain.
-		write(output, pipeline.finish(last_timestamp)?)?;
+	if saw_frame {
+		// One-shot group: drain whatever the encoder still buffers. Every packet
+		// keeps the timestamp of the frame that produced it.
+		write(output, pipeline.finish()?)?;
 	}
 	Ok(())
 }
 
 /// Append encoded packets to the output group in the legacy hang framing.
-fn write(output: &mut moq_net::group::Producer, packets: Vec<(moq_net::Timestamp, Bytes)>) -> Result<(), Error> {
-	for (timestamp, payload) in packets {
+fn write(output: &mut moq_net::group::Producer, packets: Vec<moq_video::encode::Packet>) -> Result<(), Error> {
+	for moq_video::encode::Packet { timestamp, payload, .. } in packets {
 		let frame = hang::container::Frame { timestamp, payload };
 		frame.write_to(output)?;
 	}
@@ -391,10 +385,9 @@ impl Pipeline {
 		payload: &Bytes,
 		timestamp: moq_net::Timestamp,
 		keyframe: bool,
-	) -> Result<Vec<(moq_net::Timestamp, Bytes)>, Error> {
+	) -> Result<Vec<moq_video::encode::Packet>, Error> {
 		let mut packets = Vec::new();
 		for raw in self.decoder.decode(payload, timestamp, keyframe)? {
-			let raw_timestamp = raw.timestamp;
 			let encoded = if raw.size == self.size {
 				// Already at the rung size (the decoder scaled): feed the frame
 				// through as-is, keeping a GPU frame on the GPU.
@@ -402,23 +395,14 @@ impl Pipeline {
 			} else {
 				self.encoder.encode(&raw.resize(self.size)?, keyframe)?
 			};
-			for packet in encoded {
-				packets.push((raw_timestamp, packet));
-			}
+			packets.extend(encoded);
 		}
 		Ok(packets)
 	}
 
-	/// Drain the encoder, pairing any buffered packets with `timestamp`.
-	///
 	/// Consumes the pipeline, since flushing the encoder consumes it: a one-shot
 	/// group's pipeline is done once drained.
-	fn finish(self, timestamp: moq_net::Timestamp) -> Result<Vec<(moq_net::Timestamp, Bytes)>, Error> {
-		Ok(self
-			.encoder
-			.finish()?
-			.into_iter()
-			.map(|packet| (timestamp, packet))
-			.collect())
+	fn finish(self) -> Result<Vec<moq_video::encode::Packet>, Error> {
+		Ok(self.encoder.finish()?)
 	}
 }

--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -335,16 +335,16 @@ async fn transcode_group_inner(
 	}
 
 	if saw_frame {
-		// One-shot group: drain whatever the encoder still buffers. Every packet
+		// One-shot group: drain whatever the encoder still buffers. Every frame
 		// keeps the timestamp of the frame that produced it.
 		write(output, pipeline.finish()?)?;
 	}
 	Ok(())
 }
 
-/// Append encoded packets to the output group in the legacy hang framing.
-fn write(output: &mut moq_net::group::Producer, packets: Vec<moq_video::encode::Packet>) -> Result<(), Error> {
-	for moq_video::encode::Packet { timestamp, payload, .. } in packets {
+/// Append encoded frames to the output group in the legacy hang framing.
+fn write(output: &mut moq_net::group::Producer, frames: Vec<moq_video::encode::Frame>) -> Result<(), Error> {
+	for moq_video::encode::Frame { timestamp, payload } in frames {
 		let frame = hang::container::Frame { timestamp, payload };
 		frame.write_to(output)?;
 	}
@@ -378,15 +378,15 @@ impl Pipeline {
 		})
 	}
 
-	/// Transcode one container payload into zero or more encoded packets, each
+	/// Transcode one container payload into zero or more encoded frames, each
 	/// paired with its presentation timestamp.
 	fn process(
 		&mut self,
 		payload: &Bytes,
 		timestamp: moq_net::Timestamp,
 		keyframe: bool,
-	) -> Result<Vec<moq_video::encode::Packet>, Error> {
-		let mut packets = Vec::new();
+	) -> Result<Vec<moq_video::encode::Frame>, Error> {
+		let mut frames = Vec::new();
 		for raw in self.decoder.decode(payload, timestamp, keyframe)? {
 			let encoded = if raw.size == self.size {
 				// Already at the rung size (the decoder scaled): feed the frame
@@ -395,14 +395,14 @@ impl Pipeline {
 			} else {
 				self.encoder.encode(&raw.resize(self.size)?, keyframe)?
 			};
-			packets.extend(encoded);
+			frames.extend(encoded);
 		}
-		Ok(packets)
+		Ok(frames)
 	}
 
 	/// Consumes the pipeline, since flushing the encoder consumes it: a one-shot
 	/// group's pipeline is done once drained.
-	fn finish(self) -> Result<Vec<moq_video::encode::Packet>, Error> {
+	fn finish(self) -> Result<Vec<moq_video::encode::Frame>, Error> {
 		Ok(self.encoder.finish()?)
 	}
 }

--- a/rs/moq-video/CHANGELOG.md
+++ b/rs/moq-video/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [**breaking**] Carry each input timestamp through `encode::Packet`, including
-  packets drained by `Encoder::finish`, and publish packets at their own
+- [**breaking**] Carry each input timestamp through `encode::Frame`, including
+  frames drained by `Encoder::finish`, and publish frames at their own
   timestamps.
 
 - `decode::Frame::resize(width, height)`: a scaled copy of a decoded frame,

--- a/rs/moq-video/CHANGELOG.md
+++ b/rs/moq-video/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [**breaking**] Carry each input timestamp through `encode::Packet`, including
+  packets drained by `Encoder::finish`, and publish packets at their own
+  timestamps.
+
 - `decode::Frame::resize(width, height)`: a scaled copy of a decoded frame,
   preserving the timestamp. A CUDA frame (NVDEC output) resizes on the GPU with
   a box-filter kernel (vendored PTX, JIT-compiled by the driver; no CUDA

--- a/rs/moq-video/DESIGN-native-codecs.md
+++ b/rs/moq-video/DESIGN-native-codecs.md
@@ -77,11 +77,14 @@ selection + linear fallback chain (which is already the right shape, see
 ```rust
 // encode/backend/mod.rs
 pub(crate) trait Backend: Send {
-    /// Encode one NV12 frame. `force_keyframe` requests an IDR. Returns zero or
-    /// more H.264 packets in this backend's native framing (see `wire_mode`):
-    /// Annex-B for Avc3 backends, length-prefixed NALs for Avc1.
-    fn encode(&mut self, frame: &Nv12, force_keyframe: bool) -> Result<Vec<Bytes>, Error>;
-    fn finish(&mut self) -> Result<Vec<Bytes>, Error>;
+    /// Encode one frame. Every emitted packet keeps the input timestamp.
+    fn encode(
+        &mut self,
+        frame: &Frame,
+        timestamp: Timestamp,
+        force_keyframe: bool,
+    ) -> Result<Vec<Packet>, Error>;
+    fn finish(&mut self) -> Result<Vec<Packet>, Error>;
 
     /// Which `moq_mux::h264::Mode` the producer should run for this backend.
     /// Avc3 (Annex-B, in-band SPS/PPS) for openh264/nvenc/vaapi; Avc1 for VT.
@@ -109,9 +112,9 @@ encode/
     openh264.rs     # software fallback, all platforms
 ```
 
-The public surface (`Encoder`, `Config`, `Kind`, `Producer`, `Options`,
-`publish_capture`) stays **identical**, so `moq-cli` and the catalog/producer
-path don't change. `Kind::Named(String)` keeps working but its meaning shifts
+The backend selection surface (`Encoder`, `Config`, `Kind`, `Producer`,
+`Options`, `publish_capture`) stays codec-agnostic. `Kind::Named(String)` keeps
+working but its meaning shifts
 from "ffmpeg encoder name" to "backend id" (`"videotoolbox"`, `"nvenc"`,
 `"vaapi"`, `"openh264"`); document the change.
 

--- a/rs/moq-video/DESIGN-native-codecs.md
+++ b/rs/moq-video/DESIGN-native-codecs.md
@@ -77,14 +77,14 @@ selection + linear fallback chain (which is already the right shape, see
 ```rust
 // encode/backend/mod.rs
 pub(crate) trait Backend: Send {
-    /// Encode one frame. Every emitted packet keeps the input timestamp.
+    /// Encode one frame. Every emitted frame keeps the input timestamp.
     fn encode(
         &mut self,
         frame: &Frame,
         timestamp: Timestamp,
         force_keyframe: bool,
-    ) -> Result<Vec<Packet>, Error>;
-    fn finish(&mut self) -> Result<Vec<Packet>, Error>;
+    ) -> Result<Vec<Frame>, Error>;
+    fn finish(&mut self) -> Result<Vec<Frame>, Error>;
 
     /// Which `moq_mux::h264::Mode` the producer should run for this backend.
     /// Avc3 (Annex-B, in-band SPS/PPS) for openh264/nvenc/vaapi; Avc1 for VT.
@@ -469,7 +469,7 @@ The "H.264 only" scope above was the ffmpeg-removal project. H.265 encode landed
 afterward on top of the same `Backend` seam:
 
 - `Encoder`/`Config`/`Options` gained a `Codec` field (`H264` / `H265`);
-  `Producer::new` takes the codec and routes packets to the matching
+  `Producer::new` takes the codec and routes frames to the matching
   `moq_mux::codec` importer (`.avc3` / `.hev1`). The mux + `hang` catalog already
   supported both, so only `moq-video` needed work.
 - Backends advertise the codecs they emit and `backend::open` filters by the

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -45,8 +45,8 @@ Two public entry points:
 - `encode::publish_capture(...)` captures a webcam, encodes it, and publishes on
   demand: the track and catalog are advertised up front, but the camera opens
   only while a subscriber is watching and is released when the last one leaves.
-- `encode::Producer` publishes `encode::Packet`s you encoded yourself, handling
-  the catalog and framing. Each packet carries its own presentation timestamp,
+- `encode::Producer` publishes `encode::Frame`s you encoded yourself, handling
+  the catalog and framing. Each frame carries its own presentation timestamp,
   so delayed encoder output is published at the input frame's time.
 
 The NVENC and VAAPI backends are Linux-only and gated behind their respective

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -45,8 +45,9 @@ Two public entry points:
 - `encode::publish_capture(...)` captures a webcam, encodes it, and publishes on
   demand: the track and catalog are advertised up front, but the camera opens
   only while a subscriber is watching and is released when the last one leaves.
-- `encode::Producer` publishes packets you encoded yourself, handling the catalog
-  and framing.
+- `encode::Producer` publishes `encode::Packet`s you encoded yourself, handling
+  the catalog and framing. Each packet carries its own presentation timestamp,
+  so delayed encoder output is published at the input frame's time.
 
 The NVENC and VAAPI backends are Linux-only and gated behind their respective
 features. Both `dlopen` the vendor driver at runtime (and fall back to software

--- a/rs/moq-video/src/decode/backend/nvdec.rs
+++ b/rs/moq-video/src/decode/backend/nvdec.rs
@@ -515,8 +515,11 @@ mod tests {
 		let mut out = Vec::new();
 		for i in 0..10u64 {
 			let timestamp = Timestamp::from_micros(i * 33_333).unwrap();
-			for packet in encoder.encode_rgba(&rgba, crate::Size::new(w, h), i == 0).unwrap() {
-				for decoded in decoder.decode(packet, timestamp, i == 0).unwrap() {
+			for packet in encoder
+				.encode_rgba(&rgba, crate::Size::new(w, h), timestamp, i == 0)
+				.unwrap()
+			{
+				for decoded in decoder.decode(packet.payload, packet.timestamp, i == 0).unwrap() {
 					let i420 = decoded.frame.to_i420().unwrap().into_owned();
 					out.push((decoded.timestamp.as_micros() as u64, i420));
 				}
@@ -652,8 +655,11 @@ mod tests {
 			let mut frames = Vec::new();
 			for i in 0..10u64 {
 				let timestamp = Timestamp::from_micros(i * 33_333).unwrap();
-				for packet in source.encode_rgba(&rgba, crate::Size::new(w, h), i == 0).unwrap() {
-					frames.extend(decoder.decode(packet, timestamp, i == 0).unwrap());
+				for packet in source
+					.encode_rgba(&rgba, crate::Size::new(w, h), timestamp, i == 0)
+					.unwrap()
+				{
+					frames.extend(decoder.decode(packet.payload, packet.timestamp, i == 0).unwrap());
 				}
 			}
 			frames
@@ -666,7 +672,7 @@ mod tests {
 				matches!(out.frame, Frame::Cuda(_)),
 				"NVDEC produced a non-CUDA frame; the zero-copy path is not exercised"
 			);
-			packets.extend(nvenc.encode_raw(&out.frame, i == 0).unwrap());
+			packets.extend(nvenc.encode_raw(&out.frame, out.timestamp, i == 0).unwrap());
 		}
 		packets.extend(nvenc.finish().unwrap());
 		assert!(!packets.is_empty(), "NVENC produced no packets from CUDA frames");
@@ -692,10 +698,7 @@ mod tests {
 		.unwrap();
 		let mut last = None;
 		for (i, packet) in packets.into_iter().enumerate() {
-			for out in check
-				.decode(packet, Timestamp::from_micros(i as u64).unwrap(), i == 0)
-				.unwrap()
-			{
+			for out in check.decode(packet.payload, packet.timestamp, i == 0).unwrap() {
 				last = Some(out.frame.to_i420().unwrap().into_owned());
 			}
 		}

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -234,10 +234,10 @@ mod tests {
 			// Distinct, spread-apart timestamps so a round-tripped value is unambiguous.
 			let timestamp = Timestamp::from_micros(i * 33_333).unwrap();
 			for packet in encoder
-				.encode_rgba(&frame, crate::Size::new(320, 240), keyframe)
+				.encode_rgba(&frame, crate::Size::new(320, 240), timestamp, keyframe)
 				.unwrap()
 			{
-				decoded.extend(decoder.decode(packet, timestamp, keyframe).unwrap());
+				decoded.extend(decoder.decode(packet.payload, packet.timestamp, keyframe).unwrap());
 			}
 		}
 

--- a/rs/moq-video/src/encode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/encode/backend/mediafoundation.rs
@@ -13,10 +13,12 @@
 //! thread (see `encode::sink`), so its COM apartment stays balanced and its
 //! blocking waits never park a tokio worker.
 
+use std::collections::HashMap;
 use std::mem::ManuallyDrop;
 use std::ptr;
 
 use bytes::Bytes;
+use moq_net::Timestamp;
 use windows::Win32::Foundation::{VARIANT_BOOL, VARIANT_TRUE};
 use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11Texture2D};
 use windows::Win32::Media::MediaFoundation::{
@@ -36,7 +38,7 @@ use windows::Win32::Media::MediaFoundation::{
 use windows::Win32::System::Variant::{VARIANT, VT_BOOL, VT_UI4};
 use windows::core::{GUID, Interface};
 
-use super::super::encoder::{Codec, Config};
+use super::super::encoder::{Codec, Config, Packet};
 use super::Backend;
 use crate::Error;
 use crate::frame::{Frame, interleave_uv};
@@ -45,8 +47,7 @@ use crate::mf::{ComGuard, mf_err, pack_2x32};
 pub(crate) const NAME: &str = "mediafoundation";
 
 /// Stream tick for sample timestamps, in 100ns units (the Media Foundation time
-/// base). Timestamps only need to increase; the moq timestamp is applied
-/// downstream, so a monotonic index over the framerate is enough.
+/// base).
 const HNS_PER_SEC: i64 = 10_000_000;
 
 pub(crate) struct MediaFoundation {
@@ -70,6 +71,8 @@ pub(crate) struct MediaFoundation {
 	/// True once the MFT has asked for input and we haven't fed it since.
 	needs_input: bool,
 	sample_index: i64,
+	/// Original timestamps keyed by the sample time that rides through the MFT.
+	timestamps: HashMap<i64, Timestamp>,
 	/// Kept alive for the MFT's lifetime once a texture frame binds a device.
 	_manager: Option<IMFDXGIDeviceManager>,
 	_com: ComGuard,
@@ -124,6 +127,7 @@ impl MediaFoundation {
 			output_size: 0,
 			needs_input: false,
 			sample_index: 0,
+			timestamps: HashMap::new(),
 			_manager: None,
 			_com: com,
 		}))
@@ -255,7 +259,7 @@ impl MediaFoundation {
 
 	/// Wrap a captured frame as an input [`IMFSample`]: a zero-copy DXGI surface
 	/// buffer for a texture, or a freshly uploaded NV12 memory buffer for I420.
-	fn build_sample(&self, frame: &Frame) -> Result<IMFSample, Error> {
+	fn build_sample(&self, frame: &Frame) -> Result<(IMFSample, i64), Error> {
 		let buffer = match frame {
 			Frame::Texture(texture) => unsafe {
 				let buffer =
@@ -281,17 +285,18 @@ impl MediaFoundation {
 		};
 
 		let sample = unsafe { MFCreateSample().map_err(|e| mf_err("MFCreateSample", e))? };
+		let tick = (HNS_PER_SEC / self.framerate.max(1) as i64).max(1);
+		let sample_time = self.sample_index * tick;
 		unsafe {
 			sample.AddBuffer(&buffer).map_err(|e| mf_err("AddBuffer", e))?;
-			let tick = HNS_PER_SEC / self.framerate.max(1) as i64;
 			sample
-				.SetSampleTime(self.sample_index * tick)
+				.SetSampleTime(sample_time)
 				.map_err(|e| mf_err("SetSampleTime", e))?;
 			sample
 				.SetSampleDuration(tick)
 				.map_err(|e| mf_err("SetSampleDuration", e))?;
 		}
-		Ok(sample)
+		Ok((sample, sample_time))
 	}
 
 	/// Copy a CPU I420 frame into a system-memory NV12 buffer (the fallback when
@@ -328,7 +333,7 @@ impl MediaFoundation {
 	/// Block on events until the MFT is ready for input, collecting any output
 	/// that arrives meanwhile. Runs on the dedicated encode thread (see
 	/// `encode::sink`), so this blocking wait never parks a tokio worker.
-	fn wait_for_input(&mut self, out: &mut Vec<Bytes>) -> Result<(), Error> {
+	fn wait_for_input(&mut self, out: &mut Vec<Packet>) -> Result<(), Error> {
 		while !self.needs_input {
 			let event = unsafe {
 				self.events
@@ -341,7 +346,7 @@ impl MediaFoundation {
 	}
 
 	/// Drain events already queued without blocking (called after feeding input).
-	fn drain_ready(&mut self, out: &mut Vec<Bytes>) -> Result<(), Error> {
+	fn drain_ready(&mut self, out: &mut Vec<Packet>) -> Result<(), Error> {
 		loop {
 			match unsafe { self.events.GetEvent(MF_EVENT_FLAG_NO_WAIT) } {
 				Ok(event) => self.handle_event(&event, out)?,
@@ -351,7 +356,7 @@ impl MediaFoundation {
 		}
 	}
 
-	fn handle_event(&mut self, event: &IMFMediaEvent, out: &mut Vec<Bytes>) -> Result<(), Error> {
+	fn handle_event(&mut self, event: &IMFMediaEvent, out: &mut Vec<Packet>) -> Result<(), Error> {
 		// Surface an async failure (e.g. an MEError event) instead of looping in
 		// `wait_for_input` forever for an input request that will never come.
 		unsafe { event.GetStatus() }
@@ -376,7 +381,7 @@ impl MediaFoundation {
 
 	/// Pull one encoded access unit. Returns `None` if the MFT had nothing ready
 	/// or asked us to renegotiate the output type.
-	fn process_output(&mut self) -> Result<Option<Bytes>, Error> {
+	fn process_output(&mut self) -> Result<Option<Packet>, Error> {
 		let provided = if self.provides_samples {
 			None
 		} else {
@@ -414,12 +419,18 @@ impl MediaFoundation {
 		}
 
 		let Some(sample) = sample else { return Ok(None) };
-		Ok(Some(sample_to_bytes(&sample)?))
+		let sample_time = unsafe { sample.GetSampleTime().map_err(|e| mf_err("GetSampleTime", e))? };
+		let timestamp = self.timestamps.remove(&sample_time).ok_or_else(|| {
+			Error::Codec(anyhow::anyhow!(
+				"Media Foundation returned unknown sample time {sample_time}"
+			))
+		})?;
+		Ok(Some(Packet::new(sample_to_bytes(&sample)?, timestamp)))
 	}
 }
 
 impl Backend for MediaFoundation {
-	fn encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<Packet>, Error> {
 		if !self.started {
 			self.start(frame)?;
 		}
@@ -431,12 +442,13 @@ impl Backend for MediaFoundation {
 			self.set_codec(&CODECAPI_AVEncVideoForceKeyFrame, variant_u32(1))?;
 		}
 
-		let sample = self.build_sample(frame)?;
+		let (sample, sample_time) = self.build_sample(frame)?;
 		unsafe {
 			self.transform
 				.ProcessInput(0, &sample, 0)
 				.map_err(|e| mf_err("ProcessInput", e))?;
 		}
+		self.timestamps.insert(sample_time, timestamp);
 		self.needs_input = false;
 		self.sample_index += 1;
 
@@ -444,7 +456,7 @@ impl Backend for MediaFoundation {
 		Ok(out)
 	}
 
-	fn finish(&mut self) -> Result<Vec<Bytes>, Error> {
+	fn finish(&mut self) -> Result<Vec<Packet>, Error> {
 		if !self.started {
 			return Ok(Vec::new());
 		}

--- a/rs/moq-video/src/encode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/encode/backend/mediafoundation.rs
@@ -38,7 +38,7 @@ use windows::Win32::Media::MediaFoundation::{
 use windows::Win32::System::Variant::{VARIANT, VT_BOOL, VT_UI4};
 use windows::core::{GUID, Interface};
 
-use super::super::encoder::{Codec, Config, Packet};
+use super::super::encoder::{Codec, Config, Frame as EncodedFrame};
 use super::Backend;
 use crate::Error;
 use crate::frame::{Frame, interleave_uv};
@@ -333,7 +333,7 @@ impl MediaFoundation {
 	/// Block on events until the MFT is ready for input, collecting any output
 	/// that arrives meanwhile. Runs on the dedicated encode thread (see
 	/// `encode::sink`), so this blocking wait never parks a tokio worker.
-	fn wait_for_input(&mut self, out: &mut Vec<Packet>) -> Result<(), Error> {
+	fn wait_for_input(&mut self, out: &mut Vec<EncodedFrame>) -> Result<(), Error> {
 		while !self.needs_input {
 			let event = unsafe {
 				self.events
@@ -346,7 +346,7 @@ impl MediaFoundation {
 	}
 
 	/// Drain events already queued without blocking (called after feeding input).
-	fn drain_ready(&mut self, out: &mut Vec<Packet>) -> Result<(), Error> {
+	fn drain_ready(&mut self, out: &mut Vec<EncodedFrame>) -> Result<(), Error> {
 		loop {
 			match unsafe { self.events.GetEvent(MF_EVENT_FLAG_NO_WAIT) } {
 				Ok(event) => self.handle_event(&event, out)?,
@@ -356,7 +356,7 @@ impl MediaFoundation {
 		}
 	}
 
-	fn handle_event(&mut self, event: &IMFMediaEvent, out: &mut Vec<Packet>) -> Result<(), Error> {
+	fn handle_event(&mut self, event: &IMFMediaEvent, out: &mut Vec<EncodedFrame>) -> Result<(), Error> {
 		// Surface an async failure (e.g. an MEError event) instead of looping in
 		// `wait_for_input` forever for an input request that will never come.
 		unsafe { event.GetStatus() }
@@ -381,7 +381,7 @@ impl MediaFoundation {
 
 	/// Pull one encoded access unit. Returns `None` if the MFT had nothing ready
 	/// or asked us to renegotiate the output type.
-	fn process_output(&mut self) -> Result<Option<Packet>, Error> {
+	fn process_output(&mut self) -> Result<Option<EncodedFrame>, Error> {
 		let provided = if self.provides_samples {
 			None
 		} else {
@@ -425,12 +425,12 @@ impl MediaFoundation {
 				"Media Foundation returned unknown sample time {sample_time}"
 			))
 		})?;
-		Ok(Some(Packet::new(sample_to_bytes(&sample)?, timestamp)))
+		Ok(Some(EncodedFrame::new(sample_to_bytes(&sample)?, timestamp)))
 	}
 }
 
 impl Backend for MediaFoundation {
-	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<Packet>, Error> {
+	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<EncodedFrame>, Error> {
 		if !self.started {
 			self.start(frame)?;
 		}
@@ -456,7 +456,7 @@ impl Backend for MediaFoundation {
 		Ok(out)
 	}
 
-	fn finish(&mut self) -> Result<Vec<Packet>, Error> {
+	fn finish(&mut self) -> Result<Vec<EncodedFrame>, Error> {
 		if !self.started {
 			return Ok(Vec::new());
 		}

--- a/rs/moq-video/src/encode/backend/mod.rs
+++ b/rs/moq-video/src/encode/backend/mod.rs
@@ -12,9 +12,9 @@
 //! considered, hardware (platform-gated) before the always-available openh264
 //! software fallback.
 
-use bytes::Bytes;
+use moq_net::Timestamp;
 
-use super::encoder::{Codec, Config, Kind};
+use super::encoder::{Codec, Config, Kind, Packet};
 use crate::Error;
 use crate::frame::Frame;
 
@@ -35,12 +35,12 @@ mod vaapi;
 /// An opened video encoder. Feed it frames at the configured resolution; get
 /// back zero or more packets in the codec's wire framing.
 pub(crate) trait Backend: Send {
-	/// Encode one frame. Set `keyframe` to force an IDR (e.g. on resume so a
-	/// re-subscribing viewer can start decoding at once).
-	fn encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Bytes>, Error>;
+	/// Encode one frame. Every emitted packet keeps `timestamp`, including when
+	/// output was queued by an earlier call. Set `keyframe` to force an IDR.
+	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<Packet>, Error>;
 
 	/// Flush the encoder, returning any buffered packets.
-	fn finish(&mut self) -> Result<Vec<Bytes>, Error>;
+	fn finish(&mut self) -> Result<Vec<Packet>, Error>;
 
 	/// Retune the live encoder to `bitrate` bits per second, taking effect from
 	/// roughly the next frame. Called as the congestion controller's estimate

--- a/rs/moq-video/src/encode/backend/mod.rs
+++ b/rs/moq-video/src/encode/backend/mod.rs
@@ -5,7 +5,7 @@
 //! takes a planar I420 [`Frame`] and emits Annex-B with in-band parameter sets
 //! (SPS/PPS, plus VPS for H.265), the framing the matching catalog importer
 //! expects. Each backend produces exactly one codec, so the producer can route
-//! its packets to the right importer.
+//! its encoded frames to the right importer.
 //!
 //! [`open`] picks the best backend for a [`Codec`](super::Codec) +
 //! [`Kind`](super::Kind): only candidates that support the requested codec are
@@ -14,7 +14,7 @@
 
 use moq_net::Timestamp;
 
-use super::encoder::{Codec, Config, Kind, Packet};
+use super::encoder::{Codec, Config, Frame as EncodedFrame, Kind};
 use crate::Error;
 use crate::frame::Frame;
 
@@ -33,14 +33,14 @@ mod nvenc;
 mod vaapi;
 
 /// An opened video encoder. Feed it frames at the configured resolution; get
-/// back zero or more packets in the codec's wire framing.
+/// back zero or more encoded frames in the codec's wire framing.
 pub(crate) trait Backend: Send {
-	/// Encode one frame. Every emitted packet keeps `timestamp`, including when
+	/// Encode one frame. Every emitted frame keeps `timestamp`, including when
 	/// output was queued by an earlier call. Set `keyframe` to force an IDR.
-	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<Packet>, Error>;
+	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<EncodedFrame>, Error>;
 
-	/// Flush the encoder, returning any buffered packets.
-	fn finish(&mut self) -> Result<Vec<Packet>, Error>;
+	/// Flush the encoder, returning any buffered frames.
+	fn finish(&mut self) -> Result<Vec<EncodedFrame>, Error>;
 
 	/// Retune the live encoder to `bitrate` bits per second, taking effect from
 	/// roughly the next frame. Called as the congestion controller's estimate

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -40,7 +40,7 @@ use moq_nvenc::sys::nvEncodeAPI::{
 };
 use moq_nvenc::{Encoder, EncoderInitParams, Session};
 
-use super::super::encoder::{Codec, Config, Packet};
+use super::super::encoder::{Codec, Config, Frame as EncodedFrame};
 use super::Backend;
 use crate::Error;
 use crate::frame::{Frame, interleave_uv};
@@ -158,7 +158,7 @@ impl Nvenc {
 }
 
 impl Backend for Nvenc {
-	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<Packet>, Error> {
+	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<EncodedFrame>, Error> {
 		let mut output = self
 			.session
 			.create_output_bitstream()
@@ -240,11 +240,11 @@ impl Backend for Nvenc {
 		Ok(if data.is_empty() {
 			Vec::new()
 		} else {
-			vec![Packet::new(Bytes::from(data), timestamp)]
+			vec![EncodedFrame::new(Bytes::from(data), timestamp)]
 		})
 	}
 
-	fn finish(&mut self) -> Result<Vec<Packet>, Error> {
+	fn finish(&mut self) -> Result<Vec<EncodedFrame>, Error> {
 		// Each encode locks its own output synchronously, so nothing is buffered.
 		Ok(Vec::new())
 	}

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -30,6 +30,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use cudarc::driver::CudaContext;
+use moq_net::Timestamp;
 // The CUDA zero-copy input path only exists when NVDEC (its producer) is on.
 #[cfg(feature = "nvdec")]
 use moq_nvenc::sys::nvEncodeAPI::NV_ENC_INPUT_RESOURCE_TYPE;
@@ -39,7 +40,7 @@ use moq_nvenc::sys::nvEncodeAPI::{
 };
 use moq_nvenc::{Encoder, EncoderInitParams, Session};
 
-use super::super::encoder::{Codec, Config};
+use super::super::encoder::{Codec, Config, Packet};
 use super::Backend;
 use crate::Error;
 use crate::frame::{Frame, interleave_uv};
@@ -157,7 +158,7 @@ impl Nvenc {
 }
 
 impl Backend for Nvenc {
-	fn encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<Packet>, Error> {
 		let mut output = self
 			.session
 			.create_output_bitstream()
@@ -239,11 +240,11 @@ impl Backend for Nvenc {
 		Ok(if data.is_empty() {
 			Vec::new()
 		} else {
-			vec![Bytes::from(data)]
+			vec![Packet::new(Bytes::from(data), timestamp)]
 		})
 	}
 
-	fn finish(&mut self) -> Result<Vec<Bytes>, Error> {
+	fn finish(&mut self) -> Result<Vec<Packet>, Error> {
 		// Each encode locks its own output synchronously, so nothing is buffered.
 		Ok(Vec::new())
 	}
@@ -374,9 +375,13 @@ mod tests {
 		for i in 0..10u32 {
 			let keyframe = i == 0 || i == 5;
 			let packets = encoder
-				.encode_rgba(&frame, crate::Size::new(320, 240), keyframe)
+				.encode_rgba(&frame, crate::Size::new(320, 240), Timestamp::ZERO, keyframe)
 				.unwrap();
-			let joined: Vec<u8> = packets.iter().flatten().copied().collect();
+			let joined: Vec<u8> = packets
+				.iter()
+				.flat_map(|packet| packet.payload.iter())
+				.copied()
+				.collect();
 			if i == 0 {
 				first = joined;
 			} else if i == 5 {
@@ -421,9 +426,13 @@ mod tests {
 		for i in 0..10u32 {
 			let keyframe = i == 0 || i == 5;
 			let packets = encoder
-				.encode_rgba(&frame, crate::Size::new(320, 240), keyframe)
+				.encode_rgba(&frame, crate::Size::new(320, 240), Timestamp::ZERO, keyframe)
 				.unwrap();
-			let joined: Vec<u8> = packets.iter().flatten().copied().collect();
+			let joined: Vec<u8> = packets
+				.iter()
+				.flat_map(|packet| packet.payload.iter())
+				.copied()
+				.collect();
 			if i == 0 {
 				first = joined;
 			} else if i == 5 {
@@ -466,8 +475,14 @@ mod tests {
 		// Never force a keyframe (only frame 0 would be); the backend must insert
 		// IDRs at frames 3 and 6 on its own.
 		for i in 0..7u32 {
-			let packets = encoder.encode_rgba(&frame, crate::Size::new(320, 240), false).unwrap();
-			let joined: Vec<u8> = packets.iter().flatten().copied().collect();
+			let packets = encoder
+				.encode_rgba(&frame, crate::Size::new(320, 240), Timestamp::ZERO, false)
+				.unwrap();
+			let joined: Vec<u8> = packets
+				.iter()
+				.flat_map(|packet| packet.payload.iter())
+				.copied()
+				.collect();
 			let types = h264_nal_types(&joined);
 			if types.contains(&5) {
 				assert!(types.contains(&7), "periodic IDR at frame {i} missing SPS: {types:?}");
@@ -529,8 +544,11 @@ mod tests {
 		let mut decoded = None;
 		for i in 0..10u64 {
 			let timestamp = moq_net::Timestamp::from_micros(i * 33_333).unwrap();
-			for packet in encoder.encode_rgba(&rgba, crate::Size::new(w, h), i == 0).unwrap() {
-				for out in decoder.decode(packet, timestamp, i == 0).unwrap() {
+			for packet in encoder
+				.encode_rgba(&rgba, crate::Size::new(w, h), timestamp, i == 0)
+				.unwrap()
+			{
+				for out in decoder.decode(packet.payload, packet.timestamp, i == 0).unwrap() {
 					decoded = Some(out.frame.to_i420().unwrap().into_owned());
 				}
 			}

--- a/rs/moq-video/src/encode/backend/openh264.rs
+++ b/rs/moq-video/src/encode/backend/openh264.rs
@@ -4,12 +4,13 @@
 //! in-band SPS/PPS, ready for `moq_mux::codec::h264::Import` in avc3 mode.
 
 use bytes::Bytes;
+use moq_net::Timestamp;
 use openh264::OpenH264API;
 use openh264::encoder::{BitRate, Encoder, EncoderConfig, FrameRate, IntraFramePeriod, RateControlMode, UsageType};
 use openh264::formats::YUVSlices;
 use openh264_sys2::{ENCODER_OPTION_BITRATE, SBitrateInfo, SPATIAL_LAYER_ALL};
 
-use super::super::encoder::Config;
+use super::super::encoder::{Config, Packet};
 use super::Backend;
 use crate::Error;
 use crate::frame::Frame;
@@ -97,7 +98,7 @@ impl Openh264 {
 }
 
 impl Backend for Openh264 {
-	fn encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<Packet>, Error> {
 		// A rate deferred from before the encoder existed lands here, ahead of the
 		// frame rather than after it, so a rejected rate can't cost us a frame's
 		// packets on the way out.
@@ -131,11 +132,11 @@ impl Backend for Openh264 {
 		Ok(if bytes.is_empty() {
 			Vec::new()
 		} else {
-			vec![Bytes::from(bytes)]
+			vec![Packet::new(Bytes::from(bytes), timestamp)]
 		})
 	}
 
-	fn finish(&mut self) -> Result<Vec<Bytes>, Error> {
+	fn finish(&mut self) -> Result<Vec<Packet>, Error> {
 		// Low-delay: nothing is buffered, so there's nothing to flush.
 		Ok(Vec::new())
 	}
@@ -184,7 +185,7 @@ mod tests {
 	#[test]
 	fn set_bitrate_reaches_the_encoder() {
 		let mut enc = Openh264::new(&config()).unwrap();
-		enc.encode(&gray(), true).unwrap();
+		enc.encode(&gray(), Timestamp::ZERO, true).unwrap();
 
 		let lower = config().resolved_bitrate() / 2;
 		enc.set_bitrate(lower).unwrap();
@@ -198,7 +199,7 @@ mod tests {
 	#[test]
 	fn set_bitrate_above_the_opening_rate_is_rejected() {
 		let mut enc = Openh264::new(&config()).unwrap();
-		enc.encode(&gray(), true).unwrap();
+		enc.encode(&gray(), Timestamp::ZERO, true).unwrap();
 
 		let higher = config().resolved_bitrate() * 4;
 		assert!(enc.set_bitrate(higher).is_err());
@@ -210,7 +211,7 @@ mod tests {
 	#[test]
 	fn set_bitrate_at_the_opening_rate_is_accepted() {
 		let mut enc = Openh264::new(&config()).unwrap();
-		enc.encode(&gray(), true).unwrap();
+		enc.encode(&gray(), Timestamp::ZERO, true).unwrap();
 		let opened = config().resolved_bitrate();
 
 		enc.set_bitrate(opened / 2).unwrap();
@@ -230,11 +231,11 @@ mod tests {
 
 		// Deferred: the encoder doesn't exist yet.
 		enc.set_bitrate(opened / 2).unwrap();
-		enc.encode(&gray(), true).unwrap();
+		enc.encode(&gray(), Timestamp::ZERO, true).unwrap();
 
 		// Live: this is the rate the caller last asked for.
 		enc.set_bitrate(opened / 4).unwrap();
-		enc.encode(&gray(), false).unwrap();
+		enc.encode(&gray(), Timestamp::ZERO, false).unwrap();
 
 		assert_eq!(enc.read_bitrate(), (opened / 4) as i64, "the deferred rate resurrected");
 	}

--- a/rs/moq-video/src/encode/backend/openh264.rs
+++ b/rs/moq-video/src/encode/backend/openh264.rs
@@ -10,7 +10,7 @@ use openh264::encoder::{BitRate, Encoder, EncoderConfig, FrameRate, IntraFramePe
 use openh264::formats::YUVSlices;
 use openh264_sys2::{ENCODER_OPTION_BITRATE, SBitrateInfo, SPATIAL_LAYER_ALL};
 
-use super::super::encoder::{Config, Packet};
+use super::super::encoder::{Config, Frame as EncodedFrame};
 use super::Backend;
 use crate::Error;
 use crate::frame::Frame;
@@ -98,7 +98,7 @@ impl Openh264 {
 }
 
 impl Backend for Openh264 {
-	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<Packet>, Error> {
+	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<EncodedFrame>, Error> {
 		// A rate deferred from before the encoder existed lands here, ahead of the
 		// frame rather than after it, so a rejected rate can't cost us a frame's
 		// packets on the way out.
@@ -132,11 +132,11 @@ impl Backend for Openh264 {
 		Ok(if bytes.is_empty() {
 			Vec::new()
 		} else {
-			vec![Packet::new(Bytes::from(bytes), timestamp)]
+			vec![EncodedFrame::new(Bytes::from(bytes), timestamp)]
 		})
 	}
 
-	fn finish(&mut self) -> Result<Vec<Packet>, Error> {
+	fn finish(&mut self) -> Result<Vec<EncodedFrame>, Error> {
 		// Low-delay: nothing is buffered, so there's nothing to flush.
 		Ok(Vec::new())
 	}

--- a/rs/moq-video/src/encode/backend/vaapi.rs
+++ b/rs/moq-video/src/encode/backend/vaapi.rs
@@ -24,7 +24,7 @@ use bytes::Bytes;
 use moq_net::Timestamp;
 use moq_vaapi::encode::{Config as VaapiConfig, Encoder};
 
-use super::super::encoder::{Config, Packet};
+use super::super::encoder::{Config, Frame as EncodedFrame};
 use super::Backend;
 use crate::Error;
 use crate::frame::{Frame, I420};
@@ -57,7 +57,7 @@ impl Vaapi {
 }
 
 impl Backend for Vaapi {
-	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<Packet>, Error> {
+	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<EncodedFrame>, Error> {
 		let i420 = frame.to_i420()?;
 		let nv12 = i420_to_nv12(&i420);
 		let annexb = self
@@ -68,11 +68,11 @@ impl Backend for Vaapi {
 		Ok(if annexb.is_empty() {
 			Vec::new()
 		} else {
-			vec![Packet::new(Bytes::from(annexb), timestamp)]
+			vec![EncodedFrame::new(Bytes::from(annexb), timestamp)]
 		})
 	}
 
-	fn finish(&mut self) -> Result<Vec<Packet>, Error> {
+	fn finish(&mut self) -> Result<Vec<EncodedFrame>, Error> {
 		// The encoder submits and reads back synchronously per frame, so nothing
 		// is buffered at shutdown.
 		Ok(Vec::new())

--- a/rs/moq-video/src/encode/backend/vaapi.rs
+++ b/rs/moq-video/src/encode/backend/vaapi.rs
@@ -21,9 +21,10 @@
 //! playback.
 
 use bytes::Bytes;
+use moq_net::Timestamp;
 use moq_vaapi::encode::{Config as VaapiConfig, Encoder};
 
-use super::super::encoder::Config;
+use super::super::encoder::{Config, Packet};
 use super::Backend;
 use crate::Error;
 use crate::frame::{Frame, I420};
@@ -56,7 +57,7 @@ impl Vaapi {
 }
 
 impl Backend for Vaapi {
-	fn encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<Packet>, Error> {
 		let i420 = frame.to_i420()?;
 		let nv12 = i420_to_nv12(&i420);
 		let annexb = self
@@ -67,11 +68,11 @@ impl Backend for Vaapi {
 		Ok(if annexb.is_empty() {
 			Vec::new()
 		} else {
-			vec![Bytes::from(annexb)]
+			vec![Packet::new(Bytes::from(annexb), timestamp)]
 		})
 	}
 
-	fn finish(&mut self) -> Result<Vec<Bytes>, Error> {
+	fn finish(&mut self) -> Result<Vec<Packet>, Error> {
 		// The encoder submits and reads back synchronously per frame, so nothing
 		// is buffered at shutdown.
 		Ok(Vec::new())

--- a/rs/moq-video/src/encode/backend/videotoolbox.rs
+++ b/rs/moq-video/src/encode/backend/videotoolbox.rs
@@ -18,6 +18,7 @@ use std::ptr::{self, NonNull};
 use std::slice;
 
 use bytes::{BufMut, Bytes, BytesMut};
+use moq_net::Timestamp;
 use objc2_core_foundation::{
 	CFDictionary, CFNumber, CFNumberType, CFRetained, CFString, CFType, kCFBooleanFalse, kCFBooleanTrue,
 };
@@ -38,7 +39,7 @@ use objc2_video_toolbox::{
 	kVTProfileLevel_HEVC_Main_AutoLevel,
 };
 
-use super::super::encoder::{Codec, Config};
+use super::super::encoder::{Codec, Config, Packet};
 use super::Backend;
 use crate::Error;
 use crate::frame::{Frame, I420};
@@ -155,7 +156,7 @@ impl VideoToolbox {
 }
 
 impl Backend for VideoToolbox {
-	fn encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<Packet>, Error> {
 		self.sink.packets.clear();
 		self.sink.error = None;
 
@@ -203,10 +204,13 @@ impl Backend for VideoToolbox {
 				"VideoToolbox encode callback failed: {status}"
 			)));
 		}
-		Ok(std::mem::take(&mut self.sink.packets))
+		Ok(std::mem::take(&mut self.sink.packets)
+			.into_iter()
+			.map(|payload| Packet::new(payload, timestamp))
+			.collect())
 	}
 
-	fn finish(&mut self) -> Result<Vec<Bytes>, Error> {
+	fn finish(&mut self) -> Result<Vec<Packet>, Error> {
 		// complete_frames runs per-encode, so nothing is buffered at shutdown.
 		Ok(Vec::new())
 	}

--- a/rs/moq-video/src/encode/backend/videotoolbox.rs
+++ b/rs/moq-video/src/encode/backend/videotoolbox.rs
@@ -39,7 +39,7 @@ use objc2_video_toolbox::{
 	kVTProfileLevel_HEVC_Main_AutoLevel,
 };
 
-use super::super::encoder::{Codec, Config, Packet};
+use super::super::encoder::{Codec, Config, Frame as EncodedFrame};
 use super::Backend;
 use crate::Error;
 use crate::frame::{Frame, I420};
@@ -156,7 +156,7 @@ impl VideoToolbox {
 }
 
 impl Backend for VideoToolbox {
-	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<Packet>, Error> {
+	fn encode(&mut self, frame: &Frame, timestamp: Timestamp, keyframe: bool) -> Result<Vec<EncodedFrame>, Error> {
 		self.sink.packets.clear();
 		self.sink.error = None;
 
@@ -206,11 +206,11 @@ impl Backend for VideoToolbox {
 		}
 		Ok(std::mem::take(&mut self.sink.packets)
 			.into_iter()
-			.map(|payload| Packet::new(payload, timestamp))
+			.map(|payload| EncodedFrame::new(payload, timestamp))
 			.collect())
 	}
 
-	fn finish(&mut self) -> Result<Vec<Packet>, Error> {
+	fn finish(&mut self) -> Result<Vec<EncodedFrame>, Error> {
 		// complete_frames runs per-encode, so nothing is buffered at shutdown.
 		Ok(Vec::new())
 	}

--- a/rs/moq-video/src/encode/encoder.rs
+++ b/rs/moq-video/src/encode/encoder.rs
@@ -1,7 +1,7 @@
 //! Video encoder front end.
 //!
 //! Accepts raw RGBA frames, converts them to I420, and delegates the actual
-//! encode to a [`Backend`](super::backend::Backend). The resulting packets are
+//! encode to a [`Backend`](super::backend::Backend). The resulting frames are
 //! Annex-B in the framing the catalog importer for [`Config::codec`] expects:
 //! H.264 (`moq_mux::codec::h264`) or H.265 (`moq_mux::codec::h265`).
 
@@ -9,22 +9,21 @@ use bytes::Bytes;
 use moq_net::Timestamp;
 
 use super::backend::{self, Backend};
-use crate::frame::{Frame, I420};
+use crate::frame::{Frame as RawFrame, I420};
 use crate::{Error, Size};
 
 /// One encoded video access unit and the presentation timestamp of its input frame.
 ///
-/// Construct packets for [`Producer`](super::Producer) with [`Packet::new`].
+/// Construct encoded frames for [`Producer`](super::Producer) with [`Frame::new`].
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct Packet {
+pub struct Frame {
 	/// The encoded access unit in the codec's framing.
 	pub payload: Bytes,
 	/// The presentation timestamp carried by the frame that produced this access unit.
 	pub timestamp: Timestamp,
 }
 
-impl Packet {
+impl Frame {
 	/// Pair an encoded access unit with its presentation timestamp.
 	pub fn new(payload: Bytes, timestamp: Timestamp) -> Self {
 		Self { payload, timestamp }
@@ -121,7 +120,7 @@ impl Config {
 }
 
 /// Video encoder. Build one with [`Encoder::new`], feed it raw RGBA frames via
-/// [`encode_rgba`](Self::encode_rgba), and publish the resulting packets through
+/// [`encode_rgba`](Self::encode_rgba), and publish the resulting frames through
 /// a [`Producer`](super::Producer) built for the same [`Codec`].
 pub struct Encoder {
 	backend: Box<dyn Backend>,
@@ -195,13 +194,13 @@ impl Encoder {
 	}
 
 	/// The codec this encoder emits. A [`Producer`](super::Producer) must be
-	/// built for the same codec to publish its packets.
+	/// built for the same codec to publish its frames.
 	pub fn codec(&self) -> Codec {
 		self.codec
 	}
 
 	/// Encode one tightly-packed RGBA frame of `size`, returning zero or more
-	/// encoded packets in the codec's framing. Every packet carries `timestamp`,
+	/// encoded frames in the codec's framing. Every frame carries `timestamp`,
 	/// even when a backend emits it from a later encode or [`finish`](Self::finish).
 	/// Set `keyframe` to force an IDR (e.g. on resume so a re-subscribing viewer
 	/// can start decoding at once).
@@ -214,19 +213,19 @@ impl Encoder {
 		size: Size,
 		timestamp: Timestamp,
 		keyframe: bool,
-	) -> Result<Vec<Packet>, Error> {
+	) -> Result<Vec<Frame>, Error> {
 		// The encoder resolution is validated even and non-zero in `new`, so a
 		// frame matching it is even too and the conversion below can't fail on odd
 		// dimensions.
 		self.check_frame(size, rgba.len(), size.pixels() as usize * 4, "RGBA")?;
 
-		let frame = Frame::I420(I420::from_rgba(rgba, size.width * 4, size.width, size.height)?);
+		let frame = RawFrame::I420(I420::from_rgba(rgba, size.width * 4, size.width, size.height)?);
 		self.encode_raw(&frame, timestamp, keyframe)
 	}
 
 	/// Encode one tightly-packed I420 frame of `size` (Y then U then V, no row
-	/// padding, BT.601 limited range), returning zero or more encoded packets in
-	/// the codec's framing. Every packet carries `timestamp`. Set `keyframe` to
+	/// padding, BT.601 limited range), returning zero or more encoded frames in
+	/// the codec's framing. Every frame carries `timestamp`. Set `keyframe` to
 	/// force an IDR.
 	///
 	/// `size` must equal the encoder's [`size`](Self::size), and `i420` must hold
@@ -242,10 +241,10 @@ impl Encoder {
 		size: Size,
 		timestamp: Timestamp,
 		keyframe: bool,
-	) -> Result<Vec<Packet>, Error> {
+	) -> Result<Vec<Frame>, Error> {
 		self.check_frame(size, i420.len(), I420::len(size.width, size.height), "I420")?;
 
-		let frame = Frame::I420(I420 {
+		let frame = RawFrame::I420(I420 {
 			width: size.width,
 			height: size.height,
 			data: i420.to_vec(),
@@ -280,19 +279,19 @@ impl Encoder {
 	/// directly (NVDEC -> NVENC stays on the GPU); everything else falls back to
 	/// a CPU I420 upload. The frame must already be at the encoder's resolution;
 	/// decode with [`decode::Config::resize`](crate::decode::Config) (or scale
-	/// yourself) first. Each output packet preserves [`Frame::timestamp`](crate::decode::Frame::timestamp).
-	pub fn encode(&mut self, frame: &crate::decode::Frame, keyframe: bool) -> Result<Vec<Packet>, Error> {
+	/// yourself) first. Each output frame preserves [`Frame::timestamp`](crate::decode::Frame::timestamp).
+	pub fn encode(&mut self, frame: &crate::decode::Frame, keyframe: bool) -> Result<Vec<Frame>, Error> {
 		self.encode_raw(&frame.inner, frame.timestamp, keyframe)
 	}
 
-	/// Encode a captured [`Frame`] (a GPU surface or CPU I420). The frame must
+	/// Encode a captured frame (a GPU surface or CPU I420). The frame must
 	/// already be at the encoder's resolution.
 	pub(crate) fn encode_raw(
 		&mut self,
-		frame: &Frame,
+		frame: &RawFrame,
 		timestamp: Timestamp,
 		keyframe: bool,
-	) -> Result<Vec<Packet>, Error> {
+	) -> Result<Vec<Frame>, Error> {
 		let size = Size::new(frame.width(), frame.height());
 		if size != self.size {
 			return Err(Error::Codec(anyhow::anyhow!(
@@ -303,11 +302,11 @@ impl Encoder {
 		self.backend.encode(frame, timestamp, keyframe)
 	}
 
-	/// Flush the encoder, returning any buffered packets with their input timestamps.
+	/// Flush the encoder, returning any buffered frames with their input timestamps.
 	///
 	/// Consumes the encoder: nothing can be encoded after a flush, so this is the
 	/// last call rather than one leaving a drained encoder in your hands.
-	pub fn finish(mut self) -> Result<Vec<Packet>, Error> {
+	pub fn finish(mut self) -> Result<Vec<Frame>, Error> {
 		self.backend.finish()
 	}
 }
@@ -328,18 +327,18 @@ mod tests {
 	}
 
 	impl Backend for Delayed {
-		fn encode(&mut self, _frame: &Frame, timestamp: Timestamp, _keyframe: bool) -> Result<Vec<Packet>, Error> {
+		fn encode(&mut self, _frame: &RawFrame, timestamp: Timestamp, _keyframe: bool) -> Result<Vec<Frame>, Error> {
 			let Some(timestamp) = self.pending.replace(timestamp) else {
 				return Ok(Vec::new());
 			};
-			Ok(vec![Packet::new(Bytes::from_static(b"encoded"), timestamp)])
+			Ok(vec![Frame::new(Bytes::from_static(b"encoded"), timestamp)])
 		}
 
-		fn finish(&mut self) -> Result<Vec<Packet>, Error> {
+		fn finish(&mut self) -> Result<Vec<Frame>, Error> {
 			Ok(self
 				.pending
 				.take()
-				.map(|timestamp| vec![Packet::new(Bytes::from_static(b"tail"), timestamp)])
+				.map(|timestamp| vec![Frame::new(Bytes::from_static(b"tail"), timestamp)])
 				.unwrap_or_default())
 		}
 
@@ -654,7 +653,7 @@ mod tests {
 
 		let mut packets = Vec::new();
 		for i in 0..10 {
-			let frame = Frame::Surface(nv12_surface(320, 240));
+			let frame = RawFrame::Surface(nv12_surface(320, 240));
 			packets.extend(encoder.encode_raw(&frame, Timestamp::ZERO, i == 0).unwrap());
 		}
 		packets.extend(encoder.finish().unwrap());
@@ -678,7 +677,7 @@ mod tests {
 		};
 		let mut encoder = Encoder::new(&config).unwrap();
 
-		let frame = Frame::Surface(nv12_surface(320, 240));
+		let frame = RawFrame::Surface(nv12_surface(320, 240));
 		let mut packets = encoder.encode_raw(&frame, Timestamp::ZERO, true).unwrap();
 		packets.extend(encoder.finish().unwrap());
 
@@ -796,7 +795,7 @@ mod tests {
 		let mut textures = 0;
 		for i in 0..30 {
 			let frame = camera.read().await.expect("frame, not end of stream");
-			if matches!(frame, Frame::Texture(_)) {
+			if matches!(frame, RawFrame::Texture(_)) {
 				textures += 1;
 			}
 			packets.extend(encoder.encode_raw(&frame, Timestamp::ZERO, i == 0).unwrap());

--- a/rs/moq-video/src/encode/encoder.rs
+++ b/rs/moq-video/src/encode/encoder.rs
@@ -6,10 +6,30 @@
 //! H.264 (`moq_mux::codec::h264`) or H.265 (`moq_mux::codec::h265`).
 
 use bytes::Bytes;
+use moq_net::Timestamp;
 
 use super::backend::{self, Backend};
 use crate::frame::{Frame, I420};
 use crate::{Error, Size};
+
+/// One encoded video access unit and the presentation timestamp of its input frame.
+///
+/// Construct packets for [`Producer`](super::Producer) with [`Packet::new`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Packet {
+	/// The encoded access unit in the codec's framing.
+	pub payload: Bytes,
+	/// The presentation timestamp carried by the frame that produced this access unit.
+	pub timestamp: Timestamp,
+}
+
+impl Packet {
+	/// Pair an encoded access unit with its presentation timestamp.
+	pub fn new(payload: Bytes, timestamp: Timestamp) -> Self {
+		Self { payload, timestamp }
+	}
+}
 
 /// Output video codec. `#[non_exhaustive]` so new codecs can be added without
 /// breaking external `match`es.
@@ -181,24 +201,33 @@ impl Encoder {
 	}
 
 	/// Encode one tightly-packed RGBA frame of `size`, returning zero or more
-	/// encoded packets in the codec's framing. Set `keyframe` to force an IDR
-	/// (e.g. on resume so a re-subscribing viewer can start decoding at once).
+	/// encoded packets in the codec's framing. Every packet carries `timestamp`,
+	/// even when a backend emits it from a later encode or [`finish`](Self::finish).
+	/// Set `keyframe` to force an IDR (e.g. on resume so a re-subscribing viewer
+	/// can start decoding at once).
 	///
 	/// `size` must equal the encoder's [`size`](Self::size), and `rgba` must hold
 	/// exactly `width * height * 4` bytes with no row padding.
-	pub fn encode_rgba(&mut self, rgba: &[u8], size: Size, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+	pub fn encode_rgba(
+		&mut self,
+		rgba: &[u8],
+		size: Size,
+		timestamp: Timestamp,
+		keyframe: bool,
+	) -> Result<Vec<Packet>, Error> {
 		// The encoder resolution is validated even and non-zero in `new`, so a
 		// frame matching it is even too and the conversion below can't fail on odd
 		// dimensions.
 		self.check_frame(size, rgba.len(), size.pixels() as usize * 4, "RGBA")?;
 
 		let frame = Frame::I420(I420::from_rgba(rgba, size.width * 4, size.width, size.height)?);
-		self.encode_raw(&frame, keyframe)
+		self.encode_raw(&frame, timestamp, keyframe)
 	}
 
 	/// Encode one tightly-packed I420 frame of `size` (Y then U then V, no row
 	/// padding, BT.601 limited range), returning zero or more encoded packets in
-	/// the codec's framing. Set `keyframe` to force an IDR.
+	/// the codec's framing. Every packet carries `timestamp`. Set `keyframe` to
+	/// force an IDR.
 	///
 	/// `size` must equal the encoder's [`size`](Self::size), and `i420` must hold
 	/// exactly `width * height * 3 / 2` bytes.
@@ -207,7 +236,13 @@ impl Encoder {
 	/// it. A transcoder should prefer [`encode`](Self::encode): it takes a decoded
 	/// frame directly and keeps a GPU one on the GPU, so it neither copies nor
 	/// round-trips through system memory.
-	pub fn encode_i420(&mut self, i420: &[u8], size: Size, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+	pub fn encode_i420(
+		&mut self,
+		i420: &[u8],
+		size: Size,
+		timestamp: Timestamp,
+		keyframe: bool,
+	) -> Result<Vec<Packet>, Error> {
 		self.check_frame(size, i420.len(), I420::len(size.width, size.height), "I420")?;
 
 		let frame = Frame::I420(I420 {
@@ -215,7 +250,7 @@ impl Encoder {
 			height: size.height,
 			data: i420.to_vec(),
 		});
-		self.encode_raw(&frame, keyframe)
+		self.encode_raw(&frame, timestamp, keyframe)
 	}
 
 	/// Reject a frame the encoder can't encode: the wrong shape, or a buffer that
@@ -245,14 +280,19 @@ impl Encoder {
 	/// directly (NVDEC -> NVENC stays on the GPU); everything else falls back to
 	/// a CPU I420 upload. The frame must already be at the encoder's resolution;
 	/// decode with [`decode::Config::resize`](crate::decode::Config) (or scale
-	/// yourself) first.
-	pub fn encode(&mut self, frame: &crate::decode::Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
-		self.encode_raw(&frame.inner, keyframe)
+	/// yourself) first. Each output packet preserves [`Frame::timestamp`](crate::decode::Frame::timestamp).
+	pub fn encode(&mut self, frame: &crate::decode::Frame, keyframe: bool) -> Result<Vec<Packet>, Error> {
+		self.encode_raw(&frame.inner, frame.timestamp, keyframe)
 	}
 
 	/// Encode a captured [`Frame`] (a GPU surface or CPU I420). The frame must
 	/// already be at the encoder's resolution.
-	pub(crate) fn encode_raw(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
+	pub(crate) fn encode_raw(
+		&mut self,
+		frame: &Frame,
+		timestamp: Timestamp,
+		keyframe: bool,
+	) -> Result<Vec<Packet>, Error> {
 		let size = Size::new(frame.width(), frame.height());
 		if size != self.size {
 			return Err(Error::Codec(anyhow::anyhow!(
@@ -260,14 +300,14 @@ impl Encoder {
 				self.size
 			)));
 		}
-		self.backend.encode(frame, keyframe)
+		self.backend.encode(frame, timestamp, keyframe)
 	}
 
-	/// Flush the encoder, returning any buffered packets.
+	/// Flush the encoder, returning any buffered packets with their input timestamps.
 	///
 	/// Consumes the encoder: nothing can be encoded after a flush, so this is the
 	/// last call rather than one leaving a drained encoder in your hands.
-	pub fn finish(mut self) -> Result<Vec<Bytes>, Error> {
+	pub fn finish(mut self) -> Result<Vec<Packet>, Error> {
 		self.backend.finish()
 	}
 }
@@ -279,6 +319,62 @@ mod tests {
 	/// A mid-gray RGBA frame: encodable without a camera.
 	fn gray_rgba(width: u32, height: u32) -> Vec<u8> {
 		vec![0x80u8; width as usize * height as usize * 4]
+	}
+
+	/// A one-frame-delay backend that emits frame N while frame N+1 is submitted,
+	/// then drains the final frame from `finish`.
+	struct Delayed {
+		pending: Option<Timestamp>,
+	}
+
+	impl Backend for Delayed {
+		fn encode(&mut self, _frame: &Frame, timestamp: Timestamp, _keyframe: bool) -> Result<Vec<Packet>, Error> {
+			let Some(timestamp) = self.pending.replace(timestamp) else {
+				return Ok(Vec::new());
+			};
+			Ok(vec![Packet::new(Bytes::from_static(b"encoded"), timestamp)])
+		}
+
+		fn finish(&mut self) -> Result<Vec<Packet>, Error> {
+			Ok(self
+				.pending
+				.take()
+				.map(|timestamp| vec![Packet::new(Bytes::from_static(b"tail"), timestamp)])
+				.unwrap_or_default())
+		}
+
+		fn set_bitrate(&mut self, _bitrate: u64) -> Result<(), Error> {
+			Ok(())
+		}
+
+		fn name(&self) -> &str {
+			"delayed"
+		}
+	}
+
+	#[test]
+	fn delayed_packets_keep_their_input_timestamps_through_finish() {
+		let mut encoder = Encoder {
+			backend: Box::new(Delayed { pending: None }),
+			codec: Codec::H264,
+			size: Size::new(2, 2),
+			bitrate: 1,
+		};
+		let frame = gray_rgba(2, 2);
+		let first = Timestamp::from_micros(100).unwrap();
+		let second = Timestamp::from_micros(200).unwrap();
+
+		assert!(
+			encoder
+				.encode_rgba(&frame, Size::new(2, 2), first, true)
+				.unwrap()
+				.is_empty()
+		);
+		let packets = encoder.encode_rgba(&frame, Size::new(2, 2), second, false).unwrap();
+		assert_eq!(packets[0].timestamp, first);
+
+		let tail = encoder.finish().unwrap();
+		assert_eq!(tail[0].timestamp, second);
 	}
 
 	#[test]
@@ -293,7 +389,11 @@ mod tests {
 		let frame = gray_rgba(320, 240);
 		let mut packets = Vec::new();
 		for i in 0..30 {
-			packets.extend(encoder.encode_rgba(&frame, Size::new(320, 240), i == 0).unwrap());
+			packets.extend(
+				encoder
+					.encode_rgba(&frame, Size::new(320, 240), Timestamp::ZERO, i == 0)
+					.unwrap(),
+			);
 		}
 		packets.extend(encoder.finish().unwrap());
 
@@ -301,7 +401,7 @@ mod tests {
 
 		// The first packet must start with an Annex-B start code so the avc3
 		// importer can find the inline SPS/PPS.
-		let first = &packets[0];
+		let first = &packets[0].payload;
 		let has_start_code = first.starts_with(&[0, 0, 0, 1]) || first.starts_with(&[0, 0, 1]);
 		assert!(
 			has_start_code,
@@ -319,10 +419,14 @@ mod tests {
 		let mut encoder = Encoder::new(&config).unwrap();
 
 		let rgba = gray_rgba(320, 240);
-		let mut packets = encoder.encode_rgba(&rgba, Size::new(320, 240), true).unwrap();
+		let timestamp = Timestamp::from_micros(123_456).unwrap();
+		let mut packets = encoder
+			.encode_rgba(&rgba, Size::new(320, 240), timestamp, true)
+			.unwrap();
+		assert!(packets.iter().all(|packet| packet.timestamp == timestamp));
 		packets.extend(encoder.finish().unwrap());
 		assert!(!packets.is_empty());
-		assert!(packets[0].starts_with(&[0, 0, 0, 1]) || packets[0].starts_with(&[0, 0, 1]));
+		assert!(packets[0].payload.starts_with(&[0, 0, 0, 1]) || packets[0].payload.starts_with(&[0, 0, 1]));
 	}
 
 	#[test]
@@ -335,10 +439,12 @@ mod tests {
 
 		// A mid-gray I420 frame: flat 0x80 across all three planes.
 		let data = vec![0x80u8; I420::len(320, 240)];
-		let mut packets = encoder.encode_i420(&data, Size::new(320, 240), true).unwrap();
+		let mut packets = encoder
+			.encode_i420(&data, Size::new(320, 240), Timestamp::ZERO, true)
+			.unwrap();
 		packets.extend(encoder.finish().unwrap());
 		assert!(!packets.is_empty());
-		assert!(packets[0].starts_with(&[0, 0, 0, 1]) || packets[0].starts_with(&[0, 0, 1]));
+		assert!(packets[0].payload.starts_with(&[0, 0, 0, 1]) || packets[0].payload.starts_with(&[0, 0, 1]));
 	}
 
 	/// A buffer that doesn't hold one whole frame of the declared size must error
@@ -349,7 +455,7 @@ mod tests {
 			return;
 		};
 		assert!(matches!(
-			encoder.encode_i420(&[0u8; 16], Size::new(320, 240), false),
+			encoder.encode_i420(&[0u8; 16], Size::new(320, 240), Timestamp::ZERO, false),
 			Err(Error::Codec(_))
 		));
 	}
@@ -361,7 +467,7 @@ mod tests {
 		};
 		// Far smaller than 320*240*4: must error, not panic on conversion.
 		assert!(matches!(
-			encoder.encode_rgba(&[0u8; 16], Size::new(320, 240), false),
+			encoder.encode_rgba(&[0u8; 16], Size::new(320, 240), Timestamp::ZERO, false),
 			Err(Error::Codec(_))
 		));
 	}
@@ -375,7 +481,7 @@ mod tests {
 		};
 		let rgba = gray_rgba(640, 480);
 		assert!(matches!(
-			encoder.encode_rgba(&rgba, Size::new(640, 480), false),
+			encoder.encode_rgba(&rgba, Size::new(640, 480), Timestamp::ZERO, false),
 			Err(Error::Codec(_))
 		));
 	}
@@ -389,7 +495,7 @@ mod tests {
 		};
 		let data = vec![0x80u8; I420::len(640, 480)];
 		assert!(matches!(
-			encoder.encode_i420(&data, Size::new(640, 480), false),
+			encoder.encode_i420(&data, Size::new(640, 480), Timestamp::ZERO, false),
 			Err(Error::Codec(_))
 		));
 	}
@@ -406,14 +512,14 @@ mod tests {
 		let rgba = gray_rgba(240, 320);
 		assert_eq!(rgba.len(), gray_rgba(320, 240).len(), "the byte counts must collide");
 		assert!(matches!(
-			encoder.encode_rgba(&rgba, Size::new(240, 320), false),
+			encoder.encode_rgba(&rgba, Size::new(240, 320), Timestamp::ZERO, false),
 			Err(Error::Codec(_))
 		));
 
 		let i420 = vec![0x80u8; I420::len(240, 320)];
 		assert_eq!(i420.len(), I420::len(320, 240), "the byte counts must collide");
 		assert!(matches!(
-			encoder.encode_i420(&i420, Size::new(240, 320), false),
+			encoder.encode_i420(&i420, Size::new(240, 320), Timestamp::ZERO, false),
 			Err(Error::Codec(_))
 		));
 	}
@@ -451,12 +557,16 @@ mod tests {
 		let frame = gray_rgba(320, 240);
 		let mut packets = Vec::new();
 		for i in 0..10 {
-			packets.extend(encoder.encode_rgba(&frame, Size::new(320, 240), i == 0).unwrap());
+			packets.extend(
+				encoder
+					.encode_rgba(&frame, Size::new(320, 240), Timestamp::ZERO, i == 0)
+					.unwrap(),
+			);
 		}
 		packets.extend(encoder.finish().unwrap());
 
 		assert!(!packets.is_empty(), "encoder produced no packets");
-		let first = &packets[0];
+		let first = &packets[0].payload;
 		assert!(
 			first.starts_with(&[0, 0, 0, 1]) || first.starts_with(&[0, 0, 1]),
 			"first packet is not Annex-B"
@@ -488,12 +598,16 @@ mod tests {
 		let frame = gray_rgba(320, 240);
 		let mut packets = Vec::new();
 		for i in 0..10 {
-			packets.extend(encoder.encode_rgba(&frame, Size::new(320, 240), i == 0).unwrap());
+			packets.extend(
+				encoder
+					.encode_rgba(&frame, Size::new(320, 240), Timestamp::ZERO, i == 0)
+					.unwrap(),
+			);
 		}
 		packets.extend(encoder.finish().unwrap());
 
 		assert!(!packets.is_empty(), "encoder produced no packets");
-		let first = &packets[0];
+		let first = &packets[0].payload;
 		assert!(
 			first.starts_with(&[0, 0, 0, 1]) || first.starts_with(&[0, 0, 1]),
 			"first packet is not Annex-B"
@@ -541,12 +655,12 @@ mod tests {
 		let mut packets = Vec::new();
 		for i in 0..10 {
 			let frame = Frame::Surface(nv12_surface(320, 240));
-			packets.extend(encoder.encode_raw(&frame, i == 0).unwrap());
+			packets.extend(encoder.encode_raw(&frame, Timestamp::ZERO, i == 0).unwrap());
 		}
 		packets.extend(encoder.finish().unwrap());
 
 		assert!(!packets.is_empty());
-		let types = nal_types(&packets[0]);
+		let types = nal_types(&packets[0].payload);
 		assert!(
 			types.contains(&7) && types.contains(&8) && types.contains(&5),
 			"no IDR: {types:?}"
@@ -565,11 +679,11 @@ mod tests {
 		let mut encoder = Encoder::new(&config).unwrap();
 
 		let frame = Frame::Surface(nv12_surface(320, 240));
-		let mut packets = encoder.encode_raw(&frame, true).unwrap();
+		let mut packets = encoder.encode_raw(&frame, Timestamp::ZERO, true).unwrap();
 		packets.extend(encoder.finish().unwrap());
 
 		assert!(!packets.is_empty());
-		assert!(packets[0].starts_with(&[0, 0, 0, 1]) || packets[0].starts_with(&[0, 0, 1]));
+		assert!(packets[0].payload.starts_with(&[0, 0, 0, 1]) || packets[0].payload.starts_with(&[0, 0, 1]));
 	}
 
 	/// A mid-gray NV12 `CVPixelBuffer`, the format AVFoundation/ScreenCaptureKit
@@ -645,12 +759,16 @@ mod tests {
 		let frame = gray_rgba(640, 480);
 		let mut packets = Vec::new();
 		for i in 0..30 {
-			packets.extend(encoder.encode_rgba(&frame, Size::new(640, 480), i == 0).unwrap());
+			packets.extend(
+				encoder
+					.encode_rgba(&frame, Size::new(640, 480), Timestamp::ZERO, i == 0)
+					.unwrap(),
+			);
 		}
 		packets.extend(encoder.finish().unwrap());
 
 		assert!(!packets.is_empty(), "encoder produced no packets");
-		let types = nal_types(&packets[0]);
+		let types = nal_types(&packets[0].payload);
 		assert!(types.contains(&7), "no SPS in first packet: {types:?}");
 		assert!(types.contains(&8), "no PPS in first packet: {types:?}");
 		assert!(types.contains(&5), "first packet is not an IDR: {types:?}");
@@ -681,7 +799,7 @@ mod tests {
 			if matches!(frame, Frame::Texture(_)) {
 				textures += 1;
 			}
-			packets.extend(encoder.encode_raw(&frame, i == 0).unwrap());
+			packets.extend(encoder.encode_raw(&frame, Timestamp::ZERO, i == 0).unwrap());
 		}
 		packets.extend(encoder.finish().unwrap());
 
@@ -689,7 +807,7 @@ mod tests {
 		// against silently testing only the CPU fallback.
 		assert!(textures > 0, "capture never produced a GPU texture");
 		assert!(!packets.is_empty(), "encoder produced no packets");
-		let types = nal_types(&packets[0]);
+		let types = nal_types(&packets[0].payload);
 		assert!(
 			types.contains(&7) && types.contains(&8) && types.contains(&5),
 			"no IDR: {types:?}"
@@ -712,16 +830,20 @@ mod tests {
 		assert_eq!(opened, config.resolved_bitrate());
 
 		// Encode first: this is the live-retune path, once the encoder exists.
-		encoder.encode_rgba(&rgba, Size::new(320, 240), true).unwrap();
+		encoder
+			.encode_rgba(&rgba, Size::new(320, 240), Timestamp::ZERO, true)
+			.unwrap();
 
 		let halved = opened / 2;
 		encoder.set_bitrate(halved).unwrap();
 		assert_eq!(encoder.bitrate(), halved);
 
 		// The retuned encoder must still emit a decodable keyframe, not wedge.
-		let packets = encoder.encode_rgba(&rgba, Size::new(320, 240), true).unwrap();
+		let packets = encoder
+			.encode_rgba(&rgba, Size::new(320, 240), Timestamp::ZERO, true)
+			.unwrap();
 		assert!(!packets.is_empty(), "encoder produced nothing after a retune");
-		assert!(packets[0].starts_with(&[0, 0, 0, 1]) || packets[0].starts_with(&[0, 0, 1]));
+		assert!(packets[0].payload.starts_with(&[0, 0, 0, 1]) || packets[0].payload.starts_with(&[0, 0, 1]));
 	}
 
 	/// Regression: openh264 creates its encoder lazily on the first frame and
@@ -741,12 +863,18 @@ mod tests {
 
 		// The deferred rate is applied during this encode, which must still work.
 		let rgba = gray_rgba(320, 240);
-		let packets = encoder.encode_rgba(&rgba, Size::new(320, 240), true).unwrap();
+		let packets = encoder
+			.encode_rgba(&rgba, Size::new(320, 240), Timestamp::ZERO, true)
+			.unwrap();
 		assert!(!packets.is_empty());
 
 		// And the encoder is live now, so a further retune takes the direct path.
 		encoder.set_bitrate(halved / 2).unwrap();
-		assert!(encoder.encode_rgba(&rgba, Size::new(320, 240), false).is_ok());
+		assert!(
+			encoder
+				.encode_rgba(&rgba, Size::new(320, 240), Timestamp::ZERO, false)
+				.is_ok()
+		);
 	}
 
 	/// Setting the current rate must not reach the backend at all: the control

--- a/rs/moq-video/src/encode/mod.rs
+++ b/rs/moq-video/src/encode/mod.rs
@@ -7,8 +7,8 @@
 //! - [`publish_capture`] captures and publishes a webcam (turnkey).
 //! - [`Encoder`] encodes raw RGBA frames you supply, and [`Producer`]
 //!   publishes the resulting packets (bring your own frames). Build both for the
-//!   same [`Codec`].
-//! - [`Producer`] alone publishes packets you already encoded.
+//!   same [`Codec`]. Each [`Packet`] carries the timestamp of its input frame.
+//! - [`Producer`] alone publishes timestamped packets you already encoded.
 //!
 //! [`Options`] / [`Kind`] / [`Config`] configure them. The decode/consume
 //! counterpart (mirror of `moq-audio`'s consumer) lives in the sibling
@@ -24,5 +24,5 @@ mod sink;
 
 pub mod rate;
 
-pub use encoder::{Codec, Config, Encoder, Kind};
+pub use encoder::{Codec, Config, Encoder, Kind, Packet};
 pub use producer::{Options, Producer, publish_capture};

--- a/rs/moq-video/src/encode/mod.rs
+++ b/rs/moq-video/src/encode/mod.rs
@@ -6,9 +6,9 @@
 //! Entry points, high to low level:
 //! - [`publish_capture`] captures and publishes a webcam (turnkey).
 //! - [`Encoder`] encodes raw RGBA frames you supply, and [`Producer`]
-//!   publishes the resulting packets (bring your own frames). Build both for the
-//!   same [`Codec`]. Each [`Packet`] carries the timestamp of its input frame.
-//! - [`Producer`] alone publishes timestamped packets you already encoded.
+//!   publishes the resulting encoded frames (bring your own frames). Build both for the
+//!   same [`Codec`]. Each [`Frame`] carries the timestamp of its input frame.
+//! - [`Producer`] alone publishes timestamped frames you already encoded.
 //!
 //! [`Options`] / [`Kind`] / [`Config`] configure them. The decode/consume
 //! counterpart (mirror of `moq-audio`'s consumer) lives in the sibling
@@ -24,5 +24,5 @@ mod sink;
 
 pub mod rate;
 
-pub use encoder::{Codec, Config, Encoder, Kind, Packet};
+pub use encoder::{Codec, Config, Encoder, Frame, Kind};
 pub use producer::{Options, Producer, publish_capture};

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -13,7 +13,7 @@ use moq_net::Timestamp;
 use crate::Error;
 use crate::capture;
 
-use super::encoder::{self, Codec};
+use super::encoder::{self, Codec, Packet};
 use super::rate::{Control, Policy};
 use super::sink::Sink;
 
@@ -82,19 +82,20 @@ impl Producer {
 		}
 	}
 
-	/// Publish already-encoded packets at the given timestamp. Each packet is one
-	/// whole access unit in the producer's codec framing.
-	pub fn publish(&mut self, packets: Vec<bytes::Bytes>, timestamp: Timestamp) -> Result<(), Error> {
+	/// Publish already-encoded packets. Each packet is one whole access unit in
+	/// the producer's codec framing with its own presentation timestamp.
+	pub fn publish(&mut self, packets: Vec<Packet>) -> Result<(), Error> {
 		for packet in packets {
+			let Packet { payload, timestamp, .. } = packet;
 			// The encoder emits one whole access unit per packet, so flush to emit it.
 			match &mut self.codecs {
 				Codecs::H264 { split, import } => {
-					let mut frames = split.decode(&packet, Some(timestamp))?;
+					let mut frames = split.decode(&payload, Some(timestamp))?;
 					frames.extend(split.flush(Some(timestamp))?);
 					import.decode(frames)?;
 				}
 				Codecs::H265 { split, import } => {
-					let mut frames = split.decode(&packet, Some(timestamp))?;
+					let mut frames = split.decode(&payload, Some(timestamp))?;
 					frames.extend(split.flush(Some(timestamp))?);
 					import.decode(frames)?;
 				}
@@ -384,12 +385,12 @@ async fn capture_loop(
 			let Some(frame) = frame else { break }; // device stopped producing frames
 
 			let ts = Timestamp::from_micros(clock.micros())?;
-			let packets = encoder.encode(frame, force_keyframe).await?;
+			let packets = encoder.encode(frame, ts, force_keyframe).await?;
 			force_keyframe = false;
 			// Once the encoder emits a frame the importer has parsed the SPS and
 			// the catalog rendition exists, so demand gating can take over.
 			catalog_ready |= !packets.is_empty();
-			producer.publish(packets, ts)?;
+			producer.publish(packets)?;
 		}
 
 		// Drop the camera (LED off) and encoder before waiting for the next viewer.
@@ -427,14 +428,14 @@ mod tests {
 
 		let rgba = vec![0x80u8; 320 * 240 * 4];
 		for i in 0..10u64 {
-			let packets = encoder.encode_rgba(&rgba, crate::Size::new(320, 240), i == 0).unwrap();
 			let ts = Timestamp::from_micros(i * 33_333).unwrap();
-			producer.publish(packets, ts).unwrap();
+			let packets = encoder
+				.encode_rgba(&rgba, crate::Size::new(320, 240), ts, i == 0)
+				.unwrap();
+			producer.publish(packets).unwrap();
 		}
 		let tail = encoder.finish().unwrap();
-		producer
-			.publish(tail, Timestamp::from_micros(10 * 33_333).unwrap())
-			.unwrap();
+		producer.publish(tail).unwrap();
 
 		let snapshot = catalog.snapshot();
 		snapshot

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -13,14 +13,14 @@ use moq_net::Timestamp;
 use crate::Error;
 use crate::capture;
 
-use super::encoder::{self, Codec, Packet};
+use super::encoder::{self, Codec, Frame};
 use super::rate::{Control, Policy};
 use super::sink::Sink;
 
 /// Last-resort framerate when neither the caller nor the camera reports one.
 const DEFAULT_FRAMERATE: u32 = 30;
 
-/// Per-codec splitter + importer pair. Each codec frames its packets and resolves
+/// Per-codec splitter + importer pair. Each codec frames its access units and resolves
 /// its catalog rendition differently, so the producer holds one of these.
 enum Codecs {
 	H264 {
@@ -46,7 +46,7 @@ pub struct Producer {
 
 impl Producer {
 	/// Publish a track for `codec` into `broadcast`, registering its rendition
-	/// in `catalog`. The packets fed to [`publish`](Self::publish) must be in
+	/// in `catalog`. The frames fed to [`publish`](Self::publish) must be in
 	/// that codec's framing (the matching [`Encoder`](super::Encoder) emits it).
 	pub fn new(
 		mut broadcast: moq_net::broadcast::Producer,
@@ -82,12 +82,12 @@ impl Producer {
 		}
 	}
 
-	/// Publish already-encoded packets. Each packet is one whole access unit in
+	/// Publish already-encoded frames. Each frame is one whole access unit in
 	/// the producer's codec framing with its own presentation timestamp.
-	pub fn publish(&mut self, packets: Vec<Packet>) -> Result<(), Error> {
-		for packet in packets {
-			let Packet { payload, timestamp, .. } = packet;
-			// The encoder emits one whole access unit per packet, so flush to emit it.
+	pub fn publish(&mut self, frames: Vec<Frame>) -> Result<(), Error> {
+		for frame in frames {
+			let Frame { payload, timestamp } = frame;
+			// The encoder emits one whole access unit per frame, so flush to emit it.
 			match &mut self.codecs {
 				Codecs::H264 { split, import } => {
 					let mut frames = split.decode(&payload, Some(timestamp))?;

--- a/rs/moq-video/src/encode/sink.rs
+++ b/rs/moq-video/src/encode/sink.rs
@@ -9,7 +9,7 @@
 //! per-thread COM refcount as the future migrates between workers and park a
 //! worker on a stalled MFT. Confining the whole encoder lifetime to one thread
 //! fixes both; frames are `Send` there (Windows D3D11 textures and CPU I420 both
-//! are) and packets come back over a channel.
+//! are) and encoded frames come back over a channel.
 //!
 //! macOS keeps encoding inline: VideoToolbox has no COM apartment to balance and
 //! doesn't block on an event loop, so a thread would only add a hop, and its
@@ -28,7 +28,7 @@ mod threaded {
 	use moq_net::Timestamp;
 	use tokio::sync::{mpsc, oneshot};
 
-	use super::super::encoder::{self, Encoder, Packet};
+	use super::super::encoder::{self, Encoder, Frame as EncodedFrame};
 	use crate::Error;
 	use crate::frame::Frame;
 
@@ -37,12 +37,12 @@ mod threaded {
 	/// racing them.
 	enum Request {
 		/// A frame and whether to force a keyframe, plus a oneshot to return that
-		/// frame's packets (or an error) in order.
+		/// frame's encoded output (or an error) in order.
 		Encode {
 			frame: Frame,
 			timestamp: Timestamp,
 			keyframe: bool,
-			resp: oneshot::Sender<Result<Vec<Packet>, Error>>,
+			resp: oneshot::Sender<Result<Vec<EncodedFrame>, Error>>,
 		},
 		/// Retune to a new bitrate, reporting whether the backend took it so the
 		/// caller can stop adapting against an encoder that can't. The round trip
@@ -124,14 +124,14 @@ mod threaded {
 			&self.name
 		}
 
-		/// Encode one frame, awaiting its packets. The frame is moved to the
+		/// Encode one frame, awaiting its output. The frame is moved to the
 		/// encode thread; the result returns over a oneshot.
 		pub(in crate::encode) async fn encode(
 			&mut self,
 			frame: Frame,
 			timestamp: Timestamp,
 			keyframe: bool,
-		) -> Result<Vec<Packet>, Error> {
+		) -> Result<Vec<EncodedFrame>, Error> {
 			self.request(|resp| Request::Encode {
 				frame,
 				timestamp,
@@ -184,7 +184,7 @@ mod threaded {
 mod inline {
 	use moq_net::Timestamp;
 
-	use super::super::encoder::{self, Encoder, Packet};
+	use super::super::encoder::{self, Encoder, Frame as EncodedFrame};
 	use crate::Error;
 	use crate::frame::Frame;
 
@@ -206,7 +206,7 @@ mod inline {
 			frame: Frame,
 			timestamp: Timestamp,
 			keyframe: bool,
-		) -> Result<Vec<Packet>, Error> {
+		) -> Result<Vec<EncodedFrame>, Error> {
 			self.0.encode_raw(&frame, timestamp, keyframe)
 		}
 

--- a/rs/moq-video/src/encode/sink.rs
+++ b/rs/moq-video/src/encode/sink.rs
@@ -25,10 +25,10 @@ pub(super) use inline::Sink;
 mod threaded {
 	use std::thread::JoinHandle;
 
-	use bytes::Bytes;
+	use moq_net::Timestamp;
 	use tokio::sync::{mpsc, oneshot};
 
-	use super::super::encoder::{self, Encoder};
+	use super::super::encoder::{self, Encoder, Packet};
 	use crate::Error;
 	use crate::frame::Frame;
 
@@ -40,8 +40,9 @@ mod threaded {
 		/// frame's packets (or an error) in order.
 		Encode {
 			frame: Frame,
+			timestamp: Timestamp,
 			keyframe: bool,
-			resp: oneshot::Sender<Result<Vec<Bytes>, Error>>,
+			resp: oneshot::Sender<Result<Vec<Packet>, Error>>,
 		},
 		/// Retune to a new bitrate, reporting whether the backend took it so the
 		/// caller can stop adapting against an encoder that can't. The round trip
@@ -88,8 +89,13 @@ mod threaded {
 				// MFT handles are created, used, and dropped only on this thread.
 				while let Some(req) = req_rx.blocking_recv() {
 					match req {
-						Request::Encode { frame, keyframe, resp } => {
-							let _ = resp.send(encoder.encode_raw(&frame, keyframe));
+						Request::Encode {
+							frame,
+							timestamp,
+							keyframe,
+							resp,
+						} => {
+							let _ = resp.send(encoder.encode_raw(&frame, timestamp, keyframe));
 						}
 						Request::SetBitrate { bitrate, resp } => {
 							let _ = resp.send(encoder.set_bitrate(bitrate));
@@ -120,8 +126,19 @@ mod threaded {
 
 		/// Encode one frame, awaiting its packets. The frame is moved to the
 		/// encode thread; the result returns over a oneshot.
-		pub(in crate::encode) async fn encode(&mut self, frame: Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
-			self.request(|resp| Request::Encode { frame, keyframe, resp }).await
+		pub(in crate::encode) async fn encode(
+			&mut self,
+			frame: Frame,
+			timestamp: Timestamp,
+			keyframe: bool,
+		) -> Result<Vec<Packet>, Error> {
+			self.request(|resp| Request::Encode {
+				frame,
+				timestamp,
+				keyframe,
+				resp,
+			})
+			.await
 		}
 
 		/// Retune the encoder, awaiting the backend's verdict.
@@ -165,9 +182,9 @@ mod threaded {
 
 #[cfg(target_os = "macos")]
 mod inline {
-	use bytes::Bytes;
+	use moq_net::Timestamp;
 
-	use super::super::encoder::{self, Encoder};
+	use super::super::encoder::{self, Encoder, Packet};
 	use crate::Error;
 	use crate::frame::Frame;
 
@@ -184,8 +201,13 @@ mod inline {
 			self.0.name()
 		}
 
-		pub(in crate::encode) async fn encode(&mut self, frame: Frame, keyframe: bool) -> Result<Vec<Bytes>, Error> {
-			self.0.encode_raw(&frame, keyframe)
+		pub(in crate::encode) async fn encode(
+			&mut self,
+			frame: Frame,
+			timestamp: Timestamp,
+			keyframe: bool,
+		) -> Result<Vec<Packet>, Error> {
+			self.0.encode_raw(&frame, timestamp, keyframe)
 		}
 
 		/// Retune the encoder. Async only to match the threaded `Sink`; there's


### PR DESCRIPTION
## Summary

- Add `encode::Frame { payload, timestamp }` and carry each frame timestamp through every encoder backend, including delayed output returned by later calls or `finish()`.
- Publish and transcode each encoded frame at its own timestamp instead of the submission time of the frame that happens to receive it.
- Correlate Media Foundation output sample times back to exact `moq_net::Timestamp` values and add a one-frame-delay regression backend covering tail drain.

Root cause: the capture and transcode paths stamped every encoded access unit with the timestamp available at the call site that received it. That only works for zero-delay encoders. A queued backend can return frame N while frame N+1 is submitted, and a drained tail has no current input timestamp to borrow.

## Public API changes

This is breaking, so the PR targets `dev`.

- Add `moq_video::encode::Frame` with public `payload` and `timestamp` fields plus `Frame::new`.
- Add a `Timestamp` argument to `Encoder::encode_rgba` and `Encoder::encode_i420`, and return `Vec<Frame>`.
- Return `Vec<Frame>` from `Encoder::encode` and `Encoder::finish`.
- Change `Producer::publish` to accept `Vec<Frame>` and publish each frame at its own timestamp.

The internal `Backend::encode` and `finish` APIs mirror the new frame shape.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `cargo test -p moq-transcode` (13 passed)
- `cargo test -p moq-video -- --skip videotoolbox --skip h265_roundtrip_publishes_hev1` (43 passed, 6 hardware cases filtered, doctest passed)

A full `moq-video` run reached 44/49. The five remaining tests require VideoToolbox hardware unavailable in the sandbox. Linux and Windows cross-checks were also attempted but stopped in OpenH264's C++ build before Rust code because the local macOS host lacks the target cross compilers.

## Cross-Package Sync

No table row applies. This changes no wire format, catalog format, `moq-ffi` surface, or gateway contract. In-repo `moq-transcode`, `moq-boy`, and `libmoq` callers are updated.

Closes #2481

(Written by GPT-5)
