### PR TITLE
chore(net): require @moq/qmux 0.3.2 for fallback reset codes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -179,7 +179,7 @@
       "name": "@moq/net",
       "version": "0.2.0",
       "dependencies": {
-        "@moq/qmux": "^0.3.1",
+        "@moq/qmux": "^0.3.2",
         "@moq/signals": "workspace:*",
         "async-mutex": "^0.5.0",
       },
@@ -581,7 +581,7 @@
 
     "@moq/publish": ["@moq/publish@workspace:js/publish"],
 
-    "@moq/qmux": ["@moq/qmux@0.3.1", "", { "dependencies": { "@moq/web-socket-stream": "^0.1.1" } }, "sha512-0bSa8S8Mpr6J/kM94MgPRCPefmLhFwMzkFpNsu873SuS5Jne4oYzXoud/5tyDDoS5JAXb1/KBOBrim55qSrViA=="],
+    "@moq/qmux": ["@moq/qmux@0.3.2", "", { "dependencies": { "@moq/web-socket-stream": "^0.1.1" } }, "sha512-8ymBriVxvD5ISfnTJ3k07Zzt4pBOoh/JnulGCjenY2NrUdCr5PUOy42y/9drSXA3SfCfOdaw4A+BSrWN92qVvg=="],
 
     "@moq/signals": ["@moq/signals@workspace:js/signals"],
 

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -17,7 +17,7 @@
 		"release": "bun ../common/release.ts"
 	},
 	"dependencies": {
-		"@moq/qmux": "^0.3.1",
+		"@moq/qmux": "^0.3.2",
 		"@moq/signals": "workspace:*",
 		"async-mutex": "^0.5.0"
 	},

--- a/js/net/src/error.test.ts
+++ b/js/net/src/error.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, test } from "bun:test";
+import { StreamError } from "@moq/qmux";
 import { fromTransport, RemoteError, reason } from "./error.ts";
 
 // Minimal stand-in for the DOM WebTransportError, which the test runtime may not define.
@@ -94,4 +95,13 @@ test("reason: WebTransportError keeps a populated message and appends details", 
 
 test("reason: a decoded remote error names its code", () => {
 	expect(reason(new RemoteError(31))).toBe("remote error: 31");
+});
+
+test("fromTransport: decodes a real qmux stream reset", () => {
+	// The WebSocket fallback's actual error type, not a stand-in: this is the contract the
+	// fallback path depends on, and it only holds from @moq/qmux 0.3.2 on. Before that, qmux
+	// formatted the code into an Error message and this silently decoded nothing.
+	const err = fromTransport(new StreamError(2, "RESET_STREAM"));
+	expect(err).toBeInstanceOf(RemoteError);
+	expect((err as RemoteError).code).toBe(2);
 });


### PR DESCRIPTION
## Summary

- Bumps `@moq/net`'s `@moq/qmux` range from `^0.3.1` to `^0.3.2` and refreshes the lockfile. This is the last step of #2508: #2510 landed the decode, and moq-dev/web-transport#342 (released as 0.3.2) is what makes a code available to decode on the WebSocket fallback.
- 0.3.2 is the first release that exposes an incoming reset code as `streamErrorCode` rather than formatting it into an `Error` message. `fromTransport` reads that field, so resolving an older qmux leaves the fallback silently code-less while native WebTransport works. `^0.3.1` would have accepted 0.3.2 on its own, but the range now states the actual minimum instead of letting a stale resolve degrade quietly.
- Adds a test against qmux's own `StreamError` rather than a local stand-in, pinning the cross-package contract the fallback depends on. That test could not be written before this release.

## Public API changes

None. Dependency range and lockfile only, plus one test.

## Test plan

- Verified `@moq/qmux@0.3.2` on npm actually ships the change before bumping (`StreamError` exported from `index.d.ts`, `resetCode` wired at all five send sites, `streamCode` on both receive paths) rather than trusting the release workflow's exit status. Worth noting: the `release-js` run for the feature merge itself reported success while publishing nothing, because the version was unchanged.
- `just js check`, `just js test`, `just js fix` clean across all packages.

(Written by Opus 5)