### PR TITLE
feat(hang): define segment-addressed recordings

### DIFF
--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -625,14 +625,17 @@ A broadcast with no timeline has no segments and cannot be recorded this way.
 A recording is a set of objects under a common prefix:
 
 ~~~
+<prefix>/.complete
 <prefix>/.timeline
 <prefix>/<track>/.track
 <prefix>/<track>/<segment>
 ~~~
 
+The common prefix is application-defined and is not interpreted by this format.
+
 `<track>` is the track's name with every byte outside `A-Z a-z 0-9 _ -` percent-encoded as `%` followed by two uppercase hexadecimal digits.
 For example, `catalog.json` becomes `catalog%2Ejson`.
-An encoded name therefore never contains `/` and never begins with `.`, so a track can neither collide with the reserved `.timeline` name nor address anything outside the prefix.
+An encoded name therefore never contains `/` and never begins with `.`, so a track can neither collide with the reserved `.complete` and `.timeline` names nor address anything outside the prefix.
 
 `.track` stores the immutable properties of its parent track ({{recording-track}}).
 The name is reserved within an encoded track directory and cannot collide with a decimal segment number.
@@ -733,8 +736,9 @@ A group that arrives after its segment object has been written is not recorded.
 A writer SHOULD wait for the segment to be complete rather than write early, and MAY bound that wait so a track that has stopped without closing cannot stall the recording indefinitely.
 This is a deliberate trade: addressing content by segment is what makes a segment retrievable in one request, and it costs the ability to append a late group to an object already written.
 
-A writer SHOULD record the broadcast's final state on a clean end, so a reader can distinguish an ended recording from one whose writer died.
-Once ended, every object in the recording is immutable.
+On a clean end, the writer MUST make the final track objects, segment objects, and timeline durable before creating an empty `.complete` object as its last write.
+It MUST NOT create `.complete` when finalization fails.
+The marker is immutable; its presence distinguishes a clean end, while its absence means the recording is live or was interrupted.
 
 ## Retention {#recording-retention}
 A recording has one of two retention modes:
@@ -754,10 +758,10 @@ Relay cache eviction does not change the recording timeline.
 Reading segment N of track T is: resolve T's object name from N, GET it, and parse the groups.
 Nothing on that path reads media the consumer did not ask for, and nothing requires a second request.
 
-Segment objects and track objects are immutable and SHOULD be served with long-lived caching.
+Segment objects, track objects, and `.complete` are immutable and SHOULD be served with long-lived caching.
 `.timeline` changes while the recording is live and SHOULD be served with a short lifetime and an entity validator.
-All objects in an unbounded recording become immutable once the recording has ended.
-A bounded recording's timeline can continue to change while retention is active.
+An unbounded recording's timeline becomes immutable when `.complete` exists.
+A bounded recording's timeline can continue to change while retention is active, even after `.complete` exists.
 
 A reader MAY serve moq-lite FETCH from a recording.
 Given a group, the timeline record whose range covers it names the segment; the object's group headers locate the group within it; and its frames are the FETCH response body unchanged.

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -630,7 +630,8 @@ A recording is a set of objects under a common prefix:
 <prefix>/<track>/<segment>
 ~~~
 
-`<track>` is the track's name with every byte outside `A-Z a-z 0-9 _ -` percent-encoded.
+`<track>` is the track's name with every byte outside `A-Z a-z 0-9 _ -` percent-encoded as `%` followed by two uppercase hexadecimal digits.
+For example, `catalog.json` becomes `catalog%2Ejson`.
 An encoded name therefore never contains `/` and never begins with `.`, so a track can neither collide with the reserved `.timeline` name nor address anything outside the prefix.
 
 `.track` stores the immutable properties of its parent track ({{recording-track}}).
@@ -698,8 +699,9 @@ Segment objects are immutable once written.
 `.timeline` holds the timeline records in order, using the track's framing ({{timeline-framing}}).
 It is the one track not addressed by segment, because it is the index that names the segments.
 
-An unbounded archive stores the timeline track's frames verbatim.
+An unbounded archive re-encodes each source record into a recording-owned timeline stream.
 The object grows as the broadcast does, and its content is append-only: bytes once written never change.
+Re-encoding lets the writer replace a source record with an atomic gap ({{recording-writer}}) while keeping one coherent compression window for the recording.
 
 A reader starting fresh reads the object from the beginning, which the shared DEFLATE window requires anyway.
 A reader following a live recording issues a ranged GET from the offset it last read and feeds the new bytes to the decompressor it already holds: each frame's sync-flush block terminates its own compressed data, so the appended bytes decode without re-reading earlier ones.
@@ -723,6 +725,8 @@ Since the timeline record itself is only published once the segment is complete 
 
 If any object for a segment cannot be made durable, the writer MUST record an atomic gap for that segment rather than publish a partial set of tracks.
 The gap is the same timeline record with `tracks` absent or empty, so it preserves the segment number and timing but references no objects.
+The writer encodes that gap and every subsequent record through the recording's own DEFLATE encoder, whose shared dictionary therefore contains the gap rather than the source record it replaced.
+It MUST NOT append a later source frame compressed against the source timeline's different dictionary.
 The writer then continues with the next segment.
 
 A group that arrives after its segment object has been written is not recorded.

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -542,14 +542,14 @@ A pacing track that has produced nothing for the span holds the record back; a p
 
 A pacing track is one whose groups arrive continuously, which is what makes them usable as boundaries.
 A track that publishes on its own schedule cannot pace: a catalog emits a group only when the renditions change, so a timeline waiting for it would stall the moment it went quiet.
-Such a track is *passive*: its groups are listed in whichever segment is open when they arrive, but it never determines a boundary and never holds a record back.
+Such a track is *non-pacing*: its groups are listed in whichever segment is open when they arrive, but it never determines a boundary and never holds a record back.
 A publisher SHOULD record its catalog this way, so a recording can resolve the renditions in effect at any segment.
 
-Placement of a passive track's groups is therefore by arrival rather than by content time: nothing waits for them, so a group that arrives after its segment has already been published is listed in the next one.
-When a segment closes, every passive group that arrived while it was open belongs to that segment regardless of the timestamp basis carried by the passive track.
+Placement of a non-pacing track's groups is therefore by arrival rather than by content time: nothing waits for them, so a group that arrives after its segment has already been published is listed in the next one.
+When a segment closes, every non-pacing group that arrived while it was open belongs to that segment regardless of the timestamp basis carried by the non-pacing track.
 The frames still carry their own timestamps, so no timing information is lost.
-A passive track's timestamps do not extend the final segment's duration.
-A passive track whose group never closes (an append-log such as a `moq-json` stream) is listed once, in the segment its group opened in.
+A non-pacing track's timestamps do not extend the final segment's duration.
+A non-pacing track whose group never closes (an append-log such as a `moq-json` stream) is listed once, in the segment its group opened in.
 A publisher that needs such content addressable per segment SHOULD roll the group at segment boundaries, which costs the shared compression window but makes each segment self-contained.
 
 A group that starts before the first boundary belongs to the first segment.

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -513,10 +513,14 @@ Numbers are consecutive within a broadcast, anchoring HLS `EXT-X-MEDIA-SEQUENCE`
 The `pts` field is the segment's start and `duration` its length, both in the timeline's timescale.
 The next record's `pts` equals `pts + duration` unless content time itself jumped; a consumer SHOULD treat such a jump as a discontinuity.
 
-The `tracks` field maps each participating media track name to the group ranges it contributes.
+The `tracks` field maps each participating track name to the group ranges it contributes.
 Each range covers groups `start` through `end` inclusive, as used by moq-lite FETCH and SUBSCRIBE.
 More than one range means the group sequence is discontinuous inside the segment: the skipped groups never existed.
 A track absent from the map has no content for the span (a gap; HLS `EXT-X-GAP`).
+
+Participating tracks need not be audio or video.
+A catalog, or an application's own metadata track such as a chat log, is listed exactly like a media track, which is what lets a recording ({{recording}}) address all of them the same way.
+A consumer that only wants renditions therefore MUST select tracks by consulting the catalog rather than by assuming every name in the map is media.
 A record MUST tolerate and SHOULD preserve unknown fields, like the catalog.
 
 The `keyframe` field states whether the range's first group starts with a keyframe, i.e. whether a player can join or switch renditions there.
@@ -532,9 +536,19 @@ A publisher pacing itself SHOULD end a segment at the earliest point that is a g
 A minimum is always satisfiable, whereas a maximum is not: a single group longer than it cannot be divided.
 Where no such point exists because two tracks have different coarse cadences, a publisher MUST choose one of them rather than a point interior to any track's group.
 
-Whatever the policy, a publisher MUST NOT emit a record until the segment is complete: every participating track's groups for the span are known.
+Whatever the policy, a publisher MUST NOT emit a record until the segment is complete: every *pacing* track's groups for the span are known.
 Records are therefore self-contained and immediately servable, and the newest record is the live edge.
-An enrolled track that has produced nothing for the span holds the record back; a publisher that knows a track has stopped for good closes it, and the record then simply omits it (a gap).
+A pacing track that has produced nothing for the span holds the record back; a publisher that knows a track has stopped for good closes it, and the record then simply omits it (a gap).
+
+A pacing track is one whose groups arrive continuously, which is what makes them usable as boundaries.
+A track that publishes on its own schedule cannot pace: a catalog emits a group only when the renditions change, so a timeline waiting for it would stall the moment it went quiet.
+Such a track is *passive*: its groups are listed in whichever segment is open when they arrive, but it never determines a boundary and never holds a record back.
+A publisher SHOULD record its catalog this way, so a recording can resolve the renditions in effect at any segment.
+
+Placement of a passive track's groups is therefore by arrival rather than by content time: nothing waits for them, so a group that arrives after its segment has already been published is listed in the next one.
+The frames still carry their own timestamps, so no timing information is lost.
+A passive track whose group never closes (an append-log such as a `moq-json` stream) is listed once, in the segment its group opened in.
+A publisher that needs such content addressable per segment SHOULD roll the group at segment boundaries, which costs the shared compression window but makes each segment self-contained.
 
 A group that starts before the first boundary belongs to the first segment.
 The final segment of an ended broadcast has no closing boundary; its `duration` runs to the newest known content.
@@ -609,13 +623,15 @@ A broadcast with no timeline has no segments and cannot be recorded this way.
 A recording is a set of objects under a common prefix:
 
 ~~~
-<prefix>/.catalog/<segment>
 <prefix>/.timeline
 <prefix>/<track>/<segment>
 ~~~
 
-`<track>` is the media track's name with every byte outside `A-Z a-z 0-9 _ -` percent-encoded.
-An encoded name therefore never contains `/` and never begins with `.`, so a track can neither collide with the reserved `.catalog` and `.timeline` names nor address anything outside the prefix.
+`<track>` is the track's name with every byte outside `A-Z a-z 0-9 _ -` percent-encoded.
+An encoded name therefore never contains `/` and never begins with `.`, so a track can neither collide with the reserved `.timeline` name nor address anything outside the prefix.
+
+Every track the timeline lists is stored the same way, including a passively enrolled catalog or metadata track ({{timeline-segmentation}}).
+There is no separate rule for non-media content: the catalog in effect at segment N is the newest catalog object numbered at or before N, found the same way a player finds the media.
 
 `<segment>` is the timeline record's `segment` value in decimal without leading zeros, so an object name is computed from a record rather than discovered by listing.
 
@@ -653,16 +669,13 @@ The timeline is needed to *find* an object, not to read one.
 
 Segment objects are immutable once written.
 
-## Timeline and Catalog Objects {#recording-metadata}
+## The Timeline Object {#recording-metadata}
 `.timeline` holds the frames of the timeline track verbatim, in order, using the track's own framing ({{timeline-framing}}).
+It is the one track not addressed by segment, because it is the index that names the segments.
 The object grows as the broadcast does, and its content is append-only: bytes once written never change.
 
 A reader starting fresh reads the object from the beginning, which the shared DEFLATE window requires anyway.
 A reader following a live recording issues a ranged GET from the offset it last read and feeds the new bytes to the decompressor it already holds: each frame's sync-flush block terminates its own compressed data, so the appended bytes decode without re-reading earlier ones.
