### PR TITLE
fix(net): avoid duplicate subscribe streams

### DIFF
--- a/rs/moq-net/src/lite/mod.rs
+++ b/rs/moq-net/src/lite/mod.rs
@@ -21,6 +21,8 @@ mod setup;
 mod stream;
 mod subscribe;
 mod subscriber;
+#[cfg(test)]
+pub(crate) mod test_transport;
 mod track;
 mod version;
 

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1027,191 +1027,15 @@ mod test {
 	}
 }
 
-/// Transport doubles shared by the lite tests: a session whose streams record
-/// everything written and every reset code, and peers that never speak.
-#[cfg(test)]
-pub(crate) mod test_transport {
-	use std::sync::{
-		Arc, Mutex,
-		atomic::{AtomicBool, AtomicUsize, Ordering},
-	};
-
-	type OnWrite = Arc<dyn Fn() + Send + Sync>;
-
-	#[derive(Debug, Clone, Default)]
-	pub struct SinkError;
-
-	impl std::fmt::Display for SinkError {
-		fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-			write!(f, "sink transport error")
-		}
-	}
-
-	impl std::error::Error for SinkError {}
-
-	impl web_transport_trait::Error for SinkError {
-		fn session_error(&self) -> Option<(u32, String)> {
-			Some((0, "closed".to_string()))
-		}
-	}
-
-	/// What the session's send streams recorded. Resets are a list, not a last-value, so a
-	/// stray second reset (a drop fallback firing behind an abort) is visible.
-	#[derive(Clone, Default)]
-	pub struct Log {
-		pub writes: Arc<Mutex<Vec<u8>>>,
-		pub resets: Arc<Mutex<Vec<u32>>>,
-		bi_enabled: Arc<AtomicBool>,
-		bi_opens: Arc<AtomicUsize>,
-		on_write: Arc<Mutex<Option<OnWrite>>>,
-	}
-
-	impl Log {
-		pub fn resets(&self) -> Vec<u32> {
-			self.resets.lock().unwrap().clone()
-		}
-
-		pub fn bi_opens(&self) -> usize {
-			self.bi_opens.load(Ordering::Relaxed)
-		}
-
-		pub fn set_on_write(&self, callback: impl Fn() + Send + Sync + 'static) {
-			*self.on_write.lock().unwrap() = Some(Arc::new(callback));
-		}
-	}
-
-	pub struct SinkSend {
-		pub log: Log,
-	}
-
-	impl web_transport_trait::SendStream for SinkSend {
-		type Error = SinkError;
-
-		async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-			if let Some(callback) = self.log.on_write.lock().unwrap().as_ref() {
-				callback();
-			}
-			self.log.writes.lock().unwrap().extend_from_slice(buf);
-			Ok(buf.len())
-		}
-
-		fn set_priority(&mut self, _order: u8) {}
-
-		fn finish(&mut self) -> Result<(), Self::Error> {
-			Ok(())
-		}
-
-		fn reset(&mut self, code: u32) {
-			self.log.resets.lock().unwrap().push(code);
-		}
-
-		async fn closed(&mut self) -> Result<(), Self::Error> {
-			std::future::pending().await
-		}
-	}
-
-	/// A peer that never speaks and never closes, so a test only ever acts on
-	/// model-side events.
-	pub struct PendingRecv;
-
-	impl web_transport_trait::RecvStream for PendingRecv {
-		type Error = SinkError;
-
-		async fn read(&mut self, _dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
-			std::future::pending().await
-		}
-
-		fn stop(&mut self, _code: u32) {}
-
-		async fn closed(&mut self) -> Result<(), Self::Error> {
-			std::future::pending().await
-		}
-	}
-
-	/// Send streams record their bytes while peer reads park forever.
-	#[derive(Clone, Default)]
-	pub struct SinkSession {
-		pub log: Log,
-	}
-
-	impl SinkSession {
-		pub fn with_bi() -> Self {
-			let session = Self::default();
-			session.log.bi_enabled.store(true, Ordering::Relaxed);
-			session
-		}
-	}
-
-	impl web_transport_trait::Session for SinkSession {
-		type SendStream = SinkSend;
-		type RecvStream = PendingRecv;
-		type Error = SinkError;
-
-		async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
-			std::future::pending().await
-		}
-
-		async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-			std::future::pending().await
-		}
-
-		async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-			if !self.log.bi_enabled.load(Ordering::Relaxed) {
-				return std::future::pending().await;
-			}
-			self.log.bi_opens.fetch_add(1, Ordering::Relaxed);
-			Ok((SinkSend { log: self.log.clone() }, PendingRecv))
-		}
-
-		async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
-			Ok(SinkSend { log: self.log.clone() })
-		}
-
-		fn send_datagram(&self, _payload: bytes::Bytes) -> Result<(), Self::Error> {
-			Ok(())
-		}
-
-		async fn recv_datagram(&self) -> Result<bytes::Bytes, Self::Error> {
-			std::future::pending().await
-		}
-
-		fn max_datagram_size(&self) -> usize {
-			0
-		}
-
-		fn protocol(&self) -> Option<&str> {
-			None
-		}
-
-		fn close(&self, _code: u32, _reason: &str) {}
-
-		async fn closed(&self) -> Self::Error {
-			std::future::pending().await
-		}
-
-		fn stats(&self) -> impl web_transport_trait::Stats {
-			SinkStats
-		}
-	}
-
-	pub struct SinkStats;
-
-	impl web_transport_trait::Stats for SinkStats {
-		fn estimated_send_rate(&self) -> Option<u64> {
-			None
-		}
-	}
-}
-
 /// The announce loop's demand/linger state machine: a drained broadcast keeps
 /// advertising zero for `COST_LINGER` before the restart that restores its cold
 /// cost, demand returning in the window cancels the restore, and a route change
 /// supersedes it. Time is paused, so the 5s linger is deterministic.
 #[cfg(test)]
 mod announce_test {
-	use super::test_transport::*;
 	use super::*;
 	use crate::coding::{Decode, Reader};
+	use crate::lite::test_transport::*;
 	use std::sync::Mutex;
 
 	const VERSION: Version = Version::Lite06Wip;
@@ -1351,7 +1175,7 @@ mod announce_test {
 		let writes = log.writes.clone();
 		let consumer = origin.consume();
 		let mut stream = Stream::<SinkSession, Version> {
-			writer: Writer::new(SinkSend { log }, VERSION),
+			writer: Writer::new(SinkSend::new(log), VERSION),
 			reader: Reader::new(PendingRecv, VERSION),
 		};
 		let task = tokio::spawn(async move {
@@ -2054,14 +1878,14 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 /// blanket [`Error::Cancel`] from the writer's drop fallback loses the reason.
 #[cfg(test)]
 mod serve_group_test {
-	use super::test_transport::*;
 	use super::*;
+	use crate::lite::test_transport::*;
 	use crate::{Timestamp, broadcast};
 
 	#[tokio::test]
 	async fn resets_with_the_abort_code() {
 		let log = Log::default();
-		let session = SinkSession { log: log.clone() };
+		let session = SinkSession::new(log.clone());
 
 		let track_priority = kio::Producer::new(0u8);
 		let subscription = Subscription {

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1027,11 +1027,16 @@ mod test {
 	}
 }
 
-/// Transport doubles shared by the publisher tests: a session whose streams record
+/// Transport doubles shared by the lite tests: a session whose streams record
 /// everything written and every reset code, and peers that never speak.
 #[cfg(test)]
-mod test_transport {
-	use std::sync::{Arc, Mutex};
+pub(crate) mod test_transport {
+	use std::sync::{
+		Arc, Mutex,
+		atomic::{AtomicBool, AtomicUsize, Ordering},
+	};
+
+	type OnWrite = Arc<dyn Fn() + Send + Sync>;
 
 	#[derive(Debug, Clone, Default)]
 	pub struct SinkError;
@@ -1056,11 +1061,22 @@ mod test_transport {
 	pub struct Log {
 		pub writes: Arc<Mutex<Vec<u8>>>,
 		pub resets: Arc<Mutex<Vec<u32>>>,
+		bi_enabled: Arc<AtomicBool>,
+		bi_opens: Arc<AtomicUsize>,
+		on_write: Arc<Mutex<Option<OnWrite>>>,
 	}
 
 	impl Log {
 		pub fn resets(&self) -> Vec<u32> {
 			self.resets.lock().unwrap().clone()
+		}
+
+		pub fn bi_opens(&self) -> usize {
+			self.bi_opens.load(Ordering::Relaxed)
+		}
+
+		pub fn set_on_write(&self, callback: impl Fn() + Send + Sync + 'static) {
+			*self.on_write.lock().unwrap() = Some(Arc::new(callback));
 		}
 	}
 
@@ -1072,6 +1088,9 @@ mod test_transport {
 		type Error = SinkError;
 
 		async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+			if let Some(callback) = self.log.on_write.lock().unwrap().as_ref() {
+				callback();
+			}
 			self.log.writes.lock().unwrap().extend_from_slice(buf);
 			Ok(buf.len())
 		}
@@ -1109,11 +1128,18 @@ mod test_transport {
 		}
 	}
 
-	/// Only `open_uni` yields; everything else parks. Tests that drive a bidi stream
-	/// build one directly from [`SinkSend`] and [`PendingRecv`] instead.
+	/// Send streams record their bytes while peer reads park forever.
 	#[derive(Clone, Default)]
 	pub struct SinkSession {
 		pub log: Log,
+	}
+
+	impl SinkSession {
+		pub fn with_bi() -> Self {
+			let session = Self::default();
+			session.log.bi_enabled.store(true, Ordering::Relaxed);
+			session
+		}
 	}
 
 	impl web_transport_trait::Session for SinkSession {
@@ -1130,7 +1156,11 @@ mod test_transport {
 		}
 
 		async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-			std::future::pending().await
+			if !self.log.bi_enabled.load(Ordering::Relaxed) {
+				return std::future::pending().await;
+			}
+			self.log.bi_opens.fetch_add(1, Ordering::Relaxed);
+			Ok((SinkSend { log: self.log.clone() }, PendingRecv))
 		}
 
 		async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -840,47 +840,80 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::lite::publisher::test_transport::SinkSession;
+	use crate::coding::Decode;
+	use crate::lite::test_transport::SinkSession;
 	use crate::util::TaskSet;
 
+	const VERSION: Version = Version::Lite05;
+
+	/// `establish` puts exactly one SUBSCRIBE on the wire, and the id is registered
+	/// before any of it reaches the transport.
+	///
+	/// Both halves matter: a second stream re-requests the same id, which the peer is
+	/// free to serve twice, and a late insert loses the race with a publisher that
+	/// serves its first group the instant it reads the request (`recv_group` drops a
+	/// group whose id isn't in the map yet).
 	#[tokio::test]
 	async fn establish_sends_one_registered_subscribe() {
-		let session = SinkSession::with_bi();
+		// Writes park until this opens, so the assertions below run at the exact moment
+		// the request would hit the wire.
+		let gate = kio::Producer::new(false);
+		let session = SinkSession::gated_bi(gate.consume());
+
 		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
 		let (tasks, _task_set) = TaskSet::new();
 		let subscriber = Subscriber::new(SubscriberConfig {
 			session: session.clone(),
 			origin,
 			recv_bandwidth: None,
-			version: Version::Lite05,
+			version: VERSION,
 			peer_setup: Default::default(),
 			cost: None,
 			tasks,
 		});
-		let subscriptions = subscriber.subscribes.clone();
-		session.log.set_on_write(move || {
-			assert!(subscriptions.lock().contains_key(&0));
-		});
+		let subscribes = subscriber.subscribes.clone();
 		let serve = TrackServe {
 			subscriber,
-			path: Path::new("rooms/U123/host").to_owned(),
+			path: Path::new("room/host").to_owned(),
 			name: "catalog.json".to_string(),
 		};
 
 		let mut broadcast = crate::broadcast::Info::new().produce();
 		let mut producer = broadcast.create_track("catalog.json", None).unwrap();
 		let mut sub = Sub::None;
-		serve
-			.establish(
-				&mut producer,
-				&mut sub,
-				Subscription::default(),
-				Some(Timescale::default()),
-			)
-			.await
-			.unwrap();
+		let mut establish = std::pin::pin!(serve.establish(
+			&mut producer,
+			&mut sub,
+			Subscription::default(),
+			Some(Timescale::default()),
+		));
 
+		// Parked on the first write: the stream is open and nothing has been sent yet.
+		assert!(futures::poll!(establish.as_mut()).is_pending());
 		assert_eq!(session.log.bi_opens(), 1);
+		assert!(subscribes.lock().contains_key(&0), "registered before the wire");
+
+		let Ok(mut open) = gate.write() else {
+			panic!("gate closed")
+		};
+		*open = true;
+		drop(open);
+
+		establish.await.unwrap();
+
+		// One request, on one stream, and nothing else behind it.
+		assert_eq!(session.log.bi_opens(), 1);
+
+		let writes = session.log.writes.lock().unwrap().clone();
+		let mut wire = writes.as_slice();
+		assert_eq!(
+			lite::ControlType::decode(&mut wire, VERSION).unwrap(),
+			lite::ControlType::Subscribe
+		);
+		let msg = lite::Subscribe::decode(&mut wire, VERSION).unwrap();
+		assert_eq!(msg.id, 0);
+		assert_eq!(msg.track, "catalog.json");
+		assert!(wire.is_empty(), "a second SUBSCRIBE trailed the first");
 	}
 }
 

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -837,6 +837,53 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 }
 
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::lite::publisher::test_transport::SinkSession;
+	use crate::util::TaskSet;
+
+	#[tokio::test]
+	async fn establish_sends_one_registered_subscribe() {
+		let session = SinkSession::with_bi();
+		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let (tasks, _task_set) = TaskSet::new();
+		let subscriber = Subscriber::new(SubscriberConfig {
+			session: session.clone(),
+			origin,
+			recv_bandwidth: None,
+			version: Version::Lite05,
+			peer_setup: Default::default(),
+			cost: None,
+			tasks,
+		});
+		let subscriptions = subscriber.subscribes.clone();
+		session.log.set_on_write(move || {
+			assert!(subscriptions.lock().contains_key(&0));
+		});
+		let serve = TrackServe {
+			subscriber,
+			path: Path::new("rooms/U123/host").to_owned(),
+			name: "catalog.json".to_string(),
+		};
+
+		let mut broadcast = crate::broadcast::Info::new().produce();
+		let mut producer = broadcast.create_track("catalog.json", None).unwrap();
+		let mut sub = Sub::None;
+		serve
+			.establish(
+				&mut producer,
+				&mut sub,
+				Subscription::default(),
+				Some(Timescale::default()),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(session.log.bi_opens(), 1);
+	}
+}
+
 /// The at-most-one live upstream subscription: its control stream plus the params
 /// echoed in every SUBSCRIBE_UPDATE.
 struct SubStream<S: web_transport_trait::Session> {
@@ -1238,13 +1285,6 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		};
 
 		tracing::info!(id, broadcast = %self.subscriber.log_path(&self.path), track = %self.name, "subscribe started");
-
-		let mut stream = Stream::open(&self.subscriber.session, self.subscriber.version).await?;
-		stream.writer.encode(&lite::ControlType::Subscribe).await?;
-		stream.writer.encode(&msg).await?;
-
-		// Pre-lite-05 acknowledges with SUBSCRIBE_OK; it arrives on this stream and
-		// is consumed (and logged) by the serve loop's response arm.
 
 		// Register before the SUBSCRIBE hits the wire. `id` is live the moment the peer
 		// reads it, and a publisher may serve its first group immediately, so a late

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -1,0 +1,201 @@
+//! Transport doubles shared by the lite tests: a session whose streams record
+//! everything written and every reset code, and peers that never speak.
+
+use std::{
+	sync::{
+		Arc, Mutex,
+		atomic::{AtomicUsize, Ordering},
+	},
+	task::Poll,
+};
+
+#[derive(Debug, Clone, Default)]
+pub struct SinkError;
+
+impl std::fmt::Display for SinkError {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "sink transport error")
+	}
+}
+
+impl std::error::Error for SinkError {}
+
+impl web_transport_trait::Error for SinkError {
+	fn session_error(&self) -> Option<(u32, String)> {
+		Some((0, "closed".to_string()))
+	}
+}
+
+/// What the session's send streams recorded. Resets are a list, not a last-value, so a
+/// stray second reset (a drop fallback firing behind an abort) is visible.
+#[derive(Clone, Default)]
+pub struct Log {
+	pub writes: Arc<Mutex<Vec<u8>>>,
+	pub resets: Arc<Mutex<Vec<u32>>>,
+	bi_opens: Arc<AtomicUsize>,
+}
+
+impl Log {
+	pub fn resets(&self) -> Vec<u32> {
+		self.resets.lock().unwrap().clone()
+	}
+
+	/// How many bidi streams the session has opened, so a test can pin down how many
+	/// requests were sent and not just what they said.
+	pub fn bi_opens(&self) -> usize {
+		self.bi_opens.load(Ordering::Relaxed)
+	}
+}
+
+pub struct SinkSend {
+	pub log: Log,
+	/// Writes park until this flips to true; `None` writes immediately. See
+	/// [`SinkSession::gated_bi`].
+	gate: Option<kio::Consumer<bool>>,
+}
+
+impl SinkSend {
+	pub fn new(log: Log) -> Self {
+		Self { log, gate: None }
+	}
+}
+
+impl web_transport_trait::SendStream for SinkSend {
+	type Error = SinkError;
+
+	async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+		if let Some(gate) = &self.gate {
+			// A closed gate parks forever, which surfaces as a hung test rather than a
+			// write that silently skipped the gate.
+			let _ = gate
+				.wait(|open| if **open { Poll::Ready(()) } else { Poll::Pending })
+				.await;
+		}
+		self.log.writes.lock().unwrap().extend_from_slice(buf);
+		Ok(buf.len())
+	}
+
+	fn set_priority(&mut self, _order: u8) {}
+
+	fn finish(&mut self) -> Result<(), Self::Error> {
+		Ok(())
+	}
+
+	fn reset(&mut self, code: u32) {
+		self.log.resets.lock().unwrap().push(code);
+	}
+
+	async fn closed(&mut self) -> Result<(), Self::Error> {
+		std::future::pending().await
+	}
+}
+
+/// A peer that never speaks and never closes, so a test only ever acts on
+/// model-side events.
+pub struct PendingRecv;
+
+impl web_transport_trait::RecvStream for PendingRecv {
+	type Error = SinkError;
+
+	async fn read(&mut self, _dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+		std::future::pending().await
+	}
+
+	fn stop(&mut self, _code: u32) {}
+
+	async fn closed(&mut self) -> Result<(), Self::Error> {
+		std::future::pending().await
+	}
+}
+
+/// Send streams record their bytes while peer reads park forever.
+#[derive(Clone, Default)]
+pub struct SinkSession {
+	pub log: Log,
+	/// Set by [`Self::gated_bi`]. `None` parks `open_bi` itself forever, which is all
+	/// a test driving only uni streams needs.
+	bi_gate: Option<kio::Consumer<bool>>,
+}
+
+impl SinkSession {
+	pub fn new(log: Log) -> Self {
+		Self { log, bi_gate: None }
+	}
+
+	/// Serve bidi streams, holding every write until `gate` flips to true.
+	///
+	/// The pause is the point: it lets a test assert what must already be true at the
+	/// instant the first byte would reach the wire, without the transport calling back
+	/// into the test.
+	pub fn gated_bi(gate: kio::Consumer<bool>) -> Self {
+		Self {
+			log: Log::default(),
+			bi_gate: Some(gate),
+		}
+	}
+}
+
+impl web_transport_trait::Session for SinkSession {
+	type SendStream = SinkSend;
+	type RecvStream = PendingRecv;
+	type Error = SinkError;
+
+	async fn accept_uni(&self) -> Result<Self::RecvStream, Self::Error> {
+		std::future::pending().await
+	}
+
+	async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+		std::future::pending().await
+	}
+
+	async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
+		let Some(gate) = self.bi_gate.clone() else {
+			return std::future::pending().await;
+		};
+		self.log.bi_opens.fetch_add(1, Ordering::Relaxed);
+
+		let send = SinkSend {
+			log: self.log.clone(),
+			gate: Some(gate),
+		};
+		Ok((send, PendingRecv))
+	}
+
+	async fn open_uni(&self) -> Result<Self::SendStream, Self::Error> {
+		Ok(SinkSend::new(self.log.clone()))
+	}
+
+	fn send_datagram(&self, _payload: bytes::Bytes) -> Result<(), Self::Error> {
+		Ok(())
+	}
+
+	async fn recv_datagram(&self) -> Result<bytes::Bytes, Self::Error> {
+		std::future::pending().await
+	}
+
+	fn max_datagram_size(&self) -> usize {
+		0
+	}
+
+	fn protocol(&self) -> Option<&str> {
+		None
+	}
+
+	fn close(&self, _code: u32, _reason: &str) {}
+
+	async fn closed(&self) -> Self::Error {
+		std::future::pending().await
+	}
+
+	fn stats(&self) -> impl web_transport_trait::Stats {
+		SinkStats
+	}
+}
+
+pub struct SinkStats;
+
+impl web_transport_trait::Stats for SinkStats {
+	fn estimated_send_rate(&self) -> Option<u64> {
+		None
+	}
+}


### PR DESCRIPTION
## Summary

- Remove the second SUBSCRIBE stream that `TrackServe::establish` opened for every upstream track.
- Add a regression test covering the single-stream invariant and the registration ordering it depends on.

## Root cause

#2302 factored the SUBSCRIBE open-and-encode into `open_subscribe` and moved the subscription-map insert ahead of it. #2241 was in flight across that refactor and re-added the inline `Stream::open` + encode above the insert. So `establish` opened two bidi streams, each encoding the same `Subscribe { id }`, and the first was reset with `Error::Cancel` when its shadowed binding dropped at the end of the function.

Per upstream track subscription, that means:

- The peer sees a reused Subscribe ID. The draft is explicit that "A Subscribe ID MUST NOT be reused within the same session, even if the prior subscription has been closed", but `recv_subscribe` never validates it, so the publisher serves both requests.
- Both subscriptions stream the same groups. Whichever copy loses the race into `track::Producer::create_group` is rejected with `Error::Duplicate` and has its stream reset, so the upstream bandwidth is wasted.
- When the doomed stream's copy of a group wins that race, the group is delivered and then aborted as the publisher cancels that subscription, while the good copy is dropped as a duplicate. The delivered group can carry a partially written frame, since `run_frame` writes chunks into the model as they arrive.

Nothing caught it. The publisher doesn't enforce ID uniqueness, the duplicate group streams fail at `debug` level, and no test asserted stream counts: the full lite-01..06 / moqt-14..19 end-to-end matrix passes with the bug present. The one visible symptom is a paired `subscribe started` / `subscribed cancelled` with the same id in relay logs, once per track.

Affected releases: `moq-net` 0.2.0-0.2.2, `moq-relay` 0.14.0-0.14.2, `moq-ffi` 0.3.0-0.3.2.

## Public API changes

None. This corrects internal moq-lite subscription behavior; the wire format is unchanged, so no draft or binding updates are needed.

## Test plan

- `cargo nextest run -p moq-net -p moq-native --all-targets --all-features` (751 passed)
- `just fix` and `just rs check`
- Confirmed the new test fails when the duplicate open is restored, on both the ordering assertion and the single-stream assertion.

## Follow-up

Worth enforcing the draft's Subscribe ID uniqueness rule in `recv_subscribe`. It would have caught this immediately, and today a peer can multiply a relay's work simply by reusing an ID.

(Written by Opus 5)
