### PR TITLE
ci: compile-check the Windows and macOS code paths on PRs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,6 +12,14 @@ permissions:
 # than windows.yml: only the two crates that hold Apple-gated code. Everything
 # else shipping on macOS already compiles in swift.yml. Cargo.lock is
 # deliberately absent, so a bare dependency bump doesn't spin up a Mac.
+#
+# The known cost of that: the Apple backends import from other crates
+# (decode/backend/videotoolbox.rs uses moq_net::Timestamp and moq_mux's
+# NalIterator), so a breaking change confined to moq-net or moq-mux won't fire
+# this gate, and the Linux gate never compiles those cfg'd files either. Such a
+# break lands on main and surfaces at release. That is an accepted trade for
+# keeping Mac minutes down, not an oversight: widen the paths below only if the
+# runner budget changes.
 on:
   pull_request:
     # `closed` is here only so merging/closing a PR cancels its in-flight run

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,10 +9,9 @@ permissions:
 # `just check` on a Mac. This job compiles them.
 #
 # macOS runners are the expensive ones, so the trigger is deliberately tighter
-# than windows.yml: only the two crates that hold Apple-gated code, and
-# the lockfile (an objc2 bump inside an existing version range is exactly the
-# kind of change that breaks these bindings and nothing else). Everything else
-# shipping on macOS already compiles in swift.yml.
+# than windows.yml: only the two crates that hold Apple-gated code. Everything
+# else shipping on macOS already compiles in swift.yml. Cargo.lock is
+# deliberately absent, so a bare dependency bump doesn't spin up a Mac.
 on:
   pull_request:
     # `closed` is here only so merging/closing a PR cancels its in-flight run
@@ -22,7 +21,6 @@ on:
       - "rs/moq-video/**"
       - "rs/moq-audio/**"
       - "rs/justfile"
-      - "Cargo.lock"
       - "rust-toolchain.toml"
       - ".github/workflows/macos.yml"
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,62 @@
+name: macOS
+
+permissions:
+  contents: read
+
+# The main gate (check.yml) runs on Linux only, so `#[cfg(target_os = "macos")]`
+# code compiles nowhere in CI: moq-video's VideoToolbox and ScreenCaptureKit
+# backends and moq-audio's system-audio capture rest on a maintainer running
+# `just check` on a Mac. This job compiles them.
+#
+# macOS runners are the expensive ones, so the trigger is deliberately tighter
+# than windows.yml: only the two crates that hold Apple-gated code, and
+# the lockfile (an objc2 bump inside an existing version range is exactly the
+# kind of change that breaks these bindings and nothing else). Everything else
+# shipping on macOS already compiles in swift.yml.
+on:
+  pull_request:
+    # `closed` is here only so merging/closing a PR cancels its in-flight run
+    # via the concurrency group below; the job itself is skipped on close.
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - "rs/moq-video/**"
+      - "rs/moq-audio/**"
+      - "rs/justfile"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/macos.yml"
+
+concurrency:
+  group: macos-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: macOS
+    if: github.event.action != 'closed'
+    runs-on: macos-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # No toolchain step: rust-toolchain.toml pins the version and the runner's
+      # rustup installs it on the first cargo call, so this gate compiles with
+      # the same rustc as the Nix-pinned Linux one. No Nix either, since
+      # installing it costs more than the check saves.
+
+      - name: Install just
+        uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2.85.0
+        with:
+          tool: just
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
+
+      - name: Check
+        run: just rs macos

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,66 @@
+name: Windows
+
+permissions:
+  contents: read
+
+# The main gate (check.yml) runs on Linux only, so `#[cfg(target_os = "windows")]`
+# code compiles for the first time in a tag-triggered release build, long after
+# review. This job compiles it on every Rust-touching PR instead. It's a plain
+# `cargo check`, not the full `just ci`: lint/format/test coverage stays on the
+# Linux gate, which is cheaper and where those results are platform-independent.
+on:
+  pull_request:
+    # `closed` is here only so merging/closing a PR cancels its in-flight run
+    # via the concurrency group below; the job itself is skipped on close.
+    types: [opened, synchronize, reopened, closed]
+    # Windows compilation can only break on a Rust or toolchain change, and a
+    # Windows runner is slow, so keep it off doc/JS/config PRs entirely.
+    paths:
+      - "rs/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - "justfile"
+      - ".github/workflows/windows.yml"
+
+concurrency:
+  group: windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Windows
+    if: github.event.action != 'closed'
+    runs-on: windows-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      # No toolchain step: rust-toolchain.toml pins the version and the runner's
+      # rustup installs it on the first cargo call, so this gate compiles with
+      # the same rustc as the Nix-pinned Linux one.
+
+      - name: Install just
+        uses: taiki-e/install-action@7572810d7dd469b651bb7793945692cf78da5dd7 # v2.85.0
+        with:
+          tool: just
+
+      # aws-lc-rs assembles its x86_64 crypto with NASM on Windows.
+      - name: Install NASM
+        shell: pwsh
+        run: |
+          choco install nasm -y --no-progress
+          "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          cache-on-failure: true
+
+      - name: Check
+        shell: bash
+        run: just rs windows

