### PR TITLE
refactor(net): replace the global LRU cache pool with per-track write-time eviction

### DIFF
--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -402,16 +402,17 @@ environment variable (`MOQ_STATS_ENABLED`, `MOQ_STATS_PREFIX`,
 Memory budget for cached groups. Old (non-latest) groups stay cached until their
 track's retention window expires, the `duration` ceiling is reached, or the pool
 runs out of room, whichever comes first. Under memory pressure each track evicts
-its own oldest groups as it writes, proportional to how much it writes, so usage
-converges on the budget without any global scan; groups that FETCH requests keep
-hitting are retained over ones nobody reads. The latest group of every track is
+its own stalest groups as it writes, ordered by when each was last written or
+served from cache, and proportional to how much it writes, so usage converges on
+the budget without any global scan; groups that FETCH requests keep hitting are
+retained over ones nobody reads. The latest group of every track is
 always retained. With none of the knobs set the cache is unbounded and only each
 track's own window limits memory.
 
 ```toml
 [cache]
-# Target bytes of cached group payload, converged toward as tracks write (not
-# a hard limit). Accepts absolute sizes ("8GiB", "512MB") or a percentage of
+# Target bytes of cached group payload, which usage converges toward as tracks
+# write (not a hard limit). Accepts absolute sizes ("8GiB", "512MB") or a percentage of
 # memory ("75%", respecting the cgroup limit inside containers). Unbounded
 # when unset.
 capacity = "8GiB"
@@ -420,7 +421,7 @@ capacity = "8GiB"
 # background governor that re-sizes the cache every few seconds: it grows into
 # idle memory and shrinks (evicting as tracks write) when the rest of the system
 # needs it, so the cache is effectively the lowest-priority user of RAM. Combine
-# with `capacity` to also cap the absolute size.
+# with `capacity` to also bound the target from above.
 headroom = "2GiB"
 
 # Maximum time a non-latest cached group is retained since it was last written

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -410,9 +410,10 @@ track's own window limits memory.
 
 ```toml
 [cache]
-# Maximum bytes of cached group payload. Accepts absolute sizes ("8GiB",
-# "512MB") or a percentage of memory ("75%", respecting the cgroup limit
-# inside containers). Unbounded when unset.
+# Target bytes of cached group payload, converged toward as tracks write (not
+# a hard limit). Accepts absolute sizes ("8GiB", "512MB") or a percentage of
+# memory ("75%", respecting the cgroup limit inside containers). Unbounded
+# when unset.
 capacity = "8GiB"
 
 # Keep at least this much system memory available ("2GiB" or "10%"). Enables a

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -423,11 +423,13 @@ capacity = "8GiB"
 # with `capacity` to also cap the absolute size.
 headroom = "2GiB"
 
-# Maximum age of a non-latest cached group ("30s", "500ms"). Caps each track's
-# own retention window: a publisher advertising a longer window is clamped down
-# to this, bounding how much history a track accumulates no matter what upstream
-# asks for. The latest group of every track is always retained, as it is the
-# live edge. Unbounded (each track keeps its own window) when unset.
+# Maximum time a non-latest cached group is retained since it was last written
+# or served from cache by a FETCH ("30s", "500ms"). Caps each track's own
+# retention window: a publisher advertising a longer window is clamped down to
+# this, bounding how much history a track accumulates no matter what upstream
+# asks for. A FETCH cache hit restarts the clock, so actively-read history
+# stays cached. The latest group of every track is always retained, as it is
+# the live edge. Unbounded (each track keeps its own window) when unset.
 duration = "30s"
 ```
 

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -401,8 +401,10 @@ environment variable (`MOQ_STATS_ENABLED`, `MOQ_STATS_PREFIX`,
 
 Memory budget for cached groups. Old (non-latest) groups stay cached until their
 track's retention window expires, the `duration` ceiling is reached, or the pool
-runs out of room, whichever comes first; under memory pressure the
-least-recently-read groups are evicted first. The latest group of every track is
+runs out of room, whichever comes first. Under memory pressure each track evicts
+its own oldest groups as it writes, proportional to how much it writes, so usage
+converges on the budget without any global scan; groups that FETCH requests keep
+hitting are retained over ones nobody reads. The latest group of every track is
 always retained. With none of the knobs set the cache is unbounded and only each
 track's own window limits memory.
 
@@ -415,9 +417,9 @@ capacity = "8GiB"
 
 # Keep at least this much system memory available ("2GiB" or "10%"). Enables a
 # background governor that re-sizes the cache every few seconds: it grows into
-# idle memory and shrinks (evicting) when the rest of the system needs it, so
-# the cache is effectively the lowest-priority user of RAM. Combine with
-# `capacity` to also cap the absolute size.
+# idle memory and shrinks (evicting as tracks write) when the rest of the system
+# needs it, so the cache is effectively the lowest-priority user of RAM. Combine
+# with `capacity` to also cap the absolute size.
 headroom = "2GiB"
 
 # Maximum age of a non-latest cached group ("30s", "500ms"). Caps each track's
@@ -434,12 +436,12 @@ available memory). `duration` is the age counterpart: it stops a long-running
 relay from accumulating hours of history per track when the byte budget alone
 leaves room for it.
 
-A track's expiry is evaluated as it writes its next group, so `duration` caps
-how much history an *active* publisher builds up rather than acting as a
-background reaper. A publisher that stops writing but stays connected keeps what
-it had cached until it resumes or the broadcast closes, and a publisher that
-disconnects has its groups released once the broadcast closes (see
-`cluster.linger`). Set `capacity` or `headroom` alongside it to bound those.
+All eviction happens as tracks write (there is no background reaper), so both
+`duration` and the byte budget cap how much history *active* publishers build
+up. A publisher that stops writing but stays connected keeps what it had cached
+until it resumes or the broadcast closes; under memory pressure the byte budget
+is repaid by the tracks that are still writing. A publisher that disconnects has
+its groups released once the broadcast closes (see `cluster.linger`).
 
 All three flags also accept CLI arguments (`--cache-capacity`,
 `--cache-headroom`, `--cache-duration`) and environment variables

--- a/rs/kio/src/lib.rs
+++ b/rs/kio/src/lib.rs
@@ -35,7 +35,7 @@ pub use pollable::{Pending, Pollable};
 pub use producer::{Mut, Producer, Ref};
 pub use shared::Shared;
 pub use waiter::{Waiter, WaiterList, wait};
-pub use weak::{ConsumerWeak, ProducerWeak};
+pub use weak::{ConsumerWeak, ProducerWeak, Weak};
 
 /// The channel closed before the awaited condition held.
 ///

--- a/rs/kio/src/lock.rs
+++ b/rs/kio/src/lock.rs
@@ -1,7 +1,7 @@
 use std::{
 	fmt,
 	ops::{Deref, DerefMut},
-	sync::{Arc, Mutex, MutexGuard},
+	sync::{Arc, Mutex, MutexGuard, Weak},
 };
 
 /// A cloneable mutex wrapper backed by `Arc<Mutex<T>>`.
@@ -24,6 +24,47 @@ impl<T> Lock<T> {
 
 	pub fn is_clone(&self, other: &Self) -> bool {
 		Arc::ptr_eq(&self.inner, &other.inner)
+	}
+
+	/// Create a handle that doesn't own the value, so it can be stored inside the
+	/// value itself without leaking the allocation.
+	pub fn downgrade(&self) -> WeakLock<T> {
+		WeakLock {
+			inner: Arc::downgrade(&self.inner),
+		}
+	}
+}
+
+/// A [`Lock`] that doesn't own its value, backed by `Weak<Mutex<T>>`.
+pub struct WeakLock<T> {
+	inner: Weak<Mutex<T>>,
+}
+
+impl<T> WeakLock<T> {
+	/// A handle that never upgrades, for a placeholder before a value exists.
+	pub fn new() -> Self {
+		Self { inner: Weak::new() }
+	}
+
+	/// Recover the owning [`Lock`], or `None` once the value has been dropped.
+	pub fn upgrade(&self) -> Option<Lock<T>> {
+		Some(Lock {
+			inner: self.inner.upgrade()?,
+		})
+	}
+}
+
+impl<T> Clone for WeakLock<T> {
+	fn clone(&self) -> Self {
+		Self {
+			inner: self.inner.clone(),
+		}
+	}
+}
+
+impl<T> fmt::Debug for WeakLock<T> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_tuple("WeakLock").finish()
 	}
 }
 
@@ -66,5 +107,11 @@ impl<T> Deref for LockGuard<'_, T> {
 impl<T> DerefMut for LockGuard<'_, T> {
 	fn deref_mut(&mut self) -> &mut Self::Target {
 		&mut self.inner
+	}
+}
+
+impl<T> Default for WeakLock<T> {
+	fn default() -> Self {
+		Self::new()
 	}
 }

--- a/rs/kio/src/producer.rs
+++ b/rs/kio/src/producer.rs
@@ -254,11 +254,11 @@ impl<T> Producer<T> {
 	}
 
 	/// Returns `true` if this is the only remaining producer.
-	///
-	/// Inherently racy if other handles may clone this producer or upgrade a
-	/// [`ProducerWeak`] concurrently. Intended for a producer's own
-	/// `Drop`, where this handle has not yet been counted out, to gate
-	/// last-producer cleanup.
+	#[doc(hidden)]
+	#[deprecated(
+		note = "racy: a clone, or a Weak upgraded by another thread, can invalidate the answer \
+		        before you act on it. Run last-handle cleanup from the Drop of a shared guard instead."
+	)]
 	pub fn is_last(&self) -> bool {
 		self.counts.producers.load(Ordering::Acquire) == 1
 	}
@@ -417,24 +417,6 @@ impl<T> Deref for Ref<'_, T> {
 #[cfg(test)]
 mod test {
 	use super::*;
-
-	#[test]
-	fn is_last_tracks_producer_count() {
-		let producer = Producer::new(0u8);
-		assert!(producer.is_last());
-
-		let clone = producer.clone();
-		assert!(!producer.is_last());
-		assert!(!clone.is_last());
-
-		drop(clone);
-		assert!(producer.is_last());
-
-		// Consumers and weak handles don't count as producers.
-		let _consumer = producer.consume();
-		let _weak = producer.weak();
-		assert!(producer.is_last());
-	}
 
 	#[test]
 	fn poll_gates_on_predicate_then_writes() {

--- a/rs/kio/src/producer.rs
+++ b/rs/kio/src/producer.rs
@@ -4,7 +4,13 @@ use std::{
 	task::Poll,
 };
 
-use crate::{Closed, Counts, State, consumer::Consumer, lock::*, waiter::*, weak::ProducerWeak};
+use crate::{
+	Closed, Counts, State,
+	consumer::Consumer,
+	lock::*,
+	waiter::*,
+	weak::{ProducerWeak, Weak},
+};
 
 /// The producing side of a shared state channel.
 ///
@@ -261,6 +267,17 @@ impl<T> Producer<T> {
 	pub fn weak(&self) -> ProducerWeak<T> {
 		ProducerWeak {
 			state: self.state.clone(),
+			counts: self.counts.clone(),
+		}
+	}
+
+	/// Create a [`Weak`] reference that owns nothing, not even the state allocation.
+	///
+	/// Use this instead of [`Self::weak`] for a handle stored inside the state itself,
+	/// where a [`ProducerWeak`] would keep the allocation alive through its own value.
+	pub fn downgrade(&self) -> Weak<T> {
+		Weak {
+			state: self.state.downgrade(),
 			counts: self.counts.clone(),
 		}
 	}

--- a/rs/kio/src/producer.rs
+++ b/rs/kio/src/producer.rs
@@ -296,21 +296,22 @@ impl<T> Clone for Producer<T> {
 
 impl<T> Drop for Producer<T> {
 	fn drop(&mut self) {
-		// Atomically decrement and check if we were the last producer
-		let prev = self.counts.producers.fetch_sub(1, Ordering::AcqRel);
-		if prev > 1 {
-			return;
-		}
-
-		// We were the last producer, need to close. Every waiter reacts to
-		// closure (value/closed resolve, `used`/`unused` resolve to `None`),
-		// so wake all the lists.
 		let mut waiters = {
+			// The count moves under the state lock, in step with the closed flag it
+			// decides. Decrementing outside it would let `ProducerWeak::produce` slip
+			// between the decrement and the close, handing back a producer for a
+			// channel that is about to close.
 			let mut state = self.state.lock();
+			if self.counts.producers.fetch_sub(1, Ordering::AcqRel) > 1 {
+				return;
+			}
 			if state.closed {
 				return;
 			}
 
+			// We were the last producer, so close. Every waiter reacts to closure
+			// (value/closed resolve, `used`/`unused` resolve to `None`), so drain
+			// every list and wake them once the lock is released.
 			state.closed = true;
 			state.take_close_waiters()
 		};

--- a/rs/kio/src/weak.rs
+++ b/rs/kio/src/weak.rs
@@ -7,7 +7,7 @@ use crate::{
 	Closed, Counts, State,
 	consumer::Consumer,
 	lock::*,
-	producer::{Mut, Producer, Ref},
+	producer::{Producer, Ref},
 	waiter::*,
 };
 
@@ -18,7 +18,7 @@ use crate::{
 /// handle you can store *inside* the state it points at (a child holding a link back to
 /// its parent, say) without the two keeping each other alive forever.
 ///
-/// [`upgrade`](Self::upgrade) it while the state is still around.
+/// [`upgrade`](Self::upgrade) it back to a [`Producer`] while the channel is still live.
 pub struct Weak<T> {
 	pub(crate) state: WeakLock<State<T>>,
 	pub(crate) counts: Arc<Counts>,
@@ -36,14 +36,19 @@ impl<T> Weak<T> {
 		}
 	}
 
-	/// Recover a [`ProducerWeak`], or `None` once the state has been dropped.
+	/// Recover a [`Producer`], or `None` once the state has been dropped or the
+	/// channel closed.
 	///
-	/// The channel may still be closed; check or write through the returned handle.
-	pub fn upgrade(&self) -> Option<ProducerWeak<T>> {
-		Some(ProducerWeak {
+	/// This counts: while the returned producer lives the channel stays open, and
+	/// dropping it can be what finally closes it.
+	pub fn upgrade(&self) -> Option<Producer<T>> {
+		// Reuse `produce`'s increment-then-check ordering, which is what keeps the
+		// last `Producer::drop` from closing the channel out from under us.
+		ProducerWeak {
 			state: self.state.upgrade()?,
 			counts: self.counts.clone(),
-		})
+		}
+		.produce()
 	}
 }
 
@@ -124,20 +129,6 @@ impl<T> ProducerWeak<T> {
 	pub fn read(&self) -> Ref<'_, T> {
 		Ref {
 			state: self.state.lock(),
-		}
-	}
-
-	/// Acquire mutable access to the shared state, like [`Producer::write`].
-	///
-	/// Returns `Ok(Mut)` if the channel is open, or `Err(Ref)` with read-only access
-	/// if closed. No new producer is minted, so this can't resurrect a channel or
-	/// perturb the producer count; a closed channel stays closed.
-	pub fn write(&self) -> Result<Mut<'_, T>, Ref<'_, T>> {
-		let state = self.state.lock();
-		if state.closed {
-			Err(Ref { state })
-		} else {
-			Ok(Mut::new(state))
 		}
 	}
 
@@ -381,41 +372,45 @@ mod test {
 		assert_eq!(Arc::strong_count(&alive), 2, "the state is alive");
 
 		let weak = producer.downgrade();
-		assert!(weak.upgrade().is_some());
+		assert!(weak.upgrade().is_some(), "upgradeable while the channel is live");
 
 		drop(producer);
 		assert_eq!(Arc::strong_count(&alive), 1, "the state is gone despite the cycle");
 		assert!(weak.upgrade().is_none());
 	}
 
-	/// A consumer draining a closed channel keeps the state around, so a weak handle
-	/// stored inside it still upgrades. It just can't write.
+	/// A closed channel never upgrades, even while a consumer is still draining it.
+	/// Producing into it again would resurrect a channel every reader has been told
+	/// is over.
 	#[test]
-	fn weak_upgrades_while_a_consumer_remains() {
+	fn weak_does_not_upgrade_once_closed() {
 		let producer = Producer::new(0u32);
 		let weak = producer.downgrade();
 		let consumer = producer.consume();
 
 		drop(producer);
-		let strong = weak.upgrade().expect("the consumer holds the state");
-		assert!(strong.is_closed());
-		assert!(strong.write().is_err(), "a closed channel stays closed");
+		assert!(weak.upgrade().is_none(), "closed, despite the state being alive");
 
-		// The upgraded handle owns the state too, so it has to go first.
-		drop(strong);
 		drop(consumer);
 		assert!(weak.upgrade().is_none());
 	}
 
-	/// Writing through a `ProducerWeak` notifies consumers without minting a producer.
+	/// An upgrade counts as a producer for as long as it lives, so the channel can't
+	/// close underneath it.
 	#[test]
-	fn producer_weak_writes() {
+	fn upgrade_holds_the_channel_open() {
 		let producer = Producer::new(0u32);
-		let weak = producer.weak();
+		let weak = producer.downgrade();
 		let consumer = producer.consume();
 
-		*weak.write().ok().expect("open") = 7;
-		assert_eq!(*consumer.read(), 7);
+		let upgraded = weak.upgrade().expect("open");
+		assert!(!producer.is_last(), "the upgrade is counted");
+
+		drop(producer);
+		assert!(!consumer.is_closed(), "the upgrade keeps it open");
+
+		drop(upgraded);
+		assert!(consumer.is_closed(), "dropping the last one closes it");
 	}
 
 	#[tokio::test]

--- a/rs/kio/src/weak.rs
+++ b/rs/kio/src/weak.rs
@@ -91,16 +91,15 @@ pub struct ProducerWeak<T> {
 impl<T> ProducerWeak<T> {
 	/// Upgrade to a [`Producer`], returning `None` if the channel is already closed.
 	pub fn produce(&self) -> Option<Producer<T>> {
-		// Increment first to prevent the last Producer::drop from
-		// closing the state between our check and the return.
-		self.counts.producers.fetch_add(1, Ordering::Relaxed);
-
 		{
+			// Registering under the same lock that guards `closed` is what makes the
+			// returned producer keep the channel open: a concurrent last-producer drop
+			// either closes first (and we bail) or sees our count and doesn't close.
 			let state = self.state.lock();
 			if state.closed {
-				self.counts.producers.fetch_sub(1, Ordering::Relaxed);
 				return None;
 			}
+			self.counts.producers.fetch_add(1, Ordering::Relaxed);
 		}
 
 		Some(Producer {
@@ -393,6 +392,44 @@ mod test {
 
 		drop(consumer);
 		assert!(weak.upgrade().is_none());
+	}
+
+	/// An upgrade racing the last producer's drop either loses (no handle) or wins
+	/// (a handle that is genuinely open). It must never hand back a producer for a
+	/// channel that the drop is about to close.
+	///
+	/// A smoke test, not a reproducer: the window is a few instructions wide and this
+	/// doesn't trip on the unsynchronized ordering even with the barrier. What rules
+	/// the interleaving out is doing the count transition under the state lock.
+	#[test]
+	fn upgrade_never_wins_a_closing_channel() {
+		for _ in 0..2_000 {
+			let producer = Producer::new(0u32);
+			let weak = producer.downgrade();
+			// Keeps the state allocated so the upgrade is about the channel, not the
+			// allocation.
+			let consumer = producer.consume();
+
+			// Line both threads up on the drop/upgrade window.
+			let gate = std::sync::Arc::new(std::sync::Barrier::new(2));
+			let dropper = {
+				let gate = gate.clone();
+				std::thread::spawn(move || {
+					gate.wait();
+					drop(producer);
+				})
+			};
+
+			gate.wait();
+			if let Some(upgraded) = weak.upgrade() {
+				assert!(
+					upgraded.write().is_ok(),
+					"an upgrade must not resolve a closing channel"
+				);
+			}
+			dropper.join().expect("dropper panicked");
+			drop(consumer);
+		}
 	}
 
 	/// An upgrade counts as a producer for as long as it lives, so the channel can't

--- a/rs/kio/src/weak.rs
+++ b/rs/kio/src/weak.rs
@@ -7,14 +7,76 @@ use crate::{
 	Closed, Counts, State,
 	consumer::Consumer,
 	lock::*,
-	producer::{Producer, Ref},
+	producer::{Mut, Producer, Ref},
 	waiter::*,
 };
+
+/// A handle that owns nothing at all ([`Producer::downgrade`](crate::Producer::downgrade)).
+///
+/// Unlike [`ProducerWeak`], which keeps the state allocated so it stays readable after
+/// the channel closes, this drops with the last real handle. That makes it the one
+/// handle you can store *inside* the state it points at (a child holding a link back to
+/// its parent, say) without the two keeping each other alive forever.
+///
+/// [`upgrade`](Self::upgrade) it while the state is still around.
+pub struct Weak<T> {
+	pub(crate) state: WeakLock<State<T>>,
+	pub(crate) counts: Arc<Counts>,
+}
+
+impl<T> Weak<T> {
+	/// A handle that never upgrades, mirroring [`std::sync::Weak::new`].
+	///
+	/// Useful as a placeholder for a link that isn't wired up yet, or that a
+	/// standalone (channel-less) value doesn't have.
+	pub fn new() -> Self {
+		Self {
+			state: WeakLock::new(),
+			counts: Arc::new(Counts::default()),
+		}
+	}
+
+	/// Recover a [`ProducerWeak`], or `None` once the state has been dropped.
+	///
+	/// The channel may still be closed; check or write through the returned handle.
+	pub fn upgrade(&self) -> Option<ProducerWeak<T>> {
+		Some(ProducerWeak {
+			state: self.state.upgrade()?,
+			counts: self.counts.clone(),
+		})
+	}
+}
+
+impl<T> Default for Weak<T> {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl<T> Clone for Weak<T> {
+	fn clone(&self) -> Self {
+		Self {
+			state: self.state.clone(),
+			counts: self.counts.clone(),
+		}
+	}
+}
+
+impl<T> std::fmt::Debug for Weak<T> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Weak")
+			.field("alive", &self.state.upgrade().is_some())
+			.finish()
+	}
+}
 
 /// A weak handle from the producing side ([`Producer::weak`](crate::Producer::weak)).
 ///
 /// Holds no ref count, so it never keeps the channel open. Upgrade it back to a [`Producer`]
 /// (write access) or a [`Consumer`] (read access) while the channel is still live.
+///
+/// It does keep the state *allocated*, which is what lets it read a closed channel's final
+/// value. Reach for [`Weak`] instead when the handle is stored inside that same state.
 #[derive(Debug)]
 pub struct ProducerWeak<T> {
 	pub(crate) state: Lock<State<T>>,
@@ -62,6 +124,20 @@ impl<T> ProducerWeak<T> {
 	pub fn read(&self) -> Ref<'_, T> {
 		Ref {
 			state: self.state.lock(),
+		}
+	}
+
+	/// Acquire mutable access to the shared state, like [`Producer::write`].
+	///
+	/// Returns `Ok(Mut)` if the channel is open, or `Err(Ref)` with read-only access
+	/// if closed. No new producer is minted, so this can't resurrect a channel or
+	/// perturb the producer count; a closed channel stays closed.
+	pub fn write(&self) -> Result<Mut<'_, T>, Ref<'_, T>> {
+		let state = self.state.lock();
+		if state.closed {
+			Err(Ref { state })
+		} else {
+			Ok(Mut::new(state))
 		}
 	}
 
@@ -284,6 +360,62 @@ mod test {
 
 		drop(consumer);
 		assert_eq!(weak.unused().await, Ok(()));
+	}
+
+	/// A state holding a handle back to itself is still deallocated once the last real
+	/// handle drops. `ProducerWeak` would keep it (and everything it owns) alive forever.
+	#[test]
+	fn weak_breaks_a_self_reference() {
+		struct Node {
+			// Only its refcount matters: it's how the test sees the state deallocate.
+			_alive: Arc<()>,
+			back: Option<Weak<Node>>,
+		}
+
+		let alive = Arc::new(());
+		let producer = Producer::new(Node {
+			_alive: alive.clone(),
+			back: None,
+		});
+		producer.write().ok().expect("open").back = Some(producer.downgrade());
+		assert_eq!(Arc::strong_count(&alive), 2, "the state is alive");
+
+		let weak = producer.downgrade();
+		assert!(weak.upgrade().is_some());
+
+		drop(producer);
+		assert_eq!(Arc::strong_count(&alive), 1, "the state is gone despite the cycle");
+		assert!(weak.upgrade().is_none());
+	}
+
+	/// A consumer draining a closed channel keeps the state around, so a weak handle
+	/// stored inside it still upgrades. It just can't write.
+	#[test]
+	fn weak_upgrades_while_a_consumer_remains() {
+		let producer = Producer::new(0u32);
+		let weak = producer.downgrade();
+		let consumer = producer.consume();
+
+		drop(producer);
+		let strong = weak.upgrade().expect("the consumer holds the state");
+		assert!(strong.is_closed());
+		assert!(strong.write().is_err(), "a closed channel stays closed");
+
+		// The upgraded handle owns the state too, so it has to go first.
+		drop(strong);
+		drop(consumer);
+		assert!(weak.upgrade().is_none());
+	}
+
+	/// Writing through a `ProducerWeak` notifies consumers without minting a producer.
+	#[test]
+	fn producer_weak_writes() {
+		let producer = Producer::new(0u32);
+		let weak = producer.weak();
+		let consumer = producer.consume();
+
+		*weak.write().ok().expect("open") = 7;
+		assert_eq!(*consumer.read(), 7);
 	}
 
 	#[tokio::test]

--- a/rs/kio/src/weak.rs
+++ b/rs/kio/src/weak.rs
@@ -404,7 +404,6 @@ mod test {
 		let consumer = producer.consume();
 
 		let upgraded = weak.upgrade().expect("open");
-		assert!(!producer.is_last(), "the upgrade is counted");
 
 		drop(producer);
 		assert!(!consumer.is_closed(), "the upgrade keeps it open");

--- a/rs/moq-net/src/error.rs
+++ b/rs/moq-net/src/error.rs
@@ -130,9 +130,9 @@ pub enum Error {
 	#[error("frame timestamp doesn't match track timescale")]
 	TimestampMismatch,
 
-	/// The group was evicted from the cache under memory pressure (see
-	/// [`cache::Pool`](crate::cache::Pool)). Unlike [`Self::Old`], the group was
-	/// still within the publisher's window; it can be re-fetched.
+	/// The group was evicted by its own track to pay eviction debt under memory
+	/// pressure (see [`cache::Pool`](crate::cache::Pool)). Unlike [`Self::Old`],
+	/// the group was still within the publisher's window; it can be re-fetched.
 	#[error("evicted")]
 	Evicted,
 

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -260,9 +260,9 @@ pub struct Producer {
 	// handle (threaded down by [`Self::create_track`] / [`Self::reserve_track`]).
 	info: Arc<Info>,
 
-	// Broadcast liveness. Consumers watch this (read-only) for close; dropping every
-	// producer (this handle and every `Dynamic`) ends the broadcast.
-	alive: kio::Producer<()>,
+	// Broadcast liveness, shared with every `Dynamic`. Consumers watch it (read-only)
+	// for close; the guard ends the broadcast when the last of those handles drops.
+	alive: Arc<Alive>,
 
 	// Track registry plus the dynamic request queue, mutated by producers and
 	// consumers alike under one lock.
@@ -277,10 +277,11 @@ pub struct Producer {
 impl Producer {
 	/// Create a producer for the given broadcast metadata. Prefer [`Info::produce`].
 	pub fn new(info: Info) -> Self {
+		let state = kio::Shared::<BroadcastState>::default();
 		Self {
 			info: Arc::new(info),
-			alive: Default::default(),
-			state: Default::default(),
+			alive: Alive::new(state.clone()),
+			state,
 			stats: stats::Scope::default(),
 		}
 	}
@@ -296,13 +297,14 @@ impl Producer {
 	/// tracks that are spliced across per-session tracks, queued for a route to
 	/// serve. Used by the origin for broadcasts reached over the network.
 	pub(crate) fn new_spliced(info: Info) -> Self {
+		let state = kio::Shared::new(BroadcastState {
+			spliced: Some(SplicedState::default()),
+			..Default::default()
+		});
 		Self {
 			info: Arc::new(info),
-			alive: Default::default(),
-			state: kio::Shared::new(BroadcastState {
-				spliced: Some(SplicedState::default()),
-				..Default::default()
-			}),
+			alive: Alive::new(state.clone()),
+			state,
 			// The origin-owned spliced broadcast stays untagged: egress attribution is
 			// applied when a tagged `origin::Consumer` hands the consumer out.
 			stats: stats::Scope::default(),
@@ -317,7 +319,7 @@ impl Producer {
 	/// A watch-only handle to the broadcast's demand. See [`Demand`].
 	pub fn demand(&self) -> Demand {
 		Demand {
-			alive: self.alive.consume().weak(),
+			alive: self.alive.token.consume().weak(),
 			state: self.state.clone(),
 		}
 	}
@@ -441,7 +443,7 @@ impl Producer {
 	pub fn consume(&self) -> Consumer {
 		Consumer {
 			info: self.info.clone(),
-			alive: self.alive.consume(),
+			alive: self.alive.token.consume(),
 			state: self.state.clone(),
 			route_seen: None,
 			stats: stats::Scope::default(),
@@ -469,7 +471,7 @@ impl Producer {
 		}
 		// Ending the broadcast is what consumers wait on, so signal it here rather
 		// than leaving it to the last handle drop.
-		let _ = self.alive.close();
+		let _ = self.alive.token.close();
 	}
 
 	/// Abort the broadcast, ending it for consumers with `err`.
@@ -493,7 +495,7 @@ impl Producer {
 			state.closing = true;
 			state.abort = Some(err);
 		}
-		let _ = self.alive.close();
+		let _ = self.alive.token.close();
 		Ok(())
 	}
 
@@ -503,16 +505,30 @@ impl Producer {
 	}
 }
 
-impl Drop for Producer {
+/// Ends the broadcast when the last [`Producer`] or [`Dynamic`] drops, closing the
+/// liveness channel every [`Consumer`] watches.
+///
+/// A refcount rather than a "am I the last one?" check inside `Drop`: that answer is
+/// a snapshot, and acting on it is exactly what invalidates it.
+struct Alive {
+	token: kio::Producer<()>,
+	state: kio::Shared<BroadcastState>,
+}
+
+impl Alive {
+	fn new(state: kio::Shared<BroadcastState>) -> Arc<Self> {
+		Arc::new(Self {
+			token: kio::Producer::default(),
+			state,
+		})
+	}
+}
+
+impl Drop for Alive {
 	fn drop(&mut self) {
-		// Only the last producer ending the broadcast matters; a clone dropping
-		// leaves it live (`alive` is shared with every `Dynamic` too). Warn if that
-		// last exit wasn't an explicit finish(), since consumers will then see
-		// Error::Dropped (classically a GC-collected handle in a language binding
-		// that tears the stream down mid-publish).
-		if !self.alive.is_last() {
-			return;
-		}
+		// Warn if the last exit wasn't an explicit finish(), since consumers will
+		// then see Error::Dropped (classically a GC-collected handle in a language
+		// binding that tears the stream down mid-publish).
 		if !self.state.read().closing {
 			tracing::warn!(
 				"broadcast::Producer dropped without finish(). Keep the producer alive while publishing, then call finish()."
@@ -589,7 +605,7 @@ impl Drop for SourceGuard {
 pub struct Dynamic {
 	info: Arc<Info>,
 	// Keeps the broadcast alive while a handler exists (mirrors a producer).
-	alive: kio::Producer<()>,
+	alive: Arc<Alive>,
 	state: kio::Shared<BroadcastState>,
 	// Ingress stats scope, applied to the tracks this handler serves. Empty (no-op)
 	// for an untagged broadcast.
@@ -613,7 +629,7 @@ impl Clone for Dynamic {
 }
 
 impl Dynamic {
-	fn new(info: Arc<Info>, alive: kio::Producer<()>, state: kio::Shared<BroadcastState>, stats: stats::Scope) -> Self {
+	fn new(info: Arc<Info>, alive: Arc<Alive>, state: kio::Shared<BroadcastState>, stats: stats::Scope) -> Self {
 		state.lock().requests.add_handler();
 
 		Self {
@@ -665,7 +681,7 @@ impl Dynamic {
 	pub fn consume(&self) -> Consumer {
 		Consumer {
 			info: self.info.clone(),
-			alive: self.alive.consume(),
+			alive: self.alive.token.consume(),
 			state: self.state.clone(),
 			route_seen: None,
 			stats: stats::Scope::default(),
@@ -682,7 +698,7 @@ impl Dynamic {
 	/// [`Producer::abort`], or [`Error::Dropped`] for a [`Producer::finish`] or a
 	/// dropped producer (check [`Consumer::is_finished`] to tell those apart).
 	pub fn poll_closed(&self, waiter: &kio::Waiter) -> Poll<Error> {
-		ready!(self.alive.poll_closed(waiter));
+		ready!(self.alive.token.poll_closed(waiter));
 		Poll::Ready(self.state.read().abort.clone().unwrap_or(Error::Dropped))
 	}
 

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -1,8 +1,9 @@
 //! A shared byte budget for cached groups, repaid by write-time eviction.
 //!
 //! Every group charges its cached bytes into a [`Pool`] through a crate-internal
-//! `Charge`. The pool itself never evicts: it is a handful of atomic counters. While
-//! the pool is over capacity, each track accrues eviction debt as it writes (`accrue`),
+//! `Charge`, billed to its track's `Track` account. The pool itself never evicts: it is
+//! a handful of atomic counters. While the pool is over capacity, each track accrues
+//! eviction debt as it writes (`accrue`),
 //! sized proportionally to what it wrote, and pays that debt by aborting its own oldest
 //! groups with [`Error::Evicted`](crate::Error::Evicted). Reclamation is therefore
 //! distributed across every writing track and converges on the capacity without any
@@ -24,6 +25,8 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
+
+use super::track::TrackState;
 
 /// Fixed bookkeeping charged per cached group on top of its frame payload bytes.
 ///
@@ -210,21 +213,95 @@ impl std::fmt::Debug for Pool {
 	}
 }
 
+/// Gross bytes a track writes before a frame write settles its eviction debt itself,
+/// so a track appending frames to open groups (never inserting another group) still
+/// pays. Coarse: the cost is one track-state lock per threshold crossing.
+const WRITE_CHARGE_THRESHOLD: u64 = 256 * 1024;
+
+/// One track's account against the [`Pool`], shared with every group it creates.
+///
+/// Groups charge their bytes here (through a [`Charge`]) rather than straight into the
+/// pool, so the track can drain what its own groups wrote into eviction debt and pay it
+/// off by evicting them. The link back to the track is a [`kio::Weak`] because the track
+/// owns its cached groups and each of those owns this account: anything stronger would
+/// make a track's cache immortal.
+///
+/// The default account is detached: an unbounded pool and no track, so every operation
+/// is a no-op.
+#[derive(Default)]
+pub(crate) struct Track {
+	pool: Pool,
+
+	// Gross bytes charged by this track's groups (payload plus overhead), never
+	// decremented here: the track swaps it out as it accrues debt.
+	written: AtomicU64,
+
+	// The track that pays this account off, holding the groups being charged.
+	state: kio::Weak<TrackState>,
+}
+
+impl Track {
+	/// Open an account against `pool` for the track behind `state`.
+	pub(crate) fn new(pool: Pool, state: kio::Weak<TrackState>) -> Arc<Self> {
+		Arc::new(Self {
+			pool,
+			written: AtomicU64::new(0),
+			state,
+		})
+	}
+
+	/// The pool this track caches into.
+	pub(crate) fn pool(&self) -> &Pool {
+		&self.pool
+	}
+
+	/// Charge a new group's fixed overhead, returning its [`Charge`].
+	pub(crate) fn charge(self: &Arc<Self>) -> Charge {
+		self.pool.add(ENTRY_OVERHEAD);
+		self.written.fetch_add(ENTRY_OVERHEAD, Ordering::Relaxed);
+		let last = self.pool.now();
+		Charge {
+			track: Some(self.clone()),
+			bytes: ENTRY_OVERHEAD,
+			last,
+			counted: false,
+		}
+	}
+
+	/// Take everything written since the last call, to be turned into eviction debt.
+	pub(crate) fn take_written(&self) -> u64 {
+		self.written.swap(0, Ordering::Relaxed)
+	}
+
+	/// Settle eviction debt from a frame write, once enough bytes accumulate.
+	///
+	/// Called with no group lock held (locks are ordered track then group). Cheap
+	/// until the threshold crosses: one relaxed load. This is what makes a track
+	/// that only appends frames to open groups, never inserting another group,
+	/// still pay its debt (and age its content out).
+	pub(crate) fn settle(&self) {
+		if self.written.load(Ordering::Relaxed) < WRITE_CHARGE_THRESHOLD {
+			return;
+		}
+		let Some(state) = self.state.upgrade() else { return };
+		if let Ok(mut state) = state.write() {
+			state.charge_debt();
+		}
+	}
+}
+
 /// The RAII byte accounting for one cached group, owned by the group's state.
 ///
 /// `add`/`sub` mirror the group's cached payload bytes into the pool with plain
 /// atomics, and every charged byte (overhead included) is also accumulated into the
-/// track's gross-write counter, which the track drains into eviction debt on its
-/// next write. The charge also owns the group's sample in the pool's access mean,
-/// so the sample lives exactly as long as the cached bytes do: aborting or dropping
-/// the group removes both, no matter who does it or when. The default charge is
-/// detached: it belongs to no pool and every operation is a no-op.
+/// track's account, which the track drains into eviction debt on its next write. The
+/// charge also owns the group's sample in the pool's access mean, so the sample lives
+/// exactly as long as the cached bytes do: aborting or dropping the group removes both,
+/// no matter who does it or when. The default charge is detached: it belongs to no
+/// account and every operation is a no-op.
 #[derive(Default)]
 pub(crate) struct Charge {
-	pool: Option<Pool>,
-	// The owning track's gross-write counter (see `track::Info`); never decremented
-	// here, the track swaps it out as it accrues debt.
-	written: Option<Arc<AtomicU64>>,
+	track: Option<Arc<Track>>,
 	// Bytes currently charged, including ENTRY_OVERHEAD, released on drop.
 	bytes: u64,
 	// Tick of the last cache access: creation, a FETCH hit, or a fetched backfill's
@@ -236,20 +313,6 @@ pub(crate) struct Charge {
 }
 
 impl Charge {
-	/// Charge a new group's fixed overhead into `pool`, counting it as written.
-	pub(crate) fn new(pool: Pool, written: Arc<AtomicU64>) -> Self {
-		pool.add(ENTRY_OVERHEAD);
-		written.fetch_add(ENTRY_OVERHEAD, Ordering::Relaxed);
-		let last = pool.now();
-		Self {
-			pool: Some(pool),
-			written: Some(written),
-			bytes: ENTRY_OVERHEAD,
-			last,
-			counted: false,
-		}
-	}
-
 	/// Charge `n` more payload bytes, counting them as written.
 	///
 	/// A write is also an access: it restarts the retention clock and keeps an
@@ -257,20 +320,18 @@ impl Charge {
 	/// being evicted or expired mid-write, even within the same coarse tick as
 	/// content that was merely inserted.
 	pub(crate) fn add(&mut self, n: u64) {
-		if let Some(pool) = &self.pool {
-			pool.add(n);
+		if let Some(track) = &self.track {
+			track.pool.add(n);
+			track.written.fetch_add(n, Ordering::Relaxed);
 			self.bytes += n;
-		}
-		if let Some(written) = &self.written {
-			written.fetch_add(n, Ordering::Relaxed);
 		}
 		self.touch(WRITE_BOOST);
 	}
 
 	/// Release `n` payload bytes (a frame evicted by the group's own cap).
 	pub(crate) fn sub(&mut self, n: u64) {
-		if let Some(pool) = &self.pool {
-			pool.sub(n);
+		if let Some(track) = &self.track {
+			track.pool.sub(n);
 			self.bytes = self.bytes.saturating_sub(n);
 		}
 	}
@@ -289,10 +350,10 @@ impl Charge {
 	/// or inserted behind it), sampling its access time into the pool's mean.
 	/// Idempotent.
 	pub(crate) fn demote(&mut self) {
-		if let Some(pool) = &self.pool
+		if let Some(track) = &self.track
 			&& !self.counted
 		{
-			pool.access_insert(self.last);
+			track.pool.access_insert(self.last);
 			self.counted = true;
 		}
 	}
@@ -310,13 +371,13 @@ impl Charge {
 	/// weaker accesses. Idempotent within a tick (monotone, never regressing), so
 	/// repeated accesses can't run ahead of the clock by more than the boost.
 	fn touch(&mut self, boost: u64) {
-		let Some(pool) = &self.pool else { return };
-		let target = pool.now().saturating_add(boost);
+		let Some(track) = &self.track else { return };
+		let target = track.pool.now().saturating_add(boost);
 		if target <= self.last {
 			return;
 		}
 		if self.counted {
-			pool.access_refresh(self.last, target);
+			track.pool.access_refresh(self.last, target);
 		}
 		self.last = target;
 	}
@@ -324,11 +385,11 @@ impl Charge {
 	/// Release everything this charge holds: bytes, overhead, and the access
 	/// sample. Idempotent; used when the group aborts and clears its frames.
 	pub(crate) fn clear(&mut self) {
-		if let Some(pool) = &self.pool {
-			pool.sub(self.bytes);
+		if let Some(track) = &self.track {
+			track.pool.sub(self.bytes);
 			self.bytes = 0;
 			if self.counted {
-				pool.access_remove(self.last);
+				track.pool.access_remove(self.last);
 				self.counted = false;
 			}
 		}
@@ -346,7 +407,8 @@ mod test {
 	use super::*;
 
 	fn charge(pool: &Pool) -> Charge {
-		Charge::new(pool.clone(), Arc::new(AtomicU64::new(0)))
+		// No track behind the account: nothing here settles debt, it just accounts.
+		Track::new(pool.clone(), kio::Weak::new()).charge()
 	}
 
 	#[test]
@@ -437,12 +499,12 @@ mod test {
 
 	#[test]
 	fn charge_counts_gross_writes() {
-		let pool = Pool::new(1000);
-		let written = Arc::new(AtomicU64::new(0));
-		let mut c = Charge::new(pool.clone(), written.clone());
+		let track = Track::new(Pool::new(1000), kio::Weak::new());
+		let mut c = track.charge();
 		c.add(100);
 		c.sub(40); // releases don't refund the gross counter
-		assert_eq!(written.load(Ordering::Relaxed), ENTRY_OVERHEAD + 100);
+		assert_eq!(track.take_written(), ENTRY_OVERHEAD + 100);
+		assert_eq!(track.take_written(), 0, "taking it drains the counter");
 	}
 
 	#[test]

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -33,7 +33,9 @@ const ENTRY_OVERHEAD: u64 = 256;
 /// The pool tracks how many payload bytes are cached across every registered group.
 /// It never evicts on its own: tracks accrue eviction debt as they write and evict
 /// their own oldest groups to pay it, so every operation here is a few atomics with
-/// no lock.
+/// no lock. The capacity is therefore a target usage converges toward, not a hard
+/// limit: carried debt, capped payments, and the always-protected live edge all let
+/// usage transiently exceed it.
 #[derive(Clone, Default)]
 pub struct Pool {
 	inner: Arc<Inner>,
@@ -60,10 +62,11 @@ impl Default for Inner {
 }
 
 impl Pool {
-	/// Create a pool with a byte budget that tracks evict toward as they write.
+	/// Create a pool with a byte target that tracks evict toward as they write.
 	///
 	/// The budget counts frame payload bytes (plus a small fixed overhead per
-	/// group), not process RSS; leave headroom when sizing it from real memory.
+	/// group), not process RSS, and is a convergence target rather than a hard
+	/// limit; leave headroom when sizing it from real memory.
 	pub fn new(capacity: u64) -> Self {
 		let pool = Self::default();
 		pool.inner.capacity.store(capacity, Ordering::Relaxed);
@@ -75,7 +78,7 @@ impl Pool {
 		Self::default()
 	}
 
-	/// The configured capacity in bytes, or `None` when unbounded.
+	/// The configured byte target, or `None` when unbounded.
 	pub fn capacity(&self) -> Option<u64> {
 		match self.inner.capacity.load(Ordering::Relaxed) {
 			u64::MAX => None,

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -283,6 +283,8 @@ impl Track {
 		if self.written.load(Ordering::Relaxed) < WRITE_CHARGE_THRESHOLD {
 			return;
 		}
+		// Counts as a producer while it lives, which is why `track::Producer` gates
+		// its teardown on its own clone count rather than the state's.
 		let Some(state) = self.state.upgrade() else { return };
 		if let Ok(mut state) = state.write() {
 			state.charge_debt();

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -245,10 +245,21 @@ impl Charge {
 	}
 
 	/// Charge `n` more payload bytes, counting them as written.
+	///
+	/// A write is also an access: it restarts the retention clock and keeps an
+	/// actively-growing group (a straggler or backfill still being filled) from
+	/// being evicted or expired mid-write.
 	pub(crate) fn add(&mut self, n: u64) {
 		if let Some(pool) = &self.pool {
 			pool.add(n);
 			self.bytes += n;
+			let now = pool.now();
+			if now > self.last {
+				if self.counted {
+					pool.access_refresh(self.last, now);
+				}
+				self.last = now;
+			}
 		}
 		if let Some(written) = &self.written {
 			written.fetch_add(n, Ordering::Relaxed);

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -1,22 +1,25 @@
-//! A shared byte budget for cached groups, reclaimed with LRU eviction.
+//! A shared byte budget for cached groups, repaid by write-time eviction.
 //!
-//! Every group registers its cached bytes in a [`Pool`]. When the pool exceeds its
-//! capacity, the least-recently-read groups are aborted with
-//! [`Error::Evicted`](crate::Error::Evicted), freeing their frames immediately. The
-//! latest group of each track is pinned and never evicted, so the live edge always
-//! survives memory pressure.
+//! Every group charges its cached bytes into a [`Pool`] through a crate-internal
+//! `Charge`. The pool itself never evicts: it is a handful of atomic counters. While
+//! the pool is over capacity, each track accrues eviction debt as it writes (`accrue`),
+//! sized proportionally to what it wrote, and pays that debt by aborting its own oldest
+//! groups with [`Error::Evicted`](crate::Error::Evicted). Reclamation is therefore
+//! distributed across every writing track and converges on the capacity without any
+//! global lock, registry, or background task.
+//!
+//! A group that a FETCH refreshed is spared by its track and its bytes are put back
+//! into the pool as `credit`; the credit is re-billed to all writers on top of their
+//! base debt, so protecting hot groups never lowers the total eviction rate, it only
+//! shifts it toward tracks whose content goes unread.
 //!
 //! A pool is inert by default ([`Pool::unbounded`]): publishers and subscribers that
 //! never set a capacity pay only a couple of atomic counters. A relay creates one
 //! bounded pool and shares it across every origin so the whole process caches into a
 //! single budget.
 
-use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashMap};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-
-use web_async::Lock;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Fixed bookkeeping charged per cached group on top of its frame payload bytes.
 ///
@@ -25,33 +28,25 @@ use web_async::Lock;
 /// just its payload bytes.
 const ENTRY_OVERHEAD: u64 = 256;
 
-/// Slack before [`Lru::compact`] rebuilds the heap, so a pool holding just a few
-/// entries doesn't rebuild on every registration.
-const COMPACT_SLACK: usize = 64;
-
 /// A shared byte budget that caches charge into; cloning shares the same budget.
 ///
-/// The pool tracks how many payload bytes are cached across every registered group
-/// and evicts the least-recently-read groups once `used` exceeds `capacity`.
-/// Eviction aborts the victim group with [`Error::Evicted`](crate::Error::Evicted),
-/// which frees its frames immediately and wakes any parked readers. Pinned (latest)
-/// groups are never evicted but still count against the budget.
-///
-/// Reads and writes only touch atomics; the internal lock is taken when a group
-/// registers/unregisters and when the pool is actually over budget.
+/// The pool tracks how many payload bytes are cached across every registered group.
+/// It never evicts on its own: tracks accrue eviction debt as they write and evict
+/// their own oldest groups to pay it, so every operation here is a few atomics with
+/// no lock.
 #[derive(Clone, Default)]
 pub struct Pool {
 	inner: Arc<Inner>,
 }
 
 struct Inner {
-	// Total bytes currently charged, including pinned entries and per-entry overhead.
+	// Total bytes currently charged, including per-entry overhead.
 	used: AtomicU64,
 	// u64::MAX means unbounded.
 	capacity: AtomicU64,
-	// Reference point for the coarse `last_access` clock.
-	epoch: web_async::time::Instant,
-	lru: Lock<Lru>,
+	// Bytes spared from eviction because a FETCH refreshed them, awaiting re-billing
+	// through `accrue` so the total eviction rate is conserved.
+	credit: AtomicU64,
 }
 
 impl Default for Inner {
@@ -59,97 +54,13 @@ impl Default for Inner {
 		Self {
 			used: AtomicU64::new(0),
 			capacity: AtomicU64::new(u64::MAX),
-			epoch: web_async::time::Instant::now(),
-			lru: Lock::default(),
+			credit: AtomicU64::new(0),
 		}
-	}
-}
-
-#[derive(Default)]
-struct Lru {
-	// Min-heap of (last_access snapshot, id). Snapshots go stale when an entry is
-	// touched; a popped entry whose current last_access differs is re-pushed with
-	// the fresh key instead of being evicted (lazy re-keying).
-	heap: BinaryHeap<Reverse<(u64, u64)>>,
-	// Live entries by id. An id popped from the heap that's no longer here was
-	// already evicted or dropped.
-	entries: HashMap<u64, Arc<Entry>>,
-	next_id: u64,
-}
-
-impl Lru {
-	/// Drop heap slots whose entry is gone, once they outnumber the live ones.
-	///
-	/// Unregistering leaves its heap slot behind to be discarded on a later pop,
-	/// but `evict` is the only thing that pops and it returns early while the pool
-	/// is under capacity -- so an UNBOUNDED pool never pops at all and the heap
-	/// would grow without bound. Rebuilding costs O(n) but is amortized by the
-	/// doubling threshold, so steady-state churn keeps the heap within 2x live.
-	fn compact(&mut self) {
-		if self.heap.len() <= 2 * self.entries.len() + COMPACT_SLACK {
-			return;
-		}
-		self.heap = self
-			.entries
-			.values()
-			.map(|entry| Reverse((entry.last_access.load(Ordering::Relaxed), entry.id)))
-			.collect();
-	}
-}
-
-/// A single cached group's registration in the pool.
-///
-/// Holds only atomics plus the eviction hook, so touching recency or flipping the
-/// pin never takes a lock.
-///
-/// The hook's `kio::ProducerWeak` does NOT make this cheap to leave registered:
-/// it holds no producer/consumer ref count, but it does hold the group's
-/// `Arc<Mutex<State>>` storage, so a live registration keeps the whole group
-/// alive. Registrations must therefore be dropped as soon as the group stops
-/// being an eviction candidate (see [`Charge::clear`]), not merely on `Drop`.
-pub(crate) struct Entry {
-	id: u64,
-	// Payload bytes plus ENTRY_OVERHEAD currently charged by this entry.
-	bytes: AtomicU64,
-	// Coarse milliseconds since the pool epoch of the last read (or write).
-	last_access: AtomicU64,
-	// Pinned entries (the track's latest group) are skipped by eviction.
-	pinned: AtomicBool,
-	// Aborts the group with Error::Evicted. Called without any pool lock held.
-	//
-	// `None` once the group stopped being an eviction candidate. Taking it is what
-	// releases the group's state, so it must be dropped (not just left registered)
-	// as soon as the group is dead -- see the type-level note above.
-	evict: Lock<Option<Box<dyn Fn() + Send + Sync>>>,
-	epoch: web_async::time::Instant,
-}
-
-impl Entry {
-	fn now(&self) -> u64 {
-		self.epoch.elapsed().as_millis() as u64
-	}
-
-	/// Take the eviction hook, so dropping it releases whatever it captured.
-	///
-	/// The caller MUST drop the returned hook with no pool lock held: releasing the
-	/// group's state can cascade into drops that re-enter the pool.
-	fn take_hook(&self) -> Option<Box<dyn Fn() + Send + Sync>> {
-		self.evict.lock().take()
-	}
-
-	/// Record a read so eviction considers this group recently used.
-	pub(crate) fn touch(&self) {
-		self.last_access.store(self.now(), Ordering::Relaxed);
-	}
-
-	/// Pin or unpin this entry. Pinned entries are immune to eviction.
-	pub(crate) fn set_pinned(&self, pinned: bool) {
-		self.pinned.store(pinned, Ordering::Relaxed);
 	}
 }
 
 impl Pool {
-	/// Create a pool that evicts once `capacity` bytes are cached.
+	/// Create a pool with a byte budget that tracks evict toward as they write.
 	///
 	/// The budget counts frame payload bytes (plus a small fixed overhead per
 	/// group), not process RSS; leave headroom when sizing it from real memory.
@@ -177,12 +88,13 @@ impl Pool {
 		self.inner.used.load(Ordering::Relaxed)
 	}
 
-	/// Change the capacity, evicting immediately if the new capacity is exceeded.
-	/// `None` makes the pool unbounded.
+	/// Change the capacity. `None` makes the pool unbounded.
+	///
+	/// Takes effect as tracks write: a shrink leaves the pool over budget, which every
+	/// subsequent write pays down proportionally. Nothing is reclaimed synchronously.
 	pub fn resize(&self, capacity: impl Into<Option<u64>>) {
 		let capacity = capacity.into().unwrap_or(u64::MAX);
 		self.inner.capacity.store(capacity, Ordering::Relaxed);
-		self.evict();
 	}
 
 	/// Returns true if both handles share the same underlying pool.
@@ -190,123 +102,58 @@ impl Pool {
 		Arc::ptr_eq(&self.inner, &other.inner)
 	}
 
-	/// Test-only snapshot of the live entries: (id, last_access ms, bytes, pinned),
-	/// plus the pool's current clock reading. For diagnosing eviction order.
-	#[cfg(test)]
-	pub(crate) fn debug_entries(&self) -> (u64, Vec<(u64, u64, u64, bool)>) {
-		let now = self.inner.epoch.elapsed().as_millis() as u64;
-		let lru = self.inner.lru.lock();
-		let mut entries: Vec<_> = lru
-			.entries
-			.values()
-			.map(|e| {
-				(
-					e.id,
-					e.last_access.load(Ordering::Relaxed),
-					e.bytes.load(Ordering::Relaxed),
-					e.pinned.load(Ordering::Relaxed),
-				)
-			})
-			.collect();
-		entries.sort_unstable();
-		(now, entries)
+	/// Charge `n` more cached bytes.
+	pub(crate) fn add(&self, n: u64) {
+		self.inner.used.fetch_add(n, Ordering::Relaxed);
 	}
 
-	/// Register a group, returning the [`Charge`] that tracks its bytes.
-	///
-	/// `evict` must abort the group (releasing its charge); it is invoked without
-	/// any pool lock held, and never after the returned charge is dropped.
-	pub(crate) fn register(&self, evict: Box<dyn Fn() + Send + Sync>) -> Charge {
-		let inner = self.inner.clone();
-		let entry = {
-			let mut lru = inner.lru.lock();
-			let id = lru.next_id;
-			lru.next_id += 1;
-
-			let entry = Arc::new(Entry {
-				id,
-				bytes: AtomicU64::new(ENTRY_OVERHEAD),
-				last_access: AtomicU64::new(0),
-				pinned: AtomicBool::new(false),
-				evict: Lock::new(Some(evict)),
-				epoch: inner.epoch,
-			});
-			entry.touch();
-
-			lru.entries.insert(id, entry.clone());
-			lru.heap.push(Reverse((entry.last_access.load(Ordering::Relaxed), id)));
-			lru.compact();
-			entry
-		};
-
-		inner.used.fetch_add(ENTRY_OVERHEAD, Ordering::Relaxed);
-		Charge {
-			inner: Some((inner, entry)),
-		}
+	/// Release `n` cached bytes.
+	pub(crate) fn sub(&self, n: u64) {
+		self.inner.used.fetch_sub(n, Ordering::Relaxed);
 	}
 
-	/// Evict least-recently-read groups until the pool is back under capacity.
+	/// The eviction debt a track takes on by writing `written` bytes, or `None` while
+	/// the pool is under capacity (the caller should forget any outstanding debt).
 	///
-	/// Victims are collected under the lock but aborted after it's released, so an
-	/// eviction hook can freely take its group's lock.
-	pub(crate) fn evict(&self) {
-		let inner = &self.inner;
-		if inner.used.load(Ordering::Relaxed) <= inner.capacity.load(Ordering::Relaxed) {
-			return;
+	/// The base debt is `written * used / capacity`, so paying it evicts slightly
+	/// more than was written and the overshoot decays toward the capacity. On top of
+	/// that, a proportional share of the outstanding [`credit`](Self::credit) is
+	/// drained and re-billed, conserving the total eviction rate when hot groups are
+	/// being spared.
+	pub(crate) fn accrue(&self, written: u64) -> Option<u64> {
+		let used = self.inner.used.load(Ordering::Relaxed);
+		let capacity = self.inner.capacity.load(Ordering::Relaxed);
+		if used <= capacity {
+			return None;
 		}
 
-		let mut victims = Vec::new();
-		{
-			let mut lru = inner.lru.lock();
-			// Bytes the collected victims will release once aborted below.
-			let mut freed = 0u64;
-			// Pinned entries popped this pass; re-pushing them immediately would just
-			// pop them again (same key), so they're held aside until the pass ends.
-			let mut pinned = Vec::new();
-			// Bounding the pops guarantees termination: an entry needs at most two
-			// (one re-key of its stale snapshot, one settle). A concurrent touch can
-			// steal a slot, ending the pass early; the next write retries.
-			let mut budget = 2 * lru.heap.len();
+		let capacity = capacity.max(1) as u128;
+		let base = (written as u128 * used as u128 / capacity) as u64;
 
-			while budget > 0
-				&& inner.used.load(Ordering::Relaxed).saturating_sub(freed) > inner.capacity.load(Ordering::Relaxed)
-			{
-				budget -= 1;
-				let Some(Reverse((snapshot, id))) = lru.heap.pop() else {
-					break;
-				};
-				let Some(entry) = lru.entries.get(&id) else {
-					// Already evicted or dropped; discard the stale heap slot.
-					continue;
-				};
-				let access = entry.last_access.load(Ordering::Relaxed);
-				if access != snapshot {
-					// Touched since this snapshot; re-key instead of evicting.
-					lru.heap.push(Reverse((access, id)));
-					continue;
-				}
-				if entry.pinned.load(Ordering::Relaxed) {
-					pinned.push(Reverse((access, id)));
-					continue;
-				}
-
-				let entry = lru.entries.remove(&id).unwrap();
-				freed += entry.bytes.load(Ordering::Relaxed);
-				victims.push(entry);
-			}
-
-			for slot in pinned {
-				lru.heap.push(slot);
-			}
+		// Drain credit over roughly one capacity turnover of writes, claiming only
+		// what's actually left so racing writers never re-bill the same bytes twice.
+		let credit = self.inner.credit.load(Ordering::Relaxed);
+		let mut drain = (written as u128 * credit as u128 / capacity) as u64;
+		if drain > 0 {
+			let claimed = self
+				.inner
+				.credit
+				.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
+					Some(cur.saturating_sub(drain))
+				})
+				.unwrap_or(0);
+			drain = drain.min(claimed);
 		}
 
-		// Taking the hook also drops it once it has run, releasing the group state
-		// the closure captured. The pool lock is already released here.
-		for victim in victims {
-			if let Some(hook) = victim.take_hook() {
-				hook();
-			}
-		}
+		Some(base.saturating_add(drain))
+	}
+
+	/// Report `n` bytes spared from eviction because a FETCH refreshed them.
+	///
+	/// The spared bytes count as debt paid for the sparing track and are re-billed to
+	/// all writers through [`Self::accrue`].
+	pub(crate) fn credit(&self, n: u64) {
+		self.inner.credit.fetch_add(n, Ordering::Relaxed);
 	}
 }
 
@@ -319,315 +166,158 @@ impl std::fmt::Debug for Pool {
 	}
 }
 
-/// The RAII side of a group's pool registration, owned by the group's state.
+/// The RAII byte accounting for one cached group, owned by the group's state.
 ///
 /// `add`/`sub` mirror the group's cached payload bytes into the pool with plain
-/// atomics; no lock is taken until the group unregisters. Dropping (or
-/// [`clear`](Self::clear)ing) the charge releases everything it holds. The default
-/// charge is detached: it belongs to no pool and every operation is a no-op.
+/// atomics. Dropping (or [`clear`](Self::clear)ing) the charge releases everything it
+/// holds. The default charge is detached: it belongs to no pool and every operation
+/// is a no-op.
 #[derive(Default)]
 pub(crate) struct Charge {
-	inner: Option<(Arc<Inner>, Arc<Entry>)>,
+	pool: Option<Pool>,
+	// Bytes currently charged, including ENTRY_OVERHEAD, released on drop.
+	bytes: u64,
 }
 
 impl Charge {
-	/// Charge `n` more payload bytes and mark the group recently used.
-	///
-	/// Doesn't evict; callers trigger [`Pool::evict`] after releasing their own locks.
-	pub(crate) fn add(&self, n: u64) {
-		if let Some((inner, entry)) = &self.inner {
-			entry.bytes.fetch_add(n, Ordering::Relaxed);
-			inner.used.fetch_add(n, Ordering::Relaxed);
-			entry.touch();
+	/// Charge a new group's fixed overhead into `pool`.
+	pub(crate) fn new(pool: Pool) -> Self {
+		pool.add(ENTRY_OVERHEAD);
+		Self {
+			pool: Some(pool),
+			bytes: ENTRY_OVERHEAD,
+		}
+	}
+
+	/// Charge `n` more payload bytes.
+	pub(crate) fn add(&mut self, n: u64) {
+		if let Some(pool) = &self.pool {
+			pool.add(n);
+			self.bytes += n;
 		}
 	}
 
 	/// Release `n` payload bytes (a frame evicted by the group's own cap).
-	pub(crate) fn sub(&self, n: u64) {
-		if let Some((inner, entry)) = &self.inner {
-			entry.bytes.fetch_sub(n, Ordering::Relaxed);
-			inner.used.fetch_sub(n, Ordering::Relaxed);
+	pub(crate) fn sub(&mut self, n: u64) {
+		if let Some(pool) = &self.pool {
+			pool.sub(n);
+			self.bytes = self.bytes.saturating_sub(n);
 		}
 	}
 
-	/// Release everything this charge holds (bytes and overhead) AND drop the
-	/// pool's registration. Idempotent; used when the group aborts and clears its
-	/// frames.
-	///
-	/// Unregistering here, rather than waiting for [`Drop`], is what keeps an
-	/// unbounded pool from growing without bound. The pool's `entries` map holds an
-	/// `Arc<Entry>`, the entry owns the eviction hook, and the hook captures a
-	/// `kio::ProducerWeak<GroupState>` -- which holds no producer/consumer ref count
-	/// but DOES hold the group's `Arc<Mutex<State>>` storage alive. So the map keeps
-	/// the group's state alive, the state owns this charge, and `Charge::drop` (the
-	/// only other unregister) can never run: a cycle, one per group forever.
-	/// `Pool::evict` also unregisters and would break it, but it returns early while
-	/// under capacity, so an unbounded pool never gets there.
-	///
-	/// A released group holds no bytes and is closed, so it is not an eviction
-	/// candidate and has no reason to stay registered.
-	pub(crate) fn clear(&self) {
-		let Some((inner, entry)) = &self.inner else {
-			return;
-		};
-
-		let bytes = entry.bytes.swap(0, Ordering::Relaxed);
-		inner.used.fetch_sub(bytes, Ordering::Relaxed);
-
-		{
-			// Safe to take the pool lock under the group's own lock: `Pool::evict`
-			// releases the pool lock BEFORE invoking a hook that locks a group, so
-			// no thread ever holds the pool lock while waiting on a group lock.
-			let mut lru = inner.lru.lock();
-			lru.entries.remove(&entry.id);
-			lru.compact();
+	/// Release everything this charge holds (bytes and overhead). Idempotent; used
+	/// when the group aborts and clears its frames.
+	pub(crate) fn clear(&mut self) {
+		if let Some(pool) = &self.pool {
+			pool.sub(self.bytes);
+			self.bytes = 0;
 		}
-
-		// Drop the hook with no pool lock held (see `Entry::take_hook`). This is the
-		// drop that actually frees the group: the caller holds the group's state
-		// lock, so its storage outlives this by at least that handle.
-		drop(entry.take_hook());
-	}
-
-	/// Mark the group recently used (a consumer read a frame).
-	pub(crate) fn touch(&self) {
-		if let Some((_, entry)) = &self.inner {
-			entry.touch();
-		}
-	}
-
-	/// The registration entry, for pinning. `None` when detached.
-	pub(crate) fn entry(&self) -> Option<Arc<Entry>> {
-		self.inner.as_ref().map(|(_, entry)| entry.clone())
 	}
 }
 
 impl Drop for Charge {
 	fn drop(&mut self) {
-		let Some((inner, entry)) = self.inner.take() else {
-			return;
-		};
-		let bytes = entry.bytes.swap(0, Ordering::Relaxed);
-		inner.used.fetch_sub(bytes, Ordering::Relaxed);
-		// The heap slot (if any) goes stale and is discarded on its next pop.
-		inner.lru.lock().entries.remove(&entry.id);
+		self.clear();
 	}
 }
 
 #[cfg(test)]
 mod test {
 	use super::*;
-	use std::time::Duration;
-
-	fn flag() -> (Arc<AtomicBool>, Box<dyn Fn() + Send + Sync>) {
-		let evicted = Arc::new(AtomicBool::new(false));
-		let hook = evicted.clone();
-		(
-			evicted,
-			Box::new(move || {
-				hook.store(true, Ordering::Relaxed);
-			}),
-		)
-	}
 
 	#[test]
-	fn unbounded_never_evicts() {
+	fn unbounded_never_accrues() {
 		let pool = Pool::unbounded();
-		let (evicted, hook) = flag();
-		let charge = pool.register(hook);
+		let mut charge = Charge::new(pool.clone());
 		charge.add(1 << 40);
-		pool.evict();
-		assert!(!evicted.load(Ordering::Relaxed));
+		assert_eq!(pool.accrue(1 << 30), None);
 		assert_eq!(pool.used(), (1 << 40) + ENTRY_OVERHEAD);
 		drop(charge);
 		assert_eq!(pool.used(), 0);
 	}
 
-	/// An unbounded pool must not accumulate bookkeeping for groups that have
-	/// released their cache. Before the fix `entries` grew one slot per group
-	/// forever (each holding the group's whole state alive through the eviction
-	/// hook's `ProducerWeak`), because `evict` -- the only unregister that runs
-	/// under capacity -- returns early on an unbounded pool. Observed as ~75 kB/s
-	/// of RSS growth in a publisher, which is `moq-cli`'s default configuration.
 	#[test]
-	fn unbounded_reclaims_cleared_entries() {
-		let pool = Pool::unbounded();
-
-		// Churn far more groups than could ever be live at once, the way a
-		// publisher does: register, charge some bytes, then release on abort.
-		for _ in 0..10_000 {
-			let (_evicted, hook) = flag();
-			let charge = pool.register(hook);
-			charge.add(4096);
-			charge.clear();
-		}
-
-		let (live, entries) = {
-			let lru = pool.inner.lru.lock();
-			(lru.entries.len(), lru.heap.len())
-		};
-		assert_eq!(live, 0, "cleared groups must not stay registered");
-		assert!(
-			entries <= 2 * COMPACT_SLACK,
-			"stale heap slots must be compacted, got {entries}"
-		);
-		assert_eq!(pool.used(), 0);
+	fn accrue_none_under_capacity() {
+		let pool = Pool::new(1000);
+		let mut charge = Charge::new(pool.clone());
+		charge.add(500);
+		assert_eq!(pool.accrue(100), None);
 	}
 
-	/// A cleared charge must not keep its group's state alive: the hook is the
-	/// only thing holding it, so dropping the registration must drop the hook.
 	#[test]
-	fn clear_releases_the_eviction_hook() {
-		let pool = Pool::unbounded();
-		let canary = Arc::new(());
-		let held = canary.clone();
+	fn accrue_proportional_over_capacity() {
+		let pool = Pool::new(1000);
+		let mut charge = Charge::new(pool.clone());
+		charge.add(2000 - ENTRY_OVERHEAD); // used = 2000, twice the capacity
 
-		let charge = pool.register(Box::new(move || {
-			// Capture a strong ref the way the real hook captures group state.
-			let _ = &held;
-		}));
-		assert_eq!(Arc::strong_count(&canary), 2, "hook holds the capture");
+		// Debt exceeds what was written by the overshoot ratio, so the pool drains.
+		assert_eq!(pool.accrue(100), Some(200));
+		// Zero written accrues zero: an idle track takes on no debt.
+		assert_eq!(pool.accrue(0), Some(0));
+	}
+
+	#[test]
+	fn accrue_drains_credit() {
+		let pool = Pool::new(1000);
+		let mut charge = Charge::new(pool.clone());
+		charge.add(2000 - ENTRY_OVERHEAD); // used = 2000
+
+		// A spared group re-bills its bytes on top of the base debt: base 200 plus
+		// 100 * 500/1000 = 50 of the credit.
+		pool.credit(500);
+		assert_eq!(pool.accrue(100), Some(250));
+
+		// The drained share is claimed, not copied: repeated accruals exhaust it.
+		let mut total = 250u64;
+		for _ in 0..100 {
+			total += pool.accrue(100).unwrap() - 200;
+		}
+		assert!(total <= 250 + 500, "drained more credit than was granted");
+	}
+
+	#[test]
+	fn charge_raii() {
+		let pool = Pool::new(1000);
+		let mut charge = Charge::new(pool.clone());
+		assert_eq!(pool.used(), ENTRY_OVERHEAD);
+
+		charge.add(100);
+		assert_eq!(pool.used(), ENTRY_OVERHEAD + 100);
+		charge.sub(40);
+		assert_eq!(pool.used(), ENTRY_OVERHEAD + 60);
 
 		charge.clear();
-		assert_eq!(
-			Arc::strong_count(&canary),
-			1,
-			"clearing must drop the hook, releasing whatever it captured"
-		);
+		assert_eq!(pool.used(), 0);
+		// Idempotent: a second clear (and the eventual drop) releases nothing more.
+		charge.clear();
+		drop(charge);
+		assert_eq!(pool.used(), 0);
 	}
 
 	#[test]
 	fn detached_charge_is_noop() {
-		let charge = Charge::default();
+		let mut charge = Charge::default();
 		charge.add(123);
 		charge.sub(23);
 		charge.clear();
-		charge.touch();
-		assert!(charge.entry().is_none());
-	}
-
-	#[tokio::test]
-	async fn evicts_least_recently_used() {
-		tokio::time::pause();
-
-		let pool = Pool::new(3 * ENTRY_OVERHEAD + 2500);
-		let (evicted_a, hook_a) = flag();
-		let (evicted_b, hook_b) = flag();
-		let (evicted_c, hook_c) = flag();
-
-		let a = pool.register(hook_a);
-		a.add(1000);
-		tokio::time::advance(Duration::from_millis(10)).await;
-		let b = pool.register(hook_b);
-		b.add(1000);
-		tokio::time::advance(Duration::from_millis(10)).await;
-
-		// Read A so B becomes the least recently used.
-		a.touch();
-		tokio::time::advance(Duration::from_millis(10)).await;
-
-		let c = pool.register(hook_c);
-		c.add(1000);
-		// Over budget by 500: evicting B (stalest) is enough once its charge clears.
-		pool.evict();
-
-		assert!(!evicted_a.load(Ordering::Relaxed));
-		assert!(evicted_b.load(Ordering::Relaxed));
-		assert!(!evicted_c.load(Ordering::Relaxed));
-
-		// The hook is responsible for releasing the charge (a real group aborts).
-		b.clear();
-		assert_eq!(pool.used(), 2 * (1000 + ENTRY_OVERHEAD));
-	}
-
-	#[tokio::test]
-	async fn pinned_entries_survive() {
-		tokio::time::pause();
-
-		let pool = Pool::new(ENTRY_OVERHEAD);
-		let (evicted_a, hook_a) = flag();
-		let (evicted_b, hook_b) = flag();
-
-		let a = pool.register(hook_a);
-		a.entry().unwrap().set_pinned(true);
-		a.add(1000);
-		tokio::time::advance(Duration::from_millis(10)).await;
-
-		let b = pool.register(hook_b);
-		b.add(1000);
-
-		pool.evict();
-		// A is older but pinned; B is the only eligible victim.
-		assert!(!evicted_a.load(Ordering::Relaxed));
-		assert!(evicted_b.load(Ordering::Relaxed));
-
-		// With B gone, everything left is pinned: eviction terminates without
-		// touching A even though the pool stays over budget.
-		b.clear();
-		drop(b);
-		pool.evict();
-		assert!(!evicted_a.load(Ordering::Relaxed));
-	}
-
-	#[tokio::test]
-	async fn resize_evicts() {
-		tokio::time::pause();
-
-		let pool = Pool::unbounded();
-		let (evicted_a, hook_a) = flag();
-		let a = pool.register(hook_a);
-		a.add(1000);
-
-		pool.evict();
-		assert!(!evicted_a.load(Ordering::Relaxed));
-
-		pool.resize(100);
-		assert!(evicted_a.load(Ordering::Relaxed));
-
-		// Back to unbounded: nothing more to do, and capacity() reports None.
-		pool.resize(None);
-		assert_eq!(pool.capacity(), None);
-	}
-
-	#[tokio::test]
-	async fn touched_entry_is_rekeyed_not_evicted() {
-		tokio::time::pause();
-
-		let pool = Pool::new(2 * ENTRY_OVERHEAD + 1500);
-		let (evicted_a, hook_a) = flag();
-		let (evicted_b, hook_b) = flag();
-
-		let a = pool.register(hook_a);
-		a.add(1000);
-		tokio::time::advance(Duration::from_millis(10)).await;
-		let b = pool.register(hook_b);
-		b.add(1000);
-		tokio::time::advance(Duration::from_millis(10)).await;
-
-		// A's heap snapshot is stale after this touch, so eviction re-keys A and
-		// picks B instead.
-		a.touch();
-		tokio::time::advance(Duration::from_millis(10)).await;
-		pool.evict();
-
-		assert!(!evicted_a.load(Ordering::Relaxed));
-		assert!(evicted_b.load(Ordering::Relaxed));
 	}
 
 	#[test]
-	fn dropped_charge_leaves_stale_heap_slot() {
-		let pool = Pool::new(0);
-		let (evicted_a, hook_a) = flag();
-		let a = pool.register(hook_a);
-		drop(a);
+	fn resize() {
+		let pool = Pool::unbounded();
+		assert_eq!(pool.capacity(), None);
 
-		// The heap still has A's slot, but the entry is gone: eviction discards it
-		// without calling the hook.
-		let (evicted_b, hook_b) = flag();
-		let b = pool.register(hook_b);
-		b.add(1);
-		pool.evict();
-		assert!(!evicted_a.load(Ordering::Relaxed));
-		assert!(evicted_b.load(Ordering::Relaxed));
+		let mut charge = Charge::new(pool.clone());
+		charge.add(1000);
+
+		// Shrinking doesn't reclaim anything synchronously; writers accrue debt instead.
+		pool.resize(100);
+		assert_eq!(pool.capacity(), Some(100));
+		assert!(pool.used() > 100);
+		assert!(pool.accrue(50).unwrap() > 50);
+
+		pool.resize(None);
+		assert_eq!(pool.capacity(), None);
+		assert_eq!(pool.accrue(50), None);
 	}
 }

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -8,10 +8,13 @@
 //! distributed across every writing track and converges on the capacity without any
 //! global lock, registry, or background task.
 //!
-//! A group that a FETCH refreshed is spared by its track and its bytes are put back
-//! into the pool as `credit`; the credit is re-billed to all writers on top of their
-//! base debt, so protecting hot groups never lowers the total eviction rate, it only
-//! shifts it toward tracks whose content goes unread.
+//! Cross-track ordering comes from one statistic: the mean last-access time of the
+//! evictable population (every cached group except each track's protected latest).
+//! A group accessed more recently than that mean is never evicted, so a fresh fetch
+//! in one track can't die while another track holds staler content, and a track
+//! whose oldest group is staler than the mean accrues debt at double rate. Evicting
+//! old entries and inserting new ones both advance the mean, so the eviction
+//! frontier moves with cache turnover on its own.
 //!
 //! A pool is inert by default ([`Pool::unbounded`]): publishers and subscribers that
 //! never set a capacity pay only a couple of atomic counters. A relay creates one
@@ -20,22 +23,34 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 
 /// Fixed bookkeeping charged per cached group on top of its frame payload bytes.
 ///
 /// Covers the group/track slot allocations so a track producing many tiny groups
 /// (e.g. one frame per group) is billed roughly for its real footprint instead of
-/// just its payload bytes.
+/// just its payload bytes. Also bounds the live group count (`used / 256`), which
+/// keeps the access-time sum below u64 (see [`TICK_MS`]).
 const ENTRY_OVERHEAD: u64 = 256;
+
+/// Milliseconds per tick of the coarse clock behind access timestamps.
+///
+/// Coarse ticks keep the count-weighted timestamp sum far from u64 overflow: the
+/// sum is bounded by `elapsed_ticks * live_groups`, live groups are bounded by
+/// `used / ENTRY_OVERHEAD`, and twenty years of ticks (6.3e9) times a 64 GiB
+/// target's worst-case ~270M groups is ~1.7e18, a tenth of `u64::MAX`. A
+/// byte-weighted mean would overflow u64 even at whole-second ticks, which is why
+/// the mean is count-weighted.
+const TICK_MS: u64 = 100;
 
 /// A shared byte budget that caches charge into; cloning shares the same budget.
 ///
-/// The pool tracks how many payload bytes are cached across every registered group.
-/// It never evicts on its own: tracks accrue eviction debt as they write and evict
-/// their own oldest groups to pay it, so every operation here is a few atomics with
-/// no lock. The capacity is therefore a target usage converges toward, not a hard
-/// limit: carried debt, capped payments, and the always-protected live edge all let
-/// usage transiently exceed it.
+/// The pool tracks how many payload bytes are cached across every registered group,
+/// plus the mean last-access time of the evictable ones. It never evicts on its own:
+/// tracks accrue eviction debt as they write and evict their own oldest groups to
+/// pay it, so every operation here is a few atomics with no lock. The capacity is
+/// therefore a target usage converges toward, not a hard limit: carried debt, capped
+/// payments, and the always-protected live edge all let usage transiently exceed it.
 #[derive(Clone, Default)]
 pub struct Pool {
 	inner: Arc<Inner>,
@@ -46,9 +61,13 @@ struct Inner {
 	used: AtomicU64,
 	// u64::MAX means unbounded.
 	capacity: AtomicU64,
-	// Bytes spared from eviction because a FETCH refreshed them, awaiting re-billing
-	// through `accrue` so the total eviction rate is conserved.
-	credit: AtomicU64,
+	// Reference point for the coarse tick clock.
+	epoch: web_async::time::Instant,
+	// Sum and count of last-access ticks across the evictable population, giving a
+	// count-weighted mean. Tracks add a group when it becomes evictable (demoted
+	// from the live edge, or inserted behind it) and remove it when it leaves.
+	access_sum: AtomicU64,
+	access_count: AtomicU64,
 }
 
 impl Default for Inner {
@@ -56,7 +75,9 @@ impl Default for Inner {
 		Self {
 			used: AtomicU64::new(0),
 			capacity: AtomicU64::new(u64::MAX),
-			credit: AtomicU64::new(0),
+			epoch: web_async::time::Instant::now(),
+			access_sum: AtomicU64::new(0),
+			access_count: AtomicU64::new(0),
 		}
 	}
 }
@@ -115,48 +136,60 @@ impl Pool {
 		self.inner.used.fetch_sub(n, Ordering::Relaxed);
 	}
 
+	/// Coarse ticks since the pool was created: the clock access timestamps use.
+	pub(crate) fn now(&self) -> u64 {
+		self.inner.epoch.elapsed().as_millis() as u64 / TICK_MS
+	}
+
+	/// Convert a duration into coarse ticks, saturating.
+	pub(crate) fn ticks(duration: Duration) -> u64 {
+		u64::try_from(duration.as_millis() / TICK_MS as u128).unwrap_or(u64::MAX)
+	}
+
+	/// Mean last-access tick across the evictable population, or `None` when it is
+	/// empty. The sum and count are read separately, so the mean is approximate
+	/// under concurrent updates; eviction only needs a rough frontier.
+	pub(crate) fn average(&self) -> Option<u64> {
+		let count = self.inner.access_count.load(Ordering::Relaxed);
+		if count == 0 {
+			return None;
+		}
+		Some(self.inner.access_sum.load(Ordering::Relaxed) / count)
+	}
+
+	/// A group with last-access tick `ts` joined the evictable population.
+	pub(crate) fn access_insert(&self, ts: u64) {
+		self.inner.access_sum.fetch_add(ts, Ordering::Relaxed);
+		self.inner.access_count.fetch_add(1, Ordering::Relaxed);
+	}
+
+	/// A group with last-access tick `ts` left the evictable population.
+	pub(crate) fn access_remove(&self, ts: u64) {
+		self.inner.access_sum.fetch_sub(ts, Ordering::Relaxed);
+		self.inner.access_count.fetch_sub(1, Ordering::Relaxed);
+	}
+
+	/// An evictable group's last-access tick moved from `old` to `new` (a FETCH hit).
+	pub(crate) fn access_refresh(&self, old: u64, new: u64) {
+		// A single wrapping add keeps the sum exact even under racing refreshes.
+		self.inner
+			.access_sum
+			.fetch_add(new.wrapping_sub(old), Ordering::Relaxed);
+	}
+
 	/// The eviction debt a track takes on by writing `written` bytes, or `None` while
 	/// the pool is under capacity (the caller should forget any outstanding debt).
 	///
-	/// The base debt is `written * used / capacity`, so paying it evicts slightly
-	/// more than was written and the overshoot decays toward the capacity. On top of
-	/// that, a proportional share of the outstanding [`credit`](Self::credit) is
-	/// drained and re-billed, conserving the total eviction rate when hot groups are
-	/// being spared.
+	/// The debt is `written * used / capacity`, so paying it evicts slightly more
+	/// than was written and the overshoot decays toward the capacity. Tracks double
+	/// it when their oldest content is staler than [`Self::average`].
 	pub(crate) fn accrue(&self, written: u64) -> Option<u64> {
 		let used = self.inner.used.load(Ordering::Relaxed);
 		let capacity = self.inner.capacity.load(Ordering::Relaxed);
 		if used <= capacity {
 			return None;
 		}
-
-		let capacity = capacity.max(1) as u128;
-		let base = (written as u128 * used as u128 / capacity) as u64;
-
-		// Drain credit over roughly one capacity turnover of writes, claiming only
-		// what's actually left so racing writers never re-bill the same bytes twice.
-		let credit = self.inner.credit.load(Ordering::Relaxed);
-		let mut drain = (written as u128 * credit as u128 / capacity) as u64;
-		if drain > 0 {
-			let claimed = self
-				.inner
-				.credit
-				.fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
-					Some(cur.saturating_sub(drain))
-				})
-				.unwrap_or(0);
-			drain = drain.min(claimed);
-		}
-
-		Some(base.saturating_add(drain))
-	}
-
-	/// Report `n` bytes spared from eviction because a FETCH refreshed them.
-	///
-	/// The spared bytes count as debt paid for the sparing track and are re-billed to
-	/// all writers through [`Self::accrue`].
-	pub(crate) fn credit(&self, n: u64) {
-		self.inner.credit.fetch_add(n, Ordering::Relaxed);
+		Some((written as u128 * used as u128 / capacity.max(1) as u128) as u64)
 	}
 }
 
@@ -260,22 +293,22 @@ mod test {
 	}
 
 	#[test]
-	fn accrue_drains_credit() {
+	fn average_tracks_evictable_population() {
 		let pool = Pool::new(1000);
-		let mut charge = Charge::new(pool.clone());
-		charge.add(2000 - ENTRY_OVERHEAD); // used = 2000
+		assert_eq!(pool.average(), None);
 
-		// A spared group re-bills its bytes on top of the base debt: base 200 plus
-		// 100 * 500/1000 = 50 of the credit.
-		pool.credit(500);
-		assert_eq!(pool.accrue(100), Some(250));
+		pool.access_insert(10);
+		pool.access_insert(20);
+		assert_eq!(pool.average(), Some(15));
 
-		// The drained share is claimed, not copied: repeated accruals exhaust it.
-		let mut total = 250u64;
-		for _ in 0..100 {
-			total += pool.accrue(100).unwrap() - 200;
-		}
-		assert!(total <= 250 + 500, "drained more credit than was granted");
+		// A refresh moves one member's contribution, exactly.
+		pool.access_refresh(10, 40);
+		assert_eq!(pool.average(), Some(30));
+
+		pool.access_remove(40);
+		assert_eq!(pool.average(), Some(20));
+		pool.access_remove(20);
+		assert_eq!(pool.average(), None);
 	}
 
 	#[test]

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -182,14 +182,16 @@ impl Pool {
 	///
 	/// The debt is `written * used / capacity`, so paying it evicts slightly more
 	/// than was written and the overshoot decays toward the capacity. Tracks double
-	/// it when their oldest content is staler than [`Self::average`].
+	/// it when their oldest content is staler than [`Self::average`]. Saturates: a
+	/// tiny capacity must not wrap a huge debt into a small one.
 	pub(crate) fn accrue(&self, written: u64) -> Option<u64> {
 		let used = self.inner.used.load(Ordering::Relaxed);
 		let capacity = self.inner.capacity.load(Ordering::Relaxed);
 		if used <= capacity {
 			return None;
 		}
-		Some((written as u128 * used as u128 / capacity.max(1) as u128) as u64)
+		let debt = written as u128 * used as u128 / capacity.max(1) as u128;
+		Some(u64::try_from(debt).unwrap_or(u64::MAX))
 	}
 }
 
@@ -205,31 +207,51 @@ impl std::fmt::Debug for Pool {
 /// The RAII byte accounting for one cached group, owned by the group's state.
 ///
 /// `add`/`sub` mirror the group's cached payload bytes into the pool with plain
-/// atomics. Dropping (or [`clear`](Self::clear)ing) the charge releases everything it
-/// holds. The default charge is detached: it belongs to no pool and every operation
-/// is a no-op.
+/// atomics, and every charged byte (overhead included) is also accumulated into the
+/// track's gross-write counter, which the track drains into eviction debt on its
+/// next write. The charge also owns the group's sample in the pool's access mean,
+/// so the sample lives exactly as long as the cached bytes do: aborting or dropping
+/// the group removes both, no matter who does it or when. The default charge is
+/// detached: it belongs to no pool and every operation is a no-op.
 #[derive(Default)]
 pub(crate) struct Charge {
 	pool: Option<Pool>,
+	// The owning track's gross-write counter (see `track::Info`); never decremented
+	// here, the track swaps it out as it accrues debt.
+	written: Option<Arc<AtomicU64>>,
 	// Bytes currently charged, including ENTRY_OVERHEAD, released on drop.
 	bytes: u64,
+	// Tick of the last cache access: creation, a FETCH hit, or a fetched backfill's
+	// birth. Eviction protection and age expiry key off this.
+	last: u64,
+	// Whether `last` is currently a sample in the pool's access mean, i.e. the
+	// group is in the evictable population.
+	counted: bool,
 }
 
 impl Charge {
-	/// Charge a new group's fixed overhead into `pool`.
-	pub(crate) fn new(pool: Pool) -> Self {
+	/// Charge a new group's fixed overhead into `pool`, counting it as written.
+	pub(crate) fn new(pool: Pool, written: Arc<AtomicU64>) -> Self {
 		pool.add(ENTRY_OVERHEAD);
+		written.fetch_add(ENTRY_OVERHEAD, Ordering::Relaxed);
+		let last = pool.now();
 		Self {
 			pool: Some(pool),
+			written: Some(written),
 			bytes: ENTRY_OVERHEAD,
+			last,
+			counted: false,
 		}
 	}
 
-	/// Charge `n` more payload bytes.
+	/// Charge `n` more payload bytes, counting them as written.
 	pub(crate) fn add(&mut self, n: u64) {
 		if let Some(pool) = &self.pool {
 			pool.add(n);
 			self.bytes += n;
+		}
+		if let Some(written) = &self.written {
+			written.fetch_add(n, Ordering::Relaxed);
 		}
 	}
 
@@ -241,12 +263,56 @@ impl Charge {
 		}
 	}
 
-	/// Release everything this charge holds (bytes and overhead). Idempotent; used
-	/// when the group aborts and clears its frames.
+	/// The group's full cached footprint: payload bytes plus overhead.
+	pub(crate) fn size(&self) -> u64 {
+		self.bytes
+	}
+
+	/// Tick of the group's last cache access.
+	pub(crate) fn accessed(&self) -> u64 {
+		self.last
+	}
+
+	/// Enter the group into the evictable population (demoted from the live edge,
+	/// or inserted behind it), sampling its access time into the pool's mean.
+	/// Idempotent.
+	pub(crate) fn demote(&mut self) {
+		if let Some(pool) = &self.pool
+			&& !self.counted
+		{
+			pool.access_insert(self.last);
+			self.counted = true;
+		}
+	}
+
+	/// Record a cache access (a FETCH hit, or a fetched backfill's birth).
+	///
+	/// Stamps one tick past the current one, so an access within the same coarse
+	/// tick as the population mean still reads as strictly newer and protects the
+	/// group. Idempotent within a tick, so repeated hits can't run ahead of the
+	/// clock.
+	pub(crate) fn refresh(&mut self) {
+		let Some(pool) = &self.pool else { return };
+		let now = pool.now().saturating_add(1);
+		if now <= self.last {
+			return;
+		}
+		if self.counted {
+			pool.access_refresh(self.last, now);
+		}
+		self.last = now;
+	}
+
+	/// Release everything this charge holds: bytes, overhead, and the access
+	/// sample. Idempotent; used when the group aborts and clears its frames.
 	pub(crate) fn clear(&mut self) {
 		if let Some(pool) = &self.pool {
 			pool.sub(self.bytes);
 			self.bytes = 0;
+			if self.counted {
+				pool.access_remove(self.last);
+				self.counted = false;
+			}
 		}
 	}
 }
@@ -261,10 +327,14 @@ impl Drop for Charge {
 mod test {
 	use super::*;
 
+	fn charge(pool: &Pool) -> Charge {
+		Charge::new(pool.clone(), Arc::new(AtomicU64::new(0)))
+	}
+
 	#[test]
 	fn unbounded_never_accrues() {
 		let pool = Pool::unbounded();
-		let mut charge = Charge::new(pool.clone());
+		let mut charge = charge(&pool);
 		charge.add(1 << 40);
 		assert_eq!(pool.accrue(1 << 30), None);
 		assert_eq!(pool.used(), (1 << 40) + ENTRY_OVERHEAD);
@@ -275,7 +345,7 @@ mod test {
 	#[test]
 	fn accrue_none_under_capacity() {
 		let pool = Pool::new(1000);
-		let mut charge = Charge::new(pool.clone());
+		let mut charge = charge(&pool);
 		charge.add(500);
 		assert_eq!(pool.accrue(100), None);
 	}
@@ -283,7 +353,7 @@ mod test {
 	#[test]
 	fn accrue_proportional_over_capacity() {
 		let pool = Pool::new(1000);
-		let mut charge = Charge::new(pool.clone());
+		let mut charge = charge(&pool);
 		charge.add(2000 - ENTRY_OVERHEAD); // used = 2000, twice the capacity
 
 		// Debt exceeds what was written by the overshoot ratio, so the pool drains.
@@ -314,7 +384,7 @@ mod test {
 	#[test]
 	fn charge_raii() {
 		let pool = Pool::new(1000);
-		let mut charge = Charge::new(pool.clone());
+		let mut charge = charge(&pool);
 		assert_eq!(pool.used(), ENTRY_OVERHEAD);
 
 		charge.add(100);
@@ -339,11 +409,62 @@ mod test {
 	}
 
 	#[test]
+	fn accrue_saturates() {
+		// A huge overshoot against a tiny capacity must saturate, not wrap.
+		let pool = Pool::new(1);
+		let mut c = charge(&pool);
+		c.add(1 << 40);
+		assert_eq!(pool.accrue(1 << 40), Some(u64::MAX));
+	}
+
+	#[test]
+	fn charge_counts_gross_writes() {
+		let pool = Pool::new(1000);
+		let written = Arc::new(AtomicU64::new(0));
+		let mut c = Charge::new(pool.clone(), written.clone());
+		c.add(100);
+		c.sub(40); // releases don't refund the gross counter
+		assert_eq!(written.load(Ordering::Relaxed), ENTRY_OVERHEAD + 100);
+	}
+
+	#[test]
+	fn charge_owns_access_sample() {
+		let pool = Pool::new(1000);
+		let mut c = charge(&pool);
+		assert_eq!(pool.average(), None, "not evictable until demoted");
+
+		c.demote();
+		c.demote(); // idempotent
+		assert!(pool.average().is_some());
+
+		// Clearing (an abort, from anyone) removes the sample with the bytes.
+		c.clear();
+		assert_eq!(pool.average(), None, "aborted groups leave no ghost sample");
+		drop(c);
+		assert_eq!(pool.average(), None);
+	}
+
+	#[test]
+	fn refresh_protects_within_a_tick() {
+		let pool = Pool::new(1000);
+		let mut c = charge(&pool);
+		c.demote();
+		let average = pool.average().unwrap();
+		// A refresh in the same coarse tick still lifts the group above the mean.
+		c.refresh();
+		assert!(c.accessed() > average);
+		// Repeated same-tick refreshes are idempotent, not runaway.
+		let stamped = c.accessed();
+		c.refresh();
+		assert_eq!(c.accessed(), stamped);
+	}
+
+	#[test]
 	fn resize() {
 		let pool = Pool::unbounded();
 		assert_eq!(pool.capacity(), None);
 
-		let mut charge = Charge::new(pool.clone());
+		let mut charge = charge(&pool);
 		charge.add(1000);
 
 		// Shrinking doesn't reclaim anything synchronously; writers accrue debt instead.

--- a/rs/moq-net/src/model/cache.rs
+++ b/rs/moq-net/src/model/cache.rs
@@ -33,6 +33,12 @@ use std::time::Duration;
 /// keeps the access-time sum below u64 (see [`TICK_MS`]).
 const ENTRY_OVERHEAD: u64 = 256;
 
+/// Sub-tick boosts applied to the last-access stamp, breaking ties within one
+/// coarse tick: a frame write outranks merely-inserted content, and an explicit
+/// read (FETCH hit or backfill birth) outranks both.
+const WRITE_BOOST: u64 = 1;
+const READ_BOOST: u64 = 2;
+
 /// Milliseconds per tick of the coarse clock behind access timestamps.
 ///
 /// Coarse ticks keep the count-weighted timestamp sum far from u64 overflow: the
@@ -248,22 +254,17 @@ impl Charge {
 	///
 	/// A write is also an access: it restarts the retention clock and keeps an
 	/// actively-growing group (a straggler or backfill still being filled) from
-	/// being evicted or expired mid-write.
+	/// being evicted or expired mid-write, even within the same coarse tick as
+	/// content that was merely inserted.
 	pub(crate) fn add(&mut self, n: u64) {
 		if let Some(pool) = &self.pool {
 			pool.add(n);
 			self.bytes += n;
-			let now = pool.now();
-			if now > self.last {
-				if self.counted {
-					pool.access_refresh(self.last, now);
-				}
-				self.last = now;
-			}
 		}
 		if let Some(written) = &self.written {
 			written.fetch_add(n, Ordering::Relaxed);
 		}
+		self.touch(WRITE_BOOST);
 	}
 
 	/// Release `n` payload bytes (a frame evicted by the group's own cap).
@@ -296,22 +297,28 @@ impl Charge {
 		}
 	}
 
-	/// Record a cache access (a FETCH hit, or a fetched backfill's birth).
-	///
-	/// Stamps one tick past the current one, so an access within the same coarse
-	/// tick as the population mean still reads as strictly newer and protects the
-	/// group. Idempotent within a tick, so repeated hits can't run ahead of the
-	/// clock.
+	/// Record a cache read (a FETCH hit, or a fetched backfill's birth).
 	pub(crate) fn refresh(&mut self) {
+		self.touch(READ_BOOST);
+	}
+
+	/// Advance the last-access tick to `boost` ticks past the coarse clock.
+	///
+	/// The boost breaks ties within one coarse tick: written content outranks
+	/// merely-inserted content, and explicitly read content outranks both, so a
+	/// same-tick access still reads as strictly newer than the population mean of
+	/// weaker accesses. Idempotent within a tick (monotone, never regressing), so
+	/// repeated accesses can't run ahead of the clock by more than the boost.
+	fn touch(&mut self, boost: u64) {
 		let Some(pool) = &self.pool else { return };
-		let now = pool.now().saturating_add(1);
-		if now <= self.last {
+		let target = pool.now().saturating_add(boost);
+		if target <= self.last {
 			return;
 		}
 		if self.counted {
-			pool.access_refresh(self.last, now);
+			pool.access_refresh(self.last, target);
 		}
-		self.last = now;
+		self.last = target;
 	}
 
 	/// Release everything this charge holds: bytes, overhead, and the access

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -13,6 +13,7 @@ use crate::frame::{self, Frame, FrameBuf};
 use crate::{Timescale, stats, track};
 use std::collections::VecDeque;
 use std::mem::MaybeUninit;
+use std::sync::Arc;
 use std::task::{Poll, ready};
 
 use crate::{Error, IntoBytes, Result, Timestamp};
@@ -42,7 +43,7 @@ impl Info {
 	/// tests that don't exercise timestamps.
 	#[cfg(test)]
 	pub(crate) fn produce(self) -> Producer {
-		Producer::new(self, track::Info::default())
+		Producer::new(self, track::Info::default(), Default::default())
 	}
 }
 
@@ -206,11 +207,16 @@ pub struct Producer {
 	// inherited by each frame (see [`Self::create_frame`]).
 	info: Info,
 
-	// The parent track's info, inherited rather than passed piecemeal. Its
+	// The parent track's properties, inherited rather than passed piecemeal. Its
 	// `timescale` is used by [`Self::create_frame`] to normalize every frame's
 	// timestamp into the track scale before it enters the stream. Threaded down by
 	// value from [`track::Producer::create_group`] / `append_group`.
 	track: track::Info,
+
+	// The parent track's account against the shared cache pool. Held here as well as
+	// in the group's `cache::Charge` so a frame write can settle the track's eviction
+	// debt with the group lock released.
+	cache: Arc<cache::Track>,
 
 	// Ingress payload meter, set by a tagged [`track::Producer`] via
 	// [`Self::with_meter`]. Empty (no-op) for an untagged group.
@@ -226,24 +232,24 @@ impl std::ops::Deref for Producer {
 }
 
 impl Producer {
-	/// Create a group producer bound to its parent track's [`track::Info`].
+	/// Create a group producer bound to its parent track's [`track::Info`] and cache
+	/// account.
 	///
 	/// Crate-private: groups are only constructed via [`track::Producer`], which
-	/// threads its [`track::Info`] down so properties like the timescale are inherited
-	/// rather than passed in. Every frame added to this group is normalized to the
-	/// track's timescale by [`Self::create_frame`].
+	/// threads both down so properties like the timescale are inherited rather than
+	/// passed in. Every frame added to this group is normalized to the track's
+	/// timescale by [`Self::create_frame`].
 	///
-	/// Charges the group into the shared cache pool reached through the track's
-	/// broadcast (`track.broadcast.origin.pool`), so its cached bytes count against
-	/// the budget the track evicts toward under memory pressure.
-	pub(crate) fn new(info: Info, track: track::Info) -> Self {
+	/// Charges the group into `cache`, so its cached bytes count against the budget the
+	/// track evicts toward under memory pressure.
+	pub(crate) fn new(info: Info, track: track::Info, cache: Arc<cache::Track>) -> Self {
 		let state = kio::Producer::<GroupState>::default();
-		state.write().ok().expect("a new group is open").charge =
-			cache::Charge::new(track.broadcast.origin.pool.clone(), track.written.clone());
+		state.write().ok().expect("a new group is open").charge = cache.charge();
 		Self {
 			info,
 			state,
 			track,
+			cache,
 			stats: stats::Meter::default(),
 		}
 	}
@@ -296,7 +302,7 @@ impl Producer {
 
 		// With the group lock released (lock order is track then group), settle
 		// eviction debt if enough has been written since the track last paid.
-		self.track.maybe_charge();
+		self.cache.settle();
 
 		// Ingress payload: one whole frame written.
 		self.stats.frames(1);
@@ -338,7 +344,7 @@ impl Producer {
 
 		// With the group lock released (lock order is track then group), settle
 		// eviction debt if enough has been written since the track last paid.
-		self.track.maybe_charge();
+		self.cache.settle();
 
 		// Ingress payload: one frame opened; its bytes are counted per chunk as the
 		// frame::Producer writes them.
@@ -443,7 +449,7 @@ impl Producer {
 		Consumer {
 			info: self.info,
 			state: self.state.consume(),
-			track: self.track.clone(),
+			track: self.track,
 			index: 0,
 			prefetch: Prefetch::default(),
 			// Untagged: a tagged track attaches the egress meter via `with_meter`
@@ -478,7 +484,8 @@ impl Clone for Producer {
 		Self {
 			info: self.info,
 			state: self.state.clone(),
-			track: self.track.clone(),
+			track: self.track,
+			cache: self.cache.clone(),
 			stats: self.stats.clone(),
 		}
 	}
@@ -607,7 +614,7 @@ impl Clone for Consumer {
 		Self {
 			state: self.state.clone(),
 			info: self.info,
-			track: self.track.clone(),
+			track: self.track,
 			index: self.index,
 			prefetch: Prefetch::default(),
 			// Inherit the meter without re-counting the group: the original already
@@ -1162,6 +1169,7 @@ mod test {
 		let mut producer = Producer::new(
 			Info { sequence: 0 },
 			track::Info::default().with_timescale(Timescale::MICRO),
+			Default::default(),
 		);
 		let frame = frame::Info {
 			size: 3,
@@ -1180,6 +1188,7 @@ mod test {
 		let mut producer = Producer::new(
 			Info { sequence: 0 },
 			track::Info::default().with_timescale(Timescale::MICRO),
+			Default::default(),
 		);
 		let writer = producer
 			.create_frame(frame::Info {

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -294,6 +294,10 @@ impl Producer {
 		state.evict();
 		drop(state);
 
+		// With the group lock released (lock order is track then group), settle
+		// eviction debt if enough has been written since the track last paid.
+		self.track.maybe_charge();
+
 		// Ingress payload: one whole frame written.
 		self.stats.frames(1);
 		self.stats.bytes(size);
@@ -331,6 +335,10 @@ impl Producer {
 		});
 		state.evict();
 		drop(state);
+
+		// With the group lock released (lock order is track then group), settle
+		// eviction debt if enough has been written since the track last paid.
+		self.track.maybe_charge();
 
 		// Ingress payload: one frame opened; its bytes are counted per chunk as the
 		// frame::Producer writes them.

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -221,6 +221,41 @@ pub struct Producer {
 	// Ingress payload meter, set by a tagged [`track::Producer`] via
 	// [`Self::with_meter`]. Empty (no-op) for an untagged group.
 	stats: stats::Meter,
+
+	// Shared by every clone: its `Drop` is the abrupt-teardown, running exactly once
+	// when the last of them goes.
+	alive: Arc<Alive>,
+}
+
+/// Ends the group when the last [`Producer`] clone drops, including the clone the
+/// parent track holds in its cache.
+///
+/// A refcount rather than a "am I the last one?" check inside `Drop`: that answer is
+/// a snapshot, and acting on it is exactly what can invalidate it. Holding a producer
+/// of its own also keeps the state writable until the teardown has run, whatever order
+/// the last owner's fields drop in.
+struct Alive {
+	info: Info,
+	state: kio::Producer<GroupState>,
+}
+
+impl Drop for Alive {
+	fn drop(&mut self) {
+		// See track::Alive: the last producer dropping without a clean finish releases
+		// the cached frames so a stale consumer can't pin their buffers forever. A
+		// finished group keeps its cache so consumers can drain.
+		if let Ok(mut state) = modify(&self.state)
+			&& state.fin.is_none()
+		{
+			// Dropped without finish() or abort(), so consumers will see
+			// Error::Dropped mid-group. Deliberate ends go through finish()/abort().
+			tracing::warn!(
+				sequence = self.info.sequence,
+				"group::Producer dropped without finish() or abort()"
+			);
+			state.release();
+		}
+	}
 }
 
 impl std::ops::Deref for Producer {
@@ -245,12 +280,17 @@ impl Producer {
 	pub(crate) fn new(info: Info, track: track::Info, cache: Arc<cache::Track>) -> Self {
 		let state = kio::Producer::<GroupState>::default();
 		state.write().ok().expect("a new group is open").charge = cache.charge();
+		let alive = Arc::new(Alive {
+			info,
+			state: state.clone(),
+		});
 		Self {
 			info,
 			state,
 			track,
 			cache,
 			stats: stats::Meter::default(),
+			alive,
 		}
 	}
 
@@ -487,28 +527,7 @@ impl Clone for Producer {
 			track: self.track,
 			cache: self.cache.clone(),
 			stats: self.stats.clone(),
-		}
-	}
-}
-
-impl Drop for Producer {
-	fn drop(&mut self) {
-		// See track::Producer::drop: the last producer dropping without a clean finish
-		// releases the cached frames so a stale consumer can't pin their buffers forever.
-		// A finished group keeps its cache so consumers can drain.
-		if !self.state.is_last() {
-			return;
-		}
-		if let Ok(mut state) = modify(&self.state)
-			&& state.fin.is_none()
-		{
-			// Dropped without finish() or abort(), so consumers will see
-			// Error::Dropped mid-group. Deliberate ends go through finish()/abort().
-			tracing::warn!(
-				sequence = self.info.sequence,
-				"group::Producer dropped without finish() or abort()"
-			);
-			state.release();
+			alive: self.alive.clone(),
 		}
 	}
 }

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -489,7 +489,7 @@ impl Producer {
 		Consumer {
 			info: self.info,
 			state: self.state.consume(),
-			track: self.track,
+			track: self.track.clone(),
 			index: 0,
 			prefetch: Prefetch::default(),
 			// Untagged: a tagged track attaches the egress meter via `with_meter`
@@ -524,7 +524,7 @@ impl Clone for Producer {
 		Self {
 			info: self.info,
 			state: self.state.clone(),
-			track: self.track,
+			track: self.track.clone(),
 			cache: self.cache.clone(),
 			stats: self.stats.clone(),
 			alive: self.alive.clone(),
@@ -633,7 +633,7 @@ impl Clone for Consumer {
 		Self {
 			state: self.state.clone(),
 			info: self.info,
-			track: self.track,
+			track: self.track.clone(),
 			index: self.index,
 			prefetch: Prefetch::default(),
 			// Inherit the meter without re-counting the group: the original already

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -13,7 +13,6 @@ use crate::frame::{self, Frame, FrameBuf};
 use crate::{Timescale, stats, track};
 use std::collections::VecDeque;
 use std::mem::MaybeUninit;
-use std::sync::Arc;
 use std::task::{Poll, ready};
 
 use crate::{Error, IntoBytes, Result, Timestamp};
@@ -101,8 +100,8 @@ pub(crate) struct GroupState {
 	// The total size (in bytes) of all cached frames plus any in-flight frame.
 	pub(crate) cache: u64,
 
-	// This group's registration in the track's cache pool; mirrors `cache` so the
-	// pool can evict the least-recently-read groups under memory pressure.
+	// Mirrors `cache` into the track's shared cache pool, so the group's bytes count
+	// against the byte budget tracks evict toward.
 	charge: cache::Charge,
 
 	// Once finalized, the total number of frames the group will ever contain. Recorded
@@ -122,7 +121,6 @@ impl GroupState {
 		}
 		let local = index - self.offset;
 		if let Some(f) = self.frames.get(local) {
-			self.charge.touch();
 			let info = frame::Info {
 				size: f.payload.len() as u64,
 				timestamp: f.timestamp,
@@ -132,7 +130,6 @@ impl GroupState {
 		if local == self.frames.len()
 			&& let Some(p) = &self.partial
 		{
-			self.charge.touch();
 			let info = frame::Info {
 				size: p.buf.capacity() as u64,
 				timestamp: p.timestamp,
@@ -196,20 +193,6 @@ fn modify(state: &kio::Producer<GroupState>) -> Result<kio::Mut<'_, GroupState>>
 	state.write().map_err(|r| r.abort.clone().unwrap_or(Error::Dropped))
 }
 
-/// The pool's eviction hook: abort the group with [`Error::Evicted`], freeing its
-/// frames immediately. A no-op once the group is already aborted or fully dropped.
-fn evict(weak: &kio::ProducerWeak<GroupState>) {
-	// Upgrade to write; a closed (finished or fully dropped) group has nothing to free.
-	let Some(producer) = weak.produce() else { return };
-	let Ok(mut state) = producer.write() else { return };
-	if state.abort.is_some() {
-		return;
-	}
-	state.abort = Some(Error::Evicted);
-	state.release();
-	state.close();
-}
-
 /// Writes frames to a group in order.
 ///
 /// Each group is delivered independently over a QUIC stream.
@@ -250,14 +233,13 @@ impl Producer {
 	/// rather than passed in. Every frame added to this group is normalized to the
 	/// track's timescale by [`Self::create_frame`].
 	///
-	/// Registers the group in the shared cache pool reached through the track's
+	/// Charges the group into the shared cache pool reached through the track's
 	/// broadcast (`track.broadcast.origin.pool`), so its cached bytes count against
-	/// the budget and it can be evicted under memory pressure.
+	/// the budget the track evicts toward under memory pressure.
 	pub(crate) fn new(info: Info, track: track::Info) -> Self {
 		let state = kio::Producer::<GroupState>::default();
-		let weak = state.weak();
-		let charge = track.broadcast.origin.pool.register(Box::new(move || evict(&weak)));
-		state.write().ok().expect("a new group is open").charge = charge;
+		state.write().ok().expect("a new group is open").charge =
+			cache::Charge::new(track.broadcast.origin.pool.clone());
 		Self {
 			info,
 			state,
@@ -310,11 +292,7 @@ impl Producer {
 		state.charge.add(size);
 		state.frames.push_back(Frame { timestamp, payload });
 		state.evict();
-
-		// The pool evicts other groups' state, so trigger it only after releasing our
-		// lock. Reached via the parent chain; a no-op when the pool is unbounded.
 		drop(state);
-		self.track.broadcast.origin.pool.evict();
 
 		// Ingress payload: one whole frame written.
 		self.stats.frames(1);
@@ -352,11 +330,7 @@ impl Producer {
 			buf: buf.clone(),
 		});
 		state.evict();
-
-		// The pool evicts other groups' state, so trigger it only after releasing our
-		// lock. Reached via the parent chain; a no-op when the pool is unbounded.
 		drop(state);
-		self.track.broadcast.origin.pool.evict();
 
 		// Ingress payload: one frame opened; its bytes are counted per chunk as the
 		// frame::Producer writes them.
@@ -427,10 +401,10 @@ impl Producer {
 		self.state.read().abort.is_some()
 	}
 
-	/// This group's cache pool registration, used by the track to pin the latest
-	/// group. `None` when the pool is detached (the unbounded default).
-	pub(crate) fn cache_entry(&self) -> Option<Arc<cache::Entry>> {
-		self.state.read().charge.entry()
+	/// The group's currently cached payload bytes, used by the track to size this
+	/// group as an eviction victim.
+	pub(crate) fn cached_bytes(&self) -> u64 {
+		self.state.read().cache
 	}
 
 	/// Create a new consumer for the group.
@@ -705,10 +679,6 @@ impl Consumer {
 			let local = (index - state.offset).min(state.frames.len());
 			prefetch.fill(state.frames.range(local..).cloned());
 			if prefetch.len > 0 {
-				// Mark the group recently read so the cache pool keeps it over staler
-				// groups. Touching once per batch fill is enough; the drained pops that
-				// follow serve from the prefetch without re-locking.
-				state.charge.touch();
 				return Poll::Ready(Ok(()));
 			}
 			// Nothing completed at `index`: an in-flight tail waits, otherwise resolve

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -239,7 +239,7 @@ impl Producer {
 	pub(crate) fn new(info: Info, track: track::Info) -> Self {
 		let state = kio::Producer::<GroupState>::default();
 		state.write().ok().expect("a new group is open").charge =
-			cache::Charge::new(track.broadcast.origin.pool.clone());
+			cache::Charge::new(track.broadcast.origin.pool.clone(), track.written.clone());
 		Self {
 			info,
 			state,
@@ -401,10 +401,33 @@ impl Producer {
 		self.state.read().abort.is_some()
 	}
 
-	/// The group's currently cached payload bytes, used by the track to size this
-	/// group as an eviction victim.
-	pub(crate) fn cached_bytes(&self) -> u64 {
-		self.state.read().cache
+	/// The group's full cached footprint (payload plus fixed overhead), used by the
+	/// track to size this group as an eviction victim.
+	pub(crate) fn cache_size(&self) -> u64 {
+		self.state.read().charge.size()
+	}
+
+	/// Tick of the group's last cache access, driving eviction protection and age
+	/// expiry (see [`cache::Pool::average`]).
+	pub(crate) fn cache_accessed(&self) -> u64 {
+		self.state.read().charge.accessed()
+	}
+
+	/// Enter the group into the evictable population: demoted from the live edge,
+	/// or inserted behind it. Idempotent; a no-op once the group is closed.
+	pub(crate) fn cache_demote(&self) {
+		if let Ok(mut state) = self.state.write() {
+			state.charge.demote();
+		}
+	}
+
+	/// Record a cache access (a FETCH hit, or a fetched backfill's birth),
+	/// protecting the group from eviction and restarting its expiry clock. A no-op
+	/// once the group is closed.
+	pub(crate) fn cache_refresh(&self) {
+		if let Ok(mut state) = self.state.write() {
+			state.charge.refresh();
+		}
 	}
 
 	/// Create a new consumer for the group.

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -101,11 +101,11 @@ pub struct Info {
 	/// detection and shortest-path routing.
 	pub id: Origin,
 
-	/// The cache pool broadcasts under this origin charge their groups into. It
-	/// flows down the ownership chain (origin -> broadcast -> track -> group), so a
-	/// group reaches it via `track.broadcast.origin.pool`. Unbounded by default; a
-	/// relay sets a bounded one (via [`Self::with_pool`]) so cached groups across the
-	/// whole process share one memory budget.
+	/// The cache pool broadcasts under this origin charge their groups into. It flows
+	/// down the ownership chain (origin -> broadcast -> track -> group): a track opens
+	/// an account against it, and its groups charge through that. Unbounded by
+	/// default; a relay sets a bounded one (via [`Self::with_pool`]) so cached groups
+	/// across the whole process share one memory budget.
 	pub pool: cache::Pool,
 
 	/// Ceiling on how long any non-latest group under this origin is retained. Each

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -89,7 +89,7 @@ impl Origin {
 ///
 /// Doubles as the construction config for an [origin `Producer`](Producer) and as the
 /// parent handle every broadcast carries ([`broadcast::Info::origin`]): the origin owns
-/// the [`cache::Pool`] every group in the tree registers with, so a relay configures one
+/// the [`cache::Pool`] every group in the tree charges into, so a relay configures one
 /// bounded pool here and every broadcast, track, and group beneath it reaches that single
 /// budget by walking up the ownership chain. Defaults to an unbounded pool
 /// ([`Origin::produce`] is the shorthand for that). Cheap to clone (a `Copy` id plus an
@@ -101,7 +101,7 @@ pub struct Info {
 	/// detection and shortest-path routing.
 	pub id: Origin,
 
-	/// The cache pool broadcasts under this origin register their groups with. It
+	/// The cache pool broadcasts under this origin charge their groups into. It
 	/// flows down the ownership chain (origin -> broadcast -> track -> group), so a
 	/// group reaches it via `track.broadcast.origin.pool`. Unbounded by default; a
 	/// relay sets a bounded one (via [`Self::with_pool`]) so cached groups across the

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -21,8 +21,9 @@ use super::{Datagram, Requests};
 pub use super::subscription::Subscription;
 
 use std::{
-	collections::{HashSet, VecDeque},
+	collections::{HashMap, VecDeque},
 	sync::Arc,
+	sync::atomic::{AtomicBool, Ordering},
 	task::{Poll, ready},
 	time::Duration,
 };
@@ -36,6 +37,10 @@ pub const DEFAULT_LATENCY_MAX: Duration = Duration::from_secs(5);
 /// few tens of milliseconds are kept, so a consumer that stalls loses stale datagrams instead of
 /// replaying them. Sized like a typical send buffer for real-time audio/video.
 const MAX_DATAGRAM_AGE: Duration = Duration::from_millis(50);
+
+/// Slack before the eviction order is rebuilt, so a track holding just a few groups
+/// doesn't rebuild on every write.
+const EVICT_SLACK: usize = 64;
 
 /// Publisher-side properties of a track.
 ///
@@ -155,13 +160,30 @@ struct TrackState {
 	// `origin.pool` is the shared cache pool every group registers with.
 	broadcast: Arc<broadcast::Info>,
 
-	// The pool registration of the current max_sequence group, pinned so the
-	// latest group is immune to pool eviction. `None` when the pool is detached
-	// or no group exists yet.
-	latest_entry: Option<Arc<cache::Entry>>,
+	// Cached groups by sequence: the single source of truth for what is cached. The
+	// two orderings below hold bare sequences and validate against this map, so a
+	// removed or replaced group turns their entries into discarded-on-pop hints.
+	lookup: HashMap<u64, Slot>,
 
-	// Groups in arrival order. `None` entries are tombstones for evicted groups.
-	groups: VecDeque<Option<(group::Producer, web_async::time::Instant)>>,
+	// Publisher-produced sequences in arrival order, walked by subscriptions.
+	// Fetched backfill (`insert_group_request`) is deliberately absent: it is
+	// served by sequence, never replayed to arrival-order subscribers.
+	arrival: VecDeque<u64>,
+
+	// Eviction order under memory pressure: every cached group except the current
+	// max_sequence, so the live edge is protected by omission rather than pinning.
+	// `pay_debt` pops victims from the front; a FETCH-refreshed group re-queues at
+	// the back instead of dying, decoupling eviction order from arrival order.
+	evict: VecDeque<(u64, u32)>,
+
+	// Outstanding eviction debt in bytes, accrued by writes while the shared pool
+	// is over capacity (see `cache::Pool::accrue`) and paid by aborting this
+	// track's own oldest groups. Per track, so eviction lands proportionally to
+	// what each track writes and never touches another track's cache.
+	debt: u64,
+
+	// Incarnation counter for `Slot::epoch`.
+	next_epoch: u32,
 
 	// Datagrams in arrival order paired with their arrival time, a best-effort send buffer
 	// evicted by age (see `MAX_DATAGRAM_AGE`). Shares the group `max_sequence` namespace but
@@ -172,12 +194,8 @@ struct TrackState {
 	// cursor to an index into `datagrams` (mirrors `offset` for groups).
 	datagram_offset: usize,
 
-	// Sequences currently occupying a cache slot, used to reject a duplicate
-	// `create_group`/`write_group` with `Error::Duplicate`. Entries are removed on
-	// expiry/eviction so a pool-evicted sequence can be re-fetched into its slot.
-	duplicates: HashSet<u64>,
-
-	// We've popped the front of this VecDeque this many times, used to map sequence -> index.
+	// We've popped the front of `arrival` this many times, mapping a subscriber's
+	// absolute cursor to an index.
 	offset: usize,
 
 	// The highest sequence number successfully appended to the track.
@@ -197,6 +215,25 @@ struct TrackState {
 	// The reverse fetch queue (see [`FetchState`]), same reasoning: cache-miss
 	// `fetch_group` calls enqueue here and a `Dynamic` drains.
 	fetch: kio::Shared<FetchState>,
+}
+
+/// A cached group plus its bookkeeping in the track's `lookup` map.
+struct Slot {
+	group: group::Producer,
+
+	// When the group was inserted, driving age expiry.
+	created_at: web_async::time::Instant,
+
+	// Identity of this (sequence, group) incarnation. Eviction-order entries carry
+	// the epoch they were enqueued with, so an entry left over from a replaced
+	// incarnation (an evicted sequence served again) is recognized and discarded.
+	epoch: u32,
+
+	// Set by a FETCH cache hit, which runs under the track's read lock (hence
+	// atomic). The eviction walk spares a touched group once: its bytes count as
+	// debt paid (re-billed through the pool's credit) and it re-queues at the back,
+	// so a refresh buys a full trip through the eviction order.
+	touched: AtomicBool,
 }
 
 /// The registered subscriptions, aggregated by the producer.
@@ -236,17 +273,17 @@ impl TrackState {
 		}
 	}
 
-	/// Find the next non-tombstoned group at or after `index` in arrival order.
+	/// Find the next live group at or after `index` in arrival order.
 	///
 	/// Returns the group and its absolute index so the consumer can advance past it.
 	fn poll_recv_group(&self, index: usize, min_sequence: u64) -> Poll<Result<Option<(group::Consumer, usize)>>> {
 		let start = index.saturating_sub(self.offset);
-		for (i, slot) in self.groups.iter().enumerate().skip(start) {
-			if let Some((group, _)) = slot
-				&& group.sequence >= min_sequence
-				&& !group.is_aborted()
+		for (i, sequence) in self.arrival.iter().enumerate().skip(start) {
+			if *sequence >= min_sequence
+				&& let Some(slot) = self.lookup.get(sequence)
+				&& !slot.group.is_aborted()
 			{
-				return Poll::Ready(Ok(Some((group.consume(), self.offset + i))));
+				return Poll::Ready(Ok(Some((slot.group.consume(), self.offset + i))));
 			}
 		}
 
@@ -305,16 +342,18 @@ impl TrackState {
 	) -> Poll<Result<Option<(frame::Frame, usize, u64)>>> {
 		let start = index.saturating_sub(self.offset);
 		let mut pending_seen = false;
-		for (i, slot) in self.groups.iter().enumerate().skip(start) {
-			let Some((group, _)) = slot else { continue };
-			if group.sequence < next_sequence {
+		for (i, sequence) in self.arrival.iter().enumerate().skip(start) {
+			if *sequence < next_sequence {
 				continue;
 			}
+			let Some(slot) = self.lookup.get(sequence) else {
+				continue;
+			};
 
-			let mut consumer = group.consume();
+			let mut consumer = slot.group.consume();
 			match consumer.poll_read_frame(waiter) {
 				Poll::Ready(Ok(Some(frame))) => {
-					return Poll::Ready(Ok(Some((frame, self.offset + i, group.sequence))));
+					return Poll::Ready(Ok(Some((frame, self.offset + i, *sequence))));
 				}
 				Poll::Ready(Ok(None)) => continue,
 				// A single group failing (aborted upstream, or evicted from the
@@ -367,7 +406,8 @@ impl TrackState {
 		}
 
 		let mut best: Option<&group::Producer> = None;
-		for (group, _) in self.groups.iter().flatten() {
+		for slot in self.lookup.values() {
+			let group = &slot.group;
 			if group.sequence < next_sequence {
 				continue;
 			}
@@ -402,15 +442,17 @@ impl TrackState {
 		Poll::Pending
 	}
 
-	/// Find a cached group by sequence, skipping tombstones and groups evicted from
-	/// the cache pool (a fetch treats those as a miss and re-fetches). Synchronous,
-	/// never blocks.
+	/// Find a cached group by sequence; an aborted (evicted) group is a miss, so a
+	/// fetch re-fetches it. Synchronous, never blocks. Test hook for `peek_group`;
+	/// the real fetch path is [`Self::poll_fetch_cached`], which also refreshes the
+	/// group.
+	#[cfg(test)]
 	fn cached_group(&self, sequence: u64) -> Option<group::Consumer> {
-		self.groups
-			.iter()
-			.flatten()
-			.find(|(group, _)| group.sequence == sequence && !group.is_aborted())
-			.map(|(group, _)| group.consume())
+		let slot = self.lookup.get(&sequence)?;
+		if slot.group.is_aborted() {
+			return None;
+		}
+		Some(slot.group.consume())
 	}
 
 	/// The publisher's latency window, or `None` while the info is unknown (an
@@ -424,8 +466,13 @@ impl TrackState {
 	/// end-of-stream. The handler side (a rejection, or no [`Dynamic`] at all) lives
 	/// in [`FetchState`]; [`Fetching`] polls both.
 	fn poll_fetch_cached(&self, sequence: u64) -> Poll<Result<group::Consumer>> {
-		if let Some(group) = self.cached_group(sequence) {
-			return Poll::Ready(Ok(group));
+		if let Some(slot) = self.lookup.get(&sequence)
+			&& !slot.group.is_aborted()
+		{
+			// A cache hit refreshes the group: the next eviction walk spares it and
+			// re-queues it at the back instead (see `pay_debt`).
+			slot.touched.store(true, Ordering::Relaxed);
+			return Poll::Ready(Ok(slot.group.consume()));
 		}
 
 		if let Some(err) = &self.abort {
@@ -442,63 +489,217 @@ impl TrackState {
 
 	/// Evict groups older than `max_age`, never evicting the max_sequence group.
 	///
-	/// Groups are in arrival order, so we can stop early when we hit a non-expired,
-	/// non-max_sequence group (everything after it arrived even later).
-	/// When max_sequence is at the front, we skip past it and tombstone expired groups
-	/// behind it.
-	///
-	/// Also reaps slots whose group the cache pool already evicted (walked before
-	/// the early exit); ones behind fresh groups stay as soft tombstones that every
-	/// read path skips, and are replaced in place if the sequence is re-fetched.
+	/// Publisher-produced groups are walked in arrival order, which matches creation
+	/// order, so the walk stops early at the first fresh group. Slots whose group was
+	/// already aborted (evicted under memory pressure, or upstream) are reclaimed on
+	/// the way so the sequence can be re-fetched. Fetched backfill isn't in arrival
+	/// order; it ages out from the front of the eviction order instead.
 	fn evict_expired(&mut self, now: web_async::time::Instant, max_age: Duration) {
-		for slot in self.groups.iter_mut() {
-			let Some((group, created_at)) = slot else { continue };
+		for i in 0..self.arrival.len() {
+			let sequence = self.arrival[i];
+			let Some(slot) = self.lookup.get(&sequence) else {
+				continue;
+			};
 
-			// Evicted by the pool: the frames are already gone, reclaim the slot
-			// and the sequence so a later fetch can re-insert it.
-			if group.is_aborted() {
-				self.duplicates.remove(&group.sequence);
-				*slot = None;
+			// Already aborted: the frames are gone, reclaim the slot so a later
+			// fetch can serve the sequence again.
+			if slot.group.is_aborted() {
+				self.lookup.remove(&sequence);
 				continue;
 			}
 
-			if Some(group.sequence) == self.max_sequence {
+			if Some(sequence) == self.max_sequence {
 				continue;
 			}
 
-			if now.duration_since(*created_at) <= max_age {
+			if now.duration_since(slot.created_at) <= max_age {
 				break;
 			}
 
-			self.duplicates.remove(&group.sequence);
 			// Take the group out of the cache and abort it, so any consumer still reading
 			// surfaces `Error::Old` instead of blocking forever on a frame that will never
 			// arrive. Without this a reader parked on an aged-out group hangs indefinitely,
 			// since the group is neither finished nor aborted.
-			if let Some((group, _)) = slot.take() {
-				let _ = group.abort(Error::Old);
-			}
+			let slot = self.lookup.remove(&sequence).unwrap();
+			let _ = slot.group.abort(Error::Old);
 		}
 
-		// Trim leading tombstones to advance the offset.
-		while let Some(None) = self.groups.front() {
-			self.groups.pop_front();
+		// Trim dead leading arrival entries to advance the subscriber offset.
+		while let Some(sequence) = self.arrival.front() {
+			if self.lookup.contains_key(sequence) {
+				break;
+			}
+			self.arrival.pop_front();
 			self.offset += 1;
+		}
+
+		// The eviction order is roughly enqueue order: drop dead entries and age out
+		// expired groups (the only expiry that reaches fetched backfill) from the
+		// front, stopping at the first live fresh entry.
+		while let Some(&(sequence, epoch)) = self.evict.front() {
+			let Some(slot) = self.lookup.get(&sequence) else {
+				self.evict.pop_front();
+				continue;
+			};
+			if slot.epoch != epoch {
+				self.evict.pop_front();
+				continue;
+			}
+			if slot.group.is_aborted() {
+				self.lookup.remove(&sequence);
+				self.evict.pop_front();
+				continue;
+			}
+			if now.duration_since(slot.created_at) <= max_age {
+				break;
+			}
+			let slot = self.lookup.remove(&sequence).unwrap();
+			let _ = slot.group.abort(Error::Old);
+			self.evict.pop_front();
+		}
+
+		// Dead entries behind a fresh front can linger; rebuild once they clearly
+		// outnumber the live slots.
+		if self.evict.len() > 2 * self.lookup.len() + EVICT_SLACK {
+			let lookup = &self.lookup;
+			self.evict
+				.retain(|(sequence, epoch)| lookup.get(sequence).is_some_and(|slot| slot.epoch == *epoch));
 		}
 	}
 
-	/// Pin `group` as the latest (immune to pool eviction) if it holds the track's
-	/// max_sequence, releasing the previous pin. Call after updating `max_sequence`.
-	fn pin_latest(&mut self, group: &group::Producer) {
-		if Some(group.sequence) != self.max_sequence {
-			return;
+	/// Reject a sequence that is still cached; a dead (aborted or evicted)
+	/// incarnation is removed so a fresh group can serve the sequence again.
+	///
+	/// Best effort: nothing remembers a sequence whose slot is already gone, so a
+	/// publisher re-sending a long-evicted sequence is accepted as new.
+	fn claim_sequence(&mut self, sequence: u64) -> Result<()> {
+		if let Some(slot) = self.lookup.get(&sequence) {
+			if !slot.group.is_aborted() {
+				return Err(Error::Duplicate);
+			}
+			self.lookup.remove(&sequence);
 		}
-		if let Some(prev) = self.latest_entry.take() {
-			prev.set_pinned(false);
+		Ok(())
+	}
+
+	/// Insert a freshly-created group into the cache.
+	///
+	/// Updates the live edge, demoting the previous latest into the eviction order;
+	/// the current latest is never enqueued, which is what protects it from
+	/// eviction. `visible` controls arrival-order delivery: publisher-produced
+	/// groups reach subscribers, fetched backfill is served by sequence only.
+	/// Returns the demoted group's cached bytes, the write this insert owes
+	/// eviction debt for.
+	fn insert_group(&mut self, group: &group::Producer, now: web_async::time::Instant, visible: bool) -> u64 {
+		let sequence = group.sequence;
+		self.next_epoch = self.next_epoch.wrapping_add(1);
+		let epoch = self.next_epoch;
+
+		let mut written = 0;
+		if self.max_sequence.is_none_or(|max| sequence >= max) {
+			// Demote the previous latest: it joins the eviction order like any other
+			// cached group, sized at what the publisher wrote into it.
+			if let Some(max) = self.max_sequence
+				&& sequence > max
+				&& let Some(prev) = self.lookup.get(&max)
+			{
+				written = prev.group.cached_bytes();
+				self.evict.push_back((max, prev.epoch));
+			}
+			self.max_sequence = Some(sequence);
+		} else {
+			self.evict.push_back((sequence, epoch));
 		}
-		if let Some(entry) = group.cache_entry() {
-			entry.set_pinned(true);
-			self.latest_entry = Some(entry);
+
+		self.lookup.insert(
+			sequence,
+			Slot {
+				group: group.clone(),
+				created_at: now,
+				epoch,
+				touched: AtomicBool::new(false),
+			},
+		);
+		if visible {
+			self.arrival.push_back(sequence);
+		}
+		written
+	}
+
+	/// Write-path cache upkeep, run after inserting a group: accrue and pay
+	/// eviction debt while the shared pool is over capacity, then expire groups
+	/// past the track's age window.
+	fn maintain(&mut self, written: u64, now: web_async::time::Instant, max_age: Duration) {
+		let pool = self.broadcast.origin.pool.clone();
+		match pool.accrue(written) {
+			Some(accrued) => {
+				// `used` bounds what eviction could ever free, keeping a track that
+				// can't pay (everything protected) from hoarding a stale schedule.
+				self.debt = self.debt.saturating_add(accrued).min(pool.used());
+				self.pay_debt(&pool);
+			}
+			// Under capacity there is nothing to work off, and stale debt would
+			// cause a spurious eviction burst at the next pressure spike.
+			None => self.debt = 0,
+		}
+		self.evict_expired(now, max_age);
+	}
+
+	/// Abort this track's oldest groups until the outstanding debt is paid.
+	///
+	/// Pops the eviction order from the front, validating every entry against
+	/// `lookup`. When the next victim is larger than the remaining debt it is left
+	/// alone and the debt carries over, so a small write never evicts a huge group.
+	/// A FETCH-touched group is spared: its bytes count as paid (re-billed to every
+	/// writer through the pool's credit) and it re-queues at the back.
+	fn pay_debt(&mut self, pool: &cache::Pool) {
+		for _ in 0..self.evict.len() {
+			if self.debt == 0 {
+				return;
+			}
+			let Some((sequence, epoch)) = self.evict.pop_front() else {
+				return;
+			};
+			let Some(slot) = self.lookup.get(&sequence) else {
+				// Evicted or expired; discard the dead entry.
+				continue;
+			};
+			if slot.epoch != epoch {
+				// A replaced incarnation; the live entry is elsewhere in the queue.
+				continue;
+			}
+			if slot.group.is_aborted() {
+				// Aborted upstream: the frames are already gone, reclaim the slot.
+				self.lookup.remove(&sequence);
+				continue;
+			}
+			if Some(sequence) == self.max_sequence {
+				// The live edge is never enqueued, but tolerate finding it anyway.
+				self.evict.push_back((sequence, epoch));
+				continue;
+			}
+
+			let size = slot.group.cached_bytes();
+			if size == 0 {
+				// An empty group (e.g. a backfill still being filled) frees nothing;
+				// evicting it would only destroy a fresh fetch. Send it to the back.
+				self.evict.push_back((sequence, epoch));
+				continue;
+			}
+			if slot.touched.swap(false, Ordering::Relaxed) {
+				pool.credit(size);
+				self.debt = self.debt.saturating_sub(size);
+				self.evict.push_back((sequence, epoch));
+				continue;
+			}
+			if size > self.debt {
+				self.evict.push_front((sequence, epoch));
+				return;
+			}
+
+			self.debt -= size;
+			let slot = self.lookup.remove(&sequence).unwrap();
+			let _ = slot.group.abort(Error::Evicted);
 		}
 	}
 
@@ -541,31 +742,6 @@ impl TrackState {
 		producer.write().map_err(|r| r.abort.clone().unwrap_or(Error::Dropped))
 	}
 
-	/// Replace the slot of a duplicate `sequence` whose group was evicted from the
-	/// cache pool, returning the fresh producer. `Err(Duplicate)` when the cached
-	/// group is still live; `None` when no slot holds the sequence.
-	fn replace_evicted(
-		&mut self,
-		sequence: u64,
-		track: Info,
-		now: web_async::time::Instant,
-	) -> Option<Result<group::Producer>> {
-		let slot = self
-			.groups
-			.iter_mut()
-			.find(|slot| matches!(slot, Some((group, _)) if group.sequence == sequence))?;
-		let (existing, _) = slot.as_ref().unwrap();
-		if !existing.is_aborted() {
-			return Some(Err(Error::Duplicate));
-		}
-		let group = group::Producer::new(group::Info { sequence }, track);
-		*slot = Some((group.clone(), now));
-		// The replaced group can hold max_sequence when the publisher aborted the
-		// latest group itself; re-pin so the live edge stays eviction-immune.
-		self.pin_latest(&group);
-		Some(Ok(group))
-	}
-
 	/// Insert a group fetched for a [`GroupRequest`], setting the track's [`Info`]
 	/// if it isn't accepted yet. The group's timescale comes from that info, so a
 	/// fetch can serve an as-yet-unaccepted track (e.g. a relay with no live
@@ -594,19 +770,15 @@ impl TrackState {
 			})
 			.clone();
 
-		if !self.duplicates.insert(sequence) {
-			// A pool-evicted group can be re-fetched into its old slot.
-			return self
-				.replace_evicted(sequence, info, now)
-				.unwrap_or(Err(Error::Duplicate));
-		}
+		// An evicted sequence can be re-fetched; a live one is a duplicate.
+		self.claim_sequence(sequence)?;
 
 		let latency_max = info.latency_max;
 		let group = group::Producer::new(group::Info { sequence }, info);
-		self.max_sequence = Some(self.max_sequence.unwrap_or(0).max(sequence));
-		self.groups.push_back(Some((group.clone(), now)));
-		self.pin_latest(&group);
-		self.evict_expired(now, latency_max);
+		// Backfill is invisible to arrival-order subscribers: it was fetched on
+		// demand, not produced live by the publisher.
+		let written = self.insert_group(&group, now, false);
+		self.maintain(written, now, latency_max);
 		Ok(group)
 	}
 }
@@ -686,18 +858,12 @@ impl Producer {
 		let latency_max = info.latency_max;
 		let now = web_async::time::Instant::now();
 
-		if !state.duplicates.insert(group.sequence) {
-			// A pool-evicted group can be re-created into its old slot.
-			return state
-				.replace_evicted(group.sequence, track, now)
-				.unwrap_or(Err(Error::Duplicate));
-		}
+		// An evicted sequence can be re-created; a live one is a duplicate.
+		state.claim_sequence(group.sequence)?;
 
 		let group = group::Producer::new(group, track).with_meter(self.stats.meter());
-		state.max_sequence = Some(state.max_sequence.unwrap_or(0).max(group.sequence));
-		state.groups.push_back(Some((group.clone(), now)));
-		state.pin_latest(&group);
-		state.evict_expired(now, latency_max);
+		let written = state.insert_group(&group, now, true);
+		state.maintain(written, now, latency_max);
 
 		Ok(group)
 	}
@@ -722,11 +888,8 @@ impl Producer {
 		let group = group::Producer::new(group::Info { sequence }, track).with_meter(self.stats.meter());
 
 		let now = web_async::time::Instant::now();
-		state.duplicates.insert(sequence);
-		state.max_sequence = Some(sequence);
-		state.groups.push_back(Some((group.clone(), now)));
-		state.pin_latest(&group);
-		state.evict_expired(now, latency_max);
+		let written = state.insert_group(&group, now, true);
+		state.maintain(written, now, latency_max);
 
 		Ok(group)
 	}
@@ -863,10 +1026,11 @@ impl Producer {
 	pub fn abort(self, err: Error) -> Result<()> {
 		let mut guard = self.modify()?;
 		guard.abort = Some(err);
-		guard.groups.clear();
+		guard.lookup.clear();
+		guard.arrival.clear();
+		guard.evict.clear();
 		guard.datagrams.clear();
-		guard.duplicates.clear();
-		guard.latest_entry = None;
+		guard.debt = 0;
 		guard.close();
 		Ok(())
 	}
@@ -1198,10 +1362,11 @@ impl Drop for Producer {
 				track = %self.name(),
 				"track::Producer dropped without finish() or abort()"
 			);
-			state.groups.clear();
+			state.lookup.clear();
+			state.arrival.clear();
+			state.evict.clear();
 			state.datagrams.clear();
-			state.duplicates.clear();
-			state.latest_entry = None;
+			state.debt = 0;
 		}
 	}
 }
@@ -2440,14 +2605,18 @@ mod test {
 		Producer::new(Arc::new(broadcast::Info::default()), name, info)
 	}
 
-	/// Helper: count non-tombstoned groups in state.
+	/// Helper: count live cached groups in state.
 	fn live_groups(state: &TrackState) -> usize {
-		state.groups.iter().flatten().count()
+		state.lookup.len()
 	}
 
-	/// Helper: get the sequence number of the first live group.
+	/// Helper: get the sequence number of the first live group in arrival order.
 	fn first_live_sequence(state: &TrackState) -> u64 {
-		state.groups.iter().flatten().next().unwrap().0.sequence
+		*state
+			.arrival
+			.iter()
+			.find(|sequence| state.lookup.contains_key(sequence))
+			.unwrap()
 	}
 
 	/// Helper: non-blocking datagram receive that must be ready with a datagram.
@@ -2696,10 +2865,10 @@ mod test {
 			assert_eq!(live_groups(&state), 1);
 			assert_eq!(first_live_sequence(&state), 3);
 			assert_eq!(state.offset, 3);
-			assert!(!state.duplicates.contains(&0));
-			assert!(!state.duplicates.contains(&1));
-			assert!(!state.duplicates.contains(&2));
-			assert!(state.duplicates.contains(&3));
+			assert!(!state.lookup.contains_key(&0));
+			assert!(!state.lookup.contains_key(&1));
+			assert!(!state.lookup.contains_key(&2));
+			assert!(state.lookup.contains_key(&3));
 		}
 	}
 
@@ -3021,10 +3190,10 @@ mod test {
 			let state = producer.state.read();
 			assert_eq!(live_groups(&state), 1);
 			assert_eq!(first_live_sequence(&state), 6);
-			assert!(!state.duplicates.contains(&3));
-			assert!(!state.duplicates.contains(&4));
-			assert!(!state.duplicates.contains(&5));
-			assert!(state.duplicates.contains(&6));
+			assert!(!state.lookup.contains_key(&3));
+			assert!(!state.lookup.contains_key(&4));
+			assert!(!state.lookup.contains_key(&5));
+			assert!(state.lookup.contains_key(&6));
 		}
 	}
 
@@ -3064,9 +3233,9 @@ mod test {
 			let state = producer.state.read();
 			assert_eq!(live_groups(&state), 2);
 			assert_eq!(state.offset, 0);
-			assert!(state.duplicates.contains(&5));
-			assert!(!state.duplicates.contains(&3));
-			assert!(state.duplicates.contains(&2));
+			assert!(state.lookup.contains_key(&5));
+			assert!(!state.lookup.contains_key(&3));
+			assert!(state.lookup.contains_key(&2));
 		}
 
 		// Consumer should still be able to read through the hole.
@@ -3090,8 +3259,9 @@ mod test {
 
 		{
 			let state = producer.state.read();
-			assert!(state.groups.is_empty(), "cached groups should be dropped on abort");
-			assert!(state.duplicates.is_empty());
+			assert!(state.lookup.is_empty(), "cached groups should be dropped on abort");
+			assert!(state.arrival.is_empty());
+			assert!(state.evict.is_empty());
 		}
 
 		// The consumer now surfaces the abort error rather than the leftover cache.
@@ -3927,7 +4097,7 @@ mod test {
 		assert!(dynamic.poll_requested_group(&kio::Waiter::noop()).is_pending());
 	}
 
-	/// Mint a track whose groups register with a bounded [`cache::Pool`].
+	/// Mint a track whose groups charge into a bounded [`cache::Pool`].
 	fn pooled_producer(capacity: u64) -> (Producer, cache::Pool) {
 		let pool = cache::Pool::new(capacity);
 		let broadcast = broadcast::Info {
@@ -3947,152 +4117,142 @@ mod test {
 		group.sequence
 	}
 
+	/// While the pool is over capacity, every append accrues debt and pays it by
+	/// evicting this track's own oldest groups, so the newest content survives.
 	#[tokio::test]
-	async fn pool_evicts_oldest_group() {
+	async fn debt_evicts_oldest_group() {
 		tokio::time::pause();
 
-		// Fits two 1000-byte groups (plus per-group overhead) but not three.
-		let (mut producer, pool) = pooled_producer(3000);
+		// Fits one 10k group; each additional group pushes the pool over budget.
+		let (mut producer, pool) = pooled_producer(10_000);
 
-		finished_group(&mut producer, 1000); // seq 0
-		tokio::time::advance(Duration::from_millis(10)).await;
-		finished_group(&mut producer, 1000); // seq 1
-		tokio::time::advance(Duration::from_millis(10)).await;
-		finished_group(&mut producer, 1000); // seq 2, pinned as latest
-
-		// The write to seq 2 pushed the pool over budget: seq 0 (stalest, unpinned)
-		// was evicted and its bytes released.
-		assert!(pool.used() <= 3000, "pool should be back under budget");
+		finished_group(&mut producer, 10_000); // seq 0
+		finished_group(&mut producer, 10_000); // seq 1: over budget, accrues and pays
+		finished_group(&mut producer, 10_000); // seq 2
 
 		let consumer = producer.consume();
-		assert!(consumer.peek_group(0).is_none(), "evicted group is a cache miss");
-		assert!(consumer.peek_group(1).is_some());
-		assert!(consumer.peek_group(2).is_some());
+		assert!(consumer.peek_group(0).is_none(), "oldest group is evicted");
+		assert!(consumer.peek_group(2).is_some(), "latest group survives");
+		assert!(pool.used() <= 12_000, "usage hovers near capacity: {}", pool.used());
 
-		// A fresh subscriber skips the evicted group entirely.
+		// A fresh subscriber skips the evicted groups entirely.
 		let mut subscriber = producer.subscribe(None);
-		assert_eq!(subscriber.assert_group().sequence, 1);
-		assert_eq!(subscriber.assert_group().sequence, 2);
+		assert!(subscriber.assert_group().sequence > 0, "evicted group is not delivered");
 	}
 
+	/// The latest group is never in the eviction order, so it survives any budget.
 	#[tokio::test]
-	async fn pool_never_evicts_latest() {
+	async fn latest_group_never_evicted() {
 		tokio::time::pause();
 
-		// Far too small for even one group: the latest is pinned and survives anyway.
+		// Far too small for even one group: the latest survives anyway.
 		let (mut producer, pool) = pooled_producer(100);
-		finished_group(&mut producer, 1000);
+		finished_group(&mut producer, 1000); // seq 0
+		assert!(pool.used() > 100, "the latest may exceed the budget");
 
-		assert!(pool.used() > 100, "pinned latest may exceed the budget");
-		let mut subscriber = producer.subscribe(None);
-		let mut group = subscriber.assert_group();
+		// Another write evicts the demoted seq 0, but seq 1 is untouchable in turn.
+		finished_group(&mut producer, 1000); // seq 1
+
+		let consumer = producer.consume();
+		assert!(consumer.peek_group(0).is_none());
+		let mut group = consumer.peek_group(1).expect("latest survives");
 		assert_eq!(group.read_frame().await.unwrap().unwrap().payload.len(), 1000);
 	}
 
+	/// A FETCH cache hit refreshes the group: the eviction walk spares it (re-queued
+	/// at the back, bytes credited) and evicts unread groups instead.
 	#[tokio::test]
-	async fn pool_reads_bump_recency() {
+	async fn fetch_refresh_survives_eviction() {
 		tokio::time::pause();
 
-		let (mut producer, pool) = pooled_producer(3000);
-		let mut subscriber = producer.subscribe(None);
-
-		finished_group(&mut producer, 1000); // seq 0
-		tokio::time::advance(Duration::from_millis(10)).await;
-		finished_group(&mut producer, 1000); // seq 1
-		tokio::time::advance(Duration::from_millis(10)).await;
-
-		// Read seq 0 so seq 1 becomes the least recently used.
-		let mut group = subscriber.assert_group();
-		assert_eq!(group.sequence, 0);
-		group.read_frame().await.unwrap().unwrap();
-		tokio::time::advance(Duration::from_millis(10)).await;
-
-		// Over budget: seq 1 (stale) is the victim, the just-read seq 0 survives.
-		finished_group(&mut producer, 1000); // seq 2, pinned
-
+		let (mut producer, _pool) = pooled_producer(10_000);
 		let consumer = producer.consume();
-		assert!(
-			consumer.peek_group(0).is_some(),
-			"recently read group survives: {:?}",
-			pool.debug_entries()
-		);
-		assert!(
-			consumer.peek_group(1).is_none(),
-			"stale group is evicted: {:?}",
-			pool.debug_entries()
-		);
+
+		finished_group(&mut producer, 5_000); // seq 0
+		finished_group(&mut producer, 5_000); // seq 1
+
+		// FETCH seq 0: the cache hit marks it refreshed.
+		let mut fetched = consumer.fetch_group(0, None).await.unwrap();
+		assert_eq!(fetched.read_frame().await.unwrap().unwrap().payload.len(), 5_000);
+
+		// Pressure. seq 0 is first in eviction order but refreshed, so it is spared;
+		// the debt carries and lands on seq 1 at the next write.
+		finished_group(&mut producer, 5_000); // seq 2
+		consumer.fetch_group(0, None).await.unwrap(); // keep seq 0 hot
+		finished_group(&mut producer, 5_000); // seq 3
+
+		assert!(consumer.peek_group(0).is_some(), "refreshed group survives");
+		assert!(consumer.peek_group(1).is_none(), "unread group is evicted instead");
 	}
 
+	/// A consumer holding an evicted group surfaces the eviction, not a hang or a
+	/// truncated clean end.
 	#[tokio::test]
-	async fn pool_eviction_aborts_readers() {
+	async fn eviction_aborts_readers() {
 		tokio::time::pause();
 
-		let (mut producer, pool) = pooled_producer(3000);
+		let (mut producer, _pool) = pooled_producer(10_000);
 		let mut subscriber = producer.subscribe(None);
 
-		finished_group(&mut producer, 1000); // seq 0
-		let group0 = subscriber.assert_group();
+		finished_group(&mut producer, 10_000); // seq 0
+		let mut group0 = subscriber.assert_group();
 
-		tokio::time::advance(Duration::from_millis(10)).await;
-		finished_group(&mut producer, 1000); // seq 1
-		tokio::time::advance(Duration::from_millis(10)).await;
-		finished_group(&mut producer, 1000); // seq 2 evicts seq 0
+		finished_group(&mut producer, 10_000); // seq 1: evicts seq 0
 
-		// A consumer holding the evicted group surfaces the eviction, not a hang
-		// or a truncated clean end.
-		let mut group0 = group0;
 		let read = group0.read_frame().await;
+		assert!(matches!(read, Err(Error::Evicted)), "expected Evicted, got {read:?}");
+	}
+
+	/// A write smaller than the next victim carries debt instead of evicting: a
+	/// large group dies only once enough debt accumulates, never to pay off a
+	/// far smaller write.
+	#[tokio::test]
+	async fn small_writes_carry_debt() {
+		tokio::time::pause();
+
+		let (mut producer, pool) = pooled_producer(22_000);
+		let consumer = producer.consume();
+
+		finished_group(&mut producer, 20_000); // seq 0, the large victim-to-be
+
+		// The first few small writes owe far less than seq 0's size: the debt
+		// carries over instead of evicting it.
+		for _ in 0..3 {
+			finished_group(&mut producer, 1_000);
+		}
+		assert!(consumer.peek_group(0).is_some(), "debt smaller than the victim carries");
+
+		// Enough small writes accumulate the debt to finally evict it.
+		for _ in 0..20 {
+			finished_group(&mut producer, 1_000);
+		}
 		assert!(
-			matches!(read, Err(Error::Evicted)),
-			"expected Evicted, got {read:?}: {:?}",
-			pool.debug_entries()
+			consumer.peek_group(0).is_none(),
+			"accumulated debt evicts the large group"
 		);
+		// Steady state hovers within about one group of capacity: a victim smaller
+		// than the outstanding debt is never evicted, so the excess stays bounded.
+		assert!(pool.used() <= 24_000, "usage hovers near capacity: {}", pool.used());
 	}
 
+	/// A refetched group that reclaims max_sequence is the live edge again: it must
+	/// not re-enter the eviction order, or memory pressure could evict the newest
+	/// content.
 	#[tokio::test]
-	async fn pool_growth_on_old_group_charges() {
+	async fn refetched_latest_stays_protected() {
 		tokio::time::pause();
 
-		let (mut producer, pool) = pooled_producer(3000);
-
-		// Seq 0 stays open (a straggler still being written).
-		let mut group0 = producer.append_group().unwrap();
-		tokio::time::advance(Duration::from_millis(10)).await;
-		// Seq 1 becomes the pinned latest; seq 0 is now evictable.
-		let _group1 = producer.append_group().unwrap();
-		tokio::time::advance(Duration::from_millis(10)).await;
-
-		// A late frame on the old group still counts against the budget, and can
-		// evict that very group once it blows past capacity.
-		group0
-			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 4000]))
-			.unwrap();
-		assert!(pool.used() <= 3000, "growth on an old group triggers eviction");
-		assert!(matches!(group0.abort(Error::Cancel), Err(Error::Evicted)));
-	}
-
-	#[tokio::test]
-	async fn refetched_latest_group_is_repinned() {
-		tokio::time::pause();
-
-		let (mut producer, pool) = pooled_producer(3000);
+		let (mut producer, _pool) = pooled_producer(10_000);
 		let dynamic = producer.dynamic();
+		let consumer = producer.consume();
 
-		// Seq 0 stays open: the straggler used to apply memory pressure later.
-		let mut straggler = producer.append_group().unwrap();
-		straggler
-			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 1000]))
-			.unwrap();
-		tokio::time::advance(Duration::from_millis(10)).await;
+		let straggler = producer.append_group().unwrap(); // seq 0
 
-		// The publisher aborts its own latest group; the slot stays at max_sequence.
+		// The publisher aborts its own latest group; the sequence stays at the live edge.
 		let latest = producer.append_group().unwrap(); // seq 1
 		latest.abort(Error::Cancel).unwrap();
-		tokio::time::advance(Duration::from_millis(10)).await;
 
-		// Re-fetch it: the replacement takes over max_sequence and must be
-		// re-pinned, or memory pressure could evict the live edge.
-		let consumer = producer.consume();
+		// Re-fetch it: the replacement takes over max_sequence.
 		let pending = consumer.fetch_group(1, None);
 		let req = dynamic
 			.requested_group()
@@ -4105,34 +4265,32 @@ mod test {
 			.unwrap();
 		group.finish().unwrap();
 		pending.await.unwrap();
-		tokio::time::advance(Duration::from_millis(10)).await;
 
-		// Blow the budget with the straggler; the refetched latest is pinned, so
-		// the straggler itself is the only eligible victim.
-		straggler
-			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 4000]))
-			.unwrap();
-
-		assert!(pool.used() <= 3000);
-		let mut group = consumer.peek_group(1).expect("refetched latest must stay pinned");
-		assert_eq!(group.read_frame().await.unwrap().unwrap().payload.len(), 1000);
+		// The refetched latest is protected by omission: it has no live entry in the
+		// eviction order, so no amount of debt can select it.
+		{
+			let state = producer.state.read();
+			let slot = state.lookup.get(&1).expect("refetched group is cached");
+			assert!(
+				!state.evict.iter().any(|(seq, epoch)| *seq == 1 && *epoch == slot.epoch),
+				"the live edge must not be an eviction candidate"
+			);
+		}
+		drop(straggler);
 	}
 
+	/// An evicted group is a cache miss, so a fetch re-fetches it and the accepted
+	/// replacement serves the sequence again (not `Error::Duplicate`).
 	#[tokio::test]
-	async fn pool_eviction_allows_refetch() {
+	async fn eviction_allows_refetch() {
 		tokio::time::pause();
 
-		let (mut producer, _pool) = pooled_producer(3000);
+		let (mut producer, _pool) = pooled_producer(10_000);
 		let dynamic = producer.dynamic();
 
-		finished_group(&mut producer, 1000); // seq 0
-		tokio::time::advance(Duration::from_millis(10)).await;
-		finished_group(&mut producer, 1000); // seq 1
-		tokio::time::advance(Duration::from_millis(10)).await;
-		finished_group(&mut producer, 1000); // seq 2 evicts seq 0
+		finished_group(&mut producer, 10_000); // seq 0
+		finished_group(&mut producer, 10_000); // seq 1: evicts seq 0
 
-		// The evicted group is a miss, so the fetch queues for the dynamic handler
-		// (a relay would issue a wire FETCH upstream).
 		let consumer = producer.consume();
 		assert!(consumer.peek_group(0).is_none());
 		let pending = consumer.fetch_group(0, None);
@@ -4144,7 +4302,6 @@ mod test {
 			.unwrap();
 		assert_eq!(req.sequence(), 0);
 
-		// Accept replaces the evicted slot in place (not Error::Duplicate).
 		let mut group = req.accept(None).unwrap();
 		group
 			.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"refetched"))
@@ -4153,6 +4310,76 @@ mod test {
 
 		let mut group = pending.await.unwrap();
 		assert_eq!(&group.read_frame().await.unwrap().unwrap().payload[..], b"refetched");
+	}
+
+	/// A fetched (backfill) group is served by sequence but never replayed to
+	/// arrival-order subscribers.
+	#[tokio::test]
+	async fn fetched_backfill_not_subscribed() {
+		let (mut producer, _pool) = pooled_producer(1 << 40);
+		let dynamic = producer.dynamic();
+		let consumer = producer.consume();
+
+		// The publisher starts at seq 5; earlier groups exist only upstream.
+		producer.create_group(5u64.into()).unwrap().finish().unwrap();
+		producer.create_group(6u64.into()).unwrap().finish().unwrap();
+
+		// Fetch the gap: it lands in the cache and resolves the fetch...
+		let pending = consumer.fetch_group(2, None);
+		let req = dynamic
+			.requested_group()
+			.now_or_never()
+			.expect("should not block")
+			.unwrap();
+		let mut group = req.accept(None).unwrap();
+		group
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"backfill"))
+			.unwrap();
+		group.finish().unwrap();
+		let mut fetched = pending.await.unwrap();
+		assert_eq!(&fetched.read_frame().await.unwrap().unwrap().payload[..], b"backfill");
+		assert!(consumer.peek_group(2).is_some(), "backfill is cached for later fetches");
+
+		// ...but an arrival-order subscriber only sees the live groups.
+		let mut subscriber = producer.subscribe(None);
+		assert_eq!(subscriber.assert_group().sequence, 5);
+		assert_eq!(subscriber.assert_group().sequence, 6);
+		subscriber.assert_no_group();
+	}
+
+	/// Fetched backfill isn't in arrival order, so it ages out through the eviction
+	/// order instead of lingering until the track closes.
+	#[tokio::test]
+	async fn expired_backfill_reclaimed() {
+		tokio::time::pause();
+
+		let (mut producer, pool) = pooled_producer(1 << 40);
+		let dynamic = producer.dynamic();
+		let consumer = producer.consume();
+
+		producer.create_group(5u64.into()).unwrap().finish().unwrap();
+
+		// Serve a backfill fetch for an old sequence.
+		let pending = consumer.fetch_group(2, None);
+		let req = dynamic
+			.requested_group()
+			.now_or_never()
+			.expect("should not block")
+			.unwrap();
+		let mut group = req.accept(None).unwrap();
+		group
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 1000]))
+			.unwrap();
+		group.finish().unwrap();
+		pending.await.unwrap();
+		let used = pool.used();
+
+		// Age past the track window; the next write reclaims the backfill.
+		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
+		producer.create_group(6u64.into()).unwrap().finish().unwrap();
+
+		assert!(consumer.peek_group(2).is_none(), "expired backfill is reclaimed");
+		assert!(pool.used() < used, "its bytes are released");
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1446,6 +1446,8 @@ impl Alive {
 	fn publish(&self, stats: Option<&stats::Scope>) {
 		self.published.store(true, Ordering::Relaxed);
 		if let Some(scope) = stats {
+			// At most one scope ever arrives: a track is minted either through
+			// `Producer::new` (+ `with_stats`) or through `Request::accept`, never both.
 			let _ = self.stats.set(scope.subscribe());
 		}
 	}

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -588,22 +588,18 @@ impl TrackState {
 	/// the current latest is never enqueued, which is what protects it from
 	/// eviction. `visible` controls arrival-order delivery: publisher-produced
 	/// groups reach subscribers, fetched backfill is served by sequence only.
-	/// Returns the demoted group's cached bytes, the write this insert owes
-	/// eviction debt for.
-	fn insert_group(&mut self, group: &group::Producer, now: web_async::time::Instant, visible: bool) -> u64 {
+	fn insert_group(&mut self, group: &group::Producer, now: web_async::time::Instant, visible: bool) {
 		let sequence = group.sequence;
 		self.next_epoch = self.next_epoch.wrapping_add(1);
 		let epoch = self.next_epoch;
 
-		let mut written = 0;
 		if self.max_sequence.is_none_or(|max| sequence >= max) {
 			// Demote the previous latest: it joins the eviction order like any other
-			// cached group, sized at what the publisher wrote into it.
+			// cached group.
 			if let Some(max) = self.max_sequence
 				&& sequence > max
 				&& let Some(prev) = self.lookup.get(&max)
 			{
-				written = prev.group.cached_bytes();
 				self.evict.push_back((max, prev.epoch));
 			}
 			self.max_sequence = Some(sequence);
@@ -623,38 +619,56 @@ impl TrackState {
 		if visible {
 			self.arrival.push_back(sequence);
 		}
-		written
 	}
 
-	/// Write-path cache upkeep, run after inserting a group: accrue and pay
-	/// eviction debt while the shared pool is over capacity, then expire groups
-	/// past the track's age window.
-	fn maintain(&mut self, written: u64, now: web_async::time::Instant, max_age: Duration) {
+	/// The cached bytes of the group that inserting `sequence` would demote from
+	/// the live edge: the inflow this insert accrues eviction debt for. Zero when
+	/// `sequence` isn't a new maximum (a straggler or backfill).
+	fn demotion_bytes(&self, sequence: u64) -> u64 {
+		if let Some(max) = self.max_sequence
+			&& sequence > max
+			&& let Some(prev) = self.lookup.get(&max)
+		{
+			prev.group.cached_bytes()
+		} else {
+			0
+		}
+	}
+
+	/// Accrue and pay eviction debt for `written` fresh bytes.
+	///
+	/// Runs BEFORE the new group is inserted, so a brand-new entry is never a
+	/// victim of the very write that created it.
+	fn charge_debt(&mut self, written: u64) {
 		let pool = self.broadcast.origin.pool.clone();
 		match pool.accrue(written) {
 			Some(accrued) => {
 				// `used` bounds what eviction could ever free, keeping a track that
 				// can't pay (everything protected) from hoarding a stale schedule.
 				self.debt = self.debt.saturating_add(accrued).min(pool.used());
-				self.pay_debt(&pool);
+				// Cap each payment at twice what was written so one write never dumps
+				// a deep backlog at once; the remainder carries to the next write.
+				self.pay_debt(&pool, written.saturating_mul(2));
 			}
 			// Under capacity there is nothing to work off, and stale debt would
 			// cause a spurious eviction burst at the next pressure spike.
 			None => self.debt = 0,
 		}
-		self.evict_expired(now, max_age);
 	}
 
-	/// Abort this track's oldest groups until the outstanding debt is paid.
+	/// Abort this track's oldest groups until the outstanding debt is paid, or
+	/// `cap` bytes have been freed by this call.
 	///
 	/// Pops the eviction order from the front, validating every entry against
 	/// `lookup`. When the next victim is larger than the remaining debt it is left
-	/// alone and the debt carries over, so a small write never evicts a huge group.
+	/// alone and the debt carries over, so a small write never evicts a huge group
+	/// (once the debt does cover it, that one victim may overshoot `cap`).
 	/// A FETCH-touched group is spared: its bytes count as paid (re-billed to every
 	/// writer through the pool's credit) and it re-queues at the back.
-	fn pay_debt(&mut self, pool: &cache::Pool) {
+	fn pay_debt(&mut self, pool: &cache::Pool, cap: u64) {
+		let mut paid = 0u64;
 		for _ in 0..self.evict.len() {
-			if self.debt == 0 {
+			if self.debt == 0 || paid >= cap {
 				return;
 			}
 			let Some((sequence, epoch)) = self.evict.pop_front() else {
@@ -698,6 +712,7 @@ impl TrackState {
 			}
 
 			self.debt -= size;
+			paid = paid.saturating_add(size);
 			let slot = self.lookup.remove(&sequence).unwrap();
 			let _ = slot.group.abort(Error::Evicted);
 		}
@@ -772,13 +787,15 @@ impl TrackState {
 
 		// An evicted sequence can be re-fetched; a live one is a duplicate.
 		self.claim_sequence(sequence)?;
+		let written = self.demotion_bytes(sequence);
+		self.charge_debt(written);
 
 		let latency_max = info.latency_max;
 		let group = group::Producer::new(group::Info { sequence }, info);
 		// Backfill is invisible to arrival-order subscribers: it was fetched on
 		// demand, not produced live by the publisher.
-		let written = self.insert_group(&group, now, false);
-		self.maintain(written, now, latency_max);
+		self.insert_group(&group, now, false);
+		self.evict_expired(now, latency_max);
 		Ok(group)
 	}
 }
@@ -860,10 +877,12 @@ impl Producer {
 
 		// An evicted sequence can be re-created; a live one is a duplicate.
 		state.claim_sequence(group.sequence)?;
+		let written = state.demotion_bytes(group.sequence);
+		state.charge_debt(written);
 
 		let group = group::Producer::new(group, track).with_meter(self.stats.meter());
-		let written = state.insert_group(&group, now, true);
-		state.maintain(written, now, latency_max);
+		state.insert_group(&group, now, true);
+		state.evict_expired(now, latency_max);
 
 		Ok(group)
 	}
@@ -885,11 +904,13 @@ impl Producer {
 		let track = info.clone();
 		let latency_max = info.latency_max;
 
-		let group = group::Producer::new(group::Info { sequence }, track).with_meter(self.stats.meter());
-
 		let now = web_async::time::Instant::now();
-		let written = state.insert_group(&group, now, true);
-		state.maintain(written, now, latency_max);
+		let written = state.demotion_bytes(sequence);
+		state.charge_debt(written);
+
+		let group = group::Producer::new(group::Info { sequence }, track).with_meter(self.stats.meter());
+		state.insert_group(&group, now, true);
+		state.evict_expired(now, latency_max);
 
 		Ok(group)
 	}
@@ -4127,13 +4148,15 @@ mod test {
 		let (mut producer, pool) = pooled_producer(10_000);
 
 		finished_group(&mut producer, 10_000); // seq 0
-		finished_group(&mut producer, 10_000); // seq 1: over budget, accrues and pays
-		finished_group(&mut producer, 10_000); // seq 2
+		finished_group(&mut producer, 10_000); // seq 1: over budget, debt starts accruing
+		finished_group(&mut producer, 10_000); // seq 2: pays by evicting seq 0
 
 		let consumer = producer.consume();
 		assert!(consumer.peek_group(0).is_none(), "oldest group is evicted");
 		assert!(consumer.peek_group(2).is_some(), "latest group survives");
-		assert!(pool.used() <= 12_000, "usage hovers near capacity: {}", pool.used());
+		// Steady state carries the protected live edge plus the just-demoted group
+		// (debt is charged before the demotion, so eviction lags one append).
+		assert!(pool.used() <= 21_000, "usage hovers near capacity: {}", pool.used());
 
 		// A fresh subscriber skips the evicted groups entirely.
 		let mut subscriber = producer.subscribe(None);
@@ -4150,12 +4173,13 @@ mod test {
 		finished_group(&mut producer, 1000); // seq 0
 		assert!(pool.used() > 100, "the latest may exceed the budget");
 
-		// Another write evicts the demoted seq 0, but seq 1 is untouchable in turn.
-		finished_group(&mut producer, 1000); // seq 1
+		// Later writes evict the demoted seq 0; each new latest is untouchable in turn.
+		finished_group(&mut producer, 1000); // seq 1: demotes seq 0
+		finished_group(&mut producer, 1000); // seq 2: pays by evicting seq 0
 
 		let consumer = producer.consume();
 		assert!(consumer.peek_group(0).is_none());
-		let mut group = consumer.peek_group(1).expect("latest survives");
+		let mut group = consumer.peek_group(2).expect("latest survives");
 		assert_eq!(group.read_frame().await.unwrap().unwrap().payload.len(), 1000);
 	}
 
@@ -4197,7 +4221,8 @@ mod test {
 		finished_group(&mut producer, 10_000); // seq 0
 		let mut group0 = subscriber.assert_group();
 
-		finished_group(&mut producer, 10_000); // seq 1: evicts seq 0
+		finished_group(&mut producer, 10_000); // seq 1: demotes seq 0
+		finished_group(&mut producer, 10_000); // seq 2: pays by evicting seq 0
 
 		let read = group0.read_frame().await;
 		assert!(matches!(read, Err(Error::Evicted)), "expected Evicted, got {read:?}");
@@ -4233,6 +4258,32 @@ mod test {
 		// Steady state hovers within about one group of capacity: a victim smaller
 		// than the outstanding debt is never evicted, so the excess stays bounded.
 		assert!(pool.used() <= 24_000, "usage hovers near capacity: {}", pool.used());
+	}
+
+	/// One write pays at most twice what it produced, so a capacity shrink (or one
+	/// track's burst) drains gradually instead of one writer dumping its whole
+	/// backlog in a single call.
+	#[tokio::test]
+	async fn payment_capped_per_write() {
+		tokio::time::pause();
+
+		let (mut producer, pool) = pooled_producer(1 << 40);
+		for _ in 0..10 {
+			finished_group(&mut producer, 1_000);
+		}
+
+		// The governor slashes the target; nothing is reclaimed synchronously.
+		pool.resize(100);
+		let before = pool.used();
+
+		// One 1k write may evict at most ~2k of backlog, not all ten groups.
+		finished_group(&mut producer, 1_000);
+
+		let consumer = producer.consume();
+		assert!(consumer.peek_group(0).is_none(), "the oldest groups are evicted");
+		assert!(consumer.peek_group(1).is_none());
+		assert!(consumer.peek_group(2).is_some(), "the backlog drains gradually");
+		assert!(pool.used() > before - 4_000, "one write must not dump the backlog");
 	}
 
 	/// A refetched group that reclaims max_sequence is the live edge again: it must
@@ -4289,7 +4340,8 @@ mod test {
 		let dynamic = producer.dynamic();
 
 		finished_group(&mut producer, 10_000); // seq 0
-		finished_group(&mut producer, 10_000); // seq 1: evicts seq 0
+		finished_group(&mut producer, 10_000); // seq 1: demotes seq 0
+		finished_group(&mut producer, 10_000); // seq 2: pays by evicting seq 0
 
 		let consumer = producer.consume();
 		assert!(consumer.peek_group(0).is_none());

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -23,7 +23,6 @@ pub use super::subscription::Subscription;
 use std::{
 	collections::{HashMap, VecDeque},
 	sync::Arc,
-	sync::atomic::{AtomicU64, Ordering},
 	task::{Poll, ready},
 	time::Duration,
 };
@@ -47,20 +46,13 @@ const EVICT_SLACK: usize = 64;
 /// groups, small enough that a write never scans a long queue.
 const EVICT_SCAN: usize = 4;
 
-/// Gross bytes written before a frame write settles eviction debt itself, so a
-/// track appending frames to open groups (never inserting another group) still
-/// pays. Coarse: the cost is one track-state lock per threshold crossing.
-const WRITE_CHARGE_THRESHOLD: u64 = 256 * 1024;
-
 /// Publisher-side properties of a track.
 ///
 /// These are fixed by the publisher when the track is created and don't change
 /// while the track is alive. A subscriber learns them via
 /// [`broadcast::Consumer::track`](broadcast::Consumer::track),
 /// which returns the publisher's [`Info`] once the subscription is accepted.
-///
-/// Not `Copy`: it carries an internal handle to its parent broadcast.
-#[derive(Clone)]
+#[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub struct Info {
 	/// Units per second for per-frame timestamps on this track.
@@ -86,47 +78,6 @@ pub struct Info {
 	/// out-of-order (or not at all) over the network. Used only to break ties,
 	/// reported in TRACK_INFO (Lite05+), and defaults to `false` (newest-first).
 	pub ordered: bool,
-
-	// The broadcast this track belongs to, bound when the track is created under one
-	// (`create_track` / `reserve_track` / `Request::accept`); until then it's a
-	// standalone broadcast with an unbounded pool. Not on the wire, and not a knob:
-	// every bind path overwrites whatever is here. It's the parent link a group walks
-	// to reach the shared cache pool (`track.broadcast.origin.pool`), which stays
-	// crate-private.
-	pub(crate) broadcast: Arc<broadcast::Info>,
-
-	// Gross bytes charged by this track's groups (payload plus overhead), shared
-	// with every group via its `cache::Charge` and drained into eviction debt.
-	// Owned by the TrackState and installed here whenever an info is attached to
-	// a track (see `TrackState::install`), so cloning or re-binding an Info never
-	// splits a live track's accounting.
-	pub(crate) written: Arc<AtomicU64>,
-
-	// Weak handle back to the owning track's state, installed alongside `written`,
-	// so a frame write can settle eviction debt itself once enough bytes accumulate
-	// (`Self::maybe_charge`). Weak: a group holding this must not keep the track
-	// alive. `None` until the info is attached to a track.
-	pub(crate) track: Option<kio::ProducerWeak<TrackState>>,
-}
-
-impl std::fmt::Debug for Info {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		f.debug_struct("Info")
-			.field("timescale", &self.timescale)
-			.field("latency_max", &self.latency_max)
-			.field("priority", &self.priority)
-			.field("ordered", &self.ordered)
-			.finish()
-	}
-}
-
-/// The shared parent for a not-yet-bound [`Info`]: a standalone broadcast with an
-/// unbounded pool. Cheap to hand out (one `Arc` clone) and replaced the moment the
-/// track is bound to a real broadcast.
-fn default_broadcast() -> Arc<broadcast::Info> {
-	static DEFAULT: std::sync::LazyLock<Arc<broadcast::Info>> =
-		std::sync::LazyLock::new(|| Arc::new(broadcast::Info::default()));
-	DEFAULT.clone()
 }
 
 impl Default for Info {
@@ -136,9 +87,6 @@ impl Default for Info {
 			latency_max: DEFAULT_LATENCY_MAX,
 			priority: 0,
 			ordered: false,
-			broadcast: default_broadcast(),
-			written: Arc::default(),
-			track: None,
 		}
 	}
 }
@@ -172,46 +120,22 @@ impl Info {
 		self.ordered = ordered;
 		self
 	}
-
-	/// Bind this track to its parent `broadcast`, the moment groups gain a shared
-	/// cache pool to register with. Also clamps [`Self::latency_max`] down to the
-	/// origin's [`cache_duration`](crate::origin::Info::cache_duration) ceiling, so a
-	/// group is never retained longer than the origin allows regardless of the window
-	/// the publisher advertised. Every bind path funnels through here, so the clamp
-	/// covers local publishers and relayed (lite / IETF) tracks alike.
-	pub(crate) fn bind(&mut self, broadcast: Arc<broadcast::Info>) {
-		self.latency_max = self.latency_max.min(broadcast.origin.cache_duration);
-		self.broadcast = broadcast;
-	}
-
-	/// Settle eviction debt from a frame write, once enough bytes accumulate.
-	///
-	/// Called with no group lock held (locks are ordered track then group). Cheap
-	/// until the threshold crosses: one relaxed load. This is what makes a track
-	/// that only appends frames to open groups, never inserting another group,
-	/// still pay its debt.
-	pub(crate) fn maybe_charge(&self) {
-		if self.written.load(Ordering::Relaxed) < WRITE_CHARGE_THRESHOLD {
-			return;
-		}
-		let Some(track) = &self.track else { return };
-		let Some(producer) = track.produce() else { return };
-		if let Ok(mut state) = producer.write() {
-			state.charge_debt();
-		}
-	}
 }
 
 #[derive(Default)]
 pub(crate) struct TrackState {
-	// The info for the track; always Some for Subscriber/Producer. Inherited (cloned)
-	// by each group it creates, which reaches the cache pool through its `broadcast`.
+	// The publisher's properties, once known; always Some for Subscriber/Producer.
+	// Copied by value into each group it creates.
 	info: Option<Info>,
 
-	// The broadcast this track belongs to, the source for stamping `Info::broadcast`
-	// on groups (and on a not-yet-accepted track's default info). Its
-	// `origin.pool` is the shared cache pool every group registers with.
+	// The broadcast this track belongs to. Supplies the cache pool its groups charge
+	// into and the `cache_duration` ceiling clamping `Info::latency_max`.
 	broadcast: Arc<broadcast::Info>,
+
+	// This track's account against the shared cache pool, shared with every group it
+	// creates (see `cache::Track`). Holds the gross-write counter `charge_debt` drains,
+	// and the weak link a frame write follows back here to settle its own debt.
+	cache: Arc<cache::Track>,
 
 	// Cached groups by sequence: the single source of truth for what is cached. The
 	// two orderings below hold bare sequences and validate against this map, so a
@@ -238,12 +162,6 @@ pub(crate) struct TrackState {
 	// track's own oldest groups. Per track, so eviction lands proportionally to
 	// what each track writes and never touches another track's cache.
 	debt: u64,
-
-	// The track's gross-write counter, drained by `charge_debt`. Owned here and
-	// installed into every info attached to this track, so replacing the info
-	// (e.g. `Request::accept` after pre-accept backfill) never strands the bytes
-	// already-created groups keep charging.
-	written: Arc<AtomicU64>,
 
 	// Datagrams in arrival order paired with their arrival time, a best-effort send buffer
 	// evicted by age (see `MAX_DATAGRAM_AGE`). Shares the group `max_sequence` namespace but
@@ -337,7 +255,7 @@ struct FetchOutcome {
 impl TrackState {
 	fn poll_info(&self) -> Poll<Result<Info>> {
 		if let Some(info) = &self.info {
-			Poll::Ready(Ok(info.clone()))
+			Poll::Ready(Ok(*info))
 		} else {
 			Poll::Pending
 		}
@@ -573,7 +491,7 @@ impl TrackState {
 	/// few writes. Expiry throughput is therefore EVICT_SCAN groups per write; the
 	/// byte budget reclaims the remainder under memory pressure.
 	fn evict_expired(&mut self, max_age: Duration) {
-		let now = self.broadcast.origin.pool.now();
+		let now = self.cache.pool().now();
 		let max_ticks = cache::Pool::ticks(max_age);
 
 		let len = self.evict.len();
@@ -643,14 +561,30 @@ impl TrackState {
 		self.debt = 0;
 	}
 
-	/// Attach `info` to this track, installing the state-owned write counter and
-	/// the weak state handle every info attached to a live track must carry.
-	/// Replacing the info (e.g. [`Request::accept`] after pre-accept backfill)
-	/// therefore never strands the bytes already-created groups keep charging.
-	fn install(&mut self, mut info: Info, track: Option<kio::ProducerWeak<TrackState>>) {
-		info.written = self.written.clone();
-		info.track = track;
+	/// Attach `info` to this track, clamping the publisher's window down to the
+	/// origin's [`cache_duration`](crate::origin::Info::cache_duration) ceiling so a
+	/// group is never retained longer than the origin allows. Every path that binds an
+	/// info to a track funnels through here, covering local publishers and relayed
+	/// (lite / IETF) tracks alike.
+	fn install(&mut self, mut info: Info) {
+		info.latency_max = info.latency_max.min(self.broadcast.origin.cache_duration);
 		self.info = Some(info);
+	}
+
+	/// Create the shared state for a track under `broadcast`, along with the cache
+	/// account it and its groups charge into.
+	///
+	/// The account holds a [`kio::Weak`] back to this state: a group must be able to
+	/// settle the track's eviction debt as it writes, but the track owns its cached
+	/// groups, so anything stronger would make the pair immortal.
+	fn spawn(broadcast: Arc<broadcast::Info>) -> kio::Producer<Self> {
+		let state = kio::Producer::new(Self {
+			broadcast: broadcast.clone(),
+			..Default::default()
+		});
+		let cache = cache::Track::new(broadcast.origin.pool.clone(), state.downgrade());
+		state.write().ok().expect("a new track is open").cache = cache;
+		state
 	}
 
 	/// Reject a sequence that is still cached; a dead (aborted or evicted)
@@ -721,20 +655,20 @@ impl TrackState {
 	}
 
 	/// Accrue and pay eviction debt for everything written since the last charge:
-	/// the track's gross-write counter, which the groups' charges feed on every
-	/// frame (so growth on already-demoted groups and backfill is billed too).
+	/// this track's account, which the groups' charges feed on every frame (so
+	/// growth on already-demoted groups and backfill is billed too).
 	///
 	/// Runs BEFORE the new group is inserted, so a brand-new entry is never a
 	/// victim of the very write that created it. A track whose oldest content is
 	/// staler than the pool-wide average access time accrues at double rate, so
 	/// stale-heavy tracks drain first.
 	///
-	/// Also runs from the frame-write path via [`Info::maybe_charge`] once a
-	/// track accumulates [`WRITE_CHARGE_THRESHOLD`] unbilled bytes, so a track
-	/// that only appends frames to open groups still pays.
-	fn charge_debt(&mut self) {
-		let written = self.written.swap(0, Ordering::Relaxed);
-		let pool = self.broadcast.origin.pool.clone();
+	/// Also runs from the frame-write path via [`cache::Track::settle`], which is
+	/// why it's reachable from the account, so a track that only appends frames to
+	/// open groups still pays.
+	pub(super) fn charge_debt(&mut self) {
+		let written = self.cache.take_written();
+		let pool = self.cache.pool().clone();
 		match pool.accrue(written) {
 			Some(mut accrued) => {
 				if self.oldest_is_stale(&pool) {
@@ -888,22 +822,19 @@ impl TrackState {
 			return Err(Error::Closed);
 		}
 
-		// Adopt the supplied info only if the track hasn't been accepted yet, binding
-		// it to this track's broadcast so its groups reach the shared pool. No weak
-		// handle exists at this depth; groups created here still charge the
-		// state-owned counter, they just can't settle debt from the frame path.
+		// Adopt the supplied info only if the track hasn't been accepted yet. Groups
+		// created here charge the same account as any other, so backfill written
+		// before the track is accepted settles its debt like the rest.
 		if self.info.is_none() {
-			let mut info = info.unwrap_or_default();
-			info.bind(self.broadcast.clone());
-			self.install(info, None);
+			self.install(info.unwrap_or_default());
 		}
-		let info = self.info.clone().unwrap();
+		let info = self.info.unwrap();
 
 		// An evicted sequence can be re-fetched; a live one is a duplicate.
 		self.claim_sequence(sequence)?;
 
 		let latency_max = info.latency_max;
-		let group = group::Producer::new(group::Info { sequence }, info);
+		let group = group::Producer::new(group::Info { sequence }, info, self.cache.clone());
 		// A backfill exists because someone is fetching it right now: stamp that
 		// access so the eviction walk can't kill it before the fetch resolves.
 		// It is also invisible to arrival-order subscribers: fetched on demand,
@@ -935,25 +866,19 @@ impl Producer {
 	/// Crate-private: tracks are born from their broadcast via
 	/// [`broadcast::Producer::create_track`] (or served on demand through a
 	/// [`Request`]), which threads the broadcast's `Arc<broadcast::Info>` down. The
-	/// track binds it onto its [`Info`] so every group reaches the shared cache pool
-	/// by walking `track.broadcast.origin.pool`.
+	/// track opens its cache account against that broadcast's origin pool, and every
+	/// group it creates charges into it.
 	pub(crate) fn new(
 		broadcast: Arc<broadcast::Info>,
 		name: impl Into<Arc<str>>,
 		info: impl Into<Option<Info>>,
 	) -> Self {
-		let mut info = info.into().unwrap_or_default();
-		info.bind(broadcast.clone());
-		let state = kio::Producer::new(TrackState {
-			broadcast: broadcast.clone(),
-			..Default::default()
-		});
-		let weak = state.weak();
+		let state = TrackState::spawn(broadcast.clone());
 		state
 			.write()
 			.ok()
 			.expect("a new track is open")
-			.install(info, Some(weak));
+			.install(info.into().unwrap_or_default());
 		Self {
 			name: name.into(),
 			state,
@@ -990,14 +915,13 @@ impl Producer {
 		{
 			return Err(Error::Closed);
 		}
-		let info = state.info.as_ref().unwrap();
-		let track = info.clone();
-		let latency_max = info.latency_max;
+		let track = state.info.unwrap();
+		let latency_max = track.latency_max;
 
 		// An evicted sequence can be re-created; a live one is a duplicate.
 		state.claim_sequence(group.sequence)?;
 
-		let group = group::Producer::new(group, track).with_meter(self.stats.meter());
+		let group = group::Producer::new(group, track, state.cache.clone()).with_meter(self.stats.meter());
 		state.commit_group(&group, true, latency_max);
 
 		Ok(group)
@@ -1016,11 +940,11 @@ impl Producer {
 			return Err(Error::Closed);
 		}
 
-		let info = state.info.as_ref().unwrap();
-		let track = info.clone();
-		let latency_max = info.latency_max;
+		let track = state.info.unwrap();
+		let latency_max = track.latency_max;
 
-		let group = group::Producer::new(group::Info { sequence }, track).with_meter(self.stats.meter());
+		let group =
+			group::Producer::new(group::Info { sequence }, track, state.cache.clone()).with_meter(self.stats.meter());
 		state.commit_group(&group, true, latency_max);
 
 		Ok(group)
@@ -1245,13 +1169,7 @@ impl Producer {
 		// requiring a live producer state. If the track already ended, the returned
 		// subscriber surfaces the close/abort on its first read; the preferences are
 		// simply never registered (nothing aggregates them anymore).
-		let info = self
-			.state
-			.read()
-			.info
-			.as_ref()
-			.expect("producer always has info")
-			.clone();
+		let info = *self.state.read().info.as_ref().expect("producer always has info");
 		let subscription = kio::Producer::new(preferences);
 		register_subscription(self.state.read(), &subscription);
 
@@ -2550,10 +2468,7 @@ pub struct Request {
 impl Request {
 	pub(crate) fn new(broadcast: Arc<broadcast::Info>, name: impl Into<Arc<str>>) -> Self {
 		let name = name.into();
-		let state = kio::Producer::new(TrackState {
-			broadcast: broadcast.clone(),
-			..Default::default()
-		});
+		let state = TrackState::spawn(broadcast.clone());
 		let dynamic = Dynamic::new(name.clone(), state.clone());
 		Self {
 			name,
@@ -2602,13 +2517,10 @@ impl Request {
 	/// [`Producer`] is inert: writes fail with the abort error, as if it had been
 	/// aborted immediately after accepting.
 	pub fn accept(self, info: impl Into<Option<Info>>) -> Producer {
-		let mut info = info.into().unwrap_or_default();
-		info.bind(self.broadcast.clone());
 		// A closed state means the track was aborted under us. Mirror `reject` and
 		// tolerate it: the Producer we hand back simply can't write.
-		let weak = self.state.weak();
 		if let Ok(mut state) = self.state.write() {
-			state.install(info, Some(weak));
+			state.install(info.into().unwrap_or_default());
 		}
 		// Accepting the request creates the track producer: count it as one ingress
 		// subscription (closed on the last producer drop). No-op when untagged.
@@ -4506,18 +4418,97 @@ mod test {
 		assert!(matches!(demoted.finish(), Err(Error::Evicted)));
 	}
 
-	/// A cloned `Info` reused for several tracks must not share eviction
-	/// accounting: every track instantiation gets its own write counter.
+	/// One `Info` describing several tracks must not join their eviction accounting:
+	/// each track opens its own account against the pool.
 	#[tokio::test]
-	async fn cloned_info_does_not_share_accounting() {
+	async fn each_track_owns_its_account() {
 		let broadcast = Arc::new(broadcast::Info::default());
 		let info = Info::default();
-		let a = Producer::new(broadcast.clone(), "a", info.clone());
+		let a = Producer::new(broadcast.clone(), "a", info);
 		let b = Producer::new(broadcast, "b", info);
 
-		let a = a.state.read().info.as_ref().unwrap().written.clone();
-		let b = b.state.read().info.as_ref().unwrap().written.clone();
-		assert!(!Arc::ptr_eq(&a, &b), "each track owns its write counter");
+		let a = a.state.read().cache.clone();
+		let b = b.state.read().cache.clone();
+		assert!(!Arc::ptr_eq(&a, &b), "each track owns its account");
+	}
+
+	/// A finished track releases everything once every handle is gone.
+	///
+	/// Its groups hold the cache account, and the account links back here, so that link
+	/// has to be weak: anything stronger makes the state (and every cached frame in it)
+	/// immortal, even with no producer or consumer left.
+	#[tokio::test]
+	async fn finished_track_frees_its_cache() {
+		let (mut producer, pool) = pooled_producer(1 << 40);
+		finished_group(&mut producer, 100);
+		producer.finish().unwrap();
+
+		let state = producer.state.downgrade();
+		drop(producer);
+
+		assert!(state.upgrade().is_none(), "the track state is freed");
+		assert_eq!(pool.used(), 0, "so are its cached bytes");
+	}
+
+	/// A subscriber holding one cached group must not pin the whole track: a group
+	/// carries the track's properties by value, not a handle back to its state.
+	#[tokio::test]
+	async fn cached_group_outlives_its_track() {
+		let (mut producer, pool) = pooled_producer(1 << 40);
+		let sequence = finished_group(&mut producer, 100);
+		let group = producer.consume().peek_group(sequence).expect("cached");
+		producer.finish().unwrap();
+
+		let state = producer.state.downgrade();
+		drop(producer);
+		assert!(state.upgrade().is_none(), "the track state is freed");
+		assert!(pool.used() > 0, "the retained group keeps its own bytes");
+
+		drop(group);
+		assert_eq!(pool.used(), 0, "which it releases when dropped");
+	}
+
+	/// A backfill served before the track was accepted settles its own debt: the
+	/// account exists from the moment the state does, so acceptance replacing the
+	/// `Info` can't leave already-created groups writing for free.
+	#[tokio::test]
+	async fn pre_accept_backfill_settles_late_writes() {
+		tokio::time::pause();
+
+		let pool = cache::Pool::new(2_000);
+		let broadcast = broadcast::Info {
+			origin: crate::origin::Info::default().with_pool(pool.clone()),
+			..Default::default()
+		};
+		let request = Request::new(Arc::new(broadcast), "test");
+		let dynamic = request.dynamic();
+		let consumer = request.consume();
+
+		// Serve backfill seq 0 before the track is accepted.
+		let pending = consumer.fetch_group(0, None);
+		let req = dynamic
+			.requested_group()
+			.now_or_never()
+			.expect("should not block")
+			.unwrap();
+		let mut backfill = req.accept(None).unwrap();
+		pending.await.unwrap();
+
+		// Accept, then demote the backfill with a live group.
+		let mut producer = request.accept(None);
+		producer.append_group().unwrap().finish().unwrap();
+
+		// No further insert: the late write into the demoted backfill is the only
+		// thing that can pay the debt it just took on.
+		backfill
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 300_000]))
+			.unwrap();
+
+		assert!(
+			pool.used() <= 5_000,
+			"the frame write settled the debt: {}",
+			pool.used()
+		);
 	}
 
 	/// A late frame write restarts the retention clock (retention is documented as

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -854,6 +854,11 @@ pub struct Producer {
 	broadcast: Arc<broadcast::Info>,
 	state: kio::Producer<TrackState>,
 	prev_subscription: Option<Subscription>,
+	// Counts the producer clones, and only them, so teardown fires exactly when the
+	// publisher lets go. The track state's own producer count is a different
+	// question: a group settling its eviction debt upgrades the account's weak
+	// handle, which momentarily counts there (see `cache::Track::settle`).
+	alive: kio::Producer<()>,
 	// Ingress stats scope, inherited from a tagged [`broadcast::Producer`]. Bumped as
 	// one subscription on tag and closed when the last producer clone drops. Empty
 	// (no-op) for an untagged broadcast.
@@ -884,6 +889,7 @@ impl Producer {
 			state,
 			broadcast,
 			prev_subscription: None,
+			alive: Default::default(),
 			stats: stats::Scope::default(),
 		}
 	}
@@ -1394,7 +1400,7 @@ impl Drop for Producer {
 		// release the cached groups so a stale consumer can't pin them (and their
 		// frame buffers) forever, the same as an explicit abort. A cleanly
 		// finished track keeps its cache so consumers can still drain it.
-		if !self.state.is_last() {
+		if !self.alive.is_last() {
 			return;
 		}
 		// The last ingress producer closing the track ends its subscription.
@@ -2530,6 +2536,7 @@ impl Request {
 			broadcast: self.broadcast,
 			state: self.state,
 			prev_subscription: None,
+			alive: Default::default(),
 			stats: self.stats,
 		}
 	}
@@ -4448,6 +4455,22 @@ mod test {
 
 		assert!(state.upgrade().is_none(), "the track state is freed");
 		assert_eq!(pool.used(), 0, "so are its cached bytes");
+	}
+
+	/// A group settling its eviction debt upgrades the account's weak handle, which
+	/// counts as a producer on the track state. Teardown must not mistake that for a
+	/// surviving publisher, or an abrupt drop silently behaves like a clean finish.
+	#[tokio::test]
+	async fn teardown_ignores_a_settling_group() {
+		let (mut producer, pool) = pooled_producer(1 << 40);
+		finished_group(&mut producer, 100);
+
+		// Stand in for a concurrent `cache::Track::settle`, mid-upgrade.
+		let settling = producer.state.downgrade().upgrade().expect("open");
+		drop(producer);
+
+		assert_eq!(pool.used(), 0, "the abrupt teardown still released the cache");
+		drop(settling);
 	}
 
 	/// A subscriber holding one cached group must not pin the whole track: a group

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -47,6 +47,11 @@ const EVICT_SLACK: usize = 64;
 /// groups, small enough that a write never scans a long queue.
 const EVICT_SCAN: usize = 4;
 
+/// Gross bytes written before a frame write settles eviction debt itself, so a
+/// track appending frames to open groups (never inserting another group) still
+/// pays. Coarse: the cost is one track-state lock per threshold crossing.
+const WRITE_CHARGE_THRESHOLD: u64 = 256 * 1024;
+
 /// Publisher-side properties of a track.
 ///
 /// These are fixed by the publisher when the track is created and don't change
@@ -55,7 +60,7 @@ const EVICT_SCAN: usize = 4;
 /// which returns the publisher's [`Info`] once the subscription is accepted.
 ///
 /// Not `Copy`: it carries an internal handle to its parent broadcast.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 #[non_exhaustive]
 pub struct Info {
 	/// Units per second for per-frame timestamps on this track.
@@ -91,10 +96,28 @@ pub struct Info {
 	pub(crate) broadcast: Arc<broadcast::Info>,
 
 	// Gross bytes charged by this track's groups (payload plus overhead), shared
-	// with every group via its `cache::Charge`. Drained by `charge_debt` on each
-	// group insert, so eviction debt observes actual writes, including growth on
-	// already-demoted groups and backfill, not just group transitions.
+	// with every group via its `cache::Charge` and drained into eviction debt.
+	// Owned by the TrackState and installed here whenever an info is attached to
+	// a track (see `TrackState::install`), so cloning or re-binding an Info never
+	// splits a live track's accounting.
 	pub(crate) written: Arc<AtomicU64>,
+
+	// Weak handle back to the owning track's state, installed alongside `written`,
+	// so a frame write can settle eviction debt itself once enough bytes accumulate
+	// (`Self::maybe_charge`). Weak: a group holding this must not keep the track
+	// alive. `None` until the info is attached to a track.
+	pub(crate) track: Option<kio::ProducerWeak<TrackState>>,
+}
+
+impl std::fmt::Debug for Info {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Info")
+			.field("timescale", &self.timescale)
+			.field("latency_max", &self.latency_max)
+			.field("priority", &self.priority)
+			.field("ordered", &self.ordered)
+			.finish()
+	}
 }
 
 /// The shared parent for a not-yet-bound [`Info`]: a standalone broadcast with an
@@ -115,6 +138,7 @@ impl Default for Info {
 			ordered: false,
 			broadcast: default_broadcast(),
 			written: Arc::default(),
+			track: None,
 		}
 	}
 }
@@ -158,15 +182,28 @@ impl Info {
 	pub(crate) fn bind(&mut self, broadcast: Arc<broadcast::Info>) {
 		self.latency_max = self.latency_max.min(broadcast.origin.cache_duration);
 		self.broadcast = broadcast;
-		// Every track instantiation funnels through here exactly once: give it its
-		// own write counter, so an `Info` cloned into several tracks can't drain or
-		// inflate another track's eviction accounting.
-		self.written = Arc::default();
+	}
+
+	/// Settle eviction debt from a frame write, once enough bytes accumulate.
+	///
+	/// Called with no group lock held (locks are ordered track then group). Cheap
+	/// until the threshold crosses: one relaxed load. This is what makes a track
+	/// that only appends frames to open groups, never inserting another group,
+	/// still pay its debt.
+	pub(crate) fn maybe_charge(&self) {
+		if self.written.load(Ordering::Relaxed) < WRITE_CHARGE_THRESHOLD {
+			return;
+		}
+		let Some(track) = &self.track else { return };
+		let Some(producer) = track.produce() else { return };
+		if let Ok(mut state) = producer.write() {
+			state.charge_debt();
+		}
 	}
 }
 
 #[derive(Default)]
-struct TrackState {
+pub(crate) struct TrackState {
 	// The info for the track; always Some for Subscriber/Producer. Inherited (cloned)
 	// by each group it creates, which reaches the cache pool through its `broadcast`.
 	info: Option<Info>,
@@ -187,20 +224,26 @@ struct TrackState {
 	// served by sequence, never replayed to arrival-order subscribers.
 	arrival: VecDeque<(u64, u32)>,
 
-	// Eviction order under memory pressure: every cached group except the current
-	// max_sequence, so the live edge is protected by omission rather than pinning.
-	// `pay_debt` scans victims from the front; groups accessed more recently than
-	// the pool-wide average rotate to the back instead of dying, decoupling
-	// eviction order from arrival order. Entries are hints validated against
-	// `lookup` on pop, and eviction is deliberately approximate: a bounded scan
-	// per write, sometimes out of order.
-	evict: VecDeque<u64>,
+	// Eviction order under memory pressure as (sequence, stamp): every cached
+	// group except the protected latest. `pay_debt` scans victims from the front;
+	// groups accessed more recently than the pool-wide average rotate to the back
+	// instead of dying, decoupling eviction order from arrival order. Entries are
+	// hints that only resolve while their stamp matches the slot's, so a re-served
+	// sequence can't accumulate duplicate hints that alias its replacement.
+	// Eviction is deliberately approximate: a bounded scan per write.
+	evict: VecDeque<(u64, u32)>,
 
 	// Outstanding eviction debt in bytes, accrued by writes while the shared pool
 	// is over capacity (see `cache::Pool::accrue`) and paid by aborting this
 	// track's own oldest groups. Per track, so eviction lands proportionally to
 	// what each track writes and never touches another track's cache.
 	debt: u64,
+
+	// The track's gross-write counter, drained by `charge_debt`. Owned here and
+	// installed into every info attached to this track, so replacing the info
+	// (e.g. `Request::accept` after pre-accept backfill) never strands the bytes
+	// already-created groups keep charging.
+	written: Arc<AtomicU64>,
 
 	// Datagrams in arrival order paired with their arrival time, a best-effort send buffer
 	// evicted by age (see `MAX_DATAGRAM_AGE`). Shares the group `max_sequence` namespace but
@@ -537,10 +580,14 @@ impl TrackState {
 		if len > 0 {
 			let start = self.expire_cursor % len;
 			for step in 0..len.min(EVICT_SCAN) {
-				let sequence = self.evict[(start + step) % len];
+				let (sequence, stamp) = self.evict[(start + step) % len];
 				let Some(slot) = self.lookup.get(&sequence) else {
 					continue;
 				};
+				if slot.stamp != stamp {
+					// A historical hint; the live entry is elsewhere in the queue.
+					continue;
+				}
 				// Already aborted: the frames are gone, reclaim the slot so a
 				// later fetch can serve the sequence again.
 				if slot.group.is_aborted() {
@@ -570,8 +617,8 @@ impl TrackState {
 		}
 
 		// Drop dead leading eviction entries so scans stay over live candidates.
-		while let Some(sequence) = self.evict.front() {
-			if self.lookup.contains_key(sequence) {
+		while let Some((sequence, stamp)) = self.evict.front() {
+			if self.lookup.get(sequence).is_some_and(|slot| slot.stamp == *stamp) {
 				break;
 			}
 			self.evict.pop_front();
@@ -581,7 +628,8 @@ impl TrackState {
 		// outnumber the live slots.
 		if self.evict.len() > 2 * self.lookup.len() + EVICT_SLACK {
 			let lookup = &self.lookup;
-			self.evict.retain(|sequence| lookup.contains_key(sequence));
+			self.evict
+				.retain(|(sequence, stamp)| lookup.get(sequence).is_some_and(|slot| slot.stamp == *stamp));
 		}
 	}
 
@@ -593,6 +641,16 @@ impl TrackState {
 		self.evict.clear();
 		self.latest_group = None;
 		self.debt = 0;
+	}
+
+	/// Attach `info` to this track, installing the state-owned write counter and
+	/// the weak state handle every info attached to a live track must carry.
+	/// Replacing the info (e.g. [`Request::accept`] after pre-accept backfill)
+	/// therefore never strands the bytes already-created groups keep charging.
+	fn install(&mut self, mut info: Info, track: Option<kio::ProducerWeak<TrackState>>) {
+		info.written = self.written.clone();
+		info.track = track;
+		self.info = Some(info);
 	}
 
 	/// Reject a sequence that is still cached; a dead (aborted or evicted)
@@ -632,12 +690,12 @@ impl TrackState {
 				&& let Some(prev) = self.lookup.get(&latest)
 			{
 				prev.group.cache_demote();
-				self.evict.push_back(latest);
+				self.evict.push_back((latest, prev.stamp));
 			}
 			self.latest_group = Some(sequence);
 		} else {
 			group.cache_demote();
-			self.evict.push_back(sequence);
+			self.evict.push_back((sequence, stamp));
 		}
 
 		self.max_sequence = Some(self.max_sequence.map_or(sequence, |max| max.max(sequence)));
@@ -671,14 +729,11 @@ impl TrackState {
 	/// staler than the pool-wide average access time accrues at double rate, so
 	/// stale-heavy tracks drain first.
 	///
-	/// Known limitation: payment only runs here, on group insert. A track that
-	/// keeps appending frames to existing groups without ever inserting another
-	/// group accrues into the counter but doesn't pay, bounding its exposure at
-	/// the per-group frame cap times its open groups; the shared budget squeezes
-	/// the other, still-inserting tracks in the meantime.
+	/// Also runs from the frame-write path via [`Info::maybe_charge`] once a
+	/// track accumulates [`WRITE_CHARGE_THRESHOLD`] unbilled bytes, so a track
+	/// that only appends frames to open groups still pays.
 	fn charge_debt(&mut self) {
-		let Some(info) = &self.info else { return };
-		let written = info.written.swap(0, Ordering::Relaxed);
+		let written = self.written.swap(0, Ordering::Relaxed);
 		let pool = self.broadcast.origin.pool.clone();
 		match pool.accrue(written) {
 			Some(mut accrued) => {
@@ -705,13 +760,13 @@ impl TrackState {
 		let Some(average) = pool.average() else {
 			return false;
 		};
-		let Some(sequence) = self.evict.front() else {
+		let Some((sequence, stamp)) = self.evict.front() else {
 			return false;
 		};
 		let Some(slot) = self.lookup.get(sequence) else {
 			return false;
 		};
-		!slot.group.is_aborted() && slot.group.cache_accessed() <= average
+		slot.stamp == *stamp && !slot.group.is_aborted() && slot.group.cache_accessed() <= average
 	}
 
 	/// Abort this track's stalest groups until the outstanding debt is paid, or
@@ -734,13 +789,17 @@ impl TrackState {
 			if self.debt == 0 || paid >= cap || scanned >= EVICT_SCAN {
 				return;
 			}
-			let Some(sequence) = self.evict.pop_front() else {
+			let Some((sequence, stamp)) = self.evict.pop_front() else {
 				return;
 			};
 			let Some(slot) = self.lookup.get(&sequence) else {
 				// Evicted or expired; discard the dead entry.
 				continue;
 			};
+			if slot.stamp != stamp {
+				// A historical hint; the live entry is elsewhere in the queue.
+				continue;
+			}
 			if slot.group.is_aborted() {
 				// Aborted upstream: the frames are already gone, reclaim the slot.
 				self.lookup.remove(&sequence);
@@ -748,7 +807,7 @@ impl TrackState {
 			}
 			if Some(sequence) == self.latest_group {
 				// The live edge is never enqueued, but tolerate finding it anyway.
-				self.evict.push_back(sequence);
+				self.evict.push_back((sequence, stamp));
 				continue;
 			}
 
@@ -757,14 +816,14 @@ impl TrackState {
 			// a FETCH hit, which also covers a backfill still being filled). Rotate
 			// to the back.
 			if slot.group.cache_accessed() > average {
-				self.evict.push_back(sequence);
+				self.evict.push_back((sequence, stamp));
 				continue;
 			}
 			// The full footprint including overhead, so even empty groups repay
 			// their share of the budget when evicted.
 			let size = slot.group.cache_size();
 			if size > self.debt {
-				self.evict.push_front(sequence);
+				self.evict.push_front((sequence, stamp));
 				return;
 			}
 
@@ -830,16 +889,15 @@ impl TrackState {
 		}
 
 		// Adopt the supplied info only if the track hasn't been accepted yet, binding
-		// it to this track's broadcast so its groups reach the shared pool.
-		let broadcast = self.broadcast.clone();
-		let info = self
-			.info
-			.get_or_insert_with(|| {
-				let mut info = info.unwrap_or_default();
-				info.bind(broadcast);
-				info
-			})
-			.clone();
+		// it to this track's broadcast so its groups reach the shared pool. No weak
+		// handle exists at this depth; groups created here still charge the
+		// state-owned counter, they just can't settle debt from the frame path.
+		if self.info.is_none() {
+			let mut info = info.unwrap_or_default();
+			info.bind(self.broadcast.clone());
+			self.install(info, None);
+		}
+		let info = self.info.clone().unwrap();
 
 		// An evicted sequence can be re-fetched; a live one is a duplicate.
 		self.claim_sequence(sequence)?;
@@ -886,13 +944,19 @@ impl Producer {
 	) -> Self {
 		let mut info = info.into().unwrap_or_default();
 		info.bind(broadcast.clone());
+		let state = kio::Producer::new(TrackState {
+			broadcast: broadcast.clone(),
+			..Default::default()
+		});
+		let weak = state.weak();
+		state
+			.write()
+			.ok()
+			.expect("a new track is open")
+			.install(info, Some(weak));
 		Self {
 			name: name.into(),
-			state: kio::Producer::new(TrackState {
-				info: Some(info),
-				broadcast: broadcast.clone(),
-				..Default::default()
-			}),
+			state,
 			broadcast,
 			prev_subscription: None,
 			stats: stats::Scope::default(),
@@ -2542,8 +2606,9 @@ impl Request {
 		info.bind(self.broadcast.clone());
 		// A closed state means the track was aborted under us. Mirror `reject` and
 		// tolerate it: the Producer we hand back simply can't write.
+		let weak = self.state.weak();
 		if let Ok(mut state) = self.state.write() {
-			state.info = Some(info);
+			state.install(info, Some(weak));
 		}
 		// Accepting the request creates the track producer: count it as one ingress
 		// subscription (closed on the last producer drop). No-op when untagged.
@@ -4334,6 +4399,113 @@ mod test {
 		assert!(pool.used() > before - 4_000, "one write must not dump the backlog");
 	}
 
+	/// Accepting a track after pre-accept backfill must keep the same write
+	/// counter: the counter is owned by the track state, so replacing the info
+	/// can't strand the bytes already-created groups keep charging.
+	#[tokio::test]
+	async fn accept_preserves_write_accounting() {
+		tokio::time::pause();
+
+		let pool = cache::Pool::new(12_000);
+		let broadcast = broadcast::Info {
+			origin: crate::origin::Info::default().with_pool(pool.clone()),
+			..Default::default()
+		};
+		let request = Request::new(Arc::new(broadcast), "test");
+		let dynamic = request.dynamic();
+		let consumer = request.consume();
+
+		// Serve a backfill before the track is accepted, then grow it.
+		let pending = consumer.fetch_group(0, None);
+		let req = dynamic
+			.requested_group()
+			.now_or_never()
+			.expect("should not block")
+			.unwrap();
+		let mut backfill = req.accept(None).unwrap();
+		pending.await.unwrap();
+		backfill
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 30_000]))
+			.unwrap();
+
+		// Accept with a fresh Info: the pre-accept group's writes must still be
+		// drained by this track's future charges.
+		let mut producer = request.accept(None);
+		producer.append_group().unwrap().finish().unwrap();
+		producer.append_group().unwrap().finish().unwrap();
+
+		assert!(
+			producer.consume().peek_group(0).is_none(),
+			"pre-accept backfill growth is reclaimed after accept"
+		);
+		assert!(pool.used() <= 13_000, "usage converges: {}", pool.used());
+	}
+
+	/// Re-serving a sequence many times must not accumulate eviction hints: stale
+	/// hints die on stamp mismatch and compaction reclaims them.
+	#[tokio::test]
+	async fn recreated_sequence_bounds_eviction_hints() {
+		let (mut producer, _pool) = pooled_producer(1 << 40);
+		producer.create_group(5u64.into()).unwrap().finish().unwrap();
+
+		for _ in 0..200 {
+			let group = producer.create_group(1u64.into()).unwrap();
+			group.abort(Error::Cancel).unwrap();
+		}
+
+		let state = producer.state.read();
+		assert!(
+			state.evict.len() <= 2 * state.lookup.len() + EVICT_SLACK,
+			"stale hints are compacted: {} entries for {} slots",
+			state.evict.len(),
+			state.lookup.len()
+		);
+	}
+
+	/// A frame write within the same coarse tick still outranks merely-inserted
+	/// content, so the freshly-written group survives and the empty one pays.
+	#[tokio::test]
+	async fn same_tick_write_outranks_inserted() {
+		tokio::time::pause();
+
+		// No time advances: every stamp lands in the same tick.
+		let (mut producer, _pool) = pooled_producer(10_000);
+
+		producer.append_group().unwrap().finish().unwrap(); // seq 0: empty
+		finished_group(&mut producer, 3_000); // seq 1: written
+		finished_group(&mut producer, 3_000); // seq 2
+		finished_group(&mut producer, 3_000); // seq 3
+		finished_group(&mut producer, 3_000); // seq 4: over budget, pays
+
+		let consumer = producer.consume();
+		assert!(consumer.peek_group(0).is_none(), "insert-only content pays first");
+		assert!(consumer.peek_group(1).is_some(), "same-tick written content survives");
+	}
+
+	/// A track that only appends frames to an open group, never inserting another
+	/// group, still settles its eviction debt once enough bytes accumulate.
+	#[tokio::test]
+	async fn frame_only_writer_pays() {
+		tokio::time::pause();
+
+		let (mut producer, pool) = pooled_producer(2_000);
+		let mut demoted = producer.append_group().unwrap(); // seq 0
+		producer.append_group().unwrap().finish().unwrap(); // seq 1 demotes seq 0
+
+		// One large frame crosses the charge threshold: the write itself pays,
+		// with no further group insert on this track.
+		demoted
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 300_000]))
+			.unwrap();
+
+		assert!(
+			pool.used() <= 5_000,
+			"the frame write settled the debt: {}",
+			pool.used()
+		);
+		assert!(matches!(demoted.finish(), Err(Error::Evicted)));
+	}
+
 	/// A cloned `Info` reused for several tracks must not share eviction
 	/// accounting: every track instantiation gets its own write counter.
 	#[tokio::test]
@@ -4652,7 +4824,7 @@ mod test {
 			let state = producer.state.read();
 			assert!(state.lookup.contains_key(&1), "refetched group is cached");
 			assert!(
-				!state.evict.contains(&1),
+				state.evict.iter().all(|(sequence, _)| *sequence != 1),
 				"the live edge must not be an eviction candidate"
 			);
 		}

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -54,7 +54,11 @@ const EVICT_SCAN: usize = 4;
 /// while the track is alive. A subscriber learns them via
 /// [`broadcast::Consumer::track`](broadcast::Consumer::track),
 /// which returns the publisher's [`Info`] once the subscription is accepted.
-#[derive(Clone, Copy, Debug)]
+//
+// Deliberately not `Copy`, even though it's now a plain value: adding `Copy` turns
+// every existing `info.clone()` in a consumer's code into a `clippy::clone_on_copy`
+// error under `-D warnings`.
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct Info {
 	/// Units per second for per-frame timestamps on this track.
@@ -257,7 +261,7 @@ struct FetchOutcome {
 impl TrackState {
 	fn poll_info(&self) -> Poll<Result<Info>> {
 		if let Some(info) = &self.info {
-			Poll::Ready(Ok(*info))
+			Poll::Ready(Ok(info.clone()))
 		} else {
 			Poll::Pending
 		}
@@ -830,7 +834,7 @@ impl TrackState {
 		if self.info.is_none() {
 			self.install(info.unwrap_or_default());
 		}
-		let info = self.info.unwrap();
+		let info = self.info.clone().unwrap();
 
 		// An evicted sequence can be re-fetched; a live one is a duplicate.
 		self.claim_sequence(sequence)?;
@@ -923,7 +927,7 @@ impl Producer {
 		{
 			return Err(Error::Closed);
 		}
-		let track = state.info.unwrap();
+		let track = state.info.clone().unwrap();
 		let latency_max = track.latency_max;
 
 		// An evicted sequence can be re-created; a live one is a duplicate.
@@ -948,7 +952,7 @@ impl Producer {
 			return Err(Error::Closed);
 		}
 
-		let track = state.info.unwrap();
+		let track = state.info.clone().unwrap();
 		let latency_max = track.latency_max;
 
 		let group =
@@ -1177,7 +1181,7 @@ impl Producer {
 		// requiring a live producer state. If the track already ended, the returned
 		// subscriber surfaces the close/abort on its first read; the preferences are
 		// simply never registered (nothing aggregates them anymore).
-		let info = *self.state.read().info.as_ref().expect("producer always has info");
+		let info = self.state.read().info.clone().expect("producer always has info");
 		let subscription = kio::Producer::new(preferences);
 		register_subscription(self.state.read(), &subscription);
 
@@ -2963,8 +2967,9 @@ mod test {
 		// Append a new group to trigger eviction.
 		producer.append_group().unwrap(); // seq 3
 
-		// Groups 0, 1, 2 are expired but seq 3 (max_sequence) is kept.
-		// Leading tombstones are trimmed, so only seq 3 remains.
+		// Groups 0, 1, 2 are expired but seq 3 (the live edge) is kept. Their arrival
+		// entries no longer resolve, so the leading ones are trimmed and the offset
+		// advances past them.
 		{
 			let state = producer.state.read();
 			assert_eq!(live_groups(&state), 1);
@@ -3330,10 +3335,10 @@ mod test {
 		// Seq 2 arrives late, triggering eviction.
 		producer.create_group(group::Info { sequence: 2 }).unwrap();
 
-		// Seq 5 is still max_sequence (protected, at front, blocks trim).
-		// Seq 3 is expired → tombstoned.
-		// Seq 2 is fresh → kept.
-		// VecDeque: [Some(5), None, Some(2)]. Leading entry is Some, so offset stays.
+		// Seq 5 is the live edge (protected) and still resolves at the front of
+		// `arrival`, so nothing is trimmed and the offset stays. Seq 3 expired out of
+		// `lookup`, leaving a hole its arrival entry no longer resolves; seq 2 is
+		// fresh and kept.
 		{
 			let state = producer.state.read();
 			assert_eq!(live_groups(&state), 2);
@@ -3346,7 +3351,7 @@ mod test {
 		// Consumer should still be able to read through the hole.
 		let mut consumer = producer.subscribe(None);
 		let group = consumer.assert_group();
-		// consume() starts at index 0, first non-tombstoned group is seq 5.
+		// consume() starts at index 0; the first arrival entry that still resolves is seq 5.
 		assert_eq!(group.sequence, 5);
 	}
 
@@ -4489,7 +4494,7 @@ mod test {
 	async fn each_track_owns_its_account() {
 		let broadcast = Arc::new(broadcast::Info::default());
 		let info = Info::default();
-		let a = Producer::new(broadcast.clone(), "a", info);
+		let a = Producer::new(broadcast.clone(), "a", info.clone());
 		let b = Producer::new(broadcast, "b", info);
 
 		let a = a.state.read().cache.clone();

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -158,6 +158,10 @@ impl Info {
 	pub(crate) fn bind(&mut self, broadcast: Arc<broadcast::Info>) {
 		self.latency_max = self.latency_max.min(broadcast.origin.cache_duration);
 		self.broadcast = broadcast;
+		// Every track instantiation funnels through here exactly once: give it its
+		// own write counter, so an `Info` cloned into several tracks can't drain or
+		// inflate another track's eviction accounting.
+		self.written = Arc::default();
 	}
 }
 
@@ -177,10 +181,11 @@ struct TrackState {
 	// removed or replaced group turns their entries into discarded-on-pop hints.
 	lookup: HashMap<u64, Slot>,
 
-	// Publisher-produced sequences in arrival order, walked by subscriptions.
+	// Publisher-produced groups in arrival order as (sequence, stamp), walked by
+	// subscriptions; an entry only resolves while its stamp matches the slot's.
 	// Fetched backfill (`insert_group_request`) is deliberately absent: it is
 	// served by sequence, never replayed to arrival-order subscribers.
-	arrival: VecDeque<u64>,
+	arrival: VecDeque<(u64, u32)>,
 
 	// Eviction order under memory pressure: every cached group except the current
 	// max_sequence, so the live edge is protected by omission rather than pinning.
@@ -220,6 +225,13 @@ struct TrackState {
 	// edge must still demote correctly when the next group lands past one.
 	latest_group: Option<u64>,
 
+	// Incarnation counter for `Slot::stamp`.
+	next_stamp: u32,
+
+	// Rotating position of the expiry scan over `evict`, so entries beyond one
+	// scan window can't be starved by fresh entries in front of them.
+	expire_cursor: usize,
+
 	// The sequence number at which the track was finalized.
 	final_sequence: Option<u64>,
 
@@ -244,15 +256,11 @@ struct TrackState {
 struct Slot {
 	group: group::Producer,
 
-	// When the group was inserted. Only the arrival-order expiry walk uses this,
-	// for its early exit; the expiry itself keys off the group's last access.
-	created_at: web_async::time::Instant,
-
-	// Whether arrival-order subscribers may deliver this slot. False for fetched
-	// backfill, and checked on every resolution: a stale arrival entry whose
-	// sequence was later re-served by a fetch must not leak the replacement into
-	// a subscription.
-	visible: bool,
+	// Incarnation stamp, echoed by this slot's arrival entry (if any). A re-served
+	// sequence (an aborted group re-created by the publisher or re-fetched as
+	// backfill) gets a fresh stamp, so a historical arrival entry can't resolve to
+	// the replacement and deliver it twice or at the wrong position.
+	stamp: u32,
 }
 
 /// The registered subscriptions, aggregated by the producer.
@@ -297,10 +305,10 @@ impl TrackState {
 	/// Returns the group and its absolute index so the consumer can advance past it.
 	fn poll_recv_group(&self, index: usize, min_sequence: u64) -> Poll<Result<Option<(group::Consumer, usize)>>> {
 		let start = index.saturating_sub(self.offset);
-		for (i, sequence) in self.arrival.iter().enumerate().skip(start) {
+		for (i, (sequence, stamp)) in self.arrival.iter().enumerate().skip(start) {
 			if *sequence >= min_sequence
 				&& let Some(slot) = self.lookup.get(sequence)
-				&& slot.visible
+				&& slot.stamp == *stamp
 				&& !slot.group.is_aborted()
 			{
 				return Poll::Ready(Ok(Some((slot.group.consume(), self.offset + i))));
@@ -362,16 +370,16 @@ impl TrackState {
 	) -> Poll<Result<Option<(frame::Frame, usize, u64)>>> {
 		let start = index.saturating_sub(self.offset);
 		let mut pending_seen = false;
-		for (i, sequence) in self.arrival.iter().enumerate().skip(start) {
+		for (i, (sequence, stamp)) in self.arrival.iter().enumerate().skip(start) {
 			if *sequence < next_sequence {
 				continue;
 			}
 			let Some(slot) = self.lookup.get(sequence) else {
 				continue;
 			};
-			if !slot.visible {
-				// A stale arrival entry resolving to fetched backfill that later
-				// re-served this sequence; backfill is never delivered in arrival order.
+			if slot.stamp != *stamp {
+				// A historical entry; the sequence was re-served by a newer
+				// incarnation, delivered (if at all) at its own arrival position.
 				continue;
 			}
 
@@ -513,85 +521,55 @@ impl TrackState {
 		Poll::Pending
 	}
 
-	/// Evict groups whose last access is older than `max_age`, never evicting the
-	/// max_sequence group.
+	/// Expire groups whose last access is older than `max_age`, never the latest.
 	///
-	/// Publisher-produced groups are walked in arrival order, which matches creation
-	/// order, so the walk stops early at the first created-fresh group (a group is
-	/// never accessed before it is created, so everything deeper is fresh too).
-	/// Slots whose group was already aborted (evicted under memory pressure, or
-	/// upstream) are reclaimed on the way so the sequence can be re-fetched. Fetched
-	/// backfill isn't in arrival order; it ages out from the front of the eviction
-	/// order instead.
-	fn evict_expired(&mut self, now: web_async::time::Instant, max_age: Duration) {
-		let now_ticks = self.broadcast.origin.pool.now();
+	/// One bounded, rotating scan over the eviction order, which holds every cached
+	/// group except the protected latest. The cursor persists across calls, so
+	/// entries beyond one scan window can't be starved by fresh (recently fetched
+	/// or written) entries in front of them: every position is revisited within a
+	/// few writes. Expiry throughput is therefore EVICT_SCAN groups per write; the
+	/// byte budget reclaims the remainder under memory pressure.
+	fn evict_expired(&mut self, max_age: Duration) {
+		let now = self.broadcast.origin.pool.now();
 		let max_ticks = cache::Pool::ticks(max_age);
-		let expired = |group: &group::Producer| now_ticks.saturating_sub(group.cache_accessed()) > max_ticks;
 
-		for i in 0..self.arrival.len() {
-			let sequence = self.arrival[i];
-			let Some(slot) = self.lookup.get(&sequence) else {
-				continue;
-			};
-
-			// Already aborted: the frames are gone, reclaim the slot so a later
-			// fetch can serve the sequence again.
-			if slot.group.is_aborted() {
-				self.lookup.remove(&sequence);
-				continue;
+		let len = self.evict.len();
+		if len > 0 {
+			let start = self.expire_cursor % len;
+			for step in 0..len.min(EVICT_SCAN) {
+				let sequence = self.evict[(start + step) % len];
+				let Some(slot) = self.lookup.get(&sequence) else {
+					continue;
+				};
+				// Already aborted: the frames are gone, reclaim the slot so a
+				// later fetch can serve the sequence again.
+				if slot.group.is_aborted() {
+					self.lookup.remove(&sequence);
+					continue;
+				}
+				if Some(sequence) == self.latest_group || now.saturating_sub(slot.group.cache_accessed()) <= max_ticks {
+					continue;
+				}
+				// Take the group out of the cache and abort it, so any consumer
+				// still reading surfaces `Error::Old` instead of blocking forever
+				// on a frame that will never arrive.
+				let slot = self.lookup.remove(&sequence).unwrap();
+				let _ = slot.group.abort(Error::Old);
 			}
-
-			if Some(sequence) == self.latest_group {
-				continue;
-			}
-
-			if now.duration_since(slot.created_at) <= max_age {
-				break;
-			}
-
-			// Created long ago but fetched recently: expiry keys off the last access.
-			if !expired(&slot.group) {
-				continue;
-			}
-
-			// Take the group out of the cache and abort it, so any consumer still reading
-			// surfaces `Error::Old` instead of blocking forever on a frame that will never
-			// arrive. Without this a reader parked on an aged-out group hangs indefinitely,
-			// since the group is neither finished nor aborted.
-			let slot = self.lookup.remove(&sequence).unwrap();
-			let _ = slot.group.abort(Error::Old);
+			self.expire_cursor = (start + EVICT_SCAN) % len;
 		}
 
-		// Trim dead leading arrival entries to advance the subscriber offset.
-		while let Some(sequence) = self.arrival.front() {
-			if self.lookup.contains_key(sequence) {
+		// Trim dead leading arrival entries to advance the subscriber offset. An
+		// entry is dead once its slot is gone or re-stamped by a newer incarnation.
+		while let Some((sequence, stamp)) = self.arrival.front() {
+			if self.lookup.get(sequence).is_some_and(|slot| slot.stamp == *stamp) {
 				break;
 			}
 			self.arrival.pop_front();
 			self.offset += 1;
 		}
 
-		// The only expiry that reaches fetched backfill (it isn't in arrival order).
-		// The eviction order isn't sorted by access time (FETCH hits refresh entries
-		// in place), so scan a bounded prefix instead of stopping at the first fresh
-		// entry: an expired group can't hide behind a refreshed one for long.
-		for i in 0..self.evict.len().min(EVICT_SCAN) {
-			let sequence = self.evict[i];
-			let Some(slot) = self.lookup.get(&sequence) else {
-				continue;
-			};
-			if slot.group.is_aborted() {
-				self.lookup.remove(&sequence);
-				continue;
-			}
-			if Some(sequence) == self.latest_group || !expired(&slot.group) {
-				continue;
-			}
-			let slot = self.lookup.remove(&sequence).unwrap();
-			let _ = slot.group.abort(Error::Old);
-		}
-
-		// Drop dead leading entries so the scan window stays over live candidates.
+		// Drop dead leading eviction entries so scans stay over live candidates.
 		while let Some(sequence) = self.evict.front() {
 			if self.lookup.contains_key(sequence) {
 				break;
@@ -638,8 +616,10 @@ impl TrackState {
 	/// the current latest is never enqueued, which is what protects it from
 	/// eviction. `visible` controls arrival-order delivery: publisher-produced
 	/// groups reach subscribers, fetched backfill is served by sequence only.
-	fn insert_group(&mut self, group: &group::Producer, now: web_async::time::Instant, visible: bool) {
+	fn insert_group(&mut self, group: &group::Producer, visible: bool) {
 		let sequence = group.sequence;
+		self.next_stamp = self.next_stamp.wrapping_add(1);
+		let stamp = self.next_stamp;
 
 		// The live edge is tracked separately from `max_sequence`, which datagrams
 		// share and can push past any cached group: demotion must still fire when
@@ -665,13 +645,21 @@ impl TrackState {
 			sequence,
 			Slot {
 				group: group.clone(),
-				created_at: now,
-				visible,
+				stamp,
 			},
 		);
 		if visible {
-			self.arrival.push_back(sequence);
+			self.arrival.push_back((sequence, stamp));
 		}
+	}
+
+	/// Admit a freshly-created group: settle eviction debt first (so the newcomer
+	/// can never be a victim of the very write that created it), insert it, then
+	/// expire by age.
+	fn commit_group(&mut self, group: &group::Producer, visible: bool, latency_max: Duration) {
+		self.charge_debt();
+		self.insert_group(group, visible);
+		self.evict_expired(latency_max);
 	}
 
 	/// Accrue and pay eviction debt for everything written since the last charge:
@@ -682,6 +670,12 @@ impl TrackState {
 	/// victim of the very write that created it. A track whose oldest content is
 	/// staler than the pool-wide average access time accrues at double rate, so
 	/// stale-heavy tracks drain first.
+	///
+	/// Known limitation: payment only runs here, on group insert. A track that
+	/// keeps appending frames to existing groups without ever inserting another
+	/// group accrues into the counter but doesn't pay, bounding its exposure at
+	/// the per-group frame cap times its open groups; the shared budget squeezes
+	/// the other, still-inserting tracks in the meantime.
 	fn charge_debt(&mut self) {
 		let Some(info) = &self.info else { return };
 		let written = info.written.swap(0, Ordering::Relaxed);
@@ -705,27 +699,19 @@ impl TrackState {
 	}
 
 	/// Whether this track's oldest evictable group was accessed at or before the
-	/// pool-wide average, doubling the debt it accrues. Dead entries encountered at
-	/// the front are dropped along the way.
-	fn oldest_is_stale(&mut self, pool: &cache::Pool) -> bool {
+	/// pool-wide average, doubling the debt it accrues. A dead entry at the front
+	/// just reads as not-stale until the next payment or expiry cleans it up.
+	fn oldest_is_stale(&self, pool: &cache::Pool) -> bool {
 		let Some(average) = pool.average() else {
 			return false;
 		};
-		loop {
-			let Some(&sequence) = self.evict.front() else {
-				return false;
-			};
-			let Some(slot) = self.lookup.get(&sequence) else {
-				self.evict.pop_front();
-				continue;
-			};
-			if slot.group.is_aborted() {
-				self.lookup.remove(&sequence);
-				self.evict.pop_front();
-				continue;
-			}
-			return slot.group.cache_accessed() <= average;
-		}
+		let Some(sequence) = self.evict.front() else {
+			return false;
+		};
+		let Some(slot) = self.lookup.get(sequence) else {
+			return false;
+		};
+		!slot.group.is_aborted() && slot.group.cache_accessed() <= average
 	}
 
 	/// Abort this track's stalest groups until the outstanding debt is paid, or
@@ -845,7 +831,6 @@ impl TrackState {
 
 		// Adopt the supplied info only if the track hasn't been accepted yet, binding
 		// it to this track's broadcast so its groups reach the shared pool.
-		let now = web_async::time::Instant::now();
 		let broadcast = self.broadcast.clone();
 		let info = self
 			.info
@@ -858,17 +843,15 @@ impl TrackState {
 
 		// An evicted sequence can be re-fetched; a live one is a duplicate.
 		self.claim_sequence(sequence)?;
-		self.charge_debt();
 
 		let latency_max = info.latency_max;
 		let group = group::Producer::new(group::Info { sequence }, info);
 		// A backfill exists because someone is fetching it right now: stamp that
 		// access so the eviction walk can't kill it before the fetch resolves.
+		// It is also invisible to arrival-order subscribers: fetched on demand,
+		// not produced live by the publisher.
 		group.cache_refresh();
-		// Backfill is invisible to arrival-order subscribers: it was fetched on
-		// demand, not produced live by the publisher.
-		self.insert_group(&group, now, false);
-		self.evict_expired(now, latency_max);
+		self.commit_group(&group, false, latency_max);
 		Ok(group)
 	}
 }
@@ -946,15 +929,12 @@ impl Producer {
 		let info = state.info.as_ref().unwrap();
 		let track = info.clone();
 		let latency_max = info.latency_max;
-		let now = web_async::time::Instant::now();
 
 		// An evicted sequence can be re-created; a live one is a duplicate.
 		state.claim_sequence(group.sequence)?;
-		state.charge_debt();
 
 		let group = group::Producer::new(group, track).with_meter(self.stats.meter());
-		state.insert_group(&group, now, true);
-		state.evict_expired(now, latency_max);
+		state.commit_group(&group, true, latency_max);
 
 		Ok(group)
 	}
@@ -976,12 +956,8 @@ impl Producer {
 		let track = info.clone();
 		let latency_max = info.latency_max;
 
-		let now = web_async::time::Instant::now();
-		state.charge_debt();
-
 		let group = group::Producer::new(group::Info { sequence }, track).with_meter(self.stats.meter());
-		state.insert_group(&group, now, true);
-		state.evict_expired(now, latency_max);
+		state.commit_group(&group, true, latency_max);
 
 		Ok(group)
 	}
@@ -2698,10 +2674,11 @@ mod test {
 
 	/// Helper: get the sequence number of the first live group in arrival order.
 	fn first_live_sequence(state: &TrackState) -> u64 {
-		*state
+		state
 			.arrival
 			.iter()
-			.find(|sequence| state.lookup.contains_key(sequence))
+			.find(|(sequence, stamp)| state.lookup.get(sequence).is_some_and(|slot| slot.stamp == *stamp))
+			.map(|(sequence, _)| *sequence)
 			.unwrap()
 	}
 
@@ -4355,6 +4332,111 @@ mod test {
 		assert!(consumer.peek_group(1).is_none());
 		assert!(consumer.peek_group(2).is_some(), "the backlog drains gradually");
 		assert!(pool.used() > before - 4_000, "one write must not dump the backlog");
+	}
+
+	/// A cloned `Info` reused for several tracks must not share eviction
+	/// accounting: every track instantiation gets its own write counter.
+	#[tokio::test]
+	async fn cloned_info_does_not_share_accounting() {
+		let broadcast = Arc::new(broadcast::Info::default());
+		let info = Info::default();
+		let a = Producer::new(broadcast.clone(), "a", info.clone());
+		let b = Producer::new(broadcast, "b", info);
+
+		let a = a.state.read().info.as_ref().unwrap().written.clone();
+		let b = b.state.read().info.as_ref().unwrap().written.clone();
+		assert!(!Arc::ptr_eq(&a, &b), "each track owns its write counter");
+	}
+
+	/// A late frame write restarts the retention clock (retention is documented as
+	/// time since last written or fetched), so an actively-growing group is not
+	/// expired as old mid-write.
+	#[tokio::test]
+	async fn write_restarts_retention_clock() {
+		tokio::time::pause();
+
+		let (mut producer, _pool) = pooled_producer(1 << 40);
+		let mut straggler = producer.append_group().unwrap(); // seq 0
+		producer.append_group().unwrap().finish().unwrap(); // seq 1 demotes seq 0
+
+		// Idle past the window, then the straggler receives a late frame.
+		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
+		straggler
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 100]))
+			.unwrap();
+		producer.append_group().unwrap().finish().unwrap(); // seq 2 runs expiry
+
+		let consumer = producer.consume();
+		assert!(consumer.peek_group(0).is_some(), "the write restarted the clock");
+
+		// Once the writes stop, the group ages out normally.
+		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
+		producer.append_group().unwrap().finish().unwrap(); // seq 3 runs expiry
+		assert!(consumer.peek_group(0).is_none(), "idle content still expires");
+	}
+
+	/// Continuously refreshed entries at the front of the eviction order must not
+	/// starve expiry of entries behind them: the scan cursor rotates.
+	#[tokio::test]
+	async fn refreshed_front_does_not_starve_expiry() {
+		tokio::time::pause();
+
+		let (mut producer, _pool) = pooled_producer(1 << 40);
+		let dynamic = producer.dynamic();
+		let consumer = producer.consume();
+
+		producer.create_group(10u64.into()).unwrap().finish().unwrap();
+		for sequence in 1..=5u64 {
+			let pending = consumer.fetch_group(sequence, None);
+			let req = dynamic
+				.requested_group()
+				.now_or_never()
+				.expect("should not block")
+				.unwrap();
+			let mut group = req.accept(None).unwrap();
+			group
+				.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 100]))
+				.unwrap();
+			group.finish().unwrap();
+			pending.await.unwrap();
+		}
+
+		// Age everything out, then refresh the first four backfills so they sit
+		// fresh at the front of the eviction order, hiding the expired fifth.
+		tokio::time::advance(DEFAULT_LATENCY_MAX + Duration::from_secs(1)).await;
+		for sequence in 1..=4u64 {
+			consumer.fetch_group(sequence, None).await.unwrap();
+		}
+
+		// The rotating cursor reaches the fifth entry within a few writes.
+		for _ in 0..3 {
+			producer.append_group().unwrap().finish().unwrap();
+		}
+		assert!(consumer.peek_group(5).is_none(), "expired backfill is reclaimed");
+		assert!(consumer.peek_group(1).is_some(), "refreshed backfill survives");
+	}
+
+	/// A publisher re-creating an aborted sequence is delivered exactly once, at
+	/// its actual arrival position: the historical arrival entry is dead.
+	#[tokio::test]
+	async fn recreated_sequence_delivered_once() {
+		let (mut producer, _pool) = pooled_producer(1 << 40);
+
+		producer.create_group(0u64.into()).unwrap().finish().unwrap();
+		let aborted = producer.create_group(1u64.into()).unwrap();
+		aborted.abort(Error::Cancel).unwrap();
+		producer.create_group(2u64.into()).unwrap().finish().unwrap();
+		producer.create_group(1u64.into()).unwrap().finish().unwrap();
+
+		let mut subscriber = producer.subscribe(None);
+		assert_eq!(subscriber.assert_group().sequence, 0);
+		assert_eq!(subscriber.assert_group().sequence, 2);
+		assert_eq!(
+			subscriber.assert_group().sequence,
+			1,
+			"replacement arrives at its own position"
+		);
+		subscriber.assert_no_group();
 	}
 
 	/// Datagrams share `max_sequence` but must not break group demotion: the live

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -23,7 +23,7 @@ pub use super::subscription::Subscription;
 use std::{
 	collections::{HashMap, VecDeque},
 	sync::Arc,
-	sync::atomic::{AtomicBool, AtomicU64, Ordering},
+	sync::atomic::{AtomicU64, Ordering},
 	task::{Poll, ready},
 	time::Duration,
 };
@@ -89,6 +89,12 @@ pub struct Info {
 	// to reach the shared cache pool (`track.broadcast.origin.pool`), which stays
 	// crate-private.
 	pub(crate) broadcast: Arc<broadcast::Info>,
+
+	// Gross bytes charged by this track's groups (payload plus overhead), shared
+	// with every group via its `cache::Charge`. Drained by `charge_debt` on each
+	// group insert, so eviction debt observes actual writes, including growth on
+	// already-demoted groups and backfill, not just group transitions.
+	pub(crate) written: Arc<AtomicU64>,
 }
 
 /// The shared parent for a not-yet-bound [`Info`]: a standalone broadcast with an
@@ -108,6 +114,7 @@ impl Default for Info {
 			priority: 0,
 			ordered: false,
 			broadcast: default_broadcast(),
+			written: Arc::default(),
 		}
 	}
 }
@@ -203,8 +210,15 @@ struct TrackState {
 	// absolute cursor to an index.
 	offset: usize,
 
-	// The highest sequence number successfully appended to the track.
+	// The highest sequence number successfully appended to the track. Shared with
+	// datagrams, so it can run ahead of any cached group.
 	max_sequence: Option<u64>,
+
+	// The sequence of the newest cached group: the live edge, protected from
+	// eviction by never entering the eviction order. Tracked separately from
+	// `max_sequence` because datagrams advance that shared counter, and the live
+	// edge must still demote correctly when the next group lands past one.
+	latest_group: Option<u64>,
 
 	// The sequence number at which the track was finalized.
 	final_sequence: Option<u64>,
@@ -223,25 +237,22 @@ struct TrackState {
 }
 
 /// A cached group plus its bookkeeping in the track's `lookup` map.
+///
+/// Access times and the evictable-population sample live in the group's own
+/// `cache::Charge`, so they share the group's lifecycle exactly: an abort from any
+/// handle releases the bytes and the sample together.
 struct Slot {
 	group: group::Producer,
 
 	// When the group was inserted. Only the arrival-order expiry walk uses this,
-	// for its early exit; the expiry itself keys off `accessed`.
+	// for its early exit; the expiry itself keys off the group's last access.
 	created_at: web_async::time::Instant,
 
-	// Coarse tick of the last FETCH cache hit, initially the insert tick. Age
-	// expiry and eviction protection both key off this: a group accessed more
-	// recently than the pool-wide average is never evicted. Atomic because the
-	// FETCH hit runs under the track's read lock.
-	accessed: AtomicU64,
-
-	// Whether this slot is in the evictable population: enqueued in the eviction
-	// order and counted in the pool's access average. The latest group stays out,
-	// which is what protects the live edge (and keeps stalled tracks' immortal
-	// latest groups from dragging the average into the past). Atomic so the FETCH
-	// refresh can check it under the read lock.
-	counted: AtomicBool,
+	// Whether arrival-order subscribers may deliver this slot. False for fetched
+	// backfill, and checked on every resolution: a stale arrival entry whose
+	// sequence was later re-served by a fetch must not leak the replacement into
+	// a subscription.
+	visible: bool,
 }
 
 /// The registered subscriptions, aggregated by the producer.
@@ -289,6 +300,7 @@ impl TrackState {
 		for (i, sequence) in self.arrival.iter().enumerate().skip(start) {
 			if *sequence >= min_sequence
 				&& let Some(slot) = self.lookup.get(sequence)
+				&& slot.visible
 				&& !slot.group.is_aborted()
 			{
 				return Poll::Ready(Ok(Some((slot.group.consume(), self.offset + i))));
@@ -357,6 +369,11 @@ impl TrackState {
 			let Some(slot) = self.lookup.get(sequence) else {
 				continue;
 			};
+			if !slot.visible {
+				// A stale arrival entry resolving to fetched backfill that later
+				// re-served this sequence; backfill is never delivered in arrival order.
+				continue;
+			}
 
 			let mut consumer = slot.group.consume();
 			match consumer.poll_read_frame(waiter) {
@@ -480,12 +497,7 @@ impl TrackState {
 			// A cache hit refreshes the group: it resets both its age (expiry keys
 			// off the last access) and its standing against the pool-wide average,
 			// so the eviction walk keeps it over never-read groups.
-			let pool = &self.broadcast.origin.pool;
-			let now = pool.now();
-			let old = slot.accessed.swap(now, Ordering::Relaxed);
-			if slot.counted.load(Ordering::Relaxed) {
-				pool.access_refresh(old, now);
-			}
+			slot.group.cache_refresh();
 			return Poll::Ready(Ok(slot.group.consume()));
 		}
 
@@ -512,10 +524,9 @@ impl TrackState {
 	/// backfill isn't in arrival order; it ages out from the front of the eviction
 	/// order instead.
 	fn evict_expired(&mut self, now: web_async::time::Instant, max_age: Duration) {
-		let pool = self.broadcast.origin.pool.clone();
-		let now_ticks = pool.now();
+		let now_ticks = self.broadcast.origin.pool.now();
 		let max_ticks = cache::Pool::ticks(max_age);
-		let expired = |slot: &Slot| now_ticks.saturating_sub(slot.accessed.load(Ordering::Relaxed)) > max_ticks;
+		let expired = |group: &group::Producer| now_ticks.saturating_sub(group.cache_accessed()) > max_ticks;
 
 		for i in 0..self.arrival.len() {
 			let sequence = self.arrival[i];
@@ -526,11 +537,11 @@ impl TrackState {
 			// Already aborted: the frames are gone, reclaim the slot so a later
 			// fetch can serve the sequence again.
 			if slot.group.is_aborted() {
-				self.remove_slot(sequence);
+				self.lookup.remove(&sequence);
 				continue;
 			}
 
-			if Some(sequence) == self.max_sequence {
+			if Some(sequence) == self.latest_group {
 				continue;
 			}
 
@@ -539,7 +550,7 @@ impl TrackState {
 			}
 
 			// Created long ago but fetched recently: expiry keys off the last access.
-			if !expired(slot) {
+			if !expired(&slot.group) {
 				continue;
 			}
 
@@ -547,7 +558,7 @@ impl TrackState {
 			// surfaces `Error::Old` instead of blocking forever on a frame that will never
 			// arrive. Without this a reader parked on an aged-out group hangs indefinitely,
 			// since the group is neither finished nor aborted.
-			let slot = self.remove_slot(sequence).unwrap();
+			let slot = self.lookup.remove(&sequence).unwrap();
 			let _ = slot.group.abort(Error::Old);
 		}
 
@@ -560,28 +571,35 @@ impl TrackState {
 			self.offset += 1;
 		}
 
-		// The eviction order is roughly enqueue order: drop dead entries and age out
-		// expired groups (the only expiry that reaches fetched backfill) from the
-		// front, stopping at the first live fresh entry.
-		while let Some(&sequence) = self.evict.front() {
+		// The only expiry that reaches fetched backfill (it isn't in arrival order).
+		// The eviction order isn't sorted by access time (FETCH hits refresh entries
+		// in place), so scan a bounded prefix instead of stopping at the first fresh
+		// entry: an expired group can't hide behind a refreshed one for long.
+		for i in 0..self.evict.len().min(EVICT_SCAN) {
+			let sequence = self.evict[i];
 			let Some(slot) = self.lookup.get(&sequence) else {
-				self.evict.pop_front();
 				continue;
 			};
 			if slot.group.is_aborted() {
-				self.remove_slot(sequence);
-				self.evict.pop_front();
+				self.lookup.remove(&sequence);
 				continue;
 			}
-			if !expired(slot) {
+			if Some(sequence) == self.latest_group || !expired(&slot.group) {
+				continue;
+			}
+			let slot = self.lookup.remove(&sequence).unwrap();
+			let _ = slot.group.abort(Error::Old);
+		}
+
+		// Drop dead leading entries so the scan window stays over live candidates.
+		while let Some(sequence) = self.evict.front() {
+			if self.lookup.contains_key(sequence) {
 				break;
 			}
-			let slot = self.remove_slot(sequence).unwrap();
-			let _ = slot.group.abort(Error::Old);
 			self.evict.pop_front();
 		}
 
-		// Dead entries behind a fresh front can linger; rebuild once they clearly
+		// Dead entries behind a live front can linger; rebuild once they clearly
 		// outnumber the live slots.
 		if self.evict.len() > 2 * self.lookup.len() + EVICT_SLACK {
 			let lookup = &self.lookup;
@@ -589,30 +607,13 @@ impl TrackState {
 		}
 	}
 
-	/// Remove a slot from the cache, releasing its share of the pool's access
-	/// average if it was in the evictable population.
-	fn remove_slot(&mut self, sequence: u64) -> Option<Slot> {
-		let slot = self.lookup.remove(&sequence)?;
-		if slot.counted.load(Ordering::Relaxed) {
-			self.broadcast
-				.origin
-				.pool
-				.access_remove(slot.accessed.load(Ordering::Relaxed));
-		}
-		Some(slot)
-	}
-
-	/// Drop every cached group and reset the eviction bookkeeping, releasing the
-	/// evictable population's share of the pool's access average.
+	/// Drop every cached group and reset the eviction bookkeeping. Each group's
+	/// access sample lives in its own charge, released when the group itself dies.
 	fn clear_cache(&mut self) {
-		let pool = self.broadcast.origin.pool.clone();
-		for (_, slot) in self.lookup.drain() {
-			if slot.counted.load(Ordering::Relaxed) {
-				pool.access_remove(slot.accessed.load(Ordering::Relaxed));
-			}
-		}
+		self.lookup.clear();
 		self.arrival.clear();
 		self.evict.clear();
+		self.latest_group = None;
 		self.debt = 0;
 	}
 
@@ -626,7 +627,7 @@ impl TrackState {
 			if !slot.group.is_aborted() {
 				return Err(Error::Duplicate);
 			}
-			self.remove_slot(sequence);
+			self.lookup.remove(&sequence);
 		}
 		Ok(())
 	}
@@ -638,61 +639,52 @@ impl TrackState {
 	/// eviction. `visible` controls arrival-order delivery: publisher-produced
 	/// groups reach subscribers, fetched backfill is served by sequence only.
 	fn insert_group(&mut self, group: &group::Producer, now: web_async::time::Instant, visible: bool) {
-		let pool = &self.broadcast.origin.pool;
 		let sequence = group.sequence;
-		let ticks = pool.now();
-		let slot = Slot {
-			group: group.clone(),
-			created_at: now,
-			accessed: AtomicU64::new(ticks),
-			counted: AtomicBool::new(false),
-		};
 
-		if self.max_sequence.is_none_or(|max| sequence >= max) {
+		// The live edge is tracked separately from `max_sequence`, which datagrams
+		// share and can push past any cached group: demotion must still fire when
+		// the next group lands beyond a datagram-advanced counter.
+		if self.latest_group.is_none_or(|latest| sequence >= latest) {
 			// Demote the previous latest: it joins the eviction order (and the
 			// pool's access average) like any other cached group.
-			if let Some(max) = self.max_sequence
-				&& sequence > max
-				&& let Some(prev) = self.lookup.get(&max)
+			if let Some(latest) = self.latest_group
+				&& sequence > latest
+				&& let Some(prev) = self.lookup.get(&latest)
 			{
-				prev.counted.store(true, Ordering::Relaxed);
-				pool.access_insert(prev.accessed.load(Ordering::Relaxed));
-				self.evict.push_back(max);
+				prev.group.cache_demote();
+				self.evict.push_back(latest);
 			}
-			self.max_sequence = Some(sequence);
+			self.latest_group = Some(sequence);
 		} else {
-			slot.counted.store(true, Ordering::Relaxed);
-			pool.access_insert(ticks);
+			group.cache_demote();
 			self.evict.push_back(sequence);
 		}
 
-		self.lookup.insert(sequence, slot);
+		self.max_sequence = Some(self.max_sequence.map_or(sequence, |max| max.max(sequence)));
+		self.lookup.insert(
+			sequence,
+			Slot {
+				group: group.clone(),
+				created_at: now,
+				visible,
+			},
+		);
 		if visible {
 			self.arrival.push_back(sequence);
 		}
 	}
 
-	/// The cached bytes of the group that inserting `sequence` would demote from
-	/// the live edge: the inflow this insert accrues eviction debt for. Zero when
-	/// `sequence` isn't a new maximum (a straggler or backfill).
-	fn demotion_bytes(&self, sequence: u64) -> u64 {
-		if let Some(max) = self.max_sequence
-			&& sequence > max
-			&& let Some(prev) = self.lookup.get(&max)
-		{
-			prev.group.cached_bytes()
-		} else {
-			0
-		}
-	}
-
-	/// Accrue and pay eviction debt for `written` fresh bytes.
+	/// Accrue and pay eviction debt for everything written since the last charge:
+	/// the track's gross-write counter, which the groups' charges feed on every
+	/// frame (so growth on already-demoted groups and backfill is billed too).
 	///
 	/// Runs BEFORE the new group is inserted, so a brand-new entry is never a
 	/// victim of the very write that created it. A track whose oldest content is
 	/// staler than the pool-wide average access time accrues at double rate, so
 	/// stale-heavy tracks drain first.
-	fn charge_debt(&mut self, written: u64) {
+	fn charge_debt(&mut self) {
+		let Some(info) = &self.info else { return };
+		let written = info.written.swap(0, Ordering::Relaxed);
 		let pool = self.broadcast.origin.pool.clone();
 		match pool.accrue(written) {
 			Some(mut accrued) => {
@@ -728,11 +720,11 @@ impl TrackState {
 				continue;
 			};
 			if slot.group.is_aborted() {
-				self.remove_slot(sequence);
+				self.lookup.remove(&sequence);
 				self.evict.pop_front();
 				continue;
 			}
-			return slot.accessed.load(Ordering::Relaxed) <= average;
+			return slot.group.cache_accessed() <= average;
 		}
 	}
 
@@ -765,24 +757,26 @@ impl TrackState {
 			};
 			if slot.group.is_aborted() {
 				// Aborted upstream: the frames are already gone, reclaim the slot.
-				self.remove_slot(sequence);
+				self.lookup.remove(&sequence);
 				continue;
 			}
-			if Some(sequence) == self.max_sequence {
+			if Some(sequence) == self.latest_group {
 				// The live edge is never enqueued, but tolerate finding it anyway.
 				self.evict.push_back(sequence);
 				continue;
 			}
 
 			scanned += 1;
-			let size = slot.group.cached_bytes();
 			// Protected: accessed more recently than the average (a fresh insert or
-			// a FETCH hit), or empty (a backfill still being filled, which eviction
-			// would destroy while freeing nothing). Rotate to the back.
-			if size == 0 || slot.accessed.load(Ordering::Relaxed) > average {
+			// a FETCH hit, which also covers a backfill still being filled). Rotate
+			// to the back.
+			if slot.group.cache_accessed() > average {
 				self.evict.push_back(sequence);
 				continue;
 			}
+			// The full footprint including overhead, so even empty groups repay
+			// their share of the budget when evicted.
+			let size = slot.group.cache_size();
 			if size > self.debt {
 				self.evict.push_front(sequence);
 				return;
@@ -790,7 +784,7 @@ impl TrackState {
 
 			self.debt -= size;
 			paid = paid.saturating_add(size);
-			let slot = self.remove_slot(sequence).unwrap();
+			let slot = self.lookup.remove(&sequence).unwrap();
 			let _ = slot.group.abort(Error::Evicted);
 		}
 	}
@@ -864,11 +858,13 @@ impl TrackState {
 
 		// An evicted sequence can be re-fetched; a live one is a duplicate.
 		self.claim_sequence(sequence)?;
-		let written = self.demotion_bytes(sequence);
-		self.charge_debt(written);
+		self.charge_debt();
 
 		let latency_max = info.latency_max;
 		let group = group::Producer::new(group::Info { sequence }, info);
+		// A backfill exists because someone is fetching it right now: stamp that
+		// access so the eviction walk can't kill it before the fetch resolves.
+		group.cache_refresh();
 		// Backfill is invisible to arrival-order subscribers: it was fetched on
 		// demand, not produced live by the publisher.
 		self.insert_group(&group, now, false);
@@ -954,8 +950,7 @@ impl Producer {
 
 		// An evicted sequence can be re-created; a live one is a duplicate.
 		state.claim_sequence(group.sequence)?;
-		let written = state.demotion_bytes(group.sequence);
-		state.charge_debt(written);
+		state.charge_debt();
 
 		let group = group::Producer::new(group, track).with_meter(self.stats.meter());
 		state.insert_group(&group, now, true);
@@ -982,8 +977,7 @@ impl Producer {
 		let latency_max = info.latency_max;
 
 		let now = web_async::time::Instant::now();
-		let written = state.demotion_bytes(sequence);
-		state.charge_debt(written);
+		state.charge_debt();
 
 		let group = group::Producer::new(group::Info { sequence }, track).with_meter(self.stats.meter());
 		state.insert_group(&group, now, true);
@@ -4361,6 +4355,182 @@ mod test {
 		assert!(consumer.peek_group(1).is_none());
 		assert!(consumer.peek_group(2).is_some(), "the backlog drains gradually");
 		assert!(pool.used() > before - 4_000, "one write must not dump the backlog");
+	}
+
+	/// Datagrams share `max_sequence` but must not break group demotion: the live
+	/// edge is tracked per group, so interleaving datagrams can't strand groups
+	/// outside the eviction order and bypass the budget.
+	#[tokio::test]
+	async fn datagrams_do_not_block_eviction() {
+		tokio::time::pause();
+
+		let (mut producer, pool) = pooled_producer(1_000);
+		for _ in 0..10 {
+			finished_group(&mut producer, 1_000);
+			producer.append_datagram(Timestamp::ZERO, &b"beat"[..]).unwrap();
+		}
+
+		let consumer = producer.consume();
+		assert!(consumer.peek_group(0).is_none(), "old groups still evict");
+		assert!(
+			pool.used() < 4 * 1_256,
+			"interleaved datagrams must not bypass the budget: {}",
+			pool.used()
+		);
+	}
+
+	/// An aborted group releases its access sample along with its bytes, from any
+	/// handle: ghost samples must not linger in the pool mean where they'd hold it
+	/// in the past and over-protect every live group.
+	#[tokio::test]
+	async fn aborted_group_leaves_no_ghost_sample() {
+		tokio::time::pause();
+
+		let (mut producer, pool) = pooled_producer(1 << 40);
+		let group0 = producer.append_group().unwrap();
+		producer.append_group().unwrap(); // demotes seq 0 into the mean
+
+		assert!(pool.average().is_some(), "demoted group is sampled");
+		group0.abort(Error::Cancel).unwrap();
+		assert_eq!(pool.average(), None, "the abort must remove the sample");
+	}
+
+	/// Empty groups still carry fixed overhead; they must repay the budget when
+	/// evicted rather than being unevictable freeloaders.
+	#[tokio::test]
+	async fn empty_groups_repay_overhead() {
+		tokio::time::pause();
+
+		let (mut producer, pool) = pooled_producer(1_000);
+		for _ in 0..100 {
+			let mut group = producer.append_group().unwrap();
+			group.finish().unwrap();
+		}
+
+		assert!(
+			pool.used() <= 3_000,
+			"empty-group overhead must stay near the budget: {}",
+			pool.used()
+		);
+	}
+
+	/// Late growth on an already-demoted group is billed: the gross-write counter
+	/// feeds debt on the next append, so a straggler can't grow unbounded.
+	#[tokio::test]
+	async fn growth_on_demoted_group_is_billed() {
+		tokio::time::pause();
+
+		let (mut producer, pool) = pooled_producer(2_000);
+		let mut straggler = producer.append_group().unwrap(); // seq 0
+		producer.append_group().unwrap().finish().unwrap(); // seq 1 demotes seq 0
+
+		// The demoted group balloons: no eviction yet (nothing ran), but billed.
+		straggler
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 10_000]))
+			.unwrap();
+
+		// The next append observes the growth and evicts the straggler.
+		producer.append_group().unwrap().finish().unwrap(); // seq 2
+
+		let consumer = producer.consume();
+		assert!(consumer.peek_group(0).is_none(), "the ballooned group is evicted");
+		assert!(pool.used() <= 3_000, "growth is reclaimed: {}", pool.used());
+	}
+
+	/// A stale arrival entry whose sequence was later re-served by fetched backfill
+	/// must not leak the replacement into arrival-order subscriptions.
+	#[tokio::test]
+	async fn refilled_sequence_stays_out_of_subscriptions() {
+		let (mut producer, _pool) = pooled_producer(1 << 40);
+		let dynamic = producer.dynamic();
+		let consumer = producer.consume();
+
+		producer.create_group(0u64.into()).unwrap().finish().unwrap();
+		let aborted = producer.create_group(1u64.into()).unwrap();
+		aborted.abort(Error::Cancel).unwrap();
+		producer.create_group(2u64.into()).unwrap().finish().unwrap();
+
+		// Re-serve seq 1 as backfill; its slot replaces the aborted one, and the
+		// old arrival entry for seq 1 now resolves to it.
+		let pending = consumer.fetch_group(1, None);
+		let req = dynamic
+			.requested_group()
+			.now_or_never()
+			.expect("should not block")
+			.unwrap();
+		let mut group = req.accept(None).unwrap();
+		group
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"backfill"))
+			.unwrap();
+		group.finish().unwrap();
+		pending.await.unwrap();
+
+		// The backfill serves by sequence, but never in arrival order.
+		assert!(consumer.peek_group(1).is_some());
+		let mut subscriber = producer.subscribe(None);
+		assert_eq!(subscriber.assert_group().sequence, 0);
+		assert_eq!(subscriber.assert_group().sequence, 2);
+		subscriber.assert_no_group();
+	}
+
+	/// An expired backfill can't hide behind a refreshed one: the eviction-order
+	/// expiry scans a bounded prefix instead of stopping at the first fresh entry.
+	#[tokio::test]
+	async fn expired_backfill_behind_refreshed_reclaimed() {
+		tokio::time::pause();
+
+		let (mut producer, _pool) = pooled_producer(1 << 40);
+		let dynamic = producer.dynamic();
+		let consumer = producer.consume();
+
+		producer.create_group(5u64.into()).unwrap().finish().unwrap();
+		for sequence in [2u64, 3u64] {
+			let pending = consumer.fetch_group(sequence, None);
+			let req = dynamic
+				.requested_group()
+				.now_or_never()
+				.expect("should not block")
+				.unwrap();
+			let mut group = req.accept(None).unwrap();
+			group
+				.write_frame(Timestamp::ZERO, bytes::Bytes::from(vec![0u8; 100]))
+				.unwrap();
+			group.finish().unwrap();
+			pending.await.unwrap();
+		}
+
+		// Keep seq 2 fresh while seq 3 (behind it in eviction order) expires.
+		tokio::time::advance(Duration::from_secs(4)).await;
+		consumer.fetch_group(2, None).await.unwrap();
+		tokio::time::advance(DEFAULT_LATENCY_MAX - Duration::from_secs(2)).await;
+		producer.create_group(6u64.into()).unwrap().finish().unwrap();
+
+		let consumer = producer.consume();
+		assert!(consumer.peek_group(2).is_some(), "refreshed backfill survives");
+		assert!(consumer.peek_group(3).is_none(), "expired backfill is reclaimed");
+	}
+
+	/// A FETCH hit within the same coarse clock tick still protects the group: the
+	/// refresh stamps one tick ahead, so it reads strictly newer than the mean.
+	#[tokio::test]
+	async fn same_tick_fetch_protects() {
+		tokio::time::pause();
+
+		// No time advances at all: every timestamp lands in the same tick.
+		let (mut producer, _pool) = pooled_producer(10_000);
+		let consumer = producer.consume();
+
+		finished_group(&mut producer, 3_000); // seq 0
+		finished_group(&mut producer, 3_000); // seq 1
+		finished_group(&mut producer, 3_000); // seq 2
+
+		consumer.fetch_group(0, None).await.unwrap();
+
+		finished_group(&mut producer, 3_000); // seq 3
+		finished_group(&mut producer, 3_000); // seq 4
+
+		assert!(consumer.peek_group(0).is_some(), "same-tick refresh protects");
+		assert!(consumer.peek_group(1).is_none(), "the unread group dies instead");
 	}
 
 	/// A refetched group that reclaims max_sequence is the live edge again: it must

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -23,7 +23,7 @@ pub use super::subscription::Subscription;
 use std::{
 	collections::{HashMap, VecDeque},
 	sync::Arc,
-	sync::atomic::{AtomicBool, Ordering},
+	sync::atomic::{AtomicBool, AtomicU64, Ordering},
 	task::{Poll, ready},
 	time::Duration,
 };
@@ -41,6 +41,11 @@ const MAX_DATAGRAM_AGE: Duration = Duration::from_millis(50);
 /// Slack before the eviction order is rebuilt, so a track holding just a few groups
 /// doesn't rebuild on every write.
 const EVICT_SLACK: usize = 64;
+
+/// How many live eviction candidates one debt payment examines (Redis-style
+/// bounded sampling): enough to step over a few protected (recently accessed)
+/// groups, small enough that a write never scans a long queue.
+const EVICT_SCAN: usize = 4;
 
 /// Publisher-side properties of a track.
 ///
@@ -172,18 +177,18 @@ struct TrackState {
 
 	// Eviction order under memory pressure: every cached group except the current
 	// max_sequence, so the live edge is protected by omission rather than pinning.
-	// `pay_debt` pops victims from the front; a FETCH-refreshed group re-queues at
-	// the back instead of dying, decoupling eviction order from arrival order.
-	evict: VecDeque<(u64, u32)>,
+	// `pay_debt` scans victims from the front; groups accessed more recently than
+	// the pool-wide average rotate to the back instead of dying, decoupling
+	// eviction order from arrival order. Entries are hints validated against
+	// `lookup` on pop, and eviction is deliberately approximate: a bounded scan
+	// per write, sometimes out of order.
+	evict: VecDeque<u64>,
 
 	// Outstanding eviction debt in bytes, accrued by writes while the shared pool
 	// is over capacity (see `cache::Pool::accrue`) and paid by aborting this
 	// track's own oldest groups. Per track, so eviction lands proportionally to
 	// what each track writes and never touches another track's cache.
 	debt: u64,
-
-	// Incarnation counter for `Slot::epoch`.
-	next_epoch: u32,
 
 	// Datagrams in arrival order paired with their arrival time, a best-effort send buffer
 	// evicted by age (see `MAX_DATAGRAM_AGE`). Shares the group `max_sequence` namespace but
@@ -221,19 +226,22 @@ struct TrackState {
 struct Slot {
 	group: group::Producer,
 
-	// When the group was inserted, driving age expiry.
+	// When the group was inserted. Only the arrival-order expiry walk uses this,
+	// for its early exit; the expiry itself keys off `accessed`.
 	created_at: web_async::time::Instant,
 
-	// Identity of this (sequence, group) incarnation. Eviction-order entries carry
-	// the epoch they were enqueued with, so an entry left over from a replaced
-	// incarnation (an evicted sequence served again) is recognized and discarded.
-	epoch: u32,
+	// Coarse tick of the last FETCH cache hit, initially the insert tick. Age
+	// expiry and eviction protection both key off this: a group accessed more
+	// recently than the pool-wide average is never evicted. Atomic because the
+	// FETCH hit runs under the track's read lock.
+	accessed: AtomicU64,
 
-	// Set by a FETCH cache hit, which runs under the track's read lock (hence
-	// atomic). The eviction walk spares a touched group once: its bytes count as
-	// debt paid (re-billed through the pool's credit) and it re-queues at the back,
-	// so a refresh buys a full trip through the eviction order.
-	touched: AtomicBool,
+	// Whether this slot is in the evictable population: enqueued in the eviction
+	// order and counted in the pool's access average. The latest group stays out,
+	// which is what protects the live edge (and keeps stalled tracks' immortal
+	// latest groups from dragging the average into the past). Atomic so the FETCH
+	// refresh can check it under the read lock.
+	counted: AtomicBool,
 }
 
 /// The registered subscriptions, aggregated by the producer.
@@ -469,9 +477,15 @@ impl TrackState {
 		if let Some(slot) = self.lookup.get(&sequence)
 			&& !slot.group.is_aborted()
 		{
-			// A cache hit refreshes the group: the next eviction walk spares it and
-			// re-queues it at the back instead (see `pay_debt`).
-			slot.touched.store(true, Ordering::Relaxed);
+			// A cache hit refreshes the group: it resets both its age (expiry keys
+			// off the last access) and its standing against the pool-wide average,
+			// so the eviction walk keeps it over never-read groups.
+			let pool = &self.broadcast.origin.pool;
+			let now = pool.now();
+			let old = slot.accessed.swap(now, Ordering::Relaxed);
+			if slot.counted.load(Ordering::Relaxed) {
+				pool.access_refresh(old, now);
+			}
 			return Poll::Ready(Ok(slot.group.consume()));
 		}
 
@@ -487,14 +501,22 @@ impl TrackState {
 		Poll::Pending
 	}
 
-	/// Evict groups older than `max_age`, never evicting the max_sequence group.
+	/// Evict groups whose last access is older than `max_age`, never evicting the
+	/// max_sequence group.
 	///
 	/// Publisher-produced groups are walked in arrival order, which matches creation
-	/// order, so the walk stops early at the first fresh group. Slots whose group was
-	/// already aborted (evicted under memory pressure, or upstream) are reclaimed on
-	/// the way so the sequence can be re-fetched. Fetched backfill isn't in arrival
-	/// order; it ages out from the front of the eviction order instead.
+	/// order, so the walk stops early at the first created-fresh group (a group is
+	/// never accessed before it is created, so everything deeper is fresh too).
+	/// Slots whose group was already aborted (evicted under memory pressure, or
+	/// upstream) are reclaimed on the way so the sequence can be re-fetched. Fetched
+	/// backfill isn't in arrival order; it ages out from the front of the eviction
+	/// order instead.
 	fn evict_expired(&mut self, now: web_async::time::Instant, max_age: Duration) {
+		let pool = self.broadcast.origin.pool.clone();
+		let now_ticks = pool.now();
+		let max_ticks = cache::Pool::ticks(max_age);
+		let expired = |slot: &Slot| now_ticks.saturating_sub(slot.accessed.load(Ordering::Relaxed)) > max_ticks;
+
 		for i in 0..self.arrival.len() {
 			let sequence = self.arrival[i];
 			let Some(slot) = self.lookup.get(&sequence) else {
@@ -504,7 +526,7 @@ impl TrackState {
 			// Already aborted: the frames are gone, reclaim the slot so a later
 			// fetch can serve the sequence again.
 			if slot.group.is_aborted() {
-				self.lookup.remove(&sequence);
+				self.remove_slot(sequence);
 				continue;
 			}
 
@@ -516,11 +538,16 @@ impl TrackState {
 				break;
 			}
 
+			// Created long ago but fetched recently: expiry keys off the last access.
+			if !expired(slot) {
+				continue;
+			}
+
 			// Take the group out of the cache and abort it, so any consumer still reading
 			// surfaces `Error::Old` instead of blocking forever on a frame that will never
 			// arrive. Without this a reader parked on an aged-out group hangs indefinitely,
 			// since the group is neither finished nor aborted.
-			let slot = self.lookup.remove(&sequence).unwrap();
+			let slot = self.remove_slot(sequence).unwrap();
 			let _ = slot.group.abort(Error::Old);
 		}
 
@@ -536,24 +563,20 @@ impl TrackState {
 		// The eviction order is roughly enqueue order: drop dead entries and age out
 		// expired groups (the only expiry that reaches fetched backfill) from the
 		// front, stopping at the first live fresh entry.
-		while let Some(&(sequence, epoch)) = self.evict.front() {
+		while let Some(&sequence) = self.evict.front() {
 			let Some(slot) = self.lookup.get(&sequence) else {
 				self.evict.pop_front();
 				continue;
 			};
-			if slot.epoch != epoch {
-				self.evict.pop_front();
-				continue;
-			}
 			if slot.group.is_aborted() {
-				self.lookup.remove(&sequence);
+				self.remove_slot(sequence);
 				self.evict.pop_front();
 				continue;
 			}
-			if now.duration_since(slot.created_at) <= max_age {
+			if !expired(slot) {
 				break;
 			}
-			let slot = self.lookup.remove(&sequence).unwrap();
+			let slot = self.remove_slot(sequence).unwrap();
 			let _ = slot.group.abort(Error::Old);
 			self.evict.pop_front();
 		}
@@ -562,9 +585,35 @@ impl TrackState {
 		// outnumber the live slots.
 		if self.evict.len() > 2 * self.lookup.len() + EVICT_SLACK {
 			let lookup = &self.lookup;
-			self.evict
-				.retain(|(sequence, epoch)| lookup.get(sequence).is_some_and(|slot| slot.epoch == *epoch));
+			self.evict.retain(|sequence| lookup.contains_key(sequence));
 		}
+	}
+
+	/// Remove a slot from the cache, releasing its share of the pool's access
+	/// average if it was in the evictable population.
+	fn remove_slot(&mut self, sequence: u64) -> Option<Slot> {
+		let slot = self.lookup.remove(&sequence)?;
+		if slot.counted.load(Ordering::Relaxed) {
+			self.broadcast
+				.origin
+				.pool
+				.access_remove(slot.accessed.load(Ordering::Relaxed));
+		}
+		Some(slot)
+	}
+
+	/// Drop every cached group and reset the eviction bookkeeping, releasing the
+	/// evictable population's share of the pool's access average.
+	fn clear_cache(&mut self) {
+		let pool = self.broadcast.origin.pool.clone();
+		for (_, slot) in self.lookup.drain() {
+			if slot.counted.load(Ordering::Relaxed) {
+				pool.access_remove(slot.accessed.load(Ordering::Relaxed));
+			}
+		}
+		self.arrival.clear();
+		self.evict.clear();
+		self.debt = 0;
 	}
 
 	/// Reject a sequence that is still cached; a dead (aborted or evicted)
@@ -577,7 +626,7 @@ impl TrackState {
 			if !slot.group.is_aborted() {
 				return Err(Error::Duplicate);
 			}
-			self.lookup.remove(&sequence);
+			self.remove_slot(sequence);
 		}
 		Ok(())
 	}
@@ -589,33 +638,35 @@ impl TrackState {
 	/// eviction. `visible` controls arrival-order delivery: publisher-produced
 	/// groups reach subscribers, fetched backfill is served by sequence only.
 	fn insert_group(&mut self, group: &group::Producer, now: web_async::time::Instant, visible: bool) {
+		let pool = &self.broadcast.origin.pool;
 		let sequence = group.sequence;
-		self.next_epoch = self.next_epoch.wrapping_add(1);
-		let epoch = self.next_epoch;
+		let ticks = pool.now();
+		let slot = Slot {
+			group: group.clone(),
+			created_at: now,
+			accessed: AtomicU64::new(ticks),
+			counted: AtomicBool::new(false),
+		};
 
 		if self.max_sequence.is_none_or(|max| sequence >= max) {
-			// Demote the previous latest: it joins the eviction order like any other
-			// cached group.
+			// Demote the previous latest: it joins the eviction order (and the
+			// pool's access average) like any other cached group.
 			if let Some(max) = self.max_sequence
 				&& sequence > max
 				&& let Some(prev) = self.lookup.get(&max)
 			{
-				self.evict.push_back((max, prev.epoch));
+				prev.counted.store(true, Ordering::Relaxed);
+				pool.access_insert(prev.accessed.load(Ordering::Relaxed));
+				self.evict.push_back(max);
 			}
 			self.max_sequence = Some(sequence);
 		} else {
-			self.evict.push_back((sequence, epoch));
+			slot.counted.store(true, Ordering::Relaxed);
+			pool.access_insert(ticks);
+			self.evict.push_back(sequence);
 		}
 
-		self.lookup.insert(
-			sequence,
-			Slot {
-				group: group.clone(),
-				created_at: now,
-				epoch,
-				touched: AtomicBool::new(false),
-			},
-		);
+		self.lookup.insert(sequence, slot);
 		if visible {
 			self.arrival.push_back(sequence);
 		}
@@ -638,11 +689,16 @@ impl TrackState {
 	/// Accrue and pay eviction debt for `written` fresh bytes.
 	///
 	/// Runs BEFORE the new group is inserted, so a brand-new entry is never a
-	/// victim of the very write that created it.
+	/// victim of the very write that created it. A track whose oldest content is
+	/// staler than the pool-wide average access time accrues at double rate, so
+	/// stale-heavy tracks drain first.
 	fn charge_debt(&mut self, written: u64) {
 		let pool = self.broadcast.origin.pool.clone();
 		match pool.accrue(written) {
-			Some(accrued) => {
+			Some(mut accrued) => {
+				if self.oldest_is_stale(&pool) {
+					accrued = accrued.saturating_mul(2);
+				}
 				// `used` bounds what eviction could ever free, keeping a track that
 				// can't pay (everything protected) from hoarding a stale schedule.
 				self.debt = self.debt.saturating_add(accrued).min(pool.used());
@@ -656,64 +712,85 @@ impl TrackState {
 		}
 	}
 
-	/// Abort this track's oldest groups until the outstanding debt is paid, or
+	/// Whether this track's oldest evictable group was accessed at or before the
+	/// pool-wide average, doubling the debt it accrues. Dead entries encountered at
+	/// the front are dropped along the way.
+	fn oldest_is_stale(&mut self, pool: &cache::Pool) -> bool {
+		let Some(average) = pool.average() else {
+			return false;
+		};
+		loop {
+			let Some(&sequence) = self.evict.front() else {
+				return false;
+			};
+			let Some(slot) = self.lookup.get(&sequence) else {
+				self.evict.pop_front();
+				continue;
+			};
+			if slot.group.is_aborted() {
+				self.remove_slot(sequence);
+				self.evict.pop_front();
+				continue;
+			}
+			return slot.accessed.load(Ordering::Relaxed) <= average;
+		}
+	}
+
+	/// Abort this track's stalest groups until the outstanding debt is paid, or
 	/// `cap` bytes have been freed by this call.
 	///
-	/// Pops the eviction order from the front, validating every entry against
-	/// `lookup`. When the next victim is larger than the remaining debt it is left
-	/// alone and the debt carries over, so a small write never evicts a huge group
-	/// (once the debt does cover it, that one victim may overshoot `cap`).
-	/// A FETCH-touched group is spared: its bytes count as paid (re-billed to every
-	/// writer through the pool's credit) and it re-queues at the back.
+	/// Deliberately approximate, Redis-style: at most a handful of live candidates
+	/// are examined per call, from the front of the eviction order. A group
+	/// accessed more recently than the pool-wide average is protected and rotates
+	/// to the back, so fresh content in this track never dies while staler content
+	/// survives elsewhere; the unfreed bytes keep the pool over budget, shifting
+	/// the debt onto the tracks holding that staler content. When the next victim
+	/// is larger than the remaining debt it is left in place and the debt carries
+	/// over, so a small write never evicts a huge group (once the debt does cover
+	/// it, that one victim may overshoot `cap`).
 	fn pay_debt(&mut self, pool: &cache::Pool, cap: u64) {
+		let average = pool.average().unwrap_or(0);
 		let mut paid = 0u64;
+		let mut scanned = 0usize;
 		for _ in 0..self.evict.len() {
-			if self.debt == 0 || paid >= cap {
+			if self.debt == 0 || paid >= cap || scanned >= EVICT_SCAN {
 				return;
 			}
-			let Some((sequence, epoch)) = self.evict.pop_front() else {
+			let Some(sequence) = self.evict.pop_front() else {
 				return;
 			};
 			let Some(slot) = self.lookup.get(&sequence) else {
 				// Evicted or expired; discard the dead entry.
 				continue;
 			};
-			if slot.epoch != epoch {
-				// A replaced incarnation; the live entry is elsewhere in the queue.
-				continue;
-			}
 			if slot.group.is_aborted() {
 				// Aborted upstream: the frames are already gone, reclaim the slot.
-				self.lookup.remove(&sequence);
+				self.remove_slot(sequence);
 				continue;
 			}
 			if Some(sequence) == self.max_sequence {
 				// The live edge is never enqueued, but tolerate finding it anyway.
-				self.evict.push_back((sequence, epoch));
+				self.evict.push_back(sequence);
 				continue;
 			}
 
+			scanned += 1;
 			let size = slot.group.cached_bytes();
-			if size == 0 {
-				// An empty group (e.g. a backfill still being filled) frees nothing;
-				// evicting it would only destroy a fresh fetch. Send it to the back.
-				self.evict.push_back((sequence, epoch));
-				continue;
-			}
-			if slot.touched.swap(false, Ordering::Relaxed) {
-				pool.credit(size);
-				self.debt = self.debt.saturating_sub(size);
-				self.evict.push_back((sequence, epoch));
+			// Protected: accessed more recently than the average (a fresh insert or
+			// a FETCH hit), or empty (a backfill still being filled, which eviction
+			// would destroy while freeing nothing). Rotate to the back.
+			if size == 0 || slot.accessed.load(Ordering::Relaxed) > average {
+				self.evict.push_back(sequence);
 				continue;
 			}
 			if size > self.debt {
-				self.evict.push_front((sequence, epoch));
+				self.evict.push_front(sequence);
 				return;
 			}
 
 			self.debt -= size;
 			paid = paid.saturating_add(size);
-			let slot = self.lookup.remove(&sequence).unwrap();
+			let slot = self.remove_slot(sequence).unwrap();
 			let _ = slot.group.abort(Error::Evicted);
 		}
 	}
@@ -1047,11 +1124,8 @@ impl Producer {
 	pub fn abort(self, err: Error) -> Result<()> {
 		let mut guard = self.modify()?;
 		guard.abort = Some(err);
-		guard.lookup.clear();
-		guard.arrival.clear();
-		guard.evict.clear();
+		guard.clear_cache();
 		guard.datagrams.clear();
-		guard.debt = 0;
 		guard.close();
 		Ok(())
 	}
@@ -1383,11 +1457,8 @@ impl Drop for Producer {
 				track = %self.name(),
 				"track::Producer dropped without finish() or abort()"
 			);
-			state.lookup.clear();
-			state.arrival.clear();
-			state.evict.clear();
+			state.clear_cache();
 			state.datagrams.clear();
-			state.debt = 0;
 		}
 	}
 }
@@ -4183,8 +4254,9 @@ mod test {
 		assert_eq!(group.read_frame().await.unwrap().unwrap().payload.len(), 1000);
 	}
 
-	/// A FETCH cache hit refreshes the group: the eviction walk spares it (re-queued
-	/// at the back, bytes credited) and evicts unread groups instead.
+	/// A FETCH cache hit refreshes the group's access time: anything accessed more
+	/// recently than the pool-wide average is protected, so the eviction walk skips
+	/// it and evicts a never-read group instead, even one that arrived later.
 	#[tokio::test]
 	async fn fetch_refresh_survives_eviction() {
 		tokio::time::pause();
@@ -4192,18 +4264,23 @@ mod test {
 		let (mut producer, _pool) = pooled_producer(10_000);
 		let consumer = producer.consume();
 
-		finished_group(&mut producer, 5_000); // seq 0
-		finished_group(&mut producer, 5_000); // seq 1
+		finished_group(&mut producer, 3_000); // seq 0
+		tokio::time::advance(Duration::from_secs(1)).await;
+		finished_group(&mut producer, 3_000); // seq 1
+		tokio::time::advance(Duration::from_secs(1)).await;
+		finished_group(&mut producer, 3_000); // seq 2
+		tokio::time::advance(Duration::from_millis(500)).await;
 
-		// FETCH seq 0: the cache hit marks it refreshed.
+		// FETCH seq 0: the cache hit lifts its access time above the average.
 		let mut fetched = consumer.fetch_group(0, None).await.unwrap();
-		assert_eq!(fetched.read_frame().await.unwrap().unwrap().payload.len(), 5_000);
+		assert_eq!(fetched.read_frame().await.unwrap().unwrap().payload.len(), 3_000);
+		tokio::time::advance(Duration::from_millis(500)).await;
 
-		// Pressure. seq 0 is first in eviction order but refreshed, so it is spared;
-		// the debt carries and lands on seq 1 at the next write.
-		finished_group(&mut producer, 5_000); // seq 2
-		consumer.fetch_group(0, None).await.unwrap(); // keep seq 0 hot
-		finished_group(&mut producer, 5_000); // seq 3
+		// Pressure: seq 0 is first in eviction order but freshly accessed, so it
+		// rotates to the back and the never-read seq 1 dies instead.
+		finished_group(&mut producer, 3_000); // seq 3
+		tokio::time::advance(Duration::from_secs(1)).await;
+		finished_group(&mut producer, 3_000); // seq 4
 
 		assert!(consumer.peek_group(0).is_some(), "refreshed group survives");
 		assert!(consumer.peek_group(1).is_none(), "unread group is evicted instead");
@@ -4317,13 +4394,13 @@ mod test {
 		group.finish().unwrap();
 		pending.await.unwrap();
 
-		// The refetched latest is protected by omission: it has no live entry in the
+		// The refetched latest is protected by omission: it has no entry in the
 		// eviction order, so no amount of debt can select it.
 		{
 			let state = producer.state.read();
-			let slot = state.lookup.get(&1).expect("refetched group is cached");
+			assert!(state.lookup.contains_key(&1), "refetched group is cached");
 			assert!(
-				!state.evict.iter().any(|(seq, epoch)| *seq == 1 && *epoch == slot.epoch),
+				!state.evict.contains(&1),
 				"the live edge must not be an eviction candidate"
 			);
 		}

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -23,6 +23,8 @@ pub use super::subscription::Subscription;
 use std::{
 	collections::{HashMap, VecDeque},
 	sync::Arc,
+	sync::OnceLock,
+	sync::atomic::{AtomicBool, Ordering},
 	task::{Poll, ready},
 	time::Duration,
 };
@@ -854,11 +856,8 @@ pub struct Producer {
 	broadcast: Arc<broadcast::Info>,
 	state: kio::Producer<TrackState>,
 	prev_subscription: Option<Subscription>,
-	// Counts the producer clones, and only them, so teardown fires exactly when the
-	// publisher lets go. The track state's own producer count is a different
-	// question: a group settling its eviction debt upgrades the account's weak
-	// handle, which momentarily counts there (see `cache::Track::settle`).
-	alive: kio::Producer<()>,
+	// Shared with every clone and every `Dynamic`: its `Drop` is the teardown.
+	alive: Arc<Alive>,
 	// Ingress stats scope, inherited from a tagged [`broadcast::Producer`]. Bumped as
 	// one subscription on tag and closed when the last producer clone drops. Empty
 	// (no-op) for an untagged broadcast.
@@ -878,18 +877,21 @@ impl Producer {
 		name: impl Into<Arc<str>>,
 		info: impl Into<Option<Info>>,
 	) -> Self {
+		let name = name.into();
 		let state = TrackState::spawn(broadcast.clone());
 		state
 			.write()
 			.ok()
 			.expect("a new track is open")
 			.install(info.into().unwrap_or_default());
+		let alive = Alive::new(name.clone(), state.clone());
+		alive.publish(None);
 		Self {
-			name: name.into(),
+			name,
 			state,
 			broadcast,
 			prev_subscription: None,
-			alive: Default::default(),
+			alive,
 			stats: stats::Scope::default(),
 		}
 	}
@@ -898,7 +900,7 @@ impl Producer {
 	/// ingress subscription (closed when the last producer clone drops). Called by a
 	/// tagged [`broadcast::Producer`] when it creates the track.
 	pub(crate) fn with_stats(mut self, scope: stats::Scope) -> Self {
-		scope.open_subscription();
+		self.alive.publish(Some(&scope));
 		self.stats = scope;
 		self
 	}
@@ -1266,7 +1268,7 @@ impl Producer {
 	/// (old) groups. Most producers never need this; a relay creates one to fetch
 	/// past groups from upstream.
 	pub fn dynamic(&self) -> Dynamic {
-		Dynamic::new(self.name.clone(), self.state.clone())
+		Dynamic::new(self.name.clone(), self.state.clone(), self.alive.clone())
 	}
 
 	fn modify(&self) -> Result<kio::Mut<'_, TrackState>> {
@@ -1334,13 +1336,21 @@ pub struct Dynamic {
 	state: kio::Producer<TrackState>,
 	// The fetch queue this handle drains; its `dynamic` count gates `fetch_group`.
 	fetch: kio::Shared<FetchState>,
+	// Shared with the track's producers: a handler still serving fetches keeps the
+	// track alive, like a producer clone does.
+	alive: Arc<Alive>,
 }
 
 impl Dynamic {
-	fn new(name: Arc<str>, state: kio::Producer<TrackState>) -> Self {
+	fn new(name: Arc<str>, state: kio::Producer<TrackState>, alive: Arc<Alive>) -> Self {
 		let fetch = state.read().fetch.clone();
 		fetch.lock().add_handler();
-		Self { name, state, fetch }
+		Self {
+			name,
+			state,
+			fetch,
+			alive,
+		}
 	}
 
 	/// The track's name, unique within its broadcast.
@@ -1376,6 +1386,7 @@ impl Clone for Dynamic {
 			name: self.name.clone(),
 			state: self.state.clone(),
 			fetch: self.fetch.clone(),
+			alive: self.alive.clone(),
 		}
 	}
 }
@@ -1394,17 +1405,58 @@ impl Drop for Dynamic {
 	}
 }
 
-impl Drop for Producer {
+/// Ends the track when the last [`Producer`] or [`Dynamic`] drops.
+///
+/// A refcount rather than a "am I the last one?" check inside `Drop`: that answer is a
+/// snapshot, and acting on it is exactly what invalidates it. The track state's own
+/// producer count can't answer it either, since a group settling its eviction debt
+/// upgrades the account's weak handle and counts there for the duration (see
+/// [`cache::Track::settle`]). Holding a producer of its own also keeps the state
+/// writable until the teardown has run, whatever order the last owner's fields drop in.
+struct Alive {
+	name: Arc<str>,
+	state: kio::Producer<TrackState>,
+
+	// Set when a `Producer` is first minted, so a `Request` nobody accepted (its
+	// `Dynamic` holds this guard too) isn't reported as an abandoned publisher.
+	published: AtomicBool,
+
+	// Ingress subscription for this track, opened by the tagged producer that claimed
+	// it and closed when this guard drops.
+	stats: OnceLock<stats::Subscription>,
+}
+
+impl Alive {
+	fn new(name: Arc<str>, state: kio::Producer<TrackState>) -> Arc<Self> {
+		Arc::new(Self {
+			name,
+			state,
+			published: Default::default(),
+			stats: Default::default(),
+		})
+	}
+
+	/// Note that a [`Producer`] was minted from this track, optionally under a tagged
+	/// broadcast's ingress scope (counted as one subscription for as long as the track
+	/// has a publisher).
+	fn publish(&self, stats: Option<&stats::Scope>) {
+		self.published.store(true, Ordering::Relaxed);
+		if let Some(scope) = stats {
+			let _ = self.stats.set(scope.subscribe());
+		}
+	}
+}
+
+impl Drop for Alive {
 	fn drop(&mut self) {
+		// A request nobody accepted was never publishing; there's nothing to tear down.
+		if !self.published.load(Ordering::Relaxed) {
+			return;
+		}
 		// The last producer going away without finishing is an abrupt teardown:
 		// release the cached groups so a stale consumer can't pin them (and their
 		// frame buffers) forever, the same as an explicit abort. A cleanly
 		// finished track keeps its cache so consumers can still drain it.
-		if !self.alive.is_last() {
-			return;
-		}
-		// The last ingress producer closing the track ends its subscription.
-		self.stats.close_subscription();
 		if let Ok(mut state) = self.state.write()
 			&& state.final_sequence.is_none()
 		{
@@ -1412,7 +1464,7 @@ impl Drop for Producer {
 			// Error::Dropped instead of a clean end. Deliberate ends go through
 			// finish()/abort().
 			tracing::warn!(
-				track = %self.name(),
+				track = %self.name,
 				"track::Producer dropped without finish() or abort()"
 			);
 			state.clear_cache();
@@ -2460,6 +2512,10 @@ pub struct Request {
 	// The previous subscription that was combined, used to detect changes.
 	prev_subscription: Option<Subscription>,
 
+	// Shared with the accepted [`Producer`] and every [`Dynamic`]: its `Drop` is the
+	// teardown, and it stays inert until a producer is minted.
+	alive: Arc<Alive>,
+
 	// A requested track is served on demand, so it counts as fetch-capable from
 	// birth: a consumer's cache-miss `fetch_group` waits to be served instead of
 	// racing the producer (e.g. a relay) into creating its own handler. Released
@@ -2475,12 +2531,14 @@ impl Request {
 	pub(crate) fn new(broadcast: Arc<broadcast::Info>, name: impl Into<Arc<str>>) -> Self {
 		let name = name.into();
 		let state = TrackState::spawn(broadcast.clone());
-		let dynamic = Dynamic::new(name.clone(), state.clone());
+		let alive = Alive::new(name.clone(), state.clone());
+		let dynamic = Dynamic::new(name.clone(), state.clone(), alive.clone());
 		Self {
 			name,
 			broadcast,
 			state,
 			prev_subscription: None,
+			alive,
 			_dynamic: dynamic,
 			stats: stats::Scope::default(),
 		}
@@ -2507,7 +2565,7 @@ impl Request {
 	/// groups, before [`Self::accept`] is even called. A relay creates one to fetch
 	/// past groups from upstream while (or instead of) serving a live subscription.
 	pub fn dynamic(&self) -> Dynamic {
-		Dynamic::new(self.name.clone(), self.state.clone())
+		Dynamic::new(self.name.clone(), self.state.clone(), self.alive.clone())
 	}
 
 	/// Poll for the request becoming unused (every consumer dropped), so a relay can
@@ -2529,14 +2587,14 @@ impl Request {
 			state.install(info.into().unwrap_or_default());
 		}
 		// Accepting the request creates the track producer: count it as one ingress
-		// subscription (closed on the last producer drop). No-op when untagged.
-		self.stats.open_subscription();
+		// subscription (closed when the last handle drops). No-op when untagged.
+		self.alive.publish(Some(&self.stats));
 		Producer {
 			name: self.name,
 			broadcast: self.broadcast,
 			state: self.state,
 			prev_subscription: None,
-			alive: Default::default(),
+			alive: self.alive,
 			stats: self.stats,
 		}
 	}
@@ -4437,6 +4495,21 @@ mod test {
 		let a = a.state.read().cache.clone();
 		let b = b.state.read().cache.clone();
 		assert!(!Arc::ptr_eq(&a, &b), "each track owns its account");
+	}
+
+	/// A `Dynamic` still serving fetches keeps the track alive, so the publisher
+	/// letting go isn't an abrupt teardown: the handler can still serve the cache.
+	#[tokio::test]
+	async fn a_dynamic_defers_teardown() {
+		let (mut producer, pool) = pooled_producer(1 << 40);
+		let dynamic = producer.dynamic();
+		finished_group(&mut producer, 100);
+
+		drop(producer);
+		assert!(pool.used() > 0, "the handler still serves the cache");
+
+		drop(dynamic);
+		assert_eq!(pool.used(), 0, "the last handle tears it down");
 	}
 
 	/// A finished track releases everything once every handle is gone.

--- a/rs/moq-net/src/stats.rs
+++ b/rs/moq-net/src/stats.rs
@@ -1070,24 +1070,6 @@ impl Scope {
 		}
 	}
 
-	/// Bump `subscriptions` once. The ingress (producer-lifetime) counterpart to
-	/// [`Self::subscribe`], which cannot use an RAII guard because the producer is
-	/// cloneable and closes only on the last clone drop. No viewer refcount (that is
-	/// egress-only). Pair with [`Self::close_subscription`].
-	pub(crate) fn open_subscription(&self) {
-		if let Some(counters) = self.counters() {
-			counters.subscriptions.fetch_add(1, Ordering::Relaxed);
-		}
-	}
-
-	/// Bump `subscriptions_closed` once. See [`Self::open_subscription`].
-	pub(crate) fn close_subscription(&self) {
-		if let Some(counters) = self.counters() {
-			// Release pairs with the readout's Acquire load of `subscriptions_closed`.
-			counters.subscriptions_closed.fetch_add(1, Ordering::Release);
-		}
-	}
-
 	/// Open an announce guard: bumps `announced` and adds the path length to
 	/// `announced_bytes` now; on drop bumps `announced_closed` and adds the path
 	/// length again. Used for egress announce-stream events and ingress
@@ -1559,18 +1541,17 @@ mod tests {
 
 	#[test]
 	fn ingress_subscription_has_no_viewer() {
-		// The ingress (producer-lifetime) subscription pair bumps subscriptions but
-		// never the viewer refcount.
+		// An ingress (producer-lifetime) subscription bumps subscriptions but never
+		// the viewer refcount, which is egress-only.
 		let stats = test_stats();
 		let ctx = stats.tier(Tier::default()).session("root");
-		let scope = ctx.ingress("demo/bbb");
-		scope.open_subscription();
+		let guard = ctx.ingress("demo/bbb").subscribe();
 		let sub = tier_counters(&stats, "demo/bbb", &Tier::default())
 			.subscriber
 			.snapshot();
 		assert_eq!(sub.subscriptions, 1);
 		assert_eq!(sub.broadcasts, 0, "ingress has no viewer refcount");
-		scope.close_subscription();
+		drop(guard);
 		assert_eq!(
 			tier_counters(&stats, "demo/bbb", &Tier::default())
 				.subscriber

--- a/rs/moq-relay/src/cache.rs
+++ b/rs/moq-relay/src/cache.rs
@@ -44,13 +44,15 @@ pub struct CacheConfig {
 	#[arg(long = "cache-headroom", env = "MOQ_CACHE_HEADROOM")]
 	pub headroom: Option<String>,
 
-	/// Maximum age of a non-latest cached group, e.g. "30s" or "500ms".
+	/// Maximum time a non-latest cached group is retained since it was last
+	/// written or served from cache by a FETCH, e.g. "30s" or "500ms".
 	///
 	/// Caps each track's own retention window: a publisher advertising a longer
 	/// window is clamped down to this, bounding how much history a track can
-	/// accumulate no matter what upstream asks for. This bounds memory by age
-	/// where `capacity` bounds it by bytes. Unbounded (each track keeps its own
-	/// window) when unset.
+	/// accumulate no matter what upstream asks for. A FETCH cache hit restarts
+	/// the clock, so actively-read history stays cached. This bounds memory by
+	/// age where `capacity` bounds it by bytes. Unbounded (each track keeps its
+	/// own window) when unset.
 	///
 	/// Two caveats on the ceiling. The latest group of every track is always
 	/// retained, since it is the live edge. And expiry is evaluated when a track

--- a/rs/moq-relay/src/cache.rs
+++ b/rs/moq-relay/src/cache.rs
@@ -55,7 +55,8 @@ pub struct CacheConfig {
 	/// retained, since it is the live edge. And expiry is evaluated when a track
 	/// writes its next group, so a publisher that stops writing without
 	/// disconnecting keeps whatever it had cached until it resumes or the
-	/// broadcast closes; the `capacity` budget is what reclaims those.
+	/// broadcast closes; under memory pressure the `capacity` budget is repaid by
+	/// the tracks that are still writing.
 	#[arg(long = "cache-duration", env = "MOQ_CACHE_DURATION", value_parser = humantime::parse_duration)]
 	#[serde(default, with = "humantime_serde")]
 	pub duration: Option<Duration>,
@@ -133,8 +134,8 @@ fn total_memory() -> u64 {
 }
 
 /// Re-size the pool periodically so at least `headroom` bytes of system memory
-/// stay available: the cache grows into idle memory and shrinks (evicting LRU
-/// groups) when the rest of the system needs it.
+/// stay available: the cache grows into idle memory and shrinks (tracks evict
+/// their oldest groups as they write) when the rest of the system needs it.
 async fn governor(pool: cache::Pool, capacity: Option<u64>, headroom: u64) {
 	let mut sys = sysinfo::System::new();
 	let mut interval = tokio::time::interval(GOVERNOR_INTERVAL);

--- a/rs/moq-relay/src/cache.rs
+++ b/rs/moq-relay/src/cache.rs
@@ -29,8 +29,8 @@ pub struct CacheConfig {
 	/// percentage of memory like "75%" (respecting the cgroup limit when set).
 	/// Unbounded when unset.
 	///
-	/// A target usage converges toward as tracks write, not a hard limit, and it
-	/// counts payload bytes, not process RSS; leave some slack below physical
+	/// A target that usage converges toward as tracks write, not a hard limit, and
+	/// it counts payload bytes, not process RSS; leave some slack below physical
 	/// memory or combine with `headroom`.
 	#[arg(long = "cache-capacity", env = "MOQ_CACHE_CAPACITY")]
 	pub capacity: Option<String>,
@@ -138,7 +138,7 @@ fn total_memory() -> u64 {
 
 /// Re-size the pool periodically so at least `headroom` bytes of system memory
 /// stay available: the cache grows into idle memory and shrinks (tracks evict
-/// their oldest groups as they write) when the rest of the system needs it.
+/// their stalest groups as they write) when the rest of the system needs it.
 async fn governor(pool: cache::Pool, capacity: Option<u64>, headroom: u64) {
 	let mut sys = sysinfo::System::new();
 	let mut interval = tokio::time::interval(GOVERNOR_INTERVAL);

--- a/rs/moq-relay/src/cache.rs
+++ b/rs/moq-relay/src/cache.rs
@@ -25,12 +25,13 @@ const GOVERNOR_INTERVAL: Duration = Duration::from_secs(5);
 #[non_exhaustive]
 #[group(id = "cache-config")]
 pub struct CacheConfig {
-	/// Maximum bytes of cached group payload, e.g. "8GiB", "512MB", or a
+	/// Target bytes of cached group payload, e.g. "8GiB", "512MB", or a
 	/// percentage of memory like "75%" (respecting the cgroup limit when set).
 	/// Unbounded when unset.
 	///
-	/// The budget counts payload bytes, not process RSS; leave some slack below
-	/// physical memory or combine with `headroom`.
+	/// A target usage converges toward as tracks write, not a hard limit, and it
+	/// counts payload bytes, not process RSS; leave some slack below physical
+	/// memory or combine with `headroom`.
 	#[arg(long = "cache-capacity", env = "MOQ_CACHE_CAPACITY")]
 	pub capacity: Option<String>,
 


### PR DESCRIPTION
# Why

The cache pool kept a global registry of every cached group to implement exact LRU: a lazily re-keyed binary heap ordered by last-access snapshots, a compaction heuristic (`COMPACT_SLACK`), a bounded-pop budget to guarantee termination, and a process-wide lock taken on every group create, drop, and, at steady state, every frame write. A cache whose purpose is to soak idle RAM sits *at* capacity permanently (the headroom governor guarantees it), so the lock plus O(log n) heap pops were the normal write path, not a rare slow path. The registry also owned each group's eviction hook, which kept the group state alive and forced the `Charge::clear` ownership dance (see #2525) to avoid leaks.

# What

The pool shrinks to a handful of atomics (`used`, `capacity`, and a count-weighted mean last-access time), with no lock, no registry, no hooks, and no background work. Eviction is distributed to the tracks themselves:

- **Debt accrual.** While the pool is over its byte target, a track accrues eviction debt as it writes, sized at `written * used / capacity` (doubled when its oldest content is staler than the pool-wide mean), so aggregate eviction slightly outpaces ingest, the overshoot decays exponentially onto the target, and stale-heavy tracks drain first. Debt is per-track: eviction lands proportionally to what each track writes and never touches another track's cache.
- **Debt payment.** Debt is paid by aborting the track's own stalest groups (`Error::Evicted`) in a Redis-style approximate walk: at most 4 live candidates examined per write, from the front of a per-track eviction order. Payment runs *before* the new group is inserted, so a brand-new entry is never a victim of the write that created it. A victim larger than the outstanding debt carries the debt forward (a small write never evicts a huge group), and each payment is capped at twice the bytes written so one write never dumps a deep backlog, e.g. after the governor slashes the target.
- **Cross-track ordering by mean access time.** The pool maintains the mean last-access tick of the evictable population with two atomics (insert/remove/refresh deltas, exact bookkeeping rather than sampling). A group accessed more recently than the mean is never evicted; the walk rotates it to the back. A fresh fetch in one track therefore can't die while staler content survives in another, and the unfreed bytes keep the pool over budget, shifting the debt onto the tracks holding that staler content, so the used/target feedback alone conserves the total eviction rate. Evicting old entries and inserting new ones both advance the mean, so the eviction frontier moves with cache turnover on its own. Ticks are 100ms: the count-weighted sum stays a decimal order of magnitude under u64 overflow at 20-year uptimes and a 64 GiB target's worst-case group count (`used / ENTRY_OVERHEAD`); a byte-weighted mean would overflow u64 even at whole-second ticks.
- **Live-edge protection by omission.** The `max_sequence` group is never enqueued for eviction and stays *out of the mean* (it enters both when superseded), replacing the pin/unpin machinery. Keeping immortal latest groups out of the statistic matters: a stalled track's ancient latest would otherwise drag the mean into the past and stall eviction everywhere.
- **FETCH refresh.** A cache hit swaps the group's access tick to now, which both lifts it above the mean (eviction protection) and restarts its retention clock: cache-duration expiry now keys off the last access, so actively-read history stays cached. Group reads on the subscribe path touch no shared state at all.
- **Track-side structure.** `TrackState` indexes groups in a sequence-keyed `HashMap` plus two bare-sequence deques: arrival order (subscriptions, expiry early-exit) and eviction order (memory pressure). Entries are hints validated against the map on pop. FETCH lookup goes from a linear scan to O(1).
- **Per-track accounting.** A `cache::Track` account sits between the pool and each group's `Charge` (`Pool -> Track -> Charge`): it owns the pool handle, the gross-write counter `charge_debt` drains, and the link a frame write follows back to the track to settle its own debt. Opened once by a single `TrackState::spawn` constructor, so it exists from the moment the state does. `track::Info` stays what it says it is, the publisher's four wire-visible properties, and is `Copy` again. Groups served before `Request::accept` therefore charge the same account as any other, rather than being unable to settle at all.
- **A genuinely weak link.** The account's link back to the track is a new `kio::Weak` (`Producer::downgrade`), which owns neither the ref count nor the state allocation and upgrades back to a `Producer` while the channel is live. `ProducerWeak` is weak only in liveness: it clones the `Arc<Mutex<..>>`, so storing one inside the state it points at (as every group's `Info` did) keeps that state, and every cached frame in it, alive forever. Because that upgrade counts as a producer, and `kio::Producer::is_last` answered "am I the only one?" with a snapshot that the caller's next act invalidates, `is_last` is gone: each last-handle teardown (track, group, broadcast) moves into the `Drop` of a shared `Alive` guard, so the refcount runs it exactly once. That also closes a pre-existing leak of the track's ingress stats subscription whenever a `Dynamic` outlived the producer, and retires `stats::Scope::{open_subscription, close_subscription}` in favour of the RAII `subscribe()` guard.
- **Fetched backfill** is inserted outside arrival order: served by sequence (including `next_group`), never replayed to arrival-order subscribers, and aged out through the eviction order since it isn't in the arrival walk.

Behavior notes:

- The capacity is explicitly a **target** usage converges toward, not a hard limit: carried debt, capped payments, and the protected live edge all let usage transiently exceed it. Renaming `Pool::capacity` / `--cache-capacity` to say "target" is a breaking change left for a dev-targeted follow-up; docs already use the new framing.
- `Pool::resize` no longer evicts synchronously; a shrink is repaid as tracks write. The relay headroom governor already sampled on a 5s tick, so reclaim latency is comparable.
- A publisher that stops writing but stays connected keeps its cache; under pressure the budget is repaid by tracks that are still writing. Docs updated to say so.
- No public API changes: `cache::Pool`'s `pub` surface is unchanged, and `kio::Producer::is_last` is hidden and `#[deprecated]` rather than removed, so this stays additive and targets `main`.

# Cross-package sync

- `doc/bin/relay/config.md` cache section updated for the new eviction and last-access-expiry semantics.
- No wire change, so no draft updates. `js/net` has no cache pool counterpart. `moq-ffi`'s surface (`Pool::new`/`capacity`) is untouched.

# Testing

- New unit tests in `cache.rs` for accrual math, the access-mean bookkeeping, and the `Charge` RAII, and in `track.rs` for oldest-first eviction, live-edge protection, FETCH-refresh survival under pressure, reader aborts, debt carrying (small write vs large victim), the per-write payment cap, refetch-after-eviction, backfill invisibility to subscribers, and backfill expiry.
- Regression tests for the leak: a finished track frees its state and its cached bytes once every handle is gone, a retained `group::Consumer` outlives its track without pinning it, and a pre-accept backfill settles a late 300 KB write with no subsequent group insert. Plus one for the teardown gate: an abrupt drop still releases the cache while a group is mid-settle. In `kio`, a state holding a `Weak` to itself is still deallocated, an upgrade holds the channel open, and a closed channel never upgrades. A `Dynamic` outliving its publisher still defers teardown, as before.
- `cargo test -p moq-net -p moq-relay -p moq-ffi -p hang -p moq-mux -p kio` green; clippy `-D warnings`, `cargo fmt --check`, and `cargo doc -D warnings` clean. The `moq-relay` smoke tests fail in this container for lack of IPv6 (`BindSocket: Address family not supported by protocol`), unrelated to the change.

(Written by Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019FLZgQ65CLJFtHRbg2Vz7q



