### PR TITLE
fix(net): stop a lingering track spinning on its departed route, and still release it when idle

### DIFF
--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1911,9 +1911,10 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 		// The countdown keys off the segment, not our handle on the route that
 		// produced it: a route that leaves (or a copy that dies) drops the handle
 		// while the segment stays spliced, and that segment is exactly what the
-		// release exists to reclaim. Keying off the handle would strand it until the
-		// front closes, and the next takeover would then splice above its edge,
-		// skipping a reconnecting publisher that restarts its group numbering.
+		// release exists to reclaim. Keying off the handle strands it until the front
+		// closes, which pins the departed source's cached groups for a linger that
+		// may never expire and leaves a dead segment's edge behind for the next
+		// takeover to splice above.
 		let used = resume.is_used();
 		idle_since = match (resume.is_spliced(), used) {
 			(true, false) => idle_since.or_else(|| Some(web_async::time::Instant::now())),
@@ -4249,13 +4250,12 @@ mod tests {
 	///
 	/// A departed route drops the loop's handle on it, so the idle countdown has to
 	/// key off the segment itself. Otherwise the segment is stranded for the life of
-	/// the front, and the boundary [`resume::Producer::takeover`] computes from it
-	/// silently swallows a reconnecting publisher that restarts its group numbering:
-	/// the new segment starts above the stale edge, so the republished group 0 is
-	/// filtered and a viewer waits forever for a track that only ever writes once.
+	/// the front, pinning the dead source's cached groups.
 	///
-	/// Observed through that boundary rather than the release itself, since delivery
-	/// is what a viewer actually feels.
+	/// Asserted through the boundary a stranded segment would leave behind, since
+	/// `resume` is private and delivery is what a viewer actually feels: a released
+	/// segment set splices the next source unbounded, so its first group arrives,
+	/// while a retained one caps it below that edge.
 	#[tokio::test(start_paused = true)]
 	async fn test_idle_release_survives_the_route_leaving() {
 		let origin = Info::new(Origin::random())

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1907,8 +1907,15 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 		// Demand gates both directions: an unread track never splices a source in,
 		// and a spliced one is released once the linger expires. Both sides use the
 		// same signal, so a release can't immediately re-splice and spin.
+		//
+		// The countdown keys off the segment, not our handle on the route that
+		// produced it: a route that leaves (or a copy that dies) drops the handle
+		// while the segment stays spliced, and that segment is exactly what the
+		// release exists to reclaim. Keying off the handle would strand it until the
+		// front closes, and the next takeover would then splice above its edge,
+		// skipping a reconnecting publisher that restarts its group numbering.
 		let used = resume.is_used();
-		idle_since = match (serving.is_some(), used) {
+		idle_since = match (resume.is_spliced(), used) {
 			(true, false) => idle_since.or_else(|| Some(web_async::time::Instant::now())),
 			_ => None,
 		};
@@ -4236,6 +4243,71 @@ mod tests {
 		producer.create_group(group::Info { sequence: 1 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 1);
 		sub.assert_not_closed();
+	}
+
+	/// An idle segment is released even once the route that produced it is gone.
+	///
+	/// A departed route drops the loop's handle on it, so the idle countdown has to
+	/// key off the segment itself. Otherwise the segment is stranded for the life of
+	/// the front, and the boundary [`resume::Producer::takeover`] computes from it
+	/// silently swallows a reconnecting publisher that restarts its group numbering:
+	/// the new segment starts above the stale edge, so the republished group 0 is
+	/// filtered and a viewer waits forever for a track that only ever writes once.
+	///
+	/// Observed through that boundary rather than the release itself, since delivery
+	/// is what a viewer actually feels.
+	#[tokio::test(start_paused = true)]
+	async fn test_idle_release_survives_the_route_leaving() {
+		let origin = Info::new(Origin::random())
+			.with_linger(Duration::from_secs(600))
+			.produce();
+		let consumer = origin.consume();
+
+		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let source = origin
+			.create_broadcast("test", announce().with_hops(hops.clone()))
+			.unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+
+		let subscribing = broadcast.track("catalog.json").unwrap().subscribe(None);
+		let mut producer = accept_track(&mut dynamic, "catalog.json").await;
+		settle().await;
+		let mut sub = subscribing.await.unwrap();
+		producer.append_group().unwrap();
+		assert_eq!(sub.assert_group().sequence, 0);
+
+		// The publisher's session dies, then the viewer gives up: nothing holds the
+		// segment, and nothing is left to serve the track.
+		source.abort(Error::Dropped).unwrap();
+		settle().await;
+		settle().await;
+		drop(sub);
+		drop(producer);
+		drop(dynamic);
+		settle().await;
+		tokio::time::sleep(TRACK_IDLE_LINGER + Duration::from_secs(1)).await;
+		settle().await;
+
+		// The publisher reconnects under the same identity, so it joins the front as
+		// a route rather than replacing it, and restarts its group numbering.
+		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+		let subscribing = broadcast.track("catalog.json").unwrap().subscribe(None);
+		let mut producer = accept_track(&mut dynamic, "catalog.json").await;
+		settle().await;
+		let mut sub = subscribing.await.unwrap();
+		producer.append_group().unwrap();
+		assert_eq!(
+			sub.assert_group().sequence,
+			0,
+			"the reconnect's first group must not be filtered by a stale boundary"
+		);
 	}
 
 	/// A deliberate finish never lingers, even with a linger configured: a clean

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -1995,9 +1995,14 @@ async fn serve_track(state: kio::Producer<FrontState>, name: Arc<str>, mut resum
 			// The outer loop recomputes `used` and the countdown on the next pass.
 			Step::Demand => {}
 			// The sweep is closed out at the top of the loop, which clears the
-			// refusals so the retry below picks a source. The spliced copy stays
-			// readable until a replacement is proven servable.
-			Step::Resweep => {}
+			// refusals so the retry below picks a source.
+			//
+			// Forget which route we were serving from, or the `gone` edge that woke
+			// us keeps firing: the id stays absent from the table, the wait returns
+			// Ready at once, and the loop spins on a full core without ever parking.
+			// The segment itself stays spliced into `resume` (readers keep whatever
+			// it delivered) until a replacement is proven servable.
+			Step::Resweep => serving = None,
 			Step::Idle => {
 				// Nobody has read the track for the linger: drop the source's copy so
 				// its session can release the track (and the cached `track::Info` that
@@ -4166,6 +4171,65 @@ mod tests {
 		let again = consumer.request_broadcast("test").await.unwrap();
 		assert!(again.is_clone(&broadcast), "the reconnect must splice, not replace");
 		drop(source);
+	}
+
+	/// A lingering broadcast with a live subscription must park, not spin.
+	///
+	/// An ungraceful loss empties the route table while the front waits out its
+	/// linger, so the route a track is spliced from is gone and no replacement can
+	/// serve it: the resweep. `serve_track` used to keep `serving_id` across it, so
+	/// the "route gone" edge re-fired on every poll, the wait returned Ready
+	/// immediately, and the loop ran hot for the whole linger. That burns a core per
+	/// subscribed track and starves the runtime that has to deliver the reconnect,
+	/// so a track written once (a catalog) never reaches the viewer again.
+	///
+	/// The empty table is what makes it unbounded: the strike budget is gated on
+	/// `!routes.is_empty()`, so the sweep at the top of the loop cannot spend one,
+	/// and every pass sees identical state. Under a paused clock the spin never
+	/// yields, so a regression hangs here rather than failing.
+	#[tokio::test(start_paused = true)]
+	async fn test_linger_parks_a_live_subscription() {
+		let origin = Info::new(Origin::random())
+			.with_linger(Duration::from_secs(5))
+			.produce();
+		let consumer = origin.consume();
+
+		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let source = origin
+			.create_broadcast("test", announce().with_hops(hops.clone()))
+			.unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		settle().await;
+		let broadcast = consumer.request_broadcast("test").await.unwrap();
+
+		// A viewer reading a track that is written once and then stays quiet, like a
+		// catalog.
+		let subscribing = broadcast.track("catalog.json").unwrap().subscribe(None);
+		let mut producer = accept_track(&mut dynamic, "catalog.json").await;
+		settle().await;
+		let mut sub = subscribing.await.unwrap();
+		producer.append_group().unwrap();
+		assert_eq!(sub.assert_group().sequence, 0);
+
+		// The publisher's session dies abruptly: the table empties and the front
+		// lingers, holding the subscription open for a reconnect. The track copy
+		// outlives the broadcast (closes don't cascade), so nothing reports the
+		// spliced segment as ended: the departed route is the only edge left.
+		source.abort(Error::Dropped).unwrap();
+		settle().await;
+		settle().await;
+		sub.assert_not_closed();
+
+		// The reconnect inside the window resumes the same subscription.
+		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
+		let mut dynamic = source.dynamic();
+		settle().await;
+		let mut producer = accept_track(&mut dynamic, "catalog.json").await;
+		settle().await;
+		producer.create_group(group::Info { sequence: 1 }).unwrap();
+		assert_eq!(sub.assert_group().sequence, 1);
+		sub.assert_not_closed();
 	}
 
 	/// A deliberate finish never lingers, even with a linger configured: a clean

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -4173,20 +4173,20 @@ mod tests {
 		drop(source);
 	}
 
-	/// A lingering broadcast with a live subscription must park, not spin.
+	/// A lingering broadcast with a live subscription parks, then resumes on the
+	/// reconnect.
 	///
 	/// An ungraceful loss empties the route table while the front waits out its
-	/// linger, so the route a track is spliced from is gone and no replacement can
-	/// serve it: the resweep. `serve_track` used to keep `serving_id` across it, so
-	/// the "route gone" edge re-fired on every poll, the wait returned Ready
-	/// immediately, and the loop ran hot for the whole linger. That burns a core per
-	/// subscribed track and starves the runtime that has to deliver the reconnect,
-	/// so a track written once (a catalog) never reaches the viewer again.
+	/// linger, so the route a track is spliced from is gone with no replacement to
+	/// serve it: the resweep. The task has to park for the whole window on the
+	/// strength of dropping the departed route, because nothing else bounds it. The
+	/// strike budget is gated on `!routes.is_empty()`, so an empty table never spends
+	/// one, and a "route gone" edge that keeps firing yields a wait that is Ready on
+	/// every poll: a full core per subscribed track, and the runtime that has to
+	/// deliver the reconnect starved along with it.
 	///
-	/// The empty table is what makes it unbounded: the strike budget is gated on
-	/// `!routes.is_empty()`, so the sweep at the top of the loop cannot spend one,
-	/// and every pass sees identical state. Under a paused clock the spin never
-	/// yields, so a regression hangs here rather than failing.
+	/// Under a paused clock that spin never yields, so a regression hangs here
+	/// rather than failing.
 	#[tokio::test(start_paused = true)]
 	async fn test_linger_parks_a_live_subscription() {
 		let origin = Info::new(Origin::random())
@@ -4218,6 +4218,12 @@ mod tests {
 		// spliced segment as ended: the departed route is the only edge left.
 		source.abort(Error::Dropped).unwrap();
 		settle().await;
+		settle().await;
+		sub.assert_not_closed();
+
+		// Most of the window with no source at all: the subscription stays parked
+		// rather than being cut, which is what the linger promises a reconnect.
+		tokio::time::sleep(Duration::from_secs(4)).await;
 		settle().await;
 		sub.assert_not_closed();
 

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -233,6 +233,17 @@ impl Producer {
 		Ok(())
 	}
 
+	/// Whether any segment is spliced in, and so whether there is anything for
+	/// [`Self::release`] to drop.
+	///
+	/// A segment outlives the route that produced it: the source can leave, or its
+	/// copy can die, while the segment stays spliced so readers keep what it already
+	/// delivered. That makes this, not the caller's own handle on the serving route,
+	/// the condition for arming an idle release.
+	pub(crate) fn is_spliced(&self) -> bool {
+		!self.state.read().segments.is_empty()
+	}
+
 	/// Mark the logical track as complete: no further switches. Subscribers see a
 	/// clean end once the final segment's track finishes.
 	pub fn finish(&mut self) -> Result<()> {


### PR DESCRIPTION
## Summary

Two fixes in `serve_track`, both from one conflation: the loop's handle on the route it serves from (`serving`) was also read as "does `resume` still own a spliced segment". A segment deliberately outlives the route that produced it, so those are different facts.

**1. Spin (`Step::Resweep`).** An ungraceful publisher loss empties `FrontState.routes` while the front waits out its linger, so a track spliced from that route has a `serving_id` no longer in the table and nothing to replace it with. The `kio::wait` predicate checks the source table first, which is Ready via `gone`; `serve_route` on an empty table is `None`, so it returns `Step::Resweep` before reaching the `poll_complete` check that would have cleared `serving`. The arm changed nothing, so the next poll saw the same stale id and returned Ready again. The strike budget can't bound it either: `exhausted` is gated on `!routes.is_empty()`, so an *empty* table never spends a strike. Every pass sees identical state.

Instrumented state at the trigger, from a relay-level repro: `serving=Some(0) complete=Some(true) routes=[] excluded=0 refused={} dead={} used=true`, 2.5M `Step::Resweep` iterations in one run. `sample` confirmed the process pegged inside `serve_track` -> `kio::wait` -> `is_used`/`serve_route`/`prefer_untainted` with no park.

Cost: a core per subscribed track for the linger window (`--cluster-linger`, 5s by default), with the runtime that has to deliver the reconnect starved alongside it.

**2. Stranded segment (idle release).** The idle countdown was armed from that same handle, so a departed route disabled it and `resume.release()` was never reached. The segment then survives until the front closes, pinning the dead source's cached groups for a linger that may never expire (`Duration::MAX` is supported), and leaving a dead edge behind for the next takeover to splice above. Now keyed off `resume::Producer::is_spliced()`, which is the actual condition for having something to release.

This one is **reachable on main today** through the `Step::Failed` arm, which has always cleared `serving` on a dead copy; verified by reproducing it with the resweep fix reverted. It is not fallout from fix 1, though fix 1 adds a third way in. Fixed here rather than split off because it is the same root shape in the same function, and the resweep path leads straight into it.

Found while investigating a report of viewers intermittently losing `catalog.json` after a publisher restart. Neither was caught earlier because the existing linger tests (`test_linger_forever`, `test_route_detach_immediate`) have no live track subscription, and on a multi-worker runtime one spinning task degrades rather than wedges.

### Not in scope

Review raised whether a same-identity reconnect that restarts its group numbering at 0 should also be rescued, since the boundary filters its first groups. It should not: a route that changes identity is already a replacement (unannounce + announce, fresh producer, no segments), and a source that keeps its identity is asserting the continuity that makes the boundary correct. Verified the replacement path holds today: the old subscription errors rather than stalling or splicing, and a fresh resolve delivers the new publisher's group 0.

## Public API changes

None. `serve_track` is private and `resume::Producer::is_spliced` is `pub(crate)`.

## Test plan

- `test_linger_parks_a_live_subscription`: linger + live subscription + `source.abort(Dropped)` with the track copy still alive (closes don't cascade, so no segment-ended edge), then most of the window advanced with no source before the reconnect.
- `test_idle_release_survives_the_route_leaving`: route dies, viewer leaves, clock advanced past `TRACK_IDLE_LINGER`. Asserts through the boundary a stranded segment would leave behind, since `resume` is private and delivery is what a viewer feels.
- Mutation-checked each fix independently: reverting the resweep clear TIMEOUTs both tests (under `start_paused` the spin starves the clock); reverting the `is_spliced` arming fails only the idle-release test.
- `cargo nextest run -p moq-net -p moq-relay -p moq-native`: 942/942 pass.
- `just rs loom`: 5/5 pass (model layer touched).
- `cargo fmt`, `cargo clippy --all-targets`, and `RUSTDOCFLAGS=-D warnings cargo doc` clean via the nix dev shell.

## Cross-package sync

No rows apply: no wire format, catalog, config, or CLI surface change.

(Written by Opus 5)