### PR TITLE
fix(moq-video): keep Media Foundation decoded frames on the GPU, and stop losing frames at group boundaries

### DIFF
--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -144,6 +144,13 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 
 			match item {
 				Some(Item::Group(sequence)) => {
+					// Empty the codec before opening the next group even though this one
+					// is being abandoned: a pipelined encoder still holding the previous
+					// group's tail would otherwise emit it into the new group, ahead of
+					// the keyframe requested just below.
+					if let Some(encoder) = &mut encoder {
+						encoder.flush()?;
+					}
 					if let Some(output) = current.take() {
 						// A group boundary without an end: treat as incomplete.
 						output.abort(moq_net::Error::Cancel)?;
@@ -205,6 +212,11 @@ async fn live(rung: &Rung, producer: &mut moq_net::track::Producer) -> Result<()
 				}
 				Some(Item::End) => {
 					if let Some(mut output) = current.take() {
+						// The source group is complete, so this one has to be too: a
+						// hardware encoder is still holding its last frames.
+						if let Some(encoder) = &mut encoder {
+							write(&mut output, encoder.flush()?)?;
+						}
 						output.finish()?;
 					}
 				}

--- a/rs/moq-video/src/capture/mediafoundation.rs
+++ b/rs/moq-video/src/capture/mediafoundation.rs
@@ -3,10 +3,11 @@
 //! Drives an [`IMFSourceReader`] over the selected capture device. When a
 //! Direct3D11 device is available the reader runs with that device's DXGI
 //! manager and the advanced video processor, so each sample arrives as a
-//! GPU-resident NV12 texture ([`Surface::Texture`]) that the hardware encoder MFT
-//! consumes zero-copy. Without a GPU (e.g. a headless VM) it falls back to the
-//! source reader's software video processor, copying each sample to a packed CPU
-//! [`I420`] ([`Surface::I420`]) the encoder uploads.
+//! GPU-resident NV12 texture: one blit out of the reader's pool (see
+//! [`Texture::copy_from_sample`]) and it is a [`Surface::Texture`] the hardware
+//! encoder MFT consumes with no further copy. Without a GPU (e.g. a headless VM)
+//! it falls back to the source reader's software video processor, copying each
+//! sample to a packed CPU [`I420`] ([`Surface::I420`]) the encoder uploads.
 
 use std::ffi::c_void;
 use std::ptr;
@@ -208,9 +209,15 @@ impl Camera {
 		})
 	}
 
-	/// Wrap a GPU sample's DXGI texture as a zero-copy [`Surface::Texture`].
+	/// Take a GPU sample's picture into a [`Surface::Texture`] of our own, on the
+	/// GPU.
+	///
+	/// The reader hands out textures from a pool it recycles as soon as the sample
+	/// is released, and a captured frame outlives that: it waits in the frame
+	/// channel while the pump reads on. Blitting it out is what stops the next
+	/// picture landing on a frame the encoder has not reached yet.
 	fn sample_to_texture(&self, device: &ID3D11Device, sample: &IMFSample) -> Result<Surface, Error> {
-		let texture = Texture::from_sample(device, sample, self.width, self.height)?;
+		let texture = Texture::copy_from_sample(device, sample, self.width, self.height)?;
 		Ok(Surface::Texture(texture))
 	}
 

--- a/rs/moq-video/src/capture/mediafoundation.rs
+++ b/rs/moq-video/src/capture/mediafoundation.rs
@@ -12,10 +12,10 @@ use std::ffi::c_void;
 use std::ptr;
 use std::slice;
 
