### PR TITLE
refactor(kio): rename WaiterCell to Park

### DIFF
--- a/rs/kio/README.md
+++ b/rs/kio/README.md
@@ -15,9 +15,9 @@ Producers can modify the state and consumers are automatically notified via asyn
 The channel auto-closes when all producers are dropped.
 
 `Shared` is the role-less sibling for state that both sides mutate, and `Queue` is a
-poll-native FIFO queue (bounded or unbounded) built in the same style. `WaiterCell`
-bridges a `std::task::Context` to kio's waiter-based polls, for implementing
-`poll_*` trait methods on top of kio channels.
+poll-native FIFO queue (bounded or unbounded) built in the same style. `Park` holds a
+waiter for as long as a poll stays pending, bridging a `std::task::Context` to kio's
+waiter-based polls when implementing `Future` or `poll_*` on top of kio channels.
 
 It's used internally by [moq-net](https://github.com/moq-dev/moq/tree/main/rs/moq-net) and friends, but is generic enough to be useful on its own.
 

--- a/rs/kio/src/lib.rs
+++ b/rs/kio/src/lib.rs
@@ -48,7 +48,7 @@ pub use pollable::{Pending, Pollable};
 pub use producer::{Mut, Producer, Ref};
 pub use queue::{PushError, Queue};
 pub use shared::Shared;
-pub use waiter::{Waiter, WaiterCell, WaiterList, wait};
+pub use waiter::{Park, Waiter, WaiterList, wait};
 pub use weak::{ConsumerWeak, ProducerWeak, Weak};
 
 /// The channel closed before the awaited condition held.

--- a/rs/kio/src/pollable.rs
+++ b/rs/kio/src/pollable.rs
@@ -5,7 +5,7 @@ use std::{
 	task::{Context, Poll},
 };
 
-use crate::{Waiter, WaiterCell};
+use crate::{Park, Waiter};
 
 /// A pollable computation backed by kio channels.
 ///
@@ -14,8 +14,8 @@ use crate::{Waiter, WaiterCell};
 ///
 /// This exists because a kio [`Waiter`] holds the strong `Arc<Waker>` while the
 /// channel's [`crate::WaiterList`] keeps only a `Weak`. A bare [`Future`] would have
