### PR TITLE
fix(moq-hls): support nested and encoded HLS routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4488,6 +4488,7 @@ dependencies = [
  "m3u8-rs",
  "moq-mux",
  "moq-net",
+ "percent-encoding",
  "reqwest",
  "thiserror 2.0.19",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ moq-transcode = { version = "0.0.5", path = "rs/moq-transcode", default-features
 # dlopen's libva at runtime (no libva-dev at build, no NEEDED libva in the binary).
 moq-vaapi = "0.0.3"
 moq-video = { version = "0.0.11", path = "rs/moq-video", default-features = false }
+percent-encoding = "2"
 qmux = { version = "0.4.0", default-features = false }
 serde = { version = "1", features = ["derive"] }
 tokio = "1.48"

--- a/rs/moq-hls/Cargo.toml
+++ b/rs/moq-hls/Cargo.toml
@@ -29,6 +29,7 @@ kio = { workspace = true }
 m3u8-rs = "6"
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
+percent-encoding = "2"
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "gzip"] }
 thiserror = "2"
 tokio = { workspace = true, features = ["full"] }

--- a/rs/moq-hls/Cargo.toml
+++ b/rs/moq-hls/Cargo.toml
@@ -29,7 +29,7 @@ kio = { workspace = true }
 m3u8-rs = "6"
 moq-mux = { workspace = true }
 moq-net = { workspace = true }
-percent-encoding = "2"
+percent-encoding = { workspace = true }
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "gzip"] }
 thiserror = "2"
 tokio = { workspace = true, features = ["full"] }

--- a/rs/moq-hls/src/export/master.rs
+++ b/rs/moq-hls/src/export/master.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeMap;
 use std::fmt::Write;
 
-use percent_encoding::{AsciiSet, CONTROLS, NON_ALPHANUMERIC, utf8_percent_encode};
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
 
 use super::Kind;
 
@@ -15,8 +15,6 @@ const AUDIO_GROUP: &str = "aud";
 
 /// RFC 3986 unreserved characters, which are safe in one URL path segment.
 const PATH_SEGMENT: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'.').remove(b'_').remove(b'~');
