### PR TITLE
chore(js): bump package patch versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -94,7 +94,7 @@
     },
     "js/hang": {
       "name": "@moq/hang",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
         "@libav.js/variant-opus-af": "^6.9.8",
@@ -177,7 +177,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@moq/qmux": "^0.3.2",
         "@moq/signals": "workspace:*",
@@ -197,7 +197,7 @@
     },
     "js/publish": {
       "name": "@moq/publish",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/net": "workspace:^",
@@ -260,7 +260,7 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/msf": "workspace:^",

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"jsr": false,
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",


### PR DESCRIPTION
## Summary

- Bump `@moq/net` to 0.2.1 for the compatible remote-error and qmux fixes landed since 0.2.0.
- Bump `@moq/hang` to 0.3.2, `@moq/watch` to 0.4.2, and `@moq/publish` to 0.4.1 for their unreleased fixes.
- Keep the Bun workspace lockfile in sync so the JS release workflow publishes all four versions with updated dependency floors.

## Public API changes

- None in this PR. These version bumps publish compatible fixes and additive API work that already landed on `main`.

## Test plan

- `nix develop --command just ci`
- Release dry runs for all four packages, including npm packing, JSR validation where enabled, and workspace dependency rewriting.

Cross-package sync does not apply because this PR changes release metadata only.

(Written by GPT-5)