### PR TITLE
fix(moq-video): convert and label RGB captures in one color space

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bitstream-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
+
+[[package]]
 name = "blake3"
 version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2425,6 +2431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "four-cc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "795cbfc56d419a7ce47ccbb7504dd9a5b7c484c083c356e797de08bd988d9629"
+
+[[package]]
 name = "fs-err"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2931,6 +2943,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "253b313319f7109de64e480ffb606f89475cd758bae82e096e00c5d95341d30e"
 
 [[package]]
+name = "h264-reader"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "036a78b2620d92f0ec57690bc792b3bb87348632ee5225302ba2e66a48021c6c"
+dependencies = [
+ "bitstream-io",
+ "hex-slice",
+ "log",
+ "memchr",
+ "rfc6381-codec",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3040,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-slice"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5491a308e0214554f07a81d8944abe45f552871c12e3c3c6e7e5d354039a6c4c"
 
 [[package]]
 name = "hickory-net"
@@ -4795,6 +4826,7 @@ dependencies = [
  "cudarc",
  "dispatch2",
  "fast_image_resize",
+ "h264-reader",
  "hang",
  "libloading 0.9.0",
  "moq-mux",
@@ -4860,10 +4892,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "mp4ra-rust"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdbc3d3867085d66ac6270482e66f3dd2c5a18451a3dc9ad7269e94844a536b7"
+dependencies = [
+ "four-cc",
+]
+
+[[package]]
 name = "mpeg2ts"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7541fc1a42604cbd10e8607a4e6d4b231db982888fe8065ccb191b751d6368d6"
+
+[[package]]
+name = "mpeg4-audio-const"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a1fe2275b68991faded2c80aa4a33dba398b77d276038b8f50701a22e55918"
 
 [[package]]
 name = "muldiv"
@@ -7013,6 +7060,16 @@ name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
+name = "rfc6381-codec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed54c20f5c3ec82eab6d998b313dc75ec5d5650d4f57675e61d72489040297fd"
+dependencies = [
+ "mp4ra-rust",
+ "mpeg4-audio-const",
+]
 
 [[package]]
 name = "rfc6979"

--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -60,11 +60,17 @@ impl Rung {
 	}
 
 	/// An encoder producing this rung's rendition.
-	fn encode(&self) -> Result<moq_video::encode::Encoder, Error> {
+	///
+	/// `color` is the space the frames reaching it are in, taken from the first
+	/// decoded frame where the decoder knows. A rung below 576 lines fed by an HD
+	/// source carries the source's space, not the one its own size implies, so
+	/// leaving this to the encoder's size guess would label the rung wrongly.
+	fn encode(&self, color: Option<moq_video::Color>) -> Result<moq_video::encode::Encoder, Error> {
 		let mut config =
 			moq_video::encode::Config::new(self.info.size.width, self.info.size.height, self.info.framerate);
 		config.bitrate = Some(self.info.bitrate);
 		config.kind = self.encoder.clone();
+		config.color = color;
 		// Keyframes are forced at every group boundary; the GOP is only a
 		// backstop against pathologically long source groups.
 		config.gop = self.info.framerate.saturating_mul(8).max(1);
@@ -115,7 +121,11 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 		// Dropping them on unused releases the shared decode (if last) and the
 		// encoder session until someone subscribes again.
 		let mut listener = rung.feed.listen();
-		let mut encoder = rung.encode()?;
+		// Built from the first frame: the encoder writes that frame's color space
+		// into the bitstream, so it cannot open before one has arrived. A keyframe
+		// asked for at a group boundary waits here until it exists.
+		let mut encoder: Option<moq_video::encode::Encoder> = None;
+		let mut pending_keyframe = false;
 
 		// The output group currently being written, if the feed is mid-group.
 		let mut current: Option<moq_net::group::Producer> = None;
@@ -141,7 +151,10 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 					// A subscriber has to be able to start at this group, so its first
 					// frame must be an IDR. The request waits for the next frame, so a
 					// rung that skips this group simply carries it forward.
-					encoder.keyframe();
+					match &mut encoder {
+						Some(encoder) => encoder.keyframe(),
+						None => pending_keyframe = true,
+					}
 					// Mirror the source sequence so fetches and rendition
 					// switches map 1:1.
 					let info = moq_net::group::Info { sequence };
@@ -167,13 +180,28 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 
 					// The feed decodes at the source's native size; size this rung's copy
 					// here. A GPU frame resizes on the GPU and feeds the encoder without
-					// touching the CPU.
-					let encoded = if frame.size() == rung.info.size {
-						encoder.encode(&frame)?
-					} else {
-						encoder.encode(&frame.resize(rung.info.size)?)?
+					// touching the CPU. The resize carries the source's color space
+					// across, which is why the encoder is opened from the scaled frame
+					// rather than from this rung's size.
+					let resized;
+					let frame: &moq_video::Frame = match frame.size() == rung.info.size {
+						true => &frame,
+						false => {
+							resized = frame.resize(rung.info.size)?;
+							&resized
+						}
 					};
-					write(output, encoded)?;
+					let encoder = match &mut encoder {
+						Some(encoder) => encoder,
+						None => {
+							let mut opened = rung.encode(frame.surface.color())?;
+							if std::mem::take(&mut pending_keyframe) {
+								opened.keyframe();
+							}
+							encoder.insert(opened)
+						}
+					};
+					write(output, encoder.encode(frame)?)?;
 				}
 				Some(Item::End) => {
 					if let Some(mut output) = current.take() {
@@ -357,7 +385,12 @@ fn write(output: &mut moq_net::group::Producer, encoded: Vec<moq_video::encode::
 /// or a hardware decoder without a scaler) get `Frame::resize` instead.
 struct Pipeline {
 	decoder: moq_video::decode::Decoder,
-	encoder: moq_video::encode::Encoder,
+	/// Opened from the first decoded frame, whose color space it has to declare.
+	/// `None` until one arrives; a keyframe requested before then waits in
+	/// `pending_keyframe`.
+	encoder: Option<moq_video::encode::Encoder>,
+	pending_keyframe: bool,
+	rung: Rung,
 	size: moq_video::Size,
 }
 
@@ -370,7 +403,9 @@ impl Pipeline {
 
 		Ok(Self {
 			decoder,
-			encoder: rung.encode()?,
+			encoder: None,
+			pending_keyframe: false,
+			rung: rung.clone(),
 			size: rung.info.size,
 		})
 	}
@@ -387,18 +422,35 @@ impl Pipeline {
 		// actually arrives, which matters because a decoder that buffers returns
 		// nothing for the access unit that asked for one.
 		if keyframe {
-			self.encoder.keyframe();
+			match &mut self.encoder {
+				Some(encoder) => encoder.keyframe(),
+				None => self.pending_keyframe = true,
+			}
 		}
 
 		let mut encoded = Vec::new();
 		for raw in self.decoder.decode(payload, timestamp, keyframe)? {
-			encoded.extend(if raw.size() == self.size {
-				// Already at the rung size (the decoder scaled): feed the frame
-				// through as-is, keeping a GPU frame on the GPU.
-				self.encoder.encode(&raw)?
-			} else {
-				self.encoder.encode(&raw.resize(self.size)?)?
-			});
+			// Already at the rung size (the decoder scaled): feed the frame through
+			// as-is, keeping a GPU frame on the GPU.
+			let resized;
+			let raw: &moq_video::Frame = match raw.size() == self.size {
+				true => &raw,
+				false => {
+					resized = raw.resize(self.size)?;
+					&resized
+				}
+			};
+			let encoder = match &mut self.encoder {
+				Some(encoder) => encoder,
+				None => {
+					let mut opened = self.rung.encode(raw.surface.color())?;
+					if std::mem::take(&mut self.pending_keyframe) {
+						opened.keyframe();
+					}
+					self.encoder.insert(opened)
+				}
+			};
+			encoded.extend(encoder.encode(raw)?);
 		}
 		Ok(encoded)
 	}
@@ -408,6 +460,10 @@ impl Pipeline {
 	/// Consumes the pipeline, since flushing the encoder consumes it: a one-shot
 	/// group's pipeline is done once drained.
 	fn finish(self) -> Result<Vec<moq_video::encode::Encoded>, Error> {
-		self.encoder.finish().map_err(Into::into)
+		// No encoder means no frame ever decoded, so there is nothing buffered.
+		match self.encoder {
+			Some(encoder) => encoder.finish().map_err(Into::into),
+			None => Ok(Vec::new()),
+		}
 	}
 }

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -157,3 +157,6 @@ windows = { version = "0.62", features = [
     "Win32_System_Ole",
     "Win32_System_Variant",
 ] }
+
+[dev-dependencies]
+h264-reader = "0.8.0"

--- a/rs/moq-video/src/color.rs
+++ b/rs/moq-video/src/color.rs
@@ -58,6 +58,26 @@ impl Color {
 			(_, false) => Color::Bt709Full,
 		}
 	}
+	/// Whether luma is 16..235 rather than 0..255.
+	///
+	/// The encoders need it for the VUI's `video_full_range_flag`, so unlike
+	/// [`weights`](crate::render) it is not render-only.
+	pub(crate) fn limited(self) -> bool {
+		matches!(self, Color::Bt601Limited | Color::Bt709Limited)
+	}
+
+	/// How the `yuv` crate names this color space, for the RGB conversions.
+	pub(crate) fn yuv(self) -> (yuv::YuvRange, yuv::YuvStandardMatrix) {
+		let range = match self.limited() {
+			true => yuv::YuvRange::Limited,
+			false => yuv::YuvRange::Full,
+		};
+		let matrix = match self {
+			Color::Bt601Limited | Color::Bt601Full => yuv::YuvStandardMatrix::Bt601,
+			Color::Bt709Limited | Color::Bt709Full => yuv::YuvStandardMatrix::Bt709,
+		};
+		(range, matrix)
+	}
 }
 
 #[cfg(test)]

--- a/rs/moq-video/src/color.rs
+++ b/rs/moq-video/src/color.rs
@@ -58,10 +58,11 @@ impl Color {
 			(_, false) => Color::Bt709Full,
 		}
 	}
+
 	/// Whether luma is 16..235 rather than 0..255.
 	///
-	/// The encoders need it for the VUI's `video_full_range_flag`, so unlike
-	/// [`weights`](crate::render) it is not render-only.
+	/// The encoders need it for the VUI's `video_full_range_flag`, so unlike the
+	/// render module's `weights` it is not render-only.
 	pub(crate) fn limited(self) -> bool {
 		matches!(self, Color::Bt601Limited | Color::Bt709Limited)
 	}

--- a/rs/moq-video/src/encode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/encode/backend/mediafoundation.rs
@@ -24,15 +24,18 @@ use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11Texture2D};
 use windows::Win32::Media::MediaFoundation::{
 	CODECAPI_AVEncCommonMeanBitRate, CODECAPI_AVEncCommonRateControlMode, CODECAPI_AVEncMPVGOPSize,
 	CODECAPI_AVEncVideoForceKeyFrame, CODECAPI_AVLowLatencyMode, ICodecAPI, IMFDXGIDeviceManager, IMFMediaBuffer,
-	IMFMediaEvent, IMFMediaEventGenerator, IMFSample, IMFTransform, METransformHaveOutput, METransformNeedInput,
-	MF_E_NO_EVENTS_AVAILABLE, MF_E_TRANSFORM_NEED_MORE_INPUT, MF_E_TRANSFORM_STREAM_CHANGE, MF_EVENT_FLAG_NO_WAIT,
-	MF_EVENT_FLAG_NONE, MF_MT_AVG_BITRATE, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE, MF_MT_INTERLACE_MODE, MF_MT_MAJOR_TYPE,
-	MF_MT_MPEG2_PROFILE, MF_MT_SUBTYPE, MF_TRANSFORM_ASYNC_UNLOCK, MFCreateDXGIDeviceManager,
-	MFCreateDXGISurfaceBuffer, MFCreateMediaType, MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video,
-	MFT_CATEGORY_VIDEO_ENCODER, MFT_ENUM_FLAG_HARDWARE, MFT_ENUM_FLAG_SORTANDFILTER, MFT_MESSAGE_COMMAND_DRAIN,
-	MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, MFT_MESSAGE_NOTIFY_END_OF_STREAM, MFT_MESSAGE_NOTIFY_START_OF_STREAM,
-	MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO,
-	MFTEnumEx, MFVideoFormat_H264, MFVideoFormat_HEVC, MFVideoFormat_NV12, MFVideoInterlace_Progressive,
+	IMFMediaEvent, IMFMediaEventGenerator, IMFMediaType, IMFSample, IMFTransform, METransformHaveOutput,
+	METransformNeedInput, MF_E_NO_EVENTS_AVAILABLE, MF_E_TRANSFORM_NEED_MORE_INPUT, MF_E_TRANSFORM_STREAM_CHANGE,
+	MF_EVENT_FLAG_NO_WAIT, MF_EVENT_FLAG_NONE, MF_MT_AVG_BITRATE, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE,
+	MF_MT_INTERLACE_MODE, MF_MT_MAJOR_TYPE, MF_MT_MPEG2_PROFILE, MF_MT_SUBTYPE, MF_MT_TRANSFER_FUNCTION,
+	MF_MT_VIDEO_NOMINAL_RANGE, MF_MT_VIDEO_PRIMARIES, MF_MT_YUV_MATRIX, MF_TRANSFORM_ASYNC_UNLOCK,
+	MFCreateDXGIDeviceManager, MFCreateDXGISurfaceBuffer, MFCreateMediaType, MFCreateMemoryBuffer, MFCreateSample,
+	MFMediaType_Video, MFNominalRange_0_255, MFNominalRange_16_235, MFT_CATEGORY_VIDEO_ENCODER, MFT_ENUM_FLAG_HARDWARE,
+	MFT_ENUM_FLAG_SORTANDFILTER, MFT_MESSAGE_COMMAND_DRAIN, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING,
+	MFT_MESSAGE_NOTIFY_END_OF_STREAM, MFT_MESSAGE_NOTIFY_START_OF_STREAM, MFT_MESSAGE_SET_D3D_MANAGER,
+	MFT_OUTPUT_DATA_BUFFER, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO, MFTEnumEx, MFVideoFormat_H264,
+	MFVideoFormat_HEVC, MFVideoFormat_NV12, MFVideoInterlace_Progressive, MFVideoPrimaries_BT709,
+	MFVideoPrimaries_SMPTE170M, MFVideoTransFunc_709, MFVideoTransferMatrix_BT601, MFVideoTransferMatrix_BT709,
 	eAVEncCommonRateControlMode_CBR, eAVEncH264VProfile_High, eAVEncH265VProfile_Main_420_8,
 };
 use windows::Win32::System::Variant::{VARIANT, VT_BOOL, VT_UI4};
@@ -42,7 +45,7 @@ use super::super::encoder::{Codec, Config};
 use super::{Backend, Encoded};
 use crate::frame::{Surface, interleave_uv};
 use crate::mf::{ComGuard, mf_err, pack_2x32};
-use crate::{Error, Frame};
+use crate::{Color, Error, Frame};
 
 pub(crate) const NAME: &str = "mediafoundation";
 
@@ -62,6 +65,9 @@ pub(crate) struct MediaFoundation {
 	framerate: u32,
 	bitrate: u32,
 	gop: u32,
+	/// The color space of the input frames, stamped onto both media types so the
+	/// encoder writes it into the bitstream's VUI.
+	color: Color,
 	/// Lazily configured on the first frame, since the Direct3D11 device to bind
 	/// (for zero-copy texture input) comes from the frame itself.
 	started: bool,
@@ -132,6 +138,7 @@ impl MediaFoundation {
 			framerate: config.framerate,
 			bitrate: clamp_u32(config.resolved_bitrate()),
 			gop: config.gop,
+			color: config.resolved_color(),
 			started: false,
 			provides_samples: false,
 			output_size: 0,
@@ -211,6 +218,39 @@ impl MediaFoundation {
 		Ok(())
 	}
 
+	/// Stamp the color space onto a media type. Media Foundation takes these as a
+	/// request rather than a guarantee, so a driver may still emit an untagged
+	/// stream; the conversion picks the matrix an untagged stream implies, which
+	/// is what keeps that case correct.
+	fn set_color(&self, media: &IMFMediaType) -> Result<(), Error> {
+		let (primaries, matrix) = match self.color {
+			Color::Bt601Limited | Color::Bt601Full => (MFVideoPrimaries_SMPTE170M, MFVideoTransferMatrix_BT601),
+			Color::Bt709Limited | Color::Bt709Full => (MFVideoPrimaries_BT709, MFVideoTransferMatrix_BT709),
+		};
+		// BT.601 and BT.709 share a transfer curve; only primaries and matrix differ.
+		let transfer = MFVideoTransFunc_709;
+		let range = match self.color.limited() {
+			true => MFNominalRange_16_235,
+			false => MFNominalRange_0_255,
+		};
+
+		unsafe {
+			media
+				.SetUINT32(&MF_MT_VIDEO_PRIMARIES, primaries.0 as u32)
+				.map_err(|e| mf_err("color primaries", e))?;
+			media
+				.SetUINT32(&MF_MT_TRANSFER_FUNCTION, transfer.0 as u32)
+				.map_err(|e| mf_err("transfer function", e))?;
+			media
+				.SetUINT32(&MF_MT_YUV_MATRIX, matrix.0 as u32)
+				.map_err(|e| mf_err("yuv matrix", e))?;
+			media
+				.SetUINT32(&MF_MT_VIDEO_NOMINAL_RANGE, range.0 as u32)
+				.map_err(|e| mf_err("nominal range", e))?;
+		}
+		Ok(())
+	}
+
 	fn set_output_type(&self) -> Result<(), Error> {
 		let format = OutputFormat::for_codec(self.codec);
 		let media = unsafe { MFCreateMediaType().map_err(|e| mf_err("create output type", e))? };
@@ -236,6 +276,7 @@ impl MediaFoundation {
 			media
 				.SetUINT64(&MF_MT_FRAME_RATE, pack_2x32(self.framerate, 1))
 				.map_err(|e| mf_err("output frame rate", e))?;
+			self.set_color(&media)?;
 			self.transform
 				.SetOutputType(0, &media, 0)
 				.map_err(|e| mf_err("SetOutputType", e))?;
@@ -261,6 +302,7 @@ impl MediaFoundation {
 			media
 				.SetUINT64(&MF_MT_FRAME_RATE, pack_2x32(self.framerate, 1))
 				.map_err(|e| mf_err("input frame rate", e))?;
+			self.set_color(&media)?;
 			self.transform
 				.SetInputType(0, &media, 0)
 				.map_err(|e| mf_err("SetInputType", e))?;

--- a/rs/moq-video/src/encode/backend/mod.rs
+++ b/rs/moq-video/src/encode/backend/mod.rs
@@ -137,3 +137,48 @@ pub(crate) fn open(config: &Config) -> Result<Box<dyn Backend>, Error> {
 
 	Err(Error::NoEncoder(tried.join(", ")))
 }
+
+#[cfg(test)]
+pub(crate) mod test_util {
+	use h264_reader::nal::sps::SeqParameterSet;
+	use h264_reader::nal::{Nal, RefNal, UnitType};
+
+	use crate::Color;
+
+	/// The color space an H.264 Annex-B stream declares in its SPS, or `None` if
+	/// it carries no color description and a decoder would have to guess.
+	///
+	/// Reads the bitstream rather than the encoder's config, so a backend that
+	/// quietly drops the VUI (or a driver that ignores it) fails the test instead
+	/// of passing on our own bookkeeping.
+	pub(crate) fn declared_color(annexb: &[u8]) -> Option<Color> {
+		// Every 4-byte start code contains a 3-byte one at offset 1, so scanning
+		// for the short form finds both.
+		let starts: Vec<usize> = (0..annexb.len().saturating_sub(2))
+			.filter(|&i| annexb[i..i + 3] == [0, 0, 1])
+			.map(|i| i + 3)
+			.collect();
+
+		let sps = starts.iter().enumerate().find_map(|(n, &start)| {
+			// Bound the NAL at the next start code: a trailing slice would
+			// leave the SPS parser reading into the following NAL.
+			let end = starts.get(n + 1).map_or(annexb.len(), |&next| next - 3);
+			let nal = RefNal::new(&annexb[start..end], &[], true);
+			match nal.header().ok()?.nal_unit_type() {
+				UnitType::SeqParameterSet => SeqParameterSet::from_bits(nal.rbsp_bits()).ok(),
+				_ => None,
+			}
+		})?;
+
+		let signal = sps.vui_parameters.as_ref()?.video_signal_type.as_ref()?;
+		let description = signal.colour_description.as_ref()?;
+		let limited = !signal.video_full_range_flag;
+		Some(match (description.matrix_coefficients, limited) {
+			(1, true) => Color::Bt709Limited,
+			(1, false) => Color::Bt709Full,
+			(5 | 6, true) => Color::Bt601Limited,
+			(5 | 6, false) => Color::Bt601Full,
+			(other, _) => panic!("unexpected matrix_coefficients {other}"),
+		})
+	}
+}

--- a/rs/moq-video/src/encode/backend/mod.rs
+++ b/rs/moq-video/src/encode/backend/mod.rs
@@ -143,15 +143,51 @@ pub(crate) mod test_util {
 	use h264_reader::nal::sps::SeqParameterSet;
 	use h264_reader::nal::{Nal, RefNal, UnitType};
 
-	use crate::Color;
+	/// A stream's VUI color description, as the raw code points ISO/IEC 23091-2
+	/// assigns them plus the range flag.
+	///
+	/// Deliberately not mapped onto [`Color`](crate::Color): the mapping is lossy
+	/// (several code points share a matrix, and BT.709 and SMPTE 170M define the
+	/// same transfer curve under different numbers), so a test that compared
+	/// `Color`s could not see a backend drift on the fields `Color` folds away.
+	#[derive(Debug, PartialEq, Eq)]
+	pub(crate) struct Described {
+		pub primaries: u8,
+		pub transfer: u8,
+		pub matrix: u8,
+		pub full_range: bool,
+	}
 
-	/// The color space an H.264 Annex-B stream declares in its SPS, or `None` if
-	/// it carries no color description and a decoder would have to guess.
+	/// The description we emit for BT.601 and BT.709 limited range, shared by the
+	/// backend tests so a backend drifting from the others fails rather than
+	/// quietly encoding its own dialect.
+	///
+	/// BT.601 goes out as SMPTE 170M primaries and matrix (code point 6) with the
+	/// BT.709 transfer curve (1). The two curves are defined identically, and
+	/// CoreVideo's SMPTE 170M transfer constant is deprecated while Media
+	/// Foundation has none at all, so 1 is the only value all four backends can
+	/// actually emit.
+	pub(crate) const BT601_DESCRIBED: Described = Described {
+		primaries: 6,
+		transfer: 1,
+		matrix: 6,
+		full_range: false,
+	};
+
+	pub(crate) const BT709_DESCRIBED: Described = Described {
+		primaries: 1,
+		transfer: 1,
+		matrix: 1,
+		full_range: false,
+	};
+
+	/// The color description an H.264 Annex-B stream carries in its SPS, or `None`
+	/// if it carries none and a decoder would have to guess.
 	///
 	/// Reads the bitstream rather than the encoder's config, so a backend that
 	/// quietly drops the VUI (or a driver that ignores it) fails the test instead
 	/// of passing on our own bookkeeping.
-	pub(crate) fn declared_color(annexb: &[u8]) -> Option<Color> {
+	pub(crate) fn declared_color(annexb: &[u8]) -> Option<Described> {
 		// Every 4-byte start code contains a 3-byte one at offset 1, so scanning
 		// for the short form finds both.
 		let starts: Vec<usize> = (0..annexb.len().saturating_sub(2))
@@ -172,13 +208,11 @@ pub(crate) mod test_util {
 
 		let signal = sps.vui_parameters.as_ref()?.video_signal_type.as_ref()?;
 		let description = signal.colour_description.as_ref()?;
-		let limited = !signal.video_full_range_flag;
-		Some(match (description.matrix_coefficients, limited) {
-			(1, true) => Color::Bt709Limited,
-			(1, false) => Color::Bt709Full,
-			(5 | 6, true) => Color::Bt601Limited,
-			(5 | 6, false) => Color::Bt601Full,
-			(other, _) => panic!("unexpected matrix_coefficients {other}"),
+		Some(Described {
+			primaries: description.colour_primaries,
+			transfer: description.transfer_characteristics,
+			matrix: description.matrix_coefficients,
+			full_range: signal.video_full_range_flag,
 		})
 	}
 }

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -35,14 +35,15 @@ use cudarc::driver::CudaContext;
 use moq_nvenc::sys::nvEncodeAPI::NV_ENC_INPUT_RESOURCE_TYPE;
 use moq_nvenc::sys::nvEncodeAPI::{
 	GUID, NV_ENC_BUFFER_FORMAT, NV_ENC_CODEC_H264_GUID, NV_ENC_CODEC_HEVC_GUID, NV_ENC_PARAMS_RC_MODE,
-	NV_ENC_PRESET_P4_GUID, NV_ENC_TUNING_INFO,
+	NV_ENC_PRESET_P4_GUID, NV_ENC_TUNING_INFO, NV_ENC_VUI_COLOR_PRIMARIES, NV_ENC_VUI_MATRIX_COEFFS,
+	NV_ENC_VUI_TRANSFER_CHARACTERISTIC, NV_ENC_VUI_VIDEO_FORMAT,
 };
 use moq_nvenc::{Encoder, EncoderInitParams, Session};
 
 use super::super::encoder::{Codec, Config};
 use super::{Backend, Encoded};
 use crate::frame::{Surface, interleave_uv};
-use crate::{Error, Frame};
+use crate::{Color, Error, Frame};
 
 pub(crate) const NAME: &str = "nvenc";
 
@@ -109,18 +110,56 @@ impl Nvenc {
 		//     undecodable for late joiners.
 		//   - idrPeriod == gopLength: make every periodic I-frame an IDR (a clean
 		//     random-access point), so each GOP boundary is joinable.
-		//
+
+		// State the color space in the SPS so a decoder doesn't fall back to
+		// guessing it from the frame height. BT.601 goes out as the SMPTE 170M set
+		// (the 525-line variant, code point 6), which is what every other encoder
+		// writes for standard definition.
+		let color = config.resolved_color();
+		let (primaries, transfer, matrix) = match color {
+			Color::Bt601Limited | Color::Bt601Full => (
+				NV_ENC_VUI_COLOR_PRIMARIES::NV_ENC_VUI_COLOR_PRIMARIES_SMPTE170M,
+				NV_ENC_VUI_TRANSFER_CHARACTERISTIC::NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE170M,
+				NV_ENC_VUI_MATRIX_COEFFS::NV_ENC_VUI_MATRIX_COEFFS_SMPTE170M,
+			),
+			Color::Bt709Limited | Color::Bt709Full => (
+				NV_ENC_VUI_COLOR_PRIMARIES::NV_ENC_VUI_COLOR_PRIMARIES_BT709,
+				NV_ENC_VUI_TRANSFER_CHARACTERISTIC::NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT709,
+				NV_ENC_VUI_MATRIX_COEFFS::NV_ENC_VUI_MATRIX_COEFFS_BT709,
+			),
+		};
+
 		// SAFETY: the preset config's codec union was initialized by
 		// `get_preset_config` for `codec_guid`, so we write the matching arm.
 		unsafe {
+			// The two codecs' VUI structs are distinct types with identical fields,
+			// so the assignments are written per-arm rather than shared.
 			match config.codec {
 				Codec::H264 => {
 					cfg.encodeCodecConfig.h264Config.set_repeatSPSPPS(1);
 					cfg.encodeCodecConfig.h264Config.idrPeriod = config.gop;
+
+					let vui = &mut cfg.encodeCodecConfig.h264Config.h264VUIParameters;
+					vui.videoSignalTypePresentFlag = 1;
+					vui.videoFormat = NV_ENC_VUI_VIDEO_FORMAT::NV_ENC_VUI_VIDEO_FORMAT_UNSPECIFIED;
+					vui.videoFullRangeFlag = u32::from(!color.limited());
+					vui.colourDescriptionPresentFlag = 1;
+					vui.colourPrimaries = primaries;
+					vui.transferCharacteristics = transfer;
+					vui.colourMatrix = matrix;
 				}
 				Codec::H265 => {
 					cfg.encodeCodecConfig.hevcConfig.set_repeatSPSPPS(1);
 					cfg.encodeCodecConfig.hevcConfig.idrPeriod = config.gop;
+
+					let vui = &mut cfg.encodeCodecConfig.hevcConfig.hevcVUIParameters;
+					vui.videoSignalTypePresentFlag = 1;
+					vui.videoFormat = NV_ENC_VUI_VIDEO_FORMAT::NV_ENC_VUI_VIDEO_FORMAT_UNSPECIFIED;
+					vui.videoFullRangeFlag = u32::from(!color.limited());
+					vui.colourDescriptionPresentFlag = 1;
+					vui.colourPrimaries = primaries;
+					vui.transferCharacteristics = transfer;
+					vui.colourMatrix = matrix;
 				}
 			}
 		}

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -112,14 +112,15 @@ impl Nvenc {
 		//     random-access point), so each GOP boundary is joinable.
 
 		// State the color space in the SPS so a decoder doesn't fall back to
-		// guessing it from the frame height. BT.601 goes out as the SMPTE 170M set
-		// (the 525-line variant, code point 6), which is what every other encoder
-		// writes for standard definition.
+		// guessing it from the frame height. BT.601 goes out as SMPTE 170M primaries
+		// and matrix (code point 6) with the BT.709 transfer curve (1): the two
+		// curves are defined identically, and 1 is the only one CoreVideo and Media
+		// Foundation can name, so every backend emits the same triple.
 		let color = config.resolved_color();
 		let (primaries, transfer, matrix) = match color {
 			Color::Bt601Limited | Color::Bt601Full => (
 				NV_ENC_VUI_COLOR_PRIMARIES::NV_ENC_VUI_COLOR_PRIMARIES_SMPTE170M,
-				NV_ENC_VUI_TRANSFER_CHARACTERISTIC::NV_ENC_VUI_TRANSFER_CHARACTERISTIC_SMPTE170M,
+				NV_ENC_VUI_TRANSFER_CHARACTERISTIC::NV_ENC_VUI_TRANSFER_CHARACTERISTIC_BT709,
 				NV_ENC_VUI_MATRIX_COEFFS::NV_ENC_VUI_MATRIX_COEFFS_SMPTE170M,
 			),
 			Color::Bt709Limited | Color::Bt709Full => (

--- a/rs/moq-video/src/encode/backend/openh264.rs
+++ b/rs/moq-video/src/encode/backend/openh264.rs
@@ -5,13 +5,15 @@
 
 use bytes::Bytes;
 use openh264::OpenH264API;
-use openh264::encoder::{BitRate, Encoder, EncoderConfig, FrameRate, IntraFramePeriod, RateControlMode, UsageType};
+use openh264::encoder::{
+	BitRate, Encoder, EncoderConfig, FrameRate, IntraFramePeriod, RateControlMode, UsageType, VuiConfig,
+};
 use openh264::formats::YUVSlices;
 use openh264_sys2::{ENCODER_OPTION_BITRATE, SBitrateInfo, SPATIAL_LAYER_ALL};
 
 use super::super::encoder::Config;
 use super::{Backend, Encoded};
-use crate::{Error, Frame};
+use crate::{Color, Error, Frame};
 
 pub(crate) const NAME: &str = "openh264";
 
@@ -31,13 +33,23 @@ impl Openh264 {
 	}
 
 	fn new(config: &Config) -> Result<Self, Error> {
+		let color = config.resolved_color();
+		// State the color space in the SPS so a decoder doesn't fall back to
+		// guessing it from the frame height.
+		let vui = match color {
+			Color::Bt601Limited | Color::Bt601Full => VuiConfig::bt601(),
+			Color::Bt709Limited | Color::Bt709Full => VuiConfig::bt709(),
+		}
+		.full_range(!color.limited());
+
 		let cfg = EncoderConfig::new()
 			.bitrate(BitRate::from_bps(config.resolved_bitrate().min(u32::MAX as u64) as u32))
 			.max_frame_rate(FrameRate::from_hz(config.framerate as f32))
 			.rate_control_mode(RateControlMode::Bitrate)
 			// Real-time camera: prioritize latency over compression.
 			.usage_type(UsageType::CameraVideoRealTime)
-			.intra_frame_period(IntraFramePeriod::from_num_frames(config.gop));
+			.intra_frame_period(IntraFramePeriod::from_num_frames(config.gop))
+			.vui(vui);
 
 		let encoder = Encoder::with_api_config(OpenH264API::from_source(), cfg)
 			.map_err(|e| Error::Codec(anyhow::anyhow!("openh264 init: {e}")))?;
@@ -236,5 +248,40 @@ mod tests {
 		enc.encode(&gray(), false).unwrap();
 
 		assert_eq!(enc.read_bitrate(), (opened / 4) as i64, "the deferred rate resurrected");
+	}
+
+	/// The SPS states the color space, so a decoder never falls back to guessing
+	/// it from the frame height, and it states the space the pixels were actually
+	/// converted into. Read back out of the bitstream, not off our own config.
+	#[test]
+	fn the_sps_declares_the_color_space() {
+		use super::super::test_util::declared_color;
+		use crate::{Color, Size};
+
+		for (size, expected) in [
+			(Size::new(640, 480), Color::Bt601Limited),
+			(Size::new(1920, 1080), Color::Bt709Limited),
+		] {
+			let config = Config {
+				kind: Kind::Software,
+				..Config::new(size.width, size.height, 30)
+			};
+			let mut enc = Openh264::new(&config).unwrap();
+
+			// Saturated red: the color the two matrices disagree most about, so a
+			// mislabeled stream is a visible bug rather than a rounding difference.
+			let rgba = [255u8, 0, 0, 255].repeat(size.pixels() as usize);
+			let surface = Surface::rgba(&rgba, size).unwrap();
+			let frame = Frame::new(surface, moq_net::Timestamp::from_micros(0).unwrap());
+
+			let encoded = enc.encode(&frame, true).unwrap();
+			let annexb = &encoded.first().expect("a keyframe").payload;
+
+			assert_eq!(declared_color(annexb), Some(expected), "{size} SPS color description");
+
+			// The label has to match the pixels: same source of truth on both sides.
+			let i420 = frame.surface.to_i420().unwrap();
+			assert_eq!(i420.color(), Some(expected), "{size} converted pixels");
+		}
 	}
 }

--- a/rs/moq-video/src/encode/backend/openh264.rs
+++ b/rs/moq-video/src/encode/backend/openh264.rs
@@ -6,7 +6,8 @@
 use bytes::Bytes;
 use openh264::OpenH264API;
 use openh264::encoder::{
-	BitRate, Encoder, EncoderConfig, FrameRate, IntraFramePeriod, RateControlMode, UsageType, VuiConfig,
+	BitRate, Encoder, EncoderConfig, FrameRate, IntraFramePeriod, RateControlMode, TransferCharacteristics, UsageType,
+	VuiConfig,
 };
 use openh264::formats::YUVSlices;
 use openh264_sys2::{ENCODER_OPTION_BITRATE, SBitrateInfo, SPATIAL_LAYER_ALL};
@@ -36,8 +37,16 @@ impl Openh264 {
 		let color = config.resolved_color();
 		// State the color space in the SPS so a decoder doesn't fall back to
 		// guessing it from the frame height.
+		//
+		// `VuiConfig::bt601()` would pair SMPTE 170M primaries and matrix with the
+		// SMPTE 170M transfer curve (code point 6). We override the curve to BT.709
+		// (1), which is defined identically, because CoreVideo's 170M transfer
+		// constant is deprecated and Media Foundation has none, so 1 is the only
+		// value every backend can emit. Same curve, one number across all of them.
 		let vui = match color {
-			Color::Bt601Limited | Color::Bt601Full => VuiConfig::bt601(),
+			Color::Bt601Limited | Color::Bt601Full => {
+				VuiConfig::bt601().transfer_characteristics(TransferCharacteristics::Bt709)
+			}
 			Color::Bt709Limited | Color::Bt709Full => VuiConfig::bt709(),
 		}
 		.full_range(!color.limited());
@@ -255,12 +264,12 @@ mod tests {
 	/// converted into. Read back out of the bitstream, not off our own config.
 	#[test]
 	fn the_sps_declares_the_color_space() {
-		use super::super::test_util::declared_color;
+		use super::super::test_util::{BT601_DESCRIBED, BT709_DESCRIBED, declared_color};
 		use crate::{Color, Size};
 
-		for (size, expected) in [
-			(Size::new(640, 480), Color::Bt601Limited),
-			(Size::new(1920, 1080), Color::Bt709Limited),
+		for (size, described) in [
+			(Size::new(640, 480), BT601_DESCRIBED),
+			(Size::new(1920, 1080), BT709_DESCRIBED),
 		] {
 			let config = Config {
 				kind: Kind::Software,
@@ -277,11 +286,11 @@ mod tests {
 			let encoded = enc.encode(&frame, true).unwrap();
 			let annexb = &encoded.first().expect("a keyframe").payload;
 
-			assert_eq!(declared_color(annexb), Some(expected), "{size} SPS color description");
+			assert_eq!(declared_color(annexb), Some(described), "{size} SPS color description");
 
 			// The label has to match the pixels: same source of truth on both sides.
 			let i420 = frame.surface.to_i420().unwrap();
-			assert_eq!(i420.color(), Some(expected), "{size} converted pixels");
+			assert_eq!(i420.color(), Some(Color::infer(size)), "{size} converted pixels");
 		}
 	}
 }

--- a/rs/moq-video/src/encode/backend/videotoolbox.rs
+++ b/rs/moq-video/src/encode/backend/videotoolbox.rs
@@ -26,18 +26,24 @@ use objc2_core_media::{
 	CMVideoFormatDescriptionGetHEVCParameterSetAtIndex, kCMTimeInvalid, kCMVideoCodecType_H264, kCMVideoCodecType_HEVC,
 };
 use objc2_core_video::CVImageBuffer;
+use objc2_core_video::{
+	kCVImageBufferColorPrimaries_ITU_R_709_2, kCVImageBufferColorPrimaries_SMPTE_C,
+	kCVImageBufferTransferFunction_ITU_R_709_2, kCVImageBufferYCbCrMatrix_ITU_R_601_4,
+	kCVImageBufferYCbCrMatrix_ITU_R_709_2,
+};
 use objc2_video_toolbox::{
 	VTCompressionSession, VTEncodeInfoFlags, VTSessionSetProperty, kVTCompressionPropertyKey_AllowFrameReordering,
-	kVTCompressionPropertyKey_AverageBitRate, kVTCompressionPropertyKey_ExpectedFrameRate,
-	kVTCompressionPropertyKey_MaxKeyFrameInterval, kVTCompressionPropertyKey_ProfileLevel,
-	kVTCompressionPropertyKey_RealTime, kVTEncodeFrameOptionKey_ForceKeyFrame, kVTProfileLevel_H264_High_AutoLevel,
-	kVTProfileLevel_HEVC_Main_AutoLevel,
+	kVTCompressionPropertyKey_AverageBitRate, kVTCompressionPropertyKey_ColorPrimaries,
+	kVTCompressionPropertyKey_ExpectedFrameRate, kVTCompressionPropertyKey_MaxKeyFrameInterval,
+	kVTCompressionPropertyKey_ProfileLevel, kVTCompressionPropertyKey_RealTime,
+	kVTCompressionPropertyKey_TransferFunction, kVTCompressionPropertyKey_YCbCrMatrix,
+	kVTEncodeFrameOptionKey_ForceKeyFrame, kVTProfileLevel_H264_High_AutoLevel, kVTProfileLevel_HEVC_Main_AutoLevel,
 };
 
 use super::super::encoder::{Codec, Config};
 use super::{Backend, Encoded};
 use crate::frame::Surface;
-use crate::{Error, Frame};
+use crate::{Color, Error, Frame};
 
 pub(crate) const NAME: &str = "videotoolbox";
 
@@ -130,6 +136,32 @@ impl VideoToolbox {
 			unsafe { kVTCompressionPropertyKey_ExpectedFrameRate },
 			config.framerate as i32,
 		)?;
+
+		// State the color space in the SPS so a decoder doesn't fall back to
+		// guessing it from the frame height. BT.601 goes out as SMPTE C primaries
+		// with the 709 transfer curve, which is the 170M set: 601 and 709 differ in
+		// primaries and matrix, not in gamma.
+		let (primaries, transfer, matrix) = unsafe {
+			match config.resolved_color() {
+				Color::Bt601Limited | Color::Bt601Full => (
+					kCVImageBufferColorPrimaries_SMPTE_C,
+					kCVImageBufferTransferFunction_ITU_R_709_2,
+					kCVImageBufferYCbCrMatrix_ITU_R_601_4,
+				),
+				Color::Bt709Limited | Color::Bt709Full => (
+					kCVImageBufferColorPrimaries_ITU_R_709_2,
+					kCVImageBufferTransferFunction_ITU_R_709_2,
+					kCVImageBufferYCbCrMatrix_ITU_R_709_2,
+				),
+			}
+		};
+		set_property(&session, unsafe { kVTCompressionPropertyKey_ColorPrimaries }, primaries)?;
+		set_property(
+			&session,
+			unsafe { kVTCompressionPropertyKey_TransferFunction },
+			transfer,
+		)?;
+		set_property(&session, unsafe { kVTCompressionPropertyKey_YCbCrMatrix }, matrix)?;
 
 		let force_keyframe = force_keyframe_dict()?;
 

--- a/rs/moq-video/src/encode/backend/videotoolbox.rs
+++ b/rs/moq-video/src/encode/backend/videotoolbox.rs
@@ -139,8 +139,10 @@ impl VideoToolbox {
 
 		// State the color space in the SPS so a decoder doesn't fall back to
 		// guessing it from the frame height. BT.601 goes out as SMPTE C primaries
-		// with the 709 transfer curve, which is the 170M set: 601 and 709 differ in
-		// primaries and matrix, not in gamma.
+		// and the 601 matrix (both code point 6) with the BT.709 transfer curve (1),
+		// since 601 and 709 differ in primaries and matrix, not in gamma. CoreVideo
+		// does have a 170M transfer constant, but it is deprecated, and Media
+		// Foundation has none, so 1 is what every backend emits.
 		let (primaries, transfer, matrix) = unsafe {
 			match config.resolved_color() {
 				Color::Bt601Limited | Color::Bt601Full => (

--- a/rs/moq-video/src/encode/encoder.rs
+++ b/rs/moq-video/src/encode/encoder.rs
@@ -7,7 +7,7 @@
 
 use super::Encoded;
 use super::backend::{self, Backend};
-use crate::{Error, Frame, Size};
+use crate::{Color, Error, Frame, Size};
 
 /// Output video codec. `#[non_exhaustive]` so new codecs can be added without
 /// breaking external `match`es.
@@ -65,6 +65,14 @@ pub struct Config {
 	/// Output codec. Defaults to [`Codec::H264`].
 	pub codec: Codec,
 	pub kind: Kind,
+	/// The color space of the input frames, written into the bitstream's VUI so a
+	/// decoder doesn't have to guess. `None` uses [`Color::infer`], which is both
+	/// what the crate's own RGB conversions produce and what a player falls back
+	/// to, so leaving it unset keeps the pixels and the label in agreement.
+	///
+	/// Set it only when feeding frames the crate did not convert and whose space
+	/// you know from elsewhere.
+	pub color: Option<Color>,
 }
 
 impl Config {
@@ -80,12 +88,21 @@ impl Config {
 			gop: framerate.saturating_mul(2).max(1),
 			codec: Codec::default(),
 			kind: Kind::Auto,
+			color: None,
 		}
 	}
 
 	/// The encoded resolution.
 	pub fn size(&self) -> Size {
 		Size::new(self.width, self.height)
+	}
+
+	/// Resolved input color space: explicit override, or the size-based guess
+	/// every player makes for an untagged stream. Backends write this into the
+	/// VUI; the crate's RGB conversions pick the same answer for the same size,
+	/// so the samples match what the bitstream claims.
+	pub(crate) fn resolved_color(&self) -> Color {
+		self.color.unwrap_or_else(|| Color::infer(self.size()))
 	}
 
 	/// Resolved bitrate: explicit override, or a pixels-per-second estimate.
@@ -980,5 +997,37 @@ mod tests {
 				.unwrap()
 				.is_empty()
 		);
+	}
+
+	/// The hardware encoder states the color space too, and states the one the
+	/// pixels were actually converted into. VideoToolbox takes the three
+	/// properties as a request, so read the SPS back rather than trusting that it
+	/// honored them.
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn videotoolbox_sps_declares_the_color_space() {
+		use super::backend::test_util::declared_color;
+		use crate::Color;
+
+		for (size, expected) in [
+			(Size::new(640, 480), Color::Bt601Limited),
+			(Size::new(1920, 1080), Color::Bt709Limited),
+		] {
+			let config = Config {
+				kind: Kind::Named("videotoolbox".into()),
+				..Config::new(size.width, size.height, 30)
+			};
+			let mut encoder = Encoder::new(&config).expect("videotoolbox is available on macOS");
+
+			let rgba = [255u8, 0, 0, 255].repeat(size.pixels() as usize);
+			let surface = crate::frame::Surface::rgba(&rgba, size).unwrap();
+			encoder.keyframe();
+			let frames = encoder
+				.encode(&Frame::new(surface, moq_net::Timestamp::from_micros(0).unwrap()))
+				.unwrap();
+
+			let keyframe = frames.first().expect("a keyframe");
+			assert_eq!(declared_color(&keyframe.payload), Some(expected), "{size} SPS");
+		}
 	}
 }

--- a/rs/moq-video/src/encode/encoder.rs
+++ b/rs/moq-video/src/encode/encoder.rs
@@ -1006,12 +1006,11 @@ mod tests {
 	#[cfg(target_os = "macos")]
 	#[test]
 	fn videotoolbox_sps_declares_the_color_space() {
-		use super::backend::test_util::declared_color;
-		use crate::Color;
+		use super::backend::test_util::{BT601_DESCRIBED, BT709_DESCRIBED, declared_color};
 
-		for (size, expected) in [
-			(Size::new(640, 480), Color::Bt601Limited),
-			(Size::new(1920, 1080), Color::Bt709Limited),
+		for (size, described) in [
+			(Size::new(640, 480), BT601_DESCRIBED),
+			(Size::new(1920, 1080), BT709_DESCRIBED),
 		] {
 			let config = Config {
 				kind: Kind::Named("videotoolbox".into()),
@@ -1027,7 +1026,7 @@ mod tests {
 				.unwrap();
 
 			let keyframe = frames.first().expect("a keyframe");
-			assert_eq!(declared_color(&keyframe.payload), Some(expected), "{size} SPS");
+			assert_eq!(declared_color(&keyframe.payload), Some(described), "{size} SPS");
 		}
 	}
 }

--- a/rs/moq-video/src/encode/encoder.rs
+++ b/rs/moq-video/src/encode/encoder.rs
@@ -123,6 +123,9 @@ pub struct Encoder {
 	codec: Codec,
 	size: Size,
 	bitrate: u64,
+	/// What the backend wrote into the bitstream's VUI, kept so a frame declaring
+	/// a different space is caught rather than silently mislabeled.
+	color: Color,
 	/// A keyframe asked for by [`Encoder::keyframe`], applied to the next frame.
 	/// Held rather than applied immediately because the caller decides a group
 	/// boundary before it has the frame that opens it.
@@ -148,6 +151,7 @@ impl Encoder {
 			codec: config.codec,
 			size,
 			bitrate: config.resolved_bitrate(),
+			color: config.resolved_color(),
 			pending_keyframe: false,
 		})
 	}
@@ -238,6 +242,27 @@ impl Encoder {
 				"frame {size} does not match encoder {}",
 				self.size
 			)));
+		}
+		// The VUI is fixed when the session opens, so a frame in a different space
+		// gets encoded under the wrong label. Reached by resizing across the
+		// standard-definition boundary, where the pixels keep their space but the
+		// encoder was sized into another one; `Config::color` is the way to pin it.
+		//
+		// Warn rather than reject: a live gateway transcoding a source whose VUI
+		// disagrees with its resolution should keep serving a mislabeled stream
+		// rather than drop it, and this is no worse than the untagged stream that
+		// came before. Once, because it would otherwise fire every frame.
+		if let Some(color) = frame.surface.color()
+			&& color != self.color
+		{
+			static WARN_ONCE: std::sync::Once = std::sync::Once::new();
+			WARN_ONCE.call_once(|| {
+				tracing::warn!(
+					frame = ?color,
+					encoder = ?self.color,
+					"frame color space differs from the one written into the bitstream; set encode::Config::color"
+				);
+			});
 		}
 		let encoded = self.backend.encode(frame, self.pending_keyframe)?;
 		// Cleared only once the frame is through: a failed encode produced no
@@ -820,6 +845,7 @@ mod tests {
 			codec: config.codec,
 			size: config.size(),
 			bitrate: config.resolved_bitrate(),
+			color: config.resolved_color(),
 			pending_keyframe: false,
 		}
 	}
@@ -1028,5 +1054,60 @@ mod tests {
 			let keyframe = frames.first().expect("a keyframe");
 			assert_eq!(declared_color(&keyframe.payload), Some(described), "{size} SPS");
 		}
+	}
+
+	/// Resizing across the standard-definition boundary keeps the pixels' color
+	/// space but moves the encoder into another one, which would emit BT.709
+	/// pixels under a BT.601 label. `Config::color` pins the real space, and the
+	/// bitstream then says so.
+	#[test]
+	fn config_color_pins_the_space_a_resize_carried() {
+		use crate::Color;
+
+		let big = Size::new(1280, 720);
+		let small = Size::new(640, 480);
+
+		// Converted at 720p, so the samples are BT.709.
+		let rgba = vec![0x80u8; big.pixels() as usize * 4];
+		let frame = Frame::new(
+			crate::frame::Surface::rgba(&rgba, big).unwrap(),
+			moq_net::Timestamp::from_micros(0).unwrap(),
+		);
+		let scaled = frame.resize(small).unwrap();
+		assert_eq!(
+			scaled.surface.color(),
+			Some(Color::Bt709Limited),
+			"resize keeps the space"
+		);
+
+		// Left to infer, a 480p encoder writes BT.601 over those BT.709 samples. It
+		// still encodes (a live gateway keeps serving) but the label is wrong, which
+		// is what `Config::color` exists to fix.
+		let config = Config {
+			kind: Kind::Software,
+			..Config::new(small.width, small.height, 30)
+		};
+		let mut encoder = Encoder::new(&config).unwrap();
+		encoder.keyframe();
+		let frames = encoder.encode(&scaled).expect("a mismatch warns rather than fails");
+		use super::backend::test_util::{BT601_DESCRIBED, BT709_DESCRIBED, declared_color};
+		assert_eq!(
+			declared_color(&frames.first().expect("a keyframe").payload),
+			Some(BT601_DESCRIBED),
+			"the inferred label is the wrong one, which is the case Config::color covers"
+		);
+
+		// Declaring the real space fixes the label.
+		let config = Config {
+			kind: Kind::Software,
+			color: Some(Color::Bt709Limited),
+			..Config::new(small.width, small.height, 30)
+		};
+		let mut encoder = Encoder::new(&config).unwrap();
+		encoder.keyframe();
+		let frames = encoder.encode(&scaled).expect("a declared space encodes");
+
+		let keyframe = frames.first().expect("a keyframe");
+		assert_eq!(declared_color(&keyframe.payload), Some(BT709_DESCRIBED));
 	}
 }

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 use bytes::Bytes;
 use moq_net::Timestamp;
 
-use yuv::{YuvChromaSubsampling, YuvConversionMode, YuvPlanarImageMut, YuvRange, YuvStandardMatrix, rgba_to_yuv420};
+use yuv::{YuvChromaSubsampling, YuvConversionMode, YuvPlanarImageMut, rgba_to_yuv420};
 
 use crate::{Color, Error, Size};
 
@@ -128,8 +128,9 @@ impl Surface {
 	}
 
 	/// Convert tightly-packed RGBA (`width * height * 4` bytes, no row padding) to
-	/// a CPU I420 surface, BT.601 limited range (what H.264 decoders expect by
-	/// default).
+	/// a CPU I420 surface in [`Color::infer`]'s color space for `size`, limited
+	/// range. The result reports it via [`I420::color`], and an encoder writes it
+	/// into the bitstream, so the pixels and their label cannot disagree.
 	///
 	/// The bring-your-own-pixels entry point: wrap the result in a [`Frame`] to
 	/// encode it. A capture source or decoder hands you a surface directly, often a
@@ -188,9 +189,12 @@ impl Surface {
 		})
 	}
 
-	/// The pixels as tightly-packed I420 (YUV 4:2:0, BT.601 limited range): Y
-	/// (`width * height` bytes), then U, then V (`width/2 * height/2` each), no row
-	/// padding.
+	/// The pixels as tightly-packed I420 (YUV 4:2:0): Y (`width * height` bytes),
+	/// then U, then V (`width/2 * height/2` each), no row padding.
+	///
+	/// Bytes only, so the color space does not come along. Take it from
+	/// [`I420::color`] first if you need to interpret these samples, since this
+	/// consumes the surface.
 	///
 	/// Always available, whichever variant you hold, so it is the universal arm of
 	/// a `match`. Free for `Surface::I420`; downloads any GPU surface.
@@ -317,43 +321,34 @@ impl I420 {
 		luma + luma / 2
 	}
 
-	/// Convert RGBA (`stride` bytes per row, >= `width * 4`) to I420, BT.601
-	/// limited range (studio swing, what H.264 decoders expect by default). Used
-	/// by [`Surface::rgba`] (tightly packed) and
-	/// the screen-capture paths, whose surfaces carry a driver-chosen row pitch.
+	/// Convert RGBA (`stride` bytes per row, >= `width * 4`) to I420 in
+	/// [`Color::infer`]'s color space for this size, limited range. Used by
+	/// [`Surface::rgba`] (tightly packed) and the screen-capture paths, whose
+	/// surfaces carry a driver-chosen row pitch.
 	pub(crate) fn from_rgba(rgba: &[u8], stride: u32, width: u32, height: u32) -> Result<Self, Error> {
+		let color = Color::infer(Size::new(width, height));
+		let (range, matrix) = color.yuv();
 		let mut planar = YuvPlanarImageMut::alloc(width, height, YuvChromaSubsampling::Yuv420);
-		rgba_to_yuv420(
-			&mut planar,
-			rgba,
-			stride,
-			YuvRange::Limited,
-			YuvStandardMatrix::Bt601,
-			YuvConversionMode::Balanced,
-		)
-		.map_err(|e| Error::Codec(anyhow::anyhow!("rgba_to_yuv420 failed for {width}x{height}: {e}")))?;
-		Ok(Self::pack(&planar, width, height, Some(Color::Bt601Limited)))
+		rgba_to_yuv420(&mut planar, rgba, stride, range, matrix, YuvConversionMode::Balanced)
+			.map_err(|e| Error::Codec(anyhow::anyhow!("rgba_to_yuv420 failed for {width}x{height}: {e}")))?;
+		Ok(Self::pack(&planar, width, height, Some(color)))
 	}
 
-	/// Convert BGRA to I420, BT.601 limited range. `stride` is the source row
-	/// pitch in bytes (>= `width * 4`), so a padded surface maps directly. Used by
-	/// the screen-capture paths: Windows Desktop Duplication (BGRA staging
-	/// texture) and Linux PipeWire (BGRx/BGRA shared-memory buffers).
+	/// Convert BGRA to I420 in [`Color::infer`]'s color space for this size.
+	/// `stride` is the source row pitch in bytes (>= `width * 4`), so a padded
+	/// surface maps directly. Used by the screen-capture paths: Windows Desktop
+	/// Duplication (BGRA staging texture) and Linux PipeWire (BGRx/BGRA
+	/// shared-memory buffers).
 	#[cfg(any(target_os = "windows", all(target_os = "linux", feature = "pipewire")))]
 	pub(crate) fn from_bgra(bgra: &[u8], stride: u32, width: u32, height: u32) -> Result<Self, Error> {
 		use yuv::bgra_to_yuv420;
 
+		let color = Color::infer(Size::new(width, height));
+		let (range, matrix) = color.yuv();
 		let mut planar = YuvPlanarImageMut::alloc(width, height, YuvChromaSubsampling::Yuv420);
-		bgra_to_yuv420(
-			&mut planar,
-			bgra,
-			stride,
-			YuvRange::Limited,
-			YuvStandardMatrix::Bt601,
-			YuvConversionMode::Balanced,
-		)
-		.map_err(|e| Error::Codec(anyhow::anyhow!("bgra_to_yuv420 failed for {width}x{height}: {e}")))?;
-		Ok(Self::pack(&planar, width, height, Some(Color::Bt601Limited)))
+		bgra_to_yuv420(&mut planar, bgra, stride, range, matrix, YuvConversionMode::Balanced)
+			.map_err(|e| Error::Codec(anyhow::anyhow!("bgra_to_yuv420 failed for {width}x{height}: {e}")))?;
+		Ok(Self::pack(&planar, width, height, Some(color)))
 	}
 
 	/// Pack strided Y/U/V planes (4:2:0, full-size luma, half-size chroma) into a
@@ -393,23 +388,19 @@ impl I420 {
 		}
 	}
 
-	/// Convert tightly-packed RGB (`width * height * 3` bytes) to I420, BT.601
-	/// limited range. Used for MJPEG capture (Linux V4L2), which decodes to RGB.
+	/// Convert tightly-packed RGB (`width * height * 3` bytes) to I420 in
+	/// [`Color::infer`]'s color space for this size. Used for MJPEG capture
+	/// (Linux V4L2), which decodes to RGB.
 	#[cfg(target_os = "linux")]
 	pub(crate) fn from_rgb(rgb: &[u8], width: u32, height: u32) -> Result<Self, Error> {
 		use yuv::rgb_to_yuv420;
 
+		let color = Color::infer(Size::new(width, height));
+		let (range, matrix) = color.yuv();
 		let mut planar = YuvPlanarImageMut::alloc(width, height, YuvChromaSubsampling::Yuv420);
-		rgb_to_yuv420(
-			&mut planar,
-			rgb,
-			width * 3,
-			YuvRange::Limited,
-			YuvStandardMatrix::Bt601,
-			YuvConversionMode::Balanced,
-		)
-		.map_err(|e| Error::Codec(anyhow::anyhow!("rgb_to_yuv420 failed for {width}x{height}: {e}")))?;
-		Ok(Self::pack(&planar, width, height, Some(Color::Bt601Limited)))
+		rgb_to_yuv420(&mut planar, rgb, width * 3, range, matrix, YuvConversionMode::Balanced)
+			.map_err(|e| Error::Codec(anyhow::anyhow!("rgb_to_yuv420 failed for {width}x{height}: {e}")))?;
+		Ok(Self::pack(&planar, width, height, Some(color)))
 	}
 
 	/// Convert packed YUYV (YUV 4:2:2, `stride` bytes per row) to I420. A chroma
@@ -1521,6 +1512,64 @@ mod tests {
 		assert!(Surface::rgba(&ok[..ok.len() - 4], Size::new(64, 32)).is_err());
 		assert!(Surface::rgba(&ok, Size::new(32, 32)).is_err());
 		assert!(Surface::rgba(&ok, Size::new(0, 32)).is_err());
+	}
+
+	/// The conversion picks its matrix by resolution, matching what a player
+	/// assumes for an untagged stream, and reports the one it used.
+	///
+	/// The regression: every RGB conversion hardcoded BT.601. A 1080p screen
+	/// capture was converted with BT.601, encoded untagged, and decoded with the
+	/// BT.709 inverse, which turns pure red into roughly (255, 24, 0). Grays are
+	/// unaffected, which is why it survived casual inspection.
+	#[test]
+	fn rgb_conversion_follows_the_size_heuristic() {
+		use yuv::{YuvPlanarImage, yuv420_to_rgba};
+
+		use crate::Color;
+
+		let red = |size: Size| {
+			let rgba = [255u8, 0, 0, 255].repeat(size.pixels() as usize);
+			I420::from_rgba(&rgba, size.width * 4, size.width, size.height).unwrap()
+		};
+
+		// Decode with the matrix a player picks for an untagged stream of this
+		// size, and sample the middle of the frame.
+		let decode = |i420: &I420| {
+			let (w, h) = (i420.width, i420.height);
+			let (range, matrix) = Color::infer(Size::new(w, h)).yuv();
+			let planar = YuvPlanarImage {
+				y_plane: i420.y(),
+				y_stride: w,
+				u_plane: i420.u(),
+				u_stride: w / 2,
+				v_plane: i420.v(),
+				v_stride: w / 2,
+				width: w,
+				height: h,
+			};
+			let mut rgba = vec![0u8; (w * h * 4) as usize];
+			yuv420_to_rgba(&planar, &mut rgba, w * 4, range, matrix).unwrap();
+			let px = ((h / 2 * w + w / 2) * 4) as usize;
+			[rgba[px], rgba[px + 1], rgba[px + 2]]
+		};
+
+		for (size, expected) in [
+			(Size::new(720, 480), Color::Bt601Limited),
+			(Size::new(720, 576), Color::Bt601Limited),
+			(Size::new(1280, 720), Color::Bt709Limited),
+			(Size::new(1920, 1080), Color::Bt709Limited),
+		] {
+			let i420 = red(size);
+			assert_eq!(i420.color(), Some(expected), "{size} reported color");
+
+			// Red survives the round trip at every size. Before the fix the 720p and
+			// 1080p cases came back around (255, 24, 0).
+			let rgb = decode(&i420);
+			assert!(
+				rgb[1] <= 2 && rgb[2] <= 2,
+				"{size} red came back as {rgb:?}, so the matrix and the label disagree"
+			);
+		}
 	}
 
 	/// The frame's size comes from the surface rather than a field alongside it,

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -229,6 +229,27 @@ impl Surface {
 		}
 	}
 
+	/// The color space these samples are in, when it is known rather than
+	/// guessed. `None` for a GPU surface whose format names none, and for pixels
+	/// that merely passed through without anything naming their space.
+	///
+	/// Worth reading before encoding pixels you resized: [`resize`](Self::resize)
+	/// carries the space across, so a frame scaled past 576 lines no longer
+	/// matches what an encoder sized for the result would infer. Pass this to
+	/// [`encode::Config::color`](crate::encode::Config::color) to keep the label
+	/// honest.
+	pub fn color(&self) -> Option<Color> {
+		match self {
+			#[cfg(target_os = "macos")]
+			Surface::PixelBuffer(s) => s.color(),
+			#[cfg(target_os = "windows")]
+			Surface::Texture(_) => None,
+			#[cfg(all(target_os = "linux", feature = "nvdec"))]
+			Surface::Cuda(_) => None,
+			Surface::I420(i) => i.color(),
+		}
+	}
+
 	/// A CPU I420 view, downloading a GPU frame only if necessary.
 	pub(crate) fn to_i420(&self) -> Result<Cow<'_, I420>, Error> {
 		match self {
@@ -592,7 +613,8 @@ pub mod macos {
 	use objc2_core_video::{
 		CVPixelBuffer, CVPixelBufferCreate, CVPixelBufferGetBaseAddressOfPlane, CVPixelBufferGetBytesPerRowOfPlane,
 		CVPixelBufferGetPixelFormatType, CVPixelBufferLockBaseAddress, CVPixelBufferLockFlags, CVPixelBufferPool,
-		CVPixelBufferUnlockBaseAddress, kCVPixelBufferHeightKey, kCVPixelBufferIOSurfacePropertiesKey,
+		CVPixelBufferUnlockBaseAddress, kCVImageBufferYCbCrMatrix_ITU_R_601_4, kCVImageBufferYCbCrMatrix_ITU_R_709_2,
+		kCVImageBufferYCbCrMatrixKey, kCVPixelBufferHeightKey, kCVPixelBufferIOSurfacePropertiesKey,
 		kCVPixelBufferPixelFormatTypeKey, kCVPixelBufferWidthKey, kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
 		kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange, kCVPixelFormatType_420YpCbCr8Planar,
 	};
@@ -728,11 +750,57 @@ pub mod macos {
 			result
 		}
 
+		/// The color space this buffer's matrix attachment names, falling back to
+		/// [`Color::infer`] when it carries none.
+		///
+		/// VideoToolbox copies the matrix out of the stream's VUI onto every decoded
+		/// buffer, so this is the source's own answer wherever the source gave one.
+		/// The range is not in this attachment; the caller pairs it with the one the
+		/// pixel format names.
+		fn matrix(&self) -> Color {
+			let inferred = Color::infer(crate::Size::new(self.width, self.height));
+			// SAFETY: a null attachment mode is documented as "don't report it".
+			let Some(value) = (unsafe { self.buffer.attachment(kCVImageBufferYCbCrMatrixKey, ptr::null_mut()) }) else {
+				return inferred;
+			};
+			let Some(name) = value.downcast_ref::<CFString>() else {
+				return inferred;
+			};
+
+			// Compare against the constants rather than the string literals: these
+			// are CFString identities Apple owns, not values we should spell out.
+			if name == unsafe { kCVImageBufferYCbCrMatrix_ITU_R_709_2 } {
+				Color::Bt709Limited
+			} else if name == unsafe { kCVImageBufferYCbCrMatrix_ITU_R_601_4 } {
+				Color::Bt601Limited
+			} else {
+				// BT.2020 and the P3 matrices land here. We have no variant for them,
+				// so the size guess is the least wrong answer available.
+				inferred
+			}
+		}
+
+		/// The color space these samples are in: the matrix from the buffer's
+		/// attachment paired with the range its pixel format names. `None` for a
+		/// format that names neither.
+		pub(crate) fn color(&self) -> Option<Color> {
+			let format = CVPixelBufferGetPixelFormatType(&self.buffer);
+			let limited = if format == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange {
+				true
+			} else if format == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange {
+				false
+			} else {
+				return None;
+			};
+			Some(self.matrix().with_range(limited))
+		}
+
 		/// Download an NV12 surface to packed I420 (the CPU encode path).
 		///
 		/// A deinterleave, not a color conversion, so the samples keep whatever
-		/// space they arrived in. The pixel format names the range, which is
-		/// carried through; the matrix it does not, so that half stays inferred.
+		/// space they arrived in. The pixel format names the range and the buffer's
+		/// matrix attachment names the matrix, so a decoded frame reports the space
+		/// its own bitstream declared rather than one guessed from its size.
 		pub(crate) fn download_i420(&self) -> Result<I420, Error> {
 			let format = CVPixelBufferGetPixelFormatType(&self.buffer);
 			if format != kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange
@@ -743,8 +811,7 @@ pub mod macos {
 				)));
 			}
 
-			let limited = format == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange;
-			let color = Some(Color::infer(crate::Size::new(self.width, self.height)).with_range(limited));
+			let color = self.color();
 
 			let (w, h) = (self.width as usize, self.height as usize);
 			let (cw, ch) = (w / 2, h / 2);


### PR DESCRIPTION
Stacked on #2552 (the `render` work), which is where `Color` and `Color::infer` come from. Base this on `main` once that lands.

## The bug

Every RGB-to-I420 conversion hardcoded BT.601 limited range, and nothing wrote a VUI color description into the encoded bitstream. So a 1080p screen capture on Windows or Linux was converted with BT.601, encoded untagged, and then decoded by any standards-compliant player using the usual size heuristic (BT.601 at 576 lines and below, BT.709 above). The player applies the BT.709 inverse to BT.601 samples.

Saturated colors skew. Pure red arrives as `(255, 24, 0)`, confirmed by round-tripping a 1080p frame through `I420::from_rgba` and back through the BT.709 inverse. Grays sit on the achromatic axis and are untouched, which is why this survived casual inspection.

## The fix

Both halves, against one source of truth. `Color::infer(size)` already encoded the player's heuristic for the renderer, so:

- the RGB conversions pick their matrix from it instead of hardcoding BT.601, and
- the encoders write that same answer into the bitstream's VUI.

The pixels and the label are derived from the same function for the same size, so they cannot drift. `encode::Config` gains an optional `color` override for callers feeding frames the crate did not convert; `None` means `Color::infer`.

### Why both, rather than just the VUI

These are complementary, not alternatives. Writing the VUI removes the guess for a compliant decoder, but it does not reach every path:

| Backend | VUI | Verified |
|---|---|---|
| openh264 | `VuiConfig` | SPS parsed back, 480p + 1080p |
| VideoToolbox | 3 session properties | SPS parsed back, 480p + 1080p |
| NVENC | `h264VUIParameters` / `hevcVUIParameters` | compiles (Linux, container) |
| Media Foundation | 4 `MF_MT_*` attrs on both media types | compiles on the Windows CI runner |
| VAAPI | not expressible | conversion half only |

`VAEncSequenceParameterBufferH264` has no colour description fields at all (its `vui_fields` covers aspect ratio, timing, and bitstream restriction), so the VAAPI backend cannot tag its output today. Media Foundation treats the color attributes as a request a driver may ignore. Picking the matrix by resolution is what keeps both of those correct, because it makes the *untagged* interpretation the right one.

## Testing

The regression tests read the color description back out of the emitted SPS rather than trusting our own config, so a backend that silently drops the VUI fails rather than passing on bookkeeping. `h264-reader` is a new dev-dependency for that, rather than hand-rolling exp-Golomb in a test.

- `rgb_conversion_follows_the_size_heuristic` covers 480p/576p/720p/1080p. Mutation-checked both ways: reverting the matrix while keeping the label honest reproduces `[255, 24, 0]` exactly, and reverting the label alone also fails.
- `the_sps_declares_the_color_space` (openh264) and `videotoolbox_sps_declares_the_color_space` parse the real bitstream at 480p and 1080p.
- 64 tests pass on macOS; `cargo check --all-targets` with `nvenc,vaapi` is clean in a Fedora container; `--features render` still builds.

## Reviewer notes

- **Media Foundation compiles but is not run.** The Windows CI job is green (it caught a missing `IMFMediaType` import along the way), so the code builds against the real SDK. Nothing exercises it at runtime, since CI has no encoder hardware.
- **VAAPI's VUI is the one gap.** `moq-vaapi` writes its own packed SPS, so the colour description could go in there, but that is a separate repo and a version bump. Not urgent: the conversion half already makes VAAPI correct.
- `Color::limited()` moves back onto `Color` from `render/color.rs`. #2552 made it a private render helper on the reasoning that deriving a matrix is the shader's business; the encoders now need it for `video_full_range_flag`, so it is no longer render-only. `weights()` stays in `render/`.
- The `from_yuyv` fix in #2552 (`64bb705`) and mine were the same change, arrived at independently. Kept #2552's version and dropped my duplicate test.
- No wire or catalog change, so no draft update. Whether `hang`'s catalog should carry the color description is a real question, but it is redundant with the bitstream and needs a `draft-lcurley-moq-hang.md` update, so it belongs in its own PR.

## Update: resized frames (review follow-up)

The encoder took its VUI from the config size, but `Frame::resize` carries the
pixels' color space across. Scaling an HD frame down to a sub-576-line rung
produced BT.709 samples under a BT.601 label, the same mismatch one layer up.

`Surface::color` is now public and answers for macOS pixel buffers by reading the
matrix VideoToolbox copies out of the source VUI, so decoded frames report their
real space. moq-transcode opens its encoders from the first decoded frame and
passes that space through, so a rung inherits the source's rather than inventing
one. `Encoder::encode` warns once on a residual mismatch and names
`Config::color` as the fix; it warns rather than rejects because the VUI is fixed
at session open, so the alternatives are a mislabeled stream or a dropped one,
and a gateway should keep serving.

(written by Opus 5)