-/// Characters that cannot appear in an HLS quoted-string attribute.
-const QUOTED_STRING: &AsciiSet = &CONTROLS.add(b'"');
 
 fn rendition_uri(kind: Kind, name: &str, suffix: &str) -> String {
 	format!(
@@ -27,7 +25,15 @@ fn rendition_uri(kind: Kind, name: &str, suffix: &str) -> String {
 }
 
 fn quoted_string(value: &str) -> String {
-	utf8_percent_encode(value, QUOTED_STRING).to_string()
+	let mut quoted = String::with_capacity(value.len());
+	for character in value.chars() {
+		if character == '"' || character.is_ascii_control() {
+			let _ = write!(quoted, "%{:02X}", character as u32);
+		} else {
+			quoted.push(character);
+		}
+	}
+	quoted
 }
 
 /// A video rendition entry for the master playlist.
@@ -265,16 +271,16 @@ mod tests {
 	}
 
 	#[test]
-	fn audio_names_cannot_inject_attributes_or_lines() {
+	fn audio_names_preserve_unicode_without_injection() {
 		let audio = vec![AudioVariant {
-			name: "audio\"\nINJECT\u{7f}\u{1f3b5}".into(),
+			name: "音声\"\nINJECT\u{7f}\u{1f3b5}".into(),
 			bandwidth: 128_000,
 			codec: "opus".into(),
 		}];
 
 		let out = render_master(&[], &audio, None);
 
-		assert!(out.contains("NAME=\"audio%22%0AINJECT%7F%F0%9F%8E%B5\""));
+		assert!(out.contains("NAME=\"音声%22%0AINJECT%7F🎵\""));
 		assert!(!out.contains("\nINJECT"));
 	}
 }

--- a/rs/moq-hls/src/export/master.rs
+++ b/rs/moq-hls/src/export/master.rs
@@ -6,7 +6,7 @@
 use std::collections::BTreeMap;
 use std::fmt::Write;
 
-use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+use percent_encoding::{AsciiSet, CONTROLS, NON_ALPHANUMERIC, utf8_percent_encode};
 
 use super::Kind;
 
@@ -15,6 +15,8 @@ const AUDIO_GROUP: &str = "aud";
 
 /// RFC 3986 unreserved characters, which are safe in one URL path segment.
 const PATH_SEGMENT: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'.').remove(b'_').remove(b'~');
+/// Characters that cannot appear in an HLS quoted-string attribute.
+const QUOTED_STRING: &AsciiSet = &CONTROLS.add(b'"');
 
 fn rendition_uri(kind: Kind, name: &str, suffix: &str) -> String {
 	format!(
@@ -22,6 +24,10 @@ fn rendition_uri(kind: Kind, name: &str, suffix: &str) -> String {
 		kind.as_str(),
 		utf8_percent_encode(name, PATH_SEGMENT)
 	)
+}
+
+fn quoted_string(value: &str) -> String {
+	utf8_percent_encode(value, QUOTED_STRING).to_string()
 }
 
 /// A video rendition entry for the master playlist.
@@ -118,11 +124,12 @@ pub fn render_master(video: &[VideoVariant], audio: &[AudioVariant], query: Opti
 	for group in &audio_groups {
 		for (index, variant) in group.variants.iter().enumerate() {
 			let default = if index == 0 { "YES" } else { "NO" };
+			let name = quoted_string(&variant.name);
 			let _ = writeln!(
 				out,
 				"#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"{}\",NAME=\"{}\",DEFAULT={default},AUTOSELECT=YES,URI=\"{}\"",
 				group.id,
-				variant.name,
+				name,
 				rendition_uri(Kind::Audio, &variant.name, &suffix)
 			);
 		}
@@ -255,5 +262,19 @@ mod tests {
 
 		assert!(out.contains("\nvideo/cam%231%2Fmain%3Falt/media.m3u8?jwt=abc.def\n"));
 		assert!(out.contains("URI=\"audio/audio%20%231/media.m3u8?jwt=abc.def\""));
+	}
+
+	#[test]
+	fn audio_names_cannot_inject_attributes_or_lines() {
+		let audio = vec![AudioVariant {
+			name: "audio\"\nINJECT\u{7f}\u{1f3b5}".into(),
+			bandwidth: 128_000,
+			codec: "opus".into(),
+		}];
+
+		let out = render_master(&[], &audio, None);
+
+		assert!(out.contains("NAME=\"audio%22%0AINJECT%7F%F0%9F%8E%B5\""));
+		assert!(!out.contains("\nINJECT"));
 	}
 }

--- a/rs/moq-hls/src/export/master.rs
+++ b/rs/moq-hls/src/export/master.rs
@@ -6,10 +6,23 @@
 use std::collections::BTreeMap;
 use std::fmt::Write;
 
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
+
 use super::Kind;
 
 const VERSION: u32 = 9;
 const AUDIO_GROUP: &str = "aud";
+
+/// RFC 3986 unreserved characters, which are safe in one URL path segment.
+const PATH_SEGMENT: &AsciiSet = &NON_ALPHANUMERIC.remove(b'-').remove(b'.').remove(b'_').remove(b'~');
+
+fn rendition_uri(kind: Kind, name: &str, suffix: &str) -> String {
+	format!(
+		"{}/{}/media.m3u8{suffix}",
+		kind.as_str(),
+		utf8_percent_encode(name, PATH_SEGMENT)
+	)
+}
 
 /// A video rendition entry for the master playlist.
 pub struct VideoVariant {
@@ -86,7 +99,7 @@ fn render_video(out: &mut String, variant: &VideoVariant, audio: Option<&AudioGr
 		let _ = write!(line, ",AUDIO=\"{}\"", group.id);
 	}
 	let _ = writeln!(out, "{line}");
-	let _ = writeln!(out, "{}/{}/media.m3u8{suffix}", Kind::Video.as_str(), variant.name);
+	let _ = writeln!(out, "{}", rendition_uri(Kind::Video, &variant.name, suffix));
 }
 
 /// Render the multivariant playlist. The first rendition in each audio codec group is default.
@@ -107,11 +120,10 @@ pub fn render_master(video: &[VideoVariant], audio: &[AudioVariant], query: Opti
 			let default = if index == 0 { "YES" } else { "NO" };
 			let _ = writeln!(
 				out,
-				"#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"{}\",NAME=\"{}\",DEFAULT={default},AUTOSELECT=YES,URI=\"{}/{}/media.m3u8{suffix}\"",
+				"#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=\"{}\",NAME=\"{}\",DEFAULT={default},AUTOSELECT=YES,URI=\"{}\"",
 				group.id,
 				variant.name,
-				Kind::Audio.as_str(),
-				variant.name
+				rendition_uri(Kind::Audio, &variant.name, &suffix)
 			);
 		}
 	}
@@ -134,7 +146,7 @@ pub fn render_master(video: &[VideoVariant], audio: &[AudioVariant], query: Opti
 				"#EXT-X-STREAM-INF:BANDWIDTH={},CODECS=\"{}\"",
 				variant.bandwidth, variant.codec
 			);
-			let _ = writeln!(out, "{}/{}/media.m3u8{suffix}", Kind::Audio.as_str(), variant.name);
+			let _ = writeln!(out, "{}", rendition_uri(Kind::Audio, &variant.name, &suffix));
 		}
 	}
 
