### PR TITLE
test(moq-srt): size the burst test below the SRT sender's drop window

### DIFF
--- a/rs/moq-srt/src/server.rs
+++ b/rs/moq-srt/src/server.rs
@@ -509,13 +509,18 @@ mod tests {
 		);
 	}
 
+	/// Regression: srt-tokio's 32-packet default sender buffer evicts unsent packets
+	/// once a burst overflows it, wedging the connection within the first few messages
+	/// (see [`configure_buffers`]).
 	#[tokio::test]
 	async fn accepted_socket_sends_a_burst_larger_than_srt_tokio_default() {
 		let probe = tokio::net::UdpSocket::bind("127.0.0.1:0").await.unwrap();
 		let addr: SocketAddr = probe.local_addr().unwrap();
 		drop(probe);
 
-		let mut server = Server::bind(addr, None).await.unwrap();
+		// TSBPD holds every payload for the negotiated latency before releasing it, so
+		// ask for a short one: this asserts buffering, not delay.
+		let mut server = Server::bind(addr, Duration::from_millis(50)).await.unwrap();
 		let caller = tokio::spawn(async move {
 			SrtSocket::builder()
 				.call(addr, Some("#!::r=buffer-test,m=request"))
@@ -530,7 +535,12 @@ mod tests {
 		let mut sender = subscribe.0.request.accept(None).await.unwrap();
 		let mut receiver = caller.await.unwrap();
 
-		const MESSAGES: usize = 1024;
+		// Several times srt-tokio's 32-packet default, which stalls before the tenth
+		// message. Keep it well under the ~1000 packets the sender paces out per second
+		// while its send buffer ages: past that, SRT drops the tail of the burst as too
+		// late and (silently, in srt-tokio) never retransmits it, which is a property of
+		// the burst size rather than of the buffer under test.
+		const MESSAGES: usize = 128;
 		for sequence in 0..MESSAGES {
 			sender
 				.send((Instant::now(), Bytes::copy_from_slice(&sequence.to_be_bytes())))


### PR DESCRIPTION
## Summary

- `server::tests::accepted_socket_sends_a_burst_larger_than_srt_tokio_default` was flaky: 2 failures in 8 idle runs of `cargo test -p moq-srt --lib` on macOS, much worse inside a full `just rs test`, panicking on the 3s per-message timeout near the end of the burst.
- **Root cause is srt-tokio pacing, not the buffer the test is named for.** srt-protocol starts its SND timer at a 1ms period (1000 pkt/s), and `SenderCongestionControl::on_input` only recomputes that period 100ms after the first input. The test hands its whole burst over in ~5ms and then goes silent, so the period stays pinned at the default and the 1024-packet burst takes ~1.02s to transmit. `SendBuffer` drops whatever is still unsent after `max(1.25 * latency, 1s)` = exactly 1s here, and `Sender::on_snd_event` handles that drop as `Drop(_) => {}`: no statistic, and no DROPREQ to the receiver (unlike the NAK path). The receiver never learns the tail existed, has no gap to NAK, and waits forever.
- Instrumented timeline of a failing run: the first ~512 packets arrive together at ~501ms, the rest at ~1 packet/ms, and the last delivery lands at **1.0033s against the 1.000s drop window**. Zero margin, so contention tips it over. Confirmed permanent (still stalled 23s later) with zero wire loss: `rx_data == tx_data`, `rx_loss=0`, `tx_nak=0`, `tx_dropped=0`. A longer timeout would not have helped.
- Fix: burst 1024 -> 128 messages, and ask for a 50ms latency instead of the 500ms production default. 128 is 4x srt-tokio's 32-packet default sender buffer (the wedge this test exists to catch), stays inside the initial send window, and is far from the 1s drop cliff.
- Production is unaffected: `serve_subscribe` feeds continuously, so the congestion-control estimator updates the send period, and later packets make the receiver NAK the gap, which does trigger a drop request. Only burst-then-silence wedges permanently.

## Public API changes

None. Test-only change inside `#[cfg(test)] mod tests`.

## Test plan

- **Before**: 4 failures in 32 runs under CPU saturation (one spinner per core, 8 concurrent test binaries), plus one failure on an idle machine.
- **After**: 64/64 clean runs of the whole `moq-srt` lib suite under the same saturation; suite time dropped from ~1.1s to 0.15s.
- **Regression value preserved**, measured with a standalone harness mirroring the test: a 128-message burst with srt-tokio's default 32-packet buffer failed 48/48 under load (stalling at message 0-1); with `configure_buffers` it passed 48/48. 33 messages still pass with the default buffer, so 128 keeps a 4x margin over the threshold.
- `cargo fmt --check` and `cargo clippy -p moq-srt --all-targets -- -D warnings` clean via the nix dev shell.

## Note for reviewers

srt-tokio silently discarding too-late sender packets without sending a DROPREQ turns a routine live-stream drop into a permanent receiver stall. That is an upstream bug worth reporting, but not one our production path hits.

(Written by Opus 5)