### PR TITLE
refactor(net)!: carry subscription bounds as positions

### DIFF
--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -229,10 +229,10 @@ impl From<&moq_subscription> for moq_net::track::Subscription {
 			.with_ordered(subscription.ordered)
 			.with_latency_max(std::time::Duration::from_millis(subscription.latency_max_ms));
 		if subscription.group_start_valid {
-			out = out.with_group_start(subscription.group_start);
+			out = out.with_start(moq_net::track::Position::group(subscription.group_start));
 		}
 		if subscription.group_end_valid {
-			out = out.with_group_end(subscription.group_end);
+			out = out.with_end(moq_net::track::Position::after_group(subscription.group_end));
 		}
 		out
 	}

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -546,10 +546,7 @@ impl Consume {
 		// very first position is the empty range, which no inclusive group can express;
 		// leaving it uncapped would serve everything, so cap at the first group and let
 		// the empty demand stop delivery upstream.
-		track.end_at(match subscription.end {
-			Some(end) => Some(end.before().map_or(0, |end| end.group)),
-			None => None,
-		});
+		track.end_at(subscription.end.map(|end| end.before().map_or(0, |end| end.group)));
 		// A closed track makes the update meaningless; the reader already sees the close.
 		let _ = track.update(subscription);
 	}

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -539,10 +539,11 @@ impl Consume {
 		subscription: Option<moq_net::track::Subscription>,
 	) {
 		let subscription = subscription.unwrap_or_default();
-		if let Some(start) = subscription.group_start.or_else(|| track.latest()) {
+		if let Some(start) = subscription.start.map(|start| start.group).or_else(|| track.latest()) {
 			track.start_at(start);
 		}
-		track.end_at(subscription.group_end);
+		// The read cursor is a group sequence, and its cap is inclusive.
+		track.end_at(subscription.end.map(|end| end.before().group));
 		// A closed track makes the update meaningless; the reader already sees the close.
 		let _ = track.update(subscription);
 	}

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -542,8 +542,14 @@ impl Consume {
 		if let Some(start) = subscription.start.map(|start| start.group).or_else(|| track.latest()) {
 			track.start_at(start);
 		}
-		// The read cursor is a group sequence, and its cap is inclusive.
-		track.end_at(subscription.end.map(|end| end.before().group));
+		// The read cursor is a group sequence, and its cap is inclusive. An end at the
+		// very first position is the empty range, which no inclusive group can express;
+		// leaving it uncapped would serve everything, so cap at the first group and let
+		// the empty demand stop delivery upstream.
+		track.end_at(match subscription.end {
+			Some(end) => Some(end.before().map_or(0, |end| end.group)),
+			None => None,
+		});
 		// A closed track makes the update meaningless; the reader already sees the close.
 		let _ = track.update(subscription);
 	}

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -72,8 +72,8 @@ impl From<MoqSubscription> for moq_net::track::Subscription {
 			.with_priority(s.priority)
 			.with_ordered(s.ordered)
 			.with_latency_max(std::time::Duration::from_millis(s.latency_max_ms))
-			.with_group_start(s.group_start)
-			.with_group_end(s.group_end)
+			.with_start(s.group_start.map(moq_net::track::Position::group))
+			.with_end(s.group_end.map(moq_net::track::Position::after_group))
 	}
 }
 

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -73,7 +73,7 @@ impl From<MoqSubscription> for moq_net::track::Subscription {
 			.with_ordered(s.ordered)
 			.with_latency_max(std::time::Duration::from_millis(s.latency_max_ms))
 			.with_start(s.group_start.map(moq_net::track::Position::group))
-			.with_end(s.group_end.map(moq_net::track::Position::after_group))
+			.with_end(s.group_end.and_then(moq_net::track::Position::after_group))
 	}
 }
 

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -924,11 +924,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			priority: subscribe.priority,
 			ordered: subscribe.ordered,
 			latency_max: subscribe.max_latency,
-			group_start: subscribe.start_group,
-			group_end: subscribe.end_group,
-			frame_start: subscribe.start_frame,
-			frame_end: subscribe.end_frame,
-			..Default::default()
+			..Bounds::from(subscribe).positions()
 		};
 
 		// Awaits the dynamic fallback if the broadcast wasn't announced; resolves
