### PR TITLE
feat(hang,mux,hls): rework the timeline as a single track of complete segments

### DIFF
--- a/doc/bin/hls.md
+++ b/doc/bin/hls.md
@@ -40,9 +40,11 @@ exactly the groups that segment's ranges cover from the relay's cache and
 transmuxes them to CMAF (one moof+mdat per fetch). A broadcast whose catalog
 advertises no timeline can't be served this way and is skipped.
 
-`EXT-X-TARGETDURATION` is the longest record duration observed. When the
-timeline advertises a wall-clock anchor, the playlist carries
-`EXT-X-PROGRAM-DATE-TIME`.
+`EXT-X-TARGETDURATION` is the timeline's declared `durationMax`, rounded up to
+whole seconds: the publisher knows and enforces its segment duration (the
+import declares the source playlist's target duration), so the exporter never
+guesses from observed durations. When the timeline advertises a wall-clock
+anchor, the playlist carries `EXT-X-PROGRAM-DATE-TIME`.
 
 One server is path-based, so it can expose many broadcasts at once:
 

--- a/doc/bin/hls.md
+++ b/doc/bin/hls.md
@@ -40,14 +40,14 @@ exactly the groups that segment's ranges cover from the relay's cache and
 transmuxes them to CMAF (one moof+mdat per fetch). A broadcast whose catalog
 advertises no timeline can't be served this way and is skipped.
 
-`EXT-X-TARGETDURATION` starts from the timeline's declared `durationMax`,
-rounded up to whole seconds: the publisher knows its segment duration up front
-(the import declares the source playlist's target duration), so the very first
-playlist carries the real value instead of one grown from observation. The
-bound is a target rather than a guarantee, though, since a single GOP longer
-than it can't be split, so the exporter raises the target duration to cover any
-segment that overran. When the timeline advertises a wall-clock anchor, the
-playlist carries `EXT-X-PROGRAM-DATE-TIME`.
+`EXT-X-TARGETDURATION` starts from the timeline's `durationMax` when the
+publisher declared one, rounded up to whole seconds, so the very first playlist
+carries the real value instead of one grown from observation. Most publishers
+can't promise a bound (a real-time GOP can run for minutes), so the exporter
+also raises the target duration to cover every segment in the window: a
+playlist whose `EXTINF` exceeds its target duration is invalid. When the
+timeline advertises a wall-clock anchor, the playlist carries
+`EXT-X-PROGRAM-DATE-TIME`.
 
 One server is path-based, so it can expose many broadcasts at once:
 
@@ -105,8 +105,9 @@ moq --client-connect https://relay.example.com/anon --broadcast my-stream.hang \
   own media playlist in an `AUDIO` group.
 - **Import** currently handles classic HLS (no LL-HLS partial segments on the
   import side) and prefers H.264 renditions. The source playlist's segmentation
-  is preserved: the primary variant cuts the broadcast's timeline at each
-  source segment, so exporting the import reproduces the original boundaries.
+  is preserved: every variant cuts the broadcast's timeline at each source
+  segment (duplicate cuts are ignored), so exporting the import reproduces the
+  original boundaries.
 - **LL-HLS parts and DASH** are not implemented yet. Parts need sub-group
   records in the timeline; an MPD generator can be added over the same
   timeline + FETCH machinery later.

--- a/doc/bin/hls.md
+++ b/doc/bin/hls.md
@@ -40,11 +40,14 @@ exactly the groups that segment's ranges cover from the relay's cache and
 transmuxes them to CMAF (one moof+mdat per fetch). A broadcast whose catalog
 advertises no timeline can't be served this way and is skipped.
 
-`EXT-X-TARGETDURATION` is the timeline's declared `durationMax`, rounded up to
-whole seconds: the publisher knows and enforces its segment duration (the
-import declares the source playlist's target duration), so the exporter never
-guesses from observed durations. When the timeline advertises a wall-clock
-anchor, the playlist carries `EXT-X-PROGRAM-DATE-TIME`.
+`EXT-X-TARGETDURATION` starts from the timeline's declared `durationMax`,
+rounded up to whole seconds: the publisher knows its segment duration up front
+(the import declares the source playlist's target duration), so the very first
+playlist carries the real value instead of one grown from observation. The
+bound is a target rather than a guarantee, though, since a single GOP longer
+than it can't be split, so the exporter raises the target duration to cover any
+segment that overran. When the timeline advertises a wall-clock anchor, the
+playlist carries `EXT-X-PROGRAM-DATE-TIME`.
 
 One server is path-based, so it can expose many broadcasts at once:
 

--- a/doc/bin/hls.md
+++ b/doc/bin/hls.md
@@ -21,26 +21,28 @@ matrix of `moq-rtc`.
 ## How export works
 
 The export server never subscribes to media. Per broadcast it subscribes to
-exactly two kinds of metadata track:
+exactly two metadata tracks:
 
 - the **catalog**, which lists the renditions and their codec configs, and
-- each rendition's **timeline** track, a tiny log of its segments: each record
-  maps an aligned segment number to the group and timestamp it starts at (the
-  `timeline` section on the rendition's catalog entry names it).
+- the broadcast's **timeline** track, a tiny log of its segments: each record
+  is one complete aligned segment, carrying its start, duration, and the group
+  ranges that hold it on each media track (the catalog's root `timeline`
+  section names the track).
 
-Media playlists are rendered purely from the timeline: each record is a
-segment, and the gap to the next record is its duration. Segment numbers are
-aligned across renditions (audio and video cut at the same boundaries, as HLS
-requires), so the same segment number names the same span of content time in
-every media playlist and `EXT-X-MEDIA-SEQUENCE` lines up. Media bytes move only
-when a player requests a segment: the server FETCHes exactly the groups that
-segment covers from the relay's cache and transmuxes them to CMAF (one
-moof+mdat per group). Renditions without a timeline track can't be served this
-way and are skipped.
+Media playlists are a pure function of the timeline: every record is a listed
+segment with an explicit duration. Segments are aligned across renditions
+(audio and video cut at the same boundaries, as HLS requires), so the same
+segment number names the same span of content time in every media playlist and
+`EXT-X-MEDIA-SEQUENCE` lines up. A record that has no ranges for a rendition
+renders as `EXT-X-GAP`, and a jump in content time as `EXT-X-DISCONTINUITY`.
+Media bytes move only when a player requests a segment: the server FETCHes
+exactly the groups that segment's ranges cover from the relay's cache and
+transmuxes them to CMAF (one moof+mdat per fetch). A broadcast whose catalog
+advertises no timeline can't be served this way and is skipped.
 
-`EXT-X-TARGETDURATION` is the longest segment gap observed in the timeline
-window (the timeline is the only cadence signal). When the timeline advertises
-a wall-clock anchor, the playlist carries `EXT-X-PROGRAM-DATE-TIME`.
+`EXT-X-TARGETDURATION` is the longest record duration observed. When the
+timeline advertises a wall-clock anchor, the playlist carries
+`EXT-X-PROGRAM-DATE-TIME`.
 
 One server is path-based, so it can expose many broadcasts at once:
 
@@ -53,9 +55,9 @@ GET /{broadcast}/{kind}/{rendition}/seg/{segment}.m4s
 
 `{kind}` is `video` or `audio`, so a video and an audio rendition that share a
 name address distinct resources. A segment is addressed by its aligned segment
-number. A video segment is a single group (a GOP); an audio segment packs every
-audio group inside the same span, so one fetch covers the whole group range up
-to the next record.
+number. A video segment is one or more whole groups (GOPs); an audio segment
+packs every audio group inside the same span. The record's ranges say exactly
+which groups to fetch, so a request is served without reading any other record.
 
 ## CLI shape
 
@@ -97,7 +99,9 @@ moq --client-connect https://relay.example.com/anon --broadcast my-stream.hang \
   resolved from the fetched keyframe. Audio renditions (AAC, Opus) get their
   own media playlist in an `AUDIO` group.
 - **Import** currently handles classic HLS (no LL-HLS partial segments on the
-  import side) and prefers H.264 renditions.
+  import side) and prefers H.264 renditions. The source playlist's segmentation
+  is preserved: the primary variant cuts the broadcast's timeline at each
+  source segment, so exporting the import reproduces the original boundaries.
 - **LL-HLS parts and DASH** are not implemented yet. Parts need sub-group
   records in the timeline; an MPD generator can be added over the same
   timeline + FETCH machinery later.

--- a/doc/bin/hls.md
+++ b/doc/bin/hls.md
@@ -24,12 +24,15 @@ The export server never subscribes to media. Per broadcast it subscribes to
 exactly two kinds of metadata track:
 
 - the **catalog**, which lists the renditions and their codec configs, and
-- each rendition's **timeline** track, a tiny log mapping every media group to
-  its start timestamp (the `timeline` section on the rendition's catalog entry
-  names it).
+- each rendition's **timeline** track, a tiny log of its segments: each record
+  maps an aligned segment number to the group and timestamp it starts at (the
+  `timeline` section on the rendition's catalog entry names it).
 
-Media playlists are rendered purely from the timeline: each record starts a
-segment, and the gap to the next record is its duration. Media bytes move only
+Media playlists are rendered purely from the timeline: each record is a
+segment, and the gap to the next record is its duration. Segment numbers are
+aligned across renditions (audio and video cut at the same boundaries, as HLS
+requires), so the same segment number names the same span of content time in
+every media playlist and `EXT-X-MEDIA-SEQUENCE` lines up. Media bytes move only
 when a player requests a segment: the server FETCHes exactly the groups that
 segment covers from the relay's cache and transmuxes them to CMAF (one
 moof+mdat per group). Renditions without a timeline track can't be served this
@@ -45,14 +48,14 @@ One server is path-based, so it can expose many broadcasts at once:
 GET /{broadcast}/master.m3u8
 GET /{broadcast}/{kind}/{rendition}/media.m3u8
 GET /{broadcast}/{kind}/{rendition}/init.mp4
-GET /{broadcast}/{kind}/{rendition}/seg/{group}.m4s
+GET /{broadcast}/{kind}/{rendition}/seg/{segment}.m4s
 ```
 
 `{kind}` is `video` or `audio`, so a video and an audio rendition that share a
-name address distinct resources. A segment is addressed by its starting group
-sequence; audio timelines may skip groups (they're throttled to about one
-record per second of media), in which case one segment covers the whole group
-range up to the next record.
+name address distinct resources. A segment is addressed by its aligned segment
+number. A video segment is a single group (a GOP); an audio segment packs every
+audio group inside the same span, so one fetch covers the whole group range up
+to the next record.
 
 ## CLI shape
 

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -104,6 +104,7 @@ The root of the catalog is a JSON document with the following schema:
 type Catalog = {
 	"audio": AudioSchema | undefined,
 	"video": VideoSchema | undefined,
+	"timeline": TimelineSchema | undefined,
 	// ... any custom fields ...
 }
 ~~~
@@ -114,7 +115,7 @@ The catalog SHOULD be mostly static, delegating any dynamic content to other tra
 For example, a `"chat"` section should include the name of a chat track, not individual chat messages.
 This way catalog updates are rare and a client MAY choose to not subscribe.
 
-This specification currently only defines audio and video tracks.
+This specification currently defines audio and video media tracks, plus an optional timeline track ({{timeline}}) indexing their segments.
 
 ## Video
 A video track contains the necessary information to decode a video stream.
@@ -323,6 +324,96 @@ A consumer MUST feed `init` to the decoder before the first frame.
 
 ## loc
 Each frame is a Low Overhead Container frame {{!I-D.ietf-moq-loc}}: a property block, carrying the timestamp among other properties, followed by the codec payload.
+
+
+# Timeline {#timeline}
+The timeline track is the broadcast's segment index.
+MoQ groups carry only an opaque sequence number; the timestamps live inside the media frames.
+The timeline republishes the broadcast's segmentation as metadata: one record per segment, mapping a span of content time to the group ranges that carry it on each media track.
+A consumer can answer "which groups cover time T on track X" and "where is the live edge" from a few bytes per segment, without downloading media.
+This is sufficient to render an HLS or DASH playlist, seek a VOD recording, or index an archive.
+
+The timeline is optional.
+There is one timeline per broadcast, because its purpose is that segments are aligned across the broadcast's tracks: segment N covers the same span of content time on every track, which is what HLS requires of switchable renditions.
+A broadcast that does not need aligned segments simply omits it.
+
+## Catalog Section {#timeline-catalog}
+The catalog's root `timeline` field advertises the track:
+
+~~~
+type TimelineSchema = {
+	"track": string,
+	"timescale": number | undefined,
+	"wall": number | undefined,
+}
+~~~
+
+The `track` field names the MoQ track carrying the segment records.
+The name `timeline.z` is RECOMMENDED; a consumer MUST use the advertised name rather than assuming it.
+
+The `timescale` field is the units per second for the records' `pts` and `duration` values, and for `wall`.
+If absent, it defaults to 1000 (milliseconds).
+
+The `wall` field, if known, is the wall-clock time of `pts` 0: in `timescale` units, measured from the moq epoch, 2020-01-01T00:00:00Z.
+A consumer derives the wall-clock time of any segment as `wall + pts`, and Unix time by adding the epoch back (for HLS `EXT-X-PROGRAM-DATE-TIME` or DASH `availabilityStartTime`).
+The epoch is 2020 rather than 1970 so the value stays small, safely within a 53-bit integer even at fine timescales.
+
+## Track Framing {#timeline-framing}
+The timeline track is an append-log: a single group that is never rolled, with one record per frame, every record preserved in order.
+Each record is a UTF-8 JSON object.
+
+The frames are DEFLATE-compressed ({{!RFC1951}}) sharing a single compression window across the group, so each record compresses against all earlier ones.
+The publisher ends each frame's compressed data with an empty sync-flush block (the `0x00 0x00 0xff 0xff` trailer is removed, as in {{?RFC7692}}), so a consumer decompresses frames incrementally with one shared window.
+The `.z` suffix on the RECOMMENDED track name marks this compression, mirroring the catalog's `catalog.json.z` sibling.
+
+A consumer MUST start reading from the group's first frame; the shared window makes a mid-group join undecodable.
+The live group is therefore bounded history; deep history is served from a recording.
+
+## Records {#timeline-records}
+Each record describes one complete segment:
+
+~~~
+type TimelineRecord = {
+	"segment": number,
+	"pts": number,
+	"duration": number,
+	"tracks": Map<TrackName, TimelineRange[]> | undefined,
+}
+
+type TimelineRange = {
+	"start": number,
+	"end": number,
+	"keyframe": boolean | undefined,
+}
+~~~
+
+The `segment` field is the segment's number.
+Numbers are consecutive within a broadcast, anchoring HLS `EXT-X-MEDIA-SEQUENCE`; they are explicit rather than implied by record order so a reader joining mid-stream, or reading a windowed recording, keeps stable numbering.
+
+The `pts` field is the segment's start and `duration` its length, both in the timeline's timescale.
+The next record's `pts` equals `pts + duration` unless content time itself jumped; a consumer SHOULD treat such a jump as a discontinuity.
+
+The `tracks` field maps each participating media track name to the group ranges it contributes.
+Each range covers groups `start` through `end` inclusive, as used by moq-lite FETCH and SUBSCRIBE.
+More than one range means the group sequence is discontinuous inside the segment: the skipped groups never existed.
+A track absent from the map has no content for the span (a gap; HLS `EXT-X-GAP`).
+A record MUST tolerate and SHOULD preserve unknown fields, like the catalog.
+
+The `keyframe` field states whether the range's first group starts with a keyframe, i.e. whether a player can join or switch renditions there.
+If absent, it defaults to true; a publisher sets `false` when a source resumes without one, so an exporter knows not to advertise the segment as independently decodable.
+
+## Segmentation {#timeline-segmentation}
+A segment is a span of content time shared by every media track.
+Segment boundaries SHOULD land on video keyframe timestamps: every group already starts with a keyframe ({{container}}), so a boundary at a video keyframe lets each video track contribute whole groups and remain independently decodable.
+Audio groups are short and can be cut anywhere; an audio track contributes every group whose start falls inside the span.
+A segment MAY span multiple video groups (small GOPs packed into a larger segment).
+
+How boundaries are chosen is publisher policy: following a source's existing segmentation (an imported HLS playlist, CMAF segments on disk), or pacing by a target duration.
+Whatever the policy, a publisher MUST NOT emit a record until the segment is complete: every participating track's groups for the span are known.
+Records are therefore self-contained and immediately servable, and the newest record is the live edge.
+
+A group that starts before the first boundary belongs to the first segment.
+The final segment of an ended broadcast has no closing boundary; its `duration` runs to the newest known content and MAY undercount the last group's duration.
 
 
 # Security Considerations

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -344,7 +344,7 @@ The catalog's root `timeline` field advertises the track:
 type TimelineSchema = {
 	"track": string,
 	"timescale": number | undefined,
-	"durationMax": number,
+	"durationMax": number | undefined,
 	"wall": number | undefined,
 }
 ~~~
@@ -355,11 +355,13 @@ The name `timeline.z` is RECOMMENDED; a consumer MUST use the advertised name ra
 The `timescale` field is the units per second for the records' `pts` and `duration` values, and for `durationMax` and `wall`.
 If absent, it defaults to 1000 (milliseconds).
 
-The `durationMax` field is the declared upper bound on a segment's `duration`, in `timescale` units.
-The publisher knows its segmentation policy up front (the encoder its keyframe cadence, an importer its source's target duration), so the bound is declared rather than inferred: a consumer can size buffers, and an HLS exporter can write `EXT-X-TARGETDURATION`, from the catalog alone.
-The value MUST NOT change for the life of the broadcast.
-A segment SHOULD NOT exceed the bound; it MAY exceed it slightly (by less than half a second, the tolerance HLS's nearest-integer rounding grants) or when the media offers no valid boundary (a single GOP longer than the bound, see {{timeline-segmentation}}).
-The bound is therefore a declared target, not a guarantee, so a consumer deriving a hard limit from it (an HLS `EXT-X-TARGETDURATION`, which every `EXTINF` must fit under) MUST raise that limit to cover any record whose `duration` exceeds the bound.
+The `durationMax` field, if present, is the declared upper bound on a segment's `duration`, in `timescale` units.
+A publisher that controls its encoder knows its keyframe cadence up front, so a consumer can size buffers or write an HLS `EXT-X-TARGETDURATION` from the catalog alone, before observing a single segment.
+The value MUST NOT change for the life of the broadcast, and a publisher MUST NOT emit a record whose `duration` exceeds it.
+A publisher that cannot honor that MUST omit the field rather than emit a record contradicting it.
+
+The field is absent when the media decides the segmentation instead, which is the common case: a real-time encoder places keyframes on demand and a single GOP may be minutes long, and a publisher importing a source it does not control cannot promise anything about that source.
+A consumer needing a bound then derives one from the records it has seen, raising it as longer segments arrive.
 
 The `wall` field, if known, is the wall-clock time of `pts` 0: in `timescale` units, measured from the moq epoch, 2020-01-01T00:00:00Z.
 A consumer derives the wall-clock time of any segment as `wall + pts`, and Unix time by adding the epoch back (for HLS `EXT-X-PROGRAM-DATE-TIME` or DASH `availabilityStartTime`).
@@ -411,15 +413,17 @@ If absent, it defaults to true; a publisher sets `false` when a source resumes w
 
 ## Segmentation {#timeline-segmentation}
 A segment is a span of content time shared by every media track.
-Segment boundaries SHOULD land on video keyframe timestamps: every group already starts with a keyframe ({{container}}), so a boundary at a video keyframe lets each video track contribute whole groups and remain independently decodable.
-Audio groups are short and can be cut anywhere; an audio track contributes every group whose start falls inside the span.
-A segment MAY span multiple video groups (small GOPs packed into a larger segment).
+A track contributes every group whose start falls inside the span, so a segment boundary SHOULD land on a group start: every group already begins with a keyframe ({{container}}), so a boundary at a group start lets each track contribute whole groups and remain independently decodable.
+A segment MAY span multiple groups of a track (short groups packed into a longer segment).
 
-How boundaries are chosen is publisher policy: following a source's existing segmentation (an imported HLS playlist, CMAF segments on disk), or pacing by a target duration.
-Either way the policy SHOULD keep every segment within the advertised `durationMax` ({{timeline-catalog}}).
-A publisher pacing on keyframes should close a segment at the last keyframe that keeps it within the bound rather than the first keyframe past it, which would overrun by up to one GOP; only a single GOP longer than the bound justifies a longer segment.
+How boundaries are chosen is publisher policy: following a source's existing segmentation (an imported HLS playlist, CMAF segments on disk), or pacing by a minimum duration.
+A publisher pacing itself SHOULD end a segment at the earliest point that is a group start on every enrolled track and at least the minimum past the segment's start, which makes the track with the coarsest groups pace the broadcast and leaves no track's group split across a boundary.
+A minimum is always satisfiable, whereas a maximum is not: a single group longer than it cannot be divided.
+Where no such point exists because two tracks have different coarse cadences, a publisher MUST choose one of them rather than a point interior to any track's group.
+
 Whatever the policy, a publisher MUST NOT emit a record until the segment is complete: every participating track's groups for the span are known.
 Records are therefore self-contained and immediately servable, and the newest record is the live edge.
+An enrolled track that has produced nothing for the span holds the record back; a publisher that knows a track has stopped for good closes it, and the record then simply omits it (a gap).
 
 A group that starts before the first boundary belongs to the first segment.
 The final segment of an ended broadcast has no closing boundary; its `duration` runs to the newest known content.

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -344,6 +344,7 @@ The catalog's root `timeline` field advertises the track:
 type TimelineSchema = {
 	"track": string,
 	"timescale": number | undefined,
+	"durationMax": number,
 	"wall": number | undefined,
 }
 ~~~
@@ -351,8 +352,13 @@ type TimelineSchema = {
 The `track` field names the MoQ track carrying the segment records.
 The name `timeline.z` is RECOMMENDED; a consumer MUST use the advertised name rather than assuming it.
 
-The `timescale` field is the units per second for the records' `pts` and `duration` values, and for `wall`.
+The `timescale` field is the units per second for the records' `pts` and `duration` values, and for `durationMax` and `wall`.
 If absent, it defaults to 1000 (milliseconds).
+
+The `durationMax` field is the declared upper bound on a segment's `duration`, in `timescale` units.
+The publisher knows its segmentation policy up front (the encoder its keyframe cadence, an importer its source's target duration), so the bound is declared rather than inferred: a consumer can size buffers, and an HLS exporter can write `EXT-X-TARGETDURATION`, from the catalog alone.
+The value MUST NOT change for the life of the broadcast.
+A segment SHOULD NOT exceed the bound; it MAY exceed it slightly (by less than half a second, the tolerance HLS's nearest-integer rounding grants) or when the media offers no valid boundary (a single GOP longer than the bound, see {{timeline-segmentation}}).
 
 The `wall` field, if known, is the wall-clock time of `pts` 0: in `timescale` units, measured from the moq epoch, 2020-01-01T00:00:00Z.
 A consumer derives the wall-clock time of any segment as `wall + pts`, and Unix time by adding the epoch back (for HLS `EXT-X-PROGRAM-DATE-TIME` or DASH `availabilityStartTime`).
@@ -409,6 +415,8 @@ Audio groups are short and can be cut anywhere; an audio track contributes every
 A segment MAY span multiple video groups (small GOPs packed into a larger segment).
 
 How boundaries are chosen is publisher policy: following a source's existing segmentation (an imported HLS playlist, CMAF segments on disk), or pacing by a target duration.
+Either way the policy SHOULD keep every segment within the advertised `durationMax` ({{timeline-catalog}}).
+A publisher pacing on keyframes should close a segment at the last keyframe that keeps it within the bound rather than the first keyframe past it, which would overrun by up to one GOP; only a single GOP longer than the bound justifies a longer segment.
 Whatever the policy, a publisher MUST NOT emit a record until the segment is complete: every participating track's groups for the span are known.
 Records are therefore self-contained and immediately servable, and the newest record is the live edge.
 

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -359,6 +359,7 @@ The `durationMax` field is the declared upper bound on a segment's `duration`, i
 The publisher knows its segmentation policy up front (the encoder its keyframe cadence, an importer its source's target duration), so the bound is declared rather than inferred: a consumer can size buffers, and an HLS exporter can write `EXT-X-TARGETDURATION`, from the catalog alone.
 The value MUST NOT change for the life of the broadcast.
 A segment SHOULD NOT exceed the bound; it MAY exceed it slightly (by less than half a second, the tolerance HLS's nearest-integer rounding grants) or when the media offers no valid boundary (a single GOP longer than the bound, see {{timeline-segmentation}}).
+The bound is therefore a declared target, not a guarantee, so a consumer deriving a hard limit from it (an HLS `EXT-X-TARGETDURATION`, which every `EXTINF` must fit under) MUST raise that limit to cover any record whose `duration` exceeds the bound.
 
 The `wall` field, if known, is the wall-clock time of `pts` 0: in `timescale` units, measured from the moq epoch, 2020-01-01T00:00:00Z.
 A consumer derives the wall-clock time of any segment as `wall + pts`, and Unix time by adding the epoch back (for HLS `EXT-X-PROGRAM-DATE-TIME` or DASH `availabilityStartTime`).
@@ -421,7 +422,8 @@ Whatever the policy, a publisher MUST NOT emit a record until the segment is com
 Records are therefore self-contained and immediately servable, and the newest record is the live edge.
 
 A group that starts before the first boundary belongs to the first segment.
-The final segment of an ended broadcast has no closing boundary; its `duration` runs to the newest known content and MAY undercount the last group's duration.
+The final segment of an ended broadcast has no closing boundary; its `duration` runs to the newest known content.
+A publisher SHOULD carry the end of the last group's content into that value, since a publisher that knows only where each group *started* would report a duration one group short, and zero for a final segment that is a single group.
 
 
 # Security Considerations

--- a/js/hang/src/catalog/audio.ts
+++ b/js/hang/src/catalog/audio.ts
@@ -3,7 +3,6 @@ import { ContainerSchema } from "./container";
 import { hexSchema } from "./hex";
 import { u53Schema } from "./integers";
 import { RelativeBroadcastSchema } from "./path";
-import { TimelineSchema } from "./timeline";
 
 // Backwards compatibility: old track schema
 const TrackSchema = z.object({
@@ -49,9 +48,6 @@ export const AudioConfigSchema = z.object({
 	// NOTE: The audio "frame" duration depends on the codec, sample rate, etc.
 	// ex: AAC often uses 1024 samples per frame, so at 44100Hz, this would be 1024/44100 = 23ms
 	jitter: z.optional(u53Schema),
-
-	// The companion timeline track indexing this rendition's groups, if the publisher offers one.
-	timeline: z.optional(TimelineSchema),
 });
 
 /** Schema for the catalog audio section: a map of track name to rendition config. */

--- a/js/hang/src/catalog/root.ts
+++ b/js/hang/src/catalog/root.ts
@@ -1,6 +1,7 @@
 import * as z from "zod/mini";
 
 import { AudioSchema } from "./audio";
+import { TimelineSchema } from "./timeline";
 import { VideoSchema } from "./video";
 
 /**
@@ -14,6 +15,8 @@ import { VideoSchema } from "./video";
 export const RootSchema = z.looseObject({
 	video: z.optional(VideoSchema),
 	audio: z.optional(AudioSchema),
+	// The broadcast's timeline track (its aligned segment index), if the publisher offers one.
+	timeline: z.optional(TimelineSchema),
 });
 
 /** The root catalog object, with optional video and audio sections plus any app extensions. */

--- a/js/hang/src/catalog/timeline.ts
+++ b/js/hang/src/catalog/timeline.ts
@@ -11,18 +11,16 @@ import { u53, u53Schema } from "./integers";
 export const MOQ_EPOCH_UNIX_MILLIS = 1_577_836_800_000;
 
 /**
- * Describes a media track's companion timeline track: the track's segment index, mapping each
- * segment (one or more groups) to its starting group and timestamp, so a consumer can seek (or
- * build an HLS/DASH playlist) without downloading the media itself.
+ * Describes the broadcast's timeline track: its segment index, one record per aligned segment
+ * mapping a span of content time to the group ranges that carry it on each media track, so a
+ * consumer can seek (or build an HLS/DASH playlist) without downloading the media itself.
  *
- * Present on a {@link VideoConfig} / {@link AudioConfig} when the publisher offers one. It is per
- * media track on purpose: a video segment is a single group while an audio segment packs many
- * shorter ones, so each track needs its own group mapping. Only the segment *numbers* are shared:
- * segment N covers the same span of content time on every track, which is what makes the
- * timelines sufficient for HLS/DASH export.
+ * Lives at the catalog root: there is one timeline per broadcast, because its whole point is
+ * that segments are aligned across the broadcast's tracks. A publisher that doesn't segment
+ * simply omits it.
  */
 export const TimelineSchema = z.object({
-	// The name of the companion MoQ track carrying this track's segment records.
+	// The name of the MoQ track carrying the broadcast's segment records.
 	track: z.string(),
 
 	// Units per second for the records' `pts` (and `wall`). Defaults to 1000 (milliseconds).

--- a/js/hang/src/catalog/timeline.ts
+++ b/js/hang/src/catalog/timeline.ts
@@ -26,6 +26,14 @@ export const TimelineSchema = z.object({
 	// Units per second for the records' `pts` (and `wall`). Defaults to 1000 (milliseconds).
 	timescale: z._default(u53Schema, u53(1000)),
 
+	// The declared upper bound on a segment's duration, in `timescale` units. The encoder
+	// knows its keyframe cadence (or the cutter its boundaries), so the bound is declared up
+	// front rather than observed: a consumer can size buffers, and an HLS exporter can write
+	// EXT-X-TARGETDURATION, from the catalog alone. A segment may exceed it only slightly
+	// (under half a second, the tolerance HLS's nearest-integer rounding grants), or
+	// arbitrarily when the media leaves no valid boundary (a GOP longer than the bound).
+	durationMax: u53Schema,
+
 	// The wall-clock time of pts 0, in `timescale` units since the moq epoch
 	// ({@link MOQ_EPOCH_UNIX_MILLIS}, 2020-01-01), if known. A consumer derives any group's
 	// wall-clock time as `wall + pts`, and Unix time by adding the moq epoch back (for HLS

--- a/js/hang/src/catalog/timeline.ts
+++ b/js/hang/src/catalog/timeline.ts
@@ -11,16 +11,18 @@ import { u53, u53Schema } from "./integers";
 export const MOQ_EPOCH_UNIX_MILLIS = 1_577_836_800_000;
 
 /**
- * Describes a media track's companion timeline track: a track mapping each of the media track's
- * groups to its start timestamp, so a consumer can seek (or build an HLS/DASH playlist) without
- * downloading the media itself.
+ * Describes a media track's companion timeline track: the track's segment index, mapping each
+ * segment (one or more groups) to its starting group and timestamp, so a consumer can seek (or
+ * build an HLS/DASH playlist) without downloading the media itself.
  *
  * Present on a {@link VideoConfig} / {@link AudioConfig} when the publisher offers one. It is per
- * media track on purpose: audio and video groups have different durations, so a single
- * broadcast-wide timeline can't describe them all.
+ * media track on purpose: a video segment is a single group while an audio segment packs many
+ * shorter ones, so each track needs its own group mapping. Only the segment *numbers* are shared:
+ * segment N covers the same span of content time on every track, which is what makes the
+ * timelines sufficient for HLS/DASH export.
  */
 export const TimelineSchema = z.object({
-	// The name of the companion MoQ track carrying this track's group -> timestamp records.
+	// The name of the companion MoQ track carrying this track's segment records.
 	track: z.string(),
 
 	// Units per second for the records' `pts` (and `wall`). Defaults to 1000 (milliseconds).

--- a/js/hang/src/catalog/timeline.ts
+++ b/js/hang/src/catalog/timeline.ts
@@ -26,13 +26,14 @@ export const TimelineSchema = z.object({
 	// Units per second for the records' `pts` (and `wall`). Defaults to 1000 (milliseconds).
 	timescale: z._default(u53Schema, u53(1000)),
 
-	// The declared upper bound on a segment's duration, in `timescale` units. The encoder
-	// knows its keyframe cadence (or the cutter its boundaries), so the bound is declared up
-	// front rather than observed: a consumer can size buffers, and an HLS exporter can write
-	// EXT-X-TARGETDURATION, from the catalog alone. A segment may exceed it only slightly
-	// (under half a second, the tolerance HLS's nearest-integer rounding grants), or
-	// arbitrarily when the media leaves no valid boundary (a GOP longer than the bound).
-	durationMax: u53Schema,
+	// The declared upper bound on a segment's duration, in `timescale` units, when the
+	// publisher can promise one. A publisher that controls its encoder knows its keyframe
+	// cadence up front, so a consumer can size buffers or write an HLS EXT-X-TARGETDURATION
+	// from the catalog alone, before observing a single segment; no record ever exceeds it.
+	// Absent when the media decides instead (real-time, where a GOP can be minutes long, or an
+	// import of a source the publisher doesn't control), and a consumer needing a bound then
+	// derives one from the records it has seen.
+	durationMax: z.optional(u53Schema),
 
 	// The wall-clock time of pts 0, in `timescale` units since the moq epoch
 	// ({@link MOQ_EPOCH_UNIX_MILLIS}, 2020-01-01), if known. A consumer derives any group's

--- a/js/hang/src/catalog/video.ts
+++ b/js/hang/src/catalog/video.ts
@@ -3,7 +3,6 @@ import { ContainerSchema } from "./container";
 import { hexSchema } from "./hex";
 import { u53Schema } from "./integers";
 import { RelativeBroadcastSchema } from "./path";
-import { TimelineSchema } from "./timeline";
 
 // Backwards compatibility: old track schema
 const TrackSchema = z.object({
@@ -59,9 +58,6 @@ export const VideoConfigSchema = z.object({
 	// - If there can be up to 3 b-frames in a row, this would be 3 * 1000/fps.
 	// - If frames are buffered into 2s segments, this would be 2s.
 	jitter: z.optional(u53Schema),
-
-	// The companion timeline track indexing this rendition's groups, if the publisher offers one.
-	timeline: z.optional(TimelineSchema),
 });
 
 /**

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -4,7 +4,7 @@ import { Time } from "@moq/net";
 export type { BufferedRange, BufferedRanges, Frame } from "./types";
 
 import type { Format as ContainerFormat } from "./format";
-import type { Producer as TimelineProducer } from "./timeline";
+import type { Recorder as TimelineRecorder } from "./timeline";
 import type { Frame } from "./types";
 
 /** The legacy hang container: a microsecond timestamp varint followed by the raw codec payload. */
@@ -48,17 +48,18 @@ export function encodeFrame(source: Uint8Array | Source, timestamp: Time.Micro):
 /** Options for a legacy-container {@link Producer}. */
 export interface ProducerProps {
 	/**
-	 * Record each group open (sequence + start timestamp) into this companion timeline track as
-	 * aligned segments, so consumers can index the media without downloading it.
+	 * Report each group open (sequence + start timestamp) into the broadcast's timeline, so
+	 * consumers can index the media without downloading it. Mint one via
+	 * {@link Timeline.Segmenter.track}.
 	 */
-	timeline?: TimelineProducer;
+	timeline?: TimelineRecorder;
 }
 
 /** Writes legacy-container frames into a MoQ track, starting a new group on each keyframe. */
 export class Producer {
 	#track: Moq.Track.Producer;
 	#group?: Moq.Group.Producer;
-	#timeline?: TimelineProducer;
+	#timeline?: TimelineRecorder;
 
 	/** Wrap a track to publish legacy-container frames into it. */
 	constructor(track: Moq.Track.Producer, props: ProducerProps = {}) {
@@ -71,8 +72,8 @@ export class Producer {
 		if (keyframe) {
 			this.#group?.close();
 			this.#group = this.#track.appendGroup();
-			// Index the group the moment it opens: its start is this keyframe's timestamp.
-			this.#timeline?.record(this.#group.sequence, timestamp);
+			// Report the group the moment it opens: its start is this keyframe's timestamp.
+			this.#timeline?.record(this.#group.sequence, timestamp, true);
 		} else if (!this.#group) {
 			throw new Error("must start with a keyframe");
 		}

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -60,6 +60,9 @@ export class Producer {
 	#track: Moq.Track.Producer;
 	#group?: Moq.Group.Producer;
 	#timeline?: TimelineRecorder;
+	// The newest timestamp written, reported to the timeline when the track closes: the last
+	// group has no successor to bound it, so its segment would be published a group short.
+	#end?: Time.Micro;
 
 	/** Wrap a track to publish legacy-container frames into it. */
 	constructor(track: Moq.Track.Producer, props: ProducerProps = {}) {
@@ -82,10 +85,13 @@ export class Producer {
 			payload: encodeFrame(data, timestamp),
 			timestamp: Time.Timestamp.fromMicros(timestamp),
 		});
+
+		if (this.#end === undefined || timestamp > this.#end) this.#end = timestamp;
 	}
 
 	/** Close the track and current group, optionally with an error. */
 	close(err?: Error) {
+		if (this.#end !== undefined) this.#timeline?.end(this.#end);
 		this.#track.close(err);
 		this.#group?.close();
 	}

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -48,8 +48,8 @@ export function encodeFrame(source: Uint8Array | Source, timestamp: Time.Micro):
 /** Options for a legacy-container {@link Producer}. */
 export interface ProducerProps {
 	/**
-	 * Record each group open (sequence + start timestamp) into this companion timeline track, so
-	 * consumers can index the media without downloading it.
+	 * Record each group open (sequence + start timestamp) into this companion timeline track as
+	 * aligned segments, so consumers can index the media without downloading it.
 	 */
 	timeline?: TimelineProducer;
 }

--- a/js/hang/src/container/legacy.ts
+++ b/js/hang/src/container/legacy.ts
@@ -50,7 +50,7 @@ export interface ProducerProps {
 	/**
 	 * Report each group open (sequence + start timestamp) into the broadcast's timeline, so
 	 * consumers can index the media without downloading it. Mint one via
-	 * {@link Timeline.Segmenter.track}.
+	 * {@link Timeline.Producer.track}.
 	 */
 	timeline?: TimelineRecorder;
 }

--- a/js/hang/src/container/timeline.test.ts
+++ b/js/hang/src/container/timeline.test.ts
@@ -231,9 +231,9 @@ test("the final segment runs to the reported end", async () => {
 
 // A record is immutable and judged against the tracks enrolled when it flushes, so a producer
 // that enrolls its tracks one batch at a time holds flushing back until they are all in.
-test("a hold defers flushing until every track enrolls", async () => {
+test("a reservation defers flushing until every track enrolls", async () => {
 	const { timeline, records } = capture();
-	const release = timeline.hold();
+	const release = timeline.reserve();
 
 	// The primary rendition runs a whole batch of segments through before its sibling exists.
 	const first = timeline.track("video0");
@@ -387,13 +387,13 @@ test("the wall-clock anchor is advertised from the config", () => {
 	expect(capture({ wall: new Date(0) }).timeline.section().wall).toBe(u53(0));
 });
 
-// Producers that each guard their own batch nest, so the first to finish doesn't publish
-// records the others are still filling in.
-test("holds nest", async () => {
+// Reservations nest like the catalog's, so the first batch to finish doesn't publish records
+// the others are still filling in.
+test("reservations nest", async () => {
 	const { timeline, records } = capture();
 
-	const outer = timeline.hold();
-	const inner = timeline.hold();
+	const outer = timeline.reserve();
+	const inner = timeline.reserve();
 
 	const first = timeline.track("video0");
 	for (const [seq, ms] of [
@@ -404,7 +404,7 @@ test("holds nest", async () => {
 		first.record(seq, us(ms));
 	}
 
-	// If the holds didn't nest, releasing this one would publish segment 0 without video1.
+	// If reservations didn't nest, releasing this one would publish segment 0 without video1.
 	inner();
 
 	const second = timeline.track("video1");

--- a/js/hang/src/container/timeline.test.ts
+++ b/js/hang/src/container/timeline.test.ts
@@ -435,3 +435,26 @@ test("reservations nest", async () => {
 		tracks: { video0: [{ start: 1, end: 1 }], video1: [{ start: 1, end: 1 }] },
 	});
 });
+
+// A cut registered before the media, landing exactly on the first reported group (what the fMP4
+// importer does: it cuts at the keyframe fragment's timestamp, then records that group). The
+// spent cut must not block the ones behind it, and durationMin pacing must not race ahead of them.
+test("a cut on the first group does not poison later cuts", async () => {
+	const { timeline, records } = capture();
+	const video = timeline.track("video0");
+
+	// Source segments every 3s, keyframes every 1s: 3s segments, not the 1s the durationMin
+	// pacing would produce on its own.
+	timeline.cut(us(0));
+	video.record(0, us(0));
+	for (let seq = 1; seq < 10; seq++) {
+		if (seq % 3 === 0) timeline.cut(us(seq * 1000));
+		video.record(seq, us(seq * 1000));
+	}
+	video.close();
+	timeline.finish();
+
+	const out = await records();
+	expect(out[0]).toEqual({ segment: 0, pts: 0, duration: 3000, tracks: { video0: [{ start: 0, end: 2 }] } });
+	expect(out[1]).toEqual({ segment: 1, pts: 3000, duration: 3000, tracks: { video0: [{ start: 3, end: 5 }] } });
+});

--- a/js/hang/src/container/timeline.test.ts
+++ b/js/hang/src/container/timeline.test.ts
@@ -1,23 +1,39 @@
 import { expect, test } from "bun:test";
+import * as Json from "@moq/json";
 import type { Time } from "@moq/net";
-import { type Record, Segmenter } from "./timeline.ts";
+import { Track } from "@moq/net";
+import { u53 } from "../catalog";
+import { Producer, type Record } from "./timeline.ts";
 
 const us = (ms: number): Time.Micro => (ms * 1000) as Time.Micro;
 
-/** A segmenter whose flushed records are captured into the returned array. */
-function capture(): { segmenter: Segmenter; records: Record[] } {
-	const segmenter = new Segmenter();
-	const records: Record[] = [];
-	segmenter.attach((record) => records.push(record));
-	return { segmenter, records };
+/** A timeline whose published records are decoded back out of its MoQ track. */
+function capture(props?: ConstructorParameters<typeof Producer>[1]): {
+	timeline: Producer;
+	records: () => Promise<Record[]>;
+} {
+	const track = new Track.Producer("timeline.z");
+	const consumer = new Json.Stream.Consumer<Record>(track.subscribe(), { compression: true });
+	const timeline = new Producer(track, props);
+
+	const records = async () => {
+		const out: Record[] = [];
+		for (;;) {
+			const record = await consumer.next();
+			if (!record) return out;
+			out.push(record);
+		}
+	};
+	return { timeline, records };
 }
 
-test("auto-cut paces on video keyframes and waits for every track", () => {
-	const { segmenter, records } = capture();
-	const video = segmenter.track("video0", "video");
-	const audio = segmenter.track("audio0", "audio");
+// The coarsest track paces: video GOPs are longer than durationMin, so segments are GOPs.
+test("the coarsest track paces the segments", async () => {
+	const { timeline, records } = capture();
+	const video = timeline.track("video0");
+	const audio = timeline.track("audio0");
 
-	// Video keyframes every 2s (the default durationMax), audio groups every 500ms.
+	// Video keyframes every 2s, audio groups every 500ms, minimum 1s.
 	video.record(0, us(0));
 	for (const [seq, ms] of [
 		[0, 0],
@@ -28,241 +44,186 @@ test("auto-cut paces on video keyframes and waits for every track", () => {
 		audio.record(seq, us(ms));
 	}
 	video.record(1, us(2000));
-	expect(records).toHaveLength(0); // audio hasn't crossed the boundary yet
-	audio.record(4, us(2000));
+	for (const [seq, ms] of [
+		[4, 2000],
+		[5, 2500],
+		[6, 3000],
+		[7, 3500],
+	] as const) {
+		audio.record(seq, us(ms));
+	}
+	video.record(2, us(4000));
+	audio.record(8, us(4000));
+	video.close();
+	audio.close();
+	timeline.finish();
 
-	// Segment 0 is complete on both tracks: self-contained, with explicit duration and
-	// inclusive group ranges per track.
-	expect(records).toEqual([
+	// Audio's own candidate (1s) loses to video's (2s), so no segment splits a GOP.
+	expect(await records()).toEqual([
 		{
 			segment: 0,
 			pts: 0,
 			duration: 2000,
 			tracks: { video0: [{ start: 0, end: 0 }], audio0: [{ start: 0, end: 3 }] },
 		},
-	]);
-
-	video.close();
-	audio.close();
-	segmenter.finish();
-	expect(records).toHaveLength(2);
-	expect(records[1]).toEqual({
-		segment: 1,
-		pts: 2000,
-		duration: 0,
-		tracks: { video0: [{ start: 1, end: 1 }], audio0: [{ start: 4, end: 4 }] },
-	});
-});
-
-test("auto-cut enforces the declared bound with misaligned keyframes", () => {
-	const { segmenter, records } = capture();
-	const video = segmenter.track("video0", "video");
-
-	// Keyframes every 900ms against the default 2s bound: when the next keyframe would
-	// overrun, the segment closes retroactively at the previous one, so no segment exceeds
-	// the declared bound.
-	for (const [seq, ms] of [
-		[0, 0],
-		[1, 900],
-		[2, 1800],
-		[3, 2700],
-		[4, 3600],
-		[5, 4500],
-	] as const) {
-		video.record(seq, us(ms));
-	}
-	video.close();
-	segmenter.finish();
-
-	expect(records).toEqual([
-		{ segment: 0, pts: 0, duration: 1800, tracks: { video0: [{ start: 0, end: 1 }] } },
-		{ segment: 1, pts: 1800, duration: 1800, tracks: { video0: [{ start: 2, end: 3 }] } },
-		{ segment: 2, pts: 3600, duration: 900, tracks: { video0: [{ start: 4, end: 5 }] } },
-	]);
-});
-
-test("a GOP longer than the bound overruns honestly", () => {
-	const { segmenter, records } = capture();
-	const video = segmenter.track("video0", "video");
-
-	video.record(0, us(0));
-	video.record(1, us(5000));
-	video.record(2, us(7000));
-	video.close();
-	segmenter.finish();
-
-	expect(records).toEqual([
-		{ segment: 0, pts: 0, duration: 5000, tracks: { video0: [{ start: 0, end: 0 }] } },
-		{ segment: 1, pts: 5000, duration: 2000, tracks: { video0: [{ start: 1, end: 1 }] } },
-		{ segment: 2, pts: 7000, duration: 0, tracks: { video0: [{ start: 2, end: 2 }] } },
-	]);
-});
-
-test("the declared bound is exposed for the catalog section", () => {
-	expect(new Segmenter().durationMax).toBe(2000);
-	expect(new Segmenter({ durationMax: 6000 }).durationMax).toBe(6000);
-	// Fractional milliseconds round up: an advertised bound must never understate.
-	expect(new Segmenter({ durationMax: 1000.5 }).durationMax).toBe(1001);
-});
-
-test("explicit cuts disable auto-cut and pack multiple GOPs per segment", () => {
-	const { segmenter, records } = capture();
-	const video = segmenter.track("video0", "video");
-
-	segmenter.cut(us(0));
-	segmenter.cut(us(6000));
-	for (const [seq, ms] of [
-		[0, 0],
-		[1, 2000],
-		[2, 4000],
-		[3, 6000],
-	] as const) {
-		video.record(seq, us(ms));
-	}
-
-	// Auto-cut (2s) must not fire between the explicit cuts: one 6s segment of three GOPs.
-	expect(records).toEqual([{ segment: 0, pts: 0, duration: 6000, tracks: { video0: [{ start: 0, end: 2 }] } }]);
-});
-
-test("audio-only paces itself at durationMax", () => {
-	const { segmenter, records } = capture();
-	const audio = segmenter.track("audio0", "audio");
-
-	for (const [seq, ms] of [
-		[0, 0],
-		[1, 500],
-		[2, 1000],
-		[3, 1500],
-		[4, 2000],
-	] as const) {
-		audio.record(seq, us(ms));
-	}
-
-	expect(records).toEqual([{ segment: 0, pts: 0, duration: 2000, tracks: { audio0: [{ start: 0, end: 3 }] } }]);
-});
-
-test("sequence gaps split ranges", () => {
-	const { segmenter, records } = capture();
-	const video = segmenter.track("video0", "video");
-	const audio = segmenter.track("audio0", "audio");
-
-	// Audio groups 2..=4 never existed inside segment 0 (a gappy source).
-	video.record(0, us(0));
-	audio.record(0, us(0));
-	audio.record(1, us(300));
-	audio.record(5, us(1500));
-	video.record(1, us(2000));
-	audio.record(6, us(2100));
-
-	expect(records[0]?.tracks?.audio0).toEqual([
-		{ start: 0, end: 1 },
-		{ start: 5, end: 5 },
-	]);
-});
-
-test("a whole-segment gap omits the track", () => {
-	const { segmenter, records } = capture();
-	const video = segmenter.track("video0", "video");
-	const audio = segmenter.track("audio0", "audio");
-
-	video.record(0, us(0));
-	audio.record(0, us(0));
-	video.record(1, us(2000));
-	video.record(2, us(4000));
-	audio.record(1, us(4500));
-
-	expect(records).toHaveLength(2);
-	expect(records[1]).toEqual({ segment: 1, pts: 2000, duration: 2000, tracks: { video0: [{ start: 1, end: 1 }] } });
-});
-
-test("a non-keyframe range start is flagged", () => {
-	const { segmenter, records } = capture();
-	const video = segmenter.track("video0", "video");
-
-	segmenter.cut(us(0));
-	segmenter.cut(us(2000));
-	video.record(0, us(0), true);
-	// A gappy source resumes without an IDR.
-	video.record(1, us(2500), false);
-	video.record(2, us(4000), true);
-	video.close();
-	segmenter.finish();
-
-	expect(records[1]?.tracks?.video0).toEqual([{ start: 1, end: 2, keyframe: false }]);
-});
-
-test("a closed track stops gating completeness", () => {
-	const { segmenter, records } = capture();
-	const video = segmenter.track("video0", "video");
-	const audio = segmenter.track("audio0", "audio");
-
-	video.record(0, us(0));
-	audio.record(0, us(0));
-	video.record(1, us(2000));
-	video.record(2, us(4000));
-	expect(records).toHaveLength(0); // audio gates both segments
-
-	// Audio dies mid-broadcast: its close is what unblocks the flushes.
-	audio.close();
-	expect(records).toHaveLength(2);
-	expect(records[1]?.tracks).toEqual({ video0: [{ start: 1, end: 1 }] });
-});
-
-test("records flushed before a sink attaches are buffered", () => {
-	const segmenter = new Segmenter();
-	const audio = segmenter.track("audio0", "audio");
-	for (const [seq, ms] of [
-		[0, 0],
-		[1, 1000],
-		[2, 2000],
-		[3, 3000],
-		[4, 4000],
-	] as const) {
-		audio.record(seq, us(ms));
-	}
-
-	const records: Record[] = [];
-	segmenter.attach((record) => records.push(record));
-	expect(records).toHaveLength(2);
-	expect(records[0]).toEqual({ segment: 0, pts: 0, duration: 2000, tracks: { audio0: [{ start: 0, end: 1 }] } });
-});
-
-test("groups before the first boundary join the first segment", () => {
-	const { segmenter, records } = capture();
-	const video = segmenter.track("video0", "video");
-	const audio = segmenter.track("audio0", "audio");
-
-	// Audio races ahead of video's first keyframe (the startup race): its early groups belong
-	// to segment 0, not to nowhere.
-	audio.record(0, us(0));
-	video.record(0, us(30));
-	video.record(1, us(2030));
-	audio.record(1, us(2100));
-
-	expect(records).toEqual([
 		{
-			segment: 0,
-			pts: 30, // the boundary is video's first keyframe; audio's earlier group still joins
+			segment: 1,
+			pts: 2000,
 			duration: 2000,
-			tracks: { video0: [{ start: 0, end: 0 }], audio0: [{ start: 0, end: 0 }] },
+			tracks: { video0: [{ start: 1, end: 1 }], audio0: [{ start: 4, end: 7 }] },
+		},
+		{
+			segment: 2,
+			pts: 4000,
+			duration: 0,
+			tracks: { video0: [{ start: 2, end: 2 }], audio0: [{ start: 8, end: 8 }] },
 		},
 	]);
 });
 
+// A real-time encoder's GOP can dwarf the minimum. Nothing is violated: there is nowhere else
+// a segment could start and stay decodable, so the segment is simply long.
+test("a GOP longer than the minimum is one segment", async () => {
+	const { timeline, records } = capture();
+	const video = timeline.track("video0");
+
+	video.record(0, us(0));
+	video.record(1, us(30_000));
+	video.end(us(60_000));
+	video.close();
+	timeline.finish();
+
+	expect(await records()).toEqual([
+		{ segment: 0, pts: 0, duration: 30_000, tracks: { video0: [{ start: 0, end: 0 }] } },
+		{ segment: 1, pts: 30_000, duration: 30_000, tracks: { video0: [{ start: 1, end: 1 }] } },
+	]);
+});
+
+// Groups shorter than the minimum pack into one segment rather than each becoming one.
+test("short groups pack up to the minimum", async () => {
+	const { timeline, records } = capture({ durationMin: 1500 });
+	const audio = timeline.track("audio0");
+
+	for (let seq = 0; seq < 8; seq++) {
+		audio.record(seq, us(seq * 500));
+	}
+	audio.close();
+	timeline.finish();
+
+	const out = await records();
+	// The first group at or past 1500ms ends segment 0, so it holds groups 0..=2.
+	expect(out[0]).toEqual({ segment: 0, pts: 0, duration: 1500, tracks: { audio0: [{ start: 0, end: 2 }] } });
+	expect(out[1]).toEqual({ segment: 1, pts: 1500, duration: 1500, tracks: { audio0: [{ start: 3, end: 5 }] } });
+});
+
+// A track that hasn't reached the minimum yet holds the segment open, so a record never omits
+// a rendition that was about to contribute to it.
+test("a segment waits for every track", async () => {
+	const { timeline, records } = capture();
+	const video = timeline.track("video0");
+	const audio = timeline.track("audio0");
+
+	video.record(0, us(0));
+	audio.record(0, us(0));
+	// Video alone would close segment 0 here, but audio hasn't crossed 2s.
+	video.record(1, us(2000));
+	audio.record(1, us(2000));
+	video.close();
+	audio.close();
+	timeline.finish();
+
+	const out = await records();
+	expect(out[0]).toEqual({
+		segment: 0,
+		pts: 0,
+		duration: 2000,
+		tracks: { video0: [{ start: 0, end: 0 }], audio0: [{ start: 0, end: 0 }] },
+	});
+});
+
+// An application that knows its own boundaries overrides the pacing.
+test("explicit cuts override the pacing", async () => {
+	const { timeline, records } = capture();
+	const video = timeline.track("video0");
+
+	// Keyframes every second, cut every three: the segments follow the cuts, not the GOPs.
+	timeline.cut(us(3000));
+	timeline.cut(us(6000));
+	for (let seq = 0; seq < 7; seq++) {
+		video.record(seq, us(seq * 1000));
+	}
+	video.close();
+	timeline.finish();
+
+	const out = await records();
+	expect(out[0]).toEqual({ segment: 0, pts: 0, duration: 3000, tracks: { video0: [{ start: 0, end: 2 }] } });
+	expect(out[1]).toEqual({ segment: 1, pts: 3000, duration: 3000, tracks: { video0: [{ start: 3, end: 5 }] } });
+});
+
+// Every rendition of one import declares the same boundaries, so a cut that would make a
+// segment shorter than the minimum is dropped rather than producing a stray segment.
+test("a cut below the minimum is ignored", async () => {
+	const { timeline, records } = capture();
+	const video = timeline.track("video0");
+
+	video.record(0, us(0));
+	timeline.cut(us(2000));
+	// A sibling rendition's duplicate, and a boundary too close to be a segment.
+	timeline.cut(us(2000));
+	timeline.cut(us(2500));
+	timeline.cut(us(4000));
+	video.record(1, us(2000));
+	video.record(2, us(4000));
+	video.close();
+	timeline.finish();
+
+	const out = await records();
+	expect(out).toHaveLength(3);
+	expect(out[0]).toEqual({ segment: 0, pts: 0, duration: 2000, tracks: { video0: [{ start: 0, end: 0 }] } });
+	expect(out[1]).toEqual({ segment: 1, pts: 2000, duration: 2000, tracks: { video0: [{ start: 1, end: 1 }] } });
+});
+
+// The declared maximum is a contract with consumers (an HLS EXT-X-TARGETDURATION), so a
+// segment that breaks it fails the timeline rather than publishing a record that contradicts
+// the catalog.
+test("exceeding the declared maximum fails the timeline", async () => {
+	const { timeline, records } = capture({ durationMin: 1000, durationMax: 3000 });
+	const video = timeline.track("video0");
+
+	video.record(0, us(0));
+	video.record(1, us(2000));
+	// A 4s GOP against a declared 3s maximum.
+	video.record(2, us(6000));
+	video.close();
+
+	expect(() => timeline.finish()).toThrow(/over the declared maximum/);
+
+	// The record that was still true published; the one that would have contradicted the
+	// catalog did not.
+	expect(await records()).toEqual([
+		{ segment: 0, pts: 0, duration: 2000, tracks: { video0: [{ start: 0, end: 0 }] } },
+	]);
+});
+
+test("an undeclared maximum is omitted from the catalog", () => {
+	expect(capture().timeline.section().durationMax).toBeUndefined();
+	expect(capture({ durationMax: 2500 }).timeline.section().durationMax).toBe(u53(2500));
+});
+
 // The last group of a broadcast has no successor to bound it, so without a reported end the
 // final segment's duration collapses to zero (an HLS EXTINF:0).
-test("the final segment runs to the reported end", () => {
-	const { segmenter, records } = capture();
-	const video = segmenter.track("video0", "video");
+test("the final segment runs to the reported end", async () => {
+	const { timeline, records } = capture();
+	const video = timeline.track("video0");
 
 	video.record(0, us(0));
 	video.record(1, us(2000));
 	// A closing container producer reports where its content stops.
 	video.end(us(4000));
 	video.close();
-	segmenter.finish();
+	timeline.finish();
 
-	expect(records).toEqual([
+	expect(await records()).toEqual([
 		{ segment: 0, pts: 0, duration: 2000, tracks: { video0: [{ start: 0, end: 0 }] } },
 		{ segment: 1, pts: 2000, duration: 2000, tracks: { video0: [{ start: 1, end: 1 }] } },
 	]);
@@ -270,12 +231,12 @@ test("the final segment runs to the reported end", () => {
 
 // A record is immutable and judged against the tracks enrolled when it flushes, so a producer
 // that enrolls its tracks one batch at a time holds flushing back until they are all in.
-test("a hold defers flushing until every track enrolls", () => {
-	const { segmenter, records } = capture();
-	const release = segmenter.hold();
+test("a hold defers flushing until every track enrolls", async () => {
+	const { timeline, records } = capture();
+	const release = timeline.hold();
 
 	// The primary rendition runs a whole batch of segments through before its sibling exists.
-	const first = segmenter.track("video0", "video");
+	const first = timeline.track("video0");
 	for (const [seq, ms] of [
 		[0, 0],
 		[1, 2000],
@@ -284,7 +245,7 @@ test("a hold defers flushing until every track enrolls", () => {
 		first.record(seq, us(ms));
 	}
 
-	const second = segmenter.track("video1", "video");
+	const second = timeline.track("video1");
 	for (const [seq, ms] of [
 		[0, 0],
 		[1, 2000],
@@ -293,24 +254,123 @@ test("a hold defers flushing until every track enrolls", () => {
 		second.record(seq, us(ms));
 	}
 
-	expect(records).toHaveLength(0);
 	release();
+	first.close();
+	second.close();
+	timeline.finish();
 
 	// Both renditions are indexed from segment 0. Without the hold, segments 0 and 1 would have
 	// flushed knowing only video0, and video1's first two groups would have folded into
 	// segment 2.
-	expect(records).toEqual([
-		{
-			segment: 0,
-			pts: 0,
-			duration: 2000,
-			tracks: { video0: [{ start: 0, end: 0 }], video1: [{ start: 0, end: 0 }] },
+	const out = await records();
+	expect(out[0]).toEqual({
+		segment: 0,
+		pts: 0,
+		duration: 2000,
+		tracks: { video0: [{ start: 0, end: 0 }], video1: [{ start: 0, end: 0 }] },
+	});
+	expect(out[1]).toEqual({
+		segment: 1,
+		pts: 2000,
+		duration: 2000,
+		tracks: { video0: [{ start: 1, end: 1 }], video1: [{ start: 1, end: 1 }] },
+	});
+});
+
+// A track that races ahead of the others still lands in the segment its content falls in.
+test("groups before the first boundary join the first segment", async () => {
+	const { timeline, records } = capture();
+	const video = timeline.track("video0");
+	const audio = timeline.track("audio0");
+
+	audio.record(0, us(0));
+	video.record(0, us(30));
+	for (const [seq, ms] of [
+		[1, 500],
+		[2, 1000],
+		[3, 1500],
+		[4, 2000],
+	] as const) {
+		audio.record(seq, us(ms));
+	}
+	video.record(1, us(2030));
+	audio.record(5, us(2500));
+	video.close();
+	audio.close();
+	timeline.finish();
+
+	const out = await records();
+	expect(out[0]).toEqual({
+		// The segment starts where the earliest content does, not at video's first keyframe.
+		segment: 0,
+		pts: 0,
+		duration: 2030,
+		tracks: { video0: [{ start: 0, end: 0 }], audio0: [{ start: 0, end: 4 }] },
+	});
+});
+
+test("sequence gaps split ranges", async () => {
+	const { timeline, records } = capture();
+	const video = timeline.track("video0");
+	const audio = timeline.track("audio0");
+
+	// Elemental-style gap: audio groups 2..=4 never existed inside segment 0.
+	video.record(0, us(0));
+	audio.record(0, us(0));
+	audio.record(1, us(300));
+	audio.record(5, us(1500));
+	video.record(1, us(2000));
+	audio.record(6, us(2100));
+	video.close();
+	audio.close();
+	timeline.finish();
+
+	const out = await records();
+	expect(out[0]).toEqual({
+		segment: 0,
+		pts: 0,
+		duration: 2000,
+		tracks: {
+			video0: [{ start: 0, end: 0 }],
+			audio0: [
+				{ start: 0, end: 1 },
+				{ start: 5, end: 5 },
+			],
 		},
-		{
-			segment: 1,
-			pts: 2000,
-			duration: 2000,
-			tracks: { video0: [{ start: 1, end: 1 }], video1: [{ start: 1, end: 1 }] },
-		},
-	]);
+	});
+});
+
+// A track with nothing to contribute is a whole-segment gap: the record simply omits it (an
+// HLS exporter renders EXT-X-GAP). Only a closed track produces one, since a live track that
+// has merely gone quiet still gets to say where the boundary is.
+test("a closed track leaves a whole segment gap", async () => {
+	const { timeline, records } = capture();
+	const video = timeline.track("video0");
+	const audio = timeline.track("audio0");
+
+	video.record(0, us(0));
+	audio.record(0, us(0));
+	audio.close();
+	video.record(1, us(2000));
+	video.record(2, us(4000));
+	video.close();
+	timeline.finish();
+
+	const out = await records();
+	expect(out[1]).toEqual({ segment: 1, pts: 2000, duration: 2000, tracks: { video0: [{ start: 1, end: 1 }] } });
+});
+
+test("a non-keyframe range start is flagged", async () => {
+	const { timeline, records } = capture();
+	const video = timeline.track("video0");
+
+	video.record(0, us(0));
+	// A mid-stream join: the group doesn't open on an IDR.
+	video.record(1, us(2000), false);
+	video.record(2, us(4000));
+	video.close();
+	timeline.finish();
+
+	const out = await records();
+	expect(out[1]?.tracks?.video0[0].keyframe).toBe(false);
 });

--- a/js/hang/src/container/timeline.test.ts
+++ b/js/hang/src/container/timeline.test.ts
@@ -248,3 +248,69 @@ test("groups before the first boundary join the first segment", () => {
 		},
 	]);
 });
+
+// The last group of a broadcast has no successor to bound it, so without a reported end the
+// final segment's duration collapses to zero (an HLS EXTINF:0).
+test("the final segment runs to the reported end", () => {
+	const { segmenter, records } = capture();
+	const video = segmenter.track("video0", "video");
+
+	video.record(0, us(0));
+	video.record(1, us(2000));
+	// A closing container producer reports where its content stops.
+	video.end(us(4000));
+	video.close();
+	segmenter.finish();
+
+	expect(records).toEqual([
+		{ segment: 0, pts: 0, duration: 2000, tracks: { video0: [{ start: 0, end: 0 }] } },
+		{ segment: 1, pts: 2000, duration: 2000, tracks: { video0: [{ start: 1, end: 1 }] } },
+	]);
+});
+
+// A record is immutable and judged against the tracks enrolled when it flushes, so a producer
+// that enrolls its tracks one batch at a time holds flushing back until they are all in.
+test("a hold defers flushing until every track enrolls", () => {
+	const { segmenter, records } = capture();
+	const release = segmenter.hold();
+
+	// The primary rendition runs a whole batch of segments through before its sibling exists.
+	const first = segmenter.track("video0", "video");
+	for (const [seq, ms] of [
+		[0, 0],
+		[1, 2000],
+		[2, 4000],
+	] as const) {
+		first.record(seq, us(ms));
+	}
+
+	const second = segmenter.track("video1", "video");
+	for (const [seq, ms] of [
+		[0, 0],
+		[1, 2000],
+		[2, 4000],
+	] as const) {
+		second.record(seq, us(ms));
+	}
+
+	expect(records).toHaveLength(0);
+	release();
+
+	// Both renditions are indexed from segment 0. Without the hold, segments 0 and 1 would have
+	// flushed knowing only video0, and video1's first two groups would have folded into
+	// segment 2.
+	expect(records).toEqual([
+		{
+			segment: 0,
+			pts: 0,
+			duration: 2000,
+			tracks: { video0: [{ start: 0, end: 0 }], video1: [{ start: 0, end: 0 }] },
+		},
+		{
+			segment: 1,
+			pts: 2000,
+			duration: 2000,
+			tracks: { video0: [{ start: 1, end: 1 }], video1: [{ start: 1, end: 1 }] },
+		},
+	]);
+});

--- a/js/hang/src/container/timeline.test.ts
+++ b/js/hang/src/container/timeline.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test";
 import * as Json from "@moq/json";
 import type { Time } from "@moq/net";
 import { Track } from "@moq/net";
-import { u53 } from "../catalog";
+import { MOQ_EPOCH_UNIX_MILLIS, u53 } from "../catalog";
 import { Producer, type Record } from "./timeline.ts";
 
 const us = (ms: number): Time.Micro => (ms * 1000) as Time.Micro;
@@ -373,4 +373,65 @@ test("a non-keyframe range start is flagged", async () => {
 
 	const out = await records();
 	expect(out[1]?.tracks?.video0[0].keyframe).toBe(false);
+});
+
+test("the wall-clock anchor is advertised from the config", () => {
+	expect(capture().timeline.section().wall).toBeUndefined();
+
+	// The wire counts from the moq epoch, so pts 0 at exactly the epoch advertises 0.
+	const epoch = new Date(MOQ_EPOCH_UNIX_MILLIS);
+	expect(capture({ wall: epoch }).timeline.section().wall).toBe(u53(0));
+	expect(capture({ wall: new Date(MOQ_EPOCH_UNIX_MILLIS + 1000) }).timeline.section().wall).toBe(u53(1000));
+
+	// A time before the epoch isn't representable, so it clamps rather than going negative.
+	expect(capture({ wall: new Date(0) }).timeline.section().wall).toBe(u53(0));
+});
+
+// Producers that each guard their own batch nest, so the first to finish doesn't publish
+// records the others are still filling in.
+test("holds nest", async () => {
+	const { timeline, records } = capture();
+
+	const outer = timeline.hold();
+	const inner = timeline.hold();
+
+	const first = timeline.track("video0");
+	for (const [seq, ms] of [
+		[0, 0],
+		[1, 2000],
+		[2, 4000],
+	] as const) {
+		first.record(seq, us(ms));
+	}
+
+	// If the holds didn't nest, releasing this one would publish segment 0 without video1.
+	inner();
+
+	const second = timeline.track("video1");
+	for (const [seq, ms] of [
+		[0, 0],
+		[1, 2000],
+		[2, 4000],
+	] as const) {
+		second.record(seq, us(ms));
+	}
+
+	outer();
+	first.close();
+	second.close();
+	timeline.finish();
+
+	const out = await records();
+	expect(out[0]).toEqual({
+		segment: 0,
+		pts: 0,
+		duration: 2000,
+		tracks: { video0: [{ start: 0, end: 0 }], video1: [{ start: 0, end: 0 }] },
+	});
+	expect(out[1]).toEqual({
+		segment: 1,
+		pts: 2000,
+		duration: 2000,
+		tracks: { video0: [{ start: 1, end: 1 }], video1: [{ start: 1, end: 1 }] },
+	});
 });

--- a/js/hang/src/container/timeline.test.ts
+++ b/js/hang/src/container/timeline.test.ts
@@ -54,6 +54,57 @@ test("auto-cut paces on video keyframes and waits for every track", () => {
 	});
 });
 
+test("auto-cut enforces the declared bound with misaligned keyframes", () => {
+	const { segmenter, records } = capture();
+	const video = segmenter.track("video0", "video");
+
+	// Keyframes every 900ms against the default 2s bound: when the next keyframe would
+	// overrun, the segment closes retroactively at the previous one, so no segment exceeds
+	// the declared bound.
+	for (const [seq, ms] of [
+		[0, 0],
+		[1, 900],
+		[2, 1800],
+		[3, 2700],
+		[4, 3600],
+		[5, 4500],
+	] as const) {
+		video.record(seq, us(ms));
+	}
+	video.close();
+	segmenter.finish();
+
+	expect(records).toEqual([
+		{ segment: 0, pts: 0, duration: 1800, tracks: { video0: [{ start: 0, end: 1 }] } },
+		{ segment: 1, pts: 1800, duration: 1800, tracks: { video0: [{ start: 2, end: 3 }] } },
+		{ segment: 2, pts: 3600, duration: 900, tracks: { video0: [{ start: 4, end: 5 }] } },
+	]);
+});
+
+test("a GOP longer than the bound overruns honestly", () => {
+	const { segmenter, records } = capture();
+	const video = segmenter.track("video0", "video");
+
+	video.record(0, us(0));
+	video.record(1, us(5000));
+	video.record(2, us(7000));
+	video.close();
+	segmenter.finish();
+
+	expect(records).toEqual([
+		{ segment: 0, pts: 0, duration: 5000, tracks: { video0: [{ start: 0, end: 0 }] } },
+		{ segment: 1, pts: 5000, duration: 2000, tracks: { video0: [{ start: 1, end: 1 }] } },
+		{ segment: 2, pts: 7000, duration: 0, tracks: { video0: [{ start: 2, end: 2 }] } },
+	]);
+});
+
+test("the declared bound is exposed for the catalog section", () => {
+	expect(new Segmenter().durationMax).toBe(2000);
+	expect(new Segmenter({ durationMax: 6000 }).durationMax).toBe(6000);
+	// Fractional milliseconds round up: an advertised bound must never understate.
+	expect(new Segmenter({ durationMax: 1000.5 }).durationMax).toBe(1001);
+});
+
 test("explicit cuts disable auto-cut and pack multiple GOPs per segment", () => {
 	const { segmenter, records } = capture();
 	const video = segmenter.track("video0", "video");

--- a/js/hang/src/container/timeline.test.ts
+++ b/js/hang/src/container/timeline.test.ts
@@ -1,69 +1,199 @@
 import { expect, test } from "bun:test";
 import type { Time } from "@moq/net";
-import { Segmenter } from "./timeline.ts";
+import { type Record, Segmenter } from "./timeline.ts";
 
 const us = (ms: number): Time.Micro => (ms * 1000) as Time.Micro;
 
-test("boundary opens a segment per group", () => {
+/** A segmenter whose flushed records are captured into the returned array. */
+function capture(): { segmenter: Segmenter; records: Record[] } {
 	const segmenter = new Segmenter();
-	expect(segmenter.boundary(us(0))).toBe(0);
-	expect(segmenter.boundary(us(2000))).toBe(1);
-	expect(segmenter.boundary(us(4000))).toBe(2);
+	const records: Record[] = [];
+	segmenter.attach((record) => records.push(record));
+	return { segmenter, records };
+}
+
+test("auto-cut paces on video keyframes and waits for every track", () => {
+	const { segmenter, records } = capture();
+	const video = segmenter.track("video0", "video");
+	const audio = segmenter.track("audio0", "audio");
+
+	// Video keyframes every 2s (the default durationMax), audio groups every 500ms.
+	video.record(0, us(0));
+	for (const [seq, ms] of [
+		[0, 0],
+		[1, 500],
+		[2, 1000],
+		[3, 1500],
+	] as const) {
+		audio.record(seq, us(ms));
+	}
+	video.record(1, us(2000));
+	expect(records).toHaveLength(0); // audio hasn't crossed the boundary yet
+	audio.record(4, us(2000));
+
+	// Segment 0 is complete on both tracks: self-contained, with explicit duration and
+	// inclusive group ranges per track.
+	expect(records).toEqual([
+		{
+			segment: 0,
+			pts: 0,
+			duration: 2000,
+			tracks: { video0: [{ start: 0, end: 0 }], audio0: [{ start: 0, end: 3 }] },
+		},
+	]);
+
+	video.close();
+	audio.close();
+	segmenter.finish();
+	expect(records).toHaveLength(2);
+	expect(records[1]).toEqual({
+		segment: 1,
+		pts: 2000,
+		duration: 0,
+		tracks: { video0: [{ start: 1, end: 1 }], audio0: [{ start: 4, end: 4 }] },
+	});
 });
 
-test("aligned records the first group at each boundary", () => {
-	const segmenter = new Segmenter();
-	let last: number | undefined;
-	const align = (ms: number): number | undefined => {
-		const segment = segmenter.align(us(ms), last);
-		if (segment !== undefined) last = segment;
-		return segment;
-	};
+test("explicit cuts disable auto-cut and pack multiple GOPs per segment", () => {
+	const { segmenter, records } = capture();
+	const video = segmenter.track("video0", "video");
 
-	expect(segmenter.boundary(us(0))).toBe(0);
-	expect(align(0)).toBe(0);
-	// Groups inside the segment extend it (no record).
-	expect(align(300)).toBeUndefined();
-	expect(align(600)).toBeUndefined();
+	segmenter.cut(us(0));
+	segmenter.cut(us(6000));
+	for (const [seq, ms] of [
+		[0, 0],
+		[1, 2000],
+		[2, 4000],
+		[3, 6000],
+	] as const) {
+		video.record(seq, us(ms));
+	}
 
-	expect(segmenter.boundary(us(2000))).toBe(1);
-	// The first group at/after the boundary starts the track's slice of segment 1.
-	expect(align(2100)).toBe(1);
-	expect(align(2400)).toBeUndefined();
+	// Auto-cut (2s) must not fire between the explicit cuts: one 6s segment of three GOPs.
+	expect(records).toEqual([{ segment: 0, pts: 0, duration: 6000, tracks: { video0: [{ start: 0, end: 2 }] } }]);
 });
 
-test("undriven aligned producer paces itself at the interval", () => {
-	const segmenter = new Segmenter();
-	let last: number | undefined;
-	const align = (ms: number): number | undefined => {
-		const segment = segmenter.align(us(ms), last);
-		if (segment !== undefined) last = segment;
-		return segment;
-	};
+test("audio-only paces itself at durationMax", () => {
+	const { segmenter, records } = capture();
+	const audio = segmenter.track("audio0", "audio");
 
-	// No boundary track: the default 1s interval paces the segments.
-	expect(align(0)).toBe(0);
-	expect(align(300)).toBeUndefined();
-	expect(align(900)).toBeUndefined();
-	expect(align(1200)).toBe(1);
+	for (const [seq, ms] of [
+		[0, 0],
+		[1, 500],
+		[2, 1000],
+		[3, 1500],
+		[4, 2000],
+	] as const) {
+		audio.record(seq, us(ms));
+	}
+
+	expect(records).toEqual([{ segment: 0, pts: 0, duration: 2000, tracks: { audio0: [{ start: 0, end: 3 }] } }]);
 });
 
-test("first boundary adopts a self-opened segment", () => {
-	const segmenter = new Segmenter();
+test("sequence gaps split ranges", () => {
+	const { segmenter, records } = capture();
+	const video = segmenter.track("video0", "video");
+	const audio = segmenter.track("audio0", "audio");
 
-	// Audio starts first and self-opens segment 0; the video keyframe arriving moments later
-	// adopts it (same number) instead of stranding an audio-only segment 0, then paces on.
-	expect(segmenter.align(us(0), undefined)).toBe(0);
-	expect(segmenter.boundary(us(30))).toBe(0);
-	expect(segmenter.boundary(us(2030))).toBe(1);
-	expect(segmenter.align(us(2100), 0)).toBe(1);
+	// Audio groups 2..=4 never existed inside segment 0 (a gappy source).
+	video.record(0, us(0));
+	audio.record(0, us(0));
+	audio.record(1, us(300));
+	audio.record(5, us(1500));
+	video.record(1, us(2000));
+	audio.record(6, us(2100));
+
+	expect(records[0]?.tracks?.audio0).toEqual([
+		{ start: 0, end: 1 },
+		{ start: 5, end: 5 },
+	]);
 });
 
-test("aligned producer joining late records the current segment", () => {
-	const segmenter = new Segmenter();
-	segmenter.boundary(us(0));
-	segmenter.boundary(us(2000));
+test("a whole-segment gap omits the track", () => {
+	const { segmenter, records } = capture();
+	const video = segmenter.track("video0", "video");
+	const audio = segmenter.track("audio0", "audio");
 
-	// An audio track added mid-broadcast: its first group lands in segment 1, not 0.
-	expect(segmenter.align(us(2050), undefined)).toBe(1);
+	video.record(0, us(0));
+	audio.record(0, us(0));
+	video.record(1, us(2000));
+	video.record(2, us(4000));
+	audio.record(1, us(4500));
+
+	expect(records).toHaveLength(2);
+	expect(records[1]).toEqual({ segment: 1, pts: 2000, duration: 2000, tracks: { video0: [{ start: 1, end: 1 }] } });
+});
+
+test("a non-keyframe range start is flagged", () => {
+	const { segmenter, records } = capture();
+	const video = segmenter.track("video0", "video");
+
+	segmenter.cut(us(0));
+	segmenter.cut(us(2000));
+	video.record(0, us(0), true);
+	// A gappy source resumes without an IDR.
+	video.record(1, us(2500), false);
+	video.record(2, us(4000), true);
+	video.close();
+	segmenter.finish();
+
+	expect(records[1]?.tracks?.video0).toEqual([{ start: 1, end: 2, keyframe: false }]);
+});
+
+test("a closed track stops gating completeness", () => {
+	const { segmenter, records } = capture();
+	const video = segmenter.track("video0", "video");
+	const audio = segmenter.track("audio0", "audio");
+
+	video.record(0, us(0));
+	audio.record(0, us(0));
+	video.record(1, us(2000));
+	video.record(2, us(4000));
+	expect(records).toHaveLength(0); // audio gates both segments
+
+	// Audio dies mid-broadcast: its close is what unblocks the flushes.
+	audio.close();
+	expect(records).toHaveLength(2);
+	expect(records[1]?.tracks).toEqual({ video0: [{ start: 1, end: 1 }] });
+});
+
+test("records flushed before a sink attaches are buffered", () => {
+	const segmenter = new Segmenter();
+	const audio = segmenter.track("audio0", "audio");
+	for (const [seq, ms] of [
+		[0, 0],
+		[1, 1000],
+		[2, 2000],
+		[3, 3000],
+		[4, 4000],
+	] as const) {
+		audio.record(seq, us(ms));
+	}
+
+	const records: Record[] = [];
+	segmenter.attach((record) => records.push(record));
+	expect(records).toHaveLength(2);
+	expect(records[0]).toEqual({ segment: 0, pts: 0, duration: 2000, tracks: { audio0: [{ start: 0, end: 1 }] } });
+});
+
+test("groups before the first boundary join the first segment", () => {
+	const { segmenter, records } = capture();
+	const video = segmenter.track("video0", "video");
+	const audio = segmenter.track("audio0", "audio");
+
+	// Audio races ahead of video's first keyframe (the startup race): its early groups belong
+	// to segment 0, not to nowhere.
+	audio.record(0, us(0));
+	video.record(0, us(30));
+	video.record(1, us(2030));
+	audio.record(1, us(2100));
+
+	expect(records).toEqual([
+		{
+			segment: 0,
+			pts: 30, // the boundary is video's first keyframe; audio's earlier group still joins
+			duration: 2000,
+			tracks: { video0: [{ start: 0, end: 0 }], audio0: [{ start: 0, end: 0 }] },
+		},
+	]);
 });

--- a/js/hang/src/container/timeline.test.ts
+++ b/js/hang/src/container/timeline.test.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "bun:test";
+import type { Time } from "@moq/net";
+import { Segmenter } from "./timeline.ts";
+
+const us = (ms: number): Time.Micro => (ms * 1000) as Time.Micro;
+
+test("boundary opens a segment per group", () => {
+	const segmenter = new Segmenter();
+	expect(segmenter.boundary(us(0))).toBe(0);
+	expect(segmenter.boundary(us(2000))).toBe(1);
+	expect(segmenter.boundary(us(4000))).toBe(2);
+});
+
+test("aligned records the first group at each boundary", () => {
+	const segmenter = new Segmenter();
+	let last: number | undefined;
+	const align = (ms: number): number | undefined => {
+		const segment = segmenter.align(us(ms), last);
+		if (segment !== undefined) last = segment;
+		return segment;
+	};
+
+	expect(segmenter.boundary(us(0))).toBe(0);
+	expect(align(0)).toBe(0);
+	// Groups inside the segment extend it (no record).
+	expect(align(300)).toBeUndefined();
+	expect(align(600)).toBeUndefined();
+
+	expect(segmenter.boundary(us(2000))).toBe(1);
+	// The first group at/after the boundary starts the track's slice of segment 1.
+	expect(align(2100)).toBe(1);
+	expect(align(2400)).toBeUndefined();
+});
+
+test("undriven aligned producer paces itself at the interval", () => {
+	const segmenter = new Segmenter();
+	let last: number | undefined;
+	const align = (ms: number): number | undefined => {
+		const segment = segmenter.align(us(ms), last);
+		if (segment !== undefined) last = segment;
+		return segment;
+	};
+
+	// No boundary track: the default 1s interval paces the segments.
+	expect(align(0)).toBe(0);
+	expect(align(300)).toBeUndefined();
+	expect(align(900)).toBeUndefined();
+	expect(align(1200)).toBe(1);
+});
+
+test("first boundary adopts a self-opened segment", () => {
+	const segmenter = new Segmenter();
+
+	// Audio starts first and self-opens segment 0; the video keyframe arriving moments later
+	// adopts it (same number) instead of stranding an audio-only segment 0, then paces on.
+	expect(segmenter.align(us(0), undefined)).toBe(0);
+	expect(segmenter.boundary(us(30))).toBe(0);
+	expect(segmenter.boundary(us(2030))).toBe(1);
+	expect(segmenter.align(us(2100), 0)).toBe(1);
+});
+
+test("aligned producer joining late records the current segment", () => {
+	const segmenter = new Segmenter();
+	segmenter.boundary(us(0));
+	segmenter.boundary(us(2000));
+
+	// An audio track added mid-broadcast: its first group lands in segment 1, not 0.
+	expect(segmenter.align(us(2050), undefined)).toBe(1);
+});

--- a/js/hang/src/container/timeline.ts
+++ b/js/hang/src/container/timeline.ts
@@ -92,6 +92,18 @@ export interface ProducerProps {
 	 * importing a source the publisher doesn't control.
 	 */
 	durationMax?: number;
+
+	/**
+	 * The wall-clock time of `pts` 0, advertised in the catalog when set.
+	 *
+	 * It anchors content time to an absolute clock, which is what an HLS
+	 * EXT-X-PROGRAM-DATE-TIME or a DASH availabilityStartTime needs: `new Date()` for a live
+	 * publisher whose timestamps start now, or the content's real start for a recording.
+	 *
+	 * Clamped to the moq epoch ({@link Catalog.MOQ_EPOCH_UNIX_MILLIS}, 2020), which the wire
+	 * format measures from: an earlier time isn't representable.
+	 */
+	wall?: Date;
 }
 
 /** One enrolled track's report state. */
@@ -137,6 +149,10 @@ export class Producer {
 		this.#trackName = track.name;
 		this.#durationMinUs = (props.durationMin ?? DEFAULT_DURATION_MIN_MS) * 1000;
 		this.#durationMaxUs = props.durationMax === undefined ? undefined : props.durationMax * 1000;
+		if (props.wall !== undefined) {
+			const unixMillis = Math.max(props.wall.getTime(), MOQ_EPOCH_UNIX_MILLIS);
+			this.#wall = Math.floor(((unixMillis - MOQ_EPOCH_UNIX_MILLIS) * DEFAULT_TIMESCALE) / 1000);
+		}
 		this.#stream = new Json.Stream.Producer<Record>(track, { compression: true });
 	}
 
@@ -208,24 +224,6 @@ export class Producer {
 			durationMax,
 			wall: this.#wall === undefined ? undefined : u53(this.#wall),
 		};
-	}
-
-	/**
-	 * Set (or replace) the wall-clock anchor advertised in the catalog section, from an observed
-	 * pairing of a media timestamp `pts` (microseconds) with its wall-clock time `wall` (defaulting
-	 * to now). Stored as the extrapolated wall-clock time of pts 0, the single value the catalog
-	 * `wall` field carries: in the timeline's timescale, measured from the moq epoch
-	 * ({@link Catalog.MOQ_EPOCH_UNIX_MILLIS}, 2020). Throws if `wall` predates the moq epoch
-	 * (unrepresentable).
-	 */
-	setWall(pts: Time.Micro, wall: Date = new Date()): void {
-		const unixMillis = wall.getTime();
-		if (unixMillis < MOQ_EPOCH_UNIX_MILLIS) {
-			throw new Error(`wall time ${unixMillis} predates the moq epoch ${MOQ_EPOCH_UNIX_MILLIS}`);
-		}
-		const ptsUnits = Math.floor((pts * DEFAULT_TIMESCALE) / 1_000_000);
-		const moqUnits = Math.floor(((unixMillis - MOQ_EPOCH_UNIX_MILLIS) * DEFAULT_TIMESCALE) / 1000);
-		this.#wall = Math.max(0, moqUnits - ptsUnits);
 	}
 
 	/**
@@ -335,16 +333,17 @@ export class Producer {
 
 		let end: Time.Micro | undefined;
 		for (const track of this.#tracks.values()) {
-			if (track.closed) continue;
 			const candidate = track.pending.find((group) => group.pts >= threshold)?.pts;
 			if (candidate === undefined) {
 				// This track has produced nothing past the minimum yet, so ending the segment
-				// would strand it. On the terminal pass it never will, so let it go.
-				if (finished) continue;
+				// would strand it. A closed track never will, and neither does anything on the
+				// terminal pass, so neither one blocks.
+				if (finished || track.closed) continue;
 				return undefined;
 			}
-			// The latest vote wins: it is a group boundary on the coarsest track, and every
-			// finer track assigns its groups by start, so no group is split.
+			// The latest vote wins: it is a group boundary on the coarsest track, and every finer
+			// track assigns its groups by start, so no group is split. A closed track still votes:
+			// it can't report more, but the groups it did report are boundaries like any other.
 			if (end === undefined || candidate > end) end = candidate;
 		}
 

--- a/js/hang/src/container/timeline.ts
+++ b/js/hang/src/container/timeline.ts
@@ -1,8 +1,15 @@
 /**
- * Publishing a media track's timeline: a companion track indexing the track's segments (one or
- * more groups each), so a consumer can seek (or build an HLS/DASH playlist) without downloading
- * the media. Segment numbers are aligned across a broadcast's tracks through a shared
- * {@link Segmenter}. See the catalog {@link Catalog.Timeline} section that advertises it.
+ * Publishing the broadcast's timeline: a single track carrying one record per aligned
+ * segment, mapping a span of content time to the group ranges that carry it on each media
+ * track. A consumer can seek (or build an HLS/DASH playlist) without downloading the media.
+ * See the catalog's root {@link Catalog.Timeline} section that advertises it.
+ *
+ * Facts flow up and policy flows down, meeting in the shared {@link Segmenter}: each media
+ * track enrolls with {@link Segmenter.track} and reports every group open through its
+ * {@link Recorder}; boundaries come from {@link Segmenter.cut} when the application knows
+ * them, or from auto-cut on the driver track's keyframes otherwise. A segment's record is
+ * published only once every enrolled track has reported past its end boundary (or closed), so
+ * records are self-contained and immediately servable.
  *
  * @module
  */
@@ -14,164 +21,362 @@ import type * as Catalog from "../catalog";
 import { MOQ_EPOCH_UNIX_MILLIS, u53 } from "../catalog";
 
 /**
- * One timeline record: segment `segment` of the media track starts at group `group`, at
- * presentation time `pts` (in the timeline's timescale). The segment covers every group up to
- * (excluding) the next record's `group`; segment numbers are aligned across the broadcast's
- * tracks.
+ * A contiguous run of groups a track contributes to a segment, `start` through `end`
+ * inclusive. More than one range in a segment means the group sequence is discontinuous (a
+ * gap: groups that never existed).
+ */
+export interface Range {
+	start: number;
+	end: number;
+	/**
+	 * Whether the run's first group starts with a keyframe, i.e. whether a player can join or
+	 * switch renditions at this range. Omitted when true (the default).
+	 */
+	keyframe?: boolean;
+}
+
+/**
+ * One timeline record: a complete aligned segment. `pts` and `duration` bound its span of
+ * content time (in the timeline's timescale), and `tracks` maps each participating media
+ * track to the group ranges that carry it. A track absent from `tracks` has no content for
+ * the span (a gap).
  */
 export interface Record {
 	segment: number;
-	group: number;
 	pts: number;
+	duration: number;
+	tracks?: { [track: string]: Range[] };
 }
 
 /** The default timeline timescale: 1000 units per second (milliseconds). */
 export const DEFAULT_TIMESCALE = 1000;
 
 /**
- * The default {@link Segmenter} interval: an undriven (audio-only) timeline opens a segment
- * about once per second of media time.
+ * The default {@link Segmenter} auto-cut threshold in milliseconds: with nobody cutting
+ * explicitly, a new segment starts at the first driver keyframe at least this far past the
+ * last boundary.
  */
-export const DEFAULT_INTERVAL_MS = 1000;
+export const DEFAULT_DURATION_MAX_MS = 2000;
 
 /**
- * The conventional companion timeline track name for a media rendition: `<rendition>.timeline.z`
- * (the `.z` marks the DEFLATE-compressed stream, like the catalog's `.json.z` sibling).
+ * The conventional name for a broadcast's timeline track (the `.z` marks the
+ * DEFLATE-compressed stream, like the catalog's `.json.z` sibling). The actual name is read
+ * from the catalog's root `timeline` section, so this is only a default.
  */
-export function trackName(rendition: string): string {
-	return `${rendition}.timeline.z`;
-}
+export const DEFAULT_NAME = "timeline.z";
 
 /**
- * How a track's groups map onto the broadcast's aligned segments.
- *
- * - `"boundary"`: every group opens the next segment (video: groups open on keyframes, and a
- *   segment must start on one, so a video segment is exactly one group). The boundary track
- *   paces the broadcast's segments; wire exactly one per {@link Segmenter}.
- * - `"aligned"`: groups pack into the segments the boundary track opens (audio: many short
- *   groups per segment). The first group at or after each boundary starts the track's slice of
- *   that segment. When no boundary track ever records, the recorder paces segments itself at
- *   the segmenter's interval, so an audio-only broadcast still segments.
+ * What a media track carries, declared when it enrolls via {@link Segmenter.track}. The
+ * segmenter prefers a video track as the auto-cut driver, since segment boundaries must land
+ * on video keyframes to keep every rendition independently decodable.
  */
-export type Cadence = "boundary" | "aligned";
+export type Kind = "video" | "audio";
 
 /** Options for a {@link Segmenter}. */
 export interface SegmenterProps {
 	/**
-	 * How often an *undriven* segmenter (no `"boundary"` producer, e.g. an audio-only
-	 * broadcast) opens a new segment, in milliseconds of media time. Ignored once a boundary
-	 * producer is pacing. Defaults to {@link DEFAULT_INTERVAL_MS}.
+	 * The auto-cut threshold in milliseconds of media time: a new segment starts at the first
+	 * driver keyframe at least this far past the last boundary. Irrelevant once
+	 * {@link Segmenter.cut} is used (explicit cuts disable auto-cut). Defaults to
+	 * {@link DEFAULT_DURATION_MAX_MS}.
 	 */
-	interval?: number;
+	durationMax?: number;
+}
+
+/** One enrolled track's report state. */
+interface TrackState {
+	kind: Kind;
+	// Group opens reported and not yet flushed into a record.
+	pending: { sequence: number; pts: Time.Micro; keyframe: boolean }[];
+	// The newest reported timestamp: everything earlier is known.
+	frontier?: Time.Micro;
+	closed: boolean;
 }
 
 /**
- * The broadcast-wide segment counter every timeline {@link Producer} shares, so segment numbers
- * align across tracks.
+ * The broadcast's segmenter: the shared boundary list every track's groups map onto.
  *
- * Create one per broadcast and pass it to each track's producer. The `"boundary"` producer
- * advances it; `"aligned"` producers read it, falling back to interval pacing only while no
- * boundary producer has spoken.
+ * One per broadcast. Media tracks enroll with {@link track} and report group opens through
+ * the returned {@link Recorder}; the application (or the auto-cut policy) declares boundaries
+ * with {@link cut}. Records flush once complete on every enrolled track, into the attached
+ * {@link Producer} (buffered until one attaches).
  */
 export class Segmenter {
-	// The open segment's number and boundary pts (microseconds), undefined before the first group.
-	#current?: { segment: number; boundary: Time.Micro };
-	// A "boundary" producer has opened a segment, so aligned producers never self-pace.
-	#driven = false;
-	// Undriven pacing interval in microseconds.
-	#intervalUs: number;
+	#durationMaxUs: number;
+	// An explicit cut() arrived: the application owns the boundaries; auto-cut stays off.
+	#manual = false;
+	// Boundaries of segments not yet flushed: boundaries[0] starts segment #nextSegment.
+	#boundaries: Time.Micro[] = [];
+	// The newest boundary ever created (never popped), the auto-cut reference point.
+	#lastBoundary?: Time.Micro;
+	#nextSegment = 0;
+	#tracks = new Map<string, TrackState>();
+	// The auto-cut driver: the first enrolled video track, else the first enrolled track.
+	#driver?: string;
+	// Where flushed records go once a Producer attaches; buffered until then.
+	#sink?: (record: Record) => void;
+	#buffered: Record[] = [];
 
 	constructor(props: SegmenterProps = {}) {
-		this.#intervalUs = (props.interval ?? DEFAULT_INTERVAL_MS) * 1000;
+		this.#durationMaxUs = (props.durationMax ?? DEFAULT_DURATION_MAX_MS) * 1000;
 	}
 
 	/**
-	 * A `"boundary"` group open at `pts`: open the next segment and return its number.
-	 *
-	 * The first boundary adopts a segment an aligned producer self-opened (rather than
-	 * stranding it as a number the boundary track never records), re-anchoring its boundary to
-	 * `pts`; from then on every call opens a new segment.
+	 * Declare a segment boundary at `pts` (microseconds): the segment before it ends, the one
+	 * after starts. For applications that know their boundaries (an imported playlist, on-disk
+	 * CMAF segments, an encoder placing keyframes). Cuts must be monotonic; an out-of-order one
+	 * is ignored. Cutting ahead of the media is fine: the record still waits for every track's
+	 * groups. The first explicit cut turns auto-cut off for good.
 	 */
-	boundary(pts: Time.Micro): number {
-		const segment =
-			this.#current === undefined ? 0 : this.#driven ? this.#current.segment + 1 : this.#current.segment;
-		this.#current = { segment, boundary: pts };
-		this.#driven = true;
-		return segment;
+	cut(pts: Time.Micro): void {
+		this.#manual = true;
+		this.#cutAt(pts);
+		this.#tryFlush(false);
 	}
 
 	/**
-	 * An `"aligned"` group open at `pts`, having last recorded `last`: the segment this group
-	 * starts for its track, or undefined if it merely extends the one already recorded.
+	 * Enroll the media track `name`, returning the {@link Recorder} it reports group opens
+	 * through. The segment records key ranges by this name, and the track gates segment
+	 * completeness until its recorder closes. Enroll a track when it is about to produce (an
+	 * enrolled but silent track holds every record back, by design). One recorder per track:
+	 * enrolling the same name again resets its state.
 	 */
-	align(pts: Time.Micro, last: number | undefined): number | undefined {
-		if (this.#current === undefined) {
-			// The very first group of the broadcast: open segment 0 at its timestamp.
-			this.#current = { segment: 0, boundary: pts };
-			return 0;
+	track(name: string, kind: Kind): Recorder {
+		this.#tracks.set(name, { kind, pending: [], frontier: undefined, closed: false });
+
+		// The first video track drives auto-cut (boundaries must land on its keyframes);
+		// without video, the first enrolled track of any kind paces instead.
+		const driver = this.#driver ? this.#tracks.get(this.#driver) : undefined;
+		if (!driver || (kind === "video" && driver.kind !== "video")) {
+			this.#driver = name;
 		}
-		const { segment, boundary } = this.#current;
-		if (last !== segment && pts >= boundary) return segment;
-		if (!this.#driven && pts >= boundary + this.#intervalUs) {
-			this.#current = { segment: segment + 1, boundary: pts };
-			return segment + 1;
+
+		return new Recorder(this, name);
+	}
+
+	#cutAt(pts: Time.Micro): void {
+		if (this.#lastBoundary !== undefined && pts <= this.#lastBoundary) return;
+		this.#boundaries.push(pts);
+		this.#lastBoundary = pts;
+	}
+
+	/** @internal A group open reported by a {@link Recorder}. */
+	report(name: string, sequence: number, pts: Time.Micro, keyframe: boolean): void {
+		const track = this.#tracks.get(name);
+		if (!track) return;
+		track.pending.push({ sequence, pts, keyframe });
+		if (track.frontier === undefined || pts > track.frontier) track.frontier = pts;
+
+		// Auto-cut: only the driver paces, only at a keyframe when the driver is video (an
+		// audio driver can cut anywhere), and never once the application cuts explicitly.
+		if (!this.#manual && this.#driver === name && (keyframe || track.kind !== "video")) {
+			const due = this.#lastBoundary === undefined || pts >= this.#lastBoundary + this.#durationMaxUs;
+			if (due) this.#cutAt(pts);
 		}
-		return undefined;
+
+		this.#tryFlush(false);
+	}
+
+	/** @internal A track's recorder closed: stop gating completeness on it. */
+	close(name: string): void {
+		const track = this.#tracks.get(name);
+		if (track) track.closed = true;
+		if (this.#driver === name) {
+			this.#driver = this.#elect();
+		}
+		this.#tryFlush(false);
+	}
+
+	// The auto-cut driver among open tracks: a video track if any, else any open track.
+	#elect(): string | undefined {
+		let any: string | undefined;
+		for (const [name, track] of this.#tracks) {
+			if (track.closed) continue;
+			if (track.kind === "video") return name;
+			any ??= name;
+		}
+		return any;
+	}
+
+	// Flush every segment whose content is final on all tracks. A segment needs its end
+	// boundary and, per open track, a report at or past it. `finished` treats every track as
+	// closed, for the terminal flush.
+	#tryFlush(finished: boolean): void {
+		// With nothing enrolled there is nothing to describe; boundaries just wait.
+		if (this.#tracks.size === 0) return;
+
+		while (this.#boundaries.length >= 2) {
+			const end = this.#boundaries[1];
+			if (!finished) {
+				for (const track of this.#tracks.values()) {
+					if (track.closed) continue;
+					if (track.frontier === undefined || track.frontier < end) return;
+				}
+			}
+			const start = this.#boundaries.shift();
+			if (start === undefined) return;
+			this.#flushSegment(start, end);
+		}
+	}
+
+	// Emit the record for the segment starting at `start`: drain every track's groups before
+	// `end` (all of them for the final, unbounded segment) into ranges. Anything reported
+	// before the first boundary lands in the oldest segment.
+	#flushSegment(start: Time.Micro, end?: Time.Micro): void {
+		const pts = Math.floor((start * DEFAULT_TIMESCALE) / 1_000_000);
+		let endUnits: number;
+		if (end !== undefined) {
+			endUnits = Math.floor((end * DEFAULT_TIMESCALE) / 1_000_000);
+		} else {
+			// The final segment has no end boundary; its duration runs to the newest report.
+			let max = start;
+			for (const track of this.#tracks.values()) {
+				if (track.frontier !== undefined && track.frontier > max) max = track.frontier;
+			}
+			endUnits = Math.floor((max * DEFAULT_TIMESCALE) / 1_000_000);
+		}
+
+		const record: Record = { segment: this.#nextSegment, pts, duration: Math.max(0, endUnits - pts) };
+		this.#nextSegment += 1;
+
+		const tracks: { [track: string]: Range[] } = {};
+		let any = false;
+		for (const [name, track] of this.#tracks) {
+			const ranges: Range[] = [];
+			while (track.pending.length > 0) {
+				const group = track.pending[0];
+				if (end !== undefined && group.pts >= end) break;
+				track.pending.shift();
+				const last = ranges.at(-1);
+				// Contiguous sequences extend the run; a skip starts a new range (a gap:
+				// groups that never existed).
+				if (last && last.end + 1 === group.sequence) {
+					last.end = group.sequence;
+				} else {
+					const range: Range = { start: group.sequence, end: group.sequence };
+					if (!group.keyframe) range.keyframe = false;
+					ranges.push(range);
+				}
+			}
+			if (ranges.length > 0) {
+				tracks[name] = ranges;
+				any = true;
+			}
+		}
+		if (any) record.tracks = tracks;
+
+		this.#emit(record);
+	}
+
+	#emit(record: Record): void {
+		if (this.#sink) {
+			this.#sink(record);
+		} else {
+			this.#buffered.push(record);
+		}
+	}
+
+	/** @internal Attach the record sink; records flushed before this are published now. */
+	attach(sink: (record: Record) => void): void {
+		for (const record of this.#buffered) sink(record);
+		this.#buffered.length = 0;
+		this.#sink = sink;
+	}
+
+	/** @internal The terminal flush: treat every track as closed, then emit the open tail. */
+	finish(): void {
+		// Content but never a boundary (nobody cut and the driver never reported): anchor the
+		// one segment at the earliest report so the content is still indexed.
+		if (this.#boundaries.length === 0) {
+			let first: Time.Micro | undefined;
+			for (const track of this.#tracks.values()) {
+				const pts = track.pending[0]?.pts;
+				if (pts !== undefined && (first === undefined || pts < first)) first = pts;
+			}
+			if (first !== undefined) this.#cutAt(first);
+		}
+
+		this.#tryFlush(true);
+
+		const start = this.#boundaries.shift();
+		if (start === undefined) return;
+		// Skip an empty tail: a cut with no content after it describes nothing.
+		for (const track of this.#tracks.values()) {
+			if (track.pending.length > 0) {
+				this.#flushSegment(start, undefined);
+				return;
+			}
+		}
+	}
+}
+
+/**
+ * Reports one media track's group opens into the shared {@link Segmenter}. It is the track's
+ * single reporting handle; {@link close} ends the track's enrollment (segments stop waiting
+ * on it). Minted by {@link Segmenter.track} and held by a {@link Legacy.Producer} (its
+ * `timeline` prop).
+ */
+export class Recorder {
+	#segmenter: Segmenter;
+	#name: string;
+
+	/** @internal Minted by {@link Segmenter.track}. */
+	constructor(segmenter: Segmenter, name: string) {
+		this.#segmenter = segmenter;
+		this.#name = name;
+	}
+
+	/**
+	 * Report that group `sequence` opened at presentation time `pts` (microseconds),
+	 * `keyframe` stating whether its first frame is one. Reports must be in group order with
+	 * monotonic timestamps.
+	 */
+	record(sequence: number, pts: Time.Micro, keyframe = true): void {
+		this.#segmenter.report(this.#name, sequence, pts, keyframe);
+	}
+
+	/** Close the track's enrollment: segments no longer wait on it. */
+	close(): void {
+		this.#segmenter.close(this.#name);
 	}
 }
 
 /** Options for a timeline {@link Producer}. */
 export interface ProducerProps {
-	/** Units per second for the records' `pts` (and the `wall` anchor). Defaults to milliseconds. */
-	timescale?: number;
-
-	/**
-	 * The broadcast's shared segment counter, so this track's segment numbers align with its
-	 * siblings'. Defaults to a fresh one (a track segmented on its own).
-	 */
+	/** The broadcast's segmenter to publish; defaults to a fresh one. */
 	segmenter?: Segmenter;
-
-	/**
-	 * How this track's groups map onto the aligned segments: `"boundary"` for video (every
-	 * group is a segment), `"aligned"` for audio (groups pack into the video's segments).
-	 * Defaults to `"boundary"`.
-	 */
-	cadence?: Cadence;
 }
 
 /**
- * Publishes one media track's timeline: an NDJSON record per segment, DEFLATE-compressed.
- *
- * {@link record} maps each group open onto the aligned segment numbering, appending a record
- * when the group starts a segment. Advertise it in the rendition's catalog config via
- * {@link section}, and attach it to a {@link Legacy.Producer} (its `timeline` prop) to record
- * group opens automatically.
+ * Publishes the broadcast's timeline track: one JSON record per complete segment,
+ * DEFLATE-compressed (a `@moq/json` stream). Attaches to the {@link Segmenter} as its record
+ * sink; advertise it in the catalog's root `timeline` section via {@link section}.
  */
 export class Producer {
 	#stream: Json.Stream.Producer<Record>;
 	#track: string;
-	#timescale: number;
+	#segmenter: Segmenter;
 	// The wall-clock time of pts 0, in timescale units since the moq epoch (advertised in the section).
 	#wall?: number;
-	#segmenter: Segmenter;
-	#cadence: Cadence;
-	// The last segment this track recorded; the cursor an aligned producer dedupes against.
-	#last?: number;
 
-	/** Wrap an already-created MoQ track (named per {@link trackName}) to publish a rendition's timeline. */
+	/** Wrap an already-created MoQ track (named {@link DEFAULT_NAME} by convention). */
 	constructor(track: Moq.Track.Producer, props: ProducerProps = {}) {
 		this.#track = track.name;
-		this.#timescale = props.timescale ?? DEFAULT_TIMESCALE;
 		this.#segmenter = props.segmenter ?? new Segmenter();
-		this.#cadence = props.cadence ?? "boundary";
 		this.#stream = new Json.Stream.Producer<Record>(track, { compression: true });
+		this.#segmenter.attach((record) => this.#stream.append(record));
 	}
 
-	/** The catalog section advertising this timeline, to attach to the rendition's config. */
+	/** The segmenter this timeline publishes (enroll tracks and cut boundaries through it). */
+	get segmenter(): Segmenter {
+		return this.#segmenter;
+	}
+
+	/** The catalog's root section advertising this timeline. */
 	section(): Catalog.Timeline {
 		return {
 			track: this.#track,
-			timescale: u53(this.#timescale),
+			timescale: u53(DEFAULT_TIMESCALE),
 			wall: this.#wall === undefined ? undefined : u53(this.#wall),
 		};
 	}
@@ -180,7 +385,7 @@ export class Producer {
 	 * Set (or replace) the wall-clock anchor advertised in the catalog section, from an observed
 	 * pairing of a media timestamp `pts` (microseconds) with its wall-clock time `wall` (defaulting
 	 * to now). Stored as the extrapolated wall-clock time of pts 0, the single value the catalog
-	 * `wall` field carries: in this timeline's timescale, measured from the moq epoch
+	 * `wall` field carries: in the timeline's timescale, measured from the moq epoch
 	 * ({@link Catalog.MOQ_EPOCH_UNIX_MILLIS}, 2020). Throws if `wall` predates the moq epoch
 	 * (unrepresentable).
 	 */
@@ -189,26 +394,14 @@ export class Producer {
 		if (unixMillis < MOQ_EPOCH_UNIX_MILLIS) {
 			throw new Error(`wall time ${unixMillis} predates the moq epoch ${MOQ_EPOCH_UNIX_MILLIS}`);
 		}
-		const ptsUnits = Math.floor((pts * this.#timescale) / 1_000_000);
-		const moqUnits = Math.floor(((unixMillis - MOQ_EPOCH_UNIX_MILLIS) * this.#timescale) / 1000);
+		const ptsUnits = Math.floor((pts * DEFAULT_TIMESCALE) / 1_000_000);
+		const moqUnits = Math.floor(((unixMillis - MOQ_EPOCH_UNIX_MILLIS) * DEFAULT_TIMESCALE) / 1000);
 		this.#wall = Math.max(0, moqUnits - ptsUnits);
 	}
 
-	/**
-	 * Record that group `sequence` opened at presentation time `pts` (microseconds). Per the
-	 * {@link Cadence}, the group either opens a segment (recorded) or extends the current one
-	 * (skipped).
-	 */
-	record(sequence: number, pts: Time.Micro): void {
-		const segment =
-			this.#cadence === "boundary" ? this.#segmenter.boundary(pts) : this.#segmenter.align(pts, this.#last);
-		if (segment === undefined) return;
-		this.#last = segment;
-		this.#stream.append({ segment, group: sequence, pts: Math.floor((pts * this.#timescale) / 1_000_000) });
-	}
-
-	/** Finish the timeline track. */
+	/** Flush the final (still open) segment and finish the track. */
 	finish(): void {
+		this.#segmenter.finish();
 		this.#stream.finish();
 	}
 }

--- a/js/hang/src/container/timeline.ts
+++ b/js/hang/src/container/timeline.ts
@@ -4,12 +4,13 @@
  * track. A consumer can seek (or build an HLS/DASH playlist) without downloading the media.
  * See the catalog's root {@link Catalog.Timeline} section that advertises it.
  *
- * Facts flow up and policy flows down, meeting in the shared {@link Segmenter}: each media
- * track enrolls with {@link Segmenter.track} and reports every group open through its
- * {@link Recorder}; boundaries come from {@link Segmenter.cut} when the application knows
- * them, or from auto-cut on the driver track's keyframes otherwise. A segment's record is
- * published only once every enrolled track has reported past its end boundary (or closed), so
- * records are self-contained and immediately servable.
+ * Facts flow up and policy flows down, meeting in the shared {@link Producer}: each media
+ * track enrolls with {@link Producer.track} and reports every group open through its
+ * {@link Recorder}. A segment ends at the first group boundary that gives it at least
+ * {@link ProducerProps.durationMin} on every enrolled track, unless the application declares
+ * its own with {@link Producer.cut}. A segment's record is published only once every enrolled
+ * track has reported past its end (or closed), so records are self-contained and immediately
+ * servable.
  *
  * @module
  */
@@ -52,10 +53,10 @@ export interface Record {
 export const DEFAULT_TIMESCALE = 1000;
 
 /**
- * The conventional {@link Segmenter} segment-duration bound in milliseconds (2 seconds), for
- * callers with no opinion of their own.
+ * The conventional {@link ProducerProps.durationMin} (1 second), in milliseconds, for callers
+ * with no opinion of their own.
  */
-export const DEFAULT_DURATION_MAX_MS = 2000;
+export const DEFAULT_DURATION_MIN_MS = 1000;
 
 /**
  * The conventional name for a broadcast's timeline track (the `.z` marks the
@@ -64,30 +65,37 @@ export const DEFAULT_DURATION_MAX_MS = 2000;
  */
 export const DEFAULT_NAME = "timeline.z";
 
-/**
- * What a media track carries, declared when it enrolls via {@link Segmenter.track}. The
- * segmenter prefers a video track as the auto-cut driver, since segment boundaries must land
- * on video keyframes to keep every rendition independently decodable.
- */
-export type Kind = "video" | "audio";
-
-/** Options for a {@link Segmenter}. */
-export interface SegmenterProps {
+/** How a {@link Producer} paces its segments. */
+export interface ProducerProps {
 	/**
-	 * The declared upper bound on a segment's duration, in milliseconds of media time. The
-	 * boundary owner knows it up front (the encoder its keyframe cadence, an importer its
-	 * source's target duration); it is advertised in the catalog's timeline section and
-	 * enforced by auto-cut, which closes a segment at the last driver keyframe that keeps it
-	 * within the bound (only a GOP longer than the bound still overruns). Explicit
-	 * {@link Segmenter.cut}s are expected to honor it too. Defaults to
-	 * {@link DEFAULT_DURATION_MAX_MS}.
+	 * The shortest a segment may be, in milliseconds of media time.
+	 *
+	 * A segment ends at the first point that is a group boundary on every enrolled track and at
+	 * least this far past the segment's start, so the track with the coarsest groups paces the
+	 * broadcast: a 2s GOP against a 1s minimum yields 2s segments, and a real-time encoder with
+	 * a 10 minute GOP yields one 10 minute segment, because there is nowhere else a segment
+	 * could start and stay decodable. A floor rather than a target on purpose: a floor is
+	 * always satisfiable (wait longer), while a ceiling is not. Defaults to
+	 * {@link DEFAULT_DURATION_MIN_MS}.
+	 */
+	durationMin?: number;
+
+	/**
+	 * The longest a segment may be, in milliseconds of media time, advertised in the catalog
+	 * when set.
+	 *
+	 * Set it only when the publisher can actually promise one, i.e. it controls the encoder's
+	 * keyframe cadence. Consumers that need a bound up front use it (an HLS exporter's
+	 * EXT-X-TARGETDURATION), so it is a contract rather than a hint: a segment that would exceed
+	 * it fails the timeline instead of publishing a record that contradicts the catalog. Leave
+	 * it unset when the media decides, which is the common case for real-time and for anything
+	 * importing a source the publisher doesn't control.
 	 */
 	durationMax?: number;
 }
 
 /** One enrolled track's report state. */
 interface TrackState {
-	kind: Kind;
 	// Group opens reported and not yet flushed into a record.
 	pending: { sequence: number; pts: Time.Micro; keyframe: boolean }[];
 	// The newest reported timestamp: everything earlier is known. Advanced by a group open (the
@@ -97,58 +105,74 @@ interface TrackState {
 }
 
 /**
- * The broadcast's segmenter: the shared boundary list every track's groups map onto.
+ * Publishes the broadcast's timeline track: one JSON record per complete segment,
+ * DEFLATE-compressed (a `@moq/json` stream), plus the shared boundary list every media track's
+ * groups map onto.
  *
- * One per broadcast. Media tracks enroll with {@link track} and report group opens through
- * the returned {@link Recorder}; the application (or the auto-cut policy) declares boundaries
- * with {@link cut}. Records flush once complete on every enrolled track, into the attached
- * {@link Producer} (buffered until one attaches).
+ * One per broadcast. Media tracks enroll with {@link track} and report group opens through the
+ * returned {@link Recorder}; an application with its own boundaries overrides the pacing with
+ * {@link cut}. Advertise it in the catalog's root `timeline` section via {@link section}.
  */
-export class Segmenter {
-	#durationMaxUs: number;
-	// An explicit cut() arrived: the application owns the boundaries; auto-cut stays off.
-	#manual = false;
-	// The driver's latest boundary candidate (a keyframe for a video driver) since the last
-	// boundary: where auto-cut retroactively closes a segment that would otherwise overrun.
-	#candidate?: Time.Micro;
-	// Boundaries of segments not yet flushed: boundaries[0] starts segment #nextSegment.
-	#boundaries: Time.Micro[] = [];
-	// The newest boundary ever created (never popped), the auto-cut reference point.
-	#lastBoundary?: Time.Micro;
+export class Producer {
+	#stream: Json.Stream.Producer<Record>;
+	#trackName: string;
+	#durationMinUs: number;
+	#durationMaxUs?: number;
+
+	// Where the open (unflushed) segment starts; undefined until the first report.
+	#start?: Time.Micro;
+	// Explicit cut() boundaries not yet reached, in order.
+	#cuts: Time.Micro[] = [];
 	#nextSegment = 0;
 	#tracks = new Map<string, TrackState>();
-	// The auto-cut driver: the first enrolled video track, else the first enrolled track.
-	#driver?: string;
-	// Where flushed records go once a Producer attaches; buffered until then.
-	#sink?: (record: Record) => void;
-	#buffered: Record[] = [];
 	// Live holds: while any exists, no record flushes (more tracks are still enrolling).
 	#holds = 0;
+	// A segment overran durationMax, so the timeline stopped publishing.
+	#overrun?: Error;
+	// The wall-clock time of pts 0, in timescale units since the moq epoch (advertised in the section).
+	#wall?: number;
 
-	constructor(props: SegmenterProps = {}) {
-		this.#durationMaxUs = (props.durationMax ?? DEFAULT_DURATION_MAX_MS) * 1000;
+	/** Wrap an already-created MoQ track (named {@link DEFAULT_NAME} by convention). */
+	constructor(track: Moq.Track.Producer, props: ProducerProps = {}) {
+		this.#trackName = track.name;
+		this.#durationMinUs = (props.durationMin ?? DEFAULT_DURATION_MIN_MS) * 1000;
+		this.#durationMaxUs = props.durationMax === undefined ? undefined : props.durationMax * 1000;
+		this.#stream = new Json.Stream.Producer<Record>(track, { compression: true });
 	}
 
 	/**
-	 * The declared segment-duration bound, in timeline timescale units (milliseconds),
-	 * rounded up. Advertised in the catalog's timeline section, so it must not change once
-	 * the timeline is published.
+	 * Enroll the media track `name`, returning the {@link Recorder} it reports through.
+	 *
+	 * The segment records key ranges by this name, and the track paces boundaries and gates
+	 * completeness until its recorder closes. Enroll a track when it is about to produce: an
+	 * enrolled but silent track holds every record back, by design, since a segment isn't
+	 * complete until every track's content is known. One recorder per track: enrolling the same
+	 * name again resets its state.
 	 */
-	get durationMax(): number {
-		return Math.ceil(this.#durationMaxUs / 1000);
+	track(name: string): Recorder {
+		this.#tracks.set(name, { pending: [], frontier: undefined, closed: false });
+		return new Recorder(this, name);
 	}
 
 	/**
-	 * Declare a segment boundary at `pts` (microseconds): the segment before it ends, the one
-	 * after starts. For applications that know their boundaries (an imported playlist, on-disk
-	 * CMAF segments, an encoder placing keyframes). Cuts must be monotonic; an out-of-order one
-	 * is ignored. Cutting ahead of the media is fine: the record still waits for every track's
-	 * groups. The first explicit cut turns auto-cut off for good.
+	 * Declare a segment boundary at `pts` (microseconds), overriding the
+	 * {@link ProducerProps.durationMin} pacing.
+	 *
+	 * For applications that know their own boundaries (an imported playlist, on-disk CMAF
+	 * segments, an encoder placing keyframes). Cutting ahead of the media is fine: the record
+	 * still waits for every track's groups. A cut that would make a segment shorter than the
+	 * minimum is ignored, so several producers declaring the same boundaries cost nothing.
+	 *
+	 * Throws if a segment already exceeded {@link ProducerProps.durationMax}.
 	 */
 	cut(pts: Time.Micro): void {
-		this.#manual = true;
-		this.#cutAt(pts);
-		this.#tryFlush(false);
+		if (this.#overrun) throw this.#overrun;
+
+		const since = this.#cuts.at(-1) ?? this.#start;
+		if (since === undefined || pts >= since + this.#durationMinUs) {
+			this.#cuts.push(pts);
+			this.#pump(false);
+		}
 	}
 
 	/**
@@ -168,322 +192,20 @@ export class Segmenter {
 			if (released) return;
 			released = true;
 			this.#holds -= 1;
-			this.#tryFlush(false);
+			this.#pump(false);
 		};
-	}
-
-	/**
-	 * Enroll the media track `name`, returning the {@link Recorder} it reports group opens
-	 * through. The segment records key ranges by this name, and the track gates segment
-	 * completeness until its recorder closes. Enroll a track when it is about to produce (an
-	 * enrolled but silent track holds every record back, by design). One recorder per track:
-	 * enrolling the same name again resets its state.
-	 */
-	track(name: string, kind: Kind): Recorder {
-		this.#tracks.set(name, { kind, pending: [], frontier: undefined, closed: false });
-
-		// The first video track drives auto-cut (boundaries must land on its keyframes);
-		// without video, the first enrolled track of any kind paces instead.
-		const driver = this.#driver ? this.#tracks.get(this.#driver) : undefined;
-		if (!driver || (kind === "video" && driver.kind !== "video")) {
-			this.#driver = name;
-			// A previous driver's pending candidate is not a valid boundary for this one.
-			this.#candidate = undefined;
-		}
-
-		return new Recorder(this, name);
-	}
-
-	#cutAt(pts: Time.Micro): void {
-		if (this.#lastBoundary !== undefined && pts <= this.#lastBoundary) return;
-		this.#boundaries.push(pts);
-		this.#lastBoundary = pts;
-	}
-
-	/** @internal A group open reported by a {@link Recorder}. */
-	report(name: string, sequence: number, pts: Time.Micro, keyframe: boolean): void {
-		const track = this.#tracks.get(name);
-		if (!track) return;
-		track.pending.push({ sequence, pts, keyframe });
-		if (track.frontier === undefined || pts > track.frontier) track.frontier = pts;
-
-		// Auto-cut: only the driver paces, only at a keyframe when the driver is video (an
-		// audio driver can cut anywhere), and never once the application cuts explicitly.
-		if (!this.#manual && this.#driver === name && (keyframe || track.kind !== "video")) {
-			this.#autoCut(pts);
-		}
-
-		this.#tryFlush(false);
-	}
-
-	/**
-	 * @internal A track's content ends at `pts`, without a group opening there. This is what
-	 * gives the final segment an honest duration, since its end is not a boundary anybody cut.
-	 */
-	reportEnd(name: string, pts: Time.Micro): void {
-		const track = this.#tracks.get(name);
-		if (!track) return;
-		if (track.frontier === undefined || pts > track.frontier) track.frontier = pts;
-		this.#tryFlush(false);
-	}
-
-	// Auto-cut policy for a driver boundary candidate at `pts`: keep every segment within the
-	// declared bound whenever the driver's cadence allows. A boundary can only land where the
-	// driver reported (a keyframe for video), so waiting for the first candidate past the
-	// bound would overrun it by up to one GOP; instead, when `pts` would overrun, the segment
-	// is closed retroactively at the previous candidate. Only a GOP longer than the bound
-	// itself still yields an honest long segment.
-	#autoCut(pts: Time.Micro): void {
-		const last = this.#lastBoundary;
-		if (last === undefined) {
-			// The first candidate anchors the first segment.
-			this.#cutAt(pts);
-			this.#candidate = pts;
-			return;
-		}
-
-		const bound = last + this.#durationMaxUs;
-		if (pts > bound) {
-			// This candidate overruns: close the segment at the previous one instead.
-			if (this.#candidate !== undefined && this.#candidate > last) {
-				this.#cutAt(this.#candidate);
-			}
-			// Still overrunning (the whole GOP is longer than the bound): cut here anyway.
-			const cutLast = this.#lastBoundary;
-			if (cutLast !== undefined && pts >= cutLast + this.#durationMaxUs) {
-				this.#cutAt(pts);
-			}
-		} else if (pts === bound) {
-			this.#cutAt(pts);
-		}
-		this.#candidate = pts;
-	}
-
-	/** @internal A track's recorder closed: stop gating completeness on it. */
-	close(name: string): void {
-		const track = this.#tracks.get(name);
-		if (track) track.closed = true;
-		if (this.#driver === name) {
-			this.#driver = this.#elect();
-			// The old driver's pending candidate is not a valid boundary for the new one.
-			this.#candidate = undefined;
-		}
-		this.#tryFlush(false);
-	}
-
-	// The auto-cut driver among open tracks: a video track if any, else any open track.
-	#elect(): string | undefined {
-		let any: string | undefined;
-		for (const [name, track] of this.#tracks) {
-			if (track.closed) continue;
-			if (track.kind === "video") return name;
-			any ??= name;
-		}
-		return any;
-	}
-
-	// Flush every segment whose content is final on all tracks. A segment needs its end
-	// boundary and, per open track, a report at or past it. `finished` treats every track as
-	// closed, for the terminal flush.
-	#tryFlush(finished: boolean): void {
-		// With nothing enrolled there is nothing to describe; boundaries just wait.
-		if (this.#tracks.size === 0) return;
-
-		// A record is immutable once published, so a caller that knows more tracks are still
-		// enrolling holds flushing back until they are (see hold()).
-		if (this.#holds > 0) return;
-
-		while (this.#boundaries.length >= 2) {
-			const end = this.#boundaries[1];
-			if (!finished) {
-				for (const track of this.#tracks.values()) {
-					if (track.closed) continue;
-					if (track.frontier === undefined || track.frontier < end) return;
-				}
-			}
-			const start = this.#boundaries.shift();
-			if (start === undefined) return;
-			this.#flushSegment(start, end);
-		}
-	}
-
-	// Emit the record for the segment starting at `start`: drain every track's groups before
-	// `end` (all of them for the final, unbounded segment) into ranges. Anything reported
-	// before the first boundary lands in the oldest segment.
-	#flushSegment(start: Time.Micro, end?: Time.Micro): void {
-		const pts = Math.floor((start * DEFAULT_TIMESCALE) / 1_000_000);
-		let endUnits: number;
-		if (end !== undefined) {
-			endUnits = Math.floor((end * DEFAULT_TIMESCALE) / 1_000_000);
-		} else {
-			// The final segment has no end boundary, so it runs to the newest thing any track
-			// reported: its end of content when the track reported one, otherwise the last group
-			// it opened, which undercounts that group's tail.
-			let max = start;
-			for (const track of this.#tracks.values()) {
-				if (track.frontier !== undefined && track.frontier > max) max = track.frontier;
-			}
-			endUnits = Math.floor((max * DEFAULT_TIMESCALE) / 1_000_000);
-		}
-
-		const record: Record = { segment: this.#nextSegment, pts, duration: Math.max(0, endUnits - pts) };
-		this.#nextSegment += 1;
-
-		const tracks: { [track: string]: Range[] } = {};
-		let any = false;
-		for (const [name, track] of this.#tracks) {
-			const ranges: Range[] = [];
-			while (track.pending.length > 0) {
-				const group = track.pending[0];
-				if (end !== undefined && group.pts >= end) break;
-				track.pending.shift();
-				const last = ranges.at(-1);
-				// Contiguous sequences extend the run; a skip starts a new range (a gap:
-				// groups that never existed).
-				if (last && last.end + 1 === group.sequence) {
-					last.end = group.sequence;
-				} else {
-					const range: Range = { start: group.sequence, end: group.sequence };
-					if (!group.keyframe) range.keyframe = false;
-					ranges.push(range);
-				}
-			}
-			if (ranges.length > 0) {
-				tracks[name] = ranges;
-				any = true;
-			}
-		}
-		if (any) record.tracks = tracks;
-
-		this.#emit(record);
-	}
-
-	#emit(record: Record): void {
-		if (this.#sink) {
-			this.#sink(record);
-		} else {
-			this.#buffered.push(record);
-		}
-	}
-
-	/** @internal Attach the record sink; records flushed before this are published now. */
-	attach(sink: (record: Record) => void): void {
-		for (const record of this.#buffered) sink(record);
-		this.#buffered.length = 0;
-		this.#sink = sink;
-	}
-
-	/** @internal The terminal flush: treat every track as closed, then emit the open tail. */
-	finish(): void {
-		// Nothing more will enroll, so an outstanding hold has nothing left to wait for.
-		this.#holds = 0;
-
-		// Content but never a boundary (nobody cut and the driver never reported): anchor the
-		// one segment at the earliest report so the content is still indexed.
-		if (this.#boundaries.length === 0) {
-			let first: Time.Micro | undefined;
-			for (const track of this.#tracks.values()) {
-				const pts = track.pending[0]?.pts;
-				if (pts !== undefined && (first === undefined || pts < first)) first = pts;
-			}
-			if (first !== undefined) this.#cutAt(first);
-		}
-
-		this.#tryFlush(true);
-
-		const start = this.#boundaries.shift();
-		if (start === undefined) return;
-		// Skip an empty tail: a cut with no content after it describes nothing.
-		for (const track of this.#tracks.values()) {
-			if (track.pending.length > 0) {
-				this.#flushSegment(start, undefined);
-				return;
-			}
-		}
-	}
-}
-
-/**
- * Reports one media track's group opens into the shared {@link Segmenter}. It is the track's
- * single reporting handle; {@link close} ends the track's enrollment (segments stop waiting
- * on it). Minted by {@link Segmenter.track} and held by a {@link Legacy.Producer} (its
- * `timeline` prop).
- */
-export class Recorder {
-	#segmenter: Segmenter;
-	#name: string;
-
-	/** @internal Minted by {@link Segmenter.track}. */
-	constructor(segmenter: Segmenter, name: string) {
-		this.#segmenter = segmenter;
-		this.#name = name;
-	}
-
-	/**
-	 * Report that group `sequence` opened at presentation time `pts` (microseconds),
-	 * `keyframe` stating whether its first frame is one. Reports must be in group order with
-	 * monotonic timestamps.
-	 */
-	record(sequence: number, pts: Time.Micro, keyframe = true): void {
-		this.#segmenter.report(this.#name, sequence, pts, keyframe);
-	}
-
-	/**
-	 * Report that this track's content extends to `pts` (microseconds), without a group opening
-	 * there.
-	 *
-	 * A group open says where content *starts*; the last group of a broadcast has no successor
-	 * to bound it, so its segment would otherwise be published a group short (zero for a segment
-	 * that is a single group). Report the end whenever you know it: closing a group, finishing a
-	 * track.
-	 */
-	end(pts: Time.Micro): void {
-		this.#segmenter.reportEnd(this.#name, pts);
-	}
-
-	/** Close the track's enrollment: segments no longer wait on it. */
-	close(): void {
-		this.#segmenter.close(this.#name);
-	}
-}
-
-/** Options for a timeline {@link Producer}. */
-export interface ProducerProps {
-	/** The broadcast's segmenter to publish; defaults to a fresh one. */
-	segmenter?: Segmenter;
-}
-
-/**
- * Publishes the broadcast's timeline track: one JSON record per complete segment,
- * DEFLATE-compressed (a `@moq/json` stream). Attaches to the {@link Segmenter} as its record
- * sink; advertise it in the catalog's root `timeline` section via {@link section}.
- */
-export class Producer {
-	#stream: Json.Stream.Producer<Record>;
-	#track: string;
-	#segmenter: Segmenter;
-	// The wall-clock time of pts 0, in timescale units since the moq epoch (advertised in the section).
-	#wall?: number;
-
-	/** Wrap an already-created MoQ track (named {@link DEFAULT_NAME} by convention). */
-	constructor(track: Moq.Track.Producer, props: ProducerProps = {}) {
-		this.#track = track.name;
-		this.#segmenter = props.segmenter ?? new Segmenter();
-		this.#stream = new Json.Stream.Producer<Record>(track, { compression: true });
-		this.#segmenter.attach((record) => this.#stream.append(record));
-	}
-
-	/** The segmenter this timeline publishes (enroll tracks and cut boundaries through it). */
-	get segmenter(): Segmenter {
-		return this.#segmenter;
 	}
 
 	/** The catalog's root section advertising this timeline. */
 	section(): Catalog.Timeline {
+		const durationMax =
+			this.#durationMaxUs === undefined
+				? undefined
+				: u53(Math.ceil((this.#durationMaxUs * DEFAULT_TIMESCALE) / 1_000_000));
 		return {
-			track: this.#track,
+			track: this.#trackName,
 			timescale: u53(DEFAULT_TIMESCALE),
-			durationMax: u53(this.#segmenter.durationMax),
+			durationMax,
 			wall: this.#wall === undefined ? undefined : u53(this.#wall),
 		};
 	}
@@ -506,9 +228,237 @@ export class Producer {
 		this.#wall = Math.max(0, moqUnits - ptsUnits);
 	}
 
-	/** Flush the final (still open) segment and finish the track. */
+	/**
+	 * Flush the final (still open) segment and finish the track.
+	 *
+	 * Throws if a segment exceeded {@link ProducerProps.durationMax}.
+	 */
 	finish(): void {
-		this.#segmenter.finish();
+		// Nothing more will enroll, so an outstanding hold has nothing left to wait for.
+		this.#holds = 0;
+		this.#pump(true);
+
+		if (this.#overrun) throw this.#overrun;
+
+		// Skip an empty tail: a boundary with no content after it describes nothing.
+		const start = this.#start;
+		this.#start = undefined;
+		if (start !== undefined) {
+			for (const track of this.#tracks.values()) {
+				if (track.pending.length > 0) {
+					this.#flushSegment(start, undefined);
+					break;
+				}
+			}
+		}
+
 		this.#stream.finish();
+	}
+
+	/** @internal A group open reported by a {@link Recorder}. */
+	report(name: string, sequence: number, pts: Time.Micro, keyframe: boolean): void {
+		const track = this.#tracks.get(name);
+		if (!track) return;
+		track.pending.push({ sequence, pts, keyframe });
+		this.#advance(track, pts);
+	}
+
+	/**
+	 * @internal A track's content ends at `pts`, without a group opening there. This is what
+	 * gives the final segment an honest duration, since its end is not a boundary anybody cut.
+	 */
+	reportEnd(name: string, pts: Time.Micro): void {
+		const track = this.#tracks.get(name);
+		if (track) this.#advance(track, pts);
+	}
+
+	/** @internal A track's recorder closed: stop gating completeness on it. */
+	close(name: string): void {
+		const track = this.#tracks.get(name);
+		if (track) track.closed = true;
+		this.#pump(false);
+	}
+
+	// Raise a track's frontier, then publish whatever that completed.
+	#advance(track: TrackState, pts: Time.Micro): void {
+		if (track.frontier === undefined || pts > track.frontier) track.frontier = pts;
+
+		// The first thing anybody reports anchors the first segment, so content produced before
+		// any boundary exists belongs to the oldest segment rather than to nowhere.
+		if (this.#start === undefined) this.#start = pts;
+
+		this.#pump(false);
+	}
+
+	// Publish every segment the media has finalized. `finished` is the terminal pass: no track
+	// will report again, so one that never reached a boundary stops voting instead of holding
+	// the timeline open forever.
+	#pump(finished: boolean): void {
+		if (this.#tracks.size === 0 || this.#holds > 0 || this.#overrun) return;
+		while (this.#closeSegment(finished)) {
+			if (this.#overrun) break;
+		}
+	}
+
+	// Publish the open segment if the media has finalized it, returning whether it did.
+	#closeSegment(finished: boolean): boolean {
+		const start = this.#start;
+		if (start === undefined) return false;
+		const boundary = this.#boundary(start, finished);
+		if (!boundary) return false;
+		const [end, cut] = boundary;
+
+		// Every open track has to have reported at or past the boundary, proving its ranges for
+		// this segment are final. The track that voted for `end` has by construction; a track
+		// with shorter groups can still be behind it.
+		if (!finished) {
+			for (const track of this.#tracks.values()) {
+				if (track.closed) continue;
+				if (track.frontier === undefined || track.frontier < end) return false;
+			}
+		}
+
+		this.#flushSegment(start, end);
+		if (cut) this.#cuts.shift();
+		this.#start = end;
+		return true;
+	}
+
+	// Where the segment starting at `start` ends: an explicit cut when one is registered,
+	// otherwise the first group boundary shared by every track that gives the segment its
+	// minimum duration. The boolean reports which.
+	#boundary(start: Time.Micro, finished: boolean): [Time.Micro, boolean] | undefined {
+		const cut = this.#cuts[0];
+		if (cut !== undefined && cut > start) return [cut, true];
+
+		const threshold = start + this.#durationMinUs;
+
+		let end: Time.Micro | undefined;
+		for (const track of this.#tracks.values()) {
+			if (track.closed) continue;
+			const candidate = track.pending.find((group) => group.pts >= threshold)?.pts;
+			if (candidate === undefined) {
+				// This track has produced nothing past the minimum yet, so ending the segment
+				// would strand it. On the terminal pass it never will, so let it go.
+				if (finished) continue;
+				return undefined;
+			}
+			// The latest vote wins: it is a group boundary on the coarsest track, and every
+			// finer track assigns its groups by start, so no group is split.
+			if (end === undefined || candidate > end) end = candidate;
+		}
+
+		return end === undefined ? undefined : [end, false];
+	}
+
+	// Emit the record for the segment starting at `start`: drain every track's groups before
+	// `end` (all of them for the final, unbounded segment) into ranges.
+	#flushSegment(start: Time.Micro, end?: Time.Micro): void {
+		const pts = Math.floor((start * DEFAULT_TIMESCALE) / 1_000_000);
+		let endUnits: number;
+		if (end !== undefined) {
+			endUnits = Math.floor((end * DEFAULT_TIMESCALE) / 1_000_000);
+		} else {
+			// The final segment has no end boundary, so it runs to the newest thing any track
+			// reported: its end of content when the track reported one, otherwise the last group
+			// it opened, which undercounts that group's tail.
+			let max = start;
+			for (const track of this.#tracks.values()) {
+				if (track.frontier !== undefined && track.frontier > max) max = track.frontier;
+			}
+			endUnits = Math.floor((max * DEFAULT_TIMESCALE) / 1_000_000);
+		}
+		const duration = Math.max(0, endUnits - pts);
+
+		// The catalog promised a bound and this segment breaks it, so the record would contradict
+		// what consumers were told. Fail the timeline rather than publish it: a declared maximum
+		// the media can't honor is a bug in the publisher.
+		if (this.#durationMaxUs !== undefined) {
+			const maxUnits = Math.ceil((this.#durationMaxUs * DEFAULT_TIMESCALE) / 1_000_000);
+			if (duration > maxUnits) {
+				this.#overrun = new Error(
+					`timeline segment ${this.#nextSegment} lasted ${duration}ms, over the declared maximum ${maxUnits}ms`,
+				);
+				// End the track rather than drop it: the records published before the promise
+				// broke are still true, and a consumer that has them should keep them.
+				this.#stream.finish();
+				return;
+			}
+		}
+
+		const record: Record = { segment: this.#nextSegment, pts, duration };
+		this.#nextSegment += 1;
+
+		const tracks: { [track: string]: Range[] } = {};
+		let any = false;
+		for (const [name, track] of this.#tracks) {
+			const ranges: Range[] = [];
+			while (track.pending.length > 0) {
+				const group = track.pending[0];
+				if (end !== undefined && group.pts >= end) break;
+				track.pending.shift();
+				const last = ranges.at(-1);
+				// Contiguous sequences extend the run; a skip starts a new range (a gap: groups
+				// that never existed).
+				if (last && last.end + 1 === group.sequence) {
+					last.end = group.sequence;
+				} else {
+					const range: Range = { start: group.sequence, end: group.sequence };
+					if (!group.keyframe) range.keyframe = false;
+					ranges.push(range);
+				}
+			}
+			if (ranges.length > 0) {
+				tracks[name] = ranges;
+				any = true;
+			}
+		}
+		if (any) record.tracks = tracks;
+
+		this.#stream.append(record);
+	}
+}
+
+/**
+ * Reports one media track's group opens into the shared {@link Producer}. It is the track's
+ * single reporting handle; {@link close} ends the track's enrollment (segments stop waiting
+ * on it). Minted by {@link Producer.track} and held by a {@link Legacy.Producer} (its
+ * `timeline` prop).
+ */
+export class Recorder {
+	#timeline: Producer;
+	#name: string;
+
+	/** @internal Minted by {@link Producer.track}. */
+	constructor(timeline: Producer, name: string) {
+		this.#timeline = timeline;
+		this.#name = name;
+	}
+
+	/**
+	 * Report that group `sequence` opened at presentation time `pts` (microseconds),
+	 * `keyframe` stating whether its first frame is one. Reports must be in group order with
+	 * monotonic timestamps.
+	 */
+	record(sequence: number, pts: Time.Micro, keyframe = true): void {
+		this.#timeline.report(this.#name, sequence, pts, keyframe);
+	}
+
+	/**
+	 * Report that this track's content extends to `pts` (microseconds), without a group opening
+	 * there.
+	 *
+	 * A group open says where content *starts*; the last group of a broadcast has no successor
+	 * to bound it, so its segment would otherwise be published a group short (zero for a segment
+	 * that is a single group). Report the end whenever you know it: closing a group, finishing a
+	 * track.
+	 */
+	end(pts: Time.Micro): void {
+		this.#timeline.reportEnd(this.#name, pts);
+	}
+
+	/** Close the track's enrollment: segments no longer wait on it. */
+	close(): void {
+		this.#timeline.close(this.#name);
 	}
 }

--- a/js/hang/src/container/timeline.ts
+++ b/js/hang/src/container/timeline.ts
@@ -137,8 +137,8 @@ export class Producer {
 	#cuts: Time.Micro[] = [];
 	#nextSegment = 0;
 	#tracks = new Map<string, TrackState>();
-	// Live holds: while any exists, no record flushes (more tracks are still enrolling).
-	#holds = 0;
+	// Live reservations: while any exists, no record flushes (more tracks are still enrolling).
+	#reservers = 0;
 	// A segment overran durationMax, so the timeline stopped publishing.
 	#overrun?: Error;
 	// The wall-clock time of pts 0, in timescale units since the moq epoch (advertised in the section).
@@ -192,22 +192,26 @@ export class Producer {
 	}
 
 	/**
-	 * Hold record publishing back until the returned dispose function is called.
+	 * Begin reserving the track set, returning a function that releases the reservation.
 	 *
-	 * A record is immutable once published, and completeness is judged against the tracks
-	 * enrolled *at that moment*, so a segment that flushes while a sibling rendition is still
-	 * enrolling omits it for good (and that rendition's earlier groups then land in whatever
-	 * segment flushes next). Take a hold around a batch that enrolls or feeds several tracks so
-	 * every one of them is accounted for before anything is published. Holds nest; the last one
-	 * released flushes.
+	 * The counterpart to the Rust catalog's `reserve`, for the same reason: while any
+	 * reservation is outstanding the track set may still grow, so records are withheld from the
+	 * broadcast. A record is immutable once published and its completeness is judged against the
+	 * tracks enrolled *at that moment*, so a segment that flushes while a sibling rendition is
+	 * still enrolling omits it for good, and that rendition's earlier groups then land in
+	 * whatever segment flushes next.
+	 *
+	 * Take one around whatever brings the tracks up, so a producer that enrolls its renditions
+	 * one at a time publishes nothing until they are all in. Reservations nest, and releasing
+	 * the same one twice is a no-op; the last one released flushes.
 	 */
-	hold(): () => void {
-		this.#holds += 1;
+	reserve(): () => void {
+		this.#reservers += 1;
 		let released = false;
 		return () => {
 			if (released) return;
 			released = true;
-			this.#holds -= 1;
+			this.#reservers -= 1;
 			this.#pump(false);
 		};
 	}
@@ -232,8 +236,8 @@ export class Producer {
 	 * Throws if a segment exceeded {@link ProducerProps.durationMax}.
 	 */
 	finish(): void {
-		// Nothing more will enroll, so an outstanding hold has nothing left to wait for.
-		this.#holds = 0;
+		// Nothing more will enroll, so an outstanding reservation has nothing left to wait for.
+		this.#reservers = 0;
 		this.#pump(true);
 
 		if (this.#overrun) throw this.#overrun;
@@ -292,7 +296,7 @@ export class Producer {
 	// will report again, so one that never reached a boundary stops voting instead of holding
 	// the timeline open forever.
 	#pump(finished: boolean): void {
-		if (this.#tracks.size === 0 || this.#holds > 0 || this.#overrun) return;
+		if (this.#tracks.size === 0 || this.#reservers > 0 || this.#overrun) return;
 		while (this.#closeSegment(finished)) {
 			if (this.#overrun) break;
 		}

--- a/js/hang/src/container/timeline.ts
+++ b/js/hang/src/container/timeline.ts
@@ -90,7 +90,8 @@ interface TrackState {
 	kind: Kind;
 	// Group opens reported and not yet flushed into a record.
 	pending: { sequence: number; pts: Time.Micro; keyframe: boolean }[];
-	// The newest reported timestamp: everything earlier is known.
+	// The newest reported timestamp: everything earlier is known. Advanced by a group open (the
+	// group starts there) and by Recorder.end (the content stops there).
 	frontier?: Time.Micro;
 	closed: boolean;
 }
@@ -121,6 +122,8 @@ export class Segmenter {
 	// Where flushed records go once a Producer attaches; buffered until then.
 	#sink?: (record: Record) => void;
 	#buffered: Record[] = [];
+	// Live holds: while any exists, no record flushes (more tracks are still enrolling).
+	#holds = 0;
 
 	constructor(props: SegmenterProps = {}) {
 		this.#durationMaxUs = (props.durationMax ?? DEFAULT_DURATION_MAX_MS) * 1000;
@@ -146,6 +149,27 @@ export class Segmenter {
 		this.#manual = true;
 		this.#cutAt(pts);
 		this.#tryFlush(false);
+	}
+
+	/**
+	 * Hold record publishing back until the returned dispose function is called.
+	 *
+	 * A record is immutable once published, and completeness is judged against the tracks
+	 * enrolled *at that moment*, so a segment that flushes while a sibling rendition is still
+	 * enrolling omits it for good (and that rendition's earlier groups then land in whatever
+	 * segment flushes next). Take a hold around a batch that enrolls or feeds several tracks so
+	 * every one of them is accounted for before anything is published. Holds nest; the last one
+	 * released flushes.
+	 */
+	hold(): () => void {
+		this.#holds += 1;
+		let released = false;
+		return () => {
+			if (released) return;
+			released = true;
+			this.#holds -= 1;
+			this.#tryFlush(false);
+		};
 	}
 
 	/**
@@ -189,6 +213,17 @@ export class Segmenter {
 			this.#autoCut(pts);
 		}
 
+		this.#tryFlush(false);
+	}
+
+	/**
+	 * @internal A track's content ends at `pts`, without a group opening there. This is what
+	 * gives the final segment an honest duration, since its end is not a boundary anybody cut.
+	 */
+	reportEnd(name: string, pts: Time.Micro): void {
+		const track = this.#tracks.get(name);
+		if (!track) return;
+		if (track.frontier === undefined || pts > track.frontier) track.frontier = pts;
 		this.#tryFlush(false);
 	}
 
@@ -254,6 +289,10 @@ export class Segmenter {
 		// With nothing enrolled there is nothing to describe; boundaries just wait.
 		if (this.#tracks.size === 0) return;
 
+		// A record is immutable once published, so a caller that knows more tracks are still
+		// enrolling holds flushing back until they are (see hold()).
+		if (this.#holds > 0) return;
+
 		while (this.#boundaries.length >= 2) {
 			const end = this.#boundaries[1];
 			if (!finished) {
@@ -277,7 +316,9 @@ export class Segmenter {
 		if (end !== undefined) {
 			endUnits = Math.floor((end * DEFAULT_TIMESCALE) / 1_000_000);
 		} else {
-			// The final segment has no end boundary; its duration runs to the newest report.
+			// The final segment has no end boundary, so it runs to the newest thing any track
+			// reported: its end of content when the track reported one, otherwise the last group
+			// it opened, which undercounts that group's tail.
 			let max = start;
 			for (const track of this.#tracks.values()) {
 				if (track.frontier !== undefined && track.frontier > max) max = track.frontier;
@@ -334,6 +375,9 @@ export class Segmenter {
 
 	/** @internal The terminal flush: treat every track as closed, then emit the open tail. */
 	finish(): void {
+		// Nothing more will enroll, so an outstanding hold has nothing left to wait for.
+		this.#holds = 0;
+
 		// Content but never a boundary (nobody cut and the driver never reported): anchor the
 		// one segment at the earliest report so the content is still indexed.
 		if (this.#boundaries.length === 0) {
@@ -382,6 +426,19 @@ export class Recorder {
 	 */
 	record(sequence: number, pts: Time.Micro, keyframe = true): void {
 		this.#segmenter.report(this.#name, sequence, pts, keyframe);
+	}
+
+	/**
+	 * Report that this track's content extends to `pts` (microseconds), without a group opening
+	 * there.
+	 *
+	 * A group open says where content *starts*; the last group of a broadcast has no successor
+	 * to bound it, so its segment would otherwise be published a group short (zero for a segment
+	 * that is a single group). Report the end whenever you know it: closing a group, finishing a
+	 * track.
+	 */
+	end(pts: Time.Micro): void {
+		this.#segmenter.reportEnd(this.#name, pts);
 	}
 
 	/** Close the track's enrollment: segments no longer wait on it. */

--- a/js/hang/src/container/timeline.ts
+++ b/js/hang/src/container/timeline.ts
@@ -135,6 +135,10 @@ export class Producer {
 	#start?: Time.Micro;
 	// Explicit cut() boundaries not yet reached, in order.
 	#cuts: Time.Micro[] = [];
+	// A cut() arrived, so the application owns the boundaries from here on and the durationMin
+	// pacing stops. Without this the pacing races ahead of a source whose segments are longer
+	// than the minimum, closing one before its real boundary is declared.
+	#manual = false;
 	#nextSegment = 0;
 	#tracks = new Map<string, TrackState>();
 	// Live reservations: while any exists, no record flushes (more tracks are still enrolling).
@@ -179,10 +183,16 @@ export class Producer {
 	 * still waits for every track's groups. A cut that would make a segment shorter than the
 	 * minimum is ignored, so several producers declaring the same boundaries cost nothing.
 	 *
+	 * The first call takes over for good: {@link ProducerProps.durationMin} pacing stops, since it
+	 * would otherwise close a segment just before the caller declares where it really ends.
+	 *
 	 * Throws if a segment already exceeded {@link ProducerProps.durationMax}.
 	 */
 	cut(pts: Time.Micro): void {
 		if (this.#overrun) throw this.#overrun;
+
+		// Even a cut this rejects says the caller owns the boundaries.
+		this.#manual = true;
 
 		const since = this.#cuts.at(-1) ?? this.#start;
 		if (since === undefined || pts >= since + this.#durationMinUs) {
@@ -306,6 +316,12 @@ export class Producer {
 	#closeSegment(finished: boolean): boolean {
 		const start = this.#start;
 		if (start === undefined) return false;
+
+		// Discard boundaries the timeline has already reached. Only the first is ever consulted,
+		// so leaving a spent one there would block every later cut behind it and silently drop
+		// the caller back to durationMin pacing.
+		while (this.#cuts.length > 0 && this.#cuts[0] <= start) this.#cuts.shift();
+
 		const boundary = this.#boundary(start, finished);
 		if (!boundary) return false;
 		const [end, cut] = boundary;
@@ -332,6 +348,10 @@ export class Producer {
 	#boundary(start: Time.Micro, finished: boolean): [Time.Micro, boolean] | undefined {
 		const cut = this.#cuts[0];
 		if (cut !== undefined && cut > start) return [cut, true];
+
+		// The application declared a boundary at some point, so it owns them all: pacing here
+		// would close a segment the caller is about to cut somewhere else.
+		if (this.#manual) return undefined;
 
 		const threshold = start + this.#durationMinUs;
 

--- a/js/hang/src/container/timeline.ts
+++ b/js/hang/src/container/timeline.ts
@@ -52,9 +52,8 @@ export interface Record {
 export const DEFAULT_TIMESCALE = 1000;
 
 /**
- * The default {@link Segmenter} auto-cut threshold in milliseconds: with nobody cutting
- * explicitly, a new segment starts at the first driver keyframe at least this far past the
- * last boundary.
+ * The conventional {@link Segmenter} segment-duration bound in milliseconds (2 seconds), for
+ * callers with no opinion of their own.
  */
 export const DEFAULT_DURATION_MAX_MS = 2000;
 
@@ -75,9 +74,12 @@ export type Kind = "video" | "audio";
 /** Options for a {@link Segmenter}. */
 export interface SegmenterProps {
 	/**
-	 * The auto-cut threshold in milliseconds of media time: a new segment starts at the first
-	 * driver keyframe at least this far past the last boundary. Irrelevant once
-	 * {@link Segmenter.cut} is used (explicit cuts disable auto-cut). Defaults to
+	 * The declared upper bound on a segment's duration, in milliseconds of media time. The
+	 * boundary owner knows it up front (the encoder its keyframe cadence, an importer its
+	 * source's target duration); it is advertised in the catalog's timeline section and
+	 * enforced by auto-cut, which closes a segment at the last driver keyframe that keeps it
+	 * within the bound (only a GOP longer than the bound still overruns). Explicit
+	 * {@link Segmenter.cut}s are expected to honor it too. Defaults to
 	 * {@link DEFAULT_DURATION_MAX_MS}.
 	 */
 	durationMax?: number;
@@ -105,6 +107,9 @@ export class Segmenter {
 	#durationMaxUs: number;
 	// An explicit cut() arrived: the application owns the boundaries; auto-cut stays off.
 	#manual = false;
+	// The driver's latest boundary candidate (a keyframe for a video driver) since the last
+	// boundary: where auto-cut retroactively closes a segment that would otherwise overrun.
+	#candidate?: Time.Micro;
 	// Boundaries of segments not yet flushed: boundaries[0] starts segment #nextSegment.
 	#boundaries: Time.Micro[] = [];
 	// The newest boundary ever created (never popped), the auto-cut reference point.
@@ -119,6 +124,15 @@ export class Segmenter {
 
 	constructor(props: SegmenterProps = {}) {
 		this.#durationMaxUs = (props.durationMax ?? DEFAULT_DURATION_MAX_MS) * 1000;
+	}
+
+	/**
+	 * The declared segment-duration bound, in timeline timescale units (milliseconds),
+	 * rounded up. Advertised in the catalog's timeline section, so it must not change once
+	 * the timeline is published.
+	 */
+	get durationMax(): number {
+		return Math.ceil(this.#durationMaxUs / 1000);
 	}
 
 	/**
@@ -149,6 +163,8 @@ export class Segmenter {
 		const driver = this.#driver ? this.#tracks.get(this.#driver) : undefined;
 		if (!driver || (kind === "video" && driver.kind !== "video")) {
 			this.#driver = name;
+			// A previous driver's pending candidate is not a valid boundary for this one.
+			this.#candidate = undefined;
 		}
 
 		return new Recorder(this, name);
@@ -170,11 +186,42 @@ export class Segmenter {
 		// Auto-cut: only the driver paces, only at a keyframe when the driver is video (an
 		// audio driver can cut anywhere), and never once the application cuts explicitly.
 		if (!this.#manual && this.#driver === name && (keyframe || track.kind !== "video")) {
-			const due = this.#lastBoundary === undefined || pts >= this.#lastBoundary + this.#durationMaxUs;
-			if (due) this.#cutAt(pts);
+			this.#autoCut(pts);
 		}
 
 		this.#tryFlush(false);
+	}
+
+	// Auto-cut policy for a driver boundary candidate at `pts`: keep every segment within the
+	// declared bound whenever the driver's cadence allows. A boundary can only land where the
+	// driver reported (a keyframe for video), so waiting for the first candidate past the
+	// bound would overrun it by up to one GOP; instead, when `pts` would overrun, the segment
+	// is closed retroactively at the previous candidate. Only a GOP longer than the bound
+	// itself still yields an honest long segment.
+	#autoCut(pts: Time.Micro): void {
+		const last = this.#lastBoundary;
+		if (last === undefined) {
+			// The first candidate anchors the first segment.
+			this.#cutAt(pts);
+			this.#candidate = pts;
+			return;
+		}
+
+		const bound = last + this.#durationMaxUs;
+		if (pts > bound) {
+			// This candidate overruns: close the segment at the previous one instead.
+			if (this.#candidate !== undefined && this.#candidate > last) {
+				this.#cutAt(this.#candidate);
+			}
+			// Still overrunning (the whole GOP is longer than the bound): cut here anyway.
+			const cutLast = this.#lastBoundary;
+			if (cutLast !== undefined && pts >= cutLast + this.#durationMaxUs) {
+				this.#cutAt(pts);
+			}
+		} else if (pts === bound) {
+			this.#cutAt(pts);
+		}
+		this.#candidate = pts;
 	}
 
 	/** @internal A track's recorder closed: stop gating completeness on it. */
@@ -183,6 +230,8 @@ export class Segmenter {
 		if (track) track.closed = true;
 		if (this.#driver === name) {
 			this.#driver = this.#elect();
+			// The old driver's pending candidate is not a valid boundary for the new one.
+			this.#candidate = undefined;
 		}
 		this.#tryFlush(false);
 	}
@@ -377,6 +426,7 @@ export class Producer {
 		return {
 			track: this.#track,
 			timescale: u53(DEFAULT_TIMESCALE),
+			durationMax: u53(this.#segmenter.durationMax),
 			wall: this.#wall === undefined ? undefined : u53(this.#wall),
 		};
 	}

--- a/js/hang/src/container/timeline.ts
+++ b/js/hang/src/container/timeline.ts
@@ -1,7 +1,8 @@
 /**
- * Publishing a media track's timeline: a companion track that maps each of the track's groups to
- * its start timestamp, so a consumer can seek (or build an HLS/DASH playlist) without downloading
- * the media. See the catalog {@link Catalog.Timeline} section that advertises it.
+ * Publishing a media track's timeline: a companion track indexing the track's segments (one or
+ * more groups each), so a consumer can seek (or build an HLS/DASH playlist) without downloading
+ * the media. Segment numbers are aligned across a broadcast's tracks through a shared
+ * {@link Segmenter}. See the catalog {@link Catalog.Timeline} section that advertises it.
  *
  * @module
  */
@@ -12,8 +13,14 @@ import type { Time } from "@moq/net";
 import type * as Catalog from "../catalog";
 import { MOQ_EPOCH_UNIX_MILLIS, u53 } from "../catalog";
 
-/** One timeline record: the media track opened `group` at presentation time `pts` (in the timeline's timescale). */
+/**
+ * One timeline record: segment `segment` of the media track starts at group `group`, at
+ * presentation time `pts` (in the timeline's timescale). The segment covers every group up to
+ * (excluding) the next record's `group`; segment numbers are aligned across the broadcast's
+ * tracks.
+ */
 export interface Record {
+	segment: number;
 	group: number;
 	pts: number;
 }
@@ -21,8 +28,11 @@ export interface Record {
 /** The default timeline timescale: 1000 units per second (milliseconds). */
 export const DEFAULT_TIMESCALE = 1000;
 
-/** The default record throttle: at most one record per second of media time. */
-export const DEFAULT_GRANULARITY_MS = 1000;
+/**
+ * The default {@link Segmenter} interval: an undriven (audio-only) timeline opens a segment
+ * about once per second of media time.
+ */
+export const DEFAULT_INTERVAL_MS = 1000;
 
 /**
  * The conventional companion timeline track name for a media rendition: `<rendition>.timeline.z`
@@ -32,25 +42,110 @@ export function trackName(rendition: string): string {
 	return `${rendition}.timeline.z`;
 }
 
+/**
+ * How a track's groups map onto the broadcast's aligned segments.
+ *
+ * - `"boundary"`: every group opens the next segment (video: groups open on keyframes, and a
+ *   segment must start on one, so a video segment is exactly one group). The boundary track
+ *   paces the broadcast's segments; wire exactly one per {@link Segmenter}.
+ * - `"aligned"`: groups pack into the segments the boundary track opens (audio: many short
+ *   groups per segment). The first group at or after each boundary starts the track's slice of
+ *   that segment. When no boundary track ever records, the recorder paces segments itself at
+ *   the segmenter's interval, so an audio-only broadcast still segments.
+ */
+export type Cadence = "boundary" | "aligned";
+
+/** Options for a {@link Segmenter}. */
+export interface SegmenterProps {
+	/**
+	 * How often an *undriven* segmenter (no `"boundary"` producer, e.g. an audio-only
+	 * broadcast) opens a new segment, in milliseconds of media time. Ignored once a boundary
+	 * producer is pacing. Defaults to {@link DEFAULT_INTERVAL_MS}.
+	 */
+	interval?: number;
+}
+
+/**
+ * The broadcast-wide segment counter every timeline {@link Producer} shares, so segment numbers
+ * align across tracks.
+ *
+ * Create one per broadcast and pass it to each track's producer. The `"boundary"` producer
+ * advances it; `"aligned"` producers read it, falling back to interval pacing only while no
+ * boundary producer has spoken.
+ */
+export class Segmenter {
+	// The open segment's number and boundary pts (microseconds), undefined before the first group.
+	#current?: { segment: number; boundary: Time.Micro };
+	// A "boundary" producer has opened a segment, so aligned producers never self-pace.
+	#driven = false;
+	// Undriven pacing interval in microseconds.
+	#intervalUs: number;
+
+	constructor(props: SegmenterProps = {}) {
+		this.#intervalUs = (props.interval ?? DEFAULT_INTERVAL_MS) * 1000;
+	}
+
+	/**
+	 * A `"boundary"` group open at `pts`: open the next segment and return its number.
+	 *
+	 * The first boundary adopts a segment an aligned producer self-opened (rather than
+	 * stranding it as a number the boundary track never records), re-anchoring its boundary to
+	 * `pts`; from then on every call opens a new segment.
+	 */
+	boundary(pts: Time.Micro): number {
+		const segment =
+			this.#current === undefined ? 0 : this.#driven ? this.#current.segment + 1 : this.#current.segment;
+		this.#current = { segment, boundary: pts };
+		this.#driven = true;
+		return segment;
+	}
+
+	/**
+	 * An `"aligned"` group open at `pts`, having last recorded `last`: the segment this group
+	 * starts for its track, or undefined if it merely extends the one already recorded.
+	 */
+	align(pts: Time.Micro, last: number | undefined): number | undefined {
+		if (this.#current === undefined) {
+			// The very first group of the broadcast: open segment 0 at its timestamp.
+			this.#current = { segment: 0, boundary: pts };
+			return 0;
+		}
+		const { segment, boundary } = this.#current;
+		if (last !== segment && pts >= boundary) return segment;
+		if (!this.#driven && pts >= boundary + this.#intervalUs) {
+			this.#current = { segment: segment + 1, boundary: pts };
+			return segment + 1;
+		}
+		return undefined;
+	}
+}
+
 /** Options for a timeline {@link Producer}. */
 export interface ProducerProps {
 	/** Units per second for the records' `pts` (and the `wall` anchor). Defaults to milliseconds. */
 	timescale?: number;
 
 	/**
-	 * Record at most one group per this much media time, in milliseconds. Video keyframes are
-	 * already this far apart so every group is indexed; short audio groups are thinned out (a
-	 * consumer extrapolates or fetches to fill a gap). Defaults to {@link DEFAULT_GRANULARITY_MS}.
+	 * The broadcast's shared segment counter, so this track's segment numbers align with its
+	 * siblings'. Defaults to a fresh one (a track segmented on its own).
 	 */
-	granularity?: number;
+	segmenter?: Segmenter;
+
+	/**
+	 * How this track's groups map onto the aligned segments: `"boundary"` for video (every
+	 * group is a segment), `"aligned"` for audio (groups pack into the video's segments).
+	 * Defaults to `"boundary"`.
+	 */
+	cadence?: Cadence;
 }
 
 /**
- * Publishes one media track's timeline: an NDJSON record per group open, DEFLATE-compressed.
+ * Publishes one media track's timeline: an NDJSON record per segment, DEFLATE-compressed.
  *
- * {@link record} appends a group's start once. Advertise it in the rendition's catalog config via
- * {@link section}, and attach it to a {@link Legacy.Producer} (its `timeline` prop) to record group
- * opens automatically.
+ * {@link record} maps each group open onto the aligned segment numbering, appending a record
+ * when the group starts a segment. Advertise it in the rendition's catalog config via
+ * {@link section}, and attach it to a {@link Legacy.Producer} (its `timeline` prop) to record
+ * group opens automatically.
  */
 export class Producer {
 	#stream: Json.Stream.Producer<Record>;
@@ -58,16 +153,17 @@ export class Producer {
 	#timescale: number;
 	// The wall-clock time of pts 0, in timescale units since the moq epoch (advertised in the section).
 	#wall?: number;
-	// Minimum media-time gap between recorded groups (throttle), in microseconds.
-	#granularityUs: number;
-	// The pts (microseconds) of the last recorded group.
-	#lastPts?: number;
+	#segmenter: Segmenter;
+	#cadence: Cadence;
+	// The last segment this track recorded; the cursor an aligned producer dedupes against.
+	#last?: number;
 
 	/** Wrap an already-created MoQ track (named per {@link trackName}) to publish a rendition's timeline. */
 	constructor(track: Moq.Track.Producer, props: ProducerProps = {}) {
 		this.#track = track.name;
 		this.#timescale = props.timescale ?? DEFAULT_TIMESCALE;
-		this.#granularityUs = (props.granularity ?? DEFAULT_GRANULARITY_MS) * 1000;
+		this.#segmenter = props.segmenter ?? new Segmenter();
+		this.#cadence = props.cadence ?? "boundary";
 		this.#stream = new Json.Stream.Producer<Record>(track, { compression: true });
 	}
 
@@ -99,14 +195,16 @@ export class Producer {
 	}
 
 	/**
-	 * Record that group `sequence` opened at presentation time `pts` (microseconds), unless it
-	 * falls within the {@link ProducerProps.granularity} of the last recorded group (skipped, so a
-	 * consumer extrapolates or fetches to fill the gap).
+	 * Record that group `sequence` opened at presentation time `pts` (microseconds). Per the
+	 * {@link Cadence}, the group either opens a segment (recorded) or extends the current one
+	 * (skipped).
 	 */
 	record(sequence: number, pts: Time.Micro): void {
-		if (this.#lastPts !== undefined && pts < this.#lastPts + this.#granularityUs) return;
-		this.#lastPts = pts;
-		this.#stream.append({ group: sequence, pts: Math.floor((pts * this.#timescale) / 1_000_000) });
+		const segment =
+			this.#cadence === "boundary" ? this.#segmenter.boundary(pts) : this.#segmenter.align(pts, this.#last);
+		if (segment === undefined) return;
+		this.#last = segment;
+		this.#stream.append({ segment, group: sequence, pts: Math.floor((pts * this.#timescale) / 1_000_000) });
 	}
 
 	/** Finish the timeline track. */

--- a/rs/hang/src/catalog/audio/mod.rs
+++ b/rs/hang/src/catalog/audio/mod.rs
@@ -112,11 +112,6 @@ pub struct AudioConfig {
 	#[serde_as(as = "Option<DurationMilliSeconds<u64>>")]
 	#[serde(default)]
 	pub jitter: Option<std::time::Duration>,
-
-	/// The companion timeline track indexing this rendition's groups, if the publisher
-	/// offers one. See [`Timeline`](crate::catalog::Timeline).
-	#[serde(default)]
-	pub timeline: Option<crate::catalog::Timeline>,
 }
 
 impl AudioConfig {
@@ -136,7 +131,6 @@ impl AudioConfig {
 			description: None,
 			container: Container::default(),
 			jitter: None,
-			timeline: None,
 		}
 	}
 }

--- a/rs/hang/src/catalog/root.rs
+++ b/rs/hang/src/catalog/root.rs
@@ -33,6 +33,11 @@ pub struct Catalog {
 	/// based on their preferences (codec, bitrate, language, etc).
 	#[serde(default)]
 	pub audio: Audio,
+
+	/// The broadcast's timeline track (its aligned segment index), if the publisher offers
+	/// one. See [`Timeline`](crate::catalog::Timeline) and the [`timeline`](crate::timeline)
+	/// module.
+	pub timeline: Option<crate::catalog::Timeline>,
 }
 
 impl Catalog {
@@ -219,7 +224,6 @@ mod test {
 				optimize_for_latency: None,
 				container: Container::Legacy,
 				jitter: Some(std::time::Duration::from_millis(100)),
-				timeline: None,
 			},
 		);
 
@@ -235,7 +239,6 @@ mod test {
 				description: None,
 				container: Container::Legacy,
 				jitter: Some(std::time::Duration::from_millis(40)),
-				timeline: None,
 			},
 		);
 

--- a/rs/hang/src/catalog/timeline.rs
+++ b/rs/hang/src/catalog/timeline.rs
@@ -32,15 +32,17 @@ pub struct Timeline {
 	pub timescale: u32,
 
 	/// The declared upper bound on a segment's duration, in [`timescale`](Self::timescale)
-	/// units.
+	/// units, when the publisher can promise one.
 	///
-	/// The encoder knows its keyframe cadence (or the cutter its boundaries), so the bound is
-	/// declared up front rather than observed: a consumer can size buffers, and an HLS
-	/// exporter can write `EXT-X-TARGETDURATION`, from the catalog alone. A segment may
-	/// exceed it only slightly (under half a second, the same tolerance HLS's
-	/// nearest-integer rounding grants), or arbitrarily when the media leaves no valid
-	/// boundary (a GOP longer than the bound).
-	pub duration_max: u64,
+	/// A publisher that controls its encoder knows its keyframe cadence up front, so a consumer
+	/// can size buffers or write an HLS `EXT-X-TARGETDURATION` from the catalog alone, before
+	/// observing a single segment. No record ever exceeds it: the publisher fails the timeline
+	/// rather than contradict this.
+	///
+	/// Absent when the media decides instead, which is the common case for real-time (where a
+	/// GOP can be minutes long) and for a publisher importing a source it doesn't control. A
+	/// consumer needing a bound then derives one from the records it has seen.
+	pub duration_max: Option<u64>,
 
 	/// The wall-clock time of `pts` 0, in [`timescale`](Self::timescale) units since the moq
 	/// epoch ([`MOQ_EPOCH_UNIX_MILLIS`], 2020-01-01), if known. A consumer derives the wall-clock
@@ -59,14 +61,15 @@ impl Timeline {
 		1000
 	}
 
-	/// A timeline section naming `track` with the declared segment-duration bound
-	/// `duration_max` (in timescale units), at the default millisecond timescale and with no
-	/// wall-clock anchor. Set [`timescale`](Self::timescale) / [`wall`](Self::wall) afterward.
-	pub fn new(track: impl Into<String>, duration_max: u64) -> Self {
+	/// A timeline section naming `track`, at the default millisecond timescale, with no
+	/// declared duration bound and no wall-clock anchor. Set
+	/// [`timescale`](Self::timescale) / [`duration_max`](Self::duration_max) /
+	/// [`wall`](Self::wall) afterward.
+	pub fn new(track: impl Into<String>) -> Self {
 		Self {
 			track: track.into(),
 			timescale: Self::default_timescale(),
-			duration_max,
+			duration_max: None,
 			wall: None,
 		}
 	}
@@ -82,19 +85,25 @@ mod test {
 		let decoded: Timeline = serde_json::from_str(json).unwrap();
 		assert_eq!(decoded.track, "timeline.z");
 		assert_eq!(decoded.timescale, 1000);
-		assert_eq!(decoded.duration_max, 2000);
+		assert_eq!(decoded.duration_max, Some(2000));
 		assert_eq!(decoded.wall, None);
 	}
 
 	#[test]
-	fn duration_max_is_required() {
+	fn duration_max_is_optional() {
 		let json = r#"{"track":"timeline.z"}"#;
-		assert!(serde_json::from_str::<Timeline>(json).is_err());
+		let decoded: Timeline = serde_json::from_str(json).unwrap();
+		assert_eq!(decoded.duration_max, None);
+		assert_eq!(
+			serde_json::to_string(&decoded).unwrap(),
+			r#"{"track":"timeline.z","timescale":1000}"#
+		);
 	}
 
 	#[test]
 	fn roundtrip_with_wall() {
-		let mut timeline = Timeline::new("timeline.z", 2000);
+		let mut timeline = Timeline::new("timeline.z");
+		timeline.duration_max = Some(2000);
 		timeline.wall = Some(1_751_846_400_000);
 		let json = serde_json::to_string(&timeline).unwrap();
 		assert_eq!(

--- a/rs/hang/src/catalog/timeline.rs
+++ b/rs/hang/src/catalog/timeline.rs
@@ -31,6 +31,17 @@ pub struct Timeline {
 	#[serde(default = "Timeline::default_timescale")]
 	pub timescale: u32,
 
+	/// The declared upper bound on a segment's duration, in [`timescale`](Self::timescale)
+	/// units.
+	///
+	/// The encoder knows its keyframe cadence (or the cutter its boundaries), so the bound is
+	/// declared up front rather than observed: a consumer can size buffers, and an HLS
+	/// exporter can write `EXT-X-TARGETDURATION`, from the catalog alone. A segment may
+	/// exceed it only slightly (under half a second, the same tolerance HLS's
+	/// nearest-integer rounding grants), or arbitrarily when the media leaves no valid
+	/// boundary (a GOP longer than the bound).
+	pub duration_max: u64,
+
 	/// The wall-clock time of `pts` 0, in [`timescale`](Self::timescale) units since the moq
 	/// epoch ([`MOQ_EPOCH_UNIX_MILLIS`], 2020-01-01), if known. A consumer derives the wall-clock
 	/// time of any group as `wall + pts`, and Unix time by adding the moq epoch back (an absolute
@@ -48,12 +59,14 @@ impl Timeline {
 		1000
 	}
 
-	/// A timeline section naming `track`, at the default millisecond timescale and with no
+	/// A timeline section naming `track` with the declared segment-duration bound
+	/// `duration_max` (in timescale units), at the default millisecond timescale and with no
 	/// wall-clock anchor. Set [`timescale`](Self::timescale) / [`wall`](Self::wall) afterward.
-	pub fn new(track: impl Into<String>) -> Self {
+	pub fn new(track: impl Into<String>, duration_max: u64) -> Self {
 		Self {
 			track: track.into(),
 			timescale: Self::default_timescale(),
+			duration_max,
 			wall: None,
 		}
 	}
@@ -65,19 +78,29 @@ mod test {
 
 	#[test]
 	fn defaults_timescale_to_ms() {
-		let json = r#"{"track":"timeline.z"}"#;
+		let json = r#"{"track":"timeline.z","durationMax":2000}"#;
 		let decoded: Timeline = serde_json::from_str(json).unwrap();
 		assert_eq!(decoded.track, "timeline.z");
 		assert_eq!(decoded.timescale, 1000);
+		assert_eq!(decoded.duration_max, 2000);
 		assert_eq!(decoded.wall, None);
 	}
 
 	#[test]
+	fn duration_max_is_required() {
+		let json = r#"{"track":"timeline.z"}"#;
+		assert!(serde_json::from_str::<Timeline>(json).is_err());
+	}
+
+	#[test]
 	fn roundtrip_with_wall() {
-		let mut timeline = Timeline::new("timeline.z");
+		let mut timeline = Timeline::new("timeline.z", 2000);
 		timeline.wall = Some(1_751_846_400_000);
 		let json = serde_json::to_string(&timeline).unwrap();
-		assert_eq!(json, r#"{"track":"timeline.z","timescale":1000,"wall":1751846400000}"#);
+		assert_eq!(
+			json,
+			r#"{"track":"timeline.z","timescale":1000,"durationMax":2000,"wall":1751846400000}"#
+		);
 		assert_eq!(serde_json::from_str::<Timeline>(&json).unwrap(), timeline);
 	}
 }

--- a/rs/hang/src/catalog/timeline.rs
+++ b/rs/hang/src/catalog/timeline.rs
@@ -7,26 +7,23 @@ use serde::{Deserialize, Serialize};
 /// consumer recovers Unix time by adding this back.
 pub const MOQ_EPOCH_UNIX_MILLIS: u64 = 1_577_836_800_000;
 
-/// Describes a media track's companion timeline track.
+/// Describes the broadcast's timeline track, its segment index.
 ///
-/// A timeline track is the media track's segment index: each record maps a segment (one or
-/// more groups) to its starting group and timestamp (see the [`timeline`](crate::timeline)
-/// module for the record format), so a consumer can seek, or build an HLS/DASH playlist,
-/// without downloading the media itself. This section, present on a
-/// [`VideoConfig`](crate::catalog::VideoConfig) or
-/// [`AudioConfig`](crate::catalog::AudioConfig) when the publisher offers one, points at that
-/// track and declares how to read its timestamps.
+/// The timeline track carries one record per aligned segment: a span of content time shared
+/// by every media track, mapped to the group ranges that carry it on each track (see the
+/// [`timeline`](crate::timeline) module for the record format). A consumer can seek, or build
+/// an HLS/DASH playlist, without downloading the media itself.
 ///
-/// The section is per media track on purpose: a video segment is a single group while an audio
-/// segment packs many shorter ones, so each track needs its own group mapping. Only the
-/// segment *numbers* are shared: segment N covers the same span of content time on every
-/// track, which is what makes the timelines sufficient for HLS/DASH export.
+/// The section lives at the catalog root ([`Catalog::timeline`](crate::Catalog)): there is one
+/// timeline per broadcast, because its whole point is that segments are aligned across the
+/// broadcast's tracks. A publisher that doesn't segment simply omits it.
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub struct Timeline {
-	/// The name of the companion MoQ track carrying this track's group -> timestamp records.
+	/// The name of the MoQ track carrying the broadcast's segment records
+	/// ([`timeline::DEFAULT_NAME`](crate::timeline::DEFAULT_NAME) by convention).
 	pub track: String,
 
 	/// Units per second for the timeline's `pts` and [`wall`](Self::wall). Defaults to 1000
@@ -68,22 +65,19 @@ mod test {
 
 	#[test]
 	fn defaults_timescale_to_ms() {
-		let json = r#"{"track":"video0.timeline"}"#;
+		let json = r#"{"track":"timeline.z"}"#;
 		let decoded: Timeline = serde_json::from_str(json).unwrap();
-		assert_eq!(decoded.track, "video0.timeline");
+		assert_eq!(decoded.track, "timeline.z");
 		assert_eq!(decoded.timescale, 1000);
 		assert_eq!(decoded.wall, None);
 	}
 
 	#[test]
 	fn roundtrip_with_wall() {
-		let mut timeline = Timeline::new("audio0.timeline");
+		let mut timeline = Timeline::new("timeline.z");
 		timeline.wall = Some(1_751_846_400_000);
 		let json = serde_json::to_string(&timeline).unwrap();
-		assert_eq!(
-			json,
-			r#"{"track":"audio0.timeline","timescale":1000,"wall":1751846400000}"#
-		);
+		assert_eq!(json, r#"{"track":"timeline.z","timescale":1000,"wall":1751846400000}"#);
 		assert_eq!(serde_json::from_str::<Timeline>(&json).unwrap(), timeline);
 	}
 }

--- a/rs/hang/src/catalog/timeline.rs
+++ b/rs/hang/src/catalog/timeline.rs
@@ -9,16 +9,18 @@ pub const MOQ_EPOCH_UNIX_MILLIS: u64 = 1_577_836_800_000;
 
 /// Describes a media track's companion timeline track.
 ///
-/// A timeline track maps each of the media track's groups to its start timestamp (see the
-/// [`timeline`](crate::timeline) module for the record format), so a consumer can seek, or
-/// build an HLS/DASH playlist, without downloading the media itself. This section, present on
-/// a [`VideoConfig`](crate::catalog::VideoConfig) or
+/// A timeline track is the media track's segment index: each record maps a segment (one or
+/// more groups) to its starting group and timestamp (see the [`timeline`](crate::timeline)
+/// module for the record format), so a consumer can seek, or build an HLS/DASH playlist,
+/// without downloading the media itself. This section, present on a
+/// [`VideoConfig`](crate::catalog::VideoConfig) or
 /// [`AudioConfig`](crate::catalog::AudioConfig) when the publisher offers one, points at that
 /// track and declares how to read its timestamps.
 ///
-/// The section is per media track on purpose: audio and video groups have different
-/// durations (and metadata tracks different still), so a single broadcast-wide timeline can't
-/// describe them all. Each media track carries its own.
+/// The section is per media track on purpose: a video segment is a single group while an audio
+/// segment packs many shorter ones, so each track needs its own group mapping. Only the
+/// segment *numbers* are shared: segment N covers the same span of content time on every
+/// track, which is what makes the timelines sufficient for HLS/DASH export.
 #[serde_with::skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/rs/hang/src/catalog/video/mod.rs
+++ b/rs/hang/src/catalog/video/mod.rs
@@ -215,11 +215,6 @@ pub struct VideoConfig {
 	#[serde_as(as = "Option<DurationMilliSeconds<u64>>")]
 	#[serde(default)]
 	pub jitter: Option<std::time::Duration>,
-
-	/// The companion timeline track indexing this rendition's groups, if the publisher
-	/// offers one. See [`Timeline`](crate::catalog::Timeline).
-	#[serde(default)]
-	pub timeline: Option<crate::catalog::Timeline>,
 }
 
 impl VideoConfig {
@@ -243,7 +238,6 @@ impl VideoConfig {
 			optimize_for_latency: None,
 			container: Container::default(),
 			jitter: None,
-			timeline: None,
 		}
 	}
 }

--- a/rs/hang/src/lib.rs
+++ b/rs/hang/src/lib.rs
@@ -22,7 +22,7 @@ pub mod catalog;
 /// The container is the contents of each media track.
 pub mod container;
 
-/// The timeline indexes a media track's aligned segments.
+/// The timeline indexes the broadcast's aligned segments.
 pub mod timeline;
 
 /// Export the moq-net version we use.

--- a/rs/hang/src/lib.rs
+++ b/rs/hang/src/lib.rs
@@ -6,7 +6,7 @@
 //!
 //! - **Catalog**: A JSON track containing codec info and track metadata, updated live as tracks change.
 //! - **Tracks**: Audio or video, supporting one or more renditions.
-//! - **Timeline**: A JSON track mapping each media group to its start timestamp, so a
+//! - **Timeline**: A JSON track indexing a media track's aligned segments (one or more groups each), so a
 //!   consumer can seek (or build indexes/playlists) without downloading media.
 //!
 //! Each track specifies a container format:
@@ -22,7 +22,7 @@ pub mod catalog;
 /// The container is the contents of each media track.
 pub mod container;
 
-/// The timeline maps each media group to its start timestamp.
+/// The timeline indexes a media track's aligned segments.
 pub mod timeline;
 
 /// Export the moq-net version we use.

--- a/rs/hang/src/timeline.rs
+++ b/rs/hang/src/timeline.rs
@@ -1,74 +1,122 @@
-//! The timeline track: an ordered log of a media track's segments, each one or more groups.
+//! The timeline track: the broadcast's segment index, one record per aligned segment.
 //!
 //! MoQ groups carry only an opaque sequence number; the timestamps live inside the media
-//! frames. A timeline track republishes a segment index as metadata: each record says "segment
-//! N of this track starts at group G, at presentation time T". A consumer can answer "which
-//! groups cover time T" (and "where is the live edge") from a few bytes per segment instead of
-//! downloading the media itself. That is exactly the information an HLS/DASH origin needs to
-//! render playlists without touching media bytes, and the index a VOD player seeks with.
+//! frames. The timeline track republishes the broadcast's segmentation as metadata: each
+//! record describes one *segment*, a span of content time shared by every media track, and
+//! maps it to the group ranges that carry it on each track. A consumer can answer "which
+//! groups cover time T on track X" (and "where is the live edge") from a few bytes per
+//! segment without downloading media. That is exactly what an HLS/DASH origin needs to render
+//! playlists without touching media bytes, and the index a VOD player seeks with.
 //!
 //! ## Segments
 //!
-//! A segment is one or more consecutive groups of a track: it spans from its record's `group`
-//! up to (excluding) the next record's `group`, and its duration is the gap to the next
-//! record's `pts`. Segment numbers are *aligned across the tracks of a broadcast*: segment 5
-//! of the audio timeline covers the same span of content time as segment 5 of the video
-//! timeline. Alignment at group granularity is what makes the timelines sufficient for
-//! HLS/DASH export, where renditions must cut at the same boundaries to be switchable.
+//! A segment covers the same span of content time on every track of the broadcast, which is
+//! what HLS requires of switchable renditions. Segment boundaries land on video keyframes
+//! (every group already opens on one), so a video track contributes whole groups to each
+//! segment; an audio track packs however many of its shorter groups fall inside the span.
+//! A record is published once the segment is *complete*: every participating track's groups
+//! for the span are known, so the record is self-contained and immediately servable.
 //!
-//! The tracks still differ in how many groups a segment holds. Video groups open on keyframes,
-//! and a keyframe is where a segment must start, so a video segment is exactly one group.
-//! Audio groups are much shorter, so an audio segment packs every audio group whose start
-//! falls inside the segment's span (the record names the first; the rest follow contiguously
-//! until the next record's group).
+//! There is one timeline per broadcast, advertised by the catalog's root
+//! [`Timeline`](crate::catalog::Timeline) section (its `track` field names this track,
+//! [`DEFAULT_NAME`](crate::timeline::DEFAULT_NAME) by convention). A broadcast that doesn't need aligned segments simply
+//! doesn't publish one.
 //!
-//! A timeline is still per media track: each track's catalog entry carries a
-//! [`Timeline`](crate::catalog::Timeline) section naming its companion timeline track, the
-//! timescale its `pts` values use (default milliseconds), and an optional wall-clock anchor.
-//! Only the segment *numbering* is shared.
-//!
-//! On the wire the track is a `moq-json` *stream* (see `moq_json::stream`): a single group, one
-//! DEFLATE-compressed record per frame. Like the catalog, a record tolerates and preserves
-//! unknown fields: extend it by flattening a `Record` into your own struct, or read its `ext`
-//! field directly.
+//! On the wire the track is a `moq-json` *stream* (see `moq_json::stream`): a single group,
+//! one DEFLATE-compressed record per frame, every record preserved in order. Like the catalog,
+//! a record tolerates and preserves unknown fields: extend it by flattening a [`Record`](crate::timeline::Record) into
+//! your own struct via [`RecordExt`](crate::timeline::RecordExt).
+
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
 use crate::Result;
 
-/// The application extension carried alongside a record's `segment`/`group`/`pts`.
+/// The conventional name for a broadcast's timeline track (the `.z` marks the
+/// DEFLATE-compressed stream, like the catalog's `.json.z` sibling).
+///
+/// A publisher records the actual name in the catalog's root
+/// [`Timeline::track`](crate::catalog::Timeline::track) field; a consumer reads it from the
+/// catalog rather than assuming, so this is only a default.
+pub const DEFAULT_NAME: &str = "timeline.z";
+
+/// The application extension carried alongside a record's base fields.
 ///
 /// Defaults to `()` (no extra fields). Set an application's own typed struct to add fields
-/// (e.g. a discontinuity flag, a measured bitrate); it is flattened into the record's JSON
-/// object, exactly like [`Catalog`](crate::Catalog)'s extension. `()` is the base case.
+/// (e.g. an ad-break marker); it is flattened into the record's JSON object, exactly like
+/// [`Catalog`](crate::Catalog)'s extension. `()` is the base case.
 pub trait RecordExt: serde::Serialize + serde::de::DeserializeOwned + Default + Clone + Send + Unpin + 'static {}
 impl RecordExt for () {}
 
-/// One timeline record: segment `segment` of the media track starts at group `group`, at
-/// presentation time `pts`.
+/// A contiguous run of groups a track contributes to a segment, `start` through `end`
+/// inclusive.
 ///
-/// Records are appended when the segment's first group opens, so the live edge of the timeline
-/// is the live edge of the broadcast. A segment's group span and duration are implicit: it runs
-/// until the next record's `group` and `pts`. Segment numbers are aligned across the broadcast's
-/// tracks (see the [module docs](self)); `pts` is in the timescale declared by the track's
-/// [`Timeline`](crate::catalog::Timeline) catalog section (default milliseconds). Extend it with
-/// a typed [`RecordExt`].
+/// A track's segment entry is an array of these: more than one range means the group
+/// sequence is discontinuous inside the segment (groups that never existed, e.g. a gappy
+/// source).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct Range {
+	/// The first group of the run, as used by FETCH/SUBSCRIBE on the media track.
+	pub start: u64,
+
+	/// The last group of the run, inclusive.
+	pub end: u64,
+
+	/// Whether the run's first group starts with a keyframe, i.e. whether a player can join or
+	/// switch renditions at this range. Defaults to `true` (and is omitted from the JSON when
+	/// true); a publisher sets `false` when a source resumes without one, so an exporter knows
+	/// not to advertise the segment as independently decodable.
+	#[serde(default = "Range::default_keyframe", skip_serializing_if = "Clone::clone")]
+	pub keyframe: bool,
+}
+
+impl Range {
+	fn default_keyframe() -> bool {
+		true
+	}
+
+	/// A range covering groups `start` through `end` inclusive, starting on a keyframe.
+	pub fn new(start: u64, end: u64) -> Self {
+		Self {
+			start,
+			end,
+			keyframe: true,
+		}
+	}
+}
+
+/// One timeline record: a complete aligned segment, mapping its span of content time to the
+/// group ranges that carry it on each track.
+///
+/// Records are self-contained: `pts` and `duration` bound the span (no peeking at the next
+/// record), and `tracks` names every participating media track's group ranges. A track absent
+/// from `tracks` has no content for the span (a gap; HLS `EXT-X-GAP`). `pts`/`duration` are in
+/// the timescale declared by the catalog's [`Timeline`](crate::catalog::Timeline) section
+/// (default milliseconds). Extend with a typed [`RecordExt`].
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(
 	rename_all = "camelCase",
 	bound(serialize = "E: serde::Serialize", deserialize = "E: serde::de::DeserializeOwned")
 )]
 pub struct Record<E: RecordExt = ()> {
-	/// The segment's number, aligned across the broadcast's tracks.
+	/// The segment's number. Consecutive within a broadcast, so it anchors HLS
+	/// `EXT-X-MEDIA-SEQUENCE`; explicit (rather than implied by record order) so a reader
+	/// joining mid-stream or across a windowed recording keeps stable numbering.
 	pub segment: u64,
 
-	/// The segment's first group, as used by FETCH/SUBSCRIBE on the media track. The segment
-	/// covers every group up to (excluding) the next record's `group`.
-	pub group: u64,
-
-	/// The segment's start (its first frame's presentation timestamp), in the timeline's
-	/// timescale.
+	/// The segment's start, in the timeline's timescale.
 	pub pts: u64,
+
+	/// The segment's duration, in the timeline's timescale. The next record's `pts` is
+	/// `pts + duration` unless content time itself jumped (a discontinuity).
+	pub duration: u64,
+
+	/// The group ranges each participating media track contributes to this segment, keyed by
+	/// track name. A track absent from the map has no content in this span.
+	#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+	pub tracks: BTreeMap<String, Vec<Range>>,
 
 	/// The application extension, flattened into the record's JSON object (nothing for the
 	/// default `()`). See [`RecordExt`].
@@ -77,12 +125,14 @@ pub struct Record<E: RecordExt = ()> {
 }
 
 impl<E: RecordExt> Record<E> {
-	/// A record with the default (empty) extension.
-	pub fn new(segment: u64, group: u64, pts: u64) -> Self {
+	/// A record with no tracks and the default (empty) extension; fill in
+	/// [`tracks`](Self::tracks) afterward.
+	pub fn new(segment: u64, pts: u64, duration: u64) -> Self {
 		Self {
 			segment,
-			group,
 			pts,
+			duration,
+			tracks: BTreeMap::new(),
 			ext: E::default(),
 		}
 	}
@@ -98,27 +148,58 @@ impl<E: RecordExt> Record<E> {
 	}
 }
 
-/// The conventional companion timeline track name for a media rendition: `<rendition>.timeline.z`
-/// (the `.z` marks the DEFLATE-compressed stream, like the catalog's `.json.z` sibling).
-///
-/// A publisher names the timeline track this way and records it in the media track's
-/// [`Timeline::track`](crate::catalog::Timeline::track) catalog field; a consumer reads the
-/// name from the catalog rather than reconstructing it, so this is only a default.
-pub fn track_name(rendition: &str) -> String {
-	format!("{rendition}.timeline.z")
-}
-
 #[cfg(test)]
 mod test {
 	use super::*;
 
 	#[test]
 	fn roundtrip() {
-		let record = Record::<()>::new(3, 42, 84_000);
+		let mut record = Record::<()>::new(3, 84_000, 6_000);
+		record.tracks.insert("video".to_string(), vec![Range::new(42, 42)]);
+		record
+			.tracks
+			.insert("audio".to_string(), vec![Range::new(512, 540), Range::new(550, 560)]);
+
 		let json = record.to_vec().unwrap();
 		assert_eq!(
 			std::str::from_utf8(&json).unwrap(),
-			r#"{"segment":3,"group":42,"pts":84000}"#
+			concat!(
+				r#"{"segment":3,"pts":84000,"duration":6000,"tracks":{"#,
+				r#""audio":[{"start":512,"end":540},{"start":550,"end":560}],"#,
+				r#""video":[{"start":42,"end":42}]}}"#
+			)
+		);
+		assert_eq!(Record::<()>::from_slice(&json).unwrap(), record);
+	}
+
+	#[test]
+	fn keyframe_false_roundtrips_and_true_is_omitted() {
+		let mut range = Range::new(7, 9);
+		range.keyframe = false;
+		let mut record = Record::<()>::new(0, 0, 2_000);
+		record.tracks.insert("video".to_string(), vec![range]);
+
+		let json = record.to_vec().unwrap();
+		assert_eq!(
+			std::str::from_utf8(&json).unwrap(),
+			r#"{"segment":0,"pts":0,"duration":2000,"tracks":{"video":[{"start":7,"end":9,"keyframe":false}]}}"#
+		);
+
+		let decoded = Record::<()>::from_slice(&json).unwrap();
+		assert_eq!(decoded, record);
+		// An omitted flag decodes as the keyframe default.
+		let plain: Record =
+			Record::from_slice(br#"{"segment":0,"pts":0,"duration":1,"tracks":{"v":[{"start":1,"end":1}]}}"#).unwrap();
+		assert!(plain.tracks["v"][0].keyframe);
+	}
+
+	#[test]
+	fn empty_tracks_is_omitted() {
+		let record = Record::<()>::new(1, 1_000, 500);
+		let json = record.to_vec().unwrap();
+		assert_eq!(
+			std::str::from_utf8(&json).unwrap(),
+			r#"{"segment":1,"pts":1000,"duration":500}"#
 		);
 		assert_eq!(Record::<()>::from_slice(&json).unwrap(), record);
 	}
@@ -135,20 +216,16 @@ mod test {
 
 		let record = Record {
 			segment: 2,
-			group: 7,
 			pts: 14_000,
+			duration: 2_000,
+			tracks: BTreeMap::new(),
 			ext: Ext { discontinuity: true },
 		};
 		let json = record.to_vec().unwrap();
 		assert_eq!(
 			std::str::from_utf8(&json).unwrap(),
-			r#"{"segment":2,"group":7,"pts":14000,"discontinuity":true}"#
+			r#"{"segment":2,"pts":14000,"duration":2000,"discontinuity":true}"#
 		);
 		assert_eq!(Record::<Ext>::from_slice(&json).unwrap(), record);
-	}
-
-	#[test]
-	fn conventional_track_name() {
-		assert_eq!(track_name("video0"), "video0.timeline.z");
 	}
 }

--- a/rs/hang/src/timeline.rs
+++ b/rs/hang/src/timeline.rs
@@ -1,32 +1,42 @@
-//! The timeline track: an ordered log mapping each of a media track's groups to its start
-//! timestamp.
+//! The timeline track: an ordered log of a media track's segments, each one or more groups.
 //!
 //! MoQ groups carry only an opaque sequence number; the timestamps live inside the media
-//! frames. A timeline track republishes that mapping as metadata, so a consumer can answer
-//! "which group covers time T" (and "where is the live edge") from a few bytes per group
-//! instead of downloading the media itself. That is the primitive an HLS/DASH origin needs to
+//! frames. A timeline track republishes a segment index as metadata: each record says "segment
+//! N of this track starts at group G, at presentation time T". A consumer can answer "which
+//! groups cover time T" (and "where is the live edge") from a few bytes per segment instead of
+//! downloading the media itself. That is exactly the information an HLS/DASH origin needs to
 //! render playlists without touching media bytes, and the index a VOD player seeks with.
 //!
-//! A timeline is per media track (audio and video groups have different durations, so they
-//! can't share one). The media track's catalog entry carries a
-//! [`Timeline`](crate::catalog::Timeline) section naming the companion timeline track and its
-//! timescale (`pts` is in those units, default milliseconds) and optional wall-clock anchor.
-//! This module is just the wire record on that track.
+//! ## Segments
+//!
+//! A segment is one or more consecutive groups of a track: it spans from its record's `group`
+//! up to (excluding) the next record's `group`, and its duration is the gap to the next
+//! record's `pts`. Segment numbers are *aligned across the tracks of a broadcast*: segment 5
+//! of the audio timeline covers the same span of content time as segment 5 of the video
+//! timeline. Alignment at group granularity is what makes the timelines sufficient for
+//! HLS/DASH export, where renditions must cut at the same boundaries to be switchable.
+//!
+//! The tracks still differ in how many groups a segment holds. Video groups open on keyframes,
+//! and a keyframe is where a segment must start, so a video segment is exactly one group.
+//! Audio groups are much shorter, so an audio segment packs every audio group whose start
+//! falls inside the segment's span (the record names the first; the rest follow contiguously
+//! until the next record's group).
+//!
+//! A timeline is still per media track: each track's catalog entry carries a
+//! [`Timeline`](crate::catalog::Timeline) section naming its companion timeline track, the
+//! timescale its `pts` values use (default milliseconds), and an optional wall-clock anchor.
+//! Only the segment *numbering* is shared.
 //!
 //! On the wire the track is a `moq-json` *stream* (see `moq_json::stream`): a single group, one
-//! DEFLATE-compressed record per frame. The record shape follows the `mediatimeline` concept
-//! from [draft-ietf-moq-msf](https://datatracker.ietf.org/doc/draft-ietf-moq-msf/), with JSON
-//! keys instead of positional arrays (DEFLATE absorbs the repeated keys) and a moq-lite group
-//! sequence instead of a `[group, object]` location (moq-lite has no object IDs).
-//!
-//! Like the catalog, a record tolerates and preserves unknown fields: extend it by flattening
-//! a `Record` into your own struct, or read its `ext` field directly.
+//! DEFLATE-compressed record per frame. Like the catalog, a record tolerates and preserves
+//! unknown fields: extend it by flattening a `Record` into your own struct, or read its `ext`
+//! field directly.
 
 use serde::{Deserialize, Serialize};
 
 use crate::Result;
 
-/// The application extension carried alongside a record's `group`/`pts`.
+/// The application extension carried alongside a record's `segment`/`group`/`pts`.
 ///
 /// Defaults to `()` (no extra fields). Set an application's own typed struct to add fields
 /// (e.g. a discontinuity flag, a measured bitrate); it is flattened into the record's JSON
@@ -34,22 +44,29 @@ use crate::Result;
 pub trait RecordExt: serde::Serialize + serde::de::DeserializeOwned + Default + Clone + Send + Unpin + 'static {}
 impl RecordExt for () {}
 
-/// One timeline record: the media track opened group `group` at presentation time `pts`.
+/// One timeline record: segment `segment` of the media track starts at group `group`, at
+/// presentation time `pts`.
 ///
-/// Records are appended when the media group opens, so the live edge of the timeline is the
-/// live edge of the broadcast. A group's duration is implicit: the gap to the next record.
-/// `pts` is in the timescale declared by the track's [`Timeline`](crate::catalog::Timeline)
-/// catalog section (default milliseconds). Extend it with a typed [`RecordExt`].
+/// Records are appended when the segment's first group opens, so the live edge of the timeline
+/// is the live edge of the broadcast. A segment's group span and duration are implicit: it runs
+/// until the next record's `group` and `pts`. Segment numbers are aligned across the broadcast's
+/// tracks (see the [module docs](self)); `pts` is in the timescale declared by the track's
+/// [`Timeline`](crate::catalog::Timeline) catalog section (default milliseconds). Extend it with
+/// a typed [`RecordExt`].
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(
 	rename_all = "camelCase",
 	bound(serialize = "E: serde::Serialize", deserialize = "E: serde::de::DeserializeOwned")
 )]
 pub struct Record<E: RecordExt = ()> {
-	/// The group's sequence number, as used by FETCH/SUBSCRIBE on the media track.
+	/// The segment's number, aligned across the broadcast's tracks.
+	pub segment: u64,
+
+	/// The segment's first group, as used by FETCH/SUBSCRIBE on the media track. The segment
+	/// covers every group up to (excluding) the next record's `group`.
 	pub group: u64,
 
-	/// The group's start (its first frame's presentation timestamp), in the timeline's
+	/// The segment's start (its first frame's presentation timestamp), in the timeline's
 	/// timescale.
 	pub pts: u64,
 
@@ -61,8 +78,9 @@ pub struct Record<E: RecordExt = ()> {
 
 impl<E: RecordExt> Record<E> {
 	/// A record with the default (empty) extension.
-	pub fn new(group: u64, pts: u64) -> Self {
+	pub fn new(segment: u64, group: u64, pts: u64) -> Self {
 		Self {
+			segment,
 			group,
 			pts,
 			ext: E::default(),
@@ -96,9 +114,12 @@ mod test {
 
 	#[test]
 	fn roundtrip() {
-		let record = Record::<()>::new(42, 84_000);
+		let record = Record::<()>::new(3, 42, 84_000);
 		let json = record.to_vec().unwrap();
-		assert_eq!(std::str::from_utf8(&json).unwrap(), r#"{"group":42,"pts":84000}"#);
+		assert_eq!(
+			std::str::from_utf8(&json).unwrap(),
+			r#"{"segment":3,"group":42,"pts":84000}"#
+		);
 		assert_eq!(Record::<()>::from_slice(&json).unwrap(), record);
 	}
 
@@ -113,6 +134,7 @@ mod test {
 		impl RecordExt for Ext {}
 
 		let record = Record {
+			segment: 2,
 			group: 7,
 			pts: 14_000,
 			ext: Ext { discontinuity: true },
@@ -120,7 +142,7 @@ mod test {
 		let json = record.to_vec().unwrap();
 		assert_eq!(
 			std::str::from_utf8(&json).unwrap(),
-			r#"{"group":7,"pts":14000,"discontinuity":true}"#
+			r#"{"segment":2,"group":7,"pts":14000,"discontinuity":true}"#
 		);
 		assert_eq!(Record::<Ext>::from_slice(&json).unwrap(), record);
 	}

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -107,7 +107,7 @@ impl<E: CatalogExt> Producer<E> {
 	/// rendition in `catalog` immediately.
 	pub fn new(
 		broadcast: &mut moq_net::broadcast::Producer,
-		catalog: moq_mux::catalog::Producer<E>,
+		mut catalog: moq_mux::catalog::Producer<E>,
 		input: Input,
 		options: &Options,
 	) -> Result<Self, Error> {
@@ -139,15 +139,10 @@ impl<E: CatalogExt> Producer<E> {
 			None => moq_mux::import::unique_track(broadcast, &format!(".{}", options.codec))?,
 		};
 		let name = track.name().to_string();
-		let track = catalog.media_producer(
-			track,
-			moq_mux::container::legacy::Wire,
-			moq_mux::timeline::Cadence::Aligned,
-		)?;
+		let track = catalog.media_producer(track, moq_mux::container::legacy::Wire, moq_mux::timeline::Kind::Audio)?;
 
 		let mut catalog_mut = catalog.clone();
-		let mut config = encoder.catalog();
-		config.timeline = Some(catalog.timeline(&name)?.section());
+		let config = encoder.catalog();
 		catalog_mut.lock().audio.insert(&name, config)?;
 
 		Ok(Self {

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -139,7 +139,11 @@ impl<E: CatalogExt> Producer<E> {
 			None => moq_mux::import::unique_track(broadcast, &format!(".{}", options.codec))?,
 		};
 		let name = track.name().to_string();
-		let track = catalog.media_producer(track, moq_mux::container::legacy::Wire)?;
+		let track = catalog.media_producer(
+			track,
+			moq_mux::container::legacy::Wire,
+			moq_mux::timeline::Cadence::Aligned,
+		)?;
 
 		let mut catalog_mut = catalog.clone();
 		let mut config = encoder.catalog();

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -139,7 +139,7 @@ impl<E: CatalogExt> Producer<E> {
 			None => moq_mux::import::unique_track(broadcast, &format!(".{}", options.codec))?,
 		};
 		let name = track.name().to_string();
-		let track = catalog.media_producer(track, moq_mux::container::legacy::Wire, moq_mux::timeline::Kind::Audio)?;
+		let track = catalog.media_producer(track, moq_mux::container::legacy::Wire)?;
 
 		let mut catalog_mut = catalog.clone();
 		let config = encoder.catalog();

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -1,11 +1,11 @@
 //! Export: serve a MoQ broadcast as HLS, fetching media on demand.
 //!
-//! A [`Broadcaster`] subscribes to one broadcast's catalog and, per rendition, to its
-//! timeline track (see [`hang::timeline`]). That is the *only* standing traffic: playlists
-//! are rendered from timeline records (each record maps a group to its start timestamp), and
-//! media bytes move only when an HTTP client requests a segment, which FETCHes exactly the
-//! groups that segment covers from the relay cache and transmuxes them to CMAF. Renditions
-//! whose catalog entry advertises no timeline can't be served this way and are skipped.
+//! A [`Broadcaster`] subscribes to one broadcast's catalog and its single timeline track (see
+//! [`hang::timeline`]). That is the *only* standing traffic: playlists are a pure function of
+//! the timeline records (each names a complete aligned segment with per-track group ranges),
+//! and media bytes move only when an HTTP client requests a segment, which FETCHes exactly
+//! the groups that segment covers from the relay cache and transmuxes them to CMAF. A
+//! broadcast whose catalog advertises no timeline can't be served this way and is skipped.
 //!
 //! The same machinery serves two kinds of consumer:
 //!
@@ -67,21 +67,27 @@ pub struct Broadcaster {
 	/// renditions themselves (see [`renditions::Producer::clear`]). Set once, right after
 	/// construction.
 	watcher: Mutex<Option<tokio::task::JoinHandle<()>>>,
+	/// The broadcast's timeline watcher, spawned by the catalog watcher once the catalog
+	/// advertises the timeline track. On drop it is aborted only when no cursor still needs
+	/// its records (see `Drop`).
+	timeline_watcher: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
 impl Broadcaster {
 	/// Resolve `source`'s catalog broadcast and start tracking its renditions.
 	pub async fn new(source: moq_mux::Source, config: Config) -> crate::Result<Arc<Self>> {
 		let broadcast = source.broadcast().await?;
-		let renditions = renditions::Producer::new();
+		let renditions = renditions::Producer::new(config.window);
+		let timeline_watcher = Arc::new(Mutex::new(None));
 		let broadcaster = Arc::new(Self {
 			broadcast: broadcast.clone(),
 			renditions: renditions.clone(),
 			watcher: Mutex::new(None),
+			timeline_watcher: timeline_watcher.clone(),
 		});
 		// The watcher owns its own producer clone; the `Broadcaster`'s `Drop` aborts it so the
 		// standing catalog subscription stops when nobody's serving from this broadcaster.
-		let watcher = tokio::spawn(watch_catalog(source, broadcast, config, renditions));
+		let watcher = tokio::spawn(watch_catalog(source, broadcast, renditions, timeline_watcher));
 		*broadcaster.watcher.lock().unwrap() = Some(watcher);
 		Ok(broadcaster)
 	}
@@ -159,19 +165,25 @@ impl Drop for Broadcaster {
 		if let Some(watcher) = self.watcher.lock().unwrap().take() {
 			watcher.abort();
 		}
-		// The rendition map lives in shared state, so unlike an owned map it does NOT free its
-		// renditions when this handle goes away: a surviving `renditions::Consumer` would pin
-		// every `Rendition`, and with it the timeline watcher and source subscription it holds.
-		// Release them here so teardown can't leak a standing subscription.
+		// A recording cursor (holding an `Arc<Rendition>`) must keep receiving timeline
+		// records after this broadcaster is gone, or its final segments would be truncated;
+		// the timeline watcher then ends on its own when the timeline (or broadcast) does.
+		// With no such holder, abort it now so teardown can't leak a standing subscription.
+		let held = self.renditions.any_held_externally();
+		// Release the map either way: a surviving `renditions::Consumer` would otherwise pin
+		// every `Rendition` forever.
 		self.renditions.clear();
+		if !held && let Some(watcher) = self.timeline_watcher.lock().unwrap().take() {
+			watcher.abort();
+		}
 	}
 }
 
 async fn watch_catalog(
 	source: moq_mux::Source,
 	broadcast: moq_net::broadcast::Consumer,
-	config: Config,
 	renditions: renditions::Producer,
+	timeline_watcher: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
 ) {
 	let mut consumer = loop {
 		match catalog::Consumer::<()>::new(&broadcast, CatalogFormat::Hang).await {
@@ -189,9 +201,19 @@ async fn watch_catalog(
 		}
 	};
 
+	let mut timeline_started = false;
 	loop {
 		match kio::wait(|waiter| consumer.poll_next(waiter)).await {
-			Ok(Some(catalog)) => renditions.sync(&source, &config, &catalog),
+			Ok(Some(catalog)) => {
+				renditions.sync(&source, &catalog);
+				// The broadcast has one timeline; subscribe once it's advertised and fan its
+				// records out to every rendition.
+				if !timeline_started && let Some(section) = catalog.timeline.clone() {
+					timeline_started = true;
+					let watcher = tokio::spawn(watch_timeline(broadcast.clone(), section, renditions.fanout()));
+					*timeline_watcher.lock().unwrap() = Some(watcher);
+				}
+			}
 			Ok(None) => break,
 			Err(err) => {
 				tracing::warn!(%err, "broadcast catalog stream ended with error");
@@ -202,6 +224,40 @@ async fn watch_catalog(
 
 	// The source is done (or errored): let recording cursors finish.
 	renditions.close();
+}
+
+/// The broadcast's timeline watcher: read the single timeline track and fan each record out
+/// to every rendition's window.
+async fn watch_timeline(
+	broadcast: moq_net::broadcast::Consumer,
+	section: hang::catalog::Timeline,
+	renditions: renditions::Fanout,
+) {
+	match watch(&broadcast, &section, &renditions).await {
+		// The timeline finished cleanly: the publisher is done, so every window can end
+		// (ENDLIST) and recording cursors drain to completion.
+		Ok(()) => renditions.end_windows(),
+		// A transient error (subscription reset, relay hiccup): don't mark the windows ended;
+		// the serve path keeps serving the frozen windows.
+		Err(err) => {
+			tracing::warn!(track = %section.track, %err, "timeline watcher error; leaving the playlists live")
+		}
+	}
+	// The timeline stream is over either way: close so recording cursors terminate instead of
+	// parking forever (the serve path still reads the last windows).
+	renditions.close_windows();
+}
+
+async fn watch(
+	broadcast: &moq_net::broadcast::Consumer,
+	section: &hang::catalog::Timeline,
+	renditions: &renditions::Fanout,
+) -> crate::Result<()> {
+	let mut timeline = moq_mux::timeline::Consumer::<()>::subscribe(broadcast, section).await?;
+	while let Some(entry) = timeline.next().await? {
+		renditions.push(entry);
+	}
+	Ok(())
 }
 
 #[cfg(test)]
@@ -234,13 +290,12 @@ mod tests {
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
 		settle().await;
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		let reserved = catalog.reserve();
 		let mut registration = reserved.video("video0");
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		config.framerate = Some(30.0);
-		config.timeline = Some(catalog.timeline("video0").unwrap().section());
 		registration.set(config);
 		drop(reserved);
 
@@ -250,7 +305,7 @@ mod tests {
 			.media_producer(
 				track,
 				moq_mux::catalog::hang::Container::Legacy,
-				moq_mux::timeline::Cadence::Boundary,
+				moq_mux::timeline::Kind::Video,
 			)
 			.unwrap();
 		media.write(frame(0, true)).unwrap();
@@ -312,17 +367,15 @@ mod tests {
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
 		settle().await;
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		let reserved = catalog.reserve();
 		let mut video_registration = reserved.video("video0");
 		let mut video_config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		video_config.framerate = Some(30.0);
-		video_config.timeline = Some(catalog.timeline("video0").unwrap().section());
 		video_registration.set(video_config);
 		let mut audio_registration = reserved.audio("audio0");
-		let mut audio_config = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Opus, 48_000, 2);
-		audio_config.timeline = Some(catalog.timeline("audio0").unwrap().section());
+		let audio_config = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Opus, 48_000, 2);
 		audio_registration.set(audio_config);
 		drop(reserved);
 
@@ -331,7 +384,7 @@ mod tests {
 			.media_producer(
 				video_track,
 				moq_mux::catalog::hang::Container::Legacy,
-				moq_mux::timeline::Cadence::Boundary,
+				moq_mux::timeline::Kind::Video,
 			)
 			.unwrap();
 		let audio_track = broadcast.create_track("audio0", None).unwrap();
@@ -339,7 +392,7 @@ mod tests {
 			.media_producer(
 				audio_track,
 				moq_mux::catalog::hang::Container::Legacy,
-				moq_mux::timeline::Cadence::Aligned,
+				moq_mux::timeline::Kind::Audio,
 			)
 			.unwrap();
 
@@ -415,7 +468,6 @@ mod tests {
 		let mut registration = reserved.video("video0");
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		config.framerate = Some(30.0);
-		config.timeline = Some(catalog.timeline("video0").unwrap().section());
 		registration.set(config);
 		drop(reserved);
 
@@ -426,7 +478,7 @@ mod tests {
 			.media_producer(
 				track,
 				moq_mux::catalog::hang::Container::Legacy,
-				moq_mux::timeline::Cadence::Boundary,
+				moq_mux::timeline::Kind::Video,
 			)
 			.unwrap();
 		media.write(frame(0, true)).unwrap();
@@ -476,18 +528,22 @@ mod tests {
 		let source = moq_mux::Source::new(origin.consume(), "live");
 
 		// Drive the producer directly so the catalog can be reconciled synchronously.
-		let renditions = renditions::Producer::new();
-		let mut media = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
-		media.timeline = Some(hang::catalog::Timeline::new("video.timeline"));
+		let renditions = renditions::Producer::new(Config::default().window);
+		let media = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		let mut catalog = moq_mux::catalog::hang::Catalog::default();
 		catalog.video.renditions.insert("video".to_string(), media);
-		renditions.sync(&source, &Config::default(), &catalog);
+		catalog.timeline = Some(hang::catalog::Timeline::new(hang::timeline::DEFAULT_NAME));
+		renditions.sync(&source, &catalog);
 
 		let rendition = renditions.get(Kind::Video, "video").expect("rendition synced");
 		let mut segments = rendition.segments();
 
 		// The catalog drops the rendition: its cursor must run dry rather than park.
-		renditions.sync(&source, &Config::default(), &moq_mux::catalog::hang::Catalog::default());
+		let empty = moq_mux::catalog::hang::Catalog {
+			timeline: Some(hang::catalog::Timeline::new(hang::timeline::DEFAULT_NAME)),
+			..Default::default()
+		};
+		renditions.sync(&source, &empty);
 		let ended = tokio::time::timeout(Duration::from_secs(5), segments.next())
 			.await
 			.expect("a removed rendition's cursor ends instead of parking")
@@ -508,13 +564,12 @@ mod tests {
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
 		settle().await;
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		let reserved = catalog.reserve();
 		let mut registration = reserved.video("video0");
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		config.framerate = Some(30.0);
-		config.timeline = Some(catalog.timeline("video0").unwrap().section());
 		registration.set(config);
 		drop(reserved);
 
@@ -523,7 +578,7 @@ mod tests {
 			.media_producer(
 				track,
 				moq_mux::catalog::hang::Container::Legacy,
-				moq_mux::timeline::Cadence::Boundary,
+				moq_mux::timeline::Kind::Video,
 			)
 			.unwrap();
 		media.write(frame(0, true)).unwrap();
@@ -571,13 +626,12 @@ mod tests {
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("publish allowed");
 		settle().await;
-		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 
 		let reserved = catalog.reserve();
 		let mut registration = reserved.video("video0");
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		config.framerate = Some(30.0);
-		config.timeline = Some(catalog.timeline("video0").unwrap().section());
 		registration.set(config);
 		drop(reserved);
 
@@ -587,7 +641,7 @@ mod tests {
 			.media_producer(
 				track,
 				moq_mux::catalog::hang::Container::Legacy,
-				moq_mux::timeline::Cadence::Boundary,
+				moq_mux::timeline::Kind::Video,
 			)
 			.unwrap();
 		media.write(frame(0, true)).unwrap();

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -363,6 +363,50 @@ mod tests {
 	// The property HLS needs from the timeline rework: audio and video renditions share one
 	// segment numbering, cut at the same boundaries. Video is one group per segment; an audio
 	// segment packs every audio group inside the video segment's span.
+	// The declared bound is a target, not a guarantee: a GOP longer than it can't be split, so
+	// the segmenter publishes an honest long segment. EXT-X-TARGETDURATION has to cover it,
+	// since a playlist whose EXTINF exceeds it is invalid.
+	#[tokio::test]
+	async fn target_duration_covers_a_segment_that_overran_the_bound() {
+		let origin = moq_net::Origin::random().produce();
+		let mut broadcast = origin
+			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
+			.expect("publish allowed");
+		settle().await;
+		let mut catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+
+		let reserved = catalog.reserve();
+		let mut registration = reserved.video("video0");
+		registration.set(hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8));
+		drop(reserved);
+
+		// 3s GOPs against the default 2s bound: every segment is one whole GOP.
+		let track = broadcast.create_track("video0", None).unwrap();
+		let mut media = catalog
+			.media_producer(
+				track,
+				moq_mux::catalog::hang::Container::Legacy,
+				moq_mux::timeline::Kind::Video,
+			)
+			.unwrap();
+		media.write(frame(0, true)).unwrap();
+		media.write(frame(3_000_000, true)).unwrap();
+		media.write(frame(6_000_000, true)).unwrap();
+
+		let source = moq_mux::Source::new(origin.consume(), "live");
+		let broadcaster = Broadcaster::new(source, Config::default()).await.unwrap();
+		let _ = tokio::time::timeout(Duration::from_secs(5), broadcaster.ready()).await;
+		let rendition = broadcaster.rendition(Kind::Video, "video0").expect("rendition");
+		let _ = tokio::time::timeout(Duration::from_secs(5), rendition.playable()).await;
+
+		let playlist = rendition.playlist();
+		assert_eq!(playlist.segments[0].duration, 3.0);
+		assert_eq!(
+			playlist.target_duration, 3,
+			"the declared bound is 2s, but a 3s segment must not exceed EXT-X-TARGETDURATION"
+		);
+	}
+
 	#[tokio::test]
 	async fn audio_and_video_segments_are_aligned() {
 		let origin = moq_net::Origin::random().produce();

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -302,11 +302,7 @@ mod tests {
 		// Three GOPs, 2s apart: groups 0 and 1 are complete, group 2 is the live edge.
 		let track = broadcast.create_track("video0", None).unwrap();
 		let mut media = catalog
-			.media_producer(
-				track,
-				moq_mux::catalog::hang::Container::Legacy,
-				moq_mux::timeline::Kind::Video,
-			)
+			.media_producer(track, moq_mux::catalog::hang::Container::Legacy)
 			.unwrap();
 		media.write(frame(0, true)).unwrap();
 		media.write(frame(1_000_000, false)).unwrap();
@@ -332,7 +328,7 @@ mod tests {
 		assert_eq!(playlist.segments[1].segment, 1);
 		assert_eq!(
 			playlist.target_duration, 2,
-			"the catalog's declared durationMax, in whole seconds"
+			"the observed segment duration, in whole seconds"
 		);
 		assert!(!playlist.finished);
 
@@ -363,11 +359,11 @@ mod tests {
 	// The property HLS needs from the timeline rework: audio and video renditions share one
 	// segment numbering, cut at the same boundaries. Video is one group per segment; an audio
 	// segment packs every audio group inside the video segment's span.
-	// The declared bound is a target, not a guarantee: a GOP longer than it can't be split, so
-	// the segmenter publishes an honest long segment. EXT-X-TARGETDURATION has to cover it,
-	// since a playlist whose EXTINF exceeds it is invalid.
+	// Most publishers declare no durationMax (a real-time GOP can be minutes long), so the
+	// exporter has to derive EXT-X-TARGETDURATION from the segments it has: a playlist whose
+	// EXTINF exceeds its target duration is invalid.
 	#[tokio::test]
-	async fn target_duration_covers_a_segment_that_overran_the_bound() {
+	async fn target_duration_covers_the_window_without_a_declared_bound() {
 		let origin = moq_net::Origin::random().produce();
 		let mut broadcast = origin
 			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
@@ -380,14 +376,10 @@ mod tests {
 		registration.set(hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8));
 		drop(reserved);
 
-		// 3s GOPs against the default 2s bound: every segment is one whole GOP.
+		// 3s GOPs against the default 1s minimum: every segment is one whole GOP.
 		let track = broadcast.create_track("video0", None).unwrap();
 		let mut media = catalog
-			.media_producer(
-				track,
-				moq_mux::catalog::hang::Container::Legacy,
-				moq_mux::timeline::Kind::Video,
-			)
+			.media_producer(track, moq_mux::catalog::hang::Container::Legacy)
 			.unwrap();
 		media.write(frame(0, true)).unwrap();
 		media.write(frame(3_000_000, true)).unwrap();
@@ -403,7 +395,7 @@ mod tests {
 		assert_eq!(playlist.segments[0].duration, 3.0);
 		assert_eq!(
 			playlist.target_duration, 3,
-			"the declared bound is 2s, but a 3s segment must not exceed EXT-X-TARGETDURATION"
+			"no bound was declared, so the target duration must still cover the 3s segment"
 		);
 	}
 
@@ -428,19 +420,11 @@ mod tests {
 
 		let video_track = broadcast.create_track("video0", None).unwrap();
 		let mut video = catalog
-			.media_producer(
-				video_track,
-				moq_mux::catalog::hang::Container::Legacy,
-				moq_mux::timeline::Kind::Video,
-			)
+			.media_producer(video_track, moq_mux::catalog::hang::Container::Legacy)
 			.unwrap();
 		let audio_track = broadcast.create_track("audio0", None).unwrap();
 		let mut audio = catalog
-			.media_producer(
-				audio_track,
-				moq_mux::catalog::hang::Container::Legacy,
-				moq_mux::timeline::Kind::Audio,
-			)
+			.media_producer(audio_track, moq_mux::catalog::hang::Container::Legacy)
 			.unwrap();
 
 		// Interleaved by pts, as a muxer would demux them: video keyframes every 2s open the
@@ -522,11 +506,7 @@ mod tests {
 		// publisher finishes.
 		let track = broadcast.create_track("video0", None).unwrap();
 		let mut media = catalog
-			.media_producer(
-				track,
-				moq_mux::catalog::hang::Container::Legacy,
-				moq_mux::timeline::Kind::Video,
-			)
+			.media_producer(track, moq_mux::catalog::hang::Container::Legacy)
 			.unwrap();
 		media.write(frame(0, true)).unwrap();
 		media.write(frame(2_000_000, true)).unwrap();
@@ -579,7 +559,7 @@ mod tests {
 		let media = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		let mut catalog = moq_mux::catalog::hang::Catalog::default();
 		catalog.video.renditions.insert("video".to_string(), media);
-		catalog.timeline = Some(hang::catalog::Timeline::new(hang::timeline::DEFAULT_NAME, 2000));
+		catalog.timeline = Some(hang::catalog::Timeline::new(hang::timeline::DEFAULT_NAME));
 		renditions.sync(&source, &catalog);
 
 		let rendition = renditions.get(Kind::Video, "video").expect("rendition synced");
@@ -587,7 +567,7 @@ mod tests {
 
 		// The catalog drops the rendition: its cursor must run dry rather than park.
 		let empty = moq_mux::catalog::hang::Catalog {
-			timeline: Some(hang::catalog::Timeline::new(hang::timeline::DEFAULT_NAME, 2000)),
+			timeline: Some(hang::catalog::Timeline::new(hang::timeline::DEFAULT_NAME)),
 			..Default::default()
 		};
 		renditions.sync(&source, &empty);
@@ -622,11 +602,7 @@ mod tests {
 
 		let track = broadcast.create_track("video0", None).unwrap();
 		let mut media = catalog
-			.media_producer(
-				track,
-				moq_mux::catalog::hang::Container::Legacy,
-				moq_mux::timeline::Kind::Video,
-			)
+			.media_producer(track, moq_mux::catalog::hang::Container::Legacy)
 			.unwrap();
 		media.write(frame(0, true)).unwrap();
 		media.write(frame(2_000_000, true)).unwrap();
@@ -685,11 +661,7 @@ mod tests {
 		// Groups 0 and 1 are complete; group 2 is the live edge until the publisher drops.
 		let track = broadcast.create_track("video0", None).unwrap();
 		let mut media = catalog
-			.media_producer(
-				track,
-				moq_mux::catalog::hang::Container::Legacy,
-				moq_mux::timeline::Kind::Video,
-			)
+			.media_producer(track, moq_mux::catalog::hang::Container::Legacy)
 			.unwrap();
 		media.write(frame(0, true)).unwrap();
 		media.write(frame(2_000_000, true)).unwrap();

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -247,7 +247,11 @@ mod tests {
 		// Three GOPs, 2s apart: groups 0 and 1 are complete, group 2 is the live edge.
 		let track = broadcast.create_track("video0", None).unwrap();
 		let mut media = catalog
-			.media_producer(track, moq_mux::catalog::hang::Container::Legacy)
+			.media_producer(
+				track,
+				moq_mux::catalog::hang::Container::Legacy,
+				moq_mux::timeline::Cadence::Boundary,
+			)
 			.unwrap();
 		media.write(frame(0, true)).unwrap();
 		media.write(frame(1_000_000, false)).unwrap();
@@ -268,9 +272,9 @@ mod tests {
 
 		let playlist = rendition.playlist();
 		assert_eq!(playlist.segments.len(), 2, "the live-edge group is not listed");
-		assert_eq!(playlist.segments[0].group, 0);
+		assert_eq!(playlist.segments[0].segment, 0);
 		assert_eq!(playlist.segments[0].duration, 2.0);
-		assert_eq!(playlist.segments[1].group, 1);
+		assert_eq!(playlist.segments[1].segment, 1);
 		assert_eq!(playlist.target_duration, 2, "ceil of the longest timeline gap");
 		assert!(!playlist.finished);
 
@@ -296,6 +300,101 @@ mod tests {
 
 		// Keep the publisher alive for the whole test.
 		drop((media, registration, broadcast));
+	}
+
+	// The property HLS needs from the timeline rework: audio and video renditions share one
+	// segment numbering, cut at the same boundaries. Video is one group per segment; an audio
+	// segment packs every audio group inside the video segment's span.
+	#[tokio::test]
+	async fn audio_and_video_segments_are_aligned() {
+		let origin = moq_net::Origin::random().produce();
+		let mut broadcast = origin
+			.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
+			.expect("publish allowed");
+		settle().await;
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+
+		let reserved = catalog.reserve();
+		let mut video_registration = reserved.video("video0");
+		let mut video_config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
+		video_config.framerate = Some(30.0);
+		video_config.timeline = Some(catalog.timeline("video0").unwrap().section());
+		video_registration.set(video_config);
+		let mut audio_registration = reserved.audio("audio0");
+		let mut audio_config = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Opus, 48_000, 2);
+		audio_config.timeline = Some(catalog.timeline("audio0").unwrap().section());
+		audio_registration.set(audio_config);
+		drop(reserved);
+
+		let video_track = broadcast.create_track("video0", None).unwrap();
+		let mut video = catalog
+			.media_producer(
+				video_track,
+				moq_mux::catalog::hang::Container::Legacy,
+				moq_mux::timeline::Cadence::Boundary,
+			)
+			.unwrap();
+		let audio_track = broadcast.create_track("audio0", None).unwrap();
+		let mut audio = catalog
+			.media_producer(
+				audio_track,
+				moq_mux::catalog::hang::Container::Legacy,
+				moq_mux::timeline::Cadence::Aligned,
+			)
+			.unwrap();
+
+		// Interleaved by pts, as a muxer would demux them: video keyframes every 2s open the
+		// segments; audio publishes a 500ms group each cut.
+		let mut audio_write = |micros: u64| {
+			let keyframe = audio.needs_keyframe();
+			audio.write(frame(micros, keyframe)).unwrap();
+			audio.cut(None).unwrap();
+		};
+		video.write(frame(0, true)).unwrap(); // segment 0
+		for micros in [0u64, 500_000, 1_000_000, 1_500_000] {
+			audio_write(micros); // audio groups 0..=3 pack into segment 0
+		}
+		video.write(frame(2_000_000, true)).unwrap(); // segment 1
+		for micros in [2_000_000u64, 2_500_000, 3_000_000, 3_500_000] {
+			audio_write(micros); // audio groups 4..=7 pack into segment 1
+		}
+		video.write(frame(4_000_000, true)).unwrap(); // segment 2 (live edge)
+		audio_write(4_000_000); // audio group 8 opens its slice of segment 2
+
+		let source = moq_mux::Source::new(origin.consume(), "live");
+		let broadcaster = Broadcaster::new(source, Config::default()).await.unwrap();
+		let _ = tokio::time::timeout(Duration::from_secs(5), broadcaster.ready()).await;
+		let video_rendition = broadcaster.rendition(Kind::Video, "video0").expect("video discovered");
+		let audio_rendition = broadcaster.rendition(Kind::Audio, "audio0").expect("audio discovered");
+		let _ = tokio::time::timeout(Duration::from_secs(5), video_rendition.playable()).await;
+		let _ = tokio::time::timeout(Duration::from_secs(5), audio_rendition.playable()).await;
+
+		// Both playlists list the same segment numbers over the same spans.
+		let video_playlist = video_rendition.playlist();
+		let audio_playlist = audio_rendition.playlist();
+		assert_eq!(video_playlist.media_sequence, audio_playlist.media_sequence);
+		let video_segments: Vec<u64> = video_playlist.segments.iter().map(|s| s.segment).collect();
+		let audio_segments: Vec<u64> = audio_playlist.segments.iter().map(|s| s.segment).collect();
+		assert_eq!(video_segments, vec![0, 1]);
+		assert_eq!(audio_segments, vec![0, 1], "audio lists the same aligned segments");
+		assert_eq!(audio_playlist.segments[0].duration, 2.0, "cut at the video boundary");
+
+		// The same URI names the same span of content time on either rendition.
+		let rendered = audio_rendition.media_playlist(None).expect("playable");
+		assert!(rendered.contains("seg/0.m4s\n"));
+		assert!(rendered.contains("seg/1.m4s\n"));
+
+		// A video segment is one group; the matching audio segment transmuxes its four groups.
+		let video_segment = video_rendition.segment(1).await.unwrap().expect("video segment");
+		assert_eq!(&video_segment[4..8], b"moof");
+		let audio_segment = audio_rendition.segment(1).await.unwrap().expect("audio segment");
+		assert_eq!(&audio_segment[4..8], b"moof");
+		assert!(
+			audio_segment.len() > video_segment.len(),
+			"the audio segment packs multiple groups into one fragment"
+		);
+
+		drop((video, audio, video_registration, audio_registration, broadcast));
 	}
 
 	// Dropping the broadcaster must not truncate a recording in progress. A cursor holds its
@@ -324,7 +423,11 @@ mod tests {
 		// publisher finishes.
 		let track = broadcast.create_track("video0", None).unwrap();
 		let mut media = catalog
-			.media_producer(track, moq_mux::catalog::hang::Container::Legacy)
+			.media_producer(
+				track,
+				moq_mux::catalog::hang::Container::Legacy,
+				moq_mux::timeline::Cadence::Boundary,
+			)
 			.unwrap();
 		media.write(frame(0, true)).unwrap();
 		media.write(frame(2_000_000, true)).unwrap();
@@ -351,7 +454,7 @@ mod tests {
 			.expect("the cursor drains without parking")
 			.unwrap()
 		{
-			groups.push(segment.group);
+			groups.push(segment.segment);
 		}
 		assert!(
 			groups.contains(&1),
@@ -417,7 +520,11 @@ mod tests {
 
 		let track = broadcast.create_track("video0", None).unwrap();
 		let mut media = catalog
-			.media_producer(track, moq_mux::catalog::hang::Container::Legacy)
+			.media_producer(
+				track,
+				moq_mux::catalog::hang::Container::Legacy,
+				moq_mux::timeline::Cadence::Boundary,
+			)
 			.unwrap();
 		media.write(frame(0, true)).unwrap();
 		media.write(frame(2_000_000, true)).unwrap();
@@ -477,7 +584,11 @@ mod tests {
 		// Groups 0 and 1 are complete; group 2 is the live edge until the publisher drops.
 		let track = broadcast.create_track("video0", None).unwrap();
 		let mut media = catalog
-			.media_producer(track, moq_mux::catalog::hang::Container::Legacy)
+			.media_producer(
+				track,
+				moq_mux::catalog::hang::Container::Legacy,
+				moq_mux::timeline::Cadence::Boundary,
+			)
 			.unwrap();
 		media.write(frame(0, true)).unwrap();
 		media.write(frame(2_000_000, true)).unwrap();
@@ -505,13 +616,13 @@ mod tests {
 			.expect("first segment finalizes")
 			.unwrap()
 			.expect("a segment, not end");
-		assert_eq!(first.group, 0);
+		assert_eq!(first.segment, 0);
 		assert_eq!(&first.media[4..8], b"moof", "the segment carries its transmuxed media");
 		assert_eq!(first.duration, 2.0);
 		assert!(!first.discontinuity, "a clean start is not a discontinuity");
 
 		let second = segments.next().await.unwrap().expect("second segment");
-		assert_eq!(second.group, 1);
+		assert_eq!(second.segment, 1);
 		assert!(!second.discontinuity, "consecutive segments are continuous");
 
 		// Tear down the publisher mid-group. The track ends abruptly (the cursor drains the

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -330,7 +330,10 @@ mod tests {
 		assert_eq!(playlist.segments[0].segment, 0);
 		assert_eq!(playlist.segments[0].duration, 2.0);
 		assert_eq!(playlist.segments[1].segment, 1);
-		assert_eq!(playlist.target_duration, 2, "ceil of the longest timeline gap");
+		assert_eq!(
+			playlist.target_duration, 2,
+			"the catalog's declared durationMax, in whole seconds"
+		);
 		assert!(!playlist.finished);
 
 		let rendered = rendition.media_playlist(None).expect("playable");
@@ -532,7 +535,7 @@ mod tests {
 		let media = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		let mut catalog = moq_mux::catalog::hang::Catalog::default();
 		catalog.video.renditions.insert("video".to_string(), media);
-		catalog.timeline = Some(hang::catalog::Timeline::new(hang::timeline::DEFAULT_NAME));
+		catalog.timeline = Some(hang::catalog::Timeline::new(hang::timeline::DEFAULT_NAME, 2000));
 		renditions.sync(&source, &catalog);
 
 		let rendition = renditions.get(Kind::Video, "video").expect("rendition synced");
@@ -540,7 +543,7 @@ mod tests {
 
 		// The catalog drops the rendition: its cursor must run dry rather than park.
 		let empty = moq_mux::catalog::hang::Catalog {
-			timeline: Some(hang::catalog::Timeline::new(hang::timeline::DEFAULT_NAME)),
+			timeline: Some(hang::catalog::Timeline::new(hang::timeline::DEFAULT_NAME, 2000)),
 			..Default::default()
 		};
 		renditions.sync(&source, &empty);

--- a/rs/moq-hls/src/export/playlist.rs
+++ b/rs/moq-hls/src/export/playlist.rs
@@ -1,8 +1,8 @@
 //! Hand-written HLS media playlist generation.
 //!
-//! Rendered purely from timeline records: each record starts a segment (numbered by the
-//! broadcast's aligned segment sequence, so renditions cut at the same boundaries) and the gap
-//! to the next record is its duration. URIs are relative to the media playlist
+//! Rendered purely from timeline records: each record is one complete aligned segment
+//! (numbered by the broadcast's shared segment sequence, so renditions cut at the same
+//! boundaries) carrying its own duration. URIs are relative to the media playlist
 //! (`/<broadcast>/<kind>/<rendition>/media.m3u8`), so they resolve against the rendition
 //! directory.
 
@@ -11,6 +11,9 @@ use std::time::SystemTime;
 
 /// fMP4 segments via `EXT-X-MAP` require protocol version 6.
 const VERSION: u32 = 6;
+
+/// `EXT-X-GAP` requires protocol version 8.
+const VERSION_GAP: u32 = 8;
 
 /// Everything a media playlist render needs; built by the crate-internal
 /// `Rendition::playlist`.
@@ -34,6 +37,11 @@ pub(crate) struct Segment {
 	pub segment: u64,
 	/// `EXTINF` duration in seconds.
 	pub duration: f64,
+	/// The rendition has no content for this span (`EXT-X-GAP`): the segment keeps its slot in
+	/// the aligned numbering, but a player should not request it.
+	pub gap: bool,
+	/// Content time jumped before this segment (`EXT-X-DISCONTINUITY`).
+	pub discontinuity: bool,
 }
 
 /// Render a media playlist for one rendition from a [`Snapshot`].
@@ -44,9 +52,16 @@ pub(crate) struct Segment {
 pub(crate) fn render_media(snapshot: &Snapshot, query: Option<&str>) -> String {
 	let suffix = query.map(|q| format!("?{q}")).unwrap_or_default();
 
+	// EXT-X-GAP needs a newer protocol version; only require it when actually used.
+	let version = if snapshot.segments.iter().any(|s| s.gap) {
+		VERSION_GAP
+	} else {
+		VERSION
+	};
+
 	let mut out = String::new();
 	let _ = writeln!(out, "#EXTM3U");
-	let _ = writeln!(out, "#EXT-X-VERSION:{VERSION}");
+	let _ = writeln!(out, "#EXT-X-VERSION:{version}");
 	let _ = writeln!(out, "#EXT-X-TARGETDURATION:{}", snapshot.target_duration);
 	let _ = writeln!(out, "#EXT-X-MEDIA-SEQUENCE:{}", snapshot.media_sequence);
 	let _ = writeln!(out, "#EXT-X-MAP:URI=\"init.mp4{suffix}\"");
@@ -60,6 +75,12 @@ pub(crate) fn render_media(snapshot: &Snapshot, query: Option<&str>) -> String {
 				"#EXT-X-PROGRAM-DATE-TIME:{}",
 				humantime::format_rfc3339_millis(pdt)
 			);
+		}
+		if segment.discontinuity {
+			let _ = writeln!(out, "#EXT-X-DISCONTINUITY");
+		}
+		if segment.gap {
+			let _ = writeln!(out, "#EXT-X-GAP");
 		}
 		let _ = writeln!(out, "#EXTINF:{:.5},", segment.duration);
 		let _ = writeln!(out, "seg/{}.m4s{suffix}", segment.segment);
@@ -87,10 +108,14 @@ mod tests {
 				Segment {
 					segment: 10,
 					duration: 2.0,
+					gap: false,
+					discontinuity: false,
 				},
 				Segment {
 					segment: 11,
 					duration: 1.96,
+					gap: false,
+					discontinuity: false,
 				},
 			],
 			finished: false,
@@ -122,6 +147,8 @@ mod tests {
 			segments: vec![Segment {
 				segment: 0,
 				duration: 4.0,
+				gap: false,
+				discontinuity: false,
 			}],
 			finished: true,
 			program_date_time: None,

--- a/rs/moq-hls/src/export/playlist.rs
+++ b/rs/moq-hls/src/export/playlist.rs
@@ -1,7 +1,8 @@
 //! Hand-written HLS media playlist generation.
 //!
-//! Rendered purely from timeline records: each segment is a starting group plus the gap to
-//! the next record. URIs are relative to the media playlist
+//! Rendered purely from timeline records: each record starts a segment (numbered by the
+//! broadcast's aligned segment sequence, so renditions cut at the same boundaries) and the gap
+//! to the next record is its duration. URIs are relative to the media playlist
 //! (`/<broadcast>/<kind>/<rendition>/media.m3u8`), so they resolve against the rendition
 //! directory.
 
@@ -29,8 +30,8 @@ pub(crate) struct Snapshot {
 
 /// One listed segment.
 pub(crate) struct Segment {
-	/// The starting group sequence; the URI is `seg/{group}.m4s`.
-	pub group: u64,
+	/// The aligned segment number; the URI is `seg/{segment}.m4s`.
+	pub segment: u64,
 	/// `EXTINF` duration in seconds.
 	pub duration: f64,
 }
@@ -61,7 +62,7 @@ pub(crate) fn render_media(snapshot: &Snapshot, query: Option<&str>) -> String {
 			);
 		}
 		let _ = writeln!(out, "#EXTINF:{:.5},", segment.duration);
-		let _ = writeln!(out, "seg/{}.m4s{suffix}", segment.group);
+		let _ = writeln!(out, "seg/{}.m4s{suffix}", segment.segment);
 	}
 
 	if snapshot.finished {
@@ -84,11 +85,11 @@ mod tests {
 			media_sequence: 10,
 			segments: vec![
 				Segment {
-					group: 10,
+					segment: 10,
 					duration: 2.0,
 				},
 				Segment {
-					group: 11,
+					segment: 11,
 					duration: 1.96,
 				},
 			],
@@ -119,7 +120,7 @@ mod tests {
 			target_duration: 4,
 			media_sequence: 0,
 			segments: vec![Segment {
-				group: 0,
+				segment: 0,
 				duration: 4.0,
 			}],
 			finished: true,

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -194,15 +194,27 @@ impl Rendition {
 	pub(crate) fn playlist(&self) -> Snapshot {
 		let window = self.live.window();
 
-		// EXT-X-TARGETDURATION comes straight from the catalog's declared bound: the encoder
-		// (or cutter) knows and enforces its segment duration, so the exporter never has to
-		// guess from observed durations. Rounded up, since HLS wants whole seconds and the
-		// advertised value must never understate the bound.
-		let target_duration = self
+		// EXT-X-TARGETDURATION starts from the catalog's declared bound: the encoder (or
+		// cutter) knows its segment duration up front, so the first playlist already carries
+		// the real value instead of a guess grown from observation. Rounded up, since HLS
+		// wants whole seconds and the advertised value must never understate the bound.
+		let declared = self
 			.section
 			.duration_max
 			.div_ceil((self.section.timescale as u64).max(1))
 			.max(1);
+
+		// The bound is a target, not a guarantee: a single GOP longer than it cannot be split,
+		// so the segmenter publishes an honest long segment (and warns). HLS requires
+		// EXT-X-TARGETDURATION to be at least every EXTINF, so cover the window rather than
+		// render a playlist players are entitled to reject.
+		let observed = window
+			.segments
+			.iter()
+			.map(|s| s.duration.ceil().max(0.0) as u64)
+			.max()
+			.unwrap_or(0);
+		let target_duration = declared.max(observed);
 
 		let program_date_time = window.segments.first().and_then(|first| self.wall_clock(first.pts));
 

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -229,7 +229,7 @@ impl Rendition {
 				.segments
 				.into_iter()
 				.map(|s| Segment {
-					group: s.group,
+					segment: s.segment,
 					duration: s.duration,
 				})
 				.collect(),
@@ -307,13 +307,13 @@ impl Rendition {
 		Ok(Some(bytes))
 	}
 
-	/// Fetch and transmux the segment starting at group `sequence`.
+	/// Fetch and transmux the segment numbered `segment`.
 	///
-	/// Fetches every group the segment covers (audio timelines skip groups, so a segment may span
-	/// several) and encodes them as a single CMAF fragment. `None` when the segment isn't in the
-	/// playlist window or its groups already left the relay cache.
-	pub async fn segment(&self, sequence: u64) -> Result<Option<Bytes>> {
-		let Some((start, end)) = self.live.segment_groups(sequence) else {
+	/// Fetches every group the segment covers (an audio segment packs many short groups) and
+	/// encodes them as a single CMAF fragment. `None` when the segment isn't in the playlist
+	/// window or its groups already left the relay cache.
+	pub async fn segment(&self, segment: u64) -> Result<Option<Bytes>> {
+		let Some((start, end)) = self.live.segment_groups(segment) else {
 			return Ok(None);
 		};
 		let Some(track) = self.track() else {
@@ -364,7 +364,7 @@ impl Rendition {
 		if frames.is_empty() {
 			return Ok(None);
 		}
-		Ok(Some(muxer.fragment(start as u32, &frames)?))
+		Ok(Some(muxer.fragment(segment as u32, &frames)?))
 	}
 }
 

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -194,27 +194,26 @@ impl Rendition {
 	pub(crate) fn playlist(&self) -> Snapshot {
 		let window = self.live.window();
 
-		// EXT-X-TARGETDURATION starts from the catalog's declared bound: the encoder (or
-		// cutter) knows its segment duration up front, so the first playlist already carries
-		// the real value instead of a guess grown from observation. Rounded up, since HLS
-		// wants whole seconds and the advertised value must never understate the bound.
+		// EXT-X-TARGETDURATION starts from the catalog's declared bound when the publisher
+		// offered one: it knows its segment duration up front, so the first playlist already
+		// carries the real value instead of a guess grown from observation. Rounded up, since
+		// HLS wants whole seconds and the advertised value must never understate the bound.
 		let declared = self
 			.section
 			.duration_max
-			.div_ceil((self.section.timescale as u64).max(1))
-			.max(1);
+			.map(|max| max.div_ceil((self.section.timescale as u64).max(1)))
+			.unwrap_or(0);
 
-		// The bound is a target, not a guarantee: a single GOP longer than it cannot be split,
-		// so the segmenter publishes an honest long segment (and warns). HLS requires
-		// EXT-X-TARGETDURATION to be at least every EXTINF, so cover the window rather than
-		// render a playlist players are entitled to reject.
+		// Most publishers can't promise a bound (a real-time GOP can be minutes long), and even
+		// a declared one is only a promise about content the publisher controls. HLS requires
+		// EXT-X-TARGETDURATION to be at least every EXTINF, so cover the window either way.
 		let observed = window
 			.segments
 			.iter()
 			.map(|s| s.duration.ceil().max(0.0) as u64)
 			.max()
 			.unwrap_or(0);
-		let target_duration = declared.max(observed);
+		let target_duration = declared.max(observed).max(1);
 
 		let program_date_time = window.segments.first().and_then(|first| self.wall_clock(first.pts));
 

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -87,10 +87,6 @@ pub struct Rendition {
 	/// The source and (possibly sibling) broadcast reference, resolved lazily for FETCH.
 	source: moq_mux::Source,
 	sibling: Option<moq_net::PathRelativeOwned>,
-	/// The largest `EXT-X-TARGETDURATION` advertised so far, in seconds. Latched monotonically:
-	/// HLS forbids a live playlist's target duration from changing, so it never shrinks even
-	/// after a long segment evicts from the window.
-	target_duration: std::sync::atomic::AtomicU64,
 	/// The init segment, built on first request.
 	init: tokio::sync::Mutex<Option<Bytes>>,
 }
@@ -118,7 +114,6 @@ impl Rendition {
 			live: Arc::new(segments::Producer::new()),
 			source: source.clone(),
 			sibling: config.broadcast.clone(),
-			target_duration: std::sync::atomic::AtomicU64::new(0),
 			init: tokio::sync::Mutex::new(None),
 		}
 	}
@@ -137,7 +132,6 @@ impl Rendition {
 			live: Arc::new(segments::Producer::new()),
 			source: source.clone(),
 			sibling: config.broadcast.clone(),
-			target_duration: std::sync::atomic::AtomicU64::new(0),
 			init: tokio::sync::Mutex::new(None),
 		}
 	}
@@ -200,16 +194,15 @@ impl Rendition {
 	pub(crate) fn playlist(&self) -> Snapshot {
 		let window = self.live.window();
 
-		// EXT-X-TARGETDURATION must be >= every segment's duration and, per the HLS spec, must not
-		// change over a playlist's lifetime. Records carry explicit durations, so take the longest
-		// seen so far and latch it monotonically (fetch_max) so a long segment evicting from the
-		// window can never shrink the advertised value.
-		let longest = window.segments.iter().map(|s| s.duration).fold(0.0f64, f64::max);
-		let want = (longest.ceil() as u64).max(1);
+		// EXT-X-TARGETDURATION comes straight from the catalog's declared bound: the encoder
+		// (or cutter) knows and enforces its segment duration, so the exporter never has to
+		// guess from observed durations. Rounded up, since HLS wants whole seconds and the
+		// advertised value must never understate the bound.
 		let target_duration = self
-			.target_duration
-			.fetch_max(want, std::sync::atomic::Ordering::Relaxed)
-			.max(want);
+			.section
+			.duration_max
+			.div_ceil((self.section.timescale as u64).max(1))
+			.max(1);
 
 		let program_date_time = window.segments.first().and_then(|first| self.wall_clock(first.pts));
 

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -1,4 +1,5 @@
-//! One rendition: playlists from its timeline track, segments fetched on demand.
+//! One rendition: playlists from its view of the broadcast timeline, segments fetched on
+//! demand.
 
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
@@ -6,6 +7,7 @@ use std::time::{Duration, SystemTime};
 use bytes::Bytes;
 use hang::catalog::{AudioConfig, MOQ_EPOCH_UNIX_MILLIS, Timeline, VideoConfig};
 use moq_mux::container::fmp4::Muxer;
+use moq_mux::timeline::Entry;
 
 use super::playlist::{Segment, Snapshot};
 use super::segments;
@@ -15,8 +17,8 @@ use crate::Result;
 const DEFAULT_VIDEO_BITRATE: u64 = 2_000_000;
 const DEFAULT_AUDIO_BITRATE: u64 = 128_000;
 
-/// Upper bound on the groups fetched for one segment, so a corrupt timeline (or an unbounded
-/// final segment) can't turn one HTTP request into an endless fetch loop.
+/// Upper bound on the groups fetched for one segment, so a corrupt timeline can't turn one
+/// HTTP request into an endless fetch loop.
 const MAX_SEGMENT_GROUPS: u64 = 1024;
 
 /// Whether a rendition carries video or audio.
@@ -60,8 +62,8 @@ enum Config {
 	Audio(AudioConfig),
 }
 
-/// A single HLS rendition: master-playlist metadata, the live timeline window that renders
-/// its media playlist, and on-demand segment fetching.
+/// A single HLS rendition: master-playlist metadata, its view of the broadcast timeline (which
+/// renders its media playlist), and on-demand segment fetching.
 pub struct Rendition {
 	/// Rendition name (the catalog track name; also its URL path component).
 	pub name: String,
@@ -77,18 +79,20 @@ pub struct Rendition {
 	pub codec: String,
 
 	config: Config,
-	/// The catalog timeline section: the timeline track's name, timescale, and wall anchor.
+	/// The catalog's root timeline section: the timescale and wall anchor timings decode with.
 	section: Timeline,
-	/// The timeline window shared with the watcher task.
+	/// This rendition's window over the broadcast timeline, fed by the catalog watcher's
+	/// fan-out.
 	live: Arc<segments::Producer>,
+	/// The source and (possibly sibling) broadcast reference, resolved lazily for FETCH.
+	source: moq_mux::Source,
+	sibling: Option<moq_net::PathRelativeOwned>,
 	/// The largest `EXT-X-TARGETDURATION` advertised so far, in seconds. Latched monotonically:
 	/// HLS forbids a live playlist's target duration from changing, so it never shrinks even
 	/// after a long segment evicts from the window.
 	target_duration: std::sync::atomic::AtomicU64,
 	/// The init segment, built on first request.
 	init: tokio::sync::Mutex<Option<Bytes>>,
-	/// Aborts the timeline watcher when the rendition is dropped.
-	watcher: tokio::task::JoinHandle<()>,
 }
 
 impl Rendition {
@@ -100,24 +104,9 @@ impl Rendition {
 		self.config == Config::Audio(config.clone())
 	}
 
-	/// Build a video rendition and spawn its timeline watcher. `None` if the catalog doesn't
-	/// advertise a timeline (fetch-on-demand needs one).
-	pub(crate) fn video(
-		name: String,
-		config: &VideoConfig,
-		source: &moq_mux::Source,
-		window: Duration,
-	) -> Option<Self> {
-		let section = config.timeline.clone()?;
-		let live = Arc::new(segments::Producer::new());
-		let watcher = spawn_watcher(
-			source.clone(),
-			config.broadcast.clone(),
-			section.clone(),
-			live.clone(),
-			window,
-		);
-		Some(Self {
+	/// Build a video rendition over the broadcast's timeline `section`.
+	pub(crate) fn video(name: String, config: &VideoConfig, source: &moq_mux::Source, section: Timeline) -> Self {
+		Self {
 			name,
 			kind: Kind::Video,
 			bandwidth: config.bitrate.unwrap_or(DEFAULT_VIDEO_BITRATE),
@@ -126,31 +115,17 @@ impl Rendition {
 			codec: config.codec.to_string(),
 			config: Config::Video(config.clone()),
 			section,
-			live,
+			live: Arc::new(segments::Producer::new()),
+			source: source.clone(),
+			sibling: config.broadcast.clone(),
 			target_duration: std::sync::atomic::AtomicU64::new(0),
 			init: tokio::sync::Mutex::new(None),
-			watcher,
-		})
+		}
 	}
 
-	/// Build an audio rendition and spawn its timeline watcher. `None` if the catalog doesn't
-	/// advertise a timeline.
-	pub(crate) fn audio(
-		name: String,
-		config: &AudioConfig,
-		source: &moq_mux::Source,
-		window: Duration,
-	) -> Option<Self> {
-		let section = config.timeline.clone()?;
-		let live = Arc::new(segments::Producer::new());
-		let watcher = spawn_watcher(
-			source.clone(),
-			config.broadcast.clone(),
-			section.clone(),
-			live.clone(),
-			window,
-		);
-		Some(Self {
+	/// Build an audio rendition over the broadcast's timeline `section`.
+	pub(crate) fn audio(name: String, config: &AudioConfig, source: &moq_mux::Source, section: Timeline) -> Self {
+		Self {
 			name,
 			kind: Kind::Audio,
 			bandwidth: config.bitrate.unwrap_or(DEFAULT_AUDIO_BITRATE),
@@ -159,29 +134,45 @@ impl Rendition {
 			codec: config.codec.to_string(),
 			config: Config::Audio(config.clone()),
 			section,
-			live,
+			live: Arc::new(segments::Producer::new()),
+			source: source.clone(),
+			sibling: config.broadcast.clone(),
 			target_duration: std::sync::atomic::AtomicU64::new(0),
 			init: tokio::sync::Mutex::new(None),
-			watcher,
-		})
+		}
 	}
 
-	/// A cursor over this rendition's finalized segments, with their media, in timeline order.
+	/// Feed one timeline record into this rendition's window: its own ranges (empty when the
+	/// record carries none for it, a gap), timed by the record.
+	pub(crate) fn push(&self, entry: &Entry, window: Duration) {
+		let row = segments::Row {
+			segment: entry.segment,
+			ranges: entry.tracks.get(&self.name).cloned().unwrap_or_default(),
+			duration: entry.duration.as_secs_f64(),
+			pts: entry.pts,
+			end: Duration::from(entry.pts) + entry.duration,
+		};
+		self.live.push(row, window);
+	}
+
+	/// Mark this rendition's window ended (the timeline finished cleanly).
+	pub(crate) fn end(&self) {
+		self.live.end();
+	}
+
+	/// A cursor over this rendition's segments, with their media, in timeline order.
 	/// For a recorder mirroring the broadcast; see [`segments::Consumer`].
 	pub fn segments(self: &Arc<Self>) -> segments::Consumer {
 		self.live.subscribe(self.clone())
 	}
 
-	/// Retire this rendition: close its segment timeline so every [`segments::Consumer`] over it
-	/// drains what's left and then ends, and stop the timeline watcher (releasing its standing
-	/// source subscription).
+	/// Retire this rendition: close its window so every [`segments::Consumer`] over it drains
+	/// what's left and then ends.
 	///
-	/// Called when the catalog drops or replaces the rendition. The media track may continue
-	/// through a replacement, so the old watcher has no clean end to await; a cursor's
-	/// `Arc<Self>` would otherwise keep it subscribed and parked forever.
+	/// Called when the catalog drops or replaces the rendition; a cursor's `Arc<Self>` would
+	/// otherwise park forever on a window nothing feeds anymore.
 	pub(crate) fn close(&self) {
 		self.live.close();
-		self.watcher.abort();
 	}
 
 	/// Resolve once the playlist is renderable, i.e. once [`media_playlist`](Self::media_playlist)
@@ -192,8 +183,8 @@ impl Rendition {
 	}
 
 	/// Render this rendition's media playlist from the current timeline window, or `None` when
-	/// there is nothing to serve yet (no complete segment, and the broadcast has not ended) --
-	/// a playlist with no segments confuses players, so a server should treat `None` as "not
+	/// there is nothing to serve yet (no segment, and the broadcast has not ended) -- a
+	/// playlist with no segments confuses players, so a server should treat `None` as "not
 	/// ready" rather than serve it.
 	///
 	/// `query` is an optional query string (without the leading `?`, e.g. `jwt=<token>`)
@@ -210,9 +201,9 @@ impl Rendition {
 		let window = self.live.window();
 
 		// EXT-X-TARGETDURATION must be >= every segment's duration and, per the HLS spec, must not
-		// change over a playlist's lifetime. The timeline is our only cadence signal, so take the
-		// longest gap seen so far and latch it monotonically (fetch_max) so a long segment evicting
-		// from the window can never shrink the advertised value.
+		// change over a playlist's lifetime. Records carry explicit durations, so take the longest
+		// seen so far and latch it monotonically (fetch_max) so a long segment evicting from the
+		// window can never shrink the advertised value.
 		let longest = window.segments.iter().map(|s| s.duration).fold(0.0f64, f64::max);
 		let want = (longest.ceil() as u64).max(1);
 		let target_duration = self
@@ -222,24 +213,39 @@ impl Rendition {
 
 		let program_date_time = window.segments.first().and_then(|first| self.wall_clock(first.pts));
 
+		// A jump in content time between consecutive rows is a discontinuity: the next segment
+		// doesn't continue the previous one's timeline. Tolerate sub-millisecond drift from
+		// timescale rounding.
+		let mut previous_end: Option<Duration> = None;
+		let segments = window
+			.segments
+			.into_iter()
+			.map(|s| {
+				let discontinuity = previous_end.is_some_and(|end| {
+					let start = Duration::from(s.pts);
+					start.saturating_sub(end).max(end.saturating_sub(start)) > Duration::from_millis(1)
+				});
+				previous_end = Some(s.end);
+				Segment {
+					segment: s.segment,
+					duration: s.duration,
+					gap: s.ranges.is_empty(),
+					discontinuity,
+				}
+			})
+			.collect();
+
 		Snapshot {
 			target_duration,
 			media_sequence: window.sequence,
-			segments: window
-				.segments
-				.into_iter()
-				.map(|s| Segment {
-					segment: s.segment,
-					duration: s.duration,
-				})
-				.collect(),
+			segments,
 			finished: window.ended,
 			program_date_time,
 		}
 	}
 
-	/// Whether the playlist has anything to serve yet (at least one complete segment, or the
-	/// broadcast already ended).
+	/// Whether the playlist has anything to serve yet (at least one segment, or the broadcast
+	/// already ended).
 	pub(crate) fn is_playable(&self) -> bool {
 		self.live.is_playable()
 	}
@@ -260,9 +266,13 @@ impl Rendition {
 		})
 	}
 
-	/// The media track handle on its (possibly sibling) broadcast; `None` until the watcher
-	/// has resolved the broadcast.
-	fn track(&self) -> Option<moq_net::track::Consumer> {
+	/// The media track handle on its (possibly sibling) broadcast, resolved lazily on the
+	/// first fetch.
+	async fn track(&self) -> Option<moq_net::track::Consumer> {
+		if self.live.broadcast.get().is_none() {
+			let broadcast = self.source.resolve(self.sibling.as_ref()).await.ok()?;
+			let _ = self.live.broadcast.set(broadcast);
+		}
 		let broadcast = self.live.broadcast.get()?;
 		broadcast.track(&self.name).ok()
 	}
@@ -270,7 +280,7 @@ impl Rendition {
 	/// The rendition's CMAF init segment, built on first request and cached.
 	///
 	/// For inline-parameter-set codecs (no catalog `description`), the parameter sets are
-	/// resolved by fetching the newest complete segment's group first.
+	/// resolved by fetching the newest keyframe group first.
 	pub(crate) async fn init(&self) -> Result<Option<Bytes>> {
 		let mut cache = self.init.lock().await;
 		if let Some(bytes) = cache.as_ref() {
@@ -280,14 +290,14 @@ impl Rendition {
 		let mut muxer = self.muxer()?;
 
 		// An out-of-band codec builds its init straight from the catalog; an inline one returns
-		// `None` until a keyframe group is read, so bootstrap it from the newest complete segment.
+		// `None` until a keyframe group is read, so bootstrap it from the newest one indexed.
 		let bytes = match muxer.init()? {
 			Some(bytes) => bytes,
 			None => {
-				let Some(sequence) = self.live.latest_group() else {
+				let Some(sequence) = self.live.latest_keyframe_group() else {
 					return Ok(None);
 				};
-				let Some(track) = self.track() else {
+				let Some(track) = self.track().await else {
 					return Ok(None);
 				};
 				let Some(mut group) = fetch(&track, sequence).await? else {
@@ -309,32 +319,37 @@ impl Rendition {
 
 	/// Fetch and transmux the segment numbered `segment`.
 	///
-	/// Fetches every group the segment covers (an audio segment packs many short groups) and
-	/// encodes them as a single CMAF fragment. `None` when the segment isn't in the playlist
-	/// window or its groups already left the relay cache.
+	/// Fetches every group the segment's ranges cover (an audio segment packs many short
+	/// groups) and encodes them as a single CMAF fragment. `None` when the segment isn't in
+	/// the playlist window, is a gap for this rendition, or its groups already left the relay
+	/// cache.
 	pub async fn segment(&self, segment: u64) -> Result<Option<Bytes>> {
-		let Some((start, end)) = self.live.segment_groups(segment) else {
+		let Some(ranges) = self.live.segment_ranges(segment) else {
 			return Ok(None);
 		};
-		let Some(track) = self.track() else {
+		if ranges.is_empty() {
+			// A gap: the record says this rendition has no content for the span.
 			return Ok(None);
-		};
+		}
 
-		let bounded = end.is_some();
-		// A bounded segment must be served whole. If its real group span exceeds the safety cap
-		// (a pathologically coarse timeline), 404 rather than silently truncating it to a segment
+		// A segment must be served whole. If its group span exceeds the safety cap (a
+		// pathologically coarse timeline), 404 rather than silently truncating it to a segment
 		// shorter than its advertised duration.
-		if let Some(end) = end
-			&& end.saturating_sub(start) > MAX_SEGMENT_GROUPS
-		{
+		let total: u64 = ranges
+			.iter()
+			.map(|r| r.end.saturating_sub(r.start).saturating_add(1))
+			.sum();
+		if total > MAX_SEGMENT_GROUPS {
 			tracing::warn!(
-				start,
-				end,
+				total,
 				"segment spans more than MAX_SEGMENT_GROUPS; refusing to truncate"
 			);
 			return Ok(None);
 		}
-		let end = end.unwrap_or(u64::MAX).min(start.saturating_add(MAX_SEGMENT_GROUPS));
+
+		let Some(track) = self.track().await else {
+			return Ok(None);
+		};
 
 		let mut muxer = self.muxer()?;
 		// Accumulate every group's frames into ONE fragment, so duration inference sees each
@@ -342,35 +357,25 @@ impl Rendition {
 		// group (its real successor lives in the next group), audible on audio segments that span
 		// many groups.
 		let mut frames = Vec::new();
-		for sequence in start..end {
-			let Some(mut group) = fetch(&track, sequence).await? else {
-				// A missing group: a bounded segment left the relay cache (serve nothing); the
-				// open-ended final segment simply ends at the last present group.
-				if bounded {
+		for range in &ranges {
+			for sequence in range.start..=range.end {
+				let Some(mut group) = fetch(&track, sequence).await? else {
+					// A missing group: the segment left the relay cache; serve nothing rather
+					// than a truncated segment.
 					return Ok(None);
-				}
-				break;
-			};
-			let Some(mut group_frames) = read_group(&mut muxer, &mut group).await? else {
-				// The group aged out of the cache mid-read.
-				if bounded {
+				};
+				let Some(mut group_frames) = read_group(&mut muxer, &mut group).await? else {
+					// The group aged out of the cache mid-read.
 					return Ok(None);
-				}
-				break;
-			};
-			frames.append(&mut group_frames);
+				};
+				frames.append(&mut group_frames);
+			}
 		}
 
 		if frames.is_empty() {
 			return Ok(None);
 		}
 		Ok(Some(muxer.fragment(segment as u32, &frames)?))
-	}
-}
-
-impl Drop for Rendition {
-	fn drop(&mut self) {
-		self.watcher.abort();
 	}
 }
 
@@ -414,49 +419,4 @@ fn is_cache_miss_mux(err: &moq_mux::Error) -> bool {
 		moq_mux::Error::Cmaf(moq_mux::container::fmp4::Error::Moq(err)) => is_cache_miss(err),
 		_ => false,
 	}
-}
-
-/// Spawn the per-rendition watcher: resolve the (possibly sibling) broadcast, subscribe to
-/// the timeline track, and feed records into the shared window.
-fn spawn_watcher(
-	source: moq_mux::Source,
-	broadcast: Option<moq_net::PathRelativeOwned>,
-	section: Timeline,
-	live: Arc<segments::Producer>,
-	window: Duration,
-) -> tokio::task::JoinHandle<()> {
-	tokio::spawn(async move {
-		match watch(source, broadcast, &section, &live, window).await {
-			// The timeline finished cleanly: the publisher is done, so its media groups are
-			// finalized and the last record can become a servable (ENDLIST) segment.
-			Ok(()) => live.end(),
-			// A transient error (subscription reset, relay hiccup): don't mark the window ended,
-			// which would turn the last record into an open-ended segment whose FETCH could park
-			// on a still-open group. The serve path keeps serving the frozen window.
-			Err(err) => {
-				tracing::warn!(track = %section.track, %err, "timeline watcher error; leaving the playlist live")
-			}
-		}
-		// The timeline stream is over either way: close so a recording cursor terminates instead
-		// of parking forever (the serve path still reads the last window).
-		live.close();
-	})
-}
-
-async fn watch(
-	source: moq_mux::Source,
-	broadcast: Option<moq_net::PathRelativeOwned>,
-	section: &Timeline,
-	live: &segments::Producer,
-	window: Duration,
-) -> Result<()> {
-	let broadcast = source.resolve(broadcast.as_ref()).await?;
-	// Publish the resolved broadcast so segment requests can FETCH from it.
-	let _ = live.broadcast.set(broadcast.clone());
-
-	let mut timeline = moq_mux::timeline::Consumer::<()>::subscribe(&broadcast, section).await?;
-	while let Some(entry) = timeline.next().await? {
-		live.push(entry, window);
-	}
-	Ok(())
 }

--- a/rs/moq-hls/src/export/renditions.rs
+++ b/rs/moq-hls/src/export/renditions.rs
@@ -1,19 +1,22 @@
 //! A broadcast's rendition set, as a `Producer`/[`Consumer`] pair.
 //!
-//! The `Producer` holds the current renditions, reconciled from the catalog by
-//! its `sync`; the HTTP serve path reads them synchronously (look one up, render
-//! the master playlist). A [`Consumer`] is a cursor for a recorder that mirrors the *whole*
-//! broadcast: [`next`](Consumer::next) yields one [`Event`] at a time as renditions are added
-//! or removed, replaying the current set as [`Added`](Event::Added) when first consumed, and
-//! returning `None` once the source closes.
+//! The `Producer` holds the current renditions, reconciled from the catalog by its `sync`;
+//! the HTTP serve path reads them synchronously (look one up, render the master playlist). It
+//! is also the fan-out point for the broadcast's single timeline: the timeline watcher's
+//! `Fanout` handle hands each record to every rendition, which keeps its own window over it.
+//! A [`Consumer`] is a cursor for a recorder that mirrors the *whole* broadcast: [`next`](Consumer::next)
+//! yields one [`Event`] at a time as renditions are added or removed, replaying the current
+//! set as [`Added`](Event::Added) when first consumed, and returning `None` once the source
+//! closes.
 
-use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::{Arc, Mutex, Weak};
 use std::task::Poll;
+use std::time::Duration;
 
 use moq_mux::catalog::hang::Catalog;
+use moq_mux::timeline::Entry;
 
-use super::Config;
 use super::rendition::{Kind, Rendition};
 
 /// The `(kind, name)` identity of a rendition. Video and audio are separate axes, so a video
@@ -34,6 +37,23 @@ pub enum Event {
 	},
 }
 
+/// The timeline fan-out state: who gets fed, and what a late-created rendition replays.
+///
+/// Feeds by `Weak` reference rather than through the rendition map: a recording cursor's
+/// `Arc<Rendition>` must keep receiving records after `Broadcaster::drop` clears the map, or
+/// its final segments would be silently lost.
+struct Feed {
+	/// Every rendition ever created and still alive, pruned as they drop.
+	targets: Vec<Weak<Rendition>>,
+	/// Recent records, replayed into a rendition created mid-broadcast so its playlist window
+	/// isn't empty until the next record. Evicted with the same policy as the windows.
+	history: VecDeque<Entry>,
+	/// The timeline ended cleanly; late-created renditions start ended (`EXT-X-ENDLIST`).
+	ended: bool,
+	/// The timeline stream is over (cleanly or not); late-created renditions start closed.
+	closed: bool,
+}
+
 /// The producing side of a broadcast's rendition set.
 ///
 /// [`sync`](Self::sync) reconciles it against a catalog snapshot; [`close`](Self::close) marks
@@ -43,13 +63,40 @@ pub enum Event {
 #[derive(Clone)]
 pub(crate) struct Producer {
 	state: kio::Producer<BTreeMap<Key, Arc<Rendition>>>,
+	fanout: Fanout,
+}
+
+/// The timeline fan-out handle: everything the timeline watcher needs, and nothing more.
+///
+/// Deliberately separate from [`Producer`]: the watcher outlives the `Broadcaster` while a
+/// recording cursor drains, and holding a full `Producer` there would keep the rendition-set
+/// channel open (so `renditions()` cursors would never terminate).
+#[derive(Clone)]
+pub(crate) struct Fanout {
+	feed: Arc<Mutex<Feed>>,
+	/// The playlist window duration (see [`Config::window`](super::Config::window)), applied on every push.
+	window: Duration,
 }
 
 impl Producer {
-	pub fn new() -> Self {
+	pub fn new(window: Duration) -> Self {
 		Self {
 			state: kio::Producer::new(BTreeMap::new()),
+			fanout: Fanout {
+				feed: Arc::new(Mutex::new(Feed {
+					targets: Vec::new(),
+					history: VecDeque::new(),
+					ended: false,
+					closed: false,
+				})),
+				window,
+			},
 		}
+	}
+
+	/// The timeline fan-out handle for the timeline watcher task.
+	pub fn fanout(&self) -> Fanout {
+		self.fanout.clone()
 	}
 
 	/// A cursor over rendition changes, replaying the current set as [`Event::Added`].
@@ -76,19 +123,22 @@ impl Producer {
 		self.state.read().is_empty()
 	}
 
+	/// Whether anything outside the map (a recording cursor, a handed-out `Arc`) still holds a
+	/// rendition. `Broadcaster::drop` checks this to decide whether the timeline watcher must
+	/// outlive it (so those holders keep receiving records) or can be aborted.
+	pub fn any_held_externally(&self) -> bool {
+		self.state.read().values().any(|r| Arc::strong_count(r) > 1)
+	}
+
 	/// Release every rendition the map is holding.
 	///
 	/// The map lives in shared state, so a surviving [`Consumer`] would otherwise keep every
-	/// rendition -- and the standing timeline subscription each watcher holds -- alive after the
-	/// owning `Broadcaster` is gone. `Broadcaster::drop` calls this so teardown doesn't depend on
-	/// consumers dropping first: a rendition nobody else holds drops here, and its `Drop` aborts
-	/// its watcher.
+	/// rendition alive after the owning `Broadcaster` is gone. `Broadcaster::drop` calls this
+	/// so teardown doesn't depend on consumers dropping first.
 	///
-	/// Deliberately drops rather than [`Rendition::close`]s. A rendition a cursor still holds is
-	/// left to finish on its own, because its watcher ends a cleanly-finished timeline with
-	/// `end()` *then* `close()`, and `end()` is what promotes the live-edge record into the final
-	/// segment. Force-closing here would race that: `end()` is a no-op on an already-closed
-	/// channel, so the last segment of a recording would be silently dropped.
+	/// Deliberately drops rather than [`Rendition::close`]s: a rendition a cursor still holds
+	/// keeps receiving timeline records through the [`Feed`]'s weak list, so a recording in
+	/// progress drains to the real end of the broadcast instead of being truncated here.
 	pub fn clear(&self) {
 		if let Ok(mut current) = self.state.write() {
 			current.clear();
@@ -97,16 +147,77 @@ impl Producer {
 
 	/// Close the channel, signalling consumers that no more renditions will appear.
 	///
-	/// Deliberately does NOT cascade into the renditions' own segment channels, for two reasons.
-	/// On a clean end it's unnecessary and harmful: each rendition's watcher already ends its
-	/// timeline with `end()` then `close()`, and cascading a bare `close()` here would race that
-	/// and lose the final segment (see [`Self::clear`]). On a catalog-stream *error* the media
-	/// tracks are usually still fine, so cutting every in-flight segment cursor would truncate a
-	/// recording over a transient fault.
+	/// Deliberately does NOT cascade into the renditions' own segment windows: those are ended
+	/// or closed by the timeline watcher (see [`Fanout::end_windows`] /
+	/// [`Fanout::close_windows`]), whose clean-end path must run `end()` before `close()` or
+	/// the playlist never gets its `EXT-X-ENDLIST`.
 	pub fn close(&self) {
 		let _ = self.state.close();
 	}
+}
 
+impl Fanout {
+	/// Fan one timeline record out to every living rendition, and into the replay history.
+	pub fn push(&self, entry: Entry) {
+		let mut feed = self.feed.lock().unwrap();
+
+		// Same eviction policy as the per-rendition windows, so a replay reconstructs the
+		// same window a live rendition would have.
+		if let Some(back) = feed.history.back()
+			&& (Duration::from(entry.pts) < Duration::from(back.pts) || entry.segment <= back.segment)
+		{
+			feed.history.clear();
+		}
+		feed.history.push_back(entry.clone());
+		while feed.history.len() >= 2 {
+			let newest = feed.history.back().unwrap();
+			let span =
+				(Duration::from(newest.pts) + newest.duration).saturating_sub(Duration::from(feed.history[1].pts));
+			if span < self.window {
+				break;
+			}
+			feed.history.pop_front();
+		}
+
+		let window = self.window;
+		feed.targets.retain(|target| {
+			let Some(rendition) = target.upgrade() else {
+				return false;
+			};
+			rendition.push(&entry, window);
+			true
+		});
+	}
+
+	/// Mark every living rendition's window ended (the timeline finished cleanly).
+	pub fn end_windows(&self) {
+		let mut feed = self.feed.lock().unwrap();
+		feed.ended = true;
+		feed.targets.retain(|target| {
+			let Some(rendition) = target.upgrade() else {
+				return false;
+			};
+			rendition.end();
+			true
+		});
+	}
+
+	/// Close every living rendition's window: no more records will arrive. Cursors drain what
+	/// they can still see and end; the serve path keeps reading the frozen windows.
+	pub fn close_windows(&self) {
+		let mut feed = self.feed.lock().unwrap();
+		feed.closed = true;
+		feed.targets.retain(|target| {
+			let Some(rendition) = target.upgrade() else {
+				return false;
+			};
+			rendition.close();
+			true
+		});
+	}
+}
+
+impl Producer {
 	/// Resolve once at least one rendition has been discovered. Bounding how long to wait is
 	/// the caller's policy, so wrap this in a timeout rather than passing one in.
 	pub async fn ready(&self) {
@@ -122,17 +233,43 @@ impl Producer {
 		.await;
 	}
 
+	/// Enroll a freshly-created rendition in the timeline feed, replaying the recent history
+	/// (and the ended/closed markers) so its window matches its siblings'.
+	fn register(&self, rendition: &Arc<Rendition>) {
+		let mut feed = self.fanout.feed.lock().unwrap();
+		for entry in &feed.history {
+			rendition.push(entry, self.fanout.window);
+		}
+		if feed.ended {
+			rendition.end();
+		}
+		if feed.closed {
+			rendition.close();
+		}
+		feed.targets.push(Arc::downgrade(rendition));
+	}
+
 	/// Reconcile the rendition set with a complete catalog snapshot. Removed or reconfigured
-	/// renditions are dropped before replacements become visible, which also aborts their
-	/// timeline watchers and releases their subscriptions.
-	pub fn sync(&self, source: &moq_mux::Source, config: &Config, catalog: &Catalog) {
+	/// renditions are closed (so cursors over them end) before replacements become visible.
+	///
+	/// Renditions are only servable when the catalog advertises the broadcast's timeline (its
+	/// root `timeline` section): without one there is nothing to render playlists from, so the
+	/// whole catalog is skipped with a warning.
+	pub fn sync(&self, source: &moq_mux::Source, catalog: &Catalog) {
+		let Some(section) = catalog.timeline.clone() else {
+			if !catalog.video.renditions.is_empty() || !catalog.audio.renditions.is_empty() {
+				tracing::warn!("catalog advertises no timeline; its renditions can't be served as HLS");
+			}
+			return;
+		};
+
 		let Ok(mut current) = self.state.write() else {
 			return;
 		};
 
 		// Renditions the catalog dropped or reconfigured. Close each as it goes so any cursor
-		// over it drains and ends, instead of parking on a timeline that never finishes -- the
-		// cursor's own `Arc<Rendition>` would otherwise keep it (and its subscription) alive.
+		// over it drains and ends, instead of parking on a window that never finishes -- the
+		// cursor's own `Arc<Rendition>` would otherwise keep it alive.
 		let stale: Vec<Key> = current
 			.iter()
 			.filter(|((kind, name), rendition)| match kind {
@@ -160,24 +297,18 @@ impl Producer {
 			if current.contains_key(&key) {
 				continue;
 			}
-			match Rendition::video(name.clone(), video, source, config.window) {
-				Some(rendition) => {
-					current.insert(key, Arc::new(rendition));
-				}
-				None => tracing::warn!(%name, "skipping video rendition without a timeline track"),
-			}
+			let rendition = Arc::new(Rendition::video(name.clone(), video, source, section.clone()));
+			self.register(&rendition);
+			current.insert(key, rendition);
 		}
 		for (name, audio) in &catalog.audio.renditions {
 			let key = (Kind::Audio, name.clone());
 			if current.contains_key(&key) {
 				continue;
 			}
-			match Rendition::audio(name.clone(), audio, source, config.window) {
-				Some(rendition) => {
-					current.insert(key, Arc::new(rendition));
-				}
-				None => tracing::warn!(%name, "skipping audio rendition without a timeline track"),
-			}
+			let rendition = Arc::new(Rendition::audio(name.clone(), audio, source, section.clone()));
+			self.register(&rendition);
+			current.insert(key, rendition);
 		}
 	}
 }

--- a/rs/moq-hls/src/export/segments.rs
+++ b/rs/moq-hls/src/export/segments.rs
@@ -1,13 +1,17 @@
 //! One rendition's segment timeline, as a `Producer`/[`Consumer`] pair.
 //!
 //! The `Producer` is fed [`moq_mux::timeline::Entry`]s by a background task as the publisher
-//! indexes new groups; it keeps a bounded window of them. Two things read that window:
+//! indexes new segments; it keeps a bounded window of them. Two things read that window:
 //!
 //! * the HTTP serve path, synchronously, to render a media playlist and look up a segment's
 //!   group span (nothing here touches media bytes on that path); and
 //! * a [`Consumer`] cursor, for a recorder that wants every finalized segment *with its media*,
 //!   in order, exactly once. `next()` waits for the next segment to finalize, FETCHes and
 //!   transmuxes its groups (via [`Rendition`]), and yields the CMAF bytes.
+//!
+//! Entries carry the broadcast's aligned segment numbers, so a segment is addressed by that
+//! number everywhere (the `seg/{segment}.m4s` URI, `EXT-X-MEDIA-SEQUENCE`, the recorder
+//! cursor), and the same number names the same span of content time on every rendition.
 
 use std::collections::VecDeque;
 use std::sync::{Arc, OnceLock};
@@ -38,21 +42,20 @@ pub(crate) struct Producer {
 
 struct State {
 	/// Timeline records within the window, oldest first. Consecutive records bound a segment:
-	/// record `i` starts it, record `i + 1` supplies its duration, so the last record is the
-	/// live edge (its segment is still growing).
+	/// record `i` starts it, record `i + 1` supplies its duration and group span, so the last
+	/// record is the live edge (its segment is still growing).
 	entries: VecDeque<Entry>,
-	/// Records evicted from the front of the window since subscribing; the playlist's
-	/// `EXT-X-MEDIA-SEQUENCE` base, so segment positions stay stable across reloads.
-	dropped: u64,
 	/// The timeline track ended: the broadcast is over and the last record is a full segment.
 	ended: bool,
 }
 
-/// One playlist segment: a starting group and the media it covers.
+/// One playlist segment: its aligned number, its starting group, and the media span it covers.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct Row {
-	/// The first group of the segment (its URI: `seg/{group}.m4s`). The segment covers every
-	/// group up to (excluding) the next segment's `group`.
+	/// The aligned segment number (its URI: `seg/{segment}.m4s`), shared across renditions.
+	pub segment: u64,
+	/// The rendition's first group of the segment. The segment covers every group up to
+	/// (excluding) the next record's group.
 	pub group: u64,
 	/// Presentation duration in seconds (the gap to the next timeline record).
 	pub duration: f64,
@@ -63,7 +66,8 @@ pub(crate) struct Row {
 /// A consistent read of the window, for rendering one playlist (the serve path only).
 #[cfg_attr(not(feature = "server"), allow(dead_code))]
 pub(crate) struct Window {
-	/// The `EXT-X-MEDIA-SEQUENCE` of the first listed segment.
+	/// The `EXT-X-MEDIA-SEQUENCE` of the first listed segment: its aligned segment number, so
+	/// sequence numbers line up across renditions.
 	pub sequence: u64,
 	/// Complete segments, oldest first.
 	pub segments: Vec<Row>,
@@ -73,8 +77,8 @@ pub(crate) struct Window {
 
 /// The next finalized segment a [`Consumer`] should emit, resolved from the window.
 enum Next {
-	/// A finalized segment is ready to fetch, along with the group that follows it in the
-	/// window (`None` if it's the last / ended-final record). The successor lets a cursor
+	/// A finalized segment is ready to fetch, along with the segment number that follows it in
+	/// the window (`None` if it's the last / ended-final record). The successor lets a cursor
 	/// notice a gap: if the next segment it emits isn't this successor, records were evicted
 	/// unseen in between.
 	Ready { row: Row, successor: Option<u64> },
@@ -104,6 +108,7 @@ impl State {
 			&& let Some(last) = self.entries.back()
 		{
 			segments.push(Row {
+				segment: last.segment,
 				group: last.group,
 				duration: self.final_duration(),
 				pts: last.pts,
@@ -111,7 +116,7 @@ impl State {
 		}
 
 		Window {
-			sequence: self.dropped,
+			sequence: segments.first().map(|s| s.segment).unwrap_or(0),
 			segments,
 			ended: self.ended,
 		}
@@ -134,7 +139,7 @@ impl State {
 			.max(DEFAULT_SEGMENT.as_secs_f64())
 	}
 
-	/// The first finalized segment starting past `after`, for a cursor.
+	/// The first finalized segment numbered past `after`, for a cursor.
 	///
 	/// A record is finalized once a later record bounds its duration, or the timeline has
 	/// ended (making the live-edge record the final segment). Segments evicted from the front
@@ -142,7 +147,7 @@ impl State {
 	/// oldest record still in the window.
 	fn next_after(&self, after: Option<u64>) -> Next {
 		let mut iter = self.entries.iter().enumerate().filter(|(_, e)| match after {
-			Some(after) => e.group > after,
+			Some(after) => e.segment > after,
 			None => true,
 		});
 		let Some((index, entry)) = iter.next() else {
@@ -152,12 +157,13 @@ impl State {
 			// Bounded by the next record: finalized, and that record is its successor.
 			Some(next) => Next::Ready {
 				row: row(entry, Some(next)),
-				successor: Some(next.group),
+				successor: Some(next.segment),
 			},
 			// The live-edge record is only a segment once the timeline ended; nothing follows it,
 			// so it takes the same estimated duration the serve path advertises for it.
 			None if self.ended => Next::Ready {
 				row: Row {
+					segment: entry.segment,
 					group: entry.group,
 					duration: self.final_duration(),
 					pts: entry.pts,
@@ -174,7 +180,6 @@ impl Producer {
 		Self {
 			state: kio::Producer::new(State {
 				entries: VecDeque::new(),
-				dropped: 0,
 				ended: false,
 			}),
 			broadcast: OnceLock::new(),
@@ -187,18 +192,17 @@ impl Producer {
 			return;
 		};
 
-		if let Some(back_pts) = state.entries.back().map(|e| e.pts) {
+		if let Some(back) = state.entries.back() {
 			// A non-advancing record (a duplicate, or a stalled/mis-scaled source) would open a
 			// zero-duration segment and never trigger eviction; drop it so the prior segment just
 			// covers its groups too.
-			if entry.pts == back_pts {
+			if entry.pts == back.pts {
 				return;
 			}
-			// A backward jump means the publisher restarted its timeline; the old window can't be
-			// stitched onto the new one, so start over (keeping the sequence monotonic).
-			if entry.pts < back_pts {
+			// A backward jump in pts or segment number means the publisher restarted its timeline;
+			// the old window can't be stitched onto the new one, so start over.
+			if entry.pts < back.pts || entry.segment <= back.segment {
 				tracing::warn!("timeline jumped backwards; resetting the playlist window");
-				state.dropped += state.entries.len() as u64;
 				state.entries.clear();
 			}
 		}
@@ -214,7 +218,6 @@ impl Producer {
 				break;
 			}
 			state.entries.pop_front();
-			state.dropped += 1;
 		}
 	}
 
@@ -239,15 +242,15 @@ impl Producer {
 		self.state.read().window()
 	}
 
-	/// The groups covered by the segment starting at `group`, or `None` if it isn't in the
-	/// window. An open end means "until the track ends" (the final segment of an ended
-	/// timeline).
-	pub fn segment_groups(&self, group: u64) -> Option<(u64, Option<u64>)> {
+	/// The groups covered by segment `segment`, or `None` if it isn't in the window. An open
+	/// end means "until the track ends" (the final segment of an ended timeline).
+	pub fn segment_groups(&self, segment: u64) -> Option<(u64, Option<u64>)> {
 		let state = self.state.read();
-		let index = state.entries.iter().position(|e| e.group == group)?;
+		let index = state.entries.iter().position(|e| e.segment == segment)?;
+		let entry = &state.entries[index];
 		match state.entries.get(index + 1) {
-			Some(next) => Some((group, Some(next.group))),
-			None if state.ended => Some((group, None)),
+			Some(next) => Some((entry.group, Some(next.group))),
+			None if state.ended => Some((entry.group, None)),
 			None => None,
 		}
 	}
@@ -302,7 +305,10 @@ impl Producer {
 
 /// A finalized segment with its transmuxed media, yielded by a [`Consumer`].
 pub struct Segment {
-	/// The segment's starting group (also its `seg/{group}.m4s` URI stem).
+	/// The aligned segment number (also its `seg/{segment}.m4s` URI stem), shared across the
+	/// broadcast's renditions.
+	pub segment: u64,
+	/// The rendition's first group of the segment.
 	pub group: u64,
 	/// The transmuxed CMAF fragment (`moof`+`mdat`), fetched on demand by [`Consumer::next`].
 	pub media: Bytes,
@@ -324,11 +330,11 @@ pub struct Segment {
 pub struct Consumer {
 	state: kio::Consumer<State>,
 	rendition: Arc<Rendition>,
-	/// The group of the last segment returned; the next call resumes strictly after it. Only
+	/// The number of the last segment returned; the next call resumes strictly after it. Only
 	/// advanced once a segment is fetched or skipped, so a transient fetch error re-tries the
 	/// same segment on the next call instead of losing it.
 	after: Option<u64>,
-	/// The successor group recorded when the last segment was emitted. If the next segment
+	/// The successor segment recorded when the last one was emitted. If the next segment
 	/// isn't it, records were evicted unseen in between (a gap).
 	expected: Option<u64>,
 	/// A gap opened since the last emitted segment (a skip); set on the next one's discontinuity.
@@ -355,14 +361,15 @@ impl Consumer {
 			};
 			// A gap opened if the segment we're about to emit isn't the successor the previous
 			// one recorded (records between them evicted unseen).
-			let gap = self.gap || self.expected.is_some_and(|expected| expected != row.group);
+			let gap = self.gap || self.expected.is_some_and(|expected| expected != row.segment);
 
-			match self.rendition.segment(row.group).await? {
+			match self.rendition.segment(row.segment).await? {
 				Some(media) => {
-					self.after = Some(row.group);
+					self.after = Some(row.segment);
 					self.expected = successor;
 					self.gap = false;
 					return Ok(Some(Segment {
+						segment: row.segment,
 						group: row.group,
 						media,
 						duration: row.duration,
@@ -373,7 +380,7 @@ impl Consumer {
 				// Its groups aged out of the cache before we fetched them; skip to the next and
 				// carry the gap onto whichever segment we emit next.
 				None => {
-					self.after = Some(row.group);
+					self.after = Some(row.segment);
 					self.expected = successor;
 					self.gap = true;
 				}
@@ -401,6 +408,7 @@ fn row(entry: &Entry, next: Option<&Entry>) -> Row {
 		.map(|next| Duration::from(next.pts).saturating_sub(Duration::from(entry.pts)))
 		.unwrap_or(DEFAULT_SEGMENT);
 	Row {
+		segment: entry.segment,
 		group: entry.group,
 		duration: duration.as_secs_f64(),
 		pts: entry.pts,
@@ -411,8 +419,9 @@ fn row(entry: &Entry, next: Option<&Entry>) -> Row {
 mod tests {
 	use super::*;
 
-	fn entry(group: u64, pts_ms: u64) -> Entry {
+	fn entry(segment: u64, group: u64, pts_ms: u64) -> Entry {
 		Entry {
+			segment,
 			group,
 			pts: moq_net::Timestamp::from_millis(pts_ms).unwrap(),
 			ext: (),
@@ -422,17 +431,17 @@ mod tests {
 	#[test]
 	fn last_record_is_the_live_edge_until_ended() {
 		let live = Producer::new();
-		live.push(entry(0, 0), Duration::from_secs(30));
-		live.push(entry(1, 2_000), Duration::from_secs(30));
-		live.push(entry(2, 4_000), Duration::from_secs(30));
+		live.push(entry(0, 0, 0), Duration::from_secs(30));
+		live.push(entry(1, 1, 2_000), Duration::from_secs(30));
+		live.push(entry(2, 2, 4_000), Duration::from_secs(30));
 
 		let window = live.window();
 		assert_eq!(window.sequence, 0);
 		assert!(!window.ended);
 		assert_eq!(window.segments.len(), 2, "the live-edge record is not listed");
-		assert_eq!(window.segments[0].group, 0);
+		assert_eq!(window.segments[0].segment, 0);
 		assert_eq!(window.segments[0].duration, 2.0);
-		assert_eq!(window.segments[1].group, 1);
+		assert_eq!(window.segments[1].segment, 1);
 
 		live.end();
 		let window = live.window();
@@ -446,65 +455,69 @@ mod tests {
 		let live = Producer::new();
 		let window = Duration::from_secs(4);
 		for i in 0..6u64 {
-			live.push(entry(i, i * 2_000), window);
+			live.push(entry(i, i, i * 2_000), window);
 		}
 
 		let snapshot = live.window();
-		// Segments still cover >= 4s after eviction, and the sequence counts the drops.
+		// Segments still cover >= 4s after eviction, and the sequence is the first listed
+		// segment's aligned number.
 		assert!(snapshot.sequence > 0);
 		let span: f64 = snapshot.segments.iter().map(|s| s.duration).sum();
 		assert!(span >= 4.0);
-		assert_eq!(snapshot.segments.first().unwrap().group, snapshot.sequence);
+		assert_eq!(snapshot.segments.first().unwrap().segment, snapshot.sequence);
 	}
 
 	#[test]
-	fn segment_groups_cover_record_gaps() {
+	fn segment_groups_span_to_the_next_record() {
 		let live = Producer::new();
 		let window = Duration::from_secs(30);
-		// An audio-style timeline: records skip groups (granularity throttling).
-		live.push(entry(0, 0), window);
-		live.push(entry(50, 1_000), window);
-		live.push(entry(100, 2_000), window);
+		// An audio-style timeline: each segment packs many groups, so records skip group numbers.
+		live.push(entry(0, 0, 0), window);
+		live.push(entry(1, 50, 1_000), window);
+		live.push(entry(2, 100, 2_000), window);
 
 		assert_eq!(live.segment_groups(0), Some((0, Some(50))));
-		assert_eq!(live.segment_groups(50), Some((50, Some(100))));
-		// The live edge isn't a segment yet, and unknown groups miss.
-		assert_eq!(live.segment_groups(100), None);
+		assert_eq!(live.segment_groups(1), Some((50, Some(100))));
+		// The live edge isn't a segment yet, and unknown segments miss.
+		assert_eq!(live.segment_groups(2), None);
 		assert_eq!(live.segment_groups(7), None);
 
 		live.end();
-		assert_eq!(live.segment_groups(100), Some((100, None)));
+		assert_eq!(live.segment_groups(2), Some((100, None)));
 	}
 
 	#[test]
 	fn backwards_jump_resets_the_window() {
 		let live = Producer::new();
 		let window = Duration::from_secs(30);
-		live.push(entry(0, 10_000), window);
-		live.push(entry(1, 12_000), window);
-		live.push(entry(2, 1_000), window); // restart
+		live.push(entry(0, 0, 10_000), window);
+		live.push(entry(1, 1, 12_000), window);
+		live.push(entry(2, 2, 1_000), window); // restart: pts rewound
 
 		let snapshot = live.window();
-		assert_eq!(snapshot.sequence, 2, "reset keeps the media sequence monotonic");
 		assert!(snapshot.segments.is_empty(), "only the live edge remains");
+
+		// A segment number that rewinds (a restarted publisher) resets the same way.
+		live.push(entry(0, 0, 2_000), window);
+		assert!(live.window().segments.is_empty(), "only the live edge remains");
 	}
 
 	#[test]
 	fn non_advancing_record_is_skipped() {
 		let live = Producer::new();
 		let window = Duration::from_secs(30);
-		live.push(entry(0, 0), window);
-		live.push(entry(1, 2_000), window);
+		live.push(entry(0, 0, 0), window);
+		live.push(entry(1, 1, 2_000), window);
 		// A record whose pts equals the live edge would open a zero-duration segment; it's dropped
 		// so the prior segment just covers its groups.
-		live.push(entry(2, 2_000), window);
-		live.push(entry(3, 4_000), window);
+		live.push(entry(2, 2, 2_000), window);
+		live.push(entry(3, 3, 4_000), window);
 
 		live.end();
 		let window = live.window();
 		let durations: Vec<f64> = window.segments.iter().map(|s| s.duration).collect();
 		assert!(!durations.contains(&0.0), "no zero-duration segment: {durations:?}");
-		// Group 2 was absorbed into group 1's segment (still bounded by group 3's record).
+		// Segment 2 was absorbed into segment 1 (still bounded by segment 3's record).
 		assert_eq!(live.segment_groups(1), Some((1, Some(3))));
 		assert_eq!(live.segment_groups(2), None, "the skipped record is not a boundary");
 	}
@@ -519,8 +532,8 @@ mod tests {
 
 		// The watcher's own order: end() then close() -- the live edge finalizes.
 		let clean = Producer::new();
-		clean.push(entry(0, 0), window);
-		clean.push(entry(1, 2_000), window);
+		clean.push(entry(0, 0, 0), window);
+		clean.push(entry(1, 1, 2_000), window);
 		clean.end();
 		clean.close();
 		assert!(
@@ -530,8 +543,8 @@ mod tests {
 
 		// Reversed: a close() that races ahead of end() strands it forever.
 		let raced = Producer::new();
-		raced.push(entry(0, 0), window);
-		raced.push(entry(1, 2_000), window);
+		raced.push(entry(0, 0, 0), window);
+		raced.push(entry(1, 1, 2_000), window);
 		raced.close();
 		raced.end();
 		assert!(
@@ -547,21 +560,21 @@ mod tests {
 		let live = Producer::new();
 		let window = Duration::from_secs(30);
 		// A 6s cadence, so the flat 4s DEFAULT_SEGMENT would be wrong for the last segment.
-		live.push(entry(0, 0), window);
-		live.push(entry(1, 6_000), window);
-		live.push(entry(2, 12_000), window);
+		live.push(entry(0, 0, 0), window);
+		live.push(entry(1, 1, 6_000), window);
+		live.push(entry(2, 2, 12_000), window);
 		live.end();
 
 		let served = live.window();
 		let last_served = served.segments.last().expect("a final segment");
-		assert_eq!(last_served.group, 2);
+		assert_eq!(last_served.segment, 2);
 		assert_eq!(last_served.duration, 6.0, "serve path estimates from the cadence");
 
 		let last_recorded = match live.state.read().next_after(Some(1)) {
 			Next::Ready { row, .. } => row,
 			_ => panic!("ending finalizes the live edge"),
 		};
-		assert_eq!(last_recorded.group, 2);
+		assert_eq!(last_recorded.segment, 2);
 		assert_eq!(
 			last_recorded.duration, last_served.duration,
 			"the cursor times the final segment like the serve path"
@@ -572,21 +585,21 @@ mod tests {
 	fn next_after_walks_finalized_segments() {
 		let live = Producer::new();
 		let window = Duration::from_secs(30);
-		live.push(entry(0, 0), window);
-		live.push(entry(1, 2_000), window);
-		live.push(entry(2, 4_000), window);
+		live.push(entry(0, 0, 0), window);
+		live.push(entry(1, 1, 2_000), window);
+		live.push(entry(2, 2, 4_000), window);
 
-		// Groups 0 and 1 are finalized; group 2 is the live edge.
+		// Segments 0 and 1 are finalized; segment 2 is the live edge.
 		let first = match live.state.read().next_after(None) {
 			Next::Ready { row, .. } => row,
 			_ => panic!("expected a finalized segment"),
 		};
-		assert_eq!(first.group, 0);
+		assert_eq!(first.segment, 0);
 		let second = match live.state.read().next_after(Some(0)) {
 			Next::Ready { row, .. } => row,
 			_ => panic!("expected a finalized segment"),
 		};
-		assert_eq!(second.group, 1);
+		assert_eq!(second.segment, 1);
 		assert!(
 			matches!(live.state.read().next_after(Some(1)), Next::Pending),
 			"the live edge is not finalized while live"
@@ -597,7 +610,7 @@ mod tests {
 			Next::Ready { row, .. } => row,
 			_ => panic!("ending finalizes the live edge"),
 		};
-		assert_eq!(last.group, 2);
+		assert_eq!(last.segment, 2);
 		assert!(matches!(live.state.read().next_after(Some(2)), Next::Ended));
 	}
 }

--- a/rs/moq-hls/src/export/segments.rs
+++ b/rs/moq-hls/src/export/segments.rs
@@ -1,15 +1,19 @@
-//! One rendition's segment timeline, as a `Producer`/[`Consumer`] pair.
+//! One rendition's view of the broadcast timeline, as a `Producer`/[`Consumer`] pair.
 //!
-//! The `Producer` is fed [`moq_mux::timeline::Entry`]s by a background task as the publisher
-//! indexes new segments; it keeps a bounded window of them. Two things read that window:
+//! The broadcast has a single timeline track; the catalog watcher reads it and fans each
+//! record out to every rendition as a row: the segment's number, timing, and this
+//! rendition's group ranges (empty when the record carries no content for it, a gap). Records
+//! are self-contained (the segmenter only publishes a segment once its content is final on
+//! every track), so every row is immediately listable and fetchable. Two things read the
+//! window:
 //!
 //! * the HTTP serve path, synchronously, to render a media playlist and look up a segment's
-//!   group span (nothing here touches media bytes on that path); and
-//! * a [`Consumer`] cursor, for a recorder that wants every finalized segment *with its media*,
-//!   in order, exactly once. `next()` waits for the next segment to finalize, FETCHes and
-//!   transmuxes its groups (via [`Rendition`]), and yields the CMAF bytes.
+//!   group ranges (nothing here touches media bytes on that path); and
+//! * a [`Consumer`] cursor, for a recorder that wants every segment *with its media*, in
+//!   order, exactly once. `next()` waits for the next row, FETCHes and transmuxes its groups
+//!   (via [`Rendition`]), and yields the CMAF bytes.
 //!
-//! Entries carry the broadcast's aligned segment numbers, so a segment is addressed by that
+//! Rows carry the broadcast's aligned segment numbers, so a segment is addressed by that
 //! number everywhere (the `seg/{segment}.m4s` URI, `EXT-X-MEDIA-SEQUENCE`, the recorder
 //! cursor), and the same number names the same span of content time on every rendition.
 
@@ -19,48 +23,45 @@ use std::task::Poll;
 use std::time::{Duration, SystemTime};
 
 use bytes::Bytes;
-use moq_mux::timeline::Entry;
+use hang::timeline::Range;
 
 use super::Rendition;
 use crate::Result;
 
-/// Duration assumed for the live-edge segment of an ended timeline before any complete
-/// segment has revealed the real cadence.
-const DEFAULT_SEGMENT: Duration = Duration::from_secs(4);
-
 /// The producing side of a rendition's timeline window.
 ///
-/// A background task appends timeline records via [`push`](Self::push) and marks the stream
+/// The catalog watcher appends rows via [`push`](Self::push) and marks the stream
 /// [`end`](Self::end)ed. Cheap to share behind an `Arc`; the window state lives in a
 /// [`kio::Producer`] so a [`Consumer`] can await changes without a separate signal.
 pub(crate) struct Producer {
 	state: kio::Producer<State>,
-	/// The broadcast serving the media track, resolved once by the background task (it may be
-	/// a sibling broadcast when the catalog rendition carries a `broadcast` reference).
+	/// The broadcast serving the media track, resolved once (it may be a sibling broadcast
+	/// when the catalog rendition carries a `broadcast` reference).
 	pub broadcast: OnceLock<moq_net::broadcast::Consumer>,
 }
 
 struct State {
-	/// Timeline records within the window, oldest first. Consecutive records bound a segment:
-	/// record `i` starts it, record `i + 1` supplies its duration and group span, so the last
-	/// record is the live edge (its segment is still growing).
-	entries: VecDeque<Entry>,
-	/// The timeline track ended: the broadcast is over and the last record is a full segment.
+	/// Rows within the window, oldest first. Every row is a complete segment.
+	rows: VecDeque<Row>,
+	/// The timeline track ended: the broadcast is over (`EXT-X-ENDLIST`).
 	ended: bool,
 }
 
-/// One playlist segment: its aligned number, its starting group, and the media span it covers.
+/// One playlist segment: its aligned number, timing, and this rendition's group ranges.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct Row {
 	/// The aligned segment number (its URI: `seg/{segment}.m4s`), shared across renditions.
 	pub segment: u64,
-	/// The rendition's first group of the segment. The segment covers every group up to
-	/// (excluding) the next record's group.
-	pub group: u64,
-	/// Presentation duration in seconds (the gap to the next timeline record).
+	/// This rendition's group ranges within the segment. Empty means the rendition has no
+	/// content for the span (`EXT-X-GAP`).
+	pub ranges: Vec<Range>,
+	/// Presentation duration in seconds.
 	pub duration: f64,
 	/// The segment's starting presentation timestamp.
 	pub pts: moq_net::Timestamp,
+	/// The segment's ending presentation timestamp (`pts + duration`), for window eviction
+	/// and discontinuity detection.
+	pub end: Duration,
 }
 
 /// A consistent read of the window, for rendering one playlist (the serve path only).
@@ -69,18 +70,17 @@ pub(crate) struct Window {
 	/// The `EXT-X-MEDIA-SEQUENCE` of the first listed segment: its aligned segment number, so
 	/// sequence numbers line up across renditions.
 	pub sequence: u64,
-	/// Complete segments, oldest first.
+	/// Listed segments, oldest first.
 	pub segments: Vec<Row>,
 	/// Whether the timeline (and so the playlist) has ended.
 	pub ended: bool,
 }
 
-/// The next finalized segment a [`Consumer`] should emit, resolved from the window.
+/// The next segment a [`Consumer`] should emit, resolved from the window.
 enum Next {
-	/// A finalized segment is ready to fetch, along with the segment number that follows it in
-	/// the window (`None` if it's the last / ended-final record). The successor lets a cursor
-	/// notice a gap: if the next segment it emits isn't this successor, records were evicted
-	/// unseen in between.
+	/// A segment is ready to fetch, along with the segment number that follows it in the
+	/// window (`None` if it's the newest row). The successor lets a cursor notice a gap: if
+	/// the next segment it emits isn't this successor, rows were evicted unseen in between.
 	Ready { row: Row, successor: Option<u64> },
 	/// No further segment will ever appear (the timeline ended).
 	Ended,
@@ -89,88 +89,32 @@ enum Next {
 }
 
 impl State {
-	/// Snapshot the current window.
-	///
-	/// A segment needs the next record for its duration, so the live-edge record isn't
-	/// listed; once the timeline ends it becomes the final segment, whose duration is
-	/// estimated as the largest gap seen in the window (falling back to
-	/// [`DEFAULT_SEGMENT`] before any complete segment exists).
+	/// Snapshot the current window. Every row is a complete segment, so all are listed.
 	#[cfg_attr(not(feature = "server"), allow(dead_code))]
 	fn window(&self) -> Window {
-		let mut segments = Vec::with_capacity(self.entries.len());
-
-		for (entry, next) in self.entries.iter().zip(self.entries.iter().skip(1)) {
-			segments.push(row(entry, Some(next)));
-		}
-
-		// The final (open-ended) segment has no successor record to time it.
-		if self.ended
-			&& let Some(last) = self.entries.back()
-		{
-			segments.push(Row {
-				segment: last.segment,
-				group: last.group,
-				duration: self.final_duration(),
-				pts: last.pts,
-			});
-		}
-
 		Window {
-			sequence: segments.first().map(|s| s.segment).unwrap_or(0),
-			segments,
+			sequence: self.rows.front().map(|s| s.segment).unwrap_or(0),
+			segments: self.rows.iter().cloned().collect(),
 			ended: self.ended,
 		}
 	}
 
-	/// The duration to advertise for the final (open-ended) segment of an ended timeline, which
-	/// has no successor record to time it: the largest gap seen in the window, floored at
-	/// [`DEFAULT_SEGMENT`] before any complete segment has revealed the real cadence. Shared by
-	/// the serve path and the recording cursor so both time that segment identically.
-	fn final_duration(&self) -> f64 {
-		self.entries
-			.iter()
-			.zip(self.entries.iter().skip(1))
-			.map(|(entry, next)| {
-				Duration::from(next.pts)
-					.saturating_sub(Duration::from(entry.pts))
-					.as_secs_f64()
-			})
-			.fold(0.0f64, f64::max)
-			.max(DEFAULT_SEGMENT.as_secs_f64())
-	}
-
-	/// The first finalized segment numbered past `after`, for a cursor.
+	/// The first segment numbered past `after`, for a cursor.
 	///
-	/// A record is finalized once a later record bounds its duration, or the timeline has
-	/// ended (making the live-edge record the final segment). Segments evicted from the front
-	/// of the window before the cursor reached them are skipped: the cursor resumes at the
-	/// oldest record still in the window.
+	/// Rows are complete the moment they arrive. Segments evicted from the front of the
+	/// window before the cursor reached them are skipped: the cursor resumes at the oldest
+	/// row still in the window.
 	fn next_after(&self, after: Option<u64>) -> Next {
-		let mut iter = self.entries.iter().enumerate().filter(|(_, e)| match after {
-			Some(after) => e.segment > after,
+		let mut iter = self.rows.iter().enumerate().filter(|(_, r)| match after {
+			Some(after) => r.segment > after,
 			None => true,
 		});
-		let Some((index, entry)) = iter.next() else {
+		let Some((index, row)) = iter.next() else {
 			return if self.ended { Next::Ended } else { Next::Pending };
 		};
-		match self.entries.get(index + 1) {
-			// Bounded by the next record: finalized, and that record is its successor.
-			Some(next) => Next::Ready {
-				row: row(entry, Some(next)),
-				successor: Some(next.segment),
-			},
-			// The live-edge record is only a segment once the timeline ended; nothing follows it,
-			// so it takes the same estimated duration the serve path advertises for it.
-			None if self.ended => Next::Ready {
-				row: Row {
-					segment: entry.segment,
-					group: entry.group,
-					duration: self.final_duration(),
-					pts: entry.pts,
-				},
-				successor: None,
-			},
-			None => Next::Pending,
+		Next::Ready {
+			row: row.clone(),
+			successor: self.rows.get(index + 1).map(|next| next.segment),
 		}
 	}
 }
@@ -179,57 +123,49 @@ impl Producer {
 	pub fn new() -> Self {
 		Self {
 			state: kio::Producer::new(State {
-				entries: VecDeque::new(),
+				rows: VecDeque::new(),
 				ended: false,
 			}),
 			broadcast: OnceLock::new(),
 		}
 	}
 
-	/// Append a timeline record, evicting the front of the window past `window`.
-	pub fn push(&self, entry: Entry, window: Duration) {
+	/// Append a row, evicting the front of the window past `window`.
+	pub fn push(&self, row: Row, window: Duration) {
 		let Ok(mut state) = self.state.write() else {
 			return;
 		};
 
-		if let Some(back) = state.entries.back() {
-			// A non-advancing record (a duplicate, or a stalled/mis-scaled source) would open a
-			// zero-duration segment and never trigger eviction; drop it so the prior segment just
-			// covers its groups too.
-			if entry.pts == back.pts {
-				return;
-			}
+		if let Some(back) = state.rows.back() {
 			// A backward jump in pts or segment number means the publisher restarted its timeline;
 			// the old window can't be stitched onto the new one, so start over.
-			if entry.pts < back.pts || entry.segment <= back.segment {
+			if Duration::from(row.pts) < Duration::from(back.pts) || row.segment <= back.segment {
 				tracing::warn!("timeline jumped backwards; resetting the playlist window");
-				state.entries.clear();
+				state.rows.clear();
 			}
 		}
 
-		state.entries.push_back(entry);
+		state.rows.push_back(row);
 
-		// Evict from the front while the *listed* segments (which start at the second entry
-		// once the first is dropped) still cover the window.
-		while state.entries.len() >= 3 {
-			let span =
-				Duration::from(state.entries.back().unwrap().pts).saturating_sub(Duration::from(state.entries[1].pts));
+		// Evict from the front while the remaining rows still cover the window.
+		while state.rows.len() >= 2 {
+			let span = state.rows.back().unwrap().end.saturating_sub(state.rows[1].pts.into());
 			if span < window {
 				break;
 			}
-			state.entries.pop_front();
+			state.rows.pop_front();
 		}
 	}
 
-	/// Mark the timeline ended (the broadcast finished cleanly): the live-edge record becomes
-	/// the final segment.
+	/// Mark the timeline ended (the broadcast finished cleanly): the playlist gets
+	/// `EXT-X-ENDLIST` and cursors end once drained.
 	pub fn end(&self) {
 		if let Ok(mut state) = self.state.write() {
 			state.ended = true;
 		}
 	}
 
-	/// Close the channel: no more records will arrive. A [`Consumer`] drains the segments it
+	/// Close the channel: no more rows will arrive. A [`Consumer`] drains the segments it
 	/// can still see and then ends; the serve path keeps reading the frozen window. Call after
 	/// [`end`](Self::end) on a clean finish, or on its own when the source is lost mid-stream.
 	pub fn close(&self) {
@@ -242,56 +178,53 @@ impl Producer {
 		self.state.read().window()
 	}
 
-	/// The groups covered by segment `segment`, or `None` if it isn't in the window. An open
-	/// end means "until the track ends" (the final segment of an ended timeline).
-	pub fn segment_groups(&self, segment: u64) -> Option<(u64, Option<u64>)> {
+	/// The group ranges segment `segment` covers for this rendition, or `None` if it isn't in
+	/// the window. An empty vec means the segment is a gap for this rendition.
+	pub fn segment_ranges(&self, segment: u64) -> Option<Vec<Range>> {
 		let state = self.state.read();
-		let index = state.entries.iter().position(|e| e.segment == segment)?;
-		let entry = &state.entries[index];
-		match state.entries.get(index + 1) {
-			Some(next) => Some((entry.group, Some(next.group))),
-			None if state.ended => Some((entry.group, None)),
-			None => None,
-		}
+		let row = state.rows.iter().find(|r| r.segment == segment)?;
+		Some(row.ranges.clone())
 	}
 
-	/// The newest complete segment's starting group, used to bootstrap an init segment for
+	/// The newest group known to start with a keyframe, used to bootstrap an init segment for
 	/// inline-parameter-set codecs.
-	pub fn latest_group(&self) -> Option<u64> {
+	pub fn latest_keyframe_group(&self) -> Option<u64> {
 		let state = self.state.read();
-		if state.ended {
-			return state.entries.back().map(|e| e.group);
-		}
-		// The back entry is the live edge; the one before it starts a complete segment.
-		state.entries.iter().rev().nth(1).map(|e| e.group)
+		state
+			.rows
+			.iter()
+			.rev()
+			.flat_map(|row| row.ranges.iter().rev())
+			.find(|range| range.keyframe)
+			.map(|range| range.start)
 	}
 
-	/// Whether the playlist has anything to serve yet (at least one complete segment, or the
-	/// broadcast already ended).
+	/// Whether the playlist has anything to serve yet (at least one segment, or the broadcast
+	/// already ended).
 	#[cfg_attr(not(feature = "server"), allow(dead_code))]
 	pub fn is_playable(&self) -> bool {
 		let state = self.state.read();
-		state.ended || state.entries.len() >= 2
+		state.ended || !state.rows.is_empty()
 	}
 
 	/// Poll until [`is_playable`](Self::is_playable), for the serve path's long-poll.
 	#[cfg_attr(not(feature = "server"), allow(dead_code))]
 	pub fn poll_playable(&self, waiter: &kio::Waiter) -> Poll<()> {
 		let poll = self.state.poll_ref(waiter, |state| {
-			if state.ended || state.entries.len() >= 2 {
+			if state.ended || !state.rows.is_empty() {
 				Poll::Ready(())
 			} else {
 				Poll::Pending
 			}
 		});
 		match poll {
-			// Ready, or the channel closed (no more records will arrive): stop waiting either way.
+			// Ready, or the channel closed (no more rows will arrive): stop waiting either way.
 			Poll::Ready(_) => Poll::Ready(()),
 			Poll::Pending => Poll::Pending,
 		}
 	}
 
-	/// A cursor over finalized segments, starting from the oldest still in the window.
+	/// A cursor over segments, starting from the oldest still in the window.
 	pub fn subscribe(&self, rendition: Arc<Rendition>) -> Consumer {
 		Consumer {
 			state: self.state.consume(),
@@ -303,30 +236,28 @@ impl Producer {
 	}
 }
 
-/// A finalized segment with its transmuxed media, yielded by a [`Consumer`].
+/// A segment with its transmuxed media, yielded by a [`Consumer`].
 pub struct Segment {
 	/// The aligned segment number (also its `seg/{segment}.m4s` URI stem), shared across the
 	/// broadcast's renditions.
 	pub segment: u64,
-	/// The rendition's first group of the segment.
-	pub group: u64,
 	/// The transmuxed CMAF fragment (`moof`+`mdat`), fetched on demand by [`Consumer::next`].
 	pub media: Bytes,
 	/// Presentation duration in seconds.
 	pub duration: f64,
 	/// Wall-clock start time, when the timeline advertises an anchor.
 	pub program_date_time: Option<SystemTime>,
-	/// The media timeline is broken before this segment: one or more finalized segments were
-	/// skipped (evicted from the window before they could be fetched) since the previous one.
-	/// A recorder marks an `EXT-X-DISCONTINUITY` here.
+	/// The media timeline is broken before this segment: one or more segments were skipped
+	/// since the previous one (evicted from the window before they could be fetched, or gaps
+	/// with no content for this rendition). A recorder marks an `EXT-X-DISCONTINUITY` here.
 	pub discontinuity: bool,
 }
 
-/// A cursor over one rendition's finalized segments, in timeline order.
+/// A cursor over one rendition's segments, in timeline order.
 ///
 /// Obtained from [`Rendition::segments`](super::Rendition::segments). Drives the same
 /// fetch-on-demand path the HTTP serve path uses, so it adds no standing traffic: each
-/// [`next`](Self::next) awaits the next segment to finalize, then FETCHes and transmuxes it.
+/// [`next`](Self::next) awaits the next segment, then FETCHes and transmuxes it.
 pub struct Consumer {
 	state: kio::Consumer<State>,
 	rendition: Arc<Rendition>,
@@ -335,7 +266,7 @@ pub struct Consumer {
 	/// same segment on the next call instead of losing it.
 	after: Option<u64>,
 	/// The successor segment recorded when the last one was emitted. If the next segment
-	/// isn't it, records were evicted unseen in between (a gap).
+	/// isn't it, rows were evicted unseen in between (a gap).
 	expected: Option<u64>,
 	/// A gap opened since the last emitted segment (a skip); set on the next one's discontinuity.
 	gap: bool,
@@ -343,24 +274,25 @@ pub struct Consumer {
 
 impl Consumer {
 	/// The rendition's CMAF init segment, built once and cached; `None` until it can be built
-	/// (an inline-parameter-set codec needs the first complete segment first).
+	/// (an inline-parameter-set codec needs the first segment first).
 	pub async fn init(&self) -> Result<Option<Bytes>> {
 		self.rendition.init().await
 	}
 
-	/// The next finalized segment, with its media; `None` once the rendition ends.
+	/// The next segment, with its media; `None` once the rendition ends.
 	///
-	/// Waits for the next segment to finalize, then FETCHes and transmuxes its groups. A
-	/// segment whose groups already left the relay cache is skipped (this resumes at the next
-	/// one, flagging [`Segment::discontinuity`]) rather than surfaced as an error; a real
-	/// fetch/transmux failure is returned, leaving the cursor to retry it on the next call.
+	/// Waits for the next segment, then FETCHes and transmuxes its groups. A segment whose
+	/// groups already left the relay cache (or that is a gap for this rendition) is skipped
+	/// (this resumes at the next one, flagging [`Segment::discontinuity`]) rather than
+	/// surfaced as an error; a real fetch/transmux failure is returned, leaving the cursor to
+	/// retry it on the next call.
 	pub async fn next(&mut self) -> Result<Option<Segment>> {
 		loop {
 			let Some((row, successor)) = kio::wait(|waiter| self.poll_next(waiter)).await else {
 				return Ok(None);
 			};
 			// A gap opened if the segment we're about to emit isn't the successor the previous
-			// one recorded (records between them evicted unseen).
+			// one recorded (rows between them evicted unseen).
 			let gap = self.gap || self.expected.is_some_and(|expected| expected != row.segment);
 
 			match self.rendition.segment(row.segment).await? {
@@ -370,15 +302,15 @@ impl Consumer {
 					self.gap = false;
 					return Ok(Some(Segment {
 						segment: row.segment,
-						group: row.group,
 						media,
 						duration: row.duration,
 						program_date_time: self.rendition.wall_clock(row.pts),
 						discontinuity: gap,
 					}));
 				}
-				// Its groups aged out of the cache before we fetched them; skip to the next and
-				// carry the gap onto whichever segment we emit next.
+				// A gap for this rendition, or its groups aged out of the cache before we
+				// fetched them; skip to the next and carry the gap onto whichever segment we
+				// emit next.
 				None => {
 					self.after = Some(row.segment);
 					self.expected = successor;
@@ -403,51 +335,36 @@ impl Consumer {
 	}
 }
 
-fn row(entry: &Entry, next: Option<&Entry>) -> Row {
-	let duration = next
-		.map(|next| Duration::from(next.pts).saturating_sub(Duration::from(entry.pts)))
-		.unwrap_or(DEFAULT_SEGMENT);
-	Row {
-		segment: entry.segment,
-		group: entry.group,
-		duration: duration.as_secs_f64(),
-		pts: entry.pts,
-	}
-}
-
 #[cfg(test)]
 mod tests {
 	use super::*;
 
-	fn entry(segment: u64, group: u64, pts_ms: u64) -> Entry {
-		Entry {
+	fn row(segment: u64, group: u64, pts_ms: u64, duration_ms: u64) -> Row {
+		let pts = moq_net::Timestamp::from_millis(pts_ms).unwrap();
+		Row {
 			segment,
-			group,
-			pts: moq_net::Timestamp::from_millis(pts_ms).unwrap(),
-			ext: (),
+			ranges: vec![Range::new(group, group)],
+			duration: duration_ms as f64 / 1000.0,
+			pts,
+			end: Duration::from(pts) + Duration::from_millis(duration_ms),
 		}
 	}
 
 	#[test]
-	fn last_record_is_the_live_edge_until_ended() {
+	fn every_row_is_listed() {
 		let live = Producer::new();
-		live.push(entry(0, 0, 0), Duration::from_secs(30));
-		live.push(entry(1, 1, 2_000), Duration::from_secs(30));
-		live.push(entry(2, 2, 4_000), Duration::from_secs(30));
+		live.push(row(0, 0, 0, 2_000), Duration::from_secs(30));
+		live.push(row(1, 1, 2_000, 2_000), Duration::from_secs(30));
 
 		let window = live.window();
 		assert_eq!(window.sequence, 0);
 		assert!(!window.ended);
-		assert_eq!(window.segments.len(), 2, "the live-edge record is not listed");
+		assert_eq!(window.segments.len(), 2, "rows are complete segments; all are listed");
 		assert_eq!(window.segments[0].segment, 0);
 		assert_eq!(window.segments[0].duration, 2.0);
-		assert_eq!(window.segments[1].segment, 1);
 
 		live.end();
-		let window = live.window();
-		assert!(window.ended);
-		assert_eq!(window.segments.len(), 3, "ending lists the final record");
-		assert_eq!(window.segments[2].duration, 4.0, "final duration falls back");
+		assert!(live.window().ended);
 	}
 
 	#[test]
@@ -455,7 +372,7 @@ mod tests {
 		let live = Producer::new();
 		let window = Duration::from_secs(4);
 		for i in 0..6u64 {
-			live.push(entry(i, i, i * 2_000), window);
+			live.push(row(i, i, i * 2_000, 2_000), window);
 		}
 
 		let snapshot = live.window();
@@ -468,149 +385,77 @@ mod tests {
 	}
 
 	#[test]
-	fn segment_groups_span_to_the_next_record() {
+	fn segment_ranges_and_gaps() {
 		let live = Producer::new();
 		let window = Duration::from_secs(30);
-		// An audio-style timeline: each segment packs many groups, so records skip group numbers.
-		live.push(entry(0, 0, 0), window);
-		live.push(entry(1, 50, 1_000), window);
-		live.push(entry(2, 100, 2_000), window);
+		live.push(row(0, 0, 0, 1_000), window);
+		// Segment 1 is a gap for this rendition: no ranges.
+		live.push(
+			Row {
+				segment: 1,
+				ranges: Vec::new(),
+				duration: 1.0,
+				pts: moq_net::Timestamp::from_millis(1_000).unwrap(),
+				end: Duration::from_millis(2_000),
+			},
+			window,
+		);
+		live.push(row(2, 100, 2_000, 1_000), window);
 
-		assert_eq!(live.segment_groups(0), Some((0, Some(50))));
-		assert_eq!(live.segment_groups(1), Some((50, Some(100))));
-		// The live edge isn't a segment yet, and unknown segments miss.
-		assert_eq!(live.segment_groups(2), None);
-		assert_eq!(live.segment_groups(7), None);
+		assert_eq!(live.segment_ranges(0), Some(vec![Range::new(0, 0)]));
+		assert_eq!(live.segment_ranges(1), Some(vec![]), "a gap is present but empty");
+		assert_eq!(live.segment_ranges(7), None, "unknown segments miss");
 
-		live.end();
-		assert_eq!(live.segment_groups(2), Some((100, None)));
+		// The gap row carries no keyframe group; the bootstrap group comes from segment 2.
+		assert_eq!(live.latest_keyframe_group(), Some(100));
 	}
 
 	#[test]
 	fn backwards_jump_resets_the_window() {
 		let live = Producer::new();
 		let window = Duration::from_secs(30);
-		live.push(entry(0, 0, 10_000), window);
-		live.push(entry(1, 1, 12_000), window);
-		live.push(entry(2, 2, 1_000), window); // restart: pts rewound
+		live.push(row(0, 0, 10_000, 2_000), window);
+		live.push(row(1, 1, 12_000, 2_000), window);
+		live.push(row(2, 2, 1_000, 2_000), window); // restart: pts rewound
 
 		let snapshot = live.window();
-		assert!(snapshot.segments.is_empty(), "only the live edge remains");
+		assert_eq!(snapshot.segments.len(), 1, "the window restarted at the new row");
+		assert_eq!(snapshot.segments[0].segment, 2);
 
 		// A segment number that rewinds (a restarted publisher) resets the same way.
-		live.push(entry(0, 0, 2_000), window);
-		assert!(live.window().segments.is_empty(), "only the live edge remains");
+		live.push(row(0, 0, 2_000, 2_000), window);
+		assert_eq!(live.window().segments.len(), 1);
 	}
 
 	#[test]
-	fn non_advancing_record_is_skipped() {
+	fn next_after_walks_segments() {
 		let live = Producer::new();
 		let window = Duration::from_secs(30);
-		live.push(entry(0, 0, 0), window);
-		live.push(entry(1, 1, 2_000), window);
-		// A record whose pts equals the live edge would open a zero-duration segment; it's dropped
-		// so the prior segment just covers its groups.
-		live.push(entry(2, 2, 2_000), window);
-		live.push(entry(3, 3, 4_000), window);
+		live.push(row(0, 0, 0, 2_000), window);
+		live.push(row(1, 1, 2_000, 2_000), window);
 
-		live.end();
-		let window = live.window();
-		let durations: Vec<f64> = window.segments.iter().map(|s| s.duration).collect();
-		assert!(!durations.contains(&0.0), "no zero-duration segment: {durations:?}");
-		// Segment 2 was absorbed into segment 1 (still bounded by segment 3's record).
-		assert_eq!(live.segment_groups(1), Some((1, Some(3))));
-		assert_eq!(live.segment_groups(2), None, "the skipped record is not a boundary");
-	}
-
-	// `end()` is what promotes the live-edge record into the final segment, and it is a no-op
-	// once the channel is closed. So anything retiring a rendition must NOT force-close a
-	// timeline that is about to end on its own, or that last segment is silently lost -- which
-	// is why `renditions::Producer::clear` drops its renditions rather than closing them.
-	#[test]
-	fn closing_before_end_loses_the_final_segment() {
-		let window = Duration::from_secs(30);
-
-		// The watcher's own order: end() then close() -- the live edge finalizes.
-		let clean = Producer::new();
-		clean.push(entry(0, 0, 0), window);
-		clean.push(entry(1, 1, 2_000), window);
-		clean.end();
-		clean.close();
-		assert!(
-			matches!(clean.state.read().next_after(Some(0)), Next::Ready { .. }),
-			"end() before close() finalizes the live edge"
-		);
-
-		// Reversed: a close() that races ahead of end() strands it forever.
-		let raced = Producer::new();
-		raced.push(entry(0, 0, 0), window);
-		raced.push(entry(1, 1, 2_000), window);
-		raced.close();
-		raced.end();
-		assert!(
-			matches!(raced.state.read().next_after(Some(0)), Next::Pending),
-			"end() is a no-op after close(), so the final segment never finalizes"
-		);
-	}
-
-	// The cursor and the serve path must time the final (open-ended) segment identically:
-	// estimated from the observed cadence, not a flat DEFAULT_SEGMENT.
-	#[test]
-	fn final_segment_duration_matches_the_serve_path() {
-		let live = Producer::new();
-		let window = Duration::from_secs(30);
-		// A 6s cadence, so the flat 4s DEFAULT_SEGMENT would be wrong for the last segment.
-		live.push(entry(0, 0, 0), window);
-		live.push(entry(1, 1, 6_000), window);
-		live.push(entry(2, 2, 12_000), window);
-		live.end();
-
-		let served = live.window();
-		let last_served = served.segments.last().expect("a final segment");
-		assert_eq!(last_served.segment, 2);
-		assert_eq!(last_served.duration, 6.0, "serve path estimates from the cadence");
-
-		let last_recorded = match live.state.read().next_after(Some(1)) {
-			Next::Ready { row, .. } => row,
-			_ => panic!("ending finalizes the live edge"),
-		};
-		assert_eq!(last_recorded.segment, 2);
-		assert_eq!(
-			last_recorded.duration, last_served.duration,
-			"the cursor times the final segment like the serve path"
-		);
-	}
-
-	#[test]
-	fn next_after_walks_finalized_segments() {
-		let live = Producer::new();
-		let window = Duration::from_secs(30);
-		live.push(entry(0, 0, 0), window);
-		live.push(entry(1, 1, 2_000), window);
-		live.push(entry(2, 2, 4_000), window);
-
-		// Segments 0 and 1 are finalized; segment 2 is the live edge.
 		let first = match live.state.read().next_after(None) {
-			Next::Ready { row, .. } => row,
-			_ => panic!("expected a finalized segment"),
+			Next::Ready { row, successor } => {
+				assert_eq!(successor, Some(1));
+				row
+			}
+			_ => panic!("expected a segment"),
 		};
 		assert_eq!(first.segment, 0);
 		let second = match live.state.read().next_after(Some(0)) {
-			Next::Ready { row, .. } => row,
-			_ => panic!("expected a finalized segment"),
+			Next::Ready { row, successor } => {
+				assert_eq!(successor, None);
+				row
+			}
+			_ => panic!("expected a segment"),
 		};
 		assert_eq!(second.segment, 1);
 		assert!(
 			matches!(live.state.read().next_after(Some(1)), Next::Pending),
-			"the live edge is not finalized while live"
+			"nothing further while live"
 		);
 
 		live.end();
-		let last = match live.state.read().next_after(Some(1)) {
-			Next::Ready { row, .. } => row,
-			_ => panic!("ending finalizes the live edge"),
-		};
-		assert_eq!(last.segment, 2);
-		assert!(matches!(live.state.read().next_after(Some(2)), Next::Ended));
+		assert!(matches!(live.state.read().next_after(Some(1)), Next::Ended));
 	}
 }

--- a/rs/moq-hls/src/export/segments.rs
+++ b/rs/moq-hls/src/export/segments.rs
@@ -3,7 +3,7 @@
 //! The broadcast has a single timeline track; the catalog watcher reads it and fans each
 //! record out to every rendition as a row: the segment's number, timing, and this
 //! rendition's group ranges (empty when the record carries no content for it, a gap). Records
-//! are self-contained (the segmenter only publishes a segment once its content is final on
+//! are self-contained (the timeline only publishes a segment once its content is final on
 //! every track), so every row is immediately listable and fetchable. Two things read the
 //! window:
 //!

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -40,6 +40,12 @@ const ERROR_BACKOFF: Duration = Duration::from_secs(1);
 /// instead: enough to prime a player's buffer, without the lag.
 const ANCHOR_SEGMENTS: usize = 3;
 
+/// How many consecutive failed steps retire a rendition (see [`TrackState::evict`]).
+///
+/// Enough to ride out a transient fetch error or a stale playlist, short enough that a
+/// genuinely dead variant stops holding the broadcast's timeline back within a few seconds.
+const MAX_RENDITION_FAILURES: usize = 3;
+
 /// Configuration for the HLS import loop.
 #[derive(Clone)]
 #[non_exhaustive]
@@ -343,6 +349,9 @@ struct TrackState {
 	/// The `EXT-X-MAP` resource the current `importer` was initialized from.
 	map: Option<Resource>,
 	media_range: RangeCursor,
+	/// Consecutive failed ingest attempts, reset by any successful one. See
+	/// [`MAX_RENDITION_FAILURES`].
+	failures: usize,
 }
 
 impl TrackState {
@@ -359,7 +368,21 @@ impl TrackState {
 			next_discontinuity: None,
 			map: None,
 			media_range: RangeCursor::default(),
+			failures: 0,
 		}
+	}
+
+	/// Give up on this rendition's current importer generation after repeated failures.
+	///
+	/// An enrolled track gates *every* segment record until it reports past the boundary, so a
+	/// rendition that stopped making progress freezes the whole broadcast's timeline rather
+	/// than just its own playlist. Dropping the importer closes its recorders (and retires its
+	/// catalog entries), letting the healthy renditions publish again; a later successful step
+	/// rebuilds it from the init segment.
+	fn evict(&mut self) {
+		self.importer = None;
+		self.map = None;
+		self.reanchor();
 	}
 
 	/// Fetch this track's current media playlist and consume any fresh segments,
@@ -677,17 +700,35 @@ impl Import {
 	async fn step(&mut self, on_error: OnError) -> Result<StepOutcome> {
 		self.ensure_tracks().await?;
 
+		// Hold the timeline back for the whole pass. Renditions are ingested one at a time, and
+		// a record is immutable once published against the tracks enrolled at that moment, so a
+		// record flushed mid-pass would omit every rendition that hasn't loaded its init
+		// segment yet (permanent EXT-X-GAP) and fold that rendition's first groups into
+		// whichever segment flushes next.
+		let _hold = self.sink.catalog.segmenter().hold();
+
 		let mut wrote_segments = 0;
 		let mut target_duration = None;
 
 		for track in self.video.iter_mut().chain(self.audio.iter_mut()) {
 			match track.ingest(&self.fetcher, &mut target_duration).await {
-				Ok(count) => wrote_segments += count,
+				Ok(count) => {
+					track.failures = 0;
+					wrote_segments += count;
+				}
 				Err(err) => match on_error {
 					OnError::Fail => return Err(err),
 					// Keep the other renditions going: one bad variant or segment shouldn't
 					// drop the rest or abort the whole step.
-					OnError::Warn => warn!(label = %track.label, %err, "rendition import step failed, will retry"),
+					OnError::Warn => {
+						track.failures += 1;
+						if track.failures >= MAX_RENDITION_FAILURES && track.importer.is_some() {
+							warn!(label = %track.label, %err, failures = track.failures, "rendition import keeps failing, dropping it until it recovers");
+							track.evict();
+						} else {
+							warn!(label = %track.label, %err, "rendition import step failed, will retry");
+						}
+					}
 				},
 			}
 		}
@@ -1328,6 +1369,47 @@ mod tests {
 		assert_eq!(snapshot.video.renditions.len(), 1);
 		assert_eq!(snapshot.audio.renditions.len(), 1);
 		assert_eq!(import.video[0].next_sequence, Some(2));
+	}
+
+	/// An enrolled track gates every timeline record until it reports past the boundary, so a
+	/// rendition that has stopped making progress would otherwise freeze the whole broadcast's
+	/// timeline (and every healthy rendition's playlist with it). After a few consecutive
+	/// failures its importer is dropped, which closes its recorders.
+	#[tokio::test]
+	async fn a_persistently_failing_rendition_is_evicted() {
+		let (init, fragments) = fmp4_parts(2);
+		let mut resource = init.clone();
+		resource.extend_from_slice(&fragments[0]);
+		resource.extend_from_slice(&fragments[1]);
+		let playlist = format!(
+			"#EXTM3U\n#EXT-X-VERSION:7\n#EXT-X-TARGETDURATION:2\n#EXT-X-MAP:URI=\"media.mp4\",BYTERANGE=\"{}@0\"\n#EXTINF:1,\n#EXT-X-BYTERANGE:{}@{}\nmedia.mp4\n#EXTINF:1,\n#EXT-X-BYTERANGE:{}\nmedia.mp4\n",
+			init.len(),
+			fragments[0].len(),
+			init.len(),
+			fragments[1].len()
+		);
+		let dir = temp_dir();
+		let (mut import, _catalog) = write_import(&dir, &resource, &playlist);
+
+		import.init().await.unwrap();
+		assert!(import.video[0].importer.is_some(), "the rendition imported once");
+
+		// The source goes away underneath us.
+		std::fs::remove_file(dir.join("media.m3u8")).unwrap();
+
+		for _ in 0..MAX_RENDITION_FAILURES - 1 {
+			import.step(OnError::Warn).await.unwrap();
+			assert!(
+				import.video[0].importer.is_some(),
+				"a transient failure keeps the rendition"
+			);
+		}
+
+		import.step(OnError::Warn).await.unwrap();
+		assert!(
+			import.video[0].importer.is_none(),
+			"the dead rendition stops gating the broadcast's timeline"
+		);
 	}
 
 	/// A live window longer than `ANCHOR_SEGMENTS` is joined mid-playlist, which means the

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -333,6 +333,9 @@ struct TrackState {
 	/// Whether this rendition declares the broadcast's segment boundaries (the source
 	/// playlist's segmentation): one cut per pushed segment. Exactly one track cuts.
 	cuts: bool,
+	/// The cutting track already declared the source's target duration as the broadcast's
+	/// segment-duration bound.
+	declared: bool,
 	/// The importer for the current init segment generation, minted by [`Self::ensure_map`].
 	importer: Option<Fmp4>,
 	next_sequence: Option<u64>,
@@ -350,6 +353,7 @@ impl TrackState {
 			select,
 			sink,
 			cuts,
+			declared: false,
 			importer: None,
 			next_sequence: None,
 			next_discontinuity: None,
@@ -365,6 +369,22 @@ impl TrackState {
 		if target_duration.is_none() {
 			*target_duration = Some(playlist.target_duration);
 		}
+
+		// The cutting track reproduces the source's segmentation, so the source's target
+		// duration is the broadcast's declared bound; declare it before consuming segments,
+		// since the first init segment advertises the timeline and freezes it.
+		if self.cuts && !self.declared {
+			self.declared = true;
+			match moq_net::Timestamp::new(playlist.target_duration.max(1), moq_net::Timescale::SECOND) {
+				Ok(bound) => {
+					if let Err(err) = self.sink.catalog.segmenter().set_duration_max(bound) {
+						warn!(label = %self.label, %err, "failed to declare the source target duration");
+					}
+				}
+				Err(err) => warn!(label = %self.label, %err, "unrepresentable source target duration"),
+			}
+		}
+
 		self.consume_segments(fetcher, &playlist).await
 	}
 

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -312,16 +312,11 @@ struct Sink {
 impl Sink {
 	/// Mint an fMP4 importer that publishes only the roles in `select`.
 	///
-	/// `cuts` states whether this rendition declares the broadcast's segment boundaries:
-	/// boundaries are broadcast-wide, so exactly one rendition (the primary variant) cuts and
-	/// the rest only report their groups.
-	fn importer(&self, select: &select::Broadcast, cuts: bool) -> Fmp4 {
+	fn importer(&self, select: &select::Broadcast) -> Fmp4 {
 		// `reserve()` (not `clone()`) so the catalog isn't published until every
 		// importer's tracks resolve, keeping one-shot muxers from seeing a partial
 		// catalog (moq-mux reservation gate).
-		Fmp4::new(self.broadcast.clone(), self.catalog.reserve())
-			.with_select(select.clone())
-			.with_cut_on_boundary(cuts)
+		Fmp4::new(self.broadcast.clone(), self.catalog.reserve()).with_select(select.clone())
 	}
 }
 
@@ -336,12 +331,6 @@ struct TrackState {
 	/// separate audio rendition publishes video only).
 	select: select::Broadcast,
 	sink: Sink,
-	/// Whether this rendition declares the broadcast's segment boundaries (the source
-	/// playlist's segmentation): one cut per pushed segment. Exactly one track cuts.
-	cuts: bool,
-	/// The cutting track already declared the source's target duration as the broadcast's
-	/// segment-duration bound.
-	declared: bool,
 	/// The importer for the current init segment generation, minted by [`Self::ensure_map`].
 	importer: Option<Fmp4>,
 	next_sequence: Option<u64>,
@@ -355,14 +344,12 @@ struct TrackState {
 }
 
 impl TrackState {
-	fn new(label: String, playlist: Url, select: select::Broadcast, sink: Sink, cuts: bool) -> Self {
+	fn new(label: String, playlist: Url, select: select::Broadcast, sink: Sink) -> Self {
 		Self {
 			label,
 			playlist,
 			select,
 			sink,
-			cuts,
-			declared: false,
 			importer: None,
 			next_sequence: None,
 			next_discontinuity: None,
@@ -391,21 +378,6 @@ impl TrackState {
 		let playlist = fetcher.media_playlist(self.playlist.clone()).await?;
 		if target_duration.is_none() {
 			*target_duration = Some(playlist.target_duration);
-		}
-
-		// The cutting track reproduces the source's segmentation, so the source's target
-		// duration is the broadcast's declared bound; declare it before consuming segments,
-		// since the first init segment advertises the timeline and freezes it.
-		if self.cuts && !self.declared {
-			self.declared = true;
-			match moq_net::Timestamp::new(playlist.target_duration.max(1), moq_net::Timescale::SECOND) {
-				Ok(bound) => {
-					if let Err(err) = self.sink.catalog.segmenter().set_duration_max(bound) {
-						warn!(label = %self.label, %err, "failed to declare the source target duration");
-					}
-				}
-				Err(err) => warn!(label = %self.label, %err, "unrepresentable source target duration"),
-			}
 		}
 
 		self.consume_segments(fetcher, &playlist).await
@@ -536,7 +508,7 @@ impl TrackState {
 		}
 
 		let bytes = fetcher.fetch(&resource).await?;
-		let mut importer = self.sink.importer(&self.select, self.cuts);
+		let mut importer = self.sink.importer(&self.select);
 
 		// The importer buffers internally, so a fully-parsed init segment leaves it
 		// initialized; any trailing partial atom just waits for the next segment. A
@@ -584,11 +556,10 @@ impl TrackState {
 		if reanchored {
 			importer.seek(group_sequence)?;
 		}
-		// Every playlist entry is a source segment boundary; declare it even when the media
-		// carries no styp (the importer dedupes, so a styp-bearing segment cuts only once).
-		if self.cuts {
-			importer.cut();
-		}
+		// Every playlist entry is a source segment boundary, so declare it even when the media
+		// carries no styp. Every rendition declares the same ones; the timeline drops a cut
+		// that would land inside its minimum segment duration, so the duplicates cost nothing.
+		importer.cut();
 		importer.decode(&bytes)?;
 
 		self.media_range = range;
@@ -705,7 +676,7 @@ impl Import {
 		// record flushed mid-pass would omit every rendition that hasn't loaded its init
 		// segment yet (permanent EXT-X-GAP) and fold that rendition's first groups into
 		// whichever segment flushes next.
-		let _hold = self.sink.catalog.segmenter().hold();
+		let _hold = self.sink.catalog.timeline().hold();
 
 		let mut wrote_segments = 0;
 		let mut target_duration = None;
@@ -739,8 +710,8 @@ impl Import {
 		})
 	}
 
-	fn track(&self, label: impl Into<String>, playlist: Url, select: select::Broadcast, cuts: bool) -> TrackState {
-		TrackState::new(label.into(), playlist, select, self.sink.clone(), cuts)
+	fn track(&self, label: impl Into<String>, playlist: Url, select: select::Broadcast) -> TrackState {
+		TrackState::new(label.into(), playlist, select, self.sink.clone())
 	}
 
 	async fn ensure_tracks(&mut self) -> Result<()> {
@@ -752,7 +723,7 @@ impl Import {
 		let body = self.fetcher.fetch_url(self.base_url.clone()).await?;
 		if !m3u8_rs::is_master_playlist(&body) {
 			// Fallback: treat the provided URL as a single (muxed) media playlist.
-			let track = self.track("video[0]", self.base_url.clone(), select_muxed(), true);
+			let track = self.track("video[0]", self.base_url.clone(), select_muxed());
 			self.video.push(track);
 			return Ok(());
 		}
@@ -770,7 +741,7 @@ impl Import {
 				if let Some(uri) = &audio_tag.uri {
 					let audio_url = resolve_uri(&self.base_url, uri)?;
 					// Boundaries follow the video variant; audio only reports its groups.
-					self.audio = Some(self.track("audio", audio_url, select_audio_only(), false));
+					self.audio = Some(self.track("audio", audio_url, select_audio_only()));
 				} else {
 					warn!(%group_id, "audio rendition missing URI");
 				}
@@ -788,9 +759,7 @@ impl Import {
 		};
 		for (index, variant) in variants.iter().enumerate() {
 			let video_url = resolve_uri(&self.base_url, &variant.uri)?;
-			// The first (primary) variant declares the broadcast's segment boundaries;
-			// sibling renditions are aligned to it by the segmenter.
-			let track = self.track(format!("video[{index}]"), video_url, variant_select.clone(), index == 0);
+			let track = self.track(format!("video[{index}]"), video_url, variant_select.clone());
 			self.video.push(track);
 		}
 
@@ -1089,7 +1058,6 @@ mod tests {
 			Url::parse("https://example.com/media.m3u8").unwrap(),
 			select_muxed(),
 			sink(),
-			true,
 		)
 	}
 

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -305,11 +305,17 @@ struct Sink {
 
 impl Sink {
 	/// Mint an fMP4 importer that publishes only the roles in `select`.
-	fn importer(&self, select: &select::Broadcast) -> Fmp4 {
+	///
+	/// `cuts` states whether this rendition declares the broadcast's segment boundaries:
+	/// boundaries are broadcast-wide, so exactly one rendition (the primary variant) cuts and
+	/// the rest only report their groups.
+	fn importer(&self, select: &select::Broadcast, cuts: bool) -> Fmp4 {
 		// `reserve()` (not `clone()`) so the catalog isn't published until every
 		// importer's tracks resolve, keeping one-shot muxers from seeing a partial
 		// catalog (moq-mux reservation gate).
-		Fmp4::new(self.broadcast.clone(), self.catalog.reserve()).with_select(select.clone())
+		Fmp4::new(self.broadcast.clone(), self.catalog.reserve())
+			.with_select(select.clone())
+			.with_cut_on_boundary(cuts)
 	}
 }
 
@@ -324,6 +330,9 @@ struct TrackState {
 	/// separate audio rendition publishes video only).
 	select: select::Broadcast,
 	sink: Sink,
+	/// Whether this rendition declares the broadcast's segment boundaries (the source
+	/// playlist's segmentation): one cut per pushed segment. Exactly one track cuts.
+	cuts: bool,
 	/// The importer for the current init segment generation, minted by [`Self::ensure_map`].
 	importer: Option<Fmp4>,
 	next_sequence: Option<u64>,
@@ -334,12 +343,13 @@ struct TrackState {
 }
 
 impl TrackState {
-	fn new(label: String, playlist: Url, select: select::Broadcast, sink: Sink) -> Self {
+	fn new(label: String, playlist: Url, select: select::Broadcast, sink: Sink, cuts: bool) -> Self {
 		Self {
 			label,
 			playlist,
 			select,
 			sink,
+			cuts,
 			importer: None,
 			next_sequence: None,
 			next_discontinuity: None,
@@ -483,7 +493,7 @@ impl TrackState {
 		}
 
 		let bytes = fetcher.fetch(&resource).await?;
-		let mut importer = self.sink.importer(&self.select);
+		let mut importer = self.sink.importer(&self.select, self.cuts);
 
 		// The importer buffers internally, so a fully-parsed init segment leaves it
 		// initialized; any trailing partial atom just waits for the next segment. A
@@ -530,6 +540,11 @@ impl TrackState {
 		let importer = self.importer.as_mut().ok_or(Error::MissingMap)?;
 		if reanchored {
 			importer.seek(group_sequence)?;
+		}
+		// Every playlist entry is a source segment boundary; declare it even when the media
+		// carries no styp (the importer dedupes, so a styp-bearing segment cuts only once).
+		if self.cuts {
+			importer.cut();
 		}
 		importer.decode(&bytes)?;
 
@@ -663,8 +678,8 @@ impl Import {
 		})
 	}
 
-	fn track(&self, label: impl Into<String>, playlist: Url, select: select::Broadcast) -> TrackState {
-		TrackState::new(label.into(), playlist, select, self.sink.clone())
+	fn track(&self, label: impl Into<String>, playlist: Url, select: select::Broadcast, cuts: bool) -> TrackState {
+		TrackState::new(label.into(), playlist, select, self.sink.clone(), cuts)
 	}
 
 	async fn ensure_tracks(&mut self) -> Result<()> {
@@ -676,7 +691,7 @@ impl Import {
 		let body = self.fetcher.fetch_url(self.base_url.clone()).await?;
 		if !m3u8_rs::is_master_playlist(&body) {
 			// Fallback: treat the provided URL as a single (muxed) media playlist.
-			let track = self.track("video[0]", self.base_url.clone(), select_muxed());
+			let track = self.track("video[0]", self.base_url.clone(), select_muxed(), true);
 			self.video.push(track);
 			return Ok(());
 		}
@@ -693,7 +708,8 @@ impl Import {
 			if let Some(audio_tag) = select_audio(&master, group_id) {
 				if let Some(uri) = &audio_tag.uri {
 					let audio_url = resolve_uri(&self.base_url, uri)?;
-					self.audio = Some(self.track("audio", audio_url, select_audio_only()));
+					// Boundaries follow the video variant; audio only reports its groups.
+					self.audio = Some(self.track("audio", audio_url, select_audio_only(), false));
 				} else {
 					warn!(%group_id, "audio rendition missing URI");
 				}
@@ -711,7 +727,9 @@ impl Import {
 		};
 		for (index, variant) in variants.iter().enumerate() {
 			let video_url = resolve_uri(&self.base_url, &variant.uri)?;
-			let track = self.track(format!("video[{index}]"), video_url, variant_select.clone());
+			// The first (primary) variant declares the broadcast's segment boundaries;
+			// sibling renditions are aligned to it by the segmenter.
+			let track = self.track(format!("video[{index}]"), video_url, variant_select.clone(), index == 0);
 			self.video.push(track);
 		}
 
@@ -1010,6 +1028,7 @@ mod tests {
 			Url::parse("https://example.com/media.m3u8").unwrap(),
 			select_muxed(),
 			sink(),
+			true,
 		)
 	}
 

--- a/rs/moq-hls/src/import.rs
+++ b/rs/moq-hls/src/import.rs
@@ -671,12 +671,12 @@ impl Import {
 	async fn step(&mut self, on_error: OnError) -> Result<StepOutcome> {
 		self.ensure_tracks().await?;
 
-		// Hold the timeline back for the whole pass. Renditions are ingested one at a time, and
-		// a record is immutable once published against the tracks enrolled at that moment, so a
-		// record flushed mid-pass would omit every rendition that hasn't loaded its init
-		// segment yet (permanent EXT-X-GAP) and fold that rendition's first groups into
-		// whichever segment flushes next.
-		let _hold = self.sink.catalog.timeline().hold();
+		// Reserve the timeline for the whole pass, the way each importer reserves the catalog.
+		// Renditions are ingested one at a time, and a record is immutable once published
+		// against the tracks enrolled at that moment, so a record flushed mid-pass would omit
+		// every rendition that hasn't loaded its init segment yet (a permanent EXT-X-GAP) and
+		// fold that rendition's first groups into whichever segment flushes next.
+		let _reserved = self.sink.catalog.timeline().reserve();
 
 		let mut wrote_segments = 0;
 		let mut target_duration = None;

--- a/rs/moq-hls/src/lib.rs
+++ b/rs/moq-hls/src/lib.rs
@@ -7,7 +7,7 @@
 //!   segments into MoQ (an HTTP *client* that *publishes*).
 //! - [`server`] serves HLS playlists and CMAF segments over HTTP for MoQ
 //!   broadcasts (an HTTP *server*). It subscribes only to each broadcast's
-//!   catalog and per-rendition timeline tracks; media bytes are FETCHed from
+//!   catalog and timeline tracks; media bytes are FETCHed from
 //!   the relay one group at a time, only when a segment is actually requested.
 //!   It serves every request; gate access by layering your own middleware onto
 //!   [`Server::router`](server::Server::router).

--- a/rs/moq-hls/src/server/mod.rs
+++ b/rs/moq-hls/src/server/mod.rs
@@ -6,7 +6,7 @@
 //! GET /{broadcast}/master.m3u8
 //! GET /{broadcast}/{kind}/{rendition}/media.m3u8
 //! GET /{broadcast}/{kind}/{rendition}/init.mp4
-//! GET /{broadcast}/{kind}/{rendition}/seg/{group}.m4s
+//! GET /{broadcast}/{kind}/{rendition}/seg/{segment}.m4s
 //! ```
 //!
 //! `{kind}` is `video` or `audio`, so a video and an audio rendition that share a

--- a/rs/moq-json/src/stream.rs
+++ b/rs/moq-json/src/stream.rs
@@ -10,7 +10,7 @@
 //! compresses against all the earlier ones. There is deliberately no group rolling (and so no
 //! catch-up machinery): the only reason to roll would be moq-net's per-group frame cap, which
 //! isn't worth working around here. A caller that wants to bound the record rate throttles at
-//! the source (e.g. the timeline's granularity); a consumer that finds a gap can fetch or
+//! the source (e.g. the timeline's segment cadence); a consumer that finds a gap can fetch or
 //! extrapolate.
 //!
 //! That single group is what bounds the log's history. moq-net caps a group's cached bytes, and a

--- a/rs/moq-mux/src/catalog/consumer.rs
+++ b/rs/moq-mux/src/catalog/consumer.rs
@@ -67,6 +67,7 @@ impl<E: CatalogExt> Stream for Consumer<E> {
 				Poll::Ready(Ok(media.map(|m| Catalog::<E> {
 					video: m.video,
 					audio: m.audio,
+					timeline: m.timeline,
 					ext: E::default(),
 				})))
 			}

--- a/rs/moq-mux/src/catalog/estimate.rs
+++ b/rs/moq-mux/src/catalog/estimate.rs
@@ -40,16 +40,16 @@ impl Estimate {
 ///
 /// ```no_run
 /// # fn example<E: moq_mux::catalog::hang::CatalogExt>(
-/// #     catalog: moq_mux::catalog::Producer<E>,
+/// #     mut catalog: moq_mux::catalog::Producer<E>,
 /// #     reserved: moq_mux::catalog::Reserved<E>,
 /// #     net: moq_net::track::Producer,
 /// #     config: hang::catalog::VideoConfig,
 /// #     frame: moq_mux::container::Frame,
 /// # ) -> moq_mux::Result<()> {
 /// use moq_mux::catalog::hang::Container;
-/// use moq_mux::timeline::Cadence;
+/// use moq_mux::timeline::Kind;
 ///
-/// let mut track = catalog.media_producer(net, Container::Legacy, Cadence::Boundary)?;
+/// let mut track = catalog.media_producer(net, Container::Legacy, Kind::Video)?;
 /// let mut rendition = reserved.video(track.name());
 /// rendition.set(config);
 ///

--- a/rs/moq-mux/src/catalog/estimate.rs
+++ b/rs/moq-mux/src/catalog/estimate.rs
@@ -47,8 +47,9 @@ impl Estimate {
 /// #     frame: moq_mux::container::Frame,
 /// # ) -> moq_mux::Result<()> {
 /// use moq_mux::catalog::hang::Container;
+/// use moq_mux::timeline::Cadence;
 ///
-/// let mut track = catalog.media_producer(net, Container::Legacy)?;
+/// let mut track = catalog.media_producer(net, Container::Legacy, Cadence::Boundary)?;
 /// let mut rendition = reserved.video(track.name());
 /// rendition.set(config);
 ///

--- a/rs/moq-mux/src/catalog/estimate.rs
+++ b/rs/moq-mux/src/catalog/estimate.rs
@@ -47,9 +47,7 @@ impl Estimate {
 /// #     frame: moq_mux::container::Frame,
 /// # ) -> moq_mux::Result<()> {
 /// use moq_mux::catalog::hang::Container;
-/// use moq_mux::timeline::Kind;
-///
-/// let mut track = catalog.media_producer(net, Container::Legacy, Kind::Video)?;
+/// let mut track = catalog.media_producer(net, Container::Legacy)?;
 /// let mut rendition = reserved.video(track.name());
 /// rendition.set(config);
 ///

--- a/rs/moq-mux/src/catalog/hang/ext.rs
+++ b/rs/moq-mux/src/catalog/hang/ext.rs
@@ -101,6 +101,10 @@ pub struct Catalog<E: CatalogExt = ()> {
 	#[serde(default)]
 	pub audio: hang::catalog::Audio,
 
+	/// The broadcast's timeline track (its aligned segment index), if the publisher offers one.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub timeline: Option<hang::catalog::Timeline>,
+
 	#[serde(flatten)]
 	pub ext: E,
 }
@@ -111,6 +115,7 @@ impl<E: CatalogExt> Catalog<E> {
 		let mut catalog = hang::Catalog::default();
 		catalog.video = self.video.clone();
 		catalog.audio = self.audio.clone();
+		catalog.timeline = self.timeline.clone();
 		catalog
 	}
 }

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -53,17 +53,10 @@ pub struct Producer<E: CatalogExt = ()> {
 	/// a caller has none land on one timeline and audio/video stay in sync.
 	clock: crate::Clock,
 
-	/// A clone of the broadcast, retained so the timeline track can be created lazily when
-	/// the first media track enrolls (the codec importers hold only their media track, not
-	/// the broadcast).
-	broadcast: moq_net::broadcast::Producer,
-
-	/// The broadcast's one timeline track, created lazily by [`timeline`](Self::timeline).
-	timeline: Arc<Mutex<Option<crate::timeline::Producer>>>,
-
-	/// The broadcast's segmenter: the shared boundary list every enrolled track's groups map
-	/// onto. See [`segmenter`](Self::segmenter).
-	segmenter: crate::timeline::Segmenter,
+	/// The broadcast's timeline: the shared boundary list every enrolled track's groups map
+	/// onto, and the track those segment records are published on. See
+	/// [`timeline`](Self::timeline).
+	timeline: crate::timeline::Producer,
 }
 
 // Manual Clone so a producer is cheaply clonable regardless of whether `E` is.
@@ -76,9 +69,7 @@ impl<E: CatalogExt> Clone for Producer<E> {
 			current: self.current.clone(),
 			reservations: self.reservations.clone(),
 			clock: self.clock,
-			broadcast: self.broadcast.clone(),
 			timeline: self.timeline.clone(),
-			segmenter: self.segmenter.clone(),
 		}
 	}
 }
@@ -122,9 +113,7 @@ impl<E: CatalogExt> Producer<E> {
 			current: Arc::new(Mutex::new(catalog)),
 			reservations: Arc::new(Mutex::new(Reservations::default())),
 			clock: crate::Clock::new(),
-			broadcast: broadcast.clone(),
-			timeline: Arc::new(Mutex::new(None)),
-			segmenter: crate::timeline::Segmenter::default(),
+			timeline: crate::timeline::Producer::new(broadcast, crate::timeline::Config::default()),
 		})
 	}
 
@@ -158,6 +147,16 @@ impl<E: CatalogExt> Producer<E> {
 	/// Get a snapshot of the current catalog.
 	pub fn snapshot(&self) -> Catalog<E> {
 		self.current.lock().unwrap().clone()
+	}
+
+	/// Pace the broadcast's timeline with `config` instead of the default.
+	///
+	/// Call it before any track enrolls (the timeline's own track doesn't exist until then, so
+	/// this replaces it wholesale); afterwards the pacing is fixed for the broadcast, since the
+	/// catalog has advertised what it promises.
+	pub fn with_timeline(mut self, broadcast: &moq_net::broadcast::Producer, config: crate::timeline::Config) -> Self {
+		self.timeline = crate::timeline::Producer::new(broadcast, config);
+		self
 	}
 
 	/// Begin reserving the initial track set, returning a clonable [`Reserved`](super::Reserved).
@@ -212,64 +211,57 @@ impl<E: CatalogExt> Producer<E> {
 	/// enrolling it in the broadcast's timeline so its groups are indexed into the aligned
 	/// segments.
 	///
-	/// `kind` states what the track carries: the segmenter prefers a video track as its
-	/// auto-cut driver, since segment boundaries must land on video keyframes. The broadcast's
-	/// one timeline track is created (and advertised in the catalog's root `timeline` section)
-	/// on first use; see [`timeline`](crate::timeline) for the whole model.
+	/// The broadcast's one timeline track is created (and advertised in the catalog's root
+	/// `timeline` section) on first use; see [`timeline`](crate::timeline) for the whole model.
 	pub fn media_producer<C: crate::container::Container>(
 		&mut self,
 		track: moq_net::track::Producer,
 		container: C,
-		kind: crate::timeline::Kind,
 	) -> crate::Result<crate::container::Producer<C>> {
-		self.timeline()?;
-		let recorder = self.segmenter.track(track.name(), kind);
+		let recorder = self.enroll(track.name())?;
 		Ok(crate::container::Producer::new(track, container).with_recorder(recorder))
 	}
 
-	/// The broadcast's [`timeline::Producer`](crate::timeline::Producer), creating its track
-	/// ([`hang::timeline::DEFAULT_NAME`]) and advertising it in the catalog's root `timeline`
-	/// section on first use.
+	/// Enroll `track` in the broadcast's timeline, advertising the timeline in the catalog's
+	/// root section the first time.
 	///
-	/// [`media_producer`](Self::media_producer) calls this for you; call it directly to
-	/// [`set_wall`](crate::timeline::Producer::set_wall) or when wiring recorders by hand via
-	/// [`segmenter`](Self::segmenter).
-	///
-	/// Errors on first use if the broadcast can't create the timeline track, for example
-	/// because something else already took the name.
-	pub fn timeline(&mut self) -> crate::Result<crate::timeline::Producer> {
-		{
-			let timeline = self.timeline.lock().unwrap();
-			if let Some(timeline) = timeline.as_ref() {
-				return Ok(timeline.clone());
-			}
+	/// [`media_producer`](Self::media_producer) calls this for you; call it directly for a track
+	/// that isn't built through a [`container::Producer`](crate::container::Producer) (an fMP4
+	/// passthrough writing groups by hand).
+	pub fn enroll(&mut self, track: &str) -> crate::Result<crate::timeline::Recorder> {
+		let recorder = self.timeline.track(track)?;
+
+		let section = self.timeline.section();
+		let mut catalog = self.lock();
+		if catalog.timeline.is_none() {
+			catalog.timeline = Some(section);
 		}
 
-		let timeline = crate::timeline::Producer::new(&mut self.broadcast.clone(), &self.segmenter)?;
-		*self.timeline.lock().unwrap() = Some(timeline.clone());
-		self.lock().timeline = Some(timeline.section());
-		Ok(timeline)
+		Ok(recorder)
 	}
 
-	/// The broadcast's [`Segmenter`](crate::timeline::Segmenter): where the application cuts
-	/// segment boundaries ([`cut`](crate::timeline::Segmenter::cut)) or declares the
-	/// segment-duration bound ([`set_duration_max`](crate::timeline::Segmenter::set_duration_max),
-	/// before the first media track enrolls), and where tracks not built through
-	/// [`media_producer`](Self::media_producer) enroll.
-	pub fn segmenter(&self) -> crate::timeline::Segmenter {
-		self.segmenter.clone()
+	/// The broadcast's [`timeline::Producer`](crate::timeline::Producer): its segment index.
+	///
+	/// The MoQ track behind it is created (and advertised in the catalog's root `timeline`
+	/// section) when the first media track enrolls, so reading this costs nothing on a
+	/// broadcast that never segments. Use it to declare boundaries
+	/// ([`cut`](crate::timeline::Producer::cut)) or to hold publishing back while tracks
+	/// enroll ([`hold`](crate::timeline::Producer::hold)).
+	pub fn timeline(&self) -> crate::timeline::Producer {
+		self.timeline.clone()
 	}
 
 	/// Set the timeline's wall-clock anchor (see
 	/// [`timeline::Producer::set_wall`](crate::timeline::Producer::set_wall)) and re-advertise
 	/// the catalog's `timeline` section so consumers see it.
-	///
-	/// Creates the timeline on first use, like [`timeline`](Self::timeline).
-	pub fn set_wall(&mut self, pts: moq_net::Timestamp, wall: std::time::SystemTime) -> crate::Result<()> {
-		let mut timeline = self.timeline()?;
-		timeline.set_wall(pts, wall);
-		self.lock().timeline = Some(timeline.section());
-		Ok(())
+	pub fn set_wall(&mut self, pts: moq_net::Timestamp, wall: std::time::SystemTime) {
+		self.timeline.set_wall(pts, wall);
+
+		let section = self.timeline.section();
+		let mut catalog = self.lock();
+		if catalog.timeline.is_some() {
+			catalog.timeline = Some(section);
+		}
 	}
 
 	/// Create a consumer for this catalog, receiving updates as they're published.
@@ -282,9 +274,7 @@ impl<E: CatalogExt> Producer<E> {
 		self.hang.finish()?;
 		self.hangz.finish()?;
 		self.msf_track.finish()?;
-		if let Some(timeline) = self.timeline.lock().unwrap().as_mut() {
-			timeline.finish()?;
-		}
+		self.timeline.finish()?;
 		Ok(())
 	}
 }
@@ -579,23 +569,23 @@ mod test {
 
 		// Something else already took the name the timeline track wants.
 		let _taken = broadcast.create_track(hang::timeline::DEFAULT_NAME, None).unwrap();
-		assert!(catalog.timeline().is_err());
+		assert!(catalog.enroll("video0").is_err());
 	}
 
 	#[test]
-	fn timeline_advertises_the_catalog_section() {
+	fn enrolling_advertises_the_catalog_section() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut catalog = Producer::new(&mut broadcast).unwrap();
 
-		// First use creates the track and advertises it at the catalog root; a second call
-		// returns the same shared handle without republishing.
-		let timeline = catalog.timeline().unwrap();
+		// A broadcast that never segments never advertises a timeline.
+		assert_eq!(catalog.snapshot().timeline, None);
+
+		let _recorder = catalog.enroll("video0").unwrap();
 		assert_eq!(
 			catalog.snapshot().timeline,
-			Some(timeline.section()),
+			Some(catalog.timeline().section()),
 			"the root section should advertise the timeline track"
 		);
-		catalog.timeline().unwrap();
 	}
 
 	fn h264_config() -> VideoConfig {

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::ops::{Deref, DerefMut};
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -54,17 +53,16 @@ pub struct Producer<E: CatalogExt = ()> {
 	/// a caller has none land on one timeline and audio/video stay in sync.
 	clock: crate::Clock,
 
-	/// A clone of the broadcast, retained so per-rendition timeline tracks can be created
-	/// lazily when a rendition is registered (the codec importers hold only their media
-	/// track, not the broadcast).
+	/// A clone of the broadcast, retained so the timeline track can be created lazily when
+	/// the first media track enrolls (the codec importers hold only their media track, not
+	/// the broadcast).
 	broadcast: moq_net::broadcast::Producer,
 
-	/// The per-rendition timeline producers, memoized by media-track name so the catalog
-	/// section and the media track's group recorder share one track. See [`media_producer`](Self::media_producer).
-	timelines: Arc<Mutex<BTreeMap<String, crate::timeline::Producer>>>,
+	/// The broadcast's one timeline track, created lazily by [`timeline`](Self::timeline).
+	timeline: Arc<Mutex<Option<crate::timeline::Producer>>>,
 
-	/// The broadcast's shared segment counter, wired into every timeline so segment numbers
-	/// align across tracks. See [`segmenter`](Self::segmenter).
+	/// The broadcast's segmenter: the shared boundary list every enrolled track's groups map
+	/// onto. See [`segmenter`](Self::segmenter).
 	segmenter: crate::timeline::Segmenter,
 }
 
@@ -79,7 +77,7 @@ impl<E: CatalogExt> Clone for Producer<E> {
 			reservations: self.reservations.clone(),
 			clock: self.clock,
 			broadcast: self.broadcast.clone(),
-			timelines: self.timelines.clone(),
+			timeline: self.timeline.clone(),
 			segmenter: self.segmenter.clone(),
 		}
 	}
@@ -125,7 +123,7 @@ impl<E: CatalogExt> Producer<E> {
 			reservations: Arc::new(Mutex::new(Reservations::default())),
 			clock: crate::Clock::new(),
 			broadcast: broadcast.clone(),
-			timelines: Arc::new(Mutex::new(BTreeMap::new())),
+			timeline: Arc::new(Mutex::new(None)),
 			segmenter: crate::timeline::Segmenter::new(),
 		})
 	}
@@ -210,54 +208,53 @@ impl<E: CatalogExt> Producer<E> {
 		}
 	}
 
-	/// Build the media [`container::Producer`](crate::container::Producer) for `track`, recording its
-	/// group opens into the `<name>.timeline.z` timeline named after it as aligned segments.
+	/// Build the media [`container::Producer`](crate::container::Producer) for `track`,
+	/// enrolling it in the broadcast's timeline so its groups are indexed into the aligned
+	/// segments.
 	///
-	/// `cadence` states how the track's groups map onto the broadcast's segments: video is
-	/// [`Cadence::Boundary`](crate::timeline::Cadence::Boundary) (every group, opened by a
-	/// keyframe, is a segment) and audio is
-	/// [`Cadence::Aligned`](crate::timeline::Cadence::Aligned) (groups pack into the segments
-	/// video opens). See [`timeline`](crate::timeline).
-	///
-	/// This is the 1:1 default. To share a timeline across aligned renditions, build the producer
-	/// yourself and wire the shared timeline's recorder:
-	/// `container::Producer::new(track, container).with_recorder(catalog.timeline(shared)?.recorder(cadence))`,
-	/// and advertise `catalog.timeline(shared)?.section()` on each of their configs.
+	/// `kind` states what the track carries: the segmenter prefers a video track as its
+	/// auto-cut driver, since segment boundaries must land on video keyframes. The broadcast's
+	/// one timeline track is created (and advertised in the catalog's root `timeline` section)
+	/// on first use; see [`timeline`](crate::timeline) for the whole model.
 	pub fn media_producer<C: crate::container::Container>(
-		&self,
+		&mut self,
 		track: moq_net::track::Producer,
 		container: C,
-		cadence: crate::timeline::Cadence,
+		kind: crate::timeline::Kind,
 	) -> crate::Result<crate::container::Producer<C>> {
-		let recorder = self.timeline(track.name())?.recorder(cadence);
+		self.timeline()?;
+		let recorder = self.segmenter.track(track.name(), kind);
 		Ok(crate::container::Producer::new(track, container).with_recorder(recorder))
 	}
 
-	/// The [`timeline::Producer`](crate::timeline::Producer) named `name`, creating its
-	/// `<name>.timeline.z` track on first use and returning the same shared handle thereafter.
-	/// Every timeline minted here numbers segments through the broadcast's one
-	/// [`segmenter`](Self::segmenter), so they stay aligned.
+	/// The broadcast's [`timeline::Producer`](crate::timeline::Producer), creating its track
+	/// ([`hang::timeline::DEFAULT_NAME`]) and advertising it in the catalog's root `timeline`
+	/// section on first use.
 	///
-	/// Advertise it on a rendition by setting `config.timeline = Some(timeline.section())`, and
-	/// record group opens through its [`recorder`](crate::timeline::Producer::recorder). Two
-	/// renditions naming the same timeline share it: an aligned transcode ladder records the source
-	/// and has the rungs only advertise the same section.
+	/// [`media_producer`](Self::media_producer) calls this for you; call it directly to
+	/// [`set_wall`](crate::timeline::Producer::set_wall) or when wiring recorders by hand via
+	/// [`segmenter`](Self::segmenter).
 	///
-	/// Errors on first use if the broadcast can't create the `<name>.timeline.z` track, for example
-	/// because something else already took that name.
-	pub fn timeline(&self, name: &str) -> crate::Result<crate::timeline::Producer> {
-		let mut timelines = self.timelines.lock().unwrap();
-		if let Some(timeline) = timelines.get(name) {
-			return Ok(timeline.clone());
+	/// Errors on first use if the broadcast can't create the timeline track, for example
+	/// because something else already took the name.
+	pub fn timeline(&mut self) -> crate::Result<crate::timeline::Producer> {
+		{
+			let timeline = self.timeline.lock().unwrap();
+			if let Some(timeline) = timeline.as_ref() {
+				return Ok(timeline.clone());
+			}
 		}
 
-		let timeline = crate::timeline::Producer::new(&mut self.broadcast.clone(), name, self.segmenter.clone())?;
-		timelines.insert(name.to_string(), timeline.clone());
+		let timeline = crate::timeline::Producer::new(&mut self.broadcast.clone(), &self.segmenter)?;
+		*self.timeline.lock().unwrap() = Some(timeline.clone());
+		self.lock().timeline = Some(timeline.section());
 		Ok(timeline)
 	}
 
-	/// The broadcast's shared [`Segmenter`](crate::timeline::Segmenter): the segment counter
-	/// every timeline minted by [`timeline`](Self::timeline) aligns on.
+	/// The broadcast's [`Segmenter`](crate::timeline::Segmenter): where the application cuts
+	/// segment boundaries ([`cut`](crate::timeline::Segmenter::cut)) or tunes the auto-cut
+	/// threshold, and where tracks not built through
+	/// [`media_producer`](Self::media_producer) enroll.
 	pub fn segmenter(&self) -> crate::timeline::Segmenter {
 		self.segmenter.clone()
 	}
@@ -272,7 +269,7 @@ impl<E: CatalogExt> Producer<E> {
 		self.hang.finish()?;
 		self.hangz.finish()?;
 		self.msf_track.finish()?;
-		for timeline in self.timelines.lock().unwrap().values_mut() {
+		if let Some(timeline) = self.timeline.lock().unwrap().as_mut() {
 			timeline.finish()?;
 		}
 		Ok(())
@@ -565,11 +562,27 @@ mod test {
 	#[test]
 	fn timeline_reports_a_track_collision() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let catalog = Producer::new(&mut broadcast).unwrap();
+		let mut catalog = Producer::new(&mut broadcast).unwrap();
 
 		// Something else already took the name the timeline track wants.
-		let _taken = broadcast.create_track("video0.timeline.z", None).unwrap();
-		assert!(catalog.timeline("video0").is_err());
+		let _taken = broadcast.create_track(hang::timeline::DEFAULT_NAME, None).unwrap();
+		assert!(catalog.timeline().is_err());
+	}
+
+	#[test]
+	fn timeline_advertises_the_catalog_section() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let mut catalog = Producer::new(&mut broadcast).unwrap();
+
+		// First use creates the track and advertises it at the catalog root; a second call
+		// returns the same shared handle without republishing.
+		let timeline = catalog.timeline().unwrap();
+		assert_eq!(
+			catalog.snapshot().timeline,
+			Some(timeline.section()),
+			"the root section should advertise the timeline track"
+		);
+		catalog.timeline().unwrap();
 	}
 
 	fn h264_config() -> VideoConfig {

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -62,6 +62,10 @@ pub struct Producer<E: CatalogExt = ()> {
 	/// The per-rendition timeline producers, memoized by media-track name so the catalog
 	/// section and the media track's group recorder share one track. See [`media_producer`](Self::media_producer).
 	timelines: Arc<Mutex<BTreeMap<String, crate::timeline::Producer>>>,
+
+	/// The broadcast's shared segment counter, wired into every timeline so segment numbers
+	/// align across tracks. See [`segmenter`](Self::segmenter).
+	segmenter: crate::timeline::Segmenter,
 }
 
 // Manual Clone so a producer is cheaply clonable regardless of whether `E` is.
@@ -76,6 +80,7 @@ impl<E: CatalogExt> Clone for Producer<E> {
 			clock: self.clock,
 			broadcast: self.broadcast.clone(),
 			timelines: self.timelines.clone(),
+			segmenter: self.segmenter.clone(),
 		}
 	}
 }
@@ -121,6 +126,7 @@ impl<E: CatalogExt> Producer<E> {
 			clock: crate::Clock::new(),
 			broadcast: broadcast.clone(),
 			timelines: Arc::new(Mutex::new(BTreeMap::new())),
+			segmenter: crate::timeline::Segmenter::new(),
 		})
 	}
 
@@ -205,23 +211,32 @@ impl<E: CatalogExt> Producer<E> {
 	}
 
 	/// Build the media [`container::Producer`](crate::container::Producer) for `track`, recording its
-	/// group opens into the `<name>.timeline.z` timeline named after it.
+	/// group opens into the `<name>.timeline.z` timeline named after it as aligned segments.
+	///
+	/// `cadence` states how the track's groups map onto the broadcast's segments: video is
+	/// [`Cadence::Boundary`](crate::timeline::Cadence::Boundary) (every group, opened by a
+	/// keyframe, is a segment) and audio is
+	/// [`Cadence::Aligned`](crate::timeline::Cadence::Aligned) (groups pack into the segments
+	/// video opens). See [`timeline`](crate::timeline).
 	///
 	/// This is the 1:1 default. To share a timeline across aligned renditions, build the producer
 	/// yourself and wire the shared timeline's recorder:
-	/// `container::Producer::new(track, container).with_recorder(catalog.timeline(shared)?.recorder())`,
+	/// `container::Producer::new(track, container).with_recorder(catalog.timeline(shared)?.recorder(cadence))`,
 	/// and advertise `catalog.timeline(shared)?.section()` on each of their configs.
 	pub fn media_producer<C: crate::container::Container>(
 		&self,
 		track: moq_net::track::Producer,
 		container: C,
+		cadence: crate::timeline::Cadence,
 	) -> crate::Result<crate::container::Producer<C>> {
-		let recorder = self.timeline(track.name())?.recorder();
+		let recorder = self.timeline(track.name())?.recorder(cadence);
 		Ok(crate::container::Producer::new(track, container).with_recorder(recorder))
 	}
 
 	/// The [`timeline::Producer`](crate::timeline::Producer) named `name`, creating its
 	/// `<name>.timeline.z` track on first use and returning the same shared handle thereafter.
+	/// Every timeline minted here numbers segments through the broadcast's one
+	/// [`segmenter`](Self::segmenter), so they stay aligned.
 	///
 	/// Advertise it on a rendition by setting `config.timeline = Some(timeline.section())`, and
 	/// record group opens through its [`recorder`](crate::timeline::Producer::recorder). Two
@@ -236,9 +251,15 @@ impl<E: CatalogExt> Producer<E> {
 			return Ok(timeline.clone());
 		}
 
-		let timeline = crate::timeline::Producer::new(&mut self.broadcast.clone(), name)?;
+		let timeline = crate::timeline::Producer::new(&mut self.broadcast.clone(), name, self.segmenter.clone())?;
 		timelines.insert(name.to_string(), timeline.clone());
 		Ok(timeline)
+	}
+
+	/// The broadcast's shared [`Segmenter`](crate::timeline::Segmenter): the segment counter
+	/// every timeline minted by [`timeline`](Self::timeline) aligns on.
+	pub fn segmenter(&self) -> crate::timeline::Segmenter {
+		self.segmenter.clone()
 	}
 
 	/// Create a consumer for this catalog, receiving updates as they're published.

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -251,19 +251,6 @@ impl<E: CatalogExt> Producer<E> {
 		self.timeline.clone()
 	}
 
-	/// Set the timeline's wall-clock anchor (see
-	/// [`timeline::Producer::set_wall`](crate::timeline::Producer::set_wall)) and re-advertise
-	/// the catalog's `timeline` section so consumers see it.
-	pub fn set_wall(&mut self, pts: moq_net::Timestamp, wall: std::time::SystemTime) {
-		self.timeline.set_wall(pts, wall);
-
-		let section = self.timeline.section();
-		let mut catalog = self.lock();
-		if catalog.timeline.is_some() {
-			catalog.timeline = Some(section);
-		}
-	}
-
 	/// Create a consumer for this catalog, receiving updates as they're published.
 	pub fn consume(&self) -> Result<Consumer<E>, moq_net::Error> {
 		Ok(Consumer::new(self.hang.consume()))

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -124,7 +124,7 @@ impl<E: CatalogExt> Producer<E> {
 			clock: crate::Clock::new(),
 			broadcast: broadcast.clone(),
 			timeline: Arc::new(Mutex::new(None)),
-			segmenter: crate::timeline::Segmenter::new(),
+			segmenter: crate::timeline::Segmenter::default(),
 		})
 	}
 
@@ -252,11 +252,24 @@ impl<E: CatalogExt> Producer<E> {
 	}
 
 	/// The broadcast's [`Segmenter`](crate::timeline::Segmenter): where the application cuts
-	/// segment boundaries ([`cut`](crate::timeline::Segmenter::cut)) or tunes the auto-cut
-	/// threshold, and where tracks not built through
+	/// segment boundaries ([`cut`](crate::timeline::Segmenter::cut)) or declares the
+	/// segment-duration bound ([`set_duration_max`](crate::timeline::Segmenter::set_duration_max),
+	/// before the first media track enrolls), and where tracks not built through
 	/// [`media_producer`](Self::media_producer) enroll.
 	pub fn segmenter(&self) -> crate::timeline::Segmenter {
 		self.segmenter.clone()
+	}
+
+	/// Set the timeline's wall-clock anchor (see
+	/// [`timeline::Producer::set_wall`](crate::timeline::Producer::set_wall)) and re-advertise
+	/// the catalog's `timeline` section so consumers see it.
+	///
+	/// Creates the timeline on first use, like [`timeline`](Self::timeline).
+	pub fn set_wall(&mut self, pts: moq_net::Timestamp, wall: std::time::SystemTime) -> crate::Result<()> {
+		let mut timeline = self.timeline()?;
+		timeline.set_wall(pts, wall);
+		self.lock().timeline = Some(timeline.section());
+		Ok(())
 	}
 
 	/// Create a consumer for this catalog, receiving updates as they're published.

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -246,7 +246,8 @@ impl<E: CatalogExt> Producer<E> {
 	/// section) when the first media track enrolls, so reading this costs nothing on a
 	/// broadcast that never segments. Use it to declare boundaries
 	/// ([`cut`](crate::timeline::Producer::cut)) or to hold publishing back while tracks
-	/// enroll ([`hold`](crate::timeline::Producer::hold)).
+	/// enroll ([`reserve`](crate::timeline::Producer::reserve), the timeline's counterpart to
+	/// this producer's own [`reserve`](Self::reserve)).
 	pub fn timeline(&self) -> crate::timeline::Producer {
 		self.timeline.clone()
 	}

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -55,9 +55,9 @@ use super::hang::{Catalog, CatalogExt};
 /// configs use the same trait. Writing to `catalog.video` / `catalog.audio` from a custom config
 /// fights the media pipeline for those sections; stay in your own.
 ///
-/// To advertise a timeline for a custom track, set your config's timeline field from
-/// [`catalog::Producer::timeline`](crate::catalog::Producer::timeline) before [`set`](Rendition::set)
-/// (the same way an importer does), and record group opens through its recorder.
+/// To index a custom track in the broadcast's timeline, enroll it via
+/// [`catalog::Producer::segmenter`](crate::catalog::Producer::segmenter) (or build it through
+/// [`media_producer`](crate::catalog::Producer::media_producer), which does so for you).
 ///
 /// Opting into detection is only half of it: something has to measure. Write the track through a
 /// [`container::Producer`](crate::container::Producer) and hand its
@@ -521,46 +521,19 @@ mod tests {
 		assert_eq!(config.bitrate, Some(789), "the re-set bitrate is now authoritative");
 	}
 
-	/// Two renditions can advertise one shared timeline: the same handle yields the same section, so
-	/// an aligned ladder (source + rung) indexes off a single `.timeline.z` track.
+	/// The broadcast has one timeline: every rendition's groups index into the same track, so
+	/// an aligned ladder (source + rung) shares it by construction.
 	#[test]
-	fn renditions_share_a_timeline() {
+	fn renditions_share_the_broadcast_timeline() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let catalog = super::super::Producer::new(&mut broadcast).unwrap();
-		let reserved = catalog.reserve();
+		let mut catalog = super::super::Producer::new(&mut broadcast).unwrap();
 
-		let shared = catalog.timeline("video").unwrap();
-		let mut source = reserved.video("video0");
-		let mut rung = reserved.video("video1");
-		drop(reserved);
-
-		for rendition in [&mut source, &mut rung] {
-			let mut config = config(None, None);
-			config.timeline = Some(shared.section());
-			rendition.set(config);
-		}
-
-		let snapshot = catalog.snapshot();
-		let source_tl = snapshot
-			.video
-			.renditions
-			.get("video0")
-			.unwrap()
-			.timeline
-			.as_ref()
-			.unwrap();
-		let rung_tl = snapshot
-			.video
-			.renditions
-			.get("video1")
-			.unwrap()
-			.timeline
-			.as_ref()
-			.unwrap();
-		assert_eq!(source_tl.track, "video.timeline.z");
+		let timeline = catalog.timeline().unwrap();
+		assert_eq!(timeline.section().track, hang::timeline::DEFAULT_NAME);
 		assert_eq!(
-			rung_tl.track, source_tl.track,
-			"both renditions index off one shared timeline track"
+			catalog.snapshot().timeline,
+			Some(timeline.section()),
+			"the one timeline is advertised at the catalog root"
 		);
 	}
 
@@ -584,8 +557,6 @@ mod tests {
 			schema: String,
 			#[serde(default, skip_serializing_if = "Option::is_none")]
 			bitrate: Option<u64>,
-			#[serde(default, skip_serializing_if = "Option::is_none")]
-			timeline: Option<hang::catalog::Timeline>,
 		}
 
 		impl RenditionConfig<TelemetryExt> for Telemetry {
@@ -612,7 +583,6 @@ mod tests {
 			Telemetry {
 				schema: "gps/v1".to_string(),
 				bitrate,
-				timeline: None,
 			}
 		}
 
@@ -622,8 +592,7 @@ mod tests {
 			(broadcast, catalog)
 		}
 
-		/// A custom kind gets the same detection and drop-removal as video/audio, and advertises a
-		/// timeline the same explicit way an importer does.
+		/// A custom kind gets the same detection and drop-removal as video/audio.
 		#[test]
 		fn detects_and_advertises() {
 			let (_broadcast, catalog) = produce();
@@ -631,20 +600,12 @@ mod tests {
 			let mut rendition = reserved.init::<Telemetry>("gps");
 			drop(reserved);
 
-			// The caller advertises the timeline explicitly, exactly as an importer does for video/audio.
-			let mut config = telemetry(None);
-			config.timeline = Some(catalog.timeline("gps").unwrap().section());
-			rendition.set(config);
+			rendition.set(telemetry(None));
 			feed(&mut rendition);
 
 			let snapshot = catalog.snapshot();
 			let config = snapshot.telemetry.get("gps").unwrap();
 			assert!(config.bitrate.is_some(), "absent bitrate should be auto-detected");
-			assert_eq!(
-				config.timeline.as_ref().map(|t| t.track.as_str()),
-				Some("gps.timeline.z"),
-				"the advertised timeline names the companion track"
-			);
 
 			drop(rendition);
 			assert!(
@@ -658,7 +619,7 @@ mod tests {
 		/// themselves current, with no per-frame bookkeeping in the caller.
 		#[test]
 		fn measures_a_custom_track() {
-			let (mut broadcast, catalog) = produce();
+			let (mut broadcast, mut catalog) = produce();
 			let reserved = catalog.reserve();
 			let mut rendition = reserved.init::<Telemetry>("gps");
 			drop(reserved);
@@ -669,7 +630,7 @@ mod tests {
 				.media_producer(
 					net,
 					crate::catalog::hang::Container::Legacy,
-					crate::timeline::Cadence::Aligned,
+					crate::timeline::Kind::Audio,
 				)
 				.unwrap();
 

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -666,7 +666,11 @@ mod tests {
 
 			let net = broadcast.create_track("gps", None).unwrap();
 			let mut track = catalog
-				.media_producer(net, crate::catalog::hang::Container::Legacy)
+				.media_producer(
+					net,
+					crate::catalog::hang::Container::Legacy,
+					crate::timeline::Cadence::Aligned,
+				)
 				.unwrap();
 
 			// 40ms records of 5 kB: 1 Mbps, over more than the bitrate window.

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -56,7 +56,7 @@ use super::hang::{Catalog, CatalogExt};
 /// fights the media pipeline for those sections; stay in your own.
 ///
 /// To index a custom track in the broadcast's timeline, enroll it via
-/// [`catalog::Producer::segmenter`](crate::catalog::Producer::segmenter) (or build it through
+/// [`catalog::Producer::enroll`](crate::catalog::Producer::enroll) (or build it through
 /// [`media_producer`](crate::catalog::Producer::media_producer), which does so for you).
 ///
 /// Opting into detection is only half of it: something has to measure. Write the track through a
@@ -528,7 +528,8 @@ mod tests {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut catalog = super::super::Producer::new(&mut broadcast).unwrap();
 
-		let timeline = catalog.timeline().unwrap();
+		let _recorder = catalog.enroll("video0").unwrap();
+		let timeline = catalog.timeline();
 		assert_eq!(timeline.section().track, hang::timeline::DEFAULT_NAME);
 		assert_eq!(
 			catalog.snapshot().timeline,
@@ -627,11 +628,7 @@ mod tests {
 
 			let net = broadcast.create_track("gps", None).unwrap();
 			let mut track = catalog
-				.media_producer(
-					net,
-					crate::catalog::hang::Container::Legacy,
-					crate::timeline::Kind::Audio,
-				)
+				.media_producer(net, crate::catalog::hang::Container::Legacy)
 				.unwrap();
 
 			// 40ms records of 5 kB: 1 Mbps, over more than the bitrate window.

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -31,11 +31,9 @@ impl<E: CatalogExt> Import<E> {
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Ok(Self {
-			track: reserved.producer().media_producer(
-				track,
-				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Kind::Audio,
-			)?,
+			track: reserved
+				.producer()
+				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
 			rendition,
 		})
 	}

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -25,18 +25,16 @@ impl<E: CatalogExt> Import<E> {
 	pub fn new(
 		track: moq_net::track::Producer,
 		reserved: crate::catalog::Reserved<E>,
-		mut config: hang::catalog::AudioConfig,
+		config: hang::catalog::AudioConfig,
 	) -> crate::Result<Self> {
 		tracing::debug!(name = ?track.name(), ?config, "starting track");
-		// Advertise this rendition's timeline before publishing (the generic set() no longer does).
-		config.timeline = Some(reserved.producer().timeline(track.name())?.section());
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Ok(Self {
 			track: reserved.producer().media_producer(
 				track,
 				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Cadence::Aligned,
+				crate::timeline::Kind::Audio,
 			)?,
 			rendition,
 		})

--- a/rs/moq-mux/src/codec/aac/import.rs
+++ b/rs/moq-mux/src/codec/aac/import.rs
@@ -33,9 +33,11 @@ impl<E: CatalogExt> Import<E> {
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Ok(Self {
-			track: reserved
-				.producer()
-				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
+			track: reserved.producer().media_producer(
+				track,
+				crate::catalog::hang::Container::Legacy,
+				crate::timeline::Cadence::Aligned,
+			)?,
 			rendition,
 		})
 	}

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -47,9 +47,11 @@ impl<E: CatalogExt> Import<E> {
 		let rendition = reserved.video(track.name());
 		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint)?;
 		let mut import = Self {
-			track: reserved
-				.producer()
-				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
+			track: reserved.producer().media_producer(
+				track,
+				crate::catalog::hang::Container::Legacy,
+				crate::timeline::Cadence::Boundary,
+			)?,
 			rendition,
 			catalog,
 			last_seq: None,

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -47,11 +47,9 @@ impl<E: CatalogExt> Import<E> {
 		let rendition = reserved.video(track.name());
 		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
-			track: reserved.producer().media_producer(
-				track,
-				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Kind::Video,
-			)?,
+			track: reserved
+				.producer()
+				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
 			rendition,
 			catalog,
 			last_seq: None,

--- a/rs/moq-mux/src/codec/av1/import.rs
+++ b/rs/moq-mux/src/codec/av1/import.rs
@@ -45,12 +45,12 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> crate::Result<Self> {
 		let rendition = reserved.video(track.name());
-		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint)?;
+		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
 			track: reserved.producer().media_producer(
 				track,
 				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Cadence::Boundary,
+				crate::timeline::Kind::Video,
 			)?,
 			rendition,
 			catalog,

--- a/rs/moq-mux/src/codec/flac/import.rs
+++ b/rs/moq-mux/src/codec/flac/import.rs
@@ -34,11 +34,9 @@ impl<E: CatalogExt> Import<E> {
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Ok(Self {
-			track: reserved.producer().media_producer(
-				track,
-				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Kind::Audio,
-			)?,
+			track: reserved
+				.producer()
+				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
 			rendition,
 		})
 	}

--- a/rs/moq-mux/src/codec/flac/import.rs
+++ b/rs/moq-mux/src/codec/flac/import.rs
@@ -28,18 +28,16 @@ impl<E: CatalogExt> Import<E> {
 	pub fn new(
 		track: moq_net::track::Producer,
 		reserved: crate::catalog::Reserved<E>,
-		mut config: hang::catalog::AudioConfig,
+		config: hang::catalog::AudioConfig,
 	) -> crate::Result<Self> {
 		tracing::debug!(name = ?track.name(), ?config, "starting track");
-		// Advertise this rendition's timeline before publishing (the generic set() no longer does).
-		config.timeline = Some(reserved.producer().timeline(track.name())?.section());
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Ok(Self {
 			track: reserved.producer().media_producer(
 				track,
 				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Cadence::Aligned,
+				crate::timeline::Kind::Audio,
 			)?,
 			rendition,
 		})

--- a/rs/moq-mux/src/codec/flac/import.rs
+++ b/rs/moq-mux/src/codec/flac/import.rs
@@ -36,9 +36,11 @@ impl<E: CatalogExt> Import<E> {
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Ok(Self {
-			track: reserved
-				.producer()
-				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
+			track: reserved.producer().media_producer(
+				track,
+				crate::catalog::hang::Container::Legacy,
+				crate::timeline::Cadence::Aligned,
+			)?,
 			rendition,
 		})
 	}

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -51,11 +51,9 @@ impl<E: CatalogExt> Import<E> {
 		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
 			avc1: false,
-			track: reserved.producer().media_producer(
-				track,
-				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Kind::Video,
-			)?,
+			track: reserved
+				.producer()
+				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
 			rendition,
 			catalog,
 			last_sps: None,

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -51,9 +51,11 @@ impl<E: CatalogExt> Import<E> {
 		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint)?;
 		let mut import = Self {
 			avc1: false,
-			track: reserved
-				.producer()
-				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
+			track: reserved.producer().media_producer(
+				track,
+				crate::catalog::hang::Container::Legacy,
+				crate::timeline::Cadence::Boundary,
+			)?,
 			rendition,
 			catalog,
 			last_sps: None,

--- a/rs/moq-mux/src/codec/h264/import.rs
+++ b/rs/moq-mux/src/codec/h264/import.rs
@@ -48,13 +48,13 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> crate::Result<Self> {
 		let rendition = reserved.video(track.name());
-		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint)?;
+		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
 			avc1: false,
 			track: reserved.producer().media_producer(
 				track,
 				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Cadence::Boundary,
+				crate::timeline::Kind::Video,
 			)?,
 			rendition,
 			catalog,

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -56,11 +56,9 @@ impl<E: CatalogExt> Import<E> {
 		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
 			hvc1: false,
-			track: reserved.producer().media_producer(
-				track,
-				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Kind::Video,
-			)?,
+			track: reserved
+				.producer()
+				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
 			rendition,
 			catalog,
 			last_sps: None,

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -53,13 +53,13 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> crate::Result<Self> {
 		let rendition = reserved.video(track.name());
-		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint)?;
+		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
 			hvc1: false,
 			track: reserved.producer().media_producer(
 				track,
 				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Cadence::Boundary,
+				crate::timeline::Kind::Video,
 			)?,
 			rendition,
 			catalog,

--- a/rs/moq-mux/src/codec/h265/import.rs
+++ b/rs/moq-mux/src/codec/h265/import.rs
@@ -56,9 +56,11 @@ impl<E: CatalogExt> Import<E> {
 		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint)?;
 		let mut import = Self {
 			hvc1: false,
-			track: reserved
-				.producer()
-				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
+			track: reserved.producer().media_producer(
+				track,
+				crate::catalog::hang::Container::Legacy,
+				crate::timeline::Cadence::Boundary,
+			)?,
 			rendition,
 			catalog,
 			last_sps: None,

--- a/rs/moq-mux/src/codec/legacy.rs
+++ b/rs/moq-mux/src/codec/legacy.rs
@@ -139,7 +139,6 @@ impl<E: CatalogExt> Import<E> {
 		tracing::debug!(name = ?track.name(), config = ?audio_config, "starting track");
 
 		// Advertise this rendition's timeline before publishing (the generic set() no longer does).
-		audio_config.timeline = Some(reserved.producer().timeline(track.name())?.section());
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(audio_config);
 
@@ -147,7 +146,7 @@ impl<E: CatalogExt> Import<E> {
 			track: reserved.producer().media_producer(
 				track,
 				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Cadence::Aligned,
+				crate::timeline::Kind::Audio,
 			)?,
 			rendition,
 		})

--- a/rs/moq-mux/src/codec/legacy.rs
+++ b/rs/moq-mux/src/codec/legacy.rs
@@ -144,9 +144,11 @@ impl<E: CatalogExt> Import<E> {
 		rendition.set(audio_config);
 
 		Ok(Self {
-			track: reserved
-				.producer()
-				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
+			track: reserved.producer().media_producer(
+				track,
+				crate::catalog::hang::Container::Legacy,
+				crate::timeline::Cadence::Aligned,
+			)?,
 			rendition,
 		})
 	}

--- a/rs/moq-mux/src/codec/legacy.rs
+++ b/rs/moq-mux/src/codec/legacy.rs
@@ -143,11 +143,9 @@ impl<E: CatalogExt> Import<E> {
 		rendition.set(audio_config);
 
 		Ok(Self {
-			track: reserved.producer().media_producer(
-				track,
-				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Kind::Audio,
-			)?,
+			track: reserved
+				.producer()
+				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
 			rendition,
 		})
 	}

--- a/rs/moq-mux/src/codec/mp3.rs
+++ b/rs/moq-mux/src/codec/mp3.rs
@@ -116,18 +116,16 @@ impl<E: CatalogExt> Import<E> {
 	pub fn new(
 		track: moq_net::track::Producer,
 		reserved: crate::catalog::Reserved<E>,
-		mut config: hang::catalog::AudioConfig,
+		config: hang::catalog::AudioConfig,
 	) -> crate::Result<Self> {
 		tracing::debug!(name = ?track.name(), ?config, "starting track");
-		// Advertise this rendition's timeline before publishing (the generic set() no longer does).
-		config.timeline = Some(reserved.producer().timeline(track.name())?.section());
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Ok(Self {
 			track: reserved.producer().media_producer(
 				track,
 				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Cadence::Aligned,
+				crate::timeline::Kind::Audio,
 			)?,
 			rendition,
 		})

--- a/rs/moq-mux/src/codec/mp3.rs
+++ b/rs/moq-mux/src/codec/mp3.rs
@@ -122,11 +122,9 @@ impl<E: CatalogExt> Import<E> {
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Ok(Self {
-			track: reserved.producer().media_producer(
-				track,
-				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Kind::Audio,
-			)?,
+			track: reserved
+				.producer()
+				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
 			rendition,
 		})
 	}

--- a/rs/moq-mux/src/codec/mp3.rs
+++ b/rs/moq-mux/src/codec/mp3.rs
@@ -124,9 +124,11 @@ impl<E: CatalogExt> Import<E> {
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Ok(Self {
-			track: reserved
-				.producer()
-				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
+			track: reserved.producer().media_producer(
+				track,
+				crate::catalog::hang::Container::Legacy,
+				crate::timeline::Cadence::Aligned,
+			)?,
 			rendition,
 		})
 	}

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -34,11 +34,9 @@ impl<E: CatalogExt> Import<E> {
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Ok(Self {
-			track: reserved.producer().media_producer(
-				track,
-				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Kind::Audio,
-			)?,
+			track: reserved
+				.producer()
+				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
 			rendition,
 		})
 	}

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -28,18 +28,16 @@ impl<E: CatalogExt> Import<E> {
 	pub fn new(
 		track: moq_net::track::Producer,
 		reserved: crate::catalog::Reserved<E>,
-		mut config: hang::catalog::AudioConfig,
+		config: hang::catalog::AudioConfig,
 	) -> crate::Result<Self> {
 		tracing::debug!(name = ?track.name(), ?config, "starting track");
-		// Advertise this rendition's timeline before publishing (the generic set() no longer does).
-		config.timeline = Some(reserved.producer().timeline(track.name())?.section());
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Ok(Self {
 			track: reserved.producer().media_producer(
 				track,
 				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Cadence::Aligned,
+				crate::timeline::Kind::Audio,
 			)?,
 			rendition,
 		})

--- a/rs/moq-mux/src/codec/opus/import.rs
+++ b/rs/moq-mux/src/codec/opus/import.rs
@@ -36,9 +36,11 @@ impl<E: CatalogExt> Import<E> {
 		let mut rendition = reserved.audio(track.name());
 		rendition.set(config);
 		Ok(Self {
-			track: reserved
-				.producer()
-				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
+			track: reserved.producer().media_producer(
+				track,
+				crate::catalog::hang::Container::Legacy,
+				crate::timeline::Cadence::Aligned,
+			)?,
 			rendition,
 		})
 	}

--- a/rs/moq-mux/src/codec/video.rs
+++ b/rs/moq-mux/src/codec/video.rs
@@ -2,36 +2,29 @@
 //!
 //! Every video importer resolves its [`VideoConfig`](hang::catalog::VideoConfig) lazily from the
 //! bitstream and re-publishes it whenever the stream reveals a change. [`Catalog`] owns the part of
-//! that which is identical across codecs: overlay the caller's [`VideoHint`], advertise the
-//! rendition's timeline, and skip a publish that matches the last one. The rendition itself stays a
-//! separate field on the importer, since each drives its frame recording (`record_*`) directly.
+//! that which is identical across codecs: overlay the caller's [`VideoHint`] and skip a publish
+//! that matches the last one. The rendition itself stays a separate field on the importer, since
+//! each drives its frame recording (`record_*`) directly.
 
 use crate::catalog::hang::CatalogExt;
-use crate::catalog::{Reserved, VideoHint, VideoTrack};
+use crate::catalog::{VideoHint, VideoTrack};
 
 /// The catalog-publishing state a video importer overlays onto every config it resolves.
 ///
-/// Holds the caller's hint, the rendition's advertised timeline section, and the last config
-/// published (to dedupe re-publishes). Not generic over the extension: none of these depend on it.
+/// Holds the caller's hint and the last config published (to dedupe re-publishes). Not generic
+/// over the extension: neither depends on it.
 pub(crate) struct Catalog {
 	/// Overlaid onto every config, so a hinted field counts as supplied and is never overwritten by
 	/// the rendition's detector.
 	hint: VideoHint,
-	/// The rendition's timeline section, advertised on every config (the generic `set()` no longer
-	/// does). Snapshotted at construction; the timeline track is 1:1 by name.
-	timeline: hang::catalog::Timeline,
 	/// The last config published, so an unchanged re-resolve doesn't re-mirror the rendition.
 	last: Option<hang::catalog::VideoConfig>,
 }
 
 impl Catalog {
-	/// Snapshot the timeline for the rendition named `name`, and hold `hint` for every publish.
-	pub(crate) fn new(reserved: &Reserved<impl CatalogExt>, name: &str, hint: VideoHint) -> crate::Result<Self> {
-		Ok(Self {
-			timeline: reserved.producer().timeline(name)?.section(),
-			hint,
-			last: None,
-		})
+	/// Hold `hint` for every publish.
+	pub(crate) fn new(hint: VideoHint) -> Self {
+		Self { hint, last: None }
 	}
 
 	/// The config the hint alone resolves to, for importers that publish the catalog before parsing
@@ -46,8 +39,8 @@ impl Catalog {
 		self.last.is_some()
 	}
 
-	/// Overlay the hint and timeline onto `config` and publish it to `rendition`, unless it matches
-	/// the last publish. A changed config just re-mirrors the rendition; there are no fixed tracks to
+	/// Overlay the hint onto `config` and publish it to `rendition`, unless it matches the last
+	/// publish. A changed config just re-mirrors the rendition; there are no fixed tracks to
 	/// reject a reconfiguration.
 	pub(crate) fn publish(
 		&mut self,
@@ -55,7 +48,6 @@ impl Catalog {
 		mut config: hang::catalog::VideoConfig,
 	) {
 		self.hint.apply(&mut config);
-		config.timeline = Some(self.timeline.clone());
 		if self.last.as_ref() == Some(&config) {
 			return;
 		}

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -34,11 +34,9 @@ impl<E: CatalogExt> Import<E> {
 		let rendition = reserved.video(track.name());
 		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
-			track: reserved.producer().media_producer(
-				track,
-				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Kind::Video,
-			)?,
+			track: reserved
+				.producer()
+				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
 			rendition,
 			catalog,
 		};

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -34,9 +34,11 @@ impl<E: CatalogExt> Import<E> {
 		let rendition = reserved.video(track.name());
 		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint)?;
 		let mut import = Self {
-			track: reserved
-				.producer()
-				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
+			track: reserved.producer().media_producer(
+				track,
+				crate::catalog::hang::Container::Legacy,
+				crate::timeline::Cadence::Boundary,
+			)?,
 			rendition,
 			catalog,
 		};

--- a/rs/moq-mux/src/codec/vp8/import.rs
+++ b/rs/moq-mux/src/codec/vp8/import.rs
@@ -32,12 +32,12 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> crate::Result<Self> {
 		let rendition = reserved.video(track.name());
-		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint)?;
+		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
 			track: reserved.producer().media_producer(
 				track,
 				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Cadence::Boundary,
+				crate::timeline::Kind::Video,
 			)?,
 			rendition,
 			catalog,

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -34,11 +34,9 @@ impl<E: CatalogExt> Import<E> {
 		let rendition = reserved.video(track.name());
 		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
-			track: reserved.producer().media_producer(
-				track,
-				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Kind::Video,
-			)?,
+			track: reserved
+				.producer()
+				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
 			rendition,
 			catalog,
 		};

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -34,9 +34,11 @@ impl<E: CatalogExt> Import<E> {
 		let rendition = reserved.video(track.name());
 		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint)?;
 		let mut import = Self {
-			track: reserved
-				.producer()
-				.media_producer(track, crate::catalog::hang::Container::Legacy)?,
+			track: reserved.producer().media_producer(
+				track,
+				crate::catalog::hang::Container::Legacy,
+				crate::timeline::Cadence::Boundary,
+			)?,
 			rendition,
 			catalog,
 		};

--- a/rs/moq-mux/src/codec/vp9/import.rs
+++ b/rs/moq-mux/src/codec/vp9/import.rs
@@ -32,12 +32,12 @@ impl<E: CatalogExt> Import<E> {
 		hint: crate::catalog::VideoHint,
 	) -> crate::Result<Self> {
 		let rendition = reserved.video(track.name());
-		let catalog = crate::codec::video::Catalog::new(&reserved, track.name(), hint)?;
+		let catalog = crate::codec::video::Catalog::new(hint);
 		let mut import = Self {
 			track: reserved.producer().media_producer(
 				track,
 				crate::catalog::hang::Container::Legacy,
-				crate::timeline::Cadence::Boundary,
+				crate::timeline::Kind::Video,
 			)?,
 			rendition,
 			catalog,

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -501,9 +501,11 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			VideoStream {
 				// Leading deltas before the first keyframe are skipped at the write
 				// site (the producer reports MissingKeyframe), so a mid-GOP join works.
-				track: self
-					.catalog
-					.media_producer(net_track, crate::catalog::hang::Container::Legacy)?,
+				track: self.catalog.media_producer(
+					net_track,
+					crate::catalog::hang::Container::Legacy,
+					crate::timeline::Cadence::Boundary,
+				)?,
 				config,
 			},
 		);
@@ -525,9 +527,11 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		self.audio.insert(
 			track_id,
 			AudioStream {
-				track: self
-					.catalog
-					.media_producer(net_track, crate::catalog::hang::Container::Legacy)?,
+				track: self.catalog.media_producer(
+					net_track,
+					crate::catalog::hang::Container::Legacy,
+					crate::timeline::Cadence::Aligned,
+				)?,
 				config,
 			},
 		);

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -501,11 +501,9 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			VideoStream {
 				// Leading deltas before the first keyframe are skipped at the write
 				// site (the producer reports MissingKeyframe), so a mid-GOP join works.
-				track: self.catalog.media_producer(
-					net_track,
-					crate::catalog::hang::Container::Legacy,
-					crate::timeline::Kind::Video,
-				)?,
+				track: self
+					.catalog
+					.media_producer(net_track, crate::catalog::hang::Container::Legacy)?,
 				config,
 			},
 		);
@@ -527,11 +525,9 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		self.audio.insert(
 			track_id,
 			AudioStream {
-				track: self.catalog.media_producer(
-					net_track,
-					crate::catalog::hang::Container::Legacy,
-					crate::timeline::Kind::Audio,
-				)?,
+				track: self
+					.catalog
+					.media_producer(net_track, crate::catalog::hang::Container::Legacy)?,
 				config,
 			},
 		);

--- a/rs/moq-mux/src/container/flv/import.rs
+++ b/rs/moq-mux/src/container/flv/import.rs
@@ -504,7 +504,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 				track: self.catalog.media_producer(
 					net_track,
 					crate::catalog::hang::Container::Legacy,
-					crate::timeline::Cadence::Boundary,
+					crate::timeline::Kind::Video,
 				)?,
 				config,
 			},
@@ -530,7 +530,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 				track: self.catalog.media_producer(
 					net_track,
 					crate::catalog::hang::Container::Legacy,
-					crate::timeline::Cadence::Aligned,
+					crate::timeline::Kind::Audio,
 				)?,
 				config,
 			},

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -59,12 +59,9 @@ pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
 	// here for the rest to arrive on the next call.
 	buffer: BytesMut,
 
-	// A segment boundary (styp or explicit `cut()`) waiting to land on the next keyframe
-	// fragment, where it becomes a `Segmenter::cut` at that fragment's timestamp.
+	// A segment boundary (a styp or an explicit `cut()`) waiting to land on the next keyframe
+	// fragment, where it becomes a timeline cut at that fragment's timestamp.
 	pending_cut: bool,
-
-	// Whether a styp atom marks a segment boundary (see `with_cut_on_boundary`).
-	cut_on_styp: bool,
 }
 
 #[derive(PartialEq, Debug)]
@@ -124,26 +121,16 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			broadcast,
 			buffer: BytesMut::new(),
 			pending_cut: false,
-			cut_on_styp: true,
 		}
 	}
 
-	/// Whether a `styp` atom marks a segment boundary (a CMAF segment on disk), cutting the
-	/// broadcast's [`Segmenter`](crate::timeline::Segmenter) at the next keyframe fragment.
-	/// On by default.
+	/// Declare that the next keyframe fragment starts a new segment, for callers that know the
+	/// source's segmentation out of band (e.g. an HLS import following its playlist).
 	///
-	/// Turn it off on every importer but one when several feed a single broadcast (e.g. an
-	/// HLS import with separate audio renditions): boundaries are broadcast-wide, so only
-	/// one source should declare them.
-	pub fn with_cut_on_boundary(mut self, cut: bool) -> Self {
-		self.cut_on_styp = cut;
-		self
-	}
-
-	/// Declare that the next keyframe fragment starts a new segment, for callers that know
-	/// the source's segmentation out of band (e.g. an HLS import following its playlist).
-	/// Equivalent to what a `styp` atom triggers when
-	/// [`with_cut_on_boundary`](Self::with_cut_on_boundary) is on.
+	/// A `styp` atom (a CMAF segment on disk) does this on its own, so an importer reading a
+	/// segmented file needs no help. Boundaries are broadcast-wide, but redundant ones cost
+	/// nothing: the timeline ignores a cut that would land inside its minimum segment duration,
+	/// so several renditions of one source may all declare the same boundaries.
 	pub fn cut(&mut self) {
 		self.pending_cut = true;
 	}
@@ -206,8 +193,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 				Any::Ftyp(_) => {}
 				// A styp opens a CMAF segment: the on-disk segmentation is the boundary
 				// hint, landing on the next keyframe fragment.
-				Any::Styp(_) if self.cut_on_styp => self.pending_cut = true,
-				Any::Styp(_) => {}
+				Any::Styp(_) => self.pending_cut = true,
 				Any::Moov(moov) => {
 					self.init(moov)?;
 				}
@@ -233,13 +219,17 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	}
 
 	fn init(&mut self, moov: Moov) -> Result<()> {
-		// Create the broadcast's timeline before locking the catalog below: creating it
-		// publishes the root section through that same lock.
-		self.catalog.timeline()?;
+		let timeline = self.catalog.timeline();
 
 		// Clone the catalog to avoid the borrow checker.
 		let mut catalog = self.catalog.clone();
 		let mut catalog = catalog.lock();
+
+		// The tracks below enroll in the timeline, so advertise it in the same catalog update
+		// rather than publishing a second snapshot for it.
+		if catalog.timeline.is_none() && !moov.trak.is_empty() {
+			catalog.timeline = Some(timeline.section());
+		}
 
 		for trak in &moov.trak {
 			let track_id = trak.tkhd.track_id;
@@ -276,11 +266,9 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 			// Enroll every track in the broadcast's timeline: passthrough writes groups by hand
 			// (no `container::Producer`), so the recorder is fed directly at each group open.
-			let timeline_kind = match kind {
-				TrackKind::Video => crate::timeline::Kind::Video,
-				TrackKind::Audio => crate::timeline::Kind::Audio,
-			};
-			let recorder = self.catalog.segmenter().track(track.name(), timeline_kind);
+			// Enrolling on the timeline directly rather than through `catalog::Producer::enroll`,
+			// because the catalog is already locked here; the root section is advertised below.
+			let recorder = timeline.track(track.name())?;
 
 			let detect_bitrate = match kind {
 				TrackKind::Video => {
@@ -815,11 +803,11 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 				// audio-only import the audio fragment is the best anchor there is.
 				if self.pending_cut && (track.kind == TrackKind::Video || !has_video) {
 					self.pending_cut = false;
-					self.catalog.segmenter().cut(timestamp);
+					self.catalog.timeline().cut(timestamp)?;
 				}
 
 				// A keyframe fragment just opened a new group; report it so the broadcast's
-				// timeline can index the segment (the segmenter absorbs publish failures).
+				// timeline can index the segment (the timeline absorbs publish failures).
 				if let Some(recorder) = track.recorder.as_mut() {
 					recorder.record(g.sequence, timestamp, true);
 				}

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -58,6 +58,13 @@ pub struct Import<E: crate::catalog::hang::CatalogExt = ()> {
 	// Bytes carried across calls: a partial atom at the tail of one `decode` waits
 	// here for the rest to arrive on the next call.
 	buffer: BytesMut,
+
+	// A segment boundary (styp or explicit `cut()`) waiting to land on the next keyframe
+	// fragment, where it becomes a `Segmenter::cut` at that fragment's timestamp.
+	pending_cut: bool,
+
+	// Whether a styp atom marks a segment boundary (see `with_cut_on_boundary`).
+	cut_on_styp: bool,
 }
 
 #[derive(PartialEq, Debug)]
@@ -72,11 +79,9 @@ struct Fmp4Track {
 	track: moq_net::track::Producer,
 	group: Option<moq_net::group::Producer>,
 
-	// Indexes this track's group opens into its `<name>.timeline.z` timeline, advertised in the
-	// rendition's config. Passthrough writes groups by hand (no `container::Producer`), so the
-	// recorder is fed directly at each keyframe rather than through `with_recorder`.
-	// `None` once recording has failed, matching `container::Producer`: the timeline is an
-	// optional sidecar, so losing it must not take the media down with it.
+	// Reports this track's group opens into the broadcast's timeline. Passthrough writes
+	// groups by hand (no `container::Producer`), so the recorder is fed directly at each
+	// keyframe fragment rather than through `with_recorder`.
 	recorder: Option<crate::timeline::Recorder>,
 
 	// The minimum buffer required for the track.
@@ -118,7 +123,29 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			moof_size: 0,
 			broadcast,
 			buffer: BytesMut::new(),
+			pending_cut: false,
+			cut_on_styp: true,
 		}
+	}
+
+	/// Whether a `styp` atom marks a segment boundary (a CMAF segment on disk), cutting the
+	/// broadcast's [`Segmenter`](crate::timeline::Segmenter) at the next keyframe fragment.
+	/// On by default.
+	///
+	/// Turn it off on every importer but one when several feed a single broadcast (e.g. an
+	/// HLS import with separate audio renditions): boundaries are broadcast-wide, so only
+	/// one source should declare them.
+	pub fn with_cut_on_boundary(mut self, cut: bool) -> Self {
+		self.cut_on_styp = cut;
+		self
+	}
+
+	/// Declare that the next keyframe fragment starts a new segment, for callers that know
+	/// the source's segmentation out of band (e.g. an HLS import following its playlist).
+	/// Equivalent to what a `styp` atom triggers when
+	/// [`with_cut_on_boundary`](Self::with_cut_on_boundary) is on.
+	pub fn cut(&mut self) {
+		self.pending_cut = true;
 	}
 
 	/// Restrict which track roles are published.
@@ -176,7 +203,11 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 		for (atom, start, size) in parsed {
 			match atom {
-				Any::Ftyp(_) | Any::Styp(_) => {}
+				Any::Ftyp(_) => {}
+				// A styp opens a CMAF segment: the on-disk segmentation is the boundary
+				// hint, landing on the next keyframe fragment.
+				Any::Styp(_) if self.cut_on_styp => self.pending_cut = true,
+				Any::Styp(_) => {}
 				Any::Moov(moov) => {
 					self.init(moov)?;
 				}
@@ -202,6 +233,10 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 	}
 
 	fn init(&mut self, moov: Moov) -> Result<()> {
+		// Create the broadcast's timeline before locking the catalog below: creating it
+		// publishes the root section through that same lock.
+		self.catalog.timeline()?;
+
 		// Clone the catalog to avoid the borrow checker.
 		let mut catalog = self.catalog.clone();
 		let mut catalog = catalog.lock();
@@ -239,27 +274,24 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 				moq_net::track::Info::default().with_timescale(timescale),
 			)?;
 
-			// Each track indexes its own group opens: audio and video group boundaries differ, so a
-			// per-track timeline (the 1:1 default) is correct here, not a shared one. The cadence
-			// keeps their segment numbers aligned: video groups open segments, audio packs into them.
-			let timeline = self.catalog.timeline(track.name())?;
-			let cadence = match kind {
-				TrackKind::Video => crate::timeline::Cadence::Boundary,
-				TrackKind::Audio => crate::timeline::Cadence::Aligned,
+			// Enroll every track in the broadcast's timeline: passthrough writes groups by hand
+			// (no `container::Producer`), so the recorder is fed directly at each group open.
+			let timeline_kind = match kind {
+				TrackKind::Video => crate::timeline::Kind::Video,
+				TrackKind::Audio => crate::timeline::Kind::Audio,
 			};
+			let recorder = self.catalog.segmenter().track(track.name(), timeline_kind);
 
 			let detect_bitrate = match kind {
 				TrackKind::Video => {
-					let mut config = self.init_video(trak, &moov)?;
+					let config = self.init_video(trak, &moov)?;
 					let detect = config.bitrate.is_none();
-					config.timeline = Some(timeline.section());
 					catalog.video.renditions.insert(track.name().to_string(), config);
 					detect
 				}
 				TrackKind::Audio => {
-					let mut config = self.init_audio(trak, &moov)?;
+					let config = self.init_audio(trak, &moov)?;
 					let detect = config.bitrate.is_none();
-					config.timeline = Some(timeline.section());
 					catalog.audio.renditions.insert(track.name().to_string(), config);
 					detect
 				}
@@ -271,7 +303,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 					kind,
 					track,
 					group: None,
-					recorder: Some(timeline.recorder(cadence)),
+					recorder: Some(recorder),
 					jitter: None,
 					last_timestamp: None,
 					min_duration: None,
@@ -533,6 +565,9 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 	// Extract all frames out of an mdat atom using CMAF passthrough.
 	fn extract(&mut self, mdat: Mdat, mdat_raw: &[u8]) -> Result<()> {
+		// A pending cut waits for a video keyframe; only an import with no video at all may
+		// anchor a boundary on another track's fragment.
+		let has_video = self.tracks.values().any(|t| t.kind == TrackKind::Video);
 		let moov = self.moov.as_ref().ok_or(Error::NoMoov)?;
 		let moof = self.moof.take().ok_or(Error::NoMoof)?;
 		let moof_size = self.moof_size;
@@ -774,19 +809,19 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			// consumer still drives playback from the fragment's internal timing.
 			let timestamp = min_timestamp.ok_or(Error::MissingTrun)?;
 
-			// A keyframe fragment just opened a new group; index it in the track's timeline (mapped
-			// onto the aligned segments per the recorder's cadence) so a playlist/seek/VOD reader
-			// can map time to group.
-			// The timeline is an optional sidecar (consumers extrapolate across gaps), so a recording
-			// failure must NOT abort the passthrough. Drop the recorder and carry on.
 			if contains_keyframe {
-				let timeline_err = match track.recorder.as_mut() {
-					Some(recorder) => recorder.record(g.sequence, timestamp).err(),
-					None => None,
-				};
-				if let Some(err) = timeline_err {
-					tracing::warn!(?err, "timeline recording failed; dropping the timeline for this track");
-					track.recorder = None;
+				// A pending segment boundary (a styp, or an explicit `cut()`) lands on the next
+				// keyframe fragment: for video that is where a segment can start, and for an
+				// audio-only import the audio fragment is the best anchor there is.
+				if self.pending_cut && (track.kind == TrackKind::Video || !has_video) {
+					self.pending_cut = false;
+					self.catalog.segmenter().cut(timestamp);
+				}
+
+				// A keyframe fragment just opened a new group; report it so the broadcast's
+				// timeline can index the segment (the segmenter absorbs publish failures).
+				if let Some(recorder) = track.recorder.as_mut() {
+					recorder.record(g.sequence, timestamp, true);
 				}
 			}
 

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -240,8 +240,13 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			)?;
 
 			// Each track indexes its own group opens: audio and video group boundaries differ, so a
-			// per-track timeline (the 1:1 default) is correct here, not a shared one.
+			// per-track timeline (the 1:1 default) is correct here, not a shared one. The cadence
+			// keeps their segment numbers aligned: video groups open segments, audio packs into them.
 			let timeline = self.catalog.timeline(track.name())?;
+			let cadence = match kind {
+				TrackKind::Video => crate::timeline::Cadence::Boundary,
+				TrackKind::Audio => crate::timeline::Cadence::Aligned,
+			};
 
 			let detect_bitrate = match kind {
 				TrackKind::Video => {
@@ -266,7 +271,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 					kind,
 					track,
 					group: None,
-					recorder: Some(timeline.recorder()),
+					recorder: Some(timeline.recorder(cadence)),
 					jitter: None,
 					last_timestamp: None,
 					min_duration: None,
@@ -769,8 +774,9 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			// consumer still drives playback from the fragment's internal timing.
 			let timestamp = min_timestamp.ok_or(Error::MissingTrun)?;
 
-			// A keyframe fragment just opened a new group; index it in the track's timeline (throttled
-			// to the recorder's granularity) so a playlist/seek/VOD reader can map time to group.
+			// A keyframe fragment just opened a new group; index it in the track's timeline (mapped
+			// onto the aligned segments per the recorder's cadence) so a playlist/seek/VOD reader
+			// can map time to group.
 			// The timeline is an optional sidecar (consumers extrapolate across gaps), so a recording
 			// failure must NOT abort the passthrough. Drop the recorder and carry on.
 			if contains_keyframe {

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -844,6 +844,16 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 			track.estimator.write(timestamp, fragment_len);
 
+			// Report how far this fragment presents. Every group but the last is bounded by the
+			// next one's open, so this is what keeps the final segment from being published a
+			// group short. Same timescale throughout, so the add can't mismatch scales.
+			if let Some(recorder) = track.recorder.as_mut()
+				&& let Some(max) = max_timestamp
+			{
+				let end = track.min_duration.and_then(|d| max.checked_add(d).ok()).unwrap_or(max);
+				recorder.end(end);
+			}
+
 			if let (Some(min), Some(max), Some(min_duration)) = (min_timestamp, max_timestamp, track.min_duration) {
 				// All three share the track timescale (min/max are this fragment's frame
 				// timestamps, min_duration is derived from them).

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -329,11 +329,11 @@ async fn test_msf_catalog_roundtrip() {
 }
 
 /// Passthrough writes groups by hand (no `container::Producer`), so the timeline recorder is fed
-/// directly. This guards that every rendition advertises a `<name>.timeline.z` section and that its
-/// group opens are actually recorded, the index the VOD/playlist export reads. Regression for the
-/// missing-timeline break that skipped VOD renditions.
+/// directly. This guards that the import advertises the broadcast's timeline at the catalog root
+/// and actually records both renditions' group opens into it, the index the VOD/playlist export
+/// reads. Regression for the missing-timeline break that skipped VOD renditions.
 #[tokio::test]
-async fn import_populates_per_rendition_timeline() {
+async fn import_populates_the_broadcast_timeline() {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let consumer = broadcast.consume();
 	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
@@ -346,43 +346,33 @@ async fn import_populates_per_rendition_timeline() {
 	fmp4.finish().unwrap();
 
 	let snapshot = catalog.snapshot();
+	assert_eq!(snapshot.video.renditions.len(), 1, "bbb has one video rendition");
+	assert_eq!(snapshot.audio.renditions.len(), 1, "bbb has one audio rendition");
+	let video_name = snapshot.video.renditions.keys().next().unwrap().clone();
+	let audio_name = snapshot.audio.renditions.keys().next().unwrap().clone();
 
-	// Every rendition (one video + one audio) advertises a timeline named after its media track.
-	let mut sections = Vec::new();
-	for (name, config) in &snapshot.video.renditions {
-		let section = config
-			.timeline
-			.clone()
-			.unwrap_or_else(|| panic!("video {name} advertises no timeline"));
-		assert_eq!(section.track, format!("{name}.timeline.z"));
-		sections.push(section);
-	}
-	for (name, config) in &snapshot.audio.renditions {
-		let section = config
-			.timeline
-			.clone()
-			.unwrap_or_else(|| panic!("audio {name} advertises no timeline"));
-		assert_eq!(section.track, format!("{name}.timeline.z"));
-		sections.push(section);
-	}
-	assert_eq!(sections.len(), 2, "bbb has one video and one audio rendition");
+	// The one timeline is advertised at the catalog root, named by convention.
+	let section = snapshot.timeline.clone().expect("the import advertises a timeline");
+	assert_eq!(section.track, hang::timeline::DEFAULT_NAME);
 
-	// Subscribe while the producer is alive, then finish so each timeline group closes and the reader
-	// terminates rather than blocking; the first recorded group (sequence 0) must be present.
-	let mut timelines: Vec<crate::timeline::Consumer> = Vec::new();
-	for section in sections {
-		timelines.push(crate::timeline::Consumer::subscribe(&consumer, &section).await.unwrap());
-	}
+	// Subscribe while the producer is alive, then finish so the timeline group closes and the
+	// reader terminates rather than blocking.
+	let mut timeline = crate::timeline::Consumer::<()>::subscribe(&consumer, &section)
+		.await
+		.unwrap();
 	catalog.finish().unwrap();
 
-	for mut timeline in timelines {
-		let first = timeline
-			.next()
-			.await
-			.unwrap()
-			.expect("a group open should be recorded in the timeline");
-		assert_eq!(first.group, 0, "the first recorded group is sequence 0");
-	}
+	// The first record indexes both renditions from their first group (sequence 0).
+	let first = timeline
+		.next()
+		.await
+		.unwrap()
+		.expect("a segment should be recorded in the timeline");
+	assert_eq!(first.segment, 0);
+	let video_ranges = first.tracks.get(&video_name).expect("video is indexed");
+	assert_eq!(video_ranges[0].start, 0, "the first video group is sequence 0");
+	let audio_ranges = first.tracks.get(&audio_name).expect("audio is indexed");
+	assert_eq!(audio_ranges[0].start, 0, "the first audio group is sequence 0");
 }
 
 // ---- Sample-duration handling in decode() ----

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -279,8 +279,8 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		// timeline track can collide), and a rendition published for a track we then fail
 		// to produce would be advertised to consumers but never served.
 		let cadence = match kind {
-			TrackKind::Video => crate::timeline::Cadence::Boundary,
-			TrackKind::Audio => crate::timeline::Cadence::Aligned,
+			TrackKind::Video => crate::timeline::Kind::Video,
+			TrackKind::Audio => crate::timeline::Kind::Audio,
 		};
 		let media = self
 			.catalog

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -278,13 +278,9 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		// Build the media producer before publishing the rendition. It is fallible (its
 		// timeline track can collide), and a rendition published for a track we then fail
 		// to produce would be advertised to consumers but never served.
-		let cadence = match kind {
-			TrackKind::Video => crate::timeline::Kind::Video,
-			TrackKind::Audio => crate::timeline::Kind::Audio,
-		};
 		let media = self
 			.catalog
-			.media_producer(track, crate::catalog::hang::Container::Legacy, cadence)?;
+			.media_producer(track, crate::catalog::hang::Container::Legacy)?;
 
 		let mut catalog = self.catalog.clone();
 		let mut catalog = catalog.lock();

--- a/rs/moq-mux/src/container/mkv/import.rs
+++ b/rs/moq-mux/src/container/mkv/import.rs
@@ -278,9 +278,13 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 		// Build the media producer before publishing the rendition. It is fallible (its
 		// timeline track can collide), and a rendition published for a track we then fail
 		// to produce would be advertised to consumers but never served.
+		let cadence = match kind {
+			TrackKind::Video => crate::timeline::Cadence::Boundary,
+			TrackKind::Audio => crate::timeline::Cadence::Aligned,
+		};
 		let media = self
 			.catalog
-			.media_producer(track, crate::catalog::hang::Container::Legacy)?;
+			.media_producer(track, crate::catalog::hang::Container::Legacy, cadence)?;
 
 		let mut catalog = self.catalog.clone();
 		let mut catalog = catalog.lock();

--- a/rs/moq-mux/src/container/mkv/import_test.rs
+++ b/rs/moq-mux/src/container/mkv/import_test.rs
@@ -396,10 +396,10 @@ fn rendition_is_not_published_when_the_media_producer_fails() {
 	let mut broadcast = moq_net::broadcast::Info::new().produce();
 	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 
-	// Squat the timeline track the first video rendition will want, so building its media
-	// producer fails. `unique_name` is deterministic, so this is the name it will pick. The
-	// handle must stay alive: the broadcast tracks names weakly, so dropping it frees the name.
-	let _squat = broadcast.create_track("0.mkv-v.timeline.z", None).unwrap();
+	// Squat the broadcast's timeline track, so building the media producer (which creates it
+	// on first use) fails. The handle must stay alive: the broadcast tracks names weakly, so
+	// dropping it frees the name.
+	let _squat = broadcast.create_track(hang::timeline::DEFAULT_NAME, None).unwrap();
 
 	let mut mkv = crate::container::mkv::Import::new(broadcast, catalog.reserve());
 	let buf = bytes::BytesMut::from(&data[..]);

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -111,14 +111,12 @@ impl<C: Container> Producer<C> {
 		self
 	}
 
-	/// Record each group open (sequence + keyframe timestamp) through `recorder`, so consumers can
-	/// index the media without downloading it.
+	/// Report each group open (sequence, timestamp, keyframe) through `recorder`, enrolling
+	/// this track in the broadcast's timeline so consumers can index the media without
+	/// downloading it.
 	///
-	/// Mint the recorder from a [`timeline::Producer`](crate::timeline::Producer) (see
-	/// [`catalog::Producer::timeline`](crate::catalog::Producer::timeline)). The record carries no
-	/// track id, so wire one recorder per timeline; a set of aligned renditions shares a timeline by
-	/// recording only the source and advertising the same section on the rest.
-	/// [`media_producer`](crate::catalog::Producer::media_producer) wires the 1:1 default for you.
+	/// Mint the recorder from the broadcast's [`Segmenter`](crate::timeline::Segmenter);
+	/// [`media_producer`](crate::catalog::Producer::media_producer) wires it for you.
 	pub fn with_recorder(mut self, recorder: crate::timeline::Recorder) -> Self {
 		self.recorder = Some(recorder);
 		self
@@ -156,16 +154,11 @@ impl<C: Container> Producer<C> {
 				None => self.inner.append_group()?,
 			};
 
-			// Index the group the moment it opens: its start is this keyframe's timestamp. The
-			// timeline is an optional sidecar (consumers tolerate gaps by extrapolating), so a
-			// recording failure must NOT abort the media write. Drop the recorder and carry on.
-			let timeline_err = match self.recorder.as_mut() {
-				Some(recorder) => recorder.record(group.sequence, frame.timestamp).err(),
-				None => None,
-			};
-			if let Some(err) = timeline_err {
-				tracing::warn!(?err, "timeline recording failed; dropping the timeline for this track");
-				self.recorder = None;
+			// Report the group the moment it opens: its start is this frame's timestamp. The
+			// segmenter absorbs publish failures itself (the timeline is an optional sidecar),
+			// so reporting can't abort the media write.
+			if let Some(recorder) = self.recorder.as_mut() {
+				recorder.record(group.sequence, frame.timestamp, frame.keyframe);
 			}
 
 			self.group = Some(group);

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -49,6 +49,11 @@ pub struct Producer<C: Container> {
 	/// timeline track, when the producer was built with one.
 	recorder: Option<crate::timeline::Recorder>,
 
+	/// The furthest presentation point written, i.e. `max(timestamp + duration)`. Reported to
+	/// `recorder` on each [`cut`](Self::cut), since the last group of a track has no successor
+	/// to bound it and its segment would otherwise be published a group short.
+	end: Option<moq_net::Timestamp>,
+
 	/// Measures the jitter and bitrate of what gets written, for the catalog. Always on: it costs
 	/// two counters, and a caller who doesn't publish a rendition simply never reads it.
 	estimator: crate::catalog::Estimator,
@@ -69,6 +74,7 @@ impl<C: Container> Producer<C> {
 			latency: std::time::Duration::ZERO,
 			pending_sequence: None,
 			recorder: None,
+			end: None,
 			estimator: crate::catalog::Estimator::new(),
 		}
 	}
@@ -167,17 +173,19 @@ impl<C: Container> Producer<C> {
 		// Buffer or write the frame.
 		if self.latency.is_zero() {
 			let group = self.group.as_mut().unwrap();
-			let (timestamp, bytes) = (frame.timestamp, frame.payload.len());
+			let (timestamp, duration, bytes) = (frame.timestamp, frame.duration, frame.payload.len());
 			self.container.write(group, &[frame])?;
 
 			// Only what the container accepted is measured. A rejected frame (too large for the
 			// group, a timestamp that won't convert) leaves the producer usable, and the estimate's
 			// extrema never fall, so counting one would inflate the catalog for good.
 			self.estimator.write(timestamp, bytes);
+			self.observe_end(timestamp, duration);
 		} else {
 			// Buffered frames are measured on the way in instead. The flush that eventually writes
 			// them takes the track down with it when it fails, so there is nothing to unwind.
 			self.estimator.write(frame.timestamp, frame.payload.len());
+			self.observe_end(frame.timestamp, frame.duration);
 			self.buffer.push(frame);
 
 			// Flush if the buffered span has reached the latency budget. Compute
@@ -206,11 +214,39 @@ impl<C: Container> Producer<C> {
 		// Before the flush, which can fail: an unbounded cut leaves the measurement open to fold
 		// into the next group anyway, so cutting often costs the catalog nothing.
 		self.estimator.cut(end);
+
+		// Tell the timeline where this group's content stops: the caller's bound when it has
+		// one, otherwise the furthest point we wrote. Only the last group of a track actually
+		// needs this (every earlier one is bounded by its successor's open), but reporting it
+		// on every cut keeps the segmenter's frontier honest as we go.
+		if let Some(recorder) = self.recorder.as_mut()
+			&& let Some(end) = end.max(self.end)
+		{
+			recorder.end(end);
+		}
+
 		self.flush(end)?;
 		if let Some(mut group) = self.group.take() {
 			group.finish()?;
 		}
 		Ok(())
+	}
+
+	/// Raise the furthest presentation point written, for [`cut`](Self::cut) to report.
+	fn observe_end(&mut self, timestamp: moq_net::Timestamp, duration: Option<moq_net::Timestamp>) {
+		if self.recorder.is_none() {
+			return;
+		}
+		// Timestamp and duration can be at different scales, so add them in micros; the
+		// sub-microsecond rounding that costs is far below a segment boundary.
+		let micros = timestamp.as_micros() + duration.map(|d| d.as_micros()).unwrap_or(0);
+		let Ok(micros) = u64::try_from(micros) else { return };
+		let Ok(end) = moq_net::Timestamp::from_micros(micros) else {
+			return;
+		};
+		if self.end.is_none_or(|prev| end > prev) {
+			self.end = Some(end);
+		}
 	}
 
 	#[doc(hidden)]

--- a/rs/moq-mux/src/container/producer.rs
+++ b/rs/moq-mux/src/container/producer.rs
@@ -121,7 +121,7 @@ impl<C: Container> Producer<C> {
 	/// this track in the broadcast's timeline so consumers can index the media without
 	/// downloading it.
 	///
-	/// Mint the recorder from the broadcast's [`Segmenter`](crate::timeline::Segmenter);
+	/// Mint the recorder from the broadcast's [`timeline::Producer`](crate::timeline::Producer);
 	/// [`media_producer`](crate::catalog::Producer::media_producer) wires it for you.
 	pub fn with_recorder(mut self, recorder: crate::timeline::Recorder) -> Self {
 		self.recorder = Some(recorder);
@@ -161,7 +161,7 @@ impl<C: Container> Producer<C> {
 			};
 
 			// Report the group the moment it opens: its start is this frame's timestamp. The
-			// segmenter absorbs publish failures itself (the timeline is an optional sidecar),
+			// timeline absorbs publish failures itself (it is an optional sidecar),
 			// so reporting can't abort the media write.
 			if let Some(recorder) = self.recorder.as_mut() {
 				recorder.record(group.sequence, frame.timestamp, frame.keyframe);
@@ -218,7 +218,7 @@ impl<C: Container> Producer<C> {
 		// Tell the timeline where this group's content stops: the caller's bound when it has
 		// one, otherwise the furthest point we wrote. Only the last group of a track actually
 		// needs this (every earlier one is bounded by its successor's open), but reporting it
-		// on every cut keeps the segmenter's frontier honest as we go.
+		// on every cut keeps the timeline's frontier honest as we go.
 		if let Some(recorder) = self.recorder.as_mut()
 			&& let Some(end) = end.max(self.end)
 		{

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -730,7 +730,11 @@ fn register_verbatim<E: catalog::Catalog>(
 	// timeline track can collide), and the `VerbatimEntry` that removes this catalog
 	// entry on drop only exists once this function returns successfully, so an entry
 	// published first would be stranded.
-	let media = catalog.media_producer(track, crate::catalog::hang::Container::Legacy)?;
+	let media = catalog.media_producer(
+		track,
+		crate::catalog::hang::Container::Legacy,
+		crate::timeline::Cadence::Boundary,
+	)?;
 
 	let mut guard = catalog.lock();
 	let Some(mpegts) = guard.mpegts_mut() else {

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -730,11 +730,7 @@ fn register_verbatim<E: catalog::Catalog>(
 	// timeline track can collide), and the `VerbatimEntry` that removes this catalog
 	// entry on drop only exists once this function returns successfully, so an entry
 	// published first would be stranded.
-	let media = catalog.media_producer(
-		track,
-		crate::catalog::hang::Container::Legacy,
-		crate::timeline::Kind::Video,
-	)?;
+	let media = catalog.media_producer(track, crate::catalog::hang::Container::Legacy)?;
 
 	let mut guard = catalog.lock();
 	let Some(mpegts) = guard.mpegts_mut() else {

--- a/rs/moq-mux/src/container/ts/import.rs
+++ b/rs/moq-mux/src/container/ts/import.rs
@@ -733,7 +733,7 @@ fn register_verbatim<E: catalog::Catalog>(
 	let media = catalog.media_producer(
 		track,
 		crate::catalog::hang::Container::Legacy,
-		crate::timeline::Cadence::Boundary,
+		crate::timeline::Kind::Video,
 	)?;
 
 	let mut guard = catalog.lock();

--- a/rs/moq-mux/src/error.rs
+++ b/rs/moq-mux/src/error.rs
@@ -113,6 +113,11 @@ pub enum Error {
 		composition_time_ms: i32,
 	},
 
+	/// The timeline's declared segment-duration bound was changed after the catalog
+	/// advertised it; set it before the first media track enrolls.
+	#[error("the timeline is already advertised in the catalog")]
+	TimelineAdvertised,
+
 	/// Error from a muxer/demuxer that reports via `anyhow` (currently MPEG-TS).
 	/// Boxed in an `Arc` so the enum stays `Clone` (`anyhow::Error` is not).
 	#[error("{0}")]

--- a/rs/moq-mux/src/error.rs
+++ b/rs/moq-mux/src/error.rs
@@ -113,10 +113,18 @@ pub enum Error {
 		composition_time_ms: i32,
 	},
 
-	/// The timeline's declared segment-duration bound was changed after the catalog
-	/// advertised it; set it before the first media track enrolls.
-	#[error("the timeline is already advertised in the catalog")]
-	TimelineAdvertised,
+	/// A segment ran past the [`duration_max`](crate::timeline::Config::duration_max) the
+	/// catalog advertised, so the timeline stopped publishing rather than contradict it. The
+	/// publisher declared a bound its media can't honor.
+	#[error("timeline segment {segment} lasted {duration:?}, over the declared maximum {duration_max:?}")]
+	TimelineOverrun {
+		/// The segment that broke the bound.
+		segment: u64,
+		/// How long it actually ran.
+		duration: std::time::Duration,
+		/// The bound the catalog advertised.
+		duration_max: std::time::Duration,
+	},
 
 	/// Error from a muxer/demuxer that reports via `anyhow` (currently MPEG-TS).
 	/// Boxed in an `Arc` so the enum stays `Clone` (`anyhow::Error` is not).

--- a/rs/moq-mux/src/lib.rs
+++ b/rs/moq-mux/src/lib.rs
@@ -16,9 +16,10 @@
 //!   a format string. It picks the right concrete importer for you.
 //! - [`select`] picks which renditions of a broadcast to keep, on either
 //!   the import or the consume side.
-//! - [`timeline`](mod@timeline) publishes the broadcast's group index: one
-//!   record per media group mapping it to its start timestamp, so consumers
-//!   can seek or build playlists without downloading media.
+//! - [`timeline`](mod@timeline) publishes each track's segment index: one
+//!   record per aligned segment (one or more groups) mapping it to its
+//!   starting group and timestamp, so consumers can seek or build HLS/DASH
+//!   playlists without downloading media.
 
 pub mod catalog;
 mod clock;

--- a/rs/moq-mux/src/lib.rs
+++ b/rs/moq-mux/src/lib.rs
@@ -16,10 +16,10 @@
 //!   a format string. It picks the right concrete importer for you.
 //! - [`select`] picks which renditions of a broadcast to keep, on either
 //!   the import or the consume side.
-//! - [`timeline`](mod@timeline) publishes each track's segment index: one
-//!   record per aligned segment (one or more groups) mapping it to its
-//!   starting group and timestamp, so consumers can seek or build HLS/DASH
-//!   playlists without downloading media.
+//! - [`timeline`](mod@timeline) publishes the broadcast's segment index: one
+//!   record per aligned segment, mapping a span of content time to the group
+//!   ranges that carry it on each track, so consumers can seek or build
+//!   HLS/DASH playlists without downloading media.
 
 pub mod catalog;
 mod clock;

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -8,25 +8,19 @@
 //!
 //! ## Facts up, policy down
 //!
-//! The write side splits into facts and policy, meeting in the shared [`Segmenter`]:
+//! The write side splits into facts and policy, meeting in the shared [`Producer`]:
 //!
-//! - **Tracks report facts.** Each media track enrolls via [`Segmenter::track`], declaring its
-//!   [`Kind`], and its [`Recorder`] reports every group open (sequence, timestamp, keyframe).
-//!   A container import never decides where segments fall; it only states what it published.
-//! - **The owner sets policy.** Segment boundaries come from [`Segmenter::cut`] when the
-//!   application knows them (an HLS import following the source playlist, a CMAF file's
-//!   on-disk segments, an encoder that places its own keyframes). When nobody cuts, the
-//!   segmenter auto-cuts on the driver track's keyframes, keeping every segment within the
-//!   `duration_max` bound declared at [`Segmenter::new`] (see there for the exact rule). The
-//!   driver is the first enrolled video track (video keyframes are where a segment must
-//!   start), or the first enrolled track of any kind when the broadcast has no video. The
-//!   first explicit cut disables auto-cut: the application has taken control, and its cuts
-//!   are expected to honor the same declared bound.
+//! - **Tracks report facts.** Each media track enrolls via [`Producer::track`], and its
+//!   [`Recorder`] reports every group open (sequence, timestamp, keyframe) plus where its
+//!   content ends. A container import never decides where segments fall; it only states what
+//!   it published.
+//! - **The timeline sets policy.** A segment ends at the first group boundary that gives it at
+//!   least [`Config::duration_min`] on every enrolled track (see [`Config`] for the exact
+//!   rule). An application that knows its own boundaries overrides that with [`Producer::cut`].
 //! - **Records flush on completeness.** A segment's record is published only once every
-//!   enrolled track has reported a group at or past the segment's end boundary (or closed),
-//!   proving the segment's group ranges are final on every track. The record is then
-//!   self-contained and immediately servable; a future cut (e.g. pre-registered from a source
-//!   playlist) just waits for the media to catch up.
+//!   enrolled track has reported a group at or past the segment's end (or closed), proving the
+//!   segment's group ranges are final on every track. The record is then self-contained and
+//!   immediately servable.
 //!
 //! Alignment falls out of construction: every track maps its groups onto the same boundary
 //! list, so segment N covers the same span of content time on every track, which is what HLS
@@ -34,16 +28,16 @@
 //!
 //! ## Wiring
 //!
-//! [`catalog::Producer`](crate::catalog::Producer) owns the broadcast's segmenter (the
-//! catalog is what owns the broadcast's shape) and wires all of this up:
-//! [`media_producer`](crate::catalog::Producer::media_producer) enrolls the track and
-//! creates the timeline track on first use, advertising it in the catalog's root
-//! [`hang::catalog::Timeline`] section. A broadcast that never enrolls a track
-//! publishes no timeline at all: segmentation is opt-in per broadcast, never per track.
+//! [`catalog::Producer`](crate::catalog::Producer) owns the broadcast's timeline (the catalog
+//! is what owns the broadcast's shape) and wires all of this up:
+//! [`media_producer`](crate::catalog::Producer::media_producer) enrolls the track, which
+//! creates the timeline track on first use and advertises it in the catalog's root
+//! [`hang::catalog::Timeline`] section. A broadcast that never enrolls a track publishes no
+//! timeline at all: segmentation is opt-in per broadcast, never per track.
 //!
 //! On the read side, [`Consumer::subscribe`] reads the timeline straight from the catalog's
-//! [`hang::catalog::Timeline`] section (so the track name and timescale can't be
-//! mismatched) and yields decoded [`Entry`]s. On the wire the track is a DEFLATE-compressed
+//! [`hang::catalog::Timeline`] section (so the track name and timescale can't be mismatched)
+//! and yields decoded [`Entry`]s. On the wire the track is a DEFLATE-compressed
 //! [`moq_json::stream`] (a single group, one record per frame; see [`hang::timeline`] for the
 //! record schema).
 
@@ -57,217 +51,225 @@ use hang::timeline::{DEFAULT_NAME, Range, Record, RecordExt};
 
 use moq_net::{Timescale, Timestamp};
 
-/// The conventional [`Segmenter`] segment-duration bound (2 seconds), for callers with no
-/// opinion of their own.
-pub const DEFAULT_DURATION_MAX: Timestamp = Timestamp::new_const(2, Timescale::SECOND);
+/// The conventional [`Config::duration_min`] (1 second), for callers with no opinion.
+pub const DEFAULT_DURATION_MIN: Duration = Duration::from_secs(1);
 
-/// What a media track carries, declared when it enrolls via [`Segmenter::track`].
-///
-/// The segmenter prefers a video track as the auto-cut driver, since segment boundaries must
-/// land on video keyframes to keep every rendition independently decodable.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Kind {
-	/// Video: groups open on keyframes, the natural segment boundaries.
-	Video,
-	/// Audio (or any short-group track): groups pack into whatever segments exist.
-	Audio,
+/// How a [`Producer`] paces its segments.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct Config {
+	/// The shortest a segment may be.
+	///
+	/// A segment ends at the first point that is a group boundary on every enrolled track and
+	/// at least this far past the segment's start, so the track with the coarsest groups paces
+	/// the broadcast. A 2 second GOP against a 1 second minimum yields 2 second segments; a
+	/// real-time encoder with a 10 minute GOP yields one 10 minute segment, because there is
+	/// nowhere else a segment could start and stay decodable.
+	///
+	/// A floor rather than a target on purpose: a floor is always satisfiable (wait longer),
+	/// while a ceiling is not (a single group longer than it can't be split).
+	pub duration_min: Duration,
+
+	/// The longest a segment may be, advertised in the catalog when set.
+	///
+	/// Set it only when the publisher can actually promise one, i.e. it controls the encoder's
+	/// keyframe cadence. Consumers that need a bound up front use it (an HLS exporter's
+	/// `EXT-X-TARGETDURATION`), so it is a contract rather than a hint: a segment that would
+	/// exceed it fails the timeline instead of publishing a record that contradicts the
+	/// catalog. Leave it `None` when the media decides, which is the common case for real-time
+	/// and for anything importing a source it doesn't control.
+	pub duration_max: Option<Duration>,
+}
+
+impl Default for Config {
+	fn default() -> Self {
+		Self {
+			duration_min: DEFAULT_DURATION_MIN,
+			duration_max: None,
+		}
+	}
 }
 
 /// One enrolled track's report state.
+#[derive(Default)]
 struct TrackState {
-	kind: Kind,
 	/// Group opens reported and not yet flushed into a record: (sequence, pts, keyframe).
 	pending: VecDeque<(u64, Timestamp, bool)>,
 	/// The newest reported timestamp: everything earlier is known, which is what lets a
-	/// segment ending at or before it flush. Advanced by a group open (the group starts
-	/// there) and by [`Recorder::end`] (the content stops there).
+	/// segment ending at or before it flush. Advanced by a group open (the group starts there)
+	/// and by [`Recorder::end`] (the content stops there).
 	frontier: Option<Timestamp>,
-	/// The recorder was dropped; this track no longer gates completeness.
+	/// The recorder was dropped; this track no longer paces boundaries or gates completeness.
 	closed: bool,
 }
 
-/// The state one [`Segmenter`] guards.
+impl TrackState {
+	/// The first unflushed group starting at or after `threshold` micros: this track's vote for
+	/// where the open segment can end.
+	fn candidate(&self, threshold: u128) -> Option<Timestamp> {
+		self.pending
+			.iter()
+			.map(|&(_, pts, _)| pts)
+			.find(|pts| pts.as_micros() >= threshold)
+	}
+}
+
+/// The state one [`Producer`] guards.
 struct State {
-	/// The declared segment-duration bound (see [`Segmenter::new`]). Frozen once the
-	/// timeline track advertises it.
-	duration_max: Timestamp,
-	/// An explicit [`cut`](Segmenter::cut) arrived: the application owns the boundaries and
-	/// auto-cut stays off for the rest of the broadcast.
-	manual: bool,
-	/// The driver's latest reported boundary candidate (a keyframe for a video driver) since
-	/// the last boundary: where auto-cut retroactively closes a segment that would otherwise
-	/// overrun `duration_max`.
-	candidate: Option<Timestamp>,
-	/// A segment already overran the declared bound and was warned about; log it once.
-	warned_overrun: bool,
-	/// Boundaries of segments not yet flushed: `boundaries[0]` starts segment `next_segment`,
-	/// which spans to `boundaries[1]`.
-	boundaries: VecDeque<Timestamp>,
-	/// The newest boundary ever created (never popped), the auto-cut reference point.
-	last_boundary: Option<Timestamp>,
+	config: Config,
+	/// Retained so the timeline track can be created when the first media track enrolls.
+	broadcast: moq_net::broadcast::Producer,
+	/// The timeline track, created by the first [`Producer::track`] call.
+	sink: Option<moq_json::stream::Producer<Record>>,
+	/// Where the open (unflushed) segment starts; `None` until the first report.
+	start: Option<Timestamp>,
+	/// Explicit [`Producer::cut`] boundaries not yet reached, in order.
+	cuts: VecDeque<Timestamp>,
 	/// The number the next flushed record gets.
 	next_segment: u64,
 	/// Every enrolled track, keyed by media track name.
 	tracks: BTreeMap<String, TrackState>,
-	/// The auto-cut driver: the first enrolled video track, else the first enrolled track.
-	driver: Option<String>,
-	/// Where flushed records go once a [`Producer`] attaches; buffered until then.
-	sink: Option<moq_json::stream::Producer<Record>>,
-	/// Records flushed before a sink attached, drained into it on attach.
-	buffered: Vec<Record>,
 	/// Live [`Hold`]s: while any exists, no record flushes (more tracks are still enrolling).
 	holds: usize,
+	/// A segment overran [`Config::duration_max`]: `(segment, duration)`. The timeline stops
+	/// publishing, since the catalog's promise is already broken.
+	overrun: Option<(u64, Duration)>,
+	/// The wall-clock time of pts 0, in timescale units since the moq epoch.
+	wall: Option<u64>,
 	/// The wire timescale for `pts`/`duration` (the catalog section's default: milliseconds).
 	timescale: Timescale,
 }
 
 impl State {
-	/// Register a boundary at `pts`, ignoring a non-monotonic one.
-	fn cut_at(&mut self, pts: Timestamp) {
-		if let Some(last) = self.last_boundary
-			&& pts.as_micros() <= last.as_micros()
-		{
-			return;
-		}
-		self.boundaries.push_back(pts);
-		self.last_boundary = Some(pts);
-	}
-
-	/// A group open reported by `name`: record the fact, auto-cut if this is the driver and
-	/// the policy says so, and flush whatever became complete.
+	/// A group open reported by `name`: record the fact and publish whatever became complete.
 	fn report(&mut self, name: &str, sequence: u64, pts: Timestamp, keyframe: bool) {
 		let Some(track) = self.tracks.get_mut(name) else {
 			return;
 		};
 		track.pending.push_back((sequence, pts, keyframe));
-		if track.frontier.is_none_or(|f| pts.as_micros() > f.as_micros()) {
-			track.frontier = Some(pts);
-		}
-
-		// Auto-cut: only the driver paces, only at a keyframe when the driver is video (an
-		// audio driver can cut anywhere), and never once the application cuts explicitly.
-		if !self.manual && self.driver.as_deref() == Some(name) {
-			let kind = self.tracks[name].kind;
-			if keyframe || kind != Kind::Video {
-				self.auto_cut(pts);
-			}
-		}
-
-		self.try_flush(false);
+		self.advance(name, pts);
 	}
 
-	/// `name`'s content ends at `pts`: everything up to there is now known, even though no
-	/// group opened at it. This is what gives the final segment an honest duration, since its
-	/// end is not a boundary anybody cut.
+	/// `name`'s content ends at `pts`, without a group opening there. This is what gives the
+	/// final segment an honest duration, since its end is not a boundary anybody cut.
 	fn report_end(&mut self, name: &str, pts: Timestamp) {
-		let Some(track) = self.tracks.get_mut(name) else {
-			return;
-		};
-		if track.frontier.is_none_or(|f| pts.as_micros() > f.as_micros()) {
+		if self.tracks.contains_key(name) {
+			self.advance(name, pts);
+		}
+	}
+
+	/// Raise `name`'s frontier to `pts`, then publish whatever that completed.
+	fn advance(&mut self, name: &str, pts: Timestamp) {
+		if let Some(track) = self.tracks.get_mut(name)
+			&& track.frontier.is_none_or(|f| pts.as_micros() > f.as_micros())
+		{
 			track.frontier = Some(pts);
 		}
-		self.try_flush(false);
-	}
 
-	/// Auto-cut policy for a driver boundary candidate at `pts`: keep every segment within
-	/// the declared `duration_max` whenever the driver's cadence allows.
-	///
-	/// A boundary can only land where the driver reported (a keyframe for video), so waiting
-	/// for the first candidate past the bound would overrun it by up to one GOP. Instead,
-	/// when `pts` would overrun, the segment is closed retroactively at the previous
-	/// candidate. Only a GOP longer than the bound itself still yields an honest long
-	/// segment.
-	fn auto_cut(&mut self, pts: Timestamp) {
-		let Some(last) = self.last_boundary else {
-			// The first candidate anchors the first segment.
-			self.cut_at(pts);
-			self.candidate = Some(pts);
-			return;
-		};
-
-		let bound = last.as_micros() + self.duration_max.as_micros();
-		if pts.as_micros() > bound {
-			// This candidate overruns: close the segment at the previous one instead.
-			if let Some(candidate) = self.candidate
-				&& candidate.as_micros() > last.as_micros()
-			{
-				self.cut_at(candidate);
-			}
-			// Still overrunning (the whole GOP is longer than the bound): cut here anyway.
-			if let Some(last) = self.last_boundary
-				&& pts.as_micros() >= last.as_micros() + self.duration_max.as_micros()
-			{
-				self.cut_at(pts);
-			}
-		} else if pts.as_micros() == bound {
-			self.cut_at(pts);
+		// The first thing anybody reports anchors the first segment, so content produced before
+		// any boundary exists belongs to the oldest segment rather than to nowhere.
+		if self.start.is_none() {
+			self.start = Some(pts);
 		}
-		self.candidate = Some(pts);
+
+		self.pump(false);
 	}
 
-	/// A track's recorder was dropped: stop gating completeness on it and re-elect the driver.
+	/// A track's recorder was dropped: stop gating completeness on it.
 	fn close(&mut self, name: &str) {
 		if let Some(track) = self.tracks.get_mut(name) {
 			track.closed = true;
 		}
-		if self.driver.as_deref() == Some(name) {
-			self.driver = self.elect();
-			// The old driver's pending candidate is not a valid boundary for the new one.
-			self.candidate = None;
-		}
-		self.try_flush(false);
+		self.pump(false);
 	}
 
-	/// The auto-cut driver among open tracks: a video track if any, else any open track.
-	fn elect(&self) -> Option<String> {
-		self.tracks
-			.iter()
-			.find(|(_, t)| !t.closed && t.kind == Kind::Video)
-			.or_else(|| self.tracks.iter().find(|(_, t)| !t.closed))
-			.map(|(name, _)| name.clone())
-	}
-
-	/// Flush every segment whose content is final on all tracks.
+	/// Publish every segment the media has finalized.
 	///
-	/// A segment needs its end boundary and, per open track, a report at or past it (closed
-	/// tracks can't report again, so they never gate). `finished` treats every track as
-	/// closed, for the terminal flush.
-	fn try_flush(&mut self, finished: bool) {
-		// With nothing enrolled there is nothing to describe; boundaries just wait. This also
-		// keeps pre-registered cuts (e.g. an HLS import cutting ahead of its media) from
-		// flushing empty records.
-		if self.tracks.is_empty() {
+	/// `finished` is the terminal pass: no track will report again, so a track that never
+	/// reached a boundary stops voting instead of holding the timeline open forever.
+	fn pump(&mut self, finished: bool) {
+		// With nothing enrolled there is nothing to describe. A record is immutable once
+		// published, so a caller that knows more tracks are still enrolling holds it back (see
+		// [`Producer::hold`]), and an overrun has already broken the catalog's promise.
+		if self.tracks.is_empty() || self.holds > 0 || self.overrun.is_some() {
 			return;
 		}
 
-		// A record is immutable once published, so a caller that knows more tracks are still
-		// enrolling holds flushing back until they are (see [`Segmenter::hold`]).
-		if self.holds > 0 {
-			return;
-		}
-
-		while self.boundaries.len() >= 2 {
-			let end = self.boundaries[1];
-			let complete = finished
-				|| self
-					.tracks
-					.values()
-					.all(|t| t.closed || t.frontier.is_some_and(|f| f.as_micros() >= end.as_micros()));
-			if !complete {
-				return;
+		while self.close_segment(finished) {
+			// A segment that broke the declared maximum ends the timeline; every later record
+			// would inherit the same broken promise.
+			if self.overrun.is_some() {
+				break;
 			}
-
-			let start = self.boundaries.pop_front().expect("checked len");
-			self.flush_segment(start, Some(end));
 		}
+	}
+
+	/// Publish the open segment if the media has finalized it, returning whether it did.
+	fn close_segment(&mut self, finished: bool) -> bool {
+		let Some(start) = self.start else {
+			return false;
+		};
+		let Some((end, cut)) = self.boundary(start, finished) else {
+			return false;
+		};
+
+		// Every open track has to have reported at or past the boundary, proving its ranges for
+		// this segment are final. The track that voted for `end` has by construction; a track
+		// with shorter groups can still be behind it.
+		let complete = finished
+			|| self
+				.tracks
+				.values()
+				.all(|t| t.closed || t.frontier.is_some_and(|f| f.as_micros() >= end.as_micros()));
+		if !complete {
+			return false;
+		}
+
+		self.flush_segment(start, Some(end));
+		if cut {
+			self.cuts.pop_front();
+		}
+		self.start = Some(end);
+		true
+	}
+
+	/// Where the segment starting at `start` ends, once the media says so: an explicit cut when
+	/// one is registered, otherwise the first group boundary shared by every track that gives
+	/// the segment its minimum duration. The bool reports which.
+	fn boundary(&self, start: Timestamp, finished: bool) -> Option<(Timestamp, bool)> {
+		if let Some(&cut) = self.cuts.front()
+			&& cut.as_micros() > start.as_micros()
+		{
+			return Some((cut, true));
+		}
+
+		let threshold = start.as_micros() + self.config.duration_min.as_micros();
+
+		let mut end: Option<Timestamp> = None;
+		for track in self.tracks.values() {
+			if track.closed {
+				continue;
+			}
+			match track.candidate(threshold) {
+				// The latest vote wins: it is a group boundary on the coarsest track, and every
+				// finer track assigns its groups by start, so no group is split.
+				Some(pts) => {
+					if end.is_none_or(|e| pts.as_micros() > e.as_micros()) {
+						end = Some(pts);
+					}
+				}
+				// This track has produced nothing past the minimum yet, so ending the segment
+				// would strand it. On the terminal pass it never will, so let it go.
+				None if finished => continue,
+				None => return None,
+			}
+		}
+
+		end.map(|end| (end, false))
 	}
 
 	/// Emit the record for the segment starting at `start`: drain every track's groups before
 	/// `end` (all of them for the final, unbounded segment) into ranges.
-	///
-	/// Anything reported before the first boundary lands in the oldest segment: the segment's
-	/// span is nominal, and early groups (a track racing ahead of the first cut) belong to it
-	/// rather than to nowhere.
 	fn flush_segment(&mut self, start: Timestamp, end: Option<Timestamp>) {
 		let pts = start.as_scale(self.timescale) as u64;
 		let duration = match end {
@@ -286,19 +288,28 @@ impl State {
 				.saturating_sub(pts),
 		};
 
-		// A segment materially past the declared bound means the producer misdeclared it (or
-		// the media left no valid boundary); the catalog already advertised the bound, so all
-		// we can do is say so. Allow the sub-half-second slack HLS rounding grants.
-		let slack = self.timescale.as_u64() / 2;
-		let bound = (self.duration_max.as_micros() * self.timescale.as_u64() as u128).div_ceil(1_000_000) as u64;
-		if !self.warned_overrun && duration > bound + slack {
-			self.warned_overrun = true;
-			tracing::warn!(
+		// The catalog promised a bound and this segment breaks it, so the record would
+		// contradict what consumers were told. Fail the timeline rather than publish it: a
+		// declared maximum the media can't honor is a bug in the publisher, and nothing a
+		// consumer reading the catalog can work around.
+		if let Some(max) = self.config.duration_max
+			&& duration > self.units(max)
+		{
+			let observed = Duration::from_nanos(duration * (1_000_000_000 / self.timescale.as_u64()));
+			tracing::error!(
 				segment = self.next_segment,
-				duration,
-				duration_max = bound,
-				"segment overran the declared duration_max; consumers (e.g. HLS TARGETDURATION) trust the declared bound"
+				duration = ?observed,
+				duration_max = ?max,
+				"segment exceeded the declared duration_max; dropping the timeline track"
 			);
+			self.overrun = Some((self.next_segment, observed));
+			// End the track rather than drop it: the records published before the promise broke
+			// are still true, and a consumer that has them should keep them.
+			if let Some(sink) = self.sink.as_mut() {
+				let _ = sink.finish();
+			}
+			self.sink = None;
+			return;
 		}
 
 		let mut record = Record::new(self.next_segment, pts, duration);
@@ -330,13 +341,17 @@ impl State {
 		self.emit(record);
 	}
 
-	/// Publish a flushed record, buffering until a sink attaches.
+	/// A duration in the wire timescale's units, rounded up so a bound never understates itself.
+	fn units(&self, duration: Duration) -> u64 {
+		(duration.as_micros() * self.timescale.as_u64() as u128).div_ceil(1_000_000) as u64
+	}
+
+	/// Publish a flushed record.
 	///
 	/// The timeline is an optional sidecar, so a transport failure logs and stops publishing
 	/// rather than tearing down the media path.
 	fn emit(&mut self, record: Record) {
 		let Some(sink) = self.sink.as_mut() else {
-			self.buffered.push(record);
 			return;
 		};
 		if let Err(err) = sink.append(&record) {
@@ -345,81 +360,133 @@ impl State {
 		}
 	}
 
-	/// The terminal flush: treat every track as closed, then emit the final open segment.
+	/// The terminal flush: publish what the media finalized, then the open tail.
 	fn finish(&mut self) {
 		// Nothing more will enroll, so an outstanding hold has nothing left to wait for.
 		self.holds = 0;
+		self.pump(true);
 
-		// Content but never a boundary (nobody cut and the driver never reported): anchor the
-		// one segment at the earliest report so the content is still indexed.
-		if self.boundaries.is_empty() {
-			let first = self
-				.tracks
-				.values()
-				.filter_map(|t| t.pending.front().map(|&(_, pts, _)| pts))
-				.min_by_key(|pts| pts.as_micros());
-			if let Some(first) = first {
-				self.cut_at(first);
-			}
+		if self.overrun.is_some() {
+			return;
 		}
 
-		self.try_flush(true);
-
-		if let Some(start) = self.boundaries.pop_front() {
-			// Skip an empty tail: a cut with no content after it describes nothing.
-			if self.tracks.values().any(|t| !t.pending.is_empty()) {
-				self.flush_segment(start, None);
-			}
+		// Skip an empty tail: a boundary with no content after it describes nothing.
+		if let Some(start) = self.start.take()
+			&& self.tracks.values().any(|t| !t.pending.is_empty())
+		{
+			self.flush_segment(start, None);
 		}
+	}
+
+	/// The error a segment overrunning [`Config::duration_max`] left behind, if any.
+	fn failure(&self) -> Option<crate::Error> {
+		let (segment, duration) = self.overrun?;
+		Some(crate::Error::TimelineOverrun {
+			segment,
+			duration,
+			duration_max: self.config.duration_max.unwrap_or_default(),
+		})
+	}
+
+	/// The catalog section advertising this timeline.
+	fn section(&self) -> Timeline {
+		let mut section = Timeline::new(DEFAULT_NAME);
+		section.timescale = self.timescale.as_u64() as u32;
+		section.duration_max = self.config.duration_max.map(|max| self.units(max));
+		section.wall = self.wall;
+		section
 	}
 }
 
-/// The broadcast's segmenter: the shared boundary list every track's groups map onto.
+/// The broadcast's timeline: the shared boundary list every track's groups map onto, and the
+/// track those segment records are published on.
 ///
-/// One per broadcast, owned by [`catalog::Producer`](crate::catalog::Producer); `Clone`
-/// shares it. Media tracks enroll with [`track`](Self::track) and report group opens through
-/// the returned [`Recorder`]; the application (or the auto-cut policy) declares boundaries
-/// with [`cut`](Self::cut). See the [module docs](self) for the full model.
+/// One per broadcast, owned by [`catalog::Producer`](crate::catalog::Producer); `Clone` shares
+/// it. Media tracks enroll with [`track`](Self::track) and report group opens through the
+/// returned [`Recorder`]; an application with its own boundaries overrides the pacing with
+/// [`cut`](Self::cut). See the [module docs](self) for the whole model.
 #[derive(Clone)]
-pub struct Segmenter {
+pub struct Producer {
 	state: Arc<Mutex<State>>,
 }
 
-impl Default for Segmenter {
-	/// A segmenter declaring the conventional [`DEFAULT_DURATION_MAX`] bound.
-	fn default() -> Self {
-		Self::new(DEFAULT_DURATION_MAX)
-	}
-}
-
-impl Segmenter {
-	/// A fresh segmenter declaring `duration_max`, the upper bound on a segment's duration.
+impl Producer {
+	/// A timeline for `broadcast`, paced by `config`.
 	///
-	/// The bound is policy the boundary owner knows up front: the encoder its keyframe
-	/// cadence, an importer its source's target duration. It is advertised in the catalog's
-	/// timeline section (consumers derive HLS `EXT-X-TARGETDURATION` from it, so it must not
-	/// change once advertised) and enforced by auto-cut: a segment is closed at the last
-	/// driver keyframe that keeps it within the bound, falling back to an honest overrun
-	/// only when a single GOP exceeds the bound. Explicit [`cut`](Self::cut)s are expected
-	/// to honor it too; a materially longer segment is logged.
-	pub fn new(duration_max: Timestamp) -> Self {
+	/// The MoQ track itself is created when the first media track enrolls, so a broadcast that
+	/// never segments never publishes (or advertises) one.
+	pub fn new(broadcast: &moq_net::broadcast::Producer, config: Config) -> Self {
 		Self {
 			state: Arc::new(Mutex::new(State {
-				duration_max,
-				manual: false,
-				candidate: None,
-				warned_overrun: false,
-				boundaries: VecDeque::new(),
-				last_boundary: None,
+				config,
+				broadcast: broadcast.clone(),
+				sink: None,
+				start: None,
+				cuts: VecDeque::new(),
 				next_segment: 0,
 				tracks: BTreeMap::new(),
-				driver: None,
-				sink: None,
-				buffered: Vec::new(),
 				holds: 0,
+				overrun: None,
+				wall: None,
 				timescale: Timescale::MILLI,
 			})),
 		}
+	}
+
+	/// Enroll the media track `name`, returning the [`Recorder`] it reports through.
+	///
+	/// The segment records key ranges by this name, and the track paces boundaries and gates
+	/// completeness until its recorder drops. Enroll a track when it is about to produce: an
+	/// enrolled but silent track holds every record back, by design, since a segment isn't
+	/// complete until every track's content is known. One recorder per track: enrolling the
+	/// same name again resets its state.
+	///
+	/// Creates the timeline track on first use, which errors if the broadcast can't (something
+	/// else already took the name).
+	pub fn track(&self, name: &str) -> crate::Result<Recorder> {
+		let mut state = self.state.lock().unwrap();
+
+		if state.sink.is_none() && state.overrun.is_none() {
+			let net = state.broadcast.create_track(DEFAULT_NAME, None)?;
+			let config = moq_json::stream::ProducerConfig::default().with_compression(true);
+			state.sink = Some(moq_json::stream::Producer::new(net, config));
+		}
+
+		state.tracks.insert(name.to_string(), TrackState::default());
+
+		Ok(Recorder {
+			state: self.state.clone(),
+			name: name.to_string(),
+		})
+	}
+
+	/// Declare a segment boundary at `pts`, overriding the [`Config::duration_min`] pacing.
+	///
+	/// For applications that know their own boundaries (an HLS import following the source
+	/// playlist, CMAF segments on disk, an encoder placing keyframes). Cutting ahead of the
+	/// media is fine: the segment's record still waits for every track's groups. A cut that
+	/// would make a segment shorter than [`Config::duration_min`] is ignored, so several
+	/// producers declaring the same boundaries (the renditions of one import) cost nothing.
+	///
+	/// Errors if a segment already overran [`Config::duration_max`].
+	pub fn cut(&self, pts: Timestamp) -> crate::Result<()> {
+		let mut state = self.state.lock().unwrap();
+		if let Some(err) = state.failure() {
+			return Err(err);
+		}
+
+		let floor = state
+			.cuts
+			.back()
+			.copied()
+			.or(state.start)
+			.map(|since| since.as_micros() + state.config.duration_min.as_micros());
+		if floor.is_none_or(|floor| pts.as_micros() >= floor) {
+			state.cuts.push_back(pts);
+			state.pump(false);
+		}
+
+		Ok(())
 	}
 
 	/// Hold record publishing back until the returned [`Hold`] drops.
@@ -437,77 +504,60 @@ impl Segmenter {
 		}
 	}
 
-	/// Replace the declared segment-duration bound, for an owner that learns it after the
-	/// segmenter exists (e.g. an HLS import reading the source playlist's target duration).
+	/// The catalog's root section advertising this timeline.
+	pub fn section(&self) -> Timeline {
+		self.state.lock().unwrap().section()
+	}
+
+	/// Set (or replace) the wall-clock anchor advertised in the catalog section, from an
+	/// observed pairing of a media timestamp `pts` with its wall-clock time `wall`.
 	///
-	/// Errors once the timeline track exists: the catalog has advertised the bound by then,
-	/// and consumers hold it for the life of the broadcast. Set it before the first media
-	/// track enrolls.
-	pub fn set_duration_max(&self, duration_max: Timestamp) -> crate::Result<()> {
+	/// Stored as the extrapolated wall-clock time of pts 0, the single value the
+	/// [`Timeline::wall`](hang::catalog::Timeline::wall) field carries: in this timeline's
+	/// timescale, measured from the moq epoch
+	/// ([`MOQ_EPOCH_UNIX_MILLIS`](hang::catalog::MOQ_EPOCH_UNIX_MILLIS), 2020). The catalog
+	/// snapshots [`section`](Self::section) when it advertises the timeline, so go through
+	/// [`catalog::Producer::set_wall`](crate::catalog::Producer::set_wall) (which re-advertises)
+	/// rather than calling this after the timeline is advertised.
+	pub fn set_wall(&self, pts: Timestamp, wall: SystemTime) {
 		let mut state = self.state.lock().unwrap();
-		if state.sink.is_some() {
-			return Err(crate::Error::TimelineAdvertised);
+		let unix_millis = wall
+			.duration_since(SystemTime::UNIX_EPOCH)
+			.unwrap_or_default()
+			.as_millis();
+		let scale = state.timescale.as_u64() as u128;
+		let pts_units = pts.as_scale(state.timescale);
+		let moq_millis = unix_millis.saturating_sub(hang::catalog::MOQ_EPOCH_UNIX_MILLIS as u128);
+		let moq_units = moq_millis * scale / 1000;
+		state.wall = Some(moq_units.saturating_sub(pts_units) as u64);
+	}
+
+	/// Flush the final (still open) segment and finish the track.
+	///
+	/// Errors if a segment overran [`Config::duration_max`], or if the track can't be finished.
+	pub fn finish(&mut self) -> crate::Result<()> {
+		let mut state = self.state.lock().unwrap();
+		state.finish();
+		if let Some(err) = state.failure() {
+			return Err(err);
 		}
-		state.duration_max = duration_max;
-		Ok(())
-	}
 
-	/// Declare a segment boundary at `pts`: the segment before it ends, the one after starts.
-	///
-	/// For applications that know their boundaries (an HLS import following the source
-	/// playlist, CMAF segments on disk, an encoder placing keyframes). Cuts must be
-	/// monotonic; an out-of-order one is ignored. Cutting ahead of the media is fine: the
-	/// segment's record still waits for every track's groups. The first explicit cut turns
-	/// auto-cut off for good.
-	pub fn cut(&self, pts: Timestamp) {
-		let mut state = self.state.lock().unwrap();
-		state.manual = true;
-		state.cut_at(pts);
-		state.try_flush(false);
-	}
-
-	/// Enroll the media track `name`, returning the [`Recorder`] it reports group opens
-	/// through.
-	///
-	/// The segment records key ranges by this name, and the track gates segment completeness
-	/// until its recorder drops. Enroll a track when it is about to produce (an enrolled but
-	/// silent track holds every record back, by design: a segment isn't complete until every
-	/// track's content is known). One recorder per track: enrolling the same name again
-	/// resets its state.
-	pub fn track(&self, name: &str, kind: Kind) -> Recorder {
-		let mut state = self.state.lock().unwrap();
-		state.tracks.insert(
-			name.to_string(),
-			TrackState {
-				kind,
-				pending: VecDeque::new(),
-				frontier: None,
-				closed: false,
-			},
-		);
-
-		// The first video track drives auto-cut (boundaries must land on its keyframes);
-		// without video, the first enrolled track of any kind paces instead.
-		let promote = match &state.driver {
-			None => true,
-			Some(driver) => kind == Kind::Video && state.tracks.get(driver).is_none_or(|d| d.kind != Kind::Video),
+		// Finish the sink in place (dropping it would retire the track before late readers
+		// catch up); a post-finish flush then fails in emit() and is logged there.
+		let Some(sink) = state.sink.as_mut() else {
+			return Ok(());
 		};
-		if promote {
-			state.driver = Some(name.to_string());
-			// A previous driver's pending candidate is not a valid boundary for this one.
-			state.candidate = None;
-		}
-
-		Recorder {
-			state: self.state.clone(),
-			name: name.to_string(),
+		match sink.finish() {
+			Ok(()) => Ok(()),
+			Err(moq_json::Error::Net(err)) => Err(err.into()),
+			Err(err) => unreachable!("timeline finish failed to encode: {err}"),
 		}
 	}
 }
 
-/// Holds [`Segmenter`] record publishing back while tracks are still enrolling.
+/// Holds [`Producer`] record publishing back while tracks are still enrolling.
 ///
-/// Minted by [`Segmenter::hold`]; whatever became complete meanwhile flushes when it drops.
+/// Minted by [`Producer::hold`]; whatever became complete meanwhile flushes when it drops.
 pub struct Hold {
 	state: Arc<Mutex<State>>,
 }
@@ -516,14 +566,14 @@ impl Drop for Hold {
 	fn drop(&mut self) {
 		let mut state = self.state.lock().unwrap();
 		state.holds = state.holds.saturating_sub(1);
-		state.try_flush(false);
+		state.pump(false);
 	}
 }
 
-/// Reports one media track's group opens into the shared [`Segmenter`].
+/// Reports one media track's group opens into the shared [`Producer`].
 ///
 /// Move-only: it is the track's single reporting handle, and dropping it closes the track's
-/// enrollment (segments stop waiting on it). Minted by [`Segmenter::track`] and held by a
+/// enrollment (segments stop waiting on it). Minted by [`Producer::track`] and held by a
 /// rendition's [`container::Producer`](crate::container::Producer).
 pub struct Recorder {
 	state: Arc<Mutex<State>>,
@@ -534,18 +584,18 @@ impl Recorder {
 	/// Report that group `sequence` opened at presentation time `pts`, `keyframe` stating
 	/// whether its first frame is one (i.e. whether a player could join here).
 	///
-	/// Reports must be in group order with monotonic timestamps; this is the fact the
-	/// segmenter builds ranges and completeness from.
+	/// Reports must be in group order with monotonic timestamps; this is the fact the timeline
+	/// builds ranges, boundaries and completeness from.
 	pub(crate) fn record(&mut self, sequence: u64, pts: Timestamp, keyframe: bool) {
 		self.state.lock().unwrap().report(&self.name, sequence, pts, keyframe);
 	}
 
 	/// Report that this track's content extends to `pts`, without a group opening there.
 	///
-	/// A group open says where content *starts*; the last group of a broadcast has no
-	/// successor to bound it, so its segment would otherwise be published a group short (zero
-	/// for a segment that is a single group). Report the end whenever you know it: closing a
-	/// group, finishing a track.
+	/// A group open says where content *starts*; the last group of a broadcast has no successor
+	/// to bound it, so its segment would otherwise be published a group short (zero for a
+	/// segment that is a single group). Report the end whenever you know it: closing a group,
+	/// finishing a track.
 	pub(crate) fn end(&mut self, pts: Timestamp) {
 		self.state.lock().unwrap().report_end(&self.name, pts);
 	}
@@ -554,103 +604,6 @@ impl Recorder {
 impl Drop for Recorder {
 	fn drop(&mut self) {
 		self.state.lock().unwrap().close(&self.name);
-	}
-}
-
-/// The broadcast's timeline track: where the segmenter's records are published, plus the
-/// catalog section advertising it.
-///
-/// `Clone`; clones share the one track and wall anchor. Get one from
-/// [`catalog::Producer::timeline`](crate::catalog::Producer::timeline), which owns it and
-/// finishes it with the catalog.
-#[derive(Clone)]
-pub struct Producer {
-	state: Arc<Mutex<State>>,
-	track: String,
-	timescale: Timescale,
-	// The declared segment-duration bound in timescale units, frozen at creation (the
-	// segmenter rejects changes once the timeline exists).
-	duration_max: u64,
-	// The wall-clock time of pts 0, in timescale units since the moq epoch, advertised in
-	// section(). Shared across clones.
-	wall: Arc<Mutex<Option<u64>>>,
-}
-
-impl Producer {
-	/// Create the broadcast's timeline track ([`DEFAULT_NAME`]) and attach it to `segmenter`
-	/// as the record sink; records flushed before this call are published immediately.
-	pub fn new(broadcast: &mut moq_net::broadcast::Producer, segmenter: &Segmenter) -> Result<Self, moq_net::Error> {
-		let net = broadcast.create_track(DEFAULT_NAME, None)?;
-		let config = moq_json::stream::ProducerConfig::default().with_compression(true);
-		let mut sink = moq_json::stream::Producer::new(net, config);
-
-		let (timescale, duration_max) = {
-			let mut state = segmenter.state.lock().unwrap();
-			for record in state.buffered.drain(..) {
-				if let Err(err) = sink.append(&record) {
-					tracing::warn!(%err, "timeline publish failed; dropping the buffered records");
-					break;
-				}
-			}
-			state.sink = Some(sink);
-			// Freeze the declared bound in the section's timescale, rounding up: an
-			// advertised bound must never understate the declared one.
-			let units = (state.duration_max.as_micros() * state.timescale.as_u64() as u128).div_ceil(1_000_000) as u64;
-			(state.timescale, units)
-		};
-
-		Ok(Self {
-			state: segmenter.state.clone(),
-			track: DEFAULT_NAME.to_string(),
-			timescale,
-			duration_max,
-			wall: Arc::new(Mutex::new(None)),
-		})
-	}
-
-	/// The catalog's root section advertising this timeline.
-	pub fn section(&self) -> Timeline {
-		let mut section = Timeline::new(&self.track, self.duration_max);
-		section.timescale = self.timescale.as_u64() as u32;
-		section.wall = *self.wall.lock().unwrap();
-		section
-	}
-
-	/// Set (or replace) the wall-clock anchor advertised in the catalog section, from an observed
-	/// pairing of a media timestamp `pts` with its wall-clock time `wall`.
-	///
-	/// Stored as the extrapolated wall-clock time of pts 0, the single value the
-	/// [`Timeline::wall`](hang::catalog::Timeline::wall) field carries: in this timeline's timescale,
-	/// measured from the moq epoch ([`MOQ_EPOCH_UNIX_MILLIS`](hang::catalog::MOQ_EPOCH_UNIX_MILLIS),
-	/// 2020). The catalog snapshots [`section`](Self::section) when it advertises the timeline, so
-	/// go through [`catalog::Producer::set_wall`](crate::catalog::Producer::set_wall) (which
-	/// re-advertises) rather than calling this after the timeline is advertised.
-	pub fn set_wall(&mut self, pts: Timestamp, wall: SystemTime) {
-		let unix_millis = wall
-			.duration_since(SystemTime::UNIX_EPOCH)
-			.unwrap_or_default()
-			.as_millis();
-		let scale = self.timescale.as_u64() as u128;
-		let pts_units = pts.as_scale(self.timescale);
-		let moq_millis = unix_millis.saturating_sub(hang::catalog::MOQ_EPOCH_UNIX_MILLIS as u128);
-		let moq_units = moq_millis * scale / 1000;
-		*self.wall.lock().unwrap() = Some(moq_units.saturating_sub(pts_units) as u64);
-	}
-
-	/// Flush the final (still open) segment and finish the track.
-	pub fn finish(&mut self) -> Result<(), moq_net::Error> {
-		let mut state = self.state.lock().unwrap();
-		state.finish();
-		// Finish the sink in place (dropping it would retire the track before late readers
-		// catch up); a post-finish flush then fails in emit() and is logged there.
-		let Some(sink) = state.sink.as_mut() else {
-			return Ok(());
-		};
-		match sink.finish() {
-			Ok(()) => Ok(()),
-			Err(moq_json::Error::Net(err)) => Err(err),
-			Err(err) => unreachable!("timeline finish failed to encode: {err}"),
-		}
 	}
 }
 
@@ -738,8 +691,6 @@ impl<E: RecordExt> Consumer<E> {
 
 #[cfg(test)]
 mod test {
-	use std::time::Duration;
-
 	use super::*;
 
 	fn ms(v: u64) -> Timestamp {
@@ -778,21 +729,24 @@ mod test {
 		out
 	}
 
-	fn setup() -> (moq_net::broadcast::Producer, Segmenter, Producer) {
-		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let segmenter = Segmenter::default();
-		let producer = Producer::new(&mut broadcast, &segmenter).unwrap();
-		(broadcast, segmenter, producer)
+	fn setup() -> (moq_net::broadcast::Producer, Producer) {
+		setup_with(Config::default())
 	}
 
-	#[tokio::test]
-	async fn auto_cut_paces_on_video_keyframes() {
-		let (broadcast, segmenter, mut timeline) = setup();
-		let mut video = segmenter.track("video0", Kind::Video);
-		let mut audio = segmenter.track("audio0", Kind::Audio);
+	fn setup_with(config: Config) -> (moq_net::broadcast::Producer, Producer) {
+		let broadcast = moq_net::broadcast::Info::new().produce();
+		let timeline = Producer::new(&broadcast, config);
+		(broadcast, timeline)
+	}
 
-		// Video keyframes every 2s (the default duration_max), audio groups every 500ms.
-		// Reports interleave like a real muxer: audio runs slightly ahead.
+	// The coarsest track paces: video GOPs are longer than duration_min, so segments are GOPs.
+	#[tokio::test]
+	async fn the_coarsest_track_paces_the_segments() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
+		let mut audio = timeline.track("audio0").unwrap();
+
+		// Video keyframes every 2s, audio groups every 500ms, minimum 1s.
 		video.record(0, ms(0), true);
 		for (seq, t) in [(0u64, 0u64), (1, 500), (2, 1_000), (3, 1_500)] {
 			audio.record(seq, ms(t), true);
@@ -807,8 +761,8 @@ mod test {
 		drop(audio);
 		timeline.finish().unwrap();
 
-		// Segment 0 flushes only once BOTH tracks reported past 2s; every record is
-		// self-contained (start AND end groups, explicit duration).
+		// Audio's own candidate (1s) loses to video's (2s), so no segment splits a GOP. Every
+		// record is self-contained: start AND end groups, explicit duration.
 		assert_eq!(
 			drain(&broadcast, &timeline).await,
 			vec![
@@ -819,289 +773,175 @@ mod test {
 		);
 	}
 
-	// Keyframes that don't divide duration_max evenly must not accumulate overrun: when the
-	// next keyframe would overrun the bound, the segment closes retroactively at the previous
-	// keyframe, so every segment stays within the declared bound.
+	// A real-time encoder's GOP can dwarf the minimum. Nothing is violated: there is nowhere
+	// else a segment could start and stay decodable, so the segment is simply long.
 	#[tokio::test]
-	async fn auto_cut_enforces_the_declared_bound() {
-		let (broadcast, segmenter, mut timeline) = setup();
-		let mut video = segmenter.track("video0", Kind::Video);
-
-		// Keyframes every 900ms against the default 2s bound.
-		for (seq, t) in [(0u64, 0u64), (1, 900), (2, 1_800), (3, 2_700), (4, 3_600), (5, 4_500)] {
-			video.record(seq, ms(t), true);
-		}
-		drop(video);
-		timeline.finish().unwrap();
-
-		assert_eq!(
-			drain(&broadcast, &timeline).await,
-			vec![
-				entry(0, 0, 1_800, &[("video0", &[(0, 1)])]),
-				entry(1, 1_800, 1_800, &[("video0", &[(2, 3)])]),
-				entry(2, 3_600, 900, &[("video0", &[(4, 5)])]),
-			]
-		);
-	}
-
-	// A single GOP longer than the bound leaves no valid boundary; the segment overruns
-	// honestly rather than splitting a group.
-	#[tokio::test]
-	async fn a_gop_longer_than_the_bound_overruns_honestly() {
-		let (broadcast, segmenter, mut timeline) = setup();
-		let mut video = segmenter.track("video0", Kind::Video);
+	async fn a_gop_longer_than_the_minimum_is_one_segment() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
 
 		video.record(0, ms(0), true);
-		video.record(1, ms(5_000), true);
-		video.record(2, ms(7_000), true);
+		video.record(1, ms(30_000), true);
+		video.end(ms(60_000));
 		drop(video);
 		timeline.finish().unwrap();
 
 		assert_eq!(
 			drain(&broadcast, &timeline).await,
 			vec![
-				entry(0, 0, 5_000, &[("video0", &[(0, 0)])]),
-				entry(1, 5_000, 2_000, &[("video0", &[(1, 1)])]),
-				entry(2, 7_000, 0, &[("video0", &[(2, 2)])]),
+				entry(0, 0, 30_000, &[("video0", &[(0, 0)])]),
+				entry(1, 30_000, 30_000, &[("video0", &[(1, 1)])]),
 			]
 		);
 	}
 
-	// The declared bound is set at construction (or before the timeline track exists) and
-	// frozen once advertised: the catalog section carries it for the life of the broadcast.
-	#[test]
-	fn duration_max_is_declared_and_frozen() {
-		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let segmenter = Segmenter::new(Timestamp::from_millis(6_500).unwrap());
-		segmenter
-			.set_duration_max(Timestamp::from_millis(6_000).unwrap())
-			.expect("settable before the timeline exists");
+	// Groups shorter than the minimum pack into one segment rather than each becoming one.
+	#[tokio::test]
+	async fn short_groups_pack_up_to_the_minimum() {
+		let (broadcast, mut timeline) = setup_with(Config {
+			duration_min: Duration::from_millis(1_500),
+			..Default::default()
+		});
+		let mut audio = timeline.track("audio0").unwrap();
 
-		let timeline = Producer::new(&mut broadcast, &segmenter).unwrap();
-		assert_eq!(timeline.section().duration_max, 6_000);
-		assert!(
-			segmenter
-				.set_duration_max(Timestamp::from_millis(4_000).unwrap())
-				.is_err(),
-			"the advertised bound must not change"
-		);
-		assert_eq!(timeline.section().duration_max, 6_000);
+		for seq in 0..8u64 {
+			audio.record(seq, ms(seq * 500), true);
+		}
+		drop(audio);
+		timeline.finish().unwrap();
+
+		let entries = drain(&broadcast, &timeline).await;
+		// The first group at or past 1500ms ends segment 0, so it holds groups 0..=2.
+		assert_eq!(entries[0], entry(0, 0, 1_500, &[("audio0", &[(0, 2)])]));
+		assert_eq!(entries[1], entry(1, 1_500, 1_500, &[("audio0", &[(3, 5)])]));
 	}
 
+	// A track that hasn't reached the minimum yet holds the segment open, so a record never
+	// omits a rendition that was about to contribute to it.
 	#[tokio::test]
 	async fn a_segment_waits_for_every_track() {
-		let (broadcast, segmenter, timeline) = setup();
-		let mut video = segmenter.track("video0", Kind::Video);
-		let mut audio = segmenter.track("audio0", Kind::Audio);
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
+		let mut audio = timeline.track("audio0").unwrap();
 
-		// Video is two boundaries ahead, but audio hasn't crossed the first one: nothing
-		// may flush, because audio's groups for segment 0 aren't final yet.
-		video.record(0, ms(0), true);
-		video.record(1, ms(2_000), true);
-		video.record(2, ms(4_000), true);
-		audio.record(0, ms(0), true);
-		let section = timeline.section();
-		let mut consumer = Consumer::<()>::subscribe(&broadcast.consume(), &section).await.unwrap();
-		let waiter = kio::Waiter::noop();
-		assert!(consumer.poll_next(&waiter).is_pending());
-
-		// Audio crossing the second boundary finalizes segment 0 (and only segment 0).
-		audio.record(1, ms(2_100), true);
-		match consumer.poll_next(&waiter) {
-			Poll::Ready(Ok(Some(got))) => {
-				assert_eq!(got, entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 0)])]))
-			}
-			other => panic!("expected segment 0, got {other:?}"),
-		}
-		assert!(consumer.poll_next(&waiter).is_pending());
-	}
-
-	#[tokio::test]
-	async fn explicit_cuts_disable_auto_cut() {
-		let (broadcast, segmenter, mut timeline) = setup();
-		let mut video = segmenter.track("video0", Kind::Video);
-
-		// The app cuts every 6s (e.g. following a source playlist); video keyframes every 2s.
-		// Auto-cut (duration_max 2s) must not fire between the explicit cuts.
-		segmenter.cut(ms(0));
-		segmenter.cut(ms(6_000));
-		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000), (3, 6_000), (4, 8_000)] {
-			video.record(seq, ms(t), true);
-		}
-		drop(video);
-		timeline.finish().unwrap();
-
-		// One multi-GOP segment per cut: tiny GOPs pack into larger segments.
-		assert_eq!(
-			drain(&broadcast, &timeline).await,
-			vec![
-				entry(0, 0, 6_000, &[("video0", &[(0, 2)])]),
-				entry(1, 6_000, 2_000, &[("video0", &[(3, 4)])]),
-			]
-		);
-	}
-
-	#[tokio::test]
-	async fn cutting_ahead_of_the_media_waits_for_it() {
-		let (broadcast, segmenter, mut timeline) = setup();
-
-		// An HLS import pre-registers boundaries from the playlist before any media arrives.
-		segmenter.cut(ms(0));
-		segmenter.cut(ms(6_000));
-		segmenter.cut(ms(12_000));
-
-		let mut video = segmenter.track("video0", Kind::Video);
-		let section = timeline.section();
-		let mut consumer = Consumer::<()>::subscribe(&broadcast.consume(), &section).await.unwrap();
-		let waiter = kio::Waiter::noop();
-		assert!(consumer.poll_next(&waiter).is_pending(), "no media, no records");
-
-		for (seq, t) in [(0u64, 0u64), (1, 3_000), (2, 6_000), (3, 9_000)] {
-			video.record(seq, ms(t), true);
-		}
-		drop(video);
-		timeline.finish().unwrap();
-
-		assert_eq!(
-			drain(&broadcast, &timeline).await,
-			vec![
-				entry(0, 0, 6_000, &[("video0", &[(0, 1)])]),
-				entry(1, 6_000, 6_000, &[("video0", &[(2, 3)])]),
-			]
-		);
-	}
-
-	#[tokio::test]
-	async fn audio_only_paces_itself() {
-		let (broadcast, segmenter, mut timeline) = setup();
-		let mut audio = segmenter.track("audio0", Kind::Audio);
-
-		// No video: the first (audio) track drives, cutting every duration_max (2s).
-		for (seq, t) in [(0u64, 0u64), (1, 500), (2, 1_000), (3, 1_500), (4, 2_000), (5, 2_500)] {
-			audio.record(seq, ms(t), true);
-		}
-		drop(audio);
-		timeline.finish().unwrap();
-
-		assert_eq!(
-			drain(&broadcast, &timeline).await,
-			vec![
-				entry(0, 0, 2_000, &[("audio0", &[(0, 3)])]),
-				entry(1, 2_000, 500, &[("audio0", &[(4, 5)])]),
-			]
-		);
-	}
-
-	#[tokio::test]
-	async fn video_enrolling_late_takes_over_the_pacing() {
-		let (broadcast, segmenter, mut timeline) = setup();
-		let mut audio = segmenter.track("audio0", Kind::Audio);
-		audio.record(0, ms(0), true);
-		audio.record(1, ms(2_000), true); // audio-driven boundary at 2s
-
-		// Video joins: it becomes the driver, and boundaries land on ITS keyframes. The
-		// keyframe at 4.1s would leave a 2.1s segment, so the segment is closed retroactively
-		// at the 2.1s keyframe, keeping every segment within the declared 2s bound (and
-		// starting the video segment on its keyframe).
-		let mut video = segmenter.track("video0", Kind::Video);
-		video.record(0, ms(2_100), true);
-		video.record(1, ms(4_100), true);
-		audio.record(2, ms(4_200), true);
-		drop(video);
-		drop(audio);
-		timeline.finish().unwrap();
-
-		assert_eq!(
-			drain(&broadcast, &timeline).await,
-			vec![
-				entry(0, 0, 2_000, &[("audio0", &[(0, 0)])]),
-				entry(1, 2_000, 100, &[("audio0", &[(1, 1)])]),
-				entry(2, 2_100, 2_000, &[("video0", &[(0, 0)])]),
-				entry(3, 4_100, 100, &[("audio0", &[(2, 2)]), ("video0", &[(1, 1)])]),
-			]
-		);
-	}
-
-	#[tokio::test]
-	async fn groups_before_the_first_boundary_join_the_first_segment() {
-		let (broadcast, segmenter, mut timeline) = setup();
-		let mut video = segmenter.track("video0", Kind::Video);
-		let mut audio = segmenter.track("audio0", Kind::Audio);
-
-		// Audio races ahead of video's first keyframe (the startup race): its early groups
-		// belong to segment 0, not to nowhere.
-		audio.record(0, ms(0), true);
-		video.record(0, ms(30), true);
-		video.record(1, ms(2_030), true);
-		audio.record(1, ms(2_100), true);
-		drop(video);
-		drop(audio);
-		timeline.finish().unwrap();
-
-		assert_eq!(
-			drain(&broadcast, &timeline).await,
-			vec![
-				entry(0, 30, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 0)])]),
-				entry(1, 2_030, 70, &[("video0", &[(1, 1)]), ("audio0", &[(1, 1)])]),
-			]
-		);
-	}
-
-	#[tokio::test]
-	async fn sequence_gaps_split_ranges() {
-		let (broadcast, segmenter, mut timeline) = setup();
-		let mut video = segmenter.track("video0", Kind::Video);
-		let mut audio = segmenter.track("audio0", Kind::Audio);
-
-		// Elemental-style gap: audio groups 2..=4 never existed inside segment 0.
 		video.record(0, ms(0), true);
 		audio.record(0, ms(0), true);
-		audio.record(1, ms(300), true);
-		audio.record(5, ms(1_500), true);
 		video.record(1, ms(2_000), true);
-		audio.record(6, ms(2_100), true);
+		// Video alone would close segment 0 here, but audio hasn't crossed 2s.
+		assert!(drain(&broadcast, &timeline).await.is_empty());
+
+		audio.record(1, ms(2_000), true);
+		let entries = drain(&broadcast, &timeline).await;
+		assert_eq!(
+			entries,
+			vec![entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 0)])])]
+		);
 		drop(video);
 		drop(audio);
+		timeline.finish().unwrap();
+	}
+
+	// An application that knows its own boundaries overrides the pacing.
+	#[tokio::test]
+	async fn explicit_cuts_override_the_pacing() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
+
+		// Keyframes every second, cut every three: the segments follow the cuts, not the GOPs.
+		timeline.cut(ms(3_000)).unwrap();
+		timeline.cut(ms(6_000)).unwrap();
+		for seq in 0..7u64 {
+			video.record(seq, ms(seq * 1_000), true);
+		}
+		drop(video);
 		timeline.finish().unwrap();
 
 		let entries = drain(&broadcast, &timeline).await;
-		assert_eq!(
-			entries[0],
-			entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 1), (5, 5)])]),
-		);
+		assert_eq!(entries[0], entry(0, 0, 3_000, &[("video0", &[(0, 2)])]));
+		assert_eq!(entries[1], entry(1, 3_000, 3_000, &[("video0", &[(3, 5)])]));
 	}
 
+	// Every rendition of one import declares the same boundaries, so a cut that would make a
+	// segment shorter than the minimum is dropped rather than producing a stray segment.
 	#[tokio::test]
-	async fn a_whole_segment_gap_omits_the_track() {
-		let (broadcast, segmenter, mut timeline) = setup();
-		let mut video = segmenter.track("video0", Kind::Video);
-		let mut audio = segmenter.track("audio0", Kind::Audio);
+	async fn a_cut_below_the_minimum_is_ignored() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
 
-		// Audio drops out for all of segment 1 and returns in segment 2: the record simply
-		// has no audio entry (an HLS exporter renders EXT-X-GAP).
 		video.record(0, ms(0), true);
-		audio.record(0, ms(0), true);
+		timeline.cut(ms(2_000)).unwrap();
+		// A sibling rendition's duplicate, and a boundary too close to be a segment.
+		timeline.cut(ms(2_000)).unwrap();
+		timeline.cut(ms(2_500)).unwrap();
+		timeline.cut(ms(4_000)).unwrap();
 		video.record(1, ms(2_000), true);
 		video.record(2, ms(4_000), true);
-		audio.record(1, ms(4_500), true);
 		drop(video);
-		drop(audio);
 		timeline.finish().unwrap();
 
 		let entries = drain(&broadcast, &timeline).await;
+		assert_eq!(entries.len(), 3, "the duplicate and the 500ms cut are both dropped");
+		assert_eq!(entries[0], entry(0, 0, 2_000, &[("video0", &[(0, 0)])]));
 		assert_eq!(entries[1], entry(1, 2_000, 2_000, &[("video0", &[(1, 1)])]));
-		assert_eq!(
-			entries[2],
-			entry(2, 4_000, 500, &[("video0", &[(2, 2)]), ("audio0", &[(1, 1)])])
-		);
 	}
 
-	// The last group of a broadcast has no successor to bound it, so without a reported end
-	// the final segment's duration collapses to zero (an HLS `EXTINF:0`).
+	// The declared maximum is a contract with consumers (an HLS EXT-X-TARGETDURATION), so a
+	// segment that breaks it fails the timeline rather than publishing a record that
+	// contradicts the catalog.
+	#[tokio::test]
+	async fn exceeding_the_declared_maximum_fails_the_timeline() {
+		let (broadcast, mut timeline) = setup_with(Config {
+			duration_min: Duration::from_secs(1),
+			duration_max: Some(Duration::from_secs(3)),
+		});
+		let mut video = timeline.track("video0").unwrap();
+
+		let mut consumer = {
+			video.record(0, ms(0), true);
+			video.record(1, ms(2_000), true);
+			Consumer::<()>::subscribe(&broadcast.consume(), &timeline.section())
+				.await
+				.unwrap()
+		};
+
+		// A 4s GOP against a declared 3s maximum.
+		video.record(2, ms(6_000), true);
+		drop(video);
+
+		let err = timeline.finish().unwrap_err();
+		assert!(
+			matches!(err, crate::Error::TimelineOverrun { segment: 1, .. }),
+			"unexpected error: {err}"
+		);
+
+		// The record that was still true published; the one that would have contradicted the
+		// catalog did not, and the track ended there.
+		let waiter = kio::Waiter::noop();
+		let mut entries = Vec::new();
+		while let Poll::Ready(Ok(Some(entry))) = consumer.poll_next(&waiter) {
+			entries.push(entry);
+		}
+		assert_eq!(entries, vec![entry(0, 0, 2_000, &[("video0", &[(0, 0)])])]);
+	}
+
+	#[tokio::test]
+	async fn an_undeclared_maximum_is_omitted_from_the_catalog() {
+		let (_broadcast, timeline) = setup();
+		assert_eq!(timeline.section().duration_max, None);
+
+		let (_broadcast, timeline) = setup_with(Config {
+			duration_max: Some(Duration::from_millis(2_500)),
+			..Default::default()
+		});
+		assert_eq!(timeline.section().duration_max, Some(2_500));
+	}
+
+	// The last group of a broadcast has no successor to bound it, so without a reported end the
+	// final segment's duration collapses to zero (an HLS EXTINF:0).
 	#[tokio::test]
 	async fn the_final_segment_runs_to_the_reported_end() {
-		let (broadcast, segmenter, mut timeline) = setup();
-		let mut video = segmenter.track("video0", Kind::Video);
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
 
 		video.record(0, ms(0), true);
 		video.record(1, ms(2_000), true);
@@ -1124,17 +964,17 @@ mod test {
 	// renditions) holds flushing back until they are all in.
 	#[tokio::test]
 	async fn a_hold_defers_flushing_until_every_track_enrolls() {
-		let (broadcast, segmenter, mut timeline) = setup();
-		let hold = segmenter.hold();
+		let (broadcast, mut timeline) = setup();
+		let hold = timeline.hold();
 
-		// The primary rendition runs a whole batch of segments through before its sibling
-		// has even loaded an init segment.
-		let mut first = segmenter.track("video0", Kind::Video);
+		// The primary rendition runs a whole batch of segments through before its sibling has
+		// even loaded an init segment.
+		let mut first = timeline.track("video0").unwrap();
 		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
 			first.record(seq, ms(t), true);
 		}
 
-		let mut second = segmenter.track("video1", Kind::Video);
+		let mut second = timeline.track("video1").unwrap();
 		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
 			second.record(seq, ms(t), true);
 		}
@@ -1144,9 +984,9 @@ mod test {
 		drop(second);
 		timeline.finish().unwrap();
 
-		// Both renditions are indexed from segment 0. Without the hold, segments 0 and 1
-		// would have flushed knowing only video0 (a permanent gap for video1), and video1's
-		// first two groups would have folded into segment 2.
+		// Both renditions are indexed from segment 0. Without the hold, segments 0 and 1 would
+		// have flushed knowing only video0 (a permanent gap for video1), and video1's first two
+		// groups would have folded into segment 2.
 		let entries = drain(&broadcast, &timeline).await;
 		assert_eq!(
 			entries[0],
@@ -1158,132 +998,159 @@ mod test {
 		);
 	}
 
+	// A track that races ahead of the others still lands in the segment its content falls in.
 	#[tokio::test]
-	async fn a_non_keyframe_range_start_is_flagged() {
-		let (broadcast, segmenter, mut timeline) = setup();
-		let mut video = segmenter.track("video0", Kind::Video);
+	async fn groups_before_the_first_boundary_join_the_first_segment() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
+		let mut audio = timeline.track("audio0").unwrap();
 
-		segmenter.cut(ms(0));
-		segmenter.cut(ms(2_000));
-		video.record(0, ms(0), true);
-		// A gappy source resumes without an IDR: the range says so, and auto-cut would not
-		// have cut here anyway (explicit cuts are in charge).
-		video.record(1, ms(2_500), false);
-		video.record(2, ms(4_000), true);
+		// Audio races ahead of video's first keyframe (the startup race): its early group
+		// belongs to segment 0, which starts where the earliest content does.
+		audio.record(0, ms(0), true);
+		video.record(0, ms(30), true);
+		for (seq, t) in [(1u64, 500u64), (2, 1_000), (3, 1_500), (4, 2_000)] {
+			audio.record(seq, ms(t), true);
+		}
+		video.record(1, ms(2_030), true);
+		audio.record(5, ms(2_500), true);
 		drop(video);
+		drop(audio);
 		timeline.finish().unwrap();
 
 		let entries = drain(&broadcast, &timeline).await;
-		let ranges = &entries[1].tracks["video0"];
-		assert_eq!((ranges[0].start, ranges[0].end, ranges[0].keyframe), (1, 2, false));
-	}
-
-	#[tokio::test]
-	async fn a_closed_track_stops_gating() {
-		let (broadcast, segmenter, mut timeline) = setup();
-		let mut video = segmenter.track("video0", Kind::Video);
-		let mut audio = segmenter.track("audio0", Kind::Audio);
-
-		video.record(0, ms(0), true);
-		audio.record(0, ms(0), true);
-		video.record(1, ms(2_000), true);
-		video.record(2, ms(4_000), true);
-
-		// Audio dies mid-broadcast. Its recorder dropping is what unblocks segment 0 (and 1):
-		// completeness can't wait forever on a track that will never report again.
-		drop(audio);
-		drop(video);
-		timeline.finish().unwrap();
-
 		assert_eq!(
-			drain(&broadcast, &timeline).await,
-			vec![
-				entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 0)])]),
-				entry(1, 2_000, 2_000, &[("video0", &[(1, 1)])]),
-				entry(2, 4_000, 0, &[("video0", &[(2, 2)])]),
-			]
+			entries[0],
+			entry(0, 0, 2_030, &[("video0", &[(0, 0)]), ("audio0", &[(0, 4)])]),
 		);
 	}
 
 	#[tokio::test]
-	async fn records_flushed_before_the_track_exists_are_buffered() {
-		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let segmenter = Segmenter::default();
+	async fn sequence_gaps_split_ranges() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
+		let mut audio = timeline.track("audio0").unwrap();
 
-		// Segments complete before any timeline track exists (e.g. the catalog wires the
-		// track lazily): they publish the moment it attaches.
-		let mut audio = segmenter.track("audio0", Kind::Audio);
-		for (seq, t) in [(0u64, 0u64), (1, 1_000), (2, 2_000), (3, 3_000), (4, 4_000)] {
-			audio.record(seq, ms(t), true);
-		}
-
-		let mut timeline = Producer::new(&mut broadcast, &segmenter).unwrap();
+		// Elemental-style gap: audio groups 2..=4 never existed inside segment 0.
+		video.record(0, ms(0), true);
+		audio.record(0, ms(0), true);
+		audio.record(1, ms(300), true);
+		audio.record(5, ms(1_500), true);
+		video.record(1, ms(2_000), true);
+		audio.record(6, ms(2_100), true);
+		drop(video);
 		drop(audio);
 		timeline.finish().unwrap();
 
 		let entries = drain(&broadcast, &timeline).await;
-		assert_eq!(entries[0], entry(0, 0, 2_000, &[("audio0", &[(0, 1)])]));
-		assert_eq!(entries.len(), 3);
+		assert_eq!(
+			entries[0],
+			entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 1), (5, 5)])]),
+		);
 	}
 
-	#[test]
-	fn section_advertises_track_and_wall() {
-		let (_broadcast, _segmenter, mut timeline) = setup();
+	// A track with nothing to contribute is a whole-segment gap: the record simply omits it
+	// (an HLS exporter renders EXT-X-GAP). Only a *closed* track produces one, since a live
+	// track that has merely gone quiet still gets to say where the boundary is.
+	#[tokio::test]
+	async fn a_closed_track_leaves_a_whole_segment_gap() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
+		let mut audio = timeline.track("audio0").unwrap();
 
+		video.record(0, ms(0), true);
+		audio.record(0, ms(0), true);
+		drop(audio);
+		video.record(1, ms(2_000), true);
+		video.record(2, ms(4_000), true);
+		drop(video);
+		timeline.finish().unwrap();
+
+		let entries = drain(&broadcast, &timeline).await;
+		assert_eq!(entries[1], entry(1, 2_000, 2_000, &[("video0", &[(1, 1)])]));
+	}
+
+	#[tokio::test]
+	async fn a_non_keyframe_range_start_is_flagged() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
+
+		video.record(0, ms(0), true);
+		// A mid-stream join: the group doesn't open on an IDR.
+		video.record(1, ms(2_000), false);
+		video.record(2, ms(4_000), true);
+		drop(video);
+		timeline.finish().unwrap();
+
+		let entries = drain(&broadcast, &timeline).await;
+		let range = entries[1].tracks["video0"][0];
+		assert!(!range.keyframe, "a range whose first group isn't an IDR says so");
+	}
+
+	// A dead track would otherwise hold every later segment: dropping its recorder is what
+	// says it will never report again.
+	#[tokio::test]
+	async fn a_closed_track_stops_gating() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
+		let mut audio = timeline.track("audio0").unwrap();
+
+		video.record(0, ms(0), true);
+		audio.record(0, ms(0), true);
+		video.record(1, ms(2_000), true);
+		assert!(drain(&broadcast, &timeline).await.is_empty(), "audio still gates");
+
+		drop(audio);
+		let entries = drain(&broadcast, &timeline).await;
+		assert_eq!(
+			entries,
+			vec![entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 0)])])]
+		);
+		drop(video);
+		timeline.finish().unwrap();
+	}
+
+	// The timeline track (and its catalog section) exist only once a media track enrolls.
+	#[tokio::test]
+	async fn the_track_is_created_on_first_enrollment() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let timeline = Producer::new(&broadcast, Config::default());
+		assert!(
+			broadcast.create_track(DEFAULT_NAME, None).is_ok(),
+			"nothing took the name yet"
+		);
+
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let timeline2 = Producer::new(&broadcast, Config::default());
+		let _recorder = timeline2.track("video0").unwrap();
+		assert!(
+			broadcast.create_track(DEFAULT_NAME, None).is_err(),
+			"the timeline took the name once a track enrolled"
+		);
+		drop(timeline);
+	}
+
+	#[tokio::test]
+	async fn section_advertises_track_and_wall() {
+		let (_broadcast, timeline) = setup();
 		let section = timeline.section();
-		assert_eq!(section.track, "timeline.z");
+		assert_eq!(section.track, DEFAULT_NAME);
 		assert_eq!(section.timescale, 1000);
 		assert_eq!(section.wall, None);
 
-		// pts 0 observed at a wall time => wall of pts 0 is that time minus the moq epoch (ms scale).
-		let moq = hang::catalog::MOQ_EPOCH_UNIX_MILLIS;
-		let observed = SystemTime::UNIX_EPOCH + Duration::from_millis(1_751_846_400_000);
-		timeline.set_wall(Timestamp::from_micros(0).unwrap(), observed);
-		assert_eq!(timeline.section().wall, Some(1_751_846_400_000 - moq));
-
-		// A nonzero pts extrapolates back to pts 0: a frame at pts 2s observed at that wall time means
-		// pts 0 was 2s (2000 ms) earlier.
-		timeline.set_wall(Timestamp::from_micros(2_000_000).unwrap(), observed);
-		assert_eq!(timeline.section().wall, Some(1_751_846_400_000 - moq - 2_000));
+		// 2020-01-01T00:00:01Z paired with pts 1s puts pts 0 exactly at the moq epoch.
+		let wall = SystemTime::UNIX_EPOCH + Duration::from_millis(hang::catalog::MOQ_EPOCH_UNIX_MILLIS + 1_000);
+		timeline.set_wall(ms(1_000), wall);
+		assert_eq!(timeline.section().wall, Some(0));
 	}
 
 	#[tokio::test]
 	async fn rejects_an_invalid_timescale() {
-		let (broadcast, _segmenter, mut timeline) = setup();
-		timeline.finish().unwrap();
-
-		// A timescale of 0 can't be honored, and quietly reading the track at milliseconds would
-		// report timestamps the publisher never meant.
+		let (broadcast, timeline) = setup();
+		let _recorder = timeline.track("video0").unwrap();
 		let mut section = timeline.section();
 		section.timescale = 0;
-		match Consumer::<()>::subscribe(&broadcast.consume(), &section).await {
-			Err(crate::Error::InvalidTimescale(0)) => {}
-			Err(err) => panic!("expected an invalid timescale, got {err:?}"),
-			Ok(_) => panic!("expected an invalid timescale to be rejected"),
-		}
-	}
-
-	#[tokio::test]
-	async fn rejects_an_out_of_range_pts() {
-		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let segmenter = Segmenter::default();
-		let timeline = Producer::new(&mut broadcast, &segmenter).unwrap();
-
-		// Publish a record whose pts no Timestamp can hold, bypassing the segmenter.
-		let track = broadcast.create_track("raw.timeline.z", None).unwrap();
-		let config = moq_json::stream::ProducerConfig::default().with_compression(true);
-		let mut raw = moq_json::stream::Producer::new(track, config);
-		raw.append(&Record::<()>::new(0, u64::MAX, 0)).unwrap();
-		raw.finish().unwrap();
-
-		let mut section = timeline.section();
-		section.track = "raw.timeline.z".to_string();
-		let mut consumer = Consumer::<()>::subscribe(&broadcast.consume(), &section).await.unwrap();
-
-		let waiter = kio::Waiter::noop();
-		match consumer.poll_next(&waiter) {
-			Poll::Ready(Err(crate::Error::TimestampOverflow(_))) => {}
-			other => panic!("expected a decode error, got {other:?}"),
-		}
+		let err = Consumer::<()>::subscribe(&broadcast.consume(), &section).await;
+		assert!(matches!(err, Err(crate::Error::InvalidTimescale(0))));
 	}
 }

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -79,6 +79,18 @@ pub struct Config {
 	/// catalog. Leave it `None` when the media decides, which is the common case for real-time
 	/// and for anything importing a source it doesn't control.
 	pub duration_max: Option<Duration>,
+
+	/// The wall-clock time of `pts` 0, advertised in the catalog when set.
+	///
+	/// It anchors content time to an absolute clock, which is what an HLS
+	/// `EXT-X-PROGRAM-DATE-TIME` or a DASH `availabilityStartTime` needs. A publisher stamping
+	/// timestamps from [`catalog::Producer::timestamp`](crate::catalog::Producer::timestamp) has
+	/// its `pts` 0 at construction, so `Some(SystemTime::now())` is the live answer; a recording
+	/// or an import passes the content's real start instead.
+	///
+	/// Clamped to the moq epoch ([`MOQ_EPOCH_UNIX_MILLIS`](hang::catalog::MOQ_EPOCH_UNIX_MILLIS),
+	/// 2020), which the wire format measures from: an earlier time isn't representable.
+	pub wall: Option<SystemTime>,
 }
 
 impl Default for Config {
@@ -86,6 +98,7 @@ impl Default for Config {
 		Self {
 			duration_min: DEFAULT_DURATION_MIN,
 			duration_max: None,
+			wall: None,
 		}
 	}
 }
@@ -134,8 +147,6 @@ struct State {
 	/// A segment overran [`Config::duration_max`]: `(segment, duration)`. The timeline stops
 	/// publishing, since the catalog's promise is already broken.
 	overrun: Option<(u64, Duration)>,
-	/// The wall-clock time of pts 0, in timescale units since the moq epoch.
-	wall: Option<u64>,
 	/// The wire timescale for `pts`/`duration` (the catalog section's default: milliseconds).
 	timescale: Timescale,
 }
@@ -247,20 +258,20 @@ impl State {
 
 		let mut end: Option<Timestamp> = None;
 		for track in self.tracks.values() {
-			if track.closed {
-				continue;
-			}
 			match track.candidate(threshold) {
 				// The latest vote wins: it is a group boundary on the coarsest track, and every
-				// finer track assigns its groups by start, so no group is split.
+				// finer track assigns its groups by start, so no group is split. A closed track
+				// still votes: it can't report more, but the groups it did report are boundaries
+				// like any other, and without them a backlog would collapse into one segment.
 				Some(pts) => {
 					if end.is_none_or(|e| pts.as_micros() > e.as_micros()) {
 						end = Some(pts);
 					}
 				}
 				// This track has produced nothing past the minimum yet, so ending the segment
-				// would strand it. On the terminal pass it never will, so let it go.
-				None if finished => continue,
+				// would strand it. A closed track never will, and neither does anything on the
+				// terminal pass, so neither one blocks.
+				None if finished || track.closed => continue,
 				None => return None,
 			}
 		}
@@ -393,7 +404,16 @@ impl State {
 		let mut section = Timeline::new(DEFAULT_NAME);
 		section.timescale = self.timescale.as_u64() as u32;
 		section.duration_max = self.config.duration_max.map(|max| self.units(max));
-		section.wall = self.wall;
+		section.wall = self.config.wall.map(|wall| {
+			// The wire measures from the moq epoch rather than the Unix one, so the value stays
+			// small enough for a 53-bit integer even at fine timescales.
+			let unix_millis = wall
+				.duration_since(SystemTime::UNIX_EPOCH)
+				.unwrap_or_default()
+				.as_millis();
+			let moq_millis = unix_millis.saturating_sub(hang::catalog::MOQ_EPOCH_UNIX_MILLIS as u128);
+			(moq_millis * self.timescale.as_u64() as u128 / 1000) as u64
+		});
 		section
 	}
 }
@@ -427,7 +447,6 @@ impl Producer {
 				tracks: BTreeMap::new(),
 				holds: 0,
 				overrun: None,
-				wall: None,
 				timescale: Timescale::MILLI,
 			})),
 		}
@@ -507,29 +526,6 @@ impl Producer {
 	/// The catalog's root section advertising this timeline.
 	pub fn section(&self) -> Timeline {
 		self.state.lock().unwrap().section()
-	}
-
-	/// Set (or replace) the wall-clock anchor advertised in the catalog section, from an
-	/// observed pairing of a media timestamp `pts` with its wall-clock time `wall`.
-	///
-	/// Stored as the extrapolated wall-clock time of pts 0, the single value the
-	/// [`Timeline::wall`](hang::catalog::Timeline::wall) field carries: in this timeline's
-	/// timescale, measured from the moq epoch
-	/// ([`MOQ_EPOCH_UNIX_MILLIS`](hang::catalog::MOQ_EPOCH_UNIX_MILLIS), 2020). The catalog
-	/// snapshots [`section`](Self::section) when it advertises the timeline, so go through
-	/// [`catalog::Producer::set_wall`](crate::catalog::Producer::set_wall) (which re-advertises)
-	/// rather than calling this after the timeline is advertised.
-	pub fn set_wall(&self, pts: Timestamp, wall: SystemTime) {
-		let mut state = self.state.lock().unwrap();
-		let unix_millis = wall
-			.duration_since(SystemTime::UNIX_EPOCH)
-			.unwrap_or_default()
-			.as_millis();
-		let scale = state.timescale.as_u64() as u128;
-		let pts_units = pts.as_scale(state.timescale);
-		let moq_millis = unix_millis.saturating_sub(hang::catalog::MOQ_EPOCH_UNIX_MILLIS as u128);
-		let moq_units = moq_millis * scale / 1000;
-		state.wall = Some(moq_units.saturating_sub(pts_units) as u64);
 	}
 
 	/// Flush the final (still open) segment and finish the track.
@@ -893,6 +889,7 @@ mod test {
 		let (broadcast, mut timeline) = setup_with(Config {
 			duration_min: Duration::from_secs(1),
 			duration_max: Some(Duration::from_secs(3)),
+			..Default::default()
 		});
 		let mut video = timeline.track("video0").unwrap();
 
@@ -1138,10 +1135,75 @@ mod test {
 		assert_eq!(section.timescale, 1000);
 		assert_eq!(section.wall, None);
 
-		// 2020-01-01T00:00:01Z paired with pts 1s puts pts 0 exactly at the moq epoch.
-		let wall = SystemTime::UNIX_EPOCH + Duration::from_millis(hang::catalog::MOQ_EPOCH_UNIX_MILLIS + 1_000);
-		timeline.set_wall(ms(1_000), wall);
+		// The wire counts from the moq epoch, so pts 0 at exactly the epoch advertises 0.
+		let (_broadcast, timeline) = setup_with(Config {
+			wall: Some(SystemTime::UNIX_EPOCH + Duration::from_millis(hang::catalog::MOQ_EPOCH_UNIX_MILLIS)),
+			..Default::default()
+		});
 		assert_eq!(timeline.section().wall, Some(0));
+
+		// A second later is a second's worth of timescale units.
+		let (_broadcast, timeline) = setup_with(Config {
+			wall: Some(SystemTime::UNIX_EPOCH + Duration::from_millis(hang::catalog::MOQ_EPOCH_UNIX_MILLIS + 1_000)),
+			..Default::default()
+		});
+		assert_eq!(timeline.section().wall, Some(1_000));
+	}
+
+	// Producers that each guard their own batch nest, so the first to finish doesn't publish
+	// records the others are still filling in.
+	#[tokio::test]
+	async fn holds_nest() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
+
+		let outer = timeline.hold();
+		let inner = timeline.hold();
+
+		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
+			video.record(seq, ms(t), true);
+		}
+
+		drop(inner);
+		assert!(
+			drain(&broadcast, &timeline).await.is_empty(),
+			"the outer hold still gates"
+		);
+
+		drop(outer);
+		assert_eq!(
+			drain(&broadcast, &timeline).await.len(),
+			2,
+			"the last hold released flushes"
+		);
+
+		drop(video);
+		timeline.finish().unwrap();
+	}
+
+	// A hold outstanding when the broadcast ends must not strand the terminal flush.
+	#[tokio::test]
+	async fn finish_overrides_an_outstanding_hold() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
+		let hold = timeline.hold();
+
+		video.record(0, ms(0), true);
+		video.record(1, ms(2_000), true);
+		video.end(ms(4_000));
+		drop(video);
+
+		timeline.finish().unwrap();
+		assert_eq!(
+			drain(&broadcast, &timeline).await,
+			vec![
+				entry(0, 0, 2_000, &[("video0", &[(0, 0)])]),
+				entry(1, 2_000, 2_000, &[("video0", &[(1, 1)])]),
+			]
+		);
+
+		// Dropping it afterwards is a no-op rather than an underflow.
+		drop(hold);
 	}
 
 	#[tokio::test]

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -1,104 +1,306 @@
-//! Timeline publish/subscribe: the segment index HLS/DASH export is built from.
+//! Timeline publish/subscribe: the broadcast's segment index HLS/DASH export is built from.
 //!
-//! A timeline is one media track's segment index: one [`hang::timeline::Record`] per segment,
-//! appended the moment the segment's first group opens, mapping an aligned segment number to
-//! the group and timestamp it starts at. A consumer can answer "which groups cover segment N"
-//! and "where is the live edge" from a few bytes per segment without subscribing to media,
-//! which is the primitive a playlist server (HLS/DASH), a seek bar, or a recorder index needs.
+//! A broadcast has one timeline track, carrying one [`hang::timeline::Record`] per *segment*:
+//! a span of content time shared by every media track, mapped to the group ranges that carry
+//! it on each track. A consumer can answer "which groups cover segment N on track X" and
+//! "where is the live edge" from a few bytes per segment without subscribing to media, which
+//! is the primitive a playlist server (HLS/DASH), a seek bar, or a recorder index needs.
 //!
-//! ## Aligned segments
+//! ## Facts up, policy down
 //!
-//! Segment numbers are shared across the broadcast's tracks through one [`Segmenter`]: segment
-//! 5 of the audio timeline covers the same span of content time as segment 5 of the video
-//! timeline, which is what HLS requires of switchable renditions. The tracks differ only in
-//! how many groups a segment holds, declared per recorder as a [`Cadence`]:
+//! The write side splits into facts and policy, meeting in the shared [`Segmenter`]:
 //!
-//! - [`Cadence::Boundary`]: every group opens the next segment. This is the video track: its
-//!   groups already open on keyframes, and a keyframe is where a segment must start, so a
-//!   video segment is exactly one group. The boundary track is what paces the broadcast's
-//!   segments; wire exactly one per segmenter.
-//! - [`Cadence::Aligned`]: groups pack into the segments the boundary track opens. This is
-//!   audio (and any other short-group track): the first group at or after each boundary is
-//!   recorded as the segment's start, and the groups before the next record fill out the
-//!   segment. When no boundary track ever records (an audio-only broadcast), an aligned
-//!   recorder paces segments itself at the segmenter's [`interval`](Segmenter::with_interval).
+//! - **Tracks report facts.** Each media track enrolls via [`Segmenter::track`], declaring its
+//!   [`Kind`], and its [`Recorder`] reports every group open (sequence, timestamp, keyframe).
+//!   A container import never decides where segments fall; it only states what it published.
+//! - **The owner sets policy.** Segment boundaries come from [`Segmenter::cut`] when the
+//!   application knows them (an HLS import following the source playlist, a CMAF file's
+//!   on-disk segments, an encoder that places its own keyframes). When nobody cuts, the
+//!   segmenter auto-cuts: on the driver track's keyframes once
+//!   [`duration_max`](Segmenter::with_duration_max) has elapsed since the last boundary. The
+//!   driver is the first enrolled video track (video keyframes are where a segment must
+//!   start), or the first enrolled track of any kind when the broadcast has no video. The
+//!   first explicit cut disables auto-cut: the application has taken control.
+//! - **Records flush on completeness.** A segment's record is published only once every
+//!   enrolled track has reported a group at or past the segment's end boundary (or closed),
+//!   proving the segment's group ranges are final on every track. The record is then
+//!   self-contained and immediately servable; a future cut (e.g. pre-registered from a source
+//!   playlist) just waits for the media to catch up.
 //!
-//! ## Handles
+//! Alignment falls out of construction: every track maps its groups onto the same boundary
+//! list, so segment N covers the same span of content time on every track, which is what HLS
+//! requires of switchable renditions.
 //!
-//! The write side splits by role:
+//! ## Wiring
 //!
-//! - [`Producer`] owns the track and its catalog metadata: the [`section`](Producer::section)
-//!   advertised in a rendition's config and the [`set_wall`](Producer::set_wall) anchor. Get one
-//!   from [`catalog::Producer::timeline`](crate::catalog::Producer::timeline); it is `Clone`, and
-//!   every clone shares the one track, so N renditions advertising the same timeline share it.
-//! - [`Recorder`] is the move-only handle a media track records group opens through, wired into a
-//!   rendition's [`container::Producer`](crate::container::Producer) via
-//!   [`with_recorder`](crate::container::Producer::with_recorder) (or, for the 1:1 default,
-//!   [`catalog::Producer::media_producer`](crate::catalog::Producer::media_producer)). Recording is
-//!   what fills a shared timeline, so wire exactly one recorder into it (the source), and let the
-//!   other renditions only advertise.
+//! [`catalog::Producer`](crate::catalog::Producer) owns the broadcast's segmenter (the
+//! catalog is what owns the broadcast's shape) and wires all of this up:
+//! [`media_producer`](crate::catalog::Producer::media_producer) enrolls the track and
+//! creates the timeline track on first use, advertising it in the catalog's root
+//! [`hang::catalog::Timeline`] section. A broadcast that never enrolls a track
+//! publishes no timeline at all: segmentation is opt-in per broadcast, never per track.
 //!
-//! On the read side, [`Consumer::subscribe`] reads a timeline straight from its
-//! [`hang::catalog::Timeline`] section (so the track name and timescale come from the catalog and
-//! can't be mismatched) and yields decoded [`Entry`]s with a real [`Timestamp`]. It is generic over
-//! a [`RecordExt`], so it can read the extra fields another publisher flattens into a record; the
-//! write side publishes the base record shape only.
-//!
-//! On the wire the track is a DEFLATE-compressed [`moq_json::stream`] (a single group, one record
-//! per frame; see [`hang::timeline`] for the record schema).
+//! On the read side, [`Consumer::subscribe`] reads the timeline straight from the catalog's
+//! [`hang::catalog::Timeline`] section (so the track name and timescale can't be
+//! mismatched) and yields decoded [`Entry`]s. On the wire the track is a DEFLATE-compressed
+//! [`moq_json::stream`] (a single group, one record per frame; see [`hang::timeline`] for the
+//! record schema).
 
+use std::collections::{BTreeMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::task::Poll;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 use hang::catalog::Timeline;
-use hang::timeline::{Record, RecordExt, track_name};
+use hang::timeline::{DEFAULT_NAME, Range, Record, RecordExt};
 
 use moq_net::{Timescale, Timestamp};
 
-/// The default [`Segmenter`] interval: an undriven (audio-only) timeline opens a segment about
-/// once per second of media time.
-pub const DEFAULT_INTERVAL: Timestamp = Timestamp::new_const(1, Timescale::SECOND);
+/// The default [`Segmenter`] auto-cut threshold: with nobody cutting explicitly, a new
+/// segment starts at the first driver keyframe at least this far past the last boundary.
+pub const DEFAULT_DURATION_MAX: Timestamp = Timestamp::new_const(2, Timescale::SECOND);
 
-/// How a track's groups map onto the broadcast's aligned segments.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum Cadence {
-	/// Every group opens the next segment (video: groups open on keyframes, and a segment must
-	/// start on one, so a video segment is exactly one group). The boundary track paces the
-	/// broadcast's segments; wire exactly one per [`Segmenter`].
-	Boundary,
-
-	/// Groups pack into the segments the boundary track opens (audio: many short groups per
-	/// segment). The first group at or after each boundary starts the track's slice of that
-	/// segment. When no boundary track ever records, the recorder paces segments itself at the
-	/// segmenter's interval, so an audio-only broadcast still segments.
-	Aligned,
-}
-
-/// The state one [`Segmenter`] guards: the open segment and how it was opened.
-struct SegmenterState {
-	/// The open segment's number and boundary timestamp, `None` before the first group.
-	current: Option<(u64, Timestamp)>,
-	/// A [`Cadence::Boundary`] recorder has opened a segment, so aligned recorders never
-	/// self-pace: the boundary track owns the cadence from its first group on.
-	driven: bool,
-	/// How often an *undriven* segmenter opens a new segment (see [`Segmenter::with_interval`]).
-	interval: Timestamp,
-}
-
-/// The broadcast-wide segment counter every [`Recorder`] shares, so segment numbers align
-/// across tracks.
+/// What a media track carries, declared when it enrolls via [`Segmenter::track`].
 ///
-/// One per broadcast: [`catalog::Producer`](crate::catalog::Producer) owns one and wires it
-/// into every timeline it mints (see
-/// [`catalog::Producer::segmenter`](crate::catalog::Producer::segmenter)). `Clone` shares the
-/// counter. The [`Cadence::Boundary`] recorder advances it; [`Cadence::Aligned`] recorders
-/// read it, falling back to [`interval`](Self::with_interval) pacing only while no boundary
-/// recorder has spoken.
+/// The segmenter prefers a video track as the auto-cut driver, since segment boundaries must
+/// land on video keyframes to keep every rendition independently decodable.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Kind {
+	/// Video: groups open on keyframes, the natural segment boundaries.
+	Video,
+	/// Audio (or any short-group track): groups pack into whatever segments exist.
+	Audio,
+}
+
+/// One enrolled track's report state.
+struct TrackState {
+	kind: Kind,
+	/// Group opens reported and not yet flushed into a record: (sequence, pts, keyframe).
+	pending: VecDeque<(u64, Timestamp, bool)>,
+	/// The newest reported timestamp: everything earlier is known, which is what lets a
+	/// segment ending at or before it flush.
+	frontier: Option<Timestamp>,
+	/// The recorder was dropped; this track no longer gates completeness.
+	closed: bool,
+}
+
+/// The state one [`Segmenter`] guards.
+struct State {
+	/// The auto-cut threshold (see [`Segmenter::with_duration_max`]).
+	duration_max: Timestamp,
+	/// An explicit [`cut`](Segmenter::cut) arrived: the application owns the boundaries and
+	/// auto-cut stays off for the rest of the broadcast.
+	manual: bool,
+	/// Boundaries of segments not yet flushed: `boundaries[0]` starts segment `next_segment`,
+	/// which spans to `boundaries[1]`.
+	boundaries: VecDeque<Timestamp>,
+	/// The newest boundary ever created (never popped), the auto-cut reference point.
+	last_boundary: Option<Timestamp>,
+	/// The number the next flushed record gets.
+	next_segment: u64,
+	/// Every enrolled track, keyed by media track name.
+	tracks: BTreeMap<String, TrackState>,
+	/// The auto-cut driver: the first enrolled video track, else the first enrolled track.
+	driver: Option<String>,
+	/// Where flushed records go once a [`Producer`] attaches; buffered until then.
+	sink: Option<moq_json::stream::Producer<Record>>,
+	/// Records flushed before a sink attached, drained into it on attach.
+	buffered: Vec<Record>,
+	/// The wire timescale for `pts`/`duration` (the catalog section's default: milliseconds).
+	timescale: Timescale,
+}
+
+impl State {
+	/// Register a boundary at `pts`, ignoring a non-monotonic one.
+	fn cut_at(&mut self, pts: Timestamp) {
+		if let Some(last) = self.last_boundary
+			&& pts.as_micros() <= last.as_micros()
+		{
+			return;
+		}
+		self.boundaries.push_back(pts);
+		self.last_boundary = Some(pts);
+	}
+
+	/// A group open reported by `name`: record the fact, auto-cut if this is the driver and
+	/// the policy says so, and flush whatever became complete.
+	fn report(&mut self, name: &str, sequence: u64, pts: Timestamp, keyframe: bool) {
+		let Some(track) = self.tracks.get_mut(name) else {
+			return;
+		};
+		track.pending.push_back((sequence, pts, keyframe));
+		if track.frontier.is_none_or(|f| pts.as_micros() > f.as_micros()) {
+			track.frontier = Some(pts);
+		}
+
+		// Auto-cut: only the driver paces, only at a keyframe when the driver is video (an
+		// audio driver can cut anywhere), and never once the application cuts explicitly.
+		if !self.manual && self.driver.as_deref() == Some(name) {
+			let kind = self.tracks[name].kind;
+			if keyframe || kind != Kind::Video {
+				let due = match self.last_boundary {
+					None => true,
+					Some(last) => pts.as_micros() >= last.as_micros() + self.duration_max.as_micros(),
+				};
+				if due {
+					self.cut_at(pts);
+				}
+			}
+		}
+
+		self.try_flush(false);
+	}
+
+	/// A track's recorder was dropped: stop gating completeness on it and re-elect the driver.
+	fn close(&mut self, name: &str) {
+		if let Some(track) = self.tracks.get_mut(name) {
+			track.closed = true;
+		}
+		if self.driver.as_deref() == Some(name) {
+			self.driver = self.elect();
+		}
+		self.try_flush(false);
+	}
+
+	/// The auto-cut driver among open tracks: a video track if any, else any open track.
+	fn elect(&self) -> Option<String> {
+		self.tracks
+			.iter()
+			.find(|(_, t)| !t.closed && t.kind == Kind::Video)
+			.or_else(|| self.tracks.iter().find(|(_, t)| !t.closed))
+			.map(|(name, _)| name.clone())
+	}
+
+	/// Flush every segment whose content is final on all tracks.
+	///
+	/// A segment needs its end boundary and, per open track, a report at or past it (closed
+	/// tracks can't report again, so they never gate). `finished` treats every track as
+	/// closed, for the terminal flush.
+	fn try_flush(&mut self, finished: bool) {
+		// With nothing enrolled there is nothing to describe; boundaries just wait. This also
+		// keeps pre-registered cuts (e.g. an HLS import cutting ahead of its media) from
+		// flushing empty records.
+		if self.tracks.is_empty() {
+			return;
+		}
+
+		while self.boundaries.len() >= 2 {
+			let end = self.boundaries[1];
+			let complete = finished
+				|| self
+					.tracks
+					.values()
+					.all(|t| t.closed || t.frontier.is_some_and(|f| f.as_micros() >= end.as_micros()));
+			if !complete {
+				return;
+			}
+
+			let start = self.boundaries.pop_front().expect("checked len");
+			self.flush_segment(start, Some(end));
+		}
+	}
+
+	/// Emit the record for the segment starting at `start`: drain every track's groups before
+	/// `end` (all of them for the final, unbounded segment) into ranges.
+	///
+	/// Anything reported before the first boundary lands in the oldest segment: the segment's
+	/// span is nominal, and early groups (a track racing ahead of the first cut) belong to it
+	/// rather than to nowhere.
+	fn flush_segment(&mut self, start: Timestamp, end: Option<Timestamp>) {
+		let pts = start.as_scale(self.timescale) as u64;
+		let duration = match end {
+			Some(end) => (end.as_scale(self.timescale) as u64).saturating_sub(pts),
+			// The final segment has no end boundary; its duration runs to the newest report.
+			// The last group's own duration is unknown, so this is short by up to one group.
+			None => self
+				.tracks
+				.values()
+				.filter_map(|t| t.frontier)
+				.map(|f| f.as_scale(self.timescale) as u64)
+				.max()
+				.unwrap_or(pts)
+				.saturating_sub(pts),
+		};
+
+		let mut record = Record::new(self.next_segment, pts, duration);
+		self.next_segment += 1;
+
+		for (name, track) in &mut self.tracks {
+			let mut ranges: Vec<Range> = Vec::new();
+			while let Some(&(sequence, group_pts, keyframe)) = track.pending.front() {
+				if end.is_some_and(|end| group_pts.as_micros() >= end.as_micros()) {
+					break;
+				}
+				track.pending.pop_front();
+				match ranges.last_mut() {
+					// Contiguous sequences extend the run; a skip starts a new range (a gap:
+					// groups that never existed).
+					Some(last) if last.end + 1 == sequence => last.end = sequence,
+					_ => {
+						let mut range = Range::new(sequence, sequence);
+						range.keyframe = keyframe;
+						ranges.push(range);
+					}
+				}
+			}
+			if !ranges.is_empty() {
+				record.tracks.insert(name.clone(), ranges);
+			}
+		}
+
+		self.emit(record);
+	}
+
+	/// Publish a flushed record, buffering until a sink attaches.
+	///
+	/// The timeline is an optional sidecar, so a transport failure logs and stops publishing
+	/// rather than tearing down the media path.
+	fn emit(&mut self, record: Record) {
+		let Some(sink) = self.sink.as_mut() else {
+			self.buffered.push(record);
+			return;
+		};
+		if let Err(err) = sink.append(&record) {
+			tracing::warn!(%err, "timeline publish failed; dropping the timeline track");
+			self.sink = None;
+		}
+	}
+
+	/// The terminal flush: treat every track as closed, then emit the final open segment.
+	fn finish(&mut self) {
+		// Content but never a boundary (nobody cut and the driver never reported): anchor the
+		// one segment at the earliest report so the content is still indexed.
+		if self.boundaries.is_empty() {
+			let first = self
+				.tracks
+				.values()
+				.filter_map(|t| t.pending.front().map(|&(_, pts, _)| pts))
+				.min_by_key(|pts| pts.as_micros());
+			if let Some(first) = first {
+				self.cut_at(first);
+			}
+		}
+
+		self.try_flush(true);
+
+		if let Some(start) = self.boundaries.pop_front() {
+			// Skip an empty tail: a cut with no content after it describes nothing.
+			if self.tracks.values().any(|t| !t.pending.is_empty()) {
+				self.flush_segment(start, None);
+			}
+		}
+	}
+}
+
+/// The broadcast's segmenter: the shared boundary list every track's groups map onto.
+///
+/// One per broadcast, owned by [`catalog::Producer`](crate::catalog::Producer); `Clone`
+/// shares it. Media tracks enroll with [`track`](Self::track) and report group opens through
+/// the returned [`Recorder`]; the application (or the auto-cut policy) declares boundaries
+/// with [`cut`](Self::cut). See the [module docs](self) for the full model.
 #[derive(Clone)]
 pub struct Segmenter {
-	state: Arc<Mutex<SegmenterState>>,
+	state: Arc<Mutex<State>>,
 }
 
 impl Default for Segmenter {
@@ -108,114 +310,159 @@ impl Default for Segmenter {
 }
 
 impl Segmenter {
-	/// A fresh segmenter: no segments yet, [`DEFAULT_INTERVAL`] pacing while undriven.
+	/// A fresh segmenter: no tracks, no boundaries, auto-cut at [`DEFAULT_DURATION_MAX`].
 	pub fn new() -> Self {
 		Self {
-			state: Arc::new(Mutex::new(SegmenterState {
-				current: None,
-				driven: false,
-				interval: DEFAULT_INTERVAL,
+			state: Arc::new(Mutex::new(State {
+				duration_max: DEFAULT_DURATION_MAX,
+				manual: false,
+				boundaries: VecDeque::new(),
+				last_boundary: None,
+				next_segment: 0,
+				tracks: BTreeMap::new(),
+				driver: None,
+				sink: None,
+				buffered: Vec::new(),
+				timescale: Timescale::MILLI,
 			})),
 		}
 	}
 
-	/// Set the pacing interval an *undriven* segmenter (no [`Cadence::Boundary`] recorder, e.g.
-	/// an audio-only broadcast) opens segments at. Ignored once a boundary recorder is pacing.
+	/// Set the auto-cut threshold: a new segment starts at the first driver keyframe at least
+	/// this far past the last boundary. Translates to HLS `EXT-X-TARGETDURATION` (though an
+	/// exporter should trust the observed durations: a long GOP makes a longer segment, since
+	/// a boundary can only land on a keyframe).
 	///
 	/// Applies to the shared state, so it also works on a clone that is already wired in.
-	pub fn with_interval(self, interval: Timestamp) -> Self {
-		self.state.lock().unwrap().interval = interval;
+	/// Irrelevant once [`cut`](Self::cut) is used; explicit cuts disable auto-cut.
+	pub fn with_duration_max(self, duration_max: Timestamp) -> Self {
+		self.state.lock().unwrap().duration_max = duration_max;
 		self
 	}
 
-	/// A [`Cadence::Boundary`] group open at `pts`: open the next segment and return its number.
+	/// Declare a segment boundary at `pts`: the segment before it ends, the one after starts.
 	///
-	/// The first boundary adopts a segment an aligned recorder self-opened (rather than
-	/// stranding it as a number the boundary track never records), re-anchoring its boundary to
-	/// `pts`; from then on every call opens a new segment.
-	fn boundary(&self, pts: Timestamp) -> u64 {
+	/// For applications that know their boundaries (an HLS import following the source
+	/// playlist, CMAF segments on disk, an encoder placing keyframes). Cuts must be
+	/// monotonic; an out-of-order one is ignored. Cutting ahead of the media is fine: the
+	/// segment's record still waits for every track's groups. The first explicit cut turns
+	/// auto-cut off for good.
+	pub fn cut(&self, pts: Timestamp) {
 		let mut state = self.state.lock().unwrap();
-		let segment = match state.current {
-			None => 0,
-			Some((segment, _)) if !state.driven => segment,
-			Some((segment, _)) => segment + 1,
-		};
-		state.current = Some((segment, pts));
-		state.driven = true;
-		segment
+		state.manual = true;
+		state.cut_at(pts);
+		state.try_flush(false);
 	}
 
-	/// A [`Cadence::Aligned`] group open at `pts`, having last recorded `last`: the segment this
-	/// group starts for its track, or `None` if it merely extends the one already recorded.
+	/// Enroll the media track `name`, returning the [`Recorder`] it reports group opens
+	/// through.
 	///
-	/// A group before the current boundary extends the previous segment; the first group at or
-	/// after it starts the track's slice of the current one. While undriven, a group a full
-	/// interval past the boundary opens the next segment itself.
-	fn align(&self, pts: Timestamp, last: Option<u64>) -> Option<u64> {
+	/// The segment records key ranges by this name, and the track gates segment completeness
+	/// until its recorder drops. Enroll a track when it is about to produce (an enrolled but
+	/// silent track holds every record back, by design: a segment isn't complete until every
+	/// track's content is known). One recorder per track: enrolling the same name again
+	/// resets its state.
+	pub fn track(&self, name: &str, kind: Kind) -> Recorder {
 		let mut state = self.state.lock().unwrap();
-		let Some((segment, boundary)) = state.current else {
-			// The very first group of the broadcast: open segment 0 at its timestamp.
-			state.current = Some((0, pts));
-			return Some(0);
+		state.tracks.insert(
+			name.to_string(),
+			TrackState {
+				kind,
+				pending: VecDeque::new(),
+				frontier: None,
+				closed: false,
+			},
+		);
+
+		// The first video track drives auto-cut (boundaries must land on its keyframes);
+		// without video, the first enrolled track of any kind paces instead.
+		let promote = match &state.driver {
+			None => true,
+			Some(driver) => kind == Kind::Video && state.tracks.get(driver).is_none_or(|d| d.kind != Kind::Video),
 		};
-		if last != Some(segment) && pts.as_micros() >= boundary.as_micros() {
-			return Some(segment);
+		if promote {
+			state.driver = Some(name.to_string());
 		}
-		if !state.driven && pts.as_micros() >= boundary.as_micros() + state.interval.as_micros() {
-			state.current = Some((segment + 1, pts));
-			return Some(segment + 1);
+
+		Recorder {
+			state: self.state.clone(),
+			name: name.to_string(),
 		}
-		None
 	}
 }
 
-/// A media timeline: its catalog [`section`](Self::section) and wall anchor, and the [`Recorder`]
-/// its group opens are recorded through.
+/// Reports one media track's group opens into the shared [`Segmenter`].
 ///
-/// Publishes the base [`Record`] shape (no extension); a [`Consumer`] can still read a record
-/// extension published by another implementation. `Clone`, and every clone shares the one track and
-/// its wall anchor, so a set of aligned renditions can advertise one timeline. Get one from
-/// [`catalog::Producer::timeline`](crate::catalog::Producer::timeline), which keeps ownership,
-/// wires the broadcast's shared [`Segmenter`], and closes the track when the catalog finishes.
+/// Move-only: it is the track's single reporting handle, and dropping it closes the track's
+/// enrollment (segments stop waiting on it). Minted by [`Segmenter::track`] and held by a
+/// rendition's [`container::Producer`](crate::container::Producer).
+pub struct Recorder {
+	state: Arc<Mutex<State>>,
+	name: String,
+}
+
+impl Recorder {
+	/// Report that group `sequence` opened at presentation time `pts`, `keyframe` stating
+	/// whether its first frame is one (i.e. whether a player could join here).
+	///
+	/// Reports must be in group order with monotonic timestamps; this is the fact the
+	/// segmenter builds ranges and completeness from.
+	pub(crate) fn record(&mut self, sequence: u64, pts: Timestamp, keyframe: bool) {
+		self.state.lock().unwrap().report(&self.name, sequence, pts, keyframe);
+	}
+}
+
+impl Drop for Recorder {
+	fn drop(&mut self) {
+		self.state.lock().unwrap().close(&self.name);
+	}
+}
+
+/// The broadcast's timeline track: where the segmenter's records are published, plus the
+/// catalog section advertising it.
+///
+/// `Clone`; clones share the one track and wall anchor. Get one from
+/// [`catalog::Producer::timeline`](crate::catalog::Producer::timeline), which owns it and
+/// finishes it with the catalog.
 #[derive(Clone)]
 pub struct Producer {
-	inner: moq_json::stream::Producer<Record>,
+	state: Arc<Mutex<State>>,
 	track: String,
 	timescale: Timescale,
-	segmenter: Segmenter,
-	// The wall-clock time of pts 0, in timescale units since the moq epoch, advertised in section().
-	// Shared across clones so a set_wall on one is seen by every rendition advertising this timeline.
+	// The wall-clock time of pts 0, in timescale units since the moq epoch, advertised in
+	// section(). Shared across clones.
 	wall: Arc<Mutex<Option<u64>>>,
 }
 
 impl Producer {
-	/// Create a timeline track for the media rendition `name` on the given broadcast, numbering
-	/// segments through `segmenter`.
-	///
-	/// Pass the broadcast's shared segmenter so this track's segment numbers align with its
-	/// siblings'; a track segmented on its own (nothing to align with) passes a fresh one. The
-	/// track is named per [`hang::timeline::track_name`] (`<name>.timeline.z`) at the default
-	/// millisecond timescale.
-	pub fn new(
-		broadcast: &mut moq_net::broadcast::Producer,
-		name: &str,
-		segmenter: Segmenter,
-	) -> Result<Self, moq_net::Error> {
-		let track = track_name(name);
-		let net = broadcast.create_track(track.as_str(), None)?;
-
+	/// Create the broadcast's timeline track ([`DEFAULT_NAME`]) and attach it to `segmenter`
+	/// as the record sink; records flushed before this call are published immediately.
+	pub fn new(broadcast: &mut moq_net::broadcast::Producer, segmenter: &Segmenter) -> Result<Self, moq_net::Error> {
+		let net = broadcast.create_track(DEFAULT_NAME, None)?;
 		let config = moq_json::stream::ProducerConfig::default().with_compression(true);
+		let mut sink = moq_json::stream::Producer::new(net, config);
+
+		let timescale = {
+			let mut state = segmenter.state.lock().unwrap();
+			for record in state.buffered.drain(..) {
+				if let Err(err) = sink.append(&record) {
+					tracing::warn!(%err, "timeline publish failed; dropping the buffered records");
+					break;
+				}
+			}
+			state.sink = Some(sink);
+			state.timescale
+		};
 
 		Ok(Self {
-			inner: moq_json::stream::Producer::new(net, config),
-			track,
-			timescale: Timescale::new(Timeline::default_timescale() as u64).expect("default timescale is nonzero"),
-			segmenter,
+			state: segmenter.state.clone(),
+			track: DEFAULT_NAME.to_string(),
+			timescale,
 			wall: Arc::new(Mutex::new(None)),
 		})
 	}
 
-	/// The catalog section advertising this timeline, to attach to the rendition's config.
+	/// The catalog's root section advertising this timeline.
 	pub fn section(&self) -> Timeline {
 		let mut section = Timeline::new(&self.track);
 		section.timescale = self.timescale.as_u64() as u32;
@@ -229,8 +476,7 @@ impl Producer {
 	/// Stored as the extrapolated wall-clock time of pts 0, the single value the
 	/// [`Timeline::wall`](hang::catalog::Timeline::wall) field carries: in this timeline's timescale,
 	/// measured from the moq epoch ([`MOQ_EPOCH_UNIX_MILLIS`](hang::catalog::MOQ_EPOCH_UNIX_MILLIS),
-	/// 2020). Read every time the rendition republishes its catalog entry, so set it before (or as)
-	/// the rendition registers.
+	/// 2020). Read every time the catalog republishes the section, so set it early.
 	pub fn set_wall(&mut self, pts: Timestamp, wall: SystemTime) {
 		let unix_millis = wall
 			.duration_since(SystemTime::UNIX_EPOCH)
@@ -243,25 +489,16 @@ impl Producer {
 		*self.wall.lock().unwrap() = Some(moq_units.saturating_sub(pts_units) as u64);
 	}
 
-	/// Mint a [`Recorder`] to record group opens into this timeline, mapping them onto the
-	/// shared segment numbering per `cadence`.
-	///
-	/// Wire it into a media track's [`container::Producer`](crate::container::Producer) with
-	/// [`with_recorder`](crate::container::Producer::with_recorder). A recorder owns its own
-	/// cursor, so wire exactly one per timeline (a shared timeline is filled by its source alone).
-	pub fn recorder(&self, cadence: Cadence) -> Recorder {
-		Recorder {
-			inner: self.inner.clone(),
-			timescale: self.timescale,
-			segmenter: self.segmenter.clone(),
-			cadence,
-			last: None,
-		}
-	}
-
-	/// Finish the timeline track, closing its group.
+	/// Flush the final (still open) segment and finish the track.
 	pub fn finish(&mut self) -> Result<(), moq_net::Error> {
-		match self.inner.finish() {
+		let mut state = self.state.lock().unwrap();
+		state.finish();
+		// Finish the sink in place (dropping it would retire the track before late readers
+		// catch up); a post-finish flush then fails in emit() and is logged there.
+		let Some(sink) = state.sink.as_mut() else {
+			return Ok(());
+		};
+		match sink.finish() {
 			Ok(()) => Ok(()),
 			Err(moq_json::Error::Net(err)) => Err(err),
 			Err(err) => unreachable!("timeline finish failed to encode: {err}"),
@@ -269,66 +506,29 @@ impl Producer {
 	}
 }
 
-/// Records a media track's group opens into its timeline as aligned segments.
-///
-/// Move-only (not `Clone`): it owns its segment cursor, so wire exactly one per timeline. Minted by
-/// [`Producer::recorder`] with the track's [`Cadence`] and held by a rendition's
-/// [`container::Producer`](crate::container::Producer).
-pub struct Recorder {
-	inner: moq_json::stream::Producer<Record>,
-	timescale: Timescale,
-	segmenter: Segmenter,
-	cadence: Cadence,
-	// The last segment this track recorded; the cursor an aligned recorder dedupes against.
-	last: Option<u64>,
-}
-
-impl Recorder {
-	/// Record that group `sequence` opened at presentation time `pts`. Per the [`Cadence`], the
-	/// group either opens a segment (recorded) or extends the current one (skipped).
-	pub(crate) fn record(&mut self, sequence: u64, pts: Timestamp) -> Result<(), moq_net::Error> {
-		let segment = match self.cadence {
-			Cadence::Boundary => Some(self.segmenter.boundary(pts)),
-			Cadence::Aligned => self.segmenter.align(pts, self.last),
-		};
-		let Some(segment) = segment else {
-			return Ok(());
-		};
-		self.last = Some(segment);
-
-		let record = Record::new(segment, sequence, pts.as_scale(self.timescale) as u64);
-		match self.inner.append(&record) {
-			Ok(()) => Ok(()),
-			Err(moq_json::Error::Net(err)) => Err(err),
-			// A base record is plain integers and the DEFLATE encoder is infallible, so only a
-			// transport error can surface.
-			Err(err) => unreachable!("timeline record failed to encode: {err}"),
-		}
-	}
-}
-
-/// One decoded timeline entry: an aligned segment, the group it starts at for this track, and
-/// the [`Timestamp`] it opened at.
-///
-/// `pts` is a real timestamp, already converted from the record's on-wire timescale, so a reader
-/// never juggles timescale units.
+/// One decoded timeline entry: a complete aligned segment with real [`Timestamp`]s and the
+/// group ranges each track contributes.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Entry<E: RecordExt = ()> {
-	/// The segment's number, aligned across the broadcast's tracks.
+	/// The segment's number, consecutive within the broadcast.
 	pub segment: u64,
 
-	/// The segment's first group, as used by FETCH/SUBSCRIBE on the media track. The segment
-	/// covers every group up to (excluding) the next entry's `group`.
-	pub group: u64,
-
-	/// The segment's start (its first frame's presentation timestamp).
+	/// The segment's start.
 	pub pts: Timestamp,
+
+	/// The segment's duration. The next entry starts at `pts + duration` unless content time
+	/// itself jumped (a discontinuity).
+	pub duration: Duration,
+
+	/// The group ranges each participating media track contributes, keyed by track name. A
+	/// track absent from the map has no content in this span (HLS `EXT-X-GAP`).
+	pub tracks: BTreeMap<String, Vec<Range>>,
 
 	/// The record's application extension (nothing for the default `()`).
 	pub ext: E,
 }
 
-/// Reads a media track's timeline, yielding decoded [`Entry`]s in publish order.
+/// Reads a broadcast's timeline, yielding decoded [`Entry`]s in segment order.
 ///
 /// Generic over the record extension `E` (see [`RecordExt`]).
 pub struct Consumer<E: RecordExt = ()> {
@@ -337,12 +537,11 @@ pub struct Consumer<E: RecordExt = ()> {
 }
 
 impl<E: RecordExt> Consumer<E> {
-	/// Subscribe to the timeline advertised by a media track's [`Timeline`] catalog section.
+	/// Subscribe to the timeline advertised by the catalog's [`Timeline`] section.
 	///
-	/// The section supplies both the track name and the timescale, so a reader can't pair the wrong
-	/// scale with the track.
-	///
-	/// Errors if the section declares a timescale that isn't representable.
+	/// The section supplies both the track name and the timescale, so a reader can't pair the
+	/// wrong scale with the track. Errors if the section declares a timescale that isn't
+	/// representable.
 	pub async fn subscribe(broadcast: &moq_net::broadcast::Consumer, section: &Timeline) -> crate::Result<Self> {
 		let track = broadcast.track(&section.track)?.subscribe(None).await?;
 
@@ -355,15 +554,18 @@ impl<E: RecordExt> Consumer<E> {
 		})
 	}
 
-	/// Decode a record into an entry, converting its pts out of the wire timescale.
+	/// Decode a record into an entry, converting its timing out of the wire timescale.
 	///
 	/// A pts the timescale can't represent is an error rather than a substituted value: silently
 	/// moving a timestamp would misdirect seeking and live-edge logic.
 	fn decode(&self, record: Record<E>) -> crate::Result<Entry<E>> {
+		let scale = self.timescale.as_u64() as u128;
+		let nanos = (record.duration as u128) * 1_000_000_000 / scale;
 		Ok(Entry {
 			segment: record.segment,
-			group: record.group,
 			pts: Timestamp::new(record.pts, self.timescale)?,
+			duration: Duration::from_nanos(nanos as u64),
+			tracks: record.tracks,
 			ext: record.ext,
 		})
 	}
@@ -392,17 +594,27 @@ mod test {
 
 	use super::*;
 
-	fn entry(segment: u64, group: u64, pts_ms: u64) -> Entry {
-		Entry {
-			segment,
-			group,
-			pts: Timestamp::from_millis(pts_ms).unwrap(),
-			ext: (),
-		}
+	fn ms(v: u64) -> Timestamp {
+		Timestamp::from_millis(v).unwrap()
 	}
 
-	fn producer(broadcast: &mut moq_net::broadcast::Producer, name: &str, segmenter: &Segmenter) -> Producer {
-		Producer::new(broadcast, name, segmenter.clone()).unwrap()
+	/// Build an Entry the tests compare against.
+	fn entry(segment: u64, pts_ms: u64, duration_ms: u64, tracks: &[(&str, &[(u64, u64)])]) -> Entry {
+		Entry {
+			segment,
+			pts: ms(pts_ms),
+			duration: Duration::from_millis(duration_ms),
+			tracks: tracks
+				.iter()
+				.map(|(name, ranges)| {
+					(
+						name.to_string(),
+						ranges.iter().map(|&(start, end)| Range::new(start, end)).collect(),
+					)
+				})
+				.collect(),
+			ext: (),
+		}
 	}
 
 	/// Drain a finished timeline track by subscribing to the producer's advertised section.
@@ -418,154 +630,325 @@ mod test {
 		out
 	}
 
-	fn frame(timestamp_us: u64, keyframe: bool) -> crate::container::Frame {
-		crate::container::Frame {
-			timestamp: Timestamp::from_micros(timestamp_us).unwrap(),
-			payload: bytes::Bytes::from_static(&[0xDE, 0xAD]),
-			keyframe,
-			duration: None,
-		}
+	fn setup() -> (moq_net::broadcast::Producer, Segmenter, Producer) {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let segmenter = Segmenter::new();
+		let producer = Producer::new(&mut broadcast, &segmenter).unwrap();
+		(broadcast, segmenter, producer)
 	}
 
 	#[tokio::test]
-	async fn boundary_records_every_group_as_a_segment() {
-		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let mut timeline = producer(&mut broadcast, "video0", &Segmenter::new());
-		assert_eq!(timeline.track, "video0.timeline.z");
+	async fn auto_cut_paces_on_video_keyframes() {
+		let (broadcast, segmenter, mut timeline) = setup();
+		let mut video = segmenter.track("video0", Kind::Video);
+		let mut audio = segmenter.track("audio0", Kind::Audio);
 
-		let track = broadcast.create_track("video0", None).unwrap();
-		let mut media = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy)
-			.with_recorder(timeline.recorder(Cadence::Boundary));
-
-		media.write(frame(0, true)).unwrap(); // group 0 @ 0us
-		media.write(frame(2_000_000, false)).unwrap(); // extends group 0
-		media.write(frame(4_000_000, true)).unwrap(); // group 1 @ 4_000_000us
-		media.finish().unwrap();
+		// Video keyframes every 2s (the default duration_max), audio groups every 500ms.
+		// Reports interleave like a real muxer: audio runs slightly ahead.
+		video.record(0, ms(0), true);
+		for (seq, t) in [(0u64, 0u64), (1, 500), (2, 1_000), (3, 1_500)] {
+			audio.record(seq, ms(t), true);
+		}
+		video.record(1, ms(2_000), true);
+		for (seq, t) in [(4u64, 2_000u64), (5, 2_500), (6, 3_000), (7, 3_500)] {
+			audio.record(seq, ms(t), true);
+		}
+		video.record(2, ms(4_000), true);
+		audio.record(8, ms(4_000), true);
+		drop(video);
+		drop(audio);
 		timeline.finish().unwrap();
 
-		// Entry pts is a real Timestamp (decoded from the ms-timescale record); each group is a segment.
+		// Segment 0 flushes only once BOTH tracks reported past 2s; every record is
+		// self-contained (start AND end groups, explicit duration).
 		assert_eq!(
 			drain(&broadcast, &timeline).await,
-			vec![entry(0, 0, 0), entry(1, 1, 4_000)]
+			vec![
+				entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 3)])]),
+				entry(1, 2_000, 2_000, &[("video0", &[(1, 1)]), ("audio0", &[(4, 7)])]),
+				entry(2, 4_000, 0, &[("video0", &[(2, 2)]), ("audio0", &[(8, 8)])]),
+			]
 		);
 	}
 
 	#[tokio::test]
-	async fn aligned_records_the_first_group_at_each_boundary() {
-		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let segmenter = Segmenter::new();
-		let mut video = producer(&mut broadcast, "video0", &segmenter);
-		let mut audio = producer(&mut broadcast, "audio0", &segmenter);
-		let mut leader = video.recorder(Cadence::Boundary);
-		let mut follower = audio.recorder(Cadence::Aligned);
+	async fn a_segment_waits_for_every_track() {
+		let (broadcast, segmenter, timeline) = setup();
+		let mut video = segmenter.track("video0", Kind::Video);
+		let mut audio = segmenter.track("audio0", Kind::Audio);
 
-		// Interleaved group opens: video keyframes every 2s, audio groups every 300ms.
-		leader.record(0, Timestamp::from_millis(0).unwrap()).unwrap(); // segment 0 @ 0
-		for (seq, ms) in [
-			(0u64, 0u64),
-			(1, 300),
-			(2, 600),
-			(3, 900),
-			(4, 1_200),
-			(5, 1_500),
-			(6, 1_800),
-		] {
-			follower.record(seq, Timestamp::from_millis(ms).unwrap()).unwrap();
-		}
-		leader.record(1, Timestamp::from_millis(2_000).unwrap()).unwrap(); // segment 1 @ 2s
-		for (seq, ms) in [(7u64, 2_100u64), (8, 2_400)] {
-			follower.record(seq, Timestamp::from_millis(ms).unwrap()).unwrap();
-		}
-		video.finish().unwrap();
-		audio.finish().unwrap();
+		// Video is two boundaries ahead, but audio hasn't crossed the first one: nothing
+		// may flush, because audio's groups for segment 0 aren't final yet.
+		video.record(0, ms(0), true);
+		video.record(1, ms(2_000), true);
+		video.record(2, ms(4_000), true);
+		audio.record(0, ms(0), true);
+		let section = timeline.section();
+		let mut consumer = Consumer::<()>::subscribe(&broadcast.consume(), &section).await.unwrap();
+		let waiter = kio::Waiter::noop();
+		assert!(consumer.poll_next(&waiter).is_pending());
 
-		// Video: one group per segment. Audio: the first group at/after each boundary; the rest
-		// of its groups pack into the segment implicitly (they run until the next record's group).
+		// Audio crossing the second boundary finalizes segment 0 (and only segment 0).
+		audio.record(1, ms(2_100), true);
+		match consumer.poll_next(&waiter) {
+			Poll::Ready(Ok(Some(got))) => {
+				assert_eq!(got, entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 0)])]))
+			}
+			other => panic!("expected segment 0, got {other:?}"),
+		}
+		assert!(consumer.poll_next(&waiter).is_pending());
+	}
+
+	#[tokio::test]
+	async fn explicit_cuts_disable_auto_cut() {
+		let (broadcast, segmenter, mut timeline) = setup();
+		let mut video = segmenter.track("video0", Kind::Video);
+
+		// The app cuts every 6s (e.g. following a source playlist); video keyframes every 2s.
+		// Auto-cut (duration_max 2s) must not fire between the explicit cuts.
+		segmenter.cut(ms(0));
+		segmenter.cut(ms(6_000));
+		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000), (3, 6_000), (4, 8_000)] {
+			video.record(seq, ms(t), true);
+		}
+		drop(video);
+		timeline.finish().unwrap();
+
+		// One multi-GOP segment per cut: tiny GOPs pack into larger segments.
 		assert_eq!(
-			drain(&broadcast, &video).await,
-			vec![entry(0, 0, 0), entry(1, 1, 2_000)]
-		);
-		assert_eq!(
-			drain(&broadcast, &audio).await,
-			vec![entry(0, 0, 0), entry(1, 7, 2_100)]
+			drain(&broadcast, &timeline).await,
+			vec![
+				entry(0, 0, 6_000, &[("video0", &[(0, 2)])]),
+				entry(1, 6_000, 2_000, &[("video0", &[(3, 4)])]),
+			]
 		);
 	}
 
 	#[tokio::test]
-	async fn undriven_aligned_recorder_paces_itself() {
-		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let mut timeline = producer(&mut broadcast, "audio0", &Segmenter::new());
-		let mut recorder = timeline.recorder(Cadence::Aligned);
+	async fn cutting_ahead_of_the_media_waits_for_it() {
+		let (broadcast, segmenter, mut timeline) = setup();
 
-		// No boundary track: the default interval is 1s, so group opens 300ms apart self-open a
-		// segment only once a full interval has passed since the last boundary.
-		for (seq, ms) in [(0u64, 0u64), (1, 300), (2, 600), (3, 900), (4, 1_200)] {
-			recorder.record(seq, Timestamp::from_millis(ms).unwrap()).unwrap();
+		// An HLS import pre-registers boundaries from the playlist before any media arrives.
+		segmenter.cut(ms(0));
+		segmenter.cut(ms(6_000));
+		segmenter.cut(ms(12_000));
+
+		let mut video = segmenter.track("video0", Kind::Video);
+		let section = timeline.section();
+		let mut consumer = Consumer::<()>::subscribe(&broadcast.consume(), &section).await.unwrap();
+		let waiter = kio::Waiter::noop();
+		assert!(consumer.poll_next(&waiter).is_pending(), "no media, no records");
+
+		for (seq, t) in [(0u64, 0u64), (1, 3_000), (2, 6_000), (3, 9_000)] {
+			video.record(seq, ms(t), true);
 		}
-		drop(recorder);
+		drop(video);
 		timeline.finish().unwrap();
 
 		assert_eq!(
 			drain(&broadcast, &timeline).await,
-			vec![entry(0, 0, 0), entry(1, 4, 1_200)]
+			vec![
+				entry(0, 0, 6_000, &[("video0", &[(0, 1)])]),
+				entry(1, 6_000, 6_000, &[("video0", &[(2, 3)])]),
+			]
 		);
 	}
 
 	#[tokio::test]
-	async fn first_boundary_adopts_a_self_opened_segment() {
-		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let segmenter = Segmenter::new();
-		let mut video = producer(&mut broadcast, "video0", &segmenter);
-		let mut audio = producer(&mut broadcast, "audio0", &segmenter);
-		let mut leader = video.recorder(Cadence::Boundary);
-		let mut follower = audio.recorder(Cadence::Aligned);
+	async fn audio_only_paces_itself() {
+		let (broadcast, segmenter, mut timeline) = setup();
+		let mut audio = segmenter.track("audio0", Kind::Audio);
 
-		// Audio starts first and self-opens segment 0; the video keyframe arriving moments later
-		// adopts it (same number) instead of stranding an audio-only segment 0, then paces on.
-		follower.record(0, Timestamp::from_millis(0).unwrap()).unwrap();
-		leader.record(0, Timestamp::from_millis(30).unwrap()).unwrap();
-		leader.record(1, Timestamp::from_millis(2_030).unwrap()).unwrap();
-		follower.record(70, Timestamp::from_millis(2_100).unwrap()).unwrap();
-		video.finish().unwrap();
-		audio.finish().unwrap();
+		// No video: the first (audio) track drives, cutting every duration_max (2s).
+		for (seq, t) in [(0u64, 0u64), (1, 500), (2, 1_000), (3, 1_500), (4, 2_000), (5, 2_500)] {
+			audio.record(seq, ms(t), true);
+		}
+		drop(audio);
+		timeline.finish().unwrap();
 
 		assert_eq!(
-			drain(&broadcast, &video).await,
-			vec![entry(0, 0, 30), entry(1, 1, 2_030)]
-		);
-		assert_eq!(
-			drain(&broadcast, &audio).await,
-			vec![entry(0, 0, 0), entry(1, 70, 2_100)]
+			drain(&broadcast, &timeline).await,
+			vec![
+				entry(0, 0, 2_000, &[("audio0", &[(0, 3)])]),
+				entry(1, 2_000, 500, &[("audio0", &[(4, 5)])]),
+			]
 		);
 	}
 
 	#[tokio::test]
-	async fn aligned_recorder_joining_late_records_the_current_segment() {
+	async fn video_enrolling_late_takes_over_the_pacing() {
+		let (broadcast, segmenter, mut timeline) = setup();
+		let mut audio = segmenter.track("audio0", Kind::Audio);
+		audio.record(0, ms(0), true);
+		audio.record(1, ms(2_000), true); // audio-driven boundary at 2s
+
+		// Video joins: it becomes the driver, and the next boundary lands on ITS keyframe.
+		let mut video = segmenter.track("video0", Kind::Video);
+		video.record(0, ms(2_100), true);
+		video.record(1, ms(4_100), true);
+		audio.record(2, ms(4_200), true);
+		drop(video);
+		drop(audio);
+		timeline.finish().unwrap();
+
+		assert_eq!(
+			drain(&broadcast, &timeline).await,
+			vec![
+				entry(0, 0, 2_000, &[("audio0", &[(0, 0)])]),
+				entry(1, 2_000, 2_100, &[("audio0", &[(1, 1)]), ("video0", &[(0, 0)])]),
+				entry(2, 4_100, 100, &[("audio0", &[(2, 2)]), ("video0", &[(1, 1)])]),
+			]
+		);
+	}
+
+	#[tokio::test]
+	async fn groups_before_the_first_boundary_join_the_first_segment() {
+		let (broadcast, segmenter, mut timeline) = setup();
+		let mut video = segmenter.track("video0", Kind::Video);
+		let mut audio = segmenter.track("audio0", Kind::Audio);
+
+		// Audio races ahead of video's first keyframe (the startup race): its early groups
+		// belong to segment 0, not to nowhere.
+		audio.record(0, ms(0), true);
+		video.record(0, ms(30), true);
+		video.record(1, ms(2_030), true);
+		audio.record(1, ms(2_100), true);
+		drop(video);
+		drop(audio);
+		timeline.finish().unwrap();
+
+		assert_eq!(
+			drain(&broadcast, &timeline).await,
+			vec![
+				entry(0, 30, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 0)])]),
+				entry(1, 2_030, 70, &[("video0", &[(1, 1)]), ("audio0", &[(1, 1)])]),
+			]
+		);
+	}
+
+	#[tokio::test]
+	async fn sequence_gaps_split_ranges() {
+		let (broadcast, segmenter, mut timeline) = setup();
+		let mut video = segmenter.track("video0", Kind::Video);
+		let mut audio = segmenter.track("audio0", Kind::Audio);
+
+		// Elemental-style gap: audio groups 2..=4 never existed inside segment 0.
+		video.record(0, ms(0), true);
+		audio.record(0, ms(0), true);
+		audio.record(1, ms(300), true);
+		audio.record(5, ms(1_500), true);
+		video.record(1, ms(2_000), true);
+		audio.record(6, ms(2_100), true);
+		drop(video);
+		drop(audio);
+		timeline.finish().unwrap();
+
+		let entries = drain(&broadcast, &timeline).await;
+		assert_eq!(
+			entries[0],
+			entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 1), (5, 5)])]),
+		);
+	}
+
+	#[tokio::test]
+	async fn a_whole_segment_gap_omits_the_track() {
+		let (broadcast, segmenter, mut timeline) = setup();
+		let mut video = segmenter.track("video0", Kind::Video);
+		let mut audio = segmenter.track("audio0", Kind::Audio);
+
+		// Audio drops out for all of segment 1 and returns in segment 2: the record simply
+		// has no audio entry (an HLS exporter renders EXT-X-GAP).
+		video.record(0, ms(0), true);
+		audio.record(0, ms(0), true);
+		video.record(1, ms(2_000), true);
+		video.record(2, ms(4_000), true);
+		audio.record(1, ms(4_500), true);
+		drop(video);
+		drop(audio);
+		timeline.finish().unwrap();
+
+		let entries = drain(&broadcast, &timeline).await;
+		assert_eq!(entries[1], entry(1, 2_000, 2_000, &[("video0", &[(1, 1)])]));
+		assert_eq!(
+			entries[2],
+			entry(2, 4_000, 500, &[("video0", &[(2, 2)]), ("audio0", &[(1, 1)])])
+		);
+	}
+
+	#[tokio::test]
+	async fn a_non_keyframe_range_start_is_flagged() {
+		let (broadcast, segmenter, mut timeline) = setup();
+		let mut video = segmenter.track("video0", Kind::Video);
+
+		segmenter.cut(ms(0));
+		segmenter.cut(ms(2_000));
+		video.record(0, ms(0), true);
+		// A gappy source resumes without an IDR: the range says so, and auto-cut would not
+		// have cut here anyway (explicit cuts are in charge).
+		video.record(1, ms(2_500), false);
+		video.record(2, ms(4_000), true);
+		drop(video);
+		timeline.finish().unwrap();
+
+		let entries = drain(&broadcast, &timeline).await;
+		let ranges = &entries[1].tracks["video0"];
+		assert_eq!((ranges[0].start, ranges[0].end, ranges[0].keyframe), (1, 2, false));
+	}
+
+	#[tokio::test]
+	async fn a_closed_track_stops_gating() {
+		let (broadcast, segmenter, mut timeline) = setup();
+		let mut video = segmenter.track("video0", Kind::Video);
+		let mut audio = segmenter.track("audio0", Kind::Audio);
+
+		video.record(0, ms(0), true);
+		audio.record(0, ms(0), true);
+		video.record(1, ms(2_000), true);
+		video.record(2, ms(4_000), true);
+
+		// Audio dies mid-broadcast. Its recorder dropping is what unblocks segment 0 (and 1):
+		// completeness can't wait forever on a track that will never report again.
+		drop(audio);
+		drop(video);
+		timeline.finish().unwrap();
+
+		assert_eq!(
+			drain(&broadcast, &timeline).await,
+			vec![
+				entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("audio0", &[(0, 0)])]),
+				entry(1, 2_000, 2_000, &[("video0", &[(1, 1)])]),
+				entry(2, 4_000, 0, &[("video0", &[(2, 2)])]),
+			]
+		);
+	}
+
+	#[tokio::test]
+	async fn records_flushed_before_the_track_exists_are_buffered() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let segmenter = Segmenter::new();
-		let mut video = producer(&mut broadcast, "video0", &segmenter);
-		let mut audio = producer(&mut broadcast, "audio0", &segmenter);
-		let mut leader = video.recorder(Cadence::Boundary);
 
-		leader.record(0, Timestamp::from_millis(0).unwrap()).unwrap();
-		leader.record(1, Timestamp::from_millis(2_000).unwrap()).unwrap();
+		// Segments complete before any timeline track exists (e.g. the catalog wires the
+		// track lazily): they publish the moment it attaches.
+		let mut audio = segmenter.track("audio0", Kind::Audio);
+		for (seq, t) in [(0u64, 0u64), (1, 1_000), (2, 2_000), (3, 3_000), (4, 4_000)] {
+			audio.record(seq, ms(t), true);
+		}
 
-		// An audio track added mid-broadcast: its first group lands in segment 1, not 0.
-		let mut follower = audio.recorder(Cadence::Aligned);
-		follower.record(0, Timestamp::from_millis(2_050).unwrap()).unwrap();
-		video.finish().unwrap();
-		audio.finish().unwrap();
+		let mut timeline = Producer::new(&mut broadcast, &segmenter).unwrap();
+		drop(audio);
+		timeline.finish().unwrap();
 
-		assert_eq!(drain(&broadcast, &audio).await, vec![entry(1, 0, 2_050)]);
+		let entries = drain(&broadcast, &timeline).await;
+		assert_eq!(entries[0], entry(0, 0, 2_000, &[("audio0", &[(0, 1)])]));
+		assert_eq!(entries.len(), 3);
 	}
 
 	#[test]
 	fn section_advertises_track_and_wall() {
-		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let mut timeline = producer(&mut broadcast, "audio0", &Segmenter::new());
+		let (_broadcast, _segmenter, mut timeline) = setup();
 
 		let section = timeline.section();
-		assert_eq!(section.track, "audio0.timeline.z");
+		assert_eq!(section.track, "timeline.z");
 		assert_eq!(section.timescale, 1000);
 		assert_eq!(section.wall, None);
 
@@ -583,8 +966,7 @@ mod test {
 
 	#[tokio::test]
 	async fn rejects_an_invalid_timescale() {
-		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let mut timeline = producer(&mut broadcast, "video0", &Segmenter::new());
+		let (broadcast, _segmenter, mut timeline) = setup();
 		timeline.finish().unwrap();
 
 		// A timescale of 0 can't be honored, and quietly reading the track at milliseconds would
@@ -601,13 +983,14 @@ mod test {
 	#[tokio::test]
 	async fn rejects_an_out_of_range_pts() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let timeline = producer(&mut broadcast, "video0", &Segmenter::new());
+		let segmenter = Segmenter::new();
+		let timeline = Producer::new(&mut broadcast, &segmenter).unwrap();
 
-		// Publish a record whose pts no Timestamp can hold, bypassing the recorder.
+		// Publish a record whose pts no Timestamp can hold, bypassing the segmenter.
 		let track = broadcast.create_track("raw.timeline.z", None).unwrap();
 		let config = moq_json::stream::ProducerConfig::default().with_compression(true);
 		let mut raw = moq_json::stream::Producer::new(track, config);
-		raw.append(&Record::<()>::new(0, 0, u64::MAX)).unwrap();
+		raw.append(&Record::<()>::new(0, u64::MAX, 0)).unwrap();
 		raw.finish().unwrap();
 
 		let mut section = timeline.section();
@@ -619,23 +1002,5 @@ mod test {
 			Poll::Ready(Err(crate::Error::TimestampOverflow(_))) => {}
 			other => panic!("expected a decode error, got {other:?}"),
 		}
-	}
-
-	#[tokio::test]
-	async fn consumer_decodes_pts_from_the_section() {
-		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let mut timeline = producer(&mut broadcast, "video0", &Segmenter::new());
-		timeline
-			.recorder(Cadence::Boundary)
-			.record(3, Timestamp::from_micros(7_000).unwrap())
-			.unwrap();
-		timeline.finish().unwrap();
-
-		// The reader takes the track name + timescale from the section, and yields a real Timestamp.
-		// The pts is decoded at the timeline's (millisecond) timescale, so compare the instant rather
-		// than the scale-sensitive representation (7ms == 7000us as an instant, but not field-wise).
-		let entries = drain(&broadcast, &timeline).await;
-		assert_eq!(entries, vec![entry(0, 3, 7)]);
-		assert_eq!(entries[0].pts.as_micros(), 7_000);
 	}
 }

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -1,14 +1,31 @@
-//! Timeline publish/subscribe.
+//! Timeline publish/subscribe: the segment index HLS/DASH export is built from.
 //!
-//! A timeline is one media track's group index: one [`hang::timeline::Record`] per group,
-//! appended the moment the group opens, mapping a group sequence to the group's start
-//! timestamp. A consumer can answer "which group covers time T" and "where is the live edge"
-//! from a few bytes per group without subscribing to media, the primitive a playlist server
-//! (HLS/DASH), a seek bar, or a recorder index needs.
+//! A timeline is one media track's segment index: one [`hang::timeline::Record`] per segment,
+//! appended the moment the segment's first group opens, mapping an aligned segment number to
+//! the group and timestamp it starts at. A consumer can answer "which groups cover segment N"
+//! and "where is the live edge" from a few bytes per segment without subscribing to media,
+//! which is the primitive a playlist server (HLS/DASH), a seek bar, or a recorder index needs.
 //!
-//! A timeline can be shared: audio and video groups have different durations so they need separate
-//! timelines, but an aligned set of renditions (a transcode ladder whose rungs mirror the source's
-//! group boundaries) can point at one. The write side splits by role:
+//! ## Aligned segments
+//!
+//! Segment numbers are shared across the broadcast's tracks through one [`Segmenter`]: segment
+//! 5 of the audio timeline covers the same span of content time as segment 5 of the video
+//! timeline, which is what HLS requires of switchable renditions. The tracks differ only in
+//! how many groups a segment holds, declared per recorder as a [`Cadence`]:
+//!
+//! - [`Cadence::Boundary`]: every group opens the next segment. This is the video track: its
+//!   groups already open on keyframes, and a keyframe is where a segment must start, so a
+//!   video segment is exactly one group. The boundary track is what paces the broadcast's
+//!   segments; wire exactly one per segmenter.
+//! - [`Cadence::Aligned`]: groups pack into the segments the boundary track opens. This is
+//!   audio (and any other short-group track): the first group at or after each boundary is
+//!   recorded as the segment's start, and the groups before the next record fill out the
+//!   segment. When no boundary track ever records (an audio-only broadcast), an aligned
+//!   recorder paces segments itself at the segmenter's [`interval`](Segmenter::with_interval).
+//!
+//! ## Handles
+//!
+//! The write side splits by role:
 //!
 //! - [`Producer`] owns the track and its catalog metadata: the [`section`](Producer::section)
 //!   advertised in a rendition's config and the [`set_wall`](Producer::set_wall) anchor. Get one
@@ -29,12 +46,6 @@
 //!
 //! On the wire the track is a DEFLATE-compressed [`moq_json::stream`] (a single group, one record
 //! per frame; see [`hang::timeline`] for the record schema).
-//!
-//! Recording is throttled to a [`granularity`](Producer::with_granularity) (default
-//! [`DEFAULT_GRANULARITY`], one second): at most one record per that much media time. Video
-//! keyframes are already a granularity or more apart, so every group is indexed; short audio groups
-//! are thinned out. A consumer that lands between two records extrapolates the group number
-//! (sequences are contiguous) or fetches to fill the gap.
 
 use std::sync::{Arc, Mutex};
 use std::task::Poll;
@@ -45,9 +56,118 @@ use hang::timeline::{Record, RecordExt, track_name};
 
 use moq_net::{Timescale, Timestamp};
 
-/// The default [`granularity`](Producer::with_granularity): at most one record per second of
-/// media time.
-pub const DEFAULT_GRANULARITY: Timestamp = Timestamp::new_const(1, Timescale::SECOND);
+/// The default [`Segmenter`] interval: an undriven (audio-only) timeline opens a segment about
+/// once per second of media time.
+pub const DEFAULT_INTERVAL: Timestamp = Timestamp::new_const(1, Timescale::SECOND);
+
+/// How a track's groups map onto the broadcast's aligned segments.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Cadence {
+	/// Every group opens the next segment (video: groups open on keyframes, and a segment must
+	/// start on one, so a video segment is exactly one group). The boundary track paces the
+	/// broadcast's segments; wire exactly one per [`Segmenter`].
+	Boundary,
+
+	/// Groups pack into the segments the boundary track opens (audio: many short groups per
+	/// segment). The first group at or after each boundary starts the track's slice of that
+	/// segment. When no boundary track ever records, the recorder paces segments itself at the
+	/// segmenter's interval, so an audio-only broadcast still segments.
+	Aligned,
+}
+
+/// The state one [`Segmenter`] guards: the open segment and how it was opened.
+struct SegmenterState {
+	/// The open segment's number and boundary timestamp, `None` before the first group.
+	current: Option<(u64, Timestamp)>,
+	/// A [`Cadence::Boundary`] recorder has opened a segment, so aligned recorders never
+	/// self-pace: the boundary track owns the cadence from its first group on.
+	driven: bool,
+	/// How often an *undriven* segmenter opens a new segment (see [`Segmenter::with_interval`]).
+	interval: Timestamp,
+}
+
+/// The broadcast-wide segment counter every [`Recorder`] shares, so segment numbers align
+/// across tracks.
+///
+/// One per broadcast: [`catalog::Producer`](crate::catalog::Producer) owns one and wires it
+/// into every timeline it mints (see
+/// [`catalog::Producer::segmenter`](crate::catalog::Producer::segmenter)). `Clone` shares the
+/// counter. The [`Cadence::Boundary`] recorder advances it; [`Cadence::Aligned`] recorders
+/// read it, falling back to [`interval`](Self::with_interval) pacing only while no boundary
+/// recorder has spoken.
+#[derive(Clone)]
+pub struct Segmenter {
+	state: Arc<Mutex<SegmenterState>>,
+}
+
+impl Default for Segmenter {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl Segmenter {
+	/// A fresh segmenter: no segments yet, [`DEFAULT_INTERVAL`] pacing while undriven.
+	pub fn new() -> Self {
+		Self {
+			state: Arc::new(Mutex::new(SegmenterState {
+				current: None,
+				driven: false,
+				interval: DEFAULT_INTERVAL,
+			})),
+		}
+	}
+
+	/// Set the pacing interval an *undriven* segmenter (no [`Cadence::Boundary`] recorder, e.g.
+	/// an audio-only broadcast) opens segments at. Ignored once a boundary recorder is pacing.
+	///
+	/// Applies to the shared state, so it also works on a clone that is already wired in.
+	pub fn with_interval(self, interval: Timestamp) -> Self {
+		self.state.lock().unwrap().interval = interval;
+		self
+	}
+
+	/// A [`Cadence::Boundary`] group open at `pts`: open the next segment and return its number.
+	///
+	/// The first boundary adopts a segment an aligned recorder self-opened (rather than
+	/// stranding it as a number the boundary track never records), re-anchoring its boundary to
+	/// `pts`; from then on every call opens a new segment.
+	fn boundary(&self, pts: Timestamp) -> u64 {
+		let mut state = self.state.lock().unwrap();
+		let segment = match state.current {
+			None => 0,
+			Some((segment, _)) if !state.driven => segment,
+			Some((segment, _)) => segment + 1,
+		};
+		state.current = Some((segment, pts));
+		state.driven = true;
+		segment
+	}
+
+	/// A [`Cadence::Aligned`] group open at `pts`, having last recorded `last`: the segment this
+	/// group starts for its track, or `None` if it merely extends the one already recorded.
+	///
+	/// A group before the current boundary extends the previous segment; the first group at or
+	/// after it starts the track's slice of the current one. While undriven, a group a full
+	/// interval past the boundary opens the next segment itself.
+	fn align(&self, pts: Timestamp, last: Option<u64>) -> Option<u64> {
+		let mut state = self.state.lock().unwrap();
+		let Some((segment, boundary)) = state.current else {
+			// The very first group of the broadcast: open segment 0 at its timestamp.
+			state.current = Some((0, pts));
+			return Some(0);
+		};
+		if last != Some(segment) && pts.as_micros() >= boundary.as_micros() {
+			return Some(segment);
+		}
+		if !state.driven && pts.as_micros() >= boundary.as_micros() + state.interval.as_micros() {
+			state.current = Some((segment + 1, pts));
+			return Some(segment + 1);
+		}
+		None
+	}
+}
 
 /// A media timeline: its catalog [`section`](Self::section) and wall anchor, and the [`Recorder`]
 /// its group opens are recorded through.
@@ -55,25 +175,32 @@ pub const DEFAULT_GRANULARITY: Timestamp = Timestamp::new_const(1, Timescale::SE
 /// Publishes the base [`Record`] shape (no extension); a [`Consumer`] can still read a record
 /// extension published by another implementation. `Clone`, and every clone shares the one track and
 /// its wall anchor, so a set of aligned renditions can advertise one timeline. Get one from
-/// [`catalog::Producer::timeline`](crate::catalog::Producer::timeline), which keeps ownership and
-/// closes the track when the catalog finishes.
+/// [`catalog::Producer::timeline`](crate::catalog::Producer::timeline), which keeps ownership,
+/// wires the broadcast's shared [`Segmenter`], and closes the track when the catalog finishes.
 #[derive(Clone)]
 pub struct Producer {
 	inner: moq_json::stream::Producer<Record>,
 	track: String,
 	timescale: Timescale,
-	granularity: Timestamp,
+	segmenter: Segmenter,
 	// The wall-clock time of pts 0, in timescale units since the moq epoch, advertised in section().
 	// Shared across clones so a set_wall on one is seen by every rendition advertising this timeline.
 	wall: Arc<Mutex<Option<u64>>>,
 }
 
 impl Producer {
-	/// Create a timeline track for the media rendition `name` on the given broadcast.
+	/// Create a timeline track for the media rendition `name` on the given broadcast, numbering
+	/// segments through `segmenter`.
 	///
-	/// The track is named per [`hang::timeline::track_name`] (`<name>.timeline.z`) at the
-	/// default millisecond timescale and [`DEFAULT_GRANULARITY`].
-	pub fn new(broadcast: &mut moq_net::broadcast::Producer, name: &str) -> Result<Self, moq_net::Error> {
+	/// Pass the broadcast's shared segmenter so this track's segment numbers align with its
+	/// siblings'; a track segmented on its own (nothing to align with) passes a fresh one. The
+	/// track is named per [`hang::timeline::track_name`] (`<name>.timeline.z`) at the default
+	/// millisecond timescale.
+	pub fn new(
+		broadcast: &mut moq_net::broadcast::Producer,
+		name: &str,
+		segmenter: Segmenter,
+	) -> Result<Self, moq_net::Error> {
 		let track = track_name(name);
 		let net = broadcast.create_track(track.as_str(), None)?;
 
@@ -83,16 +210,9 @@ impl Producer {
 			inner: moq_json::stream::Producer::new(net, config),
 			track,
 			timescale: Timescale::new(Timeline::default_timescale() as u64).expect("default timescale is nonzero"),
-			granularity: DEFAULT_GRANULARITY,
+			segmenter,
 			wall: Arc::new(Mutex::new(None)),
 		})
-	}
-
-	/// Set the record throttle: at most one record per `granularity` of media time. See
-	/// [`DEFAULT_GRANULARITY`]. Applies to recorders minted after this call.
-	pub fn with_granularity(mut self, granularity: Timestamp) -> Self {
-		self.granularity = granularity;
-		self
 	}
 
 	/// The catalog section advertising this timeline, to attach to the rendition's config.
@@ -123,16 +243,18 @@ impl Producer {
 		*self.wall.lock().unwrap() = Some(moq_units.saturating_sub(pts_units) as u64);
 	}
 
-	/// Mint a [`Recorder`] to record group opens into this timeline.
+	/// Mint a [`Recorder`] to record group opens into this timeline, mapping them onto the
+	/// shared segment numbering per `cadence`.
 	///
 	/// Wire it into a media track's [`container::Producer`](crate::container::Producer) with
-	/// [`with_recorder`](crate::container::Producer::with_recorder). A recorder owns its own throttle
+	/// [`with_recorder`](crate::container::Producer::with_recorder). A recorder owns its own
 	/// cursor, so wire exactly one per timeline (a shared timeline is filled by its source alone).
-	pub fn recorder(&self) -> Recorder {
+	pub fn recorder(&self, cadence: Cadence) -> Recorder {
 		Recorder {
 			inner: self.inner.clone(),
 			timescale: self.timescale,
-			granularity: self.granularity,
+			segmenter: self.segmenter.clone(),
+			cadence,
 			last: None,
 		}
 	}
@@ -147,31 +269,34 @@ impl Producer {
 	}
 }
 
-/// Records a media track's group opens into its timeline, throttled to a granularity.
+/// Records a media track's group opens into its timeline as aligned segments.
 ///
-/// Move-only (not `Clone`): it owns its throttle cursor, so wire exactly one per timeline. Minted by
-/// [`Producer::recorder`] and held by a rendition's
+/// Move-only (not `Clone`): it owns its segment cursor, so wire exactly one per timeline. Minted by
+/// [`Producer::recorder`] with the track's [`Cadence`] and held by a rendition's
 /// [`container::Producer`](crate::container::Producer).
 pub struct Recorder {
 	inner: moq_json::stream::Producer<Record>,
 	timescale: Timescale,
-	granularity: Timestamp,
-	// The pts of the last recorded group; the throttle floor. Owned, since a recorder is 1:1.
-	last: Option<Timestamp>,
+	segmenter: Segmenter,
+	cadence: Cadence,
+	// The last segment this track recorded; the cursor an aligned recorder dedupes against.
+	last: Option<u64>,
 }
 
 impl Recorder {
-	/// Record that group `sequence` opened at presentation time `pts`, unless it falls within the
-	/// granularity of the last recorded group (skipped, so a consumer extrapolates or fetches).
+	/// Record that group `sequence` opened at presentation time `pts`. Per the [`Cadence`], the
+	/// group either opens a segment (recorded) or extends the current one (skipped).
 	pub(crate) fn record(&mut self, sequence: u64, pts: Timestamp) -> Result<(), moq_net::Error> {
-		if let Some(last) = self.last
-			&& pts.as_micros() < last.as_micros() + self.granularity.as_micros()
-		{
+		let segment = match self.cadence {
+			Cadence::Boundary => Some(self.segmenter.boundary(pts)),
+			Cadence::Aligned => self.segmenter.align(pts, self.last),
+		};
+		let Some(segment) = segment else {
 			return Ok(());
-		}
-		self.last = Some(pts);
+		};
+		self.last = Some(segment);
 
-		let record = Record::new(sequence, pts.as_scale(self.timescale) as u64);
+		let record = Record::new(segment, sequence, pts.as_scale(self.timescale) as u64);
 		match self.inner.append(&record) {
 			Ok(()) => Ok(()),
 			Err(moq_json::Error::Net(err)) => Err(err),
@@ -182,16 +307,21 @@ impl Recorder {
 	}
 }
 
-/// One decoded timeline entry: a group and the [`Timestamp`] it opened at.
+/// One decoded timeline entry: an aligned segment, the group it starts at for this track, and
+/// the [`Timestamp`] it opened at.
 ///
 /// `pts` is a real timestamp, already converted from the record's on-wire timescale, so a reader
 /// never juggles timescale units.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Entry<E: RecordExt = ()> {
-	/// The group's sequence number, as used by FETCH/SUBSCRIBE on the media track.
+	/// The segment's number, aligned across the broadcast's tracks.
+	pub segment: u64,
+
+	/// The segment's first group, as used by FETCH/SUBSCRIBE on the media track. The segment
+	/// covers every group up to (excluding) the next entry's `group`.
 	pub group: u64,
 
-	/// The group's start (its first frame's presentation timestamp).
+	/// The segment's start (its first frame's presentation timestamp).
 	pub pts: Timestamp,
 
 	/// The record's application extension (nothing for the default `()`).
@@ -231,6 +361,7 @@ impl<E: RecordExt> Consumer<E> {
 	/// moving a timestamp would misdirect seeking and live-edge logic.
 	fn decode(&self, record: Record<E>) -> crate::Result<Entry<E>> {
 		Ok(Entry {
+			segment: record.segment,
 			group: record.group,
 			pts: Timestamp::new(record.pts, self.timescale)?,
 			ext: record.ext,
@@ -261,12 +392,17 @@ mod test {
 
 	use super::*;
 
-	fn entry(group: u64, pts_ms: u64) -> Entry {
+	fn entry(segment: u64, group: u64, pts_ms: u64) -> Entry {
 		Entry {
+			segment,
 			group,
 			pts: Timestamp::from_millis(pts_ms).unwrap(),
 			ext: (),
 		}
+	}
+
+	fn producer(broadcast: &mut moq_net::broadcast::Producer, name: &str, segmenter: &Segmenter) -> Producer {
+		Producer::new(broadcast, name, segmenter.clone()).unwrap()
 	}
 
 	/// Drain a finished timeline track by subscribing to the producer's advertised section.
@@ -292,14 +428,14 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn records_group_opens_in_milliseconds() {
+	async fn boundary_records_every_group_as_a_segment() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let mut timeline = Producer::new(&mut broadcast, "video0").unwrap();
+		let mut timeline = producer(&mut broadcast, "video0", &Segmenter::new());
 		assert_eq!(timeline.track, "video0.timeline.z");
 
 		let track = broadcast.create_track("video0", None).unwrap();
 		let mut media = crate::container::Producer::new(track, crate::catalog::hang::Container::Legacy)
-			.with_recorder(timeline.recorder());
+			.with_recorder(timeline.recorder(Cadence::Boundary));
 
 		media.write(frame(0, true)).unwrap(); // group 0 @ 0us
 		media.write(frame(2_000_000, false)).unwrap(); // extends group 0
@@ -307,31 +443,126 @@ mod test {
 		media.finish().unwrap();
 		timeline.finish().unwrap();
 
-		// Entry pts is a real Timestamp (decoded from the ms-timescale record).
-		assert_eq!(drain(&broadcast, &timeline).await, vec![entry(0, 0), entry(1, 4_000)]);
+		// Entry pts is a real Timestamp (decoded from the ms-timescale record); each group is a segment.
+		assert_eq!(
+			drain(&broadcast, &timeline).await,
+			vec![entry(0, 0, 0), entry(1, 1, 4_000)]
+		);
 	}
 
 	#[tokio::test]
-	async fn granularity_throttles_records() {
+	async fn aligned_records_the_first_group_at_each_boundary() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let mut timeline = Producer::new(&mut broadcast, "audio0").unwrap();
-		let mut recorder = timeline.recorder();
+		let segmenter = Segmenter::new();
+		let mut video = producer(&mut broadcast, "video0", &segmenter);
+		let mut audio = producer(&mut broadcast, "audio0", &segmenter);
+		let mut leader = video.recorder(Cadence::Boundary);
+		let mut follower = audio.recorder(Cadence::Aligned);
 
-		// Default granularity is 1s. Group opens 300ms apart, all within a second of the first, then
-		// one past it: only the first and the one past the granularity are recorded.
-		for (seq, ms) in [(0u64, 0u64), (1, 300), (2, 600), (3, 900), (4, 1200)] {
+		// Interleaved group opens: video keyframes every 2s, audio groups every 300ms.
+		leader.record(0, Timestamp::from_millis(0).unwrap()).unwrap(); // segment 0 @ 0
+		for (seq, ms) in [
+			(0u64, 0u64),
+			(1, 300),
+			(2, 600),
+			(3, 900),
+			(4, 1_200),
+			(5, 1_500),
+			(6, 1_800),
+		] {
+			follower.record(seq, Timestamp::from_millis(ms).unwrap()).unwrap();
+		}
+		leader.record(1, Timestamp::from_millis(2_000).unwrap()).unwrap(); // segment 1 @ 2s
+		for (seq, ms) in [(7u64, 2_100u64), (8, 2_400)] {
+			follower.record(seq, Timestamp::from_millis(ms).unwrap()).unwrap();
+		}
+		video.finish().unwrap();
+		audio.finish().unwrap();
+
+		// Video: one group per segment. Audio: the first group at/after each boundary; the rest
+		// of its groups pack into the segment implicitly (they run until the next record's group).
+		assert_eq!(
+			drain(&broadcast, &video).await,
+			vec![entry(0, 0, 0), entry(1, 1, 2_000)]
+		);
+		assert_eq!(
+			drain(&broadcast, &audio).await,
+			vec![entry(0, 0, 0), entry(1, 7, 2_100)]
+		);
+	}
+
+	#[tokio::test]
+	async fn undriven_aligned_recorder_paces_itself() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let mut timeline = producer(&mut broadcast, "audio0", &Segmenter::new());
+		let mut recorder = timeline.recorder(Cadence::Aligned);
+
+		// No boundary track: the default interval is 1s, so group opens 300ms apart self-open a
+		// segment only once a full interval has passed since the last boundary.
+		for (seq, ms) in [(0u64, 0u64), (1, 300), (2, 600), (3, 900), (4, 1_200)] {
 			recorder.record(seq, Timestamp::from_millis(ms).unwrap()).unwrap();
 		}
 		drop(recorder);
 		timeline.finish().unwrap();
 
-		assert_eq!(drain(&broadcast, &timeline).await, vec![entry(0, 0), entry(4, 1200)]);
+		assert_eq!(
+			drain(&broadcast, &timeline).await,
+			vec![entry(0, 0, 0), entry(1, 4, 1_200)]
+		);
+	}
+
+	#[tokio::test]
+	async fn first_boundary_adopts_a_self_opened_segment() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let segmenter = Segmenter::new();
+		let mut video = producer(&mut broadcast, "video0", &segmenter);
+		let mut audio = producer(&mut broadcast, "audio0", &segmenter);
+		let mut leader = video.recorder(Cadence::Boundary);
+		let mut follower = audio.recorder(Cadence::Aligned);
+
+		// Audio starts first and self-opens segment 0; the video keyframe arriving moments later
+		// adopts it (same number) instead of stranding an audio-only segment 0, then paces on.
+		follower.record(0, Timestamp::from_millis(0).unwrap()).unwrap();
+		leader.record(0, Timestamp::from_millis(30).unwrap()).unwrap();
+		leader.record(1, Timestamp::from_millis(2_030).unwrap()).unwrap();
+		follower.record(70, Timestamp::from_millis(2_100).unwrap()).unwrap();
+		video.finish().unwrap();
+		audio.finish().unwrap();
+
+		assert_eq!(
+			drain(&broadcast, &video).await,
+			vec![entry(0, 0, 30), entry(1, 1, 2_030)]
+		);
+		assert_eq!(
+			drain(&broadcast, &audio).await,
+			vec![entry(0, 0, 0), entry(1, 70, 2_100)]
+		);
+	}
+
+	#[tokio::test]
+	async fn aligned_recorder_joining_late_records_the_current_segment() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let segmenter = Segmenter::new();
+		let mut video = producer(&mut broadcast, "video0", &segmenter);
+		let mut audio = producer(&mut broadcast, "audio0", &segmenter);
+		let mut leader = video.recorder(Cadence::Boundary);
+
+		leader.record(0, Timestamp::from_millis(0).unwrap()).unwrap();
+		leader.record(1, Timestamp::from_millis(2_000).unwrap()).unwrap();
+
+		// An audio track added mid-broadcast: its first group lands in segment 1, not 0.
+		let mut follower = audio.recorder(Cadence::Aligned);
+		follower.record(0, Timestamp::from_millis(2_050).unwrap()).unwrap();
+		video.finish().unwrap();
+		audio.finish().unwrap();
+
+		assert_eq!(drain(&broadcast, &audio).await, vec![entry(1, 0, 2_050)]);
 	}
 
 	#[test]
 	fn section_advertises_track_and_wall() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let mut timeline = Producer::new(&mut broadcast, "audio0").unwrap();
+		let mut timeline = producer(&mut broadcast, "audio0", &Segmenter::new());
 
 		let section = timeline.section();
 		assert_eq!(section.track, "audio0.timeline.z");
@@ -353,7 +584,7 @@ mod test {
 	#[tokio::test]
 	async fn rejects_an_invalid_timescale() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let mut timeline = Producer::new(&mut broadcast, "video0").unwrap();
+		let mut timeline = producer(&mut broadcast, "video0", &Segmenter::new());
 		timeline.finish().unwrap();
 
 		// A timescale of 0 can't be honored, and quietly reading the track at milliseconds would
@@ -370,13 +601,13 @@ mod test {
 	#[tokio::test]
 	async fn rejects_an_out_of_range_pts() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let timeline = Producer::new(&mut broadcast, "video0").unwrap();
+		let timeline = producer(&mut broadcast, "video0", &Segmenter::new());
 
 		// Publish a record whose pts no Timestamp can hold, bypassing the recorder.
 		let track = broadcast.create_track("raw.timeline.z", None).unwrap();
 		let config = moq_json::stream::ProducerConfig::default().with_compression(true);
 		let mut raw = moq_json::stream::Producer::new(track, config);
-		raw.append(&Record::<()>::new(0, u64::MAX)).unwrap();
+		raw.append(&Record::<()>::new(0, 0, u64::MAX)).unwrap();
 		raw.finish().unwrap();
 
 		let mut section = timeline.section();
@@ -393,9 +624,9 @@ mod test {
 	#[tokio::test]
 	async fn consumer_decodes_pts_from_the_section() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let mut timeline = Producer::new(&mut broadcast, "video0").unwrap();
+		let mut timeline = producer(&mut broadcast, "video0", &Segmenter::new());
 		timeline
-			.recorder()
+			.recorder(Cadence::Boundary)
 			.record(3, Timestamp::from_micros(7_000).unwrap())
 			.unwrap();
 		timeline.finish().unwrap();
@@ -404,7 +635,7 @@ mod test {
 		// The pts is decoded at the timeline's (millisecond) timescale, so compare the instant rather
 		// than the scale-sensitive representation (7ms == 7000us as an instant, but not field-wise).
 		let entries = drain(&broadcast, &timeline).await;
-		assert_eq!(entries, vec![entry(3, 7)]);
+		assert_eq!(entries, vec![entry(0, 3, 7)]);
 		assert_eq!(entries[0].pts.as_micros(), 7_000);
 	}
 }

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -20,7 +20,8 @@
 //! - **Records flush on completeness.** A segment's record is published only once every
 //!   enrolled track has reported a group at or past the segment's end (or closed), proving the
 //!   segment's group ranges are final on every track. The record is then self-contained and
-//!   immediately servable.
+//!   immediately servable. [`Producer::reserve`] extends that across a batch of enrollments,
+//!   the way the catalog's own reservation does.
 //!
 //! Alignment falls out of construction: every track maps its groups onto the same boundary
 //! list, so segment N covers the same span of content time on every track, which is what HLS
@@ -142,8 +143,9 @@ struct State {
 	next_segment: u64,
 	/// Every enrolled track, keyed by media track name.
 	tracks: BTreeMap<String, TrackState>,
-	/// Live [`Hold`]s: while any exists, no record flushes (more tracks are still enrolling).
-	holds: usize,
+	/// Live [`Reserved`] handles: while any exists, no record flushes (more tracks are still
+	/// enrolling). Mirrors the catalog's own reservation gate.
+	reservers: usize,
 	/// A segment overran [`Config::duration_max`]: `(segment, duration)`. The timeline stops
 	/// publishing, since the catalog's promise is already broken.
 	overrun: Option<(u64, Duration)>,
@@ -200,9 +202,9 @@ impl State {
 	/// reached a boundary stops voting instead of holding the timeline open forever.
 	fn pump(&mut self, finished: bool) {
 		// With nothing enrolled there is nothing to describe. A record is immutable once
-		// published, so a caller that knows more tracks are still enrolling holds it back (see
-		// [`Producer::hold`]), and an overrun has already broken the catalog's promise.
-		if self.tracks.is_empty() || self.holds > 0 || self.overrun.is_some() {
+		// published, so a caller that knows more tracks are still enrolling withholds it (see
+		// [`Producer::reserve`]), and an overrun has already broken the catalog's promise.
+		if self.tracks.is_empty() || self.reservers > 0 || self.overrun.is_some() {
 			return;
 		}
 
@@ -373,8 +375,8 @@ impl State {
 
 	/// The terminal flush: publish what the media finalized, then the open tail.
 	fn finish(&mut self) {
-		// Nothing more will enroll, so an outstanding hold has nothing left to wait for.
-		self.holds = 0;
+		// Nothing more will enroll, so an outstanding reservation has nothing left to wait for.
+		self.reservers = 0;
 		self.pump(true);
 
 		if self.overrun.is_some() {
@@ -445,7 +447,7 @@ impl Producer {
 				cuts: VecDeque::new(),
 				next_segment: 0,
 				tracks: BTreeMap::new(),
-				holds: 0,
+				reservers: 0,
 				overrun: None,
 				timescale: Timescale::MILLI,
 			})),
@@ -508,17 +510,23 @@ impl Producer {
 		Ok(())
 	}
 
-	/// Hold record publishing back until the returned [`Hold`] drops.
+	/// Begin reserving the track set, returning a clonable [`Reserved`].
 	///
-	/// A record is immutable once published, and completeness is judged against the tracks
-	/// enrolled *at that moment*, so a segment that flushes while a sibling rendition is still
-	/// enrolling omits it for good (and that rendition's earlier groups then land in whatever
-	/// segment flushes next). Take a hold around a batch that enrolls or feeds several tracks
-	/// (an HLS import walking its renditions one at a time) so every one of them is accounted
-	/// for before anything is published. Holds nest; the last one to drop flushes.
-	pub fn hold(&self) -> Hold {
-		self.state.lock().unwrap().holds += 1;
-		Hold {
+	/// The counterpart to [`catalog::Producer::reserve`](crate::catalog::Producer::reserve), for
+	/// the same reason: while any `Reserved` clone is alive the track set may still grow, so
+	/// records are withheld from the broadcast. A record is immutable once published and its
+	/// completeness is judged against the tracks enrolled *at that moment*, so a segment that
+	/// flushes while a sibling rendition is still enrolling omits it for good, and that
+	/// rendition's earlier groups then land in whatever segment flushes next.
+	///
+	/// Hand it (or clones) to whatever brings the tracks up, so an importer that enrolls its
+	/// renditions one at a time publishes nothing until they are all in. Unlike the catalog's,
+	/// this gate is not one-shot: the catalog is a snapshot, so only its *first* publish needs
+	/// protecting, while every timeline record is an immutable log entry. Take a fresh
+	/// reservation around every batch.
+	pub fn reserve(&self) -> Reserved {
+		self.state.lock().unwrap().reservers += 1;
+		Reserved {
 			state: self.state.clone(),
 		}
 	}
@@ -551,17 +559,27 @@ impl Producer {
 	}
 }
 
-/// Holds [`Producer`] record publishing back while tracks are still enrolling.
+/// A clonable reservation withholding [`Producer`] records while tracks are still enrolling.
 ///
-/// Minted by [`Producer::hold`]; whatever became complete meanwhile flushes when it drops.
-pub struct Hold {
+/// Made via [`Producer::reserve`], mirroring [`catalog::Reserved`](crate::catalog::Reserved).
+/// Whatever became complete meanwhile flushes once the last clone drops.
+pub struct Reserved {
 	state: Arc<Mutex<State>>,
 }
 
-impl Drop for Hold {
+impl Clone for Reserved {
+	fn clone(&self) -> Self {
+		self.state.lock().unwrap().reservers += 1;
+		Self {
+			state: self.state.clone(),
+		}
+	}
+}
+
+impl Drop for Reserved {
 	fn drop(&mut self) {
 		let mut state = self.state.lock().unwrap();
-		state.holds = state.holds.saturating_sub(1);
+		state.reservers = state.reservers.saturating_sub(1);
 		state.pump(false);
 	}
 }
@@ -960,9 +978,9 @@ mod test {
 	// producer that enrolls its tracks one batch at a time (an HLS import walking its
 	// renditions) holds flushing back until they are all in.
 	#[tokio::test]
-	async fn a_hold_defers_flushing_until_every_track_enrolls() {
+	async fn a_reservation_defers_flushing_until_every_track_enrolls() {
 		let (broadcast, mut timeline) = setup();
-		let hold = timeline.hold();
+		let reserved = timeline.reserve();
 
 		// The primary rendition runs a whole batch of segments through before its sibling has
 		// even loaded an init segment.
@@ -976,12 +994,12 @@ mod test {
 			second.record(seq, ms(t), true);
 		}
 
-		drop(hold);
+		drop(reserved);
 		drop(first);
 		drop(second);
 		timeline.finish().unwrap();
 
-		// Both renditions are indexed from segment 0. Without the hold, segments 0 and 1 would
+		// Both renditions are indexed from segment 0. Without the reservation, segments 0 and 1 would
 		// have flushed knowing only video0 (a permanent gap for video1), and video1's first two
 		// groups would have folded into segment 2.
 		let entries = drain(&broadcast, &timeline).await;
@@ -1150,15 +1168,15 @@ mod test {
 		assert_eq!(timeline.section().wall, Some(1_000));
 	}
 
-	// Producers that each guard their own batch nest, so the first to finish doesn't publish
-	// records the others are still filling in.
+	// Clones nest like the catalog's, so the first batch to finish doesn't publish records the
+	// others are still filling in.
 	#[tokio::test]
-	async fn holds_nest() {
+	async fn reservations_nest() {
 		let (broadcast, mut timeline) = setup();
 		let mut video = timeline.track("video0").unwrap();
 
-		let outer = timeline.hold();
-		let inner = timeline.hold();
+		let outer = timeline.reserve();
+		let inner = outer.clone();
 
 		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
 			video.record(seq, ms(t), true);
@@ -1167,26 +1185,26 @@ mod test {
 		drop(inner);
 		assert!(
 			drain(&broadcast, &timeline).await.is_empty(),
-			"the outer hold still gates"
+			"the other clone still gates"
 		);
 
 		drop(outer);
 		assert_eq!(
 			drain(&broadcast, &timeline).await.len(),
 			2,
-			"the last hold released flushes"
+			"the last clone dropped flushes"
 		);
 
 		drop(video);
 		timeline.finish().unwrap();
 	}
 
-	// A hold outstanding when the broadcast ends must not strand the terminal flush.
+	// A reservation outstanding when the broadcast ends must not strand the terminal flush.
 	#[tokio::test]
-	async fn finish_overrides_an_outstanding_hold() {
+	async fn finish_overrides_an_outstanding_reservation() {
 		let (broadcast, mut timeline) = setup();
 		let mut video = timeline.track("video0").unwrap();
-		let hold = timeline.hold();
+		let reserved = timeline.reserve();
 
 		video.record(0, ms(0), true);
 		video.record(1, ms(2_000), true);
@@ -1203,7 +1221,7 @@ mod test {
 		);
 
 		// Dropping it afterwards is a no-op rather than an underflow.
-		drop(hold);
+		drop(reserved);
 	}
 
 	#[tokio::test]

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -139,6 +139,10 @@ struct State {
 	start: Option<Timestamp>,
 	/// Explicit [`Producer::cut`] boundaries not yet reached, in order.
 	cuts: VecDeque<Timestamp>,
+	/// A [`Producer::cut`] arrived, so the application owns the boundaries from here on and the
+	/// `duration_min` pacing stops. Without this the pacing races ahead of a source whose
+	/// segments are longer than the minimum, closing one before its real boundary is declared.
+	manual: bool,
 	/// The number the next flushed record gets.
 	next_segment: u64,
 	/// Every enrolled track, keyed by media track name.
@@ -222,6 +226,14 @@ impl State {
 		let Some(start) = self.start else {
 			return false;
 		};
+
+		// Discard boundaries the timeline has already reached. Only the front is ever consulted,
+		// so leaving a spent one there would block every later cut behind it and silently drop
+		// the caller back to `duration_min` pacing.
+		while self.cuts.front().is_some_and(|c| c.as_micros() <= start.as_micros()) {
+			self.cuts.pop_front();
+		}
+
 		let Some((end, cut)) = self.boundary(start, finished) else {
 			return false;
 		};
@@ -254,6 +266,12 @@ impl State {
 			&& cut.as_micros() > start.as_micros()
 		{
 			return Some((cut, true));
+		}
+
+		// The application declared a boundary at some point, so it owns them all: pacing here
+		// would close a segment the caller is about to cut somewhere else.
+		if self.manual {
+			return None;
 		}
 
 		let threshold = start.as_micros() + self.config.duration_min.as_micros();
@@ -445,6 +463,7 @@ impl Producer {
 				sink: None,
 				start: None,
 				cuts: VecDeque::new(),
+				manual: false,
 				next_segment: 0,
 				tracks: BTreeMap::new(),
 				reservers: 0,
@@ -489,12 +508,20 @@ impl Producer {
 	/// would make a segment shorter than [`Config::duration_min`] is ignored, so several
 	/// producers declaring the same boundaries (the renditions of one import) cost nothing.
 	///
+	/// The first call takes over for good: [`Config::duration_min`] pacing stops, since it would
+	/// otherwise close a segment just before the caller declares where it really ends. Segments
+	/// then last exactly as long as the caller says, and the final one runs to the end of the
+	/// media.
+	///
 	/// Errors if a segment already overran [`Config::duration_max`].
 	pub fn cut(&self, pts: Timestamp) -> crate::Result<()> {
 		let mut state = self.state.lock().unwrap();
 		if let Some(err) = state.failure() {
 			return Err(err);
 		}
+
+		// Even a cut this rejects says the caller owns the boundaries.
+		state.manual = true;
 
 		let floor = state
 			.cuts
@@ -1232,5 +1259,33 @@ mod test {
 		section.timescale = 0;
 		let err = Consumer::<()>::subscribe(&broadcast.consume(), &section).await;
 		assert!(matches!(err, Err(crate::Error::InvalidTimescale(0))));
+	}
+
+	// A cut registered before the media, landing exactly on the first reported group (what the
+	// fMP4 importer does: it cuts at the keyframe fragment's timestamp, then records that group).
+	#[tokio::test]
+	async fn a_cut_on_the_first_group_does_not_poison_later_cuts() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
+
+		// Source segments every 3s, keyframes every 1s: 3s segments, not the 1s the
+		// duration_min pacing would produce on its own.
+		timeline.cut(ms(0)).unwrap();
+		video.record(0, ms(0), true);
+		for seq in 1..10u64 {
+			if seq % 3 == 0 {
+				timeline.cut(ms(seq * 1_000)).unwrap();
+			}
+			video.record(seq, ms(seq * 1_000), true);
+		}
+		drop(video);
+		timeline.finish().unwrap();
+
+		let entries = drain(&broadcast, &timeline).await;
+		assert_eq!(
+			entries[0],
+			entry(0, 0, 3_000, &[("video0", &[(0, 2)])]),
+			"the source's 3s boundaries should be reproduced, not duration_min pacing"
+		);
 	}
 }

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -16,11 +16,12 @@
 //! - **The owner sets policy.** Segment boundaries come from [`Segmenter::cut`] when the
 //!   application knows them (an HLS import following the source playlist, a CMAF file's
 //!   on-disk segments, an encoder that places its own keyframes). When nobody cuts, the
-//!   segmenter auto-cuts: on the driver track's keyframes once
-//!   [`duration_max`](Segmenter::with_duration_max) has elapsed since the last boundary. The
+//!   segmenter auto-cuts on the driver track's keyframes, keeping every segment within the
+//!   `duration_max` bound declared at [`Segmenter::new`] (see there for the exact rule). The
 //!   driver is the first enrolled video track (video keyframes are where a segment must
 //!   start), or the first enrolled track of any kind when the broadcast has no video. The
-//!   first explicit cut disables auto-cut: the application has taken control.
+//!   first explicit cut disables auto-cut: the application has taken control, and its cuts
+//!   are expected to honor the same declared bound.
 //! - **Records flush on completeness.** A segment's record is published only once every
 //!   enrolled track has reported a group at or past the segment's end boundary (or closed),
 //!   proving the segment's group ranges are final on every track. The record is then
@@ -56,8 +57,8 @@ use hang::timeline::{DEFAULT_NAME, Range, Record, RecordExt};
 
 use moq_net::{Timescale, Timestamp};
 
-/// The default [`Segmenter`] auto-cut threshold: with nobody cutting explicitly, a new
-/// segment starts at the first driver keyframe at least this far past the last boundary.
+/// The conventional [`Segmenter`] segment-duration bound (2 seconds), for callers with no
+/// opinion of their own.
 pub const DEFAULT_DURATION_MAX: Timestamp = Timestamp::new_const(2, Timescale::SECOND);
 
 /// What a media track carries, declared when it enrolls via [`Segmenter::track`].
@@ -86,11 +87,18 @@ struct TrackState {
 
 /// The state one [`Segmenter`] guards.
 struct State {
-	/// The auto-cut threshold (see [`Segmenter::with_duration_max`]).
+	/// The declared segment-duration bound (see [`Segmenter::new`]). Frozen once the
+	/// timeline track advertises it.
 	duration_max: Timestamp,
 	/// An explicit [`cut`](Segmenter::cut) arrived: the application owns the boundaries and
 	/// auto-cut stays off for the rest of the broadcast.
 	manual: bool,
+	/// The driver's latest reported boundary candidate (a keyframe for a video driver) since
+	/// the last boundary: where auto-cut retroactively closes a segment that would otherwise
+	/// overrun `duration_max`.
+	candidate: Option<Timestamp>,
+	/// A segment already overran the declared bound and was warned about; log it once.
+	warned_overrun: bool,
 	/// Boundaries of segments not yet flushed: `boundaries[0]` starts segment `next_segment`,
 	/// which spans to `boundaries[1]`.
 	boundaries: VecDeque<Timestamp>,
@@ -138,17 +146,47 @@ impl State {
 		if !self.manual && self.driver.as_deref() == Some(name) {
 			let kind = self.tracks[name].kind;
 			if keyframe || kind != Kind::Video {
-				let due = match self.last_boundary {
-					None => true,
-					Some(last) => pts.as_micros() >= last.as_micros() + self.duration_max.as_micros(),
-				};
-				if due {
-					self.cut_at(pts);
-				}
+				self.auto_cut(pts);
 			}
 		}
 
 		self.try_flush(false);
+	}
+
+	/// Auto-cut policy for a driver boundary candidate at `pts`: keep every segment within
+	/// the declared `duration_max` whenever the driver's cadence allows.
+	///
+	/// A boundary can only land where the driver reported (a keyframe for video), so waiting
+	/// for the first candidate past the bound would overrun it by up to one GOP. Instead,
+	/// when `pts` would overrun, the segment is closed retroactively at the previous
+	/// candidate. Only a GOP longer than the bound itself still yields an honest long
+	/// segment.
+	fn auto_cut(&mut self, pts: Timestamp) {
+		let Some(last) = self.last_boundary else {
+			// The first candidate anchors the first segment.
+			self.cut_at(pts);
+			self.candidate = Some(pts);
+			return;
+		};
+
+		let bound = last.as_micros() + self.duration_max.as_micros();
+		if pts.as_micros() > bound {
+			// This candidate overruns: close the segment at the previous one instead.
+			if let Some(candidate) = self.candidate
+				&& candidate.as_micros() > last.as_micros()
+			{
+				self.cut_at(candidate);
+			}
+			// Still overrunning (the whole GOP is longer than the bound): cut here anyway.
+			if let Some(last) = self.last_boundary
+				&& pts.as_micros() >= last.as_micros() + self.duration_max.as_micros()
+			{
+				self.cut_at(pts);
+			}
+		} else if pts.as_micros() == bound {
+			self.cut_at(pts);
+		}
+		self.candidate = Some(pts);
 	}
 
 	/// A track's recorder was dropped: stop gating completeness on it and re-elect the driver.
@@ -158,6 +196,8 @@ impl State {
 		}
 		if self.driver.as_deref() == Some(name) {
 			self.driver = self.elect();
+			// The old driver's pending candidate is not a valid boundary for the new one.
+			self.candidate = None;
 		}
 		self.try_flush(false);
 	}
@@ -221,6 +261,21 @@ impl State {
 				.unwrap_or(pts)
 				.saturating_sub(pts),
 		};
+
+		// A segment materially past the declared bound means the producer misdeclared it (or
+		// the media left no valid boundary); the catalog already advertised the bound, so all
+		// we can do is say so. Allow the sub-half-second slack HLS rounding grants.
+		let slack = self.timescale.as_u64() / 2;
+		let bound = (self.duration_max.as_micros() * self.timescale.as_u64() as u128).div_ceil(1_000_000) as u64;
+		if !self.warned_overrun && duration > bound + slack {
+			self.warned_overrun = true;
+			tracing::warn!(
+				segment = self.next_segment,
+				duration,
+				duration_max = bound,
+				"segment overran the declared duration_max; consumers (e.g. HLS TARGETDURATION) trust the declared bound"
+			);
+		}
 
 		let mut record = Record::new(self.next_segment, pts, duration);
 		self.next_segment += 1;
@@ -304,18 +359,29 @@ pub struct Segmenter {
 }
 
 impl Default for Segmenter {
+	/// A segmenter declaring the conventional [`DEFAULT_DURATION_MAX`] bound.
 	fn default() -> Self {
-		Self::new()
+		Self::new(DEFAULT_DURATION_MAX)
 	}
 }
 
 impl Segmenter {
-	/// A fresh segmenter: no tracks, no boundaries, auto-cut at [`DEFAULT_DURATION_MAX`].
-	pub fn new() -> Self {
+	/// A fresh segmenter declaring `duration_max`, the upper bound on a segment's duration.
+	///
+	/// The bound is policy the boundary owner knows up front: the encoder its keyframe
+	/// cadence, an importer its source's target duration. It is advertised in the catalog's
+	/// timeline section (consumers derive HLS `EXT-X-TARGETDURATION` from it, so it must not
+	/// change once advertised) and enforced by auto-cut: a segment is closed at the last
+	/// driver keyframe that keeps it within the bound, falling back to an honest overrun
+	/// only when a single GOP exceeds the bound. Explicit [`cut`](Self::cut)s are expected
+	/// to honor it too; a materially longer segment is logged.
+	pub fn new(duration_max: Timestamp) -> Self {
 		Self {
 			state: Arc::new(Mutex::new(State {
-				duration_max: DEFAULT_DURATION_MAX,
+				duration_max,
 				manual: false,
+				candidate: None,
+				warned_overrun: false,
 				boundaries: VecDeque::new(),
 				last_boundary: None,
 				next_segment: 0,
@@ -328,16 +394,19 @@ impl Segmenter {
 		}
 	}
 
-	/// Set the auto-cut threshold: a new segment starts at the first driver keyframe at least
-	/// this far past the last boundary. Translates to HLS `EXT-X-TARGETDURATION` (though an
-	/// exporter should trust the observed durations: a long GOP makes a longer segment, since
-	/// a boundary can only land on a keyframe).
+	/// Replace the declared segment-duration bound, for an owner that learns it after the
+	/// segmenter exists (e.g. an HLS import reading the source playlist's target duration).
 	///
-	/// Applies to the shared state, so it also works on a clone that is already wired in.
-	/// Irrelevant once [`cut`](Self::cut) is used; explicit cuts disable auto-cut.
-	pub fn with_duration_max(self, duration_max: Timestamp) -> Self {
-		self.state.lock().unwrap().duration_max = duration_max;
-		self
+	/// Errors once the timeline track exists: the catalog has advertised the bound by then,
+	/// and consumers hold it for the life of the broadcast. Set it before the first media
+	/// track enrolls.
+	pub fn set_duration_max(&self, duration_max: Timestamp) -> crate::Result<()> {
+		let mut state = self.state.lock().unwrap();
+		if state.sink.is_some() {
+			return Err(crate::Error::TimelineAdvertised);
+		}
+		state.duration_max = duration_max;
+		Ok(())
 	}
 
 	/// Declare a segment boundary at `pts`: the segment before it ends, the one after starts.
@@ -382,6 +451,8 @@ impl Segmenter {
 		};
 		if promote {
 			state.driver = Some(name.to_string());
+			// A previous driver's pending candidate is not a valid boundary for this one.
+			state.candidate = None;
 		}
 
 		Recorder {
@@ -429,6 +500,9 @@ pub struct Producer {
 	state: Arc<Mutex<State>>,
 	track: String,
 	timescale: Timescale,
+	// The declared segment-duration bound in timescale units, frozen at creation (the
+	// segmenter rejects changes once the timeline exists).
+	duration_max: u64,
 	// The wall-clock time of pts 0, in timescale units since the moq epoch, advertised in
 	// section(). Shared across clones.
 	wall: Arc<Mutex<Option<u64>>>,
@@ -442,7 +516,7 @@ impl Producer {
 		let config = moq_json::stream::ProducerConfig::default().with_compression(true);
 		let mut sink = moq_json::stream::Producer::new(net, config);
 
-		let timescale = {
+		let (timescale, duration_max) = {
 			let mut state = segmenter.state.lock().unwrap();
 			for record in state.buffered.drain(..) {
 				if let Err(err) = sink.append(&record) {
@@ -451,20 +525,24 @@ impl Producer {
 				}
 			}
 			state.sink = Some(sink);
-			state.timescale
+			// Freeze the declared bound in the section's timescale, rounding up: an
+			// advertised bound must never understate the declared one.
+			let units = (state.duration_max.as_micros() * state.timescale.as_u64() as u128).div_ceil(1_000_000) as u64;
+			(state.timescale, units)
 		};
 
 		Ok(Self {
 			state: segmenter.state.clone(),
 			track: DEFAULT_NAME.to_string(),
 			timescale,
+			duration_max,
 			wall: Arc::new(Mutex::new(None)),
 		})
 	}
 
 	/// The catalog's root section advertising this timeline.
 	pub fn section(&self) -> Timeline {
-		let mut section = Timeline::new(&self.track);
+		let mut section = Timeline::new(&self.track, self.duration_max);
 		section.timescale = self.timescale.as_u64() as u32;
 		section.wall = *self.wall.lock().unwrap();
 		section
@@ -476,7 +554,9 @@ impl Producer {
 	/// Stored as the extrapolated wall-clock time of pts 0, the single value the
 	/// [`Timeline::wall`](hang::catalog::Timeline::wall) field carries: in this timeline's timescale,
 	/// measured from the moq epoch ([`MOQ_EPOCH_UNIX_MILLIS`](hang::catalog::MOQ_EPOCH_UNIX_MILLIS),
-	/// 2020). Read every time the catalog republishes the section, so set it early.
+	/// 2020). The catalog snapshots [`section`](Self::section) when it advertises the timeline, so
+	/// go through [`catalog::Producer::set_wall`](crate::catalog::Producer::set_wall) (which
+	/// re-advertises) rather than calling this after the timeline is advertised.
 	pub fn set_wall(&mut self, pts: Timestamp, wall: SystemTime) {
 		let unix_millis = wall
 			.duration_since(SystemTime::UNIX_EPOCH)
@@ -632,7 +712,7 @@ mod test {
 
 	fn setup() -> (moq_net::broadcast::Producer, Segmenter, Producer) {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let segmenter = Segmenter::new();
+		let segmenter = Segmenter::default();
 		let producer = Producer::new(&mut broadcast, &segmenter).unwrap();
 		(broadcast, segmenter, producer)
 	}
@@ -669,6 +749,75 @@ mod test {
 				entry(2, 4_000, 0, &[("video0", &[(2, 2)]), ("audio0", &[(8, 8)])]),
 			]
 		);
+	}
+
+	// Keyframes that don't divide duration_max evenly must not accumulate overrun: when the
+	// next keyframe would overrun the bound, the segment closes retroactively at the previous
+	// keyframe, so every segment stays within the declared bound.
+	#[tokio::test]
+	async fn auto_cut_enforces_the_declared_bound() {
+		let (broadcast, segmenter, mut timeline) = setup();
+		let mut video = segmenter.track("video0", Kind::Video);
+
+		// Keyframes every 900ms against the default 2s bound.
+		for (seq, t) in [(0u64, 0u64), (1, 900), (2, 1_800), (3, 2_700), (4, 3_600), (5, 4_500)] {
+			video.record(seq, ms(t), true);
+		}
+		drop(video);
+		timeline.finish().unwrap();
+
+		assert_eq!(
+			drain(&broadcast, &timeline).await,
+			vec![
+				entry(0, 0, 1_800, &[("video0", &[(0, 1)])]),
+				entry(1, 1_800, 1_800, &[("video0", &[(2, 3)])]),
+				entry(2, 3_600, 900, &[("video0", &[(4, 5)])]),
+			]
+		);
+	}
+
+	// A single GOP longer than the bound leaves no valid boundary; the segment overruns
+	// honestly rather than splitting a group.
+	#[tokio::test]
+	async fn a_gop_longer_than_the_bound_overruns_honestly() {
+		let (broadcast, segmenter, mut timeline) = setup();
+		let mut video = segmenter.track("video0", Kind::Video);
+
+		video.record(0, ms(0), true);
+		video.record(1, ms(5_000), true);
+		video.record(2, ms(7_000), true);
+		drop(video);
+		timeline.finish().unwrap();
+
+		assert_eq!(
+			drain(&broadcast, &timeline).await,
+			vec![
+				entry(0, 0, 5_000, &[("video0", &[(0, 0)])]),
+				entry(1, 5_000, 2_000, &[("video0", &[(1, 1)])]),
+				entry(2, 7_000, 0, &[("video0", &[(2, 2)])]),
+			]
+		);
+	}
+
+	// The declared bound is set at construction (or before the timeline track exists) and
+	// frozen once advertised: the catalog section carries it for the life of the broadcast.
+	#[test]
+	fn duration_max_is_declared_and_frozen() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let segmenter = Segmenter::new(Timestamp::from_millis(6_500).unwrap());
+		segmenter
+			.set_duration_max(Timestamp::from_millis(6_000).unwrap())
+			.expect("settable before the timeline exists");
+
+		let timeline = Producer::new(&mut broadcast, &segmenter).unwrap();
+		assert_eq!(timeline.section().duration_max, 6_000);
+		assert!(
+			segmenter
+				.set_duration_max(Timestamp::from_millis(4_000).unwrap())
+				.is_err(),
+			"the advertised bound must not change"
+		);
+		assert_eq!(timeline.section().duration_max, 6_000);
 	}
 
 	#[tokio::test]
@@ -782,7 +931,10 @@ mod test {
 		audio.record(0, ms(0), true);
 		audio.record(1, ms(2_000), true); // audio-driven boundary at 2s
 
-		// Video joins: it becomes the driver, and the next boundary lands on ITS keyframe.
+		// Video joins: it becomes the driver, and boundaries land on ITS keyframes. The
+		// keyframe at 4.1s would leave a 2.1s segment, so the segment is closed retroactively
+		// at the 2.1s keyframe, keeping every segment within the declared 2s bound (and
+		// starting the video segment on its keyframe).
 		let mut video = segmenter.track("video0", Kind::Video);
 		video.record(0, ms(2_100), true);
 		video.record(1, ms(4_100), true);
@@ -795,8 +947,9 @@ mod test {
 			drain(&broadcast, &timeline).await,
 			vec![
 				entry(0, 0, 2_000, &[("audio0", &[(0, 0)])]),
-				entry(1, 2_000, 2_100, &[("audio0", &[(1, 1)]), ("video0", &[(0, 0)])]),
-				entry(2, 4_100, 100, &[("audio0", &[(2, 2)]), ("video0", &[(1, 1)])]),
+				entry(1, 2_000, 100, &[("audio0", &[(1, 1)])]),
+				entry(2, 2_100, 2_000, &[("video0", &[(0, 0)])]),
+				entry(3, 4_100, 100, &[("audio0", &[(2, 2)]), ("video0", &[(1, 1)])]),
 			]
 		);
 	}
@@ -925,7 +1078,7 @@ mod test {
 	#[tokio::test]
 	async fn records_flushed_before_the_track_exists_are_buffered() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let segmenter = Segmenter::new();
+		let segmenter = Segmenter::default();
 
 		// Segments complete before any timeline track exists (e.g. the catalog wires the
 		// track lazily): they publish the moment it attaches.
@@ -983,7 +1136,7 @@ mod test {
 	#[tokio::test]
 	async fn rejects_an_out_of_range_pts() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
-		let segmenter = Segmenter::new();
+		let segmenter = Segmenter::default();
 		let timeline = Producer::new(&mut broadcast, &segmenter).unwrap();
 
 		// Publish a record whose pts no Timestamp can hold, bypassing the segmenter.

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -79,7 +79,8 @@ struct TrackState {
 	/// Group opens reported and not yet flushed into a record: (sequence, pts, keyframe).
 	pending: VecDeque<(u64, Timestamp, bool)>,
 	/// The newest reported timestamp: everything earlier is known, which is what lets a
-	/// segment ending at or before it flush.
+	/// segment ending at or before it flush. Advanced by a group open (the group starts
+	/// there) and by [`Recorder::end`] (the content stops there).
 	frontier: Option<Timestamp>,
 	/// The recorder was dropped; this track no longer gates completeness.
 	closed: bool,
@@ -114,6 +115,8 @@ struct State {
 	sink: Option<moq_json::stream::Producer<Record>>,
 	/// Records flushed before a sink attached, drained into it on attach.
 	buffered: Vec<Record>,
+	/// Live [`Hold`]s: while any exists, no record flushes (more tracks are still enrolling).
+	holds: usize,
 	/// The wire timescale for `pts`/`duration` (the catalog section's default: milliseconds).
 	timescale: Timescale,
 }
@@ -150,6 +153,19 @@ impl State {
 			}
 		}
 
+		self.try_flush(false);
+	}
+
+	/// `name`'s content ends at `pts`: everything up to there is now known, even though no
+	/// group opened at it. This is what gives the final segment an honest duration, since its
+	/// end is not a boundary anybody cut.
+	fn report_end(&mut self, name: &str, pts: Timestamp) {
+		let Some(track) = self.tracks.get_mut(name) else {
+			return;
+		};
+		if track.frontier.is_none_or(|f| pts.as_micros() > f.as_micros()) {
+			track.frontier = Some(pts);
+		}
 		self.try_flush(false);
 	}
 
@@ -224,6 +240,12 @@ impl State {
 			return;
 		}
 
+		// A record is immutable once published, so a caller that knows more tracks are still
+		// enrolling holds flushing back until they are (see [`Segmenter::hold`]).
+		if self.holds > 0 {
+			return;
+		}
+
 		while self.boundaries.len() >= 2 {
 			let end = self.boundaries[1];
 			let complete = finished
@@ -250,8 +272,10 @@ impl State {
 		let pts = start.as_scale(self.timescale) as u64;
 		let duration = match end {
 			Some(end) => (end.as_scale(self.timescale) as u64).saturating_sub(pts),
-			// The final segment has no end boundary; its duration runs to the newest report.
-			// The last group's own duration is unknown, so this is short by up to one group.
+			// The final segment has no end boundary, so it runs to the newest thing any track
+			// reported: its end of content when the track reported one (a finished
+			// `container::Producer` does), otherwise the last group it opened, which
+			// undercounts that group's tail.
 			None => self
 				.tracks
 				.values()
@@ -323,6 +347,9 @@ impl State {
 
 	/// The terminal flush: treat every track as closed, then emit the final open segment.
 	fn finish(&mut self) {
+		// Nothing more will enroll, so an outstanding hold has nothing left to wait for.
+		self.holds = 0;
+
 		// Content but never a boundary (nobody cut and the driver never reported): anchor the
 		// one segment at the earliest report so the content is still indexed.
 		if self.boundaries.is_empty() {
@@ -389,8 +416,24 @@ impl Segmenter {
 				driver: None,
 				sink: None,
 				buffered: Vec::new(),
+				holds: 0,
 				timescale: Timescale::MILLI,
 			})),
+		}
+	}
+
+	/// Hold record publishing back until the returned [`Hold`] drops.
+	///
+	/// A record is immutable once published, and completeness is judged against the tracks
+	/// enrolled *at that moment*, so a segment that flushes while a sibling rendition is still
+	/// enrolling omits it for good (and that rendition's earlier groups then land in whatever
+	/// segment flushes next). Take a hold around a batch that enrolls or feeds several tracks
+	/// (an HLS import walking its renditions one at a time) so every one of them is accounted
+	/// for before anything is published. Holds nest; the last one to drop flushes.
+	pub fn hold(&self) -> Hold {
+		self.state.lock().unwrap().holds += 1;
+		Hold {
+			state: self.state.clone(),
 		}
 	}
 
@@ -462,6 +505,21 @@ impl Segmenter {
 	}
 }
 
+/// Holds [`Segmenter`] record publishing back while tracks are still enrolling.
+///
+/// Minted by [`Segmenter::hold`]; whatever became complete meanwhile flushes when it drops.
+pub struct Hold {
+	state: Arc<Mutex<State>>,
+}
+
+impl Drop for Hold {
+	fn drop(&mut self) {
+		let mut state = self.state.lock().unwrap();
+		state.holds = state.holds.saturating_sub(1);
+		state.try_flush(false);
+	}
+}
+
 /// Reports one media track's group opens into the shared [`Segmenter`].
 ///
 /// Move-only: it is the track's single reporting handle, and dropping it closes the track's
@@ -480,6 +538,16 @@ impl Recorder {
 	/// segmenter builds ranges and completeness from.
 	pub(crate) fn record(&mut self, sequence: u64, pts: Timestamp, keyframe: bool) {
 		self.state.lock().unwrap().report(&self.name, sequence, pts, keyframe);
+	}
+
+	/// Report that this track's content extends to `pts`, without a group opening there.
+	///
+	/// A group open says where content *starts*; the last group of a broadcast has no
+	/// successor to bound it, so its segment would otherwise be published a group short (zero
+	/// for a segment that is a single group). Report the end whenever you know it: closing a
+	/// group, finishing a track.
+	pub(crate) fn end(&mut self, pts: Timestamp) {
+		self.state.lock().unwrap().report_end(&self.name, pts);
 	}
 }
 
@@ -1025,6 +1093,68 @@ mod test {
 		assert_eq!(
 			entries[2],
 			entry(2, 4_000, 500, &[("video0", &[(2, 2)]), ("audio0", &[(1, 1)])])
+		);
+	}
+
+	// The last group of a broadcast has no successor to bound it, so without a reported end
+	// the final segment's duration collapses to zero (an HLS `EXTINF:0`).
+	#[tokio::test]
+	async fn the_final_segment_runs_to_the_reported_end() {
+		let (broadcast, segmenter, mut timeline) = setup();
+		let mut video = segmenter.track("video0", Kind::Video);
+
+		video.record(0, ms(0), true);
+		video.record(1, ms(2_000), true);
+		// A finished `container::Producer` reports where its content stops.
+		video.end(ms(4_000));
+		drop(video);
+		timeline.finish().unwrap();
+
+		assert_eq!(
+			drain(&broadcast, &timeline).await,
+			vec![
+				entry(0, 0, 2_000, &[("video0", &[(0, 0)])]),
+				entry(1, 2_000, 2_000, &[("video0", &[(1, 1)])]),
+			]
+		);
+	}
+
+	// A record is immutable and judged against the tracks enrolled when it flushes, so a
+	// producer that enrolls its tracks one batch at a time (an HLS import walking its
+	// renditions) holds flushing back until they are all in.
+	#[tokio::test]
+	async fn a_hold_defers_flushing_until_every_track_enrolls() {
+		let (broadcast, segmenter, mut timeline) = setup();
+		let hold = segmenter.hold();
+
+		// The primary rendition runs a whole batch of segments through before its sibling
+		// has even loaded an init segment.
+		let mut first = segmenter.track("video0", Kind::Video);
+		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
+			first.record(seq, ms(t), true);
+		}
+
+		let mut second = segmenter.track("video1", Kind::Video);
+		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
+			second.record(seq, ms(t), true);
+		}
+
+		drop(hold);
+		drop(first);
+		drop(second);
+		timeline.finish().unwrap();
+
+		// Both renditions are indexed from segment 0. Without the hold, segments 0 and 1
+		// would have flushed knowing only video0 (a permanent gap for video1), and video1's
+		// first two groups would have folded into segment 2.
+		let entries = drain(&broadcast, &timeline).await;
+		assert_eq!(
+			entries[0],
+			entry(0, 0, 2_000, &[("video0", &[(0, 0)]), ("video1", &[(0, 0)])])
+		);
+		assert_eq!(
+			entries[1],
+			entry(1, 2_000, 2_000, &[("video0", &[(1, 1)]), ("video1", &[(1, 1)])])
 		);
 	}
 

--- a/rs/moq-rtc/src/codec/vp8.rs
+++ b/rs/moq-rtc/src/codec/vp8.rs
@@ -16,13 +16,13 @@ pub struct Bridge {
 
 impl Bridge {
 	/// Publish a `.vp8` track on `broadcast`; the catalog rendition is added on the first frame.
-	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
+	pub fn new(mut broadcast: moq_net::broadcast::Producer, mut catalog: moq_mux::catalog::Producer) -> Result<Self> {
 		let track = broadcast.create_track(broadcast.unique_name(".vp8"), hang::container::track_info())?;
 		let name = track.name().to_string();
 		let producer = catalog.media_producer(
 			track,
 			moq_mux::catalog::hang::Container::Legacy,
-			moq_mux::timeline::Cadence::Boundary,
+			moq_mux::timeline::Kind::Video,
 		)?;
 		Ok(Self {
 			rendition: codec::VideoRendition { catalog, name },
@@ -38,7 +38,6 @@ impl Bridge {
 		let name = self.rendition.name.clone();
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8);
 		config.container = hang::catalog::Container::Legacy;
-		config.timeline = Some(self.rendition.catalog.timeline(&name)?.section());
 		// Publish explicitly rather than through the guard's drop, which only warns:
 		// marking the rendition announced when the catalog never took it would leave the
 		// media track advertised nowhere, and `announced` latches so we'd never retry.

--- a/rs/moq-rtc/src/codec/vp8.rs
+++ b/rs/moq-rtc/src/codec/vp8.rs
@@ -19,7 +19,11 @@ impl Bridge {
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
 		let track = broadcast.create_track(broadcast.unique_name(".vp8"), hang::container::track_info())?;
 		let name = track.name().to_string();
-		let producer = catalog.media_producer(track, moq_mux::catalog::hang::Container::Legacy)?;
+		let producer = catalog.media_producer(
+			track,
+			moq_mux::catalog::hang::Container::Legacy,
+			moq_mux::timeline::Cadence::Boundary,
+		)?;
 		Ok(Self {
 			rendition: codec::VideoRendition { catalog, name },
 			track: producer,

--- a/rs/moq-rtc/src/codec/vp8.rs
+++ b/rs/moq-rtc/src/codec/vp8.rs
@@ -19,11 +19,7 @@ impl Bridge {
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, mut catalog: moq_mux::catalog::Producer) -> Result<Self> {
 		let track = broadcast.create_track(broadcast.unique_name(".vp8"), hang::container::track_info())?;
 		let name = track.name().to_string();
-		let producer = catalog.media_producer(
-			track,
-			moq_mux::catalog::hang::Container::Legacy,
-			moq_mux::timeline::Kind::Video,
-		)?;
+		let producer = catalog.media_producer(track, moq_mux::catalog::hang::Container::Legacy)?;
 		Ok(Self {
 			rendition: codec::VideoRendition { catalog, name },
 			track: producer,

--- a/rs/moq-rtc/src/codec/vp9.rs
+++ b/rs/moq-rtc/src/codec/vp9.rs
@@ -15,13 +15,13 @@ pub struct Bridge {
 
 impl Bridge {
 	/// Publish a `.vp9` track on `broadcast`; the catalog rendition is added on the first frame.
-	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
+	pub fn new(mut broadcast: moq_net::broadcast::Producer, mut catalog: moq_mux::catalog::Producer) -> Result<Self> {
 		let track = broadcast.create_track(broadcast.unique_name(".vp9"), hang::container::track_info())?;
 		let name = track.name().to_string();
 		let producer = catalog.media_producer(
 			track,
 			moq_mux::catalog::hang::Container::Legacy,
-			moq_mux::timeline::Cadence::Boundary,
+			moq_mux::timeline::Kind::Video,
 		)?;
 		Ok(Self {
 			rendition: codec::VideoRendition { catalog, name },
@@ -37,7 +37,6 @@ impl Bridge {
 		let name = self.rendition.name.clone();
 		let mut config = hang::catalog::VideoConfig::new(hang::catalog::VP9::default());
 		config.container = hang::catalog::Container::Legacy;
-		config.timeline = Some(self.rendition.catalog.timeline(&name)?.section());
 		// Publish explicitly rather than through the guard's drop, which only warns:
 		// marking the rendition announced when the catalog never took it would leave the
 		// media track advertised nowhere, and `announced` latches so we'd never retry.

--- a/rs/moq-rtc/src/codec/vp9.rs
+++ b/rs/moq-rtc/src/codec/vp9.rs
@@ -18,7 +18,11 @@ impl Bridge {
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, catalog: moq_mux::catalog::Producer) -> Result<Self> {
 		let track = broadcast.create_track(broadcast.unique_name(".vp9"), hang::container::track_info())?;
 		let name = track.name().to_string();
-		let producer = catalog.media_producer(track, moq_mux::catalog::hang::Container::Legacy)?;
+		let producer = catalog.media_producer(
+			track,
+			moq_mux::catalog::hang::Container::Legacy,
+			moq_mux::timeline::Cadence::Boundary,
+		)?;
 		Ok(Self {
 			rendition: codec::VideoRendition { catalog, name },
 			track: producer,

--- a/rs/moq-rtc/src/codec/vp9.rs
+++ b/rs/moq-rtc/src/codec/vp9.rs
@@ -18,11 +18,7 @@ impl Bridge {
 	pub fn new(mut broadcast: moq_net::broadcast::Producer, mut catalog: moq_mux::catalog::Producer) -> Result<Self> {
 		let track = broadcast.create_track(broadcast.unique_name(".vp9"), hang::container::track_info())?;
 		let name = track.name().to_string();
-		let producer = catalog.media_producer(
-			track,
-			moq_mux::catalog::hang::Container::Legacy,
-			moq_mux::timeline::Kind::Video,
-		)?;
+		let producer = catalog.media_producer(track, moq_mux::catalog::hang::Container::Legacy)?;
 		Ok(Self {
 			rendition: codec::VideoRendition { catalog, name },
 			track: producer,


### PR DESCRIPTION
## Summary

The broadcast now has **one timeline track** (`timeline.z`, advertised at the catalog root) carrying one self-contained record per aligned segment:

```json
{
  "segment": 42,
  "pts": 123456000,
  "duration": 6000000,
  "tracks": {
    "video": [{ "start": 105, "end": 105 }],
    "audio": [{ "start": 512, "end": 540 }, { "start": 550, "end": 560 }]
  }
}
```

- **Self-contained records**: explicit `duration` (live edge usable immediately; `next.pts != pts + duration` marks a discontinuity) and per-track arrays of inclusive group ranges, so serving `seg/{n}.m4s` needs only record N. Multiple ranges represent sequence gaps (Elemental-style); an absent track is a whole-segment gap (`EXT-X-GAP`); an optional `keyframe: false` per range flags a non-IDR range start.
- **Paced by a minimum, not a maximum**: a segment ends at the first point that is a group boundary on *every* enrolled track and at least `duration_min` (1s default) past its start, so the track with the coarsest groups paces the broadcast. A 2s GOP against a 1s minimum yields 2s segments; a real-time encoder with a 10 minute GOP yields one 10 minute segment, because there is nowhere else a segment could start and stay decodable. A minimum is always satisfiable (wait longer); a maximum is not, since a single group longer than it cannot be split.
- **`durationMax` is an optional contract**: for consumers that need a bound before observing anything (an HLS exporter's `EXT-X-TARGETDURATION`). Absent by default, because most publishers cannot promise one. When declared, a segment that would exceed it fails the timeline (`Error::TimelineOverrun`) rather than publishing a record that contradicts the catalog.
- **Facts up, policy down** (`moq_mux::timeline::Producer`): media tracks enroll (`track(name)`) and report every group open plus where their content ends; they never decide boundaries. The pacing above is the default policy, and `cut(pts)` overrides it when the application knows better (an HLS import following its source playlist, CMAF segments on disk). No track kinds, no elected driver, no wall clocks: timestamps only.
- **Completeness-based flush**: a record publishes only once every enrolled track reported a group at or past the segment's end (or closed), so a record never omits a rendition that was about to contribute. `reserve()` extends that across a batch of enrollments, mirroring the catalog's own reservation gate, for a producer that brings its tracks up one at a time.
- **Explicit cuts wired end to end**: the fMP4 importer cuts on `styp` atoms (CMAF segments on disk) and exposes `cut()`; the HLS import cuts per source-playlist segment on every variant, so importing then exporting reproduces the origin's segmentation. Duplicate cuts are free: the timeline ignores one that would land inside `duration_min`.
- **Wire format**: a `moq-json` *stream* (single group, one DEFLATE-compressed JSON record per frame, shared window), so verbose records compress against all earlier ones. Live history is bounded by the group cache; VOD reads a recording.
- **moq-hls export** is a pure function of the timeline: one timeline subscription fans records out to per-rendition windows; playlists agree on `EXT-X-MEDIA-SEQUENCE`/`EXTINF` by construction, render `EXT-X-GAP` (protocol version bumps to 8 only when used) and `EXT-X-DISCONTINUITY`, and take `EXT-X-TARGETDURATION` from the declared bound when there is one, raised to cover the window either way (a playlist whose `EXTINF` exceeds its target duration is invalid).
- **Spec**: `drafts/draft-lcurley-moq-hang.md` gains a Timeline section (catalog section incl. the optional `durationMax`, framing, record schema, segmentation rules) and the catalog root schema now lists `timeline`.

## Public API changes

All breaking; this PR was born as a breaking rework of an unspecced surface.

- `hang::timeline`: `Record` is `{segment, pts, duration, tracks}` + `Range`; `track_name(rendition)` replaced by `DEFAULT_NAME` (`"timeline.z"`). `hang::Catalog` gains a root `timeline` section (`catalog::Timeline::new(track)`, optional `durationMax`); `VideoConfig`/`AudioConfig` lose theirs.
- `moq_mux::timeline`: one public `Producer` (`Segmenter` merged into it), constructed with `Config { duration_min: Duration, duration_max: Option<Duration>, wall: Option<SystemTime> }`. `track(name)` enrolls (no `Kind`), `cut(pts)` overrides the pacing, `reserve()` defers publishing (a clonable RAII handle mirroring `catalog::Producer::reserve`), `finish()` errors on an overrun. `Kind`, `DEFAULT_DURATION_MAX`, `set_duration_max` and `Error::TimelineAdvertised` are gone; `DEFAULT_DURATION_MIN` and `Error::TimelineOverrun` replace them. `Recorder` reports `(sequence, pts, keyframe)` plus `end(pts)`, and closes on drop. `set_wall()` is gone: the anchor is `Config::wall`, the wall-clock time of `pts` 0. `Entry` carries `duration: std::time::Duration` and the ranges map.
- `moq_mux::catalog::Producer`: `media_producer(track, container)` drops the `Kind` argument; `timeline()` is infallible; new `enroll(name)` for tracks not built through a `container::Producer`, and `with_timeline(broadcast, config)` to pace the broadcast. `segmenter()` and `set_wall()` are gone (the anchor is `Config::wall`).
- `moq_mux::container::fmp4::Import`: new `cut()`; `with_cut_on_boundary` removed (a `styp` always cuts).
- `moq_hls::export::segments::Segment` drops `group`; gap/discontinuity surface through the playlist instead.
- JS `@moq/hang`: `Timeline.Segmenter` folds into `Timeline.Producer` with the same shape (`track()`, `cut()`, `reserve()`, `Recorder.end()`), constructed with `{ durationMin, durationMax, wall }`; catalog `timeline` moves to the root schema with an optional `durationMax`.

These are breaking `pub` changes in core libraries plus a catalog format break, so this targets `dev` per Branch Targeting.

## Open questions

- Boundaries land on the *latest* candidate across tracks, which keeps any track's group from being split. When two tracks have genuinely different coarse cadences (rare: audio groups are normally far shorter than a GOP), that lumps two of the finer track's groups into one segment rather than splitting either. The alternative strands a track with an empty segment, which is worse.
- An enrolled track that goes quiet holds the timeline open rather than producing an `EXT-X-GAP`; only closing it yields a gap. That is the "wait for every track" rule working as intended, but it means a paused source needs `discontinuity()` or a close, not silence.
- `duration_max` has no in-tree caller yet. It is for a publisher that controls its encoder; the HLS import deliberately does not declare its source's target duration, since a non-conformant source would then kill the timeline rather than just producing a long segment.

## Cross-package sync

- `js/hang` mirrors the record shape, the merged timeline producer (pacing, reservations, overrun), and the root catalog section.
- `doc/bin/hls.md` updated (single timeline, gaps/discontinuities, TARGETDURATION from the declared bound *or* the observed window, import preserving source segmentation).
- `drafts/draft-lcurley-moq-hang.md` specs the timeline, including the optional `durationMax` contract and the minimum-duration segmentation rule (`just drafts check` passes).
- `moq-ffi` and the language wrappers do not expose the timeline; nothing to mirror.

## Test plan

- `moq-mux` timeline tests: coarsest-track pacing, a GOP longer than the minimum, short groups packing up to the minimum, completeness gating, explicit cuts, sub-minimum cuts ignored, `duration_max` overrun failing the timeline, the final segment running to a reported end, `reserve()` covering the enrollment race, nested reservations, a reservation outstanding at `finish()`, sequence-gap ranges, closed-track gaps, `keyframe: false`, lazy track creation.
- `moq-hls`: export end-to-end tests (playlists from the shared timeline, target duration covering the window, aligned sequences, gap rows, recorder cursors draining after `Broadcaster` drop); import test for evicting a persistently failing rendition; fmp4 import test asserting the root section + both renditions indexed from group 0.
- JS: bun tests mirror the Rust cases 1:1, decoding records back off a real `@moq/json` stream.
- `cargo test` green on `moq-mux`, `moq-hls`, `hang`, `moq-audio`, `moq-rtc`; `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --check`, `cargo doc -D warnings` on the workspace, `just js check`, `bun test js/hang`, and `just drafts check` all pass.

## History

The first push used per-track timelines with cadence inference. The second reworked it into one broadcast track of complete segments with a required `durationMax` enforced by auto-cut on an elected video driver. An adversarial review then found four defects (a zero-duration final segment, `EXT-X-TARGETDURATION` below an `EXTINF`, records published before sibling renditions enrolled, and one dead rendition freezing every healthy one), all fixed with regression tests. The final commit replaces the unenforceable maximum with an enforceable minimum, which also removed the driver election, the track `Kind`, the retroactive-close logic, and most of the call-site churn: it is a net 228 lines smaller than what it replaced.

(Written by Claude Fable, revised by Opus 5)




