### PR TITLE
docs(doc): document moq-video and moq-audio

### DIFF
--- a/doc/.vitepress/config.ts
+++ b/doc/.vitepress/config.ts
@@ -187,6 +187,8 @@ export default defineConfig({
 										{ text: "moq-native", link: "/lib/rs/crate/moq-native" },
 										{ text: "moq-token", link: "/lib/rs/crate/moq-token" },
 										{ text: "hang", link: "/lib/rs/crate/hang" },
+										{ text: "moq-video", link: "/lib/rs/crate/moq-video" },
+										{ text: "moq-audio", link: "/lib/rs/crate/moq-audio" },
 										{ text: "web-transport", link: "/lib/rs/crate/web-transport" },
 										{ text: "libmoq", link: "/lib/rs/crate/libmoq" },
 									],

--- a/doc/lib/rs/crate/index.md
+++ b/doc/lib/rs/crate/index.md
@@ -15,4 +15,6 @@ Rust crates providing the MoQ protocol implementation and related tooling.
 | [hang](./hang) | Media encoding/streaming (catalog, container) |
 | [web-transport](./web-transport) | WebTransport protocol support |
 | [moq-mux](./moq-mux) | Media muxers/demuxers (fMP4, CMAF, MPEG-TS, FLV) |
+| [moq-video](./moq-video) | Native video capture, codecs, and GPU rendering |
+| [moq-audio](./moq-audio) | Native audio capture, codecs, playback, and echo cancellation |
 | [libmoq](./libmoq) | C FFI bindings |

--- a/doc/lib/rs/crate/moq-audio.md
+++ b/doc/lib/rs/crate/moq-audio.md
@@ -1,0 +1,151 @@
+---
+title: moq-audio
+description: Native audio capture, encoding, decoding, playback, and echo cancellation for MoQ
+---
+
+# moq-audio
+
+[![crates.io](https://img.shields.io/crates/v/moq-audio)](https://crates.io/crates/moq-audio)
+[![docs.rs](https://docs.rs/moq-audio/badge.svg)](https://docs.rs/moq-audio)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/moq-dev/moq/blob/main/LICENSE-MIT)
+
+The native audio stack, and the counterpart to
+[moq-video](/lib/rs/crate/moq-video): a microphone in, a
+[hang](/lib/rs/crate/hang) track out, and a speaker at the far end.
+
+## Overview
+
+| Module | Does | Feature |
+| --- | --- | --- |
+| `capture` | Microphone (CoreAudio / WASAPI / ALSA) or macOS system audio | `capture` |
+| `encode` | PCM to Opus or PCM, published through `moq-mux` | always |
+| `decode` | A subscribed track back to PCM | always |
+| `playback` | PCM out a speaker, mixing every track into one device stream | `playback` |
+| `aec` | Subtract what the speaker plays from what the microphone hears | `aec` |
+
+Everything is pure Rust. Opus is `unsafe-libopus`, devices are `cpal`, resampling
+is `rubato`, and echo cancellation is [`sonora`](https://crates.io/crates/sonora),
+a port of WebRTC's audio processing. There is no C toolchain, CMake step, or
+system codec anywhere in the graph.
+
+`Frame` is a timestamp and a payload. Layout lives on the producer or consumer
+(`encode::Input` / `decode::Config`) rather than on each frame, so you cannot
+drift between calls, and `Format` mirrors the WebCodecs `AudioData.format` values
+with conversions to the interleaved `f32` that the codecs want.
+
+## Installation
+
+Device I/O is off by default, so a service that only encodes or relays pulls in
+neither `cpal` nor (on Linux) the ALSA build dependency:
+
+```bash
+cargo add moq-audio --features capture,playback,aec
+```
+
+`aec` implies both `capture` and `playback`, since the canceller taps the output
+mix as its reference.
+
+## Publishing
+
+`encode::publish_capture` advertises the track and catalog up front and opens the
+microphone only while somebody is listening:
+
+```rust
+use moq_audio::{capture, encode};
+
+let config = capture::Config::default();
+
+encode::publish_capture(
+    broadcast,
+    catalog,
+    config,
+    encode::Options::default(),
+    clock,
+).await?;
+```
+
+`encode::Producer` takes PCM you supply instead. Either way the codec is
+`encode::Codec`: Opus (the default) or uncompressed PCM, which trades bandwidth
+for the lowest possible latency and no codec delay.
+
+## Subscribing and playback
+
+`decode::Consumer` reads the catalog entry to pick a decoder and resamples to
+whatever rate you ask for. `playback::Engine` owns the output device, and each
+`playback::Sink` is one stream mixed into it:
+
+```rust
+use moq_audio::playback;
+
+let engine = playback::Engine::open(playback::Config::default()).await?;
+let mut sink = engine.sink(playback::Input {
+    sample_rate: audio.sample_rate(),
+    channels: audio.channels(),
+    ..Default::default()
+})?;
+
+while let Some(frame) = audio.read().await? {
+    sink.write(&frame.data)?;
+}
+```
+
+That split is deliberate: a call with several participants mixes into one device
+stream instead of opening one per speaker, which is what the device wants and what
+echo cancellation needs a single reference from.
+
+The device is not your problem. Opening it, renegotiating its format, resampling
+to its rate, and reopening it after it disappears all happen on a driver thread
+behind the `Engine`. A `Sink` keeps taking writes throughout and its samples land
+wherever the device currently is. Volume changes ramp over a few milliseconds, so
+there is no click on mute; `set_volume(0.0)` is the pause.
+
+`Sink::buffered()` reports how much audio sits between your last write and the
+hardware callback. That is the pacing signal an A/V sync clock steers by: audio
+plays at exactly the device's rate, so video follows it rather than the other way
+around.
+
+## Echo cancellation
+
+Without it, anyone on a laptop with no headset sends the call back to itself. A
+`Canceller` comes from the `Engine` doing the playing, because cancelling an echo
+means knowing what was played, and goes into the capture config so the microphone
+you publish is already clean:
+
+```rust
+use moq_audio::{aec, capture, playback};
+
+let engine = playback::Engine::open(playback::Config::default()).await?;
+
+let mut capture = capture::Config::default();
+capture.aec = Some(engine.canceller(aec::Config::default()));
+```
+
+One canceller belongs to one microphone: it holds the adaptive filter modelling
+the path from that speaker to that microphone. Clones share it, so clone for a
+mute button on a UI thread, not to run a second capture.
+
+The work runs in the microphone callback on 10 ms frames, which is where the up-to
+10 ms of added capture latency comes from. Both the reference and the microphone
+are processed there, in that order, because that is the ordering the echo model
+needs. It applies to microphones only: macOS system audio is already the output,
+so there is nothing to subtract from it.
+
+## Devices
+
+```rust
+moq_audio::capture::devices().await?;   // inputs
+moq_audio::playback::devices().await?;  // outputs
+```
+
+Both hand back ids that go straight into `capture::Config::source` and
+`playback::Config::device`; `None` opens the system default.
+
+## API Reference
+
+Full API documentation: [docs.rs/moq-audio](https://docs.rs/moq-audio)
+
+## Next Steps
+
+- Pair it with [moq-video](/lib/rs/crate/moq-video) for the other half of a call
+- Publish through [hang](/lib/rs/crate/hang) catalogs and [moq-mux](/lib/rs/crate/moq-mux) containers
+- Capture and publish from the command line with [moq-cli](/bin/cli)

--- a/doc/lib/rs/crate/moq-audio.md
+++ b/doc/lib/rs/crate/moq-audio.md
@@ -23,10 +23,16 @@ The native audio stack, and the counterpart to
 | `playback` | PCM out a speaker, mixing every track into one device stream | `playback` |
 | `aec` | Subtract what the speaker plays from what the microphone hears | `aec` |
 
-Everything is pure Rust. Opus is `unsafe-libopus`, devices are `cpal`, resampling
-is `rubato`, and echo cancellation is [`sonora`](https://crates.io/crates/sonora),
-a port of WebRTC's audio processing. There is no C toolchain, CMake step, or
-system codec anywhere in the graph.
+The codecs and DSP are Rust, all the way down. Opus is `unsafe-libopus` (libopus
+transpiled, not wrapped), resampling is `rubato`, echo cancellation is
+[`sonora`](https://crates.io/crates/sonora), a port of WebRTC's audio processing,
+and devices go through `cpal`. So there is no C toolchain, no CMake step, and no
+codec to install on the host.
+
+The one system dependency is the platform's audio API, and only when you enable
+`capture` or `playback`: CoreAudio and WASAPI ship with the OS, but a Linux build
+needs the ALSA development headers (`libasound2-dev` or your distro's equivalent)
+for cpal to link. A default build has neither feature and needs nothing.
 
 `Frame` is a timestamp and a payload. Layout lives on the producer or consumer
 (`encode::Input` / `decode::Config`) rather than on each frame, so you cannot
@@ -75,7 +81,10 @@ whatever rate you ask for. `playback::Engine` owns the output device, and each
 `playback::Sink` is one stream mixed into it:
 
 ```rust
-use moq_audio::playback;
+use moq_audio::{decode, playback};
+
+// `rendition` is the hang catalog's AudioConfig for the track you want.
+let mut audio = decode::Consumer::new(&broadcast, &rendition, "audio", decode::Config::default()).await?;
 
 let engine = playback::Engine::open(playback::Config::default()).await?;
 let mut sink = engine.sink(playback::Input {

--- a/doc/lib/rs/crate/moq-video.md
+++ b/doc/lib/rs/crate/moq-video.md
@@ -1,0 +1,180 @@
+---
+title: moq-video
+description: Native video capture, encoding, decoding, and GPU rendering for MoQ
+---
+
+# moq-video
+
+[![crates.io](https://img.shields.io/crates/v/moq-video)](https://crates.io/crates/moq-video)
+[![docs.rs](https://docs.rs/moq-video/badge.svg)](https://docs.rs/moq-video)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/moq-dev/moq/blob/main/LICENSE-MIT)
+
+The native video stack: grab pictures from a camera or a screen, encode them with
+a hardware codec, publish them as a [hang](/lib/rs/crate/hang) track, and do the
+same in reverse down to a texture on screen.
+
+This is what the browser gets from WebCodecs and `getUserMedia`. A native
+application has no such thing, so `moq-video` provides it: no ffmpeg, no GStreamer,
+just the platform APIs and a couple of pure-Rust fallbacks.
+
+## Overview
+
+Four role modules, symmetric on both ends of the wire:
+
+| Module | Does | Platform |
+| --- | --- | --- |
+| `capture` | Camera, display, window, or application frames | AVFoundation + ScreenCaptureKit (macOS), V4L2 + PipeWire (Linux), Media Foundation + DXGI (Windows) |
+| `encode` | Raw frames to H.264/H.265, published through `moq-mux` | VideoToolbox, Media Foundation, NVENC, VAAPI, openh264 |
+| `decode` | A subscribed track back to raw frames | VideoToolbox, Media Foundation/DXVA, NVDEC, openh264 |
+| `render` | A frame drawn on the GPU, handed back as a `wgpu` texture | wgpu, with a zero-copy Metal import on macOS |
+
+A picture is a `Frame` wherever it crosses the API: a `moq_net::Timestamp` and a
+`Surface` holding the pixels. Capture and decode produce them, encode and render
+consume them.
+
+Backend selection is automatic and degrading. Every hardware library is loaded at
+runtime (`dlopen`), so a binary built with NVENC still links and starts on a
+machine with no NVIDIA driver, falls through to the next encoder, and ends at the
+statically-linked openh264 software encoder. No public type, function, or error
+variant names a backend, so swapping one is never a breaking change for you.
+
+## Installation
+
+```bash
+cargo add moq-video
+```
+
+Hardware codecs are on by default. Rendering and PipeWire screen capture are not,
+since they pull in a graphics stack and a `libpipewire` build dependency
+respectively:
+
+```bash
+cargo add moq-video --features render,pipewire
+```
+
+| Feature | Default | Pulls in |
+| --- | --- | --- |
+| `nvenc` / `nvdec` | yes | NVIDIA encode/decode on Linux (`cudarc`, `moq-nvenc`) |
+| `vaapi` | yes | Intel/AMD encode on Linux (`moq-vaapi`) |
+| `render` | no | `wgpu` and the GPU renderer |
+| `pipewire` | no | Wayland/X11 screen capture via xdg-desktop-portal |
+
+The three default features are Linux-only in effect (their dependencies are), and
+`--no-default-features` gives a slim build that still captures V4L2 and encodes
+with openh264. A relay never needs any of them.
+
+## Publishing
+
+`encode::publish_capture` is the turnkey path: it advertises the track and catalog
+up front, then opens the camera only while somebody is watching and releases it
+when the last subscriber leaves.
+
+```rust
+use moq_video::{capture, encode};
+
+// Defaults to the default camera; pick a specific one by id.
+let mut config = capture::Config::default();
+if let Some(camera) = capture::cameras().await?.first() {
+    config.source = camera.source();
+}
+
+encode::publish_capture(
+    broadcast,
+    catalog,
+    config,
+    encode::Options::default(),
+    clock,
+).await?;
+```
+
+To encode frames you produced yourself (from a decoder, a game engine, or your own
+pixels), drive `encode::Encoder` and publish the results with `encode::Producer`.
+Keyframes are the encoder's business: it inserts them per `encode::Config::gop`,
+and `Encoder::keyframe` is there for the rarer case where you need one at a
+specific frame.
+
+## Subscribing
+
+`decode::Consumer` is the mirror. It reads the rendition's catalog entry to pick a
+decoder, then hands back one `Frame` per call:
+
+```rust
+use moq_video::decode;
+
+// `rendition` is the hang catalog's VideoConfig for the track you want.
+let mut video = decode::Consumer::new(&broadcast, &rendition, "video", decode::Config::default()).await?;
+
+while let Some(frame) = video.read().await? {
+    // frame.timestamp, frame.surface
+}
+```
+
+## Zero-copy
+
+A hardware-decoded frame stays on the GPU. `Surface` is a `#[non_exhaustive]` enum
+naming what actually holds the pixels: a `CVPixelBuffer` on macOS, a Direct3D 11
+texture on Windows, CUDA memory on Linux, or plain I420 anywhere.
+
+That matters for two paths that would otherwise pay for a round trip through
+system memory on every frame:
+
+- **Transcode.** A decoded NVDEC frame feeds NVENC without leaving the GPU, and
+  `decode::Config::resize` scales it there too.
+- **Playback.** The `render` module imports the decoder's surface as a texture
+  rather than copying it, converting YUV to RGB in a shader.
+
+Matching on `Surface` stays portable because every variant has a universal
+fallback in `Surface::into_i420()`: take the fast path you recognize and let the
+`_` arm download. The renderer does exactly this, and an import path that keeps
+failing retires itself after a few frames instead of paying for the attempt
+forever.
+
+## Rendering
+
+`render::Renderer` takes a `wgpu` device and queue and hands back a
+`wgpu::Texture` per frame. That texture is the entire integration seam: present
+it to a window, feed it to egui or bevy, or copy it back. The module carries no
+windowing or UI dependency and never picks a surface format for you.
+
+```rust
+use moq_video::render::{Config, Renderer};
+
+let mut renderer = Renderer::new(&device, &queue, Config::new())?;
+
+while let Some(frame) = video.read().await? {
+    let texture = renderer.render(&frame)?;
+    // ... present it ...
+}
+```
+
+The `wgpu` version this was built against is re-exported as
+`moq_video::render::wgpu`, so you name the exact version rather than guessing at
+a compatible one.
+
+Color is carried end to end rather than assumed: `Color` names the matrix and
+range (BT.601 or BT.709, limited or full), capture labels what it produced, and
+the shader converts accordingly.
+
+## Devices
+
+Each enumerator returns ids that go straight back into `capture::Config::source`:
+
+```rust
+moq_video::capture::cameras().await?;   // webcams
+moq_video::capture::displays().await?;  // monitors
+moq_video::capture::windows().await?;   // single windows (macOS)
+moq_video::capture::apps().await?;      // every window of an app (macOS)
+```
+
+The [`moq devices`](/bin/cli) subcommand prints the same lists from the command
+line.
+
+## API Reference
+
+Full API documentation: [docs.rs/moq-video](https://docs.rs/moq-video)
+
+## Next Steps
+
+- Pair it with [moq-audio](/lib/rs/crate/moq-audio) for the other half of a call
+- Publish through [hang](/lib/rs/crate/hang) catalogs and [moq-mux](/lib/rs/crate/moq-mux) containers
+- Capture and publish from the command line with [moq-cli](/bin/cli)

--- a/doc/lib/rs/crate/moq-video.md
+++ b/doc/lib/rs/crate/moq-video.md
@@ -14,8 +14,10 @@ a hardware codec, publish them as a [hang](/lib/rs/crate/hang) track, and do the
 same in reverse down to a texture on screen.
 
 This is what the browser gets from WebCodecs and `getUserMedia`. A native
-application has no such thing, so `moq-video` provides it: no ffmpeg, no GStreamer,
-just the platform APIs and a couple of pure-Rust fallbacks.
+application has no such thing, so `moq-video` provides it: no ffmpeg, no
+GStreamer, no system codec to install. Just the platform APIs, plus a vendored
+statically-linked openh264 so a build never depends on what the host happens to
+have.
 
 ## Overview
 
@@ -32,11 +34,17 @@ A picture is a `Frame` wherever it crosses the API: a `moq_net::Timestamp` and a
 `Surface` holding the pixels. Capture and decode produce them, encode and render
 consume them.
 
-Backend selection is automatic and degrading. Every hardware library is loaded at
-runtime (`dlopen`), so a binary built with NVENC still links and starts on a
-machine with no NVIDIA driver, falls through to the next encoder, and ends at the
-statically-linked openh264 software encoder. No public type, function, or error
-variant names a backend, so swapping one is never a breaking change for you.
+Backend selection is automatic and ordered: platform hardware first, then the
+software fallback. The Linux hardware libraries are loaded at runtime (`dlopen`),
+so a binary built with NVENC still links on a GPU-less builder and starts on a
+machine with no NVIDIA driver, falling through to the next backend instead of
+failing to load. No public type, function, or error variant names a backend, so
+swapping one is never a breaking change for you.
+
+**openh264 is the fallback for H.264 only.** It is statically linked and always
+compiled in, so H.264 encodes and decodes on any machine. H.265 is hardware-only:
+with no usable platform backend you get `NoEncoder` / `NoDecoder` rather than a
+slow path. AV1 is decode-only, via NVDEC.
 
 ## Installation
 
@@ -111,23 +119,33 @@ while let Some(frame) = video.read().await? {
 
 ## Zero-copy
 
-A hardware-decoded frame stays on the GPU. `Surface` is a `#[non_exhaustive]` enum
-naming what actually holds the pixels: a `CVPixelBuffer` on macOS, a Direct3D 11
-texture on Windows, CUDA memory on Linux, or plain I420 anywhere.
+`Surface` is a `#[non_exhaustive]` enum naming what actually holds a frame's
+pixels: a `CVPixelBuffer` on macOS, a Direct3D 11 texture on Windows, CUDA memory
+on Linux, or plain I420 anywhere. Keeping a decoded frame in the first three
+avoids a round trip through system memory on every frame.
 
-That matters for two paths that would otherwise pay for a round trip through
-system memory on every frame:
+How far that gets today depends on the platform, so here is the honest matrix
+rather than a blanket promise:
 
-- **Transcode.** A decoded NVDEC frame feeds NVENC without leaving the GPU, and
-  `decode::Config::resize` scales it there too.
-- **Playback.** The `render` module imports the decoder's surface as a texture
-  rather than copying it, converting YUV to RGB in a shader.
+| Platform | Decode output | Zero-copy transcode | Zero-copy render |
+| --- | --- | --- | --- |
+| macOS | `PixelBuffer` (VideoToolbox) | yes | yes, via `CVMetalTextureCache` |
+| Linux | `Cuda` (NVDEC) | yes, straight into NVENC | no, downloaded to I420 first |
+| Windows | `I420` (Media Foundation downloads its DXVA texture) | no | no |
+
+So the transcode path is real on macOS and Linux: a decoded frame feeds the
+encoder without leaving the GPU, and `decode::Config::resize` scales it there too.
+Rendering is zero-copy on macOS only. The Vulkan and EGL importers that would
+extend it to Linux, and the Media Foundation decode-surface retention that would
+give Windows a GPU frame at all, are both tracked in
+[#2481](https://github.com/moq-dev/moq/issues/2481).
 
 Matching on `Surface` stays portable because every variant has a universal
 fallback in `Surface::into_i420()`: take the fast path you recognize and let the
 `_` arm download. The renderer does exactly this, and an import path that keeps
 failing retires itself after a few frames instead of paying for the attempt
-forever.
+forever. Set `render::Config::zero_copy` to `false` to force the download path
+when comparing output or working around a driver.
 
 ## Rendering
 
@@ -151,9 +169,17 @@ The `wgpu` version this was built against is re-exported as
 `moq_video::render::wgpu`, so you name the exact version rather than guessing at
 a compatible one.
 
-Color is carried end to end rather than assumed: `Color` names the matrix and
-range (BT.601 or BT.709, limited or full), capture labels what it produced, and
-the shader converts accordingly.
+`Color` names the matrix and range (BT.601 or BT.709, limited or full), and the
+shader converts per frame rather than assuming one space. A capture labels what it
+produced, so a locally captured frame renders correctly with no help from you.
+
+A decoded frame is the case to watch. The authoritative answer lives in the
+bitstream's VUI and does not survive decoding, and a Windows or CUDA surface
+carries no color metadata at all, so the renderer falls back to inferring from
+resolution (BT.601 at 576 lines or fewer, BT.709 above). That is a good guess, not
+a correct one: full-range content, or an unusual resolution, will render with the
+wrong range or matrix. Set `render::Config::color` when you know the stream's
+color space and the frame does not.
 
 ## Devices
 

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -72,10 +72,10 @@ GPU rendering of decoded frames.
 
 **Features:**
 
-- VideoToolbox, Media Foundation, NVENC/NVDEC, VAAPI, openh264 fallback
-- Decoded frames stay on the GPU (transcode and render without a round trip)
-- `wgpu` renderer handing back a texture you present
-- Every hardware library `dlopen`'d, so a build degrades instead of failing
+- VideoToolbox, Media Foundation, NVENC/NVDEC, VAAPI, with openh264 as the H.264 software fallback
+- Decoded frames stay on the GPU where the platform allows, so transcoding skips the round trip
+- `wgpu` renderer handing back a texture you present, importing the decoder's surface zero-copy on macOS
+- Linux hardware libraries `dlopen`'d, so a build links and starts without a GPU
 
 [Learn more](/lib/rs/crate/moq-video)
 

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -56,6 +56,46 @@ Media muxers and demuxers for importing existing formats into MoQ.
 
 [Learn more](/lib/rs/crate/moq-mux)
 
+## Native Media
+
+What a browser gets from WebCodecs and `getUserMedia`, for native applications:
+devices, hardware codecs, and the playback path back out. No ffmpeg, no
+GStreamer.
+
+### moq-video
+
+[![crates.io](https://img.shields.io/crates/v/moq-video)](https://crates.io/crates/moq-video)
+[![docs.rs](https://docs.rs/moq-video/badge.svg)](https://docs.rs/moq-video)
+
+Camera, display, and window capture, hardware H.264/H.265 encode and decode, and
+GPU rendering of decoded frames.
+
+**Features:**
+
+- VideoToolbox, Media Foundation, NVENC/NVDEC, VAAPI, openh264 fallback
+- Decoded frames stay on the GPU (transcode and render without a round trip)
+- `wgpu` renderer handing back a texture you present
+- Every hardware library `dlopen`'d, so a build degrades instead of failing
+
+[Learn more](/lib/rs/crate/moq-video)
+
+### moq-audio
+
+[![crates.io](https://img.shields.io/crates/v/moq-audio)](https://crates.io/crates/moq-audio)
+[![docs.rs](https://docs.rs/moq-audio/badge.svg)](https://docs.rs/moq-audio)
+
+Microphone and system-audio capture, Opus and PCM codecs, speaker playback, and
+acoustic echo cancellation.
+
+**Features:**
+
+- CoreAudio / WASAPI / ALSA devices via cpal
+- One output device mixing every track in a call
+- Echo cancellation so a laptop without a headset doesn't send itself back
+- Pure Rust throughout: no C toolchain, no CMake, no system codec
+
+[Learn more](/lib/rs/crate/moq-audio)
+
 ## Authentication
 
 ### moq-token
@@ -266,6 +306,8 @@ Full API documentation is available on [docs.rs](https://docs.rs):
 - [moq-net API](https://docs.rs/moq-net)
 - [hang API](https://docs.rs/hang)
 - [moq-mux API](https://docs.rs/moq-mux)
+- [moq-video API](https://docs.rs/moq-video)
+- [moq-audio API](https://docs.rs/moq-audio)
 - [moq-token API](https://docs.rs/moq-token)
 - [moq-native API](https://docs.rs/moq-native)
 - [libmoq API](https://docs.rs/libmoq)
@@ -275,5 +317,6 @@ Full API documentation is available on [docs.rs](https://docs.rs):
 - Explore [moq-net](/lib/rs/crate/moq-net) - Networking layer
 - Explore [hang](/lib/rs/crate/hang) - Media library
 - Explore [moq-mux](/lib/rs/crate/moq-mux) - Media import
+- Explore [moq-video](/lib/rs/crate/moq-video) and [moq-audio](/lib/rs/crate/moq-audio) - Native capture, codecs, and playback
 - Deploy [moq-relay](/bin/relay/) - Relay server
 - View [code examples](https://github.com/moq-dev/moq/tree/main/rs)

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -84,15 +84,15 @@ GPU rendering of decoded frames.
 [![crates.io](https://img.shields.io/crates/v/moq-audio)](https://crates.io/crates/moq-audio)
 [![docs.rs](https://docs.rs/moq-audio/badge.svg)](https://docs.rs/moq-audio)
 
-Microphone and system-audio capture, Opus and PCM codecs, speaker playback, and
-acoustic echo cancellation.
+Microphone and macOS system-audio capture, Opus and PCM codecs, speaker playback,
+and acoustic echo cancellation.
 
 **Features:**
 
 - CoreAudio / WASAPI / ALSA devices via cpal
 - One output device mixing every track in a call
 - Echo cancellation so a laptop without a headset doesn't send itself back
-- Pure Rust throughout: no C toolchain, no CMake, no system codec
+- Rust codecs and DSP: no C toolchain, no CMake, no codec to install (ALSA headers are the one Linux build dependency)
 
 [Learn more](/lib/rs/crate/moq-audio)
 


### PR DESCRIPTION
## Summary

- Neither `moq-video` nor `moq-audio` had a documentation page, so the renderer (#2552), playback (#2529), and echo cancellation (#2538) that landed over the last two weeks are undiscoverable outside docs.rs. This is the last non-hardware item on the #2481 adoption gate: iroh-live's users need to find this stack before they delete theirs.
- Each page covers the whole crate rather than appending a section, since there was nothing to append to: the role modules, the feature flags and what pulling each one in costs, the backend set and the dlopen-and-degrade rule, plus short examples for publish, subscribe, render, playback, and AEC.
- `moq-video` documents the zero-copy story as a per-platform matrix rather than a blanket claim: macOS decodes to a `PixelBuffer` and both transcodes and renders zero-copy, Linux transcodes NVDEC straight into NVENC but downloads for render, and the Media Foundation decoder downloads its DXVA texture today. The gaps point at #2481. Also covers `Surface::into_i420()` as the universal fallback and the `wgpu::Texture` integration seam.
- Capability claims are scoped to what actually ships: openh264 is the fallback for H.264 only (H.265 returns `NoEncoder`/`NoDecoder` with no usable hardware backend), `dlopen` applies to the Linux backends, and the renderer infers color from resolution when a surface carries none, since VUI does not survive decoding.
- `moq-audio` documents the `Engine`/`Sink` split, `Sink::buffered()` as the A/V pacing signal, and the AEC wiring (`Engine::canceller` -> `capture::Config::aec`) with its 10 ms cost and microphone-only scope.
- Registered both pages in the VitePress sidebar, the crate index table, and the Rust libraries landing page under a new \"Native Media\" section.

## Public API changes

None. Documentation only; no crate touched.

## Cross-package sync

No rows apply: nothing under `rs/` changed, so there is no paired package or draft to update. This PR *is* the `doc/` half of the #2481 gate for work that already landed.

## Test plan

- `bun run check` in `doc/` (tsc + VitePress build, which fails the build on dead links) passes.
- `bun remark doc --quiet --frail` passes.
- `bun biome check doc/.vitepress/config.ts` passes.
- A `/codex:adversarial-review` pass challenged the capability claims; all three findings were verified against the backend registrations and the renderer's import path, and the prose was corrected in a follow-up commit.
- Every example was written against the current source rather than the issue's description of it; two drafts that would not have typechecked were corrected (`capture::Config::source` is a `Source`, not an `Option<Source>`, and `decode::Consumer::new` takes the rendition's `VideoConfig`, not the catalog producer).

Refs #2481

(Written by Opus 5)