@@ -1909,6 +1905,29 @@ struct Bounds {
 }
 
 impl Bounds {
+	/// The requested range as the model's half-open pair of [`track::Position`]s.
+	///
+	/// The wire carries the two halves of each bound separately and both ends
+	/// inclusive; the model carries whole positions with an exclusive end. The
+	/// [`Subscription`] builders own that conversion, so this goes through them
+	/// rather than repeating it.
+	fn positions(&self) -> crate::track::Subscription {
+		let mut sub = crate::track::Subscription::default();
+		if let Some(group) = self.start_group {
+			sub = sub.with_start(track::Position {
+				group,
+				frame: self.start_frame,
+			});
+		}
+		if let Some(group) = self.end_group {
+			sub = sub.with_end(match self.end_frame {
+				Some(frame) => track::Position::after(group, frame),
+				None => track::Position::after_group(group),
+			});
+		}
+		sub
+	}
+
 	/// The group to apply a frame offset to and the offset itself, or `None` when
 	/// delivery starts on a group boundary.
 	fn start_frame(&self) -> Option<(u64, u64)> {
@@ -2090,21 +2109,17 @@ impl<S: web_transport_trait::Session> Subscription<S> {
 					}
 					// Feed the full update into the model subscriber so the producer's
 					// aggregate reflects it (and a relay re-forwards it upstream).
+					let bounds = Bounds::from(&upd);
 					let _ = track.update(crate::track::Subscription {
 						priority: upd.priority,
 						ordered: upd.ordered,
 						latency_max: upd.max_latency,
-						group_start: upd.start_group,
-						group_end: upd.end_group,
-						frame_start: upd.start_frame,
-						frame_end: upd.end_frame,
-						..Default::default()
+						..bounds.positions()
 					});
 					if let Some(start_group) = upd.start_group {
 						track.start_at(start_group);
 					}
 					track.end_at(upd.end_group);
-					let bounds = Bounds::from(&upd);
 					start_frame = bounds.start_frame();
 					end_frame = bounds.end_frame();
 				}
@@ -2357,6 +2372,48 @@ mod serve_group_test {
 	use super::*;
 	use crate::lite::test_transport::*;
 	use crate::{Timestamp, broadcast};
+
+	/// The wire's inclusive pair maps to the model's exclusive end.
+	///
+	/// The inverse of the subscriber's `WireBounds`, and the same off-by-one risk: a
+	/// whole end group becomes the head of the next one, a capped frame becomes the head
+	/// of the frame above it.
+	#[test]
+	fn bounds_convert_to_positions() {
+		let whole = Bounds {
+			start_group: None,
+			start_frame: 0,
+			end_group: Some(5),
+			end_frame: None,
+		};
+		assert_eq!(whole.positions().end, Some(track::Position::group(6)));
+
+		let capped = Bounds {
+			end_frame: Some(2),
+			..whole
+		};
+		assert_eq!(capped.positions().end, Some(track::Position { group: 5, frame: 3 }));
+
+		let started = Bounds {
+			start_group: Some(5),
+			start_frame: 3,
+			end_group: None,
+			end_frame: None,
+		};
+		let positions = started.positions();
+		assert_eq!(positions.start, Some(track::Position { group: 5, frame: 3 }));
+		assert_eq!(positions.end, None);
+
+		// A frame bound the peer sent without its group has nothing to count from, so it
+		// cannot reach the model at all.
+		let orphan = Bounds {
+			start_group: None,
+			start_frame: 3,
+			end_group: None,
+			end_frame: Some(7),
+		};
+		assert_eq!((orphan.positions().start, orphan.positions().end), (None, None));
+	}
 
 	/// A group whose head the publisher no longer holds is skipped, not served short:
 	/// only a subscriber that asked for a partial group may receive one.

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -14,7 +14,7 @@ use crate::{
 	AsPath, Error, Path, PathOwned, Timescale, Timestamp, bandwidth,
 	coding::{Decode, Reader, Stream},
 	lite,
-	track::Subscription,
+	track::{Position, Subscription},
 };
 
 use super::{ConnectingProducer, RouteCost, Version};
@@ -1017,7 +1017,9 @@ mod tests {
 
 	/// The `(group, frame)` bounds `resume::slice` produces after a mid-group takeover.
 	fn mid_group_demand() -> Subscription {
-		Subscription::default().with_start(5, 3).with_end(5, 2)
+		Subscription::default()
+			.with_start(Position { group: 5, frame: 3 })
+			.with_end(Position::after(5, 2))
 	}
 
 	/// A mid-group resume boundary handed to a peer that predates lite-06 is widened to
@@ -1083,42 +1085,46 @@ mod tests {
 		assert_eq!((msg.start_frame, msg.end_frame), (3, Some(2)));
 	}
 
-	/// A frame index never reaches the wire without the group it counts from.
+	/// The model's exclusive end maps back to the wire's inclusive pair.
 	///
-	/// [`Subscription::with_start`] pairs the two, so the builder cannot express this.
-	/// The fields are still `pub`, so assigning one alone can; the encode path reads the
-	/// pair through `Subscription::start`, which drops a frame with no group rather than
-	/// emitting one the peer must reject as `InvalidSubscribeLocation`.
-	#[tokio::test]
-	async fn a_frame_bound_without_its_group_is_dropped() {
-		let mut h = Harness::new(Version::Lite06Wip);
-		let mut sub = Sub::None;
+	/// The two disagree deliberately (see [`Subscription::end`]), so this pins the seam:
+	/// an end at the head of a group means the group below it, served whole, while one
+	/// mid-group caps the frame below it. Off by one here would silently drop or
+	/// duplicate a frame at every relay hop.
+	#[test]
+	fn wire_bounds_convert_the_exclusive_end() {
+		// The whole of group 5 is the head of group 6.
+		let bounds = WireBounds::new(None, Some(Position::group(6)));
+		assert_eq!((bounds.end_group, bounds.end_frame), (Some(5), None));
 
-		// Deliberately built by field rather than by builder: `with_start` and `with_end`
-		// are exactly what makes this unreachable through the intended surface.
-		let demand = Subscription {
-			frame_start: 3,
-			frame_end: Some(7),
-			..Default::default()
-		};
+		// Group 5 through frame 2 is the head of frame 3.
+		let bounds = WireBounds::new(None, Some(Position { group: 5, frame: 3 }));
+		assert_eq!((bounds.end_group, bounds.end_frame), (Some(5), Some(2)));
 
-		h.serve
-			.handle_subscription(
-				&mut h.producer,
-				&mut sub,
-				Some(demand),
-				true,
-				Some(Timescale::default()),
-			)
-			.await
-			.unwrap();
+		// Unbounded stays unbounded.
+		let bounds = WireBounds::new(None, None);
+		assert_eq!((bounds.end_group, bounds.end_frame), (None, None));
 
-		let wire = h.wire();
-		let mut wire = wire.as_slice();
-		lite::ControlType::decode(&mut wire, Version::Lite06Wip).unwrap();
-		let msg = lite::Subscribe::decode(&mut wire, Version::Lite06Wip).unwrap();
-		assert_eq!((msg.start_group, msg.start_frame), (None, 0));
-		assert_eq!((msg.end_group, msg.end_frame), (None, None));
+		// Starts are inclusive on both sides, so they pass straight through.
+		let bounds = WireBounds::new(Some(Position { group: 5, frame: 3 }), None);
+		assert_eq!((bounds.start_group, bounds.start_frame), (Some(5), 3));
+	}
+
+	/// The builders produce exactly what the wire conversion expects, so an inclusive
+	/// bound survives the trip out to a peer unchanged.
+	#[test]
+	fn wire_bounds_match_the_builders() {
+		let whole = Subscription::default().with_end(Position::after_group(5));
+		let bounds = WireBounds::new(whole.start, whole.end);
+		assert_eq!((bounds.end_group, bounds.end_frame), (Some(5), None));
+
+		let capped = Subscription::default().with_end(Position::after(5, 2));
+		let bounds = WireBounds::new(capped.start, capped.end);
+		assert_eq!((bounds.end_group, bounds.end_frame), (Some(5), Some(2)));
+
+		let started = Subscription::default().with_start(Position { group: 5, frame: 3 });
+		let bounds = WireBounds::new(started.start, started.end);
+		assert_eq!((bounds.start_group, bounds.start_frame), (Some(5), 3));
 	}
 
 	/// The widening covers SUBSCRIBE_UPDATE too: a downstream peer asking for a frame
@@ -1161,6 +1167,38 @@ mod tests {
 	}
 }
 
+/// The four wire fields a subscription's half-open range encodes to.
+///
+/// The inverse of the publisher's `Bounds::positions`: the model carries whole
+/// positions with an exclusive end, while the wire splits each bound into a group and a
+/// frame and states both ends inclusive.
+struct WireBounds {
+	start_group: Option<u64>,
+	start_frame: u64,
+	end_group: Option<u64>,
+	end_frame: Option<u64>,
+}
+
+impl WireBounds {
+	fn new(start: Option<Position>, end: Option<Position>) -> Self {
+		let (end_group, end_frame) = match end {
+			// An exclusive end at the head of a group means the group below it is the
+			// last one, and it is served whole. Saturating covers an end of (0, 0),
+			// which would serve nothing and which nothing produces.
+			Some(end) if end.frame == 0 => (Some(end.group.saturating_sub(1)), None),
+			Some(end) => (Some(end.group), Some(end.frame - 1)),
+			None => (None, None),
+		};
+
+		Self {
+			start_group: start.map(|start| start.group),
+			start_frame: start.map_or(0, |start| start.frame),
+			end_group,
+			end_frame,
+		}
+	}
+}
+
 /// The at-most-one live upstream subscription: its control stream plus the params
 /// echoed in every SUBSCRIBE_UPDATE.
 struct SubStream<S: web_transport_trait::Session> {
@@ -1170,8 +1208,7 @@ struct SubStream<S: web_transport_trait::Session> {
 	/// downstream aggregate changes.
 	ordered: bool,
 	max_latency: Duration,
-	start_group: Option<u64>,
-	start_frame: u64,
+	start: Option<Position>,
 	priority: u8,
 }
 
@@ -1502,15 +1539,23 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			return;
 		}
 
-		if subscription.frame_start != 0 || subscription.frame_end.is_some() {
+		// Round both bounds outward to the enclosing group, so the peer sends at least
+		// what was asked for and never less.
+		let start = subscription.start.map(|start| Position::group(start.group));
+		let end = subscription.end.map(|end| match end.frame {
+			0 => end,
+			_ => Position::group(end.group.saturating_add(1)),
+		});
+
+		if (start, end) != (subscription.start, subscription.end) {
 			tracing::debug!(
 				track = %self.name,
 				version = ?self.subscriber.version,
 				"widening frame bounds to whole groups for an older peer"
 			);
 		}
-		subscription.frame_start = 0;
-		subscription.frame_end = None;
+		subscription.start = start;
+		subscription.end = end;
 	}
 
 	/// Apply a subscription-demand change: open the upstream SUBSCRIBE on the first
@@ -1537,12 +1582,9 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 						active.priority = subscription.priority;
 						active.ordered = subscription.ordered;
 						active.max_latency = subscription.latency_max;
-						let start = subscription.start();
-						active.start_group = start.map(|start| start.group);
-						active.start_frame = start.map_or(0, |start| start.frame);
+						active.start = subscription.start;
 						if supports_update {
-							let end_frame = subscription.group_end.and(subscription.frame_end);
-							self.send_update(active, subscription.group_end, end_frame).await?;
+							self.send_update(active, subscription.end).await?;
 						}
 					}
 				}
@@ -1589,7 +1631,7 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 
 		// Both halves of each bound come from the same position, so a frame can never
 		// reach the wire without the group it counts from (which the peer would reject).
-		let start = subscription.start();
+		let bounds = WireBounds::new(subscription.start, subscription.end);
 		let msg = lite::Subscribe {
 			id,
 			broadcast: self.path.as_path(),
@@ -1597,10 +1639,10 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			priority: subscription.priority,
 			ordered: subscription.ordered,
 			max_latency: subscription.latency_max,
-			start_group: start.map(|start| start.group),
-			end_group: subscription.group_end,
-			start_frame: start.map_or(0, |start| start.frame),
-			end_frame: subscription.group_end.and(subscription.frame_end),
+			start_group: bounds.start_group,
+			end_group: bounds.end_group,
+			start_frame: bounds.start_frame,
+			end_frame: bounds.end_frame,
 		};
 
 		tracing::info!(id, broadcast = %self.subscriber.log_path(&self.path), track = %self.name, "subscribe started");
@@ -1660,30 +1702,24 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 			id,
 			ordered: subscription.ordered,
 			max_latency: subscription.latency_max,
-			start_group: subscription.group_start,
-			start_frame: subscription.frame_start,
+			start: subscription.start,
 			priority: subscription.priority,
 		});
 
 		Ok(())
 	}
 
