### PR TITLE
feat(net): release idle spliced tracks after a linger

### DIFF
--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -891,6 +891,10 @@ enum Teardown {
 	/// The route or session failed: abort the track so the origin re-splices it
 	/// from another source.
 	GiveBack(Error),
+	/// The origin released this copy: nobody is reading it, so drop it (and the
+	/// `TRACK_INFO` behind it) rather than holding the state for a reader that
+	/// may never come back.
+	Released,
 }
 
 /// One step for the [`TrackServe`] loop, produced by racing track demand, the
@@ -906,6 +910,8 @@ enum Event {
 	SubResponse(lite::SubscribeResponse),
 	/// The upstream subscribe stream closed: `Ok` is a clean FIN, `Err` a transport error.
 	SubClosed(Result<(), Error>),
+	/// Every reader of this copy went away (the origin released it).
+	Unused,
 	/// The whole session died.
 	SessionClosed,
 }
@@ -1002,7 +1008,15 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 						}
 					}
 
-					// (3) The upstream subscribe stream closed, or carried a START/END/DROP.
+					// (3) Nobody reads this copy anymore: the origin released it after its
+					// idle linger, so drop it instead of holding the track state (and its
+					// TRACK_INFO) for a reader that may never return. In-flight fetches
+					// keep it alive: work already accepted still gets finished.
+					if fetches.is_empty() && serving.poll_unused(waiter).is_ready() {
+						return Poll::Ready(Event::Unused);
+					}
+
+					// (4) The upstream subscribe stream closed, or carried a START/END/DROP.
 					if let Poll::Ready(res) = waiter.poll_future(sub_msg.as_mut()) {
 						return Poll::Ready(match res {
 							Ok(Some(msg)) => Event::SubResponse(msg),
@@ -1011,7 +1025,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 						});
 					}
 
-					// (4) The session died: hand the track back for another route.
+					// (5) The session died: hand the track back for another route.
 					if waiter.poll_future(session_closed.as_mut()).is_ready() {
 						return Poll::Ready(Event::SessionClosed);
 					}
@@ -1071,6 +1085,10 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 					tracing::warn!(broadcast = %self.subscriber.log_path(&self.path), track = %self.name, %err, "subscribe error");
 					break Teardown::GiveBack(err);
 				}
+				Event::Unused => {
+					tracing::debug!(broadcast = %self.subscriber.log_path(&self.path), track = %self.name, "track released (idle)");
+					break Teardown::Released;
+				}
 				Event::SessionClosed => {
 					break Teardown::GiveBack(Error::Dropped);
 				}
@@ -1092,6 +1110,12 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 				// Mark this copy dead: subscribers stall while the origin
 				// re-splices the track from the next source.
 				let _ = serving.abort(err);
