### PR TITLE
docs(drafts): address relay-hops review feedback

### DIFF
--- a/drafts/draft-lcurley-moq-relay-hops.md
+++ b/drafts/draft-lcurley-moq-relay-hops.md
@@ -24,7 +24,7 @@ informative:
 --- abstract
 
 This document defines a Relay Hops extension for MoQ Transport {{moqt}}.
-Each namespace advertisement carries an ordered list of Hop IDs identifying the relays it has traversed, starting with the origin publisher.
+Each namespace advertisement carries an ordered list of Hop IDs identifying the relays it has traversed, starting with the original publisher.
 This lets a subscriber prefer the shortest of several paths to the same namespace, identify which advertisements refer to the same broadcast (same origin), and lets a relay cluster detect and avoid routing loops.
 A namespace subscription MAY carry a single Hop ID to exclude, which a relay uses to suppress advertisements that have already passed through that hop.
 
@@ -32,6 +32,9 @@ A namespace subscription MAY carry a single Hop ID to exclude, which a relay use
 
 # Conventions and Definitions
 {::boilerplate bcp14-tagged}
+
+This document uses **upstream** and **downstream** relative to the flow of a namespace advertisement: an advertisement travels from its original publisher downstream toward subscribers, so on a given session the peer that sends an advertisement is the upstream peer and the peer that receives it is the downstream peer.
+{{moqt}} uses these terms relative to the original publisher of the content; in a relay mesh the same pair of relays can carry advertisements in both directions, so here the direction is a property of each advertisement, not of the endpoints.
 
 
 # Introduction
@@ -47,13 +50,13 @@ This redundancy is desirable for failover, but it leaves a receiver with no info
 - **Broadcast identity**: two advertisements for the same namespace may refer to the same broadcast or to two distinct origins reusing a namespace. With no origin identity a receiver cannot tell them apart, nor deduplicate redundant paths to one broadcast.
 - **Routing loops**: relay A advertises a namespace to relay B, which advertises it back to A (directly or through a cycle). Without a way to recognize an advertisement it has already seen, a relay will re-advertise it indefinitely.
 
-This extension solves all three with a single mechanism: an ordered list of **Hop IDs** that records the path an advertisement has taken, starting with the origin publisher and with one entry appended per relay.
+This extension solves all three with a single mechanism: an ordered list of **Hop IDs** that records the path an advertisement has taken, starting with the original publisher and with one entry appended per relay.
 The first entry identifies the origin (broadcast identity); the list length gives the path length (path selection); a relay finding its own Hop ID already in the list detects a loop.
 
 ## Why per-hop, not end-to-end
 The Hop ID list is rewritten at every relay: a relay appends its own Hop ID before forwarding an advertisement downstream.
 A relay therefore detects a loop by finding its own Hop ID already present in an incoming advertisement, and a subscriber compares path lengths using the list length.
