### PR TITLE
test(relay): restore env vars and serialize them on one lock

### DIFF
--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -1345,6 +1345,10 @@ mod tests {
 	/// `mesh` is a string (clobber-safe) that accepts a TOML boolean.
 	#[test]
 	fn cluster_node_and_mesh_round_trip() {
+		// clap reads the environment while parsing, so serialize with the tests
+		// that mutate it.
+		let _env = crate::test_env::EnvGuard::lock();
+
 		let toml =
 			"[cluster]\nnode = \"us-east.example.com:4443\"\nmesh = true\nconnect = [\"root.example.com:4443\"]\n";
 		let dir = std::env::temp_dir().join("moq-relay-cluster-test");
@@ -1437,6 +1441,10 @@ mod tests {
 	/// config tests guard, which is why the field is `Option<String>`).
 	#[test]
 	fn cluster_connect_api_survives_toml_merge() {
+		// clap reads the environment while parsing, so serialize with the tests
+		// that mutate it.
+		let _env = crate::test_env::EnvGuard::lock();
+
 		let toml = "[cluster]\nconnect_api = \"https://api.example.com/cluster/connect\"\n";
 		let dir = std::env::temp_dir().join("moq-relay-cluster-test");
 		std::fs::create_dir_all(&dir).unwrap();

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -111,55 +111,8 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
-	use std::sync::Mutex;
-
 	use super::*;
-
-	/// Clears environment variables for the duration of a test, restoring what
-	/// they held (or their absence) on drop.
-	///
-	/// clap reads the `MOQ_*` vars via `env = ...`, so a value set in the host
-	/// environment would make these assertions pass for the wrong reason. The
-	/// restore keeps the rest of the test process seeing the environment it
-	/// started with, rather than one the suite quietly emptied.
-	struct EnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
-
-	impl EnvGuard {
-		/// Removes each variable, remembering what it held.
-		///
-		/// The caller must hold the matching per-group mutex: the process env is
-		/// shared, and the restore on drop is as racy as the removal here.
-		fn clear(vars: &[&'static str]) -> Self {
-			Self(
-				vars.iter()
-					.map(|&key| {
-						let prev = std::env::var_os(key);
-						// SAFETY: the caller's group mutex serializes env access.
-						unsafe { std::env::remove_var(key) };
-						(key, prev)
-					})
-					.collect(),
-			)
-		}
-	}
-
-	impl Drop for EnvGuard {
-		fn drop(&mut self) {
-			for (key, prev) in &self.0 {
-				// SAFETY: the caller's group mutex is still held; see `clear`.
-				match prev {
-					Some(value) => unsafe { std::env::set_var(key, value) },
-					None => unsafe { std::env::remove_var(key) },
-				}
-			}
-		}
-	}
-
-	/// Serializes tests that touch `MOQ_STATS_*`. Cargo runs tests in parallel
-	/// within a single binary, and `env::set_var` / `remove_var` are not
-	/// thread-safe with concurrent env reads (which is why they're `unsafe` as
-	/// of Rust 1.80). Any test that mutates this env must hold this lock.
-	static STATS_ENV_LOCK: Mutex<()> = Mutex::new(());
+	use crate::test_env::EnvGuard;
 
 	/// Regression test for the clap+TOML interaction documented on
 	/// `Config::parse_and_merge`. A TOML file that enables stats with no
@@ -171,7 +124,6 @@ mod tests {
 	/// stats publishing for any deployment that configured it via TOML.
 	#[test]
 	fn cli_does_not_clobber_toml_stats_enabled() {
-		let _guard = STATS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&["MOQ_STATS_ENABLED", "MOQ_STATS_DEPTH"]);
 
 		let toml = r#"
@@ -204,16 +156,11 @@ depth = 2
 		assert_eq!(config.stats.depth, Some(2));
 	}
 
-	/// Serializes tests that touch `MOQ_CACHE_*`. Same rationale as
-	/// `STATS_ENV_LOCK`.
-	static CACHE_ENV_LOCK: Mutex<()> = Mutex::new(());
-
 	/// Regression test for the clap+TOML clobber bug applied to `[cache]`. Both
 	/// fields are `Option<String>` so a TOML-configured cache size survives the
 	/// CLI re-parse when no `--cache-*` flag is passed.
 	#[test]
 	fn cli_does_not_clobber_toml_cache() {
-		let _guard = CACHE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&["MOQ_CACHE_CAPACITY", "MOQ_CACHE_HEADROOM", "MOQ_CACHE_DURATION"]);
 
 		let toml = r#"
@@ -261,16 +208,11 @@ duration = "30s"
 		toml::to_string(&unset).expect("serialize None");
 	}
 
-	/// Serializes tests that touch `MOQ_CLUSTER_LINGER`. Same rationale as
-	/// `STATS_ENV_LOCK`.
-	static LINGER_ENV_LOCK: Mutex<()> = Mutex::new(());
-
 	/// Regression test for the clap+TOML clobber bug applied to `cluster.linger`.
 	/// The field is `Option<Duration>` so a TOML-configured window survives the
 	/// CLI re-parse when no `--cluster-linger` flag is passed.
 	#[test]
 	fn cli_does_not_clobber_toml_linger() {
-		let _guard = LINGER_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&["MOQ_CLUSTER_LINGER"]);
 
 		let toml = r#"
@@ -292,10 +234,6 @@ linger = "30s"
 		);
 	}
 
-	/// Serializes tests that touch `MOQ_SERVER_PREFERRED_V4` / `_V6`. Same
-	/// rationale as `STATS_ENV_LOCK`.
-	static PREFERRED_ENV_LOCK: Mutex<()> = Mutex::new(());
-
 	/// Regression test for the same clap+TOML clobber bug applied to the
 	/// `preferred_v4` / `preferred_v6` fields on `moq-native::ServerConfig`.
 	/// If either field is ever re-typed as a bare `SocketAddrV4` / `SocketAddrV6`
@@ -305,7 +243,6 @@ linger = "30s"
 	/// TOML. This test asserts the TOML value survives an absent CLI flag.
 	#[test]
 	fn cli_does_not_clobber_toml_preferred_addresses() {
-		let _guard = PREFERRED_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&["MOQ_SERVER_PREFERRED_V4", "MOQ_SERVER_PREFERRED_V6"]);
 
 		let toml = r#"
@@ -337,7 +274,6 @@ preferred_v6 = "[2001:db8::1]:443"
 	/// directory: a TOML-configured trace dir must survive the CLI re-parse.
 	#[test]
 	fn cli_does_not_clobber_toml_qlog() {
-		let _guard = PREFERRED_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&["MOQ_SERVER_QUIC_QLOG"]);
 
 		let toml = r#"
@@ -359,10 +295,6 @@ qlog = "/tmp/moq-qlog"
 		);
 	}
 