+			}
+			Teardown::Released => {
+				// A deliberate end with no reader to observe it, which also drops the
+				// cached groups. The origin re-requests the track from this session if
+				// one comes back.
+				let _ = serving.abort(Error::Cancel);
 			}
 		}
 	}

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -219,10 +219,10 @@ impl BroadcastState {
 	fn register_demand(&self, waiter: &kio::Waiter, want: bool) {
 		if let Some(spliced) = &self.spliced {
 			for track in spliced.tracks.values() {
-				match want {
+				let _ = match want {
 					true => track.poll_used(waiter),
 					false => track.poll_unused(waiter),
-				}
+				};
 			}
 			return;
 		}

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1064,7 +1064,13 @@ const MAX_TRACK_RETRIES: u32 = 3;
 /// fetches, reuses the source's copy: no new track request, and no second round
 /// trip for its `TRACK_INFO`. After it, the copy is released so an idle track
 /// costs nothing upstream.
-const TRACK_IDLE_LINGER: Duration = Duration::from_secs(5);
+///
+/// Sized above the fetch cadence of a segmented consumer: HLS polls every
+/// `TARGETDURATION` seconds, commonly 6 or 10, so a shorter window would drop the
+/// copy between every segment and re-request the track each time. A warm copy
+/// holds no upstream subscription (that is canceled as soon as demand ends), so
+/// waiting longer costs cached state, not a viewer.
+const TRACK_IDLE_LINGER: Duration = Duration::from_secs(30);
 
 /// One attached source in a [`FrontState`] table.
 struct FrontRoute {

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1058,6 +1058,14 @@ impl Producer {
 /// rejecting one track.
 const MAX_TRACK_RETRIES: u32 = 3;
 
+/// How long a spliced track stays warm after its last reader leaves.
+///
+/// Within the window a returning viewer, or the next of a run of back-to-back
+/// fetches, reuses the source's copy: no new track request, and no second round
+/// trip for its `TRACK_INFO`. After it, the copy is released so an idle track
+/// costs nothing upstream.
+const TRACK_IDLE_LINGER: Duration = Duration::from_secs(5);
+
 /// One attached source in a [`FrontState`] table.
 struct FrontRoute {
 	id: u64,
@@ -1508,6 +1516,10 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 		Splice(u64, broadcast::Consumer),
 		Complete,
 		Failed,
+		/// The linger expired with the track still unread: release the segment.
+		Idle,
+		/// A reader arrived or the last one left: recompute the demand gate.
+		Demand,
 	}
 
 	let mut fails = 0u32;
@@ -1517,51 +1529,101 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 	// about to detach it, so wait for the table to move on rather than burning
 	// the strike budget on a corpse (ids are never reused, so this cannot wedge).
 	let mut dead: Option<u64> = None;
+	// When the spliced segment stopped being read, starting the release countdown.
+	let mut idle_since: Option<web_async::time::Instant> = None;
 
 	loop {
 		let serving_id = serving.as_ref().map(|(id, _)| *id);
-		let step = kio::wait(|waiter| {
-			// Watch the source table: the front closing, or the active source
-			// moving away from the one currently spliced in (skipping one whose
-			// closure we already observed).
-			match state.poll(waiter, |s| {
-				if s.closed || matches!(s.active, Some(active) if Some(active) != serving_id && Some(active) != dead) {
-					Poll::Ready(())
-				} else {
-					Poll::Pending
-				}
-			}) {
-				Poll::Ready(Ok(guard)) => {
-					if guard.closed {
-						return Poll::Ready(Step::Closed);
-					}
-					let active = guard.active.expect("predicate guaranteed an active source");
-					let source = guard
-						.routes
-						.iter()
-						.find(|r| r.id == active)
-						.expect("active source in table")
-						.source
-						.clone();
-					return Poll::Ready(Step::Splice(active, source));
-				}
-				Poll::Ready(Err(_)) => return Poll::Ready(Step::Closed),
-				Poll::Pending => {}
-			}
 
-			// Watch the spliced copy for its end: complete means the logical
-			// track is over; anything else means the serving source died.
-			if let Some((_, track)) = &serving
-				&& let Poll::Ready(result) = track.poll_complete(waiter)
-			{
-				return Poll::Ready(match result {
-					Ok(()) => Step::Complete,
-					Err(_) => Step::Failed,
-				});
-			}
-			Poll::Pending
-		})
-		.await;
+		// Demand gates both directions: an unread track never splices a source in,
+		// and a spliced one is released once the linger expires. Both sides use the
+		// same signal, so a release can't immediately re-splice and spin.
+		let used = resume.is_used();
+		idle_since = match (serving.is_some(), used) {
+			(true, false) => idle_since.or_else(|| Some(web_async::time::Instant::now())),
+			_ => None,
+		};
+		let deadline = idle_since.and_then(|at| at.checked_add(TRACK_IDLE_LINGER));
+
+		let step = {
+			// Pinned outside the closure: a future re-created on every poll would
+			// restart the countdown each time and never fire. Fused via `fired`: a
+			// completed future must not be polled again.
+			let mut sleep = std::pin::pin!(async {
+				match deadline {
+					Some(at) => {
+						web_async::time::sleep(at.saturating_duration_since(web_async::time::Instant::now())).await
+					}
+					None => std::future::pending().await,
+				}
+			});
+			let mut fired = false;
+
+			kio::wait(|waiter| {
+				// Watch the source table: the front closing, or the active source
+				// moving away from the one currently spliced in (skipping one whose
+				// closure we already observed). Splicing waits for a reader.
+				match state.poll(waiter, |s| {
+					if s.closed
+						|| (used
+							&& matches!(s.active, Some(active) if Some(active) != serving_id && Some(active) != dead))
+					{
+						Poll::Ready(())
+					} else {
+						Poll::Pending
+					}
+				}) {
+					Poll::Ready(Ok(guard)) => {
+						if guard.closed {
+							return Poll::Ready(Step::Closed);
+						}
+						let active = guard.active.expect("predicate guaranteed an active source");
+						let source = guard
+							.routes
+							.iter()
+							.find(|r| r.id == active)
+							.expect("active source in table")
+							.source
+							.clone();
+						return Poll::Ready(Step::Splice(active, source));
+					}
+					Poll::Ready(Err(_)) => return Poll::Ready(Step::Closed),
+					Poll::Pending => {}
+				}
+
+				// Watch the demand edge in whichever direction is unmet. This has to end
+				// the wait, not just wake it: `used` and the countdown are computed by
+				// the outer loop, so a wake that stayed inside would re-poll with the
+				// stale value and never arm (or cancel) the linger.
+				let edge = match used {
+					true => resume.poll_unused(waiter),
+					false => resume.poll_used(waiter),
+				};
+				if edge.is_ready() {
+					return Poll::Ready(Step::Demand);
+				}
+
+				// Watch the spliced copy for its end: complete means the logical
+				// track is over; anything else means the serving source died.
+				if let Some((_, track)) = &serving
+					&& let Poll::Ready(result) = track.poll_complete(waiter)
+				{
+					return Poll::Ready(match result {
+						Ok(()) => Step::Complete,
+						Err(_) => Step::Failed,
+					});
+				}
+
+				if deadline.is_some() && !fired && waiter.poll_future(sleep.as_mut()).is_ready() {
+					fired = true;
+				}
+				if fired {
+					return Poll::Ready(Step::Idle);
+				}
+				Poll::Pending
+			})
+			.await
+		};
 
 		match step {
 			// The front's teardown aborts the logical track.
@@ -1573,6 +1635,19 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 			Step::Failed => {
 				// The spliced copy died mid-serve: failover, not a strike.
 				// Re-splice from the (possibly same) active source.
+				serving = None;
+			}
+			// The outer loop recomputes `used` and the countdown on the next pass.
+			Step::Demand => {}
+			Step::Idle => {
+				// Nobody has read the track for the linger: drop the source's copy so
+				// its session can release the track (and the cached `track::Info` that
+				// came with it). The logical track stays alive and re-splices on the
+				// next reader, so a returning viewer or a follow-up fetch resumes.
+				if resume.release().is_err() {
+					// Finished or aborted meanwhile; the track is over either way.
+					return;
+				}
 				serving = None;
 			}
 			Step::Splice(id, source) => {
@@ -3409,6 +3484,121 @@ mod tests {
 			!fresh.is_clone(&broadcast),
 			"re-create must not splice the old broadcast"
 		);
+	}
+
+	/// A track nobody reads keeps the source's copy for [`TRACK_IDLE_LINGER`], then
+	/// releases it. Crucially, the release must not immediately re-splice: the same
+	/// demand signal gates both directions, so an idle track settles instead of
+	/// re-requesting the track (and its info) every linger.
+	#[tokio::test(start_paused = true)]
+	async fn test_idle_track_releases_without_respinning() {
+		let origin = Info::new(Origin::random()).produce();
+		let consumer = origin.consume();
+
+		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		let producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+		let sub = subscribing.await.unwrap();
+
+		// The reader leaves, but the copy stays warm inside the window so a viewer
+		// coming back (or a follow-up fetch) reuses it.
+		drop(sub);
+		tokio::time::sleep(TRACK_IDLE_LINGER / 2).await;
+		settle().await;
+		assert!(
+			producer.poll_unused(&kio::Waiter::noop()).is_pending(),
+			"the copy must stay spliced inside the linger",
+		);
+
+		// Past the window the segment is released, so the serving session sees its
+		// copy go unused and can drop it (along with the track info).
+		tokio::time::sleep(TRACK_IDLE_LINGER).await;
+		settle().await;
+		assert!(
+			producer.poll_unused(&kio::Waiter::noop()).is_ready(),
+			"an idle copy must be released after the linger",
+		);
+
+		// The anti-spin property: the release must not re-arm the splice. Ungated,
+		// the loop re-attaches the copy immediately and drops it again every linger,
+		// re-requesting the track (and its info) from the session each time it dies.
+		for _ in 0..3 {
+			tokio::time::sleep(TRACK_IDLE_LINGER).await;
+			settle().await;
+			assert!(
+				producer.poll_unused(&kio::Waiter::noop()).is_ready(),
+				"an unread copy must stay released, not be re-spliced",
+			);
+		}
+		assert!(
+			dynamic.requested_track().now_or_never().is_none(),
+			"an unread track must not be re-requested",
+		);
+		drop(producer);
+
+		// A returning reader re-splices: the origin asks the source for a fresh copy.
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		let mut producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+		let mut sub = subscribing.await.unwrap();
+		producer.append_group().unwrap();
+		assert_eq!(sub.assert_group().sequence, 0);
+	}
+
+	/// Back-to-back fetches reuse the source's copy: only the first asks the source
+	/// for the track, so a fetch-driven consumer (HLS pulling segment after segment)
+	/// doesn't re-request the track, and its `TRACK_INFO`, for every group.
+	#[tokio::test(start_paused = true)]
+	async fn test_back_to_back_fetches_reuse_the_track() {
+		let origin = Info::new(Origin::random()).produce();
+		let consumer = origin.consume();
+
+		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+
+		// The first fetch has to ask the source for the track.
+		let fetching = broadcast.track("video").unwrap().fetch_group(0, None);
+		let mut producer = accept_track(&mut dynamic, "video").await;
+		producer.append_group().unwrap().finish().unwrap();
+		settle().await;
+		let first = fetching.await.expect("first fetch");
+		drop(first);
+
+		// A second fetch inside the linger reuses the copy already spliced in.
+		settle().await;
+		let fetching = broadcast.track("video").unwrap().fetch_group(0, None);
+		settle().await;
+		assert!(
+			dynamic.requested_track().now_or_never().is_none(),
+			"a fetch inside the linger must reuse the track, not re-request it",
+		);
+		drop(fetching.await.expect("second fetch"));
+
+		// Once the fetches stop, the copy is released like any other idle track.
+		tokio::time::sleep(TRACK_IDLE_LINGER * 2).await;
+		settle().await;
+		assert!(
+			producer.poll_unused(&kio::Waiter::noop()).is_ready(),
+			"the copy must be released once the fetches stop",
+		);
+		drop(producer);
+
+		// And a later fetch re-requests it: `accept_track` times out if it doesn't.
+		settle().await;
+		let fetching = broadcast.track("video").unwrap().fetch_group(0, None);
+		let mut producer = accept_track(&mut dynamic, "video").await;
+		producer.append_group().unwrap().finish().unwrap();
+		settle().await;
+		fetching.await.expect("fetch after the linger");
 	}
 
 	/// With a linger configured, an ungraceful source loss keeps the broadcast

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -212,6 +212,27 @@ impl Producer {
 		state.switch(track, start)
 	}
 
+	/// Drop every segment, releasing the underlying tracks while keeping the
+	/// logical track alive for a later [`Self::takeover`].
+	///
+	/// For a track nobody is reading: releasing the last consumer of a segment lets
+	/// the serving session tear its copy down, so an idle track stops costing an
+	/// upstream subscription and a cached [`track::Info`]. The next takeover starts
+	/// unbounded again, since with no segments there is no boundary to splice
+	/// around.
+	pub(crate) fn release(&mut self) -> Result<()> {
+		let mut state = self.state.write().map_err(|_| Error::Dropped)?;
+		if state.finished || state.abort.is_some() {
+			return Err(Error::Closed);
+		}
+		if state.segments.is_empty() {
+			return Ok(());
+		}
+		state.segments.clear();
+		state.epoch += 1;
+		Ok(())
+	}
+
 	/// Mark the logical track as complete: no further switches. Subscribers see a
 	/// clean end once the final segment's track finishes.
 	pub fn finish(&mut self) -> Result<()> {
@@ -254,16 +275,17 @@ impl Producer {
 		self.state.is_used()
 	}
 
-	/// Park `waiter` for the next consumer appearing; a no-op once one exists.
-	/// Feeds [`crate::broadcast::Demand`], which recomputes on wake.
-	pub(crate) fn poll_used(&self, waiter: &kio::Waiter) {
-		let _ = self.state.poll_used(waiter);
+	/// Poll for a consumer appearing, parking `waiter` until one does. Ready
+	/// immediately once one exists (or the track closed). Feeds
+	/// [`crate::broadcast::Demand`], which recomputes on wake.
+	pub(crate) fn poll_used(&self, waiter: &kio::Waiter) -> Poll<()> {
+		self.state.poll_used(waiter).map(|_| ())
 	}
 
-	/// Park `waiter` for the last consumer going away; a no-op once none remain.
-	/// Feeds [`crate::broadcast::Demand`].
-	pub(crate) fn poll_unused(&self, waiter: &kio::Waiter) {
-		let _ = self.state.poll_unused(waiter);
+	/// Poll for the last consumer going away, parking `waiter` until it does.
+	/// Ready immediately once none remain (or the track closed).
+	pub(crate) fn poll_unused(&self, waiter: &kio::Waiter) -> Poll<()> {
+		self.state.poll_unused(waiter).map(|_| ())
 	}
 }
 


### PR DESCRIPTION
## Summary

- A logical track held its source's copy for the broadcast's lifetime. `spliced.tracks` entries are never pruned and `serve_track` kept its segment spliced regardless of demand, so a track nobody reads kept an upstream subscription and a cached `TRACK_INFO` alive indefinitely.
- `serve_track` now gates on demand in **both** directions, with a 5s `TRACK_IDLE_LINGER`: an unread track never splices a source in, and a spliced one is released once the linger expires.
- Within the window the copy stays warm, so a returning viewer, or the next of a run of back-to-back fetches (the HLS fetch-per-segment shape), reuses it instead of paying for a fresh track request plus a round trip for `TRACK_INFO`.
- `TrackServe` (moq-lite subscriber) exits when its copy goes unused, which is what actually drops the `TRACK_INFO`. In-flight fetches keep it alive so accepted work still finishes.

Follow-up to #2500, which stopped idle subscriptions from being *parked*; this stops the track state behind them from being held forever.

### Why one demand signal, not two

Using the same signal for both directions is load-bearing. If the release and the re-splice disagree, a released segment is immediately re-spliced, dropped again at the next linger, and the track (with its info) is re-requested from the session every 5s, forever. `MAX_TRACK_RETRIES` does not stop that: a copy dying *after* a successful splice is explicitly "failover, not a strike", and the strike budget resets on each splice. The regression test below covers exactly this.

## Public API changes

None. `resume` is `pub(crate)`:

- Added `resume::Producer::release()` (`pub(crate)`): drops every segment while keeping the logical track alive for a later `takeover`.
- `resume::Producer::poll_used` / `poll_unused` now return `Poll<()>` instead of `()`, because the caller needs the demand edge to *end* the wait rather than just wake it. The only other caller, `broadcast::register_demand`, discards it.
- Added `Teardown::Released` and `Event::Unused` to the moq-lite subscriber's private track loop.

## Test plan

- `test_idle_track_releases_without_respinning` - warm inside the window, released after it, **stays** released across three lingers, and re-splices for a returning reader. Verified it fails with the demand gate removed.
- `test_back_to_back_fetches_reuse_the_track` - the second fetch inside the window files no new track request; a fetch after the window does. Both use paused time, so they are instant rather than sleeping 5s of wall clock.
- `cargo test -p moq-net` (550) and `cargo test -p moq-native` (174) pass; `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean.

## Cross-package sync

- No wire change, so no draft update: the linger is a local caching policy, and moq-lite already allows either endpoint to cancel a subscription at any time.
- No `js/net` mirror: this is origin-side splice machinery (`resume` / `serve_track`) that only the Rust implementation has. `js/net` already tears its subscription down on `unused()`.

(Written by Opus 5)