### PR TITLE
fix(net): tear down idle upstream subscriptions

### DIFF
--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -1822,27 +1822,20 @@ async fn broadcast_race_quic_wins() {
 		.expect("server task failed");
 }
 
-// ── Linger: relay-style subscription reuse ──────────────────────────
+// ── Subscription churn: drop the last consumer, then come back ──────
 //
-// When the last consumer of an upstream subscription drops, the relay keeps
-// the TrackProducer alive briefly so a returning consumer reuses it instead
-// of triggering a fresh upstream Subscribe. This is the moq-lite linger
-// behavior: on `track.unused()` the subscriber sends `SubscribeUpdate(priority=0)`
-// + FIN, then waits up to LINGER_TIMEOUT for either the upstream to FIN back,
-// the timeout to expire, or a new consumer to arrive (resume with
-// `start_group = max + 1`).
-//
-// Reliably distinguishing the Reused vs Complete vs Cancelled branches from a
-// black-box client test is hard because all three paths converge on the same
-// observable behavior at the consumer (groups eventually flow). What we *can*
-// test cheaply here is the end-to-end smoke: subscribe → drop → resubscribe
-// must keep working, with a fresh group flowing afterwards.
+// When the last consumer of an upstream subscription drops, the subscriber
+// cancels the upstream SUBSCRIBE (FIN) rather than parking it. The track
+// producer stays alive, so a returning consumer re-establishes a fresh
+// SUBSCRIBE against the same cache. These tests cover both halves: the
+// re-subscribe keeps flowing, and the cancel actually releases the
+// publisher's viewer accounting.
 
-/// Smoke test: dropping the last consumer and resubscribing within the linger
-/// window doesn't wedge the subscription, and groups appended after the resume
-/// still arrive at the new consumer.
+/// Smoke test: dropping the last consumer and resubscribing doesn't wedge the
+/// subscription, and groups appended after the resume still arrive at the new
+/// consumer.
 #[tokio::test]
