### PR TITLE
feat(moq-video): render decoded frames on the GPU, and carry color spaces end to end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
 name = "ashpd"
 version = "0.13.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,6 +685,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
 name = "bit-vec"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +848,20 @@ name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "byteorder"
@@ -1154,6 +1186,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
  "thiserror 2.0.19",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1918,6 +1961,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.8.9",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +2695,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
 name = "glib"
 version = "0.20.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2705,6 +2768,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "glow"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29038e1c483364cc6bb3cf78feee1816002e127c331a1eec55a4d202b9e1adb5"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2747,6 +2831,20 @@ dependencies = [
  "smallvec",
  "spinning_top",
  "web-time",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51255ea7cfaadb6c5f1528d43e92a82acb2b96c43365989a28b2d44ee38f8795"
+dependencies = [
+ "ash",
+ "hashbrown 0.16.1",
+ "log",
+ "presser",
+ "thiserror 2.0.19",
+ "windows",
 ]
 
 [[package]]
@@ -2840,6 +2938,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -3856,6 +3955,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading 0.8.9",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
 name = "kio"
 version = "0.5.1"
 dependencies = [
@@ -4674,6 +4790,7 @@ dependencies = [
  "anyhow",
  "ashpd",
  "block2",
+ "bytemuck",
  "bytes",
  "cudarc",
  "dispatch2",
@@ -4691,6 +4808,7 @@ dependencies = [
  "objc2-core-media",
  "objc2-core-video",
  "objc2-foundation",
+ "objc2-metal",
  "objc2-screen-capture-kit",
  "objc2-video-toolbox",
  "openh264",
@@ -4700,6 +4818,7 @@ dependencies = [
  "tokio",
  "tracing",
  "v4l",
+ "wgpu",
  "windows",
  "yuv",
  "zune-jpeg",
@@ -4816,6 +4935,44 @@ dependencies = [
  "derive_more 2.1.1",
  "n0-error",
  "n0-future",
+]
+
+[[package]]
+name = "naga"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bf0a141a9ab6f07dbb492db53245e464bc9db42f407772d9ae03d83a2c1033"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "libm",
+ "log",
+ "naga-types",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "thiserror 2.0.19",
+ "unicode-ident",
+]
+
+[[package]]
+name = "naga-types"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658200ddc25c6c7b860747516d132d1b284c0fafb7a380233acee9a72fb30e11"
+dependencies = [
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "rustc-hash 1.1.0",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5528,7 +5685,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
 dependencies = [
  "bitflags 2.13.1",
+ "block2",
+ "dispatch2",
  "objc2",
+ "objc2-core-foundation",
  "objc2-foundation",
 ]
 
@@ -5540,7 +5700,10 @@ checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.13.1",
  "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -5767,6 +5930,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c26d27bb1aeab65138e4bf7666045169d1717febcc9ff870166be8348b223d0"
 dependencies = [
  "paste",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -6204,6 +6376,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6279,6 +6457,12 @@ dependencies = [
  "bitflags 2.13.1",
  "hex",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 
 [[package]]
 name = "prometheus"
@@ -6641,12 +6825,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags 2.13.1",
+]
+
+[[package]]
+name = "raw-window-handle"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
+
+[[package]]
+name = "raw-window-metal"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d213455a5f1dc59214213c7330e074ddf8114c9a42411eb890c767357ce135"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -6741,6 +6949,12 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
@@ -7656,6 +7870,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7729,6 +7952,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spirv"
+version = "0.4.0+sdk-1.4.341.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9571ea910ebd84c86af4b3ed27f9dbdc6ad06f17c5f96146b2b671e2976744f"
+dependencies = [
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -8052,6 +8284,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -9191,6 +9432,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "once_cell",
+ "pkg-config",
+]
+
+[[package]]
 name = "web-async"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9386,6 +9639,179 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom 7.1.3",
+]
+
+[[package]]
+name = "wgpu"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8f4bd44d92da5270f03409dba9f952dab24f128e05d6a554926101d1bf9114"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.1",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.17.1",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08763620e76fc980bca7bf84de82568614487a53172dd968d89187282eb87fa2"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.13.1",
+ "bytemuck",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.17.1",
+ "indexmap 2.14.0",
+ "log",
+ "naga",
+ "naga-types",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.19",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3283b6da70d7fc892de95840215aa36381b5d0cbc479e88ee2b173c7b992b225"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85dcf2b2e5c2afb9eda64c570a87a4e570304bf39e52eddbaaf222d655b656ad"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76bc9c1c186ff3d9054e0d224c93c8c1c79d6653907c5249a5c1ea1a2cb1e43"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf765132d8d5f50e192e7880464890c13f4e7457aafe8e5466e8174586e9f101"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.13.1",
+ "block2",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-allocator",
+ "hashbrown 0.17.1",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading 0.8.9",
+ "log",
+ "naga",
+ "naga-types",
+ "ndk-sys",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "objc2-metal",
+ "objc2-quartz-core",
+ "once_cell",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "portable-atomic-util",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "raw-window-metal",
+ "renderdoc-sys",
+ "smallvec",
+ "static_assertions",
+ "thiserror 2.0.19",
+ "wasm-bindgen",
+ "wayland-sys",
+ "web-sys",
+ "wgpu-naga-bridge",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+ "windows-result",
+]
+
+[[package]]
+name = "wgpu-naga-bridge"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9eaac644e5008925c78567d272b9d66ef83da55a53cc17fc7daade7bb6e66e5"
+dependencies = [
+ "naga",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "30.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a9c93c2b35edde326df60ffdee4c0f5864eac3011d6768b70d43f028ad93565"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "naga-types",
+ "raw-window-handle",
+ "static_assertions",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bitstream-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+
+[[package]]
 name = "blake3"
 version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,6 +2431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "four-cc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "795cbfc56d419a7ce47ccbb7504dd9a5b7c484c083c356e797de08bd988d9629"
+
+[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2931,6 +2943,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "253b313319f7109de64e480ffb606f89475cd758bae82e096e00c5d95341d30e"
 
 [[package]]
+name = "h264-reader"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "036a78b2620d92f0ec57690bc792b3bb87348632ee5225302ba2e66a48021c6c"
+dependencies = [
+ "bitstream-io",
+ "hex-slice",
+ "log",
+ "memchr",
+ "rfc6381-codec",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3040,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-slice"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5491a308e0214554f07a81d8944abe45f552871c12e3c3c6e7e5d354039a6c4c"
 
 [[package]]
 name = "hickory-net"
@@ -4795,6 +4826,7 @@ dependencies = [
  "cudarc",
  "dispatch2",
  "fast_image_resize",
+ "h264-reader",
  "hang",
  "libloading 0.9.0",
  "moq-mux",
@@ -4860,10 +4892,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "mp4ra-rust"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdbc3d3867085d66ac6270482e66f3dd2c5a18451a3dc9ad7269e94844a536b7"
+dependencies = [
+ "four-cc",
+]
+
+[[package]]
 name = "mpeg2ts"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7541fc1a42604cbd10e8607a4e6d4b231db982888fe8065ccb191b751d6368d6"
+
+[[package]]
+name = "mpeg4-audio-const"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a1fe2275b68991faded2c80aa4a33dba398b77d276038b8f50701a22e55918"
 
 [[package]]
 name = "muldiv"
@@ -7013,6 +7060,16 @@ name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
+name = "rfc6381-codec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed54c20f5c3ec82eab6d998b313dc75ec5d5650d4f57675e61d72489040297fd"
+dependencies = [
+ "mp4ra-rust",
+ "mpeg4-audio-const",
+]
 
 [[package]]
 name = "rfc6979"

--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -60,11 +60,17 @@ impl Rung {
 	}
 
 	/// An encoder producing this rung's rendition.
-	fn encode(&self) -> Result<moq_video::encode::Encoder, Error> {
+	///
+	/// `color` is the space the frames reaching it are in, taken from the first
+	/// decoded frame where the decoder knows. A rung below 576 lines fed by an HD
+	/// source carries the source's space, not the one its own size implies, so
+	/// leaving this to the encoder's size guess would label the rung wrongly.
+	fn encode(&self, color: Option<moq_video::Color>) -> Result<moq_video::encode::Encoder, Error> {
 		let mut config =
 			moq_video::encode::Config::new(self.info.size.width, self.info.size.height, self.info.framerate);
 		config.bitrate = Some(self.info.bitrate);
 		config.kind = self.encoder.clone();
+		config.color = color;
 		// Keyframes are forced at every group boundary; the GOP is only a
 		// backstop against pathologically long source groups.
 		config.gop = self.info.framerate.saturating_mul(8).max(1);
@@ -115,7 +121,11 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 		// Dropping them on unused releases the shared decode (if last) and the
 		// encoder session until someone subscribes again.
 		let mut listener = rung.feed.listen();
-		let mut encoder = rung.encode()?;
+		// Built from the first frame: the encoder writes that frame's color space
+		// into the bitstream, so it cannot open before one has arrived. A keyframe
+		// asked for at a group boundary waits here until it exists.
+		let mut encoder: Option<moq_video::encode::Encoder> = None;
+		let mut pending_keyframe = false;
 
 		// The output group currently being written, if the feed is mid-group.
 		let mut current: Option<moq_net::group::Producer> = None;
@@ -141,7 +151,10 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 					// A subscriber has to be able to start at this group, so its first
 					// frame must be an IDR. The request waits for the next frame, so a
 					// rung that skips this group simply carries it forward.
-					encoder.keyframe();
+					match &mut encoder {
+						Some(encoder) => encoder.keyframe(),
+						None => pending_keyframe = true,
+					}
 					// Mirror the source sequence so fetches and rendition
 					// switches map 1:1.
 					let info = moq_net::group::Info { sequence };
@@ -167,13 +180,28 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 
 					// The feed decodes at the source's native size; size this rung's copy
 					// here. A GPU frame resizes on the GPU and feeds the encoder without
-					// touching the CPU.
-					let encoded = if frame.size() == rung.info.size {
-						encoder.encode(&frame)?
-					} else {
-						encoder.encode(&frame.resize(rung.info.size)?)?
+					// touching the CPU. The resize carries the source's color space
+					// across, which is why the encoder is opened from the scaled frame
+					// rather than from this rung's size.
+					let resized;
+					let frame: &moq_video::Frame = match frame.size() == rung.info.size {
+						true => &frame,
+						false => {
+							resized = frame.resize(rung.info.size)?;
+							&resized
+						}
 					};
-					write(output, encoded)?;
+					let encoder = match &mut encoder {
+						Some(encoder) => encoder,
+						None => {
+							let mut opened = rung.encode(frame.surface.color())?;
+							if std::mem::take(&mut pending_keyframe) {
+								opened.keyframe();
+							}
+							encoder.insert(opened)
+						}
+					};
+					write(output, encoder.encode(frame)?)?;
 				}
 				Some(Item::End) => {
 					if let Some(mut output) = current.take() {
@@ -357,7 +385,12 @@ fn write(output: &mut moq_net::group::Producer, encoded: Vec<moq_video::encode::
 /// or a hardware decoder without a scaler) get `Frame::resize` instead.
 struct Pipeline {
 	decoder: moq_video::decode::Decoder,
-	encoder: moq_video::encode::Encoder,
+	/// Opened from the first decoded frame, whose color space it has to declare.
+	/// `None` until one arrives; a keyframe requested before then waits in
+	/// `pending_keyframe`.
+	encoder: Option<moq_video::encode::Encoder>,
+	pending_keyframe: bool,
+	rung: Rung,
 	size: moq_video::Size,
 }
 
@@ -370,7 +403,9 @@ impl Pipeline {
 
 		Ok(Self {
 			decoder,
-			encoder: rung.encode()?,
+			encoder: None,
+			pending_keyframe: false,
+			rung: rung.clone(),
 			size: rung.info.size,
 		})
 	}
@@ -387,18 +422,35 @@ impl Pipeline {
 		// actually arrives, which matters because a decoder that buffers returns
 		// nothing for the access unit that asked for one.
 		if keyframe {
-			self.encoder.keyframe();
+			match &mut self.encoder {
+				Some(encoder) => encoder.keyframe(),
+				None => self.pending_keyframe = true,
+			}
 		}
 
 		let mut encoded = Vec::new();
 		for raw in self.decoder.decode(payload, timestamp, keyframe)? {
-			encoded.extend(if raw.size() == self.size {
-				// Already at the rung size (the decoder scaled): feed the frame
-				// through as-is, keeping a GPU frame on the GPU.
-				self.encoder.encode(&raw)?
-			} else {
-				self.encoder.encode(&raw.resize(self.size)?)?
-			});
+			// Already at the rung size (the decoder scaled): feed the frame through
+			// as-is, keeping a GPU frame on the GPU.
+			let resized;
+			let raw: &moq_video::Frame = match raw.size() == self.size {
+				true => &raw,
+				false => {
+					resized = raw.resize(self.size)?;
+					&resized
+				}
+			};
+			let encoder = match &mut self.encoder {
+				Some(encoder) => encoder,
+				None => {
+					let mut opened = self.rung.encode(raw.surface.color())?;
+					if std::mem::take(&mut self.pending_keyframe) {
+						opened.keyframe();
+					}
+					self.encoder.insert(opened)
+				}
+			};
+			encoded.extend(encoder.encode(raw)?);
 		}
 		Ok(encoded)
 	}
@@ -408,6 +460,10 @@ impl Pipeline {
 	/// Consumes the pipeline, since flushing the encoder consumes it: a one-shot
 	/// group's pipeline is done once drained.
 	fn finish(self) -> Result<Vec<moq_video::encode::Encoded>, Error> {
-		self.encoder.finish().map_err(Into::into)
+		// No encoder means no frame ever decoded, so there is nothing buffered.
+		match self.encoder {
+			Some(encoder) => encoder.finish().map_err(Into::into),
+			None => Ok(Vec::new()),
+		}
 	}
 }

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -33,6 +33,19 @@ nvdec = ["dep:cudarc", "dep:moq-nvenc", "dep:libloading"]
 # libva-less host; automatic backend selection then falls back to the next encoder,
 # like the NVENC backend.
 vaapi = ["dep:moq-vaapi"]
+# GPU rendering of decoded frames (the `render` module): a wgpu pipeline that
+# converts a frame to RGBA and hands back a texture the caller presents. Off by
+# default because wgpu pulls a graphics stack (and its backend drivers) that a
+# relay or a headless publisher has no use for; only an application that actually
+# draws video turns it on.
+render = [
+    "dep:bytemuck",
+    "dep:wgpu",
+    "dep:objc2-metal",
+    "objc2-core-video/CVMetalTexture",
+    "objc2-core-video/CVMetalTextureCache",
+    "objc2-core-video/objc2-metal",
+]
 # Screen capture on Linux via xdg-desktop-portal + PipeWire (Wayland and X11).
 # Off by default because the `pipewire` crate links libpipewire-0.3 via pkg-config
 # at build time (and its bindgen needs libclang), so it only belongs in builds
@@ -41,6 +54,9 @@ pipewire = ["dep:pipewire", "dep:ashpd"]
 
 [dependencies]
 anyhow = "1"
+# Casting the color-conversion uniform to the bytes wgpu wants, without an
+# unsafe reinterpret of our own. Already in the graph via wgpu.
+bytemuck = { version = "1", optional = true }
 bytes = "1"
 # CPU I420 resize (SIMD per-plane convolution), the software fallback for
 # Frame::resize; CUDA and macOS pixel-buffer frames resize on the GPU instead.
@@ -63,6 +79,10 @@ openh264-sys2 = { version = "0.9.6", default-features = false }
 thiserror = "2"
 tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }
 tracing = "0.1"
+# GPU rendering behind the `render` feature. `wgpu::hal` is re-exported by wgpu
+# itself, so the zero-copy import paths reach the platform handles without a
+# separate wgpu-hal dependency that could drift to a different version.
+wgpu = { version = "30", optional = true }
 # RGBA -> I420 color conversion (replaces ffmpeg swscale).
 yuv = "0.8.14"
 
@@ -110,6 +130,10 @@ objc2-core-graphics = { version = "0.3.2", features = ["CGDirectDisplay"] }
 objc2-core-media = "0.3.2"
 objc2-core-video = "0.3.2"
 objc2-foundation = "0.3.2"
+# MTLDevice / MTLTexture for the `render` feature's zero-copy CVPixelBuffer
+# import (CVMetalTextureCache aliases the decoder's IOSurface as a Metal texture,
+# which wgpu then adopts).
+objc2-metal = { version = "0.3.2", optional = true }
 objc2-screen-capture-kit = "0.3.2"
 objc2-video-toolbox = "0.3.2"
 

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -157,3 +157,6 @@ windows = { version = "0.62", features = [
     "Win32_System_Ole",
     "Win32_System_Variant",
 ] }
+
+[dev-dependencies]
+h264-reader = "0.8.0"

--- a/rs/moq-video/src/capture/channel.rs
+++ b/rs/moq-video/src/capture/channel.rs
@@ -94,6 +94,7 @@ mod tests {
 			width: id,
 			height: 2,
 			data: Vec::new(),
+			color: None,
 		})
 	}
 

--- a/rs/moq-video/src/color.rs
+++ b/rs/moq-video/src/color.rs
@@ -46,9 +46,9 @@ impl Color {
 	/// The same matrix as `self` but in the given range, for a caller that knows
 	/// the range and not the matrix.
 	///
-	/// Only a surface whose pixel format spells out its range reaches this, and
-	/// CoreVideo's video-range/full-range NV12 is the only one today. It widens
-	/// when a platform that carries range metadata gains an import path.
+	/// Only a surface whose pixel format spells out its range reaches this, which
+	/// is why it is macOS-only: CoreVideo's video-range and full-range NV12 name
+	/// theirs.
 	#[cfg(target_os = "macos")]
 	pub(crate) fn with_range(self, limited: bool) -> Self {
 		match (self, limited) {

--- a/rs/moq-video/src/color.rs
+++ b/rs/moq-video/src/color.rs
@@ -11,11 +11,12 @@ use crate::Size;
 /// is the classic tinted-video bug: it leaves grays untouched and skews
 /// saturated colors, so it survives a casual look at the picture.
 ///
-/// [`I420::color`](crate::I420::color) reports it where the crate knows, which
-/// is when the crate did the conversion itself. It is `None` for pixels that
-/// merely passed through (a decoder's output, a camera's), since the
-/// authoritative answer lives in the bitstream's VUI and does not survive into a
-/// decoded [`Frame`](crate::Frame). [`Color::infer`] is the fallback then.
+/// [`Surface::color`](crate::Surface::color) reports it where the crate knows:
+/// when the crate did the conversion itself, or when the surface carries the
+/// answer (a macOS pixel buffer names its matrix, which VideoToolbox copies out
+/// of the stream's VUI). It is `None` for pixels that merely passed through with
+/// nothing naming their space, a camera's raw YUYV among them.
+/// [`Color::infer`] is the fallback then.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum Color {

--- a/rs/moq-video/src/color.rs
+++ b/rs/moq-video/src/color.rs
@@ -58,6 +58,27 @@ impl Color {
 			(_, false) => Color::Bt709Full,
 		}
 	}
+
+	/// Whether luma is 16..235 rather than 0..255.
+	///
+	/// The encoders need it for the VUI's `video_full_range_flag`, so unlike the
+	/// render module's `weights` it is not render-only.
+	pub(crate) fn limited(self) -> bool {
+		matches!(self, Color::Bt601Limited | Color::Bt709Limited)
+	}
+
+	/// How the `yuv` crate names this color space, for the RGB conversions.
+	pub(crate) fn yuv(self) -> (yuv::YuvRange, yuv::YuvStandardMatrix) {
+		let range = match self.limited() {
+			true => yuv::YuvRange::Limited,
+			false => yuv::YuvRange::Full,
+		};
+		let matrix = match self {
+			Color::Bt601Limited | Color::Bt601Full => yuv::YuvStandardMatrix::Bt601,
+			Color::Bt709Limited | Color::Bt709Full => yuv::YuvStandardMatrix::Bt709,
+		};
+		(range, matrix)
+	}
 }
 
 #[cfg(test)]

--- a/rs/moq-video/src/color.rs
+++ b/rs/moq-video/src/color.rs
@@ -44,26 +44,18 @@ impl Color {
 	}
 
 	/// The same matrix as `self` but in the given range, for a caller that knows
-	/// the range (a pixel format says so) and not the matrix.
+	/// the range and not the matrix.
+	///
+	/// Only a surface whose pixel format spells out its range reaches this, and
+	/// CoreVideo's video-range/full-range NV12 is the only one today. It widens
+	/// when a platform that carries range metadata gains an import path.
+	#[cfg(target_os = "macos")]
 	pub(crate) fn with_range(self, limited: bool) -> Self {
 		match (self, limited) {
 			(Color::Bt601Limited | Color::Bt601Full, true) => Color::Bt601Limited,
 			(Color::Bt601Limited | Color::Bt601Full, false) => Color::Bt601Full,
 			(_, true) => Color::Bt709Limited,
 			(_, false) => Color::Bt709Full,
-		}
-	}
-
-	/// Whether luma is 16..235 rather than 0..255.
-	pub(crate) fn limited(self) -> bool {
-		matches!(self, Color::Bt601Limited | Color::Bt709Limited)
-	}
-
-	/// The luma/chroma weights (`kr`, `kb`) this matrix is derived from.
-	pub(crate) fn weights(self) -> (f32, f32) {
-		match self {
-			Color::Bt601Limited | Color::Bt601Full => (0.299, 0.114),
-			Color::Bt709Limited | Color::Bt709Full => (0.2126, 0.0722),
 		}
 	}
 }
@@ -79,6 +71,7 @@ mod tests {
 		assert_eq!(Color::infer(Size::new(1280, 720)), Color::Bt709Limited);
 	}
 
+	#[cfg(target_os = "macos")]
 	#[test]
 	fn with_range_keeps_the_matrix() {
 		assert_eq!(Color::Bt709Limited.with_range(false), Color::Bt709Full);

--- a/rs/moq-video/src/color.rs
+++ b/rs/moq-video/src/color.rs
@@ -1,0 +1,88 @@
+//! [`Color`]: which YUV color space a frame's samples are in.
+
+use crate::Size;
+
+/// Which YUV color space a frame's samples are in.
+///
+/// Video carries luma and chroma, not RGB, and the matrix that converts between
+/// them differs by generation (BT.601 for standard definition, BT.709 for high
+/// definition) as does the numeric range (limited/studio swing pins luma to
+/// 16..235, full/full swing uses 0..255). Pairing samples with the wrong matrix
+/// is the classic tinted-video bug: it leaves grays untouched and skews
+/// saturated colors, so it survives a casual look at the picture.
+///
+/// [`I420::color`](crate::I420::color) reports it where the crate knows, which
+/// is when the crate did the conversion itself. It is `None` for pixels that
+/// merely passed through (a decoder's output, a camera's), since the
+/// authoritative answer lives in the bitstream's VUI and does not survive into a
+/// decoded [`Frame`](crate::Frame). [`Color::infer`] is the fallback then.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Color {
+	/// BT.601 (standard definition), limited range.
+	Bt601Limited,
+	/// BT.601 (standard definition), full range.
+	Bt601Full,
+	/// BT.709 (high definition), limited range.
+	Bt709Limited,
+	/// BT.709 (high definition), full range.
+	Bt709Full,
+}
+
+impl Color {
+	/// The conventional guess for a frame of this size: BT.601 up to standard
+	/// definition (576 lines), BT.709 above it, both limited range.
+	///
+	/// What a player does when the bitstream carries no VUI color description,
+	/// which is most of the time. A guess, so prefer a known [`Color`] whenever
+	/// one is available.
+	pub fn infer(size: Size) -> Self {
+		match size.height <= 576 {
+			true => Color::Bt601Limited,
+			false => Color::Bt709Limited,
+		}
+	}
+
+	/// The same matrix as `self` but in the given range, for a caller that knows
+	/// the range (a pixel format says so) and not the matrix.
+	pub(crate) fn with_range(self, limited: bool) -> Self {
+		match (self, limited) {
+			(Color::Bt601Limited | Color::Bt601Full, true) => Color::Bt601Limited,
+			(Color::Bt601Limited | Color::Bt601Full, false) => Color::Bt601Full,
+			(_, true) => Color::Bt709Limited,
+			(_, false) => Color::Bt709Full,
+		}
+	}
+
+	/// Whether luma is 16..235 rather than 0..255.
+	pub(crate) fn limited(self) -> bool {
+		matches!(self, Color::Bt601Limited | Color::Bt709Limited)
+	}
+
+	/// The luma/chroma weights (`kr`, `kb`) this matrix is derived from.
+	pub(crate) fn weights(self) -> (f32, f32) {
+		match self {
+			Color::Bt601Limited | Color::Bt601Full => (0.299, 0.114),
+			Color::Bt709Limited | Color::Bt709Full => (0.2126, 0.0722),
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn inference_splits_at_standard_definition() {
+		assert_eq!(Color::infer(Size::new(720, 480)), Color::Bt601Limited);
+		assert_eq!(Color::infer(Size::new(720, 576)), Color::Bt601Limited);
+		assert_eq!(Color::infer(Size::new(1280, 720)), Color::Bt709Limited);
+	}
+
+	#[test]
+	fn with_range_keeps_the_matrix() {
+		assert_eq!(Color::Bt709Limited.with_range(false), Color::Bt709Full);
+		assert_eq!(Color::Bt709Full.with_range(true), Color::Bt709Limited);
+		assert_eq!(Color::Bt601Limited.with_range(false), Color::Bt601Full);
+	}
+}

--- a/rs/moq-video/src/encode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/encode/backend/mediafoundation.rs
@@ -24,15 +24,18 @@ use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11Texture2D};
 use windows::Win32::Media::MediaFoundation::{
 	CODECAPI_AVEncCommonMeanBitRate, CODECAPI_AVEncCommonRateControlMode, CODECAPI_AVEncMPVGOPSize,
 	CODECAPI_AVEncVideoForceKeyFrame, CODECAPI_AVLowLatencyMode, ICodecAPI, IMFDXGIDeviceManager, IMFMediaBuffer,
-	IMFMediaEvent, IMFMediaEventGenerator, IMFSample, IMFTransform, METransformHaveOutput, METransformNeedInput,
-	MF_E_NO_EVENTS_AVAILABLE, MF_E_TRANSFORM_NEED_MORE_INPUT, MF_E_TRANSFORM_STREAM_CHANGE, MF_EVENT_FLAG_NO_WAIT,
-	MF_EVENT_FLAG_NONE, MF_MT_AVG_BITRATE, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE, MF_MT_INTERLACE_MODE, MF_MT_MAJOR_TYPE,
-	MF_MT_MPEG2_PROFILE, MF_MT_SUBTYPE, MF_TRANSFORM_ASYNC_UNLOCK, MFCreateDXGIDeviceManager,
-	MFCreateDXGISurfaceBuffer, MFCreateMediaType, MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video,
-	MFT_CATEGORY_VIDEO_ENCODER, MFT_ENUM_FLAG_HARDWARE, MFT_ENUM_FLAG_SORTANDFILTER, MFT_MESSAGE_COMMAND_DRAIN,
-	MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, MFT_MESSAGE_NOTIFY_END_OF_STREAM, MFT_MESSAGE_NOTIFY_START_OF_STREAM,
-	MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO,
-	MFTEnumEx, MFVideoFormat_H264, MFVideoFormat_HEVC, MFVideoFormat_NV12, MFVideoInterlace_Progressive,
+	IMFMediaEvent, IMFMediaEventGenerator, IMFMediaType, IMFSample, IMFTransform, METransformHaveOutput,
+	METransformNeedInput, MF_E_NO_EVENTS_AVAILABLE, MF_E_TRANSFORM_NEED_MORE_INPUT, MF_E_TRANSFORM_STREAM_CHANGE,
+	MF_EVENT_FLAG_NO_WAIT, MF_EVENT_FLAG_NONE, MF_MT_AVG_BITRATE, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE,
+	MF_MT_INTERLACE_MODE, MF_MT_MAJOR_TYPE, MF_MT_MPEG2_PROFILE, MF_MT_SUBTYPE, MF_MT_TRANSFER_FUNCTION,
+	MF_MT_VIDEO_NOMINAL_RANGE, MF_MT_VIDEO_PRIMARIES, MF_MT_YUV_MATRIX, MF_TRANSFORM_ASYNC_UNLOCK,
+	MFCreateDXGIDeviceManager, MFCreateDXGISurfaceBuffer, MFCreateMediaType, MFCreateMemoryBuffer, MFCreateSample,
+	MFMediaType_Video, MFNominalRange_0_255, MFNominalRange_16_235, MFT_CATEGORY_VIDEO_ENCODER, MFT_ENUM_FLAG_HARDWARE,
+	MFT_ENUM_FLAG_SORTANDFILTER, MFT_MESSAGE_COMMAND_DRAIN, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING,
+	MFT_MESSAGE_NOTIFY_END_OF_STREAM, MFT_MESSAGE_NOTIFY_START_OF_STREAM, MFT_MESSAGE_SET_D3D_MANAGER,
+	MFT_OUTPUT_DATA_BUFFER, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO, MFTEnumEx, MFVideoFormat_H264,
+	MFVideoFormat_HEVC, MFVideoFormat_NV12, MFVideoInterlace_Progressive, MFVideoPrimaries_BT709,
+	MFVideoPrimaries_SMPTE170M, MFVideoTransFunc_709, MFVideoTransferMatrix_BT601, MFVideoTransferMatrix_BT709,
 	eAVEncCommonRateControlMode_CBR, eAVEncH264VProfile_High, eAVEncH265VProfile_Main_420_8,
 };
 use windows::Win32::System::Variant::{VARIANT, VT_BOOL, VT_UI4};
@@ -42,7 +45,7 @@ use super::super::encoder::{Codec, Config};
 use super::{Backend, Encoded};
 use crate::frame::{Surface, interleave_uv};
 use crate::mf::{ComGuard, mf_err, pack_2x32};
-use crate::{Error, Frame};
+use crate::{Color, Error, Frame};
 
 pub(crate) const NAME: &str = "mediafoundation";
 
@@ -62,6 +65,9 @@ pub(crate) struct MediaFoundation {
 	framerate: u32,
 	bitrate: u32,
 	gop: u32,
+	/// The color space of the input frames, stamped onto both media types so the
+	/// encoder writes it into the bitstream's VUI.
+	color: Color,
 	/// Lazily configured on the first frame, since the Direct3D11 device to bind
 	/// (for zero-copy texture input) comes from the frame itself.
 	started: bool,
@@ -132,6 +138,7 @@ impl MediaFoundation {
 			framerate: config.framerate,
 			bitrate: clamp_u32(config.resolved_bitrate()),
 			gop: config.gop,
+			color: config.resolved_color(),
 			started: false,
 			provides_samples: false,
 			output_size: 0,
@@ -211,6 +218,39 @@ impl MediaFoundation {
 		Ok(())
 	}
 
+	/// Stamp the color space onto a media type. Media Foundation takes these as a
+	/// request rather than a guarantee, so a driver may still emit an untagged
+	/// stream; the conversion picks the matrix an untagged stream implies, which
+	/// is what keeps that case correct.
+	fn set_color(&self, media: &IMFMediaType) -> Result<(), Error> {
+		let (primaries, matrix) = match self.color {
+			Color::Bt601Limited | Color::Bt601Full => (MFVideoPrimaries_SMPTE170M, MFVideoTransferMatrix_BT601),
+			Color::Bt709Limited | Color::Bt709Full => (MFVideoPrimaries_BT709, MFVideoTransferMatrix_BT709),
+		};
+		// BT.601 and BT.709 share a transfer curve; only primaries and matrix differ.
+		let transfer = MFVideoTransFunc_709;
+		let range = match self.color.limited() {
+			true => MFNominalRange_16_235,
+			false => MFNominalRange_0_255,
+		};
+
+		unsafe {
+			media
+				.SetUINT32(&MF_MT_VIDEO_PRIMARIES, primaries.0 as u32)
+				.map_err(|e| mf_err("color primaries", e))?;
+			media
+				.SetUINT32(&MF_MT_TRANSFER_FUNCTION, transfer.0 as u32)
+				.map_err(|e| mf_err("transfer function", e))?;
+			media
+				.SetUINT32(&MF_MT_YUV_MATRIX, matrix.0 as u32)
+				.map_err(|e| mf_err("yuv matrix", e))?;
+			media
+				.SetUINT32(&MF_MT_VIDEO_NOMINAL_RANGE, range.0 as u32)
+				.map_err(|e| mf_err("nominal range", e))?;
+		}
+		Ok(())
+	}
+
 	fn set_output_type(&self) -> Result<(), Error> {
 		let format = OutputFormat::for_codec(self.codec);
 		let media = unsafe { MFCreateMediaType().map_err(|e| mf_err("create output type", e))? };
@@ -236,6 +276,7 @@ impl MediaFoundation {
 			media
 				.SetUINT64(&MF_MT_FRAME_RATE, pack_2x32(self.framerate, 1))
 				.map_err(|e| mf_err("output frame rate", e))?;
+			self.set_color(&media)?;
 			self.transform
 				.SetOutputType(0, &media, 0)
 				.map_err(|e| mf_err("SetOutputType", e))?;
@@ -261,6 +302,7 @@ impl MediaFoundation {
 			media
 				.SetUINT64(&MF_MT_FRAME_RATE, pack_2x32(self.framerate, 1))
 				.map_err(|e| mf_err("input frame rate", e))?;
+			self.set_color(&media)?;
 			self.transform
 				.SetInputType(0, &media, 0)
 				.map_err(|e| mf_err("SetInputType", e))?;

--- a/rs/moq-video/src/encode/backend/mod.rs
+++ b/rs/moq-video/src/encode/backend/mod.rs
@@ -137,3 +137,82 @@ pub(crate) fn open(config: &Config) -> Result<Box<dyn Backend>, Error> {
 
 	Err(Error::NoEncoder(tried.join(", ")))
 }
+
+#[cfg(test)]
+pub(crate) mod test_util {
+	use h264_reader::nal::sps::SeqParameterSet;
+	use h264_reader::nal::{Nal, RefNal, UnitType};
+
+	/// A stream's VUI color description, as the raw code points ISO/IEC 23091-2
+	/// assigns them plus the range flag.
+	///
+	/// Deliberately not mapped onto [`Color`](crate::Color): the mapping is lossy
+	/// (several code points share a matrix, and BT.709 and SMPTE 170M define the
+	/// same transfer curve under different numbers), so a test that compared
+	/// `Color`s could not see a backend drift on the fields `Color` folds away.
+	#[derive(Debug, PartialEq, Eq)]
+	pub(crate) struct Described {
+		pub primaries: u8,
+		pub transfer: u8,
+		pub matrix: u8,
+		pub full_range: bool,
+	}
+
+	/// The description we emit for BT.601 and BT.709 limited range, shared by the
+	/// backend tests so a backend drifting from the others fails rather than
+	/// quietly encoding its own dialect.
+	///
+	/// BT.601 goes out as SMPTE 170M primaries and matrix (code point 6) with the
+	/// BT.709 transfer curve (1). The two curves are defined identically, and
+	/// CoreVideo's SMPTE 170M transfer constant is deprecated while Media
+	/// Foundation has none at all, so 1 is the only value all four backends can
+	/// actually emit.
+	pub(crate) const BT601_DESCRIBED: Described = Described {
+		primaries: 6,
+		transfer: 1,
+		matrix: 6,
+		full_range: false,
+	};
+
+	pub(crate) const BT709_DESCRIBED: Described = Described {
+		primaries: 1,
+		transfer: 1,
+		matrix: 1,
+		full_range: false,
+	};
+
+	/// The color description an H.264 Annex-B stream carries in its SPS, or `None`
+	/// if it carries none and a decoder would have to guess.
+	///
+	/// Reads the bitstream rather than the encoder's config, so a backend that
+	/// quietly drops the VUI (or a driver that ignores it) fails the test instead
+	/// of passing on our own bookkeeping.
+	pub(crate) fn declared_color(annexb: &[u8]) -> Option<Described> {
+		// Every 4-byte start code contains a 3-byte one at offset 1, so scanning
+		// for the short form finds both.
+		let starts: Vec<usize> = (0..annexb.len().saturating_sub(2))
+			.filter(|&i| annexb[i..i + 3] == [0, 0, 1])
+			.map(|i| i + 3)
+			.collect();
+
+		let sps = starts.iter().enumerate().find_map(|(n, &start)| {
+			// Bound the NAL at the next start code: a trailing slice would
+			// leave the SPS parser reading into the following NAL.
+			let end = starts.get(n + 1).map_or(annexb.len(), |&next| next - 3);
+			let nal = RefNal::new(&annexb[start..end], &[], true);
+			match nal.header().ok()?.nal_unit_type() {
+				UnitType::SeqParameterSet => SeqParameterSet::from_bits(nal.rbsp_bits()).ok(),
+				_ => None,
+			}
+		})?;
+
+		let signal = sps.vui_parameters.as_ref()?.video_signal_type.as_ref()?;
+		let description = signal.colour_description.as_ref()?;
+		Some(Described {
+			primaries: description.colour_primaries,
+			transfer: description.transfer_characteristics,
+			matrix: description.matrix_coefficients,
+			full_range: signal.video_full_range_flag,
+		})
+	}
+}

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -35,14 +35,15 @@ use cudarc::driver::CudaContext;
 use moq_nvenc::sys::nvEncodeAPI::NV_ENC_INPUT_RESOURCE_TYPE;
 use moq_nvenc::sys::nvEncodeAPI::{
 	GUID, NV_ENC_BUFFER_FORMAT, NV_ENC_CODEC_H264_GUID, NV_ENC_CODEC_HEVC_GUID, NV_ENC_PARAMS_RC_MODE,
-	NV_ENC_PRESET_P4_GUID, NV_ENC_TUNING_INFO,
+	NV_ENC_PRESET_P4_GUID, NV_ENC_TUNING_INFO, NV_ENC_VUI_COLOR_PRIMARIES, NV_ENC_VUI_MATRIX_COEFFS,
+	NV_ENC_VUI_TRANSFER_CHARACTERISTIC, NV_ENC_VUI_VIDEO_FORMAT,
 };
 use moq_nvenc::{Encoder, EncoderInitParams, Session};
 
 use super::super::encoder::{Codec, Config};
 use super::{Backend, Encoded};
 use crate::frame::{Surface, interleave_uv};
-use crate::{Error, Frame};
+use crate::{Color, Error, Frame};
 
 pub(crate) const NAME: &str = "nvenc";
 
@@ -109,18 +110,57 @@ impl Nvenc {
 		//     undecodable for late joiners.
 		//   - idrPeriod == gopLength: make every periodic I-frame an IDR (a clean
 		//     random-access point), so each GOP boundary is joinable.
-		//
+
+		// State the color space in the SPS so a decoder doesn't fall back to
+		// guessing it from the frame height. BT.601 goes out as SMPTE 170M primaries
+		// and matrix (code point 6) with the BT.709 transfer curve (1): the two
+		// curves are defined identically, and 1 is the only one CoreVideo and Media
+		// Foundation can name, so every backend emits the same triple.
+		let color = config.resolved_color();
+		let (primaries, transfer, matrix) = match color {
+			Color::Bt601Limited | Color::Bt601Full => (
+				NV_ENC_VUI_COLOR_PRIMARIES::NV_ENC_VUI_COLOR_PRIMARIES_SMPTE170M,
+				NV_ENC_VUI_TRANSFER_CHARACTERISTIC::NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT709,
+				NV_ENC_VUI_MATRIX_COEFFS::NV_ENC_VUI_MATRIX_COEFFS_SMPTE170M,
+			),
+			Color::Bt709Limited | Color::Bt709Full => (
+				NV_ENC_VUI_COLOR_PRIMARIES::NV_ENC_VUI_COLOR_PRIMARIES_BT709,
+				NV_ENC_VUI_TRANSFER_CHARACTERISTIC::NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT709,
+				NV_ENC_VUI_MATRIX_COEFFS::NV_ENC_VUI_MATRIX_COEFFS_BT709,
+			),
+		};
+
 		// SAFETY: the preset config's codec union was initialized by
 		// `get_preset_config` for `codec_guid`, so we write the matching arm.
 		unsafe {
+			// The two codecs' VUI structs are distinct types with identical fields,
+			// so the assignments are written per-arm rather than shared.
 			match config.codec {
 				Codec::H264 => {
 					cfg.encodeCodecConfig.h264Config.set_repeatSPSPPS(1);
 					cfg.encodeCodecConfig.h264Config.idrPeriod = config.gop;
+
+					let vui = &mut cfg.encodeCodecConfig.h264Config.h264VUIParameters;
+					vui.videoSignalTypePresentFlag = 1;
+					vui.videoFormat = NV_ENC_VUI_VIDEO_FORMAT::NV_ENC_VUI_VIDEO_FORMAT_UNSPECIFIED;
+					vui.videoFullRangeFlag = u32::from(!color.limited());
+					vui.colourDescriptionPresentFlag = 1;
+					vui.colourPrimaries = primaries;
+					vui.transferCharacteristics = transfer;
+					vui.colourMatrix = matrix;
 				}
 				Codec::H265 => {
 					cfg.encodeCodecConfig.hevcConfig.set_repeatSPSPPS(1);
 					cfg.encodeCodecConfig.hevcConfig.idrPeriod = config.gop;
+
+					let vui = &mut cfg.encodeCodecConfig.hevcConfig.hevcVUIParameters;
+					vui.videoSignalTypePresentFlag = 1;
+					vui.videoFormat = NV_ENC_VUI_VIDEO_FORMAT::NV_ENC_VUI_VIDEO_FORMAT_UNSPECIFIED;
+					vui.videoFullRangeFlag = u32::from(!color.limited());
+					vui.colourDescriptionPresentFlag = 1;
+					vui.colourPrimaries = primaries;
+					vui.transferCharacteristics = transfer;
+					vui.colourMatrix = matrix;
 				}
 			}
 		}

--- a/rs/moq-video/src/encode/backend/openh264.rs
+++ b/rs/moq-video/src/encode/backend/openh264.rs
@@ -5,13 +5,16 @@
 
 use bytes::Bytes;
 use openh264::OpenH264API;
-use openh264::encoder::{BitRate, Encoder, EncoderConfig, FrameRate, IntraFramePeriod, RateControlMode, UsageType};
+use openh264::encoder::{
+	BitRate, Encoder, EncoderConfig, FrameRate, IntraFramePeriod, RateControlMode, TransferCharacteristics, UsageType,
+	VuiConfig,
+};
 use openh264::formats::YUVSlices;
 use openh264_sys2::{ENCODER_OPTION_BITRATE, SBitrateInfo, SPATIAL_LAYER_ALL};
 
 use super::super::encoder::Config;
 use super::{Backend, Encoded};
-use crate::{Error, Frame};
+use crate::{Color, Error, Frame};
 
 pub(crate) const NAME: &str = "openh264";
 
@@ -31,13 +34,31 @@ impl Openh264 {
 	}
 
 	fn new(config: &Config) -> Result<Self, Error> {
+		let color = config.resolved_color();
+		// State the color space in the SPS so a decoder doesn't fall back to
+		// guessing it from the frame height.
+		//
+		// `VuiConfig::bt601()` would pair SMPTE 170M primaries and matrix with the
+		// SMPTE 170M transfer curve (code point 6). We override the curve to BT.709
+		// (1), which is defined identically, because CoreVideo's 170M transfer
+		// constant is deprecated and Media Foundation has none, so 1 is the only
+		// value every backend can emit. Same curve, one number across all of them.
+		let vui = match color {
+			Color::Bt601Limited | Color::Bt601Full => {
+				VuiConfig::bt601().transfer_characteristics(TransferCharacteristics::Bt709)
+			}
+			Color::Bt709Limited | Color::Bt709Full => VuiConfig::bt709(),
+		}
+		.full_range(!color.limited());
+
 		let cfg = EncoderConfig::new()
 			.bitrate(BitRate::from_bps(config.resolved_bitrate().min(u32::MAX as u64) as u32))
 			.max_frame_rate(FrameRate::from_hz(config.framerate as f32))
 			.rate_control_mode(RateControlMode::Bitrate)
 			// Real-time camera: prioritize latency over compression.
 			.usage_type(UsageType::CameraVideoRealTime)
-			.intra_frame_period(IntraFramePeriod::from_num_frames(config.gop));
+			.intra_frame_period(IntraFramePeriod::from_num_frames(config.gop))
+			.vui(vui);
 
 		let encoder = Encoder::with_api_config(OpenH264API::from_source(), cfg)
 			.map_err(|e| Error::Codec(anyhow::anyhow!("openh264 init: {e}")))?;
@@ -236,5 +257,40 @@ mod tests {
 		enc.encode(&gray(), false).unwrap();
 
 		assert_eq!(enc.read_bitrate(), (opened / 4) as i64, "the deferred rate resurrected");
+	}
+
+	/// The SPS states the color space, so a decoder never falls back to guessing
+	/// it from the frame height, and it states the space the pixels were actually
+	/// converted into. Read back out of the bitstream, not off our own config.
+	#[test]
+	fn the_sps_declares_the_color_space() {
+		use super::super::test_util::{BT601_DESCRIBED, BT709_DESCRIBED, declared_color};
+		use crate::{Color, Size};
+
+		for (size, described) in [
+			(Size::new(640, 480), BT601_DESCRIBED),
+			(Size::new(1920, 1080), BT709_DESCRIBED),
+		] {
+			let config = Config {
+				kind: Kind::Software,
+				..Config::new(size.width, size.height, 30)
+			};
+			let mut enc = Openh264::new(&config).unwrap();
+
+			// Saturated red: the color the two matrices disagree most about, so a
+			// mislabeled stream is a visible bug rather than a rounding difference.
+			let rgba = [255u8, 0, 0, 255].repeat(size.pixels() as usize);
+			let surface = Surface::rgba(&rgba, size).unwrap();
+			let frame = Frame::new(surface, moq_net::Timestamp::from_micros(0).unwrap());
+
+			let encoded = enc.encode(&frame, true).unwrap();
+			let annexb = &encoded.first().expect("a keyframe").payload;
+
+			assert_eq!(declared_color(annexb), Some(described), "{size} SPS color description");
+
+			// The label has to match the pixels: same source of truth on both sides.
+			let i420 = frame.surface.to_i420().unwrap();
+			assert_eq!(i420.color(), Some(Color::infer(size)), "{size} converted pixels");
+		}
 	}
 }

--- a/rs/moq-video/src/encode/backend/videotoolbox.rs
+++ b/rs/moq-video/src/encode/backend/videotoolbox.rs
@@ -26,18 +26,24 @@ use objc2_core_media::{
 	CMVideoFormatDescriptionGetHEVCParameterSetAtIndex, kCMTimeInvalid, kCMVideoCodecType_H264, kCMVideoCodecType_HEVC,
 };
 use objc2_core_video::CVImageBuffer;
+use objc2_core_video::{
+	kCVImageBufferColorPrimaries_ITU_R_709_2, kCVImageBufferColorPrimaries_SMPTE_C,
+	kCVImageBufferTransferFunction_ITU_R_709_2, kCVImageBufferYCbCrMatrix_ITU_R_601_4,
+	kCVImageBufferYCbCrMatrix_ITU_R_709_2,
+};
 use objc2_video_toolbox::{
 	VTCompressionSession, VTEncodeInfoFlags, VTSessionSetProperty, kVTCompressionPropertyKey_AllowFrameReordering,
-	kVTCompressionPropertyKey_AverageBitRate, kVTCompressionPropertyKey_ExpectedFrameRate,
-	kVTCompressionPropertyKey_MaxKeyFrameInterval, kVTCompressionPropertyKey_ProfileLevel,
-	kVTCompressionPropertyKey_RealTime, kVTEncodeFrameOptionKey_ForceKeyFrame, kVTProfileLevel_H264_High_AutoLevel,
-	kVTProfileLevel_HEVC_Main_AutoLevel,
+	kVTCompressionPropertyKey_AverageBitRate, kVTCompressionPropertyKey_ColorPrimaries,
+	kVTCompressionPropertyKey_ExpectedFrameRate, kVTCompressionPropertyKey_MaxKeyFrameInterval,
+	kVTCompressionPropertyKey_ProfileLevel, kVTCompressionPropertyKey_RealTime,
+	kVTCompressionPropertyKey_TransferFunction, kVTCompressionPropertyKey_YCbCrMatrix,
+	kVTEncodeFrameOptionKey_ForceKeyFrame, kVTProfileLevel_H264_High_AutoLevel, kVTProfileLevel_HEVC_Main_AutoLevel,
 };
 
 use super::super::encoder::{Codec, Config};
 use super::{Backend, Encoded};
 use crate::frame::Surface;
-use crate::{Error, Frame};
+use crate::{Color, Error, Frame};
 
 pub(crate) const NAME: &str = "videotoolbox";
 
@@ -130,6 +136,34 @@ impl VideoToolbox {
 			unsafe { kVTCompressionPropertyKey_ExpectedFrameRate },
 			config.framerate as i32,
 		)?;
+
+		// State the color space in the SPS so a decoder doesn't fall back to
+		// guessing it from the frame height. BT.601 goes out as SMPTE C primaries
+		// and the 601 matrix (both code point 6) with the BT.709 transfer curve (1),
+		// since 601 and 709 differ in primaries and matrix, not in gamma. CoreVideo
+		// does have a 170M transfer constant, but it is deprecated, and Media
+		// Foundation has none, so 1 is what every backend emits.
+		let (primaries, transfer, matrix) = unsafe {
+			match config.resolved_color() {
+				Color::Bt601Limited | Color::Bt601Full => (
+					kCVImageBufferColorPrimaries_SMPTE_C,
+					kCVImageBufferTransferFunction_ITU_R_709_2,
+					kCVImageBufferYCbCrMatrix_ITU_R_601_4,
+				),
+				Color::Bt709Limited | Color::Bt709Full => (
+					kCVImageBufferColorPrimaries_ITU_R_709_2,
+					kCVImageBufferTransferFunction_ITU_R_709_2,
+					kCVImageBufferYCbCrMatrix_ITU_R_709_2,
+				),
+			}
+		};
+		set_property(&session, unsafe { kVTCompressionPropertyKey_ColorPrimaries }, primaries)?;
+		set_property(
+			&session,
+			unsafe { kVTCompressionPropertyKey_TransferFunction },
+			transfer,
+		)?;
+		set_property(&session, unsafe { kVTCompressionPropertyKey_YCbCrMatrix }, matrix)?;
 
 		let force_keyframe = force_keyframe_dict()?;
 

--- a/rs/moq-video/src/encode/encoder.rs
+++ b/rs/moq-video/src/encode/encoder.rs
@@ -7,7 +7,7 @@
 
 use super::Encoded;
 use super::backend::{self, Backend};
-use crate::{Error, Frame, Size};
+use crate::{Color, Error, Frame, Size};
 
 /// Output video codec. `#[non_exhaustive]` so new codecs can be added without
 /// breaking external `match`es.
@@ -65,6 +65,14 @@ pub struct Config {
 	/// Output codec. Defaults to [`Codec::H264`].
 	pub codec: Codec,
 	pub kind: Kind,
+	/// The color space of the input frames, written into the bitstream's VUI so a
+	/// decoder doesn't have to guess. `None` uses [`Color::infer`], which is both
+	/// what the crate's own RGB conversions produce and what a player falls back
+	/// to, so leaving it unset keeps the pixels and the label in agreement.
+	///
+	/// Set it only when feeding frames the crate did not convert and whose space
+	/// you know from elsewhere.
+	pub color: Option<Color>,
 }
 
 impl Config {
@@ -80,12 +88,21 @@ impl Config {
 			gop: framerate.saturating_mul(2).max(1),
 			codec: Codec::default(),
 			kind: Kind::Auto,
+			color: None,
 		}
 	}
 
 	/// The encoded resolution.
 	pub fn size(&self) -> Size {
 		Size::new(self.width, self.height)
+	}
+
+	/// Resolved input color space: explicit override, or the size-based guess
+	/// every player makes for an untagged stream. Backends write this into the
+	/// VUI; the crate's RGB conversions pick the same answer for the same size,
+	/// so the samples match what the bitstream claims.
+	pub(crate) fn resolved_color(&self) -> Color {
+		self.color.unwrap_or_else(|| Color::infer(self.size()))
 	}
 
 	/// Resolved bitrate: explicit override, or a pixels-per-second estimate.
@@ -106,6 +123,9 @@ pub struct Encoder {
 	codec: Codec,
 	size: Size,
 	bitrate: u64,
+	/// What the backend wrote into the bitstream's VUI, kept so a frame declaring
+	/// a different space is caught rather than silently mislabeled.
+	color: Color,
 	/// A keyframe asked for by [`Encoder::keyframe`], applied to the next frame.
 	/// Held rather than applied immediately because the caller decides a group
 	/// boundary before it has the frame that opens it.
@@ -131,6 +151,7 @@ impl Encoder {
 			codec: config.codec,
 			size,
 			bitrate: config.resolved_bitrate(),
+			color: config.resolved_color(),
 			pending_keyframe: false,
 		})
 	}
@@ -221,6 +242,27 @@ impl Encoder {
 				"frame {size} does not match encoder {}",
 				self.size
 			)));
+		}
+		// The VUI is fixed when the session opens, so a frame in a different space
+		// gets encoded under the wrong label. Reached by resizing across the
+		// standard-definition boundary, where the pixels keep their space but the
+		// encoder was sized into another one; `Config::color` is the way to pin it.
+		//
+		// Warn rather than reject: a live gateway transcoding a source whose VUI
+		// disagrees with its resolution should keep serving a mislabeled stream
+		// rather than drop it, and this is no worse than the untagged stream that
+		// came before. Once, because it would otherwise fire every frame.
+		if let Some(color) = frame.surface.color()
+			&& color != self.color
+		{
+			static WARN_ONCE: std::sync::Once = std::sync::Once::new();
+			WARN_ONCE.call_once(|| {
+				tracing::warn!(
+					frame = ?color,
+					encoder = ?self.color,
+					"frame color space differs from the one written into the bitstream; set encode::Config::color"
+				);
+			});
 		}
 		let encoded = self.backend.encode(frame, self.pending_keyframe)?;
 		// Cleared only once the frame is through: a failed encode produced no
@@ -803,6 +845,7 @@ mod tests {
 			codec: config.codec,
 			size: config.size(),
 			bitrate: config.resolved_bitrate(),
+			color: config.resolved_color(),
 			pending_keyframe: false,
 		}
 	}
@@ -980,5 +1023,91 @@ mod tests {
 				.unwrap()
 				.is_empty()
 		);
+	}
+
+	/// The hardware encoder states the color space too, and states the one the
+	/// pixels were actually converted into. VideoToolbox takes the three
+	/// properties as a request, so read the SPS back rather than trusting that it
+	/// honored them.
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn videotoolbox_sps_declares_the_color_space() {
+		use super::backend::test_util::{BT601_DESCRIBED, BT709_DESCRIBED, declared_color};
+
+		for (size, described) in [
+			(Size::new(640, 480), BT601_DESCRIBED),
+			(Size::new(1920, 1080), BT709_DESCRIBED),
+		] {
+			let config = Config {
+				kind: Kind::Named("videotoolbox".into()),
+				..Config::new(size.width, size.height, 30)
+			};
+			let mut encoder = Encoder::new(&config).expect("videotoolbox is available on macOS");
+
+			let rgba = [255u8, 0, 0, 255].repeat(size.pixels() as usize);
+			let surface = crate::frame::Surface::rgba(&rgba, size).unwrap();
+			encoder.keyframe();
+			let frames = encoder
+				.encode(&Frame::new(surface, moq_net::Timestamp::from_micros(0).unwrap()))
+				.unwrap();
+
+			let keyframe = frames.first().expect("a keyframe");
+			assert_eq!(declared_color(&keyframe.payload), Some(described), "{size} SPS");
+		}
+	}
+
+	/// Resizing across the standard-definition boundary keeps the pixels' color
+	/// space but moves the encoder into another one, which would emit BT.709
+	/// pixels under a BT.601 label. `Config::color` pins the real space, and the
+	/// bitstream then says so.
+	#[test]
+	fn config_color_pins_the_space_a_resize_carried() {
+		use crate::Color;
+
+		let big = Size::new(1280, 720);
+		let small = Size::new(640, 480);
+
+		// Converted at 720p, so the samples are BT.709.
+		let rgba = vec![0x80u8; big.pixels() as usize * 4];
+		let frame = Frame::new(
+			crate::frame::Surface::rgba(&rgba, big).unwrap(),
+			moq_net::Timestamp::from_micros(0).unwrap(),
+		);
+		let scaled = frame.resize(small).unwrap();
+		assert_eq!(
+			scaled.surface.color(),
+			Some(Color::Bt709Limited),
+			"resize keeps the space"
+		);
+
+		// Left to infer, a 480p encoder writes BT.601 over those BT.709 samples. It
+		// still encodes (a live gateway keeps serving) but the label is wrong, which
+		// is what `Config::color` exists to fix.
+		let config = Config {
+			kind: Kind::Software,
+			..Config::new(small.width, small.height, 30)
+		};
+		let mut encoder = Encoder::new(&config).unwrap();
+		encoder.keyframe();
+		let frames = encoder.encode(&scaled).expect("a mismatch warns rather than fails");
+		use super::backend::test_util::{BT601_DESCRIBED, BT709_DESCRIBED, declared_color};
+		assert_eq!(
+			declared_color(&frames.first().expect("a keyframe").payload),
+			Some(BT601_DESCRIBED),
+			"the inferred label is the wrong one, which is the case Config::color covers"
+		);
+
+		// Declaring the real space fixes the label.
+		let config = Config {
+			kind: Kind::Software,
+			color: Some(Color::Bt709Limited),
+			..Config::new(small.width, small.height, 30)
+		};
+		let mut encoder = Encoder::new(&config).unwrap();
+		encoder.keyframe();
+		let frames = encoder.encode(&scaled).expect("a declared space encodes");
+
+		let keyframe = frames.first().expect("a keyframe");
+		assert_eq!(declared_color(&keyframe.payload), Some(BT709_DESCRIBED));
 	}
 }

--- a/rs/moq-video/src/error.rs
+++ b/rs/moq-video/src/error.rs
@@ -31,6 +31,11 @@ pub enum Error {
 	#[error("encoder {0} cannot change bitrate while running")]
 	BitrateUnsupported(&'static str),
 
+	/// GPU rendering failure: building the pipeline, importing a frame's surface
+	/// as a texture, or the device itself.
+	#[error("render: {0}")]
+	Render(#[source] anyhow::Error),
+
 	/// Capture / encode / codec failure (the message carries the detail).
 	#[error(transparent)]
 	Codec(#[from] anyhow::Error),

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -21,7 +21,7 @@ use moq_net::Timestamp;
 
 use yuv::{YuvChromaSubsampling, YuvConversionMode, YuvPlanarImageMut, YuvRange, YuvStandardMatrix, rgba_to_yuv420};
 
-use crate::{Error, Size};
+use crate::{Color, Error, Size};
 
 /// One raw (uncompressed) video frame: the pixels plus when they are shown.
 ///
@@ -247,6 +247,11 @@ pub struct I420 {
 	pub(crate) height: u32,
 	/// Y plane (`width * height`) then U then V (`width/2 * height/2` each).
 	pub(crate) data: Vec<u8>,
+	/// The color space these samples are in, when it is known rather than
+	/// guessed. Set by the conversions that pick a matrix themselves; `None`
+	/// where the pixels only passed through (a decode, a camera) and the
+	/// bitstream's answer did not come with them.
+	pub(crate) color: Option<Color>,
 }
 
 impl I420 {
@@ -265,7 +270,12 @@ impl I420 {
 				data.len()
 			)));
 		}
-		Ok(Self { width, height, data })
+		Ok(Self {
+			width,
+			height,
+			data,
+			color: None,
+		})
 	}
 
 	/// The frame width in pixels.
@@ -281,6 +291,24 @@ impl I420 {
 	/// The packed planes, Y then U then V.
 	pub fn data(&self) -> &[u8] {
 		&self.data
+	}
+
+	/// The color space these samples are in, or `None` when the crate does not
+	/// know: the pixels came out of a decoder or a camera, and the bitstream's
+	/// color description did not travel with them.
+	///
+	/// Anything converting these samples to RGB needs an answer either way, so
+	/// treat `None` as "fall back to [`Color::infer`]" rather than "does not
+	/// matter". Use [`with_color`](Self::with_color) if you know better.
+	pub fn color(&self) -> Option<Color> {
+		self.color
+	}
+
+	/// Declare the color space of these samples, for a caller who knows it (the
+	/// stream's VUI, a camera's documented output) where the crate cannot.
+	pub fn with_color(mut self, color: Color) -> Self {
+		self.color = Some(color);
+		self
 	}
 
 	/// Tightly-packed I420 byte length for the given even dimensions.
@@ -357,7 +385,12 @@ impl I420 {
 			v_dst[row * cw..row * cw + cw].copy_from_slice(&v[row * uv_stride..row * uv_stride + cw]);
 		}
 
-		Self { width, height, data }
+		Self {
+			width,
+			height,
+			data,
+			color: None,
+		}
 	}
 
 	/// Convert tightly-packed RGB (`width * height * 3` bytes) to I420, BT.601
@@ -419,7 +452,12 @@ impl I420 {
 		data[..luma].copy_from_slice(&nv12[..luma]);
 		let (u_dst, v_dst) = data[luma..].split_at_mut(chroma);
 		deinterleave_uv(&nv12[luma..need], u_dst, v_dst);
-		Ok(Self { width, height, data })
+		Ok(Self {
+			width,
+			height,
+			data,
+			color: None,
+		})
 	}
 
 	/// Resize to `width` x `height` (both even) with a per-plane SIMD bilinear
@@ -472,17 +510,31 @@ impl I420 {
 			plane(resizer, self.v(), sw2, sh2, v_dst, dw2, dh2)
 		})?;
 
-		Ok(Self { width, height, data })
+		// Resampling moves samples around, it does not reinterpret them.
+		Ok(Self {
+			width,
+			height,
+			data,
+			color: self.color,
+		})
 	}
 
 	/// Flatten the three planes of a freshly-converted image into one tightly
 	/// packed I420 buffer (Y, then U, then V).
+	/// Every caller converts from RGB with `YuvRange::Limited` +
+	/// `YuvStandardMatrix::Bt601`, so the result's color space is known outright
+	/// rather than left to be guessed from the resolution downstream.
 	fn pack(planar: &YuvPlanarImageMut<u8>, width: u32, height: u32) -> Self {
 		let mut data = Vec::with_capacity(Self::len(width, height));
 		data.extend_from_slice(planar.y_plane.borrow());
 		data.extend_from_slice(planar.u_plane.borrow());
 		data.extend_from_slice(planar.v_plane.borrow());
-		Self { width, height, data }
+		Self {
+			width,
+			height,
+			data,
+			color: Some(Color::Bt601Limited),
+		}
 	}
 
 	fn luma_len(&self) -> usize {
@@ -554,7 +606,7 @@ pub mod macos {
 	use objc2_video_toolbox::VTPixelTransferSession;
 
 	use super::I420;
-	use crate::Error;
+	use crate::{Color, Error};
 
 	/// Read-only lock flag (`kCVPixelBufferLock_ReadOnly`).
 	const LOCK_READ_ONLY: CVPixelBufferLockFlags = CVPixelBufferLockFlags(1);
@@ -684,6 +736,10 @@ pub mod macos {
 		}
 
 		/// Download an NV12 surface to packed I420 (the CPU encode path).
+		///
+		/// A deinterleave, not a color conversion, so the samples keep whatever
+		/// space they arrived in. The pixel format names the range, which is
+		/// carried through; the matrix it does not, so that half stays inferred.
 		pub(crate) fn download_i420(&self) -> Result<I420, Error> {
 			let format = CVPixelBufferGetPixelFormatType(&self.buffer);
 			if format != kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
@@ -693,6 +749,9 @@ pub mod macos {
 					"cannot download pixel format {format:#x}; expected NV12"
 				)));
 			}
+
+			let limited = format == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange;
+			let color = Some(Color::infer(crate::Size::new(self.width, self.height)).with_range(limited));
 
 			let (w, h) = (self.width as usize, self.height as usize);
 			let (cw, ch) = (w / 2, h / 2);
@@ -735,6 +794,7 @@ pub mod macos {
 				width: self.width,
 				height: self.height,
 				data,
+				color,
 			})
 		}
 	}
@@ -1119,6 +1179,9 @@ pub mod cuda {
 				width: self.width,
 				height: self.height,
 				data,
+				// A deinterleave, not a color conversion, and nothing here names
+				// the space these samples are in. Left unknown to be inferred.
+				color: None,
 			})
 		}
 
@@ -1362,6 +1425,9 @@ pub mod d3d11 {
 				width: self.width,
 				height: self.height,
 				data,
+				// A deinterleave, not a color conversion, and nothing here names
+				// the space these samples are in. Left unknown to be inferred.
+				color: None,
 			})
 		}
 	}
@@ -1459,7 +1525,12 @@ mod tests {
 				v[row * cw + col] = (((row + col) * 255) / (ch + cw)) as u8;
 			}
 		}