-	/// Echo the current params upstream as a SUBSCRIBE_UPDATE, varying only the end bound
-	/// (`end_group` and the `end_frame` qualifying it).
-	async fn send_update(
-		&self,
-		active: &mut SubStream<S>,
-		end_group: Option<u64>,
-		end_frame: Option<u64>,
-	) -> Result<(), Error> {
+	/// Echo the current params upstream as a SUBSCRIBE_UPDATE, varying only the end bound.
+	async fn send_update(&self, active: &mut SubStream<S>, end: Option<Position>) -> Result<(), Error> {
+		let bounds = WireBounds::new(active.start, end);
 		let update = lite::SubscribeUpdate {
 			priority: active.priority,
 			ordered: active.ordered,
 			max_latency: active.max_latency,
-			start_group: active.start_group,
-			end_group,
-			start_frame: active.start_frame,
-			end_frame,
+			start_group: bounds.start_group,
+			end_group: bounds.end_group,
+			start_frame: bounds.start_frame,
+			end_frame: bounds.end_frame,
 		};
 		active.stream.writer.encode(&update).await
 	}

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1127,6 +1127,56 @@ mod tests {
 		assert_eq!((bounds.start_group, bounds.start_frame), (Some(5), 3));
 	}
 
+	/// A subscription that asks for nothing opens nothing.
+	///
+	/// `Position::group(0)` is the empty range: nothing sorts below it. The wire cannot
+	/// say that, and the nearest thing it can say is "through group 0", which would
+	/// deliver the single group the caller excluded.
+	#[tokio::test]
+	async fn an_empty_range_opens_no_subscription() {
+		let mut h = Harness::new(Version::Lite06Wip);
+		let mut sub = Sub::None;
+
+		let empty = Subscription::default().with_end(Position::group(0));
+		h.serve
+			.handle_subscription(&mut h.producer, &mut sub, Some(empty), true, Some(Timescale::default()))
+			.await
+			.unwrap();
+
+		assert!(matches!(sub, Sub::None), "must not open a subscription");
+		assert!(h.wire().is_empty(), "nothing reached the wire");
+	}
+
+	/// Demand collapsing to nothing cancels the upstream rather than sending a bound
+	/// that means the opposite.
+	#[tokio::test]
+	async fn an_empty_range_cancels_a_live_subscription() {
+		let mut h = Harness::new(Version::Lite06Wip);
+		let mut sub = Sub::None;
+
+		h.serve
+			.handle_subscription(
+				&mut h.producer,
+				&mut sub,
+				Some(Subscription::default()),
+				true,
+				Some(Timescale::default()),
+			)
+			.await
+			.unwrap();
+		assert!(matches!(sub, Sub::Active(_)), "the first subscriber opens one");
+		let established = h.wire().len();
+
+		let empty = Subscription::default().with_end(Position::group(0));
+		h.serve
+			.handle_subscription(&mut h.producer, &mut sub, Some(empty), true, Some(Timescale::default()))
+			.await
+			.unwrap();
+
+		assert!(matches!(sub, Sub::None), "the upstream must be canceled");
+		assert_eq!(h.wire().len(), established, "no SUBSCRIBE_UPDATE claiming group 0");
+	}
+
 	/// The widening covers SUBSCRIBE_UPDATE too: a downstream peer asking for a frame
 	/// offset must not tear down an older upstream that is already serving.
 	#[tokio::test]
@@ -1181,10 +1231,16 @@ struct WireBounds {
 
 impl WireBounds {
 	fn new(start: Option<Position>, end: Option<Position>) -> Self {
+		// The empty range has no wire encoding, and flooring it below would ask for the
+		// group it excludes. `handle_subscription` drops such a subscription instead.
+		debug_assert!(
+			end != Some(Position::group(0)),
+			"an empty range cannot be encoded; it should have been dropped as no demand"
+		);
+
 		let (end_group, end_frame) = match end {
 			// An exclusive end at the head of a group means the group below it is the
-			// last one, and it is served whole. Saturating covers an end of (0, 0),
-			// which would serve nothing and which nothing produces.
+			// last one, and it is served whole.
 			Some(end) if end.frame == 0 => (Some(end.group.saturating_sub(1)), None),
 			Some(end) => (Some(end.group), Some(end.frame - 1)),
 			None => (None, None),
@@ -1568,6 +1624,13 @@ impl<S: web_transport_trait::Session> TrackServe<S> {
 		supports_update: bool,
 		timescale: Option<Timescale>,
 	) -> Result<(), Error> {
+		// A range ending at the very first position asks for nothing. The wire has no
+		// encoding for that (`Group End` = 0 already means unbounded), and the closest it
+		// can say is "through group 0", which would deliver the one group the caller
+		// excluded. No demand at all is the faithful translation, and it is reachable
+		// only from a caller: every internal bound sits at or above the first frame.
+		let pref = pref.filter(|sub| sub.end != Some(Position::group(0)));
+
 		match pref {
 			Some(mut subscription) => {
 				self.widen_frame_bounds(&mut subscription);

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -2977,6 +2977,7 @@ mod tests {
 	use crate::group;
 
 	use super::*;
+	use crate::track::Position;
 
 	/// An announced direct route.
 	fn announce() -> broadcast::Route {
@@ -3557,7 +3558,7 @@ mod tests {
 		// Demand registers as the subscriber polls; a fresh segment carries no
 		// boundary, so the demand is the subscriber's own.
 		sub.assert_no_group();
-		assert_eq!(producer.subscription().unwrap().group_start, None);
+		assert_eq!(producer.subscription().unwrap().start, None);
 
 		producer.append_group().unwrap();
 		producer.append_group().unwrap();
@@ -3578,7 +3579,7 @@ mod tests {
 		let mut producer = accept_track(&mut dynamic_b, "video").await;
 		settle().await;
 		sub.assert_no_group();
-		assert_eq!(producer.subscription().unwrap().group_start, Some(2));
+		assert_eq!(producer.subscription().unwrap().start, Some(Position::group(2)));
 		producer.create_group(group::Info { sequence: 1 }).unwrap();
 		producer.create_group(group::Info { sequence: 2 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 2, "groups below the boundary are filtered");
@@ -3676,7 +3677,7 @@ mod tests {
 		// Demand registers as the subscriber polls; the new segment starts at the
 		// splice boundary.
 		sub.assert_no_group();
-		assert_eq!(producer_b.subscription().unwrap().group_start, Some(1));
+		assert_eq!(producer_b.subscription().unwrap().start, Some(Position::group(1)));
 		producer_b.create_group(group::Info { sequence: 1 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 1);
 		sub.assert_not_closed();
@@ -3824,8 +3825,8 @@ mod tests {
 		// The old copy's demand is capped at the boundary; the new copy's starts
 		// there. Both propagate as the subscriber polls.
 		sub.assert_no_group();
-		assert_eq!(producer_a.subscription().unwrap().group_end, Some(1));
-		assert_eq!(producer_b.subscription().unwrap().group_start, Some(2));
+		assert_eq!(producer_a.subscription().unwrap().end, Some(Position::group(2)));
+		assert_eq!(producer_b.subscription().unwrap().start, Some(Position::group(2)));
 
 		// The old copy racing past its cap is filtered; the new copy serves on.
 		producer_a.create_group(group::Info { sequence: 2 }).unwrap();
@@ -4095,7 +4096,7 @@ mod tests {
 		let mut producer = accept_track(&mut dynamic, "video").await;
 		settle().await;
 		sub.assert_no_group();
-		assert_eq!(producer.subscription().unwrap().group_start, Some(2));
+		assert_eq!(producer.subscription().unwrap().start, Some(Position::group(2)));
 		producer.create_group(group::Info { sequence: 2 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 2);
 		sub.assert_not_closed();
@@ -4731,7 +4732,7 @@ mod tests {
 		let mut producer_local = accept_track(&mut dynamic_local, "video").await;
 		settle().await;
 		sub.assert_no_group();
-		assert_eq!(producer_local.subscription().unwrap().group_start, Some(1));
+		assert_eq!(producer_local.subscription().unwrap().start, Some(Position::group(1)));
 		producer_local.create_group(group::Info { sequence: 1 }).unwrap();
 		assert_eq!(sub.assert_group().sequence, 1);
 		sub.assert_not_closed();

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -805,7 +805,17 @@ impl SegmentSub {
 	/// The last group this segment can serve (inclusive), for the underlying read
 	/// cursor. `None` while it is the newest segment.
 	fn last_group(&self) -> Option<u64> {
-		self.end.map(|end| end.before().group)
+		let end = self.end?;
+		// An empty segment would serve nothing, and no switch produces one: every
+		// boundary comes from `resume_position`, which sits at or above the first frame.
+		// `None` here reads as "no cap", which is why it is asserted rather than relied
+		// on; the authoritative filter is `Segment::covers`, which uses the exclusive
+		// bound directly.
+		debug_assert!(
+			end != Position::default(),
+			"a segment cannot end at the start of the track"
+		);
+		Some(end.before()?.group)
 	}
 }
 

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -66,11 +66,13 @@ impl Segment {
 /// The demand to register on an underlying track: the subscriber's own
 /// preferences intersected with a segment's bounds.
 fn slice(prefs: &Subscription, start: Option<Position>, end: Option<Position>) -> Subscription {
-	let mut sub = prefs.clone();
-	sub.set_start(max_unbounded_start(prefs.start(), start));
-	// The segment bound is exclusive and a subscription's is inclusive.
-	sub.set_end(min_some(prefs.end(), end.map(Position::before)));
-	sub
+	// A segment's bounds and a subscription's are both half-open, so they intersect
+	// directly with no inclusive/exclusive conversion in between.
+	Subscription {
+		start: max_unbounded_start(prefs.start, start),
+		end: min_some(prefs.end, end),
+		..prefs.clone()
+	}
 }
 
 /// The later of two optional start bounds, treating `None` as "the live edge" for the
@@ -1395,17 +1397,17 @@ mod test {
 
 		let mut sub = producer
 			.consume()
-			.subscribe(Subscription::default().with_group_start(0));
+			.subscribe(Subscription::default().with_start(Position::group(0)));
 		// Poll once so the subscriber registers on segment A.
 		recv_pending(&mut sub);
-		assert_eq!(track_a.subscription().unwrap().group_end, None);
+		assert_eq!(track_a.subscription().unwrap().end, None);
 
 		producer.switch(&consumer_b, Position::group(5)).unwrap();
 		recv_pending(&mut sub);
 
 		// The old session sees its demand capped; the new one starts at the boundary.
-		assert_eq!(track_a.subscription().unwrap().group_end, Some(4));
-		assert_eq!(track_b.subscription().unwrap().group_start, Some(5));
+		assert_eq!(track_a.subscription().unwrap().end, Some(Position::group(5)));
+		assert_eq!(track_b.subscription().unwrap().start, Some(Position::group(5)));
 	}
 
 	#[tokio::test]
@@ -1782,8 +1784,11 @@ mod test {
 		recv_pending(&mut sub);
 
 		let demand = track_b.subscription().unwrap();
-		assert_eq!(demand.group_start, Some(0), "resumes in the same group");
-		assert_eq!(demand.frame_start, 2, "resumes at the frame the old route stopped on");
+		assert_eq!(
+			demand.start,
+			Some(Position { group: 0, frame: 2 }),
+			"resumes in the same group, at the frame the old route stopped on"
+		);
 
 		let mut group = track_b.create_group(group::Info { sequence: 0 }).unwrap();
 		group.start_at(2).unwrap();
@@ -1875,8 +1880,8 @@ mod test {
 
 		let demand = track_b.subscription().unwrap();
 		assert_eq!(
-			(demand.group_start, demand.frame_start),
-			(Some(0), 1),
+			demand.start,
+			Some(Position { group: 0, frame: 1 }),
 			"the half-written frame must be redelivered, not skipped"
 		);
 
@@ -1909,7 +1914,8 @@ mod test {
 		recv_pending(&mut sub);
 		// The old copy's demand is capped just below the boundary.
 		let demand = track_a.subscription().unwrap();
-		assert_eq!((demand.group_end, demand.frame_end), (Some(0), Some(0)));
+		// Exclusive: serve group 0 up to and including frame 0.
+		assert_eq!(demand.end, Some(Position { group: 0, frame: 1 }));
 
 		// A keeps writing anyway; those frames belong to B's range now.
 		group_a.write_frame(Timestamp::ZERO, b"a1-over-cap".to_vec()).unwrap();
@@ -1938,8 +1944,7 @@ mod test {
 		producer.takeover(&consumer_b).unwrap();
 		recv_pending(&mut sub);
 		let demand = track_b.subscription().unwrap();
-		assert_eq!(demand.group_start, Some(1));
-		assert_eq!(demand.frame_start, 0);
+		assert_eq!(demand.start, Some(Position::group(1)));
 	}
 
 	/// A copy dying mid-group stalls its readers instead of erroring them, the same

--- a/rs/moq-net/src/model/subscription.rs
+++ b/rs/moq-net/src/model/subscription.rs
@@ -23,34 +23,30 @@ pub struct Subscription {
 	/// cache. Receivers that buffer (e.g. a jitter buffer) enforce the same budget
 	/// locally, and a group is skipped once either measure exceeds it.
 	pub latency_max: Duration,
-	/// First group the publisher should deliver, or `None` to start at the latest group.
+	/// First [`Position`] the publisher should deliver, or `None` to start at the latest
+	/// group.
 	///
 	/// A request, aggregated across every live subscriber (the earliest explicit start
 	/// wins), so it says what the publisher sends, not what any one subscriber sees.
 	/// [`crate::track::Subscriber::start_at`] is the local read cursor; setting one does
 	/// not imply the other. See [Local cursor vs wire
 	/// preference](crate::track::Subscriber#local-cursor-vs-wire-preference).
-	pub group_start: Option<u64>,
-	/// Last group the publisher should deliver (inclusive), or `None` for no end.
+	pub start: Option<Position>,
+	/// First [`Position`] the publisher should *not* deliver, or `None` for no end.
+	///
+	/// Exclusive, like the end of a [`std::ops::Range`], which is what lets one field
+	/// carry both "through the end of group 5" ([`Position::after_group(5)`](Position::after_group))
+	/// and "up to frame 2 of group 5" ([`Position::after(5, 2)`](Position::after)). An
+	/// inclusive end cannot express the first without a sentinel frame, and the ordering
+	/// falls out for free: group 6's head sorts above any frame of group 5, so a
+	/// whole-group subscriber correctly absorbs a frame-capped one in the aggregate.
+	///
+	/// The wire agrees: `Group End` and `Frame End` are both encoded as `absolute + 1`.
 	///
 	/// A request, aggregated across every live subscriber (any unbounded subscriber makes
 	/// the aggregate unbounded). [`crate::track::Subscriber::end_at`] is the local read
-	/// cursor; setting one does not imply the other. See [Local cursor vs wire
-	/// preference](crate::track::Subscriber#local-cursor-vs-wire-preference).
-	pub group_end: Option<u64>,
-	/// First frame to deliver within [`Self::group_start`]'s group. `0` (the default)
-	/// starts at the beginning of that group.
-	///
-	/// Frames are numbered per group, so this counts from nothing without an explicit
-	/// `group_start` and is ignored when there is none. Set the pair together with
-	/// [`Self::with_start`], which is the only way to reach it.
-	pub frame_start: u64,
-	/// Last frame to deliver (inclusive) within [`Self::group_end`]'s group, or `None`
-	/// (the default) for through the end of that group.
-	///
-	/// Ignored without an explicit `group_end`, mirroring [`Self::frame_start`]. Set the
-	/// pair together with [`Self::with_end`].
-	pub frame_end: Option<u64>,
+	/// cursor; setting one does not imply the other.
+	pub end: Option<Position>,
 }
 
 impl Default for Subscription {
@@ -59,10 +55,8 @@ impl Default for Subscription {
 			priority: 0,
 			ordered: false,
 			latency_max: Duration::ZERO,
-			group_start: None,
-			group_end: None,
-			frame_start: 0,
-			frame_end: None,
+			start: None,
+			end: None,
 		}
 	}
 }
@@ -88,69 +82,24 @@ impl Subscription {
 		self
 	}
 
-	/// Set the first group to deliver, returning `self` for chaining.
-	pub fn with_group_start(mut self, group_start: impl Into<Option<u64>>) -> Self {
-		self.group_start = group_start.into();
-		self
-	}
-
-	/// Set the last group to deliver (inclusive), returning `self` for chaining.
-	pub fn with_group_end(mut self, group_end: impl Into<Option<u64>>) -> Self {
-		self.group_end = group_end.into();
-		self
-	}
-
-	/// Set the first position to deliver: frame `frame` of group `group`, returning `self`
-	/// for chaining.
+	/// Start delivery at `start`, or at the latest group when `None`. Returns `self` for
+	/// chaining.
 	///
-	/// The group comes with it because a frame index only means something relative to a
-	/// group, so there is no way to name a frame without the group it belongs to.
-	/// [`Self::with_group_start`] is the whole-group form, the same as `frame` 0.
-	pub fn with_start(mut self, group: u64, frame: u64) -> Self {
-		self.group_start = Some(group);
-		self.frame_start = frame;
+	/// [`Position::group`] is the whole-group form.
+	pub fn with_start(mut self, start: impl Into<Option<Position>>) -> Self {
+		self.start = start.into();
 		self
 	}
 
-	/// Set the last position to deliver (inclusive): frame `frame` of group `group`, or
-	/// all of `group` when `frame` is `None`. Returns `self` for chaining.
+	/// Stop delivery at `end`, or leave the subscription unbounded when `None`. Returns
+	/// `self` for chaining.
 	///
-	/// Pairs the group with the frame for the same reason as [`Self::with_start`].
-	pub fn with_end(mut self, group: u64, frame: impl Into<Option<u64>>) -> Self {
-		self.group_end = Some(group);
-		self.frame_end = frame.into();
+	/// Exclusive, matching [`Self::end`], so pass the position *after* the last one you
+	/// want. [`Position::after`] and [`Position::after_group`] name that conversion so no
+	/// call site has to write the `+ 1` itself.
+	pub fn with_end(mut self, end: impl Into<Option<Position>>) -> Self {
+		self.end = end.into();
 		self
-	}
-
-	/// The requested start as an ordered position, or `None` for the live edge.
-	pub(crate) fn start(&self) -> Option<Position> {
-		self.group_start.map(|group| Position {
-			group,
-			frame: self.frame_start,
-		})
-	}
-
-	/// The requested end as an ordered position, or `None` for unbounded. The frame is
-	/// `u64::MAX` when the whole end group is wanted, so the ordering matches the
-	/// "widest end wins" aggregate.
-	pub(crate) fn end(&self) -> Option<Position> {
-		self.group_end.map(|group| Position {
-			group,
-			frame: self.frame_end.unwrap_or(u64::MAX),
-		})
-	}
-
-	/// Apply an aggregated start position, or the live edge when `None`.
-	pub(crate) fn set_start(&mut self, start: Option<Position>) {
-		self.group_start = start.map(|start| start.group);
-		self.frame_start = start.map_or(0, |start| start.frame);
-	}
-
-	/// Apply an aggregated end position, or unbounded when `None`. A `u64::MAX` frame
-	/// maps back to "the whole end group".
-	pub(crate) fn set_end(&mut self, end: Option<Position>) {
-		self.group_end = end.map(|end| end.group);
-		self.frame_end = end.and_then(|end| (end.frame != u64::MAX).then_some(end.frame));
 	}
 
 	// Fold this subscription into the running aggregate: Ready with the merged
@@ -161,18 +110,17 @@ impl Subscription {
 			return Poll::Ready(self.clone());
 		};
 
-		let mut merged = Subscription {
+		let merged = Subscription {
 			priority: self.priority.max(combined.priority),
 			// Sequence-first prioritization is enabled only when every subscriber wants it.
 			ordered: self.ordered && combined.ordered,
 			latency_max: self.latency_max.max(combined.latency_max),
-			..Subscription::default()
+			// Bounds fold as whole positions. Two subscribers starting in the same group
+			// are separated only by their frame, so folding group and frame independently
+			// would invent a bound neither asked for.
+			start: min_some(self.start, combined.start),
+			end: max_unbounded(self.end, combined.end),
 		};
-		// Frame-precise bounds fold as whole positions: two subscribers starting in the
-		// same group are separated only by their frame, so folding the group and the
-		// frame independently would invent a start neither asked for.
-		merged.set_start(min_some(self.start(), combined.start()));
-		merged.set_end(max_unbounded(self.end(), combined.end()));
 
 		if &merged != combined {
 			return Poll::Ready(merged);
@@ -186,23 +134,47 @@ impl Subscription {
 ///
 /// Ordered lexicographically, so comparing positions is the same as comparing groups
 /// and only falling back to frames within one. This is the model's counterpart of the
-/// wire's (`Group`, `Frame`) pairs on SUBSCRIBE / SUBSCRIBE_OK / FETCH.
+/// wire's (`Group`, `Frame`) pairs on SUBSCRIBE and FETCH.
+///
+/// Pairing the two is the point: a frame index counts from the start of a group, so it
+/// means nothing on its own. Carrying them together makes "frame 5 of nothing"
+/// unrepresentable rather than merely undefined.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) struct Position {
+pub struct Position {
 	/// The group sequence.
 	pub group: u64,
-	/// The frame index within the group.
+	/// The frame index within the group, numbered from 0 in write order.
 	pub frame: u64,
 }
 
 impl Position {
-	/// The start of a group.
+	/// The first frame of `group`.
+	///
+	/// As an exclusive end this means "everything before `group`"; as a start it means
+	/// "`group` from the beginning".
 	pub fn group(group: u64) -> Self {
 		Self { group, frame: 0 }
 	}
 
-	/// The last position strictly below this one, converting a half-open bound into the
-	/// inclusive one a [`Subscription`] carries.
+	/// The position just past `frame` of `group`: the exclusive end that includes it.
+	pub fn after(group: u64, frame: u64) -> Self {
+		Self {
+			group,
+			// Saturating so the last representable frame cannot wrap into an empty
+			// range. Unreachable from the wire, where varints cap at 2^62-1.
+			frame: frame.saturating_add(1),
+		}
+	}
+
+	/// The position just past every frame of `group`: the exclusive end that includes
+	/// the group whole.
+	pub fn after_group(group: u64) -> Self {
+		Self::group(group.saturating_add(1))
+	}
+
+	/// The last position strictly below this one, turning an exclusive bound such as
+	/// [`Subscription::end`] into the inclusive one an API like
+	/// [`crate::track::Subscriber::end_at`] wants.
 	///
 	/// A boundary at the head of a group backs up to all of the group below it, which
 	/// saturates at the very first frame. Nothing produces a boundary there: a segment
@@ -275,68 +247,72 @@ mod tests {
 
 	#[test]
 	fn combined_group_start_uses_earliest_explicit_start() {
-		let live = Subscription::default().with_group_start(None);
-		let catchup = Subscription::default().with_group_start(10);
-		let older_catchup = Subscription::default().with_group_start(5);
+		// No start at all is the live edge, which loses to any explicit one.
+		let live = Subscription::default();
+		let catchup = Subscription::default().with_start(Position::group(10));
+		let older_catchup = Subscription::default().with_start(Position::group(5));
 
 		let combined = combine(&[live, catchup, older_catchup]).unwrap();
 
-		assert_eq!(combined.group_start, Some(5));
+		assert_eq!(combined.start, Some(Position::group(5)));
 	}
 
 	#[test]
 	fn combined_group_end_keeps_live_subscription_unbounded() {
-		let live = Subscription::default().with_group_end(None);
-		let bounded = Subscription::default().with_group_end(10);
+		// No end at all is unbounded, which absorbs any explicit one.
+		let live = Subscription::default();
+		let bounded = Subscription::default().with_end(Position::after_group(10));
 
 		let combined = combine(&[live, bounded]).unwrap();
 
-		assert_eq!(combined.group_end, None);
+		assert_eq!(combined.end, None);
 	}
 
 	#[test]
 	fn combined_start_folds_the_whole_position() {
-		let early_frame = Subscription::default().with_start(5, 2);
-		let late_frame = Subscription::default().with_start(5, 9);
+		let early_frame = Subscription::default().with_start(Position { group: 5, frame: 2 });
+		let late_frame = Subscription::default().with_start(Position { group: 5, frame: 9 });
 
 		// Same group: the earlier frame wins.
 		let combined = combine(&[late_frame.clone(), early_frame.clone()]).unwrap();
-		assert_eq!((combined.group_start, combined.frame_start), (Some(5), 2));
+		assert_eq!(combined.start, Some(Position { group: 5, frame: 2 }));
 
 		// An earlier group wins outright, carrying its own frame rather than the
 		// smallest frame across the two.
-		let earlier_group = Subscription::default().with_start(4, 7);
+		let earlier_group = Subscription::default().with_start(Position { group: 4, frame: 7 });
 		let combined = combine(&[early_frame, earlier_group]).unwrap();
-		assert_eq!((combined.group_start, combined.frame_start), (Some(4), 7));
+		assert_eq!(combined.start, Some(Position { group: 4, frame: 7 }));
 	}
 
 	#[test]
 	fn combined_end_folds_the_whole_position() {
-		let short = Subscription::default().with_end(5, 2);
-		let long = Subscription::default().with_end(5, 9);
+		let short = Subscription::default().with_end(Position::after(5, 2));
+		let long = Subscription::default().with_end(Position::after(5, 9));
 
-		// Same group: the later frame wins.
+		// Same group: the later frame wins. Ends are exclusive, so an inclusive frame 9
+		// is stored as 10.
 		let combined = combine(&[short.clone(), long.clone()]).unwrap();
-		assert_eq!((combined.group_end, combined.frame_end), (Some(5), Some(9)));
+		assert_eq!(combined.end, Some(Position { group: 5, frame: 10 }));
 
-		// An unbounded frame is the whole group, so it absorbs any capped one.
-		let whole = Subscription::default().with_group_end(5);
+		// The whole group is the head of the next one, which outsorts every frame of
+		// this one, so it absorbs any capped end without a sentinel.
+		let whole = Subscription::default().with_end(Position::after_group(5));
 		let combined = combine(&[long, whole]).unwrap();
-		assert_eq!((combined.group_end, combined.frame_end), (Some(5), None));
+		assert_eq!(combined.end, Some(Position::group(6)));
 
 		// A later group wins outright, carrying its own frame.
-		let later_group = Subscription::default().with_end(6, 1);
+		let later_group = Subscription::default().with_end(Position::after(6, 1));
 		let combined = combine(&[short, later_group]).unwrap();
-		assert_eq!((combined.group_end, combined.frame_end), (Some(6), Some(1)));
+		assert_eq!(combined.end, Some(Position { group: 6, frame: 2 }));
 	}
 
 	#[test]
 	fn combined_group_end_uses_latest_bounded_end() {
-		let early = Subscription::default().with_group_end(10);
-		let late = Subscription::default().with_group_end(20);
+		let early = Subscription::default().with_end(Position::after_group(10));
+		let late = Subscription::default().with_end(Position::after_group(20));
 
 		let combined = combine(&[early, late]).unwrap();
 
-		assert_eq!(combined.group_end, Some(20));
+		assert_eq!(combined.end, Some(Position::group(21)));
 	}
 }

--- a/rs/moq-net/src/model/subscription.rs
+++ b/rs/moq-net/src/model/subscription.rs
@@ -157,40 +157,45 @@ impl Position {
 	}
 
 	/// The position just past `frame` of `group`: the exclusive end that includes it.
-	pub fn after(group: u64, frame: u64) -> Self {
-		Self {
-			group,
-			// Saturating so the last representable frame cannot wrap into an empty
-			// range. Unreachable from the wire, where varints cap at 2^62-1.
-			frame: frame.saturating_add(1),
+	///
+	/// `None` when there is no such position, i.e. the very last frame of the very last
+	/// group. That is past everything, which [`Subscription::end`] spells `None` too, so
+	/// the two meanings line up and `with_end` can take this directly.
+	pub fn after(group: u64, frame: u64) -> Option<Self> {
+		match frame.checked_add(1) {
+			Some(frame) => Some(Self { group, frame }),
+			// Past the last frame of a group is the head of the next one.
+			None => Self::after_group(group),
 		}
 	}
 
 	/// The position just past every frame of `group`: the exclusive end that includes
 	/// the group whole.
-	pub fn after_group(group: u64) -> Self {
-		Self::group(group.saturating_add(1))
+	///
+	/// `None` past the last group, for the reason given on [`Self::after`].
+	pub fn after_group(group: u64) -> Option<Self> {
+		Some(Self::group(group.checked_add(1)?))
 	}
 
 	/// The last position strictly below this one, turning an exclusive bound such as
 	/// [`Subscription::end`] into the inclusive one an API like
 	/// [`crate::track::Subscriber::end_at`] wants.
 	///
-	/// A boundary at the head of a group backs up to all of the group below it, which
-	/// saturates at the very first frame. Nothing produces a boundary there: a segment
-	/// capped at the start of the track would serve nothing, and such a segment is
-	/// replaced outright rather than capped.
-	pub fn before(self) -> Self {
-		match self.frame.checked_sub(1) {
-			Some(frame) => Self {
+	/// `None` for the very first position, which is the empty range: nothing sorts below
+	/// it, so there is no inclusive bound to convert to. Saturating instead would return
+	/// a position *above* the input and quietly include the group it excludes.
+	pub fn before(self) -> Option<Self> {
+		if let Some(frame) = self.frame.checked_sub(1) {
+			return Some(Self {
 				group: self.group,
 				frame,
-			},
-			None => Self {
-				group: self.group.saturating_sub(1),
-				frame: u64::MAX,
-			},
+			});
 		}
+
+		Some(Self {
+			group: self.group.checked_sub(1)?,
+			frame: u64::MAX,
+		})
 	}
 }
 
@@ -243,6 +248,39 @@ mod tests {
 		let combined = combine(&[unordered, ordered]).unwrap();
 
 		assert!(!combined.ordered);
+	}
+
+	/// The exclusive representation runs out at both extremes, and `Option` says so
+	/// rather than saturating into a bound that contradicts the request.
+	#[test]
+	fn positions_are_total_at_the_extremes() {
+		// Past the last frame of a group is the head of the next one, not a wider frame
+		// in the same group.
+		assert_eq!(Position::after(5, u64::MAX), Some(Position::group(6)));
+
+		// Past everything has no position. `Subscription::end` spells that `None` too,
+		// so the meanings coincide and the group is included rather than dropped.
+		assert_eq!(Position::after_group(u64::MAX), None);
+		assert_eq!(Position::after(u64::MAX, u64::MAX), None);
+		assert_eq!(
+			Subscription::default().with_end(Position::after_group(u64::MAX)).end,
+			None
+		);
+
+		// Nothing sorts below the first position, so there is no inclusive bound for the
+		// empty range. Saturating would return one *above* the input.
+		assert_eq!(Position::group(0).before(), None);
+		assert_eq!(
+			Position::group(1).before(),
+			Some(Position {
+				group: 0,
+				frame: u64::MAX
+			})
+		);
+		assert_eq!(
+			Position::after(4, 7).unwrap().before(),
+			Some(Position { group: 4, frame: 7 })
+		);
 	}
 
 	#[test]

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -18,9 +18,7 @@ use crate::{broadcast, cache, frame, group, stats};
 
 use super::{Datagram, Requests};
 
-pub use super::subscription::Subscription;
-
-pub(crate) use super::subscription::Position;
+pub use super::subscription::{Position, Subscription};
 
 use std::{
 	collections::{HashMap, VecDeque},
@@ -2283,7 +2281,7 @@ impl kio::Pollable for Fetching {
 ///
 /// - [`Self::start_at`] / [`Self::end_at`] move **this subscriber's read cursor**. They
 ///   filter exactly what this handle returns and are invisible to the publisher.
-/// - [`Subscription::group_start`] / [`Subscription::group_end`], set via [`Self::update`],
+/// - [`Subscription::start`] / [`Subscription::end`], set via [`Self::update`],
 ///   are a **request to the publisher**. They're aggregated across every live subscriber
 ///   (earliest start, widest end), so they say what the publisher should send, not what
 ///   this subscriber sees.
@@ -2589,7 +2587,7 @@ impl Subscriber {
 	///
 	/// A local filter, not a request: it doesn't tell the publisher anything, so the
 	/// skipped groups are still delivered and simply not returned. To ask the publisher
-	/// to start there instead, set [`Subscription::group_start`] via [`Self::update`].
+	/// to start there instead, set [`Subscription::start`] via [`Self::update`].
 	/// See [Local cursor vs wire preference](Self#local-cursor-vs-wire-preference).
 	pub fn start_at(&mut self, sequence: u64) {
 		match &mut self.inner {
@@ -2603,7 +2601,7 @@ impl Subscriber {
 	///
 	/// Accepts a bare `u64` (cap), `Some(u64)`, or `None` (uncap).
 	///
-	/// A local filter, not a request; [`Subscription::group_end`] is the wire-level
+	/// A local filter, not a request; [`Subscription::end`] is the wire-level
 	/// counterpart. See [Local cursor vs wire preference](Self#local-cursor-vs-wire-preference).
 	///
 	/// Affects [`Self::next_group`] only: groups beyond the cap stay in the producer's


### PR DESCRIPTION
## Summary

`moq_net::track::Subscription` exposed its delivery range as four independently-settable public fields (`group_start` / `frame_start` / `group_end` / `frame_end`) while the model itself worked in whole positions. `set_start` / `set_end` / `start()` / `end()` existed purely to adapt between the two shapes, and a frame index without the group it counts from stayed expressible, caught only by the remote peer's decoder as `InvalidSubscribeLocation`.

`start` and `end` are now `Option<Position>`, and the adapter layer is deleted.

This is the follow-up promised in #2537, which landed the frame-precise bounds themselves and closed the builder path with `with_start` / `with_end`. That left the field path open; this closes it.

## The end is exclusive

Half-open, like `std::ops::Range`, in the field *and* in the builders. That is the load-bearing decision, so it is worth stating why.

The end bound has three states, not two: unbounded, through the end of a group, and capped at a frame within a group. An *inclusive* end can only express the middle one with a sentinel frame, which is exactly what `end()` was doing (`frame_end.unwrap_or(u64::MAX)`) so the "widest end wins" fold would order correctly. A plain `Option<Position>` would have had to either leak that sentinel to consumers or nest a second `Option`, which is two fields again.

Exclusive collapses all three into one uniform value:

| Meaning | `end` |
|---|---|
| Unbounded | `None` |
| Through the end of group 5 | `Some(Position::group(6))` |
| Group 5 up to frame 2 | `Some(Position { group: 5, frame: 3 })` |

The ordering then falls out for free: group 6's head sorts above every frame of group 5, so a whole-group subscriber absorbs a frame-capped one in the aggregate with no special case. And the wire already agreed, since `Group End` and `Frame End` are both encoded as `absolute + 1`.

## What this deletes

- `Subscription::{set_start, set_end, start, end}` (the four-field/two-position adapter) and the `u64::MAX` sentinel with it.
- `resume::slice`'s inclusive/exclusive conversion. Segment bounds were already half-open, so intersecting them is now `min_some(prefs.end, end)` where it was `min_some(prefs.end(), end.map(Position::before))`.
- `SubStream`'s split `start_group` / `start_frame`, now one `start: Option<Position>`.

The wire conversion is now two named inverses, `Bounds::positions` (decode) and `WireBounds::new` (encode), instead of being spelled out field by field at four call sites.

`widen_frame_bounds` also reads as what it actually does: rounding both bounds outward to the enclosing group.

## Public API changes

Breaking, hence `dev`.

- `moq_net::track::Subscription`: `group_start` / `frame_start` / `group_end` / `frame_end` are replaced by `start: Option<Position>` and `end: Option<Position>`.
- `moq_net::track::Position` is now public (was `pub(crate)`), along with `Position::group` and `Position::before`.
- `with_group_start` and `with_group_end` are replaced by `with_start` and `with_end`, each taking `impl Into<Option<Position>>` and matching the field exactly. Four builders become two.
- New: `Position::after(group, frame)` and `Position::after_group(group)`.

The builders are exclusive rather than translating, so what you set is what you read back. An earlier revision kept them inclusive to spare call sites; that was wrong, because it meant `with_group_end(5)` and `sub.end` disagreed by one with nothing in the name to warn you. `Position::after` / `after_group` build the exclusive bound from the inclusive one a caller usually holds, which puts the `+ 1` in a single named place and states the convention at the call site:

```rust
Subscription::default()
    .with_start(Position::group(5))              // group 5 onward
    .with_end(Position::after_group(9))          // through group 9

Subscription::default()
    .with_start(Position { group: 5, frame: 3 }) // resume mid-group
    .with_end(Position::after(7, 2))             // through frame 2 of group 7
```

`rs/moq-ffi` and `rs/libmoq` keep their own inclusive `group_start` / `group_end` in their binding structs, which suits those audiences; only the conversion into `Subscription` moved. No bindings regenerate, and `doc/lib/c/index.md` documents that C struct, so it stays accurate. `libmoq/src/consume.rs` also read the fields directly, and now maps the position back to the group sequence its local read cursor wants.

## Review round 1 (adversarial)

**Fixed: an empty range asked for group 0.** The wire has no encoding for an empty range, since `Group End` = 0 already means unbounded. `WireBounds::new` floored an exclusive end of `(0, 0)` with `saturating_sub`, putting `end_group` = 0 on the wire, which means "through group 0" and delivers the single group the caller excluded.

The root cause is that the model's range algebra is strictly more expressive than the wire's, and the encoder rounded to the nearest representable value instead of refusing. For the empty range, the nearest value is its opposite.

It became reachable in this PR: before the builders took a `Position` directly, `with_group_end(g)` produced `g + 1` and `with_end(g, f)` produced `frame + 1`, so `(0, 0)` could not be built. Nothing internal produces it either, since every model bound sits at or above the first frame. So it needed a caller, and `Position::group`'s own doc invites one.

An empty range is now dropped as no demand before it reaches the wire, which is what "serve me nothing" means: nothing opens on establish, and a live subscription is canceled on update. The aggregate can only be empty when every downstream subscriber wants nothing, since an unbounded one absorbs the rest, so canceling upstream is right. Regression tests `an_empty_range_opens_no_subscription` and `an_empty_range_cancels_a_live_subscription` both fail with the filter removed.

**Fixed: the position conversions saturated at both extremes.** `after`, `after_group` and `before` each returned a value that contradicted its own contract at the ends of the `u64 x u64` lattice: `after_group(u64::MAX)` excluded the group it promised to include, `after(g, u64::MAX)` dropped the last frame instead of rolling to the next group, and `group(0).before()` returned a position sorting *above* its input. The last was reachable through `libmoq`, whose local read cursor bypasses the wire-side filter above.

All three return `Option` now. Past the last group has no position, and `Subscription::end` already spells unbounded as `None`, so the two meanings coincide and `with_end(Position::after_group(u64::MAX))` correctly includes the group. `None` reads as "no cap" at both `before` call sites, so neither propagates it blindly. Pinned by `positions_are_total_at_the_extremes`.

## Cross-Package Sync

No row applies. The wire bytes are unchanged: this moves the Rust type that feeds the codec, not the codec. `drafts/`, `js/net`, and `doc/` are untouched on purpose rather than by omission.

## Test plan

- `nix develop --command just check` — clean, including `cargo doc -D warnings`, which caught four intra-doc links to the renamed fields that compilation alone missed.
- `nix develop --command just rs test` — 2391 tests run, 2391 passed. (nextest flags `moq-relay config::tests::cli_does_not_clobber_toml_tiers` as leaky; it is unrelated, and `moq-relay` is untouched here.)
- `nix develop --command just rs loom` — passes (9 + 5 model checks, no deadlock or leaked `Arc`). `rs/CLAUDE.md` makes this a manual gate for changes under `moq-net/src/model/`.

New coverage for the exclusive seam, which is where an off-by-one would silently drop or duplicate a frame at every relay hop: `wire_bounds_convert_the_exclusive_end` and `wire_bounds_match_the_builders` on the encode side, `bounds_convert_to_positions` on the decode side (including a frame bound arriving without its group, which now cannot reach the model at all).

`a_frame_bound_without_its_group_is_dropped` from #2537 is removed rather than ported. It asserted that a frame with no group is dropped on encode; that state is now unrepresentable, so its input is a legitimate position and the assertion had inverted. Deleting a test because the type system subsumed it is the point of the change.

(Written by Opus 5)
