### PR TITLE
fix(moq-net): deliver groups from a takeover source that restarted its numbering

### DIFF
--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -3676,6 +3676,65 @@ mod tests {
 		sub.assert_not_closed();
 	}
 
+	/// A replacement source that RESTARTS its group numbering (a fresh session's
+	/// fresh producer beginning at sequence 0, which is what a real reconnecting
+	/// publisher does) must still reach the spliced consumer. The resume hint
+	/// (`group_start`) is advisory for a source that resumes; it must not filter
+	/// a restarted source's groups into a permanent stall.
+	#[tokio::test(start_paused = true)]
+	async fn test_linger_reconnect_restarted_sequences_still_deliver() {
+		let origin = Info::new(Origin::random())
+			.with_linger(Duration::from_secs(5))
+			.produce();
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+
+		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let source = origin
+			.create_broadcast("test", announce().with_hops(hops.clone()))
+			.unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+		announced.assert_next_some("test");
+
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		let mut producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+		let mut sub = subscribing.await.unwrap();
+
+		producer.append_group().unwrap();
+		producer.append_group().unwrap();
+		assert_eq!(sub.assert_group().sequence, 0);
+		assert_eq!(sub.assert_group().sequence, 1);
+
+		// The session dies without unannouncing: the broadcast lingers.
+		drop(producer);
+		source.abort(Error::Dropped).unwrap();
+		drop(dynamic);
+		settle().await;
+		sub.assert_no_group();
+		sub.assert_not_closed();
+
+		// The publisher reconnects as a NEW session: fresh broadcast, fresh
+		// producer, group numbering restarted from zero.
+		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+
+		let mut producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+
+		// The restarted source publishes an event the consumer must see.
+		producer.append_group().unwrap();
+		settle().await;
+		let group = sub.assert_group();
+		assert_eq!(group.sequence, 0, "the restarted source's first group is delivered");
+		sub.assert_not_closed();
+	}
+
 	/// The linger window expiring without a replacement closes the broadcast: the
 	/// path unannounces, tracks abort, and a later re-create is a fresh broadcast.
 	#[tokio::test(start_paused = true)]

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1526,11 +1526,19 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 		Idle,
 		/// A reader arrived or the last one left: recompute the demand gate.
 		Demand,
+		/// The freshly spliced copy produced a group: decide whether its source
+		/// resumed the old numbering or restarted its own.
+		Produced(Option<u64>),
 	}
 
 	let mut fails = 0u32;
 	// The source whose copy is currently spliced in, and that copy.
 	let mut serving: Option<(u64, track::Consumer)> = None;
+	// Restart watch over the newest splice: the last production edge observed
+	// on the serving copy, and whether the resumed-vs-restarted question is
+	// already settled (see resume::Producer::reanchor_restarted).
+	let mut splice_latest: Option<u64> = None;
+	let mut splice_settled = true;
 	// A source whose splice failed because it had already closed. Its watcher is
 	// about to detach it, so wait for the table to move on rather than burning
 	// the strike budget on a corpse (ids are never reused, so this cannot wedge).
@@ -1620,6 +1628,17 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 					});
 				}
 
+				// Watch the spliced copy's production while the takeover boundary
+				// is still provisional: a replacement source that restarted its
+				// group numbering produces below the boundary, which the splice
+				// would otherwise filter forever.
+				if let Some((_, track)) = &serving
+					&& !splice_settled
+					&& let Poll::Ready(latest) = track.poll_latest_changed(splice_latest, waiter)
+				{
+					return Poll::Ready(Step::Produced(latest));
+				}
+
 				if deadline.is_some() && !fired && waiter.poll_future(sleep.as_mut()).is_ready() {
 					fired = true;
 				}
@@ -1645,6 +1664,14 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 			}
 			// The outer loop recomputes `used` and the countdown on the next pass.
 			Step::Demand => {}
+			Step::Produced(latest) => {
+				splice_latest = latest;
+				splice_settled = match resume.reanchor_restarted() {
+					Ok(super::resume::Reanchor::Pending) => false,
+					Ok(_) => true,
+					Err(_) => return,
+				};
+			}
 			Step::Idle => {
 				// Nobody has read the track for the linger: drop the source's copy so
 				// its session can release the track (and the cached `track::Info` that
@@ -1705,6 +1732,15 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 							// aborted); nothing left to serve.
 							return;
 						}
+						// Arm the restart watch: the source may have produced
+						// before the splice (decide now) or produce later
+						// (decide on the production edge).
+						splice_latest = track.latest();
+						splice_settled = match resume.reanchor_restarted() {
+							Ok(super::resume::Reanchor::Pending) => false,
+							Ok(_) => true,
+							Err(_) => return,
+						};
 						// A successful splice proves the track servable: reset
 						// the strike budget.
 						fails = 0;