-		I420 { width, height, data }
+		I420 {
+			width,
+			height,
+			data,
+			color: None,
+		}
 	}
 
 	/// Mean absolute error between two equal-length planes.

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -332,7 +332,7 @@ impl I420 {
 			YuvConversionMode::Balanced,
 		)
 		.map_err(|e| Error::Codec(anyhow::anyhow!("rgba_to_yuv420 failed for {width}x{height}: {e}")))?;
-		Ok(Self::pack(&planar, width, height))
+		Ok(Self::pack(&planar, width, height, Some(Color::Bt601Limited)))
 	}
 
 	/// Convert BGRA to I420, BT.601 limited range. `stride` is the source row
@@ -353,7 +353,7 @@ impl I420 {
 			YuvConversionMode::Balanced,
 		)
 		.map_err(|e| Error::Codec(anyhow::anyhow!("bgra_to_yuv420 failed for {width}x{height}: {e}")))?;
-		Ok(Self::pack(&planar, width, height))
+		Ok(Self::pack(&planar, width, height, Some(Color::Bt601Limited)))
 	}
 
 	/// Pack strided Y/U/V planes (4:2:0, full-size luma, half-size chroma) into a
@@ -409,7 +409,7 @@ impl I420 {
 			YuvConversionMode::Balanced,
 		)
 		.map_err(|e| Error::Codec(anyhow::anyhow!("rgb_to_yuv420 failed for {width}x{height}: {e}")))?;
