### PR TITLE
feat(net): drop Exclude Hop from ANNOUNCE_REQUEST in lite-06

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ For wire, `moq-ffi`, or gateway changes, also run the cross-language interop mat
 
 ## Branch Targeting
 
-PRs target `main` by default, however large the change: bug fixes, new behavior, additive APIs, docs, refactors. `dev` is reserved for changes that break an existing published contract: wire-protocol changes under `rs/moq-net`, breaking (renamed/removed/signature-changed, not newly added) `pub` API changes in the core libraries or language wrappers, and catalog/container format breaks. When in doubt, target `main`. Full rules in [CONTRIBUTING.md](CONTRIBUTING.md#branch-targeting).
+PRs target `main` by default, however large the change: bug fixes, new behavior, additive APIs, docs, refactors, and wire-protocol work. `dev` is reserved for one thing, a semver break in a published API: a renamed, removed, or signature-changed `pub`/exported item in the core libraries or language wrappers. Adding an item is additive, so it goes to `main`. When in doubt, target `main`. Full rules in [CONTRIBUTING.md](CONTRIBUTING.md#branch-targeting).
 
 ## Workflow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,15 +4,16 @@ How a change lands in this repo: branch targeting, commits, PR descriptions, rev
 
 ## Branch Targeting
 
-Two long-lived branches. The split is about **semver breakage, not size or novelty**: `dev` is only for changes that break an existing published contract. Everything else (bug fixes, new behavior, new/additive APIs, docs, refactors) goes to `main`, however large.
+Two long-lived branches. The split is about **semver breakage of a published API, not size or novelty**: `dev` is only for changes that break the API contract consumers compile against. Everything else (bug fixes, new behavior, new/additive APIs, docs, refactors, wire-protocol work) goes to `main`, however large.
 
-- **`main`**: the default. Bug fixes, new behavior, new/additive APIs, docs, and refactors that preserve the existing public/wire contract. A change that only *adds* is additive and lands here even when it is big: a new `pub` item, a new option, or a parser accepting a broader set of inputs it previously rejected. Changing what a component does with input it *already* takes (e.g. recognizing a media pattern it used to mishandle) is a fix, not a break, so it also lands here.
-- **`dev`**: reserved for changes that violate semver by breaking an existing contract. Target it only for:
-  - Wire-protocol changes (anything under `rs/moq-net`, including `moq-lite` / `moq-transport` framing or draft bumps).
-  - Breaking changes to public APIs in `rs/moq-ffi`, `rs/libmoq`, `rs/moq-net`, `rs/hang`, `js/net`, `js/hang`, or any of the language wrappers under `swift/`, `kt/`, `go/`, `py/`. This means a renamed, removed, or signature-changed `pub` item, not a newly *added* one (adding is additive, so it goes to `main`).
-  - Catalog/container format changes in `rs/hang` or `js/hang` that alter existing on-the-wire framing or fields.
+- **`main`**: the default. Bug fixes, new behavior, new/additive APIs, docs, and refactors that preserve the existing public API. A change that only *adds* is additive and lands here even when it is big: a new `pub` item, a new option, or a parser accepting a broader set of inputs it previously rejected. Changing what a component does with input it *already* takes (e.g. recognizing a media pattern it used to mishandle) is a fix, not a break, so it also lands here.
 
-`dev` periodically merges into `main` (or vice versa) when the batch is ready to ship. When in doubt, target `main`; reviewers will redirect to `dev` if a change turns out to break an existing contract. CI (`pull_request:` workflows) runs on PRs against either branch, so no extra setup is needed when you switch the base.
+  Wire-protocol and format work lands here too, including `moq-lite` / `moq-transport` framing, a new draft version, a field added to or removed from an in-progress one, and catalog/container format changes in `rs/hang` or `js/hang`. Versions are negotiated per session, so a peer keeps speaking whatever version it already supports; the change reaches it only once both ends offer the new one. Ship it behind a version gate (see the Version matching section of [`rs/CLAUDE.md`](rs/CLAUDE.md)) and update the matching draft under `drafts/` in the same PR.
+- **`dev`**: reserved for changes that violate semver by breaking a published API. That means a renamed, removed, or signature-changed `pub` (Rust) or exported (TS) item in `rs/moq-net`, `rs/hang`, `rs/moq-ffi`, `rs/libmoq`, `js/net`, `js/hang`, or any of the language wrappers under `swift/`, `kt/`, `go/`, `py/`. A newly *added* item is additive and goes to `main`.
+
+  A wire change usually needs no API break to land, since the version gate is internal. If yours does, that break is what sends the PR to `dev`, not the wire change itself.
+
+`dev` periodically merges into `main` (or vice versa) when the batch is ready to ship. When in doubt, target `main`; reviewers will redirect to `dev` if a change turns out to break a published API. CI (`pull_request:` workflows) runs on PRs against either branch, so no extra setup is needed when you switch the base.
 
 ## Commit Messages
 

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -675,16 +675,11 @@ A subscriber sends an ANNOUNCE_REQUEST message to indicate it wants to receive a
 ANNOUNCE_REQUEST Message {
   Message Length (i)
   Broadcast Path Prefix (s),
-  Exclude Hop (i),
 }
 ~~~
 
 **Broadcast Path Prefix**:
 Indicate interest for any broadcasts with a path that starts with this prefix.
-
-**Exclude Hop**:
-If non-zero, the publisher SHOULD skip announcements for broadcasts whose Hop ID entries (including the publisher's own `Hop ID` from ANNOUNCE_OK) contain this value.
-This is used by relays to avoid routing loops in a cluster.
 
 The publisher MUST respond with an ANNOUNCE_OK message followed by ANNOUNCE_START messages for any matching and available broadcasts, followed by ANNOUNCE_START, ANNOUNCE_END, and ANNOUNCE_RESTART messages for any future updates.
 Implementations SHOULD consider reasonable limits on the number of matching broadcasts to prevent resource exhaustion.
@@ -755,6 +750,12 @@ When forwarding an announcement received from an upstream peer, a relay MUST app
 The total path length is `Hop Count + 1` (including the implicit ANNOUNCE_OK `Hop ID`).
 The first entry of the reconstructed path (the first Hop ID, or the ANNOUNCE_OK `Hop ID` when the list is empty) identifies the original publisher of the broadcast; ANNOUNCE_RESTART uses it to distinguish a route change from a replacement (see [ANNOUNCE_RESTART](#announce-restart)).
 A Hop ID value of 0 means the hop is unknown: either it was never assigned (e.g. when bridging from an older protocol version) or a relay deliberately withholds it to obscure the underlying routing; the Hop Count still reflects the total number of entries including unknown hops.
+
+A receiver MUST discard an announcement whose reconstructed path contains its own Hop ID.
+Such an announcement has looped back, so the receiver neither forwards it nor selects it as a route to the broadcast; forwarding would extend the loop, and subscribing through it would route the receiver back to itself.
+This is the only loop defense moq-lite requires, and it catches loops of any length.
+A publisher MAY additionally skip sending an announcement toward the peer it was learned from, but that is a bandwidth optimization rather than a correctness measure: the receiver discards the announcement either way.
+A relay that withholds its Hop ID (advertising 0) cannot be detected this way, so loops through it are caught only by the hop limit.
 
 **Route Cost**:
 The marginal cost of subscribing to the broadcast via this advertisement, in units chosen by the deployment.
@@ -1169,6 +1170,8 @@ The `Message Length` describes the payload size on the wire.
 - Defined the first entry of the reconstructed path as the original publisher's identity: a restart that preserves it is a route change (TRACK_INFO stays valid, subscriptions may resume), one that changes it replaces the broadcast (TRACK_INFO discarded, nothing resumes).
 - Added a `Route Cost` field to ANNOUNCE_START and ANNOUNCE_RESTART: the accumulated cost of the transfers a subscription via this advertisement would newly cause. Route selection prefers the lowest cost, with path length as the tie-break.
 - Added a SETUP `Cost` parameter (0x4) declaring the price a link adds to every announcement crossing it; unpriced links default to 1, degrading to shortest-path routing.
+- Removed `Exclude Hop` from ANNOUNCE_REQUEST. The receiver's hop-based loop check already discards a looped announcement, so the field only saved the wasted send.
+- Stated the receiver's loop check normatively in ANNOUNCE_START: an announcement whose reconstructed path contains the receiver's own Hop ID is neither forwarded nor selected as a route.
 
 ## moq-lite-05
 - Renamed ANNOUNCE_INTEREST to ANNOUNCE_REQUEST and ANNOUNCE to ANNOUNCE_BROADCAST.
@@ -1294,7 +1297,7 @@ The `Increase` Probe level (see [Probe Parameter](#probe-parameter)) lets a subs
 GOAWAY carries an optional New Session URI that asks the peer to reconnect elsewhere. A malicious or compromised peer could use this to redirect a client to an attacker-controlled server. A recipient MUST validate the URI against local policy — scheme, authority, and port — before reconnecting, and MUST NOT reconnect if validation fails (see [GOAWAY](#goaway)). Migrated subscriptions carry no implicit trust from the prior session; the new session is authenticated independently.
 
 ## Routing Metadata and Privacy
-Hop IDs (see [ANNOUNCE_OK](#announce-ok) and [ANNOUNCE_START](#announce-start)) expose the relay path of a broadcast, which may reveal internal topology. A relay that does not wish to disclose its position MAY use the reserved value 0 ("unknown") instead of a stable identifier. The `Exclude Hop` filter in ANNOUNCE_REQUEST is a loop-avoidance hint, not an access control; a publisher is not required to honor it, and it MUST NOT be relied upon to hide broadcasts.
+Hop IDs (see [ANNOUNCE_OK](#announce-ok) and [ANNOUNCE_START](#announce-start)) expose the relay path of a broadcast, which may reveal internal topology. A relay that does not wish to disclose its position MAY use the reserved value 0 ("unknown") instead of a stable identifier, at the cost of losing loop detection through itself (see [ANNOUNCE_START](#announce-start)).
 
 ## Resource Exhaustion
 A peer can open many streams (subscriptions, announcements, fetches) or request large announce prefixes. Implementations SHOULD bound the number of concurrent subscriptions, announce matches, and cached groups, and SHOULD rely on QUIC flow control and stream limits to backpressure a misbehaving peer (see [ANNOUNCE_REQUEST](#announce-request)). Expiration (see [Expiration](#expiration)) bounds how long stale groups consume memory and flow control.

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -755,7 +755,7 @@ A receiver MUST discard an announcement whose reconstructed path contains its ow
 Such an announcement has looped back, so the receiver neither forwards it nor selects it as a route to the broadcast; forwarding would extend the loop, and subscribing through it would route the receiver back to itself.
 This is the only loop defense moq-lite requires, and it catches loops of any length.
 A publisher MAY additionally skip sending an announcement toward the peer it was learned from, but that is a bandwidth optimization rather than a correctness measure: the receiver discards the announcement either way.
-A relay that withholds its Hop ID (advertising 0) cannot be detected this way, so loops through it are caught only by the hop limit.
+A relay that withholds its Hop ID (advertising 0) does not appear in the path under a distinguishable identity, so it cannot recognize an announcement that already passed through it; withholding the ID trades loop detection for privacy.
 
 **Route Cost**:
 The marginal cost of subscribing to the broadcast via this advertisement, in units chosen by the deployment.

--- a/drafts/draft-lcurley-moq-relay-hops.md
+++ b/drafts/draft-lcurley-moq-relay-hops.md
@@ -26,7 +26,6 @@ informative:
 This document defines a Relay Hops extension for MoQ Transport {{moqt}}.
 Each namespace advertisement carries an ordered list of Hop IDs identifying the relays it has traversed, starting with the original publisher.
 This lets a subscriber prefer the shortest of several paths to the same namespace, identify which advertisements refer to the same broadcast (same origin), and lets a relay cluster detect and avoid routing loops.
-A namespace subscription MAY carry a single Hop ID to exclude, which a relay uses to suppress advertisements that have already passed through that hop.
 
 --- middle
 
@@ -70,10 +69,10 @@ The extension applies to a single hop (one MOQT session) and is negotiated indep
 
 Negotiating this extension on a session also enables the extended NAMESPACE message format defined in [Carrying Parameters on Namespace Advertisements](#carrying-parameters-on-namespace-advertisements), which appends a Parameters field to NAMESPACE so that it, too, can carry HOP_PATH.
 
-A relay that negotiated this extension on a downstream session MUST include the HOP_PATH parameter on every PUBLISH_NAMESPACE and NAMESPACE it sends on that session, and MUST honor an EXCLUDE_HOP parameter it receives in SUBSCRIBE_NAMESPACE.
+A relay that negotiated this extension on a downstream session MUST include the HOP_PATH parameter on every PUBLISH_NAMESPACE and NAMESPACE it sends on that session.
 A receiver that negotiated this extension and receives a PUBLISH_NAMESPACE or NAMESPACE without HOP_PATH MUST close the session with a PROTOCOL_VIOLATION.
 
-Message parameters in {{moqt}} have no generic skip rule: a receiver must know a parameter's serialization to parse past it, so an endpoint MUST NOT send HOP_PATH or EXCLUDE_HOP on a session that did not negotiate the extension.
+Message parameters in {{moqt}} have no generic skip rule: a receiver must know a parameter's serialization to parse past it, so an endpoint MUST NOT send HOP_PATH on a session that did not negotiate the extension.
 A relay forwarding an advertisement into a non-supporting session therefore strips HOP_PATH (and, for NAMESPACE, the appended Parameters field); the advertisement loses its hop information.
 
 
@@ -149,8 +148,11 @@ The stand-in MUST be stable for the lifetime of the upstream session and unique 
 
 When a relay receives a namespace advertisement on a session that negotiated this extension, it MUST inspect the HOP_PATH:
 
-- If its own Hop ID already appears in the list, the advertisement has looped. The relay MUST NOT forward it and SHOULD drop it.
+- If its own Hop ID already appears in the list, the advertisement has looped back to this relay. The relay MUST discard it: it MUST NOT forward it, and MUST NOT select it as a path to the namespace. Forwarding it would extend the loop, and subscribing through it would route the relay back to itself.
 - Otherwise the relay MAY forward it downstream, appending its own Hop ID as described above.
+
+This receiver-side check is the only loop defense this extension requires, and it catches loops of any length.
+A relay MAY additionally avoid sending an advertisement back toward a peer it came from, but that is a bandwidth optimization: the advertisement is discarded on arrival either way.
 
 ## Path Selection
 A relay or subscriber that receives advertisements for the same namespace over multiple sessions MAY use the length of the HOP_PATH list as a tiebreaker, preferring the advertisement with the fewest hops (usually the lowest-latency path).
@@ -158,28 +160,6 @@ This is advisory: the receiver MAY apply additional local policy (e.g. measured 
 
 Two advertisements for the same namespace whose HOP_PATH begins with the same Hop ID share an origin and therefore refer to the same broadcast; a receiver MAY treat them as redundant paths and keep only the best one.
 If the first Hop IDs differ, the advertisements come from distinct origins that happen to reuse a namespace, and a receiver MUST NOT treat them as interchangeable.
-
-
-# EXCLUDE_HOP Parameter
-The EXCLUDE_HOP parameter lets a downstream subscriber tell an upstream relay to suppress advertisements that have already passed through a given hop.
-A relay in a cluster uses it to prevent the upstream from sending back an advertisement that the downstream originated, the most common source of a two-hop loop.
-
-It is a parameter carried in a SUBSCRIBE_NAMESPACE message ({{moqt}} Section 10.18).
-Its value is a single varint:
-
-~~~
-EXCLUDE_HOP Parameter {
-  Type (vi64) = 0x40B58
-  Hop ID (vi64)
-}
-~~~
-
-**Hop ID**:
-The single Hop ID to exclude.
-To exclude nothing, a subscriber simply omits the parameter; there is no reserved "exclude nothing" value.
-
-A relay that receives a SUBSCRIBE_NAMESPACE carrying EXCLUDE_HOP MUST NOT send, for that subscription, any namespace advertisement whose HOP_PATH contains the excluded Hop ID (including the entry the relay would itself append).
-The exclusion is scoped to the namespace subscription it accompanies; advertisements sent for other subscriptions, or proactively, are unaffected.
 
 
 # Security Considerations
@@ -205,13 +185,12 @@ This document requests a registration in the "MOQT Setup Options" registry ({{mo
 
 ## MOQT Message Parameters
 
-This document requests registrations in the "MOQT Message Parameters" registry ({{moqt}} Section 15.7).
-HOP_PATH is carried in PUBLISH_NAMESPACE and in the extended NAMESPACE message defined by this document (see [Carrying Parameters on Namespace Advertisements](#carrying-parameters-on-namespace-advertisements)); EXCLUDE_HOP is carried in SUBSCRIBE_NAMESPACE.
+This document requests a registration in the "MOQT Message Parameters" registry ({{moqt}} Section 15.7).
+HOP_PATH is carried in PUBLISH_NAMESPACE and in the extended NAMESPACE message defined by this document (see [Carrying Parameters on Namespace Advertisements](#carrying-parameters-on-namespace-advertisements)).
 
 | Value   | Name        | Carried In                   | Reference     |
 |:--------|:------------|:-----------------------------|:--------------|
 | 0x40B57 | HOP_PATH    | PUBLISH_NAMESPACE, NAMESPACE | This Document |
-| 0x40B58 | EXCLUDE_HOP | SUBSCRIBE_NAMESPACE          | This Document |
 
 
 --- back

--- a/js/net/src/lite/announce.test.ts
+++ b/js/net/src/lite/announce.test.ts
@@ -1,7 +1,12 @@
 import { expect, test } from "bun:test";
 import * as Path from "../path.ts";
 import { Reader, Writer } from "../stream.ts";
-import { type AnnounceBroadcast, decodeAnnounceBroadcast, encodeAnnounceBroadcast } from "./announce.ts";
+import {
+	type AnnounceBroadcast,
+	AnnounceRequest,
+	decodeAnnounceBroadcast,
+	encodeAnnounceBroadcast,
+} from "./announce.ts";
 import { OriginSchema } from "./origin.ts";
 import { Version } from "./version.ts";
 
@@ -99,4 +104,28 @@ test("AnnounceBroadcast rejects explicit restart status before draft-05", async 
 	wire[1] = 2;
 
 	await expect(decodeAnnounceBroadcast(new Reader(undefined, wire), Version.DRAFT_04)).rejects.toThrow();
+});
+
+async function requestRoundTrip(msg: AnnounceRequest, version: Version): Promise<AnnounceRequest> {
+	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, version)));
+	return AnnounceRequest.decode(reader, version);
+}
+
+// Draft04/05 carry the subscriber's origin id so the publisher can skip reflected
+// announces before they hit the wire.
+test("AnnounceRequest carries excludeHop on draft-05", async () => {
+	const got = await requestRoundTrip(new AnnounceRequest(Path.from("room/"), 42n), Version.DRAFT_05);
+	expect(got.excludeHop).toBe(42n);
+});
+
+// Draft06 dropped the field: the receiver's reflected-announce check catches the same
+// loops, so a value set locally is simply not sent and decodes as zero.
+test("AnnounceRequest drops excludeHop on draft-06", async () => {
+	const msg = new AnnounceRequest(Path.from("room/"), 42n);
+	const got = await requestRoundTrip(msg, Version.DRAFT_06);
+	expect(got.excludeHop).toBe(0n);
+
+	const with05 = await bytes((w) => msg.encode(w, Version.DRAFT_05));
+	const with06 = await bytes((w) => msg.encode(w, Version.DRAFT_06));
+	expect(with06.byteLength).toBeLessThan(with05.byteLength);
 });

--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -2,7 +2,7 @@ import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
 import * as Message from "./message.ts";
 import { type Origin, OriginSchema } from "./origin.ts";
-import { hasAnnounceId, hasAnnounceOk, hasRouteCost, Version } from "./version.ts";
+import { hasAnnounceId, hasAnnounceOk, hasExcludeHop, hasRouteCost, Version } from "./version.ts";
 
 // Must match the MAX_HOPS in Rust's model/origin.rs. Broadcasts with longer
 // hop chains are rejected; this keeps loop-detection bounded and rejects
@@ -233,8 +233,12 @@ export async function decodeAnnounceBroadcastMaybe(
  */
 export class AnnounceRequest {
 	prefix: Path.Valid;
-	// 62-bit Origin id of the peer asking for announces. Zero means "no exclusion".
-	// Must be a bigint: peer origins are up to 62 bits and overflow u53.
+	/** Lite04/05 only: the 62-bit Origin id of the peer asking for announces, which the
+	 * publisher uses to skip announces that already passed through it. Zero means "no
+	 * exclusion". Not on the wire elsewhere, so a value set here is ignored when encoding
+	 * for another version and decodes as zero.
+	 *
+	 * Must be a bigint: peer origins are up to 62 bits and overflow u53. */
 	excludeHop: bigint;
 
 	constructor(prefix: Path.Valid, excludeHop: bigint = 0n) {
@@ -244,30 +248,14 @@ export class AnnounceRequest {
 
 	async #encode(w: Writer, version: Version) {
 		await w.string(Path.encode(this.prefix));
-		switch (version) {
-			case Version.DRAFT_01:
-			case Version.DRAFT_02:
-			case Version.DRAFT_03:
-				break;
-			default:
-				// Lite04+: exclude_hop field (u62 varint).
-				await w.u62(this.excludeHop);
-				break;
+		if (hasExcludeHop(version)) {
+			await w.u62(this.excludeHop);
 		}
 	}
 
 	static async #decode(r: Reader, version: Version): Promise<AnnounceRequest> {
 		const prefix = Path.decode(await r.string());
-		let excludeHop = 0n;
-		switch (version) {
-			case Version.DRAFT_01:
-			case Version.DRAFT_02:
-			case Version.DRAFT_03:
-				break;
-			default:
-				excludeHop = await r.u62();
-				break;
-		}
+		const excludeHop = hasExcludeHop(version) ? await r.u62() : 0n;
 		return new AnnounceRequest(prefix, excludeHop);
 	}
 

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -159,6 +159,13 @@ export class Subscriber {
 		// Rust subscriber's `exclude_hop: self.self_origin.id` in `run_announce_prefix`.
 		const msg = new AnnounceRequest(prefix, this.origin);
 
+		// Drop reflected announces so callers asking for "someone else's broadcasts"
+		// don't re-see their own publishes. A caller can always ask for this, and it is
+		// required on versions that don't carry excludeHop above: there the peer isn't
+		// filtering them out for us, so filtering here keeps what the app sees the same
+		// as lite-05. Lite01-03 carry no real hop ids, so the check never matches there.
+		const dropReflected = options.ignoreSelf || !hasExcludeHop(this.version);
+
 		try {
 			// Open a stream and send the announce interest.
 			const stream = await Stream.open(this.#quic);
@@ -247,16 +254,8 @@ export class Subscriber {
 					}
 				}
 
-				// Drop reflected announces so callers asking for "someone else's
-				// broadcasts" don't re-see their own publishes. A caller can always ask
-				// for this, and it is required on versions that don't carry excludeHop in
-				// ANNOUNCE_REQUEST: there the peer isn't filtering them out for us, so
-				// filtering here keeps what the app sees the same as lite-05. Lite01-03
-				// carry no real hop ids, so the check never matches there anyway.
-				//
 				// In Lite05+ the sender's origin arrives via AnnounceOk, not in each hop
 				// list, so fold it back in before checking.
-				const dropReflected = options.ignoreSelf || !hasExcludeHop(this.version);
 				if (hops !== undefined && dropReflected) {
 					const full = responderOrigin !== undefined ? [...hops, responderOrigin] : hops;
 					if (full.includes(this.origin)) {

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -21,7 +21,7 @@ import { ProbeLevel, type Setup } from "./setup.ts";
 import { StreamId } from "./stream.ts";
 import { decodeSubscribeResponse, decodeSubscribeResponseMaybe, Subscribe, SubscribeUpdate } from "./subscribe.ts";
 import { TrackInfo, Track as TrackMessage } from "./track.ts";
-import { hasAnnounceId, hasAnnounceOk, hasDatagrams, Version } from "./version.ts";
+import { hasAnnounceId, hasAnnounceOk, hasDatagrams, hasExcludeHop, Version } from "./version.ts";
 
 // Bound on how long stream-open plus the first response (SUBSCRIBE_OK on older
 // drafts, or TRACK_INFO on lite-05+) may take. Browsers cap concurrent QUIC
@@ -57,6 +57,10 @@ export interface AnnouncedOptions {
 	 * to false for backwards compatibility: existing code (notably hang.live)
 	 * relies on seeing its own publishes as the signal that a namespace
 	 * published successfully.
+	 *
+	 * Only meaningful on lite-04/05, where the peer filters reflected announces
+	 * on request (ANNOUNCE_REQUEST's `Exclude Hop`). Later versions dropped that
+	 * field, so reflected announces are always skipped.
 	 */
 	ignoreSelf?: boolean;
 }
@@ -149,9 +153,10 @@ export class Subscriber {
 
 	async #runAnnounced(announced: announce.Producer, prefix: Path.Valid, options: AnnouncedOptions): Promise<void> {
 		console.debug(`announced: prefix=${prefix}`);
-		// Send our own session-level origin id so the peer can skip announces
-		// whose hop chain already passed through us. Matches the Rust subscriber's
-		// `exclude_hop: self.self_origin.id` in `run_announce_prefix`.
+		// Lite04/05: send our own session-level origin id so the peer can skip announces
+		// whose hop chain already passed through us. Encoding drops it on every other
+		// version, where we drop the reflected announce on receipt instead. Matches the
+		// Rust subscriber's `exclude_hop: self.self_origin.id` in `run_announce_prefix`.
 		const msg = new AnnounceRequest(prefix, this.origin);
 
 		try {
@@ -242,11 +247,17 @@ export class Subscriber {
 					}
 				}
 
-				// Optionally drop reflected announces so callers asking for
-				// "someone else's broadcasts" don't re-see their own publishes. In
-				// Lite05+ the sender's origin arrives via AnnounceOk, not in each hop
+				// Drop reflected announces so callers asking for "someone else's
+				// broadcasts" don't re-see their own publishes. A caller can always ask
+				// for this, and it is required on versions that don't carry excludeHop in
+				// ANNOUNCE_REQUEST: there the peer isn't filtering them out for us, so
+				// filtering here keeps what the app sees the same as lite-05. Lite01-03
+				// carry no real hop ids, so the check never matches there anyway.
+				//
+				// In Lite05+ the sender's origin arrives via AnnounceOk, not in each hop
 				// list, so fold it back in before checking.
-				if (hops !== undefined && options.ignoreSelf) {
+				const dropReflected = options.ignoreSelf || !hasExcludeHop(this.version);
+				if (hops !== undefined && dropReflected) {
 					const full = responderOrigin !== undefined ? [...hops, responderOrigin] : hops;
 					if (full.includes(this.origin)) {
 						continue;

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -74,6 +74,26 @@ export function hasAnnounceId(version: Version): boolean {
 	}
 }
 
+/** Whether ANNOUNCE_REQUEST carries the Exclude Hop field: the subscriber's own
+ * origin id, which the publisher uses to skip announces whose hop chain already
+ * passed through the subscriber. Present in lite-04 and lite-05 only.
+ *
+ * The receiver's own reflected-announce check drops those announces anyway (and
+ * catches loops of any length, not just the two-hop case), so lite-06 drops the
+ * field and keeps the check.
+ *
+ * Unlike the gates above, this lists the versions that *have* the field: it was
+ * removed rather than added, so future versions default to not carrying it. */
+export function hasExcludeHop(version: Version): boolean {
+	switch (version) {
+		case Version.DRAFT_04:
+		case Version.DRAFT_05:
+			return true;
+		default:
+			return false;
+	}
+}
+
 /** Whether announcements carry a route cost varint alongside the hop chain: the
  * marginal cost of pulling the broadcast via this route, accumulated per link.
  * Added in lite-06. Older versions carry nothing, so a received route stays at

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -259,27 +259,26 @@ fn encode_hops<W: bytes::BufMut>(w: &mut W, version: Version, hops: &OriginList)
 pub struct AnnounceRequest<'a> {
 	// Request tracks with this prefix.
 	pub prefix: Path<'a>,
-	// If non-zero, the publisher SHOULD skip announces whose hop IDs contain this value.
+	// Lite04/05 only: if non-zero, the publisher SHOULD skip announces whose hop IDs
+	// contain this value. Not on the wire elsewhere, so the value set here is ignored
+	// when encoding for another version and decodes as zero.
 	pub exclude_hop: u64,
 }
 
 impl Message for AnnounceRequest<'_> {
 	fn decode_msg<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
 		let prefix = Path::decode(r, version)?;
-		let exclude_hop = match version {
-			Version::Lite01 | Version::Lite02 | Version::Lite03 => 0,
-			_ => u64::decode(r, version)?,
+		let exclude_hop = match version.has_exclude_hop() {
+			true => u64::decode(r, version)?,
+			false => 0,
 		};
 		Ok(Self { prefix, exclude_hop })
 	}
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
 		self.prefix.encode(w, version)?;
-		match version {
-			Version::Lite01 | Version::Lite02 | Version::Lite03 => {}
-			_ => {
-				self.exclude_hop.encode(w, version)?;
-			}
+		if version.has_exclude_hop() {
+			self.exclude_hop.encode(w, version)?;
 		}
 
 		Ok(())
@@ -600,6 +599,50 @@ mod tests {
 			.encode(&mut buf, Version::Lite06Wip)
 			.unwrap();
 		assert_eq!(buf.len(), 3);
+	}
+
+	fn request_round_trip(msg: &AnnounceRequest, version: Version) -> AnnounceRequest<'static> {
+		let mut buf = bytes::BytesMut::new();
+		msg.encode(&mut buf, version).unwrap();
+		let mut slice = &buf[..];
+		let got = AnnounceRequest::decode(&mut slice, version).unwrap();
+		assert!(slice.is_empty(), "trailing bytes after decode");
+		AnnounceRequest {
+			prefix: got.prefix.to_owned(),
+			exclude_hop: got.exclude_hop,
+		}
+	}
+
+	// Lite04/05 carry the subscriber's origin id so the publisher can skip reflected
+	// announces before they hit the wire.
+	#[test]
+	fn announce_request_carries_exclude_hop_on_lite05() {
+		let msg = AnnounceRequest {
+			prefix: Path::new("room/"),
+			exclude_hop: 42,
+		};
+		assert_eq!(request_round_trip(&msg, Version::Lite05).exclude_hop, 42);
+	}
+
+	// Lite06 dropped the field: the receiver's reflected-announce check catches the same
+	// loops, so a value set locally is simply not sent and decodes as zero.
+	#[test]
+	fn announce_request_drops_exclude_hop_on_lite06() {
+		let msg = AnnounceRequest {
+			prefix: Path::new("room/"),
+			exclude_hop: 42,
+		};
+		assert_eq!(request_round_trip(&msg, Version::Lite06Wip).exclude_hop, 0);
+
+		// And it costs nothing on the wire: the body is just the prefix.
+		let mut with = bytes::BytesMut::new();
+		msg.encode(&mut with, Version::Lite05).unwrap();
+		let mut without = bytes::BytesMut::new();
+		msg.encode(&mut without, Version::Lite06Wip).unwrap();
+		assert!(
+			without.len() < with.len(),
+			"lite06 must not encode the exclude_hop varint"
+		);
 	}
 
 	#[test]

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -222,10 +222,11 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		announced: &mut announce::Consumer,
 		prefix: impl AsPath,
 		self_origin: Origin,
-		// Peer's session-level origin id, sent in AnnounceInterest. We skip
-		// forwarding announces whose hop chain already contains this id, so
-		// reflected announces (cluster loops) never hit the wire. Zero means
-		// the peer didn't set it (Lite03 or earlier), pass through.
+		// Peer's session-level origin id, sent in ANNOUNCE_REQUEST on lite-04/05.
+		// We skip forwarding announces whose hop chain already contains this id, so
+		// reflected announces (cluster loops) never hit the wire. Zero means the peer
+		// didn't send one (every other version), in which case we forward and the peer
+		// drops the reflection on receipt.
 		exclude_hop: u64,
 		version: Version,
 	) -> Result<(), Error> {
@@ -671,7 +672,8 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	/// Decide whether to forward an active announcement and compute the outgoing hop chain.
 	///
 	/// Returns `None` when the announce should be skipped: the peer asked us to exclude it
-	/// (`exclude_hop`), it already passed through us (reflected loop), or the hop chain is full.
+	/// (`exclude_hop`, lite-04/05 only), it already passed through us (reflected loop), or
+	/// the hop chain is full.
 	fn prepare_active_hops(
 		hops: &OriginList,
 		self_origin: Origin,

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -48,10 +48,11 @@ pub(super) struct Subscriber<S: web_transport_trait::Session> {
 
 	origin: origin::Producer,
 	recv_bandwidth: Option<bandwidth::Producer>,
-	// Session-level origin id shared with the Publisher. Used to filter out
-	// reflected announces: we ask the peer (via AnnounceInterest.exclude_hop)
-	// to skip broadcasts whose hop chain already passed through us, and we
-	// double-check incoming announces against it as defense in depth.
+	// Session-level origin id shared with the Publisher. Used to drop reflected
+	// announces: any incoming announce whose hop chain already passed through us
+	// has looped, so it is neither used as a route nor forwarded. On lite-04/05
+	// we also ask the peer to filter them out (AnnounceRequest.exclude_hop) so
+	// they never hit the wire, but this check is what makes it correct.
 	self_origin: crate::Origin,
 	// A random per-connection origin stamped into the hop chain of broadcasts
 	// from versions that don't carry real hop ids on the wire (Lite01/02/03).
@@ -229,9 +230,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		let mut stream = Stream::open(&self.session, self.version).await?;
 		stream.writer.encode(&lite::ControlType::Announce).await?;
 
-		// Ask the peer to filter out announces that already passed through us, so
-		// reflected announces (the simple loop case) never hit the wire. Lite03
-		// peers ignore this field, in which case start_announce below still drops.
+		// Lite04/05: ask the peer to filter out announces that already passed through
+		// us, so the reflected ones never hit the wire. Encoding drops this on every
+		// other version, where start_announce below is the only filter.
 		let msg = lite::AnnounceRequest {
 			prefix: prefix.as_path(),
 			exclude_hop: self.self_origin.id(),
@@ -494,9 +495,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		}
 
 		// Drop announces that already passed through us. This connection is
-		// a reflection, not a new path. Peers should be filtering via
-		// AnnounceInterest.exclude_hop, but Lite03 peers can't, so this is
-		// the authoritative cluster-loop check on the receiver.
+		// a reflection, not a new path. Lite04/05 peers filter these out for us
+		// via AnnounceRequest.exclude_hop, but that is only an optimization:
+		// this is the authoritative cluster-loop check, and the only one on
+		// every other version.
 		if hops.contains(&self.self_origin) {
 			tracing::debug!(broadcast = %self.log_path(&path), "dropping reflected announce");
 			return Ok(false);

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -84,6 +84,20 @@ impl Version {
 		}
 	}
 
+	/// Whether ANNOUNCE_REQUEST carries the Exclude Hop field: the subscriber's own
+	/// origin id, which the publisher uses to skip announces whose hop chain already
+	/// passed through the subscriber. Present in lite-04 and lite-05 only.
+	///
+	/// The receiver's own reflected-announce check drops those announces anyway (and
+	/// catches loops of any length, not just the two-hop case), so lite-06 drops the
+	/// field and keeps the check.
+	///
+	/// Unlike the gates above, this lists the versions that *have* the field: it was
+	/// removed rather than added, so future versions default to not carrying it.
+	pub fn has_exclude_hop(self) -> bool {
+		matches!(self, Self::Lite04 | Self::Lite05)
+	}
+
 	/// Whether announcements carry the route cost: the marginal cost of pulling
 	/// the broadcast via this route, accumulated per link. Added in lite-06.
 	/// Older versions carry nothing, so a received route stays at zero and ranks


### PR DESCRIPTION
Removes `Exclude Hop` from ANNOUNCE_REQUEST in moq-lite-06 and EXCLUDE_HOP from the relay-hops IETF draft, and implements the wire change in Rust and JS. moq-lite-05 keeps the field.

Also rescopes the `dev` branch rule, in the second commit, so it covers semver-breaking API changes only.

## Why it is safe to remove

`Exclude Hop` let a subscriber ask the publisher to skip announces whose hop chain already passed through the subscriber, avoiding the two-hop reflection that is the common case of a cluster loop. It was never load-bearing:

- The receiver already drops any announce whose hop chain contains its own origin (`Subscriber::start_announce` and `restart_announce` in `rs/moq-net/src/lite/subscriber.rs`). The in-code comment called it "the authoritative cluster-loop check on the receiver".
- That check catches loops of **any** length, not just the two-hop case, and it is what keeps lite-01 through lite-03 correct, since those versions never carried the field at all.
- So `Exclude Hop` only saved the wasted send. lite-06 drops it and keeps the check.

## Wire change

`Version::has_exclude_hop()` (Rust) / `hasExcludeHop()` (JS) gates the field to lite-04 and lite-05. Unlike the other version gates, this one lists the versions that *have* the field rather than those that lack it: it was removed rather than added, so future versions default to not carrying it. Both gates carry a comment saying so, since it inverts the repo convention.

The `exclude_hop` / `excludeHop` field stays on `AnnounceRequest` for the versions that still carry it; encoding simply skips it elsewhere, and decoding yields zero. The publisher's existing `exclude_hop != 0` filter therefore no-ops on lite-06 with no change needed.

## JS behavior preservation

The JS subscriber's reflected-announce drop was opt-in (`AnnouncedOptions.ignoreSelf`, defaulting to false so apps like hang.live can see their own publishes). The JS publisher and subscriber share one connection origin, so on lite-05 the *peer* filtered a client's own publishes back out via `Exclude Hop`, and the app never saw them regardless of `ignoreSelf`.

With the field gone the peer no longer filters, so a client would have started seeing its own publishes echoed back. The drop is now unconditional on versions that lack the field, keeping what an app sees unchanged. `ignoreSelf` still applies on lite-04/05, and its doc comment now says so. Lite-01 through lite-03 carry no real hop ids, so the check never matches there.

## Draft changes

**`draft-lcurley-moq-lite.md`**: removed `Exclude Hop` from the ANNOUNCE_REQUEST message and field list; dropped the sentence about it from Routing Metadata and Privacy; two changelog bullets under moq-lite-06.

**`draft-lcurley-moq-relay-hops.md`**: removed the EXCLUDE_HOP parameter section, its IANA registration (0x40B58), and the references in the abstract and Setup Negotiation.

Both drafts also now state the receiver's loop check normatively. It was only mentioned parenthetically in moq-lite and implied in relay-hops; with `Exclude Hop` gone it is the only loop defense, so it now says explicitly that a looped announcement is neither forwarded **nor selected as a route** (the second half matters: selecting it would route the receiver back to itself). Both note that skipping the send toward the peer it was learned from remains a legal bandwidth optimization.

## Branch targeting

Targets `main`. No public API is renamed, removed, or signature-changed here: the version gates are new additive items, and `AnnounceRequest`'s field keeps its name and type.

The second commit rescopes the rule that would previously have sent this to `dev`. `dev` covered wire-protocol changes alongside API breaks, but the two are not the same risk: protocol versions are negotiated per session, so a new draft version or a field added to an in-progress one leaves existing peers on the version they already speak, which is a rollout concern rather than a semver break. `dev` now means one thing, a renamed, removed, or signature-changed public item; wire and format work targets `main` behind a version gate with the matching draft updated in the same PR. `CLAUDE.md` and `CONTRIBUTING.md` are updated together so they do not disagree.

## Testing

- New round-trip regression tests in both languages: the field survives on lite-05, is dropped on lite-06, and the lite-06 encoding is strictly shorter.
- `cargo test -p moq-net`: 584 passed.
- `bun test js/net`: 628 passed.
- `cargo check --workspace --all-targets` clean (excluding `moq-gst`, which needs gstreamer system libs unavailable in this container), `cargo clippy -p moq-net` clean, `cargo fmt --check` clean, `tsc -b` and `biome check` clean.
- Both drafts validated with `kramdown-rfc --v3`.

Not run here: `just test smoke-full` (the cross-language interop matrix), which needs the Nix dev shell. Worth running before this leaves draft, since it is a wire change.

(Written by Claude Fable 5)