### PR TITLE
feat(moq-native)!: expand quiche backend parity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9260,9 +9260,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-quiche"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea3eb47ecea9f8b748d57349c0697742581e43dadd4715650ba5d8119f81bd2"
+checksum = "3599414f964f4f1132dc8bd8f6c497b7a7b97043e4d5de53abbc155527d48fdf"
 dependencies = [
  "boring",
  "bytes",
@@ -9274,6 +9274,7 @@ dependencies = [
  "tokio",
  "tokio-quiche",
  "tracing",
+ "url",
  "web-transport-proto",
  "web-transport-trait",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ web-transport-iroh = "0.6"
 # 0.2.1 for the `qlog` passthrough feature moq-native's `qlog` forwards to.
 web-transport-noq = { version = "0.2.1", default-features = false }
 web-transport-proto = "0.6"
-web-transport-quiche = "0.4"
+web-transport-quiche = "0.5"
 web-transport-quinn = "0.11"
 web-transport-trait = "0.3.4"
 

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -320,7 +320,9 @@ impl Client {
 		feature = "uds"
 	))]
 	pub async fn connect(&self, url: Url) -> crate::Result<moq_net::Session> {
-		let pair = self.connect_inner(url).await?;
+		// Each compiled backend adds state to this dispatch future. Keep it off the
+		// caller's stack so all-feature builds remain safe on standard 2 MiB threads.
+		let pair = Box::pin(self.connect_inner(url)).await?;
 		tracing::info!(version = %pair.0.version(), "connected");
 		Ok(crate::spawn_session(pair))
 	}

