### PR TITLE
test(failover): two-relay 1+1 source-failover drill

### DIFF
--- a/test/failover/README.md
+++ b/test/failover/README.md
@@ -1,0 +1,111 @@
+# Two-relay 1+1 source-failover drill
+
+`just test failover` stands up two meshed relays, two publishers of the same
+broadcast, and three subscribers, then kills the active publisher and checks that
+the surviving standby takes over.
+
+This is the end-to-end counterpart to the routing unit tests in
+`rs/moq-net/src/model/origin.rs`. Those cover the model. This covers the wiring:
+two real `moq-relay` processes, real `moq import ts` publishers whose tracks are
+created lazily by the demuxer, and the QUIC idle timeout in the loop.
+
+## Topology
+
+```text
+pubA ──▶ relayA(:4443) ◀──cluster──▶ relayB(:5443) ◀── pubB
+          ▲   ▲                          ▲
+        sub1 sub2                       sub3
+```
+
+`pubA` and `pubB` publish the same broadcast with the **same `--origin` id**,
+which is what declares them interchangeable sources rather than different
+content. (`moq --origin` arrives with
+[#2473](https://github.com/moq-dev/moq/pull/2473); on a build without it the
+drill exits with a diagnostic rather than reporting a bogus zero-byte failure.)
+
+`sub3` matters more than it looks. It subscribes on relayB, which has no local
+publisher at first, so relayB has to carry the broadcast across the mesh from
+relayA. That makes relayA a hop in relayB's own route, and therefore the peer
+that per-peer announce selection has to treat specially: relayB must not
+advertise the route that runs *through* relayA back to relayA, but it must
+advertise the local `pubB` standby once that exists. Without `sub3` the
+interesting case never arises.
+
+## What is checked
+
+| Check | Proves |
+|---|---|
+| **1, failover** | After `pubA` is killed, `sub1` on relayA resumes. relayA had already been told about the `pubB` standby and reselected onto it. |
+| **2, standby join** | `sub3` on relayB keeps its subscription when `pubB` attaches locally. A standby wins dispatch the moment it attaches, which is *before* a real publisher has created every track, so a per-track refusal must not abort the whole subscription. |
+
+Check 2 is a regression test for a bug that only appears with real publishers.
+`moq import` announces its broadcast on connect and creates each track only once
+its demuxer reaches it, so a freshly attached standby legitimately cannot serve
+some tracks yet. A model-level standby accepts every track request immediately
+and never reproduces it.
+
+## Three things about the harness that are load-bearing
+
+Changing any of them turns a real result into a meaningless one, quietly. Each
+cost a wrong conclusion at least once, so each is commented where it is set.
+
+**The observation window is derived, not chosen.** Killing a publisher never
+sends `CONNECTION_CLOSE`, so the relay keeps serving the dead source until the
+**QUIC idle timeout** expires, 30 s by default. The relay logs nothing at all
+between the kill and `connection closed err=timed out`, and only then can it
+reselect. **A grading window shorter than that budget cannot pass on any build.**
+So the drill kills the active publisher at t=32 and grades at least 20 s *after*
+the budget elapses. Recovery time is dominated by detection, not by the reselect:
+expect `sub1` to resume roughly one idle timeout after the kill (30 to 33 s
+measured). `--idle` pins a lower timeout on the relays and shortens the run with
+it; it must stay above the keep-alive interval or healthy sessions will flap.
+
+**The kill is atomic.** The publisher pipeline is SIGKILLed in one pass, because
+killing `tsp` first would leave `moq import` reading a truncated stream plus EOF.
+It would then shut its broadcast down *cleanly*, the relay would unannounce
+immediately, and the drill would be grading a graceful detach rather than a
+source failure. The two paths behave nothing alike: one waits out an idle timeout
+and fails over, the other unannounces at once, and on that path the subscriber's
+`export ts` currently dies with `TS track layout changed after PAT/PMT was
+emitted` instead of switching to the standby.
+
+**The standby joins early, and that is deliberate.** The two publishers replay
+independent copies of the same clip *from its start*, so the standby's media
+timeline lags the active one by roughly its join delay. On the splice the
+subscriber's muxer has to wait for the new source's timestamps to overtake the
+last ones it wrote, and that wait scales one-for-one with the join delay (join at
+t=4 costs under 2 s, t=10 costs 9 s, t=20 costs 18 s). It is a property of this
+harness, not of the relay, which reselects in the same millisecond the standby
+connects. A real 1+1 pair shares a timestamp-aligned feed and does not pay it.
+Hence the default join at t=4, and hence check 2 only warns when a stall exceeds
+what that offset explains.
+
+## Usage
+
+```bash
+just test failover                  # generated clip, 30s detection budget (~90s)
+just test failover --idle 10s       # faster run (~70s)
+just test failover --source cap.ts  # publish a real capture instead
+just test failover --keep-logs      # keep the work dir (relay logs, sizes.csv)
+```
+
+Requires `cargo`, `ffmpeg`, `curl`, `pgrep`, `pkill`, and TSDuck's `tsp` (for PCR
+pacing).
+
+Environment overrides: `FAILOVER_PORT_A`, `FAILOVER_PORT_B`, `FAILOVER_PROFILE`
+(`debug`/`release`), `FAILOVER_ORIGIN`, `FAILOVER_PRE` (standby join time),
+`FAILOVER_KILLA` (when the active source is killed).
+
+## Debugging a failure
+
+`--keep-logs` prints the work dir, which holds both relay logs, every client log,
+and `sizes.csv` (per-second byte counts for `sub1` and `sub3`).
+
+`RUST_LOG=moq_net=debug` makes the announce decisions visible, which is usually
+what you want:
+
+- `no advertisable route for this peer exclude_hop=…`: relayB correctly
+  advertising nothing while it is merely carrying via relayA.
+- `announce broadcast=… hops=2`: relayB advertising the local standby to relayA
+  once `pubB` joins. This is the line that must appear at the join; without it
+  there is nothing for relayA to reselect onto.

