### PR TITLE
feat(doc): render the IETF drafts on the documentation site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ node_modules
 # Cloudflare Wrangler
 .wrangler/
 
+# VitePress pages generated from drafts/ by doc/.vitepress/drafts.ts
+/doc/draft/
+
 # We're using bun
 package-lock.json
 yarn.lock

--- a/.remarkignore
+++ b/.remarkignore
@@ -8,5 +8,7 @@ pkg/
 **/CHANGELOG.md
 
 # IETF drafts are kramdown-rfc markdown, not CommonMark; linted by `just
-# drafts check` (kramdown-rfc) instead.
+# drafts check` (kramdown-rfc) instead. doc/draft/ is generated from them by
+# doc/.vitepress/drafts.ts.
 drafts/draft-*.md
+doc/draft/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Top-level layout only. Per-crate and per-package detail lives in the nested guid
 - `/cpp/` - C/C++ consumers of `libmoq`. `cpp/obs/` is the OBS Studio plugin (CMake; links `libmoq` via `MOQ_LOCAL`), licensed GPL-2.0-or-later because it links `libobs`. See `doc/bin/obs.md`.
 - `/demo/` - demos and test media: relay configs, the web demo, MoQ Boy, media hosting, and a network throttle script.
 - `/test/` - cross-language interop smoke tests (`test/smoke/`), run via `just test smoke[-full]`.
-- `/doc/` - documentation site (VitePress, deployed via Cloudflare).
+- `/doc/` - documentation site (VitePress, deployed via Cloudflare). The `/draft/` section is generated from `drafts/` by `doc/.vitepress/drafts.ts`.
 - `/drafts/` - IETF Internet-Drafts (kramdown-rfc) for the MoQ protocols implemented here. Built and published to the datatracker via `just drafts`. See `drafts/CLAUDE.md`.
 
 ## Language Bindings
@@ -163,6 +163,7 @@ Changes in one area usually need matching updates elsewhere, including docs. If 
 | `rs/moq-gst` | `doc/bin/gstreamer.md` |
 | `rs/libmoq` C ABI (`moq.h`) | `cpp/obs/src`, `doc/bin/obs.md` |
 | `js/{watch,publish}` UI/API | `demo/web` if it consumes the API |
+| a kramdown-rfc construct new to `drafts/` | `doc/.vitepress/drafts.ts`, which translates the drafts into `/draft/` site pages |
 
 **Any change to the on-the-wire format MUST update the matching IETF draft under `drafts/` in the same PR.** The drafts are the normative spec other implementations (and future us) build against, so a wire change that lands without the draft update silently forks the code from the spec. This covers new/changed/removed SETUP parameters, messages, fields, framing, enum values, and version bumps anywhere under `rs/moq-net` (and the catalog/container framing in `rs/hang`). Update the draft for the specific feature you touched: `draft-lcurley-moq-lite.md` for moq-lite session/SETUP/framing, and the per-feature draft for the rest (`draft-lcurley-moq-probe.md`, `draft-lcurley-moq-relay-hops.md`, `draft-lcurley-moq-timestamp.md`, `draft-lcurley-moq-hang.md`, etc.). New capabilities go in as backward-compatible extensions even after a draft is published: SETUP requires receivers to ignore unknown parameter IDs, so a new parameter is additive. Validate with `just drafts check` (kramdown-rfc). See [`drafts/CLAUDE.md`](drafts/CLAUDE.md).
 

