### PR TITLE
feat(native): mesh MoQ peers over the LAN with mDNS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3515,6 +3515,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "igd-next"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4257,6 +4267,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "mdns-sd"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86dbb9f00c8c367f75ed3a775d3eb31d0375a72f58275ef64a1bc53c255a2ce2"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket-pktinfo",
+ "socket2 0.6.5",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4424,6 +4449,7 @@ dependencies = [
  "moq-video",
  "rustls",
  "sd-notify",
+ "tempfile",
  "tokio",
  "tower-http 0.7.0",
  "tracing",
@@ -4577,10 +4603,12 @@ dependencies = [
  "clap",
  "futures",
  "hex",
+ "hmac 0.13.0",
  "humantime",
  "humantime-serde",
  "jni 0.22.4",
  "libc",
+ "mdns-sd",
  "moq-net",
  "noq-proto",
  "notify",
@@ -4596,7 +4624,9 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "serde_with",
+ "sha2",
  "socket2 0.6.5",
+ "subtle",
  "tempfile",
  "thiserror 2.0.19",
  "tikv-jemalloc-ctl",
@@ -7966,6 +7996,17 @@ name = "smawk"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
+
+[[package]]
+name = "socket-pktinfo"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612942246d0cc239cfd83af1dfd39be47f649208a3524e5e9da651910128e0ac"
+dependencies = [
+ "libc",
+ "socket2 0.6.5",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4601,6 +4601,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "flume",
  "futures",
  "hex",
  "hmac 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,10 +75,15 @@ rust-version = "1.91"
 [workspace.dependencies]
 flate2 = "1.1"
 hang = { version = "0.20", path = "rs/hang" }
+# HMAC-SHA256 for the mDNS membership proofs (moq-native's `mdns` feature).
+hmac = "0.13"
 kio = { version = "0.5", path = "rs/kio" }
 # Permutation testing for the kio primitives (and everything built on them).
 # Only compiled under `--cfg loom`; see `just rs loom`.
 loom = { version = "0.7.2", features = ["futures"] }
+# DNS-SD advertisement and browsing for LAN peer discovery (moq-native's `mdns` feature).
+# `async` awaits the event channel instead of blocking a thread on it.
+mdns-sd = { version = "0.20", features = ["async"] }
 moq-audio = { version = "0.0.16", path = "rs/moq-audio" }
 moq-flate = { version = "0.1.1", path = "rs/moq-flate" }
 moq-hls = { version = "0.4.6", path = "rs/moq-hls", default-features = false }
@@ -111,6 +116,9 @@ moq-video = { version = "0.0.14", path = "rs/moq-video", default-features = fals
 percent-encoding = "2"
 qmux = { version = "0.4.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
+sha2 = "0.11"
+subtle = "2.6"
+tempfile = "3"
 tokio = "1.48"
 web-async = { version = "0.1.5", features = ["tracing"] }
 web-transport-iroh = "0.6"

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -84,10 +84,12 @@ moq <MoQ side>  <import|export>  <endpoint> [endpoint options]
     broadcast.
   - `--server-bind <addr>` hosts MoQ sessions directly (with `--tls-generate` /
     `--tls-cert` + `--tls-key`).
+  - `--cluster-lan` meshes with every other participating process on the LAN via
+    mDNS, no relay or internet needed. See [LAN Cluster](#lan-cluster-mdns).
 
-  Both may be given at once (dial a relay *and* accept incoming sessions).
-  `--origin <id>` pins the process's origin id (default: fresh and random per
-  run); see [Redundant Publishers](#redundant-publishers-11).
+  Any combination may be given at once (e.g. dial a relay *and* accept incoming
+  sessions). `--origin <id>` pins the process's origin id (default: fresh and
+  random per run); see [Redundant Publishers](#redundant-publishers-11).
 - **`import`** routes media INTO MoQ (a source fills the Origin); **`export`**
   routes it OUT (a sink drains the Origin). The verb fixes the data direction.
 - **endpoint** is one subcommand: a container format (`avc3`, `fmp4`, `ts`, `flv`
@@ -124,6 +126,57 @@ Subtitles ride in the source container. The current `moq import` path does not p
 tracks in fragmented MP4, so captions arrive over the GStreamer path instead: `moqsink` accepts a
 decoded text pad and publishes it as a caption track. See
 [GStreamer](gstreamer.md).
+
+### LAN Cluster (mDNS)
+
+`--cluster-lan` advertises this process over mDNS (DNS-SD, `_moq._udp.local`)
+and connects to every other participating MoQ process on the LAN, with no relay,
+internet, or certificate setup needed. Each pair opens one bidirectional session
+and shares one set of broadcasts, like a miniature relay cluster:
+
+```bash
+# On one machine: publish a stream to the LAN.
+ffmpeg -i video.mp4 -c copy -f mpegts - | \
+    moq --cluster-lan --broadcast lan-demo.hang import ts
+
+# On another: discover it and play it.
+moq --cluster-lan --broadcast lan-demo.hang export ts | mpv -
+```
+
+Peers connect to the `--server-bind` listener, which `--cluster-lan` fills in
+when you haven't: an ephemeral port with a generated certificate, whose SHA-256
+fingerprint rides along in the advertisement. Dialers pin that fingerprint, so
+sessions are encrypted without a CA. Pass `--server-bind` yourself to put the
+mesh on a fixed port and your own certificate, shared with ordinary viewers.
+
+It composes with the other MoQ sides. The common pairing is a LAN mesh plus a
+CDN for everyone else: `--cluster-lan --client-connect
+https://relay.example.com/anon` serves viewers on the same network directly
+while the relay serves external ones, all from one process and one set of
+broadcasts. With `--cluster-lan` alone nothing leaves the local network.
+
+By default anyone who can reach the listener joins, exactly like a bare
+`--server-bind`, so use it on networks you trust. On a network you don't
+control, generate a key and give the same one to every peer:
+
+```bash
+openssl rand -hex 32 > cluster.key
+moq --cluster-lan --cluster-lan-secret cluster.key --broadcast lan-demo.hang export ts
+```
+
+Peers then prove they hold the key before anything else happens. Each
+advertisement carries an HMAC-SHA256 proof bound to the record it travels in
+(the advertiser's service instance, port, nonce, certificate fingerprint, and
+node identity), and a peer whose proof doesn't verify is never dialed at all.
+Copying another member's proof into your own advertisement therefore gets you
+nowhere, even though the record is public. The proof a dialer presents in return is bound to the one
+listener it was derived from, so an impostor that advertises a fingerprint it
+controls gets nothing it can reuse anywhere else. The key itself never crosses
+the network, and peers with different keys (or none) are mutually invisible.
+
+Because the proofs are HMACs over a public nonce, a weak key can be brute-forced
+offline by anyone watching the network. Generate 32 random bytes as above rather
+than choosing something memorable.
 
 ### Redundant Publishers (1+1)
 

--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -103,6 +103,12 @@ carries a proof of key possession, bound to the record it travels in so it
 cannot be copied into someone else's, and a relay only dials peers whose proof
 verifies.
 
+Startup waits for the mesh to come up before the relay reports itself ready
+(`READY=1` under systemd), so a bad key, a missing `node`, or a host where
+multicast is blocked fails the relay rather than releasing the units that depend
+on it. One working interface is enough: a down VPN adapter or a container bridge
+with multicast off doesn't hold startup back.
+
 ## Origin id
 
 Each relay has an origin id: the value it adds to a broadcast's hop list for loop detection and shortest-path routing. On `moq-lite`, and on a `moqt-17`-or-later session that negotiated the cluster extension, each end declares it at setup so the other can avoid announcing (or serving) a path that already flows through it. Older sessions carry no identity, so a peer only has one if you assign it. By default a fresh random id is picked on every start, which is fine for loop detection but means a relay looks like a brand-new node each time it restarts.

--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -72,6 +72,37 @@ When two gossiping nodes discover each other, only one of them dials: the node w
 
 A relay with `node` + `mesh` and no `connect` is a passive rendezvous: it sits and waits for inbound connections, then helps everyone else find each other.
 
+### On a local network
+
+On a LAN there may be no seed peer to gossip through and no external service to
+list peers. `cluster.lan` advertises this relay over mDNS and dials the peers
+that advertise themselves back, so a rack or a home lab meshes with no seed list
+at all:
+
+```toml
+[cluster]
+node = "us-west.local:4443"
+
+[cluster.lan]
+enabled = true
+secret  = "/etc/moq/cluster.key"
+```
+
+mDNS only replaces *how peers find each other*. They are dialed at their `node`
+URL and authenticate with `cluster.token` exactly like a gossiped or
+`connect_api` peer, the same tiebreaker decides which side dials, and the same
+dial map means a peer found two ways still opens one session. `lan.enabled`
+without `node` is an error, since there'd be no address to advertise.
+
+`lan.secret` is required rather than optional, and every peer needs the same
+value (`openssl rand -hex 32 > cluster.key`). mDNS is an open channel: anyone on
+the network can advertise, including an attacker naming a URL it controls. Since
+the relay attaches `cluster.token` to any peer it dials, an unauthenticated
+advertisement would be enough to collect that token. So each advertisement
+carries a proof of key possession, bound to the record it travels in so it
+cannot be copied into someone else's, and a relay only dials peers whose proof
+verifies.
+
 ## Origin id
 
 Each relay has an origin id: the value it adds to a broadcast's hop list for loop detection and shortest-path routing. On `moq-lite`, and on a `moqt-17`-or-later session that negotiated the cluster extension, each end declares it at setup so the other can avoid announcing (or serving) a path that already flows through it. Older sessions carry no identity, so a peer only has one if you assign it. By default a fresh random id is picked on every start, which is fine for loop detection but means a relay looks like a brand-new node each time it restarts.

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -196,6 +196,17 @@ token = "cluster.jwt"
 # never notice. A clean unannounce always takes effect immediately. "0"
 # unannounces abrupt losses immediately too. Default: 5s.
 linger = "5s"
+
+[cluster.lan]
+# Optional. Discover peers on the local network with mDNS instead of (or as well
+# as) gossip and connect_api. Requires `node` and `secret`.
+enabled = true
+
+# The shared key admitting a peer to the LAN mesh: 64 hexadecimal characters, or
+# a path to a file containing them. Every peer needs the same value. Required,
+# because mDNS is unauthenticated and the relay attaches `token` to any peer it
+# dials.
+secret = "/etc/moq/cluster.key"
 ```
 
 See [Clustering](/bin/relay/cluster) for topology choices and the trade-off between hand-listed peers and gossip.

--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -45,6 +45,19 @@ The client supports several URL schemes:
 The URL path and query mean the same thing on every scheme.
 Raw QUIC has no request URI to put them in, so the client sends them in the MoQ SETUP instead; the server sees the same request path either way.
 
+### Several Addresses for One Peer
+
+`connect` takes a `Url` for the usual case of a peer at a known address.
+When the same peer has several candidate addresses and only some of them route from here, pass [`Addrs`](https://docs.rs/moq-native/latest/moq_native/struct.Addrs.html) instead: each attempt walks them in order and keeps the first that connects.
+
+```rust
+let addrs = moq_native::Addrs::new(primary).or(fallback);
+let connection = client.connect(addrs).established().await?;
+```
+
+This is for a peer that was *discovered* rather than configured, where the record lists every interface it answered on and nothing says which one reaches you.
+`Addrs` is non-empty by construction, so a connection always has somewhere to dial; use `Addrs::collect` when the addresses come from an iterator that may be empty.
+
 ### Transport Racing
 
 `client.connect()` automatically races QUIC and WebSocket connections.

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -18,8 +18,10 @@ name = "moq"
 path = "src/main.rs"
 
 [features]
-default = ["iroh", "quinn", "websocket", "nvenc", "nvdec", "pipewire"]
+default = ["iroh", "cluster-lan", "quinn", "websocket", "nvenc", "nvdec", "pipewire"]
 iroh = ["moq-native/iroh"]
+# LAN discovery and meshing (`--cluster-lan`).
+cluster-lan = ["moq-native/mdns"]
 jemalloc = ["moq-native/jemalloc"]
 noq = ["moq-native/noq"]
 quinn = ["moq-native/quinn"]
@@ -83,6 +85,7 @@ url = "2"
 sd-notify = "0.5"
 
 [dev-dependencies]
+tempfile = { workspace = true }
 # `test-util` enables `tokio::time::pause` so the TS round-trip test simulates the
 # exporter drain timeouts instantly instead of waiting on the wall clock.
 tokio = { workspace = true, features = ["test-util"] }

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -2,9 +2,10 @@
 //!
 //! Grammar: `moq <MoQ side> <import|export> <endpoint> [endpoint opts]`.
 //!
-//! - The MoQ side (`--client-connect` / `--server-bind`, both optional, at least
-//!   one) attaches the shared Origin to the MoQ network, and comes before the
-//!   verb. Both may be given: dial a relay *and* accept incoming sessions.
+//! - The MoQ side (`--client-connect`, `--server-bind`, `--cluster-lan`; all
+//!   optional, at least one) attaches the shared Origin to the MoQ network, and
+//!   comes before the verb. They compose: dial a relay, accept incoming
+//!   sessions, and mesh with the LAN all at once.
 //! - `import` routes media INTO MoQ from one source; `export` routes it OUT to
 //!   one sink. The verb fixes the data direction (and thus, for the
 //!   bidirectional gateways, whether `--connect`/`--listen` push or pull).
@@ -42,14 +43,21 @@ pub struct Cli {
 	pub command: Command,
 }
 
-/// The MoQ attachment. At least one of `--client-connect` / `--server-bind`;
-/// both may be given at once.
+/// The MoQ attachment: a relay dial, a server listener, a LAN mesh, or any
+/// combination.
 ///
 /// The group is not `required`, because the local verbs (`token`, `devices`) run
 /// without a MoQ side. Every verb that does need one calls
 /// [`validate`](Self::validate).
 #[derive(Args, Clone)]
-#[command(group = ArgGroup::new("moq").multiple(true).args(["client-connect", "server-bind"]))]
+#[cfg_attr(
+	feature = "cluster-lan",
+	command(group = ArgGroup::new("moq").multiple(true).args(["client-connect", "server-bind", "cluster-lan"]))
+)]
+#[cfg_attr(
+	not(feature = "cluster-lan"),
+	command(group = ArgGroup::new("moq").multiple(true).args(["client-connect", "server-bind"]))
+)]
 pub struct MoqSide {
 	/// The broadcast name. Optional for the point endpoints (stdin/stdout, HLS
 	/// import, and the `--connect` dials), which default to the root broadcast at
@@ -81,6 +89,11 @@ pub struct MoqSide {
 	#[cfg(feature = "iroh")]
 	#[command(flatten)]
 	pub iroh: moq_native::iroh::EndpointConfig,
+
+	/// LAN clustering config (`--cluster-lan`, `--cluster-lan-secret`).
+	#[cfg(feature = "cluster-lan")]
+	#[command(flatten)]
+	pub cluster: crate::cluster::Args,
 }
 
 impl MoqSide {
@@ -95,14 +108,46 @@ impl MoqSide {
 		.produce())
 	}
 
+	/// Whether `--cluster-lan` asked this process to mesh over the LAN.
+	pub fn lan(&self) -> bool {
+		#[cfg(feature = "cluster-lan")]
+		return self.cluster.enabled();
+		#[cfg(not(feature = "cluster-lan"))]
+		false
+	}
+
+	/// The server to bind, which the LAN mesh shares with ordinary clients.
+	///
+	/// `--cluster-lan` needs a listener for peers to dial, so it fills in the two
+	/// things the user would otherwise have to spell out: an ephemeral port and a
+	/// generated certificate. An explicit `--server-bind` or `--tls-*` wins, which
+	/// is what puts the mesh on the same port and certificate as everything else.
+	pub fn server_config(&self) -> moq_native::ServerConfig {
+		let mut config = self.server.clone();
+		if self.lan() {
+			config.bind.get_or_insert_with(|| "[::]:0".to_string());
+			if config.tls.generate.is_empty() && config.tls.cert.is_empty() {
+				config.tls.generate = vec!["moq-cluster-lan".to_string()];
+			}
+		}
+		config
+	}
+
+	/// Whether a listener has to be bound at all.
+	pub fn serves(&self) -> bool {
+		self.server.bind.is_some() || self.lan()
+	}
+
 	/// Reject a verb that needs the MoQ network but was given no way to reach it.
 	/// Stands in for the clap `required` the `moq` group can't carry, since
 	/// `devices` is exempt.
 	pub fn validate(&self) -> anyhow::Result<()> {
 		anyhow::ensure!(
-			self.client.connect.is_some() || self.server.bind.is_some(),
-			"a MoQ side is required: pass --client-connect <url> to dial a relay, or --server-bind <addr> to self-host"
+			self.client.connect.is_some() || self.serves(),
+			"a MoQ side is required: pass --client-connect <url> to dial a relay, --server-bind <addr> to self-host, or --cluster-lan to mesh over the LAN"
 		);
+		#[cfg(feature = "cluster-lan")]
+		self.cluster.validate()?;
 		Ok(())
 	}
 
@@ -117,6 +162,7 @@ impl MoqSide {
 		let ignored = [
 			("--client-connect", self.client.connect.is_some()),
 			("--server-bind", self.server.bind.is_some()),
+			("--cluster-lan", self.lan()),
 			("--broadcast", self.broadcast.is_some()),
 		];
 
@@ -370,5 +416,89 @@ mod tests {
 			let err = cli.moq.reject("token").unwrap_err().to_string();
 			assert!(err.contains(flag[0]), "{err}");
 		}
+
+		#[cfg(feature = "cluster-lan")]
+		{
+			let cli = Cli::try_parse_from(["moq", "--cluster-lan", "token", "generate"]).unwrap();
+			let err = cli.moq.reject("token").unwrap_err().to_string();
+			assert!(err.contains("--cluster-lan"), "{err}");
+		}
+	}
+
+	/// `--cluster-lan` is a MoQ side on its own, and it supplies the listener the
+	/// user would otherwise have to spell out.
+	#[cfg(feature = "cluster-lan")]
+	#[test]
+	fn cluster_lan_is_a_moq_side_and_fills_in_a_listener() {
+		let cli = Cli::try_parse_from(["moq", "--cluster-lan", "import", "ts"]).expect("parse");
+		assert!(cli.moq.lan());
+		assert!(cli.moq.validate().is_ok(), "the LAN mesh is a MoQ side on its own");
+
+		let server = cli.moq.server_config();
+		assert_eq!(server.bind.as_deref(), Some("[::]:0"), "an ephemeral port");
+		assert_eq!(server.tls.generate, ["moq-cluster-lan"], "a generated certificate");
+
+		// An explicit listener wins, so the mesh shares one port and certificate
+		// with ordinary clients.
+		let cli = Cli::try_parse_from([
+			"moq",
+			"--cluster-lan",
+			"--server-bind",
+			"[::]:4443",
+			"--tls-generate",
+			"localhost",
+			"import",
+			"ts",
+		])
+		.expect("parse");
+		let server = cli.moq.server_config();
+		assert_eq!(server.bind.as_deref(), Some("[::]:4443"));
+		assert_eq!(server.tls.generate, ["localhost"]);
+
+		// Without the mesh, nothing is filled in.
+		let cli = Cli::try_parse_from(["moq", "--client-connect", "https://relay.example.com", "import", "ts"])
+			.expect("parse");
+		assert!(!cli.moq.lan());
+		assert_eq!(cli.moq.server_config().bind, None);
+	}
+
+	/// The secret is only read by the mesh, so configuring one without it is an
+	/// error rather than a silently ignored flag.
+	#[cfg(feature = "cluster-lan")]
+	#[test]
+	fn cluster_lan_secret_requires_the_mesh() {
+		let err = Cli::try_parse_from(["moq", "--cluster-lan-secret", "cluster.key", "import", "ts"])
+			.err()
+			.expect("the secret must require --cluster-lan")
+			.to_string();
+		assert!(err.contains("--cluster-lan"), "{err}");
+
+		// `--cluster-lan=false` satisfies clap's `requires` (the flag is present),
+		// so the real check lives in `validate`.
+		let cli = Cli::try_parse_from([
+			"moq",
+			"--cluster-lan=false",
+			"--cluster-lan-secret",
+			"cluster.key",
+			"--client-connect",
+			"https://relay.example.com",
+			"import",
+			"ts",
+		])
+		.expect("parse");
+		let err = cli.moq.validate().unwrap_err().to_string();
+		assert!(err.contains("--cluster-lan=true"), "{err}");
+
+		let cli = Cli::try_parse_from([
+			"moq",
+			"--cluster-lan",
+			"--cluster-lan-secret",
+			"cluster.key",
+			"import",
+			"ts",
+		])
+		.expect("parse");
+		assert!(cli.moq.validate().is_ok());
+		assert_eq!(cli.moq.cluster.secret.as_deref(), Some("cluster.key"));
 	}
 }

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -147,7 +147,12 @@ impl MoqSide {
 			"a MoQ side is required: pass --client-connect <url> to dial a relay, --server-bind <addr> to self-host, or --cluster-lan to mesh over the LAN"
 		);
 		#[cfg(feature = "cluster-lan")]
-		self.cluster.validate()?;
+		{
+			self.cluster.validate()?;
+			if self.lan() {
+				crate::cluster::validate_versions(&self.client, &self.server_config())?;
+			}
+		}
 		Ok(())
 	}
 
@@ -159,10 +164,16 @@ impl MoqSide {
 	/// fail `moq token` in any shell that exports the variable for a publisher, and an
 	/// ambient env value is not the deliberate request this is meant to catch.
 	pub fn reject(&self, command: &str) -> anyhow::Result<()> {
+		#[cfg(feature = "cluster-lan")]
+		let cluster_secret = self.cluster.secret.is_some();
+		#[cfg(not(feature = "cluster-lan"))]
+		let cluster_secret = false;
+
 		let ignored = [
 			("--client-connect", self.client.connect.is_some()),
 			("--server-bind", self.server.bind.is_some()),
 			("--cluster-lan", self.lan()),
+			("--cluster-lan-secret", cluster_secret),
 			("--broadcast", self.broadcast.is_some()),
 		];
 
@@ -422,6 +433,21 @@ mod tests {
 			let cli = Cli::try_parse_from(["moq", "--cluster-lan", "token", "generate"]).unwrap();
 			let err = cli.moq.reject("token").unwrap_err().to_string();
 			assert!(err.contains("--cluster-lan"), "{err}");
+
+			// Clap considers the secret's `requires` satisfied when the boolean flag
+			// is explicitly present but false. The local verb still has to reject the
+			// otherwise silently ignored secret.
+			let cli = Cli::try_parse_from([
+				"moq",
+				"--cluster-lan=false",
+				"--cluster-lan-secret",
+				"cluster.key",
+				"token",
+				"generate",
+			])
+			.unwrap();
+			let err = cli.moq.reject("token").unwrap_err().to_string();
+			assert!(err.contains("--cluster-lan-secret"), "{err}");
 		}
 	}
 
@@ -500,5 +526,33 @@ mod tests {
 		.expect("parse");
 		assert!(cli.moq.validate().is_ok());
 		assert_eq!(cli.moq.cluster.secret.as_deref(), Some("cluster.key"));
+	}
+
+	/// A mesh dial authenticates through its request path, which legacy moq-lite
+	/// versions do not carry.
+	#[cfg(feature = "cluster-lan")]
+	#[test]
+	fn cluster_lan_requires_a_path_capable_version() {
+		for flag in ["--client-version", "--server-version"] {
+			let cli =
+				Cli::try_parse_from(["moq", "--cluster-lan", flag, "moq-lite-04", "import", "ts"]).expect("parse");
+			let err = cli.moq.validate().unwrap_err().to_string();
+			assert!(err.contains(flag), "{err}");
+		}
+
+		let cli = Cli::try_parse_from([
+			"moq",
+			"--cluster-lan",
+			"--client-version",
+			"moq-lite-04",
+			"--client-version",
+			"moq-lite-05",
+			"--server-version",
+			"moq-lite-05",
+			"import",
+			"ts",
+		])
+		.expect("parse");
+		assert!(cli.moq.validate().is_ok());
 	}
 }

--- a/rs/moq-cli/src/cluster.rs
+++ b/rs/moq-cli/src/cluster.rs
@@ -1,0 +1,577 @@
+//! LAN clustering: find MoQ peers with mDNS and mesh with them.
+//!
+//! [`Lan`] advertises this process's `--server-bind` listener over mDNS, dials
+//! every peer it discovers, and attaches each session to the shared origin in
+//! both directions, so the whole network converges on one set of broadcasts
+//! with no relay involved. Loop prevention comes from each broadcast's route,
+//! like a relay cluster.
+//!
+//! Discovery and the membership proofs live in [`moq_native::mdns`] and the
+//! dials are plain [`moq_native::Connection`] loops, so this module is only the
+//! policy: who to dial, and who is allowed in.
+
+use std::collections::HashMap;
+
+use anyhow::Context;
+use hang::moq_net;
+use moq_native::mdns;
+use url::Url;
+
+/// The request path prefix a mesh dial presents, marking it as a peer rather
+/// than an ordinary publisher or viewer on the same listener.
+const MESH_PATH: &str = "/.cluster";
+
+/// The LAN mesh policy: dial every discovered peer, accept the ones that prove
+/// membership.
+///
+/// Cheap to clone; the inbound accept path and the outbound dial loop share one.
+#[derive(Clone)]
+pub struct Lan {
+	/// Published to and ingested from every peer, so all of them converge.
+	origin: moq_net::origin::Producer,
+
+	/// The proof an inbound peer must present, mirroring what we advertised.
+	/// `None` trusts everyone who can reach the port, like a bare `--server-bind`.
+	credential: Option<String>,
+
+	/// The dial template, per-peer fingerprint applied on top.
+	client: moq_native::ClientConfig,
+}
+
+impl Lan {
+	/// Advertise `server` on the LAN and start browsing for peers.
+	///
+	/// Binds nothing itself: the listener is the one `--server-bind` already
+	/// configured, so peers and ordinary clients share a port and a certificate.
+	/// Returns the live [`mdns::Discovery`] alongside, so a bind or mDNS failure
+	/// surfaces before readiness is signaled and [`run`](Self::run) can consume it.
+	pub fn start(
+		args: &Args,
+		origin: moq_net::origin::Producer,
+		server: &moq_native::Server,
+		mut client: moq_native::ClientConfig,
+	) -> anyhow::Result<(Self, mdns::Discovery)> {
+		let port = server
+			.local_addr()
+			.context("--cluster-lan needs a QUIC listener")?
+			.port();
+
+		let mut config = mdns::Config::new(port);
+		// Peers pin this instead of validating against a certificate authority,
+		// which is what lets a generated certificate work with no setup at all.
+		if let Some(fingerprint) = server.certificates().fingerprints().into_iter().next() {
+			config = config.with_fingerprint(fingerprint);
+		}
+		if let Some(secret) = args.secret()? {
+			config = config.with_secret(secret);
+		}
+
+		// A peer that is still advertising is still wanted, however long it has
+		// been unreachable; mDNS expiry is what ends a dial, not a retry budget.
+		client.backoff.timeout = Some(std::time::Duration::ZERO);
+
+		let discovery = config.advertise()?;
+		let credential = discovery.credential().map(str::to_string);
+		Ok((
+			Self {
+				origin,
+				credential,
+				client,
+			},
+			discovery,
+		))
+	}
+
+	/// Whether `request` is a mesh dial rather than an ordinary client.
+	pub fn is_peer(&self, request: &moq_native::Request) -> bool {
+		split_credential(request.path()).0 == MESH_PATH
+	}
+
+	/// Authorize an inbound mesh dial and attach it to the origin in both
+	/// directions, returning once the session closes.
+	pub async fn accept(&self, request: moq_native::Request) -> anyhow::Result<()> {
+		if !self.authorized(request.path()) {
+			request.close(403).await.ok();
+			anyhow::bail!("LAN peer did not present this listener's membership proof");
+		}
+
+		let session = request
+			.with_publisher(&self.origin)
+			.with_subscriber(self.origin.clone())
+			.ok()
+			.await?;
+		tracing::info!("accepted LAN peer");
+		Err(session.closed().await.into())
+	}
+
+	/// Whether an inbound dial proved membership, if there is anything to prove.
+	fn authorized(&self, path: &str) -> bool {
+		match &self.credential {
+			None => true,
+			Some(expected) => match split_credential(path) {
+				(MESH_PATH, Some(presented)) => mdns::ct_eq(expected, presented),
+				_ => false,
+			},
+		}
+	}
+
+	/// Discover peers and keep one session alive to each until discovery stops.
+	///
+	/// Both sides of a pair see each other and a MoQ session is bidirectional, so
+	/// only the lower identity dials ([`mdns::Discovery::should_dial`]); the other
+	/// waits in [`accept`](Self::accept).
+	pub async fn run(self, mut discovery: mdns::Discovery) -> anyhow::Result<()> {
+		// Each entry is a reconnect loop; dropping it closes the session and stops
+		// retrying, so the map is the whole lifecycle.
+		let mut dials: HashMap<String, Dial> = HashMap::new();
+
+		while let Some(event) = discovery.recv().await {
+			match event {
+				mdns::Event::Found(peer) => {
+					if !discovery.should_dial(&peer.id) {
+						continue;
+					}
+					match dials.get(&peer.id) {
+						// A periodic re-resolve with the same details; the dial stands.
+						Some(dial) if dial.peer == peer => continue,
+						// New addresses, port, or certificate. The old loop would retry
+						// stale details forever, so replace it.
+						Some(_) => tracing::info!(peer = %peer.id, "LAN peer re-advertised; redialing"),
+						None => tracing::info!(peer = %peer.id, "discovered LAN peer; dialing"),
+					}
+					match self.dial(&peer) {
+						Ok(connection) => {
+							dials.insert(peer.id.clone(), Dial { connection, peer });
+						}
+						Err(err) => {
+							// The advertisement the old loop was started from is gone, so
+							// leaving it in place would retry a stale address forever.
+							dials.remove(&peer.id);
+							tracing::warn!(%err, peer = %peer.id, "failed to dial LAN peer");
+						}
+					}
+				}
+				mdns::Event::Lost(id) => {
+					if dials.remove(&id).is_some() {
+						tracing::info!(peer = %id, "LAN peer expired; dropping dial");
+					}
+				}
+				_ => continue,
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Start a reconnecting session to one peer.
+	fn dial(&self, peer: &mdns::Peer) -> anyhow::Result<moq_native::Connection> {
+		// Every advertised address is a candidate: only the peer's own routing table
+		// knows which of them reaches it from here. A peer that advertised nothing
+		// reachable has nothing to dial, which `Addrs` makes us handle here rather
+		// than inside a connection that would retry an empty list.
+		let addrs = moq_native::Addrs::collect(self.dial_urls(peer)).context("peer advertised no reachable address")?;
+
+		let mut config = self.client.clone();
+		// A peer that advertised a fingerprint serves a generated certificate, so
+		// the relay's CA roots and client certificate say nothing about it. Pinning
+		// the advertised fingerprint is the whole trust decision, and combining it
+		// with roots is rejected outright, so start from a clean TLS config.
+		if let Some(fingerprint) = &peer.fingerprint {
+			config.tls = moq_native::tls::Client::default();
+			config.tls.fingerprint = vec![fingerprint.clone()];
+		}
+
+		let client = config
+			.init()?
+			.with_publisher(&self.origin)
+			.with_subscriber(self.origin.clone());
+		Ok(client.connect(addrs))
+	}
+
+	/// Every URL worth trying for `peer`, each carrying the membership proof.
+	///
+	/// The proof is [`mdns::Peer::credential`], which discovery derived from that
+	/// peer's own advertisement. It authenticates to that listener and nowhere
+	/// else, so an impostor that got itself dialed learns nothing it can reuse.
+	fn dial_urls(&self, peer: &mdns::Peer) -> Vec<Url> {
+		peer.urls()
+			.into_iter()
+			.map(|mut url| {
+				// A peer that advertised a canonical node URL is reachable by name
+				// and brings its own path; only a bare LAN socket gets the marker.
+				if peer.node.is_none() {
+					url.set_path(&match &peer.credential {
+						Some(credential) => format!("{MESH_PATH}/{credential}"),
+						None => MESH_PATH.to_string(),
+					});
+				}
+				url
+			})
+			.collect()
+	}
+}
+
+/// Split a mesh request path into its marker prefix and the credential it carries.
+fn split_credential(request: &str) -> (&str, Option<&str>) {
+	let Some(rest) = request.strip_prefix(MESH_PATH) else {
+		return (request, None);
+	};
+	match rest {
+		"" => (MESH_PATH, None),
+		// Only a path segment boundary counts, so `/.clusterish` is not the marker.
+		_ => match rest.strip_prefix('/') {
+			Some("") | None => (request, None),
+			Some(credential) => (MESH_PATH, Some(credential)),
+		},
+	}
+}
+
+/// Accept inbound sessions, splitting mesh peers off from ordinary clients.
+///
+/// Both share one listener, so a peer and a viewer reach this process the same
+/// way; only the request path tells them apart. Without a mesh,
+/// [`moq_native::Server::serve_publish`] and its sibling already do the ordinary
+/// half, so this exists only to interleave the two.
+pub async fn serve(
+	mut server: moq_native::Server,
+	lan: Lan,
+	origin: moq_net::origin::Producer,
+	direction: crate::Direction,
+) -> anyhow::Result<()> {
+	let mut tasks = tokio::task::JoinSet::new();
+
+	while let Some(request) = server.accept().await {
+		// Reap before dispatching, so a listener that only ever sees mesh peers
+		// still drains: their branch returns early.
+		while tasks.try_join_next().is_some() {}
+
+		if lan.is_peer(&request) {
+			let lan = lan.clone();
+			tasks.spawn(async move {
+				if let Err(err) = lan.accept(request).await {
+					tracing::warn!(%err, "LAN peer session ended");
+				}
+			});
+			continue;
+		}
+
+		let request = match direction {
+			crate::Direction::Import => request.with_publisher(origin.consume()),
+			crate::Direction::Export => request.with_subscriber(origin.clone()),
+		};
+		tasks.spawn(async move {
+			let err = match request.ok().await {
+				Ok(session) => session.closed().await.into(),
+				Err(err) => err,
+			};
+			tracing::warn!(%err, "session ended with error");
+		});
+	}
+
+	Ok(())
+}
+
+/// One peer's reconnect loop, plus the advertisement it was started from so a
+/// refreshed advertisement can be told apart from a periodic re-resolve.
+struct Dial {
+	/// Dropped when the peer is lost or re-advertises, which closes the session.
+	#[allow(dead_code, reason = "held to keep the reconnect loop alive")]
+	connection: moq_native::Connection,
+	peer: mdns::Peer,
+}
+
+/// The `--cluster-lan` flags.
+#[derive(clap::Args, Clone, Default)]
+pub struct Args {
+	/// Discover and mesh with every other participating MoQ process on the LAN
+	/// via mDNS: no relay, internet, or certificate setup needed. Reuses the
+	/// --server-bind listener, defaulting it to an ephemeral port with a
+	/// generated certificate. Composes with --client-connect, e.g. mesh locally
+	/// while a relay serves external viewers.
+	#[arg(
+		id = "cluster-lan",
+		long = "cluster-lan",
+		env = "MOQ_CLUSTER_LAN",
+		help_heading = "Cluster",
+		default_missing_value = "true",
+		num_args = 0..=1,
+		require_equals = true,
+	)]
+	pub enabled: Option<bool>,
+
+	/// Restrict the LAN mesh to peers holding this key, as 64 hexadecimal
+	/// characters or a path containing them. Every peer needs the same value, and
+	/// peers without it are mutually invisible.
+	///
+	/// Without it, anyone who can reach the listener joins, so leave it unset only
+	/// on networks you trust. A missing file is an error, never generated.
+	#[arg(
+		id = "cluster-lan-secret",
+		long = "cluster-lan-secret",
+		env = "MOQ_CLUSTER_LAN_SECRET",
+		help_heading = "Cluster",
+		requires = "cluster-lan",
+		value_name = "HEX_OR_PATH"
+	)]
+	pub secret: Option<String>,
+}
+
+impl Args {
+	/// Whether `--cluster-lan` asked for the mesh.
+	pub fn enabled(&self) -> bool {
+		self.enabled.unwrap_or(false)
+	}
+
+	/// Reject a secret configured without the mesh that would read it.
+	pub fn validate(&self) -> anyhow::Result<()> {
+		anyhow::ensure!(
+			self.secret.is_none() || self.enabled(),
+			"--cluster-lan-secret requires --cluster-lan=true"
+		);
+		Ok(())
+	}
+
+	/// The configured key, read from the value itself or the file it names.
+	pub fn secret(&self) -> anyhow::Result<Option<mdns::Secret>> {
+		self.secret
+			.as_deref()
+			.map(mdns::Secret::load)
+			.transpose()
+			.context("invalid --cluster-lan-secret")
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+	const KEY: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+	#[test]
+	fn split_credential_separates_the_marker_from_the_proof() {
+		assert_eq!(split_credential("/.cluster"), ("/.cluster", None));
+		assert_eq!(split_credential("/.cluster/"), ("/.cluster/", None));
+		assert_eq!(split_credential("/.cluster/abc"), ("/.cluster", Some("abc")));
+		assert_eq!(split_credential("/room"), ("/room", None));
+		// A path that merely starts with the marker's letters is not the marker.
+		assert_eq!(split_credential("/.clusterish/abc"), ("/.clusterish/abc", None));
+	}
+
+	fn lan(credential: Option<&str>) -> Lan {
+		Lan {
+			origin: moq_net::Origin::random().produce(),
+			credential: credential.map(str::to_string),
+			client: moq_native::ClientConfig::default(),
+		}
+	}
+
+	/// Without a secret the mesh is open, matching a bare `--server-bind`. With
+	/// one, only this listener's own proof gets in.
+	#[test]
+	fn authorized_requires_the_proof_only_when_a_secret_is_set() {
+		assert!(lan(None).authorized(MESH_PATH));
+		assert!(lan(None).authorized("/.cluster/anything"));
+
+		let closed = lan(Some("expected-proof"));
+		assert!(closed.authorized("/.cluster/expected-proof"));
+		assert!(!closed.authorized(MESH_PATH), "a missing proof must be rejected");
+		assert!(!closed.authorized("/.cluster/other-proof"));
+		assert!(!closed.authorized("/.cluster/expected-proof-plus"));
+		assert!(!closed.authorized("/room"));
+	}
+
+	/// The dial presents the proof discovery derived from that peer's own
+	/// advertisement, at every address the peer offered.
+	#[test]
+	fn dial_urls_carry_the_proof_to_every_address() {
+		let lan = lan(Some("ours"));
+
+		let socket = mdns::Peer {
+			id: "peer".into(),
+			addrs: ["192.168.1.5:4443", "127.0.0.1:4443"]
+				.into_iter()
+				.map(|addr| addr.parse().expect("valid address"))
+				.collect(),
+			fingerprint: Some("abcd".into()),
+			node: None,
+			credential: Some("theirs".into()),
+		};
+		let urls: Vec<String> = lan.dial_urls(&socket).into_iter().map(String::from).collect();
+		assert_eq!(
+			urls,
+			[
+				"moqt://192.168.1.5:4443/.cluster/theirs",
+				"moqt://127.0.0.1:4443/.cluster/theirs",
+			],
+			"the peer's own proof, at each candidate, loopback last"
+		);
+
+		// A node URL is dialed exactly as advertised.
+		let node = mdns::Peer {
+			id: "peer".into(),
+			addrs: vec![],
+			fingerprint: None,
+			node: Some("https://relay.example.com/anon".parse().expect("valid url")),
+			credential: Some("theirs".into()),
+		};
+		assert_eq!(lan.dial_urls(&node)[0].path(), "/anon");
+	}
+
+	/// A pinned peer ignores the CA roots configured for `--client-connect`:
+	/// combining the two is rejected outright, and they say nothing about a
+	/// generated certificate anyway.
+	#[tokio::test]
+	async fn pinning_a_peer_drops_the_relay_roots() {
+		let mut client = moq_native::ClientConfig::default();
+		client.tls.root = vec!["ca.pem".into()];
+		let mut lan = lan(None);
+		lan.client = client;
+
+		let peer = mdns::Peer {
+			id: "peer".into(),
+			addrs: vec!["127.0.0.1:4443".parse().expect("valid address")],
+			fingerprint: Some("00".repeat(32)),
+			node: None,
+			credential: None,
+		};
+		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+		lan.dial(&peer).expect("a pinned dial must not inherit the CA roots");
+	}
+
+	#[test]
+	fn secret_reads_hex_or_a_file() {
+		let args = Args {
+			enabled: Some(true),
+			secret: Some(KEY.to_string()),
+		};
+		assert!(args.secret().expect("valid hex").is_some());
+		assert!(args.validate().is_ok());
+
+		let file = tempfile::NamedTempFile::new().expect("temp file");
+		std::fs::write(file.path(), format!("{KEY}\n")).expect("write");
+		let args = Args {
+			enabled: Some(true),
+			secret: Some(file.path().to_str().expect("utf-8").to_string()),
+		};
+		assert!(args.secret().expect("valid file").is_some());
+
+		let args = Args {
+			enabled: Some(true),
+			secret: Some("definitely-missing-key".to_string()),
+		};
+		// The message has to cover both readings: a mistyped inline key looks
+		// exactly like a path that isn't there.
+		let err = format!("{:#}", args.secret().unwrap_err());
+		assert!(err.contains("64 hexadecimal characters"), "{err}");
+		assert!(err.contains("definitely-missing-key"), "{err}");
+
+		// A secret nothing would read is an error, not a silently ignored flag.
+		let args = Args {
+			enabled: Some(false),
+			secret: Some(KEY.to_string()),
+		};
+		assert!(args.validate().unwrap_err().to_string().contains("--cluster-lan=true"));
+	}
+
+	/// Bind a listener the way `--cluster-lan` does, returning it plus the peer
+	/// record mDNS would have produced for it.
+	fn listener() -> (moq_native::Server, mdns::Peer) {
+		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+		let mut config = moq_native::ServerConfig::default();
+		config.bind = Some("127.0.0.1:0".to_string());
+		config.tls.generate = vec!["moq-cluster-lan".to_string()];
+		let server = config.init().expect("failed to bind listener");
+
+		let port = server.local_addr().expect("no local addr").port();
+		let fingerprint = server
+			.certificates()
+			.fingerprints()
+			.into_iter()
+			.next()
+			.expect("no fingerprint");
+		let peer = mdns::Peer {
+			id: "peer".into(),
+			addrs: vec![format!("127.0.0.1:{port}").parse().expect("valid address")],
+			fingerprint: Some(fingerprint),
+			node: None,
+			credential: None,
+		};
+		(server, peer)
+	}
+
+	/// One mesh session carries both directions: a broadcast published on either
+	/// side's origin is announced on the other. Wires `serve` to `dial` directly,
+	/// so the test needs no multicast and stays CI-safe.
+	#[tokio::test]
+	async fn session_shares_origin_bidirectionally() {
+		let origin_a = moq_net::Origin::random().produce();
+		let origin_b = moq_net::Origin::random().produce();
+
+		// Published before the session exists; announcements flow once it connects.
+		let _from_a = origin_a
+			.create_broadcast("from-a", moq_net::broadcast::Route::new().with_announce(true))
+			.expect("failed to create broadcast");
+
+		let (server, peer) = listener();
+		let mut accept = lan(None);
+		accept.origin = origin_b.clone();
+		// The mesh shares the listener with ordinary clients, so go through the
+		// same dispatch `--cluster-lan` installs rather than calling `accept`.
+		tokio::spawn(serve(server, accept, origin_b.clone(), crate::Direction::Import));
+
+		let mut dialer = lan(None);
+		dialer.origin = origin_a.clone();
+		let _dial = dialer.dial(&peer).expect("dial");
+
+		let mut announced_on_b = origin_b.consume().announced();
+		let update = tokio::time::timeout(TIMEOUT, announced_on_b.next())
+			.await
+			.expect("timed out waiting for announcement")
+			.expect("origin closed");
+		assert_eq!(update.path.as_str(), "from-a");
+
+		// And the reverse direction over the same session. This stream replays a's
+		// own "from-a" first, so read until the remote broadcast shows up.
+		let _from_b = origin_b
+			.create_broadcast("from-b", moq_net::broadcast::Route::new().with_announce(true))
+			.expect("failed to create broadcast");
+		let mut announced_on_a = origin_a.consume().announced();
+		loop {
+			let update = tokio::time::timeout(TIMEOUT, announced_on_a.next())
+				.await
+				.expect("timed out waiting for announcement")
+				.expect("origin closed");
+			if update.path.as_str() == "from-b" {
+				break;
+			}
+		}
+	}
+
+	/// A dial that cannot produce this listener's proof is rejected before the
+	/// origin is attached: reaching the listener is not membership.
+	#[tokio::test]
+	async fn mesh_rejects_a_dial_without_the_proof() {
+		let origin_a = moq_net::Origin::random().produce();
+		let origin_b = moq_net::Origin::random().produce();
+		let _from_b = origin_b
+			.create_broadcast("from-b", moq_net::broadcast::Route::new().with_announce(true))
+			.expect("failed to create broadcast");
+
+		let (server, peer) = listener();
+		let mut accept = lan(Some("the-real-proof"));
+		accept.origin = origin_b.clone();
+		tokio::spawn(serve(server, accept, origin_b.clone(), crate::Direction::Import));
+
+		// A peer that reached the port but never saw a verifiable advertisement.
+		let mut dialer = lan(None);
+		dialer.origin = origin_a.clone();
+		let _dial = dialer.dial(&peer).expect("dial");
+
+		// Nothing is ever announced, because the session is closed at authorization.
+		let mut announced_on_a = origin_a.consume().announced();
+		let update = tokio::time::timeout(std::time::Duration::from_secs(2), announced_on_a.next()).await;
+		assert!(update.is_err(), "an unauthorized peer must not share broadcasts");
+	}
+}

--- a/rs/moq-cli/src/cluster.rs
+++ b/rs/moq-cli/src/cluster.rs
@@ -21,6 +21,27 @@ use url::Url;
 /// than an ordinary publisher or viewer on the same listener.
 const MESH_PATH: &str = "/.cluster";
 
+/// Whether a protocol version carries the request path used to mark a mesh dial.
+fn carries_request_path(version: &moq_net::Version) -> bool {
+	!version.is_lite() || version.code() >= 0xff0dad05
+}
+
+/// Reject version restrictions that leave the mesh with no request path.
+pub(crate) fn validate_versions(
+	client: &moq_native::ClientConfig,
+	server: &moq_native::ServerConfig,
+) -> anyhow::Result<()> {
+	let client = client.versions();
+	let server = server.versions();
+	anyhow::ensure!(
+		client
+			.iter()
+			.any(|version| carries_request_path(version) && server.contains(version)),
+		"--cluster-lan needs --client-version and --server-version to share a version that carries a request path (moq-lite-05 or any moq-transport version)"
+	);
+	Ok(())
+}
+
 /// The LAN mesh policy: dial every discovered peer, accept the ones that prove
 /// membership.
 ///
@@ -79,6 +100,15 @@ impl Lan {
 		// nonzero `--client-bind` means the second peer (or the first, when
 		// `--client-connect` already owns it) fails with EADDRINUSE.
 		client.bind.set_port(0);
+		// The membership proof rides in the request path. Legacy moq-lite versions
+		// ignore that path, so they cannot be offered by a mesh dial even when the
+		// same client config also serves an ordinary relay connection.
+		client.version = client
+			.versions()
+			.iter()
+			.filter(|version| carries_request_path(version))
+			.copied()
+			.collect();
 
 		let discovery = config.advertise().await?;
 		let credential = discovery.credential().map(str::to_string);

--- a/rs/moq-cli/src/cluster.rs
+++ b/rs/moq-cli/src/cluster.rs
@@ -69,6 +69,16 @@ impl Lan {
 		// A peer that is still advertising is still wanted, however long it has
 		// been unreachable; mDNS expiry is what ends a dial, not a retry budget.
 		client.backoff.timeout = Some(std::time::Duration::ZERO);
+		// Whatever `--client-reconnect` means for the relay dial, a mesh dial has to
+		// keep redialing: the map is keyed on the advertisement, so a one-shot handle
+		// that stopped after the first session would sit there dead until mDNS
+		// expired the peer and re-reported it.
+		client.reconnect = Some(true);
+		// Each peer gets its own client, so they cannot all share one fixed port.
+		// Keep the configured interface and let the OS pick the port, otherwise a
+		// nonzero `--client-bind` means the second peer (or the first, when
+		// `--client-connect` already owns it) fails with EADDRINUSE.
+		client.bind.set_port(0);
 
 		let discovery = config.advertise().await?;
 		let credential = discovery.credential().map(str::to_string);
@@ -237,6 +247,7 @@ pub async fn serve(
 	lan: Lan,
 	origin: moq_net::origin::Producer,
 	direction: crate::Direction,
+	public: bool,
 ) -> anyhow::Result<()> {
 	let mut tasks = tokio::task::JoinSet::new();
 
@@ -252,6 +263,17 @@ pub async fn serve(
 					tracing::warn!(%err, "LAN peer session ended");
 				}
 			});
+			continue;
+		}
+
+		// The mesh's own listener is not a public one. `--cluster-lan` fills in
+		// `--server-bind` when it is unset, so a user who asked only to mesh never
+		// asked to serve viewers, and the membership proof gates the mesh path
+		// alone. Attaching an unauthenticated stranger to the origin here would
+		// hand them exactly what the secret is meant to withhold.
+		if !public {
+			tracing::debug!(path = %request.path(), "refusing a non-peer request on the LAN mesh listener");
+			request.close(404).await.ok();
 			continue;
 		}
 
@@ -436,7 +458,9 @@ mod tests {
 			credential: None,
 		};
 		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-		lan.dial(&peer).expect("a pinned dial must not inherit the CA roots");
+		// Held rather than dropped: the dial is what's under test, and dropping the
+		// connection would abort it before the assertion means anything.
+		let _connection = lan.dial(&peer).expect("a pinned dial must not inherit the CA roots");
 	}
 
 	#[test]
@@ -519,7 +543,7 @@ mod tests {
 		accept.origin = origin_b.clone();
 		// The mesh shares the listener with ordinary clients, so go through the
 		// same dispatch `--cluster-lan` installs rather than calling `accept`.
-		tokio::spawn(serve(server, accept, origin_b.clone(), crate::Direction::Import));
+		tokio::spawn(serve(server, accept, origin_b.clone(), crate::Direction::Import, false));
 
 		let mut dialer = lan(None);
 		dialer.origin = origin_a.clone();
@@ -562,7 +586,7 @@ mod tests {
 		let (server, peer) = listener();
 		let mut accept = lan(Some("the-real-proof"));
 		accept.origin = origin_b.clone();
-		tokio::spawn(serve(server, accept, origin_b.clone(), crate::Direction::Import));
+		tokio::spawn(serve(server, accept, origin_b.clone(), crate::Direction::Import, false));
 
 		// A peer that reached the port but never saw a verifiable advertisement.
 		let mut dialer = lan(None);
@@ -573,5 +597,48 @@ mod tests {
 		let mut announced_on_a = origin_a.consume().announced();
 		let update = tokio::time::timeout(std::time::Duration::from_secs(2), announced_on_a.next()).await;
 		assert!(update.is_err(), "an unauthorized peer must not share broadcasts");
+	}
+
+	/// A listener `--cluster-lan` invented is for the mesh, not for viewers.
+	///
+	/// The membership proof only gates the `/.cluster` path, so an ordinary path
+	/// used to skip authorization entirely and be attached to the origin: someone
+	/// who found the advertised ephemeral port could read an `import` or publish
+	/// into an `export` without the secret, which is what the secret is for. A
+	/// user who passed `--server-bind` did ask to serve, so that case still does.
+	#[tokio::test]
+	async fn a_mesh_only_listener_refuses_ordinary_clients() {
+		let origin = moq_net::Origin::random().produce();
+		let _published = origin
+			.create_broadcast("secret-stream", moq_net::broadcast::Route::new().with_announce(true))
+			.expect("failed to create broadcast");
+
+		let (server, peer) = listener();
+		let mut accept = lan(Some("the-real-proof"));
+		accept.origin = origin.clone();
+		// `public: false` is what `--cluster-lan` passes with no `--server-bind`.
+		tokio::spawn(serve(server, accept, origin.clone(), crate::Direction::Import, false));
+
+		// An ordinary client: no mesh marker, no proof, just the advertised port.
+		let mut config = moq_native::ClientConfig::default();
+		config.tls = moq_native::tls::Client::default();
+		config.tls.fingerprint = vec![peer.fingerprint.clone().expect("fingerprint")];
+		config.reconnect = Some(false);
+		let stolen = moq_net::Origin::random().produce();
+		let url = peer.urls().into_iter().next().expect("an address");
+		let connection = config
+			.init()
+			.expect("client")
+			.with_subscriber(stolen.clone())
+			.connect(url);
+
+		// The broadcast must never reach them.
+		let mut announced = stolen.consume().announced();
+		let update = tokio::time::timeout(std::time::Duration::from_secs(2), announced.next()).await;
+		assert!(
+			update.is_err(),
+			"a mesh-only listener must not serve broadcasts to an unauthenticated client"
+		);
+		drop(connection);
 	}
 }

--- a/rs/moq-cli/src/cluster.rs
+++ b/rs/moq-cli/src/cluster.rs
@@ -170,7 +170,11 @@ impl Lan {
 			}
 		}
 
-		Ok(())
+		// Discovery only ends if the daemon or its channel died, which is a failure
+		// rather than a finished job: `drive` returns on the first task to report
+		// `Ok(())`, so returning success here would exit an otherwise healthy
+		// process with status zero and take the media tasks down with it.
+		anyhow::bail!("LAN discovery stopped unexpectedly");
 	}
 
 	/// Start a reconnecting session to one peer.
@@ -290,7 +294,10 @@ pub async fn serve(
 		});
 	}
 
-	Ok(())
+	// Same reasoning as `Lan::run`: the accept loop only ends if the listener is
+	// gone, and reporting that as success would exit the process cleanly. A
+	// shutdown never gets here, since `drive` returns on the signal task instead.
+	anyhow::bail!("the MoQ listener stopped accepting");
 }
 
 /// One peer's reconnect loop, plus the advertisement it was started from so a

--- a/rs/moq-cli/src/cluster.rs
+++ b/rs/moq-cli/src/cluster.rs
@@ -45,7 +45,7 @@ impl Lan {
 	/// configured, so peers and ordinary clients share a port and a certificate.
 	/// Returns the live [`mdns::Discovery`] alongside, so a bind or mDNS failure
 	/// surfaces before readiness is signaled and [`run`](Self::run) can consume it.
-	pub fn start(
+	pub async fn start(
 		args: &Args,
 		origin: moq_net::origin::Producer,
 		server: &moq_native::Server,
@@ -70,7 +70,7 @@ impl Lan {
 		// been unreachable; mDNS expiry is what ends a dial, not a retry budget.
 		client.backoff.timeout = Some(std::time::Duration::ZERO);
 
-		let discovery = config.advertise()?;
+		let discovery = config.advertise().await?;
 		let credential = discovery.credential().map(str::to_string);
 		Ok((
 			Self {

--- a/rs/moq-cli/src/cluster.rs
+++ b/rs/moq-cli/src/cluster.rs
@@ -51,9 +51,9 @@ pub struct Lan {
 	/// Published to and ingested from every peer, so all of them converge.
 	origin: moq_net::origin::Producer,
 
-	/// The proof an inbound peer must present, mirroring what we advertised.
-	/// `None` trusts everyone who can reach the port, like a bare `--server-bind`.
-	credential: Option<String>,
+	/// The per-advertisement credential an inbound peer must present.
+	/// Without a secret this is public and prevents path collisions, not access.
+	credential: String,
 
 	/// The dial template, per-peer fingerprint applied on top.
 	client: moq_native::ClientConfig,
@@ -64,7 +64,7 @@ struct DialTarget {
 	urls: Vec<Url>,
 	has_node: bool,
 	fingerprint: Option<String>,
-	credential: Option<String>,
+	credential: String,
 }
 
 impl From<&mdns::Peer> for DialTarget {
@@ -130,7 +130,7 @@ impl Lan {
 			.collect();
 
 		let discovery = config.advertise().await?;
-		let credential = discovery.credential().map(str::to_string);
+		let credential = discovery.credential().to_string();
 		Ok((
 			Self {
 				origin,
@@ -143,7 +143,7 @@ impl Lan {
 
 	/// Whether `request` is a mesh dial rather than an ordinary client.
 	pub fn is_peer(&self, request: &moq_native::Request) -> bool {
-		split_credential(request.path()).0 == MESH_PATH
+		self.authorized(request.path())
 	}
 
 	/// Authorize an inbound mesh dial and attach it to the origin in both
@@ -163,14 +163,11 @@ impl Lan {
 		Err(session.closed().await.into())
 	}
 
-	/// Whether an inbound dial proved membership, if there is anything to prove.
+	/// Whether an inbound dial presented this advertisement's credential.
 	fn authorized(&self, path: &str) -> bool {
-		match &self.credential {
-			None => true,
-			Some(expected) => match split_credential(path) {
-				(MESH_PATH, Some(presented)) => mdns::ct_eq(expected, presented),
-				_ => false,
-			},
+		match split_credential(path) {
+			(MESH_PATH, Some(presented)) => mdns::ct_eq(&self.credential, presented),
+			_ => false,
 		}
 	}
 
@@ -258,9 +255,9 @@ impl Lan {
 
 	/// Every URL worth trying for `peer`, each carrying the membership proof.
 	///
-	/// The proof is [`mdns::Peer::credential`], which discovery derived from that
-	/// peer's own advertisement. It authenticates to that listener and nowhere
-	/// else, so an impostor that got itself dialed learns nothing it can reuse.
+	/// The credential is [`mdns::Peer::credential`], which discovery derived from
+	/// that peer's own advertisement. With a secret it authenticates to that
+	/// listener and nowhere else; without one it is only a collision-proof marker.
 	fn dial_urls(&self, peer: &DialTarget) -> Vec<Url> {
 		peer.urls
 			.iter()
@@ -269,10 +266,7 @@ impl Lan {
 				// A peer that advertised a canonical node URL is reachable by name
 				// and brings its own path; only a bare LAN socket gets the marker.
 				if !peer.has_node {
-					url.set_path(&match &peer.credential {
-						Some(credential) => format!("{MESH_PATH}/{credential}"),
-						None => MESH_PATH.to_string(),
-					});
+					url.set_path(&format!("{MESH_PATH}/{}", peer.credential));
 				}
 				url
 			})
@@ -442,22 +436,18 @@ mod tests {
 		assert_eq!(split_credential("/.clusterish/abc"), ("/.clusterish/abc", None));
 	}
 
-	fn lan(credential: Option<&str>) -> Lan {
+	fn lan(credential: &str) -> Lan {
 		Lan {
 			origin: moq_net::Origin::random().produce(),
-			credential: credential.map(str::to_string),
+			credential: credential.to_string(),
 			client: moq_native::ClientConfig::default(),
 		}
 	}
 
-	/// Without a secret the mesh is open, matching a bare `--server-bind`. With
-	/// one, only this listener's own proof gets in.
+	/// Only this listener's per-advertisement credential gets in.
 	#[test]
-	fn authorized_requires_the_proof_only_when_a_secret_is_set() {
-		assert!(lan(None).authorized(MESH_PATH));
-		assert!(lan(None).authorized("/.cluster/anything"));
-
-		let closed = lan(Some("expected-proof"));
+	fn authorized_requires_the_advertised_credential() {
+		let closed = lan("expected-proof");
 		assert!(closed.authorized("/.cluster/expected-proof"));
 		assert!(!closed.authorized(MESH_PATH), "a missing proof must be rejected");
 		assert!(!closed.authorized("/.cluster/other-proof"));
@@ -469,7 +459,7 @@ mod tests {
 	/// advertisement, at every address the peer offered.
 	#[test]
 	fn dial_urls_carry_the_proof_to_every_address() {
-		let lan = lan(Some("ours"));
+		let lan = lan("ours");
 
 		let socket = DialTarget {
 			urls: ["moqt://192.168.1.5:4443", "moqt://127.0.0.1:4443"]
@@ -478,7 +468,7 @@ mod tests {
 				.collect(),
 			has_node: false,
 			fingerprint: Some("abcd".into()),
-			credential: Some("theirs".into()),
+			credential: "theirs".into(),
 		};
 		let urls: Vec<String> = lan.dial_urls(&socket).into_iter().map(String::from).collect();
 		assert_eq!(
@@ -495,7 +485,7 @@ mod tests {
 			urls: vec!["https://relay.example.com/anon".parse().expect("valid url")],
 			has_node: true,
 			fingerprint: None,
-			credential: Some("theirs".into()),
+			credential: "theirs".into(),
 		};
 		assert_eq!(lan.dial_urls(&node)[0].path(), "/anon");
 	}
@@ -507,14 +497,14 @@ mod tests {
 	async fn pinning_a_peer_drops_the_relay_roots() {
 		let mut client = moq_native::ClientConfig::default();
 		client.tls.root = vec!["ca.pem".into()];
-		let mut lan = lan(None);
+		let mut lan = lan("ours");
 		lan.client = client;
 
 		let peer = DialTarget {
 			urls: vec!["moqt://127.0.0.1:4443".parse().expect("valid url")],
 			has_node: false,
 			fingerprint: Some("00".repeat(32)),
-			credential: None,
+			credential: "theirs".into(),
 		};
 		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 		// Held rather than dropped: the dial is what's under test, and dropping the
@@ -580,7 +570,7 @@ mod tests {
 			urls: vec![format!("moqt://127.0.0.1:{port}").parse().expect("valid url")],
 			has_node: false,
 			fingerprint: Some(fingerprint),
-			credential: None,
+			credential: "listener-proof".into(),
 		};
 		(server, peer)
 	}
@@ -599,13 +589,13 @@ mod tests {
 			.expect("failed to create broadcast");
 
 		let (server, peer) = listener();
-		let mut accept = lan(None);
+		let mut accept = lan("listener-proof");
 		accept.origin = origin_b.clone();
 		// The mesh shares the listener with ordinary clients, so go through the
 		// same dispatch `--cluster-lan` installs rather than calling `accept`.
 		tokio::spawn(serve(server, accept, origin_b.clone(), crate::Direction::Import, false));
 
-		let mut dialer = lan(None);
+		let mut dialer = lan("dialer-proof");
 		dialer.origin = origin_a.clone();
 		let _dial = dialer.dial_target(&peer).expect("dial");
 
@@ -644,12 +634,12 @@ mod tests {
 			.expect("failed to create broadcast");
 
 		let (server, peer) = listener();
-		let mut accept = lan(Some("the-real-proof"));
+		let mut accept = lan("the-real-proof");
 		accept.origin = origin_b.clone();
 		tokio::spawn(serve(server, accept, origin_b.clone(), crate::Direction::Import, false));
 
 		// A peer that reached the port but never saw a verifiable advertisement.
-		let mut dialer = lan(None);
+		let mut dialer = lan("dialer-proof");
 		dialer.origin = origin_a.clone();
 		let _dial = dialer.dial_target(&peer).expect("dial");
 
@@ -674,7 +664,7 @@ mod tests {
 			.expect("failed to create broadcast");
 
 		let (server, peer) = listener();
-		let mut accept = lan(Some("the-real-proof"));
+		let mut accept = lan("the-real-proof");
 		accept.origin = origin.clone();
 		// `public: false` is what `--cluster-lan` passes with no `--server-bind`.
 		tokio::spawn(serve(server, accept, origin.clone(), crate::Direction::Import, false));

--- a/rs/moq-cli/src/cluster.rs
+++ b/rs/moq-cli/src/cluster.rs
@@ -59,6 +59,25 @@ pub struct Lan {
 	client: moq_native::ClientConfig,
 }
 
+/// The discovered details needed to open one LAN dial.
+struct DialTarget {
+	urls: Vec<Url>,
+	has_node: bool,
+	fingerprint: Option<String>,
+	credential: Option<String>,
+}
+
+impl From<&mdns::Peer> for DialTarget {
+	fn from(peer: &mdns::Peer) -> Self {
+		Self {
+			urls: peer.urls(),
+			has_node: peer.node.is_some(),
+			fingerprint: peer.fingerprint.clone(),
+			credential: peer.credential.clone(),
+		}
+	}
+}
+
 impl Lan {
 	/// Advertise `server` on the LAN and start browsing for peers.
 	///
@@ -209,6 +228,11 @@ impl Lan {
 
 	/// Start a reconnecting session to one peer.
 	fn dial(&self, peer: &mdns::Peer) -> anyhow::Result<moq_native::Connection> {
+		self.dial_target(&peer.into())
+	}
+
+	/// Start a reconnecting session from the discovered details needed by a dial.
+	fn dial_target(&self, peer: &DialTarget) -> anyhow::Result<moq_native::Connection> {
 		// Every advertised address is a candidate: only the peer's own routing table
 		// knows which of them reaches it from here. A peer that advertised nothing
 		// reachable has nothing to dial, which `Addrs` makes us handle here rather
@@ -237,13 +261,14 @@ impl Lan {
 	/// The proof is [`mdns::Peer::credential`], which discovery derived from that
 	/// peer's own advertisement. It authenticates to that listener and nowhere
 	/// else, so an impostor that got itself dialed learns nothing it can reuse.
-	fn dial_urls(&self, peer: &mdns::Peer) -> Vec<Url> {
-		peer.urls()
-			.into_iter()
+	fn dial_urls(&self, peer: &DialTarget) -> Vec<Url> {
+		peer.urls
+			.iter()
+			.cloned()
 			.map(|mut url| {
 				// A peer that advertised a canonical node URL is reachable by name
 				// and brings its own path; only a bare LAN socket gets the marker.
-				if peer.node.is_none() {
+				if !peer.has_node {
 					url.set_path(&match &peer.credential {
 						Some(credential) => format!("{MESH_PATH}/{credential}"),
 						None => MESH_PATH.to_string(),
@@ -446,14 +471,13 @@ mod tests {
 	fn dial_urls_carry_the_proof_to_every_address() {
 		let lan = lan(Some("ours"));
 
-		let socket = mdns::Peer {
-			id: "peer".into(),
-			addrs: ["192.168.1.5:4443", "127.0.0.1:4443"]
+		let socket = DialTarget {
+			urls: ["moqt://192.168.1.5:4443", "moqt://127.0.0.1:4443"]
 				.into_iter()
-				.map(|addr| addr.parse().expect("valid address"))
+				.map(|url| url.parse().expect("valid url"))
 				.collect(),
+			has_node: false,
 			fingerprint: Some("abcd".into()),
-			node: None,
 			credential: Some("theirs".into()),
 		};
 		let urls: Vec<String> = lan.dial_urls(&socket).into_iter().map(String::from).collect();
@@ -467,11 +491,10 @@ mod tests {
 		);
 
 		// A node URL is dialed exactly as advertised.
-		let node = mdns::Peer {
-			id: "peer".into(),
-			addrs: vec![],
+		let node = DialTarget {
+			urls: vec!["https://relay.example.com/anon".parse().expect("valid url")],
+			has_node: true,
 			fingerprint: None,
-			node: Some("https://relay.example.com/anon".parse().expect("valid url")),
 			credential: Some("theirs".into()),
 		};
 		assert_eq!(lan.dial_urls(&node)[0].path(), "/anon");
@@ -487,17 +510,18 @@ mod tests {
 		let mut lan = lan(None);
 		lan.client = client;
 
-		let peer = mdns::Peer {
-			id: "peer".into(),
-			addrs: vec!["127.0.0.1:4443".parse().expect("valid address")],
+		let peer = DialTarget {
+			urls: vec!["moqt://127.0.0.1:4443".parse().expect("valid url")],
+			has_node: false,
 			fingerprint: Some("00".repeat(32)),
-			node: None,
 			credential: None,
 		};
 		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 		// Held rather than dropped: the dial is what's under test, and dropping the
 		// connection would abort it before the assertion means anything.
-		let _connection = lan.dial(&peer).expect("a pinned dial must not inherit the CA roots");
+		let _connection = lan
+			.dial_target(&peer)
+			.expect("a pinned dial must not inherit the CA roots");
 	}
 
 	#[test]
@@ -537,7 +561,7 @@ mod tests {
 
 	/// Bind a listener the way `--cluster-lan` does, returning it plus the peer
 	/// record mDNS would have produced for it.
-	fn listener() -> (moq_native::Server, mdns::Peer) {
+	fn listener() -> (moq_native::Server, DialTarget) {
 		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
 		let mut config = moq_native::ServerConfig::default();
@@ -552,11 +576,10 @@ mod tests {
 			.into_iter()
 			.next()
 			.expect("no fingerprint");
-		let peer = mdns::Peer {
-			id: "peer".into(),
-			addrs: vec![format!("127.0.0.1:{port}").parse().expect("valid address")],
+		let peer = DialTarget {
+			urls: vec![format!("moqt://127.0.0.1:{port}").parse().expect("valid url")],
+			has_node: false,
 			fingerprint: Some(fingerprint),
-			node: None,
 			credential: None,
 		};
 		(server, peer)
@@ -584,7 +607,7 @@ mod tests {
 
 		let mut dialer = lan(None);
 		dialer.origin = origin_a.clone();
-		let _dial = dialer.dial(&peer).expect("dial");
+		let _dial = dialer.dial_target(&peer).expect("dial");
 
 		let mut announced_on_b = origin_b.consume().announced();
 		let update = tokio::time::timeout(TIMEOUT, announced_on_b.next())
@@ -628,7 +651,7 @@ mod tests {
 		// A peer that reached the port but never saw a verifiable advertisement.
 		let mut dialer = lan(None);
 		dialer.origin = origin_a.clone();
-		let _dial = dialer.dial(&peer).expect("dial");
+		let _dial = dialer.dial_target(&peer).expect("dial");
 
 		// Nothing is ever announced, because the session is closed at authorization.
 		let mut announced_on_a = origin_a.consume().announced();
@@ -662,7 +685,7 @@ mod tests {
 		config.tls.fingerprint = vec![peer.fingerprint.clone().expect("fingerprint")];
 		config.reconnect = Some(false);
 		let stolen = moq_net::Origin::random().produce();
-		let url = peer.urls().into_iter().next().expect("an address");
+		let url = peer.urls.into_iter().next().expect("an address");
 		let connection = config
 			.init()
 			.expect("client")

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -5,6 +5,8 @@
 //! selected endpoint.
 
 mod args;
+#[cfg(feature = "cluster-lan")]
+mod cluster;
 #[cfg(feature = "capture")]
 mod devices;
 mod hls;
@@ -59,6 +61,84 @@ impl Net {
 		};
 		Ok(server)
 	}
+}
+
+/// Which way media flows, which is what an inbound session is offered.
+#[derive(Clone, Copy)]
+pub enum Direction {
+	/// `import`: clients subscribe to what this process publishes.
+	Import,
+	/// `export`: clients publish into this process's origin.
+	Export,
+}
+
+/// Bind the MoQ listener and spawn everything that serves on it: ordinary
+/// clients, the LAN mesh when `--cluster-lan` is on, and the certificate
+/// endpoint for an explicit `--server-bind`. A no-op with no listener configured.
+///
+/// Readiness is signaled once every attachment is live, so a bind, mDNS, or key
+/// failure surfaces before the process claims to be up.
+fn spawn_server(
+	tasks: &mut JoinSet<anyhow::Result<()>>,
+	moq: &MoqSide,
+	origin: &moq_net::origin::Producer,
+	net: &Net,
+	direction: Direction,
+) -> anyhow::Result<()> {
+	if !moq.serves() {
+		return Ok(());
+	}
+
+	let server = net.server(moq.server_config())?;
+	let certificates = server.certificates();
+
+	#[cfg(feature = "cluster-lan")]
+	let lan = match moq.lan() {
+		true => Some(cluster::Lan::start(
+			&moq.cluster,
+			origin.clone(),
+			&server,
+			moq.client.clone(),
+		)?),
+		false => None,
+	};
+	moq::notify_ready();
+
+	#[cfg(feature = "cluster-lan")]
+	match lan {
+		Some((lan, discovery)) => {
+			tasks.spawn(cluster::serve(server, lan.clone(), origin.clone(), direction));
+			tasks.spawn(lan.run(discovery));
+		}
+		None => spawn_serve(tasks, server, origin, direction),
+	}
+	#[cfg(not(feature = "cluster-lan"))]
+	spawn_serve(tasks, server, origin, direction);
+
+	// The certificate endpoint is for clients dialing a URL, so it follows the
+	// explicit listener rather than the mesh's ephemeral one.
+	if let Some(web_bind) = moq.server.bind.clone() {
+		tasks.spawn(async move { web::run_web(&web_bind, certificates).await });
+	}
+
+	Ok(())
+}
+
+/// Serve ordinary clients with moq-native's own accept loop.
+fn spawn_serve(
+	tasks: &mut JoinSet<anyhow::Result<()>>,
+	server: moq_native::Server,
+	origin: &moq_net::origin::Producer,
+	direction: Direction,
+) {
+	let origin = origin.clone();
+	tasks.spawn(async move {
+		match direction {
+			Direction::Import => server.serve_publish(origin.consume()).await?,
+			Direction::Export => server.serve_consume(origin).await?,
+		}
+		Ok(())
+	});
 }
 
 #[tokio::main]
@@ -165,14 +245,7 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 		}
 		tasks.spawn(async move { Ok(reconnect.closed().await?) });
 	}
-	if let Some(web_bind) = moq.server.bind.clone() {
-		let server = net.server(moq.server.clone())?;
-		let certificates = server.certificates();
-		moq::notify_ready();
-		let origin = origin.consume();
-		tasks.spawn(async move { Ok(server.serve_publish(origin).await?) });
-		tasks.spawn(async move { web::run_web(&web_bind, certificates).await });
-	}
+	spawn_server(&mut tasks, &moq, &origin, &net, Direction::Import)?;
 
 	// Foreign side: the single source.
 	if let Some(format) = import.source.stdin_format() {
@@ -267,14 +340,7 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 		moq::notify_ready();
 		tasks.spawn(async move { Ok(reconnect.closed().await?) });
 	}
-	if let Some(web_bind) = moq.server.bind.clone() {
-		let server = net.server(moq.server.clone())?;
-		let certificates = server.certificates();
-		moq::notify_ready();
-		let origin = origin.clone();
-		tasks.spawn(async move { Ok(server.serve_consume(origin).await?) });
-		tasks.spawn(async move { web::run_web(&web_bind, certificates).await });
-	}
+	spawn_server(&mut tasks, &moq, &origin, &net, Direction::Export)?;
 
 	// Foreign side: the single sink.
 	if let Some((format, max_latency, fragment_duration)) = export.sink.stdout() {

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -102,7 +102,13 @@ async fn spawn_server(
 	#[cfg(feature = "cluster-lan")]
 	match lan {
 		Some((lan, discovery)) => {
-			tasks.spawn(cluster::serve(server, lan.clone(), origin.clone(), direction));
+			tasks.spawn(cluster::serve(
+				server,
+				lan.clone(),
+				origin.clone(),
+				direction,
+				moq.server.bind.is_some(),
+			));
 			tasks.spawn(lan.run(discovery));
 		}
 		None => spawn_serve(tasks, server, origin, direction),

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -76,8 +76,6 @@ pub enum Direction {
 /// clients, the LAN mesh when `--cluster-lan` is on, and the certificate
 /// endpoint for an explicit `--server-bind`. A no-op with no listener configured.
 ///
-/// Readiness is signaled once every attachment is live, so a bind, mDNS, or key
-/// failure surfaces before the process claims to be up.
 async fn spawn_server(
 	tasks: &mut JoinSet<anyhow::Result<()>>,
 	moq: &MoqSide,
@@ -97,8 +95,6 @@ async fn spawn_server(
 		true => Some(cluster::Lan::start(&moq.cluster, origin.clone(), &server, moq.client.clone()).await?),
 		false => None,
 	};
-	moq::notify_ready();
-
 	#[cfg(feature = "cluster-lan")]
 	match lan {
 		Some((lan, discovery)) => {
@@ -236,7 +232,6 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 	if moq.client.connect.is_some()
 		&& let Some(reconnect) = net.client(moq.client.clone())?.publish(origin.consume())
 	{
-		moq::notify_ready();
 		// Read before the handle moves into the task. This consumer is
 		// persistent: it survives reconnects, reading `None` while down, so it
 		// can be wired up before anything connects.
@@ -247,6 +242,10 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 		tasks.spawn(async move { Ok(reconnect.closed().await?) });
 	}
 	spawn_server(&mut tasks, &moq, &origin, &net, Direction::Import).await?;
+	// Every configured MoQ attachment is now initialized. In particular, a
+	// combined client + LAN process must not report ready before the listener and
+	// mDNS announcement have succeeded.
+	moq::notify_ready();
 
 	// Foreign side: the single source.
 	if let Some(format) = import.source.stdin_format() {
@@ -338,10 +337,13 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 	if moq.client.connect.is_some()
 		&& let Some(reconnect) = net.client(moq.client.clone())?.consume(origin.clone())
 	{
-		moq::notify_ready();
 		tasks.spawn(async move { Ok(reconnect.closed().await?) });
 	}
 	spawn_server(&mut tasks, &moq, &origin, &net, Direction::Export).await?;
+	// Every configured MoQ attachment is now initialized. In particular, a
+	// combined client + LAN process must not report ready before the listener and
+	// mDNS announcement have succeeded.
+	moq::notify_ready();
 
 	// Foreign side: the single sink.
 	if let Some((format, max_latency, fragment_duration)) = export.sink.stdout() {

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -78,7 +78,7 @@ pub enum Direction {
 ///
 /// Readiness is signaled once every attachment is live, so a bind, mDNS, or key
 /// failure surfaces before the process claims to be up.
-fn spawn_server(
+async fn spawn_server(
 	tasks: &mut JoinSet<anyhow::Result<()>>,
 	moq: &MoqSide,
 	origin: &moq_net::origin::Producer,
@@ -94,12 +94,7 @@ fn spawn_server(
 
 	#[cfg(feature = "cluster-lan")]
 	let lan = match moq.lan() {
-		true => Some(cluster::Lan::start(
-			&moq.cluster,
-			origin.clone(),
-			&server,
-			moq.client.clone(),
-		)?),
+		true => Some(cluster::Lan::start(&moq.cluster, origin.clone(), &server, moq.client.clone()).await?),
 		false => None,
 	};
 	moq::notify_ready();
@@ -245,7 +240,7 @@ async fn run_import(moq: MoqSide, import: Import, net: Net) -> anyhow::Result<()
 		}
 		tasks.spawn(async move { Ok(reconnect.closed().await?) });
 	}
-	spawn_server(&mut tasks, &moq, &origin, &net, Direction::Import)?;
+	spawn_server(&mut tasks, &moq, &origin, &net, Direction::Import).await?;
 
 	// Foreign side: the single source.
 	if let Some(format) = import.source.stdin_format() {
@@ -340,7 +335,7 @@ async fn run_export(moq: MoqSide, export: Export, net: Net) -> anyhow::Result<()
 		moq::notify_ready();
 		tasks.spawn(async move { Ok(reconnect.closed().await?) });
 	}
-	spawn_server(&mut tasks, &moq, &origin, &net, Direction::Export)?;
+	spawn_server(&mut tasks, &moq, &origin, &net, Direction::Export).await?;
 
 	// Foreign side: the single sink.
 	if let Some((format, max_latency, fragment_duration)) = export.sink.stdout() {

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -29,6 +29,8 @@ qlog = ["quinn?/qlog", "web-transport-noq?/qlog"]
 # are off on each backend dep), so a backend without aws-lc-rs/ring has no initial cipher.
 aws-lc-rs = ["rustls/aws-lc-rs", "rcgen?/aws_lc_rs", "quinn?/rustls-aws-lc-rs", "web-transport-noq?/aws-lc-rs"]
 iroh = ["dep:web-transport-iroh", "dep:web-transport-proto", "dep:noq-proto"]
+# LAN peer discovery over mDNS (the `mdns` module).
+mdns = ["dep:mdns-sd", "dep:hmac", "dep:sha2", "dep:subtle"]
 jemalloc = ["dep:tikv-jemallocator", "dep:tikv-jemalloc-ctl"]
 websocket = ["dep:qmux"]
 # Plain-TCP qmux transport (`tcp://`), no TLS. Server-side and client-side.
@@ -43,8 +45,10 @@ android-logcat = ["dep:tracing-android"]
 clap = { version = "4", features = ["derive", "env"] }
 futures = "0.3"
 hex = "0.4"
+hmac = { workspace = true, optional = true }
 humantime = "2.3"
 humantime-serde = "1.1"
+mdns-sd = { workspace = true, optional = true }
 
 moq-net = { workspace = true }
 # iroh runs on noq but re-exports only the ControllerFactory trait, not the concrete
@@ -65,7 +69,9 @@ rustls-platform-verifier = "0.7"
 rustls-webpki = { version = "0.103", features = ["aws-lc-rs"], optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_with = { version = "3", features = ["hex"] }
+sha2 = { workspace = true, optional = true }
 socket2 = "0.6"
+subtle = { workspace = true, optional = true }
 thiserror = "2"
 tikv-jemalloc-ctl = { version = "0.6", optional = true }
 tikv-jemallocator = { version = "0.6", features = ["profiling", "unprefixed_malloc_on_supported_platforms"], optional = true }

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -105,8 +105,8 @@ libc = "0.2"
 anyhow = "1"
 bytes = "1"
 chrono = "0.4"
-# The channel type `mdns_sd::Receiver` is an alias for, so the mDNS readiness
-# gate can be driven with synthetic daemon events.
+# Use the channel type behind `mdns_sd::Receiver` so the mDNS readiness gate can
+# be driven with synthetic daemon events.
 flume = "0.12"
 rcgen = { version = "0.14", default-features = false, features = ["pem", "aws_lc_rs"] }
 tempfile = "3"

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -105,6 +105,9 @@ libc = "0.2"
 anyhow = "1"
 bytes = "1"
 chrono = "0.4"
+# The channel type `mdns_sd::Receiver` is an alias for, so the mDNS readiness
+# gate can be driven with synthetic daemon events.
+flume = "0.12"
 rcgen = { version = "0.14", default-features = false, features = ["pem", "aws_lc_rs"] }
 tempfile = "3"
 # test-util adds tokio::time::pause/auto-advance for the time-dependent tests.

--- a/rs/moq-native/src/client.rs
+++ b/rs/moq-native/src/client.rs
@@ -1,4 +1,4 @@
-use crate::{Backoff, Connection, Error, GoawayConfig, QuicBackend};
+use crate::{Addrs, Backoff, Connection, Error, GoawayConfig, QuicBackend};
 #[cfg(feature = "websocket")]
 use std::future::Future;
 use std::net;
@@ -359,7 +359,7 @@ impl Client {
 		self
 	}
 
-	/// Open a connection to the given URL.
+	/// Open a connection to the given peer.
 	///
 	/// A background task dials, completes the MoQ handshake, and (by default)
 	/// redials with exponential backoff whenever the session drops. Wait for the
@@ -367,8 +367,13 @@ impl Client {
 	/// with [`Connection::closed`]; drop the last clone to stop it. Disable the
 	/// redialing with [`ClientConfig::reconnect`] / [`Self::with_reconnect`] for
 	/// a one-shot dial.
-	pub fn connect(&self, url: Url) -> Connection {
-		Connection::new(self.clone(), url)
+	///
+	/// Takes a [`Url`] for the usual case of a peer at a known address. Pass
+	/// [`Addrs`] instead when the same peer has several candidate addresses and
+	/// only some of them route from here; each attempt walks them in order and
+	/// keeps the first that connects.
+	pub fn connect(&self, addrs: impl Into<Addrs>) -> Connection {
+		Connection::new(self.clone(), addrs.into())
 	}
 
 	/// Connect to the configured [`ClientConfig::connect`] URL, publishing

--- a/rs/moq-native/src/connect.rs
+++ b/rs/moq-native/src/connect.rs
@@ -1,3 +1,54 @@
+use url::Url;
+
+/// One or more addresses for the same peer, tried in order until one connects.
+///
+/// Most callers have a single URL and never name this type:
+/// [`Client::connect`](crate::Client::connect) takes `impl Into<Addrs>` and the
+/// [`From<Url>`] impl covers it. Several addresses are for a peer that was
+/// discovered rather than configured, where the record lists every interface the
+/// peer answered on and nothing says which of them routes from here.
+///
+/// Non-empty by construction, so a connection always has somewhere to dial.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Addrs(
+	/// Never empty: every constructor takes at least one URL.
+	Vec<Url>,
+);
+
+impl Addrs {
+	/// A peer reachable at one address.
+	pub fn new(url: Url) -> Self {
+		Self(vec![url])
+	}
+
+	/// Add a fallback, tried only when everything before it fails.
+	pub fn or(mut self, url: Url) -> Self {
+		self.0.push(url);
+		self
+	}
+
+	/// Collect addresses in dial order, or `None` when there are none.
+	///
+	/// The `None` is where an empty candidate list has to be dealt with: a peer
+	/// that advertised no reachable address is not something to dial and retry,
+	/// it's something to skip.
+	pub fn collect(urls: impl IntoIterator<Item = Url>) -> Option<Self> {
+		let urls: Vec<Url> = urls.into_iter().collect();
+		(!urls.is_empty()).then_some(Self(urls))
+	}
+
+	/// The addresses, in the order they are dialed. Never empty.
+	pub fn as_slice(&self) -> &[Url] {
+		&self.0
+	}
+}
+
+impl From<Url> for Addrs {
+	fn from(url: Url) -> Self {
+		Self::new(url)
+	}
+}
+
 /// Error returned when connection setup fails for a terminal auth reason.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
 #[non_exhaustive]
@@ -44,5 +95,36 @@ mod tests {
 		for status in [400, 404, 500] {
 			assert_eq!(ConnectError::from_status_u16(status), None);
 		}
+	}
+
+	fn url(s: &str) -> Url {
+		s.parse().expect("valid url")
+	}
+
+	/// Dial order is the order the addresses went in, and a lone URL converts
+	/// implicitly so `connect(url)` keeps reading the same.
+	#[test]
+	fn addrs_preserve_dial_order() {
+		let one = Addrs::from(url("moqt://a:4443"));
+		assert_eq!(one.as_slice(), [url("moqt://a:4443")]);
+
+		let three = Addrs::new(url("moqt://a:4443"))
+			.or(url("moqt://b:4443"))
+			.or(url("moqt://c:4443"));
+		assert_eq!(
+			three.as_slice(),
+			[url("moqt://a:4443"), url("moqt://b:4443"), url("moqt://c:4443")]
+		);
+	}
+
+	/// A peer that advertised nothing reachable is `None` at construction, not a
+	/// connection that retries an empty list forever.
+	#[test]
+	fn addrs_collect_rejects_an_empty_list() {
+		assert_eq!(Addrs::collect([]), None);
+		assert_eq!(
+			Addrs::collect([url("moqt://a:4443"), url("moqt://b:4443")]),
+			Some(Addrs::new(url("moqt://a:4443")).or(url("moqt://b:4443")))
+		);
 	}
 }

--- a/rs/moq-native/src/connect.rs
+++ b/rs/moq-native/src/connect.rs
@@ -49,6 +49,35 @@ impl From<Url> for Addrs {
 	}
 }
 
+/// A dial URL reduced to the part that names the peer, for logs and errors.
+///
+/// A dial URL's path and query are exactly where credentials live: `?jwt=` on a
+/// relay dial, and a LAN mesh membership proof, which rides as a path segment
+/// because raw QUIC has no headers to put it in. Formatting one into a log line
+/// puts a replayable credential wherever logs are shipped, so nothing outside
+/// this type formats a dial `Url` directly.
+///
+/// Dropping both rather than redacting known-secret spellings is deliberate: a
+/// denylist only covers the credentials that exist today, and the next one to be
+/// added would leak until someone remembered to extend it.
+pub(crate) struct Endpoint<'a>(pub &'a Url);
+
+impl std::fmt::Display for Endpoint<'_> {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{}://", self.0.scheme())?;
+		let Some(host) = self.0.host_str() else {
+			// No host at all, e.g. a `unix:` socket, where the path is the address
+			// rather than a credential and is the only thing that identifies it.
+			return write!(f, "{}", self.0.path());
+		};
+		write!(f, "{host}")?;
+		match self.0.port() {
+			Some(port) => write!(f, ":{port}"),
+			None => Ok(()),
+		}
+	}
+}
+
 /// Error returned when connection setup fails for a terminal auth reason.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
 #[non_exhaustive]
@@ -115,6 +144,42 @@ mod tests {
 			three.as_slice(),
 			[url("moqt://a:4443"), url("moqt://b:4443"), url("moqt://c:4443")]
 		);
+	}
+
+	/// The whole point of [`Endpoint`]: a dial URL's credentials live in its path
+	/// and query, so neither may survive into anything loggable.
+	///
+	/// The LAN mesh case is the sharp one. Its membership proof is a path segment
+	/// (raw QUIC has no headers to put it in), so a dial URL logged verbatim hands
+	/// a replayable credential to anyone who can read logs.
+	#[test]
+	fn endpoint_keeps_credentials_out_of_logs() {
+		const SECRET: &str = "a4f1c93e8b7d";
+
+		for dial in [
+			// A LAN mesh dial: the proof is a path segment.
+			&format!("moqt://192.168.1.5:4443/.cluster/{SECRET}"),
+			// A relay dial: the token is in the query.
+			&format!("https://relay.example.com/anon?jwt={SECRET}"),
+			// Both at once, plus userinfo.
+			&format!("https://user:{SECRET}@relay.example.com:8443/room/{SECRET}?jwt={SECRET}"),
+		] {
+			let rendered = Endpoint(&url(dial)).to_string();
+			assert!(!rendered.contains(SECRET), "{dial} leaked through as {rendered}");
+		}
+
+		// It still names the peer, which is what a log line is for.
+		assert_eq!(
+			Endpoint(&url("moqt://192.168.1.5:4443/.cluster/abc")).to_string(),
+			"moqt://192.168.1.5:4443"
+		);
+		// A default port is elided rather than invented.
+		assert_eq!(
+			Endpoint(&url("https://relay.example.com/anon?jwt=abc")).to_string(),
+			"https://relay.example.com"
+		);
+		// A socket path is the address, not a credential, so it survives.
+		assert_eq!(Endpoint(&url("unix:/run/moq.sock")).to_string(), "unix:///run/moq.sock");
 	}
 
 	/// A peer that advertised nothing reachable is `None` at construction, not a

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -25,6 +25,19 @@ fn attempt_timeout(index: usize, total: usize) -> Option<Duration> {
 	(index + 1 < total).then_some(CONNECT_ATTEMPT)
 }
 
+/// The retry window as a deadline for the address walk, or `None` to leave each
+/// attempt to the client's own connect timeout.
+///
+/// Only when reconnecting. `Backoff::timeout` is how long to keep *retrying*, so
+/// applying it to a one-shot dial would cut short the single attempt there will
+/// ever be: a handshake slower than the retry window but well inside
+/// [`ClientConfig::timeout`](crate::ClientConfig::timeout) would fail for a
+/// reason that does not apply. That deadline is the one governing a one-shot
+/// dial, and it already does.
+fn retry_budget(reconnect: bool, retry_start: tokio::time::Instant, timeout: Duration) -> Option<tokio::time::Instant> {
+	(reconnect && !timeout.is_zero()).then(|| retry_start + timeout)
+}
+
 /// When the attempt at candidate `index` of `total` must be given up, or `None`
 /// to let it run.
 ///
@@ -598,9 +611,7 @@ impl Connection {
 				return Err(timeout_error(timeout, last_error.as_ref()));
 			}
 
-			// The walk respects the same give-up window the loop does, so a list of
-			// black-holed addresses cannot outrun it several attempts at a time.
-			let budget = (!timeout.is_zero()).then(|| retry_start + timeout);
+			let budget = retry_budget(client.reconnect, retry_start, timeout);
 
 			match Self::dial_any(shared, &client, &addrs, &mut draining, budget).await {
 				Ok((url, session)) => {
@@ -1596,6 +1607,29 @@ mod tests {
 		assert!(logs_contain("connecting"), "the dial never logged at all");
 		assert!(!logs_contain(SECRET), "a log line leaked the credential");
 		assert!(!format!("{err}").contains(SECRET), "the error leaked it: {err}");
+	}
+
+	/// The retry window bounds the walk only when there are retries.
+	///
+	/// It is a budget for *retrying*, so spending it on the single attempt a
+	/// one-shot dial gets would fail a handshake that is merely slower than the
+	/// retry window while well inside the connect timeout that actually governs it.
+	#[test]
+	fn only_a_reconnecting_dial_spends_the_retry_window() {
+		let start = tokio::time::Instant::now();
+		let timeout = Duration::from_secs(10);
+
+		assert_eq!(retry_budget(true, start, timeout), Some(start + timeout));
+		assert_eq!(
+			retry_budget(false, start, timeout),
+			None,
+			"a one-shot dial is bounded by the connect timeout, not the retry window"
+		);
+		assert_eq!(
+			retry_budget(true, start, Duration::ZERO),
+			None,
+			"zero means retry forever, so nothing bounds the walk"
+		);
 	}
 
 	/// Whichever of the two bounds comes first wins, and the retry window applies

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -53,9 +53,19 @@ fn attempt_deadline(
 	now: tokio::time::Instant,
 	budget: Option<tokio::time::Instant>,
 ) -> Option<tokio::time::Instant> {
+	// An equal share of what's left, not all of it. Handing each candidate the
+	// whole remaining window lets the first couple spend it between them and
+	// strand a reachable address further down the list, which is the opposite of
+	// what walking the list is for. Recomputed per attempt, so one that fails fast
+	// leaves more for the rest.
+	let share = budget.map(|budget| {
+		let remaining = total - index;
+		now + budget.saturating_duration_since(now) / remaining as u32
+	});
 	let bound = attempt_timeout(index, total).map(|limit| now + limit);
-	match (bound, budget) {
-		(Some(bound), Some(budget)) => Some(bound.min(budget)),
+
+	match (bound, share) {
+		(Some(bound), Some(share)) => Some(bound.min(share)),
 		(Some(only), None) | (None, Some(only)) => Some(only),
 		(None, None) => None,
 	}
@@ -1679,12 +1689,27 @@ mod tests {
 		assert_eq!(attempt_deadline(0, 2, now, None), Some(now + CONNECT_ATTEMPT));
 		assert_eq!(attempt_deadline(1, 2, now, None), None);
 
-		// A budget shorter than the fixed bound wins, including on the last
-		// candidate, which used to run to the client's connect timeout and let a
-		// few black-holed addresses overrun the give-up window several times over.
-		let tight = now + Duration::from_secs(1);
-		assert_eq!(attempt_deadline(0, 2, now, Some(tight)), Some(tight));
+		// A tight budget is split, not spent by whoever asks first. Two seconds
+		// across two candidates is a second each, so the second one still gets a
+		// turn; handing the first the whole window would strand it.
+		let tight = now + Duration::from_secs(2);
+		assert_eq!(
+			attempt_deadline(0, 2, now, Some(tight)),
+			Some(now + Duration::from_secs(1))
+		);
+		// The last candidate gets what is actually left, which here is all of it
+		// because nothing has been spent yet in this synthetic call.
 		assert_eq!(attempt_deadline(1, 2, now, Some(tight)), Some(tight));
+
+		// The share is what a black-holed pair used to exhaust: with the default
+		// 10s window and the 5s bound, two candidates ate it and a reachable third
+		// was never dialed. Now each gets a third.
+		let default_window = now + Duration::from_secs(10);
+		assert_eq!(
+			attempt_deadline(0, 3, now, Some(default_window)),
+			Some(now + Duration::from_secs(10) / 3),
+			"a reachable third candidate must still get a turn"
+		);
 
 		// A budget with room to spare leaves the per-candidate bound in charge, so
 		// one slow address still cannot eat the others' turn.

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -7,7 +7,22 @@ use moq_net::kio;
 use rand::RngExt;
 use url::Url;
 
-use crate::{Client, Error};
+use crate::{Addrs, Client, Error};
+
+/// How long one address gets before [`Connection`] moves to the peer's next one.
+const CONNECT_ATTEMPT: Duration = Duration::from_secs(5);
+
+/// The deadline for the attempt at candidate `index` of `total`, or `None` to
+/// let it run.
+///
+/// A black-holed address answers nothing rather than refusing, so without a
+/// bound the QUIC idle timeout would decide how long the remaining candidates
+/// wait. Only an attempt with a later candidate to fall back on is worth
+/// bounding: cutting the last one short just turns a slow connect into a failed
+/// one, on every reconnect cycle.
+fn attempt_timeout(index: usize, total: usize) -> Option<Duration> {
+	(index + 1 < total).then_some(CONNECT_ATTEMPT)
+}
 
 /// Exponential backoff configuration for reconnection attempts.
 ///
@@ -459,7 +474,7 @@ impl Drop for AbortOnDrop {
 type CloseGuard = std::sync::Arc<std::sync::Mutex<Option<moq_net::Error>>>;
 
 impl Connection {
-	pub(crate) fn new(client: Client, url: Url) -> Self {
+	pub(crate) fn new(client: Client, addrs: Addrs) -> Self {
 		let producer = kio::Producer::<State>::default();
 		let state = producer.consume();
 
@@ -481,7 +496,7 @@ impl Connection {
 				recv_bw,
 				closed: task_closed,
 			};
-			if let Err(err) = Self::run(&shared, client, url).await {
+			if let Err(err) = Self::run(&shared, client, addrs).await {
 				// In one-shot mode the session ending is the expected lifecycle, and
 				// its close reason arrives here; don't dress it up as a loop failure.
 				match reconnect {
@@ -504,6 +519,7 @@ impl Connection {
 		}
 	}
 
+<<<<<<< HEAD
 	/// Stop the loop now, for every clone, closing the live session with `err`.
 	///
 	/// `err` is the code the peer sees. Locally this is still a deliberate stop, so
@@ -537,7 +553,7 @@ impl Connection {
 		self.abort(moq_net::Error::Cancel);
 	}
 
-	async fn run(shared: &Shared, client: Client, url: Url) -> crate::Result<()> {
+	async fn run(shared: &Shared, client: Client, addrs: Addrs) -> crate::Result<()> {
 		let backoff = client.backoff.clone();
 		let goaway = client.goaway.clone();
 		let pacing = Pacing::new(&backoff);
@@ -547,8 +563,8 @@ impl Connection {
 		let mut last_error: Option<Error> = None;
 		// Sticky across migrations: a redirect is an assignment, not a detour, so a
 		// later drop redials wherever we were last sent. Scoped to this loop, so a
-		// fresh Connection starts from the configured URL again.
-		let mut url = url;
+		// fresh Connection starts from the configured addresses again.
+		let mut addrs = addrs;
 		// An old session kept alive after a GOAWAY so its in-flight groups finish.
 		let mut draining: Option<Draining> = None;
 
@@ -558,24 +574,8 @@ impl Connection {
 				return Err(timeout_error(timeout, last_error.as_ref()));
 			}
 
-			tracing::info!(%url, "connecting");
-
-			// Keep a predecessor's handover bounded across the dial. A GOAWAY off a
-			// healthy session comes straight here with the old one still draining, and
-			// a slow or blackholed replacement would otherwise hold it past the
-			// deadline we promised, still reported as `Migrating`, until the dial
-			// returned.
-			let mut dial = std::pin::pin!(client.dial(url.clone()));
-			let dialed = kio::wait(|waiter| {
-				if poll_draining(&mut draining, waiter) {
-					shared.disconnected();
-				}
-				waiter.poll_future(dial.as_mut())
-			})
-			.await;
-
-			match dialed {
-				Ok(session) => {
+			match Self::dial_any(shared, &client, &addrs, &mut draining).await {
+				Ok((url, session)) => {
 					tracing::info!(%url, "connected");
 					shared.connected(&session);
 
@@ -600,8 +600,11 @@ impl Connection {
 					}
 
 					if let Ended::Goaway(msg) = &ended {
-						// A redirect is an assignment: keep dialing it from here on.
-						url = goaway.redirect().resolve(&msg.uri, &url);
+						// A redirect is an assignment: keep dialing it from here on, and
+						// only it. The peer named exactly one place to go, which retires
+						// whatever other addresses got us to this session.
+						let url = goaway.redirect().resolve(&msg.uri, &url);
+						addrs = Addrs::new(url.clone());
 
 						// Hand over gracefully however the backoff bookkeeping scores this
 						// session. The old one keeps serving until it closes or overstays,
@@ -715,7 +718,9 @@ impl Connection {
 			let Some(wait) = retry_wait(delay, retry_start, timeout) else {
 				return Err(timeout_error(timeout, last_error.as_ref()));
 			};
-			tracing::warn!(%url, ?wait, "reconnecting after backoff");
+			// No URL here: with several candidates there isn't one to name, and each
+			// attempt already logged the address it tried.
+			tracing::warn!(?wait, "reconnecting after backoff");
 			// Drain-aware: a GOAWAY off a healthy session continues straight to the
 			// replacement dial, so a predecessor can still be draining when that dial
 			// fails and lands here. A plain sleep would stop enforcing its handover
@@ -724,6 +729,60 @@ impl Connection {
 			sleep_draining(wait, &mut draining, shared).await;
 			delay = pacing.next(delay);
 		}
+	}
+
+	/// Try each address in turn, returning the first session that connects and the
+	/// address that produced it.
+	///
+	/// A peer discovered rather than configured can advertise several addresses,
+	/// only some of which route from here (its loopback, a container bridge, an
+	/// interface on another subnet). Nothing in the record says which, so every
+	/// attempt walks the whole list rather than pinning whichever sorted first.
+	///
+	/// A predecessor left over from a migration keeps draining across the whole
+	/// walk, not just one attempt: its handover deadline is wall-clock, and a walk
+	/// past several black-holed addresses is exactly when it would overstay.
+	async fn dial_any(
+		shared: &Shared,
+		client: &Client,
+		addrs: &Addrs,
+		draining: &mut Option<Draining>,
+	) -> crate::Result<(Url, moq_net::Session)> {
+		let candidates = addrs.as_slice();
+		let mut last = None;
+
+		for (index, url) in candidates.iter().enumerate() {
+			tracing::info!(%url, "connecting");
+
+			let mut dial = std::pin::pin!(client.dial(url.clone()));
+			let dialed = kio::wait(|waiter| {
+				if poll_draining(draining, waiter) {
+					shared.disconnected();
+				}
+				waiter.poll_future(dial.as_mut())
+			});
+
+			let dialed = match attempt_timeout(index, candidates.len()) {
+				None => dialed.await,
+				Some(limit) => match tokio::time::timeout(limit, dialed).await {
+					Ok(dialed) => dialed,
+					Err(_) => Err(Error::Reconnect(format!("timed out connecting to {url}"))),
+				},
+			};
+
+			match dialed {
+				Ok(session) => return Ok((url.clone(), session)),
+				// Credentials are the peer's answer, not this address's, so don't keep
+				// offering them at the rest of its addresses.
+				Err(err) if err.is_auth() => return Err(err),
+				Err(err) => {
+					tracing::debug!(%url, %err, "address unreachable");
+					last = Some(err);
+				}
+			}
+		}
+
+		Err(last.expect("Addrs is never empty, so at least one attempt ran"))
 	}
 
 	/// Poll until a session is established (the first connect, or the current one).
@@ -1375,5 +1434,110 @@ mod tests {
 		src.abort(moq_net::Error::Cancel).unwrap();
 		poll_forward(&mut bw, &out, &waiter);
 		assert!(bw.is_none());
+	}
+
+	const WALK_TIMEOUT: Duration = Duration::from_secs(30);
+
+	fn url(value: &str) -> Url {
+		value.parse().expect("valid url")
+	}
+
+	/// A loopback TCP port with nothing on it, which refuses instantly.
+	///
+	/// A dead address that *refuses* rather than black-holes is what keeps these
+	/// tests fast and deterministic: the walk itself is what's under test, and
+	/// bounding a black-holed attempt is covered by
+	/// [`only_a_candidate_with_a_fallback_is_bounded`] as a pure function.
+	#[cfg(feature = "tcp")]
+	fn refused() -> Url {
+		let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
+		let port = probe.local_addr().expect("local addr").port();
+		drop(probe);
+		url(&format!("tcp://127.0.0.1:{port}/"))
+	}
+
+	/// A bound stream listener, the URL that reaches it, and a client for it.
+	#[cfg(feature = "tcp")]
+	fn pair() -> (crate::Server, Url, Client) {
+		let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+		for _ in 0..20 {
+			let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("bind probe");
+			let port = probe.local_addr().expect("local addr").port();
+			drop(probe);
+
+			let mut config = crate::ServerConfig::default();
+			config.tcp.bind = Some(format!("127.0.0.1:{port}").parse().expect("valid address"));
+			let Ok(server) = config.init() else { continue };
+
+			let mut config = crate::ClientConfig::default();
+			config.tls.disable_verify = Some(true);
+			let client = config.init().expect("build client");
+
+			return (server, url(&format!("tcp://127.0.0.1:{port}/")), client);
+		}
+		panic!("could not bind a free TCP port after 20 attempts");
+	}
+
+	fn shared() -> Shared {
+		Shared {
+			state: kio::Producer::default(),
+			send_bw: BandwidthProducer::new(),
+			recv_bw: BandwidthProducer::new(),
+		}
+	}
+
+	/// The first address that answers wins, however many dead ones precede it.
+	/// This is what keeps a peer reachable when discovery advertises an interface
+	/// that doesn't route from here ahead of the one that does.
+	#[cfg(feature = "tcp")]
+	#[tokio::test]
+	async fn dial_any_walks_past_the_dead_addresses() {
+		let (mut server, live, client) = pair();
+		tokio::spawn(async move { while server.accept().await.is_some() {} });
+
+		let addrs = Addrs::collect([refused(), refused(), live.clone()]).expect("not empty");
+		let shared = shared();
+		let mut draining = None;
+
+		let (connected, _session) = tokio::time::timeout(
+			WALK_TIMEOUT,
+			Connection::dial_any(&shared, &client, &addrs, &mut draining),
+		)
+		.await
+		.expect("the walk must not hang")
+		.expect("the live address must connect");
+		assert_eq!(connected, live, "the walk must land on the one that answers");
+	}
+
+	/// With nothing reachable the walk reports a failure rather than hanging.
+	#[cfg(feature = "tcp")]
+	#[tokio::test]
+	async fn dial_any_reports_failure_when_nothing_answers() {
+		let (_server, _live, client) = pair();
+
+		let addrs = Addrs::collect([refused(), refused()]).expect("not empty");
+		let shared = shared();
+		let mut draining = None;
+
+		let result = tokio::time::timeout(
+			WALK_TIMEOUT,
+			Connection::dial_any(&shared, &client, &addrs, &mut draining),
+		)
+		.await
+		.expect("the walk must not hang");
+		assert!(result.is_err(), "every address refused, so the walk must fail");
+	}
+
+	/// Only an attempt with somewhere to fall back on is bounded. The last
+	/// candidate runs to completion, so a reachable-but-slow final address is not
+	/// cancelled and then re-cancelled on every reconnect cycle.
+	#[test]
+	fn only_a_candidate_with_a_fallback_is_bounded() {
+		assert_eq!(attempt_timeout(0, 1), None, "a lone address");
+		assert_eq!(attempt_timeout(0, 2), Some(CONNECT_ATTEMPT), "one more to try");
+		assert_eq!(attempt_timeout(1, 2), None, "the last of two");
+		assert_eq!(attempt_timeout(1, 3), Some(CONNECT_ATTEMPT), "still one more");
+		assert_eq!(attempt_timeout(2, 3), None, "the last of three");
 	}
 }

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -7,6 +7,7 @@ use moq_net::kio;
 use rand::RngExt;
 use url::Url;
 
+use crate::connect::Endpoint;
 use crate::{Addrs, Client, Error};
 
 /// How long one address gets before [`Connection`] moves to the peer's next one.
@@ -576,7 +577,7 @@ impl Connection {
 
 			match Self::dial_any(shared, &client, &addrs, &mut draining).await {
 				Ok((url, session)) => {
-					tracing::info!(%url, "connected");
+					tracing::info!(peer = %Endpoint(&url), "connected");
 					shared.connected(&session);
 
 					let connected = tokio::time::Instant::now();
@@ -611,7 +612,7 @@ impl Connection {
 						// so its routes stay attached and live tracks splice onto the
 						// replacement at a group boundary. Tearing it down here instead
 						// would drop every group published until the replacement caught up.
-						tracing::info!(%url, "upstream GOAWAY; migrating");
+						tracing::info!(peer = %Endpoint(&url), "upstream GOAWAY; migrating");
 						shared.migrating();
 						// Retire any predecessor first: overwriting would drop its deadline
 						// on the floor and leave it holding the connection open.
@@ -636,7 +637,7 @@ impl Connection {
 						let Some(wait) = retry_wait(delay, retry_start, timeout) else {
 							return Err(timeout_error(timeout, last_error.as_ref()));
 						};
-						tracing::warn!(%url, ?wait, "peer redirected immediately; retrying after backoff");
+						tracing::warn!(peer = %Endpoint(&url), ?wait, "peer redirected immediately; retrying after backoff");
 						// Keep the handover bounded across the sleep: nothing else polls the
 						// predecessor while the loop is between connections.
 						sleep_draining(wait, &mut draining, shared).await;
@@ -669,7 +670,7 @@ impl Connection {
 
 					if healthy {
 						// Reset the backoff window so a one-off drop reconnects promptly.
-						tracing::warn!(%url, "session closed, reconnecting");
+						tracing::warn!(peer = %Endpoint(&url), "session closed, reconnecting");
 						delay = initial;
 						retry_start = tokio::time::Instant::now();
 						last_error = None;
@@ -695,10 +696,10 @@ impl Connection {
 						// a caller observes those rejections directly.
 						match err {
 							Some(err) => {
-								tracing::warn!(%url, %err, "session severed immediately, retrying");
+								tracing::warn!(peer = %Endpoint(&url), %err, "session severed immediately, retrying");
 								last_error = Some(err);
 							}
-							None => tracing::warn!(%url, "session severed immediately, retrying"),
+							None => tracing::warn!(peer = %Endpoint(&url), "session severed immediately, retrying"),
 						}
 					}
 				}
@@ -752,7 +753,7 @@ impl Connection {
 		let mut last = None;
 
 		for (index, url) in candidates.iter().enumerate() {
-			tracing::info!(%url, "connecting");
+			tracing::info!(peer = %Endpoint(url), "connecting");
 
 			let mut dial = std::pin::pin!(client.dial(url.clone()));
 			let dialed = kio::wait(|waiter| {
@@ -766,7 +767,7 @@ impl Connection {
 				None => dialed.await,
 				Some(limit) => match tokio::time::timeout(limit, dialed).await {
 					Ok(dialed) => dialed,
-					Err(_) => Err(Error::Reconnect(format!("timed out connecting to {url}"))),
+					Err(_) => Err(Error::Reconnect(format!("timed out connecting to {}", Endpoint(url)))),
 				},
 			};
 
@@ -776,7 +777,7 @@ impl Connection {
 				// offering them at the rest of its addresses.
 				Err(err) if err.is_auth() => return Err(err),
 				Err(err) => {
-					tracing::debug!(%url, %err, "address unreachable");
+					tracing::debug!(peer = %Endpoint(url), %err, "address unreachable");
 					last = Some(err);
 				}
 			}
@@ -1527,6 +1528,37 @@ mod tests {
 		.await
 		.expect("the walk must not hang");
 		assert!(result.is_err(), "every address refused, so the walk must fail");
+	}
+
+	/// Dialing must not write the LAN mesh's membership credential to the log.
+	///
+	/// The proof rides as a URL path segment, since raw QUIC has no headers to put
+	/// it in, and a dial URL logged verbatim would hand a replayable credential to
+	/// anyone who can read logs. This drives the real `tracing` stack rather than
+	/// [`Endpoint`]'s `Display`, so it also catches a log site that forgot to use
+	/// it.
+	#[cfg(feature = "tcp")]
+	#[tracing_test::traced_test]
+	#[tokio::test]
+	async fn dialing_never_logs_the_credential() {
+		const SECRET: &str = "b91d7fe20c4a";
+
+		let (_server, _live, client) = pair();
+		let mut target = refused();
+		target.set_path(&format!("/.cluster/{SECRET}"));
+
+		let addrs = Addrs::new(target);
+		let shared = shared();
+		let mut draining = None;
+		// `Session` isn't `Debug`, so unwrap the failure by hand.
+		let Err(err) = Connection::dial_any(&shared, &client, &addrs, &mut draining).await else {
+			panic!("a refused address must fail");
+		};
+
+		// The log line did happen, so the assertion below isn't vacuously true.
+		assert!(logs_contain("connecting"), "the dial never logged at all");
+		assert!(!logs_contain(SECRET), "a log line leaked the credential");
+		assert!(!format!("{err}").contains(SECRET), "the error leaked it: {err}");
 	}
 
 	/// Only an attempt with somewhere to fall back on is bounded. The last

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -819,9 +819,18 @@ impl Connection {
 
 			match dialed {
 				Ok(session) => return Ok((url.clone(), session)),
-				// Credentials are the peer's answer, not this address's, so don't keep
-				// offering them at the rest of its addresses.
-				Err(err) if err.is_auth() => return Err(err),
+				// A status the peer actually sent is its answer, not this address's, so
+				// unless it invites another attempt it settles the whole walk. Carrying
+				// on would offer the same rejected credentials at the peer's other
+				// addresses, and worse, a later transport failure would overwrite the
+				// real reason and leave the outer loop retrying until its budget ran out.
+				Err(err)
+					if err
+						.status()
+						.is_some_and(|status| !crate::error::status_retryable(status)) =>
+				{
+					return Err(err);
+				}
 				Err(err) => {
 					tracing::debug!(peer = %Endpoint(url), %err, "address unreachable");
 					last = Some(err);
@@ -1607,6 +1616,33 @@ mod tests {
 		assert!(logs_contain("connecting"), "the dial never logged at all");
 		assert!(!logs_contain(SECRET), "a log line leaked the credential");
 		assert!(!format!("{err}").contains(SECRET), "the error leaked it: {err}");
+	}
+
+	/// A settled answer from one candidate ends the walk instead of being buried.
+	///
+	/// The walk keeps only the last failure, so without this a `404` from the first
+	/// address would be overwritten by a transport error from the second, and the
+	/// outer loop would retry the whole list until its budget ran out over a
+	/// question the peer had already answered. Only the statuses that invite
+	/// another attempt keep the walk going.
+	#[test]
+	fn a_settled_status_stops_the_walk() {
+		let settled = [401, 403, 404, 400, 500];
+		for status in settled {
+			assert!(
+				!crate::error::status_retryable(status),
+				"{status} is the peer's answer, so the walk should stop"
+			);
+		}
+
+		// The ones worth asking again about: request timeout, rate limit, and the
+		// gateway/overload statuses. A different address may well do better.
+		for status in [408, 429, 502, 503, 504] {
+			assert!(
+				crate::error::status_retryable(status),
+				"{status} invites another attempt, so the walk should continue"
+			);
+		}
 	}
 
 	/// The retry window bounds the walk only when there are retries.

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -25,6 +25,29 @@ fn attempt_timeout(index: usize, total: usize) -> Option<Duration> {
 	(index + 1 < total).then_some(CONNECT_ATTEMPT)
 }
 
+/// When the attempt at candidate `index` of `total` must be given up, or `None`
+/// to let it run.
+///
+/// Two bounds, whichever comes first. [`attempt_timeout`] keeps one slow
+/// candidate from eating the others' turn, and `budget` is the retry window from
+/// [`Backoff::timeout`], which the walk has to respect too: bounding only the
+/// non-final attempts left the last one to run to the client's connect timeout,
+/// so a handful of black-holed addresses could blow through a give-up budget
+/// several times over before reporting anything.
+fn attempt_deadline(
+	index: usize,
+	total: usize,
+	now: tokio::time::Instant,
+	budget: Option<tokio::time::Instant>,
+) -> Option<tokio::time::Instant> {
+	let bound = attempt_timeout(index, total).map(|limit| now + limit);
+	match (bound, budget) {
+		(Some(bound), Some(budget)) => Some(bound.min(budget)),
+		(Some(only), None) | (None, Some(only)) => Some(only),
+		(None, None) => None,
+	}
+}
+
 /// Exponential backoff configuration for reconnection attempts.
 ///
 /// Every field is optional so a value set in TOML survives the CLI re-parse that follows it; read
@@ -575,7 +598,11 @@ impl Connection {
 				return Err(timeout_error(timeout, last_error.as_ref()));
 			}
 
-			match Self::dial_any(shared, &client, &addrs, &mut draining).await {
+			// The walk respects the same give-up window the loop does, so a list of
+			// black-holed addresses cannot outrun it several attempts at a time.
+			let budget = (!timeout.is_zero()).then(|| retry_start + timeout);
+
+			match Self::dial_any(shared, &client, &addrs, &mut draining, budget).await {
 				Ok((url, session)) => {
 					tracing::info!(peer = %Endpoint(&url), "connected");
 					shared.connected(&session);
@@ -748,11 +775,18 @@ impl Connection {
 		client: &Client,
 		addrs: &Addrs,
 		draining: &mut Option<Draining>,
+		budget: Option<tokio::time::Instant>,
 	) -> crate::Result<(Url, moq_net::Session)> {
 		let candidates = addrs.as_slice();
 		let mut last = None;
 
 		for (index, url) in candidates.iter().enumerate() {
+			// The retry window can run out mid-walk. Stop rather than starting an
+			// attempt with no time to finish; the caller reports the budget error.
+			if budget.is_some_and(|budget| tokio::time::Instant::now() >= budget) {
+				break;
+			}
+
 			tracing::info!(peer = %Endpoint(url), "connecting");
 
 			let mut dial = std::pin::pin!(client.dial(url.clone()));
@@ -763,9 +797,10 @@ impl Connection {
 				waiter.poll_future(dial.as_mut())
 			});
 
-			let dialed = match attempt_timeout(index, candidates.len()) {
+			let deadline = attempt_deadline(index, candidates.len(), tokio::time::Instant::now(), budget);
+			let dialed = match deadline {
 				None => dialed.await,
-				Some(limit) => match tokio::time::timeout(limit, dialed).await {
+				Some(deadline) => match tokio::time::timeout_at(deadline, dialed).await {
 					Ok(dialed) => dialed,
 					Err(_) => Err(Error::Reconnect(format!("timed out connecting to {}", Endpoint(url)))),
 				},
@@ -783,7 +818,9 @@ impl Connection {
 			}
 		}
 
-		Err(last.expect("Addrs is never empty, so at least one attempt ran"))
+		// `Addrs` is never empty, so the only way to get here without a failure is
+		// the budget running out before the first attempt started.
+		Err(last.unwrap_or_else(|| Error::Reconnect("retry window elapsed before dialing".to_string())))
 	}
 
 	/// Poll until a session is established (the first connect, or the current one).
@@ -1503,7 +1540,7 @@ mod tests {
 
 		let (connected, _session) = tokio::time::timeout(
 			WALK_TIMEOUT,
-			Connection::dial_any(&shared, &client, &addrs, &mut draining),
+			Connection::dial_any(&shared, &client, &addrs, &mut draining, None),
 		)
 		.await
 		.expect("the walk must not hang")
@@ -1523,7 +1560,7 @@ mod tests {
 
 		let result = tokio::time::timeout(
 			WALK_TIMEOUT,
-			Connection::dial_any(&shared, &client, &addrs, &mut draining),
+			Connection::dial_any(&shared, &client, &addrs, &mut draining, None),
 		)
 		.await
 		.expect("the walk must not hang");
@@ -1551,7 +1588,7 @@ mod tests {
 		let shared = shared();
 		let mut draining = None;
 		// `Session` isn't `Debug`, so unwrap the failure by hand.
-		let Err(err) = Connection::dial_any(&shared, &client, &addrs, &mut draining).await else {
+		let Err(err) = Connection::dial_any(&shared, &client, &addrs, &mut draining, None).await else {
 			panic!("a refused address must fail");
 		};
 
@@ -1561,9 +1598,32 @@ mod tests {
 		assert!(!format!("{err}").contains(SECRET), "the error leaked it: {err}");
 	}
 
-	/// Only an attempt with somewhere to fall back on is bounded. The last
-	/// candidate runs to completion, so a reachable-but-slow final address is not
-	/// cancelled and then re-cancelled on every reconnect cycle.
+	/// Whichever of the two bounds comes first wins, and the retry window applies
+	/// to every candidate including the last.
+	#[test]
+	fn the_retry_window_bounds_the_walk_too() {
+		let now = tokio::time::Instant::now();
+
+		// No budget: only the fixed per-candidate bound applies, and the last
+		// candidate runs free.
+		assert_eq!(attempt_deadline(0, 2, now, None), Some(now + CONNECT_ATTEMPT));
+		assert_eq!(attempt_deadline(1, 2, now, None), None);
+
+		// A budget shorter than the fixed bound wins, including on the last
+		// candidate, which used to run to the client's connect timeout and let a
+		// few black-holed addresses overrun the give-up window several times over.
+		let tight = now + Duration::from_secs(1);
+		assert_eq!(attempt_deadline(0, 2, now, Some(tight)), Some(tight));
+		assert_eq!(attempt_deadline(1, 2, now, Some(tight)), Some(tight));
+
+		// A budget with room to spare leaves the per-candidate bound in charge, so
+		// one slow address still cannot eat the others' turn.
+		let loose = now + Duration::from_secs(60);
+		assert_eq!(attempt_deadline(0, 2, now, Some(loose)), Some(now + CONNECT_ATTEMPT));
+		assert_eq!(attempt_deadline(1, 2, now, Some(loose)), Some(loose));
+	}
+
+	/// Only an attempt with somewhere to fall back on gets the fixed bound.
 	#[test]
 	fn only_a_candidate_with_a_fallback_is_bounded() {
 		assert_eq!(attempt_timeout(0, 1), None, "a lone address");

--- a/rs/moq-native/src/connection.rs
+++ b/rs/moq-native/src/connection.rs
@@ -556,7 +556,6 @@ impl Connection {
 		}
 	}
 
-<<<<<<< HEAD
 	/// Stop the loop now, for every clone, closing the live session with `err`.
 	///
 	/// `err` is the code the peer sees. Locally this is still a deliberate stop, so
@@ -1542,6 +1541,7 @@ mod tests {
 			state: kio::Producer::default(),
 			send_bw: BandwidthProducer::new(),
 			recv_bw: BandwidthProducer::new(),
+			closed: CloseGuard::default(),
 		}
 	}
 

--- a/rs/moq-native/src/lib.rs
+++ b/rs/moq-native/src/lib.rs
@@ -8,7 +8,8 @@
 //! - Unix domain socket via the `unix://` scheme (qmux, peer-credential aware; requires `uds` feature, unix-only)
 //! - Iroh P2P (requires `iroh` feature)
 //!
-//! See [`Client`] for connecting to relays and [`Server`] for accepting connections.
+//! See [`Client`] for connecting to relays and [`Server`] for accepting
+//! connections. [`mdns`] finds peers to connect to on the local network.
 
 #![warn(missing_docs)]
 
@@ -44,7 +45,7 @@ pub mod websocket;
 // Enumerated rather than globbed, so the root surface is a deliberate list and a
 // new `pub` item in these modules doesn't silently join it.
 pub use client::{Client, ClientConfig};
-pub use connect::ConnectError;
+pub use connect::{Addrs, ConnectError};
 pub use connection::{Backoff, Connection, ConnectionStatsReader, GoawayConfig, Redirect, Status};
 pub use error::{Error, Result};
 pub use log::Log;
@@ -80,6 +81,9 @@ pub mod quiche;
 
 #[cfg(feature = "iroh")]
 pub mod iroh;
+
+#[cfg(feature = "mdns")]
+pub mod mdns;
 
 /// The QUIC backend to use for connections.
 #[derive(Clone, Debug, clap::ValueEnum, serde::Serialize, serde::Deserialize)]

--- a/rs/moq-native/src/mdns.rs
+++ b/rs/moq-native/src/mdns.rs
@@ -1,0 +1,967 @@
+//! LAN peer discovery over mDNS (DNS-SD), so MoQ processes on the same network
+//! find each other with no relay, DNS, or certificate authority.
+//!
+//! [`Config::advertise`] registers this process as a `_moq._udp.local.` service
+//! and starts browsing for the others, yielding [`Event`]s. Discovery is all
+//! this does: what to do with a peer (dial it, list it, ignore it) stays with
+//! the caller. [`Discovery::should_dial`] offers the pair tiebreaker so both
+//! sides agree on who opens the connection.
+//!
+//! The advertisement carries the listener's port plus, optionally, its
+//! certificate fingerprint (so a peer with a generated certificate can be
+//! pinned without a CA) and its canonical node URL (so a peer with real DNS and
+//! a real certificate is dialed the same way any other cluster peer is).
+//!
+//! Anyone can advertise on mDNS, so an unauthenticated record proves nothing:
+//! an attacker can publish its own address and certificate fingerprint and be
+//! discovered like any other peer. [`Config::with_secret`] closes that off. Each
+//! side proves possession of a shared [`Secret`] with an HMAC-SHA256 proof bound
+//! to its own nonce, fingerprint, and node identity, so a peer without the
+//! secret is never reported at all, and the [`Peer::credential`] a dialer then
+//! presents is bound to that one listener and replays nowhere else.
+//!
+//! Without a secret this is discovery only: treat the peer list as a hint and
+//! authenticate the session by other means before trusting it with anything.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::net::{IpAddr, SocketAddr, SocketAddrV6};
+use std::str::FromStr;
+
+use hmac::{KeyInit, Mac};
+use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
+use subtle::ConstantTimeEq;
+use url::Url;
+
+/// The DNS-SD service MoQ processes advertise under.
+const SERVICE_TYPE: &str = "_moq._udp.local.";
+
+/// The TXT key carrying the listener certificate's hex SHA-256 fingerprint.
+const TXT_FINGERPRINT: &str = "fp";
+
+/// The TXT key carrying the peer's canonical node URL.
+const TXT_NODE: &str = "node";
+
+/// The TXT key carrying the random nonce the secret proofs are bound to.
+const TXT_NONCE: &str = "n";
+
+/// The TXT key carrying the advertiser's proof that it knows the secret.
+const TXT_PROOF: &str = "a";
+
+/// Domain separators for the two proofs, so the one an advertiser publishes can
+/// never stand in for the one a dialer has to present.
+const CONTEXT_ADVERT: &str = "moq-mdns-advert";
+const CONTEXT_DIAL: &str = "moq-mdns-dial";
+
+/// An error while advertising on or browsing the LAN.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct Error(ErrorKind);
+
+#[derive(Debug, thiserror::Error)]
+enum ErrorKind {
+	#[error(transparent)]
+	Mdns(#[from] mdns_sd::Error),
+
+	#[error(
+		"secret must be exactly 32 bytes encoded as 64 hexadecimal characters, or a path to a file containing them"
+	)]
+	InvalidSecret,
+
+	#[error("secret must be 64 hexadecimal characters or a path to a file containing them, and {0} is neither")]
+	SecretFile(String, #[source] std::io::Error),
+}
+
+impl From<mdns_sd::Error> for Error {
+	fn from(err: mdns_sd::Error) -> Self {
+		Self(ErrorKind::Mdns(err))
+	}
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+/// A 32-byte pre-shared key proving membership of a discovery group.
+///
+/// Peers holding different secrets (or none) never see each other. The proofs
+/// are HMACs over a public nonce, so the secret never travels the network but a
+/// weak one can be brute-forced offline by anyone watching it; generate a random
+/// 32 bytes rather than choosing one.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Secret([u8; 32]);
+
+impl Secret {
+	/// Decode a key from exactly 64 hexadecimal characters.
+	pub fn new(secret: impl AsRef<str>) -> Result<Self> {
+		let secret = secret.as_ref();
+		let mut key = [0; 32];
+		if secret.len() != key.len() * 2 || hex::decode_to_slice(secret, &mut key).is_err() {
+			return Err(Error(ErrorKind::InvalidSecret));
+		}
+		Ok(Self(key))
+	}
+
+	/// Decode a key given inline, or read it from the file `value` names.
+	///
+	/// What a `--*-secret <HEX_OR_PATH>` flag accepts. A path that exists but
+	/// holds something other than a key is an error rather than a silent fallback,
+	/// and a path that doesn't exist is never created.
+	pub fn load(value: impl AsRef<str>) -> Result<Self> {
+		let value = value.as_ref();
+		if let Ok(secret) = Self::new(value) {
+			return Ok(secret);
+		}
+		// Not a key, so it can only have been meant as a path. A read failure here
+		// is the useful error: it names the file the operator actually typed.
+		let contents =
+			std::fs::read_to_string(value).map_err(|err| Error(ErrorKind::SecretFile(value.to_string(), err)))?;
+		Self::new(contents.trim())
+	}
+}
+
+impl FromStr for Secret {
+	type Err = Error;
+
+	fn from_str(secret: &str) -> Result<Self> {
+		Self::new(secret)
+	}
+}
+
+impl fmt::Debug for Secret {
+	fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+		formatter.write_str("Secret([redacted])")
+	}
+}
+
+/// Everything a proof is bound to, so one captured off the network
+/// authenticates nowhere else.
+///
+/// The service `instance` and `port` are the load-bearing pair: they are always
+/// present, and a peer resolves under its own instance name, so an attacker that
+/// copies another member's nonce and proof verbatim cannot make them verify
+/// against its own record. `fingerprint` and `node` are folded in too, but only
+/// as extra binding, never as the only binding, since a caller may advertise
+/// neither.
+struct Identity<'a> {
+	instance: &'a str,
+	port: u16,
+	nonce: &'a str,
+	fingerprint: Option<&'a str>,
+	node: Option<&'a str>,
+}
+
+/// An HMAC-SHA256 proof of knowing `secret`, bound to one listener's
+/// [`Identity`], plus a `context` separating the advertise and dial roles.
+fn proof(secret: &Secret, context: &str, id: &Identity<'_>) -> String {
+	let mut mac = hmac::Hmac::<sha2::Sha256>::new_from_slice(&secret.0).expect("HMAC accepts any key length");
+	let port = id.port.to_string();
+	for field in [
+		context,
+		id.instance,
+		&port,
+		id.nonce,
+		id.fingerprint.unwrap_or_default(),
+		id.node.unwrap_or_default(),
+	] {
+		mac.update(field.as_bytes());
+		mac.update(&[0]);
+	}
+	hex::encode(mac.finalize().into_bytes())
+}
+
+/// Constant-time equality, for comparing a credential against the expected one
+/// without leaking it byte-by-byte through timing.
+pub fn ct_eq(a: &str, b: &str) -> bool {
+	a.len() == b.len() && bool::from(a.as_bytes().ct_eq(b.as_bytes()))
+}
+
+/// One peer's advertisement: the fields it published, plus the record they
+/// arrived in. Every one of them is attacker-supplied until [`verify`] says
+/// otherwise.
+struct Advert<'a> {
+	instance: &'a str,
+	port: u16,
+	fingerprint: Option<&'a str>,
+	node: Option<String>,
+	nonce: Option<&'a str>,
+	proof: Option<&'a str>,
+}
+
+/// Check an advertisement's proof, returning the credential to present when
+/// dialing that peer back.
+///
+/// `Err(())` means the peer belongs to a different group: it advertised no proof
+/// while we require one, its proof doesn't verify, or it advertised one while we
+/// run without a secret. Those cases are mutually invisible on purpose, so two
+/// groups can share a network without half-connecting.
+fn verify(secret: Option<&Secret>, advert: Advert<'_>) -> std::result::Result<Option<String>, ()> {
+	let Some(secret) = secret else {
+		return match advert.proof {
+			Some(_) => Err(()),
+			None => Ok(None),
+		};
+	};
+
+	let (nonce, presented) = (advert.nonce.ok_or(())?, advert.proof.ok_or(())?);
+	let id = Identity {
+		instance: advert.instance,
+		port: advert.port,
+		nonce,
+		fingerprint: advert.fingerprint,
+		node: advert.node.as_deref(),
+	};
+	if !ct_eq(presented, &proof(secret, CONTEXT_ADVERT, &id)) {
+		return Err(());
+	}
+	Ok(Some(proof(secret, CONTEXT_DIAL, &id)))
+}
+
+/// What to advertise about this process.
+///
+/// Build with [`new`](Self::new), then [`advertise`](Self::advertise).
+#[derive(Clone, Debug)]
+pub struct Config {
+	port: u16,
+	fingerprint: Option<String>,
+	node: Option<Url>,
+	secret: Option<Secret>,
+}
+
+impl Config {
+	/// Advertise a MoQ listener on `port` of this host's addresses.
+	pub fn new(port: u16) -> Self {
+		Self {
+			port,
+			fingerprint: None,
+			node: None,
+			secret: None,
+		}
+	}
+
+	/// Advertise the listener certificate's hex SHA-256 fingerprint, so peers can
+	/// pin it instead of validating against a certificate authority.
+	///
+	/// Required to reach a listener with a generated certificate.
+	pub fn with_fingerprint(mut self, fingerprint: impl Into<String>) -> Self {
+		self.fingerprint = Some(fingerprint.into());
+		self
+	}
+
+	/// Advertise a canonical node URL, which peers dial in preference to the
+	/// discovered socket address.
+	///
+	/// Use it when this process is reachable by name with a certificate peers
+	/// already trust. It also becomes the discovery identity, so a restart keeps
+	/// the same one.
+	pub fn with_node(mut self, node: Url) -> Self {
+		self.node = Some(node);
+		self
+	}
+
+	/// Restrict discovery to peers holding the same secret, and prove this process
+	/// holds it.
+	///
+	/// Without this, any mDNS responder is reported as a peer, including one that
+	/// made up its address and fingerprint. With it, a peer is only reported once
+	/// its advertised proof verifies, and [`Peer::credential`] carries the matching
+	/// proof to present when dialing it.
+	pub fn with_secret(mut self, secret: Secret) -> Self {
+		self.secret = Some(secret);
+		self
+	}
+
+	/// Register the advertisement and start browsing for peers.
+	pub fn advertise(self) -> Result<Discovery> {
+		Discovery::new(self)
+	}
+}
+
+/// A MoQ process discovered on the LAN.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Peer {
+	/// The advertised node URL when there is one, otherwise the per-run service
+	/// instance. Stable across a re-resolve, and what [`Discovery::should_dial`]
+	/// compares.
+	pub id: String,
+
+	/// The socket addresses the peer advertised, IPv4 first, with IPv6 scope ids
+	/// preserved.
+	pub addrs: Vec<SocketAddr>,
+
+	/// The hex SHA-256 fingerprint of the peer's certificate, to pin when dialing.
+	/// Absent when the peer serves a certificate it expects to be validated normally.
+	pub fingerprint: Option<String>,
+
+	/// The peer's canonical node URL, when it advertised one.
+	pub node: Option<Url>,
+
+	/// The proof of shared-secret membership to present when dialing this peer,
+	/// or `None` when discovery runs without a secret.
+	///
+	/// Bound to this peer's advertisement, so it authenticates nowhere else. The
+	/// peer expects it as its listener's [`Discovery::credential`].
+	pub credential: Option<String>,
+}
+
+impl Peer {
+	/// Every URL worth trying to reach this peer at, best first.
+	///
+	/// A canonical [`node`](Self::node) URL is the only candidate when there is
+	/// one, since it comes with a name its certificate can match. Otherwise these
+	/// are the advertised addresses, and there is usually more than one worth
+	/// keeping: mDNS reports every interface the peer answered on, so its
+	/// loopback, a container bridge, and a VPN address arrive alongside the LAN
+	/// address that actually routes from here. Nothing in the record says which
+	/// is which, so a dialer has to try them (collect them into [`Addrs`] and pass
+	/// that to [`Client::connect`](crate::Client::connect)).
+	///
+	/// [`Addrs`]: crate::Addrs
+	///
+	/// Ordered LAN-routable first and loopback last, and an IPv6 link-local
+	/// address is dropped: dialing one needs an interface scope a URL host cannot
+	/// carry.
+	pub fn urls(&self) -> Vec<Url> {
+		if let Some(node) = &self.node {
+			return vec![node.clone()];
+		}
+
+		let mut addrs = self.addrs.clone();
+		// A peer's own loopback only reaches us if it shares this host, in which
+		// case its LAN address reaches it too, so it is a last resort rather than
+		// the default the numeric sort would otherwise make it.
+		addrs.sort_by_key(|addr| (addr.ip().is_loopback(), addr.is_ipv6(), *addr));
+		addrs.iter().filter_map(|addr| addr_url(*addr)).collect()
+	}
+}
+
+/// A change in the set of discovered peers.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum Event {
+	/// A peer appeared on the LAN, or re-advertised with different details.
+	Found(Peer),
+
+	/// A previously discovered peer (by [`Peer::id`]) stopped advertising.
+	Lost(String),
+}
+
+/// Advertises this process on the LAN and discovers the others.
+///
+/// Dropping it stops advertising and browsing.
+pub struct Discovery {
+	/// Our own service instance, to recognize and skip our own record.
+	instance: String,
+	/// Our identity for the [`should_dial`] tiebreaker: the node URL, or `instance`.
+	id: String,
+	/// The shared secret, when membership is restricted.
+	secret: Option<Secret>,
+	/// The proof an inbound peer must present, mirroring what we advertised.
+	credential: Option<String>,
+	/// Service instance -> peer id, so a `Lost` event can name what a `Found` did.
+	peers: HashMap<String, String>,
+	daemon: ServiceDaemon,
+	events: mdns_sd::Receiver<ServiceEvent>,
+}
+
+impl Discovery {
+	fn new(config: Config) -> Result<Self> {
+		let instance = format!("{:016x}", rand::random::<u64>());
+		let id = match &config.node {
+			Some(node) => node.to_string(),
+			None => instance.clone(),
+		};
+
+		let mut txt = HashMap::new();
+		if let Some(fingerprint) = &config.fingerprint {
+			txt.insert(TXT_FINGERPRINT.to_string(), fingerprint.clone());
+		}
+		if let Some(node) = &config.node {
+			txt.insert(TXT_NODE.to_string(), node.to_string());
+		}
+
+		// Publish a proof that we hold the secret, and keep the matching dial proof
+		// as what an inbound peer has to present. Both are bound to this nonce and
+		// this listener, so neither authenticates anywhere else.
+		let credential = config.secret.as_ref().map(|secret| {
+			let nonce = format!("{:016x}{:016x}", rand::random::<u64>(), rand::random::<u64>());
+			let node = config.node.as_ref().map(Url::to_string);
+			let id = Identity {
+				instance: &instance,
+				port: config.port,
+				nonce: &nonce,
+				fingerprint: config.fingerprint.as_deref(),
+				node: node.as_deref(),
+			};
+			let advert = proof(secret, CONTEXT_ADVERT, &id);
+			let dial = proof(secret, CONTEXT_DIAL, &id);
+			txt.insert(TXT_PROOF.to_string(), advert);
+			txt.insert(TXT_NONCE.to_string(), nonce);
+			dial
+		});
+
+		let daemon = ServiceDaemon::new()?;
+		let service = ServiceInfo::new(
+			SERVICE_TYPE,
+			&instance,
+			&format!("{instance}.local."),
+			"",
+			config.port,
+			txt,
+		)?
+		.enable_addr_auto();
+		daemon.register(service)?;
+		let events = daemon.browse(SERVICE_TYPE)?;
+
+		tracing::info!(%id, port = config.port, "advertising on the LAN");
+		Ok(Self {
+			instance,
+			id,
+			secret: config.secret,
+			credential,
+			peers: HashMap::new(),
+			daemon,
+			events,
+		})
+	}
+
+	/// This process's discovery identity, as peers see it.
+	pub fn id(&self) -> &str {
+		&self.id
+	}
+
+	/// The proof an inbound peer must present to prove it saw this advertisement
+	/// and holds the secret, or `None` when discovery runs without one.
+	///
+	/// Compare an inbound session's credential against this with
+	/// [`verify_credential`](Self::verify_credential).
+	pub fn credential(&self) -> Option<&str> {
+		self.credential.as_deref()
+	}
+
+	/// Whether `presented` is the credential this listener expects.
+	///
+	/// Always true without a secret, since there is then nothing to prove.
+	pub fn verify_credential(&self, presented: Option<&str>) -> bool {
+		match (&self.credential, presented) {
+			(None, _) => true,
+			(Some(expected), Some(presented)) => ct_eq(expected, presented),
+			(Some(_), None) => false,
+		}
+	}
+
+	/// The next discovery event, or `None` once discovery shuts down.
+	///
+	/// A peer already reported may be reported again when its advertisement
+	/// changes or is periodically re-resolved, so compare against what you have
+	/// rather than assuming each [`Event::Found`] is new.
+	pub async fn recv(&mut self) -> Option<Event> {
+		while let Ok(event) = self.events.recv_async().await {
+			match event {
+				ServiceEvent::ServiceResolved(info) => {
+					let Some(instance) = instance_id(&info.fullname) else {
+						continue;
+					};
+					if instance == self.instance {
+						continue;
+					}
+
+					let node = info
+						.txt_properties
+						.get_property_val_str(TXT_NODE)
+						.and_then(|node| Url::parse(node).ok());
+					let fingerprint = info.txt_properties.get_property_val_str(TXT_FINGERPRINT);
+
+					// Everything in this record is attacker-supplied until the proof
+					// says otherwise, so a peer that can't produce one is not reported
+					// at all rather than reported and left for the caller to filter.
+					let advert = Advert {
+						instance,
+						port: info.port,
+						fingerprint,
+						node: node.as_ref().map(Url::to_string),
+						nonce: info.txt_properties.get_property_val_str(TXT_NONCE),
+						proof: info.txt_properties.get_property_val_str(TXT_PROOF),
+					};
+					let credential = match verify(self.secret.as_ref(), advert) {
+						Ok(credential) => credential,
+						Err(()) => {
+							tracing::debug!(peer = %instance, "ignoring a peer that failed the membership check");
+							continue;
+						}
+					};
+
+					let id = match &node {
+						Some(node) => node.to_string(),
+						None => instance.to_string(),
+					};
+
+					let mut addrs: Vec<SocketAddr> = info
+						.addresses
+						.iter()
+						.map(|addr| discovered_addr(addr, info.port))
+						.collect();
+					// Deterministic order, preferring IPv4 when both families are advertised.
+					addrs.sort_by_key(|addr| (addr.is_ipv6(), *addr));
+
+					self.peers.insert(instance.to_string(), id.clone());
+					return Some(Event::Found(Peer {
+						id,
+						addrs,
+						fingerprint: fingerprint.map(str::to_string),
+						node,
+						credential,
+					}));
+				}
+				ServiceEvent::ServiceRemoved(_ty, fullname) => {
+					let Some(instance) = instance_id(&fullname) else {
+						continue;
+					};
+					let Some(id) = self.peers.remove(instance) else {
+						continue;
+					};
+					// A peer that restarted advertises a fresh instance under the same
+					// node URL, so it is only lost once the last instance goes away.
+					if self.peers.values().any(|other| other == &id) {
+						continue;
+					}
+					return Some(Event::Lost(id));
+				}
+				_ => continue,
+			}
+		}
+		None
+	}
+
+	/// Whether this process dials `remote`, or waits for `remote` to dial it.
+	///
+	/// Both sides of a pair discover each other, and a MoQ session is
+	/// bidirectional, so one connection suffices: the lower id dials and the
+	/// higher accepts. Deterministic on both sides with no coordination.
+	pub fn should_dial(&self, remote: &str) -> bool {
+		should_dial(&self.id, remote)
+	}
+}
+
+impl Drop for Discovery {
+	fn drop(&mut self) {
+		// Best-effort goodbye; peers otherwise learn of the exit via TTL expiry.
+		self.daemon.shutdown().ok();
+	}
+}
+
+/// The [`Discovery::should_dial`] tiebreaker: the lower id dials.
+fn should_dial(local: &str, remote: &str) -> bool {
+	local < remote
+}
+
+/// Turn an mDNS address into a socket address without discarding an IPv6
+/// interface scope.
+fn discovered_addr(addr: &mdns_sd::ScopedIp, port: u16) -> SocketAddr {
+	match addr {
+		mdns_sd::ScopedIp::V6(addr) => scoped_addr(IpAddr::V6(*addr.addr()), port, addr.scope_id().index),
+		_ => scoped_addr(addr.to_ip_addr(), port, 0),
+	}
+}
+
+fn scoped_addr(ip: IpAddr, port: u16, scope_id: u32) -> SocketAddr {
+	match ip {
+		IpAddr::V4(ip) => SocketAddr::new(IpAddr::V4(ip), port),
+		IpAddr::V6(ip) => SocketAddr::V6(SocketAddrV6::new(ip, port, 0, scope_id)),
+	}
+}
+
+/// The URL that reaches `addr`, or `None` for an address a URL host cannot express.
+fn addr_url(addr: SocketAddr) -> Option<Url> {
+	let url = match addr.ip() {
+		IpAddr::V4(ip) => format!("moqt://{ip}:{}", addr.port()),
+		// A link-local address is only meaningful together with the interface it
+		// was seen on, and a URL host has nowhere to put that scope.
+		IpAddr::V6(ip) if ip.is_unicast_link_local() => return None,
+		IpAddr::V6(ip) => format!("moqt://[{ip}]:{}", addr.port()),
+	};
+	url.parse().ok()
+}
+
+/// The instance portion of a DNS-SD fullname like `<instance>._moq._udp.local.`.
+fn instance_id(fullname: &str) -> Option<&str> {
+	fullname.strip_suffix(SERVICE_TYPE)?.strip_suffix('.')
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const KEY_A: &str = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+	const KEY_B: &str = "202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f";
+
+	/// Exactly one side of every pair dials: the lower id. Symmetric ids never
+	/// dial themselves.
+	#[test]
+	fn tiebreak_is_asymmetric() {
+		assert!(should_dial("aaaa", "bbbb"));
+		assert!(!should_dial("bbbb", "aaaa"));
+		assert!(!should_dial("aaaa", "aaaa"));
+	}
+
+	#[test]
+	fn instance_id_strips_the_service_suffix() {
+		assert_eq!(
+			instance_id("0123456789abcdef._moq._udp.local."),
+			Some("0123456789abcdef")
+		);
+		assert_eq!(instance_id("weird name._moq._udp.local."), Some("weird name"));
+		assert_eq!(instance_id("not-a-moq-service._http._tcp.local."), None);
+	}
+
+	#[test]
+	fn secret_requires_exactly_32_hex_bytes_and_redacts_debug() {
+		for invalid in ["", "00", &"x".repeat(64), &"00".repeat(33)] {
+			assert!(Secret::new(invalid).is_err(), "{invalid:?} must not parse");
+		}
+		assert_eq!(
+			format!("{:?}", Secret::new(KEY_A).expect("valid")),
+			"Secret([redacted])"
+		);
+	}
+
+	fn identity<'a>(instance: &'a str, port: u16, fingerprint: Option<&'a str>, node: Option<&'a str>) -> Identity<'a> {
+		Identity {
+			instance,
+			port,
+			nonce: "nonce",
+			fingerprint,
+			node,
+		}
+	}
+
+	/// Each proof is bound to the secret, the role, and every field identifying
+	/// the listener, so one captured anywhere stands in nowhere else.
+	#[test]
+	fn proofs_are_bound_to_one_listener() {
+		let a = Secret::new(KEY_A).expect("valid secret");
+		let b = Secret::new(KEY_B).expect("valid secret");
+		let base = proof(
+			&a,
+			CONTEXT_DIAL,
+			&identity("inst", 443, Some("fp1"), Some("moqt://node-a")),
+		);
+
+		assert_eq!(
+			base,
+			proof(
+				&a,
+				CONTEXT_DIAL,
+				&identity("inst", 443, Some("fp1"), Some("moqt://node-a"))
+			)
+		);
+		for other in [
+			// A different role, secret, or nonce.
+			proof(
+				&a,
+				CONTEXT_ADVERT,
+				&identity("inst", 443, Some("fp1"), Some("moqt://node-a")),
+			),
+			proof(
+				&b,
+				CONTEXT_DIAL,
+				&identity("inst", 443, Some("fp1"), Some("moqt://node-a")),
+			),
+			proof(
+				&a,
+				CONTEXT_DIAL,
+				&Identity {
+					nonce: "other",
+					..identity("inst", 443, Some("fp1"), Some("moqt://node-a"))
+				},
+			),
+			// A different listener, by any of the four fields that name one.
+			proof(
+				&a,
+				CONTEXT_DIAL,
+				&identity("other", 443, Some("fp1"), Some("moqt://node-a")),
+			),
+			proof(
+				&a,
+				CONTEXT_DIAL,
+				&identity("inst", 4443, Some("fp1"), Some("moqt://node-a")),
+			),
+			proof(
+				&a,
+				CONTEXT_DIAL,
+				&identity("inst", 443, Some("fp2"), Some("moqt://node-a")),
+			),
+			proof(
+				&a,
+				CONTEXT_DIAL,
+				&identity("inst", 443, Some("fp1"), Some("moqt://node-b")),
+			),
+			proof(&a, CONTEXT_DIAL, &identity("inst", 443, Some("fp1"), None)),
+			proof(&a, CONTEXT_DIAL, &identity("inst", 443, None, Some("moqt://node-a"))),
+		] {
+			assert_ne!(base, other);
+			assert!(!ct_eq(&base, &other));
+		}
+
+		// Each field ends with a NUL, so shifting a boundary between two NUL-free
+		// fields cannot produce the same input.
+		assert_ne!(
+			proof(&a, CONTEXT_DIAL, &identity("ab", 1, Some("c"), None)),
+			proof(&a, CONTEXT_DIAL, &identity("a", 1, Some("bc"), None))
+		);
+		assert!(!ct_eq("abc", "ab"));
+	}
+
+	/// Loopback is a last resort, link-local is unusable, and everything else is
+	/// kept: nothing in an mDNS record says which interface routes from here.
+	#[test]
+	fn every_routable_address_is_a_candidate() {
+		let peer = Peer {
+			id: "peer".into(),
+			// As advertised: loopback sorts numerically ahead of the LAN address,
+			// and a container bridge sits between them.
+			addrs: [
+				"127.0.0.1:4443",
+				"172.17.0.1:4443",
+				"192.168.1.5:4443",
+				"[fe80::1]:4443",
+			]
+			.into_iter()
+			.map(|addr| addr.parse().expect("valid address"))
+			.collect(),
+			fingerprint: None,
+			node: None,
+			credential: None,
+		};
+
+		let urls: Vec<String> = peer.urls().into_iter().map(String::from).collect();
+		assert_eq!(
+			urls,
+			[
+				"moqt://172.17.0.1:4443",
+				"moqt://192.168.1.5:4443",
+				"moqt://127.0.0.1:4443",
+			],
+			"loopback last, link-local dropped, the rest kept for failover"
+		);
+	}
+
+	/// The canonical node URL wins outright: it comes with a name the peer's
+	/// certificate can match, so there is nothing to fail over between.
+	#[test]
+	fn a_node_url_is_the_only_candidate() {
+		let mut peer = Peer {
+			id: "peer".into(),
+			addrs: vec!["192.168.1.5:4443".parse().expect("valid address")],
+			fingerprint: None,
+			node: Some("https://peer.example.com".parse().expect("valid url")),
+			credential: None,
+		};
+		assert_eq!(peer.urls(), ["https://peer.example.com/".parse().expect("valid url")]);
+
+		peer.node = None;
+		assert_eq!(peer.urls(), ["moqt://192.168.1.5:4443".parse().expect("valid url")]);
+
+		peer.addrs = vec!["[fe80::1]:4443".parse().expect("valid address")];
+		assert!(peer.urls().is_empty(), "a link-local address is not dialable");
+	}
+
+	/// One peer's advertisement, owning its strings so [`Advert`] can borrow them.
+	#[derive(Clone)]
+	struct Advertised {
+		instance: String,
+		port: u16,
+		fingerprint: Option<String>,
+		node: Option<String>,
+		nonce: String,
+		proof: String,
+	}
+
+	impl Advertised {
+		/// What an honest holder of `secret` publishes about itself.
+		fn new(secret: &Secret, instance: &str, fingerprint: Option<&str>, node: Option<&str>) -> Self {
+			let (nonce, port) = ("nonce".to_string(), 443);
+			let id = Identity {
+				instance,
+				port,
+				nonce: &nonce,
+				fingerprint,
+				node,
+			};
+			Self {
+				instance: instance.to_string(),
+				port,
+				fingerprint: fingerprint.map(str::to_string),
+				node: node.map(str::to_string),
+				proof: proof(secret, CONTEXT_ADVERT, &id),
+				nonce,
+			}
+		}
+
+		fn advert(&self) -> Advert<'_> {
+			Advert {
+				instance: &self.instance,
+				port: self.port,
+				fingerprint: self.fingerprint.as_deref(),
+				node: self.node.clone(),
+				nonce: Some(&self.nonce),
+				proof: Some(&self.proof),
+			}
+		}
+	}
+
+	/// The membership decision, every branch, without touching the network.
+	///
+	/// This is the check that stops an attacker from being dialed at all: it can
+	/// advertise any address and fingerprint it likes, but without the secret it
+	/// cannot produce a proof over them, so it is never reported as a peer and
+	/// never receives a credential.
+	#[test]
+	fn verify_admits_only_the_secret_holder() {
+		let ours = Secret::new(KEY_A).expect("valid secret");
+		let theirs = Secret::new(KEY_B).expect("valid secret");
+
+		// The holder is admitted, and gets the proof that peer will check.
+		let honest = Advertised::new(&ours, "honest", Some("fp"), None);
+		assert_eq!(
+			verify(Some(&ours), honest.advert()).expect("admitted"),
+			Some(proof(&ours, CONTEXT_DIAL, &identity("honest", 443, Some("fp"), None)))
+		);
+
+		// A peer proving a different secret is invisible.
+		assert!(
+			verify(
+				Some(&ours),
+				Advertised::new(&theirs, "honest", Some("fp"), None).advert()
+			)
+			.is_err()
+		);
+
+		// So is one with no proof, or a proof with no nonce to bind it.
+		let mut stripped = honest.advert();
+		stripped.proof = None;
+		assert!(verify(Some(&ours), stripped).is_err(), "no proof");
+		let mut stripped = honest.advert();
+		stripped.nonce = None;
+		assert!(verify(Some(&ours), stripped).is_err(), "no nonce");
+
+		// Without a secret, an unproven peer is fine and a proven one is not ours,
+		// so the two groups stay mutually invisible instead of half-connecting.
+		let bare = Advert {
+			instance: "bare",
+			port: 443,
+			fingerprint: Some("fp"),
+			node: None,
+			nonce: None,
+			proof: None,
+		};
+		assert_eq!(verify(None, bare), Ok(None));
+		assert!(verify(None, honest.advert()).is_err());
+	}
+
+	/// An eavesdropper cannot lift a member's nonce and proof into its own
+	/// advertisement. Both TXT values are public, so the only thing stopping a
+	/// verbatim copy is that the proof is bound to the record it arrived in.
+	///
+	/// Every combination matters, including the one where a caller advertises
+	/// neither a fingerprint nor a node URL: with nothing else to bind to, the
+	/// service instance and port are what make the proof non-transferable.
+	#[test]
+	fn a_stolen_proof_does_not_transfer() {
+		let ours = Secret::new(KEY_A).expect("valid secret");
+
+		for (fingerprint, node) in [
+			(None, None),
+			(Some("victim-fp"), None),
+			(None, Some("moqt://victim.example")),
+			(Some("victim-fp"), Some("moqt://victim.example")),
+		] {
+			let victim = Advertised::new(&ours, "victim", fingerprint, node);
+			assert!(verify(Some(&ours), victim.advert()).is_ok(), "the victim is a member");
+
+			// The attacker republishes the stolen nonce and proof under its own
+			// service instance, keeping everything else it can copy.
+			let mut thief = victim.clone();
+			thief.instance = "thief".to_string();
+			assert!(
+				verify(Some(&ours), thief.advert()).is_err(),
+				"a proof lifted onto another instance must not verify ({fingerprint:?}, {node:?})"
+			);
+
+			// Or on the victim's instance but its own port, which is what a second
+			// listener on the same host would look like.
+			let mut thief = victim.clone();
+			thief.port = 4443;
+			assert!(
+				verify(Some(&ours), thief.advert()).is_err(),
+				"a proof lifted onto another port must not verify ({fingerprint:?}, {node:?})"
+			);
+
+			// And the two it could otherwise swap to redirect the dial.
+			let mut thief = victim.clone();
+			thief.fingerprint = Some("thief-fp".to_string());
+			assert!(verify(Some(&ours), thief.advert()).is_err(), "another fingerprint");
+			let mut thief = victim.clone();
+			thief.node = Some("moqt://thief.example".to_string());
+			assert!(verify(Some(&ours), thief.advert()).is_err(), "another node");
+		}
+	}
+
+	/// Advertise on a port nothing listens on, purely to exercise the record.
+	fn discovery(secret: Option<&str>, fingerprint: &str) -> Discovery {
+		let mut config = Config::new(4443).with_fingerprint(fingerprint);
+		if let Some(secret) = secret {
+			config = config.with_secret(Secret::new(secret).expect("valid secret"));
+		}
+		config.advertise().expect("advertise")
+	}
+
+	/// Wait for the peer advertising `fingerprint`, or give up.
+	async fn find(discovery: &mut Discovery, fingerprint: &str) -> Peer {
+		let wait = async {
+			loop {
+				if let Some(Event::Found(peer)) = discovery.recv().await
+					&& peer.fingerprint.as_deref() == Some(fingerprint)
+				{
+					return peer;
+				}
+			}
+		};
+		tokio::time::timeout(std::time::Duration::from_secs(30), wait)
+			.await
+			.unwrap_or_else(|_| panic!("timed out discovering {fingerprint}"))
+	}
+
+	/// Two processes sharing a secret find each other over real mDNS, and each
+	/// ends up holding exactly the credential the other expects.
+	///
+	/// This covers the plumbing: that the nonce and proof survive the TXT record
+	/// and that both sides derive matching credentials from them. It deliberately
+	/// does not try to show the rejection half. Over multicast, "never reported"
+	/// is indistinguishable from "the record never arrived", so such a test would
+	/// pass whether or not the filter ran. [`verify_admits_only_the_secret_holder`]
+	/// and [`a_stolen_proof_does_not_transfer`] prove that half deterministically.
+	///
+	/// Ignored because it multicasts on the host network, which CI runners may
+	/// block; run it by hand when touching discovery:
+	/// `just rs test -p moq-native --features mdns --run-ignored ignored-only`.
+	#[tokio::test]
+	#[ignore = "needs multicast on the host network; run manually"]
+	async fn a_shared_secret_carries_through_real_mdns() {
+		let mut ours = discovery(Some(KEY_A), "ours");
+		let mut theirs = discovery(Some(KEY_A), "theirs");
+
+		let (on_ours, on_theirs) = tokio::join!(find(&mut ours, "theirs"), find(&mut theirs, "ours"));
+
+		// Each side computed the credential the other will check, and neither the
+		// secret nor the credential ever crossed the network.
+		assert!(theirs.verify_credential(on_ours.credential.as_deref()));
+		assert!(ours.verify_credential(on_theirs.credential.as_deref()));
+		assert!(!ours.verify_credential(on_ours.credential.as_deref()), "not its own");
+		assert!(!ours.verify_credential(None));
+
+		assert_ne!(
+			ours.should_dial(&on_ours.id),
+			theirs.should_dial(&on_theirs.id),
+			"exactly one side of the pair dials"
+		);
+	}
+}

--- a/rs/moq-native/src/mdns.rs
+++ b/rs/moq-native/src/mdns.rs
@@ -36,6 +36,14 @@ use url::Url;
 /// The DNS-SD service MoQ processes advertise under.
 const SERVICE_TYPE: &str = "_moq._udp.local.";
 
+/// How long [`Config::advertise`] waits for the daemon to announce on some
+/// interface before giving up.
+///
+/// Generous, because this only has to outlast the daemon opening a socket and
+/// writing one multicast packet; the cost of being wrong is refusing to start a
+/// process that would have meshed fine.
+const ANNOUNCE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// The TXT key carrying the listener certificate's hex SHA-256 fingerprint.
 const TXT_FINGERPRINT: &str = "fp";
 
@@ -70,6 +78,12 @@ enum ErrorKind {
 
 	#[error("secret must be 64 hexadecimal characters or a path to a file containing them, and {0} is neither")]
 	SecretFile(String, #[source] std::io::Error),
+
+	#[error("no network interface could announce on the LAN within {0:?}")]
+	NoInterface(std::time::Duration),
+
+	#[error("no network interface could announce on the LAN")]
+	Interface(#[source] mdns_sd::Error),
 }
 
 impl From<mdns_sd::Error> for Error {
@@ -270,8 +284,12 @@ impl Config {
 	}
 
 	/// Register the advertisement and start browsing for peers.
-	pub fn advertise(self) -> Result<Discovery> {
-		Discovery::new(self)
+	///
+	/// Waits for the daemon to announce on at least one interface before
+	/// returning, so a caller can treat success as "the mesh is live" and gate
+	/// process readiness on it. Errors if no interface works within 5 seconds.
+	pub async fn advertise(self) -> Result<Discovery> {
+		Discovery::new(self).await
 	}
 }
 
@@ -363,7 +381,7 @@ pub struct Discovery {
 }
 
 impl Discovery {
-	fn new(config: Config) -> Result<Self> {
+	async fn new(config: Config) -> Result<Self> {
 		let instance = format!("{:016x}", rand::random::<u64>());
 		let id = match &config.node {
 			Some(node) => node.to_string(),
@@ -399,6 +417,12 @@ impl Discovery {
 		});
 
 		let daemon = ServiceDaemon::new()?;
+		// Subscribe before registering. The daemon opens its multicast sockets
+		// lazily on its own thread, so `ServiceDaemon::new` succeeding proves
+		// nothing; the announcement (or the failure) arrives here. Subscribing
+		// after `register` would race the very event we are waiting for.
+		let monitor = daemon.monitor()?;
+
 		let service = ServiceInfo::new(
 			SERVICE_TYPE,
 			&instance,
@@ -411,6 +435,7 @@ impl Discovery {
 		daemon.register(service)?;
 		let events = daemon.browse(SERVICE_TYPE)?;
 
+		announced(&monitor).await?;
 		tracing::info!(%id, port = config.port, "advertising on the LAN");
 		Ok(Self {
 			instance,
@@ -579,6 +604,52 @@ fn addr_url(addr: SocketAddr) -> Option<Url> {
 		IpAddr::V6(ip) => format!("moqt://[{ip}]:{}", addr.port()),
 	};
 	url.parse().ok()
+}
+
+/// Wait for the daemon to announce on at least one interface.
+///
+/// The daemon opens its multicast sockets lazily on its own thread, so a
+/// per-interface bind or permission failure never reaches the constructor: it
+/// arrives here as [`mdns_sd::DaemonEvent::Error`]. Without this wait, a process
+/// on a host where multicast is blocked reports itself ready and then sits
+/// permanently isolated, which is the failure this whole gate exists to catch.
+///
+/// One interface is enough. A box routinely has interfaces that cannot carry
+/// mDNS (a down VPN adapter, a container bridge with multicast off), and
+/// refusing to start over one of those would be wrong; an error only decides the
+/// outcome if *nothing* announces.
+async fn announced(monitor: &mdns_sd::Receiver<mdns_sd::DaemonEvent>) -> Result<()> {
+	let deadline = tokio::time::Instant::now() + ANNOUNCE_TIMEOUT;
+	// Kept so a total failure reports why rather than just "timed out".
+	let mut failure = None;
+
+	loop {
+		let event = match tokio::time::timeout_at(deadline, monitor.recv_async()).await {
+			Ok(Ok(event)) => event,
+			// The daemon died, or nothing announced in time. Either way the mesh is
+			// not live, which is exactly what the caller is gating on.
+			Ok(Err(_)) | Err(_) => {
+				return Err(Error(match failure {
+					Some(err) => ErrorKind::Interface(err),
+					None => ErrorKind::NoInterface(ANNOUNCE_TIMEOUT),
+				}));
+			}
+		};
+
+		match event {
+			mdns_sd::DaemonEvent::Announce(service, intf) => {
+				tracing::debug!(%service, %intf, "announced on an interface");
+				return Ok(());
+			}
+			// Not fatal on its own: another interface may still work. Keep the
+			// first one, since it's the likeliest explanation if none does.
+			mdns_sd::DaemonEvent::Error(err) => {
+				tracing::warn!(%err, "an interface could not join the LAN mesh");
+				failure.get_or_insert(err);
+			}
+			_ => continue,
+		}
+	}
 }
 
 /// The instance portion of a DNS-SD fullname like `<instance>._moq._udp.local.`.
@@ -906,12 +977,12 @@ mod tests {
 	}
 
 	/// Advertise on a port nothing listens on, purely to exercise the record.
-	fn discovery(secret: Option<&str>, fingerprint: &str) -> Discovery {
+	async fn discovery(secret: Option<&str>, fingerprint: &str) -> Discovery {
 		let mut config = Config::new(4443).with_fingerprint(fingerprint);
 		if let Some(secret) = secret {
 			config = config.with_secret(Secret::new(secret).expect("valid secret"));
 		}
-		config.advertise().expect("advertise")
+		config.advertise().await.expect("advertise")
 	}
 
 	/// Wait for the peer advertising `fingerprint`, or give up.
@@ -940,14 +1011,62 @@ mod tests {
 	/// pass whether or not the filter ran. [`verify_admits_only_the_secret_holder`]
 	/// and [`a_stolen_proof_does_not_transfer`] prove that half deterministically.
 	///
+	/// One working interface is enough, even when others failed first.
+	///
+	/// The daemon reports per-interface failures as it goes, and a host routinely
+	/// has interfaces that cannot carry mDNS (a down VPN adapter, a container
+	/// bridge with multicast off). Treating the first error as fatal would refuse
+	/// to start a process whose real NIC was fine.
+	#[tokio::test]
+	async fn announce_on_any_interface_is_enough() {
+		let (tx, rx) = flume::unbounded();
+		tx.send(mdns_sd::DaemonEvent::Error(mdns_sd::Error::Msg("eth1 is down".into())))
+			.expect("send");
+		tx.send(mdns_sd::DaemonEvent::Announce(
+			SERVICE_TYPE.to_string(),
+			"eth0".to_string(),
+		))
+		.expect("send");
+
+		announced(&rx).await.expect("one usable interface is enough");
+	}
+
+	/// The whole point of the gate: when nothing announces, advertising fails
+	/// rather than reporting a mesh that is permanently isolated.
+	///
+	/// `ServiceDaemon::new` cannot catch this. It returns before the daemon thread
+	/// opens any socket, so a blocked or unpermitted multicast surfaces only here.
+	#[tokio::test(start_paused = true)]
+	async fn no_usable_interface_fails_the_gate() {
+		// Every interface reported a failure, and none ever announced.
+		let (tx, rx) = flume::unbounded();
+		tx.send(mdns_sd::DaemonEvent::Error(mdns_sd::Error::Msg(
+			"multicast not permitted".into(),
+		)))
+		.expect("send");
+		let err = announced(&rx).await.expect_err("no interface announced");
+		// The per-interface cause, not just "timed out".
+		assert!(format!("{err:#}").contains("no network interface"), "{err}");
+		assert!(
+			std::error::Error::source(&err).is_some(),
+			"the interface failure must be kept as the cause"
+		);
+
+		// And silence is a failure too, not an indefinite wait.
+		let (tx, rx) = flume::unbounded::<mdns_sd::DaemonEvent>();
+		let err = announced(&rx).await.expect_err("silence must not hang");
+		assert!(format!("{err}").contains("within"), "{err}");
+		drop(tx);
+	}
+
 	/// Ignored because it multicasts on the host network, which CI runners may
 	/// block; run it by hand when touching discovery:
 	/// `just rs test -p moq-native --features mdns --run-ignored ignored-only`.
 	#[tokio::test]
 	#[ignore = "needs multicast on the host network; run manually"]
 	async fn a_shared_secret_carries_through_real_mdns() {
-		let mut ours = discovery(Some(KEY_A), "ours");
-		let mut theirs = discovery(Some(KEY_A), "theirs");
+		let mut ours = discovery(Some(KEY_A), "ours").await;
+		let mut theirs = discovery(Some(KEY_A), "theirs").await;
 
 		let (on_ours, on_theirs) = tokio::join!(find(&mut ours, "theirs"), find(&mut theirs, "ours"));
 

--- a/rs/moq-native/src/mdns.rs
+++ b/rs/moq-native/src/mdns.rs
@@ -317,6 +317,7 @@ impl Config {
 
 /// A MoQ process discovered on the LAN.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct Peer {
 	/// The advertised node URL when there is one, otherwise the per-run service
 	/// instance. Stable across a re-resolve, and what [`Discovery::should_dial`]

--- a/rs/moq-native/src/mdns.rs
+++ b/rs/moq-native/src/mdns.rs
@@ -398,6 +398,9 @@ pub struct Discovery {
 	credential: Option<String>,
 	/// Service instance -> peer id, so a `Lost` event can name what a `Found` did.
 	peers: HashMap<String, String>,
+	/// Events produced ahead of the caller asking, since one resolve can retire a
+	/// previous identity and report a new one.
+	pending: std::collections::VecDeque<Event>,
 	daemon: ServiceDaemon,
 	events: mdns_sd::Receiver<ServiceEvent>,
 }
@@ -476,6 +479,7 @@ impl Discovery {
 			secret: config.secret,
 			credential,
 			peers: HashMap::new(),
+			pending: std::collections::VecDeque::new(),
 			daemon,
 			events,
 		})
@@ -512,6 +516,12 @@ impl Discovery {
 	/// changes or is periodically re-resolved, so compare against what you have
 	/// rather than assuming each [`Event::Found`] is new.
 	pub async fn recv(&mut self) -> Option<Event> {
+		// Drained before reading the socket, so a retired identity is reported
+		// before the replacement that displaced it.
+		if let Some(event) = self.pending.pop_front() {
+			return Some(event);
+		}
+
 		while let Ok(event) = self.events.recv_async().await {
 			match event {
 				ServiceEvent::ServiceResolved(info) => {
@@ -560,14 +570,22 @@ impl Discovery {
 					// Deterministic order, preferring IPv4 when both families are advertised.
 					addrs.sort_by_key(|addr| (addr.is_ipv6(), *addr));
 
-					self.peers.insert(instance.to_string(), id.clone());
-					return Some(Event::Found(Peer {
-						id,
+					let peer = Peer {
+						id: id.clone(),
 						addrs,
 						fingerprint: fingerprint.map(str::to_string),
 						node,
 						credential,
-					}));
+					};
+
+					// Retire a displaced identity before reporting the replacement, so the
+					// caller drops that dial rather than stranding it.
+					if let Some(old) = retire_previous(&mut self.peers, instance, &id) {
+						self.pending.push_back(Event::Found(peer));
+						return Some(Event::Lost(old));
+					}
+
+					return Some(Event::Found(peer));
 				}
 				ServiceEvent::ServiceRemoved(_ty, fullname) => {
 					let Some(instance) = instance_id(&fullname) else {
@@ -683,6 +701,26 @@ async fn announced(monitor: &mdns_sd::Receiver<mdns_sd::DaemonEvent>) -> Result<
 			_ => continue,
 		}
 	}
+}
+
+/// Point `instance` at `id`, returning a previous identity that nothing else
+/// still refers to and which therefore has to be retired.
+///
+/// A service instance is not its identity: the identity is the advertised node
+/// URL when there is one, so an instance that restarts with a different node URL
+/// comes back under a new id. Callers key their dials by id, and the removal
+/// that eventually arrives names only the new one, so overwriting silently would
+/// leave the old dial running forever against an address nobody advertises.
+///
+/// `None` when the identity is unchanged, or when another instance still
+/// advertises the old one, which is the ordinary case of a peer restarting under
+/// a fresh instance while keeping its node URL.
+fn retire_previous(peers: &mut HashMap<String, String>, instance: &str, id: &str) -> Option<String> {
+	let previous = peers.insert(instance.to_string(), id.to_string())?;
+	if previous == id || peers.values().any(|other| other == &previous) {
+		return None;
+	}
+	Some(previous)
 }
 
 /// The instance portion of a DNS-SD fullname like `<instance>._moq._udp.local.`.
@@ -1007,6 +1045,39 @@ mod tests {
 			thief.node = Some("moqt://thief.example".to_string());
 			assert!(verify(Some(&ours), thief.advert()).is_err(), "another node");
 		}
+	}
+
+	/// An instance that changes identity retires the old one.
+	///
+	/// Without this the caller strands a dial: it keys by peer id, and the removal
+	/// that eventually arrives names only the new id, so the dial opened against
+	/// the old node URL runs forever against an address nobody advertises.
+	#[test]
+	fn a_changed_identity_retires_the_old_one() {
+		let mut peers = HashMap::new();
+
+		// First sighting: nothing to retire.
+		assert_eq!(retire_previous(&mut peers, "aaa", "https://relay.example/"), None);
+		// A periodic re-resolve of the same thing is not a change.
+		assert_eq!(retire_previous(&mut peers, "aaa", "https://relay.example/"), None);
+
+		// The node URL changed across a restart, so the old identity is stranded
+		// unless it comes back out here.
+		assert_eq!(
+			retire_previous(&mut peers, "aaa", "https://relay.example/?cost=5"),
+			Some("https://relay.example/".to_string())
+		);
+
+		// A peer restarting under a fresh instance keeps its node URL, and the old
+		// instance is still advertising it, so nothing is retired yet.
+		peers.clear();
+		retire_previous(&mut peers, "aaa", "https://relay.example/");
+		retire_previous(&mut peers, "bbb", "https://relay.example/");
+		assert_eq!(
+			retire_previous(&mut peers, "bbb", "https://other.example/"),
+			None,
+			"instance aaa still advertises the old identity"
+		);
 	}
 
 	/// Advertise on a port nothing listens on, purely to exercise the record.

--- a/rs/moq-native/src/mdns.rs
+++ b/rs/moq-native/src/mdns.rs
@@ -79,6 +79,11 @@ enum ErrorKind {
 	#[error("secret must be 64 hexadecimal characters or a path to a file containing them, and {0} is neither")]
 	SecretFile(String, #[source] std::io::Error),
 
+	#[error(
+		"a secret needs a fingerprint or a node URL to bind its proof to, otherwise the whole record can be replayed from another address"
+	)]
+	UnboundSecret,
+
 	#[error("no network interface could announce on the LAN within {0:?}")]
 	NoInterface(std::time::Duration),
 
@@ -266,7 +271,24 @@ impl Config {
 	/// Use it when this process is reachable by name with a certificate peers
 	/// already trust. It also becomes the discovery identity, so a restart keeps
 	/// the same one.
-	pub fn with_node(mut self, node: Url) -> Self {
+	///
+	/// Userinfo and the fragment are stripped before the URL goes out: the record
+	/// is multicast in the clear, and a secret authenticates it rather than hiding
+	/// it, so a `user:password@` would be published to everyone on the network.
+	/// Neither means anything to a peer dialing this URL, so dropping them costs
+	/// nothing.
+	///
+	/// The **query is published verbatim**, because callers use it to carry dial
+	/// parameters a peer needs (the relay prices links with `?cost=`). Nothing in
+	/// this module can tell a parameter from a credential, so a caller that puts
+	/// one in the query is publishing it; sanitize there, where the vocabulary is
+	/// known.
+	pub fn with_node(mut self, mut node: Url) -> Self {
+		node.set_fragment(None);
+		// These only fail on a URL that cannot have userinfo (e.g. `mailto:`),
+		// which is already not something a peer could dial.
+		node.set_username("").ok();
+		node.set_password(None).ok();
 		self.node = Some(node);
 		self
 	}
@@ -382,6 +404,17 @@ pub struct Discovery {
 
 impl Discovery {
 	async fn new(config: Config) -> Result<Self> {
+		// A proof binds to the record's public fields, and every one of them can be
+		// copied: mDNS has no authentication, so a responder can answer with another
+		// host's instance name, port, nonce, and proof while its own A records point
+		// at itself. What it cannot forge is a certificate it has no key for, or a
+		// name it does not control. Without one of those the record verifies from
+		// anywhere and discovery reports the impostor as a member, so refuse the
+		// combination rather than advertising a proof that proves nothing.
+		if config.secret.is_some() && config.fingerprint.is_none() && config.node.is_none() {
+			return Err(Error(ErrorKind::UnboundSecret));
+		}
+
 		let instance = format!("{:016x}", rand::random::<u64>());
 		let id = match &config.node {
 			Some(node) => node.to_string(),

--- a/rs/moq-native/src/mdns.rs
+++ b/rs/moq-native/src/mdns.rs
@@ -205,18 +205,19 @@ struct Advert<'a> {
 	proof: Option<&'a str>,
 }
 
-/// Check an advertisement's proof, returning the credential to present when
-/// dialing that peer back.
+/// Check an advertisement's group, returning the credential to present when
+/// dialing that peer back. Open discovery uses the public nonce as its marker;
+/// secret discovery verifies the proof and derives a private dial proof.
 ///
 /// `Err(())` means the peer belongs to a different group: it advertised no proof
 /// while we require one, its proof doesn't verify, or it advertised one while we
 /// run without a secret. Those cases are mutually invisible on purpose, so two
 /// groups can share a network without half-connecting.
-fn verify(secret: Option<&Secret>, advert: Advert<'_>) -> std::result::Result<Option<String>, ()> {
+fn verify(secret: Option<&Secret>, advert: Advert<'_>) -> std::result::Result<String, ()> {
 	let Some(secret) = secret else {
 		return match advert.proof {
 			Some(_) => Err(()),
-			None => Ok(None),
+			None => advert.nonce.map(str::to_string).ok_or(()),
 		};
 	};
 
@@ -231,7 +232,7 @@ fn verify(secret: Option<&Secret>, advert: Advert<'_>) -> std::result::Result<Op
 	if !ct_eq(presented, &proof(secret, CONTEXT_ADVERT, &id)) {
 		return Err(());
 	}
-	Ok(Some(proof(secret, CONTEXT_DIAL, &id)))
+	Ok(proof(secret, CONTEXT_DIAL, &id))
 }
 
 /// What to advertise about this process.
@@ -335,12 +336,14 @@ pub struct Peer {
 	/// The peer's canonical node URL, when it advertised one.
 	pub node: Option<Url>,
 
-	/// The proof of shared-secret membership to present when dialing this peer,
-	/// or `None` when discovery runs without a secret.
+	/// The per-advertisement credential to present when dialing this peer.
 	///
-	/// Bound to this peer's advertisement, so it authenticates nowhere else. The
-	/// peer expects it as its listener's [`Discovery::credential`].
-	pub credential: Option<String>,
+	/// With a shared secret this proves membership and is bound to this peer's
+	/// advertisement. Without one it is a public random marker that prevents an
+	/// ordinary request path from being mistaken for a peer, but provides no
+	/// authentication. The peer expects it as its listener's
+	/// [`Discovery::credential`].
+	pub credential: String,
 }
 
 impl Peer {
@@ -395,8 +398,8 @@ pub struct Discovery {
 	id: String,
 	/// The shared secret, when membership is restricted.
 	secret: Option<Secret>,
-	/// The proof an inbound peer must present, mirroring what we advertised.
-	credential: Option<String>,
+	/// The per-advertisement credential an inbound peer must present.
+	credential: String,
 	/// Service instance -> peer id, so a `Lost` event can name what a `Found` did.
 	peers: HashMap<String, String>,
 	/// Events produced ahead of the caller asking, since one resolve can retire a
@@ -433,25 +436,29 @@ impl Discovery {
 			txt.insert(TXT_NODE.to_string(), node.to_string());
 		}
 
-		// Publish a proof that we hold the secret, and keep the matching dial proof
-		// as what an inbound peer has to present. Both are bound to this nonce and
-		// this listener, so neither authenticates anywhere else.
-		let credential = config.secret.as_ref().map(|secret| {
-			let nonce = format!("{:016x}{:016x}", rand::random::<u64>(), rand::random::<u64>());
-			let node = config.node.as_ref().map(Url::to_string);
-			let id = Identity {
-				instance: &instance,
-				port: config.port,
-				nonce: &nonce,
-				fingerprint: config.fingerprint.as_deref(),
-				node: node.as_deref(),
-			};
-			let advert = proof(secret, CONTEXT_ADVERT, &id);
-			let dial = proof(secret, CONTEXT_DIAL, &id);
-			txt.insert(TXT_PROOF.to_string(), advert);
-			txt.insert(TXT_NONCE.to_string(), nonce);
-			dial
-		});
+		// Every peer presents this advertisement's nonce when dialing, so the mesh
+		// marker cannot collide with an ordinary request path. With a secret, replace
+		// the public nonce with a proof bound to this listener; the advertisement
+		// carries the matching proof so peers outside the group never report it.
+		let nonce = format!("{:016x}{:016x}", rand::random::<u64>(), rand::random::<u64>());
+		txt.insert(TXT_NONCE.to_string(), nonce.clone());
+		let credential = match config.secret.as_ref() {
+			Some(secret) => {
+				let node = config.node.as_ref().map(Url::to_string);
+				let id = Identity {
+					instance: &instance,
+					port: config.port,
+					nonce: &nonce,
+					fingerprint: config.fingerprint.as_deref(),
+					node: node.as_deref(),
+				};
+				let advert = proof(secret, CONTEXT_ADVERT, &id);
+				let dial = proof(secret, CONTEXT_DIAL, &id);
+				txt.insert(TXT_PROOF.to_string(), advert);
+				dial
+			}
+			None => nonce,
+		};
 
 		let daemon = ServiceDaemon::new()?;
 		// Subscribe before registering. The daemon opens its multicast sockets
@@ -491,24 +498,22 @@ impl Discovery {
 		&self.id
 	}
 
-	/// The proof an inbound peer must present to prove it saw this advertisement
-	/// and holds the secret, or `None` when discovery runs without one.
+	/// The per-advertisement credential an inbound peer must present.
 	///
+	/// With a shared secret this proves membership. Without one it is a public
+	/// random marker that distinguishes peer dials from ordinary request paths.
 	/// Compare an inbound session's credential against this with
 	/// [`verify_credential`](Self::verify_credential).
-	pub fn credential(&self) -> Option<&str> {
-		self.credential.as_deref()
+	pub fn credential(&self) -> &str {
+		&self.credential
 	}
 
 	/// Whether `presented` is the credential this listener expects.
 	///
-	/// Always true without a secret, since there is then nothing to prove.
-	pub fn verify_credential(&self, presented: Option<&str>) -> bool {
-		match (&self.credential, presented) {
-			(None, _) => true,
-			(Some(expected), Some(presented)) => ct_eq(expected, presented),
-			(Some(_), None) => false,
-		}
+	/// Without a secret this verifies only the public collision-avoidance marker,
+	/// not membership.
+	pub fn verify_credential(&self, presented: &str) -> bool {
+		ct_eq(&self.credential, presented)
 	}
 
 	/// The next discovery event, or `None` once discovery shuts down.
@@ -872,7 +877,7 @@ mod tests {
 			.collect(),
 			fingerprint: None,
 			node: None,
-			credential: None,
+			credential: "marker".into(),
 		};
 
 		let urls: Vec<String> = peer.urls().into_iter().map(String::from).collect();
@@ -896,7 +901,7 @@ mod tests {
 			addrs: vec!["192.168.1.5:4443".parse().expect("valid address")],
 			fingerprint: None,
 			node: Some("https://peer.example.com".parse().expect("valid url")),
-			credential: None,
+			credential: "marker".into(),
 		};
 		assert_eq!(peer.urls(), ["https://peer.example.com/".parse().expect("valid url")]);
 
@@ -966,7 +971,7 @@ mod tests {
 		let honest = Advertised::new(&ours, "honest", Some("fp"), None);
 		assert_eq!(
 			verify(Some(&ours), honest.advert()).expect("admitted"),
-			Some(proof(&ours, CONTEXT_DIAL, &identity("honest", 443, Some("fp"), None)))
+			proof(&ours, CONTEXT_DIAL, &identity("honest", 443, Some("fp"), None))
 		);
 
 		// A peer proving a different secret is invisible.
@@ -986,17 +991,18 @@ mod tests {
 		stripped.nonce = None;
 		assert!(verify(Some(&ours), stripped).is_err(), "no nonce");
 
-		// Without a secret, an unproven peer is fine and a proven one is not ours,
-		// so the two groups stay mutually invisible instead of half-connecting.
+		// Without a secret, an unproven peer gets its public nonce as the dial
+		// marker. A proven one is not ours, so the two groups stay mutually
+		// invisible instead of half-connecting.
 		let bare = Advert {
 			instance: "bare",
 			port: 443,
 			fingerprint: Some("fp"),
 			node: None,
-			nonce: None,
+			nonce: Some("public-marker"),
 			proof: None,
 		};
-		assert_eq!(verify(None, bare), Ok(None));
+		assert_eq!(verify(None, bare), Ok("public-marker".to_string()));
 		assert!(verify(None, honest.advert()).is_err());
 	}
 
@@ -1177,10 +1183,10 @@ mod tests {
 
 		// Each side computed the credential the other will check, and neither the
 		// secret nor the credential ever crossed the network.
-		assert!(theirs.verify_credential(on_ours.credential.as_deref()));
-		assert!(ours.verify_credential(on_theirs.credential.as_deref()));
-		assert!(!ours.verify_credential(on_ours.credential.as_deref()), "not its own");
-		assert!(!ours.verify_credential(None));
+		assert!(theirs.verify_credential(&on_ours.credential));
+		assert!(ours.verify_credential(&on_theirs.credential));
+		assert!(!ours.verify_credential(&on_ours.credential), "not its own");
+		assert!(!ours.verify_credential(""));
 
 		assert_ne!(
 			ours.should_dial(&on_ours.id),

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -342,7 +342,7 @@ impl NoqClient {
 		let mut config = noq::ClientConfig::new(Arc::new(config));
 		config.transport_config(self.transport.clone());
 
-		tracing::debug!(%url, ?candidates, "connecting");
+		tracing::debug!(peer = %crate::connect::Endpoint(&url), ?candidates, "connecting");
 
 		// Use the configured host_name override for SNI + cert verification, else the URL host.
 		let host_name = self.host_name.clone().unwrap_or(host);

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -334,7 +334,7 @@ impl QuicheClient {
 			candidates.truncate(1);
 		}
 
-		tracing::debug!(%url, ?candidates, "connecting via quiche");
+		tracing::debug!(peer = %crate::connect::Endpoint(&url), ?candidates, "connecting via quiche");
 
 		// Race only the QUIC handshake: the winner alone performs the WebTransport
 		// CONNECT below, so the server sees a single request no matter how many

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -355,7 +355,7 @@ impl QuinnClient {
 		let mut config = quinn::ClientConfig::new(Arc::new(config));
 		config.transport_config(self.transport.clone());
 
-		tracing::debug!(%url, ?candidates, "connecting");
+		tracing::debug!(peer = %crate::connect::Endpoint(&url), ?candidates, "connecting");
 
 		// Use the configured host_name override for SNI + cert verification, else the URL host.
 		let host_name = self.host_name.clone().unwrap_or(host);

--- a/rs/moq-native/src/tcp.rs
+++ b/rs/moq-native/src/tcp.rs
@@ -94,7 +94,7 @@ pub(crate) async fn connect(
 	let host = url.host_str().ok_or(Error::MissingHostname)?;
 	let port = url.port().ok_or(Error::MissingPort)?;
 
-	tracing::debug!(%url, "connecting via TCP");
+	tracing::debug!(peer = %crate::connect::Endpoint(&url), "connecting via TCP");
 	let addrs = tokio::net::lookup_host((host, port)).await?;
 	connect_addrs(crate::failover::interleave(addrs), protocols, failover_delay).await
 }

--- a/rs/moq-native/src/unix.rs
+++ b/rs/moq-native/src/unix.rs
@@ -142,7 +142,7 @@ pub struct PeerCred {
 /// path: `unix:///run/moq/internal.sock`.
 pub(crate) async fn connect(url: Url, protocols: &[&str]) -> Result<qmux::Session> {
 	let path = socket_path(&url).ok_or(Error::MissingPath)?;
-	tracing::debug!(%url, "connecting via Unix socket");
+	tracing::debug!(peer = %crate::connect::Endpoint(&url), "connecting via Unix socket");
 	qmux::uds::Config::new(WIRE_VERSION)
 		.protocols(protocols.iter().copied())
 		.connect(path)

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -150,7 +150,7 @@ pub(crate) async fn connect(
 	match config.delay {
 		Some(delay) if !WEBSOCKET_WON.lock().unwrap().contains(&key) => {
 			tokio::time::sleep(delay).await;
-			tracing::debug!(%url, delay_ms = %delay.as_millis(), "QUIC not yet connected, attempting WebSocket fallback");
+			tracing::debug!(peer = %crate::connect::Endpoint(&url), delay_ms = %delay.as_millis(), "QUIC not yet connected, attempting WebSocket fallback");
 		}
 		_ => {}
 	}
@@ -171,7 +171,7 @@ pub(crate) async fn connect(
 		_ => return Err(Error::UnsupportedScheme(url.scheme().to_string())),
 	};
 
-	tracing::debug!(%url, "connecting via WebSocket");
+	tracing::debug!(peer = %crate::connect::Endpoint(&url), "connecting via WebSocket");
 
 	// Use the existing TLS config (which respects tls-disable-verify) for secure connections.
 	let connector = if needs_tls {
@@ -193,7 +193,7 @@ pub(crate) async fn connect(
 		.await
 		.map_err(Error::Connect)?;
 
-	tracing::warn!(%url, "using WebSocket fallback");
+	tracing::warn!(peer = %crate::connect::Endpoint(&url), "using WebSocket fallback");
 	WEBSOCKET_WON.lock().unwrap().insert(key);
 
 	Ok(session)

--- a/rs/moq-native/tests/reconnect.rs
+++ b/rs/moq-native/tests/reconnect.rs
@@ -25,7 +25,7 @@ async fn a_transient_failure_retries_until_the_budget_runs_out() {
 	backoff.timeout = Some(Duration::from_millis(200));
 
 	// Nothing listens on port 1, so every attempt is refused: transient as far as this layer knows.
-	let url = "tcp://127.0.0.1:1".parse().expect("failed to parse url");
+	let url: url::Url = "tcp://127.0.0.1:1".parse().expect("failed to parse url");
 	let started = tokio::time::Instant::now();
 	let reconnect = client(backoff).connect(url);
 

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -23,8 +23,10 @@ path = "src/main.rs"
 doc = false
 
 [features]
-default = ["iroh", "quinn", "websocket", "uds"]
+default = ["iroh", "cluster-lan", "quinn", "websocket", "uds"]
 iroh = ["moq-native/iroh"]
+# Discover cluster peers on the LAN with mDNS (`--cluster-lan`).
+cluster-lan = ["moq-native/mdns"]
 jemalloc = ["moq-native/jemalloc"]
 noq = ["moq-native/noq"]
 quinn = ["moq-native/quinn"]

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -441,30 +441,47 @@ pub struct LanConfig {
 /// a [`stats::Registry`](moq_net::stats::Registry) with the `with_*` builder
 /// methods. A cluster without a client can serve local sessions but cannot
 /// dial remote peers.
-/// The validated config and bound resources [`Cluster::run`] needs, produced by
-/// [`Cluster::start`].
+/// A [`Cluster`] whose config is validated and whose resources are bound,
+/// produced by [`Cluster::start`] and run with [`run`](Self::run).
 ///
-/// Opaque: it exists so the fallible half of starting a cluster happens before
-/// the process signals readiness, not to be inspected. Holding one means the
-/// config parsed and the LAN advertisement (if any) is live, so dropping it
-/// without running retires that advertisement.
-pub struct Startup {
-	/// `None` when nothing is configured, so [`Cluster::run`] returns immediately.
+/// It owns the cluster it came from rather than being handed back to one. The
+/// two carry matched state (a resolved node URL, a token, a live mDNS
+/// advertisement), so letting a caller pair them up would let one cluster run on
+/// another's identity, or a standalone startup silently disable a configured
+/// cluster. Owning it makes that unrepresentable instead of merely wrong.
+///
+/// Holding one means the config parsed and the LAN advertisement (if any) is
+/// live, so dropping it without running retires that advertisement.
+pub struct Started {
+	cluster: Cluster,
+	/// `None` when nothing is configured, so [`run`](Self::run) returns immediately.
 	work: Option<Work>,
+}
+
+impl Started {
+	/// Run the cluster until it stops.
+	///
+	/// Returns immediately when nothing is configured (standalone).
+	pub async fn run(self) -> anyhow::Result<()> {
+		match self.work {
+			Some(work) => self.cluster.run_work(work).await,
+			None => Ok(()),
+		}
+	}
 }
 
 /// Hand-written because the bound mDNS advertisement isn't `Debug`, and the
 /// contents are internal anyway: what a reader wants is whether there is
 /// anything to run.
-impl std::fmt::Debug for Startup {
+impl std::fmt::Debug for Started {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-		f.debug_struct("Startup")
+		f.debug_struct("Started")
 			.field("standalone", &self.work.is_none())
 			.finish()
 	}
 }
 
-/// The resolved settings behind a [`Startup`] that has work to do.
+/// The resolved settings behind a [`Started`] that has work to do.
 struct Work {
 	gossip: bool,
 	node: Option<String>,
@@ -572,7 +589,7 @@ impl Cluster {
 
 	/// Attach a QUIC client used to dial cluster peers.
 	///
-	/// Required when `config.connect` is non-empty; [`run`](Self::run) returns
+	/// Required when `config.connect` is non-empty; [`start`](Self::start) returns
 	/// an error otherwise.
 	pub fn with_client(mut self, client: moq_native::Client) -> Self {
 		self.client = Some(client);
@@ -668,10 +685,10 @@ impl Cluster {
 		false
 	}
 
-	/// Validate the cluster config and bind anything that can fail, returning the
-	/// [`Startup`] that [`run`](Self::run) consumes.
+	/// Validate the cluster config and bind anything that can fail, returning a
+	/// [`Started`] to run.
 	///
-	/// Split from `run` because `run`'s future is first polled well after the
+	/// Split from running because that future is first polled well after the
 	/// process reports itself ready. Anything fallible left inside it (a malformed
 	/// node URL, an unreadable token file, a bad LAN key, an mDNS bind failure)
 	/// would release systemd's dependent units on a relay that is about to exit.
@@ -679,7 +696,7 @@ impl Cluster {
 	///
 	/// Bails when `mesh` gossip is on without `node`, or when peers are configured
 	/// to dial but no client was attached via [`with_client`](Self::with_client).
-	pub async fn start(&self) -> anyhow::Result<Startup> {
+	pub async fn start(self) -> anyhow::Result<Started> {
 		let (gossip, node) = self.resolve_mesh()?;
 		anyhow::ensure!(
 			!gossip || node.is_some(),
@@ -710,7 +727,10 @@ impl Cluster {
 		let has_work = can_dial || gossip;
 		if !has_work {
 			tracing::info!("no cluster peers configured; running standalone");
-			return Ok(Startup { work: None });
+			return Ok(Started {
+				work: None,
+				cluster: self,
+			});
 		}
 
 		if can_dial {
@@ -759,7 +779,7 @@ impl Cluster {
 			false => None,
 		};
 
-		Ok(Startup {
+		Ok(Started {
 			work: Some(Work {
 				gossip,
 				node,
@@ -768,21 +788,18 @@ impl Cluster {
 				#[cfg(feature = "cluster-lan")]
 				discovery,
 			}),
+			cluster: self,
 		})
 	}
 
-	/// Runs the cluster event loop, using the [`Startup`] from
-	/// [`start`](Self::start).
+	/// Runs the cluster event loop against the work [`start`](Self::start)
+	/// resolved.
 	///
-	/// Modes are derived from config: standalone (no work) returns immediately;
-	/// passive rendezvous (`node` + `mesh` gossip, no peers to dial) parks after
-	/// publishing self-registration and does not require a QUIC client; active
-	/// (`connect` / `connect_api` set) dials peers and, when `mesh` gossip is on,
-	/// also advertises `node` and runs discovery.
-	pub async fn run(self, startup: Startup) -> anyhow::Result<()> {
-		let Some(work) = startup.work else {
-			return Ok(());
-		};
+	/// Modes are derived from config: passive rendezvous (`node` + `mesh` gossip,
+	/// no peers to dial) parks after publishing self-registration and does not
+	/// require a QUIC client; active (`connect` / `connect_api` set) dials peers
+	/// and, when `mesh` gossip is on, also advertises `node` and runs discovery.
+	async fn run_work(self, work: Work) -> anyhow::Result<()> {
 		let Work {
 			gossip,
 			node,
@@ -801,6 +818,10 @@ impl Cluster {
 		// peers that truly left.
 		let dialed = DialMap::default();
 		let mut tasks = tokio::task::JoinSet::new();
+		// Tasks whose ending is a failure rather than an ordinary lifecycle event,
+		// so their result has to be looked at instead of drained.
+		#[allow(unused_mut, reason = "only the cluster-lan feature spawns into it")]
+		let mut supervised: tokio::task::JoinSet<anyhow::Result<()>> = tokio::task::JoinSet::new();
 
 		for peer in &self.config.connect {
 			let key = canonicalize_peer_key(peer);
@@ -842,9 +863,11 @@ impl Cluster {
 			let this = self.clone();
 			let token = token.clone();
 			let dialed = dialed.clone();
-			tasks.spawn(async move {
+			// Supervised rather than fire-and-forget: a dial task ending is ordinary
+			// (that peer went away), but discovery ending is the relay going blind.
+			supervised.spawn(async move {
 				this.run_mdns(canonicalize_peer_key(&node), token, dialed, discovery)
-					.await;
+					.await
 			});
 		}
 
@@ -877,13 +900,22 @@ impl Cluster {
 			None
 		};
 
-		if tasks.is_empty() {
+		if tasks.is_empty() && supervised.is_empty() {
 			// Passive rendezvous: park to keep `self_registration` alive. The
 			// process still exits via the other arms of `tokio::select!` in main.
 			std::future::pending::<()>().await
 		}
 
-		while tasks.join_next().await.is_some() {}
+		loop {
+			tokio::select! {
+				// A supervised task ending at all is a failure, so its result decides
+				// the cluster's. A panic surfaces too rather than being swallowed.
+				Some(res) = supervised.join_next() => res.context("cluster task panicked")??,
+				// A dial task ending is ordinary: that peer went away.
+				Some(_) = tasks.join_next() => {}
+				else => break,
+			}
+		}
 
 		// Deliberate shutdown: finish the registration rather than dropping it, so
 		// there is no dropped-without-finish warning.
@@ -979,7 +1011,7 @@ impl Cluster {
 		token: String,
 		dialed: DialMap,
 		mut discovery: moq_native::mdns::Discovery,
-	) {
+	) -> anyhow::Result<()> {
 		use moq_native::mdns::Event;
 
 		while let Some(event) = discovery.recv().await {
@@ -1018,6 +1050,12 @@ impl Cluster {
 				_ => continue,
 			}
 		}
+
+		// Discovery only ends if the daemon or its channel died. The relay would
+		// otherwise keep serving, still reporting ready, while permanently blind to
+		// LAN peers. Startup refuses to come up without mDNS, so losing it later is
+		// the same failure arriving late.
+		anyhow::bail!("LAN discovery stopped unexpectedly");
 	}
 
 	/// Drive `--cluster-connect-api`: an http(s) URL is polled, a local path (or
@@ -1762,9 +1800,8 @@ mod tests {
 		// `cluster` so we can later check that the registration was published.
 		let mut watcher = cluster.origin.consume().announced();
 
-		let cluster_run = cluster.clone();
-		let startup = cluster_run.start().await.expect("cluster start");
-		let mut handle = tokio::spawn(async move { cluster_run.run(startup).await });
+		let started = cluster.clone().start().await.expect("cluster start");
+		let mut handle = tokio::spawn(async move { started.run().await });
 
 		// Give the runtime a moment to execute the synchronous setup work.
 		tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -1253,7 +1253,12 @@ impl Cluster {
 		// a failed attempt, so an A-redirects-to-B-redirects-to-A loop escalates
 		// through backoff and eventually gives up instead of migrating forever.
 		// Downstream sessions never see a GOAWAY of their own.
-		let mut reconnect = client.connect(url.clone());
+		//
+		// Forced on regardless of `--client-reconnect`: that flag is about the
+		// relay's own upstream dial, and a cluster peer link that stopped following
+		// GOAWAY would break rolling handoff, redialing the drained URL after the
+		// old session finally closed instead of migrating to the replacement.
+		let mut reconnect = client.with_reconnect(true).connect(url.clone());
 		let mut connection = None;
 		loop {
 			match reconnect.status().await? {
@@ -1277,12 +1282,23 @@ impl Cluster {
 async fn lan_discovery(node: &str, secret: &str) -> anyhow::Result<moq_native::mdns::Discovery> {
 	let url = peer_url(node)?;
 	// The advertisement is multicast in the clear. The secret authenticates the
-	// record, it does not hide it, so an inline token here would be handed to
-	// every listener on the network.
+	// record, it does not hide it, so anything in the query is handed to every
+	// listener on the network.
+	//
+	// An allowlist rather than a `jwt` denylist: `cost` is the only query param a
+	// peer needs off the advertised URL, and listing what may go out means the
+	// next credential-bearing param is refused the day it is added instead of
+	// leaking until someone remembers to ban it.
+	let published: Vec<String> = url
+		.query_pairs()
+		.map(|(key, _)| key.into_owned())
+		.filter(|key| key != "cost")
+		.collect();
 	anyhow::ensure!(
-		!url.query_pairs().any(|(key, value)| key == "jwt" && !value.is_empty()),
-		"`--cluster-node` carries an inline `?jwt=`, which `--cluster-lan` would broadcast in the clear. \
-		 Drop it from the node URL and pass the credential with `--cluster-token` instead."
+		published.is_empty(),
+		"`--cluster-node` carries query parameters that `--cluster-lan` would broadcast in the clear ({}). \
+		 Only `?cost=` may be advertised; pass credentials with `--cluster-token` instead.",
+		published.join(", ")
 	);
 	let port = url.port_or_known_default().unwrap_or(443);
 	let secret = moq_native::mdns::Secret::load(secret).context("invalid --cluster-lan-secret")?;

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -65,6 +65,11 @@ enum DialSource {
 	/// Supplied by `--cluster-connect-api`. Released when a fetched peer list no
 	/// longer contains the peer.
 	Api,
+	/// Discovered on the LAN via mDNS (`--cluster-lan`). Released as soon as the
+	/// advertisement goes away, which (unlike gossip) is a definite signal rather
+	/// than one that flaps.
+	#[cfg(feature = "cluster-lan")]
+	Mdns,
 }
 
 /// The set of [`DialSource`]s currently keeping a dial alive.
@@ -73,6 +78,8 @@ struct DialSources {
 	seeded: bool,
 	gossip: bool,
 	api: bool,
+	#[cfg(feature = "cluster-lan")]
+	mdns: bool,
 }
 
 impl DialSources {
@@ -81,6 +88,8 @@ impl DialSources {
 			DialSource::Static => self.seeded = true,
 			DialSource::Gossip => self.gossip = true,
 			DialSource::Api => self.api = true,
+			#[cfg(feature = "cluster-lan")]
+			DialSource::Mdns => self.mdns = true,
 		}
 	}
 
@@ -89,11 +98,17 @@ impl DialSources {
 			DialSource::Static => self.seeded = false,
 			DialSource::Gossip => self.gossip = false,
 			DialSource::Api => self.api = false,
+			#[cfg(feature = "cluster-lan")]
+			DialSource::Mdns => self.mdns = false,
 		}
 	}
 
 	fn any(&self) -> bool {
-		self.seeded || self.gossip || self.api
+		#[cfg(feature = "cluster-lan")]
+		let extra = self.mdns;
+		#[cfg(not(feature = "cluster-lan"))]
+		let extra = false;
+		self.seeded || self.gossip || self.api || extra
 	}
 }
 
@@ -191,6 +206,23 @@ impl DialMap {
 				false
 			}
 		});
+	}
+
+	/// Release `source` from `peer`, aborting the dial only if no other source
+	/// still wants it. For a source whose "gone" signal is definite, unlike the
+	/// gossip unannounce that [`sweep_stale`](Self::sweep_stale) has to wait out.
+	#[cfg(feature = "cluster-lan")]
+	fn release(&self, peer: &str, source: DialSource) {
+		let mut map = self.inner.lock().expect("dial map poisoned");
+		let Some(entry) = map.get_mut(peer) else { return };
+		entry.sources.clear(source);
+		if entry.sources.any() {
+			tracing::debug!(%peer, "peer no longer discovered; still wanted by another source");
+			return;
+		}
+		tracing::info!(%peer, "peer no longer discovered; abandoning dial");
+		entry.handle.abort();
+		map.remove(peer);
 	}
 
 	/// Reconcile the API source against `desired`: release [`DialSource::Api`] from
@@ -322,6 +354,12 @@ pub struct ClusterConfig {
 	#[serde(default, deserialize_with = "deserialize_bool_or_string")]
 	pub mesh: Option<String>,
 
+	/// LAN discovery over mDNS (`[cluster.lan]`).
+	#[cfg(feature = "cluster-lan")]
+	#[command(flatten)]
+	#[serde(default)]
+	pub lan: LanConfig,
+
 	/// JWT presented on outbound cluster dials, read from this file. Applied to
 	/// any peer whose URL doesn't already carry a `?jwt=` (so it authenticates
 	/// gossip- and `connect_api`-discovered peers, whose addresses can't embed a
@@ -351,6 +389,50 @@ pub struct ClusterConfig {
 
 /// A relay cluster built around a single [`origin::Producer`].
 ///
+/// LAN discovery configuration (`[cluster.lan]`).
+///
+/// Advertises [`ClusterConfig::node`] over mDNS and dials the node URLs other
+/// relays advertise, so a rack or a home lab meshes with no seed list and no
+/// shared rendezvous. mDNS only replaces *how* peers are found: they are dialed
+/// and authenticated exactly like any other cluster peer.
+#[derive(clap::Args, Clone, Debug, serde::Serialize, serde::Deserialize, Default)]
+#[serde_with::skip_serializing_none]
+#[serde(default, deny_unknown_fields)]
+#[non_exhaustive]
+#[group(id = "cluster-lan-config")]
+#[cfg(feature = "cluster-lan")]
+pub struct LanConfig {
+	/// Enable mDNS discovery. Requires [`ClusterConfig::node`], so there is an
+	/// address to advertise, and [`Self::secret`]. Boolean flag: pass
+	/// `--cluster-lan` (or `=true` / `=false`).
+	#[arg(
+		id = "cluster-lan",
+		long = "cluster-lan",
+		env = "MOQ_CLUSTER_LAN",
+		default_missing_value = "true",
+		num_args = 0..=1,
+		require_equals = true,
+	)]
+	pub enabled: Option<bool>,
+
+	/// The shared key admitting a peer to the LAN mesh, as 64 hexadecimal
+	/// characters or a path to a file containing them. Required by
+	/// [`Self::enabled`].
+	///
+	/// mDNS is an open channel: anyone can advertise, including an attacker
+	/// naming a URL it controls. Without a proof that the advertiser holds this
+	/// key, this relay would dial that URL and hand it
+	/// [`ClusterConfig::token`]. So the key is mandatory rather than optional,
+	/// and only peers that prove they hold it are ever dialed.
+	#[arg(
+		id = "cluster-lan-secret",
+		long = "cluster-lan-secret",
+		env = "MOQ_CLUSTER_LAN_SECRET",
+		value_name = "HEX_OR_PATH"
+	)]
+	pub secret: Option<String>,
+}
+
 /// Local sessions and remote cluster connections all publish into the same
 /// origin. Loop prevention and route preference come from the hop list carried
 /// on each broadcast's route (see [`moq_net::broadcast::Route`]).
@@ -359,6 +441,40 @@ pub struct ClusterConfig {
 /// a [`stats::Registry`](moq_net::stats::Registry) with the `with_*` builder
 /// methods. A cluster without a client can serve local sessions but cannot
 /// dial remote peers.
+/// The validated config and bound resources [`Cluster::run`] needs, produced by
+/// [`Cluster::start`].
+///
+/// Opaque: it exists so the fallible half of starting a cluster happens before
+/// the process signals readiness, not to be inspected. Holding one means the
+/// config parsed and the LAN advertisement (if any) is live, so dropping it
+/// without running retires that advertisement.
+pub struct Startup {
+	/// `None` when nothing is configured, so [`Cluster::run`] returns immediately.
+	work: Option<Work>,
+}
+
+/// Hand-written because the bound mDNS advertisement isn't `Debug`, and the
+/// contents are internal anyway: what a reader wants is whether there is
+/// anything to run.
+impl std::fmt::Debug for Startup {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		f.debug_struct("Startup")
+			.field("standalone", &self.work.is_none())
+			.finish()
+	}
+}
+
+/// The resolved settings behind a [`Startup`] that has work to do.
+struct Work {
+	gossip: bool,
+	node: Option<String>,
+	can_dial: bool,
+	token: String,
+	/// The live mDNS advertisement, bound by [`Cluster::start`].
+	#[cfg(feature = "cluster-lan")]
+	discovery: Option<moq_native::mdns::Discovery>,
+}
+
 #[derive(Clone)]
 pub struct Cluster {
 	config: ClusterConfig,
@@ -544,17 +660,26 @@ impl Cluster {
 		}
 	}
 
-	/// Runs the cluster event loop.
+	/// Whether `--cluster-lan` asked this relay to discover peers over mDNS.
+	fn lan(&self) -> bool {
+		#[cfg(feature = "cluster-lan")]
+		return self.config.lan.enabled.unwrap_or(false);
+		#[cfg(not(feature = "cluster-lan"))]
+		false
+	}
+
+	/// Validate the cluster config and bind anything that can fail, returning the
+	/// [`Startup`] that [`run`](Self::run) consumes.
 	///
-	/// Modes are derived from config: standalone (no work) returns immediately;
-	/// passive rendezvous (`node` + `mesh` gossip, no peers to dial) parks after
-	/// publishing self-registration and does not require a QUIC client; active
-	/// (`connect` / `connect_api` set) dials peers and, when `mesh` gossip is on,
-	/// also advertises `node` and runs discovery.
+	/// Split from `run` because `run`'s future is first polled well after the
+	/// process reports itself ready. Anything fallible left inside it (a malformed
+	/// node URL, an unreadable token file, a bad LAN key, an mDNS bind failure)
+	/// would release systemd's dependent units on a relay that is about to exit.
+	/// Call this before signalling readiness, and hand the result to `run`.
 	///
 	/// Bails when `mesh` gossip is on without `node`, or when peers are configured
 	/// to dial but no client was attached via [`with_client`](Self::with_client).
-	pub async fn run(self) -> anyhow::Result<()> {
+	pub fn start(&self) -> anyhow::Result<Startup> {
 		let (gossip, node) = self.resolve_mesh()?;
 		anyhow::ensure!(
 			!gossip || node.is_some(),
@@ -562,17 +687,44 @@ impl Cluster {
 			 See https://doc.moq.dev/bin/relay/cluster."
 		);
 
+		let lan = self.lan();
+		anyhow::ensure!(
+			!lan || node.is_some(),
+			"`--cluster-lan` requires `--cluster-node <self-url>` so there's an address to advertise. \
+			 See https://doc.moq.dev/bin/relay/cluster."
+		);
+		// Without this, an attacker advertising a URL it controls would be dialed
+		// like any other peer and handed `--cluster-token`.
+		#[cfg(feature = "cluster-lan")]
+		anyhow::ensure!(
+			!lan || self.config.lan.secret.is_some(),
+			"`--cluster-lan` requires `--cluster-lan-secret <hex-or-path>`, shared by every peer. \
+			 mDNS is unauthenticated, so without it any advertiser on the network would be dialed. \
+			 See https://doc.moq.dev/bin/relay/cluster."
+		);
+
 		let has_outbound = !self.config.connect.is_empty() || self.config.connect_api.is_some();
-		let has_work = has_outbound || gossip;
+		// Every mechanism that opens a dial, so gossip discovery runs whenever
+		// there is something to dial with, not only when a peer was listed.
+		let can_dial = has_outbound || lan;
+		let has_work = can_dial || gossip;
 		if !has_work {
 			tracing::info!("no cluster peers configured; running standalone");
-			return Ok(());
+			return Ok(Startup { work: None });
 		}
 
-		if has_outbound {
+		if can_dial {
 			anyhow::ensure!(
 				self.client.is_some(),
 				"cluster peers configured but no QUIC client attached (call Cluster::with_client)"
+			);
+		}
+
+		// Only http(s) sources need the TLS client; a local file doesn't.
+		if let Some(source) = &self.config.connect_api {
+			anyhow::ensure!(
+				!connect_api_is_http(source) || self.client_tls.is_some(),
+				"cluster.connect_api with an http(s) URL needs client TLS (call Cluster::with_client_tls)"
 			);
 		}
 
@@ -587,6 +739,58 @@ impl Cluster {
 				.to_string(),
 			None => String::new(),
 		};
+
+		// Binds the multicast socket and reads the key, so it belongs here rather
+		// than in `run`: both fail loudly, and the whole point of `--cluster-lan` is
+		// that a relay which cannot join the mesh is misconfigured, not degraded.
+		#[cfg(feature = "cluster-lan")]
+		let discovery = match lan {
+			// Checked above: the LAN mesh advertises `node` and requires a key.
+			true => {
+				let node = node.as_deref().expect("--cluster-lan requires --cluster-node");
+				let secret = self
+					.config
+					.lan
+					.secret
+					.as_deref()
+					.expect("--cluster-lan requires --cluster-lan-secret");
+				Some(lan_discovery(node, secret)?)
+			}
+			false => None,
+		};
+
+		Ok(Startup {
+			work: Some(Work {
+				gossip,
+				node,
+				can_dial,
+				token,
+				#[cfg(feature = "cluster-lan")]
+				discovery,
+			}),
+		})
+	}
+
+	/// Runs the cluster event loop, using the [`Startup`] from
+	/// [`start`](Self::start).
+	///
+	/// Modes are derived from config: standalone (no work) returns immediately;
+	/// passive rendezvous (`node` + `mesh` gossip, no peers to dial) parks after
+	/// publishing self-registration and does not require a QUIC client; active
+	/// (`connect` / `connect_api` set) dials peers and, when `mesh` gossip is on,
+	/// also advertises `node` and runs discovery.
+	pub async fn run(self, startup: Startup) -> anyhow::Result<()> {
+		let Some(work) = startup.work else {
+			return Ok(());
+		};
+		let Work {
+			gossip,
+			node,
+			can_dial,
+			token,
+			#[cfg(feature = "cluster-lan")]
+			discovery,
+		} = work;
 
 		// Static `--cluster-connect` peers and gossip-discovered peers share one
 		// dial map so a peer reached via both paths only opens a single dial.
@@ -622,17 +826,25 @@ impl Cluster {
 		}
 
 		if let Some(source) = self.config.connect_api.clone() {
-			// Only http(s) sources need the TLS client; a local file doesn't.
-			anyhow::ensure!(
-				!connect_api_is_http(&source) || self.client_tls.is_some(),
-				"cluster.connect_api with an http(s) URL needs client TLS (call Cluster::with_client_tls)"
-			);
 			let this = self.clone();
 			let token = token.clone();
 			let dialed = dialed.clone();
 			let node = node.clone();
 			tasks.spawn(async move {
 				this.run_connect_api(source, node, token, dialed).await;
+			});
+		}
+
+		#[cfg(feature = "cluster-lan")]
+		if let Some(discovery) = discovery {
+			// `start` only binds discovery when the LAN mesh is on, which requires `node`.
+			let node = node.clone().expect("--cluster-lan requires --cluster-node");
+			let this = self.clone();
+			let token = token.clone();
+			let dialed = dialed.clone();
+			tasks.spawn(async move {
+				this.run_mdns(canonicalize_peer_key(&node), token, dialed, discovery)
+					.await;
 			});
 		}
 
@@ -649,7 +861,7 @@ impl Cluster {
 				.expect(".internal/origins is within the relay origin's root");
 			tracing::info!(%node, %path, "advertising cluster node URL");
 
-			if has_outbound {
+			if can_dial {
 				let this = self.clone();
 				let token = token.clone();
 				let dialed = dialed.clone();
@@ -745,6 +957,65 @@ impl Cluster {
 				_ = sweep.tick() => {
 					dialed.sweep_stale(Instant::now(), STALE_AFTER);
 				}
+			}
+		}
+	}
+
+	/// Dial every relay that advertises itself on the LAN, the same way gossip
+	/// dials every relay that advertises itself on the cluster origin.
+	///
+	/// mDNS only supplies the peer URL; everything downstream (the tiebreaker, the
+	/// shared dial map, `?jwt=`, `?cost=`, stats, the node view) is the ordinary
+	/// cluster path. A peer that advertises no node URL is skipped: this relay
+	/// dials by name, not by discovered socket.
+	///
+	/// Discovery only reports a peer whose advertisement proved possession of the
+	/// shared key, which is what makes the URL safe to dial with `--cluster-token`
+	/// attached. An unauthenticated record never reaches this loop.
+	#[cfg(feature = "cluster-lan")]
+	async fn run_mdns(
+		self,
+		self_url: String,
+		token: String,
+		dialed: DialMap,
+		mut discovery: moq_native::mdns::Discovery,
+	) {
+		use moq_native::mdns::Event;
+
+		while let Some(event) = discovery.recv().await {
+			match event {
+				Event::Found(peer) => {
+					let Some(node) = peer.node.as_ref() else {
+						tracing::debug!(peer = %peer.id, "LAN peer advertised no --cluster-node URL; skipping");
+						continue;
+					};
+					// The address to dial keeps its query, since `run_remote` reads
+					// `?cost=` off it. The key is only its identity, exactly as on the
+					// gossip path.
+					let peer = node.to_string();
+					let key = canonicalize_peer_key(&peer);
+					// Skip any peer we lose the tiebreaker to; that side dials us.
+					if !should_dial(&self_url, &key) {
+						continue;
+					}
+					if dialed.contains(&key) {
+						dialed.add_source(&key, DialSource::Mdns);
+						continue;
+					}
+					tracing::info!(peer = %key, "discovered LAN cluster peer; dialing");
+					let this = self.clone();
+					let token = token.clone();
+					// Logged by key, never `peer`, so an inline query stays out of the logs.
+					let log_peer = key.clone();
+					let handle = tokio::spawn(async move {
+						if let Err(err) = this.run_remote(&peer, token).await {
+							tracing::warn!(%err, peer = %log_peer, "cluster peer connection ended");
+						}
+					});
+					dialed.insert(key, handle.abort_handle(), DialSource::Mdns);
+				}
+				Event::Lost(id) => dialed.release(&canonicalize_peer_key(&id), DialSource::Mdns),
+				_ => continue,
 			}
 		}
 	}
@@ -995,6 +1266,30 @@ impl Cluster {
 			}
 		}
 	}
+}
+
+/// Advertise this relay's node URL on the LAN, gated on the shared key.
+///
+/// The DNS-SD record needs a port, so it carries the node URL's; peers dial the
+/// URL itself, which is what keeps the relay's normal name-and-certificate path
+/// intact. The key is what makes the advertised URL trustworthy enough to dial.
+#[cfg(feature = "cluster-lan")]
+fn lan_discovery(node: &str, secret: &str) -> anyhow::Result<moq_native::mdns::Discovery> {
+	let url = peer_url(node)?;
+	// The advertisement is multicast in the clear. The secret authenticates the
+	// record, it does not hide it, so an inline token here would be handed to
+	// every listener on the network.
+	anyhow::ensure!(
+		!url.query_pairs().any(|(key, value)| key == "jwt" && !value.is_empty()),
+		"`--cluster-node` carries an inline `?jwt=`, which `--cluster-lan` would broadcast in the clear. \
+		 Drop it from the node URL and pass the credential with `--cluster-token` instead."
+	);
+	let port = url.port_or_known_default().unwrap_or(443);
+	let secret = moq_native::mdns::Secret::load(secret).context("invalid --cluster-lan-secret")?;
+	Ok(moq_native::mdns::Config::new(port)
+		.with_node(url)
+		.with_secret(secret)
+		.advertise()?)
 }
 
 /// Extract and remove the `cost` query param from a peer URL.
@@ -1394,13 +1689,13 @@ mod tests {
 
 	/// Enabling gossip (`--cluster-mesh`) without `--cluster-node` has no address to
 	/// advertise, so it must fail fast with a message naming the missing flag.
-	#[tokio::test]
-	async fn gossip_without_node_errors() {
+	#[test]
+	fn gossip_without_node_errors() {
 		let config = ClusterConfig {
 			mesh: Some("true".to_string()),
 			..Default::default()
 		};
-		let err = Cluster::new(config).unwrap().run().await.expect_err("should error");
+		let err = Cluster::new(config).unwrap().start().expect_err("should error");
 		let msg = format!("{err}");
 		assert!(msg.contains("--cluster-node"), "missing --cluster-node in: {msg}");
 		assert!(msg.contains("--cluster-mesh"), "missing --cluster-mesh in: {msg}");
@@ -1451,7 +1746,8 @@ mod tests {
 		let mut watcher = cluster.origin.consume().announced();
 
 		let cluster_run = cluster.clone();
-		let mut handle = tokio::spawn(async move { cluster_run.run().await });
+		let startup = cluster_run.start().expect("cluster start");
+		let mut handle = tokio::spawn(async move { cluster_run.run(startup).await });
 
 		// Give the runtime a moment to execute the synchronous setup work.
 		tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
@@ -1645,6 +1941,115 @@ mod tests {
 	/// `cluster.connect_api` set in TOML must survive the CLI re-parse when no
 	/// `--cluster-connect-api` flag is passed (same clap+TOML clobber pitfall the
 	/// config tests guard, which is why the field is `Option<String>`).
+	/// The nested `[cluster.lan]` table survives the TOML -> CLI merge, the
+	/// footgun that `Option<T>` fields exist to avoid.
+	#[cfg(feature = "cluster-lan")]
+	#[test]
+	fn cluster_lan_survives_toml_merge() {
+		// clap reads the environment while parsing, so serialize with the tests
+		// that mutate it.
+		let _env = crate::test_env::EnvGuard::clear(&["MOQ_CLUSTER_LAN", "MOQ_CLUSTER_LAN_SECRET"]);
+
+		let toml = "[cluster]\nnode = \"https://relay.example.com\"\n\n[cluster.lan]\nenabled = true\nsecret = \"cluster.key\"\n";
+		let dir = std::env::temp_dir().join("moq-relay-cluster-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("cluster-lan-toml.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![std::ffi::OsString::from("moq-relay"), std::ffi::OsString::from(&path)];
+		let config = Config::parse_and_merge(args).expect("config load");
+		assert_eq!(config.cluster.lan.enabled, Some(true));
+		assert_eq!(config.cluster.lan.secret.as_deref(), Some("cluster.key"));
+		assert_eq!(config.cluster.node.as_deref(), Some("https://relay.example.com"));
+	}
+
+	/// A CLI flag overrides the same key from TOML, rather than the nesting
+	/// hiding it from `update_from`.
+	#[cfg(feature = "cluster-lan")]
+	#[test]
+	fn cli_overrides_toml_cluster_lan() {
+		let _env = crate::test_env::EnvGuard::clear(&["MOQ_CLUSTER_LAN", "MOQ_CLUSTER_LAN_SECRET"]);
+
+		let toml = "[cluster.lan]\nenabled = true\nsecret = \"from-toml.key\"\n";
+		let dir = std::env::temp_dir().join("moq-relay-cluster-test");
+		std::fs::create_dir_all(&dir).unwrap();
+		let path = dir.join("cluster-lan-override.toml");
+		std::fs::write(&path, toml).unwrap();
+
+		let args = vec![
+			std::ffi::OsString::from("moq-relay"),
+			std::ffi::OsString::from(&path),
+			std::ffi::OsString::from("--cluster-lan-secret"),
+			std::ffi::OsString::from("from-cli.key"),
+		];
+		let config = Config::parse_and_merge(args).expect("config load");
+		assert_eq!(config.cluster.lan.secret.as_deref(), Some("from-cli.key"));
+		assert_eq!(config.cluster.lan.enabled, Some(true), "the untouched key survives");
+	}
+
+	/// The LAN needs an address to advertise, like gossip does.
+	#[cfg(feature = "cluster-lan")]
+	#[test]
+	fn lan_without_node_errors() {
+		let config = ClusterConfig {
+			lan: LanConfig {
+				enabled: Some(true),
+				..Default::default()
+			},
+			..Default::default()
+		};
+		let err = Cluster::new(config)
+			.unwrap()
+			.start()
+			.expect_err("--cluster-lan without --cluster-node must fail");
+		let msg = format!("{err}");
+		assert!(msg.contains("--cluster-node"), "missing --cluster-node in: {msg}");
+		assert!(msg.contains("--cluster-lan"), "missing --cluster-lan in: {msg}");
+	}
+
+	/// mDNS is unauthenticated, so a discovered URL is only safe to dial with
+	/// `--cluster-token` attached once its advertiser proved it holds the shared
+	/// key. Starting without one would leak the token to any advertiser, so it is
+	/// refused rather than defaulted to an open mesh.
+	#[cfg(feature = "cluster-lan")]
+	#[test]
+	fn lan_without_a_secret_errors() {
+		let config = ClusterConfig {
+			node: Some("https://us-west.example.com".to_string()),
+			lan: LanConfig {
+				enabled: Some(true),
+				..Default::default()
+			},
+			..Default::default()
+		};
+		let err = Cluster::new(config)
+			.unwrap()
+			.start()
+			.expect_err("--cluster-lan without --cluster-lan-secret must fail");
+		let msg = format!("{err}");
+		assert!(msg.contains("--cluster-lan-secret"), "missing the secret in: {msg}");
+	}
+
+	/// mDNS is just another wanter: a peer also reached by a static seed keeps
+	/// its dial when the advertisement goes away, and only the last release
+	/// tears it down.
+	#[cfg(feature = "cluster-lan")]
+	#[tokio::test]
+	async fn mdns_release_respects_the_other_sources() {
+		let dialed = DialMap::default();
+		dialed.insert("peer:4443".into(), placeholder_handle(), DialSource::Mdns);
+		dialed.add_source("peer:4443", DialSource::Static);
+
+		dialed.release("peer:4443", DialSource::Mdns);
+		assert!(dialed.contains("peer:4443"), "the static seed still wants it");
+
+		dialed.release("peer:4443", DialSource::Static);
+		assert!(!dialed.contains("peer:4443"), "the last release abandons the dial");
+
+		// Releasing an unknown peer is a no-op, not a panic.
+		dialed.release("never-dialed", DialSource::Mdns);
+	}
+
 	#[test]
 	fn cluster_connect_api_survives_toml_merge() {
 		// clap reads the environment while parsing, so serialize with the tests

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -387,8 +387,6 @@ pub struct ClusterConfig {
 	pub linger: Option<Duration>,
 }
 
-/// A relay cluster built around a single [`origin::Producer`].
-///
 /// LAN discovery configuration (`[cluster.lan]`).
 ///
 /// Advertises [`ClusterConfig::node`] over mDNS and dials the node URLs other
@@ -433,14 +431,6 @@ pub struct LanConfig {
 	pub secret: Option<String>,
 }
 
-/// Local sessions and remote cluster connections all publish into the same
-/// origin. Loop prevention and route preference come from the hop list carried
-/// on each broadcast's route (see [`moq_net::broadcast::Route`]).
-///
-/// Construct with [`Cluster::new`], then attach a QUIC client and (optionally)
-/// a [`stats::Registry`](moq_net::stats::Registry) with the `with_*` builder
-/// methods. A cluster without a client can serve local sessions but cannot
-/// dial remote peers.
 /// A [`Cluster`] whose config is validated and whose resources are bound,
 /// produced by [`Cluster::start`] and run with [`run`](Self::run).
 ///
@@ -492,6 +482,16 @@ struct Work {
 	discovery: Option<moq_native::mdns::Discovery>,
 }
 
+/// A relay cluster built around a single [`origin::Producer`].
+///
+/// Local sessions and remote cluster connections all publish into the same
+/// origin. Loop prevention and route preference come from the hop list carried
+/// on each broadcast's route (see [`moq_net::broadcast::Route`]).
+///
+/// Construct with [`Cluster::new`], then attach a QUIC client and (optionally)
+/// a [`stats::Registry`](moq_net::stats::Registry) with the `with_*` builder
+/// methods. A cluster without a client can serve local sessions but cannot
+/// dial remote peers.
 #[derive(Clone)]
 pub struct Cluster {
 	config: ClusterConfig,
@@ -811,7 +811,7 @@ impl Cluster {
 
 		// Static `--cluster-connect` peers and gossip-discovered peers share one
 		// dial map so a peer reached via both paths only opens a single dial.
-		// Gossip-driven unannounces don't abort immediately — the discovery loop
+		// Gossip-driven unannounces don't abort immediately. The discovery loop
 		// runs a periodic sweep that only aborts entries whose unannounce has
 		// stuck for [`STALE_AFTER`]. That filters out the prefer-shorter-hop flap
 		// (sub-millisecond unannounce-then-announce) while still cleaning up

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -858,17 +858,18 @@ impl Cluster {
 
 		#[cfg(feature = "cluster-lan")]
 		if let Some(discovery) = discovery {
-			// `start` only binds discovery when the LAN mesh is on, which requires `node`.
-			let node = node.clone().expect("--cluster-lan requires --cluster-node");
 			let this = self.clone();
 			let token = token.clone();
 			let dialed = dialed.clone();
+			// The identity discovery actually advertises, not the configured URL it
+			// came from. `with_node` strips userinfo before publishing, so comparing
+			// the raw `--cluster-node` here would tiebreak against a spelling no peer
+			// ever sees: both sides could decide the other should dial, and neither
+			// would.
+			let self_url = canonicalize_peer_key(discovery.id());
 			// Supervised rather than fire-and-forget: a dial task ending is ordinary
 			// (that peer went away), but discovery ending is the relay going blind.
-			supervised.spawn(async move {
-				this.run_mdns(canonicalize_peer_key(&node), token, dialed, discovery)
-					.await
-			});
+			supervised.spawn(async move { this.run_mdns(self_url, token, dialed, discovery).await });
 		}
 
 		// Held in scope so the registration stays announced until `run` exits.

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -679,7 +679,7 @@ impl Cluster {
 	///
 	/// Bails when `mesh` gossip is on without `node`, or when peers are configured
 	/// to dial but no client was attached via [`with_client`](Self::with_client).
-	pub fn start(&self) -> anyhow::Result<Startup> {
+	pub async fn start(&self) -> anyhow::Result<Startup> {
 		let (gossip, node) = self.resolve_mesh()?;
 		anyhow::ensure!(
 			!gossip || node.is_some(),
@@ -754,7 +754,7 @@ impl Cluster {
 					.secret
 					.as_deref()
 					.expect("--cluster-lan requires --cluster-lan-secret");
-				Some(lan_discovery(node, secret)?)
+				Some(lan_discovery(node, secret).await?)
 			}
 			false => None,
 		};
@@ -1274,7 +1274,7 @@ impl Cluster {
 /// URL itself, which is what keeps the relay's normal name-and-certificate path
 /// intact. The key is what makes the advertised URL trustworthy enough to dial.
 #[cfg(feature = "cluster-lan")]
-fn lan_discovery(node: &str, secret: &str) -> anyhow::Result<moq_native::mdns::Discovery> {
+async fn lan_discovery(node: &str, secret: &str) -> anyhow::Result<moq_native::mdns::Discovery> {
 	let url = peer_url(node)?;
 	// The advertisement is multicast in the clear. The secret authenticates the
 	// record, it does not hide it, so an inline token here would be handed to
@@ -1289,7 +1289,8 @@ fn lan_discovery(node: &str, secret: &str) -> anyhow::Result<moq_native::mdns::D
 	Ok(moq_native::mdns::Config::new(port)
 		.with_node(url)
 		.with_secret(secret)
-		.advertise()?)
+		.advertise()
+		.await?)
 }
 
 /// Extract and remove the `cost` query param from a peer URL.
@@ -1689,13 +1690,13 @@ mod tests {
 
 	/// Enabling gossip (`--cluster-mesh`) without `--cluster-node` has no address to
 	/// advertise, so it must fail fast with a message naming the missing flag.
-	#[test]
-	fn gossip_without_node_errors() {
+	#[tokio::test]
+	async fn gossip_without_node_errors() {
 		let config = ClusterConfig {
 			mesh: Some("true".to_string()),
 			..Default::default()
 		};
-		let err = Cluster::new(config).unwrap().start().expect_err("should error");
+		let err = Cluster::new(config).unwrap().start().await.expect_err("should error");
 		let msg = format!("{err}");
 		assert!(msg.contains("--cluster-node"), "missing --cluster-node in: {msg}");
 		assert!(msg.contains("--cluster-mesh"), "missing --cluster-mesh in: {msg}");
@@ -1746,7 +1747,7 @@ mod tests {
 		let mut watcher = cluster.origin.consume().announced();
 
 		let cluster_run = cluster.clone();
-		let startup = cluster_run.start().expect("cluster start");
+		let startup = cluster_run.start().await.expect("cluster start");
 		let mut handle = tokio::spawn(async move { cluster_run.run(startup).await });
 
 		// Give the runtime a moment to execute the synchronous setup work.
@@ -1989,8 +1990,8 @@ mod tests {
 
 	/// The LAN needs an address to advertise, like gossip does.
 	#[cfg(feature = "cluster-lan")]
-	#[test]
-	fn lan_without_node_errors() {
+	#[tokio::test]
+	async fn lan_without_node_errors() {
 		let config = ClusterConfig {
 			lan: LanConfig {
 				enabled: Some(true),
@@ -2001,6 +2002,7 @@ mod tests {
 		let err = Cluster::new(config)
 			.unwrap()
 			.start()
+			.await
 			.expect_err("--cluster-lan without --cluster-node must fail");
 		let msg = format!("{err}");
 		assert!(msg.contains("--cluster-node"), "missing --cluster-node in: {msg}");
@@ -2012,8 +2014,8 @@ mod tests {
 	/// key. Starting without one would leak the token to any advertiser, so it is
 	/// refused rather than defaulted to an open mesh.
 	#[cfg(feature = "cluster-lan")]
-	#[test]
-	fn lan_without_a_secret_errors() {
+	#[tokio::test]
+	async fn lan_without_a_secret_errors() {
 		let config = ClusterConfig {
 			node: Some("https://us-west.example.com".to_string()),
 			lan: LanConfig {
@@ -2025,6 +2027,7 @@ mod tests {
 		let err = Cluster::new(config)
 			.unwrap()
 			.start()
+			.await
 			.expect_err("--cluster-lan without --cluster-lan-secret must fail");
 		let msg = format!("{err}");
 		assert!(msg.contains("--cluster-lan-secret"), "missing the secret in: {msg}");

--- a/rs/moq-relay/src/relay.rs
+++ b/rs/moq-relay/src/relay.rs
@@ -192,6 +192,12 @@ impl Relay {
 			..
 		} = self;
 
+		// Validate the cluster and bind its LAN advertisement before claiming to be
+		// ready: the `cluster.run()` below is first polled after the notify, so a bad
+		// key or an mDNS failure would otherwise release the units depending on a
+		// relay that is about to exit.
+		let startup = cluster.start().await.context("cluster failed to start")?;
+
 		#[cfg(unix)]
 		// Notify systemd that we're ready after all initialization is complete
 		let _ = sd_notify::notify(&[sd_notify::NotifyState::Ready]);
@@ -202,7 +208,7 @@ impl Relay {
 		let jemalloc = std::future::pending::<anyhow::Result<()>>();
 
 		tokio::select! {
-			Err(err) = cluster.clone().run() => Err(err).context("cluster failed"),
+			Err(err) = cluster.clone().run(startup) => Err(err).context("cluster failed"),
 			Err(err) = web.run() => Err(err).context("web server failed"),
 			Err(err) = internal.run() => Err(err).context("internal server failed"),
 			Err(err) = serve(server, cluster, auth, shutdown.clone()) => Err(err).context("server failed"),

--- a/rs/moq-relay/src/relay.rs
+++ b/rs/moq-relay/src/relay.rs
@@ -196,7 +196,7 @@ impl Relay {
 		// ready: the `cluster.run()` below is first polled after the notify, so a bad
 		// key or an mDNS failure would otherwise release the units depending on a
 		// relay that is about to exit.
-		let startup = cluster.start().await.context("cluster failed to start")?;
+		let started = cluster.clone().start().await.context("cluster failed to start")?;
 
 		#[cfg(unix)]
 		// Notify systemd that we're ready after all initialization is complete
@@ -208,7 +208,7 @@ impl Relay {
 		let jemalloc = std::future::pending::<anyhow::Result<()>>();
 
 		tokio::select! {
-			Err(err) = cluster.clone().run(startup) => Err(err).context("cluster failed"),
+			Err(err) = started.run() => Err(err).context("cluster failed"),
 			Err(err) = web.run() => Err(err).context("web server failed"),
 			Err(err) = internal.run() => Err(err).context("internal server failed"),
 			Err(err) = serve(server, cluster, auth, shutdown.clone()) => Err(err).context("server failed"),

--- a/rs/moq-relay/tests/goaway_cluster.rs
+++ b/rs/moq-relay/tests/goaway_cluster.rs
@@ -202,8 +202,8 @@ async fn cluster_migrates_on_upstream_goaway_inner() {
 		cluster_config.connect = vec![format!("tcp://127.0.0.1:{port_a}/")];
 		let cluster = Cluster::new(cluster_config).expect("cluster init").with_client(client);
 
-		let startup = cluster.start().await.expect("cluster start");
-		let cluster_run = tokio::spawn(cluster.clone().run(startup));
+		let started = cluster.clone().start().await.expect("cluster start");
+		let cluster_run = tokio::spawn(started.run());
 
 		// A dials in; hold its server-side session so we can drain it.
 		let session_a = accepted_a.recv().await.expect("sibling A accepts the cluster dial");
@@ -318,11 +318,10 @@ async fn spawn_relay_with_upstream(
 
 	let cluster = Cluster::new(cluster_config).expect("cluster init").with_client(client);
 
-	let startup = cluster.start().await.expect("cluster start");
+	let started = cluster.clone().start().await.expect("cluster start");
 	let handle = tokio::spawn(async move {
-		let cluster_run = cluster.clone();
 		tokio::spawn(async move {
-			let _ = cluster_run.run(startup).await;
+			let _ = started.run().await;
 		});
 
 		let mut accept_notify = accept_notify;
@@ -607,8 +606,8 @@ async fn cluster_reconnects_on_empty_uri_goaway_inner() {
 	let mut cluster_config = ClusterConfig::default();
 	cluster_config.connect = vec![format!("tcp://127.0.0.1:{port}/")];
 	let cluster = Cluster::new(cluster_config).expect("cluster init").with_client(client);
-	let startup = cluster.start().await.expect("cluster start");
-	let cluster_run = tokio::spawn(cluster.clone().run(startup));
+	let started = cluster.clone().start().await.expect("cluster start");
+	let cluster_run = tokio::spawn(started.run());
 
 	let first_dial = within("upstream accepts the cluster dial", accepted.recv())
 		.await

--- a/rs/moq-relay/tests/goaway_cluster.rs
+++ b/rs/moq-relay/tests/goaway_cluster.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use moq_net::Origin;
 use moq_relay::{AuthConfig, Cluster, ClusterConfig, Connection, PublicConfig};
+use url::Url;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(15);
 
@@ -201,7 +202,8 @@ async fn cluster_migrates_on_upstream_goaway_inner() {
 		cluster_config.connect = vec![format!("tcp://127.0.0.1:{port_a}/")];
 		let cluster = Cluster::new(cluster_config).expect("cluster init").with_client(client);
 
-		let cluster_run = tokio::spawn(cluster.clone().run());
+		let startup = cluster.start().expect("cluster start");
+		let cluster_run = tokio::spawn(cluster.clone().run(startup));
 
 		// A dials in; hold its server-side session so we can drain it.
 		let session_a = accepted_a.recv().await.expect("sibling A accepts the cluster dial");
@@ -316,10 +318,11 @@ async fn spawn_relay_with_upstream(
 
 	let cluster = Cluster::new(cluster_config).expect("cluster init").with_client(client);
 
+	let startup = cluster.start().expect("cluster start");
 	let handle = tokio::spawn(async move {
 		let cluster_run = cluster.clone();
 		tokio::spawn(async move {
-			let _ = cluster_run.run().await;
+			let _ = cluster_run.run(startup).await;
 		});
 
 		let mut accept_notify = accept_notify;
@@ -604,7 +607,8 @@ async fn cluster_reconnects_on_empty_uri_goaway_inner() {
 	let mut cluster_config = ClusterConfig::default();
 	cluster_config.connect = vec![format!("tcp://127.0.0.1:{port}/")];
 	let cluster = Cluster::new(cluster_config).expect("cluster init").with_client(client);
-	let cluster_run = tokio::spawn(cluster.clone().run());
+	let startup = cluster.start().expect("cluster start");
+	let cluster_run = tokio::spawn(cluster.clone().run(startup));
 
 	let first_dial = within("upstream accepts the cluster dial", accepted.recv())
 		.await
@@ -726,7 +730,8 @@ async fn goaway_handover_is_enforced_while_the_replacement_dial_hangs_inner() {
 	client_config.backoff.initial = Some(Duration::from_millis(50));
 	let client = client_config.init().expect("client init");
 
-	let connection = client.connect(format!("tcp://127.0.0.1:{port}/").parse().expect("parse url"));
+	let url: Url = format!("tcp://127.0.0.1:{port}/").parse().expect("parse url");
+	let connection = client.connect(url);
 	let connection = within("client connects", connection.established())
 		.await
 		.expect("connect");

--- a/rs/moq-relay/tests/goaway_cluster.rs
+++ b/rs/moq-relay/tests/goaway_cluster.rs
@@ -202,7 +202,7 @@ async fn cluster_migrates_on_upstream_goaway_inner() {
 		cluster_config.connect = vec![format!("tcp://127.0.0.1:{port_a}/")];
 		let cluster = Cluster::new(cluster_config).expect("cluster init").with_client(client);
 
-		let startup = cluster.start().expect("cluster start");
+		let startup = cluster.start().await.expect("cluster start");
 		let cluster_run = tokio::spawn(cluster.clone().run(startup));
 
 		// A dials in; hold its server-side session so we can drain it.
@@ -318,7 +318,7 @@ async fn spawn_relay_with_upstream(
 
 	let cluster = Cluster::new(cluster_config).expect("cluster init").with_client(client);
 
-	let startup = cluster.start().expect("cluster start");
+	let startup = cluster.start().await.expect("cluster start");
 	let handle = tokio::spawn(async move {
 		let cluster_run = cluster.clone();
 		tokio::spawn(async move {
@@ -607,7 +607,7 @@ async fn cluster_reconnects_on_empty_uri_goaway_inner() {
 	let mut cluster_config = ClusterConfig::default();
 	cluster_config.connect = vec![format!("tcp://127.0.0.1:{port}/")];
 	let cluster = Cluster::new(cluster_config).expect("cluster init").with_client(client);
-	let startup = cluster.start().expect("cluster start");
+	let startup = cluster.start().await.expect("cluster start");
 	let cluster_run = tokio::spawn(cluster.clone().run(startup));
 
 	let first_dial = within("upstream accepts the cluster dial", accepted.recv())


### PR DESCRIPTION
> **Rebased onto `dev` and stacked on #2614.** This PR now targets `dev` instead of `main`, because the multi-address dial it needs became a breaking change to `Client::connect` rather than an additive `reconnect_any` sibling. The first 8 commits are #2614's; **review only the last 4**. GitHub will show the parent's diff until #2614 merges.

## Summary

`moq --cluster-lan` meshes with every other participating MoQ process on the LAN over mDNS: no relay, internet, or certificate setup needed. `moq-relay --cluster-lan` does the same for a rack or home lab of relays.

The work splits into a discovery primitive and two thin policies on top:

- **`moq_native::mdns`** (feature `mdns`) advertises this process as a `_moq._udp.local.` service and browses for the others, yielding `Found`/`Lost` peers. Discovery only: what to do with a peer stays with the caller, and `should_dial` supplies the pair tiebreaker. The record carries the listener port plus, optionally, the certificate fingerprint (pinned in place of a CA) and a canonical node URL (dialed by name when the peer has real DNS and a real certificate).
- **`moq --cluster-lan`** reuses the `--server-bind` listener, filling it in with an ephemeral port and a generated certificate when unset, so the mesh shares one port and one certificate with ordinary clients rather than standing up a second listener. Each peer is a plain `moq_native::Connection`, so backoff, status, bandwidth, and stats come for free.
- **`moq-relay --cluster-lan`** adds `DialSource::Mdns` to the existing cluster dial map. mDNS only replaces *how peers are found*: they are dialed at their `--cluster-node` URL through the unchanged `run_remote`, with `--cluster-token`, `?cost=`, stats, and the node view all intact, and the shared dial map means a peer found two ways still opens one session.

## The API change (why this moved to `dev`)

A discovered peer advertises every interface it answered on: its loopback, a container bridge, a VPN address, the LAN address that actually routes from here. Nothing in the record says which is which, so a dial has to walk them.

Against `main` that had to be additive, so it was `Client::reconnect_any(urls)` alongside `reconnect(url)` — two entry points differing only in arity. On `dev`, with #2614 having already made `connect` the front door, it collapses into one:

```rust
pub fn connect(&self, addrs: impl Into<Addrs>) -> Connection   // was: url: Url
```

`Addrs` is a non-empty list of addresses for the **same** peer, walked in order until one connects. `From<Url>` covers the single-address case, so every existing `connect(url)` caller is untouched.

The concrete win is that an empty candidate list stops being representable. It had been a runtime `Error::Reconnect("no address to connect to")` checked inside the dial loop — needed only because the mesh sets `--backoff-timeout=0` (retry forever), which would otherwise spin on nothing — plus a test to pin that behavior. It is now an `Option` returned by `Addrs::collect` at the one call site that can produce empty, where `Lan::dial` already had to handle it. That is less code than the two-entry-point version, not more.

Two knobs I prototyped and dropped as invented requirements: a per-dial TLS override and a configurable attempt timeout. Neither has a caller.

Only an attempt with a later candidate to fall back on is bounded (5s). Cutting the last one short would turn a slow connect into a failed one on every reconnect cycle. A GOAWAY redirect collapses the list to the single URL the peer named, since that is an assignment rather than a detour.

## Membership

Anyone can advertise on mDNS, so an unauthenticated record proves nothing. `--cluster-lan-secret` (64 hex characters or a path containing them, shared by every peer) closes that off:

- Each advertisement carries an HMAC-SHA256 proof bound to that listener's own service instance, port, nonce, certificate fingerprint, and node identity.
- A peer whose proof does not verify is **never reported by discovery**, so it is never dialed and never receives anything.
- The credential a dialer presents in return is derived from that one advertisement, so it authenticates to that listener and nowhere else.
- The key never crosses the network, and peers with different keys (or none) are mutually invisible.

Without a secret, `moq --cluster-lan` is open to anyone who can reach the listener, exactly like a bare `--server-bind`. `moq-relay` **requires** the secret instead of defaulting to an open mesh, because it is the side holding a `--cluster-token` that an unauthenticated advertiser could otherwise collect.

Because the proofs are HMACs over a public nonce, a weak key can be brute-forced offline by anyone watching the network; the docs say to generate 32 random bytes.

## `Cluster::start()` / `run(startup)`

This was the known-open item from the previous round, and it is fixed here.

`main.rs` signalled systemd `READY=1` *before* `cluster.run()` was first polled from the `tokio::select!` below it. So a bad LAN key or an mDNS bind failure released dependent units on a relay that was about to exit.

`Cluster::run` now splits: `start()` does every fallible step (mesh/node validation, the token file read, the `connect_api` TLS check, and the mDNS bind) and returns an opaque `Startup` that `run` consumes. `main` calls `start()` before the notify. The three tests asserting a config error now call `start()` and are synchronous rather than `#[tokio::test]`.

## Public API changes

- **Breaking (`moq-native`)**: `Client::connect` takes `impl Into<Addrs>` instead of `Url`. Source-compatible for every existing caller via `From<Url>`. One exception worth knowing: an inline `client.connect(s.parse().unwrap())` no longer infers `Url` and needs an explicit binding. There was exactly one such site in the tree.
- **Breaking (`moq-relay`)**: `Cluster::run` takes a `Startup`, produced by the new `Cluster::start`.
- New `moq_native::mdns` module and `mdns` feature, exposing `Config`, `Discovery`, `Peer`, `Event`, `Secret`, `Error`, and `ct_eq`. `mdns_sd` is not re-exported.
- New `moq_native::Addrs`.
- New CLI flags: `--cluster-lan` / `MOQ_CLUSTER_LAN` and `--cluster-lan-secret` / `MOQ_CLUSTER_LAN_SECRET` on `moq`, and `[cluster.lan] enabled/secret` on `moq-relay`. The `cluster-lan` feature is on by default for both binaries.
- New dependency: `mdns-sd`. `hmac`, `sha2`, and `subtle` were already in the tree.

## Test plan

- `just fix` and `just check` green
- `just rs test`: 2516 passed, 1 skipped
- `just test smoke`: all checks passed
- `cargo check -p moq-cli --no-default-features --features quinn` and the same for `moq-relay` (the feature compiles out)
- Real-multicast tests, `#[ignore]`d because CI runners may block multicast: `cargo test -p moq-native --features mdns,quinn mdns:: -- --include-ignored`, 9 passed locally.

Three things worth substantiating rather than asserting:

- **The candidate walk is falsifiable.** `dial_any_walks_past_the_dead_addresses` was mutation-tested by truncating the walk to the first candidate (`.take(1)`); it fails with `ConnectionRefused`, as it should.
- **Those walk tests went from 6s to 0.08s.** They had used reserved documentation addresses (192.0.2.1, 198.51.100.1) over `moqt://`, which cost a full 5s per-attempt bound *and* were routing-dependent: one black-holes, the other fast-fails, and which is which varies by host. They now use `tcp://` at a closed loopback port, which RSTs instantly and deterministically. The bound-only-if-there-is-a-fallback policy is covered separately by `attempt_timeout` as a pure function, which is the right split: the walk and the timeout policy are different concerns.
- **Three pre-existing tests that the previous force-push had silently deleted are restored**: `test_backoff_default`, `test_backoff_linger`, and `poll_forward_mirrors_until_the_source_closes`. They survive on #2614, so basing on it brought them back.

Cross-package sync: `doc/bin/cli.md`, `doc/bin/relay/cluster.md`, `doc/bin/relay/config.md`, and `doc/lib/rs/env/native.md` (the new `Addrs` shape). No wire format or `moq-ffi` surface changed, so no draft or language-binding update is required.

## Known and open

Both are pre-existing and neither blocks this PR:

- The advertised certificate fingerprint is snapshotted at startup, so a `--tls-cert` hot reload strands peers pinning the old one.
- `Lan::dial` builds a whole `Client` per peer, and therefore a UDP socket per peer, purely to pin a per-peer fingerprint. The backends already accept a `&rustls::ClientConfig` per dial, so this is fixable without an API change.

(written by Opus 5)
