### PR TITLE
feat(cli): add jemalloc heap profiling

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -59,7 +59,7 @@ The binary will be in `target/release/moq-cli`.
 ### Heap profiling
 
 The Nix package includes jemalloc profiling support. Source builds can opt in
-with `--features jemalloc`. Start `moq` with profiling enabled, then send
+with `--features jemalloc`. Start `moq` with profiling enabled and then send
 `SIGUSR1` whenever a heap snapshot is needed:
 
 ```bash

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -56,6 +56,20 @@ cargo build --release --bin moq-cli
 
 The binary will be in `target/release/moq-cli`.
 
+### Heap profiling
+
+The Nix package includes jemalloc profiling support. Source builds can opt in
+with `--features jemalloc`. Start `moq` with profiling enabled, then send
+`SIGUSR1` whenever a heap snapshot is needed:
+
+```bash
+MALLOC_CONF=prof:true,prof_active:true,prof_prefix:/tmp/moq.heap moq ...
+kill -USR1 <pid>
+```
+
+Each signal writes a numbered `/tmp/moq.heap.*.heap` profile for analysis with
+`jeprof`.
+
 ## The grammar
 
 ```

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -68,7 +68,12 @@ let
       filter =
         path: type: (final.lib.hasInfix "/test_data/" path) || (craneLib.filterCargoSources path type);
     };
-    cargoExtraArgs = "-p moq-cli";
+    cargoExtraArgs = "-p moq-cli --features jemalloc";
+    # Enable frame pointers so jemalloc profiles resolve complete call stacks.
+    RUSTFLAGS = "-C force-frame-pointers=yes";
+    # jemalloc's configure uses -O0 test builds, which conflict with
+    # Nix's _FORTIFY_SOURCE hardening (requires -O).
+    hardeningDisable = [ "fortify" ];
     # The crate is `moq-cli`, but its `[[bin]]` ships as `moq`.
     meta.mainProgram = "moq";
   };

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 [features]
 default = ["iroh", "quinn", "websocket", "nvenc", "vaapi", "nvdec", "pipewire"]
 iroh = ["moq-native/iroh"]
+jemalloc = ["moq-native/jemalloc"]
 noq = ["moq-native/noq"]
 quinn = ["moq-native/quinn"]
 quiche = ["moq-native/quiche"]

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -27,6 +27,10 @@ use anyhow::Context;
 use clap::Parser;
 use tokio::task::JoinSet;
 
+#[cfg(feature = "jemalloc")]
+#[global_allocator]
+static ALLOC: moq_native::jemalloc::tikv_jemallocator::Jemalloc = moq_native::jemalloc::tikv_jemallocator::Jemalloc;
+
 /// Everything needed to build MoQ clients/servers, encapsulating the optional
 /// iroh endpoint so the rest of the code is feature-agnostic.
 #[derive(Clone)]
@@ -83,13 +87,25 @@ async fn main() -> anyhow::Result<()> {
 		iroh: cli.moq.iroh.clone().bind(&cli.moq.client.quic).await?,
 	};
 
-	match cli.command {
-		Command::Import(import) => run_import(cli.moq, import, net).await,
-		Command::Export(export) => run_export(cli.moq, export, net).await,
-		#[cfg(feature = "transcode")]
-		Command::Transcode(args) => transcode::run(cli.moq, args, net).await,
-		#[cfg(feature = "capture")]
-		Command::Devices => unreachable!("handled above, before the transport is bound"),
+	#[cfg(feature = "jemalloc")]
+	let jemalloc = moq_native::jemalloc::run();
+	#[cfg(not(feature = "jemalloc"))]
+	let jemalloc = std::future::pending::<anyhow::Result<()>>();
+
+	let run = async move {
+		match cli.command {
+			Command::Import(import) => run_import(cli.moq, import, net).await,
+			Command::Export(export) => run_export(cli.moq, export, net).await,
+			#[cfg(feature = "transcode")]
+			Command::Transcode(args) => transcode::run(cli.moq, args, net).await,
+			#[cfg(feature = "capture")]
+			Command::Devices => unreachable!("handled above, before the transport is bound"),
+		}
+	};
+
+	tokio::select! {
+		result = run => result,
+		Err(err) = jemalloc => Err(err).context("jemalloc profiler failed"),
 	}
 }
 


### PR DESCRIPTION
## Summary

- add an opt-in `jemalloc` feature to `moq-cli` using the existing `moq-native` allocator and `SIGUSR1` profile dumper
- enable that feature, frame pointers, and compatible hardening for the Nix `moq-cli` package, matching `moq-relay` and `moq-boy`
- document how to enable profiling and capture heap snapshots

This provides upstream, on-demand heap profiles for investigating the sustained memory growth observed in a long-running `moq-cli` publisher. It adds diagnostics; it does not claim to fix the allocation growth itself.

## Public API changes

None. The new Cargo feature is additive, and the Nix package now uses jemalloc by default.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just ci` passed formatting, dependency policy, no-default-features checks, all-features clippy, docs, and Cargo deny before reaching the nextest result below
- `cargo nextest run --workspace --all-targets --all-features --no-fail-fast`: 2,339 passed, 1 failed, 2 skipped
- isolated rerun of `moq-srt server::tests::accepted_socket_sends_a_burst_larger_than_srt_tokio_default`: passed in 1.18s
- `nix flake check`

The SRT burst test reproducibly hits its fixed 4-second timeout only under the fully concurrent suite on this machine and passes alone; it is outside this diff.

(Written by Codex)
