### PR TITLE
feat(ci): alert Discord when a workflow fails outside a pull request

### DIFF
--- a/.github/justfile
+++ b/.github/justfile
@@ -3,7 +3,9 @@ set fallback
 # Lint GitHub Actions workflows. Silently skipped if actionlint is not installed.
 check:
     @if command -v actionlint >/dev/null 2>&1; then actionlint; fi
+    {{ justfile_directory() }}/scripts/alert.sh check-coverage
 
 # CI variant: actionlint is required (provided by the nix devShell).
 ci:
     actionlint
+    {{ justfile_directory() }}/scripts/alert.sh check-coverage

--- a/.github/justfile
+++ b/.github/justfile
@@ -3,9 +3,9 @@ set fallback
 # Lint GitHub Actions workflows. Silently skipped if actionlint is not installed.
 check:
     @if command -v actionlint >/dev/null 2>&1; then actionlint; fi
-    {{ justfile_directory() }}/scripts/alert.sh check-coverage
+    {{ source_directory() }}/scripts/alert.sh check-coverage
 
 # CI variant: actionlint is required (provided by the nix devShell).
 ci:
     actionlint
-    {{ justfile_directory() }}/scripts/alert.sh check-coverage
+    {{ source_directory() }}/scripts/alert.sh check-coverage

--- a/.github/scripts/alert.sh
+++ b/.github/scripts/alert.sh
@@ -151,11 +151,15 @@ workflow_triggers() {
 }
 
 # Names of workflows carrying at least one non-pull_request trigger.
