### PR TITLE
fix(moq-token): write private key files owner-only

### DIFF
--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -48,6 +48,10 @@ moq-token generate --algorithm ES256 --out-dir ./private/ --public-dir ./keys/
 
 A random key ID is generated if `--id` is not specified.
 
+Any file holding private key material is written owner-only (mode `0600` on
+Unix), so a relay running as another user needs the public half instead. Public
+key files keep the default permissions.
+
 ### Scope a Key
 
 Keys can embed immutable publish and subscribe limits. Every token signed or

--- a/js/token/src/cli.test.ts
+++ b/js/token/src/cli.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const CLI = join(import.meta.dir, "cli.ts");
+
+function run(...args: string[]) {
+	const result = Bun.spawnSync(["bun", CLI, ...args]);
+	expect(result.stderr.toString()).toBe("");
+	expect(result.exitCode).toBe(0);
+}
+
+function mode(path: string): number {
+	return statSync(path).mode & 0o777;
+}
+
+// The mode bits don't exist on Windows, where the file inherits the directory's ACL instead.
+describe.skipIf(process.platform === "win32")("generate permissions", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "moq-token-cli-"));
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	test("private key is owner-only", () => {
+		const key = join(dir, "private.jwk");
+		run("generate", "--key", key);
+		expect(mode(key)).toBe(0o600);
+	});
+
+	test("private key tightens an existing file", async () => {
+		const key = join(dir, "existing.jwk");
+		writeFileSync(key, "stale");
+		chmodSync(key, 0o644);
+
+		run("generate", "--key", key);
+		expect(mode(key)).toBe(0o600);
+
+		// The old contents are gone, not just hidden behind the new mode.
+		expect(await Bun.file(key).text()).not.toContain("stale");
+	});
+
+	test("public key keeps default permissions", () => {
+		const key = join(dir, "private.jwk");
+		const pub = join(dir, "public.jwk");
+		writeFileSync(pub, "");
+		chmodSync(pub, 0o644);
+
+		run("generate", "--key", key, "--algorithm", "ES256", "--public", pub);
+		expect(mode(pub)).toBe(0o644);
+	});
+});

--- a/js/token/src/cli.ts
+++ b/js/token/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { closeSync, fchmodSync, openSync, readFileSync, writeFileSync, writeSync } from "node:fs";
 import * as base64 from "@hexagon/base64";
 import { Command, Option } from "commander";
 import type { Algorithm } from "./algorithm.ts";
@@ -47,7 +47,7 @@ program
 				return json;
 			};
 
-			writeFileSync(options.key, encodeKey(key), "utf-8");
+			writePrivateFileSync(options.key, encodeKey(key));
 			console.log(`Generated ${algorithm} key: ${options.key}`);
 
 			if (options.public && key.kty !== "oct") {
@@ -123,6 +123,26 @@ program
 			process.exit(1);
 		}
 	});