-		Ok(Self::pack(&planar, width, height))
+		Ok(Self::pack(&planar, width, height, Some(Color::Bt601Limited)))
 	}
 
 	/// Convert packed YUYV (YUV 4:2:2, `stride` bytes per row) to I420. A chroma
@@ -428,7 +428,9 @@ impl I420 {
 		};
 		yuyv422_to_yuv420(&mut planar, &packed)
 			.map_err(|e| Error::Codec(anyhow::anyhow!("yuyv422_to_yuv420 failed for {width}x{height}: {e}")))?;
-		Ok(Self::pack(&planar, width, height))
+		// A chroma resample, not a color conversion: these samples are in
+		// whatever space the camera produced, which nothing here names.
+		Ok(Self::pack(&planar, width, height, None))
 	}
 
 	/// Split tightly-packed NV12 (Y plane `width * height`, then interleaved UV
@@ -521,10 +523,10 @@ impl I420 {
 
 	/// Flatten the three planes of a freshly-converted image into one tightly
 	/// packed I420 buffer (Y, then U, then V).
-	/// Every caller converts from RGB with `YuvRange::Limited` +
-	/// `YuvStandardMatrix::Bt601`, so the result's color space is known outright
-	/// rather than left to be guessed from the resolution downstream.
-	fn pack(planar: &YuvPlanarImageMut<u8>, width: u32, height: u32) -> Self {
+	/// `color` is what the caller's conversion produced: the RGB conversions pick
+	/// a matrix, so they know it outright, while a caller that only resamples
+	/// chroma passes `None` and leaves the samples' space open.
+	fn pack(planar: &YuvPlanarImageMut<u8>, width: u32, height: u32, color: Option<Color>) -> Self {
 		let mut data = Vec::with_capacity(Self::len(width, height));
 		data.extend_from_slice(planar.y_plane.borrow());
 		data.extend_from_slice(planar.u_plane.borrow());
@@ -533,7 +535,7 @@ impl I420 {
 			width,
 			height,
 			data,
-			color: Some(Color::Bt601Limited),
+			color,
 		}
 	}
 
@@ -1446,6 +1448,52 @@ pub mod d3d11 {
 
 #[cfg(test)]
 mod tests {
+	/// A conversion that picks a matrix says so; one that only moves samples
+	/// around must not.
+	///
+	/// The distinction decides whether a renderer trusts the frame or guesses
+	/// from the resolution, and guessing wrong tints saturated colors (see the
+	/// render module's HD test). Labeling everything with the RGB matrix would be
+	/// worse than labeling nothing: a 720p camera's BT.709 samples would be
+	/// pinned to BT.601 rather than inferring BT.709 correctly.
+	#[test]
+	fn only_a_real_color_conversion_labels_its_output() {
+		use super::I420;
+		use crate::{Color, Size};
+
+		let size = Size::new(64, 64);
+		let rgba = vec![0u8; size.pixels() as usize * 4];
+		let converted = I420::from_rgba(&rgba, size.width * 4, size.width, size.height).expect("rgba to i420");
+		assert_eq!(
+			converted.color(),
+			Some(Color::Bt601Limited),
+			"an RGB conversion knows the matrix it used"
+		);
+
+		// Resampling moves samples around; it does not reinterpret them.
+		let resized = converted.resize(32, 32).expect("resize");
+		assert_eq!(resized.color(), Some(Color::Bt601Limited), "resize preserves the space");
+
+		// A passthrough leaves it open for the consumer to infer.
+		let raw = I420::new(64, 64, vec![0; I420::len(64, 64)]).expect("i420");
+		assert_eq!(raw.color(), None);
+		assert_eq!(raw.with_color(Color::Bt709Full).color(), Some(Color::Bt709Full));
+	}
+
+	/// V4L2 hands back YUYV already in the camera's color space, so the 4:2:2 ->
+	/// 4:2:0 chroma resample must not claim it is BT.601: a 720p camera is
+	/// usually BT.709, and mislabeling pins it to the wrong matrix instead of
+	/// letting the resolution heuristic get it right.
+	#[cfg(target_os = "linux")]
+	#[test]
+	fn yuyv_capture_keeps_its_color_space_open() {
+		let (width, height) = (1280, 720);
+		// YUYV packs two pixels into four bytes.
+		let yuyv = vec![0u8; width as usize * height as usize * 2];
+		let frame = super::I420::from_yuyv(&yuyv, width * 2, width, height).expect("yuyv to i420");
+		assert_eq!(frame.color(), None, "a chroma resample names no color space");
+	}
+
 	/// A short buffer is rejected at construction rather than panicking later: the
 	/// plane splits in `y`/`u`/`v` and the CoreVideo upload both index blindly, so
 	/// a public `I420` has to be impossible to build malformed.

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 use bytes::Bytes;
 use moq_net::Timestamp;
 
-use yuv::{YuvChromaSubsampling, YuvConversionMode, YuvPlanarImageMut, YuvRange, YuvStandardMatrix, rgba_to_yuv420};
+use yuv::{YuvChromaSubsampling, YuvConversionMode, YuvPlanarImageMut, rgba_to_yuv420};
 
 use crate::{Color, Error, Size};
 
@@ -128,8 +128,9 @@ impl Surface {
 	}
 
 	/// Convert tightly-packed RGBA (`width * height * 4` bytes, no row padding) to
-	/// a CPU I420 surface, BT.601 limited range (what H.264 decoders expect by
-	/// default).
+	/// a CPU I420 surface in [`Color::infer`]'s color space for `size`, limited
+	/// range. The result reports it via [`I420::color`], and an encoder writes it
+	/// into the bitstream, so the pixels and their label cannot disagree.
 	///
 	/// The bring-your-own-pixels entry point: wrap the result in a [`Frame`] to
 	/// encode it. A capture source or decoder hands you a surface directly, often a
@@ -188,9 +189,12 @@ impl Surface {
 		})
 	}
 
-	/// The pixels as tightly-packed I420 (YUV 4:2:0, BT.601 limited range): Y
-	/// (`width * height` bytes), then U, then V (`width/2 * height/2` each), no row
-	/// padding.
+	/// The pixels as tightly-packed I420 (YUV 4:2:0): Y (`width * height` bytes),
+	/// then U, then V (`width/2 * height/2` each), no row padding.
+	///
+	/// Bytes only, so the color space does not come along. Take it from
+	/// [`I420::color`] first if you need to interpret these samples, since this
+	/// consumes the surface.
 	///
 	/// Always available, whichever variant you hold, so it is the universal arm of
 	/// a `match`. Free for `Surface::I420`; downloads any GPU surface.
@@ -222,6 +226,27 @@ impl Surface {
 		match self {
 			Surface::PixelBuffer(pixels) => Ok(pixels.buffer),
 			Surface::I420(i420) => macos::upload_i420(&i420),
+		}
+	}
+
+	/// The color space these samples are in, when it is known rather than
+	/// guessed. `None` for a GPU surface whose format names none, and for pixels
+	/// that merely passed through without anything naming their space.
+	///
+	/// Worth reading before encoding pixels you resized: [`resize`](Self::resize)
+	/// carries the space across, so a frame scaled past 576 lines no longer
+	/// matches what an encoder sized for the result would infer. Pass this to
+	/// [`encode::Config::color`](crate::encode::Config::color) to keep the label
+	/// honest.
+	pub fn color(&self) -> Option<Color> {
+		match self {
+			#[cfg(target_os = "macos")]
+			Surface::PixelBuffer(s) => s.color(),
+			#[cfg(target_os = "windows")]
+			Surface::Texture(_) => None,
+			#[cfg(all(target_os = "linux", feature = "nvdec"))]
+			Surface::Cuda(_) => None,
+			Surface::I420(i) => i.color(),
 		}
 	}
 
@@ -317,43 +342,34 @@ impl I420 {
 		luma + luma / 2
 	}
 
-	/// Convert RGBA (`stride` bytes per row, >= `width * 4`) to I420, BT.601
-	/// limited range (studio swing, what H.264 decoders expect by default). Used
-	/// by [`Surface::rgba`] (tightly packed) and
-	/// the screen-capture paths, whose surfaces carry a driver-chosen row pitch.
+	/// Convert RGBA (`stride` bytes per row, >= `width * 4`) to I420 in
+	/// [`Color::infer`]'s color space for this size, limited range. Used by
+	/// [`Surface::rgba`] (tightly packed) and the screen-capture paths, whose
+	/// surfaces carry a driver-chosen row pitch.
 	pub(crate) fn from_rgba(rgba: &[u8], stride: u32, width: u32, height: u32) -> Result<Self, Error> {
+		let color = Color::infer(Size::new(width, height));
+		let (range, matrix) = color.yuv();
 		let mut planar = YuvPlanarImageMut::alloc(width, height, YuvChromaSubsampling::Yuv420);
-		rgba_to_yuv420(
-			&mut planar,
-			rgba,
-			stride,
-			YuvRange::Limited,
-			YuvStandardMatrix::Bt601,
-			YuvConversionMode::Balanced,
-		)
-		.map_err(|e| Error::Codec(anyhow::anyhow!("rgba_to_yuv420 failed for {width}x{height}: {e}")))?;
-		Ok(Self::pack(&planar, width, height, Some(Color::Bt601Limited)))
+		rgba_to_yuv420(&mut planar, rgba, stride, range, matrix, YuvConversionMode::Balanced)
+			.map_err(|e| Error::Codec(anyhow::anyhow!("rgba_to_yuv420 failed for {width}x{height}: {e}")))?;
+		Ok(Self::pack(&planar, width, height, Some(color)))
 	}
 
-	/// Convert BGRA to I420, BT.601 limited range. `stride` is the source row
-	/// pitch in bytes (>= `width * 4`), so a padded surface maps directly. Used by
-	/// the screen-capture paths: Windows Desktop Duplication (BGRA staging
-	/// texture) and Linux PipeWire (BGRx/BGRA shared-memory buffers).
+	/// Convert BGRA to I420 in [`Color::infer`]'s color space for this size.
+	/// `stride` is the source row pitch in bytes (>= `width * 4`), so a padded
+	/// surface maps directly. Used by the screen-capture paths: Windows Desktop
+	/// Duplication (BGRA staging texture) and Linux PipeWire (BGRx/BGRA
+	/// shared-memory buffers).
 	#[cfg(any(target_os = "windows", all(target_os = "linux", feature = "pipewire")))]
 	pub(crate) fn from_bgra(bgra: &[u8], stride: u32, width: u32, height: u32) -> Result<Self, Error> {
 		use yuv::bgra_to_yuv420;
 
+		let color = Color::infer(Size::new(width, height));
+		let (range, matrix) = color.yuv();
 		let mut planar = YuvPlanarImageMut::alloc(width, height, YuvChromaSubsampling::Yuv420);
-		bgra_to_yuv420(
-			&mut planar,
-			bgra,
-			stride,
-			YuvRange::Limited,
-			YuvStandardMatrix::Bt601,
-			YuvConversionMode::Balanced,
-		)
-		.map_err(|e| Error::Codec(anyhow::anyhow!("bgra_to_yuv420 failed for {width}x{height}: {e}")))?;
-		Ok(Self::pack(&planar, width, height, Some(Color::Bt601Limited)))
+		bgra_to_yuv420(&mut planar, bgra, stride, range, matrix, YuvConversionMode::Balanced)
+			.map_err(|e| Error::Codec(anyhow::anyhow!("bgra_to_yuv420 failed for {width}x{height}: {e}")))?;
+		Ok(Self::pack(&planar, width, height, Some(color)))
 	}
 
 	/// Pack strided Y/U/V planes (4:2:0, full-size luma, half-size chroma) into a
@@ -393,23 +409,19 @@ impl I420 {
 		}
 	}
 
-	/// Convert tightly-packed RGB (`width * height * 3` bytes) to I420, BT.601
-	/// limited range. Used for MJPEG capture (Linux V4L2), which decodes to RGB.
+	/// Convert tightly-packed RGB (`width * height * 3` bytes) to I420 in
+	/// [`Color::infer`]'s color space for this size. Used for MJPEG capture
+	/// (Linux V4L2), which decodes to RGB.
 	#[cfg(target_os = "linux")]
 	pub(crate) fn from_rgb(rgb: &[u8], width: u32, height: u32) -> Result<Self, Error> {
 		use yuv::rgb_to_yuv420;
 
+		let color = Color::infer(Size::new(width, height));
+		let (range, matrix) = color.yuv();
 		let mut planar = YuvPlanarImageMut::alloc(width, height, YuvChromaSubsampling::Yuv420);
-		rgb_to_yuv420(
-			&mut planar,
-			rgb,
-			width * 3,
-			YuvRange::Limited,
-			YuvStandardMatrix::Bt601,
-			YuvConversionMode::Balanced,
-		)
-		.map_err(|e| Error::Codec(anyhow::anyhow!("rgb_to_yuv420 failed for {width}x{height}: {e}")))?;
-		Ok(Self::pack(&planar, width, height, Some(Color::Bt601Limited)))
+		rgb_to_yuv420(&mut planar, rgb, width * 3, range, matrix, YuvConversionMode::Balanced)
+			.map_err(|e| Error::Codec(anyhow::anyhow!("rgb_to_yuv420 failed for {width}x{height}: {e}")))?;
+		Ok(Self::pack(&planar, width, height, Some(color)))
 	}
 
 	/// Convert packed YUYV (YUV 4:2:2, `stride` bytes per row) to I420. A chroma
@@ -601,7 +613,8 @@ pub mod macos {
 	use objc2_core_video::{
 		CVPixelBuffer, CVPixelBufferCreate, CVPixelBufferGetBaseAddressOfPlane, CVPixelBufferGetBytesPerRowOfPlane,
 		CVPixelBufferGetPixelFormatType, CVPixelBufferLockBaseAddress, CVPixelBufferLockFlags, CVPixelBufferPool,
-		CVPixelBufferUnlockBaseAddress, kCVPixelBufferHeightKey, kCVPixelBufferIOSurfacePropertiesKey,
+		CVPixelBufferUnlockBaseAddress, kCVImageBufferYCbCrMatrix_ITU_R_601_4, kCVImageBufferYCbCrMatrix_ITU_R_709_2,
+		kCVImageBufferYCbCrMatrixKey, kCVPixelBufferHeightKey, kCVPixelBufferIOSurfacePropertiesKey,
 		kCVPixelBufferPixelFormatTypeKey, kCVPixelBufferWidthKey, kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
 		kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange, kCVPixelFormatType_420YpCbCr8Planar,
 	};
@@ -737,11 +750,57 @@ pub mod macos {
 			result
 		}
 
+		/// The color space this buffer's matrix attachment names, falling back to
+		/// [`Color::infer`] when it carries none.
+		///
+		/// VideoToolbox copies the matrix out of the stream's VUI onto every decoded
+		/// buffer, so this is the source's own answer wherever the source gave one.
+		/// The range is not in this attachment; the caller pairs it with the one the
+		/// pixel format names.
+		fn matrix(&self) -> Color {
+			let inferred = Color::infer(crate::Size::new(self.width, self.height));
+			// SAFETY: a null attachment mode is documented as "don't report it".
+			let Some(value) = (unsafe { self.buffer.attachment(kCVImageBufferYCbCrMatrixKey, ptr::null_mut()) }) else {
+				return inferred;
+			};
+			let Some(name) = value.downcast_ref::<CFString>() else {
+				return inferred;
+			};
+
+			// Compare against the constants rather than the string literals: these
+			// are CFString identities Apple owns, not values we should spell out.
+			if name == unsafe { kCVImageBufferYCbCrMatrix_ITU_R_709_2 } {
+				Color::Bt709Limited
+			} else if name == unsafe { kCVImageBufferYCbCrMatrix_ITU_R_601_4 } {
+				Color::Bt601Limited
+			} else {
+				// BT.2020 and the P3 matrices land here. We have no variant for them,
+				// so the size guess is the least wrong answer available.
+				inferred
+			}
+		}
+
+		/// The color space these samples are in: the matrix from the buffer's
+		/// attachment paired with the range its pixel format names. `None` for a
+		/// format that names neither.
+		pub(crate) fn color(&self) -> Option<Color> {
+			let format = CVPixelBufferGetPixelFormatType(&self.buffer);
+			let limited = if format == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange {
+				true
+			} else if format == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange {
+				false
+			} else {
+				return None;
+			};
+			Some(self.matrix().with_range(limited))
+		}
+
 		/// Download an NV12 surface to packed I420 (the CPU encode path).
 		///
 		/// A deinterleave, not a color conversion, so the samples keep whatever
-		/// space they arrived in. The pixel format names the range, which is
-		/// carried through; the matrix it does not, so that half stays inferred.
+		/// space they arrived in. The pixel format names the range and the buffer's
+		/// matrix attachment names the matrix, so a decoded frame reports the space
+		/// its own bitstream declared rather than one guessed from its size.
 		pub(crate) fn download_i420(&self) -> Result<I420, Error> {
 			let format = CVPixelBufferGetPixelFormatType(&self.buffer);
 			if format != kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
@@ -752,8 +811,7 @@ pub mod macos {
 				)));
 			}
 
