### PR TITLE
feat(js/publish): fan captured media out to every consumer

### DIFF
--- a/demo/web/src/publish.ts
+++ b/demo/web/src/publish.ts
@@ -460,7 +460,7 @@ viz.run((effect) => {
 	if (!fanout) return;
 
 	const reader = fanout.subscribe(effect).getReader();
-	effect.cleanup(() => void reader.cancel());
+	effect.cleanup(() => reader.cancel().catch(() => {}));
 
 	effect.spawn(async () => {
 		for (;;) {

--- a/demo/web/src/publish.ts
+++ b/demo/web/src/publish.ts
@@ -450,10 +450,25 @@ const rttGraph = graph(viz, "Round trip", { color: "#38bdf8", format: (v) => `${
 $("publish-graphs").append(captureGraph.el, uploadGraph.el, rttGraph.el);
 
 // Count captured frames; the publish API has no encoded-frame counter, so this
-// is the capture rate feeding the encoder (a good proxy for output fps).
+// is the capture rate feeding the encoder (a good proxy for output fps). Read off our own stream:
+// a signal coalesces a burst into one notification, which undercounts the rate.
 let frames = 0;
 viz.run((effect) => {
-	if (effect.get(publish.capture.out.frame)) frames++;
+	const fanout = effect.get(publish.capture.out.frames);
+	if (!fanout) return;
+
+	const reader = fanout.subscribe(effect).getReader();
+	effect.cleanup(() => void reader.cancel());
+
+	effect.spawn(async () => {
+		for (;;) {
+			const next = await Promise.race([reader.read(), effect.cancel]);
+			if (!next?.value) break;
+
+			frames++;
+			next.value.close();
+		}
+	});
 });
 
 let prevFrames = 0;

--- a/demo/web/src/publish.ts
+++ b/demo/web/src/publish.ts
@@ -162,11 +162,12 @@ ui.run((effect) => {
 	effect.set(source.constraints, cameraConstraints(readVideoTarget(effect)));
 });
 
-// Audio general settings (volume gain, output sample rate, channel mix).
+// Audio general settings. Volume is per-rendition; the capture format is shared by all of them,
+// so rate and channel mix live on the capture rather than the encoder.
 ui.run((effect) => {
 	publish.audio.volume.set(effect.get(volume));
-	publish.audio.sampleRate.set(effect.get(sampleRate));
-	publish.audio.channelCount.set(effect.get(channelCount));
+	publish.audioCapture.sampleRate.set(effect.get(sampleRate));
+	publish.audioCapture.channelCount.set(effect.get(channelCount));
 });
 
 // Mic processing constraints go to the capture itself (getUserMedia re-acquires the track on

--- a/demo/web/src/publish.ts
+++ b/demo/web/src/publish.ts
@@ -166,8 +166,10 @@ ui.run((effect) => {
 // so rate and channel mix live on the capture rather than the encoder.
 ui.run((effect) => {
 	publish.audio.volume.set(effect.get(volume));
-	publish.audioCapture.sampleRate.set(effect.get(sampleRate));
-	publish.audioCapture.channelCount.set(effect.get(channelCount));
+
+	const capture = publish.audio.capture;
+	capture?.sampleRate.set(effect.get(sampleRate));
+	capture?.channelCount.set(effect.get(channelCount));
 });
 
 // Mic processing constraints go to the capture itself (getUserMedia re-acquires the track on

--- a/demo/web/src/publish.ts
+++ b/demo/web/src/publish.ts
@@ -460,7 +460,9 @@ viz.run((effect) => {
 	if (!fanout) return;
 
 	const reader = fanout.subscribe(effect).getReader();
-	effect.cleanup(() => reader.cancel().catch(() => {}));
+	effect.cleanup(() => {
+		reader.cancel().catch(() => {});
+	});
 
 	effect.spawn(async () => {
 		for (;;) {

--- a/js/publish/src/audio/capture.test.ts
+++ b/js/publish/src/audio/capture.test.ts
@@ -1,12 +1,11 @@
 import { expect, mock, spyOn, test } from "bun:test";
-import { Signal } from "@moq/signals";
+import { Effect, Signal } from "@moq/signals";
 
-// The encoder pulls the capture processor in as a `?worklet` blob URL, which the bun test loader can't
+// The capture pulls its processor in as a `?worklet` blob URL, which the bun test loader can't
 // resolve. Stub it so the module imports; the value is only ever passed to our fake addModule.
 mock.module("./capture-worklet.ts?worklet", () => ({ default: "blob:fake-capture" }));
 
-const { Encoder } = await import("./encoder.ts");
-type Codec = import("./encoder.ts").Codec;
+const { Capture } = await import("./capture.ts");
 
 const flush = () => new Promise<void>((resolve) => queueMicrotask(resolve));
 async function settle(times = 5): Promise<void> {
@@ -98,7 +97,7 @@ test("does not construct an AudioWorkletNode when torn down mid worklet load", a
 	using webaudio = installFakeWebAudio();
 	const error = spyOn(console, "error").mockImplementation(() => {});
 
-	const encoder = new Encoder("audio", {
+	const capture = new Capture({
 		enabled: true,
 		source: new Signal(fakeSource()) as never,
 	});
@@ -108,7 +107,7 @@ test("does not construct an AudioWorkletNode when torn down mid worklet load", a
 
 	// Tear the run down before the module finishes loading. cleanup() calls context.close(), which on
 	// Firefox/Safari leaves .state === "suspended", then effect.cancel wins the race.
-	encoder.close();
+	capture.close();
 	await settle();
 
 	expect(webaudio.audioWorkletNodes).toBe(0);
@@ -118,67 +117,110 @@ test("does not construct an AudioWorkletNode when torn down mid worklet load", a
 // Regression: a Bluetooth mic on macOS reports 44100 after an A2DP flip. Capturing at that rate means
 // the encoder silently resamples to 48000 while the catalog advertises 44100, which no Opus decoder can
 // honor: Safari's AudioDecoder fails every decode with InternalAudioDecoderCocoa.
-async function requestedRate(sampleRate: number | undefined, codec?: "opus" | "aac") {
+async function requestedRate(sampleRate: number | undefined, override?: number) {
 	using webaudio = installFakeWebAudio();
 
-	const encoder = new Encoder("audio", {
+	const capture = new Capture({
 		enabled: true,
 		source: new Signal(fakeSource(sampleRate)) as never,
-		...(codec ? { codec } : {}),
+		...(override !== undefined ? { sampleRate: override } : {}),
 	});
 	await settle();
-	encoder.close();
+	capture.close();
 	await settle();
 
 	return webaudio.requestedRates.at(-1);
 }
 
-test("snaps the capture rate to one Opus supports", async () => {
+test("snaps a rate Opus can't decode up to full band", async () => {
 	expect(await requestedRate(44_100)).toBe(48_000);
-	expect(await requestedRate(22_050)).toBe(24_000);
+	expect(await requestedRate(22_050)).toBe(48_000);
 });
 
-test("leaves an Opus-native capture rate alone", async () => {
+// Every rate Opus takes is also in the AAC table, so a narrowband mic is left alone rather than
+// upsampled: a voice track has nothing above 8kHz to recover.
+test("leaves a rate both codecs support alone", async () => {
 	expect(await requestedRate(16_000)).toBe(16_000);
 	expect(await requestedRate(48_000)).toBe(48_000);
 });
 
 // captureStream() tracks report no rate, which would otherwise let the AudioContext fall back to the
 // machine's output rate (44100 on most Macs).
-test("requests full-band Opus when the source reports no rate", async () => {
+test("requests full band when the source reports no rate", async () => {
 	expect(await requestedRate(undefined)).toBe(48_000);
 });
 
-// 44100 is in the AAC sampling frequency table, so it must survive untouched.
-test("leaves an AAC-native capture rate alone", async () => {
-	expect(await requestedRate(44_100, "aac")).toBe(44_100);
+test("honors an explicit rate override", async () => {
+	expect(await requestedRate(48_000, 16_000)).toBe(16_000);
 });
 
-// Regression: only the codec's mime picks the capture rate, so tweaking an encode-only knob must not
-// tear down the microphone. Subscribing the capture to the whole codec signal rebuilt the AudioContext
-// on every change, which dropped #worklet and closed the track being published. The demo writes this
-// signal from live bitrate/complexity sliders, so it fired on every slider tick.
-test("does not rebuild the capture graph when an encode-only knob changes", async () => {
+// Regression: tweaking an encoder knob must not tear down the microphone. The capture used to take
+// the codec as an input, so it rebuilt the AudioContext on a codec change, dropping the worklet and
+// closing the track being published. Now the capture is codec-independent, which it has to be:
+// several renditions share one, and they can encode differently.
+test("never rebuilds the capture graph for encoder settings", async () => {
 	using webaudio = installFakeWebAudio();
 
-	const codec = new Signal<Codec>({ mime: "opus", bitrate: 32_000 });
-	const encoder = new Encoder("audio", {
+	const rate = new Signal<number | undefined>(undefined);
+	const capture = new Capture({
 		enabled: true,
 		source: new Signal(fakeSource()) as never,
-		codec,
+		sampleRate: rate,
 	});
 	await settle();
 	expect(webaudio.requestedRates.length).toBe(1);
 
-	codec.set({ mime: "opus", bitrate: 64_000 });
-	await settle();
-	expect(webaudio.requestedRates.length).toBe(1);
-
-	// A real codec switch still has to rebuild: AAC captures at rates Opus can't.
-	codec.set({ mime: "aac" });
+	// Only something that changes the capture itself may rebuild it.
+	rate.set(16_000);
 	await settle();
 	expect(webaudio.requestedRates.length).toBe(2);
 
-	encoder.close();
+	capture.close();
+	await settle();
+});
+
+// The gap this fanout closes: a decoded file exposes one ReadableStream, so the second rendition
+// used to throw on a locked stream and publish nothing while still advertising a catalog.
+test("feeds every rendition off one decoded source", async () => {
+	let push!: (value: number) => void;
+	const samples = new ReadableStream<AudioData>({
+		start(controller) {
+			push = (value) =>
+				controller.enqueue({
+					timestamp: value * 1000,
+					numberOfFrames: 4,
+					numberOfChannels: 1,
+					copyTo: (dest: Float32Array) => dest.fill(value),
+					close: () => {},
+				} as unknown as AudioData);
+		},
+	});
+
+	const capture = new Capture({
+		enabled: true,
+		source: new Signal({ samples, sampleRate: 48_000, channelCount: 1, kind: "auto" }) as never,
+	});
+	await settle();
+
+	const fanout = capture.out.frames.peek();
+	expect(fanout).toBeDefined();
+
+	// Both renditions attach before anything is published; a late one only sees what comes next.
+	const first = new Effect();
+	const second = new Effect();
+	const a = fanout?.subscribe(first).getReader();
+	const b = fanout?.subscribe(second).getReader();
+
+	for (const value of [1, 2, 3]) {
+		push(value);
+
+		// Both renditions see the same audio; neither steals it from the other.
+		expect((await a?.read())?.value?.channels[0][0]).toBe(value);
+		expect((await b?.read())?.value?.channels[0][0]).toBe(value);
+	}
+
+	first.close();
+	second.close();
+	capture.close();
 	await settle();
 });

--- a/js/publish/src/audio/capture.test.ts
+++ b/js/publish/src/audio/capture.test.ts
@@ -224,3 +224,13 @@ test("feeds every rendition off one decoded source", async () => {
 	capture.close();
 	await settle();
 });
+
+// The removed `source` prop would otherwise be ignored in plain JS: the encoder would build, the
+// catalog would never appear, and the audio would just be missing.
+test("rejects the removed source prop instead of publishing nothing", async () => {
+	const { Encoder } = await import("./encoder.ts");
+
+	expect(
+		() => new Encoder("audio", { enabled: true, source: new Signal(fakeSource()) } as never),
+	).toThrow("moved to Audio.Capture");
+});

--- a/js/publish/src/audio/capture.test.ts
+++ b/js/publish/src/audio/capture.test.ts
@@ -230,7 +230,7 @@ test("feeds every rendition off one decoded source", async () => {
 test("rejects the removed source prop instead of publishing nothing", async () => {
 	const { Encoder } = await import("./encoder.ts");
 
-	expect(
-		() => new Encoder("audio", { enabled: true, source: new Signal(fakeSource()) } as never),
-	).toThrow("moved to Audio.Capture");
+	expect(() => new Encoder("audio", { enabled: true, source: new Signal(fakeSource()) } as never)).toThrow(
+		"moved to Audio.Capture",
+	);
 });

--- a/js/publish/src/audio/capture.ts
+++ b/js/publish/src/audio/capture.ts
@@ -2,15 +2,9 @@ import * as Util from "@moq/hang/util";
 import type { Time } from "@moq/net";
 import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Signal } from "@moq/signals";
 // Compiled and inlined as a blob URL via vite-plugin-worklet.
+import { Fanout } from "../fanout";
 import CaptureWorklet from "./capture-worklet.ts?worklet";
-import {
-	type CodecMime,
-	isSampleSource,
-	normalizeSource,
-	type SampleSource,
-	type Source,
-	type SourceConfig,
-} from "./types";
+import { isSampleSource, normalizeSource, type SampleSource, type Source, type SourceConfig } from "./types";
 
 /** A chunk of planar PCM, timestamped against the shared wall clock. */
 export interface AudioFrame {
@@ -30,10 +24,16 @@ export interface Format {
 	channelCount: number;
 }
 
-// How many capture quanta to hold before dropping. A worklet pushes on the audio thread and can't
-// be told to wait, so a reader that falls this far behind loses the oldest audio rather than
-// growing the queue without bound. Roughly 85ms at 48kHz.
+// How many capture quanta a rendition may fall behind before it starts losing the oldest. A worklet
+// pushes on the audio thread and can't be told to wait. Roughly 85ms at 48kHz.
 const QUEUE = 32;
+
+// The rate to run the capture graph at when nothing asks for another.
+//
+// Fixed rather than derived from the codec, because one capture feeds every rendition and they can
+// encode differently. 48kHz is the one rate both Opus and AAC take, so the usual case needs no
+// conversion at all, and Web Audio resamples the device to it far better than we could.
+const DEFAULT_SAMPLE_RATE = 48_000;
 
 // Signals the capture reads.
 export type CaptureInput = {
@@ -43,22 +43,19 @@ export type CaptureInput = {
 	// Whether to hold the capture device. Decoded samples ignore this: there's no device to release,
 	// and their stream is one-shot, so dropping it would mean never reading it again.
 	enabled: Getter<boolean>;
+};
 
-	// The codec the PCM is destined for. Codecs only encode at a discrete set of rates, so this
-	// picks the rate the capture graph runs at.
-	codec: Getter<CodecMime>;
-
-	// Override the capture rate in Hz. Defaults to the track's own.
-	sampleRate: Getter<number | undefined>;
-
-	// Force the captured channel count. Defaults to the track's requested count.
-	channelCount: Getter<number | undefined>;
+/** Constructor options: the wired inputs plus the live-editable format knobs. */
+export type CaptureProps = Inputs<CaptureInput> & {
+	// Seed a value or wire a Signal; also live-editable via the matching field.
+	sampleRate?: number | Signal<number | undefined>;
+	channelCount?: number | Signal<number | undefined>;
 };
 
 type CaptureOutput = {
-	// The PCM to encode, replaced whenever the source changes. Single consumer: audio can't be
-	// dropped on the floor the way a stale video frame can, so this is a stream, not a signal.
-	frames: Signal<ReadableStream<AudioFrame> | undefined>;
+	// The PCM to encode, replaced whenever the source changes. Subscribe for a stream of your own:
+	// several renditions share one capture, and each needs every frame rather than the newest.
+	frames: Signal<Fanout<AudioFrame> | undefined>;
 
 	// The format the frames arrive in, or undefined while there's no capture.
 	format: Signal<Format | undefined>;
@@ -79,8 +76,14 @@ type CaptureOutput = {
 export class Capture {
 	readonly in: Readonlys<CaptureInput>;
 
+	/** Override the capture rate in Hz. Defaults to the device's, snapped to one every codec takes. */
+	sampleRate: Signal<number | undefined>;
+
+	/** Force the captured channel count. Defaults to the track's requested count. */
+	channelCount: Signal<number | undefined>;
+
 	readonly #out: CaptureOutput = {
-		frames: new Signal<ReadableStream<AudioFrame> | undefined>(undefined),
+		frames: new Signal<Fanout<AudioFrame> | undefined>(undefined),
 		format: new Signal<Format | undefined>(undefined),
 		root: new Signal<AudioNode | undefined>(undefined),
 	};
@@ -88,14 +91,13 @@ export class Capture {
 
 	#signals = new Effect();
 
-	constructor(props?: Inputs<CaptureInput>) {
+	constructor(props?: CaptureProps) {
 		this.in = {
 			source: getter(props?.source),
 			enabled: getter(props?.enabled ?? false),
-			codec: getter(props?.codec ?? "opus"),
-			sampleRate: getter(props?.sampleRate),
-			channelCount: getter(props?.channelCount),
 		};
+		this.sampleRate = Signal.from<number | undefined>(props?.sampleRate);
+		this.channelCount = Signal.from<number | undefined>(props?.channelCount);
 
 		this.#signals.run(this.#run.bind(this));
 	}
@@ -118,8 +120,11 @@ export class Capture {
 	#runSamples(source: SampleSource, effect: Effect): void {
 		const { sampleRate, channelCount } = source;
 
+		const fanout = new Fanout(source.samples.pipeThrough(planar()), { queue: QUEUE });
+		effect.cleanup(() => fanout.close());
+
 		effect.set(this.#out.format, { sampleRate, channelCount }, undefined);
-		effect.set(this.#out.frames, source.samples.pipeThrough(planar()), undefined);
+		effect.set(this.#out.frames, fanout, undefined);
 	}
 
 	#runTrack(source: SourceConfig, effect: Effect): void {
@@ -127,19 +132,13 @@ export class Capture {
 		if (!effect.get(this.in.enabled)) return;
 
 		const settings = source.track.getSettings();
-		const overrideSampleRate = effect.get(this.in.sampleRate);
-		const mime = effect.get(this.in.codec);
-		const sampleRate = pickSampleRate(mime, overrideSampleRate ?? settings.sampleRate);
-
-		if (overrideSampleRate !== undefined && sampleRate !== overrideSampleRate) {
-			console.warn(`${mime} does not support ${overrideSampleRate}Hz, capturing at ${sampleRate}Hz`);
-		}
+		const sampleRate = effect.get(this.sampleRate) ?? pickCaptureRate(settings.sampleRate);
 
 		// macOS misreports a mono mic as stereo: getSettings().channelCount is undefined and
 		// MediaStreamAudioSourceNode.channelCount defaults to 2, so the graph carries (and Opus
 		// encodes) duplicated mono as stereo. Prefer an explicitly requested channel count, from
 		// the prop or the track's applied getUserMedia constraint, and force the worklet to mix to it.
-		const requestedChannels = effect.get(this.in.channelCount) ?? requestedChannelCount(source.track);
+		const requestedChannels = effect.get(this.channelCount) ?? requestedChannelCount(source.track);
 
 		const context = new AudioContext({
 			latencyHint: "interactive",
@@ -185,16 +184,17 @@ export class Capture {
 
 			root.connect(worklet);
 
-			const frames = this.#drain(worklet, context.sampleRate, effect);
+			const fanout = new Fanout(this.#drain(worklet, context.sampleRate, effect), { queue: QUEUE });
+			effect.cleanup(() => fanout.close());
 
 			effect.set(this.#out.root, root);
-			effect.set(this.#out.frames, frames);
+			effect.set(this.#out.frames, fanout);
 		});
 	}
 
 	// Turn the quanta the worklet pushes into a stream. The audio thread can't be asked to wait, so
-	// a reader that falls too far behind loses the oldest audio; downstream that reads as a
-	// timestamp gap, which the framer re-anchors on rather than silently sliding.
+	// this never applies backpressure; the fanout above bounds each reader instead. A drop shows up
+	// downstream as a timestamp gap, which the framer re-anchors on rather than silently sliding.
 	#drain(worklet: AudioWorkletNode, sampleRate: number, effect: Effect): ReadableStream<AudioFrame> {
 		return new ReadableStream<AudioFrame>(
 			{
@@ -253,25 +253,13 @@ function requestedChannelCount(track: MediaStreamTrack): number | undefined {
 	return constraint.exact ?? constraint.ideal ?? constraint.max ?? constraint.min;
 }
 
-/**
- * Pick the rate to run the capture graph at, given what the source reports (or the caller asked
- * for). Codecs only encode at a discrete set of rates, so snap to one they actually support.
- *
- * This has to happen at the AudioContext rather than just in the catalog. A context running at
- * 44100 hands 44100 AudioData to an encoder configured for 48000, which WebCodecs rejects outright.
- * Snapping here keeps one rate across the capture graph, the encoder config, and the catalog.
- */
-export function pickSampleRate(mime: CodecMime, requested: number | undefined): number | undefined {
-	// Treat a nonsense rate as unknown. It would otherwise snap to the codec's floor (7350Hz for AAC)
-	// instead of throwing NotSupportedError at the AudioContext where it's obvious.
-	const rate = requested !== undefined && Number.isFinite(requested) && requested > 0 ? requested : undefined;
-
-	if (mime === "opus") {
-		// An unknown rate (captureStream reports none) would let the AudioContext fall back to the
-		// machine's output rate, which is 44100 on most Macs. Ask for full-band Opus instead.
-		return Util.Opus.pickRate(rate ?? Util.Opus.DEFAULT_SAMPLE_RATE);
-	}
-
-	// The AAC table includes 44100, so an unknown rate can safely fall through to the context default.
-	return rate !== undefined ? Util.Aac.pickRate(rate) : undefined;
+// Pick the rate to run the capture graph at, given what the device reports.
+//
+// Every rate Opus encodes at is also in the AAC table, so staying on that set means one capture can
+// feed any rendition without conversion. A device reporting anything else (a Bluetooth mic drops to
+// 44.1kHz after an A2DP flip) gets resampled to 48kHz by Web Audio, which does it far better than
+// we would, and which keeps the catalog off a rate Opus cannot decode.
+function pickCaptureRate(reported: number | undefined): number {
+	if (reported === undefined || !Number.isFinite(reported) || reported <= 0) return DEFAULT_SAMPLE_RATE;
+	return Util.Opus.supportsRate(reported) ? reported : DEFAULT_SAMPLE_RATE;
 }

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -149,6 +149,13 @@ export class Encoder {
 	#signals = new Effect();
 
 	constructor(name: string, props?: EncoderProps) {
+		// `source` moved to Audio.Capture, which renditions share. TypeScript catches this, but a
+		// plain JS caller would otherwise get an encoder with nothing attached: no catalog, no
+		// audio, and nothing to explain why.
+		if (props && "source" in props) {
+			throw new Error("Audio.Encoder: `source` moved to Audio.Capture; construct one and pass `capture`");
+		}
+
 		this.name = name;
 		this.in = {
 			enabled: getter(props?.enabled ?? false),
@@ -184,7 +191,7 @@ export class Encoder {
 		// Our own stream off the shared capture, so another rendition reading slowly can't take
 		// frames from this one.
 		const reader = fanout.subscribe(effect).getReader();
-		effect.cleanup(() => void reader.cancel());
+		effect.cleanup(() => reader.cancel().catch(() => {}));
 
 		const gain = new Gain();
 

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -123,6 +123,16 @@ export class Encoder {
 	/** The live-editable codec selection plus its encoder settings. */
 	codec: Signal<Codec>;
 
+	/**
+	 * The capture supplying this rendition, or undefined while none is wired.
+	 *
+	 * A snapshot, for reaching the shared capture format knobs (`audio.capture?.sampleRate`). Read
+	 * {@link in}.capture through an effect instead when you need to react to it being swapped.
+	 */
+	get capture(): Capture | undefined {
+		return this.in.capture.peek();
+	}
+
 	readonly #out: EncoderOutput = {
 		catalog: new Signal<Catalog.AudioConfig | undefined>(undefined),
 		root: new Signal<AudioNode | undefined>(undefined),

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -191,7 +191,9 @@ export class Encoder {
 		// Our own stream off the shared capture, so another rendition reading slowly can't take
 		// frames from this one.
 		const reader = fanout.subscribe(effect).getReader();
-		effect.cleanup(() => reader.cancel().catch(() => {}));
+		effect.cleanup(() => {
+			reader.cancel().catch(() => {});
+		});
 
 		const gain = new Gain();
 

--- a/js/publish/src/audio/encoder.ts
+++ b/js/publish/src/audio/encoder.ts
@@ -5,10 +5,10 @@ import type * as Moq from "@moq/net";
 import { Time } from "@moq/net";
 import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Signal } from "@moq/signals";
 import type { Broadcast } from "../broadcast";
-import { type AudioFrame, Capture, type Format, pickSampleRate } from "./capture";
+import type { AudioFrame, Capture, Format } from "./capture";
 import { Gain } from "./gain";
 import { Resampler } from "./resampler";
-import type { CodecMime, Kind, Source } from "./types";
+import type { CodecMime, Kind } from "./types";
 import { sourceKind } from "./types";
 
 const OPUS_BITRATE_PER_CHANNEL = 32_000;
@@ -69,8 +69,9 @@ export type EncoderInput = {
 	// The broadcast to register the rendition on. Undefined resolves the config but has nowhere to publish.
 	broadcast: Getter<Broadcast | undefined>;
 
-	// The microphone (or other) track supplying samples.
-	source: Getter<Source | undefined>;
+	// The capture supplying PCM. Shared: one capture feeds any number of renditions, so build it
+	// yourself and pass the same instance to each.
+	capture: Getter<Capture | undefined>;
 };
 
 /** Constructor options: the wired inputs plus the live-editable tuning knobs. */
@@ -78,8 +79,6 @@ export type EncoderProps = Inputs<EncoderInput> & {
 	// User tuning knobs. Seed a value or wire a Signal; also live-editable via the matching field.
 	muted?: boolean | Signal<boolean>;
 	volume?: number | Signal<number>;
-	sampleRate?: number | Signal<number | undefined>;
-	channelCount?: number | Signal<number | undefined>;
 
 	// Codec selection plus encoder settings. Defaults to "opus".
 	codec?: Codec | Signal<Codec>;
@@ -121,17 +120,8 @@ export class Encoder {
 	muted: Signal<boolean>;
 	/** Linear gain applied before encoding, where 1 is unity. */
 	volume: Signal<number>;
-	/** Override the capture sample rate in Hz. Defaults to the track's own rate. */
-	sampleRate: Signal<number | undefined>;
-	/** Override the captured channel count. Defaults to the track's requested count. */
-	channelCount: Signal<number | undefined>;
 	/** The live-editable codec selection plus its encoder settings. */
 	codec: Signal<Codec>;
-
-	// Only the mime picks the capture sample rate, so the capture tracks this rather than the whole
-	// codec signal. Otherwise changing an encode-only knob (bitrate, complexity) would rebuild the
-	// AudioContext and close the track we're publishing.
-	#codecMime: Signal<CodecMime>;
 
 	readonly #out: EncoderOutput = {
 		catalog: new Signal<Catalog.AudioConfig | undefined>(undefined),
@@ -140,9 +130,6 @@ export class Encoder {
 		stats: new Signal<Stats>({ frames: 0, bytes: 0 }),
 	};
 	readonly out = readonlys(this.#out);
-
-	// Turns whichever kind of source we were handed into a stream of PCM.
-	#capture: Capture;
 
 	// The encode chain currently publishing, or undefined while nothing is. The read loop pushes
 	// into this; frames that arrive while it's undefined are dropped, which the framer treats as a
@@ -156,31 +143,17 @@ export class Encoder {
 		this.in = {
 			enabled: getter(props?.enabled ?? false),
 			broadcast: getter(props?.broadcast),
-			source: getter(props?.source),
+			capture: getter(props?.capture),
 		};
 		this.muted = Signal.from(props?.muted ?? false);
 		this.volume = Signal.from(props?.volume ?? 1);
-		this.sampleRate = Signal.from<number | undefined>(props?.sampleRate);
-		this.channelCount = Signal.from<number | undefined>(props?.channelCount);
 		this.codec = Signal.from<Codec>(props?.codec ?? "opus");
-		this.#codecMime = new Signal(normalizeCodec(this.codec.peek()).mime);
 
+		// Only the capture graph has a node to expose.
 		this.#signals.run((effect) => {
-			this.#codecMime.set(normalizeCodec(effect.get(this.codec)).mime);
-		});
-
-		this.#capture = new Capture({
-			source: this.in.source,
-			enabled: this.in.enabled,
-			codec: this.#codecMime,
-			sampleRate: this.sampleRate,
-			channelCount: this.channelCount,
-		});
-		this.#signals.cleanup(() => this.#capture.close());
-
-		// The capture graph is the only thing that has a node to expose.
-		this.#signals.run((effect) => {
-			effect.proxy(this.#out.root, this.#capture.out.root);
+			const capture = effect.get(this.in.capture);
+			if (!capture) return;
+			effect.proxy(this.#out.root, capture.out.root);
 		});
 
 		this.#signals.run(this.#runCapture.bind(this));
@@ -192,10 +165,15 @@ export class Encoder {
 	// the way through. Tied to the capture's lifetime rather than the encoder's, so reconfiguring
 	// (or muting) never has to reacquire the stream, which for a decoded file would be fatal.
 	#runCapture(effect: Effect): void {
-		const frames = effect.get(this.#capture.out.frames);
-		if (!frames) return;
+		const capture = effect.get(this.in.capture);
+		if (!capture) return;
 
-		const reader = frames.getReader();
+		const fanout = effect.get(capture.out.frames);
+		if (!fanout) return;
+
+		// Our own stream off the shared capture, so another rendition reading slowly can't take
+		// frames from this one.
+		const reader = fanout.subscribe(effect).getReader();
 		effect.cleanup(() => void reader.cancel());
 
 		const gain = new Gain();
@@ -205,12 +183,13 @@ export class Encoder {
 				const next = await Promise.race([reader.read(), effect.cancel]);
 				if (!next?.value) break;
 
-				const frame = next.value;
-				const format = this.#capture.out.format.peek();
+				const format = capture.out.format.peek();
 				if (!format) continue;
 
+				// Every rendition shares the captured frame, so gain returns a copy rather than
+				// scaling in place; muting one rendition must not silence the rest.
+				const frame = gain.apply(next.value, format.sampleRate);
 				gain.set(this.muted.peek() ? 0 : this.volume.peek());
-				gain.apply(frame, format.sampleRate);
 
 				// The config rebuilds when the channel count moves, so skip anything that arrives
 				// mid-swap rather than framing it wrong.
@@ -234,7 +213,8 @@ export class Encoder {
 
 		effect.run((effect) => {
 			const enabled = effect.get(this.in.enabled);
-			const format = effect.get(this.#capture.out.format);
+			const capture = effect.get(this.in.capture);
+			const format = capture ? effect.get(capture.out.format) : undefined;
 			const track = effect.get(rendition.track);
 			effect.set(this.#out.active, enabled && !!format && !!track, false);
 			if (!enabled || !format || !track) return;
@@ -284,7 +264,8 @@ export class Encoder {
 	// Gated on `enabled` the same way the video encoder is: a disabled rendition has to drop out of
 	// the catalog, and a sample source keeps its format while muted rather than tearing down.
 	#runConfig(effect: Effect): void {
-		const captured = effect.get(this.#capture.out.format);
+		const capture = effect.get(this.in.capture);
+		const captured = capture ? effect.get(capture.out.format) : undefined;
 		if (!effect.get(this.in.enabled) || !captured) {
 			effect.set(this.#out.catalog, undefined);
 			return;
@@ -320,7 +301,8 @@ export class Encoder {
 				const config = effect.get(this.out.catalog);
 				if (!config) return;
 
-				const source = effect.get(this.in.source);
+				const capture = effect.get(this.in.capture);
+				const source = capture ? effect.get(capture.in.source) : undefined;
 				const kind: Kind = source ? sourceKind(source) : "auto";
 				const encoderConfig = toEncoderConfig(config, kind, this.#opusOptions(effect));
 
@@ -505,4 +487,22 @@ function toEncoderConfig(
 	}
 
 	return encoderConfig;
+}
+
+/**
+ * Snap a rate to one the codec can actually encode at.
+ *
+ * The capture runs at whatever suits the device, and several renditions may share it, so each
+ * rendition converts on its own. WebCodecs rejects input whose rate doesn't match the configured
+ * one rather than converting for us, which is what #encode's resampler is for.
+ */
+function pickSampleRate(mime: CodecMime, requested: number | undefined): number | undefined {
+	// Treat a nonsense rate as unknown, rather than snapping it to the codec's floor (7350Hz for AAC).
+	const rate = requested !== undefined && Number.isFinite(requested) && requested > 0 ? requested : undefined;
+
+	// Opus only decodes at a handful of rates, and 44.1kHz is not one of them.
+	if (mime === "opus") return Util.Opus.pickRate(rate ?? Util.Opus.DEFAULT_SAMPLE_RATE);
+
+	// The AAC table includes 44100, so an unknown rate can fall through to whatever we captured.
+	return rate !== undefined ? Util.Aac.pickRate(rate) : undefined;
 }

--- a/js/publish/src/audio/gain.test.ts
+++ b/js/publish/src/audio/gain.test.ts
@@ -21,9 +21,9 @@ describe("Gain", () => {
 		const frame = ones(128);
 
 		gain.set(1);
-		gain.apply(frame, RATE);
+		const out = gain.apply(frame, RATE);
 
-		expect([...frame.channels[0]]).toEqual(Array.from({ length: 128 }, () => 1));
+		expect([...out.channels[0]]).toEqual(Array.from({ length: 128 }, () => 1));
 	});
 
 	// Jumping straight to the target is what clicks, so the level has to walk there.
@@ -32,13 +32,16 @@ describe("Gain", () => {
 		const frame = ones(128);
 
 		gain.set(0);
-		gain.apply(frame, RATE);
+		const out = gain.apply(frame, RATE);
 
 		// 128 samples is far less than the 0.2s fade, so it has barely moved.
-		expect(frame.channels[0][0]).toBeLessThan(1);
-		expect(frame.channels[0][0]).toBeGreaterThan(0.99);
-		expect(frame.channels[0][127]).toBeLessThan(frame.channels[0][0]);
-		expect(frame.channels[0][127]).toBeGreaterThan(0.98);
+		expect(out.channels[0][0]).toBeLessThan(1);
+		expect(out.channels[0][0]).toBeGreaterThan(0.99);
+		expect(out.channels[0][127]).toBeLessThan(out.channels[0][0]);
+		expect(out.channels[0][127]).toBeGreaterThan(0.98);
+
+		// The input is shared with every other rendition, so it must come back untouched.
+		expect(frame.channels[0][0]).toBe(1);
 	});
 
 	test("reaches silence after the full fade", () => {
@@ -49,8 +52,7 @@ describe("Gain", () => {
 		let last = 1;
 		for (let n = 0; n < Math.ceil(0.2 * RATE) / 128; n++) {
 			const frame = ones(128);
-			gain.apply(frame, RATE);
-			last = frame.channels[0][127];
+			last = gain.apply(frame, RATE).channels[0][127];
 		}
 
 		expect(last).toBeCloseTo(0, 5);
@@ -67,16 +69,16 @@ describe("Gain", () => {
 		};
 
 		gain.set(0);
-		gain.apply(frame, RATE);
+		const out = gain.apply(frame, RATE);
 
 		// Every channel rides one level, so each keeps its own value and their ratio is untouched.
 		for (let index = 0; index < 128; index++) {
-			expect(frame.channels[1][index]).toBeCloseTo(frame.channels[0][index] * -0.5, 6);
+			expect(out.channels[1][index]).toBeCloseTo(out.channels[0][index] * -0.5, 6);
 		}
 
 		// And the level actually moved, so the ratio above isn't just 0 === 0.
-		expect(frame.channels[0][127]).toBeLessThan(1);
-		expect(frame.channels[0][127]).toBeGreaterThan(0);
+		expect(out.channels[0][127]).toBeLessThan(1);
+		expect(out.channels[0][127]).toBeGreaterThan(0);
 	});
 
 	// The ramp is per-sample, so a slower rate has to cover the same fade in fewer samples.
@@ -89,9 +91,9 @@ describe("Gain", () => {
 
 		fast.set(0);
 		slow.set(0);
-		fast.apply(fastFrame, RATE);
-		slow.apply(slowFrame, SLOW_RATE);
+		const fastOut = fast.apply(fastFrame, RATE);
+		const slowOut = slow.apply(slowFrame, SLOW_RATE);
 
-		expect(slowFrame.channels[0][127]).toBeLessThan(fastFrame.channels[0][127]);
+		expect(slowOut.channels[0][127]).toBeLessThan(fastOut.channels[0][127]);
 	});
 });

--- a/js/publish/src/audio/gain.ts
+++ b/js/publish/src/audio/gain.ts
@@ -19,21 +19,30 @@ export class Gain {
 		this.#target = value;
 	}
 
-	/** Scale a frame in place, advancing the ramp across its samples. */
-	apply(frame: AudioFrame, sampleRate: number): void {
+	/**
+	 * Scale a frame, advancing the ramp across its samples.
+	 *
+	 * Returns a new frame rather than writing through: one capture feeds every rendition, and each
+	 * has its own volume, so scaling in place would let one rendition's mute silence the others.
+	 * At unity it returns the input untouched, which is the common case and copies nothing.
+	 */
+	apply(frame: AudioFrame, sampleRate: number): AudioFrame {
 		// Unity already, and staying there: every sample would be multiplied by 1.
-		if (this.#current === 1 && this.#target === 1) return;
+		if (this.#current === 1 && this.#target === 1) return frame;
 
 		// How far the level may move per sample to cover the full range in FADE seconds.
 		const step = 1 / (FADE * sampleRate);
 		const samples = frame.channels[0]?.length ?? 0;
+		const channels = frame.channels.map((channel) => new Float32Array(channel));
 
 		for (let index = 0; index < samples; index++) {
 			if (this.#current < this.#target) this.#current = Math.min(this.#target, this.#current + step);
 			else if (this.#current > this.#target) this.#current = Math.max(this.#target, this.#current - step);
 
 			if (this.#current === 1) continue;
-			for (const channel of frame.channels) channel[index] *= this.#current;
+			for (const channel of channels) channel[index] *= this.#current;
 		}
+
+		return { timestamp: frame.timestamp, channels };
 	}
 }

--- a/js/publish/src/audio/index.ts
+++ b/js/publish/src/audio/index.ts
@@ -1,6 +1,7 @@
 import type * as Catalog from "@moq/hang/catalog";
 import type { Rendition as BaseRendition } from "../rendition";
 
+export * from "./capture";
 export * from "./encoder";
 export * from "./types";
 

--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -87,10 +87,8 @@ export default class MoqPublish extends HTMLElement {
 	};
 
 	connection: Moq.Connection.Reload;
-	/** The video capture, shared by every video rendition. */
+	/** The video capture, shared by every video rendition. Also reachable as `video.capture`. */
 	capture: Video.Capture;
-	/** The audio capture, shared by every audio rendition. */
-	audioCapture: Audio.Capture;
 	broadcast: Broadcast;
 
 	// The single video and audio encoders. For multiple renditions (e.g. simulcast), drop the element
@@ -108,7 +106,7 @@ export default class MoqPublish extends HTMLElement {
 	};
 
 	// The captured media tracks, written by #runSource. Fed to the video and audio captures, so
-	// consumers read them back via `capture.in.source` / `audioCapture.in.source` rather than here.
+	// consumers read them back via `capture.in.source` / `audio.capture.in.source` rather than here.
 	#videoSource = new Signal<Video.Source | undefined>(undefined);
 	#audioSource = new Signal<Audio.Source | undefined>(undefined);
 
@@ -209,11 +207,12 @@ export default class MoqPublish extends HTMLElement {
 		this.capture = new Video.Capture({ source: this.#videoSource });
 		this.signals.cleanup(() => this.capture.close());
 
-		this.audioCapture = new Audio.Capture({
+		// Reached as `audio.capture` rather than a field of its own, so audio and video read alike.
+		const audioCapture = new Audio.Capture({
 			source: this.#audioSource,
 			enabled: this.#audioEnabled,
 		});
-		this.signals.cleanup(() => this.audioCapture.close());
+		this.signals.cleanup(() => audioCapture.close());
 
 		this.broadcast = new Broadcast({
 			connection: this.connection.established,
@@ -235,7 +234,7 @@ export default class MoqPublish extends HTMLElement {
 		this.audio = new Audio.Encoder("audio", {
 			broadcast: this.broadcast,
 			enabled: this.#audioEnabled,
-			capture: this.audioCapture,
+			capture: audioCapture,
 		});
 		this.signals.cleanup(() => this.audio.close());
 

--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -87,7 +87,10 @@ export default class MoqPublish extends HTMLElement {
 	};
 
 	connection: Moq.Connection.Reload;
+	/** The video capture, shared by every video rendition. */
 	capture: Video.Capture;
+	/** The audio capture, shared by every audio rendition. */
+	audioCapture: Audio.Capture;
 	broadcast: Broadcast;
 
 	// The single video and audio encoders. For multiple renditions (e.g. simulcast), drop the element
@@ -104,8 +107,8 @@ export default class MoqPublish extends HTMLElement {
 		file: new Signal<Source.File | undefined>(undefined),
 	};
 
-	// The captured media tracks, written by #runSource. Fed to `capture` (video) and the `audio` encoder,
-	// so consumers read them back via `capture.in.source` and `audio.in.source` rather than here.
+	// The captured media tracks, written by #runSource. Fed to the video and audio captures, so
+	// consumers read them back via `capture.in.source` / `audioCapture.in.source` rather than here.
 	#videoSource = new Signal<Video.Source | undefined>(undefined);
 	#audioSource = new Signal<Audio.Source | undefined>(undefined);
 
@@ -206,6 +209,12 @@ export default class MoqPublish extends HTMLElement {
 		this.capture = new Video.Capture({ source: this.#videoSource });
 		this.signals.cleanup(() => this.capture.close());
 
+		this.audioCapture = new Audio.Capture({
+			source: this.#audioSource,
+			enabled: this.#audioEnabled,
+		});
+		this.signals.cleanup(() => this.audioCapture.close());
+
 		this.broadcast = new Broadcast({
 			connection: this.connection.established,
 			enabled: this.#publishEnabled,
@@ -226,7 +235,7 @@ export default class MoqPublish extends HTMLElement {
 		this.audio = new Audio.Encoder("audio", {
 			broadcast: this.broadcast,
 			enabled: this.#audioEnabled,
-			source: this.#audioSource,
+			capture: this.audioCapture,
 		});
 		this.signals.cleanup(() => this.audio.close());
 

--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -256,7 +256,7 @@ export default class MoqPublish extends HTMLElement {
 			if (preview instanceof HTMLCanvasElement) {
 				const renderer = new Preview.Renderer({
 					canvas: preview,
-					frame: this.capture.out.frame,
+					frames: this.capture.out.frames,
 					display: this.capture.out.display,
 					flip: this.#flip,
 					encoder: this.video,

--- a/js/publish/src/fanout.test.ts
+++ b/js/publish/src/fanout.test.ts
@@ -189,6 +189,62 @@ describe("Fanout", () => {
 		fanout.close();
 	});
 
+	// Without this the pump just logged and stopped, leaving every reader parked on read() forever:
+	// the encoders stalled with no terminal signal while still reporting themselves active.
+	test("surfaces a source failure to every reader", async () => {
+		let control!: ReadableStreamDefaultController<number>;
+		const source = new ReadableStream<number>({
+			start: (controller) => {
+				control = controller;
+			},
+		});
+
+		const fanout = new Fanout(source);
+		const effect = new Effect();
+
+		const a = fanout.subscribe(effect).getReader();
+		const b = fanout.subscribe(effect).getReader();
+
+		// Audio that already made it through is still delivered.
+		control.enqueue(1);
+		await flush();
+		await expect(a.read().then((r) => r.value)).resolves.toBe(1);
+		await expect(b.read().then((r) => r.value)).resolves.toBe(1);
+
+		control.error(new Error("capture died"));
+		await flush();
+
+		// Both readers learn it died, rather than parking on a read that never settles.
+		await expect(a.read()).rejects.toThrow("capture died");
+		await expect(b.read()).rejects.toThrow("capture died");
+
+		effect.close();
+		fanout.close();
+	});
+
+	// FrameSource and SampleSource both document that their stream is cancelled when dropped, and a
+	// one-shot decode keeps running (and holding the stream locked) if we don't.
+	test("cancels its source on close", async () => {
+		let cancelled = 0;
+		const source = new ReadableStream<number>({
+			cancel: () => {
+				cancelled++;
+			},
+		});
+
+		const fanout = new Fanout(source);
+		await flush();
+
+		fanout.close();
+		await flush();
+		expect(cancelled).toBe(1);
+
+		// Idempotent: the pump also closes on end-of-stream, so this must not double-cancel.
+		fanout.close();
+		await flush();
+		expect(cancelled).toBe(1);
+	});
+
 	test("closes its readers when the source ends", async () => {
 		const source = pushable<number>();
 		const fanout = new Fanout(source.stream);

--- a/js/publish/src/fanout.test.ts
+++ b/js/publish/src/fanout.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "@moq/signals";
+import { Fanout } from "./fanout";
+
+// A stream we can feed by hand, so a test controls exactly when values arrive.
+function pushable<T>(): { stream: ReadableStream<T>; push: (value: T) => void; close: () => void } {
+	let controller!: ReadableStreamDefaultController<T>;
+	const stream = new ReadableStream<T>({
+		start: (c) => {
+			controller = c;
+		},
+	});
+	return {
+		stream,
+		push: (value) => controller.enqueue(value),
+		close: () => controller.close(),
+	};
+}
+
+// Let the fanout's pump drain everything pushed so far, so a test that asserts on the queue's
+// contents isn't racing it.
+const flush = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+// Read up to `count` values, giving up once the stream goes quiet.
+async function take<T>(stream: ReadableStream<T>, count: number): Promise<T[]> {
+	const reader = stream.getReader();
+	const out: T[] = [];
+
+	for (let i = 0; i < count; i++) {
+		const next = await Promise.race([
+			reader.read(),
+			new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 50)),
+		]);
+		if (!next || next.done) break;
+		out.push(next.value);
+	}
+
+	reader.releaseLock();
+	return out;
+}
+
+describe("Fanout", () => {
+	// The whole point: one source, several encoders, none of them stealing from the others.
+	test("delivers every value to every reader", async () => {
+		const source = pushable<number>();
+		const fanout = new Fanout(source.stream);
+		const effect = new Effect();
+
+		const a = fanout.subscribe(effect);
+		const b = fanout.subscribe(effect);
+
+		source.push(1);
+		source.push(2);
+		source.push(3);
+
+		expect(await take(a, 3)).toEqual([1, 2, 3]);
+		expect(await take(b, 3)).toEqual([1, 2, 3]);
+
+		effect.close();
+		fanout.close();
+	});
+
+	// A second reader used to be impossible: pipeThrough/getReader locks the one stream.
+	test("lets a reader attach after another is already reading", async () => {
+		const source = pushable<number>();
+		const fanout = new Fanout(source.stream);
+		const effect = new Effect();
+
+		const a = fanout.subscribe(effect);
+		source.push(1);
+		expect(await take(a, 1)).toEqual([1]);
+
+		// Joins late, so it sees what comes next rather than the backlog.
+		const b = fanout.subscribe(effect);
+		source.push(2);
+
+		expect(await take(a, 1)).toEqual([2]);
+		expect(await take(b, 1)).toEqual([2]);
+
+		effect.close();
+		fanout.close();
+	});
+
+	// Head-of-line blocking would be worse than dropping: the source is a live capture.
+	test("drops a slow reader's oldest without starving the others", async () => {
+		const source = pushable<number>();
+		const fanout = new Fanout(source.stream, { queue: 2 });
+		const effect = new Effect();
+
+		const slow = fanout.subscribe(effect);
+		const fast = fanout.subscribe(effect);
+
+		// Drain `fast` as we go; `slow` never reads, so it overflows its queue of 2.
+		for (const value of [1, 2, 3, 4]) {
+			source.push(value);
+			expect(await take(fast, 1)).toEqual([value]);
+		}
+
+		// The newest two survive; the older two were dropped for this reader alone.
+		expect(await take(slow, 2)).toEqual([3, 4]);
+
+		effect.close();
+		fanout.close();
+	});
+
+	test("stops delivering once its effect is torn down", async () => {
+		const source = pushable<number>();
+		const fanout = new Fanout(source.stream);
+		const effect = new Effect();
+
+		const stream = fanout.subscribe(effect);
+		source.push(1);
+		expect(await take(stream, 1)).toEqual([1]);
+
+		effect.close();
+		source.push(2);
+
+		expect(await take(stream, 1)).toEqual([]);
+		fanout.close();
+	});
+
+	// A reader closes what it receives, so handing the same VideoFrame to two renditions would
+	// close it out from under the other. Content equality can't catch that; identity can.
+	test("gives each reader its own copy", async () => {
+		const source = pushable<{ id: number }>();
+		const fanout = new Fanout(source.stream, {
+			clone: (value) => ({ ...value }),
+			release: () => {},
+		});
+		const effect = new Effect();
+
+		const a = fanout.subscribe(effect);
+		const b = fanout.subscribe(effect);
+
+		source.push({ id: 1 });
+		await flush();
+
+		const [fromA] = await take(a, 1);
+		const [fromB] = await take(b, 1);
+
+		expect(fromA).toEqual({ id: 1 });
+		expect(fromB).toEqual({ id: 1 });
+		expect(fromA).not.toBe(fromB);
+
+		effect.close();
+		fanout.close();
+	});
+
+	// Everything the fanout discards has to be released, or a VideoFrame's buffers leak.
+	test("releases what it discards", async () => {
+		const source = pushable<{ id: number }>();
+		const released: number[] = [];
+
+		const fanout = new Fanout(source.stream, {
+			queue: 1,
+			clone: (value) => ({ ...value }),
+			release: (value) => released.push(value.id),
+		});
+		const effect = new Effect();
+
+		const stream = fanout.subscribe(effect);
+
+		source.push({ id: 1 });
+		source.push({ id: 2 });
+		await flush();
+
+		// One reader with a queue of 1: id 1 is dropped for it, and both originals are released
+		// because each reader took a clone.
+		expect(await take(stream, 1)).toEqual([{ id: 2 }]);
+
+		// id 1 twice: the original the reader cloned from, plus the clone dropped from its queue.
+		expect(released.filter((id) => id === 1).length).toBe(2);
+		expect(released).toContain(2);
+
+		effect.close();
+		fanout.close();
+	});
+
+	test("releases values that arrive with nobody attached", async () => {
+		const source = pushable<{ id: number }>();
+		const released: number[] = [];
+
+		const fanout = new Fanout(source.stream, { release: (value) => released.push(value.id) });
+
+		source.push({ id: 7 });
+		await flush();
+
+		expect(released).toEqual([7]);
+		fanout.close();
+	});
+
+	test("closes its readers when the source ends", async () => {
+		const source = pushable<number>();
+		const fanout = new Fanout(source.stream);
+		const effect = new Effect();
+
+		const stream = fanout.subscribe(effect);
+		source.push(1);
+		source.close();
+
+		const reader = stream.getReader();
+		expect((await reader.read()).value).toBe(1);
+		expect((await reader.read()).done).toBe(true);
+
+		effect.close();
+	});
+});

--- a/js/publish/src/fanout.ts
+++ b/js/publish/src/fanout.ts
@@ -154,7 +154,8 @@ export class Fanout<T> {
 			}
 
 			for (const target of this.#readers) {
-				// The last reader can take the original; everyone before it needs its own copy.
+				// Every reader takes its own copy, including the last: handing one of them the
+				// original would leave it closing a value the fanout still owns.
 				this.#push(target, this.#clone ? this.#clone(value) : value);
 			}
 

--- a/js/publish/src/fanout.ts
+++ b/js/publish/src/fanout.ts
@@ -1,0 +1,159 @@
+import type { Effect } from "@moq/signals";
+
+// How many values a reader may fall behind before it starts losing its oldest.
+const QUEUE = 4;
+
+/** Constructor options for {@link Fanout}. */
+export interface FanoutProps<T> {
+	/** How many values each reader may buffer before its oldest is dropped. Defaults to 4. */
+	queue?: number;
+
+	/**
+	 * Produce a reader's own copy of a value.
+	 *
+	 * Required for values that own a resource (a `VideoFrame`), since each reader closes what it
+	 * receives. Omit it for plain immutable data, which every reader can share.
+	 */
+	clone?: (value: T) => T;
+
+	/** Release a value the fanout is discarding: dropped from a full queue, or never delivered. */
+	release?: (value: T) => void;
+}
+
+/**
+ * Distributes one stream to any number of readers.
+ *
+ * Each reader gets its own bounded queue, so one that falls behind loses its own oldest values
+ * rather than stalling the source or the other readers. Head-of-line blocking would be worse than
+ * dropping here: the source is a live capture that can't be asked to wait.
+ *
+ * This exists because a `Signal` is the wrong channel for media. Signal writes coalesce within a
+ * microtask, so a burst delivers only the newest value and the rest are destroyed without any
+ * reader seeing them, which for an encoder means silently skipped frames.
+ */
+export class Fanout<T> {
+	readonly #queue: number;
+	readonly #clone: ((value: T) => T) | undefined;
+	readonly #release: ((value: T) => void) | undefined;
+
+	readonly #readers = new Set<Reader<T>>();
+
+	#closed = false;
+
+	constructor(source: ReadableStream<T>, props?: FanoutProps<T>) {
+		this.#queue = props?.queue ?? QUEUE;
+		this.#clone = props?.clone;
+		this.#release = props?.release;
+
+		void this.#pump(source).catch((err) => console.error("fanout source failed:", err));
+	}
+
+	/** A stream of everything published from now on, cancelled when `effect` is torn down. */
+	subscribe(effect: Effect): ReadableStream<T> {
+		const reader: Reader<T> = { queue: [], waiting: undefined, done: this.#closed };
+		this.#readers.add(reader);
+
+		effect.cleanup(() => {
+			this.#readers.delete(reader);
+			this.#drain(reader);
+			reader.done = true;
+			reader.waiting?.();
+			reader.waiting = undefined;
+		});
+
+		return new ReadableStream<T>(
+			{
+				pull: async (controller) => {
+					for (;;) {
+						const value = reader.queue.shift();
+						if (value !== undefined) {
+							controller.enqueue(value);
+							return;
+						}
+
+						if (reader.done) {
+							controller.close();
+							return;
+						}
+
+						await new Promise<void>((resolve) => {
+							reader.waiting = resolve;
+						});
+					}
+				},
+				cancel: () => {
+					this.#readers.delete(reader);
+					this.#drain(reader);
+				},
+			},
+			// A stream buffers ahead by default, which would pull values out of the queue above and
+			// hold them where the drop policy can't reach: the reader would keep a stale value and
+			// lose a fresh one instead. Pulling only on demand keeps that queue the single buffer.
+			{ highWaterMark: 0 },
+		);
+	}
+
+	/** Stop distributing and release anything still queued. */
+	close(): void {
+		this.#closed = true;
+
+		for (const reader of this.#readers) {
+			this.#drain(reader);
+			reader.done = true;
+			reader.waiting?.();
+			reader.waiting = undefined;
+		}
+
+		this.#readers.clear();
+	}
+
+	async #pump(source: ReadableStream<T>): Promise<void> {
+		const reader = source.getReader();
+
+		for (;;) {
+			const { value } = await reader.read();
+			if (value === undefined) break;
+
+			// Nobody attached, so this value has nowhere to go.
+			if (this.#readers.size === 0) {
+				this.#release?.(value);
+				continue;
+			}
+
+			for (const target of this.#readers) {
+				// The last reader can take the original; everyone before it needs its own copy.
+				this.#push(target, this.#clone ? this.#clone(value) : value);
+			}
+
+			// Every reader holds a clone of its own, so the original is ours to release.
+			if (this.#clone) this.#release?.(value);
+		}
+
+		this.close();
+	}
+
+	#push(reader: Reader<T>, value: T): void {
+		// Drop this reader's oldest rather than stalling the source for everyone.
+		while (reader.queue.length >= this.#queue) {
+			const dropped = reader.queue.shift();
+			if (dropped !== undefined) this.#release?.(dropped);
+		}
+
+		reader.queue.push(value);
+
+		reader.waiting?.();
+		reader.waiting = undefined;
+	}
+
+	#drain(reader: Reader<T>): void {
+		for (const value of reader.queue) this.#release?.(value);
+		reader.queue.length = 0;
+	}
+}
+
+// One attached reader: what it hasn't consumed yet, plus a resolver parked on an empty queue.
+type Reader<T> = {
+	queue: T[];
+	waiting: (() => void) | undefined;
+	done: boolean;
+};

--- a/js/publish/src/fanout.ts
+++ b/js/publish/src/fanout.ts
@@ -48,9 +48,14 @@ export class Fanout<T> {
 		void this.#pump(source).catch((err) => console.error("fanout source failed:", err));
 	}
 
-	/** A stream of everything published from now on, cancelled when `effect` is torn down. */
-	subscribe(effect: Effect): ReadableStream<T> {
-		const reader: Reader<T> = { queue: [], waiting: undefined, done: this.#closed };
+	/**
+	 * A stream of everything published from now on, cancelled when `effect` is torn down.
+	 *
+	 * `queue` overrides how far this reader may fall behind before it loses its oldest. Pass 1 for a
+	 * consumer that only wants the newest, like a preview that draws one frame per paint.
+	 */
+	subscribe(effect: Effect, queue = this.#queue): ReadableStream<T> {
+		const reader: Reader<T> = { queue: [], limit: queue, waiting: undefined, done: this.#closed };
 		this.#readers.add(reader);
 
 		effect.cleanup(() => {
@@ -134,7 +139,7 @@ export class Fanout<T> {
 
 	#push(reader: Reader<T>, value: T): void {
 		// Drop this reader's oldest rather than stalling the source for everyone.
-		while (reader.queue.length >= this.#queue) {
+		while (reader.queue.length >= reader.limit) {
 			const dropped = reader.queue.shift();
 			if (dropped !== undefined) this.#release?.(dropped);
 		}
@@ -154,6 +159,7 @@ export class Fanout<T> {
 // One attached reader: what it hasn't consumed yet, plus a resolver parked on an empty queue.
 type Reader<T> = {
 	queue: T[];
+	limit: number;
 	waiting: (() => void) | undefined;
 	done: boolean;
 };

--- a/js/publish/src/fanout.ts
+++ b/js/publish/src/fanout.ts
@@ -37,15 +37,21 @@ export class Fanout<T> {
 	readonly #release: ((value: T) => void) | undefined;
 
 	readonly #readers = new Set<Reader<T>>();
+	readonly #reader: ReadableStreamDefaultReader<T>;
 
 	#closed = false;
+
+	// Why the source stopped, when it stopped by failing. Readers surface this rather than seeing a
+	// clean end, so a consumer can tell "the capture died" from "the capture finished".
+	#failure: { error: unknown } | undefined;
 
 	constructor(source: ReadableStream<T>, props?: FanoutProps<T>) {
 		this.#queue = props?.queue ?? QUEUE;
 		this.#clone = props?.clone;
 		this.#release = props?.release;
+		this.#reader = source.getReader();
 
-		void this.#pump(source).catch((err) => console.error("fanout source failed:", err));
+		void this.#pump();
 	}
 
 	/**
@@ -77,7 +83,11 @@ export class Fanout<T> {
 						}
 
 						if (reader.done) {
-							controller.close();
+							// A source that failed has to reach the reader as an error. Closing
+							// cleanly would look like a finished capture, and the consumer would
+							// just stop rather than report it.
+							if (this.#failure) controller.error(this.#failure.error);
+							else controller.close();
 							return;
 						}
 
@@ -98,9 +108,16 @@ export class Fanout<T> {
 		);
 	}
 
-	/** Stop distributing and release anything still queued. */
+	/** Stop distributing, cancel the source, and release anything still queued. */
 	close(): void {
+		if (this.#closed) return;
 		this.#closed = true;
+
+		// The source is ours to release. Without this the pump stays parked on a read, holding the
+		// stream locked and letting a swapped-out capture keep producing into nothing.
+		// Cancelling an errored stream rejects with that error. We already recorded it, so swallow
+		// the rejection rather than letting it surface as unhandled.
+		this.#reader.cancel().catch(() => {});
 
 		for (const reader of this.#readers) {
 			this.#drain(reader);
@@ -112,11 +129,22 @@ export class Fanout<T> {
 		this.#readers.clear();
 	}
 
-	async #pump(source: ReadableStream<T>): Promise<void> {
-		const reader = source.getReader();
+	async #pump(): Promise<void> {
+		try {
+			await this.#read();
+		} catch (error) {
+			// Surface it through every reader rather than only logging: a silent stall would leave
+			// the encoders waiting on a source that is never coming back.
+			console.error("fanout source failed:", error);
+			this.#failure = { error };
+		}
 
+		this.close();
+	}
+
+	async #read(): Promise<void> {
 		for (;;) {
-			const { value } = await reader.read();
+			const { value } = await this.#reader.read();
 			if (value === undefined) break;
 
 			// Nobody attached, so this value has nowhere to go.
@@ -133,8 +161,6 @@ export class Fanout<T> {
 			// Every reader holds a clone of its own, so the original is ours to release.
 			if (this.#clone) this.#release?.(value);
 		}
-
-		this.close();
 	}
 
 	#push(reader: Reader<T>, value: T): void {

--- a/js/publish/src/preview.ts
+++ b/js/publish/src/preview.ts
@@ -111,7 +111,9 @@ export class Renderer {
 		if (!fanout) return;
 
 		const reader = fanout.subscribe(effect, 1).getReader();
-		effect.cleanup(() => reader.cancel().catch(() => {}));
+		effect.cleanup(() => {
+			reader.cancel().catch(() => {});
+		});
 
 		effect.cleanup(() => {
 			this.#latest.update((prev) => {
@@ -261,7 +263,9 @@ export class Transcode {
 
 			// Only the newest matters: this feeds a preview, not the wire.
 			const reader = fanout.subscribe(inner, 1).getReader();
-			inner.cleanup(() => reader.cancel().catch(() => {}));
+			inner.cleanup(() => {
+				reader.cancel().catch(() => {});
+			});
 
 			inner.spawn(async () => {
 				for (;;) {

--- a/js/publish/src/preview.ts
+++ b/js/publish/src/preview.ts
@@ -111,7 +111,7 @@ export class Renderer {
 		if (!fanout) return;
 
 		const reader = fanout.subscribe(effect, 1).getReader();
-		effect.cleanup(() => void reader.cancel());
+		effect.cleanup(() => reader.cancel().catch(() => {}));
 
 		effect.cleanup(() => {
 			this.#latest.update((prev) => {
@@ -261,7 +261,7 @@ export class Transcode {
 
 			// Only the newest matters: this feeds a preview, not the wire.
 			const reader = fanout.subscribe(inner, 1).getReader();
-			inner.cleanup(() => void reader.cancel());
+			inner.cleanup(() => reader.cancel().catch(() => {}));
 
 			inner.spawn(async () => {
 				for (;;) {

--- a/js/publish/src/preview.ts
+++ b/js/publish/src/preview.ts
@@ -1,5 +1,6 @@
 import { Time } from "@moq/net";
 import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Signal } from "@moq/signals";
+import type { Fanout } from "./fanout";
 import type * as Video from "./video";
 
 // What the canvas preview renders.
@@ -13,8 +14,8 @@ export type Mode = "none" | "source" | "encoded";
 export type RendererInput = {
 	// The canvas to draw into. Undefined renders nothing.
 	canvas: Getter<HTMLCanvasElement | undefined>;
-	// The captured frame to draw (owned by the capture pipeline; never closed here).
-	frame: Getter<VideoFrame | undefined>;
+	// The captured frames to draw. We subscribe for our own copies and close them.
+	frames: Getter<Fanout<VideoFrame> | undefined>;
 	// The display size, for sizing the canvas before the first frame.
 	display: Getter<{ width: number; height: number } | undefined>;
 	// Whether to mirror the video horizontally.
@@ -37,13 +38,16 @@ export class Renderer {
 	// Whether we've already warned about `encoded` mode without an encoder, so it fires at most once.
 	#warnedNoEncoder = false;
 
-	// Where to read the frame from: the capture pipeline, or the transcoder in `encoded` mode.
+	// Where to read the frame from: our own latest capture, or the transcoder in `encoded` mode.
 	//
 	// This holds the signal rather than the frame itself so #runRender always reads the *current*
 	// frame. Copying the frame across would leave us holding one its owner has already closed,
-	// since a signal write reaches us a microtask after the owner moved on. Capture only closes a
-	// frame when replacing it, so whatever is current is always safe to draw.
+	// since a signal write reaches us a microtask after the owner moved on.
 	#source = new Signal<Getter<VideoFrame | undefined> | undefined>(undefined);
+
+	// The newest captured frame, owned here: a preview draws one frame per paint, so anything older
+	// is thrown away rather than queued.
+	#latest = new Signal<VideoFrame | undefined>(undefined);
 
 	#ctx = new Signal<CanvasRenderingContext2D | undefined>(undefined);
 	#signals = new Effect();
@@ -51,7 +55,7 @@ export class Renderer {
 	constructor(props?: RendererProps) {
 		this.in = {
 			canvas: getter(props?.canvas),
-			frame: getter(props?.frame),
+			frames: getter(props?.frames),
 			display: getter(props?.display),
 			flip: getter(props?.flip ?? false),
 			encoder: getter(props?.encoder),
@@ -80,7 +84,7 @@ export class Renderer {
 			const encoder = effect.get(this.in.encoder);
 			if (encoder) {
 				const transcode = new Transcode({
-					source: this.in.frame,
+					source: this.in.frames,
 					config: encoder.out.resolved,
 					settings: encoder.config,
 				});
@@ -96,7 +100,37 @@ export class Renderer {
 			}
 		}
 
-		effect.set(this.#source, this.in.frame, undefined);
+		this.#pump(effect);
+		effect.set(this.#source, this.#latest, undefined);
+	}
+
+	// Keep only the newest captured frame. A queue of 1 means a busy main thread drops frames at the
+	// fanout instead of drawing a backlog of stale ones.
+	#pump(effect: Effect): void {
+		const fanout = effect.get(this.in.frames);
+		if (!fanout) return;
+
+		const reader = fanout.subscribe(effect, 1).getReader();
+		effect.cleanup(() => void reader.cancel());
+
+		effect.cleanup(() => {
+			this.#latest.update((prev) => {
+				prev?.close();
+				return undefined;
+			});
+		});
+
+		effect.spawn(async () => {
+			for (;;) {
+				const next = await Promise.race([reader.read(), effect.cancel]);
+				if (!next?.value) break;
+
+				this.#latest.update((prev) => {
+					prev?.close();
+					return next.value;
+				});
+			}
+		});
 	}
 
 	#runRender(effect: Effect): void {
@@ -141,8 +175,8 @@ export class Renderer {
 
 // Signals the transcoder reads.
 export type TranscodeInput = {
-	// The captured frame to re-encode (owned by the capture pipeline; never closed here).
-	source: Getter<VideoFrame | undefined>;
+	// The captured frames to re-encode. We subscribe for our own copies and close them.
+	source: Getter<Fanout<VideoFrame> | undefined>;
 	// The resolved WebCodecs config to mirror.
 	config: Getter<VideoEncoderConfig | undefined>;
 	// The rendition's encoder settings, read for keyframe cadence so the preview's GOP matches the wire.
@@ -222,20 +256,38 @@ export class Transcode {
 		let lastKeyframe: Time.Micro | undefined;
 
 		effect.run((inner) => {
-			const frame = inner.get(this.in.source);
-			if (!frame) return;
-			if (encoder.state !== "configured") return;
+			const fanout = inner.get(this.in.source);
+			if (!fanout) return;
 
-			// Mirror Encoder.serve: default to a 2s GOP unless the rendition overrides it.
-			const settings = inner.get(this.in.settings);
-			const interval = settings?.keyframeInterval ?? Time.Milli.fromSecond(2 as Time.Second);
+			// Only the newest matters: this feeds a preview, not the wire.
+			const reader = fanout.subscribe(inner, 1).getReader();
+			inner.cleanup(() => void reader.cancel());
 
-			const timestamp = frame.timestamp as Time.Micro;
-			const keyFrame = lastKeyframe === undefined || lastKeyframe + Time.Micro.fromMilli(interval) <= timestamp;
-			if (keyFrame) lastKeyframe = timestamp;
+			inner.spawn(async () => {
+				for (;;) {
+					const next = await Promise.race([reader.read(), inner.cancel]);
+					if (!next?.value) break;
 
-			// The capture pipeline owns and closes the frame, so we just read it here.
-			encoder.encode(frame, { keyFrame });
+					// Ours now, so close it once the encoder has taken what it needs.
+					const frame = next.value;
+					try {
+						if (encoder.state !== "configured") continue;
+
+						// Mirror Encoder.serve: default to a 2s GOP unless the rendition overrides it.
+						const settings = this.in.settings.peek();
+						const interval = settings?.keyframeInterval ?? Time.Milli.fromSecond(2 as Time.Second);
+
+						const timestamp = frame.timestamp as Time.Micro;
+						const keyFrame =
+							lastKeyframe === undefined || lastKeyframe + Time.Micro.fromMilli(interval) <= timestamp;
+						if (keyFrame) lastKeyframe = timestamp;
+
+						encoder.encode(frame, { keyFrame });
+					} finally {
+						frame.close();
+					}
+				}
+			});
 		});
 
 		effect.cleanup(() => {

--- a/js/publish/src/ui/components/stats-tab.ts
+++ b/js/publish/src/ui/components/stats-tab.ts
@@ -107,7 +107,9 @@ export function statsTab(parent: Effect, publish: MoqPublish): HTMLElement {
 		if (!fanout) return;
 
 		const reader = fanout.subscribe(effect).getReader();
-		effect.cleanup(() => reader.cancel().catch(() => {}));
+		effect.cleanup(() => {
+			reader.cancel().catch(() => {});
+		});
 
 		effect.spawn(async () => {
 			for (;;) {

--- a/js/publish/src/ui/components/stats-tab.ts
+++ b/js/publish/src/ui/components/stats-tab.ts
@@ -107,7 +107,7 @@ export function statsTab(parent: Effect, publish: MoqPublish): HTMLElement {
 		if (!fanout) return;
 
 		const reader = fanout.subscribe(effect).getReader();
-		effect.cleanup(() => void reader.cancel());
+		effect.cleanup(() => reader.cancel().catch(() => {}));
 
 		effect.spawn(async () => {
 			for (;;) {

--- a/js/publish/src/ui/components/stats-tab.ts
+++ b/js/publish/src/ui/components/stats-tab.ts
@@ -99,9 +99,25 @@ export function statsTab(parent: Effect, publish: MoqPublish): HTMLElement {
 	// Live graphs: frame rate from captured frames, bitrate measured from the bytes we encoded.
 	// The congestion controller's send estimate would be simpler, but Safari's WebTransport has no
 	// getStats(), so it has no estimate at all and the graph stayed empty there.
+	// Counted off our own stream rather than a signal, which would coalesce a burst of frames into
+	// one notification and undercount the rate.
 	let frames = 0;
-	parent.subscribe(publish.capture.out.frame, () => {
-		frames++;
+	parent.run((effect) => {
+		const fanout = effect.get(publish.capture.out.frames);
+		if (!fanout) return;
+
+		const reader = fanout.subscribe(effect).getReader();
+		effect.cleanup(() => void reader.cancel());
+
+		effect.spawn(async () => {
+			for (;;) {
+				const next = await Promise.race([reader.read(), effect.cancel]);
+				if (!next?.value) break;
+
+				frames++;
+				next.value.close();
+			}
+		});
 	});
 
 	const encoded = () => publish.video.out.stats.peek().bytes;

--- a/js/publish/src/ui/components/status-badge.ts
+++ b/js/publish/src/ui/components/status-badge.ts
@@ -32,7 +32,7 @@ export function statusBadge(parent: Effect, publish: MoqPublish): HTMLElement {
 	parent.run((effect) => {
 		const url = effect.get(publish.connection.url);
 		const status = effect.get(publish.connection.status);
-		const audioSource = effect.get(publish.audio.in.source);
+		const audioSource = effect.get(publish.audioCapture.in.source);
 		const videoSource = effect.get(publish.capture.in.source);
 		const muted = effect.get(publish.controls.muted);
 		const invisible = effect.get(publish.controls.invisible);

--- a/js/publish/src/ui/components/status-badge.ts
+++ b/js/publish/src/ui/components/status-badge.ts
@@ -32,7 +32,8 @@ export function statusBadge(parent: Effect, publish: MoqPublish): HTMLElement {
 	parent.run((effect) => {
 		const url = effect.get(publish.connection.url);
 		const status = effect.get(publish.connection.status);
-		const audioSource = effect.get(publish.audioCapture.in.source);
+		const audioCapture = effect.get(publish.audio.in.capture);
+		const audioSource = audioCapture ? effect.get(audioCapture.in.source) : undefined;
 		const videoSource = effect.get(publish.capture.in.source);
 		const muted = effect.get(publish.controls.muted);
 		const invisible = effect.get(publish.controls.invisible);

--- a/js/publish/src/video/capture.ts
+++ b/js/publish/src/video/capture.ts
@@ -1,4 +1,5 @@
 import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Signal } from "@moq/signals";
+import { Fanout } from "../fanout";
 import { TrackProcessor } from "./processor";
 import { isStreamTrack, type Source } from "./types";
 
@@ -8,23 +9,25 @@ export type CaptureInput = {
 };
 
 type CaptureOutput = {
-	// The latest captured frame. Owned here: closed when replaced and on close().
-	frame: Signal<VideoFrame | undefined>;
+	// The captured frames, replaced whenever the source changes. Subscribe for a stream of your own;
+	// each reader owns the frames it receives and must close them.
+	frames: Signal<Fanout<VideoFrame> | undefined>;
 	// The captured (coded) dimensions, tracked from each frame.
 	display: Signal<{ width: number; height: number } | undefined>;
 };
 
 /**
- * Pumps frames off a capture {@link Source} onto an owned {@link out} frame signal.
+ * Pumps frames off a capture {@link Source} and distributes them to any number of readers.
  *
- * Split out of the encoders so one capture feeds any number of renditions. The output frame is owned
- * here (closed on replace and on {@link close}); readers must not close it.
+ * Split out of the encoders so one capture feeds every rendition, the preview, and the stats. Each
+ * reader gets its own copy of every frame and closes what it receives; a reader that falls behind
+ * loses its own oldest rather than stalling the capture.
  */
 export class Capture {
 	readonly in: Readonlys<CaptureInput>;
 
 	readonly #out: CaptureOutput = {
-		frame: new Signal<VideoFrame | undefined>(undefined),
+		frames: new Signal<Fanout<VideoFrame> | undefined>(undefined),
 		display: new Signal<{ width: number; height: number } | undefined>(undefined),
 	};
 	readonly out = readonlys(this.#out);
@@ -47,38 +50,33 @@ export class Capture {
 		// wall clock so they stay consistent when the source changes or the encoder reloads. A
 		// FrameSource already stamps against that clock, so take its frames as they are.
 		const stream = isStreamTrack(source) ? TrackProcessor(source) : source.frames;
-		const reader = stream.getReader();
-		effect.cleanup(() => reader.cancel());
 
-		effect.spawn(async () => {
-			for (;;) {
-				const next = await Promise.race([reader.read(), effect.cancel]);
-				if (!next?.value) break;
-
-				this.#out.frame.update((prev) => {
-					prev?.close();
-					return next.value;
-				});
-
-				this.#out.display.set({ width: next.value.codedWidth, height: next.value.codedHeight });
-			}
+		const fanout = new Fanout(stream.pipeThrough(this.#measure()), {
+			// A frame is a resource with an explicit lifetime, so every reader needs its own handle
+			// and closes it. Sharing one would let the first reader close it under the others.
+			clone: (frame) => frame.clone(),
+			release: (frame) => frame.close(),
 		});
+		effect.cleanup(() => fanout.close());
 
+		effect.set(this.#out.frames, fanout, undefined);
 		effect.cleanup(() => {
-			this.#out.frame.update((prev) => {
-				prev?.close();
-				return undefined;
-			});
 			this.#out.display.set(undefined);
+		});
+	}
+
+	// Read the coded size off each frame on its way past. The signal only notifies when the size
+	// actually changes, so this costs nothing per frame beyond the comparison.
+	#measure(): TransformStream<VideoFrame, VideoFrame> {
+		return new TransformStream<VideoFrame, VideoFrame>({
+			transform: (frame, controller) => {
+				this.#out.display.set({ width: frame.codedWidth, height: frame.codedHeight });
+				controller.enqueue(frame);
+			},
 		});
 	}
 
 	close() {
 		this.#signals.close();
-
-		this.#out.frame.update((prev) => {
-			prev?.close();
-			return undefined;
-		});
 	}
 }

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -213,7 +213,9 @@ export class Encoder {
 				// Our own stream off the shared capture, so the preview or another rendition reading
 				// slowly can't take frames from this one.
 				const reader = fanout.subscribe(effect).getReader();
-				effect.cleanup(() => reader.cancel().catch(() => {}));
+				effect.cleanup(() => {
+					reader.cancel().catch(() => {});
+				});
 
 				effect.spawn(async () => {
 					for (;;) {

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -197,33 +197,52 @@ export class Encoder {
 			});
 
 			effect.run((effect) => {
-				const frame = effect.get(capture.out.frame);
-				if (!frame) return;
+				const fanout = effect.get(capture.out.frames);
+				if (!fanout) return;
 
-				if (encoder.state !== "configured") return;
+				// Our own stream off the shared capture, so the preview or another rendition reading
+				// slowly can't take frames from this one.
+				const reader = fanout.subscribe(effect).getReader();
+				effect.cleanup(() => void reader.cancel());
 
-				// This doesn't need to be reactive.
-				const config = this.config.peek();
+				effect.spawn(async () => {
+					for (;;) {
+						const next = await Promise.race([reader.read(), effect.cancel]);
+						if (!next?.value) break;
 
-				// Pace to the target frame rate by dropping frames that arrive too soon.
-				// Allow half an interval of slack so jittery capture timestamps don't drop a frame we meant to keep.
-				// The shared frame Signal owner closes frames, so we just skip encoding here.
-				const targetFrameRate = config?.frameRate;
-				if (targetFrameRate && lastEncoded !== undefined) {
-					const minGap = Time.Micro.fromSecond((1 / targetFrameRate) as Time.Second);
-					if (frame.timestamp - lastEncoded < minGap - minGap / 2) return;
-				}
-				lastEncoded = frame.timestamp as Time.Micro;
+						// Ours now: every path below has to close it.
+						const frame = next.value;
+						try {
+							if (encoder.state !== "configured") continue;
 
-				const interval = config?.keyframeInterval ?? Time.Milli.fromSecond(2 as Time.Second);
+							// This doesn't need to be reactive.
+							const config = this.config.peek();
 
-				// Force a keyframe if this is the first frame (no group yet), or GOP elapsed.
-				const keyFrame = !lastKeyframe || lastKeyframe + Time.Micro.fromMilli(interval) <= frame.timestamp;
-				if (keyFrame) {
-					lastKeyframe = frame.timestamp as Time.Micro;
-				}
+							// Pace to the target frame rate by dropping frames that arrive too soon.
+							// Allow half an interval of slack so jittery capture timestamps don't drop
+							// a frame we meant to keep.
+							const targetFrameRate = config?.frameRate;
+							if (targetFrameRate && lastEncoded !== undefined) {
+								const minGap = Time.Micro.fromSecond((1 / targetFrameRate) as Time.Second);
+								if (frame.timestamp - lastEncoded < minGap - minGap / 2) continue;
+							}
+							lastEncoded = frame.timestamp as Time.Micro;
 
-				encoder.encode(frame, { keyFrame });
+							const interval = config?.keyframeInterval ?? Time.Milli.fromSecond(2 as Time.Second);
+
+							// Force a keyframe if this is the first frame (no group yet), or GOP elapsed.
+							const keyFrame =
+								!lastKeyframe || lastKeyframe + Time.Micro.fromMilli(interval) <= frame.timestamp;
+							if (keyFrame) {
+								lastKeyframe = frame.timestamp as Time.Micro;
+							}
+
+							encoder.encode(frame, { keyFrame });
+						} finally {
+							frame.close();
+						}
+					}
+				});
 			});
 		});
 	}
@@ -353,15 +372,17 @@ export class Encoder {
 		const capture = effect.get(this.in.capture);
 		if (!capture) return;
 
-		const frame = effect.get(capture.out.frame);
-		if (!frame) return;
+		// The captured size, rather than a frame: this only needs the dimensions, and holding a frame
+		// here would mean owning and closing it.
+		const display = effect.get(capture.out.display);
+		if (!display) return;
 
 		const source = effect.get(capture.in.source);
 		if (!source) return;
 
 		const user = effect.get(this.config);
 
-		const sourcePixels = frame.codedWidth * frame.codedHeight;
+		const sourcePixels = display.width * display.height;
 
 		// maxPixels caps absolutely; maxScale caps relative to the source. The smaller cap wins.
 		let maxPixels = user?.maxPixels ?? sourceConstraintPixels(source) ?? sourcePixels;
@@ -376,8 +397,8 @@ export class Encoder {
 
 		// Make sure width/height is a power of 16
 		// TODO should this be on a per-codec basis?
-		const width = 16 * Math.floor((frame.codedWidth * ratio) / 16);
-		const height = 16 * Math.floor((frame.codedHeight * ratio) / 16);
+		const width = 16 * Math.floor((display.width * ratio) / 16);
+		const height = 16 * Math.floor((display.height * ratio) / 16);
 
 		effect.set(this.#dimensions, { width, height });
 	}

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -213,7 +213,7 @@ export class Encoder {
 				// Our own stream off the shared capture, so the preview or another rendition reading
 				// slowly can't take frames from this one.
 				const reader = fanout.subscribe(effect).getReader();
-				effect.cleanup(() => void reader.cancel());
+				effect.cleanup(() => reader.cancel().catch(() => {}));
 
 				effect.spawn(async () => {
 					for (;;) {

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -103,6 +103,16 @@ export class Encoder {
 	/** The live-editable encoder tuning knobs (codec, dimensions, bitrate, frame rate). */
 	config: Signal<Config | undefined>;
 
+	/**
+	 * The capture supplying this rendition, or undefined while none is wired.
+	 *
+	 * A snapshot. Read {@link in}.capture through an effect instead when you need to react to it
+	 * being swapped.
+	 */
+	get capture(): Capture | undefined {
+		return this.in.capture.peek();
+	}
+
 	readonly #out: EncoderOutput = {
 		catalog: new Signal<Catalog.VideoConfig | undefined>(undefined),
 		resolved: new Signal<VideoEncoderConfig | undefined>(undefined),


### PR DESCRIPTION
Follow-up to #2541, which merged to `dev` as 8d59b231d. Rebased onto `dev`, so this diff is only the fanout work.

Targets `dev` because it breaks published `@moq/publish` API. My earlier read was that `CONTRIBUTING.md`'s dev list names `js/net` and `js/hang` but not `js/publish`; that was too literal.

## Summary

Two problems with how captured media reaches its consumers, both found by an adversarial review of #2541.

**A decoded audio source could feed only one encoder.** `SampleSource` exposes a single `ReadableStream`, and every `Audio.Encoder` built its own `Capture`, whose `pipeThrough` locked it. A second audio rendition off a file threw on the locked stream: it still advertised a catalog and looked active, but published nothing. Simulcast off a file was impossible.

**A `Signal` silently drops frames.** `Signal.set` guards its flush with `#pending`, so several writes in one microtask collapse to a single notification carrying only the newest value, and `Video.Capture` closed the rest undelivered. Three consumers shared that signal (the encoder, the preview, the stats), so the encoder silently skipped frames it should have encoded and the stats counter undercounted the rate. This one predates #2541 and affects camera publishing too.

## Approach

A `Fanout` primitive reads the source once and gives each consumer its own bounded queue, dropping *that consumer's* oldest on overflow. Head-of-line blocking would be worse than dropping: the source is a live capture that can't be asked to wait, and one slow rendition must not stall the others. Optional `clone`/`release` adapters carry values that own a resource, so each reader closes only its own copy.

Applied to both captures:

- `Audio.Encoder` now takes a shared `capture` input, mirroring `Video.Encoder`. `Gain` returns a copy instead of scaling in place, so one rendition's mute can't silence the others; at unity it copies nothing.
- `Video.Capture` fans frames out. The preview subscribes one deep, since it draws one frame per paint and wants the newest rather than a backlog.

A shared audio capture can't run at any one rendition's codec rate, so it picks a rate every codec accepts and each encoder resamples from there. The Bluetooth-44100 regression (a mic reporting a rate Opus can't decode) stays fixed by that same snap, and the graph now never rebuilds for an encoder setting at all, which is strictly stronger than the old "only the mime rebuilds it".

## Public API changes

All in `@moq/publish`, which `CONTRIBUTING.md` doesn't list for `dev`, so this targets `main`.

Breaking:
- `Audio.Encoder.in.source` → `in.capture` (takes a shared `Audio.Capture`).
- `Audio.Encoder.sampleRate` / `.channelCount` move to `Audio.Capture`. They describe the capture format, which renditions share; leaving them on the encoder would have made them silently ignored for one of the two source kinds, which is the second thing the review flagged.
- `Video.Capture.out.frame: Signal<VideoFrame>` → `out.frames: Signal<Fanout<VideoFrame>>`. Readers now own and close what they receive, where before the capture owned it.

Additive: `Audio.Capture` is exported (callers construct it now), `MoqPublish.audioCapture`, and `Fanout` (internal, not re-exported).

## Terminal paths

Two defects in `Fanout`'s teardown, both found by adversarial review and both fixed here:

- **A failing source hung every reader.** `#pump` only reached `close()` on normal completion, so a read, transform, or clone that threw was caught, logged, and left every reader blocked on `read()` forever. Encoders stalled with no terminal signal while `out.active` still reported true. Readers now surface it as a stream error, so a consumer can tell a dead capture from a finished one.
- **`close()` never cancelled its source**, contradicting the contract documented on `FrameSource.frames` and `SampleSource.samples`. A swapped-out capture kept its stream locked and kept decoding into nothing. Now cancelled exactly once, idempotent across close, EOF, and failure.

Cancelling a stream we errored rejects with that error, so the cancels on every teardown path swallow it rather than leaving it unhandled.

`Audio.Encoder` also throws when handed the removed `source` prop. TypeScript catches it, but a plain JS caller would otherwise build an encoder with nothing attached and lose audio silently.

## Test plan

**Unit** (68 pass): `fanout.test.ts` covers multi-reader delivery, late attach, per-reader drop without starving others, teardown, per-reader copies, releasing discards, and source end. Every assertion is mutation-verified: breaking fanout, the drop policy, cloning, error propagation, or source cancellation each fails a test. The audio capture gains a two-rendition regression test that hangs when fanout is single-consumer. `just js check` clean.

**Browser** (Chrome, local relay, real `<moq-watch>` subscriber, 5s 640x480@24 + 44.1kHz file):

| | result |
|---|---|
| video (3 consumers on the fanout) | **24.00 fps**, subscriber receives 24 |
| audio rendition 1 | **50.1 fps** (nominal 50 for 20ms Opus) |
| audio rendition 2 | **50.1 fps** |
| both renditions over a raw subscription | 302 and 266 frames in 6s |
| preview canvas | painting, 100% non-black |
| console errors | **0** over 10s |
| swapping the source mid-publish | clean, 0 errors (exercises cancel-on-close) |

Zero errors is the load-bearing one: `VideoFrame has been closed` is the failure mode this refactor could introduce, and it doesn't appear.

**Not verified:** a real camera (none in this environment; the capture graph's teardown and rate logic are covered by the existing fake-WebAudio tests, which pass unchanged against the moved code), and Safari/Firefox.

Cross-Package Sync: `demo/web` consumes the moved audio knobs and the frame signal, and is updated in the same commits.

(written by Opus 5)


