### PR TITLE
fix(moq-boy,moq-native): dial the relay via --client-connect again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4243,7 +4243,6 @@ dependencies = [
  "serde",
  "tokio",
  "tracing",
- "url",
 ]
 
 [[package]]

--- a/demo/pub/justfile
+++ b/demo/pub/justfile
@@ -205,7 +205,7 @@ clock action url="http://localhost:4443" *args:
     	exit 1; \
     fi
 
-    cargo run -p moq-native --example clock -- --url "{{ url }}" --broadcast "clock" {{ args }} {{ action }}
+    cargo run -p moq-native --example clock -- --client-connect "{{ url }}" --broadcast "clock" {{ args }} {{ action }}
 
 # --- GStreamer ---
 

--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -140,10 +140,15 @@ Then `Config::load()?` (initializes tracing), build clients/servers via `.init()
 ## Testing
 
 - `just check` runs all tests + lint; `just fix` auto-fixes formatting/lint. `cargo test -p <crate>` for one crate.
+
 - Rust tests are `#[cfg(test)] mod tests` inline in the source file.
+
 - Async tests that depend on time call `tokio::time::pause()` first so timers fire instantly and deterministically (e.g. the tests in `moq-net/src/model/origin.rs`).
+
 - Config-merge regressions belong next to the config (`moq-relay/src/config.rs::tests`); they serialize env mutation with a lock since clap reads env.
+
 - **`just check` only compiles the host's platform.** `#[cfg(target_os = "...")]` code for other platforms is invisible to it, and `cargo fmt` skips those modules too. Each platform has its own gate, and each only runs on that platform's runner:
