### PR TITLE
fix(net): prefer the newest route so a reconnect takes over immediately

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -128,7 +128,7 @@ whenever routing prefers another (not only on failure), splicing at the next
 group boundary, so encoders that drift (for example segment-numbered tracks
 from processes started at different times) tear down subscribers on the
 switch. Independent publishers with different tracks or timelines MUST use
-different origin ids; the newcomer then waits as a replacement instead of
+different origin ids; the newcomer then takes the broadcast over instead of
 joining. Run the same command from two aligned encoders, pinning the same id
 on both:
 
@@ -139,9 +139,12 @@ moq --origin 42 --client-connect https://relay-b.example.com/anon --broadcast ev
 
 Leave `--origin` unset everywhere else. The default fresh id per run is what
 makes a restarted encoder look like new content (ending subscriptions and
-invalidating caches) instead of silently splicing mid-stream, and a second
-publisher with a *different* id waits invisibly until the first ends rather
-than joining it.
+invalidating caches) instead of silently splicing mid-stream. A publisher with
+a *different* id takes the broadcast over the moment it announces, ending the
+incumbent rather than waiting behind it, so a reconnect is live again without
+waiting for the relay's transport to time out the connection it replaced. The
+last publisher to announce a path owns it, so use authorization to decide who
+may publish where.
 
 ### Capture a Webcam
 

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -299,10 +299,12 @@ The first entry of the reconstructed path identifies the original publisher (see
 A publisher MUST NOT keep multiple current advertisements for the same broadcast on the same stream: each broadcast has at most one current advertisement at a time, and a second ANNOUNCE_START for an already-available path is a protocol violation (use ANNOUNCE_RESTART).
 A subscriber that sees the same broadcast advertised across multiple streams SHOULD route subscriptions to the advertisement with the lowest Route Cost after adding each arriving link's cost, breaking ties by the shortest total path length (see [ANNOUNCE_START](#announce-start)).
 Advertisements from peers that predate the Route Cost carry an effective cost of 0, so a mixed mesh degrades to shortest-path routing.
+Advertisements that tie on every advertised property SHOULD be broken toward the most recently received: they are indistinguishable to the rest of the mesh, and a publisher reconnecting over a new session is otherwise outranked by the session it replaced until the transport declares that one gone.
 
 Advertisements for the same broadcast path whose reconstructed paths share the same first entry carry interchangeable content: a relay MAY hold them as redundant routes for one broadcast and splice a live subscription across them at a Group boundary, e.g. when the serving route ends.
 Cooperating redundant publishers MAY share a Hop ID to opt into this.
-Advertisements whose first entries differ are distinct broadcasts colliding on one path: a relay MUST NOT splice between them, and SHOULD keep serving the earlier one, treating the later as a replacement only once the earlier ends.
+Advertisements whose first entries differ are distinct broadcasts colliding on one path: a relay MUST NOT splice between them, and SHOULD treat the later as a replacement for the earlier, ending the earlier advertisement before starting the later one.
+Serving the earlier until it ends on its own instead would hold the path for however long the transport takes to notice a publisher is gone, which is exactly the case a reconnecting publisher hits.
 
 When serving a subscription, a publisher MUST select the source by the same rule it uses for advertisements to that session: a path whose entries avoid the origin the subscriber declared in its SETUP (see [Origin Parameter](#origin-parameter)).
 A subscriber that declared no origin is served from the publisher's preferred source as usual.
@@ -1194,13 +1196,13 @@ The `Message Length` describes the payload size on the wire.
 - ANNOUNCE_END and ANNOUNCE_RESTART reference the Announce ID instead of repeating the broadcast path.
 - Replaced the duplicate-`active` restart idiom with ANNOUNCE_RESTART; a second ANNOUNCE_START for an already-available path is now a protocol violation.
 - Defined the first entry of the reconstructed path as the original publisher's identity: a restart that preserves it is a route change (TRACK_INFO stays valid, subscriptions may resume), one that changes it replaces the broadcast (TRACK_INFO discarded, nothing resumes).
-- Added a `Route Cost` field to ANNOUNCE_START and ANNOUNCE_RESTART: the accumulated cost of the transfers a subscription via this advertisement would newly cause. Route selection prefers the lowest cost, with path length as the tie-break.
+- Added a `Route Cost` field to ANNOUNCE_START and ANNOUNCE_RESTART: the accumulated cost of the transfers a subscription via this advertisement would newly cause. Route selection prefers the lowest cost, with path length as the tie-break, and the most recently received advertisement below that.
 - Added a SETUP `Cost` parameter (0x4) declaring the price a link adds to every announcement crossing it; unpriced links default to 1, degrading to shortest-path routing.
 - Removed `Exclude Hop` from ANNOUNCE_REQUEST. The receiver's hop-based loop check already discards a looped announcement, so the field only saved the wasted send.
 - Stated the receiver's loop check normatively in ANNOUNCE_START: an announcement whose reconstructed path contains the receiver's own Hop ID is neither forwarded nor selected as a route.
 - Added a SETUP `Origin` parameter (0x5): each endpoint declares its Hop ID at session setup, carrying session-wide the identity `Exclude Hop` carried per announce stream, and filtering subscriptions as well as announcements (including sessions that never open an Announce Stream).
 - Made advertisement selection per subscriber: the publisher advertises the best path avoiding each subscriber's declared origin (a subscriber the serving path flows through receives the best standby instead of nothing), MUST serve subscriptions by the same exclusion, and the actively-carrying cost discount applies only to the serving path. This is how redundant (shared first hop) publishers fail over across a mesh.
-- Defined same-path advertisements sharing a first entry as interchangeable content a relay may splice across at a Group boundary; differing first entries never splice, the earlier is served until it ends.
+- Defined same-path advertisements sharing a first entry as interchangeable content a relay may splice across at a Group boundary; differing first entries never splice, the later replacing the earlier.
 
 ## moq-lite-05
 - Renamed ANNOUNCE_INTEREST to ANNOUNCE_REQUEST and ANNOUNCE to ANNOUNCE_BROADCAST.

--- a/drafts/draft-lcurley-moq-relay-hops.md
+++ b/drafts/draft-lcurley-moq-relay-hops.md
@@ -166,9 +166,10 @@ A relay MAY additionally avoid sending an advertisement back toward a peer it ca
 ## Path Selection
 A relay or subscriber that receives advertisements for the same namespace over multiple sessions MAY use the length of the HOP_PATH list as a tiebreaker, preferring the advertisement with the fewest hops (usually the lowest-latency path).
 This is advisory: the receiver MAY apply additional local policy (e.g. measured RTT or administrative preference) and is not required to prefer the shortest path.
+Advertisements that tie on every advertised property SHOULD be broken toward the most recently received, so a publisher reconnecting over a new session is not outranked by the session it replaced until the transport declares that one gone.
 
 Two advertisements for the same namespace whose HOP_PATH begins with the same Hop ID share an origin and therefore carry interchangeable content: a receiver MAY hold them as redundant paths and switch between them, including failing an active subscription over to the surviving path when the serving one ends.
-If the first Hop IDs differ, the advertisements come from distinct origins that happen to reuse a namespace, and a receiver MUST NOT treat them as interchangeable; it SHOULD keep serving the earlier one, treating the later as a replacement only once the earlier ends.
+If the first Hop IDs differ, the advertisements come from distinct origins that happen to reuse a namespace, and a receiver MUST NOT treat them as interchangeable; it SHOULD treat the later as a replacement for the earlier rather than serving the earlier until it ends on its own, which would hold the namespace for however long the transport takes to notice a publisher is gone.
 
 A publisher (or relay acting as one) SHOULD advertise, per session, the single best path it knows whose HOP_PATH does not contain the Hop ID the peer declared at setup; when every known path contains it, the publisher SHOULD advertise nothing for that namespace on that session.
 Selection is per session: a peer that the serving path flows through receives the best standby path instead of nothing, which is what lets it fail over to that standby if its own copy dies.

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -65,7 +65,8 @@ pub struct Route {
 	pub hops: OriginList,
 
 	/// The cost of pulling the broadcast via this route, accumulated per link:
-	/// lower wins, with ties broken by hop length and then a deterministic hash.
+	/// lower wins, with ties broken by hop length, then a deterministic hash, and
+	/// finally the most recently attached route.
 	///
 	/// The original publisher seeds it with its production cost (zero for a live
 	/// publish, something large for a standby that would have to start working,

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -4443,6 +4443,11 @@ mod tests {
 	/// the incumbent. An offline source (a cache, or an on-demand handler) is
 	/// ranked below every announced route, so arriving under a different
 	/// publisher must not unannounce a live broadcast and cut its subscribers.
+	///
+	/// The tail of this test covers the park's *exit*: the parked source has to
+	/// wake and attach once the incumbent ends. Nothing else drives that wait, so
+	/// without this a lost wakeup would strand the source invisibly forever
+	/// rather than failing anything.
 	#[tokio::test]
 	async fn test_offline_mismatch_never_evicts_a_live_front() {
 		tokio::time::pause();
@@ -4454,7 +4459,7 @@ mod tests {
 		let hops_live = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
 		let hops_cache = OriginList::try_from(vec![Origin::new(2).unwrap()]).unwrap();
 
-		let live = origin
+		let mut live = origin
 			.create_broadcast("test", announce().with_hops(hops_live.clone()))
 			.unwrap();
 		let mut live_dynamic = live.dynamic();
@@ -4471,14 +4476,28 @@ mod tests {
 
 		// An offline source for different content at the same path: it stays
 		// invisible rather than displacing the live one.
-		let _cache = origin
-			.create_broadcast("test", broadcast::Route::new().with_hops(hops_cache))
+		let cache = origin
+			.create_broadcast("test", broadcast::Route::new().with_hops(hops_cache.clone()))
 			.unwrap();
 		settle().await;
 		settle().await;
 		announced.assert_next_wait();
 		assert!(!face.is_closed(), "the live front must survive");
 		assert_eq!(consumer.get_broadcast("test").unwrap().route().hops, hops_live);
+
+		// The incumbent ending hands the path to the parked source, which is the
+		// only thing that ever wakes that wait.
+		live.finish();
+		settle().await;
+		settle().await;
+		announced.assert_next_none("test");
+		let taken = consumer
+			.get_broadcast("test")
+			.expect("the parked source must take over");
+		assert_eq!(taken.route().hops, hops_cache);
+		// Offline, so it holds the path without being advertised.
+		announced.assert_next_wait();
+		drop(cache);
 	}
 
 	/// A subscription from a peer the active chain flows through is served from

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1,6 +1,7 @@
 use crate::{broadcast, cache, stats, track};
 use kio::Pollable;
 use std::{
+	cmp::Reverse,
 	collections::{BTreeMap, HashMap, HashSet},
 	fmt,
 	sync::Arc,
@@ -413,17 +414,27 @@ fn fnv_key(name: &Path, origins: impl IntoIterator<Item = Origin>) -> u64 {
 	hash
 }
 
-/// Full ordering key for a [`broadcast::Route`]: announced routes first (an
-/// actively published source beats an offline one), then the marginal cost of
-/// pulling via the route, then the [`route_key`] hop ordering. Lower wins.
+/// Full ordering key for an attached route: announced routes first (an actively
+/// published source beats an offline one), then the marginal cost of pulling via
+/// the route, then the [`route_key`] hop ordering, and finally the newest source
+/// to attach. Lower wins.
 ///
 /// Hop length stays the tie-break below cost, so peers that never carry a cost
 /// (pre-lite-06, or a plain local publish) rank exactly as they did before route
 /// cost existed, and equal-cost warm copies resolve to the closest one, which
 /// bounds same-datacenter chains to a single hop.
-fn route_order(name: &Path, route: &broadcast::Route) -> (bool, u64, usize, u64) {
-	let (len, hash) = route_key(name, &route.hops);
-	(!route.announce, route.cost, len, hash)
+///
+/// Recency is the last word, so it only separates routes that are identical in
+/// every advertised respect: same hop chain, same cost. That is a publisher
+/// reconnecting over a fresh session while its old one is still being kept alive
+/// by the transport, and the new session is the one actually carrying frames, so
+/// it wins the moment it attaches instead of after the QUIC idle timeout finally
+/// retires the corpse. Local attach order never leaks into cluster convergence:
+/// routes it can reorder are indistinguishable downstream, since what is
+/// forwarded is the chain and cost, which are equal by construction here.
+fn route_order(name: &Path, route: &FrontRoute) -> (bool, u64, usize, u64, Reverse<u64>) {
+	let (len, hash) = route_key(name, &route.route.hops);
+	(!route.route.announce, route.route.cost, len, hash, Reverse(route.id))
 }
 
 /// One coalesced update queued for an `AnnounceConsumer`.
@@ -995,8 +1006,18 @@ impl Producer {
 	/// at the same path (other local publishers, or sessions attaching announces
 	/// from the network), always serving from the best [`broadcast::Route`] (live
 	/// first, then lowest cost, then shortest hops with a deterministic
-	/// tie-break). When the best source changes, tracks resume from the
-	/// replacement at the first missing group; consumers never observe the swap.
+	/// tie-break, and the newest source among otherwise equal routes). When the
+	/// best source changes, tracks resume from the replacement at the first
+	/// missing group; consumers never observe the swap.
+	///
+	/// Splicing requires the same content identity: every source at a path must
+	/// share the first hop of its route, which is a promise that they produce
+	/// interchangeable tracks. A source arriving with a different first hop is a
+	/// *replacement* instead: it takes the path immediately and consumers see an
+	/// unannounce followed by an announce, rather than unrelated content spliced
+	/// into a live subscription. So a publisher reconnecting under a fresh
+	/// identity displaces the session it replaced right away, without waiting for
+	/// the transport to notice the old one is gone.
 	///
 	/// `route` is the source's initial metadata; update it with
 	/// [`broadcast::Producer::set_route`]. The [`broadcast::Route::announce`] flag
@@ -1188,10 +1209,12 @@ struct FrontState {
 	/// Content identity: the original publisher (first hop) shared by every
 	/// attached source, or `None` for a broadcast produced locally (no hops).
 	/// Fixed for the front's lifetime; a source with a different first hop is
-	/// new content, not an alternate route, so it parks until this front closes
-	/// (see [`attach_source`]). This is the same rule the session layer applies
-	/// to a restart whose first hop changed.
+	/// new content, not an alternate route, so it replaces this front rather than
+	/// joining it (see [`attach_source`]). This is the same rule the session layer
+	/// applies to a restart whose first hop changed.
 	publisher: Option<Origin>,
+	/// Attach counter, handed to each [`FrontRoute`] so [`route_order`] can break
+	/// an exact tie toward the newest source.
 	next_route: u64,
 	routes: Vec<FrontRoute>,
 	/// Peers currently reading this front through the shared broadcast, refcounted
@@ -1214,14 +1237,15 @@ struct FrontState {
 
 impl FrontState {
 	/// The source new track requests should dispatch to: live first, then lowest
-	/// cost, then shortest hop chain with a deterministic hash tie-break, skipping
-	/// routes that flow through a peer currently reading the front while any other
-	/// route remains (see [`Self::prefer_untainted`]).
+	/// cost, then shortest hop chain with a deterministic hash tie-break and the
+	/// newest source last, skipping routes that flow through a peer currently
+	/// reading the front while any other route remains (see
+	/// [`Self::prefer_untainted`]).
 	fn best_route(&self) -> Option<u64> {
 		let candidates: Vec<&FrontRoute> = self.routes.iter().collect();
 		self.prefer_untainted(&candidates)
 			.into_iter()
-			.min_by_key(|r| route_order(&self.path.as_path(), &r.route))
+			.min_by_key(|r| route_order(&self.path.as_path(), r))
 			.map(|r| r.id)
 	}
 
@@ -1235,7 +1259,7 @@ impl FrontState {
 		self.routes
 			.iter()
 			.filter(|r| exclude.is_none_or(|origin| !r.route.hops.contains(&origin)))
-			.min_by_key(|r| route_order(&self.path.as_path(), &r.route))
+			.min_by_key(|r| route_order(&self.path.as_path(), r))
 			.map(|r| r.id)
 	}
 
@@ -1287,7 +1311,7 @@ impl FrontState {
 		let candidates: Vec<&FrontRoute> = self.routes.iter().filter(|r| !skip(r.id)).collect();
 		self.prefer_untainted(&candidates)
 			.into_iter()
-			.min_by_key(|r| route_order(&self.path.as_path(), &r.route))
+			.min_by_key(|r| route_order(&self.path.as_path(), r))
 			.map(|r| r.id)
 	}
 
@@ -1353,7 +1377,7 @@ impl FrontState {
 	/// always what this node is actually serving from.
 	fn routes_snapshot(&self) -> Vec<broadcast::Route> {
 		let mut routes: Vec<&FrontRoute> = self.routes.iter().collect();
-		routes.sort_by_key(|r| route_order(&self.path.as_path(), &r.route));
+		routes.sort_by_key(|r| route_order(&self.path.as_path(), r));
 		routes.sort_by_key(|r| Some(r.id) != self.active);
 		routes.into_iter().map(|r| r.route.clone()).collect()
 	}
@@ -1429,10 +1453,9 @@ fn detach_source(
 /// closes. Spawned by [`Producer::create_broadcast`].
 ///
 /// A source whose original publisher (first hop) differs from the live front's
-/// parks instead of attaching: it waits invisibly until the incumbent closes,
-/// then takes over the path as a fresh broadcast. A route update that changes
-/// the source's own first hop likewise detaches it and re-runs the attach, so a
-/// publisher swap is always a replacement, never a silent splice.
+/// takes the path over as a fresh broadcast rather than joining. A route update
+/// that changes the source's own first hop likewise detaches it and re-runs the
+/// attach, so a publisher swap is always a replacement, never a silent splice.
 async fn run_source(
 	origin: Info,
 	node: Lock<OriginNode>,
@@ -1456,55 +1479,17 @@ async fn run_source(
 	let mut announce = route.announce.then(|| ingress.announce());
 
 	'attach: loop {
-		// Re-resolved every attempt: while this source was parked, the
-		// incumbent's teardown may have pruned the (then-empty) leaf from the
-		// tree, and attaching to the stale lock would publish into an orphan
-		// that lookups can no longer reach.
+		// Re-resolved every attempt: between attaches the previous front's
+		// teardown may have pruned the (then-empty) leaf from the tree, and
+		// attaching to the stale lock would publish into an orphan that lookups
+		// can no longer reach.
 		let leaf = if rest.is_empty() {
 			node.clone()
 		} else {
 			node.lock().leaf(&rest)
 		};
 
-		let (state, broadcast, id) = match attach_source(&origin, &node, &leaf, &full, &rest, &source, route.clone()) {
-			Attach::Attached(state, broadcast, id) => (state, broadcast, id),
-			Attach::Parked(incumbent) => {
-				tracing::warn!(
-					broadcast = %full,
-					"path already live with a different publisher; parking until it ends",
-				);
-				// Wait for the incumbent front to close, or for our own source to
-				// change (a new chain may match, and closure means giving up).
-				let update = kio::wait(|waiter| {
-					if let Poll::Ready(update) = source.poll_route_changed(waiter) {
-						return Poll::Ready(Some(update));
-					}
-					// Ready on either the closed flag or the channel itself dying;
-					// both mean the incumbent is gone.
-					match incumbent.poll(waiter, |s| if s.closed { Poll::Ready(()) } else { Poll::Pending }) {
-						Poll::Ready(_) => Poll::Ready(None),
-						Poll::Pending => Poll::Pending,
-					}
-				})
-				.await;
-				match update {
-					// Our route moved; recompute the guard and retry with it.
-					Some(Ok(update)) => {
-						match (update.announce, announce.is_some()) {
-							(true, false) => announce = Some(ingress.announce()),
-							(false, true) => announce = None,
-							_ => {}
-						}
-						route = update;
-					}
-					// The source closed while parked; it was never visible.
-					Some(Err(_)) => return,
-					// The incumbent is gone; retry, creating a fresh front.
-					None => {}
-				}
-				continue 'attach;
-			}
-		};
+		let (state, broadcast, id) = attach_source(&origin, &node, &leaf, &full, &rest, &source, route.clone());
 		let publisher = route.hops.iter().next().copied();
 
 		loop {
@@ -1555,26 +1540,18 @@ async fn run_source(
 	}
 }
 
-/// The outcome of [`attach_source`].
-enum Attach {
-	/// The source joined (or created) the front at its path.
-	Attached(kio::Producer<FrontState>, broadcast::Producer, u64),
-	/// The path's live front belongs to a different original publisher: the
-	/// source is new content, not an alternate route, and must not splice into
-	/// the incumbent's subscribers. The caller parks on the returned table and
-	/// retries once the incumbent closes (first wins, successor takes over).
-	Parked(kio::Producer<FrontState>),
-}
-
 /// Attach a source to the broadcast at `leaf`, creating (and publishing) the
 /// broadcast if none is live. Returns the shared source table, the spliced
 /// broadcast, and the source's table id. One lock acquisition covers the whole
 /// join-or-create decision, so concurrent attaches cannot race each other.
 ///
-/// Joining requires the same content identity (first hop): a source whose
-/// original publisher differs from the front's is [`Attach::Parked`] instead,
-/// mirroring the session layer's rule that a restart with a different first
-/// hop is a replacement, never a standby.
+/// Joining requires the same content identity (first hop). A source whose
+/// original publisher differs takes the path over instead: the incumbent front
+/// closes and a fresh one is created below, so consumers observe an unannounce
+/// followed by an announce. That mirrors the session layer's rule that a restart
+/// with a different first hop is a replacement, never a standby, and it is what
+/// keeps a reconnect from waiting on the transport to retire the session it
+/// replaced.
 fn attach_source(
 	origin: &Info,
 	node: &Lock<OriginNode>,
@@ -1583,37 +1560,46 @@ fn attach_source(
 	rest: &PathOwned,
 	source: &broadcast::Consumer,
 	route: broadcast::Route,
-) -> Attach {
+) -> (kio::Producer<FrontState>, broadcast::Producer, u64) {
 	let publisher = route.hops.iter().next().copied();
 	let mut leaf_guard = leaf.lock();
 
 	// Join the live broadcast if the leaf already has one. A closed one (torn
-	// down, or awaiting teardown) is replaced below instead.
+	// down, awaiting teardown, or evicted just below) is replaced instead.
 	if let Some(existing) = &leaf_guard.broadcast {
 		let mut joined = None;
 		let carrying = existing.broadcast.demand().is_used();
 		if let Ok(mut s) = existing.state.write()
 			&& !s.closed
 		{
-			if s.publisher != publisher {
-				return Attach::Parked(existing.state.clone());
+			if s.publisher == publisher {
+				let id = s.next_route;
+				s.next_route += 1;
+				s.routes.push(FrontRoute {
+					id,
+					route: route.clone(),
+					source: source.clone(),
+				});
+				s.reselect(carrying);
+				joined = Some(id);
+			} else {
+				// New content at a live path: the newest publisher wins it. Closing
+				// the incumbent here (rather than letting the newcomer wait it out)
+				// is what makes a reconnect immediate, and routing the takeover
+				// through the replacement path below keeps the guarantee that
+				// unrelated content is never spliced into live subscribers. The
+				// incumbent's own task observes the flag and finishes its teardown,
+				// finding the leaf slot already taken.
+				s.closed = true;
+				tracing::warn!(broadcast = %full, "replacing a live broadcast from a different publisher");
 			}
-			let id = s.next_route;
-			s.next_route += 1;
-			s.routes.push(FrontRoute {
-				id,
-				route: route.clone(),
-				source: source.clone(),
-			});
-			s.reselect(carrying);
-			joined = Some(id);
 		}
 		if let Some(id) = joined {
 			let state = existing.state.clone();
 			let broadcast = existing.broadcast.clone();
 			drop(leaf_guard);
 			sync_front(&state, &broadcast, leaf);
-			return Attach::Attached(state, broadcast, id);
+			return (state, broadcast, id);
 		}
 	}
 
@@ -1659,7 +1645,7 @@ fn attach_source(
 
 	web_async::spawn(run_front(state.clone(), broadcast.clone(), node.clone(), rest.clone()));
 
-	Attach::Attached(state, broadcast, 0)
+	(state, broadcast, 0)
 }
 
 /// Owns a front's lifecycle: dispatches each requested track to a serve task
@@ -4232,10 +4218,11 @@ mod tests {
 
 	/// A second source with a different original publisher (first hop) is new
 	/// content, not a standby: it must not splice into the incumbent's
-	/// subscribers. It parks invisibly and takes over the path only once the
-	/// incumbent ends, as a real unannounce + announce.
+	/// subscribers. It takes the path over immediately, as a real unannounce +
+	/// announce, rather than waiting out an incumbent whose session may only be
+	/// alive because the transport has not timed it out yet.
 	#[tokio::test]
-	async fn test_publisher_mismatch_parks() {
+	async fn test_publisher_mismatch_replaces() {
 		tokio::time::pause();
 
 		let origin = Origin::random().produce();
@@ -4249,26 +4236,70 @@ mod tests {
 			.create_broadcast("test", announce().with_hops(hops_a.clone()))
 			.unwrap();
 		settle().await;
-		announced.assert_next_some("test");
+		let face_a = announced.assert_next_some("test");
 
-		// A different publisher at the same path: invisible, the face still
-		// serves A's route.
+		// A different publisher at the same path: the newcomer wins it now, while
+		// the incumbent is still attached and still believes it is publishing.
 		let _source_b = origin
 			.create_broadcast("test", announce().with_hops(hops_b.clone()))
 			.unwrap();
 		settle().await;
 		settle().await;
-		announced.assert_next_wait();
-		assert_eq!(consumer.get_broadcast("test").unwrap().route().hops, hops_a);
+		announced.assert_next_none("test");
+		let face_b = announced.assert_next_some("test");
+		assert!(!face_b.is_clone(&face_a), "a replacement, never a splice");
+		assert_eq!(consumer.get_broadcast("test").unwrap().route().hops, hops_b);
+		// The displaced front is torn down, not merely unpublished: leaving it
+		// running would strand its subscribers and its source watchers on a face
+		// nothing can reach.
+		assert!(face_a.is_closed(), "the displaced front must close");
 
-		// The incumbent ending hands the path to the parked replacement:
-		// downstream observes a replacement, never a splice.
+		// The displaced incumbent ending is invisible: it no longer owns the path.
 		source_a.finish();
 		settle().await;
 		settle().await;
-		announced.assert_next_none("test");
-		announced.assert_next_some("test");
+		announced.assert_next_wait();
 		assert_eq!(consumer.get_broadcast("test").unwrap().route().hops, hops_b);
+	}
+
+	/// A publisher reconnecting under the same identity attaches as a second
+	/// route with an identical hop chain and cost. The new session is the one
+	/// actually carrying frames, so it must win selection immediately rather than
+	/// waiting for the transport to retire the old one.
+	#[tokio::test]
+	async fn test_reconnect_wins_over_stale_route() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		let consumer = origin.consume();
+
+		let publisher = Origin::new(1).unwrap();
+		let hops = OriginList::try_from(vec![publisher]).unwrap();
+
+		// The original session, still attached: its QUIC connection has not been
+		// declared dead yet.
+		let stale = origin
+			.create_broadcast("test", announce().with_hops(hops.clone()))
+			.unwrap();
+		let mut stale_dynamic = stale.dynamic();
+		settle().await;
+
+		// The same publisher reconnecting over a fresh session.
+		let fresh = origin
+			.create_broadcast("test", announce().with_hops(hops.clone()))
+			.unwrap();
+		let mut fresh_dynamic = fresh.dynamic();
+		settle().await;
+		settle().await;
+
+		// Track requests dispatch to the reconnect, not the corpse.
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		settle().await;
+		let _producer = accept_track(&mut fresh_dynamic, "video").await;
+		settle().await;
+		subscribing.await.unwrap();
+		stale_dynamic.assert_no_request();
 	}
 
 	/// A subscription from a peer the active chain flows through is served from

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1012,12 +1012,14 @@ impl Producer {
 	///
 	/// Splicing requires the same content identity: every source at a path must
 	/// share the first hop of its route, which is a promise that they produce
-	/// interchangeable tracks. A source arriving with a different first hop is a
-	/// *replacement* instead: it takes the path immediately and consumers see an
-	/// unannounce followed by an announce, rather than unrelated content spliced
-	/// into a live subscription. So a publisher reconnecting under a fresh
-	/// identity displaces the session it replaced right away, without waiting for
-	/// the transport to notice the old one is gone.
+	/// interchangeable tracks. An *announced* source arriving with a different
+	/// first hop is a replacement instead: it takes the path immediately and
+	/// consumers see an unannounce followed by an announce, rather than unrelated
+	/// content spliced into a live subscription. So a publisher reconnecting
+	/// under a fresh identity displaces the session it replaced right away,
+	/// without waiting for the transport to notice the old one is gone. An
+	/// offline source never displaces anything: it ranks below every announced
+	/// route, so it waits invisibly for the incumbent to end.
 	///
 	/// `route` is the source's initial metadata; update it with
 	/// [`broadcast::Producer::set_route`]. The [`broadcast::Route::announce`] flag
@@ -1208,10 +1210,11 @@ struct FrontState {
 	self_origin: Origin,
 	/// Content identity: the original publisher (first hop) shared by every
 	/// attached source, or `None` for a broadcast produced locally (no hops).
-	/// Fixed for the front's lifetime; a source with a different first hop is
-	/// new content, not an alternate route, so it replaces this front rather than
-	/// joining it (see [`attach_source`]). This is the same rule the session layer
-	/// applies to a restart whose first hop changed.
+	/// Fixed for the front's lifetime; a source with a different first hop is new
+	/// content, not an alternate route, so it replaces this front (or waits for
+	/// it, when offline) rather than joining it (see [`attach_source`]). This is
+	/// the same rule the session layer applies to a restart whose first hop
+	/// changed.
 	publisher: Option<Origin>,
 	/// Attach counter, handed to each [`FrontRoute`] so [`route_order`] can break
 	/// an exact tie toward the newest source.
@@ -1230,8 +1233,9 @@ struct FrontState {
 	/// [`Info::linger`]). [`run_front`] arms the countdown when the table empties.
 	linger: Duration,
 	/// Terminal: no more sources may attach and every poller stops. Set
-	/// synchronously by the detach that empties the table, or by [`run_front`]
-	/// when the linger window expires without a replacement.
+	/// synchronously by the detach that empties the table or by an
+	/// [`attach_source`] takeover, and by [`run_front`] when the linger window
+	/// expires without a replacement.
 	closed: bool,
 }
 
@@ -1452,10 +1456,11 @@ fn detach_source(
 /// route observation, forwards route updates, and detaches it when the source
 /// closes. Spawned by [`Producer::create_broadcast`].
 ///
-/// A source whose original publisher (first hop) differs from the live front's
-/// takes the path over as a fresh broadcast rather than joining. A route update
-/// that changes the source's own first hop likewise detaches it and re-runs the
-/// attach, so a publisher swap is always a replacement, never a silent splice.
+/// An announced source whose original publisher (first hop) differs from the
+/// live front's takes the path over as a fresh broadcast rather than joining; an
+/// offline one parks until the front closes. A route update that changes the
+/// source's own first hop likewise detaches it and re-runs the attach, so a
+/// publisher swap is always a replacement, never a silent splice.
 async fn run_source(
 	origin: Info,
 	node: Lock<OriginNode>,
@@ -1464,6 +1469,13 @@ async fn run_source(
 	mut source: broadcast::Consumer,
 	ingress: stats::Scope,
 ) {
+	let ctx = AttachContext {
+		origin: &origin,
+		node: &node,
+		full: &full,
+		rest: &rest,
+	};
+
 	// The first `route_changed` yields the current route immediately; nothing is
 	// visible to consumers until this attach, giving the creator a window to set
 	// up tracks and dynamic handlers.
@@ -1489,7 +1501,46 @@ async fn run_source(
 			node.lock().leaf(&rest)
 		};
 
-		let (state, broadcast, id) = attach_source(&origin, &node, &leaf, &full, &rest, &source, route.clone());
+		let (state, broadcast, id) = match attach_source(&ctx, &leaf, &source, route.clone()) {
+			Attach::Ready(state, broadcast, id) => (state, broadcast, id),
+			Attach::Parked(incumbent) => {
+				tracing::warn!(
+					broadcast = %full,
+					"path already live with a different publisher; parking an offline source until it ends",
+				);
+				// Wait for the incumbent front to close, or for our own route to
+				// change: announcing ourselves is what earns the takeover, and our
+				// source closing means giving up.
+				let update = kio::wait(|waiter| {
+					if let Poll::Ready(update) = source.poll_route_changed(waiter) {
+						return Poll::Ready(Some(update));
+					}
+					// Ready on either the closed flag or the channel itself dying;
+					// both mean the incumbent is gone.
+					match incumbent.poll(waiter, |s| if s.closed { Poll::Ready(()) } else { Poll::Pending }) {
+						Poll::Ready(_) => Poll::Ready(None),
+						Poll::Pending => Poll::Pending,
+					}
+				})
+				.await;
+				match update {
+					// Our route moved; recompute the guard and retry with it.
+					Some(Ok(update)) => {
+						match (update.announce, announce.is_some()) {
+							(true, false) => announce = Some(ingress.announce()),
+							(false, true) => announce = None,
+							_ => {}
+						}
+						route = update;
+					}
+					// The source closed while parked; it was never visible.
+					Some(Err(_)) => return,
+					// The incumbent is gone; retry, creating a fresh front.
+					None => {}
+				}
+				continue 'attach;
+			}
+		};
 		let publisher = route.hops.iter().next().copied();
 
 		loop {
@@ -1540,9 +1591,30 @@ async fn run_source(
 	}
 }
 
+/// The outcome of [`attach_source`].
+enum Attach {
+	/// The source joined (or created) the front at its path, yielding the shared
+	/// source table, the spliced broadcast, and the source's table id.
+	Ready(kio::Producer<FrontState>, broadcast::Producer, u64),
+	/// The path's live front belongs to a different original publisher and this
+	/// source is offline, so it would rank below every route the front holds and
+	/// must not take the path from it. The caller parks on the returned table
+	/// until the front closes.
+	Parked(kio::Producer<FrontState>),
+}
+
+/// Everything about a source's attach that does not change between attempts.
+struct AttachContext<'a> {
+	origin: &'a Info,
+	node: &'a Lock<OriginNode>,
+	/// Absolute path, for the front's identity and log lines.
+	full: &'a PathOwned,
+	/// Path relative to `node`, for locating (and later pruning) the leaf.
+	rest: &'a PathOwned,
+}
+
 /// Attach a source to the broadcast at `leaf`, creating (and publishing) the
-/// broadcast if none is live. Returns the shared source table, the spliced
-/// broadcast, and the source's table id. One lock acquisition covers the whole
+/// broadcast if none is live. One lock acquisition covers the whole
 /// join-or-create decision, so concurrent attaches cannot race each other.
 ///
 /// Joining requires the same content identity (first hop). A source whose
@@ -1552,15 +1624,17 @@ async fn run_source(
 /// with a different first hop is a replacement, never a standby, and it is what
 /// keeps a reconnect from waiting on the transport to retire the session it
 /// replaced.
+///
+/// Taking over requires announcing, which keeps the rule consistent with
+/// [`route_order`]: an offline source ranks below every announced route, so it
+/// waits ([`Attach::Parked`]) rather than unannouncing a live broadcast and
+/// cutting its subscribers for content nobody has advertised.
 fn attach_source(
-	origin: &Info,
-	node: &Lock<OriginNode>,
+	ctx: &AttachContext,
 	leaf: &Lock<OriginNode>,
-	full: &PathOwned,
-	rest: &PathOwned,
 	source: &broadcast::Consumer,
 	route: broadcast::Route,
-) -> (kio::Producer<FrontState>, broadcast::Producer, u64) {
+) -> Attach {
 	let publisher = route.hops.iter().next().copied();
 	let mut leaf_guard = leaf.lock();
 
@@ -1582,6 +1656,8 @@ fn attach_source(
 				});
 				s.reselect(carrying);
 				joined = Some(id);
+			} else if !route.announce {
+				return Attach::Parked(existing.state.clone());
 			} else {
 				// New content at a live path: the newest publisher wins it. Closing
 				// the incumbent here (rather than letting the newcomer wait it out)
@@ -1591,7 +1667,7 @@ fn attach_source(
 				// incumbent's own task observes the flag and finishes its teardown,
 				// finding the leaf slot already taken.
 				s.closed = true;
-				tracing::warn!(broadcast = %full, "replacing a live broadcast from a different publisher");
+				tracing::warn!(broadcast = %ctx.full, "replacing a live broadcast from a different publisher");
 			}
 		}
 		if let Some(id) = joined {
@@ -1599,17 +1675,19 @@ fn attach_source(
 			let broadcast = existing.broadcast.clone();
 			drop(leaf_guard);
 			sync_front(&state, &broadcast, leaf);
-			return (state, broadcast, id);
+			return Attach::Ready(state, broadcast, id);
 		}
 	}
 
 	// First source: create the broadcast and publish it into the tree.
 	let announce = route.announce;
-	let broadcast = broadcast::Producer::new_spliced(broadcast::Info { origin: origin.clone() });
+	let broadcast = broadcast::Producer::new_spliced(broadcast::Info {
+		origin: ctx.origin.clone(),
+	});
 	let _ = broadcast.clone().set_route(route.clone());
 	let state = kio::Producer::new(FrontState {
-		path: full.clone(),
-		self_origin: origin.id,
+		path: ctx.full.clone(),
+		self_origin: ctx.origin.id,
 		publisher,
 		next_route: 1,
 		excluded: HashMap::new(),
@@ -1619,7 +1697,7 @@ fn attach_source(
 			source: source.clone(),
 		}],
 		active: Some(0),
-		linger: origin.linger,
+		linger: ctx.origin.linger,
 		closed: false,
 	});
 
@@ -1632,20 +1710,25 @@ fn attach_source(
 		leaf_guard.notify.lock().unannounce(&stale.path);
 	}
 	let entry = OriginBroadcast {
-		path: full.clone(),
+		path: ctx.full.clone(),
 		broadcast: broadcast.clone(),
 		state: state.clone(),
 		announced: announce,
 	};
 	if entry.announced {
-		leaf_guard.notify.lock().announce(full, &broadcast.consume());
+		leaf_guard.notify.lock().announce(ctx.full, &broadcast.consume());
 	}
 	leaf_guard.broadcast = Some(entry);
 	drop(leaf_guard);
 
-	web_async::spawn(run_front(state.clone(), broadcast.clone(), node.clone(), rest.clone()));
+	web_async::spawn(run_front(
+		state.clone(),
+		broadcast.clone(),
+		ctx.node.clone(),
+		ctx.rest.clone(),
+	));
 
-	(state, broadcast, 0)
+	Attach::Ready(state, broadcast, 0)
 }
 
 /// Owns a front's lifecycle: dispatches each requested track to a serve task
@@ -3020,6 +3103,18 @@ mod tests {
 			Some(1),
 			"a direct publisher route must win while carrying"
 		);
+
+		// The peer's session reconnecting: same chain, same cost, so the gate's
+		// strictly-cheaper test does not apply and recency decides. Loosening that
+		// test to `<=` would hold a carrying front on the dead session until the
+		// transport timed it out, which is the whole point of the recency order.
+		let mut state = front_state(lost, vec![sibling_route(peer), sibling_route(peer)]);
+		state.reselect(true);
+		assert_eq!(
+			state.active,
+			Some(1),
+			"a reconnect on an identical chain must win while carrying"
+		);
 	}
 
 	/// The gate only protects an announced incumbent: one that lost its announce
@@ -4300,6 +4395,90 @@ mod tests {
 		settle().await;
 		subscribing.await.unwrap();
 		stale_dynamic.assert_no_request();
+	}
+
+	/// The same reconnect, but arriving while a subscription is already spliced
+	/// onto the stale route: the live track must re-splice onto the new session
+	/// rather than ride the dead one until the transport gives up. The gate
+	/// [`FrontState::reselect`] applies while carrying is pinned separately, in
+	/// [`test_carrying_switches_to_benign_routes`].
+	#[tokio::test]
+	async fn test_carrying_reconnect_switches_immediately() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		let consumer = origin.consume();
+
+		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+
+		let stale = origin
+			.create_broadcast("test", announce().with_hops(hops.clone()))
+			.unwrap();
+		let mut stale_dynamic = stale.dynamic();
+		settle().await;
+
+		// A live subscription riding the original session.
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		settle().await;
+		let _stale_producer = accept_track(&mut stale_dynamic, "video").await;
+		settle().await;
+		// Held: the splice only follows the active route while the track is read.
+		let _subscription = subscribing.await.unwrap();
+
+		// The reconnect arrives with the front already carrying.
+		let fresh = origin
+			.create_broadcast("test", announce().with_hops(hops.clone()))
+			.unwrap();
+		let mut fresh_dynamic = fresh.dynamic();
+		settle().await;
+		settle().await;
+
+		// The carrying front re-splices onto the reconnect rather than waiting for
+		// the stale session to die.
+		let _fresh_producer = accept_track(&mut fresh_dynamic, "video").await;
+	}
+
+	/// Taking the path over is scoped to a newcomer that would actually outrank
+	/// the incumbent. An offline source (a cache, or an on-demand handler) is
+	/// ranked below every announced route, so arriving under a different
+	/// publisher must not unannounce a live broadcast and cut its subscribers.
+	#[tokio::test]
+	async fn test_offline_mismatch_never_evicts_a_live_front() {
+		tokio::time::pause();
+
+		let origin = Origin::random().produce();
+		let consumer = origin.consume();
+		let mut announced = consumer.announced();
+
+		let hops_live = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let hops_cache = OriginList::try_from(vec![Origin::new(2).unwrap()]).unwrap();
+
+		let live = origin
+			.create_broadcast("test", announce().with_hops(hops_live.clone()))
+			.unwrap();
+		let mut live_dynamic = live.dynamic();
+		settle().await;
+		let face = announced.assert_next_some("test");
+
+		// A subscriber riding the live broadcast, which the eviction would cut.
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+		let subscribing = broadcast.track("video").unwrap().subscribe(None);
+		settle().await;
+		let _producer = accept_track(&mut live_dynamic, "video").await;
+		settle().await;
+		subscribing.await.unwrap();
+
+		// An offline source for different content at the same path: it stays
+		// invisible rather than displacing the live one.
+		let _cache = origin
+			.create_broadcast("test", broadcast::Route::new().with_hops(hops_cache))
+			.unwrap();
+		settle().await;
+		settle().await;
+		announced.assert_next_wait();
+		assert!(!face.is_closed(), "the live front must survive");
+		assert_eq!(consumer.get_broadcast("test").unwrap().route().hops, hops_live);
 	}
 
 	/// A subscription from a peer the active chain flows through is served from


### PR DESCRIPTION
## Summary

A publisher reconnecting could not reclaim its path until the transport retired the session it replaced. For an ungraceful disconnect that is the QUIC idle timeout (30s by default), which is the failover-latency caveat called out at the bottom of #2473. Two separate mechanisms preferred the older route, depending on whether the reconnect keeps its origin id:

- **Same origin id** (a Rust publisher, or an upstream relay reconnecting): both sessions attach as routes to one front, but their hop chains and costs are *identical*, so `route_order` tied exactly and `min_by_key` returned the first inserted, i.e. the corpse. Recency (`Reverse(FrontRoute::id)`, the front's attach counter) is now the final tie-break, below the hop hash, so it only separates routes that are indistinguishable to the rest of the mesh. Local attach order never leaks into cluster convergence: what gets forwarded is the chain and cost, equal by construction wherever it applies.
- **Different origin id** (`js/net` mints one per connection, so *every* browser reconnect): the newcomer never entered the table at all. `attach_source` parked it on a first-hop mismatch and waited out the incumbent's idle timeout plus the origin linger. An **announced** newcomer now closes the incumbent front and falls through to the existing stale-entry replacement path, so consumers observe an unannounce followed by an announce. That preserves the guarantee the park was protecting (unrelated content is never *spliced* into a live subscription) while making the swap immediate.

Taking a path over requires announcing, which keeps the takeover consistent with the ordering it extends: an offline source (`Route::new()`, the shape a cache or on-demand handler uses) ranks below every announced route, so it still parks rather than unannouncing a live broadcast and cutting its subscribers. The second commit fixes that; the first commit alone would let an offline different-publisher source evict a live front, which `test_offline_mismatch_never_evicts_a_live_front` reproduces.

### Behavioral change worth reviewing

Path ownership is now last-writer-wins among *announced* publishers: one announcing a path that a live different publisher holds evicts them rather than queueing behind them. Nothing can distinguish "dead but not yet timed out" from "alive" at attach time, so preferring the newest requires this. Authorization is what decides who may publish where; a takeover logs a warning. Redundant 1+1 publishers are unaffected, since they share an origin id and remain standbys.

The displaced source is orphaned rather than re-queued: it does not reclaim the path if the usurper later leaves. That is deliberate, since re-attaching on eviction would let two live publishers evict each other in a loop.

## Public API changes

None. No signature changes; `route_order`, `attach_source`, `Attach`, and `AttachContext` are private. `origin::Producer::create_broadcast` changes behavior only (an announced different-first-hop source replaces instead of parking), which reverses the corresponding bullet in #2473. Targets `main` per the branch-targeting rules.

## Wire / draft

No wire-format change. Both drafts normatively specified the old rule and are updated: `draft-lcurley-moq-lite.md` and `draft-lcurley-moq-relay-hops.md` now specify the recency tie-break and later-replaces-earlier instead of "keep serving the earlier one until it ends". Both are scoped to *advertisements*, which matches the announce requirement above. lite-06 is unreleased, so its changelog bullets are amended in place rather than appended.

## Cross-package sync

- `drafts/`: both drafts above.
- `doc/bin/cli.md`: the "Redundant Publishers (1+1)" section said a different-id publisher waits invisibly; it now describes the takeover and points at authorization for path ownership.
- `js/net`: no mirror needed. It is a leaf with no multi-route origin table, and nothing on the wire changed.

## Test plan

- `test_reconnect_wins_over_stale_route`: a same-id reconnect attaches alongside the stale route, and track requests dispatch to the new session while the stale source receives none.
- `test_carrying_reconnect_switches_immediately`: the same reconnect arriving while a subscription is already spliced onto the stale route, which re-splices onto the new session.
- `test_offline_mismatch_never_evicts_a_live_front`: an offline different-publisher source at a path with a live announced front and an active subscriber leaves both intact.
- `test_publisher_mismatch_replaces` (was `test_publisher_mismatch_parks`): the announced takeover is immediate, is a distinct face rather than a splice, and the displaced front is *closed* rather than merely unpublished.
- `test_carrying_switches_to_benign_routes` gains a tied-cost reconnect case, pinning that `reselect`'s simultaneous-activation gate stays strictly-cheaper.
- `test_offline_mismatch_never_evicts_a_live_front` also drives the park's *exit*: the incumbent ends and the parked source takes over. A review pass caught that nothing covered this (a panic planted in the wake path left all 602 tests green), which matters because a lost wakeup there strands a publisher invisibly rather than failing anything.
- Every guard above is mutation-checked: dropping `Reverse(route.id)`, dropping `s.closed = true`, dropping the `!route.announce` park, stubbing the park's incumbent poll to `Pending`, and loosening the gate to `<=` each fail exactly one test. (The eviction was invisible until the `is_closed` assertion was added, since the replacement path fires either way.)
- `just check` clean; `cargo test -p moq-net` 602 passing; `just rs loom` passes (this touches `moq-net/src/model/`).

Tooling note: finding the park gap took two runs that hung and pegged a core, because `cargo test` has no timeout. That fix (nextest by default, plus an `opt-level` override that takes the RSA keygen tests from 16s to 0.8s) is split out into #2558 rather than bundled here.

## Review notes

CodeRabbit's two maintainability findings are addressed in the second commit (`attach_source` down to 4 parameters via `AttachContext`; the `FrontState::closed` doc now lists all three triggers), as is its suggested carrying-reconnect test. Its premise for that test was half right: for a single-hop publisher chain the gate is unreachable on `hops.len() >= 2` regardless of the cost comparison, so the `<` boundary is pinned by the unit-level case in `test_carrying_switches_to_benign_routes` instead.

(Written by Opus 5)