+
+/**
+ * Write a file holding private key material, restricted to the owner on Unix.
+ *
+ * The `mode` on open(2) only applies when the file is created, and is masked by the umask either
+ * way. Chmod the handle before writing so overwriting an existing world-readable key tightens it
+ * and the secret never sits in a readable file.
+ */
+function writePrivateFileSync(path: string, contents: string) {
+	const fd = openSync(path, "w", 0o600);
+	try {
+		// Windows has no equivalent of the mode bits, so the file inherits the directory's ACL.
+		if (process.platform !== "win32") {
+			fchmodSync(fd, 0o600);
+		}
+		writeSync(fd, contents);
+	} finally {
+		closeSync(fd);
+	}
+}
 
 function parseUnixTimestamp(value: string): number {
 	const timestamp = Number.parseInt(value, 10);

--- a/js/token/src/cli.ts
+++ b/js/token/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { closeSync, fchmodSync, openSync, readFileSync, writeFileSync, writeSync } from "node:fs";
+import { closeSync, fchmodSync, openSync, readFileSync, writeFileSync } from "node:fs";
 import * as base64 from "@hexagon/base64";
 import { Command, Option } from "commander";
 import type { Algorithm } from "./algorithm.ts";
@@ -138,7 +138,8 @@ function writePrivateFileSync(path: string, contents: string) {
 		if (process.platform !== "win32") {
 			fchmodSync(fd, 0o600);
 		}
-		writeSync(fd, contents);
+		// writeFileSync loops until every byte lands, unlike writeSync's single short-write-prone call.
+		writeFileSync(fd, contents);
 	} finally {
 		closeSync(fd);
 	}

--- a/rs/moq-token/src/fs.rs
+++ b/rs/moq-token/src/fs.rs
@@ -1,0 +1,44 @@
+//! Writing key files without handing the private half to every user on the box.
+
+use std::io;
+use std::path::Path;
+
+/// Owner read/write, nobody else.
+#[cfg(unix)]
+const PRIVATE_MODE: u32 = 0o600;
+
+/// Write a key file, restricting it to the owner when `private` (it holds secret material).
+///
+/// A public key keeps the default permissions, since it's meant to be handed around and often
+/// gets read by a relay running as a different user.
+pub(crate) fn write(path: &Path, contents: &str, private: bool) -> io::Result<()> {
+	match private {
+		true => write_private(path, contents),
+		false => std::fs::write(path, contents),
+	}
+}
+
+#[cfg(unix)]
+fn write_private(path: &Path, contents: &str) -> io::Result<()> {
+	use std::io::Write;
+	use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+	let mut file = std::fs::OpenOptions::new()
+		.write(true)
+		.create(true)
+		.truncate(true)
+		.mode(PRIVATE_MODE)
+		.open(path)?;
+
+	// `mode` above only applies when open(2) creates the file, and it's masked by the umask
+	// either way. Set the bits explicitly so overwriting an existing world-readable key
+	// tightens it, and do it before write_all so the secret never sits in a readable file.
+	file.set_permissions(std::fs::Permissions::from_mode(PRIVATE_MODE))?;
+	file.write_all(contents.as_bytes())
+}
+
+/// Windows has no cheap equivalent of the Unix mode bits, so the file inherits the directory's ACL.
+#[cfg(not(unix))]
+fn write_private(path: &Path, contents: &str) -> io::Result<()> {
+	std::fs::write(path, contents)
+}

--- a/rs/moq-token/src/key.rs
+++ b/rs/moq-token/src/key.rs
@@ -361,9 +361,12 @@ impl Key {
 	}
 
 	/// Write the key to a file as base64url-encoded JSON.
+	///
+	/// A key carrying private material is written owner-only (mode `0600` on Unix), including when
+	/// it overwrites a file that was more permissive.
 	pub fn to_file<P: AsRef<StdPath>>(&self, path: P) -> crate::Result<()> {
 		let encoded = self.to_str()?;
-		std::fs::write(path, encoded)?;
+		crate::fs::write(path.as_ref(), &encoded, self.is_private())?;
 		Ok(())
 	}
 
@@ -413,10 +416,12 @@ impl Key {
 		})
 	}
 
-	/// Whether the key carries the private material signing actually needs.
+	/// Whether the key carries private material: the half signing needs, and the half that must
+	/// not leak to another user on disk.
 	///