-			let limited = format == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange;
-			let color = Some(Color::infer(crate::Size::new(self.width, self.height)).with_range(limited));
+			let color = self.color();
 
 			let (w, h) = (self.width as usize, self.height as usize);
 			let (cw, ch) = (w / 2, h / 2);
@@ -1521,6 +1579,64 @@ mod tests {
 		assert!(Surface::rgba(&ok[..ok.len() - 4], Size::new(64, 32)).is_err());
 		assert!(Surface::rgba(&ok, Size::new(32, 32)).is_err());
 		assert!(Surface::rgba(&ok, Size::new(0, 32)).is_err());
+	}
+
+	/// The conversion picks its matrix by resolution, matching what a player
+	/// assumes for an untagged stream, and reports the one it used.
+	///
+	/// The regression: every RGB conversion hardcoded BT.601. A 1080p screen
+	/// capture was converted with BT.601, encoded untagged, and decoded with the
+	/// BT.709 inverse, which turns pure red into roughly (255, 24, 0). Grays are
+	/// unaffected, which is why it survived casual inspection.
+	#[test]
+	fn rgb_conversion_follows_the_size_heuristic() {
+		use yuv::{YuvPlanarImage, yuv420_to_rgba};
+
+		use crate::Color;
+
+		let red = |size: Size| {
+			let rgba = [255u8, 0, 0, 255].repeat(size.pixels() as usize);
+			I420::from_rgba(&rgba, size.width * 4, size.width, size.height).unwrap()
+		};
+
+		// Decode with the matrix a player picks for an untagged stream of this
+		// size, and sample the middle of the frame.
+		let decode = |i420: &I420| {
+			let (w, h) = (i420.width, i420.height);
+			let (range, matrix) = Color::infer(Size::new(w, h)).yuv();
+			let planar = YuvPlanarImage {
+				y_plane: i420.y(),
+				y_stride: w,
+				u_plane: i420.u(),
+				u_stride: w / 2,
+				v_plane: i420.v(),
+				v_stride: w / 2,
+				width: w,
+				height: h,
+			};
+			let mut rgba = vec![0u8; (w * h * 4) as usize];
+			yuv420_to_rgba(&planar, &mut rgba, w * 4, range, matrix).unwrap();
+			let px = ((h / 2 * w + w / 2) * 4) as usize;
+			[rgba[px], rgba[px + 1], rgba[px + 2]]
+		};
+
+		for (size, expected) in [
+			(Size::new(720, 480), Color::Bt601Limited),
+			(Size::new(720, 576), Color::Bt601Limited),
+			(Size::new(1280, 720), Color::Bt709Limited),
+			(Size::new(1920, 1080), Color::Bt709Limited),
+		] {
+			let i420 = red(size);
+			assert_eq!(i420.color(), Some(expected), "{size} reported color");
+
+			// Red survives the round trip at every size. Before the fix the 720p and
+			// 1080p cases came back around (255, 24, 0).
+			let rgb = decode(&i420);
+			assert!(
+				rgb[1] <= 2 && rgb[2] <= 2,
+				"{size} red came back as {rgb:?}, so the matrix and the label disagree"
+			);
+		}
 	}
 
 	/// The frame's size comes from the surface rather than a field alongside it,

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -2,9 +2,9 @@
 //!
 //! Counterpart to [`moq-audio`](https://crates.io/crates/moq-audio) for video
 //! tracks, and shaped the same way: both split into `capture` / `encode` /