--- a/rs/moq-native/src/quic.rs
+++ b/rs/moq-native/src/quic.rs
@@ -88,8 +88,8 @@ pub struct Client {
 	/// Enable UDP generic segmentation offload (GSO).
 	///
 	/// GSO batches sends into one syscall for throughput, but some NICs and
-	/// middleboxes mangle segmented packets. Defaults to on. Only the quinn and
-	/// noq backends can turn it off; setting `false` errors at init on quiche/iroh.
+	/// middleboxes mangle segmented packets. Defaults to on. The iroh backend
+	/// cannot turn it off and rejects an explicit `false`.
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(
 		id = "client-quic-gso",
@@ -113,7 +113,7 @@ pub struct Client {
 	pub idle_timeout: Option<Duration>,
 
 	/// Keep-alive ping interval. Defaults to 5s; set `0s` to disable.
-	/// Ignored by the quiche and iroh backends, which have no keep-alive knob.
+	/// Ignored by the iroh backend, which has no keep-alive knob.
 	#[serde(default, skip_serializing_if = "Option::is_none", with = "humantime_serde::option")]
 	#[arg(
 		id = "client-quic-keep-alive",
@@ -229,7 +229,6 @@ pub struct Server {
 	pub idle_timeout: Option<Duration>,
 
 	/// Keep-alive ping interval. Defaults to 5s; set `0s` to disable.
-	/// Ignored by the quiche backend, which has no keep-alive knob.
 	#[serde(default, skip_serializing_if = "Option::is_none", with = "humantime_serde::option")]
 	#[arg(
 		id = "server-quic-keep-alive",
@@ -401,10 +400,9 @@ impl Resolved {
 
 	/// Whether the config asks to turn GSO off, which not every backend can honor.
 	///
-	/// Only the quiche and iroh backends consult this, to reject a GSO-off request
-	/// they can't satisfy; quinn and noq toggle GSO directly. A default build
-	/// compiles neither, so the method is intentionally unused there.
-	#[cfg_attr(not(any(feature = "quiche", feature = "iroh")), allow(dead_code))]
+	/// Only the iroh backend consults this, to reject a GSO-off request it can't
+	/// satisfy; the other backends toggle GSO directly.
+	#[cfg_attr(not(feature = "iroh"), allow(dead_code))]
 	pub(crate) fn gso_disabled(&self) -> bool {
 		self.gso == Some(false)
 	}

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -30,6 +30,14 @@ pub enum Error {
 	#[error("invalid DNS name")]
 	InvalidDnsName,
 
+	/// DNS lookup failed for the URL's host.
+	#[error("DNS lookup failed")]
+	DnsLookup(#[source] std::io::Error),
+
+	/// DNS lookup succeeded but returned no usable address.
+	#[error("no DNS entries found")]
+	NoDnsEntries,
+
 	#[doc(hidden)]
 	#[deprecated(note = "fingerprint verification over http:// is now supported; this is never returned")]
 	#[error("fingerprint verification (http:// scheme) is not supported with the quiche backend")]
@@ -59,12 +67,13 @@ pub enum Error {
 	#[error("url scheme must be 'https', 'moqt', or 'moql'")]
 	InvalidScheme,
 
-	/// quiche resolves the dial target and the TLS SNI from the same host, so the
-	/// two cannot be decoupled. Drop the override or use the quinn backend.
+	#[doc(hidden)]
+	#[deprecated(note = "TLS hostname overrides are now supported; this is never returned")]
 	#[error("client tls host_name override is not supported with the quiche backend")]
 	HostNameUnsupported,
 
-	/// quiche probes GSO from the socket and offers no knob to force it off.
+	#[doc(hidden)]
+	#[deprecated(note = "GSO can now be disabled; this is never returned")]
 	#[error("the quiche backend cannot disable GSO; drop --*-quic-gso=false or use the quinn backend")]
 	GsoUnsupported,
 
@@ -140,10 +149,10 @@ pub enum Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
-/// Apply the resolved quic knobs quiche can honor to its settings.
+/// Apply the resolved QUIC settings that live in quiche's transport configuration.
 ///
-/// quiche has no keep-alive interval knob, so [`Resolved::keep_alive`] is ignored;
-/// GSO is probed from the socket and rejected up front (see [`Error::GsoUnsupported`]).
+/// Keep-alive and GSO are socket-driver settings, so they are applied to the
+/// client/server builders instead.
 fn apply_settings(settings: &mut web_transport_quiche::Settings, quic: &Resolved) -> Result<()> {
 	settings.initial_max_streams_bidi = quic.max_streams;
 	settings.initial_max_streams_uni = quic.max_streams;
@@ -183,29 +192,34 @@ pub(crate) struct QuicheClient {
 	/// Whether an `http://` URL may bootstrap a pin (see [crate::tls::Client::allows_http_bootstrap]).
 	pub http_bootstrap: bool,
 	pub quic: Resolved,
+	pub host_name: Option<String>,
+	identity: Option<Arc<ClientIdentity>>,
+}
+
+struct ClientIdentity {
+	chain: Vec<CertificateDer<'static>>,
+	key: PrivateKeyDer<'static>,
 }
 
 impl QuicheClient {
 	pub fn new(config: &ClientConfig) -> Result<Self> {
-		// web-transport-quiche's ClientBuilder::connect(host, port) uses `host` for BOTH
-		// DNS resolution (the dial target) AND the TLS SNI, so a host_name override that
-		// decouples them can't be applied without an upstream API change. Fail fast at
-		// init rather than silently ignoring the override on the first connect.
-		if config.tls.host_name.is_some() {
-			return Err(Error::HostNameUnsupported);
-		}
-
 		let quic = config.quic.resolve();
-		// quiche probes GSO from the socket and has no knob to force it off.
-		if quic.gso_disabled() {
-			return Err(Error::GsoUnsupported);
-		}
+		let identity = match (&config.tls.cert, &config.tls.key) {
+			(Some(cert), Some(key)) => {
+				let (chain, key) = load_quiche_cert(cert, key)?;
+				Some(Arc::new(ClientIdentity { chain, key }))
+			}
+			(None, None) => None,
+			_ => return Err(crate::tls::Error::IncompleteClientAuth.into()),
+		};
 
 		Ok(Self {
 			bind: config.bind,
 			verification: config.tls.verification()?,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
 			quic,
+			host_name: config.tls.host_name.clone(),
+			identity,
 		})
 	}
 
@@ -248,9 +262,29 @@ impl QuicheClient {
 		settings.alpn = alpns;
 		apply_settings(&mut settings, &self.quic)?;
 
+		let socket = crate::bind::udp(self.bind)?;
+		let local = socket.local_addr()?;
+		let addrs = tokio::net::lookup_host((host.as_str(), port))
+			.await
+			.map_err(Error::DnsLookup)?;
+		let remote = crate::util::pick_addr(addrs, local).ok_or(Error::NoDnsEntries)?;
+
 		let mut builder = web_transport_quiche::ez::ClientBuilder::default()
 			.with_settings(settings)
-			.with_bind(self.bind)?;
+			.with_gso(self.quic.gso.unwrap_or(true))
+			.with_socket(socket)?;
+
+		if let Some(interval) = self.quic.keep_alive {
+			builder = builder.with_keep_alive(interval);
+		}
+
+		// The builder dials the resolved IP below, so always set the original
+		// hostname explicitly for SNI and verification unless the caller overrides it.
+		builder = builder.with_server_name(self.host_name.as_deref().unwrap_or(&host));
+
+		if let Some(identity) = &self.identity {
+			builder = builder.with_single_cert(identity.chain.clone(), identity.key.clone_key());
+		}
 
 		match verification {
 			// No hook: tokio-quiche's default config with verify_peer = false.
@@ -289,7 +323,7 @@ impl QuicheClient {
 			"https" => {
 				// WebTransport over HTTP/3
 				let conn = builder
-					.connect(&host, port)
+					.connect(&remote.ip().to_string(), remote.port())
 					.await
 					.map_err(Error::Connect)?
 					.established()
@@ -303,7 +337,7 @@ impl QuicheClient {
 			"moqt" | "moql" => {
 				// Raw QUIC mode
 				let conn = builder
-					.connect(&host, port)
+					.connect(&remote.ip().to_string(), remote.port())
 					.await
 					.map_err(Error::Connect)?
 					.established()
@@ -400,13 +434,10 @@ impl QuicheServer {
 		}
 
 		let quic = config.quic.resolve();
-		// quiche probes GSO from the socket and has no knob to force it off.
-		if quic.gso_disabled() {
-			return Err(Error::GsoUnsupported);
-		}
 
 		let listen =
 			crate::util::resolve(config.bind.as_deref(), crate::server::DEFAULT_BIND).map_err(Error::ResolveBind)?;
+		let socket = crate::bind::udp(listen)?;
 
 		let (chain, key) = if !config.tls.generate.is_empty() {
 			generate_quiche_cert(&config.tls.generate)?
@@ -448,9 +479,29 @@ impl QuicheServer {
 		settings.alpn = alpns;
 		apply_settings(&mut settings, &quic)?;
 
-		let server = web_transport_quiche::ez::ServerBuilder::default()
+		let mut builder = web_transport_quiche::ez::ServerBuilder::default()
 			.with_settings(settings)
-			.with_bind(listen)?
+			.with_gso(quic.gso.unwrap_or(true));
+
+		if let Some(interval) = quic.keep_alive {
+			builder = builder.with_keep_alive(interval);
+		}
+
+		if !config.tls.root.is_empty() {
+			let roots = config
+				.tls
+				.root
+				.iter()
+				.map(|path| crate::tls::read_certs(path))
+				.collect::<crate::tls::Result<Vec<_>>>()?
+				.into_iter()
+				.flatten()
+				.collect();
+			builder = builder.with_client_auth(web_transport_quiche::ClientAuth::Optional(roots));
+		}
+
+		let server = builder
+			.with_socket(socket)?
 			.with_single_cert(chain, key)
 			.map_err(Error::ServerBuild)?;
 
@@ -521,8 +572,8 @@ fn generate_quiche_cert(
 /// A raw QUIC connection request via the quiche backend (not using HTTP/3).
 /// Accept a quiche QUIC connection, negotiate WebTransport or raw moq, and complete the
 /// handshake (a `200 OK` for WebTransport). Returns the established connection plus the
-/// request URL. The quiche backend exposes no client-cert identity, so the identity is
-/// always `None`; raw QUIC carries no request URL (the path rides the SETUP instead).
+/// request URL and any validated client identity. Raw QUIC carries no request URL
+/// because the path rides the SETUP instead.
 pub(crate) async fn accept(
 	incoming: web_transport_quiche::ez::Incoming,
 	alpns: Vec<&'static str>,
@@ -539,6 +590,7 @@ pub(crate) async fn accept(
 	// Get the negotiated ALPN from the established connection
 	let alpn = conn.alpn().ok_or(Error::MissingAlpn)?;
 	let alpn = std::str::from_utf8(&alpn)?;
+	let identity = conn.peer_certificates().map(crate::tls::PeerIdentity::from_chain);
 	tracing::debug!(ip = %conn.peer_addr(), ?alpn, "accepted via quiche");
 
 	match alpn {
@@ -556,7 +608,7 @@ pub(crate) async fn accept(
 				response = response.with_protocol(protocol);
 			}
 			let session = request.respond(response).await.map_err(Error::Accept)?;
-			Ok((session, url, None))
+			Ok((session, url, identity))
 		}
 		// Recognize any moq ALPN this server actually offered (its configured versions),
 		// not the global default set, so opt-in / work-in-progress versions (e.g.
@@ -566,7 +618,7 @@ pub(crate) async fn accept(
 			let response = web_transport_quiche::proto::ConnectResponse::OK.with_protocol(alpn);
 			// Raw QUIC carries no request URL; the path rides the SETUP.
 			let session = web_transport_quiche::Connection::raw(conn, request, response);
-			Ok((session, None, None))
+			Ok((session, None, identity))
 		}
 		_ => Err(Error::UnsupportedAlpn(alpn.to_string())),
 	}

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -155,6 +155,8 @@ impl Server {
 				QuicBackend::Quinn => true,
 				#[cfg(feature = "noq")]
 				QuicBackend::Noq => true,
+				#[cfg(feature = "quiche")]
+				QuicBackend::Quiche => true,
 				#[allow(unreachable_patterns)]
 				_ => false,
 			};

--- a/rs/moq-native/src/tls.rs
+++ b/rs/moq-native/src/tls.rs
@@ -614,10 +614,8 @@ pub struct Server {
 	/// and can be used by the application to grant elevated access. Clients that
 	/// do not present a certificate are unaffected.
 	///
-	/// Client certificate reporting is only supported by the Quinn and noq QUIC
-	/// backends. Plain-TLS listeners built via [`Self::server_config`] also use
-	/// these roots for optional mTLS when the feature set includes quinn, noq, or
-	/// quiche.
+	/// Plain-TLS listeners built via [`Self::server_config`] also use these roots
+	/// for optional mTLS.
 	#[arg(
 		long = "server-tls-root",
 		id = "server-tls-root",
@@ -706,6 +704,12 @@ impl PeerIdentity {
 	pub(crate) fn from_any(identity: Option<Box<dyn std::any::Any>>) -> Option<Self> {
 		let chain = identity?.downcast::<Vec<CertificateDer<'static>>>().ok()?;
 		Some(Self { chain: *chain })
+	}
+
+	/// Wrap a certificate chain already exposed by a QUIC backend.
+	#[cfg(feature = "quiche")]
+	pub(crate) fn from_chain(chain: Vec<CertificateDer<'static>>) -> Self {
+		Self { chain }
 	}
 
 	/// The validated certificate chain, leaf first.

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -16,6 +16,8 @@ struct ConnectTest<'a> {
 	scheme: &'a str,
 	/// Server bind address, e.g. `[::]:0` or `127.0.0.1:0`.
 	bind: &'a str,
+	/// Optional client bind address when it should differ from the server.
+	client_bind: Option<&'a str>,
 	/// Authority the client dials: a DNS name (sends SNI) or a bare IP (no SNI).
 	authority: &'a str,
 	backend: moq_native::QuicBackend,
@@ -33,6 +35,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 	connect_test(ConnectTest {
 		scheme,
 		bind: "[::]:0",
+		client_bind: None,
 		authority: "localhost",
 		backend,
 		qlog: None,
@@ -49,6 +52,7 @@ async fn no_sni_test(scheme: &str, backend: moq_native::QuicBackend) {
 	connect_test(ConnectTest {
 		scheme,
 		bind: "127.0.0.1:0",
+		client_bind: None,
 		authority: "127.0.0.1",
 		backend,
 		qlog: None,
@@ -63,6 +67,7 @@ async fn connect_test(config: ConnectTest<'_>) {
 	let ConnectTest {
 		scheme,
 		bind,
+		client_bind,
 		authority,
 		backend,
 		qlog,
@@ -100,7 +105,7 @@ async fn connect_test(config: ConnectTest<'_>) {
 	client_config.quic.qlog = qlog.map(Into::into);
 	// Bind the client to the same address family as the server so an IPv4 dial
 	// doesn't try to egress from an IPv6 socket (and vice versa).
-	client_config.bind = bind.parse().expect("invalid bind address");
+	client_config.bind = client_bind.unwrap_or(bind).parse().expect("invalid bind address");
 
 	let client = client_config.init().expect("failed to init client");
 	let url: url::Url = format!("{scheme}://{authority}:{}", addr.port()).parse().unwrap();
@@ -167,9 +172,11 @@ async fn connect_test(config: ConnectTest<'_>) {
 /// Generate a CA, a server cert + key, and a client cert + key (all PEM, the
 /// leaf certs signed by the CA) written to a tempdir. Returns the dir plus the
 /// five paths so the caller can wire them into the TLS configs.
-#[cfg(any(feature = "quinn", feature = "noq"))]
+#[cfg(any(feature = "quinn", feature = "quiche", feature = "noq"))]
 fn generate_mtls_certs() -> (tempfile::TempDir, MtlsPaths) {
-	use rcgen::{BasicConstraints, CertificateParams, IsCa, Issuer, KeyPair};
+	use rcgen::{
+		BasicConstraints, CertificateParams, DnType, ExtendedKeyUsagePurpose, IsCa, Issuer, KeyPair, KeyUsagePurpose,
+	};
 	use std::io::Write;
 
 	let dir = tempfile::tempdir().expect("failed to create tempdir");
@@ -178,17 +185,25 @@ fn generate_mtls_certs() -> (tempfile::TempDir, MtlsPaths) {
 	let ca_key = KeyPair::generate().expect("ca key");
 	let mut ca_params = CertificateParams::new(Vec::new()).expect("ca params");
 	ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+	ca_params.distinguished_name.push(DnType::CommonName, "moq test CA");
+	ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
 	let ca_cert = ca_params.self_signed(&ca_key).expect("ca cert");
 	let issuer = Issuer::from_params(&ca_params, &ca_key);
 
 	// Server leaf with a localhost SAN so the client can verify the name.
 	let server_key = KeyPair::generate().expect("server key");
-	let server_params = CertificateParams::new(vec!["localhost".to_string()]).expect("server params");
+	let mut server_params = CertificateParams::new(vec!["localhost".to_string()]).expect("server params");
+	server_params.distinguished_name.push(DnType::CommonName, "localhost");
+	server_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ServerAuth];
 	let server_cert = server_params.signed_by(&server_key, &issuer).expect("server cert");
 
 	// Client leaf presented during the handshake for mTLS.
 	let client_key = KeyPair::generate().expect("client key");
-	let client_params = CertificateParams::new(Vec::new()).expect("client params");
+	let mut client_params = CertificateParams::new(vec!["client.example".to_string()]).expect("client params");
+	client_params
+		.distinguished_name
+		.push(DnType::CommonName, "client.example");
+	client_params.extended_key_usages = vec![ExtendedKeyUsagePurpose::ClientAuth];
 	let client_cert = client_params.signed_by(&client_key, &issuer).expect("client cert");
 
 	let write = |name: &str, contents: String| {
@@ -210,7 +225,7 @@ fn generate_mtls_certs() -> (tempfile::TempDir, MtlsPaths) {
 }
 
 /// Filesystem paths to the PEM material produced by [`generate_mtls_certs`].
-#[cfg(any(feature = "quinn", feature = "noq"))]
+#[cfg(any(feature = "quinn", feature = "quiche", feature = "noq"))]
 struct MtlsPaths {
 	ca: std::path::PathBuf,
 	server_cert: std::path::PathBuf,
@@ -221,18 +236,20 @@ struct MtlsPaths {
 
 /// Connect with a client certificate signed by a CA the server trusts, and
 /// assert the server observes the validated peer certificate via mTLS.
-#[cfg(any(feature = "quinn", feature = "noq"))]
-async fn mtls_test(scheme: &str, backend: moq_native::QuicBackend) {
+#[cfg(any(feature = "quinn", feature = "quiche", feature = "noq"))]
+async fn mtls_test(scheme: &str, backend: moq_native::QuicBackend, reject: bool) {
 	let (_dir, paths) = generate_mtls_certs();
 
 	let pub_origin = Origin::random().produce();
 
 	let mut server_config = moq_native::ServerConfig::default();
-	server_config.bind = Some("[::]:0".to_string());
+	server_config.bind = Some("127.0.0.1:0".to_string());
 	server_config.tls.cert = vec![paths.server_cert.clone()];
 	server_config.tls.key = vec![paths.server_key.clone()];
 	server_config.tls.root = vec![paths.ca.clone()];
 	server_config.backend = Some(backend.clone());
+	server_config.quic.gso = Some(false);
+	server_config.quic.keep_alive = Some(Duration::from_secs(1));
 
 	let mut server = server_config.init().expect("failed to init server");
 	let addr = server.local_addr().expect("failed to get local addr");
@@ -242,15 +259,27 @@ async fn mtls_test(scheme: &str, backend: moq_native::QuicBackend) {
 	client_config.tls.system_roots = Some(false);
 	client_config.tls.cert = Some(paths.client_cert.clone());
 	client_config.tls.key = Some(paths.client_key.clone());
+	client_config.tls.host_name = Some("localhost".to_string());
 	client_config.backend = Some(backend);
+	client_config.bind = "0.0.0.0:0".parse().unwrap();
+	client_config.quic.gso = Some(false);
+	client_config.quic.keep_alive = Some(Duration::from_secs(1));
 
 	let client = client_config.init().expect("failed to init client");
-	let url: url::Url = format!("{scheme}://localhost:{}", addr.port()).parse().unwrap();
+	// Dial the IP while verifying the certificate's localhost SAN. This covers
+	// the independent TLS hostname override alongside client authentication.
+	let url: url::Url = format!("{scheme}://127.0.0.1:{}", addr.port()).parse().unwrap();
 
+	let (identity_tx, identity_rx) = tokio::sync::oneshot::channel();
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
 		// The peer cert must be visible before we accept the session.
 		let has_cert = request.peer_identity().is_some();
+		let _ = identity_tx.send(has_cert);
+		if reject {
+			request.close(403).await?;
+			return Ok::<_, anyhow::Error>(has_cert);
+		}
 		let session = request.with_publisher(pub_origin.consume()).ok().await?;
 		let _ = session.closed().await;
 		Ok::<_, anyhow::Error>(has_cert)
@@ -258,15 +287,27 @@ async fn mtls_test(scheme: &str, backend: moq_native::QuicBackend) {
 
 	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
 		.await
-		.expect("client connect timed out")
-		.expect("client connect failed");
+		.expect("client connect timed out");
 
-	drop(session);
-	let has_cert = server_handle
+	let has_cert = tokio::time::timeout(TIMEOUT, identity_rx)
 		.await
-		.expect("server task panicked")
-		.expect("server task failed");
+		.expect("identity inspection timed out")
+		.expect("server dropped identity result");
 	assert!(has_cert, "server did not observe the client certificate");
+	if !reject {
+		session.as_ref().expect("client connect failed");
+	}
+	drop(session);
+
+	if reject {
+		server_handle.abort();
+	} else {
+		tokio::time::timeout(TIMEOUT, server_handle)
+			.await
+			.expect("server task timed out")
+			.expect("server task panicked")
+			.expect("server task failed");
+	}
 }
 
 // ── Quinn backend ───────────────────────────────────────────────────
@@ -289,7 +330,7 @@ async fn quinn_raw_quic_no_sni() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn quinn_mtls() {
-	mtls_test("https", moq_native::QuicBackend::Quinn).await;
+	mtls_test("https", moq_native::QuicBackend::Quinn, false).await;
 }
 
 #[cfg(feature = "quinn")]
@@ -304,9 +345,31 @@ async fn quinn_webtransport() {
 #[cfg(feature = "quiche")]
 #[tracing_test::traced_test]
 #[tokio::test]
-#[ignore = "quiche raw QUIC (moqt://) fails; likely a web-transport-quiche bug"]
 async fn quiche_raw_quic() {
 	backend_test("moqt", moq_native::QuicBackend::Quiche).await;
+}
+
+#[cfg(feature = "quiche")]
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn quiche_dual_stack_ipv4() {
+	connect_test(ConnectTest {
+		scheme: "moqt",
+		bind: "[::]:0",
+		client_bind: Some("0.0.0.0:0"),
+		authority: "127.0.0.1",
+		backend: moq_native::QuicBackend::Quiche,
+		qlog: None,
+	})
+	.await;
+}
+
+#[cfg(feature = "quiche")]
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn quiche_mtls() {
+	// Avoid waiting on the separately tracked quiche WebTransport teardown bug.
+	mtls_test("https", moq_native::QuicBackend::Quiche, true).await;
 }
 
 #[cfg(feature = "quiche")]
@@ -479,7 +542,7 @@ async fn noq_webtransport() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn noq_mtls() {
-	mtls_test("https", moq_native::QuicBackend::Noq).await;
+	mtls_test("https", moq_native::QuicBackend::Noq, false).await;
 }
 
 // ── qlog ────────────────────────────────────────────────────────────
@@ -497,6 +560,7 @@ async fn qlog_test(scheme: &str, backend: moq_native::QuicBackend) -> Vec<std::p
 	connect_test(ConnectTest {
 		scheme,
 		bind: "[::]:0",
+		client_bind: None,
 		authority: "localhost",
 		backend,
 		qlog: Some(dir.path()),


### PR DESCRIPTION
## Summary

- upgrade `web-transport-quiche` to the 0.5 API line, currently resolved to 0.5.1
- wire keep-alive, GSO opt-out, TLS hostname override, outbound mTLS, optional inbound mTLS, and peer identity into the quiche backend
- use shared UDP binding and address-family selection, then restore raw QUIC plus dual-stack and mTLS coverage
- heap-allocate multi-backend connection dispatch so all-feature clients do not overflow standard thread stacks

## Public API changes

- **Breaking:** the re-exported `web-transport-quiche` dependency moves from 0.4 to 0.5
- existing quiche configuration fields now behave consistently with the Quinn and noq backends; no new `moq-native` public symbols were added

## Test plan

- `nix develop --command just ci`
- `nix develop --command cargo test -p moq-native --all-features --test backend quiche_raw_quic -- --exact --nocapture`
- `nix develop --command cargo test -p moq-native --no-default-features --features quiche,aws-lc-rs --test backend quiche_ -- --nocapture`
- `nix develop --command cargo test -p moq-native --all-features --test backend mtls -- --nocapture`

## Cross-package sync

No wire, FFI, or language-binding surface changed, so no paired package or draft updates are required.

Part of #2296.

(Written by GPT-5)