+
   - Windows (moq-video's Media Foundation and D3D11 backends): `just rs windows`, via `.github/workflows/windows.yml`. You can't reproduce it off Windows, since cross-compiling dies in openh264-sys2's vendored C++.
   - macOS (moq-video's VideoToolbox and ScreenCaptureKit, moq-audio's system audio): `just rs macos`, via `.github/workflows/macos.yml`. Scoped to moq-video + moq-audio, and needs `--all-features` because moq-audio's capture backend is off by default.
   - Linux: no separate gate needed. `just rs ci` already runs `--all-features` in a dev shell carrying pipewire/libva/alsa, so nvenc/nvdec/vaapi/pipewire all compile.

--- a/rs/moq-boy/Cargo.toml
+++ b/rs/moq-boy/Cargo.toml
@@ -34,4 +34,3 @@ moq-video = { workspace = true, features = ["nvenc", "vaapi"] }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = "0.1"
-url = "2"

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -201,8 +201,8 @@ async fn run(config: &Config) -> Result<()> {
 	tracing::info!(rom = %rom_path.display(), %name, "starting Game Boy emulator");
 
 	let (cmd_tx, cmd_rx) = tokio::sync::mpsc::channel::<input::Command>(64);
-	let client = config.client.clone().init()?;
 	let url = config.client.connect.clone().context("--client-connect is required")?;
+	let client = config.client.clone().init()?;
 
 	// Publish origin: the game session broadcast.
 	let publish_origin = moq_net::Origin::random().produce();
@@ -485,12 +485,14 @@ async fn main() -> Result<()> {
 mod tests {
 	use super::*;
 
-	/// The relay URL comes from the flattened `ClientConfig`, so `demo/boy/justfile`
-	/// dials with `--client-connect`. A second connect flag of our own would still
-	/// parse here but leave `--client-connect` inert, so assert the URL actually
-	/// lands where `run` reads it.
+	/// `--client-connect` is the only way to reach the relay: it must parse without
+	/// a connect flag of our own alongside it, and the URL must land where `run`
+	/// reads it. A second required flag would leave `--client-connect` inert.
+	///
+	/// The argv is a copy of `demo/boy/justfile`, not a read of it, so this pins the
+	/// binary's flag surface rather than the two staying in sync.
 	#[test]
-	fn demo_invocation_parses() {
+	fn matches_demo_invocation() {
 		let config = Config::try_parse_from([
 			"moq-boy",
 			"--client-connect",

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -502,9 +502,12 @@ mod tests {
 		])
 		.expect("demo/boy/justfile invocation should parse");
 
-		assert_eq!(
-			config.client.connect.as_ref().map(|url| url.as_str()),
-			Some("http://localhost:4443/")
-		);
+		let connect = config
+			.client
+			.connect
+			.expect("--client-connect should reach the client config");
+		assert_eq!(connect.scheme(), "http");
+		assert_eq!(connect.host_str(), Some("localhost"));
+		assert_eq!(connect.port(), Some(4443));
 	}
 }

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -31,7 +31,6 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
-use url::Url;
 
 #[cfg(feature = "jemalloc")]
 #[global_allocator]
@@ -46,10 +45,6 @@ mod video;
 
 #[derive(Parser, Clone)]
 pub struct Config {
-	/// Connect to the given relay URL.
-	#[arg(long)]
-	pub url: Url,
-
 	/// Path to the Game Boy ROM file.
 	#[arg(long)]
 	pub rom: PathBuf,
@@ -207,6 +202,7 @@ async fn run(config: &Config) -> Result<()> {
 
 	let (cmd_tx, cmd_rx) = tokio::sync::mpsc::channel::<input::Command>(64);
 	let client = config.client.clone().init()?;
+	let url = config.client.connect.clone().context("--client-connect is required")?;
 
 	// Publish origin: the game session broadcast.
 	let publish_origin = moq_net::Origin::random().produce();
@@ -231,12 +227,12 @@ async fn run(config: &Config) -> Result<()> {
 		.consume()
 		.announced();
 
-	tracing::info!(url = %config.url, %name, broadcast = %broadcast_path, "connecting to relay");
+	tracing::info!(%url, %name, broadcast = %broadcast_path, "connecting to relay");
 
 	let reconnect = client
 		.with_publisher(&publish_origin)
 		.with_subscriber(consume_origin)
-		.reconnect(config.url.clone());
+		.reconnect(url);
 
 	// Set up catalog and encoders.
 	let catalog = moq_mux::catalog::Producer::new(&mut broadcast)?;
@@ -482,5 +478,33 @@ async fn main() -> Result<()> {
 			tracing::error!(err = %format!("{err:#}"), "exiting");
 			std::process::exit(1);
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// The relay URL comes from the flattened `ClientConfig`, so `demo/boy/justfile`
+	/// dials with `--client-connect`. A second connect flag of our own would still
+	/// parse here but leave `--client-connect` inert, so assert the URL actually
+	/// lands where `run` reads it.
+	#[test]
+	fn demo_invocation_parses() {
+		let config = Config::try_parse_from([
+			"moq-boy",
+			"--client-connect",
+			"http://localhost:4443",
+			"--rom",
+			"rom/big2small.gb",
+			"--location",
+			"localhost",
+		])
+		.expect("demo/boy/justfile invocation should parse");
+
+		assert_eq!(
+			config.client.connect.as_ref().map(|url| url.as_str()),
+			Some("http://localhost:4443/")
+		);
 	}
 }

--- a/rs/moq-native/examples/clock.rs
+++ b/rs/moq-native/examples/clock.rs
@@ -8,22 +8,17 @@
 //! Run with:
 //!
 //! ```text
-//! cargo run -p moq-native --example clock -- --url https://relay.example.com/anon --broadcast clock publish
-//! cargo run -p moq-native --example clock -- --url https://relay.example.com/anon --broadcast clock subscribe
+//! cargo run -p moq-native --example clock -- --client-connect https://relay.example.com/anon --broadcast clock publish
+//! cargo run -p moq-native --example clock -- --client-connect https://relay.example.com/anon --broadcast clock subscribe
 //! ```
 
 use anyhow::Context;
 use chrono::prelude::*;
 use clap::Parser;
 use moq_net::*;
-use url::Url;
 
 #[derive(Parser, Clone)]
 struct Config {
-	/// Connect to the given URL starting with https://
-	#[arg(long)]
-	url: Url,
-
 	/// The name of the broadcast to publish or subscribe to.
 	#[arg(long)]
 	broadcast: String,
@@ -56,9 +51,10 @@ async fn main() -> anyhow::Result<()> {
 	let config = Config::parse();
 	config.log.init()?;
 
+	let url = config.client.connect.clone().context("--client-connect is required")?;
 	let client = config.client.init()?;
 
-	tracing::info!(url = ?config.url, "connecting to server");
+	tracing::info!(%url, "connecting to server");
 
 	let track = config.track;
 
@@ -72,7 +68,7 @@ async fn main() -> anyhow::Result<()> {
 			let track = broadcast.create_track(track, None)?;
 			let clock = Publisher::new(track);
 
-			let reconnect = client.with_publisher(&origin).reconnect(config.url);
+			let reconnect = client.with_publisher(&origin).reconnect(url);
 
 			// Keep the result out of the `select!` arm (a `?` there would return
 			// before the close below runs), so the broadcast is always closed.
@@ -87,7 +83,7 @@ async fn main() -> anyhow::Result<()> {
 			result
 		}
 		Command::Subscribe => {
-			let reconnect = client.with_subscriber(origin.clone()).reconnect(config.url);
+			let reconnect = client.with_subscriber(origin.clone()).reconnect(url);
 
 			// IETF MoQ + the current origin::Consumer API don't let us call
 			// `session.consume_broadcast(&path)` directly, so loop on announces


### PR DESCRIPTION
## Summary

- **Root cause**: [#2048](https://github.com/moq-dev/moq/pull/2048) moved the connect URL into `moq_native::ClientConfig`, deleting the bespoke `--url` flag from `moq-boy` and the clock example and updating their callers to `--client-connect`. Merge `f0136b6ff` ("Merge origin/main into dev"), 2h47m later, resolved `rs/moq-boy/src/main.rs` and `examples/clock.rs` in favor of dev's older copies, restoring `--url` and dropping the `client.connect` read. Every other file in #2048 survived, so the callers kept the new flag while the two binaries went back to requiring the old one.
- The visible symptom: `just b2s` in `demo/boy` died on `error: the following required arguments were not provided: --url <URL>`. `--client-connect` still parsed (it comes from the flattened `ClientConfig`) but was silently ignored, so there were two flags for one job and the documented one was inert.
- Restores #2048's shape in `moq-boy` and the clock example, and repoints `demo/pub`'s `clock` recipe, which was the one caller still passing `--url`. `doc/setup/windows.md` already documented `--client-connect` and is now correct.
- `--url` is removed outright rather than kept as an alias: `--client-connect` is the one connect flag across every binary, and moq-boy is a demo with no compatibility surface worth preserving.
- The clock example keeps its current `with_publisher`/`with_subscriber` API rather than reverting to #2048's `publish()`/`consume()` helpers, which later PRs reshaped.
- Drops the now-unused `url` dep from `moq-boy` (`cargo shear` confirms).

## Public API changes

None. `moq_boy::Config` and the clock example's `Config` are binary/example-local; the removed `url` field was never a library surface. No change to any `rs/moq-*` or `js/*` `pub` item. Targeting `main`: no wire change and no breaking `pub` API in the crates `dev` is reserved for.

## Cross-Package Sync

No rows apply: no wire format, catalog, `moq-ffi`, or gateway change. The CLI-surface row is covered, `demo/pub/justfile` and `doc/setup/windows.md` being the invocation sites for the two touched binaries.

## Test plan

- `just check` and `just rs check` pass (`cargo fmt --all --check`, `clippy --all-targets -D warnings`, `cargo doc -D warnings`, `cargo shear`, `cargo sort`).
- New `moq-boy` `tests::matches_demo_invocation` parses the `demo/boy/justfile` argv and asserts the URL reaches `client.connect`. Mutation-checked: reintroducing a bespoke required `--url` fails it with the original `MissingRequiredArgument: --url`, so it is not vacuous. It runs in CI via `just rs ci`'s `cargo nextest run --workspace --all-targets --all-features` (note `just rs check` does not run tests).
- `just start rom/big2small.gb` in `demo/boy` boots the emulator, opens the H.264 encoder, and dials the relay from `--client-connect`; it only fails to complete the handshake because no relay was running locally.

## Known gaps

- The test copies the justfile's argv rather than reading it, so it pins the binary's flag surface, not the two staying in sync. A future justfile edit would not trip it.
- The clock example has no equivalent coverage; `clippy --all-targets` compiles it, but nothing exercises `demo/pub`'s `clock` recipe, so the same divergence could recur there uncaught.
- Log lines print the full connect URL, which can carry `?jwt=`. Pre-existing (`moq_native::reconnect` does the same, and the previous `?config.url` did too), left alone here rather than widened into a redaction change.

## Follow-up worth considering

The underlying failure mode is that a `main`→`dev` merge silently discarded a merged PR's changes to two files. Nothing in CI catches that class, since both sides compile. Other PRs from that merge window may deserve the same audit.

(Written by Opus 5)