### PR TITLE
fix(moq-net): keep the clean end of a finished group that ages out

### DIFF
--- a/rs/moq-net/src/coding/writer.rs
+++ b/rs/moq-net/src/coding/writer.rs
@@ -75,9 +75,9 @@ impl<S: web_transport_trait::SendStream, V> Writer<S, V> {
 
 	/// Abort the stream with the given error.
 	///
-	/// Terminal: takes the stream, so the [`Drop`] fallback can't reset a second time and
-	/// overwrite the reason with a plain [`Error::Cancel`]. Writing after this panics.
-	pub fn abort(&mut self, err: &Error) {
+	/// Consumes the writer: a later write won't compile, and the [`Drop`] fallback can't
+	/// reset a second time and overwrite the reason with a plain [`Error::Cancel`].
+	pub fn abort(mut self, err: &Error) {
 		if let Some(mut stream) = self.stream.take() {
 			stream.reset(err.to_code());
 		}

--- a/rs/moq-net/src/coding/writer.rs
+++ b/rs/moq-net/src/coding/writer.rs
@@ -74,8 +74,13 @@ impl<S: web_transport_trait::SendStream, V> Writer<S, V> {
 	}
 
 	/// Abort the stream with the given error.
+	///
+	/// Terminal: takes the stream, so the [`Drop`] fallback can't reset a second time and
+	/// overwrite the reason with a plain [`Error::Cancel`]. Writing after this panics.
 	pub fn abort(&mut self, err: &Error) {
-		self.stream.as_mut().unwrap().reset(err.to_code());
+		if let Some(mut stream) = self.stream.take() {
+			stream.reset(err.to_code());
+		}
 	}
 
 	/// Wait for the stream to be closed, or the [Self::finish] to be acknowledged by the peer.

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1027,18 +1027,14 @@ mod test {
 	}
 }
 
-/// The announce loop's demand/linger state machine: a drained broadcast keeps
-/// advertising zero for `COST_LINGER` before the restart that restores its cold
-/// cost, demand returning in the window cancels the restore, and a route change
-/// supersedes it. Time is paused, so the 5s linger is deterministic.
+/// Transport doubles shared by the publisher tests: a session whose streams record
+/// everything written and every reset code, and peers that never speak.
 #[cfg(test)]
-mod announce_test {
-	use super::*;
-	use crate::coding::{Decode, Reader};
-	use std::sync::Mutex;
+mod test_transport {
+	use std::sync::{Arc, Mutex};
 
 	#[derive(Debug, Clone, Default)]
-	struct SinkError;
+	pub struct SinkError;
 
 	impl std::fmt::Display for SinkError {
 		fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -1054,18 +1050,29 @@ mod announce_test {
 		}
 	}
 
-	/// Captures everything the announce loop writes, so tests decode it back
-	/// into announce messages.
+	/// What the session's send streams recorded. Resets are a list, not a last-value, so a
+	/// stray second reset (a drop fallback firing behind an abort) is visible.
 	#[derive(Clone, Default)]
-	struct SinkSend {
-		writes: Arc<Mutex<Vec<u8>>>,
+	pub struct Log {
+		pub writes: Arc<Mutex<Vec<u8>>>,
+		pub resets: Arc<Mutex<Vec<u32>>>,
+	}
+
+	impl Log {
+		pub fn resets(&self) -> Vec<u32> {
+			self.resets.lock().unwrap().clone()
+		}
+	}
+
+	pub struct SinkSend {
+		pub log: Log,
 	}
 
 	impl web_transport_trait::SendStream for SinkSend {
 		type Error = SinkError;
 
 		async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-			self.writes.lock().unwrap().extend_from_slice(buf);
+			self.log.writes.lock().unwrap().extend_from_slice(buf);
 			Ok(buf.len())
 		}
 
@@ -1075,16 +1082,18 @@ mod announce_test {
 			Ok(())
 		}
 
-		fn reset(&mut self, _code: u32) {}
+		fn reset(&mut self, code: u32) {
+			self.log.resets.lock().unwrap().push(code);
+		}
 
 		async fn closed(&mut self) -> Result<(), Self::Error> {
 			std::future::pending().await
 		}
 	}
 
-	/// A peer that never speaks and never closes, so the announce loop only ever
-	/// acts on model-side events (announces, routes, demand, the linger timer).
-	struct PendingRecv;
+	/// A peer that never speaks and never closes, so a test only ever acts on
+	/// model-side events.
+	pub struct PendingRecv;
 
 	impl web_transport_trait::RecvStream for PendingRecv {
 		type Error = SinkError;
@@ -1100,10 +1109,12 @@ mod announce_test {
 		}
 	}
 
-	/// Only names the stream types for `Stream<S, Version>`; `run_announce`
-	/// never touches the session itself.
-	#[derive(Clone)]
-	struct SinkSession;
+	/// Only `open_uni` yields; everything else parks. Tests that drive a bidi stream
+	/// build one directly from [`SinkSend`] and [`PendingRecv`] instead.
+	#[derive(Clone, Default)]
+	pub struct SinkSession {
+		pub log: Log,
+	}
 
 	impl web_transport_trait::Session for SinkSession {
 		type SendStream = SinkSend;
@@ -1123,7 +1134,7 @@ mod announce_test {
 		}
 
 		async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
-			std::future::pending().await
+			Ok(SinkSend { log: self.log.clone() })
 		}
 
 		fn send_datagram(&self, _payload: bytes::Bytes) -> Result<(), Self::Error> {
@@ -1153,13 +1164,25 @@ mod announce_test {
 		}
 	}
 
-	struct SinkStats;
+	pub struct SinkStats;
 
 	impl web_transport_trait::Stats for SinkStats {
 		fn estimated_send_rate(&self) -> Option<u64> {
 			None
 		}
 	}
+}
+
+/// The announce loop's demand/linger state machine: a drained broadcast keeps
+/// advertising zero for `COST_LINGER` before the restart that restores its cold
+/// cost, demand returning in the window cancels the restore, and a route change
+/// supersedes it. Time is paused, so the 5s linger is deterministic.
+#[cfg(test)]
+mod announce_test {
+	use super::test_transport::*;
+	use super::*;
+	use crate::coding::{Decode, Reader};
+	use std::sync::Mutex;
 
 	const VERSION: Version = Version::Lite06Wip;
 
@@ -1294,10 +1317,11 @@ mod announce_test {
 		let downstream = origin.consume().announced_broadcast("cam").await.unwrap();
 		let track = demand.then(|| downstream.track("video").unwrap());
 
-		let writes = Arc::new(Mutex::new(Vec::new()));
+		let log = Log::default();
+		let writes = log.writes.clone();
 		let consumer = origin.consume();
 		let mut stream = Stream::<SinkSession, Version> {
-			writer: Writer::new(SinkSend { writes: writes.clone() }, VERSION),
+			writer: Writer::new(SinkSend { log }, VERSION),
 			reader: Reader::new(PendingRecv, VERSION),
 		};
 		let task = tokio::spawn(async move {
@@ -2000,137 +2024,14 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 /// blanket [`Error::Cancel`] from the writer's drop fallback loses the reason.
 #[cfg(test)]
 mod serve_group_test {
+	use super::test_transport::*;
 	use super::*;
 	use crate::{Timestamp, broadcast};
-	use std::sync::Mutex;
-
-	#[derive(Debug, Clone, Default)]
-	struct SinkError;
-
-	impl std::fmt::Display for SinkError {
-		fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-			write!(f, "sink transport error")
-		}
-	}
-
-	impl std::error::Error for SinkError {}
-
-	impl web_transport_trait::Error for SinkError {
-		fn session_error(&self) -> Option<(u32, String)> {
-			Some((0, "closed".to_string()))
-		}
-	}
-
-	/// Every reset code the group stream received, in order, so a second reset from the
-	/// drop fallback is visible rather than silently overwriting the first.
-	#[derive(Clone, Default)]
-	struct Resets(Arc<Mutex<Vec<u32>>>);
-
-	struct Send {
-		resets: Resets,
-	}
-
-	impl web_transport_trait::SendStream for Send {
-		type Error = SinkError;
-
-		async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-			Ok(buf.len())
-		}
-
-		fn set_priority(&mut self, _order: u8) {}
-
-		fn finish(&mut self) -> Result<(), Self::Error> {
-			Ok(())
-		}
-
-		fn reset(&mut self, code: u32) {
-			self.resets.0.lock().unwrap().push(code);
-		}
-
-		async fn closed(&mut self) -> Result<(), Self::Error> {
-			std::future::pending().await
-		}
-	}
-
-	struct Recv;
-
-	impl web_transport_trait::RecvStream for Recv {
-		type Error = SinkError;
-
-		async fn read(&mut self, _dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
-			std::future::pending().await
-		}
-
-		fn stop(&mut self, _code: u32) {}
-
-		async fn closed(&mut self) -> Result<(), Self::Error> {
-			std::future::pending().await
-		}
-	}
-
-	#[derive(Clone)]
-	struct Session {
-		resets: Resets,
-	}
-
-	impl web_transport_trait::Session for Session {
-		type SendStream = Send;
-		type RecvStream = Recv;
-		type Error = SinkError;
-
-		async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
-			std::future::pending().await
-		}
-
-		async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-			std::future::pending().await
-		}
-
-		async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-			std::future::pending().await
-		}
-
-		async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
-			Ok(Send {
-				resets: self.resets.clone(),
-			})
-		}
-
-		fn send_datagram(&self, _payload: bytes::Bytes) -> Result<(), Self::Error> {
-			Ok(())
-		}
-
-		async fn recv_datagram(&self) -> Result<bytes::Bytes, Self::Error> {
-			std::future::pending().await
-		}
-
-		fn max_datagram_size(&self) -> usize {
-			0
-		}
-
-		fn close(&self, _code: u32, _reason: &str) {}
-
-		async fn closed(&self) -> Self::Error {
-			std::future::pending().await
-		}
-
-		fn stats(&self) -> impl web_transport_trait::Stats {
-			Stats
-		}
-	}
-
-	struct Stats;
-
-	impl web_transport_trait::Stats for Stats {
-		fn estimated_send_rate(&self) -> Option<u64> {
-			None
-		}
-	}
 
 	#[tokio::test]
 	async fn resets_with_the_abort_code() {
-		let resets = Resets::default();
-		let session = Session { resets: resets.clone() };
+		let log = Log::default();
+		let session = SinkSession { log: log.clone() };
 
 		let track_priority = kio::Producer::new(0u8);
 		let subscription = Subscription {
@@ -2160,6 +2061,6 @@ mod serve_group_test {
 		group.abort(Error::Old).unwrap();
 
 		assert!(matches!(serve.await, Err(Error::Old)));
-		assert_eq!(*resets.0.lock().unwrap(), vec![Error::Old.to_code()]);
+		assert_eq!(log.resets(), vec![Error::Old.to_code()]);
 	}
 }

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1783,25 +1783,44 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 			sequence,
 		};
 		let stream = self.session.open_uni().await.map_err(Error::from_transport)?;
-
 		let mut stream = Writer::new(stream, self.version);
-		stream.set_priority(priority.current());
-		stream.encode(&lite::DataType::Group).await?;
-		stream.encode(&msg).await?;
 
-		// Lite05+ delta-encodes per-frame timestamps within the group. The first
-		// frame's delta is absolute (against an implicit prev value of 0), every
-		// subsequent delta is signed against the previous frame.
-		let mut prev_ts: u64 = 0;
-		while let Some(frame) = self.next_frame(&mut stream, &mut priority, &mut group).await? {
-			self.serve_frame(&mut stream, &mut priority, frame, &mut prev_ts)
-				.await?;
+		if let Err(err) = self.write_group(&mut stream, &msg, &mut priority, &mut group).await {
+			// Reset with the real reason (Old, Lagged, Evicted, ...) so the subscriber can
+			// tell a truncated group from a routine cancel. Without this the Writer's Drop
+			// fallback reports every failure as Cancel.
+			stream.abort(&err);
+			return Err(err);
 		}
 
 		stream.finish()?;
 		stream.closed().await?;
 
 		tracing::debug!(sequence, "finished group");
+
+		Ok(())
+	}
+
+	/// Write the group header and every frame, leaving the stream open for the caller to
+	/// finish or abort.
+	async fn write_group(
+		&mut self,
+		stream: &mut Writer<S::SendStream, Version>,
+		msg: &lite::Group,
+		priority: &mut PriorityHandle,
+		group: &mut group::Consumer,
+	) -> Result<(), Error> {
+		stream.set_priority(priority.current());
+		stream.encode(&lite::DataType::Group).await?;
+		stream.encode(msg).await?;
+
+		// Lite05+ delta-encodes per-frame timestamps within the group. The first
+		// frame's delta is absolute (against an implicit prev value of 0), every
+		// subsequent delta is signed against the previous frame.
+		let mut prev_ts: u64 = 0;
+		while let Some(frame) = self.next_frame(stream, priority, group).await? {
+			self.serve_frame(stream, priority, frame, &mut prev_ts).await?;
+		}
 
 		Ok(())
 	}
@@ -1973,5 +1992,174 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		let track_priority = self.track_priority_current();
 		priority.set_track(track_priority);
 		stream.set_priority(priority.current());
+	}
+}
+
+/// A group that fails mid-stream must reset with its own error code. The subscriber uses
+/// that code to tell a truncated group (Old, Lagged, Evicted) from a routine cancel, so a
+/// blanket [`Error::Cancel`] from the writer's drop fallback loses the reason.
+#[cfg(test)]
+mod serve_group_test {
+	use super::*;
+	use crate::{Timestamp, broadcast};
+	use std::sync::Mutex;
+
+	#[derive(Debug, Clone, Default)]
+	struct SinkError;
+
+	impl std::fmt::Display for SinkError {
+		fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+			write!(f, "sink transport error")
+		}
+	}
+
+	impl std::error::Error for SinkError {}
+
+	impl web_transport_trait::Error for SinkError {
+		fn session_error(&self) -> Option<(u32, String)> {
+			Some((0, "closed".to_string()))
+		}
+	}
+
+	/// Every reset code the group stream received, in order, so a second reset from the
+	/// drop fallback is visible rather than silently overwriting the first.
+	#[derive(Clone, Default)]
+	struct Resets(Arc<Mutex<Vec<u32>>>);
+
+	struct Send {
+		resets: Resets,
+	}
+
+	impl web_transport_trait::SendStream for Send {
+		type Error = SinkError;
+
+		async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+			Ok(buf.len())
+		}
+
+		fn set_priority(&mut self, _order: u8) {}
+
+		fn finish(&mut self) -> Result<(), Self::Error> {
+			Ok(())
+		}
+
+		fn reset(&mut self, code: u32) {
+			self.resets.0.lock().unwrap().push(code);
+		}
+
+		async fn closed(&mut self) -> Result<(), Self::Error> {
+			std::future::pending().await
+		}
+	}
+
+	struct Recv;
+
+	impl web_transport_trait::RecvStream for Recv {
+		type Error = SinkError;
+
+		async fn read(&mut self, _dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+			std::future::pending().await
+		}
+
+		fn stop(&mut self, _code: u32) {}
+
+		async fn closed(&mut self) -> Result<(), Self::Error> {
+			std::future::pending().await
+		}
+	}
+
+	#[derive(Clone)]
+	struct Session {
+		resets: Resets,
+	}
+
+	impl web_transport_trait::Session for Session {
+		type SendStream = Send;
+		type RecvStream = Recv;
+		type Error = SinkError;
+
+		async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
+			std::future::pending().await
+		}
+
+		async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+			std::future::pending().await
+		}
+
+		async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+			std::future::pending().await
+		}
+
+		async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
+			Ok(Send {
+				resets: self.resets.clone(),
+			})
+		}
+
+		fn send_datagram(&self, _payload: bytes::Bytes) -> Result<(), Self::Error> {
+			Ok(())
+		}
+
+		async fn recv_datagram(&self) -> Result<bytes::Bytes, Self::Error> {
+			std::future::pending().await
+		}
+
+		fn max_datagram_size(&self) -> usize {
+			0
+		}
+
+		fn close(&self, _code: u32, _reason: &str) {}
+
+		async fn closed(&self) -> Self::Error {
+			std::future::pending().await
+		}
+
+		fn stats(&self) -> impl web_transport_trait::Stats {
+			Stats
+		}
+	}
+
+	struct Stats;
+
+	impl web_transport_trait::Stats for Stats {
+		fn estimated_send_rate(&self) -> Option<u64> {
+			None
+		}
+	}
+
+	#[tokio::test]
+	async fn resets_with_the_abort_code() {
+		let resets = Resets::default();
+		let session = Session { resets: resets.clone() };
+
+		let track_priority = kio::Producer::new(0u8);
+		let subscription = Subscription {
+			session,
+			id: 0,
+			track_name: "test".into(),
+			priority: PriorityQueue::default(),
+			track_priority: track_priority.consume(),
+			track_priority_seen: 0,
+			version: Version::Lite06Wip,
+			timescale: Some(crate::Timescale::default()),
+		};
+
+		let mut track = track::Producer::new(Arc::new(broadcast::Info::default()), "test", None);
+		let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+		group
+			.write_frame(Timestamp::from_millis(0).unwrap(), b"hello".as_slice())
+			.unwrap();
+
+		let handle = subscription.priority.insert(Priority::new(0, 0));
+		let mut serve = std::pin::pin!(subscription.serve_group(0, handle, group.consume()));
+
+		// Drain the frame, leaving the task parked awaiting the next one.
+		assert!(futures::poll!(serve.as_mut()).is_pending());
+
+		// The group is dropped from the cache mid-stream: a truncated group, not a cancel.
+		group.abort(Error::Old).unwrap();
+
+		assert!(matches!(serve.await, Err(Error::Old)));
+		assert_eq!(*resets.0.lock().unwrap(), vec![Error::Old.to_code()]);
 	}
 }

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -105,8 +105,9 @@ pub(crate) struct GroupState {
 	// pool can evict the least-recently-read groups under memory pressure.
 	charge: cache::Charge,
 
-	// Whether the group has been finalized (no more frames).
-	pub(crate) fin: bool,
+	// Once finalized, the total number of frames the group will ever contain. Recorded
+	// at finish so the count outlives an abort that clears the cache.
+	pub(crate) fin: Option<usize>,
 
 	// The error that caused the group to be aborted, if any.
 	pub(crate) abort: Option<Error>,
@@ -138,25 +139,32 @@ impl GroupState {
 			};
 			return Poll::Ready(Ok(Some((info, frame::Source::Partial(p.buf.clone())))));
 		}