-Hop IDs are chosen randomly (see [Hop IDs](#hop-ids)) so they are unique with overwhelming probability without any central coordination, even across independently operated relays.
+Hop IDs are unique (see [Hop IDs](#hop-ids)), even across independently operated relays.
 
 
 # Setup Negotiation
@@ -72,16 +75,20 @@ The extension applies to a single hop (one MOQT session) and is negotiated indep
 Negotiating this extension on a session also enables the extended NAMESPACE message format defined in [Carrying Parameters on Namespace Advertisements](#carrying-parameters-on-namespace-advertisements), which appends a Parameters field to NAMESPACE so that it, too, can carry HOP_PATH.
 
 A relay that negotiated this extension on a downstream session MUST include the HOP_PATH parameter on every PUBLISH_NAMESPACE and NAMESPACE it sends on that session, and MUST honor an EXCLUDE_HOP parameter it receives in SUBSCRIBE_NAMESPACE.
-An endpoint that did not negotiate the extension neither adds these parameters nor, for NAMESPACE, the Parameters field that would carry them.
-PUBLISH_NAMESPACE and SUBSCRIBE_NAMESPACE carry a Parameters field in {{moqt}} regardless, and per {{moqt}} an unknown Key-Value-Pair Type is ignored; either way an advertisement forwarded into a non-supporting session loses its hop information gracefully.
+A receiver that negotiated this extension and receives a PUBLISH_NAMESPACE or NAMESPACE without HOP_PATH MUST close the session with a PROTOCOL_VIOLATION.
+
+Message parameters in {{moqt}} have no generic skip rule: a receiver must know a parameter's serialization to parse past it, so an endpoint MUST NOT send HOP_PATH or EXCLUDE_HOP on a session that did not negotiate the extension.
+A relay forwarding an advertisement into a non-supporting session therefore strips HOP_PATH (and, for NAMESPACE, the appended Parameters field); the advertisement loses its hop information.
 
 
 # Hop IDs
-A **Hop ID** is a variable-length integer that identifies a single relay (or the origin publisher) within the path of an advertisement.
+A **Hop ID** is a variable-length integer that identifies a single relay (or the original publisher) within the path of an advertisement.
 
-Each relay and each origin publisher chooses its Hop ID **randomly**.
-An endpoint SHOULD draw a full-width random value (up to the 64-bit varint maximum) so that the probability of two endpoints choosing the same Hop ID is negligible.
-Random assignment means there is no registry, no coordination, and no reserved values: a Hop ID is simply an opaque identifier that is, with overwhelming probability, unique.
+Hop IDs MUST be unique among the endpoints an advertisement can traverse.
+Loop detection and origin identification compare Hop IDs for equality, so two endpoints sharing a Hop ID are indistinguishable: advertisements get dropped as false loops, and distinct broadcasts get conflated into one origin.
+Deployments often already assign each node a unique identifier; an endpoint SHOULD use such a configured identifier as its Hop ID.
+An endpoint with no configured identifier MAY instead draw a full-width random value (up to the 64-bit varint maximum), which is unique with overwhelming probability; a receiver cannot tell how a Hop ID was chosen.
+There is no registry and no reserved values: a Hop ID is simply an opaque identifier.
 
 An endpoint SHOULD keep its Hop ID stable for the lifetime of a session (and MAY reuse it across sessions) so that loop detection and path comparison are consistent.
 
@@ -114,7 +121,6 @@ The number of Key-Value-Pair parameters that follow.
 **Parameters**:
 Zero or more Key-Value-Pairs ({{moqt}} Section 2.5).
 
-The Track Namespace Suffix is self-delimiting, so a receiver parses it and then reads the Parameters that follow, bounded by the message Length.
 Both endpoints of a session know whether Relay Hops was negotiated, so there is no ambiguity about whether a NAMESPACE message on that session carries the appended Parameters field.
 An endpoint MUST NOT append a Parameters field to a NAMESPACE message on a session that did not negotiate Relay Hops, and a receiver on such a session MUST NOT expect one.
 
@@ -122,10 +128,9 @@ This document does not extend NAMESPACE_DONE ({{moqt}} Section 10.17); it carrie
 
 
 # HOP_PATH Parameter
-The HOP_PATH parameter carries the ordered list of Hop IDs that an advertisement has traversed, from the origin publisher toward the receiver.
-It is a Key-Value-Pair (see {{moqt}} Section 2.5) carried in the Parameters of a namespace advertisement: a PUBLISH_NAMESPACE message ({{moqt}} Section 10.15) or an extended NAMESPACE message (see [Carrying Parameters on Namespace Advertisements](#carrying-parameters-on-namespace-advertisements)).
-
-Because the value is a variable-length list, HOP_PATH uses an odd Type so that it is length-prefixed:
+The HOP_PATH parameter carries the ordered list of Hop IDs that an advertisement has traversed, from the original publisher toward the receiver.
+It is a parameter (see {{moqt}} Section 2.5) carried in a namespace advertisement: a PUBLISH_NAMESPACE message ({{moqt}} Section 10.15) or an extended NAMESPACE message (see [Carrying Parameters on Namespace Advertisements](#carrying-parameters-on-namespace-advertisements)).
+As with every {{moqt}} message parameter, its serialization is defined here and a receiver only encounters it on a session that negotiated the extension:
 
 ~~~
 HOP_PATH Parameter {
@@ -135,10 +140,13 @@ HOP_PATH Parameter {
 }
 ~~~
 
+**Length**:
+The length of the Hop ID list in bytes.
+
 **Hop ID**:
-One or more Hop IDs, ordered from the origin publisher (first entry) to the relay immediately upstream of the receiver (last entry).
-The number of entries is determined by consuming Hop IDs until `Length` bytes have been read; a receiver MUST close the session with a PROTOCOL_VIOLATION if the entries do not exactly fill `Length`, or if the list is empty (`Length` 0).
-HOP_PATH always contains at least one entry: the first entry is the Hop ID of the origin publisher, even before the advertisement has traversed any relay.
+One or more Hop IDs, ordered from the original publisher (first entry) to the relay immediately upstream of the receiver (last entry).
+A receiver MUST close the session with a PROTOCOL_VIOLATION if the Hop IDs do not exactly fill `Length`, or if the list is empty (`Length` 0).
+HOP_PATH always contains at least one entry: the first entry is the Hop ID of the original publisher, even before the advertisement has traversed any relay.
 
 ## Relay Behavior
 When a relay forwards a namespace advertisement downstream on a session that negotiated this extension, it MUST append its own Hop ID to the HOP_PATH it received.
@@ -158,15 +166,15 @@ Two advertisements for the same namespace whose HOP_PATH begins with the same Ho
 If the first Hop IDs differ, the advertisements come from distinct origins that happen to reuse a namespace, and a receiver MUST NOT treat them as interchangeable.
 
 A publisher (or relay acting as one) SHOULD advertise only the single best path it currently knows for each namespace.
-If the best path changes — for example after a relay failover — the publisher MAY re-advertise the namespace; the new advertisement, carrying an updated HOP_PATH, replaces the prior one per the namespace-advertisement semantics of {{moqt}}.
+If the best path changes (for example after a relay failover), the publisher MAY re-advertise the namespace; the new advertisement, carrying an updated HOP_PATH, replaces the prior one per the namespace-advertisement semantics of {{moqt}}.
 
 
 # EXCLUDE_HOP Parameter
 The EXCLUDE_HOP parameter lets a downstream subscriber tell an upstream relay to suppress advertisements that have already passed through a given hop.
 A relay in a cluster uses it to prevent the upstream from sending back an advertisement that the downstream originated, the most common source of a two-hop loop.
 
-It is a Key-Value-Pair carried in the Parameters of a SUBSCRIBE_NAMESPACE message ({{moqt}} Section 10.18).
-A single Hop ID is excluded, so EXCLUDE_HOP uses an even Type and its value is a bare varint with no length prefix:
+It is a parameter carried in a SUBSCRIBE_NAMESPACE message ({{moqt}} Section 10.18).
+Its value is a single varint:
 
 ~~~
 EXCLUDE_HOP Parameter {
@@ -182,11 +190,11 @@ To exclude nothing, a subscriber simply omits the parameter; there is no reserve
 A relay that receives a SUBSCRIBE_NAMESPACE carrying EXCLUDE_HOP MUST NOT send, on that session, any PUBLISH_NAMESPACE whose HOP_PATH contains the excluded Hop ID (including the entry the relay would itself append).
 The exclusion is scoped to the namespace subscription it accompanies.
 
-A relay that receives EXCLUDE_HOP without having negotiated the Relay Hops extension ignores it as an unknown parameter, which is the safe default (it simply does not perform the exclusion).
+A subscriber MUST NOT send EXCLUDE_HOP on a session that did not negotiate the Relay Hops extension (see [Setup Negotiation](#setup-negotiation)); a receiver that has not negotiated it cannot parse the parameter, let alone honor it.
 
 
 # Security Considerations
-Hop IDs are opaque random integers, so an individual value reveals nothing about a relay's identity or location.
+An individual Hop ID reveals nothing about a relay's identity or location beyond what its operator encodes in it; a deployment that considers its configured identifiers sensitive can use random values instead.
 A HOP_PATH list does, however, expose the number of hops an advertisement traversed, which can hint at the size and shape of a relay deployment.
 A relay that wishes to hide its internal topology MAY coalesce the hops within its own administrative domain into a single Hop ID, or strip HOP_PATH entirely, before forwarding across a trust boundary (for example, to a subscriber outside the operator's own relay cluster).
 This is analogous to how BGP confederations hide internal AS topology while preserving loop detection; it is a deployment choice, not a requirement.
@@ -198,7 +206,6 @@ Because a relay only ever appends to HOP_PATH, it cannot make a competing path a
 
 This document requests the following registrations.
 High, distinctive values are requested to avoid the low ranges reserved by {{moqt}} and to minimize collisions with provisional registrations by other extensions; they also avoid the greasing pattern (`0x7f * N + 0x9D`).
-HOP_PATH carries a list, so its Type is odd (length-prefixed); EXCLUDE_HOP carries a single Hop ID, so its Type is even (a bare varint). See {{moqt}} Section 2.5.
 
 ## MOQT Setup Options
 

--- a/drafts/draft-lcurley-moq-relay-hops.md
+++ b/drafts/draft-lcurley-moq-relay-hops.md
@@ -52,10 +52,6 @@ This redundancy is desirable for failover, but it leaves a receiver with no info
 
 This extension solves all three with a single mechanism: an ordered list of **Hop IDs** that records the path an advertisement has taken, starting with the original publisher and with one entry appended per relay.
 The first entry identifies the origin (broadcast identity); the list length gives the path length (path selection); a relay finding its own Hop ID already in the list detects a loop.
-
-## Why per-hop, not end-to-end
-The Hop ID list is rewritten at every relay: a relay appends its own Hop ID before forwarding an advertisement downstream.
-A relay therefore detects a loop by finding its own Hop ID already present in an incoming advertisement, and a subscriber compares path lengths using the list length.
 Hop IDs are unique (see [Hop IDs](#hop-ids)), even across independently operated relays.
 
 
@@ -92,8 +88,6 @@ There is no registry and no reserved values: a Hop ID is simply an opaque identi
 
 An endpoint SHOULD keep its Hop ID stable for the lifetime of a session (and MAY reuse it across sessions) so that loop detection and path comparison are consistent.
 
-When a relay bridges an advertisement from an upstream peer that did **not** negotiate this extension, the upstream carries no HOP_PATH. The relay MUST synthesize one (see [Relay Behavior](#relay-behavior)) by assigning a random Hop ID to stand in for the unknown upstream, so that loop detection and path length still work within the cooperating region of the mesh.
-
 
 # Carrying Parameters on Namespace Advertisements
 This extension attaches its downstream state (HOP_PATH) to namespace advertisements as Key-Value-Pair parameters (see {{moqt}} Section 2.5).
@@ -121,8 +115,7 @@ The number of Key-Value-Pair parameters that follow.
 **Parameters**:
 Zero or more Key-Value-Pairs ({{moqt}} Section 2.5).
 
-Both endpoints of a session know whether Relay Hops was negotiated, so there is no ambiguity about whether a NAMESPACE message on that session carries the appended Parameters field.
-An endpoint MUST NOT append a Parameters field to a NAMESPACE message on a session that did not negotiate Relay Hops, and a receiver on such a session MUST NOT expect one.
+An endpoint MUST NOT append a Parameters field to a NAMESPACE message on a session that did not negotiate Relay Hops; both endpoints know whether it was negotiated, so there is no ambiguity about which format applies.
 
 This document does not extend NAMESPACE_DONE ({{moqt}} Section 10.17); it carries no Relay Hops state.
 
@@ -146,12 +139,13 @@ The length of the Hop ID list in bytes.
 **Hop ID**:
 One or more Hop IDs, ordered from the original publisher (first entry) to the relay immediately upstream of the receiver (last entry).
 A receiver MUST close the session with a PROTOCOL_VIOLATION if the Hop IDs do not exactly fill `Length`, or if the list is empty (`Length` 0).
-HOP_PATH always contains at least one entry: the first entry is the Hop ID of the original publisher, even before the advertisement has traversed any relay.
+HOP_PATH always contains at least one entry: the first entry is the Hop ID of the original publisher, even before the advertisement has traversed any relay (or a bridging relay's stand-in for it, see [Relay Behavior](#relay-behavior)).
 
 ## Relay Behavior
 When a relay forwards a namespace advertisement downstream on a session that negotiated this extension, it MUST append its own Hop ID to the HOP_PATH it received.
 The relay's own Hop ID is therefore always the last entry of the list it sends.
-If the advertisement arrived from an upstream that did not negotiate this extension (and so carried no HOP_PATH), the relay MUST first create a HOP_PATH whose single initial entry is a random Hop ID it assigns to stand in for that unknown upstream, then append its own Hop ID.
+If the advertisement arrived from an upstream that did not negotiate this extension (and so carried no HOP_PATH), the relay MUST first create a HOP_PATH whose single initial entry is a Hop ID the relay assigns to stand in for that upstream, then append its own Hop ID.
+The stand-in MUST be stable for the lifetime of the upstream session and unique per upstream (a random value chosen per session works); advertisements bridged from the same upstream then share an origin, so loop detection, path length, and origin-based deduplication keep working within the supporting region of the mesh.
 
 When a relay receives a namespace advertisement on a session that negotiated this extension, it MUST inspect the HOP_PATH:
 
@@ -164,9 +158,6 @@ This is advisory: the receiver MAY apply additional local policy (e.g. measured 
 
 Two advertisements for the same namespace whose HOP_PATH begins with the same Hop ID share an origin and therefore refer to the same broadcast; a receiver MAY treat them as redundant paths and keep only the best one.
 If the first Hop IDs differ, the advertisements come from distinct origins that happen to reuse a namespace, and a receiver MUST NOT treat them as interchangeable.
-
-A publisher (or relay acting as one) SHOULD advertise only the single best path it currently knows for each namespace.
-If the best path changes (for example after a relay failover), the publisher MAY re-advertise the namespace; the new advertisement, carrying an updated HOP_PATH, replaces the prior one per the namespace-advertisement semantics of {{moqt}}.
 
 
 # EXCLUDE_HOP Parameter
@@ -187,17 +178,14 @@ EXCLUDE_HOP Parameter {
 The single Hop ID to exclude.
 To exclude nothing, a subscriber simply omits the parameter; there is no reserved "exclude nothing" value.
 
-A relay that receives a SUBSCRIBE_NAMESPACE carrying EXCLUDE_HOP MUST NOT send, on that session, any PUBLISH_NAMESPACE whose HOP_PATH contains the excluded Hop ID (including the entry the relay would itself append).
-The exclusion is scoped to the namespace subscription it accompanies.
-
-A subscriber MUST NOT send EXCLUDE_HOP on a session that did not negotiate the Relay Hops extension (see [Setup Negotiation](#setup-negotiation)); a receiver that has not negotiated it cannot parse the parameter, let alone honor it.
+A relay that receives a SUBSCRIBE_NAMESPACE carrying EXCLUDE_HOP MUST NOT send, for that subscription, any namespace advertisement whose HOP_PATH contains the excluded Hop ID (including the entry the relay would itself append).
+The exclusion is scoped to the namespace subscription it accompanies; advertisements sent for other subscriptions, or proactively, are unaffected.
 
 
 # Security Considerations
 An individual Hop ID reveals nothing about a relay's identity or location beyond what its operator encodes in it; a deployment that considers its configured identifiers sensitive can use random values instead.
 A HOP_PATH list does, however, expose the number of hops an advertisement traversed, which can hint at the size and shape of a relay deployment.
 A relay that wishes to hide its internal topology MAY coalesce the hops within its own administrative domain into a single Hop ID, or strip HOP_PATH entirely, before forwarding across a trust boundary (for example, to a subscriber outside the operator's own relay cluster).
-This is analogous to how BGP confederations hide internal AS topology while preserving loop detection; it is a deployment choice, not a requirement.
 
 Because a relay only ever appends to HOP_PATH, it cannot make a competing path appear shorter than it is; the worst a misbehaving relay can do is under-report the upstream portion of its own path to win an advisory tie-break. Since path selection is advisory, the impact is limited to a suboptimal path choice. A receiver MUST NOT make security decisions based on Hop IDs, and SHOULD corroborate path selection with locally measured signals (e.g. RTT) when it matters.
 
@@ -205,7 +193,7 @@ Because a relay only ever appends to HOP_PATH, it cannot make a competing path a
 # IANA Considerations
 
 This document requests the following registrations.
-High, distinctive values are requested to avoid the low ranges reserved by {{moqt}} and to minimize collisions with provisional registrations by other extensions; they also avoid the greasing pattern (`0x7f * N + 0x9D`).
+High, distinctive values are requested to avoid the low ranges reserved by {{moqt}} and to minimize collisions with provisional registrations by other extensions.
 
 ## MOQT Setup Options
 


### PR DESCRIPTION
Addresses the review feedback in moq-dev/drafts#50 (from afrind), applied to `drafts/draft-lcurley-moq-relay-hops.md` here since the drafts are moving into the monorepo, plus a follow-up simplification pass.

## Review feedback (commit 1)

- **"MUST include HOP_PATH... or else what?"** The consequence is now specified: a receiver that negotiated the extension and gets a PUBLISH_NAMESPACE or NAMESPACE without HOP_PATH MUST close the session with a PROTOCOL_VIOLATION.
- **Parameter handling vs. MOQT draft 16.** Dropped the even/odd rationale everywhere (HOP_PATH definition, EXCLUDE_HOP definition, IANA section). The draft now follows the current MOQT convention: each message parameter has a bespoke serialization defined by its spec, and there is no generic skip rule. Consequently the "unknown parameters are ignored" graceful-degradation claim was wrong and is replaced: endpoints MUST NOT send HOP_PATH or EXCLUDE_HOP on a session that did not negotiate the extension, and a relay strips them (and the appended NAMESPACE Parameters field) when forwarding into a non-supporting session. The wire formats themselves are unchanged.
- **Hop ID uniqueness.** Uniqueness is now a MUST, with the failure modes spelled out (false loop drops, conflated origins). Configured unique identifiers are the SHOULD; a full-width random value is the fallback for endpoints with no configured ID, no longer the recommendation. Security Considerations adjusted since Hop IDs are no longer necessarily random.
- **Upstream/downstream.** Defined in Conventions and Definitions relative to the flow of each advertisement rather than the endpoints, with a note contrasting MOQT's publisher-relative usage in a mesh.
- **Number of Parameters redundancy.** Kept as-is, since it mirrors PUBLISH_NAMESPACE in MOQT (reviewer agreed it's fine).
- **Nit.** "origin publisher" is now "original publisher" throughout.
- **Editorial.** Trimmed some of the parsing pedantry.

## Simplification pass (commit 2)

- **EXCLUDE_HOP scoping fix.** The suppression rule named PUBLISH_NAMESPACE while also claiming subscription scope, but matching advertisements for a SUBSCRIBE_NAMESPACE are delivered as NAMESPACE messages. It now suppresses any namespace advertisement sent for that subscription, and states that other subscriptions and proactive advertisements are unaffected.
- **Stable stand-in Hop ID.** The Hop ID a bridging relay assigns for a non-supporting upstream must now be stable per upstream session; a fresh value per advertisement would give the same broadcast a different origin each time and break origin-based deduplication.
- **Consolidated negotiation gating.** The "don't send this without negotiation" rule is stated once in Setup Negotiation instead of three times.
- **Folded "Why per-hop, not end-to-end" into the Introduction** (it repeated the intro and Relay Behavior) and trimmed advisory/flavor text (single-best-path advertising paragraph, BGP confederation analogy, greasing aside).

EXCLUDE_HOP itself was deliberately kept despite being loop-detection-redundant: moq-lite implements the same mechanism with the same single-value shape (`AnnounceRequest.exclude_hop` in `rs/moq-net/src/lite/announce.rs`), so the moqt extension keeps parity with the shipped design.

No code or other-draft changes needed: this extension has no moqt-side implementation in the repo, and the lite wire protocol (`draft-lcurley-moq-lite`) is untouched.

Validated with `kramdown-rfc --v3` (the `just drafts check` recipe).

Fixes https://github.com/moq-dev/drafts/issues/50

(Written by Claude Fable 5)