### PR TITLE
feat(kio): add WaiterCell and Queue

### DIFF
--- a/rs/kio/README.md
+++ b/rs/kio/README.md
@@ -14,7 +14,7 @@ This crate provides `Producer` and `Consumer` types that share state through a m
 Producers can modify the state and consumers are automatically notified via async wakers.
 The channel auto-closes when all producers are dropped.
 
-`Shared` is the role-less sibling for state that both sides mutate, and `Deque` is a
+`Shared` is the role-less sibling for state that both sides mutate, and `Queue` is a
 poll-native FIFO queue (bounded or unbounded) built in the same style. `WaiterCell`
 bridges a `std::task::Context` to kio's waiter-based polls, for implementing
 `poll_*` trait methods on top of kio channels.

--- a/rs/kio/README.md
+++ b/rs/kio/README.md
@@ -14,6 +14,11 @@ This crate provides `Producer` and `Consumer` types that share state through a m
 Producers can modify the state and consumers are automatically notified via async wakers.
 The channel auto-closes when all producers are dropped.
 
+`Shared` is the role-less sibling for state that both sides mutate, and `Deque` is a
+poll-native FIFO queue (bounded or unbounded) built in the same style. `WaiterCell`
+bridges a `std::task::Context` to kio's waiter-based polls, for implementing
+`poll_*` trait methods on top of kio channels.
+
 It's used internally by [moq-net](https://github.com/moq-dev/moq/tree/main/rs/moq-net) and friends, but is generic enough to be useful on its own.
 
 See the [API documentation](https://docs.rs/kio/) for details.

--- a/rs/kio/src/deque.rs
+++ b/rs/kio/src/deque.rs
@@ -1,0 +1,485 @@
+use std::{collections::VecDeque, fmt, task::Poll};
+
+use crate::{
+	Closed,
+	lock::Lock,
+	waiter::{Waiter, WaiterList},
+};
+
+/// The push failed; the item is handed back.
+pub enum PushError<T> {
+	/// The queue is at capacity. Only a bounded [`Deque`]'s `try_push` reports this.
+	Full(T),
+	/// The queue was closed; nothing will ever pop the item.
+	Closed(T),
+}
+
+impl<T> PushError<T> {
+	/// Recover the item that failed to push.
+	pub fn into_inner(self) -> T {
+		match self {
+			Self::Full(item) | Self::Closed(item) => item,
+		}
+	}
+}
+
+// Manual, so the error is debuggable without requiring `T: Debug`.
+impl<T> fmt::Debug for PushError<T> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::Full(_) => f.debug_tuple("Full").finish_non_exhaustive(),
+			Self::Closed(_) => f.debug_tuple("Closed").finish_non_exhaustive(),
+		}
+	}
+}
+
+impl<T> fmt::Display for PushError<T> {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			Self::Full(_) => write!(f, "queue full"),
+			Self::Closed(_) => write!(f, "queue closed"),
+		}
+	}
+}
+
+impl<T> std::error::Error for PushError<T> {}
+
+#[derive(Debug)]
+struct State<T> {
+	queue: VecDeque<T>,
+	/// `None` = unbounded.
+	capacity: Option<usize>,
+	closed: bool,
+	/// Parked pops, woken by a push or close.
+	waiters_pop: WaiterList,
+	/// Parked pushes, woken by a pop or close. Always empty when unbounded.
+	waiters_push: WaiterList,
+}
+
+impl<T> State<T> {
+	fn has_space(&self) -> bool {
+		self.capacity.is_none_or(|capacity| self.queue.len() < capacity)
+	}
+}
+
+/// A poll-native FIFO queue with waker notification.
+///
+/// Role-less like [`Shared`](crate::Shared): every clone can push, pop, or close,
+/// and there is no liveness of its own — closure is explicit via
+/// [`close`](Self::close), never implied by dropping handles. Bounded queues park
+/// pushes at capacity ([`poll_push_with`](Self::poll_push_with) /
+/// [`push`](Self::push)) or reject them ([`try_push`](Self::try_push)); pops park
+/// while empty. After close, pops drain what's queued before reporting [`Closed`].
+///
+/// An event wakes *every* waiter parked on the affected side (there is no
+/// wake-one): with several handles racing to pop, one wins and the rest re-park.
+#[derive(Debug)]
+pub struct Deque<T> {
+	state: Lock<State<T>>,
+}
+
+impl<T> Deque<T> {
+	/// Create an unbounded queue: pushes never park or report full.
+	pub fn new() -> Self {
+		Self::with_capacity(None)
+	}
+
+	/// Create a bounded queue holding at most `capacity` items.
+	///
+	/// Panics if `capacity` is zero, which could never accept an item.
+	pub fn bounded(capacity: usize) -> Self {
+		assert!(capacity > 0, "a zero-capacity Deque could never accept an item");
+		Self::with_capacity(Some(capacity))
+	}
+
+	fn with_capacity(capacity: Option<usize>) -> Self {
+		Self {
+			state: Lock::new(State {
+				queue: VecDeque::new(),
+				capacity,
+				closed: false,
+				waiters_pop: WaiterList::new(),
+				waiters_push: WaiterList::new(),
+			}),
+		}
+	}
+
+	/// Push without waiting, or hand the item back when closed or (if bounded) full.
+	pub fn try_push(&self, item: T) -> Result<(), PushError<T>> {
+		let mut waiters = {
+			let mut state = self.state.lock();
+			if state.closed {
+				return Err(PushError::Closed(item));
+			}
+			if !state.has_space() {
+				return Err(PushError::Full(item));
+			}
+			state.queue.push_back(item);
+			state.waiters_pop.take()
+		};
+		waiters.wake();
+		Ok(())
+	}
+
+	/// Poll to push, building the item only once there is room for it.
+	///
+	/// The item comes from a closure so a pending poll costs nothing: nothing is
+	/// built, nothing needs handing back, and the caller retries with a fresh
+	/// closure. `make` runs with the queue lock held — it must not touch this queue
+	/// (or anything that does).
+	///
+	/// Registers `waiter` while full; a pop or close re-polls it.
+	pub fn poll_push_with<F: FnOnce() -> T>(&self, waiter: &Waiter, make: F) -> Poll<Result<(), Closed>> {
+		let mut waiters = {
+			let mut state = self.state.lock();
+			if state.closed {
+				return Poll::Ready(Err(Closed));
+			}
+			if !state.has_space() {
+				waiter.register(&mut state.waiters_push);
+				return Poll::Pending;
+			}
+			let item = make();
+			state.queue.push_back(item);
+			state.waiters_pop.take()
+		};
+		waiters.wake();
+		Poll::Ready(Ok(()))
+	}
+
+	/// Push, waiting for room while a bounded queue is full.
+	///
+	/// Returns [`Closed`] if the queue closes first (or already was); the item is
+	/// dropped in that case — use [`try_push`](Self::try_push) to get it back.
+	pub async fn push(&self, item: T) -> Result<(), Closed> {
+		let mut item = Some(item);
+		// Capture the slot by `&mut` so the closure is `Unpin` regardless of `T`.
+		let slot = &mut item;
+		crate::wait(move |waiter| self.poll_push_with(waiter, || slot.take().expect("polled after completion"))).await
+	}
+
+	/// Pop without waiting.
+	///
+	/// `Ok(None)` means the queue is empty but still open. Queued items drain
+	/// before closure is reported: [`Closed`] means empty *and* closed.
+	pub fn try_pop(&self) -> Result<Option<T>, Closed> {
+		let (item, mut waiters) = {
+			let mut state = self.state.lock();
+			match state.queue.pop_front() {
+				Some(item) => (item, state.waiters_push.take()),
+				None if state.closed => return Err(Closed),
+				None => return Ok(None),
+			}
+		};
+		waiters.wake();
+		Ok(Some(item))
+	}
+
+	/// Poll for the next item.
+	///
+	/// Queued items drain before closure is reported, so [`Closed`] means empty
+	/// *and* closed. Registers `waiter` while empty; a push or close re-polls it.
+	pub fn poll_pop(&self, waiter: &Waiter) -> Poll<Result<T, Closed>> {
+		let (item, mut waiters) = {
+			let mut state = self.state.lock();
+			match state.queue.pop_front() {
+				Some(item) => (item, state.waiters_push.take()),
+				None if state.closed => return Poll::Ready(Err(Closed)),
+				None => {
+					waiter.register(&mut state.waiters_pop);
+					return Poll::Pending;
+				}
+			}
+		};
+		waiters.wake();
+		Poll::Ready(Ok(item))
+	}
+
+	/// Pop, waiting for an item while the queue is empty.
+	///
+	/// Returns [`Closed`] once the queue is both closed and drained.
+	pub async fn pop(&self) -> Result<T, Closed> {
+		crate::wait(move |waiter| self.poll_pop(waiter)).await
+	}
+
+	/// Close the queue: pushes fail from here on, pops drain what's queued and then
+	/// report [`Closed`]. Idempotent.
+	pub fn close(&self) {
+		let mut waiters = {
+			let mut state = self.state.lock();
+			if state.closed {
+				return;
+			}
+			state.closed = true;
+			// Every waiter reacts to closure; wake both sides after unlocking.
+			[state.waiters_pop.take(), state.waiters_push.take()]
+		};
+		for list in &mut waiters {
+			list.wake();
+		}
+	}
+
+	/// Whether [`close`](Self::close) has been called. Items may still be queued.
+	pub fn is_closed(&self) -> bool {
+		self.state.lock().closed
+	}
+
+	/// Number of items currently queued.
+	pub fn len(&self) -> usize {
+		self.state.lock().queue.len()
+	}
+
+	/// Whether nothing is currently queued.
+	pub fn is_empty(&self) -> bool {
+		self.state.lock().queue.is_empty()
+	}
+
+	/// The capacity bound, or `None` when unbounded.
+	pub fn capacity(&self) -> Option<usize> {
+		self.state.lock().capacity
+	}
+
+	/// Returns `true` if both handles share the same underlying queue.
+	pub fn same_channel(&self, other: &Self) -> bool {
+		self.state.is_clone(&other.state)
+	}
+}
+
+impl<T> Default for Deque<T> {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
+impl<T> Clone for Deque<T> {
+	fn clone(&self) -> Self {
+		Self {
+			state: self.state.clone(),
+		}
+	}
+}
+
+#[cfg(all(test, not(loom)))]
+mod test {
+	use std::{
+		sync::{
+			Arc,
+			atomic::{AtomicUsize, Ordering},
+		},
+		task::{Context, Wake, Waker},
+	};
+
+	use super::*;
+	use crate::WaiterCell;
+
+	/// A waker that counts how many times it was woken (mirrors `tests.rs`).
+	struct CountWaker(AtomicUsize);
+	impl CountWaker {
+		fn count(&self) -> usize {
+			self.0.load(Ordering::SeqCst)
+		}
+	}
+	impl Wake for CountWaker {
+		fn wake(self: Arc<Self>) {
+			self.0.fetch_add(1, Ordering::SeqCst);
+		}
+		fn wake_by_ref(self: &Arc<Self>) {
+			self.0.fetch_add(1, Ordering::SeqCst);
+		}
+	}
+	fn counting() -> (Arc<CountWaker>, Waker) {
+		let waker = Arc::new(CountWaker(AtomicUsize::new(0)));
+		let w = Waker::from(waker.clone());
+		(waker, w)
+	}
+
+	#[test]
+	fn fifo_order() {
+		let deque = Deque::new();
+		deque.try_push(1).unwrap();
+		deque.try_push(2).unwrap();
+		deque.try_push(3).unwrap();
+
+		assert_eq!(deque.try_pop().unwrap(), Some(1));
+		assert_eq!(deque.try_pop().unwrap(), Some(2));
+		assert_eq!(deque.try_pop().unwrap(), Some(3));
+		assert_eq!(deque.try_pop().unwrap(), None, "empty but open");
+	}
+
+	#[test]
+	fn bounded_rejects_when_full_and_returns_the_item() {
+		let deque = Deque::bounded(1);
+		deque.try_push(1).unwrap();
+
+		match deque.try_push(2) {
+			Err(PushError::Full(item)) => assert_eq!(item, 2),
+			other => panic!("expected Full, got {other:?}"),
+		}
+
+		// Popping frees the slot.
+		assert_eq!(deque.try_pop().unwrap(), Some(1));
+		deque.try_push(2).unwrap();
+	}
+
+	#[test]
+	fn closed_rejects_pushes_and_drains_pops() {
+		let deque = Deque::new();
+		deque.try_push(1).unwrap();
+		deque.close();
+		deque.close(); // idempotent
+
+		match deque.try_push(2) {
+			Err(PushError::Closed(item)) => assert_eq!(item, 2),
+			other => panic!("expected Closed, got {other:?}"),
+		}
+
+		// The queued item drains before closure is reported.
+		assert_eq!(deque.try_pop().unwrap(), Some(1));
+		assert_eq!(deque.try_pop(), Err(Closed));
+
+		let waiter = Waiter::noop();
+		assert_eq!(deque.poll_pop(&waiter), Poll::Ready(Err(Closed)));
+		assert_eq!(deque.poll_push_with(&waiter, || 3), Poll::Ready(Err(Closed)));
+	}
+
+	#[test]
+	fn push_wakes_a_parked_pop() {
+		let deque = Deque::new();
+		let (waker, w) = counting();
+		let mut cx = Context::from_waker(&w);
+		let mut cell = WaiterCell::new();
+
+		assert!(deque.poll_pop(cell.register(&mut cx)).is_pending());
+		deque.try_push(7).unwrap();
+		assert!(waker.count() >= 1, "push should wake the parked pop");
+		assert_eq!(deque.poll_pop(cell.register(&mut cx)), Poll::Ready(Ok(7)));
+	}
+
+	#[test]
+	fn pop_wakes_a_parked_push_and_defers_the_item() {
+		let deque = Deque::bounded(1);
+		deque.try_push(1).unwrap();
+
+		let (waker, w) = counting();
+		let mut cx = Context::from_waker(&w);
+		let mut cell = WaiterCell::new();
+
+		// Full: the closure must not run, and the poll parks.
+		let made = std::cell::Cell::new(false);
+		assert!(
+			deque
+				.poll_push_with(cell.register(&mut cx), || {
+					made.set(true);
+					2
+				})
+				.is_pending()
+		);
+		assert!(!made.get(), "the item must not be built while full");
+
+		// A pop frees the slot and wakes the parked push.
+		assert_eq!(deque.try_pop().unwrap(), Some(1));
+		assert!(waker.count() >= 1, "pop should wake the parked push");
+		assert_eq!(deque.poll_push_with(cell.register(&mut cx), || 2), Poll::Ready(Ok(())));
+		assert_eq!(deque.try_pop().unwrap(), Some(2));
+	}
+
+	#[test]
+	fn close_wakes_both_sides() {
+		let deque = Deque::<u32>::bounded(1);
+		deque.try_push(1).unwrap();
+
+		let (pop_waker, w1) = counting();
+		let mut cx1 = Context::from_waker(&w1);
+		let mut pop_cell = WaiterCell::new();
+		// Park a pop on a second handle (the queued item is popped first).
+		let popper = deque.clone();
+		assert_eq!(popper.poll_pop(pop_cell.register(&mut cx1)), Poll::Ready(Ok(1)));
+		assert!(popper.poll_pop(pop_cell.register(&mut cx1)).is_pending());
+
+		// Refill so a push parks too.
+		deque.try_push(2).unwrap();
+		let (push_waker, w2) = counting();
+		let mut cx2 = Context::from_waker(&w2);
+		let mut push_cell = WaiterCell::new();
+		assert!(deque.poll_push_with(push_cell.register(&mut cx2), || 3).is_pending());
+
+		deque.close();
+		assert!(pop_waker.count() >= 1, "close should wake the parked pop");
+		assert!(push_waker.count() >= 1, "close should wake the parked push");
+
+		// The parked pop drains the remaining item; the push observes closure.
+		assert_eq!(popper.poll_pop(pop_cell.register(&mut cx1)), Poll::Ready(Ok(2)));
+		assert_eq!(popper.poll_pop(pop_cell.register(&mut cx1)), Poll::Ready(Err(Closed)));
+		assert_eq!(
+			deque.poll_push_with(push_cell.register(&mut cx2), || 3),
+			Poll::Ready(Err(Closed))
+		);
+	}
+
+	#[test]
+	fn accessors() {
+		let deque = Deque::bounded(2);
+		assert_eq!(deque.capacity(), Some(2));
+		assert!(deque.is_empty());
+		deque.try_push(1).unwrap();
+		assert_eq!(deque.len(), 1);
+		assert!(!deque.is_empty());
+		assert!(!deque.is_closed());
+
+		let clone = deque.clone();
+		let other = Deque::<u32>::new();
+		assert!(deque.same_channel(&clone));
+		assert!(!deque.same_channel(&other));
+		assert_eq!(other.capacity(), None);
+	}
+
+	#[test]
+	#[should_panic(expected = "zero-capacity")]
+	fn zero_capacity_panics() {
+		let _ = Deque::<u32>::bounded(0);
+	}
+
+	#[tokio::test]
+	async fn async_push_parks_until_popped() {
+		let deque = Deque::bounded(1);
+		deque.try_push(1u32).unwrap();
+
+		let pusher = deque.clone();
+		let task = tokio::spawn(async move { pusher.push(2).await });
+
+		// Let the push park on the full queue before making room.
+		tokio::task::yield_now().await;
+		assert_eq!(deque.pop().await, Ok(1));
+
+		task.await.unwrap().unwrap();
+		assert_eq!(deque.pop().await, Ok(2));
+	}
+
+	#[tokio::test]
+	async fn async_pop_parks_until_pushed() {
+		let deque = Deque::new();
+		let popper = deque.clone();
+		let task = tokio::spawn(async move { popper.pop().await });
+
+		tokio::task::yield_now().await;
+		deque.try_push(9u32).unwrap();
+
+		assert_eq!(task.await.unwrap(), Ok(9));
+	}
+
+	#[tokio::test]
+	async fn async_ops_observe_close() {
+		let deque = Deque::<u32>::bounded(1);
+		deque.try_push(1).unwrap();
+
+		let pusher = deque.clone();
+		let push = tokio::spawn(async move { pusher.push(2).await });
+		tokio::task::yield_now().await;
+		deque.close();
+
+		assert_eq!(push.await.unwrap(), Err(Closed));
+		// Pops still drain the queued item before reporting closure.
+		assert_eq!(deque.pop().await, Ok(1));
+		assert_eq!(deque.pop().await, Err(Closed));
+	}
+}

--- a/rs/kio/src/deque.rs
+++ b/rs/kio/src/deque.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 /// The push failed; the item is handed back.
+#[non_exhaustive]
 pub enum PushError<T> {
 	/// The queue is at capacity. Only a bounded [`Deque`]'s `try_push` reports this.
 	Full(T),
@@ -65,7 +66,7 @@ impl<T> State<T> {
 /// A poll-native FIFO queue with waker notification.
 ///
 /// Role-less like [`Shared`](crate::Shared): every clone can push, pop, or close,
-/// and there is no liveness of its own — closure is explicit via
+/// and there is no liveness of its own: closure is explicit via
 /// [`close`](Self::close), never implied by dropping handles. Bounded queues park
 /// pushes at capacity ([`poll_push_with`](Self::poll_push_with) /
 /// [`push`](Self::push)) or reject them ([`try_push`](Self::try_push)); pops park
@@ -125,7 +126,7 @@ impl<T> Deque<T> {
 	///
 	/// The item comes from a closure so a pending poll costs nothing: nothing is
 	/// built, nothing needs handing back, and the caller retries with a fresh
-	/// closure. `make` runs with the queue lock held — it must not touch this queue
+	/// closure. `make` runs with the queue lock held, so it must not touch this queue
 	/// (or anything that does).
 	///
 	/// Registers `waiter` while full; a pop or close re-polls it.
@@ -150,7 +151,7 @@ impl<T> Deque<T> {
 	/// Push, waiting for room while a bounded queue is full.
 	///
 	/// Returns [`Closed`] if the queue closes first (or already was); the item is
-	/// dropped in that case — use [`try_push`](Self::try_push) to get it back.
+	/// dropped in that case; use [`try_push`](Self::try_push) to get it back.
 	pub async fn push(&self, item: T) -> Result<(), Closed> {
 		let mut item = Some(item);
 		// Capture the slot by `&mut` so the closure is `Unpin` regardless of `T`.

--- a/rs/kio/src/lib.rs
+++ b/rs/kio/src/lib.rs
@@ -9,7 +9,7 @@
 //! [`Shared`] is a role-less sibling: every handle can lock, read, or park on a
 //! predicate, with no liveness of its own.
 //!
-//! [`Deque`] is a poll-native FIFO queue built in the same style: role-less
+//! [`Queue`] is a poll-native FIFO queue built in the same style: role-less
 //! clone-able handles, bounded or unbounded, with separate wake lists for the
 //! push and pop sides.
 
@@ -25,9 +25,9 @@ mod sync;
 mod waiter;
 
 mod consumer;
-mod deque;
 mod pollable;
 mod producer;
+mod queue;
 mod shared;
 mod weak;
 
@@ -44,9 +44,9 @@ mod loom;
 mod tests;
 
 pub use consumer::Consumer;
-pub use deque::{Deque, PushError};
 pub use pollable::{Pending, Pollable};
 pub use producer::{Mut, Producer, Ref};
+pub use queue::{PushError, Queue};
 pub use shared::Shared;
 pub use waiter::{Waiter, WaiterCell, WaiterList, wait};
 pub use weak::{ConsumerWeak, ProducerWeak, Weak};

--- a/rs/kio/src/lib.rs
+++ b/rs/kio/src/lib.rs
@@ -8,6 +8,10 @@
 //! For state that both sides legitimately mutate (e.g. a reverse request queue),
 //! [`Shared`] is a role-less sibling: every handle can lock, read, or park on a
 //! predicate, with no liveness of its own.
+//!
+//! [`Deque`] is a poll-native FIFO queue built in the same style: role-less
+//! clone-able handles, bounded or unbounded, with separate wake lists for the
+//! push and pop sides.
 
 use std::{
 	fmt,
@@ -21,6 +25,7 @@ mod sync;
 mod waiter;
 
 mod consumer;
+mod deque;
 mod pollable;
 mod producer;
 mod shared;
@@ -39,10 +44,11 @@ mod loom;
 mod tests;
 
 pub use consumer::Consumer;
+pub use deque::{Deque, PushError};
 pub use pollable::{Pending, Pollable};
 pub use producer::{Mut, Producer, Ref};
 pub use shared::Shared;
-pub use waiter::{Waiter, WaiterList, wait};
+pub use waiter::{Waiter, WaiterCell, WaiterList, wait};
 pub use weak::{ConsumerWeak, ProducerWeak, Weak};
 
 /// The channel closed before the awaited condition held.

--- a/rs/kio/src/loom.rs
+++ b/rs/kio/src/loom.rs
@@ -19,7 +19,7 @@ use std::task::Poll;
 
 use loom::{future::block_on, thread};
 
-use crate::{Closed, Deque, Producer, Ref, Shared};
+use crate::{Closed, Producer, Queue, Ref, Shared};
 
 /// Ready once the value equals `n`.
 fn equals(n: u32) -> impl FnMut(&Ref<'_, u32>) -> Poll<()> + Unpin {
@@ -185,32 +185,32 @@ fn shared_mutation_wakes_a_parked_handle() {
 	});
 }
 
-/// A push must reach a pop parked on an empty deque no matter how the two
+/// A push must reach a pop parked on an empty queue no matter how the two
 /// interleave.
 #[test]
-fn deque_push_wakes_a_parked_pop() {
+fn queue_push_wakes_a_parked_pop() {
 	loom::model(|| {
-		let deque = Deque::new();
-		let pusher = deque.clone();
+		let queue = Queue::new();
+		let pusher = queue.clone();
 
 		let push = thread::spawn(move || pusher.try_push(1u32).unwrap());
 
-		assert_eq!(block_on(deque.pop()), Ok(1), "the push was lost");
+		assert_eq!(block_on(queue.pop()), Ok(1), "the push was lost");
 		push.join().unwrap();
 	});
 }
 
-/// A pop freeing the only slot of a bounded deque must wake a push parked on it.
+/// A pop freeing the only slot of a bounded queue must wake a push parked on it.
 #[test]
-fn deque_pop_wakes_a_parked_push() {
+fn queue_pop_wakes_a_parked_push() {
 	loom::model(|| {
-		let deque = Deque::bounded(1);
-		deque.try_push(1u32).unwrap();
-		let popper = deque.clone();
+		let queue = Queue::bounded(1);
+		queue.try_push(1u32).unwrap();
+		let popper = queue.clone();
 
 		let pop = thread::spawn(move || assert_eq!(popper.try_pop().unwrap(), Some(1)));
 
-		assert_eq!(block_on(deque.push(2)), Ok(()), "the freed slot was missed");
+		assert_eq!(block_on(queue.push(2)), Ok(()), "the freed slot was missed");
 		pop.join().unwrap();
 	});
 }
@@ -218,14 +218,14 @@ fn deque_pop_wakes_a_parked_push() {
 /// A close racing a parked pop must still wake it; drained-then-closed is the
 /// only acceptable outcome.
 #[test]
-fn deque_close_wakes_a_parked_pop() {
+fn queue_close_wakes_a_parked_pop() {
 	loom::model(|| {
-		let deque = Deque::<u32>::new();
-		let closer = deque.clone();
+		let queue = Queue::<u32>::new();
+		let closer = queue.clone();
 
 		let close = thread::spawn(move || closer.close());
 
-		assert_eq!(block_on(deque.pop()), Err(Closed), "the close was lost");
+		assert_eq!(block_on(queue.pop()), Err(Closed), "the close was lost");
 		close.join().unwrap();
 	});
 }

--- a/rs/kio/src/loom.rs
+++ b/rs/kio/src/loom.rs
@@ -19,7 +19,7 @@ use std::task::Poll;
 
 use loom::{future::block_on, thread};
 
-use crate::{Producer, Ref, Shared};
+use crate::{Closed, Deque, Producer, Ref, Shared};
 
 /// Ready once the value equals `n`.
 fn equals(n: u32) -> impl FnMut(&Ref<'_, u32>) -> Poll<()> + Unpin {
@@ -182,5 +182,50 @@ fn shared_mutation_wakes_a_parked_handle() {
 
 		drop(block_on(shared.wait(equals(1))));
 		writer.join().unwrap();
+	});
+}
+
+/// A push must reach a pop parked on an empty deque no matter how the two
+/// interleave.
+#[test]
+fn deque_push_wakes_a_parked_pop() {
+	loom::model(|| {
+		let deque = Deque::new();
+		let pusher = deque.clone();
+
+		let push = thread::spawn(move || pusher.try_push(1u32).unwrap());
+
+		assert_eq!(block_on(deque.pop()), Ok(1), "the push was lost");
+		push.join().unwrap();
+	});
+}
+
+/// A pop freeing the only slot of a bounded deque must wake a push parked on it.
+#[test]
+fn deque_pop_wakes_a_parked_push() {
+	loom::model(|| {
+		let deque = Deque::bounded(1);
+		deque.try_push(1u32).unwrap();
+		let popper = deque.clone();
+
+		let pop = thread::spawn(move || assert_eq!(popper.try_pop().unwrap(), Some(1)));
+
+		assert_eq!(block_on(deque.push(2)), Ok(()), "the freed slot was missed");
+		pop.join().unwrap();
+	});
+}
+
+/// A close racing a parked pop must still wake it; drained-then-closed is the
+/// only acceptable outcome.
+#[test]
+fn deque_close_wakes_a_parked_pop() {
+	loom::model(|| {
+		let deque = Deque::<u32>::new();
+		let closer = deque.clone();
+
+		let close = thread::spawn(move || closer.close());
+
+		assert_eq!(block_on(deque.pop()), Err(Closed), "the close was lost");
+		close.join().unwrap();
 	});
 }

--- a/rs/kio/src/pollable.rs
+++ b/rs/kio/src/pollable.rs
@@ -38,7 +38,7 @@ pub trait Pollable: Unpin {
 pub struct Pending<P> {
 	inner: P,
 	// Retains the waiter across polls so its weak registrations survive (and are
-	// reused when possible) — see [`WaiterCell`].
+	// reused when possible); see [`WaiterCell`].
 	waiter: WaiterCell,
 }
 

--- a/rs/kio/src/pollable.rs
+++ b/rs/kio/src/pollable.rs
@@ -39,7 +39,7 @@ pub struct Pending<P> {
 	inner: P,
 	// Retains the waiter across polls so its weak registrations survive (and are
 	// reused when possible); see [`WaiterCell`].
-	waiter: WaiterCell,
+	cell: WaiterCell,
 }
 
 impl<P> Pending<P> {
@@ -47,7 +47,7 @@ impl<P> Pending<P> {
 	pub fn new(inner: P) -> Self {
 		Self {
 			inner,
-			waiter: WaiterCell::new(),
+			cell: WaiterCell::new(),
 		}
 	}
 
@@ -77,7 +77,7 @@ impl<P: Pollable> Future for Pending<P> {
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<P::Output> {
 		// `Pending<P>` is `Unpin` (P is, via the trait bound), so this deref is sound.
 		let this = &mut *self;
-		let waiter = this.waiter.register(cx);
+		let waiter = this.cell.waiter(cx);
 		Pollable::poll(&this.inner, waiter)
 	}
 }

--- a/rs/kio/src/pollable.rs
+++ b/rs/kio/src/pollable.rs
@@ -5,7 +5,7 @@ use std::{
 	task::{Context, Poll},
 };
 
-use crate::Waiter;
+use crate::{Waiter, WaiterCell};
 
 /// A pollable computation backed by kio channels.
 ///
@@ -37,15 +37,18 @@ pub trait Pollable: Unpin {
 /// `update`).
 pub struct Pending<P> {
 	inner: P,
-	// Retain the previous waiter so its Weak registration survives until the next
-	// poll replaces it (see [`crate::WaiterList`]).
-	waiter: Option<Waiter>,
+	// Retains the waiter across polls so its weak registrations survive (and are
+	// reused when possible) — see [`WaiterCell`].
+	waiter: WaiterCell,
 }
 
 impl<P> Pending<P> {
 	/// Wrap a [`Pollable`] so it can be `.await`ed.
 	pub fn new(inner: P) -> Self {
-		Self { inner, waiter: None }
+		Self {
+			inner,
+			waiter: WaiterCell::new(),
+		}
 	}
 
 	/// Consume the wrapper, returning the inner value.
@@ -72,12 +75,10 @@ impl<P: Pollable> Future for Pending<P> {
 	type Output = P::Output;
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<P::Output> {
-		// Replacing drops the previous waiter, killing its Weak ref in the list so
-		// the inner poll's register call can recycle the slot (see `WaiterList`).
 		// `Pending<P>` is `Unpin` (P is, via the trait bound), so this deref is sound.
 		let this = &mut *self;
-		this.waiter = Some(Waiter::new(cx.waker().clone()));
-		Pollable::poll(&this.inner, this.waiter.as_ref().unwrap())
+		let waiter = this.waiter.register(cx);
+		Pollable::poll(&this.inner, waiter)
 	}
 }
 

--- a/rs/kio/src/pollable.rs
+++ b/rs/kio/src/pollable.rs
@@ -77,7 +77,7 @@ impl<P: Pollable> Future for Pending<P> {
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<P::Output> {
 		// `Pending<P>` is `Unpin` (P is, via the trait bound), so this deref is sound.
 		let this = &mut *self;
-		let waiter = this.cell.waiter(cx);
+		let waiter = this.cell.hold(cx);
 		Pollable::poll(&this.inner, waiter)
 	}
 }

--- a/rs/kio/src/queue.rs
+++ b/rs/kio/src/queue.rs
@@ -350,10 +350,10 @@ mod test {
 		let mut cx = Context::from_waker(&w);
 		let mut cell = WaiterCell::new();
 
-		assert!(queue.poll_pop(cell.waiter(&mut cx)).is_pending());
+		assert!(queue.poll_pop(cell.hold(&mut cx)).is_pending());
 		queue.try_push(7).unwrap();
 		assert!(waker.count() >= 1, "push should wake the parked pop");
-		assert_eq!(queue.poll_pop(cell.waiter(&mut cx)), Poll::Ready(Ok(7)));
+		assert_eq!(queue.poll_pop(cell.hold(&mut cx)), Poll::Ready(Ok(7)));
 	}
 
 	#[test]
@@ -369,7 +369,7 @@ mod test {
 		let made = std::cell::Cell::new(false);
 		assert!(
 			queue
-				.poll_push_with(cell.waiter(&mut cx), || {
+				.poll_push_with(cell.hold(&mut cx), || {
 					made.set(true);
 					2
 				})
@@ -380,7 +380,7 @@ mod test {
 		// A pop frees the slot and wakes the parked push.
 		assert_eq!(queue.try_pop().unwrap(), Some(1));
 		assert!(waker.count() >= 1, "pop should wake the parked push");
-		assert_eq!(queue.poll_push_with(cell.waiter(&mut cx), || 2), Poll::Ready(Ok(())));
+		assert_eq!(queue.poll_push_with(cell.hold(&mut cx), || 2), Poll::Ready(Ok(())));
 		assert_eq!(queue.try_pop().unwrap(), Some(2));
 	}
 
@@ -394,25 +394,25 @@ mod test {
 		let mut pop_cell = WaiterCell::new();
 		// Park a pop on a second handle (the queued item is popped first).
 		let popper = queue.clone();
-		assert_eq!(popper.poll_pop(pop_cell.waiter(&mut cx1)), Poll::Ready(Ok(1)));
-		assert!(popper.poll_pop(pop_cell.waiter(&mut cx1)).is_pending());
+		assert_eq!(popper.poll_pop(pop_cell.hold(&mut cx1)), Poll::Ready(Ok(1)));
+		assert!(popper.poll_pop(pop_cell.hold(&mut cx1)).is_pending());
 
 		// Refill so a push parks too.
 		queue.try_push(2).unwrap();
 		let (push_waker, w2) = counting();
 		let mut cx2 = Context::from_waker(&w2);
 		let mut push_cell = WaiterCell::new();
-		assert!(queue.poll_push_with(push_cell.waiter(&mut cx2), || 3).is_pending());
+		assert!(queue.poll_push_with(push_cell.hold(&mut cx2), || 3).is_pending());
 
 		queue.close();
 		assert!(pop_waker.count() >= 1, "close should wake the parked pop");
 		assert!(push_waker.count() >= 1, "close should wake the parked push");
 
 		// The parked pop drains the remaining item; the push observes closure.
-		assert_eq!(popper.poll_pop(pop_cell.waiter(&mut cx1)), Poll::Ready(Ok(2)));
-		assert_eq!(popper.poll_pop(pop_cell.waiter(&mut cx1)), Poll::Ready(Err(Closed)));
+		assert_eq!(popper.poll_pop(pop_cell.hold(&mut cx1)), Poll::Ready(Ok(2)));
+		assert_eq!(popper.poll_pop(pop_cell.hold(&mut cx1)), Poll::Ready(Err(Closed)));
 		assert_eq!(
-			queue.poll_push_with(push_cell.waiter(&mut cx2), || 3),
+			queue.poll_push_with(push_cell.hold(&mut cx2), || 3),
 			Poll::Ready(Err(Closed))
 		);
 	}

--- a/rs/kio/src/queue.rs
+++ b/rs/kio/src/queue.rs
@@ -9,7 +9,7 @@ use crate::{
 /// The push failed; the item is handed back.
 #[non_exhaustive]
 pub enum PushError<T> {
-	/// The queue is at capacity. Only a bounded [`Deque`]'s `try_push` reports this.
+	/// The queue is at capacity. Only a bounded [`Queue`]'s `try_push` reports this.
 	Full(T),
 	/// The queue was closed; nothing will ever pop the item.
 	Closed(T),
@@ -75,11 +75,11 @@ impl<T> State<T> {
 /// An event wakes *every* waiter parked on the affected side (there is no
 /// wake-one): with several handles racing to pop, one wins and the rest re-park.
 #[derive(Debug)]
-pub struct Deque<T> {
+pub struct Queue<T> {
 	state: Lock<State<T>>,
 }
 
-impl<T> Deque<T> {
+impl<T> Queue<T> {
 	/// Create an unbounded queue: pushes never park or report full.
 	pub fn new() -> Self {
 		Self::with_capacity(None)
@@ -89,7 +89,7 @@ impl<T> Deque<T> {
 	///
 	/// Panics if `capacity` is zero, which could never accept an item.
 	pub fn bounded(capacity: usize) -> Self {
-		assert!(capacity > 0, "a zero-capacity Deque could never accept an item");
+		assert!(capacity > 0, "a zero-capacity Queue could never accept an item");
 		Self::with_capacity(Some(capacity))
 	}
 
@@ -246,13 +246,13 @@ impl<T> Deque<T> {
 	}
 }
 
-impl<T> Default for Deque<T> {
+impl<T> Default for Queue<T> {
 	fn default() -> Self {
 		Self::new()
 	}
 }
 
-impl<T> Clone for Deque<T> {
+impl<T> Clone for Queue<T> {
 	fn clone(&self) -> Self {
 		Self {
 			state: self.state.clone(),
@@ -296,70 +296,70 @@ mod test {
 
 	#[test]
 	fn fifo_order() {
-		let deque = Deque::new();
-		deque.try_push(1).unwrap();
-		deque.try_push(2).unwrap();
-		deque.try_push(3).unwrap();
+		let queue = Queue::new();
+		queue.try_push(1).unwrap();
+		queue.try_push(2).unwrap();
+		queue.try_push(3).unwrap();
 
-		assert_eq!(deque.try_pop().unwrap(), Some(1));
-		assert_eq!(deque.try_pop().unwrap(), Some(2));
-		assert_eq!(deque.try_pop().unwrap(), Some(3));
-		assert_eq!(deque.try_pop().unwrap(), None, "empty but open");
+		assert_eq!(queue.try_pop().unwrap(), Some(1));
+		assert_eq!(queue.try_pop().unwrap(), Some(2));
+		assert_eq!(queue.try_pop().unwrap(), Some(3));
+		assert_eq!(queue.try_pop().unwrap(), None, "empty but open");
 	}
 
 	#[test]
 	fn bounded_rejects_when_full_and_returns_the_item() {
-		let deque = Deque::bounded(1);
-		deque.try_push(1).unwrap();
+		let queue = Queue::bounded(1);
+		queue.try_push(1).unwrap();
 
-		match deque.try_push(2) {
+		match queue.try_push(2) {
 			Err(PushError::Full(item)) => assert_eq!(item, 2),
 			other => panic!("expected Full, got {other:?}"),
 		}
 
 		// Popping frees the slot.
-		assert_eq!(deque.try_pop().unwrap(), Some(1));
-		deque.try_push(2).unwrap();
+		assert_eq!(queue.try_pop().unwrap(), Some(1));
+		queue.try_push(2).unwrap();
 	}
 
 	#[test]
 	fn closed_rejects_pushes_and_drains_pops() {
-		let deque = Deque::new();
-		deque.try_push(1).unwrap();
-		deque.close();
-		deque.close(); // idempotent
+		let queue = Queue::new();
+		queue.try_push(1).unwrap();
+		queue.close();
+		queue.close(); // idempotent
 
-		match deque.try_push(2) {
+		match queue.try_push(2) {
 			Err(PushError::Closed(item)) => assert_eq!(item, 2),
 			other => panic!("expected Closed, got {other:?}"),
 		}
 
 		// The queued item drains before closure is reported.
-		assert_eq!(deque.try_pop().unwrap(), Some(1));
-		assert_eq!(deque.try_pop(), Err(Closed));
+		assert_eq!(queue.try_pop().unwrap(), Some(1));
+		assert_eq!(queue.try_pop(), Err(Closed));
 
 		let waiter = Waiter::noop();
-		assert_eq!(deque.poll_pop(&waiter), Poll::Ready(Err(Closed)));
-		assert_eq!(deque.poll_push_with(&waiter, || 3), Poll::Ready(Err(Closed)));
+		assert_eq!(queue.poll_pop(&waiter), Poll::Ready(Err(Closed)));
+		assert_eq!(queue.poll_push_with(&waiter, || 3), Poll::Ready(Err(Closed)));
 	}
 
 	#[test]
 	fn push_wakes_a_parked_pop() {
-		let deque = Deque::new();
+		let queue = Queue::new();
 		let (waker, w) = counting();
 		let mut cx = Context::from_waker(&w);
 		let mut cell = WaiterCell::new();
 
-		assert!(deque.poll_pop(cell.register(&mut cx)).is_pending());
-		deque.try_push(7).unwrap();
+		assert!(queue.poll_pop(cell.waiter(&mut cx)).is_pending());
+		queue.try_push(7).unwrap();
 		assert!(waker.count() >= 1, "push should wake the parked pop");
-		assert_eq!(deque.poll_pop(cell.register(&mut cx)), Poll::Ready(Ok(7)));
+		assert_eq!(queue.poll_pop(cell.waiter(&mut cx)), Poll::Ready(Ok(7)));
 	}
 
 	#[test]
 	fn pop_wakes_a_parked_push_and_defers_the_item() {
-		let deque = Deque::bounded(1);
-		deque.try_push(1).unwrap();
+		let queue = Queue::bounded(1);
+		queue.try_push(1).unwrap();
 
 		let (waker, w) = counting();
 		let mut cx = Context::from_waker(&w);
@@ -368,8 +368,8 @@ mod test {
 		// Full: the closure must not run, and the poll parks.
 		let made = std::cell::Cell::new(false);
 		assert!(
-			deque
-				.poll_push_with(cell.register(&mut cx), || {
+			queue
+				.poll_push_with(cell.waiter(&mut cx), || {
 					made.set(true);
 					2
 				})
@@ -378,109 +378,109 @@ mod test {
 		assert!(!made.get(), "the item must not be built while full");
 
 		// A pop frees the slot and wakes the parked push.
-		assert_eq!(deque.try_pop().unwrap(), Some(1));
+		assert_eq!(queue.try_pop().unwrap(), Some(1));
 		assert!(waker.count() >= 1, "pop should wake the parked push");
-		assert_eq!(deque.poll_push_with(cell.register(&mut cx), || 2), Poll::Ready(Ok(())));
-		assert_eq!(deque.try_pop().unwrap(), Some(2));
+		assert_eq!(queue.poll_push_with(cell.waiter(&mut cx), || 2), Poll::Ready(Ok(())));
+		assert_eq!(queue.try_pop().unwrap(), Some(2));
 	}
 
 	#[test]
 	fn close_wakes_both_sides() {
-		let deque = Deque::<u32>::bounded(1);
-		deque.try_push(1).unwrap();
+		let queue = Queue::<u32>::bounded(1);
+		queue.try_push(1).unwrap();
 
 		let (pop_waker, w1) = counting();
 		let mut cx1 = Context::from_waker(&w1);
 		let mut pop_cell = WaiterCell::new();
 		// Park a pop on a second handle (the queued item is popped first).
-		let popper = deque.clone();
-		assert_eq!(popper.poll_pop(pop_cell.register(&mut cx1)), Poll::Ready(Ok(1)));
-		assert!(popper.poll_pop(pop_cell.register(&mut cx1)).is_pending());
+		let popper = queue.clone();
+		assert_eq!(popper.poll_pop(pop_cell.waiter(&mut cx1)), Poll::Ready(Ok(1)));
+		assert!(popper.poll_pop(pop_cell.waiter(&mut cx1)).is_pending());
 
 		// Refill so a push parks too.
-		deque.try_push(2).unwrap();
+		queue.try_push(2).unwrap();
 		let (push_waker, w2) = counting();
 		let mut cx2 = Context::from_waker(&w2);
 		let mut push_cell = WaiterCell::new();
-		assert!(deque.poll_push_with(push_cell.register(&mut cx2), || 3).is_pending());
+		assert!(queue.poll_push_with(push_cell.waiter(&mut cx2), || 3).is_pending());
 
-		deque.close();
+		queue.close();
 		assert!(pop_waker.count() >= 1, "close should wake the parked pop");
 		assert!(push_waker.count() >= 1, "close should wake the parked push");
 
 		// The parked pop drains the remaining item; the push observes closure.
-		assert_eq!(popper.poll_pop(pop_cell.register(&mut cx1)), Poll::Ready(Ok(2)));
-		assert_eq!(popper.poll_pop(pop_cell.register(&mut cx1)), Poll::Ready(Err(Closed)));
+		assert_eq!(popper.poll_pop(pop_cell.waiter(&mut cx1)), Poll::Ready(Ok(2)));
+		assert_eq!(popper.poll_pop(pop_cell.waiter(&mut cx1)), Poll::Ready(Err(Closed)));
 		assert_eq!(
-			deque.poll_push_with(push_cell.register(&mut cx2), || 3),
+			queue.poll_push_with(push_cell.waiter(&mut cx2), || 3),
 			Poll::Ready(Err(Closed))
 		);
 	}
 
 	#[test]
 	fn accessors() {
-		let deque = Deque::bounded(2);
-		assert_eq!(deque.capacity(), Some(2));
-		assert!(deque.is_empty());
-		deque.try_push(1).unwrap();
-		assert_eq!(deque.len(), 1);
-		assert!(!deque.is_empty());
-		assert!(!deque.is_closed());
+		let queue = Queue::bounded(2);
+		assert_eq!(queue.capacity(), Some(2));
+		assert!(queue.is_empty());
+		queue.try_push(1).unwrap();
+		assert_eq!(queue.len(), 1);
+		assert!(!queue.is_empty());
+		assert!(!queue.is_closed());
 
-		let clone = deque.clone();
-		let other = Deque::<u32>::new();
-		assert!(deque.same_channel(&clone));
-		assert!(!deque.same_channel(&other));
+		let clone = queue.clone();
+		let other = Queue::<u32>::new();
+		assert!(queue.same_channel(&clone));
+		assert!(!queue.same_channel(&other));
 		assert_eq!(other.capacity(), None);
 	}
 
 	#[test]
 	#[should_panic(expected = "zero-capacity")]
 	fn zero_capacity_panics() {
-		let _ = Deque::<u32>::bounded(0);
+		let _ = Queue::<u32>::bounded(0);
 	}
 
 	#[tokio::test]
 	async fn async_push_parks_until_popped() {
-		let deque = Deque::bounded(1);
-		deque.try_push(1u32).unwrap();
+		let queue = Queue::bounded(1);
+		queue.try_push(1u32).unwrap();
 
-		let pusher = deque.clone();
+		let pusher = queue.clone();
 		let task = tokio::spawn(async move { pusher.push(2).await });
 
 		// Let the push park on the full queue before making room.
 		tokio::task::yield_now().await;
-		assert_eq!(deque.pop().await, Ok(1));
+		assert_eq!(queue.pop().await, Ok(1));
 
 		task.await.unwrap().unwrap();
-		assert_eq!(deque.pop().await, Ok(2));
+		assert_eq!(queue.pop().await, Ok(2));
 	}
 
 	#[tokio::test]
 	async fn async_pop_parks_until_pushed() {
-		let deque = Deque::new();
-		let popper = deque.clone();
+		let queue = Queue::new();
+		let popper = queue.clone();
 		let task = tokio::spawn(async move { popper.pop().await });
 
 		tokio::task::yield_now().await;
-		deque.try_push(9u32).unwrap();
+		queue.try_push(9u32).unwrap();
 
 		assert_eq!(task.await.unwrap(), Ok(9));
 	}
 
 	#[tokio::test]
 	async fn async_ops_observe_close() {
-		let deque = Deque::<u32>::bounded(1);
-		deque.try_push(1).unwrap();
+		let queue = Queue::<u32>::bounded(1);
+		queue.try_push(1).unwrap();
 
-		let pusher = deque.clone();
+		let pusher = queue.clone();
 		let push = tokio::spawn(async move { pusher.push(2).await });
 		tokio::task::yield_now().await;
-		deque.close();
+		queue.close();
 
 		assert_eq!(push.await.unwrap(), Err(Closed));
 		// Pops still drain the queued item before reporting closure.
-		assert_eq!(deque.pop().await, Ok(1));
-		assert_eq!(deque.pop().await, Err(Closed));
+		assert_eq!(queue.pop().await, Ok(1));
+		assert_eq!(queue.pop().await, Err(Closed));
 	}
 }

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -20,6 +20,9 @@ const INLINE_WAITERS: usize = 32;
 /// so a poll that resolves without ever parking never touches the heap. Its `Weak`s
 /// go dead the moment the owning [`Waiter`] drops, which is how a [`WaiterList`]
 /// reclaims slots with no explicit deregister.
+///
+/// A clone shares this identity: it wakes the same task, its registrations count as
+/// the original's, and they all stay live until every clone drops.
 pub struct Waiter {
 	// The task waker. Cloning it is cheap (an atomic bump, no allocation).
 	waker: Waker,
@@ -65,6 +68,19 @@ impl Waiter {
 	/// `poll_*` step when it is ready.
 	pub fn poll_future<F: Future + ?Sized>(&self, future: Pin<&mut F>) -> Poll<F::Output> {
 		future.poll(&mut Context::from_waker(self.waker()))
+	}
+}
+
+impl Clone for Waiter {
+	fn clone(&self) -> Self {
+		// Force the shared Arc into existence so both handles point at one
+		// allocation; a lazily separate Arc would give the clone its own (shorter)
+		// registration lifetime, silently killing registrations when it drops.
+		let shared = self.shared().clone();
+		Self {
+			waker: self.waker.clone(),
+			shared: OnceLock::from(shared),
+		}
 	}
 }
 
@@ -150,8 +166,12 @@ impl fmt::Debug for WaiterList {
 /// holds only weakly, so whoever drives them from a [`Context`]-based poll (a
 /// `Future`, or a `poll_*` trait method) must keep the strong `Waiter` alive
 /// between polls or the registration dies the moment the poll returns. Embed one
-/// cell per logical operation and call [`register`](Self::register) at the top of
+/// cell per logical operation and call [`waiter`](Self::waiter) at the top of
 /// each poll.
+///
+/// The returned borrow is tied to the cell, so when the rest of the poll needs
+/// `&mut self` of the type holding it, `clone()` the waiter to end the borrow;
+/// the clone shares the retained waiter's identity, so nothing is lost.
 ///
 /// `Clone` yields an *empty* cell: an in-progress registration belongs to the
 /// handle that parked it, so a cloned handle starts idle. This is what lets a
@@ -174,7 +194,7 @@ impl WaiterCell {
 	/// because [`WaiterList`] reclaims slots only when their `Arc` dies. Reusing one
 	/// with live entries would stack duplicate live registrations on every
 	/// (spuriously re-polled) `Pending`, and the list would grow without bound.
-	pub fn register(&mut self, cx: &mut Context<'_>) -> &Waiter {
+	pub fn waiter(&mut self, cx: &mut Context<'_>) -> &Waiter {
 		let reuse = self.0.as_ref().is_some_and(|waiter| {
 			cx.waker().will_wake(&waiter.waker) && waiter.shared.get().is_none_or(|shared| Arc::weak_count(shared) == 0)
 		});
@@ -200,7 +220,7 @@ impl fmt::Debug for WaiterCell {
 /// Future that drives a poll function, managing waiter lifetime across polls.
 struct WaiterFn<F, R> {
 	poll: F,
-	waiter: WaiterCell, // Retain the previous waiter so its registrations survive.
+	cell: WaiterCell, // Retain the waiter so its registrations survive.
 	// `fn() -> R` keeps the marker `Unpin` (and `Send`/`Sync`) regardless of `R`:
 	// the output is only ever moved out of `Poll::Ready`, never stored.
 	_marker: PhantomData<fn() -> R>,
@@ -216,7 +236,7 @@ where
 {
 	WaiterFn {
 		poll,
-		waiter: WaiterCell::new(),
+		cell: WaiterCell::new(),
 		_marker: PhantomData,
 	}
 }
@@ -229,7 +249,7 @@ where
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<R> {
 		let this = &mut *self;
-		let waiter = this.waiter.register(cx);
+		let waiter = this.cell.waiter(cx);
 		(this.poll)(waiter)
 	}
 }
@@ -274,13 +294,13 @@ mod tests {
 		let mut list = WaiterList::new();
 
 		// Poll 1 parks: the waiter registers with a list.
-		cell.register(&mut cx).register(&mut list);
+		cell.waiter(&mut cx).register(&mut list);
 		// Hold the Arc so a pointer comparison can't alias a recycled allocation.
 		let first = cell.0.as_ref().unwrap().shared().clone();
 
 		// Poll 2 with the registration still live must replace the waiter: reusing
 		// it would stack a duplicate live entry the list could never reclaim.
-		let second = cell.register(&mut cx);
+		let second = cell.waiter(&mut cx);
 		assert!(!Arc::ptr_eq(&first, second.shared()), "a registered waiter was reused");
 		second.register(&mut list);
 		let second = second.shared().clone();
@@ -288,7 +308,7 @@ mod tests {
 		// The wake drains the list, so poll 3 can reuse the waiter: same task, no
 		// live registrations left to duplicate.
 		list.wake();
-		let third = cell.register(&mut cx);
+		let third = cell.waiter(&mut cx);
 		assert!(Arc::ptr_eq(&second, third.shared()), "a drained waiter was not reused");
 	}
 
@@ -303,8 +323,8 @@ mod tests {
 		let waker_b = Waker::from(Arc::new(Nop));
 		let mut cell = WaiterCell::new();
 
-		let first = cell.register(&mut Context::from_waker(&waker_a)).shared().clone();
-		let second = cell.register(&mut Context::from_waker(&waker_b));
+		let first = cell.waiter(&mut Context::from_waker(&waker_a)).shared().clone();
+		let second = cell.waiter(&mut Context::from_waker(&waker_b));
 		assert!(
 			!Arc::ptr_eq(&first, second.shared()),
 			"a waiter for another task was reused"
@@ -315,12 +335,36 @@ mod tests {
 	fn waiter_cell_clone_is_idle() {
 		let waker = Waker::noop().clone();
 		let mut cell = WaiterCell::new();
-		cell.register(&mut Context::from_waker(&waker));
+		cell.waiter(&mut Context::from_waker(&waker));
 		assert!(cell.0.is_some());
 
 		// An in-progress registration belongs to the original handle.
 		let clone = cell.clone();
 		assert!(clone.0.is_none(), "a cloned cell must start idle");
+	}
+
+	#[test]
+	fn waiter_clone_shares_identity() {
+		let waker = Waker::noop().clone();
+		let mut cx = Context::from_waker(&waker);
+		let mut cell = WaiterCell::new();
+		let mut list = WaiterList::new();
+
+		// The clone shares the retained waiter's allocation, so a registration made
+		// through it belongs to the retained waiter and outlives the clone.
+		let clone = cell.waiter(&mut cx).clone();
+		assert!(Arc::ptr_eq(clone.shared(), cell.0.as_ref().unwrap().shared()));
+		clone.register(&mut list);
+		drop(clone);
+
+		// The cell still sees that registration as live, so the next poll must
+		// replace the waiter rather than stack a duplicate entry.
+		let first = cell.0.as_ref().unwrap().shared().clone();
+		let second = cell.waiter(&mut cx);
+		assert!(
+			!Arc::ptr_eq(&first, second.shared()),
+			"a waiter with a clone's live registration was reused"
+		);
 	}
 
 	#[test]

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -143,10 +143,64 @@ impl fmt::Debug for WaiterList {
 	}
 }
 
+/// Retains a [`Waiter`] across `poll` calls, bridging a [`Context`] to kio's
+/// waiter-based polls.
+///
+/// kio's `poll_*` methods take a `&Waiter` whose registrations a [`WaiterList`]
+/// holds only weakly, so whoever drives them from a [`Context`]-based poll (a
+/// `Future`, or a `poll_*` trait method) must keep the strong `Waiter` alive
+/// between polls or the registration dies the moment the poll returns. Embed one
+/// cell per logical operation and call [`register`](Self::register) at the top of
+/// each poll.
+///
+/// `Clone` yields an *empty* cell: an in-progress registration belongs to the
+/// handle that parked it, so a cloned handle starts idle. This is what lets a
+/// containing type stay `Clone` while holding cells.
+#[derive(Default)]
+pub struct WaiterCell(Option<Waiter>);
+
+impl WaiterCell {
+	/// Create an empty cell.
+	pub const fn new() -> Self {
+		Self(None)
+	}
+
+	/// The waiter to use for this poll.
+	///
+	/// The retained waiter is reused when it would wake the same task *and* has no
+	/// live list registrations — the common case after a wakeup, where every list
+	/// entry was drained — saving the `Arc` allocation and waker clone. Otherwise it
+	/// is replaced: a still-registered waiter must be retired, not re-registered,
+	/// because [`WaiterList`] reclaims slots only when their `Arc` dies. Reusing one
+	/// with live entries would stack duplicate live registrations on every
+	/// (spuriously re-polled) `Pending`, and the list would grow without bound.
+	pub fn register(&mut self, cx: &mut Context<'_>) -> &Waiter {
+		let reuse = self.0.as_ref().is_some_and(|waiter| {
+			cx.waker().will_wake(&waiter.waker) && waiter.shared.get().is_none_or(|shared| Arc::weak_count(shared) == 0)
+		});
+		if !reuse {
+			self.0 = Some(Waiter::new(cx.waker().clone()));
+		}
+		self.0.as_ref().unwrap()
+	}
+}
+
+impl Clone for WaiterCell {
+	fn clone(&self) -> Self {
+		Self(None)
+	}
+}
+
+impl fmt::Debug for WaiterCell {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("WaiterCell").field("armed", &self.0.is_some()).finish()
+	}
+}
+
 /// Future that drives a poll function, managing waiter lifetime across polls.
 struct WaiterFn<F, R> {
 	poll: F,
-	waiter: Option<Waiter>, // Store the previous waiter to avoid dropping it.
+	waiter: WaiterCell, // Retain the previous waiter so its registrations survive.
 	// `fn() -> R` keeps the marker `Unpin` (and `Send`/`Sync`) regardless of `R`:
 	// the output is only ever moved out of `Poll::Ready`, never stored.
 	_marker: PhantomData<fn() -> R>,
@@ -162,7 +216,7 @@ where
 {
 	WaiterFn {
 		poll,
-		waiter: None,
+		waiter: WaiterCell::new(),
 		_marker: PhantomData,
 	}
 }
@@ -175,10 +229,8 @@ where
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<R> {
 		let this = &mut *self;
-		// Replacing drops the previous waiter, killing its Weak ref in the
-		// list so the inner poll function's register call can recycle it.
-		this.waiter = Some(Waiter::new(cx.waker().clone()));
-		(this.poll)(this.waiter.as_ref().unwrap())
+		let waiter = this.waiter.register(cx);
+		(this.poll)(waiter)
 	}
 }
 
@@ -213,6 +265,63 @@ mod tests {
 		assert_sync::<crate::Pending<crate::Consumer<u32>>>();
 		assert_sync::<crate::Shared<u32>>();
 	};
+
+	#[test]
+	fn waiter_cell_replaces_while_registered_and_reuses_after_wake() {
+		let waker = Waker::noop().clone();
+		let mut cx = Context::from_waker(&waker);
+		let mut cell = WaiterCell::new();
+		let mut list = WaiterList::new();
+
+		// Poll 1 parks: the waiter registers with a list.
+		cell.register(&mut cx).register(&mut list);
+		// Hold the Arc so a pointer comparison can't alias a recycled allocation.
+		let first = cell.0.as_ref().unwrap().shared().clone();
+
+		// Poll 2 with the registration still live must replace the waiter: reusing
+		// it would stack a duplicate live entry the list could never reclaim.
+		let second = cell.register(&mut cx);
+		assert!(!Arc::ptr_eq(&first, second.shared()), "a registered waiter was reused");
+		second.register(&mut list);
+		let second = second.shared().clone();
+
+		// The wake drains the list, so poll 3 can reuse the waiter: same task, no
+		// live registrations left to duplicate.
+		list.wake();
+		let third = cell.register(&mut cx);
+		assert!(Arc::ptr_eq(&second, third.shared()), "a drained waiter was not reused");
+	}
+
+	#[test]
+	fn waiter_cell_replaces_for_a_different_task() {
+		struct Nop;
+		impl std::task::Wake for Nop {
+			fn wake(self: Arc<Self>) {}
+		}
+
+		let waker_a = Waker::from(Arc::new(Nop));
+		let waker_b = Waker::from(Arc::new(Nop));
+		let mut cell = WaiterCell::new();
+
+		let first = cell.register(&mut Context::from_waker(&waker_a)).shared().clone();
+		let second = cell.register(&mut Context::from_waker(&waker_b));
+		assert!(
+			!Arc::ptr_eq(&first, second.shared()),
+			"a waiter for another task was reused"
+		);
+	}
+
+	#[test]
+	fn waiter_cell_clone_is_idle() {
+		let waker = Waker::noop().clone();
+		let mut cell = WaiterCell::new();
+		cell.register(&mut Context::from_waker(&waker));
+		assert!(cell.0.is_some());
+
+		// An in-progress registration belongs to the original handle.
+		let clone = cell.clone();
+		assert!(clone.0.is_none(), "a cloned cell must start idle");
+	}
 
 	#[test]
 	fn wait_output_need_not_be_unpin() {

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -168,8 +168,8 @@ impl WaiterCell {
 	/// The waiter to use for this poll.
 	///
 	/// The retained waiter is reused when it would wake the same task *and* has no
-	/// live list registrations — the common case after a wakeup, where every list
-	/// entry was drained — saving the `Arc` allocation and waker clone. Otherwise it
+	/// live list registrations (the common case after a wakeup, where every list
+	/// entry was drained), saving the `Arc` allocation and waker clone. Otherwise it
 	/// is replaced: a still-registered waiter must be retired, not re-registered,
 	/// because [`WaiterList`] reclaims slots only when their `Arc` dies. Reusing one
 	/// with live entries would stack duplicate live registrations on every

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -166,7 +166,7 @@ impl fmt::Debug for WaiterList {
 /// holds only weakly, so whoever drives them from a [`Context`]-based poll (a
 /// `Future`, or a `poll_*` trait method) must keep the strong `Waiter` alive
 /// between polls or the registration dies the moment the poll returns. Embed one
-/// cell per logical operation and call [`waiter`](Self::waiter) at the top of
+/// cell per logical operation and call [`hold`](Self::hold) at the top of
 /// each poll.
 ///
 /// The returned borrow is tied to the cell, so when the rest of the poll needs
@@ -185,16 +185,17 @@ impl WaiterCell {
 		Self(None)
 	}
 
-	/// The waiter to use for this poll.
+	/// Hold a waiter for this poll, keeping it (and its registrations) alive until
+	/// the next call.
 	///
-	/// The retained waiter is reused when it would wake the same task *and* has no
+	/// The held waiter is reused when it would wake the same task *and* has no
 	/// live list registrations (the common case after a wakeup, where every list
 	/// entry was drained), saving the `Arc` allocation and waker clone. Otherwise it
 	/// is replaced: a still-registered waiter must be retired, not re-registered,
 	/// because [`WaiterList`] reclaims slots only when their `Arc` dies. Reusing one
 	/// with live entries would stack duplicate live registrations on every
 	/// (spuriously re-polled) `Pending`, and the list would grow without bound.
-	pub fn waiter(&mut self, cx: &mut Context<'_>) -> &Waiter {
+	pub fn hold(&mut self, cx: &mut Context<'_>) -> &Waiter {
 		let reuse = self.0.as_ref().is_some_and(|waiter| {
 			cx.waker().will_wake(&waiter.waker) && waiter.shared.get().is_none_or(|shared| Arc::weak_count(shared) == 0)
 		});
@@ -249,7 +250,7 @@ where
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<R> {
 		let this = &mut *self;
-		let waiter = this.cell.waiter(cx);
+		let waiter = this.cell.hold(cx);
 		(this.poll)(waiter)
 	}
 }
@@ -294,13 +295,13 @@ mod tests {
 		let mut list = WaiterList::new();
 
 		// Poll 1 parks: the waiter registers with a list.
-		cell.waiter(&mut cx).register(&mut list);
+		cell.hold(&mut cx).register(&mut list);
 		// Hold the Arc so a pointer comparison can't alias a recycled allocation.
 		let first = cell.0.as_ref().unwrap().shared().clone();
 
 		// Poll 2 with the registration still live must replace the waiter: reusing
 		// it would stack a duplicate live entry the list could never reclaim.
-		let second = cell.waiter(&mut cx);
+		let second = cell.hold(&mut cx);
 		assert!(!Arc::ptr_eq(&first, second.shared()), "a registered waiter was reused");
 		second.register(&mut list);
 		let second = second.shared().clone();
@@ -308,7 +309,7 @@ mod tests {
 		// The wake drains the list, so poll 3 can reuse the waiter: same task, no
 		// live registrations left to duplicate.
 		list.wake();
-		let third = cell.waiter(&mut cx);
+		let third = cell.hold(&mut cx);
 		assert!(Arc::ptr_eq(&second, third.shared()), "a drained waiter was not reused");
 	}
 
@@ -323,8 +324,8 @@ mod tests {
 		let waker_b = Waker::from(Arc::new(Nop));
 		let mut cell = WaiterCell::new();
 
-		let first = cell.waiter(&mut Context::from_waker(&waker_a)).shared().clone();
-		let second = cell.waiter(&mut Context::from_waker(&waker_b));
+		let first = cell.hold(&mut Context::from_waker(&waker_a)).shared().clone();
+		let second = cell.hold(&mut Context::from_waker(&waker_b));
 		assert!(
 			!Arc::ptr_eq(&first, second.shared()),
 			"a waiter for another task was reused"
@@ -335,7 +336,7 @@ mod tests {
 	fn waiter_cell_clone_is_idle() {
 		let waker = Waker::noop().clone();
 		let mut cell = WaiterCell::new();
-		cell.waiter(&mut Context::from_waker(&waker));
+		cell.hold(&mut Context::from_waker(&waker));
 		assert!(cell.0.is_some());
 
 		// An in-progress registration belongs to the original handle.
@@ -352,7 +353,7 @@ mod tests {
 
 		// The clone shares the retained waiter's allocation, so a registration made
 		// through it belongs to the retained waiter and outlives the clone.
-		let clone = cell.waiter(&mut cx).clone();
+		let clone = cell.hold(&mut cx).clone();
 		assert!(Arc::ptr_eq(clone.shared(), cell.0.as_ref().unwrap().shared()));
 		clone.register(&mut list);
 		drop(clone);
@@ -360,7 +361,7 @@ mod tests {
 		// The cell still sees that registration as live, so the next poll must
 		// replace the waiter rather than stack a duplicate entry.
 		let first = cell.0.as_ref().unwrap().shared().clone();
-		let second = cell.waiter(&mut cx);
+		let second = cell.hold(&mut cx);
 		assert!(
 			!Arc::ptr_eq(&first, second.shared()),
 			"a waiter with a clone's live registration was reused"

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -135,7 +135,7 @@ pub struct Driver {
 	// result) doesn't re-poll a finished future.
 	result: Option<Result<(), Error>>,
 	// Retains the waiter across `Future` polls so its kio registrations stay live.
-	waiter: kio::WaiterCell,
+	cell: kio::WaiterCell,
 }
 
 impl Driver {
@@ -185,11 +185,10 @@ impl Future for Driver {
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
 		let this = &mut *self;
-		// Take the cell so its borrow doesn't overlap the `&mut self` poll below.
-		let mut cell = std::mem::take(&mut this.waiter);
-		let result = this.poll(cell.register(cx));
-		this.waiter = cell;
-		result
+		// The clone shares the retained waiter's identity while ending the cell
+		// borrow, which the `&mut self` poll below would otherwise conflict with.
+		let waiter = this.cell.waiter(cx).clone();
+		this.poll(&waiter)
 	}
 }
 
@@ -248,7 +247,7 @@ impl Session {
 			protocol,
 			maintenance,
 			result: None,
-			waiter: kio::WaiterCell::new(),
+			cell: kio::WaiterCell::new(),
 		};
 
 		(session, driver)

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -134,9 +134,8 @@ pub struct Driver {
 	// Cached so a poll after completion (e.g. after `wait_ready` consumed the
 	// result) doesn't re-poll a finished future.
 	result: Option<Result<(), Error>>,
-	// Retains the previous poll's waiter so its kio registrations stay live until
-	// the next poll replaces it (same dance as `kio::wait`).
-	waiter: Option<kio::Waiter>,
+	// Retains the waiter across `Future` polls so its kio registrations stay live.
+	waiter: kio::WaiterCell,
 }
 
 impl Driver {
@@ -186,11 +185,10 @@ impl Future for Driver {
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
 		let this = &mut *self;
-		// Replacing drops the previous waiter, keeping this one live until the next
-		// poll so any kio registrations it made survive (see `kio::wait`).
-		let waiter = kio::Waiter::new(cx.waker().clone());
-		let result = this.poll(&waiter);
-		this.waiter = Some(waiter);
+		// Take the cell so its borrow doesn't overlap the `&mut self` poll below.
+		let mut cell = std::mem::take(&mut this.waiter);
+		let result = this.poll(cell.register(cx));
+		this.waiter = cell;
 		result
 	}
 }
@@ -250,7 +248,7 @@ impl Session {
 			protocol,
 			maintenance,
 			result: None,
-			waiter: None,
+			waiter: kio::WaiterCell::new(),
 		};
 
 		(session, driver)

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -187,7 +187,7 @@ impl Future for Driver {
 		let this = &mut *self;
 		// The clone shares the retained waiter's identity while ending the cell
 		// borrow, which the `&mut self` poll below would otherwise conflict with.
-		let waiter = this.cell.waiter(cx).clone();
+		let waiter = this.cell.hold(cx).clone();
 		this.poll(&waiter)
 	}
 }


### PR DESCRIPTION
## Summary

- `WaiterCell`: retains a strong `Waiter` across `Context`-based polls, bridging `poll_*` trait methods to kio's waiter-based polls. `hold(cx)` reuses the retained waiter after a wakeup (same task, no live registrations) to skip the per-poll `Arc` allocation, and replaces it otherwise so `WaiterList` GC can reclaim retired slots. `wait()` and `Pending` use it internally, picking up the same reuse.
- `Waiter` is now `Clone`, sharing identity: a clone wakes the same task and its registrations count as the original's, staying live until every clone drops. This is the escape hatch for a poll method that needs `&mut self` of the type holding the cell: clone the waiter to end the cell borrow.
- `Queue`: a poll-native FIFO queue in the `Shared` style. Role-less clone-able handles, bounded or unbounded, split push/pop waiter lists so a push never wakes parked pushers, explicit `close()` with drain-before-`Closed` pops. `poll_push_with` takes a closure so a pending push builds nothing and hands nothing back.
- moq-net's `Driver` now retains its waiter with `WaiterCell` instead of hand-rolling the same dance (and cloning the waker every poll).

Motivation: qmux (moq-dev/web-transport) is being converted to a poll-first state machine implementing the new `web-transport-trait` sans-I/O poll traits, built on kio. These are the two pieces kio was missing for `Context`-based poll surfaces; `Queue` should also be reusable in moq-net (e.g. rebuilding `TaskSet`'s submission channel without `futures::channel::mpsc`).

## Public API changes

All additive, in `kio`:
- `pub struct WaiterCell` with `new()`, `hold(&mut self, &mut Context) -> &Waiter`; `Clone` yields an idle cell.
- `impl Clone for Waiter` (shared identity, see above).
- `pub struct Queue<T>` with `new()`, `bounded(usize)`, `try_push`, `poll_push_with`, `push`, `try_pop`, `poll_pop`, `pop`, `close`, `is_closed`, `len`, `is_empty`, `capacity`, `same_channel`.
- `pub enum PushError<T>` (`Full`/`Closed`, `#[non_exhaustive]`) with `into_inner()`.

## Test plan

- `cargo nextest run -p kio -p moq-net` (648 tests, including WaiterCell replace/reuse/clone-identity and Queue unit tests).
- `just loom`: all 17 models (12 kio including 3 Queue wakeup/close races, 5 moq-net).
- `cargo clippy --all-targets`, `cargo fmt`, `RUSTDOCFLAGS="-D warnings" cargo doc -p kio` all clean.

(written by Fable 5)