--- a/test/failover/run.sh
+++ b/test/failover/run.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# 1+1 active/active source-failover drill across a two-relay cluster.
+#
+# Two relays are meshed, two publishers publish the SAME broadcast with a shared
+# origin id (so they are interchangeable sources), and the active publisher is
+# killed. The point is to prove, with real processes rather than model tests,
+# that the surviving standby is already advertised across the mesh and that the
+# relay serving the dead source reselects onto it.
+#
+# ```text
+#     pubA --> relayA(:4443) <--cluster--> relayB(:5443) <-- pubB
+#               ^   ^                          ^
+#             sub1 sub2                       sub3
+# ```
+#
+# sub3 subscribes on relayB, which has no local publisher at first, so relayB
+# must carry the broadcast across the mesh from relayA. That is what makes relayA
+# a hop in relayB's route, and therefore the peer that per-peer announce
+# selection has to treat specially: relayB may not advertise the route that runs
+# through relayA back to relayA, but it must advertise the local pubB standby
+# once that exists.
+#
+# Two graded checks:
+#   CHECK 1 (failover)      kill pubA; sub1 on relayA must resume, i.e. relayA
+#                           reselected onto the pubB standby advertised by relayB.
+#   CHECK 2 (standby join)  sub3 on relayB must keep its subscription when pubB
+#                           attaches locally. A standby wins dispatch the moment
+#                           it attaches, which is before a real publisher has
+#                           created every track, so a per-track refusal must not
+#                           abort the whole subscription.
+#
+# Three properties of the harness are load-bearing. Changing any of them silently
+# turns a real result into a meaningless one, so each is explained where it is
+# set: the observation window (derived from the QUIC idle timeout, see below),
+# the kill (atomic, see kill_pub), and the standby's join time (small, because
+# the two publishers are not timestamp-aligned, see PRE).
+#
+# TIMELINE, READ BEFORE CHANGING. Killing a publisher never sends
+# CONNECTION_CLOSE, so the relay keeps serving the dead source until the QUIC
+# idle timeout expires (30s by default). The relay logs nothing between the kill
+# and `connection closed err=timed out`, and only then can it reselect. A grading
+# window shorter than that budget CANNOT pass on any build. The window is
+# therefore derived from the detection budget rather than hard-coded, and
+# `--idle` shortens both together for a faster run.
+#
+# Modes:
+#   ./run.sh                  # generated clip, default 30s detection budget (~90s)
+#   ./run.sh --idle 10s       # lower the relays' idle timeout, faster (~70s)
+#   ./run.sh --source cap.ts  # publish a real capture instead of a generated clip
+#   ./run.sh --keep-logs      # keep the work dir and print its path
+set -euo pipefail
+
+DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+WORKSPACE=$(cd "$DIR/../.." && pwd)
+
+SOURCE=""
+IDLE=""        # --server-quic-idle-timeout on the relays
+IDLE_BUDGET="" # seconds the relay needs to notice a dead publisher
+PORT_A="${FAILOVER_PORT_A:-4443}"
+PORT_B="${FAILOVER_PORT_B:-5443}"
+PROFILE="${FAILOVER_PROFILE:-debug}"
+KEEP_LOGS=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source)
+            SOURCE="$2"
+            shift 2
+            ;;
+        --idle)
+            IDLE="$2"
+            shift 2
+            ;;
+        --keep-logs)
+            KEEP_LOGS=1
+            shift
+            ;;
+        *)
+            echo "error: unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# The detection budget has to be a number of seconds this script can do
+# arithmetic on, so accept only whole seconds rather than the full humantime
+# grammar the relay itself takes. Anything else would silently produce a garbage
+# window, which is the one failure mode this drill cannot afford.
+if [[ -n "$IDLE" ]]; then
+    if [[ ! "$IDLE" =~ ^([0-9]+)s?$ ]]; then
+        echo "error: --idle takes whole seconds, e.g. '10s' or '10' (got '$IDLE')" >&2
+        exit 1
+    fi
+    IDLE_BUDGET="${BASH_REMATCH[1]}"
+    IDLE="${IDLE_BUDGET}s"
+else
+    IDLE_BUDGET=30
+fi
+
+# pubB joins relayB as the standby. Keep this SMALL. The two publishers replay
+# independent copies of the same clip from its start, so the standby's media
+# timeline lags the active one by roughly PRE seconds, and on the splice the
+# subscriber's muxer has to wait for the new source's timestamps to overtake the
+# last ones it wrote. That wait is a property of this harness, not of the relay,
+# and it scales one-for-one with PRE. A real 1+1 pair shares a timestamp-aligned
+# feed and does not pay it.
+PRE="${FAILOVER_PRE:-4}"
+KILLA="${FAILOVER_KILLA:-32}"       # pubA (the active source) is killed
+KILLB=$((KILLA + IDLE_BUDGET + 20)) # >=20s of observation AFTER detection
+END=$((KILLB + 8))
+
+# GSO stalls on macOS loopback, which this drill leans on heavily.
+GSO_RELAY=()
+GSO_CLIENT=()
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    GSO_RELAY=(--server-quic-gso=false --client-quic-gso=false)
+    GSO_CLIENT=(--client-quic-gso=false)
+fi
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+require_tools() {
+    local missing=() t
+    for t in cargo tsp ffmpeg curl pgrep pkill; do
+        have "$t" || missing+=("$t")
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "error: missing required tools: ${missing[*]}" >&2
+        echo "  TSDuck (tsp) is required for PCR pacing; install from https://tsduck.io" >&2
+        exit 1
+    fi
+}
+
+require_tools
+
+TARGET_BASE=$(cargo metadata --format-version 1 --manifest-path "$WORKSPACE/Cargo.toml" --no-deps |
+    sed -n 's/.*"target_directory":"\([^"]*\)".*/\1/p')
+[[ -n "$TARGET_BASE" ]] || {
+    echo "error: could not resolve cargo target directory" >&2
+    exit 1
+}
+
+echo "### building moq-relay + moq-cli ($PROFILE)"
+flag=()
+[[ "$PROFILE" == "release" ]] && flag=(--release)
+(cd "$WORKSPACE" && cargo build ${flag[@]+"${flag[@]}"} -p moq-relay -p moq-cli)
+RELAY="$TARGET_BASE/$PROFILE/moq-relay"
+MOQ="$TARGET_BASE/$PROFILE/moq"
+
+# A 1+1 pair is only a redundant pair if both publishers declare the same origin.
+# Without that they are two unrelated broadcasts and nothing here means anything,
+# so fail loudly rather than letting every check report a bogus zero-byte result.
+if ! "$MOQ" --help 2>&1 | grep -q -- '--origin'; then
+    echo "error: this build has no 'moq --origin', so a publisher pair cannot" >&2
+    echo "  declare itself interchangeable (added in moq-dev/moq#2473)." >&2
+    exit 1
+fi
+
+TMP=$(mktemp -d)
+BROADCAST="failover-$$-${RANDOM}.hang"
+ORIGIN="${FAILOVER_ORIGIN:-424242}" # shared: declares pubA/pubB interchangeable
+SRC_TS="$TMP/source.ts"
+URL_A="http://127.0.0.1:${PORT_A}"
+URL_B="http://127.0.0.1:${PORT_B}"
+PIDS=()
+
+# shellcheck disable=SC2329  # invoked from cleanup, which runs via trap
+kill_tree() {
+    local pid="$1" child
+    for child in $(pgrep -P "$pid" 2>/dev/null || true); do kill_tree "$child"; done
+    kill -KILL "$pid" 2>/dev/null || true
+}
+
+# Killing a publisher must look like the process vanished, leaving the relay
+# holding a QUIC connection nobody will ever close. Do NOT reuse kill_tree here.
+# It walks children in pid order, so it kills `tsp` first, and `moq import` then
+# reads a truncated stream plus EOF and shuts its broadcast down cleanly. The
+# relay would unannounce immediately and the drill would grade a graceful detach
+# instead of a source failure, which is a completely different code path. SIGKILL
+# the whole pipeline in one pass so nothing gets to run shutdown code.
+kill_pub() {
+    pkill -KILL -P "$1" 2>/dev/null || true
+    kill -KILL "$1" 2>/dev/null || true
+}
+
+# shellcheck disable=SC2329  # invoked via trap
+cleanup() {
+    local pid
+    for pid in ${PIDS[@]+"${PIDS[@]}"}; do kill_tree "$pid"; done
+    if [[ -n "$KEEP_LOGS" ]]; then
+        echo "### logs kept in $TMP"
+    else
+        rm -rf "$TMP"
+    fi
+}
+trap cleanup EXIT
+
+sz() { stat -f%z "$1" 2>/dev/null || stat -c%s "$1" 2>/dev/null || echo 0; }
+
+relay_config() { # $1=port  $2=cluster id  $3=peer port
+    cat >"$TMP/relay$2.toml" <<EOF
+[log]
+level = "info"
+
+[server]
+listen = "127.0.0.1:$1"
+tls.generate = ["localhost", "127.0.0.1"]
+
+[web.http]
+listen = "127.0.0.1:$1"
+
+[auth]
+public = ""
+
+[cluster]
+id = $2
+connect = ["https://127.0.0.1:$3/"]
+EOF
+}
+
+wait_ready() { # $1=url
+    local _
+    for _ in $(seq 1 60); do
+        curl -sf "$1/certificate.sha256" >/dev/null 2>&1 && return 0
+        sleep 0.5
+    done
+    return 1
+}
+
+# The clip must outlast the whole timeline. tsp --infinite loops it as a backstop
+# but a wrap mid-drill would muddy the byte accounting.
+CLIP=$((END + 15))
+if [[ -n "$SOURCE" ]]; then
+    [[ -f "$SOURCE" ]] || {
+        echo "error: no such source: $SOURCE" >&2
+        exit 1
+    }
+    SRC_TS="$SOURCE"
+    echo "### publishing from $SOURCE"
+else
+    echo "### generating ~${CLIP}s clip with ffmpeg (H.264 + AAC, 1s GOP)"
+    ffmpeg -y -hide_banner -loglevel error \
+        -f lavfi -i "testsrc=size=640x360:rate=25" \
+        -f lavfi -i "sine=frequency=1000:sample_rate=48000" \
+        -t "$CLIP" \
+        -c:v libx264 -profile:v high -preset ultrafast -pix_fmt yuv420p \
+        -x264-params "keyint=25:min-keyint=25:scenecut=0" -b:v 2M \
+        -c:a aac -b:a 128k \
+        -f mpegts -pes_payload_size 0 "$SRC_TS"
+fi
+
+echo "### starting meshed relays on ${PORT_A} and ${PORT_B}"
+relay_config "$PORT_A" 11111 "$PORT_B"
+relay_config "$PORT_B" 22222 "$PORT_A"
+# --client-tls-disable-verify: each relay dials its peer's self-signed cert.
+for id in 11111 22222; do
+    "$RELAY" "$TMP/relay$id.toml" --client-tls-disable-verify \
+        ${GSO_RELAY[@]+"${GSO_RELAY[@]}"} \
+        ${IDLE:+--server-quic-idle-timeout "$IDLE"} >"$TMP/relay$id.log" 2>&1 &
+    PIDS+=($!)
+done
+for url in "$URL_A" "$URL_B"; do
+    wait_ready "$url" || {
+        echo "error: relay at $url never became ready" >&2
+        sed 's/^/  relay: /' "$TMP"/relay*.log >&2 || true
+        exit 1
+    }
+done
+
+LAST_PID=""
+sub() { # $1=name  $2=url
+    "$MOQ" --client-connect "$2" ${GSO_CLIENT[@]+"${GSO_CLIENT[@]}"} \
+        --broadcast "$BROADCAST" export ts >"$TMP/$1.ts" 2>"$TMP/$1.log" &
+    LAST_PID=$!
+    PIDS+=("$LAST_PID")
+}
+pub() { # $1=name  $2=url
+    # shellcheck disable=SC2016  # expansions are the child bash -c's, not ours
+    bash -c '
+        src=$1 moq=$2 url=$3 origin=$4 bcast=$5
+        shift 5
+        tsp -I file "$src" --infinite -P regulate --pcr-synchronous |
+            "$moq" --client-connect "$url" "$@" --origin "$origin" --broadcast "$bcast" import ts
+    ' _ "$SRC_TS" "$MOQ" "$2" "$ORIGIN" "$BROADCAST" \
+        ${GSO_CLIENT[@]+"${GSO_CLIENT[@]}"} >"$TMP/$1.log" 2>&1 &
+    LAST_PID=$!
+    PIDS+=("$LAST_PID")
+}
+
+echo "### timeline: pubB joins t=${PRE}, pubA killed t=${KILLA}, pubB killed t=${KILLB}, end t=${END}"
+echo "###           (detection budget ${IDLE_BUDGET}s${IDLE:+, --server-quic-idle-timeout $IDLE})"
+
+sub sub1 "$URL_A" # watched for failover
+sub sub2 "$URL_A"
+sub sub3 "$URL_B" # forces relayB to carry via relayA
+sleep 1
+pub pubA "$URL_A"
+PUBA=$LAST_PID
+
+echo "t,sub1,sub3,event" >"$TMP/sizes.csv"
+(
+    for t in $(seq 0 "$END"); do
+        ev=""
+        [[ "$t" -eq "$PRE" ]] && ev=pubB_join
+        [[ "$t" -eq "$KILLA" ]] && ev=KILL_pubA
+        [[ "$t" -eq "$KILLB" ]] && ev=KILL_pubB
+        printf '%s,%s,%s,%s\n' "$t" "$(sz "$TMP/sub1.ts")" "$(sz "$TMP/sub3.ts")" "$ev" >>"$TMP/sizes.csv"
+        sleep 1
+    done
+) &
+PIDS+=($!)
+
+sleep "$PRE"
+pub pubB "$URL_B"
+PUBB=$LAST_PID
+echo "### t=$PRE pubB joined relayB (hot standby)"
+sleep $((KILLA - PRE))
+echo "### t=$KILLA killing pubA (the active source)"
+kill_pub "$PUBA"
+sleep $((KILLB - KILLA))
+echo "### t=$KILLB killing pubB"
+kill_pub "$PUBB"
+sleep $((END - KILLB))
+
+RC=0
+
+# CHECK 1: did relayA reselect onto the standby held by relayB?
+BEFORE=$(awk -F, -v k="$KILLA" '$1==k{print $2}' "$TMP/sizes.csv")
+AFTER=$(awk -F, -v k="$((KILLB - 1))" '$1==k{print $2}' "$TMP/sizes.csv")
+RESUME=$(awk -F, -v k="$KILLA" -v b="$BEFORE" -v e="$KILLB" '$1>k && $1<e && $2>b {print $1; exit}' "$TMP/sizes.csv")
+echo
+echo "### CHECK 1 failover: sub1 at kill(t=$KILLA)=$BEFORE -> t=$((KILLB - 1))=$AFTER"
+if [[ -n "$BEFORE" && -n "$AFTER" && "$AFTER" -gt "$BEFORE" ]]; then
+    echo "PASS: sub1 resumed at t=$RESUME, $((RESUME - KILLA))s after the kill (+$((AFTER - BEFORE)) bytes)"
+else
+    echo "FAIL: sub1 frozen for the whole $((KILLB - KILLA))s window after pubA died" >&2
+    RC=1
+fi
+
+# CHECK 2: did the standby joining cost relayB's subscriber its subscription?
+# Graded on survival, sampled well clear of the join, because the join is not
+# instantaneous here: see PRE for why this harness makes the subscriber wait out
+# its own timeline offset.
+JOIN=$(awk -F, -v k="$PRE" '$1==k{print $3}' "$TMP/sizes.csv")
+JOINED=$(awk -F, -v k="$((KILLA - 1))" '$1==k{print $3}' "$TMP/sizes.csv")
+# Longest run of dead seconds between the join and the kill.
+STALL=$(awk -F, -v a="$PRE" -v b="$KILLA" '
+    NR > 1 {
+        if ($1 > a && $1 < b) { if ($3 - p <= 0) { r++; if (r > m) m = r } else r = 0 }
+        p = $3
+    }
+    END { print m + 0 }' "$TMP/sizes.csv")
+echo "### CHECK 2 standby join: sub3 at join(t=$PRE)=$JOIN -> t=$((KILLA - 1))=$JOINED"
+if [[ -n "$JOIN" && -n "$JOINED" && "$JOINED" -gt "$JOIN" ]]; then
+    echo "PASS: sub3 kept its subscription across pubB's join (+$((JOINED - JOIN)) bytes)"
+    # Up to ~PRE seconds is the harness offset. Beyond that is worth a look.
+    if [[ "$STALL" -gt "$PRE" ]]; then
+        echo "WARN: sub3 stalled ${STALL}s at the standby join, more than the ~${PRE}s this"
+        echo "      harness can explain by its own publisher timeline offset (see PRE)"
+    fi
+else
+    echo "FAIL: sub3 lost its subscription when the shared-origin standby joined the carrying relay" >&2
+    RC=1
+fi
+
+if [[ "$RC" -ne 0 ]]; then
+    echo >&2
+    echo "### sizes.csv" >&2
+    sed 's/^/  /' "$TMP/sizes.csv" >&2
+    grep -iE "unroutable|dropped" "$TMP"/sub*.log 2>/dev/null | sed 's/^/  /' >&2 || true
+fi
+
+exit "$RC"

--- a/test/justfile
+++ b/test/justfile
@@ -49,3 +49,12 @@ smoke-negative *args:
 # Check the subscriber's MPEG-TS output for IRD compliance.
 ts *args:
     ./ts/run.sh {{ args }}
+
+# Stands up two meshed relays with a 1+1 redundant publisher pair, kills the
+# active source and checks that the standby takes over. Covers the wiring the
+# routing unit tests can't: real relays, lazily-created tracks, and the QUIC
+# idle timeout that gates failure detection. `--idle 10s` for a faster run. See
+
+# failover/README.md.
+failover *args:
+    ./failover/run.sh {{ args }}


### PR DESCRIPTION
The end-to-end drill from #2461, cleaned up for the tree as `just test failover`.
It is the live counterpart to the routing unit tests in `model/origin.rs`: two
real relays, real publishers whose tracks are created lazily by the demuxer, and
the QUIC idle timeout in the loop.

```
pubA ──▶ relayA(:4443) ◀──cluster──▶ relayB(:5443) ◀── pubB
          ▲   ▲                          ▲
        sub1 sub2                       sub3
```

`sub3` is load-bearing rather than decorative: it forces relayB to carry the
broadcast via relayA, which is what makes relayA a hop in relayB's own route and
therefore the peer that per-peer announce selection has to treat specially.
Without it the interesting case never arises.

**CHECK 1 — failover.** Kill `pubA`; `sub1` on relayA must resume, which requires
relayB to have already advertised the local `pubB` standby to relayA.

**CHECK 2 — standby join.** `sub3` on relayB must survive `pubB` joining. This is
the case a model-level standby cannot reproduce: it accepts every track request
immediately, whereas `moq import` announces on connect and creates each track
only once its demuxer reaches it, so a freshly attached standby legitimately
cannot serve some tracks yet.

## Results on #2473 (head `cc11cbaf`, release, macOS)

Both checks pass, repeatably:

```
CHECK 1 failover: sub1 at kill(t=32)=5293892 -> t=81=8647624
PASS: sub1 resumed at t=65, 33s after the kill (+3353732 bytes)
CHECK 2 standby join: sub3 at join(t=10)=1624696 -> t=31=3647388
PASS: sub3 survived pubB's join (+2022692 bytes)
WARN: sub3 stalled 9s at the standby join before recovering
```

`sub1` resumes 30–33 s after the kill across runs, which is one QUIC idle
timeout — so detection dominates and the reselect itself is essentially free.

The standby join is **not** yet transparent: `sub3` stops for 8–9 s before
recovering at full rate. That is a large improvement on being torn down, but it
is still a visible outage for a viewer of a relay that is only carrying the
broadcast, so the drill measures it and prints a `WARN` rather than hiding it
behind a pass. Details in #2473.

## Two things about the harness that are easy to get wrong

Both cost me a wrong conclusion, so both are commented in the script.

**The timeline is derived, not hard-coded.** Killing a publisher sends no
`CONNECTION_CLOSE`, so the relay keeps serving the dead source until the QUIC
idle timeout expires and logs nothing at all in between. A grading window shorter
than that budget cannot pass on any build — my original drill killed at t=22 and
graded at t=43, i.e. 21 s into a 30 s timeout, which is how I first reported a
failover that did not exist. `--idle` lowers the timeout and the window together.

**The publisher pipeline is SIGKILLed in one pass.** Killing `tsp` first leaves
`moq import` reading a truncated stream plus EOF, so it shuts its broadcast down
*cleanly*, the relay unannounces immediately, and you grade a graceful detach
instead of a source failure. Worth knowing that the two paths differ sharply: on
the clean-detach path `sub1`'s `export ts` dies with `TS track layout changed
after PAT/PMT was emitted: '0.avc3' removed` instead of failing over, even with
the standby announced. I have not chased that one down; noting it in case it is
interesting.

## Dependency

Requires `moq --origin`, which arrives with #2473, so this should land with or
after it. On a build without the flag the drill exits with a diagnostic rather
than reporting a misleading zero-byte failure. Verified: on `main` it stops at
the preflight; on #2473's head both checks pass.

Not wired into the default `just test` aggregate, same as `just test smoke`.
Needs `ffmpeg` and TSDuck's `tsp`; the source clip is generated, with `--source`
to publish a real capture instead.

Made with [Cursor](https://cursor.com)