-
-`.catalog/<segment>` holds one catalog frame ({{catalog}}), where `<segment>` is the first segment it applies to.
-The catalog in effect for segment N is the object with the highest number not greater than N, so a reader resolves the renditions available at any point in the recording without scanning.
-A publisher that updates the catalog more than once within a single segment records only the last, since the earlier states were never in effect at a segment boundary.
 
 ## Writer Behavior {#recording-writer}
 A writer subscribes to the broadcast, buffers each track's groups, and writes a track's segment object once that track's groups for the span are known.

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -263,7 +263,7 @@ Unlike audio and video there is no WebCodecs decoder for text, so a consumer par
 
 ~~~
 type TextSchema = {
-	"renditions": Map<TrackName, TextConfig>,
+  "renditions": Map<TrackName, TextConfig>,
 }
 
 type TextConfig = {
@@ -303,21 +303,21 @@ For example:
 
 ~~~
 {
-	"renditions": {
-		"captions.en": {
-			"format": "vtt",
-			"container": { "kind": "legacy" },
-			"role": "caption",
-			"lang": "en",
-			"label": "English"
-		},
-		"subtitles.es": {
-			"format": "vtt",
-			"container": { "kind": "legacy" },
-			"role": "subtitle",
-			"lang": "es"
-		}
-	}
+  "renditions": {
+    "captions.en": {
+      "format": "vtt",
+      "container": { "kind": "legacy" },
+      "role": "caption",
+      "lang": "en",
+      "label": "English"
+    },
+    "subtitles.es": {
+      "format": "vtt",
+      "container": { "kind": "legacy" },
+      "role": "subtitle",
+      "lang": "es"
+    }
+  }
 }
 ~~~
 
@@ -453,10 +453,10 @@ The catalog's root `timeline` field advertises the track:
 
 ~~~
 type TimelineSchema = {
-	"track": string,
-	"timescale": number | undefined,
-	"durationMax": number | undefined,
-	"wall": number | undefined,
+  "track": string,
+  "timescale": number | undefined,
+  "durationMax": number | undefined,
+  "wall": number | undefined,
 }
 ~~~
 
@@ -494,16 +494,16 @@ Each record describes one complete segment:
 
 ~~~
 type TimelineRecord = {
-	"segment": number,
-	"pts": number,
-	"duration": number,
-	"tracks": Map<TrackName, TimelineRange[]> | undefined,
+  "segment": number,
+  "pts": number,
+  "duration": number,
+  "tracks": Map<TrackName, TimelineRange[]> | undefined,
 }
 
 type TimelineRange = {
-	"start": number,
-	"end": number,
-	"keyframe": boolean | undefined,
+  "start": number,
+  "end": number,
+  "keyframe": boolean | undefined,
 }
 ~~~
 
@@ -546,7 +546,9 @@ Such a track is *passive*: its groups are listed in whichever segment is open wh
 A publisher SHOULD record its catalog this way, so a recording can resolve the renditions in effect at any segment.
 
 Placement of a passive track's groups is therefore by arrival rather than by content time: nothing waits for them, so a group that arrives after its segment has already been published is listed in the next one.
+When a segment closes, every passive group that arrived while it was open belongs to that segment regardless of the timestamp basis carried by the passive track.
 The frames still carry their own timestamps, so no timing information is lost.
+A passive track's timestamps do not extend the final segment's duration.
 A passive track whose group never closes (an append-log such as a `moq-json` stream) is listed once, in the segment its group opened in.
 A publisher that needs such content addressable per segment SHOULD roll the group at segment boundaries, which costs the shared compression window but makes each segment self-contained.
 
@@ -624,11 +626,15 @@ A recording is a set of objects under a common prefix:
 
 ~~~
 <prefix>/.timeline
+<prefix>/<track>/.track
 <prefix>/<track>/<segment>
 ~~~
 
 `<track>` is the track's name with every byte outside `A-Z a-z 0-9 _ -` percent-encoded.
 An encoded name therefore never contains `/` and never begins with `.`, so a track can neither collide with the reserved `.timeline` name nor address anything outside the prefix.
+
+`.track` stores the immutable properties of its parent track ({{recording-track}}).
+The name is reserved within an encoded track directory and cannot collide with a decimal segment number.
 
 Every track the timeline lists is stored the same way, including a passively enrolled catalog or metadata track ({{timeline-segmentation}}).
 There is no separate rule for non-media content: the catalog in effect at segment N is the newest catalog object numbered at or before N, found the same way a player finds the media.
@@ -637,6 +643,25 @@ There is no separate rule for non-media content: the catalog in effect at segmen
 
 Each media track gets its own objects so a consumer can fetch one rendition without paying for the others, which is the point of publishing switchable renditions at all.
 For the same reason a publisher SHOULD NOT combine tracks into a single object, even when they are always played together: doing so forces every consumer to fetch the highest rendition it does not want.
+
+## Track Objects {#recording-track}
+`<track>/.track` stores the immutable publisher properties needed to interpret and replay that track:
+
+~~~
+Track Object {
+  Publisher Priority (8)
+  Publisher Ordered (8)
+  Timescale (i)
+}
+~~~
+
+The fields have the meanings and encodings defined by moq-lite `TRACK_INFO` {{moql}}.
+The source broadcast's epoch and `Publisher Max Latency` are not stored because the recording is a new generation with its own epoch and retention policy.
+A reader reconstructing `TRACK_INFO` uses the recording's resolved epoch and serving policy together with the stored fields.
+
+The track object MUST be durable before any timeline record referencing that track is written.
+It is immutable for the lifetime of the recording.
+In particular, the `Timescale` is required to decode the timestamp deltas in the track's recorded FRAME messages.
 
 ## Segment Objects {#recording-segments}
 A segment object holds one track's content for one segment, as a sequence of groups:
@@ -670,19 +695,35 @@ The timeline is needed to *find* an object, not to read one.
 Segment objects are immutable once written.
 
 ## The Timeline Object {#recording-metadata}
-`.timeline` holds the frames of the timeline track verbatim, in order, using the track's own framing ({{timeline-framing}}).
+`.timeline` holds the timeline records in order, using the track's framing ({{timeline-framing}}).
 It is the one track not addressed by segment, because it is the index that names the segments.
+
+An unbounded archive stores the timeline track's frames verbatim.
 The object grows as the broadcast does, and its content is append-only: bytes once written never change.
 
 A reader starting fresh reads the object from the beginning, which the shared DEFLATE window requires anyway.
 A reader following a live recording issues a ranged GET from the offset it last read and feeds the new bytes to the decompressor it already holds: each frame's sync-flush block terminates its own compressed data, so the appended bytes decode without re-reading earlier ones.
 
-## Writer Behavior {#recording-writer}
-A writer subscribes to the broadcast, buffers each track's groups, and writes a track's segment object once that track's groups for the span are known.
-Per-track objects are written independently: a track whose content is complete does not wait for a slower one.
+A duration-bounded recording instead stores a complete encoding of its current retained timeline suffix.
+When the oldest segment expires, the writer atomically replaces `.timeline` with a new standalone encoding that starts at the oldest retained record.
+The explicit `segment` field preserves numbering when the retained suffix does not start at zero.
+A reader uses an entity validator such as an ETag and restarts from byte zero when the object is replaced; it MUST NOT apply a byte range from one entity to another.
 
-A writer MUST make a segment's objects durable before appending the timeline record that references them, so a reader following `.timeline` never sees a record naming an object that does not yet exist.
+Re-encoding the timeline metadata for bounded retention does not re-encode any recorded media frame.
+The per-track segment objects remain byte-identical in both modes.
+
+## Writer Behavior {#recording-writer}
+A writer subscribes to the broadcast and buffers the in-progress segment independently of the publisher or relay cache.
+It writes a track's segment object once that track's groups for the span are known.
+Per-track objects are written independently: a track whose content is complete does not wait for a slower one.
+The recording contract MUST NOT depend on a relay retaining those groups while storage catches up.
+
+A writer MUST make a segment's track objects and segment objects durable before appending the timeline record that references them, so a reader following `.timeline` never sees a record naming an object that does not yet exist.
 Since the timeline record itself is only published once the segment is complete on every track ({{timeline-segmentation}}), this orders the whole recording: objects, then the record that indexes them.
+
+If any object for a segment cannot be made durable, the writer MUST record an atomic gap for that segment rather than publish a partial set of tracks.
+The gap is the same timeline record with `tracks` absent or empty, so it preserves the segment number and timing but references no objects.
+The writer then continues with the next segment.
 
 A group that arrives after its segment object has been written is not recorded.
 A writer SHOULD wait for the segment to be complete rather than write early, and MAY bound that wait so a track that has stopped without closing cannot stall the recording indefinitely.
@@ -691,12 +732,28 @@ This is a deliberate trade: addressing content by segment is what makes a segmen
 A writer SHOULD record the broadcast's final state on a clean end, so a reader can distinguish an ended recording from one whose writer died.
 Once ended, every object in the recording is immutable.
 
+## Retention {#recording-retention}
+A recording has one of two retention modes:
+
+- An *archive* is unbounded and retains every complete segment until explicitly deleted.
+- A *DVR* retains a configured duration of complete segments and expires the oldest whole segments as newer ones become durable.
+
+An application offering DVR without an explicit retention value SHOULD default to at least 30 seconds.
+The writer removes the oldest segment only when the remaining complete segments still cover the configured duration.
+Retention is measured from timeline records, not from wall-clock arrival or relay cache state.
+
+Expiration first makes a replacement `.timeline` durable that omits the expired record, then deletes that segment's per-track objects.
+The index therefore never advertises media the retention process has already deleted, although media objects MAY temporarily outlive the index.
+Relay cache eviction does not change the recording timeline.
+
 ## Reader Behavior {#recording-reader}
 Reading segment N of track T is: resolve T's object name from N, GET it, and parse the groups.
 Nothing on that path reads media the consumer did not ask for, and nothing requires a second request.
 
-Segment objects are immutable and SHOULD be served with long-lived caching.
-`.timeline` and `.catalog` change while the recording is live and SHOULD be served with short lifetimes; all three become immutable once the recording has ended.
+Segment objects and track objects are immutable and SHOULD be served with long-lived caching.
+`.timeline` changes while the recording is live and SHOULD be served with a short lifetime and an entity validator.
+All objects in an unbounded recording become immutable once the recording has ended.
+A bounded recording's timeline can continue to change while retention is active.
 
 A reader MAY serve moq-lite FETCH from a recording.
 Given a group, the timeline record whose range covers it names the segment; the object's group headers locate the group within it; and its frames are the FETCH response body unchanged.
@@ -715,6 +772,7 @@ TODO Security
 
 A consumer parsing a recording ({{recording}}) is parsing data at rest that it did not necessarily write.
 It MUST bounds-check a segment object's group `Length` and each frame's `Message Length` against the bytes actually retrieved, rather than trusting either to describe the object, and it MUST treat a malformed object as a missing segment rather than letting it invalidate the recording.
+It MUST reject a track object with an invalid `Publisher Ordered` value or a zero `Timescale`.
 Varint fields are subject to the same limits as moq-lite {{moql}}.
 A recording inherits the confidentiality and integrity properties of the storage holding it; encryption at rest is transparent to the format and out of scope.
 

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -89,7 +89,7 @@ Publishers and subscribers SHOULD terminate any subscriptions once a participant
 ANNOUNCE suffix=alice.hang active=false
 ~~~
 
-# Catalog
+# Catalog {#catalog}
 The catalog describes the available media tracks for a single participant.
 It's a JSON document that extends the W3C WebCodecs specification {{webcodecs}}.
 
@@ -594,11 +594,116 @@ This is what makes a time table proxyable: each tick republishes a small snapsho
 Carrying the source's time rather than synthesizing one keeps the clock consistent with the EPG (event times are expressed on the source's clock) and preserves TOT's local-time-offset descriptors, which are operator policy a re-multiplexer cannot invent.
 
 
+# Recording {#recording}
+A live broadcast is bounded history: moq-lite {{moql}} serves the present with SUBSCRIBE and the recent past with FETCH, both ending at the publisher's cache.
+A *recording* is the persistent tier, writing a broadcast to a filesystem or object store so it can be served back long after the live session ended.
+
+A recording is addressed by segment.
+The timeline ({{timeline}}) already names every segment and the groups that carry it, so it is the recording's only index: the segment number names the object, and no separate index needs to be stored, refreshed, or kept consistent with the media.
+A reader that wants segment N of a track issues one whole-object GET, with no range header and no second request, which is what both an HLS or DASH origin and a player seeking a VOD recording need.
+
+A recording covers the tracks the timeline describes, plus the catalog and the timeline itself.
+A broadcast with no timeline has no segments and cannot be recorded this way.
+
+## Layout {#recording-layout}
+A recording is a set of objects under a common prefix:
+
+~~~
+<prefix>/.catalog/<segment>
+<prefix>/.timeline
+<prefix>/<track>/<segment>
+~~~
+
+`<track>` is the media track's name with every byte outside `A-Z a-z 0-9 _ -` percent-encoded.
+An encoded name therefore never contains `/` and never begins with `.`, so a track can neither collide with the reserved `.catalog` and `.timeline` names nor address anything outside the prefix.
+
+`<segment>` is the timeline record's `segment` value in decimal without leading zeros, so an object name is computed from a record rather than discovered by listing.
+
+Each media track gets its own objects so a consumer can fetch one rendition without paying for the others, which is the point of publishing switchable renditions at all.
+For the same reason a publisher SHOULD NOT combine tracks into a single object, even when they are always played together: doing so forces every consumer to fetch the highest rendition it does not want.
+
+## Segment Objects {#recording-segments}
+A segment object holds one track's content for one segment, as a sequence of groups:
+
+~~~
+Segment Object {
+  Group {
+    Sequence (i)
+    Length (i)
+    Frame (..) ...
+  } ...
+}
+~~~
+
+Fields annotated `(i)` are variable-length integers using the QUIC encoding ({{!RFC9000}}, Section 16).
+
+**Sequence** is the group's sequence number, matching the range that listed it in the timeline record.
+Groups appear in ascending sequence order.
+
+**Length** is the byte length of the group's frames, so a reader skips a group it does not want without parsing it.
+
+**Frame** is the moq-lite FRAME encoding {{moql}}: a zigzag `Timestamp Delta`, a `Message Length`, and the payload, exactly as the group was delivered.
+A group's frames are therefore byte-identical to the body of a FETCH response for that group, and a recording never re-encodes media.
+
+A segment object MUST contain whole groups.
+Segmentation already forbids a boundary interior to any track's group ({{timeline-segmentation}}), so a group is never split across two segments and a reader never has to stitch one back together.
+
+Because the object carries its own group boundaries it is parseable on its own, without the timeline.
+The timeline is needed to *find* an object, not to read one.
+
+Segment objects are immutable once written.
+
+## Timeline and Catalog Objects {#recording-metadata}
+`.timeline` holds the frames of the timeline track verbatim, in order, using the track's own framing ({{timeline-framing}}).
+The object grows as the broadcast does, and its content is append-only: bytes once written never change.
+
+A reader starting fresh reads the object from the beginning, which the shared DEFLATE window requires anyway.
+A reader following a live recording issues a ranged GET from the offset it last read and feeds the new bytes to the decompressor it already holds: each frame's sync-flush block terminates its own compressed data, so the appended bytes decode without re-reading earlier ones.
+
+`.catalog/<segment>` holds one catalog frame ({{catalog}}), where `<segment>` is the first segment it applies to.
+The catalog in effect for segment N is the object with the highest number not greater than N, so a reader resolves the renditions available at any point in the recording without scanning.
+A publisher that updates the catalog more than once within a single segment records only the last, since the earlier states were never in effect at a segment boundary.
+
+## Writer Behavior {#recording-writer}
+A writer subscribes to the broadcast, buffers each track's groups, and writes a track's segment object once that track's groups for the span are known.
+Per-track objects are written independently: a track whose content is complete does not wait for a slower one.
+
+A writer MUST make a segment's objects durable before appending the timeline record that references them, so a reader following `.timeline` never sees a record naming an object that does not yet exist.
+Since the timeline record itself is only published once the segment is complete on every track ({{timeline-segmentation}}), this orders the whole recording: objects, then the record that indexes them.
+
+A group that arrives after its segment object has been written is not recorded.
+A writer SHOULD wait for the segment to be complete rather than write early, and MAY bound that wait so a track that has stopped without closing cannot stall the recording indefinitely.
+This is a deliberate trade: addressing content by segment is what makes a segment retrievable in one request, and it costs the ability to append a late group to an object already written.
+
+A writer SHOULD record the broadcast's final state on a clean end, so a reader can distinguish an ended recording from one whose writer died.
+Once ended, every object in the recording is immutable.
+
+## Reader Behavior {#recording-reader}
+Reading segment N of track T is: resolve T's object name from N, GET it, and parse the groups.
+Nothing on that path reads media the consumer did not ask for, and nothing requires a second request.
+
+Segment objects are immutable and SHOULD be served with long-lived caching.
+`.timeline` and `.catalog` change while the recording is live and SHOULD be served with short lifetimes; all three become immutable once the recording has ended.
+
+A reader MAY serve moq-lite FETCH from a recording.
+Given a group, the timeline record whose range covers it names the segment; the object's group headers locate the group within it; and its frames are the FETCH response body unchanged.
+A FETCH bounded to a frame range {{moql}} is served by counting frames within that group.
+A group absent from the recording is a normal FETCH failure.
+
+A reader deriving a presentation-ordered format renders it from the timeline and transmuxes segment objects on demand.
+Nothing derived needs to be stored: the playlist or manifest is a function of the timeline, and a media segment is a function of one recorded object.
+
+
 # Security Considerations
 A rendition's `broadcast` reference ({{field-broadcast}}) resolves against the consumer's root, which is the subtree it is authorized for.
 Clamping a reference that escapes above that root would silently redirect the subscription to an unrelated broadcast, so a consumer rejects the catalog instead.
 
 TODO Security