-async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
+async fn resubscribe_keeps_flowing_moq_lite_03() {
 	let pub_origin = Origin::random().produce();
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
@@ -1907,20 +1900,18 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 		.expect("group closed early");
 	assert_eq!(&frame.payload[..], b"a");
 
-	// Drop the only consumer to trigger the linger phase.
+	// Drop the only consumer, canceling the upstream subscription.
 	drop(g);
 	drop(sub1);
 
-	// Yield a few times so the subscriber task can observe `track.unused()` and
-	// enter the linger select. A small real sleep also makes the test less
+	// Yield a few times so the subscriber task can observe the demand going away
+	// and send the FIN. A small real sleep also makes the test less
 	// scheduler-dependent across runtimes.
 	tokio::time::sleep(Duration::from_millis(20)).await;
 
-	// Resubscribe well inside the 5s linger window.
 	let mut sub2 = bc.track("video").unwrap().subscribe(None).await.expect("subscribe2");
 
-	// A new group published after the resubscribe must reach the consumer
-	// regardless of which linger branch fired.
+	// A new group published after the resubscribe must reach the consumer.
 	let mut group1 = track.append_group().expect("append group 1");
 	group1
 		.write_frame(moq_native::moq_net::Timestamp::ZERO, b"b".as_ref())
@@ -1948,6 +1939,116 @@ async fn linger_resubscribe_keeps_flowing_moq_lite_03() {
 	assert!(
 		saw_group1,
 		"expected group 1 to be delivered to the resubscribed consumer"
+	);
+
+	drop(session);
+	server_handle
+		.await
+		.expect("server task panicked")
+		.expect("server task failed");
+}
+
+/// Active viewers on the publisher, summed across every tier. This is the number
+/// the relay's stats broadcast reports as viewers of a broadcast.
+fn active_viewers(registry: &moq_net::stats::Registry) -> u64 {
+	registry
+		.snapshot()
+		.traffic()
+		.into_iter()
+		.filter(|(_, role, _)| matches!(role, moq_net::stats::Role::Publisher))
+		.map(|(_, _, traffic)| traffic.active_broadcasts())
+		.sum()
+}
+
+/// The last consumer leaving must release the publisher's viewer refcount.
+///
+/// A subscriber that parks its upstream SUBSCRIBE instead of canceling it leaves
+/// the publisher's per-session subscription alive, so the broadcast keeps
+/// reporting a viewer that nobody is watching (and, chained through relays, a
+/// phantom viewer per hop).
+#[tokio::test]
+async fn idle_subscription_releases_the_viewer_count() {
+	let pub_origin = Origin::random().produce();
+	let mut broadcast = pub_origin
+		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
+		.expect("create broadcast");
+	let mut track = broadcast.create_track("video", None).expect("create track");
+
+	let mut group = track.append_group().expect("append group");
+	group
+		.write_frame(moq_native::moq_net::Timestamp::ZERO, b"hello".as_ref())
+		.expect("write frame");
+	group.finish().expect("finish group");
+
+	let mut server_config = moq_native::ServerConfig::default();
+	server_config.bind = Some("[::]:0".to_string());
+	server_config.tls.generate = vec!["localhost".into()];
+	let mut server = server_config.init().expect("init server");
+	let addr = server.local_addr().expect("server addr");
+
+	// The publisher counts viewers through a stats context, exactly like the relay.
+	let registry = moq_net::stats::Registry::new(moq_net::stats::Config::new());
+	let stats = registry.tier(moq_net::stats::Tier::default()).session("");
+
+	let sub_origin = Origin::random().produce();
+	let mut announcements = sub_origin.consume().announced();
+
+	let mut client_config = moq_native::ClientConfig::default();
+	client_config.tls.disable_verify = Some(true);
+	let client = client_config.init().expect("init client");
+	let url: url::Url = format!("moqt://localhost:{}", addr.port()).parse().unwrap();
+
+	let server_handle = tokio::spawn(async move {
+		let request = server.accept().await.expect("accept");
+		let session = request.with_publisher(&pub_origin).with_stats(stats).ok().await?;
+		let _broadcast = broadcast;
+		let _track = track;
+		let _ = session.closed().await;
+		Ok::<_, anyhow::Error>(())
+	});
+
+	let client = client.with_subscriber(sub_origin);
+	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+		.await
+		.expect("connect timeout")
+		.expect("connect failed");
+
+	let moq_native::moq_net::announce::Update { broadcast: bc, .. } =
+		tokio::time::timeout(TIMEOUT, announcements.next())
+			.await
+			.expect("announce timeout")
+			.expect("origin closed");
+	let bc = bc.expect("expected announce");
+
+	let mut sub = bc.track("video").unwrap().subscribe(None).await.expect("subscribe");
+	let mut g = tokio::time::timeout(TIMEOUT, sub.recv_group())
+		.await
+		.expect("recv group timeout")
+		.expect("recv group failed")
+		.expect("track closed early");
+	let frame = tokio::time::timeout(TIMEOUT, g.read_frame())
+		.await
+		.expect("read frame timeout")
+		.expect("read frame failed")
+		.expect("group closed early");
+	assert_eq!(&frame.payload[..], b"hello");
+	assert_eq!(active_viewers(&registry), 1, "the live consumer must count as a viewer");
+
+	// Stop watching, keeping the session (and its announce) open: a real viewer
+	// closing a player, not disconnecting.
+	drop(g);
+	drop(sub);
+
+	let released = tokio::time::timeout(TIMEOUT, async {
+		while active_viewers(&registry) != 0 {
+			tokio::time::sleep(Duration::from_millis(10)).await;
+		}
+	})
+	.await;
+	assert!(
+		released.is_ok(),
+		"viewer count stuck at {} after the last consumer left",
+		active_viewers(&registry)
 	);
 
 	drop(session);

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -1825,11 +1825,10 @@ async fn broadcast_race_quic_wins() {
 // ── Subscription churn: drop the last consumer, then come back ──────
 //
 // When the last consumer of an upstream subscription drops, the subscriber
-// cancels the upstream SUBSCRIBE (FIN) rather than parking it. The track
-// producer stays alive, so a returning consumer re-establishes a fresh
-// SUBSCRIBE against the same cache. These tests cover both halves: the
-// re-subscribe keeps flowing, and the cancel actually releases the
-// publisher's viewer accounting.
+// cancels the upstream SUBSCRIBE (FIN). The track producer stays alive, so a
+// returning consumer re-establishes a fresh SUBSCRIBE against the same cache.
+// These tests cover both halves: the re-subscribe keeps flowing, and the
+// cancel releases the publisher's viewer accounting.
 
 /// Smoke test: dropping the last consumer and resubscribing doesn't wedge the
 /// subscription, and groups appended after the resume still arrive at the new
@@ -1962,10 +1961,9 @@ fn active_viewers(registry: &moq_net::stats::Registry) -> u64 {
 
 /// The last consumer leaving must release the publisher's viewer refcount.
 ///
-/// A subscriber that parks its upstream SUBSCRIBE instead of canceling it leaves
-/// the publisher's per-session subscription alive, so the broadcast keeps
-/// reporting a viewer that nobody is watching (and, chained through relays, a
-/// phantom viewer per hop).
+/// The refcount is held by the publisher's per-session subscription, so an
+/// upstream SUBSCRIBE that outlives its demand keeps the broadcast reporting a
+/// viewer nobody is watching (chained through relays, one phantom per hop).
 #[tokio::test]
 async fn idle_subscription_releases_the_viewer_count() {
 	let pub_origin = Origin::random().produce();

--- a/rs/moq-net/src/error.rs
+++ b/rs/moq-net/src/error.rs
@@ -180,8 +180,13 @@ impl Error {
 
 	/// Convert a transport error into an [Error], decoding stream reset codes.
 	pub fn from_transport(err: impl web_transport_trait::Error) -> Self {
-		if let Some(code) = err.stream_error() {
-			return Self::Remote(code);
+		match err.stream_error() {
+			// Code 0 is what [`Self::Cancel`] encodes to, and what a plain stream
+			// drop sends: the peer is done with the stream, not failing. Decoding it
+			// back keeps a routine unsubscribe out of the error paths.
+			Some(0) => return Self::Cancel,
+			Some(code) => return Self::Remote(code),
+			None => {}
 		}
 
 		Self::Transport(err.to_string())

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -923,7 +923,8 @@ struct TrackServe<S: web_transport_trait::Session> {
 
 impl<S: web_transport_trait::Session> TrackServe<S> {
 	async fn run(self, request: track::Request) {
-		// SUBSCRIBE_UPDATE (and thus pause/resume) only exists on Lite03+.
+		// SUBSCRIBE_UPDATE only exists on Lite03+, so older peers can't carry a
+		// preference change to an established subscription.
 		let supports_update = !matches!(self.subscriber.version, Version::Lite01 | Version::Lite02);
 		let supports_fetch = self.subscriber.version.has_track_stream();
 

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -842,10 +842,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 struct SubStream<S: web_transport_trait::Session> {
 	stream: Stream<S, Version>,
 	id: u64,
-	/// Capped at the latest group and dropped to priority 0 because the last
-	/// downstream subscriber left. The stream stays open during the linger window
-	/// so a returning consumer resumes without a fresh SUBSCRIBE.
-	paused: bool,
 	/// Original SUBSCRIBE params, echoed in every SUBSCRIBE_UPDATE; refreshed as the
 	/// downstream aggregate changes.
 	ordered: bool,
@@ -916,9 +912,8 @@ enum Event {
 
 /// Serves one requested track for a relay: owns this session's copy of the
 /// track (spliced into the origin's logical track), driving the single upstream
-/// subscription (opened lazily on the first downstream subscriber,
-/// paused/resumed across consumer churn) concurrently with any number of
-/// one-shot fetches.
+/// subscription (opened lazily on the first downstream subscriber, canceled when
+/// the last one leaves) concurrently with any number of one-shot fetches.
 #[derive(Clone)]
 struct TrackServe<S: web_transport_trait::Session> {
 	subscriber: Subscriber<S>,
@@ -1140,7 +1135,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 	}
 
 	/// Apply a subscription-demand change: open the upstream SUBSCRIBE on the first
-	/// subscriber, resume/update it while live, or pause it when the last leaves.
+	/// subscriber, update it while live, or cancel it when the last one leaves.
 	async fn handle_subscription(
 		&self,
 		producer: &mut track::Producer,
@@ -1155,16 +1150,6 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 					// Open an upstream SUBSCRIBE for the first subscriber.
 					self.establish(producer, sub, subscription, timescale).await?;
 				}
-				Sub::Active(active) if active.paused => {
-					// A consumer returned: resume by uncapping.
-					active.paused = false;
-					active.priority = subscription.priority;
-					active.ordered = subscription.ordered;
-					active.max_latency = subscription.latency_max;
-					active.start_group = subscription.group_start;
-					self.send_update(active, subscription.group_end).await?;
-					tracing::info!(track = %self.name, "subscribe resumed");
-				}
 				Sub::Active(active) => {
 					// Downstream preferences changed: forward them upstream as a
 					// SUBSCRIBE_UPDATE (Lite03+ only; older peers can't carry one).
@@ -1178,29 +1163,11 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 				}
 			},
 			None => {
-				// Last subscriber left: pause the upstream (cap at the latest cached
-				// group, priority 0) but keep the stream open in case one returns.
-				if supports_update {
-					if let Sub::Active(active) = sub
-						&& !active.paused
-					{
-						active.paused = true;
-						active.start_group = None;
-						let cap = producer.latest().unwrap_or(0);
-						let update = lite::SubscribeUpdate {
-							priority: 0,
-							ordered: active.ordered,
-							max_latency: active.max_latency,
-							start_group: active.start_group,
-							end_group: Some(cap),
-						};
-						active.stream.writer.encode(&update).await?;
-					}
-				} else if let Sub::Active(active) = sub {
-					// No SUBSCRIBE_UPDATE to pause with (Lite01/02): cancel the
-					// upstream subscription outright, or it streams every group into
-					// the cache with zero consumers. A returning subscriber
-					// re-establishes from the current demand.
+				// Last subscriber left: cancel the upstream subscription outright. An
+				// idle subscription still streams every group into a cache nobody
+				// reads, and the upstream counts it as a live viewer of the broadcast.
+				// A returning subscriber re-establishes from the current demand.
+				if let Sub::Active(active) = sub {
 					self.subscriber.subscribes.lock().remove(&active.id);
 					let _ = active.stream.writer.finish();
 					tracing::info!(track = %self.name, "subscribe canceled (idle)");
@@ -1307,7 +1274,6 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		*sub = Sub::Active(SubStream {
 			stream,
 			id,
-			paused: false,
 			ordered: subscription.ordered,
 			max_latency: subscription.latency_max,
 			start_group: subscription.group_start,

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1210,6 +1210,11 @@ fn combined_subscription(subs: &Subscriptions, bound: Option<Duration>, waiter: 
 		if sub.is_closed() {
 			continue;
 		}
+		// Arm the closed waiter explicitly. `poll` below registers on the value
+		// channel only when it returns Pending, so a subscriber that contributes
+		// demand (always the case for the first one) would leave nothing watching
+		// for its departure, and the last one leaving would never wake this poll.
+		let _ = sub.poll_closed(waiter);
 		if let Poll::Ready(Ok(sub)) = sub.poll(waiter, |sub| sub.poll_combined(&combined)) {
 			combined = Some(sub);
 		}
@@ -2859,6 +2864,49 @@ mod test {
 			producer.subscription().is_none(),
 			"snapshot must exclude a dropped subscriber",
 		);
+	}
+
+	#[test]
+	fn dropped_subscriber_wakes_the_aggregate() {
+		// The value being right isn't enough: nothing re-polls the aggregate on its
+		// own, so the drop has to wake the waiter. A subscriber contributing demand
+		// takes `kio::Consumer::poll`'s Ready path, which registers no waiter, so
+		// the departure needs the closed waiter armed explicitly. Without it a relay
+		// never learns the last viewer left and holds the upstream subscription (and
+		// the upstream's viewer count) open forever.
+		use std::sync::atomic::{AtomicBool, Ordering};
+
+		let mut producer = track_producer("test", None);
+		let a = producer.subscribe(Subscription::default().with_priority(5));
+
+		let woken = Arc::new(AtomicBool::new(false));
+		let waiter = kio::Waiter::new(futures::task::waker(Arc::new(FlagWake(woken.clone()))));
+
+		// Prime the cursor, then confirm the next poll parks.
+		assert!(matches!(
+			producer.poll_subscription_changed(&waiter),
+			Poll::Ready(Ok(Some(_)))
+		));
+		assert!(
+			producer.poll_subscription_changed(&waiter).is_pending(),
+			"the aggregate is unchanged, so this poll must park",
+		);
+		assert!(!woken.load(Ordering::SeqCst), "nothing happened yet");
+
+		drop(a);
+		assert!(
+			woken.load(Ordering::SeqCst),
+			"the last subscriber leaving must wake the aggregate watcher",
+		);
+	}
+
+	/// An [`ArcWake`] that just records that it was woken.
+	struct FlagWake(Arc<std::sync::atomic::AtomicBool>);
+
+	impl futures::task::ArcWake for FlagWake {
+		fn wake_by_ref(arc_self: &Arc<Self>) {
+			arc_self.0.store(true, std::sync::atomic::Ordering::SeqCst);
+		}
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
## Summary

A broadcast kept reporting a viewer after the last real viewer stopped watching (observed on staging: `boy/big2small.hang` stuck at `1 viewer`, `boy/dangan.hang` dropping `2 -> 1` instead of `2 -> 0`). Two independent defects, both required to produce it:

- **The lite subscriber parked its upstream SUBSCRIBE instead of canceling it.** On Lite03+, the last downstream subscriber leaving sent `SUBSCRIBE_UPDATE(priority=0, end_group=cap)` and deliberately held the stream open for a quick resume. The upstream publisher's per-session `track::Subscriber` therefore stayed alive, so its `stats::Subscription` guard never dropped and the broadcast's viewer refcount never released. Chained through relays, that is one phantom viewer per hop. Now the `None` branch always cancels (drop the subscribe id, FIN the stream), which is what the Lite01/02 path and the IETF subscriber already did.

- **The demand aggregate never woke on the last-subscriber edge.** `combined_subscription` folds each subscriber via `kio::Consumer::poll`, which registers a waiter only on its `Pending` path. A subscriber contributing demand (always true of the first one) takes the `Ready` path and arms nothing, so when it later dropped, nothing woke `poll_subscription_changed`. The relay never learned demand had gone away and so never reached the teardown path at all. Fixed by arming `poll_closed` explicitly for each live subscriber.

The existing `dropped_subscriber_leaves_no_ghost_in_aggregate` test covers the aggregate's *value* on re-poll, which is why this survived: nothing asserted that the drop *wakes* the watcher.

Also: dropping the subscribe stream sends `STOP_SENDING(0)`, which `Error::from_transport` decoded as `Remote(0)` and the publisher logged at WARN as `subscribed error`. Since cancel-on-idle is now the common path, that would be a warning per departing viewer on every relay. Code 0 is exactly what `Error::Cancel` encodes to, so it now decodes back to `Cancel` and logs as a routine `subscribed cancelled`.

Likely also fixes moq-boy's auto-pause through a relay: that keys off `track.unused()` at the publisher, and a parked relay subscription kept the track used forever.

## Public API changes

None. `SubStream::paused` was a private field; `Error::from_transport` keeps its signature (only which variant it returns for stream code 0 changed).

## Cross-package sync

- `js/net` needs no mirror: its lite subscriber already closes the producer and stream on `unused()`. The Rust side was the outlier.
- No draft update: the pause was a local strategy, not wire behavior. `draft-lcurley-moq-lite` already states either endpoint may reset/cancel a Subscribe Stream at any time, and no message, field, or framing changed.

## Test plan

- `idle_subscription_releases_the_viewer_count` (new, `rs/moq-native/tests/broadcast.rs`): end-to-end against a `stats::Registry` on the publisher, asserting active viewers return to 0 after the last consumer drops while the session stays connected. Verified to fail with either fix reverted individually.
- `dropped_subscriber_wakes_the_aggregate` (new, `rs/moq-net/src/model/track.rs`): model-level, asserts the waker actually fires. Verified to fail without the `poll_closed` arm.
- `resubscribe_keeps_flowing_moq_lite_03` (renamed from `linger_*`): unchanged coverage that subscribe -> drop -> resubscribe still flows.
- `cargo test -p moq-net` (546) and `-p moq-native` (76) pass; `just rs check` (clippy `-D warnings`, fmt, rustdoc) passes. Full-workspace `cargo test --workspace --exclude moq-wasm`: 2232 tests across 39 suites, 0 failures.

(written by Opus 5)