-use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11Texture2D};
+use windows::Win32::Graphics::Direct3D11::ID3D11Device;
 use windows::Win32::Media::MediaFoundation::{
-	IMF2DBuffer, IMFActivate, IMFAttributes, IMFDXGIBuffer, IMFDXGIDeviceManager, IMFMediaSource, IMFSample,
-	IMFSourceReader, MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME, MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE,
+	IMF2DBuffer, IMFActivate, IMFAttributes, IMFDXGIDeviceManager, IMFMediaSource, IMFSample, IMFSourceReader,
+	MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME, MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE,
 	MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_GUID, MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK,
 	MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE, MF_MT_MAJOR_TYPE, MF_MT_SUBTYPE, MF_SOURCE_READER_D3D_MANAGER,
 	MF_SOURCE_READER_ENABLE_ADVANCED_VIDEO_PROCESSING, MF_SOURCE_READER_ENABLE_VIDEO_PROCESSING,
@@ -210,29 +210,8 @@ impl Camera {
 
 	/// Wrap a GPU sample's DXGI texture as a zero-copy [`Surface::Texture`].
 	fn sample_to_texture(&self, device: &ID3D11Device, sample: &IMFSample) -> Result<Surface, Error> {
-		let buffer = unsafe { sample.GetBufferByIndex(0).map_err(|e| mf_err("get buffer", e))? };
-		let dxgi = buffer
-			.cast::<IMFDXGIBuffer>()
-			.map_err(|e| mf_err("buffer is not a DXGI surface", e))?;
-		// GetResource returns a fresh ref (`AddRef`) we take ownership of.
-		let mut raw: *mut c_void = ptr::null_mut();
-		unsafe {
-			dxgi.GetResource(&ID3D11Texture2D::IID, &mut raw)
-				.map_err(|e| mf_err("get DXGI resource", e))?;
-		}
-		let texture = unsafe { ID3D11Texture2D::from_raw(raw) };
-		let subresource = unsafe {
-			dxgi.GetSubresourceIndex()
-				.map_err(|e| mf_err("get subresource index", e))?
-		};
-
-		Ok(Surface::Texture(Texture::new(
-			device.clone(),
-			texture,
-			subresource,
-			self.width,
-			self.height,
-		)))
+		let texture = Texture::from_sample(device, sample, self.width, self.height)?;
+		Ok(Surface::Texture(texture))
 	}
 
 	/// Copy a CPU sample's NV12 to a packed [`Surface::I420`] (the fallback path).

--- a/rs/moq-video/src/decode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/decode/backend/mediafoundation.rs
@@ -467,10 +467,10 @@ fn enumerate_decoder(subtype: GUID) -> Result<IMFTransform, Error> {
 	let mut transform: Option<IMFTransform> = None;
 	for slot in entries.iter_mut() {
 		let Some(activate) = slot.take() else { continue };
-		if transform.is_none() {
-			if let Ok(mft) = unsafe { activate.ActivateObject::<IMFTransform>() } {
-				transform = Some(mft);
-			}
+		if transform.is_none()
+			&& let Ok(mft) = unsafe { activate.ActivateObject::<IMFTransform>() }
+		{
+			transform = Some(mft);
 		}
 	}
 	unsafe {

--- a/rs/moq-video/src/decode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/decode/backend/mediafoundation.rs
@@ -13,8 +13,12 @@
 //! openh264; H.265 has no software fallback, so it simply has no decoder.
 //!
 //! Each Annex-B access unit goes in as an `IMFSample`; decoded NV12 comes back as
-//! a GPU texture (the DXVA decoder owns the output pool) that we download and
-//! deinterleave to packed I420.
+//! a GPU texture, which we blit into one of our own and hand out as
+//! [`Surface::Texture`] so the picture stays on the GPU for a renderer or a
+//! re-encode. It is downloaded to I420 only when a consumer asks. The blit is
+//! what makes the frame ours rather than a slot in the decoder's pool; see
+//! [`Texture::copy_from_sample`] for why a decoded picture can't just be handed
+//! out.
 //!
 //! The MFT learns the picture size from the bitstream, so unlike the encoder we
 //! don't know the dimensions up front: only after feeding the first access unit
@@ -30,15 +34,15 @@ use std::ptr;
 
 use bytes::Bytes;
 use moq_net::Timestamp;
-use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11Texture2D};
+use windows::Win32::Graphics::Direct3D11::ID3D11Device;
 use windows::Win32::Media::MediaFoundation::{
 	IMF2DBuffer, IMFDXGIBuffer, IMFDXGIDeviceManager, IMFMediaType, IMFSample, IMFTransform, MF_E_NO_MORE_TYPES,
 	MF_E_NOTACCEPTING, MF_E_TRANSFORM_NEED_MORE_INPUT, MF_E_TRANSFORM_STREAM_CHANGE, MF_LOW_LATENCY, MF_MT_FRAME_SIZE,
-	MF_MT_MAJOR_TYPE, MF_MT_SUBTYPE, MFCreateMediaType, MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video,
-	MFT_CATEGORY_VIDEO_DECODER, MFT_ENUM_FLAG_SORTANDFILTER, MFT_ENUM_FLAG_SYNCMFT, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING,
-	MFT_MESSAGE_NOTIFY_START_OF_STREAM, MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER,
-	MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO, MFTEnumEx, MFVideoFormat_H264, MFVideoFormat_HEVC,
-	MFVideoFormat_NV12,
+	MF_MT_MAJOR_TYPE, MF_MT_MINIMUM_DISPLAY_APERTURE, MF_MT_SUBTYPE, MFCreateMediaType, MFCreateMemoryBuffer,
+	MFCreateSample, MFMediaType_Video, MFOffset, MFT_CATEGORY_VIDEO_DECODER, MFT_ENUM_FLAG_SORTANDFILTER,
+	MFT_ENUM_FLAG_SYNCMFT, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, MFT_MESSAGE_NOTIFY_START_OF_STREAM,
+	MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO,
+	MFTEnumEx, MFVideoArea, MFVideoFormat_H264, MFVideoFormat_HEVC, MFVideoFormat_NV12,
 };
 use windows::core::{GUID, Interface};
 
@@ -198,13 +202,22 @@ impl MediaFoundation {
 		}
 	}
 
+	/// The size the pictures we hand out are: the display aperture where the stream
+	/// declares one, and the coded size otherwise.
+	///
+	/// `MF_MT_FRAME_SIZE` is the coded size, which is whole macroblocks: a 1080p
+	/// stream codes as 1088 rows and a 180-row one as 192. Those extra rows are
+	/// padding the encoder invented, not picture, and the stream says so in its
+	/// display aperture.
 	fn read_frame_size(&mut self, media: &IMFMediaType) -> Result<(), Error> {
 		let packed = unsafe {
 			media
 				.GetUINT64(&MF_MT_FRAME_SIZE)
 				.map_err(|e| mf_err("frame size", e))?
 		};
-		let (width, height) = unpack_2x32(packed);
+		let (coded_width, coded_height) = unpack_2x32(packed);
+		let (width, height) = display_aperture(media).unwrap_or((coded_width, coded_height));
+
 		// I420 chroma is 2x2 subsampled, so the download needs even dimensions.
 		if width == 0 || height == 0 || width % 2 != 0 || height % 2 != 0 {
 			return Err(Error::Codec(anyhow::anyhow!(
@@ -267,7 +280,7 @@ impl MediaFoundation {
 	/// Pull every frame the MFT has ready, stopping when it asks for more input.
 	/// No-op until the output type is configured (the decoder rejects
 	/// `ProcessOutput` before then).
-	fn drain_output(&mut self, out: &mut Vec<I420>) -> Result<(), Error> {
+	fn drain_output(&mut self, out: &mut Vec<Surface>) -> Result<(), Error> {
 		if !self.output_configured {
 			return Ok(());
 		}
@@ -278,7 +291,7 @@ impl MediaFoundation {
 	/// One `ProcessOutput`. Returns `true` if it produced a frame or handled a
 	/// stream change (so the caller keeps draining), `false` on
 	/// `MF_E_TRANSFORM_NEED_MORE_INPUT` (the decoder wants the next access unit).
-	fn process_output(&mut self, out: &mut Vec<I420>) -> Result<bool, Error> {
+	fn process_output(&mut self, out: &mut Vec<Surface>) -> Result<bool, Error> {
 		// In DXVA mode the MFT provides its own texture-backed sample, so we pass a
 		// null slot; otherwise we hand it a system-memory buffer to fill.
 		let provided = if self.provides_samples {
@@ -305,7 +318,7 @@ impl MediaFoundation {
 		match result {
 			Ok(()) => {
 				if let Some(sample) = sample {
-					out.push(self.sample_to_i420(&sample)?);
+					out.push(self.sample_to_surface(&sample)?);
 				}
 				Ok(true)
 			}
@@ -318,25 +331,16 @@ impl MediaFoundation {
 		}
 	}
 
-	/// Download a decoded NV12 output sample to packed I420. The DXVA path hands
-	/// back a GPU texture (reusing the capture staging-copy); a system-memory
-	/// fallback deinterleaves the contiguous NV12 directly.
-	fn sample_to_i420(&self, sample: &IMFSample) -> Result<I420, Error> {
+	/// Wrap a decoded output sample as a [`Surface`]. The DXVA path keeps the
+	/// picture on the GPU, blitting it out of the decoder's pool into a texture of
+	/// ours; a system-memory fallback deinterleaves the contiguous NV12 to packed
+	/// I420.
+	fn sample_to_surface(&self, sample: &IMFSample) -> Result<Surface, Error> {
 		let buffer = unsafe { sample.GetBufferByIndex(0).map_err(|e| mf_err("get output buffer", e))? };
 
-		if let Ok(dxgi) = buffer.cast::<IMFDXGIBuffer>() {
-			// GetResource returns a fresh ref (`AddRef`) we take ownership of.
-			let mut raw: *mut c_void = ptr::null_mut();
-			unsafe {
-				dxgi.GetResource(&ID3D11Texture2D::IID, &mut raw)
-					.map_err(|e| mf_err("get DXGI resource", e))?;
-			}
-			let texture = unsafe { ID3D11Texture2D::from_raw(raw) };
-			let subresource = unsafe {
-				dxgi.GetSubresourceIndex()
-					.map_err(|e| mf_err("get subresource index", e))?
-			};
-			return Texture::new(self.device.clone(), texture, subresource, self.width, self.height).download_i420();
+		if buffer.cast::<IMFDXGIBuffer>().is_ok() {
+			let texture = Texture::copy_from_sample(&self.device, sample, self.width, self.height)?;
+			return Ok(Surface::Texture(texture));
 		}
 
 		// System-memory NV12: prefer the 2D copy (strips per-row stride padding).
@@ -354,7 +358,7 @@ impl MediaFoundation {
 				.ContiguousCopyTo(&mut nv12)
 				.map_err(|e| mf_err("contiguous copy", e))?;
 		}
-		I420::from_nv12(&nv12, self.width, self.height)
+		Ok(Surface::I420(I420::from_nv12(&nv12, self.width, self.height)?))
 	}
 }
 
@@ -369,7 +373,16 @@ impl Backend for MediaFoundation {
 			match unsafe { self.transform.ProcessInput(0, &sample, 0) } {
 				Ok(()) => break,
 				Err(e) if e.code() == MF_E_NOTACCEPTING => {
+					// A drain that produces nothing means the MFT will not take this
+					// access unit and has nothing to hand back either, so retrying can
+					// only spin. Report it instead of hanging the decode task.
+					let before = out.len();
 					self.drain_output(&mut out)?;
+					if out.len() == before {
+						return Err(Error::Codec(anyhow::anyhow!(
+							"decoder rejected the access unit with no output to drain"
+						)));
+					}
 				}
 				Err(e) => return Err(mf_err("ProcessInput", e)),
 			}
@@ -386,15 +399,38 @@ impl Backend for MediaFoundation {
 		self.drain_output(&mut out)?;
 		// The synchronous MFT drains within the call, so every output frame
 		// belongs to the access unit just submitted.
-		Ok(out
-			.into_iter()
-			.map(|i420| Frame::new(Surface::I420(i420), timestamp))
-			.collect())
+		Ok(out.into_iter().map(|surface| Frame::new(surface, timestamp)).collect())
 	}
 
 	fn name(&self) -> &str {
 		NAME
 	}
+}
+
+/// The picture region of a decoder output type, from its minimum display
+/// aperture: the part of the coded frame that is actually the image.
+///
+/// `None` when the stream declares none, and when it puts the picture at an
+/// offset rather than the top left. Nothing produces the latter in practice (the
+/// cropping that turns 1088 coded rows into 1080 trims the bottom), and taking
+/// the whole coded frame keeps the picture inside it rather than sliding it.
+fn display_aperture(media: &IMFMediaType) -> Option<(u32, u32)> {
+	let mut area = MFVideoArea::default();
+	// SAFETY: the attribute is a blob of exactly this struct, and the slice
+	// covers the value we are filling in.
+	let bytes =
+		unsafe { std::slice::from_raw_parts_mut(std::ptr::from_mut(&mut area).cast::<u8>(), size_of::<MFVideoArea>()) };
+	unsafe { media.GetBlob(&MF_MT_MINIMUM_DISPLAY_APERTURE, bytes, None) }.ok()?;
+
+	// A 16.16 fixed-point offset; anything but zero means the picture starts
+	// somewhere we do not crop to.
+	let origin = |offset: MFOffset| offset.value == 0 && offset.fract == 0;
+	if !origin(area.OffsetX) || !origin(area.OffsetY) {
+		return None;
+	}
+	let width = u32::try_from(area.Area.cx).ok()?;
+	let height = u32::try_from(area.Area.cy).ok()?;
+	(width > 0 && height > 0).then_some((width, height))
 }
 
 /// Pick the first synchronous decoder MFT (`subtype` in, NV12 out). The Microsoft

--- a/rs/moq-video/src/decode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/decode/backend/mediafoundation.rs
@@ -216,7 +216,15 @@ impl MediaFoundation {
 				.map_err(|e| mf_err("frame size", e))?
 		};
 		let (coded_width, coded_height) = unpack_2x32(packed);
-		let (width, height) = display_aperture(media).unwrap_or((coded_width, coded_height));
+		// Clamped to what the decoder actually allocated, because the aperture comes
+		// from the stream and the stream comes off the network. A larger one would
+		// put the GPU copy's source region outside the decoder's texture, and
+		// `CopySubresourceRegion` returns no status: the frame would report the
+		// oversized dimensions over a texture nothing ever wrote.
+		let (width, height) = match display_aperture(media) {
+			Some((width, height)) => (width.min(coded_width), height.min(coded_height)),
+			None => (coded_width, coded_height),
+		};
 
 		// I420 chroma is 2x2 subsampled, so the download needs even dimensions.
 		if width == 0 || height == 0 || width % 2 != 0 || height % 2 != 0 {

--- a/rs/moq-video/src/decode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/decode/backend/mediafoundation.rs
@@ -288,12 +288,19 @@ impl MediaFoundation {
 	/// Pull every frame the MFT has ready, stopping when it asks for more input.
 	/// No-op until the output type is configured (the decoder rejects
 	/// `ProcessOutput` before then).
-	fn drain_output(&mut self, out: &mut Vec<Surface>) -> Result<(), Error> {
+	///
+	/// Reports whether the decoder got anywhere, which is not the same as whether
+	/// it handed back a picture: renegotiating the output type is progress too, and
+	/// it produces no frame.
+	fn drain_output(&mut self, out: &mut Vec<Surface>) -> Result<bool, Error> {
 		if !self.output_configured {
-			return Ok(());
+			return Ok(false);
 		}
-		while self.process_output(out)? {}
-		Ok(())
+		let mut progressed = false;
+		while self.process_output(out)? {
+			progressed = true;
+		}
+		Ok(progressed)
 	}
 
 	/// One `ProcessOutput`. Returns `true` if it produced a frame or handled a
@@ -381,12 +388,15 @@ impl Backend for MediaFoundation {
 			match unsafe { self.transform.ProcessInput(0, &sample, 0) } {
 				Ok(()) => break,
 				Err(e) if e.code() == MF_E_NOTACCEPTING => {
-					// A drain that produces nothing means the MFT will not take this
-					// access unit and has nothing to hand back either, so retrying can
-					// only spin. Report it instead of hanging the decode task.
-					let before = out.len();
-					self.drain_output(&mut out)?;
-					if out.len() == before {
+					// A drain that gets nowhere means the MFT will not take this access
+					// unit and has nothing to hand back either, so retrying can only
+					// spin. Report it instead of hanging the decode task.
+					//
+					// Progress, not frames: a stream that changes resolution mid-track
+					// renegotiates the output type here and produces no picture doing
+					// it, and that is exactly the case where feeding the same access
+					// unit again is the right move.
+					if !self.drain_output(&mut out)? {
 						return Err(Error::Codec(anyhow::anyhow!(
 							"decoder rejected the access unit with no output to drain"
 						)));

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -450,7 +450,7 @@ mod tests {
 	/// Foundation hardware decoder, holding every picture rather than consuming it
 	/// as it arrives. `None` when this machine has no hardware decoder.
 	#[cfg(target_os = "windows")]
-	fn decode_levels(count: u64, size: crate::Size) -> Option<Vec<Frame>> {
+	fn decode_levels(count: u64, size: crate::Size) -> Option<(Vec<Frame>, Box<dyn backend::Backend>)> {
 		let mut encoder = h264_software_encoder(size);
 		let decoder = backend::open(
 			Codec::H264,
@@ -473,7 +473,11 @@ mod tests {
 		}
 
 		assert!(!decoded.is_empty(), "decoder produced no frames");
-		Some(decoded)
+		// The decoder goes back to the caller rather than being dropped here: its
+		// `ComGuard` tears Media Foundation down for the whole thread, and a test
+		// that keeps working with the frames afterwards would be doing so in a
+		// process no application resembles.
+		Some((decoded, decoder))
 	}
 
 	/// Every plane of a decoded flat frame: its average luma, and its average U and
@@ -494,7 +498,7 @@ mod tests {
 	#[cfg(target_os = "windows")]
 	#[test]
 	fn mediafoundation_decode_stays_gpu_resident() {
-		let Some(decoded) = decode_levels(3, gray_size()) else {
+		let Some((decoded, _decoder)) = decode_levels(3, gray_size()) else {
 			return;
 		};
 		for out in &decoded {
@@ -519,7 +523,7 @@ mod tests {
 		// More frames than the decoder's pool has slices (8 on the hardware this
 		// was written against, one per picture), so it has to recycle the slices
 		// the earliest frames came out of.
-		let Some(decoded) = decode_levels(12, gray_size()) else {
+		let Some((decoded, _decoder)) = decode_levels(12, gray_size()) else {
 			return;
 		};
 
@@ -545,7 +549,9 @@ mod tests {
 	#[test]
 	fn mediafoundation_decode_crops_coded_padding() {
 		let size = crate::Size::new(320, 180);
-		let Some(decoded) = decode_levels(3, size) else { return };
+		let Some((decoded, _decoder)) = decode_levels(3, size) else {
+			return;
+		};
 
 		for (i, out) in decoded.iter().enumerate() {
 			assert_eq!(out.size(), size, "frame {i} came back at the coded size");
@@ -574,7 +580,9 @@ mod tests {
 	#[test]
 	fn mediafoundation_decoded_texture_reencodes_in_place() {
 		let size = gray_size();
-		let Some(decoded) = decode_levels(3, size) else { return };
+		let Some((decoded, _decoder)) = decode_levels(3, size) else {
+			return;
+		};
 		for out in &decoded {
 			assert!(
 				matches!(out.surface, Surface::Texture(_)),

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -624,7 +624,10 @@ mod tests {
 			);
 		}
 
-		assert!(!out.is_empty(), "re-encoded stream decoded to no frames");
+		// Every frame, not merely some: a hardware encoder holding its tail back is
+		// what this file's flush exists to stop, and a per-frame check alone cannot
+		// see a stream that came back one short.
+		assert_eq!(out.len(), decoded.len(), "the re-encoded stream lost frames");
 		for (i, frame) in out.iter().enumerate() {
 			assert_eq!(frame.size(), size, "re-encoded frame {i} changed size");
 			let (luma, _, _) = plane_averages(frame);

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -187,11 +187,17 @@ mod tests {
 	use crate::frame::I420;
 	use crate::{Frame, Surface};
 
+	/// The `index`th frame of a flat `size` stream at 30fps, every pixel at RGB
+	/// `level`.
+	fn flat_frame(index: u64, level: u8, size: crate::Size) -> Frame {
+		let rgba = vec![level; size.pixels() as usize * 4];
+		let surface = Surface::rgba(&rgba, size).unwrap();
+		Frame::new(surface, Timestamp::from_micros(index * 33_333).unwrap())
+	}
+
 	/// The `index`th frame of a mid-gray 320x240 stream, at 30fps.
 	fn gray_frame(index: u64) -> Frame {
-		let rgba = vec![0x80u8; 320 * 240 * 4];
-		let surface = Surface::rgba(&rgba, crate::Size::new(320, 240)).unwrap();
-		Frame::new(surface, Timestamp::from_micros(index * 33_333).unwrap())
+		flat_frame(index, 0x80, gray_size())
 	}
 
 	/// Assert a decoded picture is the expected size and looks like the gray frame
@@ -259,19 +265,24 @@ mod tests {
 		}
 	}
 
-	/// An openh264 (software H.264) encoder for the gray test stream.
-	fn h264_software_encoder() -> Encoder {
+	/// An openh264 (software H.264) encoder for a `size` test stream at 30fps.
+	fn h264_software_encoder(size: crate::Size) -> Encoder {
 		Encoder::new(&EncodeConfig {
 			kind: EncodeKind::Software,
-			..EncodeConfig::new(320, 240, 30)
+			..EncodeConfig::new(size.width, size.height, 30)
 		})
 		.expect("openh264 encoder")
+	}
+
+	/// The size the gray test stream is encoded at.
+	fn gray_size() -> crate::Size {
+		crate::Size::new(320, 240)
 	}
 
 	#[test]
 	fn openh264_round_trip() {
 		let decoder = backend::open(Codec::H264, &decode_config(super::Kind::Software)).expect("openh264 decoder");
-		round_trip(h264_software_encoder(), decoder, "openh264");
+		round_trip(h264_software_encoder(gray_size()), decoder, "openh264");
 	}
 
 	#[test]
@@ -303,14 +314,14 @@ mod tests {
 	fn videotoolbox_round_trip() {
 		let decoder = backend::open(Codec::H264, &decode_config(super::Kind::Named("videotoolbox".into())))
 			.expect("videotoolbox decoder");
-		round_trip(h264_software_encoder(), decoder, "videotoolbox");
+		round_trip(h264_software_encoder(gray_size()), decoder, "videotoolbox");
 	}
 
 	/// Encode `count` gray frames and decode them, returning the decoded pictures.
 	/// The shared setup for the residency and re-encode tests below.
 	#[cfg(target_os = "macos")]
 	fn decode_gray(count: u64) -> Vec<Frame> {
-		let mut encoder = h264_software_encoder();
+		let mut encoder = h264_software_encoder(gray_size());
 		let mut decoder = backend::open(Codec::H264, &decode_config(super::Kind::Named("videotoolbox".into())))
 			.expect("videotoolbox decoder");
 
@@ -417,7 +428,204 @@ mod tests {
 			eprintln!("skipping: no Media Foundation H.264 hardware decoder available");
 			return;
 		};
-		round_trip(h264_software_encoder(), decoder, "mediafoundation");
+		round_trip(h264_software_encoder(gray_size()), decoder, "mediafoundation");
+	}
+
+	/// A distinct RGB level per frame index, so a caller holding several decoded
+	/// pictures at once can tell them apart. Spaced far enough apart that lossy
+	/// coding can't blur two of them together, which caps how long a stream this
+	/// builds.
+	#[cfg(target_os = "windows")]
+	fn level(index: u64) -> u8 {
+		u8::try_from(0x20 + index * 0x10).expect("test stream is short enough to keep its levels distinct")
+	}
+
+	/// The limited-range BT.601 luma a flat [`level`] frame decodes to.
+	#[cfg(target_os = "windows")]
+	fn expected_luma(level: u8) -> u32 {
+		16 + (219 * level as u32) / 255
+	}
+
+	/// Decode `count` frames of a `size` [`level`] stream through the Media
+	/// Foundation hardware decoder, holding every picture rather than consuming it
+	/// as it arrives. `None` when this machine has no hardware decoder.
+	#[cfg(target_os = "windows")]
+	fn decode_levels(count: u64, size: crate::Size) -> Option<Vec<Frame>> {
+		let mut encoder = h264_software_encoder(size);
+		let decoder = backend::open(
+			Codec::H264,
+			&decode_config(super::Kind::Named("mediafoundation".into())),
+		);
+		let Ok(mut decoder) = decoder else {
+			eprintln!("skipping: no Media Foundation H.264 hardware decoder available");
+			return None;
+		};
+
+		let mut decoded = Vec::new();
+		for i in 0..count {
+			let keyframe = i == 0;
+			if keyframe {
+				encoder.keyframe();
+			}
+			for encoded in encoder.encode(&flat_frame(i, level(i), size)).unwrap() {
+				decoded.extend(decoder.decode(encoded.payload, encoded.timestamp, keyframe).unwrap());
+			}
+		}
+
+		assert!(!decoded.is_empty(), "decoder produced no frames");
+		Some(decoded)
+	}
+
+	/// Every plane of a decoded flat frame: its average luma, and its average U and
+	/// V, which stay neutral because the source is gray. Chroma is the half that
+	/// catches a bad plane split, since the UV plane sits after the *texture's* luma
+	/// rows rather than the frame's.
+	#[cfg(target_os = "windows")]
+	fn plane_averages(frame: &Frame) -> (u32, u32, u32) {
+		let i420 = frame.surface.to_i420().unwrap();
+		let average = |plane: &[u8]| plane.iter().map(|&b| b as u32).sum::<u32>() / plane.len() as u32;
+		(average(i420.y()), average(i420.u()), average(i420.v()))
+	}
+
+	/// A decoded frame comes back as a GPU texture rather than downloaded pixels,
+	/// which is what leaves a render or re-encode path free of a CPU round trip.
+	/// `round_trip` above only checks the pixels, so it passes either way: this is
+	/// the test that pins the frame's residency.
+	#[cfg(target_os = "windows")]
+	#[test]
+	fn mediafoundation_decode_stays_gpu_resident() {
+		let Some(decoded) = decode_levels(3, gray_size()) else {
+			return;
+		};
+		for out in &decoded {
+			assert!(
+				matches!(out.surface, Surface::Texture(_)),
+				"Media Foundation decode downloaded to the CPU instead of keeping its picture on the GPU"
+			);
+		}
+	}
+
+	/// Held frames keep their own pixels. The decoder decodes into a short array of
+	/// picture buffers and recycles a slice as soon as its sample is released, so
+	/// handing that slice out as the frame would let later pictures overwrite
+	/// frames a consumer is still holding: the decoder's texture has to be copied
+	/// into one of ours on the way out.
+	///
+	/// A distinct level per frame is what makes that visible; a fixed test picture
+	/// looks identical either way.
+	#[cfg(target_os = "windows")]
+	#[test]
+	fn mediafoundation_held_frames_keep_their_pixels() {
+		// More frames than the decoder's pool has slices (8 on the hardware this
+		// was written against, one per picture), so it has to recycle the slices
+		// the earliest frames came out of.
+		let Some(decoded) = decode_levels(12, gray_size()) else {
+			return;
+		};
+
+		for (i, out) in decoded.iter().enumerate() {
+			let (luma, _, _) = plane_averages(out);
+			let want = expected_luma(level(i as u64));
+			// Half the gap between adjacent levels, so a frame showing a neighbour's
+			// picture fails rather than squeaking through.
+			assert!(
+				luma.abs_diff(want) <= 6,
+				"frame {i} decoded to luma {luma}, expected about {want}: the decoder recycled its picture buffer"
+			);
+		}
+	}
+
+	/// A height that isn't a whole number of macroblocks is coded padded (180 rows
+	/// become 192), and the frame has to be the picture rather than the padding.
+	///
+	/// Chroma is the assertion that bites: the interleaved UV plane starts after
+	/// the *texture's* luma rows, so reading a padded texture as if it were the
+	/// frame lands in the last luma rows and colors the picture with them.
+	#[cfg(target_os = "windows")]
+	#[test]
+	fn mediafoundation_decode_crops_coded_padding() {
+		let size = crate::Size::new(320, 180);
+		let Some(decoded) = decode_levels(3, size) else { return };
+
+		for (i, out) in decoded.iter().enumerate() {
+			assert_eq!(out.size(), size, "frame {i} came back at the coded size");
+			let (luma, u, v) = plane_averages(out);
+			assert!(
+				luma.abs_diff(expected_luma(level(i as u64))) <= 6,
+				"frame {i} luma {luma} is not its own picture"
+			);
+			// Gray in, so both chroma planes stay neutral.
+			assert!(
+				u.abs_diff(128) <= 4 && v.abs_diff(128) <= 4,
+				"frame {i} chroma ({u}, {v}) is not neutral: the plane split read into the padding"
+			);
+		}
+	}
+
+	/// The transcode path stays on hardware from decode through re-encode: the
+	/// hardware encoder MFT takes the decoded texture on the same Direct3D11
+	/// device, no download and no upload. The residency assertion catches a CPU
+	/// fallback even when the pixels and dimensions still look right.
+	///
+	/// Decoding what comes back is the other half, and the one that pins the blit:
+	/// the encoder reads the texture on its own timeline, so a copy that never
+	/// landed still produces packets, just of the wrong picture.
+	#[cfg(target_os = "windows")]
+	#[test]
+	fn mediafoundation_decoded_texture_reencodes_in_place() {
+		let size = gray_size();
+		let Some(decoded) = decode_levels(3, size) else { return };
+		for out in &decoded {
+			assert!(
+				matches!(out.surface, Surface::Texture(_)),
+				"Media Foundation decode downloaded to the CPU"
+			);
+		}
+
+		let encoder = Encoder::new(&EncodeConfig {
+			kind: EncodeKind::Named("mediafoundation".into()),
+			..EncodeConfig::new(size.width, size.height, 30)
+		});
+		let Ok(mut encoder) = encoder else {
+			eprintln!("skipping: no Media Foundation H.264 hardware encoder available");
+			return;
+		};
+
+		let mut reencoded = Vec::new();
+		for (i, out) in decoded.iter().enumerate() {
+			if i == 0 {
+				encoder.keyframe();
+			}
+			reencoded.extend(encoder.encode(out).unwrap());
+		}
+		reencoded.extend(encoder.finish().unwrap());
+		assert!(
+			!reencoded.is_empty(),
+			"re-encoding decoded textures produced no packets"
+		);
+
+		// Back to pixels through the software decoder, so this leans on nothing the
+		// hardware path just did.
+		let mut decoder = backend::open(Codec::H264, &decode_config(super::Kind::Software)).expect("openh264 decoder");
+		let mut out = Vec::new();
+		for (i, encoded) in reencoded.iter().enumerate() {
+			out.extend(
+				decoder
+					.decode(encoded.payload.clone(), encoded.timestamp, i == 0)
+					.unwrap(),
+			);
+		}
+
+		assert!(!out.is_empty(), "re-encoded stream decoded to no frames");
+		for (i, frame) in out.iter().enumerate() {
+			assert_eq!(frame.size(), size, "re-encoded frame {i} changed size");
+			let (luma, _, _) = plane_averages(frame);
+			let want = expected_luma(level(i as u64));
+			assert!(
+				luma.abs_diff(want) <= 6,
+				"re-encoded frame {i} came back as luma {luma}, expected about {want}"
+			);
+		}
 	}
 
 	/// H.265 has no software encoder or decoder, so the HEVC round-trip rides the

--- a/rs/moq-video/src/encode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/encode/backend/mediafoundation.rs
@@ -320,9 +320,8 @@ impl MediaFoundation {
 	fn build_sample(&self, frame: &Surface) -> Result<IMFSample, Error> {
 		let buffer = match frame {
 			Surface::Texture(texture) => unsafe {
-				let buffer =
-					MFCreateDXGISurfaceBuffer(&ID3D11Texture2D::IID, &texture.texture, texture.subresource, false)
-						.map_err(|e| mf_err("MFCreateDXGISurfaceBuffer", e))?;
+				let buffer = MFCreateDXGISurfaceBuffer(&ID3D11Texture2D::IID, &texture.texture, 0, false)
+					.map_err(|e| mf_err("MFCreateDXGISurfaceBuffer", e))?;
 				let length = buffer
 					.cast::<windows::Win32::Media::MediaFoundation::IMF2DBuffer>()
 					.map_err(|e| mf_err("DXGI buffer is not 2D", e))?
@@ -506,7 +505,10 @@ impl MediaFoundation {
 	///
 	/// An async MFT owes a `METransformDrainComplete` for every drain, and a failed
 	/// event surfaces through [`handle_event`](Self::handle_event) as an error
-	/// rather than a silence, so the wait terminates either way.
+	/// rather than a silence, so the wait terminates either way. Both messages that
+	/// set that up are checked for the same reason: the wait is only bounded by an
+	/// MFT that accepted the drain, so failing to reach that state has to be an
+	/// error here rather than a block later.
 	fn drain(&mut self) -> Result<Vec<Encoded>, Error> {
 		let mut out = Vec::new();
 		if !self.started {
@@ -518,7 +520,9 @@ impl MediaFoundation {
 		// drain believe it was already done.
 		self.drained = false;
 		unsafe {
-			let _ = self.transform.ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM, 0);
+			self.transform
+				.ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM, 0)
+				.map_err(|e| mf_err("end of stream", e))?;
 			self.transform
 				.ProcessMessage(MFT_MESSAGE_COMMAND_DRAIN, 0)
 				.map_err(|e| mf_err("drain", e))?;

--- a/rs/moq-video/src/encode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/encode/backend/mediafoundation.rs
@@ -24,19 +24,20 @@ use windows::Win32::Graphics::Direct3D11::{ID3D11Device, ID3D11Texture2D};
 use windows::Win32::Media::MediaFoundation::{
 	CODECAPI_AVEncCommonMeanBitRate, CODECAPI_AVEncCommonRateControlMode, CODECAPI_AVEncMPVGOPSize,
 	CODECAPI_AVEncVideoForceKeyFrame, CODECAPI_AVLowLatencyMode, ICodecAPI, IMFDXGIDeviceManager, IMFMediaBuffer,
-	IMFMediaEvent, IMFMediaEventGenerator, IMFMediaType, IMFSample, IMFTransform, METransformHaveOutput,
-	METransformNeedInput, MF_E_NO_EVENTS_AVAILABLE, MF_E_TRANSFORM_NEED_MORE_INPUT, MF_E_TRANSFORM_STREAM_CHANGE,
-	MF_EVENT_FLAG_NO_WAIT, MF_EVENT_FLAG_NONE, MF_MT_AVG_BITRATE, MF_MT_FRAME_RATE, MF_MT_FRAME_SIZE,
-	MF_MT_INTERLACE_MODE, MF_MT_MAJOR_TYPE, MF_MT_MPEG2_PROFILE, MF_MT_SUBTYPE, MF_MT_TRANSFER_FUNCTION,
-	MF_MT_VIDEO_NOMINAL_RANGE, MF_MT_VIDEO_PRIMARIES, MF_MT_YUV_MATRIX, MF_TRANSFORM_ASYNC_UNLOCK,
-	MFCreateDXGIDeviceManager, MFCreateDXGISurfaceBuffer, MFCreateMediaType, MFCreateMemoryBuffer, MFCreateSample,
-	MFMediaType_Video, MFNominalRange_0_255, MFNominalRange_16_235, MFT_CATEGORY_VIDEO_ENCODER, MFT_ENUM_FLAG_HARDWARE,
-	MFT_ENUM_FLAG_SORTANDFILTER, MFT_MESSAGE_COMMAND_DRAIN, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING,
-	MFT_MESSAGE_NOTIFY_END_OF_STREAM, MFT_MESSAGE_NOTIFY_START_OF_STREAM, MFT_MESSAGE_SET_D3D_MANAGER,
-	MFT_OUTPUT_DATA_BUFFER, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO, MFTEnumEx, MFVideoFormat_H264,
-	MFVideoFormat_HEVC, MFVideoFormat_NV12, MFVideoInterlace_Progressive, MFVideoPrimaries_BT709,
-	MFVideoPrimaries_SMPTE170M, MFVideoTransFunc_709, MFVideoTransferMatrix_BT601, MFVideoTransferMatrix_BT709,
-	eAVEncCommonRateControlMode_CBR, eAVEncH264VProfile_High, eAVEncH265VProfile_Main_420_8,
+	IMFMediaEvent, IMFMediaEventGenerator, IMFMediaType, IMFSample, IMFTransform, METransformDrainComplete,
+	METransformHaveOutput, METransformNeedInput, MF_E_NO_EVENTS_AVAILABLE, MF_E_TRANSFORM_NEED_MORE_INPUT,
+	MF_E_TRANSFORM_STREAM_CHANGE, MF_EVENT_FLAG_NO_WAIT, MF_EVENT_FLAG_NONE, MF_MT_AVG_BITRATE, MF_MT_FRAME_RATE,
+	MF_MT_FRAME_SIZE, MF_MT_INTERLACE_MODE, MF_MT_MAJOR_TYPE, MF_MT_MPEG2_PROFILE, MF_MT_SUBTYPE,
+	MF_MT_TRANSFER_FUNCTION, MF_MT_VIDEO_NOMINAL_RANGE, MF_MT_VIDEO_PRIMARIES, MF_MT_YUV_MATRIX,
+	MF_TRANSFORM_ASYNC_UNLOCK, MFCreateDXGIDeviceManager, MFCreateDXGISurfaceBuffer, MFCreateMediaType,
+	MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video, MFNominalRange_0_255, MFNominalRange_16_235,
+	MFT_CATEGORY_VIDEO_ENCODER, MFT_ENUM_FLAG_HARDWARE, MFT_ENUM_FLAG_SORTANDFILTER, MFT_MESSAGE_COMMAND_DRAIN,
+	MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, MFT_MESSAGE_NOTIFY_END_OF_STREAM, MFT_MESSAGE_NOTIFY_START_OF_STREAM,
+	MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO,
+	MFTEnumEx, MFVideoFormat_H264, MFVideoFormat_HEVC, MFVideoFormat_NV12, MFVideoInterlace_Progressive,
+	MFVideoPrimaries_BT709, MFVideoPrimaries_SMPTE170M, MFVideoTransFunc_709, MFVideoTransferMatrix_BT601,
+	MFVideoTransferMatrix_BT709, eAVEncCommonRateControlMode_CBR, eAVEncH264VProfile_High,
+	eAVEncH265VProfile_Main_420_8,
 };
 use windows::Win32::System::Variant::{VARIANT, VT_BOOL, VT_UI4};
 use windows::core::{GUID, Interface};
@@ -78,6 +79,9 @@ pub(crate) struct MediaFoundation {
 	output_size: u32,
 	/// True once the MFT has asked for input and we haven't fed it since.
 	needs_input: bool,
+	/// True once the MFT has reported its drain complete, so a drain knows the
+	/// tail is out rather than still coming.
+	drained: bool,
 	sample_index: i64,
 	/// Frames handed to the MFT that haven't come back out, oldest first: the
 	/// sample time we gave the codec paired with the frame's real timestamp. This
@@ -143,6 +147,7 @@ impl MediaFoundation {
 			provides_samples: false,
 			output_size: 0,
 			needs_input: false,
+			drained: false,
 			sample_index: 0,
 			pending: VecDeque::new(),
 			last_timestamp: None,
@@ -428,6 +433,7 @@ impl MediaFoundation {
 		// `GetType` returns the raw `MF_EVENT_TYPE` value as a u32.
 		const NEED_INPUT: u32 = METransformNeedInput.0 as u32;
 		const HAVE_OUTPUT: u32 = METransformHaveOutput.0 as u32;
+		const DRAIN_COMPLETE: u32 = METransformDrainComplete.0 as u32;
 		match unsafe { event.GetType().map_err(|e| mf_err("event GetType", e))? } {
 			NEED_INPUT => self.needs_input = true,
 			HAVE_OUTPUT => {
@@ -435,6 +441,7 @@ impl MediaFoundation {
 					out.push(packet);
 				}
 			}
+			DRAIN_COMPLETE => self.drained = true,
 			_ => {}
 		}
 		Ok(())
@@ -486,6 +493,42 @@ impl MediaFoundation {
 			sample_to_bytes(&sample)?,
 			self.take_timestamp(sample_time),
 		)))
+	}
+
+	/// End the stream and wait the MFT's tail out, returning everything it was
+	/// still holding.
+	///
+	/// The blocking wait is the point. A hardware encoder holds a frame or two, and
+	/// the events carrying them are posted *after* the drain command, so sweeping
+	/// whatever happens to be queued already truncates the stream: that is one
+	/// access unit lost per group, and on a live track the frame does not vanish
+	/// but reappears ahead of the next group's keyframe.
+	///
+	/// An async MFT owes a `METransformDrainComplete` for every drain, and a failed
+	/// event surfaces through [`handle_event`](Self::handle_event) as an error
+	/// rather than a silence, so the wait terminates either way.
+	fn drain(&mut self) -> Result<Vec<Encoded>, Error> {
+		let mut out = Vec::new();
+		if !self.started {
+			return Ok(out);
+		}
+
+		// Cleared here rather than after the wait: a drain we exited early once
+		// leaves its completion queued, and reading that later would let the next
+		// drain believe it was already done.
+		self.drained = false;
+		unsafe {
+			let _ = self.transform.ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM, 0);
+			self.transform
+				.ProcessMessage(MFT_MESSAGE_COMMAND_DRAIN, 0)
+				.map_err(|e| mf_err("drain", e))?;
+		}
+		while !self.drained {
+			let event =
+				unsafe { self.events.GetEvent(MF_EVENT_FLAG_NONE) }.map_err(|e| mf_err("GetEvent (drain)", e))?;
+			self.handle_event(&event, &mut out)?;
+		}
+		Ok(out)
 	}
 
 	/// The timestamp of the frame this output belongs to, found by the sample time
@@ -557,19 +600,23 @@ impl Backend for MediaFoundation {
 		Ok(out)
 	}
 
-	fn finish(&mut self) -> Result<Vec<Encoded>, Error> {
-		if !self.started {
-			return Ok(Vec::new());
+	fn flush(&mut self) -> Result<Vec<Encoded>, Error> {
+		let out = self.drain()?;
+		if self.started {
+			// A drain leaves the MFT stopped: it stops asking for input until a new
+			// stream starts.
+			unsafe {
+				self.transform
+					.ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, 0)
+					.map_err(|e| mf_err("start of stream", e))?;
+			}
+			self.needs_input = false;
 		}
-		unsafe {
-			let _ = self.transform.ProcessMessage(MFT_MESSAGE_NOTIFY_END_OF_STREAM, 0);
-			let _ = self.transform.ProcessMessage(MFT_MESSAGE_COMMAND_DRAIN, 0);
-		}
-		// Low-latency CBR buffers almost nothing, so a non-blocking sweep of the
-		// queued events flushes the tail without risking a hang.
-		let mut out = Vec::new();
-		self.drain_ready(&mut out)?;
 		Ok(out)
+	}
+
+	fn finish(&mut self) -> Result<Vec<Encoded>, Error> {
+		self.drain()
 	}
 
 	fn set_bitrate(&mut self, bitrate: u64) -> Result<(), Error> {
@@ -625,10 +672,10 @@ fn enumerate_encoder(subtype: GUID) -> Result<IMFTransform, Error> {
 	let mut transform: Option<IMFTransform> = None;
 	for slot in entries.iter_mut() {
 		let Some(activate) = slot.take() else { continue };
-		if transform.is_none() {
-			if let Ok(mft) = unsafe { activate.ActivateObject::<IMFTransform>() } {
-				transform = Some(mft);
-			}
+		if transform.is_none()
+			&& let Ok(mft) = unsafe { activate.ActivateObject::<IMFTransform>() }
+		{
+			transform = Some(mft);
 		}
 	}
 	unsafe {

--- a/rs/moq-video/src/encode/backend/mediafoundation.rs
+++ b/rs/moq-video/src/encode/backend/mediafoundation.rs
@@ -31,13 +31,13 @@ use windows::Win32::Media::MediaFoundation::{
 	MF_MT_TRANSFER_FUNCTION, MF_MT_VIDEO_NOMINAL_RANGE, MF_MT_VIDEO_PRIMARIES, MF_MT_YUV_MATRIX,
 	MF_TRANSFORM_ASYNC_UNLOCK, MFCreateDXGIDeviceManager, MFCreateDXGISurfaceBuffer, MFCreateMediaType,
 	MFCreateMemoryBuffer, MFCreateSample, MFMediaType_Video, MFNominalRange_0_255, MFNominalRange_16_235,
-	MFT_CATEGORY_VIDEO_ENCODER, MFT_ENUM_FLAG_HARDWARE, MFT_ENUM_FLAG_SORTANDFILTER, MFT_MESSAGE_COMMAND_DRAIN,
-	MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, MFT_MESSAGE_NOTIFY_END_OF_STREAM, MFT_MESSAGE_NOTIFY_START_OF_STREAM,
-	MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER, MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO,
-	MFTEnumEx, MFVideoFormat_H264, MFVideoFormat_HEVC, MFVideoFormat_NV12, MFVideoInterlace_Progressive,
-	MFVideoPrimaries_BT709, MFVideoPrimaries_SMPTE170M, MFVideoTransFunc_709, MFVideoTransferMatrix_BT601,
-	MFVideoTransferMatrix_BT709, eAVEncCommonRateControlMode_CBR, eAVEncH264VProfile_High,
-	eAVEncH265VProfile_Main_420_8,
+	MFSampleExtension_Discontinuity, MFT_CATEGORY_VIDEO_ENCODER, MFT_ENUM_FLAG_HARDWARE, MFT_ENUM_FLAG_SORTANDFILTER,
+	MFT_MESSAGE_COMMAND_DRAIN, MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, MFT_MESSAGE_NOTIFY_END_OF_STREAM,
+	MFT_MESSAGE_NOTIFY_START_OF_STREAM, MFT_MESSAGE_SET_D3D_MANAGER, MFT_OUTPUT_DATA_BUFFER,
+	MFT_OUTPUT_STREAM_PROVIDES_SAMPLES, MFT_REGISTER_TYPE_INFO, MFTEnumEx, MFVideoFormat_H264, MFVideoFormat_HEVC,
+	MFVideoFormat_NV12, MFVideoInterlace_Progressive, MFVideoPrimaries_BT709, MFVideoPrimaries_SMPTE170M,
+	MFVideoTransFunc_709, MFVideoTransferMatrix_BT601, MFVideoTransferMatrix_BT709, eAVEncCommonRateControlMode_CBR,
+	eAVEncH264VProfile_High, eAVEncH265VProfile_Main_420_8,
 };
 use windows::Win32::System::Variant::{VARIANT, VT_BOOL, VT_UI4};
 use windows::core::{GUID, Interface};
@@ -82,6 +82,9 @@ pub(crate) struct MediaFoundation {
 	/// True once the MFT has reported its drain complete, so a drain knows the
 	/// tail is out rather than still coming.
 	drained: bool,
+	/// Set while the next sample is the first of a restarted stream, so it can be
+	/// marked as such.
+	discontinuity: bool,
 	sample_index: i64,
 	/// Frames handed to the MFT that haven't come back out, oldest first: the
 	/// sample time we gave the codec paired with the frame's real timestamp. This
@@ -148,6 +151,7 @@ impl MediaFoundation {
 			output_size: 0,
 			needs_input: false,
 			drained: false,
+			discontinuity: false,
 			sample_index: 0,
 			pending: VecDeque::new(),
 			last_timestamp: None,
@@ -588,11 +592,21 @@ impl Backend for MediaFoundation {
 		}
 
 		let sample = self.build_sample(&frame.surface)?;
+		if self.discontinuity {
+			// The first picture of a restarted stream is not temporally continuous
+			// with the one before the drain, and only this says so: the encoder would
+			// otherwise be free to predict across the seam.
+			unsafe { sample.SetUINT32(&MFSampleExtension_Discontinuity, 1) }
+				.map_err(|e| mf_err("mark discontinuity", e))?;
+		}
 		unsafe {
 			self.transform
 				.ProcessInput(0, &sample, 0)
 				.map_err(|e| mf_err("ProcessInput", e))?;
 		}
+		// Cleared only once the sample is in: a rejected one never carried the mark
+		// anywhere, so the next attempt still owns it.
+		self.discontinuity = false;
 		self.needs_input = false;
 		// Record the pairing before advancing the index, so this is the sample time
 		// `build_sample` just stamped the sample with.
@@ -615,6 +629,7 @@ impl Backend for MediaFoundation {
 					.map_err(|e| mf_err("start of stream", e))?;
 			}
 			self.needs_input = false;
+			self.discontinuity = true;
 		}
 		Ok(out)
 	}

--- a/rs/moq-video/src/encode/backend/mod.rs
+++ b/rs/moq-video/src/encode/backend/mod.rs
@@ -44,7 +44,20 @@ pub(crate) trait Backend: Send {
 	/// request, arriving via [`Encoder::keyframe`](super::Encoder::keyframe).
 	fn encode(&mut self, frame: &Frame, keyframe: bool) -> Result<Vec<Encoded>, Error>;
 
-	/// Flush the encoder, returning any buffered access units.
+	/// Return every access unit the codec is still holding, leaving the encoder
+	/// usable for the frames that follow.
+	///
+	/// The caller reaches for this at a boundary the output has to respect, which
+	/// on a live track is a group: a codec that pipelines would otherwise carry the
+	/// last frames of one group into the next, ahead of its keyframe, where a
+	/// consumer joining there cannot decode them.
+	///
+	/// No default, even though most backends have nothing to hold: a pipelined one
+	/// that inherited an empty implementation would drop frames at every boundary
+	/// and look like it worked.
+	fn flush(&mut self) -> Result<Vec<Encoded>, Error>;
+
+	/// Flush the encoder for the last time, returning any buffered access units.
 	fn finish(&mut self) -> Result<Vec<Encoded>, Error>;
 
 	/// Retune the live encoder to `bitrate` bits per second, taking effect from

--- a/rs/moq-video/src/encode/backend/nvenc.rs
+++ b/rs/moq-video/src/encode/backend/nvenc.rs
@@ -284,6 +284,11 @@ impl Backend for Nvenc {
 		})
 	}
 
+	fn flush(&mut self) -> Result<Vec<Encoded>, Error> {
+		// Each encode locks its own output synchronously, so nothing is buffered.
+		Ok(Vec::new())
+	}
+
 	fn finish(&mut self) -> Result<Vec<Encoded>, Error> {
 		// Each encode locks its own output synchronously, so nothing is buffered.
 		Ok(Vec::new())

--- a/rs/moq-video/src/encode/backend/openh264.rs
+++ b/rs/moq-video/src/encode/backend/openh264.rs
@@ -156,6 +156,11 @@ impl Backend for Openh264 {
 		})
 	}
 
+	fn flush(&mut self) -> Result<Vec<Encoded>, Error> {
+		// Low-delay: nothing is buffered, so there's nothing to flush.
+		Ok(Vec::new())
+	}
+
 	fn finish(&mut self) -> Result<Vec<Encoded>, Error> {
 		// Low-delay: nothing is buffered, so there's nothing to flush.
 		Ok(Vec::new())

--- a/rs/moq-video/src/encode/backend/vaapi.rs
+++ b/rs/moq-video/src/encode/backend/vaapi.rs
@@ -69,6 +69,12 @@ impl Backend for Vaapi {
 		})
 	}
 
+	fn flush(&mut self) -> Result<Vec<Encoded>, Error> {
+		// The encoder submits and reads back synchronously per frame, so nothing
+		// is ever buffered.
+		Ok(Vec::new())
+	}
+
 	fn finish(&mut self) -> Result<Vec<Encoded>, Error> {
 		// The encoder submits and reads back synchronously per frame, so nothing
 		// is buffered at shutdown.

--- a/rs/moq-video/src/encode/backend/videotoolbox.rs
+++ b/rs/moq-video/src/encode/backend/videotoolbox.rs
@@ -241,6 +241,11 @@ impl Backend for VideoToolbox {
 			.collect())
 	}
 
+	fn flush(&mut self) -> Result<Vec<Encoded>, Error> {
+		// complete_frames runs per-encode, so nothing is ever buffered.
+		Ok(Vec::new())
+	}
+
 	fn finish(&mut self) -> Result<Vec<Encoded>, Error> {
 		// complete_frames runs per-encode, so nothing is buffered at shutdown.
 		Ok(Vec::new())

--- a/rs/moq-video/src/encode/encoder.rs
+++ b/rs/moq-video/src/encode/encoder.rs
@@ -272,6 +272,24 @@ impl Encoder {
 		Ok(encoded)
 	}
 
+	/// Return every access unit the codec is still holding, leaving the encoder
+	/// ready for the frames that follow. Each keeps the timestamp of the raw frame
+	/// it was encoded from, so a drained tail stays in step with what came before
+	/// it.
+	///
+	/// Reach for this at a boundary the output has to respect, which for a live
+	/// broadcast is a group: a hardware codec that pipelines holds the last frames
+	/// of a group past its end, and they would otherwise be published into the next
+	/// group ahead of its keyframe, where a consumer joining there cannot decode
+	/// them. Publishing frame-by-frame with no group structure needs none of this.
+	///
+	/// Not free: emptying the pipeline gives up the overlap between one frame's
+	/// encode and the next frame's submission, so flush at boundaries rather than
+	/// per frame.
+	pub fn flush(&mut self) -> Result<Vec<Encoded>, Error> {
+		self.backend.flush()
+	}
+
 	/// Flush the encoder, returning any buffered frames. Each keeps the timestamp
 	/// of the raw frame it was encoded from, so a drained tail stays in step with
 	/// what was published before it.
@@ -824,8 +842,12 @@ mod tests {
 			Ok(previous.into_iter().collect())
 		}
 
-		fn finish(&mut self) -> Result<Vec<Encoded>, Error> {
+		fn flush(&mut self) -> Result<Vec<Encoded>, Error> {
 			Ok(self.pending.take().into_iter().collect())
+		}
+
+		fn finish(&mut self) -> Result<Vec<Encoded>, Error> {
+			self.flush()
 		}
 
 		fn set_bitrate(&mut self, _bitrate: u64) -> Result<(), Error> {
@@ -857,6 +879,10 @@ mod tests {
 	impl Backend for Recorder {
 		fn encode(&mut self, _frame: &Frame, keyframe: bool) -> Result<Vec<Encoded>, Error> {
 			self.0.lock().unwrap().push(keyframe);
+			Ok(Vec::new())
+		}
+
+		fn flush(&mut self) -> Result<Vec<Encoded>, Error> {
 			Ok(Vec::new())
 		}
 
@@ -949,6 +975,10 @@ mod tests {
 			Err(Error::Codec(anyhow::anyhow!("no")))
 		}
 
+		fn flush(&mut self) -> Result<Vec<Encoded>, Error> {
+			Ok(Vec::new())
+		}
+
 		fn finish(&mut self) -> Result<Vec<Encoded>, Error> {
 			Ok(Vec::new())
 		}
@@ -1023,6 +1053,37 @@ mod tests {
 				.unwrap()
 				.is_empty()
 		);
+	}
+
+	/// A group has to contain its own frames. A codec that pipelines is still
+	/// holding the last of them when the group ends, so the boundary flushes it;
+	/// without that they surface in the *next* group, ahead of its keyframe, where
+	/// a subscriber joining there cannot decode them.
+	///
+	/// The encoder stays usable afterwards, which is what separates this from
+	/// `finish`: a live track flushes at every group and keeps going.
+	#[test]
+	fn a_flush_empties_a_pipelined_backend_and_leaves_it_running() {
+		let config = Config::new(320, 240, 30);
+		let mut encoder = encoder_with(Box::new(Delayed { pending: None }), &config);
+
+		let mut group = Vec::new();
+		for i in 0..3 {
+			group.extend(encoder.encode(&gray_frame(320, 240, i)).unwrap());
+		}
+		group.extend(encoder.flush().unwrap());
+
+		// All three frames land in the group they belong to, in order.
+		let times: Vec<_> = group.iter().map(|packet| packet.timestamp).collect();
+		assert_eq!(times, vec![at(0), at(1), at(2)], "the group lost or reordered frames");
+
+		// The next group starts clean: nothing carried over, and the encoder still
+		// takes frames.
+		let mut next = encoder.encode(&gray_frame(320, 240, 3)).unwrap();
+		assert!(next.is_empty(), "frame 3 is buffered, so nothing comes back yet");
+		next.extend(encoder.finish().unwrap());
+		let times: Vec<_> = next.iter().map(|packet| packet.timestamp).collect();
+		assert_eq!(times, vec![at(3)], "the flush left something behind");
 	}
 
 	/// The hardware encoder states the color space too, and states the one the

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -4,12 +4,12 @@
 //! - `Surface::PixelBuffer` is a macOS `CVPixelBuffer` (IOSurface-backed NV12).
 //!   Capture and the VideoToolbox decoder both produce it, and the VideoToolbox
 //!   encoder consumes it directly, no copy and no color conversion.
-//! - `Surface::Texture` is a Windows Direct3D11 NV12 texture. Media Foundation
-//!   capture produces it on a shared D3D11 device and the hardware encoder MFT
-//!   consumes it on that same device, also zero-copy. A Media Foundation decode
-//!   produces one too, one GPU blit removed from the decoder's own picture
-//!   buffers, so a decoded frame never touches the CPU on its way to a renderer
-//!   or a re-encode.
+//! - `Surface::Texture` is a Windows Direct3D11 NV12 texture, produced by Media
+//!   Foundation capture and decode one GPU blit removed from their own pools
+//!   (which they recycle, so a frame has to be lifted out of them), and consumed
+//!   by the hardware encoder MFT on the same device with no copy at all. Nothing
+//!   on the path from a camera or a decoder to a renderer or an encoder touches
+//!   the CPU.
 //! - `Surface::I420` is CPU-resident planar I420, for the CPU encode path and
 //!   platforms without a zero-copy capture.
 //!
@@ -1345,7 +1345,7 @@ pub mod d3d11 {
 		D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT, D3D11_USAGE_STAGING, D3D11CreateDevice, ID3D11Device,
 		ID3D11DeviceContext, ID3D11Texture2D,
 	};
-	use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT;
+	use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT, DXGI_SAMPLE_DESC};
 	use windows::Win32::Media::MediaFoundation::{IMFDXGIBuffer, IMFSample};
 	use windows::core::Interface;
 
@@ -1403,51 +1403,28 @@ pub mod d3d11 {
 	}
 
 	impl Texture {
-		/// Wrap the GPU texture behind a Media Foundation sample, zero-copy.
-		///
-		/// The picture stays in the pool its producer allocated it from, so the
-		/// caller owns the timing: these pixels are this frame's only until the
-		/// producer reuses the slot, which it is free to do the moment the sample is
-		/// released. That holds only where the caller paces the producer. Where it
-		/// does not, or where the pool's textures are not ones a consumer can bind,
-		/// take [`copy_from_sample`](Self::copy_from_sample).
-		///
-		/// `width` and `height` are the display size, which the texture itself does
-		/// not know. Errors if the sample is system-memory backed, which is the
-		/// caller's cue to take its CPU path.
-		pub(crate) fn from_sample(
-			device: &ID3D11Device,
-			sample: &IMFSample,
-			width: u32,
-			height: u32,
-		) -> Result<Self, Error> {
-			let (texture, subresource) = resolve(sample)?;
-			Ok(Self {
-				device: device.clone(),
-				texture,
-				subresource,
-				width,
-				height,
-			})
-		}
-
 		/// Blit the `width` x `height` picture out of a Media Foundation sample into
 		/// a texture we own, staying on `device` and on the GPU.
 		///
-		/// The exit from a decoder's pool, which a frame cannot simply be handed out
-		/// of. A DXVA decoder decodes into a short texture array (8 slices on the
-		/// hardware this was written against) bound `D3D11_BIND_DECODER` and nothing
-		/// else, so a slice is unusable to every other consumer (no shader samples
-		/// it, no encoder reads it) and is recycled the moment its sample is
-		/// released. Handing slices out instead wedges the decoder as soon as a
-		/// consumer buffers a pool's worth of frames, with no error to report: the
-		/// MFT blocks inside `ProcessInput` waiting for a picture buffer that a
-		/// consumer is holding.
+		/// The exit from a Media Foundation pool, which a frame cannot simply be
+		/// handed out of. Both producers here allocate their output from a pool and
+		/// recycle a slot the moment its sample is released, so a texture handle
+		/// alone is not ownership: the next picture is written over a frame a
+		/// consumer is still holding. Keeping the sample instead is worse, because a
+		/// decoder's pool is short (8 slices on the hardware this was written
+		/// against) and it has no error to report when it runs dry: the MFT blocks
+		/// inside `ProcessInput` waiting for a picture buffer a consumer is holding.
+		/// A decoder's slices are bound `D3D11_BIND_DECODER` and nothing else, on
+		/// top of that, so no shader can sample one and no encoder can read it.
 		///
-		/// One GPU-to-GPU copy buys a frame that outlives the decoder, holds nothing
-		/// back, and can be bound. It also crops the coded size (a decoder allocates
-		/// in whole macroblocks) to the display size, so the result is exactly the
-		/// picture.
+		/// One GPU-to-GPU copy buys a frame that outlives its producer, holds
+		/// nothing back, and can be bound. It also crops the coded size (a decoder
+		/// allocates in whole macroblocks) to the display size, so the result is
+		/// exactly the picture. `width` and `height` are that display size, which
+		/// the texture itself does not know.
+		///
+		/// Errors if the sample is system-memory backed, which is the caller's cue
+		/// to take its CPU path.
 		pub(crate) fn copy_from_sample(
 			device: &ID3D11Device,
 			sample: &IMFSample,
@@ -1456,25 +1433,10 @@ pub mod d3d11 {
 		) -> Result<Self, Error> {
 			let (source, subresource) = resolve(sample)?;
 
-			// Same format and sample count as the decoder's, one plain slice of it.
+			// One plain slice in the producer's own format.
 			let mut desc = D3D11_TEXTURE2D_DESC::default();
 			unsafe { source.GetDesc(&mut desc) };
-			desc.Width = width;
-			desc.Height = height;
-			desc.ArraySize = 1;
-			desc.MipLevels = 1;
-			desc.Usage = D3D11_USAGE_DEFAULT;
-			desc.BindFlags = bind_flags(device, desc.Format);
-			desc.CPUAccessFlags = 0;
-			desc.MiscFlags = 0;
-
-			let mut texture: Option<ID3D11Texture2D> = None;
-			unsafe {
-				device
-					.CreateTexture2D(&desc, None, Some(&mut texture))
-					.map_err(|e| err("CreateTexture2D (decoded frame)", e))?;
-			}
-			let texture = texture.ok_or_else(|| Error::Codec(anyhow::anyhow!("CreateTexture2D returned null")))?;
+			let texture = alloc(device, width, height, desc.Format)?;
 
 			// Every edge has to be even for 4:2:0 chroma; the decoder's frame size is
 			// validated even before it reaches here.
@@ -1613,6 +1575,31 @@ pub mod d3d11 {
 				color: None,
 			})
 		}
+	}
+
+	/// A plain single-slice texture on `device`, bound for whatever the driver
+	/// supports. Where every frame this module hands out is allocated.
+	fn alloc(device: &ID3D11Device, width: u32, height: u32, format: DXGI_FORMAT) -> Result<ID3D11Texture2D, Error> {
+		let desc = D3D11_TEXTURE2D_DESC {
+			Width: width,
+			Height: height,
+			MipLevels: 1,
+			ArraySize: 1,
+			Format: format,
+			SampleDesc: DXGI_SAMPLE_DESC { Count: 1, Quality: 0 },
+			Usage: D3D11_USAGE_DEFAULT,
+			BindFlags: bind_flags(device, format),
+			CPUAccessFlags: 0,
+			MiscFlags: 0,
+		};
+
+		let mut texture: Option<ID3D11Texture2D> = None;
+		unsafe {
+			device
+				.CreateTexture2D(&desc, None, Some(&mut texture))
+				.map_err(|e| err("CreateTexture2D", e))?;
+		}
+		texture.ok_or_else(|| Error::Codec(anyhow::anyhow!("CreateTexture2D returned null")))
 	}
 
 	/// The Direct3D11 texture behind a Media Foundation sample, and which slice of

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -6,7 +6,10 @@
 //!   encoder consumes it directly, no copy and no color conversion.
 //! - `Surface::Texture` is a Windows Direct3D11 NV12 texture. Media Foundation
 //!   capture produces it on a shared D3D11 device and the hardware encoder MFT
-//!   consumes it on that same device, also zero-copy.
+//!   consumes it on that same device, also zero-copy. A Media Foundation decode
+//!   produces one too, one GPU blit removed from the decoder's own picture
+//!   buffers, so a decoded frame never touches the CPU on its way to a renderer
+//!   or a re-encode.
 //! - `Surface::I420` is CPU-resident planar I420, for the CPU encode path and
 //!   platforms without a zero-copy capture.
 //!
@@ -183,7 +186,8 @@ impl Surface {
 					Surface::I420(cuda.download_i420()?.resize(width, height)?)
 				}
 			},
-			// D3D11 textures have no GPU scaler wired up yet.
+			// D3D11 textures have no GPU scaler wired up yet, so a ladder fanning one
+			// decoded frame out to several sizes downloads it once per rung.
 			#[allow(unreachable_patterns)]
 			other => Surface::I420(other.to_i420()?.into_owned().resize(width, height)?),
 		})
@@ -1325,18 +1329,24 @@ pub mod cuda {
 #[cfg(target_os = "windows")]
 pub mod d3d11 {
 	//! Windows Direct3D11 surfaces: the NV12 [`Texture`] behind
-	//! `Surface::Texture`, shared by Media Foundation capture and encode.
+	//! `Surface::Texture`, shared by Media Foundation capture, decode, and encode.
 
+	use std::ffi::c_void;
 	use std::ptr;
 
 	use windows::Win32::Foundation::HMODULE;
 	use windows::Win32::Graphics::Direct3D::D3D_DRIVER_TYPE_HARDWARE;
 	use windows::Win32::Graphics::Direct3D10::ID3D10Multithread;
 	use windows::Win32::Graphics::Direct3D11::{
-		D3D11_CPU_ACCESS_READ, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_CREATE_DEVICE_VIDEO_SUPPORT, D3D11_MAP_READ,
-		D3D11_MAPPED_SUBRESOURCE, D3D11_SDK_VERSION, D3D11_TEXTURE2D_DESC, D3D11_USAGE_STAGING, D3D11CreateDevice,
-		ID3D11Device, ID3D11DeviceContext, ID3D11Texture2D,
+		D3D11_BIND_RENDER_TARGET, D3D11_BIND_SHADER_RESOURCE, D3D11_BIND_VIDEO_ENCODER, D3D11_BOX,
+		D3D11_CPU_ACCESS_READ, D3D11_CREATE_DEVICE_BGRA_SUPPORT, D3D11_CREATE_DEVICE_VIDEO_SUPPORT,
+		D3D11_FORMAT_SUPPORT, D3D11_FORMAT_SUPPORT_RENDER_TARGET, D3D11_FORMAT_SUPPORT_SHADER_SAMPLE,
+		D3D11_FORMAT_SUPPORT_VIDEO_ENCODER, D3D11_MAP_READ, D3D11_MAPPED_SUBRESOURCE, D3D11_SDK_VERSION,
+		D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT, D3D11_USAGE_STAGING, D3D11CreateDevice, ID3D11Device,
+		ID3D11DeviceContext, ID3D11Texture2D,
 	};
+	use windows::Win32::Graphics::Dxgi::Common::DXGI_FORMAT;
+	use windows::Win32::Media::MediaFoundation::{IMFDXGIBuffer, IMFSample};
 	use windows::core::Interface;
 
 	use super::I420;
@@ -1377,36 +1387,149 @@ pub mod d3d11 {
 		Ok(device)
 	}
 
-	/// A captured GPU texture (NV12) on the Media Foundation source reader's
-	/// Direct3D11 device. Holds the device so the download fallback and the
-	/// hardware encoder run on the same device that owns the texture. Cloning the
-	/// COM handles is a cheap `AddRef`, which is what keeps capture -> encode
-	/// zero-copy.
+	/// A GPU texture (NV12) on the Direct3D11 device of whichever Media Foundation
+	/// object produced it: the capture source reader, or the DXVA decoder. Holds
+	/// that device so the download fallback and the hardware encoder run on the
+	/// device that owns the texture. Cloning the COM handles is a cheap `AddRef`,
+	/// which is what keeps capture -> encode and decode -> encode zero-copy.
 	pub struct Texture {
 		pub(crate) device: ID3D11Device,
 		pub(crate) texture: ID3D11Texture2D,
-		/// The texture-array slice this frame lives in. Media Foundation pools the
-		/// reader's output as one texture array and reports the index per sample.
+		/// The texture-array slice this frame lives in. Media Foundation pools its
+		/// output as one texture array and reports the index per sample.
 		pub(crate) subresource: u32,
 		pub(crate) width: u32,
 		pub(crate) height: u32,
 	}
 
 	impl Texture {
-		pub(crate) fn new(
-			device: ID3D11Device,
-			texture: ID3D11Texture2D,
-			subresource: u32,
+		/// Wrap the GPU texture behind a Media Foundation sample, zero-copy.
+		///
+		/// The picture stays in the pool its producer allocated it from, so the
+		/// caller owns the timing: these pixels are this frame's only until the
+		/// producer reuses the slot, which it is free to do the moment the sample is
+		/// released. That holds only where the caller paces the producer. Where it
+		/// does not, or where the pool's textures are not ones a consumer can bind,
+		/// take [`copy_from_sample`](Self::copy_from_sample).
+		///
+		/// `width` and `height` are the display size, which the texture itself does
+		/// not know. Errors if the sample is system-memory backed, which is the
+		/// caller's cue to take its CPU path.
+		pub(crate) fn from_sample(
+			device: &ID3D11Device,
+			sample: &IMFSample,
 			width: u32,
 			height: u32,
-		) -> Self {
-			Self {
-				device,
+		) -> Result<Self, Error> {
+			let (texture, subresource) = resolve(sample)?;
+			Ok(Self {
+				device: device.clone(),
 				texture,
 				subresource,
 				width,
 				height,
+			})
+		}
+
+		/// Blit the `width` x `height` picture out of a Media Foundation sample into
+		/// a texture we own, staying on `device` and on the GPU.
+		///
+		/// The exit from a decoder's pool, which a frame cannot simply be handed out
+		/// of. A DXVA decoder decodes into a short texture array (8 slices on the
+		/// hardware this was written against) bound `D3D11_BIND_DECODER` and nothing
+		/// else, so a slice is unusable to every other consumer (no shader samples
+		/// it, no encoder reads it) and is recycled the moment its sample is
+		/// released. Handing slices out instead wedges the decoder as soon as a
+		/// consumer buffers a pool's worth of frames, with no error to report: the
+		/// MFT blocks inside `ProcessInput` waiting for a picture buffer that a
+		/// consumer is holding.
+		///
+		/// One GPU-to-GPU copy buys a frame that outlives the decoder, holds nothing
+		/// back, and can be bound. It also crops the coded size (a decoder allocates
+		/// in whole macroblocks) to the display size, so the result is exactly the
+		/// picture.
+		pub(crate) fn copy_from_sample(
+			device: &ID3D11Device,
+			sample: &IMFSample,
+			width: u32,
+			height: u32,
+		) -> Result<Self, Error> {
+			let (source, subresource) = resolve(sample)?;
+
+			// Same format and sample count as the decoder's, one plain slice of it.
+			let mut desc = D3D11_TEXTURE2D_DESC::default();
+			unsafe { source.GetDesc(&mut desc) };
+			desc.Width = width;
+			desc.Height = height;
+			desc.ArraySize = 1;
+			desc.MipLevels = 1;
+			desc.Usage = D3D11_USAGE_DEFAULT;
+			desc.BindFlags = bind_flags(device, desc.Format);
+			desc.CPUAccessFlags = 0;
+			desc.MiscFlags = 0;
+
+			let mut texture: Option<ID3D11Texture2D> = None;
+			unsafe {
+				device
+					.CreateTexture2D(&desc, None, Some(&mut texture))
+					.map_err(|e| err("CreateTexture2D (decoded frame)", e))?;
 			}
+			let texture = texture.ok_or_else(|| Error::Codec(anyhow::anyhow!("CreateTexture2D returned null")))?;
+
+			// Every edge has to be even for 4:2:0 chroma; the decoder's frame size is
+			// validated even before it reaches here.
+			let region = D3D11_BOX {
+				left: 0,
+				top: 0,
+				front: 0,
+				right: width,
+				bottom: height,
+				back: 1,
+			};
+			let context = unsafe { device.GetImmediateContext() }.map_err(|e| err("GetImmediateContext", e))?;
+			unsafe {
+				context.CopySubresourceRegion(&texture, 0, 0, 0, 0, &source, subresource, Some(&region));
+			}
+
+			Ok(Self {
+				device: device.clone(),
+				texture,
+				subresource: 0,
+				width,
+				height,
+			})
+		}
+
+		/// The Direct3D11 texture holding the pixels, and the array slice they live
+		/// in ([`subresource`](Self::subresource)). Borrowing keeps them on the GPU.
+		///
+		/// NV12, and allocated by whatever produced the frame, so it carries only
+		/// the bind flags that producer asked for and may be taller than the frame
+		/// ([`width`](Self::width) / [`height`](Self::height) are the display size).
+		pub fn texture(&self) -> &ID3D11Texture2D {
+			&self.texture
+		}
+
+		/// Which slice of [`texture`](Self::texture) this frame is, since Media
+		/// Foundation pools its output as a texture array.
+		pub fn subresource(&self) -> u32 {
+			self.subresource
+		}
+
+		/// The Direct3D11 device the texture belongs to. Anything reading the
+		/// texture has to run on this device.
+		pub fn device(&self) -> &ID3D11Device {
+			&self.device
+		}
+
+		/// The frame width in pixels.
+		pub fn width(&self) -> u32 {
+			self.width
+		}
+
+		/// The frame height in pixels.
+		pub fn height(&self) -> u32 {
+			self.height
 		}
 
 		/// Copy the NV12 texture to a CPU-readable staging texture and
@@ -1490,6 +1613,51 @@ pub mod d3d11 {
 				color: None,
 			})
 		}
+	}
+
+	/// The Direct3D11 texture behind a Media Foundation sample, and which slice of
+	/// it this sample is. Errors if the sample is system-memory backed.
+	fn resolve(sample: &IMFSample) -> Result<(ID3D11Texture2D, u32), Error> {
+		let buffer = unsafe { sample.GetBufferByIndex(0) }.map_err(|e| err("get sample buffer", e))?;
+		let dxgi = buffer
+			.cast::<IMFDXGIBuffer>()
+			.map_err(|e| err("sample buffer is not a DXGI surface", e))?;
+
+		// GetResource returns a fresh ref (`AddRef`) we take ownership of.
+		let mut raw: *mut c_void = ptr::null_mut();
+		unsafe {
+			dxgi.GetResource(&ID3D11Texture2D::IID, &mut raw)
+				.map_err(|e| err("get DXGI resource", e))?;
+		}
+		let texture = unsafe { ID3D11Texture2D::from_raw(raw) };
+		let subresource = unsafe { dxgi.GetSubresourceIndex() }.map_err(|e| err("get subresource index", e))?;
+		Ok((texture, subresource))
+	}
+
+	/// What a texture of `format` can be bound as on this device: everything a
+	/// consumer might want (sampling it in a shader, drawing into it, feeding it to
+	/// the hardware encoder) that the driver actually supports for the format.
+	///
+	/// Asked rather than assumed, because NV12 is exactly the format a driver is
+	/// allowed to be picky about, and `CreateTexture2D` fails outright on a flag it
+	/// does not support. Whatever comes back, the texture is still copyable and
+	/// downloadable, so a bare-bones driver costs a consumer a copy rather than the
+	/// frame.
+	fn bind_flags(device: &ID3D11Device, format: DXGI_FORMAT) -> u32 {
+		let support = unsafe { device.CheckFormatSupport(format) }.unwrap_or_default();
+		let supports = |flag: D3D11_FORMAT_SUPPORT| support & flag.0 as u32 != 0;
+
+		let mut flags = 0;
+		if supports(D3D11_FORMAT_SUPPORT_SHADER_SAMPLE) {
+			flags |= D3D11_BIND_SHADER_RESOURCE.0 as u32;
+		}
+		if supports(D3D11_FORMAT_SUPPORT_RENDER_TARGET) {
+			flags |= D3D11_BIND_RENDER_TARGET.0 as u32;
+		}
+		if supports(D3D11_FORMAT_SUPPORT_VIDEO_ENCODER) {
+			flags |= D3D11_BIND_VIDEO_ENCODER.0 as u32;
+		}
+		flags
 	}
 
 	struct UnmapGuard<'a> {

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -7,9 +7,12 @@
 //! - `Surface::Texture` is a Windows Direct3D11 NV12 texture, produced by Media
 //!   Foundation capture and decode one GPU blit removed from their own pools
 //!   (which they recycle, so a frame has to be lifted out of them), and consumed
-//!   by the hardware encoder MFT on the same device with no copy at all. Nothing
-//!   on the path from a camera or a decoder to a renderer or an encoder touches
-//!   the CPU.
+//!   by the hardware encoder MFT on the same device with no copy at all, so a
+//!   camera or a decoder reaches an encoder without touching the CPU. Drawing one
+//!   still goes through `into_i420`, since the render module imports a
+//!   `PixelBuffer` but has no Direct3D11 path yet.
+// `render` is deliberately not a doc link: the module sits behind a non-default
+// feature, so linking it fails the `-D warnings` rustdoc build of a plain build.
 //! - `Surface::I420` is CPU-resident planar I420, for the CPU encode path and
 //!   platforms without a zero-copy capture.
 //!
@@ -1395,9 +1398,6 @@ pub mod d3d11 {
 	pub struct Texture {
 		pub(crate) device: ID3D11Device,
 		pub(crate) texture: ID3D11Texture2D,
-		/// The texture-array slice this frame lives in. Media Foundation pools its
-		/// output as one texture array and reports the index per sample.
-		pub(crate) subresource: u32,
 		pub(crate) width: u32,
 		pub(crate) height: u32,
 	}
@@ -1456,26 +1456,21 @@ pub mod d3d11 {
 			Ok(Self {
 				device: device.clone(),
 				texture,
-				subresource: 0,
 				width,
 				height,
 			})
 		}
 
-		/// The Direct3D11 texture holding the pixels, and the array slice they live
-		/// in ([`subresource`](Self::subresource)). Borrowing keeps them on the GPU.
+		/// The Direct3D11 texture holding the pixels. Borrowing keeps them on the
+		/// GPU.
 		///
-		/// NV12, and allocated by whatever produced the frame, so it carries only
-		/// the bind flags that producer asked for and may be taller than the frame
-		/// ([`width`](Self::width) / [`height`](Self::height) are the display size).
+		/// NV12, one slice, exactly [`width`](Self::width) x
+		/// [`height`](Self::height), and bound for everything the driver supports
+		/// for the format: sampling in a shader, drawing into, and the hardware
+		/// encoder. This crate allocated it, so none of that is the producer's
+		/// choice leaking through.
 		pub fn texture(&self) -> &ID3D11Texture2D {
 			&self.texture
-		}
-
-		/// Which slice of [`texture`](Self::texture) this frame is, since Media
-		/// Foundation pools its output as a texture array.
-		pub fn subresource(&self) -> u32 {
-			self.subresource
 		}
 
 		/// The Direct3D11 device the texture belongs to. Anything reading the
@@ -1519,7 +1514,7 @@ pub mod d3d11 {
 			let staging = staging.ok_or_else(|| Error::Codec(anyhow::anyhow!("CreateTexture2D returned null")))?;
 
 			unsafe {
-				context.CopySubresourceRegion(&staging, 0, 0, 0, 0, &self.texture, self.subresource, None);
+				context.CopySubresourceRegion(&staging, 0, 0, 0, 0, &self.texture, 0, None);
 			}
 
 			let mut mapped = D3D11_MAPPED_SUBRESOURCE::default();

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -91,3 +91,10 @@ pub use objc2_core_foundation;
 /// at a matching one. A major bump here is a breaking change for this crate.
 #[cfg(target_os = "macos")]
 pub use objc2_core_video;
+/// The Direct3D11 bindings [`frame::d3d11::Texture`] hands back, re-exported for
+/// the same reason as the Apple ones above: name the exact version this crate
+/// links rather than guessing at a matching one, since a device and a texture
+/// from a different `windows` build are different types. A major bump here is a
+/// breaking change for this crate.
+#[cfg(target_os = "windows")]
+pub use windows;


### PR DESCRIPTION
## Summary

The Windows decode-surface retention from #2481, plus two more Media Foundation frame-lifetime bugs the hardware surfaced along the way. All of it validated on a real GPU (RTX 3070 Ti); none of it is reachable by CI, which never compiles these paths.

**Decoded frames stay on the GPU.** A Media Foundation decode now yields `Surface::Texture` instead of downloading every picture to I420, so decode -> render and decode -> re-encode never touch the CPU.

The plan's literal shape (retain the DXVA surface, the mirror of the VideoToolbox change in #2467) does not work on Windows, and the hardware says so three ways. The decoder's output is an 8-slice texture array bound `D3D11_BIND_DECODER` and nothing else:

- No shader can sample a slice and no encoder can read it, so retention would hand out a frame nobody can use.
- Slices are recycled the moment their sample is released. Holding a pool's worth wedges the decoder with no error to report: the MFT blocks *inside* `ProcessInput` waiting for a picture buffer a consumer is holding.
- Releasing a retained `IMFSample` after the decoder's `MFShutdown` is an access violation, which any frame outliving its decoder would hit.

So each picture takes one GPU-to-GPU blit into a texture we own, with bind flags read from `CheckFormatSupport` rather than assumed (this GPU grants `SHADER_RESOURCE | RENDER_TARGET | VIDEO_ENCODER`).

**Root cause 2: decoded frames were the wrong size.** The blit crops coded to display size, which exposed it. `MF_MT_FRAME_SIZE` is the coded size, so every decode of a stream whose height is not a whole number of macroblocks came back padded, 1080p as 1088 rows. The size now comes from the stream's minimum display aperture where it declares one.

**Root cause 3: the hardware encoder lost a frame per group.** `finish` swept whatever events were already queued, but a hardware MFT holds a frame or two and posts those events *after* the drain command. On a fetched group that dropped the tail. On a live track it was worse: nothing emptied the codec at a group boundary, so the tail of one group surfaced in the next ahead of its keyframe, where a subscriber joining there cannot decode it. `Backend` grows a `flush` that empties the pipeline and leaves the encoder running, `finish` waits the drain out, and the transcode live loop flushes at each boundary. This is what fixes the two `moq-transcode` hardware tests, which failed on every Windows machine with a GPU before this PR.

**Root cause 4: capture had the same pool-recycling hazard.** The source reader hands out textures it recycles as soon as the sample is released, while a captured frame waits in a 4-deep channel. It now takes the same blit out of the pool, which leaves `copy_from_sample` as the only way to build a `Texture` at all.

## Public API changes

Additive only, so this targets `main`.

- `moq_video::frame::d3d11::Texture` (Windows): new `texture()`, `device()`, `width()`, `height()`. Without them `Surface::Texture` is opaque to anyone outside the crate, and the retention only pays off in-tree.
- `moq_video::windows` (Windows): the `windows` crate re-exported, matching the existing objc2 re-exports, so a consumer naming a texture or a device is not guessing at a compatible version. A major bump there is a breaking change for this crate.
- `moq_video::encode::Encoder::flush()`: new.
- `pub(crate)` only, not public surface: `Backend::flush` (no default, so a future pipelined backend has to think about it), `Texture::copy_from_sample` replacing `Texture::new`.

## Test plan

Six Media Foundation tests on hardware, all skipping cleanly on a machine without a GPU, plus one portable test that runs everywhere:

- `mediafoundation_decode_stays_gpu_resident`, `mediafoundation_held_frames_keep_their_pixels`, `mediafoundation_decode_crops_coded_padding`, `mediafoundation_decoded_texture_reencodes_in_place`.
- `a_flush_empties_a_pipelined_backend_and_leaves_it_running`, over the existing `Delayed` test backend, so the group-boundary invariant is covered on Linux and macOS CI too.
- Each regression test was verified to fail against the bug it encodes. Reverting to the zero-copy hand-out gives `frame 0 decoded to luma 153, expected about 43`, a later picture written over a held frame. The re-encode test decodes its own output back to pixels, so a blit that never landed fails rather than merely producing packets.
- `moq-transcode`'s `end_to_end_hardware` and `live_multi_rung_hardware` now pass; both failed (4 of 5 frames) on `main`.
- `cargo test -p moq-video -p moq-transcode`, and `cargo check --workspace --exclude moq-gst --all-targets` (the `just rs windows` gate). Clippy and `cargo doc -D warnings` clean; the two pre-existing `collapsible_if` warnings in the MF backends are fixed in passing since Windows clippy could not be clean otherwise.

## Not in this PR

- **GPU resize for D3D11 textures**, the counterpart to #2512 on macOS. Decoded frames are now textures and `Surface::resize` has no GPU scaler, so a transcode ladder downloads once per rung instead of once per frame. I implemented it with `ID3D11VideoProcessor` and backed it out: `VideoProcessorBlt` deadlocks on a device that has a live DXVA decoder session. Two experiments isolate it. A cold processor blitting a copy destination on a *fresh* device works; the same blit on the *decoder's* device hangs, and hangs inside `VideoProcessorBlt` itself. A warm processor (one that already blitted a texture untouched by the decoder) then works on the decoder's device. Shipping a resize that can wedge the decode thread is worse than a download per rung, so this needs the `IMFDXGIDeviceManager::LockDevice` protocol investigated first.
- **Cross-package sync**: no rows apply. No wire format, no `moq-ffi` surface, and `moq-video` has no `doc/` page yet (#2481 tracks writing one).

## Review round

All six findings from Codex and CodeRabbit are addressed in 06066d58. Two were worth more than their labels suggested:

- The display aperture comes off the network and was used unclamped. `CopySubresourceRegion` reports no status, so a stream declaring an aperture larger than its coded frame would have produced a frame claiming dimensions over a texture nothing ever wrote. Now clamped to the coded size.
- `Texture::subresource()` is gone rather than re-documented. Every texture is now one this crate allocated with a single slice, so the accessor could only ever return 0.

The one suggestion not taken is CodeRabbit's request for a test that makes `MFT_MESSAGE_NOTIFY_END_OF_STREAM` fail: the backend drives a real MFT enumerated from the system, so there is nothing to inject the failure through short of a mock transform layer this crate does not have.

## One thing I could not explain

`live_multi_rung_hardware` failed once (4 of 5 frames) in a run where the `moq-video` and `moq-transcode` test binaries were executing concurrently, then passed 13 consecutive runs including 8 more of the same concurrent shape. I could not reproduce it or find a mechanism. Contention for NVENC sessions across two processes is the obvious suspect, but that is a guess, not a diagnosis.

(Written by Claude Opus 5)