-//! `decode` role modules over a shared root [`Error`]. Sits on top of [`moq_mux`]
-//! (and the `hang` catalog) and adds the native pieces a desktop/CLI publisher
-//! needs.
+//! `decode` role modules over a shared root [`Error`], with `render` as video's
+//! fourth. Sits on top of [`moq_mux`] (and the `hang` catalog) and adds the
+//! native pieces a desktop/CLI publisher needs.
 //!
 //! A raw picture is a [`Frame`] wherever it crosses the API: a timestamp and a
 //! [`Surface`] holding the pixels. Capture and [`decode`] produce them, [`encode`]
@@ -39,6 +39,11 @@
 //!   NVDEC frame stays in CUDA memory and feeds [`encode::Encoder::encode`]
 //!   zero-copy (the transcode path), scaled in hardware via
 //!   [`decode::Config::resize`].
+//! - `render` draws a [`Frame`] on the GPU and hands back a `wgpu` texture to
+//!   present, importing a GPU frame's surface directly where the platform
+//!   allows and uploading I420 otherwise. Behind the non-default `render`
+//!   feature, since it pulls in a graphics stack a publisher or relay does not
+//!   need.
 //!
 //! ## API stability
 //!
@@ -61,7 +66,10 @@
 pub mod capture;
 pub mod decode;
 pub mod encode;
+#[cfg(feature = "render")]
+pub mod render;
 
+mod color;
 mod error;
 pub mod frame;
 mod size;
@@ -69,6 +77,7 @@ mod size;
 #[cfg(target_os = "windows")]
 mod mf;
 
+pub use color::Color;
 pub use error::Error;
 pub use frame::{Frame, I420, Surface};
 pub use size::Size;

--- a/rs/moq-video/src/render/color.rs
+++ b/rs/moq-video/src/render/color.rs
@@ -2,6 +2,22 @@
 
 use crate::Color;
 
+/// The luma/chroma weights (`kr`, `kb`) a matrix is derived from.
+///
+/// Lives here rather than on [`Color`] because deriving the matrix is the
+/// shader's business; the enum itself only names a space.
+fn weights(color: Color) -> (f32, f32) {
+	match color {
+		Color::Bt601Limited | Color::Bt601Full => (0.299, 0.114),
+		Color::Bt709Limited | Color::Bt709Full => (0.2126, 0.0722),
+	}
+}
+
+/// Whether luma is 16..235 rather than 0..255.
+fn limited(color: Color) -> bool {
+	matches!(color, Color::Bt601Limited | Color::Bt709Limited)
+}
+
 /// The uniform the shader multiplies each sample by: a column-major 3x3 matrix
 /// padded to WGSL's 16-byte column stride, then the offsets to subtract from
 /// (Y, U, V) before the multiply.