--- a/bun.lock
+++ b/bun.lock
@@ -59,8 +59,11 @@
       "name": "moq-doc",
       "version": "0.1.0",
       "devDependencies": {
+        "@types/node": "^26.1.1",
+        "typescript": "7.0.2",
         "vitepress": "^1.6.4",
         "wrangler": "^4.110.0",
+        "yaml": "^2.9.0",
       },
     },
     "js/clock": {

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
       "name": "moq-doc",
       "version": "0.1.0",
       "devDependencies": {
+        "@types/bun": "^1.3.14",
         "@types/node": "^26.1.1",
         "typescript": "7.0.2",
         "vitepress": "^1.6.4",

--- a/doc/.vitepress/config.ts
+++ b/doc/.vitepress/config.ts
@@ -1,4 +1,9 @@
 import { defineConfig } from "vitepress";
+import { syncDrafts } from "./drafts";
+
+// Generated before VitePress enumerates routes, so the pages and this sidebar
+// list stay in sync with the kramdown-rfc sources under drafts/.
+const drafts = syncDrafts();
 
 export default defineConfig({
 	title: "Media over QUIC",
@@ -42,6 +47,7 @@ export default defineConfig({
 		nav: [
 			{ text: "Setup", link: "/setup/" },
 			{ text: "Concepts", link: "/concept/" },
+			{ text: "Drafts", link: "/draft/" },
 			{ text: "Apps", link: "/bin/" },
 			{
 				text: "Libraries",
@@ -118,6 +124,14 @@ export default defineConfig({
 							],
 						},
 					],
+				},
+			],
+
+			"/draft/": [
+				{
+					text: "Internet-Drafts",
+					link: "/draft/",
+					items: drafts.map((draft) => ({ text: draft.title, link: draft.link })),
 				},
 			],
 
@@ -244,7 +258,18 @@ export default defineConfig({
 		],
 
 		editLink: {
-			pattern: "https://github.com/moq-dev/moq/edit/main/doc/:path",
+			// /draft/ pages are generated, so edits go to the kramdown-rfc source
+			// instead. VitePress ships this function to the browser by stringifying
+			// it, so it has to stay closure-free: no imports, no outer variables.
+			// The inverse of `slug()` in drafts.ts.
+			pattern: ({ filePath }) => {
+				const generated = filePath.startsWith("draft/") && filePath !== "draft/index.md";
+				const slug = filePath.slice("draft/".length);
+				const path = generated
+					? `drafts/${slug.startsWith("draft-") ? slug : `draft-lcurley-${slug}`}`
+					: `doc/${filePath}`;
+				return `https://github.com/moq-dev/moq/edit/main/${path}`;
+			},
 			text: "Edit this page on GitHub",
 		},
 

--- a/doc/.vitepress/drafts.test.ts
+++ b/doc/.vitepress/drafts.test.ts
@@ -6,13 +6,14 @@
 // degrades into a paragraph.
 
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createMarkdownRenderer } from "vitepress";
 import { type DraftPage, renderDrafts } from "./drafts";
 
-const srcDir = join(dirname(fileURLToPath(import.meta.url)), "..");
-const md = await createMarkdownRenderer(srcDir);
+const here = dirname(fileURLToPath(import.meta.url));
+const md = await createMarkdownRenderer(join(here, ".."));
 
 const pages = renderDrafts();
 
@@ -23,6 +24,12 @@ function content(page: DraftPage): string {
 
 function html(page: DraftPage): string {
 	return md.render(content(page));
+}
+
+/** The kramdown-rfc source this page was generated from, metadata block stripped. */
+function source(page: DraftPage): string {
+	const raw = readFileSync(join(here, "../../drafts", `${page.name}.md`), "utf8");
+	return raw.slice(raw.indexOf("--- abstract"));
 }
 
 test("every draft produces a page", () => {
@@ -76,15 +83,12 @@ describe("citations resolve", () => {
 
 describe("tables render as tables", () => {
 	test.each(pages.map((p) => [p.name, p] as const))("%s", (_name, page) => {
-		// kramdown draws separators between body rows; GFM allows exactly one
-		// delimiter, below the header. Every source table must survive.
-		const source = content(page)
-			.split("\n")
-			.filter((line) => line.trim().startsWith("|"));
-		if (source.length === 0) return;
-
+		// Counted against the *source*, not the generated markdown: comparing
+		// the output to itself would still pass if a table were dropped whole.
+		// kramdown draws separators between body rows and GFM allows exactly
+		// one, below the header, so each source table must survive as one table.
 		const rendered = html(page);
-		expect(rendered.match(/<table/g) ?? []).toHaveLength(countTables(content(page)));
+		expect(rendered.match(/<table/g) ?? []).toHaveLength(countTables(source(page)));
 
 		// A dropped delimiter leaves the rows as paragraph text.
 		expect(rendered).not.toMatch(/<p>\s*\|/);
@@ -113,19 +117,28 @@ describe("tables render as tables", () => {
 	});
 });
 
-/** Count the table blocks in a page: runs of consecutive `|` lines. */
+/**
+ * Count the table blocks in a body: runs of consecutive `|` lines.
+ *
+ * Handles both fence styles, since the sources use `~~~` and the generated
+ * pages use ```` ``` ````.
+ */
 function countTables(body: string): number {
 	const lines = body.split("\n");
 	let count = 0;
 	let fenced = false;
+	let previous = false;
 
-	for (let i = 0; i < lines.length; i++) {
-		if (lines[i].startsWith("```")) fenced = !fenced;
-		if (fenced) continue;
+	for (const line of lines) {
+		if (/^(~~~|```)/.test(line)) {
+			fenced = !fenced;
+			previous = false;
+			continue;
+		}
 
-		const row = lines[i].trim().startsWith("|");
-		const previous = i > 0 && lines[i - 1].trim().startsWith("|");
+		const row = !fenced && line.trim().startsWith("|");
 		if (row && !previous) count++;
+		previous = row;
 	}
 	return count;
 }

--- a/doc/.vitepress/drafts.test.ts
+++ b/doc/.vitepress/drafts.test.ts
@@ -1,0 +1,131 @@
+// Checks the generated pages against the real VitePress markdown pipeline.
+//
+// Asserting on the generated markdown alone is not enough: the failure mode
+// these guard against is markdown that reads fine but renders as something
+// else. A table missing its GFM delimiter row, for instance, silently
+// degrades into a paragraph.
+
+import { describe, expect, test } from "bun:test";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createMarkdownRenderer } from "vitepress";
+import { type DraftPage, renderDrafts } from "./drafts";
+
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const md = await createMarkdownRenderer(srcDir);
+
+const pages = renderDrafts();
+
+/** Everything below the generated frontmatter. */
+function content(page: DraftPage): string {
+	return page.markdown.split("\n---\n").slice(1).join("\n---\n");
+}
+
+function html(page: DraftPage): string {
+	return md.render(content(page));
+}
+
+test("every draft produces a page", () => {
+	expect(pages.length).toBeGreaterThan(0);
+	expect(pages.map((p) => p.name)).toContain("draft-lcurley-moq-lite");
+});
+
+describe("kramdown constructs are translated", () => {
+	test.each(pages.map((p) => [p.name, p] as const))("%s", (_name, page) => {
+		const body = content(page);
+
+		// `{{ref}}` is Vue interpolation, so a survivor is a build hazard, not
+		// just a typo. The rest would render as literal punctuation.
+		expect(body).not.toInclude("{{");
+		expect(body).not.toMatch(/^\{:/m);
+		expect(body).not.toMatch(/^--- (abstract|middle|back)$/m);
+		expect(body).not.toInclude("{::boilerplate");
+	});
+});
+
+describe("citations resolve", () => {
+	test.each(pages.map((p) => [p.name, p] as const))("%s", (_name, page) => {
+		// A `[ref]` that never became a link renders as literal brackets. Match
+		// the alias shape kramdown-rfc uses (letter-initial, so example output
+		// like `sizes=[56]` doesn't count) and allow real link/image syntax.
+		const dangling: string[] = [];
+		let fenced = false;
+
+		for (const line of content(page).split("\n")) {
+			if (line.startsWith("```")) fenced = !fenced;
+			if (fenced) continue;
+
+			for (const [, bang, name] of line.matchAll(/(!?)\[([A-Za-z][\w.-]*)\](?![([])/g)) {
+				if (!bang) dangling.push(name);
+			}
+		}
+
+		expect(dangling).toEqual([]);
+	});
+
+	test("a citation before a colon is still a link", () => {
+		const page = pages.find((p) => p.name === "draft-lcurley-qmux-websocket");
+		expect(page).toBeDefined();
+
+		// "...exactly as in [qmux]: an endpoint advertises..." is prose, not a
+		// link definition, so the alias has to resolve.
+		expect(content(page as DraftPage)).not.toInclude("[qmux]:");
+		expect(html(page as DraftPage)).toInclude("draft-ietf-quic-qmux</a>: an endpoint");
+	});
+});
+
+describe("tables render as tables", () => {
+	test.each(pages.map((p) => [p.name, p] as const))("%s", (_name, page) => {
+		// kramdown draws separators between body rows; GFM allows exactly one
+		// delimiter, below the header. Every source table must survive.
+		const source = content(page)
+			.split("\n")
+			.filter((line) => line.trim().startsWith("|"));
+		if (source.length === 0) return;
+
+		const rendered = html(page);
+		expect(rendered.match(/<table/g) ?? []).toHaveLength(countTables(content(page)));
+
+		// A dropped delimiter leaves the rows as paragraph text.
+		expect(rendered).not.toMatch(/<p>\s*\|/);
+	});
+
+	test("row separators do not split a table apart", () => {
+		const page = pages.find((p) => p.name === "draft-lcurley-moq-lite");
+		expect(page).toBeDefined();
+
+		const rendered = html(page as DraftPage);
+
+		// The Bidirectional Streams table: one header, six body rows, each
+		// separated by a kramdown rule in the source. Cells carry the source's
+		// alignment, so match around the style attribute.
+		const header = /<th[^>]*>Stream<\/th>/.exec(rendered);
+		expect(header).not.toBeNull();
+
+		for (const stream of ["Announce", "Subscribe", "Fetch", "Probe", "Goaway", "Track"]) {
+			expect(rendered).toMatch(new RegExp(`<td[^>]*>${stream}</td>`));
+		}
+
+		// One header row plus six body rows, in a single table.
+		const start = rendered.lastIndexOf("<table", header?.index);
+		const rows = rendered.slice(start).split("</table>")[0];
+		expect(rows.match(/<tr>/g) ?? []).toHaveLength(7);
+	});
+});
+
+/** Count the table blocks in a page: runs of consecutive `|` lines. */
+function countTables(body: string): number {
+	const lines = body.split("\n");
+	let count = 0;
+	let fenced = false;
+
+	for (let i = 0; i < lines.length; i++) {
+		if (lines[i].startsWith("```")) fenced = !fenced;
+		if (fenced) continue;
+
+		const row = lines[i].trim().startsWith("|");
+		const previous = i > 0 && lines[i - 1].trim().startsWith("|");
+		if (row && !previous) count++;
+	}
+	return count;
+}

--- a/doc/.vitepress/drafts.ts
+++ b/doc/.vitepress/drafts.ts
@@ -1,0 +1,359 @@
+// Renders the kramdown-rfc Internet-Drafts under drafts/ into VitePress pages.
+//
+// The draft sources stay canonical: `just drafts build` still feeds them to
+// kramdown-rfc for the authoritative RFC rendering. This is the doc-site
+// approximation, generated at config load so the pages exist before VitePress
+// scans for routes.
+//
+// kramdown-rfc markdown is not CommonMark, and several of its constructs are
+// actively hostile to VitePress:
+//   - The metadata block runs to `--- abstract`, so gray-matter never finds
+//     the closing fence and the whole document parses as frontmatter.
+//   - `{{ref}}` citations collide with Vue template interpolation.
+//   - `{::boilerplate}` / `{:key="value"}` IALs and the leading table
+//     delimiter row have no CommonMark equivalent.
+// Everything below exists to translate those, one construct at a time.
+
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** kramdown-rfc sources. */
+const SRC_DIR = join(here, "../../drafts");
+
+/** Generated pages. Gitignored: regenerated on every build. */
+const OUT_DIR = join(here, "../draft");
+
+/** Route prefix for the generated pages. */
+const BASE = "/draft";
+
+/** Non-RFC, non-I-D bibxml references we cite, mapped to a canonical URL. */
+const EXTERNAL: Record<string, { label: string; url: string }> = {
+	WebCodecs: { label: "WebCodecs", url: "https://www.w3.org/TR/webcodecs/" },
+};
+
+/** What `{::boilerplate bcp14-tagged}` expands to. */
+const BCP14 =
+	'The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", ' +
+	'"RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as ' +
+	"described in BCP 14 [RFC2119](https://www.rfc-editor.org/rfc/rfc2119) " +
+	"[RFC8174](https://www.rfc-editor.org/rfc/rfc8174) when, and only when, they appear in all capitals, as shown here.";
+
+/** A generated draft page. */
+export interface DraftPage {
+	/** Source draft name, e.g. `draft-lcurley-moq-lite`. */
+	name: string;
+	/** Draft title from the source metadata. */
+	title: string;
+	/** Site route, e.g. `/draft/moq-lite`. */
+	link: string;
+}
+
+/** The metadata block above `--- abstract`. Only the fields we render. */
+interface Metadata {
+	title: string;
+	docname: string;
+	normative: Record<string, string>;
+	informative: Record<string, string>;
+}
+
+/** A citation target resolved to display text and (usually) a link. */
+interface Reference {
+	label: string;
+	url?: string;
+}
+
+/**
+ * Regenerate the draft pages and return them in sidebar order.
+ *
+ * Called from `config.ts` at module load, so the output is on disk before
+ * VitePress enumerates routes. Editing a draft needs a dev-server restart.
+ */
+export function syncDrafts(): DraftPage[] {
+	const names = readdirSync(SRC_DIR)
+		.filter((f) => f.startsWith("draft-") && f.endsWith(".md"))
+		.map((f) => f.slice(0, -3))
+		.sort();
+
+	// Cross-draft citations resolve to a local route rather than the
+	// datatracker, so `{{moql}}` in one draft links to our page for another.
+	const routes = new Map(names.map((name) => [name, `${BASE}/${slug(name)}`]));
+
+	rmSync(OUT_DIR, { recursive: true, force: true });
+	mkdirSync(OUT_DIR, { recursive: true });
+
+	const pages: DraftPage[] = [];
+	for (const name of names) {
+		const source = readFileSync(join(SRC_DIR, `${name}.md`), "utf8");
+		const { meta, body } = render(source, routes);
+		writeFileSync(join(OUT_DIR, `${slug(name)}.md`), body);
+		pages.push({ name, title: meta.title, link: `${BASE}/${slug(name)}` });
+	}
+
+	writeFileSync(join(OUT_DIR, "index.md"), renderIndex(pages));
+	return pages;
+}
+
+/**
+ * `draft-lcurley-moq-lite` -> `moq-lite`, the route segment.
+ *
+ * A draft from another author keeps its full name, so the mapping stays
+ * reversible. `editLink` in config.ts inverts this.
+ */
+function slug(name: string): string {
+	const prefix = "draft-lcurley-";
+	return name.startsWith(prefix) ? name.slice(prefix.length) : name;
+}
+
+/** `draft-lcurley-moq-lite-latest` -> the datatracker page for the draft. */
+function datatracker(docname: string): string {
+	return `https://datatracker.ietf.org/doc/${docname.replace(/-latest$/, "")}/`;
+}
+
+/** Split a draft into its metadata block and the abstract/middle/back sections. */
+function split(source: string): { meta: Metadata; abstract: string[]; middle: string[]; back: string[] } {
+	const lines = source.split("\n");
+
+	// The metadata block opens with `---` and closes at the first `--- <section>`.
+	const start = lines.findIndex((l) => l.trim() === "---");
+	const sections = new Map<string, number>();
+	for (let i = start + 1; i < lines.length; i++) {
+		const match = /^---\s+(abstract|middle|back)\s*$/.exec(lines[i]);
+		if (match) sections.set(match[1], i);
+	}
+
+	const abstract = sections.get("abstract");
+	const middle = sections.get("middle");
+	const back = sections.get("back");
+	if (abstract === undefined || middle === undefined || back === undefined) {
+		throw new Error("draft is missing an --- abstract/middle/back section marker");
+	}
+
+	const parsed = parseYaml(lines.slice(start + 1, abstract).join("\n")) ?? {};
+	const meta: Metadata = {
+		title: String(parsed.title ?? "Untitled"),
+		docname: String(parsed.docname ?? ""),
+		normative: refs(parsed.normative),
+		informative: refs(parsed.informative),
+	};
+
+	return {
+		meta,
+		abstract: lines.slice(abstract + 1, middle),
+		middle: lines.slice(middle + 1, back),
+		back: lines.slice(back + 1),
+	};
+}
+
+/**
+ * Normalize a `normative:`/`informative:` block into alias -> target.
+ *
+ * A bare `RFC9000:` key parses as a null value and is its own target. Inline
+ * reference definitions (a nested map of bibxml fields) are keyed by alias too,
+ * so the alias doubles as the target when we can't do better.
+ */
+function refs(block: unknown): Record<string, string> {
+	if (!block || typeof block !== "object") return {};
+	const out: Record<string, string> = {};
+	for (const [alias, target] of Object.entries(block as Record<string, unknown>)) {
+		out[alias] = typeof target === "string" ? target : alias;
+	}
+	return out;
+}
+
+/** Resolve a citation target to display text and a URL. */
+function resolve(target: string, routes: Map<string, string>): Reference {
+	const rfc = /^RFC\s?(\d+)$/i.exec(target);
+	if (rfc) {
+		return { label: `RFC ${rfc[1]}`, url: `https://www.rfc-editor.org/rfc/rfc${rfc[1]}` };
+	}
+
+	const draft = /^I-D\.(.+)$/.exec(target);
+	if (draft) {
+		const docname = `draft-${draft[1]}`;
+		return { label: docname, url: routes.get(docname) ?? datatracker(docname) };
+	}
+
+	return EXTERNAL[target] ?? { label: target };
+}
+
+/** Turn a resolved reference into a markdown link (or plain text if we have no URL). */
+function link(ref: Reference, suffix?: string): string {
+	const label = suffix ? `${ref.label}, ${suffix}` : ref.label;
+	if (!ref.url) return label;
+
+	// RFC section subreferences have a stable anchor; drafts don't.
+	const section = suffix && ref.url.includes("rfc-editor.org") ? /^Section\s+([\d.]+)$/.exec(suffix) : null;
+	return `[${label}](${ref.url}${section ? `#section-${section[1]}` : ""})`;
+}
+
+/** Collect `{#anchor}` -> heading text so internal citations can use the real title. */
+function anchors(lines: string[]): Map<string, string> {
+	const found = new Map<string, string>();
+	for (let i = 0; i < lines.length; i++) {
+		const heading = /^#{1,6}\s+(.*?)(?:\s+\{#([\w-]+)\})?\s*$/.exec(lines[i]);
+		if (!heading) continue;
+
+		// The anchor is either inline or on a `{: #anchor}` line below.
+		const below = /^\{:\s*#([\w-]+)\}\s*$/.exec(lines[i + 1] ?? "");
+		const anchor = heading[2] ?? below?.[1];
+		if (anchor) found.set(anchor, heading[1]);
+	}
+	return found;
+}
+
+/** Is this a table delimiter row, like `|---|:--:|`? */
+function isDelimiter(line: string): boolean {
+	return /^\s*\|[-:|\s]+\|?\s*$/.test(line.trim()) && line.includes("-");
+}
+
+/**
+ * Rewrite the citations in one run of prose.
+ *
+ * kramdown-rfc has two forms: `{{ref}}`, which also happens to be Vue's
+ * interpolation syntax, and `[ref]`, a link reference whose definition
+ * kramdown-rfc generates from the metadata block. Both render as dangling
+ * text (or worse) without a rewrite.
+ */
+function citeSegment(
+	segment: string,
+	meta: Metadata,
+	labels: Map<string, string>,
+	routes: Map<string, string>,
+): string {
+	const braces = segment.replace(/\{\{([^}]+)\}\}/g, (_, raw: string) => {
+		// A leading sigil marks the reference normative/informative inline.
+		const [target, ...rest] = raw.replace(/^[!?=<&]+/, "").split(",");
+		const suffix = rest.join(",").trim() || undefined;
+		const name = target.trim();
+
+		const heading = labels.get(name);
+		if (heading) return `[${heading}](#${name})`;
+
+		const alias = meta.normative[name] ?? meta.informative[name];
+		return link(resolve(alias ?? name, routes), suffix);
+	});
+
+	// `[ref]`, but not an image, an inline link, or a link definition. Only
+	// rewrite aliases the draft actually declared, so ordinary brackets survive.
+	return braces.replace(/(!?)\[([^\][]+)\](?![([:])/g, (whole, bang: string, name: string) => {
+		if (bang) return whole;
+		const alias = meta.normative[name] ?? meta.informative[name];
+		return alias ? link(resolve(alias, routes)) : whole;
+	});
+}
+
+/** Render one draft to a VitePress page. */
+function render(source: string, routes: Map<string, string>): { meta: Metadata; body: string } {
+	const { meta, abstract, middle, back } = split(source);
+	const labels = anchors([...middle, ...back]);
+
+	const cite = (line: string) =>
+		// Inline code is verbatim, so only rewrite the segments between backticks.
+		line
+			.split(/(`[^`]*`)/)
+			.map((segment) => (segment.startsWith("`") ? segment : citeSegment(segment, meta, labels, routes)))
+			.join("");
+
+	const body = (lines: string[]): string[] => {
+		const out: string[] = [];
+		let fenced = false;
+
+		for (let i = 0; i < lines.length; i++) {
+			const line = lines[i];
+
+			if (/^(~~~|```)/.test(line)) {
+				fenced = !fenced;
+				// kramdown accepts bare `~~~`; keep fences uniform for shiki.
+				out.push(line.startsWith("~~~") ? line.replace(/^~~~/, "```") : line);
+				continue;
+			}
+			if (fenced) {
+				out.push(line);
+				continue;
+			}
+
+			if (/^\{::boilerplate\s+bcp14/.test(line.trim())) {
+				out.push(BCP14);
+				continue;
+			}
+
+			// `{: #anchor}` binds to the heading above; VitePress spells it inline.
+			const anchor = /^\{:\s*#([\w-]+)\}\s*$/.exec(line.trim());
+			if (anchor) {
+				const prev = out.length - 1;
+				if (prev >= 0 && /^#{1,6}\s/.test(out[prev])) out[prev] = `${out[prev]} {#${anchor[1]}}`;
+				continue;
+			}
+
+			// Any other IAL (`{:numbered="false"}`) has no CommonMark meaning.
+			if (/^\{:.*\}$/.test(line.trim())) continue;
+
+			// kramdown allows a delimiter row *above* the header to mark it as one.
+			// GFM would read that as the header, so drop it.
+			if (isDelimiter(line) && !isDelimiter(lines[i - 1] ?? "") && isDelimiter(lines[i + 2] ?? "")) continue;
+
+			// Demote headings so the page title stays the only h1 and the
+			// outline picks up the draft's own sections.
+			out.push(cite(line.replace(/^(#{1,5})\s/, "#$1 ")));
+		}
+		return out;
+	};
+
+	const page = [
+		"---",
+		`title: ${JSON.stringify(meta.title)}`,
+		"outline: deep",
+		"---",
+		"",
+		`# ${meta.title}`,
+		"",
+		"::: info",
+		"Rendered from the Internet-Draft source in this repository.",
+		`Submitted versions are on the [IETF datatracker](${datatracker(meta.docname)}).`,
+		":::",
+		"",
+		"## Abstract",
+		...body(abstract),
+		...body(middle),
+		...references(meta, routes),
+		...body(back),
+		"",
+	];
+
+	return { meta, body: page.join("\n") };
+}
+
+/** The reference list kramdown-rfc would generate from the metadata block. */
+function references(meta: Metadata, routes: Map<string, string>): string[] {
+	const section = (heading: string, block: Record<string, string>): string[] => {
+		const entries = Object.values(block);
+		if (entries.length === 0) return [];
+		return ["", `## ${heading}`, "", ...entries.map((target) => `- ${link(resolve(target, routes))}`)];
+	};
+
+	return [...section("Normative References", meta.normative), ...section("Informative References", meta.informative)];
+}
+
+/** The `/draft/` landing page. */
+function renderIndex(pages: DraftPage[]): string {
+	return [
+		"---",
+		'title: "Drafts"',
+		// Generated from the whole directory, so there's no single source to edit.
+		"editLink: false",
+		"---",
+		"",
+		"# Internet-Drafts",
+		"",
+		"The IETF Internet-Drafts for the protocols implemented in this repository.",
+		"These pages are generated from the [kramdown-rfc](https://github.com/cabo/kramdown-rfc) sources under `drafts/`;",
+		"the submitted versions live on the [IETF datatracker](https://datatracker.ietf.org/person/kixelated@gmail.com).",
+		"",
+		...pages.map((page) => `- [${page.title}](${page.link}) (\`${page.name}\`)`),
+		"",
+	].join("\n");
+}

--- a/doc/.vitepress/drafts.ts
+++ b/doc/.vitepress/drafts.ts
@@ -10,9 +10,13 @@
 //   - The metadata block runs to `--- abstract`, so gray-matter never finds
 //     the closing fence and the whole document parses as frontmatter.
 //   - `{{ref}}` citations collide with Vue template interpolation.
-//   - `{::boilerplate}` / `{:key="value"}` IALs and the leading table
-//     delimiter row have no CommonMark equivalent.
+//   - `{::boilerplate}` / `{:key="value"}` IALs have no CommonMark equivalent.
+//   - Tables use delimiter rows where GFM allows exactly one, so they render
+//     as paragraphs.
 // Everything below exists to translate those, one construct at a time.
+//
+// drafts.test.ts renders the output through VitePress itself, since the
+// failure mode here is markdown that reads fine but renders as something else.
 
 import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -50,6 +54,8 @@ export interface DraftPage {
 	title: string;
 	/** Site route, e.g. `/draft/moq-lite`. */
 	link: string;
+	/** The generated VitePress markdown. */
+	markdown: string;
 }
 
 /** The metadata block above `--- abstract`. Only the fields we render. */
@@ -66,13 +72,8 @@ interface Reference {
 	url?: string;
 }
 
-/**
- * Regenerate the draft pages and return them in sidebar order.
- *
- * Called from `config.ts` at module load, so the output is on disk before
- * VitePress enumerates routes. Editing a draft needs a dev-server restart.
- */
-export function syncDrafts(): DraftPage[] {
+/** Translate every draft into a page, without touching disk. */
+export function renderDrafts(): DraftPage[] {
 	const names = readdirSync(SRC_DIR)
 		.filter((f) => f.startsWith("draft-") && f.endsWith(".md"))
 		.map((f) => f.slice(0, -3))
@@ -82,18 +83,30 @@ export function syncDrafts(): DraftPage[] {
 	// datatracker, so `{{moql}}` in one draft links to our page for another.
 	const routes = new Map(names.map((name) => [name, `${BASE}/${slug(name)}`]));
 
+	return names.map((name) => {
+		const source = readFileSync(join(SRC_DIR, `${name}.md`), "utf8");
+		const { meta, body } = render(source, routes);
+		return { name, title: meta.title, link: `${BASE}/${slug(name)}`, markdown: body };
+	});
+}
+
+/**
+ * Regenerate the draft pages on disk and return them in sidebar order.
+ *
+ * Called from `config.ts` at module load, so the output is there before
+ * VitePress enumerates routes. Editing a draft needs a dev-server restart.
+ */
+export function syncDrafts(): DraftPage[] {
+	const pages = renderDrafts();
+
 	rmSync(OUT_DIR, { recursive: true, force: true });
 	mkdirSync(OUT_DIR, { recursive: true });
 
-	const pages: DraftPage[] = [];
-	for (const name of names) {
-		const source = readFileSync(join(SRC_DIR, `${name}.md`), "utf8");
-		const { meta, body } = render(source, routes);
-		writeFileSync(join(OUT_DIR, `${slug(name)}.md`), body);
-		pages.push({ name, title: meta.title, link: `${BASE}/${slug(name)}` });
+	for (const page of pages) {
+		writeFileSync(join(OUT_DIR, `${slug(page.name)}.md`), page.markdown);
 	}
-
 	writeFileSync(join(OUT_DIR, "index.md"), renderIndex(pages));
+
 	return pages;
 }
 
@@ -210,6 +223,38 @@ function isDelimiter(line: string): boolean {
 	return /^\s*\|[-:|\s]+\|?\s*$/.test(line.trim()) && line.includes("-");
 }
 
+/** Is this any row of a table? */
+function isRow(line: string): boolean {
+	return line.trim().startsWith("|");
+}
+
+/**
+ * Rewrite one table from kramdown's shape into GFM's.
+ *
+ * kramdown treats delimiter rows as decoration: one above the first row marks
+ * it as a header, and more between body rows draw separators. GFM instead
+ * gives exactly one meaning to exactly one delimiter, the alignment row
+ * directly below the header, and renders nothing as a table without it. So
+ * keep that one and drop every other delimiter.
+ */
+function table(rows: string[]): string[] {
+	const body = rows[0] !== undefined && isDelimiter(rows[0]) ? rows.slice(1) : rows;
+	const [header, ...rest] = body;
+	if (header === undefined) return [];
+
+	// Alignment (`|---:|:---|`) only survives if the row below the header
+	// already carries it. Otherwise synthesize a plain one, since a header
+	// with no delimiter at all is not a table.
+	const columns = header
+		.trim()
+		.replace(/^\||\|$/g, "")
+		.split("|").length;
+	const [next] = rest;
+	const alignment = next !== undefined && isDelimiter(next) ? next : `|${"---|".repeat(columns)}`;
+
+	return [header, alignment, ...rest.filter((row) => !isDelimiter(row))];
+}
+
 /**
  * Rewrite the citations in one run of prose.
  *
@@ -237,9 +282,11 @@ function citeSegment(
 		return link(resolve(alias ?? name, routes), suffix);
 	});
 
-	// `[ref]`, but not an image, an inline link, or a link definition. Only
-	// rewrite aliases the draft actually declared, so ordinary brackets survive.
-	return braces.replace(/(!?)\[([^\][]+)\](?![([:])/g, (whole, bang: string, name: string) => {
+	// `[ref]`, but not an image or an inline link. Only rewrite aliases the
+	// draft actually declared, so ordinary brackets survive. A trailing colon
+	// is left in place: a citation often just precedes one ("exactly as in
+	// [qmux]: an endpoint advertises...").
+	return braces.replace(/(!?)\[([^\][]+)\](?![([])/g, (whole, bang: string, name: string) => {
 		if (bang) return whole;
 		const alias = meta.normative[name] ?? meta.informative[name];
 		return alias ? link(resolve(alias, routes)) : whole;
@@ -251,12 +298,18 @@ function render(source: string, routes: Map<string, string>): { meta: Metadata; 
 	const { meta, abstract, middle, back } = split(source);
 	const labels = anchors([...middle, ...back]);
 
-	const cite = (line: string) =>
+	const cite = (line: string) => {
+		// An actual link definition (`[ref]: url`) defines the alias rather than
+		// citing it. The drafts have none today, since kramdown-rfc synthesizes
+		// them, but rewriting one would corrupt it.
+		if (/^\s*\[[^\][]+\]:/.test(line)) return line;
+
 		// Inline code is verbatim, so only rewrite the segments between backticks.
-		line
+		return line
 			.split(/(`[^`]*`)/)
 			.map((segment) => (segment.startsWith("`") ? segment : citeSegment(segment, meta, labels, routes)))
 			.join("");
+	};
 
 	const body = (lines: string[]): string[] => {
 		const out: string[] = [];
@@ -292,9 +345,14 @@ function render(source: string, routes: Map<string, string>): { meta: Metadata; 
 			// Any other IAL (`{:numbered="false"}`) has no CommonMark meaning.
 			if (/^\{:.*\}$/.test(line.trim())) continue;
 
-			// kramdown allows a delimiter row *above* the header to mark it as one.
-			// GFM would read that as the header, so drop it.
-			if (isDelimiter(line) && !isDelimiter(lines[i - 1] ?? "") && isDelimiter(lines[i + 2] ?? "")) continue;
+			// Tables have to be reshaped as a whole, not row by row.
+			if (isRow(line)) {
+				let end = i;
+				while (end < lines.length && isRow(lines[end])) end++;
+				out.push(...table(lines.slice(i, end)).map(cite));
+				i = end - 1;
+				continue;
+			}
 
 			// Demote headings so the page title stays the only h1 and the
 			// outline picks up the draft's own sections.

--- a/doc/concept/standard/index.md
+++ b/doc/concept/standard/index.md
@@ -41,6 +41,8 @@ moq-lite is forwards compatible with moq-transport, so it works with any moq-tra
 On the media side, there are the [MSF](/concept/standard/msf) (catalog) and [LOC](/concept/standard/loc) (container) drafts.
 They are too early/unstable to be useful, so we're using a custom [hang](/concept/layer/hang) media format instead.
 
+Our own specifications are written as Internet-Drafts and rendered under [Drafts](/draft/).
+
 - [Website](https://moq.dev)
 - [GitHub](https://github.com/moq-dev/moq)
 - [Documentation](https://doc.moq.dev)

--- a/doc/package.json
+++ b/doc/package.json
@@ -6,11 +6,15 @@
 	"scripts": {
 		"dev": "vitepress dev --open",
 		"build": "vitepress build",
+		"check": "tsc --noEmit && vitepress build",
 		"preview": "vitepress preview",
 		"deploy": "vitepress build && wrangler deploy"
 	},
 	"devDependencies": {
+		"@types/node": "^26.1.1",
+		"typescript": "7.0.2",
 		"vitepress": "^1.6.4",
-		"wrangler": "^4.110.0"
+		"wrangler": "^4.110.0",
+		"yaml": "^2.9.0"
 	}
 }

--- a/doc/package.json
+++ b/doc/package.json
@@ -6,7 +6,8 @@
 	"scripts": {
 		"dev": "vitepress dev --open",
 		"build": "vitepress build",
-		"check": "tsc --noEmit && vitepress build",
+		"check": "tsc --noEmit && bun test ./.vitepress && vitepress build",
+		"test": "bun test ./.vitepress",
 		"preview": "vitepress preview",
 		"deploy": "vitepress build && wrangler deploy"
 	},

--- a/doc/package.json
+++ b/doc/package.json
@@ -12,6 +12,7 @@
 		"deploy": "vitepress build && wrangler deploy"
 	},
 	"devDependencies": {
+		"@types/bun": "^1.3.14",
 		"@types/node": "^26.1.1",
 		"typescript": "7.0.2",
 		"vitepress": "^1.6.4",

--- a/doc/tsconfig.json
+++ b/doc/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../js/tsconfig.json",
+	"compilerOptions": {
+		"noEmit": true,
+		"types": ["node"]
+	},
+	// config.ts is not type-checked: VitePress's own nav types reject the
+	// `link` + `items` combination the theme relies on.
+	"include": [".vitepress/drafts.ts"]
+}

--- a/doc/tsconfig.json
+++ b/doc/tsconfig.json
@@ -2,9 +2,9 @@
 	"extends": "../js/tsconfig.json",
 	"compilerOptions": {
 		"noEmit": true,
-		"types": ["node"]
+		"types": ["node", "bun"]
 	},
 	// config.ts is not type-checked: VitePress's own nav types reject the
 	// `link` + `items` combination the theme relies on.
-	"include": [".vitepress/drafts.ts"]
+	"include": [".vitepress/drafts.ts", ".vitepress/drafts.test.ts"]
 }

--- a/drafts/CLAUDE.md
+++ b/drafts/CLAUDE.md
@@ -45,6 +45,21 @@ There is no CI tag-trigger and no API secret. For a brand-new draft (`-00`), set
 `kramdown-rfc` fetches bibxml references into `.refcache/` on first build, so
 the initial build needs network access.
 
+## Documentation site
+
+The drafts also render on [doc.moq.dev](https://doc.moq.dev/draft/), under
+`/draft/`. `doc/.vitepress/drafts.ts` translates each source into a VitePress
+page at config load; the output lands in `doc/draft/` and is gitignored.
+
+The sources stay canonical, and no draft should be reshaped to suit the site.
+But kramdown-rfc markdown is not CommonMark, so the translator has a case for
+each construct we use: the `--- abstract`/`--- middle`/`--- back` markers, `{{ref}}`
+and `[ref]` citations, `{::boilerplate bcp14-tagged}`, `{:...}` IALs, and the
+kramdown table form with a delimiter row above the header. Using a construct the
+translator doesn't know about renders wrong (or breaks the build, since `{{...}}`
+is also Vue interpolation). Add a case there in the same PR, and check the result
+with `bun run --cwd doc dev`.
+
 ## Conventions
 
 - Draft sources are kramdown-rfc markdown; `remark` (the repo's CommonMark

--- a/drafts/CLAUDE.md
+++ b/drafts/CLAUDE.md
@@ -54,11 +54,15 @@ page at config load; the output lands in `doc/draft/` and is gitignored.
 The sources stay canonical, and no draft should be reshaped to suit the site.
 But kramdown-rfc markdown is not CommonMark, so the translator has a case for
 each construct we use: the `--- abstract`/`--- middle`/`--- back` markers, `{{ref}}`
-and `[ref]` citations, `{::boilerplate bcp14-tagged}`, `{:...}` IALs, and the
-kramdown table form with a delimiter row above the header. Using a construct the
+and `[ref]` citations, `{::boilerplate bcp14-tagged}`, `{:...}` IALs, and kramdown
+tables, whose delimiter rows GFM allows only one of. Using a construct the
 translator doesn't know about renders wrong (or breaks the build, since `{{...}}`
-is also Vue interpolation). Add a case there in the same PR, and check the result
-with `bun run --cwd doc dev`.
+is also Vue interpolation). Add a case there in the same PR.
+
+`bun run --cwd doc check` runs `drafts.test.ts`, which renders every generated
+page through VitePress and asserts on the HTML. Checking the markdown alone
+misses the common failure: output that reads fine but renders as something else,
+like a table that silently degrades into a paragraph.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

- Adds a `/draft/` section to doc.moq.dev, generated from the kramdown-rfc sources under `drafts/`, so the specs are searchable and themed alongside the rest of the docs instead of living only as datatracker submissions.
- The sources stay canonical. `just drafts build` still feeds them to kramdown-rfc for the authoritative RFC rendering, and no draft was reshaped to suit the site. `doc/.vitepress/drafts.ts` translates each source into a VitePress page at config load, early enough that the pages exist before routes are enumerated.
- Generated output lands in the gitignored `doc/draft/`, added to `.remarkignore` as well.

Raw drafts cannot go through VitePress unmodified, which is what the translator exists to handle:

| Construct | Why it breaks | Handling |
|---|---|---|
| Metadata block ending at `--- abstract` | gray-matter never sees a closing `---`, so the whole document parses as frontmatter | Parsed with `yaml`, re-emitted as VitePress frontmatter |
| `{{ref}}` citations (9 of 11 drafts) | Collides with Vue template interpolation | Resolved to links; unresolved targets still lose the braces |
| `[ref]` link references | kramdown-rfc synthesizes the definitions; markdown-it leaves them dangling | Resolved against the declared reference aliases only |
| `{::boilerplate bcp14-tagged}` | No CommonMark equivalent | Expanded to the BCP 14 paragraph |
| `{:numbered=&#34;false&#34;}`, `{: #anchor}` IALs | No CommonMark equivalent | Dropped, or folded into the heading as a VitePress `{#anchor}` |
| kramdown tables | kramdown treats delimiter rows as decoration (one above the first row marks it as a header, more between body rows draw separators); GFM allows exactly one, below the header, and renders nothing as a table without it | Reshaped as a block: drop a leading delimiter, keep the one below the header, drop the rest |

Citations resolve to rfc-editor.org and datatracker URLs, with section subreferences (`{{!RFC4648, Section 4}}`) anchored; cross-draft citations resolve to the local page instead of the datatracker. Headings are demoted one level so the page title is the only h1 and the outline picks up the draft's sections. Each page also gets the reference list kramdown-rfc would have generated from the metadata block.

Two smaller pieces:

- `doc` gains a `check` script (`tsc --noEmit && bun test ./.vitepress && vitepress build`) plus a `tsconfig.json`. The doc site had no `check` script, so `just check` ran nothing for it; now the translator is type-checked, tested, and the site build (including dead-link checking) runs in CI. The tsconfig covers `drafts.ts` and its test only: including `config.ts` surfaces a pre-existing type error, since VitePress's nav types reject the `link` + `items` combination the theme already relies on.
- `editLink` becomes a function so `/draft/` pages point at their kramdown-rfc source rather than the generated file. It has to stay closure-free because VitePress stringifies theme-config functions for the browser, which is why the slug mapping is inverted inline rather than looked up.

## Fixes found during review

Two defects landed in the first commit and were fixed in follow-ups, both of which produced valid-looking markdown that rendered as something else:

- **Tables with row separators.** The original heuristic looked at one line at a time and dropped any delimiter whose next-next line was also a delimiter, which in a row-separated table matches the required header delimiter too. Bidirectional Streams, Unidirectional Streams, and Setup Parameters in moq-lite each collapsed into a paragraph followed by a one-row table built from the trailing separator. Tables are now reshaped as a block.
- **Colon-terminated citations.** `[qmux]:` stayed literal because the rewrite skipped any match followed by a colon to avoid mangling a link definition. A definition is line-initial, so that is where the exemption belongs; the drafts contain none today, since kramdown-rfc synthesizes them.

## Public API changes

None. No `pub` Rust items or exported `@moq/*` symbols are touched; `doc/.vitepress/drafts.ts` is build tooling for the private `moq-doc` package.

## Cross-Package Sync

No rows apply: no wire format, catalog/container, CLI interface, or library API changed. Going the other way, a new kramdown-rfc construct in `drafts/` now needs a matching case in the translator, so this adds a row to the table in `CLAUDE.md` and a section to `drafts/CLAUDE.md`.

## Test plan

`doc/.vitepress/drafts.test.ts` renders every generated page through VitePress's own markdown pipeline (`createMarkdownRenderer`, so there is no second renderer to drift) and asserts on the resulting HTML. Checking the generated markdown alone is what let both defects above through.

- Per page: table count matches the count in the **kramdown-rfc source**, not in the generated markdown — comparing the output to itself would still pass if a table were dropped whole. Plus no paragraph-degraded rows, no unresolved citations, no kramdown leftovers.
- Specifically: the six-row Bidirectional Streams table renders as one table, and the `[qmux]:` citation renders as a link followed by the colon.
- Each fix was verified by reverting it and confirming the suite fails, including the dropped-table case.
- `bun run --cwd doc check` passes (36 tests, `tsc --noEmit` clean, site builds).
- Browser verification against `vitepress preview`, all 11 pages: one h1 each, no console errors, no failed requests, no broken in-page anchors. Local search indexes the generated pages, 69 in-page citations on moq-lite navigate correctly, 24 code blocks highlight, and the edit link on a draft page resolves to `drafts/draft-lcurley-moq-lite.md` rather than the generated file.
- `bun remark . --quiet --frail` and `bun install --frozen-lockfile` pass. `bun biome check` passes on the changed files; it reports three pre-existing failures elsewhere (`demo/web/src/publish.ts`, `doc/.vitepress/theme/index.js`, `js/publish/src/audio/encoder.test.ts`) that also fail on a clean tree and are left alone.
- Not run: `just check` / `just drafts check` in full, since `just` and the nix dev shell are unavailable in this environment. No draft source changed, so kramdown-rfc parsing is unaffected.

(Written by claude-fable-5)