### PR TITLE
Internal /nodes endpoint

### DIFF
--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -105,6 +105,21 @@ listen = "0.0.0.0:4443"
 
 See [HTTP Endpoints](/bin/relay/http) for available endpoints.
 
+### \[internal]
+
+Plain HTTP listener for unauthenticated operational endpoints. It is disabled
+unless `listen` is configured. Bind it only to loopback or a trusted private
+network.
+
+```toml
+[internal]
+listen = "127.0.0.1:9101"
+```
+
+It serves `/health`, Prometheus traffic counters at `/metrics`, and the local
+cluster topology view at `/nodes`. See [HTTP Endpoints](/bin/relay/http) for the
+response formats.
+
 ### \[web.https]
 
 HTTPS/WSS server for TCP fallback.

--- a/doc/bin/relay/http.md
+++ b/doc/bin/relay/http.md
@@ -93,6 +93,58 @@ Host overload monitoring (CPU, RAM, network, load average) belongs in a
 separate process that watches the host, not in the relay itself. Point your
 load balancer at that process for load shedding.
 
+## Internal Operations Endpoints
+
+The separate internal listener serves unauthenticated operational endpoints.
+Bind it only to loopback or a trusted private network:
+
+```toml
+[internal]
+listen = "127.0.0.1:9101"
+```
+
+It mirrors `/health`, exposes Prometheus traffic counters at `/metrics`, and
+adds the cluster topology endpoint below.
+
+### GET /nodes
+
+Returns this relay's local view of cluster nodes. A node is included when it is
+visible through the `.internal/origins` discovery namespace or has an
+established outbound cluster connection. An inbound connection is attached
+only after its SETUP origin id maps to one unique node advertisement. Sessions
+without a unique match are omitted.
+
+```json
+{
+  "nodes": [
+    {
+      "node": "https://relay-b.example/",
+      "origin_id": "200",
+      "announced": {
+        "hops": ["200"],
+        "hop_count": 1,
+        "cost": 1
+      },
+      "connections": [
+        { "id": 3, "direction": "inbound" }
+      ]
+    }
+  ]
+}
+```
+
+`announced` describes the selected route for the node's discovery
+advertisement, not every physical link in the cluster. A node can be visible
+without a direct connection, directly connected without an advertisement, or
+both. Origin ids are decimal strings because the wire supports values larger
+than JavaScript's precise integer range. Connection ids are process-local and
+last only for that session.
+
+Inbound association is best-effort correlation, not authenticated node
+identity. The SETUP origin id is self-declared, and `/nodes` associates it only
+when one visible advertisement has the same origin id. Do not use this endpoint
+for authorization or other security decisions.
+
 ## See Also
 
 - [Relay Configuration](/bin/relay/config) - Full config reference

--- a/doc/bin/relay/http.md
+++ b/doc/bin/relay/http.md
@@ -137,8 +137,13 @@ without a unique match are omitted.
 advertisement, not every physical link in the cluster. A node can be visible
 without a direct connection, directly connected without an advertisement, or
 both. Origin ids are decimal strings because the wire supports values larger
-than JavaScript's precise integer range. Connection ids are process-local and
-last only for that session.
+than JavaScript's precise integer range.
+
+A connection `id` is the same id the session's log lines carry in their
+`conn{id=...}` span, so a row here grep's straight to that session's logs.
+Accepted sessions and outbound dials draw from one counter, so an id names
+exactly one session. It is process-local and only lasts for that session, so
+don't persist it or compare it across relays.
 
 Inbound association is best-effort correlation, not authenticated node
 identity. The SETUP origin id is self-declared, and `/nodes` associates it only

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -998,6 +998,14 @@ impl Request {
 		request_ref!(self, r => r.role())
 	}
 
+	/// Returns the origin identity declared by a moq-lite peer.
+	///
+	/// A peer declares this when it attaches a publish or subscribe origin.
+	/// Protocol versions and peers without one return `None`.
+	pub fn peer_origin(&self) -> Option<moq_net::Origin> {
+		request_ref!(self, r => r.peer_origin())
+	}
+
 	/// The client certificate chain the peer presented, if any, validated
 	/// against a configured [`crate::tls::Server::root`] during the handshake.
 	///

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -998,10 +998,13 @@ impl Request {
 		request_ref!(self, r => r.role())
 	}
 
-	/// Returns the origin identity declared by a moq-lite peer.
+	/// The origin identity the peer declared in its SETUP (moq-lite-05+).
 	///
 	/// A peer declares this when it attaches a publish or subscribe origin.
-	/// Protocol versions and peers without one return `None`.
+	/// Older versions and peers without one return `None`.
+	///
+	/// Self-declared, so treat it as a correlation hint rather than an
+	/// authenticated identity: authorize on the token or client certificate.
 	pub fn peer_origin(&self) -> Option<moq_net::Origin> {
 		request_ref!(self, r => r.peer_origin())
 	}

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -325,6 +325,18 @@ impl<S: web_transport_trait::Session> Request<S> {
 		self.role
 	}
 
+	/// The origin identity declared by the peer, when the negotiated protocol carries one.
+	///
+	/// A moq-lite-05+ endpoint declares this when it attaches a publish or
+	/// subscribe origin. Protocol versions and endpoints without one return
+	/// `None`.
+	pub fn peer_origin(&self) -> Option<crate::Origin> {
+		match &self.inner.as_ref().expect("request already responded").handshake {
+			Handshake::LiteSetup { client_setup, .. } => client_setup.origin,
+			_ => None,
+		}
+	}
+
 	/// Publish to the connected client. Overrides any value from the [`Server`]
 	/// builder; typically set after inspecting [`path`](Self::path).
 	pub fn with_publisher(mut self, publish: impl Consume<origin::Consumer>) -> Self {
@@ -524,6 +536,7 @@ impl<S: web_transport_trait::Session> Drop for Request<S> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+	use crate::Origin;
 	use std::{
 		collections::VecDeque,
 		sync::{Arc, Mutex},
@@ -642,7 +655,7 @@ mod tests {
 	}
 
 	/// Encode a lite-05 Setup Stream: the `DataType::Setup` tag then the SETUP message.
-	fn lite05_setup(path: Option<&str>, role: Option<Role>) -> Vec<u8> {
+	fn lite05_setup(path: Option<&str>, role: Option<Role>, origin: Option<Origin>) -> Vec<u8> {
 		let v = lite::Version::Lite05;
 		let mut buf = Vec::new();
 		lite::DataType::Setup.encode(&mut buf, v).unwrap();
@@ -651,7 +664,7 @@ mod tests {
 			path: path.map(str::to_string),
 			role,
 			cost: None,
-			origin: None,
+			origin,
 		}
 		.encode(&mut buf, v)
 		.unwrap();
@@ -712,7 +725,7 @@ mod tests {
 
 	#[tokio::test(start_paused = true)]
 	async fn accept_request_reads_lite05_path() {
-		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(Some("/team/room"), None)]);
+		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(Some("/team/room"), None, None)]);
 		let request = Server::new().accept_request(session).await.unwrap();
 		assert_eq!(request.path(), "/team/room");
 		assert_eq!(request.role(), None, "a client that omits the role is bidirectional");
@@ -720,7 +733,7 @@ mod tests {
 
 	#[tokio::test(start_paused = true)]
 	async fn accept_request_lite05_without_path_is_empty() {
-		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(None, None)]);
+		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(None, None, None)]);
 		let request = Server::new().accept_request(session).await.unwrap();
 		assert_eq!(request.path(), "");
 	}