@@ -10,7 +26,7 @@ use crate::Color;
 /// magic constants means a new color space is two numbers, and the limited
 /// range scaling stays in one place.
 pub(super) fn uniform(color: Color) -> [f32; 16] {
-	let (kr, kb) = color.weights();
+	let (kr, kb) = weights(color);
 	let kg = 1.0 - kr - kb;
 	// The inverse of the RGB -> YCbCr matrix, which is fully determined by
 	// kr/kb: Cb and Cr are the blue/red difference scaled into +-0.5.
@@ -20,7 +36,7 @@ pub(super) fn uniform(color: Color) -> [f32; 16] {
 	// Limited range: luma spans 219 of 255 codes starting at 16, chroma 224
 	// centered on 128. Stretch both back to 0..1 so the matrix output is
 	// full-range RGB.
-	let y_offset = match color.limited() {
+	let y_offset = match limited(color) {
 		true => {
 			let (luma, chroma) = (255.0 / 219.0, 255.0 / 224.0);
 			y *= luma;
@@ -93,13 +109,13 @@ mod tests {
 		// shader's inverse brings it back. Catches a transposed or mis-scaled
 		// column, which a grayscale-only test would miss.
 		for color in [Color::Bt601Full, Color::Bt709Full, Color::Bt709Limited] {
-			let (kr, kb) = color.weights();
+			let (kr, kb) = weights(color);
 			let kg = 1.0 - kr - kb;
-			let (scale, offset) = match color.limited() {
+			let (scale, offset) = match limited(color) {
 				true => (219.0 / 255.0, 16.0 / 255.0),
 				false => (1.0, 0.0),
 			};
-			let chroma_scale = match color.limited() {
+			let chroma_scale = match limited(color) {
 				true => 224.0 / 255.0,
 				false => 1.0,
 			};

--- a/rs/moq-video/src/render/color.rs
+++ b/rs/moq-video/src/render/color.rs
@@ -1,0 +1,118 @@
+//! The YUV -> RGB conversion the shader applies, as the shader's uniform.
+
+use crate::Color;
+
+/// The uniform the shader multiplies each sample by: a column-major 3x3 matrix
+/// padded to WGSL's 16-byte column stride, then the offsets to subtract from
+/// (Y, U, V) before the multiply.
+///
+/// Deriving the matrix from `kr`/`kb` rather than pasting the usual table of
+/// magic constants means a new color space is two numbers, and the limited
+/// range scaling stays in one place.
+pub(super) fn uniform(color: Color) -> [f32; 16] {
+	let (kr, kb) = color.weights();
+	let kg = 1.0 - kr - kb;
+	// The inverse of the RGB -> YCbCr matrix, which is fully determined by
+	// kr/kb: Cb and Cr are the blue/red difference scaled into +-0.5.
+	let (mut y, mut cb, mut cr) = (1.0f32, 2.0 * (1.0 - kb), 2.0 * (1.0 - kr));
+	let (mut cb_g, mut cr_g) = (-cb * kb / kg, -cr * kr / kg);
+
+	// Limited range: luma spans 219 of 255 codes starting at 16, chroma 224
+	// centered on 128. Stretch both back to 0..1 so the matrix output is
+	// full-range RGB.
+	let y_offset = match color.limited() {
+		true => {
+			let (luma, chroma) = (255.0 / 219.0, 255.0 / 224.0);
+			y *= luma;
+			cb *= chroma;
+			cr *= chroma;
+			cb_g *= chroma;
+			cr_g *= chroma;
+			16.0 / 255.0
+		}
+		false => 0.0,
+	};
+
+	#[rustfmt::skip]
+	let uniform = [
+		// Column 0: the Y coefficient of R, G, B. Padded to vec4.
+		y, y, y, 0.0,
+		// Column 1: U (Cb).
+		0.0, cb_g, cb, 0.0,
+		// Column 2: V (Cr).
+		cr, cr_g, 0.0, 0.0,
+		// Offsets subtracted from (Y, U, V) before the multiply.
+		y_offset, 0.5, 0.5, 0.0,
+	];
+	uniform
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// Convert one YUV triple through the same math the shader runs, so the
+	/// expectations below read as pixels rather than matrix entries.
+	fn convert(color: Color, yuv: [f32; 3]) -> [f32; 3] {
+		let u = uniform(color);
+		let offset = [u[12], u[13], u[14]];
+		let (y, cb, cr) = (yuv[0] - offset[0], yuv[1] - offset[1], yuv[2] - offset[2]);
+		[
+			u[0] * y + u[4] * cb + u[8] * cr,
+			u[1] * y + u[5] * cb + u[9] * cr,
+			u[2] * y + u[6] * cb + u[10] * cr,
+		]
+	}
+
+	fn assert_rgb(actual: [f32; 3], expected: [f32; 3]) {
+		for (a, e) in actual.iter().zip(expected.iter()) {
+			assert!((a - e).abs() < 0.01, "got {actual:?}, expected {expected:?}");
+		}
+	}
+
+	#[test]
+	fn limited_range_black_and_white_reach_the_full_rgb_range() {
+		// The whole point of the range scaling: code 16 is black, 235 is white.
+		for color in [Color::Bt601Limited, Color::Bt709Limited] {
+			assert_rgb(convert(color, [16.0 / 255.0, 0.5, 0.5]), [0.0, 0.0, 0.0]);
+			assert_rgb(convert(color, [235.0 / 255.0, 0.5, 0.5]), [1.0, 1.0, 1.0]);
+		}
+	}
+
+	#[test]
+	fn full_range_maps_zero_and_one_straight_through() {
+		for color in [Color::Bt601Full, Color::Bt709Full] {
+			assert_rgb(convert(color, [0.0, 0.5, 0.5]), [0.0, 0.0, 0.0]);
+			assert_rgb(convert(color, [1.0, 0.5, 0.5]), [1.0, 1.0, 1.0]);
+		}
+	}
+
+	#[test]
+	fn primaries_round_trip_through_the_matrix() {
+		// Encode each primary to YUV with the forward matrix, then check the
+		// shader's inverse brings it back. Catches a transposed or mis-scaled
+		// column, which a grayscale-only test would miss.
+		for color in [Color::Bt601Full, Color::Bt709Full, Color::Bt709Limited] {
+			let (kr, kb) = color.weights();
+			let kg = 1.0 - kr - kb;
+			let (scale, offset) = match color.limited() {
+				true => (219.0 / 255.0, 16.0 / 255.0),
+				false => (1.0, 0.0),
+			};
+			let chroma_scale = match color.limited() {
+				true => 224.0 / 255.0,
+				false => 1.0,
+			};
+
+			for rgb in [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0], [0.3, 0.6, 0.9]] {
+				let luma = kr * rgb[0] + kg * rgb[1] + kb * rgb[2];
+				let yuv = [
+					luma * scale + offset,
+					(rgb[2] - luma) / (2.0 * (1.0 - kb)) * chroma_scale + 0.5,
+					(rgb[0] - luma) / (2.0 * (1.0 - kr)) * chroma_scale + 0.5,
+				];
+				assert_rgb(convert(color, yuv), rgb);
+			}
+		}
+	}
+}

--- a/rs/moq-video/src/render/metal.rs
+++ b/rs/moq-video/src/render/metal.rs
@@ -1,0 +1,246 @@
+//! Zero-copy import of a decoded `CVPixelBuffer` into `wgpu`, on macOS.
+//!
+//! VideoToolbox hands back IOSurface-backed pixel buffers, and Metal can address
+//! an IOSurface directly. `CVMetalTextureCache` is the bridge: it wraps one
+//! plane of a pixel buffer as an `MTLTexture` aliasing the same memory, and
+//! recycles those wrappers as the decoder cycles its pool. `wgpu` then adopts
+//! the texture through its `hal` seam. No download, no upload, no copy.
+//!
+//! The IOSurface backing is the load-bearing part: a pixel buffer allocated
+//! without it (a plain `CVPixelBufferCreate`, as
+//! [`Surface::into_pixel_buffer`](crate::Surface::into_pixel_buffer) does when
+//! uploading a CPU frame) has no handle Metal can address, and the import fails.
+//! Capture and decoder pools always set it, so frames off the fast path arrive
+//! importable; anything else lands on the CPU fallback, which is the right
+//! answer for pixels that were on the CPU to begin with.
+
+use std::ptr::NonNull;
+
+use objc2_core_foundation::CFRetained;
+use objc2_core_video::{
+	CVMetalTexture, CVMetalTextureCache, CVMetalTextureGetTexture, CVPixelBuffer, CVPixelBufferGetHeightOfPlane,
+	CVPixelBufferGetPixelFormatType, CVPixelBufferGetWidthOfPlane, kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+	kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange, kCVPixelFormatType_420YpCbCr8Planar,
+};
+use objc2_metal::{MTLPixelFormat, MTLTextureType};
+
+use super::source::{Layout, Source};
+use crate::frame::macos::PixelBuffer;
+use crate::{Color, Error, Size};
+
+fn err(message: impl std::fmt::Display) -> Error {
+	Error::Render(anyhow::anyhow!("{message}"))
+}
+
+/// Holds the CoreVideo wrapper for as long as wgpu keeps the texture made from
+/// it.
+///
+/// CoreVideo's contract is that the `CVMetalTexture` outlives the GPU's use of
+/// the `MTLTexture` inside it, and it is the wrapper (not the Metal texture)
+/// that holds the source `CVPixelBuffer` open. Release it when the import
+/// returns and the buffer goes back to the decoder's pool as soon as the caller
+/// drops the frame, free to be handed out and overwritten while a submitted draw
+/// is still sampling it. That is a torn frame under pool pressure and nothing at
+/// all when the pool is idle, which is the worst way for a bug to behave.
+///
+/// So the wrapper rides along in the texture's drop callback, which wgpu invokes
+/// once it no longer references the texture (after the submissions using it
+/// retire).
+struct Keepalive(#[expect(dead_code, reason = "held for its release, never read")] CFRetained<CVMetalTexture>);
+
+// SAFETY: CoreVideo objects are CoreFoundation types whose retain/release are
+// thread-safe. Nothing here dereferences the wrapper after construction; it is
+// moved into the drop callback and only ever dropped, which wgpu may do from
+// whichever thread retires the submission.
+unsafe impl Send for Keepalive {}
+unsafe impl Sync for Keepalive {}
+
+/// A `CVMetalTextureCache` bound to the renderer's Metal device.
+///
+/// Held across frames on purpose: the cache is what recycles the per-IOSurface
+/// texture wrappers, so recreating it per frame would defeat the point.
+pub(super) struct Import {
+	cache: CFRetained<CVMetalTextureCache>,
+}
+
+// SAFETY: CVMetalTextureCache is a CoreFoundation type with thread-safe
+// retain/release, and every use here goes through `&mut Import` (the renderer
+// owns exactly one), so the cache is never touched concurrently. objc2 leaves
+// CoreVideo types !Send out of conservatism, but a Renderer has to be movable
+// between threads like the rest of the crate's handles.
+unsafe impl Send for Import {}
+
+impl Import {
+	/// Build a texture cache on the same `MTLDevice` wgpu is rendering with.
+	///
+	/// Errors when the device is not a Metal one, which is how a caller running
+	/// wgpu's Vulkan or GL backend on macOS lands on the CPU path.
+	pub fn new(device: &wgpu::Device) -> Result<Self, Error> {
+		// SAFETY: the handle is only read to create the cache, and it is
+		// dropped before this returns, so nothing outlives the guard.
+		let metal = unsafe { device.as_hal::<wgpu::hal::api::Metal>() }
+			.ok_or_else(|| err("wgpu device is not a Metal device"))?;
+
+		let mut ptr: *mut CVMetalTextureCache = std::ptr::null_mut();
+		// SAFETY: no attribute dictionaries are passed (so there are no generics
+		// to get wrong), and `ptr` is a valid out-pointer for the duration.
+		let status = unsafe {
+			CVMetalTextureCache::create(
+				None,
+				None,
+				metal.raw_device(),
+				None,
+				NonNull::new(&mut ptr).expect("stack pointer is non-null"),
+			)
+		};
+		drop(metal);
+
+		let cache = NonNull::new(ptr)
+			.filter(|_| status == 0)
+			// SAFETY: CVMetalTextureCacheCreate returns a +1 reference.
+			.map(|ptr| unsafe { CFRetained::from_raw(ptr) })
+			.ok_or_else(|| err(format!("CVMetalTextureCacheCreate failed: {status}")))?;
+
+		Ok(Self { cache })
+	}
+
+	/// Alias each plane of `buffer` as a texture.
+	pub fn import(&mut self, device: &wgpu::Device, buffer: &PixelBuffer) -> Result<Source, Error> {
+		let size = Size::new(buffer.width(), buffer.height());
+		let format = CVPixelBufferGetPixelFormatType(buffer.buffer());
+
+		// The pixel format carries the range (video swing vs full swing); the
+		// matrix it does not, so that half stays inferred.
+		let (layout, range_is_full) = match format {
+			f if f == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange => (Layout::Nv12, false),
+			f if f == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange => (Layout::Nv12, true),
+			// Rare: a pool configured for planar output rather than the NV12
+			// every hardware decoder produces. Cheap to support and it keeps the
+			// import from being NV12-only by construction.
+			f if f == kCVPixelFormatType_420YpCbCr8Planar => (Layout::I420, false),
+			f => return Err(err(format!("cannot import pixel format {f:#x}"))),
+		};
+
+		let color = Color::infer(size).with_range(!range_is_full);
+
+		let (plane0, plane1, plane2) = match layout {
+			Layout::Nv12 => {
+				let y = self.plane(device, buffer, 0, MTLPixelFormat::R8Unorm, wgpu::TextureFormat::R8Unorm)?;
+				let uv = self.plane(
+					device,
+					buffer,
+					1,
+					MTLPixelFormat::RG8Unorm,
+					wgpu::TextureFormat::Rg8Unorm,
+				)?;
+				// The I420 binding goes unread by the NV12 shader, so it just
+				// needs something of the right kind bound.
+				(y, uv.clone(), uv)
+			}
+			Layout::I420 => (
+				self.plane(device, buffer, 0, MTLPixelFormat::R8Unorm, wgpu::TextureFormat::R8Unorm)?,
+				self.plane(device, buffer, 1, MTLPixelFormat::R8Unorm, wgpu::TextureFormat::R8Unorm)?,
+				self.plane(device, buffer, 2, MTLPixelFormat::R8Unorm, wgpu::TextureFormat::R8Unorm)?,
+			),
+		};
+
+		// Release the wrappers the cache has been holding for buffers the
+		// decoder has already recycled. Cheap, and skipping it grows the cache
+		// without bound.
+		self.cache.flush(0);
+
+		Ok(Source {
+			layout,
+			color,
+			plane0,
+			plane1,
+			plane2,
+		})
+	}
+
+	/// Wrap one plane as an `MTLTexture` and hand it to wgpu.
+	fn plane(
+		&self,
+		device: &wgpu::Device,
+		buffer: &PixelBuffer,
+		index: usize,
+		metal: MTLPixelFormat,
+		format: wgpu::TextureFormat,
+	) -> Result<wgpu::TextureView, Error> {
+		let image: &CVPixelBuffer = buffer.buffer();
+		let width = CVPixelBufferGetWidthOfPlane(image, index);
+		let height = CVPixelBufferGetHeightOfPlane(image, index);
+		if width == 0 || height == 0 {
+			return Err(err(format!("pixel buffer has no plane {index}")));
+		}
+
+		let mut ptr: *mut CVMetalTexture = std::ptr::null_mut();
+		// SAFETY: `image` is a live pixel buffer, no attribute dictionary is
+		// passed, the plane index is in range (checked above via its extent),
+		// and `ptr` is a valid out-pointer.
+		let status = unsafe {
+			CVMetalTextureCache::create_texture_from_image(
+				None,
+				&self.cache,
+				image,
+				None,
+				metal,
+				width,
+				height,
+				index,
+				NonNull::new(&mut ptr).expect("stack pointer is non-null"),
+			)
+		};
+		let texture = NonNull::new(ptr)
+			.filter(|_| status == 0)
+			// SAFETY: the create call returns a +1 reference.
+			.map(|ptr| unsafe { CFRetained::from_raw(ptr) })
+			.ok_or_else(|| err(format!("CVMetalTextureCacheCreateTextureFromImage failed: {status}")))?;
+
+		let raw =
+			CVMetalTextureGetTexture(&texture).ok_or_else(|| err("CVMetalTextureGetTexture returned no texture"))?;
+		let keepalive = Keepalive(texture);
+
+		let extent = wgpu::Extent3d {
+			width: width as u32,
+			height: height as u32,
+			depth_or_array_layers: 1,
+		};
+		let descriptor = wgpu::TextureDescriptor {
+			label: Some("moq-video imported plane"),
+			size: extent,
+			mip_level_count: 1,
+			sample_count: 1,
+			dimension: wgpu::TextureDimension::D2,
+			format,
+			usage: wgpu::TextureUsages::TEXTURE_BINDING,
+			view_formats: &[],
+		};
+
+		// SAFETY: the texture was created by CoreVideo on this device's
+		// MTLDevice as a 2D, single-level, single-layer texture of exactly this
+		// format and extent, matching `descriptor`. It holds decoded pixels, so
+		// it is initialized, and `RESOURCE` is the state a sampled texture is
+		// already in. `raw` transfers ownership of our retain into the texture,
+		// and the drop callback holds the CoreVideo wrapper for as long as wgpu
+		// keeps that texture (see `Keepalive`).
+		let texture = unsafe {
+			let hal = wgpu::hal::metal::Device::texture_from_raw(
+				raw,
+				format,
+				MTLTextureType::Type2D,
+				1,
+				1,
+				wgpu::hal::CopyExtent {
+					width: extent.width,
+					height: extent.height,
+					depth: 1,
+				},
+				Some(Box::new(move || drop(keepalive))),
+			);
+			device.create_texture_from_hal::<wgpu::hal::api::Metal>(hal, &descriptor, wgpu::TextureUses::RESOURCE)
+		};
+
+		Ok(texture.create_view(&Default::default()))
+	}
+}

--- a/rs/moq-video/src/render/metal.rs
+++ b/rs/moq-video/src/render/metal.rs
@@ -109,8 +109,8 @@ impl Import {
 		let size = Size::new(buffer.width(), buffer.height());
 		let format = CVPixelBufferGetPixelFormatType(buffer.buffer());
 
-		// The pixel format carries the range (video swing vs full swing); the
-		// matrix it does not, so that half stays inferred.
+		// The pixel format names the layout and the range (video swing vs full
+		// swing).
 		let (layout, range_is_full) = match format {
 			f if f == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange => (Layout::Nv12, false),
 			f if f == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange => (Layout::Nv12, true),
@@ -121,7 +121,13 @@ impl Import {
 			f => return Err(err(format!("cannot import pixel format {f:#x}"))),
 		};
 
-		let color = Color::infer(size).with_range(!range_is_full);
+		// The matrix comes off the buffer's own attachment, which VideoToolbox
+		// copies out of the stream's VUI, so an imported frame and the same frame
+		// downloaded to the CPU are read the same way. The planar format carries no
+		// such attachment, so it falls back to the size guess.
+		let color = buffer
+			.color()
+			.unwrap_or_else(|| Color::infer(size).with_range(!range_is_full));
 
 		let (plane0, plane1, plane2) = match layout {
 			Layout::Nv12 => {

--- a/rs/moq-video/src/render/mod.rs
+++ b/rs/moq-video/src/render/mod.rs
@@ -28,9 +28,9 @@
 //! A hardware-decoded frame is imported by aliasing the decoder's surface as a
 //! texture rather than copying it: `CVMetalTextureCache` on macOS, for the
 //! `PixelBuffer` variant of [`Surface`](crate::Surface) that capture and a
-//! VideoToolbox decode produce. (Named without a link because that variant only
-//! exists on macOS, and a link to it would dangle in the docs built for every
-//! other platform.)
+//! VideoToolbox decode produce.
+// `PixelBuffer` is deliberately not a doc link: the variant is macOS-only, so a
+// link to it fails the `-D warnings` rustdoc build on every other platform.
 //!
 //! Every other frame, and any import that fails, goes through
 //! [`Surface::into_i420`](crate::Surface::into_i420) and a plane upload. That

--- a/rs/moq-video/src/render/mod.rs
+++ b/rs/moq-video/src/render/mod.rs
@@ -1,0 +1,69 @@
+//! Draw decoded frames on the GPU, handing back a texture you present.
+//!
+//! The egress half of the zero-copy story, and the fourth role module alongside
+//! [`capture`](crate::capture), [`encode`](crate::encode) and
+//! [`decode`](crate::decode). [`decode`](crate::decode) keeps a hardware-decoded
+//! frame on the GPU; this draws it there too, converting YUV to RGB in a shader
+//! instead of downloading pixels to convert them on the CPU.
+//!
+//! [`Renderer::render`] returns a plain [`wgpu::Texture`], which is the whole
+//! integration seam: presenting it to a window, feeding it to egui or bevy, or
+//! copying it back is yours to do, so this module carries no windowing or UI
+//! dependency.
+//!
+//! ```no_run
+//! # fn example(device: &moq_video::render::wgpu::Device, queue: &moq_video::render::wgpu::Queue) -> Result<(), moq_video::Error> {
+//! use moq_video::render::{Config, Renderer};
+//!
+//! let mut renderer = Renderer::new(device, queue, Config::new())?;
+//! # let frame: moq_video::Frame = todo!();
+//! let texture = renderer.render(&frame)?;
+//! # let _ = texture;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Zero-copy
+//!
+//! A hardware-decoded frame is imported by aliasing the decoder's surface as a
+//! texture rather than copying it: `CVMetalTextureCache` on macOS, for a
+//! [`Surface::PixelBuffer`](crate::Surface::PixelBuffer) from capture or a
+//! VideoToolbox decode.
+//!
+//! Every other frame, and any import that fails, goes through
+//! [`Surface::into_i420`](crate::Surface::into_i420) and a plane upload. That
+//! path is always available, so a frame always renders. An import path that
+//! keeps failing (a driver that cannot do it at all) retires itself after a few
+//! frames rather than paying for the attempt forever.
+//!
+//! Enabled by the non-default `render` feature, which is what pulls in `wgpu`.
+
+mod color;
+mod renderer;
+mod source;
+
+#[cfg(target_os = "macos")]
+mod metal;
+
+pub use renderer::{Config, Renderer};
+
+/// The `wgpu` this renderer was built against, re-exported so you name the exact
+/// version rather than guessing at a compatible one.
+///
+/// [`Renderer::new`] takes this crate's `Device` and `Queue`, and
+/// [`Renderer::render`] hands back its `Texture`, so a major bump here is a
+/// breaking change for this crate.
+pub use wgpu;
+
+#[cfg(test)]
+mod tests {
+	/// An application typically decodes on one task and draws on another, so
+	/// the renderer has to cross threads like the rest of the crate's handles.
+	/// Compile-time check; fails per-platform if an imported GPU handle
+	/// regresses it.
+	#[test]
+	fn renderer_is_thread_safe() {
+		fn assert_send<T: Send>() {}
+		assert_send::<super::Renderer>();
+	}
+}

--- a/rs/moq-video/src/render/mod.rs
+++ b/rs/moq-video/src/render/mod.rs
@@ -26,15 +26,17 @@
 //! ## Zero-copy
 //!
 //! A hardware-decoded frame is imported by aliasing the decoder's surface as a
-//! texture rather than copying it: `CVMetalTextureCache` on macOS, for a
-//! [`Surface::PixelBuffer`](crate::Surface::PixelBuffer) from capture or a
-//! VideoToolbox decode.
+//! texture rather than copying it: `CVMetalTextureCache` on macOS, for the
+//! `PixelBuffer` variant of [`Surface`](crate::Surface) that capture and a
+//! VideoToolbox decode produce. (Named without a link because that variant only
+//! exists on macOS, and a link to it would dangle in the docs built for every
+//! other platform.)
 //!
 //! Every other frame, and any import that fails, goes through
 //! [`Surface::into_i420`](crate::Surface::into_i420) and a plane upload. That
-//! path is always available, so a frame always renders. An import path that
-//! keeps failing (a driver that cannot do it at all) retires itself after a few
-//! frames rather than paying for the attempt forever.
+//! path is always available, so which route a frame takes is a question of cost.
+//! An import path that keeps failing (a driver that cannot do it at all) retires
+//! itself after a few frames rather than paying for the attempt forever.
 //!
 //! Enabled by the non-default `render` feature, which is what pulls in `wgpu`.
 

--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -1,0 +1,690 @@
+//! The wgpu pipeline: plane textures in, one RGBA texture out.
+
+use super::color::uniform;
+use super::source::{self, Layout, Source};
+use crate::{Color, Error, Frame, Size};
+
+/// How many consecutive zero-copy import failures retire the fast path.
+///
+/// One failure is usually transient (a pool ran dry, a surface arrived in an
+/// unexpected format). A driver that cannot do the import at all fails every
+/// time, and retrying it per frame forever costs an allocation and a log line at
+/// frame rate, so the path is retired and the CPU fallback takes over.
+const ZERO_COPY_STRIKES: u32 = 3;
+
+/// Renderer configuration.
+///
+/// `#[non_exhaustive]`: build via [`Config::new`] (or `default()`) and set the
+/// fields you care about, so future knobs stay additive.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct Config {
+	/// Output texture size. `None` renders each frame at its own size, which
+	/// means the output texture is recreated whenever the stream changes
+	/// resolution. Set it to your target (a widget, a swapchain) to render at a
+	/// fixed size instead: the GPU scales for free while sampling.
+	///
+	/// The frame is stretched to fill the output. Aspect ratio is the caller's
+	/// policy, so pick a size that matches the frame's if you want it preserved.
+	pub size: Option<Size>,
+
+	/// Output texture format. Defaults to [`wgpu::TextureFormat::Rgba8Unorm`].
+	///
+	/// The renderer converts between color models (YUV to RGB), not between
+	/// transfer functions, so the output holds gamma-encoded values. Presenting
+	/// it to a non-sRGB surface is a straight copy. To sample it into a
+	/// linear-light pipeline, take an sRGB view: the matching
+	/// `*Srgb`/non-`Srgb` sibling of this format is always available as a view
+	/// format.
+	pub format: wgpu::TextureFormat,
+
+	/// Usages the output texture is created with, on top of the
+	/// `RENDER_ATTACHMENT | TEXTURE_BINDING` it always has. Add
+	/// [`wgpu::TextureUsages::COPY_SRC`] to read frames back.
+	pub usage: wgpu::TextureUsages,
+
+	/// How to interpret the frame's YUV samples. `None` infers it per frame from
+	/// the frame's size and, on a GPU surface, its pixel format. Set it when the
+	/// stream's color space is known.
+	pub color: Option<Color>,
+
+	/// Whether to import GPU frames zero-copy (aliasing the decoder's surface as
+	/// a texture) instead of downloading them to the CPU first. On by default.
+	///
+	/// A failing import path retires itself after a few strikes, so this is for
+	/// forcing the CPU path deliberately: comparing output, or working around a
+	/// driver without rebuilding.
+	pub zero_copy: bool,
+}
+
+impl Default for Config {
+	fn default() -> Self {
+		Self {
+			size: None,
+			format: wgpu::TextureFormat::Rgba8Unorm,
+			usage: wgpu::TextureUsages::empty(),
+			color: None,
+			zero_copy: true,
+		}
+	}
+}
+
+impl Config {
+	/// A default config: output at each frame's own size, `Rgba8Unorm`, inferred
+	/// color space, zero-copy on.
+	pub fn new() -> Self {
+		Self::default()
+	}
+}
+
+/// Draws decoded [`Frame`]s into a `wgpu` texture you present.
+///
+/// The egress end of the pipeline, and the seam an application integrates at:
+/// [`render`](Self::render) hands back a plain [`wgpu::Texture`], so what draws
+/// it (a swapchain blit, an egui image, a bevy material) stays entirely yours.
+///
+/// A GPU frame is imported without a round trip through the CPU where the
+/// platform allows it, and any frame the fast paths do not recognize falls back
+/// to uploading [`Surface::into_i420`](crate::Surface::into_i420). So which path
+/// a frame takes is a question of cost, not of whether it draws at all.
+///
+/// One renderer draws one video. It caches the pipeline, the plane textures and
+/// the output texture, so keep it alive across frames rather than rebuilding it
+/// per frame.
+pub struct Renderer {
+	device: wgpu::Device,
+	queue: wgpu::Queue,
+	config: Config,
+
+	shader: Pipelines,
+	uniform: wgpu::Buffer,
+	/// What the uniform buffer currently holds, so a steady stream writes it once.
+	color: Option<Color>,
+
+	source: source::Cache,
+	output: Option<wgpu::Texture>,
+
+	/// Consecutive zero-copy import failures, up to [`ZERO_COPY_STRIKES`].
+	strikes: u32,
+	/// Set once the fast path is retired for the life of this renderer.
+	retired: bool,
+}
+
+/// The compiled pipeline, one variant per plane layout, and everything they share.
+struct Pipelines {
+	layout: wgpu::BindGroupLayout,
+	sampler: wgpu::Sampler,
+	nv12: wgpu::RenderPipeline,
+	i420: wgpu::RenderPipeline,
+}
+
+impl Renderer {
+	/// Build a renderer on an existing `wgpu` device.
+	///
+	/// The device and queue are the application's: the renderer draws into
+	/// textures that application already owns, so it never creates a device of
+	/// its own. Both handles are cheap to clone and are kept.
+	pub fn new(device: &wgpu::Device, queue: &wgpu::Queue, config: Config) -> Result<Self, Error> {
+		if let Some(size) = config.size {
+			size.validate_nonzero("render output")?;
+		}
+
+		let shader = Pipelines::new(device, config.format)?;
+		let uniform = device.create_buffer(&wgpu::BufferDescriptor {
+			label: Some("moq-video color conversion"),
+			size: std::mem::size_of::<[f32; 16]>() as u64,
+			usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+			mapped_at_creation: false,
+		});
+
+		Ok(Self {
+			device: device.clone(),
+			queue: queue.clone(),
+			config,
+			shader,
+			uniform,
+			color: None,
+			source: source::Cache::default(),
+			output: None,
+			strikes: 0,
+			retired: false,
+		})
+	}
+
+	/// Draw `frame` and hand back the texture holding it.
+	///
+	/// The returned handle aliases a texture the renderer reuses, so the next
+	/// call overwrites what you are holding. Present or copy it before rendering
+	/// again.
+	pub fn render(&mut self, frame: &Frame) -> Result<wgpu::Texture, Error> {
+		let source = self.source(frame)?;
+		let color = self.config.color.unwrap_or(source.color);
+		if self.color != Some(color) {
+			self.queue
+				.write_buffer(&self.uniform, 0, bytemuck::cast_slice(&uniform(color)));
+			self.color = Some(color);
+		}
+
+		let output = self.output(frame.size())?;
+		let view = output.create_view(&wgpu::TextureViewDescriptor::default());
+
+		let bind = self.device.create_bind_group(&wgpu::BindGroupDescriptor {
+			label: Some("moq-video planes"),
+			layout: &self.shader.layout,
+			entries: &[
+				wgpu::BindGroupEntry {
+					binding: 0,
+					resource: self.uniform.as_entire_binding(),
+				},
+				wgpu::BindGroupEntry {
+					binding: 1,
+					resource: wgpu::BindingResource::Sampler(&self.shader.sampler),
+				},
+				wgpu::BindGroupEntry {
+					binding: 2,
+					resource: wgpu::BindingResource::TextureView(&source.plane0),
+				},
+				wgpu::BindGroupEntry {
+					binding: 3,
+					resource: wgpu::BindingResource::TextureView(&source.plane1),
+				},
+				wgpu::BindGroupEntry {
+					binding: 4,
+					resource: wgpu::BindingResource::TextureView(&source.plane2),
+				},
+			],
+		});
+
+		let pipeline = match source.layout {
+			Layout::Nv12 => &self.shader.nv12,
+			Layout::I420 => &self.shader.i420,
+		};
+
+		let mut encoder = self.device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+			label: Some("moq-video render"),
+		});
+		{
+			let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+				label: Some("moq-video yuv to rgb"),
+				color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+					view: &view,
+					resolve_target: None,
+					depth_slice: None,
+					ops: wgpu::Operations {
+						// The triangle covers every pixel, so there is nothing to clear.
+						load: wgpu::LoadOp::Load,
+						store: wgpu::StoreOp::Store,
+					},
+				})],
+				depth_stencil_attachment: None,
+				timestamp_writes: None,
+				occlusion_query_set: None,
+				multiview_mask: None,
+			});
+			pass.set_pipeline(pipeline);
+			pass.set_bind_group(0, &bind, &[]);
+			pass.draw(0..3, 0..1);
+		}
+		self.queue.submit([encoder.finish()]);
+
+		Ok(output)
+	}
+
+	/// Turn a frame into plane textures, preferring a zero-copy import and
+	/// falling back to a CPU upload.
+	fn source(&mut self, frame: &Frame) -> Result<Source, Error> {
+		if self.config.zero_copy && !self.retired {
+			match self.source.import(&self.device, &frame.surface) {
+				Ok(Some(source)) => {
+					self.strikes = 0;
+					return Ok(source);
+				}
+				// No import path for this surface on this platform. Not a
+				// failure, so it costs no strike: the CPU path is the answer
+				// for this surface and always will be.
+				Ok(None) => {}
+				Err(err) => {
+					self.strikes += 1;
+					self.retired = self.strikes >= ZERO_COPY_STRIKES;
+					match self.retired {
+						true => tracing::warn!(%err, "zero-copy import failed repeatedly; using the CPU path"),
+						false => tracing::debug!(%err, "zero-copy import failed; falling back to the CPU"),
+					}
+				}
+			}
+		}
+
+		self.source.upload(&self.device, &self.queue, frame)
+	}
+
+	/// The output texture, recreated when the size it should have changes.
+	fn output(&mut self, frame: Size) -> Result<wgpu::Texture, Error> {
+		let size = self.config.size.unwrap_or(frame);
+		if let Some(output) = &self.output
+			&& output.width() == size.width
+			&& output.height() == size.height
+		{
+			return Ok(output.clone());
+		}
+
+		size.validate_nonzero("render output")?;
+
+		// Let the caller reinterpret between the sRGB and non-sRGB siblings,
+		// since the samples are gamma-encoded either way. A format with no
+		// sibling maps to itself, and listing it twice is a validation error, so
+		// only the one that actually differs goes in.
+		let format = self.config.format;
+		let sibling = match format == format.add_srgb_suffix() {
+			true => format.remove_srgb_suffix(),
+			false => format.add_srgb_suffix(),
+		};
+		let view_formats: &[wgpu::TextureFormat] = match sibling == format {
+			true => &[],
+			false => &[sibling],
+		};
+
+		let texture = self.device.create_texture(&wgpu::TextureDescriptor {
+			label: Some("moq-video output"),
+			size: wgpu::Extent3d {
+				width: size.width,
+				height: size.height,
+				depth_or_array_layers: 1,
+			},
+			mip_level_count: 1,
+			sample_count: 1,
+			dimension: wgpu::TextureDimension::D2,
+			format,
+			usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING | self.config.usage,
+			view_formats,
+		});
+
+		self.output = Some(texture.clone());
+		Ok(texture)
+	}
+}
+
+impl Pipelines {
+	fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Result<Self, Error> {
+		let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+			label: Some("moq-video yuv"),
+			source: wgpu::ShaderSource::Wgsl(include_str!("shader.wgsl").into()),
+		});
+
+		let plane = |binding: u32| wgpu::BindGroupLayoutEntry {
+			binding,
+			visibility: wgpu::ShaderStages::FRAGMENT,
+			ty: wgpu::BindingType::Texture {
+				sample_type: wgpu::TextureSampleType::Float { filterable: true },
+				view_dimension: wgpu::TextureViewDimension::D2,
+				multisampled: false,
+			},
+			count: None,
+		};
+
+		let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+			label: Some("moq-video planes"),
+			entries: &[
+				wgpu::BindGroupLayoutEntry {
+					binding: 0,
+					visibility: wgpu::ShaderStages::FRAGMENT,
+					ty: wgpu::BindingType::Buffer {
+						ty: wgpu::BufferBindingType::Uniform,
+						has_dynamic_offset: false,
+						min_binding_size: None,
+					},
+					count: None,
+				},
+				wgpu::BindGroupLayoutEntry {
+					binding: 1,
+					visibility: wgpu::ShaderStages::FRAGMENT,
+					ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+					count: None,
+				},
+				plane(2),
+				plane(3),
+				plane(4),
+			],
+		});
+
+		let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+			label: Some("moq-video yuv"),
+			bind_group_layouts: &[Some(&layout)],
+			immediate_size: 0,
+		});
+
+		let pipeline = |entry: &str| {
+			device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+				label: Some("moq-video yuv to rgb"),
+				layout: Some(&pipeline_layout),
+				vertex: wgpu::VertexState {
+					module: &module,
+					entry_point: Some("vertex"),
+					compilation_options: Default::default(),
+					buffers: &[],
+				},
+				primitive: wgpu::PrimitiveState::default(),
+				depth_stencil: None,
+				multisample: wgpu::MultisampleState::default(),
+				fragment: Some(wgpu::FragmentState {
+					module: &module,
+					entry_point: Some(entry),
+					compilation_options: Default::default(),
+					targets: &[Some(wgpu::ColorTargetState {
+						format,
+						blend: None,
+						write_mask: wgpu::ColorWrites::ALL,
+					})],
+				}),
+				multiview_mask: None,
+				cache: None,
+			})
+		};
+
+		// Chroma is half resolution in both directions, so it is upsampled by
+		// the sampler rather than in the shader. Linear on luma too, since the
+		// output size need not match the frame's.
+		let sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+			label: Some("moq-video planes"),
+			address_mode_u: wgpu::AddressMode::ClampToEdge,
+			address_mode_v: wgpu::AddressMode::ClampToEdge,
+			address_mode_w: wgpu::AddressMode::ClampToEdge,
+			mag_filter: wgpu::FilterMode::Linear,
+			min_filter: wgpu::FilterMode::Linear,
+			mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+			..Default::default()
+		});
+
+		Ok(Self {
+			nv12: pipeline("nv12"),
+			i420: pipeline("i420"),
+			layout,
+			sampler,
+		})
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use moq_net::Timestamp;
+
+	use super::*;
+	use crate::Surface;
+
+	/// Every test here draws on a real GPU, which a headless CI runner does not
+	/// have (wgpu finds no adapter and `Renderer::new` never gets built). The
+	/// color math itself is covered by [`super::super::color`]'s tests, which
+	/// need no device and do run in CI.
+	async fn gpu() -> (wgpu::Device, wgpu::Queue) {
+		let instance = wgpu::Instance::default();
+		let adapter = instance
+			.request_adapter(&wgpu::RequestAdapterOptions::default())
+			.await
+			.expect("a GPU adapter");
+		adapter
+			.request_device(&wgpu::DeviceDescriptor::default())
+			.await
+			.expect("a GPU device")
+	}
+
+	/// A solid `rgba` frame of `size`, as a CPU I420 surface.
+	fn solid(size: Size, rgba: [u8; 4]) -> Frame {
+		let pixels: Vec<u8> = rgba.iter().copied().cycle().take(size.pixels() as usize * 4).collect();
+		let surface = Surface::rgba(&pixels, size).expect("a valid RGBA frame");
+		Frame::new(surface, Timestamp::ZERO)
+	}
+
+	/// Read an RGBA texture back to the CPU, honoring the 256-byte row
+	/// alignment `copy_texture_to_buffer` requires.
+	async fn readback(device: &wgpu::Device, queue: &wgpu::Queue, texture: &wgpu::Texture) -> Vec<[u8; 4]> {
+		let (width, height) = (texture.width(), texture.height());
+		let row = (width * 4).next_multiple_of(wgpu::COPY_BYTES_PER_ROW_ALIGNMENT);
+		let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+			label: Some("readback"),
+			size: (row * height) as u64,
+			usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+			mapped_at_creation: false,
+		});
+
+		let mut encoder = device.create_command_encoder(&Default::default());
+		encoder.copy_texture_to_buffer(
+			wgpu::TexelCopyTextureInfo {
+				texture,
+				mip_level: 0,
+				origin: wgpu::Origin3d::ZERO,
+				aspect: wgpu::TextureAspect::All,
+			},
+			wgpu::TexelCopyBufferInfo {
+				buffer: &buffer,
+				layout: wgpu::TexelCopyBufferLayout {
+					offset: 0,
+					bytes_per_row: Some(row),
+					rows_per_image: Some(height),
+				},
+			},
+			wgpu::Extent3d {
+				width,
+				height,
+				depth_or_array_layers: 1,
+			},
+		);
+		queue.submit([encoder.finish()]);
+
+		let (send, recv) = tokio::sync::oneshot::channel();
+		buffer.map_async(wgpu::MapMode::Read, .., |result| {
+			let _ = send.send(result);
+		});
+		device
+			.poll(wgpu::PollType::wait_indefinitely())
+			.expect("the copy to complete");
+		recv.await.expect("a mapping result").expect("a mapped buffer");
+
+		let view = buffer.slice(..).get_mapped_range().expect("a mapped range");
+		let mut pixels = Vec::with_capacity((width * height) as usize);
+		for y in 0..height as usize {
+			let start = y * row as usize;
+			for x in 0..width as usize {
+				let px = &view[start + x * 4..start + x * 4 + 4];
+				pixels.push([px[0], px[1], px[2], px[3]]);
+			}
+		}
+		pixels
+	}
+
+	fn assert_close(actual: [u8; 4], expected: [u8; 4]) {
+		// Two lossy conversions stack up: RGBA -> I420 on the way in (chroma
+		// subsampling plus 8-bit rounding) and the shader's matrix on the way
+		// out. A few codes of drift is the format, not a bug.
+		for channel in 0..3 {
+			let (a, e) = (actual[channel] as i32, expected[channel] as i32);
+			assert!((a - e).abs() <= 6, "got {actual:?}, expected about {expected:?}");
+		}
+		assert_eq!(actual[3], 255, "alpha should be opaque");
+	}
+
+	/// Above 576 lines the size heuristic guesses BT.709, but every RGB
+	/// conversion in this crate emits BT.601 limited whatever the resolution. So
+	/// an HD frame has to be converted back with the matrix it was actually made
+	/// with, not the one its size suggests, or saturated colors skew: red came
+	/// back as roughly (255, 25, 0) when the two disagreed.
+	///
+	/// The sibling tests all run at 64x64, which sits below the threshold where
+	/// the guess happens to agree, so only this one pins the behavior down.
+	/// Ignored: needs a GPU, which CI lacks. Run with `--ignored`.
+	#[tokio::test]
+	#[ignore]
+	async fn hd_frames_use_the_matrix_they_were_converted_with() {
+		let (device, queue) = gpu().await;
+		let size = Size::new(1280, 720);
+		let config = Config {
+			usage: wgpu::TextureUsages::COPY_SRC,
+			..Config::new()
+		};
+		let mut renderer = Renderer::new(&device, &queue, config).expect("a renderer");
+
+		// Saturated primaries, where a mismatched matrix shows up. A gray ramp
+		// would pass either way.
+		for rgba in [[255, 0, 0, 255], [0, 255, 0, 255], [0, 0, 255, 255]] {
+			let frame = solid(size, rgba);
+			assert_eq!(
+				frame.surface.to_i420().expect("i420").color(),
+				Some(crate::Color::Bt601Limited),
+				"the RGB conversion should report the space it used"
+			);
+
+			let texture = renderer.render(&frame).expect("a rendered frame");
+			let pixels = readback(&device, &queue, &texture).await;
+			assert_close(
+				pixels[(size.height as usize / 2) * size.width as usize + size.width as usize / 2],
+				rgba,
+			);
+		}
+	}
+
+	/// The universal path end to end: a CPU frame uploaded as three planes,
+	/// converted by the shader, read back. Ignored: needs a GPU, which CI lacks.
+	/// Run with `--ignored`.
+	#[tokio::test]
+	#[ignore]
+	async fn cpu_frames_survive_the_round_trip() {
+		let (device, queue) = gpu().await;
+		let size = Size::new(64, 64);
+		let config = Config {
+			usage: wgpu::TextureUsages::COPY_SRC,
+			..Config::new()
+		};
+		let mut renderer = Renderer::new(&device, &queue, config).expect("a renderer");
+
+		for rgba in [
+			[255, 0, 0, 255],
+			[0, 255, 0, 255],
+			[0, 0, 255, 255],
+			[255, 255, 255, 255],
+			[0, 0, 0, 255],
+			[77, 153, 230, 255],
+		] {
+			let texture = renderer.render(&solid(size, rgba)).expect("a rendered frame");
+			assert_eq!((texture.width(), texture.height()), (size.width, size.height));
+
+			let pixels = readback(&device, &queue, &texture).await;
+			// Sample the interior: the very edge of a subsampled solid color is
+			// still solid, but this keeps the assertion about conversion rather
+			// than about the sampler's clamp behavior.
+			assert_close(
+				pixels[(size.height as usize / 2) * size.width as usize + size.width as usize / 2],
+				rgba,
+			);
+		}
+	}
+
+	/// The output follows `Config::size` rather than the frame's, so a caller
+	/// can render straight into a fixed target. Ignored: needs a GPU. Run with
+	/// `--ignored`.
+	#[tokio::test]
+	#[ignore]
+	async fn config_size_overrides_the_frame_size() {
+		let (device, queue) = gpu().await;
+		let config = Config {
+			size: Some(Size::new(32, 16)),
+			usage: wgpu::TextureUsages::COPY_SRC,
+			..Config::new()
+		};
+		let mut renderer = Renderer::new(&device, &queue, config).expect("a renderer");
+
+		let texture = renderer
+			.render(&solid(Size::new(64, 64), [255, 0, 0, 255]))
+			.expect("a rendered frame");
+		assert_eq!((texture.width(), texture.height()), (32, 16));
+
+		let pixels = readback(&device, &queue, &texture).await;
+		assert_close(pixels[8 * 32 + 16], [255, 0, 0, 255]);
+	}
+
+	/// A pool-backed NV12 surface, shaped like a hardware decode's output.
+	#[cfg(target_os = "macos")]
+	fn pooled(size: Size, rgba: [u8; 4]) -> crate::Surface {
+		let uploaded = solid(size, rgba).surface.into_pixel_buffer().expect("a pixel buffer");
+		let planar =
+			crate::Surface::PixelBuffer(crate::frame::macos::PixelBuffer::new(uploaded, size.width, size.height));
+		// The transfer session's pool is NV12 and IOSurface-backed, which is what
+		// makes the result importable; a plain upload is neither.
+		planar.resize(size).expect("a transfer into the NV12 pool")
+	}
+
+	/// Rendering must survive the decoder recycling its buffers underneath us.
+	///
+	/// The hazard the import's keepalive exists for: a submitted draw still
+	/// samples a surface after the caller drops the frame, so if nothing holds
+	/// the pixel buffer open the pool can hand it out and overwrite it mid-draw.
+	/// Each frame here comes from the same fixed-size pool, so buffers do get
+	/// recycled, and each is dropped immediately after `render` returns.
+	///
+	/// A race, so passing is evidence rather than proof. It fails loudly when the
+	/// keepalive is missing and the pool turns over fast enough. Ignored: needs a
+	/// GPU. Run with `--ignored`.
+	#[cfg(target_os = "macos")]
+	#[tokio::test]
+	#[ignore]
+	async fn imports_survive_decoder_pool_recycling() {
+		let (device, queue) = gpu().await;
+		let size = Size::new(256, 256);
+		let config = Config {
+			usage: wgpu::TextureUsages::COPY_SRC,
+			..Config::new()
+		};
+		let mut renderer = Renderer::new(&device, &queue, config).expect("a renderer");
+
+		let colors = [[255, 0, 0, 255], [0, 255, 0, 255], [0, 0, 255, 255], [255, 255, 0, 255]];
+		for round in 0..24 {
+			let rgba = colors[round % colors.len()];
+			// Built and dropped inside the loop, so its buffer returns to the
+			// pool the moment `render` returns.
+			let texture = renderer
+				.render(&Frame::new(pooled(size, rgba), Timestamp::ZERO))
+				.expect("a rendered frame");
+			assert_eq!(renderer.strikes, 0, "round {round} fell back to the CPU");
+
+			let pixels = readback(&device, &queue, &texture).await;
+			assert_close(pixels[128 * 256 + 128], rgba);
+		}
+	}
+
+	/// The zero-copy import has to produce the same pixels as the upload, or the
+	/// fallback would silently change what the user sees. Ignored: needs a GPU.
+	/// Run with `--ignored`.
+	#[cfg(target_os = "macos")]
+	#[tokio::test]
+	#[ignore]
+	async fn the_metal_import_matches_the_cpu_path() {
+		let (device, queue) = gpu().await;
+		let size = Size::new(64, 64);
+		let rgba = [77, 153, 230, 255];
+		let config = Config {
+			usage: wgpu::TextureUsages::COPY_SRC,
+			..Config::new()
+		};
+
+		let uploaded = {
+			let mut renderer = Renderer::new(&device, &queue, config.clone()).expect("a renderer");
+			let texture = renderer.render(&solid(size, rgba)).expect("a rendered frame");
+			readback(&device, &queue, &texture).await
+		};
+
+		// The surface a hardware decode hands back: NV12 and IOSurface-backed.
+		let surface = pooled(size, rgba);
+
+		let mut renderer = Renderer::new(&device, &queue, config).expect("a renderer");
+		let texture = renderer
+			.render(&Frame::new(surface, Timestamp::ZERO))
+			.expect("a rendered frame");
+		// The point of the test: the fast path ran. Without this the CPU
+		// fallback would quietly satisfy every assertion below.
+		assert_eq!(renderer.strikes, 0, "the zero-copy import should not have failed");
+		assert!(!renderer.retired);
+
+		let imported = readback(&device, &queue, &texture).await;
+		assert_eq!(uploaded.len(), imported.len());
+		for (upload, import) in uploaded.iter().zip(imported.iter()) {
+			assert_close(*import, *upload);
+		}
+	}
+}

