### PR TITLE
fix(moq-native): dial the resolver's first choice, not the first family match

### DIFF
--- a/rs/moq-native/src/bind.rs
+++ b/rs/moq-native/src/bind.rs
@@ -31,6 +31,20 @@ pub fn udp(addr: SocketAddr) -> std::io::Result<UdpSocket> {
 	Ok(socket.into())
 }
 
+/// Whether `socket` also reaches IPv4, through IPv4-mapped addresses.
+///
+/// [`udp`] clears `IPV6_V6ONLY` best-effort, so this reads back what the
+/// platform actually did rather than assuming it took. A socket that stayed
+/// v6-only can't send to a mapped destination, and it looks identical from the
+/// outside: `local_addr` reads `[::]` either way. Always false for an IPv4
+/// socket, which reaches IPv4 natively rather than through mapping.
+pub(crate) fn udp_is_dual_stack(socket: &UdpSocket) -> bool {
+	match socket.local_addr() {
+		Ok(addr) if addr.is_ipv6() => socket2::SockRef::from(socket).only_v6().is_ok_and(|only| !only),
+		_ => false,
+	}
+}
+
 /// Bind a TCP listener, making an IPv6 socket dual-stack so it also serves IPv4.
 ///
 /// The returned listener is non-blocking, ready for

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -222,11 +222,16 @@ pub(crate) struct NoqClient {
 	pub http_bootstrap: bool,
 	/// Optional TLS SNI / verification hostname override (from config).
 	pub host_name: Option<String>,
+	/// Whether the bound socket really came back dual-stack, which decides
+	/// whether an IPv4 destination is reachable at all. Captured here because the
+	/// endpoint owns the socket from here on and `local_addr` can't tell us.
+	dual_stack: bool,
 }
 
 impl NoqClient {
 	pub fn new(config: &ClientConfig) -> Result<Self> {
 		let socket = crate::bind::udp(config.bind).map_err(Error::BindSocket)?;
+		let dual_stack = crate::bind::udp_is_dual_stack(&socket);
 
 		let mut transport = noq::TransportConfig::default();
 		let quic = config.quic.resolve();
@@ -246,6 +251,7 @@ impl NoqClient {
 			transport,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
 			host_name: config.tls.host_name.clone(),
+			dual_stack,
 		})
 	}
 