+
+A consumer parsing a recording ({{recording}}) is parsing data at rest that it did not necessarily write.
+It MUST bounds-check a segment object's group `Length` and each frame's `Message Length` against the bytes actually retrieved, rather than trusting either to describe the object, and it MUST treat a malformed object as a missing segment rather than letting it invalidate the recording.
+Varint fields are subject to the same limits as moq-lite {{moql}}.
+A recording inherits the confidentiality and integrity properties of the storage holding it; encryption at rest is transparent to the format and out of scope.
 
 
 # IANA Considerations

--- a/js/hang/src/container/timeline.test.ts
+++ b/js/hang/src/container/timeline.test.ts
@@ -458,3 +458,60 @@ test("a cut on the first group does not poison later cuts", async () => {
 	expect(out[0]).toEqual({ segment: 0, pts: 0, duration: 3000, tracks: { video0: [{ start: 0, end: 2 }] } });
 	expect(out[1]).toEqual({ segment: 1, pts: 3000, duration: 3000, tracks: { video0: [{ start: 3, end: 5 }] } });
 });
+
+// A catalog publishes a group only when the renditions change, so it can go quiet for the rest
+// of the broadcast. Enrolled as a pacing track it would stall the timeline for good; passive, it
+// rides along in whichever segment is open.
+test("a passive track neither paces nor gates", async () => {
+	const { timeline, records } = capture();
+	const video = timeline.track("video0");
+	const catalog = timeline.passive("catalog.json");
+
+	catalog.record(0, us(0));
+	video.record(0, us(0));
+	video.record(1, us(2000));
+	video.record(2, us(4000));
+	video.end(us(6000));
+	video.close();
+	timeline.finish();
+
+	expect(await records()).toEqual([
+		{
+			segment: 0,
+			pts: 0,
+			duration: 2000,
+			tracks: { "catalog.json": [{ start: 0, end: 0 }], video0: [{ start: 0, end: 0 }] },
+		},
+		{ segment: 1, pts: 2000, duration: 2000, tracks: { video0: [{ start: 1, end: 1 }] } },
+		{ segment: 2, pts: 4000, duration: 2000, tracks: { video0: [{ start: 2, end: 2 }] } },
+	]);
+});
+
+// Nothing waits for a passive track, so a group arriving after its segment already flushed is
+// recorded in the next one. Placement is by arrival; the frames still carry their own timestamps.
+test("a late passive group lands in the next segment", async () => {
+	const { timeline, records } = capture();
+	const video = timeline.track("video0");
+	const catalog = timeline.passive("catalog.json");
+
+	video.record(0, us(0));
+	// Flushes segment 0, which the catalog has contributed nothing to.
+	video.record(1, us(2000));
+
+	// The update happened a second in, but only reaches the timeline now.
+	catalog.record(0, us(1000));
+
+	video.record(2, us(4000));
+	video.end(us(6000));
+	video.close();
+	timeline.finish();
+
+	const out = await records();
+	expect(out[0]).toEqual({ segment: 0, pts: 0, duration: 2000, tracks: { video0: [{ start: 0, end: 0 }] } });
+	expect(out[1]).toEqual({
+		segment: 1,
+		pts: 2000,
+		duration: 2000,
+		tracks: { "catalog.json": [{ start: 0, end: 0 }], video0: [{ start: 1, end: 1 }] },
+	});
+});

--- a/js/hang/src/container/timeline.test.ts
+++ b/js/hang/src/container/timeline.test.ts
@@ -515,3 +515,25 @@ test("a late passive group lands in the next segment", async () => {
 		tracks: { "catalog.json": [{ start: 0, end: 0 }], video0: [{ start: 1, end: 1 }] },
 	});
 });
+
+test("a passive track uses arrival and does not extend the tail", async () => {
+	const { timeline, records } = capture();
+	const video = timeline.track("video0");
+	const catalog = timeline.passive("catalog.json");
+
+	video.record(0, us(0));
+	catalog.record(0, us(10_000));
+	video.record(1, us(2000));
+	video.end(us(4000));
+	timeline.finish();
+
+	expect(await records()).toEqual([
+		{
+			segment: 0,
+			pts: 0,
+			duration: 2000,
+			tracks: { "catalog.json": [{ start: 0, end: 0 }], video0: [{ start: 0, end: 0 }] },
+		},
+		{ segment: 1, pts: 2000, duration: 2000, tracks: { video0: [{ start: 1, end: 1 }] } },
+	]);
+});

