### PR TITLE
docs(py): correct the moq-rs install command

### DIFF
--- a/py/moq-rs/README.md
+++ b/py/moq-rs/README.md
@@ -2,15 +2,20 @@
 
 Python bindings for [Media over QUIC](https://github.com/moq-dev/moq): real-time pub/sub with built-in caching, fan-out, and prioritization, on top of QUIC.
 
-`moq` wraps the auto-generated [`moq-ffi`](https://pypi.org/project/moq-ffi/) UniFFI bindings with a Pythonic API: no `Moq` prefixes, async iterators, context managers, and simplified connection setup. At session setup it negotiates either the `moq-lite` or `moq-transport` wire protocol.
+Installed as [`moq-rs`](https://pypi.org/project/moq-rs/) (the `moq` name is taken on PyPI), imported as `moq`.
+
+It wraps the auto-generated [`moq-ffi`](https://pypi.org/project/moq-ffi/) UniFFI bindings with a Pythonic API: no `Moq` prefixes, async iterators, context managers, and simplified connection setup. At session setup it negotiates either the `moq-lite` or `moq-transport` wire protocol.
 
 ## Installation
 
 ```bash
-pip install moq
+pip install moq-rs
+
+# or with uv
+uv add moq-rs
 ```
 
-This pulls in the `moq-ffi` native bindings automatically. `moq` is pure Python and is versioned independently of `moq-ffi`; it floats to the latest compatible `moq-ffi` patch.
+This pulls in the `moq-ffi` native bindings automatically. `moq-rs` is pure Python and is versioned independently of `moq-ffi`; it floats to the latest compatible `moq-ffi` patch.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- `py/moq-rs/README.md` told readers to run `pip install moq`. That name belongs to an unrelated HTTP-mocking library on PyPI; the correct distribution is `moq-rs`.
- Root cause: the README predates the `moq` -> `moq-rs` rename (the `moq` name was already taken on PyPI, hence the dist/import split recorded in `py/moq-rs/pyproject.toml`). The rename propagated to `doc/lib/py/` and `py/moq-rs/docs/index.md` but not to this file.
- It matters more than a normal doc typo because `pyproject.toml` sets `readme = "README.md"`, so this was the install instruction rendered on the package's own PyPI page.
- Also states the dist-name/import-name split in the intro, since the `# moq` heading reads as the package name on PyPI. Wording matches what `doc/lib/py/index.md` already uses, and adds the same `uv add` variant.

## Public API changes

None. Documentation only.

## Test plan

- Confirmed `pip install moq` resolves to `moq 0.1.0` ("Python HTTP mocking made simple") and that `moq-rs 0.4.1` is the real distribution, via the PyPI JSON API.
- Grepped the repo for the same error elsewhere: `py/moq-ffi/README.md`, `py/moq-rs/docs/index.md`, `doc/lib/py/index.md`, and the Go/Kotlin/Swift install snippets all name their packages correctly. Remaining `install moq*` hits are unrelated crates (`moq-relay`, `moq-cli`, `moq-token-cli`, `moq-boy`, `moq-gst`).

## Note

Not bumping `py/moq-rs` version, so `release-py.yml` will not republish. The corrected README reaches pypi.org on the next `moq-rs` release; until then the stale text stays on the package page.

(Written by Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnCscaFDaj6TaBahqxXGqb