### PR TITLE
fix(publish): stop pinning a capture device the app never chose

### DIFF
--- a/js/publish/src/source/camera.ts
+++ b/js/publish/src/source/camera.ts
@@ -35,7 +35,12 @@ export class Camera {
 	/** The available cameras and which one to use. */
 	readonly device: Device<"video">;
 
-	/** The live-editable capture constraints, merged over {@link DEFAULT_CONSTRAINTS}. */
+	/**
+	 * The live-editable capture constraints, merged over {@link DEFAULT_CONSTRAINTS}.
+	 *
+	 * `facingMode` picks the front or rear camera, but only while `device.preferred` is unset: an
+	 * explicit deviceId names one camera and wins.
+	 */
 	constraints: Signal<Video.Constraints | undefined>;
 
 	readonly #out: CameraOutput = {

--- a/js/publish/src/source/camera.ts
+++ b/js/publish/src/source/camera.ts
@@ -38,8 +38,8 @@ export class Camera {
 	/**
 	 * The live-editable capture constraints, merged over {@link DEFAULT_CONSTRAINTS}.
 	 *
-	 * `facingMode` picks the front or rear camera, but only while `device.preferred` is unset: an
-	 * explicit deviceId names one camera and wins.
+	 * `facingMode` picks the front or rear camera, unless `device.preferred` names one that is
+	 * actually available: an explicit deviceId wins.
 	 */
 	constraints: Signal<Video.Constraints | undefined>;
 

--- a/js/publish/src/source/device.test.ts
+++ b/js/publish/src/source/device.test.ts
@@ -1,0 +1,120 @@
+import { expect, test } from "bun:test";
+import { Device } from "./device";
+import { Microphone } from "./microphone";
+
+// Android's Chromium enumerates communication devices (output routes) as audioinput, and lists the
+// earpiece first. The "default" alias carries a groupId of its own, matching nothing.
+const ANDROID: MediaDeviceInfo[] = [
+	info("default", "Default", "a6c0aec8"),
+	info("a38808f8b6", "Headset earpiece", "187ba5af"),
+	info("135f4a3918", "Speakerphone", "b09d1d01"),
+];
+
+// Desktop Chrome: the alias shares a groupId with the device it points at.
+const DESKTOP: MediaDeviceInfo[] = [
+	info("default", "Default - Studio Mic", "group-a"),
+	info("aaa", "Studio Mic", "group-a"),
+	info("bbb", "Webcam Mic", "group-b"),
+];
+
+function info(deviceId: string, label: string, groupId: string): MediaDeviceInfo {
+	return { deviceId, label, groupId, kind: "audioinput", toJSON: () => ({}) };
+}
+
+// Enough of MediaDevices for Device and Microphone, recording what getUserMedia was asked for.
+class FakeMediaDevices extends EventTarget {
+	requests: MediaStreamConstraints[] = [];
+	readonly devices: MediaDeviceInfo[];
+	readonly settled: string;
+
+	constructor(devices: MediaDeviceInfo[], settled = "default") {
+		super();
+		this.devices = devices;
+		this.settled = settled;
+	}
+
+	async enumerateDevices(): Promise<MediaDeviceInfo[]> {
+		return this.devices;
+	}
+
+	async getUserMedia(constraints: MediaStreamConstraints): Promise<MediaStream> {
+		this.requests.push(constraints);
+		const track = { getSettings: () => ({ deviceId: this.settled }), stop: () => {} };
+		return { getTracks: () => [track], getAudioTracks: () => [track] } as unknown as MediaStream;
+	}
+}
+
+function install(devices: MediaDeviceInfo[], settled?: string): FakeMediaDevices {
+	const fake = new FakeMediaDevices(devices, settled);
+	Object.defineProperty(globalThis, "navigator", {
+		configurable: true,
+		value: { mediaDevices: fake },
+	});
+	return fake;
+}
+
+const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
+async function settle(times = 10): Promise<void> {
+	for (let i = 0; i < times; i++) await flush();
+}
+
+test("an unresolvable default pins nothing", async () => {
+	install(ANDROID);
+
+	const device = new Device("audio");
+	await settle();
+
+	// The alias is dropped from the list but resolves no device, so there is nothing to pin.
+	expect(device.out.available.peek()?.map((d) => d.label)).toEqual(["Headset earpiece", "Speakerphone"]);
+	expect(device.out.default.peek()).toBeUndefined();
+	expect(device.out.requested.peek()).toBeUndefined();
+
+	device.close();
+});
+
+test("the platform default is reported but never pinned", async () => {
+	install(DESKTOP);
+
+	const device = new Device("audio");
+	await settle();
+
+	expect(device.out.default.peek()).toBe("aaa");
+	expect(device.out.requested.peek()).toBeUndefined();
+
+	device.close();
+});
+
+test("a preferred device is pinned once it is known to exist", async () => {
+	install(DESKTOP);
+
+	const device = new Device("audio", { preferred: "bbb" });
+	await settle();
+	expect(device.out.requested.peek()).toBe("bbb");
+
+	// A device that isn't there is not pinned, rather than failing every capture.
+	device.preferred.set("ccc");
+	await settle();
+	expect(device.out.requested.peek()).toBeUndefined();
+
+	device.close();
+});
+
+test("a capture without a preference stays unpinned", async () => {
+	const media = install(ANDROID);
+
+	const mic = new Microphone({ enabled: true });
+	await settle();
+
+	// No deviceId constraint, so the browser and OS keep the routing decision.
+	expect(media.requests).toHaveLength(1);
+	const audio = media.requests[0]?.audio as MediaTrackConstraints | undefined;
+	expect(audio?.deviceId).toBeUndefined();
+
+	// The settled device is reported as active, but must not become a preference: that would pin
+	// every later capture to a device the app never chose.
+	expect(mic.device.out.active.peek()).toBe("default");
+	expect(mic.device.preferred.peek()).toBeUndefined();
+	expect(mic.device.out.requested.peek()).toBeUndefined();
+
+	mic.close();
+});

--- a/js/publish/src/source/device.ts
+++ b/js/publish/src/source/device.ts
@@ -9,9 +9,10 @@ export interface DeviceProps {
 type DeviceOutput = {
 	// The devices that are available, or undefined without permission to enumerate them.
 	available: Signal<MediaDeviceInfo[] | undefined>;
-	// The default device based on heuristics.
+	// The device the platform names as its default, or undefined when it names none.
+	// Informational only: it never pins a capture.
 	default: Signal<string | undefined>;
-	// The device we want to use next. (preferred ?? default)
+	// The device to pin the next capture to, or undefined to let the browser choose.
 	requested: Signal<string | undefined>;
 	// The device backing the live capture, as reported by the owner via capture().
 	active: Signal<string | undefined>;
@@ -23,13 +24,14 @@ type DeviceOutput = {
  * The available capture devices of one {@link kind}, and which of them to use.
  *
  * Owned by a source ({@link Camera}, {@link Microphone}), which reports the device backing its live
- * capture via {@link capture}. Set {@link preferred} to choose one; the rest is discovered.
+ * capture via {@link capture}. Set {@link preferred} to choose one; leave it unset and the capture
+ * omits the `deviceId` constraint, following the browser and OS.
  */
 export class Device<Kind extends "audio" | "video"> {
 	/** Whether this tracks audio inputs or video inputs. */
 	readonly kind: Kind;
 
-	/** The deviceId to use, or undefined to use the default. */
+	/** The deviceId to capture from, or undefined to let the browser and OS choose. Only the app writes this. */
 	preferred: Signal<string | undefined>;
 
 	readonly #out: DeviceOutput = {
@@ -106,33 +108,10 @@ export class Device<Kind extends "audio" | "video"> {
 		// Remove the default device from the list.
 		devices = devices.filter((d) => d.deviceId !== "default");
 
-		let defaultDevice: MediaDeviceInfo | undefined;
-		if (alias) {
-			// Find the device with the same groupId as the default alias.
-			defaultDevice = devices.find((d) => d.groupId === alias.groupId);
-		}
-
-		// If we couldn't find a default alias, time to scan labels.
-		if (!defaultDevice) {
-			if (this.kind === "audio") {
-				// Look for default or communications device
-				defaultDevice = devices.find((d) => {
-					const label = d.label.toLowerCase();
-					return label.includes("default") || label.includes("communications");
-				});
-			} else if (this.kind === "video") {
-				// On mobile, prefer front-facing camera
-				defaultDevice = devices.find((d) => {
-					const label = d.label.toLowerCase();
-					return label.includes("front") || label.includes("external") || label.includes("usb");
-				});
-			}
-		}
-
-		if (!defaultDevice) {
-			// Still nothing, then use the top one.
-			defaultDevice = devices.at(0);
-		}
+		// Only the alias resolves a default. Guessing by label or position is unsound: Android
+		// enumerates output routes ("Headset earpiece", "Speakerphone") as audioinput devices, so
+		// the first entry is a speaker rather than a microphone.
+		const defaultDevice = alias ? devices.find((d) => d.groupId === alias.groupId) : undefined;
 
 		this.#out.available.set(devices);
 		this.#out.default.set(defaultDevice?.deviceId);
@@ -140,13 +119,12 @@ export class Device<Kind extends "audio" | "video"> {
 
 	#runRequested(effect: Effect) {
 		const preferred = effect.get(this.preferred);
-		if (preferred && effect.get(this.out.available)?.some((d) => d.deviceId === preferred)) {
-			// Use the preferred device if it's in our devices list.
-			this.#out.requested.set(preferred);
-		} else {
-			// Otherwise use the default device.
-			this.#out.requested.set(effect.get(this.out.default));
-		}
+
+		// Pin only a device that was asked for and is still present. Without a preference the
+		// capture omits the constraint, which is the only way to follow the system default: a
+		// deviceId we picked ourselves would override it forever.
+		const known = effect.get(this.out.available)?.some((d) => d.deviceId === preferred) ?? false;
+		this.#out.requested.set(preferred && known ? preferred : undefined);
 	}
 
 	/** Manually request permission for the device, ignoring the result. */
@@ -157,12 +135,6 @@ export class Device<Kind extends "audio" | "video"> {
 			.getUserMedia({ [this.kind]: true })
 			.then((stream) => {
 				this.#out.permission.set(true);
-
-				// If the user selected a device during the dialog prompt, save it as the preferred device.
-				const deviceId = stream.getTracks().at(0)?.getSettings().deviceId;
-				if (deviceId) {
-					this.preferred.set(deviceId);
-				}
 
 				stream.getTracks().forEach((track) => {
 					track.stop();

--- a/js/publish/src/source/microphone.ts
+++ b/js/publish/src/source/microphone.ts
@@ -57,7 +57,7 @@ export class Microphone {
 		const constraints = effect.get(this.constraints) ?? {};
 		const finalConstraints: MediaTrackConstraints = {
 			...constraints,
-			deviceId: device !== undefined ? { exact: device } : undefined,
+			deviceId: device ? { exact: device } : undefined,
 		};
 
 		effect.spawn(async () => {
@@ -81,11 +81,6 @@ export class Microphone {
 			// getUserMedia resolved, so we have permission even if no track came back.
 			effect.cleanup(this.device.capture(settings?.deviceId));
 			if (!track) return;
-
-			if (device === undefined) {
-				// Save the device that the user selected during the dialog prompt.
-				this.device.preferred.set(settings?.deviceId);
-			}
 
 			effect.set(this.#out.source, { track, kind: "voice" });
 		});

--- a/js/publish/src/ui/components/source-tab.ts
+++ b/js/publish/src/ui/components/source-tab.ts
@@ -61,6 +61,7 @@ function deviceField(
 	parent.run((effect) => {
 		const devices = effect.get(device.out.available) ?? [];
 		const selected = effect.get(device.out.requested);
+		const fallback = devices.find((d) => d.deviceId === effect.get(device.out.default));
 		dropdown.replaceChildren();
 
 		if (devices.length === 0) {
@@ -70,14 +71,19 @@ function deviceField(
 		}
 
 		dropdown.disabled = false;
+
+		// An empty value means no preference, letting the browser and OS route the capture.
+		const label = fallback?.label ? `Default (${fallback.label})` : "Default";
+		dropdown.appendChild(DOM.create("option", { value: "" }, label));
+
 		for (const d of devices) {
 			const option = DOM.create("option", { value: d.deviceId }, d.label || "Unknown device");
 			dropdown.appendChild(option);
 		}
-		if (selected) dropdown.value = selected;
+		dropdown.value = selected ?? "";
 	});
 
-	parent.event(dropdown, "change", () => device.preferred.set(dropdown.value));
+	parent.event(dropdown, "change", () => device.preferred.set(dropdown.value || undefined));
 	return field;
 }
 
@@ -103,6 +109,8 @@ export function sourceTab(parent: Effect, publish: MoqPublish): HTMLElement {
 		for (const f of fields) section.appendChild(f);
 		DOM.render(effect, devices, section);
 	});
+
+	container.appendChild(devices);
 
 	// File selection only applies to the file source.
 	const filePicker = DOM.create("div");


### PR DESCRIPTION
Closes #2554.

## Summary

- **Root cause.** `Device` invented a default device: alias groupId, then a label scan, then `devices.at(0)`. `Camera`/`Microphone` pinned whatever came out with `deviceId: { exact }`. Android's Chromium enumerates communication devices (output routes) as `audioinput` and lists the earpiece first, so the fallback selected "Headset earpiece" deterministically, and selecting a communication device as *input* routes the call's *output* there. `Microphone` then wrote the settled id back into `device.preferred`, so the "no choice" state was unrecoverable after the first capture.
- Only the platform's `"default"` alias row resolves a default now, via groupId. No label or position guessing.
- `out.default` is informational and never pins. With no `preferred`, `out.requested` is `undefined` and the capture omits the `deviceId` constraint entirely, which is the only way to follow the system default.
- Nothing but the app writes `preferred` (removed the self-assignment in `Microphone.#run` and in `Device.requestPermission()`).
- `facingMode` works again as a side effect: no resolved deviceId to override it.
- UI: the device dropdown gains a "Default" entry that clears the preference. Its container was also never appended to the tab body, so the dropdowns did not render at all in `<moq-publish-ui>`; that is fixed here too.

Thanks to @fperex for the on-device measurements in #2554, which are what the regression test encodes.

## Public API changes

None. `Device`'s exported shape is unchanged: `preferred`, `out.{available,default,requested,active,permission}`, `capture()`, `requestPermission()` all keep their signatures. `out.default` narrows in meaning (platform-reported only) and no longer feeds `out.requested`; both are behavior, not signature, so this targets `main`.

## Test plan

- New `js/publish/src/source/device.test.ts` drives `Device`/`Microphone` against the exact `enumerateDevices()` output reported for the Poco X7 Pro and against a desktop-Chrome list. All four tests fail against the pre-fix code and pass after.
- `just js check`, `just js fix`, `just js test` green.
- Exercised `<moq-publish-ui>` in a browser via `just dev` with `navigator.mediaDevices` stubbed to the Android list (the browser pane blocks real capture). Pre-fix: `out.default` resolved to `a38808f8b6` ("Headset earpiece"), the second `getUserMedia` carried `deviceId: { exact: "a38808f8b6" }`, and `preferred` self-assigned to `"default"`. Post-fix: no `deviceId` on any request, `preferred` stays unset, and the dropdown round-trips Default -> Speakerphone -> Default with the constraint appearing and disappearing accordingly.
- Not verified on real Android/iOS hardware; that is the one thing this cannot cover locally.

## Cross-package sync

No rows apply: no wire format, no `moq-ffi`, no CLI flags. `demo/web` consumes `<moq-publish>` but not `Device`. No `/doc` page documents device selection.

(written by Opus 5)