### PR TITLE
fix(hang): reject a non-hex catalog description instead of misreading it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4348,6 +4348,7 @@ dependencies = [
  "moq-net",
  "serde",
  "serde_json",
+ "serde_path_to_error",
  "thiserror 2.0.19",
  "tracing",
 ]

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -134,7 +134,7 @@ type VideoSchema = {
 
 The `renditions` field contains a map of track names to video decoder configurations.
 See the [WebCodecs specification](https://www.w3.org/TR/webcodecs/#video-decoder-config) for specifics and registered codecs.
-Any Uint8Array field, notably `description`, is a hex string ({{binary}}).
+Any field carrying raw bytes, notably `description`, is a hex string ({{binary}}).
 
 The `display` field is the size to render the video at, in pixels.
 It is separate from a rendition's `displayAspectWidth`/`displayAspectHeight` because changing it does not require reinitializing the decoder.
@@ -197,7 +197,7 @@ type AudioSchema = {
 
 The `renditions` field contains a map of track names to audio decoder configurations.
 See the [WebCodecs specification](https://www.w3.org/TR/webcodecs/#audio-decoder-config) for specifics and registered codecs.
-Any Uint8Array field, notably `description`, is a hex string ({{binary}}).
+Any field carrying raw bytes, notably `description`, is a hex string ({{binary}}).
 
 In addition to the WebCodecs fields, each rendition MAY carry the fields common to audio and video ({{common}}).
 
@@ -240,12 +240,12 @@ For example:
 ~~~
 
 ## Binary Fields {#binary}
-A decoder config field typed as a `Uint8Array` in WebCodecs, notably `description`, is carried in the catalog as a hex string ({{!RFC4648, Section 8}}).
+A decoder config field carrying raw bytes, notably `description` (an `AllowSharedBufferSource` in WebCodecs), is carried in the catalog as a hex string ({{!RFC4648, Section 8}}).
 A publisher SHOULD emit lowercase digits and MUST NOT emit a `0x` prefix or any separators.
 A consumer MUST accept either case.
 
 Note that this differs from the `cmaf` container's `init` field ({{container}}), which is base64 ({{!RFC4648, Section 4}}).
-A publisher that encodes `description` as base64 produces a catalog that consumers reject.
+Encoding a binary field as base64 is not reliably detectable: the alphabets overlap, so such a value is usually rejected but may instead decode to the wrong bytes.
 
 ## Common Rendition Fields {#common}
 Audio and video renditions share the following fields, extending the WebCodecs decoder config:

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -134,7 +134,7 @@ type VideoSchema = {
 
 The `renditions` field contains a map of track names to video decoder configurations.
 See the [WebCodecs specification](https://www.w3.org/TR/webcodecs/#video-decoder-config) for specifics and registered codecs.
-Any Uint8Array fields are hex-encoded as a string.
+Any Uint8Array field, notably `description`, is a hex string ({{binary}}).
 
 The `display` field is the size to render the video at, in pixels.
 It is separate from a rendition's `displayAspectWidth`/`displayAspectHeight` because changing it does not require reinitializing the decoder.
@@ -197,7 +197,7 @@ type AudioSchema = {
 
 The `renditions` field contains a map of track names to audio decoder configurations.
 See the [WebCodecs specification](https://www.w3.org/TR/webcodecs/#audio-decoder-config) for specifics and registered codecs.
-Any Uint8Array fields are hex-encoded as a string.
+Any Uint8Array field, notably `description`, is a hex string ({{binary}}).
 
 In addition to the WebCodecs fields, each rendition MAY carry the fields common to audio and video ({{common}}).
 
@@ -238,6 +238,14 @@ For example:
 	},
 }
 ~~~
+
+## Binary Fields {#binary}
+A decoder config field typed as a `Uint8Array` in WebCodecs, notably `description`, is carried in the catalog as a hex string ({{!RFC4648, Section 8}}).
+A publisher SHOULD emit lowercase digits and MUST NOT emit a `0x` prefix or any separators.
+A consumer MUST accept either case.
+
+Note that this differs from the `cmaf` container's `init` field ({{container}}), which is base64 ({{!RFC4648, Section 4}}).
+A publisher that encodes `description` as base64 produces a catalog that consumers reject.
 
 ## Common Rendition Fields {#common}
 Audio and video renditions share the following fields, extending the WebCodecs decoder config:

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -241,7 +241,7 @@ For example:
 
 ## Binary Fields {#binary}
 A decoder config field carrying raw bytes, notably `description` (an `AllowSharedBufferSource` in WebCodecs), is carried in the catalog as a hex string ({{!RFC4648, Section 8}}).
-A publisher SHOULD emit lowercase digits and MUST NOT emit a `0x` prefix or any separators.
+A publisher SHOULD emit lowercase hexadecimal characters and MUST NOT emit a `0x` prefix or any separators.
 A consumer MUST accept either case.
 
 Note that this differs from the `cmaf` container's `init` field ({{container}}), which is base64 ({{!RFC4648, Section 4}}).

--- a/js/hang/src/catalog/audio.ts
+++ b/js/hang/src/catalog/audio.ts
@@ -1,5 +1,6 @@
 import * as z from "zod/mini";
 import { ContainerSchema } from "./container";
+import { hexSchema } from "./hex";
 import { u53Schema } from "./integers";
 import { RelativeBroadcastSchema } from "./path";
 import { TimelineSchema } from "./timeline";
@@ -29,7 +30,7 @@ export const AudioConfigSchema = z.object({
 	// The description is used for some codecs.
 	// If provided, we can initialize the decoder based on the catalog alone.
 	// Otherwise, the initialization information is in-band.
-	description: z.optional(z.string()), // hex encoded TODO use base64
+	description: z.optional(hexSchema), // TODO use base64
 
 	// The sample rate of the audio in Hz
 	sampleRate: u53Schema,

--- a/js/hang/src/catalog/audio.ts
+++ b/js/hang/src/catalog/audio.ts
@@ -30,7 +30,7 @@ export const AudioConfigSchema = z.object({
 	// The description is used for some codecs.
 	// If provided, we can initialize the decoder based on the catalog alone.
 	// Otherwise, the initialization information is in-band.
-	description: z.optional(hexSchema), // TODO use base64
+	description: z.optional(hexSchema),
 
 	// The sample rate of the audio in Hz
 	sampleRate: u53Schema,

--- a/js/hang/src/catalog/hex.test.ts
+++ b/js/hang/src/catalog/hex.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { AudioConfigSchema } from "./audio";
+import { VideoConfigSchema } from "./video";
+
+describe("description encoding", () => {
+	const video = { codec: "avc1.42e02a", container: { kind: "legacy" as const } };
+	const audio = { codec: "opus", container: { kind: "legacy" as const }, sampleRate: 48000, numberOfChannels: 2 };
+
+	it("accepts hex", () => {
+		expect(VideoConfigSchema.safeParse({ ...video, description: "0142002a" }).success).toBe(true);
+		expect(AudioConfigSchema.safeParse({ ...audio, description: "4f707573486561640102" }).success).toBe(true);
+	});
+
+	// A base64 avcC ("AU...") is valid JSON and used to sail through, only to fail against a
+	// remote hex decoder that has no idea which field it is talking about.
+	it("rejects base64", () => {
+		expect(VideoConfigSchema.safeParse({ ...video, description: "AUIAKv/hABtnQgAq" }).success).toBe(false);
+		expect(AudioConfigSchema.safeParse({ ...audio, description: "T3B1c0hlYWQBAg==" }).success).toBe(false);
+	});
+
+	it("rejects an odd number of digits", () => {
+		expect(VideoConfigSchema.safeParse({ ...video, description: "014" }).success).toBe(false);
+	});
+});

--- a/js/hang/src/catalog/hex.ts
+++ b/js/hang/src/catalog/hex.ts
@@ -1,0 +1,13 @@
+import * as z from "zod/mini";
+
+/**
+ * A hex-encoded byte string, the catalog's encoding for WebCodecs `Uint8Array` fields.
+ *
+ * Validated on both publish and consume so a wrongly encoded value (base64, the encoding the CMAF
+ * `init` field uses, is the easy mistake) fails against the publisher that produced it instead of
+ * against every consumer.
+ */
+export const hexSchema = z.string().check(z.regex(/^([0-9a-fA-F]{2})*$/, "expected hex"));
+
+/** A hex-encoded byte string. Decode with `Util.Hex.toBytes`. */
+export type Hex = z.infer<typeof hexSchema>;

--- a/js/hang/src/catalog/index.ts
+++ b/js/hang/src/catalog/index.ts
@@ -8,6 +8,7 @@
 export * from "./audio";
 export * from "./container";
 export * from "./format";
+export * from "./hex";
 export * from "./integers";
 export * from "./path";
 export * from "./priority";

--- a/js/hang/src/catalog/video.ts
+++ b/js/hang/src/catalog/video.ts
@@ -26,7 +26,7 @@ export const VideoConfigSchema = z.object({
 	// The description is used for some codecs.
 	// If provided, we can initialize the decoder based on the catalog alone.
 	// Otherwise, the initialization information is (repeated) before each key-frame.
-	description: z.optional(hexSchema), // TODO use base64
+	description: z.optional(hexSchema),
 
 	// The width and height of the video in pixels.
 	// NOTE: formats that don't use a description can adjust these values in-band.

--- a/js/hang/src/catalog/video.ts
+++ b/js/hang/src/catalog/video.ts
@@ -1,5 +1,6 @@
 import * as z from "zod/mini";
 import { ContainerSchema } from "./container";
+import { hexSchema } from "./hex";
 import { u53Schema } from "./integers";
 import { RelativeBroadcastSchema } from "./path";
 import { TimelineSchema } from "./timeline";
@@ -25,7 +26,7 @@ export const VideoConfigSchema = z.object({
 	// The description is used for some codecs.
 	// If provided, we can initialize the decoder based on the catalog alone.
 	// Otherwise, the initialization information is (repeated) before each key-frame.
-	description: z.optional(z.string()), // hex encoded TODO use base64
+	description: z.optional(hexSchema), // TODO use base64
 
 	// The width and height of the video in pixels.
 	// NOTE: formats that don't use a description can adjust these values in-band.

--- a/js/hang/src/util/hex.test.ts
+++ b/js/hang/src/util/hex.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import * as Hex from "./hex";
+
+describe("hex", () => {
+	it("round-trips", () => {
+		const bytes = new Uint8Array([0x01, 0x42, 0x00, 0x2a, 0xff]);
+		expect(Hex.fromBytes(bytes)).toBe("0142002aff");
+		expect(Hex.toBytes("0142002aff")).toEqual(bytes);
+	});
+
+	it("accepts either case and an 0x prefix", () => {
+		expect(Hex.toBytes("0xAbCd")).toEqual(new Uint8Array([0xab, 0xcd]));
+	});
+
+	it("rejects an odd length", () => {
+		expect(() => Hex.toBytes("abc")).toThrow("invalid hex string length");
+	});
+
+	// A base64 avcC starts with "AU", which parseInt would silently truncate to 0x0a.
+	it("rejects base64", () => {
+		expect(() => Hex.toBytes("AUIAKv/hABtnQgAq")).toThrow("invalid hex character 'U' at position 1");
+	});
+});

--- a/js/hang/src/util/hex.ts
+++ b/js/hang/src/util/hex.ts
@@ -1,16 +1,29 @@
-/** Decode a hex string (with optional `0x` prefix) into bytes. */
+const HEX = /^[0-9a-fA-F]*$/;
+
+/**
+ * Decode a hex string (with optional `0x` prefix) into bytes.
+ *
+ * Throws on anything that isn't hex. Catalog binary fields (`description`) are hex while the CMAF
+ * `init` segment is base64, so a base64 value reaches this often enough to be worth rejecting
+ * loudly: `parseInt` stops at the first bad character rather than failing, so `"AU"` would decode
+ * to `0x0a` and hand the decoder a plausible-looking buffer of garbage.
+ */
 export function toBytes(hex: string) {
 	hex = hex.startsWith("0x") ? hex.slice(2) : hex;
 	if (hex.length % 2) {
 		throw new Error("invalid hex string length");
 	}
-
-	const matches = hex.match(/.{2}/g);
-	if (!matches) {
-		throw new Error("invalid hex string format");
+	if (!HEX.test(hex)) {
+		const index = hex.search(/[^0-9a-fA-F]/);
+		throw new Error(`invalid hex character '${hex[index]}' at position ${index}`);
 	}
 
-	return new Uint8Array(matches.map((byte) => parseInt(byte, 16)));
+	const bytes = new Uint8Array(hex.length / 2);
+	for (let i = 0; i < bytes.length; i++) {
+		bytes[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+	}
+
+	return bytes;
 }
 
 /** Encode bytes as a lowercase hex string. */

--- a/rs/hang/Cargo.toml
+++ b/rs/hang/Cargo.toml
@@ -20,7 +20,7 @@ moq-net = { workspace = true }
 regex = "1"
 serde = { workspace = true }
 serde_json = "1"
-serde_with = { version = "3", features = ["base64", "hex"] }
+serde_with = { version = "3", features = ["base64"] }
 thiserror = "2"
 url = "2"
 

--- a/rs/hang/src/catalog/audio/mod.rs
+++ b/rs/hang/src/catalog/audio/mod.rs
@@ -9,9 +9,10 @@ use std::collections::{BTreeMap, btree_map};
 use bytes::Bytes;
 
 use serde::{Deserialize, Serialize};
-use serde_with::{DisplayFromStr, DurationMilliSeconds, hex::Hex};
+use serde_with::{DisplayFromStr, DurationMilliSeconds};
 
 use crate::catalog::Container;
+use crate::catalog::hex::Hex;
 
 /// Information about an audio track in the catalog.
 ///

--- a/rs/hang/src/catalog/hex.rs
+++ b/rs/hang/src/catalog/hex.rs
@@ -41,9 +41,9 @@ mod test {
 		let err = Catalog::from_str(json).unwrap_err().to_string();
 		assert!(err.contains("expected hex"), "{err}");
 
-		// Also via `from_value`, which is how a consumer reaches this: moq-json reconstructs a
-		// Value from the frames and deserializes that. It carries no line or column, so the
-		// message is all a consumer gets (moq-json prefixes the field path on its own side).
+		// Also from an already-parsed Value, which is what a consumer deserializes: moq-json
+		// reconstructs one from the frames. That carries no line or column, so this message is
+		// all a consumer gets (moq-json prefixes the field path on its own side).
 		let value: serde_json::Value = serde_json::from_str(json).unwrap();
 		let err = serde_json::from_value::<Catalog>(value).unwrap_err().to_string();
 		assert!(err.contains("expected hex"), "{err}");

--- a/rs/hang/src/catalog/hex.rs
+++ b/rs/hang/src/catalog/hex.rs
@@ -1,0 +1,58 @@
+use bytes::Bytes;
+use serde::de::{Deserializer, Error as _};
+use serde::{Deserialize, Serialize, Serializer};
+use serde_with::{DeserializeAs, SerializeAs};
+
+/// A [`serde_with`] adapter for the catalog's hex-encoded binary fields (`description`).
+///
+/// [`serde_with::hex::Hex`] would do the job, but its failure is a bare
+/// `Invalid character 'U' at position 1` from the `hex` crate, which never says what it was
+/// trying to decode. Naming the expected encoding is the whole point here: the CMAF container's
+/// `init` field sitting next to `description` is base64, so which one applies is a real question.
+pub(crate) struct Hex;
+
+impl SerializeAs<Bytes> for Hex {
+	fn serialize_as<S: Serializer>(source: &Bytes, serializer: S) -> Result<S::Ok, S::Error> {
+		hex::encode(source).serialize(serializer)
+	}
+}
+
+impl<'de> DeserializeAs<'de, Bytes> for Hex {
+	fn deserialize_as<D: Deserializer<'de>>(deserializer: D) -> Result<Bytes, D::Error> {
+		let encoded = String::deserialize(deserializer)?;
+		hex::decode(&encoded)
+			.map(Bytes::from)
+			.map_err(|err| D::Error::custom(format_args!("expected hex: {err}")))
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use crate::catalog::Catalog;
+
+	// An avcC always starts with 0x01, so base64 encoding one starts with "AU": 'A' is a valid hex
+	// digit and 'U' is not. See https://github.com/moq-dev/moq/issues/2509.
+	#[test]
+	fn base64_description() {
+		let json = r#"{"video":{"renditions":{"video/0":{"codec":"avc1.42e02a","container":{"kind":"legacy"},"description":"AUIAKv/hABtnQgAq"}}}}"#;
+
+		let err = Catalog::from_str(json).unwrap_err().to_string();
+		assert!(err.contains("expected hex"), "{err}");
+
+		// The path a consumer takes, via moq-json's snapshot reconstruction.
+		let value: serde_json::Value = serde_json::from_str(json).unwrap();
+		let err = serde_json::from_value::<Catalog>(value).unwrap_err().to_string();
+		assert!(err.contains("expected hex"), "{err}");
+	}
+
+	#[test]
+	fn hex_description() {
+		let json = r#"{"video":{"renditions":{"video/0":{"codec":"avc1.42e02a","container":{"kind":"legacy"},"description":"0142002a"}}}}"#;
+		let catalog = Catalog::from_str(json).unwrap();
+		let rendition = catalog.video.renditions.get("video/0").unwrap();
+		assert_eq!(rendition.description.as_deref(), Some(&[0x01, 0x42, 0x00, 0x2a][..]));
+
+		// Round-trips as lowercase hex.
+		assert!(catalog.to_json().unwrap().contains(r#""description":"0142002a""#));
+	}
+}

--- a/rs/hang/src/catalog/hex.rs
+++ b/rs/hang/src/catalog/hex.rs
@@ -1,3 +1,5 @@
+//! Hex encoding for the catalog's binary fields.
+
 use bytes::Bytes;
 use serde::de::{Deserializer, Error as _};
 use serde::{Deserialize, Serialize, Serializer};
@@ -39,7 +41,9 @@ mod test {
 		let err = Catalog::from_str(json).unwrap_err().to_string();
 		assert!(err.contains("expected hex"), "{err}");
 
-		// The path a consumer takes, via moq-json's snapshot reconstruction.
+		// Also via `from_value`, which is how a consumer reaches this: moq-json reconstructs a
+		// Value from the frames and deserializes that. It carries no line or column, so the
+		// message is all a consumer gets (moq-json prefixes the field path on its own side).
 		let value: serde_json::Value = serde_json::from_str(json).unwrap();
 		let err = serde_json::from_value::<Catalog>(value).unwrap_err().to_string();
 		assert!(err.contains("expected hex"), "{err}");

--- a/rs/hang/src/catalog/mod.rs
+++ b/rs/hang/src/catalog/mod.rs
@@ -6,6 +6,7 @@
 
 mod audio;
 mod container;
+mod hex;
 mod priority;
 mod root;
 mod timeline;

--- a/rs/hang/src/catalog/video/mod.rs
+++ b/rs/hang/src/catalog/video/mod.rs
@@ -14,9 +14,10 @@ use std::collections::{BTreeMap, btree_map};
 
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
-use serde_with::{DisplayFromStr, DurationMilliSeconds, hex::Hex};
+use serde_with::{DisplayFromStr, DurationMilliSeconds};
 
 use crate::catalog::Container;
+use crate::catalog::hex::Hex;
 
 /// Information about a video track in the catalog.
 ///

--- a/rs/moq-json/Cargo.toml
+++ b/rs/moq-json/Cargo.toml
@@ -20,6 +20,7 @@ moq-flate = { workspace = true }
 moq-net = { workspace = true }
 serde = { workspace = true }
 serde_json = "1"
+serde_path_to_error = "0.1"
 thiserror = "2"
 tracing = "0.1"
 

--- a/rs/moq-json/src/snapshot.rs
+++ b/rs/moq-json/src/snapshot.rs
@@ -27,7 +27,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
-use crate::{Diff, Result, diff};
+use crate::{Diff, Error, Result, diff};
 
 /// Maximum frames (snapshot + deltas) in a single group before a new snapshot is forced.
 ///
@@ -512,12 +512,25 @@ impl<T: DeserializeOwned> Consumer<T> {
 
 	/// Materialize the current reconstructed value into `T`. Call only after at least one frame has
 	/// been applied in the current group.
+	///
+	/// Deserializing from the reconstructed [`Value`] rather than the frame bytes costs the line and
+	/// column a parse error would carry, so the error is prefixed with the JSON path of the offending
+	/// field instead. Without it a rejected field deep in a document reports only its own complaint,
+	/// with nothing to say where it came from.
 	fn reconstruct(&self) -> Result<T> {
 		let current = self
 			.current
 			.as_ref()
 			.expect("a value is present after applying a frame");
-		Ok(serde_json::from_value(current.clone())?)
+
+		serde_path_to_error::deserialize(current).map_err(|err| {
+			let path = err.path().to_string();
+			match path.as_str() {
+				// The whole document, not a field within it: nothing useful to prefix.
+				"." => Error::Json(err.into_inner().to_string()),
+				_ => Error::Json(format!("{}: {}", path, err.into_inner())),
+			}
+		})
 	}
 }
 
@@ -991,6 +1004,47 @@ mod test {
 			"windowed delta {} should be far below the raw patch {}",
 			frames[1].len(),
 			raw_delta.len()
+		);
+	}
+
+	#[test]
+	fn rejected_field_names_its_path() {
+		#[derive(serde::Deserialize)]
+		#[allow(dead_code)]
+		struct Inner {
+			count: u8,
+		}
+		#[derive(serde::Deserialize)]
+		#[allow(dead_code)]
+		struct Outer {
+			inner: Inner,
+		}
+
+		let (mut producer, track) = producer(cfg(0));
+		producer.update(&json!({ "inner": { "count": 300 } })).unwrap();
+
+		let mut consumer = Consumer::<Outer>::new(track, ConsumerConfig::default());
+		let Poll::Ready(Err(err)) = consumer.poll_next(&kio::Waiter::noop()) else {
+			panic!("expected a deserialize error");
+		};
+
+		// Deserializing from a Value has no line/column, so the path is the only locator a
+		// consumer gets. See https://github.com/moq-dev/moq/issues/2509.
+		assert!(err.to_string().starts_with("json: inner.count: "), "{err}");
+	}
+
+	#[test]
+	fn rejected_root_omits_the_path() {
+		let (mut producer, track) = producer(cfg(0));
+		producer.update(&json!("not a map")).unwrap();
+
+		let mut consumer = Consumer::<std::collections::BTreeMap<String, u8>>::new(track, ConsumerConfig::default());
+		let Poll::Ready(Err(err)) = consumer.poll_next(&kio::Waiter::noop()) else {
+			panic!("expected a deserialize error");
+		};
+		assert_eq!(
+			err.to_string(),
+			"json: invalid type: string \"not a map\", expected a map"
 		);
 	}
 


### PR DESCRIPTION
Closes #2509.

## Root cause

Not a framing or demux bug: the frame arrived intact, parsed into a complete `serde_json::Value`, and only the typed conversion failed.

A catalog `description` is hex-encoded. The reporter's web client sent base64. `serde_with::hex::Hex` calls `hex::decode`, whose `InvalidHexCharacter` formats as `Invalid character {c:?} at position {index}`, and that string is what reached them through `moq_json::Error::Json` -> `moq_mux::Error::Json`.

The `'U'` at position 1 is deterministic, not random. An `avcC` always starts with `0x01`, so base64 encoding one starts with `"AU"`: `A` is a valid hex digit and `U` is not. Their `avc1.42e02a` gives exactly that.

The absence of an `at line N column M` suffix confirms the diagnosis: `Catalog::from_str` would have carried one. A bare message only comes from `serde_json::from_value`, which is what `moq_json::snapshot::Consumer::reconstruct` calls.

## Why it was undiagnosable

Three gaps, all closed here:

1. **`Hex.toBytes` silently accepted non-hex.** It used `parseInt`, which stops at the first bad character rather than failing, so `"AU"` decoded to `0x0a`. A base64 description round-tripped web-to-web as a plausible-looking buffer of garbage, which is why only the Rust/iOS consumer ever complained.
2. **The catalog zod schema was a bare `z.string()`.** A publisher could emit a bad description with no error; only remote consumers found out. Both `description` fields now parse through a shared hex schema.
3. **The error named neither the field nor the encoding.** `moq-json` deserializes from a reconstructed `Value`, which carries no line or column, so a rejected field reported only its own complaint with nothing to locate it.

## The error, before and after

```
json: json: Invalid character 'U' at position 1
json: json: video.renditions.video/0.description: expected hex: Invalid character 'U' at position 1
```

`moq-json` now prefixes the JSON path via `serde_path_to_error` (already in the lockfile via axum), and `hang` decodes its own hex so the message can name the encoding it wanted. The message states what was expected and stops there: the decoder has no way to know what the value actually was, and guessing "not base64" would be wrong for every other kind of malformed input. The path prefix is generic: any rejected field in any snapshot track gets located, not just this one.

The doubled `json: json:` is left alone. Both prefixes are honest at their own layer, and churning a published crate's error strings for cosmetics is out of scope here.

## Draft

The draft did cover this, but only in passing: "Any Uint8Array fields are hex-encoded as a string", never naming `description`, while spelling out base64 for the CMAF `init` field with an RFC 4648 reference. A reader looking up `description` finds nothing and generalizes from `init`. There is now a Binary Fields section that names the field, cites RFC 4648 Section 8, and calls out the contrast explicitly.

No wire change: this documents and enforces what both implementations already do, so it targets `main`.

## Testing

- `js/hang/src/util/hex.test.ts`: round-trip, case and `0x` handling, odd length, and base64 rejection.
- `js/hang/src/catalog/hex.test.ts`: the video and audio schemas accept hex and reject base64.
- `rs/hang/src/catalog/hex.rs`: the reporter's exact payload, through both `from_str` and the `from_value` path a consumer takes.
- `rs/moq-json/src/snapshot.rs`: a rejected nested field names its path; a rejected root does not get a spurious one.
- `just check` and `just drafts check` pass.

(written by Opus 5)