### PR TITLE
refactor(net): poll kio readiness directly

### DIFF
--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -234,7 +234,7 @@ impl Client {
 				// via AnnounceOk + N), so a `request_broadcast()` for a live path resolves
 				// immediately instead of racing announcement gossip.
 				let (session, mut driver) = Session::new(session, version.into(), start.recv_bandwidth, start.driver);
-				driver.wait_ready(start.connecting.ready()).await;
+				driver.wait_ready(|waiter| start.connecting.poll_ready(waiter)).await;
 
 				return Ok((session, driver));
 			}
@@ -260,7 +260,7 @@ impl Client {
 					start.recv_bandwidth,
 					start.driver,
 				);
-				driver.wait_ready(start.connecting.ready()).await;
+				driver.wait_ready(|waiter| start.connecting.poll_ready(waiter)).await;
 
 				return Ok((session, driver));
 			}
@@ -287,7 +287,7 @@ impl Client {
 					start.recv_bandwidth,
 					start.driver,
 				);
-				driver.wait_ready(start.connecting.ready()).await;
+				driver.wait_ready(|waiter| start.connecting.poll_ready(waiter)).await;
 
 				return Ok((session, driver));
 			}
@@ -372,7 +372,7 @@ impl Client {
 		if let Some(connecting) = connecting {
 			// Block until the initial announce set has landed (for versions that
 			// report one); resolves immediately otherwise.
-			driver.wait_ready(connecting.ready()).await;
+			driver.wait_ready(|waiter| connecting.poll_ready(waiter)).await;
 		}
 
 		Ok((session, driver))

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -263,11 +263,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		loop {
 			// Await the next group while driving the in-flight group futures.
 			let group = {
-				let mut recv = std::pin::pin!(track.recv_group());
 				kio::wait(|waiter| {
 					let mut cx = std::task::Context::from_waker(waiter.waker());
 					while let std::task::Poll::Ready(Some(())) = tasks.poll_next_unpin(&mut cx) {}
-					waiter.poll_future(recv.as_mut())
+					track.poll_recv_group(waiter)
 				})
 				.await
 			};

--- a/rs/moq-net/src/lite/connecting.rs
+++ b/rs/moq-net/src/lite/connecting.rs
@@ -8,9 +8,8 @@
 //! Backed by `kio`: each in-flight step holds a [`ConnectingProducer`], and the
 //! session is connected once they've all been dropped (which closes the channel).
 //! A step drops its producer when it finishes (or, on an early error, when it goes
-//! out of scope), so a failed step can't hang `connect()`. Exposes both a synchronous
-//! poll API and an async one; prefer `kio` over `tokio` primitives for new async state
-//! so we keep both available.
+//! out of scope), so a failed step can't hang `connect()`. Prefer `kio` over `tokio`
+//! primitives for new async state so the synchronous poll API stays available.
 
 use std::task::Poll;
 
@@ -40,11 +39,6 @@ impl Connecting {
 	/// Poll for connection completion: ready once every step's producer has dropped.
 	pub(crate) fn poll_ready(&self, waiter: &Waiter) -> Poll<()> {
 		self.0.poll_closed(waiter)
-	}
-
-	/// Await connection completion. Resolves immediately when there are no steps.
-	pub(crate) async fn ready(&self) {
-		kio::wait(|waiter| self.poll_ready(waiter)).await;
 	}
 }
 

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -163,17 +163,15 @@ impl Driver {
 		Poll::Ready(result)
 	}
 
-	/// Drive the session until `ready` resolves, so `connect` can block on the
+	/// Drive the session until the readiness condition resolves, so `connect` can block on the
 	/// initial announce set.
 	///
-	/// A session that dies first still resolves `ready`: the connecting producers
-	/// live inside the driver, so its completion drops them (waking `ready`) and
-	/// releases the barrier. The error isn't lost, it's cached for whoever drives
-	/// the session next.
-	pub(super) async fn wait_ready(&mut self, ready: impl Future<Output = ()>) {
-		let mut ready = std::pin::pin!(ready);
+	/// A session that dies first still resolves readiness: the connecting producers
+	/// live inside the driver, so its completion drops them and releases the barrier.
+	/// The error isn't lost, it's cached for whoever drives the session next.
+	pub(super) async fn wait_ready(&mut self, poll_ready: impl Fn(&kio::Waiter) -> Poll<()>) {
 		kio::wait(|waiter| {
-			if waiter.poll_future(ready.as_mut()).is_ready() {
+			if poll_ready(waiter).is_ready() {
 				return Poll::Ready(());
 			}
 			let _ = self.poll(waiter);


### PR DESCRIPTION
## Summary

- Poll connection readiness directly through `kio` instead of wrapping the existing poll API in a future and polling it again.
- Use `track::Subscriber::poll_recv_group` directly while driving IETF publisher group tasks.
- Remove the now-unused crate-private async connecting wrapper.

## Public API changes

None. The changed readiness surface is crate-private, and the wire protocol is unchanged. No cross-package updates are needed.

## Test plan

- `nix develop --command just fix`
- `nix develop --command cargo test -p moq-net` (554 unit tests passed; doc tests passed)
- `nix develop --command just ci` (2,317 tests passed; formatting, clippy, docs, dependency policy, and Nix flake checks passed)

(Written by GPT-5)
