### PR TITLE
chore(rs): run tests under nextest, and stop wasting CPU on RSA keygen

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,28 @@
+# Shared nextest settings, picked up by every `cargo nextest` run in the workspace.
+
+[profile.default]
+# Kill a test that stops making progress instead of letting it wedge.
+#
+# The failure mode this bounds: a lost `kio` wakeup parks a task with nothing to
+# wake it, which is a hang rather than a failure. Under the plain `cargo test`
+# harness that run never ends, holding the target lock and burning a core until
+# someone notices and kills it by hand.
+#
+# `terminate-after` counts periods, so a test is reported SLOW at 30s and killed
+# at a minute, failing the run with a TIMEOUT. The slowest honest test in the
+# workspace runs in about 9s, so 30s is several times the real ceiling and the
+# SLOW label stays worth reading; keep it that way by making a test fast rather
+# than by raising this.
+slow-timeout = { period = "30s", terminate-after = 2 }
+
+# Retries hide flakes, and this repo treats an intermittent failure as a real
+# race until proven otherwise (see Root Cause First in CLAUDE.md).
+retries = 0
+
+# CI has noisier neighbours and cold caches, so give a test longer before
+# calling it wedged.
+[profile.ci]
+slow-timeout = { period = "60s", terminate-after = 2 }
+retries = 0
+# Repeat each failure at the end of the run, so it isn't buried in the log.
+failure-output = "immediate-final"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,22 @@ web-transport-trait = "0.3.4"
 [profile.dev]
 panic = "abort"
 
+# Optimize the bignum crates even in dev/test builds. RSA keygen is bignum
+# arithmetic in a loop, and unoptimized it is orders of magnitude slower: the
+# moq-token key tests spend ~16s generating 2048-bit keys, versus well under a
+# second here. These are dependencies we never step through in a debugger, so
+# optimizing them costs nothing an unoptimized build was buying us, and the
+# tests keep exercising production key sizes rather than being weakened to
+# stay fast. `profile.test` inherits these overrides.
+[profile.dev.package.num-bigint-dig]
+opt-level = 3
+
+[profile.dev.package.crypto-bigint]
+opt-level = 3
+
+[profile.dev.package.rsa]
+opt-level = 3
+
 [profile.release]
 panic = "abort"
 

--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -139,7 +139,25 @@ Then `Config::load()?` (initializes tracing), build clients/servers via `.init()
 
 ## Testing
 
-- `just check` runs all tests + lint; `just fix` auto-fixes formatting/lint. `cargo test -p <crate>` for one crate.
+- `just check` runs all tests + lint; `just fix` auto-fixes formatting/lint. `just rs test -p <crate>` (or `cargo nextest run -p <crate>`) for one crate.
+
+- **Run tests through nextest, not `cargo test`.** `.config/nextest.toml` sets a
+  `slow-timeout` with `terminate-after`, so a wedged test is reported as a
+  TIMEOUT and killed; under `cargo test`'s harness the same test hangs forever,
+  holding the target lock and burning a core. That matters here because a lost
+  `kio` wakeup parks a task with nothing to wake it, which is a hang rather than
+  a failure. `just rs test` and `just rs ci` both use nextest. Doctests are the
+  one thing it skips (`just rs doctest` covers them), and `just rs loom` stays on
+  `cargo test` since loom needs its own `--cfg loom` build.
+
+- **A test flagged SLOW is a bug to fix, not a threshold to raise.** The whole
+  workspace runs in well under a minute and the slowest single test is a few
+  seconds, which is what makes the timeout above a meaningful signal. When a
+  dependency is the reason (crypto and bignum code is orders of magnitude slower
+  unoptimized), give it an `opt-level` override in the root `Cargo.toml` rather
+  than shrinking what the test covers: `[profile.dev.package.<dep>]` applies to
+  test builds too, and took the moq-token RSA keygen tests from 16s to 0.8s while
+  still generating production-size 2048-bit keys.
 
 - Rust tests are `#[cfg(test)] mod tests` inline in the source file.
 

--- a/rs/justfile
+++ b/rs/justfile
@@ -90,7 +90,9 @@ ci FILES="":
     # `cargo test`'s serial harness). It does not build or run
     # doctests, so the `/// ```` examples are no longer compile-checked in CI -- an
     # accepted trade for speed (they still render in `cargo doc` output).
-    cargo nextest run --workspace --all-targets --all-features
+    # `--profile ci` picks up the longer hang timeout in .config/nextest.toml;
+    # without it a runner under load could trip the local one.
+    cargo nextest run --profile ci --workspace --all-targets --all-features
 
 # Auto-fix clippy/format/shear/sort.
 fix:

--- a/rs/justfile
+++ b/rs/justfile
@@ -99,8 +99,18 @@ fix:
     cargo shear --fix
     cargo sort --workspace --no-format
 
+# Run the test suite.
+#
+# nextest, not `cargo test`, so a wedged test is killed instead of pinning a core
+# until someone notices (`.config/nextest.toml` sets the timeout). It also
+# matches what `ci` runs. The trade is doctests, which nextest does not execute;
+# `just rs doctest` covers those.
 test *args:
-    cargo test --all-targets {{ args }}
+    cargo nextest run --all-targets {{ args }}
+
+# Compile and run the `/// ```` examples, which nextest skips.
+doctest *args:
+    cargo test --doc {{ args }}
 
 # Permutation-test the concurrent handoffs with loom.
 #


### PR DESCRIPTION
## Summary

Two related annoyances, both about tests eating CPU for no benefit.

**Plain `cargo test` has no timeout.** A test that parks with nothing to wake it never returns, so the harness never exits: it holds the target lock and burns a core until someone kills it by hand. That is not hypothetical in this repo, since a lost `kio` wakeup is a hang rather than a failure, and it cost two such runs while reviewing #2556. `.config/nextest.toml` adds a `slow-timeout` with `terminate-after`, so the same test is reported `TIMEOUT` and killed in bounded time: SLOW at 30s, killed at 60s, doubled on CI. `just rs test` now runs nextest, matching what `just rs ci` already did; doctests get their own recipe rather than being silently dropped, since nextest does not run them.

**A timeout is only meaningful if the honest tests are fast**, and the moq-token RSA tests were not: six 2048-bit keygens across two tests, ~16s, because `rsa` and its bignum backend are orders of magnitude slower unoptimized. Rather than shrinking the key size (which weakens the test and diverges from production), give those three dependencies an `opt-level` override in the dev profile, which test builds inherit.

| | before | after |
|---|---|---|
| slowest single test | 35s | 8.8s |
| the 5 RSA tests | 16.3s | 0.8s |
| full workspace suite | 87s | 35s |
| tests flagged SLOW | 2 | 0 |

With nothing legitimately near the limit any more, the threshold is real signal: a test flagged SLOW is now a bug to fix, not a number to raise, and `rs/CLAUDE.md` says so along with the `opt-level` escape hatch for a slow dependency.

## Public API changes

None. Build profile, test runner config, `just` recipes, and a guide.

## Test plan

- `cargo nextest run --workspace --all-targets --all-features`: 2441 passed, 0 slow.
- Timeout verified end to end, not just configured: parking a test on `std::future::pending()` is killed at exactly 120s under the old setting and reported `TIMEOUT` instead of hanging the run.
- RSA timings above measured before and after on the same machine.
- `cargo fmt --check`, `taplo format --check` (which covers the new `.config/nextest.toml`), `cargo sort --check`, and clippy `-D warnings` all clean.

Split out of #2556, which is where the hangs turned up.

(Written by Opus 5)