@@ -3152,16 +3188,24 @@ mod tests {
 		settle().await;
 		announced.assert_next_wait();
 
-		// The new copy resumes one past the spliced groups: its demand starts at
-		// the boundary, and groups the old source already delivered are filtered.
+		// The new copy resumes one past the spliced groups. Its floor is
+		// provisional until it produces in range (a reconnecting source may
+		// have restarted its numbering), so demand stays open; the read
+		// cursor still filters groups the old source already delivered.
 		let mut producer = accept_track(&mut dynamic_b, "video").await;
 		settle().await;
 		sub.assert_no_group();
-		assert_eq!(producer.subscription().unwrap().group_start, Some(2));
+		assert_eq!(producer.subscription().unwrap().group_start, None);
 		producer.create_group(group::Info { sequence: 1 }).unwrap();
 		producer.create_group(group::Info { sequence: 2 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 2, "groups below the boundary are filtered");
 		sub.assert_not_closed();
+
+		// The in-range production resolved the splice: the boundary is
+		// promoted into wire demand.
+		settle().await;
+		sub.assert_no_group();
+		assert_eq!(producer.subscription().unwrap().group_start, Some(2));
 	}
 
 	/// `route_changed` yields the current route first, then each change; equal
@@ -3250,13 +3294,20 @@ mod tests {
 
 		let mut producer_b = accept_track(&mut dynamic_b, "video").await;
 		settle().await;
-		// Demand registers as the subscriber polls; the new segment starts at the
-		// splice boundary.
+		// Demand registers as the subscriber polls. The new segment's floor is
+		// provisional until it produces in range (a reconnecting source may
+		// have restarted its numbering), so demand stays open at first.
 		sub.assert_no_group();
-		assert_eq!(producer_b.subscription().unwrap().group_start, Some(1));
+		assert_eq!(producer_b.subscription().unwrap().group_start, None);
 		producer_b.create_group(group::Info { sequence: 1 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 1);
 		sub.assert_not_closed();
+
+		// The in-range production resolved the splice: the boundary is
+		// promoted into wire demand.
+		settle().await;
+		sub.assert_no_group();
+		assert_eq!(producer_b.subscription().unwrap().group_start, Some(1));
 
 		// The active source updating its own metadata re-advertises in place.
 		source_b
@@ -3396,11 +3447,14 @@ mod tests {
 		let mut producer_b = accept_track(&mut dynamic_b, "video").await;
 		settle().await;
 
-		// The old copy's demand is capped at the boundary; the new copy's starts
-		// there. Both propagate as the subscriber polls.
+		// The old copy's demand is capped at the boundary. The new copy's
+		// splice is PROVISIONAL: its floor stays out of wire demand until the
+		// source's first production proves it resumes the old numbering (a
+		// restarted source would never number past the boundary and a floored
+		// subscription would starve it; see resume::Producer::reanchor_restarted).
 		sub.assert_no_group();
 		assert_eq!(producer_a.subscription().unwrap().group_end, Some(1));
-		assert_eq!(producer_b.subscription().unwrap().group_start, Some(2));
+		assert_eq!(producer_b.subscription().unwrap().group_start, None);
 
 		// The old copy racing past its cap is filtered; the new copy serves on.
 		producer_a.create_group(group::Info { sequence: 2 }).unwrap();
@@ -3410,6 +3464,12 @@ mod tests {
 		assert_eq!(sub.assert_group().sequence, 3);
 		sub.assert_no_group();
 		sub.assert_not_closed();
+
+		// Producing at the boundary resolved the splice: the boundary is
+		// promoted into wire demand.
+		settle().await;
+		sub.assert_no_group();
+		assert_eq!(producer_b.subscription().unwrap().group_start, Some(2));
 	}
 
 	/// A graceful detach (deliberate unannounce) closes immediately: no linger, so
@@ -3665,15 +3725,22 @@ mod tests {
 		assert!(again.is_clone(&broadcast), "the reconnect must splice, not replace");
 
 		// The pending track re-splices from the new source and resumes one past
-		// the groups the old source already delivered. Demand registers as the
-		// subscriber polls.
+		// the groups the old source already delivered. The floor is provisional
+		// (a reconnecting source may have restarted its numbering), so demand
+		// stays open until the first production proves the resume.
 		let mut producer = accept_track(&mut dynamic, "video").await;
 		settle().await;
 		sub.assert_no_group();
-		assert_eq!(producer.subscription().unwrap().group_start, Some(2));
+		assert_eq!(producer.subscription().unwrap().group_start, None);
 		producer.create_group(group::Info { sequence: 2 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 2);
 		sub.assert_not_closed();
+
+		// The in-range production resolved the splice: the boundary is
+		// promoted into wire demand.
+		settle().await;
+		sub.assert_no_group();
+		assert_eq!(producer.subscription().unwrap().group_start, Some(2));
 	}
 
 	/// A replacement source that RESTARTS its group numbering (a fresh session's

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -23,6 +23,11 @@ use crate::{
 /// Local origins are built with [`Origin::new`] or [`Origin::random`], both of
 /// which guarantee a non-zero id so loop detection can work. Remote peers may
 /// still send `0`; it is legal on the wire but cannot be used for loop detection.
+///
+/// An id identifies one producer instance and its sequence space: the first
+/// hop of an announce tells consumers whether a replacement source continues
+/// the previous broadcast or restarts it, so mint a fresh id per session
+/// rather than reusing one across restarts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Origin {
 	/// 62-bit identifier. Encoded as a QUIC varint on the wire.
@@ -1519,21 +1524,26 @@ async fn run_front(
 async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resume: super::resume::Producer) {
 	enum Step {
 		Closed,
-		Splice(u64, broadcast::Consumer),
+		Splice(u64, broadcast::Consumer, Option<Origin>),
 		Complete,
 		Failed,
 		/// The linger expired with the track still unread: release the segment.
 		Idle,
 		/// A reader arrived or the last one left: recompute the demand gate.
 		Demand,
-		/// The freshly spliced copy produced: resolve resumed vs restarted.
+		/// The freshly spliced copy produced: check the splice boundary once.
 		Produced(Option<u64>),
 	}
 
 	let mut fails = 0u32;
 	// The source whose copy is currently spliced in, and that copy.
 	let mut serving: Option<(u64, track::Consumer)> = None;
-	// Restart watch over the newest splice (resume::Producer::reanchor_restarted).
+	// The first hop of the route whose copy was last spliced in: the
+	// producer-instance identity that gates takeover vs reset. Outlives the
+	// source's death, since the linger replacement arrives after it.
+	let mut last_first_hop: Option<Origin> = None;
+	// One-shot watch over a fresh boundary splice, warning if the source
+	// violates the identity contract by producing below the boundary.
 	let mut splice_latest: Option<u64> = None;
 	let mut splice_settled = true;
 	// A source whose splice failed because it had already closed. Its watcher is
@@ -1589,14 +1599,13 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 							return Poll::Ready(Step::Closed);
 						}
 						let active = guard.active.expect("predicate guaranteed an active source");
-						let source = guard
+						let route = guard
 							.routes
 							.iter()
 							.find(|r| r.id == active)
-							.expect("active source in table")
-							.source
-							.clone();
-						return Poll::Ready(Step::Splice(active, source));
+							.expect("active source in table");
+						let first_hop = route.route.hops.iter().next().copied();
+						return Poll::Ready(Step::Splice(active, route.source.clone(), first_hop));
 					}
 					Poll::Ready(Err(_)) => return Poll::Ready(Step::Closed),
 					Poll::Pending => {}
@@ -1625,8 +1634,8 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 					});
 				}
 
-				// While the takeover boundary is provisional, watch the copy's
-				// production to resolve resumed vs restarted.
+				// Watch a fresh boundary splice's first production for an
+				// identity-contract violation (warn only).
 				if let Some((_, track)) = &serving
 					&& !splice_settled
 					&& let Poll::Ready(latest) = track.poll_latest_changed(splice_latest, waiter)
@@ -1661,11 +1670,21 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 			Step::Demand => {}
 			Step::Produced(latest) => {
 				splice_latest = latest;
-				splice_settled = match resume.reanchor_restarted() {
-					Ok(super::resume::Reanchor::Pending) => false,
-					Ok(_) => true,
-					Err(_) => return,
-				};
+				splice_settled = true;
+				if let (Some(latest), Some(boundary)) = (latest, resume.splice_boundary())
+					&& latest < boundary
+				{
+					// The identity contract says a same-hop source resumes the
+					// old numbering; producing below the boundary means these
+					// groups are never delivered. Mint origin ids per producer
+					// instance to take the reset path instead.
+					tracing::warn!(
+						name = %name,
+						latest,
+						boundary,
+						"takeover source with an unchanged identity produced below the splice boundary",
+					);
+				}
 			}
 			Step::Idle => {
 				// Nobody has read the track for the linger: drop the source's copy so
@@ -1678,7 +1697,7 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 				}
 				serving = None;
 			}
-			Step::Splice(id, source) => {
+			Step::Splice(id, source, first_hop) => {
 				// Ask the source for its copy and wait for the info to resolve,
 				// proving it servable, before splicing it in. Bail out early if
 				// the table moves on while waiting.
@@ -1722,19 +1741,29 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 
 				match attempt {
 					Ok(track) => {
-						if resume.takeover(&track).is_err() {
+						// The first hop is the producer-instance identity: the
+						// same instance resumes the old sequence space and is
+						// spliced at the boundary, while a new instance is a
+						// new broadcast with its own numbering, so the logical
+						// track resets onto it (see resume::Producer::reset_onto).
+						let continuous = match (first_hop, last_first_hop) {
+							(Some(new), Some(old)) => new == old,
+							_ => true,
+						};
+						let spliced = match continuous {
+							true => resume.takeover(&track),
+							false => resume.reset_onto(&track),
+						};
+						if spliced.is_err() {
 							// The logical track already ended (finished or
 							// aborted); nothing left to serve.
 							return;
 						}
-						// The source may have produced before the splice;
-						// otherwise the production watch decides later.
+						last_first_hop = first_hop;
+						// Arm the contract watch while the splice has a
+						// boundary the source could violate.
 						splice_latest = track.latest();
-						splice_settled = match resume.reanchor_restarted() {
-							Ok(super::resume::Reanchor::Pending) => false,
-							Ok(_) => true,
-							Err(_) => return,
-						};
+						splice_settled = resume.splice_boundary().is_none();
 						// A successful splice proves the track servable: reset
 						// the strike budget.
 						fails = 0;
@@ -3132,14 +3161,20 @@ mod tests {
 	/// source and resumes exactly at the first missing group.
 	#[tokio::test]
 	async fn test_route_failover() {
+		// Both routes originate from producer 9; the suffixes differ.
 		tokio::time::pause();
 
 		let origin = Origin::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
-		let hops_a = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let hops_b = OriginList::try_from(vec![Origin::new(2).unwrap(), Origin::new(3).unwrap()]).unwrap();
+		let hops_a = OriginList::try_from(vec![Origin::new(9).unwrap(), Origin::new(1).unwrap()]).unwrap();
+		let hops_b = OriginList::try_from(vec![
+			Origin::new(9).unwrap(),
+			Origin::new(2).unwrap(),
+			Origin::new(3).unwrap(),
+		])
+		.unwrap();
 
 		// The first source announces the broadcast.
 		let source_a = origin.create_broadcast("test", announce().with_hops(hops_a)).unwrap();
@@ -3182,24 +3217,16 @@ mod tests {
 		settle().await;
 		announced.assert_next_wait();
 
-		// The new copy resumes one past the spliced groups. Its floor is
-		// provisional until it produces in range (a reconnecting source may
-		// have restarted its numbering), so demand stays open; the read
-		// cursor still filters groups the old source already delivered.
+		// The new copy resumes one past the spliced groups: its demand starts at
+		// the boundary, and groups the old source already delivered are filtered.
 		let mut producer = accept_track(&mut dynamic_b, "video").await;
 		settle().await;
 		sub.assert_no_group();
-		assert_eq!(producer.subscription().unwrap().group_start, None);
+		assert_eq!(producer.subscription().unwrap().group_start, Some(2));
 		producer.create_group(group::Info { sequence: 1 }).unwrap();
 		producer.create_group(group::Info { sequence: 2 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 2, "groups below the boundary are filtered");
 		sub.assert_not_closed();
-
-		// The in-range production resolved the splice: the boundary is
-		// promoted into wire demand.
-		settle().await;
-		sub.assert_no_group();
-		assert_eq!(producer.subscription().unwrap().group_start, Some(2));
 	}
 
 	/// `route_changed` yields the current route first, then each change; equal
@@ -3235,6 +3262,7 @@ mod tests {
 	/// churn.
 	#[tokio::test]
 	async fn test_route_cost_update() {
+		// Both routes originate from producer 9; the suffixes differ.
 		tokio::time::pause();
 
 		// The takeover happens while a subscriber is live (carrying), so the local
@@ -3244,8 +3272,13 @@ mod tests {
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
-		let hops_a = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let hops_b = OriginList::try_from(vec![Origin::new(2).unwrap(), Origin::new(3).unwrap()]).unwrap();
+		let hops_a = OriginList::try_from(vec![Origin::new(9).unwrap(), Origin::new(1).unwrap()]).unwrap();
+		let hops_b = OriginList::try_from(vec![
+			Origin::new(9).unwrap(),
+			Origin::new(2).unwrap(),
+			Origin::new(3).unwrap(),
+		])
+		.unwrap();
 
 		// A (shorter chain) wins at equal cost.
 		let mut source_a = origin
@@ -3288,20 +3321,13 @@ mod tests {
 
 		let mut producer_b = accept_track(&mut dynamic_b, "video").await;
 		settle().await;
-		// Demand registers as the subscriber polls. The new segment's floor is
-		// provisional until it produces in range (a reconnecting source may
-		// have restarted its numbering), so demand stays open at first.
+		// Demand registers as the subscriber polls; the new segment starts at the
+		// splice boundary.
 		sub.assert_no_group();
-		assert_eq!(producer_b.subscription().unwrap().group_start, None);
+		assert_eq!(producer_b.subscription().unwrap().group_start, Some(1));
 		producer_b.create_group(group::Info { sequence: 1 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 1);
 		sub.assert_not_closed();
-
-		// The in-range production resolved the splice: the boundary is
-		// promoted into wire demand.
-		settle().await;
-		sub.assert_no_group();
-		assert_eq!(producer_b.subscription().unwrap().group_start, Some(1));
 
 		// The active source updating its own metadata re-advertises in place.
 		source_b
@@ -3401,14 +3427,20 @@ mod tests {
 	/// starts at the boundary, and the subscriber reads a seamless sequence.
 	#[tokio::test]
 	async fn test_route_handover() {
+		// Both routes originate from producer 9; the suffixes differ.
 		tokio::time::pause();
 
 		let origin = Origin::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
-		let hops_long = OriginList::try_from(vec![Origin::new(2).unwrap(), Origin::new(3).unwrap()]).unwrap();
-		let hops_short = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let hops_long = OriginList::try_from(vec![
+			Origin::new(9).unwrap(),
+			Origin::new(2).unwrap(),
+			Origin::new(3).unwrap(),
+		])
+		.unwrap();
+		let hops_short = OriginList::try_from(vec![Origin::new(9).unwrap(), Origin::new(1).unwrap()]).unwrap();
 
 		let source_a = origin
 			.create_broadcast("test", announce().with_hops(hops_long))
@@ -3441,14 +3473,11 @@ mod tests {
 		let mut producer_b = accept_track(&mut dynamic_b, "video").await;
 		settle().await;
 
-		// The old copy's demand is capped at the boundary. The new copy's
-		// splice is PROVISIONAL: its floor stays out of wire demand until the
-		// source's first production proves it resumes the old numbering (a
-		// restarted source would never number past the boundary and a floored
-		// subscription would starve it; see resume::Producer::reanchor_restarted).
+		// The old copy's demand is capped at the boundary; the new copy's starts
+		// there. Both propagate as the subscriber polls.
 		sub.assert_no_group();
 		assert_eq!(producer_a.subscription().unwrap().group_end, Some(1));
-		assert_eq!(producer_b.subscription().unwrap().group_start, None);
+		assert_eq!(producer_b.subscription().unwrap().group_start, Some(2));
 
 		// The old copy racing past its cap is filtered; the new copy serves on.
 		producer_a.create_group(group::Info { sequence: 2 }).unwrap();
@@ -3458,12 +3487,6 @@ mod tests {
 		assert_eq!(sub.assert_group().sequence, 3);
 		sub.assert_no_group();
 		sub.assert_not_closed();
-
-		// Producing at the boundary resolved the splice: the boundary is
-		// promoted into wire demand.
-		settle().await;
-		sub.assert_no_group();
-		assert_eq!(producer_b.subscription().unwrap().group_start, Some(2));
 	}
 
 	/// A graceful detach (deliberate unannounce) closes immediately: no linger, so
@@ -3719,22 +3742,15 @@ mod tests {
 		assert!(again.is_clone(&broadcast), "the reconnect must splice, not replace");
 
 		// The pending track re-splices from the new source and resumes one past
-		// the groups the old source already delivered. The floor is provisional
-		// (a reconnecting source may have restarted its numbering), so demand
-		// stays open until the first production proves the resume.
+		// the groups the old source already delivered. Demand registers as the
+		// subscriber polls.
 		let mut producer = accept_track(&mut dynamic, "video").await;
 		settle().await;
 		sub.assert_no_group();
-		assert_eq!(producer.subscription().unwrap().group_start, None);
+		assert_eq!(producer.subscription().unwrap().group_start, Some(2));
 		producer.create_group(group::Info { sequence: 2 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 2);
 		sub.assert_not_closed();
-
-		// The in-range production resolved the splice: the boundary is
-		// promoted into wire demand.
-		settle().await;
-		sub.assert_no_group();
-		assert_eq!(producer.subscription().unwrap().group_start, Some(2));
 	}
 
 	/// A replacement source that RESTARTS its group numbering (a fresh session's
@@ -3780,7 +3796,9 @@ mod tests {
 
 		// The publisher reconnects as a NEW session: fresh broadcast, fresh
 		// producer, group numbering restarted from zero.
-		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		// A reconnecting publisher is a fresh session with a fresh identity.
+		let rehops = OriginList::try_from(vec![Origin::new(2).unwrap()]).unwrap();
+		let source = origin.create_broadcast("test", announce().with_hops(rehops)).unwrap();
 		let mut dynamic = source.dynamic();
 		settle().await;
 		settle().await;
@@ -3837,7 +3855,9 @@ mod tests {
 		// The publisher reconnects as a NEW session with restarted numbering,
 		// and a LATE subscriber joins with a floor resolved against the old
 		// numbering (what a relay's run_subscribe computes from `latest()`).
-		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		// A reconnecting publisher is a fresh session with a fresh identity.
+		let rehops = OriginList::try_from(vec![Origin::new(2).unwrap()]).unwrap();
+		let source = origin.create_broadcast("test", announce().with_hops(rehops)).unwrap();
 		let mut dynamic = source.dynamic();
 		settle().await;
 		settle().await;

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1526,17 +1526,14 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 		Idle,
 		/// A reader arrived or the last one left: recompute the demand gate.
 		Demand,
-		/// The freshly spliced copy produced a group: decide whether its source
-		/// resumed the old numbering or restarted its own.
+		/// The freshly spliced copy produced: resolve resumed vs restarted.
 		Produced(Option<u64>),
 	}
 
 	let mut fails = 0u32;
 	// The source whose copy is currently spliced in, and that copy.
 	let mut serving: Option<(u64, track::Consumer)> = None;
-	// Restart watch over the newest splice: the last production edge observed
-	// on the serving copy, and whether the resumed-vs-restarted question is
-	// already settled (see resume::Producer::reanchor_restarted).
+	// Restart watch over the newest splice (resume::Producer::reanchor_restarted).
 	let mut splice_latest: Option<u64> = None;
 	let mut splice_settled = true;
 	// A source whose splice failed because it had already closed. Its watcher is
@@ -1628,10 +1625,8 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 					});
 				}
 
-				// Watch the spliced copy's production while the takeover boundary
-				// is still provisional: a replacement source that restarted its
-				// group numbering produces below the boundary, which the splice
-				// would otherwise filter forever.
+				// While the takeover boundary is provisional, watch the copy's
+				// production to resolve resumed vs restarted.
 				if let Some((_, track)) = &serving
 					&& !splice_settled
 					&& let Poll::Ready(latest) = track.poll_latest_changed(splice_latest, waiter)
@@ -1732,9 +1727,8 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 							// aborted); nothing left to serve.
 							return;
 						}
-						// Arm the restart watch: the source may have produced
-						// before the splice (decide now) or produce later
-						// (decide on the production edge).
+						// The source may have produced before the splice;
+						// otherwise the production watch decides later.
 						splice_latest = track.latest();
 						splice_settled = match resume.reanchor_restarted() {
 							Ok(super::resume::Reanchor::Pending) => false,
@@ -3800,6 +3794,66 @@ mod tests {
 		let group = sub.assert_group();
 		assert_eq!(group.sequence, 0, "the restarted source's first group is delivered");
 		sub.assert_not_closed();
+	}
+
+	/// A subscriber that late-joins between the takeover and the restarted
+	/// source's first production carries a floor resolved against the old
+	/// numbering; the era bump must reset it or the restarted groups are
+	/// filtered forever.
+	#[tokio::test(start_paused = true)]
+	async fn test_linger_restart_resets_late_join_floors() {
+		let origin = Info::new(Origin::random())
+			.with_linger(Duration::from_secs(5))
+			.produce();
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+
+		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let source = origin
+			.create_broadcast("test", announce().with_hops(hops.clone()))
+			.unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+		announced.assert_next_some("test");
+
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		let mut producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+		let mut sub = subscribing.await.unwrap();
+		producer.append_group().unwrap();
+		producer.append_group().unwrap();
+		producer.append_group().unwrap();
+		producer.append_group().unwrap();
+		assert_eq!(sub.assert_group().sequence, 0);
+
+		// The session dies without unannouncing: the broadcast lingers.
+		drop(producer);
+		source.abort(Error::Dropped).unwrap();
+		drop(dynamic);
+		settle().await;
+
+		// The publisher reconnects as a NEW session with restarted numbering,
+		// and a LATE subscriber joins with a floor resolved against the old
+		// numbering (what a relay's run_subscribe computes from `latest()`).
+		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+		let mut late = broadcast.track("video").unwrap().subscribe(None).await.unwrap();
+		late.start_at(3);
+
+		let mut producer = accept_track(&mut dynamic, "video").await;
+		settle().await;
+		producer.append_group().unwrap();
+		settle().await;
+
+		// The era change resets the stale floor: the restarted source's first
+		// group reaches the late subscriber instead of being filtered below it.
+		let group = late.assert_group();
+		assert_eq!(group.sequence, 0, "the restarted numbering resets late-join floors");
+		late.assert_not_closed();
 	}
 
 	/// The linger window expiring without a replacement closes the broadcast: the

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -30,11 +30,9 @@ struct Segment {
 	/// newest segment.
 	end: Option<u64>,
 	/// A takeover splice whose source has not yet proven it resumes the old
-	/// group numbering. The boundary binds the read cursor but stays out of
-	/// wire demand: a floored subscription would ask a RESTARTED source
-	/// (fresh session, numbering from zero) for groups it will never number,
-	/// starving it silently. Resolved by `Producer::reanchor_restarted` on
-	/// the source's first production.
+	/// numbering: the boundary binds the read cursor but stays out of wire
+	/// demand (a floored subscription would starve a source that restarted
+	/// from zero). Resolved by [`Producer::reanchor_restarted`].
 	provisional: bool,
 	/// The underlying per-session track.
 	track: track::Consumer,
@@ -57,8 +55,7 @@ impl Segment {
 		})
 	}
 
-	/// The lower bound to fold into wire demand: the segment's start, unless
-	/// the splice is still provisional (see the field doc).
+	/// The segment's start, unless the splice is still provisional.
 	fn demand_start(&self) -> Option<u64> {
 		match self.provisional {
 			true => None,
@@ -68,12 +65,8 @@ impl Segment {
 }
 
 /// The demand to register on an underlying track: the subscriber's own
-/// preferences intersected with a segment's bounds.
-///
-/// Callers pass a PROVISIONAL segment's start as `None` (see
-/// [`Segment::demand_start`]): its boundary is enforced on the read cursor
-/// only, never in wire demand, until the source proves it resumed the old
-/// numbering.
+/// preferences intersected with a segment's bounds (`start` comes from
+/// [`Segment::demand_start`], so a provisional boundary stays out of it).
 fn slice(prefs: &Subscription, start: Option<u64>, end: Option<u64>) -> Subscription {
 	let mut sub = prefs.clone();
 	sub.group_start = match (prefs.group_start, start) {
@@ -90,6 +83,9 @@ struct ResumeState {
 	segments: Vec<Segment>,
 	/// Bumped on every mutation so subscribers know to reconcile.
 	epoch: u64,
+	/// The sequence-numbering era, bumped only by a restart reanchor:
+	/// cursors anchored in the old numbering reset with it.
+	era: u64,
 	/// No more switches will happen; the logical track ends with its last segment.
 	finished: bool,
 	/// The logical track was aborted; surfaced to every subscriber.
@@ -101,6 +97,7 @@ impl Default for ResumeState {
 		Self {
 			segments: Vec::new(),
 			epoch: 1,
+			era: 0,
 			finished: false,
 			abort: None,
 		}
@@ -155,17 +152,13 @@ impl ResumeState {
 	}
 }
 
-/// Outcome of [`Producer::reanchor_restarted`]: whether the newest spliced
-/// segment's source proved itself resumed, restarted, or undecided.
+/// Outcome of [`Producer::reanchor_restarted`].
 pub(crate) enum Reanchor {
-	/// The source produced below the splice boundary: it restarted its group
-	/// numbering, and the splice was reset onto it alone (unbounded), so
-	/// subscribers reconcile onto the restarted sequence space.
+	/// The source restarted its numbering; the splice was reset onto it.
 	Restarted,
-	/// The source produced at or past the boundary: it genuinely resumed the
-	/// old numbering, and the splice stands.
+	/// The source resumed the old numbering; the splice stands.
 	Resumed,
-	/// The source has not produced anything yet; check again on production.
+	/// Nothing decisive produced yet; check again on production.
 	Pending,
 }
 
@@ -245,29 +238,16 @@ impl Producer {
 				None => Some(0),
 			}
 		};
-		// Provisional: the replacement reacted to a route LOSS, so whether it
-		// resumes the old numbering or restarted its own is unknown until it
-		// produces (`Self::reanchor_restarted`). Until then the boundary binds
-		// the read cursor only, keeping wire demand open so a restarted
-		// source's groups still arrive.
+		// Provisional: whether the replacement resumes the old numbering or
+		// restarted its own is unknown until it produces.
 		state.switch(track, start, true)
 	}
 
-	/// Reconcile a takeover whose replacement source RESTARTED its group
-	/// numbering instead of resuming the old one.
-	///
-	/// [`Self::takeover`] splices the replacement at one past the newest
-	/// delivered group, assuming the source shares the old sequence space. A
-	/// source that restarted (a reconnecting publisher with a fresh session
-	/// numbers from zero) only ever produces below that boundary, and the
-	/// splice would filter every group it publishes forever. Once the source's
-	/// first production shows which case this is, a restart drops the stale
-	/// history segments and re-splices the source unbounded: subscribers
-	/// reconcile onto its own numbering (a sequence regression, surfaced like
-	/// any other new-segment switch).
-	///
-	/// Idempotent and cheap; the serving loop calls it on every production
-	/// edge of a freshly spliced track until it returns a decided value.
+	/// Resolve a provisional takeover off its source's first production: a
+	/// resume promotes the boundary into wire demand, a restart (a fresh
+	/// session numbering from zero) resets the splice onto the source alone
+	/// so subscribers reconcile onto its own numbering. Idempotent; the
+	/// serving loop calls it on each production edge until decided.
 	pub(crate) fn reanchor_restarted(&mut self) -> Result<Reanchor> {
 		let mut state = self.state.write().map_err(|_| Error::Dropped)?;
 		if state.finished || state.abort.is_some() {
@@ -280,36 +260,26 @@ impl Producer {
 			return Ok(Reanchor::Resumed);
 		}
 		let Some(start) = newest.start else {
-			// Unbounded (the first splice): whatever the source numbers is
-			// what subscribers get, so there is nothing to resolve.
+			// Unbounded: nothing to resolve.
 			return Ok(Reanchor::Resumed);
 		};
 		let Some(latest) = newest.track.latest() else {
 			return Ok(Reanchor::Pending);
 		};
 		if latest >= start {
-			// The source resumed the old numbering: the boundary is real, so
-			// promote it into wire demand (subscribers re-slice on the epoch
-			// bump).
+			// Proven resume: promote the boundary into wire demand.
 			state.segments.last_mut().expect("checked above").provisional = false;
 			state.epoch += 1;
 			return Ok(Reanchor::Resumed);
 		}
 		if latest != 0 || start < 2 {
-			// Below the boundary but not numbering from zero: a resumed source
-			// re-delivering history it already produced (an unfloored
-			// subscription joins at the source's own latest). The cursor
-			// filters it; keep watching for the deciding production. A
-			// boundary of one is the ambiguous corner (sequence zero is both
-			// "restarted" and "re-delivered"), resolved as a resume: a
-			// genuinely restarted source recovers at its next group anyway,
-			// which lands on the boundary.
+			// Re-delivered history from a resumed source, or the ambiguous
+			// boundary-of-one corner (a restarted source recovers at its next
+			// group there anyway). The cursor filters it; keep watching.
 			return Ok(Reanchor::Pending);
 		}
-		// Restarted numbering (a fresh session counts from zero): reset the
-		// splice onto the new source alone. A fresh segment id (not a mutated
-		// bound) makes every subscriber drop its old cursors and subscribe
-		// this one without a floor.
+		// Restarted numbering: reset the splice onto the new source alone. A
+		// fresh segment id makes every subscriber re-subscribe unfloored.
 		let track = newest.track.clone();
 		state.segments.clear();
 		let id = state.epoch;
@@ -321,6 +291,7 @@ impl Producer {
 			track,
 		});
 		state.epoch += 1;
+		state.era += 1;
 		Ok(Reanchor::Restarted)
 	}
 
@@ -429,6 +400,7 @@ impl Consumer {
 			prefs,
 			last_prefs,
 			epoch: 0,
+			era: 0,
 			finished: false,
 			abort: None,
 			segments: Vec::new(),
@@ -552,8 +524,7 @@ struct SegmentSub {
 	id: u64,
 	start: Option<u64>,
 	end: Option<u64>,
-	/// The wire-demand floor: `start` once the segment is authoritative,
-	/// `None` while a takeover splice is provisional (see `Segment`).
+	/// The wire-demand floor: `None` while the splice is provisional.
 	demand_start: Option<u64>,
 	sub: SubState,
 	/// A received group held back by the subscriber's [`Subscriber::end_at`] cap,
@@ -590,6 +561,8 @@ pub struct Subscriber {
 
 	/// Last observed producer epoch; a mismatch triggers a reconcile.
 	epoch: u64,
+	/// Last observed numbering era; a change resets the sequence cursors.
+	era: u64,
 	finished: bool,
 	abort: Option<Error>,
 
@@ -640,7 +613,13 @@ impl Subscriber {
 			// the poll so its state borrow ends with this statement.
 			let (snapshot, closed) = match self.state.poll(waiter, |state| {
 				if state.epoch != epoch {
-					Poll::Ready((state.epoch, state.finished, state.abort.clone(), state.segments.clone()))
+					Poll::Ready((
+						state.epoch,
+						state.era,
+						state.finished,
+						state.abort.clone(),
+						state.segments.clone(),
+					))
 				} else {
 					Poll::Pending
 				}
@@ -649,8 +628,15 @@ impl Subscriber {
 				// The producer is gone; the state is frozen, so reconcile one last
 				// time and stop watching (existing segments can still drain).
 				Poll::Ready(Err(state)) => {
-					let snapshot = (state.epoch != epoch)
-						.then(|| (state.epoch, state.finished, state.abort.clone(), state.segments.clone()));
+					let snapshot = (state.epoch != epoch).then(|| {
+						(
+							state.epoch,
+							state.era,
+							state.finished,
+							state.abort.clone(),
+							state.segments.clone(),
+						)
+					});
 					(snapshot, true)
 				}
 				// Unchanged, and the waiter is now registered for the next switch.
@@ -669,11 +655,19 @@ impl Subscriber {
 
 	/// Apply a producer snapshot: move boundaries on known segments and subscribe
 	/// to new ones.
-	fn apply(&mut self, snapshot: (u64, bool, Option<Error>, Vec<Segment>)) {
-		let (epoch, finished, abort, segments) = snapshot;
+	fn apply(&mut self, snapshot: (u64, u64, bool, Option<Error>, Vec<Segment>)) {
+		let (epoch, era, finished, abort, segments) = snapshot;
 		self.epoch = epoch;
 		self.finished = finished;
 		self.abort = abort;
+		if era != self.era {
+			// The numbering restarted: floors anchored in the old numbering
+			// (like a late-join start resolved against the previous latest)
+			// would filter the new sequence space forever.
+			self.era = era;
+			self.next_sequence = 0;
+			self.min_sequence = 0;
+		}
 
 		// Segments removed by the producer (replaced before producing anything).
 		self.segments.retain(|s| segments.iter().any(|n| n.id == s.id));
@@ -687,9 +681,8 @@ impl Subscriber {
 						existing.demand_start = demand_start;
 						if let SubState::Active(sub) = &mut existing.sub {
 							sub.end_at(min_some(segment.end, self.end_sequence));
-							// Also re-shape the demand: a moved cap shrinks it,
-							// and a resolved provisional splice promotes the
-							// boundary upstream.
+							// Re-shape the demand: a moved cap shrinks it, a
+							// resolved splice promotes the boundary upstream.
 							let _ = sub.update(slice(&self.last_prefs, demand_start, segment.end));
 						}
 						// A still-pending subscription picks the moved boundary up

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -29,6 +29,13 @@ struct Segment {
 	/// Last group this segment serves (inclusive), or `None` while it is the
 	/// newest segment.
 	end: Option<u64>,
+	/// A takeover splice whose source has not yet proven it resumes the old
+	/// group numbering. The boundary binds the read cursor but stays out of
+	/// wire demand: a floored subscription would ask a RESTARTED source
+	/// (fresh session, numbering from zero) for groups it will never number,
+	/// starving it silently. Resolved by `Producer::reanchor_restarted` on
+	/// the source's first production.
+	provisional: bool,
 	/// The underlying per-session track.
 	track: track::Consumer,
 }
@@ -49,10 +56,24 @@ impl Segment {
 			None => latest,
 		})
 	}
+
+	/// The lower bound to fold into wire demand: the segment's start, unless
+	/// the splice is still provisional (see the field doc).
+	fn demand_start(&self) -> Option<u64> {
+		match self.provisional {
+			true => None,
+			false => self.start,
+		}
+	}
 }
 
 /// The demand to register on an underlying track: the subscriber's own
 /// preferences intersected with a segment's bounds.
+///
+/// Callers pass a PROVISIONAL segment's start as `None` (see
+/// [`Segment::demand_start`]): its boundary is enforced on the read cursor
+/// only, never in wire demand, until the source proves it resumed the old
+/// numbering.
 fn slice(prefs: &Subscription, start: Option<u64>, end: Option<u64>) -> Subscription {
 	let mut sub = prefs.clone();
 	sub.group_start = match (prefs.group_start, start) {
@@ -94,7 +115,7 @@ impl ResumeState {
 
 	/// Append a segment serving groups from `start` onward, capping (or replacing)
 	/// the previous segments so the ranges stay disjoint and ascending.
-	fn switch(&mut self, track: track::Consumer, start: Option<u64>) -> Result<()> {
+	fn switch(&mut self, track: track::Consumer, start: Option<u64>, provisional: bool) -> Result<()> {
 		if !self.segments.is_empty() {
 			// A boundary is required once a segment exists.
 			let Some(start) = start else {
@@ -126,11 +147,26 @@ impl ResumeState {
 			id,
 			start,
 			end: None,
+			provisional,
 			track,
 		});
 		self.epoch += 1;
 		Ok(())
 	}
+}
+
+/// Outcome of [`Producer::reanchor_restarted`]: whether the newest spliced
+/// segment's source proved itself resumed, restarted, or undecided.
+pub(crate) enum Reanchor {
+	/// The source produced below the splice boundary: it restarted its group
+	/// numbering, and the splice was reset onto it alone (unbounded), so
+	/// subscribers reconcile onto the restarted sequence space.
+	Restarted,
+	/// The source produced at or past the boundary: it genuinely resumed the
+	/// old numbering, and the splice stands.
+	Resumed,
+	/// The source has not produced anything yet; check again on production.
+	Pending,
 }
 
 /// Splices tracks into one logical track by switching at group boundaries.
@@ -180,7 +216,7 @@ impl Producer {
 		if state.finished || state.abort.is_some() {
 			return Err(Error::Closed);
 		}
-		state.switch(track, start)
+		state.switch(track, start, false)
 	}
 
 	/// Splice in a track that resumes wherever the current segments stop: one past
@@ -209,7 +245,83 @@ impl Producer {
 				None => Some(0),
 			}
 		};
-		state.switch(track, start)
+		// Provisional: the replacement reacted to a route LOSS, so whether it
+		// resumes the old numbering or restarted its own is unknown until it
+		// produces (`Self::reanchor_restarted`). Until then the boundary binds
+		// the read cursor only, keeping wire demand open so a restarted
+		// source's groups still arrive.
+		state.switch(track, start, true)
+	}
+
+	/// Reconcile a takeover whose replacement source RESTARTED its group
+	/// numbering instead of resuming the old one.
+	///
+	/// [`Self::takeover`] splices the replacement at one past the newest
+	/// delivered group, assuming the source shares the old sequence space. A
+	/// source that restarted (a reconnecting publisher with a fresh session
+	/// numbers from zero) only ever produces below that boundary, and the
+	/// splice would filter every group it publishes forever. Once the source's
+	/// first production shows which case this is, a restart drops the stale
+	/// history segments and re-splices the source unbounded: subscribers
+	/// reconcile onto its own numbering (a sequence regression, surfaced like
+	/// any other new-segment switch).
+	///
+	/// Idempotent and cheap; the serving loop calls it on every production
+	/// edge of a freshly spliced track until it returns a decided value.
+	pub(crate) fn reanchor_restarted(&mut self) -> Result<Reanchor> {
+		let mut state = self.state.write().map_err(|_| Error::Dropped)?;
+		if state.finished || state.abort.is_some() {
+			return Err(Error::Closed);
+		}
+		let Some(newest) = state.segments.last() else {
+			return Ok(Reanchor::Resumed);
+		};
+		if !newest.provisional {
+			return Ok(Reanchor::Resumed);
+		}
+		let Some(start) = newest.start else {
+			// Unbounded (the first splice): whatever the source numbers is
+			// what subscribers get, so there is nothing to resolve.
+			return Ok(Reanchor::Resumed);
+		};
+		let Some(latest) = newest.track.latest() else {
+			return Ok(Reanchor::Pending);
+		};
+		if latest >= start {
+			// The source resumed the old numbering: the boundary is real, so
+			// promote it into wire demand (subscribers re-slice on the epoch
+			// bump).
+			state.segments.last_mut().expect("checked above").provisional = false;
+			state.epoch += 1;
+			return Ok(Reanchor::Resumed);
+		}
+		if latest != 0 || start < 2 {
+			// Below the boundary but not numbering from zero: a resumed source
+			// re-delivering history it already produced (an unfloored
+			// subscription joins at the source's own latest). The cursor
+			// filters it; keep watching for the deciding production. A
+			// boundary of one is the ambiguous corner (sequence zero is both
+			// "restarted" and "re-delivered"), resolved as a resume: a
+			// genuinely restarted source recovers at its next group anyway,
+			// which lands on the boundary.
+			return Ok(Reanchor::Pending);
+		}
+		// Restarted numbering (a fresh session counts from zero): reset the
+		// splice onto the new source alone. A fresh segment id (not a mutated
+		// bound) makes every subscriber drop its old cursors and subscribe
+		// this one without a floor.
+		let track = newest.track.clone();
+		state.segments.clear();
+		let id = state.epoch;
+		state.segments.push(Segment {
+			id,
+			start: None,
+			end: None,
+			provisional: false,
+			track,
+		});
+		state.epoch += 1;
+		Ok(Reanchor::Restarted)
 	}
 
 	/// Drop every segment, releasing the underlying tracks while keeping the
@@ -440,6 +552,9 @@ struct SegmentSub {
 	id: u64,
 	start: Option<u64>,
 	end: Option<u64>,
+	/// The wire-demand floor: `start` once the segment is authoritative,
+	/// `None` while a takeover splice is provisional (see `Segment`).
+	demand_start: Option<u64>,
 	sub: SubState,
 	/// A received group held back by the subscriber's [`Subscriber::end_at`] cap,
 	/// re-offered once the cap rises (arrival-order reads consume the underlying
@@ -513,7 +628,7 @@ impl Subscriber {
 			self.last_prefs = prefs;
 			for seg in &mut self.segments {
 				if let SubState::Active(sub) = &mut seg.sub {
-					let _ = sub.update(slice(&self.last_prefs, seg.start, seg.end));
+					let _ = sub.update(slice(&self.last_prefs, seg.demand_start, seg.end));
 				}
 			}
 		}
@@ -564,14 +679,18 @@ impl Subscriber {
 		self.segments.retain(|s| segments.iter().any(|n| n.id == s.id));
 
 		for segment in segments {
+			let demand_start = segment.demand_start();
 			match self.segments.iter_mut().find(|s| s.id == segment.id) {
 				Some(existing) => {
-					if existing.end != segment.end {
+					if existing.end != segment.end || existing.demand_start != demand_start {
 						existing.end = segment.end;
+						existing.demand_start = demand_start;
 						if let SubState::Active(sub) = &mut existing.sub {
 							sub.end_at(min_some(segment.end, self.end_sequence));
-							// Also shrink the demand so the session can cap upstream.
-							let _ = sub.update(slice(&self.last_prefs, segment.start, segment.end));
+							// Also re-shape the demand: a moved cap shrinks it,
+							// and a resolved provisional splice promotes the
+							// boundary upstream.
+							let _ = sub.update(slice(&self.last_prefs, demand_start, segment.end));
 						}
 						// A still-pending subscription picks the moved boundary up
 						// when it activates (see `poll_activate`).
@@ -580,11 +699,12 @@ impl Subscriber {
 				None => {
 					let sub = segment
 						.track
-						.subscribe(slice(&self.last_prefs, segment.start, segment.end));
+						.subscribe(slice(&self.last_prefs, demand_start, segment.end));
 					self.segments.push(SegmentSub {
 						id: segment.id,
 						start: segment.start,
 						end: segment.end,
+						demand_start,
 						sub: SubState::Pending(sub),
 						parked: None,
 					});
@@ -610,7 +730,7 @@ impl Subscriber {
 					// case a boundary moved while the subscription was pending.
 					sub.start_at(seg.start.unwrap_or(0).max(min_sequence));
 					sub.end_at(min_some(seg.end, end_sequence));
-					let _ = sub.update(slice(prefs, seg.start, seg.end));
+					let _ = sub.update(slice(prefs, seg.demand_start, seg.end));
 					seg.sub = SubState::Active(sub);
 				}
 				// The underlying track was rejected or closed: stall, not error.

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -29,11 +29,6 @@ struct Segment {
 	/// Last group this segment serves (inclusive), or `None` while it is the
 	/// newest segment.
 	end: Option<u64>,
-	/// A takeover splice whose source has not yet proven it resumes the old
-	/// numbering: the boundary binds the read cursor but stays out of wire
-	/// demand (a floored subscription would starve a source that restarted
-	/// from zero). Resolved by [`Producer::reanchor_restarted`].
-	provisional: bool,
 	/// The underlying per-session track.
 	track: track::Consumer,
 }
@@ -54,19 +49,10 @@ impl Segment {
 			None => latest,
 		})
 	}
-
-	/// The segment's start, unless the splice is still provisional.
-	fn demand_start(&self) -> Option<u64> {
-		match self.provisional {
-			true => None,
-			false => self.start,
-		}
-	}
 }
 
 /// The demand to register on an underlying track: the subscriber's own
-/// preferences intersected with a segment's bounds (`start` comes from
-/// [`Segment::demand_start`], so a provisional boundary stays out of it).
+/// preferences intersected with a segment's bounds.
 fn slice(prefs: &Subscription, start: Option<u64>, end: Option<u64>) -> Subscription {
 	let mut sub = prefs.clone();
 	sub.group_start = match (prefs.group_start, start) {
@@ -83,7 +69,7 @@ struct ResumeState {
 	segments: Vec<Segment>,
 	/// Bumped on every mutation so subscribers know to reconcile.
 	epoch: u64,
-	/// The sequence-numbering era, bumped only by a restart reanchor:
+	/// The sequence-numbering era, bumped only by [`Producer::reset_onto`]:
 	/// cursors anchored in the old numbering reset with it.
 	era: u64,
 	/// No more switches will happen; the logical track ends with its last segment.
@@ -112,7 +98,7 @@ impl ResumeState {
 
 	/// Append a segment serving groups from `start` onward, capping (or replacing)
 	/// the previous segments so the ranges stay disjoint and ascending.
-	fn switch(&mut self, track: track::Consumer, start: Option<u64>, provisional: bool) -> Result<()> {
+	fn switch(&mut self, track: track::Consumer, start: Option<u64>) -> Result<()> {
 		if !self.segments.is_empty() {
 			// A boundary is required once a segment exists.
 			let Some(start) = start else {
@@ -144,22 +130,11 @@ impl ResumeState {
 			id,
 			start,
 			end: None,
-			provisional,
 			track,
 		});
 		self.epoch += 1;
 		Ok(())
 	}
-}
-
-/// Outcome of [`Producer::reanchor_restarted`].
-pub(crate) enum Reanchor {
-	/// The source restarted its numbering; the splice was reset onto it.
-	Restarted,
-	/// The source resumed the old numbering; the splice stands.
-	Resumed,
-	/// Nothing decisive produced yet; check again on production.
-	Pending,
 }
 
 /// Splices tracks into one logical track by switching at group boundaries.
@@ -209,7 +184,7 @@ impl Producer {
 		if state.finished || state.abort.is_some() {
 			return Err(Error::Closed);
 		}
-		state.switch(track, start, false)
+		state.switch(track, start)
 	}
 
 	/// Splice in a track that resumes wherever the current segments stop: one past
@@ -238,61 +213,39 @@ impl Producer {
 				None => Some(0),
 			}
 		};
-		// Provisional: whether the replacement resumes the old numbering or
-		// restarted its own is unknown until it produces.
-		state.switch(track, start, true)
+		state.switch(track, start)
 	}
 
-	/// Resolve a provisional takeover off its source's first production: a
-	/// resume promotes the boundary into wire demand, a restart (a fresh
-	/// session numbering from zero) resets the splice onto the source alone
-	/// so subscribers reconcile onto its own numbering. Idempotent; the
-	/// serving loop calls it on each production edge until decided.
-	pub(crate) fn reanchor_restarted(&mut self) -> Result<Reanchor> {
+	/// Replace every segment with a track serving its OWN sequence space: the
+	/// splice is reset onto it unbounded and the numbering era is bumped, so
+	/// subscribers drop cursors and floors anchored in the old numbering.
+	///
+	/// This is the takeover for a source with a NEW identity (a reconnected
+	/// publisher session numbers from zero): splicing it at a boundary would
+	/// ask it for groups it will never number and filter everything it does
+	/// publish. [`Self::takeover`] remains the same-identity path.
+	pub(crate) fn reset_onto(&mut self, track: impl super::origin_impl::Consume<track::Consumer>) -> Result<()> {
+		let track = track.consume();
 		let mut state = self.state.write().map_err(|_| Error::Dropped)?;
 		if state.finished || state.abort.is_some() {
 			return Err(Error::Closed);
 		}
-		let Some(newest) = state.segments.last() else {
-			return Ok(Reanchor::Resumed);
-		};
-		if !newest.provisional {
-			return Ok(Reanchor::Resumed);
-		}
-		let Some(start) = newest.start else {
-			// Unbounded: nothing to resolve.
-			return Ok(Reanchor::Resumed);
-		};
-		let Some(latest) = newest.track.latest() else {
-			return Ok(Reanchor::Pending);
-		};
-		if latest >= start {
-			// Proven resume: promote the boundary into wire demand.
-			state.segments.last_mut().expect("checked above").provisional = false;
-			state.epoch += 1;
-			return Ok(Reanchor::Resumed);
-		}
-		if latest != 0 || start < 2 {
-			// Re-delivered history from a resumed source, or the ambiguous
-			// boundary-of-one corner (a restarted source recovers at its next
-			// group there anyway). The cursor filters it; keep watching.
-			return Ok(Reanchor::Pending);
-		}
-		// Restarted numbering: reset the splice onto the new source alone. A
-		// fresh segment id makes every subscriber re-subscribe unfloored.
-		let track = newest.track.clone();
 		state.segments.clear();
 		let id = state.epoch;
 		state.segments.push(Segment {
 			id,
 			start: None,
 			end: None,
-			provisional: false,
 			track,
 		});
 		state.epoch += 1;
 		state.era += 1;
-		Ok(Reanchor::Restarted)
+		Ok(())
+	}
+
+	/// The newest segment's splice boundary, if any.
+	pub(crate) fn splice_boundary(&self) -> Option<u64> {
+		self.state.read().segments.last()?.start
 	}
 
 	/// Drop every segment, releasing the underlying tracks while keeping the
@@ -524,8 +477,6 @@ struct SegmentSub {
 	id: u64,
 	start: Option<u64>,
 	end: Option<u64>,
-	/// The wire-demand floor: `None` while the splice is provisional.
-	demand_start: Option<u64>,
 	sub: SubState,
 	/// A received group held back by the subscriber's [`Subscriber::end_at`] cap,
 	/// re-offered once the cap rises (arrival-order reads consume the underlying
@@ -601,7 +552,7 @@ impl Subscriber {
 			self.last_prefs = prefs;
 			for seg in &mut self.segments {
 				if let SubState::Active(sub) = &mut seg.sub {
-					let _ = sub.update(slice(&self.last_prefs, seg.demand_start, seg.end));
+					let _ = sub.update(slice(&self.last_prefs, seg.start, seg.end));
 				}
 			}
 		}
@@ -673,17 +624,14 @@ impl Subscriber {
 		self.segments.retain(|s| segments.iter().any(|n| n.id == s.id));
 
 		for segment in segments {
-			let demand_start = segment.demand_start();
 			match self.segments.iter_mut().find(|s| s.id == segment.id) {
 				Some(existing) => {
-					if existing.end != segment.end || existing.demand_start != demand_start {
+					if existing.end != segment.end {
 						existing.end = segment.end;
-						existing.demand_start = demand_start;
 						if let SubState::Active(sub) = &mut existing.sub {
 							sub.end_at(min_some(segment.end, self.end_sequence));
-							// Re-shape the demand: a moved cap shrinks it, a
-							// resolved splice promotes the boundary upstream.
-							let _ = sub.update(slice(&self.last_prefs, demand_start, segment.end));
+							// Also shrink the demand so the session can cap upstream.
+							let _ = sub.update(slice(&self.last_prefs, segment.start, segment.end));
 						}
 						// A still-pending subscription picks the moved boundary up
 						// when it activates (see `poll_activate`).
@@ -692,12 +640,11 @@ impl Subscriber {
 				None => {
 					let sub = segment
 						.track
-						.subscribe(slice(&self.last_prefs, demand_start, segment.end));
+						.subscribe(slice(&self.last_prefs, segment.start, segment.end));
 					self.segments.push(SegmentSub {
 						id: segment.id,
 						start: segment.start,
 						end: segment.end,
-						demand_start,
 						sub: SubState::Pending(sub),
 						parked: None,
 					});
@@ -723,7 +670,7 @@ impl Subscriber {
 					// case a boundary moved while the subscription was pending.
 					sub.start_at(seg.start.unwrap_or(0).max(min_sequence));
 					sub.end_at(min_some(seg.end, end_sequence));
-					let _ = sub.update(slice(prefs, seg.demand_start, seg.end));
+					let _ = sub.update(slice(prefs, seg.start, seg.end));
 					seg.sub = SubState::Active(sub);
 				}
 				// The underlying track was rejected or closed: stall, not error.

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1557,6 +1557,30 @@ impl Consumer {
 		}
 	}
 
+	/// Poll until the latest appended sequence differs from `known` (or the
+	/// track closes); ready with the current value. Registers the waiter, so a
+	/// caller can watch production without holding a subscription and therefore
+	/// without registering demand. The origin's dispatcher uses this to decide
+	/// whether a takeover's replacement source resumed the old group numbering
+	/// or restarted its own.
+	pub(crate) fn poll_latest_changed(&self, known: Option<u64>, waiter: &kio::Waiter) -> Poll<Option<u64>> {
+		let ConsumerKind::Plain(state) = &self.inner else {
+			// Spliced tracks are compositions; the dispatcher never monitors one.
+			return Poll::Pending;
+		};
+		match state.poll(waiter, |state| {
+			if state.max_sequence != known {
+				Poll::Ready(state.max_sequence)
+			} else {
+				Poll::Pending
+			}
+		}) {
+			Poll::Ready(Ok(latest)) => Poll::Ready(latest),
+			Poll::Ready(Err(closed)) => Poll::Ready(closed.max_sequence),
+			Poll::Pending => Poll::Pending,
+		}
+	}
+
 	/// Poll for the track reaching a terminal state: `Ok(())` once it is complete
 	/// (the final group was produced), `Err` once it closed or aborted before
 	/// completing. The origin's dispatcher uses this to tell a track that truly

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1559,7 +1559,7 @@ impl Consumer {
 
 	/// Poll until the latest appended sequence differs from `known` (or the
 	/// track closes); ready with the current value. Watches production without
-	/// registering demand; the dispatcher's restart watch rides it.
+	/// registering demand; the dispatcher's takeover watch rides it.
 	pub(crate) fn poll_latest_changed(&self, known: Option<u64>, waiter: &kio::Waiter) -> Poll<Option<u64>> {
 		let ConsumerKind::Plain(state) = &self.inner else {
 			// Spliced tracks are compositions; the dispatcher never monitors one.

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1558,11 +1558,8 @@ impl Consumer {
 	}
 
 	/// Poll until the latest appended sequence differs from `known` (or the
-	/// track closes); ready with the current value. Registers the waiter, so a
-	/// caller can watch production without holding a subscription and therefore
-	/// without registering demand. The origin's dispatcher uses this to decide
-	/// whether a takeover's replacement source resumed the old group numbering
-	/// or restarted its own.
+	/// track closes); ready with the current value. Watches production without
+	/// registering demand; the dispatcher's restart watch rides it.
 	pub(crate) fn poll_latest_changed(&self, known: Option<u64>, waiter: &kio::Waiter) -> Poll<Option<u64>> {
 		let ConsumerKind::Plain(state) = &self.inner else {
 			// Spliced tracks are compositions; the dispatcher never monitors one.


### PR DESCRIPTION
## Summary

- Root cause: the linger takeover (#2469) splices a replacement source at `latest + 1`, assuming it resumes the old sequence space. A reconnecting publisher is a fresh session with a fresh identity and restarted numbering, so the boundary starves it twice: the demand floor asks it for groups it will never number, and late-join floors resolved against the pre-restart `latest()` filter anything that does arrive. One-group-per-event feeds lose the next N events after every publisher reconnect.
- The takeover now gates on the announce's first hop, the producer-instance identity. A matching first hop splices at the boundary exactly as before (eager demand floor, unchanged route behavior). A differing first hop is a new broadcast: the logical track resets onto it unbounded and a numbering era bumps, clearing subscriber cursors and late-join floors anchored in the old numbering.
- A same-identity source producing below the splice boundary logs a one-shot warning (an identity-contract violation that would starve those groups); the `Origin` doc now states that ids are minted per producer instance.
- The route tests' synthetic hops are adjusted so alternate routes to the same producer share a first hop; the restart tests model a reconnect as a fresh session with a fresh identity.

## Public API changes

None. New items are `pub(crate)` (`resume::Producer::reset_onto`, `resume::Producer::splice_boundary`, `track::Consumer::poll_latest_changed`). One doc addition on `Origin`.

## Test plan

- `test_linger_reconnect_restarted_sequences_still_deliver` fails on main, passes here.
- `test_linger_restart_resets_late_join_floors` fails without the era cursor reset, passes here.
- `test_linger_reconnect_splices` and the route handover/failover/cost tests pass with their original assertions; 559 moq-net tests green.
- An out-of-tree integration suite driving the relay binary reproduces the starvation on stock 0.14.2/0.14.3 (an event-feed test failing ~90% of runs after a publisher reconnect, a publisher-rotation test starving 3/5); both pass consistently with this branch's relay.

(Written by Claude Fable 5)