-	/// Serializes tests that touch `MOQ_*_QUIC_CONGESTION_CONTROL`. Same
-	/// rationale as `STATS_ENV_LOCK`.
-	static CONGESTION_ENV_LOCK: Mutex<()> = Mutex::new(());
-
 	/// Regression test for the clap+TOML clobber bug applied to the
 	/// `congestion_control` fields on the quic sections of
 	/// `moq-native::ServerConfig` / `ClientConfig`. The fields must stay
@@ -370,7 +302,6 @@ qlog = "/tmp/moq-qlog"
 	/// CLI re-parse when no `--*-quic-congestion-control` flag is passed.
 	#[test]
 	fn cli_does_not_clobber_toml_congestion_control() {
-		let _guard = CONGESTION_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&[
 			"MOQ_SERVER_QUIC_CONGESTION_CONTROL",
 			"MOQ_CLIENT_QUIC_CONGESTION_CONTROL",
@@ -403,13 +334,8 @@ congestion_control = "loss"
 		);
 	}
 
-	/// Serializes tests that touch `MOQ_WEB_HTTPS_*`. Same rationale as
-	/// `STATS_ENV_LOCK`.
-	static WEB_HTTPS_ENV_LOCK: Mutex<()> = Mutex::new(());
-
 	#[test]
 	fn cli_does_not_clobber_toml_web_https_cert_arrays() {
-		let _guard = WEB_HTTPS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&["MOQ_WEB_HTTPS_CERT", "MOQ_WEB_HTTPS_KEY"]);
 
 		let toml = r#"
@@ -447,7 +373,6 @@ key = ["cdn.key", "moq-pro.key"]
 	/// path.
 	#[test]
 	fn cli_flag_overrides_toml_stats_enabled() {
-		let _guard = STATS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&["MOQ_STATS_ENABLED"]);
 
 		let toml = "[stats]\nenabled = true\n";
