### PR TITLE
fix(libmoq): relocate includedir in the packaged moq.pc

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -166,6 +166,13 @@ let
       # template. Stays relocatable; no build-time path leaks into the store.
       sed -i 's#^libdir=.*#libdir=''${pcfiledir}/..#' $out/lib/pkgconfig/moq.pc
 
+      # Same relocation for includedir: the template points at the cargo tree's
+      # shared target/include (../../../ from the .pc). Here the header lives in
+      # $out/include, one level up from $out/lib, so it's ../../ from the .pc.
+      # Without this, pkg-config --cflags emits a bogus -I above $out and
+      # consumers fail with "moq.h: No such file or directory".
+      sed -i 's#^includedir=.*#includedir=''${pcfiledir}/../../include#' $out/lib/pkgconfig/moq.pc
+
       major_version="$(echo "${libmoqInfo.version}" | cut -d. -f1)"
       substitute ${../rs/libmoq/cmake/moq-config.cmake.in} \
         $out/lib/cmake/moq/moq-config.cmake \


### PR DESCRIPTION
## Problem

The libmoq release tarballs ship a broken `moq.pc`: `pkg-config --cflags moq` points `-I` at a directory that doesn't exist, so any pkg-config consumer fails to compile with:

```
fatal error: moq.h: No such file or directory
```

(The direct `-I/-L` and CMake `find_package(moq)` consumer paths work fine — they don't read the `.pc`.) This is why the interop smoke test's `c-pkgconfig` cell is red across every channel.

## Root cause

`moq.pc.in` is written for the raw cargo target tree, where the header is at `target/include` — three levels up from `target/<profile>/lib/pkgconfig/`:

```
includedir=${pcfiledir}/../../../include
```

The release/brew/nix layout relocates into `$out/{lib,include}`, so the header is only **two** levels up from `$out/lib/pkgconfig/`. `nix/overlay.nix`'s installPhase already rewrites `libdir` for this relocation, but never touched `includedir` — so it still resolves to `../../../include`, one directory **above** `$out`.

## Fix

Mirror the existing `libdir` rewrite with an `includedir` rewrite to `${pcfiledir}/../../include` (`pkgconfig → lib → $out`, then `/include`).

## Verification

Against the **published** `libmoq-v0.3.14` tarball, applying this exact rewrite:

- before: `-I…/lib/pkgconfig/../../../include` → resolves above the tarball root, no `moq.h`
- after: `-I…/lib/pkgconfig/../../include` → `…/include`, **`moq.h` present**, and the C pkg-config consumer compiles.

`nix-instantiate --parse` passes.

## Note

This corrects the packaging going forward; it doesn't retro-fix already-released tarballs. The interop smoke `c-pkgconfig` cell goes green once a libmoq release built with this lands.

(written by Opus 4.8)