### PR TITLE
feat(net): start and end subscriptions and fetches at a specific frame

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -181,7 +181,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@moq/qmux": "^0.3.2",
         "@moq/signals": "workspace:*",

--- a/doc/concept/layer/moq-lite.md
+++ b/doc/concept/layer/moq-lite.md
@@ -86,7 +86,11 @@ Conceptually, these are join points, and new subscriptions will always start at 
 Groups are delivered independently and potentially out of order, so you should have some logic to reorder or skip during congestion.
 A group is closed when finished or aborted with an error (ex. during congestion).
 
-Each group consists of one or more **frames**.
+A subscription starts at the latest group by default, but can name any (group, frame) position instead.
+That is how a subscriber follows a track to a different publisher partway through a group, which matters when the current group may stay open indefinitely (a JSON append log, or a catalog that keeps appending deltas).
+A group can therefore be assembled from more than one publisher: each contributes a disjoint run of frames, and the subscriber concatenates them in index order.
+
+Each group consists of one or more **frames**, numbered from 0 in the order they were produced.
 Frames within a group are delivered reliably and in order.
 You can and should take advantage of this, for example using delta encoding.
 If frames within a group are actually independent, you should probably split them into individual groups!
@@ -163,8 +167,8 @@ But if a publisher needs a feature, then the subscriber needs it too, so you can
 
 - **No Request IDs**: A bidirectional stream for each request to avoid HoLB. (NOTE: likely to be upstreamed into moq-transport)
 - **No Push**: A subscriber must explicitly subscribe to each track.
