### PR TITLE
fix(loc): adopt the draft-ietf-moq-loc-04 Timestamp code point, and align relay-hops with lite-06

### DIFF
--- a/drafts/draft-lcurley-moq-relay-hops.md
+++ b/drafts/draft-lcurley-moq-relay-hops.md
@@ -46,13 +46,17 @@ Both PUBLISH_NAMESPACE and NAMESPACE are namespace advertisements for the purpos
 In a redundant deployment, relays are interconnected so that the same namespace can reach a given relay over more than one path.
 This redundancy is desirable for failover, but it leaves a receiver with no information that {{moqt}} does not address:
 
-- **Path selection**: when the same namespace arrives over multiple paths, a relay or subscriber has no information with which to prefer one path over another (e.g. the shorter, and usually lower-latency, one).
+- **Path selection**: when the same namespace arrives over multiple paths, a relay or subscriber has no information with which to prefer one path over another (e.g. the shorter, and usually lower-latency, one). Nor are two paths of equal length interchangeable in practice: one may cross a metered backbone while the other stays inside a datacenter, and one may already be carrying the content while the other would have to fetch it.
 - **Broadcast identity**: two advertisements for the same namespace may refer to the same broadcast or to two distinct origins reusing a namespace. With no origin identity a receiver cannot tell them apart, nor deduplicate redundant paths to one broadcast.
 - **Routing loops**: relay A advertises a namespace to relay B, which advertises it back to A (directly or through a cycle). Without a way to recognize an advertisement it has already seen, a relay will re-advertise it indefinitely.
 
 This extension solves all three with a single mechanism: an ordered list of **Hop IDs** that records the path an advertisement has taken, starting with the original publisher and with one entry appended per relay.
 The first entry identifies the origin (broadcast identity); the list length gives the path length (path selection); a relay finding its own Hop ID already in the list detects a loop.
 Hop IDs are unique (see [Hop IDs](#hop-ids)), even across independently operated relays.
+
+A second parameter, **Route Cost**, refines path selection into something a deployment can steer.
+Each link declares its price at setup, each advertisement accumulates the prices of the links it crossed, and a receiver prefers the cheapest advertisement rather than merely the shortest.
+Pricing every link at the default of 1 reproduces shortest-path routing exactly, so a deployment that does not care about cost need not configure anything.
 
 
 # Setup Negotiation
@@ -71,6 +75,28 @@ RELAY_HOPS Setup Option {
 The sender's own Hop ID (see [Hop IDs](#hop-ids)): the identity it appends to HOP_PATH when forwarding advertisements.
 An endpoint that never forwards advertisements (a leaf) MAY send an empty value (`Option Value Length` 0), declaring no identity; there is nothing of its own to exclude from a path, and the peer applies no exclusion when selecting advertisements or serving subscriptions for that session.
 
+An endpoint that supports the extension MAY additionally declare what this link costs to cross:
+
+~~~
+LINK_COST Setup Option {
+  Option Key (vi64) = 0x40B56
+  Option Value (vi64)
+}
+~~~
+
+**Option Value**:
+The price this connection adds to every advertisement crossing it, in units chosen by the deployment (the same units as [ROUTE_COST](#route_cost-parameter)).
+Both endpoints add it to the Route Cost of every advertisement they receive over the connection before forwarding or acting on it, so the link is charged the same from either direction.
+
+An absent option means the default cost of 1, under which the accumulated Route Cost equals the hop count and selection degenerates to shortest-path.
+A value of 0 is meaningful and distinct from omitting the option: it makes the link free, which is how a deployment says two relays are siblings in one datacenter.
+Larger values price a metered or long-haul link out of contention unless nothing cheaper exists.
+
+Only the client sends it: the price lives in the dialing side's configuration, and the server reads it from the client's SETUP so both ends charge the same link the same amount.
+A server MUST NOT send a LINK_COST Setup Option; a client that receives one MUST close the session with a PROTOCOL_VIOLATION.
+Like the extension itself, it describes this hop only and a relay MUST NOT forward it.
+An endpoint MUST NOT send LINK_COST without also negotiating RELAY_HOPS, since there would be no advertisement field to charge.
+
 The extension applies to a single hop (one MOQT session) and is negotiated independently for each session; a relay MUST NOT assume that because one of its sessions negotiated Relay Hops, another did.
 
 Negotiating this extension on a session also enables the extended NAMESPACE message format defined in [Carrying Parameters on Namespace Advertisements](#carrying-parameters-on-namespace-advertisements), which appends a Parameters field to NAMESPACE so that it, too, can carry HOP_PATH.
@@ -79,7 +105,7 @@ A relay that negotiated this extension on a downstream session MUST include the 
 A receiver that negotiated this extension and receives a PUBLISH_NAMESPACE or NAMESPACE without HOP_PATH MUST close the session with a PROTOCOL_VIOLATION.
 
 Message parameters in {{moqt}} have no generic skip rule: a receiver must know a parameter's serialization to parse past it, so an endpoint MUST NOT send HOP_PATH on a session that did not negotiate the extension.
-A relay forwarding an advertisement into a non-supporting session therefore strips HOP_PATH (and, for NAMESPACE, the appended Parameters field); the advertisement loses its hop information.
+A relay forwarding an advertisement into a non-supporting session therefore strips HOP_PATH and ROUTE_COST (and, for NAMESPACE, the appended Parameters field); the advertisement loses its hop and cost information.
 
 
 # Hop IDs
@@ -98,8 +124,8 @@ The default of a fresh random Hop ID per publisher is what makes a restarted pub
 
 
 # Carrying Parameters on Namespace Advertisements
-This extension attaches its downstream state (HOP_PATH) to namespace advertisements as Key-Value-Pair parameters (see {{moqt}} Section 2.5).
-PUBLISH_NAMESPACE ({{moqt}} Section 10.15) already defines a Parameters field, so HOP_PATH is added to it directly.
+This extension attaches its downstream state (HOP_PATH and ROUTE_COST) to namespace advertisements as Key-Value-Pair parameters (see {{moqt}} Section 2.5).
+PUBLISH_NAMESPACE ({{moqt}} Section 10.15) already defines a Parameters field, so both are added to it directly.
 
 The NAMESPACE message ({{moqt}} Section 10.16), which delivers advertisements on a SUBSCRIBE_NAMESPACE response stream, does **not** define a Parameters field in {{moqt}}.
 Because a subscriber-driven relay mesh propagates advertisements downstream as NAMESPACE messages, HOP_PATH would otherwise have no way to travel along that path.
@@ -149,7 +175,29 @@ One or more Hop IDs, ordered from the original publisher (first entry) to the re
 A receiver MUST close the session with a PROTOCOL_VIOLATION if the Hop IDs do not exactly fill `Length`, or if the list is empty (`Length` 0).
 HOP_PATH always contains at least one entry: the first entry is the Hop ID of the original publisher, even before the advertisement has traversed any relay (or a bridging relay's stand-in for it, see [Relay Behavior](#relay-behavior)).
 
-## Relay Behavior
+
+# ROUTE_COST Parameter
+The ROUTE_COST parameter carries the marginal cost of subscribing to the namespace via this advertisement: the price of the transfers that a subscription taken up on it would newly cause.
+It is carried alongside HOP_PATH on a namespace advertisement, in the same Parameters field:
+
+~~~
+ROUTE_COST Parameter {
+  Type (vi64) = 0x40B58
+  Value (vi64)
+}
+~~~
+
+**Value**:
+The accumulated cost, in units chosen by the deployment.
+
+ROUTE_COST is OPTIONAL and an absent parameter means 0, so an endpoint that prices nothing sends nothing and a mesh whose peers all omit it selects purely on path length.
+Costs still accumulate across such a mesh, because each receiver adds the arriving link's own price (see [LINK_COST](#setup-negotiation)) whether or not the sender declared one.
+
+The original publisher seeds the value with its production cost: 0 for content it is already producing, larger for content it would have to start producing on demand.
+A standby transcoder, for example, can advertise every namespace it *could* serve at a cost reflecting the work of actually serving it, and so be chosen only when no live copy exists.
+
+
+# Relay Behavior
 When a relay forwards a namespace advertisement downstream on a session that negotiated this extension, it MUST append its own Hop ID to the HOP_PATH it received.
 The relay's own Hop ID is therefore always the last entry of the list it sends.
 If the advertisement arrived from an upstream that did not negotiate this extension (and so carried no HOP_PATH), the relay MUST first create a HOP_PATH whose single initial entry is a Hop ID the relay assigns to stand in for that upstream, then append its own Hop ID.
@@ -163,17 +211,50 @@ When a relay receives a namespace advertisement on a session that negotiated thi
 This receiver-side check is the only loop defense this extension requires, and it catches loops of any length.
 A relay MAY additionally avoid sending an advertisement back toward a peer it came from, but that is a bandwidth optimization: the advertisement is discarded on arrival either way.
 
-## Path Selection
-A relay or subscriber that receives advertisements for the same namespace over multiple sessions MAY use the length of the HOP_PATH list as a tiebreaker, preferring the advertisement with the fewest hops (usually the lowest-latency path).
-This is advisory: the receiver MAY apply additional local policy (e.g. measured RTT or administrative preference) and is not required to prefer the shortest path.
-Advertisements that tie on every advertised property SHOULD be broken toward the most recently received, so a publisher reconnecting over a new session is not outranked by the session it replaced until the transport declares that one gone.
+## Accumulating Cost
+When a relay receives an advertisement on a session that negotiated this extension, it MUST add that session's link cost (see [Setup Negotiation](#setup-negotiation)) to the ROUTE_COST it received before forwarding or acting on the advertisement.
+The addition MUST saturate rather than wrap, so an absurd upstream value ranks last instead of overflowing to best.
+Cost therefore accumulates the same way HOP_PATH does, one entry per hop, except that each hop contributes its configured price instead of a fixed 1.
+
+A relay that is actively carrying the namespace (a live subscription exists for at least one of its tracks) SHOULD advertise a ROUTE_COST of 0 instead of the accumulated value.
+Its ingress is already paid for, so the marginal cost of one more subscriber is only the links between them, which downstream receivers add themselves.
+This is what lets a cluster deduplicate: a receiver that sees both a warm copy at 0 and the original at the full path cost pulls the copy that already exists.
+
+The discount applies only to the advertisement selecting the path the relay actually serves from.
+A standby path advertised to a peer whose declared Hop ID filtered out the serving path (see [Path Selection](#path-selection)) keeps its accumulated value, since serving that peer means opening a fresh ingest.
+When the relay stops carrying the namespace it SHOULD restore the accumulated value, optionally after a grace period so brief subscriber churn does not flap routing across the mesh.
+
+Two relays that independently begin carrying the same namespace will each see the other's zero-cost advertisement as cheaper than their own source, and switching simultaneously would leave the namespace with no source at all.
+An actively-carrying relay SHOULD therefore apply a deterministic tie-break before re-parenting onto a strictly cheaper advertisement from another actively-carrying relay (one advertising a ROUTE_COST of 0 from a HOP_PATH of two or more entries; a single-entry path is the original publisher, which can never adopt a route to its own content), such as comparing a stable hash of the namespace and each endpoint's Hop ID, so that exactly one side moves.
+Cheaper advertisements from anything else, e.g. a forwarding relay or a repriced upstream, carry no such hazard and SHOULD be adopted immediately.
+The HOP_PATH loop check remains the authority on loop freedom; this tie-break only prevents the transient double-switch.
+
+## Updating an Advertisement
+The values this extension carries change over the life of an advertisement: a route fails over and HOP_PATH changes, or a relay starts or stops carrying the namespace and its ROUTE_COST swings to or from 0.
+An endpoint updates an advertisement by re-sending it for the same namespace on the same session, carrying the new parameters.
+The new advertisement replaces the prior one in place, and a receiver MUST NOT treat the repeat as a duplicate or a protocol violation.
+
+Replacement is atomic: there is no window in which the namespace is unadvertised, so a receiver MUST NOT tear down subscriptions or forget cached state merely because an update arrived.
+What an update means for existing subscriptions depends on the first HOP_PATH entry, exactly as in [Path Selection](#path-selection): unchanged, the content is continuous and a receiver MAY resume in-flight subscriptions on the new route at a group boundary; changed, a different origin has replaced the namespace and existing subscriptions do not carry over.
+
+An update whose only change is ROUTE_COST is the expected case, and is how a relay tells its downstream that it started or stopped carrying the namespace.
+Because an update is indistinguishable from a fresh advertisement on the wire, an endpoint MAY send one whenever its state changes without coordinating with the receiver.
+Retracting an advertisement is unchanged from {{moqt}}: NAMESPACE_DONE ({{moqt}} Section 10.17) carries no Relay Hops state and is not an update.
+
+
+# Path Selection
+A relay or subscriber that receives advertisements for the same namespace over multiple sessions SHOULD prefer the one with the lowest ROUTE_COST, after adding each arriving link's own cost.
+Advertisements that tie on cost SHOULD be broken toward the shorter HOP_PATH (usually the lower-latency path), and those that tie on every advertised property toward the most recently received, so a publisher reconnecting over a new session is not outranked by the session it replaced until the transport declares that one gone.
+Selecting on cost with length as the tie-break is what makes the default pricing degrade cleanly: when every link costs 1, cost *is* path length and the two rules collapse into one.
+
+This is advisory: the receiver MAY apply additional local policy (e.g. measured RTT or administrative preference) and is not required to prefer the cheapest path.
 
 Two advertisements for the same namespace whose HOP_PATH begins with the same Hop ID share an origin and therefore carry interchangeable content: a receiver MAY hold them as redundant paths and switch between them, including failing an active subscription over to the surviving path when the serving one ends.
 If the first Hop IDs differ, the advertisements come from distinct origins that happen to reuse a namespace, and a receiver MUST NOT treat them as interchangeable; it SHOULD treat the later as a replacement for the earlier rather than serving the earlier until it ends on its own, which would hold the namespace for however long the transport takes to notice a publisher is gone.
 
 A publisher (or relay acting as one) SHOULD advertise, per session, the single best path it knows whose HOP_PATH does not contain the Hop ID the peer declared at setup; when every known path contains it, the publisher SHOULD advertise nothing for that namespace on that session.
 Selection is per session: a peer that the serving path flows through receives the best standby path instead of nothing, which is what lets it fail over to that standby if its own copy dies.
-If a session's selected path changes, the publisher MAY re-advertise the namespace; the new advertisement, carrying an updated HOP_PATH, replaces the prior one per the namespace-advertisement semantics of {{moqt}}.
+If a session's selected path changes, the publisher updates the advertisement in place as described in [Updating an Advertisement](#updating-an-advertisement).
 
 When serving a subscription, a publisher MUST select the source by the same rule it uses for advertisements to that session: a path whose entries avoid the Hop ID the subscriber declared at setup.
 If only excluded sources remain, the subscription is unroutable; serving it would hand the subscriber data that already flowed through itself.
@@ -187,6 +268,10 @@ A relay that wishes to hide its internal topology MAY coalesce the hops within i
 
 Because a relay only ever appends to HOP_PATH, it cannot make a competing path appear shorter than it is; the worst a misbehaving relay can do is under-report the upstream portion of its own path to win an advisory tie-break. Since path selection is advisory, the impact is limited to a suboptimal path choice. A receiver MUST NOT make security decisions based on Hop IDs, and SHOULD corroborate path selection with locally measured signals (e.g. RTT) when it matters.
 
+ROUTE_COST offers no such structural protection: it is a single value the sender chooses, so a relay can advertise 0 for content it is not carrying and attract subscriptions it then has to fetch.
+The consequence is again a suboptimal path rather than a security failure, and it is self-limiting, since the traffic a relay wins this way is traffic it must pay to serve.
+A deployment that spans a trust boundary SHOULD treat a peer's ROUTE_COST as a hint, clamping or ignoring values from peers it does not operate, rather than as an accounting figure.
+
 
 # IANA Considerations
 
@@ -195,20 +280,24 @@ High, distinctive values are requested to avoid the low ranges reserved by {{moq
 
 ## MOQT Setup Options
 
-This document requests a registration in the "MOQT Setup Options" registry ({{moqt}} Section 15.4), whose policy is Specification Required.
+This document requests two registrations in the "MOQT Setup Options" registry ({{moqt}} Section 15.4), whose policy is Specification Required.
 
 | Value   | Name       | Reference     |
 |:--------|:-----------|:--------------|
 | 0x40B55 | RELAY_HOPS | This Document |
+| 0x40B56 | LINK_COST  | This Document |
 
 ## MOQT Message Parameters
 
-This document requests a registration in the "MOQT Message Parameters" registry ({{moqt}} Section 15.7).
-HOP_PATH is carried in PUBLISH_NAMESPACE and in the extended NAMESPACE message defined by this document (see [Carrying Parameters on Namespace Advertisements](#carrying-parameters-on-namespace-advertisements)).
+This document requests two registrations in the "MOQT Message Parameters" registry ({{moqt}} Section 15.7).
+Both are carried in PUBLISH_NAMESPACE and in the extended NAMESPACE message defined by this document (see [Carrying Parameters on Namespace Advertisements](#carrying-parameters-on-namespace-advertisements)).
 
 | Value   | Name        | Carried In                   | Reference     |
 |:--------|:------------|:-----------------------------|:--------------|
 | 0x40B57 | HOP_PATH    | PUBLISH_NAMESPACE, NAMESPACE | This Document |
+| 0x40B58 | ROUTE_COST  | PUBLISH_NAMESPACE, NAMESPACE | This Document |
+
+The Key-Value-Pair encoding of {{moqt}} Section 2.5 makes the parity of each value load-bearing: HOP_PATH and RELAY_HOPS are odd, so their values are length-prefixed byte strings, while ROUTE_COST and LINK_COST are even, so their values are bare varints.
 
 
 --- back

--- a/drafts/draft-lcurley-moq-relay-hops.md
+++ b/drafts/draft-lcurley-moq-relay-hops.md
@@ -104,8 +104,17 @@ Negotiating this extension on a session also enables the extended NAMESPACE mess
 A relay that negotiated this extension on a downstream session MUST include the HOP_PATH parameter on every PUBLISH_NAMESPACE and NAMESPACE it sends on that session, and MUST apply the peer's declared Hop ID as described in [Path Selection](#path-selection).
 A receiver that negotiated this extension and receives a PUBLISH_NAMESPACE or NAMESPACE without HOP_PATH MUST close the session with a PROTOCOL_VIOLATION.
 
-Message parameters in {{moqt}} have no generic skip rule: a receiver must know a parameter's serialization to parse past it, so an endpoint MUST NOT send HOP_PATH on a session that did not negotiate the extension.
-A relay forwarding an advertisement into a non-supporting session therefore strips HOP_PATH and ROUTE_COST (and, for NAMESPACE, the appended Parameters field); the advertisement loses its hop and cost information.
+Message parameters in {{moqt}} have no skip rule at all: an endpoint that receives a Message Parameter it does not know MUST close the session with a PROTOCOL_VIOLATION ({{moqt}} Section 2.5), even when the type is even and its value would be trivially parseable.
+An endpoint therefore MUST NOT send HOP_PATH or ROUTE_COST on a session that did not negotiate the extension.
+A relay forwarding an advertisement into a non-supporting session strips both (and, for NAMESPACE, the appended Parameters field); the advertisement loses its hop and cost information.
+
+The two parameters are one capability, not two.
+An endpoint that sends the RELAY_HOPS Setup Option asserts that it understands HOP_PATH **and** ROUTE_COST, and a peer that negotiated RELAY_HOPS MAY send either without further signalling.
+Splitting them would gain nothing and cost correctness: because an unknown parameter is fatal rather than ignorable, a receiver that opted into one but not the other would have to be told which, and every sender would have to track it per session.
+
+That fatality also constrains how this extension may grow.
+A future revision MUST NOT add a third parameter under the RELAY_HOPS option, because an endpoint implementing this document would negotiate RELAY_HOPS, receive the unknown parameter, and be required to close the session.
+Any new parameter needs its own Setup Option, which the same {{moqt}} section makes safe: unknown *Setup Options* are ignored, so an endpoint that does not recognize the new option simply never receives the parameter.
 
 
 # Hop IDs

--- a/drafts/draft-lcurley-moq-relay-hops.md
+++ b/drafts/draft-lcurley-moq-relay-hops.md
@@ -240,14 +240,19 @@ The HOP_PATH loop check remains the authority on loop freedom; this tie-break on
 
 ## Updating an Advertisement
 The values this extension carries change over the life of an advertisement: a route fails over and HOP_PATH changes, or a relay starts or stops carrying the namespace and its ROUTE_COST swings to or from 0.
-An endpoint updates an advertisement by re-sending it for the same namespace on the same session, carrying the new parameters.
-The new advertisement replaces the prior one in place, and a receiver MUST NOT treat the repeat as a duplicate or a protocol violation.
+An endpoint updates an advertisement by re-sending it with the new parameters **on the stream that already carries it**: the request stream of the original PUBLISH_NAMESPACE, or the SUBSCRIBE_NAMESPACE response stream the original NAMESPACE arrived on.
+A receiver MUST NOT treat that repeat as a duplicate or a protocol violation.
+
+Reusing the stream is what makes the update unambiguous.
+In {{moqt}} an advertisement lives for the lifetime of its request stream, so an update sent on a *new* stream would leave two streams claiming one namespace, and closing the superseded one would retract an advertisement the peer had already replaced.
+Binding the update to the existing stream keeps one stream owning one advertisement: its parameters are whatever was sent most recently, and closing it retracts whatever is current.
+An endpoint MUST NOT open a second stream to advertise a namespace it already advertises on this session.
 
 Replacement is atomic: there is no window in which the namespace is unadvertised, so a receiver MUST NOT tear down subscriptions or forget cached state merely because an update arrived.
 What an update means for existing subscriptions depends on the first HOP_PATH entry, exactly as in [Path Selection](#path-selection): unchanged, the content is continuous and a receiver MAY resume in-flight subscriptions on the new route at a group boundary; changed, a different origin has replaced the namespace and existing subscriptions do not carry over.
 
 An update whose only change is ROUTE_COST is the expected case, and is how a relay tells its downstream that it started or stopped carrying the namespace.
-Because an update is indistinguishable from a fresh advertisement on the wire, an endpoint MAY send one whenever its state changes without coordinating with the receiver.
+An endpoint MAY send one whenever its state changes, without coordinating with the receiver.
 Retracting an advertisement is unchanged from {{moqt}}: NAMESPACE_DONE ({{moqt}} Section 10.17) carries no Relay Hops state and is not an update.
 
 

--- a/drafts/draft-lcurley-moq-timestamp.md
+++ b/drafts/draft-lcurley-moq-timestamp.md
@@ -18,14 +18,16 @@ author:
 
 normative:
   moqt: I-D.ietf-moq-transport
+  loc: I-D.ietf-moq-loc
 
 informative:
 
 --- abstract
 
-This document defines an extension for MoQ Transport {{moqt}} that attaches a media presentation timestamp to each object.
+This document specifies the transport-level use of the TIMESTAMP and TIMESCALE properties registered by {{loc}}, independent of the LOC container itself.
 A track-level Timescale property establishes the units, and an object-level Timestamp property carries the presentation time of each object.
 Exposing media time to the transport lets relays make consistent age-based decisions (e.g. dropping stale objects) without parsing the media container, and it remains consistent across hops regardless of buffering or jitter.
+No new code points are requested: an endpoint implementing this document is on the wire indistinguishable from a LOC endpoint that carries only these two properties.
 
 --- middle
 
@@ -49,8 +51,16 @@ Re-implementing per-object timestamping inside each application's container form
 This extension exposes media time to the transport with two Key-Value-Pairs ({{moqt}} Section 2.5): a track-level **Timescale** and an object-level **Timestamp**.
 The transport does not interpret the *meaning* of the timeline (it is still the application's clock); it only uses the timestamp for relative age comparisons.
 
-These properties are self-describing and require no SETUP negotiation: a receiver that understands the extension uses them directly, and one that does not ignores them per {{moqt}}.
-Whenever a property is absent — including when neither endpoint implements this extension — the defaults defined below apply: a Timescale of `1000` (milliseconds), and for an object with no Timestamp, the wall-clock arrival time of the object.
+Both properties are already registered by {{loc}}, which defines them for use inside the LOC container.
+This document reuses those registrations verbatim, with the same code points and value encodings, and specifies what a *transport* does with them.
+That reuse is deliberate: a timestamp is only useful to a relay if every publisher writes it the same way, so a second set of code points for the same concept would defeat the purpose.
+An endpoint that implements this document interoperates with a LOC endpoint without negotiation, and an endpoint that implements both writes one copy of each property, not two.
+
+These properties are self-describing and require no SETUP negotiation: a receiver that understands them uses them directly, and one that does not ignores them per {{moqt}}.
+Whenever a property is absent, including when neither endpoint implements this document, the defaults defined below apply: a Timescale of `1000` (milliseconds), and for an object with no Timestamp, the wall-clock arrival time of the object.
+
+That default differs from {{loc}}, which reads a track with no Timescale as microseconds.
+The difference is unreachable between conforming implementations because a publisher following this document always sends TIMESCALE explicitly (see [TIMESCALE Track Property](#timescale-track-property)), so the two never disagree about a timeline that is actually on the wire.
 
 
 # TIMESCALE Track Property
@@ -60,7 +70,7 @@ Because the value is a single integer, TIMESCALE uses an even Type so the value 
 
 ~~~
 TIMESCALE Track Property {
-  Type (vi64) = 0x915C0
+  Type (vi64) = 0x08
   Value (vi64)  ; units per second
 }
 ~~~
@@ -68,9 +78,14 @@ TIMESCALE Track Property {
 **Value**:
 The number of timestamp units per second.
 Common values include `1000` (milliseconds), `1000000` (microseconds), `48000` (a typical audio sample rate), and `90000` (the RTP video clock).
-The absence of the property defaults to `1000` (milliseconds), so every track has a usable timeline whether or not this extension is in use. A value of `0` is invalid and MUST be treated as this default.
+A publisher MUST send TIMESCALE on every track that carries timestamps, even when the value equals the default.
+Sending it always is what keeps a track readable by any receiver: {{loc}} defaults an absent Timescale to microseconds while this document defaults it to milliseconds, and an explicit value removes the question.
+
+The absence of the property defaults to `1000` (milliseconds), so a track from a publisher that predates this document still has a usable timeline. A value of `0` is invalid and MUST be treated as this default.
 
 The Timescale is fixed for the lifetime of the track and MUST NOT change.
+{{loc}} also registers TIMESCALE with Object scope, allowing a per-object override.
+A receiver that implements both applies such an override to that object alone; it does not redefine the track's timeline, and a publisher following this document SHOULD NOT send one.
 
 The Timescale is required to interpret the units of every Timestamp.
 The track's properties are delivered in SUBSCRIBE_OK or TRACK_STATUS ({{moqt}} Section 12); a receiver that begins receiving objects before it has them cannot yet know whether a non-default Timescale applies, so it MUST fall back to wall-clock arrival time for any age-based decision until the properties arrive.
@@ -83,7 +98,7 @@ It uses an even Type so the value is a bare varint:
 
 ~~~
 TIMESTAMP Object Property {
-  Type (vi64) = 0x915C2
+  Type (vi64) = 0x10
   Value (vi64)  ; absolute presentation time, in Timescale units
 }
 ~~~
@@ -91,6 +106,9 @@ TIMESTAMP Object Property {
 **Value**:
 The absolute presentation timestamp of the object, expressed in the track's Timescale.
 Any value (including 0) is valid.
+
+Key-Value-Pair types are themselves delta-encoded from the previous type as an unsigned varint ({{moqt}} Section 1.4.3), so an object's properties are serialized in ascending type order.
+TIMESTAMP (0x10) therefore follows any lower-numbered property in the same block, including an object-scope TIMESCALE (0x08).
 
 Each Timestamp is absolute, not delta-encoded against a previous object.
 {{moqt}} does not guarantee reliable delivery of every object within a group or subgroup, so an object may be dropped or lost independently; an absolute timestamp remains correct regardless, whereas a delta would be corrupted by any missing predecessor.
@@ -116,18 +134,19 @@ Because age-based dropping only affects which objects a live subscription receiv
 
 # IANA Considerations
 
-This document requests the following registrations.
-High, distinctive values are requested to avoid the low ranges reserved by {{moqt}} and to minimize collisions with provisional registrations by other extensions; they also avoid the greasing pattern (`0x7f * N + 0x9D`).
-The property Types are even so that each value is a bare varint with no length prefix (see {{moqt}} Section 2.5).
+This document requests no registrations.
 
-## MOQT Properties
+Both properties it uses are already registered by {{loc}} in the "MOQ Properties" registry ({{moqt}} Section 15.8), and this document changes neither their code points nor their value encodings:
 
-This document requests registrations in the "MOQT Properties" registry ({{moqt}} Section 15.8), used for object and track properties.
+| Value | Name      | Scope         | Reference |
+|:------|:----------|:--------------|:----------|
+| 0x08  | TIMESCALE | Track, Object | {{loc}}   |
+| 0x10  | TIMESTAMP | Object        | {{loc}}   |
 
-| Value   | Name      | Scope  | Reference     |
-|:--------|:----------|:-------|:--------------|
-| 0x915C0 | TIMESCALE | Track  | This Document |
-| 0x915C2 | TIMESTAMP | Object | This Document |
+Both Types are even, so each value is a bare varint with no length prefix (see {{moqt}} Section 2.5).
+
+An earlier version of this document requested its own code points (`0x915C0` and `0x915C2`) for these properties.
+They are abandoned: two registrations for one concept would leave a relay unable to read half the traffic it is meant to make decisions about.
 
 
 --- back

--- a/drafts/draft-lcurley-moq-timestamp.md
+++ b/drafts/draft-lcurley-moq-timestamp.md
@@ -57,14 +57,16 @@ That reuse is deliberate: a timestamp is only useful to a relay if every publish
 An endpoint that implements this document interoperates with a LOC endpoint without negotiation, and an endpoint that implements both writes one copy of each property, not two.
 
 These properties are self-describing and require no SETUP negotiation: a receiver that understands them uses them directly, and one that does not ignores them per {{moqt}}.
-Whenever a property is absent, including when neither endpoint implements this document, the defaults defined below apply: a Timescale of `1000` (milliseconds), and for an object with no Timestamp, the wall-clock arrival time of the object.
+TIMESCALE is what opts a track in.
+A track that carries it declares that its objects have media times and states the units; a track without it declares no timeline at all, and a receiver falls back to wall-clock arrival time for any age-based decision.
 
-That default differs from {{loc}}, which reads a track with no Timescale as microseconds.
-The difference is unreachable between conforming implementations because a publisher following this document always sends TIMESCALE explicitly (see [TIMESCALE Track Property](#timescale-track-property)), so the two never disagree about a timeline that is actually on the wire.
+There is deliberately no default timescale.
+A default would have to be guessed at exactly the moment the publisher said nothing, and a wrong guess is off by a factor of 1000 rather than detectably broken.
+Making presence the signal also keeps this document from contradicting {{loc}}, which reads a bare Timestamp as microseconds: a track this document describes always carries its own units, so the two never interpret the same bytes differently.
 
 
 # TIMESCALE Track Property
-The TIMESCALE property establishes the units for every Timestamp on a track.
+The TIMESCALE property opts a track into timestamps and establishes the units for every Timestamp on it.
 It is a track-level Key-Value-Pair, carried with the track's properties (see {{moqt}} Section 2.5 and Section 12).
 Because the value is a single integer, TIMESCALE uses an even Type so the value is a bare varint with no length prefix:
 
@@ -78,17 +80,21 @@ TIMESCALE Track Property {
 **Value**:
 The number of timestamp units per second.
 Common values include `1000` (milliseconds), `1000000` (microseconds), `48000` (a typical audio sample rate), and `90000` (the RTP video clock).
-A publisher MUST send TIMESCALE on every track that carries timestamps, even when the value equals the default.
-Sending it always is what keeps a track readable by any receiver: {{loc}} defaults an absent Timescale to microseconds while this document defaults it to milliseconds, and an explicit value removes the question.
+A value of `0` is invalid; a receiver MUST treat a track that declares it as carrying no timeline.
 
-The absence of the property defaults to `1000` (milliseconds), so a track from a publisher that predates this document still has a usable timeline. A value of `0` is invalid and MUST be treated as this default.
+Absence is meaningful and is not an error.
+A track with no TIMESCALE has no media timeline: a receiver MUST NOT infer units for it, and MUST use wall-clock arrival time for age-based decisions on that track, exactly as it would for an object with no Timestamp.
+Publishing a timestamp is therefore a per-track decision the publisher states once, rather than something a receiver discovers by watching objects go by.
+
+A publisher that emits Timestamps MUST send TIMESCALE, including when the units are ones a receiver might otherwise assume.
+{{loc}} permits a bare Timestamp and reads it as microseconds; a receiver that also implements LOC MAY apply that interpretation to a track that omits TIMESCALE, and MUST NOT apply any other.
 
 The Timescale is fixed for the lifetime of the track and MUST NOT change.
 {{loc}} also registers TIMESCALE with Object scope, allowing a per-object override.
 A receiver that implements both applies such an override to that object alone; it does not redefine the track's timeline, and a publisher following this document SHOULD NOT send one.
 
-The Timescale is required to interpret the units of every Timestamp.
-The track's properties are delivered in SUBSCRIBE_OK or TRACK_STATUS ({{moqt}} Section 12); a receiver that begins receiving objects before it has them cannot yet know whether a non-default Timescale applies, so it MUST fall back to wall-clock arrival time for any age-based decision until the properties arrive.
+The track's properties are delivered in SUBSCRIBE_OK or TRACK_STATUS ({{moqt}} Section 12).
+A receiver that begins receiving objects before it has them does not yet know whether the track is opted in, so it MUST fall back to wall-clock arrival time for any age-based decision until the properties arrive.
 
 
 # TIMESTAMP Object Property
@@ -113,8 +119,9 @@ TIMESTAMP (0x10) therefore follows any lower-numbered property in the same block
 Each Timestamp is absolute, not delta-encoded against a previous object.
 {{moqt}} does not guarantee reliable delivery of every object within a group or subgroup, so an object may be dropped or lost independently; an absolute timestamp remains correct regardless, whereas a delta would be corrupted by any missing predecessor.
 
-A publisher SHOULD attach TIMESTAMP to every object that has a media time.
+On a track that declares a TIMESCALE, a publisher SHOULD attach TIMESTAMP to every object that has a media time.
 An object with no TIMESTAMP has no media time; for age comparisons a receiver MUST treat its effective time as the wall-clock arrival time of the object, which avoids stalling expiration on objects that intentionally carry no timestamp (e.g. keep-alives or gap markers).
+The same fallback covers every object on a track that declares no TIMESCALE, so a receiver needs one rule, not two.
 
 ## Age-Based Dropping
 Given two objects on the same track, both with TIMESTAMP, a relay computes their relative age as the difference of their timestamps divided by the Timescale.

--- a/js/loc/src/index.test.ts
+++ b/js/loc/src/index.test.ts
@@ -2,8 +2,9 @@ import { expect, test } from "bun:test";
 import { type Time, Varint } from "@moq/net";
 import { Format } from "./index.ts";
 
-const PROP_TIMESTAMP = 0x06;
 const PROP_TIMESCALE = 0x08;
+const PROP_TIMESTAMP = 0x10;
+const PROP_TIMESTAMP_DRAFT03 = 0x06;
 
 function buildFrame(props: Uint8Array, payload: Uint8Array): Uint8Array {
 	const lenBytes = Varint.encode(props.byteLength);
@@ -41,10 +42,10 @@ test("Format decodes timestamp at default microseconds timescale", () => {
 test("Format honors per-frame timescale property", () => {
 	// timestamp = 96000 at per-frame timescale 48000 -> 2 seconds = 2_000_000 micros
 	const props = concat(
-		Varint.encode(PROP_TIMESTAMP),
-		Varint.encode(96_000),
-		Varint.encode(PROP_TIMESCALE - PROP_TIMESTAMP), // delta to 0x08
+		Varint.encode(PROP_TIMESCALE),
 		Varint.encode(48_000),
+		Varint.encode(PROP_TIMESTAMP - PROP_TIMESCALE), // delta to 0x10
+		Varint.encode(96_000),
 	);
 	const frame = buildFrame(props, new Uint8Array());
 
@@ -55,13 +56,13 @@ test("Format honors per-frame timescale property", () => {
 });
 
 test("Format skips unknown odd-typed properties", () => {
-	// 0x06 timestamp, then 0x0d (delta 7) video config bytes [1,2,3]
+	// 0x0d video config bytes [1,2,3], then 0x10 (delta 3) timestamp
 	const props = concat(
-		Varint.encode(PROP_TIMESTAMP),
-		Varint.encode(10),
-		Varint.encode(0x0d - PROP_TIMESTAMP),
+		Varint.encode(0x0d),
 		Varint.encode(3),
 		new Uint8Array([0x01, 0x02, 0x03]),
+		Varint.encode(PROP_TIMESTAMP - 0x0d),
+		Varint.encode(10),
 	);
 	const payload = new Uint8Array([0xaa]);
 	const frame = buildFrame(props, payload);
@@ -83,10 +84,10 @@ test("Format throws when the timestamp property is missing", () => {
 
 test("Format rejects zero per-frame timescale", () => {
 	const props = concat(
-		Varint.encode(PROP_TIMESTAMP),
-		Varint.encode(10),
-		Varint.encode(PROP_TIMESCALE - PROP_TIMESTAMP),
+		Varint.encode(PROP_TIMESCALE),
 		Varint.encode(0),
+		Varint.encode(PROP_TIMESTAMP - PROP_TIMESCALE),
+		Varint.encode(10),
 	);
 	const frame = buildFrame(props, new Uint8Array([0xaa]));
 
@@ -98,8 +99,20 @@ test("Format throws when properties_length exceeds frame size", () => {
 	const lenBytes = Varint.encode(100);
 	const buf = new Uint8Array(lenBytes.byteLength + 1);
 	buf.set(lenBytes, 0);
-	buf[lenBytes.byteLength] = 0x06;
+	buf[lenBytes.byteLength] = 0x10;
 
 	const fmt = new Format();
 	expect(() => fmt.decode(buf)).toThrow();
+});
+
+test("Format decodes the draft-03 timestamp property", () => {
+	const props = concat(Varint.encode(PROP_TIMESTAMP_DRAFT03), Varint.encode(4242));
+	const payload = new Uint8Array([0x01]);
+	const frame = buildFrame(props, payload);
+
+	const fmt = new Format();
+	const [decoded] = fmt.decode(frame);
+
+	expect(decoded.timestamp).toBe(4242 as Time.Micro);
+	expect(decoded.payload).toEqual(payload);
 });

--- a/js/loc/src/index.ts
+++ b/js/loc/src/index.ts
@@ -18,14 +18,20 @@ export interface Frame {
 	keyframe: boolean;
 }
 
-const PROP_TIMESTAMP = 0x06;
 const PROP_TIMESCALE = 0x08;
+const PROP_TIMESTAMP = 0x10;
+
+// The Timestamp id from draft-ietf-moq-loc-03, accepted on decode only. Draft-03's
+// body text and its IANA table disagreed (0x0A vs 0x06); this is the table's value,
+// which is what shipped. Draft-04 assigns 0x0A to Secure Objects private properties,
+// so it is not accepted here.
+const PROP_TIMESTAMP_DRAFT03 = 0x06;
 
 const DEFAULT_TIMESCALE = 1_000_000;
 
 /**
  * Decoder for the Low Overhead Container (LOC) defined in
- * draft-ietf-moq-loc.
+ * draft-ietf-moq-loc-04.
  *
  * Each MoQ frame is a small property block (timestamp, optional per-frame
  * timescale) followed by the codec bitstream payload. Frames without a 0x08
@@ -57,7 +63,7 @@ export class Format {
 			if (abs % 2 === 0) {
 				const [value, afterValue] = Moq.Varint.decode(cursor);
 				cursor = afterValue;
-				if (abs === PROP_TIMESTAMP) {
+				if (abs === PROP_TIMESTAMP || abs === PROP_TIMESTAMP_DRAFT03) {
 					timestamp = value;
 				} else if (abs === PROP_TIMESCALE) {
 					if (value === 0) {
@@ -97,7 +103,7 @@ export interface Source {
  * Encoder that packages frames as LOC and writes them to a moq-net track.
  *
  * Each call to {@link encode} produces one moq-net frame containing a
- * property block with the 0x06 timestamp (in microseconds) and the codec
+ * property block with the 0x10 timestamp (in microseconds) and the codec
  * bitstream payload.
  */
 export class Producer {

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -62,10 +62,15 @@ async function decodeVersioned<T>(
 	return await decoder(reader, version);
 }
 
-async function encodeFrameVersioned(frame: Frame, flags: GroupFlags, version: IetfVersion): Promise<Uint8Array> {
+async function encodeFrameVersioned(
+	frame: Frame,
+	flags: GroupFlags,
+	version: IetfVersion,
+	timescale: Timescale = Timescale.MILLI,
+): Promise<Uint8Array> {
 	const { stream, written } = createTestWritableStream();
 	const writer = new Writer(stream, version);
-	await frame.encode(writer, flags, version);
+	await frame.encode(writer, flags, timescale, version);
 	writer.close();
 	await writer.closed;
 	return concatChunks(written);
@@ -1150,13 +1155,16 @@ test("Frame object time: draft-15 uses absolute property types", async () => {
 	expect(await reader.u53()).toBe(0);
 	const extensions = await reader.read(await reader.u53());
 	const props = new Reader(undefined, extensions, Version.DRAFT_15);
-	expect(await props.u62()).toBe(0x08n);
-	expect(await props.u62()).toBe(1_000n);
 	expect(await props.u62()).toBe(0x10n);
 	expect(await props.u62()).toBe(96_000n);
 	expect(await props.done()).toBe(true);
 
-	const decoded = await Frame.decode(new Reader(undefined, encoded, Version.DRAFT_15), flags, Version.DRAFT_15);
+	const decoded = await Frame.decode(
+		new Reader(undefined, encoded, Version.DRAFT_15),
+		flags,
+		Timescale.MILLI,
+		Version.DRAFT_15,
+	);
 	expect(decoded.timestamp?.value).toBe(96_000);
 	expect(decoded.timestamp?.scale).toBe(Timescale.MILLI);
 });
@@ -1177,13 +1185,16 @@ test("Frame object time: draft-16 starts delta property types", async () => {
 	expect(await reader.u53()).toBe(0);
 	const extensions = await reader.read(await reader.u53());
 	const props = new Reader(undefined, extensions, Version.DRAFT_16);
-	expect(await props.u62()).toBe(0x08n);
-	expect(await props.u62()).toBe(1_000n);
-	expect(await props.u62()).toBe(0x08n);
+	expect(await props.u62()).toBe(0x10n);
 	expect(await props.u62()).toBe(96_000n);
 	expect(await props.done()).toBe(true);
 
-	const decoded = await Frame.decode(new Reader(undefined, encoded, Version.DRAFT_16), flags, Version.DRAFT_16);
+	const decoded = await Frame.decode(
+		new Reader(undefined, encoded, Version.DRAFT_16),
+		flags,
+		Timescale.MILLI,
+		Version.DRAFT_16,
+	);
 	expect(decoded.timestamp?.value).toBe(96_000);
 	expect(decoded.timestamp?.scale).toBe(Timescale.MILLI);
 });

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -1150,10 +1150,10 @@ test("Frame object time: draft-15 uses absolute property types", async () => {
 	expect(await reader.u53()).toBe(0);
 	const extensions = await reader.read(await reader.u53());
 	const props = new Reader(undefined, extensions, Version.DRAFT_15);
-	expect(await props.u62()).toBe(0x06n);
-	expect(await props.u62()).toBe(96_000n);
 	expect(await props.u62()).toBe(0x08n);
 	expect(await props.u62()).toBe(1_000n);
+	expect(await props.u62()).toBe(0x10n);
+	expect(await props.u62()).toBe(96_000n);
 	expect(await props.done()).toBe(true);
 
 	const decoded = await Frame.decode(new Reader(undefined, encoded, Version.DRAFT_15), flags, Version.DRAFT_15);
@@ -1177,10 +1177,10 @@ test("Frame object time: draft-16 starts delta property types", async () => {
 	expect(await reader.u53()).toBe(0);
 	const extensions = await reader.read(await reader.u53());
 	const props = new Reader(undefined, extensions, Version.DRAFT_16);
-	expect(await props.u62()).toBe(0x06n);
-	expect(await props.u62()).toBe(96_000n);
-	expect(await props.u62()).toBe(0x02n);
+	expect(await props.u62()).toBe(0x08n);
 	expect(await props.u62()).toBe(1_000n);
+	expect(await props.u62()).toBe(0x08n);
+	expect(await props.u62()).toBe(96_000n);
 	expect(await props.done()).toBe(true);
 
 	const decoded = await Frame.decode(new Reader(undefined, encoded, Version.DRAFT_16), flags, Version.DRAFT_16);

--- a/js/net/src/ietf/object.ts
+++ b/js/net/src/ietf/object.ts
@@ -3,8 +3,16 @@ import { Timescale, Timestamp } from "../time.ts";
 import { type IetfVersion, Version } from "./version.ts";
 
 const GROUP_END = 0x03;
-const PROP_TIMESTAMP = 0x06n;
+
+// MOQ Object Property ids, shared with draft-ietf-moq-loc-04.
 const PROP_TIMESCALE = 0x08n;
+const PROP_TIMESTAMP = 0x10n;
+
+// The Timestamp id from draft-ietf-moq-loc-03, accepted on decode only. Draft-03's
+// body text and its IANA table disagreed (0x0A vs 0x06); this is the table's value,
+// which is what shipped. Draft-04 assigns 0x0A to Secure Objects private properties,
+// so it is not accepted here.
+const PROP_TIMESTAMP_DRAFT03 = 0x06n;
 
 // draft-18 adds bit 0x40 (FIRST_OBJECT) to the subgroup header type per spec
 // 11.4.2. moq-lite always starts subgroups at object 0, so the bit carries no
@@ -43,11 +51,13 @@ async function encodeObjectPropertyType(
 	await w.u62(encoded);
 }
 
+// Timescale is written first because property type deltas are unsigned, so
+// properties have to appear in ascending type order.
 async function encodeObjectTime(w: Writer, timestamp: Timestamp, version: IetfVersion | undefined): Promise<void> {
-	await encodeObjectPropertyType(w, PROP_TIMESTAMP, 0n, version);
-	await w.u62(BigInt(Math.round(timestamp.value)));
-	await encodeObjectPropertyType(w, PROP_TIMESCALE, PROP_TIMESTAMP, version);
+	await encodeObjectPropertyType(w, PROP_TIMESCALE, 0n, version);
 	await w.u62(BigInt(timestamp.scale));
+	await encodeObjectPropertyType(w, PROP_TIMESTAMP, PROP_TIMESCALE, version);
+	await w.u62(BigInt(Math.round(timestamp.value)));
 }
 
 async function encodeObjectExtensions(
@@ -95,7 +105,7 @@ async function decodeObjectTime(r: Reader, version: IetfVersion | undefined): Pr
 
 		if (id % 2n === 0n) {
 			const value = await r.u62();
-			if (id === PROP_TIMESTAMP) {
+			if (id === PROP_TIMESTAMP || id === PROP_TIMESTAMP_DRAFT03) {
 				timestamp = value;
 			} else if (id === PROP_TIMESCALE) {
 				timescale = value;

--- a/js/net/src/ietf/object.ts
+++ b/js/net/src/ietf/object.ts
@@ -51,17 +51,24 @@ async function encodeObjectPropertyType(
 	await w.u62(encoded);
 }
 
-// Timescale is written first because property type deltas are unsigned, so
-// properties have to appear in ascending type order.
-async function encodeObjectTime(w: Writer, timestamp: Timestamp, version: IetfVersion | undefined): Promise<void> {
-	await encodeObjectPropertyType(w, PROP_TIMESCALE, 0n, version);
-	await w.u62(BigInt(timestamp.scale));
-	await encodeObjectPropertyType(w, PROP_TIMESTAMP, PROP_TIMESCALE, version);
-	await w.u62(BigInt(Math.round(timestamp.value)));
+// The units come from the track's TIMESCALE property, not from here: repeating the
+// timescale on every object would cost bytes per frame to restate something fixed for
+// the track's lifetime. The timestamp is converted into the track's units so the value
+// on the wire matches what the track declared.
+async function encodeObjectTime(
+	w: Writer,
+	timestamp: Timestamp,
+	timescale: Timescale,
+	version: IetfVersion | undefined,
+): Promise<void> {
+	const value = Math.round((timestamp.value * timescale) / timestamp.scale);
+	await encodeObjectPropertyType(w, PROP_TIMESTAMP, 0n, version);
+	await w.u62(BigInt(value));
 }
 
 async function encodeObjectExtensions(
 	timestamp: Timestamp | undefined,
+	timescale: Timescale,
 	version: IetfVersion | undefined,
 ): Promise<Uint8Array> {
 	if (timestamp === undefined) {
@@ -77,7 +84,7 @@ async function encodeObjectExtensions(
 		}),
 		version,
 	);
-	await encodeObjectTime(writer, timestamp, version);
+	await encodeObjectTime(writer, timestamp, timescale, version);
 	writer.close();
 	await writer.closed;
 
@@ -91,9 +98,13 @@ async function encodeObjectExtensions(
 	return result;
 }
 
-async function decodeObjectTime(r: Reader, version: IetfVersion | undefined): Promise<Timestamp | undefined> {
+async function decodeObjectTime(
+	r: Reader,
+	timescale: Timescale,
+	version: IetfVersion | undefined,
+): Promise<Timestamp | undefined> {
 	let timestamp: bigint | undefined;
-	let timescale: bigint | undefined;
+	let overrideScale: bigint | undefined;
 	let prevType = 0n;
 	let first = true;
 
@@ -108,7 +119,7 @@ async function decodeObjectTime(r: Reader, version: IetfVersion | undefined): Pr
 			if (id === PROP_TIMESTAMP || id === PROP_TIMESTAMP_DRAFT03) {
 				timestamp = value;
 			} else if (id === PROP_TIMESCALE) {
-				timescale = value;
+				overrideScale = value;
 			}
 		} else {
 			const size = await r.u53();
@@ -120,7 +131,8 @@ async function decodeObjectTime(r: Reader, version: IetfVersion | undefined): Pr
 		return undefined;
 	}
 
-	return new Timestamp(Number(timestamp), Timescale(Number(timescale ?? BigInt(Timescale.MICRO))));
+	// An object-scope Timescale (which LOC permits) overrides the track's for this object.
+	return new Timestamp(Number(timestamp), overrideScale !== undefined ? Timescale(Number(overrideScale)) : timescale);
 }
 
 export interface GroupFlags {
@@ -244,11 +256,11 @@ export class Frame {
 	}
 
 	/** Encode this frame using the group flags and negotiated IETF version. */
-	async encode(w: Writer, flags: GroupFlags, version = w.version): Promise<void> {
+	async encode(w: Writer, flags: GroupFlags, timescale: Timescale, version = w.version): Promise<void> {
 		await w.u53(0); // id_delta = 0
 
 		if (flags.hasExtensions) {
-			const extensions = await encodeObjectExtensions(this.timestamp, version);
+			const extensions = await encodeObjectExtensions(this.timestamp, timescale, version);
 			await w.u53(extensions.byteLength);
 			await w.write(extensions);
 		}
@@ -268,7 +280,12 @@ export class Frame {
 	}
 
 	/** Decode a frame using the group flags and negotiated IETF version. */
-	static async decode(r: Reader, flags: GroupFlags, version = r.version): Promise<Frame> {
+	static async decode(
+		r: Reader,
+		flags: GroupFlags,
+		timescale: Timescale | undefined,
+		version = r.version,
+	): Promise<Frame> {
 		const delta = await r.u53();
 		if (delta !== 0) {
 			throw new Error(`object ID delta is not supported: ${delta}`);
@@ -278,7 +295,11 @@ export class Frame {
 		if (flags.hasExtensions) {
 			const extensionsLength = await r.u53();
 			const extensions = await r.read(extensionsLength);
-			timestamp = await decodeObjectTime(new Reader(undefined, extensions, version), version);
+			// A track that declared no timescale opted out of timestamps, so its objects
+			// are stamped on arrival even if one carries a Timestamp we cannot interpret.
+			if (timescale !== undefined) {
+				timestamp = await decodeObjectTime(new Reader(undefined, extensions, version), timescale, version);
+			}
 		}
 
 		const payloadLength = await r.u53();

--- a/js/net/src/ietf/properties.ts
+++ b/js/net/src/ietf/properties.ts
@@ -1,19 +1,45 @@
-import type { Reader } from "../stream.ts";
+import type { Reader, Writer } from "../stream.ts";
+import { Timescale } from "../time.ts";
 import { type IetfVersion, Version } from "./version.ts";
 
-/// Skip Track Properties from the remaining bytes of a message.
+// TIMESCALE (0x08), from the MOQ Properties registry shared with draft-ietf-moq-loc-04.
+// Track scope: it declares the units of every object Timestamp on the track, and its
+// presence is what opts the track into timestamps at all.
+const TIMESCALE = 0x08n;
+
+/// Write the track's Timescale as a Track Property block.
+///
+/// Track Properties are the final field of the message, so this writes the block with
+/// no count and no length; the caller must not append anything after it.
+export async function encode(w: Writer, timescale: Timescale, version: IetfVersion): Promise<void> {
+	// Track Properties only exist in draft-17+; older drafts have nowhere to put this.
+	if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
+		return;
+	}
+
+	// First property in the block, so the delta-encoded type is the absolute id.
+	await w.u62(TIMESCALE);
+	await w.u62(BigInt(timescale));
+}
+
+/// Parse Track Properties from the remaining bytes of a message, returning the track's
+/// Timescale if it declared one.
 ///
 /// Track Properties are delta-encoded Key-Value-Pairs (same format as
 /// Message Parameters) but with NO count prefix — they extend to the
 /// end of the message payload.
 ///
+/// `undefined` means the track declared no timeline, which is not an error: the caller
+/// times its objects by arrival instead.
+///
 /// Only present in draft-17+; older drafts don't have Track Properties.
-export async function skip(r: Reader, version: IetfVersion): Promise<void> {
+export async function decode(r: Reader, version: IetfVersion): Promise<Timescale | undefined> {
 	// Track Properties only exist in draft-17+
 	if (version === Version.DRAFT_14 || version === Version.DRAFT_15 || version === Version.DRAFT_16) {
-		return;
+		return undefined;
 	}
 
+	let timescale: Timescale | undefined;
 	let prevType = 0n;
 	let i = 0;
 
@@ -25,11 +51,18 @@ export async function skip(r: Reader, version: IetfVersion): Promise<void> {
 
 		if (abs % 2n === 0n) {
 			// Even type: single varint value
-			await r.u62();
+			const value = await r.u62();
+			if (abs === TIMESCALE && value > 0n) {
+				// A zero timescale is invalid; treat it as no declaration rather than
+				// failing the whole message over one property we could have ignored.
+				timescale = Timescale(Number(value));
+			}
 		} else {
 			// Odd type: length-prefixed bytes
 			const len = await r.u53();
 			await r.read(len);
 		}
 	}
+
+	return timescale;
 }

--- a/js/net/src/ietf/publish.ts
+++ b/js/net/src/ietf/publish.ts
@@ -121,7 +121,7 @@ export class Publish {
 		}
 		// v15+: parameters followed by Track Properties (draft-17+)
 		const params = await Parameters.decode(r, version);
-		await Properties.skip(r, version);
+		await Properties.decode(r, version);
 		const groupOrder = params.groupOrder ?? 0x02;
 		const forward = params.forward ?? true;
 		const largest = params.largest;

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -4,6 +4,7 @@ import { error, reason } from "../error.ts";
 import type * as group from "../group.ts";
 import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
+import type { Timescale } from "../time.ts";
 import type { Session } from "./adapter.ts";
 import { Frame, Group as GroupMessage } from "./object.ts";
 import { PublishDone } from "./publish.ts";
@@ -153,6 +154,10 @@ export class Publisher {
 		const track = broadcast.subscribe(msg.trackName, { priority: msg.subscriberPriority });
 
 		try {
+			// Declaring the timescale is what opts the track into timestamps; every object
+			// Timestamp below is in these units.
+			const timescale = (await track.info()).timescale;
+
 			// Send SUBSCRIBE_OK
 			await stream.writer.u53(SubscribeOk.id);
 			const ok = new SubscribeOk({
@@ -161,6 +166,7 @@ export class Publisher {
 						? msg.requestId
 						: undefined,
 				trackAlias: msg.requestId,
+				timescale,
 			});
 			await ok.encode(stream.writer, version);
 			console.debug(`publish ok: broadcast=${name} track=${track.name}`);
@@ -170,7 +176,7 @@ export class Publisher {
 				for (;;) {
 					const group = await track.recvGroup();
 					if (!group) return;
-					void this.#runGroup(msg.requestId, group);
+					void this.#runGroup(msg.requestId, group, timescale);
 				}
 			})();
 
@@ -206,7 +212,7 @@ export class Publisher {
 	/**
 	 * Runs a group and sends its frames using ObjectStream (Subgroup delivery mode).
 	 */
-	async #runGroup(requestId: bigint, group: group.Consumer) {
+	async #runGroup(requestId: bigint, group: group.Consumer, timescale: Timescale) {
 		try {
 			const stream = await Writer.open(this.#quic, this.#session.version);
 
@@ -232,7 +238,7 @@ export class Publisher {
 					if (!frame) break;
 
 					const obj = new Frame({ payload: frame.payload, timestamp: frame.timestamp });
-					await obj.encode(stream, header.flags, this.#session.version);
+					await obj.encode(stream, header.flags, timescale, this.#session.version);
 				}
 
 				stream.close();

--- a/js/net/src/ietf/request.ts
+++ b/js/net/src/ietf/request.ts
@@ -87,7 +87,7 @@ export class RequestOk {
 				? await r.u62()
 				: undefined;
 		const parameters = await Parameters.decode(r, version);
-		await Properties.skip(r, version);
+		await Properties.decode(r, version);
 		return new RequestOk({ requestId, parameters });
 	}
 

--- a/js/net/src/ietf/subscribe.ts
+++ b/js/net/src/ietf/subscribe.ts
@@ -1,5 +1,6 @@
 import type * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
+import type { Timescale } from "../time.ts";
 import * as Message from "./message.ts";
 import * as Namespace from "./namespace.ts";
 import { Parameters } from "./parameters.ts";
@@ -131,9 +132,25 @@ export class SubscribeOk {
 	requestId: bigint | undefined;
 	trackAlias: bigint;
 
-	constructor({ requestId, trackAlias }: { requestId?: bigint; trackAlias: bigint }) {
+	/**
+	 * The track's Timescale, sent as a Track Property (draft-17+).
+	 *
+	 * `undefined` declares no timeline, so the subscriber times objects by arrival.
+	 */
+	timescale: Timescale | undefined;
+
+	constructor({
+		requestId,
+		trackAlias,
+		timescale,
+	}: {
+		requestId?: bigint;
+		trackAlias: bigint;
+		timescale?: Timescale;
+	}) {
 		this.requestId = requestId;
 		this.trackAlias = trackAlias;
+		this.timescale = timescale;
 	}
 
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
@@ -153,6 +170,11 @@ export class SubscribeOk {
 			const params = new Parameters();
 			params.groupOrder = GROUP_ORDER;
 			await params.encode(w, version);
+
+			// Track Properties are the final field, so nothing may follow.
+			if (this.timescale !== undefined) {
+				await Properties.encode(w, this.timescale, version);
+			}
 		}
 	}
 
@@ -170,6 +192,7 @@ export class SubscribeOk {
 				? await r.u62()
 				: undefined;
 		const trackAlias = await r.u62();
+		let timescale: Timescale | undefined;
 
 		if (version === Version.DRAFT_14) {
 			const expires = await r.u62();
@@ -190,10 +213,10 @@ export class SubscribeOk {
 		} else {
 			// v15+: parameters followed by Track Properties (draft-17+)
 			await Parameters.decode(r, version);
-			await Properties.skip(r, version);
+			timescale = await Properties.decode(r, version);
 		}
 
-		return new SubscribeOk({ requestId, trackAlias });
+		return new SubscribeOk({ requestId, trackAlias, timescale });
 	}
 }
 

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -5,7 +5,7 @@ import { error, reason } from "../error.ts";
 import * as netGroup from "../group.ts";
 import * as Path from "../path.ts";
 import type { Reader, Stream } from "../stream.ts";
-import { Timestamp } from "../time.ts";
+import { type Timescale, Timestamp } from "../time.ts";
 import type * as track from "../track.ts";
 import { withTimeout } from "../util/timeout.ts";
 import type { Session } from "./adapter.ts";
@@ -50,6 +50,11 @@ export class Subscriber {
 
 	// Publisher-chosen aliases used by incoming group streams.
 	#aliases = new TrackAliases<track.Producer>();
+
+	// Units for each track's object Timestamps, from the TIMESCALE Track Property in
+	// SUBSCRIBE_OK. A track missing from this map declared no timeline, so the publisher
+	// opted out of timestamps and its frames are stamped on arrival instead.
+	#timescales = new Map<bigint, Timescale>();
 
 	// Dedup consumed broadcasts per path: repeat consume() calls share one subscription.
 	#consumes = new BroadcastCache();
@@ -317,6 +322,7 @@ export class Subscriber {
 			);
 		} finally {
 			this.#aliases.delete(trackAlias, producer);
+			this.#timescales.delete(trackAlias);
 		}
 	}
 
@@ -365,6 +371,9 @@ export class Subscriber {
 		const ok = await SubscribeOk.decode(state.stream.reader, version);
 		try {
 			this.#aliases.set(ok.trackAlias, producer);
+			if (ok.timescale !== undefined) {
+				this.#timescales.set(ok.trackAlias, ok.timescale);
+			}
 		} catch (err) {
 			this.#session.close();
 			throw err;
@@ -504,7 +513,12 @@ export class Subscriber {
 				const done = await Promise.race([stream.done(), producer.closed, track.closed]);
 				if (done !== false) break;
 
-				const frame = await Frame.decode(stream, group.flags, this.#session.version);
+				const frame = await Frame.decode(
+					stream,
+					group.flags,
+					this.#timescales.get(group.trackAlias),
+					this.#session.version,
+				);
 				if (frame.payload === undefined) break;
 
 				producer.writeFrame({ payload: frame.payload, timestamp: frame.timestamp ?? Timestamp.now() });

--- a/rs/moq-loc/src/lib.rs
+++ b/rs/moq-loc/src/lib.rs
@@ -1,5 +1,5 @@
 //! Wire encoding for the Low Overhead Container (LOC) defined in
-//! [draft-ietf-moq-loc](https://www.ietf.org/archive/id/draft-ietf-moq-loc-00.html).
+//! [draft-ietf-moq-loc-04](https://www.ietf.org/archive/id/draft-ietf-moq-loc-04.html).
 //!
 //! A LOC frame is laid out as:
 //!
@@ -9,14 +9,15 @@
 //! [codec_bitstream: remaining bytes]
 //! ```
 //!
-//! Each KVP starts with a delta-encoded type id. Even types carry a single
-//! varint value, odd types carry length-prefixed bytes. Recognized types:
+//! Each KVP starts with a delta-encoded type id, so properties are serialized in
+//! ascending type order. Even types carry a single varint value, odd types carry
+//! length-prefixed bytes. Recognized types:
 //!
 //! | ID   | Name        | Decoded into       |
 //! |------|-------------|--------------------|
-//! | 0x06 | Timestamp   | [`Frame::timestamp`] (required) |
 //! | 0x08 | Timescale   | [`Frame::timescale`] (optional, per-frame override) |
 //! | 0x0d | Video Config | Skipped. The hang catalog's `description` is authoritative. |
+//! | 0x10 | Timestamp   | [`Frame::timestamp`] (required) |
 //!
 //! Any other property is silently skipped on decode and never emitted on
 //! encode. Public properties are not handled here. They belong in the MoQ
@@ -28,8 +29,17 @@ use bytes::{Buf, Bytes, BytesMut};
 use moq_net::{BoundsExceeded, DecodeError, EncodeError, VarInt};
 
 /// Property IDs recognized by this implementation.
-const PROP_TIMESTAMP: u64 = 0x06;
 const PROP_TIMESCALE: u64 = 0x08;
+const PROP_TIMESTAMP: u64 = 0x10;
+
+/// The Timestamp id from draft-03, accepted on decode so frames from an older
+/// peer (including our own releases) still carry a timestamp.
+///
+/// Only the value from draft-03's IANA table is honored. Draft-03's body text
+/// disagreed with its own table and said 0x0A, which draft-04 assigns to Secure
+/// Objects private properties, so decoding 0x0A as a timestamp would misread
+/// somebody else's property.
+const PROP_TIMESTAMP_DRAFT03: u64 = 0x06;
 
 /// A decoded LOC frame.
 #[derive(Clone, Debug)]
@@ -51,7 +61,7 @@ pub struct Frame {
 #[derive(Debug, Clone, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
-	/// The frame's property block did not contain a 0x06 (Timestamp) entry.
+	/// The frame's property block did not contain a 0x10 (Timestamp) entry.
 	#[error("loc frame missing required timestamp property")]
 	MissingTimestamp,
 
@@ -121,7 +131,7 @@ pub fn decode(mut buf: Bytes) -> Result<Frame, Error> {
 		if abs % 2 == 0 {
 			let value: u64 = VarInt::decode_quic(&mut props)?.into();
 			match abs {
-				PROP_TIMESTAMP => timestamp = Some(value),
+				PROP_TIMESTAMP | PROP_TIMESTAMP_DRAFT03 => timestamp = Some(value),
 				PROP_TIMESCALE => {
 					if value == 0 {
 						return Err(Error::MalformedProperties);
@@ -151,7 +161,7 @@ pub fn decode(mut buf: Bytes) -> Result<Frame, Error> {
 	})
 }
 
-/// Encode a LOC frame with a single 0x06 Timestamp property.
+/// Encode a LOC frame with a single 0x10 Timestamp property.
 ///
 /// Per-frame 0x08 timescale is never emitted. The encoder relies on the
 /// catalog timescale to interpret `timestamp`.
@@ -190,12 +200,12 @@ mod tests {
 
 	#[test]
 	fn decode_per_frame_timescale() {
-		// Manually craft: properties = [delta=0x06 timestamp=96000, delta=0x02 (abs=0x08) timescale=48000]
+		// Manually craft: properties = [delta=0x08 timescale=48000, delta=0x08 (abs=0x10) timestamp=96000]
 		let mut props = BytesMut::new();
-		write_varint(&mut props, PROP_TIMESTAMP);
-		write_varint(&mut props, 96_000);
-		write_varint(&mut props, PROP_TIMESCALE - PROP_TIMESTAMP); // delta = 2
+		write_varint(&mut props, PROP_TIMESCALE);
 		write_varint(&mut props, 48_000);
+		write_varint(&mut props, PROP_TIMESTAMP - PROP_TIMESCALE); // delta = 8
+		write_varint(&mut props, 96_000);
 
 		let mut frame = BytesMut::new();
 		write_varint(&mut frame, props.len() as u64);
@@ -210,13 +220,13 @@ mod tests {
 
 	#[test]
 	fn decode_skips_video_config() {
-		// properties = [delta=0x06 timestamp=10, delta=0x07 (abs=0x0d, video config) bytes=[1,2,3]]
+		// properties = [delta=0x0d (video config) bytes=[1,2,3], delta=0x03 (abs=0x10) timestamp=10]
 		let mut props = BytesMut::new();
-		write_varint(&mut props, PROP_TIMESTAMP);
-		write_varint(&mut props, 10);
-		write_varint(&mut props, 0x0d - PROP_TIMESTAMP); // delta = 7 -> abs 0x0d (Video Config)
+		write_varint(&mut props, 0x0d);
 		write_varint(&mut props, 3); // length
 		props.extend_from_slice(&[0x01, 0x02, 0x03]);
+		write_varint(&mut props, PROP_TIMESTAMP - 0x0d); // delta = 3
+		write_varint(&mut props, 10);
 
 		let mut frame = BytesMut::new();
 		write_varint(&mut frame, props.len() as u64);
@@ -257,10 +267,10 @@ mod tests {
 	fn decode_rejects_zero_timescale() {
 		// Per-frame 0x08 timescale of 0 is invalid (would divide by zero).
 		let mut props = BytesMut::new();
-		write_varint(&mut props, PROP_TIMESTAMP);
-		write_varint(&mut props, 10);
-		write_varint(&mut props, PROP_TIMESCALE - PROP_TIMESTAMP);
+		write_varint(&mut props, PROP_TIMESCALE);
 		write_varint(&mut props, 0);
+		write_varint(&mut props, PROP_TIMESTAMP - PROP_TIMESCALE);
+		write_varint(&mut props, 10);
 
 		let mut frame = BytesMut::new();
 		write_varint(&mut frame, props.len() as u64);
@@ -274,8 +284,33 @@ mod tests {
 	fn decode_overflowing_properties_length_errors() {
 		let mut frame = BytesMut::new();
 		write_varint(&mut frame, 100); // claims 100 bytes of properties
-		frame.extend_from_slice(&[0x06]); // only 1 byte follows
+		frame.extend_from_slice(&[0x10]); // only 1 byte follows
 
 		assert!(matches!(decode(frame.freeze()), Err(Error::MalformedProperties)));
+	}
+
+	#[test]
+	fn decode_accepts_draft03_timestamp() {
+		// A draft-03 peer wrote the Timestamp at 0x06 instead of 0x10.
+		let mut props = BytesMut::new();
+		write_varint(&mut props, PROP_TIMESTAMP_DRAFT03);
+		write_varint(&mut props, 4242);
+
+		let mut frame = BytesMut::new();
+		write_varint(&mut frame, props.len() as u64);
+		frame.extend_from_slice(&props);
+		frame.extend_from_slice(b"payload");
+
+		let decoded = decode(frame.freeze()).unwrap();
+		assert_eq!(decoded.timestamp, 4242);
+		assert_eq!(decoded.payload, Bytes::from_static(b"payload"));
+	}
+
+	#[test]
+	fn encode_uses_draft04_timestamp() {
+		// The encoder emits 0x10, never the draft-03 id: the compat is decode-only.
+		let encoded = encode(7, b"x").unwrap();
+		let props_len = encoded[0] as usize;
+		assert_eq!(encoded[1..=props_len][0], PROP_TIMESTAMP as u8);
 	}
 }

--- a/rs/moq-mux/src/container/loc/mod.rs
+++ b/rs/moq-mux/src/container/loc/mod.rs
@@ -3,7 +3,7 @@
 //! The IETF draft replacement for hang's Legacy format. Each moq frame
 //! holds a small property block (timestamp, optional per-frame
 //! timescale) followed by the codec bitstream. Defaults to microsecond
-//! timestamps. See [draft-ietf-moq-loc](https://www.ietf.org/archive/id/draft-ietf-moq-loc-00.html).
+//! timestamps. See [draft-ietf-moq-loc-04](https://www.ietf.org/archive/id/draft-ietf-moq-loc-04.html).
 
 use std::task::Poll;
 

--- a/rs/moq-net/src/ietf/fetch.rs
+++ b/rs/moq-net/src/ietf/fetch.rs
@@ -243,7 +243,9 @@ impl Message for FetchOk {
 				decode_params!(buf, version,
 					0x22 => group_order: Option<GroupOrder>,
 				);
-				super::properties::skip(buf, version)?;
+				// FETCH_OK may declare a timescale; we don't surface it yet, and a fetched
+				// object without an interpretable timestamp is stamped on arrival.
+				let _ = super::properties::decode(buf, version)?;
 
 				let group_order = group_order.unwrap_or(GroupOrder::Descending);
 

--- a/rs/moq-net/src/ietf/group.rs
+++ b/rs/moq-net/src/ietf/group.rs
@@ -18,23 +18,25 @@ const PROP_TIMESTAMP: u64 = 0x10;
 /// assigns 0x0A to Secure Objects private properties, so it is not accepted here.
 const PROP_TIMESTAMP_DRAFT03: u64 = 0x06;
 
-/// Encode a frame's presentation timestamp as moq-transport Object Properties.
+/// Encode a frame's presentation timestamp as a moq-transport Object Property.
 ///
-/// Matches the LOC encoding of the same registry ids so a relay or LOC-aware peer
+/// Matches the LOC encoding of the same registry id so a relay or LOC-aware peer
 /// reads the same bytes on drafts that delta-encode KVP type ids. The Timestamp
 /// value is always absolute. Writes the raw KVP bytes
 /// (no outer length prefix); the caller frames the block with its byte length.
 ///
-/// Timescale is written first because KVP type deltas are unsigned, so properties
-/// have to appear in ascending type order.
+/// The units come from the track's TIMESCALE property, not from here: repeating the
+/// timescale on every object would cost bytes per frame to restate something fixed for
+/// the track's lifetime. `timescale` is what the track advertised, and the timestamp is
+/// converted into it so the value on the wire matches the declared units.
 pub fn encode_object_time<W: bytes::BufMut>(
 	w: &mut W,
 	timestamp: Timestamp,
+	timescale: Timescale,
 	version: Version,
 ) -> Result<(), EncodeError> {
-	encode_object_property_type(w, PROP_TIMESCALE, 0, version)?;
-	u64::from(timestamp.scale()).encode(w, version)?;
-	encode_object_property_type(w, PROP_TIMESTAMP, PROP_TIMESCALE, version)?;
+	let timestamp = timestamp.convert(timescale).map_err(|_| EncodeError::BoundsExceeded)?;
+	encode_object_property_type(w, PROP_TIMESTAMP, 0, version)?;
 	timestamp.value().encode(w, version)?;
 	Ok(())
 }
@@ -52,12 +54,19 @@ fn encode_object_property_type<W: bytes::BufMut>(
 	encoded.encode(w, version)
 }
 
-/// Decode the Timescale (0x08) + Timestamp (0x10) Object Properties from an object's
-/// extension block, skipping any other properties. Returns `None` when no Timestamp
-/// property is present; a missing Timescale defaults to microseconds (the registry default).
-pub fn decode_object_time<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Option<Timestamp>, DecodeError> {
+/// Decode the Timestamp (0x10) Object Property from an object's extension block,
+/// skipping any other properties. Returns `None` when no Timestamp property is present.
+///
+/// `timescale` is the track's declared units. An object-scope Timescale (0x08) overrides
+/// it for that object alone, which draft-ietf-moq-loc-04 permits and we still honor on
+/// decode even though we no longer write one.
+pub fn decode_object_time<R: bytes::Buf>(
+	r: &mut R,
+	timescale: Timescale,
+	version: Version,
+) -> Result<Option<Timestamp>, DecodeError> {
 	let mut timestamp: Option<u64> = None;
-	let mut timescale: Option<u64> = None;
+	let mut override_scale: Option<u64> = None;
 	let mut prev_type: u64 = 0;
 	let mut first = true;
 
@@ -76,7 +85,7 @@ pub fn decode_object_time<R: bytes::Buf>(r: &mut R, version: Version) -> Result<
 			let value = u64::decode(r, version)?;
 			match abs {
 				PROP_TIMESTAMP | PROP_TIMESTAMP_DRAFT03 => timestamp = Some(value),
-				PROP_TIMESCALE => timescale = Some(value),
+				PROP_TIMESCALE => override_scale = Some(value),
 				_ => {}
 			}
 		} else {
@@ -92,9 +101,9 @@ pub fn decode_object_time<R: bytes::Buf>(r: &mut R, version: Version) -> Result<
 	let Some(value) = timestamp else {
 		return Ok(None);
 	};
-	let scale = match timescale {
+	let scale = match override_scale {
 		Some(s) => Timescale::new(s).map_err(|_| DecodeError::InvalidValue)?,
-		None => Timescale::MICRO,
+		None => timescale,
 	};
 	Ok(Some(
 		Timestamp::new(value, scale).map_err(|_| DecodeError::InvalidValue)?,
@@ -333,88 +342,101 @@ mod tests {
 
 	use bytes::Buf;
 
-	/// Object Property timestamp round-trips through encode/decode at its own scale.
+	/// An object Timestamp round-trips through encode/decode at the track's scale.
 	#[test]
 	fn test_object_time_roundtrip() {
 		let ts = Timestamp::new(96_000, Timescale::MICRO).unwrap();
 		let mut buf = bytes::BytesMut::new();
-		encode_object_time(&mut buf, ts, Version::Draft18).unwrap();
+		encode_object_time(&mut buf, ts, Timescale::MICRO, Version::Draft18).unwrap();
 
 		let mut bytes = buf.freeze();
-		let decoded = decode_object_time(&mut bytes, Version::Draft18).unwrap().unwrap();
+		let decoded = decode_object_time(&mut bytes, Timescale::MICRO, Version::Draft18)
+			.unwrap()
+			.unwrap();
 		assert_eq!(decoded.value(), 96_000);
 		assert_eq!(decoded.scale(), Timescale::MICRO);
 		assert!(!bytes.has_remaining());
 	}
 
+	/// The value on the wire is in the track's units, not the frame's.
+	#[test]
+	fn test_object_time_converts_into_the_track_scale() {
+		// 2 seconds, expressed in milliseconds by the frame.
+		let ts = Timestamp::new(2_000, Timescale::MILLI).unwrap();
+		let mut buf = bytes::BytesMut::new();
+		encode_object_time(&mut buf, ts, Timescale::MICRO, Version::Draft18).unwrap();
+
+		let mut bytes = buf.clone().freeze();
+		assert_eq!(u64::decode(&mut bytes, Version::Draft18).unwrap(), PROP_TIMESTAMP);
+		assert_eq!(u64::decode(&mut bytes, Version::Draft18).unwrap(), 2_000_000);
+		assert!(!bytes.has_remaining());
+
+		let mut bytes = buf.freeze();
+		let decoded = decode_object_time(&mut bytes, Timescale::MICRO, Version::Draft18)
+			.unwrap()
+			.unwrap();
+		assert_eq!(decoded.value(), 2_000_000);
+		assert_eq!(decoded.scale(), Timescale::MICRO);
+	}
+
+	/// No Timescale rides along with the object; the track declared it once.
+	#[test]
+	fn test_object_time_omits_the_timescale() {
+		let ts = Timestamp::new(96_000, Timescale::MILLI).unwrap();
+		let mut buf = bytes::BytesMut::new();
+		encode_object_time(&mut buf, ts, Timescale::MILLI, Version::Draft16).unwrap();
+
+		let mut bytes = buf.freeze();
+		assert_eq!(u64::decode(&mut bytes, Version::Draft16).unwrap(), PROP_TIMESTAMP);
+		assert_eq!(u64::decode(&mut bytes, Version::Draft16).unwrap(), 96_000);
+		assert!(!bytes.has_remaining());
+	}
+
+	/// Draft-14/15 write absolute property types rather than deltas.
 	#[test]
 	fn test_object_time_legacy_uses_absolute_types() {
 		let ts = Timestamp::new(96_000, Timescale::MILLI).unwrap();
 		let mut buf = bytes::BytesMut::new();
-		encode_object_time(&mut buf, ts, Version::Draft15).unwrap();
+		encode_object_time(&mut buf, ts, Timescale::MILLI, Version::Draft15).unwrap();
 
-		let mut bytes = buf.clone().freeze();
-		assert_eq!(u64::decode(&mut bytes, Version::Draft15).unwrap(), PROP_TIMESCALE);
-		assert_eq!(
-			u64::decode(&mut bytes, Version::Draft15).unwrap(),
-			u64::from(ts.scale())
-		);
+		let mut bytes = buf.freeze();
 		assert_eq!(u64::decode(&mut bytes, Version::Draft15).unwrap(), PROP_TIMESTAMP);
-		assert_eq!(u64::decode(&mut bytes, Version::Draft15).unwrap(), ts.value());
-		assert!(!bytes.has_remaining());
-
-		let mut bytes = buf.freeze();
-		let decoded = decode_object_time(&mut bytes, Version::Draft15).unwrap().unwrap();
-		assert_eq!(decoded.value(), ts.value());
-		assert_eq!(decoded.scale(), Timescale::MILLI);
-	}
-
-	#[test]
-	fn test_object_time_delta_types_start_at_draft16() {
-		let ts = Timestamp::new(96_000, Timescale::MILLI).unwrap();
-		let mut buf = bytes::BytesMut::new();
-		encode_object_time(&mut buf, ts, Version::Draft16).unwrap();
-
-		let mut bytes = buf.freeze();
-		assert_eq!(u64::decode(&mut bytes, Version::Draft16).unwrap(), PROP_TIMESCALE);
-		assert_eq!(
-			u64::decode(&mut bytes, Version::Draft16).unwrap(),
-			u64::from(ts.scale())
-		);
-		assert_eq!(
-			u64::decode(&mut bytes, Version::Draft16).unwrap(),
-			PROP_TIMESTAMP - PROP_TIMESCALE
-		);
-		assert_eq!(u64::decode(&mut bytes, Version::Draft16).unwrap(), ts.value());
+		assert_eq!(u64::decode(&mut bytes, Version::Draft15).unwrap(), 96_000);
 		assert!(!bytes.has_remaining());
 	}
 
+	/// An object-scope Timescale (which LOC permits) overrides the track's for that object.
 	#[test]
-	fn test_object_time_decodes_draft14_absolute_timescale() {
+	fn test_object_time_honors_an_object_scope_timescale() {
 		let mut buf = bytes::BytesMut::new();
-		PROP_TIMESCALE.encode(&mut buf, Version::Draft14).unwrap();
-		u64::from(Timescale::MILLI).encode(&mut buf, Version::Draft14).unwrap();
-		PROP_TIMESTAMP.encode(&mut buf, Version::Draft14).unwrap();
-		42u64.encode(&mut buf, Version::Draft14).unwrap();
+		PROP_TIMESCALE.encode(&mut buf, Version::Draft18).unwrap();
+		u64::from(Timescale::MILLI).encode(&mut buf, Version::Draft18).unwrap();
+		(PROP_TIMESTAMP - PROP_TIMESCALE)
+			.encode(&mut buf, Version::Draft18)
+			.unwrap();
+		42u64.encode(&mut buf, Version::Draft18).unwrap();
 
 		let mut bytes = buf.freeze();
-		let decoded = decode_object_time(&mut bytes, Version::Draft14).unwrap().unwrap();
+		let decoded = decode_object_time(&mut bytes, Timescale::MICRO, Version::Draft18)
+			.unwrap()
+			.unwrap();
 		assert_eq!(decoded.value(), 42);
 		assert_eq!(decoded.scale(), Timescale::MILLI);
 	}
 
-	/// A timescale-less extension block falls back to microseconds (registry default).
+	/// Without an object-scope override, the track's timescale supplies the units.
 	#[test]
-	fn test_object_time_defaults_to_micros() {
+	fn test_object_time_defaults_to_the_track_scale() {
 		let mut buf = bytes::BytesMut::new();
-		// Just a 0x10 Timestamp property, no 0x08.
 		PROP_TIMESTAMP.encode(&mut buf, Version::Draft18).unwrap();
 		1234u64.encode(&mut buf, Version::Draft18).unwrap();
 
 		let mut bytes = buf.freeze();
-		let decoded = decode_object_time(&mut bytes, Version::Draft18).unwrap().unwrap();
+		let decoded = decode_object_time(&mut bytes, Timescale::MILLI, Version::Draft18)
+			.unwrap()
+			.unwrap();
 		assert_eq!(decoded.value(), 1234);
-		assert_eq!(decoded.scale(), Timescale::MICRO);
+		assert_eq!(decoded.scale(), Timescale::MILLI);
 	}
 
 	/// A peer on draft-ietf-moq-loc-03 wrote the Timestamp at 0x06; still decode it.
@@ -425,7 +447,9 @@ mod tests {
 		777u64.encode(&mut buf, Version::Draft18).unwrap();
 
 		let mut bytes = buf.freeze();
-		let decoded = decode_object_time(&mut bytes, Version::Draft18).unwrap().unwrap();
+		let decoded = decode_object_time(&mut bytes, Timescale::MICRO, Version::Draft18)
+			.unwrap()
+			.unwrap();
 		assert_eq!(decoded.value(), 777);
 		assert_eq!(decoded.scale(), Timescale::MICRO);
 	}
@@ -434,7 +458,11 @@ mod tests {
 	#[test]
 	fn test_object_time_absent() {
 		let mut empty = bytes::Bytes::new();
-		assert!(decode_object_time(&mut empty, Version::Draft18).unwrap().is_none());
+		assert!(
+			decode_object_time(&mut empty, Timescale::MICRO, Version::Draft18)
+				.unwrap()
+				.is_none()
+		);
 	}
 
 	// Test table from draft-ietf-moq-transport-14 Section 10.4.2 Table 7

--- a/rs/moq-net/src/ietf/group.rs
+++ b/rs/moq-net/src/ietf/group.rs
@@ -7,9 +7,16 @@ use super::Version;
 use crate::ietf::Param;
 
 /// MOQ Object Property IDs (the MOQ Object Properties registry, shared with
-/// draft-ietf-moq-loc). Even type ids carry a single varint value.
-const PROP_TIMESTAMP: u64 = 0x06;
+/// draft-ietf-moq-loc-04). Even type ids carry a single varint value.
 const PROP_TIMESCALE: u64 = 0x08;
+const PROP_TIMESTAMP: u64 = 0x10;
+
+/// The Timestamp id from draft-ietf-moq-loc-03, accepted on decode only.
+///
+/// Draft-03's body text and its IANA table disagreed (0x0A vs 0x06); this is the
+/// table's value, which is what we and other implementations shipped. Draft-04
+/// assigns 0x0A to Secure Objects private properties, so it is not accepted here.
+const PROP_TIMESTAMP_DRAFT03: u64 = 0x06;
 
 /// Encode a frame's presentation timestamp as moq-transport Object Properties.
 ///
@@ -17,15 +24,18 @@ const PROP_TIMESCALE: u64 = 0x08;
 /// reads the same bytes on drafts that delta-encode KVP type ids. The Timestamp
 /// value is always absolute. Writes the raw KVP bytes
 /// (no outer length prefix); the caller frames the block with its byte length.
+///
+/// Timescale is written first because KVP type deltas are unsigned, so properties
+/// have to appear in ascending type order.
 pub fn encode_object_time<W: bytes::BufMut>(
 	w: &mut W,
 	timestamp: Timestamp,
 	version: Version,
 ) -> Result<(), EncodeError> {
-	encode_object_property_type(w, PROP_TIMESTAMP, 0, version)?;
-	timestamp.value().encode(w, version)?;
-	encode_object_property_type(w, PROP_TIMESCALE, PROP_TIMESTAMP, version)?;
+	encode_object_property_type(w, PROP_TIMESCALE, 0, version)?;
 	u64::from(timestamp.scale()).encode(w, version)?;
+	encode_object_property_type(w, PROP_TIMESTAMP, PROP_TIMESCALE, version)?;
+	timestamp.value().encode(w, version)?;
 	Ok(())
 }
 
@@ -42,7 +52,7 @@ fn encode_object_property_type<W: bytes::BufMut>(
 	encoded.encode(w, version)
 }
 
-/// Decode the Timestamp (0x06) + Timescale (0x08) Object Properties from an object's
+/// Decode the Timescale (0x08) + Timestamp (0x10) Object Properties from an object's
 /// extension block, skipping any other properties. Returns `None` when no Timestamp
 /// property is present; a missing Timescale defaults to microseconds (the registry default).
 pub fn decode_object_time<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Option<Timestamp>, DecodeError> {
@@ -65,7 +75,7 @@ pub fn decode_object_time<R: bytes::Buf>(r: &mut R, version: Version) -> Result<
 			// Even type: a single varint value.
 			let value = u64::decode(r, version)?;
 			match abs {
-				PROP_TIMESTAMP => timestamp = Some(value),
+				PROP_TIMESTAMP | PROP_TIMESTAMP_DRAFT03 => timestamp = Some(value),
 				PROP_TIMESCALE => timescale = Some(value),
 				_ => {}
 			}
@@ -344,13 +354,13 @@ mod tests {
 		encode_object_time(&mut buf, ts, Version::Draft15).unwrap();
 
 		let mut bytes = buf.clone().freeze();
-		assert_eq!(u64::decode(&mut bytes, Version::Draft15).unwrap(), PROP_TIMESTAMP);
-		assert_eq!(u64::decode(&mut bytes, Version::Draft15).unwrap(), ts.value());
 		assert_eq!(u64::decode(&mut bytes, Version::Draft15).unwrap(), PROP_TIMESCALE);
 		assert_eq!(
 			u64::decode(&mut bytes, Version::Draft15).unwrap(),
 			u64::from(ts.scale())
 		);
+		assert_eq!(u64::decode(&mut bytes, Version::Draft15).unwrap(), PROP_TIMESTAMP);
+		assert_eq!(u64::decode(&mut bytes, Version::Draft15).unwrap(), ts.value());
 		assert!(!bytes.has_remaining());
 
 		let mut bytes = buf.freeze();
@@ -366,26 +376,26 @@ mod tests {
 		encode_object_time(&mut buf, ts, Version::Draft16).unwrap();
 
 		let mut bytes = buf.freeze();
-		assert_eq!(u64::decode(&mut bytes, Version::Draft16).unwrap(), PROP_TIMESTAMP);
-		assert_eq!(u64::decode(&mut bytes, Version::Draft16).unwrap(), ts.value());
-		assert_eq!(
-			u64::decode(&mut bytes, Version::Draft16).unwrap(),
-			PROP_TIMESCALE - PROP_TIMESTAMP
-		);
+		assert_eq!(u64::decode(&mut bytes, Version::Draft16).unwrap(), PROP_TIMESCALE);
 		assert_eq!(
 			u64::decode(&mut bytes, Version::Draft16).unwrap(),
 			u64::from(ts.scale())
 		);
+		assert_eq!(
+			u64::decode(&mut bytes, Version::Draft16).unwrap(),
+			PROP_TIMESTAMP - PROP_TIMESCALE
+		);
+		assert_eq!(u64::decode(&mut bytes, Version::Draft16).unwrap(), ts.value());
 		assert!(!bytes.has_remaining());
 	}
 
 	#[test]
 	fn test_object_time_decodes_draft14_absolute_timescale() {
 		let mut buf = bytes::BytesMut::new();
-		PROP_TIMESTAMP.encode(&mut buf, Version::Draft14).unwrap();
-		42u64.encode(&mut buf, Version::Draft14).unwrap();
 		PROP_TIMESCALE.encode(&mut buf, Version::Draft14).unwrap();
 		u64::from(Timescale::MILLI).encode(&mut buf, Version::Draft14).unwrap();
+		PROP_TIMESTAMP.encode(&mut buf, Version::Draft14).unwrap();
+		42u64.encode(&mut buf, Version::Draft14).unwrap();
 
 		let mut bytes = buf.freeze();
 		let decoded = decode_object_time(&mut bytes, Version::Draft14).unwrap().unwrap();
@@ -397,13 +407,26 @@ mod tests {
 	#[test]
 	fn test_object_time_defaults_to_micros() {
 		let mut buf = bytes::BytesMut::new();
-		// Just a 0x06 Timestamp property, no 0x08.
+		// Just a 0x10 Timestamp property, no 0x08.
 		PROP_TIMESTAMP.encode(&mut buf, Version::Draft18).unwrap();
 		1234u64.encode(&mut buf, Version::Draft18).unwrap();
 
 		let mut bytes = buf.freeze();
 		let decoded = decode_object_time(&mut bytes, Version::Draft18).unwrap().unwrap();
 		assert_eq!(decoded.value(), 1234);
+		assert_eq!(decoded.scale(), Timescale::MICRO);
+	}
+
+	/// A peer on draft-ietf-moq-loc-03 wrote the Timestamp at 0x06; still decode it.
+	#[test]
+	fn test_object_time_decodes_draft03_timestamp() {
+		let mut buf = bytes::BytesMut::new();
+		PROP_TIMESTAMP_DRAFT03.encode(&mut buf, Version::Draft18).unwrap();
+		777u64.encode(&mut buf, Version::Draft18).unwrap();
+
+		let mut bytes = buf.freeze();
+		let decoded = decode_object_time(&mut bytes, Version::Draft18).unwrap().unwrap();
+		assert_eq!(decoded.value(), 777);
 		assert_eq!(decoded.scale(), Timescale::MICRO);
 	}
 

--- a/rs/moq-net/src/ietf/properties.rs
+++ b/rs/moq-net/src/ietf/properties.rs
@@ -7,10 +7,11 @@
 /// Unlike Message Parameters which have a count prefix, Track Properties
 /// have no count and are read until the end of the message payload.
 ///
-/// For now we parse and validate the structure but discard the values.
+/// TIMESCALE is the one property we understand; the rest are parsed and discarded.
 use bytes::Buf;
 
-use crate::coding::{Decode, DecodeError};
+use crate::Timescale;
+use crate::coding::{Decode, DecodeError, Encode, EncodeError};
 
 use super::Version;
 
@@ -18,19 +19,48 @@ const MAX_PROPERTIES: u64 = 64;
 /// Maximum byte value length per spec Section 1.4.3.
 const MAX_KVP_VALUE_LEN: usize = (1 << 16) - 1;
 
-/// Parse and discard Track Properties from the remaining bytes of a message.
+/// TIMESCALE (0x08), from the MOQ Properties registry shared with draft-ietf-moq-loc-04.
+///
+/// Track scope: it declares the units of every object Timestamp on the track, and its
+/// presence is what opts the track into timestamps at all.
+const TIMESCALE: u64 = 0x08;
+
+/// Write the track's Timescale as a Track Property block.
+///
+/// Track Properties are the final field of the message, so this writes the block with
+/// no count and no length; the caller must not append anything after it.
+pub fn encode<W: bytes::BufMut>(w: &mut W, timescale: Timescale, version: Version) -> Result<(), EncodeError> {
+	// Track Properties only exist in draft-17+; older drafts have nowhere to put this.
+	match version {
+		Version::Draft14 | Version::Draft15 | Version::Draft16 => return Ok(()),
+		_ => {}
+	}
+
+	// First property in the block, so the delta-encoded type is the absolute id.
+	TIMESCALE.encode(w, version)?;
+	u64::from(timescale).encode(w, version)
+}
+
+/// Parse Track Properties from the remaining bytes of a message, returning the track's
+/// Timescale if it declared one.
 ///
 /// Track Properties use the same Key-Value-Pair encoding as parameters:
 /// delta-encoded types, even = varint value, odd = length-prefixed bytes.
 /// They have no count prefix. Read until the buffer is empty.
 ///
+/// `None` means the track declared no timeline, which is not an error: the caller
+/// interprets its objects by arrival time instead. A Timescale of 0 is invalid and
+/// decodes to `None` for the same reason.
+///
 /// Only call this for draft-17+; older drafts don't have Track Properties.
-pub fn skip<R: Buf>(r: &mut R, version: Version) -> Result<(), DecodeError> {
+pub fn decode<R: Buf>(r: &mut R, version: Version) -> Result<Option<Timescale>, DecodeError> {
 	// Track Properties only exist in draft-17+
 	match version {
-		Version::Draft14 | Version::Draft15 | Version::Draft16 => return Ok(()),
+		Version::Draft14 | Version::Draft15 | Version::Draft16 => return Ok(None),
 		_ => {}
 	}
+
+	let mut timescale = None;
 
 	let mut prev_type: u64 = 0;
 	let mut i: u64 = 0;
@@ -51,7 +81,12 @@ pub fn skip<R: Buf>(r: &mut R, version: Version) -> Result<(), DecodeError> {
 
 		if abs % 2 == 0 {
 			// Even type: single varint value
-			let _ = u64::decode(r, version)?;
+			let value = u64::decode(r, version)?;
+			if abs == TIMESCALE {
+				// A zero timescale is invalid; treat it as no declaration rather than
+				// failing the whole message over one property we could have ignored.
+				timescale = Timescale::new(value).ok();
+			}
 		} else {
 			// Odd type: length-prefixed bytes
 			let len = u64::decode(r, version)? as usize;
@@ -65,7 +100,7 @@ pub fn skip<R: Buf>(r: &mut R, version: Version) -> Result<(), DecodeError> {
 		}
 	}
 
-	Ok(())
+	Ok(timescale)
 }
 
 #[cfg(test)]
@@ -77,7 +112,7 @@ mod tests {
 	#[test]
 	fn test_skip_empty_properties() {
 		let mut buf = bytes::Bytes::new();
-		skip(&mut buf, Version::Draft17).unwrap();
+		decode(&mut buf, Version::Draft17).unwrap();
 	}
 
 	#[test]
@@ -87,7 +122,7 @@ mod tests {
 		0x02u64.encode(&mut buf, Version::Draft17).unwrap(); // delta type
 		5000u64.encode(&mut buf, Version::Draft17).unwrap(); // value
 		let mut bytes = buf.freeze();
-		skip(&mut bytes, Version::Draft17).unwrap();
+		decode(&mut bytes, Version::Draft17).unwrap();
 		assert!(!bytes.has_remaining());
 	}
 
@@ -99,7 +134,7 @@ mod tests {
 		3u64.encode(&mut buf, Version::Draft17).unwrap(); // length
 		buf.extend_from_slice(&[0x01, 0x02, 0x03]); // value bytes
 		let mut bytes = buf.freeze();
-		skip(&mut bytes, Version::Draft17).unwrap();
+		decode(&mut bytes, Version::Draft17).unwrap();
 		assert!(!bytes.has_remaining());
 	}
 
@@ -118,7 +153,7 @@ mod tests {
 		buf.extend_from_slice(&[0xAA, 0xBB]);
 
 		let mut bytes = buf.freeze();
-		skip(&mut bytes, Version::Draft17).unwrap();
+		decode(&mut bytes, Version::Draft17).unwrap();
 		assert!(!bytes.has_remaining());
 	}
 }

--- a/rs/moq-net/src/ietf/publish.rs
+++ b/rs/moq-net/src/ietf/publish.rs
@@ -107,7 +107,7 @@ The namespace or track is not of interest to the endpoint.
 use std::borrow::Cow;
 
 use crate::{
-	Path,
+	Path, Timescale,
 	coding::{Decode, DecodeError, Encode, EncodeError},
 	ietf::{
 		FilterType, GroupOrder, Location, Parameters, RequestId,
@@ -173,6 +173,11 @@ pub struct Publish<'a> {
 	pub group_order: GroupOrder,
 	pub largest_location: Option<Location>,
 	pub forward: bool,
+
+	/// The track's Timescale, sent as a Track Property (draft-17+).
+	///
+	/// `None` declares no timeline, so the subscriber times objects by arrival.
+	pub timescale: Option<Timescale>,
 	// pub parameters: Parameters,
 }
 
@@ -208,6 +213,11 @@ impl Message for Publish<'_> {
 					0x10 => self.forward,
 					0x22 => self.group_order,
 				);
+
+				// Track Properties are the final field, so nothing may follow.
+				if let Some(timescale) = self.timescale {
+					super::properties::encode(w, timescale, version)?;
+				}
 			}
 		}
 
@@ -243,6 +253,7 @@ impl Message for Publish<'_> {
 					group_order,
 					largest_location,
 					forward,
+					timescale: None,
 				})
 			}
 			_ => {
@@ -251,7 +262,7 @@ impl Message for Publish<'_> {
 					0x10 => forward: Option<bool>,
 					0x22 => group_order: Option<GroupOrder>,
 				);
-				super::properties::skip(r, version)?;
+				let timescale = super::properties::decode(r, version)?;
 
 				let group_order = group_order.unwrap_or(GroupOrder::Descending);
 				let forward = forward.unwrap_or(true);
@@ -264,6 +275,7 @@ impl Message for Publish<'_> {
 					group_order,
 					largest_location,
 					forward,
+					timescale,
 				})
 			}
 		}
@@ -432,6 +444,7 @@ mod tests {
 			group_order: GroupOrder::Descending,
 			largest_location: Some(Location { group: 10, object: 5 }),
 			forward: true,
+			timescale: None,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft14);
@@ -455,6 +468,7 @@ mod tests {
 			group_order: GroupOrder::Descending,
 			largest_location: Some(Location { group: 10, object: 5 }),
 			forward: true,
+			timescale: None,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft15);
@@ -514,6 +528,7 @@ mod tests {
 			group_order: GroupOrder::Descending,
 			largest_location: Some(Location { group: 10, object: 5 }),
 			forward: true,
+			timescale: None,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft17);
@@ -573,6 +588,7 @@ mod tests {
 			group_order: GroupOrder::Descending,
 			largest_location: Some(Location { group: 10, object: 5 }),
 			forward: true,
+			timescale: None,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft18);
@@ -598,6 +614,7 @@ mod tests {
 			group_order: GroupOrder::Descending,
 			largest_location: None,
 			forward: true,
+			timescale: None,
 		};
 
 		let v17 = encode_message(&msg, Version::Draft17);

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -5,7 +5,7 @@ use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
 use web_transport_trait::SendStream;
 
 use crate::{
-	AsPath, Error,
+	AsPath, Error, Timescale,
 	coding::{Stream, Writer},
 	ietf::{self, Control, FetchHeader, FetchType, FilterType, GroupOrder, Location, RequestId},
 	track::Subscription,
@@ -236,6 +236,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					_ => None,
 				},
 				track_alias: request_id.0,
+				// Declaring the timescale is what opts the track into timestamps; every
+				// object Timestamp below is in these units.
+				timescale: Some(track.info().timescale),
 			})
 			.await?;
 
@@ -356,8 +359,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				group_id: sequence,
 				sub_group_id: 0,
 				publisher_priority: 0,
-				// Carry per-object timestamps as extension headers (Timestamp/Timescale
-				// Object Properties) so moq-transport peers get the real PTS.
+				// Carry per-object timestamps as extension headers (the Timestamp Object
+				// Property) so moq-transport peers get the real PTS. The units are the
+				// track's, declared once in SUBSCRIBE_OK.
 				flags: ietf::GroupFlags {
 					has_extensions: true,
 					..Default::default()
@@ -365,7 +369,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			};
 
 			let priority = track.subscription().priority;
-			tasks.push(Self::run_group(self.session.clone(), msg, priority, group, self.version).map(|_| ()));
+			let timescale = track.info().timescale;
+			tasks
+				.push(Self::run_group(self.session.clone(), msg, priority, group, timescale, self.version).map(|_| ()));
 		}
 	}
 
@@ -374,6 +380,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		msg: ietf::GroupHeader,
 		priority: u8,
 		mut group: group::Consumer,
+		timescale: Timescale,
 		version: Version,
 	) -> Result<(), Error> {
 		let mut stream = session.open_uni().await.map_err(Error::from_transport)?;
@@ -407,7 +414,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			// Per-object extension headers carry the frame's presentation timestamp.
 			if msg.flags.has_extensions {
 				let mut ext = bytes::BytesMut::new();
-				ietf::encode_object_time(&mut ext, frame.timestamp, version)?;
+				ietf::encode_object_time(&mut ext, frame.timestamp, timescale, version)?;
 				stream.encode(&(ext.len() as u64)).await?;
 				stream.write_chunk(ext.freeze()).await?;
 			}

--- a/rs/moq-net/src/ietf/subscribe.rs
+++ b/rs/moq-net/src/ietf/subscribe.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use crate::{
-	Path,
+	Path, Timescale,
 	coding::*,
 	ietf::{GroupOrder, Location, Parameters, RequestId},
 };
@@ -163,6 +163,11 @@ impl Message for Subscribe<'_> {
 pub struct SubscribeOk {
 	pub request_id: Option<RequestId>,
 	pub track_alias: u64,
+
+	/// The track's Timescale, sent as a Track Property (draft-17+).
+	///
+	/// `None` declares no timeline, so the subscriber times objects by arrival.
+	pub timescale: Option<Timescale>,
 }
 
 impl Message for SubscribeOk {
@@ -189,6 +194,11 @@ impl Message for SubscribeOk {
 				encode_params!(w, version,
 					0x22 => GroupOrder::Descending,
 				);
+
+				// Track Properties are the final field, so nothing may follow.
+				if let Some(timescale) = self.timescale {
+					super::properties::encode(w, timescale, version)?;
+				}
 			}
 		}
 
@@ -202,6 +212,7 @@ impl Message for SubscribeOk {
 			None
 		};
 		let track_alias = u64::decode(r, version)?;
+		let mut timescale = None;
 
 		match version {
 			Version::Draft14 => {
@@ -223,13 +234,14 @@ impl Message for SubscribeOk {
 				decode_params!(r, version,
 					0x22 => _group_order: Option<GroupOrder>,
 				);
-				super::properties::skip(r, version)?;
+				timescale = super::properties::decode(r, version)?;
 			}
 		}
 
 		Ok(Self {
 			request_id,
 			track_alias,
+			timescale,
 		})
 	}
 }
@@ -491,6 +503,7 @@ mod tests {
 		let msg = SubscribeOk {
 			request_id: Some(RequestId(42)),
 			track_alias: 42,
+			timescale: None,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft14);
@@ -504,6 +517,7 @@ mod tests {
 		let msg = SubscribeOk {
 			request_id: Some(RequestId(42)),
 			track_alias: 42,
+			timescale: None,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft15);
@@ -642,6 +656,7 @@ mod tests {
 		let msg = SubscribeOk {
 			request_id: None,
 			track_alias: 42,
+			timescale: None,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft17);
@@ -696,6 +711,7 @@ mod tests {
 		let msg = SubscribeOk {
 			request_id: None,
 			track_alias: 42,
+			timescale: None,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft18);

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{
-	Error, Path, PathOwned, broadcast,
+	Error, Path, PathOwned, Timescale, broadcast,
 	coding::{Reader, Stream},
 	frame, group,
 	ietf::{self, Control, FilterType, GroupOrder, RequestId},
@@ -60,6 +60,11 @@ struct State {
 struct TrackState {
 	producer: track::Producer,
 	alias: Option<u64>,
+
+	// Units for this track's object Timestamps, from the TIMESCALE Track Property in
+	// SUBSCRIBE_OK. `None` until it arrives, and for a track that declares none: the
+	// publisher opted out of timestamps, so frames are stamped on arrival instead.
+	timescale: Option<Timescale>,
 }
 
 struct BroadcastState {
@@ -608,6 +613,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				entry.insert(TrackState {
 					producer: track.clone(),
 					alias: Some(msg.track_alias),
+					timescale: msg.timescale,
 				});
 			}
 			Entry::Occupied(_) => {
@@ -708,6 +714,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				TrackState {
 					producer: track.clone(),
 					alias: None,
+					timescale: None,
 				},
 			);
 		}
@@ -727,7 +734,14 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 		// Read the response and register the alias mapping
 		match self.read_subscribe_response(&mut stream).await {
-			Ok(Some(alias)) => {
+			Ok(Some((alias, timescale))) => {
+				if let Some(timescale) = timescale {
+					let mut state = self.state.lock();
+					if let Some(track) = state.subscribes.get_mut(&request_id) {
+						track.timescale = Some(timescale);
+					}
+				}
+
 				if let Err(err) = self.register_alias(request_id, alias) {
 					self.session.close(err.to_code(), err.to_string().as_ref());
 					self.remove_subscribe(request_id);
@@ -815,7 +829,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		Ok(())
 	}
 
-	async fn read_subscribe_response(&self, stream: &mut Stream<S, Version>) -> Result<Option<u64>, Error> {
+	async fn read_subscribe_response(
+		&self,
+		stream: &mut Stream<S, Version>,
+	) -> Result<Option<(u64, Option<Timescale>)>, Error> {
 		// Read type_id + size + body from the stream
 		let type_id: u64 = stream.reader.decode().await?;
 		let size: u16 = stream.reader.decode().await?;
@@ -825,7 +842,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			ietf::SubscribeOk::ID => {
 				let msg = ietf::SubscribeOk::decode_msg(&mut data, self.version)?;
 				tracing::debug!(message = ?msg, "received subscribe ok");
-				Ok(Some(msg.track_alias))
+				Ok(Some((msg.track_alias, msg.timescale)))
 			}
 			ietf::SubscribeError::ID if self.version == Version::Draft14 => {
 				let msg = ietf::SubscribeError::decode_msg(&mut data, self.version)?;
@@ -856,7 +873,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			tracing::warn!(track_alias = %group.track_alias, "unknown track alias");
 		})?;
 
-		let (mut producer, track) = {
+		let (mut producer, track, timescale) = {
 			let mut state = self.state.lock();
 			let track = state.subscribes.get_mut(&request_id).ok_or(Error::NotFound)?;
 
@@ -866,11 +883,11 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			// Stats (groups/frames/bytes) are counted in the model as the group is
 			// written, through the tagged `track::Producer`.
 			let producer = track.producer.create_group(group_info)?;
-			(producer, track.producer.clone())
+			(producer, track.producer.clone(), track.timescale)
 		};
 
 		let res = {
-			let mut serve = std::pin::pin!(self.run_group(group, stream, producer.clone()));
+			let mut serve = std::pin::pin!(self.run_group(group, stream, producer.clone(), timescale));
 			kio::wait(|waiter| {
 				if let Poll::Ready(err) = track.poll_closed(waiter) {
 					return Poll::Ready(Err(err));
@@ -904,6 +921,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		group: ietf::GroupHeader,
 		stream: &mut Reader<S::RecvStream, Version>,
 		mut producer: group::Producer,
+		timescale: Option<Timescale>,
 	) -> Result<(), Error> {
 		while let Some(id_delta) = stream.decode_maybe::<u64>().await? {
 			if id_delta != 0 {
@@ -912,13 +930,21 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			}
 
 			// Per-object extension headers may carry the frame's presentation timestamp
-			// (Timestamp/Timescale Object Properties). Absent it, stamp the local receive time.
-			let timestamp = if group.flags.has_extensions {
-				let size: usize = stream.decode().await?;
-				let mut ext = stream.read_exact(size).await?;
-				ietf::decode_object_time(&mut ext, self.version)?
-			} else {
-				None
+			// (the Timestamp Object Property), in the units the track declared. A track
+			// that declared no timescale opted out, so its objects are stamped on arrival
+			// even if one carries a Timestamp we could not interpret.
+			let timestamp = match (group.flags.has_extensions, timescale) {
+				(true, Some(timescale)) => {
+					let size: usize = stream.decode().await?;
+					let mut ext = stream.read_exact(size).await?;
+					ietf::decode_object_time(&mut ext, timescale, self.version)?
+				}
+				(true, None) => {
+					let size: usize = stream.decode().await?;
+					stream.read_exact(size).await?;
+					None
+				}
+				(false, _) => None,
 			};
 
 			let size: u64 = stream.decode().await?;


### PR DESCRIPTION
## Summary

Follows #2578, which merged only the draft deletions. Three related changes.

**Adopts the draft-ietf-moq-loc-04 Timestamp code point, in the drafts and in the code.** `draft-ietf-moq-loc-03` contradicted itself: its body said Timestamp was `0x0A`, its IANA table said `0x06`, and we implemented the table's `0x06`. Draft-04 resolves it by moving Timestamp to `0x10` and handing `0x0A` to Secure Objects private properties, which leaves our `0x06` an unregistered code point nobody else reads.

- Encoders move to `0x10` (Timescale stays `0x08`) in all four implementations of this wire: `rs/moq-loc`, `rs/moq-net`'s IETF object properties, `js/loc`, `js/net`'s IETF object properties.
- Decoders also accept `0x06`, so frames from our own released versions keep their timestamps instead of silently falling back to wall-clock arrival time. **`0x0A` is deliberately not accepted**, since draft-04 gives it to Secure Objects and honoring it would misread somebody else's property.
- `draft-lcurley-moq-timestamp` had requested its own code points (`0x915C0`/`0x915C2`) for the same two properties, which no implementation ever wrote. It now defers to the LOC registrations and requests none of its own.

**Makes TIMESCALE the opt-in for timestamped tracks, and moves it to where that claim is true.** The draft previously carried a default timescale, which forced it to pick a value for the one case where the publisher said nothing (a bare Timestamp), and whatever it picked disagreed with LOC by a factor of 1000 with nothing on the wire to say which applied. TIMESCALE's presence now opts a track in; a track without it declares no timeline and its objects are stamped on arrival, which is already the rule for an object with no Timestamp, so a receiver implements one fallback rather than two.

That exposed a gap between the draft and the code, which this PR closes rather than papering over: both implementations only ever wrote TIMESCALE inside each object's extension block, so a conforming peer would have read every track we produce as untimed, and we were emitting an object-scope property the draft tells publishers not to send. SUBSCRIBE_OK and PUBLISH now carry a TIMESCALE **Track Property**, and each object carries only its Timestamp, converted into the units the track declared. This also shrinks every object, since the timescale was being restated per frame to describe something fixed for the track's lifetime.

**Aligns `draft-lcurley-moq-relay-hops` with moq-lite-06.** Path selection was hop-count-only and updating an advertisement deferred to an undefined "replaces the prior one per moq-transport" rule. The moq-transport flavor now carries the same three mechanisms as lite-06:

- `LINK_COST` Setup Option (`0x40B56`) declaring what a link costs to cross, defaulting to 1 so an unpriced mesh still ranks by hop count. Client-only, like lite's `Cost` parameter.
- `ROUTE_COST` parameter (`0x40B58`) carrying the accumulated marginal cost, including the actively-carrying discount (a warm relay advertises 0) and the deterministic tie-break that stops two warm relays from re-parenting onto each other at once.
- An explicit **Updating an Advertisement** section. Selection becomes lowest `ROUTE_COST`, ties broken by shorter `HOP_PATH`, then most recently received, which is lite-06's rule verbatim.

## Wire compatibility

**The LOC code point move is a deliberate, unavoidable break.** LOC renumbered Timestamp between -03 and -04 and offers no version negotiation, so a LOC frame is not self-describing about which revision wrote it. Every implementation tracking the draft has to move.

| | new decoder | old decoder |
|---|---|---|
| **new encoder** | works | **breaks**: `rs/moq-loc` raises `MissingTimestamp`; the moq-net IETF path falls back to wall-clock arrival time |
| **old encoder** | works (decoders accept `0x06`) | works |

Only the new-publisher/old-subscriber quadrant regresses. Dual-emitting `0x06` alongside `0x10` would paper over it and is rejected on purpose: `0x06` is unregistered as of draft-04 and sits in the Standards Action range, so writing it risks colliding with a future assignment, and a transitional hack in a wire encoder is never removed.

The TIMESCALE move rides the same break, and is narrower: an old peer reading a new publisher gets objects with no Timescale property, which it already interprets as the LOC default of microseconds.

## Notes for reviewers

**Property order flips.** KVP type deltas are unsigned (moq-transport Section 1.4.3), so properties are serialized in ascending type order. Timestamp is now *above* Timescale, so the old emit order would have underflowed the delta and failed every encode. Every hand-crafted test vector that built a delta by subtraction was rewritten.

**`ROUTE_COST` is bound to the `RELAY_HOPS` capability explicitly.** moq-transport gives Message Parameters no skip rule: an unknown one is a mandatory `PROTOCOL_VIOLATION` even when the type is even and the value is a bare varint. Adding a second parameter under an existing negotiation flag is only safe if the flag covers both, so the draft says sending `RELAY_HOPS` asserts support for both, and records that a future third parameter needs its own Setup Option (unknown *Setup Options* are ignored rather than fatal).

**Advertisement updates reuse the advertisement's stream.** moq-transport ties an advertisement to its request stream's lifetime, so an update on a new stream would leave two streams claiming one namespace and let the superseded one retract its replacement. Our JS IETF subscriber currently rejects a repeat `PUBLISH_NAMESPACE` outright, which the draft now forbids; that is filed as separate implementation work, since relay-hops itself is unimplemented.

## Test plan

- `just check` passes.
- `just test smoke-full` passes: all 21 publisher/subscriber combinations across rust, python, js, node, bun, c, and gst. Note this runs one checkout against itself, so it proves the Rust and JS sides agree with each other but says nothing about version skew; the table above covers that.
- `just drafts check` passes; `bun run --cwd doc check` passes (24/24).

(written by Opus 5)