-	/// `key_ops` says what a key is *permitted* to do, which a public JWK can still advertise.
-	pub(crate) fn has_signing_material(&self) -> bool {
+	/// `key_ops` says what a key is *permitted* to do, which a public JWK can still advertise, so
+	/// this asks about the material rather than the declared operations.
+	pub(crate) fn is_private(&self) -> bool {
 		match &self.material {
 			KeyMaterial::OCT { .. } => true,
 			KeyMaterial::EC { d, .. } => d.is_some(),
@@ -1789,5 +1794,58 @@ mod tests {
 
 		// Clean up
 		std::fs::remove_file(temp_path).ok();
+	}
+
+	#[cfg(unix)]
+	mod permissions {
+		use super::*;
+		use std::os::unix::fs::PermissionsExt;
+
+		fn temp_path(name: &str) -> std::path::PathBuf {
+			let unique = SystemTime::now()
+				.duration_since(SystemTime::UNIX_EPOCH)
+				.unwrap()
+				.as_nanos();
+			std::env::temp_dir().join(format!("test_perms_{name}_{unique}.jwk"))
+		}
+
+		fn mode(path: &std::path::Path) -> u32 {
+			std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+		}
+
+		#[test]
+		fn private_key_is_owner_only() {
+			let path = temp_path("private");
+			create_test_key().to_file(&path).unwrap();
+			assert_eq!(mode(&path), 0o600);
+			std::fs::remove_file(&path).ok();
+		}
+
+		#[test]
+		fn private_key_tightens_existing_file() {
+			let path = temp_path("existing");
+			std::fs::write(&path, "stale").unwrap();
+			std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+			create_test_key().to_file(&path).unwrap();
+			assert_eq!(mode(&path), 0o600);
+
+			// The old contents are gone, not just hidden behind the new mode.
+			let contents = std::fs::read_to_string(&path).unwrap();
+			assert!(!contents.contains("stale"));
+			std::fs::remove_file(&path).ok();
+		}
+
+		#[test]
+		fn public_key_keeps_default_permissions() {
+			let path = temp_path("public");
+			std::fs::write(&path, "").unwrap();
+			std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+			let public = Key::generate(Algorithm::ES256, None).unwrap().to_public().unwrap();
+			public.to_file(&path).unwrap();
+			assert_eq!(mode(&path), 0o644);
+			std::fs::remove_file(&path).ok();
+		}
 	}
 }

--- a/rs/moq-token/src/lib.rs
+++ b/rs/moq-token/src/lib.rs
@@ -8,6 +8,7 @@
 mod algorithm;
 mod claims;
 mod error;
+mod fs;
 mod generate;
 mod key;
 mod key_id;

--- a/rs/moq-token/src/set.rs
+++ b/rs/moq-token/src/set.rs
@@ -47,23 +47,31 @@ impl<'de> Deserialize<'de> for KeySet {
 }
 
 impl KeySet {
+	/// Parse a set from a JSON string.
 	#[allow(clippy::should_implement_trait)]
 	pub fn from_str(s: &str) -> crate::Result<Self> {
 		Ok(serde_json::from_str(s)?)
 	}
 
+	/// Load a set from a JSON file.
 	pub fn from_file<P: AsRef<Path>>(path: P) -> crate::Result<Self> {
 		let json = std::fs::read_to_string(&path)?;
 		Ok(serde_json::from_str(&json)?)
 	}
 
+	/// Encode the set as JSON.
 	pub fn to_str(&self) -> crate::Result<String> {
 		Ok(serde_json::to_string(&self)?)
 	}
 
+	/// Write the set to a file as JSON.
+	///
+	/// A set holding any private key is written owner-only (mode `0600` on Unix), including when
+	/// it overwrites a file that was more permissive.
 	pub fn to_file<P: AsRef<Path>>(&self, path: P) -> crate::Result<()> {
 		let json = serde_json::to_string(&self)?;
-		std::fs::write(path, json)?;
+		let private = self.keys.iter().any(|key| key.is_private());
+		crate::fs::write(path.as_ref(), &json, private)?;
 		Ok(())
 	}
 
@@ -89,9 +97,7 @@ impl KeySet {
 	pub fn find_supported_key(&self, operation: &KeyOperation) -> Option<Arc<Key>> {
 		self.keys
 			.iter()
-			.find(|key| {
-				key.operations.contains(operation) && (*operation != KeyOperation::Sign || key.has_signing_material())
-			})
+			.find(|key| key.operations.contains(operation) && (*operation != KeyOperation::Sign || key.is_private()))
 			.cloned()
 	}
 
@@ -439,6 +445,28 @@ mod tests {
 		assert_eq!(loaded.keys[0].kid.as_ref().map(|k| k.encode()), Some("1"));
 
 		// Clean up
+		let _ = std::fs::remove_file(path);
+	}
+
+	#[cfg(unix)]
+	#[test]
+	fn test_file_io_permissions() {
+		use std::os::unix::fs::PermissionsExt;
+
+		let unique = SystemTime::now()
+			.duration_since(SystemTime::UNIX_EPOCH)
+			.unwrap()
+			.as_nanos();
+		let path = std::env::temp_dir().join(format!("test_keyset_perms_{unique}.json"));
+
+		let set = KeySet {
+			keys: vec![Arc::new(create_test_key(Some("1")))],
+		};
+		set.to_file(&path).expect("failed to write to file");
+
+		let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+		assert_eq!(mode, 0o600, "a set holding a private key must be owner-only");
+
 		let _ = std::fs::remove_file(path);
 	}
 }


### PR DESCRIPTION
## Root cause

`Key::to_file` wrote through `std::fs::write`, which creates a file with mode `0666` masked by the umask. With the usual `022` that is `0644`, so every generated `.jwk` holding private material was world-readable. `KeySet::to_file` had the same problem, and overwriting an existing key file left whatever permissions that file already carried.

CodeRabbit flagged this against `moq-token-cli`'s `write_key`, but the write lives in the library, so every caller of `to_file` was affected. Fixing it at the call site would have left the next caller exposed.

## The fix

Both `Key::to_file` and `KeySet::to_file` now go through a crate-private helper (`rs/moq-token/src/fs.rs`) that opens with mode `0600` and chmods the handle before writing. The explicit chmod is load-bearing twice over:

- `OpenOptions::mode` only applies when `open(2)` actually creates the file, so a pre-existing `0644` key file would otherwise keep its permissions once the secret landed in it.
- The mode passed to `open(2)` is masked by the umask either way; setting the bits explicitly makes the result deterministic.

Doing it before `write_all` means the secret never sits in a readable file, not even briefly.

Public keys keep the default permissions. They are meant to be handed around, and a relay reading the public half often runs as a different user, so forcing `0600` there would break real deployments. The predicate is the key *material* rather than `key_ops`, since a public JWK can still advertise `sign`. `has_signing_material` is renamed to `is_private` now that it answers both questions; it is `pub(crate)`, so nothing outside the crate moves.

Windows has no cheap equivalent of the mode bits, so the file inherits the directory's ACL there.

## Cross-package sync

`js/token`'s CLI wrote the generated key the same way (`writeFileSync`), so it gets the same treatment via `openSync`/`fchmodSync`/`writeSync`, also skipped on Windows. `doc/bin/relay/auth.md` notes the new permissions next to the `generate` examples. `rs/moq-ffi` exposes no key-writing surface, so the binding wrappers are unaffected.

## Tests

Regression tests on both sides, all `#[cfg(unix)]` / skipped on Windows:

- `rs/moq-token/src/key.rs`: a private key is `0600`; overwriting a pre-existing `0644` file tightens it (and drops the old contents); a public key keeps `0644`.
- `rs/moq-token/src/set.rs`: a set holding a private key is `0600`.
- `js/token/src/cli.test.ts` (new): the same three cases, driving the real CLI.

Verified the Rust tests fail without the fix (3 fail, the public-key one still passes) and pass with it. Also exercised both CLIs end to end against a pre-existing `0644` file: private half lands at `0600`, public half at `0644`.

`cargo test -p moq-token`, `cargo clippy -p moq-token -p moq-token-cli --all-targets -- -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc -p moq-token`, `bun test` (js/token), `tsc`, `biome check`, and `remark` all pass. Nix is unavailable in this environment, so `just check` was not run as a whole; the equivalent per-tool checks above were run directly.

(Written by claude-opus-5)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Px3CEqPZE6Yz2GTDdYAkWm)_