@@ -468,11 +393,8 @@ key = ["cdn.key", "moq-pro.key"]
 	/// Same clap+TOML clobber guard applied to `auth.auth_api`. It's typed as
 	/// `Option<String>` so an absent `--auth-api` CLI flag must not wipe a
 	/// TOML-configured value during the `update_from` re-parse.
-	static AUTH_API_ENV_LOCK: Mutex<()> = Mutex::new(());
-
 	#[test]
 	fn cli_does_not_clobber_toml_auth_api() {
-		let _guard = AUTH_API_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&["MOQ_AUTH_API"]);
 
 		let toml = r#"
@@ -499,11 +421,8 @@ auth_api = "https://api.moq.dev/cluster/auth"
 	/// TOML-configured value during the `update_from` re-parse. A bare `bool`
 	/// would reset it to `false`, silently dropping the system roots for a
 	/// cluster client that opted into trusting both system and custom roots.
-	static SYSTEM_ROOTS_ENV_LOCK: Mutex<()> = Mutex::new(());
-
 	#[test]
 	fn cli_does_not_clobber_toml_system_roots() {
-		let _guard = SYSTEM_ROOTS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&["MOQ_CLIENT_TLS_SYSTEM_ROOTS"]);
 
 		let toml = r#"
@@ -530,11 +449,8 @@ system_roots = true
 	/// during the `update_from` re-parse. A bare `u64` would reset it to `0`,
 	/// which the cluster treats as reserved and silently swaps for a random id,
 	/// defeating the point of pinning a stable origin via TOML.
-	static CLUSTER_ID_ENV_LOCK: Mutex<()> = Mutex::new(());
-
 	#[test]
 	fn cli_does_not_clobber_toml_cluster_id() {
-		let _guard = CLUSTER_ID_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&["MOQ_CLUSTER_ID"]);
 
 		let toml = r#"
@@ -558,11 +474,8 @@ id = 12345
 
 	/// The per-site stats tier flags are `Option<String>`, so an absent CLI flag
 	/// must not wipe a TOML value during the `update_from` re-parse.
-	static TIER_ENV_LOCK: Mutex<()> = Mutex::new(());
-
 	#[test]
 	fn cli_does_not_clobber_toml_tiers() {
-		let _guard = TIER_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&["MOQ_CLUSTER_TIER", "MOQ_AUTH_MTLS_TIER"]);
 
 		let toml = r#"
@@ -597,12 +510,8 @@ mtls_tier = "edge"
 	/// `update_from` re-parse when their CLI flags are absent, or a TOML-configured
 	/// Unix listener (and its allowlist) gets silently dropped.
 	#[cfg(all(feature = "uds", unix))]
-	static SERVER_UNIX_ENV_LOCK: Mutex<()> = Mutex::new(());
-
-	#[cfg(all(feature = "uds", unix))]
 	#[test]
 	fn cli_does_not_clobber_toml_server_unix() {
-		let _guard = SERVER_UNIX_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&["MOQ_SERVER_UNIX_BIND", "MOQ_SERVER_UNIX_ALLOW_UID"]);
 
 		let toml = r#"
@@ -638,7 +547,6 @@ uid = [1001]
 
 	#[test]
 	fn cli_flag_overrides_toml_cluster_id() {
-		let _guard = CLUSTER_ID_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&["MOQ_CLUSTER_ID"]);
 
 		let toml = "[cluster]\nid = 12345\n";
@@ -656,10 +564,6 @@ uid = [1001]
 		assert_eq!(config.cluster.id, Some(67890));
 	}
 
-	/// Serializes tests that touch `MOQ_INTERNAL_LISTEN`. Same rationale as
-	/// `STATS_ENV_LOCK`.
-	static INTERNAL_ENV_LOCK: Mutex<()> = Mutex::new(());
-
 	/// Regression test for the same clap+TOML clobber bug on `internal.listen`
 	/// (the `--internal-listen` / `MOQ_INTERNAL_LISTEN` ops listener). It's an
 	/// `Option<SocketAddr>`, so an absent CLI flag must leave the TOML value