-- **Single-group FETCH only (lite-05+)**: Fetch one complete group by sequence. Ranges and joining fetches are not supported.
-- **No Joining Fetch**: Subscriptions start at the latest group, not the latest frame.
+- **Single-group FETCH only (lite-05+)**: Fetch one group by sequence, optionally bounded to a range of frames within it. Fetching across groups is not supported.
+- **No Joining Fetch**: A subscription resumes by asking for the missing range directly, rather than by pairing a fetch with a subscribe.
 - **No sub-groups**: SVC layers should be separate tracks.
 - **No gaps**: Makes life much easier for the relay and every application.
 - **No object properties**: Encode your metadata into the frame payload.

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -955,7 +955,7 @@ A non-zero value is the absolute group sequence + 1.
 
 **Frame Start**:
 The index of the first frame to deliver within the start group (see [Positions](#positions)).
-A value of 0 means the whole group (default).
+A value of 0 means from the start of that group (default), so the group is delivered whole.
 Unlike `Group Start` this is a plain absolute index, not the `absolute + 1` form: 0 is both a valid index and the default, so there is no absent case to encode around.
 Frames before this index are not delivered, even though the start group itself is.
 MUST be 0 when `Group Start` is 0, since the subscriber cannot number the frames of a group it has not seen.

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -126,6 +126,7 @@ The duration before an incomplete group is dropped is determined by the applicat
 
 Every subscription is scoped to a single Track.
 A subscription starts at a configurable Group (defaulting to the latest) and continues until a configurable end Group or until either the publisher or subscriber cancels the subscription.
+Both bounds may be refined to a Frame within their Group, so a subscription can start or stop partway through a Group rather than only on a Group boundary (see [Positions](#positions)).
 
 The subscriber and publisher both indicate their delivery preference:
 - `Priority` indicates if Track A should be transmitted instead of Track B.
@@ -154,9 +155,43 @@ A Frame is a payload of bytes within a Group.
 A frame is used to represent a chunk of data with an upfront size.
 The contents are opaque to the moq-lite layer.
 
+Frames within a Group are numbered from 0 in the order they were produced.
+This index is not transmitted per frame; it is implied by position within the Group, anchored by the [GROUP](#group) message's `Frame Start`.
+A Group Stream normally starts at frame 0, but MAY start later when the publisher only holds (or was only asked for) part of the Group.
+
 Each frame carries a presentation timestamp expressed in the parent Track's `Timescale` (units per second, part of the [TRACK_INFO](#track-info)).
 Every Track has a media timeline — the `Timescale` is always non-zero and every frame is timestamped.
 The timestamp is the source-of-truth for media time and is one of the two inputs to the moq-lite layer's [expiration](#expiration) decisions, alongside wall-clock arrival time.
+
+## Positions {#positions}
+A Position is a (Group Sequence, Frame Index) pair identifying one frame within a Track.
+Positions order lexicographically: by group first, then by frame within the group.
+
+SUBSCRIBE and FETCH bound their delivery by Position rather than by Group alone.
+Each carries a `Frame Start` qualifying its start group and a `Frame End` qualifying its end group; both default to the whole group, which is the behavior of a draft that has no such field.
+
+The bounds are chosen so that two subscriptions abut exactly.
+`Frame Start` is the index of the first frame to deliver and `Frame End` is the index of the last (inclusive), so a subscriber that has received frames 0 through `N-1` of group `G` and wants the remainder asks for `Group Start` = `G`, `Frame Start` = `N`.
+Capping the first subscription at `Group End` = `G`, `Frame End` = `N-1` covers exactly the complement with no gap and no overlap.
+Because `Group End` and `Frame End` are both encoded as `absolute + 1` (see [SUBSCRIBE](#subscribe)) while `Group Start` and `Frame Start` are not, the two requests carry the *same* numbers on the wire; the end bound is effectively exclusive once encoded.
+
+This is what lets a subscriber move a Track to a different publisher partway through a Group instead of waiting for the next Group to start, which matters for Tracks whose current Group may stay open indefinitely.
+A Group can therefore be assembled from more than one publisher: each contributes a disjoint run of frames, and the subscriber concatenates them in index order.
+
+A partial Group is only ever delivered to a subscriber that asked for one.
+A publisher that cannot serve a Group from the frame the subscription names MUST skip that Group entirely and resolve the subscription to a later one, rather than deliver the part it holds.
+The resolved start is therefore always either exactly the requested Position or the beginning of a later Group, never some third Position the subscriber did not choose.
+
+The asymmetry with Groups is deliberate.
+A Group is the unit of decodability: dropping leading *Groups* leaves a stream the application can still decode, whereas dropping leading *Frames* often does not, whether because the Group opens with a keyframe the rest depends on or because its compression state lives in the frames that went missing.
+Only the subscriber knows whether a partial Group is any use to it, so only the subscriber may ask for one.
+
+Frame indices are only meaningful relative to a Group the subscriber has already begun receiving, so:
+
+- A `Frame Start` is meaningless without an absolute `Group Start`; a subscriber requesting the latest group (`Group Start` = 0) MUST send `Frame Start` = 0.
+- A `Frame End` is meaningless without a `Group End`; an unbounded subscription (`Group End` = 0) MUST send `Frame End` = 0.
+
+A publisher MUST treat a violation of either rule as a protocol violation and reset the stream.
 
 # Flow
 This section outlines the flow of messages within a moq-lite session.
@@ -301,7 +336,8 @@ A subscriber that sees the same broadcast advertised across multiple streams SHO
 Advertisements from peers that predate the Route Cost carry an effective cost of 0, so a mixed mesh degrades to shortest-path routing.
 Advertisements that tie on every advertised property SHOULD be broken toward the most recently received: they are indistinguishable to the rest of the mesh, and a publisher reconnecting over a new session is otherwise outranked by the session it replaced until the transport declares that one gone.
 
-Advertisements for the same broadcast path whose reconstructed paths share the same first entry carry interchangeable content: a relay MAY hold them as redundant routes for one broadcast and splice a live subscription across them at a Group boundary, e.g. when the serving route ends.
+Advertisements for the same broadcast path whose reconstructed paths share the same first entry carry interchangeable content: a relay MAY hold them as redundant routes for one broadcast and splice a live subscription across them, e.g. when the serving route ends.
+The splice point is a [Position](#positions), not just a Group boundary, so a route that ends partway through a Group is continued from the frame it stopped on rather than abandoning the rest of the Group.
 Cooperating redundant publishers MAY share a Hop ID to opt into this.
 Advertisements whose first entries differ are distinct broadcasts colliding on one path: a relay MUST NOT splice between them, and SHOULD treat the later as a replacement for the earlier, ending the earlier advertisement before starting the later one.
 Serving the earlier until it ends on its own instead would hold the path for however long the transport takes to notice a publisher is gone, which is exactly the case a reconnecting publisher hits.
@@ -328,7 +364,7 @@ A subscription the publisher accepts but has no groups for yet is not a rejectio
 The Subscribe Stream does not carry the track's publisher properties — those are immutable and fetched once via a [Track Stream](#track-stream) (see [TRACK_INFO](#track-info)).
 The subscriber MUST have the track's TRACK_INFO before it can fully interpret the FRAME messages that arrive on Group Streams, since the timescale is needed to interpret each timestamp; it MAY open the Track and Subscribe streams concurrently and buffer frames until TRACK_INFO arrives.
 
-The publisher sends SUBSCRIBE_OK once the absolute start group is resolved, and SUBSCRIBE_END once no further groups will be produced (see [SUBSCRIBE_OK](#subscribe-ok) and [SUBSCRIBE_END](#subscribe-end)).
+The publisher sends SUBSCRIBE_OK once the absolute start position is resolved, and SUBSCRIBE_END once no further groups will be produced (see [SUBSCRIBE_OK](#subscribe-ok) and [SUBSCRIBE_END](#subscribe-end)).
 The publisher closes the stream (FIN) only once every group from start to end has been accounted for, either via a GROUP stream (completed or reset) or a SUBSCRIBE_DROP message.
 This MAY occur after SUBSCRIBE_END, since stragglers within the range can still be dropped.
 Unbounded subscriptions (no end group) stay open until the publisher sends SUBSCRIBE_END (and accounts for the remaining groups) to indicate the track has ended, or either endpoint resets.
@@ -337,9 +373,10 @@ Either endpoint MAY reset/cancel the stream at any time.
 ### Fetch
 A subscriber opens a Fetch Stream (0x3) to request a single Group from a Track.
 
-The subscriber sends a FETCH message containing the broadcast path, track name, priority, and group sequence.
+The subscriber sends a FETCH message containing the broadcast path, track name, priority, group sequence, and the frame range within that group.
 The publisher responds with FRAME messages directly on the same bidirectional stream — there is no response header.
-The Subscribe ID and Group Sequence for the returned FRAME messages are implicit, taken from the original FETCH request.
+The Subscribe ID, Group Sequence, and index of the first returned frame are implicit, taken from the original FETCH request.
+Because there is no response header, a publisher that cannot serve the requested frame range in full MUST reset the stream rather than return a shorter run; the subscriber has no way to learn where a truncated response actually started.
 As with a subscription, the subscriber MUST already have the track's [TRACK_INFO](#track-info) to parse the returned frames; because the properties are immutable, a single Track Stream lookup is reused across every FETCH of that track (group-by-group fetches do not re-fetch it).
 The publisher FINs the stream after the last frame, or resets the stream on error.
 
@@ -498,6 +535,12 @@ A publisher creates Group Streams in response to a Subscribe Stream.
 A Group Stream MUST start with a GROUP message and MAY be followed by any number of FRAME messages.
 A Group MAY contain zero FRAME messages, potentially indicating a gap in the track.
 A frame MAY contain an empty payload, potentially indicating a gap in the group.
+
+The GROUP message's `Frame Start` gives the index of the first FRAME on the stream, so a stream carrying only part of a Group is self-describing.
+It is redundant with the subscription's own `Frame Start` in the steady state, and carried anyway because a SUBSCRIBE_UPDATE that moves the bound races the Group Streams already in flight: the two travel on different streams with no ordering between them, so the receiver would otherwise have to guess which bound a given Group Stream was opened under.
+
+A publisher MUST NOT send two Group Streams for the same Group Sequence on one subscription.
+A subscriber assembling a Group from more than one publisher does so across separate subscriptions, and is responsible for concatenating the runs in index order and for ignoring any frame it has already received.
 
 Both the publisher and subscriber MAY reset the stream at any time.
 This is not a fatal error and the session remains active.
@@ -873,6 +916,8 @@ SUBSCRIBE Message {
   Subscriber Max Latency (i)
   Group Start (i)
   Group End (i)
+  Frame Start (i)
+  Frame End (i)
 }
 ~~~
 
@@ -908,6 +953,19 @@ The last group to deliver (inclusive).
 A value of 0 means unbounded (default).
 A non-zero value is the absolute group sequence + 1.
 
+**Frame Start**:
+The index of the first frame to deliver within the start group (see [Positions](#positions)).
+A value of 0 means the whole group (default).
+Unlike `Group Start` this is a plain absolute index, not the `absolute + 1` form: 0 is both a valid index and the default, so there is no absent case to encode around.
+Frames before this index are not delivered, even though the start group itself is.
+MUST be 0 when `Group Start` is 0, since the subscriber cannot number the frames of a group it has not seen.
+
+**Frame End**:
+The last frame to deliver (inclusive) within the end group (see [Positions](#positions)).
+A value of 0 means the whole group (default).
+A non-zero value is the absolute frame index + 1, matching `Group End`.
+MUST be 0 when `Group End` is 0, since an unbounded subscription has no end group to qualify.
+
 
 ## SUBSCRIBE_UPDATE
 A subscriber can modify a subscription with a SUBSCRIBE_UPDATE message.
@@ -922,10 +980,13 @@ SUBSCRIBE_UPDATE Message {
   Subscriber Max Latency (i)
   Group Start (i)
   Group End (i)
+  Frame Start (i)
+  Frame End (i)
 }
 ~~~
 
 See [SUBSCRIBE](#subscribe) for information about each field.
+Moving `Frame Start` forward within a group that is already being delivered does not retract frames the publisher has already sent; like `Group Start`, it only bounds what the publisher sends from here on.
 
 
 ## TRACK
@@ -992,10 +1053,10 @@ A subscriber that receives a `Timescale` of 0 MUST reset the Subscribe or Fetch 
 Common values include `1000` (milliseconds), `1000000` (microseconds), `48000` (audio sample rate), and `90000` (RTP video clock).
 
 ## SUBSCRIBE_OK {#subscribe-ok}
-A SUBSCRIBE_OK message confirms a subscription and resolves its absolute start group.
-It is the first message the publisher sends on the Subscribe Stream, once the start group is known.
+A SUBSCRIBE_OK message confirms a subscription and resolves its absolute start position.
+It is the first message the publisher sends on the Subscribe Stream, once the start position is known.
 
-This is the trimmed-down counterpart of MoqTransport's SUBSCRIBE_OK: it retains the name and the role of the publisher's positive response, but carries only the resolved start group (all other per-track properties live in [TRACK_INFO](#track-info)).
+This is the trimmed-down counterpart of MoqTransport's SUBSCRIBE_OK: it retains the name and the role of the publisher's positive response, but carries only the resolved start position (all other per-track properties live in [TRACK_INFO](#track-info)).
 
 ~~~
 SUBSCRIBE_OK Message {
@@ -1014,6 +1075,15 @@ This is a plain absolute sequence, **not** the `absolute + 1` form used by `Grou
 Once decoded, this MUST be greater than or equal to the requested start group.
 If it is strictly greater, the groups in between are unavailable and will not be delivered; SUBSCRIBE_OK thus also acts as an implicit drop of that leading range, and no separate SUBSCRIBE_DROP is required for it.
 A subscriber that requested the latest group (`Group Start` = 0) learns the resolved sequence here.
+
+There is no matching frame field, because the start frame is never in doubt: a partial group is only delivered when it was asked for, so the subscription starts either exactly where it asked or at the beginning of a later group (see [Positions](#positions)).
+The subscriber derives the start frame from `Group` and its own request:
+
+- `Group` equals the requested start group: delivery begins at the requested `Frame Start`.
+- `Group` is greater: delivery begins at frame 0.
+
+The second case is easy to get wrong, so to be explicit: a subscriber that requested group 5 frame 15 and receives `Group` = 6 starts at **frame 0** of group 6, not frame 15.
+The frame offset belonged to group 5 and is gone along with the rest of it; it does not carry forward to whichever group the publisher resolved to.
 
 ## SUBSCRIBE_END {#subscribe-end}
 A SUBSCRIBE_END message is sent by the publisher to signal that no group at or after a given sequence will be produced.
@@ -1079,6 +1149,8 @@ FETCH Message {
   Track Name (s)
   Subscriber Priority (8)
   Group Sequence (i)
+  Frame Start (i)
+  Frame End (i)
 }
 ~~~
 
@@ -1095,10 +1167,21 @@ See the [Prioritization](#prioritization) section for more information.
 **Group Sequence**:
 The sequence number of the group to fetch.
 
+**Frame Start**:
+The index of the first frame to return within the group (see [Positions](#positions)).
+A plain absolute index; 0 means the start of the group (default).
+
+**Frame End**:
+The last frame to return (inclusive), encoded as the absolute frame index + 1.
+A value of 0 means through the end of the group (default).
+A `Frame End` below `Frame Start` once decoded is a protocol violation; equal bounds are a legal single-frame range.
+
 The publisher responds with FRAME messages directly on the same stream — there is no response header.
-The subscriber parses them using the track's [TRACK_INFO](#track-info), which it MUST already have (see the [Track Stream](#track-stream)); the group sequence is implicit from the FETCH request.
+The subscriber parses them using the track's [TRACK_INFO](#track-info), which it MUST already have (see the [Track Stream](#track-stream)); the group sequence and the index of the first frame are implicit from the FETCH request.
 The publisher FINs the stream after the last frame, or resets on error.
 There is no FETCH_ERROR message — the publisher signals failure by resetting the stream.
+A publisher holding fewer frames than requested MUST reset rather than truncate, since a short response is indistinguishable from one that started elsewhere.
+A group that ends before `Frame End` is not a truncation: the publisher FINs after the last frame it has, provided the group is complete and it served everything from `Frame Start` onward.
 
 ## PROBE
 PROBE is used to measure the available bitrate of the connection.
@@ -1147,6 +1230,7 @@ GROUP Message {
   Message Length (i)
   Subscribe ID (i)
   Group Sequence (i)
+  Frame Start (i)
 }
 ~~~
 
@@ -1158,6 +1242,12 @@ This ID is used to distinguish between multiple subscriptions for the same track
 The sequence number of the group.
 This SHOULD increase by 1 for each new group.
 A subscriber MUST handle gaps, potentially caused by congestion.
+
+**Frame Start**:
+The index of the first FRAME message on this stream within the group (see [Positions](#positions)).
+A plain absolute index; 0 means the stream carries the group from its beginning, which is the common case.
+A non-zero value means the leading frames are not on this stream, either because the subscription started partway into this group or because the publisher only holds part of it.
+The subscriber MUST NOT assume it will receive the missing frames on another stream; they are a gap unless a separate subscription or FETCH covers them.
 
 
 ## FRAME
@@ -1202,7 +1292,11 @@ The `Message Length` describes the payload size on the wire.
 - Stated the receiver's loop check normatively in ANNOUNCE_START: an announcement whose reconstructed path contains the receiver's own Hop ID is neither forwarded nor selected as a route.
 - Added a SETUP `Origin` parameter (0x5): each endpoint declares its Hop ID at session setup, carrying session-wide the identity `Exclude Hop` carried per announce stream, and filtering subscriptions as well as announcements (including sessions that never open an Announce Stream).
 - Made advertisement selection per subscriber: the publisher advertises the best path avoiding each subscriber's declared origin (a subscriber the serving path flows through receives the best standby instead of nothing), MUST serve subscriptions by the same exclusion, and the actively-carrying cost discount applies only to the serving path. This is how redundant (shared first hop) publishers fail over across a mesh.
-- Defined same-path advertisements sharing a first entry as interchangeable content a relay may splice across at a Group boundary; differing first entries never splice, the later replacing the earlier.
+- Defined same-path advertisements sharing a first entry as interchangeable content a relay may splice across; differing first entries never splice, the later replacing the earlier.
+- Added `Frame Start` and `Frame End` to SUBSCRIBE and SUBSCRIBE_UPDATE, qualifying the start and end group with a frame index so a subscription can begin or end partway through a group. `Frame Start` is a plain index; `Frame End` is the index + 1, matching `Group End`. Both MUST be 0 when the group bound they qualify is absent.
+- Added `Frame Start` and `Frame End` to FETCH, bounding the returned frames within the group. A publisher that cannot serve the full range resets the stream.
+- Added `Frame Start` to GROUP, giving the index of the first FRAME on the stream so a partial group is self-describing.
+- Added the Positions section defining a (group, frame) position, its lexicographic ordering, and the rule that a partial group is only ever delivered to a subscriber that asked for one. A publisher that cannot serve a group from the requested frame skips it and resolves to a later group, so SUBSCRIBE_OK needs no frame field: the start frame follows from `Group` and the subscriber's own request.
 
 ## moq-lite-05
 - Renamed ANNOUNCE_INTEREST to ANNOUNCE_REQUEST and ANNOUNCE to ANNOUNCE_BROADCAST.

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.2.1",
+	"version": "0.3.0",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -273,7 +273,7 @@ export class Connection implements Established {
 	async #runUni(stream: Reader) {
 		const typ = await stream.u53();
 		if (typ === DataType.Group) {
-			const msg = await Group.decode(stream);
+			const msg = await Group.decode(stream, this.#version);
 			await this.#subscriber.runGroup(msg, stream);
 		} else if (typ === DataType.Setup) {
 			// The peer sends exactly one SETUP, then FINs. Record it so capability-gated

--- a/js/net/src/lite/fetch.test.ts
+++ b/js/net/src/lite/fetch.test.ts
@@ -32,7 +32,7 @@ async function roundtrip(version: Version, fetch: Fetch): Promise<Fetch> {
 }
 
 function sample(): Fetch {
-	return new Fetch(Path.from("room/1"), "video", 3, 42);
+	return new Fetch({ broadcast: Path.from("room/1"), track: "video", priority: 3, group: 42 });
 }
 
 test("Fetch round-trips on draft-03/04/05", async () => {

--- a/js/net/src/lite/fetch.ts
+++ b/js/net/src/lite/fetch.ts
@@ -1,7 +1,7 @@
 import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
 import * as Message from "./message.ts";
-import { Version } from "./version.ts";
+import { hasFrameBounds, Version } from "./version.ts";
 
 function guardFetch(version: Version) {
 	switch (version) {
@@ -19,36 +19,72 @@ export class Fetch {
 	priority: number;
 	group: number;
 
-	constructor(broadcast: Path.Valid, track: string, priority: number, group: number) {
+	/** Index of the first frame to return; 0 is the start of the group. Lite-06+. */
+	startFrame: number;
+
+	/**
+	 * Index of the last frame to return (inclusive), or undefined for through the end
+	 * of the group. Lite-06+.
+	 */
+	endFrame?: number;
+
+	constructor(
+		broadcast: Path.Valid,
+		track: string,
+		priority: number,
+		group: number,
+		startFrame = 0,
+		endFrame?: number,
+	) {
 		this.broadcast = broadcast;
 		this.track = track;
 		this.priority = priority;
 		this.group = group;
+		this.startFrame = startFrame;
+		this.endFrame = endFrame;
 	}
 
-	async #encode(w: Writer) {
+	async #encode(w: Writer, version: Version) {
 		await w.string(Path.encode(this.broadcast));
 		await w.string(this.track);
 		await w.u8(this.priority);
 		await w.u53(this.group);
+
+		if (hasFrameBounds(version)) {
+			await w.u53(this.startFrame);
+			await w.u53(this.endFrame !== undefined ? this.endFrame + 1 : 0);
+		} else if (this.startFrame !== 0 || this.endFrame !== undefined) {
+			// The peer would serve the whole group, including frames we excluded.
+			throw new Error("frame bounds not supported for this version");
+		}
 	}
 
-	static async #decode(r: Reader): Promise<Fetch> {
+	static async #decode(r: Reader, version: Version): Promise<Fetch> {
 		const broadcast = Path.decode(await r.string());
 		const track = await r.string();
 		const priority = await r.u8();
 		const group = await r.u53();
 
-		return new Fetch(broadcast, track, priority, group);
+		if (!hasFrameBounds(version)) {
+			return new Fetch(broadcast, track, priority, group);
+		}
+
+		const startFrame = await r.u53();
+		const endFrame = await r.u53();
+		if (endFrame > 0 && endFrame - 1 < startFrame) {
+			throw new Error("fetch frame range ends before it starts");
+		}
+
+		return new Fetch(broadcast, track, priority, group, startFrame, endFrame > 0 ? endFrame - 1 : undefined);
 	}
 
 	async encode(w: Writer, version: Version): Promise<void> {
 		guardFetch(version);
-		return Message.encode(w, (w) => this.#encode(w));
+		return Message.encode(w, (w) => this.#encode(w, version));
 	}
 
 	static async decode(r: Reader, version: Version): Promise<Fetch> {
 		guardFetch(version);
-		return Message.decode(r, (r) => Fetch.#decode(r));
+		return Message.decode(r, (r) => Fetch.#decode(r, version));
 	}
 }

--- a/js/net/src/lite/fetch.ts
+++ b/js/net/src/lite/fetch.ts
@@ -28,14 +28,21 @@ export class Fetch {
 	 */
 	endFrame?: number;
 
-	constructor(
-		broadcast: Path.Valid,
-		track: string,
-		priority: number,
-		group: number,
+	constructor({
+		broadcast,
+		track,
+		priority,
+		group,
 		startFrame = 0,
-		endFrame?: number,
-	) {
+		endFrame,
+	}: {
+		broadcast: Path.Valid;
+		track: string;
+		priority: number;
+		group: number;
+		startFrame?: number;
+		endFrame?: number;
+	}) {
 		this.broadcast = broadcast;
 		this.track = track;
 		this.priority = priority;
@@ -66,7 +73,7 @@ export class Fetch {
 		const group = await r.u53();
 
 		if (!hasFrameBounds(version)) {
-			return new Fetch(broadcast, track, priority, group);
+			return new Fetch({ broadcast, track, priority, group });
 		}
 
 		const startFrame = await r.u53();
@@ -75,7 +82,14 @@ export class Fetch {
 			throw new Error("fetch frame range ends before it starts");
 		}
 
-		return new Fetch(broadcast, track, priority, group, startFrame, endFrame > 0 ? endFrame - 1 : undefined);
+		return new Fetch({
+			broadcast,
+			track,
+			priority,
+			group,
+			startFrame,
+			endFrame: endFrame > 0 ? endFrame - 1 : undefined,
+		});
 	}
 
 	async encode(w: Writer, version: Version): Promise<void> {

--- a/js/net/src/lite/group.ts
+++ b/js/net/src/lite/group.ts
@@ -1,34 +1,55 @@
 import type { Reader, Writer } from "../stream.ts";
 import * as Message from "./message.ts";
+import { hasFrameBounds, type Version } from "./version.ts";
 
 export class Group {
 	subscribe: bigint;
 	sequence: number;
 
-	constructor(subscribe: bigint, sequence: number) {
+	/**
+	 * The index of the first frame on this stream within the group.
+	 *
+	 * 0 (the common case) means the stream carries the group from its beginning. A
+	 * higher value means the leading frames are not here, either because the
+	 * subscription started partway into the group or because the publisher only holds
+	 * the tail. Lite-06+; older versions always start at 0.
+	 */
+	frameStart: number;
+
+	constructor(subscribe: bigint, sequence: number, frameStart = 0) {
 		this.subscribe = subscribe;
 		this.sequence = sequence;
+		this.frameStart = frameStart;
 	}
 
-	async #encode(w: Writer) {
+	async #encode(w: Writer, version: Version) {
 		await w.u62(this.subscribe);
 		await w.u53(this.sequence);
+		if (hasFrameBounds(version)) {
+			await w.u53(this.frameStart);
+		} else if (this.frameStart !== 0) {
+			// The peer would number the frames from 0 and silently misalign the group.
+			throw new Error("frame offsets not supported for this version");
+		}
 	}
 
-	static async #decode(r: Reader): Promise<Group> {
-		return new Group(await r.u62(), await r.u53());
+	static async #decode(r: Reader, version: Version): Promise<Group> {
+		const subscribe = await r.u62();
+		const sequence = await r.u53();
+		const frameStart = hasFrameBounds(version) ? await r.u53() : 0;
+		return new Group(subscribe, sequence, frameStart);
 	}
 
-	async encode(w: Writer): Promise<void> {
-		return Message.encode(w, this.#encode.bind(this));
+	async encode(w: Writer, version: Version): Promise<void> {
+		return Message.encode(w, (w) => this.#encode(w, version));
 	}
 
-	static async decode(r: Reader): Promise<Group> {
-		return Message.decode(r, Group.#decode);
+	static async decode(r: Reader, version: Version): Promise<Group> {
+		return Message.decode(r, (r) => Group.#decode(r, version));
 	}
 
-	static async decodeMaybe(r: Reader): Promise<Group | undefined> {
-		return Message.decodeMaybe(r, Group.#decode);
+	static async decodeMaybe(r: Reader, version: Version): Promise<Group | undefined> {
+		return Message.decodeMaybe(r, (r) => Group.#decode(r, version));
 	}
 }
 

--- a/js/net/src/lite/group.ts
+++ b/js/net/src/lite/group.ts
@@ -16,7 +16,15 @@ export class Group {
 	 */
 	frameStart: number;
 
-	constructor(subscribe: bigint, sequence: number, frameStart = 0) {
+	constructor({
+		subscribe,
+		sequence,
+		frameStart = 0,
+	}: {
+		subscribe: bigint;
+		sequence: number;
+		frameStart?: number;
+	}) {
 		this.subscribe = subscribe;
 		this.sequence = sequence;
 		this.frameStart = frameStart;
@@ -37,7 +45,7 @@ export class Group {
 		const subscribe = await r.u62();
 		const sequence = await r.u53();
 		const frameStart = hasFrameBounds(version) ? await r.u53() : 0;
-		return new Group(subscribe, sequence, frameStart);
+		return new Group({ subscribe, sequence, frameStart });
 	}
 
 	async encode(w: Writer, version: Version): Promise<void> {

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -3,11 +3,12 @@ import { Producer as BroadcastProducer } from "../broadcast.ts";
 import { Producer as GroupProducer } from "../group.ts";
 import { createMockTransportPair } from "../mock.ts";
 import * as Path from "../path.ts";
-import { Stream } from "../stream.ts";
+import { Reader, Stream } from "../stream.ts";
+import { Group as GroupMessage } from "./group.ts";
 import { randomOrigin } from "./origin.ts";
 import { Publisher } from "./publisher.ts";
 import { decodeSubscribeResponse, Subscribe } from "./subscribe.ts";
-import { ALPN_05, Version } from "./version.ts";
+import { ALPN_05, ALPN_06_WIP, Version } from "./version.ts";
 
 // Delivers `sequences` in the given order, finishes the track, and returns the
 // SUBSCRIBE_END boundary the publisher put on the wire.
@@ -67,4 +68,144 @@ test("lite draft-05: subscribe end clears the max sequence when groups arrive ou
 // without colliding with a track whose sole group was sequence 0.
 test("lite draft-05: subscribe end is 0 when no groups were produced", async () => {
 	expect(await subscribeEnd([])).toBe(0);
+});
+
+/** One group stream the publisher put on the wire. */
+type Served = { sequence: number; frameStart: number; payloads: string[] };
+
+/**
+ * Serves `groups` (frame payloads per group, keyed by sequence) under `bounds`, and
+ * reports every group stream that reached the wire plus the resolved SUBSCRIBE_START.
+ */
+async function serve(
+	groups: Record<number, string[]>,
+	bounds: { startGroup?: number; startFrame?: number; endGroup?: number; endFrame?: number },
+): Promise<{ start?: number; served: Served[] }> {
+	const pair = createMockTransportPair(ALPN_06_WIP);
+	const publisher = new Publisher(pair.server, Version.DRAFT_06, randomOrigin());
+
+	const broadcast = new BroadcastProducer();
+	const track = broadcast.createTrack("video");
+	publisher.publish(Path.from("test"), broadcast);
+
+	const client = await Stream.open(pair.client);
+	const server = await Stream.accept(pair.server);
+	if (!server) throw new Error("publisher never accepted the subscribe stream");
+
+	const msg = new Subscribe({
+		id: 0n,
+		broadcast: Path.from("test"),
+		track: "video",
+		priority: 0,
+		startGroup: bounds.startGroup,
+		startFrame: bounds.startFrame ?? 0,
+		endGroup: bounds.endGroup,
+		endFrame: bounds.endFrame,
+	});
+	void publisher.runSubscribe(msg, server);
+
+	for (const [sequence, frames] of Object.entries(groups)) {
+		const group = new GroupProducer(Number(sequence));
+		for (const frame of frames) group.writeString(frame);
+		group.close();
+		track.writeGroup(group);
+
+		// Let the publisher drain each group before the next, so the streams arrive in
+		// the order written rather than whatever the cache hands over in one batch.
+		await new Promise((resolve) => setTimeout(resolve, 5));
+	}
+	track.close();
+
+	const reader = pair.client.incomingUnidirectionalStreams.getReader();
+	try {
+		const served: Served[] = [];
+		for (;;) {
+			// The publisher may simply have nothing more to send, so race the read
+			// against an idle timeout. Clear the timer either way, and cancel rather
+			// than release below: releasing with a read still pending would throw.
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			const idle = new Promise<undefined>((resolve) => {
+				timer = setTimeout(() => resolve(undefined), 50);
+			});
+			const next = await Promise.race([reader.read(), idle]);
+			clearTimeout(timer);
+			if (!next || next.done) break;
+
+			const stream = new Reader(next.value);
+			await stream.u53(); // stream type
+			const header = await GroupMessage.decode(stream, Version.DRAFT_06);
+
+			const payloads: string[] = [];
+			while (!(await stream.done())) {
+				// Each frame is a zigzag timestamp delta, then a length-prefixed payload.
+				await stream.u62();
+				payloads.push(new TextDecoder().decode(await stream.read(await stream.u53())));
+			}
+			served.push({ sequence: header.sequence, frameStart: header.frameStart, payloads });
+		}
+
+		let start: number | undefined;
+		for (;;) {
+			const resp = await decodeSubscribeResponse(client.reader, Version.DRAFT_06);
+			if ("start" in resp) start = resp.start.group;
+			if ("end" in resp) break;
+		}
+		return { start, served };
+	} finally {
+		// Settles the pending read as well as dropping the stream.
+		await reader.cancel();
+		broadcast.close();
+		client.close();
+	}
+}
+
+// The response has no per-frame index, so the receiver numbers what it gets from the
+// GROUP header. Ignoring the requested start would relabel frame 0 as frame N.
+test("lite draft-06: a subscription starting mid-group skips the head", async () => {
+	const { served } = await serve({ 0: ["a", "b", "c", "d"] }, { startGroup: 0, startFrame: 2 });
+	expect(served).toEqual([{ sequence: 0, frameStart: 2, payloads: ["c", "d"] }]);
+});
+
+// The end bound is inclusive.
+test("lite draft-06: a subscription capped mid-group stops at the end frame", async () => {
+	const { served } = await serve(
+		{ 0: ["a", "b", "c", "d"] },
+		{ startGroup: 0, startFrame: 1, endGroup: 0, endFrame: 2 },
+	);
+	expect(served).toEqual([{ sequence: 0, frameStart: 1, payloads: ["b", "c"] }]);
+});
+
+// The default is the whole group, byte-identical to a draft with no such field.
+test("lite draft-06: an unbounded subscription serves the whole group", async () => {
+	const { served } = await serve({ 0: ["a", "b"] }, {});
+	expect(served).toEqual([{ sequence: 0, frameStart: 0, payloads: ["a", "b"] }]);
+});
+
+// The frame bounds qualify their own group and nothing else. Without a span like this,
+// an implementation that caps every group passes just as well.
+test("lite draft-06: frame bounds apply only to the groups they name", async () => {
+	const { served } = await serve(
+		{ 0: ["a0", "a1", "a2"], 1: ["b0", "b1", "b2"], 2: ["c0", "c1", "c2"] },
+		{ startGroup: 0, startFrame: 2, endGroup: 2, endFrame: 0 },
+	);
+	expect(served).toEqual([
+		{ sequence: 0, frameStart: 2, payloads: ["a2"] },
+		// Between the bounds: served whole, from frame 0, with no cap.
+		{ sequence: 1, frameStart: 0, payloads: ["b0", "b1", "b2"] },
+		{ sequence: 2, frameStart: 0, payloads: ["c0"] },
+	]);
+});
+
+// A group below the requested start was never asked for. Serving it also lets
+// SUBSCRIBE_START name a group below the start, which the draft forbids.
+test("lite draft-06: groups below the start group are not served", async () => {
+	const { start, served } = await serve({ 0: ["x"], 1: ["y"], 2: ["z"] }, { startGroup: 1 });
+	expect(served.map((s) => s.sequence)).toEqual([1, 2]);
+	expect(start).toBe(1);
+});
+
+// The end group is inclusive; anything past it is outside the subscription.
+test("lite draft-06: groups past the end group are not served", async () => {
+	const { served } = await serve({ 0: ["w"], 1: ["x"], 2: ["y"], 3: ["z"] }, { startGroup: 1, endGroup: 2 });
+	expect(served.map((s) => s.sequence)).toEqual([1, 2]);
 });

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -48,11 +48,6 @@ function supportsTrackStream(version: Version): boolean {
 }
 
 /**
- * Handles publishing broadcasts and managing their lifecycle.
- *
- * @internal
- */
-/**
  * The frame bounds a subscription placed on its start and end group, as they stand
  * after any SUBSCRIBE_UPDATE.
  */
@@ -93,6 +88,11 @@ type ServeGroup = {
 	end?: number;
 };
 
+/**
+ * Handles publishing broadcasts and managing their lifecycle.
+ *
+ * @internal
+ */
 export class Publisher {
 	// The version of the connection.
 	readonly version: Version;

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -52,6 +52,47 @@ function supportsTrackStream(version: Version): boolean {
  *
  * @internal
  */
+/**
+ * The frame bounds a subscription placed on its start and end group, as they stand
+ * after any SUBSCRIBE_UPDATE.
+ */
+type FrameBounds = {
+	startGroup?: number;
+	startFrame: number;
+	endGroup?: number;
+	endFrame?: number;
+};
+
+/**
+ * The frames of `sequence` a subscription asked for, as a start index and an inclusive
+ * end, or `undefined` when the group falls outside the subscription entirely.
+ *
+ * The frame bounds qualify the start and end group only; every group between them is
+ * served whole. A group outside `[startGroup, endGroup]` was never asked for, and
+ * serving it would also let SUBSCRIBE_START report a group below the requested start.
+ */
+function frameRange(bounds: FrameBounds, sequence: number): { start: number; end?: number } | undefined {
+	if (bounds.startGroup !== undefined && sequence < bounds.startGroup) return;
+	if (bounds.endGroup !== undefined && sequence > bounds.endGroup) return;
+
+	return {
+		start: bounds.startGroup === sequence ? bounds.startFrame : 0,
+		end: bounds.endGroup === sequence ? bounds.endFrame : undefined,
+	};
+}
+
+/** What serving one group needs beyond the group itself. */
+type ServeGroup = {
+	/** The Subscribe ID the GROUP message references. */
+	sub: bigint;
+	/** The track's advertised timescale, which every frame timestamp is converted to. */
+	timescale: Timescale;
+	/** First frame to send; anything below it was excluded by the subscription. */
+	start: number;
+	/** Last frame to send (inclusive), or undefined for the rest of the group. */
+	end?: number;
+};
+
 export class Publisher {
 	// The version of the connection.
 	readonly version: Version;
@@ -251,6 +292,15 @@ export class Publisher {
 
 		const track = broadcast.subscribe(msg.track, { priority: msg.priority });
 
+		// Frame bounds qualify the start and end group only, and SUBSCRIBE_UPDATE can move
+		// them, so the serving loop reads them from here rather than closing over `msg`.
+		const bounds: FrameBounds = {
+			startGroup: msg.startGroup,
+			startFrame: msg.startFrame,
+			endGroup: msg.endGroup,
+			endFrame: msg.endFrame,
+		};
+
 		// The best-effort datagram loop, started once serving begins. It parks when the
 		// track finishes (recvDatagram returns undefined), so #runTrack alone ends the
 		// subscription; awaited during teardown so it doesn't outlive the subscription.
@@ -279,7 +329,12 @@ export class Publisher {
 
 			console.debug(`publish ok: broadcast=${msg.broadcast} track=${track.name}`);
 
-			const serving = this.#runTrack(msg.id, msg.broadcast, track, stream.writer, timescale);
+			const serving = this.#runTrack(track, stream.writer, {
+				sub: msg.id,
+				broadcast: msg.broadcast,
+				timescale,
+				bounds,
+			});
 
 			// Serve datagrams concurrently with groups whenever the transport carries them
 			// (the writer exists iff so). No group fallback: otherwise they simply aren't sent.
@@ -298,6 +353,10 @@ export class Publisher {
 						`subscribe update: broadcast=${msg.broadcast} track=${track.name} priority=${result.priority}`,
 					);
 					track.update({ priority: result.priority });
+					bounds.startGroup = result.startGroup;
+					bounds.startFrame = result.startFrame;
+					bounds.endGroup = result.endGroup;
+					bounds.endFrame = result.endFrame;
 				}
 			}
 
@@ -338,7 +397,7 @@ export class Publisher {
 			// The timescale is immutable, so serve exactly what TRACK_INFO advertised.
 			const info = await this.#resolveTrackInfo(msg.broadcast, msg.track);
 			group = await broadcast.track(msg.track).fetchGroup(msg.group, { priority: msg.priority });
-			await this.#runFetchGroup(group, stream.writer, Timescale(info.timescale));
+			await this.#runFetchGroup(group, stream.writer, Timescale(info.timescale), msg.startFrame, msg.endFrame);
 			console.debug(`fetch done: broadcast=${msg.broadcast} track=${msg.track} group=${msg.group}`);
 			stream.close();
 			group.close();
@@ -361,7 +420,12 @@ export class Publisher {
 	 *
 	 * @internal
 	 */
-	async #runTrack(sub: bigint, broadcast: Path.Valid, track: track.Subscriber, stream: Writer, timescale: Timescale) {
+	async #runTrack(
+		track: track.Subscriber,
+		stream: Writer,
+		serving: { sub: bigint; broadcast: Path.Valid; timescale: Timescale; bounds: FrameBounds },
+	) {
+		const { sub, broadcast, timescale, bounds } = serving;
 		// Lite-05+ resolves the range on the subscribe stream: SUBSCRIBE_START once the
 		// first group is known, SUBSCRIBE_END when the track finishes.
 		const emitRange = supportsTrackStream(this.version);
@@ -381,13 +445,22 @@ export class Publisher {
 					break;
 				}
 
+				const range = frameRange(bounds, group.sequence);
+				if (!range) {
+					// Outside the subscription's group range, so it was never asked for.
+					// Serving it would also let SUBSCRIBE_START name a group below the
+					// requested start.
+					group.close();
+					continue;
+				}
+
 				if (emitRange && !startSent) {
 					startSent = true;
 					await encodeSubscribeResponse(stream, { start: new SubscribeStart(group.sequence) }, this.version);
 				}
 				end = Math.max(end, group.sequence + 1);
 
-				void this.#runGroup(sub, group, timescale);
+				void this.#runGroup(group, { sub, timescale, start: range.start, end: range.end });
 			}
 
 			if (emitRange) {
@@ -501,9 +574,24 @@ export class Publisher {
 	 */
 	// Serialize a fetched group's frames onto the FETCH stream as bare records: each a
 	// zigzag-delta timestamp (at the track's advertised timescale) followed by size + bytes.
-	async #runFetchGroup(group: group.Consumer, stream: Writer, timescale: Timescale) {
+	async #runFetchGroup(
+		group: group.Consumer,
+		stream: Writer,
+		timescale: Timescale,
+		startFrame: number,
+		endFrame?: number,
+	) {
+		// The response carries no header, so the receiver numbers the first frame it gets
+		// as `startFrame`. Skipping the head here is the only thing keeping those numbers
+		// honest; a group that ends before we reach it can't be served at all.
+		for (let i = 0; i < startFrame; i++) {
+			if (!(await Promise.race([group.readFrame(), stream.closed]))) {
+				throw new Error(`fetch group ended at frame ${i}, before the requested start ${startFrame}`);
+			}
+		}
+
 		let prevTs = 0n;
-		for (;;) {
+		for (let index = startFrame; endFrame === undefined || index <= endFrame; index++) {
 			const frame = await Promise.race([group.readFrame(), stream.closed]);
 			if (!frame) break;
 
@@ -516,22 +604,40 @@ export class Publisher {
 		}
 	}
 
-	async #runGroup(sub: bigint, group: group.Consumer, timescale: Timescale) {
-		const msg = new GroupMessage(sub, group.sequence);
+	async #runGroup(group: group.Consumer, { sub, timescale, start: startFrame, end: endFrame }: ServeGroup) {
+		// This model holds whole groups, so frame `startFrame` is always reachable unless
+		// the group ends first. Declaring it up front keeps the stream self-describing.
+		const msg = new GroupMessage(sub, group.sequence, startFrame);
 		try {
 			const stream = await Writer.open(this.#quic);
 			await stream.u53(0); // stream type
-			await msg.encode(stream);
+			await msg.encode(stream, this.version);
 
 			// Lite05+ prefixes every frame with a zigzag-delta timestamp at the track's
 			// advertised timescale; older drafts omit it.
 			const timestamps = supportsTrackStream(this.version);
 			let prevTs = 0n;
+			// Whether the cursor ever reached the requested start, which decides how the
+			// end of the group is read below.
+			let reached = startFrame === 0;
 
 			try {
 				for (;;) {
-					const frame = await Promise.race([group.readFrame(), stream.closed]);
-					if (!frame) break;
+					const frame = await Promise.race([group.readFrameSequence(), stream.closed]);
+					if (!frame) {
+						// The group ended before the frame the subscriber asked to start
+						// at, so this publisher can't serve the range at all. FINning here
+						// would claim an empty group under that index; reset so it reads
+						// as the gap it is.
+						if (!reached) throw new Error(`group ended before frame ${startFrame}`);
+						break;
+					}
+
+					// Frames below the requested start were excluded, and the receiver
+					// numbers what it gets from `startFrame`.
+					if (frame.sequence < startFrame) continue;
+					if (endFrame !== undefined && frame.sequence > endFrame) break;
+					reached = true;
 
 					if (timestamps) {
 						// Convert each frame to the track's advertised timescale.

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -88,6 +88,9 @@ type ServeGroup = {
 	end?: number;
 };
 
+/** What serving fetched frames needs beyond the group and destination stream. */
+type ServeFetch = Omit<ServeGroup, "sub">;
+
 /**
  * Handles publishing broadcasts and managing their lifecycle.
  *
@@ -397,7 +400,11 @@ export class Publisher {
 			// The timescale is immutable, so serve exactly what TRACK_INFO advertised.
 			const info = await this.#resolveTrackInfo(msg.broadcast, msg.track);
 			group = await broadcast.track(msg.track).fetchGroup(msg.group, { priority: msg.priority });
-			await this.#runFetchGroup(group, stream.writer, Timescale(info.timescale), msg.startFrame, msg.endFrame);
+			await this.#runFetchGroup(group, stream.writer, {
+				timescale: Timescale(info.timescale),
+				start: msg.startFrame,
+				end: msg.endFrame,
+			});
 			console.debug(`fetch done: broadcast=${msg.broadcast} track=${msg.track} group=${msg.group}`);
 			stream.close();
 			group.close();
@@ -577,9 +584,7 @@ export class Publisher {
 	async #runFetchGroup(
 		group: group.Consumer,
 		stream: Writer,
-		timescale: Timescale,
-		startFrame: number,
-		endFrame?: number,
+		{ timescale, start: startFrame, end: endFrame }: ServeFetch,
 	) {
 		// The response carries no header, so the receiver numbers the first frame it gets
 		// as `startFrame`. Skipping the head here is the only thing keeping those numbers
@@ -607,7 +612,7 @@ export class Publisher {
 	async #runGroup(group: group.Consumer, { sub, timescale, start: startFrame, end: endFrame }: ServeGroup) {
 		// This model holds whole groups, so frame `startFrame` is always reachable unless
 		// the group ends first. Declaring it up front keeps the stream self-describing.
-		const msg = new GroupMessage(sub, group.sequence, startFrame);
+		const msg = new GroupMessage({ subscribe: sub, sequence: group.sequence, frameStart: startFrame });
 		try {
 			const stream = await Writer.open(this.#quic);
 			await stream.u53(0); // stream type

--- a/js/net/src/lite/subscribe.test.ts
+++ b/js/net/src/lite/subscribe.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from "bun:test";
+import * as Path from "../path.ts";
 import { Reader, Writer } from "../stream.ts";
 import {
 	decodeSubscribeResponse,
 	encodeSubscribeResponse,
+	Subscribe,
 	SubscribeDrop,
 	SubscribeEnd,
 	SubscribeOk,
@@ -36,6 +38,15 @@ async function encode(version: Version, resp: SubscribeResponse): Promise<Uint8A
 async function responseRoundtrip(version: Version, resp: SubscribeResponse): Promise<SubscribeResponse> {
 	const reader = new Reader(undefined, await encode(version, resp));
 	return decodeSubscribeResponse(reader, version);
+}
+
+async function encodeSubscribe(msg: Subscribe): Promise<void> {
+	const writer = new Writer(new WritableStream<Uint8Array>());
+	try {
+		await msg.encode(writer, Version.DRAFT_06);
+	} finally {
+		writer.close();
+	}
 }
 
 test("SubscribeOk round-trips priority/ordered/groups on draft-04", async () => {
@@ -80,4 +91,19 @@ test("SubscribeDrop is type 0x2 on draft-05 and 0x1 on draft-04", async () => {
 
 test("SUBSCRIBE_OK is rejected on draft-05", async () => {
 	await expect(encode(Version.DRAFT_05, { ok: new SubscribeOk({ priority: 1 }) })).rejects.toThrow();
+});
+
+test("frame bounds without their group bounds are rejected before encoding", async () => {
+	const base = {
+		id: 1n,
+		broadcast: Path.from("room"),
+		track: "video",
+		priority: 0,
+	};
+	await expect(encodeSubscribe(new Subscribe({ ...base, startFrame: 3 }))).rejects.toThrow(
+		"frame bound without a group bound",
+	);
+	await expect(encodeSubscribe(new Subscribe({ ...base, endFrame: 7 }))).rejects.toThrow(
+		"frame bound without a group bound",
+	);
 });

--- a/js/net/src/lite/subscribe.ts
+++ b/js/net/src/lite/subscribe.ts
@@ -1,7 +1,50 @@
 import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
 import * as Message from "./message.ts";
-import { Version } from "./version.ts";
+import { hasFrameBounds, Version } from "./version.ts";
+
+/**
+ * Encode the trailing `Frame Start` / `Frame End` pair shared by SUBSCRIBE and
+ * SUBSCRIBE_UPDATE. A no-op before lite-06, which has nowhere to put them.
+ */
+async function encodeFrameBounds(w: Writer, version: Version, startFrame: number, endFrame?: number) {
+	if (!hasFrameBounds(version)) {
+		// Silently widening to the whole group would deliver frames we excluded.
+		if (startFrame !== 0 || endFrame !== undefined) {
+			throw new Error("frame bounds not supported for this version");
+		}
+		return;
+	}
+
+	await w.u53(startFrame);
+	await w.u53(endFrame !== undefined ? endFrame + 1 : 0);
+}
+
+/**
+ * Decode the trailing `Frame Start` / `Frame End` pair, defaulting to the whole group.
+ *
+ * A frame bound without the group bound it qualifies is a protocol violation: frames
+ * are numbered per group, so there is nothing to count from.
+ */
+async function decodeFrameBounds(
+	r: Reader,
+	version: Version,
+	startGroup?: number,
+	endGroup?: number,
+): Promise<{ startFrame: number; endFrame?: number }> {
+	if (!hasFrameBounds(version)) {
+		return { startFrame: 0 };
+	}
+
+	const startFrame = await r.u53();
+	const endFrame = await r.u53();
+
+	if ((startFrame !== 0 && startGroup === undefined) || (endFrame !== 0 && endGroup === undefined)) {
+		throw new Error("frame bound without a group bound");
+	}
+
+	return { startFrame, endFrame: endFrame > 0 ? endFrame - 1 : undefined };
+}
 
 export class SubscribeUpdate {
 	priority: number;
@@ -9,6 +52,10 @@ export class SubscribeUpdate {
 	maxLatency: number;
 	startGroup?: number;
 	endGroup?: number;
+	/** See {@link Subscribe.startFrame}. */
+	startFrame: number;
+	/** See {@link Subscribe.endFrame}. */
+	endFrame?: number;
 
 	constructor(props: {
 		priority: number;
@@ -16,12 +63,16 @@ export class SubscribeUpdate {
 		maxLatency?: number;
 		startGroup?: number;
 		endGroup?: number;
+		startFrame?: number;
+		endFrame?: number;
 	}) {
 		this.priority = props.priority;
 		this.ordered = props.ordered ?? false;
 		this.maxLatency = props.maxLatency ?? 0;
 		this.startGroup = props.startGroup;
 		this.endGroup = props.endGroup;
+		this.startFrame = props.startFrame ?? 0;
+		this.endFrame = props.endFrame;
 	}
 
 	async #encode(w: Writer, version: Version) {
@@ -36,6 +87,7 @@ export class SubscribeUpdate {
 				await w.u53(this.maxLatency);
 				await w.u53(this.startGroup !== undefined ? this.startGroup + 1 : 0);
 				await w.u53(this.endGroup !== undefined ? this.endGroup + 1 : 0);
+				await encodeFrameBounds(w, version, this.startFrame, this.endFrame);
 				break;
 		}
 	}
@@ -49,14 +101,21 @@ export class SubscribeUpdate {
 				const priority = await r.u8();
 				const ordered = await r.bool();
 				const maxLatency = await r.u53();
-				const startGroup = await r.u53();
-				const endGroup = await r.u53();
+				const startGroup = (await r.u53()) || undefined;
+				const endGroup = (await r.u53()) || undefined;
+				const frames = await decodeFrameBounds(
+					r,
+					version,
+					startGroup !== undefined ? startGroup - 1 : undefined,
+					endGroup !== undefined ? endGroup - 1 : undefined,
+				);
 				return new SubscribeUpdate({
 					priority,
 					ordered,
 					maxLatency,
-					startGroup: startGroup > 0 ? startGroup - 1 : undefined,
-					endGroup: endGroup > 0 ? endGroup - 1 : undefined,
+					startGroup: startGroup !== undefined ? startGroup - 1 : undefined,
+					endGroup: endGroup !== undefined ? endGroup - 1 : undefined,
+					...frames,
 				});
 			}
 		}
@@ -86,6 +145,18 @@ export class Subscribe {
 	startGroup?: number;
 	endGroup?: number;
 
+	/**
+	 * First frame to deliver within `startGroup`'s group; 0 is the whole group.
+	 * Lite-06+, and meaningless without an explicit `startGroup`.
+	 */
+	startFrame: number;
+
+	/**
+	 * Last frame to deliver (inclusive) within `endGroup`'s group, or undefined for the
+	 * whole group. Lite-06+, and meaningless without an explicit `endGroup`.
+	 */
+	endFrame?: number;
+
 	constructor(props: {
 		id: bigint;
 		broadcast: Path.Valid;
@@ -95,6 +166,8 @@ export class Subscribe {
 		maxLatency?: number;
 		startGroup?: number;
 		endGroup?: number;
+		startFrame?: number;
+		endFrame?: number;
 	}) {
 		this.id = props.id;
 		this.broadcast = props.broadcast;
@@ -104,6 +177,8 @@ export class Subscribe {
 		this.maxLatency = props.maxLatency ?? 0;
 		this.startGroup = props.startGroup;
 		this.endGroup = props.endGroup;
+		this.startFrame = props.startFrame ?? 0;
+		this.endFrame = props.endFrame;
 	}
 
 	async #encode(w: Writer, version: Version) {
@@ -121,6 +196,7 @@ export class Subscribe {
 				await w.u53(this.maxLatency);
 				await w.u53(this.startGroup !== undefined ? this.startGroup + 1 : 0);
 				await w.u53(this.endGroup !== undefined ? this.endGroup + 1 : 0);
+				await encodeFrameBounds(w, version, this.startFrame, this.endFrame);
 				break;
 		}
 	}
@@ -138,8 +214,11 @@ export class Subscribe {
 			default: {
 				const ordered = await r.bool();
 				const maxLatency = await r.u53();
-				const startGroup = await r.u53();
-				const endGroup = await r.u53();
+				const startGroup = (await r.u53()) || undefined;
+				const endGroup = (await r.u53()) || undefined;
+				const start = startGroup !== undefined ? startGroup - 1 : undefined;
+				const end = endGroup !== undefined ? endGroup - 1 : undefined;
+				const frames = await decodeFrameBounds(r, version, start, end);
 				return new Subscribe({
 					id,
 					broadcast,
@@ -147,8 +226,9 @@ export class Subscribe {
 					priority,
 					ordered,
 					maxLatency,
-					startGroup: startGroup > 0 ? startGroup - 1 : undefined,
-					endGroup: endGroup > 0 ? endGroup - 1 : undefined,
+					startGroup: start,
+					endGroup: end,
+					...frames,
 				});
 			}
 		}
@@ -261,6 +341,10 @@ export class SubscribeOk {
  * Resolves the absolute start group of a Draft-05+ subscription. The first message
  * the publisher sends, once the start group is known. A value greater than the
  * requested start implicitly drops the leading range.
+ *
+ * There is no start frame: a partial group is only served to a subscriber that asked
+ * for one, so delivery begins either at the requested `startFrame` (when this is the
+ * requested group) or at frame 0 (when the publisher resolved to a later one).
  */
 export class SubscribeStart {
 	group: number;

--- a/js/net/src/lite/subscribe.ts
+++ b/js/net/src/lite/subscribe.ts
@@ -7,7 +7,20 @@ import { hasFrameBounds, Version } from "./version.ts";
  * Encode the trailing `Frame Start` / `Frame End` pair shared by SUBSCRIBE and
  * SUBSCRIBE_UPDATE. A no-op before lite-06, which has nowhere to put them.
  */
-async function encodeFrameBounds(w: Writer, version: Version, startFrame: number, endFrame?: number) {
+async function encodeFrameBounds(
+	w: Writer,
+	version: Version,
+	{
+		startGroup,
+		startFrame,
+		endGroup,
+		endFrame,
+	}: { startGroup?: number; startFrame: number; endGroup?: number; endFrame?: number },
+) {
+	if ((startFrame !== 0 && startGroup === undefined) || (endFrame !== undefined && endGroup === undefined)) {
+		throw new Error("frame bound without a group bound");
+	}
+
 	if (!hasFrameBounds(version)) {
 		// Silently widening to the whole group would deliver frames we excluded.
 		if (startFrame !== 0 || endFrame !== undefined) {
@@ -87,7 +100,7 @@ export class SubscribeUpdate {
 				await w.u53(this.maxLatency);
 				await w.u53(this.startGroup !== undefined ? this.startGroup + 1 : 0);
 				await w.u53(this.endGroup !== undefined ? this.endGroup + 1 : 0);
-				await encodeFrameBounds(w, version, this.startFrame, this.endFrame);
+				await encodeFrameBounds(w, version, this);
 				break;
 		}
 	}
@@ -196,7 +209,7 @@ export class Subscribe {
 				await w.u53(this.maxLatency);
 				await w.u53(this.startGroup !== undefined ? this.startGroup + 1 : 0);
 				await w.u53(this.endGroup !== undefined ? this.endGroup + 1 : 0);
-				await encodeFrameBounds(w, version, this.startFrame, this.endFrame);
+				await encodeFrameBounds(w, version, this);
 				break;
 		}
 	}

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -521,7 +521,10 @@ export class Subscriber {
 
 			try {
 				await stream.writer.u53(StreamId.Fetch);
-				await new FetchMessage(broadcast, track, priority, sequence).encode(stream.writer, this.version);
+				await new FetchMessage({ broadcast, track, priority, group: sequence }).encode(
+					stream.writer,
+					this.version,
+				);
 			} catch (err: unknown) {
 				stream.abort(error(err));
 				throw err;

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -113,10 +113,13 @@ export function hasRouteCost(version: Version): boolean {
 	}
 }
 
-/** Whether SUBSCRIBE, SUBSCRIBE_UPDATE, FETCH, SUBSCRIBE_OK, and GROUP carry frame
- * indices alongside their group sequences, so a subscription or fetch can start and end
- * partway through a group. Added in lite-06. Older versions only address whole groups,
- * so a route change has to wait for the next group before it can resume. */
+/** Whether SUBSCRIBE, SUBSCRIBE_UPDATE, FETCH, and GROUP carry frame indices alongside
+ * their group sequences, so a subscription or fetch can start and end partway through a
+ * group. Added in lite-06. Older versions only address whole groups, so a route change
+ * has to wait for the next group before it can resume.
+ *
+ * SUBSCRIBE_OK is deliberately not in that list: the resolved start frame follows from
+ * its group plus the subscriber's own request, so it needs no frame field. */
 export function hasFrameBounds(version: Version): boolean {
 	// Explicitly list older versions so future versions keep the lite-06+ behavior.
 	switch (version) {

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -7,6 +7,7 @@ export const Version = {
 	/// Work-in-progress lite-06, advertised as the preferred WebTransport subprotocol.
 	/// Adds announce ids: each active ANNOUNCE_BROADCAST implicitly assigns the next
 	/// ordinal, and ended/restart reference that id instead of repeating the path.
+	/// Also adds frame-precise subscribe/fetch bounds and a GROUP frame offset.
 	DRAFT_06: 0xff0dad06,
 } as const;
 
@@ -99,6 +100,24 @@ export function hasExcludeHop(version: Version): boolean {
  * Added in lite-06. Older versions carry nothing, so a received route stays at
  * zero and routing falls back to the hop-count tie-break. */
 export function hasRouteCost(version: Version): boolean {
+	// Explicitly list older versions so future versions keep the lite-06+ behavior.
+	switch (version) {
+		case Version.DRAFT_01:
+		case Version.DRAFT_02:
+		case Version.DRAFT_03:
+		case Version.DRAFT_04:
+		case Version.DRAFT_05:
+			return false;
+		default:
+			return true;
+	}
+}
+
+/** Whether SUBSCRIBE, SUBSCRIBE_UPDATE, FETCH, SUBSCRIBE_OK, and GROUP carry frame
+ * indices alongside their group sequences, so a subscription or fetch can start and end
+ * partway through a group. Added in lite-06. Older versions only address whole groups,
+ * so a route change has to wait for the next group before it can resume. */
+export function hasFrameBounds(version: Version): boolean {
 	// Explicitly list older versions so future versions keep the lite-06+ behavior.
 	switch (version) {
 		case Version.DRAFT_01:

--- a/rs/moq-net/src/lite/fetch.rs
+++ b/rs/moq-net/src/lite/fetch.rs
@@ -16,6 +16,11 @@ pub struct Fetch<'a> {
 	pub track: Cow<'a, str>,
 	pub priority: u8,
 	pub group: u64,
+	/// Index of the first frame to return; 0 is the start of the group. Lite06+ only.
+	pub start_frame: u64,
+	/// Index of the last frame to return (inclusive), or `None` for through the end of
+	/// the group. Lite06+ only.
+	pub end_frame: Option<u64>,
 }
 
 impl Message for Fetch<'_> {
@@ -32,11 +37,22 @@ impl Message for Fetch<'_> {
 		let priority = u8::decode(r, version)?;
 		let group = u64::decode(r, version)?;
 
+		let (start_frame, end_frame) = match version.has_frame_bounds() {
+			true => (u64::decode(r, version)?, Option::<u64>::decode(r, version)?),
+			false => (0, None),
+		};
+		// A range that ends before it starts can never be served.
+		if end_frame.is_some_and(|end| end < start_frame) {
+			return Err(DecodeError::InvalidSubscribeLocation);
+		}
+
 		Ok(Self {
 			broadcast,
 			track,
 			priority,
 			group,
+			start_frame,
+			end_frame,
 		})
 	}
 
@@ -52,6 +68,15 @@ impl Message for Fetch<'_> {
 		self.track.encode(w, version)?;
 		self.priority.encode(w, version)?;
 		self.group.encode(w, version)?;
+
+		if version.has_frame_bounds() {
+			self.start_frame.encode(w, version)?;
+			self.end_frame.encode(w, version)?;
+		} else if self.start_frame != 0 || self.end_frame.is_some() {
+			// The peer would serve the whole group, including frames the caller excluded.
+			return Err(EncodeError::Version);
+		}
+
 		Ok(())
 	}
 }
@@ -66,6 +91,8 @@ mod test {
 			track: Cow::Borrowed("video"),
 			priority: 3,
 			group: 7,
+			start_frame: 0,
+			end_frame: None,
 		}
 	}
 
@@ -85,6 +112,41 @@ mod test {
 			assert_eq!(got.priority, 3);
 			assert_eq!(got.group, 7);
 		}
+	}
+
+	#[test]
+	fn fetch_frame_range_roundtrips() {
+		let mut msg = fetch_sample();
+		msg.start_frame = 2;
+		msg.end_frame = Some(6);
+
+		let got = fetch_roundtrip(Version::Lite06Wip, &msg);
+		assert_eq!((got.start_frame, got.end_frame), (2, Some(6)));
+	}
+
+	/// A range that ends before it starts can never be served.
+	#[test]
+	fn fetch_inverted_frame_range_is_invalid() {
+		let mut msg = fetch_sample();
+		msg.start_frame = 6;
+		msg.end_frame = Some(2);
+
+		let mut buf = Vec::new();
+		msg.encode_msg(&mut buf, Version::Lite06Wip).unwrap();
+		assert!(matches!(
+			Fetch::decode_msg(&mut buf.as_slice(), Version::Lite06Wip),
+			Err(DecodeError::InvalidSubscribeLocation)
+		));
+	}
+
+	/// Older peers serve the whole group, which is not what the caller asked for.
+	#[test]
+	fn fetch_frame_range_rejected_before_lite06() {
+		let mut msg = fetch_sample();
+		msg.start_frame = 2;
+
+		let mut buf = Vec::new();
+		assert!(msg.encode_msg(&mut buf, Version::Lite05).is_err());
 	}
 
 	#[test]

--- a/rs/moq-net/src/lite/group.rs
+++ b/rs/moq-net/src/lite/group.rs
@@ -9,13 +9,27 @@ pub struct Group {
 
 	// The group sequence number
 	pub sequence: u64,
+
+	// The index of the first frame on this stream. 0 (the common case) means the stream
+	// carries the group from its beginning; a higher value means the leading frames are
+	// missing, either because the subscription started partway in or because the
+	// publisher only holds the tail. Lite06+ only; older versions always start at 0.
+	pub frame_start: u64,
 }
 
 impl Message for Group {
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		let subscribe = u64::decode(r, version)?;
+		let sequence = u64::decode(r, version)?;
+		let frame_start = match version.has_frame_bounds() {
+			true => u64::decode(r, version)?,
+			false => 0,
+		};
+
 		Ok(Self {
-			subscribe: u64::decode(r, version)?,
-			sequence: u64::decode(r, version)?,
+			subscribe,
+			sequence,
+			frame_start,
 		})
 	}
 
@@ -23,6 +37,50 @@ impl Message for Group {
 		self.subscribe.encode(w, version)?;
 		self.sequence.encode(w, version)?;
 
+		if version.has_frame_bounds() {
+			self.frame_start.encode(w, version)?;
+		} else if self.frame_start != 0 {
+			// The peer would number the frames from 0 and silently misalign the group.
+			return Err(EncodeError::Version);
+		}
+
 		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	/// A partial group is self-describing: the stream says which frame it starts at.
+	#[test]
+	fn frame_start_roundtrips() {
+		let msg = Group {
+			subscribe: 1,
+			sequence: 7,
+			frame_start: 4,
+		};
+		let mut buf = Vec::new();
+		msg.encode_msg(&mut buf, Version::Lite06Wip).unwrap();
+		let got = Group::decode_msg(&mut buf.as_slice(), Version::Lite06Wip).unwrap();
+		assert_eq!((got.sequence, got.frame_start), (7, 4));
+	}
+
+	/// An older peer would number the frames from 0 and silently misalign the group.
+	#[test]
+	fn frame_start_rejected_before_lite06() {
+		let msg = Group {
+			subscribe: 1,
+			sequence: 7,
+			frame_start: 4,
+		};
+		let mut buf = Vec::new();
+		assert!(msg.encode_msg(&mut buf, Version::Lite05).is_err());
+
+		let whole = Group { frame_start: 0, ..msg };
+		let mut buf = Vec::new();
+		whole.encode_msg(&mut buf, Version::Lite05).unwrap();
+		let got = Group::decode_msg(&mut buf.as_slice(), Version::Lite05).unwrap();
+		assert_eq!(got.frame_start, 0);
 	}
 }

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -894,6 +894,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			latency_max: subscribe.max_latency,
 			group_start: subscribe.start_group,
 			group_end: subscribe.end_group,
+			frame_start: subscribe.start_frame,
+			frame_end: subscribe.end_frame,
+			..Default::default()
 		};
 
 		// Awaits the dynamic fallback if the broadcast wasn't announced; resolves
@@ -956,8 +959,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// run_track serves groups and best-effort datagrams off the one subscriber.
 		sub.run_track(
 			track,
-			subscribe.start_group,
-			subscribe.end_group,
+			Bounds::from(subscribe),
 			&mut stream.reader,
 			&mut stream.writer,
 			&track_priority_tx,
@@ -1016,9 +1018,22 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				fetch.group,
 				group::Fetch {
 					priority: fetch.priority,
+					frame_start: fetch.start_frame,
+					..Default::default()
 				},
 			)
 			.await?;
+
+		// The response carries no header, so a short run is indistinguishable from one
+		// that started elsewhere: only serve a range we can cover exactly. `fetch_group`
+		// already positions the consumer, so this is a belt-and-braces check on a
+		// promise the wire can't restate.
+		if group.index() != fetch.start_frame {
+			return Err(Error::Lagged);
+		}
+		// The end is a serving cap only: the cached group runs to the end of the group
+		// so it stays usable for anyone else (see `group::Fetch::frame_start`).
+		group.end_at(fetch.end_frame);
 
 		// FETCH is gated to lite-05+, which learned the track timescale via TRACK_INFO.
 		let timescale = if version.has_track_stream() {
@@ -1792,6 +1807,83 @@ async fn recv_next(track: &mut track::Subscriber, datagrams: bool, emit_boundary
 	kio::wait(|waiter| poll_recv_next(track, datagrams, emit_boundary, waiter)).await
 }
 
+/// Bound `group` to what this subscription asked for, reporting whether it can be served
+/// at all.
+///
+/// Frame bounds qualify the start and end group only; everything in between is served
+/// whole. `false` means the group's head is missing and the subscriber never asked for a
+/// partial group, so it must be skipped: a group is the unit of decodability, and only
+/// the subscriber knows whether a partial one is any use to it.
+fn position_group(group: &mut group::Consumer, start: Option<(u64, u64)>, end: Option<(u64, u64)>) -> bool {
+	let expected = match start {
+		Some((sequence, frame)) if sequence == group.sequence => frame,
+		_ => 0,
+	};
+
+	// `start_at` clamps up to the first frame the group still holds, so landing higher
+	// than asked means the frames below it are gone.
+	group.start_at(expected);
+	if group.index() != expected {
+		return false;
+	}
+
+	if let Some((sequence, frame)) = end
+		&& sequence == group.sequence
+	{
+		group.end_at(frame);
+	}
+
+	true
+}
+
+/// A subscription's requested delivery range, exactly as it arrived on the wire.
+///
+/// The frame bounds qualify the start and end group, so they only mean anything paired
+/// with one; [`Self::start_frame`] / [`Self::end_frame`] hand back that pairing.
+struct Bounds {
+	start_group: Option<u64>,
+	start_frame: u64,
+	end_group: Option<u64>,
+	end_frame: Option<u64>,
+}
+
+impl Bounds {
+	/// The group to apply a frame offset to and the offset itself, or `None` when
+	/// delivery starts on a group boundary.
+	fn start_frame(&self) -> Option<(u64, u64)> {
+		self.start_group
+			.map(|group| (group, self.start_frame))
+			.filter(|(_, frame)| *frame != 0)
+	}
+
+	/// The group to cap and the last frame to serve within it (inclusive).
+	fn end_frame(&self) -> Option<(u64, u64)> {
+		self.end_group.zip(self.end_frame)
+	}
+}
+
+impl From<&lite::Subscribe<'_>> for Bounds {
+	fn from(msg: &lite::Subscribe<'_>) -> Self {
+		Self {
+			start_group: msg.start_group,
+			start_frame: msg.start_frame,
+			end_group: msg.end_group,
+			end_frame: msg.end_frame,
+		}
+	}
+}
+
+impl From<&lite::SubscribeUpdate> for Bounds {
+	fn from(msg: &lite::SubscribeUpdate) -> Self {
+		Self {
+			start_group: msg.start_group,
+			start_frame: msg.start_frame,
+			end_group: msg.end_group,
+			end_frame: msg.end_frame,
+		}
+	}
+}
+
 /// Shared per-subscription state for the publisher side. Cloned cheaply. Every
 /// field is either small or already Arc-backed for each in-flight serve_group task
 /// so each in-flight group reads the latest SUBSCRIBE_UPDATE priority via its own
@@ -1815,8 +1907,7 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 	async fn run_track(
 		mut self,
 		mut track: track::Subscriber,
-		start_group: Option<u64>,
-		initial_end_group: Option<u64>,
+		bounds: Bounds,
 		reader: &mut crate::coding::Reader<S::RecvStream, Version>,
 		writer: &mut Writer<S::SendStream, Version>,
 		track_priority_tx: &kio::Producer<u8>,
@@ -1824,13 +1915,18 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 		let mut tasks: FuturesUnordered<MaybeSendBox<'static, ()>> = FuturesUnordered::new();
 
 		// Start the consumer at the specified sequence, otherwise start at the latest group.
-		if let Some(start_group) = start_group.or_else(|| track.latest()) {
+		if let Some(start_group) = bounds.start_group.or_else(|| track.latest()) {
 			track.start_at(start_group);
 		}
 
 		// Apply the initial cap from the original Subscribe. Subsequent updates
 		// flow through the SubscribeUpdate select arm below.
-		track.end_at(initial_end_group);
+		track.end_at(bounds.end_group);
+
+		// Frame bounds qualify the start and end group only; everything in between is
+		// served whole. Each is `(group, frame)`, or `None` for no offset at all.
+		let mut start_frame = bounds.start_frame();
+		let mut end_frame = bounds.end_frame();
 
 		// Lite05+ resolves the range on the Subscribe Stream itself: SUBSCRIBE_START
 		// once the first group is known, SUBSCRIBE_END as soon as the track declares its
@@ -1882,12 +1978,22 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 
 			match event {
 				Event::Recv(res) => match res? {
-					Recv::Group(group) => {
+					Recv::Group(mut group) => {
+						let sequence = group.sequence;
+						if !position_group(&mut group, start_frame, end_frame) {
+							// Its head is gone, and this subscriber didn't ask for a
+							// partial group. Skip it rather than open a stream that can
+							// only be reset; the next servable group resolves the start.
+							tracing::debug!(subscribe = self.id, track = %self.track_name, sequence, "skipping group with a missing head");
+							continue;
+						}
 						if emit_range && !start_sent {
 							start_sent = true;
+							// Only the group: the subscriber derives the start frame from
+							// its own request (see `lite::SubscribeStart`).
 							writer
 								.encode(&lite::SubscribeResponse::Start(lite::SubscribeStart {
-									group: group.sequence,
+									group: sequence,
 								}))
 								.await?;
 						}
@@ -1929,12 +2035,17 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 						latency_max: upd.max_latency,
 						group_start: upd.start_group,
 						group_end: upd.end_group,
+						frame_start: upd.start_frame,
+						frame_end: upd.end_frame,
 						..Default::default()
 					});
 					if let Some(start_group) = upd.start_group {
 						track.start_at(start_group);
 					}
 					track.end_at(upd.end_group);
+					let bounds = Bounds::from(&upd);
+					start_frame = bounds.start_frame();
+					end_frame = bounds.end_frame();
 				}
 			}
 		}
@@ -1942,24 +2053,27 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 
 	fn queue_serve(&mut self, group: group::Consumer, tasks: &mut FuturesUnordered<MaybeSendBox<'static, ()>>) {
 		let sequence = group.sequence;
+		let frame_start = group.index();
 		tracing::debug!(subscribe = self.id, track = %self.track_name, sequence, "serving group");
 
 		// Use the latest priority for new groups so SUBSCRIBE_UPDATE applies to them too.
 		let current_priority = self.track_priority_current();
 		let handle = self.priority.insert(Priority::new(current_priority, sequence));
-		let fut = self.clone().serve_group(sequence, handle, group);
+		let fut = self.clone().serve_group(sequence, frame_start, handle, group);
 		tasks.push(fut.map(|_| ()).maybe_boxed());
 	}
 
 	async fn serve_group(
 		mut self,
 		sequence: u64,
+		frame_start: u64,
 		mut priority: PriorityHandle,
 		mut group: group::Consumer,
 	) -> Result<(), Error> {
 		let msg = lite::Group {
 			subscribe: self.id,
 			sequence,
+			frame_start,
 		};
 		let stream = self.session.open_uni().await.map_err(Error::from_transport)?;
 		let mut stream = Writer::new(stream, self.version);
@@ -2183,6 +2297,72 @@ mod serve_group_test {
 	use crate::lite::test_transport::*;
 	use crate::{Timestamp, broadcast};
 
+	/// A group whose head the publisher no longer holds is skipped, not served short:
+	/// only a subscriber that asked for a partial group may receive one.
+	#[test]
+	fn position_group_skips_a_missing_head() {
+		let mut track = track::Producer::new(Arc::new(broadcast::Info::default()), "video", None);
+		let mut group = track.create_group(group::Info { sequence: 3 }).unwrap();
+		group.start_at(5).unwrap();
+		group.write_frame(Timestamp::ZERO, b"tail".to_vec()).unwrap();
+
+		// Asked for whole groups, so the missing frames 0..5 make this unservable.
+		let mut consumer = group.consume();
+		assert!(!position_group(&mut consumer, None, None));
+
+		// Asked for exactly where it starts: servable, and positioned there.
+		let mut consumer = group.consume();
+		assert!(position_group(&mut consumer, Some((3, 5)), None));
+		assert_eq!(consumer.index(), 5);
+
+		// Asked for an earlier frame than the group holds: still a hole, still skipped.
+		let mut consumer = group.consume();
+		assert!(!position_group(&mut consumer, Some((3, 2)), None));
+
+		// The offset belongs to the start group only; a later group is served whole.
+		let mut other = track.create_group(group::Info { sequence: 4 }).unwrap();
+		other.write_frame(Timestamp::ZERO, b"whole".to_vec()).unwrap();
+		let mut consumer = other.consume();
+		assert!(position_group(&mut consumer, Some((3, 5)), None));
+		assert_eq!(consumer.index(), 0);
+	}
+
+	/// The end bound caps the end group and leaves the others whole.
+	#[test]
+	fn position_group_caps_the_end_group() {
+		let mut track = track::Producer::new(Arc::new(broadcast::Info::default()), "video", None);
+		let mut group = track.create_group(group::Info { sequence: 7 }).unwrap();
+		for i in 0..4u8 {
+			group.write_frame(Timestamp::ZERO, vec![i]).unwrap();
+		}
+		group.finish().unwrap();
+
+		let mut consumer = group.consume();
+		assert!(position_group(&mut consumer, None, Some((7, 1))));
+		assert_eq!(
+			consumer.read_frame().now_or_never().unwrap().unwrap().unwrap().payload[0],
+			0
+		);
+		assert_eq!(
+			consumer.read_frame().now_or_never().unwrap().unwrap().unwrap().payload[0],
+			1
+		);
+		assert!(
+			consumer.read_frame().now_or_never().unwrap().unwrap().is_none(),
+			"capped"
+		);
+
+		// A cap naming another group leaves this one uncapped.
+		let mut consumer = group.consume();
+		assert!(position_group(&mut consumer, None, Some((8, 1))));
+		for i in 0..4u8 {
+			assert_eq!(
+				consumer.read_frame().now_or_never().unwrap().unwrap().unwrap().payload[0],
+				i
+			);
+		}
+	}
+
 	#[tokio::test]
 	async fn resets_with_the_abort_code() {
 		let log = Log::default();
@@ -2207,7 +2387,7 @@ mod serve_group_test {
 			.unwrap();
 
 		let handle = subscription.priority.insert(Priority::new(0, 0));
-		let mut serve = std::pin::pin!(subscription.serve_group(0, handle, group.consume()));
+		let mut serve = std::pin::pin!(subscription.serve_group(0, 0, handle, group.consume()));
 
 		// Drain the frame, leaving the task parked awaiting the next one.
 		assert!(futures::poll!(serve.as_mut()).is_pending());

--- a/rs/moq-net/src/lite/subscribe.rs
+++ b/rs/moq-net/src/lite/subscribe.rs
@@ -20,6 +20,12 @@ pub struct Subscribe<'a> {
 	pub max_latency: std::time::Duration,
 	pub start_group: Option<u64>,
 	pub end_group: Option<u64>,
+	/// First frame to deliver within `start_group`'s group; 0 is the whole group.
+	/// Lite06+ only, and meaningless without an explicit `start_group`.
+	pub start_frame: u64,
+	/// Last frame to deliver (inclusive) within `end_group`'s group, or `None` for the
+	/// whole group. Lite06+ only, and meaningless without an explicit `end_group`.
+	pub end_frame: Option<u64>,
 }
 
 impl Message for Subscribe<'_> {
@@ -40,6 +46,8 @@ impl Message for Subscribe<'_> {
 			}
 		};
 
+		let (start_frame, end_frame) = decode_frame_bounds(r, version, start_group, end_group)?;
+
 		Ok(Self {
 			id,
 			broadcast,
@@ -49,6 +57,8 @@ impl Message for Subscribe<'_> {
 			max_latency,
 			start_group,
 			end_group,
+			start_frame,
+			end_frame,
 		})
 	}
 
@@ -68,8 +78,56 @@ impl Message for Subscribe<'_> {
 			}
 		}
 
+		encode_frame_bounds(w, version, self.start_frame, self.end_frame)?;
+
 		Ok(())
 	}
+}
+
+/// Decode the trailing `Frame Start` / `Frame End` pair shared by SUBSCRIBE,
+/// SUBSCRIBE_UPDATE, and FETCH.
+///
+/// Older versions carry no such fields, so they decode as the whole group. A frame bound
+/// without the group bound it qualifies is a protocol violation: frames are numbered per
+/// group, so there is nothing to count from.
+fn decode_frame_bounds<R: bytes::Buf>(
+	r: &mut R,
+	version: Version,
+	start_group: Option<u64>,
+	end_group: Option<u64>,
+) -> Result<(u64, Option<u64>), DecodeError> {
+	if !version.has_frame_bounds() {
+		return Ok((0, None));
+	}
+
+	let start_frame = u64::decode(r, version)?;
+	let end_frame = Option::<u64>::decode(r, version)?;
+
+	if (start_frame != 0 && start_group.is_none()) || (end_frame.is_some() && end_group.is_none()) {
+		return Err(DecodeError::InvalidSubscribeLocation);
+	}
+
+	Ok((start_frame, end_frame))
+}
+
+/// Encode the trailing `Frame Start` / `Frame End` pair, a no-op before lite-06.
+fn encode_frame_bounds<W: bytes::BufMut>(
+	w: &mut W,
+	version: Version,
+	start_frame: u64,
+	end_frame: Option<u64>,
+) -> Result<(), EncodeError> {
+	if !version.has_frame_bounds() {
+		// Nothing carries the bounds, so silently widening to the whole group would
+		// deliver frames the caller excluded. Refuse instead.
+		if start_frame != 0 || end_frame.is_some() {
+			return Err(EncodeError::Version);
+		}
+		return Ok(());
+	}
+
+	start_frame.encode(w, version)?;
+	end_frame.encode(w, version)
 }
 
 /// Publisher's acknowledgement on the Subscribe Stream for drafts 01-04.
@@ -145,6 +203,11 @@ impl Message for SubscribeOk {
 /// Resolves the absolute start group of a Lite05+ subscription. The first message
 /// the publisher sends, once the start group is known. A value greater than the
 /// requested start implicitly drops the leading range.
+///
+/// There is no start *frame*: a partial group is only served to a subscriber that asked
+/// for one, so delivery begins either at the requested `Frame Start` (when this is the
+/// requested group) or at frame 0 (when the publisher resolved to a later one). A
+/// subscriber that asked for group 5 frame 15 and receives group 6 starts at frame 0.
 #[derive(Clone, Debug)]
 pub struct SubscribeStart {
 	pub group: u64,
@@ -206,6 +269,10 @@ pub struct SubscribeUpdate {
 	pub max_latency: std::time::Duration,
 	pub start_group: Option<u64>,
 	pub end_group: Option<u64>,
+	/// See [`Subscribe::start_frame`].
+	pub start_frame: u64,
+	/// See [`Subscribe::end_frame`].
+	pub end_frame: Option<u64>,
 }
 
 impl Message for SubscribeUpdate {
@@ -229,12 +296,16 @@ impl Message for SubscribeUpdate {
 			group => Some(group - 1),
 		};
 
+		let (start_frame, end_frame) = decode_frame_bounds(r, version, start_group, end_group)?;
+
 		Ok(Self {
 			priority,
 			ordered,
 			max_latency,
 			start_group,
 			end_group,
+			start_frame,
+			end_frame,
 		})
 	}
 
@@ -265,6 +336,8 @@ impl Message for SubscribeUpdate {
 				.encode(w, version)?,
 			None => 0u64.encode(w, version)?,
 		}
+
+		encode_frame_bounds(w, version, self.start_frame, self.end_frame)?;
 
 		Ok(())
 	}
@@ -462,6 +535,77 @@ mod test {
 		let mut buf = Vec::new();
 		resp.encode(&mut buf, Version::Lite04).unwrap();
 		assert_eq!(buf[0], 1);
+	}
+
+	fn subscribe_sample() -> Subscribe<'static> {
+		Subscribe {
+			id: 1,
+			broadcast: Path::new("room").to_owned(),
+			track: Cow::Borrowed("video"),
+			priority: 3,
+			ordered: true,
+			max_latency: std::time::Duration::from_millis(250),
+			start_group: Some(7),
+			end_group: Some(9),
+			start_frame: 4,
+			end_frame: Some(2),
+		}
+	}
+
+	#[test]
+	fn subscribe_frame_bounds_roundtrip() {
+		let msg = subscribe_sample();
+		let mut buf = Vec::new();
+		msg.encode_msg(&mut buf, Version::Lite06Wip).unwrap();
+		let got = Subscribe::decode_msg(&mut buf.as_slice(), Version::Lite06Wip).unwrap();
+		assert_eq!((got.start_group, got.start_frame), (Some(7), 4));
+		assert_eq!((got.end_group, got.end_frame), (Some(9), Some(2)));
+	}
+
+	/// The whole-group defaults are what a version without the fields decodes to, so
+	/// lite-05 stays byte-identical.
+	#[test]
+	fn subscribe_without_frame_bounds_is_unchanged_on_lite05() {
+		let mut msg = subscribe_sample();
+		msg.start_frame = 0;
+		msg.end_frame = None;
+
+		let mut lite05 = Vec::new();
+		msg.encode_msg(&mut lite05, Version::Lite05).unwrap();
+		let mut lite06 = Vec::new();
+		msg.encode_msg(&mut lite06, Version::Lite06Wip).unwrap();
+
+		// Lite06 appends the two defaulted varints and nothing else.
+		assert_eq!(&lite06[..lite05.len()], &lite05[..]);
+		assert_eq!(&lite06[lite05.len()..], &[0, 0]);
+
+		let got = Subscribe::decode_msg(&mut lite05.as_slice(), Version::Lite05).unwrap();
+		assert_eq!((got.start_frame, got.end_frame), (0, None));
+	}
+
+	/// Silently widening to the whole group would deliver frames the caller excluded.
+	#[test]
+	fn subscribe_frame_bounds_rejected_before_lite06() {
+		let mut buf = Vec::new();
+		assert!(subscribe_sample().encode_msg(&mut buf, Version::Lite05).is_err());
+	}
+
+	/// Frames are numbered per group, so a frame bound without its group bound has
+	/// nothing to count from.
+	#[test]
+	fn subscribe_frame_bound_without_group_bound_is_invalid() {
+		let mut msg = subscribe_sample();
+		msg.start_group = None;
+		msg.start_frame = 4;
+		msg.end_group = None;
+		msg.end_frame = None;
+
+		let mut buf = Vec::new();
+		msg.encode_msg(&mut buf, Version::Lite06Wip).unwrap();
+		assert!(matches!(
+			Subscribe::decode_msg(&mut buf.as_slice(), Version::Lite06Wip),
+			Err(DecodeError::InvalidSubscribeLocation)
+		));
 	}
 
 	#[test]

--- a/rs/moq-net/src/lite/subscribe.rs
+++ b/rs/moq-net/src/lite/subscribe.rs
@@ -78,7 +78,14 @@ impl Message for Subscribe<'_> {
 			}
 		}
 
-		encode_frame_bounds(w, version, self.start_frame, self.end_frame)?;
+		encode_frame_bounds(
+			w,
+			version,
+			self.start_group,
+			self.start_frame,
+			self.end_group,
+			self.end_frame,
+		)?;
 
 		Ok(())
 	}
@@ -114,9 +121,15 @@ fn decode_frame_bounds<R: bytes::Buf>(
 fn encode_frame_bounds<W: bytes::BufMut>(
 	w: &mut W,
 	version: Version,
+	start_group: Option<u64>,
 	start_frame: u64,
+	end_group: Option<u64>,
 	end_frame: Option<u64>,
 ) -> Result<(), EncodeError> {
+	if (start_frame != 0 && start_group.is_none()) || (end_frame.is_some() && end_group.is_none()) {
+		return Err(EncodeError::InvalidState);
+	}
+
 	if !version.has_frame_bounds() {
 		// Nothing carries the bounds, so silently widening to the whole group would
 		// deliver frames the caller excluded. Refuse instead.
@@ -337,7 +350,14 @@ impl Message for SubscribeUpdate {
 			None => 0u64.encode(w, version)?,
 		}
 
-		encode_frame_bounds(w, version, self.start_frame, self.end_frame)?;
+		encode_frame_bounds(
+			w,
+			version,
+			self.start_group,
+			self.start_frame,
+			self.end_group,
+			self.end_frame,
+		)?;
 
 		Ok(())
 	}
@@ -601,10 +621,16 @@ mod test {
 		msg.end_frame = None;
 
 		let mut buf = Vec::new();
-		msg.encode_msg(&mut buf, Version::Lite06Wip).unwrap();
 		assert!(matches!(
-			Subscribe::decode_msg(&mut buf.as_slice(), Version::Lite06Wip),
-			Err(DecodeError::InvalidSubscribeLocation)
+			msg.encode_msg(&mut buf, Version::Lite06Wip),
+			Err(EncodeError::InvalidState)
+		));
+
+		msg.start_frame = 0;
+		msg.end_frame = Some(7);
+		assert!(matches!(
+			msg.encode_msg(&mut buf, Version::Lite06Wip),
+			Err(EncodeError::InvalidState)
 		));
 	}
 

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -990,6 +990,7 @@ mod tests {
 				peer_setup: Default::default(),
 				cost: None,
 				tasks,
+				going_away: Default::default(),
 			});
 			let mut broadcast = crate::broadcast::Info::new().produce();
 			let producer = broadcast.create_track("catalog.json", None).unwrap();

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1052,9 +1052,13 @@ mod tests {
 		let mut h = Harness::new(Version::Lite06Wip);
 		let mut sub = Sub::None;
 
-		let mut demand = Subscription::default();
-		demand.frame_start = 3;
-		demand.frame_end = Some(7);
+		// Deliberately built by field rather than by builder: `with_start` and `with_end`
+		// are exactly what makes this unreachable through the intended surface.
+		let demand = Subscription {
+			frame_start: 3,
+			frame_end: Some(7),
+			..Default::default()
+		};
 
 		h.serve
 			.handle_subscription(

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -725,7 +725,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let group_info = group::Info { sequence: hdr.sequence };
 			// Stats (groups/frames/bytes) are counted in the model as the group is
 			// written, through the tagged `track::Producer`.
-			let group = entry.producer.create_group(group_info)?;
+			let mut group = entry.producer.create_group(group_info)?;
+			// The stream may carry only the tail of the group; number the frames from
+			// where the publisher said they start so a reader splicing across routes
+			// lines them up.
+			group.start_at(hdr.frame_start)?;
 			(group, entry.producer.clone(), entry.timescale)
 		};
 
@@ -929,6 +933,7 @@ struct SubStream<S: web_transport_trait::Session> {
 	ordered: bool,
 	max_latency: Duration,
 	start_group: Option<u64>,
+	start_frame: u64,
 	priority: u8,
 }
 
@@ -1264,8 +1269,10 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 					active.ordered = subscription.ordered;
 					active.max_latency = subscription.latency_max;
 					active.start_group = subscription.group_start;
+					active.start_frame = subscription.frame_start;
 					if supports_update {
-						self.send_update(active, subscription.group_end).await?;
+						self.send_update(active, subscription.group_end, subscription.frame_end)
+							.await?;
 					}
 				}
 			},
@@ -1317,6 +1324,8 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			max_latency: subscription.latency_max,
 			start_group: subscription.group_start,
 			end_group: subscription.group_end,
+			start_frame: subscription.frame_start,
+			end_frame: subscription.frame_end,
 		};
 
 		tracing::info!(id, broadcast = %self.subscriber.log_path(&self.path), track = %self.name, "subscribe started");
@@ -1377,20 +1386,29 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			ordered: subscription.ordered,
 			max_latency: subscription.latency_max,
 			start_group: subscription.group_start,
+			start_frame: subscription.frame_start,
 			priority: subscription.priority,
 		});
 
 		Ok(())
 	}
 
-	/// Echo the current params upstream as a SUBSCRIBE_UPDATE, varying only `end_group`.
-	async fn send_update(&self, active: &mut SubStream<S>, end_group: Option<u64>) -> Result<(), Error> {
+	/// Echo the current params upstream as a SUBSCRIBE_UPDATE, varying only the end bound
+	/// (`end_group` and the `end_frame` qualifying it).
+	async fn send_update(
+		&self,
+		active: &mut SubStream<S>,
+		end_group: Option<u64>,
+		end_frame: Option<u64>,
+	) -> Result<(), Error> {
 		let update = lite::SubscribeUpdate {
 			priority: active.priority,
 			ordered: active.ordered,
 			max_latency: active.max_latency,
 			start_group: active.start_group,
 			end_group,
+			start_frame: active.start_frame,
+			end_frame,
 		};
 		active.stream.writer.encode(&update).await
 	}
@@ -1425,6 +1443,11 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 				track: name.as_str().into(),
 				priority: request.priority(),
 				group,
+				start_frame: request.frame_start(),
+				// Always through the end of the group: a fetch that stopped short would
+				// cache a group indistinguishable from a complete one. A downstream cap
+				// is applied when serving, not when fetching.
+				end_frame: None,
 			};
 			stream.writer.encode(&lite::ControlType::Fetch).await?;
 			stream.writer.encode(&msg).await
@@ -1441,6 +1464,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		// Relay-served FETCH is lite-05+, so `timescale` is `Some`; fall back to the
 		// default scale defensively rather than panicking.
 		let group_info = track::Info::default().with_timescale(timescale.unwrap_or_default());
+		let frame_start = request.frame_start();
 		let mut producer = match request.accept(group_info) {
 			Ok(producer) => producer,
 			Err(err) => {
@@ -1450,6 +1474,14 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 				return;
 			}
 		};
+
+		// The response starts at the requested frame, so number it from there rather
+		// than restarting the group at 0.
+		if let Err(err) = producer.start_at(frame_start) {
+			stream.writer.abort(&err);
+			let _ = producer.abort(err);
+			return;
+		}
 
 		let res = subscriber
 			.run_group(&mut stream.reader, producer.clone(), timescale)

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -921,6 +921,168 @@ mod tests {
 		assert_eq!(msg.track, "catalog.json");
 		assert!(wire.is_empty(), "a second SUBSCRIBE trailed the first");
 	}
+
+	/// Everything a `handle_subscription` test needs to stay alive for the call.
+	struct Harness {
+		serve: TrackServe<SinkSession>,
+		session: SinkSession,
+		producer: track::Producer,
+		_broadcast: crate::broadcast::Producer,
+		_gate: kio::Producer<bool>,
+		_tasks: TaskSet,
+	}
+
+	impl Harness {
+		/// A `TrackServe` writing straight to a sink session at `version`.
+		fn new(version: Version) -> Self {
+			// Open the gate up front: these tests assert what reached the wire, not
+			// what was true at the instant it would.
+			let gate = kio::Producer::new(true);
+			let session = SinkSession::gated_bi(gate.consume());
+			let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+			let (tasks, _tasks) = TaskSet::new();
+			let subscriber = Subscriber::new(SubscriberConfig {
+				session: session.clone(),
+				origin,
+				recv_bandwidth: None,
+				version,
+				peer_setup: Default::default(),
+				cost: None,
+				tasks,
+			});
+			let mut broadcast = crate::broadcast::Info::new().produce();
+			let producer = broadcast.create_track("catalog.json", None).unwrap();
+
+			Self {
+				serve: TrackServe {
+					subscriber,
+					path: Path::new("room/host").to_owned(),
+					name: "catalog.json".to_string(),
+				},
+				session,
+				producer,
+				_broadcast: broadcast,
+				_gate: gate,
+				_tasks,
+			}
+		}
+
+		/// Everything written to the session so far.
+		fn wire(&self) -> Vec<u8> {
+			self.session.log.writes.lock().unwrap().clone()
+		}
+	}
+
+	/// The `(group, frame)` bounds `resume::slice` produces after a mid-group takeover.
+	fn mid_group_demand() -> Subscription {
+		Subscription::default()
+			.with_group_start(5)
+			.with_frame_start(3)
+			.with_group_end(5)
+			.with_frame_end(2)
+	}
+
+	/// A mid-group resume boundary handed to a peer that predates lite-06 is widened to
+	/// the whole group rather than refused.
+	///
+	/// The codec rejects a frame bound such a peer cannot carry, so passing the demand
+	/// through unchanged fails the SUBSCRIBE and hands the track back. The origin then
+	/// re-splices the same route indefinitely, since the splice itself keeps succeeding
+	/// and the retry budget never trips.
+	#[tokio::test]
+	async fn frame_bounds_widen_for_an_older_peer() {
+		let mut h = Harness::new(Version::Lite05);
+		let mut sub = Sub::None;
+
+		h.serve
+			.handle_subscription(
+				&mut h.producer,
+				&mut sub,
+				Some(mid_group_demand()),
+				true,
+				Some(Timescale::default()),
+			)
+			.await
+			.expect("an older peer must not fail the subscribe");
+
+		let wire = h.wire();
+		let mut wire = wire.as_slice();
+		assert_eq!(
+			lite::ControlType::decode(&mut wire, Version::Lite05).unwrap(),
+			lite::ControlType::Subscribe
+		);
+		let msg = lite::Subscribe::decode(&mut wire, Version::Lite05).unwrap();
+		// The group bounds survive; only the frame offsets are widened away.
+		assert_eq!((msg.start_group, msg.end_group), (Some(5), Some(5)));
+		assert_eq!((msg.start_frame, msg.end_frame), (0, None));
+	}
+
+	/// The same demand on a lite-06 peer keeps its frame offsets, so the widening is
+	/// version-gated rather than unconditional.
+	#[tokio::test]
+	async fn frame_bounds_survive_on_a_lite06_peer() {
+		let mut h = Harness::new(Version::Lite06Wip);
+		let mut sub = Sub::None;
+
+		h.serve
+			.handle_subscription(
+				&mut h.producer,
+				&mut sub,
+				Some(mid_group_demand()),
+				true,
+				Some(Timescale::default()),
+			)
+			.await
+			.unwrap();
+
+		let wire = h.wire();
+		let mut wire = wire.as_slice();
+		assert_eq!(
+			lite::ControlType::decode(&mut wire, Version::Lite06Wip).unwrap(),
+			lite::ControlType::Subscribe
+		);
+		let msg = lite::Subscribe::decode(&mut wire, Version::Lite06Wip).unwrap();
+		assert_eq!((msg.start_frame, msg.end_frame), (3, Some(2)));
+	}
+
+	/// The widening covers SUBSCRIBE_UPDATE too: a downstream peer asking for a frame
+	/// offset must not tear down an older upstream that is already serving.
+	#[tokio::test]
+	async fn frame_bounds_widen_on_update() {
+		let mut h = Harness::new(Version::Lite05);
+		let mut sub = Sub::None;
+
+		h.serve
+			.handle_subscription(
+				&mut h.producer,
+				&mut sub,
+				Some(Subscription::default()),
+				true,
+				Some(Timescale::default()),
+			)
+			.await
+			.unwrap();
+		let established = h.wire().len();
+
+		// A lite-06 subscriber downstream now wants to resume mid-group.
+		h.serve
+			.handle_subscription(
+				&mut h.producer,
+				&mut sub,
+				Some(mid_group_demand()),
+				true,
+				Some(Timescale::default()),
+			)
+			.await
+			.expect("a downstream frame offset must not tear down an older upstream");
+
+		// SUBSCRIBE_UPDATE rides the subscribe stream with no control type ahead of it.
+		let wire = h.wire();
+		let mut wire = &wire[established..];
+		let msg = lite::SubscribeUpdate::decode(&mut wire, Version::Lite05).unwrap();
+		assert_eq!((msg.start_group, msg.start_frame), (Some(5), 0));
+		assert_eq!((msg.end_group, msg.end_frame), (Some(5), None));
+	}
 }
 
 /// The at-most-one live upstream subscription: its control stream plus the params
@@ -1246,6 +1408,34 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		Ok(model)
 	}
 
+	/// Widen a frame-precise request to whole groups when the peer predates lite-06.
+	///
+	/// The codec refuses to encode a frame bound an older peer cannot carry, since
+	/// widening at the message layer would hand the *caller* frames it excluded. Here we
+	/// are the caller, and we want the wider range: every group is positioned and capped
+	/// again on the read side ([`group::Consumer::start_at`] / `end_at`, driven by
+	/// [`crate::model::resume`]), so the extra frames are filtered locally and never
+	/// reach a subscriber. The only cost is transferring frames we already hold.
+	///
+	/// Passing the request through unchanged instead would fail the SUBSCRIBE, hand the
+	/// track back, and leave the origin re-splicing the same route indefinitely: the
+	/// splice itself keeps succeeding, so the retry budget never trips.
+	fn widen_frame_bounds(&self, subscription: &mut Subscription) {
+		if self.subscriber.version.has_frame_bounds() {
+			return;
+		}
+
+		if subscription.frame_start != 0 || subscription.frame_end.is_some() {
+			tracing::debug!(
+				track = %self.name,
+				version = ?self.subscriber.version,
+				"widening frame bounds to whole groups for an older peer"
+			);
+		}
+		subscription.frame_start = 0;
+		subscription.frame_end = None;
+	}
+
 	/// Apply a subscription-demand change: open the upstream SUBSCRIBE on the first
 	/// subscriber, update it while live, or cancel it when the last one leaves.
 	async fn handle_subscription(
@@ -1257,25 +1447,28 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		timescale: Option<Timescale>,
 	) -> Result<(), Error> {
 		match pref {
-			Some(subscription) => match sub {
-				Sub::None => {
-					// Open an upstream SUBSCRIBE for the first subscriber.
-					self.establish(producer, sub, subscription, timescale).await?;
-				}
-				Sub::Active(active) => {
-					// Downstream preferences changed: forward them upstream as a
-					// SUBSCRIBE_UPDATE (Lite03+ only; older peers can't carry one).
-					active.priority = subscription.priority;
-					active.ordered = subscription.ordered;
-					active.max_latency = subscription.latency_max;
-					active.start_group = subscription.group_start;
-					active.start_frame = subscription.frame_start;
-					if supports_update {
-						self.send_update(active, subscription.group_end, subscription.frame_end)
-							.await?;
+			Some(mut subscription) => {
+				self.widen_frame_bounds(&mut subscription);
+				match sub {
+					Sub::None => {
+						// Open an upstream SUBSCRIBE for the first subscriber.
+						self.establish(producer, sub, subscription, timescale).await?;
+					}
+					Sub::Active(active) => {
+						// Downstream preferences changed: forward them upstream as a
+						// SUBSCRIBE_UPDATE (Lite03+ only; older peers can't carry one).
+						active.priority = subscription.priority;
+						active.ordered = subscription.ordered;
+						active.max_latency = subscription.latency_max;
+						active.start_group = subscription.group_start;
+						active.start_frame = subscription.frame_start;
+						if supports_update {
+							self.send_update(active, subscription.group_end, subscription.frame_end)
+								.await?;
+						}
 					}
 				}
-			},
+			}
 			None => {
 				// Last subscriber left: cancel the upstream subscription outright. An
 				// idle subscription still streams every group into a cache nobody
@@ -1437,13 +1630,23 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			}
 		};
 
+		// A peer that predates lite-06 addresses whole groups only, so ask for the whole
+		// group and number the response from 0. The wider group still covers what the
+		// caller asked for (`fetch_group` positions their own consumer), and is more
+		// reusable in the cache than the tail would have been. Asking for the offset
+		// anyway would fail to encode and reject a fetch we can serve.
+		let frame_start = match subscriber.version.has_frame_bounds() {
+			true => request.frame_start(),
+			false => 0,
+		};
+
 		let send = async {
 			let msg = lite::Fetch {
 				broadcast: path.as_path(),
 				track: name.as_str().into(),
 				priority: request.priority(),
 				group,
-				start_frame: request.frame_start(),
+				start_frame: frame_start,
 				// Always through the end of the group: a fetch that stopped short would
 				// cache a group indistinguishable from a complete one. A downstream cap
 				// is applied when serving, not when fetching.
@@ -1464,7 +1667,6 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		// Relay-served FETCH is lite-05+, so `timescale` is `Some`; fall back to the
 		// default scale defensively rather than panicking.
 		let group_info = track::Info::default().with_timescale(timescale.unwrap_or_default());
-		let frame_start = request.frame_start();
 		let mut producer = match request.accept(group_info) {
 			Ok(producer) => producer,
 			Err(err) => {
@@ -1475,7 +1677,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			}
 		};
 
-		// The response starts at the requested frame, so number it from there rather
+		// The response starts at the frame we asked for, so number it from there rather
 		// than restarting the group at 0.
 		if let Err(err) = producer.start_at(frame_start) {
 			stream.writer.abort(&err);

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -975,11 +975,7 @@ mod tests {
 
 	/// The `(group, frame)` bounds `resume::slice` produces after a mid-group takeover.
 	fn mid_group_demand() -> Subscription {
-		Subscription::default()
-			.with_group_start(5)
-			.with_frame_start(3)
-			.with_group_end(5)
-			.with_frame_end(2)
+		Subscription::default().with_start(5, 3).with_end(5, 2)
 	}
 
 	/// A mid-group resume boundary handed to a peer that predates lite-06 is widened to
@@ -1043,6 +1039,40 @@ mod tests {
 		);
 		let msg = lite::Subscribe::decode(&mut wire, Version::Lite06Wip).unwrap();
 		assert_eq!((msg.start_frame, msg.end_frame), (3, Some(2)));
+	}
+
+	/// A frame index never reaches the wire without the group it counts from.
+	///
+	/// [`Subscription::with_start`] pairs the two, so the builder cannot express this.
+	/// The fields are still `pub`, so assigning one alone can; the encode path reads the
+	/// pair through `Subscription::start`, which drops a frame with no group rather than
+	/// emitting one the peer must reject as `InvalidSubscribeLocation`.
+	#[tokio::test]
+	async fn a_frame_bound_without_its_group_is_dropped() {
+		let mut h = Harness::new(Version::Lite06Wip);
+		let mut sub = Sub::None;
+
+		let mut demand = Subscription::default();
+		demand.frame_start = 3;
+		demand.frame_end = Some(7);
+
+		h.serve
+			.handle_subscription(
+				&mut h.producer,
+				&mut sub,
+				Some(demand),
+				true,
+				Some(Timescale::default()),
+			)
+			.await
+			.unwrap();
+
+		let wire = h.wire();
+		let mut wire = wire.as_slice();
+		lite::ControlType::decode(&mut wire, Version::Lite06Wip).unwrap();
+		let msg = lite::Subscribe::decode(&mut wire, Version::Lite06Wip).unwrap();
+		assert_eq!((msg.start_group, msg.start_frame), (None, 0));
+		assert_eq!((msg.end_group, msg.end_frame), (None, None));
 	}
 
 	/// The widening covers SUBSCRIBE_UPDATE too: a downstream peer asking for a frame
@@ -1460,11 +1490,12 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 						active.priority = subscription.priority;
 						active.ordered = subscription.ordered;
 						active.max_latency = subscription.latency_max;
-						active.start_group = subscription.group_start;
-						active.start_frame = subscription.frame_start;
+						let start = subscription.start();
+						active.start_group = start.map(|start| start.group);
+						active.start_frame = start.map_or(0, |start| start.frame);
 						if supports_update {
-							self.send_update(active, subscription.group_end, subscription.frame_end)
-								.await?;
+							let end_frame = subscription.group_end.and(subscription.frame_end);
+							self.send_update(active, subscription.group_end, end_frame).await?;
 						}
 					}
 				}
@@ -1508,6 +1539,9 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 	) -> Result<(), Error> {
 		let id = self.subscriber.next_id.fetch_add(1, atomic::Ordering::Relaxed);
 
+		// Both halves of each bound come from the same position, so a frame can never
+		// reach the wire without the group it counts from (which the peer would reject).
+		let start = subscription.start();
 		let msg = lite::Subscribe {
 			id,
 			broadcast: self.path.as_path(),
@@ -1515,10 +1549,10 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			priority: subscription.priority,
 			ordered: subscription.ordered,
 			max_latency: subscription.latency_max,
-			start_group: subscription.group_start,
+			start_group: start.map(|start| start.group),
 			end_group: subscription.group_end,
-			start_frame: subscription.frame_start,
-			end_frame: subscription.frame_end,
+			start_frame: start.map_or(0, |start| start.frame),
+			end_frame: subscription.group_end.and(subscription.frame_end),
 		};
 
 		tracing::info!(id, broadcast = %self.subscriber.log_path(&self.path), track = %self.name, "subscribe started");

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -100,6 +100,21 @@ impl Version {
 		matches!(self, Self::Lite04 | Self::Lite05)
 	}
 
+	/// Whether SUBSCRIBE, SUBSCRIBE_UPDATE, FETCH, and GROUP carry frame indices
+	/// alongside their group sequences, so a subscription or fetch can start and end
+	/// partway through a group. Added in lite-06.
+	///
+	/// Older versions only address whole groups, so a route change has to wait for the
+	/// next group before it can resume.
+	#[allow(clippy::match_like_matches_macro)]
+	pub fn has_frame_bounds(self) -> bool {
+		// Match form so future versions default forward (CLAUDE.md convention).
+		match self {
+			Self::Lite01 | Self::Lite02 | Self::Lite03 | Self::Lite04 | Self::Lite05 => false,
+			_ => true,
+		}
+	}
+
 	/// Whether announcements carry the route cost: the marginal cost of pulling
 	/// the broadcast via this route, accumulated per link. Added in lite-06.
 	/// Older versions carry nothing, so a received route stays at zero and ranks

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -7,6 +7,13 @@
 //! A [Consumer] reads an ordered stream of frames.
 //! The reader can be cloned, in which case each reader receives a copy of each frame. (fanout)
 //!
+//! Frames are numbered from 0 in write order. A group can be short at its front or its
+//! back but never in the middle: [Producer::start_at] starts it later, so a handle can
+//! carry the tail of a group whose leading frames came from somewhere else, and
+//! [Producer::finish] ends it wherever writing stopped. [Consumer::start_at] /
+//! [Consumer::end_at] bound a reader to a sub-range the same way [`track::Subscriber`]
+//! bounds group sequences.
+//!
 //! The stream is closed with [Error] when all writers or readers are dropped.
 use crate::cache;
 use crate::frame::{self, Frame, FrameBuf};
@@ -95,8 +102,20 @@ pub(crate) struct GroupState {
 	// The single in-flight frame, if one is open.
 	pub(crate) partial: Option<Partial>,
 
-	// The number of frames evicted from the front of the group.
+	// Index of the first frame this handle holds: frames evicted from the front, plus any
+	// the group deliberately started past (see [`Producer::start_at`]). Reading below it
+	// is [`Error::Lagged`] either way; the frames are not here.
 	pub(crate) offset: usize,
+
+	// The index the next frame written will get. Tracked separately from `frames` so it
+	// survives the cache being released: a route taking the track over needs to know where
+	// production stopped, and an abort is exactly when it asks.
+	next_index: usize,
+
+	// One past the last frame that was fully written. Trails `next_index` while a chunked
+	// frame is in flight, which is the frame a replacement route has to redeliver: only
+	// its opener saw the payload, and only partly.
+	committed: usize,
 
 	// The total size (in bytes) of all cached frames plus any in-flight frame.
 	pub(crate) cache: u64,
@@ -312,6 +331,34 @@ impl Producer {
 		self.track.timescale
 	}
 
+	/// Start the group at frame `index` rather than 0, so the first frame written lands
+	/// there.
+	///
+	/// A group can be short at its front or its back, never in the middle: this trims
+	/// the front, and simply stopping (then [`finish`](Self::finish)ing) trims the back.
+	/// The frames below `index` are not a gap this handle will ever fill, so a reader
+	/// positioned below it gets [`Error::Lagged`], the same as one that fell behind an
+	/// eviction. They belong to whoever produced the head of the group, typically
+	/// another route serving the same track (see [`crate::track::Subscriber`]).
+	///
+	/// The counterpart of [`Consumer::start_at`], which positions a *reader* the same
+	/// way. Where the group begins is part of its shape, so this must come before the
+	/// first frame; afterwards it returns [`Error::Closed`].
+	pub fn start_at(&mut self, index: u64) -> Result<()> {
+		let index = usize::try_from(index).map_err(|_| Error::BoundsExceeded(crate::coding::BoundsExceeded))?;
+
+		let mut state = modify(&self.state)?;
+		// Every write advances `next_index` past `offset`, so this is "nothing written
+		// yet" in a way a front eviction can't fake.
+		if state.fin.is_some() || state.next_index != state.offset {
+			return Err(Error::Closed);
+		}
+		state.offset = index;
+		state.next_index = index;
+		state.committed = index;
+		Ok(())
+	}
+
 	/// A helper method to write a frame from a single byte buffer.
 	///
 	/// If you want to write multiple chunks, use [Self::create_frame] to get a frame producer.
@@ -337,6 +384,8 @@ impl Producer {
 		state.cache += size;
 		state.charge.add(size);
 		state.frames.push_back(Frame { timestamp, payload });
+		state.next_index += 1;
+		state.committed = state.next_index;
 		state.evict();
 		drop(state);
 
@@ -379,6 +428,7 @@ impl Producer {
 			timestamp,
 			buf: buf.clone(),
 		});
+		state.next_index += 1;
 		state.evict();
 		drop(state);
 
@@ -411,6 +461,7 @@ impl Producer {
 		// frame was created; committing just moves the tail into the completed set.
 		state.partial = None;
 		state.frames.push_back(frame);
+		state.committed = state.next_index;
 		Ok(())
 	}
 
@@ -420,10 +471,13 @@ impl Producer {
 		let _ = self.clone().abort(err);
 	}
 
-	/// Return the number of frames written so far (completed plus any in-flight).
+	/// One past the index of the last frame written (completed or in-flight), which is
+	/// also the index the next frame will get.
+	///
+	/// Counts any frames the group [started past](Self::start_at) or evicted, so it's the
+	/// group's logical length rather than the number of frames this handle holds.
 	pub fn frame_count(&self) -> usize {
-		let state = self.state.read();
-		state.offset + state.frames.len() + state.partial.is_some() as usize
+		self.state.read().next_index
 	}
 
 	/// Mark the group as complete; no more frames will be written.
@@ -432,7 +486,7 @@ impl Producer {
 	/// [`abort`](Self::abort). The handle also keeps the cached frames readable.
 	pub fn finish(&mut self) -> Result<()> {
 		let mut state = modify(&self.state)?;
-		state.fin = Some(state.offset + state.frames.len());
+		state.fin = Some(state.next_index);
 		Ok(())
 	}
 
@@ -453,6 +507,28 @@ impl Producer {
 	/// read paths treat an aborted cached group as absent.
 	pub(crate) fn is_aborted(&self) -> bool {
 		self.state.read().abort.is_some()
+	}
+
+	/// Whether the group was cleanly finished, so no further frame can be appended.
+	pub(crate) fn is_finished(&self) -> bool {
+		self.state.read().fin.is_some()
+	}
+
+	/// The index of the first frame this group still holds: what a reader positioned
+	/// below it would be [`Error::Lagged`] on. Non-zero when the group started later
+	/// (see [`Self::start_at`]) or its head was evicted.
+	pub(crate) fn first_frame(&self) -> usize {
+		self.state.read().offset
+	}
+
+	/// One past the last frame that was fully written.
+	///
+	/// Trails [`Self::frame_count`] while a chunked frame is open, and stops there if
+	/// that frame never completes. This is the boundary a replacement route resumes
+	/// from: an incomplete frame has to be redelivered whole, since a reader can only
+	/// use it whole.
+	pub(crate) fn committed_frames(&self) -> usize {
+		self.state.read().committed
 	}
 
 	/// The group's full cached footprint (payload plus fixed overhead), used by the
@@ -488,10 +564,13 @@ impl Producer {
 	pub fn consume(&self) -> Consumer {
 		Consumer {
 			info: self.info,
-			state: self.state.consume(),
 			track: self.track.clone(),
-			index: 0,
-			prefetch: Prefetch::default(),
+			inner: ConsumerKind::Plain(Plain {
+				state: self.state.consume(),
+				index: 0,
+				end: None,
+				prefetch: Prefetch::default(),
+			}),
 			// Untagged: a tagged track attaches the egress meter via `with_meter`
 			// when it hands the consumer to a subscriber/fetch.
 			stats: stats::Meter::default(),
@@ -603,9 +682,12 @@ impl Drop for Prefetch {
 }
 
 /// Consume a group, frame-by-frame.
+///
+/// Usually a view of one [`Producer`], but a group served across a route change is
+/// *spliced*: it reads each contributing route's copy in turn, joined at the frame the
+/// takeover happened on, so the reader never sees the seam.
 pub struct Consumer {
-	// Shared state with the producer.
-	state: kio::Consumer<GroupState>,
+	inner: ConsumerKind,
 
 	// Immutable stream state.
 	info: Info,
@@ -614,28 +696,58 @@ pub struct Consumer {
 	// wire publisher emit per-frame timestamps at the right scale for a fetched group.
 	track: track::Info,
 
-	// The number of frames we've read.
-	// NOTE: Cloned readers inherit this offset, but then run in parallel.
-	index: usize,
-
-	// A batch of completed frames drained ahead under one lock (whole-frame reads only).
-	prefetch: Prefetch,
-
 	// Egress payload meter, set by a tagged track via [`Self::with_meter`]. Empty
 	// (no-op) for an untagged group.
 	stats: stats::Meter,
 }
 
-impl Clone for Consumer {
+// `Plain` is the hot path and carries an inline frame prefetch, so boxing it to even the
+// variants out would cost an allocation per group to save a pointer chase on the rare one.
+#[expect(clippy::large_enum_variant)]
+enum ConsumerKind {
+	Plain(Plain),
+	// Boxed: the spliced cursor set dwarfs the plain one, and splicing is the rare case.
+	Spliced(Box<super::resume::Group>),
+}
+
+/// The cursor state for a group backed by a single [`Producer`].
+struct Plain {
+	// Shared state with the producer.
+	state: kio::Consumer<GroupState>,
+
+	// The index of the next frame to read.
+	// NOTE: Cloned readers inherit this offset, but then run in parallel.
+	index: usize,
+
+	// Inclusive cap on `index`, set by [`Consumer::end_at`]. Reads end cleanly past it.
+	end: Option<usize>,
+
+	// A batch of completed frames drained ahead under one lock (whole-frame reads only).
+	prefetch: Prefetch,
+}
+
+impl Clone for Plain {
 	fn clone(&self) -> Self {
 		// A clone shares the channel and inherits `index`, but starts with an empty
 		// prefetch: it re-reads its batch from the shared state, in parallel.
 		Self {
 			state: self.state.clone(),
+			index: self.index,
+			end: self.end,
+			prefetch: Prefetch::default(),
+		}
+	}
+}
+
+impl Clone for Consumer {
+	fn clone(&self) -> Self {
+		Self {
+			inner: match &self.inner {
+				ConsumerKind::Plain(plain) => ConsumerKind::Plain(plain.clone()),
+				ConsumerKind::Spliced(spliced) => ConsumerKind::Spliced(Box::new((**spliced).clone())),
+			},
 			info: self.info,
 			track: self.track.clone(),
-			index: self.index,
-			prefetch: Prefetch::default(),
 			// Inherit the meter without re-counting the group: the original already
 			// counted it when the track handed it out.
 			stats: self.stats.clone(),
@@ -652,6 +764,17 @@ impl std::ops::Deref for Consumer {
 }
 
 impl Consumer {
+	/// Rebuild this consumer as the head of a group assembled across route changes,
+	/// keeping the group's identity and its track's properties. See [`super::resume`].
+	pub(crate) fn into_spliced(self, spliced: super::resume::Group) -> Self {
+		Self {
+			inner: ConsumerKind::Spliced(Box::new(spliced)),
+			info: self.info,
+			track: self.track,
+			stats: self.stats,
+		}
+	}
+
 	/// Attach an egress payload meter, counting this as one delivered group.
 	/// Called by a tagged track when it hands the consumer to a subscriber or fetch.
 	pub(crate) fn with_meter(mut self, meter: stats::Meter) -> Self {
@@ -665,6 +788,118 @@ impl Consumer {
 		self.track.timescale
 	}
 
+	/// The index of the next frame this consumer will return.
+	///
+	/// Starts at 0, or at the group's first available frame once [`Self::start_at`] has
+	/// clamped it, and advances by one per frame read.
+	pub fn index(&self) -> u64 {
+		match &self.inner {
+			ConsumerKind::Plain(plain) => plain.index as u64,
+			ConsumerKind::Spliced(spliced) => spliced.index(),
+		}
+	}
+
+	/// Skip ahead so the next frame returned is `index`, discarding anything buffered
+	/// below it.
+	///
+	/// Clamped *up* to the group's first available frame: frames the group never held
+	/// (see [`Producer::start_at`]) or has since evicted can't be returned, so asking
+	/// for one just starts at the first that exists. Read [`Self::index`] back to learn
+	/// where the cursor actually landed.
+	/// Only moves forward; a lower `index` is ignored, since the frames behind the
+	/// cursor may already have been handed out.
+	pub fn start_at(&mut self, index: u64) {
+		match &mut self.inner {
+			ConsumerKind::Plain(plain) => plain.start_at(index),
+			ConsumerKind::Spliced(spliced) => spliced.start_at(index),
+		}
+	}
+
+	/// Stop after frame `index` (inclusive), or remove the cap.
+	///
+	/// Reads past the cap end cleanly (`None`), as if the group finished there. Unlike
+	/// [`Self::start_at`] this can move in either direction: raising it re-offers frames
+	/// that are still cached.
+	pub fn end_at(&mut self, index: impl Into<Option<u64>>) {
+		let index = index.into();
+		match &mut self.inner {
+			ConsumerKind::Plain(plain) => {
+				plain.end = index.map(|index| usize::try_from(index).unwrap_or(usize::MAX));
+			}
+			ConsumerKind::Spliced(spliced) => spliced.end_at(index),
+		}
+	}
+
+	/// Return a consumer for the next frame for chunked reading.
+	pub async fn next_frame(&mut self) -> Result<Option<frame::Consumer>> {
+		kio::wait(|waiter| self.poll_next_frame(waiter)).await
+	}
+
+	/// Poll for the next frame, without blocking.
+	///
+	/// Returns None if the group is finished and the index is out of range, or the cursor
+	/// passed the [`Self::end_at`] cap.
+	pub fn poll_next_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<frame::Consumer>>> {
+		let stats = self.stats.clone();
+		match &mut self.inner {
+			ConsumerKind::Plain(plain) => plain.poll_next_frame(waiter, &stats),
+			ConsumerKind::Spliced(spliced) => {
+				// The per-route copies underneath are untagged, so meter the spliced
+				// stream here: it is the one the subscriber actually reads.
+				let res = ready!(spliced.poll_next_frame(waiter))?;
+				if res.is_some() {
+					stats.frames(1);
+				}
+				Poll::Ready(Ok(res.map(|frame| frame.with_meter(stats))))
+			}
+		}
+	}
+
+	/// Read the next frame (timestamp and payload) all at once, without blocking.
+	pub fn poll_read_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<frame::Frame>>> {
+		let stats = self.stats.clone();
+		match &mut self.inner {
+			ConsumerKind::Plain(plain) => plain.poll_read_frame(waiter, &stats),
+			ConsumerKind::Spliced(spliced) => {
+				let res = ready!(spliced.poll_read_frame(waiter))?;
+				if let Some(frame) = &res {
+					stats.frames(1);
+					stats.bytes(frame.payload.len() as u64);
+				}
+				Poll::Ready(Ok(res))
+			}
+		}
+	}
+
+	/// Read the next frame (timestamp and payload) all at once.
+	pub async fn read_frame(&mut self) -> Result<Option<frame::Frame>> {
+		if let ConsumerKind::Plain(plain) = &mut self.inner {
+			// Serve from the prefetched batch without building a future or allocating a waker.
+			if !plain.capped()
+				&& let Some(frame) = plain.prefetch.pop()
+			{
+				plain.index += 1;
+				return Ok(Some(frame));
+			}
+		}
+		kio::wait(|waiter| self.poll_read_frame(waiter)).await
+	}
+
+	/// Poll for the final number of frames in the group.
+	pub fn poll_finished(&mut self, waiter: &kio::Waiter) -> Poll<Result<u64>> {
+		match &mut self.inner {
+			ConsumerKind::Plain(plain) => plain.poll(waiter, |state| state.poll_finished()),
+			ConsumerKind::Spliced(spliced) => spliced.poll_finished(waiter),
+		}
+	}
+
+	/// Block until the group is finished, returning the number of frames in the group.
+	pub async fn finished(&mut self) -> Result<u64> {
+		kio::wait(|waiter| self.poll_finished(waiter)).await
+	}
+}
+
+impl Plain {
 	// A helper to automatically apply Dropped if the state is closed without an error.
 	fn poll<F, R>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<R>>
 	where
@@ -677,15 +912,27 @@ impl Consumer {
 		})
 	}
 
-	/// Return a consumer for the next frame for chunked reading.
-	pub async fn next_frame(&mut self) -> Result<Option<frame::Consumer>> {
-		kio::wait(|waiter| self.poll_next_frame(waiter)).await
+	/// Whether the cursor has passed the `end_at` cap.
+	fn capped(&self) -> bool {
+		self.end.is_some_and(|end| self.index > end)
 	}
 
-	/// Poll for the next frame, without blocking.
-	///
-	/// Returns None if the group is finished and the index is out of range.
-	pub fn poll_next_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<frame::Consumer>>> {
+	fn start_at(&mut self, index: u64) {
+		let index = usize::try_from(index).unwrap_or(usize::MAX);
+		let index = index.max(self.state.read().offset);
+		if index <= self.index {
+			return;
+		}
+		self.index = index;
+		// The batch was drained from below the new cursor, so it can't be reused.
+		self.prefetch = Prefetch::default();
+	}
+
+	fn poll_next_frame(&mut self, waiter: &kio::Waiter, stats: &stats::Meter) -> Poll<Result<Option<frame::Consumer>>> {
+		if self.capped() {
+			return Poll::Ready(Ok(None));
+		}
+
 		// Hand out any frames a prior read_frame prefetched before touching the tail.
 		// Their bytes were already counted at the batch fill, so the frame::Consumer
 		// carries no meter.
@@ -707,14 +954,17 @@ impl Consumer {
 		self.index += 1;
 		// A direct read (not prefetched): count the frame here; the frame::Consumer
 		// counts its bytes per chunk as they're read out.
-		self.stats.frames(1);
+		stats.frames(1);
 		Poll::Ready(Ok(Some(
-			frame::Consumer::new(self.state.clone(), info, source).with_meter(self.stats.clone()),
+			frame::Consumer::new(self.state.clone(), info, source).with_meter(stats.clone()),
 		)))
 	}
 
-	/// Read the next frame (timestamp and payload) all at once, without blocking.
-	pub fn poll_read_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<frame::Frame>>> {
+	fn poll_read_frame(&mut self, waiter: &kio::Waiter, stats: &stats::Meter) -> Poll<Result<Option<frame::Frame>>> {
+		if self.capped() {
+			return Poll::Ready(Ok(None));
+		}
+
 		// Fast path: serve from the prefetched batch without locking or allocating a waker.
 		if let Some(frame) = self.prefetch.pop() {
 			self.index += 1;
@@ -724,6 +974,9 @@ impl Consumer {
 		// The batch is drained: refill it under a single lock, registering the waiter if
 		// nothing is ready. Borrow the two fields disjointly so the closure can fill.
 		let index = self.index;
+		// Never buffer past the cap: `end_at` can be raised later, and those frames must
+		// come from the shared state then, not from a batch drained under the old cap.
+		let budget = self.end.map_or(usize::MAX, |end| (end - index).saturating_add(1));
 		let prefetch = &mut self.prefetch;
 		let res = self.state.poll(waiter, |state| {
 			if index < state.offset {
@@ -734,7 +987,7 @@ impl Consumer {
 			// panics on an out-of-bounds start. `fill` always resets the batch, so an empty
 			// range leaves `len == 0` and the terminal checks below resolve abort/fin/pending.
 			let local = (index - state.offset).min(state.frames.len());
-			prefetch.fill(state.frames.range(local..).cloned());
+			prefetch.fill(state.frames.range(local..).take(budget).cloned());
 			if prefetch.len > 0 {
 				return Poll::Ready(Ok(()));
 			}
@@ -752,32 +1005,12 @@ impl Consumer {
 		// A fresh batch was just filled (empty only on a clean end). Count the whole
 		// batch once here, under no lock, so the drained pops that follow stay free.
 		let (frames, bytes) = self.prefetch.buffered();
-		self.stats.frames(frames);
-		self.stats.bytes(bytes);
+		stats.frames(frames);
+		stats.bytes(bytes);
 
 		Poll::Ready(Ok(self.prefetch.pop().inspect(|_| {
 			self.index += 1;
 		})))
-	}
-
-	/// Read the next frame (timestamp and payload) all at once.
-	pub async fn read_frame(&mut self) -> Result<Option<frame::Frame>> {
-		// Serve from the prefetched batch without building a future or allocating a waker.
-		if let Some(frame) = self.prefetch.pop() {
-			self.index += 1;
-			return Ok(Some(frame));
-		}
-		kio::wait(|waiter| self.poll_read_frame(waiter)).await
-	}
-
-	/// Poll for the final number of frames in the group.
-	pub fn poll_finished(&mut self, waiter: &kio::Waiter) -> Poll<Result<u64>> {
-		self.poll(waiter, |state| state.poll_finished())
-	}
-
-	/// Block until the group is finished, returning the number of frames in the group.
-	pub async fn finished(&mut self) -> Result<u64> {
-		kio::wait(|waiter| self.poll_finished(waiter)).await
 	}
 }
 
@@ -787,12 +1020,30 @@ impl Consumer {
 pub struct Fetch {
 	/// Delivery priority for the fetched group's stream. Defaults to 0.
 	pub priority: u8,
+
+	/// Index of the first frame to fetch within the group. Defaults to 0, the whole group.
+	///
+	/// Use this to fill a hole left by a route change: the group's head is already
+	/// cached locally and only the tail is missing.
+	///
+	/// There is no matching end: a fetch always runs to the end of the group, and a
+	/// caller wanting less caps the returned consumer with [`Consumer::end_at`]. Stopping
+	/// the *fetch* short would put a group in the cache that is indistinguishable from a
+	/// complete one, so a later fetch of the whole group would resolve from it and come
+	/// up short.
+	pub frame_start: u64,
 }
 
 impl Fetch {
 	/// Set the delivery priority, returning `self` for chaining.
 	pub fn with_priority(mut self, priority: u8) -> Self {
 		self.priority = priority;
+		self
+	}
+
+	/// Set the first frame to fetch, returning `self` for chaining.
+	pub fn with_frame_start(mut self, frame_start: u64) -> Self {
+		self.frame_start = frame_start;
 		self
 	}
 }
@@ -1217,6 +1468,97 @@ mod test {
 			.unwrap();
 		assert_eq!(writer.timestamp.scale(), Timescale::MICRO);
 		assert!(!writer.timestamp.is_zero(), "local clock should be non-zero");
+	}
+
+	/// A group can start partway in, so a route can serve the tail of a group whose
+	/// head came from somewhere else.
+	#[test]
+	fn start_at_starts_the_group_later() {
+		let mut producer = Info { sequence: 0 }.produce();
+		producer.start_at(3).unwrap();
+		producer.write_frame(Timestamp::ZERO, Bytes::from_static(b"d")).unwrap();
+		producer.finish().unwrap();
+
+		// The frame landed at index 3, so the group's length counts the missing head.
+		assert_eq!(producer.frame_count(), 4);
+
+		let mut consumer = producer.consume();
+		assert_eq!(consumer.finished().now_or_never().unwrap().unwrap(), 4);
+
+		// A reader positioned at the start is missing the head, exactly like one that
+		// fell behind an eviction.
+		assert!(matches!(
+			consumer.read_frame().now_or_never().unwrap(),
+			Err(Error::Lagged)
+		));
+	}
+
+	/// Seeking to the group's first available frame is how a spliced reader picks up
+	/// the tail; a lower index clamps up rather than failing.
+	#[test]
+	fn start_at_clamps_up_to_the_first_frame() {
+		let mut producer = Info { sequence: 0 }.produce();
+		producer.start_at(3).unwrap();
+		producer.write_frame(Timestamp::ZERO, Bytes::from_static(b"d")).unwrap();
+		producer.finish().unwrap();
+
+		let mut consumer = producer.consume();
+		consumer.start_at(1);
+		assert_eq!(consumer.index(), 3, "clamped up to the first frame that exists");
+		assert_eq!(
+			consumer.read_frame().now_or_never().unwrap().unwrap().unwrap().payload,
+			Bytes::from_static(b"d")
+		);
+	}
+
+	/// `end_at` ends the read cleanly at the cap, and raising it re-offers the frames
+	/// still cached behind it.
+	#[test]
+	fn end_at_caps_and_reopens() {
+		let mut producer = Info { sequence: 0 }.produce();
+		for i in 0..4u8 {
+			producer.write_frame(Timestamp::ZERO, Bytes::from(vec![i])).unwrap();
+		}
+		producer.finish().unwrap();
+
+		let mut consumer = producer.consume();
+		consumer.end_at(1);
+		assert_eq!(
+			consumer.read_frame().now_or_never().unwrap().unwrap().unwrap().payload[0],
+			0
+		);
+		assert_eq!(
+			consumer.read_frame().now_or_never().unwrap().unwrap().unwrap().payload[0],
+			1
+		);
+		assert!(
+			consumer.read_frame().now_or_never().unwrap().unwrap().is_none(),
+			"capped reads end cleanly"
+		);
+
+		consumer.end_at(None);
+		assert_eq!(
+			consumer.read_frame().now_or_never().unwrap().unwrap().unwrap().payload[0],
+			2
+		);
+	}
+
+	/// Where the group begins is part of its shape, so it can't move once frames exist.
+	#[test]
+	fn start_at_rejected_after_a_frame() {
+		let mut producer = Info { sequence: 0 }.produce();
+		// Re-declaring before the first frame is fine; the shape isn't committed yet.
+		producer.start_at(2).unwrap();
+		producer.start_at(3).unwrap();
+
+		producer.write_frame(Timestamp::ZERO, Bytes::from_static(b"a")).unwrap();
+		assert!(matches!(producer.start_at(4), Err(Error::Closed)));
+		assert_eq!(producer.frame_count(), 4, "the frame landed at index 3");
+
+		// Finishing likewise settles the shape.
+		let mut producer = Info { sequence: 1 }.produce();
+		producer.finish().unwrap();
+		assert!(matches!(producer.start_at(1), Err(Error::Closed)));
 	}
 
 	/// The per-frame size cap (the group byte budget) is enforced before allocating.

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -346,6 +346,9 @@ impl Producer {
 	/// first frame; afterwards it returns [`Error::Closed`].
 	pub fn start_at(&mut self, index: u64) -> Result<()> {
 		let index = usize::try_from(index).map_err(|_| Error::BoundsExceeded(crate::coding::BoundsExceeded))?;
+		if index == usize::MAX {
+			return Err(Error::BoundsExceeded(crate::coding::BoundsExceeded));
+		}
 
 		let mut state = modify(&self.state)?;
 		// Every write advances `next_index` past `offset`, so this is "nothing written
@@ -379,12 +382,16 @@ impl Producer {
 		if state.fin.is_some() {
 			return Err(Error::Closed);
 		}
+		let next_index = state
+			.next_index
+			.checked_add(1)
+			.ok_or(Error::BoundsExceeded(crate::coding::BoundsExceeded))?;
 		debug_assert!(state.partial.is_none(), "a frame is already open");
 		let size = payload.len() as u64;
 		state.cache += size;
 		state.charge.add(size);
 		state.frames.push_back(Frame { timestamp, payload });
-		state.next_index += 1;
+		state.next_index = next_index;
 		state.committed = state.next_index;
 		state.evict();
 		drop(state);
@@ -421,6 +428,10 @@ impl Producer {
 		if state.fin.is_some() {
 			return Err(Error::Closed);
 		}
+		let next_index = state
+			.next_index
+			.checked_add(1)
+			.ok_or(Error::BoundsExceeded(crate::coding::BoundsExceeded))?;
 		debug_assert!(state.partial.is_none(), "a frame is already open");
 		state.cache += frame.size;
 		state.charge.add(frame.size);
@@ -428,7 +439,7 @@ impl Producer {
 			timestamp,
 			buf: buf.clone(),
 		});
-		state.next_index += 1;
+		state.next_index = next_index;
 		state.evict();
 		drop(state);
 
@@ -1559,6 +1570,16 @@ mod test {
 		let mut producer = Info { sequence: 1 }.produce();
 		producer.finish().unwrap();
 		assert!(matches!(producer.start_at(1), Err(Error::Closed)));
+	}
+
+	/// The start must leave room for at least one frame index.
+	#[test]
+	fn start_at_rejects_the_largest_index() {
+		let mut producer = Info { sequence: 0 }.produce();
+		assert!(matches!(
+			producer.start_at(usize::MAX as u64),
+			Err(Error::BoundsExceeded(_))
+		));
 	}
 
 	/// The per-frame size cap (the group byte budget) is enforced before allocating.

--- a/rs/moq-net/src/model/requests.rs
+++ b/rs/moq-net/src/model/requests.rs
@@ -101,6 +101,18 @@ impl<K: Clone + Eq + Hash, V> Requests<K, V> {
 		self.pending.remove(key)
 	}
 
+	/// Whether `key`'s request is still queued, i.e. no handler has popped it yet.
+	///
+	/// A popped request can still be joined, but it can no longer be *changed*: the
+	/// handler already has whatever it needs to serve it.
+	pub(crate) fn is_queued<Q>(&self, key: &Q) -> bool
+	where
+		K: std::borrow::Borrow<Q>,
+		Q: std::hash::Hash + Eq + ?Sized,
+	{
+		self.order.iter().any(|queued| queued.borrow() == key)
+	}
+
 	/// Returns `true` if a queued (not yet popped) request exists.
 	pub fn has_queued(&self) -> bool {
 		!self.order.is_empty()
@@ -161,10 +173,15 @@ mod test {
 		let mut requests = Requests::<u64, &str>::default();
 		requests.add_handler();
 		assert!(requests.insert(1, "a").is_ok());
+		assert!(requests.is_queued(&1));
 
+		// Popping hands the request to a handler: still joinable, no longer queued.
+		// That distinction is what decides whether a joiner may still widen it, since
+		// the handler already holds a copy of whatever it was popped with.
 		assert_eq!(requests.pop(), Some(1));
 		assert_eq!(requests.join(&1), Some(&mut "a"));
 		assert!(!requests.has_queued());
+		assert!(!requests.is_queued(&1));
 
 		assert_eq!(requests.remove(&1), Some("a"));
 		assert!(requests.is_empty());

--- a/rs/moq-net/src/model/requests.rs
+++ b/rs/moq-net/src/model/requests.rs
@@ -101,18 +101,6 @@ impl<K: Clone + Eq + Hash, V> Requests<K, V> {
 		self.pending.remove(key)
 	}
 
-	/// Whether `key`'s request is still queued, i.e. no handler has popped it yet.
-	///
-	/// A popped request can still be joined, but it can no longer be *changed*: the
-	/// handler already has whatever it needs to serve it.
-	pub(crate) fn is_queued<Q>(&self, key: &Q) -> bool
-	where
-		K: std::borrow::Borrow<Q>,
-		Q: std::hash::Hash + Eq + ?Sized,
-	{
-		self.order.iter().any(|queued| queued.borrow() == key)
-	}
-
 	/// Returns `true` if a queued (not yet popped) request exists.
 	pub fn has_queued(&self) -> bool {
 		!self.order.is_empty()
@@ -173,15 +161,12 @@ mod test {
 		let mut requests = Requests::<u64, &str>::default();
 		requests.add_handler();
 		assert!(requests.insert(1, "a").is_ok());
-		assert!(requests.is_queued(&1));
 
-		// Popping hands the request to a handler: still joinable, no longer queued.
-		// That distinction is what decides whether a joiner may still widen it, since
-		// the handler already holds a copy of whatever it was popped with.
+		// Popping hands the request to a handler, which leaves it joinable: a later
+		// caller wanting the same key shares its result rather than queuing a second.
 		assert_eq!(requests.pop(), Some(1));
 		assert_eq!(requests.join(&1), Some(&mut "a"));
 		assert!(!requests.has_queued());
-		assert!(!requests.is_queued(&1));
 
 		assert_eq!(requests.remove(&1), Some("a"));
 		assert!(requests.is_empty());

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -1765,6 +1765,49 @@ mod test {
 		recv_pending(&mut sub);
 	}
 
+	/// A replacement that serves the whole group instead of the requested tail still
+	/// splices cleanly: the reader picks up at the seam and never sees the frames it
+	/// already has.
+	///
+	/// This is what a peer too old for frame bounds delivers. The lite subscriber widens
+	/// the request to the whole group for such a peer rather than failing to encode it
+	/// (see `TrackServe::widen_frame_bounds`), so the extra frames are filtered here.
+	#[tokio::test]
+	async fn takeover_splices_a_replacement_that_resends_the_head() {
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (mut track_b, consumer_b) = track_pair("b");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let mut sub = producer.consume().subscribe(None);
+
+		let mut group = track_a.create_group(group::Info { sequence: 0 }).unwrap();
+		group.write_frame(Timestamp::ZERO, b"a0".to_vec()).unwrap();
+		group.write_frame(Timestamp::ZERO, b"a1".to_vec()).unwrap();
+
+		let mut reading = sub.recv_group().now_or_never().unwrap().unwrap().unwrap();
+		assert_eq!(read(&mut reading), b"a0");
+		assert_eq!(read(&mut reading), b"a1");
+
+		producer.takeover(&consumer_b).unwrap();
+		track_a.abort(Error::Dropped).unwrap();
+		recv_pending(&mut sub);
+
+		// B numbers the group from 0, as an older peer that cannot carry the offset does.
+		let mut group = track_b.create_group(group::Info { sequence: 0 }).unwrap();
+		group.write_frame(Timestamp::ZERO, b"dup0".to_vec()).unwrap();
+		group.write_frame(Timestamp::ZERO, b"dup1".to_vec()).unwrap();
+		group.write_frame(Timestamp::ZERO, b"b2".to_vec()).unwrap();
+		group.finish().unwrap();
+
+		// The reader resumes at frame 2; the re-sent head is filtered, not replayed.
+		assert_eq!(read(&mut reading), b"b2");
+		assert!(reading.read_frame().now_or_never().unwrap().unwrap().is_none());
+
+		// And the group is not surfaced a second time just because B served it whole.
+		recv_pending(&mut sub);
+	}
+
 	/// A route dying midway through a chunked frame resumes *at* that frame, not after
 	/// it. Only the dead route ever saw its payload, and only part of it, so nothing
 	/// downstream can use it.

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -596,7 +596,17 @@ impl Group {
 					// arrive. A finished logical track has no more switches coming, and an
 					// aborted one is over outright, so a dead copy is the end of the group
 					// rather than a gap to park on.
-					let terminal = state.finished || state.abort.is_some();
+					//
+					// Nor can one arrive below the resume point. [`Producer::takeover`]
+					// derives every boundary from [`ResumeState::resume_position`], which
+					// only moves forward, so once it is past this position no future segment
+					// will ever cover it and nobody will be asked for these frames again.
+					//
+					// Only once a route has been given up on, though: a live route that has
+					// not delivered this group yet may still do so out of order, and its own
+					// progress is what moved the resume point past us.
+					let stranded = dead.is_some() && state.resume_position().is_some_and(|resume| resume > position);
+					let terminal = state.finished || state.abort.is_some() || stranded;
 					match state.segments.iter().find(|segment| segment.covers(position)) {
 						// The route that owns these frames died: wait for a replacement.
 						Some(segment) if dead == Some(segment.id) => match terminal {
@@ -663,7 +673,17 @@ impl Group {
 	/// No replacement can arrive: report the loss that stalled us, or a clean end.
 	fn give_up(&mut self) -> Result<bool> {
 		match self.dead.take() {
-			Some((_, err)) => Err(err),
+			Some((_, err)) => {
+				// The only place a spliced group's loss becomes visible, so say which
+				// frames went missing rather than leaving a stuck group to explain itself.
+				tracing::warn!(
+					group = self.sequence,
+					frame = self.index,
+					%err,
+					"no route can serve the rest of this group"
+				);
+				Err(err)
+			}
 			None => Ok(false),
 		}
 	}
@@ -1974,8 +1994,12 @@ mod test {
 	/// A route whose copy of the group is missing the frames the reader needs is treated
 	/// like a dead one. Reading the tail as if it were the head would silently renumber
 	/// every frame in the group.
+	///
+	/// The loss is reported rather than parked on, because the route already produced
+	/// past the missing frames. Boundaries come from `resume_position`, which only moves
+	/// forward, so no future takeover will ever ask anyone for frame 0 again.
 	#[tokio::test]
-	async fn copy_missing_the_head_stalls() {
+	async fn copy_missing_the_head_is_lost() {
 		let (mut track_a, consumer_a) = track_pair("a");
 
 		let mut producer = Producer::new();
@@ -1991,9 +2015,49 @@ mod test {
 		assert_eq!(reading.sequence, 0);
 		assert_eq!(reading.index(), 0, "the reader still wants frame 0");
 		assert!(
-			reading.read_frame().now_or_never().is_none(),
-			"must stall rather than serve the tail as the head"
+			matches!(reading.read_frame().now_or_never(), Some(Err(Error::Lagged))),
+			"must report the loss rather than serve the tail as the head"
 		);
+	}
+
+	/// A route that has run ahead of the seam but has not been given up on still parks.
+	///
+	/// It may yet deliver the missing frames out of order, and its own progress is what
+	/// moved the resume point past them, so its being ahead is not evidence the frames
+	/// are gone. Only a route already declared dead strands the reader.
+	#[tokio::test]
+	async fn live_route_ahead_of_the_seam_still_parks() {
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (mut track_b, consumer_b) = track_pair("b");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let mut sub = producer.consume().subscribe(None);
+
+		let mut group = track_a.create_group(group::Info { sequence: 0 }).unwrap();
+		group.write_frame(Timestamp::ZERO, b"a0".to_vec()).unwrap();
+		group.write_frame(Timestamp::ZERO, b"a1".to_vec()).unwrap();
+
+		let mut reading = sub.recv_group().now_or_never().unwrap().unwrap().unwrap();
+		assert_eq!(read(&mut reading), b"a0");
+		assert_eq!(read(&mut reading), b"a1");
+
+		// B takes over inside group 0, then runs ahead to group 1 without ever serving
+		// the rest of group 0. That pushes the resume point past the seam.
+		producer.takeover(&consumer_b).unwrap();
+		write_group(&mut track_b, 1, "b1");
+		assert_eq!(recv(&mut sub), 1);
+
+		assert!(
+			reading.read_frame().now_or_never().is_none(),
+			"a live route may still fill the seam out of order"
+		);
+
+		// Once it does, the reader picks up where it left off.
+		let mut group = track_b.create_group(group::Info { sequence: 0 }).unwrap();
+		group.start_at(2).unwrap();
+		group.write_frame(Timestamp::ZERO, b"b2".to_vec()).unwrap();
+		assert_eq!(read(&mut reading), b"b2");
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -1,67 +1,86 @@
-//! Splice multiple per-session tracks into one logical track, switching at group
+//! Splice multiple per-session tracks into one logical track, switching at frame
 //! boundaries, so a subscription survives route and connection changes.
 //!
 //! A [`Producer`] holds an ordered list of segments, each a [`track::Consumer`]
-//! bounded to a half-open range of group sequences. [`Producer::switch`] appends a
-//! segment starting at group `N` and caps the previous one at `N - 1`, so the
-//! segments always partition the sequence space. A [`Subscriber`] reads across the
-//! segments as if they were one track: bounds are enforced on the read side (a
-//! route delivering outside its range is silently filtered), a segment dying
-//! stalls the subscriber instead of erroring (the next [`Producer::switch`]
-//! resumes it), and demand is forwarded to each underlying track intersected with
-//! its segment bounds, so a session serving a segment just sees an ordinary
-//! subscription that happens to start or end at a boundary.
+//! bounded to a half-open range of [`Position`]s. [`Producer::switch`] appends a
+//! segment starting at position `P` and caps the previous one there, so the segments
+//! always partition the track. A [`Subscriber`] reads across the segments as if they
+//! were one track: bounds are enforced on the read side (a route delivering outside
+//! its range is silently filtered), a segment dying stalls the subscriber instead of
+//! erroring (the next [`Producer::switch`] resumes it), and demand is forwarded to
+//! each underlying track intersected with its segment bounds, so a session serving a
+//! segment just sees an ordinary subscription that happens to start or end at a
+//! boundary.
+//!
+//! Boundaries are frame-precise, so a takeover does not have to wait for the next
+//! group. When one lands inside a group the subscriber has already handed out, the
+//! group itself is spliced: [`Group`] reads each route's copy in turn and the reader
+//! sees one continuous frame stream. This is what lets a track whose current group
+//! stays open indefinitely (a JSON append log, a catalog with deltas) survive a route
+//! change at all.
 
 use std::task::{Poll, ready};
 
 use crate::{Datagram, Error, Result, frame, group, track};
 
-use super::subscription::{Subscription, min_some};
+use super::subscription::{Position, Subscription, min_some};
 
-/// One spliced source: a track bounded to a range of group sequences.
+/// One spliced source: a track bounded to a half-open range of positions.
 #[derive(Clone)]
 struct Segment {
 	/// Monotonic id, used by subscribers to reconcile their cursor set.
 	id: u64,
-	/// First group this segment serves, or `None` for no lower bound (the
+	/// First position this segment serves, or `None` for no lower bound (the
 	/// initial segment, which may start at the live edge).
-	start: Option<u64>,
-	/// Last group this segment serves (inclusive), or `None` while it is the
-	/// newest segment.
-	end: Option<u64>,
+	start: Option<Position>,
+	/// First position this segment no longer serves, or `None` while it is the
+	/// newest segment. Exclusive, so it is exactly the next segment's `start`.
+	end: Option<Position>,
 	/// The underlying per-session track.
 	track: track::Consumer,
 }
 
 impl Segment {
-	/// The latest group this segment produced within its own range, or `None`
-	/// if nothing in range exists yet (out-of-range groups, e.g. a fetch into
+	/// Whether this segment serves `position`.
+	fn covers(&self, position: Position) -> bool {
+		self.start.is_none_or(|start| position >= start) && self.end.is_none_or(|end| position < end)
+	}
+
+	/// One past the last position this segment produced within its own range, or
+	/// `None` if nothing in range exists yet (out-of-range groups, e.g. a fetch into
 	/// the track below the segment's start, don't count).
-	fn produced(&self) -> Option<u64> {
-		let latest = self.track.latest()?;
-		if let Some(start) = self.start
-			&& latest < start
-		{
+	fn produced(&self) -> Option<Position> {
+		let produced = self.track.resume_position()?;
+		// Nothing in range yet. An unbounded segment starts at the very first frame, so
+		// a track holding only an empty group still counts as having produced nothing.
+		if produced <= self.start.unwrap_or_default() {
 			return None;
 		}
 		Some(match self.end {
-			Some(end) => latest.min(end),
-			None => latest,
+			Some(end) => produced.min(end),
+			None => produced,
 		})
 	}
 }
 
 /// The demand to register on an underlying track: the subscriber's own
 /// preferences intersected with a segment's bounds.
-fn slice(prefs: &Subscription, start: Option<u64>, end: Option<u64>) -> Subscription {
+fn slice(prefs: &Subscription, start: Option<Position>, end: Option<Position>) -> Subscription {
 	let mut sub = prefs.clone();
-	sub.group_start = match (prefs.group_start, start) {
-		(Some(a), Some(b)) => Some(a.max(b)),
-		(Some(a), None) => Some(a),
-		(None, bound) => bound,
-	};
-	sub.group_end = min_some(prefs.group_end, end);
+	sub.set_start(max_unbounded_start(prefs.start(), start));
+	// The segment bound is exclusive and a subscription's is inclusive.
+	sub.set_end(min_some(prefs.end(), end.map(Position::before)));
 	sub
+}
+
+/// The later of two optional start bounds, treating `None` as "the live edge" for the
+/// preference and "no lower bound" for the segment. Either way the other one wins.
+fn max_unbounded_start(prefs: Option<Position>, segment: Option<Position>) -> Option<Position> {
+	match (prefs, segment) {
+		(Some(a), Some(b)) => Some(a.max(b)),
+		(Some(a), None) | (None, Some(a)) => Some(a),
+		(None, None) => None,
+	}
 }
 
 struct ResumeState {
@@ -87,14 +106,26 @@ impl Default for ResumeState {
 }
 
 impl ResumeState {
-	/// The latest group sequence across the segments, clamped to their bounds.
-	fn latest(&self) -> Option<u64> {
+	/// One past the newest position across the segments, clamped to their bounds: where
+	/// a replacement segment should pick the track up.
+	fn resume_position(&self) -> Option<Position> {
 		self.segments.iter().filter_map(Segment::produced).max()
 	}
 
-	/// Append a segment serving groups from `start` onward, capping (or replacing)
+	/// The latest group sequence across the segments, clamped to their bounds.
+	fn latest(&self) -> Option<u64> {
+		let position = self.resume_position()?;
+		match position.frame {
+			// The resume point sits at the head of a group, so the newest group actually
+			// produced is the one below it.
+			0 => position.group.checked_sub(1),
+			_ => Some(position.group),
+		}
+	}
+
+	/// Append a segment serving the track from `start` onward, capping (or replacing)
 	/// the previous segments so the ranges stay disjoint and ascending.
-	fn switch(&mut self, track: track::Consumer, start: Option<u64>) -> Result<()> {
+	fn switch(&mut self, track: track::Consumer, start: Option<Position>) -> Result<()> {
 		if !self.segments.is_empty() {
 			// A boundary is required once a segment exists.
 			let Some(start) = start else {
@@ -102,9 +133,9 @@ impl ResumeState {
 			};
 
 			// Segments the new range fully covers are replaced outright, provided
-			// they never produced a group in range (nothing to splice around).
+			// they never produced anything in range (nothing to splice around).
 			while let Some(prev) = self.segments.last() {
-				let prev_start = prev.start.unwrap_or(0);
+				let prev_start = prev.start.unwrap_or_default();
 				if start > prev_start {
 					break;
 				}
@@ -114,10 +145,10 @@ impl ResumeState {
 				self.segments.pop();
 			}
 
-			// Cap whatever remains at the boundary. The loop above guarantees
-			// `start > prev.start`, so `start - 1` cannot underflow.
+			// Cap whatever remains at the boundary. The bound is exclusive, so the new
+			// segment's start is exactly the previous segment's end.
 			if let Some(prev) = self.segments.last_mut() {
-				prev.end = Some(start - 1);
+				prev.end = Some(start);
 			}
 		}
 
@@ -151,20 +182,20 @@ impl Producer {
 		Self::default()
 	}
 
-	/// Splice in a track serving groups from `start` onward, capping the previous
-	/// segment at `start - 1`.
+	/// Splice in a track serving the track from `start` onward, capping the previous
+	/// segment there.
 	///
 	/// The first switch may pass `None` to leave the segment unbounded (it serves
 	/// whatever the subscriber asks for, typically the live edge). Every later
 	/// switch must pass `Some(start)`. A previous segment whose range the new one
-	/// fully covers is replaced outright, provided it never produced a group in
+	/// fully covers is replaced outright, provided it never produced anything in
 	/// range (there is nothing to splice around); otherwise the boundary must
 	/// advance past it, or this fails with [`Error::BoundsExceeded`] and the
 	/// segment list is unchanged.
 	///
 	/// Bounds are enforced when reading: a previous segment's session may keep
 	/// delivering past its new cap (the switch races the network) and those groups
-	/// are simply never surfaced.
+	/// and frames are simply never surfaced.
 	// Production callers go through `takeover`; this is the entry point an explicit
 	// wire-driven boundary (a future manual-splice surface) would use, and the
 	// boundary tests drive it directly.
@@ -172,7 +203,7 @@ impl Producer {
 	pub fn switch(
 		&mut self,
 		track: impl super::origin_impl::Consume<track::Consumer>,
-		start: impl Into<Option<u64>>,
+		start: impl Into<Option<Position>>,
 	) -> Result<()> {
 		let track = track.consume();
 		let start = start.into();
@@ -184,18 +215,20 @@ impl Producer {
 	}
 
 	/// Splice in a track that resumes wherever the current segments stop: one past
-	/// the newest spliced group.
+	/// the newest spliced frame.
 	///
 	/// This is [`Self::switch`] with the boundary computed from the current state,
-	/// for callers reacting to a route change rather than choosing a boundary. A
-	/// group that was mid-transfer when its route died is not re-delivered live
-	/// (subscribers may already have consumed it); it stays reachable via
-	/// [`Consumer::fetch_group`] like any other loss.
+	/// for callers reacting to a route change rather than choosing a boundary. The
+	/// boundary is frame-precise, so a group that was mid-transfer when its route
+	/// died is continued rather than abandoned: the replacement is asked for the
+	/// frames from the break onward, and subscribers read across the two copies as
+	/// one group. It rolls to the next group only once the current one is complete,
+	/// since nothing more can be appended to it.
 	pub fn takeover(&mut self, track: impl super::origin_impl::Consume<track::Consumer>) -> Result<()> {
 		let track = track.consume();
 		// Compute the boundary and apply it under one write guard: a boundary
 		// computed under a separate read lock could race the old route delivering
-		// more groups, splicing the new segment below the delivered edge.
+		// more frames, splicing the new segment below the delivered edge.
 		let mut state = self.state.write().map_err(|_| Error::Dropped)?;
 		if state.finished || state.abort.is_some() {
 			return Err(Error::Closed);
@@ -203,11 +236,9 @@ impl Producer {
 		let start = if state.segments.is_empty() {
 			None
 		} else {
-			match state.latest() {
-				Some(latest) => latest.checked_add(1),
-				// Segments exist but never produced a group: replace them.
-				None => Some(0),
-			}
+			// Segments exist but never produced anything: replace them, which the very
+			// first position does.
+			Some(state.resume_position().unwrap_or_default())
 		};
 		state.switch(track, start)
 	}
@@ -390,6 +421,12 @@ impl Consumer {
 	pub fn latest(&self) -> Option<u64> {
 		self.state.read().latest()
 	}
+
+	/// One past the newest position across the segments: where a route taking this
+	/// logical track over would resume.
+	pub(crate) fn resume_position(&self) -> Option<Position> {
+		self.state.read().resume_position()
+	}
 }
 
 /// The pollable state of a [`Consumer::fetch_group`]; awaited via the
@@ -441,16 +478,302 @@ impl kio::Pollable for Fetching {
 	}
 }
 
+/// The frames of `sequence` a `[start, end)` segment range serves, as a half-open index
+/// range. `None` when the group falls outside the range entirely.
+fn frames(start: Option<Position>, end: Option<Position>, sequence: u64) -> Option<(u64, Option<u64>)> {
+	let start = match start {
+		Some(start) if start.group > sequence => return None,
+		Some(start) if start.group == sequence => start.frame,
+		_ => 0,
+	};
+	let end = match end {
+		// A boundary at the head of a later group leaves this one whole.
+		Some(end) if end.group > sequence => None,
+		Some(end) if end.group == sequence => Some(end.frame),
+		Some(_) => return None,
+		None => None,
+	};
+	Some((start, end))
+}
+
+/// A group assembled from several routes' copies, joined at frame boundaries.
+///
+/// Rather than being fed, it pulls: on every frame it asks the segment list which route
+/// owns the next frame of this group and reads that route's copy. A boundary landing
+/// mid-group therefore reaches an already-handed-out group with no bookkeeping, and a
+/// reader that never touches the subscription again still picks the continuation up.
+///
+/// A copy that dies (or never arrives) stalls the group rather than erroring it, the
+/// same way a dead segment stalls the track; the loss is only surfaced once no
+/// replacement can arrive.
+pub(crate) struct Group {
+	state: kio::Consumer<ResumeState>,
+
+	/// The logical group being assembled.
+	sequence: u64,
+
+	/// The index of the next frame to return.
+	index: u64,
+
+	/// Inclusive cap from [`Self::end_at`].
+	end: Option<u64>,
+
+	/// The route being read: its segment, the exclusive frame bound the segment puts on
+	/// this group, and this reader's positioned copy.
+	current: Option<Current>,
+
+	/// The segment whose copy died under us, and why.
+	dead: Option<(u64, Error)>,
+}
+
+struct Current {
+	segment: u64,
+	cap: Option<u64>,
+	group: group::Consumer,
+}
+
+impl Clone for Group {
+	fn clone(&self) -> Self {
+		// Cursors are per-reader, so a clone re-resolves its own positioned copy and
+		// then runs in parallel.
+		Self {
+			state: self.state.clone(),
+			sequence: self.sequence,
+			index: self.index,
+			end: self.end,
+			current: None,
+			dead: self.dead.clone(),
+		}
+	}
+}
+
+impl Group {
+	fn new(state: kio::Consumer<ResumeState>, sequence: u64, index: u64) -> Self {
+		Self {
+			state,
+			sequence,
+			index,
+			end: None,
+			current: None,
+			dead: None,
+		}
+	}
+
+	pub fn index(&self) -> u64 {
+		self.index
+	}
+
+	pub fn start_at(&mut self, index: u64) {
+		if index <= self.index {
+			return;
+		}
+		self.index = index;
+		// A different route may own the new cursor.
+		self.current = None;
+	}
+
+	pub fn end_at(&mut self, index: Option<u64>) {
+		self.end = index;
+	}
+
+	/// Point `current` at the route owning frame `index` of this group.
+	///
+	/// `Ready(Ok(false))` once the group can produce nothing more, and `Ready(Err(_))`
+	/// only when the route that died is the last word on those frames.
+	fn poll_current(&mut self, waiter: &kio::Waiter) -> Poll<Result<bool>> {
+		loop {
+			let position = Position {
+				group: self.sequence,
+				frame: self.index,
+			};
+			let dead = self.dead.as_ref().map(|(segment, _)| *segment);
+			let sequence = self.sequence;
+
+			// Scoped so the poll's state borrow ends before `self` is touched again.
+			let found = {
+				let located = self.state.poll(waiter, |state| {
+					// Waiting for a replacement route only makes sense while one can still
+					// arrive. A finished logical track has no more switches coming, and an
+					// aborted one is over outright, so a dead copy is the end of the group
+					// rather than a gap to park on.
+					let terminal = state.finished || state.abort.is_some();
+					match state.segments.iter().find(|segment| segment.covers(position)) {
+						// The route that owns these frames died: wait for a replacement.
+						Some(segment) if dead == Some(segment.id) => match terminal {
+							true => Poll::Ready(None),
+							false => Poll::Pending,
+						},
+						Some(segment) => Poll::Ready(Some((
+							segment.id,
+							segment.track.clone(),
+							frames(segment.start, segment.end, sequence).map(|(_, end)| end),
+						))),
+						// No route owns them yet; park unless none is coming.
+						None if terminal => Poll::Ready(None),
+						None => Poll::Pending,
+					}
+				});
+
+				match located {
+					Poll::Ready(Ok(found)) => found,
+					// The producer is gone, so the segment list is frozen.
+					Poll::Ready(Err(_)) => None,
+					Poll::Pending => return Poll::Pending,
+				}
+			};
+
+			let Some((segment, track, Some(cap))) = found else {
+				return Poll::Ready(self.give_up());
+			};
+
+			// Reuse the positioned handle while the route and its bound hold: it carries
+			// a frame prefetch that re-resolving would throw away.
+			if self
+				.current
+				.as_ref()
+				.is_some_and(|current| current.segment == segment && current.cap == cap)
+			{
+				return Poll::Ready(Ok(true));
+			}
+
+			// The route may not have delivered this group yet, so wait on its cache.
+			let Some(mut group) = ready!(track.poll_peek_group(sequence, waiter)) else {
+				// This route will never have it; fall back to whichever segment replaces it.
+				self.dead = Some((segment, Error::NotFound));
+				continue;
+			};
+
+			// `start_at` clamps up to the first frame the copy still holds, so landing
+			// higher than asked means this route can't cover the seam after all. Treat it
+			// like a dead copy and wait for one that can.
+			group.start_at(self.index);
+			if group.index() != self.index {
+				self.dead = Some((segment, Error::Lagged));
+				continue;
+			}
+
+			// The segment bound is exclusive; a group consumer's cap is inclusive.
+			group.end_at(cap.map(|cap| cap.saturating_sub(1)));
+			self.current = Some(Current { segment, cap, group });
+			self.dead = None;
+			return Poll::Ready(Ok(true));
+		}
+	}
+
+	/// No replacement can arrive: report the loss that stalled us, or a clean end.
+	fn give_up(&mut self) -> Result<bool> {
+		match self.dead.take() {
+			Some((_, err)) => Err(err),
+			None => Ok(false),
+		}
+	}
+
+	/// Advance past a copy that ran out at its boundary, or report the group's end.
+	/// `true` to keep reading from the next route.
+	fn roll(&mut self) -> bool {
+		let Some(current) = &self.current else {
+			return false;
+		};
+		match current.cap {
+			Some(cap) => {
+				// Reaching the bound is the only clean end a bounded copy has: the
+				// boundary was derived from what that route produced.
+				debug_assert_eq!(self.index, cap, "bounded copy ended below its boundary");
+				self.index = self.index.max(cap);
+				self.current = None;
+				true
+			}
+			// Unbounded: this route owns the rest of the group, so its end is the group's.
+			None => false,
+		}
+	}
+
+	/// Mark the current route dead so the reader waits for a replacement instead of
+	/// failing the group outright.
+	fn bury(&mut self, err: Error) {
+		self.dead = self.current.take().map(|current| (current.segment, err));
+	}
+
+	pub fn poll_read_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<frame::Frame>>> {
+		loop {
+			if self.end.is_some_and(|end| self.index > end) {
+				return Poll::Ready(Ok(None));
+			}
+			if !ready!(self.poll_current(waiter))? {
+				return Poll::Ready(Ok(None));
+			}
+			let current = self.current.as_mut().expect("resolved above");
+			match ready!(current.group.poll_read_frame(waiter)) {
+				Ok(Some(frame)) => {
+					self.index += 1;
+					return Poll::Ready(Ok(Some(frame)));
+				}
+				Ok(None) if self.roll() => continue,
+				Ok(None) => return Poll::Ready(Ok(None)),
+				Err(err) => self.bury(err),
+			}
+		}
+	}
+
+	pub fn poll_next_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<frame::Consumer>>> {
+		loop {
+			if self.end.is_some_and(|end| self.index > end) {
+				return Poll::Ready(Ok(None));
+			}
+			if !ready!(self.poll_current(waiter))? {
+				return Poll::Ready(Ok(None));
+			}
+			let current = self.current.as_mut().expect("resolved above");
+			match ready!(current.group.poll_next_frame(waiter)) {
+				Ok(Some(frame)) => {
+					self.index += 1;
+					return Poll::Ready(Ok(Some(frame)));
+				}
+				Ok(None) if self.roll() => continue,
+				Ok(None) => return Poll::Ready(Ok(None)),
+				Err(err) => self.bury(err),
+			}
+		}
+	}
+
+	/// The logical group's total frame count, which only the unbounded tail copy knows:
+	/// its own count already includes the frames it skipped.
+	pub fn poll_finished(&mut self, waiter: &kio::Waiter) -> Poll<Result<u64>> {
+		if !ready!(self.poll_current(waiter))? {
+			return Poll::Ready(Ok(self.index));
+		}
+		let current = self.current.as_mut().expect("resolved above");
+		if current.cap.is_some() {
+			// A bounded copy can't declare the end; wait for the continuation.
+			return Poll::Pending;
+		}
+		current.group.poll_finished(waiter)
+	}
+}
+
 /// A subscriber's cursor over one segment.
 struct SegmentSub {
 	id: u64,
-	start: Option<u64>,
-	end: Option<u64>,
+	start: Option<Position>,
+	end: Option<Position>,
 	sub: SubState,
 	/// A received group held back by the subscriber's [`Subscriber::end_at`] cap,
 	/// re-offered once the cap rises (arrival-order reads consume the underlying
 	/// cursor, so the group is parked here instead of dropped).
 	parked: Option<group::Consumer>,
+}
+
+impl SegmentSub {
+	/// The first group this segment can serve, for the underlying read cursor.
+	fn first_group(&self) -> u64 {
+		self.start.map_or(0, |start| start.group)
+	}
+
+	/// The last group this segment can serve (inclusive), for the underlying read
+	/// cursor. `None` while it is the newest segment.
+	fn last_group(&self) -> Option<u64> {
+		self.end.map(|end| end.before().group)
+	}
 }
 
 enum SubState {
@@ -574,13 +897,16 @@ impl Subscriber {
 				Some(existing) => {
 					if existing.end != segment.end {
 						existing.end = segment.end;
+						let cap = min_some(existing.last_group(), self.end_sequence);
 						if let SubState::Active(sub) = &mut existing.sub {
-							sub.end_at(min_some(segment.end, self.end_sequence));
+							sub.end_at(cap);
 							// Also shrink the demand so the session can cap upstream.
 							let _ = sub.update(slice(&self.last_prefs, segment.start, segment.end));
 						}
 						// A still-pending subscription picks the moved boundary up
-						// when it activates (see `poll_activate`).
+						// when it activates (see `poll_activate`). Groups already handed
+						// out need nothing: a [`Group`] re-reads the segment list on
+						// every frame, so it sees the new boundary by itself.
 					}
 				}
 				None => {
@@ -599,6 +925,23 @@ impl Subscriber {
 		}
 	}
 
+	/// Wrap a group just received from a segment so the reader can follow it across
+	/// later route changes.
+	///
+	/// Returns `None` when the copy continues a group already handed out: its segment
+	/// starts partway into the group, which only happens after an earlier segment served
+	/// the head. Those frames reach the reader through the group it already holds, so
+	/// surfacing the copy again would duplicate them.
+	fn hand_out(&self, segment: usize, group: group::Consumer) -> Option<group::Consumer> {
+		let seg = &self.segments[segment];
+		let sequence = group.sequence;
+		let (start, _) = frames(seg.start, seg.end, sequence)?;
+		if start != 0 {
+			return None;
+		}
+		Some(group.into_spliced(Group::new(self.state.clone(), sequence, 0)))
+	}
+
 	/// Resolve a segment's pending subscription, if any. Ready once the segment is
 	/// `Active` or `Done`; a rejected or closed track becomes `Done` (stall, not
 	/// error). Never consumes groups, so terminal-state pollers can share it.
@@ -614,8 +957,8 @@ impl Subscriber {
 				Poll::Ready(Ok(mut sub)) => {
 					// Enforce the bounds on the read cursor, and re-slice demand in
 					// case a boundary moved while the subscription was pending.
-					sub.start_at(seg.start.unwrap_or(0).max(min_sequence));
-					sub.end_at(min_some(seg.end, end_sequence));
+					sub.start_at(seg.first_group().max(min_sequence));
+					sub.end_at(min_some(seg.last_group(), end_sequence));
 					let _ = sub.update(slice(prefs, seg.start, seg.end));
 					seg.sub = SubState::Active(sub);
 				}
@@ -645,7 +988,7 @@ impl Subscriber {
 					Poll::Ready(Ok(Some(group))) => {
 						// `start_at` already floors the cursor; enforce the cap here since
 						// arrival-order reads don't honor `end_at`.
-						if let Some(end) = seg.end
+						if let Some(end) = seg.last_group()
 							&& group.sequence > end
 						{
 							continue;
@@ -676,6 +1019,10 @@ impl Subscriber {
 
 	/// Poll for the next group in arrival order across the segments.
 	///
+	/// A group that continues one already returned (a boundary landed inside it) is
+	/// spliced onto that group rather than surfaced again, so each sequence is handed
+	/// out exactly once no matter how many routes contributed to it.
+	///
 	/// Returns `Poll::Ready(Ok(None))` once the producer finished and every
 	/// segment completed, and `Poll::Ready(Err(_))` only if the producer aborted.
 	pub fn poll_recv_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
@@ -685,28 +1032,39 @@ impl Subscriber {
 		let beyond_cap = |sequence: u64| end_sequence.is_some_and(|end| sequence > end);
 
 		let mut all_done = true;
-		for seg in &mut self.segments {
+		for index in 0..self.segments.len() {
 			// Re-offer a group parked at the cap once the cap rises.
-			if let Some(group) = seg.parked.take_if(|group| !beyond_cap(group.sequence))
+			let parked = self.segments[index].parked.take_if(|group| !beyond_cap(group.sequence));
+			if let Some(group) = parked
 				&& group.sequence >= self.min_sequence
 			{
-				self.next_sequence = self.next_sequence.max(group.sequence.saturating_add(1));
-				return Poll::Ready(Ok(Some(group)));
+				let sequence = group.sequence;
+				if let Some(group) = self.hand_out(index, group) {
+					self.next_sequence = self.next_sequence.max(sequence.saturating_add(1));
+					return Poll::Ready(Ok(Some(group)));
+				}
 			}
 			// A `start_at` overtook the parked group; drop it and read on.
-			if seg.parked.is_some() {
+			if self.segments[index].parked.is_some() {
 				// Still capped: the segment isn't done, it's parked.
 				all_done = false;
 				continue;
 			}
 
 			loop {
-				match Self::poll_segment(seg, &self.last_prefs, self.min_sequence, end_sequence, waiter) {
+				let polled = Self::poll_segment(
+					&mut self.segments[index],
+					&self.last_prefs,
+					self.min_sequence,
+					end_sequence,
+					waiter,
+				);
+				match polled {
 					Poll::Ready(Some(group)) => {
 						if beyond_cap(group.sequence) {
 							// `end_at` parks the subscriber; hold the group until
 							// the cap rises rather than dropping it.
-							seg.parked = Some(group);
+							self.segments[index].parked = Some(group);
 							all_done = false;
 							break;
 						}
@@ -715,7 +1073,13 @@ impl Subscriber {
 							// and re-poll the same segment for what's behind it.
 							continue;
 						}
-						self.next_sequence = self.next_sequence.max(group.sequence.saturating_add(1));
+						let sequence = group.sequence;
+						// Folded into a group already handed out: keep reading this
+						// segment rather than surfacing the same sequence twice.
+						let Some(group) = self.hand_out(index, group) else {
+							continue;
+						};
+						self.next_sequence = self.next_sequence.max(sequence.saturating_add(1));
 						return Poll::Ready(Ok(Some(group)));
 					}
 					Poll::Ready(None) => break,
@@ -879,8 +1243,9 @@ impl Subscriber {
 	pub fn start_at(&mut self, sequence: u64) {
 		self.min_sequence = sequence;
 		for seg in &mut self.segments {
+			let floor = seg.first_group().max(sequence);
 			if let SubState::Active(sub) = &mut seg.sub {
-				sub.start_at(seg.start.unwrap_or(0).max(sequence));
+				sub.start_at(floor);
 			}
 		}
 	}
@@ -889,8 +1254,9 @@ impl Subscriber {
 	pub fn end_at(&mut self, sequence: impl Into<Option<u64>>) {
 		self.end_sequence = sequence.into();
 		for seg in &mut self.segments {
+			let cap = min_some(seg.last_group(), self.end_sequence);
 			if let SubState::Active(sub) = &mut seg.sub {
-				sub.end_at(min_some(seg.end, self.end_sequence));
+				sub.end_at(cap);
 			}
 		}
 	}
@@ -947,6 +1313,17 @@ mod test {
 			.sequence
 	}
 
+	fn read(group: &mut group::Consumer) -> Vec<u8> {
+		group
+			.read_frame()
+			.now_or_never()
+			.expect("should not block")
+			.expect("should not error")
+			.expect("should not be finished")
+			.payload
+			.to_vec()
+	}
+
 	fn recv_pending(sub: &mut Subscriber) {
 		assert!(sub.recv_group().now_or_never().is_none(), "should have blocked");
 	}
@@ -967,7 +1344,7 @@ mod test {
 		assert_eq!(recv(&mut sub), 1);
 
 		// Switch to B at group 2. A racing past its cap is filtered.
-		producer.switch(&consumer_b, 2).unwrap();
+		producer.switch(&consumer_b, Position::group(2)).unwrap();
 		write_group(&mut track_a, 2, "a2-over-cap");
 		write_group(&mut track_b, 2, "b2");
 		write_group(&mut track_b, 3, "b3");
@@ -992,7 +1369,7 @@ mod test {
 		recv_pending(&mut sub);
 		assert_eq!(track_a.subscription().unwrap().group_end, None);
 
-		producer.switch(&consumer_b, 5).unwrap();
+		producer.switch(&consumer_b, Position::group(5)).unwrap();
 		recv_pending(&mut sub);
 
 		// The old session sees its demand capped; the new one starts at the boundary.
@@ -1033,7 +1410,7 @@ mod test {
 		recv_pending(&mut sub);
 
 		// A replacement resumes exactly where the old route left off.
-		producer.switch(&consumer_b, 1).unwrap();
+		producer.switch(&consumer_b, Position::group(1)).unwrap();
 		write_group(&mut track_b, 1, "b1");
 		assert_eq!(recv(&mut sub), 1);
 	}
@@ -1118,7 +1495,7 @@ mod test {
 		let mut sub = producer.consume().subscribe(None);
 
 		write_group(&mut track_a, 0, "a0");
-		producer.switch(&consumer_b, 1).unwrap();
+		producer.switch(&consumer_b, Position::group(1)).unwrap();
 		write_group(&mut track_b, 1, "b1");
 
 		let frame = sub.read_frame().now_or_never().unwrap().unwrap().unwrap();
@@ -1149,7 +1526,7 @@ mod test {
 
 		let mut producer = Producer::new();
 		producer.switch(&consumer_a, None).unwrap();
-		producer.switch(&consumer_b, 10).unwrap();
+		producer.switch(&consumer_b, Position::group(10)).unwrap();
 
 		// A cached group on the newest segment resolves immediately, even below
 		// its subscribe boundary: bounds slice demand, not access.
@@ -1299,7 +1676,7 @@ mod test {
 
 		// A boundary at the delivered edge: B re-serves group 1, which was already
 		// returned and must not be delivered twice.
-		producer.switch(&consumer_b, 1).unwrap();
+		producer.switch(&consumer_b, Position::group(1)).unwrap();
 		write_group(&mut track_b, 1, "b1");
 		write_group(&mut track_b, 2, "b2");
 		assert_eq!(next(&mut sub), 2);
@@ -1344,6 +1721,238 @@ mod test {
 		assert_eq!(track_a.subscription().unwrap().priority, 2);
 	}
 
+	/// A route dying partway through a group is resumed at the frame it stopped on:
+	/// the reader keeps the same group handle, sees no duplicate frames, and never
+	/// learns a route changed. This is the whole point of frame-precise boundaries
+	/// (a JSON append log's group may never roll).
+	#[tokio::test]
+	async fn takeover_splices_mid_group() {
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (mut track_b, consumer_b) = track_pair("b");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let mut sub = producer.consume().subscribe(None);
+
+		// A opens group 0 and writes two frames, leaving it open.
+		let mut group = track_a.create_group(group::Info { sequence: 0 }).unwrap();
+		group.write_frame(Timestamp::ZERO, b"a0".to_vec()).unwrap();
+		group.write_frame(Timestamp::ZERO, b"a1".to_vec()).unwrap();
+
+		let mut reading = sub.recv_group().now_or_never().unwrap().unwrap().unwrap();
+		assert_eq!(reading.sequence, 0);
+		assert_eq!(read(&mut reading), b"a0", "first");
+		assert_eq!(read(&mut reading), b"a1", "second");
+		assert!(reading.read_frame().now_or_never().is_none(), "group is still open");
+
+		// The route dies mid-group and B takes over inside it.
+		producer.takeover(&consumer_b).unwrap();
+		track_a.abort(Error::Dropped).unwrap();
+		recv_pending(&mut sub);
+
+		let demand = track_b.subscription().unwrap();
+		assert_eq!(demand.group_start, Some(0), "resumes in the same group");
+		assert_eq!(demand.frame_start, 2, "resumes at the frame the old route stopped on");
+
+		let mut group = track_b.create_group(group::Info { sequence: 0 }).unwrap();
+		group.start_at(2).unwrap();
+		group.write_frame(Timestamp::ZERO, b"b2".to_vec()).unwrap();
+		group.finish().unwrap();
+
+		// Same handle, no seam: the continuation is not surfaced as a second group.
+		assert_eq!(read(&mut reading), b"b2");
+		assert!(reading.read_frame().now_or_never().unwrap().unwrap().is_none());
+		recv_pending(&mut sub);
+	}
+
+	/// A route dying midway through a chunked frame resumes *at* that frame, not after
+	/// it. Only the dead route ever saw its payload, and only part of it, so nothing
+	/// downstream can use it.
+	#[tokio::test]
+	async fn takeover_redelivers_an_incomplete_frame() {
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (mut track_b, consumer_b) = track_pair("b");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let mut sub = producer.consume().subscribe(None);
+
+		let mut group = track_a.create_group(group::Info { sequence: 0 }).unwrap();
+		group.write_frame(Timestamp::ZERO, b"a0".to_vec()).unwrap();
+
+		let mut reading = sub.recv_group().now_or_never().unwrap().unwrap().unwrap();
+		assert_eq!(read(&mut reading), b"a0");
+
+		// Frame 1 is opened and half written when the route dies. Dropping the frame
+		// producer without finishing aborts the group, as a broken stream would.
+		{
+			let mut frame = group
+				.create_frame(frame::Info {
+					size: 6,
+					timestamp: Timestamp::ZERO,
+				})
+				.unwrap();
+			frame.write(b"foo".to_vec()).unwrap();
+		}
+		track_a.abort(Error::Dropped).unwrap();
+
+		producer.takeover(&consumer_b).unwrap();
+		recv_pending(&mut sub);
+
+		let demand = track_b.subscription().unwrap();
+		assert_eq!(
+			(demand.group_start, demand.frame_start),
+			(Some(0), 1),
+			"the half-written frame must be redelivered, not skipped"
+		);
+
+		let mut group = track_b.create_group(group::Info { sequence: 0 }).unwrap();
+		group.start_at(1).unwrap();
+		group.write_frame(Timestamp::ZERO, b"b1".to_vec()).unwrap();
+
+		// The reader was parked on frame 1 and picks it up from the replacement.
+		assert_eq!(read(&mut reading), b"b1");
+	}
+
+	/// The old route racing past its frame boundary is filtered, exactly as an
+	/// out-of-range group is.
+	#[tokio::test]
+	async fn mid_group_boundary_caps_the_old_route() {
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (mut track_b, consumer_b) = track_pair("b");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let mut sub = producer.consume().subscribe(None);
+
+		let mut group_a = track_a.create_group(group::Info { sequence: 0 }).unwrap();
+		group_a.write_frame(Timestamp::ZERO, b"a0".to_vec()).unwrap();
+
+		let mut reading = sub.recv_group().now_or_never().unwrap().unwrap().unwrap();
+		assert_eq!(read(&mut reading), b"a0");
+
+		producer.takeover(&consumer_b).unwrap();
+		recv_pending(&mut sub);
+		// The old copy's demand is capped just below the boundary.
+		let demand = track_a.subscription().unwrap();
+		assert_eq!((demand.group_end, demand.frame_end), (Some(0), Some(0)));
+
+		// A keeps writing anyway; those frames belong to B's range now.
+		group_a.write_frame(Timestamp::ZERO, b"a1-over-cap".to_vec()).unwrap();
+
+		let mut group_b = track_b.create_group(group::Info { sequence: 0 }).unwrap();
+		group_b.start_at(1).unwrap();
+		group_b.write_frame(Timestamp::ZERO, b"b1".to_vec()).unwrap();
+
+		assert_eq!(read(&mut reading), b"b1");
+	}
+
+	/// A takeover only rolls to the next group once the current one is complete;
+	/// there is nothing left to append to it.
+	#[tokio::test]
+	async fn takeover_rolls_past_a_finished_group() {
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (track_b, consumer_b) = track_pair("b");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let mut sub = producer.consume().subscribe(None);
+
+		write_group(&mut track_a, 0, "a0");
+		assert_eq!(recv(&mut sub), 0);
+
+		producer.takeover(&consumer_b).unwrap();
+		recv_pending(&mut sub);
+		let demand = track_b.subscription().unwrap();
+		assert_eq!(demand.group_start, Some(1));
+		assert_eq!(demand.frame_start, 0);
+	}
+
+	/// A copy dying mid-group stalls its readers instead of erroring them, the same
+	/// way a dead segment stalls the track. The next takeover resumes them.
+	#[tokio::test]
+	async fn dead_copy_stalls_until_the_continuation() {
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (mut track_b, consumer_b) = track_pair("b");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let mut sub = producer.consume().subscribe(None);
+
+		let mut group = track_a.create_group(group::Info { sequence: 0 }).unwrap();
+		group.write_frame(Timestamp::ZERO, b"a0".to_vec()).unwrap();
+
+		let mut reading = sub.recv_group().now_or_never().unwrap().unwrap().unwrap();
+		assert_eq!(read(&mut reading), b"a0");
+
+		// The copy fails outright; the reader must not see the error.
+		group.abort(Error::Dropped).unwrap();
+		assert!(reading.read_frame().now_or_never().is_none(), "should stall, not error");
+
+		producer.takeover(&consumer_b).unwrap();
+		let mut group = track_b.create_group(group::Info { sequence: 0 }).unwrap();
+		group.start_at(1).unwrap();
+		group.write_frame(Timestamp::ZERO, b"b1".to_vec()).unwrap();
+		assert_eq!(read(&mut reading), b"b1");
+	}
+
+	/// A dead copy stalls only while a replacement can still arrive. Once the logical
+	/// track aborts, no switch is coming, so the reader has to surface the loss rather
+	/// than park on it forever.
+	#[tokio::test]
+	async fn dead_copy_ends_once_the_track_aborts() {
+		let (mut track_a, consumer_a) = track_pair("a");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let mut sub = producer.consume().subscribe(None);
+
+		let mut group = track_a.create_group(group::Info { sequence: 0 }).unwrap();
+		group.write_frame(Timestamp::ZERO, b"a0".to_vec()).unwrap();
+
+		let mut reading = sub.recv_group().now_or_never().unwrap().unwrap().unwrap();
+		assert_eq!(read(&mut reading), b"a0");
+
+		// The route dies. A switch could still replace it, so the reader parks.
+		group.abort(Error::Dropped).unwrap();
+		assert!(
+			reading.read_frame().now_or_never().is_none(),
+			"a switch could still come"
+		);
+
+		// The logical track aborts: nothing can replace it now.
+		producer.abort(Error::Cancel).unwrap();
+		assert!(
+			matches!(reading.read_frame().now_or_never(), Some(Err(_))),
+			"an aborted track must not leave the reader parked"
+		);
+	}
+
+	/// A route whose copy of the group is missing the frames the reader needs is treated
+	/// like a dead one. Reading the tail as if it were the head would silently renumber
+	/// every frame in the group.
+	#[tokio::test]
+	async fn copy_missing_the_head_stalls() {
+		let (mut track_a, consumer_a) = track_pair("a");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		let mut sub = producer.consume().subscribe(None);
+
+		// This route only ever held the tail: its copy starts at frame 2.
+		let mut group = track_a.create_group(group::Info { sequence: 0 }).unwrap();
+		group.start_at(2).unwrap();
+		group.write_frame(Timestamp::ZERO, b"a2".to_vec()).unwrap();
+
+		let mut reading = sub.recv_group().now_or_never().unwrap().unwrap().unwrap();
+		assert_eq!(reading.sequence, 0);
+		assert_eq!(reading.index(), 0, "the reader still wants frame 0");
+		assert!(
+			reading.read_frame().now_or_never().is_none(),
+			"must stall rather than serve the tail as the head"
+		);
+	}
+
 	#[tokio::test]
 	async fn switch_validates_boundaries() {
 		let (mut track_a, consumer_a) = track_pair("a");
@@ -1356,7 +1965,7 @@ mod test {
 		// when the previous segment never produced a group.
 		assert!(producer.switch(&consumer_b, None).is_err());
 		write_group(&mut track_a, 0, "a0");
-		assert!(producer.switch(&consumer_b, 0).is_err());
-		producer.switch(&consumer_b, 1).unwrap();
+		assert!(producer.switch(&consumer_b, Position::group(0)).is_err());
+		producer.switch(&consumer_b, Position::group(1)).unwrap();
 	}
 }

--- a/rs/moq-net/src/model/subscription.rs
+++ b/rs/moq-net/src/model/subscription.rs
@@ -41,15 +41,15 @@ pub struct Subscription {
 	/// First frame to deliver within [`Self::group_start`]'s group. `0` (the default)
 	/// starts at the beginning of that group.
 	///
-	/// Only meaningful alongside an explicit `group_start`: frames are numbered per
-	/// group, so there is nothing to count from until the group is pinned down. A
-	/// subscriber asking for the latest group must leave this at `0`.
+	/// Frames are numbered per group, so this counts from nothing without an explicit
+	/// `group_start` and is ignored when there is none. Set the pair together with
+	/// [`Self::with_start`], which is the only way to reach it.
 	pub frame_start: u64,
 	/// Last frame to deliver (inclusive) within [`Self::group_end`]'s group, or `None`
 	/// (the default) for through the end of that group.
 	///
-	/// Only meaningful alongside an explicit `group_end`, mirroring
-	/// [`Self::frame_start`].
+	/// Ignored without an explicit `group_end`, mirroring [`Self::frame_start`]. Set the
+	/// pair together with [`Self::with_end`].
 	pub frame_end: Option<u64>,
 }
 
@@ -100,21 +100,30 @@ impl Subscription {
 		self
 	}
 
-	/// Set the first frame to deliver within the start group, returning `self` for chaining.
-	pub fn with_frame_start(mut self, frame_start: u64) -> Self {
-		self.frame_start = frame_start;
+	/// Set the first position to deliver: frame `frame` of group `group`, returning `self`
+	/// for chaining.
+	///
+	/// The group comes with it because a frame index only means something relative to a
+	/// group, so there is no way to name a frame without the group it belongs to.
+	/// [`Self::with_group_start`] is the whole-group form, the same as `frame` 0.
+	pub fn with_start(mut self, group: u64, frame: u64) -> Self {
+		self.group_start = Some(group);
+		self.frame_start = frame;
 		self
 	}
 
-	/// Set the last frame to deliver (inclusive) within the end group, returning `self`
-	/// for chaining.
-	pub fn with_frame_end(mut self, frame_end: impl Into<Option<u64>>) -> Self {
-		self.frame_end = frame_end.into();
+	/// Set the last position to deliver (inclusive): frame `frame` of group `group`, or
+	/// all of `group` when `frame` is `None`. Returns `self` for chaining.
+	///
+	/// Pairs the group with the frame for the same reason as [`Self::with_start`].
+	pub fn with_end(mut self, group: u64, frame: impl Into<Option<u64>>) -> Self {
+		self.group_end = Some(group);
+		self.frame_end = frame.into();
 		self
 	}
 
 	/// The requested start as an ordered position, or `None` for the live edge.
-	pub(super) fn start(&self) -> Option<Position> {
+	pub(crate) fn start(&self) -> Option<Position> {
 		self.group_start.map(|group| Position {
 			group,
 			frame: self.frame_start,
@@ -124,7 +133,7 @@ impl Subscription {
 	/// The requested end as an ordered position, or `None` for unbounded. The frame is
 	/// `u64::MAX` when the whole end group is wanted, so the ordering matches the
 	/// "widest end wins" aggregate.
-	pub(super) fn end(&self) -> Option<Position> {
+	pub(crate) fn end(&self) -> Option<Position> {
 		self.group_end.map(|group| Position {
 			group,
 			frame: self.frame_end.unwrap_or(u64::MAX),
@@ -132,14 +141,14 @@ impl Subscription {
 	}
 
 	/// Apply an aggregated start position, or the live edge when `None`.
-	pub(super) fn set_start(&mut self, start: Option<Position>) {
+	pub(crate) fn set_start(&mut self, start: Option<Position>) {
 		self.group_start = start.map(|start| start.group);
 		self.frame_start = start.map_or(0, |start| start.frame);
 	}
 
 	/// Apply an aggregated end position, or unbounded when `None`. A `u64::MAX` frame
 	/// maps back to "the whole end group".
-	pub(super) fn set_end(&mut self, end: Option<Position>) {
+	pub(crate) fn set_end(&mut self, end: Option<Position>) {
 		self.group_end = end.map(|end| end.group);
 		self.frame_end = end.and_then(|end| (end.frame != u64::MAX).then_some(end.frame));
 	}
@@ -287,8 +296,8 @@ mod tests {
 
 	#[test]
 	fn combined_start_folds_the_whole_position() {
-		let early_frame = Subscription::default().with_group_start(5).with_frame_start(2);
-		let late_frame = Subscription::default().with_group_start(5).with_frame_start(9);
+		let early_frame = Subscription::default().with_start(5, 2);
+		let late_frame = Subscription::default().with_start(5, 9);
 
 		// Same group: the earlier frame wins.
 		let combined = combine(&[late_frame.clone(), early_frame.clone()]).unwrap();
@@ -296,15 +305,15 @@ mod tests {
 
 		// An earlier group wins outright, carrying its own frame rather than the
 		// smallest frame across the two.
-		let earlier_group = Subscription::default().with_group_start(4).with_frame_start(7);
+		let earlier_group = Subscription::default().with_start(4, 7);
 		let combined = combine(&[early_frame, earlier_group]).unwrap();
 		assert_eq!((combined.group_start, combined.frame_start), (Some(4), 7));
 	}
 
 	#[test]
 	fn combined_end_folds_the_whole_position() {
-		let short = Subscription::default().with_group_end(5).with_frame_end(2);
-		let long = Subscription::default().with_group_end(5).with_frame_end(9);
+		let short = Subscription::default().with_end(5, 2);
+		let long = Subscription::default().with_end(5, 9);
 
 		// Same group: the later frame wins.
 		let combined = combine(&[short.clone(), long.clone()]).unwrap();
@@ -316,7 +325,7 @@ mod tests {
 		assert_eq!((combined.group_end, combined.frame_end), (Some(5), None));
 
 		// A later group wins outright, carrying its own frame.
-		let later_group = Subscription::default().with_group_end(6).with_frame_end(1);
+		let later_group = Subscription::default().with_end(6, 1);
 		let combined = combine(&[short, later_group]).unwrap();
 		assert_eq!((combined.group_end, combined.frame_end), (Some(6), Some(1)));
 	}

--- a/rs/moq-net/src/model/subscription.rs
+++ b/rs/moq-net/src/model/subscription.rs
@@ -38,6 +38,19 @@ pub struct Subscription {
 	/// cursor; setting one does not imply the other. See [Local cursor vs wire
 	/// preference](crate::track::Subscriber#local-cursor-vs-wire-preference).
 	pub group_end: Option<u64>,
+	/// First frame to deliver within [`Self::group_start`]'s group. `0` (the default)
+	/// starts at the beginning of that group.
+	///
+	/// Only meaningful alongside an explicit `group_start`: frames are numbered per
+	/// group, so there is nothing to count from until the group is pinned down. A
+	/// subscriber asking for the latest group must leave this at `0`.
+	pub frame_start: u64,
+	/// Last frame to deliver (inclusive) within [`Self::group_end`]'s group, or `None`
+	/// (the default) for through the end of that group.
+	///
+	/// Only meaningful alongside an explicit `group_end`, mirroring
+	/// [`Self::frame_start`].
+	pub frame_end: Option<u64>,
 }
 
 impl Default for Subscription {
@@ -48,6 +61,8 @@ impl Default for Subscription {
 			latency_max: Duration::ZERO,
 			group_start: None,
 			group_end: None,
+			frame_start: 0,
+			frame_end: None,
 		}
 	}
 }
@@ -85,6 +100,50 @@ impl Subscription {
 		self
 	}
 
+	/// Set the first frame to deliver within the start group, returning `self` for chaining.
+	pub fn with_frame_start(mut self, frame_start: u64) -> Self {
+		self.frame_start = frame_start;
+		self
+	}
+
+	/// Set the last frame to deliver (inclusive) within the end group, returning `self`
+	/// for chaining.
+	pub fn with_frame_end(mut self, frame_end: impl Into<Option<u64>>) -> Self {
+		self.frame_end = frame_end.into();
+		self
+	}
+
+	/// The requested start as an ordered position, or `None` for the live edge.
+	pub(super) fn start(&self) -> Option<Position> {
+		self.group_start.map(|group| Position {
+			group,
+			frame: self.frame_start,
+		})
+	}
+
+	/// The requested end as an ordered position, or `None` for unbounded. The frame is
+	/// `u64::MAX` when the whole end group is wanted, so the ordering matches the
+	/// "widest end wins" aggregate.
+	pub(super) fn end(&self) -> Option<Position> {
+		self.group_end.map(|group| Position {
+			group,
+			frame: self.frame_end.unwrap_or(u64::MAX),
+		})
+	}
+
+	/// Apply an aggregated start position, or the live edge when `None`.
+	pub(super) fn set_start(&mut self, start: Option<Position>) {
+		self.group_start = start.map(|start| start.group);
+		self.frame_start = start.map_or(0, |start| start.frame);
+	}
+
+	/// Apply an aggregated end position, or unbounded when `None`. A `u64::MAX` frame
+	/// maps back to "the whole end group".
+	pub(super) fn set_end(&mut self, end: Option<Position>) {
+		self.group_end = end.map(|end| end.group);
+		self.frame_end = end.and_then(|end| (end.frame != u64::MAX).then_some(end.frame));
+	}
+
 	// Fold this subscription into the running aggregate: Ready with the merged
 	// result when it demands more than `combined`, Pending when it's a subset
 	// (so callers can skip a redundant broadcast of the same aggregate).
@@ -93,14 +152,18 @@ impl Subscription {
 			return Poll::Ready(self.clone());
 		};
 
-		let merged = Subscription {
+		let mut merged = Subscription {
 			priority: self.priority.max(combined.priority),
 			// Sequence-first prioritization is enabled only when every subscriber wants it.
 			ordered: self.ordered && combined.ordered,
 			latency_max: self.latency_max.max(combined.latency_max),
-			group_start: min_some(self.group_start, combined.group_start),
-			group_end: max_unbounded(self.group_end, combined.group_end),
+			..Subscription::default()
 		};
+		// Frame-precise bounds fold as whole positions: two subscribers starting in the
+		// same group are separated only by their frame, so folding the group and the
+		// frame independently would invent a start neither asked for.
+		merged.set_start(min_some(self.start(), combined.start()));
+		merged.set_end(max_unbounded(self.end(), combined.end()));
 
 		if &merged != combined {
 			return Poll::Ready(merged);
@@ -110,8 +173,48 @@ impl Subscription {
 	}
 }
 
+/// A frame-precise point in a track: a group sequence and a frame index within it.
+///
+/// Ordered lexicographically, so comparing positions is the same as comparing groups
+/// and only falling back to frames within one. This is the model's counterpart of the
+/// wire's (`Group`, `Frame`) pairs on SUBSCRIBE / SUBSCRIBE_OK / FETCH.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct Position {
+	/// The group sequence.
+	pub group: u64,
+	/// The frame index within the group.
+	pub frame: u64,
+}
+
+impl Position {
+	/// The start of a group.
+	pub fn group(group: u64) -> Self {
+		Self { group, frame: 0 }
+	}
+
+	/// The last position strictly below this one, converting a half-open bound into the
+	/// inclusive one a [`Subscription`] carries.
+	///
+	/// A boundary at the head of a group backs up to all of the group below it, which
+	/// saturates at the very first frame. Nothing produces a boundary there: a segment
+	/// capped at the start of the track would serve nothing, and such a segment is
+	/// replaced outright rather than capped.
+	pub fn before(self) -> Self {
+		match self.frame.checked_sub(1) {
+			Some(frame) => Self {
+				group: self.group,
+				frame,
+			},
+			None => Self {
+				group: self.group.saturating_sub(1),
+				frame: u64::MAX,
+			},
+		}
+	}
+}
+
 /// The lower of two optional bounds, treating `None` as unbounded.
-pub(super) fn min_some(a: Option<u64>, b: Option<u64>) -> Option<u64> {
+pub(super) fn min_some<T: Ord>(a: Option<T>, b: Option<T>) -> Option<T> {
 	match (a, b) {
 		(Some(a), Some(b)) => Some(a.min(b)),
 		(Some(a), None) | (None, Some(a)) => Some(a),
@@ -119,7 +222,9 @@ pub(super) fn min_some(a: Option<u64>, b: Option<u64>) -> Option<u64> {
 	}
 }
 
-fn max_unbounded(a: Option<u64>, b: Option<u64>) -> Option<u64> {
+/// The higher of two optional bounds, treating `None` as unbounded (and therefore
+/// absorbing).
+pub(super) fn max_unbounded<T: Ord>(a: Option<T>, b: Option<T>) -> Option<T> {
 	match (a, b) {
 		(Some(a), Some(b)) => Some(a.max(b)),
 		(None, _) | (_, None) => None,
@@ -178,6 +283,42 @@ mod tests {
 		let combined = combine(&[live, bounded]).unwrap();
 
 		assert_eq!(combined.group_end, None);
+	}
+
+	#[test]
+	fn combined_start_folds_the_whole_position() {
+		let early_frame = Subscription::default().with_group_start(5).with_frame_start(2);
+		let late_frame = Subscription::default().with_group_start(5).with_frame_start(9);
+
+		// Same group: the earlier frame wins.
+		let combined = combine(&[late_frame.clone(), early_frame.clone()]).unwrap();
+		assert_eq!((combined.group_start, combined.frame_start), (Some(5), 2));
+
+		// An earlier group wins outright, carrying its own frame rather than the
+		// smallest frame across the two.
+		let earlier_group = Subscription::default().with_group_start(4).with_frame_start(7);
+		let combined = combine(&[early_frame, earlier_group]).unwrap();
+		assert_eq!((combined.group_start, combined.frame_start), (Some(4), 7));
+	}
+
+	#[test]
+	fn combined_end_folds_the_whole_position() {
+		let short = Subscription::default().with_group_end(5).with_frame_end(2);
+		let long = Subscription::default().with_group_end(5).with_frame_end(9);
+
+		// Same group: the later frame wins.
+		let combined = combine(&[short.clone(), long.clone()]).unwrap();
+		assert_eq!((combined.group_end, combined.frame_end), (Some(5), Some(9)));
+
+		// An unbounded frame is the whole group, so it absorbs any capped one.
+		let whole = Subscription::default().with_group_end(5);
+		let combined = combine(&[long, whole]).unwrap();
+		assert_eq!((combined.group_end, combined.frame_end), (Some(5), None));
+
+		// A later group wins outright, carrying its own frame.
+		let later_group = Subscription::default().with_group_end(6).with_frame_end(1);
+		let combined = combine(&[short, later_group]).unwrap();
+		assert_eq!((combined.group_end, combined.frame_end), (Some(6), Some(1)));
 	}
 
 	#[test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1879,20 +1879,18 @@ impl Consumer {
 
 		if unresolved {
 			let mut fetch = fetch.lock();
-			// Widening only reaches the handler while the attempt is still queued: once
-			// popped, its range is already on the wire and the `GroupRequest` holds an
-			// immutable copy. Writing it anyway would be a no-op that reads like a
-			// promise, so don't. What actually protects the late caller is the coverage
-			// check above: it won't accept a group that starts above what it asked for,
-			// so it fails and its retry queues a fresh attempt.
-			let queued = fetch.is_queued(&sequence);
 			if let Some(pending) = fetch.join(&sequence) {
 				// Join the in-flight attempt for this sequence (queued or already being
-				// served): share its result channel, raising its priority if ours is higher.
+				// served): share its result channel, raising its priority if ours is higher
+				// and widening its range if ours starts earlier.
+				//
+				// Widening only reaches the handler while the attempt is still queued;
+				// once popped, the `GroupRequest` holds an immutable copy and its range is
+				// already on the wire. What protects the late caller either way is the
+				// coverage check above: it refuses a group starting above what it asked
+				// for, so it fails cleanly and its retry queues a fresh attempt.
 				pending.priority = pending.priority.max(options.priority);
-				if queued {
-					pending.frame_start = pending.frame_start.min(options.frame_start);
-				}
+				pending.frame_start = pending.frame_start.min(options.frame_start);
 				result = Some(pending.result.consume());
 			} else {
 				// Queue a new attempt. The handler gate is atomic with a handler
@@ -4297,11 +4295,10 @@ mod test {
 		);
 	}
 
-	/// Widening a fetch's range reaches the handler only while the attempt is still
-	/// queued. Once popped, the range is already on the wire, and a caller wanting more
-	/// than it covers fails cleanly instead of being handed the narrower group.
+	/// Joining a queued fetch widens its range, and a caller that arrives once the range
+	/// is already on the wire fails cleanly rather than being handed the narrower group.
 	#[tokio::test]
-	async fn fetch_widens_only_while_queued() {
+	async fn fetch_widens_or_fails_cleanly() {
 		let producer = track_producer("test", None);
 		let dynamic = producer.dynamic();
 		let consumer = producer.consume();
@@ -4318,8 +4315,8 @@ mod test {
 		let request = dynamic.requested_group().await.unwrap();
 		assert_eq!(request.frame_start(), 2, "widened while queued");
 
-		// Handed off now, so a later wider caller must not mutate it behind the
-		// handler's back.
+		// Handed off now: the handler holds its own copy of the range, so a later wider
+		// caller cannot move what is already being served.
 		let _widest = consumer.fetch_group(0, group::Fetch::default().with_frame_start(0));
 		let mut widest = std::pin::pin!(_widest);
 		assert!(futures::poll!(widest.as_mut()).is_pending());

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -20,6 +20,8 @@ use super::{Datagram, Requests};
 
 pub use super::subscription::Subscription;
 
+pub(crate) use super::subscription::Position;
+
 use std::{
 	collections::{HashMap, VecDeque},
 	sync::Arc,
@@ -202,6 +204,11 @@ pub(crate) struct TrackState {
 	// The sequence number at which the track was finalized.
 	final_sequence: Option<u64>,
 
+	// Where production stopped, snapshotted when the cached groups are released (an
+	// abort, or the last producer dropping). Computed live from the cache otherwise;
+	// see [`Self::resume_position`].
+	resume: Option<Position>,
+
 	// The error that caused the track to be aborted, if any.
 	abort: Option<Error>,
 
@@ -243,6 +250,11 @@ type FetchState = Requests<u64, PendingFetch>;
 struct PendingFetch {
 	// The most demanding delivery priority across the joined fetches.
 	priority: u8,
+
+	// The lowest start across the joined fetches, so serving the attempt once satisfies
+	// every one of them. Only widened while the request is still queued: once a handler
+	// has taken it, its range is already on the wire.
+	frame_start: u64,
 
 	// Result channel back to the joined fetches. Written only on rejection; a
 	// successful accept resolves them through the track cache instead. Dropping
@@ -455,6 +467,20 @@ impl TrackState {
 		Some(slot.group.consume())
 	}
 
+	/// The cached group for `sequence`, but only when it holds every frame from
+	/// `frame_start` onward.
+	///
+	/// A group cached from a frame-bounded subscription starts partway in, and serving
+	/// it to someone who asked for the whole group would silently hand back a tail. It
+	/// is a miss instead, so the fetch goes upstream for the frames that are missing.
+	fn covering_group(&self, sequence: u64, frame_start: u64) -> Option<&group::Producer> {
+		let slot = self.lookup.get(&sequence)?;
+		if slot.group.is_aborted() || slot.group.first_frame() as u64 > frame_start {
+			return None;
+		}
+		Some(&slot.group)
+	}
+
 	/// The publisher's latency window, or `None` while the info is unknown (an
 	/// unaccepted [`Request`]). Bounds the aggregate subscription; see [`clamp_combined`].
 	fn latency_bound(&self) -> Option<Duration> {
@@ -465,15 +491,13 @@ impl TrackState {
 	/// once it can never be served. A missing group is a failure ([`Error::NotFound`]), not an
 	/// end-of-stream. The handler side (a rejection, or no [`Dynamic`] at all) lives
 	/// in [`FetchState`]; [`Fetching`] polls both.
-	fn poll_fetch_cached(&self, sequence: u64) -> Poll<Result<group::Consumer>> {
-		if let Some(slot) = self.lookup.get(&sequence)
-			&& !slot.group.is_aborted()
-		{
+	fn poll_fetch_cached(&self, sequence: u64, frame_start: u64) -> Poll<Result<group::Consumer>> {
+		if let Some(group) = self.covering_group(sequence, frame_start) {
 			// A cache hit refreshes the group: it resets both its age (expiry keys
 			// off the last access) and its standing against the pool-wide average,
 			// so the eviction walk keeps it over never-read groups.
-			slot.group.cache_refresh();
-			return Poll::Ready(Ok(slot.group.consume()));
+			group.cache_refresh();
+			return Poll::Ready(Ok(group.consume()));
 		}
 
 		if let Some(err) = &self.abort {
@@ -598,9 +622,12 @@ impl TrackState {
 	///
 	/// Best effort: nothing remembers a sequence whose slot is already gone, so a
 	/// publisher re-sending a long-evicted sequence is accepted as new.
-	fn claim_sequence(&mut self, sequence: u64) -> Result<()> {
+	/// A group that starts above `frame_start` is also replaceable: it cannot answer a
+	/// request from there, so the wider producer takes the slot. Readers already
+	/// draining the old one keep their own handle.
+	fn claim_sequence(&mut self, sequence: u64, frame_start: u64) -> Result<()> {
 		if let Some(slot) = self.lookup.get(&sequence) {
-			if !slot.group.is_aborted() {
+			if !slot.group.is_aborted() && slot.group.first_frame() as u64 <= frame_start {
 				return Err(Error::Duplicate);
 			}
 			self.lookup.remove(&sequence);
@@ -799,6 +826,41 @@ impl TrackState {
 			.is_some_and(|fin| self.max_sequence.map_or(0, |max| max.saturating_add(1)) >= fin)
 	}
 
+	/// Where a replacement route should pick this track up: one past the last frame
+	/// produced, rolling to the start of the next group once the latest group is
+	/// complete (nothing more can be appended to it).
+	///
+	/// `None` while the track has produced nothing, which is an unbounded takeover.
+	fn resume_position(&self) -> Option<Position> {
+		// A snapshot taken when the cache was released wins; the groups it was derived
+		// from are gone.
+		if self.resume.is_some() {
+			return self.resume;
+		}
+
+		let max = self.max_sequence?;
+		match self.lookup.get(&max) {
+			// Still open *and* carrying frames, so the replacement continues it
+			// frame-by-frame. This holds even for an aborted group: readers that already
+			// consumed its head want the tail, and the count outlives the released cache.
+			//
+			// The *committed* count, not the written one: a route dying midway through a
+			// chunked frame leaves that frame unusable, so the replacement has to send it
+			// again rather than start after it.
+			Some(slot) if !slot.group.is_finished() && slot.group.committed_frames() > slot.group.first_frame() => {
+				Some(Position {
+					group: max,
+					frame: slot.group.committed_frames() as u64,
+				})
+			}
+			// A copy that wrote nothing has no frames to splice onto, and the reader
+			// already holds its (empty) handle. Pointing a replacement at frame 0 would
+			// hand the same sequence out twice, so roll to the next group exactly as a
+			// finished one does.
+			_ => Some(Position::group(max.saturating_add(1))),
+		}
+	}
+
 	fn poll_finished(&self) -> Poll<Result<u64>> {
 		if let Some(fin) = self.final_sequence {
 			Poll::Ready(Ok(fin))
@@ -818,7 +880,7 @@ impl TrackState {
 	/// fetch can serve an as-yet-unaccepted track (e.g. a relay with no live
 	/// subscription). The group lands in the cache so a waiting
 	/// [`Fetching`] resolves via [`Self::poll_fetch`].
-	fn insert_group_request(&mut self, sequence: u64, info: Option<Info>) -> Result<group::Producer> {
+	fn insert_group_request(&mut self, sequence: u64, frame_start: u64, info: Option<Info>) -> Result<group::Producer> {
 		if let Some(err) = &self.abort {
 			return Err(err.clone());
 		}
@@ -837,7 +899,7 @@ impl TrackState {
 		let info = self.info.clone().unwrap();
 
 		// An evicted sequence can be re-fetched; a live one is a duplicate.
-		self.claim_sequence(sequence)?;
+		self.claim_sequence(sequence, frame_start)?;
 
 		let latency_max = info.latency_max;
 		let group = group::Producer::new(group::Info { sequence }, info, self.cache.clone());
@@ -931,7 +993,7 @@ impl Producer {
 		let latency_max = track.latency_max;
 
 		// An evicted sequence can be re-created; a live one is a duplicate.
-		state.claim_sequence(group.sequence)?;
+		state.claim_sequence(group.sequence, 0)?;
 
 		let group = group::Producer::new(group, track, state.cache.clone()).with_meter(self.stats.meter());
 		state.commit_group(&group, true, latency_max);
@@ -1093,6 +1155,9 @@ impl Producer {
 	/// sequence, and lower-numbered groups may still be written afterwards.
 	pub fn abort(self, err: Error) -> Result<()> {
 		let mut guard = self.modify()?;
+		// Snapshot the frame boundary before the cache it's derived from goes away: an
+		// abort is exactly when a replacement route asks where to resume.
+		guard.resume = guard.resume_position();
 		guard.abort = Some(err);
 		guard.clear_cache();
 		guard.datagrams.clear();
@@ -1302,6 +1367,7 @@ fn poll_requested_group(
 		// `GroupRequest::{accept, reject, drop}` removes the entry.
 		let pending = guard.get(&sequence).expect("popped key must be pending");
 		let priority = pending.priority;
+		let frame_start = pending.frame_start;
 		let result = pending.result.clone();
 		drop(guard);
 		return Poll::Ready(Ok(GroupRequest {
@@ -1309,6 +1375,7 @@ fn poll_requested_group(
 			fetch: fetch.clone(),
 			sequence,
 			priority,
+			frame_start,
 			result,
 			done: false,
 		}));
@@ -1473,6 +1540,8 @@ impl Drop for Alive {
 				track = %self.name,
 				"track::Producer dropped without finish() or abort()"
 			);
+			// See `abort`: keep the frame boundary once its groups go away.
+			state.resume = state.resume_position();
 			state.clear_cache();
 			state.datagrams.clear();
 		}
@@ -1732,6 +1801,38 @@ impl Consumer {
 		}
 	}
 
+	/// Poll for a cached group by sequence, parking `waiter` until it lands.
+	///
+	/// `Ready(None)` once it can never arrive: the track ended below the sequence, or
+	/// closed. Unlike [`Self::fetch_group`] this never asks anyone to produce the group,
+	/// so it only resolves for one a live subscription is already pulling. That is what
+	/// the spliced reader in [`super::resume`] wants: it waits for the route serving a
+	/// group to deliver it, rather than opening a redundant fetch alongside.
+	pub(crate) fn poll_peek_group(&self, sequence: u64, waiter: &kio::Waiter) -> Poll<Option<group::Consumer>> {
+		let ConsumerKind::Plain(state) = &self.inner else {
+			// A segment's track is never itself spliced.
+			return Poll::Pending;
+		};
+
+		let res = state.poll(waiter, |state| {
+			match state.lookup.get(&sequence) {
+				Some(slot) if !slot.group.is_aborted() => Poll::Ready(Some(slot.group.consume())),
+				// An aborted slot is a hole this route can no longer fill.
+				Some(_) => Poll::Ready(None),
+				// Past the declared end, so it can never exist.
+				None if state.final_sequence.is_some_and(|fin| sequence >= fin) => Poll::Ready(None),
+				None => Poll::Pending,
+			}
+		});
+
+		match res {
+			Poll::Ready(Ok(res)) => Poll::Ready(res),
+			// The track died; whatever it cached went with it.
+			Poll::Ready(Err(_)) => Poll::Ready(None),
+			Poll::Pending => Poll::Pending,
+		}
+	}
+
 	/// Fetching a single past group, without holding a live subscription.
 	///
 	/// Returns a [`kio::Pending`] that resolves to the [`group::Consumer`]:
@@ -1770,15 +1871,28 @@ impl Consumer {
 		// a queue entry).
 		let (fetch, unresolved) = {
 			let state = state.read();
-			(state.fetch.clone(), state.poll_fetch_cached(sequence).is_pending())
+			(
+				state.fetch.clone(),
+				state.poll_fetch_cached(sequence, options.frame_start).is_pending(),
+			)
 		};
 
 		if unresolved {
 			let mut fetch = fetch.lock();
+			// Widening only reaches the handler while the attempt is still queued: once
+			// popped, its range is already on the wire and the `GroupRequest` holds an
+			// immutable copy. Writing it anyway would be a no-op that reads like a
+			// promise, so don't. What actually protects the late caller is the coverage
+			// check above: it won't accept a group that starts above what it asked for,
+			// so it fails and its retry queues a fresh attempt.
+			let queued = fetch.is_queued(&sequence);
 			if let Some(pending) = fetch.join(&sequence) {
 				// Join the in-flight attempt for this sequence (queued or already being
 				// served): share its result channel, raising its priority if ours is higher.
 				pending.priority = pending.priority.max(options.priority);
+				if queued {
+					pending.frame_start = pending.frame_start.min(options.frame_start);
+				}
 				result = Some(pending.result.consume());
 			} else {
 				// Queue a new attempt. The handler gate is atomic with a handler
@@ -1788,6 +1902,7 @@ impl Consumer {
 				let consumer = producer.consume();
 				let attempt = PendingFetch {
 					priority: options.priority,
+					frame_start: options.frame_start,
 					result: producer,
 				};
 				if fetch.insert(sequence, attempt).is_ok() {
@@ -1801,6 +1916,7 @@ impl Consumer {
 				state: state.clone(),
 				fetch,
 				sequence,
+				frame_start: options.frame_start,
 				result,
 			},
 			stats: self.stats.clone(),
@@ -1827,6 +1943,17 @@ impl Consumer {
 		match &self.inner {
 			ConsumerKind::Plain(state) => state.read().max_sequence,
 			ConsumerKind::Spliced(resume) => resume.latest(),
+		}
+	}
+
+	/// The frame-precise point a replacement route should resume from: one past the
+	/// last frame this copy produced. `None` if it produced nothing.
+	///
+	/// Survives the track aborting, which is when a route change asks.
+	pub(crate) fn resume_position(&self) -> Option<Position> {
+		match &self.inner {
+			ConsumerKind::Plain(state) => state.read().resume_position(),
+			ConsumerKind::Spliced(resume) => resume.resume_position(),
 		}
 	}
 
@@ -1977,6 +2104,7 @@ pub struct GroupRequest {
 	fetch: kio::Shared<FetchState>,
 	sequence: u64,
 	priority: u8,
+	frame_start: u64,
 	// Rejections route back to every joined `Fetching`.
 	result: kio::Producer<FetchOutcome>,
 	done: bool,
@@ -1993,6 +2121,17 @@ impl GroupRequest {
 		self.priority
 	}
 
+	/// The first frame of the group the consumer wants; 0 is the whole group.
+	///
+	/// A handler serving this must [`start_at`](group::Producer::start_at) it, so the frames
+	/// it writes carry the indices they have in the group rather than restarting at 0.
+	///
+	/// There is no end: the handler fetches through the end of the group so the result
+	/// is cacheable for anyone (see [`group::Fetch::frame_start`]).
+	pub fn frame_start(&self) -> u64 {
+		self.frame_start
+	}
+
 	/// Insert the fetched group into the track cache, resolving the waiting
 	/// [`Consumer::fetch_group`], and return a [`group::Producer`] to fill.
 	///
@@ -2006,7 +2145,7 @@ impl GroupRequest {
 		// through the cache, and removal closes their result channel (which alone
 		// would read as NotFound).
 		let res = TrackState::modify(&self.state)
-			.and_then(|mut state| state.insert_group_request(self.sequence, info.into()));
+			.and_then(|mut state| state.insert_group_request(self.sequence, self.frame_start, info.into()));
 		self.remove();
 		res
 	}
@@ -2060,6 +2199,9 @@ enum FetchingKind {
 		state: kio::Consumer<TrackState>,
 		fetch: kio::Shared<FetchState>,
 		sequence: u64,
+		// This caller's own start, so a cached group that begins above it is a miss
+		// rather than a short answer.
+		frame_start: u64,
 		// The joined attempt's result channel; `None` when no handler existed to queue on.
 		result: Option<kio::Consumer<FetchOutcome>>,
 	},
@@ -2071,13 +2213,14 @@ impl kio::Pollable for Fetching {
 	type Output = Result<group::Consumer>;
 
 	fn poll(&self, waiter: &kio::Waiter) -> Poll<Self::Output> {
-		let (state, fetch, sequence, result) = match &self.inner {
+		let (state, fetch, sequence, frame_start, result) = match &self.inner {
 			FetchingKind::Plain {
 				state,
 				fetch,
 				sequence,
+				frame_start,
 				result,
-			} => (state, fetch, *sequence, result.as_ref()),
+			} => (state, fetch, *sequence, *frame_start, result.as_ref()),
 			FetchingKind::Spliced(spliced) => {
 				// A fetched group is metered here (once), at the tagged handle: the
 				// spliced source track it comes from is the origin's own, untagged.
@@ -2088,8 +2231,16 @@ impl kio::Pollable for Fetching {
 
 		// Track side: the cached group, the abort error, or past-final. The outer
 		// error is the channel closing without any of those.
-		match state.poll(waiter, |state| state.poll_fetch_cached(sequence)) {
-			Poll::Ready(Ok(res)) => return Poll::Ready(res.map(|group| group.with_meter(self.stats.meter()))),
+		match state.poll(waiter, |state| state.poll_fetch_cached(sequence, frame_start)) {
+			Poll::Ready(Ok(res)) => {
+				return Poll::Ready(res.map(|mut group| {
+					// Hand back a consumer sitting where the caller asked rather than at
+					// the group's own start. Coverage was checked above, so this can only
+					// skip frames they excluded.
+					group.start_at(frame_start);
+					group.with_meter(self.stats.meter())
+				}));
+			}
 			Poll::Ready(Err(closed)) => {
 				return Poll::Ready(Err(closed.abort.clone().unwrap_or(Error::Dropped)));
 			}
@@ -4096,6 +4247,98 @@ mod test {
 
 		let mut group = retry.await.unwrap();
 		assert_eq!(&group.read_frame().await.unwrap().unwrap().payload[..], b"retry");
+	}
+
+	/// A group cached from a frame-bounded subscription starts partway in. Serving it to
+	/// someone who asked for the whole group would silently hand back a tail, so it is a
+	/// miss and the fetch goes upstream instead.
+	#[tokio::test]
+	async fn fetch_ignores_a_group_that_starts_too_late() {
+		let mut producer = track_producer("test", None);
+		let dynamic = producer.dynamic();
+		let consumer = producer.consume();
+
+		// The live subscription resumed mid-group, so only the tail is cached.
+		let mut group = producer.create_group(group::Info { sequence: 0 }).unwrap();
+		group.start_at(3).unwrap();
+		group
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"tail"))
+			.unwrap();
+		group.finish().unwrap();
+
+		// A fetch for the tail is covered and resolves from the cache.
+		let fetch = consumer.fetch_group(0, group::Fetch::default().with_frame_start(3));
+		let cached = fetch.now_or_never().expect("covered by the cache").unwrap();
+		assert_eq!(cached.index(), 3);
+
+		// A fetch for the whole group is not, so it queues for a handler rather than
+		// resolving to the tail.
+		let mut fetch = std::pin::pin!(consumer.fetch_group(0, None));
+		assert!(
+			futures::poll!(fetch.as_mut()).is_pending(),
+			"must not answer from the tail"
+		);
+
+		let request = dynamic.requested_group().await.unwrap();
+		assert_eq!((request.sequence(), request.frame_start()), (0, 0));
+
+		// Serving it replaces the too-narrow entry rather than colliding with it.
+		let mut whole = request.accept(None).unwrap();
+		whole
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"head"))
+			.unwrap();
+		whole.finish().unwrap();
+
+		let mut served = fetch.await.unwrap();
+		assert_eq!(served.index(), 0);
+		assert_eq!(
+			served.read_frame().await.unwrap().unwrap().payload,
+			bytes::Bytes::from_static(b"head")
+		);
+	}
+
+	/// Widening a fetch's range reaches the handler only while the attempt is still
+	/// queued. Once popped, the range is already on the wire, and a caller wanting more
+	/// than it covers fails cleanly instead of being handed the narrower group.
+	#[tokio::test]
+	async fn fetch_widens_only_while_queued() {
+		let producer = track_producer("test", None);
+		let dynamic = producer.dynamic();
+		let consumer = producer.consume();
+
+		let _narrow = consumer.fetch_group(0, group::Fetch::default().with_frame_start(5));
+		let mut narrow = std::pin::pin!(_narrow);
+		assert!(futures::poll!(narrow.as_mut()).is_pending());
+
+		// Still queued: widening is honored, because nothing has read the range yet.
+		let _wider = consumer.fetch_group(0, group::Fetch::default().with_frame_start(2));
+		let mut wider = std::pin::pin!(_wider);
+		assert!(futures::poll!(wider.as_mut()).is_pending());
+
+		let request = dynamic.requested_group().await.unwrap();
+		assert_eq!(request.frame_start(), 2, "widened while queued");
+
+		// Handed off now, so a later wider caller must not mutate it behind the
+		// handler's back.
+		let _widest = consumer.fetch_group(0, group::Fetch::default().with_frame_start(0));
+		let mut widest = std::pin::pin!(_widest);
+		assert!(futures::poll!(widest.as_mut()).is_pending());
+		assert_eq!(request.frame_start(), 2, "the in-flight range is already on the wire");
+
+		let mut group = request.accept(None).unwrap();
+		// A handler numbers the frames from where it was asked to start, as `serve_fetch`
+		// does; that offset is what makes the cached group too narrow for `widest`.
+		group.start_at(2).unwrap();
+		group
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"from2"))
+			.unwrap();
+		group.finish().unwrap();
+
+		// The two callers it covers resolve; the one it doesn't fails cleanly rather
+		// than being handed a group that starts above what it asked for.
+		assert_eq!(narrow.await.unwrap().index(), 5);
+		assert_eq!(wider.await.unwrap().index(), 2);
+		assert!(matches!(widest.await, Err(Error::NotFound)));
 	}
 
 	#[tokio::test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -838,7 +838,7 @@ impl TrackState {
 			return self.resume;
 		}
 
-		let max = self.max_sequence?;
+		let max = self.latest_group?;
 		match self.lookup.get(&max) {
 			// Still open *and* carrying frames, so the replacement continues it
 			// frame-by-frame. This holds even for an aborted group: readers that already
@@ -2933,6 +2933,46 @@ mod test {
 		assert_eq!(recv_datagram(&mut dg).sequence, 100);
 		// max_sequence advanced, so the next appended group/datagram continues past it.
 		assert_eq!(producer.append_group().unwrap().sequence, 101);
+	}
+
+	/// Datagram sequence advances do not move a route takeover past an open group.
+	#[test]
+	fn resume_position_uses_the_latest_group() {
+		let mut datagram_only = track_producer("datagram-only", None);
+		let datagram_only_consumer = datagram_only.consume();
+		datagram_only
+			.write_datagram(Datagram {
+				sequence: 8,
+				timestamp: Timestamp::ZERO,
+				payload: bytes::Bytes::from_static(b"x"),
+			})
+			.unwrap();
+		assert_eq!(
+			datagram_only_consumer.resume_position(),
+			None,
+			"a datagram creates no group position to resume"
+		);
+
+		let mut producer = track_producer("mixed", None);
+		let consumer = producer.consume();
+		let mut group = producer.create_group(group::Info { sequence: 3 }).unwrap();
+		group
+			.write_frame(Timestamp::ZERO, bytes::Bytes::from_static(b"head"))
+			.unwrap();
+		producer
+			.write_datagram(Datagram {
+				sequence: 8,
+				timestamp: Timestamp::ZERO,
+				payload: bytes::Bytes::from_static(b"x"),
+			})
+			.unwrap();
+
+		assert_eq!(
+			consumer.resume_position(),
+			Some(Position { group: 3, frame: 1 }),
+			"the replacement must continue the open group"
+		);
+		group.abort(Error::Cancel).unwrap();
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
Closes #2517.

**Targets `dev`.** The frame-precise work itself is additive, but it leaves `Subscription` with four loosely-coupled bound fields where the model wants two positions, and closing that properly is a semver break. Rather than ship the half-measure and reshape later, the reshape lands here. See [Follow-up](#follow-up) below for what it involves.

## Summary

Route migration splices per-session tracks at group boundaries, so it never resumes a track whose current group can stay open indefinitely. `moq-json::stream` keeps its whole append log in one group, and a quiet catalog may not roll for a long time. A route dying partway through such a group stalled the logical subscriber until a group that might never come.

Bounds are frame-precise now, end to end.

The governing rule is that **a partial group only ever goes to a subscriber that asked for one**. A publisher that cannot serve a group from the frame the subscription names skips it and resolves to a later group, rather than delivering the part it holds. A group is the unit of decodability: dropping leading *groups* leaves a stream the application can still decode, whereas dropping leading *frames* often does not, whether because the group opens with a keyframe the rest depends on or because its compression state lives in the frames that went missing. Only the subscriber knows whether a partial group is any use to it. That also keeps every subscriber which does not opt in on exactly the pre-lite-06 behavior.

### Wire (moq-lite-06)

- `SUBSCRIBE` / `SUBSCRIBE_UPDATE` carry `Frame Start` and `Frame End`, qualifying the start and end group. `Frame Start` is a plain index; `Frame End` is the index + 1, matching `Group End`. Two abutting subscriptions therefore carry the *same* numbers on the wire, which is what makes a splice exact.
- `FETCH` carries the same pair, bounding the returned frames within the group. A publisher that cannot serve the range in full resets, since the response has no header to report a different start.
- `GROUP` carries `Frame Start`, so a stream holding only part of a group is self-describing. It is redundant in the steady state, and carried anyway because a `SUBSCRIBE_UPDATE` that moves the bound races the group streams already in flight: separate streams, no ordering between them.
- `SUBSCRIBE_OK` is unchanged. It needs no frame field, because the start frame follows from `Group` plus the subscriber's own request. Worth stating explicitly since it is easy to get backwards: a subscriber that requested group 5 frame 15 and receives `Group` = 6 starts at **frame 0** of group 6, not frame 15.

### Model

- `group::Producer::start_at` starts a group at a later frame, reusing the eviction tombstone: a reader below the offset gets `Lagged` either way. A group can be short at its front or its back, never in the middle, so this and `finish` are the only two ways to trim one.
- `group::Consumer` gains `index` / `start_at` / `end_at`, mirroring how `track::Subscriber` bounds group sequences. `start_at` clamps *up* to the first frame the group still holds, which is what lets both the publisher and the spliced reader detect a missing head instead of serving one group's frames under another's numbering.
- `Subscription` gains `frame_start` / `frame_end`. The aggregate folds whole `(group, frame)` positions; folding the group and the frame independently would invent a bound nobody asked for.
- `group::Fetch` gains `frame_start` only. A fetch always runs to the end of the group, and a caller wanting less caps the returned consumer. Stopping the *fetch* short would put a group in the cache indistinguishable from a complete one, so a later fetch of the whole group would resolve from it and come up short. The wire keeps `Frame End`, applied by the serving publisher as a read cap, so a downstream peer still saves the transfer.
- The fetch cache is coverage-aware. A group cached from a frame-bounded subscription starts partway in, so answering a whole-group fetch from it would silently hand back a tail; it is a miss instead, and a too-narrow entry is replaced rather than colliding on its sequence. `fetch_group` also returns a consumer positioned where the caller asked rather than at the group's own start.
- `resume` segments are bounded by position rather than sequence, and a group straddling a boundary is itself spliced. The reader keeps one handle and *pulls* each route's copy in turn rather than being fed, so a reader that stops polling the subscription (exactly the `moq-json` case) still gets its continuation. A copy that dies, or that cannot cover the seam, stalls the group instead of erroring it, matching how a dead segment stalls the track.
- A group tracks its committed frame count alongside its written one. `create_frame` advances the written count when a chunked frame is *opened*, so a route dying midway through one used to hand the replacement a boundary past a frame nobody ever received in full, permanently stalling any whole-frame reader. It now resumes *at* that frame.

## Public API changes

All additive; nothing renamed, removed, or signature-changed.

- `moq_net::track::Subscription`: new `pub frame_start: u64`, `pub frame_end: Option<u64>`, `with_frame_start`, `with_frame_end`. `#[non_exhaustive]`, so external struct literals were never possible.
- `moq_net::group::Fetch`: new `pub frame_start: u64`, `with_frame_start`. Same reasoning.
- `moq_net::group::Producer::start_at`; `moq_net::group::Consumer::{index, start_at, end_at}`; `moq_net::track::GroupRequest::frame_start`.

Not public despite appearances:

- The `lite::{Subscribe, SubscribeUpdate, SubscribeStart, Fetch, Group}` field additions are internal: `mod lite` is private in `moq-net/src/lib.rs` and only re-exports `Role`.
- `group::Consumer` was split into `Plain` / `Spliced` variants behind the existing surface. All six public read methods were relocated; each signature is byte-identical to `main`.
- The `js/net` `lite/` changes are internal: `js/net/src/index.ts` does not export `lite`, and `package.json` exports only `.` and `./zod`.

## Test plan

- `nix develop --command just check` — clean (rust + js + drafts + shell/md/toml/gh workflow lints).
- `nix develop --command just ci` — clean; 2439 tests run, 2439 passed.
- After round 3: `just fix` and `just check` clean, `just rs test` green (2252 passed, 0 failed).
- After the round 4 lint fix: `cargo clippy --all-targets -- -D warnings` clean, `cargo test -p moq-net --lib` green (634 passed, 0 failed).
- After round 4, pre-rebase: `cargo test -p moq-net --lib` green (631 passed, 0 failed), covering the paired setters and the seam fix. Post-rebase the Rust is byte-identical and the only conflict was the changelog above, so the rebased tree is verified by CI rather than re-run locally.
- `RUSTDOCFLAGS="-D warnings" cargo doc` — clean.
- `just drafts check` — parses.
- `just test smoke` — passes.
- `just test smoke-full` — passes; 21/21 across the matrix (rust, python, and js publishers against rust / python / js / js-native-node / js-native-bun / c / gst subscribers), no failures or skips. The root guide asks for this on a wire change and only the rust-only `smoke` had been run. Needed `SMOKE_PORT` to dodge a dev relay on 4443.
- `nix develop --command just rs loom` — passes (9 + 5 model checks, no deadlock or leaked `Arc`), re-run on the current head after round 4 changed `poll_current`. `rs/CLAUDE.md` makes this a mandatory manual gate for any change under `moq-net/src/model/`, and this PR rewrites `group.rs`, `track.rs`, and `resume.rs`. It was not run at all before round 3.

New coverage: mid-group takeover splicing frames seamlessly; the old route racing past its frame cap being filtered; rolling past a finished group; a dead copy stalling until its continuation; a copy missing the head stalling rather than serving a tail as a head; a chunked frame that never completed being redelivered; `position_group` skipping a missing head and capping the end group; `start_at` / `end_at` / clamping on the group model; position-folding in the subscription aggregate; and wire roundtrips including a lite-05 byte-compatibility check.

Round 3 adds: `frame_bounds_widen_for_an_older_peer`, `frame_bounds_widen_on_update`, and `frame_bounds_survive_on_a_lite06_peer` on the wire side, plus `takeover_splices_a_replacement_that_resends_the_head` on the model side, which pins the invariant the widening relies on: a replacement serving the whole group is spliced at the seam, with the re-sent head filtered rather than replayed.

Load-bearing assertions were mutation-checked rather than assumed, since a rebase onto #2526's cache rewrite could easily have made one vacuous. Each of these reverts a fix and fails:

| Mutation | Result |
|---|---|
| `resume_position` uses the written frame count | 1 test fails |
| fetch cache coverage check removed | 2 tests fail |
| `claim_sequence` coverage check removed | 1 test fails |
| `js` publisher ignores `startFrame` | 2 tests fail |
| `js` GROUP `frameStart` hardcoded to 0 | 2 tests fail |
| `js` publisher ignores `endFrame` | 1 test fails |

One that does *not* fail is documented under the coalescing note below.

## Review follow-ups

An adversarial review pass raised three things. Two are fixed here; the third I traced and disagree with as stated.

**Fixed: range-unaware fetch cache.** Reachable, and introduced by this PR's resume path. A relay that subscribes upstream with a frame offset caches a partial group; a later whole-group fetch matched it on sequence alone and resolved to the tail. Now a cached group that starts above the request is a miss, a too-narrow entry is replaced rather than colliding on its sequence, and the end dimension is gone by construction (see `group::Fetch` above). Regression tests: `fetch_ignores_a_group_that_starts_too_late`, `fetch_widens_or_fails_cleanly`.

**Fixed: `js/net` publisher ignored frame bounds.** Both the FETCH and the SUBSCRIBE path served the whole group, so a peer asking for a tail would have frame 0's payload land under index N. The publisher now threads the bounds from SUBSCRIBE (and any SUBSCRIBE_UPDATE) through to each group, filters on the frame's real index via `readFrameSequence`, and puts the actual start in the GROUP header. A group that ends before the requested start resets rather than FINning, since FINning would claim an empty group at that index when the truth is this publisher cannot serve the range.

On severity: the review called the SUBSCRIBE half corrupting, and for a Rust peer it wasn't — JS labelled its frames from 0 and a Rust splice read the ones it needed at their true indices, so it was wasted transfer rather than wrong data. Fixed regardless, because it violated the partial-group rule above and was a trap for any peer that trusted the bound.

### Note on the coalescing guard

`join` hands back `&mut` to an entry a handler may already have snapshotted into an immutable `GroupRequest`, so widening a range after hand-off cannot reach the wire. This PR originally guarded the widen behind "still queued", and mutation testing said the guard changed no behavior: restoring the unconditional widen still passed everything, because the write was always a no-op that merely *read* like a promise. The guard (and `Requests::is_queued` with it) is gone in round 3 below. What protects the late caller is the coverage check: it refuses a group that starts above what it asked for, so the caller fails cleanly and its retry queues a fresh attempt.

## Remaining gap

**The `js/net` subscriber ignores `GROUP.Frame Start`.** Its publisher now honors frame bounds on both subscriptions and fetches, but its group model has no frame-offset concept (no equivalent of `group::Producer::start_at`), so a received partial group is numbered from 0. A browser therefore cannot yet initiate a frame-precise resume. Not reachable today: a JS subscriber never requests a frame offset, and under the partial-group rule a publisher only sends one to a subscriber that asked.

## Review round 2 (CodeRabbit)

- **JS served groups outside the requested group range.** `frameRange` handed back a whole-group range for any sequence, and the publisher never had group bounds to begin with, so SUBSCRIBE_START could name a group below the requested start. It now returns nothing outside `[startGroup, endGroup]` and those groups are skipped. Regression tests on both boundaries.
- **The draft forbade a range both implementations accept.** It called a `Frame End` "at or below `Frame Start`" a protocol violation, but Rust (`end < start_frame`) and JS (`endFrame - 1 < startFrame`) both allow equal bounds, which is a legal single-frame range. The spec was wrong, not the code. (The review's stated rationale — that the draft says "through the start of the group" — did not match the text; the contradiction below it was the real defect.)
- **`budget` overflow.** `end - index + 1` panics in debug when `end == usize::MAX`. Unreachable from the wire, since varints cap at 2^62-1, but `Consumer::end_at` is public. Now `saturating_add`.
- **Stale `send_update` doc** and **positional-parameter creep in the JS publisher** (`#runGroup` 5 args to 2, `#runTrack` 6 to 3, via a `ServeGroup` options type) both applied.

## Review round 3

A fresh review pass found one real defect, one piece of dead weight, and three doc errors.

### Fixed: no degradation path for peers that predate lite-06

`Version::has_frame_bounds` was consulted only inside the wire codecs, so a frame-precise demand reached an older peer's encoder unchanged and came back `EncodeError::Version`. That fails the SUBSCRIBE, which `handle_subscription` turns into `Teardown::GiveBack` and the origin turns into a re-splice. The splice itself keeps succeeding, so `fails` resets on every attempt and `MAX_TRACK_RETRIES` never trips: the route retries in a hot loop instead of being retired.

Two triggers, and the second needs no route change on our side:

- a mid-group takeover whose replacement upstream negotiated lite-05, which is exactly the mixed-mesh upgrade case (lite-06 is WIP; lite-05 is what is released);
- a lite-06 subscriber downstream, whose frame offset propagates through `combine` / `slice` into the relay's aggregate demand and reaches an already-serving older upstream as a SUBSCRIBE_UPDATE.

`TrackServe::widen_frame_bounds` now widens the request to whole groups for such a peer. Widening is safe *there* and not in the codec: the codec cannot know who the caller is, so widening at the message layer would hand the caller frames it excluded, and refusing is right. At the session layer we are the caller and we want the wider range, because the read side positions and caps every group copy again (`group::Consumer::{start_at, end_at}`, driven by `resume::Group`), so the extra frames are filtered locally and never reach a subscriber. The only cost is transferring frames we already hold.

FETCH takes the same treatment and skips the matching `Producer::start_at`, so the response is numbered from 0. That is strictly better than the tail: `covering_group` accepts any cached group starting at or below the request, so the wider group answers the original fetch and stays reusable for anyone else.

Regression tests: `frame_bounds_widen_for_an_older_peer`, `frame_bounds_widen_on_update`, and `frame_bounds_survive_on_a_lite06_peer` to pin that the widening is version-gated rather than unconditional.

### Removed: the `is_queued` coalescing guard

The note above already recorded that mutation testing found this guard behavior-neutral. It is: once the request is popped, `GroupRequest` holds its own copy of the range, so the write the guard suppresses cannot reach the wire either way. It cost a new `pub(crate)` API and an O(n) scan of `Requests::order` on every `fetch_group` in exchange for nothing. Both are gone. The coverage check is what actually protects the late caller, and `fetch_widens_or_fails_cleanly` (renamed from `fetch_widens_only_while_queued`, which was named for the guard) still pins it.

### Doc fixes

- `hasFrameBounds` in `js/net` listed SUBSCRIBE_OK among the messages carrying a frame index, which is what the Positions section spends a paragraph explaining it does *not* do.
- The `Publisher` class's JSDoc had been orphaned above `type FrameBounds`, leaving the exported class undocumented.
- SUBSCRIBE's `Frame Start` said "a value of 0 means the whole group", which is the *end* bound's semantics. FETCH words the same field correctly.

## Review round 4

### Targets `dev`: the frame bound is paired with its group

`Subscription` exposed `with_frame_start` / `with_frame_end` as standalone setters, so `Subscription::default().with_frame_start(5)` was expressible even though a frame index means nothing without the group it counts from. Nothing in the model rejected it. The remote decoder did, as `InvalidSubscribeLocation`.

`with_start(group, frame)` and `with_end(group, frame)` now set the pair together, so the builder cannot express the invalid state. The fields stay `pub` for reading, so assigning one alone still can, and the encode path reads both halves back through `Subscription::start`, which drops a frame that has no group rather than emitting one the peer must reject (`a_frame_bound_without_its_group_is_dropped`).

That change alone is additive against `main`: both replaced setters were added earlier in this same branch and have never been released. What is *not* additive is the shape this is halfway to, and that is why the PR now targets `dev`. See the follow-up section below.

### Fixed: a spliced group whose seam no route can serve

`Group::poll_current` parked until the whole logical track ended, so a group whose missing frames no route could supply stayed open forever. On a relay that is a downstream GROUP stream held open for the life of the track; for a single-group track (a JSON append log, the case this PR exists for) it is the whole track.

`takeover` derives every boundary from `resume_position`, which only moves forward, so once it is past a position no future segment will ever cover it and nobody will be asked for those frames again. That is now terminal for the group, and the loss already buried in `dead` is reported instead of swallowed.

Only once a route has been given up on, though. A live route that has not delivered the group yet may still do so out of order, and its own progress is what moved the resume point past us, so being ahead is not evidence the frames are gone. `live_route_ahead_of_the_seam_still_parks` pins that gate; without it the test errors instead.

`give_up` also logs the loss with the group and frame. It was silent, which is why a wedged seam presented as a mysteriously stuck group rather than anything diagnosable.

`copy_missing_the_head_stalls` becomes `copy_missing_the_head_is_lost` and now asserts the error. Its old assertion encoded the parking as correct; every future takeover starts above the missing frames, so nobody will ever be asked for them again and saying so beats parking forever.

## Known limitation: a live route that silently skips the group

Round 4 closes the case where a route has been given up on. One case remains: a route that is alive, covers the seam, and simply never delivers that group, because it skipped it under the partial-group rule (its own copy was missing the head) and resolved SUBSCRIBE_START to a later group. `poll_peek_group` parks, nothing marks the route dead, and the reader holds the group open.

The fix is not a timeout. `latency_max` defaults to `Duration::ZERO`, which would make every seam give up instantly and destroy the legitimate park the splice design rests on; it is also a cache-retention budget, not a wait budget. The exact signal is already on the wire and already parsed: the draft defines a resolved `Group` above the requested start as an implicit drop of that leading range, and the lite subscriber currently just logs it. Recording it on the per-session producer would make `poll_peek_group` return `Ready(None)` below that group, which marks the route dead, which the round 4 rule then resolves. Left for a follow-up because it reaches into the subscribe-response path and is independently useful.

## Follow-up: fold the four bound fields into `Position` {#follow-up}

`Subscription` exposes `group_start` / `frame_start` / `group_end` / `frame_end` as four independently-settable public fields, while the model works in whole `Position`s. Round 4 closes the builder path, but `sub.frame_start = 5` with no `group_start` is still writable: the invalid state is defanged, not unrepresentable.

Making the fields `start: Option<Position>` / `end: Option<Position>` fixes that and is net-negative in code, since `set_start` / `set_end` / `start()` / `end()` exist only to adapt between the four-field public shape and the two-position internal one. It breaks `group_start` / `group_end`, which *are* released, hence `dev`.

One piece needs designing rather than renaming: the end bound has three states, not two. Unbounded track, whole end group, and capped frame. Today `end()` fakes the middle one by mapping `frame_end: None` to `u64::MAX` so it sorts above any capped frame in the `max_unbounded` fold. A plain `Option<Position>` either leaks that sentinel to consumers or needs an inner `Option<u64>`, which is two fields again.

## Rebase note

Rebased three times: onto #2526, then #2473, then `dev`.

### `dev`

One conflict, in the lite-06 changelog. `dev` carries a newer revision of #2473's advertisement bullet ("the later replacing the earlier" rather than "the earlier is served until it ends"), with prose explaining why: holding the path until the transport notices a dead publisher is exactly the reconnect case. Took `dev`'s wording and re-applied only this PR's edit, dropping "at a Group boundary". The ANNOUNCE prose auto-merged into `dev`'s replacement semantics plus this PR's Position sentence.

### #2526

Rebased onto `main`, which includes #2526 (global LRU pool replaced by per-track write-time eviction). That rewrote the structures this PR builds on: `groups: VecDeque<Option<(Producer, Instant)>>` became `lookup: HashMap<u64, Slot>`, `replace_evicted` was deleted in favour of `claim_sequence`, and `Drop` moved into an `Alive` refcount. Resolved by taking main's structure and re-deriving these semantics on top of it, most notably folding the coverage rule *into* `claim_sequence` rather than keeping a parallel function. The mutation table above is the evidence that survived the move.

### #2473

The lighter of the two: one textual conflict (the lite-06 changelog, additive on both sides) plus one semantic conflict git could not see. #2473 added normative prose saying a relay may splice redundant routes *"at a Group boundary"*, which this PR supersedes; left alone the draft would contradict its own Positions section. Updated to say the splice point is a Position, and dropped the phrase from #2473's changelog bullet so the two entries agree.

That rebase also surfaced a real defect. #2473 added two standby tests that produce a group without writing to it, and they failed: `resume_position` returned `(G, 0)` for a group created but never written, so a replacement pointed at frame 0 re-served a sequence the reader already held. The boundary now rolls to the next group unless the copy actually wrote a frame (`committed_frames() > first_frame()`), which is also why this PR no longer touches `origin.rs` at all: an earlier round had me adding `finish()` to tests I do not own to accommodate the old behavior, and those edits are gone.

## Cross-Package Sync

`drafts/`, `js/net`, and `doc/concept` are updated. `rs/moq-ffi` is deliberately untouched: exposing the frame bounds there would ripple through four language wrappers for a primitive whose only consumer today is moq-net's own route resumption, which is transparent to FFI callers.

(Written by Opus 5)