+#
+# GitHub runs both .yml and .yaml, so both are scanned. nullglob keeps the
+# unmatched extension from expanding to a literal path under `set -u`.
 non_pr_workflow_names() {
     local f triggers
-    for f in "$WORKFLOWS_DIR"/*.yml; do
+    shopt -s nullglob
+    for f in "$WORKFLOWS_DIR"/*.yml "$WORKFLOWS_DIR"/*.yaml; do
         # alert.yml watches the others; watching itself would be a trigger loop.
-        [[ "$(basename "$f")" == "alert.yml" ]] && continue
+        [[ "$(basename "$f")" =~ ^alert\.ya?ml$ ]] && continue
 
         triggers=$(workflow_triggers "$f")
         if grep -qvx 'pull_request' <<<"$triggers"; then

--- a/.github/scripts/alert.sh
+++ b/.github/scripts/alert.sh
@@ -88,11 +88,11 @@ check_coverage() {
 #
 # The YAML is parsed rather than pattern-matched. GitHub accepts `on:` as a
 # block map, block sequence, flow sequence or bare scalar, any of which may wrap
-# across lines, and it runs both .yml and .yaml. Every hand-rolled version of
-# this missed a shape and then reported success for a workflow it had not
-# actually read, which is the exact silent gap the guard exists to close. bun is
-# already a hard dependency (jsDeps in flake.nix, `bun install` in CI), so its
-# YAML parser costs nothing new.
+# across lines, and it runs both .yml and .yaml. A matcher covering only some of
+# those shapes reports "no non-PR triggers" for a workflow it did not actually
+# read, which is the silent gap this guard exists to close. bun is already a
+# hard dependency (jsDeps in flake.nix, `bun install` in CI), so its YAML parser
+# costs nothing new.
 #
 # A workflow with no `name:` is an error, not a skip: GitHub falls back to the
 # file path, which alert.yml cannot reference, and skipping it would put the

--- a/.github/scripts/alert.sh
+++ b/.github/scripts/alert.sh
@@ -64,7 +64,12 @@ discord() {
 # a push/schedule trigger to a PR-only one, fails here until alert.yml matches.
 check_coverage() {
     local expected actual
-    expected=$(non_pr_workflow_names | sort -u)
+    # Not `non_pr_workflow_names | sort -u`: a failure inside a pipeline would
+    # be swallowed and read as "no workflows need watching", which is the
+    # silent pass this whole guard exists to prevent. Capture, propagate, then
+    # sort.
+    expected=$(non_pr_workflow_names) || return 2
+    expected=$(sort -u <<<"$expected")
     actual=$(watched_workflow_names | sort -u)
 
     if [[ "$expected" == "$actual" ]]; then
@@ -86,9 +91,9 @@ check_coverage() {
 # read, and check_coverage would pass while the workflow went unwatched. That
 # silent gap is the whole thing this script exists to prevent.
 #
-# Anything still unrecognized (a quoted `"on":`, say) is loud rather than empty:
-# it prints to stderr and yields no triggers, which check_coverage then reads as
-# non-PR, so the workflow is reported missing instead of quietly skipped.
+# Anything still unrecognized (a quoted `"on":`, say) is a hard error that
+# aborts check_coverage, rather than an empty result it could mistake for
+# "no non-PR triggers".
 workflow_triggers() {
     awk -v file="$1" '
         # on: [push, pull_request]
@@ -161,11 +166,34 @@ non_pr_workflow_names() {
         # alert.yml watches the others; watching itself would be a trigger loop.
         [[ "$(basename "$f")" =~ ^alert\.ya?ml$ ]] && continue
 
-        triggers=$(workflow_triggers "$f")
+        triggers=$(workflow_triggers "$f") || return 2
         if grep -qvx 'pull_request' <<<"$triggers"; then
-            sed -n 's/^name:[[:space:]]*//p' "$f" | head -1
+            workflow_name "$f" || return 2
         fi
     done
+}
+
+# The workflow's `name:`, which is what alert.yml references.
+#
+# GitHub treats `name:` as optional and falls back to the file path, which
+# workflow_run cannot reference cleanly. Every workflow here has one, so this
+# requires it: a nameless workflow would otherwise contribute nothing and slip
+# past check_coverage unwatched.
+workflow_name() {
+    local name
+    name=$(sed -n 's/^name:[[:space:]]*//p' "$1" | head -1)
+    name=${name%%#*}
+    name=${name%"${name##*[![:space:]]}"}
+    # Unquote so `name: "Foo"` matches a plain `- Foo` entry in alert.yml.
+    if [[ "$name" =~ ^\"(.*)\"$ ]] || [[ "$name" =~ ^\'(.*)\'$ ]]; then
+        name="${BASH_REMATCH[1]}"
+    fi
+
+    if [[ -z "$name" ]]; then
+        echo "alert.sh: $1 has no top-level name:, so alert.yml cannot reference it" >&2
+        return 2
+    fi
+    printf '%s\n' "$name"
 }
 
 # Names listed under alert.yml's `on.workflow_run.workflows:`.

--- a/.github/scripts/alert.sh
+++ b/.github/scripts/alert.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Discord alerting for workflow failures outside of pull requests.
+# Usage:
+#   alert.sh discord           — post the current workflow_run failure to Discord
+#   alert.sh check-coverage    — verify alert.yml watches every non-PR workflow
+#
+# Environment (discord):
+#   DISCORD_WEBHOOK   — required, the #alerts channel webhook URL
+#   RUN_NAME          — workflow name (github.event.workflow_run.name)
+#   RUN_URL           — run html_url
+#   RUN_CONCLUSION    — failure / timed_out
+#   RUN_EVENT         — what triggered the failed run (push, schedule, ...)
+#   RUN_REF           — head_branch: a branch name, or a tag for tag-triggered runs
+#   RUN_TITLE         — display_title (usually the commit subject)
+#   RUN_ACTOR         — triggering actor login
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOWS_DIR="$(cd "$SCRIPT_DIR/../workflows" && pwd)"
+
+# Post a red embed naming the workflow, what it was reacting to, and a link.
+# jq builds the body so a commit subject with quotes or newlines can't produce
+# malformed JSON.
+discord() {
+    : "${DISCORD_WEBHOOK:?DISCORD_WEBHOOK is required}"
+
+    local payload
+    payload=$(jq -n \
+        --arg title "${RUN_NAME:-workflow} ${RUN_CONCLUSION:-failed}" \
+        --arg url "${RUN_URL:-}" \
+        --arg desc "${RUN_TITLE:-}" \
+        --arg ref "${RUN_REF:-unknown}" \
+        --arg event "${RUN_EVENT:-unknown}" \
+        --arg actor "${RUN_ACTOR:-unknown}" \
+        '{
+            embeds: [{
+                title: $title,
+                url: $url,
+                description: $desc,
+                color: 15548997,
+                fields: [
+                    { name: "Ref", value: $ref, inline: true },
+                    { name: "Trigger", value: $event, inline: true },
+                    { name: "Actor", value: $actor, inline: true }
+                ]
+            }]
+        }')
+
+    # Fail the step on a non-2xx so a rotated/rejected webhook surfaces as a
+    # red run rather than silently dropping every future alert.
+    curl -sS --fail-with-body -X POST \
+        -H "Content-Type: application/json" \
+        -d "$payload" \
+        "$DISCORD_WEBHOOK"
+}
+
+# Every workflow that can run outside a pull request must be watched by
+# alert.yml, and PR-only workflows must not be (each entry costs a skipped
+# Alert run per trigger, and `Check` alone fires on every push to every PR).
+#
+# This is the guard against the list going stale: adding a workflow, or adding
+# a push/schedule trigger to a PR-only one, fails here until alert.yml matches.
+check_coverage() {
+    local expected actual
+    expected=$(non_pr_workflow_names | sort -u)
+    actual=$(watched_workflow_names | sort -u)
+
+    if [[ "$expected" == "$actual" ]]; then
+        echo "alert.yml watches all $(wc -l <<<"$expected" | tr -d ' ') non-PR workflows"
+        return 0
+    fi
+
+    echo "alert.yml's workflow list is out of sync with .github/workflows/" >&2
+    comm -23 <(echo "$expected") <(echo "$actual") | sed 's/^/  missing (add to alert.yml):  /' >&2
+    comm -13 <(echo "$expected") <(echo "$actual") | sed 's/^/  stale (remove, PR-only):    /' >&2
+    return 1
+}
+
+# Names of workflows with at least one non-pull_request trigger. Reads the
+# top-level `on:` block, which ends at the next column-0 key.
+non_pr_workflow_names() {
+    local f
+    for f in "$WORKFLOWS_DIR"/*.yml; do
+        # alert.yml watches others; watching itself would be a trigger loop.
+        [[ "$(basename "$f")" == "alert.yml" ]] && continue
+
+        awk '
+            /^on:/                  { in_on = 1; next }
+            in_on && /^[a-zA-Z_]+:/ { in_on = 0 }
+            in_on && /^  [a-z_]+:/  {
+                key = $1
+                sub(":", "", key)
+                if (key != "pull_request") non_pr = 1
+            }
+            END { exit !non_pr }
+        ' "$f" || continue
+
+        sed -n 's/^name:[[:space:]]*//p' "$f" | head -1
+    done
+}
+
+# Names listed under alert.yml's `on.workflow_run.workflows:`.
+watched_workflow_names() {
+    awk '
+        /^    workflows:/   { in_list = 1; next }
+        in_list && /^      - / { sub(/^      - /, ""); print; next }
+        in_list             { exit }
+    ' "$WORKFLOWS_DIR/alert.yml"
+}
+
+case "${1:-}" in
+    discord) discord ;;
+    check-coverage) check_coverage ;;
+    *)
+        echo "Usage: $0 {discord|check-coverage}" >&2
+        exit 1
+        ;;
+esac

