### PR TITLE
docs: point stale relay examples at cdn.moq.dev

### DIFF
--- a/doc/lib/js/env/native.md
+++ b/doc/lib/js/env/native.md
@@ -70,7 +70,7 @@ Once a transport is in place, the API is identical to the browser:
 ```javascript
 import * as Moq from "@moq/net";
 
-const url = new URL("https://relay.moq.dev/anon");
+const url = new URL("https://cdn.moq.dev/anon");
 const connection = await Moq.Connection.connect(url);
 
 // publish or subscribe exactly as you would in the browser...

--- a/doc/lib/py/index.md
+++ b/doc/lib/py/index.md
@@ -52,7 +52,7 @@ import asyncio
 import moq
 
 async def main():
-    async with moq.Client("https://relay.quic.video") as client:
+    async with moq.Client("https://cdn.moq.dev/anon") as client:
         async for announcement in client.announced():
             catalog = await announcement.broadcast.catalog()
 
@@ -70,7 +70,7 @@ import asyncio
 import moq
 
 async def main():
-    async with moq.Client("https://relay.quic.video") as client:
+    async with moq.Client("https://cdn.moq.dev/anon") as client:
         broadcast = client.create_broadcast("my-stream")
         audio = broadcast.publish_media("opus", opus_init_bytes)
 

--- a/doc/lib/rs/env/wasm.md
+++ b/doc/lib/rs/env/wasm.md
@@ -63,7 +63,7 @@ Build a transport `Session` with `web-transport`, then hand it to
 From there the pub/sub API is identical to [native](/lib/rs/env/native):
 
 ```rust
-let url = url::Url::parse("https://relay.moq.dev/anon")?;
+let url = url::Url::parse("https://cdn.moq.dev/anon")?;
 
 // On wasm this wraps the browser's native WebTransport.
 let transport = web_transport::ClientBuilder::new()

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -235,7 +235,7 @@ a relay with a few lines:
 
 ```rust
 let client = moq_native::ClientConfig::default().init()?;
-let url = url::Url::parse("https://relay.moq.dev/anon")?;
+let url = url::Url::parse("https://cdn.moq.dev/anon")?;
 let session = client.connect(url).await?;
 ```
 

--- a/py/moq-ffi/README.md
+++ b/py/moq-ffi/README.md
@@ -22,7 +22,7 @@ import moq_ffi
 
 async def main() -> None:
     client = moq_ffi.MoqClient()
-    session = await client.connect("https://relay.quic.video")
+    session = await client.connect("https://cdn.moq.dev/anon")
 
 
 asyncio.run(main())

--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -21,7 +21,7 @@ import asyncio
 import moq
 
 async def main():
-    async with moq.connect("https://relay.quic.video") as client:
+    async with moq.connect("https://cdn.moq.dev/anon") as client:
         async for announcement in client.announced():
             catalog = await announcement.broadcast.catalog()
 
@@ -41,7 +41,7 @@ import asyncio
 import moq
 
 async def main():
-    async with moq.Client("https://relay.quic.video") as client:
+    async with moq.Client("https://cdn.moq.dev/anon") as client:
         broadcast = client.create_broadcast("my-stream")
 
         # Publish an Opus audio track (init bytes from your encoder)
@@ -89,7 +89,7 @@ import moq
 
 origin = moq.OriginProducer()
 client = moq.Client(
-    "https://relay.quic.video",
+    "https://cdn.moq.dev/anon",
     publish=origin,
     subscribe=origin,
 )

--- a/py/moq-rs/docs/index.md
+++ b/py/moq-rs/docs/index.md
@@ -15,7 +15,7 @@ import moq
 
 
 async def main():
-    async with moq.Client("https://relay.quic.video") as client:
+    async with moq.Client("https://cdn.moq.dev/anon") as client:
         async for announcement in client.announced():
             catalog = await announcement.broadcast.catalog()
             print(catalog)


### PR DESCRIPTION
## Summary

- The Rust, JS, and Python quickstart examples still pointed at `relay.moq.dev` and `relay.quic.video`. **Neither hostname has any DNS records**, so every one of these snippets failed to connect when copy-pasted.
- `cdn.moq.dev` is the live relay: it resolves to the Linode cluster described in `doc/setup/dev.md`, serves a valid Let's Encrypt cert for `CN=cdn.moq.dev`, and answers on QUIC. It was already what the other 23 references in the repo used, so this makes the docs internally consistent.
- The `relay.quic.video` examples had no path at all. They now use `/anon`, the prefix configured for unauthenticated publish/subscribe (`doc/bin/relay/auth.md`, `demo/relay/root.toml`), since none of them pass a JWT. A bare root URL would connect and then fail authorization. The `relay.moq.dev` examples already carried `/anon`, so those were a pure host swap.

A repo-wide grep turned up three files beyond the doc pages, all published package READMEs:

| File | Was | Count |
|---|---|---|
| `doc/lib/js/env/native.md` | relay.moq.dev | 1 |
| `doc/lib/rs/env/wasm.md` | relay.moq.dev | 1 |
| `doc/lib/rs/index.md` | relay.moq.dev | 1 |
| `doc/lib/py/index.md` | relay.quic.video | 2 |
| `py/moq-rs/README.md` | relay.quic.video | 3 |
| `py/moq-rs/docs/index.md` | relay.quic.video | 1 |
| `py/moq-ffi/README.md` | relay.quic.video | 1 |

## Public API changes

None. Documentation and READMEs only.

## Cross-Package Sync

`py/moq-rs` and `py/moq-ffi` READMEs are updated alongside `doc/lib/py/index.md`, so the PyPI-published copies and the doc site agree. No other rows apply: no wire format, `moq-ffi`, CLI flag, or relay config changed.

## Test plan

- `dig` on all three hostnames: `cdn.moq.dev` → `173.230.134.228`; `relay.moq.dev` and `relay.quic.video` → no records.
- TLS handshake against `cdn.moq.dev:443` returns a Let's Encrypt cert for `CN=cdn.moq.dev`; an HTTP/3 probe gets a QUIC-level response, confirming the relay is up.
- Grepped the whole repo for both stale hostnames and for `quic.video` generally; no occurrences remain. Also audited every other `*.moq.dev` host referenced in the repo (`doc`, `api`, `vid`, `rom`, `apt`, `rpm`) - all resolve, none stale.
- `bun remark` passes on all seven changed files with no further edits.

(Written by Fable 5)