--- a/js/hang/src/container/timeline.test.ts
+++ b/js/hang/src/container/timeline.test.ts
@@ -30,8 +30,8 @@ function capture(props?: ConstructorParameters<typeof Producer>[1]): {
 // The coarsest track paces: video GOPs are longer than durationMin, so segments are GOPs.
 test("the coarsest track paces the segments", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = timeline.pacingTrack("video0");
+	const audio = timeline.pacingTrack("audio0");
 
 	// Video keyframes every 2s, audio groups every 500ms, minimum 1s.
 	video.record(0, us(0));
@@ -85,7 +85,7 @@ test("the coarsest track paces the segments", async () => {
 // a segment could start and stay decodable, so the segment is simply long.
 test("a GOP longer than the minimum is one segment", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = timeline.pacingTrack("video0");
 
 	video.record(0, us(0));
 	video.record(1, us(30_000));
@@ -102,7 +102,7 @@ test("a GOP longer than the minimum is one segment", async () => {
 // Groups shorter than the minimum pack into one segment rather than each becoming one.
 test("short groups pack up to the minimum", async () => {
 	const { timeline, records } = capture({ durationMin: 1500 });
-	const audio = timeline.track("audio0");
+	const audio = timeline.pacingTrack("audio0");
 
 	for (let seq = 0; seq < 8; seq++) {
 		audio.record(seq, us(seq * 500));
@@ -120,8 +120,8 @@ test("short groups pack up to the minimum", async () => {
 // a rendition that was about to contribute to it.
 test("a segment waits for every track", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = timeline.pacingTrack("video0");
+	const audio = timeline.pacingTrack("audio0");
 
 	video.record(0, us(0));
 	audio.record(0, us(0));
@@ -144,7 +144,7 @@ test("a segment waits for every track", async () => {
 // An application that knows its own boundaries overrides the pacing.
 test("explicit cuts override the pacing", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = timeline.pacingTrack("video0");
 
 	// Keyframes every second, cut every three: the segments follow the cuts, not the GOPs.
 	timeline.cut(us(3000));
@@ -164,7 +164,7 @@ test("explicit cuts override the pacing", async () => {
 // segment shorter than the minimum is dropped rather than producing a stray segment.
 test("a cut below the minimum is ignored", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = timeline.pacingTrack("video0");
 
 	video.record(0, us(0));
 	timeline.cut(us(2000));
@@ -188,7 +188,7 @@ test("a cut below the minimum is ignored", async () => {
 // the catalog.
 test("exceeding the declared maximum fails the timeline", async () => {
 	const { timeline, records } = capture({ durationMin: 1000, durationMax: 3000 });
-	const video = timeline.track("video0");
+	const video = timeline.pacingTrack("video0");
 
 	video.record(0, us(0));
 	video.record(1, us(2000));
@@ -214,7 +214,7 @@ test("an undeclared maximum is omitted from the catalog", () => {
 // final segment's duration collapses to zero (an HLS EXTINF:0).
 test("the final segment runs to the reported end", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = timeline.pacingTrack("video0");
 
 	video.record(0, us(0));
 	video.record(1, us(2000));
@@ -236,7 +236,7 @@ test("a reservation defers flushing until every track enrolls", async () => {
 	const release = timeline.reserve();
 
 	// The primary rendition runs a whole batch of segments through before its sibling exists.
-	const first = timeline.track("video0");
+	const first = timeline.pacingTrack("video0");
 	for (const [seq, ms] of [
 		[0, 0],
 		[1, 2000],
@@ -245,7 +245,7 @@ test("a reservation defers flushing until every track enrolls", async () => {
 		first.record(seq, us(ms));
 	}
 
-	const second = timeline.track("video1");
+	const second = timeline.pacingTrack("video1");
 	for (const [seq, ms] of [
 		[0, 0],
 		[1, 2000],
@@ -280,8 +280,8 @@ test("a reservation defers flushing until every track enrolls", async () => {
 // A track that races ahead of the others still lands in the segment its content falls in.
 test("groups before the first boundary join the first segment", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = timeline.pacingTrack("video0");
+	const audio = timeline.pacingTrack("audio0");
 
 	audio.record(0, us(0));
 	video.record(0, us(30));
@@ -311,8 +311,8 @@ test("groups before the first boundary join the first segment", async () => {
 
 test("sequence gaps split ranges", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = timeline.pacingTrack("video0");
+	const audio = timeline.pacingTrack("audio0");
 
 	// Elemental-style gap: audio groups 2..=4 never existed inside segment 0.
 	video.record(0, us(0));
@@ -345,8 +345,8 @@ test("sequence gaps split ranges", async () => {
 // has merely gone quiet still gets to say where the boundary is.
 test("a closed track leaves a whole segment gap", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const audio = timeline.track("audio0");
+	const video = timeline.pacingTrack("video0");
+	const audio = timeline.pacingTrack("audio0");
 
 	video.record(0, us(0));
 	audio.record(0, us(0));
@@ -362,7 +362,7 @@ test("a closed track leaves a whole segment gap", async () => {
 
 test("a non-keyframe range start is flagged", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = timeline.pacingTrack("video0");
 
 	video.record(0, us(0));
 	// A mid-stream join: the group doesn't open on an IDR.
@@ -395,7 +395,7 @@ test("reservations nest", async () => {
 	const outer = timeline.reserve();
 	const inner = timeline.reserve();
 
-	const first = timeline.track("video0");
+	const first = timeline.pacingTrack("video0");
 	for (const [seq, ms] of [
 		[0, 0],
 		[1, 2000],
@@ -407,7 +407,7 @@ test("reservations nest", async () => {
 	// If reservations didn't nest, releasing this one would publish segment 0 without video1.
 	inner();
 
-	const second = timeline.track("video1");
+	const second = timeline.pacingTrack("video1");
 	for (const [seq, ms] of [
 		[0, 0],
 		[1, 2000],
@@ -441,7 +441,7 @@ test("reservations nest", async () => {
 // spent cut must not block the ones behind it, and durationMin pacing must not race ahead of them.
 test("a cut on the first group does not poison later cuts", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
+	const video = timeline.pacingTrack("video0");
 
 	// Source segments every 3s, keyframes every 1s: 3s segments, not the 1s the durationMin
 	// pacing would produce on its own.
@@ -460,12 +460,12 @@ test("a cut on the first group does not poison later cuts", async () => {
 });
 
 // A catalog publishes a group only when the renditions change, so it can go quiet for the rest
-// of the broadcast. Enrolled as a pacing track it would stall the timeline for good; passive, it
+// of the broadcast. Enrolled as a pacing track it would stall the timeline for good; non-pacing, it
 // rides along in whichever segment is open.
-test("a passive track neither paces nor gates", async () => {
+test("a non-pacing track neither paces nor gates", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const catalog = timeline.passive("catalog.json");
+	const video = timeline.pacingTrack("video0");
+	const catalog = timeline.track("catalog.json");
 
 	catalog.record(0, us(0));
 	video.record(0, us(0));
@@ -487,12 +487,12 @@ test("a passive track neither paces nor gates", async () => {
 	]);
 });
 
-// Nothing waits for a passive track, so a group arriving after its segment already flushed is
+// Nothing waits for a non-pacing track, so a group arriving after its segment already flushed is
 // recorded in the next one. Placement is by arrival; the frames still carry their own timestamps.
-test("a late passive group lands in the next segment", async () => {
+test("a late non-pacing group lands in the next segment", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const catalog = timeline.passive("catalog.json");
+	const video = timeline.pacingTrack("video0");
+	const catalog = timeline.track("catalog.json");
 
 	video.record(0, us(0));
 	// Flushes segment 0, which the catalog has contributed nothing to.
@@ -516,10 +516,10 @@ test("a late passive group lands in the next segment", async () => {
 	});
 });
 
-test("a passive track uses arrival and does not extend the tail", async () => {
+test("a non-pacing track uses arrival and does not extend the tail", async () => {
 	const { timeline, records } = capture();
-	const video = timeline.track("video0");
-	const catalog = timeline.passive("catalog.json");
+	const video = timeline.pacingTrack("video0");
+	const catalog = timeline.track("catalog.json");
 
 	video.record(0, us(0));
 	catalog.record(0, us(10_000));

--- a/js/hang/src/container/timeline.ts
+++ b/js/hang/src/container/timeline.ts
@@ -114,6 +114,9 @@ interface TrackState {
 	// group starts there) and by Recorder.end (the content stops there).
 	frontier?: Time.Micro;
 	closed: boolean;
+	// Never paces boundaries or gates completeness, even while open: groups are recorded into
+	// whichever segment is open when they arrive. See Producer.passive.
+	passive: boolean;
 }
 
 /**
@@ -161,16 +164,44 @@ export class Producer {
 	}
 
 	/**
-	 * Enroll the media track `name`, returning the {@link Recorder} it reports through.
+	 * Enroll the media track `name` as a pacing track, returning the {@link Recorder} it reports
+	 * through.
 	 *
 	 * The segment records key ranges by this name, and the track paces boundaries and gates
 	 * completeness until its recorder closes. Enroll a track when it is about to produce: an
 	 * enrolled but silent track holds every record back, by design, since a segment isn't
 	 * complete until every track's content is known. One recorder per track: enrolling the same
 	 * name again resets its state.
+	 *
+	 * This is for tracks whose groups arrive continuously, which is what makes them usable as
+	 * boundaries. A track that publishes on its own schedule belongs in {@link passive}.
 	 */
 	track(name: string): Recorder {
-		this.#tracks.set(name, { pending: [], frontier: undefined, closed: false });
+		this.#tracks.set(name, { pending: [], frontier: undefined, closed: false, passive: false });
+		return new Recorder(this, name);
+	}
+
+	/**
+	 * Enroll the track `name` without letting it influence segmentation, returning its
+	 * {@link Recorder}.
+	 *
+	 * A passive track's groups are recorded into whichever segment is open when they arrive, but
+	 * it never votes on where a boundary falls and never holds a record back. That is what a track
+	 * publishing on its own schedule needs: a catalog that emits a group only when the renditions
+	 * change, or an application's metadata track. Enrolling such a track with {@link track}
+	 * instead would stall the timeline for good, since a segment cannot end until every pacing
+	 * track has reported past its boundary.
+	 *
+	 * The trade is that a passive track's groups are placed by arrival rather than by content
+	 * time: nothing waits for them, so a group that shows up after its segment already flushed is
+	 * recorded in the next one. The frames still carry their own timestamps.
+	 *
+	 * A group that never closes (a `@moq/json` stream log) is recorded once, in the segment its
+	 * group opened in, and never again. Roll the group at segment boundaries if its content needs
+	 * to be addressable per segment.
+	 */
+	passive(name: string): Recorder {
+		this.#tracks.set(name, { pending: [], frontier: undefined, closed: false, passive: true });
 		return new Recorder(this, name);
 	}
 
@@ -295,9 +326,11 @@ export class Producer {
 	#advance(track: TrackState, pts: Time.Micro): void {
 		if (track.frontier === undefined || pts > track.frontier) track.frontier = pts;
 
-		// The first thing anybody reports anchors the first segment, so content produced before
-		// any boundary exists belongs to the oldest segment rather than to nowhere.
-		if (this.#start === undefined) this.#start = pts;
+		// The first thing a pacing track reports anchors the first segment, so content produced
+		// before any boundary exists belongs to the oldest segment rather than to nowhere. A
+		// passive track must not anchor it: a catalog published while the encoder is still warming
+		// up would otherwise stretch segment 0 across the whole startup gap.
+		if (this.#start === undefined && !track.passive) this.#start = pts;
 
 		this.#pump(false);
 	}
@@ -326,12 +359,13 @@ export class Producer {
 		if (!boundary) return false;
 		const [end, cut] = boundary;
 
-		// Every open track has to have reported at or past the boundary, proving its ranges for
-		// this segment are final. The track that voted for `end` has by construction; a track
-		// with shorter groups can still be behind it.
+		// Every open pacing track has to have reported at or past the boundary, proving its ranges
+		// for this segment are final. The track that voted for `end` has by construction; a track
+		// with shorter groups can still be behind it. A passive track is excluded: it may publish
+		// rarely or never again, so waiting on it would stall the timeline for good.
 		if (!finished) {
 			for (const track of this.#tracks.values()) {
-				if (track.closed) continue;
+				if (track.closed || track.passive) continue;
 				if (track.frontier === undefined || track.frontier < end) return false;
 			}
 		}
@@ -357,6 +391,7 @@ export class Producer {
 
 		let end: Time.Micro | undefined;
 		for (const track of this.#tracks.values()) {
+			if (track.passive) continue;
 			const candidate = track.pending.find((group) => group.pts >= threshold)?.pts;
 			if (candidate === undefined) {
 				// This track has produced nothing past the minimum yet, so ending the segment

--- a/js/hang/src/container/timeline.ts
+++ b/js/hang/src/container/timeline.ts
@@ -422,6 +422,7 @@ export class Producer {
 			// it opened, which undercounts that group's tail.
 			let max = start;
 			for (const track of this.#tracks.values()) {
+				if (track.passive) continue;
 				if (track.frontier !== undefined && track.frontier > max) max = track.frontier;
 			}
 			endUnits = Math.floor((max * DEFAULT_TIMESCALE) / 1_000_000);
@@ -453,7 +454,10 @@ export class Producer {
 			const ranges: Range[] = [];
 			while (track.pending.length > 0) {
 				const group = track.pending[0];
-				if (end !== undefined && group.pts >= end) break;
+				// A pacing track is assigned by content time. A passive track is assigned by
+				// arrival, so every group pending when the segment closes belongs to it regardless
+				// of the timestamp basis carried by that track.
+				if (!track.passive && end !== undefined && group.pts >= end) break;
 				track.pending.shift();
 				const last = ranges.at(-1);
 				// Contiguous sequences extend the run; a skip starts a new range (a gap: groups

--- a/js/hang/src/container/timeline.ts
+++ b/js/hang/src/container/timeline.ts
@@ -4,13 +4,12 @@
  * track. A consumer can seek (or build an HLS/DASH playlist) without downloading the media.
  * See the catalog's root {@link Catalog.Timeline} section that advertises it.
  *
- * Facts flow up and policy flows down, meeting in the shared {@link Producer}: each media
- * track enrolls with {@link Producer.track} and reports every group open through its
+ * Facts flow up and policy flows down, meeting in the shared {@link Producer}: each continuous
+ * media track enrolls with {@link Producer.pacingTrack} and reports every group open through its
  * {@link Recorder}. A segment ends at the first group boundary that gives it at least
- * {@link ProducerProps.durationMin} on every enrolled track, unless the application declares
- * its own with {@link Producer.cut}. A segment's record is published only once every enrolled
- * track has reported past its end (or closed), so records are self-contained and immediately
- * servable.
+ * {@link ProducerProps.durationMin} on every pacing track, unless the application declares its
+ * own with {@link Producer.cut}. A segment's record is published only once every pacing track
+ * has reported past its end (or closed), so records are self-contained and immediately servable.
  *
  * @module
  */
@@ -114,9 +113,8 @@ interface TrackState {
 	// group starts there) and by Recorder.end (the content stops there).
 	frontier?: Time.Micro;
 	closed: boolean;
-	// Never paces boundaries or gates completeness, even while open: groups are recorded into
-	// whichever segment is open when they arrive. See Producer.passive.
-	passive: boolean;
+	// Whether this track paces boundaries and gates completeness while open.
+	pacing: boolean;
 }
 
 /**
@@ -124,9 +122,10 @@ interface TrackState {
  * DEFLATE-compressed (a `@moq/json` stream), plus the shared boundary list every media track's
  * groups map onto.
  *
- * One per broadcast. Media tracks enroll with {@link track} and report group opens through the
- * returned {@link Recorder}; an application with its own boundaries overrides the pacing with
- * {@link cut}. Advertise it in the catalog's root `timeline` section via {@link section}.
+ * One per broadcast. Tracks enroll with {@link track}; continuous media explicitly opts into
+ * segmentation through {@link pacingTrack}. Both report group opens through the returned
+ * {@link Recorder}. An application with its own boundaries overrides pacing with {@link cut}.
+ * Advertise it in the catalog's root `timeline` section via {@link section}.
  */
 export class Producer {
 	#stream: Json.Stream.Producer<Record>;
@@ -164,44 +163,33 @@ export class Producer {
 	}
 
 	/**
-	 * Enroll the media track `name` as a pacing track, returning the {@link Recorder} it reports
-	 * through.
+	 * Enroll `name` without letting it influence segmentation, returning its {@link Recorder}.
 	 *
-	 * The segment records key ranges by this name, and the track paces boundaries and gates
-	 * completeness until its recorder closes. Enroll a track when it is about to produce: an
-	 * enrolled but silent track holds every record back, by design, since a segment isn't
-	 * complete until every track's content is known. One recorder per track: enrolling the same
-	 * name again resets its state.
+	 * Its groups are recorded into whichever segment is open when they arrive, but the track never
+	 * votes on where a boundary falls and never holds a record back. This safe default is for a
+	 * catalog that emits only when renditions change, or an application's metadata track.
 	 *
-	 * This is for tracks whose groups arrive continuously, which is what makes them usable as
-	 * boundaries. A track that publishes on its own schedule belongs in {@link passive}.
+	 * Placement is by arrival rather than by content time: nothing waits for the track, so a group
+	 * that arrives after its segment flushed is recorded in the next one. Frames still carry their
+	 * own timestamps. One recorder per track: enrolling the same name again resets its state.
 	 */
 	track(name: string): Recorder {
-		this.#tracks.set(name, { pending: [], frontier: undefined, closed: false, passive: false });
+		this.#tracks.set(name, { pending: [], frontier: undefined, closed: false, pacing: false });
 		return new Recorder(this, name);
 	}
 
 	/**
-	 * Enroll the track `name` without letting it influence segmentation, returning its
-	 * {@link Recorder}.
+	 * Enroll the media track `name` as a pacing track, returning its {@link Recorder}.
 	 *
-	 * A passive track's groups are recorded into whichever segment is open when they arrive, but
-	 * it never votes on where a boundary falls and never holds a record back. That is what a track
-	 * publishing on its own schedule needs: a catalog that emits a group only when the renditions
-	 * change, or an application's metadata track. Enrolling such a track with {@link track}
-	 * instead would stall the timeline for good, since a segment cannot end until every pacing
-	 * track has reported past its boundary.
+	 * The track votes on boundaries and gates completeness until its recorder closes. Enroll it
+	 * when it is about to produce: an enrolled but silent pacing track holds every record back,
+	 * since a segment is not complete until every pacing track's content is known.
 	 *
-	 * The trade is that a passive track's groups are placed by arrival rather than by content
-	 * time: nothing waits for them, so a group that shows up after its segment already flushed is
-	 * recorded in the next one. The frames still carry their own timestamps.
-	 *
-	 * A group that never closes (a `@moq/json` stream log) is recorded once, in the segment its
-	 * group opened in, and never again. Roll the group at segment boundaries if its content needs
-	 * to be addressable per segment.
+	 * This opt-in is for continuously publishing media. A sparse track belongs in {@link track},
+	 * otherwise it can stall the timeline when it goes quiet.
 	 */
-	passive(name: string): Recorder {
-		this.#tracks.set(name, { pending: [], frontier: undefined, closed: false, passive: true });
+	pacingTrack(name: string): Recorder {
+		this.#tracks.set(name, { pending: [], frontier: undefined, closed: false, pacing: true });
 		return new Recorder(this, name);
 	}
 
@@ -328,9 +316,9 @@ export class Producer {
 
 		// The first thing a pacing track reports anchors the first segment, so content produced
 		// before any boundary exists belongs to the oldest segment rather than to nowhere. A
-		// passive track must not anchor it: a catalog published while the encoder is still warming
+		// non-pacing track must not anchor it: a catalog published while the encoder is still warming
 		// up would otherwise stretch segment 0 across the whole startup gap.
-		if (this.#start === undefined && !track.passive) this.#start = pts;
+		if (this.#start === undefined && track.pacing) this.#start = pts;
 
 		this.#pump(false);
 	}
@@ -361,11 +349,11 @@ export class Producer {
 
 		// Every open pacing track has to have reported at or past the boundary, proving its ranges
 		// for this segment are final. The track that voted for `end` has by construction; a track
-		// with shorter groups can still be behind it. A passive track is excluded: it may publish
+		// with shorter groups can still be behind it. A non-pacing track is excluded: it may publish
 		// rarely or never again, so waiting on it would stall the timeline for good.
 		if (!finished) {
 			for (const track of this.#tracks.values()) {
-				if (track.closed || track.passive) continue;
+				if (track.closed || !track.pacing) continue;
 				if (track.frontier === undefined || track.frontier < end) return false;
 			}
 		}
@@ -391,7 +379,7 @@ export class Producer {
 
 		let end: Time.Micro | undefined;
 		for (const track of this.#tracks.values()) {
-			if (track.passive) continue;
+			if (!track.pacing) continue;
 			const candidate = track.pending.find((group) => group.pts >= threshold)?.pts;
 			if (candidate === undefined) {
 				// This track has produced nothing past the minimum yet, so ending the segment
@@ -422,7 +410,7 @@ export class Producer {
 			// it opened, which undercounts that group's tail.
 			let max = start;
 			for (const track of this.#tracks.values()) {
-				if (track.passive) continue;
+				if (!track.pacing) continue;
 				if (track.frontier !== undefined && track.frontier > max) max = track.frontier;
 			}
 			endUnits = Math.floor((max * DEFAULT_TIMESCALE) / 1_000_000);
@@ -454,10 +442,10 @@ export class Producer {
 			const ranges: Range[] = [];
 			while (track.pending.length > 0) {
 				const group = track.pending[0];
-				// A pacing track is assigned by content time. A passive track is assigned by
+				// A pacing track is assigned by content time. A non-pacing track is assigned by
 				// arrival, so every group pending when the segment closes belongs to it regardless
 				// of the timestamp basis carried by that track.
-				if (!track.passive && end !== undefined && group.pts >= end) break;
+				if (track.pacing && end !== undefined && group.pts >= end) break;
 				track.pending.shift();
 				const last = ranges.at(-1);
 				// Contiguous sequences extend the run; a skip starts a new range (a gap: groups

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -259,7 +259,7 @@ impl<E: CatalogExt> Producer<E> {
 
 		let timeline = crate::timeline::Producer::new(broadcast, crate::timeline::Config::default());
 		let catalog_timeline = Arc::new(Mutex::new(CatalogTimeline {
-			recorder: timeline.passive(hang::Catalog::DEFAULT_NAME),
+			recorder: timeline.track(hang::Catalog::DEFAULT_NAME),
 			last_sequence: None,
 		}));
 
@@ -336,7 +336,7 @@ impl<E: CatalogExt> Producer<E> {
 	pub fn with_timeline(mut self, broadcast: &moq_net::broadcast::Producer, config: crate::timeline::Config) -> Self {
 		self.timeline = crate::timeline::Producer::new(broadcast, config);
 		self.outputs.catalog_timeline = Arc::new(Mutex::new(CatalogTimeline {
-			recorder: self.timeline.passive(hang::Catalog::DEFAULT_NAME),
+			recorder: self.timeline.track(hang::Catalog::DEFAULT_NAME),
 			last_sequence: None,
 		}));
 		self
@@ -431,7 +431,7 @@ impl<E: CatalogExt> Producer<E> {
 	/// that isn't built through a [`container::Producer`](crate::container::Producer) (an fMP4
 	/// passthrough writing groups by hand).
 	pub fn enroll(&mut self, track: &str) -> crate::Result<crate::timeline::Recorder> {
-		let recorder = self.timeline.track(track)?;
+		let recorder = self.timeline.pacing_track(track)?;
 
 		let section = self.timeline.section();
 		let mut catalog = self.lock();

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -58,6 +58,67 @@ struct Reservations {
 	published: bool,
 }
 
+/// The built-in catalog's enrollment in the broadcast timeline.
+struct CatalogTimeline {
+	recorder: crate::timeline::Recorder,
+	last_sequence: Option<u64>,
+}
+
+impl CatalogTimeline {
+	/// Report a newly published plaintext catalog group once.
+	fn record(&mut self, track: &moq_net::track::Producer) {
+		let Some(sequence) = track.latest() else {
+			return;
+		};
+		if self.last_sequence == Some(sequence) {
+			return;
+		}
+
+		self.last_sequence = Some(sequence);
+		self.recorder.record(sequence, moq_net::Timestamp::now(), true);
+	}
+}
+
+/// The catalog tracks and the timeline enrollment updated with them.
+struct Outputs<E: CatalogExt> {
+	hang: moq_json::snapshot::Producer<Catalog<E>>,
+	hang_track: moq_net::track::Producer,
+	hangz: moq_json::snapshot::Producer<Catalog<E>>,
+	msf_track: moq_net::track::Producer,
+	catalog_timeline: Arc<Mutex<CatalogTimeline>>,
+}
+
+impl<E: CatalogExt> Clone for Outputs<E> {
+	fn clone(&self) -> Self {
+		Self {
+			hang: self.hang.clone(),
+			hang_track: self.hang_track.clone(),
+			hangz: self.hangz.clone(),
+			msf_track: self.msf_track.clone(),
+			catalog_timeline: self.catalog_timeline.clone(),
+		}
+	}
+}
+
+impl<E: CatalogExt> Outputs<E> {
+	/// Emit the catalog to hang, compressed hang, MSF, and the broadcast timeline.
+	fn emit(&mut self, catalog: &Catalog<E>) -> crate::Result<()> {
+		// One snapshot per group while deltas are disabled; the `.z` track carries the identical catalog.
+		self.hang.update(catalog)?;
+		self.catalog_timeline.lock().unwrap().record(&self.hang_track);
+		self.hangz.update(catalog)?;
+
+		// The MSF catalog is derived from our own types, so a serialize failure means an extension broke
+		// the shape; report it like any other JSON failure rather than panicking.
+		let msf = to_msf(&catalog.media()).to_json().map_err(moq_json::Error::from)?;
+		let mut group = self.msf_track.append_group()?;
+		group.write_frame(moq_net::Timestamp::now(), msf)?;
+		group.finish()?;
+
+		Ok(())
+	}
+}
+
 /// Produces both a hang and MSF catalog track for a broadcast.
 ///
 /// Generic over the application extension `E` (defaulting to `()` for none). The catalog is a
@@ -74,9 +135,7 @@ struct Reservations {
 /// group (deltas disabled). This routes catalog publishing through the JSON merge-patch helper
 /// so deltas can be enabled later without changing the wire format used today.
 pub struct Producer<E: CatalogExt = ()> {
-	hang: moq_json::snapshot::Producer<Catalog<E>>,
-	hangz: moq_json::snapshot::Producer<Catalog<E>>,
-	msf_track: moq_net::track::Producer,
+	outputs: Outputs<E>,
 
 	current: Arc<Mutex<State<E>>>,
 
@@ -89,7 +148,6 @@ pub struct Producer<E: CatalogExt = ()> {
 	/// onto, and the track those segment records are published on. See
 	/// [`timeline`](Self::timeline).
 	timeline: crate::timeline::Producer,
-
 	/// Retention override for the media tracks minted under this catalog, or `None` to keep
 	/// hang's default. Fixed at construction, so every clone and every
 	/// [`Reserved`](super::Reserved) mints tracks under one policy. See
@@ -101,9 +159,7 @@ pub struct Producer<E: CatalogExt = ()> {
 impl<E: CatalogExt> Clone for Producer<E> {
 	fn clone(&self) -> Self {
 		Self {
-			hang: self.hang.clone(),
-			hangz: self.hangz.clone(),
-			msf_track: self.msf_track.clone(),
+			outputs: self.outputs.clone(),
 			current: self.current.clone(),
 			clock: self.clock,
 			timeline: self.timeline.clone(),
@@ -194,28 +250,38 @@ impl<E: CatalogExt> Producer<E> {
 		// Disable deltas for now to stay byte-compatible with consumers that only read snapshots.
 		let mut json_config = moq_json::snapshot::ProducerConfig::default();
 		json_config.delta_ratio = 0;
-		let hang = moq_json::snapshot::Producer::new(hang_track, json_config.clone());
+		let hang = moq_json::snapshot::Producer::new(hang_track.clone(), json_config.clone());
 
 		// The `.z` track carries the same catalog, DEFLATE-compressed. Deltas stay off for parity
 		// with the plaintext track; only the per-group compression differs.
 		json_config.compression = true;
 		let hangz = moq_json::snapshot::Producer::new(hangz_track, json_config);
 
+		let timeline = crate::timeline::Producer::new(broadcast, crate::timeline::Config::default());
+		let catalog_timeline = Arc::new(Mutex::new(CatalogTimeline {
+			recorder: timeline.passive(hang::Catalog::DEFAULT_NAME),
+			last_sequence: None,
+		}));
+
 		// The contents are `Send + Sync` natively; on wasm moq-net's handles are
 		// `Rc`-backed, so clippy sees a pointlessly atomic `Arc`. Keeping one type for
 		// both targets is worth the unused atomics on the single-threaded one.
 		#[allow(clippy::arc_with_non_send_sync)]
 		Ok(Self {
-			hang,
-			hangz,
-			msf_track,
+			outputs: Outputs {
+				hang,
+				hang_track,
+				hangz,
+				msf_track,
+				catalog_timeline,
+			},
 			current: Arc::new(Mutex::new(State {
 				catalog: config.catalog,
 				owned: BTreeSet::new(),
 				reservations: Reservations::default(),
 			})),
 			clock: crate::Clock::new(),
-			timeline: crate::timeline::Producer::new(broadcast, crate::timeline::Config::default()),
+			timeline,
 			max_age: config.max_age,
 		})
 	}
@@ -252,9 +318,7 @@ impl<E: CatalogExt> Producer<E> {
 	pub fn lock(&mut self) -> Guard<'_, E> {
 		Guard {
 			state: take(&self.current),
-			hang: &mut self.hang,
-			hangz: &mut self.hangz,
-			msf_track: &mut self.msf_track,
+			outputs: &mut self.outputs,
 			updated: false,
 		}
 	}
@@ -271,6 +335,10 @@ impl<E: CatalogExt> Producer<E> {
 	/// catalog has advertised what it promises.
 	pub fn with_timeline(mut self, broadcast: &moq_net::broadcast::Producer, config: crate::timeline::Config) -> Self {
 		self.timeline = crate::timeline::Producer::new(broadcast, config);
+		self.outputs.catalog_timeline = Arc::new(Mutex::new(CatalogTimeline {
+			recorder: self.timeline.passive(hang::Catalog::DEFAULT_NAME),
+			last_sequence: None,
+		}));
 		self
 	}
 
@@ -336,7 +404,7 @@ impl<E: CatalogExt> Producer<E> {
 			r.published = true;
 			state.catalog.clone()
 		};
-		if let Err(err) = emit(&mut self.hang, &mut self.hangz, &mut self.msf_track, &catalog) {
+		if let Err(err) = self.outputs.emit(&catalog) {
 			tracing::warn!(%err, "failed to publish the catalog");
 		}
 	}
@@ -388,14 +456,14 @@ impl<E: CatalogExt> Producer<E> {
 
 	/// Create a consumer for this catalog, receiving updates as they're published.
 	pub fn consume(&self) -> Result<Consumer<E>, moq_net::Error> {
-		Ok(Consumer::new(self.hang.consume()))
+		Ok(Consumer::new(self.outputs.hang.consume()))
 	}
 
 	/// Finish publishing to this catalog.
 	pub fn finish(&mut self) -> crate::Result<()> {
-		self.hang.finish()?;
-		self.hangz.finish()?;
-		self.msf_track.finish()?;
+		self.outputs.hang.finish()?;
+		self.outputs.hangz.finish()?;
+		self.outputs.msf_track.finish()?;
 		self.timeline.finish()?;
 		Ok(())
 	}
@@ -411,9 +479,7 @@ impl<E: CatalogExt> Producer<E> {
 /// logs a warning; call [`commit`](Self::commit) instead to handle the error.
 pub struct Guard<'a, E: CatalogExt = ()> {
 	state: MutexGuard<'a, State<E>>,
-	hang: &'a mut moq_json::snapshot::Producer<Catalog<E>>,
-	hangz: &'a mut moq_json::snapshot::Producer<Catalog<E>>,
-	msf_track: &'a mut moq_net::track::Producer,
+	outputs: &'a mut Outputs<E>,
 	updated: bool,
 }
 
@@ -445,7 +511,7 @@ impl<E: CatalogExt> Guard<'_, E> {
 			r.published = true;
 		}
 
-		emit(self.hang, self.hangz, self.msf_track, &self.state.catalog)
+		self.outputs.emit(&self.state.catalog)
 	}
 
 	/// Release a name taken by [`Producer::acquire`], along with the entry it owns.
@@ -510,28 +576,6 @@ impl<E: CatalogExt> Drop for Guard<'_, E> {
 			tracing::warn!(%err, "failed to publish the catalog on guard drop");
 		}
 	}
-}
-
-/// Emit the catalog to all tracks: hang (`catalog.json`), its DEFLATE-compressed `.z` sibling, and
-/// the MSF catalog (`catalog`) derived from the base media sections.
-fn emit<E: CatalogExt>(
-	hang: &mut moq_json::snapshot::Producer<Catalog<E>>,
-	hangz: &mut moq_json::snapshot::Producer<Catalog<E>>,
-	msf_track: &mut moq_net::track::Producer,
-	catalog: &Catalog<E>,
-) -> crate::Result<()> {
-	// One snapshot per group while deltas are disabled; the `.z` track carries the identical catalog.
-	hang.update(catalog)?;
-	hangz.update(catalog)?;
-
-	// The MSF catalog is derived from our own types, so a serialize failure means an extension broke
-	// the shape; report it like any other JSON failure rather than panicking.
-	let msf = to_msf(&catalog.media()).to_json().map_err(moq_json::Error::from)?;
-	let mut group = msf_track.append_group()?;
-	group.write_frame(moq_net::Timestamp::now(), msf)?;
-	group.finish()?;
-
-	Ok(())
 }
 
 /// Determine the SAP starting type for a given video codec.
@@ -689,8 +733,8 @@ mod test {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut catalog = Producer::new(&mut broadcast).unwrap();
 
-		let mut plain = Consumer::new(catalog.hang.consume());
-		let mut compressed = Consumer::compressed(catalog.hangz.consume());
+		let mut plain = Consumer::new(catalog.outputs.hang.consume());
+		let mut compressed = Consumer::compressed(catalog.outputs.hangz.consume());
 
 		{
 			let mut guard = catalog.lock();
@@ -735,7 +779,7 @@ mod test {
 	fn commit_publishes_once() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut catalog = Producer::new(&mut broadcast).unwrap();
-		let track = catalog.hang.consume();
+		let track = catalog.outputs.hang.consume();
 
 		let mut guard = catalog.lock();
 		guard
@@ -793,7 +837,7 @@ mod test {
 	fn reservation_gates_until_all_renditions_resolve() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = Producer::new(&mut broadcast).unwrap();
-		let mut consumer: Consumer = Consumer::new(catalog.hang.consume());
+		let mut consumer: Consumer = Consumer::new(catalog.outputs.hang.consume());
 		let waiter = kio::Waiter::noop();
 
 		let reserved = catalog.reserve();
@@ -828,7 +872,7 @@ mod test {
 	fn reservation_gate_opens_when_unresolved_reservation_is_dropped() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = Producer::new(&mut broadcast).unwrap();
-		let mut consumer: Consumer = Consumer::new(catalog.hang.consume());
+		let mut consumer: Consumer = Consumer::new(catalog.outputs.hang.consume());
 		let waiter = kio::Waiter::noop();
 
 		let reserved = catalog.reserve();
@@ -856,7 +900,7 @@ mod test {
 	fn staged_change_waits_for_a_held_reservation() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = Producer::new(&mut broadcast).unwrap();
-		let mut consumer: Consumer = Consumer::new(catalog.hang.consume());
+		let mut consumer: Consumer = Consumer::new(catalog.outputs.hang.consume());
 		let waiter = kio::Waiter::noop();
 
 		// A deferred importer grabs a reservation up front and holds it until it can resolve.

--- a/rs/moq-mux/src/catalog/producer.rs
+++ b/rs/moq-mux/src/catalog/producer.rs
@@ -258,6 +258,7 @@ impl<E: CatalogExt> Producer<E> {
 		let hangz = moq_json::snapshot::Producer::new(hangz_track, json_config);
 
 		let timeline = crate::timeline::Producer::new(broadcast, crate::timeline::Config::default());
+		#[allow(clippy::arc_with_non_send_sync)]
 		let catalog_timeline = Arc::new(Mutex::new(CatalogTimeline {
 			recorder: timeline.track(hang::Catalog::DEFAULT_NAME),
 			last_sequence: None,
@@ -333,6 +334,7 @@ impl<E: CatalogExt> Producer<E> {
 	/// Call it before any track enrolls (the timeline's own track doesn't exist until then, so
 	/// this replaces it wholesale); afterwards the pacing is fixed for the broadcast, since the
 	/// catalog has advertised what it promises.
+	#[allow(clippy::arc_with_non_send_sync)]
 	pub fn with_timeline(mut self, broadcast: &moq_net::broadcast::Producer, config: crate::timeline::Config) -> Self {
 		self.timeline = crate::timeline::Producer::new(broadcast, config);
 		self.outputs.catalog_timeline = Arc::new(Mutex::new(CatalogTimeline {

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -305,7 +305,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			// (no `container::Producer`), so the recorder is fed directly at each group open.
 			// Enrolling on the timeline directly rather than through `catalog::Producer::enroll`,
 			// because the catalog is already locked here; the root section is advertised below.
-			let recorder = timeline.track(track.name())?;
+			let recorder = timeline.pacing_track(track.name())?;
 
 			let detect_bitrate = match kind {
 				TrackKind::Video => {

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -10,17 +10,16 @@
 //!
 //! The write side splits into facts and policy, meeting in the shared [`Producer`]:
 //!
-//! - **Tracks report facts.** Each media track enrolls via [`Producer::track`], and its
+//! - **Tracks report facts.** Each media track enrolls via [`Producer::pacing_track`], and its
 //!   [`Recorder`] reports every group open (sequence, timestamp, keyframe) plus where its
 //!   content ends. A container import never decides where segments fall; it only states what
 //!   it published.
 //! - **The timeline sets policy.** A segment ends at the first group boundary that gives it at
 //!   least [`Config::duration_min`] on every enrolled pacing track (see [`Config`] for the exact
 //!   rule). An application that knows its own boundaries overrides that with [`Producer::cut`].
-//! - **Not every track can pace.** A track that publishes on its own schedule (a catalog, an
-//!   application's metadata) enrolls via [`Producer::passive`]: its groups are recorded into
-//!   whichever segment is open, but it never votes on a boundary and never holds a record back.
-//!   Pacing on such a track would stall the timeline the moment it went quiet.
+//! - **Pacing is explicit.** [`Producer::track`] safely enrolls a catalog or metadata track
+//!   without giving it control over segmentation. Continuous media opts in through
+//!   [`Producer::pacing_track`], which lets it vote on boundaries and gate completeness.
 //! - **Records flush on completeness.** A segment's record is published only once every
 //!   enrolled pacing track has reported a group at or past the segment's end (or closed), proving
 //!   the segment's group ranges are final on every track that paces. The record is then
@@ -119,9 +118,8 @@ struct TrackState {
 	frontier: Option<Timestamp>,
 	/// The recorder was dropped; this track no longer paces boundaries or gates completeness.
 	closed: bool,
-	/// This track never paces boundaries or gates completeness, even while open: its groups are
-	/// recorded into whichever segment is open when they arrive. See [`Producer::passive`].
-	passive: bool,
+	/// Whether this track paces boundaries and gates completeness while open.
+	pacing: bool,
 }
 
 impl TrackState {
@@ -140,7 +138,7 @@ struct State {
 	config: Config,
 	/// Retained so the timeline track can be created when the first media track enrolls.
 	broadcast: moq_net::broadcast::Producer,
-	/// The timeline track, created by the first [`Producer::track`] call.
+	/// The timeline track, created by the first [`Producer::pacing_track`] call.
 	sink: Option<moq_json::stream::Producer<Record>>,
 	/// Where the open (unflushed) segment starts; `None` until the first report.
 	start: Option<Timestamp>,
@@ -192,9 +190,9 @@ impl State {
 
 		// The first thing a pacing track reports anchors the first segment, so content produced
 		// before any boundary exists belongs to the oldest segment rather than to nowhere. A
-		// passive track must not anchor it: a catalog published while the encoder is still warming
+		// non-pacing track must not anchor it: a catalog published while the encoder is still warming
 		// up would otherwise stretch segment 0 across the whole startup gap.
-		if self.start.is_none() && self.tracks.get(name).is_some_and(|t| !t.passive) {
+		if self.start.is_none() && self.tracks.get(name).is_some_and(|t| t.pacing) {
 			self.start = Some(pts);
 		}
 
@@ -249,13 +247,13 @@ impl State {
 
 		// Every open pacing track has to have reported at or past the boundary, proving its ranges
 		// for this segment are final. The track that voted for `end` has by construction; a track
-		// with shorter groups can still be behind it. A passive track is excluded: it may publish
+		// with shorter groups can still be behind it. A non-pacing track is excluded: it may publish
 		// rarely or never again, so waiting on it would stall the timeline for good.
 		let complete = finished
 			|| self
 				.tracks
 				.values()
-				.all(|t| t.passive || t.closed || t.frontier.is_some_and(|f| f.as_micros() >= end.as_micros()));
+				.all(|t| !t.pacing || t.closed || t.frontier.is_some_and(|f| f.as_micros() >= end.as_micros()));
 		if !complete {
 			return false;
 		}
@@ -287,7 +285,7 @@ impl State {
 		let threshold = start.as_micros() + self.config.duration_min.as_micros();
 
 		let mut end: Option<Timestamp> = None;
-		for track in self.tracks.values().filter(|t| !t.passive) {
+		for track in self.tracks.values().filter(|t| t.pacing) {
 			match track.candidate(threshold) {
 				// The latest vote wins: it is a group boundary on the coarsest track, and every
 				// finer track assigns its groups by start, so no group is split. A closed track
@@ -322,7 +320,7 @@ impl State {
 			None => self
 				.tracks
 				.values()
-				.filter(|t| !t.passive)
+				.filter(|t| t.pacing)
 				.filter_map(|t| t.frontier)
 				.map(|f| f.as_scale(self.timescale) as u64)
 				.max()
@@ -360,10 +358,10 @@ impl State {
 		for (name, track) in &mut self.tracks {
 			let mut ranges: Vec<Range> = Vec::new();
 			while let Some(&(sequence, group_pts, keyframe)) = track.pending.front() {
-				// A pacing track is assigned by content time. A passive track is assigned by
+				// A pacing track is assigned by content time. A non-pacing track is assigned by
 				// arrival, so every group pending when the segment closes belongs to it regardless
 				// of the timestamp basis carried by that track.
-				if !track.passive && end.is_some_and(|end| group_pts.as_micros() >= end.as_micros()) {
+				if track.pacing && end.is_some_and(|end| group_pts.as_micros() >= end.as_micros()) {
 					break;
 				}
 				track.pending.pop_front();
@@ -456,9 +454,10 @@ impl State {
 /// track those segment records are published on.
 ///
 /// One per broadcast, owned by [`catalog::Producer`](crate::catalog::Producer); `Clone` shares
-/// it. Media tracks enroll with [`track`](Self::track) and report group opens through the
-/// returned [`Recorder`]; an application with its own boundaries overrides the pacing with
-/// [`cut`](Self::cut). See the [module docs](self) for the whole model.
+/// it. Continuous media enrolls with [`pacing_track`](Self::pacing_track), while sparse tracks
+/// use the non-pacing [`track`](Self::track). Both report group opens through the returned
+/// [`Recorder`]. An application with its own boundaries overrides pacing with [`cut`](Self::cut).
+/// See the [module docs](self) for the whole model.
 #[derive(Clone)]
 pub struct Producer {
 	state: Arc<Mutex<State>>,
@@ -491,58 +490,49 @@ impl Producer {
 		}
 	}
 
+	/// Enroll `name` without letting it influence segmentation, returning its [`Recorder`].
+	///
+	/// Its groups are recorded into whichever segment is open when they arrive, but the track
+	/// never votes on where a boundary falls and never holds a record back. This safe default is
+	/// for a catalog that emits only when renditions change, or an application's metadata track.
+	///
+	/// Placement is by arrival rather than by content time: nothing waits for the track, so a group
+	/// that arrives after its segment flushed is recorded in the next one. Frames still carry
+	/// their own timestamps. A group that never closes (a `moq_json::stream` log) is recorded once,
+	/// in the segment its group opened in.
+	///
+	/// This does not create the timeline track, so enrolling only non-pacing tracks publishes no
+	/// timeline. One recorder per track: enrolling the same name again resets its state.
+	pub fn track(&self, name: &str) -> Recorder {
+		let mut state = self.state.lock().unwrap();
+		self.enroll(&mut state, name, false)
+	}
+
 	/// Enroll the media track `name` as a pacing track, returning the [`Recorder`] it reports
 	/// through.
 	///
-	/// The segment records key ranges by this name, and the track paces boundaries and gates
-	/// completeness until its recorder drops. Enroll a track when it is about to produce: an
-	/// enrolled but silent track holds every record back, by design, since a segment isn't
-	/// complete until every track's content is known. One recorder per track: enrolling the
-	/// same name again resets its state.
+	/// The segment records key ranges by this name, and the track votes on boundaries and gates
+	/// completeness until its recorder drops. Enroll it when it is about to produce: an enrolled
+	/// but silent pacing track holds every record back, by design, since a segment is not complete
+	/// until every pacing track's content is known.
 	///
-	/// This is for tracks whose groups arrive continuously, which is what makes them usable as
-	/// boundaries. A track that publishes on its own schedule belongs in
-	/// [`passive`](Self::passive) instead.
+	/// This opt-in is for continuously publishing media. A sparse track belongs in
+	/// [`track`](Self::track), otherwise it can stall the timeline when it goes quiet.
 	///
-	/// Creates the timeline track on first use, which errors if the broadcast can't (something
-	/// else already took the name).
-	pub fn track(&self, name: &str) -> crate::Result<Recorder> {
+	/// Creates the timeline track on first use, which errors if the broadcast cannot because
+	/// something else already took the name.
+	pub fn pacing_track(&self, name: &str) -> crate::Result<Recorder> {
 		let mut state = self.state.lock().unwrap();
 		self.prepare_pacing(&mut state)?;
-		Ok(self.enroll(&mut state, name, false))
-	}
-
-	/// Enroll the track `name` without letting it influence segmentation, returning its
-	/// [`Recorder`].
-	///
-	/// A passive track's groups are recorded into whichever segment is open when they arrive, but
-	/// it never votes on where a boundary falls and never holds a record back. That is what a
-	/// track publishing on its own schedule needs: a catalog that emits a group only when the
-	/// renditions change, or an application's metadata track. Enrolling such a track with
-	/// [`track`](Self::track) instead would stall the timeline for good, since a segment cannot
-	/// end until every pacing track has reported past its boundary.
-	///
-	/// The trade is that a passive track's groups are placed by arrival rather than by content
-	/// time: nothing waits for them, so a group that shows up after its segment already flushed is
-	/// recorded in the next one. The frames still carry their own timestamps.
-	///
-	/// Unlike [`track`](Self::track) this does not create the timeline track, so enrolling only
-	/// passive tracks publishes no timeline at all. Segmentation stays opt-in by pacing track.
-	///
-	/// A group that never closes (a `moq_json::stream` log) is recorded once, in the segment its
-	/// group opened in, and never again. Roll the group at segment boundaries if its content
-	/// needs to be addressable per segment.
-	pub fn passive(&self, name: &str) -> Recorder {
-		let mut state = self.state.lock().unwrap();
-		self.enroll(&mut state, name, true)
+		Ok(self.enroll(&mut state, name, true))
 	}
 
 	/// Enroll `name` after any fallible pacing-track setup has completed.
-	fn enroll(&self, state: &mut State, name: &str, passive: bool) -> Recorder {
+	fn enroll(&self, state: &mut State, name: &str, pacing: bool) -> Recorder {
 		state.tracks.insert(
 			name.to_string(),
 			TrackState {
-				passive,
+				pacing,
 				..Default::default()
 			},
 		);
@@ -847,8 +837,8 @@ mod test {
 	#[tokio::test]
 	async fn the_coarsest_track_paces_the_segments() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
+		let mut audio = timeline.pacing_track("audio0").unwrap();
 
 		// Video keyframes every 2s, audio groups every 500ms, minimum 1s.
 		video.record(0, ms(0), true);
@@ -882,7 +872,7 @@ mod test {
 	#[tokio::test]
 	async fn a_gop_longer_than_the_minimum_is_one_segment() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
 
 		video.record(0, ms(0), true);
 		video.record(1, ms(30_000), true);
@@ -906,7 +896,7 @@ mod test {
 			duration_min: Duration::from_millis(1_500),
 			..Default::default()
 		});
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut audio = timeline.pacing_track("audio0").unwrap();
 
 		for seq in 0..8u64 {
 			audio.record(seq, ms(seq * 500), true);
@@ -925,8 +915,8 @@ mod test {
 	#[tokio::test]
 	async fn a_segment_waits_for_every_track() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
+		let mut audio = timeline.pacing_track("audio0").unwrap();
 
 		video.record(0, ms(0), true);
 		audio.record(0, ms(0), true);
@@ -949,7 +939,7 @@ mod test {
 	#[tokio::test]
 	async fn explicit_cuts_override_the_pacing() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
 
 		// Keyframes every second, cut every three: the segments follow the cuts, not the GOPs.
 		timeline.cut(ms(3_000)).unwrap();
@@ -970,7 +960,7 @@ mod test {
 	#[tokio::test]
 	async fn a_cut_below_the_minimum_is_ignored() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
 
 		video.record(0, ms(0), true);
 		timeline.cut(ms(2_000)).unwrap();
@@ -999,7 +989,7 @@ mod test {
 			duration_max: Some(Duration::from_secs(3)),
 			..Default::default()
 		});
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
 
 		let mut consumer = {
 			video.record(0, ms(0), true);
@@ -1046,7 +1036,7 @@ mod test {
 	#[tokio::test]
 	async fn the_final_segment_runs_to_the_reported_end() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
 
 		video.record(0, ms(0), true);
 		video.record(1, ms(2_000), true);
@@ -1074,12 +1064,12 @@ mod test {
 
 		// The primary rendition runs a whole batch of segments through before its sibling has
 		// even loaded an init segment.
-		let mut first = timeline.track("video0").unwrap();
+		let mut first = timeline.pacing_track("video0").unwrap();
 		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
 			first.record(seq, ms(t), true);
 		}
 
-		let mut second = timeline.track("video1").unwrap();
+		let mut second = timeline.pacing_track("video1").unwrap();
 		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
 			second.record(seq, ms(t), true);
 		}
@@ -1107,8 +1097,8 @@ mod test {
 	#[tokio::test]
 	async fn groups_before_the_first_boundary_join_the_first_segment() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
+		let mut audio = timeline.pacing_track("audio0").unwrap();
 
 		// Audio races ahead of video's first keyframe (the startup race): its early group
 		// belongs to segment 0, which starts where the earliest content does.
@@ -1133,8 +1123,8 @@ mod test {
 	#[tokio::test]
 	async fn sequence_gaps_split_ranges() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
+		let mut audio = timeline.pacing_track("audio0").unwrap();
 
 		// Elemental-style gap: audio groups 2..=4 never existed inside segment 0.
 		video.record(0, ms(0), true);
@@ -1160,8 +1150,8 @@ mod test {
 	#[tokio::test]
 	async fn a_closed_track_leaves_a_whole_segment_gap() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
+		let mut audio = timeline.pacing_track("audio0").unwrap();
 
 		video.record(0, ms(0), true);
 		audio.record(0, ms(0), true);
@@ -1178,7 +1168,7 @@ mod test {
 	#[tokio::test]
 	async fn a_non_keyframe_range_start_is_flagged() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
 
 		video.record(0, ms(0), true);
 		// A mid-stream join: the group doesn't open on an IDR.
@@ -1197,8 +1187,8 @@ mod test {
 	#[tokio::test]
 	async fn a_closed_track_stops_gating() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut audio = timeline.track("audio0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
+		let mut audio = timeline.pacing_track("audio0").unwrap();
 
 		video.record(0, ms(0), true);
 		audio.record(0, ms(0), true);
@@ -1227,7 +1217,7 @@ mod test {
 
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let timeline2 = Producer::new(&broadcast, Config::default());
-		let _recorder = timeline2.track("video0").unwrap();
+		let _recorder = timeline2.pacing_track("video0").unwrap();
 		assert!(
 			broadcast.create_track(DEFAULT_NAME, None).is_err(),
 			"the timeline took the name once a track enrolled"
@@ -1263,7 +1253,7 @@ mod test {
 	#[tokio::test]
 	async fn reservations_nest() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
 
 		let outer = timeline.reserve();
 		let inner = outer.clone();
@@ -1293,7 +1283,7 @@ mod test {
 	#[tokio::test]
 	async fn finish_overrides_an_outstanding_reservation() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
 		let reserved = timeline.reserve();
 
 		video.record(0, ms(0), true);
@@ -1317,7 +1307,7 @@ mod test {
 	#[tokio::test]
 	async fn rejects_an_invalid_timescale() {
 		let (broadcast, timeline) = setup();
-		let _recorder = timeline.track("video0").unwrap();
+		let _recorder = timeline.pacing_track("video0").unwrap();
 		let mut section = timeline.section();
 		section.timescale = 0;
 		let err = Consumer::<()>::subscribe(&broadcast.consume(), &section).await;
@@ -1329,7 +1319,7 @@ mod test {
 	#[tokio::test]
 	async fn a_cut_on_the_first_group_does_not_poison_later_cuts() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
+		let mut video = timeline.pacing_track("video0").unwrap();
 
 		// Source segments every 3s, keyframes every 1s: 3s segments, not the 1s the
 		// duration_min pacing would produce on its own.
@@ -1354,12 +1344,12 @@ mod test {
 
 	// A catalog publishes a group only when the renditions change, so it can go quiet for the
 	// rest of the broadcast. Enrolled as a pacing track it would stall the timeline for good;
-	// passive, it rides along in whichever segment is open.
+	// non-pacing, it rides along in whichever segment is open.
 	#[tokio::test]
-	async fn a_passive_track_neither_paces_nor_gates() {
+	async fn a_non_pacing_track_neither_paces_nor_gates() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut catalog = timeline.passive("catalog.json");
+		let mut video = timeline.pacing_track("video0").unwrap();
+		let mut catalog = timeline.track("catalog.json");
 
 		catalog.record(0, ms(0), true);
 		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
@@ -1380,14 +1370,14 @@ mod test {
 		);
 	}
 
-	// Nothing waits for a passive track, so a group arriving after its segment already flushed
+	// Nothing waits for a non-pacing track, so a group arriving after its segment already flushed
 	// is recorded in the next one. Placement is by arrival; the frames still carry their own
 	// timestamps.
 	#[tokio::test]
-	async fn a_late_passive_group_lands_in_the_next_segment() {
+	async fn a_late_non_pacing_group_lands_in_the_next_segment() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut catalog = timeline.passive("catalog.json");
+		let mut video = timeline.pacing_track("video0").unwrap();
+		let mut catalog = timeline.track("catalog.json");
 
 		video.record(0, ms(0), true);
 		// Flushes segment 0, which the catalog has contributed nothing to.
@@ -1409,14 +1399,14 @@ mod test {
 		);
 	}
 
-	// Passive placement is by arrival rather than timestamp. A catalog can stamp snapshots from a
+	// Non-pacing placement is by arrival rather than timestamp. A catalog can stamp snapshots from a
 	// wall-clock basis while imported media starts at PTS zero, so its frontier must neither hold
 	// the group for a much later segment nor stretch the final media segment to that timestamp.
 	#[tokio::test]
-	async fn a_passive_track_uses_arrival_and_does_not_extend_the_tail() {
+	async fn a_non_pacing_track_uses_arrival_and_does_not_extend_the_tail() {
 		let (broadcast, mut timeline) = setup();
-		let mut video = timeline.track("video0").unwrap();
-		let mut catalog = timeline.passive("catalog.json");
+		let mut video = timeline.pacing_track("video0").unwrap();
+		let mut catalog = timeline.track("catalog.json");
 
 		video.record(0, ms(0), true);
 		catalog.record(0, ms(10_000), true);
@@ -1434,7 +1424,7 @@ mod test {
 	}
 
 	#[tokio::test]
-	async fn the_built_in_catalog_is_recorded_passively() {
+	async fn the_built_in_catalog_is_recorded_without_pacing() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
 		let timeline = catalog.timeline();
@@ -1455,12 +1445,12 @@ mod test {
 		);
 	}
 
-	// Segmentation stays opt-in by pacing track: passive tracks alone describe nothing, so the
+	// Segmentation stays opt-in by pacing track: non-pacing tracks alone describe nothing, so the
 	// timeline track is never created and its name stays free.
 	#[tokio::test]
-	async fn passive_tracks_alone_publish_no_timeline() {
+	async fn non_pacing_tracks_alone_publish_no_timeline() {
 		let (mut broadcast, mut timeline) = setup();
-		let mut catalog = timeline.passive("catalog.json");
+		let mut catalog = timeline.track("catalog.json");
 
 		catalog.record(0, ms(0), true);
 		timeline.finish().unwrap();

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -15,11 +15,15 @@
 //!   content ends. A container import never decides where segments fall; it only states what
 //!   it published.
 //! - **The timeline sets policy.** A segment ends at the first group boundary that gives it at
-//!   least [`Config::duration_min`] on every enrolled track (see [`Config`] for the exact
+//!   least [`Config::duration_min`] on every enrolled pacing track (see [`Config`] for the exact
 //!   rule). An application that knows its own boundaries overrides that with [`Producer::cut`].
+//! - **Not every track can pace.** A track that publishes on its own schedule (a catalog, an
+//!   application's metadata) enrolls via [`Producer::passive`]: its groups are recorded into
+//!   whichever segment is open, but it never votes on a boundary and never holds a record back.
+//!   Pacing on such a track would stall the timeline the moment it went quiet.
 //! - **Records flush on completeness.** A segment's record is published only once every
-//!   enrolled track has reported a group at or past the segment's end (or closed), proving the
-//!   segment's group ranges are final on every track. The record is then self-contained and
+//!   enrolled pacing track has reported a group at or past the segment's end (or closed), proving
+//!   the segment's group ranges are final on every track that paces. The record is then self-contained and
 //!   immediately servable. [`Producer::reserve`] extends that across a batch of enrollments,
 //!   the way the catalog's own reservation does.
 //!
@@ -115,6 +119,9 @@ struct TrackState {
 	frontier: Option<Timestamp>,
 	/// The recorder was dropped; this track no longer paces boundaries or gates completeness.
 	closed: bool,
+	/// This track never paces boundaries or gates completeness, even while open: its groups are
+	/// recorded into whichever segment is open when they arrive. See [`Producer::passive`].
+	passive: bool,
 }
 
 impl TrackState {
@@ -183,9 +190,11 @@ impl State {
 			track.frontier = Some(pts);
 		}
 
-		// The first thing anybody reports anchors the first segment, so content produced before
-		// any boundary exists belongs to the oldest segment rather than to nowhere.
-		if self.start.is_none() {
+		// The first thing a pacing track reports anchors the first segment, so content produced
+		// before any boundary exists belongs to the oldest segment rather than to nowhere. A
+		// passive track must not anchor it: a catalog published while the encoder is still warming
+		// up would otherwise stretch segment 0 across the whole startup gap.
+		if self.start.is_none() && self.tracks.get(name).is_some_and(|t| !t.passive) {
 			self.start = Some(pts);
 		}
 
@@ -238,14 +247,15 @@ impl State {
 			return false;
 		};
 
-		// Every open track has to have reported at or past the boundary, proving its ranges for
-		// this segment are final. The track that voted for `end` has by construction; a track
-		// with shorter groups can still be behind it.
+		// Every open pacing track has to have reported at or past the boundary, proving its ranges
+		// for this segment are final. The track that voted for `end` has by construction; a track
+		// with shorter groups can still be behind it. A passive track is excluded: it may publish
+		// rarely or never again, so waiting on it would stall the timeline for good.
 		let complete = finished
 			|| self
 				.tracks
 				.values()
-				.all(|t| t.closed || t.frontier.is_some_and(|f| f.as_micros() >= end.as_micros()));
+				.all(|t| t.passive || t.closed || t.frontier.is_some_and(|f| f.as_micros() >= end.as_micros()));
 		if !complete {
 			return false;
 		}
@@ -277,7 +287,7 @@ impl State {
 		let threshold = start.as_micros() + self.config.duration_min.as_micros();
 
 		let mut end: Option<Timestamp> = None;
-		for track in self.tracks.values() {
+		for track in self.tracks.values().filter(|t| !t.passive) {
 			match track.candidate(threshold) {
 				// The latest vote wins: it is a group boundary on the coarsest track, and every
 				// finer track assigns its groups by start, so no group is split. A closed track
@@ -477,7 +487,8 @@ impl Producer {
 		}
 	}
 
-	/// Enroll the media track `name`, returning the [`Recorder`] it reports through.
+	/// Enroll the media track `name` as a pacing track, returning the [`Recorder`] it reports
+	/// through.
 	///
 	/// The segment records key ranges by this name, and the track paces boundaries and gates
 	/// completeness until its recorder drops. Enroll a track when it is about to produce: an
@@ -485,18 +496,58 @@ impl Producer {
 	/// complete until every track's content is known. One recorder per track: enrolling the
 	/// same name again resets its state.
 	///
+	/// This is for tracks whose groups arrive continuously, which is what makes them usable as
+	/// boundaries. A track that publishes on its own schedule belongs in
+	/// [`passive`](Self::passive) instead.
+	///
 	/// Creates the timeline track on first use, which errors if the broadcast can't (something
 	/// else already took the name).
 	pub fn track(&self, name: &str) -> crate::Result<Recorder> {
+		self.enroll(name, false)
+	}
+
+	/// Enroll the track `name` without letting it influence segmentation, returning its
+	/// [`Recorder`].
+	///
+	/// A passive track's groups are recorded into whichever segment is open when they arrive, but
+	/// it never votes on where a boundary falls and never holds a record back. That is what a
+	/// track publishing on its own schedule needs: a catalog that emits a group only when the
+	/// renditions change, or an application's metadata track. Enrolling such a track with
+	/// [`track`](Self::track) instead would stall the timeline for good, since a segment cannot
+	/// end until every pacing track has reported past its boundary.
+	///
+	/// The trade is that a passive track's groups are placed by arrival rather than by content
+	/// time: nothing waits for them, so a group that shows up after its segment already flushed is
+	/// recorded in the next one. The frames still carry their own timestamps.
+	///
+	/// Unlike [`track`](Self::track) this does not create the timeline track, so enrolling only
+	/// passive tracks publishes no timeline at all. Segmentation stays opt-in by pacing track.
+	///
+	/// A group that never closes (a `moq_json::stream` log) is recorded once, in the segment its
+	/// group opened in, and never again. Roll the group at segment boundaries if its content
+	/// needs to be addressable per segment.
+	pub fn passive(&self, name: &str) -> crate::Result<Recorder> {
+		self.enroll(name, true)
+	}
+
+	/// Enroll `name`, creating the timeline track if this is a pacing track and the first to need
+	/// it.
+	fn enroll(&self, name: &str, passive: bool) -> crate::Result<Recorder> {
 		let mut state = self.state.lock().unwrap();
 
-		if state.sink.is_none() && state.overrun.is_none() {
+		if !passive && state.sink.is_none() && state.overrun.is_none() {
 			let net = state.broadcast.create_track(DEFAULT_NAME, None)?;
 			let config = moq_json::stream::ProducerConfig::default().with_compression(true);
 			state.sink = Some(moq_json::stream::Producer::new(net, config));
 		}
 
-		state.tracks.insert(name.to_string(), TrackState::default());
+		state.tracks.insert(
+			name.to_string(),
+			TrackState {
+				passive,
+				..Default::default()
+			},
+		);
 
 		Ok(Recorder {
 			state: self.state.clone(),
@@ -1290,6 +1341,79 @@ mod test {
 			entries[0],
 			entry(0, 0, 3_000, &[("video0", &[(0, 2)])]),
 			"the source's 3s boundaries should be reproduced, not duration_min pacing"
+		);
+	}
+
+	// A catalog publishes a group only when the renditions change, so it can go quiet for the
+	// rest of the broadcast. Enrolled as a pacing track it would stall the timeline for good;
+	// passive, it rides along in whichever segment is open.
+	#[tokio::test]
+	async fn a_passive_track_neither_paces_nor_gates() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
+		let mut catalog = timeline.passive("catalog.json").unwrap();
+
+		catalog.record(0, ms(0), true);
+		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
+			video.record(seq, ms(t), true);
+		}
+		video.end(ms(6_000));
+		timeline.finish().unwrap();
+
+		let entries = drain(&broadcast, &timeline).await;
+		assert_eq!(
+			entries,
+			vec![
+				entry(0, 0, 2_000, &[("catalog.json", &[(0, 0)]), ("video0", &[(0, 0)])]),
+				entry(1, 2_000, 2_000, &[("video0", &[(1, 1)])]),
+				entry(2, 4_000, 2_000, &[("video0", &[(2, 2)])]),
+			],
+			"the silent catalog should neither hold records back nor move a boundary"
+		);
+	}
+
+	// Nothing waits for a passive track, so a group arriving after its segment already flushed
+	// is recorded in the next one. Placement is by arrival; the frames still carry their own
+	// timestamps.
+	#[tokio::test]
+	async fn a_late_passive_group_lands_in_the_next_segment() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
+		let mut catalog = timeline.passive("catalog.json").unwrap();
+
+		video.record(0, ms(0), true);
+		// Flushes segment 0, which the catalog has contributed nothing to.
+		video.record(1, ms(2_000), true);
+
+		// The update happened a second in, but only reaches the timeline now.
+		catalog.record(0, ms(1_000), true);
+
+		video.record(2, ms(4_000), true);
+		video.end(ms(6_000));
+		timeline.finish().unwrap();
+
+		let entries = drain(&broadcast, &timeline).await;
+		assert_eq!(entries[0], entry(0, 0, 2_000, &[("video0", &[(0, 0)])]));
+		assert_eq!(
+			entries[1],
+			entry(1, 2_000, 2_000, &[("catalog.json", &[(0, 0)]), ("video0", &[(1, 1)])]),
+			"the late group belongs to the segment that was open when it arrived"
+		);
+	}
+
+	// Segmentation stays opt-in by pacing track: passive tracks alone describe nothing, so the
+	// timeline track is never created and its name stays free.
+	#[tokio::test]
+	async fn passive_tracks_alone_publish_no_timeline() {
+		let (mut broadcast, mut timeline) = setup();
+		let mut catalog = timeline.passive("catalog.json").unwrap();
+
+		catalog.record(0, ms(0), true);
+		timeline.finish().unwrap();
+
+		assert!(
+			broadcast.create_track(DEFAULT_NAME, None).is_ok(),
+			"the timeline track should never have been created"
 		);
 	}
 }

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -23,9 +23,9 @@
 //!   Pacing on such a track would stall the timeline the moment it went quiet.
 //! - **Records flush on completeness.** A segment's record is published only once every
 //!   enrolled pacing track has reported a group at or past the segment's end (or closed), proving
-//!   the segment's group ranges are final on every track that paces. The record is then self-contained and
-//!   immediately servable. [`Producer::reserve`] extends that across a batch of enrollments,
-//!   the way the catalog's own reservation does.
+//!   the segment's group ranges are final on every track that paces. The record is then
+//!   self-contained and immediately servable. [`Producer::reserve`] extends that across a batch
+//!   of enrollments, the way the catalog's own reservation does.
 //!
 //! Alignment falls out of construction: every track maps its groups onto the same boundary
 //! list, so segment N covers the same span of content time on every track, which is what HLS
@@ -322,6 +322,7 @@ impl State {
 			None => self
 				.tracks
 				.values()
+				.filter(|t| !t.passive)
 				.filter_map(|t| t.frontier)
 				.map(|f| f.as_scale(self.timescale) as u64)
 				.max()
@@ -359,7 +360,10 @@ impl State {
 		for (name, track) in &mut self.tracks {
 			let mut ranges: Vec<Range> = Vec::new();
 			while let Some(&(sequence, group_pts, keyframe)) = track.pending.front() {
-				if end.is_some_and(|end| group_pts.as_micros() >= end.as_micros()) {
+				// A pacing track is assigned by content time. A passive track is assigned by
+				// arrival, so every group pending when the segment closes belongs to it regardless
+				// of the timestamp basis carried by that track.
+				if !track.passive && end.is_some_and(|end| group_pts.as_micros() >= end.as_micros()) {
 					break;
 				}
 				track.pending.pop_front();
@@ -1398,6 +1402,30 @@ mod test {
 			entries[1],
 			entry(1, 2_000, 2_000, &[("catalog.json", &[(0, 0)]), ("video0", &[(1, 1)])]),
 			"the late group belongs to the segment that was open when it arrived"
+		);
+	}
+
+	// Passive placement is by arrival rather than timestamp. A catalog can stamp snapshots from a
+	// wall-clock basis while imported media starts at PTS zero, so its frontier must neither hold
+	// the group for a much later segment nor stretch the final media segment to that timestamp.
+	#[tokio::test]
+	async fn a_passive_track_uses_arrival_and_does_not_extend_the_tail() {
+		let (broadcast, mut timeline) = setup();
+		let mut video = timeline.track("video0").unwrap();
+		let mut catalog = timeline.passive("catalog.json").unwrap();
+
+		video.record(0, ms(0), true);
+		catalog.record(0, ms(10_000), true);
+		video.record(1, ms(2_000), true);
+		video.end(ms(4_000));
+		timeline.finish().unwrap();
+
+		assert_eq!(
+			drain(&broadcast, &timeline).await,
+			vec![
+				entry(0, 0, 2_000, &[("catalog.json", &[(0, 0)]), ("video0", &[(0, 0)])]),
+				entry(1, 2_000, 2_000, &[("video0", &[(1, 1)])]),
+			]
 		);
 	}
 

--- a/rs/moq-mux/src/timeline.rs
+++ b/rs/moq-mux/src/timeline.rs
@@ -507,7 +507,9 @@ impl Producer {
 	/// Creates the timeline track on first use, which errors if the broadcast can't (something
 	/// else already took the name).
 	pub fn track(&self, name: &str) -> crate::Result<Recorder> {
-		self.enroll(name, false)
+		let mut state = self.state.lock().unwrap();
+		self.prepare_pacing(&mut state)?;
+		Ok(self.enroll(&mut state, name, false))
 	}
 
 	/// Enroll the track `name` without letting it influence segmentation, returning its
@@ -530,21 +532,13 @@ impl Producer {
 	/// A group that never closes (a `moq_json::stream` log) is recorded once, in the segment its
 	/// group opened in, and never again. Roll the group at segment boundaries if its content
 	/// needs to be addressable per segment.
-	pub fn passive(&self, name: &str) -> crate::Result<Recorder> {
-		self.enroll(name, true)
+	pub fn passive(&self, name: &str) -> Recorder {
+		let mut state = self.state.lock().unwrap();
+		self.enroll(&mut state, name, true)
 	}
 
-	/// Enroll `name`, creating the timeline track if this is a pacing track and the first to need
-	/// it.
-	fn enroll(&self, name: &str, passive: bool) -> crate::Result<Recorder> {
-		let mut state = self.state.lock().unwrap();
-
-		if !passive && state.sink.is_none() && state.overrun.is_none() {
-			let net = state.broadcast.create_track(DEFAULT_NAME, None)?;
-			let config = moq_json::stream::ProducerConfig::default().with_compression(true);
-			state.sink = Some(moq_json::stream::Producer::new(net, config));
-		}
-
+	/// Enroll `name` after any fallible pacing-track setup has completed.
+	fn enroll(&self, state: &mut State, name: &str, passive: bool) -> Recorder {
 		state.tracks.insert(
 			name.to_string(),
 			TrackState {
@@ -553,10 +547,20 @@ impl Producer {
 			},
 		);
 
-		Ok(Recorder {
+		Recorder {
 			state: self.state.clone(),
 			name: name.to_string(),
-		})
+		}
+	}
+
+	/// Create the timeline track when the first pacing track enrolls.
+	fn prepare_pacing(&self, state: &mut State) -> crate::Result<()> {
+		if state.sink.is_none() && state.overrun.is_none() {
+			let net = state.broadcast.create_track(DEFAULT_NAME, None)?;
+			let config = moq_json::stream::ProducerConfig::default().with_compression(true);
+			state.sink = Some(moq_json::stream::Producer::new(net, config));
+		}
+		Ok(())
 	}
 
 	/// Declare a segment boundary at `pts`, overriding the [`Config::duration_min`] pacing.
@@ -1355,7 +1359,7 @@ mod test {
 	async fn a_passive_track_neither_paces_nor_gates() {
 		let (broadcast, mut timeline) = setup();
 		let mut video = timeline.track("video0").unwrap();
-		let mut catalog = timeline.passive("catalog.json").unwrap();
+		let mut catalog = timeline.passive("catalog.json");
 
 		catalog.record(0, ms(0), true);
 		for (seq, t) in [(0u64, 0u64), (1, 2_000), (2, 4_000)] {
@@ -1383,7 +1387,7 @@ mod test {
 	async fn a_late_passive_group_lands_in_the_next_segment() {
 		let (broadcast, mut timeline) = setup();
 		let mut video = timeline.track("video0").unwrap();
-		let mut catalog = timeline.passive("catalog.json").unwrap();
+		let mut catalog = timeline.passive("catalog.json");
 
 		video.record(0, ms(0), true);
 		// Flushes segment 0, which the catalog has contributed nothing to.
@@ -1412,7 +1416,7 @@ mod test {
 	async fn a_passive_track_uses_arrival_and_does_not_extend_the_tail() {
 		let (broadcast, mut timeline) = setup();
 		let mut video = timeline.track("video0").unwrap();
-		let mut catalog = timeline.passive("catalog.json").unwrap();
+		let mut catalog = timeline.passive("catalog.json");
 
 		video.record(0, ms(0), true);
 		catalog.record(0, ms(10_000), true);
@@ -1429,12 +1433,34 @@ mod test {
 		);
 	}
 
+	#[tokio::test]
+	async fn the_built_in_catalog_is_recorded_passively() {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+		let timeline = catalog.timeline();
+		let mut video = catalog.enroll("video0").unwrap();
+
+		video.record(0, ms(0), true);
+		video.record(1, ms(2_000), true);
+		video.end(ms(4_000));
+		drop(video);
+		catalog.finish().unwrap();
+
+		assert_eq!(
+			drain(&broadcast, &timeline).await,
+			vec![
+				entry(0, 0, 2_000, &[("catalog.json", &[(0, 0)]), ("video0", &[(0, 0)])]),
+				entry(1, 2_000, 2_000, &[("video0", &[(1, 1)])]),
+			]
+		);
+	}
+
 	// Segmentation stays opt-in by pacing track: passive tracks alone describe nothing, so the
 	// timeline track is never created and its name stays free.
 	#[tokio::test]
 	async fn passive_tracks_alone_publish_no_timeline() {
 		let (mut broadcast, mut timeline) = setup();
-		let mut catalog = timeline.passive("catalog.json").unwrap();
+		let mut catalog = timeline.passive("catalog.json");
 
 		catalog.record(0, ms(0), true);
 		timeline.finish().unwrap();


### PR DESCRIPTION
## Summary

- Define a HANG recording format under an application-owned prefix: an immutable completion marker, a recording-owned timeline, immutable per-track metadata, and one immutable object per track and segment.
- Make durable storage authoritative with object-before-index ordering, atomic gaps, unbounded archive and duration-bounded DVR retention, exact FETCH replay, and on-demand HLS or DASH derivation.
- Make timeline enrollment non-pacing by default in Rust and TypeScript. Continuous media explicitly opts into pacing, while catalogs and sparse metadata cannot stall segmentation.
- Enroll the built-in plaintext catalog in the timeline so recordings retain the catalog groups needed to interpret media.
- Require canonical uppercase percent escapes and a recording-owned DEFLATE stream so gap substitution cannot corrupt subsequent records.

The root causes were four format and implementation gaps. Recorded frames lacked the immutable track properties needed to reconstruct TRACK_INFO. Sparse tracks were timestamp-drained as if they paced media. The production catalog bypassed timeline enrollment. A clean end was promised without a durable representation.

## Public API changes

- Rust moq_mux::timeline::Producer::track is now infallible and enrolls a non-pacing track.
- Rust adds moq_mux::timeline::Producer::pacing_track for continuous media that votes on boundaries and gates completeness.
- TypeScript @moq/hang timeline Producer.track is now non-pacing.
- TypeScript adds Producer.pacingTrack for continuous media.

This is a semantic break to the existing low-level timeline API, so the dev target remains appropriate. High-level catalog and media producers select the correct mode internally.

## Test plan

- nix develop --command just fix
- nix develop --command just drafts check
- nix develop --command just check
- nix develop --command just test (1,425 Rust tests plus the scoped JavaScript suites)

The Rust and TypeScript timeline implementations and regression tests remain in sync. No other cross-package sync row applies.

(written by GPT-5.6 Codex)