--- a/.github/scripts/alert.sh
+++ b/.github/scripts/alert.sh
@@ -70,7 +70,8 @@ check_coverage() {
     # sort.
     expected=$(non_pr_workflow_names) || return 2
     expected=$(sort -u <<<"$expected")
-    actual=$(watched_workflow_names | sort -u)
+    actual=$(watched_workflow_names) || return 2
+    actual=$(sort -u <<<"$actual")
 
     if [[ "$expected" == "$actual" ]]; then
         echo "alert.yml watches all $(wc -l <<<"$expected" | tr -d ' ') non-PR workflows"
@@ -83,130 +84,70 @@ check_coverage() {
     return 1
 }
 
-# Print one trigger name per line for a workflow file.
-#
-# GitHub accepts four serializations of `on:` (block map, block sequence, flow
-# sequence, bare scalar), so all four are handled here. A parser that understood
-# only one would report "no non-PR triggers" for a workflow it merely failed to
-# read, and check_coverage would pass while the workflow went unwatched. That
-# silent gap is the whole thing this script exists to prevent.
-#
-# Anything still unrecognized (a quoted `"on":`, say) is a hard error that
-# aborts check_coverage, rather than an empty result it could mistake for
-# "no non-PR triggers".
-workflow_triggers() {
-    awk -v file="$1" '
-        # on: [push, pull_request]
-        /^on:[[:space:]]*\[/ {
-            line = $0
-            sub(/^on:[[:space:]]*\[/, "", line)
-            sub(/\].*$/, "", line)
-            n = split(line, items, ",")
-            for (i = 1; i <= n; i++) {
-                gsub(/[[:space:]"'"'"']/, "", items[i])
-                if (items[i] != "") print items[i]
-            }
-            seen = 1
-            next
-        }
-        # on: push
-        /^on:[[:space:]]*[A-Za-z_]/ {
-            line = $0
-            sub(/^on:[[:space:]]*/, "", line)
-            sub(/[[:space:]]*#.*$/, "", line)
-            print line
-            seen = 1
-            next
-        }
-        # on:  (block map or block sequence on the following indented lines)
-        /^on:[[:space:]]*(#.*)?$/ { in_on = 1; seen = 1; next }
-
-        in_on && /^[^[:space:]#]/ { in_on = 0 }
-        !in_on { next }
-        # Blank lines and comments.
-        /^[[:space:]]*(#.*)?$/ { next }
-        # Block sequence item: "  - push"
-        /^  - [A-Za-z_]/ {
-            line = $0
-            sub(/^  - /, "", line)
-            sub(/[[:space:]]*#.*$/, "", line)
-            print line
-            next
-        }
-        # Block map key: "  push:"
-        /^  [A-Za-z_][A-Za-z_0-9]*:/ {
-            line = $1
-            sub(/:.*/, "", line)
-            print line
-            next
-        }
-        # Deeper indentation is a triggers own config (branches, tags, types).
-        /^    / { next }
-        {
-            printf "alert.sh: cannot parse the on: block of %s (line %d: %s)\n", file, NR, $0 >"/dev/stderr"
-            exit 2
-        }
-        END {
-            if (!seen) {
-                printf "alert.sh: no on: block found in %s\n", file >"/dev/stderr"
-                exit 2
-            }
-        }
-    ' "$1"
-}
-
 # Names of workflows carrying at least one non-pull_request trigger.
 #
-# GitHub runs both .yml and .yaml, so both are scanned. nullglob keeps the
-# unmatched extension from expanding to a literal path under `set -u`.
+# The YAML is parsed rather than pattern-matched. GitHub accepts `on:` as a
+# block map, block sequence, flow sequence or bare scalar, any of which may wrap
+# across lines, and it runs both .yml and .yaml. Every hand-rolled version of
+# this missed a shape and then reported success for a workflow it had not
+# actually read, which is the exact silent gap the guard exists to close. bun is
+# already a hard dependency (jsDeps in flake.nix, `bun install` in CI), so its
+# YAML parser costs nothing new.
+#
+# A workflow with no `name:` is an error, not a skip: GitHub falls back to the
+# file path, which alert.yml cannot reference, and skipping it would put the
+# workflow past this check unwatched.
 non_pr_workflow_names() {
-    local f triggers
+    local f files=()
     shopt -s nullglob
     for f in "$WORKFLOWS_DIR"/*.yml "$WORKFLOWS_DIR"/*.yaml; do
         # alert.yml watches the others; watching itself would be a trigger loop.
         [[ "$(basename "$f")" =~ ^alert\.ya?ml$ ]] && continue
-
-        triggers=$(workflow_triggers "$f") || return 2
-        if grep -qvx 'pull_request' <<<"$triggers"; then
-            workflow_name "$f" || return 2
-        fi
+        files+=("$f")
     done
+
+    printf "%s\n" "${files[@]}" | bun -e '
+const files = (await Bun.stdin.text()).split("\n").filter(Boolean);
+const names = [];
+for (const file of files) {
+    const doc = Bun.YAML.parse(await Bun.file(file).text());
+    if (doc === null || typeof doc !== "object" || Array.isArray(doc)) {
+        console.error("alert.sh: " + file + " is not a YAML mapping");
+        process.exit(2);
+    }
+    const on = doc.on;
+    let triggers;
+    if (typeof on === "string") triggers = [on];
+    else if (Array.isArray(on)) triggers = on;
+    else if (on !== null && typeof on === "object") triggers = Object.keys(on);
+    else {
+        console.error("alert.sh: cannot read the on: value of " + file);
+        process.exit(2);
+    }
+    if (!triggers.some((t) => t !== "pull_request")) continue;
+
+    const name = doc.name;
+    if (typeof name !== "string" || name.trim() === "") {
+        console.error("alert.sh: " + file + " has no top-level name:, so alert.yml cannot reference it");
+        process.exit(2);
+    }
+    names.push(name.trim());
 }
-
-# The workflow's `name:`, which is what alert.yml references.
-#
-# GitHub treats `name:` as optional and falls back to the file path, which
-# workflow_run cannot reference cleanly. Every workflow here has one, so this
-# requires it: a nameless workflow would otherwise contribute nothing and slip
-# past check_coverage unwatched.
-workflow_name() {
-    local name
-    name=$(sed -n 's/^name:[[:space:]]*//p' "$1" | head -1)
-    name=${name%%#*}
-    name=${name%"${name##*[![:space:]]}"}
-    # Unquote so `name: "Foo"` matches a plain `- Foo` entry in alert.yml.
-    if [[ "$name" =~ ^\"(.*)\"$ ]] || [[ "$name" =~ ^\'(.*)\'$ ]]; then
-        name="${BASH_REMATCH[1]}"
-    fi
-
-    if [[ -z "$name" ]]; then
-        echo "alert.sh: $1 has no top-level name:, so alert.yml cannot reference it" >&2
-        return 2
-    fi
-    printf '%s\n' "$name"
+if (names.length) console.log(names.join("\n"));
+'
 }
 
 # Names listed under alert.yml's `on.workflow_run.workflows:`.
 watched_workflow_names() {
-    awk '
-        /^    workflows:/ { in_list = 1; next }
-        in_list && /^      - / {
-            sub(/^      - /, "")
-            print
-            next
-        }
-        in_list { exit }
-    ' "$WORKFLOWS_DIR/alert.yml"
+    ALERT_YML="$WORKFLOWS_DIR/alert.yml" bun -e '
+const doc = Bun.YAML.parse(await Bun.file(Bun.env.ALERT_YML).text());
+const list = doc?.on?.workflow_run?.workflows;
+if (!Array.isArray(list)) {
+    console.error("alert.sh: alert.yml has no on.workflow_run.workflows list");
+    process.exit(2);
+}
+if (list.length) console.log(list.join("\n"));
+'
 }
 
 case "${1:-}" in

--- a/.github/scripts/alert.sh
+++ b/.github/scripts/alert.sh
@@ -57,8 +57,9 @@ discord() {
 }
 
 # Every workflow that can run outside a pull request must be watched by
-# alert.yml, and PR-only workflows must not be (each entry costs a skipped
-# Alert run per trigger, and `Check` alone fires on every push to every PR).
+# alert.yml, and pull-request-only workflows must not be (each entry costs a
+# skipped Alert run per trigger, and `Check` alone fires on every push to every
+# PR).
 #
 # This is the guard against the list going stale: adding a workflow, or adding
 # a push/schedule trigger to a PR-only one, fails here until alert.yml matches.
@@ -108,6 +109,9 @@ non_pr_workflow_names() {
 
     printf "%s\n" "${files[@]}" | bun -e '
 const files = (await Bun.stdin.text()).split("\n").filter(Boolean);
+// Both report their failure as a check on the PR itself, so alert.yml skips
+// them at runtime and a workflow triggered only by these needs no entry.
+const PR_EVENTS = new Set(["pull_request", "pull_request_target"]);
 const names = [];
 for (const file of files) {
     const doc = Bun.YAML.parse(await Bun.file(file).text());
@@ -124,7 +128,7 @@ for (const file of files) {
         console.error("alert.sh: cannot read the on: value of " + file);
         process.exit(2);
     }
-    if (!triggers.some((t) => t !== "pull_request")) continue;
+    if (!triggers.some((t) => !PR_EVENTS.has(t))) continue;
 
     const name = doc.name;
     if (typeof name !== "string" || name.trim() === "") {

--- a/.github/scripts/alert.sh
+++ b/.github/scripts/alert.sh
@@ -49,8 +49,11 @@ discord() {
         }')
 
     # Fail the step on a non-2xx so a rotated/rejected webhook surfaces as a
-    # red run rather than silently dropping every future alert.
+    # red run rather than silently dropping every future alert. Bounded so a
+    # stalled endpoint fails in seconds instead of holding a runner until the
+    # job timeout.
     curl -sS --fail-with-body -X POST \
+        --connect-timeout 5 --max-time 15 \
         -H "Content-Type: application/json" \
         -d "$payload" \
         "$DISCORD_WEBHOOK"

--- a/.github/scripts/alert.sh
+++ b/.github/scripts/alert.sh
@@ -2,18 +2,18 @@
 #
 # Discord alerting for workflow failures outside of pull requests.
 # Usage:
-#   alert.sh discord           — post the current workflow_run failure to Discord
-#   alert.sh check-coverage    — verify alert.yml watches every non-PR workflow
+#   alert.sh discord          Post the current workflow_run failure to Discord.
+#   alert.sh check-coverage   Verify alert.yml watches every non-PR workflow.
 #
 # Environment (discord):
-#   DISCORD_WEBHOOK   — required, the #alerts channel webhook URL
-#   RUN_NAME          — workflow name (github.event.workflow_run.name)
-#   RUN_URL           — run html_url
-#   RUN_CONCLUSION    — failure / timed_out
-#   RUN_EVENT         — what triggered the failed run (push, schedule, ...)
-#   RUN_REF           — head_branch: a branch name, or a tag for tag-triggered runs
-#   RUN_TITLE         — display_title (usually the commit subject)
-#   RUN_ACTOR         — triggering actor login
+#   DISCORD_WEBHOOK   Required. The #alerts channel webhook URL.
+#   RUN_NAME          Workflow name (github.event.workflow_run.name).
+#   RUN_URL           Run html_url.
+#   RUN_CONCLUSION    failure / timed_out.
+#   RUN_EVENT         What triggered the failed run (push, schedule, ...).
+#   RUN_REF           head_branch: a branch name, or a tag for tag-triggered runs.
+#   RUN_TITLE         display_title, usually the commit subject.
+#   RUN_ACTOR         Triggering actor login.
 
 set -euo pipefail
 
@@ -78,35 +78,102 @@ check_coverage() {
     return 1
 }
 
-# Names of workflows with at least one non-pull_request trigger. Reads the
-# top-level `on:` block, which ends at the next column-0 key.
+# Print one trigger name per line for a workflow file.
+#
+# GitHub accepts four serializations of `on:` (block map, block sequence, flow
+# sequence, bare scalar), so all four are handled here. A parser that understood
+# only one would report "no non-PR triggers" for a workflow it merely failed to
+# read, and check_coverage would pass while the workflow went unwatched. That
+# silent gap is the whole thing this script exists to prevent.
+#
+# Anything still unrecognized (a quoted `"on":`, say) is loud rather than empty:
+# it prints to stderr and yields no triggers, which check_coverage then reads as
+# non-PR, so the workflow is reported missing instead of quietly skipped.
+workflow_triggers() {
+    awk -v file="$1" '
+        # on: [push, pull_request]
+        /^on:[[:space:]]*\[/ {
+            line = $0
+            sub(/^on:[[:space:]]*\[/, "", line)
+            sub(/\].*$/, "", line)
+            n = split(line, items, ",")
+            for (i = 1; i <= n; i++) {
+                gsub(/[[:space:]"'"'"']/, "", items[i])
+                if (items[i] != "") print items[i]
+            }
+            seen = 1
+            next
+        }
+        # on: push
+        /^on:[[:space:]]*[A-Za-z_]/ {
+            line = $0
+            sub(/^on:[[:space:]]*/, "", line)
+            sub(/[[:space:]]*#.*$/, "", line)
+            print line
+            seen = 1
+            next
+        }
+        # on:  (block map or block sequence on the following indented lines)
+        /^on:[[:space:]]*(#.*)?$/ { in_on = 1; seen = 1; next }
+
+        in_on && /^[^[:space:]#]/ { in_on = 0 }
+        !in_on { next }
+        # Blank lines and comments.
+        /^[[:space:]]*(#.*)?$/ { next }
+        # Block sequence item: "  - push"
+        /^  - [A-Za-z_]/ {
+            line = $0
+            sub(/^  - /, "", line)
+            sub(/[[:space:]]*#.*$/, "", line)
+            print line
+            next
+        }
+        # Block map key: "  push:"
+        /^  [A-Za-z_][A-Za-z_0-9]*:/ {
+            line = $1
+            sub(/:.*/, "", line)
+            print line
+            next
+        }
+        # Deeper indentation is a triggers own config (branches, tags, types).
+        /^    / { next }
+        {
+            printf "alert.sh: cannot parse the on: block of %s (line %d: %s)\n", file, NR, $0 >"/dev/stderr"
+            exit 2
+        }
+        END {
+            if (!seen) {
+                printf "alert.sh: no on: block found in %s\n", file >"/dev/stderr"
+                exit 2
+            }
+        }
+    ' "$1"
+}
+
+# Names of workflows carrying at least one non-pull_request trigger.
 non_pr_workflow_names() {
-    local f
+    local f triggers
     for f in "$WORKFLOWS_DIR"/*.yml; do
-        # alert.yml watches others; watching itself would be a trigger loop.
+        # alert.yml watches the others; watching itself would be a trigger loop.
         [[ "$(basename "$f")" == "alert.yml" ]] && continue
 
-        awk '
-            /^on:/                  { in_on = 1; next }
-            in_on && /^[a-zA-Z_]+:/ { in_on = 0 }
-            in_on && /^  [a-z_]+:/  {
-                key = $1
-                sub(":", "", key)
-                if (key != "pull_request") non_pr = 1
-            }
-            END { exit !non_pr }
-        ' "$f" || continue
-
-        sed -n 's/^name:[[:space:]]*//p' "$f" | head -1
+        triggers=$(workflow_triggers "$f")
+        if grep -qvx 'pull_request' <<<"$triggers"; then
+            sed -n 's/^name:[[:space:]]*//p' "$f" | head -1
+        fi
     done
 }
 
 # Names listed under alert.yml's `on.workflow_run.workflows:`.
 watched_workflow_names() {
     awk '
-        /^    workflows:/   { in_list = 1; next }
-        in_list && /^      - / { sub(/^      - /, ""); print; next }
-        in_list             { exit }
+        /^    workflows:/ { in_list = 1; next }
+        in_list && /^      - / {
+            sub(/^      - /, "")
+            print
+            next
+        }
+        in_list { exit }
     ' "$WORKFLOWS_DIR/alert.yml"
 }
 

--- a/.github/workflows/alert.yml
+++ b/.github/workflows/alert.yml
@@ -5,9 +5,7 @@ name: Alert
 #
 # Why this exists: GitHub only notifies the user who *triggered* a run, and the
 # runs that matter most here are triggered by moq-bot (release tags) or by cron,
-# so nobody is notified when a release breaks. That is how libmoq shipped no
-# release for six weeks: every tag build failed, and the tags kept accumulating
-# with no artifact behind them.
+# so without this nobody is notified when a release breaks.
 #
 # PR failures are deliberately excluded. The author already sees them on the PR,
 # and that noise is what drives people to mute Actions notifications wholesale.

--- a/.github/workflows/alert.yml
+++ b/.github/workflows/alert.yml
@@ -7,8 +7,9 @@ name: Alert
 # runs that matter most here are triggered by moq-bot (release tags) or by cron,
 # so without this nobody is notified when a release breaks.
 #
-# PR failures are deliberately excluded. The author already sees them on the PR,
-# and that noise is what drives people to mute Actions notifications wholesale.
+# Pull request failures are deliberately excluded, both pull_request and
+# pull_request_target. The author already sees them as a check on the PR, and
+# that noise is what drives people to mute Actions notifications wholesale.
 #
 # Needs a DISCORD_ALERTS_WEBHOOK repo secret (Discord: Channel > Integrations >
 # Webhooks). Nothing else reads it.
@@ -16,9 +17,9 @@ name: Alert
 on:
   workflow_run:
     # Matched by workflow `name:`, not filename. Every workflow that can run
-    # outside a pull request belongs here; the PR-only ones (Check, macOS,
-    # Swift, Windows) are omitted so they don't spawn a skipped Alert run on
-    # every push to every PR. `just gh check` enforces both halves of that.
+    # outside a pull request belongs here; the pull-request-only ones (Check,
+    # macOS, Swift, Windows) are omitted so they don't spawn a skipped Alert run
+    # on every push to every PR. `just gh check` enforces both halves of that.
     workflows:
       - apt-repo
       - Cachix
@@ -60,7 +61,8 @@ jobs:
     if: >-
       (github.event.workflow_run.conclusion == 'failure' ||
       github.event.workflow_run.conclusion == 'timed_out') &&
-      github.event.workflow_run.event != 'pull_request'
+      github.event.workflow_run.event != 'pull_request' &&
+      github.event.workflow_run.event != 'pull_request_target'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/alert.yml
+++ b/.github/workflows/alert.yml
@@ -1,0 +1,83 @@
+name: Alert
+
+# Posts to the Discord #alerts channel when a workflow fails outside of a pull
+# request.
+#
+# Why this exists: GitHub only notifies the user who *triggered* a run, and the
+# runs that matter most here are triggered by moq-bot (release tags) or by cron,
+# so nobody is notified when a release breaks. That is how libmoq shipped no
+# release for six weeks: every tag build failed, and the tags kept accumulating
+# with no artifact behind them.
+#
+# PR failures are deliberately excluded. The author already sees them on the PR,
+# and that noise is what drives people to mute Actions notifications wholesale.
+#
+# Needs a DISCORD_ALERTS_WEBHOOK repo secret (Discord: Channel > Integrations >
+# Webhooks). Nothing else reads it.
+
+on:
+  workflow_run:
+    # Matched by workflow `name:`, not filename. Every workflow that can run
+    # outside a pull request belongs here; the PR-only ones (Check, macOS,
+    # Swift, Windows) are omitted so they don't spawn a skipped Alert run on
+    # every push to every PR. `just gh check` enforces both halves of that.
+    workflows:
+      - apt-repo
+      - Cachix
+      - Docker
+      - libmoq
+      - moq-cli
+      - moq-gst
+      - moq-relay
+      - moq-token-cli
+      - release-brew
+      - Release Go
+      - Release Go FFI
+      - Release JS
+      - Release Kotlin FFI
+      - Release Kotlin lib
+      - Release Py
+      - Release Py FFI
+      - Release RS
+      - Release Swift FFI
+      - Release Swift Lib
+      - release-winget
+      - rpm-repo
+      - Smoke
+      - Update Flake
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  discord:
+    name: Discord
+    # `cancelled` is excluded: concurrency groups cancel in-flight runs as a
+    # matter of course, and paging on that would be pure noise.
+    #
+    # Note the chained cases (a release tag -> release-brew -> here) sit at the
+    # third and final level workflow_run supports; a fourth would never fire.
+    if: >-
+      (github.event.workflow_run.conclusion == 'failure' ||
+      github.event.workflow_run.conclusion == 'timed_out') &&
+      github.event.workflow_run.event != 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Post to Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_ALERTS_WEBHOOK }}
+          RUN_NAME: ${{ github.event.workflow_run.name }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
+          RUN_REF: ${{ github.event.workflow_run.head_branch }}
+          RUN_TITLE: ${{ github.event.workflow_run.display_title }}
+          RUN_ACTOR: ${{ github.event.workflow_run.triggering_actor.login }}
+        run: .github/scripts/alert.sh discord

--- a/.github/workflows/alert.yml
+++ b/.github/workflows/alert.yml
@@ -11,7 +11,7 @@ name: Alert
 # pull_request_target. The author already sees them as a check on the PR, and
 # that noise is what drives people to mute Actions notifications wholesale.
 #
-# Needs a DISCORD_ALERTS_WEBHOOK repo secret (Discord: Channel > Integrations >
+# Needs a DISCORD_WEBHOOK repo secret (Discord: Channel > Integrations >
 # Webhooks). Nothing else reads it.
 
 on:
@@ -72,7 +72,7 @@ jobs:
 
       - name: Post to Discord
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_ALERTS_WEBHOOK }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           RUN_NAME: ${{ github.event.workflow_run.name }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
           RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}


### PR DESCRIPTION
Follow-up to #2597. That PR fixed the libmoq release build; this one makes the next such breakage visible instead of taking six weeks to notice.

## Why notification settings can't solve this

GitHub scopes Actions notifications to the user who **triggered** the run. GitHub says "you'll receive a notification when any workflow runs that you've triggered have completed." There's an "Only notify for failed workflows" toggle, but no branch filter, and the feature request for one ([community discussion #55379](https://github.com/orgs/community/discussions/55379)) is open and unanswered since 2023.

That's fatal here. The libmoq v0.5.2 run has `triggering_actor: moq-bot[bot]`, as do all the release tag builds. Nobody was ever going to be notified, at any notification setting. The Actions page was the only signal, and there was no reason to open it.

Filtering to `main` wouldn't have helped either: `check.yml` is `pull_request`-only, so `main` has essentially no CI runs, while everything that broke runs on **tags**.

A webhook doesn't care who pushed, which is the whole point.

## What this does

`.github/workflows/alert.yml`, a `workflow_run` watcher that POSTs to the Discord #alerts channel when:

```
conclusion in (failure, timed_out)  &&  event not in ('pull_request', 'pull_request_target')
```

- **PR failures excluded on purpose.** The author already sees them on the PR, and that noise is what drives muting Actions notifications wholesale. That is what hid this.
- **`cancelled` excluded.** Concurrency groups cancel in-flight runs routinely; paging on that is pure noise.
- **`timed_out` included.** A hung release is as broken as a failed one.

Logic lives in `.github/scripts/alert.sh` beside `release.sh`, so it runs locally.

## The list can't be allowed to rot

`workflow_run.workflows` matches by workflow **name**, not filename, and can't be safely omitted. An explicit list rots, and a rotted list fails *silently*: no alerts, no error. That's the same failure mode this PR exists to fix, so it needed a guard.

`just gh check` now asserts the list is exactly the set of workflows carrying a non-PR trigger. Adding a workflow, or adding a `push`/`schedule` trigger to a PR-only one, fails until `alert.yml` matches.

PR-only workflows (`Check`, `macOS`, `Swift`, `Windows`) are excluded from the list rather than filtered at runtime, so `Check` doesn't spawn a skipped Alert run on every push to every PR.

## Deployment note

The workflow reads the existing **`DISCORD_WEBHOOK`** repo secret. Nothing else reads it.

Also note `alert.yml` only takes effect once it's on `main`: `workflow_run` fires from the default-branch copy of the file, so this can't be exercised from the PR.

## Verification

Run locally:

| Check | Result |
|---|---|
| `check-coverage` on the real tree | Independently derives the same 23 workflows the list names |
| Entry dropped from list | Fails: `missing (add to alert.yml): libmoq` |
| PR-only workflow added to list | Fails: `stale (remove, PR-only): Windows` |
| PR-only workflow gains a `push` trigger | Fails: `missing (add to alert.yml): Windows` |
| Discord POST against a local listener | Valid JSON; quotes, backslashes and newlines in the commit subject escaped (jq builds the body) |
| Non-2xx webhook response | Step fails (`--fail-with-body`), so a rotated webhook surfaces instead of silently dropping alerts |
| Missing `DISCORD_WEBHOOK` | Step fails |
| Script run from `/` | Path-independent (resolves via `BASH_SOURCE`) |

`alert.yml` parses as YAML with the expected triggers, types and job shape.

Full `nix develop --command just ci` passed on head `f61a00146`, including `actionlint`, the workflow coverage check, and all change-scoped CI checks.

## Still worth doing separately

`workflow_run` only fires when a workflow actually runs. It won't catch a release that never triggered at all. A scheduled invariant check that verifies every `libmoq-v*` tag has a release would catch that class too, and is the check that would have caught this bug on day one. Happy to add it if you want.

---

(Written by GPT-5.6 Sol)