### PR TITLE
test(net): name the spin the misaligned-copy test actually guards

### DIFF
--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -2584,8 +2584,16 @@ mod test {
 	/// position, from a protocol-violating peer) is never latched: the latch is
 	/// trusted for alignment, so a misaligned one would surface its frames under
 	/// the wrong indices. The reader buries the copy as lagged instead.
+	///
+	/// This is also the guard on the revival in [`Group::poll_covering`], which
+	/// reconsiders a buried route ahead of the terminal checks: revival keys on
+	/// [`track::Consumer::poll_serving_group`], and if that stopped requiring the
+	/// copy to serve the requested frame, the copy here would revive, re-bury on
+	/// the very next peek, and loop forever inside one poll. That regression
+	/// surfaces as a hang rather than a failed assertion, which nextest reports
+	/// as a TIMEOUT.
 	#[tokio::test]
-	async fn misaligned_copy_is_never_latched() {
+	async fn misaligned_copy_is_lost_without_spinning() {
 		let (mut track, consumer) = track_pair("t");
 		let mut producer = Producer::new();
 		producer.takeover(&consumer).unwrap();
@@ -2599,10 +2607,15 @@ mod test {
 
 		let mut reading = sub.recv_group().now_or_never().unwrap().unwrap().unwrap();
 		assert_eq!(reading.index(), 0);
-		assert!(
-			matches!(reading.read_frame().now_or_never(), Some(Err(_))),
-			"a misaligned copy surfaces as a loss, never as misnumbered frames"
-		);
+
+		// The head is gone for good, so the group ends as a loss naming the copy
+		// that could not cover it, rather than surfacing misnumbered frames.
+		let err = reading
+			.read_frame()
+			.now_or_never()
+			.expect("the loss must resolve rather than park")
+			.expect_err("a misaligned copy is a loss, never misnumbered frames");
+		assert!(matches!(err, Error::Lagged), "expected a lagged copy, got {err:?}");
 	}
 
 	/// Seeking forward keeps a latched copy that still covers the new position:

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1876,7 +1876,11 @@ impl Consumer {
 	/// to reconsider a route it gave up on, so it must be exact about what
 	/// "available" means: a copy that cannot start at `index` (its head is gone)
 	/// leaves the route buried rather than reviving it into a peek that would
-	/// bury it again.
+	/// bury it again. That exactness is load-bearing, since the reader consults
+	/// this ahead of its terminal checks: relaxing it to "the group exists" makes
+	/// revive and re-bury alternate forever inside one poll
+	/// (`resume::test::misaligned_copy_is_lost_without_spinning`, where the
+	/// regression surfaces as a hang).
 	pub(crate) fn poll_serving_group(&self, sequence: u64, index: u64, waiter: &kio::Waiter) -> Poll<()> {
 		let ConsumerKind::Plain(state) = &self.inner else {
 			// A segment's track is never itself spliced.


### PR DESCRIPTION
Follow-up from the review on #2582: the no-spin property that PR relies on was covered only by accident.

## The gap

`Group::poll_covering` reconsiders a buried route **ahead of** its terminal checks, so the revival predicate is the only thing standing between it and an infinite loop: revive on a copy that cannot serve the requested frame, re-bury on the very next peek, revive again, forever, inside a single poll. `track::Consumer::poll_serving_group`'s exact-frame check is what prevents that.

Nothing recorded this. The property was pinned only incidentally, by a test named for *latching*, and a regression surfaced as an unexplained 60-second hang in a test whose name gave no hint why.

## What this does

Says it in both places that would be edited together:

- The test's name and doc now carry the spin: a relaxed check makes it loop, and the regression appears as a nextest TIMEOUT rather than a failed assertion (which is the repo's documented convention that a hang is a finding).
- `poll_serving_group`'s doc points back at the test, so someone tempted to relax the check to "the group exists" reads what that costs first.

It also tightens the assertion from "any error" to `Error::Lagged` specifically, which is what naming the copy that could not cover the group actually means.

## Why no new test

I set out to add a dedicated no-spin test and concluded it would be a near-duplicate. The spin needs a cached copy that cannot serve the reader's frame, and such a copy always pushes the track's resume position past that frame, which strands it. So the terminal verdict is reached in every reachable variant, and a second test would assert the same `Err` on the same setup as this one. Better to make the existing test say what it protects than to grow the suite with a copy of it.

An infinite loop inside a synchronous poll can only ever be observed as "the poll did not return", so no assertion can catch it directly; the honest improvement is making the timeout self-explanatory.

## Test plan

- `cargo nextest run -p moq-net`: 691 passed.
- **Mutation-checked**: relaxing `poll_serving_group` to ignore the frame index makes `misaligned_copy_is_lost_without_spinning` spin and time out at 60s, confirming the renamed test still catches the regression it now describes.
- `just check` clean. Loom not run: no behavior change, docs/name/assertion only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Fable 5)