-/// to stash the strong `Waiter` in a field and replace it every poll (or lose its
-/// wakeup); [`Pending`] does that once so each implementor doesn't have to.
+/// to park the strong `Waiter` in a field for as long as it stays pending (or lose
+/// its wakeup); [`Pending`] does that once so each implementor doesn't have to.
 pub trait Pollable: Unpin {
 	/// The value the computation resolves to.
 	type Output;
@@ -29,7 +29,7 @@ pub trait Pollable: Unpin {
 	fn poll(&self, waiter: &Waiter) -> Poll<Self::Output>;
 }
 
-/// Adapts a [`Pollable`] into a [`Future`], retaining the strong [`Waiter`] between
+/// Adapts a [`Pollable`] into a [`Future`], parking the strong [`Waiter`] between
 /// polls so its weak registration stays live.
 ///
 /// Derefs to the inner value, so any inherent methods you define on it are
@@ -37,9 +37,8 @@ pub trait Pollable: Unpin {
 /// `update`).
 pub struct Pending<P> {
 	inner: P,
-	// Retains the waiter across polls so its weak registrations survive (and are
-	// reused when possible); see [`WaiterCell`].
-	cell: WaiterCell,
+	// Retains a parked waiter across polls so its weak registrations survive; see [`Park`].
+	park: Park,
 }
 
 impl<P> Pending<P> {
@@ -47,7 +46,7 @@ impl<P> Pending<P> {
 	pub fn new(inner: P) -> Self {
 		Self {
 			inner,
-			cell: WaiterCell::new(),
+			park: Park::default(),
 		}
 	}
 
@@ -77,8 +76,9 @@ impl<P: Pollable> Future for Pending<P> {
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<P::Output> {
 		// `Pending<P>` is `Unpin` (P is, via the trait bound), so this deref is sound.
 		let this = &mut *self;
-		let waiter = this.cell.hold(cx);
-		Pollable::poll(&this.inner, waiter)
+		let waiter = this.park.take(cx);
+		let poll = Pollable::poll(&this.inner, &waiter);
+		this.park.hold(waiter, poll)
 	}
 }
 

--- a/rs/kio/src/pollable.rs
+++ b/rs/kio/src/pollable.rs
@@ -76,9 +76,8 @@ impl<P: Pollable> Future for Pending<P> {
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<P::Output> {
 		// `Pending<P>` is `Unpin` (P is, via the trait bound), so this deref is sound.
 		let this = &mut *self;
-		let waiter = this.park.take(cx);
-		let poll = Pollable::poll(&this.inner, &waiter);
-		this.park.hold(waiter, poll)
+		let waiter = this.park.hold(cx);
+		Pollable::poll(&this.inner, waiter)
 	}
 }
 

--- a/rs/kio/src/queue.rs
+++ b/rs/kio/src/queue.rs
@@ -267,11 +267,10 @@ mod test {
 			Arc,
 			atomic::{AtomicUsize, Ordering},
 		},
-		task::{Context, Wake, Waker},
+		task::{Wake, Waker},
 	};
 
 	use super::*;
-	use crate::WaiterCell;
 
 	/// A waker that counts how many times it was woken (mirrors `tests.rs`).
 	struct CountWaker(AtomicUsize);
@@ -347,13 +346,13 @@ mod test {
 	fn push_wakes_a_parked_pop() {
 		let queue = Queue::new();
 		let (waker, w) = counting();
-		let mut cx = Context::from_waker(&w);
-		let mut cell = WaiterCell::new();
+		// One waiter across both polls, standing in for what a `Park` retains.
+		let waiter = Waiter::new(w);
 
-		assert!(queue.poll_pop(cell.hold(&mut cx)).is_pending());
+		assert!(queue.poll_pop(&waiter).is_pending());
 		queue.try_push(7).unwrap();
 		assert!(waker.count() >= 1, "push should wake the parked pop");
-		assert_eq!(queue.poll_pop(cell.hold(&mut cx)), Poll::Ready(Ok(7)));
+		assert_eq!(queue.poll_pop(&waiter), Poll::Ready(Ok(7)));
 	}
 
 	#[test]
@@ -362,14 +361,13 @@ mod test {
 		queue.try_push(1).unwrap();
 
 		let (waker, w) = counting();
-		let mut cx = Context::from_waker(&w);
-		let mut cell = WaiterCell::new();
+		let waiter = Waiter::new(w);
 
 		// Full: the closure must not run, and the poll parks.
 		let made = std::cell::Cell::new(false);
 		assert!(
 			queue
-				.poll_push_with(cell.hold(&mut cx), || {
+				.poll_push_with(&waiter, || {
 					made.set(true);
 					2
 				})
@@ -380,7 +378,7 @@ mod test {
 		// A pop frees the slot and wakes the parked push.
 		assert_eq!(queue.try_pop().unwrap(), Some(1));
 		assert!(waker.count() >= 1, "pop should wake the parked push");
-		assert_eq!(queue.poll_push_with(cell.hold(&mut cx), || 2), Poll::Ready(Ok(())));
+		assert_eq!(queue.poll_push_with(&waiter, || 2), Poll::Ready(Ok(())));
 		assert_eq!(queue.try_pop().unwrap(), Some(2));
 	}
 
@@ -390,31 +388,26 @@ mod test {
 		queue.try_push(1).unwrap();
 
 		let (pop_waker, w1) = counting();
-		let mut cx1 = Context::from_waker(&w1);
-		let mut pop_cell = WaiterCell::new();
+		let pop_waiter = Waiter::new(w1);
 		// Park a pop on a second handle (the queued item is popped first).
 		let popper = queue.clone();
-		assert_eq!(popper.poll_pop(pop_cell.hold(&mut cx1)), Poll::Ready(Ok(1)));
-		assert!(popper.poll_pop(pop_cell.hold(&mut cx1)).is_pending());
+		assert_eq!(popper.poll_pop(&pop_waiter), Poll::Ready(Ok(1)));
+		assert!(popper.poll_pop(&pop_waiter).is_pending());
 
 		// Refill so a push parks too.
 		queue.try_push(2).unwrap();
 		let (push_waker, w2) = counting();
-		let mut cx2 = Context::from_waker(&w2);
-		let mut push_cell = WaiterCell::new();
-		assert!(queue.poll_push_with(push_cell.hold(&mut cx2), || 3).is_pending());
+		let push_waiter = Waiter::new(w2);
+		assert!(queue.poll_push_with(&push_waiter, || 3).is_pending());
 
 		queue.close();
 		assert!(pop_waker.count() >= 1, "close should wake the parked pop");
 		assert!(push_waker.count() >= 1, "close should wake the parked push");
 
 		// The parked pop drains the remaining item; the push observes closure.
-		assert_eq!(popper.poll_pop(pop_cell.hold(&mut cx1)), Poll::Ready(Ok(2)));
-		assert_eq!(popper.poll_pop(pop_cell.hold(&mut cx1)), Poll::Ready(Err(Closed)));
-		assert_eq!(
-			queue.poll_push_with(push_cell.hold(&mut cx2), || 3),
-			Poll::Ready(Err(Closed))
-		);
+		assert_eq!(popper.poll_pop(&pop_waiter), Poll::Ready(Ok(2)));
+		assert_eq!(popper.poll_pop(&pop_waiter), Poll::Ready(Err(Closed)));
+		assert_eq!(queue.poll_push_with(&push_waiter, || 3), Poll::Ready(Err(Closed)));
 	}
 
 	#[test]

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -174,25 +174,28 @@ impl fmt::Debug for WaiterList {
 /// A [`WaiterList`] keeps only a `Weak`, so a waiter built inside a poll dies the
 /// moment that poll returns, taking its registrations with it. Whoever drives kio's
 /// `poll_*` methods from a [`Context`]-based poll (a `Future`, or a `poll_*` trait
-/// method) embeds one `Park` per logical operation and brackets the poll with it:
+/// method) embeds one `Park` per logical operation and calls [`hold`](Self::hold) at
+/// the top of each poll:
 ///
 /// ```
 /// # use std::task::{Context, Poll};
 /// # use kio::{Park, Waiter};
-/// # struct Driver { park: Park }
-/// # impl Driver {
+/// # struct State;
+/// # impl State {
 /// #     fn poll_step(&mut self, _: &Waiter) -> Poll<()> { Poll::Pending }
+/// # }
+/// # struct Driver { park: Park, state: State }
+/// # impl Driver {
 /// fn poll(&mut self, cx: &mut Context<'_>) -> Poll<()> {
-///     let waiter = self.park.take(cx);
-///     let poll = self.poll_step(&waiter);
-///     self.park.hold(waiter, poll)
+///     let waiter = self.park.hold(cx);
+///     self.state.poll_step(waiter)
 /// }
 /// # }
 /// ```
 ///
-/// Only a parked waiter is worth keeping, so a `Ready` releases instead of holding.
-/// The waiter is owned outright rather than borrowed from the park, leaving the rest
-/// of the poll free to take `&mut self`.
+/// Keep the park in a field *disjoint* from the state the body polls, as above. The
+/// returned borrow lives as long as the waiter does, so a park bundled into the same
+/// `&mut self` the body needs would collide with it.
 ///
 /// `Clone` yields an *empty* park: an in-progress registration belongs to the handle
 /// that parked it, so a cloned handle starts idle. This is what lets a containing
@@ -203,43 +206,34 @@ pub struct Park(Option<Waiter>);
 impl Park {
 	/// Create a park already holding `waiter`, for the rarer case where one exists
 	/// before the first poll (a `poll_*` method stashing the waiter its caller passed
-	/// in, say). Use [`Default`] for an empty park, and prefer
-	/// [`hold`](Self::hold) once polling starts, since it also handles the release.
+	/// in, say). Use [`Default`] for an empty park.
 	pub fn new(waiter: Waiter) -> Self {
 		Self(Some(waiter))
 	}
 
-	/// Take the waiter for this poll, leaving the park empty.
+	/// Hold a waiter for this poll, keeping it (and its registrations) alive until
+	/// the next call.
 	///
-	/// The parked waiter is reused when it wakes the same task *and* has no live
-	/// registrations left (the usual case after a wakeup, which drains every list
-	/// entry), so a steady-state park allocates nothing. Otherwise it is retired for a
-	/// fresh one: a still-registered waiter must not be registered again, because
+	/// Retention happens here, *before* the body runs, so a body that returns early
+	/// (the usual `ready!` on a nested poll) still leaves its registrations live.
+	/// There is no second call to forget.
+	///
+	/// The held waiter is reused when it would wake the same task *and* has no live
+	/// list registrations (the usual case after a wakeup, which drains every entry),
+	/// so a steady-state park allocates nothing. Otherwise it is retired for a fresh
+	/// one: a still-registered waiter must not be registered again, because
 	/// [`WaiterList`] reclaims a slot only once its `Arc` dies, so reusing one with
 	/// live entries would stack duplicates the list could never collect.
-	pub fn take(&mut self, cx: &Context<'_>) -> Waiter {
-		match self.0.take() {
-			Some(waiter)
-				if cx.waker().will_wake(&waiter.waker)
-					&& waiter.shared.get().is_none_or(|shared| Arc::weak_count(shared) == 0) =>
-			{
-				waiter
-			}
-			// Any other waiter is dropped here, killing its registrations so the
-			// lists can reclaim those slots.
-			_ => Waiter::from_context(cx),
+	pub fn hold(&mut self, cx: &Context<'_>) -> &Waiter {
+		let reuse = self.0.as_ref().is_some_and(|waiter| {
+			cx.waker().will_wake(&waiter.waker) && waiter.shared.get().is_none_or(|shared| Arc::weak_count(shared) == 0)
+		});
+		if !reuse {
+			// The outgoing waiter drops here, killing its registrations so the lists
+			// can reclaim those slots.
+			self.0 = Some(Waiter::from_context(cx));
 		}
-	}
-
-	/// Hold `waiter` until the next poll if this one parked, releasing whatever was
-	/// held before.
-	///
-	/// A `Ready` poll releases instead: the operation is over, so its waiter should
-	/// die and let the lists reclaim its slots. Returns `poll` unchanged so it can
-	/// tail a `Future::poll`.
-	pub fn hold<T>(&mut self, waiter: Waiter, poll: Poll<T>) -> Poll<T> {
-		self.0 = poll.is_pending().then_some(waiter);
-		poll
+		self.0.as_ref().unwrap()
 	}
 }
 
@@ -287,9 +281,8 @@ where
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<R> {
 		let this = &mut *self;
-		let waiter = this.park.take(cx);
-		let poll = (this.poll)(&waiter);
-		this.park.hold(waiter, poll)
+		let waiter = this.park.hold(cx);
+		(this.poll)(waiter)
 	}
 }
 
@@ -326,29 +319,32 @@ mod tests {
 	};
 
 	#[test]
-	fn park_holds_a_pending_waiter_and_releases_a_ready_one() {
+	fn park_survives_a_poll_that_returns_early() {
 		let waker = Waker::noop().clone();
 		let cx = Context::from_waker(&waker);
 		let mut park = Park::default();
 		let mut list = WaiterList::new();
 
-		// A parked poll: the waiter must outlive it, or the list entry it just made
-		// goes dead and the wakeup is lost.
-		let waiter = park.take(&cx);
-		waiter.register(&mut list);
-		assert!(park.hold(waiter, Poll::<u8>::Pending).is_pending());
-		assert_eq!(list.entries[0].strong_count(), 1, "a parked waiter must stay live");
+		// A poll body that bails out the moment a nested poll is pending (the `ready!`
+		// idiom) never runs any bookkeeping of its own after registering, so retention
+		// has to be in place already or the wakeup is lost forever.
+		fn poll_step(park: &mut Park, cx: &Context<'_>, list: &mut WaiterList, nested: Poll<u8>) -> Poll<u8> {
+			let waiter = park.hold(cx);
+			waiter.register(list);
+			// Returns straight out of the function, running nothing below it.
+			let value = std::task::ready!(nested);
+			Poll::Ready(value + 1)
+		}
 
-		// Drain the entry as a wakeup would, so the next poll picks the same waiter
-		// back up.
+		assert!(poll_step(&mut park, &cx, &mut list, Poll::Pending).is_pending());
+		assert_eq!(
+			list.entries[0].strong_count(),
+			1,
+			"an early return must leave the registration live"
+		);
+
+		// The wakeup still reaches it.
 		list.wake();
-
-		// A resolved poll has nothing left to wake, so its waiter is dropped and the
-		// list can reclaim the slot.
-		let waiter = park.take(&cx);
-		waiter.register(&mut list);
-		assert_eq!(park.hold(waiter, Poll::Ready(7)), Poll::Ready(7));
-		assert_eq!(list.entries[0].strong_count(), 0, "a ready waiter must be released");
 	}
 
 	#[test]
@@ -360,23 +356,21 @@ mod tests {
 
 		// Poll 1 parks with a live registration. Hold the Arc so a pointer comparison
 		// can't alias a recycled allocation.
-		let waiter = park.take(&cx);
+		let waiter = park.hold(&cx);
 		waiter.register(&mut list);
 		let first = waiter.shared().clone();
-		assert!(park.hold(waiter, Poll::<u8>::Pending).is_pending());
 
 		// Poll 2 with that registration still live must retire the waiter: reusing it
 		// would stack a duplicate entry the list could never reclaim.
-		let waiter = park.take(&cx);
+		let waiter = park.hold(&cx);
 		assert!(!Arc::ptr_eq(&first, waiter.shared()), "a registered waiter was reused");
 		waiter.register(&mut list);
 		let second = waiter.shared().clone();
-		assert!(park.hold(waiter, Poll::<u8>::Pending).is_pending());
 
 		// The wake drains the list, so poll 3 reuses: same task, nothing left to
 		// duplicate, and no allocation.
 		list.wake();
-		let waiter = park.take(&cx);
+		let waiter = park.hold(&cx);
 		assert!(Arc::ptr_eq(&second, waiter.shared()), "a drained waiter was not reused");
 	}
 
@@ -391,13 +385,11 @@ mod tests {
 		let waker_b = Waker::from(Arc::new(Nop));
 		let mut park = Park::default();
 
-		let waiter = park.take(&Context::from_waker(&waker_a));
-		let first = waiter.shared().clone();
-		assert!(park.hold(waiter, Poll::<u8>::Pending).is_pending());
+		let first = park.hold(&Context::from_waker(&waker_a)).shared().clone();
 
 		// A different task must not inherit the parked waiter, or its wakeup goes to
 		// whoever polled last.
-		let waiter = park.take(&Context::from_waker(&waker_b));
+		let waiter = park.hold(&Context::from_waker(&waker_b));
 		assert!(
 			!Arc::ptr_eq(&first, waiter.shared()),
 			"a waiter for another task was reused"
@@ -415,13 +407,14 @@ mod tests {
 		let mut park = Park::new(waiter);
 		assert_eq!(list.entries[0].strong_count(), 1, "a constructed park must hold");
 
-		// A wakeup drains the entry, so the usual cycle picks that waiter back up and
-		// still owns the release.
+		// A wakeup drains the entry, so the next poll picks that same waiter back up
+		// rather than allocating another.
+		let shared = park.0.as_ref().unwrap().shared().clone();
 		list.wake();
-		let waiter = park.take(&cx);
-		waiter.register(&mut list);
-		assert_eq!(park.hold(waiter, Poll::Ready(())), Poll::Ready(()));
-		assert_eq!(list.entries[0].strong_count(), 0);
+		assert!(
+			Arc::ptr_eq(&shared, park.hold(&cx).shared()),
+			"the constructed waiter was not reused"
+		);
 	}
 
 	#[test]
@@ -429,8 +422,7 @@ mod tests {
 		let waker = Waker::noop().clone();
 		let cx = Context::from_waker(&waker);
 		let mut park = Park::default();
-		let waiter = park.take(&cx);
-		assert!(park.hold(waiter, Poll::<u8>::Pending).is_pending());
+		park.hold(&cx);
 		assert!(park.0.is_some());
 
 		// An in-progress registration belongs to the original handle.

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -47,6 +47,15 @@ impl Waiter {
 		Self::new(Waker::noop().clone())
 	}
 
+	/// Create a waiter for the task behind a [`Context`]: the bridge from a
+	/// `Future::poll` into kio's waiter-based poll functions.
+	///
+	/// The result lives only as long as the poll that made it, so park it in a
+	/// [`Park`] to keep its registrations alive until the next one.
+	pub fn from_context(cx: &Context<'_>) -> Self {
+		Self::new(cx.waker().clone())
+	}
+
 	/// Register this waiter with a [`WaiterList`] for future notification.
 	pub fn register(&self, list: &mut WaiterList) {
 		list.register(self);
@@ -159,69 +168,97 @@ impl fmt::Debug for WaiterList {
 	}
 }
 
-/// Retains a [`Waiter`] across `poll` calls, bridging a [`Context`] to kio's
-/// waiter-based polls.
+/// Holds a parked [`Waiter`] between polls, so the registrations it made outlive the
+/// poll that made them.
 ///
-/// kio's `poll_*` methods take a `&Waiter` whose registrations a [`WaiterList`]
-/// holds only weakly, so whoever drives them from a [`Context`]-based poll (a
-/// `Future`, or a `poll_*` trait method) must keep the strong `Waiter` alive
-/// between polls or the registration dies the moment the poll returns. Embed one
-/// cell per logical operation and call [`hold`](Self::hold) at the top of
-/// each poll.
+/// A [`WaiterList`] keeps only a `Weak`, so a waiter built inside a poll dies the
+/// moment that poll returns, taking its registrations with it. Whoever drives kio's
+/// `poll_*` methods from a [`Context`]-based poll (a `Future`, or a `poll_*` trait
+/// method) embeds one `Park` per logical operation and brackets the poll with it:
 ///
-/// The returned borrow is tied to the cell, so when the rest of the poll needs
-/// `&mut self` of the type holding it, `clone()` the waiter to end the borrow;
-/// the clone shares the retained waiter's identity, so nothing is lost.
+/// ```
+/// # use std::task::{Context, Poll};
+/// # use kio::{Park, Waiter};
+/// # struct Driver { park: Park }
+/// # impl Driver {
+/// #     fn poll_step(&mut self, _: &Waiter) -> Poll<()> { Poll::Pending }
+/// fn poll(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+///     let waiter = self.park.take(cx);
+///     let poll = self.poll_step(&waiter);
+///     self.park.hold(waiter, poll)
+/// }
+/// # }
+/// ```
 ///
-/// `Clone` yields an *empty* cell: an in-progress registration belongs to the
-/// handle that parked it, so a cloned handle starts idle. This is what lets a
-/// containing type stay `Clone` while holding cells.
+/// Only a parked waiter is worth keeping, so a `Ready` releases instead of holding.
+/// The waiter is owned outright rather than borrowed from the park, leaving the rest
+/// of the poll free to take `&mut self`.
+///
+/// `Clone` yields an *empty* park: an in-progress registration belongs to the handle
+/// that parked it, so a cloned handle starts idle. This is what lets a containing
+/// type stay `Clone`.
 #[derive(Default)]
-pub struct WaiterCell(Option<Waiter>);
+pub struct Park(Option<Waiter>);
 
-impl WaiterCell {
-	/// Create an empty cell.
-	pub const fn new() -> Self {
-		Self(None)
+impl Park {
+	/// Create a park already holding `waiter`, for the rarer case where one exists
+	/// before the first poll (a `poll_*` method stashing the waiter its caller passed
+	/// in, say). Use [`Default`] for an empty park, and prefer
+	/// [`hold`](Self::hold) once polling starts, since it also handles the release.
+	pub fn new(waiter: Waiter) -> Self {
+		Self(Some(waiter))
 	}
 
-	/// Hold a waiter for this poll, keeping it (and its registrations) alive until
-	/// the next call.
+	/// Take the waiter for this poll, leaving the park empty.
 	///
-	/// The held waiter is reused when it would wake the same task *and* has no
-	/// live list registrations (the common case after a wakeup, where every list
-	/// entry was drained), saving the `Arc` allocation and waker clone. Otherwise it
-	/// is replaced: a still-registered waiter must be retired, not re-registered,
-	/// because [`WaiterList`] reclaims slots only when their `Arc` dies. Reusing one
-	/// with live entries would stack duplicate live registrations on every
-	/// (spuriously re-polled) `Pending`, and the list would grow without bound.
-	pub fn hold(&mut self, cx: &mut Context<'_>) -> &Waiter {
-		let reuse = self.0.as_ref().is_some_and(|waiter| {
-			cx.waker().will_wake(&waiter.waker) && waiter.shared.get().is_none_or(|shared| Arc::weak_count(shared) == 0)
-		});
-		if !reuse {
-			self.0 = Some(Waiter::new(cx.waker().clone()));
+	/// The parked waiter is reused when it wakes the same task *and* has no live
+	/// registrations left (the usual case after a wakeup, which drains every list
+	/// entry), so a steady-state park allocates nothing. Otherwise it is retired for a
+	/// fresh one: a still-registered waiter must not be registered again, because
+	/// [`WaiterList`] reclaims a slot only once its `Arc` dies, so reusing one with
+	/// live entries would stack duplicates the list could never collect.
+	pub fn take(&mut self, cx: &Context<'_>) -> Waiter {
+		match self.0.take() {
+			Some(waiter)
+				if cx.waker().will_wake(&waiter.waker)
+					&& waiter.shared.get().is_none_or(|shared| Arc::weak_count(shared) == 0) =>
+			{
+				waiter
+			}
+			// Any other waiter is dropped here, killing its registrations so the
+			// lists can reclaim those slots.
+			_ => Waiter::from_context(cx),
 		}
-		self.0.as_ref().unwrap()
+	}
+
+	/// Hold `waiter` until the next poll if this one parked, releasing whatever was
+	/// held before.
+	///
+	/// A `Ready` poll releases instead: the operation is over, so its waiter should
+	/// die and let the lists reclaim its slots. Returns `poll` unchanged so it can
+	/// tail a `Future::poll`.
+	pub fn hold<T>(&mut self, waiter: Waiter, poll: Poll<T>) -> Poll<T> {
+		self.0 = poll.is_pending().then_some(waiter);
+		poll
 	}
 }
 
-impl Clone for WaiterCell {
+impl Clone for Park {
 	fn clone(&self) -> Self {
 		Self(None)
 	}
 }
 
-impl fmt::Debug for WaiterCell {
+impl fmt::Debug for Park {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		f.debug_struct("WaiterCell").field("armed", &self.0.is_some()).finish()
+		f.debug_struct("Park").field("parked", &self.0.is_some()).finish()
 	}
 }
 
 /// Future that drives a poll function, managing waiter lifetime across polls.
 struct WaiterFn<F, R> {
 	poll: F,
-	cell: WaiterCell, // Retain the waiter so its registrations survive.
+	park: Park, // Retain a parked waiter so its registrations survive.
 	// `fn() -> R` keeps the marker `Unpin` (and `Send`/`Sync`) regardless of `R`:
 	// the output is only ever moved out of `Poll::Ready`, never stored.
 	_marker: PhantomData<fn() -> R>,
@@ -237,7 +274,7 @@ where
 {
 	WaiterFn {
 		poll,
-		cell: WaiterCell::new(),
+		park: Park::default(),
 		_marker: PhantomData,
 	}
 }
@@ -250,8 +287,9 @@ where
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<R> {
 		let this = &mut *self;
-		let waiter = this.cell.hold(cx);
-		(this.poll)(waiter)
+		let waiter = this.park.take(cx);
+		let poll = (this.poll)(&waiter);
+		this.park.hold(waiter, poll)
 	}
 }
 
@@ -288,33 +326,62 @@ mod tests {
 	};
 
 	#[test]
-	fn waiter_cell_replaces_while_registered_and_reuses_after_wake() {
+	fn park_holds_a_pending_waiter_and_releases_a_ready_one() {
 		let waker = Waker::noop().clone();
-		let mut cx = Context::from_waker(&waker);
-		let mut cell = WaiterCell::new();
+		let cx = Context::from_waker(&waker);
+		let mut park = Park::default();
 		let mut list = WaiterList::new();
 
-		// Poll 1 parks: the waiter registers with a list.
-		cell.hold(&mut cx).register(&mut list);
-		// Hold the Arc so a pointer comparison can't alias a recycled allocation.
-		let first = cell.0.as_ref().unwrap().shared().clone();
+		// A parked poll: the waiter must outlive it, or the list entry it just made
+		// goes dead and the wakeup is lost.
+		let waiter = park.take(&cx);
+		waiter.register(&mut list);
+		assert!(park.hold(waiter, Poll::<u8>::Pending).is_pending());
+		assert_eq!(list.entries[0].strong_count(), 1, "a parked waiter must stay live");
 
-		// Poll 2 with the registration still live must replace the waiter: reusing
-		// it would stack a duplicate live entry the list could never reclaim.
-		let second = cell.hold(&mut cx);
-		assert!(!Arc::ptr_eq(&first, second.shared()), "a registered waiter was reused");
-		second.register(&mut list);
-		let second = second.shared().clone();
-
-		// The wake drains the list, so poll 3 can reuse the waiter: same task, no
-		// live registrations left to duplicate.
+		// Drain the entry as a wakeup would, so the next poll picks the same waiter
+		// back up.
 		list.wake();
-		let third = cell.hold(&mut cx);
-		assert!(Arc::ptr_eq(&second, third.shared()), "a drained waiter was not reused");
+
+		// A resolved poll has nothing left to wake, so its waiter is dropped and the
+		// list can reclaim the slot.
+		let waiter = park.take(&cx);
+		waiter.register(&mut list);
+		assert_eq!(park.hold(waiter, Poll::Ready(7)), Poll::Ready(7));
+		assert_eq!(list.entries[0].strong_count(), 0, "a ready waiter must be released");
 	}
 
 	#[test]
-	fn waiter_cell_replaces_for_a_different_task() {
+	fn park_reuses_a_drained_waiter_and_retires_a_registered_one() {
+		let waker = Waker::noop().clone();
+		let cx = Context::from_waker(&waker);
+		let mut park = Park::default();
+		let mut list = WaiterList::new();
+
+		// Poll 1 parks with a live registration. Hold the Arc so a pointer comparison
+		// can't alias a recycled allocation.
+		let waiter = park.take(&cx);
+		waiter.register(&mut list);
+		let first = waiter.shared().clone();
+		assert!(park.hold(waiter, Poll::<u8>::Pending).is_pending());
+
+		// Poll 2 with that registration still live must retire the waiter: reusing it
+		// would stack a duplicate entry the list could never reclaim.
+		let waiter = park.take(&cx);
+		assert!(!Arc::ptr_eq(&first, waiter.shared()), "a registered waiter was reused");
+		waiter.register(&mut list);
+		let second = waiter.shared().clone();
+		assert!(park.hold(waiter, Poll::<u8>::Pending).is_pending());
+
+		// The wake drains the list, so poll 3 reuses: same task, nothing left to
+		// duplicate, and no allocation.
+		list.wake();
+		let waiter = park.take(&cx);
+		assert!(Arc::ptr_eq(&second, waiter.shared()), "a drained waiter was not reused");
+	}
+
+	#[test]
+	fn park_retires_a_waiter_for_another_task() {
 		struct Nop;
 		impl std::task::Wake for Nop {
 			fn wake(self: Arc<Self>) {}
@@ -322,50 +389,72 @@ mod tests {
 
 		let waker_a = Waker::from(Arc::new(Nop));
 		let waker_b = Waker::from(Arc::new(Nop));
-		let mut cell = WaiterCell::new();
+		let mut park = Park::default();
 
-		let first = cell.hold(&mut Context::from_waker(&waker_a)).shared().clone();
-		let second = cell.hold(&mut Context::from_waker(&waker_b));
+		let waiter = park.take(&Context::from_waker(&waker_a));
+		let first = waiter.shared().clone();
+		assert!(park.hold(waiter, Poll::<u8>::Pending).is_pending());
+
+		// A different task must not inherit the parked waiter, or its wakeup goes to
+		// whoever polled last.
+		let waiter = park.take(&Context::from_waker(&waker_b));
 		assert!(
-			!Arc::ptr_eq(&first, second.shared()),
+			!Arc::ptr_eq(&first, waiter.shared()),
 			"a waiter for another task was reused"
 		);
 	}
 
 	#[test]
-	fn waiter_cell_clone_is_idle() {
+	fn park_new_starts_holding() {
 		let waker = Waker::noop().clone();
-		let mut cell = WaiterCell::new();
-		cell.hold(&mut Context::from_waker(&waker));
-		assert!(cell.0.is_some());
+		let cx = Context::from_waker(&waker);
+		let mut list = WaiterList::new();
+
+		let waiter = Waiter::from_context(&cx);
+		waiter.register(&mut list);
+		let mut park = Park::new(waiter);
+		assert_eq!(list.entries[0].strong_count(), 1, "a constructed park must hold");
+
+		// A wakeup drains the entry, so the usual cycle picks that waiter back up and
+		// still owns the release.
+		list.wake();
+		let waiter = park.take(&cx);
+		waiter.register(&mut list);
+		assert_eq!(park.hold(waiter, Poll::Ready(())), Poll::Ready(()));
+		assert_eq!(list.entries[0].strong_count(), 0);
+	}
+
+	#[test]
+	fn park_clone_is_idle() {
+		let waker = Waker::noop().clone();
+		let cx = Context::from_waker(&waker);
+		let mut park = Park::default();
+		let waiter = park.take(&cx);
+		assert!(park.hold(waiter, Poll::<u8>::Pending).is_pending());
+		assert!(park.0.is_some());
 
 		// An in-progress registration belongs to the original handle.
-		let clone = cell.clone();
-		assert!(clone.0.is_none(), "a cloned cell must start idle");
+		assert!(park.clone().0.is_none(), "a cloned park must start idle");
 	}
 
 	#[test]
 	fn waiter_clone_shares_identity() {
 		let waker = Waker::noop().clone();
-		let mut cx = Context::from_waker(&waker);
-		let mut cell = WaiterCell::new();
+		let cx = Context::from_waker(&waker);
 		let mut list = WaiterList::new();
 
-		// The clone shares the retained waiter's allocation, so a registration made
-		// through it belongs to the retained waiter and outlives the clone.
-		let clone = cell.hold(&mut cx).clone();
-		assert!(Arc::ptr_eq(clone.shared(), cell.0.as_ref().unwrap().shared()));
+		let waiter = Waiter::from_context(&cx);
+		let clone = waiter.clone();
+		assert!(Arc::ptr_eq(waiter.shared(), clone.shared()));
+
+		// A registration made through the clone belongs to the shared identity, so
+		// dropping the clone alone must not kill it.
 		clone.register(&mut list);
 		drop(clone);
+		assert_eq!(list.entries[0].strong_count(), 1, "the original must keep it live");
 
-		// The cell still sees that registration as live, so the next poll must
-		// replace the waiter rather than stack a duplicate entry.
-		let first = cell.0.as_ref().unwrap().shared().clone();
-		let second = cell.hold(&mut cx);
-		assert!(
-			!Arc::ptr_eq(&first, second.shared()),
-			"a waiter with a clone's live registration was reused"
-		);
+		drop(waiter);
+		assert_eq!(list.entries[0].strong_count(), 0, "the last handle must release it");
 	}
 
 	#[test]

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -47,15 +47,6 @@ impl Waiter {
 		Self::new(Waker::noop().clone())
 	}
 
-	/// Create a waiter for the task behind a [`Context`]: the bridge from a
-	/// `Future::poll` into kio's waiter-based poll functions.
-	///
-	/// The result lives only as long as the poll that made it, so park it in a
-	/// [`Park`] to keep its registrations alive until the next one.
-	pub fn from_context(cx: &Context<'_>) -> Self {
-		Self::new(cx.waker().clone())
-	}
-
 	/// Register this waiter with a [`WaiterList`] for future notification.
 	pub fn register(&self, list: &mut WaiterList) {
 		list.register(self);
@@ -231,7 +222,7 @@ impl Park {
 		if !reuse {
 			// The outgoing waiter drops here, killing its registrations so the lists
 			// can reclaim those slots.
-			self.0 = Some(Waiter::from_context(cx));
+			self.0 = Some(Waiter::new(cx.waker().clone()));
 		}
 		self.0.as_ref().unwrap()
 	}
@@ -402,7 +393,7 @@ mod tests {
 		let cx = Context::from_waker(&waker);
 		let mut list = WaiterList::new();
 
-		let waiter = Waiter::from_context(&cx);
+		let waiter = Waiter::new(cx.waker().clone());
 		waiter.register(&mut list);
 		let mut park = Park::new(waiter);
 		assert_eq!(list.entries[0].strong_count(), 1, "a constructed park must hold");
@@ -435,7 +426,7 @@ mod tests {
 		let cx = Context::from_waker(&waker);
 		let mut list = WaiterList::new();
 
-		let waiter = Waiter::from_context(&cx);
+		let waiter = Waiter::new(cx.waker().clone());
 		let clone = waiter.clone();
 		assert!(Arc::ptr_eq(waiter.shared(), clone.shared()));
 

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -134,8 +134,8 @@ pub struct Driver {
 	// Cached so a poll after completion (e.g. after `wait_ready` consumed the
 	// result) doesn't re-poll a finished future.
 	result: Option<Result<(), Error>>,
-	// Retains the waiter across `Future` polls so its kio registrations stay live.
-	cell: kio::WaiterCell,
+	// Retains a parked waiter across `Future` polls so its kio registrations stay live.
+	park: kio::Park,
 }
 
 impl Driver {
@@ -185,10 +185,9 @@ impl Future for Driver {
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
 		let this = &mut *self;
-		// The clone shares the retained waiter's identity while ending the cell
-		// borrow, which the `&mut self` poll below would otherwise conflict with.
-		let waiter = this.cell.hold(cx).clone();
-		this.poll(&waiter)
+		let waiter = this.park.take(cx);
+		let poll = this.poll(&waiter);
+		this.park.hold(waiter, poll)
 	}
 }
 
@@ -247,7 +246,7 @@ impl Session {
 			protocol,
 			maintenance,
 			result: None,
-			cell: kio::WaiterCell::new(),
+			park: kio::Park::default(),
 		};
 
 		(session, driver)

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -125,6 +125,15 @@ impl Session {
 /// On native, driving requires a tokio runtime with a time driver (timers go
 /// through `web_async::time`); see the crate-level Async docs.
 pub struct Driver {
+	state: DriverState,
+	// Retains the waiter across `Future` polls so its kio registrations stay live.
+	// Kept out of `DriverState` so the borrow `hold` hands back doesn't collide with
+	// the `&mut` that polling the state needs.
+	park: kio::Park,
+}
+
+/// Everything the driver polls, split from the park so the two borrow disjointly.
+struct DriverState {
 	protocol: MaybeSendBox<'static, Result<(), Error>>,
 	// Bandwidth sampling, polled alongside the protocol. Its completion never ends
 	// the driver: the protocol owns the teardown. `None` once finished (or when the
@@ -134,8 +143,6 @@ pub struct Driver {
 	// Cached so a poll after completion (e.g. after `wait_ready` consumed the
 	// result) doesn't re-poll a finished future.
 	result: Option<Result<(), Error>>,
-	// Retains a parked waiter across `Future` polls so its kio registrations stay live.
-	park: kio::Park,
 }
 
 impl Driver {
@@ -144,22 +151,7 @@ impl Driver {
 	/// The `poll_*` counterpart of `.await`ing the driver, for callers composing it
 	/// into their own [`kio`]-style poll functions.
 	pub fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
-		if let Some(result) = &self.result {
-			return Poll::Ready(result.clone());
-		}
-
-		if let Some(maintenance) = &mut self.maintenance
-			&& waiter.poll_future(maintenance.as_mut()).is_ready()
-		{
-			self.maintenance = None;
-		}
-
-		let result = std::task::ready!(waiter.poll_future(self.protocol.as_mut()));
-		self.result = Some(result.clone());
-		// The session is over; release the maintenance future now rather than on
-		// Drop, since it holds a transport clone.
-		self.maintenance = None;
-		Poll::Ready(result)
+		self.state.poll(waiter)
 	}
 
 	/// Drive the session until the readiness condition resolves, so `connect` can block on the
@@ -180,14 +172,36 @@ impl Driver {
 	}
 }
 
+impl DriverState {
+	fn poll(&mut self, waiter: &kio::Waiter) -> Poll<Result<(), Error>> {
+		if let Some(result) = &self.result {
+			return Poll::Ready(result.clone());
+		}
+
+		if let Some(maintenance) = &mut self.maintenance
+			&& waiter.poll_future(maintenance.as_mut()).is_ready()
+		{
+			self.maintenance = None;
+		}
+
+		let result = std::task::ready!(waiter.poll_future(self.protocol.as_mut()));
+		self.result = Some(result.clone());
+		// The session is over; release the maintenance future now rather than on
+		// Drop, since it holds a transport clone.
+		self.maintenance = None;
+		Poll::Ready(result)
+	}
+}
+
 impl Future for Driver {
 	type Output = Result<(), Error>;
 
 	fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
 		let this = &mut *self;
-		let waiter = this.park.take(cx);
-		let poll = this.poll(&waiter);
-		this.park.hold(waiter, poll)
+		// Disjoint field borrows: `hold` borrows the park for as long as the waiter
+		// lives, while the state is polled through its own `&mut`.
+		let waiter = this.park.hold(cx);
+		this.state.poll(waiter)
 	}
 }
 
@@ -243,9 +257,11 @@ impl Session {
 			recv_bandwidth,
 		};
 		let driver = Driver {
-			protocol,
-			maintenance,
-			result: None,
+			state: DriverState {
+				protocol,
+				maintenance,
+				result: None,
+			},
 			park: kio::Park::default(),
 		};
 


### PR DESCRIPTION
## Summary

`WaiterCell` was a bad name for a type that only ever holds a *parked* waiter. This renames it to `kio::Park` and fixes the one real wart in its shape.

The old `WaiterCell::hold(cx) -> &Waiter` was safe but awkward at one call site: `moq-net`'s `Driver::poll` had to `clone()` the waiter purely to end the cell borrow, because `Driver::poll(&mut self, ...)` borrows the park along with the state it polls. That turned out to be a struct-layout problem, not an API problem. Splitting the polled state into a private `DriverState` makes the two borrows disjoint, so the `Future` impl needs no clone:

```rust
fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
    let this = &mut *self;
    let waiter = this.park.hold(cx);   // borrows this.park
    this.state.poll(waiter)            // borrows this.state, disjoint
}
```

`Park::hold` keeps the original semantics: retain the waiter **before** the body runs, reusing the existing `Arc<Waker>` when it wakes the same task and has no live registrations. Retaining up front is what makes the repo's standard `ready!` idiom safe. A poll body that returns `Pending` early still leaves its registrations live, and there is no second call to forget.

An intermediate version of this PR split `hold` into `take(cx) -> Waiter` + `hold(waiter, poll)` so a `Ready` poll could release its waiter early. An adversarial review caught that this makes retention conditional on reaching the second call, so an early `ready!` return drops the only strong `Waiter` and the `WaiterList` entry it just made goes dead: a silent lost wakeup, on a public API, via the idiom `rs/CLAUDE.md` tells you to use. That shape is reverted. The park owning the waiter and handing out a borrow makes the failure impossible to express rather than merely tested.

The context bridge also stays inside `Park::hold`. A public `Waiter::from_context` would let callers recreate the same lost-wakeup state by returning `Pending` without retaining the waiter.

### On reusing the allocation

Recorded because it came up: `WaiterList` holds `Weak<Waker>` with no deregister and reclaims a slot only once its `Arc` dies, so **the allocation is the registration token**. An `AtomicWaker`-style allocation living for the whole `Park` cannot also signal "no longer registered"; registering a stable `Arc` into a list that has not drained stacks duplicates the GC can never collect, and avoiding that needs an O(n) dedupe on `register` (bad for fanout) or an intrusive list with unsafe. The `will_wake` + `weak_count == 0` gate in `hold` is the only safe reuse point, and it keeps a steady-state park allocation-free.

Measured with temporary counters over a 200-group / 20-frame produce+consume run: 200 allocations, one per `recv_group` await, with reuse firing on every re-poll within a future. The residual allocations come from a fresh `Park` per `.await` future, not from the gate failing, so `AtomicWaker` semantics would not reduce the count. Hoisting a `Park` onto the consumer types so it survives across `.await` calls is the real follow-up; it touches moq-net's model layer and belongs in its own PR.

## Public API changes

`kio` only. All of it postdates `kio-v0.5.2` and has never been published, so nothing here breaks a released API and it targets `main`.

- Renamed `kio::WaiterCell` -> `kio::Park`; `WaiterCell::hold` -> `Park::hold`, now taking `&Context` instead of `&mut Context`.
- `Park::new()` now takes a `Waiter` (a park that starts holding); `Park::default()` is the empty one.
- Context-derived waiter construction remains internal to `Park::hold`.

`moq-net`'s `Driver` gains a private `DriverState`; its public surface (`Driver::poll`, the `Future` impl) is unchanged.

## Test plan

- `nix develop --command just rs test -p kio -p moq-net`: 665 passed.
- `nix develop --command just rs loom`: 17 models passed, per the manual gate in `rs/CLAUDE.md` for waiter plumbing.
- `just fix`: clean.
- GitHub `Check` and `Windows`: passed on final head `fcda3acb6`.
- New `park_survives_a_poll_that_returns_early` covers the reviewed lost-wakeup case with a real `ready!` early return.
- Mutation-checked the reuse gate both ways: forcing `hold` to always reuse fails `park_reuses_a_drained_waiter_and_retires_a_registered_one` and `park_retires_a_waiter_for_another_task`; forcing it to never reuse fails the reuse assertion. The early-return property is structural rather than mutation-testable, since the API cannot express a caller-owned waiter that drops mid-poll.

No Cross-Package Sync rows apply: `kio` has no JS counterpart, and no wire format, catalog, CLI surface, or FFI signature changed.

(Written by Opus 5 and GPT-5)