@@ -667,7 +571,6 @@ uid = [1001]
 	/// re-parse would overwrite a TOML-configured listener with the default.
 	#[test]
 	fn cli_does_not_clobber_toml_internal_listen() {
-		let _guard = INTERNAL_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 		let _env = EnvGuard::clear(&["MOQ_INTERNAL_LISTEN"]);
 
 		let toml = "[internal]\nlisten = \"127.0.0.1:9101\"\n";

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -115,6 +115,46 @@ mod tests {
 
 	use super::*;
 
+	/// Clears environment variables for the duration of a test, restoring what
+	/// they held (or their absence) on drop.
+	///
+	/// clap reads the `MOQ_*` vars via `env = ...`, so a value set in the host
+	/// environment would make these assertions pass for the wrong reason. The
+	/// restore keeps the rest of the test process seeing the environment it
+	/// started with, rather than one the suite quietly emptied.
+	struct EnvGuard(Vec<(&'static str, Option<std::ffi::OsString>)>);
+
+	impl EnvGuard {
+		/// Removes each variable, remembering what it held.
+		///
+		/// The caller must hold the matching per-group mutex: the process env is
+		/// shared, and the restore on drop is as racy as the removal here.
+		fn clear(vars: &[&'static str]) -> Self {
+			Self(
+				vars.iter()
+					.map(|&key| {
+						let prev = std::env::var_os(key);
+						// SAFETY: the caller's group mutex serializes env access.
+						unsafe { std::env::remove_var(key) };
+						(key, prev)
+					})
+					.collect(),
+			)
+		}
+	}
+
+	impl Drop for EnvGuard {
+		fn drop(&mut self) {
+			for (key, prev) in &self.0 {
+				// SAFETY: the caller's group mutex is still held; see `clear`.
+				match prev {
+					Some(value) => unsafe { std::env::set_var(key, value) },
+					None => unsafe { std::env::remove_var(key) },
+				}
+			}
+		}
+	}
+
 	/// Serializes tests that touch `MOQ_STATS_*`. Cargo runs tests in parallel
 	/// within a single binary, and `env::set_var` / `remove_var` are not
 	/// thread-safe with concurrent env reads (which is why they're `unsafe` as
@@ -132,13 +172,7 @@ mod tests {
 	#[test]
 	fn cli_does_not_clobber_toml_stats_enabled() {
 		let _guard = STATS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// clap reads MOQ_STATS_* via `env = ...`. If the host environment has
-		// one set, the test would pass for the wrong reason. Clear them for the
-		// duration of this test (lock above serializes with sibling tests).
-		// SAFETY: STATS_ENV_LOCK ensures no other test in this binary touches
-		// these env vars concurrently.
-		unsafe { std::env::remove_var("MOQ_STATS_ENABLED") };
-		unsafe { std::env::remove_var("MOQ_STATS_DEPTH") };
+		let _env = EnvGuard::clear(&["MOQ_STATS_ENABLED", "MOQ_STATS_DEPTH"]);
 
 		let toml = r#"
 [stats]
@@ -180,13 +214,7 @@ depth = 2
 	#[test]
 	fn cli_does_not_clobber_toml_cache() {
 		let _guard = CACHE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// SAFETY: CACHE_ENV_LOCK ensures no other test in this binary touches
-		// these env vars concurrently.
-		unsafe {
-			std::env::remove_var("MOQ_CACHE_CAPACITY");
-			std::env::remove_var("MOQ_CACHE_HEADROOM");
-			std::env::remove_var("MOQ_CACHE_DURATION");
-		}
+		let _env = EnvGuard::clear(&["MOQ_CACHE_CAPACITY", "MOQ_CACHE_HEADROOM", "MOQ_CACHE_DURATION"]);
 
 		let toml = r#"
 [cache]
@@ -243,11 +271,7 @@ duration = "30s"
 	#[test]
 	fn cli_does_not_clobber_toml_linger() {
 		let _guard = LINGER_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// SAFETY: LINGER_ENV_LOCK ensures no other test in this binary touches
-		// this env var concurrently.
-		unsafe {
-			std::env::remove_var("MOQ_CLUSTER_LINGER");
-		}
+		let _env = EnvGuard::clear(&["MOQ_CLUSTER_LINGER"]);
 
 		let toml = r#"
 [cluster]
@@ -282,12 +306,7 @@ linger = "30s"
 	#[test]
 	fn cli_does_not_clobber_toml_preferred_addresses() {
 		let _guard = PREFERRED_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// SAFETY: PREFERRED_ENV_LOCK ensures no other test in this binary
-		// touches these env vars concurrently.
-		unsafe {
-			std::env::remove_var("MOQ_SERVER_PREFERRED_V4");
-			std::env::remove_var("MOQ_SERVER_PREFERRED_V6");
-		}
+		let _env = EnvGuard::clear(&["MOQ_SERVER_PREFERRED_V4", "MOQ_SERVER_PREFERRED_V6"]);
 
 		let toml = r#"
 [server.quic]
@@ -319,11 +338,7 @@ preferred_v6 = "[2001:db8::1]:443"
 	#[test]
 	fn cli_does_not_clobber_toml_qlog() {
 		let _guard = PREFERRED_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// SAFETY: PREFERRED_ENV_LOCK ensures no other test in this binary
-		// touches these env vars concurrently.
-		unsafe {
-			std::env::remove_var("MOQ_SERVER_QUIC_QLOG");
-		}
+		let _env = EnvGuard::clear(&["MOQ_SERVER_QUIC_QLOG"]);
 
 		let toml = r#"
 [server.quic]
@@ -356,12 +371,10 @@ qlog = "/tmp/moq-qlog"
 	#[test]
 	fn cli_does_not_clobber_toml_congestion_control() {
 		let _guard = CONGESTION_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// SAFETY: CONGESTION_ENV_LOCK ensures no other test in this binary
-		// touches these env vars concurrently.
-		unsafe {
-			std::env::remove_var("MOQ_SERVER_QUIC_CONGESTION_CONTROL");
-			std::env::remove_var("MOQ_CLIENT_QUIC_CONGESTION_CONTROL");
-		}
+		let _env = EnvGuard::clear(&[
+			"MOQ_SERVER_QUIC_CONGESTION_CONTROL",
+			"MOQ_CLIENT_QUIC_CONGESTION_CONTROL",
+		]);
 
 		let toml = r#"
 [server.quic]
@@ -397,12 +410,7 @@ congestion_control = "loss"
 	#[test]
 	fn cli_does_not_clobber_toml_web_https_cert_arrays() {
 		let _guard = WEB_HTTPS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// SAFETY: WEB_HTTPS_ENV_LOCK ensures no other test in this binary
-		// touches these env vars concurrently.
-		unsafe {
-			std::env::remove_var("MOQ_WEB_HTTPS_CERT");
-			std::env::remove_var("MOQ_WEB_HTTPS_KEY");
-		}
+		let _env = EnvGuard::clear(&["MOQ_WEB_HTTPS_CERT", "MOQ_WEB_HTTPS_KEY"]);
 
 		let toml = r#"
 [web.https]
@@ -440,9 +448,7 @@ key = ["cdn.key", "moq-pro.key"]
 	#[test]
 	fn cli_flag_overrides_toml_stats_enabled() {
 		let _guard = STATS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// SAFETY: STATS_ENV_LOCK ensures no other test in this binary touches
-		// this env var concurrently.
-		unsafe { std::env::remove_var("MOQ_STATS_ENABLED") };
+		let _env = EnvGuard::clear(&["MOQ_STATS_ENABLED"]);
 
 		let toml = "[stats]\nenabled = true\n";
 		let dir = std::env::temp_dir().join("moq-relay-config-test");
@@ -467,9 +473,7 @@ key = ["cdn.key", "moq-pro.key"]
 	#[test]
 	fn cli_does_not_clobber_toml_auth_api() {
 		let _guard = AUTH_API_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// SAFETY: AUTH_API_ENV_LOCK serializes this with any sibling test touching
-		// the same env var.
-		unsafe { std::env::remove_var("MOQ_AUTH_API") };
+		let _env = EnvGuard::clear(&["MOQ_AUTH_API"]);
 
 		let toml = r#"
 [auth]
@@ -500,9 +504,7 @@ auth_api = "https://api.moq.dev/cluster/auth"
 	#[test]
 	fn cli_does_not_clobber_toml_system_roots() {
 		let _guard = SYSTEM_ROOTS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// SAFETY: SYSTEM_ROOTS_ENV_LOCK serializes this with any sibling test
-		// touching the same env var.
-		unsafe { std::env::remove_var("MOQ_CLIENT_TLS_SYSTEM_ROOTS") };
+		let _env = EnvGuard::clear(&["MOQ_CLIENT_TLS_SYSTEM_ROOTS"]);
 
 		let toml = r#"
 [client.tls]
@@ -533,9 +535,7 @@ system_roots = true
 	#[test]
 	fn cli_does_not_clobber_toml_cluster_id() {
 		let _guard = CLUSTER_ID_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// SAFETY: CLUSTER_ID_ENV_LOCK serializes this with any sibling test
-		// touching the same env var.
-		unsafe { std::env::remove_var("MOQ_CLUSTER_ID") };
+		let _env = EnvGuard::clear(&["MOQ_CLUSTER_ID"]);
 
 		let toml = r#"
 [cluster]
@@ -563,12 +563,7 @@ id = 12345
 	#[test]
 	fn cli_does_not_clobber_toml_tiers() {
 		let _guard = TIER_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// SAFETY: TIER_ENV_LOCK serializes this with any sibling test touching
-		// the same env vars.
-		unsafe {
-			std::env::remove_var("MOQ_CLUSTER_TIER");
-			std::env::remove_var("MOQ_AUTH_MTLS_TIER");
-		}
+		let _env = EnvGuard::clear(&["MOQ_CLUSTER_TIER", "MOQ_AUTH_MTLS_TIER"]);
 
 		let toml = r#"
 [cluster]
@@ -608,12 +603,7 @@ mtls_tier = "edge"
 	#[test]
 	fn cli_does_not_clobber_toml_server_unix() {
 		let _guard = SERVER_UNIX_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// SAFETY: SERVER_UNIX_ENV_LOCK serializes this with any sibling test
-		// touching the same env vars.
-		unsafe {
-			std::env::remove_var("MOQ_SERVER_UNIX_BIND");
-			std::env::remove_var("MOQ_SERVER_UNIX_ALLOW_UID");
-		}
+		let _env = EnvGuard::clear(&["MOQ_SERVER_UNIX_BIND", "MOQ_SERVER_UNIX_ALLOW_UID"]);
 
 		let toml = r#"
 [server]
@@ -649,9 +639,7 @@ uid = [1001]
 	#[test]
 	fn cli_flag_overrides_toml_cluster_id() {
 		let _guard = CLUSTER_ID_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// SAFETY: CLUSTER_ID_ENV_LOCK serializes this with any sibling test
-		// touching the same env var.
-		unsafe { std::env::remove_var("MOQ_CLUSTER_ID") };
+		let _env = EnvGuard::clear(&["MOQ_CLUSTER_ID"]);
 
 		let toml = "[cluster]\nid = 12345\n";
 		let dir = std::env::temp_dir().join("moq-relay-config-test");
@@ -680,9 +668,7 @@ uid = [1001]
 	#[test]
 	fn cli_does_not_clobber_toml_internal_listen() {
 		let _guard = INTERNAL_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-		// SAFETY: INTERNAL_ENV_LOCK serializes this with any sibling test
-		// touching the same env var.
-		unsafe { std::env::remove_var("MOQ_INTERNAL_LISTEN") };
+		let _env = EnvGuard::clear(&["MOQ_INTERNAL_LISTEN"]);
 
 		let toml = "[internal]\nlisten = \"127.0.0.1:9101\"\n";
 		let dir = std::env::temp_dir().join("moq-relay-config-test");

--- a/rs/moq-relay/src/lib.rs
+++ b/rs/moq-relay/src/lib.rs
@@ -15,6 +15,8 @@ mod connection;
 mod http_client;
 mod internal;
 mod stats;
+#[cfg(test)]
+mod test_env;
 mod web;
 #[cfg(feature = "websocket")]
 mod websocket;

--- a/rs/moq-relay/src/test_env.rs
+++ b/rs/moq-relay/src/test_env.rs
@@ -1,0 +1,63 @@
+//! Serializes the tests that touch the process environment.
+
+use std::ffi::OsString;
+use std::sync::{Mutex, MutexGuard};
+
+/// One lock for every test that reads or writes the process environment.
+///
+/// `env::set_var` / `remove_var` are not thread-safe against a concurrent read,
+/// which is why they're `unsafe`, and clap reads the `MOQ_*` vars while it
+/// parses. Per-variable-group locks aren't enough: they let one group clear its
+/// vars while another group is inside `Config::parse_and_merge` reading the
+/// environment. A single lock is what actually makes that pairing safe, and
+/// these tests are fast enough that serializing them costs nothing.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Holds [`ENV_LOCK`] for as long as a test needs the environment to itself,
+/// restoring anything it cleared on drop.
+///
+/// Tests clear the `MOQ_*` vars so a value in the developer's environment can't
+/// make an assertion pass for the wrong reason. Restoring on drop keeps the rest
+/// of the test process seeing the environment it started with.
+pub(crate) struct EnvGuard {
+	_lock: MutexGuard<'static, ()>,
+	saved: Vec<(&'static str, Option<OsString>)>,
+}
+
+impl EnvGuard {
+	/// Takes the lock without touching a variable, for a test that only reads
+	/// the environment (parsing a config) and must not race a writer.
+	pub(crate) fn lock() -> Self {
+		Self::clear(&[])
+	}
+
+	/// Takes the lock, then removes each variable, remembering what it held.
+	pub(crate) fn clear(vars: &[&'static str]) -> Self {
+		let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+		let saved = vars
+			.iter()
+			.map(|&key| {
+				let prev = std::env::var_os(key);
+				// SAFETY: ENV_LOCK is held, and every test that touches the
+				// environment takes it, so nothing else reads or writes here.
+				unsafe { std::env::remove_var(key) };
+				(key, prev)
+			})
+			.collect();
+
+		Self { _lock: lock, saved }
+	}
+}
+
+impl Drop for EnvGuard {
+	fn drop(&mut self) {
+		// Runs before `_lock` is dropped, so the restore is still serialized.
+		for (key, prev) in &self.saved {
+			// SAFETY: ENV_LOCK is still held; see `clear`.
+			match prev {
+				Some(value) => unsafe { std::env::set_var(key, value) },
+				None => unsafe { std::env::remove_var(key) },
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two related fixes to the `moq-relay` config tests, both about the process environment being global shared state.

**1. Restore what the tests clear.** The `cli_does_not_clobber_toml_*` tests clear the `MOQ_*` vars that clap reads via `env = ...`, so a value in the host environment can't make an assertion pass for the wrong reason. They never put those values back, so a variable the developer had set was silently destroyed for the remainder of the test process. `EnvGuard` snapshots each variable with `var_os`, removes it, and on `Drop` restores the prior value (or re-removes it when it was originally unset).

**2. Serialize on one lock.** The per-group mutexes only serialized tests mutating the *same* variable group. Since clap reads the environment while parsing, a test clearing its own group could still race a sibling group's `Config::parse_and_merge` reading it. That is precisely the data race `set_var`/`remove_var` are `unsafe` for, and the restore in (1) would have made those writes more frequent. The two config-merge tests in `cluster.rs` held no lock at all. So the twelve per-group mutexes collapse into one `ENV_LOCK`.

The lock is folded *into* `EnvGuard` rather than sitting beside it, so it can't be forgotten: the guard holds it from the snapshot through the restore in `Drop`. `EnvGuard::lock()` covers tests that only read the environment via clap. Both live in a new `#[cfg(test)] mod test_env`, shared by `config.rs` and `cluster.rs`. Serializing costs nothing here (the whole lib suite runs in ~0.25s).

Raised by CodeRabbit: the restore-only version on #2494, and the single-lock point on this PR.

## Public API changes

None. `test_env` is `#[cfg(test)]` and `EnvGuard` is `pub(crate)`; no shipped code path is touched. In particular `Config::parse_and_merge` does **not** acquire the lock. Keeping a test-only mutex out of the production config path is deliberate; the callers take it instead.

## Test plan

- `nix develop --command cargo test -p moq-relay --lib` -> 149 passed, 0 failed.
- `cargo clippy -p moq-relay --lib --tests` and `cargo fmt -p moq-relay -- --check` -> clean.
- Restore behavior verified directly rather than assumed: a temporary probe test, run single-threaded with `MOQ_CLUSTER_ID=999` in the environment, asserted the var was absent inside the guard scope, equal to its prior value after drop, and that a never-set var stayed unset. It passed; the probe was then removed, since a permanent version would mutate process env without being able to serialize against every other test in the binary.

Note: `cargo clippy -p moq-relay --all-targets` fails in my worktree, but inside `aws-lc-sys` (clang compiling `ios-aarch64/crypto/test/trampoline-armv8.S`), unrelated to any Rust code here. The lib and test targets compile and lint clean.

## Cross-Package Sync

No rows apply: test-only change, no wire format, config surface, or CLI flag touched.

(Written by Opus 5)