--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -143,3 +143,9 @@ Then `Config::load()?` (initializes tracing), build clients/servers via `.init()
 - Rust tests are `#[cfg(test)] mod tests` inline in the source file.
 - Async tests that depend on time call `tokio::time::pause()` first so timers fire instantly and deterministically (e.g. the tests in `moq-net/src/model/origin.rs`).
 - Config-merge regressions belong next to the config (`moq-relay/src/config.rs::tests`); they serialize env mutation with a lock since clap reads env.
+- **`just check` only compiles the host's platform.** `#[cfg(target_os = "...")]` code for other platforms is invisible to it, and `cargo fmt` skips those modules too. Each platform has its own gate, and each only runs on that platform's runner:
+  - Windows (moq-video's Media Foundation and D3D11 backends): `just rs windows`, via `.github/workflows/windows.yml`. You can't reproduce it off Windows, since cross-compiling dies in openh264-sys2's vendored C++.
+  - macOS (moq-video's VideoToolbox and ScreenCaptureKit, moq-audio's system audio): `just rs macos`, via `.github/workflows/macos.yml`. Scoped to moq-video + moq-audio, and needs `--all-features` because moq-audio's capture backend is off by default.
+  - Linux: no separate gate needed. `just rs ci` already runs `--all-features` in a dev shell carrying pipewire/libva/alsa, so nvenc/nvdec/vaapi/pipewire all compile.
+
+  Both extra gates are path-filtered, so a change outside their trigger paths that breaks them surfaces on the merge commit rather than the PR.

--- a/rs/justfile
+++ b/rs/justfile
@@ -21,6 +21,37 @@ check *args:
     cargo shear
     cargo sort --workspace --check --no-format
 
+# Runs the `#[cfg(target_os = "windows")]` code past the compiler: moq-video's
+# Media Foundation capture/encode/decode and its D3D11 frames, which the Linux
+# gate skips entirely. Cross-compiling can't stand in, because openh264-sys2
+# builds vendored C++ that needs an MSVC toolchain and openh264 is a
+# non-optional dependency.
+#
+# Default features rather than `--all-features`: jemalloc and the quiche
+# backend don't build on MSVC, while moq-video's Linux-only nvenc/vaapi/nvdec
+# defaults are already no-ops off Linux. moq-gst is excluded because it links
+# GStreamer via pkg-config, which the Windows runner doesn't have.
+
+# Compile the whole workspace on a Windows host. Must run ON Windows.
+windows *args:
+    cargo check --workspace --exclude moq-gst --all-targets {{ args }}
+
+# Runs the `#[cfg(target_os = "macos")]` code past the compiler: moq-video's
+# VideoToolbox encode/decode and its ScreenCaptureKit / AVFoundation capture,
+# plus moq-audio's ScreenCaptureKit system audio and TCC permission pre-check.
+#
+# Scoped to those two crates instead of the workspace, because they hold all
+# the Apple-gated code the Linux gate misses. moq-ffi (and through it the
+# Swift/Kotlin/Go wrappers) already compiles on macOS in swift.yml.
+# `--all-features` is required, not just tidy: moq-audio's capture backend sits
+# behind an off-by-default feature, so a plain check would skip the very code
+# this recipe exists for. moq-video's Linux-only nvenc/vaapi/nvdec/pipewire
+# deps are no-ops here.
+
+# Compile the Apple-only code paths. Must run ON macOS.
+macos *args:
+    cargo check -p moq-video -p moq-audio --all-targets --all-features {{ args }}
+
 # Full Rust CI: check + feature edge cases + tests + build. Takes a
 # newline-separated list of changed files; skips if FILES is non-empty
 # and none match the Rust scope. Run `just rs ci` (no FILES) to


### PR DESCRIPTION
## Summary

- The PR gate (`check.yml`) runs on a single `ubuntu-24.04-arm` runner, so every `#[cfg(target_os = "...")]` block for another platform is invisible to it. Windows-only code first compiled in a tag-triggered release build, long after review; macOS-only code compiled nowhere in CI at all. #2503 reshaped `Backend::encode` across every moq-video encode backend with no way to compile-verify the Media Foundation or VideoToolbox ones.
- Adds two path-filtered PR gates that delegate to new `just rs windows` / `just rs macos` recipes, per the local-first rule.
- Linux needed no gate: `just rs ci` already runs `--all-features` in a dev shell carrying pipewire/libva/alsa, so `nvenc`/`nvdec`/`vaapi`/`pipewire` all compile today. This was verified, not assumed.

### Windows (`windows.yml`)

`cargo check --workspace --exclude moq-gst --all-targets` on `windows-latest`. Native toolchain, no Nix, per the CLAUDE.md carve-out for Windows runners. Reuses `libmoq.yml`'s shape (NASM via choco for aws-lc-rs).

Default features, not `--all-features`: `moq-native` carries an optional `tikv-jemallocator` in plain `[dependencies]` (jemalloc doesn't build on MSVC) and a `quiche` feature pulling BoringSSL. Default features are also what actually ships on Windows. `moq-gst` is excluded because it links GStreamer via pkg-config.

Cross-compiling can't substitute for a real runner here: `openh264-sys2` builds vendored C++ needing an MSVC toolchain, and openh264 is non-optional.

### macOS (`macos.yml`)

`cargo check -p moq-video -p moq-audio --all-targets --all-features` on `macos-latest`.

macOS runners are the expensive ones, so this is scoped tighter than the Windows gate on both axes:

- **Trigger**: only `rs/moq-video/**`, `rs/moq-audio/**`, `rs/justfile`, `rust-toolchain.toml`. Not `rs/**`.
- **Compile**: two crates, not the workspace. Everything else shipping on macOS either has no Apple-gated code or already compiles in `swift.yml`.

`Cargo.lock` is deliberately **not** in the trigger, so a bare dependency bump doesn't spin up a Mac. The trade-off is accepted rather than overlooked: an objc2 bump inside an existing version range would break these bindings without touching either crate's `Cargo.toml`, and would surface on the merge commit rather than the PR.

`--all-features` is load-bearing rather than tidy: moq-audio's macOS ScreenCaptureKit capture sits behind an off-by-default `capture` feature, so a plain `cargo check` would skip the very code the gate exists for.

## Public API changes

None. CI and tooling only.

## Test plan

Both recipes were run on a macOS host against the rebased tree:

- `just rs macos` passes (exit 0, 3m19s). Log confirms `objc2-video-toolbox`, `objc2-screen-capture-kit`, and `objc2-av-foundation` in the compile set, so the feature selection does reach the Apple code.
- `just rs windows` passes on macOS (7m08s), which validates the flags, package set, and exclusion but not Windows itself.

Both gates then passed on their real runners in this PR's own CI: **Windows 9m11s** (the first time this workspace has compiled for `x86_64-pc-windows-msvc`; no member needed an extra `--exclude`, and `--all-targets` cleared every dev-dependency) and **macOS 2m01s**.

`actionlint`, `just --fmt --check`, and `remark` are clean.

## Notes for review

- **Neither job should be marked a required status check while path-filtered.** A required check that never runs leaves PRs pending forever. `swift.yml` already has this property.
- Because both are filtered, a change outside their trigger paths that breaks them surfaces on the merge commit rather than the PR. That is the deliberate trade for not running them on everything.
- **Known and accepted gap:** the Apple backends import from other crates (`decode/backend/videotoolbox.rs` uses `moq_net::Timestamp` and moq-mux's `NalIterator`), so a break confined to `rs/moq-net` or `rs/moq-mux` fires neither this gate nor the Linux one. Widening the macOS trigger was considered and rejected on runner cost; the rationale is recorded in `macos.yml` so it isn't re-litigated. The Windows gate has no equivalent hole, since it filters on `rs/**`.
- Neither job installs a toolchain action: `rust-toolchain.toml` pins 1.95.0 and the runners' rustup installs it on the first cargo call, so both gates compile with the same rustc as the Nix-pinned Linux one.
- `taiki-e/install-action` is new to this repo (it installs `just` on the runners). Every other action used here was already in use elsewhere.
- `rs/CLAUDE.md` gains a per-platform gate table under Testing, so the next agent doesn't have to rediscover which platforms CI actually covers.

(Written by Opus 5)