@@ -267,7 +273,7 @@ impl NoqClient {
 		let addrs = tokio::net::lookup_host((host.clone(), port))
 			.await
 			.map_err(Error::DnsLookup)?;
-		let ip = crate::util::pick_addr(addrs, local).ok_or(Error::NoDnsEntries)?;
+		let ip = crate::util::pick_addr(addrs, local, self.dual_stack).ok_or(Error::NoDnsEntries)?;
 
 		if url.scheme() == "http" {
 			// Insecure per-connection bootstrap: only honored when no stronger

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -261,11 +261,8 @@ impl NoqClient {
 		let host = url.host().ok_or(Error::InvalidDnsName)?.to_string();
 		let port = url.port().unwrap_or(443);
 
-		// Look up the DNS entry.
-		// Noq doesn't support happy eyeballs, so we pick a single address,
-		// preferring one whose family matches the local socket so the OS
-		// doesn't reject it (notably on Windows, where IPv6 sockets aren't
-		// dual-stack by default).
+		// Look up the DNS entry. Noq doesn't support happy eyeballs, so we commit to
+		// a single address; `pick_addr` documents how that one is chosen.
 		let local = self.quic.local_addr().map_err(Error::LocalAddr)?;
 		let addrs = tokio::net::lookup_host((host.clone(), port))
 			.await

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -264,10 +264,11 @@ impl QuicheClient {
 
 		let socket = crate::bind::udp(self.bind)?;
 		let local = socket.local_addr()?;
+		let dual_stack = crate::bind::udp_is_dual_stack(&socket);
 		let addrs = tokio::net::lookup_host((host.as_str(), port))
 			.await
 			.map_err(Error::DnsLookup)?;
-		let remote = crate::util::pick_addr(addrs, local).ok_or(Error::NoDnsEntries)?;
+		let remote = crate::util::pick_addr(addrs, local, dual_stack).ok_or(Error::NoDnsEntries)?;
 
 		let mut builder = web_transport_quiche::ez::ClientBuilder::default()
 			.with_settings(settings)

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -235,11 +235,16 @@ pub(crate) struct QuinnClient {
 	pub http_bootstrap: bool,
 	/// Optional TLS SNI / verification hostname override (from config).
 	pub host_name: Option<String>,
+	/// Whether the bound socket really came back dual-stack, which decides
+	/// whether an IPv4 destination is reachable at all. Captured here because the
+	/// endpoint owns the socket from here on and `local_addr` can't tell us.
+	dual_stack: bool,
 }
 
 impl QuinnClient {
 	pub fn new(config: &ClientConfig) -> Result<Self> {
 		let socket = crate::bind::udp(config.bind).map_err(Error::BindSocket)?;
+		let dual_stack = crate::bind::udp_is_dual_stack(&socket);
 
 		let quic = config.quic.resolve();
 		let mut transport = quinn::TransportConfig::default();
@@ -259,6 +264,7 @@ impl QuinnClient {
 			transport,
 			http_bootstrap: config.tls.allows_http_bootstrap(),
 			host_name: config.tls.host_name.clone(),
+			dual_stack,
 		})
 	}
 
@@ -280,7 +286,7 @@ impl QuinnClient {
 		let addrs = tokio::net::lookup_host((host.clone(), port))
 			.await
 			.map_err(Error::DnsLookup)?;
-		let ip = crate::util::pick_addr(addrs, local).ok_or(Error::NoDnsEntries)?;
+		let ip = crate::util::pick_addr(addrs, local, self.dual_stack).ok_or(Error::NoDnsEntries)?;
 
 		if url.scheme() == "http" {
 			// Insecure per-connection bootstrap: only honored when no stronger

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -274,11 +274,8 @@ impl QuinnClient {
 		let host = url.host().ok_or(Error::InvalidDnsName)?.to_string();
 		let port = url.port().unwrap_or(443);
 
-		// Look up the DNS entry.
-		// Quinn doesn't support happy eyeballs, so we pick a single address,
-		// preferring one whose family matches the local socket so the OS
-		// doesn't reject it (notably on Windows, where IPv6 sockets aren't
-		// dual-stack by default).
+		// Look up the DNS entry. Quinn doesn't support happy eyeballs, so we commit to
+		// a single address; `pick_addr` documents how that one is chosen.
 		let local = self.quic.local_addr().map_err(Error::LocalAddr)?;
 		let addrs = tokio::net::lookup_host((host.clone(), port))
 			.await

--- a/rs/moq-native/src/util.rs
+++ b/rs/moq-native/src/util.rs
@@ -31,22 +31,42 @@ pub(crate) fn resolve(addr: Option<&str>, default: &str) -> std::io::Result<Sock
 ///
 /// Each entry is converted to the local socket's family when that's lossless:
 /// an IPv4-mapped IPv6 address is unwrapped for an IPv4 socket, and a plain
-/// IPv4 address is wrapped for an IPv6 socket. An entry that can't be converted
-/// is one this socket can't send to, so it's skipped in favor of one that can
-/// (a socket explicitly bound to a single family, and on Windows an IPv6 socket
-/// whose dual-stack option didn't take). Falls back to the first entry when
-/// none of them convert, so the OS reports the failure rather than us inventing
-/// one. See <https://github.com/moq-dev/moq/issues/1375>.
+/// IPv4 address is wrapped for an IPv6 socket. An entry the socket can't send
+/// to (see [`addressable`]) is skipped in favor of one it can, which is what a
+/// socket bound to a single family needs. Falls back to the first entry when
+/// there's no usable one, so the OS reports the failure rather than us
+/// inventing one. See <https://github.com/moq-dev/moq/issues/1375>.
 pub(crate) fn pick_addr(addrs: impl IntoIterator<Item = SocketAddr>, local: SocketAddr) -> Option<SocketAddr> {
 	let mut fallback = None;
 	for addr in addrs {
 		let addr = normalize_family(addr, local);
-		if addr.is_ipv4() == local.is_ipv4() {
+		if addressable(addr, local) {
 			return Some(addr);
 		}
 		fallback.get_or_insert(addr);
 	}
 	fallback
+}
+
+/// Whether a socket bound to `local` can send to `dest`.
+///
+/// Mostly this is the address family, but a dual-stack socket has a wrinkle: it
+/// reaches IPv4 by sending to an IPv4-mapped destination, which the kernel turns
+/// back into a real IPv4 packet. That needs an IPv4 source address, so it only
+/// works when the bind left the socket one to use. `[::]` does, since the kernel
+/// picks the source; an IPv4-mapped bind is already one. A concrete IPv6 bind is
+/// not, and the mirror holds: an IPv4-mapped bind can't reach a real IPv6
+/// destination.
+fn addressable(dest: SocketAddr, local: SocketAddr) -> bool {
+	let (SocketAddr::V6(dest), SocketAddr::V6(local)) = (dest, local) else {
+		return dest.is_ipv4() == local.is_ipv4();
+	};
+
+	match (dest.ip().to_ipv4_mapped(), local.ip().to_ipv4_mapped()) {
+		(Some(_), None) => local.ip().is_unspecified(),
+		(None, Some(_)) => false,
+		_ => true,
+	}
 }
 
 /// Convert `addr` to match the family of `local` when the conversion is
@@ -92,6 +112,9 @@ mod tests {
 	const V6: &str = "[2001:db8::1]:443";
 	const LOCAL_V4: &str = "0.0.0.0:0";
 	const LOCAL_V6: &str = "[::]:0";
+	/// `--client-bind` pinned to a concrete source rather than the wildcard.
+	const BOUND_V6: &str = "[2001:db8::5]:0";
+	const BOUND_V4_MAPPED: &str = "[::ffff:192.0.2.5]:0";
 
 	fn addr(s: &str) -> SocketAddr {
 		s.parse().unwrap()
@@ -115,6 +138,24 @@ mod tests {
 	#[test]
 	fn pick_addr_skips_a_family_the_socket_cant_send_to() {
 		assert_eq!(pick_addr([addr(V6), addr(V4)], addr(LOCAL_V4)), Some(addr(V4)));
+
+		// A bind pinned to a concrete IPv6 source has no IPv4 source to send an
+		// IPv4-mapped destination from, so the native IPv6 entry wins even though
+		// the resolver ranked the A record first.
+		assert_eq!(pick_addr([addr(V4), addr(V6)], addr(BOUND_V6)), Some(addr(V6)));
+		// The mirror: an IPv4-mapped bind is an IPv4 socket, so a real IPv6
+		// destination is out of reach.
+		assert_eq!(
+			pick_addr([addr(V6), addr(V4)], addr(BOUND_V4_MAPPED)),
+			Some(addr(V4_MAPPED))
+		);
+	}
+
+	/// Nothing else to try, so hand back the unusable entry and let the OS report
+	/// it. Silently failing the dial would be worse than a clear `sendmsg` error.
+	#[test]
+	fn pick_addr_still_returns_an_unusable_only_entry() {
+		assert_eq!(pick_addr([addr(V4)], addr(BOUND_V6)), Some(addr(V4_MAPPED)));
 	}
 
 	#[test]

--- a/rs/moq-native/src/util.rs
+++ b/rs/moq-native/src/util.rs
@@ -33,14 +33,19 @@ pub(crate) fn resolve(addr: Option<&str>, default: &str) -> std::io::Result<Sock
 /// an IPv4-mapped IPv6 address is unwrapped for an IPv4 socket, and a plain
 /// IPv4 address is wrapped for an IPv6 socket. An entry the socket can't send
 /// to (see [`addressable`]) is skipped in favor of one it can, which is what a
-/// socket bound to a single family needs. Falls back to the first entry when
-/// there's no usable one, so the OS reports the failure rather than us
-/// inventing one. See <https://github.com/moq-dev/moq/issues/1375>.
-pub(crate) fn pick_addr(addrs: impl IntoIterator<Item = SocketAddr>, local: SocketAddr) -> Option<SocketAddr> {
+/// socket bound to a single family needs. `dual_stack` is
+/// [`crate::bind::udp_is_dual_stack`] for that socket. Falls back to the first
+/// entry when there's no usable one, so the OS reports the failure rather than
+/// us inventing one. See <https://github.com/moq-dev/moq/issues/1375>.
+pub(crate) fn pick_addr(
+	addrs: impl IntoIterator<Item = SocketAddr>,
+	local: SocketAddr,
+	dual_stack: bool,
+) -> Option<SocketAddr> {
 	let mut fallback = None;
 	for addr in addrs {
 		let addr = normalize_family(addr, local);
-		if addressable(addr, local) {
+		if addressable(addr, local, dual_stack) {
 			return Some(addr);
 		}
 		fallback.get_or_insert(addr);
@@ -50,20 +55,21 @@ pub(crate) fn pick_addr(addrs: impl IntoIterator<Item = SocketAddr>, local: Sock
 
 /// Whether a socket bound to `local` can send to `dest`.
 ///
-/// Mostly this is the address family, but a dual-stack socket has a wrinkle: it
-/// reaches IPv4 by sending to an IPv4-mapped destination, which the kernel turns
-/// back into a real IPv4 packet. That needs an IPv4 source address, so it only
-/// works when the bind left the socket one to use. `[::]` does, since the kernel
-/// picks the source; an IPv4-mapped bind is already one. A concrete IPv6 bind is
-/// not, and the mirror holds: an IPv4-mapped bind can't reach a real IPv6
-/// destination.
-fn addressable(dest: SocketAddr, local: SocketAddr) -> bool {
+/// Mostly this is the address family, but reaching IPv4 from an IPv6 socket has
+/// a wrinkle: it means sending to an IPv4-mapped destination, which the kernel
+/// turns back into a real IPv4 packet, and that needs an IPv4 source address. So
+/// it takes both a socket that is actually dual-stack (`IPV6_V6ONLY` cleared,
+/// which [`crate::bind::udp`] only attempts) and a bind that left an IPv4 source
+/// to use: `[::]` does, since the kernel picks the source, and an IPv4-mapped
+/// bind already is one, but a concrete IPv6 bind is not. The mirror holds too:
+/// an IPv4-mapped bind can't reach a real IPv6 destination.
+fn addressable(dest: SocketAddr, local: SocketAddr, dual_stack: bool) -> bool {
 	let (SocketAddr::V6(dest), SocketAddr::V6(local)) = (dest, local) else {
 		return dest.is_ipv4() == local.is_ipv4();
 	};
 
 	match (dest.ip().to_ipv4_mapped(), local.ip().to_ipv4_mapped()) {
-		(Some(_), None) => local.ip().is_unspecified(),
+		(Some(_), None) => dual_stack && local.ip().is_unspecified(),
 		(None, Some(_)) => false,
 		_ => true,
 	}
@@ -120,6 +126,12 @@ mod tests {
 		s.parse().unwrap()
 	}
 
+	/// [`pick_addr`] for a socket that came back dual-stack, which is what
+	/// [`crate::bind::udp`] produces everywhere it can.
+	fn dual_stack(addrs: impl IntoIterator<Item = SocketAddr>, local: SocketAddr) -> Option<SocketAddr> {
+		pick_addr(addrs, local, true)
+	}
+
 	/// A dual-stack socket can reach both families, so the resolver's ranking is
 	/// the only thing that says which destination actually works. A host with no
 	/// route to the AAAA gets it ranked last by RFC 6724; preferring an address
@@ -127,26 +139,40 @@ mod tests {
 	/// the host couldn't reach.
 	#[test]
 	fn pick_addr_keeps_the_resolver_ranking() {
-		assert_eq!(pick_addr([addr(V4), addr(V6)], addr(LOCAL_V6)), Some(addr(V4_MAPPED)));
+		assert_eq!(dual_stack([addr(V4), addr(V6)], addr(LOCAL_V6)), Some(addr(V4_MAPPED)));
 		// And the other way around: a host with working IPv6 ranks the AAAA first,
 		// so that's what gets dialed.
-		assert_eq!(pick_addr([addr(V6), addr(V4)], addr(LOCAL_V6)), Some(addr(V6)));
+		assert_eq!(dual_stack([addr(V6), addr(V4)], addr(LOCAL_V6)), Some(addr(V6)));
 	}
 
 	/// A socket bound to one family skips what it can't send to, whatever the
 	/// ranking, since the alternative is a guaranteed `sendmsg` failure.
 	#[test]
 	fn pick_addr_skips_a_family_the_socket_cant_send_to() {
-		assert_eq!(pick_addr([addr(V6), addr(V4)], addr(LOCAL_V4)), Some(addr(V4)));
+		assert_eq!(dual_stack([addr(V6), addr(V4)], addr(LOCAL_V4)), Some(addr(V4)));
 
 		// A bind pinned to a concrete IPv6 source has no IPv4 source to send an
 		// IPv4-mapped destination from, so the native IPv6 entry wins even though
 		// the resolver ranked the A record first.
-		assert_eq!(pick_addr([addr(V4), addr(V6)], addr(BOUND_V6)), Some(addr(V6)));
+		assert_eq!(dual_stack([addr(V4), addr(V6)], addr(BOUND_V6)), Some(addr(V6)));
 		// The mirror: an IPv4-mapped bind is an IPv4 socket, so a real IPv6
 		// destination is out of reach.
 		assert_eq!(
-			pick_addr([addr(V6), addr(V4)], addr(BOUND_V4_MAPPED)),
+			dual_stack([addr(V6), addr(V4)], addr(BOUND_V4_MAPPED)),
+			Some(addr(V4_MAPPED))
+		);
+	}
+
+	/// `bind::udp` clears `IPV6_V6ONLY` best-effort and keeps the socket when the
+	/// platform refuses, warning rather than failing. Such a socket still reads
+	/// back as `[::]` but can't send to an IPv4-mapped destination at all, so the
+	/// native IPv6 entry has to win.
+	#[test]
+	fn pick_addr_skips_mapped_ipv4_on_a_v6_only_socket() {
+		assert_eq!(pick_addr([addr(V4), addr(V6)], addr(LOCAL_V6), false), Some(addr(V6)));
+		// The same socket with a dual-stack option that did take.
+		assert_eq!(
+			pick_addr([addr(V4), addr(V6)], addr(LOCAL_V6), true),
 			Some(addr(V4_MAPPED))
 		);
 	}
@@ -155,30 +181,31 @@ mod tests {
 	/// it. Silently failing the dial would be worse than a clear `sendmsg` error.
 	#[test]
 	fn pick_addr_still_returns_an_unusable_only_entry() {
-		assert_eq!(pick_addr([addr(V4)], addr(BOUND_V6)), Some(addr(V4_MAPPED)));
+		assert_eq!(dual_stack([addr(V4)], addr(BOUND_V6)), Some(addr(V4_MAPPED)));
+		assert_eq!(pick_addr([addr(V4)], addr(LOCAL_V6), false), Some(addr(V4_MAPPED)));
 	}
 
 	#[test]
 	fn pick_addr_wraps_v4_for_v6_socket() {
 		// IPv6 socket with only an IPv4 DNS entry: wrap as IPv4-mapped IPv6.
-		assert_eq!(pick_addr([addr(V4)], addr(LOCAL_V6)), Some(addr(V4_MAPPED)));
+		assert_eq!(dual_stack([addr(V4)], addr(LOCAL_V6)), Some(addr(V4_MAPPED)));
 	}
 
 	#[test]
 	fn pick_addr_unwraps_v4_mapped_for_v4_socket() {
 		// IPv4 socket given an IPv4-mapped IPv6 entry: unwrap to plain IPv4.
-		assert_eq!(pick_addr([addr(V4_MAPPED)], addr(LOCAL_V4)), Some(addr(V4)));
+		assert_eq!(dual_stack([addr(V4_MAPPED)], addr(LOCAL_V4)), Some(addr(V4)));
 	}
 
 	#[test]
 	fn pick_addr_falls_back_for_unmappable_v6() {
 		// IPv4 socket with only a true IPv6 entry: no conversion possible, so hand
 		// it back as-is and let the OS surface a clear error.
-		assert_eq!(pick_addr([addr(V6)], addr(LOCAL_V4)), Some(addr(V6)));
+		assert_eq!(dual_stack([addr(V6)], addr(LOCAL_V4)), Some(addr(V6)));
 	}
 
 	#[test]
 	fn pick_addr_empty() {
-		assert_eq!(pick_addr(std::iter::empty(), addr(LOCAL_V4)), None);
+		assert_eq!(dual_stack(std::iter::empty(), addr(LOCAL_V4)), None);
 	}
 }

--- a/rs/moq-native/src/util.rs
+++ b/rs/moq-native/src/util.rs
@@ -15,34 +15,38 @@ pub(crate) fn resolve(addr: Option<&str>, default: &str) -> std::io::Result<Sock
 		.ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "no addresses resolved"))
 }
 
-/// Pick a single DNS entry from `addrs`, preferring one whose address family
-/// matches `local`. Falls back to the first entry when no family match exists.
+/// Pick a single DNS entry from `addrs`: the first one the local socket can
+/// address, keeping the order the resolver returned them in.
 ///
-/// Each entry is normalized to the local socket's family when possible: an
-/// IPv4-mapped IPv6 address is unwrapped for an IPv4 socket, and a plain IPv4
-/// address is wrapped for an IPv6 socket. Quinn doesn't support happy eyeballs
-/// and the local socket may be bound to a single family (especially on
-/// Windows, where IPv6 sockets are not dual-stack by default), so a
-/// family-mismatched destination causes `sendmsg` to fail with
-/// `AddrNotAvailable`. See <https://github.com/moq-dev/moq/issues/1375>.
+/// That order is the whole point. `getaddrinfo` has already sorted its answer
+/// per RFC 6724, whose first rule demotes a destination the host has no usable
+/// source address for, so an unroutable IPv6 record sinks below the IPv4 ones.
+/// Reordering on top of that throws away the only reachability signal we have:
+/// a socket bound to `[::]` is dual-stack (see [`crate::bind`]) and matches
+/// *both* families, so preferring an address-family match would promote every
+/// AAAA over every A and hand back the one destination the host can't reach.
+/// Quinn doesn't support happy eyeballs, so that single choice is the whole
+/// dial: `sendmsg` then fails with `Network is unreachable` for every packet
+/// until the handshake times out.
+///
+/// Each entry is converted to the local socket's family when that's lossless:
+/// an IPv4-mapped IPv6 address is unwrapped for an IPv4 socket, and a plain
+/// IPv4 address is wrapped for an IPv6 socket. An entry that can't be converted
+/// is one this socket can't send to, so it's skipped in favor of one that can
+/// (a socket explicitly bound to a single family, and on Windows an IPv6 socket
+/// whose dual-stack option didn't take). Falls back to the first entry when
+/// none of them convert, so the OS reports the failure rather than us inventing
+/// one. See <https://github.com/moq-dev/moq/issues/1375>.
 pub(crate) fn pick_addr(addrs: impl IntoIterator<Item = SocketAddr>, local: SocketAddr) -> Option<SocketAddr> {
-	let mut converted = None;
-	let mut other = None;
+	let mut fallback = None;
 	for addr in addrs {
-		// A native family match wins outright.
+		let addr = normalize_family(addr, local);
 		if addr.is_ipv4() == local.is_ipv4() {
 			return Some(addr);
 		}
-		let normalized = normalize_family(addr, local);
-		if normalized.is_ipv4() == local.is_ipv4() {
-			if converted.is_none() {
-				converted = Some(normalized);
-			}
-		} else if other.is_none() {
-			other = Some(addr);
-		}
+		fallback.get_or_insert(addr);
 	}
-	converted.or(other)
+	fallback
 }
 
 /// Convert `addr` to match the family of `local` when the conversion is
@@ -83,52 +87,57 @@ mod tests {
 		assert_eq!(addr.port(), 1234);
 	}
 
-	#[test]
-	fn pick_addr_prefers_matching_family() {
-		let v4: SocketAddr = "127.0.0.1:443".parse().unwrap();
-		let v6: SocketAddr = "[::1]:443".parse().unwrap();
-		let local_v4: SocketAddr = "0.0.0.0:0".parse().unwrap();
-		let local_v6: SocketAddr = "[::]:0".parse().unwrap();
+	const V4: &str = "192.0.2.1:443";
+	const V4_MAPPED: &str = "[::ffff:192.0.2.1]:443";
+	const V6: &str = "[2001:db8::1]:443";
+	const LOCAL_V4: &str = "0.0.0.0:0";
+	const LOCAL_V6: &str = "[::]:0";
 
-		// IPv6 listed first, but local socket is IPv4: pick IPv4.
-		assert_eq!(pick_addr([v6, v4], local_v4), Some(v4));
-		// IPv4 listed first, but local socket is IPv6: pick IPv6.
-		assert_eq!(pick_addr([v4, v6], local_v6), Some(v6));
+	fn addr(s: &str) -> SocketAddr {
+		s.parse().unwrap()
+	}
+
+	/// A dual-stack socket can reach both families, so the resolver's ranking is
+	/// the only thing that says which destination actually works. A host with no
+	/// route to the AAAA gets it ranked last by RFC 6724; preferring an address
+	/// family match promoted it back to the front and dialed the one destination
+	/// the host couldn't reach.
+	#[test]
+	fn pick_addr_keeps_the_resolver_ranking() {
+		assert_eq!(pick_addr([addr(V4), addr(V6)], addr(LOCAL_V6)), Some(addr(V4_MAPPED)));
+		// And the other way around: a host with working IPv6 ranks the AAAA first,
+		// so that's what gets dialed.
+		assert_eq!(pick_addr([addr(V6), addr(V4)], addr(LOCAL_V6)), Some(addr(V6)));
+	}
+
+	/// A socket bound to one family skips what it can't send to, whatever the
+	/// ranking, since the alternative is a guaranteed `sendmsg` failure.
+	#[test]
+	fn pick_addr_skips_a_family_the_socket_cant_send_to() {
+		assert_eq!(pick_addr([addr(V6), addr(V4)], addr(LOCAL_V4)), Some(addr(V4)));
 	}
 
 	#[test]
 	fn pick_addr_wraps_v4_for_v6_socket() {
-		let v4: SocketAddr = "127.0.0.1:443".parse().unwrap();
-		let mapped: SocketAddr = "[::ffff:127.0.0.1]:443".parse().unwrap();
-		let local_v6: SocketAddr = "[::]:0".parse().unwrap();
-
 		// IPv6 socket with only an IPv4 DNS entry: wrap as IPv4-mapped IPv6.
-		assert_eq!(pick_addr([v4], local_v6), Some(mapped));
+		assert_eq!(pick_addr([addr(V4)], addr(LOCAL_V6)), Some(addr(V4_MAPPED)));
 	}
 
 	#[test]
 	fn pick_addr_unwraps_v4_mapped_for_v4_socket() {
-		let mapped: SocketAddr = "[::ffff:127.0.0.1]:443".parse().unwrap();
-		let v4: SocketAddr = "127.0.0.1:443".parse().unwrap();
-		let local_v4: SocketAddr = "0.0.0.0:0".parse().unwrap();
-
 		// IPv4 socket given an IPv4-mapped IPv6 entry: unwrap to plain IPv4.
-		assert_eq!(pick_addr([mapped], local_v4), Some(v4));
+		assert_eq!(pick_addr([addr(V4_MAPPED)], addr(LOCAL_V4)), Some(addr(V4)));
 	}
 
 	#[test]
 	fn pick_addr_falls_back_for_unmappable_v6() {
-		let v6: SocketAddr = "[2001:db8::1]:443".parse().unwrap();
-		let local_v4: SocketAddr = "0.0.0.0:0".parse().unwrap();
-
-		// IPv4 socket with only a true IPv6 entry: no conversion possible,
-		// fall back to the entry as-is so the OS surfaces a clear error.
-		assert_eq!(pick_addr([v6], local_v4), Some(v6));
+		// IPv4 socket with only a true IPv6 entry: no conversion possible, so hand
+		// it back as-is and let the OS surface a clear error.
+		assert_eq!(pick_addr([addr(V6)], addr(LOCAL_V4)), Some(addr(V6)));
 	}
 
 	#[test]
 	fn pick_addr_empty() {
-		let local: SocketAddr = "0.0.0.0:0".parse().unwrap();
-		assert_eq!(pick_addr(std::iter::empty(), local), None);
+		assert_eq!(pick_addr(std::iter::empty(), addr(LOCAL_V4)), None);
 	}
 }


### PR DESCRIPTION
## Summary

Reported from the OBS plugin: going live against a dual-stacked relay dies with

```
WARN quinn_udp: sendmsg error: Os { code: 101, kind: NetworkUnreachable, ... },
Transmit: { destination: [2606:4700:49::2]:443, src_ip: None, ... }
```

while an IPv4-only relay works.

**Root cause.** `util::pick_addr` treated a native address-family match with the local socket as an outright win over every other DNS entry. The client socket binds `[::]` and `bind::udp` clears `IPV6_V6ONLY`, so it is dual-stack and matches *both* families. Every AAAA therefore beat every A no matter where the resolver ranked them, discarding the RFC 6724 ordering `getaddrinfo` had already applied. That ordering is the only reachability signal available here: its first rule demotes a destination the host has no usable source address for (glibc determines this with a UDP `connect` per candidate), so the unroutable AAAA had already been sorted last and we promoted it back to the front.

Binding is local and says nothing about reachability. The route lookup happens at `sendmsg`, and `quinn-udp` swallows the resulting `ENETUNREACH` as a transient send error, rate-limiting the log to one line a minute:

```rust
Err(e) if e.kind() == io::ErrorKind::WouldBlock => Err(e),
Err(e) if e.raw_os_error() == Some(libc::EMSGSIZE) => Ok(()),
Err(e) => {
    log_sendmsg_error(&self.last_send_error, e, transmit);
    Ok(())
}
```

The connection future never sees it, so with one address committed to and no fallback, the dial could only end at the handshake timeout.

**Fix.** Keep the resolver's ranking: take the first entry the local socket can address. Shared by the quinn, quiche, and noq clients.

"Can address" is mostly the address family, with one wrinkle that the later commits handle. An IPv6 socket reaches IPv4 by sending to an IPv4-mapped destination, which the kernel turns back into a real IPv4 packet, and that needs an IPv4 source address. So it takes two things, neither of which is visible in the local `SocketAddr`:

- **A socket that really is dual-stack.** `bind::udp` clears `IPV6_V6ONLY` best-effort and keeps the socket when the platform refuses, warning rather than failing. `bind::udp_is_dual_stack` reads the option back off the bound socket instead of assuming the clear took; quinn and noq capture it at construction, since the endpoint takes ownership of the socket from there.
- **A bind that left an IPv4 source to use.** `[::]` does, since the kernel picks the source, and an IPv4-mapped bind already is one, but a concrete IPv6 bind (`--client-bind [2001:db8::5]:0`) is not. The mirror holds too: an IPv4-mapped bind can't reach a real IPv6 destination.

When nothing is usable the first entry is still returned, so a v4-only DNS answer is attempted rather than silently dropped and the OS reports what went wrong.

Trusting the ranking is not the same as verifying the path: an address the resolver ranks first can still be blackholed, and none of the backends race connection attempts. Happy eyeballs is the fix for that and lands separately.

## Public API changes

None. `util::pick_addr` and `bind::udp_is_dual_stack` are `pub(crate)`.

## Cross-Package Sync

No row applies: no wire format, config, CLI, or FFI surface changes.

## Test plan

- `cargo test -p moq-native --lib`: `pick_addr_keeps_the_resolver_ranking` is the regression test for the reported bug, verified to fail against the old logic. `pick_addr_skips_a_family_the_socket_cant_send_to` covers the single-family binds in both directions, `pick_addr_skips_mapped_ipv4_on_a_v6_only_socket` covers the failed dual-stack clear, and `pick_addr_still_returns_an_unusable_only_entry` pins the fallback. The existing family-conversion cases pass unchanged, so the #1375 behavior is preserved.
- `cargo clippy -p moq-native --all-features --all-targets` and `RUSTDOCFLAGS=-D warnings cargo doc -p moq-native --all-features` clean.
- Not verified: that a concrete-IPv6-bound socket really is refused an IPv4-mapped destination. This sandbox has no IPv6 stack at all (`socket(AF_INET6)` returns `EAFNOSUPPORT`), so it's reasoned from the source-address requirement rather than measured. The preference is right either way, since a bind pinned to an IPv6 source wants IPv6 egress.
- `server::tests::certificates_expose_generated_fingerprints` and 5 of `tests/backend.rs` fail identically on `main` here for the same missing-IPv6 reason: the `[::]` server bind returns `EAFNOSUPPORT`. Not touched by this change.

(Written by claude-opus-5)