-		// `abort` is checked before `fin`: an evicted group is both finished and
-		// aborted with its frames cleared, and the reader must see the abort rather
-		// than a clean end-of-group at the wrong index.
-		if let Some(err) = &self.abort {
-			return Poll::Ready(Err(err.clone()));
+		ready!(self.poll_terminal(index))?;
+		Poll::Ready(Ok(None))
+	}
+
+	/// Resolve the group's terminal state for a reader positioned at `index`.
+	///
+	/// A finished group is still aborted once its frames are released to free memory
+	/// (aged out of the track's latency window, or evicted by the cache pool). A reader
+	/// that already consumed every frame is missing nothing, so it gets the clean end of
+	/// group; one that fell short sees the abort rather than a silently truncated stream.
+	fn poll_terminal(&self, index: usize) -> Poll<Result<()>> {
+		match (self.fin, &self.abort) {
+			(Some(total), Some(err)) if index < total => Poll::Ready(Err(err.clone())),
+			(Some(_), _) => Poll::Ready(Ok(())),
+			(None, Some(err)) => Poll::Ready(Err(err.clone())),
+			(None, None) => Poll::Pending,
 		}
-		if self.fin {
-			return Poll::Ready(Ok(None));
-		}
-		Poll::Pending
 	}
 
 	fn poll_finished(&self) -> Poll<Result<u64>> {
-		if let Some(err) = &self.abort {
-			// Checked before `fin`: an evicted group is both finished and aborted,
-			// and its cleared frames would report a bogus count.
+		// The count is recorded at finish, so a later abort that cleared the cache
+		// doesn't turn a complete group into an error.
+		if let Some(total) = self.fin {
+			Poll::Ready(Ok(total as u64))
+		} else if let Some(err) = &self.abort {
 			Poll::Ready(Err(err.clone()))
-		} else if self.fin {
-			Poll::Ready(Ok((self.offset + self.frames.len()) as u64))
 		} else {
 			Poll::Pending
 		}
@@ -293,7 +301,7 @@ impl Producer {
 		}
 
 		let mut state = modify(&self.state)?;
-		if state.fin {
+		if state.fin.is_some() {
 			return Err(Error::Closed);
 		}
 		debug_assert!(state.partial.is_none(), "a frame is already open");
@@ -333,7 +341,7 @@ impl Producer {
 		let buf = FrameBuf::new(frame.size as usize);
 
 		let mut state = modify(&self.state)?;
-		if state.fin {
+		if state.fin.is_some() {
 			return Err(Error::Closed);
 		}
 		debug_assert!(state.partial.is_none(), "a frame is already open");
@@ -396,7 +404,7 @@ impl Producer {
 	/// [`abort`](Self::abort). The handle also keeps the cached frames readable.
 	pub fn finish(&mut self) -> Result<()> {
 		let mut state = modify(&self.state)?;
-		state.fin = true;
+		state.fin = Some(state.offset + state.frames.len());
 		Ok(())
 	}
 
@@ -480,7 +488,7 @@ impl Drop for Producer {
 			return;
 		}
 		if let Ok(mut state) = modify(&self.state)
-			&& !state.fin
+			&& state.fin.is_none()
 		{
 			// Dropped without finish() or abort(), so consumers will see
 			// Error::Dropped mid-group. Deliberate ends go through finish()/abort().
@@ -705,13 +713,7 @@ impl Consumer {
 			}
 			// Nothing completed at `index`: an in-flight tail waits, otherwise resolve
 			// the terminal state (whole-frame reads never stream the partial).
-			if let Some(err) = &state.abort {
-				return Poll::Ready(Err(err.clone()));
-			}
-			if state.fin {
-				return Poll::Ready(Ok(()));
-			}
-			Poll::Pending
+			state.poll_terminal(index)
 		});
 
 		match ready!(res) {
@@ -1048,6 +1050,47 @@ mod test {
 			assert_eq!(frame.payload, Bytes::from(vec![i as u8; 4]));
 		}
 		assert!(consumer.read_frame().now_or_never().unwrap().unwrap().is_none());
+	}
+
+	/// A finished group is still aborted once its frames are released to free memory (the
+	/// track's latency window, or the cache pool). A reader that already drained every frame
+	/// is missing nothing, so it must see the clean end of group rather than the abort.
+	#[test]
+	fn abort_after_finish_keeps_the_clean_end_for_a_drained_reader() {
+		let mut producer = Info { sequence: 0 }.produce();
+		producer
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"hello"))
+			.unwrap();
+		producer.finish().unwrap();
+
+		let mut drained = producer.consume();
+		let mut behind = producer.consume();
+		let frame = drained.read_frame().now_or_never().unwrap().unwrap().unwrap();
+		assert_eq!(frame.payload, Bytes::from_static(b"hello"));
+
+		producer.abort(Error::Old).unwrap();
+
+		// Drained everything before the abort: nothing is missing.
+		assert!(drained.read_frame().now_or_never().unwrap().unwrap().is_none());
+		assert!(drained.next_frame().now_or_never().unwrap().unwrap().is_none());
+
+		// Never read the frame, and its bytes are gone: a truncated stream, not a clean end.
+		assert!(matches!(behind.read_frame().now_or_never().unwrap(), Err(Error::Old)));
+	}
+
+	/// The frame count is fixed at finish, so an abort that clears the cache can't turn a
+	/// complete group into an error.
+	#[test]
+	fn finished_survives_a_later_abort() {
+		let mut producer = Info { sequence: 0 }.produce();
+		producer.write_frame(Timestamp::ZERO, Bytes::from_static(b"a")).unwrap();
+		producer.write_frame(Timestamp::ZERO, Bytes::from_static(b"b")).unwrap();
+		producer.finish().unwrap();
+
+		let mut consumer = producer.consume();
+		producer.abort(Error::Old).unwrap();
+
+		assert_eq!(consumer.finished().now_or_never().unwrap().unwrap(), 2);
 	}
 
 	/// `next_frame` drains frames a prior `read_frame` prefetched, preserving order.

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -2703,6 +2703,30 @@ mod test {
 		}
 	}
 
+	/// A group whose frames outlive `latency_max` is aged out when the next group starts, but
+	/// a subscriber that already drained it must still see the clean end of group. Otherwise a
+	/// track with long groups (a per-minute rollup, say) fails its readers at every boundary.
+	#[tokio::test]
+	async fn aging_out_a_finished_group_keeps_the_clean_end() {
+		tokio::time::pause();
+
+		let mut producer = track_producer("test", None);
+		let mut group = producer.create_group(group::Info { sequence: 0 }).unwrap();
+		let mut consumer = group.consume();
+
+		group
+			.write_frame(Timestamp::from_millis(0).unwrap(), b"hello".as_slice())
+			.unwrap();
+		assert_eq!(consumer.next_frame().await.unwrap().unwrap().size, 5);
+
+		// The group stays open well past latency_max, then the next period starts.
+		tokio::time::advance(DEFAULT_LATENCY_MAX * 12).await;
+		group.finish().unwrap();
+		let _next = producer.create_group(group::Info { sequence: 1 }).unwrap();
+
+		assert!(consumer.next_frame().await.unwrap().is_none());
+	}
+
 	#[tokio::test]
 	async fn evict_keeps_max_sequence() {
 		tokio::time::pause();


### PR DESCRIPTION
## Summary

A cleanly finished group that ages out of the track cache surfaces `Err(Old)` to a consumer that had already drained every frame, instead of the end of group. Any track whose groups outlive `latency_max` (5s by default) hits this at **every** group boundary, since the old group is aborted the instant the next one is created. Symptom in the wild: a per-minute stats rollup (one group per minute, a frame per second) failed its browser subscriber on the minute, every minute.

**Root cause** is two individually-correct changes colliding:

- #1863 added an unconditional `group.abort(Error::Old)` to `evict_expired`, fixing a real hang where a reader parked on an aged-out **unfinished** group waited forever. Harmless at the time: `fin` was checked before `abort`.
- #2110 (LRU cache pool) flipped that order to abort-first, correctly for **pool** eviction, where the frames really are cleared and a clean end at the wrong index would silently truncate. But it also caught #1863's finished-group aborts, where nothing is missing.

Bisected: the repro passes at `9968539ba` (pre-#1863) and `838c420ab` (#1863), fails from `20c749d4c` (#2110) on. Shipped in `moq-net` v0.2.0+. #2494's `--cache-duration` ceiling makes it fire more often, since a relay can clamp the window down further.

**Fix**: record the frame count at `finish()` and resolve the terminal state against the reader's position. A reader that consumed every frame gets the clean end; one that fell short still gets the abort rather than a truncated stream. The abort is unchanged, so the cached bytes are still released on schedule.

Also folded in a second, older defect found alongside it: `serve_group` returned `Err` without touching the stream, leaving `Writer`'s drop fallback to reset with a hardcoded `Error::Cancel`. Every group-stream failure reached the peer as code 0, so `Old` (2), `Lagged` (26), and `Evicted` (31) were all indistinguishable from a routine cancel and the `to_code()` table was dead weight on this path. Not a regression, it dates to the original moq-lite import. `Writer::abort` now takes the stream (terminal, disarming the drop fallback), and `serve_group` splits its body into `write_group` so it can abort with the real error.

## Public API changes

No new, renamed, removed, or signature-changed `pub` item. `GroupState` and its `fin` field are `pub(crate)`.

Two `pub` items change behavior without changing shape:

- `group::Consumer::finished()` now returns `Ok(count)` for a group that was finished and then aborted, where it previously returned `Err`. The count is recorded at `finish()`, so it is accurate even once the frames are released.
- `Writer::abort` now consumes the writer (`fn abort(mut self, ...)`) instead of taking `&mut self`. It is terminal, so the `Drop` fallback can no longer reset behind it with `Cancel`, and a later write is a compile error rather than a panic. Every caller already owned its `Stream` and treated abort as last-use, and `Stream` has no `Drop` impl, so the partial move needed no call-site changes.

No wire-format change: this makes the publisher emit the error codes the drafts already define. Targets `main` per CONTRIBUTING.

## Test plan

Four new tests, each verified to fail with its corresponding fix reverted:

- `group::test::abort_after_finish_keeps_the_clean_end_for_a_drained_reader` — two consumers on one group; the drained one gets the clean end, the one that never read gets `Err(Old)`.
- `group::test::finished_survives_a_later_abort` — `finished()` reports the real count instead of erroring.
- `track::test::aging_out_a_finished_group_keeps_the_clean_end` — the end-to-end scenario: a group held open past `latency_max`, finished, then the next group created.
- `publisher::serve_group_test::resets_with_the_abort_code` — drives a real `serve_group` over a recording session and asserts the full reset sequence the peer saw. `[0]` with the abort call removed, `[2, 0]` with a non-terminal `Writer::abort`, `[2]` correct. Asserting the sequence rather than the last code is what catches the double reset.

The transport doubles the publisher tests were each copying now live in one `test_transport` module, which nets ~100 lines out of `publisher.rs`.

Ran: `cargo test -p moq-net` (552 pass), `cargo test --workspace --all-features` (59 binaries, 0 failures), `cargo fmt --check`, `cargo clippy -p moq-net --all-targets -- -D warnings`.

## Cross-package sync

No `js/net` counterpart needed: its `#prune` closes aged mirrors cleanly rather than aborting, so it never had this bug. Worth noting the inverse gap exists there (a reader parked on an aged-out unfinished group has nothing to wake it, the case #1863 fixed on the Rust side), but that is a separate change. No wire or catalog format change, so no draft update.

(Written by Opus 5)