@@ -729,14 +742,17 @@ mod tests {
 	async fn accept_request_lite05_empty_path_is_accepted() {
 		// An empty path is valid on the wire and means the same as omitting it, so a
 		// client that wants the root doesn't have to special-case the parameter.
-		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(Some(""), None)]);
+		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(Some(""), None, None)]);
 		let request = Server::new().accept_request(session).await.unwrap();
 		assert_eq!(request.path(), "");
 	}
 
 	#[tokio::test(start_paused = true)]
 	async fn accept_request_reads_lite05_role() {
-		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(Some("/team/room"), Some(Role::Publisher))]);
+		let session = FakeSession::new(
+			ALPN_LITE_05,
+			[lite05_setup(Some("/team/room"), Some(Role::Publisher), None)],
+		);
 		let request = Server::new().accept_request(session).await.unwrap();
 		assert_eq!(request.role(), Some(Role::Publisher));
 	}
@@ -745,8 +761,19 @@ mod tests {
 	async fn accept_request_skips_uni_stream_before_setup() {
 		// A GROUP racing ahead of the SETUP is STOP_SENDING-ed and skipped; the gate
 		// keeps reading until it finds the SETUP.
-		let session = FakeSession::new(ALPN_LITE_05, [lite05_group(), lite05_setup(Some("/team/room"), None)]);
+		let session = FakeSession::new(
+			ALPN_LITE_05,
+			[lite05_group(), lite05_setup(Some("/team/room"), None, None)],
+		);
 		let request = Server::new().accept_request(session).await.unwrap();
 		assert_eq!(request.path(), "/team/room");
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn accept_request_reads_lite05_peer_origin() {
+		let origin = Origin::new(42).unwrap();
+		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(None, None, Some(origin))]);
+		let request = Server::new().accept_request(session).await.unwrap();
+		assert_eq!(request.peer_origin(), Some(origin));
 	}
 }

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -80,10 +80,11 @@ impl Server {
 	/// it's empty on versions with no in-band request path (e.g. lite 01-04).
 	pub async fn accept_request<S: web_transport_trait::Session>(&self, session: S) -> Result<Request<S>, Error> {
 		// Regimes without a path to read defer to `ok()` without surfacing one, and
-		// carry no role hint, so authorization is unchanged for them.
+		// carry no role or origin hint, so authorization is unchanged for them.
 		let deferred = |handshake| Request {
 			path: None,
 			role: None,
+			origin: None,
 			inner: Some(RequestInner {
 				server: self.clone(),
 				handshake,
@@ -144,6 +145,7 @@ impl Server {
 				return Ok(Request {
 					path: client_setup.path.clone(),
 					role: client_setup.role,
+					origin: client_setup.origin,
 					inner: Some(RequestInner {
 						server: self.clone(),
 						handshake: Handshake::LiteSetup {
@@ -216,6 +218,7 @@ impl Server {
 		Ok(Request {
 			path,
 			role: None,
+			origin: None,
 			inner: Some(RequestInner {
 				server: self.clone(),
 				handshake: Handshake::Legacy {
@@ -239,6 +242,7 @@ impl Server {
 		Ok(Request {
 			path,
 			role: None,
+			origin: None,
 			inner: Some(RequestInner {
 				server: self.clone(),
 				handshake: Handshake::IetfModern {
@@ -261,6 +265,7 @@ impl Server {
 pub struct Request<S: web_transport_trait::Session> {
 	path: Option<String>,
 	role: Option<Role>,
+	origin: Option<crate::Origin>,
 	// Taken by `ok`/`close`; `Drop` rejects the handshake if neither ran.
 	inner: Option<RequestInner<S>>,
 }
@@ -328,13 +333,12 @@ impl<S: web_transport_trait::Session> Request<S> {
 	/// The origin identity declared by the peer, when the negotiated protocol carries one.
 	///
 	/// A moq-lite-05+ endpoint declares this when it attaches a publish or
-	/// subscribe origin. Protocol versions and endpoints without one return
-	/// `None`.
+	/// subscribe origin. Older versions and endpoints without one return `None`.
+	///
+	/// Self-declared, so treat it as a correlation hint rather than an
+	/// authenticated identity: authorize on the token or client certificate.
 	pub fn peer_origin(&self) -> Option<crate::Origin> {
-		match &self.inner.as_ref().expect("request already responded").handshake {
-			Handshake::LiteSetup { client_setup, .. } => client_setup.origin,
-			_ => None,
-		}
+		self.origin
 	}
 
 	/// Publish to the connected client. Overrides any value from the [`Server`]

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -12,11 +12,7 @@ use reqwest_middleware::ClientWithMiddleware;
 use tokio::task::AbortHandle;
 use url::Url;
 
-use crate::AuthToken;
-
-/// Path prefix under which cluster nodes advertise their own URLs for gossip-style
-/// peer discovery.
-const MESH_PREFIX: &str = ".internal/origins";
+use crate::{AuthToken, nodes::MESH_PREFIX};
 
 /// How often the discovery loop scans for stale entries.
 const SWEEP_INTERVAL: Duration = Duration::from_secs(30);
@@ -364,6 +360,7 @@ pub struct ClusterConfig {
 pub struct Cluster {
 	config: ClusterConfig,
 	client: Option<moq_native::Client>,
+	pub(crate) nodes: crate::nodes::Nodes,
 
 	/// The origin's construction config (identity, cache pool, linger). Kept so
 	/// the `with_*` builders can rebuild the origin without losing each other's
@@ -407,10 +404,12 @@ impl Cluster {
 		};
 		let info = origin::Info::new(id).with_linger(config.linger.unwrap_or(DEFAULT_LINGER));
 		let origin = info.clone().produce();
+		let nodes = crate::nodes::Nodes::new(origin.clone());
 		tracing::info!(origin_id = %origin.id(), configured = config.id.is_some(), "cluster initialized");
 		Ok(Cluster {
 			config,
 			client: None,
+			nodes,
 			client_tls: None,
 			info,
 			origin,
@@ -432,6 +431,7 @@ impl Cluster {
 			.with_pool(cache.pool)
 			.with_cache_duration(cache.duration);
 		self.origin = self.info.clone().produce();
+		self.nodes = self.nodes.with_origin(self.origin.clone());
 		self
 	}
 
@@ -940,6 +940,7 @@ impl Cluster {
 			.connect(url.clone())
 			.await
 			.context("failed to connect to cluster peer")?;
+		let _connection = self.nodes.connect_outbound(log_url.to_string());
 
 		Err(cs.closed().await.into())
 	}
@@ -990,7 +991,6 @@ fn connect_api_is_http(source: &str) -> bool {
 /// verbatim. A bare host or `host:port` is still accepted for backwards
 /// compatibility and wrapped in `https://.../` (callers warn about this legacy
 /// form for user-supplied `--cluster-connect` entries).
-///
 fn peer_url(peer: &str) -> anyhow::Result<Url> {
 	// A full URL has a scheme separator; a bare host or `host:port` does not
 	// (and `Url::parse` would otherwise mis-read `host:port` as scheme `host`).
@@ -1020,7 +1020,7 @@ fn peer_url(peer: &str) -> anyhow::Result<Url> {
 /// A trailing slash on a non-empty URL path does not survive, since a path has no
 /// way to spell one. `https://a.example/edge/` advertises the same as
 /// `https://a.example/edge`.
-fn advertised_node_url(advertised: &str) -> String {
+pub(crate) fn advertised_node_url(advertised: &str) -> String {
 	match advertised.split_once('/') {
 		// The segment already ends in `:`, so this restores the `//` the path ate.
 		Some((scheme, rest)) if scheme.ends_with(':') => format!("{scheme}//{rest}"),
@@ -1040,7 +1040,7 @@ fn is_legacy_peer(peer: &str) -> bool {
 /// session. Drops the query (the jwt isn't part of a peer's identity) and lets
 /// `Url` normalize the scheme, host case, and default port. Falls back to the
 /// raw string if the peer can't be parsed.
-fn canonicalize_peer_key(peer: &str) -> String {
+pub(crate) fn canonicalize_peer_key(peer: &str) -> String {
 	match peer_url(peer) {
 		Ok(mut url) => {
 			url.set_query(None);

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -1,7 +1,10 @@
 use std::{
 	collections::{HashMap, HashSet},
 	path::PathBuf,
-	sync::{Arc, Mutex},
+	sync::{
+		Arc, Mutex,
+		atomic::{AtomicU64, Ordering},
+	},
 	time::{Duration, Instant},
 };
 
@@ -10,6 +13,7 @@ use moq_net::origin;
 use moq_net::{Origin, Path, stats::Tier};
 use reqwest_middleware::ClientWithMiddleware;
 use tokio::task::AbortHandle;
+use tracing::Instrument as _;
 use url::Url;
 
 use crate::{AuthToken, nodes::MESH_PREFIX};
@@ -362,6 +366,11 @@ pub struct Cluster {
 	client: Option<moq_native::Client>,
 	pub(crate) nodes: crate::nodes::Nodes,
 
+	/// Hands out the `conn` id every session logs under, inbound and outbound
+	/// alike, so one id space covers the whole process and an id in the `/nodes`
+	/// view always points at the same session in the logs.
+	connection_ids: Arc<AtomicU64>,
+
 	/// The origin's construction config (identity, cache pool, linger). Kept so
 	/// the `with_*` builders can rebuild the origin without losing each other's
 	/// settings.
@@ -410,6 +419,7 @@ impl Cluster {
 			config,
 			client: None,
 			nodes,
+			connection_ids: Arc::default(),
 			client_tls: None,
 			info,
 			origin,
@@ -451,6 +461,16 @@ impl Cluster {
 	pub fn with_client_tls(mut self, tls: rustls::ClientConfig) -> Self {
 		self.client_tls = Some(Arc::new(tls));
 		self
+	}
+
+	/// Reserve the next `conn` id, the handle a session is logged under.
+	///
+	/// One counter serves inbound accepts and outbound cluster dials, so an id in
+	/// the internal `/nodes` view names exactly one session in the logs. Use it for
+	/// the [`Connection::id`](crate::Connection::id) of every request you accept,
+	/// rather than counting separately.
+	pub fn next_connection_id(&self) -> u64 {
+		self.connection_ids.fetch_add(1, Ordering::Relaxed)
 	}
 
 	/// Attach a stats registry. Replaces the default disabled registry.
@@ -917,6 +937,15 @@ impl Cluster {
 	}
 
 	async fn run_remote_once(&self, url: &Url, cost: Option<u64>) -> anyhow::Result<()> {
+		// Each attempt is its own session, so it gets its own id. Matches the span an
+		// accepted connection runs under, so both directions log the same way.
+		let id = self.next_connection_id();
+		self.run_remote_session(id, url, cost)
+			.instrument(tracing::info_span!("conn", id))
+			.await
+	}
+
+	async fn run_remote_session(&self, id: u64, url: &Url, cost: Option<u64>) -> anyhow::Result<()> {
 		let mut log_url = url.clone();
 		log_url.set_query(None);
 		tracing::info!(url = %log_url, "dialing cluster peer");
@@ -940,7 +969,7 @@ impl Cluster {
 			.connect(url.clone())
 			.await
 			.context("failed to connect to cluster peer")?;
-		let _connection = self.nodes.connect_outbound(log_url.to_string());
+		let _connection = self.nodes.connect_outbound(id, log_url.to_string());
 
 		Err(cs.closed().await.into())
 	}

--- a/rs/moq-relay/src/config.rs
+++ b/rs/moq-relay/src/config.rs
@@ -51,7 +51,7 @@ pub struct Config {
 	#[serde(default)]
 	pub cache: CacheConfig,
 
-	/// Internal (ops) listener for `/metrics`, `/health`, etc. Disabled unless
+	/// Internal (ops) listener for `/metrics`, `/health`, and `/nodes`. Disabled unless
 	/// `internal.listen` is set.
 	#[command(flatten)]
 	#[serde(default)]

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -121,7 +121,7 @@ impl Connection {
 			request = request.with_subscriber(publish);
 		}
 		let session = request.ok().await?;
-		let _node_connection = peer_origin.map(|origin| self.cluster.nodes.connect_inbound(origin));
+		let _node_connection = peer_origin.map(|origin| self.cluster.nodes.connect_inbound(self.id, origin));
 
 		tracing::info!(version = %session.version(), %transport, "negotiated");
 

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -40,6 +40,7 @@ impl Connection {
 	/// Authenticates and serves this connection until it closes.
 	#[tracing::instrument("conn", skip_all, fields(id = self.id))]
 	pub async fn run(self) -> anyhow::Result<()> {
+		let peer_origin = self.request.peer_origin();
 		let token = match self.authenticate().await {
 			Ok(token) => token,
 			Err(err) => {
@@ -120,6 +121,7 @@ impl Connection {
 			request = request.with_subscriber(publish);
 		}
 		let session = request.ok().await?;
+		let _node_connection = peer_origin.map(|origin| self.cluster.nodes.connect_inbound(origin));
 
 		tracing::info!(version = %session.version(), %transport, "negotiated");
 

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -13,6 +13,8 @@
 //!   aggregators).
 //! - `/health` - a liveness mirror of the public probe, for internal checks
 //!   that don't want to hit the customer port.
+//! - `/nodes` - the cluster nodes visible through gossip plus established
+//!   direct relay connections.
 //!
 //! Everything here is unauthenticated, so bind it only to a trusted plane -
 //! loopback for a co-located scraper/agent, or a private overlay address; see
@@ -25,7 +27,7 @@ use std::net;
 
 use anyhow::Context as _;
 use axum::{
-	Router,
+	Json, Router,
 	extract::State,
 	http::{self, StatusCode},
 	response::{IntoResponse, Response},
@@ -39,7 +41,7 @@ use clap::Parser;
 #[non_exhaustive]
 pub struct InternalConfig {
 	/// Socket address for the internal listener (plain HTTP), serving the ops
-	/// endpoints (`/metrics`, `/health`).
+	/// endpoints (`/metrics`, `/health`, and `/nodes`).
 	///
 	/// These endpoints are unauthenticated, so bind it only to a trusted plane:
 	/// loopback (e.g. `127.0.0.1:9101`) for a co-located scraper/agent, or a
@@ -56,21 +58,43 @@ pub struct InternalConfig {
 pub struct Internal {
 	config: InternalConfig,
 	stats: moq_net::stats::Registry,
+	nodes: Option<crate::nodes::Nodes>,
+}
+
+#[derive(Clone)]
+struct InternalState {
+	stats: moq_net::stats::Registry,
+	nodes: Option<crate::nodes::Nodes>,
 }
 
 impl Internal {
 	/// Create the service from its config and the node's stats registry.
 	pub fn new(config: InternalConfig, stats: moq_net::stats::Registry) -> Self {
-		Self { config, stats }
+		Self {
+			config,
+			stats,
+			nodes: None,
+		}
 	}
 
-	/// Build the ops router (`/metrics` + `/health`), with the stats handle
-	/// applied as state. Exposed so embedders can mount it on their own listener.
+	/// Attach the relay cluster used to serve the `/nodes` topology snapshot.
+	pub fn with_cluster(mut self, cluster: &crate::Cluster) -> Self {
+		self.nodes = Some(cluster.nodes.clone());
+		self
+	}
+
+	/// Build the ops router (`/metrics`, `/health`, and `/nodes`).
+	///
+	/// Exposed so embedders can mount it on their own listener.
 	pub fn routes(&self) -> Router {
 		Router::new()
 			.route("/metrics", get(serve_metrics))
 			.route("/health", get(serve_health))
-			.with_state(self.stats.clone())
+			.route("/nodes", get(serve_nodes))
+			.with_state(InternalState {
+				stats: self.stats.clone(),
+				nodes: self.nodes.clone(),
+			})
 	}
 
 	/// Serve on [`InternalConfig::listen`] until it shuts down.
@@ -111,9 +135,18 @@ async fn serve_health() -> Response {
 /// exporter for those, per the relay's separation of concerns. Returns the
 /// current cumulative snapshot; a downstream scraper derives rates and live
 /// counts (`open - closed`).
-async fn serve_metrics(State(stats): State<moq_net::stats::Registry>) -> Response {
-	let body = render_metrics(&stats.snapshot());
+async fn serve_metrics(State(state): State<InternalState>) -> Response {
+	let body = render_metrics(&state.stats.snapshot());
 	([(http::header::CONTENT_TYPE, "text/plain; version=0.0.4")], body).into_response()
+}
+
+/// Cluster nodes currently visible through gossip or a direct outbound dial.
+///
+/// Inbound connections appear only after their SETUP origin identity resolves
+/// to a unique `.internal/origins` node advertisement. Sessions without a
+/// unique match are omitted.
+async fn serve_nodes(State(state): State<InternalState>) -> Json<crate::nodes::Snapshot> {
+	Json(state.nodes.map(|nodes| nodes.snapshot()).unwrap_or_default())
 }
 
 /// Render a [`moq_net::stats::Snapshot`] as Prometheus text exposition (v0.0.4).
@@ -224,6 +257,31 @@ fn render_metrics(snap: &moq_net::stats::Snapshot) -> String {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[tokio::test]
+	async fn nodes_endpoint_is_empty_without_an_attached_cluster() {
+		let state = InternalState {
+			stats: moq_net::stats::Registry::disabled(),
+			nodes: None,
+		};
+
+		let Json(snapshot) = serve_nodes(State(state)).await;
+		assert!(snapshot.nodes.is_empty());
+	}
+
+	#[tokio::test]
+	async fn nodes_endpoint_uses_the_attached_cluster_registry() {
+		let origin = moq_net::Origin::new(100).unwrap().produce();
+		let nodes = crate::nodes::Nodes::new(origin);
+		let _connection = nodes.connect_outbound("https://relay-b.example/");
+		let state = InternalState {
+			stats: moq_net::stats::Registry::disabled(),
+			nodes: Some(nodes),
+		};
+
+		let Json(snapshot) = serve_nodes(State(state)).await;
+		assert_eq!(snapshot.nodes[0].node, "https://relay-b.example/");
+	}
 
 	/// The `/metrics` renderer emits well-formed Prometheus exposition: a
 	/// HELP/TYPE header per metric and a labeled line carrying the live counter

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -273,7 +273,7 @@ mod tests {
 	async fn nodes_endpoint_uses_the_attached_cluster_registry() {
 		let origin = moq_net::Origin::new(100).unwrap().produce();
 		let nodes = crate::nodes::Nodes::new(origin);
-		let _connection = nodes.connect_outbound("https://relay-b.example/");
+		let _connection = nodes.connect_outbound(0, "https://relay-b.example/");
 		let state = InternalState {
 			stats: moq_net::stats::Registry::disabled(),
 			nodes: Some(nodes),

--- a/rs/moq-relay/src/lib.rs
+++ b/rs/moq-relay/src/lib.rs
@@ -14,6 +14,7 @@ mod config;
 mod connection;
 mod http_client;
 mod internal;
+mod nodes;
 mod stats;
 #[cfg(test)]
 mod test_env;

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -98,17 +98,15 @@ async fn main() -> anyhow::Result<()> {
 }
 
 async fn serve(mut server: moq_native::Server, cluster: Cluster, auth: Auth) -> anyhow::Result<()> {
-	let mut conn_id = 0;
-
 	while let Some(request) = server.accept().await {
 		let conn = Connection {
-			id: conn_id,
+			// Shared with outbound cluster dials so one id space covers every session.
+			id: cluster.next_connection_id(),
 			request,
 			cluster: cluster.clone(),
 			auth: auth.clone(),
 		};
 
-		conn_id += 1;
 		tokio::spawn(async move {
 			if let Err(err) = conn.run().await {
 				tracing::warn!(%err, "connection closed");

--- a/rs/moq-relay/src/main.rs
+++ b/rs/moq-relay/src/main.rs
@@ -66,9 +66,9 @@ async fn main() -> anyhow::Result<()> {
 	let cluster = cluster.with_stats(stats.registry().clone());
 
 	// Internal (ops) listener (plain HTTP, opt-in via `--internal-listen`) for
-	// /metrics + /health, separate from the customer-facing web server. No-op
+	// /metrics + /health + /nodes, separate from the customer-facing web server. No-op
 	// when unconfigured.
-	let internal = Internal::new(config.internal, cluster.stats.clone());
+	let internal = Internal::new(config.internal, cluster.stats.clone()).with_cluster(&cluster);
 
 	// Create a web server too. mTLS for HTTPS is opt-in via `--web-https-root`.
 	let web = Web::new(auth.clone(), cluster.clone(), server.certificates(), config.web);

--- a/rs/moq-relay/src/nodes.rs
+++ b/rs/moq-relay/src/nodes.rs
@@ -1,0 +1,344 @@
+use std::{
+	collections::{BTreeMap, HashMap},
+	sync::{
+		Arc, Mutex,
+		atomic::{AtomicU64, Ordering},
+	},
+};
+
+use moq_net::{Origin, origin};
+use serde::Serialize;
+
+/// Namespace containing the empty broadcasts used to advertise cluster nodes.
+pub(crate) const MESH_PREFIX: &str = ".internal/origins";
+
+/// A local view of announced cluster nodes and established direct connections.
+#[derive(Clone)]
+pub(crate) struct Nodes {
+	origin: origin::Producer,
+	connections: Arc<Connections>,
+}
+
+#[derive(Default)]
+struct Connections {
+	next_id: AtomicU64,
+	entries: Mutex<HashMap<u64, ConnectionRecord>>,
+}
+
+#[derive(Clone)]
+struct ConnectionRecord {
+	direction: Direction,
+	target: ConnectionTarget,
+}
+
+#[derive(Clone)]
+enum ConnectionTarget {
+	Node(String),
+	Origin(Origin),
+}
+
+/// The JSON document returned by the internal `/nodes` endpoint.
+#[derive(Debug, Default, Serialize)]
+pub(crate) struct Snapshot {
+	/// Announced or directly connected cluster nodes.
+	pub nodes: Vec<Node>,
+}
+
+/// One known cluster node in the local topology view.
+#[derive(Debug, Serialize)]
+pub(crate) struct Node {
+	/// Canonical URL advertised for the node.
+	pub node: String,
+	/// Origin identity from the node's announcement, when available.
+	pub origin_id: Option<String>,
+	/// Selected route for the node's internal advertisement.
+	pub announced: Option<Announcement>,
+	/// Established direct connections to this node.
+	pub connections: Vec<Connection>,
+}
+
+/// The selected route for a node advertisement.
+#[derive(Debug, Serialize)]
+pub(crate) struct Announcement {
+	/// Origin identities in traversal order, oldest first.
+	pub hops: Vec<String>,
+	/// Number of hops in the selected route.
+	pub hop_count: usize,
+	/// Accumulated cost of the selected route.
+	pub cost: u64,
+}
+
+/// An established direct cluster connection.
+#[derive(Debug, Serialize)]
+pub(crate) struct Connection {
+	/// Process-local connection identifier.
+	pub id: u64,
+	/// Whether this relay accepted or initiated the connection.
+	pub direction: Direction,
+}
+
+/// Direction of an established cluster connection.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum Direction {
+	/// A connection accepted from another relay.
+	Inbound,
+	/// A connection initiated by this relay.
+	Outbound,
+}
+
+struct NodeBuilder {
+	origin_id: Option<String>,
+	announced: Option<Announcement>,
+	connections: Vec<Connection>,
+}
+
+/// Removes a live connection from the topology view when its session ends.
+pub(crate) struct ConnectionGuard {
+	nodes: Nodes,
+	id: u64,
+}
+
+impl Nodes {
+	pub(crate) fn new(origin: origin::Producer) -> Self {
+		Self {
+			origin,
+			connections: Arc::default(),
+		}
+	}
+
+	pub(crate) fn with_origin(mut self, origin: origin::Producer) -> Self {
+		self.origin = origin;
+		self
+	}
+
+	pub(crate) fn connect_outbound(&self, node: impl Into<String>) -> ConnectionGuard {
+		self.connect(Direction::Outbound, ConnectionTarget::Node(node.into()))
+	}
+
+	pub(crate) fn connect_inbound(&self, origin: Origin) -> ConnectionGuard {
+		self.connect(Direction::Inbound, ConnectionTarget::Origin(origin))
+	}
+
+	fn connect(&self, direction: Direction, target: ConnectionTarget) -> ConnectionGuard {
+		let id = self.connections.next_id.fetch_add(1, Ordering::Relaxed);
+		self.connections
+			.entries
+			.lock()
+			.expect("node connection registry poisoned")
+			.insert(id, ConnectionRecord { direction, target });
+		ConnectionGuard {
+			nodes: self.clone(),
+			id,
+		}
+	}
+
+	pub(crate) fn snapshot(&self) -> Snapshot {
+		let mut nodes = BTreeMap::<String, NodeBuilder>::new();
+		let mut origins = HashMap::<u64, Option<String>>::new();
+
+		if let Some(consumer) = self.origin.consume().with_root(MESH_PREFIX) {
+			let mut announced = consumer.announced();
+			while let Some(moq_net::announce::Update {
+				path,
+				broadcast: Some(broadcast),
+			}) = announced.try_next()
+			{
+				let key = canonical_announced_node(path.as_str());
+				let route = broadcast.route();
+				let hop_ids = route.hops.iter().map(|origin| origin.id()).collect::<Vec<_>>();
+				let origin_id = hop_ids.first().copied().unwrap_or_else(|| self.origin.id());
+
+				origins
+					.entry(origin_id)
+					.and_modify(|current| {
+						if current.as_deref() != Some(&key) {
+							*current = None;
+						}
+					})
+					.or_insert_with(|| Some(key.clone()));
+
+				nodes.insert(
+					key,
+					NodeBuilder {
+						origin_id: Some(origin_id.to_string()),
+						announced: Some(Announcement {
+							hop_count: hop_ids.len(),
+							hops: hop_ids.into_iter().map(|origin| origin.to_string()).collect(),
+							cost: route.cost,
+						}),
+						connections: Vec::new(),
+					},
+				);
+			}
+		}
+
+		let connections = self
+			.connections
+			.entries
+			.lock()
+			.expect("node connection registry poisoned");
+		let mut connections = connections.iter().collect::<Vec<_>>();
+		connections.sort_by_key(|(id, _)| **id);
+		for (&id, connection) in connections {
+			let key = match &connection.target {
+				ConnectionTarget::Node(node) => canonical_node(node),
+				ConnectionTarget::Origin(origin) => {
+					let Some(Some(node)) = origins.get(&origin.id()) else {
+						continue;
+					};
+					node.clone()
+				}
+			};
+			let node = nodes.entry(key).or_insert_with(|| NodeBuilder {
+				origin_id: None,
+				announced: None,
+				connections: Vec::new(),
+			});
+			node.connections.push(Connection {
+				id,
+				direction: connection.direction,
+			});
+		}
+
+		Snapshot {
+			nodes: nodes
+				.into_iter()
+				.map(|(key, node)| Node {
+					node: key,
+					origin_id: node.origin_id,
+					announced: node.announced,
+					connections: node.connections,
+				})
+				.collect(),
+		}
+	}
+}
+
+impl Drop for ConnectionGuard {
+	fn drop(&mut self) {
+		self.nodes
+			.connections
+			.entries
+			.lock()
+			.expect("node connection registry poisoned")
+			.remove(&self.id);
+	}
+}
+
+fn canonical_node(node: &str) -> String {
+	crate::cluster::canonicalize_peer_key(node)
+}
+
+fn canonical_announced_node(node: &str) -> String {
+	canonical_node(&crate::cluster::advertised_node_url(node))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use moq_net::{Origin, OriginList, broadcast};
+
+	async fn announced_node(
+		origin: &moq_net::origin::Producer,
+		node: &str,
+		hops: &[u64],
+		cost: u64,
+	) -> broadcast::Producer {
+		let hops = OriginList::try_from(
+			hops.iter()
+				.map(|id| Origin::new(*id).expect("valid test origin"))
+				.collect::<Vec<_>>(),
+		)
+		.unwrap();
+		let path = moq_net::Path::new(MESH_PREFIX).join(node);
+		let broadcast = origin
+			.create_broadcast(&path, broadcast::Route::announced().with_hops(hops).with_cost(cost))
+			.unwrap();
+		origin
+			.consume()
+			.announced_broadcast(&path)
+			.await
+			.expect("test node announced");
+		broadcast
+	}
+
+	#[tokio::test]
+	async fn snapshot_combines_announcements_and_live_connections() {
+		const REMOTE_ID: u64 = 9_007_199_254_740_993;
+
+		let origin = Origin::new(100).unwrap().produce();
+		let nodes = Nodes::new(origin.clone());
+		let _remote = announced_node(&origin, "https://relay-b.example/", &[REMOTE_ID], 7).await;
+		let _outbound = nodes.connect_outbound("https://relay-b.example/");
+		let _inbound = nodes.connect_inbound(Origin::new(REMOTE_ID).unwrap());
+
+		let snapshot = nodes.snapshot();
+		assert_eq!(snapshot.nodes.len(), 1);
+		let node = &snapshot.nodes[0];
+		assert_eq!(node.node, "https://relay-b.example/");
+		assert_eq!(node.origin_id.as_deref(), Some("9007199254740993"));
+		assert_eq!(node.announced.as_ref().unwrap().hops, vec!["9007199254740993"]);
+		assert_eq!(node.announced.as_ref().unwrap().hop_count, 1);
+		assert_eq!(node.announced.as_ref().unwrap().cost, 7);
+		assert_eq!(node.connections.len(), 2);
+		assert_eq!(node.connections[0].direction, Direction::Outbound);
+		assert_eq!(node.connections[1].direction, Direction::Inbound);
+		assert_eq!(
+			serde_json::to_value(&snapshot).unwrap(),
+			serde_json::json!({
+				"nodes": [{
+					"node": "https://relay-b.example/",
+					"origin_id": "9007199254740993",
+					"announced": { "hops": ["9007199254740993"], "hop_count": 1, "cost": 7 },
+					"connections": [
+						{ "id": 0, "direction": "outbound" },
+						{ "id": 1, "direction": "inbound" }
+					]
+				}]
+			}),
+		);
+	}
+
+	#[test]
+	fn snapshot_omits_unresolved_inbound_connections() {
+		let origin = Origin::new(100).unwrap().produce();
+		let nodes = Nodes::new(origin);
+		let _inbound = nodes.connect_inbound(Origin::new(200).unwrap());
+
+		assert!(nodes.snapshot().nodes.is_empty());
+	}
+
+	#[test]
+	fn snapshot_stops_reporting_closed_outbound_connections() {
+		let origin = Origin::new(100).unwrap().produce();
+		let nodes = Nodes::new(origin);
+		let connection = nodes.connect_outbound("https://relay-b.example/");
+		assert_eq!(nodes.snapshot().nodes.len(), 1);
+
+		drop(connection);
+		assert!(nodes.snapshot().nodes.is_empty());
+	}
+
+	#[test]
+	fn outbound_node_omits_credentials_from_url() {
+		let origin = Origin::new(100).unwrap().produce();
+		let nodes = Nodes::new(origin);
+		let _connection = nodes.connect_outbound("https://relay-b.example/?jwt=secret");
+
+		assert_eq!(nodes.snapshot().nodes[0].node, "https://relay-b.example/");
+	}
+
+	#[tokio::test]
+	async fn duplicate_origin_ids_do_not_resolve_inbound_connections() {
+		let origin = Origin::new(100).unwrap().produce();
+		let nodes = Nodes::new(origin.clone());
+		let _first = announced_node(&origin, "https://relay-b.example/", &[200], 1).await;
+		let _second = announced_node(&origin, "https://relay-c.example/", &[200], 1).await;
+		let _inbound = nodes.connect_inbound(Origin::new(200).unwrap());
+
+		let snapshot = nodes.snapshot();
+		assert_eq!(snapshot.nodes.len(), 2);
+		assert!(snapshot.nodes.iter().all(|node| node.connections.is_empty()));
+	}
+}

--- a/rs/moq-relay/src/nodes.rs
+++ b/rs/moq-relay/src/nodes.rs
@@ -1,9 +1,12 @@
+//! The local cluster topology view behind the internal `/nodes` endpoint.
+//!
+//! Combines the node advertisements gossiped under [`MESH_PREFIX`] with the
+//! direct relay sessions this process currently holds, so an operator can see
+//! which peers are visible, which are connected, and who dialed whom.
+
 use std::{
 	collections::{BTreeMap, HashMap},
-	sync::{
-		Arc, Mutex,
-		atomic::{AtomicU64, Ordering},
-	},
+	sync::{Arc, Mutex},
 };
 
 use moq_net::{Origin, origin};
@@ -21,7 +24,6 @@ pub(crate) struct Nodes {
 
 #[derive(Default)]
 struct Connections {
-	next_id: AtomicU64,
 	entries: Mutex<HashMap<u64, ConnectionRecord>>,
 }
 
@@ -71,7 +73,8 @@ pub(crate) struct Announcement {
 /// An established direct cluster connection.
 #[derive(Debug, Serialize)]
 pub(crate) struct Connection {
-	/// Process-local connection identifier.
+	/// The session's `conn` id, matching the `conn{id}` span its log lines carry.
+	/// Process-local, and only meaningful while the session lasts.
 	pub id: u64,
 	/// Whether this relay accepted or initiated the connection.
 	pub direction: Direction,
@@ -93,6 +96,15 @@ struct NodeBuilder {
 	connections: Vec<Connection>,
 }
 
+/// The advertisements one scan of the discovery namespace turned up.
+#[derive(Default)]
+struct Announced {
+	nodes: BTreeMap<String, NodeBuilder>,
+	/// Origin id to the single node advertising it, or `None` once more than one
+	/// does and the id no longer identifies a peer.
+	origins: HashMap<u64, Option<String>>,
+}
+
 /// Removes a live connection from the topology view when its session ends.
 pub(crate) struct ConnectionGuard {
 	nodes: Nodes,
@@ -112,16 +124,23 @@ impl Nodes {
 		self
 	}
 
-	pub(crate) fn connect_outbound(&self, node: impl Into<String>) -> ConnectionGuard {
-		self.connect(Direction::Outbound, ConnectionTarget::Node(node.into()))
+	/// Record a dial this relay initiated, keyed by the URL it dialed.
+	///
+	/// `id` is the session's `conn` id from
+	/// [`Cluster::next_connection_id`](crate::Cluster::next_connection_id).
+	pub(crate) fn connect_outbound(&self, id: u64, node: impl Into<String>) -> ConnectionGuard {
+		self.connect(id, Direction::Outbound, ConnectionTarget::Node(node.into()))
 	}
 
-	pub(crate) fn connect_inbound(&self, origin: Origin) -> ConnectionGuard {
-		self.connect(Direction::Inbound, ConnectionTarget::Origin(origin))
+	/// Record a session this relay accepted, keyed by the origin the peer declared.
+	///
+	/// `id` is the session's `conn` id from
+	/// [`Cluster::next_connection_id`](crate::Cluster::next_connection_id).
+	pub(crate) fn connect_inbound(&self, id: u64, origin: Origin) -> ConnectionGuard {
+		self.connect(id, Direction::Inbound, ConnectionTarget::Origin(origin))
 	}
 
-	fn connect(&self, direction: Direction, target: ConnectionTarget) -> ConnectionGuard {
-		let id = self.connections.next_id.fetch_add(1, Ordering::Relaxed);
+	fn connect(&self, id: u64, direction: Direction, target: ConnectionTarget) -> ConnectionGuard {
 		self.connections
 			.entries
 			.lock()
@@ -133,45 +152,59 @@ impl Nodes {
 		}
 	}
 
-	pub(crate) fn snapshot(&self) -> Snapshot {
-		let mut nodes = BTreeMap::<String, NodeBuilder>::new();
-		let mut origins = HashMap::<u64, Option<String>>::new();
-
-		if let Some(consumer) = self.origin.consume().with_root(MESH_PREFIX) {
-			let mut announced = consumer.announced();
-			while let Some(moq_net::announce::Update {
-				path,
-				broadcast: Some(broadcast),
-			}) = announced.try_next()
-			{
-				let key = canonical_announced_node(path.as_str());
-				let route = broadcast.route();
-				let hop_ids = route.hops.iter().map(|origin| origin.id()).collect::<Vec<_>>();
-				let origin_id = hop_ids.first().copied().unwrap_or_else(|| self.origin.id());
-
-				origins
-					.entry(origin_id)
-					.and_modify(|current| {
-						if current.as_deref() != Some(&key) {
-							*current = None;
-						}
-					})
-					.or_insert_with(|| Some(key.clone()));
-
-				nodes.insert(
-					key,
-					NodeBuilder {
-						origin_id: Some(origin_id.to_string()),
-						announced: Some(Announcement {
-							hop_count: hop_ids.len(),
-							hops: hop_ids.into_iter().map(|origin| origin.to_string()).collect(),
-							cost: route.cost,
-						}),
-						connections: Vec::new(),
-					},
-				);
-			}
+	/// The node advertisements currently visible under [`MESH_PREFIX`].
+	fn announced(&self) -> Announced {
+		match self.origin.consume().with_root(MESH_PREFIX) {
+			Some(consumer) => self.scan_announced(&mut consumer.announced()),
+			None => Announced::default(),
 		}
+	}
+
+	/// Drain every update the cursor has buffered into a node map.
+	fn scan_announced(&self, announced: &mut moq_net::announce::Consumer) -> Announced {
+		let mut scanned = Announced::default();
+
+		while let Some(update) = announced.try_next() {
+			// The origin delivers a re-announce as unannounce-then-announce, so an
+			// unannounce can land mid-drain. Skip it rather than end the scan, which
+			// would drop every node still queued behind it.
+			let Some(broadcast) = update.broadcast else { continue };
+
+			let key = canonical_announced_node(update.path.as_str());
+			let route = broadcast.route();
+			let hop_ids = route.hops.iter().map(|origin| origin.id()).collect::<Vec<_>>();
+			// An advertisement with no hops never crossed a link, so it is our own.
+			let origin_id = hop_ids.first().copied().unwrap_or_else(|| self.origin.id());
+
+			scanned
+				.origins
+				.entry(origin_id)
+				.and_modify(|current| {
+					if current.as_deref() != Some(&key) {
+						*current = None;
+					}
+				})
+				.or_insert_with(|| Some(key.clone()));
+
+			scanned.nodes.insert(
+				key,
+				NodeBuilder {
+					origin_id: Some(origin_id.to_string()),
+					announced: Some(Announcement {
+						hop_count: hop_ids.len(),
+						hops: hop_ids.into_iter().map(|origin| origin.to_string()).collect(),
+						cost: route.cost,
+					}),
+					connections: Vec::new(),
+				},
+			);
+		}
+
+		scanned
+	}
+
+	pub(crate) fn snapshot(&self) -> Snapshot {
+		let Announced { mut nodes, origins } = self.announced();
 
 		let connections = self
 			.connections
@@ -270,8 +303,8 @@ mod tests {
 		let origin = Origin::new(100).unwrap().produce();
 		let nodes = Nodes::new(origin.clone());
 		let _remote = announced_node(&origin, "https://relay-b.example/", &[REMOTE_ID], 7).await;
-		let _outbound = nodes.connect_outbound("https://relay-b.example/");
-		let _inbound = nodes.connect_inbound(Origin::new(REMOTE_ID).unwrap());
+		let _outbound = nodes.connect_outbound(0, "https://relay-b.example/");
+		let _inbound = nodes.connect_inbound(1, Origin::new(REMOTE_ID).unwrap());
 
 		let snapshot = nodes.snapshot();
 		assert_eq!(snapshot.nodes.len(), 1);
@@ -304,7 +337,7 @@ mod tests {
 	fn snapshot_omits_unresolved_inbound_connections() {
 		let origin = Origin::new(100).unwrap().produce();
 		let nodes = Nodes::new(origin);
-		let _inbound = nodes.connect_inbound(Origin::new(200).unwrap());
+		let _inbound = nodes.connect_inbound(0, Origin::new(200).unwrap());
 
 		assert!(nodes.snapshot().nodes.is_empty());
 	}
@@ -313,7 +346,7 @@ mod tests {
 	fn snapshot_stops_reporting_closed_outbound_connections() {
 		let origin = Origin::new(100).unwrap().produce();
 		let nodes = Nodes::new(origin);
-		let connection = nodes.connect_outbound("https://relay-b.example/");
+		let connection = nodes.connect_outbound(0, "https://relay-b.example/");
 		assert_eq!(nodes.snapshot().nodes.len(), 1);
 
 		drop(connection);
@@ -324,9 +357,42 @@ mod tests {
 	fn outbound_node_omits_credentials_from_url() {
 		let origin = Origin::new(100).unwrap().produce();
 		let nodes = Nodes::new(origin);
-		let _connection = nodes.connect_outbound("https://relay-b.example/?jwt=secret");
+		let _connection = nodes.connect_outbound(0, "https://relay-b.example/?jwt=secret");
 
 		assert_eq!(nodes.snapshot().nodes[0].node, "https://relay-b.example/");
+	}
+
+	/// A re-announce reaches the cursor as unannounce-then-announce, so a bare
+	/// unannounce can sit ahead of nodes still queued behind it. Treating that as
+	/// the end of the scan would silently truncate `/nodes` whenever the cluster
+	/// churned mid-request.
+	#[tokio::test(start_paused = true)]
+	async fn scan_skips_an_unannounce_queued_ahead_of_another_node() {
+		let origin = Origin::new(100).unwrap().produce();
+		let nodes = Nodes::new(origin.clone());
+		let mut first = announced_node(&origin, "https://relay-a.example/", &[200], 1).await;
+		let _second = announced_node(&origin, "https://relay-b.example/", &[300], 1).await;
+
+		let consumer = origin.consume().with_root(MESH_PREFIX).expect("mesh prefix is in root");
+		let mut announced = consumer.announced();
+
+		// Take relay-a's replayed announce, then retire it so the cursor queues a
+		// bare unannounce ahead of relay-b's still-pending announce.
+		let first_update = announced.try_next().expect("replayed announce");
+		assert_eq!(
+			canonical_announced_node(first_update.path.as_str()),
+			"https://relay-a.example/"
+		);
+		first.finish();
+		// The origin retires a finished source on a spawned task; time is paused, so
+		// this advances the clock instantly.
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+
+		let scanned = nodes.scan_announced(&mut announced);
+		assert!(
+			scanned.nodes.contains_key("https://relay-b.example/"),
+			"the unannounce ahead of relay-b truncated the scan"
+		);
 	}
 
 	#[tokio::test]
@@ -335,7 +401,7 @@ mod tests {
 		let nodes = Nodes::new(origin.clone());
 		let _first = announced_node(&origin, "https://relay-b.example/", &[200], 1).await;
 		let _second = announced_node(&origin, "https://relay-c.example/", &[200], 1).await;
-		let _inbound = nodes.connect_inbound(Origin::new(200).unwrap());
+		let _inbound = nodes.connect_inbound(0, Origin::new(200).unwrap());
 
 		let snapshot = nodes.snapshot();
 		assert_eq!(snapshot.nodes.len(), 2);


### PR DESCRIPTION
Expoes a new internal `/nodes` endpoint which serves the information about remote nodes that current node knows about, either is connected or knows about them from node announcements.

The idea is to debug how the node views the whole cluster, what nodes it is connected to and who initiated the connection (either outbound or inbound), what nodes are announced but we don't have active connection to.