@@ -222,5 +234,26 @@ mod tests {
 		let out = render_master(&[], &audio, None);
 		assert!(out.contains("#EXT-X-STREAM-INF:BANDWIDTH=128000,CODECS=\"opus\"\n"));
 		assert!(out.contains("\naudio/audio/media.m3u8\n"));
+	}
+
+	#[test]
+	fn rendition_names_are_percent_encoded_in_uris() {
+		let video = vec![VideoVariant {
+			name: "cam#1/main?alt".into(),
+			bandwidth: 2_500_000,
+			width: None,
+			height: None,
+			codec: "avc1.42c01f".into(),
+		}];
+		let audio = vec![AudioVariant {
+			name: "audio #1".into(),
+			bandwidth: 128_000,
+			codec: "opus".into(),
+		}];
+
+		let out = render_master(&video, &audio, Some("jwt=abc.def"));
+
+		assert!(out.contains("\nvideo/cam%231%2Fmain%3Falt/media.m3u8?jwt=abc.def\n"));
+		assert!(out.contains("URI=\"audio/audio%20%231/media.m3u8?jwt=abc.def\""));
 	}
 }

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -271,7 +271,7 @@ impl Rendition {
 	///
 	/// For inline-parameter-set codecs (no catalog `description`), the parameter sets are
 	/// resolved by fetching the newest complete segment's group first.
-	pub(crate) async fn init(&self) -> Result<Option<Bytes>> {
+	pub async fn init(&self) -> Result<Option<Bytes>> {
 		let mut cache = self.init.lock().await;
 		if let Some(bytes) = cache.as_ref() {
 			return Ok(Some(bytes.clone()));

--- a/rs/moq-hls/src/server/mod.rs
+++ b/rs/moq-hls/src/server/mod.rs
@@ -14,11 +14,11 @@
 //!
 //! Every request is served. To gate access, wrap [`Server::router`] in your own
 //! [`axum`] middleware. It runs before routing, so a rejected request never reaches
-//! the origin, but it also sees the raw request URI rather than the path parameters
-//! axum decodes for the handlers. The broadcast is the first segment, still
-//! percent-encoded: `/li%76e/master.m3u8` serves the broadcast `live`. Decode a
-//! segment before matching it against a policy, or a name can be encoded past the
-//! check.
+//! the origin, but it also sees the raw request URI rather than the path segments
+//! the server decodes. A broadcast occupies every segment before the HLS resource
+//! suffix, still percent-encoded: `/project/li%76e/master.m3u8` serves the broadcast
+//! `project/live`. Decode each segment before matching it against a policy, or a
+//! name can be encoded past the check.
 //!
 //! ```no_run
 //! use axum::http::StatusCode;
@@ -194,6 +194,32 @@ mod tests {
 		// Pin the 404 to our handler: an unmatched route would also 404, but without
 		// the no-store that not_found() sets, so a broken URI can't fake this pass.
 		assert_eq!(allowed.headers()[header::CACHE_CONTROL], "no-store");
+	}
+
+	#[tokio::test(start_paused = true)]
+	async fn router_matches_multisegment_broadcast_when_nested() {
+		use axum::body::Body;
+		use axum::extract::Request;
+		use axum::http::{StatusCode, header};
+		use tower::ServiceExt;
+
+		let origin = moq_net::Origin::random().produce();
+		let server = Server::new(origin.consume(), Config::default());
+		let app = Router::new().nest("/hls", server.router());
+
+		let response = app
+			.oneshot(
+				Request::builder()
+					.uri("/hls/project/live/master.m3u8")
+					.body(Body::empty())
+					.unwrap(),
+			)
+			.await
+			.unwrap();
+
+		assert_eq!(response.status(), StatusCode::NOT_FOUND);
+		// The handler adds no-store. Axum's unmatched-route 404 does not.
+		assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
 	}
 
 	async fn closed_broadcaster() -> Arc<Broadcaster> {

--- a/rs/moq-hls/src/server/routes.rs
+++ b/rs/moq-hls/src/server/routes.rs
@@ -4,11 +4,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::Router;
-use axum::extract::{Path, RawQuery, State};
-use axum::http::{StatusCode, header};
+use axum::extract::{RawQuery, State};
+use axum::http::{StatusCode, Uri, header};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use bytes::Bytes;
+use percent_encoding::percent_decode_str;
 
 use super::Server;
 use crate::export::{Kind, Rendition};
@@ -21,16 +22,96 @@ const MP4: &str = "video/mp4";
 const READY_TIMEOUT: Duration = Duration::from_secs(5);
 
 pub fn router(server: Server) -> Router {
-	Router::new()
-		.route("/{broadcast}/master.m3u8", get(master))
-		.route("/{broadcast}/{kind}/{rendition}/media.m3u8", get(media))
-		.route("/{broadcast}/{kind}/{rendition}/init.mp4", get(init))
-		.route("/{broadcast}/{kind}/{rendition}/seg/{file}", get(segment))
-		.with_state(server)
+	Router::new().route("/{*path}", get(request)).with_state(server)
 }
 
-async fn master(State(server): State<Server>, Path(broadcast): Path<String>, RawQuery(query): RawQuery) -> Response {
-	let Some(broadcaster) = server.broadcaster(&broadcast).await else {
+enum Route {
+	Master {
+		broadcast: String,
+	},
+	Media {
+		broadcast: String,
+		kind: String,
+		rendition: String,
+	},
+	Init {
+		broadcast: String,
+		kind: String,
+		rendition: String,
+	},
+	Segment {
+		broadcast: String,
+		kind: String,
+		rendition: String,
+		file: String,
+	},
+}
+
+fn parse_route(path: &str) -> Option<Route> {
+	let parts = path
+		.strip_prefix('/')?
+		.split('/')
+		.map(|part| {
+			percent_decode_str(part)
+				.decode_utf8()
+				.ok()
+				.map(|part| part.into_owned())
+		})
+		.collect::<Option<Vec<_>>>()?;
+
+	match parts.as_slice() {
+		[broadcast @ .., file] if !broadcast.is_empty() && file == "master.m3u8" => Some(Route::Master {
+			broadcast: broadcast.join("/"),
+		}),
+		[broadcast @ .., kind, rendition, file] if !broadcast.is_empty() && file == "media.m3u8" => {
+			Some(Route::Media {
+				broadcast: broadcast.join("/"),
+				kind: kind.clone(),
+				rendition: rendition.clone(),
+			})
+		}
+		[broadcast @ .., kind, rendition, file] if !broadcast.is_empty() && file == "init.mp4" => Some(Route::Init {
+			broadcast: broadcast.join("/"),
+			kind: kind.clone(),
+			rendition: rendition.clone(),
+		}),
+		[broadcast @ .., kind, rendition, directory, file] if !broadcast.is_empty() && directory == "seg" => {
+			Some(Route::Segment {
+				broadcast: broadcast.join("/"),
+				kind: kind.clone(),
+				rendition: rendition.clone(),
+				file: file.clone(),
+			})
+		}
+		_ => None,
+	}
+}
+
+async fn request(State(server): State<Server>, uri: Uri, RawQuery(query): RawQuery) -> Response {
+	match parse_route(uri.path()) {
+		Some(Route::Master { broadcast }) => master(&server, &broadcast, query.as_deref()).await,
+		Some(Route::Media {
+			broadcast,
+			kind,
+			rendition,
+		}) => media(&server, &broadcast, &kind, &rendition, query.as_deref()).await,
+		Some(Route::Init {
+			broadcast,
+			kind,
+			rendition,
+		}) => init(&server, &broadcast, &kind, &rendition).await,
+		Some(Route::Segment {
+			broadcast,
+			kind,
+			rendition,
+			file,
+		}) => segment(&server, &broadcast, &kind, &rendition, &file).await,
+		None => not_found(),
+	}
+}
+
+async fn master(server: &Server, broadcast: &str, query: Option<&str>) -> Response {
+	let Some(broadcaster) = server.broadcaster(broadcast).await else {
 		return not_found();
 	};
 	let _ = tokio::time::timeout(READY_TIMEOUT, broadcaster.ready()).await;
@@ -39,15 +120,11 @@ async fn master(State(server): State<Server>, Path(broadcast): Path<String>, Raw
 	}
 	// Propagate whatever query reached the master (e.g. a credential a wrapping
 	// middleware required) down to the child media-playlist URLs.
-	m3u8(broadcaster.master_playlist(query.as_deref()))
+	m3u8(broadcaster.master_playlist(query))
 }
 
-async fn media(
-	State(server): State<Server>,
-	Path((broadcast, kind, rendition)): Path<(String, String, String)>,
-	RawQuery(query): RawQuery,
-) -> Response {
-	let Some(rendition) = rendition_for(&server, &broadcast, &kind, &rendition).await else {
+async fn media(server: &Server, broadcast: &str, kind: &str, rendition: &str, query: Option<&str>) -> Response {
+	let Some(rendition) = rendition_for(server, broadcast, kind, rendition).await else {
 		return not_found();
 	};
 
@@ -64,17 +141,14 @@ async fn media(
 		Err(err) => return server_error(err),
 	}
 
-	match rendition.media_playlist(query.as_deref()) {
+	match rendition.media_playlist(query) {
 		Some(playlist) => m3u8(playlist),
 		None => not_found(),
 	}
 }
 
-async fn init(
-	State(server): State<Server>,
-	Path((broadcast, kind, rendition)): Path<(String, String, String)>,
-) -> Response {
-	let Some(rendition) = rendition_for(&server, &broadcast, &kind, &rendition).await else {
+async fn init(server: &Server, broadcast: &str, kind: &str, rendition: &str) -> Response {
+	let Some(rendition) = rendition_for(server, broadcast, kind, rendition).await else {
 		return not_found();
 	};
 	match rendition.init().await {
@@ -84,14 +158,11 @@ async fn init(
 	}
 }
 
-async fn segment(
-	State(server): State<Server>,
-	Path((broadcast, kind, rendition, file)): Path<(String, String, String, String)>,
-) -> Response {
+async fn segment(server: &Server, broadcast: &str, kind: &str, rendition: &str, file: &str) -> Response {
 	let Some(sequence) = file.strip_suffix(".m4s").and_then(|s| s.parse::<u64>().ok()) else {
 		return not_found();
 	};
-	let Some(rendition) = rendition_for(&server, &broadcast, &kind, &rendition).await else {
+	let Some(rendition) = rendition_for(server, broadcast, kind, rendition).await else {
 		return not_found();
 	};
 	match rendition.segment(sequence).await {
@@ -139,4 +210,43 @@ fn not_found() -> Response {
 fn server_error(err: crate::Error) -> Response {
 	tracing::warn!(%err, "hls request failed");
 	(StatusCode::INTERNAL_SERVER_ERROR, [(header::CACHE_CONTROL, "no-store")]).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn parses_multisegment_broadcast_and_encoded_rendition() {
+		let Some(Route::Media {
+			broadcast,
+			kind,
+			rendition,
+		}) = parse_route("/project/live/video/cam%231%2Fmain%3Falt/media.m3u8")
+		else {
+			panic!("media route should parse");
+		};
+
+		assert_eq!(broadcast, "project/live");
+		assert_eq!(kind, "video");
+		assert_eq!(rendition, "cam#1/main?alt");
+	}
+
+	#[test]
+	fn parses_all_resource_routes() {
+		assert!(matches!(
+			parse_route("/project/live/master.m3u8"),
+			Some(Route::Master { .. })
+		));
+		assert!(matches!(
+			parse_route("/project/live/video/main/init.mp4"),
+			Some(Route::Init { .. })
+		));
+		assert!(matches!(
+			parse_route("/project/live/video/main/seg/42.m4s"),
+			Some(Route::Segment { .. })
+		));
+		assert!(parse_route("/master.m3u8").is_none());
+		assert!(parse_route("/project/live/video/main/unknown").is_none());
+	}
 }

--- a/rs/moq-hls/src/server/routes.rs
+++ b/rs/moq-hls/src/server/routes.rs
@@ -47,6 +47,10 @@ enum Route {
 	},
 }
 
+fn broadcast_path(parts: &[String]) -> Option<String> {
+	(!parts.is_empty() && parts.iter().all(|part| !part.contains('/'))).then(|| parts.join("/"))
+}
+
 fn parse_route(path: &str) -> Option<Route> {
 	let parts = path
 		.strip_prefix('/')?
@@ -63,29 +67,25 @@ fn parse_route(path: &str) -> Option<Route> {
 	}
 
 	match parts.as_slice() {
-		[broadcast @ .., file] if !broadcast.is_empty() && file == "master.m3u8" => Some(Route::Master {
-			broadcast: broadcast.join("/"),
+		[broadcast @ .., file] if file == "master.m3u8" => Some(Route::Master {
+			broadcast: broadcast_path(broadcast)?,
 		}),
-		[broadcast @ .., kind, rendition, file] if !broadcast.is_empty() && file == "media.m3u8" => {
-			Some(Route::Media {
-				broadcast: broadcast.join("/"),
-				kind: kind.clone(),
-				rendition: rendition.clone(),
-			})
-		}
-		[broadcast @ .., kind, rendition, file] if !broadcast.is_empty() && file == "init.mp4" => Some(Route::Init {
-			broadcast: broadcast.join("/"),
+		[broadcast @ .., kind, rendition, file] if file == "media.m3u8" => Some(Route::Media {
+			broadcast: broadcast_path(broadcast)?,
 			kind: kind.clone(),
 			rendition: rendition.clone(),
 		}),
-		[broadcast @ .., kind, rendition, directory, file] if !broadcast.is_empty() && directory == "seg" => {
-			Some(Route::Segment {
-				broadcast: broadcast.join("/"),
-				kind: kind.clone(),
-				rendition: rendition.clone(),
-				file: file.clone(),
-			})
-		}
+		[broadcast @ .., kind, rendition, file] if file == "init.mp4" => Some(Route::Init {
+			broadcast: broadcast_path(broadcast)?,
+			kind: kind.clone(),
+			rendition: rendition.clone(),
+		}),
+		[broadcast @ .., kind, rendition, directory, file] if directory == "seg" => Some(Route::Segment {
+			broadcast: broadcast_path(broadcast)?,
+			kind: kind.clone(),
+			rendition: rendition.clone(),
+			file: file.clone(),
+		}),
 		_ => None,
 	}
 }
@@ -256,5 +256,11 @@ mod tests {
 	#[test]
 	fn rejects_empty_path_segments() {
 		assert!(parse_route("/project//live/master.m3u8").is_none());
+	}
+
+	#[test]
+	fn rejects_encoded_broadcast_separators() {
+		assert!(parse_route("/project/private%2F/master.m3u8").is_none());
+		assert!(parse_route("/project%2Fprivate/master.m3u8").is_none());
 	}
 }

--- a/rs/moq-hls/src/server/routes.rs
+++ b/rs/moq-hls/src/server/routes.rs
@@ -58,6 +58,9 @@ fn parse_route(path: &str) -> Option<Route> {
 				.map(|part| part.into_owned())
 		})
 		.collect::<Option<Vec<_>>>()?;
+	if parts.iter().any(String::is_empty) {
+		return None;
+	}
 
 	match parts.as_slice() {
 		[broadcast @ .., file] if !broadcast.is_empty() && file == "master.m3u8" => Some(Route::Master {
@@ -248,5 +251,10 @@ mod tests {
 		));
 		assert!(parse_route("/master.m3u8").is_none());
 		assert!(parse_route("/project/live/video/main/unknown").is_none());
+	}
+
+	#[test]
+	fn rejects_empty_path_segments() {
+		assert!(parse_route("/project//live/master.m3u8").is_none());
 	}
 }


### PR DESCRIPTION
## Summary

- Parse HLS resource suffixes from a catch-all route so multi-segment broadcast paths resolve correctly, including when the router is nested.
- Percent-encode publisher-controlled rendition names in generated URI path segments and characters invalid in HLS quoted-string attributes.
- Reject empty path segments and encoded broadcast separators so HTTP authorization and normalized MoQ broadcast paths cannot disagree.
- Expose `Rendition::init` directly so downstream origins do not need to allocate a throwaway segment cursor.

The root causes were fixed route patterns that captured the broadcast as exactly one path segment, raw rendition-name interpolation into playlist syntax, and accepting non-canonical broadcast paths that `moq_net::Path` later normalized. This is the upstream half of moq-dev/moq.pro#894; moq.pro still needs to bump its pin and remove its workarounds after this lands.

## Public API changes

- `moq_hls::Rendition::init` is now public. This is additive and preserves the existing signature and cache behavior.

## Test plan

- `cargo fmt --all -- --check`
- `cargo nextest run -p moq-hls` (56 passed)
- `cargo clippy -p moq-hls --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p moq-hls --all-features --no-deps`
- Remote `nix develop --command just ci`
- Remote Windows check

(Written by GPT-5.6)