### PR TITLE
fix: unbreak the libmoq release, and moq-relay's fresh-resolve build

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -136,7 +136,14 @@ let
     };
     cargoExtraArgs = "-p libmoq";
     doCheck = false;
-    nativeBuildInputs = with final; [ pkg-config ];
+    nativeBuildInputs = with final; [
+      pkg-config
+      # libmoq is the only nix-built package that pulls moq-video, and on Linux
+      # that brings v4l -> v4l2-sys-mit, whose build.rs runs bindgen over
+      # <linux/videodev2.h>. Sets LIBCLANG_PATH + BINDGEN_EXTRA_CLANG_ARGS so it
+      # finds libclang and the libc headers, same as the devShell in flake.nix.
+      rustPlatform.bindgenHook
+    ];
 
     # libmoq.a carries moq-ffi's whole dep tree, so an unstripped build is
     # ~75 MB+. Thin LTO with a single codegen unit dead-strips the unused

--- a/rs/moq-relay/Cargo.toml
+++ b/rs/moq-relay/Cargo.toml
@@ -43,7 +43,7 @@ anyhow = { version = "1", features = ["backtrace"] }
 axum = { version = "0.8", features = ["tokio"] }
 axum-server = { version = "0.8", features = ["tls-rustls"] }
 bytes = "1"
-bytesize = { version = "2.4.2", default-features = false }
+bytesize = "2.4.2"
 clap = { version = "4", features = ["derive"] }
 futures = "0.3"
 http-body = "1"


### PR DESCRIPTION
Started from the red [smoke run 30694754328](https://github.com/moq-dev/smoke/actions/runs/30694754328). Two fixes; the second is the bigger one.

## 1. `fix(nix)`: libmoq releases have been silently failing for six weeks

**No libmoq release has been published since v0.3.14 (2026-07-18)**, even though release-please has kept bumping the version and pushing tags. `v0.4.0`, `v0.4.1`, `v0.4.2`, `v0.5.0`, `v0.5.1`, `v0.5.2` all exist as **tags with no release behind them** — `rs/libmoq/Cargo.toml` is at 0.5.2, the newest published artifact is 0.3.14.

Every `libmoq` workflow run since v0.4.0 fails both Linux build jobs in the nix deps derivation:

```
bindgen-0.65.1/lib.rs:603:31: Unable to find libclang
```

The v0.4.0 batch is when moq-video entered libmoq's dependency closure (the "native per-platform H.264 codecs, drop ffmpeg" work). Confirmed against the lockfiles at each tag — `v4l` and `v4l2-sys-mit` are absent at `libmoq-v0.3.14` and present at `libmoq-v0.4.0`:

```
libmoq -> moq-video -> v4l 0.14.0 -> v4l2-sys-mit 0.3.0 -> bindgen 0.65.1
```

`v4l2-sys-mit`'s build.rs runs bindgen over `<linux/videodev2.h>`, and `libmoqArgs` only carried `pkg-config` — no libclang in the sandbox. The `release` job is `needs: build`, so one failed matrix leg skips release creation entirely. Hence tags but no releases.

**libmoq is the only nix-built package that pulls moq-video** (verified: `cargo tree -p moq-cli -i v4l` and `-p moq-relay` are both empty), which is why moq-cli and moq-relay releases kept publishing normally and this went unnoticed.

The fix adds `rustPlatform.bindgenHook` rather than setting `LIBCLANG_PATH` by hand — it also sets `BINDGEN_EXTRA_CLANG_ARGS` so bindgen finds libc headers, and it's what the devShell in `flake.nix` already uses for exactly this reason.

### This also explains the smoke matrix

`smoke.sh::libmoq_fetch` resolves the newest `libmoq-v*` **release**, so smoke has been testing v0.3.14 for six weeks. That's why the `c-pkgconfig` leg fails on a `moq.pc` bug already fixed in #2502 (2026-07-24):

```
libdir=${pcfiledir}/..                      # correct -> <root>/lib
includedir=${pcfiledir}/../../../include    # resolves above <root>; moq.h not found
```

`c` (hand-rolled `-I`) and `c-cmake` pass because only the `.pc` is wrong. The fix has simply never reached a published artifact. Unbreaking the release is what clears it.

## 2. `fix(relay)`: bytesize default features

The `cargo` leg failed separately, at `cargo install moq-relay`:

```
error[E0277]: the trait bound `ByteSize: FromStr` is not satisfied
   --> moq-relay-0.14.5/src/cache.rs:123:4
```

`cache.rs::parse_limit` resolves `--cache-limit` through `str::parse::<bytesize::ByteSize>()`, but the dep was declared `default-features = false`. bytesize 2.5.0 added an `alloc` feature and moved `impl FromStr for ByteSize` behind it (`default = ["std"]`, `std = ["alloc"]`), so a featureless build loses the impl.

Our CI is structurally blind to this: `Cargo.lock` pins 2.4.2, where the impl is unconditional. Only a fresh resolve hits it, which is exactly what `cargo install` does. moq-relay is a std binary, so `default-features = false` bought nothing.

Verified by pinning to the version that broke it (`cargo update -p bytesize --precise 2.6.0`):

| `rs/moq-relay/Cargo.toml` | `cargo check -p moq-relay` |
|---|---|
| `default-features = false` (before) | `error[E0277]` — reproduces CI exactly |
| default features (after) | clean |

`Cargo.lock` is unchanged (still 2.4.2). 2.5.0 and 2.6.0 have since been yanked and 2.7.0 restored the unconditional impl, so this leg would go green on a re-run anyway; the declaration is what makes the next such change a non-event.

## Verification and what I could not check

- `cargo clippy -p moq-relay --all-targets` clean; 161 lib unit tests pass, including `parse_limit`'s three.
- The 5 failures in `rs/moq-relay/tests/smoke.rs` are pre-existing in my sandbox (no IPv6, `BindSocket(Os { code: 97 })`) and identical with and without these changes.
- **The nix change is not verified locally — this environment has no nix.** Worth knowing before merging.

## The gap that let this hide

Nothing builds `.#libmoq` before a tag push: `flake.nix` sets `checks = { }`, `just ci`'s `nix flake check` is eval + devShell only, and both `libmoq.yml` and `cachix.yml` trigger solely on `libmoq-v*` tags. So the release build's first and only exercise is the release itself, and a failure there is invisible unless someone reads the tag list against the release list.

Closing that (building the release packages on PRs touching `rs/` or `*.nix`) would have caught this on the PR that introduced it, and would also verify the fix above. I have not done it here since it is a real CI-cost decision — happy to follow up if you want it.

## No regression tests

Neither failure is reachable from a test. `parse_limit` already has unit tests covering bytes, percentages and garbage, and none can catch a feature-resolution compile error. The nix one is a build-environment fix. In both cases the dependency/build declaration is the guard.