### PR TITLE
chore(js): bump package patch versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -98,7 +98,7 @@
     },
     "js/hang": {
       "name": "@moq/hang",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
         "@libav.js/variant-opus-af": "^6.9.8",
@@ -181,7 +181,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@moq/qmux": "^0.3.2",
         "@moq/signals": "workspace:*",
@@ -201,7 +201,7 @@
     },
     "js/publish": {
       "name": "@moq/publish",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/net": "workspace:^",
@@ -264,7 +264,7 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/msf": "workspace:^",

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"jsr": false,
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",


### PR DESCRIPTION
## Summary

- Bump `@moq/hang` to 0.3.3 and `@moq/watch` to 0.4.3 for the additive caption APIs already landed on main.
- Bump `@moq/net` to 0.2.2 for unreleased routing and protocol behavior, and `@moq/publish` to 0.4.2 for caption integration and the capture-device fix.
- Keep the Bun workspace lockfile versions aligned.

## Public API changes

- This PR introduces no API changes itself. It publishes already-landed additive APIs and behavior as patch releases.
- No breaking changes.
- No additional cross-package sync is required because the affected JavaScript implementations and documentation are already on main.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just ci`

(Written by GPT-5)