--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -43,9 +43,15 @@ pub struct Config {
 	/// [`wgpu::TextureUsages::COPY_SRC`] to read frames back.
 	pub usage: wgpu::TextureUsages,
 
-	/// How to interpret the frame's YUV samples. `None` infers it per frame from
-	/// the frame's size and, on a GPU surface, its pixel format. Set it when the
-	/// stream's color space is known.
+	/// How to interpret the frame's YUV samples, overriding what the frame says
+	/// about itself.
+	///
+	/// `None` takes the frame's own [`I420::color`](crate::I420::color), or the
+	/// range its GPU pixel format names, and falls back to
+	/// [`Color::infer`](crate::Color::infer) for pixels that carry neither. Set
+	/// it when you know the stream's color space and the frame does not, which is
+	/// whenever it came off the wire: the authoritative answer is in the
+	/// bitstream's VUI and does not survive decoding.
 	pub color: Option<Color>,
 
 	/// Whether to import GPU frames zero-copy (aliasing the decoder's surface as

--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -513,18 +513,22 @@ mod tests {
 		assert_eq!(actual[3], 255, "alpha should be opaque");
 	}
 
-	/// Above 576 lines the size heuristic guesses BT.709, but every RGB
-	/// conversion in this crate emits BT.601 limited whatever the resolution. So
-	/// an HD frame has to be converted back with the matrix it was actually made
-	/// with, not the one its size suggests, or saturated colors skew: red came
-	/// back as roughly (255, 25, 0) when the two disagreed.
+	/// The frame's declared color space wins over the guess its size would
+	/// suggest, or saturated colors skew: red came back as roughly (255, 25, 0)
+	/// when the two disagreed.
 	///
-	/// The sibling tests all run at 64x64, which sits below the threshold where
-	/// the guess happens to agree, so only this one pins the behavior down.
-	/// Ignored: needs a GPU, which CI lacks. Run with `--ignored`.
+	/// The crate's RGB conversions now convert *into* the inferred space, so the
+	/// two agree by construction and that half of this cannot fail on its own.
+	/// The second half is the one with teeth: a frame converted at SD and scaled
+	/// past 576 lines keeps its BT.601 samples while its size says BT.709, which
+	/// is exactly the case `Surface::color` exists to report.
+	///
+	/// The sibling tests all run at 64x64, below the threshold where the guess
+	/// happens to agree. Ignored: needs a GPU, which CI lacks. Run with
+	/// `--ignored`.
 	#[tokio::test]
 	#[ignore]
-	async fn hd_frames_use_the_matrix_they_were_converted_with() {
+	async fn the_declared_color_space_beats_the_size_guess() {
 		let (device, queue) = gpu().await;
 		let size = Size::new(1280, 720);
 		let config = Config {
@@ -538,17 +542,32 @@ mod tests {
 		for rgba in [[255, 0, 0, 255], [0, 255, 0, 255], [0, 0, 255, 255]] {
 			let frame = solid(size, rgba);
 			assert_eq!(
-				frame.surface.to_i420().expect("i420").color(),
-				Some(crate::Color::Bt601Limited),
-				"the RGB conversion should report the space it used"
+				frame.surface.color(),
+				Some(crate::Color::infer(size)),
+				"the RGB conversion reports the space it converted into"
 			);
 
 			let texture = renderer.render(&frame).expect("a rendered frame");
 			let pixels = readback(&device, &queue, &texture).await;
-			assert_close(
-				pixels[(size.height as usize / 2) * size.width as usize + size.width as usize / 2],
-				rgba,
+			let center = (size.height as usize / 2) * size.width as usize + size.width as usize / 2;
+			assert_close(pixels[center], rgba);
+
+			// Convert at SD, where the crate picks BT.601, then scale past the
+			// threshold. The samples stay BT.601 while the size now implies
+			// BT.709, so rendering by size alone skews this back.
+			let sd = solid(Size::new(640, 480), rgba);
+			assert_eq!(sd.surface.color(), Some(crate::Color::Bt601Limited));
+			let scaled = sd.resize(size).expect("scale past 576 lines");
+			assert_eq!(
+				scaled.surface.color(),
+				Some(crate::Color::Bt601Limited),
+				"resize carries the space across rather than re-guessing"
 			);
+			assert_ne!(scaled.surface.color(), Some(crate::Color::infer(size)));
+
+			let texture = renderer.render(&scaled).expect("a rendered frame");
+			let pixels = readback(&device, &queue, &texture).await;
+			assert_close(pixels[center], rgba);
 		}
 	}
 

--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -114,6 +114,10 @@ pub struct Renderer {
 struct Pipelines {
 	layout: wgpu::BindGroupLayout,
 	sampler: wgpu::Sampler,
+	/// Paired with [`Layout::Nv12`], so it exists only where an importer can
+	/// hand back that layout. The shader still declares the entry point
+	/// everywhere, so it stays validated on every platform either way.
+	#[cfg(target_os = "macos")]
 	nv12: wgpu::RenderPipeline,
 	i420: wgpu::RenderPipeline,
 }
@@ -196,6 +200,7 @@ impl Renderer {
 		});
 
 		let pipeline = match source.layout {
+			#[cfg(target_os = "macos")]
 			Layout::Nv12 => &self.shader.nv12,
 			Layout::I420 => &self.shader.i420,
 		};
@@ -395,6 +400,7 @@ impl Pipelines {
 		});
 
 		Ok(Self {
+			#[cfg(target_os = "macos")]
 			nv12: pipeline("nv12"),
 			i420: pipeline("i420"),
 			layout,

--- a/rs/moq-video/src/render/shader.wgsl
+++ b/rs/moq-video/src/render/shader.wgsl
@@ -1,0 +1,60 @@
+// YUV 4:2:0 -> RGB, for the two plane layouts the renderer feeds it: NV12 (luma
+// plane + interleaved chroma plane) and I420 (three separate planes).
+//
+// Chroma is sampled with a linear filter, so the half-resolution planes are
+// upsampled by the texture unit rather than in here. Output is gamma-encoded
+// R'G'B', the same encoding the samples arrived in: this converts between color
+// models, not between transfer functions.
+
+struct Params {
+	// Columns multiply Y, U and V respectively.
+	matrix: mat3x3<f32>,
+	// Subtracted from (Y, U, V) before the multiply: the black level and the
+	// chroma midpoint.
+	offset: vec4<f32>,
+}
+
+@group(0) @binding(0) var<uniform> params: Params;
+@group(0) @binding(1) var samp: sampler;
+@group(0) @binding(2) var plane0: texture_2d<f32>;
+@group(0) @binding(3) var plane1: texture_2d<f32>;
+// Unused by the NV12 entry point, which binds plane1 here as filler so one bind
+// group layout serves both.
+@group(0) @binding(4) var plane2: texture_2d<f32>;
+
+struct Vertex {
+	@builtin(position) position: vec4<f32>,
+	@location(0) uv: vec2<f32>,
+}
+
+// A single oversized triangle covering the viewport. Cheaper than a quad (no
+// index buffer, no diagonal seam) and it needs no vertex buffer at all.
+@vertex
+fn vertex(@builtin(vertex_index) index: u32) -> Vertex {
+	var out: Vertex;
+	let uv = vec2<f32>(f32((index << 1u) & 2u), f32(index & 2u));
+	out.uv = uv;
+	out.position = vec4<f32>(uv * vec2<f32>(2.0, -2.0) + vec2<f32>(-1.0, 1.0), 0.0, 1.0);
+	return out;
+}
+
+fn convert(yuv: vec3<f32>) -> vec4<f32> {
+	let rgb = params.matrix * (yuv - params.offset.xyz);
+	return vec4<f32>(clamp(rgb, vec3<f32>(0.0), vec3<f32>(1.0)), 1.0);
+}
+
+@fragment
+fn nv12(in: Vertex) -> @location(0) vec4<f32> {
+	let y = textureSample(plane0, samp, in.uv).r;
+	// One two-channel plane holds U and V interleaved.
+	let uv = textureSample(plane1, samp, in.uv).rg;
+	return convert(vec3<f32>(y, uv.r, uv.g));
+}
+
+@fragment
+fn i420(in: Vertex) -> @location(0) vec4<f32> {
+	let y = textureSample(plane0, samp, in.uv).r;
+	let u = textureSample(plane1, samp, in.uv).r;
+	let v = textureSample(plane2, samp, in.uv).r;
+	return convert(vec3<f32>(y, u, v));
+}

--- a/rs/moq-video/src/render/source.rs
+++ b/rs/moq-video/src/render/source.rs
@@ -7,7 +7,10 @@ use crate::{Color, Error, Frame, Size, Surface};
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum Layout {
 	/// Luma plane plus one interleaved chroma plane. What every hardware
-	/// decoder hands back.
+	/// decoder hands back, so only a zero-copy import produces it: the CPU
+	/// upload path is always I420. Gated to the platforms that have such an
+	/// importer, which today means macOS alone.
+	#[cfg(target_os = "macos")]
 	Nv12,
 	/// Three separate planes.
 	I420,

--- a/rs/moq-video/src/render/source.rs
+++ b/rs/moq-video/src/render/source.rs
@@ -18,7 +18,7 @@ pub(super) enum Layout {
 
 /// One frame's planes, bound and sampled as-is.
 ///
-/// `plane2` is unused by [`Layout::Nv12`], where it holds a copy of `plane1` so
+/// `plane2` is unused by the NV12 layout, where it holds a copy of `plane1` so
 /// that one bind group layout serves both shaders.
 pub(super) struct Source {
 	pub layout: Layout,

--- a/rs/moq-video/src/render/source.rs
+++ b/rs/moq-video/src/render/source.rs
@@ -1,0 +1,162 @@
+//! Getting a frame's pixels into textures the shader can sample: a zero-copy
+//! import where the platform offers one, a CPU upload everywhere else.
+
+use crate::{Color, Error, Frame, Size, Surface};
+
+/// How the planes of a [`Source`] are arranged, which picks the fragment shader.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum Layout {
+	/// Luma plane plus one interleaved chroma plane. What every hardware
+	/// decoder hands back.
+	Nv12,
+	/// Three separate planes.
+	I420,
+}
+
+/// One frame's planes, bound and sampled as-is.
+///
+/// `plane2` is unused by [`Layout::Nv12`], where it holds a copy of `plane1` so
+/// that one bind group layout serves both shaders.
+pub(super) struct Source {
+	pub layout: Layout,
+	pub color: Color,
+	pub plane0: wgpu::TextureView,
+	pub plane1: wgpu::TextureView,
+	pub plane2: wgpu::TextureView,
+}
+
+/// The renderer's per-frame GPU state: the CPU path's plane textures, plus
+/// whatever the platform's zero-copy importer needs to keep between frames.
+#[derive(Default)]
+pub(super) struct Cache {
+	planes: Option<Planes>,
+	/// Built on first use, since it needs the device's underlying `MTLDevice`.
+	#[cfg(target_os = "macos")]
+	metal: Option<super::metal::Import>,
+}
+
+/// Three single-channel textures: Y at full size, U and V at quarter size.
+struct Planes {
+	size: Size,
+	y: wgpu::Texture,
+	u: wgpu::Texture,
+	v: wgpu::Texture,
+	views: [wgpu::TextureView; 3],
+}
+
+impl Cache {
+	/// Try to alias a GPU frame's memory as textures, no download.
+	///
+	/// `Ok(None)` means this surface has no import path here (it is a CPU frame,
+	/// or the platform's importer is not built), which is a routing decision
+	/// rather than a failure. `Err` means an import that should have worked did
+	/// not, which is what the caller counts strikes against.
+	pub fn import(&mut self, device: &wgpu::Device, surface: &Surface) -> Result<Option<Source>, Error> {
+		match surface {
+			#[cfg(target_os = "macos")]
+			Surface::PixelBuffer(buffer) => {
+				let metal = match &mut self.metal {
+					Some(metal) => metal,
+					None => self.metal.insert(super::metal::Import::new(device)?),
+				};
+				metal.import(device, buffer).map(Some)
+			}
+			_ => {
+				let _ = device;
+				Ok(None)
+			}
+		}
+	}
+
+	/// Download the frame if it is not already on the CPU, then upload its
+	/// planes. The path every surface can take, and the one a failed or absent
+	/// import falls back to. It still fails for a GPU surface holding a pixel
+	/// format the crate cannot download, which is the honest answer: those
+	/// pixels are not reachable at all rather than merely expensive.
+	pub fn upload(&mut self, device: &wgpu::Device, queue: &wgpu::Queue, frame: &Frame) -> Result<Source, Error> {
+		let i420 = frame.surface.to_i420()?;
+		let size = Size::new(i420.width(), i420.height());
+		size.validate("render source")?;
+
+		if self.planes.as_ref().is_none_or(|planes| planes.size != size) {
+			self.planes = Some(Planes::new(device, size));
+		}
+		let planes = self.planes.as_ref().expect("planes were just created");
+
+		let half = Size::new(size.width / 2, size.height / 2);
+		write(queue, &planes.y, size, i420.y());
+		write(queue, &planes.u, half, i420.u());
+		write(queue, &planes.v, half, i420.v());
+
+		let [plane0, plane1, plane2] = planes.views.clone();
+		Ok(Source {
+			layout: Layout::I420,
+			// The conversion that produced these samples says which space they
+			// are in where it knows. Only a passthrough (a decode, a camera)
+			// leaves it open, and then the resolution is all there is to go on.
+			color: i420.color().unwrap_or_else(|| Color::infer(size)),
+			plane0,
+			plane1,
+			plane2,
+		})
+	}
+}
+
+impl Planes {
+	fn new(device: &wgpu::Device, size: Size) -> Self {
+		let plane = |label: &str, size: Size| {
+			device.create_texture(&wgpu::TextureDescriptor {
+				label: Some(label),
+				size: wgpu::Extent3d {
+					width: size.width,
+					height: size.height,
+					depth_or_array_layers: 1,
+				},
+				mip_level_count: 1,
+				sample_count: 1,
+				dimension: wgpu::TextureDimension::D2,
+				format: wgpu::TextureFormat::R8Unorm,
+				usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+				view_formats: &[],
+			})
+		};
+
+		let half = Size::new(size.width / 2, size.height / 2);
+		let (y, u, v) = (
+			plane("moq-video luma", size),
+			plane("moq-video chroma u", half),
+			plane("moq-video chroma v", half),
+		);
+		let views = [
+			y.create_view(&Default::default()),
+			u.create_view(&Default::default()),
+			v.create_view(&Default::default()),
+		];
+
+		Self { size, y, u, v, views }
+	}
+}
+
+/// Upload one tightly-packed plane. `Queue::write_texture` stages the copy
+/// itself, so the rows need no alignment padding.
+fn write(queue: &wgpu::Queue, texture: &wgpu::Texture, size: Size, data: &[u8]) {
+	queue.write_texture(
+		wgpu::TexelCopyTextureInfo {
+			texture,
+			mip_level: 0,
+			origin: wgpu::Origin3d::ZERO,
+			aspect: wgpu::TextureAspect::All,
+		},
+		data,
+		wgpu::TexelCopyBufferLayout {
+			offset: 0,
+			bytes_per_row: Some(size.width),
+			rows_per_image: Some(size.height),
+		},
+		wgpu::Extent3d {
+			width: size.width,
+			height: size.height,
+			depth_or_array_layers: 1,
+		},
+	);
+}

--- a/rs/moq-video/src/size.rs
+++ b/rs/moq-video/src/size.rs
@@ -30,13 +30,21 @@ impl Size {
 	/// needs even, non-zero dimensions. Checking here keeps the rule in one place
 	/// instead of re-deriving it at each boundary.
 	pub(crate) fn validate(&self, what: &str) -> Result<(), Error> {
+		self.validate_nonzero(what)?;
+		if !self.width.is_multiple_of(2) || !self.height.is_multiple_of(2) {
+			return Err(Error::Codec(anyhow::anyhow!("{what} {self}: dimensions must be even")));
+		}
+		Ok(())
+	}
+
+	/// The half of [`Size::validate`] that is not about chroma, for the surfaces
+	/// that hold RGB and so tolerate odd dimensions (a render target sized to a
+	/// window).
+	pub(crate) fn validate_nonzero(&self, what: &str) -> Result<(), Error> {
 		if self.width == 0 || self.height == 0 {
 			return Err(Error::Codec(anyhow::anyhow!(
 				"{what} {self}: dimensions must be non-zero"
 			)));
-		}
-		if !self.width.is_multiple_of(2) || !self.height.is_multiple_of(2) {
-			return Err(Error::Codec(anyhow::anyhow!("{what} {self}: dimensions must be even")));
 		}
 		Ok(())
 	}


### PR DESCRIPTION
First half of the `render` module from #2481's Wave 1. Adds a `render` role module to moq-video behind a non-default `render` feature: a wgpu pipeline that converts a decoded frame to RGB and hands back a texture the caller presents.

This is the egress half of the zero-copy story #2467 started. `Surface::PixelBuffer` has had a producer (capture, VideoToolbox decode) and no consumer since decoded frames began staying GPU-resident; this is the consumer.

## Summary

- **`render::Renderer`** takes the application's `wgpu::Device`/`Queue` and returns a plain `wgpu::Texture` from `render(&Frame)`. That texture is the whole integration seam, so nothing here depends on windowing or a UI toolkit. The renderer caches its pipeline, plane textures, and output texture across frames.
- **Zero-copy Metal import**: `CVMetalTextureCache` aliases the decoder's IOSurface planes as Metal textures, adopted through wgpu's `hal` seam. The CoreVideo wrapper rides in the texture's drop callback, because it is the wrapper (not the `MTLTexture`) that holds the source `CVPixelBuffer` open. Releasing it when the import returns lets the decoder's pool recycle the surface while a submitted draw is still sampling it: a torn frame under pool pressure and nothing at all when the pool is idle.
- **Universal fallback**: any surface the fast paths do not recognize uploads through `Surface::into_i420`. An import path that keeps failing retires itself after three strikes rather than paying for the attempt at frame rate.
- **Color correctness**: `I420` now records the color space it was converted with, and only a conversion that actually picks a matrix labels its output. The RGB conversions emit BT.601 limited at all resolutions, so inferring BT.709 from a frame's size (what a player does with an untagged stream) applied the wrong inverse matrix above 576 lines and skewed saturated colors: red rendered as `(255, 24, 0)`. Paths that merely move samples around leave the space open for the consumer to infer, which matters for V4L2 YUYV capture, where claiming BT.601 would pin a 720p camera to the wrong matrix instead of letting the heuristic get it right. The macOS download does carry the range through, since the pixel format names it.

Deliberately split: the Vulkan DMA-BUF and EGL/GLES importers land with `Surface::DmaBuf`, which they are the consumers for. A `#[non_exhaustive]` variant with neither a producer nor a consumer would be dead public API, so it ships alongside VAAPI/PipeWire in one hardware-validated series.

## Public API changes

All additive; nothing renamed, removed, or signature-changed. Targets `main` per [Branch Targeting](https://github.com/moq-dev/moq/blob/main/CONTRIBUTING.md#branch-targeting).

- New `render` cargo feature (off by default) and `moq_video::render` module: `Renderer`, `Config`, and a re-exported `wgpu` (a major bump of which is a breaking change for this crate, same contract as the existing `objc2_core_video` re-export).
- New `moq_video::Color` enum (`#[non_exhaustive]`) with `Color::infer`.
- New `I420::color()` and `I420::with_color()`. `I420::new` is unchanged and defaults the color to unknown.
- New `Error::Render` variant on the already-`#[non_exhaustive]` error enum.
- `Size::validate_nonzero` is `pub(crate)`, split out of `validate` so an RGB render target is not held to I420's even-dimension rule.
- From #2553: `Surface::color()` reports a frame's color space where the crate knows it, and `encode::Config::color` overrides what the encoder writes into the VUI. `h264-reader` is added as a dev-dependency for the SPS-parsing tests.

Default `moq-video`, `moq-relay`, and `moq-cli` builds pull no wgpu; confirmed with `cargo tree`.

## Test plan

- `just check` clean (workspace, `--all-features`, on current `main`).
- 70 moq-video tests pass, including the wgpu ones run with `--ignored` on an M-series Mac. The four GPU tests are `#[ignore]` because CI has no adapter; the color math they depend on is covered by tests that need no device and do run in CI.
- Verified across `{macOS, Linux} x {default features, --all-features}` (clippy, rustdoc, and tests), the Linux half in a Fedora container. That matrix exists because an item is only dead where its consumers are compiled out: three helpers here are reachable solely from the macOS import or the non-default `render` feature, so a macOS-only check cannot see them. The container was confirmed to reproduce each failure before its fix rather than being trusted for going green.
- The HD color regression was verified to fail against the previous behavior (`got [255, 24, 0, 255], expected about [255, 0, 0, 255]`) before the fix. The sibling render tests all run at 64x64, which sits below the 576-line threshold where the size guess happens to agree with the conversion, so only that test pins it down.
- `imports_survive_decoder_pool_recycling` renders 24 frames through a fixed-size pool, dropping each immediately, asserting none fell back to the CPU. It is a race, so passing is evidence rather than proof.
- `the_metal_import_matches_the_cpu_path` asserts the zero-copy output is pixel-identical to the upload path, and that `strikes == 0` so a silent fallback cannot satisfy it.
- `yuyv_capture_keeps_its_color_space_open` covers the V4L2 path; Linux-only, since that is where it compiles.
- Re-verified on the combined head after #2553 merged in: `just check` clean, and CI green on Linux, Windows, and macOS.
- #2553 changed what the RGB conversions produce, which stale-dated one of the `#[ignore]`d GPU tests that CI structurally cannot run. Fixed on the combined head, and strengthened: it now also renders a frame converted at SD and scaled past 576 lines, where the samples stay BT.601 while the size implies BT.709. Mutation-checked (renderer ignoring the declared space reproduces the original `(255, 24, 0)`).

## Cross-package sync

- No wire, catalog, or container change, so no draft update.
- **Skipped: the `doc/` row.** moq-video has no page under `doc/` at all today, so this would mean authoring the crate's entire documentation presence rather than extending a page. The module and item docs cover the consumer surface via docs.rs. Worth doing as its own change.

## Stacked change: the encode side, from #2553

The encode-side half of the same bug landed here rather than separately: #2553 was opened against this branch and merged into it, so this PR now carries both. Squash-merging produces one commit for the pair.

The bug it fixes was pre-existing and worse than the rendering one, because it reaches players we do not control: every RGB-to-I420 conversion was BT.601 at all resolutions, and nothing wrote a VUI color description, so Windows Desktop Duplication, PipeWire, and V4L2 capture above 576 lines shipped BT.601 pixels in an untagged stream that a compliant player decodes as BT.709.

- The RGB conversions now convert *into* `Color::infer`'s space for the frame's size rather than always BT.601, and label the result. Pixels and label are chosen together, so they cannot drift apart.
- Every H.264 backend (VideoToolbox, Media Foundation, NVENC, openh264) writes the color description into the SPS VUI, so a decoder stops guessing.
- `encode::Config::color` pins the space when frames come from somewhere the crate did not convert. A frame whose declared space disagrees with the encoder's warns once instead of failing, so a live gateway keeps serving rather than dropping the stream.
- `moq-transcode` opens each rung's encoder from its first frame, since a rung scaled below 576 lines still carries the source's space and would otherwise be labeled by its own size.

The tests parse the color description back out of the encoded SPS rather than asserting on config, so a backend that drops the VUI (or a driver that ignores the request) fails instead of passing on our own bookkeeping.

Refs #2481, #2467, #2272, #1837.

(Written by Opus 5)


